### PR TITLE
edksetup.bat stuck on unicode locale Windows

### DIFF
--- a/BaseTools/Source/C/Makefiles/NmakeSubdirs.py
+++ b/BaseTools/Source/C/Makefiles/NmakeSubdirs.py
@@ -38,7 +38,7 @@ def RunCommand(WorkDir=None, *Args, **kwargs):
     stdout, stderr = p.communicate()
     message = ""
     if stdout is not None:
-        message = stdout.decode(encoding='utf-8', errors='ignore') #for compatibility in python 2 and 3
+        message = stdout.decode(errors='ignore') #for compatibility in python 2 and 3
 
     if p.returncode != 0:
         raise RuntimeError("Error while execute command \'{0}\' in direcotry {1}\n{2}".format(" ".join(Args), WorkDir, message))


### PR DESCRIPTION
This issue happens under two conditions.
  1. Unicode language environment in Windows
  2. Python2 (Not reproducible with Python3)

Step to reproduce
  C:\edk2>edksetup.bat forcerebuild
The edksetup.bat stuck at 'nmake cleanall'.

Signed-off-by: Aiden Park <aiden.park@intel.com>

Reviewed-by: Bob Feng <bob.c.feng@intel.com>