### PR TITLE
SecurityPkg: Add PCD for SW SMI Command port

### DIFF
--- a/SecurityPkg/SecurityPkg.dec
+++ b/SecurityPkg/SecurityPkg.dec
@@ -7,7 +7,7 @@
 #
 # Copyright (c) 2009 - 2019, Intel Corporation. All rights reserved.<BR>
 # (C) Copyright 2015 Hewlett Packard Enterprise Development LP <BR>
-# Copyright (c) 2017, Microsoft Corporation.  All rights reserved. <BR>
+# Copyright (c) Microsoft Corporation.<BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -271,6 +271,12 @@
   # @Prompt Status Code for TPM device definitions
   # @ValidList  0x80000003 | 0x010D0000
   gEfiSecurityPkgTokenSpaceGuid.PcdStatusCodeSubClassTpmDevice|0x010D0000|UINT32|0x00000007
+
+  ## Defines the IO port used to trigger a software System Management Interrupt (SMI).<BR><BR>
+  #  Used as the SMI Command IO port by security functionality that triggers a software SMI such
+  #  as Physical Presence Interface (PPI).<BR>
+  # @Prompt SMI Command IO port.
+  gEfiSecurityPkgTokenSpaceGuid.PcdSmiCommandIoPort|0xB2|UINT16|0x00000009
 
   ## Progress Code for FV verification result.<BR><BR>
   #  (EFI_SOFTWARE_PEI_MODULE | EFI_SUBCLASS_SPECIFIC | XXX)

--- a/SecurityPkg/Tcg/Tcg2Smm/Tcg2Smm.inf
+++ b/SecurityPkg/Tcg/Tcg2Smm/Tcg2Smm.inf
@@ -21,6 +21,7 @@
 #  This external input must be validated carefully to avoid security issue.
 #
 # Copyright (c) 2015 - 2019, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) Microsoft Corporation.<BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -69,6 +70,9 @@
   gEfiSmmSwDispatch2ProtocolGuid                                ## CONSUMES
   gEfiSmmVariableProtocolGuid                                   ## CONSUMES
   gEfiAcpiTableProtocolGuid                                     ## CONSUMES
+
+[FixedPcd]
+  gEfiSecurityPkgTokenSpaceGuid.PcdSmiCommandIoPort             ## CONSUMES
 
 [Pcd]
   gEfiSecurityPkgTokenSpaceGuid.PcdTpmInstanceGuid              ## CONSUMES

--- a/SecurityPkg/Tcg/Tcg2Smm/Tpm.asl
+++ b/SecurityPkg/Tcg/Tcg2Smm/Tpm.asl
@@ -4,7 +4,7 @@
 
 Copyright (c) 2015 - 2018, Intel Corporation. All rights reserved.<BR>
 (c)Copyright 2016 HP Development Company, L.P.<BR>
-Copyright (c) 2017, Microsoft Corporation.  All rights reserved. <BR>
+Copyright (c) Microsoft Corporation.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -41,10 +41,10 @@ DefinitionBlock (
       //
       // Operational region for Smi port access
       //
-      OperationRegion (SMIP, SystemIO, 0xB2, 1)
+      OperationRegion (SMIP, SystemIO, FixedPcdGet16 (PcdSmiCommandIoPort), 1)
       Field (SMIP, ByteAcc, NoLock, Preserve)
       {
-          IOB2, 8
+          IOPN, 8
       }
 
       //
@@ -258,7 +258,7 @@ DefinitionBlock (
             //
             // Trigger the SMI interrupt
             //
-            Store (MCIN, IOB2)
+            Store (MCIN, IOPN)
           }
         }
         Return (0)
