### PR TITLE
CryptoPkg: BaseCryptLib: Fix buffer double free in CryptPkcs7VerifyEku

### DIFF
--- a/CryptoPkg/Library/BaseCryptLib/Pk/CryptPkcs7VerifyEku.c
+++ b/CryptoPkg/Library/BaseCryptLib/Pk/CryptPkcs7VerifyEku.c
@@ -508,10 +508,6 @@ Exit:
     free (SignedData);
   }
 
-  if (SignerCert != NULL) {
-    X509_free (SignerCert);
-  }
-
   if (Pkcs7 != NULL) {
     PKCS7_free (Pkcs7);
   }


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=2459

SignerCert is part of Pkcs7 instance when both have valid content. OpenSLL
PKCS7_free function will release the memory of SignerCert when applicable.
Freeing SignerCert with X509_free again might cause page fault if use-
after-free guard is enabled.

Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Xiaoyu Lu <xiaoyux.lu@intel.com>
Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Guomin Jiang <guomin.jiang@intel.com>

Signed-off-by: Kun Qin <kun.q@outlook.com>
Reviewed-by: Jiewen Yao <Jiewen.yao@intel.com>