### PR TITLE
SecurityPkg/Tcg2Pei: Add missing PCRIndex in FvBlob event.

### DIFF
--- a/SecurityPkg/Tcg/Tcg2Pei/Tcg2Pei.c
+++ b/SecurityPkg/Tcg/Tcg2Pei/Tcg2Pei.c
@@ -633,6 +633,7 @@ MeasureFvImage (
     }
     FvBlob2.BlobBase      = FvBase;
     FvBlob2.BlobLength    = FvLength;
+    TcgEventHdr.PCRIndex  = 0;
     TcgEventHdr.EventType = EV_EFI_PLATFORM_FIRMWARE_BLOB2;
     TcgEventHdr.EventSize = sizeof (FvBlob2);
     EventData             = &FvBlob2;


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=2840

Cc: Jian J Wang <jian.j.wang@intel.com>
Signed-off-by: Jiewen Yao <jiewen.yao@intel.com>
Reviewed-by: Jian J Wang <jian.j.wang@intel.com>