### PR TITLE
EmbeddedPkg/TimeBaseLib: Reduce duplicate code in RTC modules

### DIFF
--- a/EmbeddedPkg/Include/Library/TimeBaseLib.h
+++ b/EmbeddedPkg/Include/Library/TimeBaseLib.h
@@ -2,6 +2,7 @@
 *
 *  Copyright (c) 2016, Hisilicon Limited. All rights reserved.
 *  Copyright (c) 2016-2019, Linaro Limited. All rights reserved.
+*  Copyright (c) 2021, Ampere Computing LLC. All rights reserved.
 *
 *  SPDX-License-Identifier: BSD-2-Clause-Patent
 *
@@ -52,18 +53,45 @@
 #define SEC_PER_HOUR                                    ((UINTN)  3600)
 #define SEC_PER_DAY                                     ((UINTN) 86400)
 
+/**
+  Check if it is a leap year.
+
+  @param    Time  The UEFI time to be checked.
+
+  @retval   TRUE  It is a leap year.
+  @retval   FALSE It is NOT a leap year.
+
+**/
 BOOLEAN
 EFIAPI
 IsLeapYear (
   IN  EFI_TIME  *Time
   );
 
+/**
+  Check if the day in the UEFI time is valid.
+
+  @param    Time    The UEFI time to be checked.
+
+  @retval   TRUE    Valid.
+  @retval   FALSE   Invalid.
+
+**/
 BOOLEAN
 EFIAPI
 IsDayValid (
   IN  EFI_TIME  *Time
   );
 
