### PR TITLE
OvmfPkg/GenericQemuLoadImageLib: Fix VS2019 UINT32 conversion error

### DIFF
--- a/OvmfPkg/Library/GenericQemuLoadImageLib/GenericQemuLoadImageLib.c
+++ b/OvmfPkg/Library/GenericQemuLoadImageLib/GenericQemuLoadImageLib.c
@@ -151,7 +151,7 @@ QemuLoadKernelImage (
     //
     // Drop the terminating NUL, convert to UTF-16.
     //
-    KernelLoadedImage->LoadOptionsSize = (CommandLineSize - 1) * 2;
+    KernelLoadedImage->LoadOptionsSize = (UINT32)((CommandLineSize - 1) * 2);
   }
 
   QemuFwCfgSelectItem (QemuFwCfgItemInitrdSize);


### PR DESCRIPTION
Building OVMF for X64 with secure boot enabled on VS2019 results in
the following error:

  d:\a\1\s\OvmfPkg\Library\GenericQemuLoadImageLib\GenericQemuLoadImageLib.c(154):
    error C2220: the following warning is treated as an error
  d:\a\1\s\OvmfPkg\Library\GenericQemuLoadImageLib\GenericQemuLoadImageLib.c(154):
    warning C4244: '=': conversion from 'UINTN' to 'UINT32', possible loss of data

Suppress the error by making the cast explicit.

Link: https://bugzilla.tianocore.org/show_bug.cgi?id=2636
Signed-off-by: Ard Biesheuvel <ard.biesheuvel@linaro.org>
Reviewed-by: Laszlo Ersek <lersek@redhat.com>