### PR TITLE
MdePkg: Add AML FieldList OpCode definitions

### DIFF
--- a/MdePkg/Include/IndustryStandard/AcpiAml.h
+++ b/MdePkg/Include/IndustryStandard/AcpiAml.h
@@ -168,4 +168,12 @@
 #define AML_EXT_BANK_FIELD_OP        0x87
 #define AML_EXT_DATA_REGION_OP       0x88
 
+//
+// FieldElement OpCode
+//
+#define AML_FIELD_RESERVED_OP        0x00
+#define AML_FIELD_ACCESS_OP          0x01
+#define AML_FIELD_CONNECTION_OP      0x02
+#define AML_FIELD_EXT_ACCESS_OP      0x03
+
 #endif


### PR DESCRIPTION
The ACPI specification, version 6.3, January 2019,
defines the Named Objects Encoding for FieldElements
in section '20.2.5.2 Named Objects Encoding'.
FieldElements can be one of the following:
NamedField | ReservedField | AccessField |
ExtendedAccessField | ConnectField

Some of these keywords are starting with an opcode,
allowing to identify their type.
E.g.: ReservedField := 0x00 PkgLength

This patch adds these FieldElement opcodes definitions to
the list of AML Opcode definitions.

Reviewed-by: Liming Gao <liming.gao@intel.com>
Reviewed-by: Sami Mujawar <sami.mujawar@arm.com>
Reviewed-by: Zhiguang Liu <zhiguang.liu@intel.com>
Signed-off-by: Pierre Gondois <pierre.gondois@arm.com>