### PR TITLE
Cpu/feature

### DIFF
--- a/UefiCpuPkg/Include/Library/RegisterCpuFeaturesLib.h
+++ b/UefiCpuPkg/Include/Library/RegisterCpuFeaturesLib.h
@@ -79,6 +79,37 @@
 /// @}
 
 ///
+/// The bit field to indicate whether the processor is the first in its parent scope.
+///
+typedef struct {
+  //
+  // Set to 1 when current processor is the first thread in the core it resides in.
+  //
+  UINT32 Thread   : 1;
+  //
+  // Set to 1 when current processor is a thread of the first core in the module it resides in.
+  //
+  UINT32 Core     : 1;
+  //
+  // Set to 1 when current processor is a thread of the first module in the tile it resides in.
+  //
+  UINT32 Module   : 1;
+  //
+  // Set to 1 when current processor is a thread of the first tile in the die it resides in.
+  //
+  UINT32 Tile     : 1;
+  //
+  // Set to 1 when current processor is a thread of the first die in the package it resides in.
+  //
+  UINT32 Die      : 1;
+  //
+  // Set to 1 when current processor is a thread of the first package in the system.
+  //
+  UINT32 Package  : 1;
+  UINT32 Reserved : 26;
+} REGISTER_CPU_FEATURE_FIRST_PROCESSOR;
+
+///
 /// CPU Information passed into the SupportFunc and InitializeFunc of the
 /// RegisterCpuFeature() library function.  This structure contains information
 /// that is commonly used during CPU feature detection and initialization.
