### PR TITLE
RedfishPkg: DSC and FDF include files for enabling EFI Redfish support

### DIFF
--- a/RedfishPkg/Redfish.dsc.inc
+++ b/RedfishPkg/Redfish.dsc.inc
@@ -1,0 +1,21 @@
+## @file
+# Redfish DSC include file for Platform DSC
+#
+# This file includes all required information to enable Redfish features.
+# It can be included to a platform DSC file by using "!include RedfishPkg/Redfish.dsc.inc".
+#
+# (C) Copyright 2020 Hewlett Packard Enterprise Development LP<BR>
+#
+#    SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  !include RedfishPkg/RedfishDefines.dsc.inc
+
+[LibraryClasses]
+  !include RedfishPkg/RedfishLibs.dsc.inc
+
+[Components]
+  !include RedfishPkg/RedfishComponents.dsc.inc
+

--- a/RedfishPkg/Redfish.fdf.inc
+++ b/RedfishPkg/Redfish.fdf.inc
@@ -1,0 +1,16 @@
+## @file
+# Redfish FDF include file for [FV*] section of all Architectures.
+#
+# This file can be included to the [FV*] section(s) of a platform FDF file
+# by using "!include RedfishPkg/RedfisLibs.fdf.inc" to specify the module instances
+# to be built in the firmware volume.
+#
+# (C) Copyright 2020 Hewlett Packard Enterprise Development LP<BR>
+#
+#    SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+!if $(REDFISH_ENABLE) == TRUE
+  INF RedfishPkg/RestJsonStructureDxe/RestJsonStructureDxe.inf
+  INF RedfishPkg/RedfishHostInterfaceDxe/RedfishHostInterfaceDxe.inf
+!endif

--- a/RedfishPkg/RedfishComponents.dsc.inc
+++ b/RedfishPkg/RedfishComponents.dsc.inc
@@ -1,0 +1,18 @@
+## @file
+# Redfish DSC include file for [Components*] section of all Architectures.
+#
+# This file can be included to the [Components*] section(s) of a platform DSC file
+# by using "!include RedfishPkg/RedfishComponents.dsc.inc" to specify the INF files
+# of EDKII Redfish drivers according to the value of flags described in
+# "RedfishDefines.dsc.inc".
+#
+# (C) Copyright 2020 Hewlett Packard Enterprise Development LP<BR>
+#
+#    SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+!if $(REDFISH_ENABLE) == TRUE
+  RedfishPkg/RestJsonStructureDxe/RestJsonStructureDxe.inf
+  RedfishPkg/RedfishHostInterfaceDxe/RedfishHostInterfaceDxe.inf
+!endif

--- a/RedfishPkg/RedfishDefines.dsc.inc
+++ b/RedfishPkg/RedfishDefines.dsc.inc
@@ -1,0 +1,27 @@
+## @file
+# RedfishPkg DSC include file for [Defines] section of all Architectures.
+#
+# This file can be included to the [Defines] section of a platform DSC file by
+# using "!include RedfishPkg/RedfishDefines.dsc.inc" to set value of
+# flags.
+#
+# These flags can be defined before the !include line, or changed on the command
+# line to enable or disable related feature support.
+#   -D FLAG=VALUE
+#
+# The default value of these flags are:
+#   DEFINE REDFISH_ENABLE = TRUE
+#
+# (C) Copyright 2020 Hewlett Packard Enterprise Development LP<BR>
+#
+#    SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+!ifndef REDFISH_ENABLE
+  #
+  # This flag is to enable or disable the whole Redfish support.
+  #
+  DEFINE REDFISH_ENABLE = TRUE
+!endif
+

--- a/RedfishPkg/RedfishLibs.dsc.inc
+++ b/RedfishPkg/RedfishLibs.dsc.inc
@@ -1,0 +1,15 @@
+## @file
+# Redfish DSC include file for [LibraryClasses*] section of all Architectures.
+#
+# This file can be included to the [LibraryClasses*] section(s) of a platform DSC file
+# by using "!include RedfishPkg/RedfisLibs.dsc.inc" to specify the library instances
+# of EDKII network library classes.
+#
+# (C) Copyright 2020 Hewlett Packard Enterprise Development LP<BR>
+#
+#    SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+!if $(REDFISH_ENABLE) == TRUE
+!endif
+


### PR DESCRIPTION
Provide the DSC/FDF include files of edk2 Redfish related
modules and definitions which can be included in platform's
DSC/FDF.

Signed-off-by: Abner Chang <abner.chang@hpe.com>

Cc: Jiaxin Wu <jiaxin.wu@intel.com>
Cc: Siyuan Fu <siyuan.fu@intel.com>
Cc: Fan Wang <fan.wang@intel.com>
Cc: Nickle Wang <nickle.wang@hpe.com>
Cc: Peter O'Hanley <peter.ohanley@hpe.com>
Reviewed-by: Nickle Wang <nickle.wang@hpe.com>