### PR TITLE
UefiPayloadPkg:Fix NOOPT build failure

### DIFF
--- a/UefiPayloadPkg/UefiPayloadPkg.fdf
+++ b/UefiPayloadPkg/UefiPayloadPkg.fdf
@@ -8,23 +8,39 @@
 #
 ##
 
+[Defines]
+DEFINE FD_BASE       = 0x00800000
+DEFINE FD_BLOCK_SIZE = 0x00001000
+
+!if $(TARGET) == "NOOPT"
+DEFINE PEI_FV_SIZE = 0x00050000
+DEFINE DXE_FV_SIZE = 0x00800000
+DEFINE FD_SIZE     = 0x00850000
+DEFINE NUM_BLOCKS  = 0x850
+!else
+DEFINE PEI_FV_SIZE = 0x30000
+DEFINE DXE_FV_SIZE = 0x3E0000
+DEFINE FD_SIZE     = 0x00410000
+DEFINE NUM_BLOCKS  = 0x410
+!endif
+
 ################################################################################
 [FD.UefiPayload]
-BaseAddress   = 0x800000|gUefiPayloadPkgTokenSpaceGuid.PcdPayloadFdMemBase
-Size          = 0x410000|gUefiPayloadPkgTokenSpaceGuid.PcdPayloadFdMemSize
+BaseAddress   = $(FD_BASE) | gUefiPayloadPkgTokenSpaceGuid.PcdPayloadFdMemBase
+Size          = $(FD_SIZE) | gUefiPayloadPkgTokenSpaceGuid.PcdPayloadFdMemSize
 ErasePolarity = 1
-BlockSize     = 0x1000
-NumBlocks     = 0x410
+BlockSize     = $(FD_BLOCK_SIZE)
+NumBlocks     = $(NUM_BLOCKS)
 
-0x00000000|0x030000
+0x00000000|$(PEI_FV_SIZE)
 FV = PEIFV
 
-0x00030000|0x3E0000
+$(PEI_FV_SIZE)|$(DXE_FV_SIZE)
 FV = DXEFV
 
 ################################################################################
 [FV.PEIFV]
-BlockSize          = 0x1000
+BlockSize          = $(FD_BLOCK_SIZE)
 FvAlignment        = 16
 ERASE_POLARITY     = 1
 MEMORY_MAPPED      = TRUE
@@ -54,7 +70,7 @@ INF MdeModulePkg/Core/DxeIplPeim/DxeIpl.inf
 ################################################################################
 
 [FV.DXEFV]
-BlockSize          = 0x1000
+BlockSize          = $(FD_BLOCK_SIZE)
 FvForceRebase      = FALSE
 FvAlignment        = 16
 ERASE_POLARITY     = 1


### PR DESCRIPTION
When build UEFI payload using NOOPT, it would build failure since
the FV size. So this patch increases FV size to support NOOPT.
If not NOOPT build, there is no change to FV size.

Signed-off-by: Guo Dong <guo.dong@intel.com>
Reviewed-by: Maurice Ma <maurice.ma@intel.com>