### PR TITLE
MdePkg/BaseSafeIntLib: Fix VS20xx IA32 link failures

### DIFF
--- a/MdePkg/Library/BaseSafeIntLib/SafeIntLib.c
+++ b/MdePkg/Library/BaseSafeIntLib/SafeIntLib.c
@@ -3380,14 +3380,14 @@ SafeUint64Mult (
       //
       // a * d must be less than 2^32 or there would be bits set in the high 64-bits
       //
-      ProductAD = (((UINT64)DwordA) *(UINT64)DwordD);
+      ProductAD = MultU64x64 ((UINT64)DwordA, (UINT64)DwordD);
       if ((ProductAD & 0xffffffff00000000) == 0) {
         DwordB = (UINT32)Multiplicand;
 
         //
         // b * c must be less than 2^32 or there would be bits set in the high 64-bits
         //
-        ProductBC = (((UINT64)DwordB) *(UINT64)DwordC);
+        ProductBC = MultU64x64 ((UINT64)DwordB, (UINT64)DwordC);
         if ((ProductBC & 0xffffffff00000000) == 0) {
           //
           // now sum them all up checking for overflow.
@@ -3397,7 +3397,7 @@ SafeUint64Mult (
             //
             // b * d
             //
-            ProductBD = (((UINT64)DwordB) *(UINT64)DwordD);
+            ProductBD = MultU64x64 ((UINT64)DwordB, (UINT64)DwordD);
 
             if (!RETURN_ERROR (SafeUint64Add (UnsignedResult, ProductBD, &UnsignedResult))) {
               *Result = UnsignedResult;


### PR DESCRIPTION
https://bugzilla.tianocore.org/show_bug.cgi?id=2525

SafeUint64Mult() looks for 64-bit overflows and performs
several 32-bit multiples with 64-bit results to check for
all possible overflow conditions.  IA32 builds using VS20xx
with optimizations enabled are producing a reference to
the _allmull intrinsic.

The fix is to use MultU64x64() instead of '*' for
these operations.  These are safe because the inputs
are guaranteed to have the upper 32-bits clear, which
means MultU64x64() can never overflow with those inputs.

Cc: Liming Gao <liming.gao@intel.com>
Cc: Sean Brogan <sean.brogan@microsoft.com>
Cc: Bret Barkelew <Bret.Barkelew@microsoft.com>
Signed-off-by: Michael D Kinney <michael.d.kinney@intel.com>