### PR TITLE
MdeModulePkg/SdMmcPciHcDxe: Fix unknown doxygen tag error

### DIFF
--- a/MdeModulePkg/Bus/Pci/SdMmcPciHcDxe/SdMmcPciHci.c
+++ b/MdeModulePkg/Bus/Pci/SdMmcPciHcDxe/SdMmcPciHci.c
@@ -765,7 +765,7 @@ SdMmcHcStopClock (
   @param[in] Slot   The slot number.
 
   @retval EFI_SUCCESS  Succeeded to start the SD clock.
-  @rtval  Others       Failed to start the SD clock.
+  @retval Others       Failed to start the SD clock.
 **/
 EFI_STATUS
 SdMmcHcStartSdClock (

--- a/MdeModulePkg/Bus/Pci/SdMmcPciHcDxe/SdMmcPciHci.h
+++ b/MdeModulePkg/Bus/Pci/SdMmcPciHcDxe/SdMmcPciHci.h
@@ -485,7 +485,7 @@ SdMmcHcStopClock (
   @param[in] Slot   The slot number.
 
   @retval EFI_SUCCESS  Succeeded to start the SD clock.
-  @rtval  Others       Failed to start the SD clock.
+  @retval Others       Failed to start the SD clock.
 **/
 EFI_STATUS
 SdMmcHcStartSdClock (


### PR DESCRIPTION
Changed @rtval to @retval in SdMmcHcStartSdClock
function description.

Signed-off-by: Mateusz Albecki <mateusz.albecki@intel.com>
Reviewed-by: Hao A Wu <hao.a.wu@intel.com>