### PR TITLE
BaseTools: Sort the Pcd set when generating the VPD binary

### DIFF
--- a/BaseTools/Source/Python/AutoGen/PlatformAutoGen.py
+++ b/BaseTools/Source/Python/AutoGen/PlatformAutoGen.py
@@ -253,7 +253,7 @@ class PlatformAutoGen(AutoGen):
         VariableInfo.SetVpdRegionMaxSize(VpdRegionSize)
         VariableInfo.SetVpdRegionOffset(VpdRegionBase)
         Index = 0
-        for Pcd in DynamicPcdSet:
+        for Pcd in sorted(DynamicPcdSet):
             pcdname = ".".join((Pcd.TokenSpaceGuidCName, Pcd.TokenCName))
             for SkuName in Pcd.SkuInfoList:
                 Sku = Pcd.SkuInfoList[SkuName]

--- a/BaseTools/Source/Python/Workspace/DscBuildData.py
+++ b/BaseTools/Source/Python/Workspace/DscBuildData.py
@@ -2584,7 +2584,7 @@ class DscBuildData(PlatformBuildClassObject):
         CApp = CApp + '\n'
         for Pcd in StructuredPcds.values():
             CApp = CApp + self.GenerateArrayAssignment(Pcd)
-        for PcdName in StructuredPcds:
+        for PcdName in sorted(StructuredPcds.keys()):
             Pcd = StructuredPcds[PcdName]
             CApp = CApp + self.GenerateSizeFunction(Pcd)
             CApp = CApp + self.GenerateDefaultValueAssignFunction(Pcd)


### PR DESCRIPTION
If VPD PcdNvStoreDefaultValueBuffer is used, all DynamicHii and
DynamicExHii PCD value will be generated into that VPD.

In order to generate the same VPD binary file in every build,
sort the Pcd set when generating VPD.

Signed-off-by: Bob Feng <bob.c.feng@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Yuwei Chen <yuwei.chen@intel.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>
Reviewed-by: Philippe Mathieu-Daude <philmd@redhat.com>