### PR TITLE
BaseTools/PatchCheck.py: Ignore CR and LF characters in subject length

### DIFF
--- a/BaseTools/Scripts/PatchCheck.py
+++ b/BaseTools/Scripts/PatchCheck.py
@@ -196,7 +196,7 @@ class CommitMessageCheck:
             self.error('Empty commit message!')
             return
 
-        if count >= 1 and len(lines[0]) >= 72:
+        if count >= 1 and len(lines[0].rstrip()) >= 72:
             self.error('First line of commit message (subject line) ' +
                        'is too long.')
 


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=113

Strip the trailing characters before checking the subject line is
less than 72 characters.

Fixes: e61406708c83f
Cc: Liming Gao <liming.gao@intel.com>
Cc: Jordan Justen <jordan.l.justen@intel.com>
Reviewed-by: Jordan Justen <jordan.l.justen@intel.com>
Reviewed-by: Bob Feng <bob.c.feng@intel.com>

Signed-off-by: Philippe Mathieu-Daude <philmd@redhat.com>