### PR TITLE
BaseTools/Ecc: Fix ECC check MetaFile Copyright information issue

### DIFF
--- a/BaseTools/Source/Python/Ecc/MetaDataParser.py
+++ b/BaseTools/Source/Python/Ecc/MetaDataParser.py
@@ -214,8 +214,12 @@ def _IsCopyrightLine (LineContent):
     LineContent = LineContent.upper()
     Result = False
 
+    #Support below Copyright format
+    # Copyright (C) 2020 Hewlett Packard Enterprise Development LP<BR>
+    # (C) Copyright 2020 Hewlett Packard Enterprise Development LP<BR>
     ReIsCopyrightRe = re.compile(r"""(^|\s)COPYRIGHT *\(""", re.DOTALL)
-    if ReIsCopyrightRe.search(LineContent):
+    ReIsCopyrightTypeB = re.compile(r"""(^|\s)\(C\)\s*COPYRIGHT""", re.DOTALL)
+    if ReIsCopyrightRe.search(LineContent) or ReIsCopyrightTypeB.search(LineContent):
         Result = True
 
     return Result


### PR DESCRIPTION
BZ: https://bugzilla.tianocore.org/show_bug.cgi?id=3011

MetaFile Copyright support below format:

#  Copyright (C) 2020 Hewlett Packard Enterprise Development LP<BR>
#  (C) Copyright 2020 Hewlett Packard Enterprise Development LP<BR>

Cc: Bob Feng <bob.c.feng@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Yuwei Chen <yuwei.chen@intel.com>
Signed-off-by: Yunhua Feng <fengyunhua@byosoft.com.cn>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>