### PR TITLE
BaseTools/build.py: Exit with 1 when AutoGen error occurred

### DIFF
--- a/BaseTools/Source/Python/build/build.py
+++ b/BaseTools/Source/Python/build/build.py
@@ -880,7 +880,10 @@ class Build():
 
             self.AutoGenMgr.join()
             rt = self.AutoGenMgr.Status
-            return rt, 0
+            err = 0
+            if not rt:
+                err = UNKNOWN_ERROR
+            return rt, err
         except FatalError as e:
             return False, e.args[0]
         except:
@@ -2724,4 +2727,3 @@ if __name__ == '__main__':
     ## 0-127 is a safe return range, and 1 is a standard default error
     if r < 0 or r > 127: r = 1
     sys.exit(r)
-


### PR DESCRIPTION
AutoGen manager/workers halt the progress when an error occurs but
doesn't propagate the error code to main and allows main exit with 0
and gets the build system unable to catch the occurrence of an error.
This change informs main with an error when a progress is halted and
helps main exit with 1.

Signed-off-by: Irene Park <ipark@nvidia.com>
Reviewed-by: Bob Feng <bob.c.feng@intel.com>