### PR TITLE
.gitmodules: ignore untracked files in brotli

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,4 @@
 [submodule "BaseTools/Source/C/BrotliCompress/brotli"]
 	path = BaseTools/Source/C/BrotliCompress/brotli
 	url = https://github.com/google/brotli
+	ignore = untracked


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=2692
BrotliCompress submodule change for BaseTools causes untracked
files in BaseTools after building. This is regression for git.

Cc: Laszlo Ersek <lersek@redhat.com>
Cc: Sean Brogan <sean.brogan@microsoft.com>
Cc: Bob Feng <bob.c.feng@intel.com>
Cc: Liming Gao <liming.gao@intel.com>
Signed-off-by: Shenglei Zhang <shenglei.zhang@intel.com>
Reviewed-by: Liming Gao <liming.gao@intel.com>
Reviewed-by: Laszlo Ersek <lersek@redhat.com>