### PR TITLE
EmbeddedPkgLibrary/VirtualRealTimeClockLib: Explicit cast to UINT32

### DIFF
--- a/EmbeddedPkg/Library/VirtualRealTimeClockLib/VirtualRealTimeClockLib.c
+++ b/EmbeddedPkg/Library/VirtualRealTimeClockLib/VirtualRealTimeClockLib.c
@@ -202,14 +202,14 @@ LibGetTime (
   // Because we use the performance counter, we can fill the Nanosecond attribute
   // provided that the remainder doesn't overflow 64-bit during multiplication.
   if (Remainder <= 18446744073U) {
-    Time->Nanosecond = MultU64x64 (Remainder, 1000000000U) / Freq;
+    Time->Nanosecond = (UINT32)(MultU64x64 (Remainder, 1000000000U) / Freq);
   } else {
     DEBUG ((DEBUG_WARN, "LibGetTime: Nanosecond value not set (64-bit overflow).\n"));
   }
 
   if (Capabilities) {
     Capabilities->Accuracy   = 0;
-    Capabilities->Resolution = Freq;
+    Capabilities->Resolution = 1;
     Capabilities->SetsToZero = FALSE;
   }
 


### PR DESCRIPTION
Addresses BZ https://bugzilla.tianocore.org/show_bug.cgi?id=2380 where
explicit casts are required for 64 to 32 bit assignment.

We can apply a straight cast for Time->Nanosecond since we already checked
for overflow.

On the other hand, we may have a frequency that is greater than UINT32_MAX
for Capabilities->Resolution. But using the frequency for the resolution
is the wrong approach anyway, since we can't actually vouch for the actual
resolution of the virtual library. Instead, play it safe by defaulting to
1 Hz, which is what a standard PC-AT CMOS RTC device would use.

Signed-off-by: Pete Batard <pete@akeo.ie>
Reviewed-by: Ard Biesheuvel <ard.biesheuvel@arm.com>