### PR TITLE
UefiCpuPkg/PiSmmCpuDxeSmm: Add missed comments for parameter.

### DIFF
--- a/UefiCpuPkg/PiSmmCpuDxeSmm/MpService.c
+++ b/UefiCpuPkg/PiSmmCpuDxeSmm/MpService.c
@@ -1142,6 +1142,8 @@ FindFirstFreeToken (
 
   If no free token, allocate new tokens then return the free one.
 
+  @param RunningApsCount    The Running Aps count for this token.
+
   @retval    return the first free PROCEDURE_TOKEN.
 
 **/


### PR DESCRIPTION
This issue caused by below change:
  SHA-1: b948a496150f4ae4f656c0f0ab672608723c80e6
  * UefiCpuPkg/PiSmmCpuDxeSmm: Pre-allocate PROCEDURE_TOKEN buffer
  REF: https://bugzilla.tianocore.org/show_bug.cgi?id=2388

Reviewed-by: Ray Ni <ray.ni@intel.com>
Acked-by: Laszlo Ersek <lersek@redhat.com>
Signed-off-by: Eric Dong <eric.dong@intel.com>