### PR TITLE
Improve shell wrappers for build commands

### DIFF
--- a/BaseTools/Bin/CYGWIN_NT-5.1-i686/BootSectImage
+++ b/BaseTools/Bin/CYGWIN_NT-5.1-i686/BootSectImage
@@ -1,29 +1,29 @@
 #!/usr/bin/env bash
-#python `dirname $0`/RunToolFromSource.py `basename $0` $*
-#exec `dirname $0`/../../../../C/bin/`basename $0` $*
 
-TOOL_BASENAME=`basename $0`
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+dir=$(dirname "$full_cmd")
+cmd=${full_cmd##*/}
 
-if [ -n "$WORKSPACE" -a -e $WORKSPACE/Conf/BaseToolsCBinaries ]
+if [ -n "$WORKSPACE" ] && [ -e "$WORKSPACE/Conf/BaseToolsCBinaries" ]
 then
-  exec $WORKSPACE/Conf/BaseToolsCBinaries/$TOOL_BASENAME
-elif [ -n "$WORKSPACE" -a -e $EDK_TOOLS_PATH/Source/C ]
+  exec "$WORKSPACE/Conf/BaseToolsCBinaries/$cmd"
+elif [ -n "$WORKSPACE" ] && [ -e "$EDK_TOOLS_PATH/Source/C" ]
 then
-  if [ ! -e $EDK_TOOLS_PATH/Source/C/bin/$TOOL_BASENAME ]
+  if [ ! -e "$EDK_TOOLS_PATH/Source/C/bin/$cmd" ]
   then
-    echo BaseTools C Tool binary was not found \($TOOL_BASENAME\)
-    echo You may need to run:
+    echo "BaseTools C Tool binary was not found ($cmd)"
+    echo "You may need to run:"
     echo "  make -C $EDK_TOOLS_PATH/Source/C"
   else
-    exec $EDK_TOOLS_PATH/Source/C/bin/$TOOL_BASENAME $*
+    exec "$EDK_TOOLS_PATH/Source/C/bin/$cmd" "$@"
   fi
-elif [ -e `dirname $0`/../../Source/C/bin/$TOOL_BASENAME ]
+elif [ -e "$dir/../../Source/C/bin/$cmd" ]
 then
-  exec `dirname $0`/../../Source/C/bin/$TOOL_BASENAME $*
+  exec "$dir/../../Source/C/bin/$cmd" "$@"
 else
-  echo Unable to find the real \'$TOOL_BASENAME\' to run
-  echo This message was printed by
+  echo "Unable to find the real '$cmd' to run"
+  echo "This message was printed by"
   echo "  $0"
-  exit -1
+  exit 127
 fi
 

--- a/BaseTools/Bin/CYGWIN_NT-5.1-i686/Ecc
+++ b/BaseTools/Bin/CYGWIN_NT-5.1-i686/Ecc
@@ -1,5 +1,14 @@
 #!/usr/bin/env bash
 #python `dirname $0`/RunToolFromSource.py `basename $0` $*
-PYTHONPATH="`dirname $0`/../../Source/Python" \
-    python "`dirname $0`/../../Source/Python"/`basename $0`/`basename $0`.py $*
 
+# If a python2 command is available, use it in preference to python
+if command -v python2 >/dev/null 2>&1; then
+    python_exe=python2
+fi
+
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+dir=$(dirname "$full_cmd")
+cmd=${full_cmd##*/}
+
+export PYTHONPATH="$dir/../../Source/Python"
+exec "${python_exe:-python}" "$dir/../../Source/Python/$cmd/$cmd.py" "$@"

--- a/BaseTools/Bin/CYGWIN_NT-5.1-i686/EfiLdrImage
+++ b/BaseTools/Bin/CYGWIN_NT-5.1-i686/EfiLdrImage
@@ -1,29 +1,29 @@
 #!/usr/bin/env bash
-#python `dirname $0`/RunToolFromSource.py `basename $0` $*
-#exec `dirname $0`/../../../../C/bin/`basename $0` $*
 
-TOOL_BASENAME=`basename $0`
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+dir=$(dirname "$full_cmd")
+cmd=${full_cmd##*/}
 
-if [ -n "$WORKSPACE" -a -e $WORKSPACE/Conf/BaseToolsCBinaries ]
+if [ -n "$WORKSPACE" ] && [ -e "$WORKSPACE/Conf/BaseToolsCBinaries" ]
 then
-  exec $WORKSPACE/Conf/BaseToolsCBinaries/$TOOL_BASENAME
-elif [ -n "$WORKSPACE" -a -e $EDK_TOOLS_PATH/Source/C ]
+  exec "$WORKSPACE/Conf/BaseToolsCBinaries/$cmd"
+elif [ -n "$WORKSPACE" ] && [ -e "$EDK_TOOLS_PATH/Source/C" ]
 then
-  if [ ! -e $EDK_TOOLS_PATH/Source/C/bin/$TOOL_BASENAME ]
+  if [ ! -e "$EDK_TOOLS_PATH/Source/C/bin/$cmd" ]
   then
-    echo BaseTools C Tool binary was not found \($TOOL_BASENAME\)
-    echo You may need to run:
+    echo "BaseTools C Tool binary was not found ($cmd)"
+    echo "You may need to run:"
     echo "  make -C $EDK_TOOLS_PATH/Source/C"
   else
-    exec $EDK_TOOLS_PATH/Source/C/bin/$TOOL_BASENAME $*
+    exec "$EDK_TOOLS_PATH/Source/C/bin/$cmd" "$@"
   fi
-elif [ -e `dirname $0`/../../Source/C/bin/$TOOL_BASENAME ]
+elif [ -e "$dir/../../Source/C/bin/$cmd" ]
 then
-  exec `dirname $0`/../../Source/C/bin/$TOOL_BASENAME $*
+  exec "$dir/../../Source/C/bin/$cmd" "$@"
 else
-  echo Unable to find the real \'$TOOL_BASENAME\' to run
-  echo This message was printed by
+  echo "Unable to find the real '$cmd' to run"
+  echo "This message was printed by"
   echo "  $0"
-  exit -1
+  exit 127
 fi
 

--- a/BaseTools/Bin/CYGWIN_NT-5.1-i686/EfiRom
+++ b/BaseTools/Bin/CYGWIN_NT-5.1-i686/EfiRom
@@ -1,29 +1,29 @@
 #!/usr/bin/env bash
-#python `dirname $0`/RunToolFromSource.py `basename $0` $*
-#exec `dirname $0`/../../../../C/bin/`basename $0` $*
 
-TOOL_BASENAME=`basename $0`
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+dir=$(dirname "$full_cmd")
+cmd=${full_cmd##*/}
 
-if [ -n "$WORKSPACE" -a -e $WORKSPACE/Conf/BaseToolsCBinaries ]
+if [ -n "$WORKSPACE" ] && [ -e "$WORKSPACE/Conf/BaseToolsCBinaries" ]
 then
-  exec $WORKSPACE/Conf/BaseToolsCBinaries/$TOOL_BASENAME
-elif [ -n "$WORKSPACE" -a -e $EDK_TOOLS_PATH/Source/C ]
+  exec "$WORKSPACE/Conf/BaseToolsCBinaries/$cmd"
+elif [ -n "$WORKSPACE" ] && [ -e "$EDK_TOOLS_PATH/Source/C" ]
 then
-  if [ ! -e $EDK_TOOLS_PATH/Source/C/bin/$TOOL_BASENAME ]
+  if [ ! -e "$EDK_TOOLS_PATH/Source/C/bin/$cmd" ]
   then
-    echo BaseTools C Tool binary was not found \($TOOL_BASENAME\)
-    echo You may need to run:
+    echo "BaseTools C Tool binary was not found ($cmd)"
+    echo "You may need to run:"
     echo "  make -C $EDK_TOOLS_PATH/Source/C"
   else
-    exec $EDK_TOOLS_PATH/Source/C/bin/$TOOL_BASENAME $*
+    exec "$EDK_TOOLS_PATH/Source/C/bin/$cmd" "$@"
   fi
-elif [ -e `dirname $0`/../../Source/C/bin/$TOOL_BASENAME ]
+elif [ -e "$dir/../../Source/C/bin/$cmd" ]
 then
-  exec `dirname $0`/../../Source/C/bin/$TOOL_BASENAME $*
+  exec "$dir/../../Source/C/bin/$cmd" "$@"
 else
-  echo Unable to find the real \'$TOOL_BASENAME\' to run
-  echo This message was printed by
+  echo "Unable to find the real '$cmd' to run"
+  echo "This message was printed by"
   echo "  $0"
-  exit -1
+  exit 127
 fi
 

--- a/BaseTools/Bin/CYGWIN_NT-5.1-i686/GenCrc32
+++ b/BaseTools/Bin/CYGWIN_NT-5.1-i686/GenCrc32
@@ -1,29 +1,29 @@
 #!/usr/bin/env bash
-#python `dirname $0`/RunToolFromSource.py `basename $0` $*
-#exec `dirname $0`/../../../../C/bin/`basename $0` $*
 
-TOOL_BASENAME=`basename $0`
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+dir=$(dirname "$full_cmd")
+cmd=${full_cmd##*/}
 
-if [ -n "$WORKSPACE" -a -e $WORKSPACE/Conf/BaseToolsCBinaries ]
+if [ -n "$WORKSPACE" ] && [ -e "$WORKSPACE/Conf/BaseToolsCBinaries" ]
 then
-  exec $WORKSPACE/Conf/BaseToolsCBinaries/$TOOL_BASENAME
-elif [ -n "$WORKSPACE" -a -e $EDK_TOOLS_PATH/Source/C ]
+  exec "$WORKSPACE/Conf/BaseToolsCBinaries/$cmd"
+elif [ -n "$WORKSPACE" ] && [ -e "$EDK_TOOLS_PATH/Source/C" ]
 then
-  if [ ! -e $EDK_TOOLS_PATH/Source/C/bin/$TOOL_BASENAME ]
+  if [ ! -e "$EDK_TOOLS_PATH/Source/C/bin/$cmd" ]
   then
-    echo BaseTools C Tool binary was not found \($TOOL_BASENAME\)
-    echo You may need to run:
+    echo "BaseTools C Tool binary was not found ($cmd)"
+    echo "You may need to run:"
     echo "  make -C $EDK_TOOLS_PATH/Source/C"
   else
-    exec $EDK_TOOLS_PATH/Source/C/bin/$TOOL_BASENAME $*
+    exec "$EDK_TOOLS_PATH/Source/C/bin/$cmd" "$@"
   fi
-elif [ -e `dirname $0`/../../Source/C/bin/$TOOL_BASENAME ]
+elif [ -e "$dir/../../Source/C/bin/$cmd" ]
 then
-  exec `dirname $0`/../../Source/C/bin/$TOOL_BASENAME $*
+  exec "$dir/../../Source/C/bin/$cmd" "$@"
 else
-  echo Unable to find the real \'$TOOL_BASENAME\' to run
-  echo This message was printed by
+  echo "Unable to find the real '$cmd' to run"
+  echo "This message was printed by"
   echo "  $0"
-  exit -1
+  exit 127
 fi
 

--- a/BaseTools/Bin/CYGWIN_NT-5.1-i686/GenDepex
+++ b/BaseTools/Bin/CYGWIN_NT-5.1-i686/GenDepex
@@ -1,3 +1,14 @@
 #!/usr/bin/env bash
-PYTHONPATH="`dirname $0`/../../Source/Python" \
-    python "`dirname $0`/../../Source/Python"/AutoGen/`basename $0`.py $*
+#python `dirname $0`/RunToolFromSource.py `basename $0` $*
+
+# If a python2 command is available, use it in preference to python
+if command -v python2 >/dev/null 2>&1; then
+    python_exe=python2
+fi
+
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+dir=$(dirname "$full_cmd")
+cmd=${full_cmd##*/}
+
+export PYTHONPATH="$dir/../../Source/Python"
+exec "${python_exe:-python}" "$dir/../../Source/Python/$cmd/$cmd.py" "$@"

--- a/BaseTools/Bin/CYGWIN_NT-5.1-i686/GenFds
+++ b/BaseTools/Bin/CYGWIN_NT-5.1-i686/GenFds
@@ -1,5 +1,14 @@
 #!/usr/bin/env bash
 #python `dirname $0`/RunToolFromSource.py `basename $0` $*
-PYTHONPATH="`dirname $0`/../../Source/Python" \
-    python "`dirname $0`/../../Source/Python"/`basename $0`/`basename $0`.py $*
 
+# If a python2 command is available, use it in preference to python
+if command -v python2 >/dev/null 2>&1; then
+    python_exe=python2
+fi
+
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+dir=$(dirname "$full_cmd")
+cmd=${full_cmd##*/}
+
+export PYTHONPATH="$dir/../../Source/Python"
+exec "${python_exe:-python}" "$dir/../../Source/Python/$cmd/$cmd.py" "$@"

--- a/BaseTools/Bin/CYGWIN_NT-5.1-i686/GenFfs
+++ b/BaseTools/Bin/CYGWIN_NT-5.1-i686/GenFfs
@@ -1,29 +1,29 @@
 #!/usr/bin/env bash
-#python `dirname $0`/RunToolFromSource.py `basename $0` $*
-#exec `dirname $0`/../../../../C/bin/`basename $0` $*
 
-TOOL_BASENAME=`basename $0`
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+dir=$(dirname "$full_cmd")
+cmd=${full_cmd##*/}
 
-if [ -n "$WORKSPACE" -a -e $WORKSPACE/Conf/BaseToolsCBinaries ]
+if [ -n "$WORKSPACE" ] && [ -e "$WORKSPACE/Conf/BaseToolsCBinaries" ]
 then
-  exec $WORKSPACE/Conf/BaseToolsCBinaries/$TOOL_BASENAME
-elif [ -n "$WORKSPACE" -a -e $EDK_TOOLS_PATH/Source/C ]
+  exec "$WORKSPACE/Conf/BaseToolsCBinaries/$cmd"
+elif [ -n "$WORKSPACE" ] && [ -e "$EDK_TOOLS_PATH/Source/C" ]
 then
-  if [ ! -e $EDK_TOOLS_PATH/Source/C/bin/$TOOL_BASENAME ]
+  if [ ! -e "$EDK_TOOLS_PATH/Source/C/bin/$cmd" ]
   then
-    echo BaseTools C Tool binary was not found \($TOOL_BASENAME\)
-    echo You may need to run:
+    echo "BaseTools C Tool binary was not found ($cmd)"
+    echo "You may need to run:"
     echo "  make -C $EDK_TOOLS_PATH/Source/C"
   else
-    exec $EDK_TOOLS_PATH/Source/C/bin/$TOOL_BASENAME $*
+    exec "$EDK_TOOLS_PATH/Source/C/bin/$cmd" "$@"
   fi
-elif [ -e `dirname $0`/../../Source/C/bin/$TOOL_BASENAME ]
+elif [ -e "$dir/../../Source/C/bin/$cmd" ]
 then
-  exec `dirname $0`/../../Source/C/bin/$TOOL_BASENAME $*
+  exec "$dir/../../Source/C/bin/$cmd" "$@"
 else
-  echo Unable to find the real \'$TOOL_BASENAME\' to run
-  echo This message was printed by
+  echo "Unable to find the real '$cmd' to run"
+  echo "This message was printed by"
   echo "  $0"
-  exit -1
+  exit 127
 fi
 

--- a/BaseTools/Bin/CYGWIN_NT-5.1-i686/GenFv
+++ b/BaseTools/Bin/CYGWIN_NT-5.1-i686/GenFv
@@ -1,29 +1,29 @@
 #!/usr/bin/env bash
-#python `dirname $0`/RunToolFromSource.py `basename $0` $*
-#exec `dirname $0`/../../../../C/bin/`basename $0` $*
 
-TOOL_BASENAME=`basename $0`
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+dir=$(dirname "$full_cmd")
+cmd=${full_cmd##*/}
 
-if [ -n "$WORKSPACE" -a -e $WORKSPACE/Conf/BaseToolsCBinaries ]
+if [ -n "$WORKSPACE" ] && [ -e "$WORKSPACE/Conf/BaseToolsCBinaries" ]
 then
-  exec $WORKSPACE/Conf/BaseToolsCBinaries/$TOOL_BASENAME
-elif [ -n "$WORKSPACE" -a -e $EDK_TOOLS_PATH/Source/C ]
+  exec "$WORKSPACE/Conf/BaseToolsCBinaries/$cmd"
+elif [ -n "$WORKSPACE" ] && [ -e "$EDK_TOOLS_PATH/Source/C" ]
 then
-  if [ ! -e $EDK_TOOLS_PATH/Source/C/bin/$TOOL_BASENAME ]
+  if [ ! -e "$EDK_TOOLS_PATH/Source/C/bin/$cmd" ]
   then
-    echo BaseTools C Tool binary was not found \($TOOL_BASENAME\)
-    echo You may need to run:
+    echo "BaseTools C Tool binary was not found ($cmd)"
+    echo "You may need to run:"
     echo "  make -C $EDK_TOOLS_PATH/Source/C"
   else
-    exec $EDK_TOOLS_PATH/Source/C/bin/$TOOL_BASENAME $*
+    exec "$EDK_TOOLS_PATH/Source/C/bin/$cmd" "$@"
   fi
-elif [ -e `dirname $0`/../../Source/C/bin/$TOOL_BASENAME ]
+elif [ -e "$dir/../../Source/C/bin/$cmd" ]
 then
-  exec `dirname $0`/../../Source/C/bin/$TOOL_BASENAME $*
+  exec "$dir/../../Source/C/bin/$cmd" "$@"
 else
-  echo Unable to find the real \'$TOOL_BASENAME\' to run
-  echo This message was printed by
+  echo "Unable to find the real '$cmd' to run"
+  echo "This message was printed by"
   echo "  $0"
-  exit -1
+  exit 127
 fi
 

--- a/BaseTools/Bin/CYGWIN_NT-5.1-i686/GenFw
+++ b/BaseTools/Bin/CYGWIN_NT-5.1-i686/GenFw
@@ -1,29 +1,29 @@
 #!/usr/bin/env bash
-#python `dirname $0`/RunToolFromSource.py `basename $0` $*
-#exec `dirname $0`/../../../../C/bin/`basename $0` $*
 
-TOOL_BASENAME=`basename $0`
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+dir=$(dirname "$full_cmd")
+cmd=${full_cmd##*/}
 
-if [ -n "$WORKSPACE" -a -e $WORKSPACE/Conf/BaseToolsCBinaries ]
+if [ -n "$WORKSPACE" ] && [ -e "$WORKSPACE/Conf/BaseToolsCBinaries" ]
 then
-  exec $WORKSPACE/Conf/BaseToolsCBinaries/$TOOL_BASENAME
-elif [ -n "$WORKSPACE" -a -e $EDK_TOOLS_PATH/Source/C ]
+  exec "$WORKSPACE/Conf/BaseToolsCBinaries/$cmd"
+elif [ -n "$WORKSPACE" ] && [ -e "$EDK_TOOLS_PATH/Source/C" ]
 then
-  if [ ! -e $EDK_TOOLS_PATH/Source/C/bin/$TOOL_BASENAME ]
+  if [ ! -e "$EDK_TOOLS_PATH/Source/C/bin/$cmd" ]
   then
-    echo BaseTools C Tool binary was not found \($TOOL_BASENAME\)
-    echo You may need to run:
+    echo "BaseTools C Tool binary was not found ($cmd)"
+    echo "You may need to run:"
     echo "  make -C $EDK_TOOLS_PATH/Source/C"
   else
-    exec $EDK_TOOLS_PATH/Source/C/bin/$TOOL_BASENAME $*
+    exec "$EDK_TOOLS_PATH/Source/C/bin/$cmd" "$@"
   fi
-elif [ -e `dirname $0`/../../Source/C/bin/$TOOL_BASENAME ]
+elif [ -e "$dir/../../Source/C/bin/$cmd" ]
 then
-  exec `dirname $0`/../../Source/C/bin/$TOOL_BASENAME $*
+  exec "$dir/../../Source/C/bin/$cmd" "$@"
 else
-  echo Unable to find the real \'$TOOL_BASENAME\' to run
-  echo This message was printed by
+  echo "Unable to find the real '$cmd' to run"
+  echo "This message was printed by"
   echo "  $0"
-  exit -1
+  exit 127
 fi
 

--- a/BaseTools/Bin/CYGWIN_NT-5.1-i686/GenPage
+++ b/BaseTools/Bin/CYGWIN_NT-5.1-i686/GenPage
@@ -1,29 +1,29 @@
 #!/usr/bin/env bash
-#python `dirname $0`/RunToolFromSource.py `basename $0` $*
-#exec `dirname $0`/../../../../C/bin/`basename $0` $*
 
-TOOL_BASENAME=`basename $0`
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+dir=$(dirname "$full_cmd")
+cmd=${full_cmd##*/}
 
-if [ -n "$WORKSPACE" -a -e $WORKSPACE/Conf/BaseToolsCBinaries ]
+if [ -n "$WORKSPACE" ] && [ -e "$WORKSPACE/Conf/BaseToolsCBinaries" ]
 then
-  exec $WORKSPACE/Conf/BaseToolsCBinaries/$TOOL_BASENAME
-elif [ -n "$WORKSPACE" -a -e $EDK_TOOLS_PATH/Source/C ]
+  exec "$WORKSPACE/Conf/BaseToolsCBinaries/$cmd"
+elif [ -n "$WORKSPACE" ] && [ -e "$EDK_TOOLS_PATH/Source/C" ]
 then
-  if [ ! -e $EDK_TOOLS_PATH/Source/C/bin/$TOOL_BASENAME ]
+  if [ ! -e "$EDK_TOOLS_PATH/Source/C/bin/$cmd" ]
   then
-    echo BaseTools C Tool binary was not found \($TOOL_BASENAME\)
-    echo You may need to run:
+    echo "BaseTools C Tool binary was not found ($cmd)"
+    echo "You may need to run:"
     echo "  make -C $EDK_TOOLS_PATH/Source/C"
   else
-    exec $EDK_TOOLS_PATH/Source/C/bin/$TOOL_BASENAME $*
+    exec "$EDK_TOOLS_PATH/Source/C/bin/$cmd" "$@"
   fi
-elif [ -e `dirname $0`/../../Source/C/bin/$TOOL_BASENAME ]
+elif [ -e "$dir/../../Source/C/bin/$cmd" ]
 then
-  exec `dirname $0`/../../Source/C/bin/$TOOL_BASENAME $*
+  exec "$dir/../../Source/C/bin/$cmd" "$@"
 else
-  echo Unable to find the real \'$TOOL_BASENAME\' to run
-  echo This message was printed by
+  echo "Unable to find the real '$cmd' to run"
+  echo "This message was printed by"
   echo "  $0"
-  exit -1
+  exit 127
 fi
 

--- a/BaseTools/Bin/CYGWIN_NT-5.1-i686/GenSec
+++ b/BaseTools/Bin/CYGWIN_NT-5.1-i686/GenSec
@@ -1,29 +1,29 @@
 #!/usr/bin/env bash
-#python `dirname $0`/RunToolFromSource.py `basename $0` $*
-#exec `dirname $0`/../../../../C/bin/`basename $0` $*
 
-TOOL_BASENAME=`basename $0`
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+dir=$(dirname "$full_cmd")
+cmd=${full_cmd##*/}
 
-if [ -n "$WORKSPACE" -a -e $WORKSPACE/Conf/BaseToolsCBinaries ]
+if [ -n "$WORKSPACE" ] && [ -e "$WORKSPACE/Conf/BaseToolsCBinaries" ]
 then
-  exec $WORKSPACE/Conf/BaseToolsCBinaries/$TOOL_BASENAME
-elif [ -n "$WORKSPACE" -a -e $EDK_TOOLS_PATH/Source/C ]
+  exec "$WORKSPACE/Conf/BaseToolsCBinaries/$cmd"
+elif [ -n "$WORKSPACE" ] && [ -e "$EDK_TOOLS_PATH/Source/C" ]
 then
-  if [ ! -e $EDK_TOOLS_PATH/Source/C/bin/$TOOL_BASENAME ]
+  if [ ! -e "$EDK_TOOLS_PATH/Source/C/bin/$cmd" ]
   then
-    echo BaseTools C Tool binary was not found \($TOOL_BASENAME\)
-    echo You may need to run:
+    echo "BaseTools C Tool binary was not found ($cmd)"
+    echo "You may need to run:"
     echo "  make -C $EDK_TOOLS_PATH/Source/C"
   else
-    exec $EDK_TOOLS_PATH/Source/C/bin/$TOOL_BASENAME $*
+    exec "$EDK_TOOLS_PATH/Source/C/bin/$cmd" "$@"
   fi
-elif [ -e `dirname $0`/../../Source/C/bin/$TOOL_BASENAME ]
+elif [ -e "$dir/../../Source/C/bin/$cmd" ]
 then
-  exec `dirname $0`/../../Source/C/bin/$TOOL_BASENAME $*
+  exec "$dir/../../Source/C/bin/$cmd" "$@"
 else
-  echo Unable to find the real \'$TOOL_BASENAME\' to run
-  echo This message was printed by
+  echo "Unable to find the real '$cmd' to run"
+  echo "This message was printed by"
   echo "  $0"
-  exit -1
+  exit 127
 fi
 

--- a/BaseTools/Bin/CYGWIN_NT-5.1-i686/GenVtf
+++ b/BaseTools/Bin/CYGWIN_NT-5.1-i686/GenVtf
@@ -1,29 +1,29 @@
 #!/usr/bin/env bash
-#python `dirname $0`/RunToolFromSource.py `basename $0` $*
-#exec `dirname $0`/../../../../C/bin/`basename $0` $*
 
-TOOL_BASENAME=`basename $0`
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+dir=$(dirname "$full_cmd")
+cmd=${full_cmd##*/}
 
-if [ -n "$WORKSPACE" -a -e $WORKSPACE/Conf/BaseToolsCBinaries ]
+if [ -n "$WORKSPACE" ] && [ -e "$WORKSPACE/Conf/BaseToolsCBinaries" ]
 then
-  exec $WORKSPACE/Conf/BaseToolsCBinaries/$TOOL_BASENAME
-elif [ -n "$WORKSPACE" -a -e $EDK_TOOLS_PATH/Source/C ]
+  exec "$WORKSPACE/Conf/BaseToolsCBinaries/$cmd"
+elif [ -n "$WORKSPACE" ] && [ -e "$EDK_TOOLS_PATH/Source/C" ]
 then
-  if [ ! -e $EDK_TOOLS_PATH/Source/C/bin/$TOOL_BASENAME ]
+  if [ ! -e "$EDK_TOOLS_PATH/Source/C/bin/$cmd" ]
   then
-    echo BaseTools C Tool binary was not found \($TOOL_BASENAME\)
-    echo You may need to run:
+    echo "BaseTools C Tool binary was not found ($cmd)"
+    echo "You may need to run:"
     echo "  make -C $EDK_TOOLS_PATH/Source/C"
   else
-    exec $EDK_TOOLS_PATH/Source/C/bin/$TOOL_BASENAME $*
+    exec "$EDK_TOOLS_PATH/Source/C/bin/$cmd" "$@"
   fi
-elif [ -e `dirname $0`/../../Source/C/bin/$TOOL_BASENAME ]
+elif [ -e "$dir/../../Source/C/bin/$cmd" ]
 then
-  exec `dirname $0`/../../Source/C/bin/$TOOL_BASENAME $*
+  exec "$dir/../../Source/C/bin/$cmd" "$@"
 else
-  echo Unable to find the real \'$TOOL_BASENAME\' to run
-  echo This message was printed by
+  echo "Unable to find the real '$cmd' to run"
+  echo "This message was printed by"
   echo "  $0"
-  exit -1
+  exit 127
 fi
 

--- a/BaseTools/Bin/CYGWIN_NT-5.1-i686/GnuGenBootSector
+++ b/BaseTools/Bin/CYGWIN_NT-5.1-i686/GnuGenBootSector
@@ -1,29 +1,29 @@
 #!/usr/bin/env bash
-#python `dirname $0`/RunToolFromSource.py `basename $0` $*
-#exec `dirname $0`/../../../../C/bin/`basename $0` $*
 
-TOOL_BASENAME=`basename $0`
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+dir=$(dirname "$full_cmd")
+cmd=${full_cmd##*/}
 
-if [ -n "$WORKSPACE" -a -e $WORKSPACE/Conf/BaseToolsCBinaries ]
+if [ -n "$WORKSPACE" ] && [ -e "$WORKSPACE/Conf/BaseToolsCBinaries" ]
 then
-  exec $WORKSPACE/Conf/BaseToolsCBinaries/$TOOL_BASENAME
-elif [ -n "$WORKSPACE" -a -e $EDK_TOOLS_PATH/Source/C ]
+  exec "$WORKSPACE/Conf/BaseToolsCBinaries/$cmd"
+elif [ -n "$WORKSPACE" ] && [ -e "$EDK_TOOLS_PATH/Source/C" ]
 then
-  if [ ! -e $EDK_TOOLS_PATH/Source/C/bin/$TOOL_BASENAME ]
+  if [ ! -e "$EDK_TOOLS_PATH/Source/C/bin/$cmd" ]
   then
-    echo BaseTools C Tool binary was not found \($TOOL_BASENAME\)
-    echo You may need to run:
+    echo "BaseTools C Tool binary was not found ($cmd)"
+    echo "You may need to run:"
     echo "  make -C $EDK_TOOLS_PATH/Source/C"
   else
-    exec $EDK_TOOLS_PATH/Source/C/bin/$TOOL_BASENAME $*
+    exec "$EDK_TOOLS_PATH/Source/C/bin/$cmd" "$@"
   fi
-elif [ -e `dirname $0`/../../Source/C/bin/$TOOL_BASENAME ]
+elif [ -e "$dir/../../Source/C/bin/$cmd" ]
 then
-  exec `dirname $0`/../../Source/C/bin/$TOOL_BASENAME $*
+  exec "$dir/../../Source/C/bin/$cmd" "$@"
 else
-  echo Unable to find the real \'$TOOL_BASENAME\' to run
-  echo This message was printed by
+  echo "Unable to find the real '$cmd' to run"
+  echo "This message was printed by"
   echo "  $0"
-  exit -1
+  exit 127
 fi
 

--- a/BaseTools/Bin/CYGWIN_NT-5.1-i686/LzmaCompress
+++ b/BaseTools/Bin/CYGWIN_NT-5.1-i686/LzmaCompress
@@ -1,29 +1,29 @@
 #!/usr/bin/env bash
-#python `dirname $0`/RunToolFromSource.py `basename $0` $*
-#exec `dirname $0`/../../../../C/bin/`basename $0` $*
 
-TOOL_BASENAME=`basename $0`
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+dir=$(dirname "$full_cmd")
+cmd=${full_cmd##*/}
 
-if [ -n "$WORKSPACE" -a -e $WORKSPACE/Conf/BaseToolsCBinaries ]
+if [ -n "$WORKSPACE" ] && [ -e "$WORKSPACE/Conf/BaseToolsCBinaries" ]
 then
-  exec $WORKSPACE/Conf/BaseToolsCBinaries/$TOOL_BASENAME
-elif [ -n "$WORKSPACE" -a -e $EDK_TOOLS_PATH/Source/C ]
+  exec "$WORKSPACE/Conf/BaseToolsCBinaries/$cmd"
+elif [ -n "$WORKSPACE" ] && [ -e "$EDK_TOOLS_PATH/Source/C" ]
 then
-  if [ ! -e $EDK_TOOLS_PATH/Source/C/bin/$TOOL_BASENAME ]
+  if [ ! -e "$EDK_TOOLS_PATH/Source/C/bin/$cmd" ]
   then
-    echo BaseTools C Tool binary was not found \($TOOL_BASENAME\)
-    echo You may need to run:
+    echo "BaseTools C Tool binary was not found ($cmd)"
+    echo "You may need to run:"
     echo "  make -C $EDK_TOOLS_PATH/Source/C"
   else
-    exec $EDK_TOOLS_PATH/Source/C/bin/$TOOL_BASENAME $*
+    exec "$EDK_TOOLS_PATH/Source/C/bin/$cmd" "$@"
   fi
-elif [ -e `dirname $0`/../../Source/C/bin/$TOOL_BASENAME ]
+elif [ -e "$dir/../../Source/C/bin/$cmd" ]
 then
-  exec `dirname $0`/../../Source/C/bin/$TOOL_BASENAME $*
+  exec "$dir/../../Source/C/bin/$cmd" "$@"
 else
-  echo Unable to find the real \'$TOOL_BASENAME\' to run
-  echo This message was printed by
+  echo "Unable to find the real '$cmd' to run"
+  echo "This message was printed by"
   echo "  $0"
-  exit -1
+  exit 127
 fi
 

--- a/BaseTools/Bin/CYGWIN_NT-5.1-i686/LzmaF86Compress
+++ b/BaseTools/Bin/CYGWIN_NT-5.1-i686/LzmaF86Compress
@@ -12,11 +12,12 @@
 # WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
 #
 
-for arg in $*; do
-  if [ "arg" = "-e" -o "arg" = "-d" ]; then
-    FLAG=--f86
-    break;
-  fi
-done
+for arg; do
+  case $arg in
+    -e|-d)
+      set -- "$@" --f86
+      break
+    ;;
+esac
 
-LzmaCompress $* $FLAG
+exec LzmaCompress "$@"

--- a/BaseTools/Bin/CYGWIN_NT-5.1-i686/Split
+++ b/BaseTools/Bin/CYGWIN_NT-5.1-i686/Split
@@ -1,29 +1,29 @@
 #!/usr/bin/env bash
-#python `dirname $0`/RunToolFromSource.py `basename $0` $*
-#exec `dirname $0`/../../../../C/bin/`basename $0` $*
 
-TOOL_BASENAME=`basename $0`
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+dir=$(dirname "$full_cmd")
+cmd=${full_cmd##*/}
 
-if [ -n "$WORKSPACE" -a -e $WORKSPACE/Conf/BaseToolsCBinaries ]
+if [ -n "$WORKSPACE" ] && [ -e "$WORKSPACE/Conf/BaseToolsCBinaries" ]
 then
-  exec $WORKSPACE/Conf/BaseToolsCBinaries/$TOOL_BASENAME
-elif [ -n "$WORKSPACE" -a -e $EDK_TOOLS_PATH/Source/C ]
+  exec "$WORKSPACE/Conf/BaseToolsCBinaries/$cmd"
+elif [ -n "$WORKSPACE" ] && [ -e "$EDK_TOOLS_PATH/Source/C" ]
 then
-  if [ ! -e $EDK_TOOLS_PATH/Source/C/bin/$TOOL_BASENAME ]
+  if [ ! -e "$EDK_TOOLS_PATH/Source/C/bin/$cmd" ]
   then
-    echo BaseTools C Tool binary was not found \($TOOL_BASENAME\)
-    echo You may need to run:
+    echo "BaseTools C Tool binary was not found ($cmd)"
+    echo "You may need to run:"
     echo "  make -C $EDK_TOOLS_PATH/Source/C"
   else
-    exec $EDK_TOOLS_PATH/Source/C/bin/$TOOL_BASENAME $*
+    exec "$EDK_TOOLS_PATH/Source/C/bin/$cmd" "$@"
   fi
-elif [ -e `dirname $0`/../../Source/C/bin/$TOOL_BASENAME ]
+elif [ -e "$dir/../../Source/C/bin/$cmd" ]
 then
-  exec `dirname $0`/../../Source/C/bin/$TOOL_BASENAME $*
+  exec "$dir/../../Source/C/bin/$cmd" "$@"
 else
-  echo Unable to find the real \'$TOOL_BASENAME\' to run
-  echo This message was printed by
+  echo "Unable to find the real '$cmd' to run"
+  echo "This message was printed by"
   echo "  $0"
-  exit -1
+  exit 127
 fi
 

--- a/BaseTools/Bin/CYGWIN_NT-5.1-i686/TargetTool
+++ b/BaseTools/Bin/CYGWIN_NT-5.1-i686/TargetTool
@@ -1,5 +1,14 @@
 #!/usr/bin/env bash
 #python `dirname $0`/RunToolFromSource.py `basename $0` $*
-PYTHONPATH="`dirname $0`/../../Source/Python" \
-    python "`dirname $0`/../../Source/Python"/`basename $0`/`basename $0`.py $*
 
+# If a python2 command is available, use it in preference to python
+if command -v python2 >/dev/null 2>&1; then
+    python_exe=python2
+fi
+
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+dir=$(dirname "$full_cmd")
+cmd=${full_cmd##*/}
+
+export PYTHONPATH="$dir/../../Source/Python"
+exec "${python_exe:-python}" "$dir/../../Source/Python/$cmd/$cmd.py" "$@"

--- a/BaseTools/Bin/CYGWIN_NT-5.1-i686/TianoCompress
+++ b/BaseTools/Bin/CYGWIN_NT-5.1-i686/TianoCompress
@@ -1,29 +1,29 @@
 #!/usr/bin/env bash
-#python `dirname $0`/RunToolFromSource.py `basename $0` $*
-#exec `dirname $0`/../../../../C/bin/`basename $0` $*
 
-TOOL_BASENAME=`basename $0`
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+dir=$(dirname "$full_cmd")
+cmd=${full_cmd##*/}
 
-if [ -n "$WORKSPACE" -a -e $WORKSPACE/Conf/BaseToolsCBinaries ]
+if [ -n "$WORKSPACE" ] && [ -e "$WORKSPACE/Conf/BaseToolsCBinaries" ]
 then
-  exec $WORKSPACE/Conf/BaseToolsCBinaries/$TOOL_BASENAME
-elif [ -n "$WORKSPACE" -a -e $EDK_TOOLS_PATH/Source/C ]
+  exec "$WORKSPACE/Conf/BaseToolsCBinaries/$cmd"
+elif [ -n "$WORKSPACE" ] && [ -e "$EDK_TOOLS_PATH/Source/C" ]
 then
-  if [ ! -e $EDK_TOOLS_PATH/Source/C/bin/$TOOL_BASENAME ]
+  if [ ! -e "$EDK_TOOLS_PATH/Source/C/bin/$cmd" ]
   then
-    echo BaseTools C Tool binary was not found \($TOOL_BASENAME\)
-    echo You may need to run:
+    echo "BaseTools C Tool binary was not found ($cmd)"
+    echo "You may need to run:"
     echo "  make -C $EDK_TOOLS_PATH/Source/C"
   else
-    exec $EDK_TOOLS_PATH/Source/C/bin/$TOOL_BASENAME $*
+    exec "$EDK_TOOLS_PATH/Source/C/bin/$cmd" "$@"
   fi
-elif [ -e `dirname $0`/../../Source/C/bin/$TOOL_BASENAME ]
+elif [ -e "$dir/../../Source/C/bin/$cmd" ]
 then
-  exec `dirname $0`/../../Source/C/bin/$TOOL_BASENAME $*
+  exec "$dir/../../Source/C/bin/$cmd" "$@"
 else
-  echo Unable to find the real \'$TOOL_BASENAME\' to run
-  echo This message was printed by
+  echo "Unable to find the real '$cmd' to run"
+  echo "This message was printed by"
   echo "  $0"
-  exit -1
+  exit 127
 fi
 

--- a/BaseTools/Bin/CYGWIN_NT-5.1-i686/Trim
+++ b/BaseTools/Bin/CYGWIN_NT-5.1-i686/Trim
@@ -1,5 +1,14 @@
 #!/usr/bin/env bash
 #python `dirname $0`/RunToolFromSource.py `basename $0` $*
-PYTHONPATH="`dirname $0`/../../Source/Python" \
-    python "`dirname $0`/../../Source/Python"/`basename $0`/`basename $0`.py $*
 
+# If a python2 command is available, use it in preference to python
+if command -v python2 >/dev/null 2>&1; then
+    python_exe=python2
+fi
+
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+dir=$(dirname "$full_cmd")
+exe=$(basename "$full_cmd")
+
+export PYTHONPATH="$dir/../../Source/Python"
+exec "${python_exe:-python}" "$dir/../../Source/Python/$exe/$exe.py" "$@"

--- a/BaseTools/Bin/CYGWIN_NT-5.1-i686/VfrCompile
+++ b/BaseTools/Bin/CYGWIN_NT-5.1-i686/VfrCompile
@@ -1,29 +1,29 @@
 #!/usr/bin/env bash
-#python `dirname $0`/RunToolFromSource.py `basename $0` $*
-#exec `dirname $0`/../../../../C/bin/`basename $0` $*
 
-TOOL_BASENAME=`basename $0`
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+dir=$(dirname "$full_cmd")
+cmd=${full_cmd##*/}
 
-if [ -n "$WORKSPACE" -a -e $WORKSPACE/Conf/BaseToolsCBinaries ]
+if [ -n "$WORKSPACE" ] && [ -e "$WORKSPACE/Conf/BaseToolsCBinaries" ]
 then
-  exec $WORKSPACE/Conf/BaseToolsCBinaries/$TOOL_BASENAME
-elif [ -n "$WORKSPACE" -a -e $EDK_TOOLS_PATH/Source/C ]
+  exec "$WORKSPACE/Conf/BaseToolsCBinaries/$cmd"
+elif [ -n "$WORKSPACE" ] && [ -e "$EDK_TOOLS_PATH/Source/C" ]
 then
-  if [ ! -e $EDK_TOOLS_PATH/Source/C/bin/$TOOL_BASENAME ]
+  if [ ! -e "$EDK_TOOLS_PATH/Source/C/bin/$cmd" ]
   then
-    echo BaseTools C Tool binary was not found \($TOOL_BASENAME\)
-    echo You may need to run:
+    echo "BaseTools C Tool binary was not found ($cmd)"
+    echo "You may need to run:"
     echo "  make -C $EDK_TOOLS_PATH/Source/C"
   else
-    exec $EDK_TOOLS_PATH/Source/C/bin/$TOOL_BASENAME $*
+    exec "$EDK_TOOLS_PATH/Source/C/bin/$cmd" "$@"
   fi
-elif [ -e `dirname $0`/../../Source/C/bin/$TOOL_BASENAME ]
+elif [ -e "$dir/../../Source/C/bin/$cmd" ]
 then
-  exec `dirname $0`/../../Source/C/bin/$TOOL_BASENAME $*
+  exec "$dir/../../Source/C/bin/$cmd" "$@"
 else
-  echo Unable to find the real \'$TOOL_BASENAME\' to run
-  echo This message was printed by
+  echo "Unable to find the real '$cmd' to run"
+  echo "This message was printed by"
   echo "  $0"
-  exit -1
+  exit 127
 fi
 

--- a/BaseTools/Bin/CYGWIN_NT-5.1-i686/VolInfo
+++ b/BaseTools/Bin/CYGWIN_NT-5.1-i686/VolInfo
@@ -1,29 +1,29 @@
 #!/usr/bin/env bash
-#python `dirname $0`/RunToolFromSource.py `basename $0` $*
-#exec `dirname $0`/../../../../C/bin/`basename $0` $*
 
-TOOL_BASENAME=`basename $0`
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+dir=$(dirname "$full_cmd")
+cmd=${full_cmd##*/}
 
-if [ -n "$WORKSPACE" -a -e $WORKSPACE/Conf/BaseToolsCBinaries ]
+if [ -n "$WORKSPACE" ] && [ -e "$WORKSPACE/Conf/BaseToolsCBinaries" ]
 then
-  exec $WORKSPACE/Conf/BaseToolsCBinaries/$TOOL_BASENAME
-elif [ -n "$WORKSPACE" -a -e $EDK_TOOLS_PATH/Source/C ]
+  exec "$WORKSPACE/Conf/BaseToolsCBinaries/$cmd"
+elif [ -n "$WORKSPACE" ] && [ -e "$EDK_TOOLS_PATH/Source/C" ]
 then
-  if [ ! -e $EDK_TOOLS_PATH/Source/C/bin/$TOOL_BASENAME ]
+  if [ ! -e "$EDK_TOOLS_PATH/Source/C/bin/$cmd" ]
   then
-    echo BaseTools C Tool binary was not found \($TOOL_BASENAME\)
-    echo You may need to run:
+    echo "BaseTools C Tool binary was not found ($cmd)"
+    echo "You may need to run:"
     echo "  make -C $EDK_TOOLS_PATH/Source/C"
   else
-    exec $EDK_TOOLS_PATH/Source/C/bin/$TOOL_BASENAME $*
+    exec "$EDK_TOOLS_PATH/Source/C/bin/$cmd" "$@"
   fi
-elif [ -e `dirname $0`/../../Source/C/bin/$TOOL_BASENAME ]
+elif [ -e "$dir/../../Source/C/bin/$cmd" ]
 then
-  exec `dirname $0`/../../Source/C/bin/$TOOL_BASENAME $*
+  exec "$dir/../../Source/C/bin/$cmd" "$@"
 else
-  echo Unable to find the real \'$TOOL_BASENAME\' to run
-  echo This message was printed by
+  echo "Unable to find the real '$cmd' to run"
+  echo "This message was printed by"
   echo "  $0"
-  exit -1
+  exit 127
 fi
 

--- a/BaseTools/Bin/CYGWIN_NT-5.1-i686/build
+++ b/BaseTools/Bin/CYGWIN_NT-5.1-i686/build
@@ -1,5 +1,14 @@
 #!/usr/bin/env bash
 #python `dirname $0`/RunToolFromSource.py `basename $0` $*
-PYTHONPATH="`dirname $0`/../../Source/Python" \
-    python "`dirname $0`/../../Source/Python"/`basename $0`/`basename $0`.py $*
 
+# If a python2 command is available, use it in preference to python
+if command -v python2 >/dev/null 2>&1; then
+    python_exe=python2
+fi
+
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+dir=$(dirname "$full_cmd")
+cmd=${full_cmd##*/}
+
+export PYTHONPATH="$dir/../../Source/Python"
+exec "${python_exe:-python}" "$dir/../../Source/Python/$cmd/$cmd.py" "$@"

--- a/BaseTools/BinWrappers/PosixLike/BPDG
+++ b/BaseTools/BinWrappers/PosixLike/BPDG
@@ -1,5 +1,14 @@
 #!/usr/bin/env bash
 #python `dirname $0`/RunToolFromSource.py `basename $0` $*
-PYTHONPATH="`dirname $0`/../../Source/Python" \
-    python "`dirname $0`/../../Source/Python"/`basename $0`/`basename $0`.py $*
 
+# If a python2 command is available, use it in preference to python
+if command -v python2 >/dev/null 2>&1; then
+    python_exe=python2
+fi
+
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+dir=$(dirname "$full_cmd")
+cmd=${full_cmd##*/}
+
+export PYTHONPATH="$dir/../../Source/Python"
+exec "${python_exe:-python}" "$dir/../../Source/Python/$cmd/$cmd.py" "$@"

--- a/BaseTools/BinWrappers/PosixLike/BootSectImage
+++ b/BaseTools/BinWrappers/PosixLike/BootSectImage
@@ -1,29 +1,29 @@
 #!/usr/bin/env bash
-#python `dirname $0`/RunToolFromSource.py `basename $0` $*
-#exec `dirname $0`/../../../../C/bin/`basename $0` $*
 
-TOOL_BASENAME=`basename $0`
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+dir=$(dirname "$full_cmd")
+cmd=${full_cmd##*/}
 
-if [ -n "$WORKSPACE" -a -e $WORKSPACE/Conf/BaseToolsCBinaries ]
+if [ -n "$WORKSPACE" ] && [ -e "$WORKSPACE/Conf/BaseToolsCBinaries" ]
 then
-  exec $WORKSPACE/Conf/BaseToolsCBinaries/$TOOL_BASENAME
-elif [ -n "$WORKSPACE" -a -e $EDK_TOOLS_PATH/Source/C ]
+  exec "$WORKSPACE/Conf/BaseToolsCBinaries/$cmd"
+elif [ -n "$WORKSPACE" ] && [ -e "$EDK_TOOLS_PATH/Source/C" ]
 then
-  if [ ! -e $EDK_TOOLS_PATH/Source/C/bin/$TOOL_BASENAME ]
+  if [ ! -e "$EDK_TOOLS_PATH/Source/C/bin/$cmd" ]
   then
-    echo BaseTools C Tool binary was not found \($TOOL_BASENAME\)
-    echo You may need to run:
+    echo "BaseTools C Tool binary was not found ($cmd)"
+    echo "You may need to run:"
     echo "  make -C $EDK_TOOLS_PATH/Source/C"
   else
-    exec $EDK_TOOLS_PATH/Source/C/bin/$TOOL_BASENAME $*
+    exec "$EDK_TOOLS_PATH/Source/C/bin/$cmd" "$@"
   fi
-elif [ -e `dirname $0`/../../Source/C/bin/$TOOL_BASENAME ]
+elif [ -e "$dir/../../Source/C/bin/$cmd" ]
 then
-  exec `dirname $0`/../../Source/C/bin/$TOOL_BASENAME $*
+  exec "$dir/../../Source/C/bin/$cmd" "$@"
 else
-  echo Unable to find the real \'$TOOL_BASENAME\' to run
-  echo This message was printed by
+  echo "Unable to find the real '$cmd' to run"
+  echo "This message was printed by"
   echo "  $0"
-  exit -1
+  exit 127
 fi
 

--- a/BaseTools/BinWrappers/PosixLike/Ecc
+++ b/BaseTools/BinWrappers/PosixLike/Ecc
@@ -1,5 +1,14 @@
 #!/usr/bin/env bash
 #python `dirname $0`/RunToolFromSource.py `basename $0` $*
-PYTHONPATH="`dirname $0`/../../Source/Python" \
-    python "`dirname $0`/../../Source/Python"/`basename $0`/`basename $0`.py $*
 
+# If a python2 command is available, use it in preference to python
+if command -v python2 >/dev/null 2>&1; then
+    python_exe=python2
+fi
+
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+dir=$(dirname "$full_cmd")
+cmd=${full_cmd##*/}
+
+export PYTHONPATH="$dir/../../Source/Python"
+exec "${python_exe:-python}" "$dir/../../Source/Python/$cmd/$cmd.py" "$@"

--- a/BaseTools/BinWrappers/PosixLike/EfiLdrImage
+++ b/BaseTools/BinWrappers/PosixLike/EfiLdrImage
@@ -1,29 +1,29 @@
 #!/usr/bin/env bash
-#python `dirname $0`/RunToolFromSource.py `basename $0` $*
-#exec `dirname $0`/../../../../C/bin/`basename $0` $*
 
-TOOL_BASENAME=`basename $0`
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+dir=$(dirname "$full_cmd")
+cmd=${full_cmd##*/}
 
-if [ -n "$WORKSPACE" -a -e $WORKSPACE/Conf/BaseToolsCBinaries ]
+if [ -n "$WORKSPACE" ] && [ -e "$WORKSPACE/Conf/BaseToolsCBinaries" ]
 then
-  exec $WORKSPACE/Conf/BaseToolsCBinaries/$TOOL_BASENAME
-elif [ -n "$WORKSPACE" -a -e $EDK_TOOLS_PATH/Source/C ]
+  exec "$WORKSPACE/Conf/BaseToolsCBinaries/$cmd"
+elif [ -n "$WORKSPACE" ] && [ -e "$EDK_TOOLS_PATH/Source/C" ]
 then
-  if [ ! -e $EDK_TOOLS_PATH/Source/C/bin/$TOOL_BASENAME ]
+  if [ ! -e "$EDK_TOOLS_PATH/Source/C/bin/$cmd" ]
   then
-    echo BaseTools C Tool binary was not found \($TOOL_BASENAME\)
-    echo You may need to run:
+    echo "BaseTools C Tool binary was not found ($cmd)"
+    echo "You may need to run:"
     echo "  make -C $EDK_TOOLS_PATH/Source/C"
   else
-    exec $EDK_TOOLS_PATH/Source/C/bin/$TOOL_BASENAME $*
+    exec "$EDK_TOOLS_PATH/Source/C/bin/$cmd" "$@"
   fi
-elif [ -e `dirname $0`/../../Source/C/bin/$TOOL_BASENAME ]
+elif [ -e "$dir/../../Source/C/bin/$cmd" ]
 then
-  exec `dirname $0`/../../Source/C/bin/$TOOL_BASENAME $*
+  exec "$dir/../../Source/C/bin/$cmd" "$@"
 else
-  echo Unable to find the real \'$TOOL_BASENAME\' to run
-  echo This message was printed by
+  echo "Unable to find the real '$cmd' to run"
+  echo "This message was printed by"
   echo "  $0"
-  exit -1
+  exit 127
 fi
 

--- a/BaseTools/BinWrappers/PosixLike/EfiRom
+++ b/BaseTools/BinWrappers/PosixLike/EfiRom
@@ -1,29 +1,29 @@
 #!/usr/bin/env bash
-#python `dirname $0`/RunToolFromSource.py `basename $0` $*
-#exec `dirname $0`/../../../../C/bin/`basename $0` $*
 
-TOOL_BASENAME=`basename $0`
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+dir=$(dirname "$full_cmd")
+cmd=${full_cmd##*/}
 
-if [ -n "$WORKSPACE" -a -e $WORKSPACE/Conf/BaseToolsCBinaries ]
+if [ -n "$WORKSPACE" ] && [ -e "$WORKSPACE/Conf/BaseToolsCBinaries" ]
 then
-  exec $WORKSPACE/Conf/BaseToolsCBinaries/$TOOL_BASENAME
-elif [ -n "$WORKSPACE" -a -e $EDK_TOOLS_PATH/Source/C ]
+  exec "$WORKSPACE/Conf/BaseToolsCBinaries/$cmd"
+elif [ -n "$WORKSPACE" ] && [ -e "$EDK_TOOLS_PATH/Source/C" ]
 then
-  if [ ! -e $EDK_TOOLS_PATH/Source/C/bin/$TOOL_BASENAME ]
+  if [ ! -e "$EDK_TOOLS_PATH/Source/C/bin/$cmd" ]
   then
-    echo BaseTools C Tool binary was not found \($TOOL_BASENAME\)
-    echo You may need to run:
+    echo "BaseTools C Tool binary was not found ($cmd)"
+    echo "You may need to run:"
     echo "  make -C $EDK_TOOLS_PATH/Source/C"
   else
-    exec $EDK_TOOLS_PATH/Source/C/bin/$TOOL_BASENAME $*
+    exec "$EDK_TOOLS_PATH/Source/C/bin/$cmd" "$@"
   fi
-elif [ -e `dirname $0`/../../Source/C/bin/$TOOL_BASENAME ]
+elif [ -e "$dir/../../Source/C/bin/$cmd" ]
 then
-  exec `dirname $0`/../../Source/C/bin/$TOOL_BASENAME $*
+  exec "$dir/../../Source/C/bin/$cmd" "$@"
 else
-  echo Unable to find the real \'$TOOL_BASENAME\' to run
-  echo This message was printed by
+  echo "Unable to find the real '$cmd' to run"
+  echo "This message was printed by"
   echo "  $0"
-  exit -1
+  exit 127
 fi
 

--- a/BaseTools/BinWrappers/PosixLike/GenCrc32
+++ b/BaseTools/BinWrappers/PosixLike/GenCrc32
@@ -1,29 +1,29 @@
 #!/usr/bin/env bash
-#python `dirname $0`/RunToolFromSource.py `basename $0` $*
-#exec `dirname $0`/../../../../C/bin/`basename $0` $*
 
-TOOL_BASENAME=`basename $0`
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+dir=$(dirname "$full_cmd")
+cmd=${full_cmd##*/}
 
-if [ -n "$WORKSPACE" -a -e $WORKSPACE/Conf/BaseToolsCBinaries ]
+if [ -n "$WORKSPACE" ] && [ -e "$WORKSPACE/Conf/BaseToolsCBinaries" ]
 then
-  exec $WORKSPACE/Conf/BaseToolsCBinaries/$TOOL_BASENAME
-elif [ -n "$WORKSPACE" -a -e $EDK_TOOLS_PATH/Source/C ]
+  exec "$WORKSPACE/Conf/BaseToolsCBinaries/$cmd"
+elif [ -n "$WORKSPACE" ] && [ -e "$EDK_TOOLS_PATH/Source/C" ]
 then
-  if [ ! -e $EDK_TOOLS_PATH/Source/C/bin/$TOOL_BASENAME ]
+  if [ ! -e "$EDK_TOOLS_PATH/Source/C/bin/$cmd" ]
   then
-    echo BaseTools C Tool binary was not found \($TOOL_BASENAME\)
-    echo You may need to run:
+    echo "BaseTools C Tool binary was not found ($cmd)"
+    echo "You may need to run:"
     echo "  make -C $EDK_TOOLS_PATH/Source/C"
   else
-    exec $EDK_TOOLS_PATH/Source/C/bin/$TOOL_BASENAME $*
+    exec "$EDK_TOOLS_PATH/Source/C/bin/$cmd" "$@"
   fi
-elif [ -e `dirname $0`/../../Source/C/bin/$TOOL_BASENAME ]
+elif [ -e "$dir/../../Source/C/bin/$cmd" ]
 then
-  exec `dirname $0`/../../Source/C/bin/$TOOL_BASENAME $*
+  exec "$dir/../../Source/C/bin/$cmd" "$@"
 else
-  echo Unable to find the real \'$TOOL_BASENAME\' to run
-  echo This message was printed by
+  echo "Unable to find the real '$cmd' to run"
+  echo "This message was printed by"
   echo "  $0"
-  exit -1
+  exit 127
 fi
 

--- a/BaseTools/BinWrappers/PosixLike/GenDepex
+++ b/BaseTools/BinWrappers/PosixLike/GenDepex
@@ -1,3 +1,14 @@
 #!/usr/bin/env bash
-PYTHONPATH="`dirname $0`/../../Source/Python" \
-    python "`dirname $0`/../../Source/Python"/AutoGen/`basename $0`.py $*
+#python `dirname $0`/RunToolFromSource.py `basename $0` $*
+
+# If a python2 command is available, use it in preference to python
+if command -v python2 >/dev/null 2>&1; then
+    python_exe=python2
+fi
+
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+dir=$(dirname "$full_cmd")
+cmd=${full_cmd##*/}
+
+export PYTHONPATH="$dir/../../Source/Python"
+exec "${python_exe:-python}" "$dir/../../Source/Python/$cmd/$cmd.py" "$@"

--- a/BaseTools/BinWrappers/PosixLike/GenFds
+++ b/BaseTools/BinWrappers/PosixLike/GenFds
@@ -1,5 +1,14 @@
 #!/usr/bin/env bash
 #python `dirname $0`/RunToolFromSource.py `basename $0` $*
-PYTHONPATH="`dirname $0`/../../Source/Python" \
-    python "`dirname $0`/../../Source/Python"/`basename $0`/`basename $0`.py $*
 
+# If a python2 command is available, use it in preference to python
+if command -v python2 >/dev/null 2>&1; then
+    python_exe=python2
+fi
+
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+dir=$(dirname "$full_cmd")
+cmd=${full_cmd##*/}
+
+export PYTHONPATH="$dir/../../Source/Python"
+exec "${python_exe:-python}" "$dir/../../Source/Python/$cmd/$cmd.py" "$@"

--- a/BaseTools/BinWrappers/PosixLike/GenFfs
+++ b/BaseTools/BinWrappers/PosixLike/GenFfs
@@ -1,29 +1,29 @@
 #!/usr/bin/env bash
-#python `dirname $0`/RunToolFromSource.py `basename $0` $*
-#exec `dirname $0`/../../../../C/bin/`basename $0` $*
 
-TOOL_BASENAME=`basename $0`
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+dir=$(dirname "$full_cmd")
+cmd=${full_cmd##*/}
 
-if [ -n "$WORKSPACE" -a -e $WORKSPACE/Conf/BaseToolsCBinaries ]
+if [ -n "$WORKSPACE" ] && [ -e "$WORKSPACE/Conf/BaseToolsCBinaries" ]
 then
-  exec $WORKSPACE/Conf/BaseToolsCBinaries/$TOOL_BASENAME
-elif [ -n "$WORKSPACE" -a -e $EDK_TOOLS_PATH/Source/C ]
+  exec "$WORKSPACE/Conf/BaseToolsCBinaries/$cmd"
+elif [ -n "$WORKSPACE" ] && [ -e "$EDK_TOOLS_PATH/Source/C" ]
 then
-  if [ ! -e $EDK_TOOLS_PATH/Source/C/bin/$TOOL_BASENAME ]
+  if [ ! -e "$EDK_TOOLS_PATH/Source/C/bin/$cmd" ]
   then
-    echo BaseTools C Tool binary was not found \($TOOL_BASENAME\)
-    echo You may need to run:
+    echo "BaseTools C Tool binary was not found ($cmd)"
+    echo "You may need to run:"
     echo "  make -C $EDK_TOOLS_PATH/Source/C"
   else
-    exec $EDK_TOOLS_PATH/Source/C/bin/$TOOL_BASENAME $*
+    exec "$EDK_TOOLS_PATH/Source/C/bin/$cmd" "$@"
   fi
-elif [ -e `dirname $0`/../../Source/C/bin/$TOOL_BASENAME ]
+elif [ -e "$dir/../../Source/C/bin/$cmd" ]
 then
-  exec `dirname $0`/../../Source/C/bin/$TOOL_BASENAME $*
+  exec "$dir/../../Source/C/bin/$cmd" "$@"
 else
-  echo Unable to find the real \'$TOOL_BASENAME\' to run
-  echo This message was printed by
+  echo "Unable to find the real '$cmd' to run"
+  echo "This message was printed by"
   echo "  $0"
-  exit -1
+  exit 127
 fi
 

--- a/BaseTools/BinWrappers/PosixLike/GenFv
+++ b/BaseTools/BinWrappers/PosixLike/GenFv
@@ -1,29 +1,29 @@
 #!/usr/bin/env bash
-#python `dirname $0`/RunToolFromSource.py `basename $0` $*
-#exec `dirname $0`/../../../../C/bin/`basename $0` $*
 
-TOOL_BASENAME=`basename $0`
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+dir=$(dirname "$full_cmd")
+cmd=${full_cmd##*/}
 
-if [ -n "$WORKSPACE" -a -e $WORKSPACE/Conf/BaseToolsCBinaries ]
+if [ -n "$WORKSPACE" ] && [ -e "$WORKSPACE/Conf/BaseToolsCBinaries" ]
 then
-  exec $WORKSPACE/Conf/BaseToolsCBinaries/$TOOL_BASENAME
-elif [ -n "$WORKSPACE" -a -e $EDK_TOOLS_PATH/Source/C ]
+  exec "$WORKSPACE/Conf/BaseToolsCBinaries/$cmd"
+elif [ -n "$WORKSPACE" ] && [ -e "$EDK_TOOLS_PATH/Source/C" ]
 then
-  if [ ! -e $EDK_TOOLS_PATH/Source/C/bin/$TOOL_BASENAME ]
+  if [ ! -e "$EDK_TOOLS_PATH/Source/C/bin/$cmd" ]
   then
-    echo BaseTools C Tool binary was not found \($TOOL_BASENAME\)
-    echo You may need to run:
+    echo "BaseTools C Tool binary was not found ($cmd)"
+    echo "You may need to run:"
     echo "  make -C $EDK_TOOLS_PATH/Source/C"
   else
-    exec $EDK_TOOLS_PATH/Source/C/bin/$TOOL_BASENAME $*
+    exec "$EDK_TOOLS_PATH/Source/C/bin/$cmd" "$@"
   fi
-elif [ -e `dirname $0`/../../Source/C/bin/$TOOL_BASENAME ]
+elif [ -e "$dir/../../Source/C/bin/$cmd" ]
 then
-  exec `dirname $0`/../../Source/C/bin/$TOOL_BASENAME $*
+  exec "$dir/../../Source/C/bin/$cmd" "$@"
 else
-  echo Unable to find the real \'$TOOL_BASENAME\' to run
-  echo This message was printed by
+  echo "Unable to find the real '$cmd' to run"
+  echo "This message was printed by"
   echo "  $0"
-  exit -1
+  exit 127
 fi
 

--- a/BaseTools/BinWrappers/PosixLike/GenFw
+++ b/BaseTools/BinWrappers/PosixLike/GenFw
@@ -1,29 +1,29 @@
 #!/usr/bin/env bash
-#python `dirname $0`/RunToolFromSource.py `basename $0` $*
-#exec `dirname $0`/../../../../C/bin/`basename $0` $*
 
-TOOL_BASENAME=`basename $0`
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+dir=$(dirname "$full_cmd")
+cmd=${full_cmd##*/}
 
-if [ -n "$WORKSPACE" -a -e $WORKSPACE/Conf/BaseToolsCBinaries ]
+if [ -n "$WORKSPACE" ] && [ -e "$WORKSPACE/Conf/BaseToolsCBinaries" ]
 then
-  exec $WORKSPACE/Conf/BaseToolsCBinaries/$TOOL_BASENAME
-elif [ -n "$WORKSPACE" -a -e $EDK_TOOLS_PATH/Source/C ]
+  exec "$WORKSPACE/Conf/BaseToolsCBinaries/$cmd"
+elif [ -n "$WORKSPACE" ] && [ -e "$EDK_TOOLS_PATH/Source/C" ]
 then
-  if [ ! -e $EDK_TOOLS_PATH/Source/C/bin/$TOOL_BASENAME ]
+  if [ ! -e "$EDK_TOOLS_PATH/Source/C/bin/$cmd" ]
   then
-    echo BaseTools C Tool binary was not found \($TOOL_BASENAME\)
-    echo You may need to run:
+    echo "BaseTools C Tool binary was not found ($cmd)"
+    echo "You may need to run:"
     echo "  make -C $EDK_TOOLS_PATH/Source/C"
   else
-    exec $EDK_TOOLS_PATH/Source/C/bin/$TOOL_BASENAME $*
+    exec "$EDK_TOOLS_PATH/Source/C/bin/$cmd" "$@"
   fi
-elif [ -e `dirname $0`/../../Source/C/bin/$TOOL_BASENAME ]
+elif [ -e "$dir/../../Source/C/bin/$cmd" ]
 then
-  exec `dirname $0`/../../Source/C/bin/$TOOL_BASENAME $*
+  exec "$dir/../../Source/C/bin/$cmd" "$@"
 else
-  echo Unable to find the real \'$TOOL_BASENAME\' to run
-  echo This message was printed by
+  echo "Unable to find the real '$cmd' to run"
+  echo "This message was printed by"
   echo "  $0"
-  exit -1
+  exit 127
 fi
 

--- a/BaseTools/BinWrappers/PosixLike/GenPage
+++ b/BaseTools/BinWrappers/PosixLike/GenPage
@@ -1,29 +1,29 @@
 #!/usr/bin/env bash
-#python `dirname $0`/RunToolFromSource.py `basename $0` $*
-#exec `dirname $0`/../../../../C/bin/`basename $0` $*
 
-TOOL_BASENAME=`basename $0`
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+dir=$(dirname "$full_cmd")
+cmd=${full_cmd##*/}
 
-if [ -n "$WORKSPACE" -a -e $WORKSPACE/Conf/BaseToolsCBinaries ]
+if [ -n "$WORKSPACE" ] && [ -e "$WORKSPACE/Conf/BaseToolsCBinaries" ]
 then
-  exec $WORKSPACE/Conf/BaseToolsCBinaries/$TOOL_BASENAME
-elif [ -n "$WORKSPACE" -a -e $EDK_TOOLS_PATH/Source/C ]
+  exec "$WORKSPACE/Conf/BaseToolsCBinaries/$cmd"
+elif [ -n "$WORKSPACE" ] && [ -e "$EDK_TOOLS_PATH/Source/C" ]
 then
-  if [ ! -e $EDK_TOOLS_PATH/Source/C/bin/$TOOL_BASENAME ]
+  if [ ! -e "$EDK_TOOLS_PATH/Source/C/bin/$cmd" ]
   then
-    echo BaseTools C Tool binary was not found \($TOOL_BASENAME\)
-    echo You may need to run:
+    echo "BaseTools C Tool binary was not found ($cmd)"
+    echo "You may need to run:"
     echo "  make -C $EDK_TOOLS_PATH/Source/C"
   else
-    exec $EDK_TOOLS_PATH/Source/C/bin/$TOOL_BASENAME $*
+    exec "$EDK_TOOLS_PATH/Source/C/bin/$cmd" "$@"
   fi
-elif [ -e `dirname $0`/../../Source/C/bin/$TOOL_BASENAME ]
+elif [ -e "$dir/../../Source/C/bin/$cmd" ]
 then
-  exec `dirname $0`/../../Source/C/bin/$TOOL_BASENAME $*
+  exec "$dir/../../Source/C/bin/$cmd" "$@"
 else
-  echo Unable to find the real \'$TOOL_BASENAME\' to run
-  echo This message was printed by
+  echo "Unable to find the real '$cmd' to run"
+  echo "This message was printed by"
   echo "  $0"
-  exit -1
+  exit 127
 fi
 

--- a/BaseTools/BinWrappers/PosixLike/GenPatchPcdTable
+++ b/BaseTools/BinWrappers/PosixLike/GenPatchPcdTable
@@ -1,5 +1,14 @@
 #!/usr/bin/env bash
 #python `dirname $0`/RunToolFromSource.py `basename $0` $*
-PYTHONPATH="`dirname $0`/../../Source/Python" \
-    python "`dirname $0`/../../Source/Python"/`basename $0`/`basename $0`.py $*
 
+# If a python2 command is available, use it in preference to python
+if command -v python2 >/dev/null 2>&1; then
+    python_exe=python2
+fi
+
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+dir=$(dirname "$full_cmd")
+cmd=${full_cmd##*/}
+
+export PYTHONPATH="$dir/../../Source/Python"
+exec "${python_exe:-python}" "$dir/../../Source/Python/$cmd/$cmd.py" "$@"

--- a/BaseTools/BinWrappers/PosixLike/GenSec
+++ b/BaseTools/BinWrappers/PosixLike/GenSec
@@ -1,29 +1,29 @@
 #!/usr/bin/env bash
-#python `dirname $0`/RunToolFromSource.py `basename $0` $*
-#exec `dirname $0`/../../../../C/bin/`basename $0` $*
 
-TOOL_BASENAME=`basename $0`
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+dir=$(dirname "$full_cmd")
+cmd=${full_cmd##*/}
 
-if [ -n "$WORKSPACE" -a -e $WORKSPACE/Conf/BaseToolsCBinaries ]
+if [ -n "$WORKSPACE" ] && [ -e "$WORKSPACE/Conf/BaseToolsCBinaries" ]
 then
-  exec $WORKSPACE/Conf/BaseToolsCBinaries/$TOOL_BASENAME
-elif [ -n "$WORKSPACE" -a -e $EDK_TOOLS_PATH/Source/C ]
+  exec "$WORKSPACE/Conf/BaseToolsCBinaries/$cmd"
+elif [ -n "$WORKSPACE" ] && [ -e "$EDK_TOOLS_PATH/Source/C" ]
 then
-  if [ ! -e $EDK_TOOLS_PATH/Source/C/bin/$TOOL_BASENAME ]
+  if [ ! -e "$EDK_TOOLS_PATH/Source/C/bin/$cmd" ]
   then
-    echo BaseTools C Tool binary was not found \($TOOL_BASENAME\)
-    echo You may need to run:
+    echo "BaseTools C Tool binary was not found ($cmd)"
+    echo "You may need to run:"
     echo "  make -C $EDK_TOOLS_PATH/Source/C"
   else
-    exec $EDK_TOOLS_PATH/Source/C/bin/$TOOL_BASENAME $*
+    exec "$EDK_TOOLS_PATH/Source/C/bin/$cmd" "$@"
   fi
-elif [ -e `dirname $0`/../../Source/C/bin/$TOOL_BASENAME ]
+elif [ -e "$dir/../../Source/C/bin/$cmd" ]
 then
-  exec `dirname $0`/../../Source/C/bin/$TOOL_BASENAME $*
+  exec "$dir/../../Source/C/bin/$cmd" "$@"
 else
-  echo Unable to find the real \'$TOOL_BASENAME\' to run
-  echo This message was printed by
+  echo "Unable to find the real '$cmd' to run"
+  echo "This message was printed by"
   echo "  $0"
-  exit -1
+  exit 127
 fi
 

--- a/BaseTools/BinWrappers/PosixLike/GenVtf
+++ b/BaseTools/BinWrappers/PosixLike/GenVtf
@@ -1,29 +1,29 @@
 #!/usr/bin/env bash
-#python `dirname $0`/RunToolFromSource.py `basename $0` $*
-#exec `dirname $0`/../../../../C/bin/`basename $0` $*
 
-TOOL_BASENAME=`basename $0`
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+dir=$(dirname "$full_cmd")
+cmd=${full_cmd##*/}
 
-if [ -n "$WORKSPACE" -a -e $WORKSPACE/Conf/BaseToolsCBinaries ]
+if [ -n "$WORKSPACE" ] && [ -e "$WORKSPACE/Conf/BaseToolsCBinaries" ]
 then
-  exec $WORKSPACE/Conf/BaseToolsCBinaries/$TOOL_BASENAME
-elif [ -n "$WORKSPACE" -a -e $EDK_TOOLS_PATH/Source/C ]
+  exec "$WORKSPACE/Conf/BaseToolsCBinaries/$cmd"
+elif [ -n "$WORKSPACE" ] && [ -e "$EDK_TOOLS_PATH/Source/C" ]
 then
-  if [ ! -e $EDK_TOOLS_PATH/Source/C/bin/$TOOL_BASENAME ]
+  if [ ! -e "$EDK_TOOLS_PATH/Source/C/bin/$cmd" ]
   then
-    echo BaseTools C Tool binary was not found \($TOOL_BASENAME\)
-    echo You may need to run:
+    echo "BaseTools C Tool binary was not found ($cmd)"
+    echo "You may need to run:"
     echo "  make -C $EDK_TOOLS_PATH/Source/C"
   else
-    exec $EDK_TOOLS_PATH/Source/C/bin/$TOOL_BASENAME $*
+    exec "$EDK_TOOLS_PATH/Source/C/bin/$cmd" "$@"
   fi
-elif [ -e `dirname $0`/../../Source/C/bin/$TOOL_BASENAME ]
+elif [ -e "$dir/../../Source/C/bin/$cmd" ]
 then
-  exec `dirname $0`/../../Source/C/bin/$TOOL_BASENAME $*
+  exec "$dir/../../Source/C/bin/$cmd" "$@"
 else
-  echo Unable to find the real \'$TOOL_BASENAME\' to run
-  echo This message was printed by
+  echo "Unable to find the real '$cmd' to run"
+  echo "This message was printed by"
   echo "  $0"
-  exit -1
+  exit 127
 fi
 

--- a/BaseTools/BinWrappers/PosixLike/GnuGenBootSector
+++ b/BaseTools/BinWrappers/PosixLike/GnuGenBootSector
@@ -1,29 +1,29 @@
 #!/usr/bin/env bash
-#python `dirname $0`/RunToolFromSource.py `basename $0` $*
-#exec `dirname $0`/../../../../C/bin/`basename $0` $*
 
-TOOL_BASENAME=`basename $0`
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+dir=$(dirname "$full_cmd")
+cmd=${full_cmd##*/}
 
-if [ -n "$WORKSPACE" -a -e $WORKSPACE/Conf/BaseToolsCBinaries ]
+if [ -n "$WORKSPACE" ] && [ -e "$WORKSPACE/Conf/BaseToolsCBinaries" ]
 then
-  exec $WORKSPACE/Conf/BaseToolsCBinaries/$TOOL_BASENAME
-elif [ -n "$WORKSPACE" -a -e $EDK_TOOLS_PATH/Source/C ]
+  exec "$WORKSPACE/Conf/BaseToolsCBinaries/$cmd"
+elif [ -n "$WORKSPACE" ] && [ -e "$EDK_TOOLS_PATH/Source/C" ]
 then
-  if [ ! -e $EDK_TOOLS_PATH/Source/C/bin/$TOOL_BASENAME ]
+  if [ ! -e "$EDK_TOOLS_PATH/Source/C/bin/$cmd" ]
   then
-    echo BaseTools C Tool binary was not found \($TOOL_BASENAME\)
-    echo You may need to run:
+    echo "BaseTools C Tool binary was not found ($cmd)"
+    echo "You may need to run:"
     echo "  make -C $EDK_TOOLS_PATH/Source/C"
   else
-    exec $EDK_TOOLS_PATH/Source/C/bin/$TOOL_BASENAME $*
+    exec "$EDK_TOOLS_PATH/Source/C/bin/$cmd" "$@"
   fi
-elif [ -e `dirname $0`/../../Source/C/bin/$TOOL_BASENAME ]
+elif [ -e "$dir/../../Source/C/bin/$cmd" ]
 then
-  exec `dirname $0`/../../Source/C/bin/$TOOL_BASENAME $*
+  exec "$dir/../../Source/C/bin/$cmd" "$@"
 else
-  echo Unable to find the real \'$TOOL_BASENAME\' to run
-  echo This message was printed by
+  echo "Unable to find the real '$cmd' to run"
+  echo "This message was printed by"
   echo "  $0"
-  exit -1
+  exit 127
 fi
 

--- a/BaseTools/BinWrappers/PosixLike/LzmaCompress
+++ b/BaseTools/BinWrappers/PosixLike/LzmaCompress
@@ -1,29 +1,29 @@
 #!/usr/bin/env bash
-#python `dirname $0`/RunToolFromSource.py `basename $0` $*
-#exec `dirname $0`/../../../../C/bin/`basename $0` $*
 
-TOOL_BASENAME=`basename $0`
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+dir=$(dirname "$full_cmd")
+cmd=${full_cmd##*/}
 
-if [ -n "$WORKSPACE" -a -e $WORKSPACE/Conf/BaseToolsCBinaries ]
+if [ -n "$WORKSPACE" ] && [ -e "$WORKSPACE/Conf/BaseToolsCBinaries" ]
 then
-  exec $WORKSPACE/Conf/BaseToolsCBinaries/$TOOL_BASENAME
-elif [ -n "$WORKSPACE" -a -e $EDK_TOOLS_PATH/Source/C ]
+  exec "$WORKSPACE/Conf/BaseToolsCBinaries/$cmd"
+elif [ -n "$WORKSPACE" ] && [ -e "$EDK_TOOLS_PATH/Source/C" ]
 then
-  if [ ! -e $EDK_TOOLS_PATH/Source/C/bin/$TOOL_BASENAME ]
+  if [ ! -e "$EDK_TOOLS_PATH/Source/C/bin/$cmd" ]
   then
-    echo BaseTools C Tool binary was not found \($TOOL_BASENAME\)
-    echo You may need to run:
+    echo "BaseTools C Tool binary was not found ($cmd)"
+    echo "You may need to run:"
     echo "  make -C $EDK_TOOLS_PATH/Source/C"
   else
-    exec $EDK_TOOLS_PATH/Source/C/bin/$TOOL_BASENAME $*
+    exec "$EDK_TOOLS_PATH/Source/C/bin/$cmd" "$@"
   fi
-elif [ -e `dirname $0`/../../Source/C/bin/$TOOL_BASENAME ]
+elif [ -e "$dir/../../Source/C/bin/$cmd" ]
 then
-  exec `dirname $0`/../../Source/C/bin/$TOOL_BASENAME $*
+  exec "$dir/../../Source/C/bin/$cmd" "$@"
 else
-  echo Unable to find the real \'$TOOL_BASENAME\' to run
-  echo This message was printed by
+  echo "Unable to find the real '$cmd' to run"
+  echo "This message was printed by"
   echo "  $0"
-  exit -1
+  exit 127
 fi
 

--- a/BaseTools/BinWrappers/PosixLike/LzmaF86Compress
+++ b/BaseTools/BinWrappers/PosixLike/LzmaF86Compress
@@ -12,11 +12,12 @@
 # WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
 #
 
-for arg in $*; do
-  if [ "$arg" = "-e" -o "$arg" = "-d" ]; then
-    FLAG=--f86
-    break;
-  fi
-done
+for arg; do
+  case $arg in
+    -e|-d)
+      set -- "$@" --f86
+      break
+    ;;
+esac
 
-LzmaCompress $* $FLAG
+exec LzmaCompress "$@"

--- a/BaseTools/BinWrappers/PosixLike/PatchPcdValue
+++ b/BaseTools/BinWrappers/PosixLike/PatchPcdValue
@@ -1,5 +1,14 @@
 #!/usr/bin/env bash
 #python `dirname $0`/RunToolFromSource.py `basename $0` $*
-PYTHONPATH="`dirname $0`/../../Source/Python" \
-    python "`dirname $0`/../../Source/Python"/`basename $0`/`basename $0`.py $*
 
+# If a python2 command is available, use it in preference to python
+if command -v python2 >/dev/null 2>&1; then
+    python_exe=python2
+fi
+
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+dir=$(dirname "$full_cmd")
+cmd=${full_cmd##*/}
+
+export PYTHONPATH="$dir/../../Source/Python"
+exec "${python_exe:-python}" "$dir/../../Source/Python/$cmd/$cmd.py" "$@"

--- a/BaseTools/BinWrappers/PosixLike/Split
+++ b/BaseTools/BinWrappers/PosixLike/Split
@@ -1,29 +1,29 @@
 #!/usr/bin/env bash
-#python `dirname $0`/RunToolFromSource.py `basename $0` $*
-#exec `dirname $0`/../../../../C/bin/`basename $0` $*
 
-TOOL_BASENAME=`basename $0`
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+dir=$(dirname "$full_cmd")
+cmd=${full_cmd##*/}
 
-if [ -n "$WORKSPACE" -a -e $WORKSPACE/Conf/BaseToolsCBinaries ]
+if [ -n "$WORKSPACE" ] && [ -e "$WORKSPACE/Conf/BaseToolsCBinaries" ]
 then
-  exec $WORKSPACE/Conf/BaseToolsCBinaries/$TOOL_BASENAME
-elif [ -n "$WORKSPACE" -a -e $EDK_TOOLS_PATH/Source/C ]
+  exec "$WORKSPACE/Conf/BaseToolsCBinaries/$cmd"
+elif [ -n "$WORKSPACE" ] && [ -e "$EDK_TOOLS_PATH/Source/C" ]
 then
-  if [ ! -e $EDK_TOOLS_PATH/Source/C/bin/$TOOL_BASENAME ]
+  if [ ! -e "$EDK_TOOLS_PATH/Source/C/bin/$cmd" ]
   then
-    echo BaseTools C Tool binary was not found \($TOOL_BASENAME\)
-    echo You may need to run:
+    echo "BaseTools C Tool binary was not found ($cmd)"
+    echo "You may need to run:"
     echo "  make -C $EDK_TOOLS_PATH/Source/C"
   else
-    exec $EDK_TOOLS_PATH/Source/C/bin/$TOOL_BASENAME $*
+    exec "$EDK_TOOLS_PATH/Source/C/bin/$cmd" "$@"
   fi
-elif [ -e `dirname $0`/../../Source/C/bin/$TOOL_BASENAME ]
+elif [ -e "$dir/../../Source/C/bin/$cmd" ]
 then
-  exec `dirname $0`/../../Source/C/bin/$TOOL_BASENAME $*
+  exec "$dir/../../Source/C/bin/$cmd" "$@"
 else
-  echo Unable to find the real \'$TOOL_BASENAME\' to run
-  echo This message was printed by
+  echo "Unable to find the real '$cmd' to run"
+  echo "This message was printed by"
   echo "  $0"
-  exit -1
+  exit 127
 fi
 

--- a/BaseTools/BinWrappers/PosixLike/TargetTool
+++ b/BaseTools/BinWrappers/PosixLike/TargetTool
@@ -1,5 +1,14 @@
 #!/usr/bin/env bash
 #python `dirname $0`/RunToolFromSource.py `basename $0` $*
-PYTHONPATH="`dirname $0`/../../Source/Python" \
-    python "`dirname $0`/../../Source/Python"/`basename $0`/`basename $0`.py $*
 
+# If a python2 command is available, use it in preference to python
+if command -v python2 >/dev/null 2>&1; then
+    python_exe=python2
+fi
+
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+dir=$(dirname "$full_cmd")
+cmd=${full_cmd##*/}
+
+export PYTHONPATH="$dir/../../Source/Python"
+exec "${python_exe:-python}" "$dir/../../Source/Python/$cmd/$cmd.py" "$@"

--- a/BaseTools/BinWrappers/PosixLike/TianoCompress
+++ b/BaseTools/BinWrappers/PosixLike/TianoCompress
@@ -1,29 +1,29 @@
 #!/usr/bin/env bash
-#python `dirname $0`/RunToolFromSource.py `basename $0` $*
-#exec `dirname $0`/../../../../C/bin/`basename $0` $*
 
-TOOL_BASENAME=`basename $0`
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+dir=$(dirname "$full_cmd")
+cmd=${full_cmd##*/}
 
-if [ -n "$WORKSPACE" -a -e $WORKSPACE/Conf/BaseToolsCBinaries ]
+if [ -n "$WORKSPACE" ] && [ -e "$WORKSPACE/Conf/BaseToolsCBinaries" ]
 then
-  exec $WORKSPACE/Conf/BaseToolsCBinaries/$TOOL_BASENAME
-elif [ -n "$WORKSPACE" -a -e $EDK_TOOLS_PATH/Source/C ]
+  exec "$WORKSPACE/Conf/BaseToolsCBinaries/$cmd"
+elif [ -n "$WORKSPACE" ] && [ -e "$EDK_TOOLS_PATH/Source/C" ]
 then
-  if [ ! -e $EDK_TOOLS_PATH/Source/C/bin/$TOOL_BASENAME ]
+  if [ ! -e "$EDK_TOOLS_PATH/Source/C/bin/$cmd" ]
   then
-    echo BaseTools C Tool binary was not found \($TOOL_BASENAME\)
-    echo You may need to run:
+    echo "BaseTools C Tool binary was not found ($cmd)"
+    echo "You may need to run:"
     echo "  make -C $EDK_TOOLS_PATH/Source/C"
   else
-    exec $EDK_TOOLS_PATH/Source/C/bin/$TOOL_BASENAME $*
+    exec "$EDK_TOOLS_PATH/Source/C/bin/$cmd" "$@"
   fi
-elif [ -e `dirname $0`/../../Source/C/bin/$TOOL_BASENAME ]
+elif [ -e "$dir/../../Source/C/bin/$cmd" ]
 then
-  exec `dirname $0`/../../Source/C/bin/$TOOL_BASENAME $*
+  exec "$dir/../../Source/C/bin/$cmd" "$@"
 else
-  echo Unable to find the real \'$TOOL_BASENAME\' to run
-  echo This message was printed by
+  echo "Unable to find the real '$cmd' to run"
+  echo "This message was printed by"
   echo "  $0"
-  exit -1
+  exit 127
 fi
 

--- a/BaseTools/BinWrappers/PosixLike/Trim
+++ b/BaseTools/BinWrappers/PosixLike/Trim
@@ -1,5 +1,14 @@
 #!/usr/bin/env bash
 #python `dirname $0`/RunToolFromSource.py `basename $0` $*
-PYTHONPATH="`dirname $0`/../../Source/Python" \
-    python "`dirname $0`/../../Source/Python"/`basename $0`/`basename $0`.py $*
 
+# If a python2 command is available, use it in preference to python
+if command -v python2 >/dev/null 2>&1; then
+    python_exe=python2
+fi
+
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+dir=$(dirname "$full_cmd")
+exe=$(basename "$full_cmd")
+
+export PYTHONPATH="$dir/../../Source/Python"
+exec "${python_exe:-python}" "$dir/../../Source/Python/$exe/$exe.py" "$@"

--- a/BaseTools/BinWrappers/PosixLike/UPT
+++ b/BaseTools/BinWrappers/PosixLike/UPT
@@ -1,5 +1,14 @@
 #!/usr/bin/env bash
 #python `dirname $0`/RunToolFromSource.py `basename $0` $*
-PYTHONPATH="`dirname $0`/../../Source/Python" \
-    python "`dirname $0`/../../Source/Python"/`basename $0`/`basename $0`.py $*
 
+# If a python2 command is available, use it in preference to python
+if command -v python2 >/dev/null 2>&1; then
+    python_exe=python2
+fi
+
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+dir=$(dirname "$full_cmd")
+cmd=${full_cmd##*/}
+
+export PYTHONPATH="$dir/../../Source/Python"
+exec "${python_exe:-python}" "$dir/../../Source/Python/$cmd/$cmd.py" "$@"

--- a/BaseTools/BinWrappers/PosixLike/VfrCompile
+++ b/BaseTools/BinWrappers/PosixLike/VfrCompile
@@ -1,29 +1,29 @@
 #!/usr/bin/env bash
-#python `dirname $0`/RunToolFromSource.py `basename $0` $*
-#exec `dirname $0`/../../../../C/bin/`basename $0` $*
 
-TOOL_BASENAME=`basename $0`
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+dir=$(dirname "$full_cmd")
+cmd=${full_cmd##*/}
 
-if [ -n "$WORKSPACE" -a -e $WORKSPACE/Conf/BaseToolsCBinaries ]
+if [ -n "$WORKSPACE" ] && [ -e "$WORKSPACE/Conf/BaseToolsCBinaries" ]
 then
-  exec $WORKSPACE/Conf/BaseToolsCBinaries/$TOOL_BASENAME
-elif [ -n "$WORKSPACE" -a -e $EDK_TOOLS_PATH/Source/C ]
+  exec "$WORKSPACE/Conf/BaseToolsCBinaries/$cmd"
+elif [ -n "$WORKSPACE" ] && [ -e "$EDK_TOOLS_PATH/Source/C" ]
 then
-  if [ ! -e $EDK_TOOLS_PATH/Source/C/bin/$TOOL_BASENAME ]
+  if [ ! -e "$EDK_TOOLS_PATH/Source/C/bin/$cmd" ]
   then
-    echo BaseTools C Tool binary was not found \($TOOL_BASENAME\)
-    echo You may need to run:
+    echo "BaseTools C Tool binary was not found ($cmd)"
+    echo "You may need to run:"
     echo "  make -C $EDK_TOOLS_PATH/Source/C"
   else
-    exec $EDK_TOOLS_PATH/Source/C/bin/$TOOL_BASENAME $*
+    exec "$EDK_TOOLS_PATH/Source/C/bin/$cmd" "$@"
   fi
-elif [ -e `dirname $0`/../../Source/C/bin/$TOOL_BASENAME ]
+elif [ -e "$dir/../../Source/C/bin/$cmd" ]
 then
-  exec `dirname $0`/../../Source/C/bin/$TOOL_BASENAME $*
+  exec "$dir/../../Source/C/bin/$cmd" "$@"
 else
-  echo Unable to find the real \'$TOOL_BASENAME\' to run
-  echo This message was printed by
+  echo "Unable to find the real '$cmd' to run"
+  echo "This message was printed by"
   echo "  $0"
-  exit -1
+  exit 127
 fi
 

--- a/BaseTools/BinWrappers/PosixLike/VolInfo
+++ b/BaseTools/BinWrappers/PosixLike/VolInfo
@@ -1,29 +1,29 @@
 #!/usr/bin/env bash
-#python `dirname $0`/RunToolFromSource.py `basename $0` $*
-#exec `dirname $0`/../../../../C/bin/`basename $0` $*
 
-TOOL_BASENAME=`basename $0`
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+dir=$(dirname "$full_cmd")
+cmd=${full_cmd##*/}
 
-if [ -n "$WORKSPACE" -a -e $WORKSPACE/Conf/BaseToolsCBinaries ]
+if [ -n "$WORKSPACE" ] && [ -e "$WORKSPACE/Conf/BaseToolsCBinaries" ]
 then
-  exec $WORKSPACE/Conf/BaseToolsCBinaries/$TOOL_BASENAME
-elif [ -n "$WORKSPACE" -a -e $EDK_TOOLS_PATH/Source/C ]
+  exec "$WORKSPACE/Conf/BaseToolsCBinaries/$cmd"
+elif [ -n "$WORKSPACE" ] && [ -e "$EDK_TOOLS_PATH/Source/C" ]
 then
-  if [ ! -e $EDK_TOOLS_PATH/Source/C/bin/$TOOL_BASENAME ]
+  if [ ! -e "$EDK_TOOLS_PATH/Source/C/bin/$cmd" ]
   then
-    echo BaseTools C Tool binary was not found \($TOOL_BASENAME\)
-    echo You may need to run:
+    echo "BaseTools C Tool binary was not found ($cmd)"
+    echo "You may need to run:"
     echo "  make -C $EDK_TOOLS_PATH/Source/C"
   else
-    exec $EDK_TOOLS_PATH/Source/C/bin/$TOOL_BASENAME $*
+    exec "$EDK_TOOLS_PATH/Source/C/bin/$cmd" "$@"
   fi
-elif [ -e `dirname $0`/../../Source/C/bin/$TOOL_BASENAME ]
+elif [ -e "$dir/../../Source/C/bin/$cmd" ]
 then
-  exec `dirname $0`/../../Source/C/bin/$TOOL_BASENAME $*
+  exec "$dir/../../Source/C/bin/$cmd" "$@"
 else
-  echo Unable to find the real \'$TOOL_BASENAME\' to run
-  echo This message was printed by
+  echo "Unable to find the real '$cmd' to run"
+  echo "This message was printed by"
   echo "  $0"
-  exit -1
+  exit 127
 fi
 

--- a/BaseTools/BinWrappers/PosixLike/build
+++ b/BaseTools/BinWrappers/PosixLike/build
@@ -1,5 +1,14 @@
 #!/usr/bin/env bash
 #python `dirname $0`/RunToolFromSource.py `basename $0` $*
-PYTHONPATH="`dirname $0`/../../Source/Python" \
-    python "`dirname $0`/../../Source/Python"/`basename $0`/`basename $0`.py $*
 
+# If a python2 command is available, use it in preference to python
+if command -v python2 >/dev/null 2>&1; then
+    python_exe=python2
+fi
+
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+dir=$(dirname "$full_cmd")
+cmd=${full_cmd##*/}
+
+export PYTHONPATH="$dir/../../Source/Python"
+exec "${python_exe:-python}" "$dir/../../Source/Python/$cmd/$cmd.py" "$@"

--- a/BaseTools/Tests/GNUmakefile
+++ b/BaseTools/Tests/GNUmakefile
@@ -14,7 +14,7 @@
 all: test
 
 test:
-	@python RunTests.py
+	@if command -v python2 >/dev/null 2>&1; then python2 RunTests.py; else python RunTests.py; fi
 
 clean:
 	find . -name '*.pyc' -exec rm '{}' ';'


### PR DESCRIPTION
- Use `python2` executable if it exists, to avoid breakage on systems (such as
  Arch Linux) where `python` is Python 3.
- Quote all references to `$0`, for safety when located in a directory
  containing spaces in its name.
- Use the `exec` shell command to avoid leaving the shell wrapper in the
  process table when invoking the actual build tool.
- Use `"$@"` rather than `$*` to pass arguments through directly rather than
  concatenating to a string, and then string-splitting and glob-expanding its
  contents.