### PR TITLE
ShellPkg:Fix bug in FileBuffer.c

### DIFF
--- a/ShellPkg/Library/UefiShellDebug1CommandsLib/Edit/FileBuffer.c
+++ b/ShellPkg/Library/UefiShellDebug1CommandsLib/Edit/FileBuffer.c
@@ -2767,6 +2767,8 @@ FileBufferCutLine (
   UINTN           Row;
   UINTN           Col;
 
+  *CutLine      = NULL;
+
   if (FileBuffer.ReadOnly) {
     StatusBarSetStatusString (L"Read Only File Can Not Be Modified");
     return EFI_SUCCESS;


### PR DESCRIPTION
REF:https://bugzilla.tianocore.org/show_bug.cgi?id=2998

In the function FileBufferCutLine(),set the CutLine pointer to NULL,
The function header specifies that the pointer is valid on a successful
or failed return code.

Signed-off-by: Enze Zhu <zhuenze@byosoft.com.cn>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>
Reviewed-by: Zhichao Gao <zhichao.gao@intel.com>