### PR TITLE
BaseTools for AArch64 GCC: Fix debugger view of globals

### DIFF
--- a/BaseTools/Conf/tools_def.template
+++ b/BaseTools/Conf/tools_def.template
@@ -3821,7 +3821,7 @@ DEFINE GCC_ARM_CC_FLAGS            = DEF(GCC_ALL_CC_FLAGS) -mword-relocations -m
 DEFINE GCC_AARCH64_CC_FLAGS        = DEF(GCC_ALL_CC_FLAGS) -mcmodel=large -mlittle-endian -fno-short-enums -save-temps -fverbose-asm -fsigned-char  -ffunction-sections -fdata-sections -fomit-frame-pointer -fno-builtin -Wno-address
 DEFINE GCC_DLINK_FLAGS_COMMON      = -nostdlib --pie
 DEFINE GCC_IA32_X64_DLINK_COMMON   = DEF(GCC_DLINK_FLAGS_COMMON) --gc-sections
-DEFINE GCC_ARM_AARCH64_DLINK_COMMON= -Ttext=0x0 --emit-relocs -nostdlib --gc-sections -u $(IMAGE_ENTRY_POINT) -e $(IMAGE_ENTRY_POINT) -Map $(DEST_DIR_DEBUG)/$(BASE_NAME).map
+DEFINE GCC_ARM_AARCH64_DLINK_COMMON= --script=$(EDK_TOOLS_PATH)/Scripts/gcc-arm-ld-script --emit-relocs -nostdlib --gc-sections -u $(IMAGE_ENTRY_POINT) -e $(IMAGE_ENTRY_POINT) -Map $(DEST_DIR_DEBUG)/$(BASE_NAME).map
 DEFINE GCC_IA32_X64_ASLDLINK_FLAGS = DEF(GCC_IA32_X64_DLINK_COMMON) --entry _ReferenceAcpiTable -u $(IMAGE_ENTRY_POINT)
 DEFINE GCC_ARM_AARCH64_ASLDLINK_FLAGS = DEF(GCC_ARM_AARCH64_DLINK_COMMON) --entry ReferenceAcpiTable -u $(IMAGE_ENTRY_POINT)
 DEFINE GCC_IA32_X64_DLINK_FLAGS    = DEF(GCC_IA32_X64_DLINK_COMMON) --entry _$(IMAGE_ENTRY_POINT) --file-alignment 0x20 --section-alignment 0x20 -Map $(DEST_DIR_DEBUG)/$(BASE_NAME).map

--- a/BaseTools/Scripts/gcc-arm-ld-script
+++ b/BaseTools/Scripts/gcc-arm-ld-script
@@ -1,0 +1,46 @@
+SECTIONS
+{
+  /* Start at 0 so we can meet more aggressive alignment requires after the PE-COFF conversion
+     like those for ARM exception vectors.  This requires debugger scripts to offset past
+     the PE-COFF header (typically 0x260).  When the PE-COFF conversion occurs we will
+     get proper alignment since the ELF section alignment is applied in the conversion process. */
+  . = 0;
+  .text ALIGN(0x20) :
+  {
+    *(.text .stub .text.* .gnu.linkonce.t.*)
+    . = ALIGN(0x20);
+  } =0x90909090
+  .data ALIGN(0x20) :
+  {
+    *(
+      .rodata .rodata.* .gnu.linkonce.r.*
+      .data .data.* .gnu.linkonce.d.*
+      .bss .bss.*
+      *COM*
+    )
+    . = ALIGN(0x20);
+  }
+  .eh_frame ALIGN(0x20) :
+  {
+    KEEP (*(.eh_frame))
+  }
+  .got ALIGN(0x20) :
+  {
+    *(.got .got.*)
+    . = ALIGN(0x20);
+  }
+  .rela ALIGN(0x20) :
+  {
+    *(.rela .rela.*)
+  }
+  /DISCARD/ : {
+    *(.note.GNU-stack) *(.gnu_debuglink)
+    *(.interp)
+    *(.dynsym)
+    *(.dynstr)
+    *(.dynamic)
+    *(.hash)
+    *(.comment)
+  }
+}
+


### PR DESCRIPTION
Before this change looking at global variables with a debugger showed bogus memory locations.  This is because the offset of the .data section in the ELF file did not reflect where it was placed in the PE-COFF (.efi) output.

This change passes a linker control script so that the data section is packed next to .text so the ELF accurately reflects the relationship between the sections when converted to PE-COFF by GenFw.
