### PR TITLE
UefiCpuPkg RegisterCpuFeaturesLib: Use AllocatePages() for InitOrder

### DIFF
--- a/UefiCpuPkg/Library/RegisterCpuFeaturesLib/CpuFeaturesInitialize.c
+++ b/UefiCpuPkg/Library/RegisterCpuFeaturesLib/CpuFeaturesInitialize.c
@@ -126,8 +126,9 @@ CpuInitDataInitialize (
 
   GetNumberOfProcessor (&NumberOfCpus, &NumberOfEnabledProcessors);
 
-  CpuFeaturesData->InitOrder = AllocateZeroPool (sizeof (CPU_FEATURES_INIT_ORDER) * NumberOfCpus);
+  CpuFeaturesData->InitOrder = AllocatePages (EFI_SIZE_TO_PAGES (sizeof (CPU_FEATURES_INIT_ORDER) * NumberOfCpus));
   ASSERT (CpuFeaturesData->InitOrder != NULL);
+  ZeroMem (CpuFeaturesData->InitOrder, sizeof (CPU_FEATURES_INIT_ORDER) * NumberOfCpus);
 
   //
   // Collect CPU Features information


### PR DESCRIPTION
The required buffer size for InitOrder will be 96K when NumberOfCpus=1024.
sizeof (CPU_FEATURES_INIT_ORDER) = 96
NumberOfCpus = 1024 = 1K
sizeof (CPU_FEATURES_INIT_ORDER) * NumberOfCpus = 96K

AllocateZeroPool() will call to PeiServicesAllocatePool() which will use
EFI_HOB_MEMORY_POOL to management memory pool.
EFI_HOB_MEMORY_POOL.Header.HobLength is UINT16 type, so there is no way
for AllocateZeroPool() to allocate > 64K memory.

So AllocateZeroPool() could not be used anymore for the case above or
even bigger required buffer size.

This patch updates the code to use AllocatePages() instead of
AllocateZeroPool() to allocate buffer for InitOrder.

Signed-off-by: Star Zeng <star.zeng@intel.com>
Reviewed-by: Ray Ni <ray.ni@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Cc: Eric Dong <eric.dong@intel.com>
Cc: Laszlo Ersek <lersek@redhat.com>