### PR TITLE
MdeModulePkg: Fixed FrameBufferBltLibBufferToVideo for PixelBlueGreenRedReserved8BitPerColor pixel format

### DIFF
--- a/MdeModulePkg/Library/FrameBufferBltLib/FrameBufferBltLib.c
+++ b/MdeModulePkg/Library/FrameBufferBltLib/FrameBufferBltLib.c
@@ -504,7 +504,7 @@ FrameBufferBltLibBufferToVideo (
     Destination = Configure->FrameBuffer + Offset;
 
     if (Configure->PixelFormat == PixelBlueGreenRedReserved8BitPerColor) {
-      Source = (UINT8 *) BltBuffer + (SrcY * Delta);
+      Source = (UINT8 *) BltBuffer + (SrcY * Delta) + SourceX;
     } else {
       for (IndexX = 0; IndexX < Width; IndexX++) {
         Blt =

--- a/MdeModulePkg/Library/FrameBufferBltLib/FrameBufferBltLib.c
+++ b/MdeModulePkg/Library/FrameBufferBltLib/FrameBufferBltLib.c
@@ -504,7 +504,7 @@ FrameBufferBltLibBufferToVideo (
     Destination = Configure->FrameBuffer + Offset;
 
     if (Configure->PixelFormat == PixelBlueGreenRedReserved8BitPerColor) {
-      Source = (UINT8 *) BltBuffer + (SrcY * Delta) + SourceX;
+      Source = (UINT8 *) BltBuffer + (SrcY * Delta) + SourceX * sizeof (EFI_GRAPHICS_OUTPUT_BLT_PIXEL);
     } else {
       for (IndexX = 0; IndexX < Width; IndexX++) {
         Blt =


### PR DESCRIPTION
There is sourceX offset missing in case when Configure->PixelFormat == PixelBlueGreenRedReserved8BitPerColor.
We are copying most left pixels without it instead of copying required rectangle.

Signed-off-by: Gris87 <Gris87@yandex.ru>
CC: Ruiyu Ni <ruiyu.ni@intel.com>