### PR TITLE
PS/2 keyboard should not normally ACK after a RESET

### DIFF
--- a/MdeModulePkg/Bus/Isa/Ps2KeyboardDxe/Ps2KbdCtrller.c
+++ b/MdeModulePkg/Bus/Isa/Ps2KeyboardDxe/Ps2KbdCtrller.c
@@ -1701,11 +1701,6 @@ InitKeyboard (
       goto Done;
     }
 
-    Status = KeyboardWaitForValue (ConsoleIn, KEYBOARD_8048_RETURN_8042_ACK);
-    if (EFI_ERROR (Status)) {
-      KeyboardError (ConsoleIn, L"Some specific value not acquired from 8042 controller!\n\r");
-      goto Done;
-    }
     //
     // wait for BAT completion code
     //


### PR DESCRIPTION
A PS/2 keyboard normally does not ACK after a reset, only the BAT SUCCESS value is sent. This should correct slow reset on some keyboards.