### PR TITLE
MdeModulePkg/Variable: Fix volatile variable RT cache update logic

### DIFF
--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/Variable.c
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/Variable.c
@@ -2296,10 +2296,10 @@ UpdateVariable (
 
 Done:
   if (!EFI_ERROR (Status)) {
-    if (Variable->Volatile) {
-      VolatileCacheInstance = &(mVariableModuleGlobal->VariableGlobal.VariableRuntimeCacheContext.VariableRuntimeVolatileCache);
-    } else {
+    if ((Variable->CurrPtr != NULL && !Variable->Volatile) || (Attributes & EFI_VARIABLE_NON_VOLATILE) != 0) {
       VolatileCacheInstance = &(mVariableModuleGlobal->VariableGlobal.VariableRuntimeCacheContext.VariableRuntimeNvCache);
+    } else {
+      VolatileCacheInstance = &(mVariableModuleGlobal->VariableGlobal.VariableRuntimeCacheContext.VariableRuntimeVolatileCache);
     }
 
     if (VolatileCacheInstance->Store != NULL) {


### PR DESCRIPTION
REF:https://bugzilla.tianocore.org/show_bug.cgi?id=2333

During a SetVariable () invocation, UpdateVariable () is called.
UpdateVariable () contains logic to determine whether a volatile or
non-volatile UEFI variable was set so the corresponding runtime
cache can be updated to reflect the change. The current logic simply
evaluates Variable->Volatile to determine which runtime cache should
be updated.

The problem is Variable->Volatile does not always reflect whether a
volatile variable is being set. Variable->Volatile is set to TRUE
only in the case a pre-existing variable is found in the volatile
variable store. Therefore, the value is FALSE when a new volatile
variable is written.

This change updates the logic to take this into account. If a new
variable is written successfully, the Attributes will accurately
reflect whether the variable is non-volatile. If a pre-existing
variable is modified, the Volatile field will reflect the type of
variable (Attributes are not reliable; e.g. 0x0 indicates deletion).

* Observable symptom: A volatile variable that was set successfully
  might return EFI_NOT_FOUND when the variable should be found.

* The issue is a regression introduced to the variable services only
  when the variable runtime cache is enabled by the following PCD
  being set to TRUE:
  gEfiMdeModulePkgTokenSpaceGuid.PcdEnableVariableRuntimeCache

* The issue was implemented in commit aab3b9b9a1 but the PCD was not
  set to TRUE by default enabling the issue until commit e07b7d024a.

Fixes: aab3b9b9a1e5e1f3fa966fb1667fc3e6c47e7706

Cc: Liming Gao <liming.gao@intel.com>
Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Hao A Wu <hao.a.wu@intel.com>
Signed-off-by: Michael Kubacki <michael.a.kubacki@intel.com>
Reviewed-by: Liming Gao <liming.gao@intel.com>