### PR TITLE
EmbeddedPkg/RealTimeClockRuntimeDxe: Drop ASSERTs on function argumen…

### DIFF
--- a/EmbeddedPkg/RealTimeClockRuntimeDxe/RealTimeClock.c
+++ b/EmbeddedPkg/RealTimeClockRuntimeDxe/RealTimeClock.c
@@ -85,10 +85,6 @@ IsDayValid (
   IN  EFI_TIME  *Time
   )
 {
-  ASSERT (Time->Day >= 1);
-  ASSERT (Time->Day <= mDayOfMonth[Time->Month - 1]);
-  ASSERT (Time->Month != 2 || IsLeapYear (Time) || Time->Day <= 28);
-
   if (Time->Day < 1 ||
       Time->Day > mDayOfMonth[Time->Month - 1] ||
       (Time->Month == 2 && !IsLeapYear (Time) && Time->Day > 28)) {
@@ -113,6 +109,7 @@ IsTimeValid(
       Time->Hour   > 23                 ||
       Time->Minute > 59                 ||
       Time->Second > 59                 ||
+      Time->Nanosecond > 999999999      ||
       !IsValidTimeZone (Time->TimeZone) ||
       !IsValidDaylight (Time->Daylight)) {
     return FALSE;


### PR DESCRIPTION
…t values

ASSERT in SetTime_Conf Consistency Test.
SCT Test expect return as Invalid Parameter.
So removed ASSERT().

While at it, check that the NanoSecond field is within the range given
by the UEFI specification.

Signed-off-by: Gaurav Jain <gaurav.jain@nxp.com>
Reviewed-by: Ard Biesheuvel <ard.biesheuvel@linaro.org>