### PR TITLE
OvmfPkg: Fix build failure with VS2015 tool chain

### DIFF
--- a/OvmfPkg/Library/X86QemuLoadImageLib/X86QemuLoadImageLib.c
+++ b/OvmfPkg/Library/X86QemuLoadImageLib/X86QemuLoadImageLib.c
@@ -384,7 +384,7 @@ QemuLoadKernelImage (
     //
     // Drop the terminating NUL, convert to UTF-16.
     //
-    KernelLoadedImage->LoadOptionsSize = (CommandLineSize - 1) * 2;
+    KernelLoadedImage->LoadOptionsSize = (UINT32) ((CommandLineSize - 1) * 2);
   }
 
   QemuFwCfgSelectItem (QemuFwCfgItemInitrdSize);


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=2582
warning C4244: '=': conversion from 'UINTN' to 'UINT32', possible loss of data
With this fix, OvmfIa32, OvmfX64 and OvmfIa32X64 can pass build.

Cc: Laszlo Ersek <lersek@redhat.com>
Cc: Ard Biesheuvel <ard.biesheuvel@linaro.org>
Signed-off-by: Liming Gao <liming.gao@intel.com>
Reviewed-by: Laszlo Ersek <lersek@redhat.com>