### PR TITLE
[edk2-devel] [PATCH 0/2] OvmfPkg: fix race conditions in VCPU hotplug (for edk2-stable202008) -- push

### DIFF
--- a/OvmfPkg/CpuHotplugSmm/CpuHotplug.c
+++ b/OvmfPkg/CpuHotplugSmm/CpuHotplug.c
@@ -193,9 +193,28 @@ CpuHotplugMmi (
   NewSlot = 0;
   while (PluggedIdx < PluggedCount) {
     APIC_ID NewApicId;
+    UINT32  CheckSlot;
     UINTN   NewProcessorNumberByProtocol;
 
     NewApicId = mPluggedApicIds[PluggedIdx];
+
+    //
+    // Check if the supposedly hot-added CPU is already known to us.
+    //
+    for (CheckSlot = 0;
+         CheckSlot < mCpuHotPlugData->ArrayLength;
+         CheckSlot++) {
+      if (mCpuHotPlugData->ApicId[CheckSlot] == NewApicId) {
+        break;
+      }
+    }
+    if (CheckSlot < mCpuHotPlugData->ArrayLength) {
+      DEBUG ((DEBUG_VERBOSE, "%a: APIC ID " FMT_APIC_ID " was hot-plugged "
+        "before; ignoring it\n", __FUNCTION__, NewApicId));
+      PluggedIdx++;
+      continue;
+    }
+
     //
     // Find the first empty slot in CPU_HOT_PLUG_DATA.
     //


### PR DESCRIPTION
https://bugzilla.tianocore.org/show_bug.cgi?id=2929
https://edk2.groups.io/g/devel/message/64659
http://mid.mail-archive.com/20200826222129.25798-1-lersek@redhat.com
~~~
Ref:    https://bugzilla.tianocore.org/show_bug.cgi?id=2929
Repo:   https://pagure.io/lersek/edk2.git
Branch: cpu_hotplug_races_bz_2929

Proposing these bugfixes for edk2-stable202008. We should either include
them in the release, or revert commit 5ba203b54e59
("OvmfPkg/SmmControl2Dxe: negotiate ICH9_LPC_SMI_F_CPU_HOTPLUG",
2020-08-24). Please see the BZ for more details.

Cc: Ard Biesheuvel <ard.biesheuvel@arm.com>
Cc: Igor Mammedov <imammedo@redhat.com>
Cc: Jordan Justen <jordan.l.justen@intel.com>
Cc: Philippe Mathieu-Daudé <philmd@redhat.com>

Thanks,
Laszlo

Laszlo Ersek (2):
  OvmfPkg/CpuHotplugSmm: fix CPU hotplug race just before SMI broadcast
  OvmfPkg/CpuHotplugSmm: fix CPU hotplug race just after SMI broadcast

 OvmfPkg/CpuHotplugSmm/CpuHotplug.c | 19 +++++++++++
 OvmfPkg/CpuHotplugSmm/Smbase.c     | 35 ++++++++++++++++----
 2 files changed, 48 insertions(+), 6 deletions(-)
~~~