### PR TITLE
MdePkg/Include: Add missing definitions of SMBIOS type 42h in SmBios.h

### DIFF
--- a/MdePkg/Include/IndustryStandard/SmBios.h
+++ b/MdePkg/Include/IndustryStandard/SmBios.h
@@ -2484,6 +2484,15 @@ typedef struct {
 } SMBIOS_TABLE_TYPE41;
 
 ///
+///  Management Controller Host Interface - Protocol Record Data Format.
+///
+typedef struct {
+  UINT8                        ProtocolType;
+  UINT8                        ProtocolTypeDataLen;
+  UINT8                        ProtocolTypeData[1];
+} MC_HOST_INTERFACE_PROTOCOL_RECORD;
+
+///
 /// Management Controller Host Interface - Interface Types.
 /// 00h - 3Fh: MCTP Host Interfaces
 ///


### PR DESCRIPTION
Add host interface Protocol Type Data Format structure in SmBios.h

BZ link,
https://bugzilla.tianocore.org/show_bug.cgi?id=2328

Signed-off-by: Abner Chang <abner.chang@hpe.com>

Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Liming Gao <liming.gao@intel.com>
Signed-off-by: Abner Chang <abner.chang@hpe.com>