### PR TITLE
[PATCH v2 1/1] MdePkg: UefiFileHandleLib: fix buffer overrun in FileHandleReadLine() -- push

### DIFF
--- a/MdePkg/Library/UefiFileHandleLib/UefiFileHandleLib.c
+++ b/MdePkg/Library/UefiFileHandleLib/UefiFileHandleLib.c
@@ -969,6 +969,7 @@ FileHandleReadLine(
   UINTN       CharSize;
   UINTN       CountSoFar;
   UINTN       CrCount;
+  UINTN       OldSize;
   UINT64      OriginalFilePosition;
 
   if (Handle == NULL
@@ -1039,10 +1040,11 @@ FileHandleReadLine(
   // if we ran out of space tell when...
   //
   if ((CountSoFar+1-CrCount)*sizeof(CHAR16) > *Size){
+    OldSize = *Size;
     *Size = (CountSoFar+1-CrCount)*sizeof(CHAR16);
     if (!Truncate) {
-      if (Buffer != NULL && *Size != 0) {
-        ZeroMem(Buffer, *Size);
+      if (Buffer != NULL && OldSize != 0) {
+        ZeroMem(Buffer, OldSize);
       }
       FileHandleSetPosition(Handle, OriginalFilePosition);
       return (EFI_BUFFER_TOO_SMALL);


### PR DESCRIPTION
https://edk2.groups.io/g/devel/message/61938
http://mid.mail-archive.com/20200702023113.10517-1-vladimir.olovyannikov@broadcom.com
~~~
If the size of the supplied buffer in FileHandleReadLine(), module
UefiFileHandleLib.c, was not 0, but was not enough to fit in
the line, the size is increased, and then the Buffer of the new
size is zeroed. This size is always larger than the supplied buffer size,
causing supplied buffer overrun. Fix the issue by using the
supplied buffer size in ZeroMem().

Signed-off-by: Vladimir Olovyannikov <vladimir.olovyannikov@broadcom.com>
Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Liming Gao <liming.gao@intel.com>
Cc: Zhiguang Liu <zhiguang.liu@intel.com>
Message-Id: <20200702023113.10517-1-vladimir.olovyannikov@broadcom.com>
Reviewed-by: Zhiguang Liu <zhiguang.liu@intel.com>
[lersek@redhat.com: remove stray space character from subject line]
~~~