### PR TITLE
BaseTools: Fix PcdValueInit tool build issue with VS compiler x64

### DIFF
--- a/BaseTools/Source/C/Common/PcdValueCommon.h
+++ b/BaseTools/Source/C/Common/PcdValueCommon.h
@@ -14,7 +14,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #define __FIELD_SIZE(TYPE, Field) (sizeof((TYPE *)0)->Field)
 #define __ARRAY_ELEMENT_SIZE(TYPE, Field) (sizeof((TYPE *)0)->Field[0])
-#define __OFFSET_OF(TYPE, Field) ((UINT32) &(((TYPE *)0)->Field))
+#define __OFFSET_OF(TYPE, Field) ((UINT32)(size_t) &(((TYPE *)0)->Field))
 #define __FLEXIBLE_SIZE(Size, TYPE, Field, MaxIndex)   if (__FIELD_SIZE(TYPE, Field) == 0) Size = MAX((__OFFSET_OF(TYPE, Field) + __ARRAY_ELEMENT_SIZE(TYPE, Field) * (MaxIndex)), Size)
 #define __ARRAY_SIZE(Array) (sizeof(Array)/sizeof(Array[0]))
 


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3001

When the 64-bit version of VS compiler is used, the generated
PcdValueInit tool will be failed to compile.

This patch is going to fix that issue.

Signed-off-by: Bob Feng <bob.c.feng@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Yuwei Chen <yuwei.chen@intel.com>
Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Sean Brogan <sean.brogan@microsoft.com>

Reviewed-by: Sean Brogan <sean.brogan@microsoft.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>