### PR TITLE
Fix unnecessary return from InsertHead/TailList

### DIFF
--- a/MdePkg/Include/Library/BaseLib.h
+++ b/MdePkg/Include/Library/BaseLib.h
@@ -2966,11 +2966,10 @@ InitializeListHead (
 
 
 /**
-  Adds a node to the beginning of a doubly linked list, and returns the pointer
-  to the head node of the doubly linked list.
+  Adds a node to the beginning of a doubly linked list.
 
   Adds the node Entry at the beginning of the doubly linked list denoted by
-  ListHead, and returns ListHead.
+  ListHead.
 
   If ListHead is NULL, then ASSERT().
   If Entry is NULL, then ASSERT().
@@ -2984,10 +2983,8 @@ InitializeListHead (
   @param  Entry     A pointer to a node that is to be inserted at the beginning
                     of a doubly linked list.
 
-  @return ListHead
-
 **/
-LIST_ENTRY *
+VOID
 EFIAPI
 InsertHeadList (
   IN OUT  LIST_ENTRY                *ListHead,
@@ -2996,11 +2993,9 @@ InsertHeadList (
 
 
 /**
-  Adds a node to the end of a doubly linked list, and returns the pointer to
-  the head node of the doubly linked list.
+  Adds a node to the end of a doubly linked list.
 
-  Adds the node Entry to the end of the doubly linked list denoted by ListHead,
-  and returns ListHead.
+  Adds the node Entry to the end of the doubly linked list denoted by ListHead.
 
   If ListHead is NULL, then ASSERT().
   If Entry is NULL, then ASSERT().
@@ -3014,10 +3009,8 @@ InsertHeadList (
   @param  Entry     A pointer to a node that is to be added at the end of the
                     doubly linked list.
 
-  @return ListHead
-
 **/
-LIST_ENTRY *
+VOID
 EFIAPI
 InsertTailList (
   IN OUT  LIST_ENTRY                *ListHead,

--- a/MdePkg/Library/BaseLib/LinkedList.c
+++ b/MdePkg/Library/BaseLib/LinkedList.c
@@ -192,11 +192,10 @@ InitializeListHead (
 }
 
 /**
-  Adds a node to the beginning of a doubly-linked list, and returns the pointer
-  to the head node of the doubly-linked list.
+  Adds a node to the beginning of a doubly-linked list.
 
   Adds the node Entry at the beginning of the doubly-linked list denoted by
-  ListHead, and returns ListHead.
+  ListHead.
 
   If ListHead is NULL, then ASSERT().
   If Entry is NULL, then ASSERT().
@@ -210,10 +209,8 @@ InitializeListHead (
   @param  Entry     A pointer to a node that is to be inserted at the beginning
                     of a doubly-linked list.
 
-  @return ListHead
-
 **/
-LIST_ENTRY *
+VOID
 EFIAPI
 InsertHeadList (
   IN OUT  LIST_ENTRY                *ListHead,
@@ -229,15 +226,12 @@ InsertHeadList (
   Entry->BackLink = ListHead;
   Entry->ForwardLink->BackLink = Entry;
   ListHead->ForwardLink = Entry;
-  return ListHead;
 }
 
 /**
-  Adds a node to the end of a doubly-linked list, and returns the pointer to
-  the head node of the doubly-linked list.
+  Adds a node to the end of a doubly-linked list.
 
-  Adds the node Entry to the end of the doubly-linked list denoted by ListHead,
-  and returns ListHead.
+  Adds the node Entry to the end of the doubly-linked list denoted by ListHead.
 
   If ListHead is NULL, then ASSERT().
   If Entry is NULL, then ASSERT().
@@ -251,10 +245,8 @@ InsertHeadList (
   @param  Entry     A pointer to a node that is to be added at the end of the
                     doubly-linked list.
 
-  @return ListHead
-
 **/
-LIST_ENTRY *
+VOID
 EFIAPI
 InsertTailList (
   IN OUT  LIST_ENTRY                *ListHead,
@@ -270,7 +262,6 @@ InsertTailList (
   Entry->BackLink = ListHead->BackLink;
   Entry->BackLink->ForwardLink = Entry;
   ListHead->BackLink = Entry;
-  return ListHead;
 }
 
 /**
@@ -545,14 +536,16 @@ SwapListEntries (
   // immediately in front of SecondEntry
   //
   if (Ptr->BackLink == SecondEntry) {
-    return InsertTailList (SecondEntry, FirstEntry);
+    InsertTailList (SecondEntry, FirstEntry);
+    return SecondEntry;
   }
 
   //
   // Ptr == SecondEntry means SecondEntry immediately follows FirstEntry,
   // then there are no further steps necessary
   //
-  if (Ptr == InsertHeadList (SecondEntry, FirstEntry)) {
+  InsertHeadList (SecondEntry, FirstEntry);
+  if (Ptr == SecondEntry) {
     return Ptr;
   }
 


### PR DESCRIPTION
ListHead param in both InsertHeadList() and InsertTailList() does not change.
Hence, return VOID.

Signed-off-by: Naveen Iyer <iyernaveenr@gmail.com>