### PR TITLE
MdeModulePkg/TerminalDxe: Terminal fifo buffer overflow.

### DIFF
--- a/MdeModulePkg/Universal/Console/TerminalDxe/Terminal.h
+++ b/MdeModulePkg/Universal/Console/TerminalDxe/Terminal.h
@@ -37,7 +37,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/BaseLib.h>
 
 
-#define RAW_FIFO_MAX_NUMBER 256
+#define RAW_FIFO_MAX_NUMBER 255
 #define FIFO_MAX_NUMBER     128
 
 typedef struct {


### PR DESCRIPTION
Fix the bug of terminal fifo buffer overflow with UINT8 type.

typedef struct {
  UINT8 Head;
  UINT8 Tail;
  UINT8 Data[RAW_FIFO_MAX_NUMBER + 1];
} RAW_DATA_FIFO;
RAW_FIFO_MAX_NUMBER is 256.
the data buffer size is 257 (Index from 0 to 256), but the max value of
the index, Head or Tail (UINT8), is 255. That means the last data of the
data buffer would be always empty if we use Head/Tail to output/input the
data correctly.  And because of the incorrect buffer size the FIFO full
check "((Tail + 1) % (RAW_FIFO_MAX_NUMBER + 1)) == Head" would never meet.

Signed-off-by: gechao <gechao@greatwall.com.cn>
Reviewed-by: Zhichao Gao <zhichao.gao@intel.com>