### PR TITLE
BaseTools: Fix the issue in VS prefix setting for VS2017/VS2019

### DIFF
--- a/BaseTools/set_vsprefix_envs.bat
+++ b/BaseTools/set_vsprefix_envs.bat
@@ -110,6 +110,9 @@ if /I "%1"=="VS2015" goto SetWinDDK
 
 :SetVS2017
 if not defined VS150COMNTOOLS (
+  @REM clear two envs so that vcvars32.bat can run successfully.
+  set VSINSTALLDIR=
+  set VCToolsVersion=
   if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" (
     if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\BuildTools" (
       call "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -products Microsoft.VisualStudio.Product.BuildTools -version 15,16 > vswhereInfo
@@ -166,6 +169,9 @@ if not defined WINSDK_PATH_FOR_RC_EXE (
 
 :SetVS2019
 if not defined VS160COMNTOOLS (
+  @REM clear two envs so that vcvars32.bat can run successfully.
+  set VSINSTALLDIR=
+  set VCToolsVersion=
   if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" (
     if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools" (
       call "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -products Microsoft.VisualStudio.Product.BuildTools -version 16,17 > vswhereInfo

--- a/BaseTools/set_vsprefix_envs.bat
+++ b/BaseTools/set_vsprefix_envs.bat
@@ -167,6 +167,8 @@ if not defined WINSDK_PATH_FOR_RC_EXE (
   )
 )
 
+if /I "%1"=="VS2017" goto SetWinDDK
+
 :SetVS2019
 if not defined VS160COMNTOOLS (
   @REM clear two envs so that vcvars32.bat can run successfully.
@@ -225,6 +227,8 @@ if not defined WINSDK_PATH_FOR_RC_EXE (
     set "WINSDK_PATH_FOR_RC_EXE=%WINSDK10_PREFIX%x86"
   )
 )
+
+if /I "%1"=="VS2019" goto SetWinDDK
 
 :SetWinDDK
 if not defined WINDDK3790_PREFIX (

--- a/BaseTools/set_vsprefix_envs.bat
+++ b/BaseTools/set_vsprefix_envs.bat
@@ -3,7 +3,7 @@
 @REM   however it may be executed directly from the BaseTools project folder
 @REM   if the file is not executed within a WORKSPACE\BaseTools folder.
 @REM
-@REM Copyright (c) 2016-2019, Intel Corporation. All rights reserved.<BR>
+@REM Copyright (c) 2016-2020, Intel Corporation. All rights reserved.<BR>
 @REM
 @REM SPDX-License-Identifier: BSD-2-Clause-Patent
 @REM
@@ -108,62 +108,6 @@ if defined VS140COMNTOOLS (
 )
 if /I "%1"=="VS2015" goto SetWinDDK
 
-:SetVS2019
-if not defined VS160COMNTOOLS (
-  if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" (
-    if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools" (
-      call "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -products Microsoft.VisualStudio.Product.BuildTools -version 16,17 > vswhereInfo
-      for /f "usebackq tokens=1* delims=: " %%i in (vswhereInfo) do (
-        if /i "%%i"=="installationPath" call "%%j\VC\Auxiliary\Build\vcvars32.bat"
-      )
-      del vswhereInfo
-    ) else (
-      call "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -version 16,17 > vswhereInfo
-      for /f "usebackq tokens=1* delims=: " %%i in (vswhereInfo) do (
-        if /i "%%i"=="installationPath" call "%%j\VC\Auxiliary\Build\vcvars32.bat"
-      )
-      del vswhereInfo
-    )
-  ) else if exist "%ProgramFiles%\Microsoft Visual Studio\Installer\vswhere.exe" (
-    if exist "%ProgramFiles%\Microsoft Visual Studio\2019\BuildTools" (
-      call "%ProgramFiles%\Microsoft Visual Studio\Installer\vswhere.exe" -products Microsoft.VisualStudio.Product.BuildTools -version 16,17 > vswhereInfo
-      for /f "usebackq tokens=1* delims=: " %%i in (vswhereInfo) do (
-        if /i "%%i"=="installationPath" call "%%j\VC\Auxiliary\Build\vcvars32.bat"
-      )
-      del vswhereInfo
-    ) else (
-      call "%ProgramFiles%\Microsoft Visual Studio\Installer\vswhere.exe" -version 16,17 > vswhereInfo
-      for /f "usebackq tokens=1* delims=: " %%i in (vswhereInfo) do (
-        if /i "%%i"=="installationPath" call "%%j\VC\Auxiliary\Build\vcvars32.bat"
-      )
-      del vswhereInfo
-    )
-  ) else (
-    if /I "%1"=="VS2019" goto ToolNotInstall
-    goto SetWinDDK
-  )
-)
-
-if defined VCToolsInstallDir (
-  if not defined VS2019_PREFIX (
-    set "VS2019_PREFIX=%VCToolsInstallDir%"
-  )
-  if not defined WINSDK10_PREFIX (
-    if defined WindowsSdkVerBinPath (
-      set "WINSDK10_PREFIX=%WindowsSdkVerBinPath%"
-    ) else if exist "%ProgramFiles(x86)%\Windows Kits\10\bin" (
-      set "WINSDK10_PREFIX=%ProgramFiles(x86)%\Windows Kits\10\bin\"
-    ) else if exist "%ProgramFiles%\Windows Kits\10\bin" (
-      set "WINSDK10_PREFIX=%ProgramFiles%\Windows Kits\10\bin\"
-    )
-  )
-)
-if not defined WINSDK_PATH_FOR_RC_EXE (
-  if defined WINSDK10_PREFIX (
-    set "WINSDK_PATH_FOR_RC_EXE=%WINSDK10_PREFIX%x86"
-  )
-)
-
 :SetVS2017
 if not defined VS150COMNTOOLS (
   if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" (
@@ -203,6 +147,62 @@ if not defined VS150COMNTOOLS (
 if defined VCToolsInstallDir (
   if not defined VS2017_PREFIX (
     set "VS2017_PREFIX=%VCToolsInstallDir%"
+  )
+  if not defined WINSDK10_PREFIX (
+    if defined WindowsSdkVerBinPath (
+      set "WINSDK10_PREFIX=%WindowsSdkVerBinPath%"
+    ) else if exist "%ProgramFiles(x86)%\Windows Kits\10\bin" (
+      set "WINSDK10_PREFIX=%ProgramFiles(x86)%\Windows Kits\10\bin\"
+    ) else if exist "%ProgramFiles%\Windows Kits\10\bin" (
+      set "WINSDK10_PREFIX=%ProgramFiles%\Windows Kits\10\bin\"
+    )
+  )
+)
+if not defined WINSDK_PATH_FOR_RC_EXE (
+  if defined WINSDK10_PREFIX (
+    set "WINSDK_PATH_FOR_RC_EXE=%WINSDK10_PREFIX%x86"
+  )
+)
+
+:SetVS2019
+if not defined VS160COMNTOOLS (
+  if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" (
+    if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools" (
+      call "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -products Microsoft.VisualStudio.Product.BuildTools -version 16,17 > vswhereInfo
+      for /f "usebackq tokens=1* delims=: " %%i in (vswhereInfo) do (
+        if /i "%%i"=="installationPath" call "%%j\VC\Auxiliary\Build\vcvars32.bat"
+      )
+      del vswhereInfo
+    ) else (
+      call "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -version 16,17 > vswhereInfo
+      for /f "usebackq tokens=1* delims=: " %%i in (vswhereInfo) do (
+        if /i "%%i"=="installationPath" call "%%j\VC\Auxiliary\Build\vcvars32.bat"
+      )
+      del vswhereInfo
+    )
+  ) else if exist "%ProgramFiles%\Microsoft Visual Studio\Installer\vswhere.exe" (
+    if exist "%ProgramFiles%\Microsoft Visual Studio\2019\BuildTools" (
+      call "%ProgramFiles%\Microsoft Visual Studio\Installer\vswhere.exe" -products Microsoft.VisualStudio.Product.BuildTools -version 16,17 > vswhereInfo
+      for /f "usebackq tokens=1* delims=: " %%i in (vswhereInfo) do (
+        if /i "%%i"=="installationPath" call "%%j\VC\Auxiliary\Build\vcvars32.bat"
+      )
+      del vswhereInfo
+    ) else (
+      call "%ProgramFiles%\Microsoft Visual Studio\Installer\vswhere.exe" -version 16,17 > vswhereInfo
+      for /f "usebackq tokens=1* delims=: " %%i in (vswhereInfo) do (
+        if /i "%%i"=="installationPath" call "%%j\VC\Auxiliary\Build\vcvars32.bat"
+      )
+      del vswhereInfo
+    )
+  ) else (
+    if /I "%1"=="VS2019" goto ToolNotInstall
+    goto SetWinDDK
+  )
+)
+
+if defined VCToolsInstallDir (
+  if not defined VS2019_PREFIX (
+    set "VS2019_PREFIX=%VCToolsInstallDir%"
   )
   if not defined WINSDK10_PREFIX (
     if defined WindowsSdkVerBinPath (


### PR DESCRIPTION
BZ: https://bugzilla.tianocore.org/show_bug.cgi?id=2896

When VS2017/VS2019 are both installed. VS prefix setting will
wrongly be set. VS2017_PREFIX is set to the same value of VS2019.

This patch clears VSINSTALLDIR and VCToolsVersion env, then
the different vcvars32 can set the correct VS env.
