### PR TITLE
[PATCH v3 0/3] XCODE5 toolchain binary patching fix

### DIFF
--- a/OvmfPkg/OvmfPkgIa32.dsc
+++ b/OvmfPkg/OvmfPkgIa32.dsc
@@ -246,7 +246,11 @@
   PeiServicesLib|MdePkg/Library/PeiServicesLib/PeiServicesLib.inf
   PeiServicesTablePointerLib|MdePkg/Library/PeiServicesTablePointerLibIdt/PeiServicesTablePointerLibIdt.inf
   MemoryAllocationLib|MdePkg/Library/PeiMemoryAllocationLib/PeiMemoryAllocationLib.inf
+!if $(TOOL_CHAIN_TAG) == "XCODE5"
+  CpuExceptionHandlerLib|UefiCpuPkg/Library/CpuExceptionHandlerLib/Xcode5SecPeiCpuExceptionHandlerLib.inf
+!else
   CpuExceptionHandlerLib|UefiCpuPkg/Library/CpuExceptionHandlerLib/SecPeiCpuExceptionHandlerLib.inf
+!endif
 
 [LibraryClasses.common.PEI_CORE]
   HobLib|MdePkg/Library/PeiHobLib/PeiHobLib.inf

--- a/OvmfPkg/OvmfPkgIa32X64.dsc
+++ b/OvmfPkg/OvmfPkgIa32X64.dsc
@@ -250,7 +250,11 @@
   PeiServicesLib|MdePkg/Library/PeiServicesLib/PeiServicesLib.inf
   PeiServicesTablePointerLib|MdePkg/Library/PeiServicesTablePointerLibIdt/PeiServicesTablePointerLibIdt.inf
   MemoryAllocationLib|MdePkg/Library/PeiMemoryAllocationLib/PeiMemoryAllocationLib.inf
+!if $(TOOL_CHAIN_TAG) == "XCODE5"
+  CpuExceptionHandlerLib|UefiCpuPkg/Library/CpuExceptionHandlerLib/Xcode5SecPeiCpuExceptionHandlerLib.inf
+!else
   CpuExceptionHandlerLib|UefiCpuPkg/Library/CpuExceptionHandlerLib/SecPeiCpuExceptionHandlerLib.inf
+!endif
 
 [LibraryClasses.common.PEI_CORE]
   HobLib|MdePkg/Library/PeiHobLib/PeiHobLib.inf

--- a/OvmfPkg/OvmfPkgX64.dsc
+++ b/OvmfPkg/OvmfPkgX64.dsc
@@ -250,7 +250,11 @@
   PeiServicesLib|MdePkg/Library/PeiServicesLib/PeiServicesLib.inf
   PeiServicesTablePointerLib|MdePkg/Library/PeiServicesTablePointerLibIdt/PeiServicesTablePointerLibIdt.inf
   MemoryAllocationLib|MdePkg/Library/PeiMemoryAllocationLib/PeiMemoryAllocationLib.inf
+!if $(TOOL_CHAIN_TAG) == "XCODE5"
+  CpuExceptionHandlerLib|UefiCpuPkg/Library/CpuExceptionHandlerLib/Xcode5SecPeiCpuExceptionHandlerLib.inf
+!else
   CpuExceptionHandlerLib|UefiCpuPkg/Library/CpuExceptionHandlerLib/SecPeiCpuExceptionHandlerLib.inf
+!endif
 
 [LibraryClasses.common.PEI_CORE]
   HobLib|MdePkg/Library/PeiHobLib/PeiHobLib.inf

--- a/OvmfPkg/OvmfXen.dsc
+++ b/OvmfPkg/OvmfXen.dsc
@@ -228,7 +228,11 @@
   PeiServicesLib|MdePkg/Library/PeiServicesLib/PeiServicesLib.inf
   PeiServicesTablePointerLib|MdePkg/Library/PeiServicesTablePointerLibIdt/PeiServicesTablePointerLibIdt.inf
   MemoryAllocationLib|MdePkg/Library/PeiMemoryAllocationLib/PeiMemoryAllocationLib.inf
+!if $(TOOL_CHAIN_TAG) == "XCODE5"
+  CpuExceptionHandlerLib|UefiCpuPkg/Library/CpuExceptionHandlerLib/Xcode5SecPeiCpuExceptionHandlerLib.inf
+!else
   CpuExceptionHandlerLib|UefiCpuPkg/Library/CpuExceptionHandlerLib/SecPeiCpuExceptionHandlerLib.inf
