### PR TITLE
MdeModulePkg/AtaAtapiPassThru: Add SATA error recovery

### DIFF
--- a/MdeModulePkg/Bus/Ata/AtaAtapiPassThru/AhciMode.h
+++ b/MdeModulePkg/Bus/Ata/AtaAtapiPassThru/AhciMode.h
@@ -1,7 +1,7 @@
 /** @file
   Header file for AHCI mode of ATA host controller.
 
-  Copyright (c) 2010 - 2018, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2010 - 2020, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -96,7 +96,7 @@ typedef union {
 #define EFI_AHCI_PORT_IS                       0x0010
 #define   EFI_AHCI_PORT_IS_DHRS                BIT0
 #define   EFI_AHCI_PORT_IS_PSS                 BIT1
-#define   EFI_AHCI_PORT_IS_SSS                 BIT2
+#define   EFI_AHCI_PORT_IS_DSS                 BIT2
 #define   EFI_AHCI_PORT_IS_SDBS                BIT3
 #define   EFI_AHCI_PORT_IS_UFS                 BIT4
 #define   EFI_AHCI_PORT_IS_DPS                 BIT5
@@ -113,6 +113,7 @@ typedef union {
 #define   EFI_AHCI_PORT_IS_CPDS                BIT31
 #define   EFI_AHCI_PORT_IS_CLEAR               0xFFFFFFFF
 #define   EFI_AHCI_PORT_IS_FIS_CLEAR           0x0000000F
+#define   EFI_AHCI_PORT_IS_ERROR_MASK          (EFI_AHCI_PORT_IS_INFS | EFI_AHCI_PORT_IS_IFS | EFI_AHCI_PORT_IS_HBDS | EFI_AHCI_PORT_IS_HBFS | EFI_AHCI_PORT_IS_TFES)
 
 #define EFI_AHCI_PORT_IE                       0x0014
 #define EFI_AHCI_PORT_CMD                      0x0018
@@ -239,6 +240,12 @@ typedef struct {
   UINT8    AhciCFisRsvd4[4];
   UINT8    AhciCFisRsvd5[44];
 } EFI_AHCI_COMMAND_FIS;
+
+typedef enum {
+  SataFisD2H = 0,
+  SataFisPioSetup,
+  SataFisDmaSetup
+} SATA_FIS_TYPE;
 
 //
 // ACMD: ATAPI command (12 or 16 bytes)

--- a/MdeModulePkg/Bus/Ata/AtaAtapiPassThru/AhciMode.h
+++ b/MdeModulePkg/Bus/Ata/AtaAtapiPassThru/AhciMode.h
@@ -192,6 +192,8 @@ typedef union {
 #define   AHCI_PORT_DEVSLP_DITO_MASK           0x01FF8000
 #define   AHCI_PORT_DEVSLP_DM_MASK             0x1E000000
 
+#define AHCI_COMMAND_RETRIES  5
+
 #pragma pack(1)
 //
 // Command List structure includes total 32 entries.

--- a/MdeModulePkg/Bus/Ata/AtaAtapiPassThru/AhciMode.h
+++ b/MdeModulePkg/Bus/Ata/AtaAtapiPassThru/AhciMode.h
@@ -114,6 +114,7 @@ typedef union {
 #define   EFI_AHCI_PORT_IS_CLEAR               0xFFFFFFFF
 #define   EFI_AHCI_PORT_IS_FIS_CLEAR           0x0000000F
 #define   EFI_AHCI_PORT_IS_ERROR_MASK          (EFI_AHCI_PORT_IS_INFS | EFI_AHCI_PORT_IS_IFS | EFI_AHCI_PORT_IS_HBDS | EFI_AHCI_PORT_IS_HBFS | EFI_AHCI_PORT_IS_TFES)
+#define   EFI_AHCI_PORT_IS_FATAL_ERROR_MASK    (EFI_AHCI_PORT_IS_IFS | EFI_AHCI_PORT_IS_HBDS | EFI_AHCI_PORT_IS_HBFS | EFI_AHCI_PORT_IS_TFES)
 
 #define EFI_AHCI_PORT_IE                       0x0014
 #define EFI_AHCI_PORT_CMD                      0x0018
@@ -122,9 +123,11 @@ typedef union {
 #define   EFI_AHCI_PORT_CMD_SUD                BIT1
 #define   EFI_AHCI_PORT_CMD_POD                BIT2
 #define   EFI_AHCI_PORT_CMD_CLO                BIT3
-#define   EFI_AHCI_PORT_CMD_CR                 BIT15
 #define   EFI_AHCI_PORT_CMD_FRE                BIT4
+#define   EFI_AHCI_PORT_CMD_CCS_MASK           (BIT8 | BIT9 | BIT10 | BIT11 | BIT12)
+#define   EFI_AHCI_PORT_CMD_CCS_SHIFT          8
 #define   EFI_AHCI_PORT_CMD_FR                 BIT14
+#define   EFI_AHCI_PORT_CMD_CR                 BIT15
 #define   EFI_AHCI_PORT_CMD_MASK               ~(EFI_AHCI_PORT_CMD_ST | EFI_AHCI_PORT_CMD_FRE | EFI_AHCI_PORT_CMD_COL)
 #define   EFI_AHCI_PORT_CMD_PMA                BIT17
 #define   EFI_AHCI_PORT_CMD_HPCP               BIT18


### PR DESCRIPTION
**BZ:**
https://bugzilla.tianocore.org/show_bug.cgi?id=3024
https://bugzilla.tianocore.org/show_bug.cgi?id=3025
https://bugzilla.tianocore.org/show_bug.cgi?id=3026

**Patch at mailing list:**
https://edk2.groups.io/g/devel/message/67038
https://edk2.groups.io/g/devel/message/67039
https://edk2.groups.io/g/devel/message/67040
https://edk2.groups.io/g/devel/message/67041

**Cover letter:**
To increase boot stability when booting from SATA drives SATA driver should implement the AHCI spec defined port error recovery. This will allow the driver to handle random fails on SATA link.

Performed tests on 2 setups. One with AHCI controller booting OS successfully without error recovery(control setup) and other which fails 1 in 5 times(fail setup).

Tests performed:
1. Booted control setup to OS successfully.
2. Checked if during normal boot none of the packets is repeated(this came up after previous code version had a bug which repeated each DMA packet 5 times).
3. Booted control setup to OS with simulated errors appearing on first packet of every DMA transaction.
4. Performed extensive tests on fail setup. Fail rate decreased from 20% failure to ~1% failure. 1% failure is observed during OS execution, not BIOS so in a way boot is 100% stable).

Change pushed to github:
This series:
https://github.com/malbecki/edk2/commits/sata_recovery2
Simulated errors:
https://github.com/malbecki/edk2/commits/sata_recovery_simulated_error

Some more information:
For the bug mentioned above in point 2, the discussion can be referred here:
https://github.com/malbecki/edk2/commit/9ea81cadf38725e194ec01e0b0c556fd133f3ced#r43226067

For the other discussion we did before this patch, please refer to:
https://github.com/malbecki/edk2/commits/sata_recovery

For logging here is the example of verbose command log(taken from v1 patch):
Starting commmand: 
ATA COMMAND BLOCK:
AtaCommand: 37
AtaFeatures: 0
AtaSectorNumber: 0
AtaCylinderLow: 16
AtaCylinderHigh: 16
AtaDeviceHead: 224
AtaSectorNumberExp: 57
AtaCylinderLowExp: 0
AtaCylinderHighExp: 0
AtaFeaturesExp: 0
AtaSectorCount: 64
AtaSectorCountExp: 0
DMA command failed at retry: 0
DMA retry 1
Starting commmand: 
ATA COMMAND BLOCK:
AtaCommand: 37
AtaFeatures: 0
AtaSectorNumber: 0
AtaCylinderLow: 16
AtaCylinderHigh: 16
AtaDeviceHead: 224
AtaSectorNumberExp: 57
AtaCylinderLowExp: 0
AtaCylinderHighExp: 0
AtaFeaturesExp: 0
AtaSectorCount: 64
AtaSectorCountExp: 0
ATA STATUS BLOCK:
AtaStatus: 80
AtaError: 0
DMA retry 0

Changes in v2:
- Changed logging per review suggestions
- Fixed small issues with commit message

Signed-off-by: Mateusz Albecki <mateusz.albecki@intel.com>

Cc: Ray Ni <ray.ni@intel.com>
Cc: Hao A Wu <hao.a.wu@intel.com>


Mateusz Albecki (4):
  MdeModulePkg/AtaAtapiPassThru: Check IS to check for command
    completion
  MdeModulePkg/AtaAtapiPassThru: Add SATA error recovery flow
  MdeModulePkg/AtaAtapiPassThru: Restart failed packets
  MdeModulePkg/AtaAtapiPassThru: Trace ATA packets

 .../Bus/Ata/AtaAtapiPassThru/AhciMode.c       | 799 +++++++++++-------
 .../Bus/Ata/AtaAtapiPassThru/AhciMode.h       |  18 +-
 2 files changed, 532 insertions(+), 285 deletions(-)
