### PR TITLE
IntelFsp2Pkg/FspSecCore: LoadMicrocodeDefault() failed with padding i…

### DIFF
--- a/IntelFsp2Pkg/FspSecCore/Ia32/FspApiEntryT.nasm
+++ b/IntelFsp2Pkg/FspSecCore/Ia32/FspApiEntryT.nasm
@@ -307,10 +307,6 @@ AdvanceFixedSize:
    add   esi, dword  1024
 
 CheckAddress:
-   ; Is valid Microcode start point ?
-   cmp   dword [esi + MicrocodeHdr.MicrocodeHdrVersion], 0ffffffffh
-   jz    Done
-
    ; Check UPD header revision
    cmp    byte [esp + LoadMicrocodeParamsFsp22.FspUpdHeaderRevision], 2
    jae    Fsp22UpdHeader1
@@ -341,6 +337,10 @@ Fsp22UpdHeader1:
    jmp   CheckMainHeader
 
 LoadMicrocodeDefault4:
+   ; Is valid Microcode start point ?
+   cmp   dword [esi + MicrocodeHdr.MicrocodeHdrVersion], 0ffffffffh
+   jz    Done
+
 LoadCheck:
    ; Get the revision of the current microcode update loaded
    mov   ecx, MSR_IA32_BIOS_SIGN_ID


### PR DESCRIPTION
…n FV.

REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3017

Platform microcode FV may have padding between each version of microcode
binary, and current FSP-T/LoadMicrocodeDefault() cannot handle this case
and return not_found unexpectedly.

Cc: Maurice Ma <maurice.ma@intel.com>
Cc: Nate DeSimone <nathaniel.l.desimone@intel.com>
Cc: Star Zeng <star.zeng@intel.com>
Cc: Chasel Chiu <chasel.chiu@intel.com>
Signed-off-by: Cosmo Lai <cosmo.lai@intel.com>
Reviewed-by: Chasel Chiu <chasel.chiu@intel.com>
Reviewed-by: Nate DeSimone <nathaniel.l.desimone@intel.com>