### PR TITLE
MdeModulePkg: Fix undefined reference to memcpy with XCODE5

### DIFF
--- a/MdeModulePkg/Core/Pei/Dispatcher/Dispatcher.c
+++ b/MdeModulePkg/Core/Pei/Dispatcher/Dispatcher.c
@@ -1256,13 +1256,13 @@ EvacuateTempRam (
   }
   for (FvIndex = 0; FvIndex < Private->FvCount; FvIndex++) {
     if (Private->Fv[FvIndex].FvHandle == PeiCoreFvHandle.FvHandle) {
-      PeiCoreFvHandle = Private->Fv[FvIndex];
+      CopyMem (&PeiCoreFvHandle, &Private->Fv[FvIndex], sizeof (PEI_CORE_FV_HANDLE));
       break;
     }
   }
   Status = EFI_SUCCESS;
 
-  ConvertPeiCorePpiPointers (Private, PeiCoreFvHandle);
+  ConvertPeiCorePpiPointers (Private, &PeiCoreFvHandle);
 
   for (FvIndex = 0; FvIndex < Private->FvCount; FvIndex++) {
     FvHeader = Private->Fv[FvIndex].FvHeader;

--- a/MdeModulePkg/Core/Pei/PeiMain.h
+++ b/MdeModulePkg/Core/Pei/PeiMain.h
@@ -542,7 +542,7 @@ ConvertPpiPointersFv (
 VOID
 ConvertPeiCorePpiPointers (
   IN  PEI_CORE_INSTANCE        *PrivateData,
-  PEI_CORE_FV_HANDLE           CoreFvHandle
+  IN  PEI_CORE_FV_HANDLE       *CoreFvHandle
   );
 
 /**

--- a/MdeModulePkg/Core/Pei/Ppi/Ppi.c
+++ b/MdeModulePkg/Core/Pei/Ppi/Ppi.c
@@ -1062,7 +1062,7 @@ ProcessPpiListFromSec (
 VOID
 ConvertPeiCorePpiPointers (
   IN  PEI_CORE_INSTANCE        *PrivateData,
-  PEI_CORE_FV_HANDLE           CoreFvHandle
+  IN  PEI_CORE_FV_HANDLE       *CoreFvHandle
   )
 {
   EFI_FV_FILE_INFO      FileInfo;
@@ -1079,16 +1079,16 @@ ConvertPeiCorePpiPointers (
   //
   // Find the PEI Core in the BFV in temporary memory.
   //
-  Status =  CoreFvHandle.FvPpi->FindFileByType (
-                                  CoreFvHandle.FvPpi,
+  Status =  CoreFvHandle->FvPpi->FindFileByType (
+                                  CoreFvHandle->FvPpi,
                                   EFI_FV_FILETYPE_PEI_CORE,
-                                  CoreFvHandle.FvHandle,
+                                  CoreFvHandle->FvHandle,
                                   &PeiCoreFileHandle
                                   );
   ASSERT_EFI_ERROR (Status);
 
   if (!EFI_ERROR (Status)) {
-    Status = CoreFvHandle.FvPpi->GetFileInfo (CoreFvHandle.FvPpi, PeiCoreFileHandle, &FileInfo);
+    Status = CoreFvHandle->FvPpi->GetFileInfo (CoreFvHandle->FvPpi, PeiCoreFileHandle, &FileInfo);
     ASSERT_EFI_ERROR (Status);
 
     Status = PeiGetPe32Data (PeiCoreFileHandle, &PeiCoreImageBase);


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3098

XCODE5 toolchain in NOOPT mode generates memcpy when trying
to copy PEI_CORE_FV_HANDLE structure. This breaks OVMF
compilation with XCODE5.

CC: Jian J Wang <jian.j.wang@intel.com>
CC: Hao A Wu <hao.a.wu@intel.com>
CC: Jordan Justen <jordan.l.justen@intel.com>
CC: Laszlo Ersek <lersek@redhat.com>
CC: Ard Biesheuvel <ard.biesheuvel@arm.com>
Signed-off-by: Vitaly Cheptsov <cheptsov@ispras.ru>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>
Reviewed-by: Michael D Kinney <michael.d.kinney@intel.com>