### PR TITLE
UefiCpuPkg/MpInitLib: Add missing explicit PcdLib dependency

### DIFF
--- a/UefiCpuPkg/Library/MpInitLib/DxeMpInitLib.inf
+++ b/UefiCpuPkg/Library/MpInitLib/DxeMpInitLib.inf
@@ -51,6 +51,7 @@
   UefiBootServicesTableLib
   DebugAgentLib
   SynchronizationLib
+  PcdLib
 
 [Protocols]
   gEfiTimerArchProtocolGuid                     ## SOMETIMES_CONSUMES

--- a/UefiCpuPkg/Library/MpInitLib/MpLib.h
+++ b/UefiCpuPkg/Library/MpInitLib/MpLib.h
@@ -31,6 +31,7 @@
 #include <Library/SynchronizationLib.h>
 #include <Library/MtrrLib.h>
 #include <Library/HobLib.h>
+#include <Library/PcdLib.h>
 
 #include <Guid/MicrocodePatchHob.h>
 

--- a/UefiCpuPkg/Library/MpInitLib/PeiMpInitLib.inf
+++ b/UefiCpuPkg/Library/MpInitLib/PeiMpInitLib.inf
@@ -50,6 +50,7 @@
   UefiCpuLib
   SynchronizationLib
   PeiServicesLib
+  PcdLib
 
 [Pcd]
   gUefiCpuPkgTokenSpaceGuid.PcdCpuMaxLogicalProcessorNumber        ## CONSUMES


### PR DESCRIPTION
REF:https://bugzilla.tianocore.org/show_bug.cgi?id=2632

Both PEI and DXE instances of the MpInitLib are using PcdLib APIs, but
none of them list the dependency of the PcdLib in INF & header files.

This commit will explicitly add such dependency in .H and .INF files.

Test done:
Library level build pass for VS2015x86 tool chain

Cc: Eric Dong <eric.dong@intel.com>
Signed-off-by: Hao A Wu <hao.a.wu@intel.com>
Reviewed-by: Ray Ni <ray.ni@intel.com>
Reviewed-by: Laszlo Ersek <lersek@redhat.com>