### PR TITLE
MdePkg: add null version of RngLib

### DIFF
--- a/MdePkg/Library/BaseRngLibNull/BaseRngLibNull.c
+++ b/MdePkg/Library/BaseRngLibNull/BaseRngLibNull.c
@@ -1,0 +1,94 @@
+/** @file
+  Null version of Random number generator services.
+
+Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Library/DebugLib.h>
+#include <Library/RngLib.h>
+
+/**
+  Generates a 16-bit random number.
+
+  if Rand is NULL, then ASSERT().
+
+  @param[out] Rand     Buffer pointer to store the 16-bit random value.
+
+  @retval TRUE         Random number generated successfully.
+  @retval FALSE        Failed to generate the random number.
+
+**/
+BOOLEAN
+EFIAPI
+GetRandomNumber16 (
+  OUT     UINT16                    *Rand
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Generates a 32-bit random number.
+
+  if Rand is NULL, then ASSERT().
+
+  @param[out] Rand     Buffer pointer to store the 32-bit random value.
+
+  @retval TRUE         Random number generated successfully.
+  @retval FALSE        Failed to generate the random number.
+
+**/
+BOOLEAN
+EFIAPI
+GetRandomNumber32 (
+  OUT     UINT32                    *Rand
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Generates a 64-bit random number.
+
+  if Rand is NULL, then ASSERT().
+
+  @param[out] Rand     Buffer pointer to store the 64-bit random value.
+
+  @retval TRUE         Random number generated successfully.
+  @retval FALSE        Failed to generate the random number.
+
+**/
+BOOLEAN
+EFIAPI
+GetRandomNumber64 (
+  OUT     UINT64                    *Rand
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Generates a 128-bit random number.
+
+  if Rand is NULL, then ASSERT().
+
+  @param[out] Rand     Buffer pointer to store the 128-bit random value.
+
+  @retval TRUE         Random number generated successfully.
+  @retval FALSE        Failed to generate the random number.
+
+**/
+BOOLEAN
+EFIAPI
+GetRandomNumber128 (
+  OUT     UINT64                    *Rand
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}

--- a/MdePkg/Library/BaseRngLibNull/BaseRngLibNull.inf
+++ b/MdePkg/Library/BaseRngLibNull/BaseRngLibNull.inf
@@ -1,0 +1,30 @@
+## @file
+#  Null instance of RNG (Random Number Generator) Library.
+#
+#  Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010029
+  BASE_NAME                      = BaseRngLibNull
+  MODULE_UNI_FILE                = BaseRngLibNull.uni
+  FILE_GUID                      = CD8991F8-2061-4084-8C9E-9C6F352DC58D
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = RngLib
+
+#
+#  VALID_ARCHITECTURES           = IA32 X64 ARM AARCH64 EBC
+#
+
+[Sources]
+  BaseRngLibNull.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+
+[LibraryClasses]
+  DebugLib

--- a/MdePkg/Library/BaseRngLibNull/BaseRngLibNull.uni
+++ b/MdePkg/Library/BaseRngLibNull/BaseRngLibNull.uni
@@ -1,0 +1,14 @@
+// /** @file
+// Null Instance of RNG (Random Number Generator) Library.
+//
+// Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+// **/
+
+
+#string STR_MODULE_ABSTRACT             #language en-US "Null Instance of RNG Library"
+
+#string STR_MODULE_DESCRIPTION          #language en-US "This library instance should be used with modules that inherit an (indirect) dependency on the RngLib class, but never actually call RngLib APIs for consuming randomness."
+

--- a/MdePkg/MdePkg.dsc
+++ b/MdePkg/MdePkg.dsc
@@ -61,6 +61,7 @@
   MdePkg/Library/BaseUefiDecompressLib/BaseUefiTianoCustomDecompressLib.inf
   MdePkg/Library/BaseSmbusLibNull/BaseSmbusLibNull.inf
   MdePkg/Library/BaseSafeIntLib/BaseSafeIntLib.inf
+  MdePkg/Library/BaseRngLibNull/BaseRngLibNull.inf
 
   MdePkg/Library/DxeCoreEntryPoint/DxeCoreEntryPoint.inf
   MdePkg/Library/DxeCoreHobLib/DxeCoreHobLib.inf


### PR DESCRIPTION
Ref: https://bugzilla.tianocore.org/show_bug.cgi?id=1871

This is null version of RngLib which should be used with modules that
inherit an (indirect) dependency on the RngLib class, but never actually
call RngLib APIs for consuming randomness.

To be more specific, if following components or functionalities are used
in a platform, the BaseRngLibNull should *not* be used. Instead, a non-Null
version of RngLib must be used (like BaseRngLib for IA32/X64, or future
DxeRngLibRngProtocol for all ARCHs).

- HddPasswordDxe.inf
- AES, TLS (TlsDxe.inf, TlsLib.inf), RSA_OAEP, RSA_PK1
- (If BaseRngLibNull interface ASSERTed at boot time)

Signed-off-by: Jian J Wang <jian.j.wang@intel.com>
Reviewed-by: Laszlo Ersek <lersek@redhat.com>
Reviewed-by: Liming Gao <liming.gao@intel.com>