### PR TITLE
IntelFsp2Pkg: Add FunctionParametePtr to FspGlobalData.

### DIFF
--- a/IntelFsp2Pkg/Include/FspGlobalData.h
+++ b/IntelFsp2Pkg/Include/FspGlobalData.h
@@ -52,12 +52,20 @@ typedef struct  {
    VOID               *MemoryInitUpdPtr;
    VOID               *SiliconInitUpdPtr;
    UINT8              ApiIdx;
-   UINT8              FspMode; // 0: FSP in API mode; 1: FSP in DISPATCH mode
+   ///
+   /// 0: FSP in API mode; 1: FSP in DISPATCH mode
+   ///
+   UINT8              FspMode;
    UINT8              OnSeparateStack;
    UINT8              Reserved3;
    UINT32             NumberOfPhases;
    UINT32             PhasesExecuted;
-   UINT8              Reserved4[20];
+   ///
+   /// To store function parameters pointer
+   /// so it can be retrieved after stack switched.
+   ///
+   VOID               *FunctionParameterPtr;
+   UINT8              Reserved4[16];
    UINT32             PerfSig;
    UINT16             PerfLen;
    UINT16             Reserved5;

--- a/IntelFsp2Pkg/Include/Library/FspSwitchStackLib.h
+++ b/IntelFsp2Pkg/Include/Library/FspSwitchStackLib.h
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2014, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2014 - 2020, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -33,6 +33,22 @@
 UINT32
 EFIAPI
 Pei2LoaderSwitchStack (
+  VOID
+  );
+
+/**
+
+  This function is equivalent to Pei2LoaderSwitchStack () but just indicates
+  the stack after switched is FSP stack.
+
+  @return ReturnKey          After switching to the saved stack,
+                             this value will be saved in eax before returning.
+
+
+**/
+UINT32
+EFIAPI
+Loader2PeiSwitchStack (
   VOID
   );
 


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=2726

When FSP switching stack and calling bootloader functions,
the function parameter in stack may not be accessible easily.
We can store the function parameter pointer to FspGlobalData
and retrieve it after stack switched.

Also need to add Loader2PeiSwitchStack () to header file
as public function for platform FSP code to consume.

Cc: Maurice Ma <maurice.ma@intel.com>
Cc: Nate DeSimone <nathaniel.l.desimone@intel.com>
Cc: Star Zeng <star.zeng@intel.com>
Signed-off-by: Chasel Chiu <chasel.chiu@intel.com>
Reviewed-by: Nate DeSimone <nathaniel.l.desimone@intel.com>