### PR TITLE
Standard Libraries: vsnprintf_ss: fix assert check on uninitialized vari...

### DIFF
--- a/StdLib/BsdSocketLib/res_mkupdate.c
+++ b/StdLib/BsdSocketLib/res_mkupdate.c
@@ -438,8 +438,12 @@ res_mkupdrec(int section, const char *dname,
          u_int class, u_int type, u_long ttl) {
     ns_updrec *rrecp = (ns_updrec *)calloc(1, sizeof(ns_updrec));
 
-    if (!rrecp || !(rrecp->r_dname = strdup(dname)))
+    if (!rrecp)
         return (NULL);
+    if (!(rrecp->r_dname = strdup(dname))) {
+        free(rrecp);
+        return (NULL);
+    }
     rrecp->r_class = (u_int16_t)class;
     rrecp->r_type = (u_int16_t)type;
     rrecp->r_ttl = (u_int32_t)ttl;

--- a/StdLib/LibC/Stdio/vsnprintf_ss.c
+++ b/StdLib/LibC/Stdio/vsnprintf_ss.c
@@ -142,7 +142,7 @@ vsnprintf_ss(char *sbuf, size_t slen, const char *fmt0, va_list ap)
   static const char xdigs_upper[16] = "0123456789ABCDEF";
 
 
-  _DIAGASSERT(n == 0 || sbuf != NULL);
+  _DIAGASSERT(sbuf != NULL);
   _DIAGASSERT(fmt != NULL);
 
   tailp = sbuf + slen;


### PR DESCRIPTION
Variable n is not yet initialized when the _DIAGASSERT() check is performed
on it, which means any old garbage in n may or may not cause the assert
to occur.  I believe this is a cut-n-paste error from vsnprintf() where
n is used as a paramater, where as vsnprintf_ss() does not.

Fix this by not asserting on n.

Signed-off-by: Colin Ian King <colin.king@canonical.com>