### PR TITLE
[edk2-devel] [PATCH 0/2] EmbeddedPkg/TimeBaseLib: remove useless truncation to 32-bit -- push

### DIFF
--- a/ArmPlatformPkg/Library/PL031RealTimeClockLib/PL031RealTimeClockLib.c
+++ b/ArmPlatformPkg/Library/PL031RealTimeClockLib/PL031RealTimeClockLib.c
@@ -200,7 +200,7 @@ LibSetTime (
     }
   }
 
-  EpochSeconds = EfiTimeToEpoch (Time);
+  EpochSeconds = (UINT32)EfiTimeToEpoch (Time);
 
   // Adjust for the correct time zone, i.e. convert to UTC time zone
   // The timezone setting also reflects the DST setting of the clock

--- a/EmbeddedPkg/Include/Library/TimeBaseLib.h
+++ b/EmbeddedPkg/Include/Library/TimeBaseLib.h
@@ -83,7 +83,7 @@ EpochToEfiTime (
 /**
   Converts EFI_TIME to Epoch seconds (elapsed since 1970 JANUARY 01, 00:00:00 UTC)
  **/
-UINT32
+UINTN
 EFIAPI
 EfiTimeToEpoch (
   IN  EFI_TIME  *Time

--- a/EmbeddedPkg/Library/TimeBaseLib/TimeBaseLib.c
+++ b/EmbeddedPkg/Library/TimeBaseLib/TimeBaseLib.c
@@ -99,14 +99,14 @@ EfiGetEpochDays (
 /**
   Converts EFI_TIME to Epoch seconds (elapsed since 1970 JANUARY 01, 00:00:00 UTC)
  **/
-UINT32
+UINTN
 EFIAPI
 EfiTimeToEpoch (
   IN  EFI_TIME  *Time
   )
 {
-  UINT32 EpochDays;   // Number of days elapsed since EPOCH_JULIAN_DAY
-  UINT32 EpochSeconds;
+  UINTN EpochDays;   // Number of days elapsed since EPOCH_JULIAN_DAY
+  UINTN EpochSeconds;
 
   EpochDays = EfiGetEpochDays (Time);
 


### PR DESCRIPTION
msgid <20201221113657.6779-1-lersek@redhat.com>
https://edk2.groups.io/g/devel/message/69313
https://www.redhat.com/archives/edk2-devel-archive/2020-December/msg01218.html
~~~
Repo:   https://pagure.io/lersek/edk2.git
Branch: timebaselib_uintn

Through the virtio-fs driver, EmbeddedPkg/TimeBaseLib got exposed to
VS2019 for the first time. VS2019 flagged an arguably unintended,
implicit UINTN->UINT32 conversion in EfiTimeToEpoch(); let's remedy
that.

Cc: Ard Biesheuvel <ard.biesheuvel@arm.com>
Cc: Leif Lindholm <leif@nuviainc.com>
Cc: Philippe Mathieu-Daudé <philmd@redhat.com>

Thanks!
Laszlo

Laszlo Ersek (2):
  ArmPlatformPkg/PL031RealTimeClockLib: cast EfiTimeToEpoch() val. to
    UINT32
  EmbeddedPkg/TimeBaseLib: remove useless truncation to 32-bit

 EmbeddedPkg/Include/Library/TimeBaseLib.h                            | 2 +-
 ArmPlatformPkg/Library/PL031RealTimeClockLib/PL031RealTimeClockLib.c | 2 +-
 EmbeddedPkg/Library/TimeBaseLib/TimeBaseLib.c                        | 6 +++---
 3 files changed, 5 insertions(+), 5 deletions(-)
~~~