### PR TITLE
[edk2-devel] [PATCH v4 0/8] Need add a FSP binary measurement -- push

### DIFF
--- a/IntelFsp2WrapperPkg/FspmWrapperPeim/FspmWrapperPeim.inf
+++ b/IntelFsp2WrapperPkg/FspmWrapperPeim/FspmWrapperPeim.inf
@@ -6,7 +6,7 @@
 # register TemporaryRamDonePpi to call TempRamExit API, and register MemoryDiscoveredPpi
 # notify to call FspSiliconInit API.
 #
-#  Copyright (c) 2014 - 2019, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2014 - 2020, Intel Corporation. All rights reserved.<BR>
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -44,17 +44,22 @@
   TimerLib
   FspWrapperApiLib
   FspWrapperApiTestLib
+  FspMeasurementLib
 
 [Packages]
   MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
   UefiCpuPkg/UefiCpuPkg.dec
+  SecurityPkg/SecurityPkg.dec
   IntelFsp2Pkg/IntelFsp2Pkg.dec
   IntelFsp2WrapperPkg/IntelFsp2WrapperPkg.dec
 
 [Pcd]
-  gIntelFsp2WrapperTokenSpaceGuid.PcdFspmBaseAddress     ## CONSUMES
-  gIntelFsp2WrapperTokenSpaceGuid.PcdFspmUpdDataAddress  ## CONSUMES
-  gIntelFsp2WrapperTokenSpaceGuid.PcdFspModeSelection    ## CONSUMES
+  gIntelFsp2WrapperTokenSpaceGuid.PcdFspmBaseAddress       ## CONSUMES
+  gIntelFsp2WrapperTokenSpaceGuid.PcdFspmUpdDataAddress    ## CONSUMES
+  gIntelFsp2WrapperTokenSpaceGuid.PcdFspModeSelection      ## CONSUMES
+  gIntelFsp2WrapperTokenSpaceGuid.PcdFsptBaseAddress       ## CONSUMES
+  gIntelFsp2WrapperTokenSpaceGuid.PcdFspMeasurementConfig  ## CONSUMES
 
 [Sources]
   FspmWrapperPeim.c
@@ -63,5 +68,10 @@
   gFspHobGuid                           ## PRODUCES ## HOB
   gFspApiPerformanceGuid                ## SOMETIMES_CONSUMES ## GUID
 
+[Ppis]
+  gEdkiiTcgPpiGuid                                       ## NOTIFY
+  gEfiPeiFirmwareVolumeInfoMeasurementExcludedPpiGuid    ## PRODUCES
+
 [Depex]
-  gEfiPeiMasterBootModePpiGuid
+  gEfiPeiMasterBootModePpiGuid AND
+  gPeiTpmInitializationDonePpiGuid

--- a/IntelFsp2WrapperPkg/FspsWrapperPeim/FspsWrapperPeim.inf
+++ b/IntelFsp2WrapperPkg/FspsWrapperPeim/FspsWrapperPeim.inf
@@ -6,7 +6,7 @@
 # register TemporaryRamDonePpi to call TempRamExit API, and register MemoryDiscoveredPpi
 # notify to call FspSiliconInit API.
 #
-#  Copyright (c) 2014 - 2019, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2014 - 2020, Intel Corporation. All rights reserved.<BR>
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -44,24 +44,30 @@
   PerformanceLib
   FspWrapperApiLib
   FspWrapperApiTestLib
+  FspMeasurementLib
 
 [Packages]
   MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
   UefiCpuPkg/UefiCpuPkg.dec
+  SecurityPkg/SecurityPkg.dec
   IntelFsp2Pkg/IntelFsp2Pkg.dec
   IntelFsp2WrapperPkg/IntelFsp2WrapperPkg.dec
 
 [Ppis]
-  gTopOfTemporaryRamPpiGuid             ## PRODUCES
-  gFspSiliconInitDonePpiGuid            ## PRODUCES
-  gEfiEndOfPeiSignalPpiGuid             ## PRODUCES
-  gEfiTemporaryRamDonePpiGuid           ## PRODUCES
-  gEfiPeiMemoryDiscoveredPpiGuid        ## NOTIFY
+  gTopOfTemporaryRamPpiGuid                              ## PRODUCES
+  gFspSiliconInitDonePpiGuid                             ## PRODUCES
+  gEfiEndOfPeiSignalPpiGuid                              ## PRODUCES
+  gEfiTemporaryRamDonePpiGuid                            ## PRODUCES
+  gEfiPeiMemoryDiscoveredPpiGuid                         ## NOTIFY
+  gEdkiiTcgPpiGuid                                       ## NOTIFY
+  gEfiPeiFirmwareVolumeInfoMeasurementExcludedPpiGuid    ## PRODUCES
 
 [Pcd]
-  gIntelFsp2WrapperTokenSpaceGuid.PcdFspsBaseAddress     ## CONSUMES
-  gIntelFsp2WrapperTokenSpaceGuid.PcdFspsUpdDataAddress  ## CONSUMES
-  gIntelFsp2WrapperTokenSpaceGuid.PcdFspModeSelection    ## CONSUMES
+  gIntelFsp2WrapperTokenSpaceGuid.PcdFspsBaseAddress       ## CONSUMES
+  gIntelFsp2WrapperTokenSpaceGuid.PcdFspsUpdDataAddress    ## CONSUMES
+  gIntelFsp2WrapperTokenSpaceGuid.PcdFspModeSelection      ## CONSUMES
+  gIntelFsp2WrapperTokenSpaceGuid.PcdFspMeasurementConfig  ## CONSUMES
 
 [Guids]
   gFspHobGuid                           ## CONSUMES ## HOB
@@ -71,4 +77,5 @@
   FspsWrapperPeim.c
 
 [Depex]
-  gEfiPeiMemoryDiscoveredPpiGuid
+  gEfiPeiMemoryDiscoveredPpiGuid AND
+  gPeiTpmInitializationDonePpiGuid

