### PR TITLE
BaseTools:replaces the two offending quotes by ascii quotes

### DIFF
--- a/BaseTools/Conf/tools_def.template
+++ b/BaseTools/Conf/tools_def.template
@@ -337,7 +337,7 @@ DEFINE DTC_BIN                 = ENV(DTC_PREFIX)dtc
 #                             Required to build platforms or ACPI tables:
 #                               Microsoft ASL ACPI Compiler (asl.exe) v4.0.0 from
 #                               http://download.microsoft.com/download/2/c/1/2c16c7e0-96c1-40f5-81fc-3e4bf7b65496/microsoft_asl_compiler-v4-0-0.msi
-#                        Notes: Since this tool chain is obsolete, it doesn’t enable the compiler option for included header file list generation,
+#                        Notes: Since this tool chain is obsolete, it doesn't enable the compiler option for included header file list generation,
 #                               and lose the incremental build capability.
 #   RVCTLINUX   -unix-   Requires:
 #                             ARM C/C++ Compiler, 5.00
@@ -345,7 +345,7 @@ DEFINE DTC_BIN                 = ENV(DTC_PREFIX)dtc
 #                             Required to build platforms or ACPI tables:
 #                               Intel(r) ACPI Compiler from
 #                               https://acpica.org/downloads
-#                        Notes: Since this tool chain is obsolete, it doesn’t enable the compiler option for included header file list generation,
+#                        Notes: Since this tool chain is obsolete, it doesn't enable the compiler option for included header file list generation,
 #                               and lose the incremental build capability.
 # * Commented out - All versions of VS2005 use the same standard install directory
 #


### PR DESCRIPTION
BZ:https://bugzilla.tianocore.org/show_bug.cgi?id=2423

That commit 13c5e34a1b introduces the first two UTF-8
characters (the quote ') in an otherwise all-ascii file.

In Conf\tools_def.template
There is tow lines of
  Notes: Since this tool chain is obsolete, it doesn't enable
  the compiler option for included header file list generation,

we replaces the two offending quotes by proper ascii quotes
The patch is going to fix this issue

Signed-off-by: Zhiju.Fan <zhijux.fan@intel.com>

Cc: Liming Gao <liming.gao@intel.com>
Cc: Bob Feng <bob.c.feng@intel.com>
Reviewed-by: Bob Feng <bob.c.feng@intel.com>