### PR TITLE
BaseTools: Script for converting .aml to .hex

### DIFF
--- a/BaseTools/BinWrappers/PosixLike/AmlToHex
+++ b/BaseTools/BinWrappers/PosixLike/AmlToHex
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+#python `dirname $0`/RunToolFromSource.py `basename $0` $*
+
+# If a ${PYTHON_COMMAND} command is available, use it in preference to python
+if command -v ${PYTHON_COMMAND} >/dev/null 2>&1; then
+    python_exe=${PYTHON_COMMAND}
+fi
+
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+dir=$(dirname "$full_cmd")
+exe=$(basename "$full_cmd")
+
+export PYTHONPATH="$dir/../../Source/Python${PYTHONPATH:+:"$PYTHONPATH"}"
+exec "${python_exe:-python}" "$dir/../../Source/Python/$exe/$exe.py" "$@"

--- a/BaseTools/BinWrappers/WindowsLike/AmlToHex.bat
+++ b/BaseTools/BinWrappers/WindowsLike/AmlToHex.bat
@@ -1,0 +1,3 @@
+@setlocal
+@set ToolName=%~n0%
+@%PYTHON_COMMAND% %BASE_TOOLS_PATH%\Source\Python\%ToolName%\%ToolName%.py %*

--- a/BaseTools/Conf/build_rule.template
+++ b/BaseTools/Conf/build_rule.template
@@ -1,6 +1,7 @@
 #
 #  Copyright (c) 2007 - 2018, Intel Corporation. All rights reserved.<BR>
 #  Portions copyright (c) 2008 - 2010, Apple Inc. All rights reserved.<BR>
+#  Copyright (c) 2020, ARM Ltd. All rights reserved.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 
@@ -427,12 +428,14 @@
         "$(ASLPP)" $(DEPS_FLAGS) $(ASLPP_FLAGS) $(INC) /I${s_path} $(OUTPUT_DIR)(+)${s_dir}(+)${s_base}.i > $(OUTPUT_DIR)(+)${s_dir}(+)${s_base}.iii
         Trim --source-code -l -o $(OUTPUT_DIR)(+)${s_dir}(+)${s_base}.iiii $(OUTPUT_DIR)(+)${s_dir}(+)${s_base}.iii 
         "$(ASL)" $(ASL_FLAGS) $(ASL_OUTFLAGS)${dst} $(OUTPUT_DIR)(+)${s_dir}(+)${s_base}.iiii
+        -AmlToHex $(OUTPUT_DIR)(+)${s_dir}(+)${s_base}.aml
 
     <Command.GCC>
         Trim --asl-file --asl-deps -o $(OUTPUT_DIR)(+)${s_dir}(+)${s_base}.i -i $(INC_LIST) ${src}
         "$(ASLPP)" $(DEPS_FLAGS) $(ASLPP_FLAGS) $(INC) -I${s_path} $(OUTPUT_DIR)(+)${s_dir}(+)${s_base}.i > $(OUTPUT_DIR)(+)${s_dir}(+)${s_base}.iii
         Trim --source-code -l -o $(OUTPUT_DIR)(+)${s_dir}(+)${s_base}.iiii $(OUTPUT_DIR)(+)${s_dir}(+)${s_base}.iii 
         "$(ASL)" $(ASL_FLAGS) $(ASL_OUTFLAGS)${dst} $(OUTPUT_DIR)(+)${s_dir}(+)${s_base}.iiii
+        -AmlToHex $(OUTPUT_DIR)(+)${s_dir}(+)${s_base}.aml
 
 [C-Code-File.AcpiTable]
     <InputFile>

