### PR TITLE
SecurityPkg: Fix incorrect return value when File is NULL

### DIFF
--- a/SecurityPkg/Library/DxeTpm2MeasureBootLib/DxeTpm2MeasureBootLib.c
+++ b/SecurityPkg/Library/DxeTpm2MeasureBootLib/DxeTpm2MeasureBootLib.c
@@ -384,7 +384,7 @@ Finish:
   and other exception operations.  The File parameter allows for possible logging
   within the SAP of the driver.
 
-  If File is NULL, then EFI_INVALID_PARAMETER is returned.
+  If File is NULL, then EFI_ACCESS_DENIED is returned.
 
   If the file specified by File with an authentication status specified by
   AuthenticationStatus is safe for the DXE Core to use, then EFI_SUCCESS is returned.
@@ -434,6 +434,13 @@ DxeTpm2MeasureBootHandler (
   EFI_FIRMWARE_VOLUME_BLOCK_PROTOCOL  *FvbProtocol;
   EFI_PHYSICAL_ADDRESS                FvAddress;
   UINT32                              Index;
+
+  //
+  // Check for invalid parameters.
+  //
+  if (File == NULL) {
+    return EFI_ACCESS_DENIED;
+  }
 
   Status = gBS->LocateProtocol (&gEfiTcg2ProtocolGuid, NULL, (VOID **) &Tcg2Protocol);
   if (EFI_ERROR (Status)) {

--- a/SecurityPkg/Library/DxeTpmMeasureBootLib/DxeTpmMeasureBootLib.c
+++ b/SecurityPkg/Library/DxeTpmMeasureBootLib/DxeTpmMeasureBootLib.c
@@ -678,7 +678,7 @@ Finish:
   and other exception operations.  The File parameter allows for possible logging
   within the SAP of the driver.
 
-  If File is NULL, then EFI_INVALID_PARAMETER is returned.
+  If File is NULL, then EFI_ACCESS_DENIED is returned.
 
   If the file specified by File with an authentication status specified by
   AuthenticationStatus is safe for the DXE Core to use, then EFI_SUCCESS is returned.
@@ -731,6 +731,13 @@ DxeTpmMeasureBootHandler (
   EFI_FIRMWARE_VOLUME_BLOCK_PROTOCOL  *FvbProtocol;
   EFI_PHYSICAL_ADDRESS                FvAddress;
   UINT32                              Index;
+
+  //
+  // Check for invalid parameters.
+  //
+  if (File == NULL) {
+    return EFI_ACCESS_DENIED;
+  }
 
   Status = gBS->LocateProtocol (&gEfiTcgProtocolGuid, NULL, (VOID **) &TcgProtocol);
   if (EFI_ERROR (Status)) {


### PR DESCRIPTION
The DxeTpmMeasureBootHandler and DxeTpm2MeasureBootHandler handlers
are SECURITY2_FILE_AUTHENTICATION_HANDLER prototype. This prototype
can not return EFI_INVALID_PARAMETER.

The prototype documentation states it returns EFI_ACCESS_DENIED if:

  "The file specified by File and FileBuffer did not authenticate,
   and the platform policy dictates that the DXE Foundation may not
   use File."

Correct the documentation, and add a early check, returning
EFI_ACCESS_DENIED when File is NULL.

Noticed while reviewing commit 6d57592740cdd0b6868baeef7929d6e6fef.

Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Chao Zhang <chao.b.zhang@intel.com>
Signed-off-by: Philippe Mathieu-Daude <philmd@redhat.com>
Reviewed-by: Laszlo Ersek <lersek@redhat.com>
Reviewed-by: Jian J Wang <jian.j.wang@intel.com>