### PR TITLE
MdeModulePkg/DxeCorePerformanceLib: Switch to UnicodeStrnToAsciiStrS

### DIFF
--- a/MdeModulePkg/Library/DxeCorePerformanceLib/DxeCorePerformanceLib.c
+++ b/MdeModulePkg/Library/DxeCorePerformanceLib/DxeCorePerformanceLib.c
@@ -837,7 +837,7 @@ GetDeviceInfoFromHandleAndUpdateLength (
       ControllerNameStringSize = FPDT_MAX_PERF_RECORD_SIZE - (*Length) - 1;
     }
 
-    UnicodeStrToAsciiStrS(StringPtr, ComponentNameString, ControllerNameStringSize);
+    UnicodeStrnToAsciiStrS(StringPtr, ControllerNameStringSize - 1, ComponentNameString, ControllerNameStringSize, &ControllerNameStringSize);
 
     //
     // Add a space in the end of the ControllerName
@@ -879,7 +879,7 @@ GetDeviceInfoFromHandleAndUpdateLength (
         AsciiStringPtr = ComponentNameString;
       }
 
-      UnicodeStrToAsciiStrS(StringPtr, AsciiStringPtr, DevicePathStringSize);
+      UnicodeStrnToAsciiStrS(StringPtr, DevicePathStringSize - 1, AsciiStringPtr, DevicePathStringSize, &DevicePathStringSize);
       *Length += (UINT8)DevicePathStringSize;
       return EFI_SUCCESS;
     }


### PR DESCRIPTION
UnicodeStrToAsciiStrS requires that the source string is shorter than
the destination buffer and will ASSERT if this is not true. Switch to
UnicodeStrnToAsciiStrS as there are cases where the source string is
longer than the buffer allocated for the device path.

Signed-off-by: Jeff Brasen <jbrasen@nvidia.com>
Reviewed-by: Dandan Bi <dandan.bi@intel.com>