### PR TITLE
BaseTools: Add image type into generate map file

### DIFF
--- a/BaseTools/Source/C/GenFv/GenFvInternalLib.c
+++ b/BaseTools/Source/C/GenFv/GenFvInternalLib.c
@@ -903,7 +903,12 @@ Returns:
     fprintf (FvMapFile, "BaseAddress=0x%010llx, ", (unsigned long long) (ImageBaseAddress + Offset));
   }
 
-  fprintf (FvMapFile, "EntryPoint=0x%010llx", (unsigned long long) (ImageBaseAddress + AddressOfEntryPoint));
+  fprintf (FvMapFile, "EntryPoint=0x%010llx, ", (unsigned long long) (ImageBaseAddress + AddressOfEntryPoint));
+  if (!pImageContext->IsTeImage) {
+    fprintf (FvMapFile, "Type=PE");
+  } else {
+    fprintf (FvMapFile, "Type=TE");
+  }
   fprintf (FvMapFile, ")\n");
 
   fprintf (FvMapFile, "(GUID=%s", FileGuidName);

--- a/BaseTools/Source/Python/build/BuildReport.py
+++ b/BaseTools/Source/Python/build/BuildReport.py
@@ -60,7 +60,7 @@ gPcdGuidPattern = re.compile(r"PCD\((\w+)[.](\w+)\)")
 gOffsetGuidPattern = re.compile(r"(0x[0-9A-Fa-f]+) ([-A-Fa-f0-9]+)")
 
 ## Pattern to find module base address and entry point in fixed flash map file
-gModulePattern = r"\n[-\w]+\s*\(([^,]+),\s*BaseAddress=%(Address)s,\s*EntryPoint=%(Address)s\)\s*\(GUID=([-0-9A-Fa-f]+)[^)]*\)"
+gModulePattern = r"\n[-\w]+\s*\(([^,]+),\s*BaseAddress=%(Address)s,\s*EntryPoint=%(Address)s,\s*Type=\w+\)\s*\(GUID=([-0-9A-Fa-f]+)[^)]*\)"
 gMapFileItemPattern = re.compile(gModulePattern % {"Address" : "(-?0[xX][0-9A-Fa-f]+)"})
 
 ## Pattern to find all module referenced header files in source files


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=2977

For a source-level BIOS debugger the .map files are quite useful with one major shortcoming: the debugger cannot know, solely from the .map file, the format (PE/COFF vs. TE) of the image included in the final BIOS ROM

Yunhua Feng (2):
  BaseTools: Add image type into generate map file
  BaseTools: update report map file format

 BaseTools/Source/C/GenFv/GenFvInternalLib.c  | 7 ++++++-  BaseTools/Source/Python/build/BuildReport.py | 2 +-
 2 files changed, 7 insertions(+), 2 deletions(-)

Cc: Bob Feng <bob.c.feng@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Yuwei Chen <yuwei.chen@intel.com>
Signed-off-by: Yunhua Feng <fengyunhua@byosoft.com.cn>
Reviewed-by: Bob Feng <bob.c.feng@intel.com>