### PR TITLE
Add a stub CONTRIBUTING.md pointing to the wiki -- push

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,3 @@
+# Contributing to EDK2
+
+Contributor documentation is maintained on the wiki: https://github.com/tianocore/tianocore.github.io/wiki/EDK-II-Development-Process


### PR DESCRIPTION
https://edk2.groups.io/g/devel/message/64005
http://mid.mail-archive.com/df6219e77613e93c494996437cf53e302c473392.1597168987.git.crobinso@redhat.com
~~~
Googling for 'edk2 pull request' did not find this wiki page:

https://github.com/tianocore/tianocore.github.io/wiki/EDK-II-Development-Process

Add it to CONTRIBUTING.md for more discoverability.

(When someone opens a pull request, they will see a link to
CONTRIBUTING.md; see
<https://docs.github.com/en/github/building-a-strong-community/setting-guidelines-for-repository-contributors>.)

Signed-off-by: Cole Robinson <crobinso@redhat.com>
Message-Id: <df6219e77613e93c494996437cf53e302c473392.1597168987.git.crobinso@redhat.com>
[lersek@redhat.com: add paragraph with docs.github.com reference]
Reviewed-by: Laszlo Ersek <lersek@redhat.com>
~~~