### PR TITLE
Fix Structured PCD Application CI build issues

### DIFF
--- a/BaseTools/Plugin/WindowsVsToolChain/WindowsVsToolChain.py
+++ b/BaseTools/Plugin/WindowsVsToolChain/WindowsVsToolChain.py
@@ -21,6 +21,9 @@ class WindowsVsToolChain(IUefiBuildPlugin):
 
     def do_pre_build(self, thebuilder):
         self.Logger = logging.getLogger("WindowsVsToolChain")
+        interesting_keys = ["ExtensionSdkDir", "INCLUDE", "LIB", "LIBPATH", "UniversalCRTSdkDir",
+                            "UCRTVersion", "WindowsLibPath", "WindowsSdkBinPath", "WindowsSdkDir", "WindowsSdkVerBinPath",
+                            "WindowsSDKVersion", "VCToolsInstallDir", "Path"]
 
 #
         # VS2017 - Follow VS2017 where there is potential for many versions of the tools.
@@ -51,6 +54,16 @@ class WindowsVsToolChain(IUefiBuildPlugin):
                 prefix = os.path.join(install_path, "VC", "Tools", "MSVC", vc_ver)
                 prefix = prefix + os.path.sep
                 shell_environment.GetEnvironment().set_shell_var("VS2017_PREFIX", prefix)
+
+                shell_env = shell_environment.GetEnvironment()
+                # Use the tools lib to determine the correct values for the vars that interest us.
+                vs_vars = locate_tools.QueryVcVariables(
+                    interesting_keys, "amd64", vs_version="vs2017")
+                for (k, v) in vs_vars.items():
+                    if k.upper() == "PATH":
+                        shell_env.insert_path(v)
+                    else:
+                        shell_env.set_shell_var(k, v)
 
             # now confirm it exists
             if not os.path.exists(shell_environment.GetEnvironment().get_shell_var("VS2017_PREFIX")):
@@ -86,6 +99,16 @@ class WindowsVsToolChain(IUefiBuildPlugin):
                 prefix = os.path.join(install_path, "VC", "Tools", "MSVC", vc_ver)
                 prefix = prefix + os.path.sep
                 shell_environment.GetEnvironment().set_shell_var("VS2019_PREFIX", prefix)
+
+                shell_env = shell_environment.GetEnvironment()
+                # Use the tools lib to determine the correct values for the vars that interest us.
+                vs_vars = locate_tools.QueryVcVariables(
+                    interesting_keys, "amd64", vs_version="vs2019")
+                for (k, v) in vs_vars.items():
+                    if k.upper() == "PATH":
+                        shell_env.insert_path(v)
+                    else:
+                        shell_env.set_shell_var(k, v)
 
             # now confirm it exists
             if not os.path.exists(shell_environment.GetEnvironment().get_shell_var("VS2019_PREFIX")):

--- a/BaseTools/Plugin/WindowsVsToolChain/WindowsVsToolChain.py
+++ b/BaseTools/Plugin/WindowsVsToolChain/WindowsVsToolChain.py
@@ -1,4 +1,4 @@
-## @file WindowsVsToolChain.py
+# @file WindowsVsToolChain.py
 # Plugin to configures paths for the VS2017 and VS2019 tool chain
 ##
 # This plugin works in conjuncture with the tools_def
@@ -14,6 +14,7 @@ from edk2toollib.windows.locate_tools import FindWithVsWhere
 from edk2toolext.environment import shell_environment
 from edk2toolext.environment import version_aggregator
 
+
 class WindowsVsToolChain(IUefiBuildPlugin):
 
     def do_post_build(self, thebuilder):
@@ -28,9 +29,9 @@ class WindowsVsToolChain(IUefiBuildPlugin):
 #
         # VS2017 - Follow VS2017 where there is potential for many versions of the tools.
         # If a specific version is required then the user must set both env variables:
-        ## VS150INSTALLPATH:  base install path on system to VC install dir.  Here you will find the VC folder, etc
-        ## VS150TOOLVER:      version number for the VC compiler tools
-        ## VS2017_PREFIX:     path to MSVC compiler folder with trailing slash (can be used instead of two vars above)
+        # VS150INSTALLPATH:  base install path on system to VC install dir.  Here you will find the VC folder, etc
+        # VS150TOOLVER:      version number for the VC compiler tools
+        # VS2017_PREFIX:     path to MSVC compiler folder with trailing slash (can be used instead of two vars above)
         if thebuilder.env.GetValue("TOOL_CHAIN_TAG") == "VS2017":
 
             # check to see if full path already configured
@@ -38,11 +39,13 @@ class WindowsVsToolChain(IUefiBuildPlugin):
                 self.Logger.info("VS2017_PREFIX is already set.")
 
             else:
