### PR TITLE
MdePkg/Tcg: Add new definition in TCG PFP spec.

### DIFF
--- a/MdePkg/Include/IndustryStandard/UefiTcgPlatform.h
+++ b/MdePkg/Include/IndustryStandard/UefiTcgPlatform.h
@@ -1,7 +1,8 @@
 /** @file
-  TCG EFI Platform Definition in TCG_EFI_Platform_1_20_Final
+  TCG EFI Platform Definition in TCG_EFI_Platform_1_20_Final and
+  TCG PC Client Platform Firmware Profile Specification, Revision 1.05
 
-  Copyright (c) 2006 - 2018, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2006 - 2019, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -21,6 +22,7 @@
 #define EV_NO_ACTION                ((TCG_EVENTTYPE) 0x00000003)
 #define EV_SEPARATOR                ((TCG_EVENTTYPE) 0x00000004)
 #define EV_ACTION                   ((TCG_EVENTTYPE) 0x00000005)
+#define EV_EVENT_TAG                ((TCG_EVENTTYPE) 0x00000006)
 #define EV_S_CRTM_CONTENTS          ((TCG_EVENTTYPE) 0x00000007)
 #define EV_S_CRTM_VERSION           ((TCG_EVENTTYPE) 0x00000008)
 #define EV_CPU_MICROCODE            ((TCG_EVENTTYPE) 0x00000009)
@@ -45,8 +47,12 @@
 #define EV_EFI_ACTION                       (EV_EFI_EVENT_BASE + 7)
 #define EV_EFI_PLATFORM_FIRMWARE_BLOB       (EV_EFI_EVENT_BASE + 8)
 #define EV_EFI_HANDOFF_TABLES               (EV_EFI_EVENT_BASE + 9)
+#define EV_EFI_PLATFORM_FIRMWARE_BLOB2      (EV_EFI_EVENT_BASE + 0xA)
+#define EV_EFI_HANDOFF_TABLES2              (EV_EFI_EVENT_BASE + 0xB)
 #define EV_EFI_HCRTM_EVENT                  (EV_EFI_EVENT_BASE + 0x10)
 #define EV_EFI_VARIABLE_AUTHORITY           (EV_EFI_EVENT_BASE + 0xE0)
+#define EV_EFI_SPDM_FIRMWARE_BLOB           (EV_EFI_EVENT_BASE + 0xE1)
+#define EV_EFI_SPDM_FIRMWARE_CONFIG         (EV_EFI_EVENT_BASE + 0xE2)
 
 #define EFI_CALLING_EFI_APPLICATION         \
   "Calling EFI Application from Boot Option"
@@ -77,6 +83,9 @@
 
 #define EV_POSTCODE_INFO_OPROM        "Embedded Option ROM"
 #define OPROM_LEN                     (sizeof(EV_POSTCODE_INFO_OPROM) - 1)
+
+#define EV_POSTCODE_INFO_EMBEDDED_UEFI_DRIVER  "Embedded UEFI Driver"
+#define EMBEDDED_UEFI_DRIVER_LEN               (sizeof(EV_POSTCODE_INFO_EMBEDDED_UEFI_DRIVER) - 1)
 
 #define FIRMWARE_DEBUGGER_EVENT_STRING      "UEFI Debug Mode"
 #define FIRMWARE_DEBUGGER_EVENT_STRING_LEN  (sizeof(FIRMWARE_DEBUGGER_EVENT_STRING) - 1)
@@ -124,6 +133,30 @@ typedef struct tdEFI_PLATFORM_FIRMWARE_BLOB {
 } EFI_PLATFORM_FIRMWARE_BLOB;
 
 ///
+/// UEFI_PLATFORM_FIRMWARE_BLOB
+///
+/// This structure is used in EV_EFI_PLATFORM_FIRMWARE_BLOB
+/// event to facilitate the measurement of firmware volume.
+///
+typedef struct tdUEFI_PLATFORM_FIRMWARE_BLOB {
+  EFI_PHYSICAL_ADDRESS              BlobBase;
+  UINT64                            BlobLength;
+} UEFI_PLATFORM_FIRMWARE_BLOB;
+
+///
+/// UEFI_PLATFORM_FIRMWARE_BLOB2
+///
+/// This structure is used in EV_EFI_PLATFORM_FIRMWARE_BLOB2
+/// event to facilitate the measurement of firmware volume.
+///
+typedef struct tdUEFI_PLATFORM_FIRMWARE_BLOB2 {
+  UINT8                             BlobDescriptionSize;
+//UINT8                             BlobDescription[BlobDescriptionSize];
+//EFI_PHYSICAL_ADDRESS              BlobBase;
+//UINT64                            BlobLength;
+} UEFI_PLATFORM_FIRMWARE_BLOB2;
+
+///
 /// EFI_IMAGE_LOAD_EVENT
 ///
 /// This structure is used in EV_EFI_BOOT_SERVICES_APPLICATION,
@@ -138,6 +171,20 @@ typedef struct tdEFI_IMAGE_LOAD_EVENT {
 } EFI_IMAGE_LOAD_EVENT;
 
 ///
+/// UEFI_IMAGE_LOAD_EVENT
+///
+/// This structure is used in EV_EFI_BOOT_SERVICES_APPLICATION,
+/// EV_EFI_BOOT_SERVICES_DRIVER and EV_EFI_RUNTIME_SERVICES_DRIVER
+///
+typedef struct tdUEFI_IMAGE_LOAD_EVENT {
+  EFI_PHYSICAL_ADDRESS              ImageLocationInMemory;
+  UINT64                            ImageLengthInMemory;
+  UINT64                            ImageLinkTimeAddress;
+  UINT64                            LengthOfDevicePath;
+  EFI_DEVICE_PATH_PROTOCOL          DevicePath[1];
+} UEFI_IMAGE_LOAD_EVENT;
+
+///
 /// EFI_HANDOFF_TABLE_POINTERS
 ///
 /// This structure is used in EV_EFI_HANDOFF_TABLES event to facilitate
@@ -147,6 +194,30 @@ typedef struct tdEFI_HANDOFF_TABLE_POINTERS {
   UINTN                             NumberOfTables;
   EFI_CONFIGURATION_TABLE           TableEntry[1];
 } EFI_HANDOFF_TABLE_POINTERS;
+
+///
+/// UEFI_HANDOFF_TABLE_POINTERS
+///
+/// This structure is used in EV_EFI_HANDOFF_TABLES event to facilitate
+/// the measurement of given configuration tables.
+///
+typedef struct tdUEFI_HANDOFF_TABLE_POINTERS {
+  UINT64                            NumberOfTables;
+  EFI_CONFIGURATION_TABLE           TableEntry[1];
+} UEFI_HANDOFF_TABLE_POINTERS;
+
+///
+/// UEFI_HANDOFF_TABLE_POINTERS2
+///
+/// This structure is used in EV_EFI_HANDOFF_TABLES2 event to facilitate
+/// the measurement of given configuration tables.
+///
+typedef struct tdUEFI_HANDOFF_TABLE_POINTERS2 {
+  UINT8                             TableDescriptionSize;
+//UINT8                             TableDescription[TableDescriptionSize];
+//UINT64                            NumberOfTables;
+//EFI_CONFIGURATION_TABLE           TableEntry[1];
+} UEFI_HANDOFF_TABLE_POINTERS2;
 
 ///
 /// EFI_VARIABLE_DATA
@@ -197,6 +268,66 @@ typedef struct tdEFI_GPT_DATA {
   EFI_PARTITION_ENTRY         Partitions[1];
 } EFI_GPT_DATA;
 
+typedef struct tdUEFI_GPT_DATA {
+  EFI_PARTITION_TABLE_HEADER  EfiPartitionHeader;
+  UINT64                      NumberOfPartitions;
+  EFI_PARTITION_ENTRY         Partitions[1];
+} UEFI_GPT_DATA;
+
+#define TCG_DEVICE_SECURITY_EVENT_DATA_SIGNATURE "SPDM Device Sec"
+#define TCG_DEVICE_SECURITY_EVENT_DATA_VERSION   0
+
+#define TCG_DEVICE_SECURITY_EVENT_DATA_DEVICE_TYPE_NULL  0
+#define TCG_DEVICE_SECURITY_EVENT_DATA_DEVICE_TYPE_PCI   1
+#define TCG_DEVICE_SECURITY_EVENT_DATA_DEVICE_TYPE_USB   2
+
+///
+/// TCG_DEVICE_SECURITY_EVENT_DATA_HEADER
+/// This is the header of TCG_DEVICE_SECURITY_EVENT_DATA, which is
+/// used in EV_EFI_SPDM_FIRMWARE_BLOB and EV_EFI_SPDM_FIRMWARE_CONFIG.
+///
+typedef struct {
+  UINT8                          Signature[16];
+  UINT16                         Version;
+  UINT16                         Length;
+  UINT32                         SpdmHashAlgo;
+  UINT32                         DeviceType;
+//SPDM_MEASUREMENT_BLOCK         SpdmMeasurementBlock;
+} TCG_DEVICE_SECURITY_EVENT_DATA_HEADER;
+
+#define TCG_DEVICE_SECURITY_EVENT_DATA_PCI_CONTEXT_VERSION  0
+
+///
+/// TCG_DEVICE_SECURITY_EVENT_DATA_PCI_CONTEXT
+/// This is the PCI context data of TCG_DEVICE_SECURITY_EVENT_DATA, which is
+/// used in EV_EFI_SPDM_FIRMWARE_BLOB and EV_EFI_SPDM_FIRMWARE_CONFIG.
+///
+typedef struct {
+  UINT16  Version;
+  UINT16  Length;
+  UINT16  VendorId;
+  UINT16  DeviceId;
+  UINT8   RevisionID;
+  UINT8   ClassCode[3];
+  UINT16  SubsystemVendorID;
+  UINT16  SubsystemID;
+} TCG_DEVICE_SECURITY_EVENT_DATA_PCI_CONTEXT;
+
+#define TCG_DEVICE_SECURITY_EVENT_DATA_USB_CONTEXT_VERSION  0
+
+///
+/// TCG_DEVICE_SECURITY_EVENT_DATA_USB_CONTEXT
+/// This is the USB context data of TCG_DEVICE_SECURITY_EVENT_DATA, which is
+/// used in EV_EFI_SPDM_FIRMWARE_BLOB and EV_EFI_SPDM_FIRMWARE_CONFIG.
+///
+typedef struct {
+  UINT16  Version;
+  UINT16  Length;
+//UINT8   DeviceDescriptor[DescLen];
+//UINT8   BodDescriptor[DescLen];
+//UINT8   ConfigurationDescriptor[DescLen][NumOfConfiguration];
+} TCG_DEVICE_SECURITY_EVENT_DATA_USB_CONTEXT;
+
 //
 // Crypto Agile Log Entry Format
 //
@@ -243,6 +374,7 @@ typedef struct {
 #define TCG_EfiSpecIDEventStruct_SPEC_VERSION_MAJOR_TPM2   2
 #define TCG_EfiSpecIDEventStruct_SPEC_VERSION_MINOR_TPM2   0
 #define TCG_EfiSpecIDEventStruct_SPEC_ERRATA_TPM2          0
+#define TCG_EfiSpecIDEventStruct_SPEC_ERRATA_TPM2_REV_105  105
 
 typedef struct {
   UINT8               signature[16];
@@ -299,20 +431,52 @@ typedef struct {
 //UINT8               vendorInfo[vendorInfoSize];
 } TCG_EfiSpecIDEventStruct;
 
+typedef struct tdTCG_PCClientTaggedEvent {
+  UINT32              taggedEventID;
+  UINT32              taggedEventDataSize;
+//UINT8               taggedEventData[taggedEventDataSize];
+} TCG_PCClientTaggedEvent;
 
+#define TCG_Sp800_155_PlatformId_Event_SIGNATURE  "SP800-155 Event"
+#define TCG_Sp800_155_PlatformId_Event2_SIGNATURE "SP800-155 Event2"
+
+typedef struct tdTCG_Sp800_155_PlatformId_Event2 {
+  UINT8               Signature[16];
+  //
+  // Where Vendor ID is an integer defined
+  // at http://www.iana.org/assignments/enterprisenumbers
+  //
+  UINT32              VendorId;
+  //
+  // 16-byte identifier of a given platform's static configuration of code
+  //
+  EFI_GUID            ReferenceManifestGuid;
+  //
+  // Below structure is newly added in TCG_Sp800_155_PlatformId_Event2.
+  //
+//UINT8               PlatformManufacturerStrSize;
+//UINT8               PlatformManufacturerStr[PlatformManufacturerStrSize];
+//UINT8               PlatformModelSize;
+//UINT8               PlatformModel[PlatformModelSize];
+//UINT8               PlatformVersionSize;
+//UINT8               PlatformVersion[PlatformVersionSize];
+//UINT8               PlatformModelSize;
+//UINT8               PlatformModel[PlatformModelSize];
+//UINT8               FirmwareManufacturerStrSize;
+//UINT8               FirmwareManufacturerStr[FirmwareManufacturerStrSize];
+//UINT32              FirmwareManufacturerId;
+//UINT8               FirmwareVersion;
+//UINT8               FirmwareVersion[FirmwareVersionSize]];
+} TCG_Sp800_155_PlatformId_Event2;
 
 #define TCG_EfiStartupLocalityEvent_SIGNATURE      "StartupLocality"
 
 
 //
-// PC Client PTP spec Table 8 Relationship between Locality and Locality Attribute
+// The Locality Indicator which sent the TPM2_Startup command
 //
-#define LOCALITY_0_INDICATOR        0x01
-#define LOCALITY_1_INDICATOR        0x02
-#define LOCALITY_2_INDICATOR        0x03
-#define LOCALITY_3_INDICATOR        0x04
-#define LOCALITY_4_INDICATOR        0x05
-
+#define LOCALITY_0_INDICATOR        0x00
+#define LOCALITY_3_INDICATOR        0x03
 
 //
 // Startup Locality Event


### PR DESCRIPTION
The latest TCG PFP specification (TCG PC Client Platform Firmware Profile
Specification, Revision 1.05) added new data structure. For example,
the SPDM device measurement. This patch adds the new content.

Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Liming Gao <liming.gao@intel.com>
Signed-off-by: Jiewen Yao <jiewen.yao@intel.com>
Reviewed-by: Liming Gao <liming.gao@intel.com>