### PR TITLE
Remove assertion for TPL changing

### DIFF
--- a/MdeModulePkg/Core/Dxe/Image/Image.c
+++ b/MdeModulePkg/Core/Dxe/Image/Image.c
@@ -1673,8 +1673,9 @@ CoreStartImage (
   //
   // Image has completed.  Verify the tpl is the same
   //
-  ASSERT (Image->Tpl == gEfiCurrentTpl);
-  CoreRestoreTpl (Image->Tpl);
+  if (Image->Tpl != gEfiCurrentTpl) {
+    CoreRestoreTpl (Image->Tpl);
+  }
 
   CoreFreePool (Image->JumpBuffer);
 


### PR DESCRIPTION
The Image->Tpl is set to the gEfiCurrentTpl at the beginning of
CoreStartImage() and will not be changed til the end.
The gEfiCurrentTpl may be changed after the image is complete, so
the TPL should be restored back to Image->Tpl.

The below assertion doesn't make any sense, it is unnecessary:

ASSERT (Image->Tpl == gEfiCurrentTpl);

Signed-off-by: Shannon Du <shannondu1986@gmail.com>