### PR TITLE
BaseTools: Fix binary file not generate map file issue

### DIFF
--- a/BaseTools/Source/Python/GenFds/EfiSection.py
+++ b/BaseTools/Source/Python/GenFds/EfiSection.py
@@ -268,7 +268,7 @@ class EfiSection (EfiSectionClassObject):
                         else:
                             Align = str (ImageObj.SectionAlignment // 0x100000) + 'M'
 
-                    if File[(len(File)-4):] == '.efi':
+                    if File[(len(File)-4):] == '.efi' and FfsInf.InfModule.BaseName == os.path.basename(File)[:-4]:
                         MapFile = File.replace('.efi', '.map')
                         CopyMapFile = os.path.join(OutputPath, ModuleName + '.map')
                         if IsMakefile:


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=2624

When EFI file come from binary file, not generate .map file, so need ignore the map file.

Cc: Bob Feng <bob.c.feng@intel.com>
Cc: Liming Gao <liming.gao@intel.com>
Signed-off-by: Yunhua Feng <yunhuax.feng@intel.com>

Reviewed-by: Bob Feng <bob.c.feng@intel.com>