+!endif
 
 [LibraryClasses.common.PEI_CORE]
   HobLib|MdePkg/Library/PeiHobLib/PeiHobLib.inf

--- a/UefiCpuPkg/Library/CpuExceptionHandlerLib/DxeCpuExceptionHandlerLib.inf
+++ b/UefiCpuPkg/Library/CpuExceptionHandlerLib/DxeCpuExceptionHandlerLib.inf
@@ -28,7 +28,7 @@
   Ia32/ArchInterruptDefs.h
 
 [Sources.X64]
-  X64/ExceptionHandlerAsm.nasm
+  X64/Xcode5ExceptionHandlerAsm.nasm
   X64/ArchExceptionHandler.c
   X64/ArchInterruptDefs.h
 

--- a/UefiCpuPkg/Library/CpuExceptionHandlerLib/SmmCpuExceptionHandlerLib.inf
+++ b/UefiCpuPkg/Library/CpuExceptionHandlerLib/SmmCpuExceptionHandlerLib.inf
@@ -28,7 +28,7 @@
   Ia32/ArchInterruptDefs.h
 
 [Sources.X64]
-  X64/ExceptionHandlerAsm.nasm
+  X64/Xcode5ExceptionHandlerAsm.nasm
   X64/ArchExceptionHandler.c
   X64/ArchInterruptDefs.h
 

--- a/UefiCpuPkg/Library/CpuExceptionHandlerLib/X64/ExceptionHandlerAsm.nasm
+++ b/UefiCpuPkg/Library/CpuExceptionHandlerLib/X64/ExceptionHandlerAsm.nasm
@@ -34,7 +34,7 @@ AsmIdtVectorBegin:
     db      0x6a        ; push  #VectorNum
     db      ($ - AsmIdtVectorBegin) / ((AsmIdtVectorEnd - AsmIdtVectorBegin) / 32) ; VectorNum
     push    rax
-    mov     rax, strict qword 0 ;    mov     rax, ASM_PFX(CommonInterruptEntry)
+    mov     rax, ASM_PFX(CommonInterruptEntry)
     jmp     rax
 %endrep
 AsmIdtVectorEnd:
@@ -44,8 +44,7 @@ HookAfterStubHeaderBegin:
 @VectorNum:
     db      0          ; 0 will be fixed
     push    rax
-    mov     rax, strict qword 0 ;     mov     rax, HookAfterStubHeaderEnd
-JmpAbsoluteAddress:
+    mov     rax, HookAfterStubHeaderEnd
     jmp     rax
 HookAfterStubHeaderEnd:
     mov     rax, rsp
@@ -257,7 +256,8 @@ HasErrorCode:
     ; and make sure RSP is 16-byte aligned
     ;
     sub     rsp, 4 * 8 + 8
-    call    ASM_PFX(CommonExceptionHandler)
+    mov     rax, ASM_PFX(CommonExceptionHandler)
+    call    rax
     add     rsp, 4 * 8 + 8
 
     cli
@@ -365,24 +365,11 @@ DoIret:
 ; comments here for definition of address map
 global ASM_PFX(AsmGetTemplateAddressMap)
 ASM_PFX(AsmGetTemplateAddressMap):
-    lea     rax, [AsmIdtVectorBegin]
+    mov     rax, AsmIdtVectorBegin
     mov     qword [rcx], rax
     mov     qword [rcx + 0x8],  (AsmIdtVectorEnd - AsmIdtVectorBegin) / 32
-    lea     rax, [HookAfterStubHeaderBegin]
+    mov     rax, HookAfterStubHeaderBegin
     mov     qword [rcx + 0x10], rax
-
-; Fix up CommonInterruptEntry address
-    lea    rax, [ASM_PFX(CommonInterruptEntry)]
-    lea    rcx, [AsmIdtVectorBegin]
-%rep  32
-    mov    qword [rcx + (JmpAbsoluteAddress - 8 - HookAfterStubHeaderBegin)], rax
-    add    rcx, (AsmIdtVectorEnd - AsmIdtVectorBegin) / 32
-%endrep
-; Fix up HookAfterStubHeaderEnd
-    lea    rax, [HookAfterStubHeaderEnd]
-    lea    rcx, [JmpAbsoluteAddress]
-    mov    qword [rcx - 8], rax
-
     ret
 
 ;-------------------------------------------------------------------------------------

