### PR TITLE
MdeModulePkg/SdMmcPciHcDxe: Fix double PciIo Unmap in TRB creation (C…

### DIFF
--- a/MdeModulePkg/Bus/Pci/SdMmcPciHcDxe/SdMmcPciHci.c
+++ b/MdeModulePkg/Bus/Pci/SdMmcPciHcDxe/SdMmcPciHci.c
@@ -1544,6 +1544,8 @@ BuildAdmaDescTable (
       PciIo,
       Trb->AdmaMap
     );
+    Trb->AdmaMap = NULL;
+
     PciIo->FreeBuffer (
       PciIo,
       EFI_SIZE_TO_PAGES (TableSize),
@@ -1753,7 +1755,6 @@ SdMmcCreateTrb (
       }
       Status = BuildAdmaDescTable (Trb, Private->ControllerVersion[Slot]);
       if (EFI_ERROR (Status)) {
-        PciIo->Unmap (PciIo, Trb->DataMap);
         goto Error;
       }
     } else if (Private->Capability[Slot].Sdma != 0) {


### PR DESCRIPTION
…VE-2019-14587)

REF:https://bugzilla.tianocore.org/show_bug.cgi?id=1989

The commit will avoid unmapping the same resource in error handling logic
for function BuildAdmaDescTable() and SdMmcCreateTrb().

For the error handling in BuildAdmaDescTable():
The error is directly related with the corresponding Map() operation
(mapped address beyond 4G, which is not supported in ADMA), so the Unmap()
operation is done in the error handling logic, and then setting
'Trb->AdmaMap' to NULL to avoid double Unmap.

For the error handling in SdMmcCreateTrb():
The error is not directly related with the corresponding Map() operation,
so the commit will update the code to left SdMmcFreeTrb() for the Unmap
operation to avoid double Unmap.

Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Signed-off-by: Hao A Wu <hao.a.wu@intel.com>
Reviewed-by: Jian J Wang <jian.j.wang@intel.com>