### PR TITLE
[edk2-devel] [PATCH 1/1] OvmfPkg/OvmfPkg.dec: Adjust PcdMptScsiStallPerPollUsec -- push

### DIFF
--- a/OvmfPkg/OvmfPkg.dec
+++ b/OvmfPkg/OvmfPkg.dec
@@ -172,7 +172,7 @@
   gUefiOvmfPkgTokenSpaceGuid.PcdMptScsiMaxTargetLimit|7|UINT8|0x39
 
   ## Microseconds to stall between polling for MptScsi request result
-  gUefiOvmfPkgTokenSpaceGuid.PcdMptScsiStallPerPollUsec|5|UINT32|0x40
+  gUefiOvmfPkgTokenSpaceGuid.PcdMptScsiStallPerPollUsec|5|UINT32|0x3a
 
   gUefiOvmfPkgTokenSpaceGuid.PcdOvmfFlashNvStorageEventLogBase|0x0|UINT32|0x8
   gUefiOvmfPkgTokenSpaceGuid.PcdOvmfFlashNvStorageEventLogSize|0x0|UINT32|0x9


### PR DESCRIPTION
https://edk2.groups.io/g/devel/message/62596
http://mid.mail-archive.com/20200715082031.30978-1-glin@suse.com
~~~
OvmfPkg/OvmfPkg.dec: Adjust PcdMptScsiStallPerPollUsec token value

The token value of PcdMptScsiStallPerPollUsec should be 0x3a since the
previous token value is 0x39.

Cc: Jordan Justen <jordan.l.justen@intel.com>
Cc: Laszlo Ersek <lersek@redhat.com>
Cc: Ard Biesheuvel <ard.biesheuvel@arm.com>
Cc: Liran Alon <liran.alon@oracle.com>
Cc: Nikita Leshenko <nikita.leshchenko@oracle.com>
Signed-off-by: Gary Lin <glin@suse.com>
Message-Id: <20200715082031.30978-1-glin@suse.com>
Reviewed-by: Liran Alon <liran.alon@oracle.com>
[lersek@redhat.com: clarify subject, fix typos in commit message]
Reviewed-by: Laszlo Ersek <lersek@redhat.com>
~~~