### PR TITLE
BaseTools/GenFfs: Optimazing else if statement

### DIFF
--- a/BaseTools/Source/C/GenFfs/GenFfs.c
+++ b/BaseTools/Source/C/GenFfs/GenFfs.c
@@ -821,12 +821,11 @@ Returns:
           if (Alignment < 0x400){
             sprintf (AlignmentBuffer, "%d", Alignment);
           }
-          else if (Alignment >= 0x400) {
-            if (Alignment >= 0x100000) {
-              sprintf (AlignmentBuffer, "%dM", Alignment/0x100000);
-            } else {
-              sprintf (AlignmentBuffer, "%dK", Alignment/0x400);
-            }
+          else if (Alignment >= 0x100000) {
+            sprintf (AlignmentBuffer, "%dM", Alignment/0x100000);
+          }
+          else {
+            sprintf (AlignmentBuffer, "%dK", Alignment/0x400);
           }
           Status = StringtoAlignment (AlignmentBuffer, &(InputFileAlign[InputFileNum]));
         }


### PR DESCRIPTION
When Alignment < 0x400 is false, the expression of Alignment >= 0x400 is
always true. So extract the expression from the else if statement.

Cc: Bob Feng <bob.c.feng@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Yuwei Chen <yuwei.chen@intel.com>
Signed-off-by: Wenyi Xie <xiewenyi2@huawei.com>

Reviewed-by: Bob Feng <bob.c.feng@intel.com>