### PR TITLE
MdeModulePkg/FileExplorerLib: remove redundant null pointer check

### DIFF
--- a/MdeModulePkg/Library/FileExplorerLib/FileExplorer.c
+++ b/MdeModulePkg/Library/FileExplorerLib/FileExplorer.c
@@ -821,13 +821,9 @@ LibFindFileSystem (
       if (Info == NULL) {
         VolumeLabel = L"NO FILE SYSTEM INFO";
       } else {
-        if (Info->VolumeLabel == NULL) {
-          VolumeLabel = L"NULL VOLUME LABEL";
-        } else {
-          VolumeLabel = Info->VolumeLabel;
-          if (*VolumeLabel == 0x0000) {
-            VolumeLabel = L"NO VOLUME LABEL";
-          }
+        VolumeLabel = Info->VolumeLabel;
+        if (*VolumeLabel == 0x0000) {
+          VolumeLabel = L"NO VOLUME LABEL";
         }
       }
       MenuEntry->DisplayString  = AllocateZeroPool (MAX_CHAR);


### PR DESCRIPTION
If "Info" is a valid pointer to an EFI_FILE_SYSTEM_VOLUME_LABEL
structure, then "Info->VolumeLabel" denotes a valid array object.
When the "Info->VolumeLabel" expression is evaluated, as seen in
the LibFindFileSystem(), it is implicitly converted to
(&Info->VolumeLabel[0]). Because the object described by the
expression (Info->VolumeLabel[0]) is a valid CHAR16 object, its
address can never compare equal to NULL. Therefore, the condition
(Info->VolumeLabel == NULL) will always evaluate to FALSE.
Substitute the constant FALSE into the "if" statement, and
simplify the resultant code (eliminate the dead branch).

Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Hao A Wu <hao.a.wu@intel.com>
Cc: Dandan Bi <dandan.bi@intel.com>
Cc: Eric Dong <eric.dong@intel.com>
Signed-off-by: Wenyi Xie <xiewenyi2@huawei.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>
Reviewed-by: Laszlo Ersek <lersek@redhat.com>