### PR TITLE
MdeModulePkg/PciBusDxe: Fix a bug in ProcessOptionRomLight

### DIFF
--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciEnumeratorSupport.c
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciEnumeratorSupport.c
@@ -1168,12 +1168,7 @@ ProcessOptionRomLight (
       ProcessOptionRomLight (Temp);
     }
 
-    PciRomGetImageMapping (Temp);
-
-    //
-    // The OpRom has already been processed in the first round
-    //
-    Temp->AllOpRomProcessed = TRUE;
+    Temp->AllOpRomProcessed = PciRomGetImageMapping (Temp);
 
     CurrentLink = CurrentLink->ForwardLink;
   }


### PR DESCRIPTION
The ProcessOptionRomLight() assumes that OpRom has already been
processed in the previous full enumeration and updates
AllOpRomProcessed flag to TRUE by default. However, this may not
be applicable with other pre-stage boot firmwares.

This will update AllOpRomProcessed flag properly by checking
PciRomGetImageMapping().

Signed-off-by: Aiden Park <aiden.park@intel.com>
Reviewed-by: Ray Ni <ray.ni@intel.com>