### PR TITLE
[edk2-devel] [Patch V2] BaseTools/Ecc: Fix an issue of path separator compatibility -- push

### DIFF
--- a/BaseTools/Source/Python/Ecc/Check.py
+++ b/BaseTools/Source/Python/Ecc/Check.py
@@ -1103,11 +1103,11 @@ class Check(object):
                     InfPathList.append(Item[0])
             SqlCommand = """
                          select ID, Path, FullPath from File where upper(FullPath) not in
-                            (select upper(A.Path) || '\\' || upper(B.Value1) from File as A, INF as B
+                            (select upper(A.Path) || '%s' || upper(B.Value1) from File as A, INF as B
                             where A.ID in (select BelongsToFile from INF where Model = %s group by BelongsToFile) and
                             B.BelongsToFile = A.ID and B.Model = %s)
                             and (Model = %s or Model = %s)
-                        """ % (MODEL_EFI_SOURCE_FILE, MODEL_EFI_SOURCE_FILE, MODEL_FILE_C, MODEL_FILE_H)
+                        """ % (os.sep, MODEL_EFI_SOURCE_FILE, MODEL_EFI_SOURCE_FILE, MODEL_FILE_C, MODEL_FILE_H)
             RecordSet = EccGlobalData.gDb.TblInf.Exec(SqlCommand)
             for Record in RecordSet:
                 Path = Record[1]
@@ -1132,9 +1132,9 @@ class Check(object):
                 BelongsToFile = Pcd[4]
                 SqlCommand = """
                              select ID from File where FullPath in
-                            (select B.Path || '\\' || A.Value1 from INF as A, File as B where A.Model = %s and A.BelongsToFile = %s
+                            (select B.Path || '%s' || A.Value1 from INF as A, File as B where A.Model = %s and A.BelongsToFile = %s
                              and B.ID = %s and (B.Model = %s or B.Model = %s))
-                             """ % (MODEL_EFI_SOURCE_FILE, BelongsToFile, BelongsToFile, MODEL_FILE_C, MODEL_FILE_H)
+                             """ % (os.sep, MODEL_EFI_SOURCE_FILE, BelongsToFile, BelongsToFile, MODEL_FILE_C, MODEL_FILE_H)
                 TableSet = EccGlobalData.gDb.TblFile.Exec(SqlCommand)
                 for Tbl in TableSet:
                     TblName = 'Identifier' + str(Tbl[0])


### PR DESCRIPTION
https://bugzilla.tianocore.org/show_bug.cgi?id=2904
https://edk2.groups.io/g/devel/message/64887
http://mid.mail-archive.com/20200901102315.38840-1-bob.c.feng@intel.com
~~~
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=2904

The path separator is different in Windows and Linux, the
original code does not handle this difference. This patch
is to fix this issue.

Signed-off-by: Bob Feng <bob.c.feng@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Yuwei Chen <yuwei.chen@intel.com>
Cc: Shenglei Zhang <shenglei.zhang@intel.com>
Message-Id: <20200901102315.38840-1-bob.c.feng@intel.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>
~~~