### PR TITLE
OvmfPkg: Add VBE2 mode info structure to LegacyVgaBios.h

### DIFF
--- a/OvmfPkg/Include/IndustryStandard/LegacyVgaBios.h
+++ b/OvmfPkg/Include/IndustryStandard/LegacyVgaBios.h
@@ -86,6 +86,44 @@ typedef struct {
   UINT32 MaxPixelClockHz;
   UINT8  Reserved[190];
 } VBE_MODE_INFO;
+
+typedef struct {
+  UINT16 ModeAttr;
+  UINT8  WindowAAttr;
+  UINT8  WindowBAttr;
+  UINT16 WindowGranularityKB;
+  UINT16 WindowSizeKB;
+  UINT16 WindowAStartSegment;
+  UINT16 WindowBStartSegment;
+  UINT32 WindowPositioningAddress;
+  UINT16 BytesPerScanLine;
+
+  UINT16 Width;
+  UINT16 Height;
+  UINT8  CharCellWidth;
+  UINT8  CharCellHeight;
+  UINT8  NumPlanes;
+  UINT8  BitsPerPixel;
+  UINT8  NumBanks;
+  UINT8  MemoryModel;
+  UINT8  BankSizeKB;
+  UINT8  NumImagePagesLessOne;
+  UINT8  Vbe3;
+
+  UINT8  RedMaskSize;
+  UINT8  RedMaskPos;
+  UINT8  GreenMaskSize;
+  UINT8  GreenMaskPos;
+  UINT8  BlueMaskSize;
+  UINT8  BlueMaskPos;
+  UINT8  ReservedMaskSize;
+  UINT8  ReservedMaskPos;
+  UINT8  DirectColorModeInfo;
+
+  UINT32 LfbAddress;
+  UINT32 OffScreenAddress;
+  UINT16 OffScreenSizeKB;
+} VBE2_MODE_INFO;
 #pragma pack ()
 
 #endif


### PR DESCRIPTION
bhyve uses the older VESA BIOS Extensions 2.0, so add the mode info
structure to IndustryStandard/LegacyVgaBios.h

Signed-off-by: Rebecca Cran <rebecca@bsdio.com>
Acked-by: Laszlo Ersek <lersek@redhat.com>
Cc: Jordan Justen <jordan.l.justen@intel.com>
Cc: Laszlo Ersek <lersek@redhat.com>
Cc: Ard Biesheuvel <ard.biesheuvel@arm.com>
Message-Id: <20200430011503.613044-1-rebecca@bsdio.com>