### PR TITLE
CryptoPkg/BaseCryptLibNull: Add missing HkdfSha256ExtractAndExpand()

### DIFF
--- a/CryptoPkg/Library/BaseCryptLibNull/BaseCryptLibNull.inf
+++ b/CryptoPkg/Library/BaseCryptLibNull/BaseCryptLibNull.inf
@@ -6,7 +6,7 @@
 #  This external input must be validated carefully to avoid security issues such as
 #  buffer overflow or integer overflow.
 #
-#  Copyright (c) 2009 - 2019, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2009 - 2020, Intel Corporation. All rights reserved.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -37,6 +37,7 @@
   Hmac/CryptHmacMd5Null.c
   Hmac/CryptHmacSha1Null.c
   Hmac/CryptHmacSha256Null.c
+  Kdf/CryptHkdfNull.c
   Cipher/CryptAesNull.c
   Cipher/CryptTdesNull.c
   Cipher/CryptArc4Null.c

--- a/CryptoPkg/Library/BaseCryptLibNull/Kdf/CryptHkdfNull.c
+++ b/CryptoPkg/Library/BaseCryptLibNull/Kdf/CryptHkdfNull.c
@@ -1,0 +1,43 @@
+/** @file
+  HMAC-SHA256 KDF Wrapper Implementation which does not provide real capabilities.
+
+Copyright (c) 2018 - 2019, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Library/BaseCryptLib.h>
+#include <Library/DebugLib.h>
+
+/**
+  Derive key data using HMAC-SHA256 based KDF.
+
+  @param[in]   Key              Pointer to the user-supplied key.
+  @param[in]   KeySize          Key size in bytes.
+  @param[in]   Salt             Pointer to the salt(non-secret) value.
+  @param[in]   SaltSize         Salt size in bytes.
+  @param[in]   Info             Pointer to the application specific info.
+  @param[in]   InfoSize         Info size in bytes.
+  @param[out]  Out              Pointer to buffer to receive hkdf value.
+  @param[in]   OutSize          Size of hkdf bytes to generate.
+
+  @retval TRUE   Hkdf generated successfully.
+  @retval FALSE  Hkdf generation failed.
+
+**/
+BOOLEAN
+EFIAPI
+HkdfSha256ExtractAndExpand (
+  IN   CONST UINT8  *Key,
+  IN   UINTN        KeySize,
+  IN   CONST UINT8  *Salt,
+  IN   UINTN        SaltSize,
+  IN   CONST UINT8  *Info,
+  IN   UINTN        InfoSize,
+  OUT  UINT8        *Out,
+  IN   UINTN        OutSize
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}


### PR DESCRIPTION
https://bugzilla.tianocore.org/show_bug.cgi?id=2493

The BaseCryptLib was expanded to add the HkdfSha256ExtractAndExpand()
service in the following commit:

https://github.com/tianocore/edk2/commit/4b1b7c1913092d73d689d8086dcfa579c0217dc8

When BaseCryptLibNull was added in the commit below, this new
service was not included.

https://github.com/tianocore/edk2/commit/d95de082da01f4a4cb3ebf87e15972a12d0f8d53

Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Xiaoyu Lu <xiaoyux.lu@intel.com>
Signed-off-by: Michael D Kinney <michael.d.kinney@intel.com>