### PR TITLE
{ArmVirtPkg,OvmfPkg}/PlatformCI: install the qemu-system package in the Ubuntu env -- personal build

### DIFF
--- a/ArmVirtPkg/PlatformCI/.azurepipelines/Ubuntu-GCC5.yml
+++ b/ArmVirtPkg/PlatformCI/.azurepipelines/Ubuntu-GCC5.yml
@@ -84,6 +84,6 @@ jobs:
         build_flags: $(Build.Flags)
         run_flags: $(Run.Flags)
         extra_install_step:
-        - bash: sudo apt-get install qemu
+        - bash: sudo apt-get install qemu-system
           displayName: Install qemu
           condition: and(gt(variables.pkg_count, 0), succeeded())

--- a/OvmfPkg/PlatformCI/.azurepipelines/Ubuntu-GCC5.yml
+++ b/OvmfPkg/PlatformCI/.azurepipelines/Ubuntu-GCC5.yml
@@ -128,6 +128,6 @@ jobs:
         build_flags: $(Build.Flags)
         run_flags: $(Run.Flags)
         extra_install_step:
-        - bash: sudo apt-get install qemu
+        - bash: sudo apt-get install qemu-system
           displayName: Install qemu
           condition: and(gt(variables.pkg_count, 0), succeeded())


### PR DESCRIPTION
~~~
"vm_image: 'ubuntu-latest'" now refers to Ubuntu Focal (20.04LTS), not
Ubuntu Bionic (18.04LTS), according to
<https://github.com/actions/virtual-environments/issues/1816>.

In Focal, the "qemu" package is a dummy package with no dependencies, and
so the actual emulators are not pulled in. Compare:

  https://packages.ubuntu.com/bionic/qemu
  https://packages.ubuntu.com/focal/qemu

This causes CI runs to fail.

Use the "qemu-system" package name, which continues to depend on the
emulators:

  https://packages.ubuntu.com/bionic/qemu-system
  https://packages.ubuntu.com/focal/qemu-system
~~~
