### PR TITLE
UefiCpuPkg/SecCore: Add pre-memory AP vector

### DIFF
--- a/UefiCpuPkg/SecCore/Ia32/ResetVec.nasmb
+++ b/UefiCpuPkg/SecCore/Ia32/ResetVec.nasmb
@@ -10,7 +10,7 @@
 ; Abstract:
 ;
 ;  Reset Vector Data structure
-;  This structure is located at 0xFFFFFFC0
+;  This structure is located at 0xFFFFF000
 ;
 ;------------------------------------------------------------------------------
 
@@ -23,19 +23,36 @@ USE16
 ;
 
     ORG     0h
+
+;
+; 0xFFFFF000
+;
+; We enter here with CS:IP = 0xFF00:0x0000. Do a far-jump to change CS to 0xF000
+; and IP to ApStartup.
+;
+ApVector:
+    mov     di, "AP"
+    jmp     0xF000:0xF000+ApStartup
+
+    TIMES 0xFC0-($-$$) nop
+
+;
+; This should be at 0xFFFFFFC0
+;
+
 ;
 ; Reserved
 ;
 ReservedData:            DD 0eeeeeeeeh, 0eeeeeeeeh
 
-    TIMES 0x10-($-$$) DB 0
+    TIMES 0xFD0-($-$$) nop
 ;
-; This is located at 0xFFFFFFD0h
+; This is located at 0xFFFFFFD0
 ;
     mov     di, "PA"
     jmp     ApStartup
 
-    TIMES 0x20-($-$$) DB 0
+    TIMES 0xFE0-($-$$) nop
 ;
 ; Pointer to the entry point of the PEI core
 ; It is located at 0xFFFFFFE0, and is fixed up by some build tool
@@ -53,7 +70,7 @@ ASM_PFX(InterruptHandler):
     jmp     $
     iret
 
-    TIMES 0x30-($-$$) DB 0
+    TIMES 0xFF0-($-$$) nop
 ;
 ; For IA32, the reset vector must be at 0xFFFFFFF0, i.e., 4G-16 byte
 ; Execution starts here upon power-on/platform-reset.
@@ -74,7 +91,7 @@ ApStartup:
     DW      -3
 
 
-    TIMES 0x38-($-$$) DB 0
+    TIMES 0xFF8-($-$$) nop
 ;
 ; Ap reset vector segment address is at 0xFFFFFFF8
 ; This will be fixed up by some build tool,
@@ -83,7 +100,7 @@ ApStartup:
 ;
 ApSegAddress:    dd      12345678h
 
-    TIMES 0x3c-($-$$) DB 0
+    TIMES 0xFFC-($-$$) nop
 ;
 ; BFV Base is at 0xFFFFFFFC
 ; This will be fixed up by some build tool,


### PR DESCRIPTION
REF:https://bugzilla.tianocore.org/show_bug.cgi?id=2776

Add a vector at 0xFF000 (0xFFFFF000) that can be used by Init-SIPI-SIPI
to start an AP before memory is initialized. This vector jumps into the
same SEC entry point as the ordinary reset vector, with a special value
of "AP" in the DI register. The platform-specific SEC code is expected
to check for that value and take a different path for APs, if this
feature is supported by the platform.

Reviewed-by: Eric Dong <eric.dong@intel.com>
Reviewed-by: Ray Ni <ray.ni@intel.com>
Cc: Laszlo Ersek <lersek@redhat.com>
Signed-off-by: Deric Cole <deric.cole@intel.com>