### PR TITLE
MdeModulePkg/SdDxe: Check the Token to avoid null pointer

### DIFF
--- a/MdeModulePkg/Bus/Sd/SdDxe/SdBlockIo.c
+++ b/MdeModulePkg/Bus/Sd/SdDxe/SdBlockIo.c
@@ -1367,7 +1367,14 @@ SdEraseBlocks (
     return Status;
   }
 
-  DEBUG ((EFI_D_ERROR, "SdEraseBlocks(): Lba 0x%x BlkNo 0x%x Event %p with %r\n", Lba, BlockNum, Token->Event, Status));
+  DEBUG ((
+    DEBUG_INFO,
+    "SdEraseBlocks(): Lba 0x%x BlkNo 0x%x Event %p with %r\n",
+    Lba,
+    BlockNum,
+    (Token != NULL) ? Token->Event : NULL,
+    Status
+    ));
 
   return Status;
 }


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=2286

Token pointer may be NULL, it should be checked before use it.

Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Hao A Wu <hao.a.wu@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Signed-off-by: Guomin Jiang <guomin.jiang@intel.com>
Reviewed-by: Hao A Wu <hao.a.wu@intel.com>