### PR TITLE
UefiCpuPkg/CpuMp: Fix hang when StackGuard is enabled in 16-core cpu

### DIFF
--- a/UefiCpuPkg/CpuMpPei/CpuMpPei.c
+++ b/UefiCpuPkg/CpuMpPei/CpuMpPei.c
@@ -1,7 +1,7 @@
 /** @file
   CPU PEI Module installs CPU Multiple Processor PPI.
 
-  Copyright (c) 2015 - 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2015 - 2021, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -532,13 +532,9 @@ InitializeMpExceptionStackSwitchHandlers (
   ExceptionNumber = FixedPcdGetSize (PcdCpuStackSwitchExceptionList);
   NewStackSize = FixedPcdGet32 (PcdCpuKnownGoodStackSize) * ExceptionNumber;
 
-  Status = PeiServicesAllocatePool (
-             NewStackSize * NumberOfProcessors,
-             (VOID **)&StackTop
-             );
+  StackTop = AllocatePages (EFI_SIZE_TO_PAGES (NewStackSize * NumberOfProcessors));
   ASSERT(StackTop != NULL);
-  if (EFI_ERROR (Status)) {
-    ASSERT_EFI_ERROR (Status);
+  if (StackTop == NULL) {
     return;
   }
   StackTop += NewStackSize  * NumberOfProcessors;

--- a/UefiCpuPkg/CpuMpPei/CpuMpPei.h
+++ b/UefiCpuPkg/CpuMpPei/CpuMpPei.h
@@ -1,7 +1,7 @@
 /** @file
   Definitions to install Multiple Processor PPI.
 
-  Copyright (c) 2015 - 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2015 - 2021, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -27,6 +27,7 @@
 #include <Library/CpuExceptionHandlerLib.h>
 #include <Library/MpInitLib.h>
 #include <Library/BaseMemoryLib.h>
+#include <Library/MemoryAllocationLib.h>
 
 extern EFI_PEI_PPI_DESCRIPTOR   mPeiCpuMpPpiDesc;
 

--- a/UefiCpuPkg/CpuMpPei/CpuMpPei.inf
+++ b/UefiCpuPkg/CpuMpPei/CpuMpPei.inf
@@ -1,7 +1,7 @@
 ## @file
 #  CPU driver installs CPU PI Multi-processor PPI.
 #
-#  Copyright (c) 2015 - 2019, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2015 - 2021, Intel Corporation. All rights reserved.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -45,6 +45,7 @@
   MpInitLib
   BaseMemoryLib
   CpuLib
+  MemoryAllocationLib
 
 [Guids]
   gEdkiiMigratedFvInfoGuid                                             ## SOMETIMES_CONSUMES     ## HOB


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3167

When StackGuard is enabled, the CpuMp driver allocates
known good stacks for all CPUs for DF# and PF# exceptions.
It uses AllocatePool to do so.

The size needed equals to 64KB
= StackSize (2K) * ExceptionNumber (2) * NumberOfProcessors (16)

However, AllocatePool max allocation size is less than 64K.
To fix the issue, AllocatePages() is used.

Signed-off-by: Ray Ni <ray.ni@intel.com>
Reviewed-by: Eric Dong <eric.dong@intel.com>
Reviewed-by: Laszlo Ersek <lersek@redhat.com>
Cc: Rahul Kumar <rahul1.kumar@intel.com>