### PR TITLE
CryptoPkg/BaseCryptLib: add crypto algorithms needed by variable prot…

### DIFF
--- a/CryptoPkg/Library/BaseCryptLib/PeiCryptLib.inf
+++ b/CryptoPkg/Library/BaseCryptLib/PeiCryptLib.inf
@@ -40,8 +40,8 @@
   Hash/CryptSha256.c
   Hash/CryptSm3.c
   Hash/CryptSha512.c
-  Hmac/CryptHmacSha256Null.c
-  Kdf/CryptHkdfNull.c
+  Hmac/CryptHmacSha256.c
+  Kdf/CryptHkdf.c
   Cipher/CryptAesNull.c
   Pk/CryptRsaBasic.c
   Pk/CryptRsaExtNull.c

--- a/CryptoPkg/Library/BaseCryptLib/RuntimeCryptLib.inf
+++ b/CryptoPkg/Library/BaseCryptLib/RuntimeCryptLib.inf
@@ -40,9 +40,9 @@
   Hash/CryptSha256.c
   Hash/CryptSm3.c
   Hash/CryptSha512Null.c
-  Hmac/CryptHmacSha256Null.c
-  Kdf/CryptHkdfNull.c
-  Cipher/CryptAesNull.c
+  Hmac/CryptHmacSha256.c
+  Kdf/CryptHkdf.c
+  Cipher/CryptAes.c
   Pk/CryptRsaBasic.c
   Pk/CryptRsaExtNull.c
   Pk/CryptPkcs1OaepNull.c


### PR DESCRIPTION
…ection

REF: https://bugzilla.tianocore.org/show_bug.cgi?id=2594

Crypto algorithms, hkdf-sha256/hmac-sha256/aes, are needed to verify
integrity of variable data, derive hmac and encryption keys, and
encrypt/decrypt varible. Replacing null version source code with real
implementations makes sure we can enable full functionalities of protected
variable later.

Cc: Xiaoyu Lu <xiaoyux.lu@intel.com>
Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Guomin Jiang <guomin.jiang@intel.com>
Cc: Nishant C Mistry <nishant.c.mistry@intel.com>
Signed-off-by: Jian J Wang <jian.j.wang@intel.com>
Reviewed-by: Jiewen Yao <jiewen.yao@intel.com>