### PR TITLE
Revert "SecurityPkg: Add RPMC Index to the RpmcLib"

### DIFF
--- a/SecurityPkg/Include/Library/RpmcLib.h
+++ b/SecurityPkg/Include/Library/RpmcLib.h
@@ -14,7 +14,6 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 /**
   Requests the monotonic counter from the designated RPMC counter.
 
-  @param[in]    CounterIndex            The RPMC index
   @param[out]   CounterValue            A pointer to a buffer to store the RPMC value.
 
   @retval       EFI_SUCCESS             The operation completed successfully.
@@ -24,14 +23,11 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 EFI_STATUS
 EFIAPI
 RequestMonotonicCounter (
-  IN  UINT8   CounterIndex,
   OUT UINT32  *CounterValue
   );
 
 /**
   Increments the monotonic counter in the SPI flash device by 1.
-
-  @param[in]    CounterIndex            The RPMC index
 
   @retval       EFI_SUCCESS             The operation completed successfully.
   @retval       EFI_DEVICE_ERROR        A device error occurred while attempting to update the counter.
@@ -40,7 +36,7 @@ RequestMonotonicCounter (
 EFI_STATUS
 EFIAPI
 IncrementMonotonicCounter (
-  IN  UINT8   CounterIndex
+  VOID
   );
 
 #endif

--- a/SecurityPkg/Library/RpmcLibNull/RpmcLibNull.c
+++ b/SecurityPkg/Library/RpmcLibNull/RpmcLibNull.c
@@ -12,7 +12,6 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 /**
   Requests the monotonic counter from the designated RPMC counter.
 
-  @param[in]    CounterIndex            The RPMC index
   @param[out]   CounterValue            A pointer to a buffer to store the RPMC value.
 
   @retval       EFI_SUCCESS             The operation completed successfully.
@@ -22,7 +21,6 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 EFI_STATUS
 EFIAPI
 RequestMonotonicCounter (
-  IN  UINT8   CounterIndex,
   OUT UINT32  *CounterValue
   )
 {
@@ -33,8 +31,6 @@ RequestMonotonicCounter (
 /**
   Increments the monotonic counter in the SPI flash device by 1.
 
-  @param[in]    CounterIndex            The RPMC index
-
   @retval       EFI_SUCCESS             The operation completed successfully.
   @retval       EFI_DEVICE_ERROR        A device error occurred while attempting to update the counter.
   @retval       EFI_UNSUPPORTED         The operation is un-supported.
@@ -42,7 +38,7 @@ RequestMonotonicCounter (
 EFI_STATUS
 EFIAPI
 IncrementMonotonicCounter (
-  IN  UINT8   CounterIndex
+  VOID
   )
 {
   ASSERT (FALSE);


### PR DESCRIPTION
This reverts commit 6c8dd15c4ae42501438a525ec41299f365f223cb.

Based on the discussion https://edk2.groups.io/g/devel/message/67764,
this change is regarded as the feature request. But, it doesn't pass
reviewed before 202011 stable tag soft feature freeze. So, it should
not be merged into 202011 stable tag.

Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Nishant C Mistry <nishant.c.mistry@intel.com>
Signed-off-by: Liming Gao <gaoliming@byosoft.com.cn>
Acked-by: Jiewen Yao <Jiewen.yao@intel.com>
Reviewed-by: Jiewen Yao <Jiewen.yao@intel.com>