### PR TITLE
Compare to `None` using identity `is` operator

### DIFF
--- a/AppPkg/Applications/Python/Python-2.7.2/Demo/metaclasses/Synch.py
+++ b/AppPkg/Applications/Python/Python-2.7.2/Demo/metaclasses/Synch.py
@@ -70,7 +70,7 @@ class Lock:
             return 0
         try:
             self.__mutex.acquire()
-            assert self.__tid == None
+            assert self.__tid is None
             assert self.__count == 0
             self.__tid = thread.get_ident()
             self.__count = 1

--- a/AppPkg/Applications/Python/Python-2.7.2/Tools/bgen/bgen/bgenObjectDefinition.py
+++ b/AppPkg/Applications/Python/Python-2.7.2/Tools/bgen/bgen/bgenObjectDefinition.py
@@ -238,8 +238,8 @@ class PEP252Mixin:
         # signify a bgen-client that has been partially converted to PEP252.
         assert self.outputGetattr.im_func == PEP252Mixin.outputGetattr.im_func
         assert self.outputSetattr.im_func == PEP252Mixin.outputSetattr.im_func
-        assert self.outputGetattrBody == None
-        assert self.outputGetattrHook == None
+        assert self.outputGetattrBody is None
+        assert self.outputGetattrHook is None
         assert self.basechain == "NULL"
 
     def outputGetattr(self):

--- a/AppPkg/Applications/Python/Python-2.7.2/Tools/gdb/libpython.py
+++ b/AppPkg/Applications/Python/Python-2.7.2/Tools/gdb/libpython.py
@@ -1128,7 +1128,7 @@ that this python file is installed to the same path as the library (or its
   /usr/lib/debug/usr/lib/libpython2.6.so.1.0.debug-gdb.py
 """
 def register (obj):
-    if obj == None:
+    if obj is None:
         obj = gdb
 
     # Wire up the pretty-printer

--- a/ArmPlatformPkg/Scripts/Ds5/firmware_volume.py
+++ b/ArmPlatformPkg/Scripts/Ds5/firmware_volume.py
@@ -215,7 +215,7 @@ class FirmwareFile:
         return highest_bit
 
     def get_next_section(self, section=None):
-        if section == None:
+        if section is None:
             if self.get_type() != FirmwareFile.EFI_FV_FILETYPE_FFS_MIN:
                 section_base = self.get_base() + 0x18;
             else:
@@ -264,7 +264,7 @@ class FirmwareVolume:
             return 0
 
     def get_next_ffs(self, ffs=None):
-        if ffs == None:
+        if ffs is None:
             # Get the offset of the first FFS file from the FV header
             ffs_base = self.fv_base +  self.ec.getMemoryService().readMemory16(self.fv_base + 0x30)
         else:

--- a/IntelFsp2Pkg/Tools/GenCfgOpt.py
+++ b/IntelFsp2Pkg/Tools/GenCfgOpt.py
@@ -531,7 +531,7 @@ EndList
                                                   break
                                         else:
                                           IncludeDsc  = open(IncludeFilePath, "r")
-                                        if IncludeDsc == None:
+                                        if IncludeDsc is None:
                                             print("ERROR: Cannot open file '%s'" % IncludeFilePath)
                                             raise SystemExit
                                         NewDscLines = IncludeDsc.readlines()
@@ -753,7 +753,7 @@ EndList
                     Match = re.match("^\s*#\s+(!BSF|@Bsf)\s+FIELD:{(.+):(\d+)([Bb])?}", DscLine)
                     if Match:
                         SubCfgDict = ConfigDict.copy()
-                        if (Match.group(4) == None) or (Match.group(4) == 'B'):
+                        if (Match.group(4) is None) or (Match.group(4) == 'B'):
                           UnitBitLen = 8
                         elif Match.group(4) == 'b':
                           UnitBitLen = 1

--- a/IntelFsp2Pkg/Tools/PatchFv.py
+++ b/IntelFsp2Pkg/Tools/PatchFv.py
@@ -706,7 +706,7 @@ class Symbols:
     #
     def getVariable(self, var):
         value = self.dictVariable.get(var, None)
-        if value == None:
+        if value is None:
             raise Exception("Unrecognized variable '%s'" % var)
         return value
 

--- a/IntelFspPkg/Tools/PatchFv.py
+++ b/IntelFspPkg/Tools/PatchFv.py
@@ -681,7 +681,7 @@ class Symbols:
     #
     def getVariable(self, var):
         value = self.dictVariable.get(var, None)
-        if value == None:
+        if value is None:
             raise Exception("Unrecognized variable '%s'" % var)
         return value
 


### PR DESCRIPTION
This is a trivial change that replaces `==` operator with `is` operator, following PEP 8 guideline:

> Comparisons to singletons like None should always be done with is or is not, never the equality operators.

https://legacy.python.org/dev/peps/pep-0008/#programming-recommendations