### PR TITLE
UefiCpuPkg: Move MigrateGdt from DiscoverMemory to TempRamDone. (CVE-…

### DIFF
--- a/UefiCpuPkg/CpuMpPei/CpuMpPei.c
+++ b/UefiCpuPkg/CpuMpPei/CpuMpPei.c
@@ -430,43 +430,6 @@ GetGdtr (
 }
 
 /**
-  Migrates the Global Descriptor Table (GDT) to permanent memory.
-
-  @retval   EFI_SUCCESS           The GDT was migrated successfully.
-  @retval   EFI_OUT_OF_RESOURCES  The GDT could not be migrated due to lack of available memory.
-
-**/
-EFI_STATUS
-MigrateGdt (
-  VOID
-  )
-{
-  EFI_STATUS          Status;
-  UINTN               GdtBufferSize;
-  IA32_DESCRIPTOR     Gdtr;
-  VOID                *GdtBuffer;
-
-  AsmReadGdtr ((IA32_DESCRIPTOR *) &Gdtr);
-  GdtBufferSize = sizeof (IA32_SEGMENT_DESCRIPTOR) -1 + Gdtr.Limit + 1;
-
-  Status =  PeiServicesAllocatePool (
-              GdtBufferSize,
-              &GdtBuffer
-              );
-  ASSERT (GdtBuffer != NULL);
-  if (EFI_ERROR (Status)) {
-    return EFI_OUT_OF_RESOURCES;
-  }
-
-  GdtBuffer = ALIGN_POINTER (GdtBuffer, sizeof (IA32_SEGMENT_DESCRIPTOR));
-  CopyMem (GdtBuffer, (VOID *) Gdtr.Base, Gdtr.Limit + 1);
-  Gdtr.Base = (UINTN) GdtBuffer;
-  AsmWriteGdtr (&Gdtr);
-
-  return EFI_SUCCESS;
-}
-
-/**
   Initializes CPU exceptions handlers for the sake of stack switch requirement.
 
   This function is a wrapper of InitializeCpuExceptionHandlersEx. It's mainly

--- a/UefiCpuPkg/CpuMpPei/CpuMpPei.inf
+++ b/UefiCpuPkg/CpuMpPei/CpuMpPei.inf
@@ -67,7 +67,6 @@
   gUefiCpuPkgTokenSpaceGuid.PcdCpuStackSwitchExceptionList              ## SOMETIMES_CONSUMES
   gUefiCpuPkgTokenSpaceGuid.PcdCpuKnownGoodStackSize                    ## SOMETIMES_CONSUMES
   gUefiCpuPkgTokenSpaceGuid.PcdCpuApStackSize                           ## SOMETIMES_CONSUMES
-  gEfiMdeModulePkgTokenSpaceGuid.PcdMigrateTemporaryRamFirmwareVolumes  ## CONSUMES
 
 [Depex]
   TRUE

--- a/UefiCpuPkg/CpuMpPei/CpuPaging.c
+++ b/UefiCpuPkg/CpuMpPei/CpuPaging.c
@@ -605,16 +605,8 @@ MemoryDiscoveredPpiNotifyCallback (
 {
   EFI_STATUS              Status;
   BOOLEAN                 InitStackGuard;
-  BOOLEAN                 InterruptState;
   EDKII_MIGRATED_FV_INFO  *MigratedFvInfo;
   EFI_PEI_HOB_POINTERS    Hob;
-
-  if (PcdGetBool (PcdMigrateTemporaryRamFirmwareVolumes)) {
-    InterruptState = SaveAndDisableInterrupts ();
-    Status = MigrateGdt ();
-    ASSERT_EFI_ERROR (Status);
-    SetInterruptState (InterruptState);
-  }
 
   //
   // Paging must be setup first. Otherwise the exception TSS setup during MP

--- a/UefiCpuPkg/SecCore/SecCore.inf
+++ b/UefiCpuPkg/SecCore/SecCore.inf
@@ -77,6 +77,7 @@
 
 [Pcd]
   gUefiCpuPkgTokenSpaceGuid.PcdPeiTemporaryRamStackSize  ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdMigrateTemporaryRamFirmwareVolumes  ## CONSUMES
 
 [UserExtensions.TianoCore."ExtraFiles"]
   SecCoreExtra.uni


### PR DESCRIPTION
…2019-11098)

REF: https://bugzilla.tianocore.org/show_bug.cgi?id=1614
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3160

The GDT still in flash with commit 60b12e69fb1c8c7180fdda92f008248b9ec83db1
after TempRamDone

So move the action to TempRamDone event to avoid reading GDT from flash.

Signed-off-by: Guomin Jiang <guomin.jiang@intel.com>
Cc: Eric Dong <eric.dong@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Cc: Laszlo Ersek <lersek@redhat.com>
Cc: Rahul Kumar <rahul1.kumar@intel.com>
Cc: Debkumar De <debkumar.de@intel.com>
Cc: Harry Han <harry.han@intel.com>
Cc: Catharine West <catharine.west@intel.com>
Reviewed-by: Ray Ni <ray.ni@intel.com>