### PR TITLE
UefiCpuPkg/CpuDxe: Remove unnecessary cast to UINT32 of UINTN pointer

### DIFF
--- a/UefiCpuPkg/CpuDxe/CpuGdt.c
+++ b/UefiCpuPkg/CpuDxe/CpuGdt.c
@@ -142,7 +142,7 @@ InitGlobalDescriptorTable (
   //
   // Write GDT register
   //
-  gdtPtr.Base = (UINT32)(UINTN)(VOID*) gdt;
+  gdtPtr.Base = (UINTN)(VOID*) gdt;
   gdtPtr.Limit = (UINT16) (sizeof (GdtTemplate) - 1);
   AsmWriteGdtr (&gdtPtr);
 


### PR DESCRIPTION
gdtPtr.Base is of the UINTN type. Value of pointer to GDT can also be
above UINT32 in case of X64, so casting in this case is a bug.

Signed-off-by: Marek Kasiewicz <marek.kasiewicz@3mdeb.com>