### PR TITLE
Remove non-cross-platform symlink

### DIFF
--- a/EmulatorPkg/Unix/Host/X11IncludeHack
+++ b/EmulatorPkg/Unix/Host/X11IncludeHack
@@ -1,1 +1,0 @@
-/opt/X11/include


### PR DESCRIPTION
On windows, it's always causing the working directory dirty.
So remove the symlink in the repository, we can create it when
building.

Signed-off-by: Yonggang Luo <luoyonggang@gmail.com>