### PR TITLE
lersek queue 2020-Apr-01

### DIFF
--- a/Maintainers.txt
+++ b/Maintainers.txt
@@ -435,6 +435,11 @@ OvmfPkg: CSM modules
 F: OvmfPkg/Csm/
 R: David Woodhouse <dwmw2@infradead.org>
 
+OvmfPkg: PVSCSI driver
+F: OvmfPkg/PvScsiDxe/
+R: Liran Alon <liran.alon@oracle.com>
+R: Nikita Leshenko <nikita.leshchenko@oracle.com>
+
 PcAtChipsetPkg
 F: PcAtChipsetPkg/
 W: https://github.com/tianocore/tianocore.github.io/wiki/PcAtChipsetPkg

--- a/NetworkPkg/UefiPxeBcDxe/PxeBcBoot.c
+++ b/NetworkPkg/UefiPxeBcDxe/PxeBcBoot.c
@@ -482,7 +482,20 @@ PxeBcDhcp4BootInfo (
     Cache4 = &Private->DhcpAck.Dhcp4;
   }
 
-  ASSERT (Cache4->OptList[PXEBC_DHCP4_TAG_INDEX_BOOTFILE] != NULL);
+  if (Cache4->OptList[PXEBC_DHCP4_TAG_INDEX_BOOTFILE] == NULL) {
+    //
+    // This should never happen in a correctly configured DHCP / PXE
+    // environment. One misconfiguration that can cause it is two DHCP servers
+    // mistakenly running on the same network segment at the same time, and
+    // racing each other in answering DHCP requests. Thus, the DHCP packets
+    // that the edk2 PXE client considers "belonging together" may actually be
+    // entirely independent, coming from two (competing) DHCP servers.
+    //
+    // Try to deal with this gracefully. Note that this check is not
+    // comprehensive, as we don't try to identify all such errors.
+    //
+    return EFI_PROTOCOL_ERROR;
+  }
 
   //
   // Parse the boot server address.
@@ -612,7 +625,20 @@ PxeBcDhcp6BootInfo (
     Cache6 = &Private->DhcpAck.Dhcp6;
   }
 
-  ASSERT (Cache6->OptList[PXEBC_DHCP6_IDX_BOOT_FILE_URL] != NULL);
+  if (Cache6->OptList[PXEBC_DHCP6_IDX_BOOT_FILE_URL] == NULL) {
+    //
+    // This should never happen in a correctly configured DHCP / PXE
+    // environment. One misconfiguration that can cause it is two DHCP servers
+    // mistakenly running on the same network segment at the same time, and
+    // racing each other in answering DHCP requests. Thus, the DHCP packets
+    // that the edk2 PXE client considers "belonging together" may actually be
+    // entirely independent, coming from two (competing) DHCP servers.
+    //
+    // Try to deal with this gracefully. Note that this check is not
+    // comprehensive, as we don't try to identify all such errors.
+    //
+    return EFI_PROTOCOL_ERROR;
+  }
 
   //
   // Set the station address to IP layer.

--- a/OvmfPkg/OvmfPkgIa32.dsc
+++ b/OvmfPkg/OvmfPkgIa32.dsc
@@ -86,14 +86,16 @@
 
 [BuildOptions.common.EDKII.DXE_RUNTIME_DRIVER]
   GCC:*_*_*_DLINK_FLAGS = -z common-page-size=0x1000
-  XCODE:*_*_*_DLINK_FLAGS =
+  XCODE:*_*_*_DLINK_FLAGS = -seg1addr 0x1000 -segalign 0x1000
+  XCODE:*_*_*_MTOC_FLAGS = -align 0x1000
   CLANGPDB:*_*_*_DLINK_FLAGS = /ALIGN:4096
 
 # Force PE/COFF sections to be aligned at 4KB boundaries to support page level
 # protection of DXE_SMM_DRIVER/SMM_CORE modules
 [BuildOptions.common.EDKII.DXE_SMM_DRIVER, BuildOptions.common.EDKII.SMM_CORE]
   GCC:*_*_*_DLINK_FLAGS = -z common-page-size=0x1000
