### PR TITLE
[edk2-devel] [PATCH] UefiCpuPkg RegisterCpuFeaturesLib: NumberOfCpus may be uninitialized -- push

### DIFF
--- a/UefiCpuPkg/Library/RegisterCpuFeaturesLib/RegisterCpuFeaturesLib.c
+++ b/UefiCpuPkg/Library/RegisterCpuFeaturesLib/RegisterCpuFeaturesLib.c
@@ -957,6 +957,7 @@ GetAcpiCpuData (
     //
     // Allocate buffer for empty RegisterTable and PreSmmInitRegisterTable for all CPUs
     //
+    NumberOfCpus = AcpiCpuData->NumberOfCpus;
     TableSize = 2 * NumberOfCpus * sizeof (CPU_REGISTER_TABLE);
     RegisterTable  = AllocatePages (EFI_SIZE_TO_PAGES (TableSize));
     ASSERT (RegisterTable != NULL);


### PR DESCRIPTION
https://bugzilla.tianocore.org/show_bug.cgi?id=3159
https://edk2.groups.io/g/devel/message/70614
https://www.redhat.com/archives/edk2-devel-archive/2021-January/msg01101.html
msgid <20210121093944.1621-1-star.zeng@intel.com>
~~~
NumberOfCpus local variable in GetAcpiCpuData will be uninitialized
when CpuS3DataDxe runs before DxeRegisterCpuFeaturesLib (linked by
CpuFeaturesDxe) because there is no code to initialize it at
(AcpiCpuData != NULL) execution path.

The issue is exposed after cefad282fb31aff3e1a6dcbd368cbbffc3fce900
and 38ee7bafa72f58982f99ac6f61eef160f80bad69.
There was negligence in that code review.
One further topic may be "Could EDK2 CI be enhanced to catch this kind
of uninitialized local variable case?". 

This patch fixes this regression issue.

Cc: Eric Dong <eric.dong@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Cc: Laszlo Ersek <lersek@redhat.com>
Signed-off-by: Star Zeng <star.zeng@intel.com>
---
 .../Library/RegisterCpuFeaturesLib/RegisterCpuFeaturesLib.c      | 1 +
 1 file changed, 1 insertion(+)
~~~