### PR TITLE
MdeModulePkg/SmiHandlerProfileInfo: Overflowed Array Index

### DIFF
--- a/MdeModulePkg/Application/SmiHandlerProfileInfo/SmiHandlerProfileInfo.c
+++ b/MdeModulePkg/Application/SmiHandlerProfileInfo/SmiHandlerProfileInfo.c
@@ -382,7 +382,7 @@ SxTypeToString (
   IN EFI_SLEEP_TYPE  Type
   )
 {
-  if (Type >= 0 && Type <= ARRAY_SIZE(mSxTypeString)) {
+  if (Type >= 0 && Type < ARRAY_SIZE(mSxTypeString)) {
     return mSxTypeString[Type];
   } else {
     AsciiSPrint (mNameString, sizeof(mNameString), "0x%x", Type);
@@ -407,7 +407,7 @@ SxPhaseToString (
   IN EFI_SLEEP_PHASE Phase
   )
 {
-  if (Phase >= 0 && Phase <= ARRAY_SIZE(mSxPhaseString)) {
+  if (Phase >= 0 && Phase < ARRAY_SIZE(mSxPhaseString)) {
     return mSxPhaseString[Phase];
   } else {
     AsciiSPrint (mNameString, sizeof(mNameString), "0x%x", Phase);
@@ -432,7 +432,7 @@ PowerButtonPhaseToString (
   IN EFI_POWER_BUTTON_PHASE  Phase
   )
 {
-  if (Phase >= 0 && Phase <= ARRAY_SIZE(mPowerButtonPhaseString)) {
+  if (Phase >= 0 && Phase < ARRAY_SIZE(mPowerButtonPhaseString)) {
     return mPowerButtonPhaseString[Phase];
   } else {
     AsciiSPrint (mNameString, sizeof(mNameString), "0x%x", Phase);
@@ -457,7 +457,7 @@ StandbyButtonPhaseToString (
   IN EFI_STANDBY_BUTTON_PHASE  Phase
   )
 {
-  if (Phase >= 0 && Phase <= ARRAY_SIZE(mStandbyButtonPhaseString)) {
+  if (Phase >= 0 && Phase < ARRAY_SIZE(mStandbyButtonPhaseString)) {
     return mStandbyButtonPhaseString[Phase];
   } else {
     AsciiSPrint (mNameString, sizeof(mNameString), "0x%x", Phase);
@@ -483,7 +483,7 @@ IoTrapTypeToString (
   IN EFI_SMM_IO_TRAP_DISPATCH_TYPE  Type
   )
 {
-  if (Type >= 0 && Type <= ARRAY_SIZE(mIoTrapTypeString)) {
+  if (Type >= 0 && Type < ARRAY_SIZE(mIoTrapTypeString)) {
     return mIoTrapTypeString[Type];
   } else {
     AsciiSPrint (mNameString, sizeof(mNameString), "0x%x", Type);
@@ -508,7 +508,7 @@ UsbTypeToString (
   IN EFI_USB_SMI_TYPE          Type
   )
 {
-  if (Type >= 0 && Type <= ARRAY_SIZE(mUsbTypeString)) {
+  if (Type >= 0 && Type < ARRAY_SIZE(mUsbTypeString)) {
     return mUsbTypeString[Type];
   } else {
     AsciiSPrint (mNameString, sizeof(mNameString), "0x%x", Type);


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=2272
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=2287
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=2288
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=2289
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=2290

Index should be off-by one than size of array, so when check
array, the max index should less than size of array.

Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Hao A Wu <hao.a.wu@intel.com>
Cc: Eric Dong <eric.dong@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Signed-off-by: Guomin Jiang <guomin.jiang@intel.com>
Reviewed-by: Jian J Wang <jian.j.wang@intel.com>