### PR TITLE
BaseTools: Fix build failure when multiple build targets given

### DIFF
--- a/BaseTools/Source/Python/AutoGen/ModuleAutoGen.py
+++ b/BaseTools/Source/Python/AutoGen/ModuleAutoGen.py
@@ -270,7 +270,7 @@ class ModuleAutoGen(AutoGen):
     #
     @cached_class_function
     def __hash__(self):
-        return hash((self.MetaFile, self.Arch))
+        return hash((self.MetaFile, self.Arch, self.ToolChain,self.BuildTarget))
     def __repr__(self):
         return "%s [%s]" % (self.MetaFile, self.Arch)
 

--- a/BaseTools/Source/Python/AutoGen/PlatformAutoGen.py
+++ b/BaseTools/Source/Python/AutoGen/PlatformAutoGen.py
@@ -148,7 +148,7 @@ class PlatformAutoGen(AutoGen):
     #
     @cached_class_function
     def __hash__(self):
-        return hash((self.MetaFile, self.Arch))
+        return hash((self.MetaFile, self.Arch,self.ToolChain,self.BuildTarget))
     @cached_class_function
     def __repr__(self):
         return "%s [%s]" % (self.MetaFile, self.Arch)

--- a/BaseTools/Source/Python/build/build.py
+++ b/BaseTools/Source/Python/build/build.py
@@ -58,6 +58,7 @@ from AutoGen.DataPipe import MemoryDataPipe
 from AutoGen.ModuleAutoGenHelper import WorkSpaceInfo, PlatformInfo
 from GenFds.FdfParser import FdfParser
 from AutoGen.IncludesAutoGen import IncludesAutoGen
+from GenFds.GenFds import resetFdsGlobalVariable
 
 ## standard targets of build command
 gSupportedTarget = ['all', 'genc', 'genmake', 'modules', 'libraries', 'fds', 'clean', 'cleanall', 'cleanlib', 'run']
@@ -2207,6 +2208,7 @@ class Build():
             GlobalData.gGlobalDefines['TARGET'] = BuildTarget
             index = 0
             for ToolChain in self.ToolChainList:
+                resetFdsGlobalVariable()
                 GlobalData.gGlobalDefines['TOOLCHAIN'] = ToolChain
                 GlobalData.gGlobalDefines['TOOL_CHAIN_TAG'] = ToolChain
                 GlobalData.gGlobalDefines['FAMILY'] = self.ToolChainFamily[index]


### PR DESCRIPTION
BZ: https://bugzilla.tianocore.org/show_bug.cgi?id=2371

This patch is to fix a regression issue that build fails
if multiple build targets given.

Two changes cause this regression issue.
One is AutoGen object __hash__ function only
hash file path and arch, missing ToolChain and build target.

The other is changing the multiple-thread-genfds function as default
build behavior. To generate the genffs command to Makefile, there
is a global data set is used, GenFdsGlobalVariable, which cause build
tool use the data of first build-target build in
the second build-target build.

Signed-off-by: Bob Feng <bob.c.feng@intel.com>

Cc: Liming Gao <liming.gao@intel.com>
Cc: Steven Shi <steven.shi@intel.com>
Cc: Ard Biesheuvel <ard.biesheuvel@linaro.org>
Reviewed-by: Liming Gao <liming.gao@intel.com>