### PR TITLE
IntelFsp2Pkg: Support Multi-Phase SiInit and debug handlers.

### DIFF
--- a/IntelFsp2Pkg/FspSecCore/Fsp22SecCoreS.inf
+++ b/IntelFsp2Pkg/FspSecCore/Fsp22SecCoreS.inf
@@ -1,0 +1,52 @@
+## @file
+#  Sec Core for FSP to support MultiPhase (SeparatePhase) SiInitialization.
+#
+#  Copyright (c) 2020, Intel Corporation. All rights reserved.<BR>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = Fsp22SecCoreS
+  FILE_GUID                      = DF0FCD70-264A-40BF-BBD4-06C76DB19CB1
+  MODULE_TYPE                    = SEC
+  VERSION_STRING                 = 1.0
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32
+#
+
+[Sources]
+  SecFspApiChk.c
+  SecFsp.h
+
+[Sources.IA32]
+  Ia32/Stack.nasm
+  Ia32/Fsp22ApiEntryS.nasm
+  Ia32/FspApiEntryCommon.nasm
+  Ia32/FspHelper.nasm
+
+[Binaries.Ia32]
+  RAW|Vtf0/Bin/ResetVec.ia32.raw |GCC
+
+[Packages]
+  MdePkg/MdePkg.dec
+  IntelFsp2Pkg/IntelFsp2Pkg.dec
+
+[LibraryClasses]
+  BaseMemoryLib
+  DebugLib
+  BaseLib
+  PciCf8Lib
+  SerialPortLib
+  FspSwitchStackLib
+  FspCommonLib
+  FspSecPlatformLib
+
+[Ppis]
+  gEfiTemporaryRamSupportPpiGuid                              ## PRODUCES
+

--- a/IntelFsp2Pkg/FspSecCore/Ia32/Fsp22ApiEntryS.nasm
+++ b/IntelFsp2Pkg/FspSecCore/Ia32/Fsp22ApiEntryS.nasm
@@ -1,0 +1,99 @@
+;; @file
+;  Provide FSP API entry points.
+;
+; Copyright (c) 2020, Intel Corporation. All rights reserved.<BR>
+; SPDX-License-Identifier: BSD-2-Clause-Patent
+;;
+
+    SECTION .text
+
+;
+; Following functions will be provided in C
+;
+extern ASM_PFX(FspApiCommon)
+extern ASM_PFX(FspMultiPhaseSiInitApiHandler)
+
+;----------------------------------------------------------------------------
+; NotifyPhase API
+;
+; This FSP API will notify the FSP about the different phases in the boot
+; process
+;
+;----------------------------------------------------------------------------
+global ASM_PFX(NotifyPhaseApi)
+ASM_PFX(NotifyPhaseApi):
+  mov    eax,  2 ; FSP_API_INDEX.NotifyPhaseApiIndex
+  jmp    ASM_PFX(FspApiCommon)
+
+;----------------------------------------------------------------------------
+; FspSiliconInit API
+;
+; This FSP API initializes the CPU and the chipset including the IO
+; controllers in the chipset to enable normal operation of these devices.
+;
+;----------------------------------------------------------------------------
+global ASM_PFX(FspSiliconInitApi)
+ASM_PFX(FspSiliconInitApi):
+  mov    eax,  5 ; FSP_API_INDEX.FspSiliconInitApiIndex
+  jmp    ASM_PFX(FspApiCommon)
+
+;----------------------------------------------------------------------------
+; FspMultiPhaseSiInitApi API
+;
+; This FSP API provides multi-phase silicon initialization, which brings greater
+; modularity beyond the existing FspSiliconInit() API.
+; Increased modularity is achieved by adding an extra API to FSP-S.
+; This allows the bootloader to add board specific initialization steps throughout
+; the SiliconInit flow as needed.
+;
+;----------------------------------------------------------------------------
+global ASM_PFX(FspMultiPhaseSiInitApi)
+ASM_PFX(FspMultiPhaseSiInitApi):
+  mov    eax,  6 ; FSP_API_INDEX.FspMultiPhaseSiInitApiIndex
+  jmp    ASM_PFX(FspApiCommon)
+
+;----------------------------------------------------------------------------
+; FspApiCommonContinue API
+;
+; This is the FSP API common entry point to resume the FSP execution
+;
+;----------------------------------------------------------------------------
+global ASM_PFX(FspApiCommonContinue)
+ASM_PFX(FspApiCommonContinue):
+  ;
+  ; Handle FspMultiPhaseSiInitApiIndex API
+  ;
+  cmp    eax, 6
+  jnz    NotMultiPhaseSiInitApi
+
+  pushad
+  push   DWORD [esp + (4 * 8 + 4)]  ; push ApiParam
+  push   eax                ; push ApiIdx
+  call   ASM_PFX(FspMultiPhaseSiInitApiHandler)
+  add    esp, 8
+  mov    dword  [esp + (4 * 7)], eax
+  popad
+  ret
+
+NotMultiPhaseSiInitApi:
+  jmp $
+  ret
+
+;----------------------------------------------------------------------------
+; TempRamInit API
+;
+; Empty function for WHOLEARCHIVE build option
+;
+;----------------------------------------------------------------------------
+global ASM_PFX(TempRamInitApi)
+ASM_PFX(TempRamInitApi):
+  jmp $
+  ret
+
+;----------------------------------------------------------------------------
+; Module Entrypoint API
+;----------------------------------------------------------------------------
+global ASM_PFX(_ModuleEntryPoint)
+ASM_PFX(_ModuleEntryPoint):
+  jmp $
+

