### PR TITLE
EmbeddedPkg/TimeBaseLib: Add macros to get build year/month/day

### DIFF
--- a/EmbeddedPkg/Include/Library/TimeBaseLib.h
+++ b/EmbeddedPkg/Include/Library/TimeBaseLib.h
@@ -12,6 +12,38 @@
 
 #include <Uefi/UefiBaseType.h>
 
+//
+// Convenience macros to obtain a build date
+//
+// These macros should work for any compiler that follows ISO/IEC 9899,
+// in which case __DATE__ is defined as a "Mmm dd yyyy" 11 chars string,
+// but add an explicit filter for compilers that have been validated.
+//
+#if (defined(__GNUC__) || defined(_MSC_VER) || defined(__clang__))
+#define TIME_BUILD_YEAR  (__DATE__[7] == '?' ? 1900 \
+          : (((__DATE__[7] - '0') * 1000 )          \
+          + (__DATE__[8] - '0') * 100               \
+          + (__DATE__[9] - '0') * 10                \
+          + __DATE__[10] - '0'))
+#define TIME_BUILD_MONTH ( __DATE__ [2] == '?' ? 1  \
+          : __DATE__ [2] == 'n' ? (                 \
+            __DATE__ [1] == 'a' ? 1 : 6)            \
+          : __DATE__ [2] == 'b' ? 2                 \
+          : __DATE__ [2] == 'r' ? (                 \
+            __DATE__ [0] == 'M' ? 3 : 4)            \
+          : __DATE__ [2] == 'y' ? 5                 \
+          : __DATE__ [2] == 'l' ? 7                 \
+          : __DATE__ [2] == 'g' ? 8                 \
+          : __DATE__ [2] == 'p' ? 9                 \
+          : __DATE__ [2] == 't' ? 10                \
+          : __DATE__ [2] == 'v' ? 11                \
+          : 12)
+#define TIME_BUILD_DAY ( __DATE__[4] == '?' ? 1     \
+          : ((__DATE__[4] == ' ' ? 0 :              \
+            ((__DATE__[4] - '0') * 10))             \
+          + __DATE__[5] - '0'))
+#endif
+
 // Define EPOCH (1970-JANUARY-01) in the Julian Date representation
 #define EPOCH_JULIAN_DATE                               2440588
 


### PR DESCRIPTION
These can be used, for instance, to automate the population of an SMBIOS
Type 0 BIOS Release Date when building a UEFI firmware (which is how we
plan to use these macros for the Raspberry Pi platform).

These macros should work for any compiler that follows ISO/IEC 9899, but
we add a check for the compiler we have tested to be on the safe side.

Note that we decided against adding a #error or #warn for compilers that
haven't been validated, as we don't want to introduce breakage for people
who may already be using the header with something else than gcc, MSVC or
Clang. Instead, we expect those to send a patch that adds their compiler
to the list, once they have tested the macros there.

Signed-off-by: Pete Batard <pete@akeo.ie>
Reviewed-by: Leif Lindholm <leif@nuviainc.com>