### PR TITLE
Turn off ecc and license in ci

### DIFF
--- a/.azurepipelines/templates/pr-gate-steps.yml
+++ b/.azurepipelines/templates/pr-gate-steps.yml
@@ -74,7 +74,7 @@ steps:
   displayName: Build and Test ${{ parameters.build_pkgs }} ${{ parameters.build_archs}}
   inputs:
     filename: stuart_ci_build
-    arguments: -c .pytool/CISettings.py -p $(pkgs_to_build) -t ${{ parameters.build_targets}} -a ${{ parameters.build_archs}} TOOL_CHAIN_TAG=${{ parameters.tool_chain_tag}}
+    arguments: -c .pytool/CISettings.py -p $(pkgs_to_build) -t ${{ parameters.build_targets}} -a ${{ parameters.build_archs}} TOOL_CHAIN_TAG=${{ parameters.tool_chain_tag}} EccCheck=skip LicenseCheck=skip
   condition: and(gt(variables.pkg_count, 0), succeeded())
 
 # Publish Test Results to Azure Pipelines/TFS

--- a/OvmfPkg/OvmfPkg.ci.yaml
+++ b/OvmfPkg/OvmfPkg.ci.yaml
@@ -22,7 +22,8 @@
         ],
         ## Both file path and directory path are accepted.
         "IgnoreFiles": [
-        ]
+        ],
+        "skip": True
     },
     ## options defined .pytool/Plugin/CompilerPlugin
     "CompilerPlugin": {


### PR DESCRIPTION
Quick test with two commits. 

1st commit - turns off EccCheck and LicenseCheck in github based PR.  This should unblock contributions but will not disable the plugin's from running locally.  

2nd commit - shows another way to disable a plugin per package (in this case OvmfPkg).  This has the benefit of impacting both server and local ci runs and given the issue like https://bugzilla.tianocore.org/show_bug.cgi?id=2986 this is desirable but will require updates to each package config file.

There are other options like changing the scope of the EccCheck plugin that could work too but that has not been prototyped here.