### PR TITLE
MdePkg PciExpress21: PCI_REG_PCIE_DEVICE_CONTROL2 struct has 17 bits

### DIFF
--- a/MdePkg/Include/IndustryStandard/PciExpress21.h
+++ b/MdePkg/Include/IndustryStandard/PciExpress21.h
@@ -304,7 +304,7 @@ typedef union {
     UINT16 AtomicOpEgressBlocking : 1;
     UINT16 IdoRequest : 1;
     UINT16 IdoCompletion : 1;
-    UINT16 LtrMechanism : 2;
+    UINT16 LtrMechanism : 1;
     UINT16 EmergencyPowerReductionRequest : 1;
     UINT16 TenBitTagRequesterEnable : 1;
     UINT16 Obff : 2;


### PR DESCRIPTION
Device Control 2 Structure have an issue.
 LtrMechanism - there is 2 bits instead of 1.

Signed-off-by: Daniel Pawel Banaszek <daniel.pawel.banaszek@intel.com>
Reviewed-by: Liming Gao <liming.gao@intel.com>
Reviewed-by: Ray Ni <ray.ni@intel.com>