### PR TITLE
CryptoPkg/OpensslLib: Add native instruction support for X64

### DIFF
--- a/CryptoPkg/Library/BaseCryptLib/Pk/CryptPkcs7VerifyEku.c
+++ b/CryptoPkg/Library/BaseCryptLib/Pk/CryptPkcs7VerifyEku.c
@@ -508,10 +508,6 @@ Exit:
     free (SignedData);
   }
 
-  if (SignerCert != NULL) {
-    X509_free (SignerCert);
-  }
-
   if (Pkcs7 != NULL) {
     PKCS7_free (Pkcs7);
   }


### PR DESCRIPTION
BZ: https://bugzilla.tianocore.org/show_bug.cgi?id=2507

V5 Changes:
  Move ApiHooks.c into X64 folder
  Update process_files.pl to clean architecture-specific subfolders without
    removing them
  Rebased INF file to merge latest changes regarding RngLib vs. TimerLib

V4 Changes:
  Add copyright header to uefi-asm.conf
  Move [Sources.X64] block to cover entire X64-specific config

V3 Changes:
  Added definitions for ptrdiff_t and wchar_t to CrtLibSupport.h for
    LLVM/Clang build support.
  Added -UWIN32 to GCC Flags for LLVM/Clang build support.
  Added missing AES GCM assembly file.

V2 Changes:
  Limit scope of assembly config to SHA and AES functions.
  Removed IA32 native support (reduced config was causing build failure and
    can be added in a later patch).
  Removed XMM instructions from assembly generation.
  Added automatic copyright header porting for generated assembly files.

This patch adds support for building the native instruction algorithms for
the X64 architecture in OpensslLib. The process_files.pl script was modified
to parse the .asm file targets from the OpenSSL build config data struct, and
generate the necessary assembly files for the EDK2 build environment.

For the X64 variant, OpenSSL includes calls to a Windows error handling API,
and that function has been stubbed out in ApiHooks.c.

For all variants, a constructor is added to call the required CPUID function
within OpenSSL to facilitate processor capability checks in the native
algorithms.

Additional native architecture variants should be simple to add by following
the changes made for this architecture.

The OpenSSL assembly files are traditionally generated at build time using a
perl script. To avoid that burden on EDK2 users, these end-result assembly
files are generated during the configuration steps performed by the package
maintainer (through process_files.pl). The perl generator scripts inside
OpenSSL do not parse file comments as they are only meant to create
intermediate build files, so process_files.pl contains additional hooks to
preserve the copyright headers as well as clean up tabs and line endings to
comply with EDK2 coding standards. The resulting file headers align with
the generated .h files which are already included in the EDK2 repository.

Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Xiaoyu Lu <xiaoyux.lu@intel.com>
Cc: Mike Kinney <michael.d.kinney@intel.com>
Cc: Ard Biesheuvel <ard.biesheuvel@arm.com>
