### PR TITLE
RedfishPkg/DxeRestExLib: DxeRestExLib

### DIFF
--- a/RedfishPkg/Include/Library/RestExLib.h
+++ b/RedfishPkg/Include/Library/RestExLib.h
@@ -1,0 +1,42 @@
+/** @file
+  This library provides help functions for REST EX Protocol.
+
+  (C) Copyright 2020 Hewlett Packard Enterprise Development LP<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef REST_EX_LIB_H_
+#define REST_EX_LIB_H_
+
+#include <Protocol/RestEx.h>
+
+///
+/// Library class public functions
+///
+
+/**
+  This function allows the caller to create child handle for specific
+  REST server.
+
+  @param[in]  Image                The image handle used to open service.
+  @param[in]  AccessMode           Access mode of REST server.
+  @param[in]  ConfigType           Underlying configuration to communicate with REST server.
+  @param[in]  ServiceType          REST service type.
+  @param[out] ChildInstanceHandle  The handle to receive the create child.
+
+  @retval  EFI_SUCCESS            Can't create the corresponding REST EX child instance.
+  @retval  EFI_INVALID_PARAMETERS Any of input parameters is improper.
+
+**/
+EFI_STATUS
+RestExLibCreateChild (
+  IN EFI_HANDLE Image,
+  IN EFI_REST_EX_SERVICE_ACCESS_MODE  AccessMode,
+  IN EFI_REST_EX_CONFIG_TYPE ConfigType,
+  IN EFI_REST_EX_SERVICE_TYPE ServiceType,
+  OUT EFI_HANDLE *ChildInstanceHandle
+);
+
+#endif

