### PR TITLE
MdeModulePkg/StatusCodeHandler: do not output \n\r for string data

### DIFF
--- a/MdeModulePkg/Universal/StatusCodeHandler/Pei/SerialStatusCodeWorker.c
+++ b/MdeModulePkg/Universal/StatusCodeHandler/Pei/SerialStatusCodeWorker.c
@@ -134,7 +134,7 @@ SerialStatusCodeReportWorker (
     CharCount = AsciiSPrint (
                   Buffer,
                   sizeof (Buffer),
-                  "%a\n\r",
+                  "%a",
                   ((EFI_STATUS_CODE_STRING_DATA *) Data)->String.Ascii
                   );
   } else {

--- a/MdeModulePkg/Universal/StatusCodeHandler/RuntimeDxe/SerialStatusCodeWorker.c
+++ b/MdeModulePkg/Universal/StatusCodeHandler/RuntimeDxe/SerialStatusCodeWorker.c
@@ -129,7 +129,7 @@ SerialStatusCodeReportWorker (
     CharCount = AsciiSPrint (
                   Buffer,
                   sizeof (Buffer),
-                  "%a\n\r",
+                  "%a",
                   ((EFI_STATUS_CODE_STRING_DATA *) Data)->String.Ascii
                   );
   } else {

--- a/MdeModulePkg/Universal/StatusCodeHandler/Smm/SerialStatusCodeWorker.c
+++ b/MdeModulePkg/Universal/StatusCodeHandler/Smm/SerialStatusCodeWorker.c
@@ -129,7 +129,7 @@ SerialStatusCodeReportWorker (
     CharCount = AsciiSPrint (
                   Buffer,
                   sizeof (Buffer),
-                  "%a\n\r",
+                  "%a",
                   ((EFI_STATUS_CODE_STRING_DATA *) Data)->String.Ascii
                   );
   } else {


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=2787

When output string data through serial port, will not ouput \n\r now.
Caller can output several data in one line, and output \n\r when needed.

Signed-off-by: Ming Tan <ming.tan@intel.com>
Reviewed-by: Jian J Wang <jian.j.wang@intel.com>
Reviewed-by: Eric Dong <eric.dong@intel.com>