### PR TITLE
NetworkPkg/DxeNetLib: Change the order of conditions in IF statement

### DIFF
--- a/NetworkPkg/Library/DxeNetLib/NetBuffer.c
+++ b/NetworkPkg/Library/DxeNetLib/NetBuffer.c
@@ -1063,7 +1063,7 @@ NetbufAllocSpace (
     } else {
       NetbufGetByte (Nbuf, 0, &Index);
 
-      if ((NET_HEADSPACE(&(Nbuf->BlockOp[Index])) < Len) && (Index > 0)) {
+      if ((Index > 0) && (NET_HEADSPACE(&(Nbuf->BlockOp[Index])) < Len)) {
         Index--;
       }
     }


### PR DESCRIPTION
The condition, NET_HEADSPACE(&(Nbuf->BlockOp[Index])) < Len, is
meaningless if Index = 0. So checking 'Index ！= 0' should be
performed first in the if statement.

Cc: Maciej Rabeda <maciej.rabeda@linux.intel.com>
Cc: Siyuan Fu <siyuan.fu@intel.com>
Cc: Jiaxin Wu <jiaxin.wu@intel.com>
Signed-off-by: Shenglei Zhang <shenglei.zhang@intel.com>