### PR TITLE
MdePkg: Include Acpi header file

### DIFF
--- a/MdePkg/Include/IndustryStandard/MemoryMappedConfigurationSpaceAccessTable.h
+++ b/MdePkg/Include/IndustryStandard/MemoryMappedConfigurationSpaceAccessTable.h
@@ -10,6 +10,8 @@
 #ifndef _MEMORY_MAPPED_CONFIGURATION_SPACE_ACCESS_TABLE_H_
 #define _MEMORY_MAPPED_CONFIGURATION_SPACE_ACCESS_TABLE_H_
 
+#include <IndustryStandard/Acpi.h>
+
 //
 // Ensure proper structure formats
 //


### PR DESCRIPTION
ACPI memory mapped configuration space access (MCFG) table requires
defination of EFI_ACPI_DESCRIPTION_HEADER.

Signed-off-by: Wasim Khan <wasim.khan@nxp.com>
Reviewed-by: Liming Gao <liming.gao@intel.com>
Reviewed-by: Philippe Mathieu-Daude <philmd@redhat.com>
Reviewed-by: Zhiguang Liu <zhiguang.liu@intel.com>