### PR TITLE
UefiPayloadPkg: Update CoreInitializeMemoryServices conditions

### DIFF
--- a/UefiPayloadPkg/UefiPayloadEntry/UefiPayloadEntry.c
+++ b/UefiPayloadPkg/UefiPayloadEntry/UefiPayloadEntry.c
@@ -6,6 +6,16 @@
 **/
 
 #include "UefiPayloadEntry.h"
+#include <Guid/MemoryTypeInformation.h>
+
+EFI_MEMORY_TYPE_INFORMATION mDefaultMemoryTypeInformation[] = {
+  { EfiACPIReclaimMemory,   FixedPcdGet32 (PcdMemoryTypeEfiACPIReclaimMemory) },
+  { EfiACPIMemoryNVS,       FixedPcdGet32 (PcdMemoryTypeEfiACPIMemoryNVS) },
+  { EfiReservedMemoryType,  FixedPcdGet32 (PcdMemoryTypeEfiReservedMemoryType) },
+  { EfiRuntimeServicesData, FixedPcdGet32 (PcdMemoryTypeEfiRuntimeServicesData) },
+  { EfiRuntimeServicesCode, FixedPcdGet32 (PcdMemoryTypeEfiRuntimeServicesCode) },
+  { EfiMaxMemoryType,       0     }
+};
 
 /**
    Callback function to build resource descriptor HOB
@@ -42,6 +52,9 @@ MemInfoCallback (
 
   if (Base >= BASE_4GB ) {
     // Remove tested attribute to avoid DXE core to dispatch driver to memory above 4GB
+    Attribue &= ~EFI_RESOURCE_ATTRIBUTE_TESTED;
+  }
+  if (Base == 0x00) {
     Attribue &= ~EFI_RESOURCE_ATTRIBUTE_TESTED;
   }
 
@@ -314,6 +327,13 @@ BuildGenericHob (
   UINT32                           RegEax;
   UINT8                            PhysicalAddressBits;
   EFI_RESOURCE_ATTRIBUTE_TYPE      ResourceAttribute;
+
+  //
+  // Create Memory Type Information HOB
+  //
+  BuildGuidDataHob (&gEfiMemoryTypeInformationGuid,
+                    mDefaultMemoryTypeInformation,
+                    sizeof (mDefaultMemoryTypeInformation));
 
   // The UEFI payload FV
   BuildMemoryAllocationHob (PcdGet32 (PcdPayloadFdMemBase), PcdGet32 (PcdPayloadFdMemSize), EfiBootServicesData);

--- a/UefiPayloadPkg/UefiPayloadEntry/UefiPayloadEntry.inf
+++ b/UefiPayloadPkg/UefiPayloadEntry/UefiPayloadEntry.inf
@@ -86,6 +86,11 @@
   gUefiPayloadPkgTokenSpaceGuid.PcdPayloadFdMemSize
   gUefiPayloadPkgTokenSpaceGuid.PcdPayloadStackTop
   gUefiPayloadPkgTokenSpaceGuid.PcdSystemMemoryUefiRegionSize
+  gUefiPayloadPkgTokenSpaceGuid.PcdMemoryTypeEfiACPIReclaimMemory
+  gUefiPayloadPkgTokenSpaceGuid.PcdMemoryTypeEfiACPIMemoryNVS
+  gUefiPayloadPkgTokenSpaceGuid.PcdMemoryTypeEfiReservedMemoryType
+  gUefiPayloadPkgTokenSpaceGuid.PcdMemoryTypeEfiRuntimeServicesData
+  gUefiPayloadPkgTokenSpaceGuid.PcdMemoryTypeEfiRuntimeServicesCode
 
   gEfiMdeModulePkgTokenSpaceGuid.PcdSetNxForStack               ## SOMETIMES_CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdDxeNxMemoryProtectionPolicy ## SOMETIMES_CONSUMES


### PR DESCRIPTION
The CoreInitializeMemoryServices() looks for a suitable memory region
for EFI Memory Service from the ResourceDescriptor Hob.
This patch does not allow legacy memory region for the Memory Service
and provides default memory type information to calculate minimal
required memory size properly for the Memory Service.

Signed-off-by: Aiden Park <aiden.park@intel.com>