### PR TITLE
MdeModulePkg/ReportStatusCodeRouter: Clear RSC Data buffer if Data NULL

### DIFF
--- a/MdeModulePkg/Universal/ReportStatusCodeRouter/RuntimeDxe/ReportStatusCodeRouterRuntimeDxe.c
+++ b/MdeModulePkg/Universal/ReportStatusCodeRouter/RuntimeDxe/ReportStatusCodeRouterRuntimeDxe.c
@@ -3,6 +3,7 @@
   and Status Code Runtime Protocol.
 
   Copyright (c) 2009 - 2018, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) Microsoft Corporation.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -307,6 +308,9 @@ ReportDispatcher (
     }
     if (Data != NULL) {
       CopyMem (&RscData->Data, Data, Data->HeaderSize + Data->Size);
+    } else {
+      ZeroMem (&RscData->Data, sizeof (RscData->Data));
+      RscData->Data.HeaderSize = sizeof (RscData->Data);
     }
 
     Status = gBS->SignalEvent (CallbackEntry->Event);


### PR DESCRIPTION
REF:https://bugzilla.tianocore.org/show_bug.cgi?id=1969

ReportDispatcher() may be invoked with a NULL Data argument. When TPL is
less than TPL_HIGH_LEVEL and Data is NULL, the EFI_STATUS_CODE_DATA
structure inside RscData should be cleared so listeners will not receive
data from a previous operation.

Cc: Dandan Bi <dandan.bi@intel.com>
Cc: Hao A Wu <hao.a.wu@intel.com>
Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Kun Qin <Kun.Qin@microsoft.com>
Cc: Liming Gao <liming.gao@intel.com>
Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>
Reviewed-by: Dandan Bi <dandan.bi@intel.com>