### PR TITLE
Check if required ACPI tables are installed

### DIFF
--- a/ShellPkg/Library/UefiShellAcpiViewCommandLib/AcpiTableParser.c
+++ b/ShellPkg/Library/UefiShellAcpiViewCommandLib/AcpiTableParser.c
@@ -3,6 +3,12 @@
 
   Copyright (c) 2016 - 2020, ARM Limited. All rights reserved.
   SPDX-License-Identifier: BSD-2-Clause-Patent
+
+  @par Glossary:
+    - Sbbr or SBBR   - Server Base Boot Requirements
+
+  @par Reference(s):
+    - Arm Server Base Boot Requirements 1.2, September 2019
 **/
 
 #include <Uefi.h>
@@ -11,6 +17,10 @@
 #include "AcpiParser.h"
 #include "AcpiTableParser.h"
 #include "AcpiView.h"
+
+#if defined(MDE_CPU_ARM) || defined (MDE_CPU_AARCH64)
+#include "Arm/SbbrValidator.h"
+#endif
 
 /**
   A list of registered ACPI table parsers.
@@ -215,6 +225,12 @@ ProcessAcpiTable (
       VerifyChecksum (TRUE, Ptr, *AcpiTableLength);
     }
   }
+
+#if defined(MDE_CPU_ARM) || defined (MDE_CPU_AARCH64)
+  if (GetMandatoryTableValidate ()) {
+    ArmSbbrIncrementTableCount (*AcpiTableSignature);
+  }
+#endif
 
   Status = GetParser (*AcpiTableSignature, &ParserProc);
   if (EFI_ERROR (Status)) {

--- a/ShellPkg/Library/UefiShellAcpiViewCommandLib/AcpiView.c
+++ b/ShellPkg/Library/UefiShellAcpiViewCommandLib/AcpiView.c
@@ -2,6 +2,12 @@
 
   Copyright (c) 2016 - 2020, ARM Limited. All rights reserved.
   SPDX-License-Identifier: BSD-2-Clause-Patent
+
+  @par Glossary:
+    - Sbbr or SBBR   - Server Base Boot Requirements
+
+  @par Reference(s):
+    - Arm Server Base Boot Requirements 1.2, September 2019
 **/
 
 #include <Library/PrintLib.h>
@@ -15,6 +21,10 @@
 #include "AcpiTableParser.h"
 #include "AcpiView.h"
 #include "UefiShellAcpiViewCommandLib.h"
+
+#if defined(MDE_CPU_ARM) || defined (MDE_CPU_AARCH64)
+#include "Arm/SbbrValidator.h"
+#endif
 
 EFI_HII_HANDLE gShellAcpiViewHiiHandle = NULL;
 
@@ -438,6 +448,12 @@ AcpiView (
       return EFI_UNSUPPORTED;
     }
 
+#if defined(MDE_CPU_ARM) || defined (MDE_CPU_AARCH64)
+    if (GetMandatoryTableValidate ()) {
+      ArmSbbrResetTableCounts ();
+    }
+#endif
+
     // The RSDP length is 4 bytes starting at offset 20
     RsdpLength = *(UINT32*)(RsdpPtr + RSDP_LENGTH_OFFSET);
 
@@ -465,6 +481,12 @@ AcpiView (
       );
     return EFI_NOT_FOUND;
   }
