### PR TITLE
MdeModulePkg/FileExplorerLib: Add return value check

### DIFF
--- a/MdeModulePkg/Library/FileExplorerLib/FileExplorer.c
+++ b/MdeModulePkg/Library/FileExplorerLib/FileExplorer.c
@@ -1408,12 +1408,14 @@ LibUpdateFileExplorer (
   if (NewFileContext->IsDir) {
     RemoveEntryList (&NewMenuEntry->Link);
     LibFreeMenu (gFileExplorerPrivate.FsOptionMenu);
-    LibGetFileHandleFromMenu (NewMenuEntry, &FileHandle);
-    Status = LibFindFiles (FileHandle, NewFileContext->FileName, NewFileContext->DeviceHandle);
+    Status = LibGetFileHandleFromMenu (NewMenuEntry, &FileHandle);
     if (!EFI_ERROR (Status)) {
-      LibUpdateFileExplorePage ();
-    } else {
-      LibFreeMenu (gFileExplorerPrivate.FsOptionMenu);
+      Status = LibFindFiles (FileHandle, NewFileContext->FileName, NewFileContext->DeviceHandle);
+      if (!EFI_ERROR (Status)) {
+        LibUpdateFileExplorePage ();
+      } else {
+        LibFreeMenu (gFileExplorerPrivate.FsOptionMenu);
+      }
     }
     LibDestroyMenuEntry (NewMenuEntry);
   }


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3113
According to FAT specification, the length of file path
should not larger than 260. When the length exceed 260,
function FatLocateOFile will return EFI_INVALID_PARAMETER
and the parameter FileHandle will be NULL. Then on the
top-level function?an exception happens when the NULL
pointer is passed and be used.
So adding return value check after calling
LibGetFileHandleFromMenu, if return value is not success,
stop calling LibFindFiles.

Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Hao A Wu <hao.a.wu@intel.com>
Cc: Dandan Bi <dandan.bi@intel.com>
Cc: Eric Dong <eric.dong@intel.com>
Signed-off-by: Wenyi Xie <xiewenyi2@huawei.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>
Reviewed-by: Dandan Bi <dandan.bi@intel.com>