### PR TITLE
BaseTools: Should always define PCD TOKEN value as Zero for static PCD

### DIFF
--- a/BaseTools/Source/Python/AutoGen/PlatformAutoGen.py
+++ b/BaseTools/Source/Python/AutoGen/PlatformAutoGen.py
@@ -1037,8 +1037,7 @@ class PlatformAutoGen(AutoGen):
                 TokenNumber += 1
 
         for Pcd in self.NonDynamicPcdList:
-            RetVal[Pcd.TokenCName, Pcd.TokenSpaceGuidCName] = TokenNumber
-            TokenNumber += 1
+            RetVal[Pcd.TokenCName, Pcd.TokenSpaceGuidCName] = 0
         return RetVal
 
     @cached_property


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3120
FixedAtBuild, PatchableInModule and FeatureFlag PCD don't use PCD TOKEN.
Their PCD TOKEN value can always be zero.
AutoGen.h will not be changed when static PCD is added or removed.
Dynamic PCD add or remove will still cause dynamic PCD token value be
changed.

Cc: Bob Feng <bob.c.feng@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Yuwei Chen <yuwei.chen@intel.com>
Signed-off-by: Yunhua Feng <fengyunhua@byosoft.com.cn>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>
Reviewed-by: Bob Feng <bob.c.feng@intel.com>