### PR TITLE
BaseTools: Limit command line length.

### DIFF
--- a/BaseTools/Source/Python/AutoGen/IncludesAutoGen.py
+++ b/BaseTools/Source/Python/AutoGen/IncludesAutoGen.py
@@ -201,7 +201,17 @@ ${END}
                             cc_options = line[len(cc_cmd)+2:].split()
                         else:
                             cc_options = line[len(cc_cmd):].split()
-                        SourceFileAbsPathMap = {os.path.basename(item):item for item in cc_options if not item.startswith("/") and os.path.exists(item)}
+                        for item in cc_options:
+                            if not item.startswith("/"):
+                                if item.endswith(".txt") and item.startswith("@"):
+                                    with open(item[1:], "r") as file:
+                                        source_files = file.readlines()[0].split()
+                                        SourceFileAbsPathMap = {os.path.basename(file): file for file in source_files if
+                                                                os.path.exists(file)}
+                                else:
+                                    if os.path.exists(item):
+                                        SourceFileAbsPathMap.update({os.path.basename(item): item.strip()})
+                        # SourceFileAbsPathMap = {os.path.basename(item):item for item in cc_options if not item.startswith("/") and os.path.exists(item)}
             if line in SourceFileAbsPathMap:
                 current_source = line
                 if current_source not in ModuleDepDict:


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=2528

Currently, CL command contains multiple C files will be compiled,
and that caused command line too long, which may trigger build error.

In order to solve this issue, the following rules is used in this scene:

If the number of C files is greater than one, a txt file will be used
to record these C files, and replaces the corresponding content in
command line with the file name.

Else (only one C file listed in the command line), the length of the
whole CL command line will determine whether use a file to record. If
the length exceeds the limited max length, use the recording file; else
C file name directly listed in the command line

Signed-off-by: Mingyue Liang <mingyuex.liang@intel.com>
Cc: Bob Feng <bob.c.feng@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Yuwei Chen <yuwei.chen@intel.com>

Reviewed-by: Bob Feng <bob.c.feng@intel.com>