--- a/IntelFsp2WrapperPkg/Include/Library/FspMeasurementLib.h
+++ b/IntelFsp2WrapperPkg/Include/Library/FspMeasurementLib.h
@@ -1,0 +1,39 @@
+/** @file
+  This library is used by FSP modules to measure data to TPM.
+
+Copyright (c) 2020, Intel Corporation. All rights reserved. <BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef _FSP_MEASUREMENT_LIB_H_
+#define _FSP_MEASUREMENT_LIB_H_
+
+#define FSP_MEASURE_FSP       BIT0
+#define FSP_MEASURE_FSPT      BIT1
+#define FSP_MEASURE_FSPM      BIT2
+#define FSP_MEASURE_FSPS      BIT3
+#define FSP_MEASURE_FSPUPD    BIT31
+
+/**
+  Measure a FSP FirmwareBlob.
+
+  @param[in]  PcrIndex                PCR Index.
+  @param[in]  Description             Description for this FirmwareBlob.
+  @param[in]  FirmwareBlobBase        Base address of this FirmwareBlob.
+  @param[in]  FirmwareBlobLength      Size in bytes of this FirmwareBlob.
+
+  @retval EFI_SUCCESS           Operation completed successfully.
+  @retval EFI_UNSUPPORTED       TPM device not available.
+  @retval EFI_OUT_OF_RESOURCES  Out of memory.
+  @retval EFI_DEVICE_ERROR      The operation was unsuccessful.
+*/
+EFI_STATUS
+EFIAPI
+MeasureFspFirmwareBlob (
+  IN UINT32                         PcrIndex,
+  IN CHAR8                          *Description OPTIONAL,
+  IN EFI_PHYSICAL_ADDRESS           FirmwareBlobBase,
+  IN UINT64                         FirmwareBlobLength
+  );
+#endif

--- a/IntelFsp2WrapperPkg/IntelFsp2WrapperPkg.dec
+++ b/IntelFsp2WrapperPkg/IntelFsp2WrapperPkg.dec
@@ -1,7 +1,7 @@
 ## @file
 # Provides drivers and definitions to support fsp in EDKII bios.
 #
-# Copyright (c) 2014 - 2018, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2014 - 2020, Intel Corporation. All rights reserved.<BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -91,6 +91,23 @@
   # 1: API mode (FSP Wrapper will call FSP API)
   #
   gIntelFsp2WrapperTokenSpaceGuid.PcdFspModeSelection|0x00000001|UINT8|0x4000000A
+
+  ## This PCD decides how FSP is measured
+  # 1) The BootGuard ACM may already measured the FSP component, such as FSPT/FSPM.
+  # We need a flag (PCD) to indicate if there is need to do such FSP measurement or NOT.
+  # 2) The FSP binary includes FSP code and FSP UPD region. The UPD region is considered
+  # as configuration block, and it may be updated by OEM by design.
+  # This flag (PCD) is to indicate if we need isolate the the UPD region from the FSP code region.
+  # BIT0: Need measure FSP. (for FSP1.x) - reserved in FSP2.
+  # BIT1: Need measure FSPT. (for FSP 2.x)
+  # BIT2: Need measure FSPM. (for FSP 2.x)
+  # BIT3: Need measure FSPS. (for FSP 2.x)
+  # BIT4~30: reserved.
+  # BIT31: Need isolate UPD region measurement.
+    #0: measure FSP[T|M|S] as one binary in one record (PCR0).
+    #1: measure FSP UPD region in one record (PCR1), the FSP code without UPD in another record (PCR0).
+  #
+  gIntelFsp2WrapperTokenSpaceGuid.PcdFspMeasurementConfig|0x00000000|UINT32|0x4000000B
 
 [PcdsFixedAtBuild, PcdsPatchableInModule,PcdsDynamic,PcdsDynamicEx]
   #

--- a/IntelFsp2WrapperPkg/IntelFsp2WrapperPkg.dsc
+++ b/IntelFsp2WrapperPkg/IntelFsp2WrapperPkg.dsc
@@ -1,7 +1,7 @@
 ## @file
 # Provides drivers and definitions to support fsp in EDKII bios.
 #
-# Copyright (c) 2014 - 2016, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2014 - 2020, Intel Corporation. All rights reserved.<BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -45,6 +45,7 @@
   # FSP Wrapper Lib
   FspWrapperApiLib|IntelFsp2WrapperPkg/Library/BaseFspWrapperApiLib/BaseFspWrapperApiLib.inf
   FspWrapperApiTestLib|IntelFsp2WrapperPkg/Library/BaseFspWrapperApiTestLibNull/BaseFspWrapperApiTestLibNull.inf
+  FspMeasurementLib|IntelFsp2WrapperPkg/Library/BaseFspMeasurementLib/BaseFspMeasurementLib.inf
 
   # FSP platform sample
   FspWrapperPlatformLib|IntelFsp2WrapperPkg/Library/BaseFspWrapperPlatformLibSample/BaseFspWrapperPlatformLibSample.inf
@@ -57,6 +58,8 @@
   PeiServicesLib|MdePkg/Library/PeiServicesLib/PeiServicesLib.inf
   MemoryAllocationLib|MdePkg/Library/PeiMemoryAllocationLib/PeiMemoryAllocationLib.inf
   HobLib|MdePkg/Library/PeiHobLib/PeiHobLib.inf
+  TpmMeasurementLib|SecurityPkg/Library/PeiTpmMeasurementLib/PeiTpmMeasurementLib.inf
+  TcgEventLogRecordLib|SecurityPkg/Library/TcgEventLogRecordLib/TcgEventLogRecordLib.inf
 
 [LibraryClasses.common.DXE_DRIVER]
   UefiDriverEntryPoint|MdePkg/Library/UefiDriverEntryPoint/UefiDriverEntryPoint.inf
@@ -73,6 +76,7 @@
   IntelFsp2WrapperPkg/Library/SecFspWrapperPlatformSecLibSample/SecFspWrapperPlatformSecLibSample.inf
   IntelFsp2WrapperPkg/Library/PeiFspWrapperHobProcessLibSample/PeiFspWrapperHobProcessLibSample.inf
   IntelFsp2WrapperPkg/Library/PeiFspWrapperApiTestLib/PeiFspWrapperApiTestLib.inf
