### PR TITLE
FmpDevicePkg/FmpDxe: Fix Clang build error

### DIFF
--- a/FmpDevicePkg/FmpDxe/FmpDxe.c
+++ b/FmpDevicePkg/FmpDxe/FmpDxe.c
@@ -1043,6 +1043,7 @@ SetTheImage (
   UINT32                            DependenciesSize;
 
   Status             = EFI_SUCCESS;
+  Private            = NULL;
   Updateable         = 0;
   BooleanValue       = FALSE;
   FmpHeaderSize      = 0;
@@ -1293,7 +1294,10 @@ SetTheImage (
 
 cleanup:
   mProgressFunc = NULL;
-  SetLastAttemptStatusInVariable (Private, LastAttemptStatus);
+
+  if (Private != NULL) {
+    SetLastAttemptStatusInVariable (Private, LastAttemptStatus);
+  }
 
   if (Progress != NULL) {
     //
@@ -1306,7 +1310,9 @@ cleanup:
   // Need repopulate after SetImage is called to
   // update LastAttemptVersion and LastAttemptStatus.
   //
-  Private->DescriptorPopulated = FALSE;
+  if (Private != NULL) {
+    Private->DescriptorPopulated = FALSE;
+  }
 
   return Status;
 }


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=2887

The local Private pointer variable in SetTheImage() is initialized
based on the caller provided This pointer argument. The cleanup
label path uses the Private pointer which will not be
initialized if This is NULL.

This change initializes Private to NULL and accounts for Private
potentially being NULL in the cleanup label path.

Cc: Liming Gao <liming.gao@intel.com>
Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Guomin Jiang <guomin.jiang@intel.com>
Cc: Wei6 Xu <wei6.xu@intel.com>
Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>
Tested-by: Liming Gao <liming.gao@intel.com>
Reviewed-by: Liming Gao <liming.gao@intel.com>
Reviewed-by: Guomin Jiang <guomin.jiang@intel.com>