### PR TITLE
BaseTools: Correct report the line number in INF file issue

### DIFF
--- a/BaseTools/Source/Python/Workspace/MetaFileTable.py
+++ b/BaseTools/Source/Python/Workspace/MetaFileTable.py
@@ -154,7 +154,7 @@ class ModuleTable(MetaFileTable):
         if BelongsToItem is not None:
             result = [item for item in result if item[7] == BelongsToItem]
 
-        result = [ [r[2],r[3],r[4],r[5],r[6],r[0],r[9]] for r in result ]
+        result = [ [r[2],r[3],r[4],r[5],r[6],r[0],r[8]] for r in result ]
         return result
 
 ## Python class representation of table storing package data


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3127

If one protocol is not found in package dec file, Build will report the
error message that module.inf(-1): error 4000: Value of Protocol
[gXxxProtocolGuid] is not found under [Protocols] section in MdePkg.dec.

Here, -1 should be the line number of this protocol in module INF file.

Cc: Bob Feng <bob.c.feng@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Yuwei Chen <yuwei.chen@intel.com>
Signed-off-by: Yunhua Feng <fengyunhua@byosoft.com.cn>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>
Reviewed-by: Bob Feng <bob.c.feng@intel.com>