### PR TITLE
[edk2-devel] [PATCH 0/3] OvmfPkg/Tcg2ConfigPei: fix ARM/AARCH64 build failure -- push

### DIFF
--- a/OvmfPkg/Tcg/Tcg2Config/Tcg2ConfigPei.inf
+++ b/OvmfPkg/Tcg/Tcg2Config/Tcg2ConfigPei.inf
@@ -30,9 +30,9 @@
 
 [LibraryClasses]
   PeimEntryPoint
+  BaseLib
   DebugLib
   PeiServicesLib
-  Tpm12CommandLib
   Tpm12DeviceLib
   Tpm2DeviceLib
 

--- a/OvmfPkg/Tcg/Tcg2Config/Tcg2ConfigPei.inf
+++ b/OvmfPkg/Tcg/Tcg2Config/Tcg2ConfigPei.inf
@@ -21,8 +21,13 @@
 
 [Sources]
   Tcg2ConfigPeim.c
-  Tpm12Support.c
   Tpm12Support.h
+
+[Sources.IA32, Sources.X64]
+  Tpm12Support.c
+
+[Sources.ARM, Sources.AARCH64]
+  Tpm12SupportNull.c
 
 [Packages]
   MdePkg/MdePkg.dec
@@ -35,8 +40,10 @@
   BaseLib
   DebugLib
   PeiServicesLib
-  Tpm12DeviceLib
   Tpm2DeviceLib
+
+[LibraryClasses.IA32, LibraryClasses.X64]
+  Tpm12DeviceLib
 
 [Guids]
   gEfiTpmDeviceSelectedGuid           ## PRODUCES ## GUID # Used as a PPI GUID

--- a/OvmfPkg/Tcg/Tcg2Config/Tcg2ConfigPei.inf
+++ b/OvmfPkg/Tcg/Tcg2Config/Tcg2ConfigPei.inf
@@ -21,6 +21,8 @@
 
 [Sources]
   Tcg2ConfigPeim.c
+  Tpm12Support.c
+  Tpm12Support.h
 
 [Packages]
   MdePkg/MdePkg.dec

--- a/OvmfPkg/Tcg/Tcg2Config/Tcg2ConfigPeim.c
+++ b/OvmfPkg/Tcg/Tcg2Config/Tcg2ConfigPeim.c
@@ -15,11 +15,11 @@
 #include <PiPei.h>
 
 #include <Guid/TpmInstance.h>
+#include <Library/BaseLib.h>
 #include <Library/DebugLib.h>
 #include <Library/PeiServicesLib.h>
 #include <Library/Tpm2DeviceLib.h>
 #include <Library/Tpm12DeviceLib.h>
