### PR TITLE
BaseTools:fix Ecc tool issue for check StructPcd

### DIFF
--- a/BaseTools/Source/Python/Ecc/MetaFileWorkspace/MetaFileParser.py
+++ b/BaseTools/Source/Python/Ecc/MetaFileWorkspace/MetaFileParser.py
@@ -1,7 +1,7 @@
 ## @file
 # This file is used to parse meta files
 #
-# Copyright (c) 2008 - 2018, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2008 - 2020, Intel Corporation. All rights reserved.<BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 
@@ -13,7 +13,7 @@ import Common.LongFilePathOs as os
 import re
 import time
 import copy
-
+from hashlib import md5
 import Common.EdkLogger as EdkLogger
 import Common.GlobalData as GlobalData
 import Ecc.EccGlobalData as EccGlobalData
@@ -1498,6 +1498,10 @@ class DecParser(MetaFileParser):
         self.TblFile = EccGlobalData.gDb.TblFile
         self.FileID = -1
 
+        self._CurrentStructurePcdName = ""
+        self._include_flag = False
+        self._package_flag = False
+
     ## Parser starter
     def Start(self):
         Content = ''
@@ -1692,6 +1696,62 @@ class DecParser(MetaFileParser):
                             File=self.MetaFile, Line=self._LineIndex+1)
             self._ValueList[0] = ''
 
+    def ParsePcdName(self,namelist):
+        if "[" in namelist[1]:
+            pcdname = namelist[1][:namelist[1].index("[")]
+            arrayindex = namelist[1][namelist[1].index("["):]
+            namelist[1] = pcdname
+            if len(namelist) == 2:
+                namelist.append(arrayindex)
+            else:
+                namelist[2] = ".".join((arrayindex,namelist[2]))
+        return namelist
+
+    def StructPcdParser(self):
+        self._ValueList[0] = self._CurrentStructurePcdName
+
+        if "|" not in self._CurrentLine:
+            if "<HeaderFiles>" == self._CurrentLine:
+                self._include_flag = True
+                self._package_flag = False
+                self._ValueList = None
+                return
+            if "<Packages>" == self._CurrentLine:
+                self._package_flag = True
+                self._ValueList = None
+                self._include_flag = False
+                return
+
+            if self._include_flag:
+                self._ValueList[1] = "<HeaderFiles>_" + md5(self._CurrentLine.encode('utf-8')).hexdigest()
+                self._ValueList[2] = self._CurrentLine
+            if self._package_flag and "}" != self._CurrentLine:
+                self._ValueList[1] = "<Packages>_" + md5(self._CurrentLine.encode('utf-8')).hexdigest()
+                self._ValueList[2] = self._CurrentLine
+            if self._CurrentLine == "}":
+                self._package_flag = False
+                self._include_flag = False
+                self._ValueList = None
+        else:
+            PcdTockens = self._CurrentLine.split(TAB_VALUE_SPLIT)
+            PcdNames = self.ParsePcdName(PcdTockens[0].split(TAB_SPLIT))
+            if len(PcdNames) == 2:
+                if PcdNames[1].strip().endswith("]"):
+                    PcdName = PcdNames[1][:PcdNames[1].index('[')]
+                    Index = PcdNames[1][PcdNames[1].index('['):]
+                    self._ValueList[0] = TAB_SPLIT.join((PcdNames[0], PcdName))
+                    self._ValueList[1] = Index
+                    self._ValueList[2] = PcdTockens[1]
+                else:
+                    self._CurrentStructurePcdName = ""
+            else:
+                if self._CurrentStructurePcdName != TAB_SPLIT.join(PcdNames[:2]):
+                    EdkLogger.error('Parser', FORMAT_INVALID, "Pcd Name does not match: %s and %s " % (
+                    self._CurrentStructurePcdName, TAB_SPLIT.join(PcdNames[:2])),
+                                    File=self.MetaFile, Line=self._LineIndex + 1)
+                self._ValueList[1] = TAB_SPLIT.join(PcdNames[2:])
+                self._ValueList[2] = PcdTockens[1]
+
     ## PCD sections parser
     #
     #   [PcdsFixedAtBuild]
@@ -1702,6 +1762,9 @@ class DecParser(MetaFileParser):
     #
     @ParseMacro
     def _PcdParser(self):
+        if self._CurrentStructurePcdName:
+            self.StructPcdParser()
+            return
         TokenList = GetSplitValueList(self._CurrentLine, TAB_VALUE_SPLIT, 1)
         self._ValueList[0:1] = GetSplitValueList(TokenList[0], TAB_SPLIT)
         # check PCD information
@@ -1759,6 +1822,10 @@ class DecParser(MetaFileParser):
         if not IsValid:
             EdkLogger.error('Parser', FORMAT_INVALID, Cause, ExtraData=self._CurrentLine,
                             File=self.MetaFile, Line=self._LineIndex+1)
+        if Cause == "StructurePcd":
+            self._CurrentStructurePcdName = TAB_SPLIT.join(self._ValueList[0:2])
+            self._ValueList[0] = self._CurrentStructurePcdName
+            self._ValueList[1] = ValueList[1].strip()
 
         if EccGlobalData.gConfig.UniCheckPCDInfo == '1' or EccGlobalData.gConfig.UniCheckAll == '1' or EccGlobalData.gConfig.CheckAll == '1':
             # check Description, Prompt information


### PR DESCRIPTION
BZ:https://bugzilla.tianocore.org/show_bug.cgi?id=2142

gAdvancedFeaturePkgTokenSpaceGuid.PcdSmbiosType0BiosInformation|
{0x0}|SMBIOS_TABLE_TYPE0|0x80010000 {
    <HeaderFiles>
      IndustryStandard/SmBios.h
    <Packages>
      MdePkg/MdePkg.dec
      AdvancedFeaturePkg/AdvancedFeaturePkg.dec
  }

If there's a PcdStructHF or PcdStructPKGs in StructPcd,
EccTool report error,IndexError: list index out of range

This patch is going to fix this issue

Cc: Liming Gao <liming.gao@intel.com>
Cc: Bob Feng <bob.c.feng@intel.com>
Signed-off-by: Zhiju.Fan <zhijux.fan@intel.com>

Reviewed-by: Bob Feng <bob.c.feng@intel.com>