### PR TITLE
Allow sending NVMe admin requests with different values for the NSID.

### DIFF
--- a/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressPassthru.c
+++ b/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressPassthru.c
@@ -561,7 +561,7 @@ NvmExpressPassThru (
   Sq  = Private->SqBuffer[QueueId] + Private->SqTdbl[QueueId].Sqt;
   Cq  = Private->CqBuffer[QueueId] + Private->CqHdbl[QueueId].Cqh;
 
-  if (Packet->NvmeCmd->Nsid != NamespaceId) {
+  if (Packet->QueueType != NVME_ADMIN_QUEUE && Packet->NvmeCmd->Nsid != NamespaceId) {
     return EFI_INVALID_PARAMETER;
   }
 


### PR DESCRIPTION
This change allows for variations in how logs are read, formats are performed, DST is performed, among other operations where the NSID is used to select between a single namespace, all namespaces, or for other uses.
Checking the NSID should be done for NVM command set commands, but not admin commands, so this check was left as long as the request isn't an admin command.

Signed-off-by: Tyler Erickson tyler.j.erickson@seagate.com