### PR TITLE
UefiCpuPkg: Add microcode flash address to EDKII microcode patch HOB.

### DIFF
--- a/UefiCpuPkg/Include/Guid/MicrocodePatchHob.h
+++ b/UefiCpuPkg/Include/Guid/MicrocodePatchHob.h
@@ -3,7 +3,7 @@
     A. Base address and size of the loaded microcode patches data;
     B. Detected microcode patch for each processor within system.
 
-  Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2019 - 2020, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -38,7 +38,15 @@ typedef struct {
   // If no microcode patch is detected for certain processor, the relating
   // element will be set to MAX_UINT64.
   //
-  UINT64    ProcessorSpecificPatchOffset[0];
+  //UINT64    ProcessorSpecificPatchOffset[];
+  //
+  // An array with 'ProcessorCount' elements that stores the original
+  // microcode patch address in flash if the patch has been shadowed to
+  // memory. This address will be the same one as specified by
+  // "MicrocodePatchAddress" with "PatchOffset" if the patch wasn't
+  // shadowed to memory.
+  //
+  //UINT64    ProcessorSpecificPatchAddrInRom[];
 } EDKII_MICROCODE_PATCH_HOB;
 
 #endif

--- a/UefiCpuPkg/Library/MpInitLib/MpLib.h
+++ b/UefiCpuPkg/Library/MpInitLib/MpLib.h
@@ -29,6 +29,8 @@
 #include <Library/MtrrLib.h>
 #include <Library/HobLib.h>
 
+#include <Guid/MicrocodePatchHob.h>
+
 #include <IndustryStandard/FirmwareInterfaceTable.h>
 
 
@@ -56,6 +58,7 @@
 //
 typedef struct {
   UINTN    Address;
+  UINTN    AddressInRam;
   UINTN    Size;
 } MICROCODE_PATCH_INFO;
 
@@ -273,6 +276,12 @@ struct _CPU_MP_DATA {
   // driver.
   //
   BOOLEAN                        WakeUpByInitSipiSipi;
+
+  //
+  // Shadow infomation of the microcode patch data.
+  //
+  UINTN                          PatchCount;
+  MICROCODE_PATCH_INFO           *PatchInfoBuffer;
 };
 
 extern EFI_GUID mCpuInitMpLibHobGuid;


### PR DESCRIPTION
**Only for CI test purpose.**

This patch adds the original microcode flash address to EDKII microcode
patch HOB after the microcode loaded by processor. This information can
be used to check if a microcode slot has been used by existing processor
or not.

BZ: https://bugzilla.tianocore.org/show_bug.cgi?id=2454

Cc: Eric Dong <eric.dong@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Cc: Laszlo Ersek <lersek@redhat.com>
Signed-off-by: Siyuan Fu <siyuan.fu@intel.com>