### PR TITLE
edksetup.bat: Simplify the step to use CLANGPDB

### DIFF
--- a/edksetup.bat
+++ b/edksetup.bat
@@ -113,6 +113,18 @@ if not defined NASM_PREFIX (
     @if not exist "C:\nasm\nasm.exe" echo   Attempting to build modules that require NASM will fail.
 )
 
+:check_CLANGPDB
+@REM In Windows, set CLANG_HOST_BIN=n to use nmake command
+@set CLANG_HOST_BIN=n
+if not defined CLANG_BIN (
+    @echo.
+    @echo !!! WARNING !!! CLANG_BIN environment variable is not set
+    @if exist "C:\Program Files\LLVM\bin\clang.exe" (
+        @set CLANG_BIN=C:\Program Files\LLVM\bin\
+        @echo   Found LLVM, setting CLANG_BIN environment variable to C:\Program Files\LLVM\bin\
+    )
+)
+
 :check_cygwin
 if defined CYGWIN_HOME (
   if not exist "%CYGWIN_HOME%" (


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=2404

Set the below two environment variables in edksetup.bat:
  set CLANG_HOST_BIN=n
  set CLANG_BIN=C:\Program Files\LLVM\bin\
In Windows, set CLANG_HOST_BIN=n to use nmake command
The CLANG_BIN is only be set if it is not defined.

Cc: Liming Gao <liming.gao@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Cc: Laszlo Ersek <lersek@redhat.com>
Signed-off-by: Zhiguang Liu <zhiguang.liu@intel.com>