### PR TITLE
SecurityPkg/DxeImageVerificationLib: Disable SHA1 base on MACRO

### DIFF
--- a/SecurityPkg/Library/DxeImageVerificationLib/DxeImageVerificationLib.c
+++ b/SecurityPkg/Library/DxeImageVerificationLib/DxeImageVerificationLib.c
@@ -59,7 +59,11 @@ UINT8 mHashOidValue[] = {
   };
 
 HASH_TABLE mHash[] = {
+#ifndef DISABLE_SHA1_DEPRECATED_INTERFACES
   { L"SHA1",   20, &mHashOidValue[0],  5, Sha1GetContextSize,   Sha1Init,   Sha1Update,   Sha1Final  },
+#else
+  { L"SHA1",   20, &mHashOidValue[0],  5, NULL,                 NULL,       NULL,         NULL       },
+#endif
   { L"SHA224", 28, &mHashOidValue[5],  9, NULL,                 NULL,       NULL,         NULL       },
   { L"SHA256", 32, &mHashOidValue[14], 9, Sha256GetContextSize, Sha256Init, Sha256Update, Sha256Final},
   { L"SHA384", 48, &mHashOidValue[23], 9, Sha384GetContextSize, Sha384Init, Sha384Update, Sha384Final},
@@ -315,10 +319,12 @@ HashPeImage (
   ZeroMem (mImageDigest, MAX_DIGEST_SIZE);
 
   switch (HashAlg) {
+#ifndef DISABLE_SHA1_DEPRECATED_INTERFACES
   case HASHALG_SHA1:
     mImageDigestSize = SHA1_DIGEST_SIZE;
     mCertType        = gEfiCertSha1Guid;
     break;
+#endif
 
   case HASHALG_SHA256:
     mImageDigestSize = SHA256_DIGEST_SIZE;


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=2943

Disable SHA1 base on the MACRO DISABLE_SHA1_DEPRECATED_INTERFACES.
SHA1 is deprecated function and the MACRO is used to remove the whole
implementation of the SHA1. For the platforms that do not need SHA1
for security, the MACRO should works for DxeImageVerificationLib as
well.

Signed-off-by: Zhichao Gao <zhichao.gao@intel.com>
Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Min Xu <min.m.xu@intel.com>
Cc: Qi Zhang <qi1.zhang@intel.com>
Reviewed-by: Jiewen Yao <Jiewen.yao@intel.com>
Reviewed-by: Jian J Wang <jian.j.wang@intel.com>