--- a/UefiCpuPkg/Library/CpuExceptionHandlerLib/X64/Xcode5ExceptionHandlerAsm.nasm
+++ b/UefiCpuPkg/Library/CpuExceptionHandlerLib/X64/Xcode5ExceptionHandlerAsm.nasm
@@ -1,0 +1,396 @@
+;------------------------------------------------------------------------------ ;
+; Copyright (c) 2012 - 2018, Intel Corporation. All rights reserved.<BR>
+; SPDX-License-Identifier: BSD-2-Clause-Patent
+;
+; Module Name:
+;
+;   ExceptionHandlerAsm.Asm
+;
+; Abstract:
+;
+;   x64 CPU Exception Handler
+;
+; Notes:
+;
+;------------------------------------------------------------------------------
+
+;
+; CommonExceptionHandler()
+;
+
+extern ASM_PFX(mErrorCodeFlag)    ; Error code flags for exceptions
+extern ASM_PFX(mDoFarReturnFlag)  ; Do far return flag
+extern ASM_PFX(CommonExceptionHandler)
+
+SECTION .data
+
+DEFAULT REL
+SECTION .text
+
+ALIGN   8
+
+AsmIdtVectorBegin:
+%rep  32
+    db      0x6a        ; push  #VectorNum
+    db      ($ - AsmIdtVectorBegin) / ((AsmIdtVectorEnd - AsmIdtVectorBegin) / 32) ; VectorNum
+    push    rax
+    mov     rax, strict qword 0 ;    mov     rax, ASM_PFX(CommonInterruptEntry)
+    jmp     rax
+%endrep
+AsmIdtVectorEnd:
+
+HookAfterStubHeaderBegin:
+    db      0x6a        ; push
+@VectorNum:
+    db      0          ; 0 will be fixed
+    push    rax
+    mov     rax, strict qword 0 ;     mov     rax, HookAfterStubHeaderEnd
+JmpAbsoluteAddress:
+    jmp     rax
+HookAfterStubHeaderEnd:
+    mov     rax, rsp
+    and     sp,  0xfff0        ; make sure 16-byte aligned for exception context
+    sub     rsp, 0x18           ; reserve room for filling exception data later
+    push    rcx
+    mov     rcx, [rax + 8]
+    bt      [ASM_PFX(mErrorCodeFlag)], ecx
+    jnc     .0
+    push    qword [rsp]             ; push additional rcx to make stack alignment
+.0:
+    xchg    rcx, [rsp]        ; restore rcx, save Exception Number in stack
+    push    qword [rax]             ; push rax into stack to keep code consistence
+
+;---------------------------------------;
+; CommonInterruptEntry                  ;
+;---------------------------------------;
+; The follow algorithm is used for the common interrupt routine.
+; Entry from each interrupt with a push eax and eax=interrupt number
+; Stack frame would be as follows as specified in IA32 manuals:
+;
+; +---------------------+ <-- 16-byte aligned ensured by processor
+; +    Old SS           +
+; +---------------------+
+; +    Old RSP          +
+; +---------------------+
+; +    RFlags           +
+; +---------------------+
+; +    CS               +
+; +---------------------+
+; +    RIP              +
+; +---------------------+
+; +    Error Code       +
+; +---------------------+
+; +   Vector Number     +
+; +---------------------+
+; +    RBP              +
+; +---------------------+ <-- RBP, 16-byte aligned
+; The follow algorithm is used for the common interrupt routine.
+global ASM_PFX(CommonInterruptEntry)
+ASM_PFX(CommonInterruptEntry):
+    cli
+    pop     rax
+    ;
+    ; All interrupt handlers are invoked through interrupt gates, so
+    ; IF flag automatically cleared at the entry point
+    ;
+    xchg    rcx, [rsp]      ; Save rcx into stack and save vector number into rcx
+    and     rcx, 0xFF
+    cmp     ecx, 32         ; Intel reserved vector for exceptions?
+    jae     NoErrorCode
+    bt      [ASM_PFX(mErrorCodeFlag)], ecx
+    jc      HasErrorCode
+
+NoErrorCode:
+
+    ;
+    ; Push a dummy error code on the stack
+    ; to maintain coherent stack map
+    ;
+    push    qword [rsp]
+    mov     qword [rsp + 8], 0
+HasErrorCode:
+    push    rbp
+    mov     rbp, rsp
+    push    0             ; clear EXCEPTION_HANDLER_CONTEXT.OldIdtHandler
+    push    0             ; clear EXCEPTION_HANDLER_CONTEXT.ExceptionDataFlag
+
+    ;
+    ; Stack:
+    ; +---------------------+ <-- 16-byte aligned ensured by processor
+    ; +    Old SS           +
+    ; +---------------------+
+    ; +    Old RSP          +
+    ; +---------------------+
+    ; +    RFlags           +
+    ; +---------------------+
+    ; +    CS               +
+    ; +---------------------+
+    ; +    RIP              +
+    ; +---------------------+
+    ; +    Error Code       +
+    ; +---------------------+
+    ; + RCX / Vector Number +
+    ; +---------------------+
+    ; +    RBP              +
+    ; +---------------------+ <-- RBP, 16-byte aligned
+    ;
+
+    ;
+    ; Since here the stack pointer is 16-byte aligned, so
+    ; EFI_FX_SAVE_STATE_X64 of EFI_SYSTEM_CONTEXT_x64
+    ; is 16-byte aligned
+    ;
+
+;; UINT64  Rdi, Rsi, Rbp, Rsp, Rbx, Rdx, Rcx, Rax;
+;; UINT64  R8, R9, R10, R11, R12, R13, R14, R15;
+    push r15
+    push r14
+    push r13
+    push r12
+    push r11
+    push r10
+    push r9
+    push r8
+    push rax
+    push qword [rbp + 8]   ; RCX
+    push rdx
+    push rbx
+    push qword [rbp + 48]  ; RSP
+    push qword [rbp]       ; RBP
+    push rsi
+    push rdi
+
+;; UINT64  Gs, Fs, Es, Ds, Cs, Ss;  insure high 16 bits of each is zero
+    movzx   rax, word [rbp + 56]
+    push    rax                      ; for ss
+    movzx   rax, word [rbp + 32]
+    push    rax                      ; for cs
+    mov     rax, ds
+    push    rax
+    mov     rax, es
+    push    rax
+    mov     rax, fs
+    push    rax
+    mov     rax, gs
+    push    rax
+
+    mov     [rbp + 8], rcx               ; save vector number
+
+;; UINT64  Rip;
+    push    qword [rbp + 24]
+
+;; UINT64  Gdtr[2], Idtr[2];
+    xor     rax, rax
+    push    rax
+    push    rax
+    sidt    [rsp]
+    mov     bx, word [rsp]
+    mov     rax, qword [rsp + 2]
+    mov     qword [rsp], rax
+    mov     word [rsp + 8], bx
+
+    xor     rax, rax
+    push    rax
+    push    rax
+    sgdt    [rsp]
+    mov     bx, word [rsp]
+    mov     rax, qword [rsp + 2]
+    mov     qword [rsp], rax
+    mov     word [rsp + 8], bx
+
+;; UINT64  Ldtr, Tr;
+    xor     rax, rax
+    str     ax
+    push    rax
+    sldt    ax
+    push    rax
+
+;; UINT64  RFlags;
+    push    qword [rbp + 40]
+
+;; UINT64  Cr0, Cr1, Cr2, Cr3, Cr4, Cr8;
+    mov     rax, cr8
+    push    rax
+    mov     rax, cr4
+    or      rax, 0x208
+    mov     cr4, rax
+    push    rax
+    mov     rax, cr3
+    push    rax
+    mov     rax, cr2
+    push    rax
+    xor     rax, rax
+    push    rax
+    mov     rax, cr0
+    push    rax
+
+;; UINT64  Dr0, Dr1, Dr2, Dr3, Dr6, Dr7;
+    mov     rax, dr7
+    push    rax
+    mov     rax, dr6
+    push    rax
+    mov     rax, dr3
+    push    rax
+    mov     rax, dr2
+    push    rax
+    mov     rax, dr1
+    push    rax
+    mov     rax, dr0
+    push    rax
+
+;; FX_SAVE_STATE_X64 FxSaveState;
+    sub rsp, 512
+    mov rdi, rsp
+    db 0xf, 0xae, 0x7 ;fxsave [rdi]
+
+;; UEFI calling convention for x64 requires that Direction flag in EFLAGs is clear
+    cld
+
+;; UINT32  ExceptionData;
+    push    qword [rbp + 16]
+
+;; Prepare parameter and call
+    mov     rcx, [rbp + 8]
+    mov     rdx, rsp
+    ;
+    ; Per X64 calling convention, allocate maximum parameter stack space
+    ; and make sure RSP is 16-byte aligned
+    ;
+    sub     rsp, 4 * 8 + 8
+    call    ASM_PFX(CommonExceptionHandler)
+    add     rsp, 4 * 8 + 8
+
+    cli
+;; UINT64  ExceptionData;
+    add     rsp, 8
+
+;; FX_SAVE_STATE_X64 FxSaveState;
+
+    mov rsi, rsp
+    db 0xf, 0xae, 0xE ; fxrstor [rsi]
+    add rsp, 512
+
+;; UINT64  Dr0, Dr1, Dr2, Dr3, Dr6, Dr7;
+;; Skip restoration of DRx registers to support in-circuit emualators
+;; or debuggers set breakpoint in interrupt/exception context
+    add     rsp, 8 * 6
+
+;; UINT64  Cr0, Cr1, Cr2, Cr3, Cr4, Cr8;
+    pop     rax
+    mov     cr0, rax
+    add     rsp, 8   ; not for Cr1
+    pop     rax
+    mov     cr2, rax
+    pop     rax
+    mov     cr3, rax
+    pop     rax
+    mov     cr4, rax
+    pop     rax
+    mov     cr8, rax
+
+;; UINT64  RFlags;
+    pop     qword [rbp + 40]
+
+;; UINT64  Ldtr, Tr;
+;; UINT64  Gdtr[2], Idtr[2];
+;; Best not let anyone mess with these particular registers...
+    add     rsp, 48
+
+;; UINT64  Rip;
+    pop     qword [rbp + 24]
+
+;; UINT64  Gs, Fs, Es, Ds, Cs, Ss;
+    pop     rax
+    ; mov     gs, rax ; not for gs
+    pop     rax
+    ; mov     fs, rax ; not for fs
+    ; (X64 will not use fs and gs, so we do not restore it)
+    pop     rax
+    mov     es, rax
+    pop     rax
+    mov     ds, rax
+    pop     qword [rbp + 32]  ; for cs
+    pop     qword [rbp + 56]  ; for ss
+
+;; UINT64  Rdi, Rsi, Rbp, Rsp, Rbx, Rdx, Rcx, Rax;
+;; UINT64  R8, R9, R10, R11, R12, R13, R14, R15;
+    pop     rdi
+    pop     rsi
+    add     rsp, 8               ; not for rbp
+    pop     qword [rbp + 48] ; for rsp
+    pop     rbx
+    pop     rdx
+    pop     rcx
+    pop     rax
+    pop     r8
+    pop     r9
+    pop     r10
+    pop     r11
+    pop     r12
+    pop     r13
+    pop     r14
+    pop     r15
+
+    mov     rsp, rbp
+    pop     rbp
+    add     rsp, 16
+    cmp     qword [rsp - 32], 0  ; check EXCEPTION_HANDLER_CONTEXT.OldIdtHandler
+    jz      DoReturn
+    cmp     qword [rsp - 40], 1  ; check EXCEPTION_HANDLER_CONTEXT.ExceptionDataFlag
+    jz      ErrorCode
+    jmp     qword [rsp - 32]
+ErrorCode:
+    sub     rsp, 8
+    jmp     qword [rsp - 24]
+
+DoReturn:
+    cmp     qword [ASM_PFX(mDoFarReturnFlag)], 0   ; Check if need to do far return instead of IRET
+    jz      DoIret
+    push    rax
+    mov     rax, rsp          ; save old RSP to rax
+    mov     rsp, [rsp + 0x20]
+    push    qword [rax + 0x10]       ; save CS in new location
+    push    qword [rax + 0x8]        ; save EIP in new location
+    push    qword [rax + 0x18]       ; save EFLAGS in new location
+    mov     rax, [rax]        ; restore rax
+    popfq                     ; restore EFLAGS
+    DB      0x48               ; prefix to composite "retq" with next "retf"
+    retf                      ; far return
+DoIret:
+    iretq
+
+;-------------------------------------------------------------------------------------
+;  GetTemplateAddressMap (&AddressMap);
+;-------------------------------------------------------------------------------------
+; comments here for definition of address map
+global ASM_PFX(AsmGetTemplateAddressMap)
+ASM_PFX(AsmGetTemplateAddressMap):
+    lea     rax, [AsmIdtVectorBegin]
+    mov     qword [rcx], rax
+    mov     qword [rcx + 0x8],  (AsmIdtVectorEnd - AsmIdtVectorBegin) / 32
+    lea     rax, [HookAfterStubHeaderBegin]
+    mov     qword [rcx + 0x10], rax
+
+; Fix up CommonInterruptEntry address
+    lea    rax, [ASM_PFX(CommonInterruptEntry)]
+    lea    rcx, [AsmIdtVectorBegin]
+%rep  32
+    mov    qword [rcx + (JmpAbsoluteAddress - 8 - HookAfterStubHeaderBegin)], rax
+    add    rcx, (AsmIdtVectorEnd - AsmIdtVectorBegin) / 32
+%endrep
+; Fix up HookAfterStubHeaderEnd
+    lea    rax, [HookAfterStubHeaderEnd]
+    lea    rcx, [JmpAbsoluteAddress]
+    mov    qword [rcx - 8], rax
+
+    ret
+
+;-------------------------------------------------------------------------------------
+;  AsmVectorNumFixup (*NewVectorAddr, VectorNum, *OldVectorAddr);
+;-------------------------------------------------------------------------------------
+global ASM_PFX(AsmVectorNumFixup)
+ASM_PFX(AsmVectorNumFixup):
+    mov     rax, rdx
+    mov     [rcx + (@VectorNum - HookAfterStubHeaderBegin)], al
+    ret
+

