### PR TITLE
Visual Studio Open Folder mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
-Build/
+/Build/
 .DS_Store
 *_extdep/
 *.pyc
 __pycache__/
 tags/
 .vscode/
+.vs/


### PR DESCRIPTION
- Limit "Build" folder exclusion to top level only, thus making "\BaseTools\Source\Python\build\" show up in Solution Explorer.
- Ignore .vs directory.