### PR TITLE
Address EDK II CI Failures

### DIFF
--- a/.azurepipelines/templates/platform-build-run-steps.yml
+++ b/.azurepipelines/templates/platform-build-run-steps.yml
@@ -51,6 +51,12 @@ steps:
 # Set default
 - bash: echo "##vso[task.setvariable variable=pkg_count]${{ 1 }}"
 
+# Fetch the target branch so that pr_eval can diff them.
+# Seems like azure pipelines/github changed checkout process in nov 2020.
+- script: git fetch origin $(System.PullRequest.targetBranch)
+  displayName: fetch target branch
+  condition: eq(variables['Build.Reason'], 'PullRequest')
+
 # trim the package list if this is a PR
 - task: CmdLine@1
   displayName: Check if ${{ parameters.build_pkg }} need testing

--- a/.azurepipelines/templates/pr-gate-steps.yml
+++ b/.azurepipelines/templates/pr-gate-steps.yml
@@ -31,6 +31,12 @@ steps:
     echo "##vso[task.setvariable variable=pkgs_to_build]${{ parameters.build_pkgs }}"
     echo "##vso[task.setvariable variable=pkg_count]${{ 1 }}"
 
+# Fetch the target branch so that pr_eval can diff them.
+# Seems like azure pipelines/github changed checkout process in nov 2020.
+- script: git fetch origin $(System.PullRequest.targetBranch)
+  displayName: fetch target branch
+  condition: eq(variables['Build.Reason'], 'PullRequest')
+
 # trim the package list if this is a PR
 - task: CmdLine@1
   displayName: Check if ${{ parameters.build_pkgs }} need testing

--- a/CryptoPkg/Test/UnitTest/Library/BaseCryptLib/HashTests.c
+++ b/CryptoPkg/Test/UnitTest/Library/BaseCryptLib/HashTests.c
@@ -21,10 +21,11 @@ GLOBAL_REMOVE_IF_UNREFERENCED CONST CHAR8 *HashData = "abc";
 //
 // Result for MD5("abc"). (From "A.5 Test suite" of IETF RFC1321)
 //
+#ifdef ENABLE_MD5_DEPRECATED_INTERFACES
 GLOBAL_REMOVE_IF_UNREFERENCED CONST UINT8 Md5Digest[MD5_DIGEST_SIZE] = {
   0x90, 0x01, 0x50, 0x98, 0x3c, 0xd2, 0x4f, 0xb0, 0xd6, 0x96, 0x3f, 0x7d, 0x28, 0xe1, 0x7f, 0x72
-
   };
+#endif
 
 //
 // Result for SHA-1("abc"). (From "A.1 SHA-1 Example" of NIST FIPS 180-2)
@@ -107,7 +108,9 @@ typedef struct {
   VOID                       *HashCtx;
 } HASH_TEST_CONTEXT;
 
+#ifdef ENABLE_MD5_DEPRECATED_INTERFACES
 HASH_TEST_CONTEXT       mMd5TestCtx    = {MD5_DIGEST_SIZE,    Md5GetContextSize,    Md5Init,    Md5Update,    Md5Final,    Md5HashAll,    Md5Digest};
+#endif
 HASH_TEST_CONTEXT       mSha1TestCtx   = {SHA1_DIGEST_SIZE,   Sha1GetContextSize,   Sha1Init,   Sha1Update,   Sha1Final,   Sha1HashAll,   Sha1Digest};
 HASH_TEST_CONTEXT       mSha256TestCtx = {SHA256_DIGEST_SIZE, Sha256GetContextSize, Sha256Init, Sha256Update, Sha256Final, Sha256HashAll, Sha256Digest};
 HASH_TEST_CONTEXT       mSha384TestCtx = {SHA384_DIGEST_SIZE, Sha384GetContextSize, Sha384Init, Sha384Update, Sha384Final, Sha384HashAll, Sha384Digest};
@@ -187,7 +190,9 @@ TEST_DESC mHashTest[] = {
     //
     // -----Description----------------Class---------------------Function---------------Pre------------------Post------------Context
     //
+#ifdef ENABLE_MD5_DEPRECATED_INTERFACES
     {"TestVerifyMd5()",    "CryptoPkg.BaseCryptLib.Hash",   TestVerifyHash, TestVerifyHashPreReq, TestVerifyHashCleanUp, &mMd5TestCtx},
+#endif
     {"TestVerifySha1()",   "CryptoPkg.BaseCryptLib.Hash",   TestVerifyHash, TestVerifyHashPreReq, TestVerifyHashCleanUp, &mSha1TestCtx},
     {"TestVerifySha256()", "CryptoPkg.BaseCryptLib.Hash",   TestVerifyHash, TestVerifyHashPreReq, TestVerifyHashCleanUp, &mSha256TestCtx},
     {"TestVerifySha384()", "CryptoPkg.BaseCryptLib.Hash",   TestVerifyHash, TestVerifyHashPreReq, TestVerifyHashCleanUp, &mSha384TestCtx},

--- a/OvmfPkg/PlatformCI/.azurepipelines/Windows-VS2019.yml
+++ b/OvmfPkg/PlatformCI/.azurepipelines/Windows-VS2019.yml
@@ -132,7 +132,7 @@ jobs:
         build_flags: $(Build.Flags)
         run_flags: $(Run.Flags)
         extra_install_step:
-        - powershell: choco install qemu; Write-Host "##vso[task.prependpath]c:\Program Files\qemu"
+        - powershell: choco install qemu --version=2020.08.14; Write-Host "##vso[task.prependpath]c:\Program Files\qemu"
           displayName: Install QEMU and Set QEMU on path # friendly name displayed in the UI
           condition: and(gt(variables.pkg_count, 0), succeeded())
 


### PR DESCRIPTION
* Always fetch the target branch of the PR (usually origin/master)
  so diffs between PR and the target branch can be performed.  There
  is no guarantee that the target branch is fetched when a PR is 
  evaluated by a CI agent.
* QEMU release for Windows from Nov 20, 2020 is installed into 
  wrong directory.  Use previous QEMU for Windows release from
  Aug 14, 2020.
* Update CryptoPkg unit tests to skip MD5 unit tests if 
  ENABLE_MD5_DEPRECATED_INTERFACES is defined.

Cc: Sean Brogan <sean.brogan@microsoft.com>
Cc: Bret Barkelew <Bret.Barkelew@microsoft.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Jordan Justen <jordan.l.justen@intel.com>
Cc: Laszlo Ersek <lersek@redhat.com>
Cc: Ard Biesheuvel <ard.biesheuvel@arm.com>
Cc: Andrew Fish <afish@apple.com>
Cc: Leif Lindholm <leif@nuviainc.com>
Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Xiaoyu Lu <xiaoyux.lu@intel.com>
Cc: Guomin Jiang <guomin.jiang@intel.com>
Signed-off-by: Michael D Kinney <michael.d.kinney@intel.com>
