### PR TITLE
MdePkg: Correcting EFI_ACPI_DMA_TRANSFER_TYPE_16_BIT definition

### DIFF
--- a/MdePkg/Include/IndustryStandard/Acpi10.h
+++ b/MdePkg/Include/IndustryStandard/Acpi10.h
@@ -358,7 +358,7 @@ typedef struct {
 #define EFI_ACPI_DMA_TRANSFER_TYPE_MASK                 0x03
 #define   EFI_ACPI_DMA_TRANSFER_TYPE_8_BIT              0x00
 #define   EFI_ACPI_DMA_TRANSFER_TYPE_8_BIT_AND_16_BIT   0x01
-#define   EFI_ACPI_DMA_TRANSFER_TYPE_16_BIT             0x10
+#define   EFI_ACPI_DMA_TRANSFER_TYPE_16_BIT             0x02
 
 //
 // IO Information


### PR DESCRIPTION
In Acpi10.h, EFI_ACPI_DMA_TRANSFER_TYPE_16_BIT is defined as 0x10,
but should be 0x02 per the ACPI Specification.

REF:https://bugzilla.tianocore.org/show_bug.cgi?id=2937

Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Zhiguang Liu <zhiguang.liu@intel.com>
Signed-off-by: Paul G <paul.grimes@amd.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>