### PR TITLE
BaseTools: fix the split output files root dir

### DIFF
--- a/BaseTools/Source/Python/Split/Split.py
+++ b/BaseTools/Source/Python/Split/Split.py
@@ -92,6 +92,27 @@ def getFileSize(filename):
 
     return length
 
+def getoutputfileabs(inputfile, prefix, outputfile,index):
+    inputfile = os.path.abspath(inputfile)
+    if outputfile is None:
+        if prefix is None:
+            outputfileabs = os.path.join(os.path.dirname(inputfile), "{}{}".format(os.path.basename(inputfile),index))
+        else:
+            if os.path.isabs(prefix):
+                outputfileabs = os.path.join(prefix, "{}{}".format(os.path.basename(inputfile),index))
+            else:
+                outputfileabs = os.path.join(os.getcwd(), prefix, "{}{}".format(os.path.basename(inputfile),index))
+    elif not os.path.isabs(outputfile):
+        if prefix is None:
+            outputfileabs = os.path.join(os.getcwd(), outputfile)
+        else:
+            if os.path.isabs(prefix):
+                outputfileabs = os.path.join(prefix, outputfile)
+            else:
+                outputfileabs = os.path.join(os.getcwd(), prefix, outputfile)
+    else:
+        outputfileabs = outputfile
+    return outputfileabs
 
 def splitFile(inputfile, position, outputdir=None, outputfile1=None, outputfile2=None):
     '''
@@ -99,8 +120,6 @@ def splitFile(inputfile, position, outputdir=None, outputfile1=None, outputfile2
     '''
     logger = logging.getLogger('Split')
 
-    inputfile = os.path.abspath(inputfile)
-    workspace = os.path.dirname(inputfile)
     if not os.path.exists(inputfile):
         logger.error("File Not Found: %s" % inputfile)
         raise(Exception)
@@ -110,44 +129,33 @@ def splitFile(inputfile, position, outputdir=None, outputfile1=None, outputfile2
             "The firstfile and the secondfile can't be the same: %s" % outputfile1)
         raise(Exception)
 
-    if not outputdir:
-        outputdir = workspace
-    elif not os.path.isabs(outputdir):
-        outputdir = os.path.join(workspace, outputdir)
-
     # Create dir for the output files
     try:
-        if not outputfile1:
-            outputfile1 = os.path.abspath(os.path.join(
-                outputdir, "{}1".format(os.path.basename(inputfile))))
-        else:
-            outputfile1 = os.path.abspath(os.path.join(outputdir, outputfile1))
-        outputdir = os.path.dirname(outputfile1)
-        if not os.path.exists(outputdir):
-            os.makedirs(outputdir)
 
-        if not outputfile2:
-            outputfile2 = os.path.abspath(os.path.join(
-                outputdir, "{}2".format(os.path.basename(inputfile))))
-        else:
-            outputfile2 = os.path.abspath(os.path.join(outputdir, outputfile2))
-        outputdir = os.path.dirname(outputfile2)
-        if not os.path.exists(outputdir):
-            os.makedirs(outputdir)
+        outputfile1 = getoutputfileabs(inputfile, outputdir, outputfile1,1)
+        outputfolder = os.path.dirname(outputfile1)
+        if not os.path.exists(outputfolder):
+            os.makedirs(outputfolder)
+
+        outputfile2 = getoutputfileabs(inputfile, outputdir, outputfile2,2)
+        outputfolder = os.path.dirname(outputfile2)
+        if not os.path.exists(outputfolder):
+            os.makedirs(outputfolder)
+
     except Exception as e:
-        logger.error("Can't make dir: %s" % outputdir)
+        logger.error("Can't make dir: %s" % outputfolder)
         raise(e)
 
     if position <= 0:
-        if outputfile2 != inputfile:
-            shutil.copy2(inputfile, outputfile2)
+        if outputfile2 != os.path.abspath(inputfile):
+            shutil.copy2(os.path.abspath(inputfile), outputfile2)
         with open(outputfile1, "wb") as fout:
             fout.write(b'')
     else:
         inputfilesize = getFileSize(inputfile)
         if position >= inputfilesize:
-            if outputfile1 != inputfile:
-                shutil.copy2(inputfile, outputfile1)
+            if outputfile1 != os.path.abspath(inputfile):
+                shutil.copy2(os.path.abspath(inputfile), outputfile1)
             with open(outputfile2, "wb") as fout:
                 fout.write(b'')
         else:

--- a/BaseTools/Source/Python/tests/Split/test_split.py
+++ b/BaseTools/Source/Python/tests/Split/test_split.py
@@ -18,26 +18,27 @@ import struct as st
 
 class TestSplit(unittest.TestCase):
     def setUp(self):
-        self.WORKSPACE = tempfile.mkdtemp()
-        self.binary_file = os.path.join(self.WORKSPACE, "Binary.bin")
+        self.tmpdir = tempfile.mkdtemp()
+        self.binary_file = os.path.join(self.tmpdir, "Binary.bin")
         self.create_inputfile()
 
     def tearDown(self):
