### PR TITLE
[BaseTools] For Basetools, use pip if available

### DIFF
--- a/BaseTools/BinPipWrappers/PosixLike/AmlToC
+++ b/BaseTools/BinPipWrappers/PosixLike/AmlToC
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+#python `dirname $0`/RunToolFromSource.py `basename $0` $*
+
+# If a ${PYTHON_COMMAND} command is available, use it in preference to python
+if command -v ${PYTHON_COMMAND} >/dev/null 2>&1; then
+    python_exe=${PYTHON_COMMAND}
+fi
+
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+dir=$(dirname "$full_cmd")
+exe=$(basename "$full_cmd")
+
+export PYTHONPATH="$dir/../../Source/Python${PYTHONPATH:+:"$PYTHONPATH"}"
+exec "${python_exe:-python}" "$dir/../../Source/Python/$exe/$exe.py" "$@"

--- a/BaseTools/BinPipWrappers/PosixLike/BPDG
+++ b/BaseTools/BinPipWrappers/PosixLike/BPDG
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+#python `dirname $0`/RunToolFromSource.py `basename $0` $*
+
+# If a ${PYTHON_COMMAND} command is available, use it in preference to python
+if command -v ${PYTHON_COMMAND} >/dev/null 2>&1; then
+    python_exe=${PYTHON_COMMAND}
+fi
+
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+cmd=${full_cmd##*/}
+
+exec "${python_exe:-python}" -m edk2basetools.$cmd.EccMain "$@"

--- a/BaseTools/BinPipWrappers/PosixLike/Brotli
+++ b/BaseTools/BinPipWrappers/PosixLike/Brotli
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+dir=$(dirname "$full_cmd")
+cmd=${full_cmd##*/}
+
+if [ -n "$WORKSPACE" ] && [ -e "$WORKSPACE/Conf/BaseToolsCBinaries" ]
+then
+  exec "$WORKSPACE/Conf/BaseToolsCBinaries/$cmd"
+elif [ -n "$WORKSPACE" ] && [ -e "$EDK_TOOLS_PATH/Source/C" ]
+then
+  if [ ! -e "$EDK_TOOLS_PATH/Source/C/bin/$cmd" ]
+  then
+    echo "BaseTools C Tool binary was not found ($cmd)"
+    echo "You may need to run:"
+    echo "  make -C $EDK_TOOLS_PATH/Source/C"
+  else
+    exec "$EDK_TOOLS_PATH/Source/C/bin/$cmd" "$@"
+  fi
+elif [ -e "$dir/../../Source/C/bin/$cmd" ]
+then
+  exec "$dir/../../Source/C/bin/$cmd" "$@"
+else
+  echo "Unable to find the real '$cmd' to run"
+  echo "This message was printed by"
+  echo "  $0"
+  exit 127
+fi
+

--- a/BaseTools/BinPipWrappers/PosixLike/BrotliCompress
+++ b/BaseTools/BinPipWrappers/PosixLike/BrotliCompress
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# This script will exec Brotli tool with -e/-d options.
+#
+# Copyright (c) 2017 - 2018, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+QLT="-q 9 -w 22"
+ARGS=
+
+while test $# -gt 0
+do
+  case $1 in
+    -e)
+      ;;
+    -d)
+      ARGS+="$1 "
+      ;;
+    -o|-g)
+      ARGS+="$1 $2 "
+      shift
+      ;;
+    -q)
+      QLT="$1 $2 "
+      shift
+      ;;
+    *)
+      ARGS+="$1 "
+      ;;
+  esac
+  shift
+done
+
+exec Brotli $QLT $ARGS

