### PR TITLE
Remove declaration of __builtin_return_address()

### DIFF
--- a/MdePkg/Include/Base.h
+++ b/MdePkg/Include/Base.h
@@ -1278,7 +1278,6 @@ typedef UINTN RETURN_STATUS;
   **/
   #define RETURN_ADDRESS(L)     ((L == 0) ? _ReturnAddress() : (VOID *) 0)
 #elif defined(__GNUC__)
-  void * __builtin_return_address (unsigned int level);
   /**
     Get the return address of the calling function.
 


### PR DESCRIPTION
This function is providded by the compiler and should not be declared.
Starting with LLVM commit https://reviews.llvm.org/rL330160 (will
be included in Clang 7) this declaration will give a compilation error.