### PR TITLE
lersek queue 2020-Apr-16 -- push

### DIFF
--- a/MdeModulePkg/Bus/Pci/NonDiscoverablePciDeviceDxe/NonDiscoverablePciDeviceIo.c
+++ b/MdeModulePkg/Bus/Pci/NonDiscoverablePciDeviceDxe/NonDiscoverablePciDeviceIo.c
@@ -1679,8 +1679,8 @@ InitializePciIoProtocol (
     ASSERT (Desc->Desc == ACPI_ADDRESS_SPACE_DESCRIPTOR);
     ASSERT (Desc->ResType == ACPI_ADDRESS_SPACE_TYPE_MEM);
 
-    if (Idx >= PCI_MAX_BARS ||
-        (Idx == PCI_MAX_BARS - 1 && Desc->AddrSpaceGranularity == 64)) {
+    if (Idx >= PCI_MAX_BAR ||
+        (Idx == PCI_MAX_BAR - 1 && Desc->AddrSpaceGranularity == 64)) {
       DEBUG ((DEBUG_ERROR,
         "%a: resource count exceeds number of emulated BARs\n",
         __FUNCTION__));

--- a/MdeModulePkg/Bus/Pci/NonDiscoverablePciDeviceDxe/NonDiscoverablePciDeviceIo.h
+++ b/MdeModulePkg/Bus/Pci/NonDiscoverablePciDeviceDxe/NonDiscoverablePciDeviceIo.h
@@ -36,8 +36,6 @@
 #define PCI_ID_VENDOR_UNKNOWN         0xffff
 #define PCI_ID_DEVICE_DONTCARE        0x0000
 
-#define PCI_MAX_BARS                  6
-
 extern EFI_CPU_ARCH_PROTOCOL      *mCpu;
 
 typedef struct {


### PR DESCRIPTION
[edk2-devel] [PATCH] MdeModulePkg/NonDiscoverablePciDeviceDxe: use standard PCI_MAX_BAR macro
https://edk2.groups.io/g/devel/message/57118
http://mid.mail-archive.com/20200409113017.18233-1-lersek@redhat.com
