### PR TITLE
.python/SpellCheck: Increase SpellCheck plugin max failures

### DIFF
--- a/.pytool/Plugin/SpellCheck/cspell.base.yaml
+++ b/.pytool/Plugin/SpellCheck/cspell.base.yaml
@@ -22,6 +22,8 @@
     ],
     "minWordLength": 5,
     "allowCompoundWords": false,
+    "maxNumberOfProblems": 200,
+    "maxDuplicateProblems": 200,
     "ignoreWords": [
         "muchange"
     ],


### PR DESCRIPTION
REF:https://bugzilla.tianocore.org/show_bug.cgi?id=2593

Increases the maximum number of failures in the SpellCheck plugin so
that more issues can be caught in a single pass.

Cc: Bob Feng <bob.c.feng@intel.com>
Cc: Bret Barkelew <Bret.Barkelew@microsoft.com>
Cc: Liming Gao <liming.gao@intel.com>
Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Sean Brogan <sean.brogan@microsoft.com>
Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>
Reviewed-by: Sean Brogan <sean.brogan@microsoft.com>
Reviewed-by: Shenglei Zhang <shenglei.zhang@intel.com>