### PR TITLE
MdePkg Base.h: Delete prototype for __builtin_return_address

### DIFF
--- a/MdePkg/Include/Base.h
+++ b/MdePkg/Include/Base.h
@@ -1273,7 +1273,6 @@ typedef UINTN RETURN_STATUS;
   **/
   #define RETURN_ADDRESS(L)     ((L == 0) ? _ReturnAddress() : (VOID *) 0)
 #elif defined (__GNUC__) || defined (__clang__)
-  void * __builtin_return_address (unsigned int level);
   /**
     Get the return address of the calling function.
 


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=1004

Being a compiler builtin, the type of __builtin_return_address is
already known to the compiler so no prototype is needed. Clang also
errors out when redeclaring certain builtins like this[1], though
currently only for ones with custom type checking. At the moment,
__builtin_return_address does not use custom type checking and so does
not trigger this error, however, the CHERI fork of LLVM, which will form
the basis of the toolchain for Arm's experimental Morello platform, does
use custom type checking for it, and so gives an error. Thus, simply
delete the unnecessary line.

[1] llvm/llvm-project@41af97137572ad6d4dafc872e7ecf6bbb08d4984

Cc: Leif Lindholm <leif@nuviainc.com>
Signed-off-by: Jessica Clarke <jrtc27@jrtc27.com>
Reviewed-by: Liming Gao <liming.gao@intel.com>
Reviewed-by: Zhiguang Liu <zhiguang.liu@intel.com>
Reviewed-by: Leif Lindholm <leif@nuviainc.com>