### PR TITLE
UefiPayloadPkg/BootManager: Add PS2 keyboard support

### DIFF
--- a/UefiPayloadPkg/UefiPayloadPkg.fdf
+++ b/UefiPayloadPkg/UefiPayloadPkg.fdf
@@ -120,6 +120,10 @@ INF MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostBridgeDxe.inf
 # ISA Support
 #
 INF MdeModulePkg/Universal/SerialDxe/SerialDxe.inf
+!if $(PS2_KEYBOARD_ENABLE) == TRUE
+INF OvmfPkg/SioBusDxe/SioBusDxe.inf
+INF MdeModulePkg/Bus/Isa/Ps2KeyboardDxe/Ps2KeyboardDxe.inf
+!endif
 
 #
 # Console Support

--- a/UefiPayloadPkg/UefiPayloadPkgIa32.dsc
+++ b/UefiPayloadPkg/UefiPayloadPkgIa32.dsc
@@ -491,6 +491,10 @@
   # ISA Support
   #
   MdeModulePkg/Universal/SerialDxe/SerialDxe.inf
+!if $(PS2_KEYBOARD_ENABLE) == TRUE
+  OvmfPkg/SioBusDxe/SioBusDxe.inf
+  MdeModulePkg/Bus/Isa/Ps2KeyboardDxe/Ps2KeyboardDxe.inf
+!endif
 
   #
   # Console Support

--- a/UefiPayloadPkg/UefiPayloadPkgIa32X64.dsc
+++ b/UefiPayloadPkg/UefiPayloadPkgIa32X64.dsc
@@ -25,6 +25,7 @@
   FLASH_DEFINITION                    = UefiPayloadPkg/UefiPayloadPkg.fdf
 
   DEFINE SOURCE_DEBUG_ENABLE          = FALSE
+  DEFINE PS2_KEYBOARD_ENABLE          = FALSE
 
   #
   # SBL:      UEFI payload for Slim Bootloader
@@ -492,6 +493,10 @@
   # ISA Support
   #
   MdeModulePkg/Universal/SerialDxe/SerialDxe.inf
+!if $(PS2_KEYBOARD_ENABLE) == TRUE
+  OvmfPkg/SioBusDxe/SioBusDxe.inf
+  MdeModulePkg/Bus/Isa/Ps2KeyboardDxe/Ps2KeyboardDxe.inf
+!endif
 
   #
   # Console Support


### PR DESCRIPTION
Add PS2 keyboard support.
REF:https://bugzilla.tianocore.org/show_bug.cgi?id=2316

This patch adds PS2 keyboard support in boot manager, and
add a build flag PS2_KEYBOARD_ENABLE for PS2 keyboard to
build PS2 keyboard driver and SIO driver. Be default the
build flag is not enabled since PS2 keyboard is not common
used. could use -DPS2_KEYBOARD_ENABLE to enable build it
if need this feature.

Signed-off-by: Guo Dong <guo.dong@intel.com>
Reviewed-by: Maurice Ma <maurice.ma@intel.com>
Reviewed-by: Benjamin You <benjamin.you@intel.com>