### PR TITLE
BaseTools: Update the FV Space Information to display decimal and Hex

### DIFF
--- a/BaseTools/Source/Python/GenFds/GenFds.py
+++ b/BaseTools/Source/Python/GenFds/GenFds.py
@@ -633,7 +633,10 @@ class GenFds(object):
             else:
                 Percentage = str((UsedSizeValue + 0.0) / TotalSizeValue)[0:4].lstrip('0.')
 
-            GenFdsGlobalVariable.InfLogger(Name + ' ' + '[' + Percentage + '%Full] ' + str(TotalSizeValue) + ' total, ' + str(UsedSizeValue) + ' used, ' + str(FreeSizeValue) + ' free')
+            GenFdsGlobalVariable.InfLogger(Name + ' ' + '[' + Percentage + '%Full] '\
+                                           + str(TotalSizeValue) + ' (' + hex(TotalSizeValue) + ')' + ' total, '\
+                                           + str(UsedSizeValue) + ' (' + hex(UsedSizeValue) + ')' + ' used, '\
+                                           + str(FreeSizeValue) + ' (' + hex(FreeSizeValue) + ')' + ' free')
 
     ## PreprocessImage()
     #


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3009

Update the FV Space Information to display decimal and Hex

FV Space Information
before format:
SECFV [13%Full] 212992 total, 28400 used, 184592 free
Updated format:
SECFV [13%Full] 212992 (0x34000) total, 28400 (0x6ef0) used,
184592 (0x2d110) free

Cc: Bob Feng <bob.c.feng@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Yuwei Chen <yuwei.chen@intel.com>
Signed-off-by: Yunhua Feng <fengyunhua@byosoft.com.cn>
Reviewed-by: Bob Feng <bob.c.feng@intel.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>