### PR TITLE
BaseTools: Fix python3.8 SyntaxWarning

### DIFF
--- a/BaseTools/Source/Python/build/build.py
+++ b/BaseTools/Source/Python/build/build.py
@@ -1499,7 +1499,7 @@ class Build():
         if self.Fdf:
             # First get the XIP base address for FV map file.
             GuidPattern = re.compile("[-a-fA-F0-9]+")
-            GuidName = re.compile("\(GUID=[-a-fA-F0-9]+")
+            GuidName = re.compile(r"\(GUID=[-a-fA-F0-9]+")
             for FvName in Wa.FdfProfile.FvDict:
                 FvMapBuffer = os.path.join(Wa.FvDir, FvName + '.Fv.map')
                 if not os.path.exists(FvMapBuffer):


### PR DESCRIPTION
Building with python3.8 shows a warning like:

SyntaxWarning: invalid escape sequence \(
  GuidName = re.compile("\(GUID=[-a-fA-F0-9]+")

It seems harmless, but it's easy enough to fix: mark the string as
raw with the 'r' prefix like is used elsewhere in the file