### PR TITLE
[edk2-devel] [PATCH] EmbeddedPkg/TimeBaseLib: remove the SEC_PER_MONTH, SEC_PER_YEAR macros -- push

### DIFF
--- a/EmbeddedPkg/Include/Library/TimeBaseLib.h
+++ b/EmbeddedPkg/Include/Library/TimeBaseLib.h
@@ -51,8 +51,6 @@
 #define SEC_PER_MIN                                     ((UINTN)    60)
 #define SEC_PER_HOUR                                    ((UINTN)  3600)
 #define SEC_PER_DAY                                     ((UINTN) 86400)
-#define SEC_PER_MONTH                                   ((UINTN)  2,592,000)
-#define SEC_PER_YEAR                                    ((UINTN) 31,536,000)
 
 BOOLEAN
 EFIAPI


### PR DESCRIPTION
https://edk2.groups.io/g/devel/message/65058
http://mid.mail-archive.com/20200904154541.23340-1-lersek@redhat.com
~~~
The SEC_PER_MONTH and SEC_PER_YEAR macros are wrong: they both evaluate to
0 (of type "int"). They are also unused (they could never be used for
division, for example); so remove them. The macros were originally
introduced in commit 0f4386e775c7 ("ArmPlatformPkg/PL031RealTimeClockLib:
Implement PL031 RTC drive", 2011-06-11).

Cc: Ard Biesheuvel <ard.biesheuvel@arm.com>
Cc: Leif Lindholm <leif@nuviainc.com>
Cc: Maciej Rabeda <maciej.rabeda@linux.intel.com>
Cc: Philippe Mathieu-Daudé <philmd@redhat.com>
Reported-by: Maciej Rabeda <maciej.rabeda@linux.intel.com>
Signed-off-by: Laszlo Ersek <lersek@redhat.com>
Message-Id: <20200904154541.23340-1-lersek@redhat.com>
Reviewed-by: Philippe Mathieu-Daudé <philmd@redhat.com>
Reviewed-by: Leif Lindholm <leif@nuviainc.com>
~~~