### PR TITLE
BaseTools: Enable MACRO for DSC Components section tag

### DIFF
--- a/BaseTools/Source/Python/Workspace/MetaFileParser.py
+++ b/BaseTools/Source/Python/Workspace/MetaFileParser.py
@@ -328,6 +328,7 @@ class MetaFileParser(object):
                 S1 = ItemList[1].upper()
             else:
                 S1 = TAB_ARCH_COMMON
+            S1 = ReplaceMacro(S1, self._Macros)
             ArchList.add(S1)
 
             # S2 may be Platform or ModuleType


### PR DESCRIPTION
BZ: https://bugzilla.tianocore.org/show_bug.cgi?id=2308

This patch is to enable MACRO for Components section architecture
modifier.

Cc: Liming Gao <liming.gao@intel.com>
Signed-off-by: Bob Feng <bob.c.feng@intel.com>
Reviewed-by: Liming Gao <liming.gao@intel.com>