### PR TITLE
MdePkg/BaseLib: Fix invalid memory access in AArch64 SetJump/LongJump

### DIFF
--- a/MdePkg/Library/BaseLib/AArch64/SetJumpLongJump.S
+++ b/MdePkg/Library/BaseLib/AArch64/SetJumpLongJump.S
@@ -20,10 +20,10 @@ GCC_ASM_EXPORT(InternalLongJump)
         REG_ONE  (x16,      96) /*IP0*/
 
 #define FPR_LAYOUT                      \
-        REG_PAIR ( d8,  d9, 112);       \
-        REG_PAIR (d10, d11, 128);       \
-        REG_PAIR (d12, d13, 144);       \
-        REG_PAIR (d14, d15, 160);
+        REG_PAIR ( d8,  d9, 104);       \
+        REG_PAIR (d10, d11, 120);       \
+        REG_PAIR (d12, d13, 136);       \
+        REG_PAIR (d14, d15, 152);
 
 #/**
 #  Saves the current CPU context that can be restored with a call to LongJump() and returns 0.#

--- a/MdePkg/Library/BaseLib/AArch64/SetJumpLongJump.asm
+++ b/MdePkg/Library/BaseLib/AArch64/SetJumpLongJump.asm
@@ -19,10 +19,10 @@
         REG_ONE  (x16,      #96) /*IP0*/
 
 #define FPR_LAYOUT                       \
-        REG_PAIR ( d8,  d9, #112);       \
-        REG_PAIR (d10, d11, #128);       \
-        REG_PAIR (d12, d13, #144);       \
-        REG_PAIR (d14, d15, #160);
+        REG_PAIR ( d8,  d9, #104);       \
+        REG_PAIR (d10, d11, #120);       \
+        REG_PAIR (d12, d13, #136);       \
+        REG_PAIR (d14, d15, #152);
 
 ;/**
 ;  Saves the current CPU context that can be restored with a call to LongJump() and returns 0.#


### PR DESCRIPTION
Correct the memory offsets used in REG_ONE/REG_PAIR macros to
synchronize them with definition of the BASE_LIBRARY_JUMP_BUFFER
structure on AArch64.

The REG_ONE macro declares only a single 64-bit register be
read/written; however, the subsequent offset is 16 bytes larger,
creating an unused memory gap in the middle of the structure and
causing SetJump/LongJump functions to read/write 8 bytes of memory
past the end of the jump buffer struct.

Signed-off-by: Jan Bobek <jbobek@nvidia.com>
Reviewed-by: Ard Biesheuvel <ard.biesheuvel@arm.com>
Acked-by: Michael D Kinney <michael.d.kinney@intel.com>
Acked-by: Liming Gao <gaoliming@byosoft.com.cn>