### PR TITLE
Fix buffer overflow with edit when we have more than 200 columns on screen

### DIFF
--- a/ShellPkg/Library/UefiShellDebug1CommandsLib/UefiShellDebug1CommandsLib.c
+++ b/ShellPkg/Library/UefiShellDebug1CommandsLib/UefiShellDebug1CommandsLib.c
@@ -302,12 +302,21 @@ EditorClearLine (
   IN UINTN LastRow
   )
 {
-  CHAR16 Line[200];
+  CHAR16 Buffer[400];
+  CHAR16 *Line = Buffer;
 
   if (Row == 0) {
     Row = 1;
   }
 
+  // If we there are more than columns than our buffer, allocate new buffer
+  if (LastCol >= (sizeof (Buffer) / sizeof (CHAR16))) {
+	  Line = AllocateZeroPool (LastCol*(sizeof(CHAR16) + 1));
+    if (Line == NULL) {
+      return;
+    }
+  }
+  
   //
   // prepare a blank line
   //
@@ -326,6 +335,10 @@ EditorClearLine (
   // print out the blank line
   //
   ShellPrintEx (0, ((INT32)Row) - 1, Line);
+  
+  // Free if allocated
+  if (Line != Buffer)
+	  FreePool (Line);
 }
 
 /**


### PR DESCRIPTION
If the shell edit command is used on a screen with more than 200 columns, we get a buffer overflow. This increases the default buffer size to 400 columns and allocates a pool when this is not enough.