### PR TITLE
basetools: fix python 3.9 incompatibilities

### DIFF
--- a/BaseTools/Source/Python/Eot/EotMain.py
+++ b/BaseTools/Source/Python/Eot/EotMain.py
@@ -196,7 +196,7 @@ class Ui(Image):
         return len(self)
 
     def _GetUiString(self):
-        return codecs.utf_16_decode(self[0:-2].tostring())[0]
+        return codecs.utf_16_decode(self[0:-2].tobytes())[0]
 
     String = property(_GetUiString)
 


### PR DESCRIPTION
due to deprecation of tostring function, use tobytes instead.
discussed in https://bugs.python.org/issue38916