### PR TITLE
MdeModulePkg/VariablePolicyLib: Fix runtime panic in ValidateSetVaria…

### DIFF
--- a/MdeModulePkg/Library/VariablePolicyLib/VariablePolicyLib.c
+++ b/MdeModulePkg/Library/VariablePolicyLib/VariablePolicyLib.c
@@ -411,7 +411,7 @@ RegisterVariablePolicy (
     }
 
     // Reallocate and copy the table.
-    NewTable = AllocatePool( NewSize );
+    NewTable = AllocateRuntimePool( NewSize );
     if (NewTable == NULL) {
       return EFI_OUT_OF_RESOURCES;
     }


### PR DESCRIPTION
The current variable policy is allocated by AllocatePool(), which is
boot time only.  This means that if you do any variable setting in the
runtime, the policy has been freed.  Ordinarily this isn't detected
because freed memory is still there, but when you boot the Linux
kernel, it's been remapped so the actual memory no longer exists in
the memory map causing a page fault.

Fix this by making it AllocateRuntimePool().  For SMM drivers, the
platform DSC is responsible for resolving the MemoryAllocationLib
class to the SmmMemoryAllocationLib instance. In the
SmmMemoryAllocationLib instance, AllocatePool() and
AllocateRuntimePool() are implemented identically. Therefore this
change is a no-op when the RegisterVariablePolicy() function is built
into an SMM driver. The fix affects runtime DXE drivers only.

Ref: https://bugzilla.tianocore.org/show_bug.cgi?id=3092
Signed-off-by: James Bottomley <jejb@linux.ibm.com>
Reviewed-by: Laszlo Ersek <lersek@redhat.com>
Tested-by: Laszlo Ersek <lersek@redhat.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>