### PR TITLE
BaseTools: Fix the build report crash issue

### DIFF
--- a/BaseTools/Source/Python/build/BuildReport.py
+++ b/BaseTools/Source/Python/build/BuildReport.py
@@ -1125,10 +1125,11 @@ class PcdReport(object):
                                             if SkuInfo.DefaultStoreDict:
                                                 DefaultStoreList = sorted(SkuInfo.DefaultStoreDict.keys())
                                                 for DefaultStore in DefaultStoreList:
-                                                    OverrideValues = Pcd.SkuOverrideValues[Sku]
-                                                    DscOverride = self.ParseStruct(OverrideValues[DefaultStore])
-                                                    if DscOverride:
-                                                        break
+                                                    OverrideValues = Pcd.SkuOverrideValues.get(Sku)
+                                                    if OverrideValues:
+                                                        DscOverride = self.ParseStruct(OverrideValues[DefaultStore])
+                                                        if DscOverride:
+                                                            break
                                             if DscOverride:
                                                 break
                             if DscOverride:
@@ -1388,9 +1389,10 @@ class PcdReport(object):
                                         FileWrite(File, ' %-*s   : %6s %10s %10s %10s = %s' % (self.MaxLen, ' ', TypeName, '(' + Pcd.DatumType + ')', '(' + SkuIdName + ')', '(' + DefaultStore + ')', Value))
                             FileWrite(File, '%*s: %s: %s' % (self.MaxLen + 4, SkuInfo.VariableGuid, SkuInfo.VariableName, SkuInfo.VariableOffset))
                             if IsStructure:
-                                OverrideValues = Pcd.SkuOverrideValues[Sku]
-                                OverrideFieldStruct = self.OverrideFieldValue(Pcd, OverrideValues[DefaultStore])
-                                self.PrintStructureInfo(File, OverrideFieldStruct)
+                                OverrideValues = Pcd.SkuOverrideValues.get(Sku)
+                                if OverrideValues:
+                                    OverrideFieldStruct = self.OverrideFieldValue(Pcd, OverrideValues[DefaultStore])
+                                    self.PrintStructureInfo(File, OverrideFieldStruct)
                             self.PrintPcdDefault(File, Pcd, IsStructure, DscMatch, DscDefaultValue, InfMatch, InfDefaultValue, DecMatch, DecDefaultValue)
                 else:
                     Value = SkuInfo.DefaultValue


### PR DESCRIPTION
In the following corner case, the build report
will crash. This patch is to fix this problem.

Case:
Multiple SKU are used and 2 more DynamicHii structure Pcds
are set in dsc file under different SKU. And 1 more of those
Pcds are not used in any INF file.

Signed-off-by: Bob Feng <bob.c.feng@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Yuwei Chen <yuwei.chen@intel.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>
Reviewed-by: Yuwei Chen<yuwei.chen@intel.com>