### PR TITLE
Maintainers.txt: Update email address and role

### DIFF
--- a/Maintainers.txt
+++ b/Maintainers.txt
@@ -378,8 +378,8 @@ NetworkPkg
 F: NetworkPkg/
 W: https://github.com/tianocore/tianocore.github.io/wiki/NetworkPkg
 M: Jiaxin Wu <jiaxin.wu@intel.com>
+M: Maciej Rabeda <maciej.rabeda@linux.intel.com>
 R: Siyuan Fu <siyuan.fu@intel.com>
-R: Maciej Rabeda <maciej.rabeda@intel.com>
 
 OvmfPkg
 F: OvmfPkg/


### PR DESCRIPTION
Created new email account that will not append legal disclaimers to
my responses/patches.

Switching to NetworkPkg maintainer.

Cc: Jiaxin Wu <jiaxin.wu@intel.com>
Cc: Siyuan Fu <siyuan.fu@intel.com>
Signed-off-by: Maciej Rabeda <maciej.rabeda@linux.intel.com>
Reviewed-by: Jiaxin Wu <jiaxin.wu@intel.com>