### PR TITLE
Some timer event may be change the Tpl to higher level than Priority …

### DIFF
--- a/MdeModulePkg/Core/Dxe/Event/Event.c
+++ b/MdeModulePkg/Core/Dxe/Event/Event.c
@@ -194,6 +194,13 @@ CoreDispatchEventNotifies (
     Event->NotifyFunction (Event, Event->NotifyContext);
 
     //
+    //Restore Tpl to Priority in case some timer event change the Tpl to higher level than Priority.
+    //
+    if (gEfiCurrentTpl != Priority) {
+      gEfiCurrentTpl = Priority;
+    }
+
+    //
     // Check for next pending event
     //
     CoreAcquireEventLock ();


### PR DESCRIPTION
…and forget to restore. This may be lead to next timer event produce fatal error when rise the Tpl to Priority. FATAL ERROR - RaiseTpl with OldTpl(0x10) > NewTpl(0x8).