### PR TITLE
Remove redundant code in CoreCheckEvent( )

### DIFF
--- a/MdeModulePkg/Core/Dxe/Event/Event.c
+++ b/MdeModulePkg/Core/Dxe/Event/Event.c
@@ -618,9 +618,9 @@ CoreCheckEvent (
     // Queue the wait notify function
     //
     CoreAcquireEventLock ();
-    if (Event->SignalCount == 0) {
-      CoreNotifyEvent (Event);
-    }
+    
+    CoreNotifyEvent (Event);
+    
     CoreReleaseEventLock ();
   }
 


### PR DESCRIPTION
Redundant code