### PR TITLE
MdeModulePkg: Fix SetMem parameter in OnigurumaUefiPort

### DIFF
--- a/MdeModulePkg/Universal/RegularExpressionDxe/OnigurumaUefiPort.c
+++ b/MdeModulePkg/Universal/RegularExpressionDxe/OnigurumaUefiPort.c
@@ -93,6 +93,6 @@ void* memcpy (void *dest, const void *src, unsigned int count)
 
 void* memset (void *dest, char ch, unsigned int count)
 {
-  return SetMem (dest, ch, count);
+  return SetMem (dest, count, ch);
 }
 


### PR DESCRIPTION
Ref: https://bugzilla.tianocore.org/show_bug.cgi?id=3085

Coding error in converting memset call to SetMem - Length and Value
is not swapped on calling SetMem

Signed-off-by: Baraneedharan Anbazhagan <anbazhagan@hp.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>