### PR TITLE
MdePkg: add definitions for ACPI NVDIMM Device Path

### DIFF
--- a/MdePkg/Include/Protocol/DevicePath.h
+++ b/MdePkg/Include/Protocol/DevicePath.h
@@ -282,6 +282,21 @@ typedef struct {
   //
 } ACPI_ADR_DEVICE_PATH;
 
+///
+/// ACPI NVDIMM Device Path SubType.
+///
+#define ACPI_NVDIMM_DP               0x04
+///
+///
+typedef struct {
+  EFI_DEVICE_PATH_PROTOCOL        Header;
+  ///
+  /// NFIT Device Handle, the _ADR of the NVDIMM device.
+  /// The value of this field comes from Section 9.20.3 of the ACPI 6.2A specification.
+  ///
+  UINT32                          NFITDeviceHandle;
+} ACPI_NVDIMM_DEVICE_PATH;
+
 #define ACPI_ADR_DISPLAY_TYPE_OTHER             0
 #define ACPI_ADR_DISPLAY_TYPE_VGA               1
 #define ACPI_ADR_DISPLAY_TYPE_TV                2


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=2716

Add definitions for ACPI NVDIMM Device Path following UEFI spec.

Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Liming Gao <liming.gao@intel.com>
Signed-off-by: James Anandraj <james.sushanth.anandraj@intel.com>
Reviewed-by: Liming Gao <liming.gao@intel.com>