### PR TITLE
EmbeddedPkg/libfdt: Add strncmp macro to use AsciiStrnCmp -- push

### DIFF
--- a/EmbeddedPkg/Include/libfdt_env.h
+++ b/EmbeddedPkg/Include/libfdt_env.h
@@ -76,4 +76,8 @@ static inline size_t strnlen (const char* str, size_t strsz ) {
   return AsciiStrnLenS (str, strsz);
 }
 
+static inline size_t strncmp (const char* str1, const char* str2, size_t strsz ) {
+  return AsciiStrnCmp (str1, str2, strsz);
+}
+
 #endif /* _LIBFDT_ENV_H */


### PR DESCRIPTION
https://edk2.groups.io/g/devel/message/63767
http://mid.mail-archive.com/20200806023421.25161-1-abner.chang@hpe.com
~~~
For the implementation which utilizes libfdt provided in EmbeddedPkg
however it uses strncmp function in the libfdt helper library,
libfdt_env.h should provide the macro implied with edk2 strncmp
implementation.

The example is RISC-V OpenSBI library. edk2 RISC-V port uses OpenSBI
library and incorporate with edk2 libfdt. edk2 libfdt_env.h provides
the necessary macros to build OpenSBI which uses fdt functions in edk2
environment. However, OpenSBI also has libfdt helper library that uses
strncmp function which is not defined in edk2 libfdt_env.h. This commit
addresses the build issue caused by missing strncmp macro in
libfdt_env.h.

Check below three commits for the corresponding changes on OpenSBI,
https://github.com/riscv/opensbi/commit/8e47649eff96c303e02fbd58cdc6c4ed341066ec
https://github.com/riscv/opensbi/commit/2845d2d2cf4fb74a89452ba223995aa4a118c07e
https://github.com/riscv/opensbi/commit/2cfd2fc9048806353298a1b967abf985901e36e8

Signed-off-by: Abner Chang <abner.chang@hpe.com>
Cc: Leif Lindholm <leif@nuviainc.com>
Cc: Ard Biesheuvel <ard.biesheuvel@arm.com>
Cc: Daniel Schaefer <daniel.schaefer@hpe.com>
Message-Id: <20200806023421.25161-1-abner.chang@hpe.com>
Reviewed-by: Leif Lindholm <leif@nuviainc.com>
[lersek@redhat.com: remove stray newline between S-o-b and first Cc]
~~~