### PR TITLE
[edk2-devel] [PATCH 0/3] SecurityPkg/DxeImageVerificationLib: catch alignment overflow (CVE-2019-14562) -- push

### DIFF
--- a/SecurityPkg/Library/DxeImageVerificationLib/DxeImageVerificationLib.c
+++ b/SecurityPkg/Library/DxeImageVerificationLib/DxeImageVerificationLib.c
@@ -1860,7 +1860,9 @@ DxeImageVerificationHandler (
       break;
     }
     WinCertificate = (WIN_CERTIFICATE *) (mImageBase + OffSet);
-    if (SecDataDirLeft < WinCertificate->dwLength) {
+    if (SecDataDirLeft < WinCertificate->dwLength ||
+        (SecDataDirLeft - WinCertificate->dwLength <
+         ALIGN_SIZE (WinCertificate->dwLength))) {
       break;
     }
 

--- a/SecurityPkg/Library/DxeImageVerificationLib/DxeImageVerificationLib.c
+++ b/SecurityPkg/Library/DxeImageVerificationLib/DxeImageVerificationLib.c
@@ -1855,10 +1855,12 @@ DxeImageVerificationHandler (
   for (OffSet = SecDataDir->VirtualAddress;
        OffSet < SecDataDirEnd;
        OffSet += (WinCertificate->dwLength + ALIGN_SIZE (WinCertificate->dwLength))) {
-    WinCertificate = (WIN_CERTIFICATE *) (mImageBase + OffSet);
     SecDataDirLeft = SecDataDirEnd - OffSet;
-    if (SecDataDirLeft <= sizeof (WIN_CERTIFICATE) ||
-        SecDataDirLeft < WinCertificate->dwLength) {
+    if (SecDataDirLeft <= sizeof (WIN_CERTIFICATE)) {
+      break;
+    }
+    WinCertificate = (WIN_CERTIFICATE *) (mImageBase + OffSet);
+    if (SecDataDirLeft < WinCertificate->dwLength) {
       break;
     }
 


### PR DESCRIPTION
https://bugzilla.tianocore.org/show_bug.cgi?id=2215
https://edk2.groups.io/g/devel/message/64882
http://mid.mail-archive.com/20200901091221.20948-1-lersek@redhat.com
~~~
Ref:    https://bugzilla.tianocore.org/show_bug.cgi?id=2215
Repo:   https://pagure.io/lersek/edk2.git
Branch: tianocore_2215

I'm neutral on whether this becomes part of edk2-stable202008.

Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Min Xu <min.m.xu@intel.com>
Cc: Wenyi Xie <xiewenyi2@huawei.com>

Thanks,
Laszlo

Laszlo Ersek (3):
  SecurityPkg/DxeImageVerificationLib: extract SecDataDirEnd,
    SecDataDirLeft
  SecurityPkg/DxeImageVerificationLib: assign WinCertificate after size
    check
  SecurityPkg/DxeImageVerificationLib: catch alignment overflow
    (CVE-2019-14562)

 SecurityPkg/Library/DxeImageVerificationLib/DxeImageVerificationLib.c | 16 ++++++++++++----
 1 file changed, 12 insertions(+), 4 deletions(-)
~~~