### PR TITLE
OvmfPkg/GenericQemuLoadImageLib: log "Not Found" at INFO level [push]

### DIFF
--- a/OvmfPkg/Library/GenericQemuLoadImageLib/GenericQemuLoadImageLib.c
+++ b/OvmfPkg/Library/GenericQemuLoadImageLib/GenericQemuLoadImageLib.c
@@ -106,7 +106,8 @@ QemuLoadKernelImage (
     goto UnloadImage;
 
   default:
-    DEBUG ((DEBUG_ERROR, "%a: LoadImage(): %r\n", __FUNCTION__, Status));
+    DEBUG ((Status == EFI_NOT_FOUND ? DEBUG_INFO : DEBUG_ERROR,
+      "%a: LoadImage(): %r\n", __FUNCTION__, Status));
     return Status;
   }
 


### PR DESCRIPTION
http://mid.mail-archive.com/20200609105414.12474-1-lersek@redhat.com
https://edk2.groups.io/g/devel/message/60948
~~~
gBS->LoadImage() returning EFI_NOT_FOUND is an expected condition; it
means that QEMU wasn't started with "-kernel". Log this status code as
INFO rather than ERROR.

Cc: Ard Biesheuvel <ard.biesheuvel@arm.com>
Cc: Jordan Justen <jordan.l.justen@intel.com>
Cc: Philippe Mathieu-Daudé <philmd@redhat.com>
Signed-off-by: Laszlo Ersek <lersek@redhat.com>
---

Notes:
    Repo:   https://pagure.io/lersek/edk2.git
    Branch: gqlil_not_found

 OvmfPkg/Library/GenericQemuLoadImageLib/GenericQemuLoadImageLib.c | 3 ++-
 1 file changed, 2 insertions(+), 1 deletion(-)
~~~
