### PR TITLE
[edk2-devel] [PATCH] OvmfPkg/VirtioFsDxe: call IsTimeValid() before EfiTimeToEpoch() -- push

### DIFF
--- a/OvmfPkg/VirtioFsDxe/Helpers.c
+++ b/OvmfPkg/VirtioFsDxe/Helpers.c
@@ -2244,12 +2244,19 @@ VirtioFsGetFuseSizeUpdate (
                            since the Epoch). Otherwise, Mtime is not written
                            to.
 
-  @retval EFI_SUCCESS        Output parameters have been set successfully.
+  @retval EFI_SUCCESS            Output parameters have been set successfully.
 
-  @retval EFI_ACCESS_DENIED  NewInfo requests changing both CreateTime and
-                             ModificationTime, but to values that differ from
-                             each other. The Virtio Filesystem device does not
-                             support this.
+  @retval EFI_INVALID_PARAMETER  At least one of the CreateTime, LastAccessTime
+                                 and ModificationTime fields in NewInfo
+                                 represents an actual update relative to the
+                                 current state of the file (expressed in Info),
+                                 but does not satisfy the UEFI spec
+                                 requirements on EFI_TIME.
+
+  @retval EFI_ACCESS_DENIED      NewInfo requests changing both CreateTime and
+                                 ModificationTime, but to values that differ
+                                 from each other. The Virtio Filesystem device
+                                 does not support this.
 **/
 EFI_STATUS
 VirtioFsGetFuseTimeUpdates (
@@ -2285,6 +2292,9 @@ VirtioFsGetFuseTimeUpdates (
         CompareMem (NewTime[Idx], Time[Idx], sizeof (EFI_TIME)) == 0) {
       Change[Idx] = FALSE;
     } else {
+      if (!IsTimeValid (NewTime[Idx])) {
+        return EFI_INVALID_PARAMETER;
+      }
       Change[Idx] = TRUE;
       Seconds[Idx] = EfiTimeToEpoch (NewTime[Idx]);
     }


### PR DESCRIPTION
https://edk2.groups.io/g/devel/message/69907
https://www.redhat.com/archives/edk2-devel-archive/2021-January/msg00395.html
Message-Id: <20210107095051.22715-1-lersek@redhat.com>
~~~
EmbeddedPkg/TimeBaseLib provides a verification function called
IsTimeValid(), for enforcing the UEFI spec requirements on an EFI_TIME
object.

When EFI_FILE_PROTOCOL.SetInfo() is called in order to update the
timestamps on the file, let's invoke IsTimeValid() first, before passing
the new EFI_FILE_INFO.{CreateTime,LastAccessTime,ModificationTime} values
to EfiTimeToEpoch().

This patch is not expected to make a practical difference, but it's better
to ascertain the preconditions of EfiTimeToEpoch() on the
EFI_FILE_PROTOCOL.SetInfo() caller. The FAT driver (EnhancedFatDxe) has a
similar check, namely in FatSetFileInfo() -> FatIsValidTime().

Cc: Ard Biesheuvel <ard.biesheuvel@arm.com>
Cc: Jordan Justen <jordan.l.justen@intel.com>
Cc: Philippe Mathieu-Daudé <philmd@redhat.com>
Signed-off-by: Laszlo Ersek <lersek@redhat.com>
---
 OvmfPkg/VirtioFsDxe/Helpers.c | 20 +++++++++++++++-----
 1 file changed, 15 insertions(+), 5 deletions(-)
~~~