### PR TITLE
MdePkg: Do not use CreateEventEx unless required

### DIFF
--- a/MdePkg/Library/DxeRuntimeDebugLibSerialPort/DebugLib.c
+++ b/MdePkg/Library/DxeRuntimeDebugLibSerialPort/DebugLib.c
@@ -77,9 +77,8 @@ DxeRuntimeDebugLibSerialPortConstructor (
     return Status;
   }
 
-  return SystemTable->BootServices->CreateEventEx (EVT_NOTIFY_SIGNAL,
+  return SystemTable->BootServices->CreateEvent (EVT_SIGNAL_EXIT_BOOT_SERVICES,
                                       TPL_NOTIFY, ExitBootServicesEvent, NULL,
-                                      &gEfiEventExitBootServicesGuid,
                                       &mEfiExitBootServicesEvent);
 }
 

--- a/MdePkg/Library/DxeRuntimeDebugLibSerialPort/DxeRuntimeDebugLibSerialPort.inf
+++ b/MdePkg/Library/DxeRuntimeDebugLibSerialPort/DxeRuntimeDebugLibSerialPort.inf
@@ -41,9 +41,6 @@
   PrintLib
   SerialPortLib
 
-[Guids]
-  gEfiEventExitBootServicesGuid                         ## CONSUMES ## Event
-
 [Pcd]
   gEfiMdePkgTokenSpaceGuid.PcdDebugClearMemoryValue     ## SOMETIMES_CONSUMES
   gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask         ## CONSUMES

--- a/MdePkg/Library/DxeRuntimePciExpressLib/DxeRuntimePciExpressLib.inf
+++ b/MdePkg/Library/DxeRuntimePciExpressLib/DxeRuntimePciExpressLib.inf
@@ -47,7 +47,3 @@
 
 [Pcd]
   gEfiMdePkgTokenSpaceGuid.PcdPciExpressBaseAddress  ## CONSUMES
-
-[Guids]
-  gEfiEventVirtualAddressChangeGuid         ## CONSUMES ## Event
-

