### PR TITLE
[edk2-devel] [PATCH 0/7] OvmfPkg, ArmVirtPkg: control PXE v4/v6 boot support from the QEMU cmdline

### DIFF
--- a/ArmVirtPkg/ArmVirtQemu.dsc
+++ b/ArmVirtPkg/ArmVirtQemu.dsc
@@ -58,6 +58,7 @@
   VirtioMmioDeviceLib|OvmfPkg/Library/VirtioMmioDeviceLib/VirtioMmioDeviceLib.inf
   QemuFwCfgLib|ArmVirtPkg/Library/QemuFwCfgLib/QemuFwCfgLib.inf
   QemuFwCfgS3Lib|OvmfPkg/Library/QemuFwCfgS3Lib/BaseQemuFwCfgS3LibNull.inf
+  QemuFwCfgSimpleParserLib|OvmfPkg/Library/QemuFwCfgSimpleParserLib/QemuFwCfgSimpleParserLib.inf
   QemuLoadImageLib|OvmfPkg/Library/GenericQemuLoadImageLib/GenericQemuLoadImageLib.inf
 
   ArmPlatformLib|ArmPlatformPkg/Library/ArmPlatformLibNull/ArmPlatformLibNull.inf
@@ -257,6 +258,12 @@
   gUefiOvmfPkgTokenSpaceGuid.PcdQemuSmbiosValidated|FALSE
 
   #
+  # IPv4 and IPv6 PXE Boot support.
+  #
+  gEfiNetworkPkgTokenSpaceGuid.PcdIPv4PXESupport|0x01
+  gEfiNetworkPkgTokenSpaceGuid.PcdIPv6PXESupport|0x01
+
+  #
   # TPM2 support
   #
   gEfiSecurityPkgTokenSpaceGuid.PcdTpmBaseAddress|0x0
@@ -430,6 +437,12 @@
   # Networking stack
   #
 !include NetworkPkg/NetworkComponents.dsc.inc
