### PR TITLE
BaseTools/PeCoffLoaderEx: Remove the unused local variable

### DIFF
--- a/BaseTools/Source/C/Common/PeCoffLoaderEx.c
+++ b/BaseTools/Source/C/Common/PeCoffLoaderEx.c
@@ -127,10 +127,7 @@ PeCoffLoaderRelocateRiscVImage (
 {
   UINT32 Value;
   UINT32 Value2;
-  UINT32 OrgValue;
 
-  OrgValue = *(UINT32 *) Fixup;
-  OrgValue = OrgValue;
   switch ((*Reloc) >> 12) {
   case EFI_IMAGE_REL_BASED_RISCV_HI20:
       RiscVHi20Fixup = (UINT32 *) Fixup;


### PR DESCRIPTION
BZ:2864 GCC build fails due to variable self assignment.

This local variable is not used at any where, we can just remove it.

Signed-off-by: Abner Chang <abner.chang@hpe.com>

Cc: Bob Feng <bob.c.feng@intel.com>
Cc: Liming Gao <liming.gao@intel.com>
Cc: Daniel Schaefer <daniel.schaefer@hpe.com>
Reviewed-by: Liming Gao <liming.gao@intel.com>