### PR TITLE
Misc fixes for EDK2

### DIFF
--- a/StdLib/BsdSocketLib/res_mkupdate.c
+++ b/StdLib/BsdSocketLib/res_mkupdate.c
@@ -438,8 +438,12 @@ res_mkupdrec(int section, const char *dname,
          u_int class, u_int type, u_long ttl) {
     ns_updrec *rrecp = (ns_updrec *)calloc(1, sizeof(ns_updrec));
 
-    if (!rrecp || !(rrecp->r_dname = strdup(dname)))
+    if (!rrecp)
         return (NULL);
+    if (!(rrecp->r_dname = strdup(dname))) {
+        free(rrecp);
+        return (NULL);
+    }
     rrecp->r_class = (u_int16_t)class;
     rrecp->r_type = (u_int16_t)type;
     rrecp->r_ttl = (u_int32_t)ttl;

--- a/StdLib/LibC/Stdio/vsnprintf_ss.c
+++ b/StdLib/LibC/Stdio/vsnprintf_ss.c
@@ -142,7 +142,7 @@ vsnprintf_ss(char *sbuf, size_t slen, const char *fmt0, va_list ap)
   static const char xdigs_upper[16] = "0123456789ABCDEF";
 
 
-  _DIAGASSERT(n == 0 || sbuf != NULL);
+  _DIAGASSERT(sbuf != NULL);
   _DIAGASSERT(fmt != NULL);
 
   tailp = sbuf + slen;


### PR DESCRIPTION
Found a couple of minor issues when statically analysing EDK2.  I've re-issued the pull request because I forgot to add the "Contributed-under:" tag in the original commit messages.