### PR TITLE
MdePkg Base.h: Use correct style to check macro _MSC_VER value

### DIFF
--- a/MdePkg/Include/Base.h
+++ b/MdePkg/Include/Base.h
@@ -33,7 +33,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 //  if the /OPT:REF linker option is used. We defined a macro as this is a
 //  a non standard extension
 //
-#if defined(_MSC_EXTENSIONS) && _MSC_VER < 1800 && !defined (MDE_CPU_EBC)
+#if defined(_MSC_VER) && _MSC_VER < 1800 && !defined (MDE_CPU_EBC)
   ///
   /// Remove global variable from the linked image if there are no references to
   /// it after all compiler and linker optimizations have been performed.

--- a/MdePkg/Include/Ia32/ProcessorBind.h
+++ b/MdePkg/Include/Ia32/ProcessorBind.h
@@ -87,7 +87,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 //
 #pragma warning ( disable : 4206 )
 
-#if _MSC_VER == 1800 || _MSC_VER == 1900 || _MSC_VER >= 1910
+#if defined(_MSC_VER) && _MSC_VER >= 1800
 
 //
 // Disable these warnings for VS2013.

--- a/MdePkg/Include/X64/ProcessorBind.h
+++ b/MdePkg/Include/X64/ProcessorBind.h
@@ -101,7 +101,7 @@
 //
 #pragma warning ( disable : 4206 )
 
-#if _MSC_VER == 1800 || _MSC_VER == 1900 || _MSC_VER >= 1910
+#if defined(_MSC_VER) && _MSC_VER >= 1800
 
 //
 // Disable these warnings for VS2013.


### PR DESCRIPTION
Signed-off-by: Zhiguang Liu <zhiguang.liu@intel.com>
Reviewed-by: Liming Gao <liming.gao@intel.com>