### PR TITLE
MdeModulePkg/VarCheckPolicyLib: implement standalone MM version

### DIFF
--- a/MdeModulePkg/Library/VarCheckPolicyLib/VarCheckPolicyLib.c
+++ b/MdeModulePkg/Library/VarCheckPolicyLib/VarCheckPolicyLib.c
@@ -12,7 +12,6 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/DebugLib.h>
 #include <Library/SafeIntLib.h>
 #include <Library/MmServicesTableLib.h>
-#include <Library/SmmMemLib.h>
 #include <Library/BaseMemoryLib.h>
 #include <Library/MemoryAllocationLib.h>
 
@@ -22,6 +21,8 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/VariablePolicyLib.h>
 
 #include <Guid/VarCheckPolicyMmi.h>
+
+#include "VarCheckPolicyLib.h"
 
 //================================================
 // As a VarCheck library, we're linked into the VariableServices
@@ -102,7 +103,8 @@ VarCheckPolicyLibMmiHandler (
   // Make sure that the buffer does not overlap SMM.
   // This should be covered by the SmiManage infrastructure, but just to be safe...
   InternalCommBufferSize = *CommBufferSize;
-  if (InternalCommBufferSize > VAR_CHECK_POLICY_MM_COMM_BUFFER_SIZE || !SmmIsBufferOutsideSmmValid((UINTN)CommBuffer, (UINT64)InternalCommBufferSize)) {
+  if (InternalCommBufferSize > VAR_CHECK_POLICY_MM_COMM_BUFFER_SIZE ||
+      !VarCheckPolicyIsBufferOutsideValid((UINTN)CommBuffer, (UINT64)InternalCommBufferSize)) {
     DEBUG ((DEBUG_ERROR, "%a - Invalid CommBuffer supplied! 0x%016lX[0x%016lX]\n", __FUNCTION__, CommBuffer, InternalCommBufferSize));
     return EFI_INVALID_PARAMETER;
   }
@@ -305,17 +307,13 @@ VarCheckPolicyLibMmiHandler (
   Constructor function of VarCheckPolicyLib to register VarCheck handler and
   SW MMI handlers.
 
-  @param[in] ImageHandle    The firmware allocated handle for the EFI image.
-  @param[in] SystemTable    A pointer to the EFI System Table.
-
   @retval EFI_SUCCESS       The constructor executed correctly.
 
 **/
 EFI_STATUS
 EFIAPI
-VarCheckPolicyLibConstructor (
-  IN EFI_HANDLE             ImageHandle,
-  IN EFI_SYSTEM_TABLE       *SystemTable
+VarCheckPolicyLibCommonConstructor (
+  VOID
   )
 {
   EFI_STATUS    Status;

--- a/MdeModulePkg/Library/VarCheckPolicyLib/VarCheckPolicyLib.h
+++ b/MdeModulePkg/Library/VarCheckPolicyLib/VarCheckPolicyLib.h
@@ -1,0 +1,42 @@
+/** @file -- VarCheckPolicyLib.h
+This internal header file defines the common interface of constructor for
+VarCheckPolicyLib.
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef _VAR_CHECK_POLICY_LIB_H_
+#define _VAR_CHECK_POLICY_LIB_H_
+
+/**
+  Common constructor function of VarCheckPolicyLib to register VarCheck handler
+  and SW MMI handlers.
+
+  @retval EFI_SUCCESS       The constructor executed correctly.
+
+**/
+EFI_STATUS
+EFIAPI
+VarCheckPolicyLibCommonConstructor (
+  VOID
+  );
+
+/**
+  This function is wrapper function to validate the buffer.
+
+  @param Buffer  The buffer start address to be checked.
+  @param Length  The buffer length to be checked.
+
+  @retval TRUE  This buffer is valid per processor architecture and not overlap with SMRAM/MMRAM.
+  @retval FALSE This buffer is not valid per processor architecture or overlap with SMRAM/MMRAM.
+**/
+BOOLEAN
+EFIAPI
+VarCheckPolicyIsBufferOutsideValid (
+  IN EFI_PHYSICAL_ADDRESS  Buffer,
+  IN UINT64                Length
+  );
+
+#endif // _VAR_CHECK_POLICY_LIB_H_

--- a/MdeModulePkg/Library/VarCheckPolicyLib/VarCheckPolicyLibStandaloneMm.c
+++ b/MdeModulePkg/Library/VarCheckPolicyLib/VarCheckPolicyLibStandaloneMm.c
@@ -1,0 +1,50 @@
+/** @file -- VarCheckPolicyLibStandaloneMm.c
+This is an instance of a VarCheck lib constructor for Standalone MM.
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Library/StandaloneMmMemLib.h>
+
+#include "VarCheckPolicyLib.h"
+
+/**
+  Standalone MM constructor function of VarCheckPolicyLib to invoke common
+  constructor routine.
+
+  @param[in] ImageHandle    The firmware allocated handle for the EFI image.
+  @param[in] SystemTable    A pointer to the EFI System Table.
+
+  @retval EFI_SUCCESS       The constructor executed correctly.
+
+**/
+EFI_STATUS
+EFIAPI
+VarCheckPolicyLibStandaloneConstructor (
+  IN EFI_HANDLE             ImageHandle,
+  IN EFI_MM_SYSTEM_TABLE    *SystemTable
+  )
+{
+  return VarCheckPolicyLibCommonConstructor ();
+}
+
+/**
+  This function is wrapper function to validate the buffer.
+
+  @param Buffer  The buffer start address to be checked.
+  @param Length  The buffer length to be checked.
+
+  @retval TRUE  This buffer is valid per processor architectureand not overlap with MMRAM.
+  @retval FALSE This buffer is not valid per processor architecture or overlap with MMRAM.
+**/
+BOOLEAN
+EFIAPI
+VarCheckPolicyIsBufferOutsideValid (
+  IN EFI_PHYSICAL_ADDRESS  Buffer,
+  IN UINT64                Length
+  )
+{
+  return MmIsBufferOutsideMmValid (Buffer, Length);
+}

--- a/MdeModulePkg/Library/VarCheckPolicyLib/VarCheckPolicyLibStandaloneMm.inf
+++ b/MdeModulePkg/Library/VarCheckPolicyLib/VarCheckPolicyLibStandaloneMm.inf
@@ -1,43 +1,47 @@
-## @file VarCheckPolicyLib.inf
+## @file VarCheckPolicyLibStandaloneMm.inf
 # This is an instance of a VarCheck lib that leverages the business logic behind
 # the VariablePolicy code to make its decisions.
 #
-# Copyright (c) Microsoft Corporation.
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
 # SPDX-License-Identifier: BSD-2-Clause-Patent
+#
 ##
 
 [Defines]
   INF_VERSION                    = 0x00010005
-  BASE_NAME                      = VarCheckPolicyLib
-  FILE_GUID                      = 9C28A48F-C884-4B1F-8B95-DEF125448023
-  MODULE_TYPE                    = DXE_RUNTIME_DRIVER
+  BASE_NAME                      = VarCheckPolicyLibStandaloneMm
+  FILE_GUID                      = 44B09E3D-5EDA-4673-ABCF-C8AE4560C8EC
+  MODULE_TYPE                    = MM_STANDALONE
+  PI_SPECIFICATION_VERSION       = 0x00010032
   VERSION_STRING                 = 1.0
-  LIBRARY_CLASS                  = NULL|DXE_RUNTIME_DRIVER DXE_SMM_DRIVER
-  CONSTRUCTOR                    = VarCheckPolicyLibTraditionalConstructor
+  LIBRARY_CLASS                  = NULL|MM_STANDALONE
+  CONSTRUCTOR                    = VarCheckPolicyLibStandaloneConstructor
 
 
 [Sources]
   VarCheckPolicyLib.c
-  VarCheckPolicyLibTraditional.c
+  VarCheckPolicyLibStandaloneMm.c
   VarCheckPolicyLib.h
 
 
 [Packages]
   MdePkg/MdePkg.dec
   MdeModulePkg/MdeModulePkg.dec
+  StandaloneMmPkg/StandaloneMmPkg.dec
 
 
 [LibraryClasses]
   BaseLib
   DebugLib
   BaseMemoryLib
+  MemLib
   MemoryAllocationLib
   VarCheckLib
   VariablePolicyLib
   VariablePolicyHelperLib
   SafeIntLib
   MmServicesTableLib
-
 
 [Guids]
   gVarCheckPolicyLibMmiHandlerGuid        ## CONSUME ## Used to register for MM Communication events.

--- a/MdeModulePkg/Library/VarCheckPolicyLib/VarCheckPolicyLibTraditional.c
+++ b/MdeModulePkg/Library/VarCheckPolicyLib/VarCheckPolicyLibTraditional.c
@@ -1,0 +1,50 @@
+/** @file -- VarCheckPolicyLibTraditional.c
+This is an instance of a VarCheck lib constructor for traditional SMM.
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Library/SmmMemLib.h>
+
+#include "VarCheckPolicyLib.h"
+
+/**
+  Traditional constructor function of VarCheckPolicyLib to invoke common
+  constructor routine.
+
+  @param[in] ImageHandle    The firmware allocated handle for the EFI image.
+  @param[in] SystemTable    A pointer to the EFI System Table.
+
+  @retval EFI_SUCCESS       The constructor executed correctly.
+
+**/
+EFI_STATUS
+EFIAPI
+VarCheckPolicyLibTraditionalConstructor (
+  IN EFI_HANDLE             ImageHandle,
+  IN EFI_SYSTEM_TABLE       *SystemTable
+  )
+{
+  return VarCheckPolicyLibCommonConstructor ();
+}
+
+/**
+  This function is wrapper function to validate the buffer.
+
+  @param Buffer  The buffer start address to be checked.
+  @param Length  The buffer length to be checked.
+
+  @retval TRUE  This buffer is valid per processor architecture and not overlap with SMRAM.
+  @retval FALSE This buffer is not valid per processor architecture or overlap with SMRAM.
+**/
+BOOLEAN
+EFIAPI
+VarCheckPolicyIsBufferOutsideValid (
+  IN EFI_PHYSICAL_ADDRESS  Buffer,
+  IN UINT64                Length
+  )
+{
+  return SmmIsBufferOutsideSmmValid (Buffer, Length);
+}

--- a/MdeModulePkg/MdeModulePkg.dsc
+++ b/MdeModulePkg/MdeModulePkg.dsc
@@ -314,6 +314,7 @@
   MdeModulePkg/Library/VariablePolicyLib/VariablePolicyLib.inf
   MdeModulePkg/Library/VariablePolicyLib/VariablePolicyLibRuntimeDxe.inf
   MdeModulePkg/Library/VarCheckPolicyLib/VarCheckPolicyLib.inf
+  MdeModulePkg/Library/VarCheckPolicyLib/VarCheckPolicyLibStandaloneMm.inf
   MdeModulePkg/Library/VarCheckLib/VarCheckLib.inf
   MdeModulePkg/Library/VarCheckHiiLib/VarCheckHiiLib.inf
   MdeModulePkg/Library/VarCheckPcdLib/VarCheckPcdLib.inf


### PR DESCRIPTION
This commit adds the VarCheckPolicyLib that will be able to
execute in the context of standalone MM.

Signed-off-by: Masahisa Kojima <masahisa.kojima@linaro.org>
Co-authored-by: Kun Qin <kun.q@outlook.com>
Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Hao A Wu <hao.a.wu@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Ard Biesheuvel <ard.biesheuvel@arm.com>
Cc: Sami Mujawar <sami.mujawar@arm.com>
Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Supreeth Venkatesh <supreeth.venkatesh@arm.com>
Cc: Bret Barkelew <Bret.Barkelew@microsoft.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>