### PR TITLE
OvmfPkg/X86QemuLoadImageLib: handle EFI_ACCESS_DENIED from LoadImage() [push]

### DIFF
--- a/OvmfPkg/Library/X86QemuLoadImageLib/X86QemuLoadImageLib.c
+++ b/OvmfPkg/Library/X86QemuLoadImageLib/X86QemuLoadImageLib.c
@@ -320,12 +320,18 @@ QemuLoadKernelImage (
 
   case EFI_SECURITY_VIOLATION:
     //
-    // We are running with UEFI secure boot enabled, and the image failed to
-    // authenticate. For compatibility reasons, we fall back to the legacy
-    // loader in this case. Since the image has been loaded, we need to unload
-    // it before proceeding
+    // Since the image has been loaded, we need to unload it before proceeding
+    // to the EFI_ACCESS_DENIED case below.
     //
     gBS->UnloadImage (KernelImageHandle);
+    //
+    // Fall through
+    //
+  case EFI_ACCESS_DENIED:
+    //
+    // We are running with UEFI secure boot enabled, and the image failed to
+    // authenticate. For compatibility reasons, we fall back to the legacy
+    // loader in this case.
     //
     // Fall through
     //


### PR DESCRIPTION
http://mid.mail-archive.com/20200605235242.32442-1-lersek@redhat.com
https://edk2.groups.io/g/devel/message/60825
~~~
When an image fails Secure Boot validation, LoadImage() returns
EFI_SECURITY_VIOLATION if the platform policy is
DEFER_EXECUTE_ON_SECURITY_VIOLATION.

If the platform policy is DENY_EXECUTE_ON_SECURITY_VIOLATION, then
LoadImage() returns EFI_ACCESS_DENIED (and the image does not remain
loaded).

(Before <https://bugzilla.tianocore.org/show_bug.cgi?id=2129>, this
difference would be masked, as DxeImageVerificationLib would incorrectly
return EFI_SECURITY_VIOLATION for DENY_EXECUTE_ON_SECURITY_VIOLATION as
well.)

In X86QemuLoadImageLib, proceed to the legacy Linux/x86 Boot Protocol upon
seeing EFI_ACCESS_DENIED too.

Cc: Ard Biesheuvel <ard.biesheuvel@arm.com>
Cc: Jordan Justen <jordan.l.justen@intel.com>
Cc: Philippe Mathieu-Daudé <philmd@redhat.com>
Ref: https://bugzilla.tianocore.org/show_bug.cgi?id=2785
Signed-off-by: Laszlo Ersek <lersek@redhat.com>
---

Notes:
    Repo:   https://pagure.io/lersek/edk2.git
    Branch: x86_qlil_access_denied

 OvmfPkg/Library/X86QemuLoadImageLib/X86QemuLoadImageLib.c | 14 ++++++++++----
 1 file changed, 10 insertions(+), 4 deletions(-)
~~~