### PR TITLE
RedfishPkg/RedfishContentCodingLib: EDKII Redfish En/Decode library

### DIFF
--- a/RedfishPkg/Include/Library/RedfishContentCodingLib.h
+++ b/RedfishPkg/Include/Library/RedfishContentCodingLib.h
@@ -1,0 +1,78 @@
+/** @file
+  Definitinos of RedfishContentCodingLib.
+
+  (C) Copyright 2021 Hewlett Packard Enterprise Development LP<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+#ifndef REDFISH_CONTENT_CODING_LIB_H_
+#define REDFISH_CONTENT_CODING_LIB_H_
+
+/**
+  This is the function to encode the content use the
+  algorithm indicated in ContentEncodedValue. The naming of
+  ContentEncodedValue is follow HTTP spec or could be a
+  platform-specific value.
+
+  @param[in]   ContentEncodedValue   HTTP conent encoded value.
+                                     The value could be one of below
+                                     or any which is platform-specific.
+                                       - HTTP_CONTENT_ENCODING_IDENTITY "identity"
+                                       - HTTP_CONTENT_ENCODING_GZIP     "gzip"
+                                       - HTTP_CONTENT_ENCODING_COMPRESS "compress"
+                                       - HTTP_CONTENT_ENCODING_DEFLATE  "deflate"
+                                       - HTTP_CONTENT_ENCODING_BROTLI   "br"
+  @param[in]   OriginalContent       Original content.
+  @param[in]   OriginalContentLength The length of original content.
+  @param[out]  EncodedContentPointer Pointer to receive the encoded content pointer.
+  @param[out]  EncodedContentLength  Length of encoded content.
+
+  @retval EFI_SUCCESS              Content is encoded successfully.
+  @retval EFI_UNSUPPORTED          No supported encoding funciton,
+  @retval EFI_INVALID_PARAMETER    One of the given parameter is invalid.
+
+**/
+
+EFI_STATUS
+RedfishContentEncode  (
+  IN CHAR8  *ContentEncodedValue,
+  IN CHAR8  *OriginalContent,
+  IN UINTN  OriginalContentLength,
+  OUT VOID  **EncodedContentPointer,
+  OUT UINTN *EncodedLength
+  );
+
+/**
+  This is the function to decode the content use the
+  algorithm indicated in ContentEncodedValue. The naming of
+  ContentEncodedValue is follow HTTP spec or could be a
+  platform-specific value.
+
+  @param[in]   ContentDecodedValue   HTTP conent decoded value.
+                                     The value could be one of below
+                                     or any which is platform-specific.
+                                       - HTTP_CONTENT_ENCODING_IDENTITY "identity"
+                                       - HTTP_CONTENT_ENCODING_GZIP     "gzip"
+                                       - HTTP_CONTENT_ENCODING_COMPRESS "compress"
+                                       - HTTP_CONTENT_ENCODING_DEFLATE  "deflate"
+                                       - HTTP_CONTENT_ENCODING_BROTLI   "br"
+  @param[in]   ContentPointer        Original content.
+  @param[in]   ContentLength         The length of original content.
+  @param[out]  DecodedContentPointer Pointer to receive decoded content pointer.
+  @param[out]  DecodedContentLength  Length of decoded content.
+
+  @retval EFI_SUCCESS              Content is decoded successfully.
+  @retval EFI_UNSUPPORTED          No supported decoding funciton,
+  @retval EFI_INVALID_PARAMETER    One of the given parameter is invalid.
+
+**/
+EFI_STATUS
+RedfishContentDecode (
+  IN CHAR8  *ContentEncodedValue,
+  IN VOID   *ContentPointer,
+  IN UINTN  ContentLength,
+  OUT VOID  **DecodedContentPointer,
+  OUT UINTN *DecodedLength
+  );
+#endif

