### PR TITLE
BaseTools: Fixed a regression issue in Makefile for incremental build

### DIFF
--- a/BaseTools/Source/Python/AutoGen/IncludesAutoGen.py
+++ b/BaseTools/Source/Python/AutoGen/IncludesAutoGen.py
@@ -52,17 +52,17 @@ class IncludesAutoGen():
             EdkLogger.error("build", PARAMETER_MISSING, Message="No Make path available.")
         elif "nmake" in MakePath:
             _INCLUDE_DEPS_TEMPLATE = TemplateString('''
-        ${BEGIN}
-        !IF EXIST(${deps_file})
-        !INCLUDE ${deps_file}
-        !ENDIF
-        ${END}
+${BEGIN}
+!IF EXIST(${deps_file})
+!INCLUDE ${deps_file}
+!ENDIF
+${END}
                ''')
         else:
             _INCLUDE_DEPS_TEMPLATE = TemplateString('''
-        ${BEGIN}
-        -include ${deps_file}
-        ${END}
+${BEGIN}
+-include ${deps_file}
+${END}
                ''')
 
         try:


### PR DESCRIPTION
This patch is to fix a increametal build regression bug
which happen when using nmake. That's introduced by 818283de3f6d.

If there is white space before !INCLUDE instruction, nmake will not
process it. Source code's dependent header files are listed in
${deps_file} file, if it's not included successfully, nmake will
not detect the change of those header file.

This patch has been verified in Windows with VS2015 and Linux with GCC5.
The header file add/modify/delete can trig the incremental build with this fix.
There is no impact on the clean build.

Cc: Andrew Fish <afish@apple.com>
Cc: Laszlo Ersek <lersek@redhat.com>
Cc: Leif Lindholm <leif@nuviainc.com>
Cc: Michael D Kinney <michael.d.kinney@intel.com>
Signed-off-by: Bob Feng <bob.c.feng@intel.com>
Reviewed-by: Liming Gao <liming.gao@intel.com>
Tested-by: Liming Gao <liming.gao@intel.com>