### PR TITLE
MdePkg/SmBios.h: Add two additional DWORD for smbios 3.3.0 type17

### DIFF
--- a/MdePkg/Include/IndustryStandard/SmBios.h
+++ b/MdePkg/Include/IndustryStandard/SmBios.h
@@ -1843,6 +1843,11 @@ typedef struct {
   UINT64                                    VolatileSize;
   UINT64                                    CacheSize;
   UINT64                                    LogicalSize;
+  //
+  // Add for smbios 3.3.0
+  //
+  UINT32                                    ExtendedSpeed;
+  UINT32                                    ExtendedConfiguredMemorySpeed;
 } SMBIOS_TABLE_TYPE17;
 
 ///


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=2482

Refer to DSP0134_3.3.0.pdf, there are two additional DWORD added
for type 17. One is "Extended Speed", the other is "Extended
Configured Memory Speed". The lack of these field may cause strange
error in some operating systems.

Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Liming Gao <liming.gao@intel.com>
Signed-off-by: Zhichao Gao <zhichao.gao@intel.com>
Reviewed-by: Liming Gao <liming.gao@intel.com>