### PR TITLE
EmulatorPkg: Add RngLib to satisfy dependency of OpensslLib

### DIFF
--- a/EmulatorPkg/EmulatorPkg.dsc
+++ b/EmulatorPkg/EmulatorPkg.dsc
@@ -113,6 +113,7 @@
   FileHandleLib|MdePkg/Library/UefiFileHandleLib/UefiFileHandleLib.inf
 
 !if $(SECURE_BOOT_ENABLE) == TRUE
+  RngLib|MdePkg/Library/BaseRngLibTimerLib/BaseRngLibTimerLib.inf
   IntrinsicLib|CryptoPkg/Library/IntrinsicLib/IntrinsicLib.inf
   OpensslLib|CryptoPkg/Library/OpensslLib/OpensslLibCrypto.inf
   PlatformSecureLib|SecurityPkg/Library/PlatformSecureLibNull/PlatformSecureLibNull.inf


### PR DESCRIPTION
* Recently, OpensslLib [LibraryClasses] has been changed
  to include RngLib which causes the SECURE_BOOT_ENABLE
  build to fail in want of RngLib

* This patch adds the RngLib for OpensslLib

Signed-off-by: Divneil Rai Wadhawan <divneil.r.wadhawan@intel.com>
Reviewed-by: Ray Ni <ray.ni@intel.com>