### PR TITLE
ShellPkg: smbiosview - Change some type 17 field values format

### DIFF
--- a/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/PrintInfo.c
+++ b/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/PrintInfo.c
@@ -746,8 +746,8 @@ SmbiosPrintStructure (
   case 17:
     PRINT_STRUCT_VALUE_H (Struct, Type17, MemoryArrayHandle);
     PRINT_STRUCT_VALUE_H (Struct, Type17, MemoryErrorInformationHandle);
-    PRINT_STRUCT_VALUE (Struct, Type17, TotalWidth);
-    PRINT_STRUCT_VALUE (Struct, Type17, DataWidth);
+    PRINT_STRUCT_VALUE_H (Struct, Type17, TotalWidth);
+    PRINT_STRUCT_VALUE_H (Struct, Type17, DataWidth);
     PRINT_STRUCT_VALUE (Struct, Type17, Size);
     DisplayMemoryDeviceFormFactor (Struct->Type17->FormFactor, Option);
     PRINT_STRUCT_VALUE_H (Struct, Type17, DeviceSet);
@@ -765,7 +765,7 @@ SmbiosPrintStructure (
     }
     if (AE_SMBIOS_VERSION (0x2, 0x7) && (Struct->Hdr->Length > 0x1C)) {
       PRINT_STRUCT_VALUE (Struct, Type17, ExtendedSize);
-      PRINT_STRUCT_VALUE (Struct, Type17, ConfiguredMemoryClockSpeed);
+      PRINT_STRUCT_VALUE_H (Struct, Type17, ConfiguredMemoryClockSpeed);
     }
     if (AE_SMBIOS_VERSION (0x2, 0x8) && (Struct->Hdr->Length > 0x22)) {
       PRINT_STRUCT_VALUE (Struct, Type17, MinimumVoltage);
@@ -783,16 +783,16 @@ SmbiosPrintStructure (
         PRINT_STRUCT_VALUE_H (Struct, Type17, MemorySubsystemControllerProductID);
       }
       if (Struct->Hdr->Length > 0x34) {
-        PRINT_STRUCT_VALUE_H (Struct, Type17, NonVolatileSize);
+        PRINT_STRUCT_VALUE_LH (Struct, Type17, NonVolatileSize);
       }
       if (Struct->Hdr->Length > 0x3C) {
-        PRINT_STRUCT_VALUE_H (Struct, Type17, VolatileSize);
+        PRINT_STRUCT_VALUE_LH (Struct, Type17, VolatileSize);
       }
       if (Struct->Hdr->Length > 0x44) {
-        PRINT_STRUCT_VALUE_H (Struct, Type17, CacheSize);
+        PRINT_STRUCT_VALUE_LH (Struct, Type17, CacheSize);
       }
       if (Struct->Hdr->Length > 0x4C) {
-        PRINT_STRUCT_VALUE_H (Struct, Type17, LogicalSize);
+        PRINT_STRUCT_VALUE_LH (Struct, Type17, LogicalSize);
       }
     }
     break;


### PR DESCRIPTION
Change how some SMBIOS TYpe 17 field values are printed:

 - TotalWidth, DataWidth, ConfiguredMemoryClockSpeed: Print as
   hex values instead of decimal, since there are some special meanings
   for certain values (e.g. 0xFFFF)
 - VolatileSize, NonVolatileSize, CacheSize, and LogicalSize: Print
   as "0x%lx" instead of "0x%x" to prevent truncating output when
   printing these QWORD fields.

Cc: Ray Ni <ray.ni@intel.com>
Cc: Zhichao Gao <zhichao.gao@intel.com>
Cc: Sami Mujawar <Sami.Mujawar@arm.com>
Signed-off-by: Samer El-Haj-Mahmoud <samer.el-haj-mahmoud@arm.com>
Reviewed-by: Zhichao Gao <zhichao.gao@intel.com>