### PR TITLE
MdeModulePkg/PciBusDxe: Handle BAR sizing fail in high 32bit of MEM64.

### DIFF
--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciEnumeratorSupport.c
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciEnumeratorSupport.c
@@ -1686,6 +1686,7 @@ PciIovParseVfBar (
                 );
 
       if (EFI_ERROR (Status)) {
+        PciIoDevice->VfPciBar[BarIndex].BarType = PciBarTypeUnknown;
         return Offset + 4;
       }
 


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3149

Address MEM64 BAR in type unknown if sizing fail in high 32bit.

Cc: Ray Ni <ray.ni@intel.com>
Cc: Hao A Wu <hao.a.wu@intel.com>
Signed-off-by: Zarcd Zhong <zarcd.zhong@intel.com>
Reviewed-by: Ray Ni <ray.ni@intel.com>