### PR TITLE
SecurityPkg: Add RPMC Index to the RpmcLib

### DIFF
--- a/SecurityPkg/Include/Library/RpmcLib.h
+++ b/SecurityPkg/Include/Library/RpmcLib.h
@@ -14,6 +14,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 /**
   Requests the monotonic counter from the designated RPMC counter.
 
+  @param[in]    CounterIndex            The RPMC index
   @param[out]   CounterValue            A pointer to a buffer to store the RPMC value.
 
   @retval       EFI_SUCCESS             The operation completed successfully.
@@ -23,11 +24,14 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 EFI_STATUS
 EFIAPI
 RequestMonotonicCounter (
+  IN  UINT8   CounterIndex,
   OUT UINT32  *CounterValue
   );
 
 /**
   Increments the monotonic counter in the SPI flash device by 1.
+
+  @param[in]    CounterIndex            The RPMC index
 
   @retval       EFI_SUCCESS             The operation completed successfully.
   @retval       EFI_DEVICE_ERROR        A device error occurred while attempting to update the counter.
@@ -36,7 +40,7 @@ RequestMonotonicCounter (
 EFI_STATUS
 EFIAPI
 IncrementMonotonicCounter (
-  VOID
+  IN  UINT8   CounterIndex
   );
 
 #endif

--- a/SecurityPkg/Library/RpmcLibNull/RpmcLibNull.c
+++ b/SecurityPkg/Library/RpmcLibNull/RpmcLibNull.c
@@ -12,6 +12,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 /**
   Requests the monotonic counter from the designated RPMC counter.
 
+  @param[in]    CounterIndex            The RPMC index
   @param[out]   CounterValue            A pointer to a buffer to store the RPMC value.
 
   @retval       EFI_SUCCESS             The operation completed successfully.
@@ -21,6 +22,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 EFI_STATUS
 EFIAPI
 RequestMonotonicCounter (
+  IN  UINT8   CounterIndex,
   OUT UINT32  *CounterValue
   )
 {
@@ -31,6 +33,8 @@ RequestMonotonicCounter (
 /**
   Increments the monotonic counter in the SPI flash device by 1.
 
+  @param[in]    CounterIndex            The RPMC index
+
   @retval       EFI_SUCCESS             The operation completed successfully.
   @retval       EFI_DEVICE_ERROR        A device error occurred while attempting to update the counter.
   @retval       EFI_UNSUPPORTED         The operation is un-supported.
@@ -38,7 +42,7 @@ RequestMonotonicCounter (
 EFI_STATUS
 EFIAPI
 IncrementMonotonicCounter (
-  VOID
+  IN  UINT8   CounterIndex
   )
 {
   ASSERT (FALSE);


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=2594

The re-design requires multiple RPMC counter usages.
The consumer will be capable of selecting amongst multiple counters.

Signed-off-by: Nishant C Mistry <nishant.c.mistry@intel.com>
Reviewed-by: Jian J Wang <jian.j.wang@intel.com>