### PR TITLE
Macro does not compile on GCC 5.4

### DIFF
--- a/MdeModulePkg/Library/ResetUtilityLib/ResetUtility.c
+++ b/MdeModulePkg/Library/ResetUtilityLib/ResetUtility.c
@@ -100,7 +100,7 @@ GetResetPlatformSpecificGuid (
   //
   if ((ResetDataStringSize < DataSize) && (DataSize - ResetDataStringSize) >= sizeof (GUID)) {
     ResetSubtypeGuid = (GUID *)((UINT8 *)ResetData + ResetDataStringSize);
-    DEBUG ((DEBUG_VERBOSE, __FUNCTION__" - Detected reset subtype %g...\n", ResetSubtypeGuid));
+    DEBUG ((DEBUG_VERBOSE, " - Detected reset subtype %g...\n", ResetSubtypeGuid));
     return ResetSubtypeGuid;
   }
   return NULL;


### PR DESCRIPTION
I'm building the version from master. I'm using Debian Stretch with a locally compiled GCC 5.4. While building I get this error message:

```
Building ... /home/hrimih/work/edk2.git/MdeModulePkg/Library/ResetUtilityLib/ResetUtilityLib.inf [X64]
"gcc" -g -fshort-wchar -fno-builtin -fno-strict-aliasing -Wall -Werror -Wno-array-bounds -ffunction-sections -fdata-sections -include AutoGen.h -fno-common -DSTRING_ARRAY_NAME=ResetUtilityLibStrings -m64 -fno-stack-protector "-DEFIAPI=__attribute__((ms_abi))" -maccumulate-outgoing-args -mno-red-zone -Wno-address -mcmodel=small -fpie -fno-asynchronous-unwind-tables -Wno-address -flto -DUSING_LTO -Os -D DISABLE_NEW_DEPRECATED_INTERFACES -c -o /home/hrimih/work/edk2.git/Build/MdeModule/DEBUG_GCC5/X64/MdeModulePkg/Library/ResetUtilityLib/ResetUtilityLib/OUTPUT/./ResetUtility.obj -I/home/hrimih/work/edk2.git/MdeModulePkg/Library/ResetUtilityLib -I/home/hrimih/work/edk2.git/Build/MdeModule/DEBUG_GCC5/X64/MdeModulePkg/Library/ResetUtilityLib/ResetUtilityLib/DEBUG -I/home/hrimih/work/edk2.git/MdePkg -I/home/hrimih/work/edk2.git/MdePkg/Include -I/home/hrimih/work/edk2.git/MdePkg/Include/X64 -I/home/hrimih/work/edk2.git/MdeModulePkg -I/home/hrimih/work/edk2.git/MdeModulePkg/Include /home/hrimih/work/edk2.git/MdeModulePkg/Library/ResetUtilityLib/ResetUtility.c
Building ... /home/hrimih/work/edk2.git/MdeModulePkg/Library/BaseResetSystemLibNull/BaseResetSystemLibNull.inf [X64]
make: Nothing to be done for 'tbuild'.
Building ... /home/hrimih/work/edk2.git/MdeModulePkg/Library/DxeSecurityManagementLib/DxeSecurityManagementLib.inf [X64]
make: Nothing to be done for 'tbuild'.
Building ... /home/hrimih/work/edk2.git/MdeModulePkg/Library/OemHookStatusCodeLibNull/OemHookStatusCodeLibNull.inf [X64]
In file included from /home/hrimih/work/edk2.git/MdeModulePkg/Library/ResetUtilityLib/ResetUtility.c:18:0:
/home/hrimih/work/edk2.git/MdeModulePkg/Library/ResetUtilityLib/ResetUtility.c: In function ‘GetResetPlatformSpecificGuid’:
/home/hrimih/work/edk2.git/MdeModulePkg/Library/ResetUtilityLib/ResetUtility.c:103:40: error: expected ‘)’ before string constant
     DEBUG ((DEBUG_VERBOSE, __FUNCTION__" - Detected reset subtype %g...\n", ResetSubtypeGuid));
                                        ^
/home/hrimih/work/edk2.git/MdePkg/Include/Library/DebugLib.h:268:35: note: in definition of macro ‘_DEBUG_PRINT’
         DebugPrint (PrintLevel, ##__VA_ARGS__);      \
                                   ^
/home/hrimih/work/edk2.git/MdePkg/Include/Library/DebugLib.h:318:9: note: in expansion of macro ‘_DEBUG’
         _DEBUG (Expression);       \
         ^
/home/hrimih/work/edk2.git/MdeModulePkg/Library/ResetUtilityLib/ResetUtility.c:103:5: note: in expansion of macro ‘DEBUG’
     DEBUG ((DEBUG_VERBOSE, __FUNCTION__" - Detected reset subtype %g...\n", ResetSubtypeGuid));
     ^
GNUmakefile:330: recipe for target '/home/hrimih/work/edk2.git/Build/MdeModule/DEBUG_GCC5/X64/MdeModulePkg/Library/ResetUtilityLib/ResetUtilityLib/OUTPUT/ResetUtility.obj' failed
make: *** [/home/hrimih/work/edk2.git/Build/MdeModule/DEBUG_GCC5/X64/MdeModulePkg/Library/ResetUtilityLib/ResetUtilityLib/OUTPUT/ResetUtility.obj] Error 1


build.py...
 : error 7000: Failed to execute command
        make tbuild [/home/hrimih/work/edk2.git/Build/MdeModule/DEBUG_GCC5/X64/MdeModulePkg/Library/ResetUtilityLib/ResetUtilityLib]


build.py...
 : error F002: Failed to build module
        /home/hrimih/work/edk2.git/MdeModulePkg/Library/ResetUtilityLib/ResetUtilityLib.inf [X64, GCC5, DEBUG]

- Failed -
Build end time: 11:02:45, Feb.12 2018
Build total time: 00:00:07
```

I'm not sure if this is the best solution but this fixes the build for me.