### PR TITLE
Fix in UnitTestFrameworkPkg

### DIFF
--- a/MdePkg/Test/UnitTest/Library/BaseLib/Base64UnitTest.c
+++ b/MdePkg/Test/UnitTest/Library/BaseLib/Base64UnitTest.c
@@ -252,9 +252,11 @@ RfcDecodeTest(
   BinSize = AsciiStrnLenS (binString, MAX_TEST_STRING_SIZE);
 
   BinData = AllocatePool (BinSize);
-  Btc->BufferToFree = BinData;
+  UT_ASSERT_NOT_NULL(BinData);
 
+  Btc->BufferToFree = BinData;
   ReturnSize = BinSize;
+
   Status = Base64Decode (b64String, b64StringLen, BinData, &ReturnSize);
 
   UT_ASSERT_STATUS_EQUAL (Status, Btc->ExpectedStatus);

--- a/UnitTestFrameworkPkg/Library/UnitTestLib/RunTests.c
+++ b/UnitTestFrameworkPkg/Library/UnitTestLib/RunTests.c
@@ -33,12 +33,12 @@ RunTestSuite (
   UNIT_TEST             *Test;
   UNIT_TEST_FRAMEWORK   *ParentFramework;
 
-  TestEntry       = NULL;
-  ParentFramework = (UNIT_TEST_FRAMEWORK *)Suite->ParentFramework;
-
   if (Suite == NULL) {
     return EFI_INVALID_PARAMETER;
   }
+
+  TestEntry       = NULL;
+  ParentFramework = (UNIT_TEST_FRAMEWORK *)Suite->ParentFramework;
 
   DEBUG ((DEBUG_VERBOSE, "---------------------------------------------------------\n"));
   DEBUG ((DEBUG_VERBOSE, "RUNNING TEST SUITE: %a\n", Suite->Title));

--- a/UnitTestFrameworkPkg/Library/UnitTestLib/UnitTestLib.c
+++ b/UnitTestFrameworkPkg/Library/UnitTestLib/UnitTestLib.c
@@ -436,7 +436,6 @@ AddTestCase (
 
   Status          = EFI_SUCCESS;
   Suite           = (UNIT_TEST_SUITE *)SuiteHandle;
-  ParentFramework = (UNIT_TEST_FRAMEWORK *)Suite->ParentFramework;
 
   //
   // First, let's check to make sure that our parameters look good.
@@ -445,6 +444,7 @@ AddTestCase (
     return EFI_INVALID_PARAMETER;
   }
 
+  ParentFramework = (UNIT_TEST_FRAMEWORK *)Suite->ParentFramework;
   //
   // Create the new entry.
   NewTestEntry = AllocateZeroPool (sizeof( UNIT_TEST_LIST_ENTRY ));

--- a/UnitTestFrameworkPkg/Library/UnitTestResultReportLib/UnitTestResultReportLib.c
+++ b/UnitTestFrameworkPkg/Library/UnitTestResultReportLib/UnitTestResultReportLib.c
@@ -65,7 +65,7 @@ GetStringForUnitTestStatus (
 {
   UINTN  Index;
 
-  for (Index = 0; Index < ARRAY_SIZE (mStatusStrings); Index++) {
+  for (Index = 0; Index < ARRAY_SIZE (mStatusStrings) - 1; Index++) {
     if (mStatusStrings[Index].Status == Status) {
       //
       // Return string from matching entry
@@ -87,7 +87,7 @@ GetStringForFailureType (
 {
   UINTN  Index;
 
-  for (Index = 0; Index < ARRAY_SIZE (mFailureTypeStrings); Index++) {
+  for (Index = 0; Index < ARRAY_SIZE (mFailureTypeStrings) - 1; Index++) {
     if (mFailureTypeStrings[Index].Type == Failure) {
       //
       // Return string from matching entry


### PR DESCRIPTION
MdePkg/UnitTestBaseLib: Add check for pointer BinData

UnitTestFrameworkPkg/UnitTestLib: Check Suite pointer before use.

UnitTestFrameworkPkg/ResultReportLib: Remove invalid index string indicator