### PR TITLE
MdePkg/DxeHstiLib: Added checks to improve error handling.

### DIFF
--- a/MdePkg/Library/DxeHstiLib/HstiDxe.c
+++ b/MdePkg/Library/DxeHstiLib/HstiDxe.c
@@ -51,7 +51,7 @@ InternalHstiFindAip (
                   &NoHandles,
                   &Handles
                   );
-  if (EFI_ERROR (Status)) {
+  if (EFI_ERROR (Status) || (Handles == NULL) || (NoHandles == 0)) {
     return NULL;
   }
 
@@ -77,7 +77,7 @@ InternalHstiFindAip (
                     &InfoTypesBuffer,
                     &InfoTypesBufferCount
                     );
-    if (EFI_ERROR (Status)) {
+    if (EFI_ERROR (Status) || (InfoTypesBuffer == NULL) || (InfoTypesBufferCount == 0)) {
       continue;
     }
 


### PR DESCRIPTION
REF:https://bugzilla.tianocore.org/show_bug.cgi?id=2138

Added checks for return parameters of LocateHandleBuffer &
GetSupportedTypes function calls in InternalHstiFindAip to
improve error handling.
An issue was observed on Dell Poweredge R740, where the Dell
PERC H740P controller UEFI driver returned InfoTypesBuffer = NULL,
InfoTypesBufferCount = 0 and caused an FreePool assert.

Signed-off-by: Jayanth Raghuram <Jayanth.Raghuram@Dell.com>
Cc: Wei G Liu <Wei_G_Liu@Dell.com>
Reviewed-by: Liming Gao <liming.gao@intel.com>