### PR TITLE
Build stuck on unicode locale Windows

### DIFF
--- a/BaseTools/Source/C/Makefiles/NmakeSubdirs.py
+++ b/BaseTools/Source/C/Makefiles/NmakeSubdirs.py
@@ -33,7 +33,7 @@ def RunCommand(WorkDir=None, *Args, **kwargs):
     if "stderr" not in kwargs:
         kwargs["stderr"] = subprocess.STDOUT
     if "stdout" not in kwargs:
-        kwargs["stdout"] = subprocess.PIPE
+        kwargs["stdout"] = sys.stdout
     p = subprocess.Popen(Args, cwd=WorkDir, stderr=kwargs["stderr"], stdout=kwargs["stdout"])
     stdout, stderr = p.communicate()
     message = ""


### PR DESCRIPTION
This issue happens under two conditions.
  1. Unicode language environment in Windows
  2. Call 'edksetup.bat forcerebuild' with python subprocess.call()

Steps to reproduce
  C:\edk2>python
  Python 2.7.12 (v2.7.12:d33e0cf91556, Jun 27 2016, 15:24:40)
  Type help, copyright, credits or license for more information.
  >>> import subprocess
  >>> subprocess.call(['edksetup.bat', 'forcerebuild'])

  The edksetup.bat stuck at 'nmake cleanall'.

One of multi-threads is on deadlock when python handles stdout and
stderr in a subprocess pipe only if the outputs include unicode chars.
Only stderr will be handled in the pipe same as a single thread call.

Reported in Slim Bootloader.
  https://github.com/slimbootloader/slimbootloader/issues/478
Local fix has been made in Slim Bootloader.
  https://github.com/slimbootloader/slimbootloader/pull/490

Signed-off-by: Aiden Park <aiden.park@intel.com>