### PR TITLE
MdeModulePkg: Use CopyMem instead of GUID assignment

### DIFF
--- a/MdeModulePkg/Library/DeviceManagerUiLib/DeviceManager.c
+++ b/MdeModulePkg/Library/DeviceManagerUiLib/DeviceManager.c
@@ -619,7 +619,7 @@ CreateDeviceManagerForm(
         TokenHelp = HiiSetString (HiiHandle, 0, String, NULL);
         FreePool (String);
 
-        FormSetGuid = ((EFI_IFR_FORM_SET *)Ptr)->Guid;
+        CopyMem (&FormSetGuid, &((EFI_IFR_FORM_SET *) Ptr)->Guid, sizeof (EFI_GUID));
 
         //
         // Network device process


### PR DESCRIPTION
GCC translates a simple assignment to memcpy, which EDKII doesn't provide.
See: https://www.mail-archive.com/edk2-devel@lists.01.org/msg11928.html

REF:https://bugzilla.tianocore.org/show_bug.cgi?id=2547

Signed-off-by: Daniel Schaefer <daniel.schaefer@hpe.com>
Cc: Abner Chang <abner.chang@hpe.com>
Cc: Gilbert Chen <gilbert.chen@hpe.com>
Cc: Leif Lindholm <leif@nuviainc.com>
Cc: Dandan Bi <dandan.bi@intel.com>
Cc: Eric Dong <eric.dong@intel.com>
Reviewed-by: Dandan Bi <dandan.bi@intel.com>