-  XCODE:*_*_*_DLINK_FLAGS =
+  XCODE:*_*_*_DLINK_FLAGS = -seg1addr 0x1000 -segalign 0x1000
+  XCODE:*_*_*_MTOC_FLAGS = -align 0x1000
   CLANGPDB:*_*_*_DLINK_FLAGS = /ALIGN:4096
 
 ################################################################################

--- a/OvmfPkg/OvmfPkgIa32X64.dsc
+++ b/OvmfPkg/OvmfPkgIa32X64.dsc
@@ -90,14 +90,16 @@
 
 [BuildOptions.common.EDKII.DXE_RUNTIME_DRIVER]
   GCC:*_*_*_DLINK_FLAGS = -z common-page-size=0x1000
-  XCODE:*_*_*_DLINK_FLAGS =
+  XCODE:*_*_*_DLINK_FLAGS = -seg1addr 0x1000 -segalign 0x1000
+  XCODE:*_*_*_MTOC_FLAGS = -align 0x1000
   CLANGPDB:*_*_*_DLINK_FLAGS = /ALIGN:4096
 
 # Force PE/COFF sections to be aligned at 4KB boundaries to support page level
 # protection of DXE_SMM_DRIVER/SMM_CORE modules
 [BuildOptions.common.EDKII.DXE_SMM_DRIVER, BuildOptions.common.EDKII.SMM_CORE]
   GCC:*_*_*_DLINK_FLAGS = -z common-page-size=0x1000
-  XCODE:*_*_*_DLINK_FLAGS =
+  XCODE:*_*_*_DLINK_FLAGS = -seg1addr 0x1000 -segalign 0x1000
+  XCODE:*_*_*_MTOC_FLAGS = -align 0x1000
   CLANGPDB:*_*_*_DLINK_FLAGS = /ALIGN:4096
 
 ################################################################################

--- a/OvmfPkg/OvmfPkgX64.dsc
+++ b/OvmfPkg/OvmfPkgX64.dsc
@@ -90,14 +90,16 @@
 
 [BuildOptions.common.EDKII.DXE_RUNTIME_DRIVER]
   GCC:*_*_*_DLINK_FLAGS = -z common-page-size=0x1000
-  XCODE:*_*_*_DLINK_FLAGS =
+  XCODE:*_*_*_DLINK_FLAGS = -seg1addr 0x1000 -segalign 0x1000
+  XCODE:*_*_*_MTOC_FLAGS = -align 0x1000
   CLANGPDB:*_*_*_DLINK_FLAGS = /ALIGN:4096
 
 # Force PE/COFF sections to be aligned at 4KB boundaries to support page level
 # protection of DXE_SMM_DRIVER/SMM_CORE modules
 [BuildOptions.common.EDKII.DXE_SMM_DRIVER, BuildOptions.common.EDKII.SMM_CORE]
   GCC:*_*_*_DLINK_FLAGS = -z common-page-size=0x1000
-  XCODE:*_*_*_DLINK_FLAGS =
+  XCODE:*_*_*_DLINK_FLAGS = -seg1addr 0x1000 -segalign 0x1000
+  XCODE:*_*_*_MTOC_FLAGS = -align 0x1000
   CLANGPDB:*_*_*_DLINK_FLAGS = /ALIGN:4096
 
 ################################################################################

--- a/OvmfPkg/OvmfXen.dsc
+++ b/OvmfPkg/OvmfXen.dsc
@@ -82,13 +82,17 @@
 
 [BuildOptions.common.EDKII.DXE_RUNTIME_DRIVER]
   GCC:*_*_*_DLINK_FLAGS = -z common-page-size=0x1000
-  XCODE:*_*_*_DLINK_FLAGS =
+  XCODE:*_*_*_DLINK_FLAGS = -seg1addr 0x1000 -segalign 0x1000
+  XCODE:*_*_*_MTOC_FLAGS = -align 0x1000
+  CLANGPDB:*_*_*_DLINK_FLAGS = /ALIGN:4096
 
 # Force PE/COFF sections to be aligned at 4KB boundaries to support page level
 # protection of DXE_SMM_DRIVER/SMM_CORE modules
 [BuildOptions.common.EDKII.DXE_SMM_DRIVER, BuildOptions.common.EDKII.SMM_CORE]
   GCC:*_*_*_DLINK_FLAGS = -z common-page-size=0x1000