+/**
+  Check if the UEFI time is valid.
+
+  @param    Time    The UEFI time to be checked.
+
+  @retval   TRUE    Valid.
+  @retval   FALSE   Invalid.
+
+**/
 BOOLEAN
 EFIAPI
 IsTimeValid (
@@ -71,8 +99,12 @@ IsTimeValid (
   );
 
 /**
-  Converts Epoch seconds (elapsed since 1970 JANUARY 01, 00:00:00 UTC) to EFI_TIME
- **/
+  Converts Epoch seconds (elapsed since 1970 JANUARY 01, 00:00:00 UTC) to EFI_TIME.
+
+  @param  EpochSeconds   Epoch seconds.
+  @param  Time           The time converted to UEFI format.
+
+**/
 VOID
 EFIAPI
 EpochToEfiTime (
@@ -81,8 +113,13 @@ EpochToEfiTime (
   );
 
 /**
-  Converts EFI_TIME to Epoch seconds (elapsed since 1970 JANUARY 01, 00:00:00 UTC)
- **/
+  Converts EFI_TIME to Epoch seconds (elapsed since 1970 JANUARY 01, 00:00:00 UTC).
+
+  @param    Time  The UEFI time to be converted.
+
+  @return   Number of seconds.
+
+**/
 UINTN
 EFIAPI
 EfiTimeToEpoch (
@@ -90,8 +127,13 @@ EfiTimeToEpoch (
   );
 
 /**
-  returns Day of the week [0-6] 0=Sunday
- **/
+  Get the day of the week from the UEFI time.
+
+  @param    Time  The UEFI time to be calculated.
+
+  @return   The day of the week: Sunday=0, Monday=1, ... Saturday=6
+
+**/
 UINTN
 EfiTimeToWday (
   IN  EFI_TIME  *Time

--- a/EmbeddedPkg/Include/Library/TimeBaseLib.h
+++ b/EmbeddedPkg/Include/Library/TimeBaseLib.h
@@ -84,6 +84,42 @@ IsDayValid (
   );
 
 /**
+  Check if the time zone is valid.
+  Valid values are between -1440 and 1440 or 2047 (EFI_UNSPECIFIED_TIMEZONE).
+
+  @param    TimeZone    The time zone to be checked.
+
+  @retval   TRUE    Valid.
+  @retval   FALSE   Invalid.
+
+**/
+BOOLEAN
+EFIAPI
+IsValidTimeZone (
+  IN  INT16  TimeZone
+  );
+
+/**
+  Check if the daylight is valid.
+  Valid values are:
+    0 : Time is not affected.
+    1 : Time is affected, and has not been adjusted for daylight savings.
+    3 : Time is affected, and has been adjusted for daylight savings.
+  All other values are invalid.
+
+  @param    Daylight    The daylight to be checked.
+
+  @retval   TRUE    Valid.
+  @retval   FALSE   Invalid.
+
+**/
+BOOLEAN
+EFIAPI
+IsValidDaylight (
+  IN  INT8  Daylight
+  );
+
+/**
   Check if the UEFI time is valid.
 
   @param    Time    The UEFI time to be checked.

--- a/EmbeddedPkg/Library/TimeBaseLib/TimeBaseLib.c
+++ b/EmbeddedPkg/Library/TimeBaseLib/TimeBaseLib.c
@@ -2,6 +2,7 @@
 *
 *  Copyright (c) 2016, Hisilicon Limited. All rights reserved.
 *  Copyright (c) 2016-2019, Linaro Limited. All rights reserved.
+*  Copyright (c) 2021, Ampere Computing LLC. All rights reserved.
 *
 *  SPDX-License-Identifier: BSD-2-Clause-Patent
 *
@@ -13,8 +14,12 @@
 #include <Library/TimeBaseLib.h>
 
 /**
-  Converts Epoch seconds (elapsed since 1970 JANUARY 01, 00:00:00 UTC) to EFI_TIME
- **/
+  Converts Epoch seconds (elapsed since 1970 JANUARY 01, 00:00:00 UTC) to EFI_TIME.
+
+  @param  EpochSeconds   Epoch seconds.
+  @param  Time           The time converted to UEFI format.
+
+**/
 VOID
 EFIAPI
 EpochToEfiTime (
@@ -71,8 +76,13 @@ EpochToEfiTime (
 }
 
 /**
-  Calculate Epoch days
- **/
+  Calculate Epoch days.
+
+  @param    Time  The UEFI time to be calculated.
+
+  @return   Number of days.
+
+**/
 UINTN
 EFIAPI
 EfiGetEpochDays (
@@ -96,9 +106,15 @@ EfiGetEpochDays (
 
   return EpochDays;
 }
+
 /**
-  Converts EFI_TIME to Epoch seconds (elapsed since 1970 JANUARY 01, 00:00:00 UTC)
- **/
+  Converts EFI_TIME to Epoch seconds (elapsed since 1970 JANUARY 01, 00:00:00 UTC).
+
+  @param    Time  The UEFI time to be converted.
+
+  @return   Number of seconds.
+
+**/
 UINTN
 EFIAPI
 EfiTimeToEpoch (
@@ -116,8 +132,13 @@ EfiTimeToEpoch (
 }
 
 /**
-  returns Day of the week [0-6] 0=Sunday
- **/
+  Get the day of the week from the UEFI time.
+
+  @param    Time  The UEFI time to be calculated.
+
+  @return   The day of the week: Sunday=0, Monday=1, ... Saturday=6
+
+**/
 UINTN
 EfiTimeToWday (
   IN  EFI_TIME  *Time
@@ -132,6 +153,15 @@ EfiTimeToWday (
   return (EpochDays + 4) % 7;
 }
 
+/**
+  Check if it is a leap year.
+
+  @param    Time  The UEFI time to be checked.
+
+  @retval   TRUE  It is a leap year.
+  @retval   FALSE It is NOT a leap year.
+
+**/
 BOOLEAN
 EFIAPI
 IsLeapYear (
@@ -153,6 +183,15 @@ IsLeapYear (
   }
 }
 
+/**
+  Check if the day in the UEFI time is valid.
+
+  @param    Time    The UEFI time to be checked.
+
+  @retval   TRUE    Valid.
+  @retval   FALSE   Invalid.
+
+**/
 BOOLEAN
 EFIAPI
 IsDayValid (
@@ -171,6 +210,15 @@ IsDayValid (
   return TRUE;
 }
 
+/**
+  Check if the UEFI time is valid.
+
+  @param    Time    The UEFI time to be checked.
+
+  @retval   TRUE    Valid.
+  @retval   FALSE   Invalid.
+
+**/
 BOOLEAN
 EFIAPI
 IsTimeValid(

--- a/EmbeddedPkg/Library/TimeBaseLib/TimeBaseLib.c
+++ b/EmbeddedPkg/Library/TimeBaseLib/TimeBaseLib.c
@@ -211,6 +211,51 @@ IsDayValid (
 }
 
 /**
+  Check if the time zone is valid.
+  Valid values are between -1440 and 1440 or 2047 (EFI_UNSPECIFIED_TIMEZONE).
+
+  @param    TimeZone    The time zone to be checked.
+
+  @retval   TRUE    Valid.
+  @retval   FALSE   Invalid.
+
+**/
+BOOLEAN
+EFIAPI
+IsValidTimeZone (
+  IN  INT16  TimeZone
+  )
+{
+  return TimeZone == EFI_UNSPECIFIED_TIMEZONE ||
+         (TimeZone >= -1440 && TimeZone <= 1440);
+}
+
+/**
+  Check if the daylight is valid.
+  Valid values are:
+    0 : Time is not affected.
+    1 : Time is affected, and has not been adjusted for daylight savings.
+    3 : Time is affected, and has been adjusted for daylight savings.
+  All other values are invalid.
+
+  @param    Daylight    The daylight to be checked.
+
+  @retval   TRUE    Valid.
+  @retval   FALSE   Invalid.
+
+**/
+BOOLEAN
+EFIAPI
+IsValidDaylight (
+  IN  INT8  Daylight
+  )
+{
+  return Daylight == 0 ||
+         Daylight == EFI_TIME_ADJUST_DAYLIGHT ||
+         Daylight == (EFI_TIME_ADJUST_DAYLIGHT | EFI_TIME_IN_DAYLIGHT);
+}
+
+/**
   Check if the UEFI time is valid.
 
   @param    Time    The UEFI time to be checked.
@@ -235,8 +280,8 @@ IsTimeValid (
      (Time->Minute > 59  )              ||
      (Time->Second > 59  )              ||
      (Time->Nanosecond > 999999999)     ||
-     (!((Time->TimeZone == EFI_UNSPECIFIED_TIMEZONE) || ((Time->TimeZone >= -1440) && (Time->TimeZone <= 1440)))) ||
-     (Time->Daylight & (~(EFI_TIME_ADJUST_DAYLIGHT | EFI_TIME_IN_DAYLIGHT)))) {
+     (!IsValidTimeZone(Time->TimeZone)) ||
+     (!IsValidDaylight(Time->Daylight))) {
     return FALSE;
   }
 

--- a/EmbeddedPkg/Library/TimeBaseLib/TimeBaseLib.c
+++ b/EmbeddedPkg/Library/TimeBaseLib/TimeBaseLib.c
@@ -221,23 +221,22 @@ IsDayValid (
 **/
 BOOLEAN
 EFIAPI
-IsTimeValid(
+IsTimeValid (
   IN EFI_TIME *Time
   )
 {
   // Check the input parameters are within the range specified by UEFI
-  if ((Time->Year   < 2000) ||
-     (Time->Year   > 2099) ||
-     (Time->Month  < 1   ) ||
-     (Time->Month  > 12  ) ||
-     (!IsDayValid (Time)    ) ||
-     (Time->Hour   > 23  ) ||
-     (Time->Minute > 59  ) ||
-     (Time->Second > 59  ) ||
-     (Time->Nanosecond > 999999999) ||
+  if ((Time->Year  < 2000)              ||
+     (Time->Year   > 2099)              ||
+     (Time->Month  < 1   )              ||
+     (Time->Month  > 12  )              ||
+     (!IsDayValid (Time) )              ||
+     (Time->Hour   > 23  )              ||
+     (Time->Minute > 59  )              ||
+     (Time->Second > 59  )              ||
+     (Time->Nanosecond > 999999999)     ||
      (!((Time->TimeZone == EFI_UNSPECIFIED_TIMEZONE) || ((Time->TimeZone >= -1440) && (Time->TimeZone <= 1440)))) ||
-     (Time->Daylight & (~(EFI_TIME_ADJUST_DAYLIGHT | EFI_TIME_IN_DAYLIGHT)))
-  ) {
+     (Time->Daylight & (~(EFI_TIME_ADJUST_DAYLIGHT | EFI_TIME_IN_DAYLIGHT)))) {
     return FALSE;
   }
 

--- a/EmbeddedPkg/RealTimeClockRuntimeDxe/RealTimeClockRuntimeDxe.inf
+++ b/EmbeddedPkg/RealTimeClockRuntimeDxe/RealTimeClockRuntimeDxe.inf
@@ -3,6 +3,7 @@
 #
 #  Copyright (c) 2006 - 2007, Intel Corporation. All rights reserved.<BR>
 #  Copyright (c) 2017, Linaro, Ltd. All rights reserved.<BR>
+#  Copyright (c) 2021, Ampere Computing LLC. All rights reserved.<BR>
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -28,6 +29,7 @@
 [LibraryClasses]
   DebugLib
   RealTimeClockLib
+  TimeBaseLib
   UefiBootServicesTableLib
   UefiDriverEntryPoint
   UefiRuntimeLib


### PR DESCRIPTION
This patch series replaces all time checking functions and leverage
the helper function in TimeBaseLib library.

Cc: Leif Lindholm <leif@nuviainc.com>
Cc: Ard Biesheuvel <ard.biesheuvel@arm.com>
Signed-off-by: Nhi Pham <nhi@os.amperecomputing.com>

Nhi Pham (4):
  EmbeddedPkg/TimeBaseLib: Update comment blocks for API functions
  EmbeddedPkg/TimeBaseLib: Fix for minor code formatting
  EmbeddedPkg/TimeBaseLib: Add function to check Timezone and Daylight
  EmbeddedPkg/RealTimeClockRuntimeDxe: Use helper functions from TimeBaseLib

 .../RealTimeClockRuntimeDxe.inf               |   2 +
 EmbeddedPkg/Include/Library/TimeBaseLib.h     |  90 +++++++++++-
 EmbeddedPkg/Library/TimeBaseLib/TimeBaseLib.c | 134 +++++++++++++++---
 .../RealTimeClockRuntimeDxe/RealTimeClock.c   |  88 +-----------
 4 files changed, 201 insertions(+), 113 deletions(-)