### PR TITLE
BaseTools:Add [packages] section in dsc file

### DIFF
--- a/BaseTools/Source/Python/AutoGen/PlatformAutoGen.py
+++ b/BaseTools/Source/Python/AutoGen/PlatformAutoGen.py
@@ -975,6 +975,7 @@ class PlatformAutoGen(AutoGen):
                 continue
             ModuleData = self.BuildDatabase[ModuleFile, self.Arch, self.BuildTarget, self.ToolChain]
             RetVal.update(ModuleData.Packages)
+        RetVal.update(self.Platform.Packages)
         return list(RetVal)
 
     @cached_property

--- a/BaseTools/Source/Python/AutoGen/WorkspaceAutoGen.py
+++ b/BaseTools/Source/Python/AutoGen/WorkspaceAutoGen.py
@@ -420,6 +420,7 @@ class WorkspaceAutoGen(AutoGen):
                     continue
                 ModuleData = self.BuildDatabase[ModuleFile, Arch, self.BuildTarget, self.ToolChain]
                 PkgSet.update(ModuleData.Packages)
+            PkgSet.update(Platform.Packages)
             Pkgs[Arch] = list(PkgSet)
         return Pkgs
 

--- a/BaseTools/Source/Python/Common/DataType.py
+++ b/BaseTools/Source/Python/Common/DataType.py
@@ -519,6 +519,7 @@ SECTIONS_HAVE_ITEM_AFTER_ARCH_SET = {TAB_LIBRARY_CLASSES.upper(), TAB_DEPEX.uppe
                                  PCDS_DYNAMICEX_VPD.upper(),
                                  PCDS_DYNAMICEX_HII.upper(),
                                  TAB_BUILD_OPTIONS.upper(),
+                                 TAB_PACKAGES.upper(),
                                  TAB_INCLUDES.upper()}
 
 #

--- a/BaseTools/Source/Python/Workspace/WorkspaceCommon.py
+++ b/BaseTools/Source/Python/Workspace/WorkspaceCommon.py
@@ -37,6 +37,8 @@ class OrderedListDict(OrderedDict):
 #
 def GetPackageList(Platform, BuildDatabase, Arch, Target, Toolchain):
     PkgSet = set()
+    if Platform.Packages:
+        PkgSet.update(Platform.Packages)
     for ModuleFile in Platform.Modules:
         Data = BuildDatabase[ModuleFile, Arch, Target, Toolchain]
         PkgSet.update(Data.Packages)

--- a/BaseTools/Source/Python/Workspace/WorkspaceDatabase.py
+++ b/BaseTools/Source/Python/Workspace/WorkspaceDatabase.py
@@ -186,6 +186,10 @@ class WorkspaceDatabase(object):
             for Package in LibObj.Packages:
                 if Package not in PackageList:
                     PackageList.append(Package)
+        for Package in Pa.Packages:
+            if Package in PackageList:
+                continue
+            PackageList.append(Package)
 
         return PackageList
 


### PR DESCRIPTION
BZ:https://bugzilla.tianocore.org/show_bug.cgi?id=2270

Currently a PCD (e.g. FeaturePCD) cannot be used in a conditional
statement in a DSC/FDF file without a module in the build referencing
the PCD package DEC file.

An example implementation that to support this is to allow a [Packages]
section in the DSC file to list additional package dependencies for PCD
references in the package DSC/FDF files.

this patch is going to  add the ability to have the [packages] section
defined in the DSC file

Cc: Liming Gao <liming.gao@intel.com>
Cc: Bob Feng <bob.c.feng@intel.com>
Signed-off-by: Zhiju.Fan <zhijux.fan@intel.com>
Acked-by: Liming Gao <liming.gao@intel.com>
Reviewed-by: Bob Feng <bob.c.feng@intel.com>