### PR TITLE
ShellPkg/ShellProtocol: Return error code while fail parsing cmd-line

### DIFF
--- a/ShellPkg/Application/Shell/ShellProtocol.c
+++ b/ShellPkg/Application/Shell/ShellProtocol.c
@@ -1497,7 +1497,10 @@ InternalShellExecuteDevicePath(
     ShellParamsProtocol.StdOut  = ShellInfoObject.NewShellParametersProtocol->StdOut;
     ShellParamsProtocol.StdErr  = ShellInfoObject.NewShellParametersProtocol->StdErr;
     Status = UpdateArgcArgv(&ShellParamsProtocol, NewCmdLine, Efi_Application, NULL, NULL);
-    ASSERT_EFI_ERROR(Status);
+    if (EFI_ERROR (Status)) {
+      goto UnloadImage;
+    }
+
     //
     // Replace Argv[0] with the full path of the binary we're executing:
     // If the command line was "foo", the binary might be called "foo.efi".


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=2395

Errors happened in the arguments parsing is not a critical error.
And it would miss the error status code in the release version of shell.
So replace the ASSERT with returning error status code while fail
parsing command-line in UpdateArgcArgv.

Cc: Ray Ni <ray.ni@intel.com>
Cc: Linson Augustine <linson.augustine@intel.com>
Reviewed-by: Philippe Mathieu-Daude <philmd@redhat.com>
Reviewed-by: Ray Ni <ray.ni@intel.com>
Signed-off-by: Zhichao Gao <zhichao.gao@intel.com>