### PR TITLE
MdePkg: SMBIOS 3.4.0 Update "adding DDR5 definitions".

### DIFF
--- a/MdePkg/Include/IndustryStandard/SmBios.h
+++ b/MdePkg/Include/IndustryStandard/SmBios.h
@@ -1718,7 +1718,9 @@ typedef enum {
   MemoryTypeLpddr4                         = 0x1E,
   MemoryTypeLogicalNonVolatileDevice       = 0x1F,
   MemoryTypeHBM                            = 0x20,
-  MemoryTypeHBM2                           = 0x21
+  MemoryTypeHBM2                           = 0x21,
+  MemoryTypeDdr5                           = 0x22,
+  MemoryTypeLpddr5                         = 0x23
 } MEMORY_DEVICE_TYPE;
 
 ///


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=2352

SMBIOS 3.4 spec adds new memory device types (DDR5, LPDDR5)

Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Zhiguang Liu <zhiguang.liu@intel.com>
Signed-off-by: Sanyo Wang <sanyo.wang@intel.com>
Reviewed-by: Zhiguang Liu <zhiguang.liu@intel.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>
Reviewed-by: Sean Brogan <sean.brogan@microsoft.com>