### PR TITLE
BaseTools: Remove the dependency on the build intermediate file

### DIFF
--- a/BaseTools/Source/Python/GenFds/Section.py
+++ b/BaseTools/Source/Python/GenFds/Section.py
@@ -140,22 +140,6 @@ class Section (SectionClassObject):
                     FileList.append(File.Path)
 
         if (not IsMakefile and Suffix is not None and os.path.exists(FfsInf.EfiOutputPath)) or (IsMakefile and Suffix is not None):
-            #
-            # Get Makefile path and time stamp
-            #
-            MakefileDir = FfsInf.EfiOutputPath[:-len('OUTPUT')]
-            Makefile = os.path.join(MakefileDir, 'Makefile')
-            if not os.path.exists(Makefile):
-                Makefile = os.path.join(MakefileDir, 'GNUmakefile')
-            if os.path.exists(Makefile):
-                # Update to search files with suffix in all sub-dirs.
-                Tuple = os.walk(FfsInf.EfiOutputPath)
-                for Dirpath, Dirnames, Filenames in Tuple:
-                    for F in Filenames:
-                        if os.path.splitext(F)[1] == Suffix:
-                            FullName = os.path.join(Dirpath, F)
-                            if os.path.getmtime(FullName) > os.path.getmtime(Makefile):
-                                FileList.append(FullName)
             if not FileList:
                 SuffixMap = FfsInf.GetFinalTargetSuffixMap()
                 if Suffix in SuffixMap:


### PR DESCRIPTION
When generating compressed section, the build tool rely on the
build intermediate files, which were generated in last build, to
get the file list. This method will cause the incremental build to
generate incorrect build result. To reproduce this incremental build
error, you can do:
1. build Ovmf
2. change the module OvmfPkg\AcpiTables a source file Facp.aslc
name from Facp.aslc to Facpxxx.aslc.
3. change the Facp.aslc file name in [sources] section of AcpiTables.inf
4. incremental build Ovmf

you will see the in AcpiTables module Makefile, the corresponding
Facp.acpi file is not changed.

This patch is to make the build always get file list from the INF.

Signed-off-by: Bob Feng <bob.c.feng@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Yuwei Chen <yuwei.chen@intel.com>

Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>