### PR TITLE
ArmPkg: only attempt building MmCommunicationDxe for AArch64

### DIFF
--- a/ArmPkg/ArmPkg.dsc
+++ b/ArmPkg/ArmPkg.dsc
@@ -145,8 +145,8 @@
 
   ArmPkg/Drivers/ArmCrashDumpDxe/ArmCrashDumpDxe.inf
   ArmPkg/Drivers/ArmScmiDxe/ArmScmiDxe.inf
-  ArmPkg/Drivers/MmCommunicationDxe/MmCommunication.inf
 
 [Components.AARCH64]
+  ArmPkg/Drivers/MmCommunicationDxe/MmCommunication.inf
   ArmPkg/Library/ArmMmuLib/ArmMmuPeiLib.inf
   ArmPkg/Library/StandaloneMmMmuLib/ArmMmuStandaloneMmLib.inf


### PR DESCRIPTION
Commit 045e4b84c18f  ("ArmPkg/ArmPkg.dsc: Add missing components")
adds some components to the ArmPkg.dsc build config, but it adds
them to Components.common, and MmCommunicationDxe is AArch64 only.
Move it to Components.AARCH64 to stop the ARM build breaking.

Cc: Ard Biesheuvel <ard.biesheuvel@arm.com>
Cc: Michael Kubacki <michael.kubacki@microsoft.com>
Signed-off-by: Leif Lindholm <leif@nuviainc.com>
Reviewed-by: Ard Biesheuvel <ard.biesheuvel@arm.com>