### PR TITLE
rrecp has been allocated but is not freed on the error return path

### DIFF
--- a/StdLib/BsdSocketLib/res_mkupdate.c
+++ b/StdLib/BsdSocketLib/res_mkupdate.c
@@ -438,8 +438,12 @@ res_mkupdrec(int section, const char *dname,
          u_int class, u_int type, u_long ttl) {
     ns_updrec *rrecp = (ns_updrec *)calloc(1, sizeof(ns_updrec));
 
-    if (!rrecp || !(rrecp->r_dname = strdup(dname)))
+    if (!rrecp)
         return (NULL);
+    if (!(rrecp->r_dname = strdup(dname))) {
+        free(rrecp);
+        return (NULL);
+    }
     rrecp->r_class = (u_int16_t)class;
     rrecp->r_type = (u_int16_t)type;
     rrecp->r_ttl = (u_int32_t)ttl;


### PR DESCRIPTION
if the strdup fails.  This is a minor memory leak that is easily
fixed by free'ing rrecp on the error return.

Contributed-under: TianoCore Contribution Agreement 1.0
Signed-off-by: Colin Ian King <colin.king@canonical.com>