+  IntelFsp2WrapperPkg/Library/BaseFspMeasurementLib/BaseFspMeasurementLib.inf
 
   IntelFsp2WrapperPkg/FspmWrapperPeim/FspmWrapperPeim.inf
   IntelFsp2WrapperPkg/FspsWrapperPeim/FspsWrapperPeim.inf

--- a/IntelFsp2WrapperPkg/IntelFsp2WrapperPkg.dsc
+++ b/IntelFsp2WrapperPkg/IntelFsp2WrapperPkg.dsc
@@ -52,6 +52,8 @@
   PlatformSecLib|IntelFsp2WrapperPkg/Library/SecFspWrapperPlatformSecLibSample/SecFspWrapperPlatformSecLibSample.inf
   FspWrapperHobProcessLib|IntelFsp2WrapperPkg/Library/PeiFspWrapperHobProcessLibSample/PeiFspWrapperHobProcessLibSample.inf
 
+  Tpm2CommandLib|SecurityPkg/Library/Tpm2CommandLib/Tpm2CommandLib.inf
+
 [LibraryClasses.common.PEIM,LibraryClasses.common.PEI_CORE]
   PeimEntryPoint|MdePkg/Library/PeimEntryPoint/PeimEntryPoint.inf
   PeiServicesTablePointerLib|MdePkg/Library/PeiServicesTablePointerLib/PeiServicesTablePointerLib.inf
@@ -60,6 +62,8 @@
   HobLib|MdePkg/Library/PeiHobLib/PeiHobLib.inf
   TpmMeasurementLib|SecurityPkg/Library/PeiTpmMeasurementLib/PeiTpmMeasurementLib.inf
   TcgEventLogRecordLib|SecurityPkg/Library/TcgEventLogRecordLib/TcgEventLogRecordLib.inf
+  HashLib|SecurityPkg/Library/HashLibBaseCryptoRouter/HashLibBaseCryptoRouterPei.inf
+  Tpm2DeviceLib|SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2DeviceLibDTpm.inf
 
 [LibraryClasses.common.DXE_DRIVER]
   UefiDriverEntryPoint|MdePkg/Library/UefiDriverEntryPoint/UefiDriverEntryPoint.inf

--- a/IntelFsp2WrapperPkg/Library/BaseFspMeasurementLib/BaseFspMeasurementLib.inf
+++ b/IntelFsp2WrapperPkg/Library/BaseFspMeasurementLib/BaseFspMeasurementLib.inf
@@ -1,0 +1,54 @@
+## @file
+#  Provides FSP measurement functions.
+#
+#  This library provides MeasureFspFirmwareBlob() to measure FSP binary.
+#
+# Copyright (c) 2020, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = FspMeasurementLib
+  FILE_GUID                      = 890B12B4-56CC-453E-B062-4597FC6D3D8C
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = FspMeasurementLib
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  FspMeasurementLib.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  SecurityPkg/SecurityPkg.dec
+  IntelFsp2Pkg/IntelFsp2Pkg.dec
+  IntelFsp2WrapperPkg/IntelFsp2WrapperPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  BaseMemoryLib
+  DebugLib
+  PrintLib
+  PcdLib
+  PeiServicesLib
+  PeiServicesTablePointerLib
+  FspWrapperApiLib
+  TcgEventLogRecordLib
+  HashLib
+
+[Ppis]
+  gEdkiiTcgPpiGuid                                                   ## CONSUMES
+
+[Pcd]
+  gIntelFsp2WrapperTokenSpaceGuid.PcdFspMeasurementConfig            ## CONSUMES
+  gIntelFsp2WrapperTokenSpaceGuid.PcdFspmBaseAddress                 ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdTcgPfpMeasurementRevision        ## CONSUMES
+