--- a/BaseTools/Source/Python/AmlToHex/AmlToHex.py
+++ b/BaseTools/Source/Python/AmlToHex/AmlToHex.py
@@ -1,0 +1,156 @@
+## @file
+#
+# Convert an AML file to a .hex file containing the AML bytecode stored in a
+# C array.
+# By default, "Tables\Dsdt.aml" will generate "Tables\Dsdt.hex".
+# "Tables\Dsdt.hex" will contain a C array named "dsdt_aml_code" that contains
+# the AML bytecode.
+#
+# Copyright (c) 2020, ARM Limited. All rights reserved.<BR>
+#
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+
+import argparse
+import Common.EdkLogger as EdkLogger
+from Common.BuildToolError import *
+import sys
+import os
+
+## Parse the command line arguments.
+#
+# @retval A argparse.NameSpace instance, containing parsed values.
+#
+def ParseArgs():
+    # Initialize the parser.
+    Parser = argparse.ArgumentParser(
+      description="Convert an AML file to a .hex file containing the AML " + \
+                  "bytecode stored in a C array. By default, " + \
+                  "\"Tables\\Dsdt.aml\" will generate" + \
+                  "\"Tables\\Dsdt.hex\". \"Tables\\Dsdt.hex\" will " + \
+                  "contain a C array named \"dsdt_aml_code\" that " + \
+                  "contains the AML bytecode."
+      )
+
+    # Define the possible arguments.
+    Parser.add_argument(
+      dest="InputFile",
+      help="Path to an input AML file to generate a .hex file from."
+      )
+    Parser.add_argument(
+      "-o", "--out-dir", dest="OutDir",
+      help="Output directory where the .hex file will be generated. " + \
+           "Default is the input file's directory."
+      )
+
+    # Parse the input arguments.
+    Args = Parser.parse_args()
+    SplitInputName = ""
+
+    if not os.path.exists(Args.InputFile):
+        EdkLogger.error(__file__, FILE_OPEN_FAILURE,
+                        ExtraData=Args.InputFile)
+        return None
+    else:
+        with open(Args.InputFile, "rb") as fIn:
+            Signature = str(fIn.read(4))
+            if ("DSDT" not in Signature) and ("SSDT" not in Signature):
+                EdkLogger.info("Invalid file type. " + \
+                                "File does not have a valid " + \
+                                "DSDT or SSDT signature: %s" % Args.InputFile)
+                return None
+
+    # Get the basename of the input file.
+    SplitInputName = os.path.splitext(Args.InputFile)
+    BaseName = os.path.basename(SplitInputName[0])
+
+    # If no output directory is specified, output to the input directory.
+    if not Args.OutDir:
+        Args.OutputFile = os.path.join(
+          os.path.dirname(Args.InputFile),
+          BaseName + ".hex"
+          )
+    else:
+        if not os.path.exists(Args.OutDir):
+            os.mkdir(Args.OutDir)
+        Args.OutputFile = os.path.join(Args.OutDir, BaseName + ".hex")
+
+    Args.BaseName = BaseName
+
+    return Args
+
+## Convert an AML file to a .hex file containing the AML bytecode stored
+#  in a C array.
+#
+# @param  InputFile     Path to the input AML file.
+# @param  OutputFile    Path to the output .hex file to generate.
+# @param  BaseName      Base name of the input file.
+#                       This is also the name of the generated .hex file.
+#
+def AmlToHex(InputFile, OutputFile, BaseName):
+
+    MacroName = "__{}_HEX__".format(BaseName.upper())
+    ArrayName = BaseName.lower() + "_aml_code"
+
+    with open(InputFile, "rb") as fIn, open(OutputFile, "w") as fOut:
+        # Write header.
+        fOut.write("// This file has been generated from:\n" + \
+                   "// \tPython script: " + \
+                   os.path.abspath(__file__) + "\n" + \
+                   "// \tInput AML file: " + \
+                   os.path.abspath(InputFile) + "\n\n" + \
+                   "#ifndef {}\n".format(MacroName) + \
+                   "#define {}\n\n".format(MacroName)
+                   )
+
+        # Write the array and its content.
+        fOut.write("unsigned char {}[] = {{\n  ".format(ArrayName))
+        cnt = 0
+        byte = fIn.read(1)
+        while len(byte) != 0:
+            fOut.write("0x{0:02X}, ".format(ord(byte)))
+            cnt += 1
+            if (cnt % 8) == 0:
+                fOut.write("\n  ")
+            byte = fIn.read(1)
+        fOut.write("\n};\n")
+
+        # Write footer.
+        fOut.write("#endif // {}\n".format(MacroName))
+
+## Main method
+#
+# This method:
+#   1-  Initialize an EdkLogger instance.
+#   2-  Parses the input arguments.
+#   3-  Converts an AML file to a .hex file containing the AML bytecode stored
+#       in a C array.
+#
+# @retval 0     Success.
+# @retval 1     Error.
+#
+def Main():
+    # Initialize an EdkLogger instance.
+    EdkLogger.Initialize()
+
+    try:
+        # Parse the input arguments.
+        CommandArguments = ParseArgs()
+        if not CommandArguments:
+            return 1
+
+        # Convert an AML file to a .hex file containing the AML bytecode stored
+        # in a C array.
+        AmlToHex(CommandArguments.InputFile, CommandArguments.OutputFile,
+                          CommandArguments.BaseName)
+    except Exception as e:
+        print(e)
+        return 1
+
+    return 0
+
+if __name__ == '__main__':
+    r = Main()
+    # 0-127 is a safe return range, and 1 is a standard default error
+    if r < 0 or r > 127: r = 1
+    sys.exit(r)


### PR DESCRIPTION
The "-tc" option of the iasl compiler allows to generate a
.hex file containing a C array storing AML bytecode.

An online discussion suggested that this "-tc" option
was specific to the iasl compiler and it shouldn't be relied
on. This conversation is available at:
https://edk2.groups.io/g/devel/topic/39786201#49659

A way to address this issue is to implement a compiler
independent script that takes an AML file as input, and
generates a .hex file.

This patch implements a Python script that converts an AML
file to a .hex file, containing a C array storing AML bytecode.
This scipt has been tested with the AML output from the
following compilers supported by the EDKII implementation:
  * Intel ASL compiler
  * Microsoft ASL compiler

Signed-off-by: Pierre Gondois <pierre.gondois@arm.com>
Reviewed-by: Bob Feng <bob.c.feng@intel.com>