--- a/UefiCpuPkg/Library/CpuExceptionHandlerLib/Xcode5SecPeiCpuExceptionHandlerLib.inf
+++ b/UefiCpuPkg/Library/CpuExceptionHandlerLib/Xcode5SecPeiCpuExceptionHandlerLib.inf
@@ -1,19 +1,24 @@
 ## @file
-#  CPU Exception Handler library instance for PEI module.
+#  CPU Exception Handler library instance for SEC/PEI modules.
 #
-#  Copyright (c) 2016 - 2018, Intel Corporation. All rights reserved.<BR>
+#  Copyright (C) 2020, Advanced Micro Devices, Inc. All rights reserved.<BR>
+#  Copyright (c) 2012 - 2018, Intel Corporation. All rights reserved.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+#  This is the XCODE5 variant of the SEC/PEI CpuExceptionHandlerLib. This
+#  variant performs binary patching to fix up addresses that allow the
+#  XCODE5 toolchain to be used.
 #
 ##
 
 [Defines]
   INF_VERSION                    = 0x00010005
-  BASE_NAME                      = PeiCpuExceptionHandlerLib
-  MODULE_UNI_FILE                = PeiCpuExceptionHandlerLib.uni
-  FILE_GUID                      = 980DDA67-44A6-4897-99E6-275290B71F9E
+  BASE_NAME                      = Xcode5SecPeiCpuExceptionHandlerLib
+  MODULE_UNI_FILE                = Xcode5SecPeiCpuExceptionHandlerLib.uni
+  FILE_GUID                      = 49C481AF-1621-42F3-8FA1-27C64143E304
   MODULE_TYPE                    = PEIM
   VERSION_STRING                 = 1.1
