### PR TITLE
ShellPkg: Validate global pointer before use

### DIFF
--- a/ShellPkg/Application/Shell/ShellParametersProtocol.c
+++ b/ShellPkg/Application/Shell/ShellParametersProtocol.c
@@ -185,6 +185,7 @@ DEBUG_CODE_END();
   @param[in, out] Argc            pointer to number of strings in Argv array
 
   @return EFI_SUCCESS           the operation was successful
+  @return EFI_INVALID_PARAMETER some parameters are invalid
   @return EFI_OUT_OF_RESOURCES  a memory allocation failed.
 **/
 EFI_STATUS

--- a/ShellPkg/Application/Shell/ShellParametersProtocol.c
+++ b/ShellPkg/Application/Shell/ShellParametersProtocol.c
@@ -1340,7 +1340,9 @@ RestoreStdInStdOutStdErr (
   @param[out] OldArgv                    Pointer to old list of parameters.
   @param[out] OldArgc                    Pointer to old number of items in Argv list.
 
+
   @retval   EFI_SUCCESS                 Operation was successful, Argv and Argc are valid.
+  @return   EFI_INVALID_PARAMETER       Some parameters are invalid.
   @retval   EFI_OUT_OF_RESOURCES        A memory allocation failed.
 **/
 EFI_STATUS

--- a/ShellPkg/Application/Shell/ShellParametersProtocol.h
+++ b/ShellPkg/Application/Shell/ShellParametersProtocol.h
@@ -71,6 +71,7 @@ CleanUpShellParametersProtocol (
   @param[out] OldArgc                   pointer to old number of items in Argv list
 
   @retval   EFI_SUCCESS                 operation was successful, Argv and Argc are valid
+  @return   EFI_INVALID_PARAMETER       some parameters are invalid
   @retval   EFI_OUT_OF_RESOURCES        a memory allocation failed.
 **/
 EFI_STATUS

--- a/ShellPkg/Application/Shell/ShellParametersProtocol.h
+++ b/ShellPkg/Application/Shell/ShellParametersProtocol.h
@@ -167,6 +167,7 @@ RestoreStdInStdOutStdErr (
   @param[in, out] Argc            pointer to number of strings in Argv array
 
   @return EFI_SUCCESS           the operation was successful
+  @return EFI_INVALID_PARAMETER some parameters are invalid
   @return EFI_OUT_OF_RESOURCES  a memory allocation failed.
 **/
 EFI_STATUS

--- a/ShellPkg/Library/UefiShellAcpiViewCommandLib/AcpiParser.c
+++ b/ShellPkg/Library/UefiShellAcpiViewCommandLib/AcpiParser.c
@@ -543,8 +543,15 @@ ParseAcpi (
 
   for (Index = 0; Index < ParserItems; Index++) {
     if ((Offset + Parser[Index].Length) > Length) {
+
+      // For fields outside the buffer length provided, reset any pointers
+      // which were supposed to be updated by this function call
+      if (Parser[Index].ItemPtr != NULL) {
+        *Parser[Index].ItemPtr = NULL;
+      }
+
       // We don't parse past the end of the max length specified
-      break;
+      continue;
     }
 
     if (GetConsistencyChecking () &&

--- a/ShellPkg/Library/UefiShellAcpiViewCommandLib/Parsers/Dbg2/Dbg2Parser.c
+++ b/ShellPkg/Library/UefiShellAcpiViewCommandLib/Parsers/Dbg2/Dbg2Parser.c
@@ -123,6 +123,24 @@ DumpDbgDeviceInfo (
     PARSER_PARAMS (DbgDevInfoParser)
     );
 
+  // Check if the values used to control the parsing logic have been
+  // successfully read.
+  if ((GasCount == NULL)              ||
+      (NameSpaceStringLength == NULL) ||
+      (NameSpaceStringOffset == NULL) ||
+      (OEMDataLength == NULL)         ||
+      (OEMDataOffset == NULL)         ||
+      (BaseAddrRegOffset == NULL)     ||
+      (AddrSizeOffset == NULL)) {
+    IncrementErrorCount ();
+    Print (
+      L"ERROR: Insufficient Debug Device Information Structure length. " \
+        L"Length = %d.\n",
+      Length
+      );
+    return;
+  }
+
   // GAS
   Index = 0;
   Offset = *BaseAddrRegOffset;
@@ -224,6 +242,18 @@ ParseAcpiDbg2 (
              PARSER_PARAMS (Dbg2Parser)
              );
 
+  // Check if the values used to control the parsing logic have been
+  // successfully read.
+  if ((OffsetDbgDeviceInfo == NULL) ||
+      (NumberDbgDeviceInfo == NULL)) {
+    IncrementErrorCount ();
+    Print (
+      L"ERROR: Insufficient table length. AcpiTableLength = %d\n",
+      AcpiTableLength
+      );
+    return;
+  }
+
   Offset = *OffsetDbgDeviceInfo;
   Index = 0;
 
@@ -238,6 +268,19 @@ ParseAcpiDbg2 (
       AcpiTableLength - Offset,
       PARSER_PARAMS (DbgDevInfoHeaderParser)
       );
+
+    // Check if the values used to control the parsing logic have been
+    // successfully read.
+    if (DbgDevInfoLen == NULL) {
+      IncrementErrorCount ();
+      Print (
+        L"ERROR: Insufficient remaining table buffer length to read the " \
+          L"Debug Device Information structure's 'Length' field. " \
+          L"RemainingTableBufferLength = %d.\n",
+        AcpiTableLength - Offset
+        );
+      return;
+    }
 
     // Make sure the Debug Device Information structure lies inside the table.
     if ((Offset + *DbgDevInfoLen) > AcpiTableLength) {

--- a/ShellPkg/Library/UefiShellAcpiViewCommandLib/Parsers/Fadt/FadtParser.c
+++ b/ShellPkg/Library/UefiShellAcpiViewCommandLib/Parsers/Fadt/FadtParser.c
@@ -1,7 +1,7 @@
 /** @file
   FADT table parser
 
-  Copyright (c) 2016 - 2019, ARM Limited. All rights reserved.
+  Copyright (c) 2016 - 2020, ARM Limited. All rights reserved.
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
   @par Reference(s):
@@ -230,9 +230,11 @@ ParseAcpiFadt (
     );
 
   if (Trace) {
-    Print (L"\nSummary:\n");
-    PrintFieldName (2, L"FADT Version");
-    Print (L"%d.%d\n",  *AcpiHdrInfo.Revision, *FadtMinorRevision);
+    if (FadtMinorRevision != NULL) {
+      Print (L"\nSummary:\n");
+      PrintFieldName (2, L"FADT Version");
+      Print (L"%d.%d\n",  *AcpiHdrInfo.Revision, *FadtMinorRevision);
+    }
 
     if (*GetAcpiXsdtHeaderInfo ()->OemTableId != *AcpiHdrInfo.OemTableId) {
       IncrementErrorCount ();
@@ -294,21 +296,20 @@ ParseAcpiFadt (
       );
   }
 
-  // If X_DSDT is not zero then use X_DSDT and ignore DSDT,
-  // else use DSDT.
-  if (*X_DsdtAddress != 0) {
+  // If X_DSDT is valid then use X_DSDT and ignore DSDT, else use DSDT.
+  if ((X_DsdtAddress != NULL) && (*X_DsdtAddress != 0)) {
     DsdtPtr = (UINT8*)(UINTN)(*X_DsdtAddress);
-  } else if (*DsdtAddress != 0) {
+  } else if ((DsdtAddress != NULL) && (*DsdtAddress != 0)) {
     DsdtPtr = (UINT8*)(UINTN)(*DsdtAddress);
   } else {
-    // Both DSDT and X_DSDT cannot be zero.
+    // Both DSDT and X_DSDT cannot be invalid.
 #if defined (MDE_CPU_ARM) || defined (MDE_CPU_AARCH64)
     if (Trace) {
       // The DSDT Table is mandatory for ARM systems
       // as the CPU information MUST be presented in
       // the DSDT.
       IncrementErrorCount ();
-      Print (L"ERROR: Both X_DSDT and DSDT are NULL.\n");
+      Print (L"ERROR: Both X_DSDT and DSDT are invalid.\n");
     }
 #endif
     return;

--- a/ShellPkg/Library/UefiShellAcpiViewCommandLib/Parsers/Fadt/FadtParser.c
+++ b/ShellPkg/Library/UefiShellAcpiViewCommandLib/Parsers/Fadt/FadtParser.c
@@ -253,7 +253,7 @@ ParseAcpiFadt (
     // present.
     if ((Trace) &&
         (Flags != NULL) &&
-        ((*Flags & EFI_ACPI_6_3_HW_REDUCED_ACPI) != 0)) {
+        ((*Flags & EFI_ACPI_6_3_HW_REDUCED_ACPI) != EFI_ACPI_6_3_HW_REDUCED_ACPI)) {
       IncrementErrorCount ();
       Print (L"ERROR: No FACS table found, "
                L"both X_FIRMWARE_CTRL and FIRMWARE_CTRL are zero.\n");

--- a/ShellPkg/Library/UefiShellAcpiViewCommandLib/Parsers/Gtdt/GtdtParser.c
+++ b/ShellPkg/Library/UefiShellAcpiViewCommandLib/Parsers/Gtdt/GtdtParser.c
@@ -189,6 +189,18 @@ DumpGTBlock (
     PARSER_PARAMS (GtBlockParser)
     );
 
+  // Check if the values used to control the parsing logic have been
+  // successfully read.
+  if ((GtBlockTimerCount == NULL) ||
+      (GtBlockTimerOffset == NULL)) {
+    IncrementErrorCount ();
+    Print (
+      L"ERROR: Insufficient GT Block Structure length. Length = %d.\n",
+      Length
+      );
+    return;
+  }
+
   Offset = *GtBlockTimerOffset;
   Index = 0;
 
@@ -272,6 +284,18 @@ ParseAcpiGtdt (
     PARSER_PARAMS (GtdtParser)
     );
 
+  // Check if the values used to control the parsing logic have been
+  // successfully read.
+  if ((GtdtPlatformTimerCount == NULL) ||
+      (GtdtPlatformTimerOffset == NULL)) {
+    IncrementErrorCount ();
+    Print (
+      L"ERROR: Insufficient table length. AcpiTableLength = %d.\n",
+      AcpiTableLength
+      );
+    return;
+  }
+
   TimerPtr = Ptr + *GtdtPlatformTimerOffset;
   Offset = *GtdtPlatformTimerOffset;
   Index = 0;
@@ -289,6 +313,19 @@ ParseAcpiGtdt (
       AcpiTableLength - Offset,
       PARSER_PARAMS (GtPlatformTimerHeaderParser)
       );
+
+    // Check if the values used to control the parsing logic have been
+    // successfully read.
+    if ((PlatformTimerType == NULL) ||
+        (PlatformTimerLength == NULL)) {
+      IncrementErrorCount ();
+      Print (
+        L"ERROR: Insufficient remaining table buffer length to read the " \
+          L"Platform Timer Structure header. Length = %d.\n",
+        AcpiTableLength - Offset
+        );
+      return;
+    }
 
     // Make sure the Platform Timer is inside the table.
     if ((Offset + *PlatformTimerLength) > AcpiTableLength) {

--- a/ShellPkg/Library/UefiShellAcpiViewCommandLib/Parsers/Iort/IortParser.c
+++ b/ShellPkg/Library/UefiShellAcpiViewCommandLib/Parsers/Iort/IortParser.c
@@ -322,6 +322,20 @@ DumpIortNodeSmmuV1V2 (
     PARSER_PARAMS (IortNodeSmmuV1V2Parser)
     );
 
+  // Check if the values used to control the parsing logic have been
+  // successfully read.
+  if ((InterruptContextCount == NULL)   ||
+      (InterruptContextOffset == NULL)  ||
+      (PmuInterruptCount == NULL)       ||
+      (PmuInterruptOffset == NULL)) {
+    IncrementErrorCount ();
+    Print (
+      L"ERROR: Insufficient SMMUv1/2 node length. Length = %d\n",
+      Length
+      );
+    return;
+  }
+
   Offset = *InterruptContextOffset;
   Index = 0;
 
@@ -432,6 +446,17 @@ DumpIortNodeIts (
             Length,
             PARSER_PARAMS (IortNodeItsParser)
             );
+
+  // Check if the values used to control the parsing logic have been
+  // successfully read.
+  if (ItsCount == NULL) {
+    IncrementErrorCount ();
+    Print (
+      L"ERROR: Insufficient ITS group length. Length = %d.\n",
+      Length
+      );
+    return;
+  }
 
   Index = 0;
 
@@ -617,6 +642,18 @@ ParseAcpiIort (
     PARSER_PARAMS (IortParser)
     );
 
+  // Check if the values used to control the parsing logic have been
+  // successfully read.
+  if ((IortNodeCount == NULL) ||
+      (IortNodeOffset == NULL)) {
+    IncrementErrorCount ();
+    Print (
+      L"ERROR: Insufficient table length. AcpiTableLength = %d.\n",
+      AcpiTableLength
+      );
+    return;
+  }
+
   Offset = *IortNodeOffset;
   NodePtr = Ptr + Offset;
   Index = 0;
@@ -634,6 +671,21 @@ ParseAcpiIort (
       AcpiTableLength - Offset,
       PARSER_PARAMS (IortNodeHeaderParser)
       );
+
+    // Check if the values used to control the parsing logic have been
+    // successfully read.
+    if ((IortNodeType == NULL)        ||
+        (IortNodeLength == NULL)      ||
+        (IortIdMappingCount == NULL)  ||
+        (IortIdMappingOffset == NULL)) {
+      IncrementErrorCount ();
+      Print (
+        L"ERROR: Insufficient remaining table buffer length to read the " \
+          L"IORT node header. Length = %d.\n",
+        AcpiTableLength - Offset
+        );
+      return;
+    }
 
     // Make sure the IORT Node is inside the table
     if ((Offset + (*IortNodeLength)) > AcpiTableLength) {

--- a/ShellPkg/Library/UefiShellAcpiViewCommandLib/Parsers/Madt/MadtParser.c
+++ b/ShellPkg/Library/UefiShellAcpiViewCommandLib/Parsers/Madt/MadtParser.c
@@ -260,6 +260,19 @@ ParseAcpiMadt (
       PARSER_PARAMS (MadtInterruptControllerHeaderParser)
       );
 
+    // Check if the values used to control the parsing logic have been
+    // successfully read.
+    if ((MadtInterruptControllerType == NULL) ||
+        (MadtInterruptControllerLength == NULL)) {
+      IncrementErrorCount ();
+      Print (
+        L"ERROR: Insufficient remaining table buffer length to read the " \
+          L"Interrupt Controller Structure header. Length = %d.\n",
+        AcpiTableLength - Offset
+        );
+      return;
+    }
+
     // Make sure forward progress is made.
     if (*MadtInterruptControllerLength < 2) {
       IncrementErrorCount ();

--- a/ShellPkg/Library/UefiShellAcpiViewCommandLib/Parsers/Pptt/PpttParser.c
+++ b/ShellPkg/Library/UefiShellAcpiViewCommandLib/Parsers/Pptt/PpttParser.c
@@ -264,6 +264,17 @@ DumpProcessorHierarchyNodeStructure (
              PARSER_PARAMS (ProcessorHierarchyNodeStructureParser)
              );
 
+  // Check if the values used to control the parsing logic have been
+  // successfully read.
+  if (NumberOfPrivateResources == NULL) {
+    IncrementErrorCount ();
+    Print (
+      L"ERROR: Insufficient Processor Hierarchy Node length. Length = %d.\n",
+      Length
+      );
+    return;
+  }
+
   // Make sure the Private Resource array lies inside this structure
   if (Offset + (*NumberOfPrivateResources * sizeof (UINT32)) > Length) {
     IncrementErrorCount ();
@@ -387,6 +398,7 @@ ParseAcpiPptt (
              AcpiTableLength,
              PARSER_PARAMS (PpttParser)
              );
+
   ProcessorTopologyStructurePtr = Ptr + Offset;
 
   while (Offset < AcpiTableLength) {
@@ -399,6 +411,19 @@ ParseAcpiPptt (
       AcpiTableLength - Offset,
       PARSER_PARAMS (ProcessorTopologyStructureHeaderParser)
       );
+
+    // Check if the values used to control the parsing logic have been
+    // successfully read.
+    if ((ProcessorTopologyStructureType == NULL) ||
+        (ProcessorTopologyStructureLength == NULL)) {
+      IncrementErrorCount ();
+      Print (
+        L"ERROR: Insufficient remaining table buffer length to read the " \
+          L"processor topology structure header. Length = %d.\n",
+        AcpiTableLength - Offset
+        );
+      return;
+    }
 
     // Make sure the PPTT structure lies inside the table
     if ((Offset + *ProcessorTopologyStructureLength) > AcpiTableLength) {

--- a/ShellPkg/Library/UefiShellAcpiViewCommandLib/Parsers/Rsdp/RsdpParser.c
+++ b/ShellPkg/Library/UefiShellAcpiViewCommandLib/Parsers/Rsdp/RsdpParser.c
@@ -138,6 +138,18 @@ ParseAcpiRsdp (
     PARSER_PARAMS (RsdpParser)
     );
 
+  // Check if the values used to control the parsing logic have been
+  // successfully read.
+  if (XsdtAddress == NULL) {
+    IncrementErrorCount ();
+    Print (
+      L"ERROR: Insufficient table length. AcpiTableLength = %d." \
+        L"RSDP parsing aborted.\n",
+      AcpiTableLength
+      );
+    return;
+  }
+
   // This code currently supports parsing of XSDT table only
   // and does not parse the RSDT table. Platforms provide the
   // RSDT to enable compatibility with ACPI 1.0 operating systems.

--- a/ShellPkg/Library/UefiShellAcpiViewCommandLib/Parsers/Slit/SlitParser.c
+++ b/ShellPkg/Library/UefiShellAcpiViewCommandLib/Parsers/Slit/SlitParser.c
@@ -1,7 +1,7 @@
 /** @file
   SLIT table parser
 
-  Copyright (c) 2016 - 2018, ARM Limited. All rights reserved.
+  Copyright (c) 2016 - 2019, ARM Limited. All rights reserved.
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
   @par Reference(s):
@@ -75,9 +75,21 @@ ParseAcpiSlit (
              AcpiTableLength,
              PARSER_PARAMS (SlitParser)
              );
-  LocalityPtr = Ptr + Offset;
 
+  // Check if the values used to control the parsing logic have been
+  // successfully read.
+  if (SlitSystemLocalityCount == NULL) {
+    IncrementErrorCount ();
+    Print (
+      L"ERROR: Insufficient table length. AcpiTableLength = %d.\n",
+      AcpiTableLength
+      );
+    return;
+  }
+
+  LocalityPtr = Ptr + Offset;
   LocalityCount = *SlitSystemLocalityCount;
+
   // We only print the Localities if the count is less than 16
   // If the locality count is more than 16 then refer to the
   // raw data dump.

--- a/ShellPkg/Library/UefiShellAcpiViewCommandLib/Parsers/Srat/SratParser.c
+++ b/ShellPkg/Library/UefiShellAcpiViewCommandLib/Parsers/Srat/SratParser.c
@@ -399,6 +399,19 @@ ParseAcpiSrat (
       PARSER_PARAMS (SratResourceAllocationParser)
       );
 
+    // Check if the values used to control the parsing logic have been
+    // successfully read.
+    if ((SratRAType == NULL) ||
+        (SratRALength == NULL)) {
+      IncrementErrorCount ();
+      Print (
+        L"ERROR: Insufficient remaining table buffer length to read the " \
+          L"Static Resource Allocation structure header. Length = %d.\n",
+        AcpiTableLength - Offset
+        );
+      return;
+    }
+
     // Make sure the SRAT structure lies inside the table
     if ((Offset + *SratRALength) > AcpiTableLength) {
       IncrementErrorCount ();


### PR DESCRIPTION
Check if global pointers have been successfully updated before they
are used for further table parsing.
