### PR TITLE
Add linked list iteration macros to BaseLib.h

### DIFF
--- a/MdeModulePkg/Bus/Pci/EhciDxe/Ehci.h
+++ b/MdeModulePkg/Bus/Pci/EhciDxe/Ehci.h
@@ -3,6 +3,7 @@
   Provides some data struct used by EHCI controller driver.
 
 Copyright (c) 2006 - 2018, Intel Corporation. All rights reserved.<BR>
+Copyright (c) Microsoft Corporation.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -79,20 +80,6 @@ typedef struct _USB2_HC_DEV  USB2_HC_DEV;
 // to protect shared data structures.
 //
 #define  EHC_TPL                     TPL_NOTIFY
-
-//
-//Iterate through the double linked list. NOT delete safe
-//
-#define EFI_LIST_FOR_EACH(Entry, ListHead)    \
-  for(Entry = (ListHead)->ForwardLink; Entry != (ListHead); Entry = Entry->ForwardLink)
-
-//
-//Iterate through the double linked list. This is delete-safe.
-//Don't touch NextEntry
-//
-#define EFI_LIST_FOR_EACH_SAFE(Entry, NextEntry, ListHead)            \
-  for(Entry = (ListHead)->ForwardLink, NextEntry = Entry->ForwardLink;\
-      Entry != (ListHead); Entry = NextEntry, NextEntry = Entry->ForwardLink)
 
 #define EFI_LIST_CONTAINER(Entry, Type, Field) BASE_CR(Entry, Type, Field)
 

--- a/MdeModulePkg/Bus/Pci/EhciDxe/EhciDebug.c
+++ b/MdeModulePkg/Bus/Pci/EhciDxe/EhciDebug.c
@@ -3,6 +3,7 @@
   This file provides the information dump support for EHCI when in debug mode.
 
 Copyright (c) 2007 - 2013, Intel Corporation. All rights reserved.<BR>
