### PR TITLE
BaseTools: PatchCheck: Exclude bash scripts from CRLF check

### DIFF
--- a/BaseTools/Scripts/PatchCheck.py
+++ b/BaseTools/Scripts/PatchCheck.py
@@ -3,6 +3,7 @@
 #
 #  Copyright (c) 2015 - 2020, Intel Corporation. All rights reserved.<BR>
 #  Copyright (C) 2020, Red Hat, Inc.<BR>
+#  Copyright (c) 2020, ARM Ltd. All rights reserved.<BR>
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -384,9 +385,14 @@ class GitDiffCheck:
                 self.is_newfile = False
                 self.force_crlf = True
                 self.force_notabs = True
-                if self.filename.endswith('.sh'):
+                if self.filename.endswith('.sh') or \
+                    self.filename.startswith('BaseTools/BinWrappers/PosixLike/') or \
+                    self.filename.startswith('BaseTools/Bin/CYGWIN_NT-5.1-i686/') or \
+                    self.filename == 'BaseTools/BuildEnv':
                     #
                     # Do not enforce CR/LF line endings for linux shell scripts.
+                    # Some linux shell scripts don't end with the ".sh" extension,
+                    # they are identified by their path.
                     #
                     self.force_crlf = False
                 if self.filename == '.gitmodules':


### PR DESCRIPTION
Bash scripts require LF line endings to work.
PatchCheck.py checks that the files added in a patch have CRLF
line endings. It excludes files ending with the ".sh" extension
from this check.

Some bash script don't have a ".sh" extension. Most of them are
located in:
 - BaseTools/BinWrappers/PosixLike/
 - BaseTools/Bin/CYGWIN_NT-5.1-i686/

This patch excludes these folder plus BaseTools/BuildEnv from
this CRLF check.

Signed-off-by: Pierre Gondois <pierre.gondois@arm.com>

Reviewed-by: Bob Feng <bob.c.feng@intel.com>