### PR TITLE
EmbeddedPkg/PrePiMemoryAllocationLib: use correct size for pool hob

### DIFF
--- a/EmbeddedPkg/Library/PrePiMemoryAllocationLib/MemoryAllocationLib.c
+++ b/EmbeddedPkg/Library/PrePiMemoryAllocationLib/MemoryAllocationLib.c
@@ -184,7 +184,9 @@ AllocatePool (
     return 0;
   } else {
 
-    Hob = (EFI_HOB_MEMORY_POOL *)CreateHob (EFI_HOB_TYPE_MEMORY_POOL, (UINT16)(sizeof (EFI_HOB_TYPE_MEMORY_POOL) + AllocationSize));
+    Hob = (EFI_HOB_MEMORY_POOL *)CreateHob (EFI_HOB_TYPE_MEMORY_POOL,
+                                   (UINT16)(sizeof (EFI_HOB_MEMORY_POOL) +
+                                            AllocationSize));
     return (VOID *)(Hob + 1);
   }
 }


### PR DESCRIPTION
Use the correct type in the sizeof() expression to calculate the size
of the newly allocated EFI_HOB_MEMORY_POOL hob.

Link: https://bugzilla.tianocore.org/show_bug.cgi?id=3139
Signed-off-by: Ard Biesheuvel <ard.biesheuvel@arm.com>
Reviewed-by: Leif Lindholm <leif@nuviainc.com>