### PR TITLE
NetworkPkg/IScsiDxe: Enhance the check for array boundary

### DIFF
--- a/NetworkPkg/IScsiDxe/IScsiDhcp.c
+++ b/NetworkPkg/IScsiDxe/IScsiDhcp.c
@@ -122,7 +122,7 @@ IScsiDhcpExtractRootPath (
   //
   if ((!NET_IS_DIGIT (*(Field->Str))) && (*(Field->Str) != '[')) {
     ConfigNvData->DnsMode = TRUE;
-    if (Field->Len > sizeof (ConfigNvData->TargetUrl)) {
+    if ((Field->Len + 2) > sizeof (ConfigNvData->TargetUrl)) {
       return EFI_INVALID_PARAMETER;
     }
     CopyMem (&ConfigNvData->TargetUrl, Field->Str, Field->Len);

--- a/NetworkPkg/IScsiDxe/IScsiDhcp6.c
+++ b/NetworkPkg/IScsiDxe/IScsiDhcp6.c
@@ -161,7 +161,7 @@ IScsiDhcp6ExtractRootPath (
   // Server name is expressed as domain name, just save it.
   //
   if (ConfigNvData->DnsMode) {
-    if (Field->Len > sizeof (ConfigNvData->TargetUrl)) {
+    if ((Field->Len + 2) > sizeof (ConfigNvData->TargetUrl)) {
       return EFI_INVALID_PARAMETER;
     }
     CopyMem (&ConfigNvData->TargetUrl, Field->Str, Field->Len);


### PR DESCRIPTION
Array 'TargetUrl' of size 255 may use index value(s) 255 and 256.
So enhance the boundary check to ensure the index is valid.

Cc: Maciej Rabeda <maciej.rabeda@linux.intel.com>
Cc: Jiaxin Wu <jiaxin.wu@intel.com>
Cc: Siyuan Fu <siyuan.fu@intel.com>
Signed-off-by: Shenglei Zhang <shenglei.zhang@intel.com>
Reviewed-by: Siyuan Fu <siyuan.fu@intel.com>