### PR TITLE
MdePkg/PciExpress40.h: DVSEC definition missing

### DIFF
--- a/MdePkg/Include/IndustryStandard/PciExpress40.h
+++ b/MdePkg/Include/IndustryStandard/PciExpress40.h
@@ -4,6 +4,7 @@ Support for the PCI Express 4.0 standard.
 This header file may not define all structures.  Please extend as required.
 
 Copyright (c) 2018, American Megatrends, Inc. All rights reserved.<BR>
+Copyright (c) 2020, Intel Corporation. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -76,6 +77,33 @@ typedef struct {
   UINT32                                                        Reserved;
   PCI_EXPRESS_REG_PHYSICAL_LAYER_16_0_LANE_EQUALIZATION_CONTROL LaneEqualizationControl[1];
 } PCI_EXPRESS_EXTENDED_CAPABILITIES_PHYSICAL_LAYER_16_0;
+///@}
+
+/// The Designated Vendor Specific Capability definitions
+/// Based on section 7.9.6 of PCI Express Base Specification 4.0.
+///@{
+typedef union {
+  struct {
+    UINT32 DvsecVendorId                                        : 16; //bit 0..15
+    UINT32 DvsecRevision                                        : 4;  //bit 16..19
+    UINT32 DvsecLength                                          : 12; //bit 20..31
+  }Bits;
+  UINT32                                                        Uint32;
+}PCI_EXPRESS_DESIGNATED_VENDOR_SPECIFIC_HEADER_1;
+
+typedef union {
+  struct {
+    UINT16 DvsecId                                              : 16; //bit 0..15
+  }Bits;
+  UINT16                                                        Uint16;
+}PCI_EXPRESS_DESIGNATED_VENDOR_SPECIFIC_HEADER_2;
+
+typedef struct {
+  PCI_EXPRESS_EXTENDED_CAPABILITIES_HEADER                      Header;
+  PCI_EXPRESS_DESIGNATED_VENDOR_SPECIFIC_HEADER_1               DesignatedVendorSpecificHeader1;
+  PCI_EXPRESS_DESIGNATED_VENDOR_SPECIFIC_HEADER_2               DesignatedVendorSpecificHeader2;
+  UINT8                                                         DesignatedVendorSpecific[1];
+}PCI_EXPRESS_EXTENDED_CAPABILITIES_DESIGNATED_VENDOR_SPECIFIC;
 ///@}
 
 #pragma pack()


### PR DESCRIPTION
BZ: https://bugzilla.tianocore.org/show_bug.cgi?id=2598

All registers definition of DVSEC are defined as per the PCI Express Base
Specification 4.0 chapter 7.9.6.

Signed-off-by: Ashraf Javeed <ashraf.javeed@intel.com>
Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Liming Gao <liming.gao@intel.com>
Cc: Zhiguang Liu <zhiguang.liu@intel.com>
Reviewed-by: Zhiguang Liu <zhiguang.liu@intel.com>
Reviewed-by: Liming Gao <liming.gao@intel.com>