### PR TITLE
MdeModulePkg/Library: Add HiiGetStringEx to UefiHiiLib for EDK2 Redfish

### DIFF
--- a/MdeModulePkg/Include/Library/HiiLib.h
+++ b/MdeModulePkg/Include/Library/HiiLib.h
@@ -1,7 +1,7 @@
 /** @file
   Public include file for the HII Library
 
-Copyright (c) 2007 - 2018, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2007 - 2021, Intel Corporation. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -152,8 +152,43 @@ HiiGetString (
   IN EFI_HII_HANDLE  HiiHandle,
   IN EFI_STRING_ID   StringId,
   IN CONST CHAR8     *Language  OPTIONAL
-  )
-;
+  );
+
+/**
+  Retrieves a string from a string package in a specific language.  If the language
+  is not specified, then a string from a string package in the current platform
+  language is retrieved.  If the string can not be retrieved using the specified
+  language or the current platform language, then the string is retrieved from
+  the string package in the first language the string package supports.  The
+  returned string is allocated using AllocatePool().  The caller is responsible
+  for freeing the allocated buffer using FreePool().
+
+  If HiiHandle is NULL, then ASSERT().
+  If StringId is 0, then ASSET.
+
+  @param[in]  HiiHandle         A handle that was previously registered in the HII Database.
+  @param[in]  StringId          The identifier of the string to retrieved from the string
+                                package associated with HiiHandle.
+  @param[in]  Language          The language of the string to retrieve.  If this parameter
+                                is NULL, then the current platform language is used.  The
+                                format of Language must follow the language format assumed
+                                the HII Database.
+  @param[in]  TryBestLanguage   If TRUE, try to get the best matching language from all
+                                supported languages.
+
+
+  @retval NULL   The string specified by StringId is not present in the string package.
+  @retval Other  The string was returned.
+
+**/
+EFI_STRING
+EFIAPI
+HiiGetStringEx (
+  IN EFI_HII_HANDLE  HiiHandle,
+  IN EFI_STRING_ID   StringId,
+  IN CONST CHAR8     *Language  OPTIONAL,
+  IN BOOLEAN         TryBestLanguage
+  );
 
 /**
   Retrieves a string from a string package named by GUID, in the specified language.


### PR DESCRIPTION
Add HiiGetStringEx and leveraged by HiiGetString function to support
getting string with the best language in optionally. This avoids the
string in x-uefi language is misled to the language defined by
"PlatformLang" or the "Supported Languages". This change is introduced
to support x-uefi keyword language for configuring BIOS setting.

Signed-off-by: Jiaxin Wu <jiaxin.wu@intel.com>
Signed-off-by: Siyuan Fu <siyuan.fu@intel.com>
Signed-off-by: Fan Wang <fan.wang@intel.com>
Signed-off-by: Abner Chang <abner.chang@hpe.com>
Cc: Dandan Bi <dandan.bi@intel.com>
Cc: Eric Dong <eric.dong@intel.com>
Cc: Nickle Wang <nickle.wang@hpe.com>