### PR TITLE
pull-request-branch-add-platform-boot-manager-protocol

### DIFF
--- a/MdeModulePkg/Include/Protocol/PlatformBootManager.h
+++ b/MdeModulePkg/Include/Protocol/PlatformBootManager.h
@@ -1,0 +1,82 @@
+/** @file
+
+  Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef __PLATFORM_BOOT_MANAGER_PROTOCOL_H__
+#define __PLATFORM_BOOT_MANAGER_PROTOCOL_H__
+
+#include <Library/UefiBootManagerLib.h>
+
+//
+// Platform Boot Manager Protocol GUID value
+//
+#define EDKII_PLATFORM_BOOT_MANAGER_PROTOCOL_GUID \
+    { \
+      0xaa17add4, 0x756c, 0x460d, { 0x94, 0xb8, 0x43, 0x88, 0xd7, 0xfb, 0x3e, 0x59 } \
+    }
+
+//
+// Protocol interface structure
+//
+typedef struct _EDKII_PLATFORM_BOOT_MANAGER_PROTOCOL EDKII_PLATFORM_BOOT_MANAGER_PROTOCOL;
+
+//
+// Revision The revision to which the protocol interface adheres.
+//          All future revisions must be backwards compatible.
+//          If a future version is not back wards compatible it is not the same GUID.
+//
+#define EDKII_PLATFORM_BOOT_MANAGER_PROTOCOL_REVISION 0x00000001
+
+//
+// Function Prototypes
+//
+
+/*
+  This function allows platform to refresh all boot options specific to the platform. Within
+  this function, platform can make modifications to the auto enumerated platform boot options
+  as well as NV boot options.
+
+  @param[in const] BootOptions             An array of auto enumerated platform boot options.
+                                           This array will be freed by caller upon successful
+                                           exit of this function and output array would be used.
+
+  @param[in const] BootOptionsCount        The number of elements in BootOptions.
+
+  @param[out]      UpdatedBootOptions      An array of boot options that have been customized
+                                           for the platform on top of input boot options. This
+                                           array would be allocated by REFRESH_ALL_BOOT_OPTIONS
+                                           and would be freed by caller after consuming it.
+
+  @param[out]      UpdatedBootOptionsCount The number of elements in UpdatedBootOptions.
+
+
+  @retval EFI_SUCCESS                      Platform refresh to input BootOptions and
+                                           BootCount have been done.
+
+  @retval EFI_OUT_OF_RESOURCES             Memory allocation failed.
+
+  @retval EFI_INVALID_PARAMETER            Input is not correct.
+
+  @retval EFI_UNSUPPORTED                  Platform specific overrides are not supported.
+*/
+typedef
+EFI_STATUS
+(EFIAPI *PLATFORM_BOOT_MANAGER_REFRESH_ALL_BOOT_OPTIONS) (
+  IN  CONST EFI_BOOT_MANAGER_LOAD_OPTION *BootOptions,
+  IN  CONST UINTN                        BootOptionsCount,
+  OUT       EFI_BOOT_MANAGER_LOAD_OPTION **UpdatedBootOptions,
+  OUT       UINTN                        *UpdatedBootOptionsCount
+  );
+
+struct _EDKII_PLATFORM_BOOT_MANAGER_PROTOCOL {
+  UINT64                                         Revision;
+  PLATFORM_BOOT_MANAGER_REFRESH_ALL_BOOT_OPTIONS RefreshAllBootOptions;
+};
+
+extern EFI_GUID gEdkiiPlatformBootManagerProtocolGuid;
+
+#endif /* __PLATFORM_BOOT_MANAGER_PROTOCOL_H__ */

--- a/MdeModulePkg/Library/UefiBootManagerLib/InternalBm.h
+++ b/MdeModulePkg/Library/UefiBootManagerLib/InternalBm.h
@@ -1,6 +1,7 @@
 /** @file
   BDS library definition, include the file and data structure
 
+Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
 Copyright (c) 2004 - 2018, Intel Corporation. All rights reserved.<BR>
 (C) Copyright 2015 Hewlett Packard Enterprise Development LP<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -41,6 +42,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Protocol/VariableLock.h>
 #include <Protocol/RamDisk.h>
 #include <Protocol/DeferredImageLoad.h>
+#include <Protocol/PlatformBootManager.h>
 
 #include <Guid/MemoryTypeInformation.h>
 #include <Guid/FileInfo.h>

--- a/MdeModulePkg/Library/UefiBootManagerLib/UefiBootManagerLib.inf
+++ b/MdeModulePkg/Library/UefiBootManagerLib/UefiBootManagerLib.inf
@@ -5,6 +5,7 @@
 #  manipulation, hotkey registration, UEFI boot, connect/disconnect, console
 #  manipulation, driver health checking and etc.
 #
+#  Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
 #  Copyright (c) 2007 - 2018, Intel Corporation. All rights reserved.<BR>
 #  (C) Copyright 2016 Hewlett Packard Enterprise Development LP<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -107,6 +108,7 @@
   gEfiFormBrowser2ProtocolGuid                  ## SOMETIMES_CONSUMES
   gEfiRamDiskProtocolGuid                       ## SOMETIMES_CONSUMES
   gEfiDeferredImageLoadProtocolGuid             ## SOMETIMES_CONSUMES
+  gEdkiiPlatformBootManagerProtocolGuid         ## SOMETIMES_CONSUMES
 
 [Pcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdResetOnMemoryTypeInformationChange      ## SOMETIMES_CONSUMES

--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -3,6 +3,7 @@
 # It also provides the definitions(including PPIs/PROTOCOLs/GUIDs and library classes)
 # and libraries instances, which are used for those modules.
 #
+# Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
 # Copyright (c) 2007 - 2019, Intel Corporation. All rights reserved.<BR>
 # Copyright (c) 2016, Linaro Ltd. All rights reserved.<BR>
 # (C) Copyright 2016 - 2019 Hewlett Packard Enterprise Development LP<BR>
@@ -608,6 +609,9 @@
 
   ## Include/Protocol/PeCoffImageEmulator.h
   gEdkiiPeCoffImageEmulatorProtocolGuid = { 0x96f46153, 0x97a7, 0x4793, { 0xac, 0xc1, 0xfa, 0x19, 0xbf, 0x78, 0xea, 0x97 } }
+
+  ## Include/Protocol/PlatformBootManager.h
+  gEdkiiPlatformBootManagerProtocolGuid = { 0xaa17add4, 0x756c, 0x460d, { 0x94, 0xb8, 0x43, 0x88, 0xd7, 0xfb, 0x3e, 0x59 } }
 
 #
 # [Error.gEfiMdeModulePkgTokenSpaceGuid]


### PR DESCRIPTION

Add edk2 platform boot manager protocol which would have platform
specific refreshes to the auto enumerated as well as NV boot options
for the platform.

Signed-off-by: Ashish Singhal <ashishsingha@nvidia.com>
Reviewed-by: Ray Ni <ray.ni@intel.com>