### PR TITLE
OvmfPkg: Add bhyve support into AcpiTimerLib

### DIFF
--- a/OvmfPkg/Include/IndustryStandard/Bhyve.h
+++ b/OvmfPkg/Include/IndustryStandard/Bhyve.h
@@ -1,0 +1,16 @@
+/** @file
+  Various register numbers and value bits based on FreeBSD's bhyve
+  at r359530.
+  - https://svnweb.freebsd.org/base?view=revision&revision=359530
+
+  Copyright (C) 2020, Rebecca Cran <rebecca@bsdio.com>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef __BHYVE_H__
+#define __BHYVE_H__
+
+#define BHYVE_ACPI_TIMER_IO_ADDR 0x408
+
+#endif // __BHYVE_H__

--- a/OvmfPkg/Include/OvmfPlatforms.h
+++ b/OvmfPkg/Include/OvmfPlatforms.h
@@ -14,6 +14,7 @@
 #include <IndustryStandard/Pci22.h>
 #include <IndustryStandard/Q35MchIch9.h>
 #include <IndustryStandard/I440FxPiix4.h>
+#include <IndustryStandard/Bhyve.h>
 
 //
 // OVMF Host Bridge DID Address

--- a/OvmfPkg/Library/AcpiTimerLib/BaseAcpiTimerLibBhyve.c
+++ b/OvmfPkg/Library/AcpiTimerLib/BaseAcpiTimerLibBhyve.c
@@ -1,0 +1,32 @@
+/** @file
+  Provide InternalAcpiGetTimerTick for the bhyve instance of the
+  Base ACPI Timer Library
+
+  Copyright (C) 2020, Rebecca Cran <rebecca@bsdio.com>
+  Copyright (C) 2014, Gabriel L. Somlo <somlo@cmu.edu>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <Library/IoLib.h>
+#include <OvmfPlatforms.h>
+
+/**
+  Internal function to read the current tick counter of ACPI.
+
+  Read the current ACPI tick counter using the counter address cached
+  by this instance's constructor.
+
+  @return The tick counter read.
+
+**/
+UINT32
+InternalAcpiGetTimerTick (
+  VOID
+  )
+{
+  //
+  // Return the current ACPI timer value.
+  //
+  return IoRead32 (BHYVE_ACPI_TIMER_IO_ADDR);
+}

--- a/OvmfPkg/Library/AcpiTimerLib/BaseAcpiTimerLibBhyve.inf
+++ b/OvmfPkg/Library/AcpiTimerLib/BaseAcpiTimerLibBhyve.inf
@@ -1,0 +1,30 @@
+## @file
+#  Base ACPI Timer Library Instance for Bhyve.
+#
+#  Copyright (C) 2020, Rebecca Cran <rebecca@bsdio.com>
+#  Copyright (C) 2014, Gabriel L. Somlo <somlo@cmu.edu>
+#  Copyright (c) 2008 - 2010, Intel Corporation. All rights reserved.
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION    = 0x00010005
+  BASE_NAME      = BaseAcpiTimerLibBhyve
+  FILE_GUID      = A5E3B247-7302-11EA-9C04-3CECEF0C1C08
+  MODULE_TYPE    = BASE
+  VERSION_STRING = 1.0
+  LIBRARY_CLASS  = TimerLib
+
+[Sources]
+  AcpiTimerLib.c
+  AcpiTimerLib.h
+  BaseAcpiTimerLibBhyve.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  OvmfPkg/OvmfPkg.dec
+
+[LibraryClasses]
+  IoLib


### PR DESCRIPTION
On bhyve, the ACPI timer is located at a fixed IO address; it need
not be programmed into, nor fetched from, the PMBA -- power
management base address -- register of the PCI host bridge.

Signed-off-by: Rebecca Cran <rebecca@bsdio.com>
Cc: Jordan Justen <jordan.l.justen@intel.com>
Cc: Laszlo Ersek <lersek@redhat.com>
Cc: Ard Biesheuvel <ard.biesheuvel@arm.com>
Message-Id: <20200430011212.612386-1-rebecca@bsdio.com>
Reviewed-by: Laszlo Ersek <lersek@redhat.com>