### PR TITLE
MdeModulePkg/PiDxeS3BootScriptLib: Fix potential numeric truncation (…

### DIFF
--- a/MdeModulePkg/Library/PiDxeS3BootScriptLib/BootScriptSave.c
+++ b/MdeModulePkg/Library/PiDxeS3BootScriptLib/BootScriptSave.c
@@ -1,7 +1,7 @@
 /** @file
   Save the S3 data to S3 boot script.
 
-  Copyright (c) 2006 - 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2006 - 2020, Intel Corporation. All rights reserved.<BR>
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -1006,6 +1006,14 @@ S3BootScriptSaveIoWrite (
   EFI_BOOT_SCRIPT_IO_WRITE  ScriptIoWrite;
 
   WidthInByte = (UINT8) (0x01 << (Width & 0x03));
+
+  //
+  // Truncation check
+  //
+  if ((Count > MAX_UINT8) ||
+      (WidthInByte * Count > MAX_UINT8 - sizeof (EFI_BOOT_SCRIPT_IO_WRITE))) {
+    return RETURN_OUT_OF_RESOURCES;
+  }
   Length = (UINT8)(sizeof (EFI_BOOT_SCRIPT_IO_WRITE) + (WidthInByte * Count));
 
   Script = S3BootScriptGetEntryAddAddress (Length);
@@ -1102,6 +1110,14 @@ S3BootScriptSaveMemWrite (
   EFI_BOOT_SCRIPT_MEM_WRITE  ScriptMemWrite;
 
   WidthInByte = (UINT8) (0x01 << (Width & 0x03));
+
+  //
+  // Truncation check
+  //
+  if ((Count > MAX_UINT8) ||
+      (WidthInByte * Count > MAX_UINT8 - sizeof (EFI_BOOT_SCRIPT_MEM_WRITE))) {
+    return RETURN_OUT_OF_RESOURCES;
+  }
   Length = (UINT8)(sizeof (EFI_BOOT_SCRIPT_MEM_WRITE) + (WidthInByte * Count));
 
   Script = S3BootScriptGetEntryAddAddress (Length);
@@ -1206,6 +1222,14 @@ S3BootScriptSavePciCfgWrite (
   }
 
   WidthInByte = (UINT8) (0x01 << (Width & 0x03));
+
+  //
+  // Truncation check
+  //
+  if ((Count > MAX_UINT8) ||
+      (WidthInByte * Count > MAX_UINT8 - sizeof (EFI_BOOT_SCRIPT_PCI_CONFIG_WRITE))) {
+    return RETURN_OUT_OF_RESOURCES;
+  }
   Length = (UINT8)(sizeof (EFI_BOOT_SCRIPT_PCI_CONFIG_WRITE) + (WidthInByte * Count));
 
   Script = S3BootScriptGetEntryAddAddress (Length);
@@ -1324,6 +1348,14 @@ S3BootScriptSavePciCfg2Write (
   }
 
   WidthInByte = (UINT8) (0x01 << (Width & 0x03));
+
+  //
+  // Truncation check
+  //
+  if ((Count > MAX_UINT8) ||
+      (WidthInByte * Count > MAX_UINT8 - sizeof (EFI_BOOT_SCRIPT_PCI_CONFIG2_WRITE))) {
+    return RETURN_OUT_OF_RESOURCES;
+  }
   Length = (UINT8)(sizeof (EFI_BOOT_SCRIPT_PCI_CONFIG2_WRITE) + (WidthInByte * Count));
 
   Script = S3BootScriptGetEntryAddAddress (Length);
@@ -1549,6 +1581,12 @@ S3BootScriptSaveSmbusExecute (
     return Status;
   }
 
+  //
+  // Truncation check
+  //
+  if (BufferLength > MAX_UINT8 - sizeof (EFI_BOOT_SCRIPT_SMBUS_EXECUTE)) {
+    return RETURN_OUT_OF_RESOURCES;
+  }
   DataSize = (UINT8)(sizeof (EFI_BOOT_SCRIPT_SMBUS_EXECUTE) + BufferLength);
 
   Script = S3BootScriptGetEntryAddAddress (DataSize);
@@ -1736,6 +1774,12 @@ S3BootScriptSaveInformation (
   UINT8                 *Script;
   EFI_BOOT_SCRIPT_INFORMATION  ScriptInformation;
 
+  //
+  // Truncation check
+  //
+  if (InformationLength > MAX_UINT8 - sizeof (EFI_BOOT_SCRIPT_INFORMATION)) {
+    return RETURN_OUT_OF_RESOURCES;
+  }
   Length = (UINT8)(sizeof (EFI_BOOT_SCRIPT_INFORMATION) + InformationLength);
 
   Script = S3BootScriptGetEntryAddAddress (Length);
@@ -2195,6 +2239,12 @@ S3BootScriptLabelInternal (
   UINT8                 *Script;
   EFI_BOOT_SCRIPT_INFORMATION  ScriptInformation;
 
+  //
+  // Truncation check
+  //
+  if (InformationLength > MAX_UINT8 - sizeof (EFI_BOOT_SCRIPT_INFORMATION)) {
+    return RETURN_OUT_OF_RESOURCES;
+  }
   Length = (UINT8)(sizeof (EFI_BOOT_SCRIPT_INFORMATION) + InformationLength);
 
   Script = S3BootScriptGetEntryAddAddress (Length);


### PR DESCRIPTION
…CVE-2019-14563)

REF:https://bugzilla.tianocore.org/show_bug.cgi?id=2001

For S3BootScriptLib APIs:

S3BootScriptSaveIoWrite
S3BootScriptSaveMemWrite
S3BootScriptSavePciCfgWrite
S3BootScriptSavePciCfg2Write
S3BootScriptSaveSmbusExecute
S3BootScriptSaveInformation
S3BootScriptSaveInformationAsciiString
S3BootScriptLabel (happen in S3BootScriptLabelInternal())

possible numeric truncations will happen that may lead to S3 boot script
entry with improper size being returned to store the boot script data.
This commit will add checks to prevent this kind of issue.

Please note that the remaining S3BootScriptLib APIs:

S3BootScriptSaveIoReadWrite
S3BootScriptSaveMemReadWrite
S3BootScriptSavePciCfgReadWrite
S3BootScriptSavePciCfg2ReadWrite
S3BootScriptSaveStall
S3BootScriptSaveDispatch2
S3BootScriptSaveDispatch
S3BootScriptSaveMemPoll
S3BootScriptSaveIoPoll
S3BootScriptSavePciPoll
S3BootScriptSavePci2Poll
S3BootScriptCloseTable
S3BootScriptExecute
S3BootScriptMoveLastOpcode
S3BootScriptCompare

are not affected by such numeric truncation.

Signed-off-by: Hao A Wu <hao.a.wu@intel.com>
Reviewed-by: Laszlo Ersek <lersek@redhat.com>
Reviewed-by: Eric Dong <eric.dong@intel.com>
Acked-by: Jian J Wang <jian.j.wang@intel.com>