-  LIBRARY_CLASS                  = CpuExceptionHandlerLib|PEI_CORE PEIM
+  LIBRARY_CLASS                  = CpuExceptionHandlerLib|SEC PEI_CORE PEIM
 
 #
 # The following information is for reference only and not required by the build tools.
@@ -35,8 +40,7 @@
 [Sources.common]
   CpuExceptionCommon.h
   CpuExceptionCommon.c
-  PeiCpuException.c
-  PeiDxeSmmCpuException.c
+  SecPeiCpuException.c
 
 [Packages]
   MdePkg/MdePkg.dec
@@ -49,10 +53,3 @@
   PrintLib
   LocalApicLib
   PeCoffGetEntryPointLib
-  HobLib
-  MemoryAllocationLib
-  SynchronizationLib
-
-[Pcd]
-  gEfiMdeModulePkgTokenSpaceGuid.PcdCpuStackGuard    # CONSUMES
-

--- a/UefiCpuPkg/Library/CpuExceptionHandlerLib/Xcode5SecPeiCpuExceptionHandlerLib.uni
+++ b/UefiCpuPkg/Library/CpuExceptionHandlerLib/Xcode5SecPeiCpuExceptionHandlerLib.uni
@@ -1,0 +1,18 @@
+// /** @file
+// XCODE5 CPU Exception Handler library instance for SEC/PEI modules.
+//
+// CPU Exception Handler library instance for SEC/PEI modules when built
+// using the XCODE5 toolchain.
+//
+// Copyright (C) 2020, Advanced Micro Devices, Inc. All rights reserved.<BR>
+// Copyright (c) 2012 - 2014, Intel Corporation. All rights reserved.<BR>
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+// **/
+
+
+#string STR_MODULE_ABSTRACT             #language en-US "CPU Exception Handler library instance for SEC/PEI modules with the XCODE5 toolchain."
+
+#string STR_MODULE_DESCRIPTION          #language en-US "CPU Exception Handler library instance for SEC/PEI modules with the XCODE5 toolchain."
+

