### PR TITLE
ArmPlatformPkg/PL011UartLib: Check PID2 if FiFoDepth is zero

### DIFF
--- a/ArmPlatformPkg/Library/PL011UartLib/PL011UartLib.c
+++ b/ArmPlatformPkg/Library/PL011UartLib/PL011UartLib.c
@@ -78,10 +78,14 @@ PL011UartInitializePort (
   UINT32      Integer;
   UINT32      Fractional;
   UINT32      HardwareFifoDepth;
+  UINT32      UartPid2;
 
-  HardwareFifoDepth = (PL011_UARTPID2_VER (MmioRead32 (UartBase + UARTPID2)) \
-                       > PL011_VER_R1P4) \
-                      ? 32 : 16 ;
+  HardwareFifoDepth = FixedPcdGet16 (PcdUartDefaultReceiveFifoDepth);
+  if (HardwareFifoDepth == 0) {
+    UartPid2 = MmioRead32 (UartBase + UARTPID2);
+    HardwareFifoDepth = (PL011_UARTPID2_VER (UartPid2) > PL011_VER_R1P4) ? 32 : 16;
+  }
+
   // The PL011 supports a buffer of 1, 16 or 32 chars. Therefore we can accept
   // 1 char buffer as the minimum FIFO size. Because everything can be rounded
   // down, there is no maximum FIFO size.

--- a/ArmPlatformPkg/Library/PL011UartLib/PL011UartLib.inf
+++ b/ArmPlatformPkg/Library/PL011UartLib/PL011UartLib.inf
@@ -30,6 +30,7 @@
   ArmPlatformPkg/ArmPlatformPkg.dec
 
 [FixedPcd]
+  gEfiMdePkgTokenSpaceGuid.PcdUartDefaultReceiveFifoDepth
   gEfiMdeModulePkgTokenSpaceGuid.PcdSerialBaudRate
 
   gArmPlatformTokenSpaceGuid.PL011UartInteger


### PR DESCRIPTION
PL011UartLib determines its FIFO depth based on the PID2 value but
the register PID2 is not mandatory as per the SBSA spec.
This change won't check PID2 if PcdUartDefaultReceiveFifoDepth is set
to a value > 0.

Signed-off-by: Irene Park <ipark@nvidia.com>
Reviewed-by: Ard Biesheuvel <ard.biesheuvel@arm.com>