### PR TITLE
Maintainers.txt: restore lexicographical order between package / subsystem headers [push]

### DIFF
--- a/Maintainers.txt
+++ b/Maintainers.txt
@@ -223,7 +223,7 @@ F: MdeModulePkg/Universal/Acpi/
 R: Dandan Bi <dandan.bi@intel.com>
 R: Liming Gao <liming.gao@intel.com>
 
-MdeModulePkg: ACPI S3 modules
+MdeModulePkg: ACPI modules related to S3
 F: MdeModulePkg/*LockBox*/
 F: MdeModulePkg/Include/*BootScript*.h
 F: MdeModulePkg/Include/*LockBox*.h

--- a/Maintainers.txt
+++ b/Maintainers.txt
@@ -389,6 +389,25 @@ M: Laszlo Ersek <lersek@redhat.com>
 M: Ard Biesheuvel <ard.biesheuvel@arm.com>
 S: Maintained
 
+OvmfPkg: CSM modules
+F: OvmfPkg/Csm/
+R: David Woodhouse <dwmw2@infradead.org>
+
+OvmfPkg: MptScsi and PVSCSI driver
+F: OvmfPkg/MptScsiDxe/
+F: OvmfPkg/PvScsiDxe/
+R: Liran Alon <liran.alon@oracle.com>
+R: Nikita Leshenko <nikita.leshchenko@oracle.com>
+
+OvmfPkg: TCG- and TPM2-related modules
+F: OvmfPkg/Include/IndustryStandard/QemuTpm.h
+F: OvmfPkg/Library/PlatformBootManagerLib/BdsPlatform.c
+F: OvmfPkg/Library/Tcg2PhysicalPresenceLib*/
+F: OvmfPkg/PlatformPei/ClearCache.c
+F: OvmfPkg/Tcg/
+R: Marc-André Lureau <marcandre.lureau@redhat.com>
+R: Stefan Berger <stefanb@linux.ibm.com>
+
 OvmfPkg: Xen-related modules
 F: OvmfPkg/AcpiPlatformDxe/Xen.c
 F: OvmfPkg/Include/Guid/XenBusRootDevice.h
@@ -421,25 +440,6 @@ F: OvmfPkg/XenResetVector/
 F: OvmfPkg/XenTimerDxe/
 R: Anthony Perard <anthony.perard@citrix.com>
 R: Julien Grall <julien@xen.org>
-
-OvmfPkg: TCG- and TPM2-related modules
-F: OvmfPkg/Include/IndustryStandard/QemuTpm.h
-F: OvmfPkg/Library/PlatformBootManagerLib/BdsPlatform.c
-F: OvmfPkg/Library/Tcg2PhysicalPresenceLib*/
-F: OvmfPkg/PlatformPei/ClearCache.c
-F: OvmfPkg/Tcg/
-R: Marc-André Lureau <marcandre.lureau@redhat.com>
-R: Stefan Berger <stefanb@linux.ibm.com>
-
-OvmfPkg: CSM modules
-F: OvmfPkg/Csm/
-R: David Woodhouse <dwmw2@infradead.org>
-
-OvmfPkg: MptScsi and PVSCSI driver
-F: OvmfPkg/MptScsiDxe/
-F: OvmfPkg/PvScsiDxe/
-R: Liran Alon <liran.alon@oracle.com>
-R: Nikita Leshenko <nikita.leshchenko@oracle.com>
 
 PcAtChipsetPkg
 F: PcAtChipsetPkg/

--- a/Maintainers.txt
+++ b/Maintainers.txt
@@ -470,6 +470,13 @@ F: SourceLevelDebugPkg/
 W: https://github.com/tianocore/tianocore.github.io/wiki/SourceLevelDebugPkg
 M: Hao A Wu <hao.a.wu@intel.com>
 
+StandaloneMmPkg
+F: StandaloneMmPkg/
+M: Ard Biesheuvel <ard.biesheuvel@arm.com>
+M: Sami Mujawar <sami.mujawar@arm.com>
+M: Jiewen Yao <jiewen.yao@intel.com>
+R: Supreeth Venkatesh <supreeth.venkatesh@arm.com>
+
 UefiCpuPkg
 F: UefiCpuPkg/
 W: https://github.com/tianocore/tianocore.github.io/wiki/UefiCpuPkg
@@ -491,10 +498,3 @@ M: Michael D Kinney <michael.d.kinney@intel.com>
 R: Sean Brogan <sean.brogan@microsoft.com>
 R: Bret Barkelew <Bret.Barkelew@microsoft.com>
 S: Maintained
-
-StandaloneMmPkg
-F: StandaloneMmPkg/
-M: Ard Biesheuvel <ard.biesheuvel@arm.com>
-M: Sami Mujawar <sami.mujawar@arm.com>
-M: Jiewen Yao <jiewen.yao@intel.com>
-R: Supreeth Venkatesh <supreeth.venkatesh@arm.com>


