### PR TITLE
MdeModulePkg BrotliCustomDecompressLib: Remove the duplicated functions

### DIFF
--- a/MdeModulePkg/Library/BrotliCustomDecompressLib/BrotliDecompress.c
+++ b/MdeModulePkg/Library/BrotliCustomDecompressLib/BrotliDecompress.c
@@ -8,29 +8,6 @@
 #include <BrotliDecompressLibInternal.h>
 
 /**
-  Dummy malloc function for compiler.
-**/
-VOID *
-BrDummyMalloc (
-  IN size_t    Size
-  )
-{
-  ASSERT (FALSE);
-  return NULL;
-}
-
-/**
-  Dummy free function for compiler.
-**/
-VOID
-BrDummyFree (
-  IN VOID *    Ptr
-  )
-{
-  ASSERT (FALSE);
-}
-
-/**
   Allocation routine used by BROTLI decompression.
 
   @param Ptr              Pointer to the BROTLI_BUFF instance.


### PR DESCRIPTION
The same functions have been defined in BrotliDecUefiSupport.c.

Signed-off-by: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Hao A Wu <hao.a.wu@intel.com>
Cc: Dandan Bi <dandan.bi@intel.com>
Reviewed-by: Hao A Wu <hao.a.wu@intel.com>