### PR TITLE
ArmPkg/ArmMmuLib: Fix implicit cast

### DIFF
--- a/ArmPkg/Library/ArmMmuLib/AArch64/ArmMmuLibCore.c
+++ b/ArmPkg/Library/ArmMmuLib/AArch64/ArmMmuLibCore.c
@@ -649,7 +649,7 @@ ArmMmuBaseLibConstructor (
   // The ArmReplaceLiveTranslationEntry () helper function may be invoked
   // with the MMU off so we have to ensure that it gets cleaned to the PoC
   //
-  WriteBackDataCacheRange (ArmReplaceLiveTranslationEntry,
+  WriteBackDataCacheRange ((VOID *)(UINTN)ArmReplaceLiveTranslationEntry,
     ArmReplaceLiveTranslationEntrySize);
 
   return RETURN_SUCCESS;


### PR DESCRIPTION
While building with the following command line:

 build -b DEBUG -a AARCH64 -t VS2017 -p MdeModulePkg\MdeModulePkg.dsc

A missing cast triggers the following warning, then triggering an error:

  ArmPkg/Library/ArmMmuLib/AArch64/ArmMmuLibCore.c(652):
  warning C4152: nonstandard extension, function/data pointer
  conversion in expression

This patch first casts the function pointer to (UINTN), then to (VOID *),
followowing the C99 standard s6.3.2.3 "Pointer", paragraphs 5 and 6.
This suppresses the warning.

Signed-off-by: Pierre Gondois <pierre.gondois@arm.com>
Suggested-by: Laszlo Ersek <lersek@redhat.com>
Reviewed-by: Ard Biesheuvel <ard.biesheuvel@arm.com>