### PR TITLE
Add MARCO to disable the MD5 and SHA1

### DIFF
--- a/CryptoPkg/Driver/Crypto.c
+++ b/CryptoPkg/Driver/Crypto.c
@@ -550,6 +550,156 @@ CryptoServiceMd5HashAll (
 }
 #endif
 
+#ifdef DISABLE_SHA1_DEPRECATED_INTERFACES
+/**
+  Retrieves the size, in bytes, of the context buffer required for SHA-1 hash operations.
+
+  If this interface is not supported, then return zero.
+
+  @retval  0   This interface is not supported.
+
+**/
+UINTN
+EFIAPI
+DeprecatedCryptoServiceSha1GetContextSize (
+  VOID
+  )
+{
+  return BaseCryptLibServiceDeprecated ("Sha1GetContextSize"), 0;
+}
+
+/**
+  Initializes user-supplied memory pointed by Sha1Context as SHA-1 hash context for
+  subsequent use.
+
+  If Sha1Context is NULL, then return FALSE.
+  If this interface is not supported, then return FALSE.
+
+  @param[out]  Sha1Context  Pointer to SHA-1 context being initialized.
+
+  @retval TRUE   SHA-1 context initialization succeeded.
+  @retval FALSE  SHA-1 context initialization failed.
+  @retval FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+DeprecatedCryptoServiceSha1Init (
+  OUT  VOID  *Sha1Context
+  )
+{
+  return BaseCryptLibServiceDeprecated ("Sha1Init"), FALSE;
+}
+
+/**
+  Makes a copy of an existing SHA-1 context.
+
+  If Sha1Context is NULL, then return FALSE.
+  If NewSha1Context is NULL, then return FALSE.
+  If this interface is not supported, then return FALSE.
+
+  @param[in]  Sha1Context     Pointer to SHA-1 context being copied.
+  @param[out] NewSha1Context  Pointer to new SHA-1 context.
+
+  @retval FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+DeprecatedCryptoServiceSha1Duplicate (
+  IN   CONST VOID  *Sha1Context,
+  OUT  VOID        *NewSha1Context
+  )
+{
+  return BaseCryptLibServiceDeprecated ("Sha1Duplicate"), FALSE;
+}
+
+/**
+  Digests the input data and updates SHA-1 context.
+
+  This function performs SHA-1 digest on a data buffer of the specified size.
+  It can be called multiple times to compute the digest of long or discontinuous data streams.
+  SHA-1 context should be already correctly initialized by Sha1Init(), and should not be finalized
+  by Sha1Final(). Behavior with invalid context is undefined.
+
+  If Sha1Context is NULL, then return FALSE.
+  If this interface is not supported, then return FALSE.
+
+  @param[in, out]  Sha1Context  Pointer to the SHA-1 context.
+  @param[in]       Data         Pointer to the buffer containing the data to be hashed.
+  @param[in]       DataSize     Size of Data buffer in bytes.
+
+  @retval FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+DeprecatedCryptoServiceSha1Update (
+  IN OUT  VOID        *Sha1Context,
+  IN      CONST VOID  *Data,
+  IN      UINTN       DataSize
+  )
+{
+  return BaseCryptLibServiceDeprecated ("Sha1Update"), FALSE;
+}
+
+/**
+  Completes computation of the SHA-1 digest value.
+
+  This function completes SHA-1 hash computation and retrieves the digest value into
+  the specified memory. After this function has been called, the SHA-1 context cannot
+  be used again.
+  SHA-1 context should be already correctly initialized by Sha1Init(), and should not be
+  finalized by Sha1Final(). Behavior with invalid SHA-1 context is undefined.
+
+  If Sha1Context is NULL, then return FALSE.
+  If HashValue is NULL, then return FALSE.
+  If this interface is not supported, then return FALSE.
+
+  @param[in, out]  Sha1Context  Pointer to the SHA-1 context.
+  @param[out]      HashValue    Pointer to a buffer that receives the SHA-1 digest
+                                value (20 bytes).
+
+  @retval FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+DeprecatedCryptoServiceSha1Final (
+  IN OUT  VOID   *Sha1Context,
+  OUT     UINT8  *HashValue
+  )
+{
+  return BaseCryptLibServiceDeprecated ("Sha1Final"), FALSE;
+}
+
+/**
+  Computes the SHA-1 message digest of a input data buffer.
+
+  This function performs the SHA-1 message digest of a given data buffer, and places
+  the digest value into the specified memory.
+
+  If this interface is not supported, then return FALSE.
+
+  @param[in]   Data        Pointer to the buffer containing the data to be hashed.
+  @param[in]   DataSize    Size of Data buffer in bytes.
+  @param[out]  HashValue   Pointer to a buffer that receives the SHA-1 digest
+                           value (20 bytes).
+
+  @retval FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+DeprecatedCryptoServiceSha1HashAll (
+  IN   CONST VOID  *Data,
+  IN   UINTN       DataSize,
+  OUT  UINT8       *HashValue
+  )
+{
+  return BaseCryptLibServiceDeprecated ("Sha1HashAll"), FALSE;
+}
+#else
 /**
   Retrieves the size, in bytes, of the context buffer required for SHA-1 hash operations.
 
@@ -707,6 +857,7 @@ CryptoServiceSha1HashAll (
 {
   return CALL_BASECRYPTLIB (Sha1.Services.HashAll, Sha1HashAll, (Data, DataSize, HashValue), FALSE);
 }
+#endif
 
 /**
   Retrieves the size, in bytes, of the context buffer required for SHA-256 hash operations.
@@ -4394,6 +4545,15 @@ const EDKII_CRYPTO_PROTOCOL mEdkiiCrypto = {
   CryptoServiceRsaPkcs1Verify,
   CryptoServiceRsaGetPrivateKeyFromPem,
   CryptoServiceRsaGetPublicKeyFromX509,
+#ifdef DISABLE_SHA1_DEPRECATED_INTERFACES
+  /// Sha1 - deprecated and unsupported
+  DeprecatedCryptoServiceSha1GetContextSize,
+  DeprecatedCryptoServiceSha1Init,
+  DeprecatedCryptoServiceSha1Duplicate,
+  DeprecatedCryptoServiceSha1Update,
+  DeprecatedCryptoServiceSha1Final,
+  DeprecatedCryptoServiceSha1HashAll,
+#else
   /// Sha1
   CryptoServiceSha1GetContextSize,
   CryptoServiceSha1Init,
@@ -4401,6 +4561,7 @@ const EDKII_CRYPTO_PROTOCOL mEdkiiCrypto = {
   CryptoServiceSha1Update,
   CryptoServiceSha1Final,
   CryptoServiceSha1HashAll,
+#endif
   /// Sha256
   CryptoServiceSha256GetContextSize,
   CryptoServiceSha256Init,

--- a/CryptoPkg/Driver/Crypto.c
+++ b/CryptoPkg/Driver/Crypto.c
@@ -243,6 +243,154 @@ DeprecatedCryptoServiceMd4HashAll (
   return BaseCryptLibServiceDeprecated ("Md4HashAll"), FALSE;
 }
 
+#ifdef DISABLE_MD5_DEPRECATED_INTERFACES
+/**
+  Retrieves the size, in bytes, of the context buffer required for MD5 hash operations.
+
+  If this interface is not supported, then return zero.
+
+  @retval  0   This interface is not supported.
+
+**/
+UINTN
+EFIAPI
+DeprecatedCryptoServiceMd5GetContextSize (
+  VOID
+  )
+{
+  return BaseCryptLibServiceDeprecated ("Md5GetContextSize"), 0;
+}
+
+/**
+  Initializes user-supplied memory pointed by Md5Context as MD5 hash context for
+  subsequent use.
+
+  If Md5Context is NULL, then return FALSE.
+  If this interface is not supported, then return FALSE.
+
+  @param[out]  Md5Context  Pointer to MD5 context being initialized.
+
+  @retval FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+DeprecatedCryptoServiceMd5Init (
+  OUT  VOID  *Md5Context
+  )
+{
+  return BaseCryptLibServiceDeprecated ("Md5Init"), FALSE;
+}
+
+/**
+  Makes a copy of an existing MD5 context.
+
+  If Md5Context is NULL, then return FALSE.
+  If NewMd5Context is NULL, then return FALSE.
+  If this interface is not supported, then return FALSE.
+
+  @param[in]  Md5Context     Pointer to MD5 context being copied.
+  @param[out] NewMd5Context  Pointer to new MD5 context.
+
+  @retval FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+DeprecatedCryptoServiceMd5Duplicate (
+  IN   CONST VOID  *Md5Context,
+  OUT  VOID        *NewMd5Context
+  )
+{
+  return BaseCryptLibServiceDeprecated ("Md5Init"), FALSE;
+}
+
+/**
+  Digests the input data and updates MD5 context.
+
+  This function performs MD5 digest on a data buffer of the specified size.
+  It can be called multiple times to compute the digest of long or discontinuous data streams.
+  MD5 context should be already correctly initialized by Md5Init(), and should not be finalized
+  by Md5Final(). Behavior with invalid context is undefined.
+
+  If Md5Context is NULL, then return FALSE.
+  If this interface is not supported, then return FALSE.
+
+  @param[in, out]  Md5Context  Pointer to the MD5 context.
+  @param[in]       Data        Pointer to the buffer containing the data to be hashed.
+  @param[in]       DataSize    Size of Data buffer in bytes.
+
+  @retval FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+DeprecatedCryptoServiceMd5Update (
+  IN OUT  VOID        *Md5Context,
+  IN      CONST VOID  *Data,
+  IN      UINTN       DataSize
+  )
+{
+  return BaseCryptLibServiceDeprecated ("Md5Init"), FALSE;
+}
+
+/**
+  Completes computation of the MD5 digest value.
+
+  This function completes MD5 hash computation and retrieves the digest value into
+  the specified memory. After this function has been called, the MD5 context cannot
+  be used again.
+  MD5 context should be already correctly initialized by Md5Init(), and should not be
+  finalized by Md5Final(). Behavior with invalid MD5 context is undefined.
+
+  If Md5Context is NULL, then return FALSE.
+  If HashValue is NULL, then return FALSE.
+  If this interface is not supported, then return FALSE.
+
+  @param[in, out]  Md5Context  Pointer to the MD5 context.
+  @param[out]      HashValue   Pointer to a buffer that receives the MD5 digest
+                               value (16 bytes).
+
+  @retval FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+DeprecatedCryptoServiceMd5Final (
+  IN OUT  VOID   *Md5Context,
+  OUT     UINT8  *HashValue
+  )
+{
+  return BaseCryptLibServiceDeprecated ("Md5Final"), FALSE;
+}
+
+/**
+  Computes the MD5 message digest of a input data buffer.
+
+  This function performs the MD5 message digest of a given data buffer, and places
+  the digest value into the specified memory.
+
+  If this interface is not supported, then return FALSE.
+
+  @param[in]   Data        Pointer to the buffer containing the data to be hashed.
+  @param[in]   DataSize    Size of Data buffer in bytes.
+  @param[out]  HashValue   Pointer to a buffer that receives the MD5 digest
+                           value (16 bytes).
+
+  @retval FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+DeprecatedCryptoServiceMd5HashAll (
+  IN   CONST VOID  *Data,
+  IN   UINTN       DataSize,
+  OUT  UINT8       *HashValue
+  )
+{
+  return BaseCryptLibServiceDeprecated ("Md5HashAll"), FALSE;
+}
+#else
 /**
   Retrieves the size, in bytes, of the context buffer required for MD5 hash operations.
 
@@ -400,6 +548,7 @@ CryptoServiceMd5HashAll (
 {
   return CALL_BASECRYPTLIB (Md5.Services.HashAll, Md5HashAll, (Data, DataSize, HashValue), FALSE);
 }
+#endif
 
 /**
   Retrieves the size, in bytes, of the context buffer required for SHA-1 hash operations.
@@ -4194,6 +4343,15 @@ const EDKII_CRYPTO_PROTOCOL mEdkiiCrypto = {
   DeprecatedCryptoServiceMd4Update,
   DeprecatedCryptoServiceMd4Final,
   DeprecatedCryptoServiceMd4HashAll,
+#ifdef DISABLE_MD5_DEPRECATED_INTERFACES
+  /// Md5 - deprecated and unsupported
+  DeprecatedCryptoServiceMd5GetContextSize,
+  DeprecatedCryptoServiceMd5Init,
+  DeprecatedCryptoServiceMd5Duplicate,
+  DeprecatedCryptoServiceMd5Update,
+  DeprecatedCryptoServiceMd5Final,
+  DeprecatedCryptoServiceMd5HashAll,
+#else
   /// Md5
   CryptoServiceMd5GetContextSize,
   CryptoServiceMd5Init,
@@ -4201,6 +4359,7 @@ const EDKII_CRYPTO_PROTOCOL mEdkiiCrypto = {
   CryptoServiceMd5Update,
   CryptoServiceMd5Final,
   CryptoServiceMd5HashAll,
+#endif
   /// Pkcs
   CryptoServicePkcs1v2Encrypt,
   CryptoServicePkcs5HashPassword,

--- a/CryptoPkg/Include/Library/BaseCryptLib.h
+++ b/CryptoPkg/Include/Library/BaseCryptLib.h
@@ -72,6 +72,7 @@ typedef enum {
 //    One-Way Cryptographic Hash Primitives
 //=====================================================================================
 
+#ifndef DISABLE_MD5_DEPRECATED_INTERFACES
 /**
   Retrieves the size, in bytes, of the context buffer required for MD5 hash operations.
 
@@ -211,6 +212,7 @@ Md5HashAll (
   IN   UINTN       DataSize,
   OUT  UINT8       *HashValue
   );
+#endif
 
 /**
   Retrieves the size, in bytes, of the context buffer required for SHA-1 hash operations.

--- a/CryptoPkg/Include/Library/BaseCryptLib.h
+++ b/CryptoPkg/Include/Library/BaseCryptLib.h
@@ -214,6 +214,7 @@ Md5HashAll (
   );
 #endif
 
+#ifndef DISABLE_SHA1_DEPRECATED_INTERFACES
 /**
   Retrieves the size, in bytes, of the context buffer required for SHA-1 hash operations.
 
@@ -353,6 +354,7 @@ Sha1HashAll (
   IN   UINTN       DataSize,
   OUT  UINT8       *HashValue
   );
+#endif
 
 /**
   Retrieves the size, in bytes, of the context buffer required for SHA-256 hash operations.

--- a/CryptoPkg/Library/BaseCryptLib/Hash/CryptMd5.c
+++ b/CryptoPkg/Library/BaseCryptLib/Hash/CryptMd5.c
@@ -9,7 +9,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include "InternalCryptLib.h"
 #include <openssl/md5.h>
 
-
+#ifndef DISABLE_MD5_DEPRECATED_INTERFACES
 /**
   Retrieves the size, in bytes, of the context buffer required for MD5 hash operations.
 
@@ -223,3 +223,4 @@ Md5HashAll (
     return TRUE;
   }
 }
+#endif

--- a/CryptoPkg/Library/BaseCryptLib/Hash/CryptSha1.c
+++ b/CryptoPkg/Library/BaseCryptLib/Hash/CryptSha1.c
@@ -9,7 +9,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include "InternalCryptLib.h"
 #include <openssl/sha.h>
 
-
+#ifndef DISABLE_SHA1_DEPRECATED_INTERFACES
 /**
   Retrieves the size, in bytes, of the context buffer required for SHA-1 hash operations.
 
@@ -222,3 +222,4 @@ Sha1HashAll (
     return TRUE;
   }
 }
+#endif

--- a/CryptoPkg/Library/BaseCryptLibOnProtocolPpi/CryptLib.c
+++ b/CryptoPkg/Library/BaseCryptLibOnProtocolPpi/CryptLib.c
@@ -259,6 +259,7 @@ Md5HashAll (
 }
 #endif
 
+#ifndef DISABLE_SHA1_DEPRECATED_INTERFACES
 /**
   Retrieves the size, in bytes, of the context buffer required for SHA-1 hash operations.
 
@@ -416,6 +417,7 @@ Sha1HashAll (
 {
   CALL_CRYPTO_SERVICE (Sha1HashAll, (Data, DataSize, HashValue), FALSE);
 }
+#endif
 
 /**
   Retrieves the size, in bytes, of the context buffer required for SHA-256 hash operations.

--- a/CryptoPkg/Library/BaseCryptLibOnProtocolPpi/CryptLib.c
+++ b/CryptoPkg/Library/BaseCryptLibOnProtocolPpi/CryptLib.c
@@ -99,6 +99,7 @@ CryptoServiceNotAvailable (
 //    One-Way Cryptographic Hash Primitives
 //=====================================================================================
 
+#ifndef DISABLE_MD5_DEPRECATED_INTERFACES
 /**
   Retrieves the size, in bytes, of the context buffer required for MD5 hash operations.
 
@@ -256,6 +257,7 @@ Md5HashAll (
 {
   CALL_CRYPTO_SERVICE (Md5HashAll, (Data, DataSize, HashValue), FALSE);
 }
+#endif
 
 /**
   Retrieves the size, in bytes, of the context buffer required for SHA-1 hash operations.


### PR DESCRIPTION
Add MARCO to disable the deprecated functions MD5 and SHA1