### PR TITLE
OvmfPkg/SmmControl2Dxe: negotiate ICH9_LPC_SMI_F_CPU_HOTPLUG -- push

### DIFF
--- a/OvmfPkg/SmmControl2Dxe/SmmControl2Dxe.inf
+++ b/OvmfPkg/SmmControl2Dxe/SmmControl2Dxe.inf
@@ -46,6 +46,7 @@
   BaseLib
   DebugLib
   IoLib
+  MemEncryptSevLib
   MemoryAllocationLib
   PcdLib
   PciLib


### PR DESCRIPTION
https://edk2.groups.io/g/devel/message/62561
http://mid.mail-archive.com/20200714184305.9814-1-lersek@redhat.com
~~~
The ICH9_LPC_SMI_F_BROADCAST and ICH9_LPC_SMI_F_CPU_HOTPLUG feature flags
cause QEMU to behave as follows:

  BROADCAST  CPU_HOTPLUG  use case / behavior
  ---------  -----------  ------------------------------------------------
  clear      clear        OVMF built without SMM_REQUIRE; or very old OVMF
                          (from before commit a316d7ac91d3 / 2017-02-07).
                          QEMU permits CPU hotplug operations, and does
                          not cause the OS to inject an SMI upon hotplug.
                          Firmware is not expected to be aware of hotplug
                          events.

  clear      set          Invalid feature set; QEMU rejects the feature
                          negotiation.

  set        clear        OVMF after a316d7ac91d3 / 2017-02-07, built with
                          SMM_REQUIRE, but no support for CPU hotplug.
                          QEMU gracefully refuses hotplug operations.

  set        set          OVMF after a316d7ac91d3 / 2017-02-07, built with
                          SMM_REQUIRE, and supporting CPU hotplug. QEMU
                          permits CPU hotplug operations, and causes the
                          OS to inject an SMI upon hotplug. Firmware is
                          expected to deal with hotplug events.

Negotiate ICH9_LPC_SMI_F_CPU_HOTPLUG -- but only if SEV is disabled, as
OvmfPkg/CpuHotplugSmm can't deal with SEV yet.

Cc: Ard Biesheuvel <ard.biesheuvel@arm.com>
Cc: Boris Ostrovsky <boris.ostrovsky@oracle.com>
Cc: Igor Mammedov <imammedo@redhat.com>
Cc: Jordan Justen <jordan.l.justen@intel.com>
Cc: Liran Alon <liran.alon@oracle.com>
Cc: Philippe Mathieu-Daudé <philmd@redhat.com>
Signed-off-by: Laszlo Ersek <lersek@redhat.com>
Message-Id: <20200714184305.9814-1-lersek@redhat.com>
Acked-by: Ard Biesheuvel <ard.biesheuvel@arm.com>
Reviewed-by: Philippe Mathieu-Daudé <philmd@redhat.com>
~~~