### PR TITLE
[edk2-devel] [PATCH] SecurityPkg: Initailize variable Status before it is consumed. -- push

### DIFF
--- a/SecurityPkg/Tcg/Tcg2Pei/Tcg2Pei.c
+++ b/SecurityPkg/Tcg/Tcg2Pei/Tcg2Pei.c
@@ -456,6 +456,7 @@ HashLogExtendEvent (
   if ((Flags & EDKII_TCG_PRE_HASH) != 0 || (Flags & EDKII_TCG_PRE_HASH_LOG_ONLY) != 0) {
     ZeroMem (&DigestList, sizeof(DigestList));
     CopyMem (&DigestList, HashData, sizeof(DigestList));
+    Status = EFI_SUCCESS;
     if ((Flags & EDKII_TCG_PRE_HASH) !=0 ) {
       Status = Tpm2PcrExtend (
                NewEventHdr->PCRIndex,


### PR DESCRIPTION
https://bugzilla.tianocore.org/show_bug.cgi?id=2945
https://edk2.groups.io/g/devel/message/64865
http://mid.mail-archive.com/20200901005505.1722-1-zhiguang.liu@intel.com
~~~
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=2945

V2: Move "Status = EFI_SUCCESS;" before the EDKII_TCG_PRE_HASH check.

Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Qi Zhang <qi1.zhang@intel.com>
Cc: Rahul Kumar <rahul1.kumar@intel.com>
Cc: Laszlo Ersek <lersek@redhat.com>
Reviewed-by: Jiewen Yao <jiewen.yao@intel.com>
Signed-off-by: Zhiguang Liu <zhiguang.liu@intel.com>
Message-Id: <20200901005505.1722-1-zhiguang.liu@intel.com>
Reviewed-by: Laszlo Ersek <lersek@redhat.com>
~~~