### PR TITLE
BaseTools: Fix the improper error logging

### DIFF
--- a/BaseTools/Source/Python/AutoGen/GenPcdDb.py
+++ b/BaseTools/Source/Python/AutoGen/GenPcdDb.py
@@ -894,7 +894,7 @@ def CreatePcdDataBase(PcdDBData):
     delta = {}
     for skuname, skuid in PcdDBData:
         if len(PcdDBData[(skuname, skuid)][1]) != len(PcdDBData[(TAB_DEFAULT, "0")][1]):
-            EdkLogger.ERROR("The size of each sku in one pcd are not same")
+            EdkLogger.error("build", AUTOGEN_ERROR, "The size of each sku in one pcd are not same")
     for skuname, skuid in PcdDBData:
         if skuname == TAB_DEFAULT:
             continue


### PR DESCRIPTION
EdkLogger.ERROR() was replaced with EdkLogger.error() to deliver the
expected error message when an error occurs.

Signed-off-by: Irene Park <ipark@nvidia.com>
Reviewed-by: Bob Feng <bob.c.feng@intel.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>