### PR TITLE
UefiCpuPkg/MpService: GetProcessorInfo returns 6-level topology

### DIFF
--- a/UefiCpuPkg/Library/MpInitLib/MpLib.c
+++ b/UefiCpuPkg/Library/MpInitLib/MpLib.c
@@ -1879,9 +1879,16 @@ MpInitLibGetProcessorInfo (
   CPU_MP_DATA            *CpuMpData;
   UINTN                  CallerNumber;
   CPU_INFO_IN_HOB        *CpuInfoInHob;
+  UINTN                  OriginalProcessorNumber;
 
   CpuMpData = GetCpuMpData ();
   CpuInfoInHob = (CPU_INFO_IN_HOB *) (UINTN) CpuMpData->CpuInfoInHob;
+
+  //
+  // Lower 24 bits contains the actual processor number.
+  //
+  OriginalProcessorNumber = ProcessorNumber;
+  ProcessorNumber &= BIT24 - 1;
 
   //
   // Check whether caller processor is BSP
@@ -1922,6 +1929,18 @@ MpInitLibGetProcessorInfo (
     &ProcessorInfoBuffer->Location.Core,
     &ProcessorInfoBuffer->Location.Thread
     );
+
+  if ((OriginalProcessorNumber & CPU_V2_EXTENDED_TOPOLOGY) != 0) {
+    GetProcessorLocation2ByApicId (
+      CpuInfoInHob[ProcessorNumber].ApicId,
+      &ProcessorInfoBuffer->ExtendedInformation.Location2.Package,
+      &ProcessorInfoBuffer->ExtendedInformation.Location2.Die,
+      &ProcessorInfoBuffer->ExtendedInformation.Location2.Tile,
+      &ProcessorInfoBuffer->ExtendedInformation.Location2.Module,
+      &ProcessorInfoBuffer->ExtendedInformation.Location2.Core,
+      &ProcessorInfoBuffer->ExtendedInformation.Location2.Thread
+      );
+  }
 
   if (HealthData != NULL) {
     HealthData->Uint32 = CpuInfoInHob[ProcessorNumber].Health;


### PR DESCRIPTION
Intel SDM introduces 6-levels for describing the CPU topology:
* Package
* Module
* Tile
* Die
* Core
* Thread

A PI spec ECR was submitted to enhance CPU_MP PPI/Protocol to
support returning such information through GetProcessorInfo().
An accordingly change was implemented and pushed to edk2-staging.

Now the PI spec has been published.
The patch is cherry-picked from edk2-staging to edk2.

Signed-off-by: Ray Ni <ray.ni@intel.com>
Reviewed-by: Eric Dong <eric.dong@intel.com>