### PR TITLE
[edk2-devel] [PATCH] OvmfPkg/X86QemuLoadImageLib: fix "unused variable" error in X64 DXE builds -- push

### DIFF
--- a/OvmfPkg/Library/X86QemuLoadImageLib/X86QemuLoadImageLib.c
+++ b/OvmfPkg/Library/X86QemuLoadImageLib/X86QemuLoadImageLib.c
@@ -460,7 +460,6 @@ QemuStartKernelImage (
 {
   EFI_STATUS                    Status;
   OVMF_LOADED_X86_LINUX_KERNEL  *LoadedImage;
-  EFI_HANDLE                    KernelImageHandle;
 
   Status = gBS->OpenProtocol (
                   *ImageHandle,
@@ -481,6 +480,8 @@ QemuStartKernelImage (
                   );
 #ifdef MDE_CPU_IA32
   if (Status == EFI_UNSUPPORTED) {
+    EFI_HANDLE KernelImageHandle;
+
     //
     // On IA32, EFI_UNSUPPORTED means that the image's machine type is X64 while
     // we are expecting a IA32 one, and the StartImage () boot service is unable


### PR DESCRIPTION
https://bugzilla.tianocore.org/show_bug.cgi?id=2572
https://edk2.groups.io/g/devel/message/55622
http://mid.mail-archive.com/20200306230442.24100-1-lersek@redhat.com