@@ -88,6 +119,11 @@ typedef struct {
   /// The package that the CPU resides
   ///
   EFI_PROCESSOR_INFORMATION            ProcessorInfo;
+
+  ///
+  /// The bit flag indicating whether the CPU is the first Thread/Core/Module/Tile/Die/Package in its parent scope.
+  ///
+  REGISTER_CPU_FEATURE_FIRST_PROCESSOR First;
   ///
   /// The Display Family of the CPU computed from CPUID leaf CPUID_VERSION_INFO
   ///

--- a/UefiCpuPkg/Include/Library/RegisterCpuFeaturesLib.h
+++ b/UefiCpuPkg/Include/Library/RegisterCpuFeaturesLib.h
@@ -69,17 +69,8 @@
 
 #define CPU_FEATURE_BEFORE_ALL                      BIT23
 #define CPU_FEATURE_AFTER_ALL                       BIT24
-//
-// CPU_FEATURE_BEFORE and CPU_FEATURE_AFTER only mean Thread scope
-// before and Thread scope after.
-// It will be replace with CPU_FEATURE_THREAD_BEFORE and
-// CPU_FEATURE_THREAD_AFTER, and should not be used anymore.
-//
-#define CPU_FEATURE_BEFORE                          BIT25
-#define CPU_FEATURE_AFTER                           BIT26
-
-#define CPU_FEATURE_THREAD_BEFORE                   CPU_FEATURE_BEFORE
-#define CPU_FEATURE_THREAD_AFTER                    CPU_FEATURE_AFTER
+#define CPU_FEATURE_THREAD_BEFORE                   BIT25
+#define CPU_FEATURE_THREAD_AFTER                    BIT26
 #define CPU_FEATURE_CORE_BEFORE                     BIT27
 #define CPU_FEATURE_CORE_AFTER                      BIT28
 #define CPU_FEATURE_PACKAGE_BEFORE                  BIT29

--- a/UefiCpuPkg/Library/CpuCommonFeaturesLib/CpuCommonFeaturesLib.c
+++ b/UefiCpuPkg/Library/CpuCommonFeaturesLib/CpuCommonFeaturesLib.c
@@ -95,7 +95,7 @@ CpuCommonFeaturesLibConstructor (
                SmxSupport,
                SmxInitialize,
                CPU_FEATURE_SMX,
-               CPU_FEATURE_LOCK_FEATURE_CONTROL_REGISTER | CPU_FEATURE_BEFORE,
+               CPU_FEATURE_LOCK_FEATURE_CONTROL_REGISTER | CPU_FEATURE_THREAD_BEFORE,
                CPU_FEATURE_END
                );
     ASSERT_EFI_ERROR (Status);
@@ -107,7 +107,7 @@ CpuCommonFeaturesLibConstructor (
                VmxSupport,
                VmxInitialize,
                CPU_FEATURE_VMX,
-               CPU_FEATURE_LOCK_FEATURE_CONTROL_REGISTER | CPU_FEATURE_BEFORE,
+               CPU_FEATURE_LOCK_FEATURE_CONTROL_REGISTER | CPU_FEATURE_THREAD_BEFORE,
                CPU_FEATURE_END
                );
     ASSERT_EFI_ERROR (Status);
@@ -207,7 +207,7 @@ CpuCommonFeaturesLibConstructor (
                LmceSupport,
                LmceInitialize,
                CPU_FEATURE_LMCE,
-               CPU_FEATURE_LOCK_FEATURE_CONTROL_REGISTER | CPU_FEATURE_BEFORE,
+               CPU_FEATURE_LOCK_FEATURE_CONTROL_REGISTER | CPU_FEATURE_THREAD_BEFORE,
                CPU_FEATURE_END
                );
     ASSERT_EFI_ERROR (Status);

--- a/UefiCpuPkg/Library/RegisterCpuFeaturesLib/CpuFeaturesInitialize.c
+++ b/UefiCpuPkg/Library/RegisterCpuFeaturesLib/CpuFeaturesInitialize.c
@@ -105,6 +105,9 @@ CpuInitDataInitialize (
   EFI_CPU_PHYSICAL_LOCATION            *Location;
   BOOLEAN                              *CoresVisited;
   UINTN                                Index;
+  UINT32                               PackageIndex;
+  UINT32                               CoreIndex;
+  UINT32                               First;
   ACPI_CPU_DATA                        *AcpiCpuData;
   CPU_STATUS_INFORMATION               *CpuStatus;
   UINT32                               *ValidCoreCountPerPackage;
@@ -234,6 +237,77 @@ CpuInitDataInitialize (
   ASSERT (CpuFeaturesData->CpuFlags.CoreSemaphoreCount != NULL);
   CpuFeaturesData->CpuFlags.PackageSemaphoreCount = AllocateZeroPool (sizeof (UINT32) * CpuStatus->PackageCount * CpuStatus->MaxCoreCount * CpuStatus->MaxThreadCount);
   ASSERT (CpuFeaturesData->CpuFlags.PackageSemaphoreCount != NULL);
+
+  //
+  // Initialize CpuFeaturesData->InitOrder[].CpuInfo.First
+  //
+
+  //
+  // Set First.Package for each thread belonging to the first package.
+  //
+  First = MAX_UINT32;
+  for (ProcessorNumber = 0; ProcessorNumber < NumberOfCpus; ProcessorNumber++) {
+    Location = &CpuFeaturesData->InitOrder[ProcessorNumber].CpuInfo.ProcessorInfo.Location;
+    First = MIN (Location->Package, First);
+  }
+  for (ProcessorNumber = 0; ProcessorNumber < NumberOfCpus; ProcessorNumber++) {
+    Location = &CpuFeaturesData->InitOrder[ProcessorNumber].CpuInfo.ProcessorInfo.Location;
+    if (Location->Package == First) {
+      CpuFeaturesData->InitOrder[ProcessorNumber].CpuInfo.First.Package = 1;
+    }
+  }
+
+  //
+  // Set First.Die/Tile/Module for each thread assuming:
+  //  single Die under each package, single Tile under each Die, single Module under each Tile
+  //
+  for (ProcessorNumber = 0; ProcessorNumber < NumberOfCpus; ProcessorNumber++) {
+    CpuFeaturesData->InitOrder[ProcessorNumber].CpuInfo.First.Die = 1;
+    CpuFeaturesData->InitOrder[ProcessorNumber].CpuInfo.First.Tile = 1;
+    CpuFeaturesData->InitOrder[ProcessorNumber].CpuInfo.First.Module = 1;
+  }
+
+  for (PackageIndex = 0; PackageIndex < CpuStatus->PackageCount; PackageIndex++) {
+    //
+    // Set First.Core for each thread in the first core of each package.
+    //
+    First = MAX_UINT32;
+    for (ProcessorNumber = 0; ProcessorNumber < NumberOfCpus; ProcessorNumber++) {
+      Location = &CpuFeaturesData->InitOrder[ProcessorNumber].CpuInfo.ProcessorInfo.Location;
+      if (Location->Package == PackageIndex) {
+        First = MIN (Location->Core, First);
+      }
+    }
+
+    for (ProcessorNumber = 0; ProcessorNumber < NumberOfCpus; ProcessorNumber++) {
+      Location = &CpuFeaturesData->InitOrder[ProcessorNumber].CpuInfo.ProcessorInfo.Location;
+      if (Location->Package == PackageIndex && Location->Core == First) {
+        CpuFeaturesData->InitOrder[ProcessorNumber].CpuInfo.First.Core = 1;
+      }
+    }
+  }
+
+  for (PackageIndex = 0; PackageIndex < CpuStatus->PackageCount; PackageIndex++) {
+    for (CoreIndex = 0; CoreIndex < CpuStatus->MaxCoreCount; CoreIndex++) {
+      //
+      // Set First.Thread for the first thread of each core.
+      //
+      First = MAX_UINT32;
+      for (ProcessorNumber = 0; ProcessorNumber < NumberOfCpus; ProcessorNumber++) {
+        Location = &CpuFeaturesData->InitOrder[ProcessorNumber].CpuInfo.ProcessorInfo.Location;
+        if (Location->Package == PackageIndex && Location->Core == CoreIndex) {
+          First = MIN (Location->Thread, First);
+        }
+      }
+
+      for (ProcessorNumber = 0; ProcessorNumber < NumberOfCpus; ProcessorNumber++) {
+        Location = &CpuFeaturesData->InitOrder[ProcessorNumber].CpuInfo.ProcessorInfo.Location;
+        if (Location->Package == PackageIndex && Location->Core == CoreIndex && Location->Thread == First) {
+          CpuFeaturesData->InitOrder[ProcessorNumber].CpuInfo.First.Thread = 1;
+        }
+      }
+    }
+  }
 }
 
 /**

--- a/UefiCpuPkg/Library/RegisterCpuFeaturesLib/RegisterCpuFeatures.h
+++ b/UefiCpuPkg/Library/RegisterCpuFeaturesLib/RegisterCpuFeatures.h
@@ -43,8 +43,8 @@ typedef struct {
   CPU_FEATURE_GET_CONFIG_DATA  GetConfigDataFunc;
   CPU_FEATURE_SUPPORT          SupportFunc;
   CPU_FEATURE_INITIALIZE       InitializeFunc;
-  UINT8                        *BeforeFeatureBitMask;
-  UINT8                        *AfterFeatureBitMask;
+  UINT8                        *ThreadBeforeFeatureBitMask;
+  UINT8                        *ThreadAfterFeatureBitMask;
   UINT8                        *CoreBeforeFeatureBitMask;
   UINT8                        *CoreAfterFeatureBitMask;
   UINT8                        *PackageBeforeFeatureBitMask;

--- a/UefiCpuPkg/Library/RegisterCpuFeaturesLib/RegisterCpuFeaturesLib.c
+++ b/UefiCpuPkg/Library/RegisterCpuFeaturesLib/RegisterCpuFeaturesLib.c
@@ -858,16 +858,16 @@ RegisterCpuFeature (
                     != (CPU_FEATURE_CORE_BEFORE | CPU_FEATURE_CORE_AFTER));
     ASSERT ((Feature & (CPU_FEATURE_PACKAGE_BEFORE | CPU_FEATURE_PACKAGE_AFTER))
                     != (CPU_FEATURE_PACKAGE_BEFORE | CPU_FEATURE_PACKAGE_AFTER));
-    if (Feature < CPU_FEATURE_BEFORE) {
+    if (Feature < CPU_FEATURE_THREAD_BEFORE) {
       BeforeAll = ((Feature & CPU_FEATURE_BEFORE_ALL) != 0) ? TRUE : FALSE;
       AfterAll  = ((Feature & CPU_FEATURE_AFTER_ALL) != 0) ? TRUE : FALSE;
       Feature  &= ~(CPU_FEATURE_BEFORE_ALL | CPU_FEATURE_AFTER_ALL);
       ASSERT (FeatureMask == NULL);
       SetCpuFeaturesBitMask (&FeatureMask, Feature, CpuFeaturesData->BitMaskSize);
-    } else if ((Feature & CPU_FEATURE_BEFORE) != 0) {
-      SetCpuFeaturesBitMask (&BeforeFeatureBitMask, Feature & ~CPU_FEATURE_BEFORE, CpuFeaturesData->BitMaskSize);
-    } else if ((Feature & CPU_FEATURE_AFTER) != 0) {
-      SetCpuFeaturesBitMask (&AfterFeatureBitMask, Feature & ~CPU_FEATURE_AFTER, CpuFeaturesData->BitMaskSize);
+    } else if ((Feature & CPU_FEATURE_THREAD_BEFORE) != 0) {
+      SetCpuFeaturesBitMask (&BeforeFeatureBitMask, Feature & ~CPU_FEATURE_THREAD_BEFORE, CpuFeaturesData->BitMaskSize);
+    } else if ((Feature & CPU_FEATURE_THREAD_AFTER) != 0) {
+      SetCpuFeaturesBitMask (&AfterFeatureBitMask, Feature & ~CPU_FEATURE_THREAD_AFTER, CpuFeaturesData->BitMaskSize);
     } else if ((Feature & CPU_FEATURE_CORE_BEFORE) != 0) {
       SetCpuFeaturesBitMask (&CoreBeforeFeatureBitMask, Feature & ~CPU_FEATURE_CORE_BEFORE, CpuFeaturesData->BitMaskSize);
     } else if ((Feature & CPU_FEATURE_CORE_AFTER) != 0) {


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=1584

The flow of CPU feature initialization logic is:
1. BSP calls GetConfigDataFunc() for each thread/AP;
2. Each thread/AP calls SupportFunc() to detect its own capability;
3. BSP calls InitializeFunc() for each thread/AP.

There is a design gap in step #3. For a package scope feature that only
requires one thread of each package does the initialization operation,
what InitializeFunc() currently does is to do the initialization
operation only CPU physical location Core# is 0.
But in certain platform, Core#0 might be disabled in hardware level
which results the certain package scope feature isn't initialized at
all.

The patch adds a new field Fist to indicate the CPU's location in
its parent scope.
First.Package is set for all APs/threads under first package;
First.Core is set for all APs/threads under first core of each
package;
First.Thread is set for the AP/thread of each core.
