### PR TITLE
MdeModulePkg/DeviceManagerUiLib: connect all before creating menu page

### DIFF
--- a/MdeModulePkg/Library/DeviceManagerUiLib/DeviceManager.c
+++ b/MdeModulePkg/Library/DeviceManagerUiLib/DeviceManager.c
@@ -893,6 +893,13 @@ DeviceManagerUiLibConstructor (
   ASSERT (gDeviceManagerPrivate.HiiHandle != NULL);
 
   //
+  // The device manager form contains a page listing all the network
+  // controllers in the system. This list can only be populated if all
+  // handles have been connected, so do it here.
+  //
+  EfiBootManagerConnectAll ();
+
+  //
   // Update boot manager page
   //
   CreateDeviceManagerForm (DEVICE_MANAGER_FORM_ID);

--- a/MdeModulePkg/Library/DeviceManagerUiLib/DeviceManager.h
+++ b/MdeModulePkg/Library/DeviceManagerUiLib/DeviceManager.h
@@ -23,6 +23,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/BaseLib.h>
 #include <Library/HiiLib.h>
 #include <Library/DevicePathLib.h>
+#include <Library/UefiBootManagerLib.h>
 #include <Library/UefiHiiServicesLib.h>
 
 //

--- a/MdeModulePkg/Library/DeviceManagerUiLib/DeviceManagerUiLib.inf
+++ b/MdeModulePkg/Library/DeviceManagerUiLib/DeviceManagerUiLib.inf
@@ -40,6 +40,7 @@
   DebugLib
   PrintLib
   HiiLib
+  UefiBootManagerLib
   UefiHiiServicesLib
 
 [Guids]


### PR DESCRIPTION
The device manager UI library creates a UiApp submenu that contains a
list of network devices in the system. The logic that creates this menu
assumes that all handles have been connected to their drivers, but this
is not guaranteed in the general case: due to the way UiApp is constructed,
this logic runs before the UiApp entrypoint is invoked, which is where
ConnectAll() is normally called to ensure that all existing controllers
are connected to their drivers. Moving this call into DeviceManagerUiLib
is not an option, since it is incorporated into UiApp via NULL library
class resolution, and so it may not be included to begin with.

So work around this by doing an explicit additional ConnectAll() before
populating the pages.

Signed-off-by: Ard Biesheuvel <ard.biesheuvel@arm.com>
Link: https://edk2.groups.io/g/devel/topic/72879609#57075
Reviewed-by: Dandan Bi <dandan.bi@intel.com>