+
+#if defined(MDE_CPU_ARM) || defined (MDE_CPU_AARCH64)
+  if (GetMandatoryTableValidate ()) {
+    ArmSbbrReqsValidate ((ARM_SBBR_VERSION)GetMandatoryTableSpec ());
+  }
+#endif
 
   ReportOption = GetReportOption ();
   if (ReportTableList != ReportOption) {

--- a/ShellPkg/Library/UefiShellAcpiViewCommandLib/AcpiView.h
+++ b/ShellPkg/Library/UefiShellAcpiViewCommandLib/AcpiView.h
@@ -1,7 +1,7 @@
 /** @file
   Header file for AcpiView
 
-  Copyright (c) 2016 - 2019, ARM Limited. All rights reserved.
+  Copyright (c) 2016 - 2020, ARM Limited. All rights reserved.
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
@@ -110,6 +110,48 @@ GetConsistencyChecking (
 VOID
 SetConsistencyChecking (
   BOOLEAN ConsistencyChecking
+  );
+
+/**
+  This function returns the ACPI table requirements validation flag.
+
+  @retval TRUE if check for mandatory table presence should be performed.
+**/
+BOOLEAN
+GetMandatoryTableValidate (
+  VOID
+  );
+
+/**
+  This function sets the ACPI table requirements validation flag.
+
+  @param  Validate    Enable/Disable ACPI table requirements validation.
+**/
+VOID
+SetMandatoryTableValidate (
+  BOOLEAN Validate
+  );
+
+/**
+  This function returns the identifier of specification to validate ACPI table
+  requirements against.
+
+  @return   ID of specification listing mandatory tables.
+**/
+UINTN
+GetMandatoryTableSpec (
+  VOID
+  );
+
+/**
+  This function sets the identifier of specification to validate ACPI table
+  requirements against.
+
+  @param  Spec      ID of specification listing mandatory tables.
+**/
+VOID
+SetMandatoryTableSpec (
+  UINTN Spec
   );
 
 /**

--- a/ShellPkg/Library/UefiShellAcpiViewCommandLib/Arm/SbbrValidator.c
+++ b/ShellPkg/Library/UefiShellAcpiViewCommandLib/Arm/SbbrValidator.c
@@ -1,0 +1,222 @@
+/** @file
+  Arm Server Base Boot Requirements ACPI table requirement validator.
+
+  Copyright (c) 2020, ARM Limited. All rights reserved.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+  @par Glossary:
+    - Sbbr or SBBR   - Server Base Boot Requirements
+    - Sbsa or SBSA   - Server Base System Architecture
+
+  @par Reference(s):
+    - Arm Server Base Boot Requirements 1.2, September 2019
+    - Arm Server Base Boot Requirements 1.1, May 2018
+    - Arm Server Base Boot Requirements 1.0, March 2016
+    - Arm Server Base System Architecture 6.0
+**/
+
+#include <Library/DebugLib.h>
+#include <Library/UefiLib.h>
+#include "AcpiParser.h"
+#include "Arm/SbbrValidator.h"
+
+/**
+  SBBR specification version strings
+**/
+STATIC CONST CHAR8* ArmSbbrVersions[ArmSbbrVersionMax] = {
+  "1.0",     // ArmSbbrVersion_1_0
+  "1.1",     // ArmSbbrVersion_1_1
+  "1.2"      // ArmSbbrVersion_1_2
+};
+
+/**
+  SBBR 1.0 mandatory ACPI tables
+**/
+STATIC CONST UINT32 ArmSbbr10Mandatory[] = {
+  EFI_ACPI_6_3_EXTENDED_SYSTEM_DESCRIPTION_TABLE_SIGNATURE,
+  EFI_ACPI_6_3_FIXED_ACPI_DESCRIPTION_TABLE_SIGNATURE,
+  EFI_ACPI_6_3_DIFFERENTIATED_SYSTEM_DESCRIPTION_TABLE_SIGNATURE,
+  EFI_ACPI_6_3_MULTIPLE_APIC_DESCRIPTION_TABLE_SIGNATURE,
+  EFI_ACPI_6_3_GENERIC_TIMER_DESCRIPTION_TABLE_SIGNATURE,
+  EFI_ACPI_6_3_DEBUG_PORT_2_TABLE_SIGNATURE,
+  EFI_ACPI_6_3_SERIAL_PORT_CONSOLE_REDIRECTION_TABLE_SIGNATURE
+};
+
+/**
+  SBBR 1.1 mandatory ACPI tables
+**/
+STATIC CONST UINT32 ArmSbbr11Mandatory[] = {
+  EFI_ACPI_6_3_EXTENDED_SYSTEM_DESCRIPTION_TABLE_SIGNATURE,
+  EFI_ACPI_6_3_FIXED_ACPI_DESCRIPTION_TABLE_SIGNATURE,
+  EFI_ACPI_6_3_DIFFERENTIATED_SYSTEM_DESCRIPTION_TABLE_SIGNATURE,
+  EFI_ACPI_6_3_MULTIPLE_APIC_DESCRIPTION_TABLE_SIGNATURE,
+  EFI_ACPI_6_3_GENERIC_TIMER_DESCRIPTION_TABLE_SIGNATURE,
+  EFI_ACPI_6_3_DEBUG_PORT_2_TABLE_SIGNATURE,
+  EFI_ACPI_6_3_SERIAL_PORT_CONSOLE_REDIRECTION_TABLE_SIGNATURE,
+  EFI_ACPI_6_3_PCI_EXPRESS_MEMORY_MAPPED_CONFIGURATION_SPACE_BASE_ADDRESS_DESCRIPTION_TABLE_SIGNATURE
+};
+
+/**
+  SBBR 1.2 mandatory ACPI tables
+**/
+STATIC CONST UINT32 ArmSbbr12Mandatory[] = {
+  EFI_ACPI_6_3_EXTENDED_SYSTEM_DESCRIPTION_TABLE_SIGNATURE,
+  EFI_ACPI_6_3_FIXED_ACPI_DESCRIPTION_TABLE_SIGNATURE,
+  EFI_ACPI_6_3_DIFFERENTIATED_SYSTEM_DESCRIPTION_TABLE_SIGNATURE,
+  EFI_ACPI_6_3_MULTIPLE_APIC_DESCRIPTION_TABLE_SIGNATURE,
+  EFI_ACPI_6_3_GENERIC_TIMER_DESCRIPTION_TABLE_SIGNATURE,
+  EFI_ACPI_6_3_DEBUG_PORT_2_TABLE_SIGNATURE,
+  EFI_ACPI_6_3_SERIAL_PORT_CONSOLE_REDIRECTION_TABLE_SIGNATURE,
+  EFI_ACPI_6_3_PCI_EXPRESS_MEMORY_MAPPED_CONFIGURATION_SPACE_BASE_ADDRESS_DESCRIPTION_TABLE_SIGNATURE,
+  EFI_ACPI_6_3_PROCESSOR_PROPERTIES_TOPOLOGY_TABLE_STRUCTURE_SIGNATURE
+};
+
+/**
+  Mandatory ACPI tables for every SBBR specification version.
+**/
+STATIC CONST ACPI_SBBR_REQ ArmSbbrReqs[ArmSbbrVersionMax] = {
+  { ArmSbbr10Mandatory, ARRAY_SIZE (ArmSbbr10Mandatory) },    // SBBR v1.0
+  { ArmSbbr11Mandatory, ARRAY_SIZE (ArmSbbr11Mandatory) },    // SBBR v1.1
+  { ArmSbbr12Mandatory, ARRAY_SIZE (ArmSbbr12Mandatory) }     // SBBR v1.2
+};
+
+/**
+  Data structure to track instance counts for all ACPI tables which are
+  defined as 'mandatory' in any SBBR version.
+**/
+STATIC ACPI_TABLE_COUNTER ArmSbbrTableCounts[] = {
+  {EFI_ACPI_6_3_EXTENDED_SYSTEM_DESCRIPTION_TABLE_SIGNATURE, 0},
+  {EFI_ACPI_6_3_FIXED_ACPI_DESCRIPTION_TABLE_SIGNATURE, 0},
+  {EFI_ACPI_6_3_DIFFERENTIATED_SYSTEM_DESCRIPTION_TABLE_SIGNATURE, 0},
+  {EFI_ACPI_6_3_MULTIPLE_APIC_DESCRIPTION_TABLE_SIGNATURE, 0},
+  {EFI_ACPI_6_3_GENERIC_TIMER_DESCRIPTION_TABLE_SIGNATURE, 0},
+  {EFI_ACPI_6_3_DEBUG_PORT_2_TABLE_SIGNATURE, 0},
+  {EFI_ACPI_6_3_SERIAL_PORT_CONSOLE_REDIRECTION_TABLE_SIGNATURE, 0},
+  {EFI_ACPI_6_3_PCI_EXPRESS_MEMORY_MAPPED_CONFIGURATION_SPACE_BASE_ADDRESS_DESCRIPTION_TABLE_SIGNATURE, 0},
+  {EFI_ACPI_6_3_PROCESSOR_PROPERTIES_TOPOLOGY_TABLE_STRUCTURE_SIGNATURE, 0}
+};
+
+/**
+  Reset the platform ACPI table instance count for all SBBR-mandatory tables.
+**/
+VOID
+EFIAPI
+ArmSbbrResetTableCounts (
+  VOID
+  )
+{
+  UINT32 Table;
+
+  for (Table = 0; Table < ARRAY_SIZE (ArmSbbrTableCounts); Table++) {
+    ArmSbbrTableCounts[Table].Count = 0;
+  }
+}
+
+/**
+  Increment instance count for SBBR-mandatory ACPI table with the given
+  signature.
+
+  @param [in]  Signature        ACPI table signature.
+
+  @retval TRUE      Count incremented successfully.
+  @retval FALSE     Table with the input signature not found.
+**/
+BOOLEAN
+EFIAPI
+ArmSbbrIncrementTableCount (
+  UINT32 Signature
+  )
+{
+  UINT32 Table;
+
+  for (Table = 0; Table < ARRAY_SIZE (ArmSbbrTableCounts); Table++) {
+    if (Signature == ArmSbbrTableCounts[Table].Signature) {
+      ArmSbbrTableCounts[Table].Count++;
+      return TRUE;
+    }
+  }
+
+  return FALSE;
+}
+
+/**
+  Validate that all ACPI tables required by the given SBBR specification
+  version are installed on the platform.
+
+  @param [in]  Version      SBBR spec version to validate against.
+
+  @retval EFI_SUCCESS             All required tables are present.
+  @retval EFI_INVALID_PARAMETER   Invalid SBBR version.
+  @retval EFI_NOT_FOUND           One or more mandatory tables are missing.
+  @retval EFI_UNSUPPORTED         Mandatory ACPI table does not have its
+                                  instance count tracked.
+**/
+EFI_STATUS
+EFIAPI
+ArmSbbrReqsValidate (
+  ARM_SBBR_VERSION Version
+  )
+{
+  UINT32        Table;
+  UINT32        Index;
+  UINT32        MandatoryTable;
+  CONST UINT8*  SignaturePtr;
+  BOOLEAN       IsArmSbbrViolated;
+
+  if (Version >= ArmSbbrVersionMax) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  IsArmSbbrViolated = FALSE;
+
+  // Go through the list of mandatory tables for the input SBBR version
+  for (Table = 0; Table < ArmSbbrReqs[Version].TableCount; Table++) {
+    MandatoryTable = ArmSbbrReqs[Version].Tables[Table];
+    SignaturePtr = (CONST UINT8*)(UINTN)&MandatoryTable;
+
+    // Locate the instance count for the table with the given signature
+    Index = 0;
+    while ((Index < ARRAY_SIZE (ArmSbbrTableCounts)) &&
+           (ArmSbbrTableCounts[Index].Signature != MandatoryTable)) {
+      Index++;
+    }
+
+    if (Index >= ARRAY_SIZE (ArmSbbrTableCounts)) {
+      IncrementErrorCount ();
+      Print (
+        L"\nERROR: SBBR v%a: Mandatory %c%c%c%c table's instance count not " \
+          L"found\n",
+        ArmSbbrVersions[Version],
+        SignaturePtr[0],
+        SignaturePtr[1],
+        SignaturePtr[2],
+        SignaturePtr[3]
+        );
+      return EFI_UNSUPPORTED;
+    }
+
+    if (ArmSbbrTableCounts[Index].Count == 0) {
+      IsArmSbbrViolated = TRUE;
+      IncrementErrorCount ();
+      Print (
+        L"\nERROR: SBBR v%a: Mandatory %c%c%c%c table is missing",
+        ArmSbbrVersions[Version],
+        SignaturePtr[0],
+        SignaturePtr[1],
+        SignaturePtr[2],
+        SignaturePtr[3]
+        );
+    }
+  }
+
+  if (!IsArmSbbrViolated) {
+    Print (
+      L"\nINFO: SBBR v%a: All mandatory ACPI tables are installed",
+      ArmSbbrVersions[Version]
+      );
+  }
+
+  Print (L"\n");
+
+  return IsArmSbbrViolated ? EFI_NOT_FOUND : EFI_SUCCESS;
+}

--- a/ShellPkg/Library/UefiShellAcpiViewCommandLib/Arm/SbbrValidator.h
+++ b/ShellPkg/Library/UefiShellAcpiViewCommandLib/Arm/SbbrValidator.h
@@ -1,0 +1,91 @@
+/** @file
+  Header file for SbbrValidator.c
+
+  Copyright (c) 2020, ARM Limited. All rights reserved.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+  @par Glossary:
+    - Sbbr or SBBR   - Server Base Boot Requirements
+    - Sbsa or SBSA   - Server Base System Architecture
+
+  @par Reference(s):
+    - Arm Server Base Boot Requirements 1.2, September 2019
+    - Arm Server Base Boot Requirements 1.1, May 2018
+    - Arm Server Base Boot Requirements 1.0, March 2016
+    - Arm Server Base System Architecture 6.0
+**/
+
+#ifndef SBBR_VALIDATOR_H_
+#define SBBR_VALIDATOR_H_
+
+#include <IndustryStandard/Acpi.h>
+
+/**
+  Arm SBBR specification versions.
+**/
+typedef enum {
+  ArmSbbrVersion_1_0    = 0,
+  ArmSbbrVersion_1_1    = 1,
+  ArmSbbrVersion_1_2    = 2,
+  ArmSbbrVersionMax     = 3
+} ARM_SBBR_VERSION;
+
+/**
+  The ACPI table instance counter.
+**/
+typedef struct AcpiTableCounter {
+  CONST UINT32  Signature;        /// ACPI table signature
+  UINT32        Count;            /// Instance count
+} ACPI_TABLE_COUNTER;
+
+/**
+  ACPI table SBBR requirements.
+**/
+typedef struct AcpiSbbrReq {
+  CONST UINT32* Tables;          /// List of required tables
+  CONST UINT32  TableCount;      /// Number of elements in Tables
+} ACPI_SBBR_REQ;
+
+/**
+  Reset the platform ACPI table instance count for all SBBR-mandatory tables.
+**/
+VOID
+EFIAPI
+ArmSbbrResetTableCounts (
+  VOID
+  );
+
+/**
+  Increment instance count for SBBR-mandatory ACPI table with the given
+  signature.
+
+  @param [in]  Signature        ACPI table signature.
+
+  @retval TRUE      Count incremented successfully.
+  @retval FALSE     Table with the input signature not found.
+**/
+BOOLEAN
+EFIAPI
+ArmSbbrIncrementTableCount (
+  UINT32 Signature
+  );
+
+/**
+  Validate that all ACPI tables required by the given SBBR specification
+  version are installed on the platform.
+
+  @param [in]  Version      SBBR spec version to validate against.
+
+  @retval EFI_SUCCESS             All required tables are present.
+  @retval EFI_INVALID_PARAMETER   Invalid SBBR version.
+  @retval EFI_NOT_FOUND           One or more mandatory tables are missing.
+  @retval EFI_UNSUPPORTED         Mandatory ACPI table does not have its
+                                  instance count tracked.
+**/
+EFI_STATUS
+EFIAPI
+ArmSbbrReqsValidate (
+  ARM_SBBR_VERSION Version
+  );
+
+#endif // SBBR_VALIDATOR_H_

--- a/ShellPkg/Library/UefiShellAcpiViewCommandLib/UefiShellAcpiViewCommandLib.inf
+++ b/ShellPkg/Library/UefiShellAcpiViewCommandLib/UefiShellAcpiViewCommandLib.inf
@@ -1,7 +1,7 @@
 ##  @file
 # Provides Shell 'acpiview' command functions
 #
-# Copyright (c) 2016 - 2019, ARM Limited. All rights reserved.<BR>
+# Copyright (c) 2016 - 2020, ARM Limited. All rights reserved.<BR>
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -46,6 +46,10 @@
   Parsers/Xsdt/XsdtParser.c
   Parsers/Madt/MadtParser.h
   Parsers/Pptt/PpttParser.h
+
+[Sources.ARM, Sources.AARCH64]
+  Arm/SbbrValidator.h
+  Arm/SbbrValidator.c
 
 [Packages]
   MdePkg/MdePkg.dec

--- a/ShellPkg/Library/UefiShellAcpiViewCommandLib/UefiShellAcpiViewCommandLib.uni
+++ b/ShellPkg/Library/UefiShellAcpiViewCommandLib/UefiShellAcpiViewCommandLib.uni
@@ -1,6 +1,6 @@
 // /**
 //
-// Copyright (c) 2016 - 2019, ARM Limited. All rights reserved.<BR>
+// Copyright (c) 2016 - 2020, ARM Limited. All rights reserved.<BR>
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
 // Module Name:
@@ -30,7 +30,7 @@
 "Display ACPI Table information.\r\n"
 ".SH SYNOPSIS\r\n"
 " \r\n"
-"ACPIVIEW [[-?] | [[-l] | [-s AcpiTable [-d]]] [-q] [-h]]\r\n"
+"ACPIVIEW [[-?] | [[[[-l] | [-s AcpiTable [-d]]] [-q] [-h]] [-r Spec]]]\r\n"
 " \r\n"
 ".SH OPTIONS\r\n"
 " \r\n"
@@ -41,6 +41,12 @@
 "  -d - Generate a binary file dump of the specified AcpiTable.\r\n"
 "  -q - Quiet. Suppress errors and warnings. Disables consistency checks.\r\n"
 "  -h - Enable colour highlighting.\r\n"
+"  -r - Validate that all required ACPI tables are installed\r\n"
+"         Spec  : Specification to validate against.\r\n"
+"                 For Arm, the possible values are:\r\n"
+"                   0 - Server Base Boot Requirements v1.0\r\n"
+"                   1 - Server Base Boot Requirements v1.1\r\n"
+"                   2 - Server Base Boot Requirements v1.2\r\n"
 "  -? - Show help.\r\n"
 " \r\n"
 ".SH DESCRIPTION\r\n"
@@ -117,6 +123,10 @@
 " \r\n"
 "  * To display contents of all ACPI tables:\r\n"
 "    fs0:\> acpiview\r\n"
+" \r\n"
+"  * To check if all Server Base Boot Requirements (SBBR) v1.2 mandatory\r\n"
+"    ACPI tables are installed (Arm only):\r\n"
+"    fs0:\> acpiview -r 2\r\n"
 " \r\n"
 ".SH RETURNVALUES\r\n"
 " \r\n"


### PR DESCRIPTION
This patch series adds a new capability to the Acpiview UEFI shell tool.
Using the -r command line parameter, it is now possible to choose a
specification which lists mandatory ACPI tables. The parameter value is
then consumed by a library which validates ACPI tables identified on the
platform against these requirements.

The -r parameter is architecture agnostic. However, as of now, the
possible values for the parameter are only defined in the context of
the Arm architecture.

For Arm-based platforms, it is now possible to validate that Server Base
Boot Requirements (SBBR) mandatory ACPI tables are present on the
platform.

Changes can be seen at: https://github.com/KrzysztofKoch1/edk2/tree/617_sbbr_validate_acpi_table_counts_v1