### PR TITLE
OvmfPkg/LinuxInitrdDynamicShellCommand: Cast UNIT64 to UNITN in assig…

### DIFF
--- a/OvmfPkg/LinuxInitrdDynamicShellCommand/LinuxInitrdDynamicShellCommand.c
+++ b/OvmfPkg/LinuxInitrdDynamicShellCommand/LinuxInitrdDynamicShellCommand.c
@@ -196,7 +196,7 @@ CacheInitrdFile (
     ASSERT_EFI_ERROR (Status);
   }
 
-  mInitrdFileSize = FileSize;
+  mInitrdFileSize = (UINTN)FileSize;
   return EFI_SUCCESS;
 
 FreeMemory:


### PR DESCRIPTION
…nment

REF: https://bugzilla.tianocore.org/show_bug.cgi?id=2580

Ovmf build failed on Windows with VS2017 tool chain.
The error message like:

OvmfPkg\LinuxInitrdDynamicShellCommand\LinuxInitr
 dDynamicShellCommand.c(199): error C2220: warning treated as error -
 no 'object' file generated
OvmfPkg\LinuxInitrdDynamicShellCommand\LinuxInitrdDynamicShellCommand.c(199):
warning C4244: '=': conversion from 'UINT64' to 'UINTN',
possible loss of data

This patch is to cast UINT64 type to UINTN type
when doing the variable assignment.

Signed-off-by: Bob Feng <bob.c.feng@intel.com>
Cc: Ard Biesheuvel <ard.biesheuvel@linaro.org>
Cc: Laszlo Ersek <lersek@redhat.com>
Reviewed-by: Laszlo Ersek <lersek@redhat.com>