### PR TITLE
IntelFsp2Pkg: Support FSP private temporary memory.

### DIFF
--- a/IntelFsp2Pkg/FspSecCore/FspSecCoreM.inf
+++ b/IntelFsp2Pkg/FspSecCore/FspSecCoreM.inf
@@ -1,7 +1,7 @@
 ## @file
 #  Sec Core for FSP
 #
-#  Copyright (c) 2016 - 2019, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2016 - 2021, Intel Corporation. All rights reserved.<BR>
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -59,6 +59,7 @@
   gIntelFsp2PkgTokenSpaceGuid.PcdFspTemporaryRamSize           ## CONSUMES
   gIntelFsp2PkgTokenSpaceGuid.PcdFspHeapSizePercentage         ## CONSUMES
   gIntelFsp2PkgTokenSpaceGuid.PcdFspMaxInterruptSupported      ## CONSUMES
+  gIntelFsp2PkgTokenSpaceGuid.PcdFspPrivateTemporaryRamSize    ## CONSUMES
 
 [Ppis]
   gEfiTemporaryRamSupportPpiGuid                              ## PRODUCES

--- a/IntelFsp2Pkg/FspSecCore/SecMain.c
+++ b/IntelFsp2Pkg/FspSecCore/SecMain.c
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2014 - 2020, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2014 - 2021, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -150,15 +150,18 @@ SecStartup (
   SecCoreData.BootFirmwareVolumeBase = BootFirmwareVolume;
   SecCoreData.BootFirmwareVolumeSize = (UINT32)((EFI_FIRMWARE_VOLUME_HEADER *)BootFirmwareVolume)->FvLength;
 
-  SecCoreData.TemporaryRamBase       = (VOID*)(UINTN) TempRamBase;
+  //
+  // Support FSP reserved temporary memory from the whole temporary memory provided by bootloader.
+  // FSP reserved temporary memory will not be given to PeiCore.
+  //
+  SecCoreData.TemporaryRamBase       = (UINT8 *)(UINTN) TempRamBase  + PcdGet32 (PcdFspPrivateTemporaryRamSize);
+  SecCoreData.TemporaryRamSize       = SizeOfRam - PcdGet32 (PcdFspPrivateTemporaryRamSize);
   if (PcdGet8 (PcdFspHeapSizePercentage) == 0) {
-    SecCoreData.TemporaryRamSize       = SizeOfRam; // stack size that is going to be copied to the permanent memory
     SecCoreData.PeiTemporaryRamBase    = SecCoreData.TemporaryRamBase;
     SecCoreData.PeiTemporaryRamSize    = SecCoreData.TemporaryRamSize;
     SecCoreData.StackBase              = (VOID *)GetFspEntryStack(); // Share the same boot loader stack
     SecCoreData.StackSize              = 0;
   } else {
-    SecCoreData.TemporaryRamSize       = SizeOfRam;
     SecCoreData.PeiTemporaryRamBase    = SecCoreData.TemporaryRamBase;
     SecCoreData.PeiTemporaryRamSize    = SecCoreData.TemporaryRamSize * PcdGet8 (PcdFspHeapSizePercentage) / 100;
     SecCoreData.StackBase              = (VOID*)(UINTN)((UINTN)SecCoreData.TemporaryRamBase + SecCoreData.PeiTemporaryRamSize);

--- a/IntelFsp2Pkg/IntelFsp2Pkg.dec
+++ b/IntelFsp2Pkg/IntelFsp2Pkg.dec
@@ -1,7 +1,7 @@
 ## @file
 # Provides driver and definitions to build fsp in EDKII bios.
 #
-# Copyright (c) 2014 - 2019, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2014 - 2021, Intel Corporation. All rights reserved.<BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -98,6 +98,11 @@
   # Maximal Interrupt supported in IDT table.
   #
   gIntelFsp2PkgTokenSpaceGuid.PcdFspMaxInterruptSupported |        34| UINT8|0x10000005
+  #
+  # Allows FSP-M to reserve a section of Temporary RAM for implementation specific use.
+  # Reduces the amount of memory available for the PeiCore heap.
+  #
+  gIntelFsp2PkgTokenSpaceGuid.PcdFspPrivateTemporaryRamSize |0x00000000|UINT32|0x10000006
 
 [PcdsFixedAtBuild,PcdsDynamic,PcdsDynamicEx]
   gIntelFsp2PkgTokenSpaceGuid.PcdFspReservedMemoryLength |0x00100000|UINT32|0x46530000


### PR DESCRIPTION
REF:https://bugzilla.tianocore.org/show_bug.cgi?id=3153

In FSP the temporary memory provided by bootloader typically will be
totally given to PeiCore as Heap, but in some cases FSP may have to
reserve some more temporary memory for private usage.

This commit adds this flexibility for FSP to reserve some
temporary memory before giving them to PeiCore.

Cc: Maurice Ma <maurice.ma@intel.com>
Cc: Nate DeSimone <nathaniel.l.desimone@intel.com>
Cc: Star Zeng <star.zeng@intel.com>
Signed-off-by: Chasel Chiu <chasel.chiu@intel.com>
Reviewed-by: Nate DeSimone <nathaniel.l.desimone@intel.com>
Reviewed-by: Star Zeng <star.zeng@intel.com>