### PR TITLE
MdeModulePkg/SetupBrowserDxe: Do not reconnect driver with form-update

### DIFF
--- a/MdeModulePkg/Universal/SetupBrowserDxe/Presentation.c
+++ b/MdeModulePkg/Universal/SetupBrowserDxe/Presentation.c
@@ -19,6 +19,7 @@ LIST_ENTRY         mRefreshEventList = INITIALIZE_LIST_HEAD_VARIABLE (mRefreshEv
 UINT16             mCurFakeQestId;
 FORM_DISPLAY_ENGINE_FORM gDisplayFormData;
 BOOLEAN            mFinishRetrieveCall = FALSE;
+BOOLEAN            mDynamicFormUpdated = FALSE;
 
 /**
   Check whether the ConfigAccess protocol is available.
@@ -1762,6 +1763,7 @@ FormUpdateNotify (
   )
 {
   mHiiPackageListUpdated = TRUE;
+  mDynamicFormUpdated = TRUE;
 
   return EFI_SUCCESS;
 }

--- a/MdeModulePkg/Universal/SetupBrowserDxe/Setup.c
+++ b/MdeModulePkg/Universal/SetupBrowserDxe/Setup.c
@@ -68,6 +68,7 @@ extern EFI_GUID        mCurrentFormSetGuid;
 extern EFI_HII_HANDLE  mCurrentHiiHandle;
 extern UINT16          mCurrentFormId;
 extern FORM_DISPLAY_ENGINE_FORM gDisplayFormData;
+extern BOOLEAN         mDynamicFormUpdated;
 
 /**
   Create a menu with specified formset GUID and form ID, and add it as a child
@@ -536,6 +537,7 @@ SendForm (
       }
       Selection->FormSet = FormSet;
       mSystemLevelFormSet = FormSet;
+      mDynamicFormUpdated = FALSE;
 
       //
       // Display this formset
@@ -547,7 +549,11 @@ SendForm (
       gCurrentSelection = NULL;
       mSystemLevelFormSet = NULL;
 
-      if (gFlagReconnect || gCallbackReconnect) {
+      //
+      // If callback update form dynamically, it's not exiting of the formset for user so system do not reconnect driver hanlde
+      // this time.
+      //
+      if (!mDynamicFormUpdated && (gFlagReconnect || gCallbackReconnect)) {
         RetVal = ReconnectController (FormSet->DriverHandle);
         if (!RetVal) {
           PopupErrorMessage(BROWSER_RECONNECT_FAIL, NULL, NULL, NULL);


### PR DESCRIPTION
REF:https://bugzilla.tianocore.org/show_bug.cgi?id=2701

Recording to the spec, the reconnect is activated upon exiting of the
formset or the browser. Exiting is by user but form-browser internal
logic. That means the reconnection is only happened when user press
ESC or _EXIT action to exit form.
Driver callback may update HII form dynamically so form-browser needs
to refresh its internal data. It's not exiting formset for user
exactly and they didn't know what happened. So use a flag to record
that and do not reconnect driver if updated by callback.

Signed-off-by: Walon Li <walon.li@hpe.com>
Reviewed-by: Dandan Bi <dandan.bi@intel.com>