### PR TITLE
EmulatorPkg/PlatformSmbiosDxe: fix a spell error of platform.

### DIFF
--- a/EmulatorPkg/PlatformSmbiosDxe/PlatformSmbiosDxe.c
+++ b/EmulatorPkg/PlatformSmbiosDxe/PlatformSmbiosDxe.c
@@ -82,7 +82,7 @@ CreatePlatformSmbiosMemoryRecords (
 **/
 EFI_STATUS
 EFIAPI
-PlatfomrSmbiosDriverEntryPoint (
+PlatformSmbiosDriverEntryPoint (
   IN EFI_HANDLE         ImageHandle,
   IN EFI_SYSTEM_TABLE   *SystemTable
   )

--- a/EmulatorPkg/PlatformSmbiosDxe/PlatformSmbiosDxe.inf
+++ b/EmulatorPkg/PlatformSmbiosDxe/PlatformSmbiosDxe.inf
@@ -15,7 +15,7 @@
   FILE_GUID                      = 67FA951E-4FA2-9F4E-A658-4DBD954AC22E
   MODULE_TYPE                    = DXE_DRIVER
   VERSION_STRING                 = 1.0
-  ENTRY_POINT                    = PlatfomrSmbiosDriverEntryPoint
+  ENTRY_POINT                    = PlatformSmbiosDriverEntryPoint
 
 
 [Sources]


### PR DESCRIPTION
Old code use platfomr.
Change PlatfomrSmbiosDriverEntryPoint to PlatformSmbiosDriverEntryPoint.

Signed-off-by: Ming Tan <ming.tan@intel.com>
Reviewed-by: Ray Ni <ray.ni@intel.com>
Reviewed-by: Liming Gao <liming.gao@intel.com>
Reviewed-by: Philippe Mathieu-Daude <philmd@redhat.com>