### PR TITLE
FmpDevicePkg/FmpDxe: Fix uninitialized pointer dereference

### DIFF
--- a/FmpDevicePkg/FmpDxe/Dependency.c
+++ b/FmpDevicePkg/FmpDxe/Dependency.c
@@ -552,7 +552,7 @@ EvaluateImageDependencies (
     return EFI_ABORTED;
   }
 
-  mFmpImageInfoBuf = AllocatePool (sizeof(EFI_FIRMWARE_IMAGE_DESCRIPTOR *) * mNumberOfFmpInstance);
+  mFmpImageInfoBuf = AllocateZeroPool (sizeof(EFI_FIRMWARE_IMAGE_DESCRIPTOR *) * mNumberOfFmpInstance);
   if (mFmpImageInfoBuf == NULL) {
     return EFI_OUT_OF_RESOURCES;
   }


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=2602

Zero the allocated buffer in case GetImageInfo `continue` in the middle of
a loop. This will cause unexpected GetImageInfo failure not clearing the
corresponding entry and lead to GP faults when dereferencing this entry.

Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Liming Gao <liming.gao@intel.com>
Signed-off-by: Wei6 Xu <wei6.xu@intel.com>
Reviewed-by: Guomin Jiang <guomin.jiang@intel.com>
Reviewed-by: Michael D Kinney <michael.d.kinney@intel.com>