### PR TITLE
BaseTools/Scripts: Ignore the CRLF check when upgrade submodule.

### DIFF
--- a/BaseTools/Scripts/PatchCheck.py
+++ b/BaseTools/Scripts/PatchCheck.py
@@ -502,7 +502,7 @@ class GitDiffCheck:
 
         stripped = line.rstrip()
 
-        if self.force_crlf and eol != '\r\n':
+        if self.force_crlf and eol != '\r\n' and (line.find('Subproject commit') == -1):
             self.added_line_error('Line ending (%s) is not CRLF' % repr(eol),
                                   line)
         if self.force_notabs and '\t' in line:


### PR DESCRIPTION
If the submodule is upgraded, skip the CRLF check as it isn't change for
file.

Signed-off-by: Guomin Jiang <guomin.jiang@intel.com>
Cc: Bob Feng <bob.c.feng@intel.com>
Cc: Liming Gao <liming.gao@intel.com>

Reviewed-by: Bob Feng <bob.c.feng@intel.com>