### PR TITLE
ArmPkg/Library: prevent endless reboot loop with emulated NV varstore

### DIFF
--- a/ArmPkg/Library/PlatformBootManagerLib/PlatformBm.c
+++ b/ArmPkg/Library/PlatformBootManagerLib/PlatformBm.c
@@ -848,11 +848,15 @@ PlatformBootManagerUnableToBoot (
   // If the number of configured boot options has changed, reboot
   // the system so the new boot options will be taken into account
   // while executing the ordinary BDS bootflow sequence.
+  // *Unless* persistent varstore is being emulated, since we would
+  // then end up in an endless reboot loop.
   //
-  if (NewBootOptionCount != OldBootOptionCount) {
-    DEBUG ((DEBUG_WARN, "%a: rebooting after refreshing all boot options\n",
-      __FUNCTION__));
-    gRT->ResetSystem (EfiResetCold, EFI_SUCCESS, 0, NULL);
+  if (!PcdGetBool (PcdEmuVariableNvModeEnable)) {
+    if (NewBootOptionCount != OldBootOptionCount) {
+      DEBUG ((DEBUG_WARN, "%a: rebooting after refreshing all boot options\n",
+        __FUNCTION__));
+      gRT->ResetSystem (EfiResetCold, EFI_SUCCESS, 0, NULL);
+    }
   }
 
   Status = EfiBootManagerGetBootManagerMenu (&BootManagerMenu);

--- a/ArmPkg/Library/PlatformBootManagerLib/PlatformBootManagerLib.inf
+++ b/ArmPkg/Library/PlatformBootManagerLib/PlatformBootManagerLib.inf
@@ -55,6 +55,7 @@
   gEfiMdePkgTokenSpaceGuid.PcdUgaConsumeSupport
 
 [FixedPcd]
+  gEfiMdeModulePkgTokenSpaceGuid.PcdEmuVariableNvModeEnable
   gEfiMdeModulePkgTokenSpaceGuid.PcdFirmwareVersionString
   gEfiMdePkgTokenSpaceGuid.PcdUartDefaultBaudRate
   gEfiMdePkgTokenSpaceGuid.PcdUartDefaultDataBits


### PR DESCRIPTION
If no valid boot options were found, PlatformBootManagerLib refreshes a
set of sane default options and then reboots. However, if there is in
fact no persistent varstore, the same thing happens again on next boot,
and we end up in an endlessly rebooting loop.

So when PcdEmuVariableNvModeEnable is TRUE, skip the reboot step and
enter the setup menu instead.

Cc: Ard Biesheuvel <ardb+tianocore@kernel.org>
Cc: Laszlo Ersek <lersek@redhat.com>
Signed-off-by: Leif Lindholm <leif@nuviainc.com>
Acked-by: Laszlo Ersek <lersek@redhat.com>
Reviewed-by: Ard Biesheuvel <ardb@kernel.org>