### PR TITLE
MdePkg DebugLib: Enable FILE NAME as DEBUG ASSERT for CLANG

### DIFF
--- a/MdePkg/Include/Library/DebugLib.h
+++ b/MdePkg/Include/Library/DebugLib.h
@@ -8,7 +8,7 @@
   of size reduction when compiler optimization is disabled. If MDEPKG_NDEBUG is
   defined, then debug and assert related macros wrapped by it are the NULL implementations.
 
-Copyright (c) 2006 - 2019, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2006 - 2020, Intel Corporation. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -289,7 +289,11 @@ DebugPrintLevelEnabled (
   @param  Expression  Boolean expression that evaluated to FALSE
 
 **/
+#if defined(__clang__) && defined(__FILE_NAME__)
+#define _ASSERT(Expression)  DebugAssert (__FILE_NAME__, __LINE__, #Expression)
+#else
 #define _ASSERT(Expression)  DebugAssert (__FILE__, __LINE__, #Expression)
+#endif
 
 
 /**


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=1548
For clang compiler, This change will make the generated image not include the
absolute file path. If so, the generated debug image can be reproduced in the
different root directory. Also, it will reduce the size of debug image size.
To do so, use __FILE_NAME__ macro to replace __FILE__. __FILE_NAME__ is
Clang-specific extension that functions similar to __FILE__ but only renders
the last path component (the filename) instead of an invocation dependent full
path to that file, and __FILE_NAME__ is introduced since clang 9.

CC: Michael D Kinney <michael.d.kinney@intel.com>
CC: Liming Gao <liming.gao@intel.com>
Reviewed-by: Liming Gao <liming.gao@intel.com>
Signed-off-by: Zhiguang Liu <zhiguang.liu@intel.com>