### PR TITLE
Remove non-cross-platform symlink, create it when necessary.

### DIFF
--- a/EmulatorPkg/Unix/Host/X11IncludeHack
+++ b/EmulatorPkg/Unix/Host/X11IncludeHack
@@ -1,1 +1,0 @@
-/opt/X11/include


### PR DESCRIPTION
On windows, it's always causing the working directory dirty.