### PR TITLE
RedfishPkg: Add PCD definition to RedfishPkg

### DIFF
--- a/RedfishPkg/RedfishPkg.dec
+++ b/RedfishPkg/RedfishPkg.dec
@@ -28,3 +28,25 @@
 [Guids]
   gEfiRedfishPkgTokenSpaceGuid      = { 0x4fdbccb7, 0xe829, 0x4b4c, { 0x88, 0x87, 0xb2, 0x3f, 0xd7, 0x25, 0x4b, 0x85 }}
 
+[PcdsFixedAtBuild, PcdsPatchableInModule]
+  #
+  # This PCD is the UEFI device path which is used as the Redfish host interface.
+  #
+  gEfiRedfishPkgTokenSpaceGuid.PcdRedfishRestExServiceDevicePath|{0x0}|REST_EX_SERVICE_DEVICE_PATH_DATA|0x00001000 {
+  <HeaderFiles>
+    Pcd/RestExServiceDevicePath.h
+  <Packages>
+    MdePkg/MdePkg.dec
+    MdeModulePkg/MdeModulePkg.dec
+    RedfishPkg/RedfishPkg.dec
+  }
+  #
+  # This PCD indicates the EFI REST EX access mode to Redfish service.
+  # Default is set to out of band access.
+  #
+  gEfiRedfishPkgTokenSpaceGuid.PcdRedfishRestExServiceAccessModeInBand|FALSE|BOOLEAN|0x00001001
+  #
+  # This PCD indicates the access mode EFI Discover protocol uses to look for the proper EFI REST EX
+  # protocol instance.
+  #
+  gEfiRedfishPkgTokenSpaceGuid.PcdRedfishDiscoverAccessModeInBand|FALSE|BOOLEAN|0x00001002


### PR DESCRIPTION
This PCD is the UEFI device path which is used as the Redfish
host interface.

Signed-off-by: Jiaxin Wu <jiaxin.wu@intel.com>
Signed-off-by: Ting Ye <ting.ye@intel.com>
Signed-off-by: Siyuan Fu <siyuan.fu@intel.com>
Signed-off-by: Fan Wang <fan.wang@intel.com>
Signed-off-by: Abner Chang <abner.chang@hpe.com>

Cc: Nickle Wang <nickle.wang@hpe.com>
Cc: Peter O'Hanley <peter.ohanley@hpe.com>
Reviewed-by: Nickle Wang <nickle.wang@hpe.com>