### PR DESCRIPTION
http://mid.mail-archive.com/20200603160627.3594-1-lersek@redhat.com
https://edk2.groups.io/g/devel/message/60681
https://bugzilla.tianocore.org/show_bug.cgi?id=2778
~~~
Ref:    https://bugzilla.tianocore.org/show_bug.cgi?id=2778
Repo:   https://pagure.io/lersek/edk2.git
Branch: sort_maintainers

We originally meant to keep the subsystem (package) titles sorted, in
"Maintainers.txt".

However, as of 7191dd3c5990 ("ArmPkg/PlatformBootManagerLib: reject
'default' parity and stop bit count", 2020-06-03), we have some disorder
introduced.

This patch series restores lexicographical order between the subsystem
(package) headers.

The package / subsystem headers can be collected with the following
small script:

$ dos2unix < Maintainers.txt \
  | sed -n -e '/^EDK II Packages:$/,$p' \
  | tail -n +3 \
  | grep -E -v '^($|[LMRWTSFX]:)'

Where

- "dos2unix" strips CRs,

- "sed" removes the first part of the file that precedes the "EDK II
  Packages:" heading,

- "tail" removes that heading plus the underline on the next line,

- and "grep" removes the empty lines and the section entries.

What remains is the section headers.

Here's a comparison between the outputs of this script, before (that is,
at commit 7191dd3c5990) and after the series is applied:

> @@ -1,42 +1,42 @@
>  ArmPkg
>  ArmPlatformPkg
>  ArmVirtPkg
>  ArmVirtPkg: modules used on Xen
>  BaseTools
>  CryptoPkg
>  DynamicTablesPkg
>  EmbeddedPkg
>  EmulatorPkg
>  FatPkg
>  FmpDevicePkg
>  IntelFsp2Pkg
>  IntelFsp2WrapperPkg
>  MdeModulePkg
>  MdeModulePkg: ACPI modules
> -MdeModulePkg: ACPI S3 modules
> +MdeModulePkg: ACPI modules related to S3
>  MdeModulePkg: BDS modules
>  MdeModulePkg: Console and Graphics modules
>  MdeModulePkg: Core services (PEI, DXE and Runtime) modules
>  MdeModulePkg: Device and Peripheral modules
>  MdeModulePkg: Firmware Update modules
>  MdeModulePkg: HII and UI modules
>  MdeModulePkg: Management Mode (MM, SMM) modules
>  MdeModulePkg: Reset modules
>  MdeModulePkg: SMBIOS modules
>  MdeModulePkg: UEFI Variable modules
>  MdePkg
>  NetworkPkg
>  OvmfPkg
> -OvmfPkg: Xen-related modules
> -OvmfPkg: TCG- and TPM2-related modules
>  OvmfPkg: CSM modules
>  OvmfPkg: MptScsi and PVSCSI driver
> +OvmfPkg: TCG- and TPM2-related modules
> +OvmfPkg: Xen-related modules
>  PcAtChipsetPkg
>  SecurityPkg
>  ShellPkg
>  SignedCapsulePkg
>  SourceLevelDebugPkg
> +StandaloneMmPkg
>  UefiCpuPkg
>  UefiPayloadPkg
>  UnitTestFrameworkPkg
> -StandaloneMmPkg

Cc: Andrew Fish <afish@apple.com>
Cc: Anthony Perard <anthony.perard@citrix.com>
Cc: Ard Biesheuvel <ard.biesheuvel@arm.com>
Cc: David Woodhouse <dwmw2@infradead.org>
Cc: Eric Dong <eric.dong@intel.com>
Cc: Hao A Wu <hao.a.wu@intel.com>
Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Jordan Justen <jordan.l.justen@intel.com>
Cc: Julien Grall <julien@xen.org>
Cc: Leif Lindholm <leif@nuviainc.com>
Cc: Liran Alon <liran.alon@oracle.com>
Cc: Marc-André Lureau <marcandre.lureau@redhat.com>
Cc: Michael Kinney <michael.d.kinney@intel.com>
Cc: Nikita Leshenko <nikita.leshchenko@oracle.com>
Cc: Philippe Mathieu-Daudé <philmd@redhat.com>
Cc: Sami Mujawar <sami.mujawar@arm.com>
Cc: Stefan Berger <stefanb@linux.ibm.com>
Cc: Supreeth Venkatesh <supreeth.venkatesh@arm.com>

Thanks,
Laszlo

Laszlo Ersek (3):
  Maintainers.txt: retitle "MdeModulePkg: ACPI S3 modules"
  Maintainers.txt: restore order of OvmfPkg sections
  Maintainers.txt: move StandaloneMmPkg to the right spot

 Maintainers.txt | 54 ++++++++++----------
 1 file changed, 27 insertions(+), 27 deletions(-)
~~~
