### PR TITLE
[edk2-devel] [Patch 0/1] EmulatorPkg/PlatformCI: stick with "ubuntu-18.04" for now -- push

### DIFF
--- a/EmulatorPkg/PlatformCI/.azurepipelines/Ubuntu-GCC5.yml
+++ b/EmulatorPkg/PlatformCI/.azurepipelines/Ubuntu-GCC5.yml
@@ -17,7 +17,7 @@ jobs:
   - job: Platform_CI
     variables:
       package: 'EmulatorPkg'
-      vm_image: 'ubuntu-latest'
+      vm_image: 'ubuntu-18.04'
       should_run: false
       run_flags: "MAKE_STARTUP_NSH=TRUE"
 


### PR DESCRIPTION
msgid <20201221031903.1950-1-bob.c.feng@intel.com>
https://edk2.groups.io/g/devel/message/69293
https://www.redhat.com/archives/edk2-devel-archive/2020-December/msg01198.html

msgid <20201221031930.1799-1-bob.c.feng@intel.com>
https://edk2.groups.io/g/devel/message/69294
https://www.redhat.com/archives/edk2-devel-archive/2020-December/msg01199.html

~~~
The following PRs failed caused by Ubuntu-20.04. 
https://github.com/tianocore/edk2/pull/1249 
https://github.com/tianocore/edk2/pull/1250
https://github.com/tianocore/edk2/pull/1251

This patch is to fix this issue. This patch was tested by PR
https://github.com/tianocore/edk2/pull/1252


Bob Feng (1):
  EmulatorPkg/PlatformCI: stick with "ubuntu-18.04" for now

 EmulatorPkg/PlatformCI/.azurepipelines/Ubuntu-GCC5.yml | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
~~~