### PR TITLE
MdeModulePkg/Core: Support standalone MM in FV2 protocol GetNextFile().

### DIFF
--- a/MdeModulePkg/Core/Dxe/FwVol/FwVolRead.c
+++ b/MdeModulePkg/Core/Dxe/FwVol/FwVolRead.c
@@ -1,7 +1,7 @@
 /** @file
   Implements functions to read firmware file
 
-Copyright (c) 2006 - 2017, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2006 - 2020, Intel Corporation. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -143,9 +143,9 @@ FvGetNextFile (
     return EFI_ACCESS_DENIED;
   }
 
-  if (*FileType > EFI_FV_FILETYPE_SMM_CORE) {
+  if (*FileType > EFI_FV_FILETYPE_MM_CORE_STANDALONE) {
     //
-    // File type needs to be in 0 - 0x0D
+    // File type needs to be in 0 - 0x0F
     //
     return EFI_NOT_FOUND;
   }


### PR DESCRIPTION
REF:https://bugzilla.tianocore.org/show_bug.cgi?id=3028

The FirmwareVolume2Protocol->GetNextFile() produced by DXE Core can be used
to search for a file based on the value of *FileType input. However, this
service will always return EFI_NOT_FOUND if the input FileType is set to
EFI_FV_FILETYPE_MM_STANDALONE or EFI_FV_FILETYPE_MM_CORE_STANDALONE, Which
means user can't use this service to search any standalone MM image in that
FV.
This patch update the FirmwareVolume2Protocol->GetNextFile() service to
support searching standalone MM module.

Signed-off-by: Siyuan Fu <siyuan.fu@intel.com>
Cc: Dandan Bi <dandan.bi@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>