### PR TITLE
Revert "MdeModulePkg/PartitionDxe: Fix the incorrect LBA size in child..."

### DIFF
--- a/MdeModulePkg/Universal/Disk/PartitionDxe/Partition.c
+++ b/MdeModulePkg/Universal/Disk/PartitionDxe/Partition.c
@@ -1149,8 +1149,8 @@ PartitionInstallChildHandle (
 
   Private->Signature        = PARTITION_PRIVATE_DATA_SIGNATURE;
 
-  Private->Start            = MultU64x32 (Start, BlockSize);
-  Private->End              = MultU64x32 (End + 1, BlockSize);
+  Private->Start            = MultU64x32 (Start, ParentBlockIo->Media->BlockSize);
+  Private->End              = MultU64x32 (End + 1, ParentBlockIo->Media->BlockSize);
 
   Private->BlockSize        = BlockSize;
   Private->ParentBlockIo    = ParentBlockIo;
@@ -1187,7 +1187,13 @@ PartitionInstallChildHandle (
 
   Private->Media.IoAlign   = 0;
   Private->Media.LogicalPartition = TRUE;
-  Private->Media.LastBlock = End - Start;
+  Private->Media.LastBlock = DivU64x32 (
+                               MultU64x32 (
+                                 End - Start + 1,
+                                 ParentBlockIo->Media->BlockSize
+                                 ),
+                                BlockSize
+                               ) - 1;
 
   Private->Media.BlockSize = (UINT32) BlockSize;
 


### PR DESCRIPTION
This reverts commit e0eacd7daa6f2e59de2b35a5dfe8bb4c38821e31.

REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3012

The patch to fix LBA size would cause a regression that make the
partition of CD image with media type other than NO_EMULATOR unobserved.

The patch used to fix the CD image's MBR table issue. The CD MBR
table would always be ignored because it would be handled by the
Eltorito partition handler first and never go into the MBR handler.
So directly revert it.

Cc: Ray Ni <ray.ni@intel.com>
Cc: Hao A Wu <hao.a.wu@intel.com>
Signed-off-by: Zhichao Gao <zhichao.gao@intel.com>
Reviewed-by: Ray Ni <ray.ni@intel.com>
Tested-by: Gary Lin <glin@suse.com>