--- a/RedfishPkg/Library/RedfishContentCodingLibNull/RedfishContentCodingLibNull.c
+++ b/RedfishPkg/Library/RedfishContentCodingLibNull/RedfishContentCodingLibNull.c
@@ -1,0 +1,81 @@
+/** @file
+  NULL instace of RedfishContentCodingLib
+
+  (C) Copyright 2021 Hewlett Packard Enterprise Development LP<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+#include <Uefi.h>
+
+/**
+  This is the function to encode the content use the
+  algorithm indicated in ContentEncodedValue. The naming of
+  ContentEncodedValue is follow HTTP spec or could be a
+  platform-specific value.
+
+  @param[in]   ContentEncodedValue   HTTP conent encoded value.
+                                     The value could be one of below
+                                     or any which is platform-specific.
+                                       - HTTP_CONTENT_ENCODING_IDENTITY "identity"
+                                       - HTTP_CONTENT_ENCODING_GZIP     "gzip"
+                                       - HTTP_CONTENT_ENCODING_COMPRESS "compress"
+                                       - HTTP_CONTENT_ENCODING_DEFLATE  "deflate"
+                                       - HTTP_CONTENT_ENCODING_BROTLI   "br"
+  @param[in]   OriginalContent       Original content.
+  @param[in]   OriginalContentLength The length of original content.
+  @param[out]  EncodedContentPointer Pointer to receive the encoded content pointer.
+  @param[out]  EncodedContentLength  Length of encoded content.
+
+  @retval EFI_SUCCESS              Content is encoded successfully.
+  @retval EFI_UNSUPPORTED          No supported encoding funciton,
+  @retval EFI_INVALID_PARAMETER    One of the given parameter is invalid.
+
+**/
+EFI_STATUS
+RedfishContentEncode  (
+  IN CHAR8  *ContentEncodedValue,
+  IN CHAR8  *OriginalContent,
+  IN UINTN  OriginalContentLength,
+  OUT VOID  **EncodedContentPointer,
+  OUT UINTN *EncodedContentLength
+  )
+{
+  return EFI_UNSUPPORTED;
+}
+
+/**
+  This is the function to decode the content use the
+  algorithm indicated in ContentEncodedValue. The naming of
+  ContentEncodedValue is follow HTTP spec or could be a
+  platform-specific value.
+
+  @param[in]   ContentDecodedValue   HTTP conent decoded value.
+                                     The value could be one of below
+                                     or any which is platform-specific.
+                                       - HTTP_CONTENT_ENCODING_IDENTITY "identity"
+                                       - HTTP_CONTENT_ENCODING_GZIP     "gzip"
+                                       - HTTP_CONTENT_ENCODING_COMPRESS "compress"
+                                       - HTTP_CONTENT_ENCODING_DEFLATE  "deflate"
+                                       - HTTP_CONTENT_ENCODING_BROTLI   "br"
+  @param[in]   ContentPointer        Original content.
+  @param[in]   ContentLength         The length of original content.
+  @param[out]  DecodedContentPointer Pointer to receive decoded content pointer.
+  @param[out]  DecodedContentLength  Length of decoded content.
+
+  @retval EFI_SUCCESS              Content is decoded successfully.
+  @retval EFI_UNSUPPORTED          No supported decoding funciton,
+  @retval EFI_INVALID_PARAMETER    One of the given parameter is invalid.
+
+**/
+EFI_STATUS
+RedfishContentDecode (
+  IN CHAR8  *ContentDecodedValue,
+  IN VOID   *ContentPointer,
+  IN UINTN  ContentLength,
+  OUT VOID  **DecodedContentPointer,
+  OUT UINTN *DecodedContentLength
+  )
+{
+  return EFI_UNSUPPORTED;
+}

