### PR TITLE
BaseTools: Mentioned get_vsvars.bat at ReadMe

### DIFF
--- a/BaseTools/ReadMe.txt
+++ b/BaseTools/ReadMe.txt
@@ -7,7 +7,9 @@ directory contatins tools source.
 
 === Windows/Visual Studio Notes ===
 
-To build the BaseTools, you should run the standard vsvars32.bat script.
+To build the BaseTools, you should run the standard vsvars32.bat script
+from your preferred Visual Studio installation or you can run get_vsvars.bat
+to use latest automatically detected version.
 
 In addition to this, you should set the following environment variables:
 


### PR DESCRIPTION
When someone doesn't know where to find or what to do with
vsvars32.bat, get_vsvars.bat can be used.

Contributed-under: TianoCore Contribution Agreement 1.0
Signed-off-by: Peter Kirmeier <topeterk@freenet.de>