--- a/IntelFsp2WrapperPkg/Library/BaseFspMeasurementLib/FspMeasurementLib.c
+++ b/IntelFsp2WrapperPkg/Library/BaseFspMeasurementLib/FspMeasurementLib.c
@@ -1,0 +1,248 @@
+/** @file
+  This library is used by FSP modules to measure data to TPM.
+
+Copyright (c) 2020, Intel Corporation. All rights reserved. <BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <PiPei.h>
+#include <Uefi.h>
+
+#include <Library/BaseMemoryLib.h>
+#include <Library/PeiServicesLib.h>
+#include <Library/PeiServicesTablePointerLib.h>
+#include <Library/PcdLib.h>
+#include <Library/PrintLib.h>
+#include <Library/DebugLib.h>
+#include <Library/FspWrapperApiLib.h>
+#include <Library/TpmMeasurementLib.h>
+#include <Library/FspMeasurementLib.h>
+#include <Library/TcgEventLogRecordLib.h>
+#include <Library/HashLib.h>
+
+#include <Ppi/Tcg.h>
+#include <IndustryStandard/UefiTcgPlatform.h>
+
+/**
+  Tpm measure and log data, and extend the measurement result into a specific PCR.
+
+  @param[in]  PcrIndex         PCR Index.
+  @param[in]  EventType        Event type.
+  @param[in]  EventLog         Measurement event log.
+  @param[in]  LogLen           Event log length in bytes.
+  @param[in]  HashData         The start of the data buffer to be hashed, extended.
+  @param[in]  HashDataLen      The length, in bytes, of the buffer referenced by HashData
+  @param[in]  Flags            Bitmap providing additional information.
+
+  @retval EFI_SUCCESS           Operation completed successfully.
+  @retval EFI_UNSUPPORTED       TPM device not available.
+  @retval EFI_OUT_OF_RESOURCES  Out of memory.
+  @retval EFI_DEVICE_ERROR      The operation was unsuccessful.
+**/
+EFI_STATUS
+EFIAPI
+TpmMeasureAndLogDataWithFlags (
+  IN UINT32             PcrIndex,
+  IN UINT32             EventType,
+  IN VOID               *EventLog,
+  IN UINT32             LogLen,
+  IN VOID               *HashData,
+  IN UINT64             HashDataLen,
+  IN UINT64             Flags
+  )
+{
+  EFI_STATUS                Status;
+  EDKII_TCG_PPI             *TcgPpi;
+  TCG_PCR_EVENT_HDR         TcgEventHdr;
+
+  Status = PeiServicesLocatePpi(
+             &gEdkiiTcgPpiGuid,
+             0,
+             NULL,
+             (VOID**)&TcgPpi
+             );
+  if (EFI_ERROR(Status)) {
+    return Status;
+  }
+
+  TcgEventHdr.PCRIndex  = PcrIndex;
+  TcgEventHdr.EventType = EventType;
+  TcgEventHdr.EventSize = LogLen;
+
+  Status = TcgPpi->HashLogExtendEvent (
+                     TcgPpi,
+                     Flags,
+                     HashData,
+                     (UINTN)HashDataLen,
+                     &TcgEventHdr,
+                     EventLog
+                     );
+  return Status;
+}
+
+/**
+  Measure a FSP FirmwareBlob.
+
+  @param[in]  Description             Description for this FirmwareBlob.
+  @param[in]  FirmwareBlobBase        Base address of this FirmwareBlob.
+  @param[in]  FirmwareBlobLength      Size in bytes of this FirmwareBlob.
+  @param[in]  CfgRegionOffset         Configuration region offset in bytes.
+  @param[in]  CfgRegionSize           Configuration region in bytes.
+
+  @retval EFI_SUCCESS           Operation completed successfully.
+  @retval EFI_UNSUPPORTED       TPM device not available.
+  @retval EFI_OUT_OF_RESOURCES  Out of memory.
+  @retval EFI_DEVICE_ERROR      The operation was unsuccessful.
+**/
+STATIC
+EFI_STATUS
+EFIAPI
+MeasureFspFirmwareBlobWithCfg (
+  IN CHAR8                          *Description OPTIONAL,
+  IN EFI_PHYSICAL_ADDRESS           FirmwareBlobBase,
+  IN UINT64                         FirmwareBlobLength,
+  IN UINT32                         CfgRegionOffset,
+  IN UINT32                         CfgRegionSize
+  )
+{
+  EFI_PLATFORM_FIRMWARE_BLOB        FvBlob, UpdBlob;
+  PLATFORM_FIRMWARE_BLOB2_STRUCT    FvBlob2, UpdBlob2;
+  VOID                              *FvName;
+  UINT32                            FvEventType;
+  VOID                              *FvEventLog, *UpdEventLog;
+  UINT32                            FvEventLogSize, UpdEventLogSize;
+  EFI_STATUS                        Status;
+  HASH_HANDLE                       HashHandle;
+  UINT8                             *HashBase;
+  UINTN                             HashSize;
+  TPML_DIGEST_VALUES                DigestList;
+
+  FvName = TpmMeasurementGetFvName (FirmwareBlobBase, FirmwareBlobLength);
+
+  if (((Description != NULL) || (FvName != NULL)) &&
+      (PcdGet32(PcdTcgPfpMeasurementRevision) >= TCG_EfiSpecIDEventStruct_SPEC_ERRATA_TPM2_REV_105)) {
+    if (Description != NULL) {
+      AsciiSPrint((CHAR8*)FvBlob2.BlobDescription, sizeof(FvBlob2.BlobDescription), "%a", Description);
+      AsciiSPrint((CHAR8*)UpdBlob2.BlobDescription, sizeof(UpdBlob2.BlobDescription), "%aUDP", Description);
+     } else {
+      AsciiSPrint((CHAR8*)FvBlob2.BlobDescription, sizeof(FvBlob2.BlobDescription), "Fv(%g)", FvName);
+      AsciiSPrint((CHAR8*)UpdBlob2.BlobDescription, sizeof(UpdBlob2.BlobDescription), "(%g)UDP", FvName);
+    }
+
+    FvBlob2.BlobDescriptionSize = sizeof(FvBlob2.BlobDescription);
+    FvBlob2.BlobBase = FirmwareBlobBase;
+    FvBlob2.BlobLength = FirmwareBlobLength;
+    FvEventType = EV_EFI_PLATFORM_FIRMWARE_BLOB2;
+    FvEventLog = &FvBlob2;
+    FvEventLogSize = sizeof(FvBlob2);
+
+    UpdBlob2.BlobDescriptionSize = sizeof(UpdBlob2.BlobDescription);
+    UpdBlob2.BlobBase = CfgRegionOffset;
+    UpdBlob2.BlobLength = CfgRegionSize;
+    UpdEventLog = &UpdBlob2;
+    UpdEventLogSize = sizeof(UpdBlob2);
+  } else {
+    FvBlob.BlobBase = FirmwareBlobBase;
+    FvBlob.BlobLength = FirmwareBlobLength;
+    FvEventType = EV_EFI_PLATFORM_FIRMWARE_BLOB;
+    FvEventLog = &FvBlob;
+    FvEventLogSize = sizeof(FvBlob);
+
+    UpdBlob.BlobBase = CfgRegionOffset;
+    UpdBlob.BlobLength = CfgRegionSize;
+    UpdEventLog = &UpdBlob;
+    UpdEventLogSize = sizeof(UpdBlob);
+  }
+
+  /** Initialize a SHA hash context. **/
+  Status = HashStart (&HashHandle);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "HashStart failed - %r\n", Status));
+    return Status;
+  }
+
+  /** Hash FSP binary before UDP **/
+  HashBase = (UINT8 *) (UINTN) FirmwareBlobBase;
+  HashSize = (UINTN) CfgRegionOffset;
+  Status = HashUpdate (HashHandle, HashBase, HashSize);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "HashUpdate failed - %r\n", Status));
+    return Status;
+  }
+
+  /** Hash FSP binary after UDP **/
+  HashBase = (UINT8 *) (UINTN) FirmwareBlobBase + CfgRegionOffset + CfgRegionSize;
+  HashSize = (UINTN)(FirmwareBlobLength - CfgRegionOffset - CfgRegionSize);
+  Status = HashUpdate (HashHandle, HashBase, HashSize);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "HashUpdate failed - %r\n", Status));
+    return Status;
+  }
+
+  /** Finalize the SHA hash. **/
+  Status = HashCompleteAndExtend (HashHandle, 0, NULL, 0, &DigestList);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "HashCompleteAndExtend failed - %r\n", Status));
+    return Status;
+  }
+
+  Status = TpmMeasureAndLogDataWithFlags (
+             0,
+             FvEventType,
+             FvEventLog,
+             FvEventLogSize,
+             (UINT8 *) &DigestList,
+             (UINTN) sizeof(DigestList),
+             EDKII_TCG_PRE_HASH_LOG_ONLY
+             );
+
+  Status = TpmMeasureAndLogData (
+             1,
+             EV_PLATFORM_CONFIG_FLAGS,
+             UpdEventLog,
+             UpdEventLogSize,
+             (UINT8 *) (UINTN) FirmwareBlobBase + CfgRegionOffset,
+             CfgRegionSize
+             );
+
+  return Status;
+}
+
+/**
+  Measure a FSP FirmwareBlob.
+
+  @param[in]  PcrIndex                PCR Index.
+  @param[in]  Description             Description for this FirmwareBlob.
+  @param[in]  FirmwareBlobBase        Base address of this FirmwareBlob.
+  @param[in]  FirmwareBlobLength      Size in bytes of this FirmwareBlob.
+
+  @retval EFI_SUCCESS           Operation completed successfully.
+  @retval EFI_UNSUPPORTED       TPM device not available.
+  @retval EFI_OUT_OF_RESOURCES  Out of memory.
+  @retval EFI_DEVICE_ERROR      The operation was unsuccessful.
+**/
+EFI_STATUS
+EFIAPI
+MeasureFspFirmwareBlob (
+  IN UINT32                         PcrIndex,
+  IN CHAR8                          *Description OPTIONAL,
+  IN EFI_PHYSICAL_ADDRESS           FirmwareBlobBase,
+  IN UINT64                         FirmwareBlobLength
+  )
+{
+  UINT32           FspMeasureMask;
+  FSP_INFO_HEADER  *FspHeaderPtr;
+
+  FspMeasureMask = PcdGet32 (PcdFspMeasurementConfig);
+  if ((FspMeasureMask & FSP_MEASURE_FSPUPD) != 0) {
+    FspHeaderPtr = (FSP_INFO_HEADER *) FspFindFspHeader (FirmwareBlobBase);
+    if (FspHeaderPtr != NULL) {
+      return MeasureFspFirmwareBlobWithCfg(Description, FirmwareBlobBase, FirmwareBlobLength,
+                                           FspHeaderPtr->CfgRegionOffset, FspHeaderPtr->CfgRegionSize);
+    }
+  }
+
+  return MeasureFirmwareBlob (PcrIndex, Description, FirmwareBlobBase, FirmwareBlobLength);
+}
+

