### PR TITLE
ShellPkg/SmbiosView: Add DDR5 support

### DIFF
--- a/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/QueryTable.c
+++ b/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/QueryTable.c
@@ -2550,6 +2550,14 @@ TABLE_ITEM  MemoryDeviceTypeTable[] = {
   {
     MemoryTypeHBM2,
     L"  HBM2 (High Bandwidth Memory Generation 2)"
+  },
+  {
+    MemoryTypeDdr5,
+    L"  DDR5"
+  },
+  {
+    MemoryTypeLpddr5,
+    L"  LPDDR5"
   }
 };
 


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=2352

Refer to SMBIOS 3.4 spec, add new memory device type - DDR5
and LPDDR5 support for the shell command "smbiosview".

Cc: Ray Ni <ray.ni@intel.com>
Signed-off-by: Zhichao Gao <zhichao.gao@intel.com>
Reviewed-by: Ray Ni <ray.ni@intel.com>