### PR TITLE
[edk2-devel] [PATCH V3 0/4] Add New Memory Attributes -- push

### DIFF
--- a/MdeModulePkg/Core/Dxe/Gcd/Gcd.c
+++ b/MdeModulePkg/Core/Dxe/Gcd/Gcd.c
@@ -35,13 +35,6 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #define PRESENT_MEMORY_ATTRIBUTES     (EFI_RESOURCE_ATTRIBUTE_PRESENT)
 
-#define EXCLUSIVE_MEMORY_ATTRIBUTES   (EFI_MEMORY_UC | EFI_MEMORY_WC | \
-                                       EFI_MEMORY_WT | EFI_MEMORY_WB | \
-                                       EFI_MEMORY_WP | EFI_MEMORY_UCE)
-
-#define NONEXCLUSIVE_MEMORY_ATTRIBUTES (EFI_MEMORY_XP | EFI_MEMORY_RP | \
-                                        EFI_MEMORY_RO)
-
 //
 // Module Variables
 //
@@ -665,7 +658,7 @@ ConverToCpuArchAttributes (
 {
   UINT64      CpuArchAttributes;
 
-  CpuArchAttributes = Attributes & NONEXCLUSIVE_MEMORY_ATTRIBUTES;
+  CpuArchAttributes = Attributes & EFI_MEMORY_ATTRIBUTE_MASK;
 
   if ( (Attributes & EFI_MEMORY_UC) == EFI_MEMORY_UC) {
     CpuArchAttributes |= EFI_MEMORY_UC;
@@ -951,7 +944,7 @@ CoreConvertSpace (
         // Keep original CPU arch attributes when caller just calls
         // SetMemorySpaceAttributes() with none CPU arch attributes (for example, RUNTIME).
         //
-        Attributes |= (Entry->Attributes & (EXCLUSIVE_MEMORY_ATTRIBUTES | NONEXCLUSIVE_MEMORY_ATTRIBUTES));
+        Attributes |= (Entry->Attributes & (EFI_CACHE_ATTRIBUTE_MASK | EFI_MEMORY_ATTRIBUTE_MASK));
       }
       Entry->Attributes = Attributes;
       break;

--- a/MdeModulePkg/Core/Dxe/Mem/Page.c
+++ b/MdeModulePkg/Core/Dxe/Mem/Page.c
@@ -1857,8 +1857,7 @@ CoreGetMemoryMap (
       MemoryMap->VirtualStart  = 0;
       MemoryMap->NumberOfPages = RShiftU64 ((MergeGcdMapEntry.EndAddress - MergeGcdMapEntry.BaseAddress + 1), EFI_PAGE_SHIFT);
       MemoryMap->Attribute     = (MergeGcdMapEntry.Attributes & ~EFI_MEMORY_PORT_IO) |
-                                (MergeGcdMapEntry.Capabilities & (EFI_MEMORY_RP | EFI_MEMORY_WP | EFI_MEMORY_XP | EFI_MEMORY_RO |
-                                EFI_MEMORY_UC | EFI_MEMORY_UCE | EFI_MEMORY_WC | EFI_MEMORY_WT | EFI_MEMORY_WB));
+                                (MergeGcdMapEntry.Capabilities & (EFI_CACHE_ATTRIBUTE_MASK | EFI_MEMORY_ATTRIBUTE_MASK));
 
       if (MergeGcdMapEntry.GcdMemoryType == EfiGcdMemoryTypeReserved) {
         MemoryMap->Type = EfiReservedMemoryType;
@@ -1892,8 +1891,7 @@ CoreGetMemoryMap (
       MemoryMap->VirtualStart  = 0;
       MemoryMap->NumberOfPages = RShiftU64 ((MergeGcdMapEntry.EndAddress - MergeGcdMapEntry.BaseAddress + 1), EFI_PAGE_SHIFT);
       MemoryMap->Attribute     = MergeGcdMapEntry.Attributes | EFI_MEMORY_NV |
-                                (MergeGcdMapEntry.Capabilities & (EFI_MEMORY_RP | EFI_MEMORY_WP | EFI_MEMORY_XP | EFI_MEMORY_RO |
-                                EFI_MEMORY_UC | EFI_MEMORY_UCE | EFI_MEMORY_WC | EFI_MEMORY_WT | EFI_MEMORY_WB));
+                                (MergeGcdMapEntry.Capabilities & (EFI_CACHE_ATTRIBUTE_MASK | EFI_MEMORY_ATTRIBUTE_MASK));
       MemoryMap->Type          = EfiPersistentMemory;
 
       //
@@ -1935,8 +1933,7 @@ CoreGetMemoryMap (
   MemoryMapEnd = MemoryMap;
   MemoryMap = MemoryMapStart;
   while (MemoryMap < MemoryMapEnd) {
-    MemoryMap->Attribute &= ~(UINT64)(EFI_MEMORY_RP | EFI_MEMORY_RO |
-                                      EFI_MEMORY_XP);
+    MemoryMap->Attribute &= ~(UINT64)EFI_MEMORY_ATTRIBUTE_MASK;
     MemoryMap = NEXT_MEMORY_DESCRIPTOR (MemoryMap, Size);
   }
   MergeMemoryMap (MemoryMapStart, &BufferSize, Size);

--- a/MdeModulePkg/Core/Dxe/Misc/MemoryProtection.c
+++ b/MdeModulePkg/Core/Dxe/Misc/MemoryProtection.c
@@ -42,9 +42,6 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include "DxeMain.h"
 #include "Mem/HeapGuard.h"
 
-#define CACHE_ATTRIBUTE_MASK   (EFI_MEMORY_UC | EFI_MEMORY_WC | EFI_MEMORY_WT | EFI_MEMORY_WB | EFI_MEMORY_UCE | EFI_MEMORY_WP)
-#define MEMORY_ATTRIBUTE_MASK  (EFI_MEMORY_RP | EFI_MEMORY_XP | EFI_MEMORY_RO)
-
 //
 // Image type definitions
 //
@@ -221,7 +218,7 @@ SetUefiImageMemoryAttributes (
   Status = CoreGetMemorySpaceDescriptor(BaseAddress, &Descriptor);
   ASSERT_EFI_ERROR(Status);
 
-  FinalAttributes = (Descriptor.Attributes & CACHE_ATTRIBUTE_MASK) | (Attributes & MEMORY_ATTRIBUTE_MASK);
+  FinalAttributes = (Descriptor.Attributes & EFI_CACHE_ATTRIBUTE_MASK) | (Attributes & EFI_MEMORY_ATTRIBUTE_MASK);
 
   DEBUG ((DEBUG_INFO, "SetUefiImageMemoryAttributes - 0x%016lx - 0x%016lx (0x%016lx)\n", BaseAddress, Length, FinalAttributes));
 
@@ -924,7 +921,7 @@ InitializeDxeNxMemoryProtectionPolicy (
             (EFI_MEMORY_PRESENT | EFI_MEMORY_INITIALIZED)) {
 
         Attributes = GetPermissionAttributeForMemoryType (EfiConventionalMemory) |
-                     (Entry->Attributes & CACHE_ATTRIBUTE_MASK);
+                     (Entry->Attributes & EFI_CACHE_ATTRIBUTE_MASK);
 
         DEBUG ((DEBUG_INFO,
           "Untested GCD memory space region: - 0x%016lx - 0x%016lx (0x%016lx)\n",

--- a/MdeModulePkg/Core/PiSmmCore/PiSmmIpl.c
+++ b/MdeModulePkg/Core/PiSmmCore/PiSmmIpl.c
@@ -39,12 +39,6 @@
 
 #define SMRAM_CAPABILITIES  (EFI_MEMORY_WB | EFI_MEMORY_UC)
 
-#define MEMORY_CACHE_ATTRIBUTES (EFI_MEMORY_UC | EFI_MEMORY_WC | \
-                                 EFI_MEMORY_WT | EFI_MEMORY_WB | \
-                                 EFI_MEMORY_WP | EFI_MEMORY_UCE)
-
-#define MEMORY_PAGE_ATTRIBUTES  (EFI_MEMORY_XP | EFI_MEMORY_RP | EFI_MEMORY_RO)
-
 //
 // Function prototypes from produced protocols
 //
@@ -1710,7 +1704,7 @@ SmmIplEntry (
     CpuArch = NULL;
     Status = gBS->LocateProtocol (&gEfiCpuArchProtocolGuid, NULL, (VOID **)&CpuArch);
     if (!EFI_ERROR (Status)) {
-      MemDesc.Attributes &= ~(MEMORY_CACHE_ATTRIBUTES | MEMORY_PAGE_ATTRIBUTES);
+      MemDesc.Attributes &= ~(EFI_CACHE_ATTRIBUTE_MASK | EFI_MEMORY_ATTRIBUTE_MASK);
       MemDesc.Attributes |= EFI_MEMORY_WB;
       Status = gDS->SetMemorySpaceAttributes (
                       mSmramCacheBase,
@@ -1727,7 +1721,7 @@ SmmIplEntry (
                &MemDesc
                );
         DEBUG ((DEBUG_INFO, "SMRAM attributes: %016lx\n", MemDesc.Attributes));
-        ASSERT ((MemDesc.Attributes & MEMORY_PAGE_ATTRIBUTES) == 0);
+        ASSERT ((MemDesc.Attributes & EFI_MEMORY_ATTRIBUTE_MASK) == 0);
       );
     }
     //

--- a/MdePkg/Include/Uefi/UefiSpec.h
+++ b/MdePkg/Include/Uefi/UefiSpec.h
@@ -96,9 +96,9 @@ typedef enum {
 #define EFI_MEMORY_SP               0x0000000000040000ULL
 //
 // If this flag is set, the memory region is capable of being
-// protected with the CPU?s memory cryptographic
+// protected with the CPU's memory cryptographic
 // capabilities. If this flag is clear, the memory region is not
-// capable of being protected with the CPU?s memory
+// capable of being protected with the CPU's memory
 // cryptographic capabilities or the CPU does not support CPU
 // memory cryptographic capabilities.
 //
@@ -108,6 +108,12 @@ typedef enum {
 // Runtime memory attribute
 //
 #define EFI_MEMORY_RUNTIME          0x8000000000000000ULL
+
+//
+// Attributes bitmasks, grouped by type
+//
+#define EFI_CACHE_ATTRIBUTE_MASK (EFI_MEMORY_UC | EFI_MEMORY_WC | EFI_MEMORY_WT | EFI_MEMORY_WB | EFI_MEMORY_UCE | EFI_MEMORY_WP)
+#define EFI_MEMORY_ATTRIBUTE_MASK (EFI_MEMORY_RP | EFI_MEMORY_XP | EFI_MEMORY_RO | EFI_MEMORY_SP | EFI_MEMORY_CPU_CRYPTO)
 
 ///
 /// Memory descriptor version number.

--- a/UefiCpuPkg/CpuDxe/CpuDxe.c
+++ b/UefiCpuPkg/CpuDxe/CpuDxe.c
@@ -10,9 +10,6 @@
 #include "CpuMp.h"
 #include "CpuPageTable.h"
 
-#define CACHE_ATTRIBUTE_MASK   (EFI_MEMORY_UC | EFI_MEMORY_WC | EFI_MEMORY_WT | EFI_MEMORY_WB | EFI_MEMORY_UCE | EFI_MEMORY_WP)
-#define MEMORY_ATTRIBUTE_MASK  (EFI_MEMORY_RP | EFI_MEMORY_XP | EFI_MEMORY_RO)
-
 //
 // Global Variables
 //
@@ -417,8 +414,8 @@ CpuSetMemoryAttributes (
     return EFI_SUCCESS;
   }
 
-  CacheAttributes = Attributes & CACHE_ATTRIBUTE_MASK;
-  MemoryAttributes = Attributes & MEMORY_ATTRIBUTE_MASK;
+  CacheAttributes = Attributes & EFI_CACHE_ATTRIBUTE_MASK;
+  MemoryAttributes = Attributes & EFI_MEMORY_ATTRIBUTE_MASK;
 
   if (Attributes != (CacheAttributes | MemoryAttributes)) {
     return EFI_INVALID_PARAMETER;
@@ -677,7 +674,7 @@ SetGcdMemorySpaceAttributes (
     gDS->SetMemorySpaceAttributes (
            RegionStart,
            RegionLength,
-           (MemorySpaceMap[Index].Attributes & ~EFI_MEMORY_CACHETYPE_MASK) | (MemorySpaceMap[Index].Capabilities & Attributes)
+           (MemorySpaceMap[Index].Attributes & ~EFI_CACHE_ATTRIBUTE_MASK) | (MemorySpaceMap[Index].Capabilities & Attributes)
            );
   }
 
@@ -754,7 +751,7 @@ RefreshMemoryAttributesFromMtrr (
     gDS->SetMemorySpaceAttributes (
            MemorySpaceMap[Index].BaseAddress,
            MemorySpaceMap[Index].Length,
-           (MemorySpaceMap[Index].Attributes & ~EFI_MEMORY_CACHETYPE_MASK) |
+           (MemorySpaceMap[Index].Attributes & ~EFI_CACHE_ATTRIBUTE_MASK) |
            (MemorySpaceMap[Index].Capabilities & DefaultAttributes)
            );
   }

--- a/UefiCpuPkg/CpuDxe/CpuDxe.h
+++ b/UefiCpuPkg/CpuDxe/CpuDxe.h
@@ -39,19 +39,6 @@
 #include <Guid/IdleLoopEvent.h>
 #include <Guid/VectorHandoffTable.h>
 
-#define EFI_MEMORY_CACHETYPE_MASK     (EFI_MEMORY_UC  | \
-                                       EFI_MEMORY_WC  | \
-                                       EFI_MEMORY_WT  | \
-                                       EFI_MEMORY_WB  | \
-                                       EFI_MEMORY_UCE | \
-                                       EFI_MEMORY_WP    \
-                                       )
-
-#define EFI_MEMORY_PAGETYPE_MASK      (EFI_MEMORY_RP  | \
-                                       EFI_MEMORY_XP  | \
-                                       EFI_MEMORY_RO    \
-                                       )
-
 #define HEAP_GUARD_NONSTOP_MODE       \
         ((PcdGet8 (PcdHeapGuardPropertyMask) & (BIT6|BIT4|BIT1|BIT0)) > BIT6)
 

--- a/UefiCpuPkg/CpuDxe/CpuDxe.h
+++ b/UefiCpuPkg/CpuDxe/CpuDxe.h
@@ -43,7 +43,8 @@
                                        EFI_MEMORY_WC  | \
                                        EFI_MEMORY_WT  | \
                                        EFI_MEMORY_WB  | \
-                                       EFI_MEMORY_UCE   \
+                                       EFI_MEMORY_UCE | \
+                                       EFI_MEMORY_WP    \
                                        )
 
 #define EFI_MEMORY_PAGETYPE_MASK      (EFI_MEMORY_RP  | \

--- a/UefiCpuPkg/CpuDxe/CpuPageTable.c
+++ b/UefiCpuPkg/CpuDxe/CpuPageTable.c
@@ -717,7 +717,7 @@ ConvertMemoryPageAttributes (
     return RETURN_INVALID_PARAMETER;
   }
 
-  if ((Attributes & ~(EFI_MEMORY_RP | EFI_MEMORY_RO | EFI_MEMORY_XP)) != 0) {
+  if ((Attributes & ~EFI_MEMORY_ATTRIBUTE_MASK) != 0) {
     DEBUG ((DEBUG_ERROR, "Attributes(0x%lx) has unsupported bit\n", Attributes));
     return EFI_UNSUPPORTED;
   }
@@ -1018,9 +1018,9 @@ RefreshGcdMemoryAttributesFromPaging (
 
       Length = MIN (PageLength, MemorySpaceLength);
       if (Attributes != (MemorySpaceMap[Index].Attributes &
-                         EFI_MEMORY_PAGETYPE_MASK)) {
+                         EFI_MEMORY_ATTRIBUTE_MASK)) {
         NewAttributes = (MemorySpaceMap[Index].Attributes &
-                         ~EFI_MEMORY_PAGETYPE_MASK) | Attributes;
+                         ~EFI_MEMORY_ATTRIBUTE_MASK) | Attributes;
         Status = gDS->SetMemorySpaceAttributes (
                         BaseAddress,
                         Length,

--- a/UefiCpuPkg/PiSmmCpuDxeSmm/SmmCpuMemoryManagement.c
+++ b/UefiCpuPkg/PiSmmCpuDxeSmm/SmmCpuMemoryManagement.c
@@ -435,7 +435,7 @@ ConvertMemoryPageAttributes (
   EFI_PHYSICAL_ADDRESS              MaximumSupportMemAddress;
 
   ASSERT (Attributes != 0);
-  ASSERT ((Attributes & ~(EFI_MEMORY_RP | EFI_MEMORY_RO | EFI_MEMORY_XP)) == 0);
+  ASSERT ((Attributes & ~EFI_MEMORY_ATTRIBUTE_MASK) == 0);
 
   ASSERT ((BaseAddress & (SIZE_4KB - 1)) == 0);
   ASSERT ((Length & (SIZE_4KB - 1)) == 0);


### PR DESCRIPTION
https://edk2.groups.io/g/devel/message/61992
http://mid.mail-archive.com/20200702205039.52400-1-oleksiyy@ami.com
~~~
This series of patches add usage of new memory
attributes EFI_MEMORY_SP and EFI_MEMORY_CPU_CRYPTO,
introduced in UEFI2.8 (mantis 1919 and 1872).
First patch fix typos in description and introduce two
bitmasks for all memory type attributes.
Second and fourth patches get rid of multiple memory attributes
bitmasks definitions trough multiple files and headers,
and replace them with new common definitions from MdePkg.
Third patch includes WP attribute into cache type mask in
CpuDexe.h to make next change in this file more clear.

Oleksiy Yakovlev (4):
  MdePkg: Add New Memory Attributes
  MdeModulePkg: Add New Memory Attributes
  UefiCpuPkg: Update EFI_MEMORY_CACHETYPE_MASK definition
  UefiCpuPkg: Add New Memory Attributes

 MdeModulePkg/Core/Dxe/Gcd/Gcd.c                    | 11 ++---------
 MdeModulePkg/Core/Dxe/Mem/Page.c                   |  9 +++------
 MdeModulePkg/Core/Dxe/Misc/MemoryProtection.c      |  7 ++-----
 MdeModulePkg/Core/PiSmmCore/PiSmmIpl.c             | 10 ++--------
 MdePkg/Include/Uefi/UefiSpec.h                     | 10 ++++++++--
 UefiCpuPkg/CpuDxe/CpuDxe.c                         | 11 ++++-------
 UefiCpuPkg/CpuDxe/CpuDxe.h                         | 12 ------------
 UefiCpuPkg/CpuDxe/CpuPageTable.c                   |  6 +++---
 UefiCpuPkg/PiSmmCpuDxeSmm/SmmCpuMemoryManagement.c |  2 +-
 9 files changed, 25 insertions(+), 53 deletions(-)
~~~
