### PR TITLE
Add missing strings for uni files

### DIFF
--- a/MdeModulePkg/MdeModulePkg.uni
+++ b/MdeModulePkg/MdeModulePkg.uni
@@ -660,6 +660,18 @@
                                                                                                         "TRUE  - Device Path From Text Protocol will be produced.<BR>\n"
                                                                                                         "FALSE - Device Path From Text Protocol will not be produced.<BR>"
 
+#string STR_gEfiMdeModulePkgTokenSpaceGuid_PcdEnableVariableRuntimeCache_PROMPT  #language en-US "Enable the UEFI variable runtime cache."
+
+#string STR_gEfiMdeModulePkgTokenSpaceGuid_PcdEnableVariableRuntimeCache_HELP  #language en-US "Indicates if the UEFI variable runtime cache should be enabled.<BR><BR>\n"
+                                                                                               "This setting only applies if SMM variables are enabled. When enabled, all variable<BR>\n"
+                                                                                               "data for Runtime Service GetVariable () and GetNextVariableName () calls is retrieved<BR>\n"
+                                                                                               "from a runtime data buffer referred to as the "runtime cache". An SMI is not triggered<BR>\n"
+                                                                                               "at all for these requests. Variables writes still trigger an SMI. This can greatly<BR>\n"
+                                                                                               "reduce overall system SMM usage as most boots tend to issue far more variable reads<BR>\n"
+                                                                                               "than writes.<BR>\n"
+                                                                                               "TRUE  - The UEFI variable runtime cache is enabled.<BR>\n"
+                                                                                               "FALSE - The UEFI variable runtime cache is disabled.<BR>"
+
 #string STR_gEfiMdeModulePkgTokenSpaceGuid_PcdVariableCollectStatistics_PROMPT  #language en-US "Enable variable statistics collection"
 
 #string STR_gEfiMdeModulePkgTokenSpaceGuid_PcdVariableCollectStatistics_HELP  #language en-US "Indicates if the statistics about variable usage will be collected. This information is stored as a vendor configuration table into the EFI system table. Set this PCD to TRUE to use VariableInfo application in MdeModulePkg\Application directory to get variable usage info. VariableInfo application will not output information if not set to TRUE.<BR><BR>\n"

--- a/NetworkPkg/NetworkPkg.uni
+++ b/NetworkPkg/NetworkPkg.uni
@@ -61,6 +61,13 @@
                                                                                           "TRUE  - Certificate Authentication feature is enabled.<BR>\n"
                                                                                           "FALSE - Does not support Certificate Authentication.<BR>"
 
+#string STR_gEfiNetworkPkgTokenSpaceGuid_PcdSnpCreateExitBootServicesEvent_PROMPT  #language en-US "Indicates whether SnpDxe creates event for ExitBootServices() call."
+
+#string STR_gEfiNetworkPkgTokenSpaceGuid_PcdSnpCreateExitBootServicesEvent_HELP  #language en-US "Indicates whether SnpDxe driver will create an event that will be notified<BR><BR>\n"
+                                                                                                 "upon gBS->ExitBootServices() call.<BR>\n"
+                                                                                                 "TRUE - Event being triggered upon ExitBootServices call will be created<BR>\n"
+                                                                                                 "FALSE - Event being triggered upon ExitBootServices call will NOT be created<BR>"
+
 #string STR_gEfiNetworkPkgTokenSpaceGuid_PcdDhcp6UidType_PROMPT  #language en-US "Type Value of Dhcp6 Unique Identifier (DUID)."
 
 #string STR_gEfiNetworkPkgTokenSpaceGuid_PcdDhcp6UidType_HELP  #language en-US "IPv6 DHCP Unique Identifier (DUID) Type configuration (From RFCs 3315 and 6355).\n"

--- a/UefiCpuPkg/UefiCpuPkg.uni
+++ b/UefiCpuPkg/UefiCpuPkg.uni
@@ -195,6 +195,22 @@
 
 #string STR_gUefiCpuPkgTokenSpaceGuid_PcdIsPowerOnReset_HELP  #language en-US "Indicates if the current boot is a power-on reset."
 
+#string STR_gUefiCpuPkgTokenSpaceGuid_PcdCpuSmmRestrictedMemoryAccess_PROMPT  #language en-US "Access to non-SMRAM memory is restricted to reserved, runtime and ACPI NVS type after SmmReadyToLock."
+
+#string STR_gUefiCpuPkgTokenSpaceGuid_PcdCpuSmmRestrictedMemoryAccess_HELP  #language en-US "Indicate access to non-SMRAM memory is restricted to reserved, runtime and ACPI NVS type after SmmReadyToLock.<BR><BR>\n"
+                                                                                            "MMIO access is always allowed regardless of the value of this PCD.<BR>\n"
+                                                                                            "Loose of such restriction is only required by RAS components in X64 platforms.<BR>\n"
+                                                                                            "The PCD value is considered as constantly TRUE in IA32 platforms.<BR>\n"
+                                                                                            "When the PCD value is TRUE, page table is initialized to cover all memory spaces<BR>\n"
+                                                                                            "and the memory occupied by page table is protected by page table itself as read-only.<BR>\n"
+                                                                                            "In X64 build, it cannot be enabled at the same time with SMM profile feature (PcdCpuSmmProfileEnable).<BR>\n"
+                                                                                            "In X64 build, it could not be enabled also at the same time with heap guard feature for SMM<BR>\n"
+                                                                                            "(PcdHeapGuardPropertyMask in MdeModulePkg).<BR>\n"
+                                                                                            "In IA32 build, page table memory is not marked as read-only when either SMM profile feature (PcdCpuSmmProfileEnable)<BR>\n"
+                                                                                            "or heap guard feature for SMM (PcdHeapGuardPropertyMask in MdeModulePkg) is enabled.<BR>\n"
+                                                                                            "TRUE  - Access to non-SMRAM memory is restricted to reserved, runtime and ACPI NVS type after SmmReadyToLock.<BR>\n"
+                                                                                            "FALSE - Access to any type of non-SMRAM memory after SmmReadyToLock is allowed.<BR>"
+
 #string STR_gUefiCpuPkgTokenSpaceGuid_PcdCpuFeaturesCapability_PROMPT  #language en-US "Processor feature capabilities."
 
 #string STR_gUefiCpuPkgTokenSpaceGuid_PcdCpuFeaturesCapability_HELP  #language en-US "Indicates processor feature capabilities, each bit corresponding to a specific feature."


### PR DESCRIPTION
There are missing strings in MdeModulePkg.uni, NetworkPkg.uni
and UefiCpuPkg.uni. So add them into uni files.
