### PR TITLE
[edk2-devel] [PATCH] Revert "UefiCpuPkg/CpuDxe: Fix boot error" -- push

### DIFF
--- a/UefiCpuPkg/CpuDxe/X64/CpuAsm.nasm
+++ b/UefiCpuPkg/CpuDxe/X64/CpuAsm.nasm
@@ -23,8 +23,8 @@ ASM_PFX(SetCodeSelector):
     sub     rsp, 0x10
     lea     rax, [setCodeSelectorLongJump]
     mov     [rsp], rax
-    mov     [rsp+8], cx
-    jmp     qword far [rsp]
+    mov     [rsp+4], cx
+    jmp     dword far [rsp]
 setCodeSelectorLongJump:
     add     rsp, 0x10
     ret


### PR DESCRIPTION
https://bugzilla.tianocore.org/show_bug.cgi?id=3121
https://edk2.groups.io/g/devel/message/69087
https://www.redhat.com/archives/edk2-devel-archive/2020-December/msg00990.html
msgid: <20201217085055.15131-1-lersek@redhat.com>
~~~
This reverts commit cee5b0441af39dd6f76cc4e0447a1c7f788cbb00.

Commit cee5b0441af3 ("UefiCpuPkg/CpuDxe: Fix boot error", 2020-12-08)
breaks CpuDxe (and with it, OVMF boot) on AMD processors. AMD processors
cannot do far jumps to 64-bit targets, as documented in the AMD64
Architecture Programmer's Manual.

Revert the patch until a RETFQ-based substitute is posted.

Cc: Eric Dong <eric.dong@intel.com>
Cc: Guo Dong <guo.dong@intel.com>
Cc: James Bottomley <James.Bottomley@HansenPartnership.com>
Cc: Rahul Kumar <rahul1.kumar@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Cc: Thomas Lendacky <thomas.lendacky@amd.com>
Ref: https://edk2.groups.io/g/devel/message/68597
Ref: https://www.redhat.com/archives/edk2-devel-archive/2020-December/msg00493.html
Reported-by: Thomas Lendacky <thomas.lendacky@amd.com>
Ref: https://edk2.groups.io/g/devel/message/68832
Ref: https://www.redhat.com/archives/edk2-devel-archive/2020-December/msg00737.html
Reported-by: James Bottomley <James.Bottomley@HansenPartnership.com>
Signed-off-by: Laszlo Ersek <lersek@redhat.com>
---

Notes:
    The broken patch was committed on December 8th; Tom reported the
    regression the next day, and James reported it independently on Dec
    14th/15th (dependent on one's time zone).
    
    Nine days after merging the broken patch, I've only seen "pondering" of
    how we should fix the issue. I'll tell you how: I'm going to merge this
    revert later today unless I see a patch that implements the RETFQ-based
    replacement.
    
    Regressing code and not working diligently to address the problem is
    unacceptable.

 UefiCpuPkg/CpuDxe/X64/CpuAsm.nasm | 4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)
~~~