### PR TITLE
Revert ".pytool/EccCheck: Disable Ecc error code 10014 for open CI"

### DIFF
--- a/.pytool/Plugin/EccCheck/EccCheck.py
+++ b/.pytool/Plugin/EccCheck/EccCheck.py
@@ -301,7 +301,6 @@ class EccCheck(ICiBuildPlugin):
                              "10011",
                              "10012",
                              "10013",
-                             "10014", #need to be removed after BZ2904 is fixed
                              "10015",
                              "10016",
                              "10017",


### PR DESCRIPTION
This reverts commit d4e0b9607c9a64a8eff20724b2e35ea2cd5bd33f.

REF: https://bugzilla.tianocore.org/show_bug.cgi?id=2951
Previously false positive Ecc issue whose error code is 10014 was reported
under Linux OS. So we disabled it in EccCheck plugin for edk2 open CI.
As the bug is fixed, we need to revert the change and re-enable it.

Cc: Sean Brogan <sean.brogan@microsoft.com>
Cc: Bret Barkelew <Bret.Barkelew@microsoft.com>
Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Signed-off-by: Shenglei Zhang <shenglei.zhang@intel.com>
Reviewed-by: Laszlo Ersek <lersek@redhat.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>