### PR TITLE
MdeModulePkg/HiiDB: Remove configuration table when it's freed (CVE-2…

### DIFF
--- a/MdeModulePkg/Universal/HiiDatabaseDxe/Database.c
+++ b/MdeModulePkg/Universal/HiiDatabaseDxe/Database.c
@@ -1,7 +1,7 @@
 /** @file
 Implementation for EFI_HII_DATABASE_PROTOCOL.
 
-Copyright (c) 2007 - 2019, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2007 - 2020, Intel Corporation. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -3376,6 +3376,10 @@ HiiGetConfigRespInfo(
       if (gRTConfigRespBuffer == NULL){
         FreePool(ConfigAltResp);
         DEBUG ((DEBUG_ERROR, "[HiiDatabase]: No enough memory resource to store the ConfigResp string.\n"));
+        //
+        // Remove from the System Table when the configuration runtime buffer is freed.
+        //
+        gBS->InstallConfigurationTable (&gEfiHiiConfigRoutingProtocolGuid, NULL);
         return EFI_OUT_OF_RESOURCES;
       }
     } else {
@@ -3431,6 +3435,10 @@ HiiGetDatabaseInfo(
     gRTDatabaseInfoBuffer = AllocateRuntimeZeroPool (gDatabaseInfoSize);
     if (gRTDatabaseInfoBuffer == NULL){
       DEBUG ((DEBUG_ERROR, "[HiiDatabase]: No enough memory resource to store the HiiDatabase info.\n"));
+      //
+      // Remove from the System Table when the configuration runtime buffer is freed.
+      //
+      gBS->InstallConfigurationTable (&gEfiHiiDatabaseProtocolGuid, NULL);
       return EFI_OUT_OF_RESOURCES;
     }
   } else {


### PR DESCRIPTION
…019-14586)

REF: https://bugzilla.tianocore.org/show_bug.cgi?id=1995

Fix the corner case issue that the original configuration runtime
memory is freed, but it is still exposed to the OS runtime.
So this patch is to remove the configuration table to avoid being
used in OS runtime when the configuration runtime memory is freed.

Cc: Liming Gao <liming.gao@intel.com>
Cc: Eric Dong <eric.dong@intel.com>
Cc: Jian J Wang <jian.j.wang@intel.com>
Signed-off-by: Dandan Bi <dandan.bi@intel.com>
Reviewed-by: Eric Dong <eric.dong@intel.com>
Reviewed-by: Jian J Wang <jian.j.wang@intel.com>