### PR TITLE
IntelFsp2Pkg/Tools: Fix a typo issue

### DIFF
--- a/IntelFsp2Pkg/Tools/PatchFv.py
+++ b/IntelFsp2Pkg/Tools/PatchFv.py
@@ -163,7 +163,7 @@ class Symbols:
         # If the fvDir is not a directory, then raise an exception
         #
         if not os.path.isdir(fvDir):
-            raise Exception ("'%s' is not a valid directory!" % FvDir)
+            raise Exception ("'%s' is not a valid directory!" % fvDir)
 
         #
         # If the Guid.xref is not existing in fvDir, then raise an exception


### PR DESCRIPTION
Error message:
raise Exception ("'%s' is not a valid directory!" % FvDir)
NameError: name 'FvDir' is not defined

FvDir should be fvDir.

Cc: Chasel Chiu <chasel.chiu@intel.com>
Cc: Nate DeSimone <nathaniel.l.desimone@intel.com>
Cc: Star Zeng <star.zeng@intel.com>
Signed-off-by: Yunhua Feng <fengyunhua@byosoft.com.cn>
Reviewed-by: Chasel Chiu <chasel.chiu@intel.com>
Reviewed-by: Nate DeSimone <nathaniel.l.desimone@intel.com>