--- a/UefiCpuPkg/UefiCpuPkg.dsc
+++ b/UefiCpuPkg/UefiCpuPkg.dsc
@@ -59,7 +59,11 @@
 
 [LibraryClasses.common.SEC]
   PlatformSecLib|UefiCpuPkg/Library/PlatformSecLibNull/PlatformSecLibNull.inf
+!if $(TOOL_CHAIN_TAG) == "XCODE5"
+  CpuExceptionHandlerLib|UefiCpuPkg/Library/CpuExceptionHandlerLib/Xcode5SecPeiCpuExceptionHandlerLib.inf
+!else
   CpuExceptionHandlerLib|UefiCpuPkg/Library/CpuExceptionHandlerLib/SecPeiCpuExceptionHandlerLib.inf
+!endif
   HobLib|MdePkg/Library/PeiHobLib/PeiHobLib.inf
   PeiServicesTablePointerLib|MdePkg/Library/PeiServicesTablePointerLibIdt/PeiServicesTablePointerLibIdt.inf
   MemoryAllocationLib|MdePkg/Library/PeiMemoryAllocationLib/PeiMemoryAllocationLib.inf
@@ -123,9 +127,12 @@
   UefiCpuPkg/Library/BaseXApicX2ApicLib/BaseXApicX2ApicLib.inf
   UefiCpuPkg/Library/CpuCommonFeaturesLib/CpuCommonFeaturesLib.inf
   UefiCpuPkg/Library/CpuExceptionHandlerLib/DxeCpuExceptionHandlerLib.inf
