### PR TITLE
decrease retry count and increase retry interval

### DIFF
--- a/MdeModulePkg/Bus/Pci/XhciDxe/XhciSched.c
+++ b/MdeModulePkg/Bus/Pci/XhciDxe/XhciSched.c
@@ -1291,7 +1291,7 @@ XhcExecTransfer (
   }
 
   Status = EFI_SUCCESS;
-  Loop   = Timeout * XHC_1_MILLISECOND;
+  Loop   = Timeout;
   if (Timeout == 0) {
     Loop = 0xFFFFFFFF;
   }
@@ -1303,7 +1303,7 @@ XhcExecTransfer (
     if (Finished) {
       break;
     }
-    gBS->Stall (XHC_1_MICROSECOND);
+    gBS->Stall (XHC_1_MILLISECOND);
   }
 
   if (Index == Loop) {


### PR DESCRIPTION
It's common that caller of this function set Timeout to 3000 or larger. indicate that caller want wait for  3 seconds. if the retry interval is 1 microsecond, then it will retry 3000*1000 times ( 3 million times) which is too much.