### PR TITLE
CryptoPkg: BaseCryptLib: Fix buffer double free in CryptPkcs7VerifyEku

### DIFF
--- a/CryptoPkg/Library/BaseCryptLib/Pk/CryptPkcs7VerifyEku.c
+++ b/CryptoPkg/Library/BaseCryptLib/Pk/CryptPkcs7VerifyEku.c
@@ -508,10 +508,6 @@ Exit:
     free (SignedData);
   }
 
-  if (SignerCert != NULL) {
-    X509_free (SignerCert);
-  }
-
   if (Pkcs7 != NULL) {
     PKCS7_free (Pkcs7);
   }


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=2459

*The issue is in VerifyEKUsInPkcs7Signature routine of
CryptoPkg/Library/BaseCryptLib/Pk/CryptPkcs7VerifyEku.c:

At the "Exit" portion of this routine, this function uses X509_free to free
SignerCert instance and PKCS7_free function to free Pkcs7. But SignerCert
is part of Pkcs7 instance, thus PKCS7_free will release the memory of
SignerCert for a second time with existed routine, which will cause page
fault if use-after-free guard is enabled.

The patch fix is to free Pkcs7 instance only using PKCS7_free.

The v2 patch includes changes from updated git configuration and reworded
patch to include review tag.

Patch v1 branch: https://github.com/kuqin12/edk2/tree/buffer_double_free_v1
Patch v2 branch: https://github.com/kuqin12/edk2/tree/buffer_double_free_v2

Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Xiaoyu Lu <xiaoyux.lu@intel.com>
Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Guomin Jiang <guomin.jiang@intel.com>

Signed-off-by: Kun Qin <kun.q@outlook.com>
Reviewed-by: Jiewen Yao <Jiewen.yao@intel.com>

Kun Qin (1):
  CryptoPkg: BaseCryptLib: Fix buffer double free in CryptPkcs7VerifyEku

 CryptoPkg/Library/BaseCryptLib/Pk/CryptPkcs7VerifyEku.c | 4 ----
 1 file changed, 4 deletions(-)
