### PR TITLE
UefiCpuPkg/RegisterCpuFeaturesLib: Support MpServices2 only case.

### DIFF
--- a/UefiCpuPkg/Library/RegisterCpuFeaturesLib/PeiRegisterCpuFeaturesLib.inf
+++ b/UefiCpuPkg/Library/RegisterCpuFeaturesLib/PeiRegisterCpuFeaturesLib.inf
@@ -1,7 +1,7 @@
 ## @file
 #  Register CPU Features Library PEI instance.
 #
-#  Copyright (c) 2017 - 2019, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2017 - 2020, Intel Corporation. All rights reserved.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -45,7 +45,6 @@
   IoLib
 
 [Ppis]
-  gEfiPeiMpServicesPpiGuid                                             ## CONSUMES
   gEdkiiPeiMpServices2PpiGuid                                          ## CONSUMES
 
 [Pcd]
@@ -55,4 +54,4 @@
   gUefiCpuPkgTokenSpaceGuid.PcdCpuFeaturesSetting                      ## CONSUMES ## PRODUCES
 
 [Depex]
-  gEfiPeiMpServicesPpiGuid AND gEdkiiCpuFeaturesSetDoneGuid
+  gEdkiiPeiMpServices2PpiGuid AND gEdkiiCpuFeaturesSetDoneGuid

--- a/UefiCpuPkg/Library/RegisterCpuFeaturesLib/RegisterCpuFeatures.h
+++ b/UefiCpuPkg/Library/RegisterCpuFeaturesLib/RegisterCpuFeatures.h
@@ -10,7 +10,7 @@
 #define _REGISTER_CPU_FEATURES_H_
 #include <PiPei.h>
 #include <PiDxe.h>
-#include <Ppi/MpServices.h>
+#include <Ppi/MpServices2.h>
 #include <Protocol/MpService.h>
 
 #include <Library/BaseLib.h>
@@ -64,8 +64,8 @@ typedef struct {
 } PROGRAM_CPU_REGISTER_FLAGS;
 
 typedef union {
-  EFI_MP_SERVICES_PROTOCOL  *Protocol;
-  EFI_PEI_MP_SERVICES_PPI   *Ppi;
+  EFI_MP_SERVICES_PROTOCOL   *Protocol;
+  EDKII_PEI_MP_SERVICES2_PPI *Ppi;
 } MP_SERVICES;
 
 typedef struct {


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=2883

MpServices Ppi can be replaced by MpServices2 Ppi and MpServices2
Ppi is mandatory for RegisterCpuFeaturesLib functionality,
basing on this we can drop MpServices Ppi usage from the library
and the constraint that both Ppis must be installed.

Cc: Eric Dong <eric.dong@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Cc: Laszlo Ersek <lersek@redhat.com>
Cc: Rahul Kumar <rahul1.kumar@intel.com>
Cc: Nate DeSimone <nathaniel.l.desimone@intel.com>
Signed-off-by: Chasel Chiu <chasel.chiu@intel.com>
Reviewed-by: Eric Dong <eric.dong@intel.com>
Reviewed-by: Ray Ni <ray.ni@intel.com>