### PR TITLE
Http11 definitions

### DIFF
--- a/MdePkg/Include/IndustryStandard/Http11.h
+++ b/MdePkg/Include/IndustryStandard/Http11.h
@@ -3,7 +3,7 @@
 
   This file contains common HTTP 1.1 definitions from RFC 2616 
    
-  (C) Copyright 2015 Hewlett Packard Enterprise Development LP<BR>
+  (C) Copyright 2015-2016 Hewlett Packard Enterprise Development LP<BR>
   This program and the accompanying materials
   are licensed and made available under the terms and conditions of the BSD License
   which accompanies this distribution.  The full text of the license may be found at
@@ -24,8 +24,8 @@
 /// The version of an HTTP message is indicated by an HTTP-Version field
 /// in the first line of the message.
 ///
-#define HTTP_VERSION        "HTTP/1.1"
-
+#define HTTP_VERSION_STR       "HTTP/1.1"
+#define HTTP_VERSION_CRLF_STR  " HTTP/1.1\r\n"
 
 ///
 /// HTTP Request Method definitions
@@ -43,7 +43,11 @@
 #define HTTP_METHOD_CONNECT "CONNECT"
 #define HTTP_METHOD_PATCH   "PATCH"
 
-#define HTTP_METHOD_MAXIMUM_LEN  sizeof ("CONNECT")
+///
+/// Connect method has maximum length according to EFI_HTTP_METHOD defined in
+/// UEFI2.5 spec so use this.
+///
+#define HTTP_METHOD_MAXIMUM_LEN  sizeof (HTTP_METHOD_CONNECT)
 
 ///
 /// Accept Request Header
@@ -106,7 +110,7 @@
 #define HTTP_CONTENT_ENCODING_GZIP     "gzip"      /// Content-Encoding: GNU zip format (described in RFC 1952).
 #define HTTP_CONTENT_ENCODING_COMPRESS "compress"  /// encoding format produced by the common UNIX file compression program "compress". 
 #define HTTP_CONTENT_ENCODING_DEFLATE  "deflate"   /// The "zlib" format defined in RFC 1950 in combination with the "deflate" 
-                                                    /// compression mechanism described in RFC 1951.
+                                                   /// compression mechanism described in RFC 1951.
 
 
 ///
@@ -152,13 +156,37 @@
 
 
 ///
+/// User Agent Request Header
+/// 
+/// The User-Agent request-header field contains information about the user agent originating 
+/// the request. This is for statistical purposes, the tracing of protocol violations, and 
+/// automated recognition of user agents for the sake of tailoring responses to avoid 
+/// particular user agent limitations. User agents SHOULD include this field with requests. 
+/// The field can contain multiple product tokens and comments identifying the agent and any 
+/// subproducts which form a significant part of the user agent. 
+/// By convention, the product tokens are listed in order of their significance for 
+/// identifying the application.
+///
+#define HTTP_HEADER_USER_AGENT         "User-Agent"
+
+///
 /// Host Request Header
 ///
 /// The Host request-header field specifies the Internet host and port number of the resource 
 /// being requested, as obtained from the original URI given by the user or referring resource 
 ///
-#define  HTTP_HEADER_HOST              "Host"
+#define HTTP_HEADER_HOST              "Host"
 
+///
+/// Location Response Header
+/// 
+/// The Location response-header field is used to redirect the recipient to a location other than 
+/// the Request-URI for completion of the request or identification of a new resource. 
+/// For 201 (Created) responses, the Location is that of the new resource which was created by 
+/// the request. For 3xx responses, the location SHOULD indicate the server's preferred URI for 
+/// automatic redirection to the resource. The field value consists of a single absolute URI.
+///
+#define HTTP_HEADER_LOCATION           "Location"
 
 ///
 /// The If-Match request-header field is used with a method to make it conditional.
@@ -170,7 +198,7 @@
 /// to prevent inadvertent modification of the wrong version of a resource. 
 /// As a special case, the value "*" matches any current entity of the resource.
 ///
-#define  HTTP_HEADER_IF_MATCH          "If-Match"
+#define HTTP_HEADER_IF_MATCH          "If-Match"
 
 
 ///
@@ -182,7 +210,7 @@
 /// to prevent a method (e.g. PUT) from inadvertently modifying an existing resource when the 
 /// client believes that the resource does not exist.
 ///
-#define  HTTP_HEADER_IF_NONE_MATCH     "If-None-Match"
+#define HTTP_HEADER_IF_NONE_MATCH     "If-None-Match"
 
 
 
