### PR TITLE
OvmfPkg: drop redundant VendorID check in VirtioMmioDeviceLib

### DIFF
--- a/OvmfPkg/Library/VirtioMmioDeviceLib/VirtioMmioDevice.c
+++ b/OvmfPkg/Library/VirtioMmioDeviceLib/VirtioMmioDevice.c
@@ -58,7 +58,6 @@ VirtioMmioInit (
   )
 {
   UINT32     MagicValue;
-  UINT32     VendorId;
   UINT32     Version;
 
   //
@@ -82,20 +81,6 @@ VirtioMmioInit (
   Version = VIRTIO_CFG_READ (Device, VIRTIO_MMIO_OFFSET_VERSION);
   if (Version != 1) {
     return EFI_UNSUPPORTED;
-  }
-
-  //
-  // Double-check MMIO-specific values
-  //
-  VendorId = VIRTIO_CFG_READ (Device, VIRTIO_MMIO_OFFSET_VENDOR_ID);
-  if (VendorId != VIRTIO_VENDOR_ID) {
-    //
-    // The ARM Base and Foundation Models do not report a valid VirtIo VendorId.
-    // They return a value of 0x0 for the VendorId.
-    //
-    DEBUG((DEBUG_WARN, "VirtioMmioInit: Warning: The VendorId (0x%X) does not "
-                       "match the VirtIo VendorId (0x%X).\n",
-                       VendorId, VIRTIO_VENDOR_ID));
   }
 
   return EFI_SUCCESS;


### PR DESCRIPTION
There is a DEBUG warning printout in VirtioMmioDeviceLib if the current
device's VendorID does not match the traditional 16-bit Red Hat PCIe
vendor ID used with virtio-pci. The virtio-mmio vendor ID is 32-bit and
has no connection to the PCIe registry.

Most specifically, this causes a bunch of noise when booting an AArch64
QEMU platform, since QEMU's virtio-mmio implementation used 'QEMU' as
the vendor ID:
VirtioMmioInit: Warning:
  The VendorId (0x554D4551) does not match the VirtIo VendorId (0x1AF4).

Drop the warning message.

Cc: Jordan Justen <jordan.l.justen@intel.com>
Cc: Laszlo Ersek <lersek@redhat.com>
Cc: Ard Biesheuvel <ard.biesheuvel@arm.com>
Signed-off-by: Leif Lindholm <leif@nuviainc.com>
Reviewed-by: Laszlo Ersek <lersek@redhat.com>
Reviewed-by: Philippe Mathieu-Daudé <philmd@redhat.com>