### PR TITLE
[edk2-devel] [PATCH v3 00/11] SEV-ES guest support fixes and cleanup -- push

### DIFF
--- a/MdePkg/Include/Register/Amd/Ghcb.h
+++ b/MdePkg/Include/Register/Amd/Ghcb.h
@@ -82,35 +82,10 @@
 #define IOIO_SEG_DS         (BIT11 | BIT10)
 
 
-typedef enum {
-  GhcbCpl              = 25,
-  GhcbRflags           = 46,
-  GhcbRip,
-  GhcbRsp              = 59,
-  GhcbRax              = 63,
-  GhcbRcx              = 97,
-  GhcbRdx,
-  GhcbRbx,
-  GhcbRbp              = 101,
-  GhcbRsi,
-  GhcbRdi,
-  GhcbR8,
-  GhcbR9,
-  GhcbR10,
-  GhcbR11,
-  GhcbR12,
-  GhcbR13,
-  GhcbR14,
-  GhcbR15,
-  GhcbXCr0             = 125,
-} GHCB_REGISTER;
-
 typedef PACKED struct {
   UINT8                  Reserved1[203];
   UINT8                  Cpl;
-  UINT8                  Reserved2[148];
-  UINT64                 Dr7;
-  UINT8                  Reserved3[144];
+  UINT8                  Reserved8[300];
   UINT64                 Rax;
   UINT8                  Reserved4[264];
   UINT64                 Rcx;
@@ -135,6 +110,19 @@ typedef PACKED struct {
   UINT16                 ProtocolVersion;
   UINT32                 GhcbUsage;
 } GHCB;
+
+typedef enum {
+  GhcbCpl          = OFFSET_OF (GHCB, SaveArea.Cpl) / sizeof (UINT64),
+  GhcbRax          = OFFSET_OF (GHCB, SaveArea.Rax) / sizeof (UINT64),
+  GhcbRbx          = OFFSET_OF (GHCB, SaveArea.Rbx) / sizeof (UINT64),
+  GhcbRcx          = OFFSET_OF (GHCB, SaveArea.Rcx) / sizeof (UINT64),
+  GhcbRdx          = OFFSET_OF (GHCB, SaveArea.Rdx) / sizeof (UINT64),
+  GhcbXCr0         = OFFSET_OF (GHCB, SaveArea.XCr0) / sizeof (UINT64),
+  GhcbSwExitCode   = OFFSET_OF (GHCB, SaveArea.SwExitCode) / sizeof (UINT64),
+  GhcbSwExitInfo1  = OFFSET_OF (GHCB, SaveArea.SwExitInfo1) / sizeof (UINT64),
+  GhcbSwExitInfo2  = OFFSET_OF (GHCB, SaveArea.SwExitInfo2) / sizeof (UINT64),
+  GhcbSwScratch    = OFFSET_OF (GHCB, SaveArea.SwScratch) / sizeof (UINT64),
+} GHCB_REGISTER;
 
 typedef union {
   struct {

--- a/OvmfPkg/Library/VmgExitLib/VmgExitLib.c
+++ b/OvmfPkg/Library/VmgExitLib/VmgExitLib.c
@@ -110,6 +110,10 @@ VmgExit (
   Ghcb->SaveArea.SwExitInfo1 = ExitInfo1;
   Ghcb->SaveArea.SwExitInfo2 = ExitInfo2;
 
+  VmgSetOffsetValid (Ghcb, GhcbSwExitCode);
+  VmgSetOffsetValid (Ghcb, GhcbSwExitInfo1);
+  VmgSetOffsetValid (Ghcb, GhcbSwExitInfo2);
+
   //
   // Guest memory is used for the guest-hypervisor communication, so fence
   // the invocation of the VMGEXIT instruction to ensure GHCB accesses are

--- a/OvmfPkg/Library/VmgExitLib/VmgExitLib.c
+++ b/OvmfPkg/Library/VmgExitLib/VmgExitLib.c
@@ -157,3 +157,57 @@ VmgDone (
 {
 }
 
+/**
+  Marks a field at the specified offset as valid in the GHCB.
+
+  The ValidBitmap area represents the areas of the GHCB that have been marked
+  valid. Set the bit in ValidBitmap for the input offset.
+
+  @param[in, out] Ghcb    Pointer to the Guest-Hypervisor Communication Block
+  @param[in]      Offset  Qword offset in the GHCB to mark valid
+
+**/
+VOID
+EFIAPI
+VmgSetOffsetValid (
+  IN OUT GHCB                *Ghcb,
+  IN     GHCB_REGISTER       Offset
+  )
+{
+  UINT32  OffsetIndex;
+  UINT32  OffsetBit;
+
+  OffsetIndex = Offset / 8;
+  OffsetBit   = Offset % 8;
+
+  Ghcb->SaveArea.ValidBitmap[OffsetIndex] |= (1 << OffsetBit);
+}
+
+/**
+  Checks if a specified offset is valid in the GHCB.
+
+  The ValidBitmap area represents the areas of the GHCB that have been marked
+  valid. Return whether the bit in the ValidBitmap is set for the input offset.
+
+  @param[in]  Ghcb            A pointer to the GHCB
+  @param[in]  Offset          Qword offset in the GHCB to mark valid
+
+  @retval TRUE                Offset is marked valid in the GHCB
+  @retval FALSE               Offset is not marked valid in the GHCB
+
+**/
+BOOLEAN
+EFIAPI
+VmgIsOffsetValid (
+  IN GHCB                    *Ghcb,
+  IN GHCB_REGISTER           Offset
+  )
+{
+  UINT32  OffsetIndex;
+  UINT32  OffsetBit;
+
+  OffsetIndex = Offset / 8;
+  OffsetBit   = Offset % 8;
+
+  return ((Ghcb->SaveArea.ValidBitmap[OffsetIndex] & (1 << OffsetBit)) != 0);
+}

--- a/OvmfPkg/Library/VmgExitLib/VmgExitVcHandler.c
+++ b/OvmfPkg/Library/VmgExitLib/VmgExitVcHandler.c
@@ -1568,6 +1568,7 @@ VmgExitHandleVc (
   SEV_ES_INSTRUCTION_DATA   InstructionData;
   UINT64                    ExitCode, Status;
   EFI_STATUS                VcRet;
+  BOOLEAN                   InterruptState;
 
   VcRet = EFI_SUCCESS;
 
@@ -1578,7 +1579,7 @@ VmgExitHandleVc (
   Regs = SystemContext.SystemContextX64;
   Ghcb = Msr.Ghcb;
 
-  VmgInit (Ghcb);
+  VmgInit (Ghcb, &InterruptState);
 
   ExitCode = Regs->ExceptionData;
   switch (ExitCode) {
@@ -1662,7 +1663,7 @@ VmgExitHandleVc (
     VcRet = EFI_PROTOCOL_ERROR;
   }
 
-  VmgDone (Ghcb);
+  VmgDone (Ghcb, InterruptState);
 
   return VcRet;
 }

--- a/OvmfPkg/Library/VmgExitLib/VmgExitVcHandler.c
+++ b/OvmfPkg/Library/VmgExitLib/VmgExitVcHandler.c
@@ -1233,6 +1233,7 @@ IoioExit (
       }
 
       Ghcb->SaveArea.SwScratch = (UINT64) Ghcb->SharedBuffer;
+      VmgSetOffsetValid (Ghcb, GhcbSwScratch);
       Status = VmgExit (Ghcb, SVM_EXIT_IOIO_PROT, ExitInfo1, ExitInfo2);
       if (Status != 0) {
         return Status;

--- a/OvmfPkg/Library/VmgExitLib/VmgExitVcHandler.c
+++ b/OvmfPkg/Library/VmgExitLib/VmgExitVcHandler.c
@@ -664,6 +664,7 @@ MmioExit (
     CopyMem (Ghcb->SharedBuffer, &InstructionData->Ext.RegData, Bytes);
 
     Ghcb->SaveArea.SwScratch = (UINT64) Ghcb->SharedBuffer;
+    VmgSetOffsetValid (Ghcb, GhcbSwScratch);
     Status = VmgExit (Ghcb, SVM_EXIT_MMIO_WRITE, ExitInfo1, ExitInfo2);
     if (Status != 0) {
       return Status;
@@ -693,6 +694,7 @@ MmioExit (
     CopyMem (Ghcb->SharedBuffer, InstructionData->Immediate, Bytes);
 
     Ghcb->SaveArea.SwScratch = (UINT64) Ghcb->SharedBuffer;
+    VmgSetOffsetValid (Ghcb, GhcbSwScratch);
     Status = VmgExit (Ghcb, SVM_EXIT_MMIO_WRITE, ExitInfo1, ExitInfo2);
     if (Status != 0) {
       return Status;
@@ -725,6 +727,7 @@ MmioExit (
     ExitInfo2 = Bytes;
 
     Ghcb->SaveArea.SwScratch = (UINT64) Ghcb->SharedBuffer;
+    VmgSetOffsetValid (Ghcb, GhcbSwScratch);
     Status = VmgExit (Ghcb, SVM_EXIT_MMIO_READ, ExitInfo1, ExitInfo2);
     if (Status != 0) {
       return Status;
@@ -755,6 +758,7 @@ MmioExit (
     ExitInfo2 = Bytes;
 
     Ghcb->SaveArea.SwScratch = (UINT64) Ghcb->SharedBuffer;
+    VmgSetOffsetValid (Ghcb, GhcbSwScratch);
     Status = VmgExit (Ghcb, SVM_EXIT_MMIO_READ, ExitInfo1, ExitInfo2);
     if (Status != 0) {
       return Status;
@@ -780,6 +784,7 @@ MmioExit (
     ExitInfo2 = Bytes;
 
     Ghcb->SaveArea.SwScratch = (UINT64) Ghcb->SharedBuffer;
+    VmgSetOffsetValid (Ghcb, GhcbSwScratch);
     Status = VmgExit (Ghcb, SVM_EXIT_MMIO_READ, ExitInfo1, ExitInfo2);
     if (Status != 0) {
       return Status;

--- a/OvmfPkg/QemuFlashFvbServicesRuntimeDxe/QemuFlash.c
+++ b/OvmfPkg/QemuFlashFvbServicesRuntimeDxe/QemuFlash.c
@@ -232,8 +232,8 @@ QemuFlashEraseBlock (
   }
 
   Ptr = QemuFlashPtr (Lba, 0);
-  *Ptr = BLOCK_ERASE_CMD;
-  *Ptr = BLOCK_ERASE_CONFIRM_CMD;
+  QemuFlashPtrWrite (Ptr, BLOCK_ERASE_CMD);
+  QemuFlashPtrWrite (Ptr, BLOCK_ERASE_CONFIRM_CMD);
   return EFI_SUCCESS;
 }
 

--- a/OvmfPkg/QemuFlashFvbServicesRuntimeDxe/QemuFlashDxe.c
+++ b/OvmfPkg/QemuFlashFvbServicesRuntimeDxe/QemuFlashDxe.c
@@ -66,6 +66,7 @@ QemuFlashPtrWrite (
     VmgInit (Ghcb);
     Ghcb->SharedBuffer[0] = Value;
     Ghcb->SaveArea.SwScratch = (UINT64) (UINTN) Ghcb->SharedBuffer;
+    VmgSetOffsetValid (Ghcb, GhcbSwScratch);
     VmgExit (Ghcb, SVM_EXIT_MMIO_WRITE, (UINT64) (UINTN) Ptr, 1);
     VmgDone (Ghcb);
   } else {

--- a/UefiCpuPkg/Include/Library/VmgExitLib.h
+++ b/UefiCpuPkg/Include/Library/VmgExitLib.h
@@ -75,6 +75,43 @@ VmgDone (
   );
 
 /**
+  Marks a specified offset as valid in the GHCB.
+
+  The ValidBitmap area represents the areas of the GHCB that have been marked
+  valid. Set the bit in ValidBitmap for the input offset.
+
+  @param[in, out]  Ghcb       A pointer to the GHCB
+  @param[in]       Offset     Qword offset in the GHCB to mark valid
+
+**/
+VOID
+EFIAPI
+VmgSetOffsetValid (
+  IN OUT GHCB                *Ghcb,
+  IN     GHCB_REGISTER       Offset
+  );
+
+/**
+  Checks if a specified offset is valid in the GHCB.
+
+  The ValidBitmap area represents the areas of the GHCB that have been marked
+  valid. Return whether the bit in the ValidBitmap is set for the input offset.
+
+  @param[in]  Ghcb            A pointer to the GHCB
+  @param[in]  Offset          Qword offset in the GHCB to mark valid
+
+  @retval TRUE                Offset is marked valid in the GHCB
+  @retval FALSE               Offset is not marked valid in the GHCB
+
+**/
+BOOLEAN
+EFIAPI
+VmgIsOffsetValid (
+  IN GHCB                    *Ghcb,
+  IN GHCB_REGISTER           Offset
+  );
+
+/**
   Handle a #VC exception.
 
   Performs the necessary processing to handle a #VC exception.

--- a/UefiCpuPkg/Include/Library/VmgExitLib.h
+++ b/UefiCpuPkg/Include/Library/VmgExitLib.h
@@ -50,13 +50,16 @@ VmgExit (
   Performs the necessary steps in preparation for invoking VMGEXIT. Must be
   called before setting any fields within the GHCB.
 
-  @param[in, out]  Ghcb       A pointer to the GHCB
+  @param[in, out]  Ghcb            A pointer to the GHCB
+  @param[in, out]  InterruptState  A pointer to hold the current interrupt
+                                   state, used for restoring in VmgDone ()
 
 **/
 VOID
 EFIAPI
 VmgInit (
-  IN OUT GHCB                *Ghcb
+  IN OUT GHCB                *Ghcb,
+  IN OUT BOOLEAN             *InterruptState
   );
 
 /**
@@ -65,13 +68,16 @@ VmgInit (
   Performs the necessary steps to cleanup after invoking VMGEXIT. Must be
   called after obtaining needed fields within the GHCB.
 
-  @param[in, out]  Ghcb       A pointer to the GHCB
+  @param[in, out]  Ghcb            A pointer to the GHCB
+  @param[in]       InterruptState  An indicator to conditionally (re)enable
+                                   interrupts
 
 **/
 VOID
 EFIAPI
 VmgDone (
-  IN OUT GHCB                *Ghcb
+  IN OUT GHCB                *Ghcb,
+  IN     BOOLEAN             InterruptState
   );
 
 /**

--- a/UefiCpuPkg/Library/MpInitLib/DxeMpLib.c
+++ b/UefiCpuPkg/Library/MpInitLib/DxeMpLib.c
@@ -171,6 +171,7 @@ GetSevEsAPMemory (
   EFI_PHYSICAL_ADDRESS      StartAddress;
   MSR_SEV_ES_GHCB_REGISTER  Msr;
   GHCB                      *Ghcb;
+  BOOLEAN                   InterruptState;
 
   //
   // Allocate 1 page for AP jump table page
@@ -192,9 +193,9 @@ GetSevEsAPMemory (
   Msr.GhcbPhysicalAddress = AsmReadMsr64 (MSR_SEV_ES_GHCB);
   Ghcb = Msr.Ghcb;
 
-  VmgInit (Ghcb);
+  VmgInit (Ghcb, &InterruptState);
   VmgExit (Ghcb, SVM_EXIT_AP_JUMP_TABLE, 0, (UINT64) (UINTN) StartAddress);
-  VmgDone (Ghcb);
+  VmgDone (Ghcb, InterruptState);
 
   return (UINTN) StartAddress;
 }

--- a/UefiCpuPkg/Library/MpInitLib/MpLib.c
+++ b/UefiCpuPkg/Library/MpInitLib/MpLib.c
@@ -680,10 +680,15 @@ MpInitLibSevEsAPReset (
   IN CPU_MP_DATA                  *CpuMpData
   )
 {
+  EFI_STATUS       Status;
+  UINTN            ProcessorNumber;
   UINT16           Code16, Code32;
   AP_RESET         *APResetFn;
   UINTN            BufferStart;
   UINTN            StackStart;
+
+  Status = GetProcessorNumber (CpuMpData, &ProcessorNumber);
+  ASSERT_EFI_ERROR (Status);
 
   Code16 = GetProtectedMode16CS ();
   Code32 = GetProtectedMode32CS ();
@@ -696,7 +701,7 @@ MpInitLibSevEsAPReset (
 
   BufferStart = CpuMpData->MpCpuExchangeInfo->BufferStart;
   StackStart = CpuMpData->SevEsAPResetStackStart -
-                 (AP_RESET_STACK_SIZE * GetApicId ());
+                 (AP_RESET_STACK_SIZE * ProcessorNumber);
 
   //
   // This call never returns.

--- a/UefiCpuPkg/Library/MpInitLib/MpLib.c
+++ b/UefiCpuPkg/Library/MpInitLib/MpLib.c
@@ -884,6 +884,7 @@ ApWakeupFunction (
           GHCB                      *Ghcb;
           UINT64                    Status;
           BOOLEAN                   DoDecrement;
+          BOOLEAN                   InterruptState;
 
           DoDecrement = (BOOLEAN) (CpuMpData->InitFlag == ApInitConfig);
 
@@ -891,7 +892,7 @@ ApWakeupFunction (
             Msr.GhcbPhysicalAddress = AsmReadMsr64 (MSR_SEV_ES_GHCB);
             Ghcb = Msr.Ghcb;
 
-            VmgInit (Ghcb);
+            VmgInit (Ghcb, &InterruptState);
 
             if (DoDecrement) {
               DoDecrement = FALSE;
@@ -905,11 +906,11 @@ ApWakeupFunction (
 
             Status = VmgExit (Ghcb, SVM_EXIT_AP_RESET_HOLD, 0, 0);
             if ((Status == 0) && (Ghcb->SaveArea.SwExitInfo2 != 0)) {
-              VmgDone (Ghcb);
+              VmgDone (Ghcb, InterruptState);
               break;
             }
 
-            VmgDone (Ghcb);
+            VmgDone (Ghcb, InterruptState);
           }
 
           //

--- a/UefiCpuPkg/Library/MpInitLib/X64/MpFuncs.nasm
+++ b/UefiCpuPkg/Library/MpInitLib/X64/MpFuncs.nasm
@@ -533,6 +533,12 @@ BITS 64
 
     mov        rax, 0x80000004   ; VMGEXIT AP_RESET_HOLD
     mov        [rdx + 0x390], rax
+    mov        rax, 114          ; Set SwExitCode valid bit
+    bts        [rdx + 0x3f0], rax
+    inc        rax               ; Set SwExitInfo1 valid bit
+    bts        [rdx + 0x3f0], rax
+    inc        rax               ; Set SwExitInfo2 valid bit
+    bts        [rdx + 0x3f0], rax
 
     pop        rdx
     pop        rcx

--- a/UefiCpuPkg/Library/VmgExitLibNull/VmgExitLibNull.c
+++ b/UefiCpuPkg/Library/VmgExitLibNull/VmgExitLibNull.c
@@ -57,15 +57,16 @@ VmgExit (
   Performs the necessary steps in preparation for invoking VMGEXIT. Must be
   called before setting any fields within the GHCB.
 
-  The base library function does nothing.
-
-  @param[in, out]  Ghcb       A pointer to the GHCB
+  @param[in, out]  Ghcb            A pointer to the GHCB
+  @param[in, out]  InterruptState  A pointer to hold the current interrupt
+                                   state, used for restoring in VmgDone ()
 
 **/
 VOID
 EFIAPI
 VmgInit (
-  IN OUT GHCB                *Ghcb
+  IN OUT GHCB                *Ghcb,
+  IN OUT BOOLEAN             *InterruptState
   )
 {
 }
@@ -76,15 +77,16 @@ VmgInit (
   Performs the necessary steps to cleanup after invoking VMGEXIT. Must be
   called after obtaining needed fields within the GHCB.
 
-  The base library function does nothing.
-
-  @param[in, out]  Ghcb       A pointer to the GHCB
+  @param[in, out]  Ghcb            A pointer to the GHCB
+  @param[in]       InterruptState  An indicator to conditionally (re)enable
+                                   interrupts
 
 **/
 VOID
 EFIAPI
 VmgDone (
-  IN OUT GHCB                *Ghcb
+  IN OUT GHCB                *Ghcb,
+  IN     BOOLEAN             InterruptState
   )
 {
 }

--- a/UefiCpuPkg/Library/VmgExitLibNull/VmgExitLibNull.c
+++ b/UefiCpuPkg/Library/VmgExitLibNull/VmgExitLibNull.c
@@ -90,6 +90,48 @@ VmgDone (
 }
 
 /**
+  Marks a field at the specified offset as valid in the GHCB.
+
+  The ValidBitmap area represents the areas of the GHCB that have been marked
+  valid. Set the bit in ValidBitmap for the input offset.
+
+  @param[in, out] Ghcb    Pointer to the Guest-Hypervisor Communication Block
+  @param[in]      Offset  Qword offset in the GHCB to mark valid
+
+**/
+VOID
+EFIAPI
+VmgSetOffsetValid (
+  IN OUT GHCB                *Ghcb,
+  IN     GHCB_REGISTER       Offset
+  )
+{
+}
+
+/**
+  Checks if a specified offset is valid in the GHCB.
+
+  The ValidBitmap area represents the areas of the GHCB that have been marked
+  valid. Return whether the bit in the ValidBitmap is set for the input offset.
+
+  @param[in]  Ghcb            A pointer to the GHCB
+  @param[in]  Offset          Qword offset in the GHCB to mark valid
+
+  @retval TRUE                Offset is marked valid in the GHCB
+  @retval FALSE               Offset is not marked valid in the GHCB
+
+**/
+BOOLEAN
+EFIAPI
+VmgIsOffsetValid (
+  IN GHCB                    *Ghcb,
+  IN GHCB_REGISTER           Offset
+  )
+{
+  return FALSE;
+}
+
+/**
   Handle a #VC exception.
 
   Performs the necessary processing to handle a #VC exception.


### PR DESCRIPTION
https://bugzilla.tianocore.org/show_bug.cgi?id=3008
https://edk2.groups.io/g/devel/message/66741
http://mid.mail-archive.com/cover.1603981082.git.thomas.lendacky@amd.com
~~~
From: Tom Lendacky <thomas.lendacky@amd.com>

This patch series provides some fixes, updates and cleanup to the SEV-ES
guest support:

- Update the calculation of the qword offset of fields within the GHCB
  by removing the hardcoding of the offsets and using the OFFSET_OF ()
  and sizeof () functions to calculate the values. Remove unused values
  and add values that will be used in later patches.

- Set the SwExitCode, SwExitInfo1, SwExitInfo2 and SwScratch valid bits
  in the GHCB ValidBitmap area when these fields are for a VMGEXIT. This
  is done by adding two new interfaces to the VmgExitLib library to set
  and test the bits of the GHCB ValidBitmap. This reduces code duplication
  and keeps access to the ValidBitmap field within the VmgExitLib library.

- Update the Qemu flash drive services support to add SEV-ES support for
  erasing blocks.

- Disable interrupts when using the GHCB.

- Use the processor number for setting the AP stack pointer instead of the
  APIC ID by calling GetProcessorNumber().

BZ: https://bugzilla.tianocore.org/show_bug.cgi?id=3008

---

These patches are based on commit:
6ad819c1abe3 ("FmpDevicePkg/FmpDeviceLib: Add Last Attempt Status to Check/Set API")

Cc: Ard Biesheuvel <ard.biesheuvel@arm.com>
Cc: Eric Dong <eric.dong@intel.com>
Cc: Laszlo Ersek <lersek@redhat.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Jordan Justen <jordan.l.justen@intel.com>
Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Rahul Kumar <rahul1.kumar@intel.com>
Cc: Zhiguang Liu <zhiguang.liu@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Cc: Tom Lendacky <thomas.lendacky@amd.com>
Cc: Brijesh Singh <brijesh.singh@amd.com>

Changes since v2:
- Don't rename the GHCB_REGISTER enum type.

Changes since v1:
- For the GHCB savearea changes, create a new reserved area name instead
  of "renumbering" the reserved areas.
- Rework the ValidBitmap set/test support to be part of the VmgExitLib
  library. Create two new interfaces for setting and testing bits in the
  GHCB ValidBitmap field and adjust all existing code and the new code in
  this series to use these interfaces for the ValidBitmap updates/checks.
- Don't disable interrupts for just the Qemu flash services support, but
  rather, cover all users of the GHCB by disabling interrupts in VmgInit()
  and restoring them in VmgDone(). This requires changes to those
  interaces.

Tom Lendacky (11):
  MdePkg: Clean up GHCB field offsets and save area
  UefiCpuPkg/VmgExitLib: Add interfaces to set/read GHCB ValidBitmap
    bits
  OvmfPkg/VmgExitLib: Implement new VmgExitLib interfaces
  OvmfPkg/VmgExitLib: Set the SW exit fields when performing VMGEXIT
  OvmfPkg/VmgExitLib: Set the SwScratch valid bit for IOIO events
  OvmfPkg/VmgExitLib: Set the SwScratch valid bit for MMIO events
  UefiCpuPkg/MpInitLib: Set the SW exit fields when performing VMGEXIT
  OvmfPkg/QemuFlashFvbServicesRuntimeDxe: Set the SwScratch valid bit
  OvmfPkg/QemuFlashFvbServicesRuntimeDxe: Fix erase blocks for SEV-ES
  UefiCpuPkg, OvmfPkg: Disable interrupts when using the GHCB
  UefiCpuPkg/MpInitLib: For SEV-ES guest, set stack based on processor
    number

 MdePkg/Include/Register/Amd/Ghcb.h                    |  40 +++---
 UefiCpuPkg/Include/Library/VmgExitLib.h               |  51 +++++++-
 OvmfPkg/Library/VmgExitLib/VmgExitLib.c               |  84 ++++++++++++-
 OvmfPkg/Library/VmgExitLib/VmgExitVcHandler.c         | 129 ++++++--------------
 OvmfPkg/QemuFlashFvbServicesRuntimeDxe/QemuFlash.c    |   4 +-
 OvmfPkg/QemuFlashFvbServicesRuntimeDxe/QemuFlashDxe.c |   6 +-
 UefiCpuPkg/Library/MpInitLib/DxeMpLib.c               |   5 +-
 UefiCpuPkg/Library/MpInitLib/MpLib.c                  |  14 ++-
 UefiCpuPkg/Library/VmgExitLibNull/VmgExitLibNull.c    |  60 +++++++--
 UefiCpuPkg/Library/MpInitLib/X64/MpFuncs.nasm         |   6 +
 10 files changed, 258 insertions(+), 141 deletions(-)
~~~