@@ -192,17 +220,16 @@
 /// containing the authentication information of the user agent for
 /// the realm of the resource being requested.
 ///
-#define  HTTP_HEADER_AUTHORIZATION     "Authorization"
+#define HTTP_HEADER_AUTHORIZATION     "Authorization"
 
 ///
 /// ETAG Response Header
 /// The ETag response-header field provides the current value of the entity tag 
 /// for the requested variant. 
 ///
-#define  HTTP_HEADER_ETAG              "ETag"
-
-
+#define HTTP_HEADER_ETAG              "ETag"
 
 
 #pragma pack()
+
 #endif

--- a/NetworkPkg/HttpBootDxe/HttpBootClient.c
+++ b/NetworkPkg/HttpBootDxe/HttpBootClient.c
@@ -2,6 +2,7 @@
   Implementation of the boot file download function.
 
 Copyright (c) 2015 - 2016, Intel Corporation. All rights reserved.<BR>
+(C) Copyright 2016 Hewlett Packard Enterprise Development LP<BR>
 This program and the accompanying materials are licensed and made available under 
 the terms and conditions of the BSD License that accompanies this distribution.  
 The full text of the license may be found at
@@ -807,7 +808,7 @@ HttpBootGetBootFile (
   }
   Status = HttpBootSetHeader (
              HttpIoHeader,
-             HTTP_FIELD_NAME_HOST,
+             HTTP_HEADER_HOST,
              HostName
              );
   FreePool (HostName);