+
+  NetworkPkg/UefiPxeBcDxe/UefiPxeBcDxe.inf {
+    <LibraryClasses>
+      NULL|OvmfPkg/Library/PxeBcPcdProducerLib/PxeBcPcdProducerLib.inf
+  }
+
 !if $(NETWORK_TLS_ENABLE) == TRUE
   NetworkPkg/TlsAuthConfigDxe/TlsAuthConfigDxe.inf {
     <LibraryClasses>

--- a/ArmVirtPkg/ArmVirtQemuKernel.dsc
+++ b/ArmVirtPkg/ArmVirtQemuKernel.dsc
@@ -56,6 +56,7 @@
   VirtioMmioDeviceLib|OvmfPkg/Library/VirtioMmioDeviceLib/VirtioMmioDeviceLib.inf
   QemuFwCfgLib|ArmVirtPkg/Library/QemuFwCfgLib/QemuFwCfgLib.inf
   QemuFwCfgS3Lib|OvmfPkg/Library/QemuFwCfgS3Lib/BaseQemuFwCfgS3LibNull.inf
+  QemuFwCfgSimpleParserLib|OvmfPkg/Library/QemuFwCfgSimpleParserLib/QemuFwCfgSimpleParserLib.inf
   QemuLoadImageLib|OvmfPkg/Library/GenericQemuLoadImageLib/GenericQemuLoadImageLib.inf
 
   ArmVirtMemInfoLib|ArmVirtPkg/Library/QemuVirtMemInfoLib/QemuVirtMemInfoLib.inf
@@ -239,6 +240,12 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdSmbiosDocRev|0x0
   gUefiOvmfPkgTokenSpaceGuid.PcdQemuSmbiosValidated|FALSE
 
+  #
+  # IPv4 and IPv6 PXE Boot support.
+  #
+  gEfiNetworkPkgTokenSpaceGuid.PcdIPv4PXESupport|0x01
+  gEfiNetworkPkgTokenSpaceGuid.PcdIPv6PXESupport|0x01
+
 ################################################################################
 #
 # Components Section - list of all EDK II Modules needed by this Platform
@@ -369,6 +376,12 @@
   # Networking stack
   #
 !include NetworkPkg/NetworkComponents.dsc.inc
+
+  NetworkPkg/UefiPxeBcDxe/UefiPxeBcDxe.inf {
+    <LibraryClasses>
+      NULL|OvmfPkg/Library/PxeBcPcdProducerLib/PxeBcPcdProducerLib.inf
+  }
+
 !if $(NETWORK_TLS_ENABLE) == TRUE
   NetworkPkg/TlsAuthConfigDxe/TlsAuthConfigDxe.inf {
     <LibraryClasses>

--- a/ArmVirtPkg/Library/QemuFwCfgLib/QemuFwCfgLib.inf
+++ b/ArmVirtPkg/Library/QemuFwCfgLib/QemuFwCfgLib.inf
@@ -15,7 +15,7 @@
   FILE_GUID                      = B271F41F-B841-48A9-BA8D-545B4BC2E2BF
   MODULE_TYPE                    = BASE
   VERSION_STRING                 = 1.0
-  LIBRARY_CLASS                  = QemuFwCfgLib|DXE_DRIVER
+  LIBRARY_CLASS                  = QemuFwCfgLib|DXE_DRIVER UEFI_DRIVER
 
   CONSTRUCTOR                    = QemuFwCfgInitialize
 

--- a/OvmfPkg/Include/Library/QemuFwCfgSimpleParserLib.h
+++ b/OvmfPkg/Include/Library/QemuFwCfgSimpleParserLib.h
@@ -1,0 +1,128 @@
+/** @file
+  Parse the contents of named fw_cfg files as simple (scalar) data types.
+
+  Copyright (C) 2020, Red Hat, Inc.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef QEMU_FW_CFG_SIMPLE_PARSER_LIB_H_
+#define QEMU_FW_CFG_SIMPLE_PARSER_LIB_H_
+
+#include <Base.h>
+
+/**
+  Look up FileName with QemuFwCfgFindFile() from QemuFwCfgLib. Read the fw_cfg
+  file into a small array with automatic storage duration. Parse the array as
+  the textual representation of a BOOLEAN.
+
+  @param[in] FileName  The name of the fw_cfg file to look up and parse.
+
+  @param[out] Value    On success, Value is TRUE if the contents of the fw_cfg
+                       file case-insensitively match "true", "yes", "y",
+                       "enable", "enabled", "1".
+
+                       On success, Value is FALSE if the contents of the fw_cfg
+                       file case-insensitively match "false", "no", "n",
+                       "disable", "disabled", "0".
+
+                       On failure, Value is not changed.
+
+  @retval RETURN_SUCCESS         Parsing successful. Value has been set.
+
+  @retval RETURN_UNSUPPORTED     Firmware configuration is unavailable.
+
+  @retval RETURN_PROTOCOL_ERROR  Parsing failed. Value has not been changed.
+
+  @return                        Error codes propagated from
+                                 QemuFwCfgFindFile(). Value has not been
+                                 changed.
+**/
+RETURN_STATUS
+EFIAPI
+QemuFwCfgParseBool (
+  IN  CONST CHAR8 *FileName,
+  OUT BOOLEAN     *Value
+  );
+
+/**
+  Look up FileName with QemuFwCfgFindFile() from QemuFwCfgLib. Read the fw_cfg
+  file into a small array with automatic storage duration. Parse the array as
+  the textual representation of a UINT8.
+
+  @param[in] FileName    The name of the fw_cfg file to look up and parse.
+
+  @param[in] ParseAsHex  If TRUE, call BaseLib's AsciiStrHexToUint64S() for
+                         parsing the fw_cfg file.
+
+                         If FALSE, call BaseLib's AsciiStrDecimalToUint64S()
+                         for parsing the fw_cfg file.
+
+  @param[out] Value      On success, Value has been parsed with the BaseLib
+                         function determined by ParseAsHex, and also
+                         range-checked for [0, MAX_UINT8].
+
+                         On failure, Value is not changed.
+
+  @retval RETURN_SUCCESS         Parsing successful. Value has been set.
+
+  @retval RETURN_UNSUPPORTED     Firmware configuration is unavailable.
+
+  @retval RETURN_PROTOCOL_ERROR  Parsing failed. Value has not been changed.
+
+  @retval RETURN_PROTOCOL_ERROR  Parsing succeeded, but the result does not fit
+                                 in the [0, MAX_UINT8] range. Value has not
+                                 been changed.
+
+  @return                        Error codes propagated from
+                                 QemuFwCfgFindFile() and from the BaseLib
+                                 function selected by ParseAsHex. Value has not
+                                 been changed.
+**/
+RETURN_STATUS
+EFIAPI
+QemuFwCfgParseUint8 (
+  IN  CONST CHAR8 *FileName,
+  IN  BOOLEAN     ParseAsHex,
+  OUT UINT8       *Value
+  );
+
+//
+// The following functions behave identically to QemuFwCfgParseUint8(),
+// only their range checks use MAX_UINT16, MAX_UINT32, MAX_UINT64, MAX_UINTN,
+// respectively.
+//
+
+RETURN_STATUS
+EFIAPI
+QemuFwCfgParseUint16 (
+  IN  CONST CHAR8 *FileName,
+  IN  BOOLEAN     ParseAsHex,
+  OUT UINT16      *Value
+  );
+
+RETURN_STATUS
+EFIAPI
+QemuFwCfgParseUint32 (
+  IN  CONST CHAR8 *FileName,
+  IN  BOOLEAN     ParseAsHex,
+  OUT UINT32      *Value
+  );
+
+RETURN_STATUS
+EFIAPI
+QemuFwCfgParseUint64 (
+  IN  CONST CHAR8 *FileName,
+  IN  BOOLEAN     ParseAsHex,
+  OUT UINT64      *Value
+  );
+
+RETURN_STATUS
+EFIAPI
+QemuFwCfgParseUintn (
+  IN  CONST CHAR8 *FileName,
+  IN  BOOLEAN     ParseAsHex,
+  OUT UINTN       *Value
+  );
+
+#endif // QEMU_FW_CFG_SIMPLE_PARSER_LIB_H_

--- a/OvmfPkg/Library/PxeBcPcdProducerLib/PxeBcPcd.c
+++ b/OvmfPkg/Library/PxeBcPcdProducerLib/PxeBcPcd.c
@@ -1,0 +1,39 @@
+/** @file
+  Configure some PCDs dynamically for
+  "NetworkPkg/UefiPxeBcDxe/UefiPxeBcDxe.inf", from QEMU's fw_cfg.
+
+  Copyright (C) 2020, Red Hat, Inc.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <Library/PcdLib.h>
+#include <Library/QemuFwCfgSimpleParserLib.h>
+
+RETURN_STATUS
+EFIAPI
+SetPxeBcPcds (
+  VOID
+  )
+{
+  BOOLEAN       FwCfgBool;
+  RETURN_STATUS PcdStatus;
+
+  if (!RETURN_ERROR (QemuFwCfgParseBool ("opt/org.tianocore/IPv4PXESupport",
+                       &FwCfgBool))) {
+    PcdStatus = PcdSet8S (PcdIPv4PXESupport, FwCfgBool);
+    if (RETURN_ERROR (PcdStatus)) {
+      return PcdStatus;
+    }
+  }
+
+  if (!RETURN_ERROR (QemuFwCfgParseBool ("opt/org.tianocore/IPv6PXESupport",
+                       &FwCfgBool))) {
+    PcdStatus = PcdSet8S (PcdIPv6PXESupport, FwCfgBool);
+    if (RETURN_ERROR (PcdStatus)) {
+      return PcdStatus;
+    }
+  }
+
+  return RETURN_SUCCESS;
+}

--- a/OvmfPkg/Library/PxeBcPcdProducerLib/PxeBcPcdProducerLib.inf
+++ b/OvmfPkg/Library/PxeBcPcdProducerLib/PxeBcPcdProducerLib.inf
@@ -1,0 +1,33 @@
+## @file
+# Configure some PCDs dynamically for
+# "NetworkPkg/UefiPxeBcDxe/UefiPxeBcDxe.inf", from QEMU's fw_cfg.
+#
+# Copyright (C) 2020, Red Hat, Inc.
+#
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION                    = 1.29
+  BASE_NAME                      = PxeBcPcdProducerLib
+  FILE_GUID                      = 1da2723f-52df-432a-8d03-6e8fa8acc107
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = NULL
+  CONSTRUCTOR                    = SetPxeBcPcds
+
+[Sources]
+  PxeBcPcd.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  NetworkPkg/NetworkPkg.dec
+  OvmfPkg/OvmfPkg.dec
+
+[LibraryClasses]
+  PcdLib
+  QemuFwCfgSimpleParserLib
+
+[Pcd]
+  gEfiNetworkPkgTokenSpaceGuid.PcdIPv4PXESupport       ## SOMETIMES_PRODUCES
+  gEfiNetworkPkgTokenSpaceGuid.PcdIPv6PXESupport       ## SOMETIMES_PRODUCES

--- a/OvmfPkg/Library/QemuFwCfgLib/QemuFwCfgDxeLib.inf
+++ b/OvmfPkg/Library/QemuFwCfgLib/QemuFwCfgDxeLib.inf
@@ -16,7 +16,7 @@
   FILE_GUID                      = 80474090-55e7-4c28-b25c-9f236ba41f28
   MODULE_TYPE                    = BASE
   VERSION_STRING                 = 1.0
-  LIBRARY_CLASS                  = QemuFwCfgLib|DXE_DRIVER DXE_RUNTIME_DRIVER DXE_SMM_DRIVER
+  LIBRARY_CLASS                  = QemuFwCfgLib|DXE_DRIVER DXE_RUNTIME_DRIVER DXE_SMM_DRIVER UEFI_DRIVER
 
   CONSTRUCTOR                    = QemuFwCfgInitialize
 

--- a/OvmfPkg/Library/QemuFwCfgSimpleParserLib/QemuFwCfgSimpleParser.c
+++ b/OvmfPkg/Library/QemuFwCfgSimpleParserLib/QemuFwCfgSimpleParser.c
@@ -1,0 +1,398 @@
+/** @file
+  Parse the contents of named fw_cfg files as simple (scalar) data types.
+
+  Copyright (C) 2020, Red Hat, Inc.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <Library/BaseLib.h>
+#include <Library/QemuFwCfgLib.h>
+#include <Library/QemuFwCfgSimpleParserLib.h>
+
+//
+// Size of the longest valid UINT64 string, including the terminating NUL.
+//
+#define UINT64_STRING_MAX_SIZE \
+  MAX (sizeof "18446744073709551615", sizeof "0xFFFFFFFFFFFFFFFF")
+
+//
+// Size of the longest valid BOOL string (see the "mTrueString" and
+// "mFalseString" arrays below), including the terminating NUL.
+//
+#define BOOL_STRING_MAX_SIZE (sizeof "disabled")
+
+//
+// Length of "\r\n", not including the terminating NUL.
+//
+#define CRLF_LENGTH (sizeof "\r\n" - 1)
+
+//
+// Words recognized as representing TRUE or FALSE.
+//
+STATIC CONST CHAR8 * CONST mTrueString[] = {
+  "true", "yes", "y", "enable", "enabled", "1"
+};
+STATIC CONST CHAR8 * CONST mFalseString[] = {
+  "false", "no", "n", "disable", "disabled", "0"
+};
+
+//
+// Helper functions.
+//
+
+/**
+  Look up FileName with QemuFwCfgFindFile() from QemuFwCfgLib. Read the fw_cfg
+  file into the caller-provided CHAR8 array. NUL-terminate the array.
+
+  @param[in] FileName        The name of the fw_cfg file to look up and read.
+
+  @param[in,out] BufferSize  On input, number of bytes available in Buffer.
+
+                             On output, the number of bytes that have been
+                             stored to Buffer.
+
+                             On error, BufferSize is indeterminate.
+
+  @param[out] Buffer         The buffer to read the fw_cfg file into. If the
+                             fw_cfg file contents are not NUL-terminated, then
+                             a NUL character is placed into Buffer after the
+                             fw_cfg file contents.
+
+                             On error, Buffer is indeterminate.
+
+  @retval RETURN_SUCCESS         Buffer has been populated with the fw_cfg file
+                                 contents. Buffer is NUL-terminated regardless
+                                 of whether the fw_cfg file itself was
+                                 NUL-terminated.
+
+  @retval RETURN_UNSUPPORTED     Firmware configuration is unavailable.
+
+  @retval RETURN_PROTOCOL_ERROR  The fw_cfg file does not fit into Buffer.
+                                 (This is considered a QEMU configuration
+                                 error; BufferSize is considered authoritative
+                                 for the contents of the fw_cfg file identified
+                                 by FileName.)
+
+  @retval RETURN_PROTOCOL_ERROR  The fw_cfg file contents are not themselves
+                                 NUL-terminated, and an extra NUL byte does not
+                                 fit into Buffer. (Again a QEMU configuration
+                                 error.)
+
+  @return                        Error codes propagated from
+                                 QemuFwCfgFindFile().
+**/
+STATIC
+RETURN_STATUS
+QemuFwCfgGetAsString (
+  IN     CONST CHAR8 *FileName,
+  IN OUT UINTN       *BufferSize,
+  OUT    CHAR8       *Buffer
+  )
+{
+  RETURN_STATUS        Status;
+  FIRMWARE_CONFIG_ITEM FwCfgItem;
+  UINTN                FwCfgSize;
+
+  if (!QemuFwCfgIsAvailable ()) {
+    return RETURN_UNSUPPORTED;
+  }
+
+  Status = QemuFwCfgFindFile (FileName, &FwCfgItem, &FwCfgSize);
+  if (RETURN_ERROR (Status)) {
+    return Status;
+  }
+  if (FwCfgSize > *BufferSize) {
+    return RETURN_PROTOCOL_ERROR;
+  }
+
+  QemuFwCfgSelectItem (FwCfgItem);
+  QemuFwCfgReadBytes (FwCfgSize, Buffer);
+
+  //
+  // If Buffer is already NUL-terminated due to fw_cfg contents, we're done.
+  //
+  if (FwCfgSize > 0 && Buffer[FwCfgSize - 1] == '\0') {
+    *BufferSize = FwCfgSize;
+    return RETURN_SUCCESS;
+  }
+  //
+  // Otherwise, append a NUL byte to Buffer (if we have room for it).
+  //
+  if (FwCfgSize == *BufferSize) {
+    return RETURN_PROTOCOL_ERROR;
+  }
+  Buffer[FwCfgSize] = '\0';
+  *BufferSize = FwCfgSize + 1;
+  return RETURN_SUCCESS;
+}
+
+/**
+  Remove a trailing \r\n or \n sequence from a string.
+
+  @param[in,out] BufferSize  On input, the number of bytes in Buffer, including
+                             the terminating NUL.
+
+                             On output, the adjusted string size (including the
+                             terminating NUL), after stripping the \r\n or \n
+                             suffix.
+
+  @param[in,out] Buffer      The NUL-terminated string to trim.
+**/
+STATIC
+VOID
+StripNewline (
+  IN OUT UINTN *BufferSize,
+  IN OUT CHAR8 *Buffer
+  )
+{
+  UINTN InSize, OutSize;
+
+  InSize = *BufferSize;
+  OutSize = InSize;
+
+  if (InSize >= 3 &&
+      Buffer[InSize - 3] == '\r' && Buffer[InSize - 2] == '\n') {
+    OutSize = InSize - 2;
+  } else if (InSize >= 2 && Buffer[InSize - 2] == '\n') {
+    OutSize = InSize - 1;
+  }
+
+  if (OutSize < InSize) {
+    Buffer[OutSize - 1] = '\0';
+    *BufferSize = OutSize;
+  }
+}
+
+/**
+  Read the fw_cfg file identified by FileName as a string into a small array
+  with automatic storage duration, using QemuFwCfgGetAsString(). Parse the
+  string as a UINT64. Perform a range-check on the parsed value.
+
+  @param[in] FileName    The name of the fw_cfg file to look up and parse.
+
+  @param[in] ParseAsHex  If TRUE, call BaseLib's AsciiStrHexToUint64S() for
+                         parsing the fw_cfg file.
+
+                         If FALSE, call BaseLib's AsciiStrDecimalToUint64S()
+                         for parsing the fw_cfg file.
+
+  @param[in] Limit       The inclusive upper bound on the parsed UINT64 value.
+
+  @param[out] Value      On success, Value has been parsed with the BaseLib
+                         function determined by ParseAsHex, and has been
+                         range-checked against [0, Limit].
+
+                         On failure, Value is not changed.
+
+  @retval RETURN_SUCCESS         Parsing successful. Value has been set.
+
+  @retval RETURN_UNSUPPORTED     Firmware configuration is unavailable.
+
+  @retval RETURN_PROTOCOL_ERROR  Parsing failed. Value has not been changed.
+
+  @retval RETURN_PROTOCOL_ERROR  Parsing succeeded, but the result does not fit
+                                 in the [0, Limit] range. Value has not been
+                                 changed.
+
+  @return                        Error codes propagated from
+                                 QemuFwCfgFindFile() and from the BaseLib
+                                 function selected by ParseAsHex. Value has not
+                                 been changed.
+**/
+STATIC
+RETURN_STATUS
+QemuFwCfgParseUint64WithLimit (
+  IN  CONST CHAR8 *FileName,
+  IN  BOOLEAN     ParseAsHex,
+  IN  UINT64      Limit,
+  OUT UINT64      *Value
+  )
+{
+  UINTN         Uint64StringSize;
+  CHAR8         Uint64String[UINT64_STRING_MAX_SIZE + CRLF_LENGTH];
+  RETURN_STATUS Status;
+  CHAR8         *EndPointer;
+  UINT64        Uint64;
+
+  Uint64StringSize = sizeof Uint64String;
+  Status = QemuFwCfgGetAsString (FileName, &Uint64StringSize, Uint64String);
+  if (RETURN_ERROR (Status)) {
+    return Status;
+  }
+
+  StripNewline (&Uint64StringSize, Uint64String);
+
+  if (ParseAsHex) {
+    Status = AsciiStrHexToUint64S (Uint64String, &EndPointer, &Uint64);
+  } else {
+    Status = AsciiStrDecimalToUint64S (Uint64String, &EndPointer, &Uint64);
+  }
+  if (RETURN_ERROR (Status)) {
+    return Status;
+  }
+
+  //
+  // Report a wire protocol error if the subject sequence is empty, or trailing
+  // garbage is present, or Limit is not honored.
+  //
+  if (EndPointer == Uint64String || *EndPointer != '\0' || Uint64 > Limit) {
+    return RETURN_PROTOCOL_ERROR;
+  }
+
+  *Value = Uint64;
+  return RETURN_SUCCESS;
+}
+
+//
+// Public functions.
+//
+
+RETURN_STATUS
+EFIAPI
+QemuFwCfgSimpleParserInit (
+  VOID
+  )
+{
+  //
+  // Do nothing, just participate in constructor dependency ordering.
+  //
+  return RETURN_SUCCESS;
+}
+
+RETURN_STATUS
+EFIAPI
+QemuFwCfgParseBool (
+  IN  CONST CHAR8 *FileName,
+  OUT BOOLEAN     *Value
+  )
+{
+  UINTN         BoolStringSize;
+  CHAR8         BoolString[BOOL_STRING_MAX_SIZE + CRLF_LENGTH];
+  RETURN_STATUS Status;
+  UINTN         Idx;
+
+  BoolStringSize = sizeof BoolString;
+  Status = QemuFwCfgGetAsString (FileName, &BoolStringSize, BoolString);
+  if (RETURN_ERROR (Status)) {
+    return Status;
+  }
+
+  StripNewline (&BoolStringSize, BoolString);
+
+  for (Idx = 0; Idx < ARRAY_SIZE (mTrueString); ++Idx) {
+    if (AsciiStriCmp (BoolString, mTrueString[Idx]) == 0) {
+      *Value = TRUE;
+      return RETURN_SUCCESS;
+    }
+  }
+
+  for (Idx = 0; Idx < ARRAY_SIZE (mFalseString); ++Idx) {
+    if (AsciiStriCmp (BoolString, mFalseString[Idx]) == 0) {
+      *Value = FALSE;
+      return RETURN_SUCCESS;
+    }
+  }
+
+  return RETURN_PROTOCOL_ERROR;
+}
+
+RETURN_STATUS
+EFIAPI
+QemuFwCfgParseUint8 (
+  IN  CONST CHAR8 *FileName,
+  IN  BOOLEAN     ParseAsHex,
+  OUT UINT8       *Value
+  )
+{
+  RETURN_STATUS Status;
+  UINT64        Uint64;
+
+  Status = QemuFwCfgParseUint64WithLimit (FileName, ParseAsHex, MAX_UINT8,
+             &Uint64);
+  if (RETURN_ERROR (Status)) {
+    return Status;
+  }
+  *Value = (UINT8)Uint64;
+  return RETURN_SUCCESS;
+}
+
+RETURN_STATUS
+EFIAPI
+QemuFwCfgParseUint16 (
+  IN  CONST CHAR8 *FileName,
+  IN  BOOLEAN     ParseAsHex,
+  OUT UINT16      *Value
+  )
+{
+  RETURN_STATUS Status;
+  UINT64        Uint64;
+
+  Status = QemuFwCfgParseUint64WithLimit (FileName, ParseAsHex, MAX_UINT16,
+             &Uint64);
+  if (RETURN_ERROR (Status)) {
+    return Status;
+  }
+  *Value = (UINT16)Uint64;
+  return RETURN_SUCCESS;
+}
+
+RETURN_STATUS
+EFIAPI
+QemuFwCfgParseUint32 (
+  IN  CONST CHAR8 *FileName,
+  IN  BOOLEAN     ParseAsHex,
+  OUT UINT32      *Value
+  )
+{
+  RETURN_STATUS Status;
+  UINT64        Uint64;
+
+  Status = QemuFwCfgParseUint64WithLimit (FileName, ParseAsHex, MAX_UINT32,
+             &Uint64);
+  if (RETURN_ERROR (Status)) {
+    return Status;
+  }
+  *Value = (UINT32)Uint64;
+  return RETURN_SUCCESS;
+}
+
+RETURN_STATUS
+EFIAPI
+QemuFwCfgParseUint64 (
+  IN  CONST CHAR8 *FileName,
+  IN  BOOLEAN     ParseAsHex,
+  OUT UINT64      *Value
+  )
+{
+  RETURN_STATUS Status;
+  UINT64        Uint64;
+
+  Status = QemuFwCfgParseUint64WithLimit (FileName, ParseAsHex, MAX_UINT64,
+             &Uint64);
+  if (RETURN_ERROR (Status)) {
+    return Status;
+  }
+  *Value = Uint64;
+  return RETURN_SUCCESS;
+}
+
+RETURN_STATUS
+EFIAPI
+QemuFwCfgParseUintn (
+  IN  CONST CHAR8 *FileName,
+  IN  BOOLEAN     ParseAsHex,
+  OUT UINTN       *Value
+  )
+{
+  RETURN_STATUS Status;
+  UINT64        Uint64;
+
+  Status = QemuFwCfgParseUint64WithLimit (FileName, ParseAsHex, MAX_UINTN,
+             &Uint64);
+  if (RETURN_ERROR (Status)) {
+    return Status;
+  }
+  *Value = (UINTN)Uint64;
+  return RETURN_SUCCESS;
+}

--- a/OvmfPkg/Library/QemuFwCfgSimpleParserLib/QemuFwCfgSimpleParserLib.inf
+++ b/OvmfPkg/Library/QemuFwCfgSimpleParserLib/QemuFwCfgSimpleParserLib.inf
@@ -1,0 +1,27 @@
+## @file
+# Parse the contents of named fw_cfg files as simple (scalar) data types.
+#
+# Copyright (C) 2020, Red Hat, Inc.
+#
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION                    = 1.29
+  BASE_NAME                      = QemuFwCfgSimpleParserLib
+  FILE_GUID                      = a9a1211d-061e-4b64-af30-5dd0cac9dc99
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = QemuFwCfgSimpleParserLib
+  CONSTRUCTOR                    = QemuFwCfgSimpleParserInit
+
+[Sources]
+  QemuFwCfgSimpleParser.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  OvmfPkg/OvmfPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  QemuFwCfgLib

--- a/OvmfPkg/OvmfPkg.dec
+++ b/OvmfPkg/OvmfPkg.dec
@@ -60,6 +60,10 @@
   #
   QemuFwCfgS3Lib|Include/Library/QemuFwCfgS3Lib.h
 
+  ##  @libraryclass  Parse the contents of named fw_cfg files as simple
+  #                  (scalar) data types.
+  QemuFwCfgSimpleParserLib|Include/Library/QemuFwCfgSimpleParserLib.h
+
   ##  @libraryclass  Rewrite the BootOrder NvVar based on QEMU's "bootorder"
   #                  fw_cfg file.
   #

--- a/OvmfPkg/OvmfPkgIa32.dsc
+++ b/OvmfPkg/OvmfPkgIa32.dsc
@@ -160,6 +160,7 @@
   UefiUsbLib|MdePkg/Library/UefiUsbLib/UefiUsbLib.inf
   SerializeVariablesLib|OvmfPkg/Library/SerializeVariablesLib/SerializeVariablesLib.inf
   QemuFwCfgLib|OvmfPkg/Library/QemuFwCfgLib/QemuFwCfgDxeLib.inf
+  QemuFwCfgSimpleParserLib|OvmfPkg/Library/QemuFwCfgSimpleParserLib/QemuFwCfgSimpleParserLib.inf
   VirtioLib|OvmfPkg/Library/VirtioLib/VirtioLib.inf
   LoadLinuxLib|OvmfPkg/Library/LoadLinuxLib/LoadLinuxLib.inf
   MemEncryptSevLib|OvmfPkg/Library/BaseMemEncryptSevLib/BaseMemEncryptSevLib.inf

--- a/OvmfPkg/OvmfPkgIa32.dsc
+++ b/OvmfPkg/OvmfPkgIa32.dsc
@@ -605,6 +605,10 @@
   gEfiSecurityPkgTokenSpaceGuid.PcdTpmInstanceGuid|{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
 !endif
 
+  # IPv4 and IPv6 PXE Boot support.
+  gEfiNetworkPkgTokenSpaceGuid.PcdIPv4PXESupport|0x01
+  gEfiNetworkPkgTokenSpaceGuid.PcdIPv6PXESupport|0x01
+
 [PcdsDynamicHii]
 !if $(TPM_ENABLE) == TRUE && $(TPM_CONFIG_ENABLE) == TRUE
   gEfiSecurityPkgTokenSpaceGuid.PcdTcgPhysicalPresenceInterfaceVer|L"TCG2_VERSION"|gTcg2ConfigFormSetGuid|0x0|"1.3"|NV,BS
@@ -821,6 +825,11 @@
   # Network Support
   #
 !include NetworkPkg/NetworkComponents.dsc.inc
+
+  NetworkPkg/UefiPxeBcDxe/UefiPxeBcDxe.inf {
+    <LibraryClasses>
+      NULL|OvmfPkg/Library/PxeBcPcdProducerLib/PxeBcPcdProducerLib.inf
+  }
 
 !if $(NETWORK_TLS_ENABLE) == TRUE
   NetworkPkg/TlsAuthConfigDxe/TlsAuthConfigDxe.inf {

--- a/OvmfPkg/OvmfPkgIa32X64.dsc
+++ b/OvmfPkg/OvmfPkgIa32X64.dsc
@@ -164,6 +164,7 @@
   UefiUsbLib|MdePkg/Library/UefiUsbLib/UefiUsbLib.inf
   SerializeVariablesLib|OvmfPkg/Library/SerializeVariablesLib/SerializeVariablesLib.inf
   QemuFwCfgLib|OvmfPkg/Library/QemuFwCfgLib/QemuFwCfgDxeLib.inf
+  QemuFwCfgSimpleParserLib|OvmfPkg/Library/QemuFwCfgSimpleParserLib/QemuFwCfgSimpleParserLib.inf
   VirtioLib|OvmfPkg/Library/VirtioLib/VirtioLib.inf
   LoadLinuxLib|OvmfPkg/Library/LoadLinuxLib/LoadLinuxLib.inf
   MemEncryptSevLib|OvmfPkg/Library/BaseMemEncryptSevLib/BaseMemEncryptSevLib.inf

--- a/OvmfPkg/OvmfPkgIa32X64.dsc
+++ b/OvmfPkg/OvmfPkgIa32X64.dsc
@@ -616,6 +616,11 @@
   gEfiSecurityPkgTokenSpaceGuid.PcdTpmInstanceGuid|{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
 !endif
 
+[PcdsDynamicDefault.X64]
+  # IPv4 and IPv6 PXE Boot support.
+  gEfiNetworkPkgTokenSpaceGuid.PcdIPv4PXESupport|0x01
+  gEfiNetworkPkgTokenSpaceGuid.PcdIPv6PXESupport|0x01
+
 [PcdsDynamicHii]
 !if $(TPM_ENABLE) == TRUE && $(TPM_CONFIG_ENABLE) == TRUE
   gEfiSecurityPkgTokenSpaceGuid.PcdTcgPhysicalPresenceInterfaceVer|L"TCG2_VERSION"|gTcg2ConfigFormSetGuid|0x0|"1.3"|NV,BS
@@ -833,6 +838,11 @@
   # Network Support
   #
 !include NetworkPkg/NetworkComponents.dsc.inc
+
+  NetworkPkg/UefiPxeBcDxe/UefiPxeBcDxe.inf {
+    <LibraryClasses>
+      NULL|OvmfPkg/Library/PxeBcPcdProducerLib/PxeBcPcdProducerLib.inf
+  }
 
 !if $(NETWORK_TLS_ENABLE) == TRUE
   NetworkPkg/TlsAuthConfigDxe/TlsAuthConfigDxe.inf {

--- a/OvmfPkg/OvmfPkgX64.dsc
+++ b/OvmfPkg/OvmfPkgX64.dsc
@@ -164,6 +164,7 @@
   UefiUsbLib|MdePkg/Library/UefiUsbLib/UefiUsbLib.inf
   SerializeVariablesLib|OvmfPkg/Library/SerializeVariablesLib/SerializeVariablesLib.inf
   QemuFwCfgLib|OvmfPkg/Library/QemuFwCfgLib/QemuFwCfgDxeLib.inf
+  QemuFwCfgSimpleParserLib|OvmfPkg/Library/QemuFwCfgSimpleParserLib/QemuFwCfgSimpleParserLib.inf
   VirtioLib|OvmfPkg/Library/VirtioLib/VirtioLib.inf
   LoadLinuxLib|OvmfPkg/Library/LoadLinuxLib/LoadLinuxLib.inf
   MemEncryptSevLib|OvmfPkg/Library/BaseMemEncryptSevLib/BaseMemEncryptSevLib.inf

--- a/OvmfPkg/OvmfPkgX64.dsc
+++ b/OvmfPkg/OvmfPkgX64.dsc
@@ -615,6 +615,10 @@
   gEfiSecurityPkgTokenSpaceGuid.PcdTpmInstanceGuid|{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
 !endif
 
+  # IPv4 and IPv6 PXE Boot support.
+  gEfiNetworkPkgTokenSpaceGuid.PcdIPv4PXESupport|0x01
+  gEfiNetworkPkgTokenSpaceGuid.PcdIPv6PXESupport|0x01
+
 [PcdsDynamicHii]
 !if $(TPM_ENABLE) == TRUE && $(TPM_CONFIG_ENABLE) == TRUE
   gEfiSecurityPkgTokenSpaceGuid.PcdTcgPhysicalPresenceInterfaceVer|L"TCG2_VERSION"|gTcg2ConfigFormSetGuid|0x0|"1.3"|NV,BS
@@ -831,6 +835,11 @@
   # Network Support
   #
 !include NetworkPkg/NetworkComponents.dsc.inc
+
+  NetworkPkg/UefiPxeBcDxe/UefiPxeBcDxe.inf {
+    <LibraryClasses>
+      NULL|OvmfPkg/Library/PxeBcPcdProducerLib/PxeBcPcdProducerLib.inf
+  }
 
 !if $(NETWORK_TLS_ENABLE) == TRUE
   NetworkPkg/TlsAuthConfigDxe/TlsAuthConfigDxe.inf {

--- a/OvmfPkg/PlatformPei/Platform.c
+++ b/OvmfPkg/PlatformPei/Platform.c
@@ -27,6 +27,7 @@
 #include <Library/PeiServicesLib.h>
 #include <Library/QemuFwCfgLib.h>
 #include <Library/QemuFwCfgS3Lib.h>
+#include <Library/QemuFwCfgSimpleParserLib.h>
 #include <Library/ResourcePublicationLib.h>
 #include <Ppi/MasterBootMode.h>
 #include <IndustryStandard/I440FxPiix4.h>
@@ -254,56 +255,12 @@ MemMapInitialization (
   ASSERT_RETURN_ERROR (PcdStatus);
 }
 
-EFI_STATUS
-GetNamedFwCfgBoolean (
-  IN  CHAR8   *FwCfgFileName,
-  OUT BOOLEAN *Setting
-  )
-{
-  EFI_STATUS           Status;
-  FIRMWARE_CONFIG_ITEM FwCfgItem;
-  UINTN                FwCfgSize;
-  UINT8                Value[3];
-
-  Status = QemuFwCfgFindFile (FwCfgFileName, &FwCfgItem, &FwCfgSize);
-  if (EFI_ERROR (Status)) {
-    return Status;
-  }
-  if (FwCfgSize > sizeof Value) {
-    return EFI_BAD_BUFFER_SIZE;
-  }
-  QemuFwCfgSelectItem (FwCfgItem);
-  QemuFwCfgReadBytes (FwCfgSize, Value);
-
-  if ((FwCfgSize == 1) ||
-      (FwCfgSize == 2 && Value[1] == '\n') ||
-      (FwCfgSize == 3 && Value[1] == '\r' && Value[2] == '\n')) {
-    switch (Value[0]) {
-      case '0':
-      case 'n':
-      case 'N':
-        *Setting = FALSE;
-        return EFI_SUCCESS;
-
-      case '1':
-      case 'y':
-      case 'Y':
-        *Setting = TRUE;
-        return EFI_SUCCESS;
-
-      default:
-        break;
-    }
-  }
-  return EFI_PROTOCOL_ERROR;
-}
-
 #define UPDATE_BOOLEAN_PCD_FROM_FW_CFG(TokenName)                   \
           do {                                                      \
             BOOLEAN       Setting;                                  \
             RETURN_STATUS PcdStatus;                                \
                                                                     \
-            if (!EFI_ERROR (GetNamedFwCfgBoolean (                  \
+            if (!RETURN_ERROR (QemuFwCfgParseBool (                 \
                               "opt/ovmf/" #TokenName, &Setting))) { \
               PcdStatus = PcdSetBoolS (TokenName, Setting);         \
               ASSERT_RETURN_ERROR (PcdStatus);                      \

--- a/OvmfPkg/PlatformPei/PlatformPei.inf
+++ b/OvmfPkg/PlatformPei/PlatformPei.inf
@@ -60,6 +60,7 @@
   PeimEntryPoint
   QemuFwCfgLib
   QemuFwCfgS3Lib
+  QemuFwCfgSimpleParserLib
   MtrrLib
   MemEncryptSevLib
   PcdLib


### PR DESCRIPTION
https://bugzilla.tianocore.org/show_bug.cgi?id=2681
https://edk2.groups.io/g/devel/message/58030
http://mid.mail-archive.com/20200424075353.8489-1-lersek@redhat.com

~~~
Ref:    https://bugzilla.tianocore.org/show_bug.cgi?id=2681
Repo:   https://pagure.io/lersek/edk2.git
Branch: pxe_fw_cfg

With this series applied, the QEMU command line options listed below
control whether the guest firmware supports PXEv4 / PXEv6 boot. And
correspondingly, whether UefiBootManagerLib generates *new* PXEv4 /
PXEv6 boot options automatically. (Existent boot options are never
deleted in response to just the flags below.)

  -fw_cfg name=opt/org.tianocore/IPv4PXESupport,string=[yn]

  -fw_cfg name=opt/org.tianocore/IPv6PXESupport,string=[yn]

Cc: Ard Biesheuvel <ard.biesheuvel@arm.com>
Cc: Jordan Justen <jordan.l.justen@intel.com>
Cc: Leif Lindholm <leif@nuviainc.com>
Cc: Per Sundstrom <per_sundstrom@yahoo.com>
Cc: Philippe Mathieu-Daudé <philmd@redhat.com>

Thanks
Laszlo

Laszlo Ersek (7):
  OvmfPkg: introduce QemuFwCfgSimpleParserLib
  OvmfPkg/PlatformPei: parse "X-PciMmio64Mb" with
    QemuFwCfgSimpleParserLib
  OvmfPkg/PlatformPei: use QemuFwCfgParseBool in
    UPDATE_BOOLEAN_PCD_FROM_...
  OvmfPkg/QemuFwCfgDxeLib: allow UEFI_DRIVER modules
  OvmfPkg: control PXEv4 / PXEv6 boot support from the QEMU command line
  ArmVirtPkg/QemuFwCfgLib: allow UEFI_DRIVER modules
  ArmVirtPkg: control PXEv4 / PXEv6 boot support from the QEMU command
    line

 ArmVirtPkg/ArmVirtQemu.dsc                                            |  13 +
 ArmVirtPkg/ArmVirtQemuKernel.dsc                                      |  13 +
 ArmVirtPkg/Library/QemuFwCfgLib/QemuFwCfgLib.inf                      |   2 +-
 OvmfPkg/Include/Library/QemuFwCfgSimpleParserLib.h                    | 128 +++++++
 OvmfPkg/Library/PxeBcPcdProducerLib/PxeBcPcd.c                        |  39 ++
 OvmfPkg/Library/PxeBcPcdProducerLib/PxeBcPcdProducerLib.inf           |  33 ++
 OvmfPkg/Library/QemuFwCfgLib/QemuFwCfgDxeLib.inf                      |   2 +-
 OvmfPkg/Library/QemuFwCfgSimpleParserLib/QemuFwCfgSimpleParser.c      | 398 ++++++++++++++++++++
 OvmfPkg/Library/QemuFwCfgSimpleParserLib/QemuFwCfgSimpleParserLib.inf |  27 ++
 OvmfPkg/OvmfPkg.dec                                                   |   4 +
 OvmfPkg/OvmfPkgIa32.dsc                                               |  10 +
 OvmfPkg/OvmfPkgIa32X64.dsc                                            |  11 +
 OvmfPkg/OvmfPkgX64.dsc                                                |  10 +
 OvmfPkg/PlatformPei/MemDetect.c                                       |  36 +-
 OvmfPkg/PlatformPei/Platform.c                                        |  47 +--
 OvmfPkg/PlatformPei/PlatformPei.inf                                   |   1 +
 16 files changed, 712 insertions(+), 62 deletions(-)
 create mode 100644 OvmfPkg/Include/Library/QemuFwCfgSimpleParserLib.h
 create mode 100644 OvmfPkg/Library/PxeBcPcdProducerLib/PxeBcPcd.c
 create mode 100644 OvmfPkg/Library/PxeBcPcdProducerLib/PxeBcPcdProducerLib.inf
 create mode 100644 OvmfPkg/Library/QemuFwCfgSimpleParserLib/QemuFwCfgSimpleParser.c
 create mode 100644 OvmfPkg/Library/QemuFwCfgSimpleParserLib/QemuFwCfgSimpleParserLib.inf
~~~