### PR TITLE
BaseTools: replace fromstring and tostring Method

### DIFF
--- a/BaseTools/Source/Python/Eot/EotMain.py
+++ b/BaseTools/Source/Python/Eot/EotMain.py
@@ -152,11 +152,11 @@ class CompressedImage(Image):
         try:
             TmpData = DeCompress('Efi', self[self._HEADER_SIZE_:])
             DecData = array('B')
-            DecData.fromstring(TmpData)
+            DecData.fromlist(array('B',TmpData).tolist())
         except:
             TmpData = DeCompress('Framework', self[self._HEADER_SIZE_:])
             DecData = array('B')
-            DecData.fromstring(TmpData)
+            DecData.fromlist(array('B',TmpData).tolist())
 
         SectionList = []
         Offset = 0
@@ -196,7 +196,7 @@ class Ui(Image):
         return len(self)
 
     def _GetUiString(self):
-        return codecs.utf_16_decode(self[0:-2].tostring())[0]
+        return codecs.utf_16_decode(b"".join(list(map(lambda x:bytes([x]), self[0:-2].tolist()))))[0]
 
     String = property(_GetUiString)
 
@@ -738,7 +738,7 @@ class GuidDefinedImage(Image):
                 Offset = self.DataOffset - 4
                 TmpData = DeCompress('Framework', self[self.Offset:])
                 DecData = array('B')
-                DecData.fromstring(TmpData)
+                DecData.fromlist(array('B',TmpData).tolist())
                 Offset = 0
                 while Offset < len(DecData):
                     Sec = Section()
@@ -759,7 +759,7 @@ class GuidDefinedImage(Image):
 
                 TmpData = DeCompress('Lzma', self[self.Offset:])
                 DecData = array('B')
-                DecData.fromstring(TmpData)
+                DecData.fromlist(array('B',TmpData).tolist())
                 Offset = 0
                 while Offset < len(DecData):
                     Sec = Section()

--- a/BaseTools/Source/Python/GenFds/GenFdsGlobalVariable.py
+++ b/BaseTools/Source/Python/GenFds/GenFdsGlobalVariable.py
@@ -463,12 +463,12 @@ class GenFdsGlobalVariable:
                     GenFdsGlobalVariable.SecCmdList.append(' '.join(Cmd).strip())
             else:
                 SectionData = array('B', [0, 0, 0, 0])
-                SectionData.fromstring(Ui.encode("utf_16_le"))
+                SectionData.fromlist(array('B',Ui.encode('utf-16-le')).tolist())
                 SectionData.append(0)
                 SectionData.append(0)
                 Len = len(SectionData)
                 GenFdsGlobalVariable.SectionHeader.pack_into(SectionData, 0, Len & 0xff, (Len >> 8) & 0xff, (Len >> 16) & 0xff, 0x15)
-                SaveFileOnChange(Output, SectionData.tostring())
+                SaveFileOnChange(Output, b"".join(list(map(lambda x:bytes([x]), SectionData.tolist()))))
 
         elif Ver:
             Cmd += ("-n", Ver)


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3136
Because after Python 3.2, array.tostring and
array.fromstring method is renamed tobytes
and frombytes,so it needs to be modified to
support python2 and python3 methods.

Signed-off-by: Mingyue Liang <mingyuex.liang@intel.com>
Cc: Bob Feng <bob.c.feng@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Yuwei Chen <yuwei.chen@intel.com>
Cc: Mingyue Liang <mingyuex.liang@intel.com>

Reviewed-by: Bob Feng <bob.c.feng@intel.com>