### PR TITLE
ArmPkg/ArmDisassemblerLib: fix incorrect comparison

### DIFF
--- a/ArmPkg/Library/ArmDisassemblerLib/ArmDisassembler.c
+++ b/ArmPkg/Library/ArmDisassemblerLib/ArmDisassembler.c
@@ -240,7 +240,7 @@ DisassembleArmInstruction (
           if (shift_imm == 0) {
             shift_imm = 32;
           }
-        } else if (shift == 0x12) {
+        } else if (shift == 0x2) {
           Type = "ASR";
         } else if (shift_imm == 0) {
           AsciiSPrint (&Buf[Index], Size - Index, "[%a, #%a%a, %a, RRX]%a", gReg[Rn], SIGN (U), gReg[Rm], WRITE (W));
@@ -270,7 +270,7 @@ DisassembleArmInstruction (
           if (shift_imm == 0) {
             shift_imm = 32;
           }
-        } else if (shift == 0x12) {
+        } else if (shift == 0x2) {
           Type = "ASR";
         } else if (shift_imm == 0) {
           AsciiSPrint (&Buf[Index], Size - Index, "[%a], #%a%a, %a, RRX", gReg[Rn], SIGN (U), gReg[Rm]);


### PR DESCRIPTION
As shift = (OpCode >> 5) & 0x3, shift will never be larger than 0x3,
so the comparison between shift and 0x12 will always be false. The right
shift type of ASR is 0x2.

Cc: Leif Lindholm <leif@nuviainc.com>
Cc: Ard Biesheuvel <ard.biesheuvel@arm.com>
Signed-off-by: Wenyi Xie <xiewenyi2@huawei.com>
Reviewed-by: Leif Lindholm <leif@nuviainc.com>