### PR TITLE
BaseTools: Warn user the file not found issue instead of break build.

### DIFF
--- a/BaseTools/Source/Python/Trim/Trim.py
+++ b/BaseTools/Source/Python/Trim/Trim.py
@@ -281,9 +281,11 @@ def DoInclude(Source, Indent='', IncludePathList=[], LocalSearchPath=None, Inclu
                         F = File.readlines()
                 break
         else:
-            EdkLogger.error("Trim", "Failed to find include file %s" % Source)
+            EdkLogger.warn("Trim", "Failed to find include file %s" % Source)
+            return []
     except:
-        EdkLogger.error("Trim", FILE_OPEN_FAILURE, ExtraData=Source)
+        EdkLogger.warn("Trim", FILE_OPEN_FAILURE, ExtraData=Source)
+        return []
 
 
     # avoid A "include" B and B "include" A


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=2770

The Trim.py would break the build process when the file not found
issue occures, however sometimes we do not care about this issue.
This patch changes the error with warning in order to solve this
kind of break.

Cc: Bob Feng <bob.c.feng@intel.com>
Cc: Liming Gao <liming.gao@intel.com>
Signed-off-by: Yuwei Chen <yuwei.chen@intel.com>
Reviewed-by: Bob Feng<bob.c.feng@intel.com>