### PR TITLE
MdeModulePkg: Make retval in UninstallMultipleProtocol follow Spec

### DIFF
--- a/MdeModulePkg/Core/Dxe/Hand/Handle.c
+++ b/MdeModulePkg/Core/Dxe/Hand/Handle.c
@@ -802,20 +802,27 @@ Done:
 
 
 
-
 /**
   Uninstalls a list of protocol interface in the boot services environment.
-  This function calls UnisatllProtocolInterface() in a loop. This is
+  This function calls UninstallProtocolInterface() in a loop. This is
   basically a lib function to save space.
 
-  @param  Handle                 The handle to uninstall the protocol
+  If any errors are generated while the protocol interfaces are being
+  uninstalled, then the protocol interfaces uninstalled prior to the error will
+  be reinstalled and EFI_INVALID_PARAMETER will be returned.
+
+  @param  Handle                 The handle to uninstall the protocol interfaces
+                                 from.
   @param  ...                    EFI_GUID followed by protocol instance. A NULL
-                                 terminates the  list. The pairs are the
+                                 terminates the list. The pairs are the
                                  arguments to UninstallProtocolInterface(). All
                                  the protocols are added to Handle.
 
-  @return Status code
-
+  @retval EFI_SUCCESS            if all protocol interfaces where uninstalled.
+  @retval EFI_INVALID_PARAMETER  if any protocol interface could not be
+                                 uninstalled and an attempt was made to
+                                 reinstall previously uninstalled protocol
+                                 interfaces.
 **/
 EFI_STATUS
 EFIAPI
@@ -864,6 +871,7 @@ CoreUninstallMultipleProtocolInterfaces (
       CoreInstallProtocolInterface (&Handle, Protocol, EFI_NATIVE_INTERFACE, Interface);
     }
     VA_END (Args);
+    Status = EFI_INVALID_PARAMETER;
   }
 
   return Status;


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=1869

The UEFI spec requires that if any error occurs in
UninstallMultipleProtocolInterfaces(), EFI_INVALID_PARAMETER is returned
and not the return code of UninstallProtocolInterface().

Signed-off-by: Heinrich Schuchardt <xypron.glpk@gmx.de>
Reviewed-by: Dandan Bi <dandan.bi@intel.com>