### PR TITLE
BaseTools: Move CreateAsBuiltInf into AutoGenWorker for parallel

### DIFF
--- a/BaseTools/Source/Python/AutoGen/AutoGenWorker.py
+++ b/BaseTools/Source/Python/AutoGen/AutoGenWorker.py
@@ -280,7 +280,7 @@ class AutoGenWorkerInProcess(mp.Process):
 
                 Ma.CreateCodeFile(False)
                 Ma.CreateMakeFile(False,GenFfsList=FfsCmd.get((Ma.MetaFile.Path, Ma.Arch),[]))
-
+                Ma.CreateAsBuiltInf()
                 if GlobalData.gBinCacheSource and CommandTarget in [None, "", "all"]:
                     try:
                         CacheResult = Ma.CanSkipbyMakeCache()

--- a/BaseTools/Source/Python/build/build.py
+++ b/BaseTools/Source/Python/build/build.py
@@ -873,7 +873,7 @@ class Build():
 
                     PcdMa.CreateCodeFile(False)
                     PcdMa.CreateMakeFile(False,GenFfsList = DataPipe.Get("FfsCommand").get((PcdMa.MetaFile.Path, PcdMa.Arch),[]))
-
+                    PcdMa.CreateAsBuiltInf()
                     # Force cache miss for PCD driver
                     if GlobalData.gBinCacheSource and self.Target in [None, "", "all"]:
                         cqueue.put((PcdMa.MetaFile.Path, PcdMa.Arch, "MakeCache", False))
@@ -1265,7 +1265,6 @@ class Build():
         if BuildModule:
             BuildCommand = BuildCommand + [Target]
             LaunchCommand(BuildCommand, AutoGenObject.MakeFileDir)
-            self.CreateAsBuiltInf()
             if GlobalData.gBinCacheDest:
                 self.GenDestCache()
             elif GlobalData.gUseHashCache and not GlobalData.gBinCacheSource:
@@ -2276,7 +2275,6 @@ class Build():
                 #
                 ExitFlag.set()
                 BuildTask.WaitForComplete()
-                self.CreateAsBuiltInf()
                 if GlobalData.gBinCacheDest:
                     self.GenDestCache()
                 elif GlobalData.gUseHashCache and not GlobalData.gBinCacheSource:


### PR DESCRIPTION
AsBuiltInf can be created during AutoGen phase. Move CreateAsBuiltInf
into AutoGenWorker to make this step run in parallel.

Signed-off-by: Bob Feng <bob.c.feng@intel.com>
Cc: Liming Gao <liming.gao@intel.com>
Cc: Yuwei Chen <yuwei.chen@intel.com>
Reviewed-by: Jaben Carsey <jaben.carsey@intel.com>
Reviewed-by: Bob Feng <bob.c.feng@intel.com>