### PR TITLE
[edk2-devel] [PATCH v1 1/1] OvmfPkg: Disable EccCheck CI until EccCheck issues are fixed -- push

### DIFF
--- a/OvmfPkg/OvmfPkg.ci.yaml
+++ b/OvmfPkg/OvmfPkg.ci.yaml
@@ -22,7 +22,8 @@
         ],
         ## Both file path and directory path are accepted.
         "IgnoreFiles": [
-        ]
+        ],
+        "skip": True
     },
     ## options defined .pytool/Plugin/CompilerPlugin
     "CompilerPlugin": {


### PR DESCRIPTION
https://edk2.groups.io/g/devel/message/68670
https://www.redhat.com/archives/edk2-devel-archive/2020-December/msg00669.html
~~~
From: Sean Brogan <sean.brogan@microsoft.com>

Cc: Jordan Justen <jordan.l.justen@intel.com>
Cc: Laszlo Ersek <lersek@redhat.com>
Cc: Ard Biesheuvel <ard.biesheuvel@arm.com>
Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>
---
 OvmfPkg/OvmfPkg.ci.yaml | 3 ++-
 1 file changed, 2 insertions(+), 1 deletion(-)
~~~