### PR TITLE
BaseTools: Fix BaseTools nmake cleanall hang issue

### DIFF
--- a/BaseTools/Source/C/Makefiles/NmakeSubdirs.py
+++ b/BaseTools/Source/C/Makefiles/NmakeSubdirs.py
@@ -45,7 +45,10 @@ def RunCommand(WorkDir=None, *Args, **kwargs):
 
     output_lock.acquire(True)
     print("execute command \"{0}\" in directory {1}".format(" ".join(Args), WorkDir))
-    print(message)
+    try:
+        print(message)
+    except:
+        pass
     output_lock.release()
 
     return p.returncode, stdout


### PR DESCRIPTION
On windows system, when use command chcp displays the number of the
active console code page, if the active console code is 936, run
make cleanall in the BaseTools will hang.
Issue reproduce step:
chcp 936
edksetup.bat VS2015
cd BaseTools
nmake cleanall

Cc: Bob Feng <bob.c.feng@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Yuwei Chen <yuwei.chen@intel.com>
Signed-off-by: Yunhua Feng <fengyunhua@byosoft.com.cn>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>