### PR TITLE
BaseTools:build failure in CLANGPDB tool chain

### DIFF
--- a/BaseTools/Source/Python/AutoGen/IncludesAutoGen.py
+++ b/BaseTools/Source/Python/AutoGen/IncludesAutoGen.py
@@ -111,6 +111,8 @@ class IncludesAutoGen():
                         continue
                     dependency_file = item.strip(" \\\n")
                     dependency_file = dependency_file.strip('''"''')
+                    if dependency_file == '':
+                        continue
                     if os.path.normpath(dependency_file +".deps") == abspath:
                         continue
                     filename = os.path.basename(dependency_file).strip()


### PR DESCRIPTION
REF:https://bugzilla.tianocore.org/show_bug.cgi?id=2520

Incremental build failure in CLANGPDB tool chain on Windows host
The build failure is like below when do incremental build.
The root cause is in generated deps_target file. It has one line ":".

Signed-off-by: Zhiju.Fan <zhijux.fan@intel.com>

Cc: Liming Gao <liming.gao@intel.com>
Cc: Bob Feng <bob.c.feng@intel.com>
Reviewed-by: Bob Feng <bob.c.feng@intel.com>