--- a/IntelFsp2Pkg/FspSecCore/Ia32/FspApiEntryCommon.nasm
+++ b/IntelFsp2Pkg/FspSecCore/Ia32/FspApiEntryCommon.nasm
@@ -1,7 +1,7 @@
 ;; @file
 ;  Provide FSP API entry points.
 ;
-; Copyright (c) 2016, Intel Corporation. All rights reserved.<BR>
+; Copyright (c) 2016 - 2020, Intel Corporation. All rights reserved.<BR>
 ; SPDX-License-Identifier: BSD-2-Clause-Patent
 ;;
 
@@ -60,6 +60,9 @@ exit:
 FspApiCommon2:
   popad
   cmp    eax, 3   ; FspMemoryInit API
+  jz     FspApiCommon3
+
+  cmp    eax, 6   ; FspMultiPhaseSiInitApiIndex API
   jz     FspApiCommon3
 
   call   ASM_PFX(AsmGetFspInfoHeader)

--- a/IntelFsp2Pkg/FspSecCore/SecFsp.c
+++ b/IntelFsp2Pkg/FspSecCore/SecFsp.c
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2014 - 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2014 - 2020, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -159,6 +159,16 @@ FspGlobalDataInit (
   SetFspUpdDataPointer (FspmUpdDataPtr);
   SetFspMemoryInitUpdDataPointer (FspmUpdDataPtr);
   SetFspSiliconInitUpdDataPointer (NULL);
+
+  //
+  // Initialize OnSeparateStack value.
+  //
+  if (PcdGet8 (PcdFspHeapSizePercentage) != 0) {
+    //
+    // FSP is running on its own stack and may need switching stack when calling bootloader functions.
+    //
+    GetFspGlobalDataPointer ()->OnSeparateStack = 1;
+  }
 
   //
   // Initialize serial port

--- a/IntelFsp2Pkg/FspSecCore/SecFspApiChk.c
+++ b/IntelFsp2Pkg/FspSecCore/SecFspApiChk.c
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2016 - 2018, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2016 - 2020, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -59,7 +59,7 @@ FspApiCallingCheck (
         Status = EFI_UNSUPPORTED;
       }
     }