+!if $(TOOL_CHAIN_TAG) != "XCODE5"
   UefiCpuPkg/Library/CpuExceptionHandlerLib/SecPeiCpuExceptionHandlerLib.inf
+!endif
   UefiCpuPkg/Library/CpuExceptionHandlerLib/SmmCpuExceptionHandlerLib.inf
   UefiCpuPkg/Library/CpuExceptionHandlerLib/PeiCpuExceptionHandlerLib.inf
+  UefiCpuPkg/Library/CpuExceptionHandlerLib/Xcode5SecPeiCpuExceptionHandlerLib.inf
   UefiCpuPkg/Library/MpInitLib/PeiMpInitLib.inf
   UefiCpuPkg/Library/MpInitLib/DxeMpInitLib.inf
   UefiCpuPkg/Library/MpInitLibUp/MpInitLibUp.inf


### PR DESCRIPTION
https://bugzilla.tianocore.org/show_bug.cgi?id=2340
http://mid.mail-archive.com/cover.1588856809.git.thomas.lendacky@amd.com
https://edk2.groups.io/g/devel/message/58786
~~~
Commit 2db0ccc2d7fe ("UefiCpuPkg: Update CpuExceptionHandlerLib pass
XCODE5 tool chain") introduced binary patching in the
ExceptionHandlerAsm.nasm in order to support the XCODE5 toolchain.
However, the CpuExceptionHandlerLib can be used during SEC phase which
would result in binary patching of flash.

This series creates a new CpuExceptionHandlerLib file to support
the required binary patching for the XCODE5 toolchain, while reverting
the changes from commit 2db0ccc2d7fe in the standard file. As the Pei,
Dxe and SMM versions of the library operate in memory (as opposed to
flash), only the SEC/PEI version is of the library is updated to use the
version of the ExceptionHandlerAsm.nasm that does not perform binary
patching.

This is accomplished in phases:
  - Create a new XCODE5 specific version of the ExceptionHandlerAsm.nasm
    file and update all CpuExceptionHandler INF files to use it while also
    creating a new SEC/PEI CpuExceptionHandler INF file specifically for
    the XCODE5 toolchain.
  - Update all package DSC files that use the SecPeiCpuExceptionHandlerLib
    version of the library to use the XCODE5 version of the library,
    Xcode5SecPeiCpuExceptionHandlerLib, when the XCODE5 toolchain is used.
  - Revert the changes made by commit 2db0ccc2d7fe in the standard file
    and update the SecPeiCpuExceptionHandlerLib.inf file to use the
    standard file.

I don't have access to an XCODE5 toolchain setup, so I have not tested
this with XCODE5. I would like to request that someone who does please
test this.

---

These patches are based on commit:
faef5a367c83 ("ShellPkg: acpiview: Check if SBBR mandatory ACPI tables are installed")

Cc: Andrew Fish <afish@apple.com>
Cc: Anthony Perard <anthony.perard@citrix.com>
Cc: Ard Biesheuvel <ard.biesheuvel@linaro.org>
Cc: Brijesh Singh <brijesh.singh@amd.com>
Cc: Eric Dong <eric.dong@intel.com>
Cc: Jordan Justen <jordan.l.justen@intel.com>
Cc: Julien Grall <julien@xen.org>
Cc: Laszlo Ersek <lersek@redhat.com>
Cc: Liming Gao <liming.gao@intel.com>
Cc: Ray Ni <ray.ni@intel.com>

Changes since v2:
- Updated [Components] section of UefiCpuPkg.dsc to conditionally exclude
  SecPeiCpuExceptionHandlerLib.inf for the XCODE5 toolchain.
- Added some missed Reviewed-by: and Acked-by: tags from previous
  versions.

Changes since v1:
- Only apply the revert to the Sec/Pei CpuExceptionHandler library and
  leave the Pei, Dxe and Smm versions using the binary patching version.
- Generate a unique file GUID for the new library INF file and create
  a corresponding UNI file.
- Remove any references to SEV-ES (original patches accidentally submitted
  from wrong tree).

Tom Lendacky (3):
  UefiCpuPkg/CpuExceptionHandler: Make XCODE5 changes toolchain specific
  OvmfPkg: Use toolchain appropriate CpuExceptionHandlerLib
  UefiCpuPkg/CpuExceptionHandler: Revert CpuExceptionHandler binary
    patching

 OvmfPkg/OvmfPkgIa32.dsc                       |  4 +++
 OvmfPkg/OvmfPkgIa32X64.dsc                    |  4 +++
 OvmfPkg/OvmfPkgX64.dsc                        |  4 +++
 OvmfPkg/OvmfXen.dsc                           |  4 +++
 UefiCpuPkg/UefiCpuPkg.dsc                     |  7 ++++++
 .../DxeCpuExceptionHandlerLib.inf             |  2 +-
 .../PeiCpuExceptionHandlerLib.inf             |  2 +-
 .../SmmCpuExceptionHandlerLib.inf             |  2 +-
 ...=> Xcode5SecPeiCpuExceptionHandlerLib.inf} | 13 +++++++---
 .../X64/ExceptionHandlerAsm.nasm              | 25 +++++--------------
 ...sm.nasm => Xcode5ExceptionHandlerAsm.nasm} |  0
 .../Xcode5SecPeiCpuExceptionHandlerLib.uni    | 18 +++++++++++++
 12 files changed, 59 insertions(+), 26 deletions(-)
 copy UefiCpuPkg/Library/CpuExceptionHandlerLib/{SecPeiCpuExceptionHandlerLib.inf => Xcode5SecPeiCpuExceptionHandlerLib.inf} (64%)
 copy UefiCpuPkg/Library/CpuExceptionHandlerLib/X64/{ExceptionHandlerAsm.nasm => Xcode5ExceptionHandlerAsm.nasm} (100%)
 create mode 100644 UefiCpuPkg/Library/CpuExceptionHandlerLib/Xcode5SecPeiCpuExceptionHandlerLib.uni
~~~
