### PR TITLE
Payload/pci

### DIFF
--- a/MdePkg/Include/Library/PciSegmentInfoLib.h
+++ b/MdePkg/Include/Library/PciSegmentInfoLib.h
@@ -3,7 +3,7 @@
 
   This library is consumed by PciSegmentLib to support multiple segment PCI configuration access.
 
-  Copyright (c) 2017, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017 - 2020, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -28,6 +28,7 @@ typedef struct {
   @retval A callee owned array holding the segment information.
 **/
 PCI_SEGMENT_INFO *
+EFIAPI
 GetPciSegmentInfo (
   UINTN  *Count
   );

--- a/MdePkg/Library/BasePciSegmentInfoLibNull/PciSegmentInfoLib.c
+++ b/MdePkg/Library/BasePciSegmentInfoLibNull/PciSegmentInfoLib.c
@@ -2,7 +2,7 @@
   Default PCI Segment Information Library that returns one segment whose
   segment base address equals to PcdPciExpressBaseAddress.
 
-  Copyright (c) 2017, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017 - 2020, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -21,6 +21,7 @@
   @retval A callee owned array holding the segment information.
 **/
 PCI_SEGMENT_INFO *
+EFIAPI
 GetPciSegmentInfo (
   UINTN  *Count
   )

--- a/UefiPayloadPkg/BlSupportDxe/BlSupportDxe.c
+++ b/UefiPayloadPkg/BlSupportDxe/BlSupportDxe.c
@@ -2,7 +2,7 @@
   This driver will report some MMIO/IO resources to dxe core, extract smbios and acpi
   tables from bootloader.
 
-  Copyright (c) 2014 - 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2014 - 2020, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -101,6 +101,7 @@ BlDxeEntryPoint (
   EFI_HOB_GUID_TYPE          *GuidHob;
   SYSTEM_TABLE_INFO          *SystemTableInfo;
   EFI_PEI_GRAPHICS_INFO_HOB  *GfxInfo;
+  ACPI_BOARD_INFO            *AcpiBoardInfo;
 
   Status = EFI_SUCCESS;
   //
@@ -150,6 +151,16 @@ BlDxeEntryPoint (
     Status = PcdSet32S (PcdSetupVideoHorizontalResolution, GfxInfo->GraphicsMode.HorizontalResolution);
     ASSERT_EFI_ERROR (Status);
     Status = PcdSet32S (PcdSetupVideoVerticalResolution, GfxInfo->GraphicsMode.VerticalResolution);
+    ASSERT_EFI_ERROR (Status);
+  }
+
+  //
+  // Set PcdPciExpressBaseAddress by HOB info
+  //
+  GuidHob = GetFirstGuidHob (&gUefiAcpiBoardInfoGuid);
+  if (GuidHob != NULL) {
+    AcpiBoardInfo = (ACPI_BOARD_INFO *)GET_GUID_HOB_DATA (GuidHob);
+    Status = PcdSet64S (PcdPciExpressBaseAddress, AcpiBoardInfo->PcieBaseAddress);
     ASSERT_EFI_ERROR (Status);
   }
 

--- a/UefiPayloadPkg/BlSupportDxe/BlSupportDxe.inf
+++ b/UefiPayloadPkg/BlSupportDxe/BlSupportDxe.inf
@@ -3,7 +3,7 @@
 #
 # Report some MMIO/IO resources to dxe core, extract smbios and acpi tables
 #
-#  Copyright (c) 2014 - 2019, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2014 - 2020, Intel Corporation. All rights reserved.<BR>
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -53,6 +53,7 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdVideoVerticalResolution
   gEfiMdeModulePkgTokenSpaceGuid.PcdSetupVideoHorizontalResolution
   gEfiMdeModulePkgTokenSpaceGuid.PcdSetupVideoVerticalResolution
+  gEfiMdePkgTokenSpaceGuid.PcdPciExpressBaseAddress
 
 [Depex]
   TRUE

--- a/UefiPayloadPkg/Library/PciSegmentInfoLibAcpiBoardInfo/PciSegmentInfoLibAcpiBoardInfo.c
+++ b/UefiPayloadPkg/Library/PciSegmentInfoLibAcpiBoardInfo/PciSegmentInfoLibAcpiBoardInfo.c
@@ -1,0 +1,59 @@
+/** @file
+  PCI Segment Information Library that returns one segment whose
+  segment base address is retrieved from AcpiBoardInfo HOB.
+
+  Copyright (c) 2020, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <PiDxe.h>
+#include <Guid/AcpiBoardInfoGuid.h>
+
+#include <Library/HobLib.h>
+#include <Library/PciSegmentInfoLib.h>
+#include <Library/DebugLib.h>
+
+STATIC PCI_SEGMENT_INFO mPciSegment0 = {
+  0,  // Segment number
+  0,  // To be fixed later
+  0,  // Start bus number
+  255 // End bus number
+};
+
+/**
+  Return an array of PCI_SEGMENT_INFO holding the segment information.
+
+  Note: The returned array/buffer is owned by callee.
+
+  @param  Count  Return the count of segments.
+
+  @retval A callee owned array holding the segment information.
+**/
+PCI_SEGMENT_INFO *
+EFIAPI
+GetPciSegmentInfo (
+  UINTN  *Count
+  )
+{
+  EFI_HOB_GUID_TYPE  *GuidHob;
+  ACPI_BOARD_INFO    *AcpiBoardInfo;
+
+  ASSERT (Count != NULL);
+  if (Count == NULL) {
+    return NULL;
+  }
+
+  if (mPciSegment0.BaseAddress == 0) {
+    //
+    // Find the acpi board information guid hob
+    //
+    GuidHob = GetFirstGuidHob (&gUefiAcpiBoardInfoGuid);
+    ASSERT (GuidHob != NULL);
+
+    AcpiBoardInfo = (ACPI_BOARD_INFO *) GET_GUID_HOB_DATA (GuidHob);
+    mPciSegment0.BaseAddress = AcpiBoardInfo->PcieBaseAddress;
+  }
+  *Count = 1;
+  return &mPciSegment0;
+}

--- a/UefiPayloadPkg/Library/PciSegmentInfoLibAcpiBoardInfo/PciSegmentInfoLibAcpiBoardInfo.inf
+++ b/UefiPayloadPkg/Library/PciSegmentInfoLibAcpiBoardInfo/PciSegmentInfoLibAcpiBoardInfo.inf
@@ -1,0 +1,36 @@
+## @file
+#   PCI Segment Information Library that returns one segment whose
+#   segment base address is retrieved from AcpiBoardInfo HOB.
+#
+# Copyright (c) 2020, Intel Corporation. All rights reserved.<BR>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = PciSegmentInfoLibAcpiBoardInfo
+  FILE_GUID                      = 0EA82AA2-6C36-4FD5-BC90-FFA3ECB5E0CE
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = PciSegmentInfoLib | DXE_DRIVER
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64 EBC
+#
+
+[Sources]
+  PciSegmentInfoLibAcpiBoardInfo.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  UefiPayloadPkg/UefiPayloadPkg.dec
+
+[LibraryClasses]
+  PcdLib
+  HobLib
+  DebugLib

--- a/UefiPayloadPkg/UefiPayloadPkgIa32.dsc
+++ b/UefiPayloadPkg/UefiPayloadPkgIa32.dsc
@@ -40,7 +40,7 @@
   #
   # PCI options
   #
-  DEFINE PCIE_BASE                    = 0xE0000000
+  DEFINE PCIE_BASE_SUPPORT            = TRUE
 
   #
   # Serial port set up
@@ -121,14 +121,15 @@
   PrintLib|MdePkg/Library/BasePrintLib/BasePrintLib.inf
   CpuLib|MdePkg/Library/BaseCpuLib/BaseCpuLib.inf
   IoLib|MdePkg/Library/BaseIoLibIntrinsic/BaseIoLibIntrinsic.inf
-!if $(PCIE_BASE) == 0
+!if $(PCIE_BASE_SUPPORT) == FALSE
   PciLib|MdePkg/Library/BasePciLibCf8/BasePciLibCf8.inf
   PciCf8Lib|MdePkg/Library/BasePciCf8Lib/BasePciCf8Lib.inf
 !else
   PciLib|MdePkg/Library/BasePciLibPciExpress/BasePciLibPciExpress.inf
   PciExpressLib|MdePkg/Library/BasePciExpressLib/BasePciExpressLib.inf
 !endif
-  PciSegmentLib|MdePkg/Library/BasePciSegmentLibPci/BasePciSegmentLibPci.inf
+  PciSegmentLib|MdePkg/Library/PciSegmentLibSegmentInfo/BasePciSegmentLibSegmentInfo.inf
+  PciSegmentInfoLib|UefiPayloadPkg/Library/PciSegmentInfoLibAcpiBoardInfo/PciSegmentInfoLibAcpiBoardInfo.inf
   PeCoffLib|MdePkg/Library/BasePeCoffLib/BasePeCoffLib.inf
   PeCoffGetEntryPointLib|MdePkg/Library/BasePeCoffGetEntryPointLib/BasePeCoffGetEntryPointLib.inf
   CacheMaintenanceLib|MdePkg/Library/BaseCacheMaintenanceLib/BaseCacheMaintenanceLib.inf
@@ -357,6 +358,7 @@
 
   gEfiMdeModulePkgTokenSpaceGuid.PcdConOutRow|31
   gEfiMdeModulePkgTokenSpaceGuid.PcdConOutColumn|100
+  gEfiMdePkgTokenSpaceGuid.PcdPciExpressBaseAddress|0
 
 ################################################################################
 #

--- a/UefiPayloadPkg/UefiPayloadPkgIa32X64.dsc
+++ b/UefiPayloadPkg/UefiPayloadPkgIa32X64.dsc
@@ -41,7 +41,7 @@
   #
   # PCI options
   #
-  DEFINE PCIE_BASE                    = 0xE0000000
+  DEFINE PCIE_BASE_SUPPORT            = TRUE
 
   #
   # Serial port set up
@@ -122,14 +122,15 @@
   PrintLib|MdePkg/Library/BasePrintLib/BasePrintLib.inf
   CpuLib|MdePkg/Library/BaseCpuLib/BaseCpuLib.inf
   IoLib|MdePkg/Library/BaseIoLibIntrinsic/BaseIoLibIntrinsic.inf
-!if $(PCIE_BASE) == 0
+!if $(PCIE_BASE_SUPPORT) == FALSE
   PciLib|MdePkg/Library/BasePciLibCf8/BasePciLibCf8.inf
   PciCf8Lib|MdePkg/Library/BasePciCf8Lib/BasePciCf8Lib.inf
 !else
   PciLib|MdePkg/Library/BasePciLibPciExpress/BasePciLibPciExpress.inf
   PciExpressLib|MdePkg/Library/BasePciExpressLib/BasePciExpressLib.inf
 !endif
-  PciSegmentLib|MdePkg/Library/BasePciSegmentLibPci/BasePciSegmentLibPci.inf
+  PciSegmentLib|MdePkg/Library/PciSegmentLibSegmentInfo/BasePciSegmentLibSegmentInfo.inf
+  PciSegmentInfoLib|UefiPayloadPkg/Library/PciSegmentInfoLibAcpiBoardInfo/PciSegmentInfoLibAcpiBoardInfo.inf
   PeCoffLib|MdePkg/Library/BasePeCoffLib/BasePeCoffLib.inf
   PeCoffGetEntryPointLib|MdePkg/Library/BasePeCoffGetEntryPointLib/BasePeCoffGetEntryPointLib.inf
   CacheMaintenanceLib|MdePkg/Library/BaseCacheMaintenanceLib/BaseCacheMaintenanceLib.inf
@@ -288,7 +289,6 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdUse1GPageTable|TRUE
   gEfiMdeModulePkgTokenSpaceGuid.PcdBootManagerMenuFile|{ 0x21, 0xaa, 0x2c, 0x46, 0x14, 0x76, 0x03, 0x45, 0x83, 0x6e, 0x8a, 0xb6, 0xf4, 0x66, 0x23, 0x31 }
 
-  gEfiMdePkgTokenSpaceGuid.PcdPciExpressBaseAddress|$(PCIE_BASE)
 
 !if $(SOURCE_DEBUG_ENABLE)
   gEfiSourceLevelDebugPkgTokenSpaceGuid.PcdDebugLoadImageMethod|0x2
@@ -359,6 +359,7 @@
 
   gEfiMdeModulePkgTokenSpaceGuid.PcdConOutRow|31
   gEfiMdeModulePkgTokenSpaceGuid.PcdConOutColumn|100
+  gEfiMdePkgTokenSpaceGuid.PcdPciExpressBaseAddress|0
 
 ################################################################################
 #


### PR DESCRIPTION
Today's UefiPayloadPkg always uses 0xE0000000 as the PCIE base address
and ignores the value set in AcpiBoardInfo HOB created by the boot
loader. This makes the payload binary cannot work in environment
where the PCIE base address set by boot loader doesn't equal to
0xE0000000.

The patch enhances UefiPayloadPkg so that the PCIE base address
set by boot loader in the AcpiBoardInfo HOB is used.