### PR TITLE
BaseTools/EfiRom: remove redundant checking of argc

### DIFF
--- a/BaseTools/Source/C/EfiRom/EfiRom.c
+++ b/BaseTools/Source/C/EfiRom/EfiRom.c
@@ -1014,7 +1014,7 @@ Returns:
         // Device IDs specified with -i
         // Make sure there's at least one more parameter
         //
-        if (Argc < 1) {
+        if (Argc == 1) {
           Error (NULL, 0, 2000, "Invalid parameter", "Missing Device Id with %s option!", OptionName);
           ReturnStatus = 1;
           goto Done;


### PR DESCRIPTION
As the condition of while statement is argc > 0, so argc < 1 will always
be false, it's redundant.

Cc: Bob Feng <bob.c.feng@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Yuwei Chen <yuwei.chen@intel.com>
Signed-off-by: Wenyi Xie <xiewenyi2@huawei.com>
Reviewed-by: Bob Feng <bob.c.feng@intel.com>