### PR TITLE
[edk2-devel] [PATCH RESEND 0/1] security fix: possible heap corruption with LzmaUefiDecompressGetInfo -- push

### DIFF
--- a/MdeModulePkg/Library/LzmaCustomDecompressLib/LzmaDecompress.c
+++ b/MdeModulePkg/Library/LzmaCustomDecompressLib/LzmaDecompress.c
@@ -127,6 +127,10 @@ GetDecodedSizeOfBuf(
                           in DestinationSize and the size of the scratch
                           buffer was returned in ScratchSize.
 
+  @retval RETURN_UNSUPPORTED  DestinationSize cannot be output because the
+                              uncompressed buffer size (in bytes) does not fit
+                              in a UINT32. Output parameters have not been
+                              modified.
 **/
 RETURN_STATUS
 EFIAPI
@@ -142,6 +146,9 @@ LzmaUefiDecompressGetInfo (
   ASSERT(SourceSize >= LZMA_HEADER_SIZE);
 
   DecodedSize = GetDecodedSizeOfBuf((UINT8*)Source);
+  if (DecodedSize > MAX_UINT32) {
+    return RETURN_UNSUPPORTED;
+  }
 
   *DestinationSize = (UINT32)DecodedSize;
   *ScratchSize = SCRATCH_BUFFER_REQUEST_SIZE;

--- a/MdeModulePkg/Library/LzmaCustomDecompressLib/LzmaDecompressLibInternal.h
+++ b/MdeModulePkg/Library/LzmaCustomDecompressLib/LzmaDecompressLibInternal.h
@@ -9,6 +9,7 @@
 #ifndef __LZMADECOMPRESSLIB_INTERNAL_H__
 #define __LZMADECOMPRESSLIB_INTERNAL_H__
 
+#include <Base.h>
 #include <PiPei.h>
 #include <Library/BaseLib.h>
 #include <Library/BaseMemoryLib.h>
@@ -45,6 +46,10 @@
                           in DestinationSize and the size of the scratch
                           buffer was returned in ScratchSize.
 
+  @retval RETURN_UNSUPPORTED  DestinationSize cannot be output because the
+                              uncompressed buffer size (in bytes) does not fit
+                              in a UINT32. Output parameters have not been
+                              modified.
 **/
 RETURN_STATUS
 EFIAPI


### PR DESCRIPTION
msgid <20201119115034.12897-1-lersek@redhat.com>
https://edk2.groups.io/g/devel/message/67708
https://www.redhat.com/archives/edk2-devel-archive/2020-November/msg00866.html
~~~
Repo:   https://pagure.io/lersek/edk2.git
Branch: tianocore_1816_resend
Ref:    https://bugzilla.tianocore.org/show_bug.cgi?id=1816

"RESEND" because I'm publicly posting the patch from
<https://bugzilla.tianocore.org/show_bug.cgi?id=1816#c9>.

The Reviewed-by tags on the patch originate from
<https://bugzilla.tianocore.org/show_bug.cgi?id=1816#c12> and
<https://bugzilla.tianocore.org/show_bug.cgi?id=1816#c17>.

Repeated the simple regression test at
<https://bugzilla.tianocore.org/show_bug.cgi?id=1816#c10>.

This series targets edk2-stable202011. I plan to merge it later this
week, based on Liming's R-b.

Liming, highlighting TianoCore#1816 in the "proposed features" list
could be useful.

Cc: Dandan Bi <dandan.bi@intel.com>
Cc: Hao A Wu <hao.a.wu@intel.com>
Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Philippe Mathieu-Daudé <philmd@redhat.com>

Thanks!
Laszlo

Laszlo Ersek (1):
  MdeModulePkg/LzmaCustomDecompressLib: catch 4GB+ uncompressed buffer
    sizes

 MdeModulePkg/Library/LzmaCustomDecompressLib/LzmaDecompressLibInternal.h | 5 +++++
 MdeModulePkg/Library/LzmaCustomDecompressLib/LzmaDecompress.c            | 7 +++++++
 2 files changed, 12 insertions(+)
~~~