### PR TITLE
BaseTools: Add Guid name support in GenFfs.

### DIFF
--- a/BaseTools/Source/Python/AutoGen/WorkspaceAutoGen.py
+++ b/BaseTools/Source/Python/AutoGen/WorkspaceAutoGen.py
@@ -108,6 +108,10 @@ class WorkspaceAutoGen(AutoGen):
         #
         # Mark now build in AutoGen Phase
         #
+        #
+        # Collect Platform Guids to support Guid name in Fdfparser.
+        #
+        self.CollectPlatformGuids()
         GlobalData.gAutoGenPhase = True
         self.ProcessModuleFromPdf()
         self.ProcessPcdType()
@@ -153,6 +157,26 @@ class WorkspaceAutoGen(AutoGen):
             EdkLogger.error("build", PARAMETER_INVALID,
                             ExtraData="Build target [%s] is not supported by the platform. [Valid target: %s]"
                                       % (self.BuildTarget, " ".join(self.Platform.BuildTargets)))
+
+    def CollectPlatformGuids(self):
+        oriInfList = []
+        oriPkgSet = set()
+        PlatformPkg = set()
+        for Arch in self.ArchList:
+            Platform = self.BuildDatabase[self.MetaFile, Arch, self.BuildTarget, self.ToolChain]
+            oriInfList = Platform.Modules
+            for ModuleFile in oriInfList:
+                ModuleData = self.BuildDatabase[ModuleFile, Platform._Arch, Platform._Target, Platform._Toolchain]
+                oriPkgSet.update(ModuleData.Packages)
+                for Pkg in oriPkgSet:
+                    Guids = Pkg.Guids
+                    GlobalData.gGuidDict.update(Guids)
+            if Platform.Packages:
+                PlatformPkg.update(Platform.Packages)
+                for Pkg in PlatformPkg:
+                    Guids = Pkg.Guids
+                    GlobalData.gGuidDict.update(Guids)
+
     @cached_property
     def FdfProfile(self):
         if not self.FdfFile:

--- a/BaseTools/Source/Python/Common/GlobalData.py
+++ b/BaseTools/Source/Python/Common/GlobalData.py
@@ -29,6 +29,7 @@ gProcessingFile = ''
 gBuildingModule = ''
 gSkuids = []
 gDefaultStores = []
+gGuidDict = {}
 
 # definition for a MACRO name.  used to create regular expressions below.
 _MacroNamePattern = "[A-Z][A-Z0-9_]*"

--- a/BaseTools/Source/Python/GenFds/FdfParser.py
+++ b/BaseTools/Source/Python/GenFds/FdfParser.py
@@ -18,7 +18,7 @@ from uuid import UUID
 
 from Common.BuildToolError import *
 from Common import EdkLogger
-from Common.Misc import PathClass, tdict, ProcessDuplicatedInf
+from Common.Misc import PathClass, tdict, ProcessDuplicatedInf, GuidStructureStringToGuidString
 from Common.StringUtils import NormPath, ReplaceMacro
 from Common import GlobalData
 from Common.Expression import *
@@ -1086,6 +1086,8 @@ class FdfParser:
         if not self._GetNextToken():
             return False
         if GlobalData.gGuidPattern.match(self._Token) is not None:
+            return True
+        elif self._Token in GlobalData.gGuidDict:
             return True
         else:
             self._UndoToken()
@@ -2248,6 +2250,8 @@ class FdfParser:
 
         if not self._GetNextGuid():
             raise Warning.Expected("GUID value", self.FileName, self.CurrentLineNumber)
+        if self._Token in GlobalData.gGuidDict:
+            self._Token = GuidStructureStringToGuidString(GlobalData.gGuidDict[self._Token]).upper()
 
         FvObj.FvNameGuid = self._Token
 
@@ -2459,6 +2463,8 @@ class FdfParser:
                 raise Warning.ExpectedEquals(self.FileName, self.CurrentLineNumber)
             if not self._GetNextGuid():
                 raise Warning.Expected("GUID value", self.FileName, self.CurrentLineNumber)
+            if self._Token in GlobalData.gGuidDict:
+                self._Token = GuidStructureStringToGuidString(GlobalData.gGuidDict[self._Token]).upper()
             FfsInfObj.OverrideGuid = self._Token
 
         if self._IsKeyword("RuleOverride"):
@@ -2550,6 +2556,8 @@ class FdfParser:
                     raise Warning.Expected("')'", self.FileName, self.CurrentLineNumber)
                 self._Token = 'PCD('+PcdPair[1]+TAB_SPLIT+PcdPair[0]+')'
 
+        if self._Token in GlobalData.gGuidDict:
+            self._Token = GuidStructureStringToGuidString(GlobalData.gGuidDict[self._Token]).upper()
         FfsFileObj.NameGuid = self._Token
 
         self._GetFilePart(FfsFileObj)
@@ -2980,6 +2988,8 @@ class FdfParser:
         elif self._IsKeyword("GUIDED"):
             GuidValue = None
             if self._GetNextGuid():
+                if self._Token in GlobalData.gGuidDict:
+                    self._Token = GuidStructureStringToGuidString(GlobalData.gGuidDict[self._Token]).upper()
                 GuidValue = self._Token
 
             AttribDict = self._GetGuidAttrib()
@@ -4049,6 +4059,8 @@ class FdfParser:
         elif self._IsKeyword("GUIDED"):
             GuidValue = None
             if self._GetNextGuid():
+                if self._Token in GlobalData.gGuidDict:
+                    self._Token = GuidStructureStringToGuidString(GlobalData.gGuidDict[self._Token]).upper()
                 GuidValue = self._Token
 
             if self._IsKeyword("$(NAMED_GUID)"):


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=2762

The Fv Section in the FDF files use hard coding Guid values
which is inconvenient to manage. This patch adds Guid name
support in GenFfs to solve this problem.

Signed-off-by: Yuwei Chen <yuwei.chen@intel.com>
Reviewed-by: Bob Feng<bob.c.feng@intel.com>