### PR TITLE
BaseTools/PatchCheck.py: Skip length check for user name in xxx-by

### DIFF
--- a/BaseTools/Scripts/PatchCheck.py
+++ b/BaseTools/Scripts/PatchCheck.py
@@ -268,7 +268,14 @@ class CommitMessageCheck:
         for i in range(2, count):
             if (len(lines[i]) >= 76 and
                 len(lines[i].split()) > 1 and
-                not lines[i].startswith('git-svn-id:')):
+                not lines[i].startswith('git-svn-id:') and
+                not lines[i].startswith('Reviewed-by') and
+                not lines[i].startswith('Acked-by:') and
+                not lines[i].startswith('Tested-by:') and
+                not lines[i].startswith('Reported-by:') and
+                not lines[i].startswith('Suggested-by:') and
+                not lines[i].startswith('Signed-off-by:') and
+                not lines[i].startswith('Cc:')):
                 #
                 # Print a warning if body line is longer than 75 characters
                 #


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=2836
Current PatchCheck.py checks each line to ensure line's length is not
larger than 76. But there's a case that length of user's name is much
longer than that number. So enhance the script to handle this case.

Cc: Bob Feng <bob.c.feng@intel.com>
Cc: Liming Gao <liming.gao@intel.com>
Signed-off-by: Shenglei Zhang <shenglei.zhang@intel.com>
Reviewed-by: Yuwei Chen<yuwei.chen@intel.com>
Reviewed-by: Liming Gao <liming.gao@intel.com>