### PR TITLE
docs: fix simple typo, optionaly -> optionally

### DIFF
--- a/EmulatorPkg/EmuGopDxe/GopInput.c
+++ b/EmulatorPkg/EmuGopDxe/GopInput.c
@@ -283,7 +283,7 @@ EmuGopSimpleTextInExResetEx (
 /*++
 
   Routine Description:
-    Reset the input device and optionaly run diagnostics
+    Reset the input device and optionally run diagnostics
 
   Arguments:
     This                 - Protocol instance pointer.

--- a/MdeModulePkg/Universal/Console/ConSplitterDxe/ConSplitter.c
+++ b/MdeModulePkg/Universal/Console/ConSplitterDxe/ConSplitter.c
@@ -3430,7 +3430,7 @@ ConSplitterTextOutDeleteDevice (
 
 
 /**
-  Reset the input device and optionaly run diagnostics
+  Reset the input device and optionally run diagnostics
 
   @param  This                     Protocol instance pointer.
   @param  ExtendedVerification     Driver may perform diagnostics on reset.
@@ -3715,7 +3715,7 @@ IsKeyRegistered (
 
 
 /**
-  Reset the input device and optionaly run diagnostics
+  Reset the input device and optionally run diagnostics
 
   @param  This                     Protocol instance pointer.
   @param  ExtendedVerification     Driver may perform diagnostics on reset.
@@ -4126,7 +4126,7 @@ ConSplitterTextInUnregisterKeyNotify (
 
 
 /**
-  Reset the input device and optionaly run diagnostics
+  Reset the input device and optionally run diagnostics
 
   @param  This                     Protocol instance pointer.
   @param  ExtendedVerification     Driver may perform diagnostics on reset.
@@ -4537,7 +4537,7 @@ ConSplitterAbsolutePointerWaitForInput (
 
 
 /**
-  Reset the text output device hardware and optionaly run diagnostics
+  Reset the text output device hardware and optionally run diagnostics
 
   @param  This                     Protocol instance pointer.
   @param  ExtendedVerification     Driver may perform more exhaustive verfication

--- a/MdeModulePkg/Universal/Console/ConSplitterDxe/ConSplitter.h
+++ b/MdeModulePkg/Universal/Console/ConSplitterDxe/ConSplitter.h
@@ -1251,7 +1251,7 @@ ConSplitterTextOutDeleteDevice (
 //
 
 /**
-  Reset the input device and optionaly run diagnostics
+  Reset the input device and optionally run diagnostics
 
   @param  This                     Protocol instance pointer.
   @param  ExtendedVerification     Driver may perform diagnostics on reset.
@@ -1325,7 +1325,7 @@ ConSplitterTextInExDeleteDevice (
 //
 
 /**
-  Reset the input device and optionaly run diagnostics
+  Reset the input device and optionally run diagnostics
 
   @param  This                     Protocol instance pointer.
   @param  ExtendedVerification     Driver may perform diagnostics on reset.
@@ -1482,7 +1482,7 @@ ConSplitterTextInPrivateReadKeyStroke (
   );
 
 /**
-  Reset the input device and optionaly run diagnostics
+  Reset the input device and optionally run diagnostics
 
   @param  This                     Protocol instance pointer.
   @param  ExtendedVerification     Driver may perform diagnostics on reset.
@@ -1541,7 +1541,7 @@ ConSplitterSimplePointerWaitForInput (
 //
 
 /**
-  Reset the text output device hardware and optionaly run diagnostics
+  Reset the text output device hardware and optionally run diagnostics
 
   @param  This                     Protocol instance pointer.
   @param  ExtendedVerification     Driver may perform more exhaustive verfication

--- a/MdePkg/Include/Protocol/SimpleTextOut.h
+++ b/MdePkg/Include/Protocol/SimpleTextOut.h
@@ -151,7 +151,7 @@ typedef EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL   SIMPLE_TEXT_OUTPUT_INTERFACE;
 #define EFI_WIDE_ATTRIBUTE  0x80
 
 /**
-  Reset the text output device hardware and optionaly run diagnostics
+  Reset the text output device hardware and optionally run diagnostics
 
   @param  This                 The protocol instance pointer.
   @param  ExtendedVerification Driver may perform more exhaustive verification


### PR DESCRIPTION
There is a small typo in EmulatorPkg/EmuGopDxe/GopInput.c, MdeModulePkg/Universal/Console/ConSplitterDxe/ConSplitter.c, MdeModulePkg/Universal/Console/ConSplitterDxe/ConSplitter.h, MdePkg/Include/Protocol/SimpleTextOut.h.

Should read `optionally` rather than `optionaly`.

