### PR TITLE
MdeModulePkg: Sets the Cursor to selected BootOption.

### DIFF
--- a/MdeModulePkg/Application/BootManagerMenuApp/BootManagerMenu.c
+++ b/MdeModulePkg/Application/BootManagerMenuApp/BootManagerMenu.c
@@ -451,20 +451,10 @@ BootMenuSelectItem (
   }
 
   //
-  // Print want to select item
-  //
-  FirstItem = BootMenuData->ScrollBarControl.FirstItem;
-  gST->ConOut->SetAttribute (gST->ConOut, EFI_WHITE | EFI_BACKGROUND_BLACK);
-  String = HiiGetString (gStringPackHandle, BootMenuData->PtrTokens[WantSelectItem], NULL);
-  PrintCol = StartCol  + 1;
-  PrintRow = StartRow + TITLE_TOKEN_COUNT + 2 + WantSelectItem - FirstItem;
-  PrintStringAt (PrintCol, PrintRow, String);
-  FreePool (String);
-
-  //
   // if Want Select and selected item isn't the same and doesn't re-draw selectable
   // items, clear select item
   //
+  FirstItem = BootMenuData->ScrollBarControl.FirstItem;
   if (WantSelectItem != BootMenuData->SelectItem && !RePaintItems) {
     gST->ConOut->SetAttribute (gST->ConOut, EFI_WHITE | EFI_BACKGROUND_BLUE);
     String = HiiGetString (gStringPackHandle, BootMenuData->PtrTokens[BootMenuData->SelectItem], NULL);
@@ -473,6 +463,16 @@ BootMenuSelectItem (
     PrintStringAt (PrintCol, PrintRow, String);
     FreePool (String);
   }
+
+  //
+  // Print want to select item
+  //
+  gST->ConOut->SetAttribute (gST->ConOut, EFI_WHITE | EFI_BACKGROUND_BLACK);
+  String = HiiGetString (gStringPackHandle, BootMenuData->PtrTokens[WantSelectItem], NULL);
+  PrintCol = StartCol  + 1;
+  PrintRow = StartRow + TITLE_TOKEN_COUNT + 2 + WantSelectItem - FirstItem;
+  PrintStringAt (PrintCol, PrintRow, String);
+  FreePool (String);
 
   gST->ConOut->SetAttribute (gST->ConOut, SavedAttribute);
   BootMenuData->SelectItem = WantSelectItem;


### PR DESCRIPTION
Its been observed that in MenuManagerMenuApp when user
selects a different BootOption using Up/Down key, the
current Cursor position is not chaning.
Still points to the old BootOption.

This changes first dispalys/redraws the old BootOption
followed by new BootOption. Doing so will make current
cursor pointing to the user selected BootOption.

Signed-off-by: Abdul Lateef Attar <abdul@marvell.com>
Reviewed-by: Dandan Bi <dandan.bi@intel.com>