--- a/SecurityPkg/Include/Library/TcgEventLogRecordLib.h
+++ b/SecurityPkg/Include/Library/TcgEventLogRecordLib.h
@@ -1,0 +1,97 @@
+/** @file
+  This library is used by other modules to measure Firmware to TPM.
+
+Copyright (c) 2020, Intel Corporation. All rights reserved. <BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef _TCG_EVENTLOGRECORD_LIB_H_
+#define _TCG_EVENTLOGRECORD_LIB_H_
+
+#include <Uefi.h>
+
+#pragma pack (1)
+
+#define PLATFORM_FIRMWARE_BLOB_DESC "Fv(XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX)"
+typedef struct {
+  UINT8                             BlobDescriptionSize;
+  UINT8                             BlobDescription[sizeof(PLATFORM_FIRMWARE_BLOB_DESC)];
+  EFI_PHYSICAL_ADDRESS              BlobBase;
+  UINT64                            BlobLength;
+} PLATFORM_FIRMWARE_BLOB2_STRUCT;
+
+#define HANDOFF_TABLE_POINTER_DESC  "1234567890ABCDEF"
+typedef struct {
+  UINT8                             TableDescriptionSize;
+  UINT8                             TableDescription[sizeof(HANDOFF_TABLE_POINTER_DESC)];
+  UINT64                            NumberOfTables;
+  EFI_CONFIGURATION_TABLE           TableEntry[1];
+} HANDOFF_TABLE_POINTERS2_STRUCT;
+
+#pragma pack ()
+
+/**
+  Get the FvName from the FV header.
+
+  Causion: The FV is untrusted input.
+
+  @param[in]  FvBase            Base address of FV image.
+  @param[in]  FvLength          Length of FV image.
+
+  @return FvName pointer
+  @retval NULL   FvName is NOT found
+**/
+VOID *
+TpmMeasurementGetFvName (
+  IN EFI_PHYSICAL_ADDRESS           FvBase,
+  IN UINT64                         FvLength
+  );
+
+/**
+  Measure a FirmwareBlob.
+
+  @param[in]  PcrIndex                PCR Index.
+  @param[in]  Description             Description for this FirmwareBlob.
+  @param[in]  FirmwareBlobBase        Base address of this FirmwareBlob.
+  @param[in]  FirmwareBlobLength      Size in bytes of this FirmwareBlob.
+
+  @retval EFI_SUCCESS           Operation completed successfully.
+  @retval EFI_UNSUPPORTED       TPM device not available.
+  @retval EFI_OUT_OF_RESOURCES  Out of memory.
+  @retval EFI_DEVICE_ERROR      The operation was unsuccessful.
+*/
+EFI_STATUS
+EFIAPI
+MeasureFirmwareBlob (
+  IN UINT32                         PcrIndex,
+  IN CHAR8                          *Description OPTIONAL,
+  IN EFI_PHYSICAL_ADDRESS           FirmwareBlobBase,
+  IN UINT64                         FirmwareBlobLength
+  );
+
+/**
+  Measure a HandoffTable.
+
+  @param[in]  PcrIndex                PcrIndex of the measurement.
+  @param[in]  Description             Description for this HandoffTable.
+  @param[in]  TableGuid               GUID of this HandoffTable.
+  @param[in]  TableAddress            Base address of this HandoffTable.
+  @param[in]  TableLength             Size in bytes of this HandoffTable.
+
+  @retval EFI_SUCCESS           Operation completed successfully.
+  @retval EFI_UNSUPPORTED       TPM device not available.
+  @retval EFI_OUT_OF_RESOURCES  Out of memory.
+  @retval EFI_DEVICE_ERROR      The operation was unsuccessful.
+*/
+EFI_STATUS
+EFIAPI
+MeasureHandoffTable (
+  IN UINT32                         PcrIndex,
+  IN CHAR8                          *Description OPTIONAL,
+  IN EFI_GUID                       *TableGuid,
+  IN VOID                           *TableAddress,
+  IN UINTN                          TableLength
+  );
+
+#endif

