### PR TITLE
BaseTools: Resolve index out of range errors.

### DIFF
--- a/BaseTools/Source/Python/AutoGen/IncludesAutoGen.py
+++ b/BaseTools/Source/Python/AutoGen/IncludesAutoGen.py
@@ -291,7 +291,8 @@ ${END}
                 targetitem = self.GetRealTarget(source_abs.strip(" :"))
 
                 targetitem += ": "
-                targetitem += lines[1]
+                if len(lines)>=2:
+                    targetitem += lines[1]
                 newcontent.append(targetitem)
                 newcontent.extend(lines[2:])
                 newcontent.append("\n")


### PR DESCRIPTION
This problem is generated by solving bz2972's
patch, and the commit ID is
0af7f8e6a9253960ba820cd6ddfd8c36543d30cb.

This is a problem when updating the DEPs file.
The code does not consider that there is only
one line of content in the file, so the filter
condition is added to prevent the index from
exceeding the range.

Signed-off-by: Mingyue Liang <mingyuex.liang@intel.com>
Cc: Bob Feng <bob.c.feng@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Yuwei Chen <yuwei.chen@intel.com>
Reviewed-by: Yuwei Chen <yuwei.chen@intel.com>
Reviewed-by: Bob Feng <bob.c.feng@intel.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>