### PR TITLE
SecurityPkg/TcgPhysicalPresenceLib: Replace the ASSERT with error code

### DIFF
--- a/SecurityPkg/Library/DxeTcgPhysicalPresenceLib/DxeTcgPhysicalPresenceLib.c
+++ b/SecurityPkg/Library/DxeTcgPhysicalPresenceLib/DxeTcgPhysicalPresenceLib.c
@@ -102,9 +102,13 @@ GetTpmCapability (
                           sizeof (RecvBuffer),
                           (UINT8*)&RecvBuffer
                           );
-  ASSERT_EFI_ERROR (Status);
-  ASSERT (TpmRsp->tag == SwapBytes16 (TPM_TAG_RSP_COMMAND));
-  ASSERT (TpmRsp->returnCode == 0);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  if ((TpmRsp->tag != SwapBytes16 (TPM_TAG_RSP_COMMAND)) || (TpmRsp->returnCode != 0)) {
+    return EFI_DEVICE_ERROR;
+  }
 
   TpmPermanentFlags = (TPM_PERMANENT_FLAGS *)&RecvBuffer[sizeof (TPM_RSP_COMMAND_HDR) + sizeof (UINT32)];
 
@@ -157,8 +161,14 @@ TpmPhysicalPresence (
                           sizeof (TpmRsp),
                           (UINT8*)&TpmRsp
                           );
-  ASSERT_EFI_ERROR (Status);
-  ASSERT (TpmRsp.tag == SwapBytes16 (TPM_TAG_RSP_COMMAND));
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  if (TpmRsp.tag != SwapBytes16 (TPM_TAG_RSP_COMMAND)) {
+    return EFI_DEVICE_ERROR;
+  }
+
   if (TpmRsp.returnCode != 0) {
     //
     // If it fails, some requirements may be needed for this command.
@@ -1273,7 +1283,10 @@ TcgPhysicalPresenceLibProcessRequest (
   //
   // Set operator physical presence flags
   //
-  TpmPhysicalPresence (TcgProtocol, TPM_PHYSICAL_PRESENCE_PRESENT);
+  Status = TpmPhysicalPresence (TcgProtocol, TPM_PHYSICAL_PRESENCE_PRESENT);
+  if (EFI_ERROR (Status)) {
+    return;
+  }
 
   //
   // Execute pending TPM request.


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=2472

Replace the ASSERT with the error code return in the TpmPhysicalPresence
and GetTpmCapability.
Add missing error checking after call TpmPhysicalPresence in
TcgPhysicalPresenceLibProcessRequest.

Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Chao Zhang <chao.b.zhang@intel.com>
Reviewed-by: Jiewen Yao <jiewen.yao@intel.com>
Signed-off-by: Zhichao Gao <zhichao.gao@intel.com>