-#include <Library/Tpm12CommandLib.h>
 #include <Ppi/TpmInitialized.h>
 
 STATIC CONST EFI_PEI_PPI_DESCRIPTOR mTpmSelectedPpi = {

--- a/OvmfPkg/Tcg/Tcg2Config/Tcg2ConfigPeim.c
+++ b/OvmfPkg/Tcg/Tcg2Config/Tcg2ConfigPeim.c
@@ -15,12 +15,12 @@
 #include <PiPei.h>
 
 #include <Guid/TpmInstance.h>
-#include <Library/BaseLib.h>
 #include <Library/DebugLib.h>
 #include <Library/PeiServicesLib.h>
 #include <Library/Tpm2DeviceLib.h>
-#include <Library/Tpm12DeviceLib.h>
 #include <Ppi/TpmInitialized.h>
+
+#include "Tpm12Support.h"
 
 STATIC CONST EFI_PEI_PPI_DESCRIPTOR mTpmSelectedPpi = {
   (EFI_PEI_PPI_DESCRIPTOR_PPI | EFI_PEI_PPI_DESCRIPTOR_TERMINATE_LIST),
@@ -33,44 +33,6 @@ STATIC CONST EFI_PEI_PPI_DESCRIPTOR  mTpmInitializationDonePpiList = {
   &gPeiTpmInitializationDonePpiGuid,
   NULL
 };
-
-#pragma pack (1)
-
-typedef struct {
-  TPM_RSP_COMMAND_HDR   Hdr;
-  TPM_CURRENT_TICKS     CurrentTicks;
-} TPM_RSP_GET_TICKS;
-
-#pragma pack ()
-
-/**
-  Probe for the TPM for 1.2 version, by sending TPM1.2 GetTicks
-
-  Sending a TPM1.2 command to a TPM2 should return a TPM1.2
-  header (tag = 0xc4) and error code (TPM_BADTAG = 0x1e)
-**/
-static
-EFI_STATUS
-TestTpm12 (
-  )
-{
-  EFI_STATUS           Status;
-  TPM_RQU_COMMAND_HDR  Command;
-  TPM_RSP_GET_TICKS    Response;
-  UINT32               Length;
-
-  Command.tag       = SwapBytes16 (TPM_TAG_RQU_COMMAND);
-  Command.paramSize = SwapBytes32 (sizeof (Command));
-  Command.ordinal   = SwapBytes32 (TPM_ORD_GetTicks);
-
-  Length = sizeof (Response);
-  Status = Tpm12SubmitCommand (sizeof (Command), (UINT8 *)&Command, &Length, (UINT8 *)&Response);
-  if (EFI_ERROR (Status)) {
-    return Status;
-  }
-
-  return EFI_SUCCESS;
-}
 
 /**
   The entry point for Tcg2 configuration driver.
@@ -90,8 +52,8 @@ Tcg2ConfigPeimEntryPoint (
 
   DEBUG ((DEBUG_INFO, "%a\n", __FUNCTION__));
 
-  Status = Tpm12RequestUseTpm ();
-  if (!EFI_ERROR (Status) && !EFI_ERROR (TestTpm12 ())) {
+  Status = InternalTpm12Detect ();
+  if (!EFI_ERROR (Status)) {
     DEBUG ((DEBUG_INFO, "%a: TPM1.2 detected\n", __FUNCTION__));
     Size = sizeof (gEfiTpmDeviceInstanceTpm12Guid);
     Status = PcdSetPtrS (

--- a/OvmfPkg/Tcg/Tcg2Config/Tpm12Support.c
+++ b/OvmfPkg/Tcg/Tcg2Config/Tpm12Support.c
@@ -1,0 +1,79 @@
+/** @file
+  Implement the InternalTpm12Detect() function on top of the Tpm12DeviceLib
+  class.
+
+  Copyright (C) 2020, Red Hat, Inc.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <Library/BaseLib.h>
+#include <Library/Tpm12DeviceLib.h>
+
+#include "Tpm12Support.h"
+
+#pragma pack (1)
+typedef struct {
+  TPM_RSP_COMMAND_HDR   Hdr;
+  TPM_CURRENT_TICKS     CurrentTicks;
+} TPM_RSP_GET_TICKS;
+#pragma pack ()
+
+/**
+  Probe for the TPM for 1.2 version, by sending TPM1.2 GetTicks
+
+  Sending a TPM1.2 command to a TPM2 should return a TPM1.2
+  header (tag = 0xc4) and error code (TPM_BADTAG = 0x1e)
+
+  @retval EFI_SUCCESS  TPM version 1.2 probing successful.
+
+  @return              Error codes propagated from Tpm12SubmitCommand().
+**/
+STATIC
+EFI_STATUS
+TestTpm12 (
+  )
+{
+  EFI_STATUS           Status;
+  TPM_RQU_COMMAND_HDR  Command;
+  TPM_RSP_GET_TICKS    Response;
+  UINT32               Length;
+
+  Command.tag       = SwapBytes16 (TPM_TAG_RQU_COMMAND);
+  Command.paramSize = SwapBytes32 (sizeof (Command));
+  Command.ordinal   = SwapBytes32 (TPM_ORD_GetTicks);
+
+  Length = sizeof (Response);
+  Status = Tpm12SubmitCommand (sizeof (Command), (UINT8 *)&Command, &Length,
+             (UINT8 *)&Response);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Detect the presence of a TPM with interface version 1.2.
+
+  @retval EFI_SUCCESS      TPM-1.2 available. The Tpm12RequestUseTpm() and
+                           Tpm12SubmitCommand(TPM_ORD_GetTicks) operations
+                           (from the Tpm12DeviceLib class) have succeeded.
+
+  @return                  Error codes propagated from Tpm12RequestUseTpm() and
+                           Tpm12SubmitCommand().
+**/
+EFI_STATUS
+InternalTpm12Detect (
+  VOID
+  )
+{
+  EFI_STATUS Status;
+
+  Status = Tpm12RequestUseTpm ();
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  return TestTpm12 ();
+}

--- a/OvmfPkg/Tcg/Tcg2Config/Tpm12Support.h
+++ b/OvmfPkg/Tcg/Tcg2Config/Tpm12Support.h
@@ -1,0 +1,30 @@
+/** @file
+  Declare the InternalTpm12Detect() function, hiding the TPM-1.2 detection
+  internals.
+
+  Copyright (C) 2020, Red Hat, Inc.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef TPM12_SUPPORT_H_
+#define TPM12_SUPPORT_H_
+
+#include <Uefi/UefiBaseType.h>
+
+/**
+  Detect the presence of a TPM with interface version 1.2.
+
+  @retval EFI_SUCCESS      TPM-1.2 available. The Tpm12RequestUseTpm() and
+                           Tpm12SubmitCommand(TPM_ORD_GetTicks) operations
+                           (from the Tpm12DeviceLib class) have succeeded.
+
+  @return                  Error codes propagated from Tpm12RequestUseTpm() and
+                           Tpm12SubmitCommand().
+**/
+EFI_STATUS
+InternalTpm12Detect (
+  VOID
+  );
+
+#endif // TPM12_SUPPORT_H_

--- a/OvmfPkg/Tcg/Tcg2Config/Tpm12Support.h
+++ b/OvmfPkg/Tcg/Tcg2Config/Tpm12Support.h
@@ -15,6 +15,10 @@
 /**
   Detect the presence of a TPM with interface version 1.2.
 
+  @retval EFI_UNSUPPORTED  The platform that includes this particular
+                           implementation of the function does not support
+                           TPM-1.2.
+
   @retval EFI_SUCCESS      TPM-1.2 available. The Tpm12RequestUseTpm() and
                            Tpm12SubmitCommand(TPM_ORD_GetTicks) operations
                            (from the Tpm12DeviceLib class) have succeeded.

--- a/OvmfPkg/Tcg/Tcg2Config/Tpm12SupportNull.c
+++ b/OvmfPkg/Tcg/Tcg2Config/Tpm12SupportNull.c
@@ -1,0 +1,25 @@
+/** @file
+  Null implementation of InternalTpm12Detect(), always returning
+  EFI_UNSUPPORTED.
+
+  Copyright (C) 2020, Red Hat, Inc.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include "Tpm12Support.h"
+
+/**
+  Detect the presence of a TPM with interface version 1.2.
+
+  @retval EFI_UNSUPPORTED  The platform that includes this particular
+                           implementation of the function does not support
+                           TPM-1.2.
+**/
+EFI_STATUS
+InternalTpm12Detect (
+  VOID
+  )
+{
+  return EFI_UNSUPPORTED;
+}


### PR DESCRIPTION
https://bugzilla.tianocore.org/show_bug.cgi?id=2728
http://mid.mail-archive.com/20200520225841.17793-1-lersek@redhat.com
https://edk2.groups.io/g/devel/message/60005
~~~
Ref:    https://bugzilla.tianocore.org/show_bug.cgi?id=2728
Repo:   https://pagure.io/lersek/edk2.git
Branch: restrict_tpm12_to_x86_bz_2728

Another regression fix for edk2-stable202005.

End of February 2020, Ard and Marc-André worked on two TPM-related
features in parallel. Respectively:

- [edk2-devel] [PATCH v4 00/11]
  ArmVirtPkg: implement measured boot for ArmVirtQemu

  http://mid.mail-archive.com/20200227144056.56988-1-ard.biesheuvel@linaro.org
  https://edk2.groups.io/g/devel/message/55004

- [edk2-devel] [PATCH v4 0/5]
  Ovmf: enable TPM 1.2

  http://mid.mail-archive.com/20200226152433.1295789-1-marcandre.lureau@redhat.com
  https://edk2.groups.io/g/devel/message/54894

Both series were merged tightly one after the other. There was no merge
conflict, and standing alone (without rebasing one on the other), each
series was self-contained and correct. Their combination however led to
an ArmVirtQemu build regression. There never was an intent to support
TPM-1.2 in ArmVirtQemu, but the TPM-1.2 series for OVMF kind of made
that "mandatory".

Worse, the build regression has remained hidden for 2+ months because
(a) I didn't expect Marc-André's series to affect any ArmVirtPkg
platform, (b) my ArmVirtQemu build script did not set TPM2_ENABLE.

This series fixes the build regression, and intends no functional
changes at all.

Functional regression-testing would be appreciated:

- from Simon regarding their TPM-1.2 passthrough use case,

- from Marc-André regarding vTPM-2.0 on X64,

- from Eric regarding vTPM-2.0 on AARCH64.

This is a regression fix, therefore it is eligible for merging during
the edk2-stable202005 Hard Feature Freeze too
<https://github.com/tianocore/tianocore.github.io/wiki/EDK-II-Release-Planning>.

If you plan to regression-test this series, then please say so soon,
otherwise I wouldn't like to wait for long -- assuming an R-b from Ard
or Jordan -- even without Tested-by's.

In the future we should likely set some "-D" flags somewhere under
"ArmVirtPkg/PlatformCI/" (so that our CI coverage grow). The best I can
personally do about that is maybe file a BZ?...

Cc: Ard Biesheuvel <ard.biesheuvel@arm.com>
Cc: Eric Auger <eric.auger@redhat.com>
Cc: Jordan Justen <jordan.l.justen@intel.com>
Cc: Marc-André Lureau <marcandre.lureau@redhat.com>
Cc: Philippe Mathieu-Daudé <philmd@redhat.com>
Cc: Simon Hardy <simon.hardy@itdev.co.uk>
Cc: Stefan Berger <stefanb@linux.ibm.com>

Thanks,
Laszlo

Laszlo Ersek (3):
  OvmfPkg/Tcg2ConfigPei: clean up some lib class dependencies
  OvmfPkg/Tcg2ConfigPei: factor out InternalTpm12Detect()
  OvmfPkg/Tcg2ConfigPei: skip TPM-1.2 detection when building for
    ARM/AARCH64

 OvmfPkg/Tcg/Tcg2Config/Tcg2ConfigPei.inf  | 13 +++-
 OvmfPkg/Tcg/Tcg2Config/Tcg2ConfigPeim.c   | 46 +-----------
 OvmfPkg/Tcg/Tcg2Config/Tpm12Support.c     | 79 ++++++++++++++++++++
 OvmfPkg/Tcg/Tcg2Config/Tpm12Support.h     | 34 +++++++++
 OvmfPkg/Tcg/Tcg2Config/Tpm12SupportNull.c | 25 +++++++
 5 files changed, 153 insertions(+), 44 deletions(-)
 create mode 100644 OvmfPkg/Tcg/Tcg2Config/Tpm12Support.c
 create mode 100644 OvmfPkg/Tcg/Tcg2Config/Tpm12Support.h
 create mode 100644 OvmfPkg/Tcg/Tcg2Config/Tpm12SupportNull.c
~~~