-  } else if (ApiIdx == FspSiliconInitApiIndex) {
+  } else if ((ApiIdx == FspSiliconInitApiIndex) || (ApiIdx == FspMultiPhaseSiInitApiIndex)) {
     //
     // FspSiliconInit check
     //
@@ -68,7 +68,7 @@ FspApiCallingCheck (
     } else {
       if (FspData->Signature != FSP_GLOBAL_DATA_SIGNATURE) {
         Status = EFI_UNSUPPORTED;
-      } else if (EFI_ERROR (FspUpdSignatureCheck (ApiIdx, ApiParam))) {
+      } else if (EFI_ERROR (FspUpdSignatureCheck (FspSiliconInitApiIndex, ApiParam))) {
         Status = EFI_INVALID_PARAMETER;
       }
     }

--- a/IntelFsp2Pkg/FspSecCore/SecMain.c
+++ b/IntelFsp2Pkg/FspSecCore/SecMain.c
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2014 - 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2014 - 2020, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -220,6 +220,12 @@ SecTemporaryRamSupport (
 
   UINTN             CurrentStack;
   UINTN             FspStackBase;
+
+  //
+  // Override OnSeparateStack to 1 because this function will switch stack to permanent memory
+  // which makes FSP running on different stack from bootloader temporary ram stack.
+  //
+  GetFspGlobalDataPointer ()->OnSeparateStack = 1;
 
   if (PcdGet8 (PcdFspHeapSizePercentage) == 0) {
 

--- a/IntelFsp2Pkg/Include/FspGlobalData.h
+++ b/IntelFsp2Pkg/Include/FspGlobalData.h
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2014 - 2018, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2014 - 2020, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -22,6 +22,7 @@ typedef enum {
   FspMemoryInitApiIndex,
   TempRamExitApiIndex,
   FspSiliconInitApiIndex,
+  FspMultiPhaseSiInitApiIndex,
   FspApiIndexMax
 } FSP_API_INDEX;
 
@@ -52,10 +53,14 @@ typedef struct  {
    VOID               *SiliconInitUpdPtr;
    UINT8              ApiIdx;
    UINT8              FspMode; // 0: FSP in API mode; 1: FSP in DISPATCH mode
-   UINT8              Reserved3[30];
+   UINT8              OnSeparateStack;
+   UINT8              Reserved3;
+   UINT32             NumberOfPhases;
+   UINT32             PhasesExecuted;
+   UINT8              Reserved4[20];
    UINT32             PerfSig;
    UINT16             PerfLen;
-   UINT16             Reserved4;
+   UINT16             Reserved5;
    UINT32             PerfIdx;
    UINT64             PerfData[32];
 } FSP_GLOBAL_DATA;

--- a/IntelFsp2Pkg/Include/Guid/FspHeaderFile.h
+++ b/IntelFsp2Pkg/Include/Guid/FspHeaderFile.h
@@ -1,8 +1,8 @@
 /** @file
   Intel FSP Header File definition from Intel Firmware Support Package External
-  Architecture Specification v2.0.
+  Architecture Specification v2.0 and above.
 
-  Copyright (c) 2014 - 2018, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2014 - 2020, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -110,6 +110,12 @@ typedef struct {
   /// Byte 0x44: The offset for the API to initialize the CPU and chipset.
   ///
   UINT32  FspSiliconInitEntryOffset;
+  ///
+  /// Byte 0x48: Offset for the API for the optional Multi-Phase processor and chipset initialization.
+  ///            This value is only valid if FSP HeaderRevision is >= 5.
+  ///            If the value is set to 0x00000000, then this API is not available in this component.
+  ///
+  UINT32  FspMultiPhaseSiInitEntryOffset;
 } FSP_INFO_HEADER;
 
 ///

--- a/IntelFsp2Pkg/Include/Library/FspSecPlatformLib.h
+++ b/IntelFsp2Pkg/Include/Library/FspSecPlatformLib.h
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2015 - 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2015 - 2020, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -75,6 +75,20 @@ SecCarInit (
 EFI_STATUS
 EFIAPI
 FspUpdSignatureCheck (
+  IN UINT32   ApiIdx,
+  IN VOID     *ApiParam
+  );
+
+/**
+  This function handles FspMultiPhaseSiInitApi.
+
+  @param[in]  ApiIdx           Internal index of the FSP API.
+  @param[in]  ApiParam         Parameter of the FSP API.
+
+**/
+EFI_STATUS
+EFIAPI
+FspMultiPhaseSiInitApiHandler (
   IN UINT32   ApiIdx,
   IN VOID     *ApiParam
   );

--- a/IntelFsp2Pkg/Library/SecFspSecPlatformLibNull/PlatformSecLibNull.c
+++ b/IntelFsp2Pkg/Library/SecFspSecPlatformLibNull/PlatformSecLibNull.c
@@ -1,7 +1,7 @@
 /** @file
   Null instance of Platform Sec Lib.
 
-  Copyright (c) 2014 - 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2014 - 2020, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -19,6 +19,23 @@
 EFI_STATUS
 EFIAPI
 FspUpdSignatureCheck (
+  IN UINT32   ApiIdx,
+  IN VOID     *ApiParam
+  )
+{
+  return EFI_SUCCESS;
+}
+
+/**
+  This function handles FspMultiPhaseSiInitApi.
+
+  @param[in]  ApiIdx           Internal index of the FSP API.
+  @param[in]  ApiParam         Parameter of the FSP API.
+
+**/
+EFI_STATUS
+EFIAPI
+FspMultiPhaseSiInitApiHandler (
   IN UINT32   ApiIdx,
   IN VOID     *ApiParam
   )


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=2698

To enhance FSP silicon initialization flexibility an optional
Multi-Phase API is introduced and FSP header needs update for
new API offset. Also new SecCore module created for
FspMultiPhaseSiInit API

New ARCH_UPD introduced for enhancing FSP debug message
flexibility now bootloader can pass its own debug handler
function pointer and FSP will call the function to handle
debug message.
To support calling bootloader functions, a FspGlobalData field
added to indicate if FSP needs to switch stack when FSP running
on separate stack from bootloader.

Cc: Maurice Ma <maurice.ma@intel.com>
Cc: Nate DeSimone <nathaniel.l.desimone@intel.com>
Cc: Star Zeng <star.zeng@intel.com>
Signed-off-by: Chasel Chiu <chasel.chiu@intel.com>
Reviewed-by: Nate DeSimone <nathaniel.l.desimone@intel.com>