-        if os.path.exists(self.WORKSPACE):
-            shutil.rmtree(self.WORKSPACE)
+        if os.path.exists(self.tmpdir):
+            shutil.rmtree(self.tmpdir)
 
     def test_splitFile_position(self):
         position = [-1, 0, 256, 512, 700, 1024, 2048]
         result = [(0, 1024), (0, 1024), (256, 768),
                   (512, 512), (700, 324), (1024, 0), (1024, 0)]
+        outputfolder = self.tmpdir
         for index, po in enumerate(position):
             try:
                 sp.splitFile(self.binary_file, po)
             except Exception as e:
                 self.assertTrue(False, msg="splitFile function error")
 
-            output1 = os.path.join(self.WORKSPACE, "Binary.bin1")
-            output2 = os.path.join(self.WORKSPACE, "Binary.bin2")
+            output1 = os.path.join(outputfolder, "Binary.bin1")
+            output2 = os.path.join(outputfolder, "Binary.bin2")
             with open(output1, "rb") as f1:
                 size1 = len(f1.read())
             with open(output2, "rb") as f2:
@@ -53,58 +54,61 @@ class TestSplit(unittest.TestCase):
                 fout.write(st.pack("<H", i))
 
     def test_splitFile_outputfile(self):
-        output = [None, "Binary.bin", "Binary1.bin", r"output/Binary1.bin",
-                  os.path.join(self.WORKSPACE, r"output/Binary1.bin")]
-        for o in output:
+        output = [
+            None,
+            "Binary.bin",
+            "Binary1.bin",
+            r"output/Binary1.bin",
+            os.path.abspath( r"output/Binary1.bin")
+            ]
+        expected_output = [
+            os.path.join(os.path.dirname(self.binary_file),"Binary.bin1" ),
+            os.path.join(os.getcwd(),"Binary.bin"),
+            os.path.join(os.getcwd(),"Binary1.bin"),
+            os.path.join(os.getcwd(),r"output/Binary1.bin"),
+            os.path.join(os.path.abspath( r"output/Binary1.bin"))
+            ]
+        for index, o in enumerate(output):
             try:
                 sp.splitFile(self.binary_file, 123, outputfile1=o)
             except Exception as e:
                 self.assertTrue(False, msg="splitFile function error")
-            if o is None:
-                self.assertTrue(os.path.exists(
-                    os.path.join(self.WORKSPACE, "Binary.bin1")))
-            else:
-                if os.path.isabs(o):
-                    self.assertTrue(os.path.exists(o))
-                else:
-                    self.assertTrue(os.path.exists(
-                        os.path.join(self.WORKSPACE, o)))
-            self.create_inputfile()
 
-            try:
-                sp.splitFile(self.binary_file, 123, outputfile2=o)
-            except Exception as e:
-                self.assertTrue(False, msg="splitFile function error")
-            if o is None:
-                self.assertTrue(os.path.exists(
-                    os.path.join(self.WORKSPACE, "Binary.bin2")))
-            else:
-                if os.path.isabs(o):
-                    self.assertTrue(os.path.exists(o))
-                else:
-                    self.assertTrue(os.path.exists(
-                        os.path.join(self.WORKSPACE, o)))
+            self.assertTrue(os.path.exists(expected_output[index]))
             self.create_inputfile()
 
     def test_splitFile_outputfolder(self):
-        outputfolder = [None, "output", r"output1/output2",
-                        os.path.join(self.WORKSPACE, "output")]
-        for o in outputfolder:
+        outputfolder = [
+            None,
+            "output",
+            r"output1/output2",
+            os.path.abspath("output"),
+            "output"
+            ]
+        output = [
+            None,
+            None,
+            "Binary1.bin",
+            r"output/Binary1.bin",
+            os.path.abspath( r"output_1/Binary1.bin")
+            ]
+
+        expected_output = [
+            os.path.join(os.path.dirname(self.binary_file),"Binary.bin1" ),
+            os.path.join(os.getcwd(),"output", "Binary.bin1"),
+            os.path.join(os.getcwd(), r"output1/output2" , "Binary1.bin"),
+            os.path.join(os.getcwd(),r"output", "output/Binary1.bin"),
+            os.path.join(os.path.abspath( r"output/Binary1.bin"))
+            ]
+
+        for index, o in enumerate(outputfolder):
             try:
-                sp.splitFile(self.binary_file, 123, outputdir=o)
+                sp.splitFile(self.binary_file, 123, outputdir=o,outputfile1=output[index])
             except Exception as e:
                 self.assertTrue(False, msg="splitFile function error")
 
-            if o is None:
-                self.assertTrue(os.path.exists(
-                    os.path.join(self.WORKSPACE, "Binary.bin1")))
-            else:
-                if os.path.isabs(o):
-                    self.assertTrue(os.path.exists(
-                        os.path.join(o, "Binary.bin1")))
-                else:
-                    self.assertTrue(os.path.exists(
-                        os.path.join(self.WORKSPACE, o, "Binary.bin1")))
+            self.assertTrue(os.path.exists(expected_output[index]))
+            self.create_inputfile()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
If the output file path is a relative path, the split
tool will create the output file under the input file path.
But the expected behavior for this case is the output file
should be relative to the current directory. This patch will
fix this bug.

If the output file path is not specified and output prefix is not
specified, the output file should be under the input file path

Signed-off-by: Bob Feng <bob.c.feng@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Yuwei Chen <yuwei.chen@intel.com>