### PR TITLE
StandaloneMmPkg: Fix build failure

### DIFF
--- a/StandaloneMmPkg/StandaloneMmPkg.dsc
+++ b/StandaloneMmPkg/StandaloneMmPkg.dsc
@@ -2,7 +2,7 @@
 # Standalone MM Platform.
 #
 # Copyright (c) 2015, Intel Corporation. All rights reserved.<BR>
-# Copyright (c) 2016 - 2018, ARM Limited. All rights reserved.<BR>
+# Copyright (c) 2016 - 2019, ARM Limited. All rights reserved.<BR>
 #
 #    SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -19,7 +19,7 @@
   PLATFORM_VERSION               = 1.0
   DSC_SPECIFICATION              = 0x00010011
   OUTPUT_DIRECTORY               = Build/StandaloneMm
-  SUPPORTED_ARCHITECTURES        = IA32|X64|AARCH64
+  SUPPORTED_ARCHITECTURES        = AARCH64
   BUILD_TARGETS                  = DEBUG|RELEASE
   SKUID_IDENTIFIER               = DEFAULT
 


### PR DESCRIPTION
The StandaloneMmPkg currently has code for supporting
Arm architecture only. Support for X64 and IA32 is
currently under development on a separate branch.

However, StandaloneMmPkg/StandaloneMmPkg.dsc is
indicating that support for X64 and IA32 is
available which is causing build failures.
This has been reported in
https://bugzilla.tianocore.org/show_bug.cgi?id=2253

This issue has been discussed earlier on the list:
(1) https://edk2.groups.io/g/devel/message/47276

(2) https://edk2.groups.io/g/devel/message/47283

In light of the above, this patch removes IA32 and X64
from SUPPORTED_ARCHITECTURES, until support for the
respective architectures is merged into StandaloneMmPkg.

Cc: Achin Gupta <achin.gupta@arm.com>
Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Supreeth Venkatesh <supreeth.venkatesh@arm.com>
Cc: Laszlo Ersek <lersek@redhat.com>
Signed-off-by: Sami Mujawar <sami.mujawar@arm.com>
Reviewed-by: Laszlo Ersek <lersek@redhat.com>
Reviewed-by: Jiewen Yao <jiewen.yao@intel.com>