### PR TITLE
[edk2-devel] [PATCH v2 0/1] OvmfPkg/XenPvBlkDxe: add return value if allocting fail -- push

### DIFF
--- a/OvmfPkg/XenPvBlkDxe/BlockFront.c
+++ b/OvmfPkg/XenPvBlkDxe/BlockFront.c
@@ -155,6 +155,10 @@ XenPvBlockFrontInitialization (
   ASSERT (NodeName != NULL);
 
   Dev = AllocateZeroPool (sizeof (XEN_BLOCK_FRONT_DEVICE));
+  if (Dev == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
   Dev->Signature = XEN_BLOCK_FRONT_SIGNATURE;
   Dev->NodeName = NodeName;
   Dev->XenBusIo = XenBusIo;


### PR DESCRIPTION
msgid <1606183592-81879-1-git-send-email-xiewenyi2@huawei.com>
https://edk2.groups.io/g/devel/message/67862
https://www.redhat.com/archives/edk2-devel-archive/2020-November/msg01022.html
~~~
Main Changes since v1 :
Returning EFI_OUT_OF_RESOURCES if pool allocting fail.

Wenyi Xie (1):
  OvmfPkg/XenPvBlkDxe: add return value if allocting fail

 OvmfPkg/XenPvBlkDxe/BlockFront.c | 4 ++++
 1 file changed, 4 insertions(+)
~~~