### PR TITLE
MdeModulePkg/Library/VarCheckLib: Allow SetVariable from SMM

### DIFF
--- a/MdeModulePkg/Library/VarCheckLib/VarCheckLib.c
+++ b/MdeModulePkg/Library/VarCheckLib/VarCheckLib.c
@@ -1,7 +1,7 @@
 /** @file
   Implementation functions and structures for var check services.
 
-Copyright (c) 2015 - 2016, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2015 - 2021, Intel Corporation. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -655,6 +655,13 @@ VarCheckLibSetVariableCheck (
                DataSize,
                Data
                );
+    if (Status == EFI_WRITE_PROTECTED && RequestSource == VarCheckFromTrusted) {
+      //
+      // If RequestSource is trusted, then allow variable to be set even if it
+      // is write protected.
+      //
+      continue;
+    }
     if (EFI_ERROR (Status)) {
       DEBUG ((EFI_D_INFO, "Variable Check handler fail %r - %g:%s\n", Status, VendorGuid, VariableName));
       return Status;


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3154

Update VarCheckLibSetVariableCheck() to allow locked variables
to be updated if the RequestSource is VarCheckFromTrusted even
if one or more variable check handlers return EFI_WRITE_PROTECTED.
RequestSource is only set to VarCheckFromTrusted if the request
is through the EFI_SMM_VARAIBLE_PROTOCOL.

Cc: Bret Barkelew <Bret.Barkelew@microsoft.com>
Cc: Hao A Wu <hao.a.wu@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Signed-off-by: Michael D Kinney <michael.d.kinney@intel.com>
Reviewed-by: Bret Barkelew <bret.barkelew@microsoft.com>
Reviewed-by: Hao A Wu <hao.a.wu@intel.com>
(cherry picked from commit 248d08c5983b561549891fec54c213e1f354179c)
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>