--- a/SecurityPkg/Include/Ppi/Tcg.h
+++ b/SecurityPkg/Include/Ppi/Tcg.h
@@ -18,6 +18,11 @@ typedef struct _EDKII_TCG_PPI EDKII_TCG_PPI;
 //
 #define EDKII_TCG_PRE_HASH  0x0000000000000001
 
+//
+// This bit is shall be set when HashData is the pre-hash digest and log only.
+//
+#define EDKII_TCG_PRE_HASH_LOG_ONLY  0x0000000000000002
+
 /**
   Tpm measure and log data, and extend the measurement result into a specific PCR.
 

--- a/SecurityPkg/Library/TcgEventLogRecordLib/TcgEventLogRecordLib.c
+++ b/SecurityPkg/Library/TcgEventLogRecordLib/TcgEventLogRecordLib.c
@@ -1,0 +1,197 @@
+/** @file
+  This library is used by other modules to measure data to TPM.
+
+Copyright (c) 2020, Intel Corporation. All rights reserved. <BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Uefi/UefiBaseType.h>
+#include <Pi/PiFirmwareVolume.h>
+
+#include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
+#include <Library/ReportStatusCodeLib.h>
+#include <Library/PcdLib.h>
+#include <Library/PrintLib.h>
+#include <Library/TcgEventLogRecordLib.h>
+#include <Library/TpmMeasurementLib.h>
+
+#include <IndustryStandard/UefiTcgPlatform.h>
+
+/**
+  Get the FvName from the FV header.
+
+  Causion: The FV is untrusted input.
+
+  @param[in]  FvBase            Base address of FV image.
+  @param[in]  FvLength          Length of FV image.
+
+  @return FvName pointer
+  @retval NULL   FvName is NOT found
+**/
+VOID *
+TpmMeasurementGetFvName (
+  IN EFI_PHYSICAL_ADDRESS           FvBase,
+  IN UINT64                         FvLength
+  )
+{
+  EFI_FIRMWARE_VOLUME_HEADER      *FvHeader;
+  EFI_FIRMWARE_VOLUME_EXT_HEADER  *FvExtHeader;
+
+  if (FvBase >= MAX_ADDRESS) {
+    return NULL;
+  }
+  if (FvLength >= MAX_ADDRESS - FvBase) {
+    return NULL;
+  }
+  if (FvLength < sizeof(EFI_FIRMWARE_VOLUME_HEADER)) {
+    return NULL;
+  }
+
+  FvHeader = (EFI_FIRMWARE_VOLUME_HEADER *)(UINTN)FvBase;
+  if (FvHeader->Signature != EFI_FVH_SIGNATURE) {
+    return NULL;
+  }
+  if (FvHeader->ExtHeaderOffset < sizeof(EFI_FIRMWARE_VOLUME_HEADER)) {
+    return NULL;
+  }
+  if (FvHeader->ExtHeaderOffset + sizeof(EFI_FIRMWARE_VOLUME_EXT_HEADER) > FvLength) {
+    return NULL;
+  }
+  FvExtHeader = (EFI_FIRMWARE_VOLUME_EXT_HEADER *)(UINTN)(FvBase + FvHeader->ExtHeaderOffset);
+
+  return &FvExtHeader->FvName;
+}
+
+/**
+  Measure a FirmwareBlob.
+
+  @param[in]  PcrIndex                PcrIndex of the measurement.
+  @param[in]  Description             Description for this FirmwareBlob.
+  @param[in]  FirmwareBlobBase        Base address of this FirmwareBlob.
+  @param[in]  FirmwareBlobLength      Size in bytes of this FirmwareBlob.
+
+  @retval EFI_SUCCESS           Operation completed successfully.
+  @retval EFI_UNSUPPORTED       TPM device not available.
+  @retval EFI_OUT_OF_RESOURCES  Out of memory.
+  @retval EFI_DEVICE_ERROR      The operation was unsuccessful.
+**/
+EFI_STATUS
+EFIAPI
+MeasureFirmwareBlob (
+  IN UINT32                         PcrIndex,
+  IN CHAR8                          *Description OPTIONAL,
+  IN EFI_PHYSICAL_ADDRESS           FirmwareBlobBase,
+  IN UINT64                         FirmwareBlobLength
+  )
+{
+  EFI_PLATFORM_FIRMWARE_BLOB        FvBlob;
+  PLATFORM_FIRMWARE_BLOB2_STRUCT    FvBlob2;
+  VOID                              *FvName;
+  UINT32                            EventType;
+  VOID                              *EventLog;
+  UINT32                            EventLogSize;
+  EFI_STATUS                        Status;
+
+  FvName = TpmMeasurementGetFvName (FirmwareBlobBase, FirmwareBlobLength);
+
+  if (((Description != NULL) || (FvName != NULL)) &&
+      (PcdGet32(PcdTcgPfpMeasurementRevision) >= TCG_EfiSpecIDEventStruct_SPEC_ERRATA_TPM2_REV_105)) {
+    if (Description != NULL) {
+      AsciiSPrint((CHAR8*)FvBlob2.BlobDescription, sizeof(FvBlob2.BlobDescription), "%a", Description);
+    } else {
+      AsciiSPrint((CHAR8*)FvBlob2.BlobDescription, sizeof(FvBlob2.BlobDescription), "Fv(%g)", FvName);
+    }
+
+    FvBlob2.BlobDescriptionSize = sizeof(FvBlob2.BlobDescription);
+    FvBlob2.BlobBase = FirmwareBlobBase;
+    FvBlob2.BlobLength = FirmwareBlobLength;
+
+    EventType = EV_EFI_PLATFORM_FIRMWARE_BLOB2;
+    EventLog = &FvBlob2;
+    EventLogSize = sizeof(FvBlob2);
+  } else {
+    FvBlob.BlobBase = FirmwareBlobBase;
+    FvBlob.BlobLength = FirmwareBlobLength;
+
+    EventType = EV_EFI_PLATFORM_FIRMWARE_BLOB;
+    EventLog = &FvBlob;
+    EventLogSize = sizeof(FvBlob);
+  }
+
+  Status = TpmMeasureAndLogData (
+             PcrIndex,
+             EventType,
+             EventLog,
+             EventLogSize,
+             (VOID*)(UINTN)FirmwareBlobBase,
+             FirmwareBlobLength
+             );
+
+  return Status;
+}
+
+/**
+  Measure a HandoffTable.
+
+  @param[in]  PcrIndex                PcrIndex of the measurement.
+  @param[in]  Description             Description for this HandoffTable.
+  @param[in]  TableGuid               GUID of this HandoffTable.
+  @param[in]  TableAddress            Base address of this HandoffTable.
+  @param[in]  TableLength             Size in bytes of this HandoffTable.
+
+  @retval EFI_SUCCESS           Operation completed successfully.
+  @retval EFI_UNSUPPORTED       TPM device not available.
+  @retval EFI_OUT_OF_RESOURCES  Out of memory.
+  @retval EFI_DEVICE_ERROR      The operation was unsuccessful.
+**/
+EFI_STATUS
+EFIAPI
+MeasureHandoffTable (
+  IN UINT32                         PcrIndex,
+  IN CHAR8                          *Description OPTIONAL,
+  IN EFI_GUID                       *TableGuid,
+  IN VOID                           *TableAddress,
+  IN UINTN                          TableLength
+  )
+{
+  EFI_HANDOFF_TABLE_POINTERS        HandoffTables;
+  HANDOFF_TABLE_POINTERS2_STRUCT    HandoffTables2;
+  UINT32                            EventType;
+  VOID                              *EventLog;
+  UINT32                            EventLogSize;
+  EFI_STATUS                        Status;
+
+  if ((Description != NULL) &&
+      (PcdGet32(PcdTcgPfpMeasurementRevision) >= TCG_EfiSpecIDEventStruct_SPEC_ERRATA_TPM2_REV_105)) {
+    AsciiSPrint((CHAR8*)HandoffTables2.TableDescription, sizeof(HandoffTables2.TableDescription), "%a", Description);
+
+    HandoffTables2.TableDescriptionSize = sizeof(HandoffTables2.TableDescription);
+    HandoffTables2.NumberOfTables = 1;
+    CopyGuid (&(HandoffTables2.TableEntry[0].VendorGuid), TableGuid);
+    HandoffTables2.TableEntry[0].VendorTable = TableAddress;
+
+    EventType = EV_EFI_HANDOFF_TABLES2;
+    EventLog = &HandoffTables2;
+    EventLogSize = sizeof(HandoffTables2);
+  } else {
+    HandoffTables.NumberOfTables = 1;
+    CopyGuid (&(HandoffTables.TableEntry[0].VendorGuid), TableGuid);
+    HandoffTables.TableEntry[0].VendorTable = TableAddress;
+
+    EventType = EV_EFI_HANDOFF_TABLES;
+    EventLog = &HandoffTables;
+    EventLogSize = sizeof(HandoffTables);
+  }
+
+  Status = TpmMeasureAndLogData (
+             PcrIndex,
+             EventType,
+             EventLog,
+             EventLogSize,
+             TableAddress,
+             TableLength
+             );
+  return Status;
+}

