### PR TITLE
EmbeddedPkg/RealTimeClockRuntimeDxe: depend on gEfiVariableArchProtocolGuid

### DIFF
--- a/EmbeddedPkg/RealTimeClockRuntimeDxe/RealTimeClockRuntimeDxe.inf
+++ b/EmbeddedPkg/RealTimeClockRuntimeDxe/RealTimeClockRuntimeDxe.inf
@@ -38,5 +38,5 @@
   gEfiRealTimeClockArchProtocolGuid
 
 [Depex]
-  TRUE
+  gEfiVariableArchProtocolGuid
 


### PR DESCRIPTION
The EfiGetVariable() is used in the entry of this module. So, the
variable services are required to be ready before they are used. This
patch adds the arch protocol gEfiVariableArchProtocolGuid to dependency
expression to guarantee that this module will be started once the
variable protocol is available.

Cc: Leif Lindholm <leif@nuviainc.com>
Cc: Ard Biesheuvel <ard.biesheuvel@arm.com>
Signed-off-by: Nhi Pham <nhi@os.amperecomputing.com>
Reviewed-by: Laszlo Ersek <lersek@redhat.com>
Reviewed-by: Leif Lindholm <leif@nuviainc.com>