### PR TITLE
UnitTestFrameworkPkg/UnitTestLib: Fix XCODE parenthesis issues

### DIFF
--- a/UnitTestFrameworkPkg/Library/UnitTestLib/Assert.c
+++ b/UnitTestFrameworkPkg/Library/UnitTestLib/Assert.c
@@ -247,7 +247,7 @@ UnitTestAssertEqual (
   IN CONST CHAR8  *DescriptionB
   )
 {
-  if ((ValueA != ValueB)) {
+  if (ValueA != ValueB) {
     UnitTestLogFailure (
       FAILURETYPE_ASSERTEQUAL,
       "%a::%d Value %a != %a (%d != %d)!\n",
@@ -365,7 +365,7 @@ UnitTestAssertNotEqual (
   IN CONST CHAR8  *DescriptionB
   )
 {
-  if ((ValueA == ValueB)) {
+  if (ValueA == ValueB) {
     UnitTestLogFailure (
       FAILURETYPE_ASSERTNOTEQUAL,
       "%a::%d Value %a == %a (%d == %d)!\n",
@@ -420,7 +420,7 @@ UnitTestAssertStatusEqual (
   IN CONST CHAR8  *Description
   )
 {
-  if ((Status != Expected)) {
+  if (Status != Expected) {
     UnitTestLogFailure (
       FAILURETYPE_ASSERTSTATUSEQUAL,
       "%a::%d Status '%a' is %r, should be %r!\n",

--- a/UnitTestFrameworkPkg/Library/UnitTestLib/Log.c
+++ b/UnitTestFrameworkPkg/Library/UnitTestLib/Log.c
@@ -136,7 +136,7 @@ UnitTestLogInit (
     return;
   }
 
-  if((Buffer != NULL) && (BufferSize > 0) && ((BufferSize <= UNIT_TEST_MAX_LOG_BUFFER))) {
+  if((Buffer != NULL) && (BufferSize > 0) && (BufferSize <= UNIT_TEST_MAX_LOG_BUFFER)) {
     CopyMem (Test->Log, Buffer, BufferSize);
   }
 }


### PR DESCRIPTION
https://bugzilla.tianocore.org/show_bug.cgi?id=2512

Remove extra sets of parenthesis that generate warnings on XCODE5
builds.

Cc: Sean Brogan <sean.brogan@microsoft.com>
Cc: Bret Barkelew <Bret.Barkelew@microsoft.com>
Signed-off-by: Michael D Kinney <michael.d.kinney@intel.com>
Reviewed-by: Sean Brogan <sean.brogan@microsoft.com>