### PR TITLE
OvmfPkg/build.sh: update gcc detection

### DIFF
--- a/OvmfPkg/build.sh
+++ b/OvmfPkg/build.sh
@@ -83,6 +83,13 @@ case `uname` in
   Linux*)
     gcc_version=$(gcc -v 2>&1 | tail -1 | awk '{print $3}')
     case $gcc_version in
+      4.[3210].*|3.*|2.*)
+        echo "gcc version $gcc_version is unsupported"
+        exit 1
+        ;;
+      4.4.*)
+        TARGET_TOOLS=GCC44
+        ;;
       4.5.*)
         TARGET_TOOLS=GCC45
         ;;
@@ -99,7 +106,8 @@ case `uname` in
         TARGET_TOOLS=GCC49
         ;;
       *)
-        TARGET_TOOLS=GCC44
+        # assume the latest, we cant keep up with gcc releases
+        TARGET_TOOLS=GCC49
         ;;
     esac
 esac


### PR DESCRIPTION
Adjust the code to look forward instead of backwards.
Existing gcc releases are known to work or break. Upcoming gcc releases
are assumed to work like the last handled gcc version does.
Doing it that way will reduce the burden to update the script for each
upcoming gcc variant.

This fixes issue #99.

Signed-off-by: Olaf Hering <olaf@aepfle.de>