### PR TITLE
Security: add validation of Offset(CVE-2019-14562)

### DIFF
--- a/SecurityPkg/Library/DxeImageVerificationLib/DxeImageVerificationLib.c
+++ b/SecurityPkg/Library/DxeImageVerificationLib/DxeImageVerificationLib.c
@@ -1854,7 +1854,8 @@ DxeImageVerificationHandler (
        OffSet += (WinCertificate->dwLength + ALIGN_SIZE (WinCertificate->dwLength))) {
     WinCertificate = (WIN_CERTIFICATE *) (mImageBase + OffSet);
     if ((SecDataDir->VirtualAddress + SecDataDir->Size - OffSet) <= sizeof (WIN_CERTIFICATE) ||
-        (SecDataDir->VirtualAddress + SecDataDir->Size - OffSet) < WinCertificate->dwLength) {
+        (SecDataDir->VirtualAddress + SecDataDir->Size - OffSet) < WinCertificate->dwLength ||
+		(MAX_UINT32 - WinCertificate->dwLength - ALIGN_SIZE (WinCertificate->dwLength)) < offset) {
       break;
     }
 


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=2215

There is an integer overflow vulnerability in the
DxeImageVerificationHandler(..) function when parsing
the PE files attribute certificate table. In cases
where WinCertificate->dwLength is sufficiently large,
it's possible to overflow Offset back to 0 causing an
endless loop.
Adding validation of Offset to avoid overflowing.

Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Chao Zhang <chao.b.zhang@intel.com>
Signed-off-by: Wenyi Xie <xiewenyi@163.com>