@@ -820,7 +821,7 @@ HttpBootGetBootFile (
   //
   Status = HttpBootSetHeader (
              HttpIoHeader,
-             HTTP_FIELD_NAME_ACCEPT,
+             HTTP_HEADER_ACCEPT,
              "*/*"
              );
   if (EFI_ERROR (Status)) {
@@ -832,7 +833,7 @@ HttpBootGetBootFile (
   //
   Status = HttpBootSetHeader (
              HttpIoHeader,
-             HTTP_FIELD_NAME_USER_AGENT,
+             HTTP_HEADER_USER_AGENT,
              HTTP_USER_AGENT_EFI_HTTP_BOOT
              );
   if (EFI_ERROR (Status)) {

--- a/NetworkPkg/HttpBootDxe/HttpBootClient.h
+++ b/NetworkPkg/HttpBootDxe/HttpBootClient.h
@@ -2,6 +2,7 @@
   Declaration of the boot file download function.
 
 Copyright (c) 2015, Intel Corporation. All rights reserved.<BR>
+(C) Copyright 2016 Hewlett Packard Enterprise Development LP<BR>
 This program and the accompanying materials are licensed and made available under 
 the terms and conditions of the BSD License that accompanies this distribution.  
 The full text of the license may be found at
@@ -18,9 +19,6 @@ WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
 #define HTTP_BOOT_REQUEST_TIMEOUT            5000      // 5 seconds in uints of millisecond.
 #define HTTP_BOOT_BLOCK_SIZE                 1500
 
-#define HTTP_FIELD_NAME_USER_AGENT           "User-Agent"
-#define HTTP_FIELD_NAME_HOST                 "Host"
-#define HTTP_FIELD_NAME_ACCEPT               "Accept"
 
 
 #define HTTP_USER_AGENT_EFI_HTTP_BOOT        "UefiHttpBoot/1.0"

--- a/NetworkPkg/HttpBootDxe/HttpBootDxe.h
+++ b/NetworkPkg/HttpBootDxe/HttpBootDxe.h
@@ -2,6 +2,7 @@
   UEFI HTTP boot driver's private data structure and interfaces declaration.
 
 Copyright (c) 2015, Intel Corporation. All rights reserved.<BR>
+(C) Copyright 2016 Hewlett Packard Enterprise Development LP<BR>
 This program and the accompanying materials are licensed and made available under 
 the terms and conditions of the BSD License that accompanies this distribution.  
 The full text of the license may be found at
@@ -16,6 +17,7 @@ WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
 #define __EFI_HTTP_BOOT_DXE_H__
 
 #include <Uefi.h>
+#include <IndustryStandard/Http11.h>
 
 //
 // Libraries

--- a/NetworkPkg/HttpDxe/HttpDriver.h
+++ b/NetworkPkg/HttpDxe/HttpDriver.h
@@ -2,7 +2,7 @@
   The header files of the driver binding and service binding protocol for HttpDxe driver.
 
   Copyright (c) 2015, Intel Corporation. All rights reserved.<BR>
-
+  (C) Copyright 2016 Hewlett Packard Enterprise Development LP<BR>
   This program and the accompanying materials
   are licensed and made available under the terms and conditions of the BSD License
   which accompanies this distribution.  The full text of the license may be found at
@@ -17,6 +17,7 @@
 #define __EFI_HTTP_DRIVER_H__
 
 #include <Uefi.h>
+#include <IndustryStandard/Http11.h>
 
 //
 // Libraries

--- a/NetworkPkg/HttpDxe/HttpImpl.h
+++ b/NetworkPkg/HttpDxe/HttpImpl.h
@@ -2,7 +2,7 @@
   The header files of implementation of EFI_HTTP_PROTOCOL protocol interfaces.
 
   Copyright (c) 2015 - 2016, Intel Corporation. All rights reserved.<BR>
-
+  (C) Copyright 2016 Hewlett Packard Enterprise Development LP<BR>
   This program and the accompanying materials
   are licensed and made available under the terms and conditions of the BSD License
   which accompanies this distribution.  The full text of the license may be found at
@@ -19,17 +19,8 @@
 #define HTTP_DEFAULT_PORT        80
 #define HTTP_END_OF_HDR_STR      "\r\n\r\n"
 #define HTTP_CRLF_STR            "\r\n"
-#define HTTP_VERSION_STR         "HTTP/1.1"
-#define HTTP_VERSION_CRLF_STR    " HTTP/1.1\r\n"
-#define HTTP_GET_STR             "GET "
-#define HTTP_HEAD_STR            "HEAD "
 #define HTTP_ERROR_OR_NOT_SUPPORT_STATUS_CODE         300
 
-//
-// Connect method has maximum length according to EFI_HTTP_METHOD defined in
-// UEFI2.5 spec so use this.
-//
-#define HTTP_MAXIMUM_METHOD_LEN  sizeof ("CONNECT")
 
 /**
   Returns the operational parameters for the current HTTP child instance.

--- a/NetworkPkg/HttpDxe/HttpProto.c
+++ b/NetworkPkg/HttpDxe/HttpProto.c
@@ -2,7 +2,7 @@
   Miscellaneous routines for HttpDxe driver.
 
 Copyright (c) 2015, Intel Corporation. All rights reserved.<BR>
-(C) Copyright 2015 Hewlett Packard Enterprise Development LP<BR>
+(C) Copyright 2015-2016 Hewlett Packard Enterprise Development LP<BR>
 This program and the accompanying materials
 are licensed and made available under the terms and conditions of the BSD License
 which accompanies this distribution.  The full text of the license may be found at
@@ -2023,7 +2023,7 @@ HttpGenRequestString (
   //
   // Calculate HTTP message length.
   //
-  MsgSize = Message->BodyLength + HTTP_MAXIMUM_METHOD_LEN + AsciiStrLen (Url) + 
+  MsgSize = Message->BodyLength + HTTP_METHOD_MAXIMUM_LEN + AsciiStrLen (Url) + 
             AsciiStrLen (HTTP_VERSION_CRLF_STR) + HttpHdrSize;
   Request = AllocateZeroPool (MsgSize);
   if (Request == NULL) {
@@ -2036,19 +2036,23 @@ HttpGenRequestString (
   //
   switch (Message->Data.Request->Method) {
   case HttpMethodGet:
-    StrLength = sizeof (HTTP_GET_STR) - 1;
-    CopyMem (RequestPtr, HTTP_GET_STR, StrLength);
+    StrLength = sizeof (HTTP_METHOD_GET) - 1;
+    CopyMem (RequestPtr, HTTP_METHOD_GET, StrLength);
     RequestPtr += StrLength;
     break;
   case HttpMethodHead:
-    StrLength = sizeof (HTTP_HEAD_STR) - 1;
-    CopyMem (RequestPtr, HTTP_HEAD_STR, StrLength);
+    StrLength = sizeof (HTTP_METHOD_HEAD) - 1;
+    CopyMem (RequestPtr, HTTP_METHOD_HEAD, StrLength);
     RequestPtr += StrLength;
     break;
   default:
     ASSERT (FALSE);
     goto Exit;
   }
+
+  StrLength = AsciiStrLen(" ");
+  CopyMem (RequestPtr, " ", StrLength);
+  RequestPtr += StrLength;
 
   StrLength = AsciiStrLen (Url);
   CopyMem (RequestPtr, Url, StrLength);


### PR DESCRIPTION
Add additional HTTP 1.1 standard definitions, and cleanup the HTTP Boot drivers to use them.