### PR TITLE
UnitTestFrameworkPkg/UnitTestResultReportLib: Use AsciiStrnCpyS()

### DIFF
--- a/UnitTestFrameworkPkg/Library/UnitTestResultReportLib/UnitTestResultReportLibConOut.c
+++ b/UnitTestFrameworkPkg/Library/UnitTestResultReportLib/UnitTestResultReportLibConOut.c
@@ -42,7 +42,7 @@ ReportOutput (
 
   Length = AsciiStrLen (Output);
   for (Index = 0; Index < Length; Index += (sizeof (AsciiString) - 1)) {
-    AsciiStrCpyS (AsciiString, sizeof (AsciiString), &Output[Index]);
+    AsciiStrnCpyS (AsciiString, sizeof (AsciiString), &Output[Index], sizeof (AsciiString) - 1);
     ReportPrint ("%a", AsciiString);
   }
 }

--- a/UnitTestFrameworkPkg/Library/UnitTestResultReportLib/UnitTestResultReportLibDebugLib.c
+++ b/UnitTestFrameworkPkg/Library/UnitTestResultReportLib/UnitTestResultReportLibDebugLib.c
@@ -41,7 +41,7 @@ ReportOutput (
 
   Length = AsciiStrLen (Output);
   for (Index = 0; Index < Length; Index += (sizeof (AsciiString) - 1)) {
-    AsciiStrCpyS (AsciiString, sizeof (AsciiString), &Output[Index]);
+    AsciiStrnCpyS (AsciiString, sizeof (AsciiString), &Output[Index], sizeof (AsciiString) - 1);
     DEBUG ((DEBUG_INFO, AsciiString));
   }
 }


### PR DESCRIPTION
REF:https://bugzilla.tianocore.org/show_bug.cgi?id=2721

The ReportOutput() function in UnitTestResultReportLib copies characters
from a function input buffer to an intermediate local buffer in fixed
size chunks of the maximum size of the intermediate buffer. The
implementation currently calls AsciiStrCpyS() which will ASSERT on an
error.

This commit changes the call to AsciiStrnCpyS() to avoid the
ASSERT which is not expected in the usage of the string copy in this
implementation.

Cc: Bret Barkelew <Bret.Barkelew@microsoft.com>
Cc: Sean Brogan <sean.brogan@microsoft.com>
Cc: Liming Gao <liming.gao@intel.com>
Cc: Michael D Kinney <michael.d.kinney@intel.com>
Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>
Reviewed-by: Bret Barkelew <bret.barkelew@microsoft.com>