### PR TITLE
BaseTools/GenSec: Fix spelling mistake

### DIFF
--- a/BaseTools/Source/C/GenSec/GenSec.c
+++ b/BaseTools/Source/C/GenSec/GenSec.c
@@ -177,7 +177,7 @@ Returns:
   fprintf (stdout, "  -l GuidHeaderLength, --HeaderLength GuidHeaderLength\n\
                         GuidHeaderLength is the size of header of guided data\n");
   fprintf (stdout, "  -r GuidAttr, --attributes GuidAttr\n\
-                        GuidAttr is guid section atttributes, which may be\n\
+                        GuidAttr is guid section attributes, which may be\n\
                         PROCESSING_REQUIRED, AUTH_STATUS_VALID and NONE. \n\
                         if -r option is not given, default PROCESSING_REQUIRED\n");
   fprintf (stdout, "  -n String, --name String\n\


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=2345

Cc: Bob Feng <bob.c.feng@intel.com>
Cc: Liming Gao <liming.gao@intel.com>
Signed-off-by: Michael D Kinney <michael.d.kinney@intel.com>
Reviewed-by: Liming Gao <liming.gao@intel.com>