### PR TITLE
UefiPayloadPkg: Set default PciBaseSize on Ia32 [V2]

### DIFF
--- a/UefiPayloadPkg/UefiPayloadPkgIa32.dsc
+++ b/UefiPayloadPkg/UefiPayloadPkgIa32.dsc
@@ -292,8 +292,6 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdStatusCodeUseMemory|FALSE
   gEfiMdeModulePkgTokenSpaceGuid.PcdBootManagerMenuFile|{ 0x21, 0xaa, 0x2c, 0x46, 0x14, 0x76, 0x03, 0x45, 0x83, 0x6e, 0x8a, 0xb6, 0xf4, 0x66, 0x23, 0x31 }
 
-  gEfiMdePkgTokenSpaceGuid.PcdPciExpressBaseAddress|$(PCIE_BASE)
-
 !if $(SOURCE_DEBUG_ENABLE)
   gEfiSourceLevelDebugPkgTokenSpaceGuid.PcdDebugLoadImageMethod|0x2
 !endif
@@ -364,6 +362,7 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdConOutRow|31
   gEfiMdeModulePkgTokenSpaceGuid.PcdConOutColumn|100
   gEfiMdePkgTokenSpaceGuid.PcdPciExpressBaseAddress|0
+  gEfiMdePkgTokenSpaceGuid.PcdPciExpressBaseSize|0
 
 ################################################################################
 #


### PR DESCRIPTION
This commit fix UefiPayloadPkgIa32 build in master.

In commit 8028b2907e20b21cd7d69639a36ac82a77c81dc1 I did forget to set the
default value for PcdPciExpressBaseSize on Ia32 Targets. This patch does insert
it afterwards. It would be great if it could be merged asap.

PS: I added the Ia32 target to our CI to avoid this issue in future. Sorry for
the misfortune.

v2:
  * Remove no longer required build-time PcdPciExpressBaseAddress

Marcello Sylvester Bauer (1):
  UefiPayloadPkg: Set default PciBaseSize on Ia32

 UefiPayloadPkg/UefiPayloadPkgIa32.dsc | 3 +--
 1 file changed, 1 insertion(+), 2 deletions(-)

--
2.28.0