### PR TITLE
EmulatorPkg/host: fix overflow in Mult

### DIFF
--- a/EmulatorPkg/Win/Host/WinHost.c
+++ b/EmulatorPkg/Win/Host/WinHost.c
@@ -577,7 +577,7 @@ Returns:
     //
     // Save the size of the memory and make a Unicode filename SystemMemory00, ...
     //
-    gSystemMemory[Index].Size = _wtoi (MemorySizeStr) * SIZE_1MB;
+    gSystemMemory[Index].Size = ((UINT64)_wtoi (MemorySizeStr)) * ((UINT64)SIZE_1MB);
 
     //
     // Find the next region


### PR DESCRIPTION
REF:https://bugzilla.tianocore.org/show_bug.cgi?id=2947

When calculating memory regions and store the information in the
gSystemMemory in file WinHost.c, the code below will cause overflow,
because _wtoi (MemorySizeStr) return an int value and SIZE_1MB is
also an int value, if MemorySizeStr is lager for example 2048, then
result of multiplication will overflow.

for (Index = 0, Done = FALSE; !Done; Index++) {
  //
  // Save the size of the memory and make a Unicode filename SystemMemory00
  //
  gSystemMemory[Index].Size = _wtoi (MemorySizeStr) * SIZE_1MB;

Cc: Jordan Justen <jordan.l.justen@intel.com>
Cc: Andrew Fish <afish@apple.com>
Reviewed-by: Ray Ni <ray.ni@intel.com>
Signed-off-by: Wenyi Xie <xiewenyi2@huawei.com>