### PR TITLE
BaseTools: add handling for 'S:' flag to GetMaintainer.py

### DIFF
--- a/BaseTools/Scripts/GetMaintainer.py
+++ b/BaseTools/Scripts/GetMaintainer.py
@@ -77,8 +77,12 @@ def get_section_maintainers(path, section):
        matching the provided path in the provided section."""
     maintainers = []
     lists = []
+    nowarn_status = ['Supported', 'Maintained']
 
     if path_in_section(path, section):
+        for status in section['status']:
+            if status not in nowarn_status:
+                print('WARNING: Maintained status for "%s" is \'%s\'!' % (path, status))
         for address in section['maintainer'], section['reviewer']:
             # Convert to list if necessary
             if isinstance(address, list):


### PR DESCRIPTION
GetMaintainer.py already extracts the value of any S: tags for sections,
but it doesn't do anything with that information.

Print a warning message, with the status, for each matching section with
a status explicitly set to anything other than 'Supported' or
'Maintained'.

Cc: Bob Feng <bob.c.feng@intel.com>
Cc: Liming Gao <liming.gao@intel.com>
Signed-off-by: Leif Lindholm <leif@nuviainc.com>
Acked-by: Ard Biesheuvel <ard.biesheuvel@arm.com>
Reviewed-by: Bob Feng <bob.c.feng@intel.com>