### PR TITLE
IntelFsp2Pkg GenCfgOpt.py: Initialize IncLines as empty list

### DIFF
--- a/IntelFsp2Pkg/Tools/GenCfgOpt.py
+++ b/IntelFsp2Pkg/Tools/GenCfgOpt.py
@@ -1177,6 +1177,7 @@ EndList
         UpdSignatureCheck = ['FSPT_UPD_SIGNATURE', 'FSPM_UPD_SIGNATURE', 'FSPS_UPD_SIGNATURE']
         ExcludedSpecificUpd = ['FSPT_ARCH_UPD', 'FSPM_ARCH_UPD', 'FSPS_ARCH_UPD']
 
+        IncLines = []
         if InputHeaderFile != '':
             if not os.path.exists(InputHeaderFile):
                  self.Error = "Input header file '%s' does not exist" % InputHeaderFile


### PR DESCRIPTION
IncLines as empty list for the case when InputHeaderFile is not specified.

Cc: Chasel Chiu <chasel.chiu@intel.com>
Cc: Nate DeSimone <nathaniel.l.desimone@intel.com>
Cc: Star Zeng <star.zeng@intel.com>
Signed-off-by: Liming Gao <gaoliming@byosoft.com.cn>
Reviewed-by: Chasel Chiu <chasel.chiu@intel.com>
Reviewed-by: Star Zeng <star.zeng@intel.com>