### PR TITLE
OvmfPkg/Tcg2ConfigPei: trivial cleanups [push]

### DIFF
--- a/OvmfPkg/Tcg/Tcg2Config/Tcg2ConfigPei.inf
+++ b/OvmfPkg/Tcg/Tcg2Config/Tcg2ConfigPei.inf
@@ -37,12 +37,12 @@
 
 [LibraryClasses]
   PeimEntryPoint
-  BaseLib
   DebugLib
   PeiServicesLib
   Tpm2DeviceLib
 
 [LibraryClasses.IA32, LibraryClasses.X64]
+  BaseLib
   Tpm12DeviceLib
 
 [Guids]

--- a/OvmfPkg/Tcg/Tcg2Config/Tcg2ConfigPei.inf
+++ b/OvmfPkg/Tcg/Tcg2Config/Tcg2ConfigPei.inf
@@ -2,7 +2,7 @@
 # Set TPM device type
 #
 # In SecurityPkg, this module initializes the TPM device type based on a UEFI
-# variable and/or hardware detection. In OvmfPkg, the module only performs TPM2
+# variable and/or hardware detection. In OvmfPkg, the module only performs TPM
 # hardware detection.
 #
 # Copyright (c) 2015 - 2016, Intel Corporation. All rights reserved.<BR>

--- a/OvmfPkg/Tcg/Tcg2Config/Tcg2ConfigPeim.c
+++ b/OvmfPkg/Tcg/Tcg2Config/Tcg2ConfigPeim.c
@@ -2,7 +2,7 @@
   Set TPM device type
 
   In SecurityPkg, this module initializes the TPM device type based on a UEFI
-  variable and/or hardware detection. In OvmfPkg, the module only performs TPM2
+  variable and/or hardware detection. In OvmfPkg, the module only performs TPM
   hardware detection.
 
   Copyright (c) 2015, Intel Corporation. All rights reserved.<BR>


### PR DESCRIPTION
https://bugzilla.tianocore.org/show_bug.cgi?id=2752
http://mid.mail-archive.com/20200603170413.23936-1-lersek@redhat.com
https://edk2.groups.io/g/devel/message/60690
~~~
Ref:    https://bugzilla.tianocore.org/show_bug.cgi?id=2752
Repo:   https://pagure.io/lersek/edk2.git
Branch: tcg_config_pei_trivial

Two trivial cleanups after commit 89236992913f ("OvmfPkg: detect TPM 1.2
in Tcg2ConfigPei", 2020-03-04) and commit 74f90d38c446
("OvmfPkg/Tcg2ConfigPei: skip TPM-1.2 detection when building for
ARM/AARCH64", 2020-05-21), respectively.

Cc: Ard Biesheuvel <ard.biesheuvel@arm.com>
Cc: Jordan Justen <jordan.l.justen@intel.com>
Cc: Marc-André Lureau <marcandre.lureau@redhat.com>
Cc: Philippe Mathieu-Daudé <philmd@redhat.com>
Cc: Stefan Berger <stefanb@linux.ibm.com>

Thanks
Laszlo

Laszlo Ersek (2):
  OvmfPkg/Tcg2ConfigPei: generalize TPM2-only file-top comments
  OvmfPkg/Tcg2ConfigPei: restrict BaseLib class dependency to IA32 and
    X64

 OvmfPkg/Tcg/Tcg2Config/Tcg2ConfigPei.inf | 4 ++--
 OvmfPkg/Tcg/Tcg2Config/Tcg2ConfigPeim.c  | 2 +-
 2 files changed, 3 insertions(+), 3 deletions(-)
~~~
