### PR TITLE
NetworkPkg/HttpDxe: TlsChildHandle is not cleared when reset

### DIFF
--- a/NetworkPkg/HttpDxe/HttpProto.c
+++ b/NetworkPkg/HttpDxe/HttpProto.c
@@ -873,6 +873,7 @@ HttpCleanProtocol (
     // Destroy the TLS instance.
     //
     HttpInstance->TlsSb->DestroyChild (HttpInstance->TlsSb, HttpInstance->TlsChildHandle);
+    HttpInstance->TlsChildHandle = NULL;
   }
 
   if (HttpInstance->Tcp4ChildHandle != NULL) {


### PR DESCRIPTION
BZ #2909,
https://bugzilla.tianocore.org/show_bug.cgi?id=2909

When Http->Configure() is invoked with HttpConfigData set to
NULL to reset the EFI HTTP instance, TLS child instance is
destroyed but HttpInstance->TlsChildHandle is not set to
NULL. After reconfiguring HTTP through Http->Configure()
and sending the HTTP request to HTTPS URL, TLS child
instance is not recreated because
HttpInstance->TlsChildHandle is not NULL.

Cc: Maciej Rabeda <maciej.rabeda@linux.intel.com>
Cc: Wu Jiaxin <jiaxin.wu@intel.com>
Cc: Fu Siyuan <siyuan.fu@intel.com>
Cc: Nickle Wang <nickle.wang@hpe.com>
Signed-off-by: Abner Chang <abner.chang@hpe.com>
Reviewed-by: Wu Jiaxin <jiaxin.wu@intel.com>
Reviewed-by: Maciej Rabeda <maciej.rabeda@linux.intel.com>