### PR TITLE
IntelFsp2Pkg/Tools/GenCfgOpt.py: Fix a bug about parse macro

### DIFF
--- a/IntelFsp2Pkg/Tools/GenCfgOpt.py
+++ b/IntelFsp2Pkg/Tools/GenCfgOpt.py
@@ -546,11 +546,11 @@ EndList
                 #DEFINE FSP_T_UPD_TOOL_GUID = 34686CA3-34F9-4901-B82A-BA630F0714C6
                 #DEFINE FSP_M_UPD_TOOL_GUID = 39A250DB-E465-4DD1-A2AC-E2BD3C0E2385
                 #DEFINE FSP_S_UPD_TOOL_GUID = CAE3605B-5B34-4C85-B3D7-27D54273C40F
-                Match = re.match("^\s*(?:DEFINE\s+)*(\w+)\s*=\s*([-.\w]+)", DscLine)
+                Match = re.match("^\s*(?:DEFINE\s+)*(\w+)\s*=\s*([/$()-.\w]+)", DscLine)
                 if Match:
-                    self._MacroDict[Match.group(1)] = Match.group(2)
+                    self._MacroDict[Match.group(1)] = self.ExpandMacros(Match.group(2))
                     if self.Debug:
-                        print ("INFO : DEFINE %s = [ %s ]" % (Match.group(1), Match.group(2)))
+                        print ("INFO : DEFINE %s = [ %s ]" % (Match.group(1), self.ExpandMacros(Match.group(2))))
             elif IsPcdSect:
                 #gSiPkgTokenSpaceGuid.PcdTxtEnable|FALSE
                 #gSiPkgTokenSpaceGuid.PcdOverclockEnable|TRUE


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=2827

Fix a bug about parse the macro value which use another macro.

Use the following example to verify:
[Define]
  DEFINE M1 = V1
  DEFINE M2 = $(M1)/V2

  !include $(M2)/pcd.dsc

The old code will failed parse M2 and cause following error:
Traceback (most recent call last):
  File "Edk2\IntelFsp2Pkg\Tools\GenCfgOpt.py", line 1550, in <module>
    sys.exit(Main())
  File "Edk2\IntelFsp2Pkg\Tools\GenCfgOpt.py", line 1513, in Main
    if GenCfgOpt.ParseDscFile(DscFile, FvDir) != 0:
  File "Edk2\IntelFsp2Pkg\Tools\GenCfgOpt.py", line 533, in ParseDscFile
    NewDscLines = IncludeDsc.readlines()
ValueError: I/O operation on closed file.

The tool should support the value use another macro, and expand it.

Cc: Chasel Chiu <chasel.chiu@intel.com>
Cc: Nate DeSimone <nathaniel.l.desimone@intel.com>
Cc: Star Zeng <star.zeng@intel.com>
Signed-off-by: Ming Tan <ming.tan@intel.com>
Reviewed-by: Chasel Chiu <chasel.chiu@intel.com>