### PR TITLE
BaseTools/Source/C/GNUmakefile: Added a condition for handling invalid A...

### DIFF
--- a/BaseTools/Source/C/GNUmakefile
+++ b/BaseTools/Source/C/GNUmakefile
@@ -12,6 +12,19 @@
 #  WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
 #
 
+ifdef ARCH
+  #
+  # ARCH is expected to be a particular string
+  # all other strings will potentially fail build
+  #
+  ifneq ($(ARCH),X64)
+    ifneq ($(ARCH),IA32)
+      $(info ERROR: ARCH must be set to X64 or IA32)
+      $(error ARCH set to invalid/unknown string)
+    endif
+  endif
+endif
+
 ifndef ARCH
   #
   # If ARCH is not defined, then we use 'uname -m' to attempt


### PR DESCRIPTION
BaseTools/Source/C/GNUmakefile: Added a condition for handling invalid ARCH values.

If a user has ARCH already set to x86_64, then the makefile would fail.  In the new code, a check is inserted to ensure that ARCH is set to X64 or IA32.  If it's not, then notify the user of the problem detected and exit.

Contributed-under: TianoCore Contribution Agreement 1.0
Signed-off-by: Mike Wade <michael.wade@gmail.com>