### PR TITLE
NetworkPkg/ArpDxe: Recycle invalid ARP packets (CVE-2019-14559)

### DIFF
--- a/NetworkPkg/ArpDxe/ArpImpl.c
+++ b/NetworkPkg/ArpDxe/ArpImpl.c
@@ -1,7 +1,7 @@
 /** @file
   The implementation of the ARP protocol.
 
-Copyright (c) 2006 - 2018, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2006 - 2020, Intel Corporation. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -113,7 +113,7 @@ ArpOnFrameRcvdDpc (
     //
     // Restart the receiving if packet size is not correct.
     //
-    goto RESTART_RECEIVE;
+    goto RECYCLE_RXDATA;
   }
 
   //
@@ -125,7 +125,7 @@ ArpOnFrameRcvdDpc (
   Head->OpCode    = NTOHS (Head->OpCode);
 
   if (RxData->DataLength < (sizeof (ARP_HEAD) + 2 * Head->HwAddrLen + 2 * Head->ProtoAddrLen)) {
-    goto RESTART_RECEIVE;
+    goto RECYCLE_RXDATA;
   }
 
   if ((Head->HwType != ArpService->SnpMode.IfType) ||


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=2031

This patch triggers the RecycleEvent for invalid ARP packets.
Prior to this, we would just ignore invalid ARP packets,
and never free them.

Cc: Jiaxin Wu <jiaxin.wu@intel.com>
Cc: Maciej Rabeda <maciej.rabeda@linux.intel.com>
Cc: Siyuan Fu <siyuan.fu@intel.com>
Signed-off-by: Nicholas Armour <nicholas.armour@intel.com>
Reviewed-by: Siyuan Fu <siyuan.fu@intel.com>