### PR TITLE
SignedCapsulePkg: Address NULL pointer dereference case.

### DIFF
--- a/SignedCapsulePkg/Universal/SystemFirmwareUpdate/SystemFirmwareUpdateDxe.c
+++ b/SignedCapsulePkg/Universal/SystemFirmwareUpdate/SystemFirmwareUpdateDxe.c
@@ -681,32 +681,35 @@ FindMatchingFmpHandles (
     //
     // Loop through the set of EFI_FIRMWARE_IMAGE_DESCRIPTORs.
     //
-    FmpImageInfoBuf = OriginalFmpImageInfoBuf;
     MatchFound = FALSE;
-    for (Index2 = 0; Index2 < FmpImageInfoCount; Index2++) {
-      for (Index3 = 0; Index3 < mSystemFmpPrivate->DescriptorCount; Index3++) {
-        MatchFound = CompareGuid (
-                       &FmpImageInfoBuf->ImageTypeId,
-                       &mSystemFmpPrivate->ImageDescriptor[Index3].ImageTypeId
-                       );
+    if (OriginalFmpImageInfoBuf != NULL) {
+      FmpImageInfoBuf = OriginalFmpImageInfoBuf;
+
+      for (Index2 = 0; Index2 < FmpImageInfoCount; Index2++) {
+        for (Index3 = 0; Index3 < mSystemFmpPrivate->DescriptorCount; Index3++) {
+          MatchFound = CompareGuid (
+                        &FmpImageInfoBuf->ImageTypeId,
+                        &mSystemFmpPrivate->ImageDescriptor[Index3].ImageTypeId
+                        );
+          if (MatchFound) {
+            break;
+          }
+        }
         if (MatchFound) {
           break;
         }
+        //
+        // Increment the buffer pointer ahead by the size of the descriptor
+        //
+        FmpImageInfoBuf = (EFI_FIRMWARE_IMAGE_DESCRIPTOR *)(((UINT8 *)FmpImageInfoBuf) + DescriptorSize);
       }
       if (MatchFound) {
-        break;
+        HandleBuffer[*HandleCount] = HandleBuffer[Index];
+        (*HandleCount)++;
       }
-      //
-      // Increment the buffer pointer ahead by the size of the descriptor
-      //
-      FmpImageInfoBuf = (EFI_FIRMWARE_IMAGE_DESCRIPTOR *)(((UINT8 *)FmpImageInfoBuf) + DescriptorSize);
-    }
-    if (MatchFound) {
-      HandleBuffer[*HandleCount] = HandleBuffer[Index];
-      (*HandleCount)++;
-    }
 
-    FreePool (OriginalFmpImageInfoBuf);
+      FreePool (OriginalFmpImageInfoBuf);
+    }
   }
 
   if ((*HandleCount) == 0) {


### PR DESCRIPTION
Original code GetFmpImageDescriptors for OriginalFmpImageInfoBuf
pointer, if failed, return a NULL pointer. The OriginalFmpImageInfoBuf
should not be NULL and the NULL pointer dereference case
should be false positive.

Signed-off-by: Vin Xue <vinxue@outlook.comr>