+Copyright (c) Microsoft Corporation.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -185,7 +186,7 @@ EhcDumpQh (
 
   DEBUG ((EFI_D_VERBOSE, "\n"));
 
-  EFI_LIST_FOR_EACH (Entry, &Qh->Qtds) {
+  BASE_LIST_FOR_EACH (Entry, &Qh->Qtds) {
     Qtd = EFI_LIST_CONTAINER (Entry, EHC_QTD, QtdList);
     EhcDumpQtd (Qtd, NULL);
 

--- a/MdeModulePkg/Bus/Pci/EhciDxe/EhciSched.c
+++ b/MdeModulePkg/Bus/Pci/EhciDxe/EhciSched.c
@@ -3,6 +3,7 @@
   EHCI transfer scheduling routines.
 
 Copyright (c) 2007 - 2018, Intel Corporation. All rights reserved.<BR>
+Copyright (c) Microsoft Corporation.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -577,7 +578,7 @@ EhcCheckUrbResult (
     goto ON_EXIT;
   }
 
-  EFI_LIST_FOR_EACH (Entry, &Urb->Qh->Qtds) {
+  BASE_LIST_FOR_EACH (Entry, &Urb->Qh->Qtds) {
     Qtd   = EFI_LIST_CONTAINER (Entry, EHC_QTD, QtdList);
     QtdHw = &Qtd->QtdHw;
     State = (UINT8) QtdHw->Status;
@@ -757,7 +758,7 @@ EhciDelAsyncIntTransfer (
   Direction = (((EpNum & 0x80) != 0) ? EfiUsbDataIn : EfiUsbDataOut);
   EpNum    &= 0x0F;
 
-  EFI_LIST_FOR_EACH_SAFE (Entry, Next, &Ehc->AsyncIntTransfers) {
+  BASE_LIST_FOR_EACH_SAFE (Entry, Next, &Ehc->AsyncIntTransfers) {
     Urb = EFI_LIST_CONTAINER (Entry, URB, UrbList);
 
     if ((Urb->Ep.DevAddr == DevAddr) && (Urb->Ep.EpAddr == EpNum) &&
@@ -797,7 +798,7 @@ EhciDelAllAsyncIntTransfers (
   LIST_ENTRY              *Next;
   URB                     *Urb;
 
-  EFI_LIST_FOR_EACH_SAFE (Entry, Next, &Ehc->AsyncIntTransfers) {
+  BASE_LIST_FOR_EACH_SAFE (Entry, Next, &Ehc->AsyncIntTransfers) {
     Urb = EFI_LIST_CONTAINER (Entry, URB, UrbList);
 
     EhcUnlinkQhFromPeriod (Ehc, Urb->Qh);
@@ -965,7 +966,7 @@ EhcUpdateAsyncRequest (
   if (Urb->Result == EFI_USB_NOERROR) {
     FirstQtd = NULL;
 
-    EFI_LIST_FOR_EACH (Entry, &Urb->Qh->Qtds) {
+    BASE_LIST_FOR_EACH (Entry, &Urb->Qh->Qtds) {
       Qtd = EFI_LIST_CONTAINER (Entry, EHC_QTD, QtdList);
 
       if (FirstQtd == NULL) {
@@ -1049,7 +1050,7 @@ EhcMonitorAsyncRequests (
   OldTpl  = gBS->RaiseTPL (EHC_TPL);
   Ehc     = (USB2_HC_DEV *) Context;
 
-  EFI_LIST_FOR_EACH_SAFE (Entry, Next, &Ehc->AsyncIntTransfers) {
+  BASE_LIST_FOR_EACH_SAFE (Entry, Next, &Ehc->AsyncIntTransfers) {
     Urb = EFI_LIST_CONTAINER (Entry, URB, UrbList);
 
     //

--- a/MdeModulePkg/Bus/Pci/EhciDxe/EhciUrb.c
+++ b/MdeModulePkg/Bus/Pci/EhciDxe/EhciUrb.c
@@ -4,6 +4,7 @@
     URB (Usb Request Block).
 
 Copyright (c) 2007 - 2010, Intel Corporation. All rights reserved.<BR>
+Copyright (c) Microsoft Corporation.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -299,7 +300,7 @@ EhcFreeQtds (
   LIST_ENTRY              *Next;
   EHC_QTD                 *Qtd;
 
-  EFI_LIST_FOR_EACH_SAFE (Entry, Next, Qtds) {
+  BASE_LIST_FOR_EACH_SAFE (Entry, Next, Qtds) {
     Qtd = EFI_LIST_CONTAINER (Entry, EHC_QTD, QtdList);
 
     RemoveEntryList (&Qtd->QtdList);
@@ -482,7 +483,7 @@ EhcCreateQtds (
   //
   // OK, all the QTDs needed are created. Now, fix the NextQtd point
   //
-  EFI_LIST_FOR_EACH (Entry, &Qh->Qtds) {
+  BASE_LIST_FOR_EACH (Entry, &Qh->Qtds) {
     Qtd = EFI_LIST_CONTAINER (Entry, EHC_QTD, QtdList);
 
     //

--- a/MdeModulePkg/Bus/Pci/EhciPei/EhcPeim.h
+++ b/MdeModulePkg/Bus/Pci/EhciPei/EhcPeim.h
@@ -2,6 +2,7 @@
 Private Header file for Usb Host Controller PEIM
 
 Copyright (c) 2010 - 2018, Intel Corporation. All rights reserved.<BR>
+Copyright (c) Microsoft Corporation.<BR>
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -17,6 +18,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Ppi/IoMmu.h>
 #include <Ppi/EndOfPeiPhase.h>
 
+#include <Library/BaseLib.h>
 #include <Library/DebugLib.h>
 #include <Library/PeimEntryPoint.h>
 #include <Library/PeiServicesLib.h>
@@ -59,20 +61,6 @@ typedef struct _PEI_USB2_HC_DEV PEI_USB2_HC_DEV;
 // Sync transfer polling interval, set by experience.
 //
 #define EHC_SYNC_POLL_INTERVAL       (6 * EHC_1_MILLISECOND)
-
-//
-//Iterate through the double linked list. NOT delete safe
-//
-#define EFI_LIST_FOR_EACH(Entry, ListHead)    \
-  for(Entry = (ListHead)->ForwardLink; Entry != (ListHead); Entry = Entry->ForwardLink)
-
-//
-//Iterate through the double linked list. This is delete-safe.
-//Don't touch NextEntry
-//
-#define EFI_LIST_FOR_EACH_SAFE(Entry, NextEntry, ListHead)            \
-  for(Entry = (ListHead)->ForwardLink, NextEntry = Entry->ForwardLink;\
-      Entry != (ListHead); Entry = NextEntry, NextEntry = Entry->ForwardLink)
 
 #define EFI_LIST_CONTAINER(Entry, Type, Field) BASE_CR(Entry, Type, Field)
 

--- a/MdeModulePkg/Bus/Pci/EhciPei/EhciPei.inf
+++ b/MdeModulePkg/Bus/Pci/EhciPei/EhciPei.inf
@@ -5,6 +5,7 @@
 # which is used to enable recovery function from USB Drivers.
 #
 # Copyright (c) 2010 - 2018, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) Microsoft Corporation.<BR>
 #
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -47,6 +48,7 @@
 [LibraryClasses]
   IoLib
   TimerLib
+  BaseLib
   BaseMemoryLib
   PeimEntryPoint
   PeiServicesLib

--- a/MdeModulePkg/Bus/Pci/EhciPei/EhciSched.c
+++ b/MdeModulePkg/Bus/Pci/EhciPei/EhciSched.c
@@ -3,6 +3,7 @@ PEIM to produce gPeiUsb2HostControllerPpiGuid based on gPeiUsbControllerPpiGuid
 which is used to enable recovery function from USB Drivers.
 
 Copyright (c) 2010 - 2018, Intel Corporation. All rights reserved.<BR>
+Copyright (c) Microsoft Corporation.<BR>
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -323,7 +324,7 @@ EhcCheckUrbResult (
     goto ON_EXIT;
   }
 
-  EFI_LIST_FOR_EACH (Entry, &Urb->Qh->Qtds) {
+  BASE_LIST_FOR_EACH (Entry, &Urb->Qh->Qtds) {
     Qtd   = EFI_LIST_CONTAINER (Entry, PEI_EHC_QTD, QtdList);
     QtdHw = &Qtd->QtdHw;
     State = (UINT8) QtdHw->Status;

--- a/MdeModulePkg/Bus/Pci/EhciPei/EhciUrb.c
+++ b/MdeModulePkg/Bus/Pci/EhciPei/EhciUrb.c
@@ -3,6 +3,7 @@ PEIM to produce gPeiUsb2HostControllerPpiGuid based on gPeiUsbControllerPpiGuid
 which is used to enable recovery function from USB Drivers.
 
 Copyright (c) 2010 - 2018, Intel Corporation. All rights reserved.<BR>
+Copyright (c) Microsoft Corporation.<BR>
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -290,7 +291,7 @@ EhcFreeQtds (
   EFI_LIST_ENTRY          *Next;
   PEI_EHC_QTD             *Qtd;
 
-  EFI_LIST_FOR_EACH_SAFE (Entry, Next, Qtds) {
+  BASE_LIST_FOR_EACH_SAFE (Entry, Next, Qtds) {
     Qtd = EFI_LIST_CONTAINER (Entry, PEI_EHC_QTD, QtdList);
 
     RemoveEntryList (&Qtd->QtdList);
@@ -461,7 +462,7 @@ EhcCreateQtds (
   //
   // OK, all the QTDs needed are created. Now, fix the NextQtd point
   //
-  EFI_LIST_FOR_EACH (Entry, &Qh->Qtds) {
+  BASE_LIST_FOR_EACH (Entry, &Qh->Qtds) {
     Qtd = EFI_LIST_CONTAINER (Entry, PEI_EHC_QTD, QtdList);
 
     //

--- a/MdeModulePkg/Bus/Pci/XhciDxe/Xhci.h
+++ b/MdeModulePkg/Bus/Pci/XhciDxe/Xhci.h
@@ -3,6 +3,7 @@
   Provides some data structure definitions used by the XHCI host controller driver.
 
 Copyright (c) 2011 - 2017, Intel Corporation. All rights reserved.<BR>
+Copyright (c) Microsoft Corporation.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -81,14 +82,6 @@ typedef struct _USB_DEV_CONTEXT      USB_DEV_CONTEXT;
 #define BULK_INTER                   2
 #define INT_INTER                    3
 #define INT_INTER_ASYNC              4
-
-//
-// Iterate through the double linked list. This is delete-safe.
-// Don't touch NextEntry
-//
-#define EFI_LIST_FOR_EACH_SAFE(Entry, NextEntry, ListHead) \
-  for (Entry = (ListHead)->ForwardLink, NextEntry = Entry->ForwardLink;\
-      Entry != (ListHead); Entry = NextEntry, NextEntry = Entry->ForwardLink)
 
 #define EFI_LIST_CONTAINER(Entry, Type, Field) BASE_CR(Entry, Type, Field)
 

--- a/MdeModulePkg/Bus/Pci/XhciDxe/XhciSched.c
+++ b/MdeModulePkg/Bus/Pci/XhciDxe/XhciSched.c
@@ -3,6 +3,7 @@
   XHCI transfer scheduling routines.
 
 Copyright (c) 2011 - 2018, Intel Corporation. All rights reserved.<BR>
+Copyright (c) Microsoft Corporation.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -1051,7 +1052,7 @@ IsAsyncIntTrb (
   LIST_ENTRY              *Next;
   URB                     *CheckedUrb;
 
-  EFI_LIST_FOR_EACH_SAFE (Entry, Next, &Xhc->AsyncIntTransfers) {
+  BASE_LIST_FOR_EACH_SAFE (Entry, Next, &Xhc->AsyncIntTransfers) {
     CheckedUrb = EFI_LIST_CONTAINER (Entry, URB, UrbList);
     if (IsTransferRingTrb (Xhc, Trb, CheckedUrb)) {
       *Urb = CheckedUrb;
@@ -1346,7 +1347,7 @@ XhciDelAsyncIntTransfer (
 
   Urb = NULL;
 
-  EFI_LIST_FOR_EACH_SAFE (Entry, Next, &Xhc->AsyncIntTransfers) {
+  BASE_LIST_FOR_EACH_SAFE (Entry, Next, &Xhc->AsyncIntTransfers) {
     Urb = EFI_LIST_CONTAINER (Entry, URB, UrbList);
     if ((Urb->Ep.BusAddr == BusAddr) &&
         (Urb->Ep.EpAddr == EpNum) &&
@@ -1386,7 +1387,7 @@ XhciDelAllAsyncIntTransfers (
   URB                     *Urb;
   EFI_STATUS              Status;
 
-  EFI_LIST_FOR_EACH_SAFE (Entry, Next, &Xhc->AsyncIntTransfers) {
+  BASE_LIST_FOR_EACH_SAFE (Entry, Next, &Xhc->AsyncIntTransfers) {
     Urb = EFI_LIST_CONTAINER (Entry, URB, UrbList);
 
     //
@@ -1578,7 +1579,7 @@ XhcMonitorAsyncRequests (
 
   Xhc    = (USB_XHCI_INSTANCE*) Context;
 
-  EFI_LIST_FOR_EACH_SAFE (Entry, Next, &Xhc->AsyncIntTransfers) {
+  BASE_LIST_FOR_EACH_SAFE (Entry, Next, &Xhc->AsyncIntTransfers) {
     Urb = EFI_LIST_CONTAINER (Entry, URB, UrbList);
 
     //

--- a/MdeModulePkg/Bus/Ufs/UfsPassThruDxe/UfsPassThru.c
+++ b/MdeModulePkg/Bus/Ufs/UfsPassThruDxe/UfsPassThru.c
@@ -1,6 +1,7 @@
 /** @file
 
   Copyright (c) 2014 - 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) Microsoft Corporation.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -1083,7 +1084,7 @@ UfsPassThruDriverBindingStop (
   // Cleanup the resources of I/O requests in the async I/O queue
   //
   if (!IsListEmpty(&Private->Queue)) {
-    EFI_LIST_FOR_EACH_SAFE (Entry, NextEntry, &Private->Queue) {
+    BASE_LIST_FOR_EACH_SAFE (Entry, NextEntry, &Private->Queue) {
       TransReq  = UFS_PASS_THRU_TRANS_REQ_FROM_THIS (Entry);
 
       //

--- a/MdeModulePkg/Bus/Ufs/UfsPassThruDxe/UfsPassThru.h
+++ b/MdeModulePkg/Bus/Ufs/UfsPassThruDxe/UfsPassThru.h
@@ -1,6 +1,7 @@
 /** @file
 
   Copyright (c) 2014 - 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) Microsoft Corporation.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -45,14 +46,6 @@ typedef struct {
   UINT16   BitMask:12;              // Bit 0~7 is 1/1 mapping to common luns. Bit 8~11 is 1/1 mapping to well-known luns.
   UINT16   Rsvd:4;
 } UFS_EXPOSED_LUNS;
-
-//
-// Iterate through the double linked list. This is delete-safe.
-// Do not touch NextEntry
-//
-#define EFI_LIST_FOR_EACH_SAFE(Entry, NextEntry, ListHead)            \
-  for(Entry = (ListHead)->ForwardLink, NextEntry = Entry->ForwardLink;\
-      Entry != (ListHead); Entry = NextEntry, NextEntry = Entry->ForwardLink)
 
 typedef struct _UFS_PASS_THRU_PRIVATE_DATA {
   UINT32                              Signature;

--- a/MdeModulePkg/Bus/Ufs/UfsPassThruDxe/UfsPassThruHci.c
+++ b/MdeModulePkg/Bus/Ufs/UfsPassThruDxe/UfsPassThruHci.c
@@ -3,6 +3,7 @@
   for upper layer application to execute UFS-supported SCSI cmds.
 
   Copyright (c) 2014 - 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) Microsoft Corporation.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -2285,7 +2286,7 @@ ProcessAsyncTaskList (
   // Check the entries in the async I/O queue are done or not.
   //
   if (!IsListEmpty(&Private->Queue)) {
-    EFI_LIST_FOR_EACH_SAFE (Entry, NextEntry, &Private->Queue) {
+    BASE_LIST_FOR_EACH_SAFE (Entry, NextEntry, &Private->Queue) {
       TransReq  = UFS_PASS_THRU_TRANS_REQ_FROM_THIS (Entry);
       Packet    = TransReq->Packet;
 

--- a/MdeModulePkg/Universal/Disk/RamDiskDxe/RamDiskDriver.c
+++ b/MdeModulePkg/Universal/Disk/RamDiskDxe/RamDiskDriver.c
@@ -2,6 +2,7 @@
   The driver entry point for RamDiskDxe driver.
 
   Copyright (c) 2016, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) Microsoft Corporation.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -92,7 +93,7 @@ RamDiskAcpiCheck (
     return;
   }
 
-  EFI_LIST_FOR_EACH (Entry, &RegisteredRamDisks) {
+  BASE_LIST_FOR_EACH (Entry, &RegisteredRamDisks) {
     PrivateData = RAM_DISK_PRIVATE_FROM_THIS (Entry);
     RamDiskPublishNfit (PrivateData);
   }

--- a/MdeModulePkg/Universal/Disk/RamDiskDxe/RamDiskImpl.c
+++ b/MdeModulePkg/Universal/Disk/RamDiskDxe/RamDiskImpl.c
@@ -3,6 +3,7 @@
 
   Copyright (c) 2016, Intel Corporation. All rights reserved.<BR>
   (C) Copyright 2016-2018 Hewlett Packard Enterprise Development LP<BR>
+  Copyright (c) Microsoft Corporation.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -165,7 +166,7 @@ UnregisterAllRamDisks (
   RAM_DISK_PRIVATE_DATA           *PrivateData;
 
   if (!IsListEmpty(&RegisteredRamDisks)) {
-    EFI_LIST_FOR_EACH_SAFE (Entry, NextEntry, &RegisteredRamDisks) {
+    BASE_LIST_FOR_EACH_SAFE (Entry, NextEntry, &RegisteredRamDisks) {
       PrivateData = RAM_DISK_PRIVATE_FROM_THIS (Entry);
 
       gBS->UninstallMultipleProtocolInterfaces (
@@ -507,7 +508,7 @@ UpdateMainForm (
   EndLabel->Number       = MAIN_LABEL_LIST_END;
 
   Index = 0;
-  EFI_LIST_FOR_EACH (Entry, &RegisteredRamDisks) {
+  BASE_LIST_FOR_EACH (Entry, &RegisteredRamDisks) {
     PrivateData                  = RAM_DISK_PRIVATE_FROM_THIS (Entry);
     PrivateData->CheckBoxId      = (EFI_QUESTION_ID)
                                    (MAIN_CHECKBOX_QUESTION_ID_START + Index);
@@ -689,7 +690,7 @@ RamDiskCallback (
       //
       // Remove the selected RAM disks
       //
-      EFI_LIST_FOR_EACH_SAFE (Entry, NextEntry, &RegisteredRamDisks) {
+      BASE_LIST_FOR_EACH_SAFE (Entry, NextEntry, &RegisteredRamDisks) {
         PrivateData = RAM_DISK_PRIVATE_FROM_THIS (Entry);
         if (PrivateData->CheckBoxChecked) {
           RamDiskUnregister (
@@ -742,7 +743,7 @@ RamDiskCallback (
       //
       if ((QuestionId >= MAIN_CHECKBOX_QUESTION_ID_START) &&
           (QuestionId < CREATE_RAW_RAM_DISK_FORM_ID)) {
-        EFI_LIST_FOR_EACH (Entry, &RegisteredRamDisks) {
+        BASE_LIST_FOR_EACH (Entry, &RegisteredRamDisks) {
           PrivateData = RAM_DISK_PRIVATE_FROM_THIS (Entry);
           if (PrivateData->CheckBoxId == QuestionId) {
             PrivateData->CheckBoxChecked = (BOOLEAN) (Value->u8 != 0);

--- a/MdeModulePkg/Universal/Disk/RamDiskDxe/RamDiskImpl.h
+++ b/MdeModulePkg/Universal/Disk/RamDiskDxe/RamDiskImpl.h
@@ -2,6 +2,7 @@
   The header file of RamDiskDxe driver.
 
   Copyright (c) 2016 - 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) Microsoft Corporation.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -46,20 +47,6 @@
 // Default block size for RAM disk
 //
 #define RAM_DISK_DEFAULT_BLOCK_SIZE 512
-
-//
-// Iterate through the double linked list. NOT delete safe
-//
-#define EFI_LIST_FOR_EACH(Entry, ListHead)    \
-  for(Entry = (ListHead)->ForwardLink; Entry != (ListHead); Entry = Entry->ForwardLink)
-
-//
-// Iterate through the double linked list. This is delete-safe.
-// Do not touch NextEntry
-//
-#define EFI_LIST_FOR_EACH_SAFE(Entry, NextEntry, ListHead)            \
-  for(Entry = (ListHead)->ForwardLink, NextEntry = Entry->ForwardLink;\
-      Entry != (ListHead); Entry = NextEntry, NextEntry = Entry->ForwardLink)
 
 //
 // RamDiskDxe driver maintains a list of registered RAM disks.

--- a/MdeModulePkg/Universal/Disk/RamDiskDxe/RamDiskProtocol.c
+++ b/MdeModulePkg/Universal/Disk/RamDiskDxe/RamDiskProtocol.c
@@ -3,6 +3,7 @@
 
   Copyright (c) 2016 - 2019, Intel Corporation. All rights reserved.<BR>
   (C) Copyright 2016 Hewlett Packard Enterprise Development LP<BR>
+  Copyright (c) Microsoft Corporation.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -662,7 +663,7 @@ RamDiskRegister (
   if (!IsListEmpty(&RegisteredRamDisks)) {
     DevicePathSize = GetDevicePathSize (PrivateData->DevicePath);
 
-    EFI_LIST_FOR_EACH (Entry, &RegisteredRamDisks) {
+    BASE_LIST_FOR_EACH (Entry, &RegisteredRamDisks) {
       RegisteredPrivateData = RAM_DISK_PRIVATE_FROM_THIS (Entry);
       if (DevicePathSize == GetDevicePathSize (RegisteredPrivateData->DevicePath)) {
         //
@@ -797,7 +798,7 @@ RamDiskUnregister (
   EndingAddr     = ReadUnaligned64 ((UINT64 *) &(RamDiskDevNode->EndingAddr[0]));
 
   if (!IsListEmpty(&RegisteredRamDisks)) {
-    EFI_LIST_FOR_EACH_SAFE (Entry, NextEntry, &RegisteredRamDisks) {
+    BASE_LIST_FOR_EACH_SAFE (Entry, NextEntry, &RegisteredRamDisks) {
       PrivateData = RAM_DISK_PRIVATE_FROM_THIS (Entry);
 
       //

--- a/MdePkg/Include/Library/BaseLib.h
+++ b/MdePkg/Include/Library/BaseLib.h
@@ -4,6 +4,7 @@
 
 Copyright (c) 2006 - 2019, Intel Corporation. All rights reserved.<BR>
 Portions copyright (c) 2008 - 2009, Apple Inc. All rights reserved.<BR>
+Copyright (c) Microsoft Corporation.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -2972,6 +2973,32 @@ PathCleanUpDirectories(
 **/
 #define INITIALIZE_LIST_HEAD_VARIABLE(ListHead)  {&(ListHead), &(ListHead)}
 
+/**
+  Iterates over each node in a doubly linked list using each node's forward link.
+
+  @param  Entry     A pointer to a list node used as a loop cursor during iteration
+  @param  ListHead  The head node of the doubly linked list
+
+**/
+#define BASE_LIST_FOR_EACH(Entry, ListHead)    \
+  for(Entry = (ListHead)->ForwardLink; Entry != (ListHead); Entry = Entry->ForwardLink)
+
+/**
+  Iterates over each node in a doubly linked list using each node's forward link
+  with safety against node removal.
+
+  This macro uses NextEntry to temporarily store the next list node so the node
+  pointed to by Entry may be deleted in the current loop iteration step and
+  iteration can continue from the node pointed to by NextEntry.
+
+  @param  Entry     A pointer to a list node used as a loop cursor during iteration
+  @param  NextEntry A pointer to a list node used to temporarily store the next node
+  @param  ListHead  The head node of the doubly linked list
+
+**/
+#define BASE_LIST_FOR_EACH_SAFE(Entry, NextEntry, ListHead)            \
+  for(Entry = (ListHead)->ForwardLink, NextEntry = Entry->ForwardLink;\
+      Entry != (ListHead); Entry = NextEntry, NextEntry = Entry->ForwardLink)
 
 /**
   Checks whether FirstEntry and SecondEntry are part of the same doubly-linked

--- a/SecurityPkg/HddPassword/HddPasswordDxe.c
+++ b/SecurityPkg/HddPassword/HddPasswordDxe.c
@@ -2,6 +2,7 @@
   HDD password driver which is used to support HDD security feature.
 
   Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) Microsoft Corporation.<BR>
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -115,7 +116,7 @@ BuildHddPasswordDeviceInfo (
   // Build HDD password device info and save them to LockBox.
   //
   DevInfoLength = 0;
-  EFI_LIST_FOR_EACH (Entry, &mHddPasswordConfigFormList) {
+  BASE_LIST_FOR_EACH (Entry, &mHddPasswordConfigFormList) {
     ConfigFormEntry = BASE_CR (Entry, HDD_PASSWORD_CONFIG_FORM_ENTRY, Link);
 
     //
@@ -164,7 +165,7 @@ BuildHddPasswordDeviceInfo (
   ASSERT (DevInfo != NULL);
 
   TempDevInfo = DevInfo;
-  EFI_LIST_FOR_EACH (Entry, &mHddPasswordConfigFormList) {
+  BASE_LIST_FOR_EACH (Entry, &mHddPasswordConfigFormList) {
     ConfigFormEntry = BASE_CR (Entry, HDD_PASSWORD_CONFIG_FORM_ENTRY, Link);
 
     if ((!PasswordIsFullZero (ConfigFormEntry->Password)) ||
@@ -472,7 +473,7 @@ HddPasswordEndOfDxeEventNotify (
   //
   // Zero passsword and freeze lock device.
   //
-  EFI_LIST_FOR_EACH (Entry, &mHddPasswordConfigFormList) {
+  BASE_LIST_FOR_EACH (Entry, &mHddPasswordConfigFormList) {
     ConfigFormEntry = BASE_CR (Entry, HDD_PASSWORD_CONFIG_FORM_ENTRY, Link);
 
     ZeroMem (ConfigFormEntry->Password, HDD_PASSWORD_MAX_LENGTH);
@@ -2026,7 +2027,7 @@ HddPasswordGetConfigFormEntryByIndex (
   CurrentIndex    = 0;
   ConfigFormEntry = NULL;
 
-  EFI_LIST_FOR_EACH (Entry, &mHddPasswordConfigFormList) {
+  BASE_LIST_FOR_EACH (Entry, &mHddPasswordConfigFormList) {
     if (CurrentIndex == Index) {
       ConfigFormEntry = BASE_CR (Entry, HDD_PASSWORD_CONFIG_FORM_ENTRY, Link);
       break;
@@ -2408,7 +2409,7 @@ HddPasswordConfigUpdateForm (
   ConfigFormEntry = NULL;
   EntryExisted    = FALSE;
 
-  EFI_LIST_FOR_EACH (Entry, &mHddPasswordConfigFormList) {
+  BASE_LIST_FOR_EACH (Entry, &mHddPasswordConfigFormList) {
     ConfigFormEntry = BASE_CR (Entry, HDD_PASSWORD_CONFIG_FORM_ENTRY, Link);
 
     if ((ConfigFormEntry->Bus == Bus) &&
@@ -2503,7 +2504,7 @@ HddPasswordConfigUpdateForm (
     EndLabel->Number       = HDD_DEVICE_LABEL_END;
 
     mNumberOfHddDevices = 0;
-    EFI_LIST_FOR_EACH (Entry, &mHddPasswordConfigFormList) {
+    BASE_LIST_FOR_EACH (Entry, &mHddPasswordConfigFormList) {
       ConfigFormEntry = BASE_CR (Entry, HDD_PASSWORD_CONFIG_FORM_ENTRY, Link);
 
       HiiCreateGotoOpCode (

--- a/SecurityPkg/HddPassword/HddPasswordDxe.h
+++ b/SecurityPkg/HddPassword/HddPasswordDxe.h
@@ -1,6 +1,7 @@
 /** @file
 
   Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) Microsoft Corporation.<BR>
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -86,12 +87,6 @@ typedef struct _HDD_PASSWORD_DXE_PRIVATE_DATA {
 } HDD_PASSWORD_DXE_PRIVATE_DATA;
 
 #define HDD_PASSWORD_DXE_PRIVATE_FROM_THIS(a)  CR (a, HDD_PASSWORD_DXE_PRIVATE_DATA, ConfigAccess, HDD_PASSWORD_DXE_PRIVATE_SIGNATURE)
-
-//
-//Iterate through the double linked list. NOT delete safe
-//
-#define EFI_LIST_FOR_EACH(Entry, ListHead)    \
-  for (Entry = (ListHead)->ForwardLink; Entry != (ListHead); Entry = Entry->ForwardLink)
 
 #define PASSWORD_SALT_SIZE                  32
 


### PR DESCRIPTION
REF:https://bugzilla.tianocore.org/show_bug.cgi?id=1959

The macros EFI_LIST_FOR_EACH and EFI_LIST_FOR_EACH_SAFE have been
duplicated across several drivers such as:

* EhciPei
* EhciDxe
* HddPasswordDxe
* RamDiskDxe
* UfsPassThruDxe
* XhciDxe

These macros have proven useful and established a commonly used pattern
for linked list iteration.

This patch series consolidates the definitions to a single definition in
BaseLib.h so they are maintained alongside other pre-existing generic
linked list macros and functions.

Note: Another commonly used generic linked list macro is
EFI_LIST_CONTAINER.
I'm considering consolidating that to BaseLib.h as well but that is not
done in this patch series since it satisfies a separate use case than the
iteration macros and the change can be made independently.

On a separate note, shallow threading might not work on this patch series
due to changes made by the SMTP server. Please bear with me while I am
investigating if this can be changed.

Cc: Chao Zhang <chao.b.zhang@intel.com>
Cc: Dandan Bi <dandan.bi@intel.com>
Cc: Hao A Wu <hao.a.wu@intel.com>
Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Liming Gao <liming.gao@intel.com>
Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Cc: Sean Brogan <sean.brogan@microsoft.com>
Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>