--- a/BaseTools/BinPipWrappers/PosixLike/DevicePath
+++ b/BaseTools/BinPipWrappers/PosixLike/DevicePath
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+dir=$(dirname "$full_cmd")
+cmd=${full_cmd##*/}
+
+if [ -n "$WORKSPACE" ] && [ -e "$WORKSPACE/Conf/BaseToolsCBinaries" ]
+then
+  exec "$WORKSPACE/Conf/BaseToolsCBinaries/$cmd"
+elif [ -n "$WORKSPACE" ] && [ -e "$EDK_TOOLS_PATH/Source/C" ]
+then
+  if [ ! -e "$EDK_TOOLS_PATH/Source/C/bin/$cmd" ]
+  then
+    echo "BaseTools C Tool binary was not found ($cmd)"
+    echo "You may need to run:"
+    echo "  make -C $EDK_TOOLS_PATH/Source/C"
+  else
+    exec "$EDK_TOOLS_PATH/Source/C/bin/$cmd" "$@"
+  fi
+elif [ -e "$dir/../../Source/C/bin/$cmd" ]
+then
+  exec "$dir/../../Source/C/bin/$cmd" "$@"
+else
+  echo "Unable to find the real '$cmd' to run"
+  echo "This message was printed by"
+  echo "  $0"
+  exit 127
+fi
+

--- a/BaseTools/BinPipWrappers/PosixLike/Ecc
+++ b/BaseTools/BinPipWrappers/PosixLike/Ecc
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+#python `dirname $0`/RunToolFromSource.py `basename $0` $*
+
+# If a ${PYTHON_COMMAND} command is available, use it in preference to python
+if command -v ${PYTHON_COMMAND} >/dev/null 2>&1; then
+    python_exe=${PYTHON_COMMAND}
+fi
+
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+cmd=${full_cmd##*/}
+
+export PYTHONPATH="$dir/../../Source/Python${PYTHONPATH:+:"$PYTHONPATH"}"
+exec "${python_exe:-python}" -m $cmd.EccMain "$@"

--- a/BaseTools/BinPipWrappers/PosixLike/EfiRom
+++ b/BaseTools/BinPipWrappers/PosixLike/EfiRom
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+dir=$(dirname "$full_cmd")
+cmd=${full_cmd##*/}
+
+if [ -n "$WORKSPACE" ] && [ -e "$WORKSPACE/Conf/BaseToolsCBinaries" ]
+then
+  exec "$WORKSPACE/Conf/BaseToolsCBinaries/$cmd"
+elif [ -n "$WORKSPACE" ] && [ -e "$EDK_TOOLS_PATH/Source/C" ]
+then
+  if [ ! -e "$EDK_TOOLS_PATH/Source/C/bin/$cmd" ]
+  then
+    echo "BaseTools C Tool binary was not found ($cmd)"
+    echo "You may need to run:"
+    echo "  make -C $EDK_TOOLS_PATH/Source/C"
+  else
+    exec "$EDK_TOOLS_PATH/Source/C/bin/$cmd" "$@"
+  fi
+elif [ -e "$dir/../../Source/C/bin/$cmd" ]
+then
+  exec "$dir/../../Source/C/bin/$cmd" "$@"
+else
+  echo "Unable to find the real '$cmd' to run"
+  echo "This message was printed by"
+  echo "  $0"
+  exit 127
+fi
+

--- a/BaseTools/BinPipWrappers/PosixLike/GenCrc32
+++ b/BaseTools/BinPipWrappers/PosixLike/GenCrc32
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+dir=$(dirname "$full_cmd")
+cmd=${full_cmd##*/}
+
+if [ -n "$WORKSPACE" ] && [ -e "$WORKSPACE/Conf/BaseToolsCBinaries" ]
+then
+  exec "$WORKSPACE/Conf/BaseToolsCBinaries/$cmd"
+elif [ -n "$WORKSPACE" ] && [ -e "$EDK_TOOLS_PATH/Source/C" ]
+then
+  if [ ! -e "$EDK_TOOLS_PATH/Source/C/bin/$cmd" ]
+  then
+    echo "BaseTools C Tool binary was not found ($cmd)"
+    echo "You may need to run:"
+    echo "  make -C $EDK_TOOLS_PATH/Source/C"
+  else
+    exec "$EDK_TOOLS_PATH/Source/C/bin/$cmd" "$@"
+  fi
+elif [ -e "$dir/../../Source/C/bin/$cmd" ]
+then
+  exec "$dir/../../Source/C/bin/$cmd" "$@"
+else
+  echo "Unable to find the real '$cmd' to run"
+  echo "This message was printed by"
+  echo "  $0"
+  exit 127
+fi
+

--- a/BaseTools/BinPipWrappers/PosixLike/GenDepex
+++ b/BaseTools/BinPipWrappers/PosixLike/GenDepex
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+#python `dirname $0`/RunToolFromSource.py `basename $0` $*
+
+# If a ${PYTHON_COMMAND} command is available, use it in preference to python
+if command -v ${PYTHON_COMMAND} >/dev/null 2>&1; then
+    python_exe=${PYTHON_COMMAND}
+fi
+
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+cmd=${full_cmd##*/}
+
+exec "${python_exe:-python}" -m edk2basetools.AutoGen.$cmd "$@"

--- a/BaseTools/BinPipWrappers/PosixLike/GenFds
+++ b/BaseTools/BinPipWrappers/PosixLike/GenFds
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+#python `dirname $0`/RunToolFromSource.py `basename $0` $*
+
+# If a ${PYTHON_COMMAND} command is available, use it in preference to python
+if command -v ${PYTHON_COMMAND} >/dev/null 2>&1; then
+    python_exe=${PYTHON_COMMAND}
+fi
+
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+cmd=${full_cmd##*/}
+
+exec "${python_exe:-python}" -m edk2basetools.$cmd "$@"

--- a/BaseTools/BinPipWrappers/PosixLike/GenFfs
+++ b/BaseTools/BinPipWrappers/PosixLike/GenFfs
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+dir=$(dirname "$full_cmd")
+cmd=${full_cmd##*/}
+
+if [ -n "$WORKSPACE" ] && [ -e "$WORKSPACE/Conf/BaseToolsCBinaries" ]
+then
+  exec "$WORKSPACE/Conf/BaseToolsCBinaries/$cmd"
+elif [ -n "$WORKSPACE" ] && [ -e "$EDK_TOOLS_PATH/Source/C" ]
+then
+  if [ ! -e "$EDK_TOOLS_PATH/Source/C/bin/$cmd" ]
+  then
+    echo "BaseTools C Tool binary was not found ($cmd)"
+    echo "You may need to run:"
+    echo "  make -C $EDK_TOOLS_PATH/Source/C"
+  else
+    exec "$EDK_TOOLS_PATH/Source/C/bin/$cmd" "$@"
+  fi
+elif [ -e "$dir/../../Source/C/bin/$cmd" ]
+then
+  exec "$dir/../../Source/C/bin/$cmd" "$@"
+else
+  echo "Unable to find the real '$cmd' to run"
+  echo "This message was printed by"
+  echo "  $0"
+  exit 127
+fi
+

--- a/BaseTools/BinPipWrappers/PosixLike/GenFv
+++ b/BaseTools/BinPipWrappers/PosixLike/GenFv
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+dir=$(dirname "$full_cmd")
+cmd=${full_cmd##*/}
+
+if [ -n "$WORKSPACE" ] && [ -e "$WORKSPACE/Conf/BaseToolsCBinaries" ]
+then
+  exec "$WORKSPACE/Conf/BaseToolsCBinaries/$cmd"
+elif [ -n "$WORKSPACE" ] && [ -e "$EDK_TOOLS_PATH/Source/C" ]
+then
+  if [ ! -e "$EDK_TOOLS_PATH/Source/C/bin/$cmd" ]
+  then
+    echo "BaseTools C Tool binary was not found ($cmd)"
+    echo "You may need to run:"
+    echo "  make -C $EDK_TOOLS_PATH/Source/C"
+  else
+    exec "$EDK_TOOLS_PATH/Source/C/bin/$cmd" "$@"
+  fi
+elif [ -e "$dir/../../Source/C/bin/$cmd" ]
+then
+  exec "$dir/../../Source/C/bin/$cmd" "$@"
+else
+  echo "Unable to find the real '$cmd' to run"
+  echo "This message was printed by"
+  echo "  $0"
+  exit 127
+fi
+

--- a/BaseTools/BinPipWrappers/PosixLike/GenFw
+++ b/BaseTools/BinPipWrappers/PosixLike/GenFw
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+dir=$(dirname "$full_cmd")
+cmd=${full_cmd##*/}
+
+if [ -n "$WORKSPACE" ] && [ -e "$WORKSPACE/Conf/BaseToolsCBinaries" ]
+then
+  exec "$WORKSPACE/Conf/BaseToolsCBinaries/$cmd"
+elif [ -n "$WORKSPACE" ] && [ -e "$EDK_TOOLS_PATH/Source/C" ]
+then
+  if [ ! -e "$EDK_TOOLS_PATH/Source/C/bin/$cmd" ]
+  then
+    echo "BaseTools C Tool binary was not found ($cmd)"
+    echo "You may need to run:"
+    echo "  make -C $EDK_TOOLS_PATH/Source/C"
+  else
+    exec "$EDK_TOOLS_PATH/Source/C/bin/$cmd" "$@"
+  fi
+elif [ -e "$dir/../../Source/C/bin/$cmd" ]
+then
+  exec "$dir/../../Source/C/bin/$cmd" "$@"
+else
+  echo "Unable to find the real '$cmd' to run"
+  echo "This message was printed by"
+  echo "  $0"
+  exit 127
+fi
+

--- a/BaseTools/BinPipWrappers/PosixLike/GenPatchPcdTable
+++ b/BaseTools/BinPipWrappers/PosixLike/GenPatchPcdTable
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+#python `dirname $0`/RunToolFromSource.py `basename $0` $*
+
+# If a ${PYTHON_COMMAND} command is available, use it in preference to python
+if command -v ${PYTHON_COMMAND} >/dev/null 2>&1; then
+    python_exe=${PYTHON_COMMAND}
+fi
+
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+cmd=${full_cmd##*/}
+
+exec "${python_exe:-python}" -m edk2basetools.$cmd.$cmd "$@"

--- a/BaseTools/BinPipWrappers/PosixLike/GenSec
+++ b/BaseTools/BinPipWrappers/PosixLike/GenSec
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+dir=$(dirname "$full_cmd")
+cmd=${full_cmd##*/}
+
+if [ -n "$WORKSPACE" ] && [ -e "$WORKSPACE/Conf/BaseToolsCBinaries" ]
+then
+  exec "$WORKSPACE/Conf/BaseToolsCBinaries/$cmd"
+elif [ -n "$WORKSPACE" ] && [ -e "$EDK_TOOLS_PATH/Source/C" ]
+then
+  if [ ! -e "$EDK_TOOLS_PATH/Source/C/bin/$cmd" ]
+  then
+    echo "BaseTools C Tool binary was not found ($cmd)"
+    echo "You may need to run:"
+    echo "  make -C $EDK_TOOLS_PATH/Source/C"
+  else
+    exec "$EDK_TOOLS_PATH/Source/C/bin/$cmd" "$@"
+  fi
+elif [ -e "$dir/../../Source/C/bin/$cmd" ]
+then
+  exec "$dir/../../Source/C/bin/$cmd" "$@"
+else
+  echo "Unable to find the real '$cmd' to run"
+  echo "This message was printed by"
+  echo "  $0"
+  exit 127
+fi
+

--- a/BaseTools/BinPipWrappers/PosixLike/GenerateCapsule
+++ b/BaseTools/BinPipWrappers/PosixLike/GenerateCapsule
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+#python `dirname $0`/RunToolFromSource.py `basename $0` $*
+
+# If a ${PYTHON_COMMAND} command is available, use it in preference to python
+if command -v ${PYTHON_COMMAND} >/dev/null 2>&1; then
+    python_exe=${PYTHON_COMMAND}
+fi
+
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+cmd=${full_cmd##*/}
+
+exec "${python_exe:-python}" -m edk2basetools.Capsule.$cmd "$@"

--- a/BaseTools/BinPipWrappers/PosixLike/LzmaCompress
+++ b/BaseTools/BinPipWrappers/PosixLike/LzmaCompress
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+dir=$(dirname "$full_cmd")
+cmd=${full_cmd##*/}
+
+if [ -n "$WORKSPACE" ] && [ -e "$WORKSPACE/Conf/BaseToolsCBinaries" ]
+then
+  exec "$WORKSPACE/Conf/BaseToolsCBinaries/$cmd"
+elif [ -n "$WORKSPACE" ] && [ -e "$EDK_TOOLS_PATH/Source/C" ]
+then
+  if [ ! -e "$EDK_TOOLS_PATH/Source/C/bin/$cmd" ]
+  then
+    echo "BaseTools C Tool binary was not found ($cmd)"
+    echo "You may need to run:"
+    echo "  make -C $EDK_TOOLS_PATH/Source/C"
+  else
+    exec "$EDK_TOOLS_PATH/Source/C/bin/$cmd" "$@"
+  fi
+elif [ -e "$dir/../../Source/C/bin/$cmd" ]
+then
+  exec "$dir/../../Source/C/bin/$cmd" "$@"
+else
+  echo "Unable to find the real '$cmd' to run"
+  echo "This message was printed by"
+  echo "  $0"
+  exit 127
+fi
+

--- a/BaseTools/BinPipWrappers/PosixLike/LzmaF86Compress
+++ b/BaseTools/BinPipWrappers/PosixLike/LzmaF86Compress
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+#
+# This script will exec LzmaCompress tool with --f86 option that enables converter for x86 code.
+#
+# (C) Copyright 2016 Hewlett Packard Enterprise Development LP<BR>
+# Copyright (c) 2012, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+
+for arg; do
+  case $arg in
+    -e|-d)
+      set -- "$@" --f86
+      break
+    ;;
+  esac
+done
+
+exec LzmaCompress "$@"

--- a/BaseTools/BinPipWrappers/PosixLike/PatchPcdValue
+++ b/BaseTools/BinPipWrappers/PosixLike/PatchPcdValue
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+#python `dirname $0`/RunToolFromSource.py `basename $0` $*
+
+# If a ${PYTHON_COMMAND} command is available, use it in preference to python
+if command -v ${PYTHON_COMMAND} >/dev/null 2>&1; then
+    python_exe=${PYTHON_COMMAND}
+fi
+
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+cmd=${full_cmd##*/}
+
+exec "${python_exe:-python}" -m edk2basetools.$cmd.$cmd "$@"

--- a/BaseTools/BinPipWrappers/PosixLike/Pkcs7Sign
+++ b/BaseTools/BinPipWrappers/PosixLike/Pkcs7Sign
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+#python `dirname $0`/RunToolFromSource.py `basename $0` $*
+
+# If a ${PYTHON_COMMAND} command is available, use it in preference to python
+if command -v ${PYTHON_COMMAND} >/dev/null 2>&1; then
+    python_exe=${PYTHON_COMMAND}
+fi
+
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+cmd=${full_cmd##*/}
+
+exec "${python_exe:-python}" -m edk2basetools.$cmd.$cmd "$@"

--- a/BaseTools/BinPipWrappers/PosixLike/Rsa2048Sha256GenerateKeys
+++ b/BaseTools/BinPipWrappers/PosixLike/Rsa2048Sha256GenerateKeys
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+#python `dirname $0`/RunToolFromSource.py `basename $0` $*
+
+# If a ${PYTHON_COMMAND} command is available, use it in preference to python
+if command -v ${PYTHON_COMMAND} >/dev/null 2>&1; then
+    python_exe=${PYTHON_COMMAND}
+fi
+
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+cmd=${full_cmd##*/}
+
+exec "${python_exe:-python}" -m edk2basetools.Rsa2048Sha256Sign.$cmd "$@"

--- a/BaseTools/BinPipWrappers/PosixLike/Rsa2048Sha256Sign
+++ b/BaseTools/BinPipWrappers/PosixLike/Rsa2048Sha256Sign
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+#python `dirname $0`/RunToolFromSource.py `basename $0` $*
+
+# If a ${PYTHON_COMMAND} command is available, use it in preference to python
+if command -v ${PYTHON_COMMAND} >/dev/null 2>&1; then
+    python_exe=${PYTHON_COMMAND}
+fi
+
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+cmd=${full_cmd##*/}
+
+exec "${python_exe:-python}" -m edk2basetools.$cmd.$cmd "$@"

--- a/BaseTools/BinPipWrappers/PosixLike/Split
+++ b/BaseTools/BinPipWrappers/PosixLike/Split
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+dir=$(dirname "$full_cmd")
+cmd=${full_cmd##*/}
+
+if [ -n "$WORKSPACE" ] && [ -e "$WORKSPACE/Conf/BaseToolsCBinaries" ]
+then
+  exec "$WORKSPACE/Conf/BaseToolsCBinaries/$cmd"
+elif [ -n "$WORKSPACE" ] && [ -e "$EDK_TOOLS_PATH/Source/C" ]
+then
+  if [ ! -e "$EDK_TOOLS_PATH/Source/C/bin/$cmd" ]
+  then
+    echo "BaseTools C Tool binary was not found ($cmd)"
+    echo "You may need to run:"
+    echo "  make -C $EDK_TOOLS_PATH/Source/C"
+  else
+    exec "$EDK_TOOLS_PATH/Source/C/bin/$cmd" "$@"
+  fi
+elif [ -e "$dir/../../Source/C/bin/$cmd" ]
+then
+  exec "$dir/../../Source/C/bin/$cmd" "$@"
+else
+  echo "Unable to find the real '$cmd' to run"
+  echo "This message was printed by"
+  echo "  $0"
+  exit 127
+fi
+

--- a/BaseTools/BinPipWrappers/PosixLike/TargetTool
+++ b/BaseTools/BinPipWrappers/PosixLike/TargetTool
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+#python `dirname $0`/RunToolFromSource.py `basename $0` $*
+
+# If a ${PYTHON_COMMAND} command is available, use it in preference to python
+if command -v ${PYTHON_COMMAND} >/dev/null 2>&1; then
+    python_exe=${PYTHON_COMMAND}
+fi
+
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+cmd=${full_cmd##*/}
+
+exec "${python_exe:-python}" -m edk2basetools.$cmd.$cmd "$@"

--- a/BaseTools/BinPipWrappers/PosixLike/TianoCompress
+++ b/BaseTools/BinPipWrappers/PosixLike/TianoCompress
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+dir=$(dirname "$full_cmd")
+cmd=${full_cmd##*/}
+
+if [ -n "$WORKSPACE" ] && [ -e "$WORKSPACE/Conf/BaseToolsCBinaries" ]
+then
+  exec "$WORKSPACE/Conf/BaseToolsCBinaries/$cmd"
+elif [ -n "$WORKSPACE" ] && [ -e "$EDK_TOOLS_PATH/Source/C" ]
+then
+  if [ ! -e "$EDK_TOOLS_PATH/Source/C/bin/$cmd" ]
+  then
+    echo "BaseTools C Tool binary was not found ($cmd)"
+    echo "You may need to run:"
+    echo "  make -C $EDK_TOOLS_PATH/Source/C"
+  else
+    exec "$EDK_TOOLS_PATH/Source/C/bin/$cmd" "$@"
+  fi
+elif [ -e "$dir/../../Source/C/bin/$cmd" ]
+then
+  exec "$dir/../../Source/C/bin/$cmd" "$@"
+else
+  echo "Unable to find the real '$cmd' to run"
+  echo "This message was printed by"
+  echo "  $0"
+  exit 127
+fi
+

--- a/BaseTools/BinPipWrappers/PosixLike/Trim
+++ b/BaseTools/BinPipWrappers/PosixLike/Trim
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+#python `dirname $0`/RunToolFromSource.py `basename $0` $*
+
+# If a ${PYTHON_COMMAND} command is available, use it in preference to python
+if command -v ${PYTHON_COMMAND} >/dev/null 2>&1; then
+    python_exe=${PYTHON_COMMAND}
+fi
+
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+cmd=$(basename "$full_cmd")
+
+exec "${python_exe:-python}" -m edk2basetools.$cmd.$cmd "$@"
+

--- a/BaseTools/BinPipWrappers/PosixLike/UPT
+++ b/BaseTools/BinPipWrappers/PosixLike/UPT
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+#python `dirname $0`/RunToolFromSource.py `basename $0` $*
+
+# If a ${PYTHON_COMMAND} command is available, use it in preference to python
+if command -v ${PYTHON_COMMAND} >/dev/null 2>&1; then
+    python_exe=${PYTHON_COMMAND}
+fi
+
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+cmd=${full_cmd##*/}
+
+exec "${python_exe:-python}" -m edk2basetools.$cmd.$cmd "$@"

--- a/BaseTools/BinPipWrappers/PosixLike/VfrCompile
+++ b/BaseTools/BinPipWrappers/PosixLike/VfrCompile
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+dir=$(dirname "$full_cmd")
+cmd=${full_cmd##*/}
+
+if [ -n "$WORKSPACE" ] && [ -e "$WORKSPACE/Conf/BaseToolsCBinaries" ]
+then
+  exec "$WORKSPACE/Conf/BaseToolsCBinaries/$cmd"
+elif [ -n "$WORKSPACE" ] && [ -e "$EDK_TOOLS_PATH/Source/C" ]
+then
+  if [ ! -e "$EDK_TOOLS_PATH/Source/C/bin/$cmd" ]
+  then
+    echo "BaseTools C Tool binary was not found ($cmd)"
+    echo "You may need to run:"
+    echo "  make -C $EDK_TOOLS_PATH/Source/C"
+  else
+    exec "$EDK_TOOLS_PATH/Source/C/bin/$cmd" "$@"
+  fi
+elif [ -e "$dir/../../Source/C/bin/$cmd" ]
+then
+  exec "$dir/../../Source/C/bin/$cmd" "$@"
+else
+  echo "Unable to find the real '$cmd' to run"
+  echo "This message was printed by"
+  echo "  $0"
+  exit 127
+fi
+

--- a/BaseTools/BinPipWrappers/PosixLike/VolInfo
+++ b/BaseTools/BinPipWrappers/PosixLike/VolInfo
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+dir=$(dirname "$full_cmd")
+cmd=${full_cmd##*/}
+
+if [ -n "$WORKSPACE" ] && [ -e "$WORKSPACE/Conf/BaseToolsCBinaries" ]
+then
+  exec "$WORKSPACE/Conf/BaseToolsCBinaries/$cmd"
+elif [ -n "$WORKSPACE" ] && [ -e "$EDK_TOOLS_PATH/Source/C" ]
+then
+  if [ ! -e "$EDK_TOOLS_PATH/Source/C/bin/$cmd" ]
+  then
+    echo "BaseTools C Tool binary was not found ($cmd)"
+    echo "You may need to run:"
+    echo "  make -C $EDK_TOOLS_PATH/Source/C"
+  else
+    exec "$EDK_TOOLS_PATH/Source/C/bin/$cmd" "$@"
+  fi
+elif [ -e "$dir/../../Source/C/bin/$cmd" ]
+then
+  exec "$dir/../../Source/C/bin/$cmd" "$@"
+else
+  echo "Unable to find the real '$cmd' to run"
+  echo "This message was printed by"
+  echo "  $0"
+  exit 127
+fi
+

--- a/BaseTools/BinPipWrappers/PosixLike/build
+++ b/BaseTools/BinPipWrappers/PosixLike/build
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+#python `dirname $0`/RunToolFromSource.py `basename $0` $*
+
+# If a ${PYTHON_COMMAND} command is available, use it in preference to python
+if command -v ${PYTHON_COMMAND} >/dev/null 2>&1; then
+    python_exe=${PYTHON_COMMAND}
+fi
+
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+cmd=${full_cmd##*/}
+
+exec "${python_exe:-python}" -m edk2basetools.$cmd.$cmd "$@"

--- a/BaseTools/BinPipWrappers/WindowsLike/AmlToC.bat
+++ b/BaseTools/BinPipWrappers/WindowsLike/AmlToC.bat
@@ -1,0 +1,3 @@
+@setlocal
+@set ToolName=%~n0%
+@%PYTHON_COMMAND% -m edk2basetools.%ToolName%.%ToolName% %*

--- a/BaseTools/BinPipWrappers/WindowsLike/BPDG.bat
+++ b/BaseTools/BinPipWrappers/WindowsLike/BPDG.bat
@@ -1,0 +1,3 @@
+@setlocal
+@set ToolName=%~n0%
+@%PYTHON_COMMAND% -m edk2basetools.%ToolName%.%ToolName% %*

--- a/BaseTools/BinPipWrappers/WindowsLike/BrotliCompress.bat
+++ b/BaseTools/BinPipWrappers/WindowsLike/BrotliCompress.bat
@@ -1,0 +1,55 @@
+@REM @file
+@REM This script will exec Brotli tool with -e/-d options.
+@REM
+@REM Copyright (c) 2017 - 2018, Intel Corporation. All rights reserved.<BR>
+@REM SPDX-License-Identifier: BSD-2-Clause-Patent
+@REM
+
+@echo off
+@setlocal
+
+set QLT=-q 9 -w 22
+set ARGS=
+
+:Begin
+if "%1"=="" goto End
+
+if "%1"=="-d" (
+  set ARGS=%ARGS% %1
+  shift
+  goto Begin
+)
+
+if "%1"=="-e" (
+  shift
+  goto Begin
+)
+
+if "%1"=="-g" (
+  set ARGS=%ARGS% %1 %2
+  shift
+  shift
+  goto Begin
+)
+
+if "%1"=="-o" (
+  set ARGS=%ARGS% %1 %2
+  shift
+  shift
+  goto Begin
+)
+
+if "%1"=="-q" (
+  set QLT=%1 %2
+  shift
+  shift
+  goto Begin
+)
+
+set ARGS=%ARGS% %1
+shift
+goto Begin
+
+:End
+Brotli %QLT% %ARGS%
+@echo on

--- a/BaseTools/BinPipWrappers/WindowsLike/Ecc.bat
+++ b/BaseTools/BinPipWrappers/WindowsLike/Ecc.bat
@@ -1,0 +1,3 @@
+@setlocal
+@set ToolName=%~n0%
+@%PYTHON_COMMAND% -m edk2basetools.%ToolName%.EccMain %*

--- a/BaseTools/BinPipWrappers/WindowsLike/GenDepex.bat
+++ b/BaseTools/BinPipWrappers/WindowsLike/GenDepex.bat
@@ -1,0 +1,3 @@
+@setlocal
+@set ToolName=%~n0%
+@%PYTHON_COMMAND% -m edk2basetools.AutoGen.%ToolName% %*

--- a/BaseTools/BinPipWrappers/WindowsLike/GenFds.bat
+++ b/BaseTools/BinPipWrappers/WindowsLike/GenFds.bat
@@ -1,0 +1,3 @@
+@setlocal
+@set ToolName=%~n0%
+@%PYTHON_COMMAND% -m edk2basetools.%ToolName%.%ToolName% %*

--- a/BaseTools/BinPipWrappers/WindowsLike/GenPatchPcdTable.bat
+++ b/BaseTools/BinPipWrappers/WindowsLike/GenPatchPcdTable.bat
@@ -1,0 +1,3 @@
+@setlocal
+@set ToolName=%~n0%
+@%PYTHON_COMMAND% -m edk2basetools.%ToolName%.%ToolName% %*

--- a/BaseTools/BinPipWrappers/WindowsLike/GenerateCapsule.bat
+++ b/BaseTools/BinPipWrappers/WindowsLike/GenerateCapsule.bat
@@ -1,0 +1,1 @@
+@%PYTHON_COMMAND% -m edk2basetools.Capsule.GenerateCapsule %*

--- a/BaseTools/BinPipWrappers/WindowsLike/PatchPcdValue.bat
+++ b/BaseTools/BinPipWrappers/WindowsLike/PatchPcdValue.bat
@@ -1,0 +1,3 @@
+@setlocal
+@set ToolName=%~n0%
+@%PYTHON_COMMAND% -m edk2basetools.%ToolName%.%ToolName% %*

--- a/BaseTools/BinPipWrappers/WindowsLike/Pkcs7Sign.bat
+++ b/BaseTools/BinPipWrappers/WindowsLike/Pkcs7Sign.bat
@@ -1,0 +1,3 @@
+@setlocal
+@set ToolName=%~n0%
+@%PYTHON_COMMAND% -m edk2basetools.%ToolName%.%ToolName% %*

--- a/BaseTools/BinPipWrappers/WindowsLike/Rsa2048Sha256GenerateKeys.bat
+++ b/BaseTools/BinPipWrappers/WindowsLike/Rsa2048Sha256GenerateKeys.bat
@@ -1,0 +1,1 @@
+@%PYTHON_COMMAND% -m edk2basetools.Rsa2048Sha256Sign.Rsa2048Sha256GenerateKeys %*

--- a/BaseTools/BinPipWrappers/WindowsLike/Rsa2048Sha256Sign.bat
+++ b/BaseTools/BinPipWrappers/WindowsLike/Rsa2048Sha256Sign.bat
@@ -1,0 +1,3 @@
+@setlocal
+@set ToolName=%~n0%
+@%PYTHON_COMMAND% -m edk2basetools.%ToolName%.%ToolName% %*

--- a/BaseTools/BinPipWrappers/WindowsLike/TargetTool.bat
+++ b/BaseTools/BinPipWrappers/WindowsLike/TargetTool.bat
@@ -1,0 +1,3 @@
+@setlocal
+@set ToolName=%~n0%
+@%PYTHON_COMMAND% -m edk2basetools.%ToolName%.%ToolName% %*

--- a/BaseTools/BinPipWrappers/WindowsLike/Trim.bat
+++ b/BaseTools/BinPipWrappers/WindowsLike/Trim.bat
@@ -1,0 +1,3 @@
+@setlocal
+@set ToolName=%~n0%
+@%PYTHON_COMMAND% -m edk2basetools.%ToolName%.%ToolName% %*

--- a/BaseTools/BinPipWrappers/WindowsLike/UPT.bat
+++ b/BaseTools/BinPipWrappers/WindowsLike/UPT.bat
@@ -1,0 +1,3 @@
+@setlocal
+@set ToolName=%~n0%
+@%PYTHON_COMMAND% -m edk2basetools.%ToolName%.%ToolName% %*

--- a/BaseTools/BinPipWrappers/WindowsLike/build.bat
+++ b/BaseTools/BinPipWrappers/WindowsLike/build.bat
@@ -1,0 +1,3 @@
+@setlocal
+@set ToolName=%~n0%
+@%PYTHON_COMMAND% -m edk2basetools.%ToolName%.%ToolName% %*

--- a/BaseTools/BuildEnv
+++ b/BaseTools/BuildEnv
@@ -46,7 +46,7 @@ RestorePreviousConfiguration() {
       done
     fi
   fi
-  
+
   PREVIOUS_CONF_FILE=$CONF_PATH/BuildEnv.sh
   if [ -e $PREVIOUS_CONF_FILE ]
   then
@@ -198,7 +198,17 @@ AddEdkToolsToPath() {
 
   EDK_TOOLS_PATH_BIN=`GetEdkToolsPathBinDirectory`
 
-  AddDirToStartOfPath $EDK_TOOLS_PATH/BinWrappers/PosixLike
+  # check if the edk2basetools pip package is available
+  if $PYTHON_COMMAND -c "import edk2basetools" &> /dev/null; then
+    # if it is, use the pip version of the wrappers
+    echo "Using Pip Basetools"
+    AddDirToStartOfPath $EDK_TOOLS_PATH/BinPipWrappers/PosixLike
+  else
+    echo "Using EDK2 in-source Basetools"
+    AddDirToStartOfPath $EDK_TOOLS_PATH/BinWrappers/PosixLike
+  fi
+
+
   AddDirToStartOfPath $EDK_TOOLS_PATH_BIN
 
 }

--- a/BaseTools/Scripts/PatchCheck.py
+++ b/BaseTools/Scripts/PatchCheck.py
@@ -359,6 +359,7 @@ class GitDiffCheck:
                 self.force_notabs = True
                 if self.filename.endswith('.sh') or \
                     self.filename.startswith('BaseTools/BinWrappers/PosixLike/') or \
+                    self.filename.startswith('BaseTools/BinPipWrappers/PosixLike/') or \
                     self.filename.startswith('BaseTools/Bin/CYGWIN_NT-5.1-i686/') or \
                     self.filename == 'BaseTools/BuildEnv':
                     #

--- a/BaseTools/Tests/TestTools.py
+++ b/BaseTools/Tests/TestTools.py
@@ -53,7 +53,7 @@ def GetBaseToolsPaths():
         return [
                 os.path.join(BaseToolsDir, 'Bin', uname),
                 os.path.join(BaseToolsDir, 'BinWrappers', uname),
-                os.path.join(BaseToolsDir, 'BinWrappers', 'PosixLike')
+                os.path.join(BaseToolsDir, 'BinWrappers', 'PosixLike'),
             ]
 
 BaseToolsBinPaths = GetBaseToolsPaths()

--- a/BaseTools/toolsetup.bat
+++ b/BaseTools/toolsetup.bat
@@ -393,12 +393,31 @@ goto end
     goto check_freezer_path
   )
 
+
+
 :check_freezer_path
   endlocal
+
+  %PYTHON_COMMAND% -c "import edk2basetools" >NUL 2>NUL
+  if %ERRORLEVEL% EQU 0 (
+    goto use_pip_basetools
+  ) else (
+    goto use_builtin_basetools
+  )
+
+:use_builtin_basetools
+  @echo Using EDK2 in-source Basetools
   if defined BASETOOLS_PYTHON_SOURCE goto print_python_info
   set "PATH=%BASE_TOOLS_PATH%\BinWrappers\WindowsLike;%PATH%"
   set BASETOOLS_PYTHON_SOURCE=%BASE_TOOLS_PATH%\Source\Python
   set PYTHONPATH=%BASETOOLS_PYTHON_SOURCE%;%PYTHONPATH%
+  goto print_python_info
+
+:use_pip_basetools
+  @echo Using Pip Basetools
+  set "PATH=%BASE_TOOLS_PATH%\BinPipWrappers\WindowsLike;%PATH%"
+  set BASETOOLS_PYTHON_SOURCE=edk2basetools
+  goto print_python_info
 
 :print_python_info
   echo                PATH = %PATH%


### PR DESCRIPTION
Use the new edk2-basetools pip module.
Includes a helpful message in setup to let users know which has been
selected.

Signed-off-by: Matthew Carlson <matthewfcarlson@gmail.com>