### PR TITLE
.pytool/EccCheck: Disable Ecc error code 10014 for open CI

### DIFF
--- a/.pytool/Plugin/EccCheck/EccCheck.py
+++ b/.pytool/Plugin/EccCheck/EccCheck.py
@@ -301,6 +301,7 @@ class EccCheck(ICiBuildPlugin):
                              "10011",
                              "10012",
                              "10013",
+                             "10014", #need to be removed after BZ2904 is fixed
                              "10015",
                              "10016",
                              "10017",


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=2920
Ecc issues whose error code is 10014, can't be correctly handled
under Linux OS, resulting from a bug in Ecc tool.
So we need to disable it before ecc tool is repaired.

Cc: Sean Brogan <sean.brogan@microsoft.com>
Cc: Bret Barkelew <Bret.Barkelew@microsoft.com>
Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Liming Gao <liming.gao@intel.com>
Signed-off-by: Shenglei Zhang <shenglei.zhang@intel.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>