-  XCODE:*_*_*_DLINK_FLAGS =
+  XCODE:*_*_*_DLINK_FLAGS = -seg1addr 0x1000 -segalign 0x1000
+  XCODE:*_*_*_MTOC_FLAGS = -align 0x1000
+  CLANGPDB:*_*_*_DLINK_FLAGS = /ALIGN:4096
 
 ################################################################################
 #

--- a/OvmfPkg/PvScsiDxe/PvScsi.c
+++ b/OvmfPkg/PvScsiDxe/PvScsi.c
@@ -991,13 +991,6 @@ PvScsiInitRings (
   )
 {
   EFI_STATUS Status;
-  union {
-    PVSCSI_CMD_DESC_SETUP_RINGS Cmd;
-    UINT32                      Uint32;
-  } AlignedCmd;
-  PVSCSI_CMD_DESC_SETUP_RINGS *Cmd;
-
-  Cmd = &AlignedCmd.Cmd;
 
   Status = PvScsiAllocateSharedPages (
              Dev,
@@ -1032,45 +1025,7 @@ PvScsiInitRings (
   }
   ZeroMem (Dev->RingDesc.RingCmps, EFI_PAGE_SIZE);
 
-  ZeroMem (Cmd, sizeof (*Cmd));
-  Cmd->ReqRingNumPages = 1;
-  Cmd->CmpRingNumPages = 1;
-  Cmd->RingsStatePPN = RShiftU64 (
-                         Dev->RingDesc.RingStateDmaDesc.DeviceAddress,
-                         EFI_PAGE_SHIFT
-                         );
-  Cmd->ReqRingPPNs[0] = RShiftU64 (
-                          Dev->RingDesc.RingReqsDmaDesc.DeviceAddress,
-                          EFI_PAGE_SHIFT
-                          );
-  Cmd->CmpRingPPNs[0] = RShiftU64 (
-                          Dev->RingDesc.RingCmpsDmaDesc.DeviceAddress,
-                          EFI_PAGE_SHIFT
-                          );
-
-  STATIC_ASSERT (
-    sizeof (*Cmd) % sizeof (UINT32) == 0,
-    "Cmd must be multiple of 32-bit words"
-    );
-  Status = PvScsiWriteCmdDesc (
-             Dev,
-             PvScsiCmdSetupRings,
-             (UINT32 *)Cmd,
-             sizeof (*Cmd) / sizeof (UINT32)
-             );
-  if (EFI_ERROR (Status)) {
-    goto FreeRingCmps;
-  }
-
   return EFI_SUCCESS;
-
-FreeRingCmps:
-  PvScsiFreeSharedPages (
-    Dev,
-    1,
-    Dev->RingDesc.RingCmps,
-    &Dev->RingDesc.RingCmpsDmaDesc
-    );
 
 FreeRingReqs:
   PvScsiFreeSharedPages (
@@ -1117,6 +1072,48 @@ PvScsiFreeRings (
     Dev->RingDesc.RingState,
     &Dev->RingDesc.RingStateDmaDesc
     );
+}
+
+STATIC
+EFI_STATUS
+PvScsiSetupRings (
+  IN OUT PVSCSI_DEV *Dev
+  )
+{
+  union {
+    PVSCSI_CMD_DESC_SETUP_RINGS Cmd;
+    UINT32                      Uint32;
+  } AlignedCmd;
+  PVSCSI_CMD_DESC_SETUP_RINGS *Cmd;
+
+  Cmd = &AlignedCmd.Cmd;
+
+  ZeroMem (Cmd, sizeof (*Cmd));
+  Cmd->ReqRingNumPages = 1;
+  Cmd->CmpRingNumPages = 1;
+  Cmd->RingsStatePPN = RShiftU64 (
+                         Dev->RingDesc.RingStateDmaDesc.DeviceAddress,
+                         EFI_PAGE_SHIFT
+                         );
+  Cmd->ReqRingPPNs[0] = RShiftU64 (
+                          Dev->RingDesc.RingReqsDmaDesc.DeviceAddress,
+                          EFI_PAGE_SHIFT
+                          );
+  Cmd->CmpRingPPNs[0] = RShiftU64 (
+                          Dev->RingDesc.RingCmpsDmaDesc.DeviceAddress,
+                          EFI_PAGE_SHIFT
+                          );
+
+  STATIC_ASSERT (
+    sizeof (*Cmd) % sizeof (UINT32) == 0,
+    "Cmd must be multiple of 32-bit words"
+    );
+  return PvScsiWriteCmdDesc (
+           Dev,
+           PvScsiCmdSetupRings,
+           (UINT32 *)Cmd,
+           sizeof (*Cmd) / sizeof (UINT32)
+           );
 }
 
 STATIC
@@ -1172,6 +1169,14 @@ PvScsiInit (
   }
 
   //
+  // Setup rings against device
+  //
+  Status = PvScsiSetupRings (Dev);
+  if (EFI_ERROR (Status)) {
+    goto FreeDmaCommBuffer;
+  }
+
+  //
   // Populate the exported interface's attributes
   //
   Dev->PassThru.Mode             = &Dev->PassThruMode;
@@ -1202,13 +1207,15 @@ PvScsiInit (
 
   return EFI_SUCCESS;
 
-FreeRings:
-  //
-  // Reset device to stop device usage of the rings.
-  // This is required to safely free the rings.
-  //
-  PvScsiResetAdapter (Dev);
+FreeDmaCommBuffer:
+  PvScsiFreeSharedPages (
+    Dev,
+    EFI_SIZE_TO_PAGES (sizeof (*Dev->DmaBuf)),
+    Dev->DmaBuf,
+    &Dev->DmaBufDmaDesc
+    );
 
+FreeRings:
   PvScsiFreeRings (Dev);
 
 RestorePciAttributes:

--- a/OvmfPkg/PvScsiDxe/PvScsi.c
+++ b/OvmfPkg/PvScsiDxe/PvScsi.c
@@ -455,8 +455,12 @@ HandleResponse (
 
   //
   // Report target status
+  // (Strangely, PVSCSI interface defines Response->ScsiStatus as UINT16.
+  // But it should de-facto always have a value that fits UINT8. To avoid
+  // unexpected behavior, verify value is in UINT8 bounds before casting)
   //
-  Packet->TargetStatus = Response->ScsiStatus;
+  ASSERT (Response->ScsiStatus <= MAX_UINT8);
+  Packet->TargetStatus = (UINT8)Response->ScsiStatus;
 
   //
   // Host adapter status and function return value depend on


### PR DESCRIPTION
* [edk2-devel] [PATCH 1/1] OvmfPkg: Fix SMM/RT driver section alignment for XCODE5/CLANGPDB
  https://edk2.groups.io/g/devel/message/56559
  http://mid.mail-archive.com/20200329132158.35259-2-cheptsov@ispras.ru

* [edk2-devel] [PATCH] NetworkPkg/UefiPxeBcDxe: handle competing DHCP servers (more) gracefully
  https://edk2.groups.io/g/devel/message/56699
  http://mid.mail-archive.com/20200331004749.16128-1-lersek@redhat.com

* [edk2-devel] [PATCH] Maintainers.txt: Add Liran and Nikita as OvmfPkg/PvScsiDxe reviewers
  https://edk2.groups.io/g/devel/message/56746
  http://mid.mail-archive.com/20200331110244.51409-1-liran.alon@oracle.com

* [edk2-devel] [PATCH] OvmfPkg/PvScsiDxe: Fix VS2019 build error because of implicit cast
  https://edk2.groups.io/g/devel/message/56747
  http://mid.mail-archive.com/20200331110452.51992-1-liran.alon@oracle.com

* [edk2-devel] [PATCH v2] OvmfPkg/PvScsiDxe: Refactor setup of rings to separate function 
  https://edk2.groups.io/g/devel/message/56794
  http://mid.mail-archive.com/20200331225637.123318-1-liran.alon@oracle.com
