### PR TITLE
BaseTools: Enable Module Scope Structure Pcd

### DIFF
--- a/BaseTools/Source/Python/AutoGen/DataPipe.py
+++ b/BaseTools/Source/Python/AutoGen/DataPipe.py
@@ -72,9 +72,10 @@ class MemoryDataPipe(DataPipe):
         #Platform Module Pcds
         ModulePcds = {}
         for m in PlatformInfo.Platform.Modules:
-            m_pcds =  PlatformInfo.Platform.Modules[m].Pcds
+            module = PlatformInfo.Platform.Modules[m]
+            m_pcds =  module.Pcds
             if m_pcds:
-                ModulePcds[(m.File,m.Root,m.Arch)] = [PCD_DATA(
+                ModulePcds[module.Guid] = [PCD_DATA(
             pcd.TokenCName,pcd.TokenSpaceGuidCName,pcd.Type,
             pcd.DatumType,pcd.SkuInfoList,pcd.DefaultValue,
             pcd.MaxDatumSize,pcd.UserDefinedDefaultStoresFlag,pcd.validateranges,

--- a/BaseTools/Source/Python/AutoGen/ModuleAutoGen.py
+++ b/BaseTools/Source/Python/AutoGen/ModuleAutoGen.py
@@ -1032,7 +1032,7 @@ class ModuleAutoGen(AutoGen):
     @cached_property
     def ModulePcdList(self):
         # apply PCD settings from platform
-        RetVal = self.PlatformInfo.ApplyPcdSetting(self.Module, self.Module.Pcds)
+        RetVal = self.PlatformInfo.ApplyPcdSetting(self, self.Module.Pcds)
 
         return RetVal
     @cached_property
@@ -1063,7 +1063,7 @@ class ModuleAutoGen(AutoGen):
                     continue
                 Pcds.add(Key)
                 PcdsInLibrary[Key] = copy.copy(Library.Pcds[Key])
-            RetVal.extend(self.PlatformInfo.ApplyPcdSetting(self.Module, PcdsInLibrary, Library=Library))
+            RetVal.extend(self.PlatformInfo.ApplyPcdSetting(self, PcdsInLibrary, Library=Library))
         return RetVal
 
     ## Get the GUID value mapping

--- a/BaseTools/Source/Python/AutoGen/ModuleAutoGenHelper.py
+++ b/BaseTools/Source/Python/AutoGen/ModuleAutoGenHelper.py
@@ -479,8 +479,9 @@ class PlatformInfo(AutoGenInfo):
                 SkuName : SkuInfoClass(SkuName, self.Platform.SkuIds[SkuName][0], '', '', '', '', '', ToPcd.DefaultValue)
             }
 
-    def ApplyPcdSetting(self, Module, Pcds, Library=""):
+    def ApplyPcdSetting(self, Ma, Pcds, Library=""):
         # for each PCD in module
+        Module=Ma.Module
         for Name, Guid in Pcds:
             PcdInModule = Pcds[Name, Guid]
             # find out the PCD setting in platform
@@ -507,9 +508,12 @@ class PlatformInfo(AutoGenInfo):
                                 )
 
         # override PCD settings with module specific setting
+        ModuleScopePcds = self.DataPipe.Get("MOL_PCDS")
         if Module in self.Platform.Modules:
             PlatformModule = self.Platform.Modules[str(Module)]
-            for Key  in PlatformModule.Pcds:
+            PCD_DATA = ModuleScopePcds.get(Ma.Guid,{})
+            mPcds = {(pcd.TokenCName,pcd.TokenSpaceGuidCName): pcd for pcd in PCD_DATA}
+            for Key  in mPcds:
                 if self.BuildOptionPcd:
                     for pcd in self.BuildOptionPcd:
                         (TokenSpaceGuidCName, TokenCName, FieldName, pcdvalue, _) = pcd
@@ -528,7 +532,7 @@ class PlatformInfo(AutoGenInfo):
                             Flag = True
                             break
                 if Flag:
-                    self._OverridePcd(ToPcd, PlatformModule.Pcds[Key], Module, Msg="DSC Components Module scoped PCD section", Library=Library)
+                    self._OverridePcd(ToPcd, mPcds[Key], Module, Msg="DSC Components Module scoped PCD section", Library=Library)
         # use PCD value to calculate the MaxDatumSize when it is not specified
         for Name, Guid in Pcds:
             Pcd = Pcds[Name, Guid]

--- a/BaseTools/Source/Python/AutoGen/PlatformAutoGen.py
+++ b/BaseTools/Source/Python/AutoGen/PlatformAutoGen.py
@@ -1043,7 +1043,13 @@ class PlatformAutoGen(AutoGen):
 
     @cached_property
     def _MbList(self):
-        return [self.BuildDatabase[m, self.Arch, self.BuildTarget, self.ToolChain] for m in self.Platform.Modules]
+        ModuleList = []
+        for m in self.Platform.Modules:
+            component = self.Platform.Modules[m]
+            module = self.BuildDatabase[m, self.Arch, self.BuildTarget, self.ToolChain]
+            module.Guid = component.Guid
+            ModuleList.append(module)
+        return ModuleList
 
     @cached_property
     def _MaList(self):

--- a/BaseTools/Source/Python/Workspace/BuildClassObject.py
+++ b/BaseTools/Source/Python/Workspace/BuildClassObject.py
@@ -70,6 +70,7 @@ class PcdClassObject(object):
             self.DscDefaultValue = Value
         self.PcdValueFromComm = ""
         self.PcdValueFromFdf = ""
+        self.PcdValueFromComponents = {} #{ModuleGuid:value, file_path,lineNo}
         self.CustomAttribute = {}
         self.UserDefinedDefaultStoresFlag = UserDefinedDefaultStoresFlag
         self._Capacity = None
@@ -298,6 +299,7 @@ class StructurePcd(PcdClassObject):
         self.PcdFieldValueFromComm = OrderedDict()
         self.PcdFieldValueFromFdf = OrderedDict()
         self.DefaultFromDSC=None
+        self.PcdFiledValueFromDscComponent = OrderedDict()
     def __repr__(self):
         return self.TypeName
 
@@ -323,6 +325,12 @@ class StructurePcd(PcdClassObject):
             del self.SkuOverrideValues[SkuName][DefaultStoreName][DimensionAttr][FieldName]
         self.SkuOverrideValues[SkuName][DefaultStoreName][DimensionAttr][FieldName] = [Value.strip(), FileName, LineNo]
         return self.SkuOverrideValues[SkuName][DefaultStoreName][DimensionAttr][FieldName]
+
+    def AddComponentOverrideValue(self,FieldName, Value, ModuleGuid, FileName="", LineNo=0, DimensionAttr = '-1'):
+        self.PcdFiledValueFromDscComponent.setdefault(ModuleGuid, OrderedDict())
+        self.PcdFiledValueFromDscComponent[ModuleGuid].setdefault(DimensionAttr,OrderedDict())
+        self.PcdFiledValueFromDscComponent[ModuleGuid][DimensionAttr][FieldName] =  [Value.strip(), FileName, LineNo]
+        return self.PcdFiledValueFromDscComponent[ModuleGuid][DimensionAttr][FieldName]
 
     def SetPcdMode (self, PcdMode):
         self.PcdMode = PcdMode
@@ -365,6 +373,7 @@ class StructurePcd(PcdClassObject):
             self.ValueChain = PcdObject.ValueChain if PcdObject.ValueChain else self.ValueChain
             self.PcdFieldValueFromComm = PcdObject.PcdFieldValueFromComm if PcdObject.PcdFieldValueFromComm else self.PcdFieldValueFromComm
             self.PcdFieldValueFromFdf = PcdObject.PcdFieldValueFromFdf if PcdObject.PcdFieldValueFromFdf else self.PcdFieldValueFromFdf
+            self.PcdFiledValueFromDscComponent = PcdObject.PcdFiledValueFromDscComponent if PcdObject.PcdFiledValueFromDscComponent else self.PcdFiledValueFromDscComponent
 
     def __deepcopy__(self,memo):
         new_pcd = StructurePcd()
@@ -383,6 +392,7 @@ class StructurePcd(PcdClassObject):
         new_pcd.SkuOverrideValues = CopyDict(self.SkuOverrideValues)
         new_pcd.PcdFieldValueFromComm = CopyDict(self.PcdFieldValueFromComm)
         new_pcd.PcdFieldValueFromFdf = CopyDict(self.PcdFieldValueFromFdf)
+        new_pcd.PcdFiledValueFromDscComponent = CopyDict(self.PcdFiledValueFromDscComponent)
         new_pcd.ValueChain = {item for item in self.ValueChain}
         return new_pcd
 
@@ -463,6 +473,8 @@ class ModuleBuildClassObject(object):
         self.Pcds                    = {}
         self.BuildOptions            = {}
         self.Depex                   = {}
+        self.StrPcdSet               = []
+        self.StrPcdOverallValue      = {}
 
     ## Convert the class to a string
     #


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=2648

This patch is to enable the Module scoped Structure Pcd usage.
User can set structure pcd field value in module scope. For example,
under the [components] section of a dsc file, user can override some
field value for a specific module.

  Package/Module.inf{
      <PcdsFixedAtBuild>
      gUefiTokenSpaceGuid.StructurePcdModule.FieldName | 5
  }

Signed-off-by: Bob Feng <bob.c.feng@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Yuwei Chen <yuwei.chen@intel.com>

Tested-by: Liming Gao <gaoliming@byosoft.com.cn>
Acked-by: Liming Gao <gaoliming@byosoft.com.cn>