### PR TITLE
BaseTools/Ecc: Replace deprecated function time.clock()

### DIFF
--- a/BaseTools/Source/Python/Ecc/EccMain.py
+++ b/BaseTools/Source/Python/Ecc/EccMain.py
@@ -2,6 +2,7 @@
 # This file is used to be the main entrance of ECC tool
 #
 # Copyright (c) 2009 - 2018, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) Microsoft Corporation.<BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 
@@ -406,9 +407,9 @@ if __name__ == '__main__':
     EdkLogger.Initialize()
     EdkLogger.IsRaiseError = False
 
-    StartTime = time.clock()
+    StartTime = time.perf_counter()
     Ecc = Ecc()
-    FinishTime = time.clock()
+    FinishTime = time.perf_counter()
 
     BuildDuration = time.strftime("%M:%S", time.gmtime(int(round(FinishTime - StartTime))))
     EdkLogger.quiet("\n%s [%s]" % (time.strftime("%H:%M:%S, %b.%d %Y", time.localtime()), BuildDuration))


### PR DESCRIPTION
REF:https://bugzilla.tianocore.org/show_bug.cgi?id=2707

Ecc fails with Python 3.8 because it uses the deprecated time.clock()
function - https://docs.python.org/3.7/library/time.html#time.clock

This change updates EccMain.py to use time.perf_counter().

Cc: Bob Feng <bob.c.feng@intel.com>
Cc: Liming Gao <liming.gao@intel.com>
Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>
Reviewed-by: Bob Feng <bob.c.feng@intel.com>