-                install_path = self._get_vs_install_path("VS2017".lower(), "VS150INSTALLPATH")
+                install_path = self._get_vs_install_path(
+                    "VS2017".lower(), "VS150INSTALLPATH")
                 vc_ver = self._get_vc_version(install_path, "VS150TOOLVER")
 
                 if install_path is None or vc_ver is None:
-                    self.Logger.error("Failed to configure environment for VS2017")
+                    self.Logger.error(
+                        "Failed to configure environment for VS2017")
                     return -1
 
                 version_aggregator.GetVersionAggregator().ReportVersion(
@@ -50,8 +53,9 @@ class WindowsVsToolChain(IUefiBuildPlugin):
                 version_aggregator.GetVersionAggregator().ReportVersion(
                     "VC Version", vc_ver, version_aggregator.VersionTypes.TOOL)
 
-                #make VS2017_PREFIX to align with tools_def.txt
-                prefix = os.path.join(install_path, "VC", "Tools", "MSVC", vc_ver)
+                # make VS2017_PREFIX to align with tools_def.txt
+                prefix = os.path.join(install_path, "VC",
+                                      "Tools", "MSVC", vc_ver)
                 prefix = prefix + os.path.sep
                 shell_environment.GetEnvironment().set_shell_var("VS2017_PREFIX", prefix)
 
@@ -73,9 +77,9 @@ class WindowsVsToolChain(IUefiBuildPlugin):
         #
         # VS2019 - Follow VS2019 where there is potential for many versions of the tools.
         # If a specific version is required then the user must set both env variables:
-        ## VS160INSTALLPATH:  base install path on system to VC install dir.  Here you will find the VC folder, etc
-        ## VS160TOOLVER:      version number for the VC compiler tools
-        ## VS2019_PREFIX:     path to MSVC compiler folder with trailing slash (can be used instead of two vars above)
+        # VS160INSTALLPATH:  base install path on system to VC install dir.  Here you will find the VC folder, etc
+        # VS160TOOLVER:      version number for the VC compiler tools
+        # VS2019_PREFIX:     path to MSVC compiler folder with trailing slash (can be used instead of two vars above)
         elif thebuilder.env.GetValue("TOOL_CHAIN_TAG") == "VS2019":
 
             # check to see if full path already configured
@@ -83,11 +87,13 @@ class WindowsVsToolChain(IUefiBuildPlugin):
                 self.Logger.info("VS2019_PREFIX is already set.")
 
             else:
-                install_path = self._get_vs_install_path("VS2019".lower(), "VS160INSTALLPATH")
+                install_path = self._get_vs_install_path(
+                    "VS2019".lower(), "VS160INSTALLPATH")
                 vc_ver = self._get_vc_version(install_path, "VS160TOOLVER")
 
                 if install_path is None or vc_ver is None:
-                    self.Logger.error("Failed to configure environment for VS2019")
+                    self.Logger.error(
+                        "Failed to configure environment for VS2019")
                     return -1
 
                 version_aggregator.GetVersionAggregator().ReportVersion(
@@ -95,8 +101,9 @@ class WindowsVsToolChain(IUefiBuildPlugin):
                 version_aggregator.GetVersionAggregator().ReportVersion(
                     "VC Version", vc_ver, version_aggregator.VersionTypes.TOOL)
 
-                #make VS2019_PREFIX to align with tools_def.txt
-                prefix = os.path.join(install_path, "VC", "Tools", "MSVC", vc_ver)
+                # make VS2019_PREFIX to align with tools_def.txt
+                prefix = os.path.join(install_path, "VC",
+                                      "Tools", "MSVC", vc_ver)
                 prefix = prefix + os.path.sep
                 shell_environment.GetEnvironment().set_shell_var("VS2019_PREFIX", prefix)
 
@@ -126,14 +133,16 @@ class WindowsVsToolChain(IUefiBuildPlugin):
             if rc == 0 and path is not None and os.path.exists(path):
                 self.Logger.debug("Found VS instance for %s", vs_version)
             else:
-                self.Logger.error("Failed to find VS instance with VsWhere (%d)" % rc)
+                self.Logger.error(
+                    "Failed to find VS instance with VsWhere (%d)" % rc)
         return path
 
     def _get_vc_version(self, path, varname):
         # check if already specified
         vc_ver = shell_environment.GetEnvironment().get_shell_var(varname)
         if (path is None):
-            self.Logger.critical("Failed to find Visual Studio tools.  Might need to check for VS install")
+            self.Logger.critical(
+                "Failed to find Visual Studio tools.  Might need to check for VS install")
             return vc_ver
         if(vc_ver is None):
             # Not specified...find latest
@@ -145,5 +154,3 @@ class WindowsVsToolChain(IUefiBuildPlugin):
             vc_ver = os.listdir(p2)[-1].strip()  # get last in list
             self.Logger.debug("Found VC Tool version is %s" % vc_ver)
         return vc_ver
-
-

--- a/BaseTools/Source/C/Common/GNUmakefile
+++ b/BaseTools/Source/C/Common/GNUmakefile
@@ -28,7 +28,6 @@ OBJECTS = \
   PeCoffLoaderEx.o \
   SimpleFileParsing.o \
   StringFuncs.o \
-  TianoCompress.o \
-  PcdValueCommon.o
+  TianoCompress.o
 
 include $(MAKEROOT)/Makefiles/lib.makefile

--- a/BaseTools/Source/C/Common/Makefile
+++ b/BaseTools/Source/C/Common/Makefile
@@ -28,8 +28,7 @@ OBJECTS = \
   PeCoffLoaderEx.obj \
   SimpleFileParsing.obj \
   StringFuncs.obj \
-  TianoCompress.obj \
-  PcdValueCommon.obj
+  TianoCompress.obj
 
 !INCLUDE ..\Makefiles\ms.lib
 

--- a/BaseTools/Source/C/Common/PcdValueCommon.c
+++ b/BaseTools/Source/C/Common/PcdValueCommon.c
@@ -478,7 +478,7 @@ Returns:
   //
   // Read all of the file contents.
   //
-  BytesRead = fread (*FileBuffer, sizeof (UINT8), *FileSize, InputFile);
+  BytesRead = (UINT32)fread (*FileBuffer, sizeof (UINT8), *FileSize, InputFile);
   if (BytesRead != *FileSize * sizeof (UINT8)) {
     fprintf (stderr, "Error reading the input file %s\n", InputFileName);
     fclose (InputFile);

--- a/BaseTools/Source/Python/Workspace/DscBuildData.py
+++ b/BaseTools/Source/Python/Workspace/DscBuildData.py
@@ -91,9 +91,6 @@ WindowsCFLAGS = 'CFLAGS = $(CFLAGS) /wd4200 /wd4034 /wd4101 '
 LinuxCFLAGS = 'BUILD_CFLAGS += -Wno-pointer-to-int-cast -Wno-unused-variable '
 PcdMakefileEnd = '''
 !INCLUDE $(BASE_TOOLS_PATH)\Source\C\Makefiles\ms.common
-
-LIBS = $(LIB_PATH)\Common.lib
-
 !INCLUDE $(BASE_TOOLS_PATH)\Source\C\Makefiles\ms.app
 '''
 
@@ -2637,10 +2634,10 @@ class DscBuildData(PlatformBuildClassObject):
 
         MakeApp = PcdMakefileHeader
         if sys.platform == "win32":
-            MakeApp = MakeApp + 'APPFILE = %s\%s.exe\n' % (self.OutputPath, PcdValueInitName) + 'APPNAME = %s\n' % (PcdValueInitName) + 'OBJECTS = %s\%s.obj\n' % (self.OutputPath, PcdValueInitName) + 'INC = '
+            MakeApp = MakeApp + 'APPFILE = %s\%s.exe\n' % (self.OutputPath, PcdValueInitName) + 'APPNAME = %s\n' % (PcdValueInitName) + 'OBJECTS = %s\%s.obj %s.obj\n' % (self.OutputPath, PcdValueInitName, os.path.normpath(mws.join(GlobalData.gGlobalDefines["EDK_TOOLS_PATH"], "Source/C/Common/PcdValueCommon"))) + 'INC = '
         else:
             MakeApp = MakeApp + PcdGccMakefile
-            MakeApp = MakeApp + 'APPFILE = %s/%s\n' % (self.OutputPath, PcdValueInitName) + 'APPNAME = %s\n' % (PcdValueInitName) + 'OBJECTS = %s/%s.o\n' % (self.OutputPath, PcdValueInitName) + \
+            MakeApp = MakeApp + 'APPFILE = %s/%s\n' % (self.OutputPath, PcdValueInitName) + 'APPNAME = %s\n' % (PcdValueInitName) + 'OBJECTS = %s/%s.o %s.o\n' % (self.OutputPath, PcdValueInitName, os.path.normpath(mws.join(GlobalData.gGlobalDefines["EDK_TOOLS_PATH"], "Source/C/Common/PcdValueCommon"))) + \
                       'include $(MAKEROOT)/Makefiles/app.makefile\n' + 'INCLUDE +='
 
         IncSearchList = []
@@ -2739,8 +2736,8 @@ class DscBuildData(PlatformBuildClassObject):
                     IncludeFileFullPaths.append(os.path.normpath(includefullpath))
                     break
         SearchPathList = []
-        SearchPathList.append(os.path.normpath(mws.join(GlobalData.gWorkspace, "BaseTools/Source/C/Include")))
-        SearchPathList.append(os.path.normpath(mws.join(GlobalData.gWorkspace, "BaseTools/Source/C/Common")))
+        SearchPathList.append(os.path.normpath(mws.join(GlobalData.gGlobalDefines["EDK_TOOLS_PATH"], "BaseTools/Source/C/Include")))
+        SearchPathList.append(os.path.normpath(mws.join(GlobalData.gGlobalDefines["EDK_TOOLS_PATH"], "BaseTools/Source/C/Common")))
         SearchPathList.extend(str(item) for item in IncSearchList)
         IncFileList = GetDependencyList(IncludeFileFullPaths, SearchPathList)
         for include_file in IncFileList:
@@ -2768,6 +2765,7 @@ class DscBuildData(PlatformBuildClassObject):
             returncode, StdOut, StdErr = DscBuildData.ExecuteCommand (MakeCommand)
             Messages = StdErr
 
+        EdkLogger.verbose ('%s\n%s\n%s' % (MakeCommand, StdOut, StdErr))
         Messages = Messages.split('\n')
         MessageGroup = []
         if returncode != 0:
@@ -2777,16 +2775,21 @@ class DscBuildData(PlatformBuildClassObject):
             File.close()
             for Message in Messages:
                 if " error" in Message or "warning" in Message:
-                    FileInfo = Message.strip().split('(')
-                    if len (FileInfo) > 1:
-                        FileName = FileInfo [0]
-                        FileLine = FileInfo [1].split (')')[0]
-                    else:
-                        FileInfo = Message.strip().split(':')
-                        if len(FileInfo) < 2:
-                            continue
-                        FileName = FileInfo [0]
-                        FileLine = FileInfo [1]
+                    try:
+                        FileInfo = Message.strip().split('(')
+                        if len (FileInfo) > 1:
+                            FileName = FileInfo [0]
+                            FileLine = FileInfo [1].split (')')[0]
+                        else:
+                            FileInfo = Message.strip().split(':')
+                            if len(FileInfo) < 2:
+                                continue
+                            FileName = FileInfo [0]
+                            FileLine = FileInfo [1]
+                    except:
+                        continue
+                    if "PcdValueInit.c" not in FileName:
+                        continue
                     if FileLine.isdigit():
                         error_line = FileData[int (FileLine) - 1]
                         if r"//" in error_line:
@@ -2812,13 +2815,14 @@ class DscBuildData(PlatformBuildClassObject):
             if MessageGroup:
                 EdkLogger.error("build", PCD_STRUCTURE_PCD_ERROR, "\n".join(MessageGroup) )
             else:
-                EdkLogger.error('Build', COMMAND_FAILURE, 'Can not execute command: %s' % MakeCommand)
+                EdkLogger.error('Build', COMMAND_FAILURE, 'Can not execute command: %s\n%s\n%s' % (MakeCommand, StdOut, StdErr))
 
         if DscBuildData.NeedUpdateOutput(OutputValueFile, Dest_PcdValueInitExe, InputValueFile):
             Command = Dest_PcdValueInitExe + ' -i %s -o %s' % (InputValueFile, OutputValueFile)
             returncode, StdOut, StdErr = DscBuildData.ExecuteCommand (Command)
+            EdkLogger.verbose ('%s\n%s\n%s' % (Command, StdOut, StdErr))
             if returncode != 0:
-                EdkLogger.warn('Build', COMMAND_FAILURE, 'Can not collect output from command: %s' % Command)
+                EdkLogger.warn('Build', COMMAND_FAILURE, 'Can not collect output from command: %s\n%s\n' % (Command, StdOut, StdErr))
 
         File = open (OutputValueFile, 'r')
         FileBuffer = File.readlines()


### PR DESCRIPTION
https://bugzilla.tianocore.org/show_bug.cgi?id=2495
https://bugzilla.tianocore.org/show_bug.cgi?id=2496

* Remove use of Common.lib.  Use PcdValueCommon.c instead and remove
  PcdValueCommon.c from Common.lib.
* Fix 64-bit host build issues with fread()
* Setup VS2017/VS2019 env in BaseTools Plugin for CI builds.
* Improve log messages when the Structured PCD app fails to build or run.

Cc: Sean Brogan <sean.brogan@microsoft.com>
Cc: Bob Feng <bob.c.feng@intel.com>
Cc: Liming Gao <liming.gao@intel.com>
Signed-off-by: Michael D Kinney <michael.d.kinney@intel.com>
