### PR TITLE
BaseTools/DscBuildData: Fix PCD autogen include file conflict

### DIFF
--- a/BaseTools/Source/Python/Workspace/DscBuildData.py
+++ b/BaseTools/Source/Python/Workspace/DscBuildData.py
@@ -1,7 +1,7 @@
 ## @file
 # This file is used to create a database used by build tool
 #
-# Copyright (c) 2008 - 2019, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2008 - 2020, Intel Corporation. All rights reserved.<BR>
 # (C) Copyright 2016 Hewlett Packard Enterprise Development LP<BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -2667,6 +2667,22 @@ class DscBuildData(PlatformBuildClassObject):
             for pkg in PcdDependDEC:
                 if pkg in PlatformInc:
                     for inc in PlatformInc[pkg]:
+                        #
+                        # Get list of files in potential -I include path
+                        #
+                        FileList = os.listdir (str(inc))
+                        #
+                        # Skip -I include path if one of the include files required
+                        # by PcdValueInit.c are present in the include paths from
+                        # the DEC file.  PcdValueInit.c must use the standard include
+                        # files from the host compiler.
+                        #
+                        if 'stdio.h' in FileList:
+                          continue
+                        if 'stdlib.h' in FileList:
+                          continue
+                        if 'string.h' in FileList:
+                          continue
                         MakeApp += '-I'  + str(inc) + ' '
                         IncSearchList.append(inc)
         MakeApp = MakeApp + '\n'


### PR DESCRIPTION
https://bugzilla.tianocore.org/show_bug.cgi?id=2494

When using structured PCDs, a C application is auto generated
to fill in the structured PCD value.  The C application uses
the standard include files <stdio.h>, <stdlib.h>, and <string.h>.
This C application also supports include paths from package DEC
files when a structured PCD declaration provides a <Packages>
list.  The complete list of include paths are -I options for
include paths from package DEC files and the compiler's standard
include paths.

-I include paths are higher priority than the standard include
paths.  If the -I included paths from package DEC files contain
<stdio.h>, <stdlib.h>, or <string.h> the wrong include files are
used to compile the C application for the structured PCD value.

Update GenerateByteArrayValue() to skip a package DEC include
paths that contain <stdio.h>, <stdlib.h>, or <string.h>.

Build failures were observed when adding a structured PCD to
CryptoPkg.  CryptoPkg contains <stdio.h>, <stdlib.h>, and
<string.h> in the path CryptoPkg/Library/Include to support
building Open SSL.  The Library/Include path is listed as a
private include path in CryptoPkg.dec.  Without this change, the
standard include files designed to support build OpenSLL are
used to build the structured PCD C application, and that build
fails.

Other packages that provide a standard C lib or a gasket for
a subset of the standard C lib will run into this same issue
if they also define and use a Structured PCD.  So this issue
is not limited to the CryptoPkg.

Cc: Bob Feng <bob.c.feng@intel.com>
Cc: Liming Gao <liming.gao@intel.com>
Signed-off-by: Michael D Kinney <michael.d.kinney@intel.com>
Reviewed-by: Liming Gao <liming.gao@intel.com>