### PR TITLE
MdeModulePkg/BaseSerialPortLib16550: Fix Serial Port Ready

### DIFF
--- a/MdeModulePkg/Library/BaseSerialPortLib16550/BaseSerialPortLib16550.c
+++ b/MdeModulePkg/Library/BaseSerialPortLib16550/BaseSerialPortLib16550.c
@@ -646,7 +646,7 @@ SerialPortWrite (
     // Wait for the serial port to be ready, to make sure both the transmit FIFO
     // and shift register empty.
     //
-    while ((SerialPortReadRegister (SerialRegisterBase, R_UART_LSR) & B_UART_LSR_TEMT) == 0);
+    while ((SerialPortReadRegister (SerialRegisterBase, R_UART_LSR) & (B_UART_LSR_TEMT | B_UART_LSR_TXRDY)) != (B_UART_LSR_TEMT | B_UART_LSR_TXRDY));
 
     //
     // Fill then entire Tx FIFO


### PR DESCRIPTION
Before writing data to FIFO, wait for the serial port to be ready,
to make sure both the transmit FIFO and shift register empty. Code
comment was saying the right thing but code was missing a check.

Reviewed-by: Zhichao Gao <zhichao.gao@intel.com>
Signed-off-by: Ashish Singhal <ashishsingha@nvidia.com>