### PR TITLE
MdeModulePkg/PartitionDxe: Fix the partition check issue

### DIFF
--- a/MdeModulePkg/Universal/Disk/PartitionDxe/Mbr.c
+++ b/MdeModulePkg/Universal/Disk/PartitionDxe/Mbr.c
@@ -135,14 +135,17 @@ PartitionInstallMbrChildHandles (
   EFI_DEVICE_PATH_PROTOCOL     *LastDevicePathNode;
   UINT32                       BlockSize;
   UINT32                       MediaId;
-  EFI_LBA                      LastBlock;
+  EFI_LBA                      LastSector;
   EFI_PARTITION_INFO_PROTOCOL  PartitionInfo;
 
   Found           = EFI_NOT_FOUND;
 
-  BlockSize = BlockIo->Media->BlockSize;
-  MediaId   = BlockIo->Media->MediaId;
-  LastBlock = BlockIo->Media->LastBlock;
+  BlockSize   = BlockIo->Media->BlockSize;
+  MediaId     = BlockIo->Media->MediaId;
+  LastSector  = DivU64x32 (
+                  MultU64x32 (BlockIo->Media->LastBlock + 1, BlockSize),
+                  MBR_SIZE
+                  ) - 1;
 
   //
   // Ensure the block size can hold the MBR
@@ -167,7 +170,7 @@ PartitionInstallMbrChildHandles (
     Found = Status;
     goto Done;
   }
-  if (!PartitionValidMbr (Mbr, LastBlock)) {
+  if (!PartitionValidMbr (Mbr, LastSector)) {
     goto Done;
   }
   //

--- a/MdeModulePkg/Universal/Disk/PartitionDxe/Mbr.c
+++ b/MdeModulePkg/Universal/Disk/PartitionDxe/Mbr.c
@@ -39,6 +39,7 @@ PartitionValidMbr (
   UINT32  StartingLBA;
   UINT32  EndingLBA;
   UINT32  NewEndingLBA;
+  UINT32  SizeInLBA;
   INTN    Index1;
   INTN    Index2;
   BOOLEAN MbrValid;
@@ -51,13 +52,34 @@ PartitionValidMbr (
   //
   MbrValid = FALSE;
   for (Index1 = 0; Index1 < MAX_MBR_PARTITIONS; Index1++) {
-    if (Mbr->Partition[Index1].OSIndicator == 0x00 || UNPACK_UINT32 (Mbr->Partition[Index1].SizeInLBA) == 0) {
+    StartingLBA = UNPACK_UINT32 (Mbr->Partition[Index1].StartingLBA);
+    SizeInLBA   = UNPACK_UINT32 (Mbr->Partition[Index1].SizeInLBA);
+
+    //
+    // If the MBR with partition entry covering the ENTIRE disk, i.e. start at LBA0
+    // with whole disk size, we treat it as an invalid MBR partition.
+    //
+    if ((StartingLBA == 0) &&
+        (SizeInLBA == (LastLba + 1))) {
+      //
+      // Refer to the http://manpages.ubuntu.com/manpages/bionic/man8/mkudffs.8.html
+      // "WHOLE DISK VS PARTITION"
+      // Some linux ISOs may put the MBR table in the first 512 bytes for compatibility reasons with Windows.
+      // Linux  kernel  ignores MBR table if contains partition which starts at sector 0.
+      // Skip it because we don't have the partition check for UDF(El Torito compatible).
+      // It would continue to do the whole disk check in the UDF routine.
+      //
+      DEBUG ((DEBUG_INFO, "PartitionValidMbr: MBR table has partition entry covering the ENTIRE disk. Don't treat it as a valid MBR.\n"));
+
+      return FALSE;
+    }
+
+    if (Mbr->Partition[Index1].OSIndicator == 0x00 || SizeInLBA == 0) {
       continue;
     }
 
     MbrValid    = TRUE;
-    StartingLBA = UNPACK_UINT32 (Mbr->Partition[Index1].StartingLBA);
-    EndingLBA   = StartingLBA + UNPACK_UINT32 (Mbr->Partition[Index1].SizeInLBA) - 1;
+    EndingLBA   = StartingLBA + SizeInLBA - 1;
     if (EndingLBA > LastLba) {
       //
       // Compatibility Errata:
@@ -77,12 +99,15 @@ PartitionValidMbr (
     }
 
     for (Index2 = Index1 + 1; Index2 < MAX_MBR_PARTITIONS; Index2++) {
-      if (Mbr->Partition[Index2].OSIndicator == 0x00 || UNPACK_UINT32 (Mbr->Partition[Index2].SizeInLBA) == 0) {
+      StartingLBA = UNPACK_UINT32 (Mbr->Partition[Index2].StartingLBA);
+      SizeInLBA   = UNPACK_UINT32 (Mbr->Partition[Index2].SizeInLBA);
+
+      if (Mbr->Partition[Index2].OSIndicator == 0x00 || SizeInLBA == 0) {
         continue;
       }
 
-      NewEndingLBA = UNPACK_UINT32 (Mbr->Partition[Index2].StartingLBA) + UNPACK_UINT32 (Mbr->Partition[Index2].SizeInLBA) - 1;
-      if (NewEndingLBA >= StartingLBA && UNPACK_UINT32 (Mbr->Partition[Index2].StartingLBA) <= EndingLBA) {
+      NewEndingLBA = StartingLBA + SizeInLBA - 1;
+      if (NewEndingLBA >= StartingLBA && StartingLBA <= EndingLBA) {
         //
         // This region overlaps with the Index1'th region
         //

--- a/MdeModulePkg/Universal/Disk/PartitionDxe/Partition.c
+++ b/MdeModulePkg/Universal/Disk/PartitionDxe/Partition.c
@@ -1276,6 +1276,15 @@ PartitionInstallChildHandle (
   } else {
     FreePool (Private->DevicePath);
     FreePool (Private);
+
+    //
+    // if the Status == EFI_ALREADY_STARTED, it means the child handles
+    // are already installed. So return EFI_SUCCESS to avoid do the next
+    // partition type check.
+    //
+    if (Status == EFI_ALREADY_STARTED) {
+      Status = EFI_SUCCESS;
+    }
   }
 
   return Status;


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=2823

Drop V1 because it is a bug: there should not be two partition types in one media.
1. Correct the LastBlock value in MBR handler. It should be the number of
sectors (512 bytes).
2. Skip the MBR check if the MBR is added for the Windows comaptiblity. We treat such
media as ElTorito and do the check.
3. Fix the partition check bug: One partition type returns already started should
be treated as success to avoid multi partition type be installed into same media.