@@ -359,7 +359,7 @@ DefinitionBlock (
             //
             // Trigger the SMI interrupt
             //
-            Store (PPIN, IOB2)
+            Store (PPIN, IOPN)
             Return (FRET)
 
 
@@ -390,7 +390,7 @@ DefinitionBlock (
             //
             // Trigger the SMI interrupt
             //
-            Store (PPIN, IOB2)
+            Store (PPIN, IOPN)
 
             Store (LPPR, Index (TPM3, 0x01))
             Store (PPRP, Index (TPM3, 0x02))
@@ -422,7 +422,7 @@ DefinitionBlock (
             //
             // Trigger the SMI interrupt
             //
-            Store (PPIN, IOB2)
+            Store (PPIN, IOPN)
             Return (FRET)
           }
           Case (8)
@@ -436,7 +436,7 @@ DefinitionBlock (
             //
             // Trigger the SMI interrupt
             //
-            Store (PPIN, IOB2)
+            Store (PPIN, IOPN)
 
             Return (FRET)
           }
@@ -475,7 +475,7 @@ DefinitionBlock (
             //
             // Trigger the SMI interrupt
             //
-            Store (MCIN, IOB2)
+            Store (MCIN, IOPN)
             Return (MRET)
           }
           Default {BreakPoint}

--- a/SecurityPkg/Tcg/TcgSmm/TcgSmm.inf
+++ b/SecurityPkg/Tcg/TcgSmm/TcgSmm.inf
@@ -10,6 +10,7 @@
 #  This external input must be validated carefully to avoid security issue.
 #
 # Copyright (c) 2011 - 2018, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) Microsoft Corporation.<BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -62,6 +63,9 @@
   gEfiSmmSwDispatch2ProtocolGuid                        ## CONSUMES
   gEfiSmmVariableProtocolGuid                           ## CONSUMES
   gEfiAcpiTableProtocolGuid                             ## CONSUMES
+
+[FixedPcd]
+  gEfiSecurityPkgTokenSpaceGuid.PcdSmiCommandIoPort     ## CONSUMES
 
 [Pcd]
   gEfiSecurityPkgTokenSpaceGuid.PcdTpmInstanceGuid      ## CONSUMES

--- a/SecurityPkg/Tcg/TcgSmm/Tpm.asl
+++ b/SecurityPkg/Tcg/TcgSmm/Tpm.asl
@@ -3,6 +3,7 @@
   and MemoryClear.
 
 Copyright (c) 2011 - 2018, Intel Corporation. All rights reserved.<BR>
+Copyright (c) Microsoft Corporation.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -41,10 +42,10 @@ DefinitionBlock (
       //
       // Operational region for Smi port access
       //
-      OperationRegion (SMIP, SystemIO, 0xB2, 1)
+      OperationRegion (SMIP, SystemIO, FixedPcdGet16 (PcdSmiCommandIoPort), 1)
       Field (SMIP, ByteAcc, NoLock, Preserve)
       {
-          IOB2, 8
+          IOPN, 8
       }
 
       //
@@ -96,7 +97,7 @@ DefinitionBlock (
             //
             // Trigger the SMI interrupt
             //
-            Store (MCIN, IOB2)
+            Store (MCIN, IOPN)
           }
         }
         Return (0)
@@ -196,7 +197,7 @@ DefinitionBlock (
             //
             // Trigger the SMI interrupt
             //
-            Store (PPIN, IOB2)
+            Store (PPIN, IOPN)
             Return (FRET)
 
 
@@ -227,7 +228,7 @@ DefinitionBlock (
             //
             // Trigger the SMI interrupt
             //
-            Store (PPIN, IOB2)
+            Store (PPIN, IOPN)
 
             Store (LPPR, Index (TPM3, 0x01))
             Store (PPRP, Index (TPM3, 0x02))
@@ -255,7 +256,7 @@ DefinitionBlock (
             //
             // Trigger the SMI interrupt
             //
-            Store (PPIN, IOB2)
+            Store (PPIN, IOPN)
             Return (FRET)
           }
           Case (8)
@@ -269,7 +270,7 @@ DefinitionBlock (
             //
             // Trigger the SMI interrupt
             //
-            Store (PPIN, IOB2)
+            Store (PPIN, IOPN)
 
             Return (FRET)
           }
@@ -308,7 +309,7 @@ DefinitionBlock (
             //
             // Trigger the SMI interrupt
             //
-            Store (MCIN, IOB2)
+            Store (MCIN, IOPN)
             Return (MRET)
           }
           Default {BreakPoint}


### PR DESCRIPTION
REF:https://bugzilla.tianocore.org/show_bug.cgi?id=2416

The software SMI Command IO Port is currently used in SecurityPkg to
support the Physical Presence Interface. The IO port is hardcoded as 0xB2
in Tpm.asl.

This patch series adds a PCD to SecurityPkg with the default value of 0xB2.
The PCD is also used as the IO port value in Tpm.asl. Some existing
platforms use IO port 0xB0 so this allows those platforms to set the value
to 0xB0 in their platform DSC.

On a separate note, shallow threading might not work on this patch series
due to changes made by the SMTP server. Please bear with me while I am
investigating if this can be changed.

Cc: Kun Qin <Kun.Qin@microsoft.com>
Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Chao Zhang <chao.b.zhang@intel.com>
Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>