### PR TITLE
BaseTools: Incremental build issue for included ASI file's deletion.

### DIFF
--- a/BaseTools/Source/Python/Trim/Trim.py
+++ b/BaseTools/Source/Python/Trim/Trim.py
@@ -372,8 +372,7 @@ def TrimAslFile(Source, Target, IncludePathFile,AslDeps = False):
     AslIncludes = []
     Lines = DoInclude(Source, '', IncludePathList,IncludeFileList=AslIncludes,filetype='ASL')
     AslIncludes = [item for item in AslIncludes if item !=Source]
-    if AslDeps and AslIncludes:
-        SaveFileOnChange(os.path.join(os.path.dirname(Target),os.path.basename(Source))+".trim.deps", " \\\n".join([Source+":"] +AslIncludes),False)
+    SaveFileOnChange(os.path.join(os.path.dirname(Target),os.path.basename(Source))+".trim.deps", " \\\n".join([Source+":"] +AslIncludes),False)
 
     #
     # Undef MIN and MAX to avoid collision in ASL source code


### PR DESCRIPTION
REF:https://bugzilla.tianocore.org/show_bug.cgi?id=2972

When using incremental build to delete an included xxx.asi file from
the ASL file, the xxx.asl.trim.deps file generated by previous build
process will not be deleted from the OUTPUT directory, which caused
the dependency file still include the xxx.asl.trim.deps file.

If the include file is deleted and DEPs is empty.

Signed-off-by: Mingyue Liang <mingyuex.liang@intel.com>
Cc: Bob Feng <bob.c.feng@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Yuwei Chen <yuwei.chen@intel.com>

Reviewed-by: Bob Feng <bob.c.feng@intel.com>