### PR TITLE
MdeModulePkg/NonDiscoverablePciDeviceDxe: Add NULL pointer check

### DIFF
--- a/MdeModulePkg/Bus/Pci/NonDiscoverablePciDeviceDxe/NonDiscoverablePciDeviceIo.c
+++ b/MdeModulePkg/Bus/Pci/NonDiscoverablePciDeviceDxe/NonDiscoverablePciDeviceIo.c
@@ -856,6 +856,10 @@ CoherentPciIoAllocateBuffer (
     return EFI_UNSUPPORTED;
   }
 
+  if (HostAddress == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
   if ((MemoryType != EfiBootServicesData) &&
       (MemoryType != EfiRuntimeServicesData)) {
     return EFI_INVALID_PARAMETER;


### PR DESCRIPTION
Add check for NULL HostAddress in AllocateBuffer as required by UEFI
specification.

Signed-off-by: Jeff Brasen <jbrasen@nvidia.com>
Reviewed-by: Hao A Wu <hao.a.wu@intel.com>