### PR TITLE
OvmfPkg: Add BaseResetSystemLibBhyve

### DIFF
--- a/OvmfPkg/Include/IndustryStandard/Bhyve.h
+++ b/OvmfPkg/Include/IndustryStandard/Bhyve.h
@@ -13,4 +13,6 @@
 
 #define BHYVE_ACPI_TIMER_IO_ADDR 0x408
 
+#define BHYVE_PM_REG 0x404
+
 #endif // __BHYVE_H__

--- a/OvmfPkg/Library/ResetSystemLib/BaseResetShutdownBhyve.c
+++ b/OvmfPkg/Library/ResetSystemLib/BaseResetShutdownBhyve.c
@@ -1,0 +1,34 @@
+/** @file
+  Base Reset System Library Shutdown API implementation for bhyve.
+
+  Copyright (C) 2020, Rebecca Cran <rebecca@bsdio.com>
+  Copyright (C) 2020, Red Hat, Inc.
+  Copyright (c) 2006 - 2019, Intel Corporation. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <Base.h>                   // BIT13
+
+#include <IndustryStandard/Bhyve.h> // BHYVE_PM_REG
+#include <Library/BaseLib.h>        // CpuDeadLoop()
+#include <Library/IoLib.h>          // IoOr16()
+#include <Library/ResetSystemLib.h> // ResetShutdown()
+
+/**
+  Calling this function causes the system to enter a power state equivalent
+  to the ACPI G2/S5 or G3 states.
+
+  System shutdown should not return, if it returns, it means the system does
+  not support shut down reset.
+**/
+VOID
+EFIAPI
+ResetShutdown (
+  VOID
+  )
+{
+  IoBitFieldWrite16 (BHYVE_PM_REG, 10, 13, 5);
+  IoOr16 (BHYVE_PM_REG, BIT13);
+  CpuDeadLoop ();
+}

--- a/OvmfPkg/Library/ResetSystemLib/BaseResetSystemLibBhyve.inf
+++ b/OvmfPkg/Library/ResetSystemLib/BaseResetSystemLibBhyve.inf
@@ -1,0 +1,40 @@
+## @file
+#  Base library instance for ResetSystem library class for bhyve
+#
+#  Copyright (C) 2020, Rebecca Cran <rebecca@bsdio.com>
+#  Copyright (C) 2020, Red Hat, Inc.
+#  Copyright (c) 2006 - 2018, Intel Corporation. All rights reserved.<BR>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 1.29
+  BASE_NAME                      = BaseResetSystemLibBhyve
+  FILE_GUID                      = 5c71b08f-0ade-4607-8b9d-946c2757fee8
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = ResetSystemLib
+
+#
+# The following information is for reference only and not required by the build
+# tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  BaseResetShutdownBhyve.c
+  ResetSystemLib.c
+
+[Packages]
+  MdeModulePkg/MdeModulePkg.dec
+  MdePkg/MdePkg.dec
+  OvmfPkg/OvmfPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  IoLib
+  TimerLib
+


### PR DESCRIPTION
Introduce BaseResetSystemLibBhyve.inf, to support powering off
bhyve guests.

Signed-off-by: Rebecca Cran <rebecca@bsdio.com>
Cc: Jordan Justen <jordan.l.justen@intel.com>
Cc: Laszlo Ersek <lersek@redhat.com>
Cc: Ard Biesheuvel <ard.biesheuvel@arm.com>
Message-Id: <20200504021853.76658-1-rebecca@bsdio.com>
[lersek@redhat.com: MODULE_TYPE: replace DXE_DRIVER with BASE]
[lersek@redhat.com: replace <OvmfPlatforms.h> with <IndustryStandard/Bhyve.h>]
[lersek@redhat.com: strip ".inf" from subject line]
Reviewed-by: Laszlo Ersek <lersek@redhat.com>