### PR TITLE
MdePkg/UefiScsiLib: Set FUA bit for synchronous SCSI Write operations

### DIFF
--- a/MdePkg/Include/IndustryStandard/Scsi.h
+++ b/MdePkg/Include/IndustryStandard/Scsi.h
@@ -1,7 +1,7 @@
 /** @file
   Support for SCSI-2 standard
 
-  Copyright (c) 2006 - 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2006 - 2020, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -174,6 +174,12 @@
 //
 #define EFI_SCSI_DATA_IN  0
 #define EFI_SCSI_DATA_OUT 1
+
+//
+// SCSI Block Command Cache Control Parameters
+//
+#define EFI_SCSI_BLOCK_FUA  BIT3  ///< Force Unit Access
+#define EFI_SCSI_BLOCK_DPO  BIT4  ///< Disable Page Out
 
 //
 // Peripheral Device Type Definitions

--- a/MdePkg/Library/UefiScsiLib/UefiScsiLib.c
+++ b/MdePkg/Library/UefiScsiLib/UefiScsiLib.c
@@ -1,7 +1,7 @@
 /** @file
   UEFI SCSI Library implementation
 
-  Copyright (c) 2006 - 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2006 - 2020, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -1055,15 +1055,16 @@ ScsiWrite10Command (
   ZeroMem (&CommandPacket, sizeof (EFI_SCSI_IO_SCSI_REQUEST_PACKET));
   ZeroMem (Cdb, EFI_SCSI_OP_LENGTH_TEN);
 
-  CommandPacket.Timeout         = Timeout;
-  CommandPacket.OutDataBuffer    = DataBuffer;
-  CommandPacket.SenseData       = SenseData;
-  CommandPacket.OutTransferLength= *DataLength;
-  CommandPacket.Cdb             = Cdb;
+  CommandPacket.Timeout           = Timeout;
+  CommandPacket.OutDataBuffer     = DataBuffer;
+  CommandPacket.SenseData         = SenseData;
+  CommandPacket.OutTransferLength = *DataLength;
+  CommandPacket.Cdb               = Cdb;
   //
   // Fill Cdb for Write (10) Command
   //
   Cdb[0]                        = EFI_SCSI_OP_WRITE10;
+  Cdb[1]                        = EFI_SCSI_BLOCK_FUA;
   WriteUnaligned32 ((UINT32 *)&Cdb[2], SwapBytes32 (StartLba));
   WriteUnaligned16 ((UINT16 *)&Cdb[7], SwapBytes16 ((UINT16) SectorSize));
 
@@ -1263,6 +1264,7 @@ ScsiWrite16Command (
   // Fill Cdb for Write (16) Command
   //
   Cdb[0]                        = EFI_SCSI_OP_WRITE16;
+  Cdb[1]                        = EFI_SCSI_BLOCK_FUA;
   WriteUnaligned64 ((UINT64 *)&Cdb[2], SwapBytes64 (StartLba));
   WriteUnaligned32 ((UINT32 *)&Cdb[10], SwapBytes32 (SectorSize));
 


### PR DESCRIPTION
The FUA (Force Unit Access) bit forces data to be written directly to
disk instead of the write cache. This prevents data from being lost if a
shutdown or reset is requested immediately after a SCSI write operation.

Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Liming Gao <liming.gao@intel.com>
Cc: Zhiguang Liu <zhiguang.liu@intel.com>
Reviewed-by: Liming Gao <liming.gao@intel.com>
Reviewed-by: Zhiguang Liu <zhiguang.liu@intel.com>
Signed-off-by: Christopher J Zurcher <christopher.j.zurcher@intel.com>