### PR TITLE
MdePkg/SmiHandlerProfileLibNull: Add MM_STANDALONE support

### DIFF
--- a/MdePkg/Library/SmiHandlerProfileLibNull/SmiHandlerProfileLibNull.c
+++ b/MdePkg/Library/SmiHandlerProfileLibNull/SmiHandlerProfileLibNull.c
@@ -6,7 +6,7 @@
 
 **/
 
-#include <PiSmm.h>
+#include <PiMm.h>
 #include <Library/SmiHandlerProfileLib.h>
 
 /**

--- a/MdePkg/Library/SmiHandlerProfileLibNull/SmiHandlerProfileLibNull.inf
+++ b/MdePkg/Library/SmiHandlerProfileLibNull/SmiHandlerProfileLibNull.inf
@@ -15,7 +15,7 @@
   FILE_GUID                      = B43D1B52-6251-4E6F-82EC-A599A5EE94C1
   MODULE_TYPE                    = DXE_SMM_DRIVER
   VERSION_STRING                 = 1.0
-  LIBRARY_CLASS                  = SmiHandlerProfileLib|DXE_SMM_DRIVER SMM_CORE
+  LIBRARY_CLASS                  = SmiHandlerProfileLib|DXE_SMM_DRIVER SMM_CORE MM_STANDALONE MM_CORE_STANDALONE
 
 #
 # The following information is for reference only and not required by the build tools.


### PR DESCRIPTION
REF:https://bugzilla.tianocore.org/show_bug.cgi?id=3184

Allows the library instance to be linked with MM_STANDALONE modules.

Cc: Eric Dong <eric.dong@intel.com>
Cc: Hao A Wu <hao.a.wu@intel.com>
Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>