### PR TITLE
UefiCpuPkg/CpuDxe: Fix boot error

### DIFF
--- a/UefiCpuPkg/CpuDxe/X64/CpuAsm.nasm
+++ b/UefiCpuPkg/CpuDxe/X64/CpuAsm.nasm
@@ -23,8 +23,8 @@ ASM_PFX(SetCodeSelector):
     sub     rsp, 0x10
     lea     rax, [setCodeSelectorLongJump]
     mov     [rsp], rax
-    mov     [rsp+4], cx
-    jmp     dword far [rsp]
+    mov     [rsp+8], cx
+    jmp     qword far [rsp]
 setCodeSelectorLongJump:
     add     rsp, 0x10
     ret


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3084

When DXE drivers are dispatched above 4GB memory and
the system is already in 64bit mode, the address
setCodeSelectorLongJump in stack will be override
by parameter. so change to use 64bit address and
jump to qword address.

Signed-off-by: Guo Dong <guo.dong@intel.com>