### PR TITLE
[PATCH v2 1/1] UefiCpuPkg/MpInitLib: Always initialize the DoDecrement variable -- push

### DIFF
--- a/UefiCpuPkg/Library/MpInitLib/MpLib.c
+++ b/UefiCpuPkg/Library/MpInitLib/MpLib.c
@@ -885,9 +885,7 @@ ApWakeupFunction (
           UINT64                    Status;
           BOOLEAN                   DoDecrement;
 
-          if (CpuMpData->InitFlag == ApInitConfig) {
-            DoDecrement = TRUE;
-          }
+          DoDecrement = (BOOLEAN) (CpuMpData->InitFlag == ApInitConfig);
 
           while (TRUE) {
             Msr.GhcbPhysicalAddress = AsmReadMsr64 (MSR_SEV_ES_GHCB);


### PR DESCRIPTION
https://edk2.groups.io/g/devel/message/64507
http://mid.mail-archive.com/76a9f18992475b915e5f8457704676067210cacf.1597935198.git.thomas.lendacky@amd.com
~~~
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=2901

The DoDecrement variable in ApWakeupFunction () wasn't always being
initialized. Update the code to always fully initialize it.

Cc: Eric Dong <eric.dong@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Cc: Laszlo Ersek <lersek@redhat.com>
Cc: Rahul Kumar <rahul1.kumar@intel.com>
Signed-off-by: Tom Lendacky <thomas.lendacky@amd.com>
Message-Id: <76a9f18992475b915e5f8457704676067210cacf.1597935198.git.thomas.lendacky@amd.com>
Reviewed-by: Eric Dong <eric.dong@intel.com>
Tested-by: Liming Gao <liming.gao@intel.com>
Reviewed-by: Laszlo Ersek <lersek@redhat.com>
~~~