### PR TITLE
Update Readme.txt

### DIFF
--- a/SourceLevelDebugPkg/Readme.txt
+++ b/SourceLevelDebugPkg/Readme.txt
@@ -2,5 +2,5 @@ UDK based firmware on UEFI IA-32 and UEFI x64 platforms can be debugged with
 SourceLevelDebugPkg in conjunction with Intel(R) UEFI Development Kit Debugger
 Tool (Intel (R) UDK Debugger Tool).
 
-The Intel(R) UDK Debugger Tool and its detailed user manual can be obtained
-from: http://www.uefidk.com/develop.
+The Intel(R) UDK Debugger Tool and its detailed user manual can be obtained from:
+https://firmware.intel.com/develop/intel-uefi-tools-and-utilities/intel-uefi-development-kit-debugger-tool


### PR DESCRIPTION
Correct link to download debugger from https://firmware.intel.com/develop/intel-uefi-tools-and-utilities/intel-uefi-development-kit-debugger-tool (uefidk.com URL is now invalid)