--- a/MdePkg/Library/DxeRuntimePciExpressLib/PciExpressLib.c
+++ b/MdePkg/Library/DxeRuntimePciExpressLib/PciExpressLib.c
@@ -124,12 +124,11 @@ DxeRuntimePciExpressLibConstructor (
   //
   // Register SetVirtualAddressMap () notify function
   //
-  Status = gBS->CreateEventEx (
-                  EVT_NOTIFY_SIGNAL,
+  Status = gBS->CreateEvent (
+                  EVT_SIGNAL_VIRTUAL_ADDRESS_CHANGE,
                   TPL_NOTIFY,
                   DxeRuntimePciExpressLibVirtualNotify,
                   NULL,
-                  &gEfiEventVirtualAddressChangeGuid,
                   &mDxeRuntimePciExpressLibVirtualNotifyEvent
                   );
   ASSERT_EFI_ERROR (Status);

--- a/MdePkg/Library/PciSegmentLibSegmentInfo/DxeRuntimePciSegmentLib.c
+++ b/MdePkg/Library/PciSegmentLibSegmentInfo/DxeRuntimePciSegmentLib.c
@@ -109,12 +109,11 @@ DxeRuntimePciSegmentLibConstructor (
   //
   // Register SetVirtualAddressMap () notify function
   //
-  Status = gBS->CreateEventEx (
-                  EVT_NOTIFY_SIGNAL,
+  Status = gBS->CreateEvent (
+                  EVT_SIGNAL_VIRTUAL_ADDRESS_CHANGE,
                   TPL_NOTIFY,
                   DxeRuntimePciSegmentLibVirtualNotify,
                   NULL,
-                  &gEfiEventVirtualAddressChangeGuid,
                   &mDxeRuntimePciSegmentLibVirtualNotifyEvent
                   );
   ASSERT_EFI_ERROR (Status);

--- a/MdePkg/Library/PciSegmentLibSegmentInfo/DxeRuntimePciSegmentLibSegmentInfo.inf
+++ b/MdePkg/Library/PciSegmentLibSegmentInfo/DxeRuntimePciSegmentLibSegmentInfo.inf
@@ -45,6 +45,3 @@
   MemoryAllocationLib
   DxeServicesTableLib
   UefiBootServicesTableLib
-
-[Guids]
-  gEfiEventVirtualAddressChangeGuid         ## CONSUMES ## Event

--- a/MdePkg/Library/UefiDebugLibConOut/DebugLibConstructor.c
+++ b/MdePkg/Library/UefiDebugLibConOut/DebugLibConstructor.c
@@ -64,12 +64,11 @@ DxeDebugLibConstructor(
 {
   mDebugST = SystemTable;
 
-  SystemTable->BootServices->CreateEventEx (
-                                EVT_NOTIFY_SIGNAL,
+  SystemTable->BootServices->CreateEvent (
+                                EVT_SIGNAL_EXIT_BOOT_SERVICES,
                                 TPL_NOTIFY,
                                 ExitBootServicesCallback,
                                 NULL,
-                                &gEfiEventExitBootServicesGuid,
                                 &mExitBootServicesEvent
                                 );
 

--- a/MdePkg/Library/UefiDebugLibConOut/UefiDebugLibConOut.inf
+++ b/MdePkg/Library/UefiDebugLibConOut/UefiDebugLibConOut.inf
@@ -46,9 +46,6 @@
   PrintLib
   DebugPrintErrorLevelLib
 
-[Guids]
-  gEfiEventExitBootServicesGuid                 ## CONSUMES
-
 [Pcd]
   gEfiMdePkgTokenSpaceGuid.PcdDebugClearMemoryValue        ## SOMETIMES_CONSUMES
   gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask            ## CONSUMES

--- a/MdePkg/Library/UefiDebugLibDebugPortProtocol/DebugLibConstructor.c
+++ b/MdePkg/Library/UefiDebugLibDebugPortProtocol/DebugLibConstructor.c
@@ -64,12 +64,11 @@ DxeDebugLibConstructor(
 {
   mDebugBS = SystemTable->BootServices;
 
-  mDebugBS->CreateEventEx (
-              EVT_NOTIFY_SIGNAL,
+  mDebugBS->CreateEvent (
+              EVT_SIGNAL_EXIT_BOOT_SERVICES,
               TPL_NOTIFY,
               ExitBootServicesCallback,
               NULL,
-              &gEfiEventExitBootServicesGuid,
               &mExitBootServicesEvent
               );
 

--- a/MdePkg/Library/UefiDebugLibDebugPortProtocol/UefiDebugLibDebugPortProtocol.inf
+++ b/MdePkg/Library/UefiDebugLibDebugPortProtocol/UefiDebugLibDebugPortProtocol.inf
@@ -46,9 +46,6 @@
   PrintLib
   DebugPrintErrorLevelLib
 
-[Guids]
-  gEfiEventExitBootServicesGuid                 ## CONSUMES
-
 [Protocols]
   gEfiDebugPortProtocolGuid                     ## CONSUMES
 

--- a/MdePkg/Library/UefiDebugLibStdErr/DebugLibConstructor.c
+++ b/MdePkg/Library/UefiDebugLibStdErr/DebugLibConstructor.c
@@ -64,12 +64,11 @@ DxeDebugLibConstructor(
 {
   mDebugST = SystemTable;
 
-  SystemTable->BootServices->CreateEventEx (
-                                EVT_NOTIFY_SIGNAL,
+  SystemTable->BootServices->CreateEvent (
+                                EVT_SIGNAL_EXIT_BOOT_SERVICES,
                                 TPL_NOTIFY,
                                 ExitBootServicesCallback,
                                 NULL,
-                                &gEfiEventExitBootServicesGuid,
                                 &mExitBootServicesEvent
                                 );
 

--- a/MdePkg/Library/UefiDebugLibStdErr/UefiDebugLibStdErr.inf
+++ b/MdePkg/Library/UefiDebugLibStdErr/UefiDebugLibStdErr.inf
@@ -44,9 +44,6 @@
   PrintLib
   DebugPrintErrorLevelLib
 
-[Guids]
-  gEfiEventExitBootServicesGuid                 ## CONSUMES
-
 [Pcd]
   gEfiMdePkgTokenSpaceGuid.PcdDebugClearMemoryValue   ## SOMETIMES_CONSUMES
   gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask       ## CONSUMES

--- a/MdePkg/Library/UefiRuntimeLib/RuntimeLib.c
+++ b/MdePkg/Library/UefiRuntimeLib/RuntimeLib.c
@@ -93,23 +93,21 @@ RuntimeDriverLibConstruct (
   //
   // Register SetVirtualAddressMap () notify function
   //
-  Status = gBS->CreateEventEx (
-                  EVT_NOTIFY_SIGNAL,
+  Status = gBS->CreateEvent (
+                  EVT_SIGNAL_VIRTUAL_ADDRESS_CHANGE,
                   TPL_NOTIFY,
                   RuntimeLibVirtualNotifyEvent,
                   NULL,
-                  &gEfiEventVirtualAddressChangeGuid,
                   &mEfiVirtualNotifyEvent
                   );
 
   ASSERT_EFI_ERROR (Status);
 
-  Status = gBS->CreateEventEx (
-                  EVT_NOTIFY_SIGNAL,
+  Status = gBS->CreateEvent (
+                  EVT_SIGNAL_EXIT_BOOT_SERVICES,
                   TPL_NOTIFY,
                   RuntimeLibExitBootServicesEvent,
                   NULL,
-                  &gEfiEventExitBootServicesGuid,
                   &mEfiExitBootServicesEvent
                   );
 

--- a/MdePkg/Library/UefiRuntimeLib/UefiRuntimeLib.inf
+++ b/MdePkg/Library/UefiRuntimeLib/UefiRuntimeLib.inf
@@ -39,8 +39,3 @@
   UefiBootServicesTableLib
   UefiRuntimeServicesTableLib
   DebugLib
-
-[Guids]
-  gEfiEventExitBootServicesGuid             ## CONSUMES ## Event
-  gEfiEventVirtualAddressChangeGuid         ## CONSUMES ## Event
-


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=2446

There are many firmwares in the wild not supporting CreateEventEx,
including devices less than 5 years old.

Signed-off-by: Vitaly Cheptsov <vit9696@protonmail.com>
Reviewed-by: Liming Gao <liming.gao@intel.com>