### PR TITLE
MdePkg,ShellPkg: Fix typos in IndustryStandard/SmBios.h

### DIFF
--- a/MdePkg/Include/IndustryStandard/SmBios.h
+++ b/MdePkg/Include/IndustryStandard/SmBios.h
@@ -1837,7 +1837,7 @@ typedef struct {
   //
   UINT8                                     MemoryTechnology;   ///< The enumeration value from MEMORY_DEVICE_TECHNOLOGY
   MEMORY_DEVICE_OPERATING_MODE_CAPABILITY   MemoryOperatingModeCapability;
-  SMBIOS_TABLE_STRING                       FirwareVersion;
+  SMBIOS_TABLE_STRING                       FirmwareVersion;
   UINT16                                    ModuleManufacturerID;
   UINT16                                    ModuleProductID;
   UINT16                                    MemorySubsystemControllerManufacturerID;

--- a/MdePkg/Include/IndustryStandard/SmBios.h
+++ b/MdePkg/Include/IndustryStandard/SmBios.h
@@ -862,17 +862,17 @@ typedef struct {
 } PROCESSOR_FEATURE_FLAGS;
 
 typedef struct {
-  UINT16  ProcessorReserved1             :1;
-  UINT16  ProcessorUnknown               :1;
-  UINT16  Processor64BitCapble           :1;
-  UINT16  ProcessorMultiCore             :1;
-  UINT16  ProcessorHardwareThread        :1;
-  UINT16  ProcessorExecuteProtection     :1;
-  UINT16  ProcessorEnhancedVirtulization :1;
-  UINT16  ProcessorPowerPerformanceCtrl  :1;
-  UINT16  Processor128bitCapble          :1;
-  UINT16  ProcessorArm64SocId            :1;
-  UINT16  ProcessorReserved2             :6;
+  UINT16  ProcessorReserved1              :1;
+  UINT16  ProcessorUnknown                :1;
+  UINT16  Processor64BitCapable           :1;
+  UINT16  ProcessorMultiCore              :1;
+  UINT16  ProcessorHardwareThread         :1;
+  UINT16  ProcessorExecuteProtection      :1;
+  UINT16  ProcessorEnhancedVirtualization :1;
+  UINT16  ProcessorPowerPerformanceCtrl   :1;
+  UINT16  Processor128BitCapable          :1;
+  UINT16  ProcessorArm64SocId             :1;
+  UINT16  ProcessorReserved2              :6;
 } PROCESSOR_CHARACTERISTIC_FLAGS;
 
 typedef struct {

--- a/MdePkg/Include/IndustryStandard/SmBios.h
+++ b/MdePkg/Include/IndustryStandard/SmBios.h
@@ -894,7 +894,7 @@ typedef struct {
   SMBIOS_TABLE_STRING   Socket;
   UINT8                 ProcessorType;          ///< The enumeration value from PROCESSOR_TYPE_DATA.
   UINT8                 ProcessorFamily;        ///< The enumeration value from PROCESSOR_FAMILY_DATA.
-  SMBIOS_TABLE_STRING   ProcessorManufacture;
+  SMBIOS_TABLE_STRING   ProcessorManufacturer;
   PROCESSOR_ID_DATA     ProcessorId;
   SMBIOS_TABLE_STRING   ProcessorVersion;
   PROCESSOR_VOLTAGE     Voltage;

--- a/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/PrintInfo.c
+++ b/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/PrintInfo.c
@@ -776,7 +776,7 @@ SmbiosPrintStructure (
       if (Struct->Hdr->Length > 0x28) {
         DisplayMemoryDeviceMemoryTechnology (Struct->Type17->MemoryTechnology, Option);
         DisplayMemoryDeviceMemoryOperatingModeCapability (Struct->Type17->MemoryOperatingModeCapability.Uint16, Option);
-        PRINT_PENDING_STRING (Struct, Type17, FirwareVersion);
+        PRINT_PENDING_STRING (Struct, Type17, FirmwareVersion);
         PRINT_STRUCT_VALUE_H (Struct, Type17, ModuleManufacturerID);
         PRINT_STRUCT_VALUE_H (Struct, Type17, ModuleProductID);
         PRINT_STRUCT_VALUE_H (Struct, Type17, MemorySubsystemControllerManufacturerID);

--- a/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/PrintInfo.c
+++ b/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/PrintInfo.c
@@ -427,7 +427,7 @@ SmbiosPrintStructure (
     } else {
       DisplayProcessorFamily (Struct->Type4->ProcessorFamily, Option);
     }
-    PRINT_PENDING_STRING (Struct, Type4, ProcessorManufacture);
+    PRINT_PENDING_STRING (Struct, Type4, ProcessorManufacturer);
     PRINT_BIT_FIELD (Struct, Type4, ProcessorId, 8);
     PRINT_PENDING_STRING (Struct, Type4, ProcessorVersion);
     DisplayProcessorVoltage (*(UINT8 *) &(Struct->Type4->Voltage), Option);


### PR DESCRIPTION
Fix typos in MdePkg/Include/IndustryStandard/SmBios.h and make
corresponding changes to the ShellPkg smbiosview command.

Testing:

Built OvmfPkgX64, OvmfPkgIa32, OvmfPkgIa32X64 for DEBUG, RELEASE, NOOPT
Built edk2-platforms RPi4, SbsaQemu for DEBUG, RELEASE, NOOPT
Built edk2-platforms Armada80x0McBin for RELEASE
Built edk2-platforms Intel UpXtreme, GalagoPro3, KabylakeRvp3

Ran stuart_ci_build with X64,AARCH64,RISCV64,IA32 for NO-TARGET,NOOPT,RELEASE,DEBUG

Ran OVMF X64 and verified smbiosview runs correctly.