--- a/RedfishPkg/Library/DxeRestExLib/DxeRestExLib.c
+++ b/RedfishPkg/Library/DxeRestExLib/DxeRestExLib.c
@@ -1,0 +1,166 @@
+/** @file
+  This library provides help functions for REST EX Protocol.
+
+  (C) Copyright 2020 Hewlett Packard Enterprise Development LP<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Uefi.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/NetLib.h>
+#include <Library/UefiBootServicesTableLib.h>
+#include <Protocol/Http.h>
+#include <Protocol/RestEx.h>
+
+#define REST_EX_CONFIG_DATA_LEN_UNKNOWN 0xff
+
+/**
+  This function allows the caller to create child handle for specific
+  REST server.
+
+  @param[in]  Image                The image handle used to open service.
+  @param[in]  AccessMode           Access mode of REST server.
+  @param[in]  ConfigType           Underlying configuration to communicate with REST server.
+  @param[in]  ServiceType          REST service type.
+  @param[out] ChildInstanceHandle  The handle to receive the create child.
+
+  @retval  EFI_SUCCESS            Can't create the corresponding REST EX child instance.
+  @retval  EFI_INVALID_PARAMETERS Any of input parameters is improper.
+
+**/
+EFI_STATUS
+RestExLibCreateChild (
+  IN EFI_HANDLE Image,
+  IN EFI_REST_EX_SERVICE_ACCESS_MODE  AccessMode,
+  IN EFI_REST_EX_CONFIG_TYPE ConfigType,
+  IN EFI_REST_EX_SERVICE_TYPE ServiceType,
+  OUT EFI_HANDLE *ChildInstanceHandle
+)
+{
+  EFI_STATUS Status;
+  UINTN NoBuffer;
+  EFI_HANDLE *Handle;
+  EFI_HANDLE ChildHandle;
+  EFI_REST_EX_PROTOCOL *RestEx;
+  EFI_REST_EX_SERVICE_INFO *RestExServiceInfo;
+  UINT8 LenOfConfig;
+
+  if (Image == NULL ||
+      AccessMode >= EfiRestExServiceModeMax ||
+      ConfigType >= EfiRestExConfigTypeMax ||
+      ServiceType >= EfiRestExServiceTypeMax ||
+      ChildInstanceHandle == NULL
+      ) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  *ChildInstanceHandle = NULL;
+  //
+  // Locate all REST EX binding service.
+  //
+  Handle = NULL;
+  NoBuffer = 0;
+  Status = gBS->LocateHandleBuffer (
+              ByProtocol,
+              &gEfiRestExServiceBindingProtocolGuid,
+              NULL,
+              &NoBuffer,
+              &Handle
+            );
+  if (EFI_ERROR (Status) && Status != EFI_BUFFER_TOO_SMALL) {
+    return Status;
+  }
+  Handle = (EFI_HANDLE *)AllocateZeroPool (sizeof(EFI_HANDLE) * NoBuffer);
+  if (Handle == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+  Status = gBS->LocateHandleBuffer (
+              ByProtocol,
+              &gEfiRestExServiceBindingProtocolGuid,
+              NULL,
+              &NoBuffer,
+              &Handle
+            );
+  if (EFI_ERROR (Status)) {
+    FreePool (Handle);
+    return Status;
+  }
+
+  //
+  // Search for the proper REST EX instance.
+  //
+  while (NoBuffer != 0) {
+    ChildHandle = NULL;
+    Status = NetLibCreateServiceChild (
+                *(Handle + (NoBuffer - 1)),
+                Image,
+                &gEfiRestExServiceBindingProtocolGuid,
+                &ChildHandle
+                );
+    if (!EFI_ERROR (Status)) {
+      Status = gBS->OpenProtocol (
+                  ChildHandle,
+                  &gEfiRestExProtocolGuid,
+                  (VOID **)&RestEx,
+                  Image,
+                  NULL,
+                  EFI_OPEN_PROTOCOL_GET_PROTOCOL
+                  );
+      if (EFI_ERROR (Status)) {
+        goto ON_ERROR;
+      }
+
+      //
+      // Get the information of REST service provided by this EFI REST EX driver
+      //
+      Status = RestEx->GetService (
+                            RestEx,
+                            &RestExServiceInfo
+                            );
+      if (EFI_ERROR (Status)) {
+        goto ON_ERROR;
+      }
+      //
+      // Check REST EX property.
+      //
+      switch (ConfigType) {
+        case EfiRestExConfigHttp:
+          LenOfConfig = sizeof (EFI_REST_EX_HTTP_CONFIG_DATA);
+          break;
+
+        case EfiRestExConfigUnspecific:
+          LenOfConfig = REST_EX_CONFIG_DATA_LEN_UNKNOWN;
+          break;
+
+        default:
+          goto ON_ERROR;
+      }
+      if (RestExServiceInfo->EfiRestExServiceInfoV10.RestServiceAccessMode != AccessMode ||
+          RestExServiceInfo->EfiRestExServiceInfoV10.RestServiceType != ServiceType ||
+          RestExServiceInfo->EfiRestExServiceInfoV10.RestExConfigType != ConfigType ||
+          ((LenOfConfig != REST_EX_CONFIG_DATA_LEN_UNKNOWN) && (RestExServiceInfo->EfiRestExServiceInfoV10.RestExConfigDataLength != LenOfConfig))) {
+        goto ON_ERROR;
+      }
+    }
+    //
+    // This is proper REST EX instance.
+    //
+    *ChildInstanceHandle = ChildHandle;
+    FreePool (Handle);
+    return EFI_SUCCESS;
+
+ON_ERROR:;
+    NetLibDestroyServiceChild (
+      *(Handle + (NoBuffer - 1)),
+      Image,
+      &gEfiRestExServiceBindingProtocolGuid,
+      ChildHandle
+      );
+    NoBuffer --;
+  };
+  FreePool (Handle);
+  return EFI_NOT_FOUND;
+}

--- a/RedfishPkg/Library/DxeRestExLib/DxeRestExLib.inf
+++ b/RedfishPkg/Library/DxeRestExLib/DxeRestExLib.inf
@@ -1,0 +1,44 @@
+##  @file
+#   Library for REST EX Protocol
+#
+#   (C) Copyright 2020 Hewlett Packard Enterprise Development LP<BR>
+#   SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x0001001b
+  BASE_NAME                      = DxeRestExLib
+  FILE_GUID                      = E9CBF727-8AF3-4602-9DBD-A3942869B5AE
+  MODULE_TYPE                    = DXE_DRIVER
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = RestExLib | DXE_DRIVER DXE_RUNTIME_DRIVER UEFI_APPLICATION UEFI_DRIVER
+
+#
+#  VALID_ARCHITECTURES           = IA32 X64 IPF EBC RISCV64
+#
+
+[Sources.common]
+  DxeRestExLib.c
+
+[Packages]
+  NetworkPkg/NetworkPkg.dec
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+
+[LibraryClasses]
+  BaseLib
+  BaseMemoryLib
+  DebugLib
+  DevicePathLib
+  MemoryAllocationLib
+  NetLib
+  PrintLib
+  UefiLib
+  UefiBootServicesTableLib
+  UefiRuntimeServicesTableLib
+
+[Protocols]
+  gEfiRestExServiceBindingProtocolGuid ## PROTOCOL ALWAYS_CONSUMED
+  gEfiRestExProtocolGuid               ## PROTOCOL ALWAYS_CONSUMED
+

--- a/RedfishPkg/RedfishLibs.dsc.inc
+++ b/RedfishPkg/RedfishLibs.dsc.inc
@@ -11,5 +11,6 @@
 #
 ##
 !if $(REDFISH_ENABLE) == TRUE
+  RestExLib|RedfishPkg/Library/DxeRestExLib/DxeRestExLib.inf
 !endif
 

--- a/RedfishPkg/RedfishPkg.dec
+++ b/RedfishPkg/RedfishPkg.dec
@@ -25,6 +25,10 @@
   #   Platform implementation-specific Redfish Credential Interface.
   RedfishPlatformCredentialLib|Include/Library/RedfishCredentialLib.h
 
+  ##  @libraryclass  The helper routines to access REST EX service.
+  #   This library is only intended to be used by UEFI network stack modules.
+  RestExLib|Include/Library/RestExLib.h
+
 [Protocols]
   ## Include/Protocol/RedfishDiscover.h
   gEfiRedfishDiscoverProtocolGuid      = { 0x5db12509, 0x4550, 0x4347, { 0x96, 0xb3, 0x73, 0xc0, 0xff, 0x6e, 0x86, 0x9f }}

--- a/RedfishPkg/RedfishPkg.dsc
+++ b/RedfishPkg/RedfishPkg.dsc
@@ -49,5 +49,6 @@
 [Components]
   RedfishPkg/Library/PlatformHostInterfaceLibNull/PlatformHostInterfaceLibNull.inf
   RedfishPkg/Library/PlatformCredentialLibNull/PlatformCredentialLibNull.inf
+  RedfishPkg/Library/DxeRestExLib/DxeRestExLib.inf
 
   !include RedfishPkg/Redfish.dsc.inc


### PR DESCRIPTION
Add EFI REST EX helper library to create child instance of
REST EX service.

Signed-off-by: Abner Chang <abner.chang@hpe.com>

Cc: Jiaxin Wu <jiaxin.wu@intel.com>
Cc: Siyuan Fu <siyuan.fu@intel.com>
Cc: Fan Wang <fan.wang@intel.com>
Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Nickle Wang <nickle.wang@hpe.com>
Cc: Peter O'Hanley <peter.ohanley@hpe.com>
Reviewed-by: Nickle Wang <nickle.wang@hpe.com>