### PR TITLE
MdeModulePkg/XhciDxe: Fix Broken Timeouts

### DIFF
--- a/MdeModulePkg/Bus/Pci/XhciDxe/XhciReg.c
+++ b/MdeModulePkg/Bus/Pci/XhciDxe/XhciReg.c
@@ -423,14 +423,15 @@ XhcClearOpRegBit (
   Wait the operation register's bit as specified by Bit
   to become set (or clear).
 
-  @param  Xhc          The XHCI Instance.
-  @param  Offset       The offset of the operation register.
-  @param  Bit          The bit of the register to wait for.
-  @param  WaitToSet    Wait the bit to set or clear.
-  @param  Timeout      The time to wait before abort (in millisecond, ms).
+  @param  Xhc                    The XHCI Instance.
+  @param  Offset                 The offset of the operation register.
+  @param  Bit                    The bit of the register to wait for.
+  @param  WaitToSet              Wait the bit to set or clear.
+  @param  Timeout                The time to wait before abort (in millisecond, ms).
 
-  @retval EFI_SUCCESS  The bit successfully changed by host controller.
-  @retval EFI_TIMEOUT  The time out occurred.
+  @retval EFI_SUCCESS            The bit successfully changed by host controller.
+  @retval EFI_TIMEOUT            The time out occurred.
+  @retval EFI_OUT_OF_RESOURCES   Memory for the timer event could not be allocated.
 
 **/
 EFI_STATUS
@@ -442,20 +443,52 @@ XhcWaitOpRegBit (
   IN UINT32               Timeout
   )
 {
-  UINT32                  Index;
-  UINT64                  Loop;
+  EFI_STATUS Status;
+  EFI_EVENT  TimeoutEvent;
 
-  Loop   = Timeout * XHC_1_MILLISECOND;
+  TimeoutEvent = NULL;
 
-  for (Index = 0; Index < Loop; Index++) {
+  if (Timeout == 0) {
+    return EFI_TIMEOUT;
+  }
+
+  Status = gBS->CreateEvent (
+                  EVT_TIMER,
+                  TPL_CALLBACK,
+                  NULL,
+                  NULL,
+                  &TimeoutEvent
+                  );
+
+  if (EFI_ERROR(Status)) {
+    goto DONE;
+  }
+
+  Status = gBS->SetTimer (TimeoutEvent,
+                          TimerRelative,
+                          EFI_TIMER_PERIOD_MILLISECONDS(Timeout));
+
+  if (EFI_ERROR(Status)) {
+    goto DONE;
+  }
+
+  do {
     if (XHC_REG_BIT_IS_SET (Xhc, Offset, Bit) == WaitToSet) {
-      return EFI_SUCCESS;
+      Status = EFI_SUCCESS;
+      goto DONE;
     }
 
     gBS->Stall (XHC_1_MICROSECOND);
+  } while (EFI_ERROR(gBS->CheckEvent (TimeoutEvent)));
+
+  Status = EFI_TIMEOUT;
+
+DONE:
+  if (TimeoutEvent != NULL) {
+    gBS->CloseEvent (TimeoutEvent);
   }
 
-  return EFI_TIMEOUT;
+  return Status;
 }
 
 /**


### PR DESCRIPTION
https://edk2.groups.io/g/devel/message/65543
https://bugzilla.tianocore.org/show_bug.cgi?id=2948

**Cover-letter:**
Timeouts in the XhciDxe driver are taking longer than expected due to the timeout loops not accounting for code execution time. As en example, 5 second timeouts have been observed to take around 36 seconds to complete.
Use SetTimer and Create/CheckEvent from Boot Services to determine when timeout occurred. This patch was tested using forced timeouts and print statements with QEmu as well as phycial hardware. The forced timeouts were implemented in code via static variables that guaranteed a timeout the first time the function with the broken timeout was called.

Example:

XhcExecTransfer (
  .
  .
 )
{
  .
  .
  static int do_once = 1;  // test line
  .
  .
  do {
    Finished = XhcCheckUrbResult (Xhc, Urb);
    if (do_once) Finished = 0; // test line
    if (Finished) {
      break;
    }
    gBS->Stall (XHC_1_MICROSECOND);
  } while (EFI_ERROR(gBS->CheckEvent (TimeoutEvent)));

  do_once = 0; // test line

Using this forced timeout approach the correct timeouts were observed on both hardware and in QEmu.

Similar broken timeout loops have been found in the Uhci and Ehci drivers. This patch does not fix those issues.

**Commit message:**
REF:https://bugzilla.tianocore.org/show_bug.cgi?id=2948

Timeouts in the XhciDxe driver are taking longer than
expected due to the timeout loops not accounting for
code execution time. As en example, 5 second timeouts
have been observed to take around 36 seconds to complete.
Use SetTimer and Create/CheckEvent from Boot Services to
determine when timeout occurred.

Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Hao A Wu <hao.a.wu@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Signed-off-by: Patrick Henz <patrick.henz@hpe.com>
Reviewed-by: Hao A Wu <hao.a.wu@intel.com>