--- a/SecurityPkg/Library/TcgEventLogRecordLib/TcgEventLogRecordLib.inf
+++ b/SecurityPkg/Library/TcgEventLogRecordLib/TcgEventLogRecordLib.inf
@@ -1,0 +1,40 @@
+## @file
+#  Provides interface for firmwware TPM measurement
+#
+# Copyright (c) 2020, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = TcgEventLogRecordLib
+  MODULE_UNI_FILE                = TcgEventLogRecordLib.uni
+  FILE_GUID                      = F8125B2A-3922-4A22-A6F8-3B6159A25A3B
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = NULL
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  TcgEventLogRecordLib.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  SecurityPkg/SecurityPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  BaseMemoryLib
+  DebugLib
+  PcdLib
+  TpmMeasurementLib
+
+[Pcd]
+  gEfiMdeModulePkgTokenSpaceGuid.PcdTcgPfpMeasurementRevision          ## CONSUMES

--- a/SecurityPkg/Library/TcgEventLogRecordLib/TcgEventLogRecordLib.uni
+++ b/SecurityPkg/Library/TcgEventLogRecordLib/TcgEventLogRecordLib.uni
@@ -1,0 +1,17 @@
+// /** @file
+// Provides interface for firmwware TPM measurement
+//
+// This library provides MeasureFirmwareBlob() and MeasureHandoffTable()
+// to measure and log data, and extend the measurement result into a specific PCR.
+//
+// Copyright (c) 2020, Intel Corporation. All rights reserved.<BR>
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+// **/
+
+
+#string STR_MODULE_ABSTRACT             #language en-US "Provides Firmware TPM measurement functions for TPM1.2 and TPM 2.0"
+
+#string STR_MODULE_DESCRIPTION          #language en-US "This library provides MeasureFirmwareBlob() and MeasureHandoffTable() to measure and log data, and extend the measurement result into a specific PCR."
+

--- a/SecurityPkg/SecurityPkg.dec
+++ b/SecurityPkg/SecurityPkg.dec
@@ -84,6 +84,9 @@
   #
   VariableKeyLib|Include/Library/VariableKeyLib.h
 
+  ## @libraryclass  Provides interfaces about firmware TPM measurement.
+  #
+  TcgEventLogRecordLib|Include/Library/TcgEventLogRecordLib.h
 [Guids]
   ## Security package token space guid.
   # Include/Guid/SecurityPkgTokenSpace.h

--- a/SecurityPkg/SecurityPkg.dsc
+++ b/SecurityPkg/SecurityPkg.dsc
@@ -66,6 +66,7 @@
   ResetSystemLib|MdeModulePkg/Library/BaseResetSystemLibNull/BaseResetSystemLibNull.inf
   VariableKeyLib|SecurityPkg/Library/VariableKeyLibNull/VariableKeyLibNull.inf
   RpmcLib|SecurityPkg/Library/RpmcLibNull/RpmcLibNull.inf
