### PR TITLE
ShellPkg: smbiosview - print field values as unsigned integers

### DIFF
--- a/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/PrintInfo.c
+++ b/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/PrintInfo.c
@@ -49,7 +49,7 @@
 #define PRINT_STRUCT_VALUE(pStruct, type, element) \
   do { \
     ShellPrintEx(-1,-1,L"%a",#element); \
-    ShellPrintEx(-1,-1,L": %d\n", (pStruct->type->element)); \
+    ShellPrintEx(-1,-1,L": %u\n", (pStruct->type->element)); \
   } while (0);
 
 #define PRINT_STRUCT_VALUE_H(pStruct, type, element) \


### PR DESCRIPTION
This prevents overflow when printing DWORD fields such as the type 17
tables's extended DIMM size.

Cc: Ray Ni <ray.ni@intel.com>
CC: Zhichao Gao <zhichao.gao@intel.com>
Signed-off-by: Rebecca Cran <rebecca@bsdio.com>