### PR TITLE
MdePkg: Use __builtin_offset with CLANGPDB toolchain

### DIFF
--- a/MdePkg/Include/Base.h
+++ b/MdePkg/Include/Base.h
@@ -781,10 +781,8 @@ typedef UINTN  *BASE_LIST;
   @return  Offset, in bytes, of field.
 
 **/
-#ifdef __GNUC__
-#if __GNUC__ >= 4
+#if (defined(__GNUC__) && __GNUC__ >= 4) || defined(__clang__)
 #define OFFSET_OF(TYPE, Field) ((UINTN) __builtin_offsetof(TYPE, Field))
-#endif
 #endif
 
 #ifndef OFFSET_OF


### PR DESCRIPTION
CLANGPDB does not define __GNUC__, but it does define __clang__. Check
for the __clang__ preprocessor definition to use __builtin_offsetof to
implement the OFFSET_OF macro.

Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Liming Gao <liming.gao@intel.com>
Signed-off-by: Alex James <theracermaster@gmail.com>