### PR TITLE
{ArmVirtPkg,OvmfPkg}/PlatformCI: stick with "ubuntu-18.04" for now -- personal build

### DIFF
--- a/ArmVirtPkg/PlatformCI/.azurepipelines/Ubuntu-GCC5.yml
+++ b/ArmVirtPkg/PlatformCI/.azurepipelines/Ubuntu-GCC5.yml
@@ -17,7 +17,7 @@ jobs:
   - job: Platform_CI
     variables:
       package: 'ArmVirtPkg'
-      vm_image: 'ubuntu-latest'
+      vm_image: 'ubuntu-18.04'
       should_run: true
       run_flags: "MAKE_STARTUP_NSH=TRUE QEMU_HEADLESS=TRUE"
 

--- a/OvmfPkg/PlatformCI/.azurepipelines/Ubuntu-GCC5.yml
+++ b/OvmfPkg/PlatformCI/.azurepipelines/Ubuntu-GCC5.yml
@@ -17,7 +17,7 @@ jobs:
   - job: Platform_CI
     variables:
       package: 'OvmfPkg'
-      vm_image: 'ubuntu-latest'
+      vm_image: 'ubuntu-18.04'
       should_run: true
       run_flags: "MAKE_STARTUP_NSH=TRUE QEMU_HEADLESS=TRUE"
 


### PR DESCRIPTION
~~~
"vm_image: 'ubuntu-latest'" now refers to Ubuntu Focal (20.04LTS), not
Ubuntu Bionic (18.04LTS), according to
<https://github.com/actions/virtual-environments/issues/1816>.

In Focal, the "qemu" package is a dummy package with no dependencies, and
so the actual emulators are not pulled in. Compare:

  https://packages.ubuntu.com/bionic/qemu
  https://packages.ubuntu.com/focal/qemu

This causes CI runs to fail.

It would be best to switch to the "qemu-system" package name, which
continues to depend on the emulators:

  https://packages.ubuntu.com/bionic/qemu-system
  https://packages.ubuntu.com/focal/qemu-system

However, while that package does make the emulators available, the
emulators crash. So for now, stick with the previous Ubuntu environment,
which continues to be supported, per
<https://github.com/actions/virtual-environments/issues/1816>.
~~~