--- a/RedfishPkg/Library/RedfishContentCodingLibNull/RedfishContentCodingLibNull.inf
+++ b/RedfishPkg/Library/RedfishContentCodingLibNull/RedfishContentCodingLibNull.inf
@@ -1,0 +1,31 @@
+## @file
+#  NULL instance of RedfishContentCodingLibNull
+#  This library is used to encode/decode Redfish payload.
+#
+#  (C) Copyright 2021 Hewlett Packard Enterprise Development LP<BR>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x0001000b
+  BASE_NAME                      = RedfishContentCodingLibNull
+  FILE_GUID                      = 06B10249-4D38-FF37-0CA5-13AFB6D625CC
+  MODULE_TYPE                    = DXE_DRIVER
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = RedfishContentCodingLib
+
+#
+#  VALID_ARCHITECTURES           = IA32 X64 ARM AARCH64 RISCV64
+#
+
+[Sources]
+  RedfishContentCodingLibNull.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  RedfishPkg/RedfishPkg.dec
+
+

--- a/RedfishPkg/RedfishPkg.dec
+++ b/RedfishPkg/RedfishPkg.dec
@@ -2,7 +2,7 @@
 # Redfish Package
 #
 # Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
-# (C) Copyright 2020 Hewlett Packard Enterprise Development LP<BR>
+# (C) Copyright 2021 Hewlett Packard Enterprise Development LP<BR>
 #
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 ##
@@ -49,6 +49,11 @@
   #  jansson library to manipulate JSON data structure.
   #
   JsonLib|Include/Library/JsonLib.h
+
+  ##  @libraryclass  Provides the library functions to encode/decode
+  #   Redfish packet.
+  #
+  RedfishContentCodingLib|Include/Library/RedfishContentCodingLib.h
 
 [LibraryClasses.Common.Private]
   ##  @libraryclass  Provides the private C runtime library functions.

--- a/RedfishPkg/RedfishPkg.dsc
+++ b/RedfishPkg/RedfishPkg.dsc
@@ -2,7 +2,7 @@
 # Redfish Package
 #
 # Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
-# (C) Copyright 2020 Hewlett-Packard Enterprise Development LP.
+# (C) Copyright 2021 Hewlett-Packard Enterprise Development LP.
 #
 #    SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -37,6 +37,7 @@
   NetLib|NetworkPkg/Library/DxeNetLib/DxeNetLib.inf
   DpcLib|NetworkPkg/Library/DxeDpcLib/DxeDpcLib.inf
   RedfishPlatformCredentialLib|RedfishPkg/Library/PlatformCredentialLibNull/PlatformCredentialLibNull.inf
+  RedfishContentCodingLib|RedfishPkg/Library/RedfishContentCodingLibNull/RedfishContentCodingLibNull.inf
 
 [LibraryClasses.ARM, LibraryClasses.AARCH64]
   #
@@ -49,6 +50,7 @@
 [Components]
   RedfishPkg/Library/PlatformHostInterfaceLibNull/PlatformHostInterfaceLibNull.inf
   RedfishPkg/Library/PlatformCredentialLibNull/PlatformCredentialLibNull.inf
+  RedfishPkg/Library/RedfishContentCodingLibNull/RedfishContentCodingLibNull.inf
   RedfishPkg/Library/DxeRestExLib/DxeRestExLib.inf
   RedfishPkg/Library/BaseUcs2Utf8Lib/BaseUcs2Utf8Lib.inf
   RedfishPkg/PrivateLibrary/RedfishCrtLib/RedfishCrtLib.inf


### PR DESCRIPTION
BZ#:3174
Platform library to provide the encoding/decoding algorithms for
the Redfish packets.
The supported value could be one of below or any which is
platform-specific.
  - HTTP_CONTENT_ENCODING_IDENTITY "identity"
  - HTTP_CONTENT_ENCODING_GZIP     "gzip"
  - HTTP_CONTENT_ENCODING_COMPRESS "compress"
  - HTTP_CONTENT_ENCODING_DEFLATE  "deflate"
  - HTTP_CONTENT_ENCODING_BROTLI   "br"

Signed-off-by: Abner Chang <abner.chang@hpe.com>
Cc: Nickle Wang <nickle.wang@hpe.com>