+  TcgEventLogRecordLib|SecurityPkg/Library/TcgEventLogRecordLib/TcgEventLogRecordLib.inf
 
 [LibraryClasses.ARM]
   #
@@ -240,6 +241,7 @@
   SecurityPkg/Library/PlatformSecureLibNull/PlatformSecureLibNull.inf
   SecurityPkg/Library/Tcg2PpVendorLibNull/Tcg2PpVendorLibNull.inf
   SecurityPkg/Library/TcgPpVendorLibNull/TcgPpVendorLibNull.inf
+  SecurityPkg/Library/TcgEventLogRecordLib/TcgEventLogRecordLib.inf
 
 [Components.IA32, Components.X64, Components.ARM, Components.AARCH64]
   SecurityPkg/Library/AuthVariableLib/AuthVariableLib.inf

--- a/SecurityPkg/Tcg/Tcg2Pei/Tcg2Pei.c
+++ b/SecurityPkg/Tcg/Tcg2Pei/Tcg2Pei.c
@@ -453,13 +453,15 @@ HashLogExtendEvent (
     return EFI_DEVICE_ERROR;
   }
 
-  if(Flags & EDKII_TCG_PRE_HASH) {
+  if ((Flags & EDKII_TCG_PRE_HASH) != 0 || (Flags & EDKII_TCG_PRE_HASH_LOG_ONLY) != 0) {
     ZeroMem (&DigestList, sizeof(DigestList));
     CopyMem (&DigestList, HashData, sizeof(DigestList));
-    Status = Tpm2PcrExtend (
-             0,
-             &DigestList
-             );
+    if ((Flags & EDKII_TCG_PRE_HASH) !=0 ) {
+      Status = Tpm2PcrExtend (
+               NewEventHdr->PCRIndex,
+               &DigestList
+               );
+    }
   } else {
     Status = HashAndExtend (
                NewEventHdr->PCRIndex,


### PR DESCRIPTION
https://bugzilla.tianocore.org/show_bug.cgi?id=2376
https://edk2.groups.io/g/devel/message/64354
http://mid.mail-archive.com/20200818062618.3698-1-qi1.zhang@intel.com
~~~
v4 change:
   rename FvEventLogRecordLib to TcgEventLogRecordLib.
v3 change:
  add a new lib FvEventLogRecordLib for gerneric code.

REF: https://bugzilla.tianocore.org/show_bug.cgi?id=2376

The EDKII BIOS calls FSP API in FSP Wrapper Pkg.
This FSP code need to be measured into TPM.

We need add a generic module in FSP Wrapper Pkg code to measure:
1) FSP-T, FSP-M, FSP-S in API mode.
2) FSP-T in Dispatch-mode. The FSP-M and FSP-S will be reported
   as standard FV and they will be measured by TCG-PEI.

Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Hao A Wu <hao.a.wu@intel.com>
Cc: Chasel Chiu <chasel.chiu@intel.com>
Cc: Nate DeSimone <nathaniel.l.desimone@intel.com>
Cc: Star Zeng <star.zeng@intel.com>
Cc: Qi Zhang <qi1.zhang@intel.com>

Jiewen Yao (4):
  IntelFsp2WrapperPkg/FspMeasurementLib: Add header file.
  IntelFsp2WrapperPkg/FspMeasurementLib: Add BaseFspMeasurementLib.
  IntelFsp2WraperPkg/Fsp{m|s}WrapperPeim: Add FspBin measurement.
  IntelFsp2Wrapper/dsc: Add FspTpmMeasurementLib and
    PcdFspMeasurementConfig.

Qi Zhang (4):
  SecurityPkg/TcgEventLogRecordLib: add new lib for firmware measurement
  SecurityPkg/dsc: add FvEventLogRecordLib
  SecurityPkg/Tcg2: handle PRE HASH and LOG ONLY
  IntelFsp2WrapperPkg/dsc: add HashLib, Tpm2CommandLib and Tpm2DeviceLib

 .../FspmWrapperPeim/FspmWrapperPeim.c         |  90 ++++++-
 .../FspmWrapperPeim/FspmWrapperPeim.inf       |  20 +-
 .../FspsWrapperPeim/FspsWrapperPeim.c         |  86 +++++-
 .../FspsWrapperPeim/FspsWrapperPeim.inf       |  27 +-
 .../Include/Library/FspMeasurementLib.h       |  39 +++
 IntelFsp2WrapperPkg/IntelFsp2WrapperPkg.dec   |  17 ++
 IntelFsp2WrapperPkg/IntelFsp2WrapperPkg.dsc   |  10 +-
 .../BaseFspMeasurementLib.inf                 |  54 ++++
 .../BaseFspMeasurementLib/FspMeasurementLib.c | 248 ++++++++++++++++++
 .../Include/Library/TcgEventLogRecordLib.h    |  97 +++++++
 SecurityPkg/Include/Ppi/Tcg.h                 |   5 +
 .../TcgEventLogRecordLib.c                    | 197 ++++++++++++++
 .../TcgEventLogRecordLib.inf                  |  40 +++
 .../TcgEventLogRecordLib.uni                  |  17 ++
 SecurityPkg/SecurityPkg.dec                   |   3 +
 SecurityPkg/SecurityPkg.dsc                   |   2 +
 SecurityPkg/Tcg/Tcg2Pei/Tcg2Pei.c             |  12 +-
 17 files changed, 939 insertions(+), 25 deletions(-)
 create mode 100644 IntelFsp2WrapperPkg/Include/Library/FspMeasurementLib.h
 create mode 100644 IntelFsp2WrapperPkg/Library/BaseFspMeasurementLib/BaseFspMeasurementLib.inf
 create mode 100644 IntelFsp2WrapperPkg/Library/BaseFspMeasurementLib/FspMeasurementLib.c
 create mode 100644 SecurityPkg/Include/Library/TcgEventLogRecordLib.h
 create mode 100644 SecurityPkg/Library/TcgEventLogRecordLib/TcgEventLogRecordLib.c
 create mode 100644 SecurityPkg/Library/TcgEventLogRecordLib/TcgEventLogRecordLib.inf
 create mode 100644 SecurityPkg/Library/TcgEventLogRecordLib/TcgEventLogRecordLib.uni
~~~