### PR TITLE
Fix the missing definitions of OBJCOPY_PATH and OBJCOPY_FLAGS for ELF…

### DIFF
--- a/BaseTools/Conf/tools_def.template
+++ b/BaseTools/Conf/tools_def.template
@@ -5501,6 +5501,7 @@ RELEASE_CLANG35_AARCH64_CC_FLAGS = DEF(CLANG35_AARCH64_CC_FLAGS) $(ARCHCC_FLAGS)
 ##################
 # X64 definitions
 ##################
+*_ELFGCC_X64_OBJCOPY_PATH          = DEF(ELFGCC_BIN)/objcopy
 *_ELFGCC_X64_CC_PATH               = DEF(ELFGCC_BIN)/gcc
 *_ELFGCC_X64_ASLCC_PATH            = DEF(ELFGCC_BIN)/gcc
 *_ELFGCC_X64_SLINK_PATH            = DEF(ELFGCC_BIN)/ar
@@ -5519,6 +5520,7 @@ RELEASE_CLANG35_AARCH64_CC_FLAGS = DEF(CLANG35_AARCH64_CC_FLAGS) $(ARCHCC_FLAGS)
 *_ELFGCC_X64_PP_FLAGS              = -E -x assembler-with-cpp -include $(DEST_DIR_DEBUG)/AutoGen.h
 *_ELFGCC_X64_VFRPP_FLAGS           = -x c -E -P -DVFRCOMPILE --include $(DEST_DIR_DEBUG)/$(MODULE_NAME)StrDefs.h
 *_ELFGCC_X64_RC_FLAGS              = DEF(GCC_X64_RC_FLAGS)
+*_ELFGCC_X64_OBJCOPY_FLAGS         =
 *_ELFGCC_X64_NASM_FLAGS            = -f elf64
 
 ##################


### PR DESCRIPTION
Otherwise the "echo objcopy not needed for " is printed during the build.

Signed-off-by: Lans Zhang <jia.zhang@windriver.com>