### PR TITLE
MdePkg: Add PCCT table signature definition

### DIFF
--- a/MdePkg/Include/IndustryStandard/Acpi50.h
+++ b/MdePkg/Include/IndustryStandard/Acpi50.h
@@ -3,6 +3,7 @@
 
   Copyright (c) 2014 Hewlett-Packard Development Company, L.P.<BR>
   Copyright (c) 2011 - 2018, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2020, ARM Ltd. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
@@ -2056,6 +2057,11 @@ typedef struct {
 /// "MSDM" MS Data Management Table
 ///
 #define EFI_ACPI_5_0_DATA_MANAGEMENT_TABLE_SIGNATURE  SIGNATURE_32('M', 'S', 'D', 'M')
+
+///
+/// "PCCT" Platform Communications Channel Table
+///
+#define EFI_ACPI_5_0_PLATFORM_COMMUNICATIONS_CHANNEL_TABLE_SIGNATURE  SIGNATURE_32('P', 'C', 'C', 'T')
 
 ///
 /// "SLIC" MS Software Licensing Table Specification

--- a/MdePkg/Include/IndustryStandard/Acpi51.h
+++ b/MdePkg/Include/IndustryStandard/Acpi51.h
@@ -4,6 +4,7 @@
   Copyright (c) 2014 Hewlett-Packard Development Company, L.P.<BR>
   Copyright (c) 2014 - 2018, Intel Corporation. All rights reserved.<BR>
   (C) Copyright 2015 Hewlett Packard Enterprise Development LP<BR>
+  Copyright (c) 2020, ARM Ltd. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
@@ -2077,6 +2078,11 @@ typedef struct {
 /// "MSDM" MS Data Management Table
 ///
 #define EFI_ACPI_5_1_DATA_MANAGEMENT_TABLE_SIGNATURE  SIGNATURE_32('M', 'S', 'D', 'M')
+
+///
+/// "PCCT" Platform Communications Channel Table
+///
+#define EFI_ACPI_5_1_PLATFORM_COMMUNICATIONS_CHANNEL_TABLE_SIGNATURE  SIGNATURE_32('P', 'C', 'C', 'T')
 
 ///
 /// "SLIC" MS Software Licensing Table Specification

--- a/MdePkg/Include/IndustryStandard/Acpi60.h
+++ b/MdePkg/Include/IndustryStandard/Acpi60.h
@@ -3,6 +3,7 @@
 
   Copyright (c) 2015 - 2018, Intel Corporation. All rights reserved.<BR>
   (C) Copyright 2015-2016 Hewlett Packard Enterprise Development LP<BR>
+  Copyright (c) 2020, ARM Ltd. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
@@ -2320,6 +2321,11 @@ typedef struct {
 /// "MSDM" MS Data Management Table
 ///
 #define EFI_ACPI_6_0_DATA_MANAGEMENT_TABLE_SIGNATURE  SIGNATURE_32('M', 'S', 'D', 'M')
+
+///
+/// "PCCT" Platform Communications Channel Table
+///
+#define EFI_ACPI_6_0_PLATFORM_COMMUNICATIONS_CHANNEL_TABLE_SIGNATURE  SIGNATURE_32('P', 'C', 'C', 'T')
 
 ///
 /// "SLIC" MS Software Licensing Table Specification

--- a/MdePkg/Include/IndustryStandard/Acpi61.h
+++ b/MdePkg/Include/IndustryStandard/Acpi61.h
@@ -3,6 +3,7 @@
 
   Copyright (c) 2016 - 2018, Intel Corporation. All rights reserved.<BR>
  (C) Copyright 2016 Hewlett Packard Enterprise Development LP<BR>
+  Copyright (c) 2020, ARM Ltd. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
@@ -2352,6 +2353,11 @@ typedef struct {
 /// "MSDM" MS Data Management Table
 ///
 #define EFI_ACPI_6_1_DATA_MANAGEMENT_TABLE_SIGNATURE  SIGNATURE_32('M', 'S', 'D', 'M')
+
+///
+/// "PCCT" Platform Communications Channel Table
+///
+#define EFI_ACPI_6_1_PLATFORM_COMMUNICATIONS_CHANNEL_TABLE_SIGNATURE  SIGNATURE_32('P', 'C', 'C', 'T')
 
 ///
 /// "SLIC" MS Software Licensing Table Specification

--- a/MdePkg/Include/IndustryStandard/Acpi62.h
+++ b/MdePkg/Include/IndustryStandard/Acpi62.h
@@ -2,6 +2,7 @@
   ACPI 6.2 definitions from the ACPI Specification Revision 6.2 May, 2017.
 
   Copyright (c) 2017, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2020, ARM Ltd. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
@@ -2878,6 +2879,11 @@ typedef struct {
 /// "MSDM" MS Data Management Table
 ///
 #define EFI_ACPI_6_2_DATA_MANAGEMENT_TABLE_SIGNATURE  SIGNATURE_32('M', 'S', 'D', 'M')
+
+///
+/// "PCCT" Platform Communications Channel Table
+///
+#define EFI_ACPI_6_2_PLATFORM_COMMUNICATIONS_CHANNEL_TABLE_SIGNATURE  SIGNATURE_32('P', 'C', 'C', 'T')
 
 ///
 /// "SDEI" Software Delegated Exceptions Interface Table

--- a/MdePkg/Include/IndustryStandard/Acpi63.h
+++ b/MdePkg/Include/IndustryStandard/Acpi63.h
@@ -2,7 +2,7 @@
   ACPI 6.3 definitions from the ACPI Specification Revision 6.3 Jan, 2019.
 
   Copyright (c) 2017, Intel Corporation. All rights reserved.<BR>
-  Copyright (c) 2019, ARM Ltd. All rights reserved.<BR>
+  Copyright (c) 2019 - 2020, ARM Ltd. All rights reserved.<BR>
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
@@ -2879,6 +2879,11 @@ typedef struct {
 /// "MSDM" MS Data Management Table
 ///
 #define EFI_ACPI_6_3_DATA_MANAGEMENT_TABLE_SIGNATURE  SIGNATURE_32('M', 'S', 'D', 'M')
+
+///
+/// "PCCT" Platform Communications Channel Table
+///
+#define EFI_ACPI_6_3_PLATFORM_COMMUNICATIONS_CHANNEL_TABLE_SIGNATURE  SIGNATURE_32('P', 'C', 'C', 'T')
 
 ///
 /// "SDEI" Software Delegated Exceptions Interface Table


### PR DESCRIPTION
The Platform Communications Channel Table (PCCT) was defined in:
ACPI Specification Version 5.0, Errata A - Published Nov. 13, 2013.

Starting from the Acpi50.h header file, there are definitions
describing the table but a macro with the table's signature is missing.

This patch adds the definition of Platform Communications Channel
Table's signature to the relevant ACPI header files.

Signed-off-by: Krzysztof Koch <krzysztof.koch@arm.com>
Reviewed-by: Liming Gao <liming.gao@intel.com>
Reviewed-by: Sami Mujawar <sami.mujawar@arm.com>