### PR TITLE
MdeModulePkg/Capsule: Remove RT restriction in UpdateCapsule service.

### DIFF
--- a/MdeModulePkg/Universal/CapsuleRuntimeDxe/CapsuleService.c
+++ b/MdeModulePkg/Universal/CapsuleRuntimeDxe/CapsuleService.c
@@ -4,7 +4,7 @@
   It installs the Capsule Architectural Protocol defined in PI1.0a to signify
   the capsule runtime services are ready.
 
-Copyright (c) 2006 - 2019, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2006 - 2020, Intel Corporation. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -138,11 +138,7 @@ UpdateCapsule (
     // Platform specific update for the non-reset capsule image.
     //
     if ((CapsuleHeader->Flags & CAPSULE_FLAGS_PERSIST_ACROSS_RESET) == 0) {
-      if (EfiAtRuntime ()) {
-        Status = EFI_OUT_OF_RESOURCES;
-      } else {
-        Status = ProcessCapsuleImage(CapsuleHeader);
-      }
+      Status = ProcessCapsuleImage(CapsuleHeader);
       if (EFI_ERROR(Status)) {
         return Status;
       }


### PR DESCRIPTION
Current UpdateCapsule service will reject all non-reset capsule images and
return EFI_OUT_OF_RESOURCE if the system is at runtime. This will block a
platform CapsuleLib from implementing ProcessCapsuleImage() with runtime
capsule processing capability. This patch removes this restriction.

BZ: https://bugzilla.tianocore.org/show_bug.cgi?id=2501

Cc: Hao A Wu <hao.a.wu@intel.com>
Cc: Liming Gao <liming.gao@intel.com>
Signed-off-by: Siyuan Fu <siyuan.fu@intel.com>