### PR TITLE
Stdlib: Add calling convention to completion callbacks

### DIFF
--- a/StdLib/EfiSocketLib/Ip4.c
+++ b/StdLib/EfiSocketLib/Ip4.c
@@ -595,6 +595,7 @@ EslIp4RemoteAddressSet (
 
 **/
 VOID
+EFIAPI
 EslIp4RxComplete (
   IN EFI_EVENT Event,
   IN ESL_IO_MGMT * pIo
@@ -1124,6 +1125,7 @@ EslIp4TxBuffer (
 
 **/
 VOID
+EFIAPI
 EslIp4TxComplete (
   IN EFI_EVENT Event,
   IN ESL_IO_MGMT * pIo
@@ -1235,13 +1237,13 @@ EslIp4VerifyLocalIpAddress (
     //  Open the configuration protocol
     //
     pService = pPort->pService;
-    Status = gBS->OpenProtocol ( 
+    Status = gBS->OpenProtocol (
                     pService->Controller,
                     &gEfiIp4Config2ProtocolGuid,
                     (VOID **)&pIpConfig2Protocol,
                     NULL,
                     NULL,
-                    EFI_OPEN_PROTOCOL_GET_PROTOCOL 
+                    EFI_OPEN_PROTOCOL_GET_PROTOCOL
                     );
     if ( EFI_ERROR ( Status )) {
       DEBUG (( DEBUG_ERROR,
@@ -1254,7 +1256,7 @@ EslIp4VerifyLocalIpAddress (
     // Get the interface information size.
     //
     DataSize = 0;
-    Status = pIpConfig2Protocol->GetData ( 
+    Status = pIpConfig2Protocol->GetData (
                                    pIpConfig2Protocol,
                                    Ip4Config2DataTypeInterfaceInfo,
                                    &DataSize,
@@ -1281,7 +1283,7 @@ EslIp4VerifyLocalIpAddress (
     //
     // Get the interface info.
     //
-    Status = pIpConfig2Protocol->GetData ( 
+    Status = pIpConfig2Protocol->GetData (
                                   pIpConfig2Protocol,
                                   Ip4Config2DataTypeInterfaceInfo,
                                   &DataSize,

--- a/StdLib/EfiSocketLib/Socket.h
+++ b/StdLib/EfiSocketLib/Socket.h
@@ -597,6 +597,7 @@ EFI_STATUS
 **/
 typedef
 VOID
+EFIAPI
 (* PFN_API_IO_COMPLETE) (
   IN EFI_EVENT Event,
   IN ESL_IO_MGMT * pIo
@@ -607,7 +608,7 @@ VOID
 
 
   @param [in] pSocket         Address of a ESL_SOCKET structure
-  
+
   @retval EFI_SUCCESS - The port is connected
   @retval EFI_NOT_STARTED - The port is not connected
 
@@ -729,7 +730,7 @@ EFI_STATUS
   This routine is called by ::EslSocketPortCloseRxDone as
   the last step of closing processing.
   See the \ref PortCloseStateMachine section.
-  
+
   @param [in] pPort       Address of an ::ESL_PORT structure.
 
   @retval EFI_SUCCESS     The port is closed
@@ -779,13 +780,13 @@ EFI_STATUS
   @param [in] pPort           Address of an ::ESL_PORT structure.
 
   @param [in] pPacket         Address of an ::ESL_PACKET structure.
-  
+
   @param [in] pbConsumePacket Address of a BOOLEAN indicating if the packet is to be consumed
-  
+
   @param [in] BufferLength    Length of the the buffer
-  
+
   @param [in] pBuffer         Address of a buffer to receive the data.
-  
+
   @param [in] pDataLength     Number of received data bytes in the buffer.
 
   @param [out] pAddress       Network address to receive the remote system address
@@ -915,6 +916,7 @@ EFI_STATUS
 **/
 typedef
 VOID
+EFIAPI
 (* PFN_API_TX_COMPLETE) (
   IN EFI_EVENT Event,
   IN ESL_IO_MGMT * pIo
@@ -1132,7 +1134,7 @@ extern CONST EFI_SERVICE_BINDING_PROTOCOL mEfiServiceBinding;
 
 /**
   Allocate and initialize a ESL_SOCKET structure.
-  
+
   This support function allocates an ::ESL_SOCKET structure
   and installs a protocol on ChildHandle.  If pChildHandle is a
   pointer to NULL, then a new handle is created and returned in
@@ -1141,7 +1143,7 @@ extern CONST EFI_SERVICE_BINDING_PROTOCOL mEfiServiceBinding;
 
   @param [in, out] pChildHandle Pointer to the handle of the child to create.
                                 If it is NULL, then a new handle is created.
-                                If it is a pointer to an existing UEFI handle, 
+                                If it is a pointer to an existing UEFI handle,
                                 then the protocol is added to the existing UEFI
                                 handle.
   @param [in] DebugFlags        Flags for debug messages
@@ -1152,7 +1154,7 @@ extern CONST EFI_SERVICE_BINDING_PROTOCOL mEfiServiceBinding;
   @retval EFI_OUT_OF_RESOURCES  There are not enough resources available to create
                                 the child
   @retval other                 The child handle was not created
-  
+
 **/
 EFI_STATUS
 EFIAPI
@@ -1217,7 +1219,7 @@ EslSocketCopyFragmentedBuffer (
   handle.
 
   @param [in] pSocketProtocol Address of an ::EFI_SOCKET_PROTOCOL structure.
-  
+
   @param [out] pErrno         Address to receive the errno value upon completion.
 
   @retval EFI_SUCCESS   The socket resources were returned successfully.
@@ -1413,7 +1415,7 @@ EslSocketPortAllocate (
     <li>::EslUdp4PortAllocate - Port initialization failure</li>
   </ul>
   See the \ref PortCloseStateMachine section.
-  
+
   @param [in] pPort       Address of an ::ESL_PORT structure.
 
   @retval EFI_SUCCESS     The port is closed

--- a/StdLib/EfiSocketLib/Tcp4.c
+++ b/StdLib/EfiSocketLib/Tcp4.c
@@ -1739,6 +1739,7 @@ EslTcp4RemoteAddressSet (
 
 **/
 VOID
+EFIAPI
 EslTcp4RxComplete (
   IN EFI_EVENT Event,
   IN ESL_IO_MGMT * pIo
@@ -2128,6 +2129,7 @@ EslTcp4TxBuffer (
 
 **/
 VOID
+EFIAPI
 EslTcp4TxComplete (
   IN EFI_EVENT Event,
   IN ESL_IO_MGMT * pIo
@@ -2185,6 +2187,7 @@ EslTcp4TxComplete (
 
 **/
 VOID
+EFIAPI
 EslTcp4TxOobComplete (
   IN EFI_EVENT Event,
   IN ESL_IO_MGMT * pIo
@@ -2286,13 +2289,13 @@ EslTcp4VerifyLocalIpAddress (
     //  Open the configuration protocol
     //
     pService = pPort->pService;
-    Status = gBS->OpenProtocol ( 
+    Status = gBS->OpenProtocol (
                     pService->Controller,
                     &gEfiIp4Config2ProtocolGuid,
                     (VOID **)&pIpConfig2Protocol,
                     NULL,
                     NULL,
-                    EFI_OPEN_PROTOCOL_GET_PROTOCOL 
+                    EFI_OPEN_PROTOCOL_GET_PROTOCOL
                     );
     if ( EFI_ERROR ( Status )) {
       DEBUG (( DEBUG_ERROR,
@@ -2305,7 +2308,7 @@ EslTcp4VerifyLocalIpAddress (
     // Get the interface information size.
     //
     DataSize = 0;
-    Status = pIpConfig2Protocol->GetData ( 
+    Status = pIpConfig2Protocol->GetData (
                                    pIpConfig2Protocol,
                                    Ip4Config2DataTypeInterfaceInfo,
                                    &DataSize,
@@ -2332,7 +2335,7 @@ EslTcp4VerifyLocalIpAddress (
     //
     // Get the interface info.
     //
-    Status = pIpConfig2Protocol->GetData ( 
+    Status = pIpConfig2Protocol->GetData (
                                   pIpConfig2Protocol,
                                   Ip4Config2DataTypeInterfaceInfo,
                                   &DataSize,

--- a/StdLib/EfiSocketLib/Tcp6.c
+++ b/StdLib/EfiSocketLib/Tcp6.c
@@ -1808,6 +1808,7 @@ EslTcp6RemoteAddressSet (
 
 **/
 VOID
+EFIAPI
 EslTcp6RxComplete (
   IN EFI_EVENT Event,
   IN ESL_IO_MGMT * pIo
@@ -2197,6 +2198,7 @@ EslTcp6TxBuffer (
 
 **/
 VOID
+EFIAPI
 EslTcp6TxComplete (
   IN EFI_EVENT Event,
   IN ESL_IO_MGMT * pIo
@@ -2254,6 +2256,7 @@ EslTcp6TxComplete (
 
 **/
 VOID
+EFIAPI
 EslTcp6TxOobComplete (
   IN EFI_EVENT Event,
   IN ESL_IO_MGMT * pIo

--- a/StdLib/EfiSocketLib/Udp4.c
+++ b/StdLib/EfiSocketLib/Udp4.c
@@ -119,7 +119,7 @@ EslUdp4LocalAddressSet (
     //  Determine if the default address is used
     //
     pConfig->UseDefaultAddress = (BOOLEAN)( 0 == pIpAddress->sin_addr.s_addr );
-    
+
     //
     //  Set the subnet mask
     //
@@ -291,13 +291,13 @@ EslUdp4PortAllocate (
   @param [in] pPort           Address of an ::ESL_PORT structure.
 
   @param [in] pPacket         Address of an ::ESL_PACKET structure.
-  
+
   @param [in] pbConsumePacket Address of a BOOLEAN indicating if the packet is to be consumed
-  
+
   @param [in] BufferLength    Length of the the buffer
-  
+
   @param [in] pBuffer         Address of a buffer to receive the data.
-  
+
   @param [in] pDataLength     Number of received data bytes in the buffer.
 
   @param [out] pAddress       Network address to receive the remote system address
@@ -491,6 +491,7 @@ EslUdp4RemoteAddressSet (
 
 **/
 VOID
+EFIAPI
 EslUdp4RxComplete (
   IN EFI_EVENT Event,
   IN ESL_IO_MGMT * pIo
@@ -500,14 +501,14 @@ EslUdp4RxComplete (
   ESL_PACKET * pPacket;
   EFI_UDP4_RECEIVE_DATA * pRxData;
   EFI_STATUS Status;
-  
+
   DBG_ENTER ( );
 
   //
   //  Get the operation status.
   //
   Status = pIo->Token.Udp4Rx.Status;
-  
+
   //
   //  Get the packet length
   //
@@ -713,7 +714,7 @@ EslUdp4RxComplete (
   //  Determine the socket configuration status
   //
   Status = pSocket->bConfigured ? EFI_SUCCESS : EFI_NOT_STARTED;
-  
+
   //
   //  Return the port connected state.
   //
@@ -976,6 +977,7 @@ EslUdp4TxBuffer (
 
 **/
 VOID
+EFIAPI
 EslUdp4TxComplete (
   IN EFI_EVENT Event,
   IN ESL_IO_MGMT * pIo
@@ -986,9 +988,9 @@ EslUdp4TxComplete (
   ESL_PACKET * pPacket;
   ESL_SOCKET * pSocket;
   EFI_STATUS Status;
-  
+
   DBG_ENTER ( );
-  
+
   //
   //  Locate the active transmit packet
   //
@@ -1087,13 +1089,13 @@ EslUdp4VerifyLocalIpAddress (
     //  Open the configuration protocol
     //
     pService = pPort->pService;
-    Status = gBS->OpenProtocol ( 
+    Status = gBS->OpenProtocol (
                     pService->Controller,
                     &gEfiIp4Config2ProtocolGuid,
                     (VOID **)&pIpConfig2Protocol,
                     NULL,
                     NULL,
-                    EFI_OPEN_PROTOCOL_GET_PROTOCOL 
+                    EFI_OPEN_PROTOCOL_GET_PROTOCOL
                     );
     if ( EFI_ERROR ( Status )) {
       DEBUG (( DEBUG_ERROR,
@@ -1106,7 +1108,7 @@ EslUdp4VerifyLocalIpAddress (
     //  Get the interface information size
     //
     DataSize = 0;
-    Status = pIpConfig2Protocol->GetData ( 
+    Status = pIpConfig2Protocol->GetData (
                                    pIpConfig2Protocol,
                                    Ip4Config2DataTypeInterfaceInfo,
                                    &DataSize,
@@ -1133,7 +1135,7 @@ EslUdp4VerifyLocalIpAddress (
     //
     // Get the interface info.
     //
-    Status = pIpConfig2Protocol->GetData ( 
+    Status = pIpConfig2Protocol->GetData (
                                   pIpConfig2Protocol,
                                   Ip4Config2DataTypeInterfaceInfo,
                                   &DataSize,

--- a/StdLib/EfiSocketLib/Udp6.c
+++ b/StdLib/EfiSocketLib/Udp6.c
@@ -275,13 +275,13 @@ EslUdp6PortAllocate (
   @param [in] pPort           Address of an ::ESL_PORT structure.
 
   @param [in] pPacket         Address of an ::ESL_PACKET structure.
-  
+
   @param [in] pbConsumePacket Address of a BOOLEAN indicating if the packet is to be consumed
-  
+
   @param [in] BufferLength    Length of the the buffer
-  
+
   @param [in] pBuffer         Address of a buffer to receive the data.
-  
+
   @param [in] pDataLength     Number of received data bytes in the buffer.
 
   @param [out] pAddress       Network address to receive the remote system address
@@ -485,6 +485,7 @@ EslUdp6RemoteAddressSet (
 
 **/
 VOID
+EFIAPI
 EslUdp6RxComplete (
   IN EFI_EVENT Event,
   IN ESL_IO_MGMT * pIo
@@ -494,14 +495,14 @@ EslUdp6RxComplete (
   ESL_PACKET * pPacket;
   EFI_UDP6_RECEIVE_DATA * pRxData;
   EFI_STATUS Status;
-  
+
   DBG_ENTER ( );
 
   //
   //  Get the operation status.
   //
   Status = pIo->Token.Udp6Rx.Status;
-  
+
   //
   //  Get the packet length
   //
@@ -758,7 +759,7 @@ EslUdp6RxComplete (
   //  Determine the socket configuration status
   //
   Status = pSocket->bConfigured ? EFI_SUCCESS : EFI_NOT_STARTED;
-  
+
   //
   //  Return the port connected state.
   //
@@ -1028,6 +1029,7 @@ EslUdp6TxBuffer (
 
 **/
 VOID
+EFIAPI
 EslUdp6TxComplete (
   IN EFI_EVENT Event,
   IN ESL_IO_MGMT * pIo
@@ -1038,9 +1040,9 @@ EslUdp6TxComplete (
   ESL_PACKET * pPacket;
   ESL_SOCKET * pSocket;
   EFI_STATUS Status;
-  
+
   DBG_ENTER ( );
-  
+
   //
   //  Locate the active transmit packet
   //


### PR DESCRIPTION
When compiling in Unix environments, the ABI defaults to SysV.
Callbacks are invoked directly by the system firmware so they
must necessarily use MS ABI.

Contributed-under: TianoCore Contribution Agreement 1.0
Signed-off-by: Marco Guerri <marco.guerri.dev@fastmail.com>