### PR TITLE
ArmPkg: Add Universal/Smbios, and related changes 

### DIFF
--- a/ArmPkg/ArmPkg.dec
+++ b/ArmPkg/ArmPkg.dec
@@ -116,6 +116,20 @@
   gArmTokenSpaceGuid.PcdArmPrimaryCore|0|UINT32|0x00000037
 
   #
+  # SMBIOS PCDs
+  #
+  gArmTokenSpaceGuid.PcdSystemProductName|L""|VOID*|0x30000053
+  gArmTokenSpaceGuid.PcdSystemVersion|L""|VOID*|0x30000054
+  gArmTokenSpaceGuid.PcdBaseBoardManufacturer|L""|VOID*|0x30000055
+  gArmTokenSpaceGuid.PcdBaseBoardProductName|L""|VOID*|0x30000056
+  gArmTokenSpaceGuid.PcdBaseBoardVersion|L""|VOID*|0x30000057
+  gArmTokenSpaceGuid.PcdProcessorManufacturer|L""|VOID*|0x30000071
+  gArmTokenSpaceGuid.PcdProcessorVersion|L""|VOID*|0x30000072
+  gArmTokenSpaceGuid.PcdProcessorSerialNumber|L""|VOID*|0x30000073
+  gArmTokenSpaceGuid.PcdProcessorAssetTag|L""|VOID*|0x30000074
+  gArmTokenSpaceGuid.PcdProcessorPartNumber|L""|VOID*|0x30000075
+
+  #
   # ARM L2x0 PCDs
   #
   gArmTokenSpaceGuid.PcdL2x0ControllerBase|0|UINT32|0x0000001B
@@ -214,6 +228,9 @@
 
   gArmTokenSpaceGuid.PcdMmBufferBase|0|UINT64|0x00000045
   gArmTokenSpaceGuid.PcdMmBufferSize|0|UINT64|0x00000046
+
+  gArmTokenSpaceGuid.PcdSystemBiosRelease|0xFFFF|UINT16|0x30000058
+  gArmTokenSpaceGuid.PcdEmbeddedControllerFirmwareRelease|0xFFFF|UINT16|0x30000059
 
 [PcdsFixedAtBuild.common, PcdsDynamic.common]
   #

--- a/ArmPkg/ArmPkg.dsc
+++ b/ArmPkg/ArmPkg.dsc
@@ -149,6 +149,7 @@
   ArmPkg/Drivers/ArmScmiDxe/ArmScmiDxe.inf
 
   ArmPkg/Universal/Smbios/ProcessorSubClassDxe/ProcessorSubClassDxe.inf
+  ArmPkg/Universal/Smbios/SmbiosMiscDxe/SmbiosMiscDxe.inf
 
 [Components.AARCH64]
   ArmPkg/Drivers/MmCommunicationDxe/MmCommunication.inf

--- a/ArmPkg/ArmPkg.dsc
+++ b/ArmPkg/ArmPkg.dsc
@@ -148,6 +148,8 @@
   ArmPkg/Drivers/ArmCrashDumpDxe/ArmCrashDumpDxe.inf
   ArmPkg/Drivers/ArmScmiDxe/ArmScmiDxe.inf
 
+  ArmPkg/Universal/Smbios/ProcessorSubClassDxe/ProcessorSubClassDxe.inf
+
 [Components.AARCH64]
   ArmPkg/Drivers/MmCommunicationDxe/MmCommunication.inf
   ArmPkg/Library/ArmMmuLib/ArmMmuPeiLib.inf

--- a/ArmPkg/ArmPkg.dsc
+++ b/ArmPkg/ArmPkg.dsc
@@ -84,6 +84,8 @@
 
   ArmMtlLib|ArmPkg/Library/ArmMtlNullLib/ArmMtlNullLib.inf
 
+  OemMiscLib|ArmPkg/Universal/Smbios/OemMiscLibNull/OemMiscLibNull.inf
+
 [LibraryClasses.common.PEIM]
   HobLib|MdePkg/Library/PeiHobLib/PeiHobLib.inf
   PeimEntryPoint|MdePkg/Library/PeimEntryPoint/PeimEntryPoint.inf

--- a/ArmPkg/Include/Chipset/AArch64.h
+++ b/ArmPkg/Include/Chipset/AArch64.h
@@ -112,6 +112,10 @@
 #define ARM_VECTOR_LOW_A32_FIQ  0x700
 #define ARM_VECTOR_LOW_A32_SERR 0x780
 
+// The ID_AA64MMFR2_EL1 register was added in ARMv8.2. Since we
+// build for ARMv8.0, we need to define the register here.
+#define ID_AA64MMFR2_EL1 S3_0_C0_C7_2
+
 #define VECTOR_BASE(tbl)          \
   .section .text.##tbl##,"ax";    \
   .align 11;                      \

--- a/ArmPkg/Include/IndustryStandard/ArmStdSmc.h
+++ b/ArmPkg/Include/IndustryStandard/ArmStdSmc.h
@@ -1,9 +1,13 @@
 /** @file
 *
+*  Copyright (c) 2020, NUVIA Inc. All rights reserved.<BR>
 *  Copyright (c) 2012-2017, ARM Limited. All rights reserved.
 *
 *  SPDX-License-Identifier: BSD-2-Clause-Patent
 *
+* @par Revision Reference:
+*  - SMC Calling Convention version 1.2
+*    (https://developer.arm.com/documentation/den0028/c/?lang=en)
 **/
 
 #ifndef __ARM_STD_SMC_H__
@@ -51,6 +55,18 @@
 #define ARM_SMC_MM_RET_INVALID_PARAMS      -2
 #define ARM_SMC_MM_RET_DENIED              -3
 #define ARM_SMC_MM_RET_NO_MEMORY           -4
+
+// ARM Architecture Calls
+#define SMCCC_VERSION           0x80000000
+#define SMCCC_ARCH_FEATURES     0x80000001
+#define SMCCC_ARCH_SOC_ID       0x80000002
+#define SMCCC_ARCH_WORKAROUND_1 0x80008000
+#define SMCCC_ARCH_WORKAROUND_2 0x80007FFF
+
+#define SMC_ARCH_CALL_SUCCESS            0
+#define SMC_ARCH_CALL_NOT_SUPPORTED     -1
+#define SMC_ARCH_CALL_NOT_REQUIRED      -2
+#define SMC_ARCH_CALL_INVALID_PARAMETER -3
 
 /*
  * Power State Coordination Interface (PSCI) calls cover a subset of the

--- a/ArmPkg/Include/Library/ArmLib.h
+++ b/ArmPkg/Include/Library/ArmLib.h
@@ -725,6 +725,17 @@ ArmHasGicSystemRegisters (
   VOID
   );
 
+/** Checks if CCIDX is implemented.
+
+   @retval TRUE  CCIDX is implemented.
+   @retval FALSE CCIDX is not implemented.
+**/
+BOOLEAN
+EFIAPI
+ArmHasCcidx (
+  VOID
+  );
+
 #ifdef MDE_CPU_ARM
 ///
 /// AArch32-only ID Register Helper functions

--- a/ArmPkg/Include/Library/ArmLib.h
+++ b/ArmPkg/Include/Library/ArmLib.h
@@ -109,6 +109,10 @@ typedef enum {
 #define GET_MPID(ClusterId, CoreId)   (((ClusterId) << 8) | (CoreId))
 #define PRIMARY_CORE_ID       (PcdGet32(PcdArmPrimaryCore) & ARM_CORE_MASK)
 
+// The ARM Architecture Reference Manual for ARMv8-A defines up
+// to 7 levels of cache, L1 through L7.
+#define MAX_ARM_CACHE_LEVEL   7
+
 UINTN
 EFIAPI
 ArmDataCacheLineLength (

--- a/ArmPkg/Include/Library/OemMiscLib.h
+++ b/ArmPkg/Include/Library/OemMiscLib.h
@@ -1,0 +1,167 @@
+/** @file
+*
+*  Copyright (c) 2021, NUVIA Inc. All rights reserved.
+*  Copyright (c) 2015, Hisilicon Limited. All rights reserved.
+*  Copyright (c) 2015, Linaro Limited. All rights reserved.
+*
+*  SPDX-License-Identifier: BSD-2-Clause-Patent
+*
+**/
+
+
+#ifndef OEM_MISC_LIB_H_
+#define OEM_MISC_LIB_H_
+
+#include <Uefi.h>
+#include <IndustryStandard/SmBios.h>
+
+typedef enum
+{
+  CpuCacheL1 = 1,
+  CpuCacheL2,
+  CpuCacheL3,
+  CpuCacheL4,
+  CpuCacheL5,
+  CpuCacheL6,
+  CpuCacheL7,
+  CpuCacheLevelMax
+} OEM_MISC_CPU_CACHE_LEVEL;
+
+typedef struct
+{
+  UINT8 Voltage;        ///< Processor voltage
+  UINT16 CurrentSpeed;  ///< Current clock speed in MHz
+  UINT16 MaxSpeed;      ///< Maximum clock speed in MHz
+  UINT16 ExternalClock; ///< External clock speed in MHz
+  UINT16 CoreCount;     ///< Number of cores available
+  UINT16 CoresEnabled;  ///< Number of cores enabled
+  UINT16 ThreadCount;   ///< Number of threads per processor
+} OEM_MISC_PROCESSOR_DATA;
+
+typedef enum
+{
+    ProductNameType01,
+    SerialNumType01,
+    UuidType01,
+    SystemManufacturerType01,
+    SkuNumberType01,
+    FamilyType01,
+    AssertTagType02,
+    SerialNumberType02,
+    BoardManufacturerType02,
+    SkuNumberType02,
+    ChassisLocationType02,
+    AssetTagType03,
+    SerialNumberType03,
+    VersionType03,
+    ChassisTypeType03,
+    ManufacturerType03,
+    SkuNumberType03,
+    SmbiosHiiStringFieldMax
+} OEM_MISC_SMBIOS_HII_STRING_FIELD;
+
+/*
+ * The following are functions that the each platform needs to
+ * implement in its OemMiscLib library.
+ */
+
+/** Gets the CPU frequency of the specified processor.
+
+  @param ProcessorIndex Index of the processor to get the frequency for.
+
+  @return               CPU frequency in Hz
+**/
+EFIAPI
+UINTN
+OemGetCpuFreq (
+  IN UINT8 ProcessorIndex
+  );
+
+/** Gets information about the specified processor and stores it in
+    the structures provided.
+
+  @param ProcessorIndex  Index of the processor to get the information for.
+  @param ProcessorStatus Processor status.
+  @param ProcessorCharacteristics Processor characteritics.
+  @param MiscProcessorData        Miscellaneous processor information.
+
+  @return  TRUE on success, FALSE on failure.
+**/
+EFIAPI
+BOOLEAN
+OemGetProcessorInformation (
+  IN UINTN ProcessorIndex,
+  IN OUT PROCESSOR_STATUS_DATA *ProcessorStatus,
+  IN OUT PROCESSOR_CHARACTERISTIC_FLAGS *ProcessorCharacteristics,
+  IN OUT OEM_MISC_PROCESSOR_DATA *MiscProcessorData
+  );
+
+/** Gets information about the cache at the specified cache level.
+
+  @param ProcessorIndex The processor to get information for.
+  @param CacheLevel     The cache level to get information for.
+  @param DataCache  Whether the cache is a data cache.
+  @param UnifiedCache Whether the cache is a unified cache.
+  @param SmbiosCacheTable The SMBIOS Type7 cache information structure.
+
+  @return TRUE on success, FALSE on failure.
+**/
+EFIAPI
+BOOLEAN
+OemGetCacheInformation (
+  IN UINT8   ProcessorIndex,
+  IN UINT8   CacheLevel,
+  IN BOOLEAN DataCache,
+  IN BOOLEAN UnifiedCache,
+  IN OUT SMBIOS_TABLE_TYPE7 *SmbiosCacheTable
+  );
+
+/** Gets the maximum number of sockets supported by the platform.
+
+  @return The maximum number of sockets.
+**/
+EFIAPI
+UINT8
+OemGetProcessorMaxSockets (
+  VOID
+  );
+
+/** Gets the type of chassis for the system.
+
+  @param ChassisType The type of the chassis.
+
+  @retval EFI_SUCCESS The chassis type was fetched successfully.
+**/
+EFIAPI
+EFI_STATUS
+OemGetChassisType (
+  OUT UINT8 *ChassisType
+  );
+
+/** Returns whether the specified processor is present or not.
+
+  @param ProcessIndex The processor index to check.
+
+  @return TRUE is the processor is present, FALSE otherwise.
+**/
+EFIAPI
+BOOLEAN
+OemIsSocketPresent (
+  IN UINTN ProcessorIndex
+  );
+
+/** Updates the HII string for the specified field.
+
+  @param mHiiHandle    The HII handle.
+  @param TokenToUpdate The string to update.
+  @param Offset        The field to get information about.
+**/
+EFIAPI
+VOID
+OemUpdateSmbiosInfo (
+  IN EFI_HII_HANDLE    HiiHandle,
+  IN EFI_STRING_ID     TokenToUpdate,
+  IN OEM_MISC_SMBIOS_HII_STRING_FIELD Offset
+  );
+
+#endif // OEM_MISC_LIB_H_

--- a/ArmPkg/Library/ArmLib/AArch64/AArch64Lib.c
+++ b/ArmPkg/Library/ArmLib/AArch64/AArch64Lib.c
@@ -2,7 +2,7 @@
 
   Copyright (c) 2008 - 2009, Apple Inc. All rights reserved.<BR>
   Portions copyright (c) 2011 - 2014, ARM Ltd. All rights reserved.<BR>
-  Copyright (c) 2020, NUVIA Inc. All rights reserved.<BR>
+  Copyright (c) 2021, NUVIA Inc. All rights reserved.<BR>
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -86,4 +86,21 @@ ArmHasGicSystemRegisters (
   )
 {
   return ((ArmReadIdAA64Pfr0 () & AARCH64_PFR0_GIC) != 0);
+}
+
+/** Checks if CCIDX is implemented.
+
+   @retval TRUE  CCIDX is implemented.
+   @retval FALSE CCIDX is not implemented.
+**/
+BOOLEAN
+EFIAPI
+ArmHasCcidx (
+  VOID
+  )
+{
+  UINTN Mmfr2;
+
+  Mmfr2 = ArmReadIdAA64Mmfr2 ();
+  return (((Mmfr2 >> 20) & 0xF) == 1) ? TRUE : FALSE;
 }

--- a/ArmPkg/Library/ArmLib/AArch64/AArch64Lib.h
+++ b/ArmPkg/Library/ArmLib/AArch64/AArch64Lib.h
@@ -41,5 +41,16 @@ EFIAPI
 ArmReadIdAA64Pfr0 (
   VOID
   );
+
+/** Reads the ID_AA64MMFR2_EL1 register.
+
+   @return The contents of the ID_AA64MMFR2_EL1 register.
+**/
+UINTN
+EFIAPI
+ArmReadIdAA64Mmfr2 (
+  VOID
+  );
+
 #endif // __AARCH64_LIB_H__
 

--- a/ArmPkg/Library/ArmLib/AArch64/AArch64Support.S
+++ b/ArmPkg/Library/ArmLib/AArch64/AArch64Support.S
@@ -425,6 +425,9 @@ ASM_FUNC(ArmCallWFI)
   wfi
   ret
 
+ASM_FUNC(ArmReadIdAA64Mmfr2)
+  mrs   x0, ID_AA64MMFR2_EL1           // read EL1 MMFR2
+  ret
 
 ASM_FUNC(ArmReadMpidr)
   mrs   x0, mpidr_el1           // read EL1 MPIDR

--- a/ArmPkg/Library/ArmLib/AArch64/ArmLibSupportV8.S
+++ b/ArmPkg/Library/ArmLib/AArch64/ArmLibSupportV8.S
@@ -84,7 +84,7 @@ ASM_FUNC(ArmDisableAllExceptions)
   ret
 
 
-// UINT32
+// UINTN
 // ReadCCSIDR (
 //   IN UINT32 CSSELR
 //   )

--- a/ArmPkg/Library/ArmLib/Arm/ArmLibSupportV7.S
+++ b/ArmPkg/Library/ArmLib/Arm/ArmLibSupportV7.S
@@ -60,6 +60,10 @@ ASM_FUNC(ArmDisableInterrupts)
   isb
   bx      LR
 
+ASM_FUNC(ArmReadIdMmfr4)
+  mrc    p15,0,r0,c0,c2,6     @ Read ID_MMFR4 Register
+  bx     lr
+
 // UINT32
 // ReadCCSIDR (
 //   IN UINT32 CSSELR

--- a/ArmPkg/Library/ArmLib/Arm/ArmLibSupportV7.S
+++ b/ArmPkg/Library/ArmLib/Arm/ArmLibSupportV7.S
@@ -64,7 +64,7 @@ ASM_FUNC(ArmReadIdMmfr4)
   mrc    p15,0,r0,c0,c2,6     @ Read ID_MMFR4 Register
   bx     lr
 
-// UINT32
+// UINTN
 // ReadCCSIDR (
 //   IN UINT32 CSSELR
 //   )

--- a/ArmPkg/Library/ArmLib/Arm/ArmLibSupportV7.S
+++ b/ArmPkg/Library/ArmLib/Arm/ArmLibSupportV7.S
@@ -75,6 +75,16 @@ ASM_FUNC(ReadCCSIDR)
   bx  lr
 
 // UINT32
+// ReadCCSIDR2 (
+//   IN UINT32 CSSELR
+//   )
+ASM_FUNC(ReadCCSIDR2)
+  mcr p15,2,r0,c0,c0,0   @ Write Cache Size Selection Register (CSSELR)
+  isb
+  mrc p15,1,r0,c0,c0,2   @ Read current CP15 Cache Size ID Register (CCSIDR2)
+  bx  lr
+
+// UINT32
 // ReadCLIDR (
 //   IN UINT32 CSSELR
 //   )

--- a/ArmPkg/Library/ArmLib/Arm/ArmLibSupportV7.asm
+++ b/ArmPkg/Library/ArmLib/Arm/ArmLibSupportV7.asm
@@ -79,6 +79,16 @@
   bx  lr
 
 // UINT32
+// ReadCCSIDR2 (
+//   IN UINT32 CSSELR
+//   )
+ RVCT_ASM_EXPORT ReadCCSIDR2
+  mcr p15,2,r0,c0,c0,0 ; Write Cache Size Selection Register (CSSELR)
+  isb
+  mrc p15,1,r0,c0,c0,2 ; Read current CP15 Cache Size ID Register (CCSIDR2)
+  bx  lr
+
+// UINT32
 // ReadCLIDR (
 //   IN UINT32 CSSELR
 //   )

--- a/ArmPkg/Library/ArmLib/Arm/ArmLibSupportV7.asm
+++ b/ArmPkg/Library/ArmLib/Arm/ArmLibSupportV7.asm
@@ -68,7 +68,7 @@
   mrc    p15,0,r0,c0,c2,6     ; Read ID_MMFR4 Register
   bx     LR
 
-// UINT32
+// UINTN
 // ReadCCSIDR (
 //   IN UINT32 CSSELR
 //   )

--- a/ArmPkg/Library/ArmLib/Arm/ArmLibSupportV7.asm
+++ b/ArmPkg/Library/ArmLib/Arm/ArmLibSupportV7.asm
@@ -64,6 +64,10 @@
   isb
   bx      LR
 
+ RVCT_ASM_EXPORT ArmReadIdMmfr4
+  mrc    p15,0,r0,c0,c2,6     ; Read ID_MMFR4 Register
+  bx     LR
+
 // UINT32
 // ReadCCSIDR (
 //   IN UINT32 CSSELR

--- a/ArmPkg/Library/ArmLib/Arm/ArmV7Lib.c
+++ b/ArmPkg/Library/ArmLib/Arm/ArmV7Lib.c
@@ -2,7 +2,7 @@
 
   Copyright (c) 2008 - 2009, Apple Inc. All rights reserved.<BR>
   Copyright (c) 2011 - 2014, ARM Limited. All rights reserved.
-  Copyright (c) 2020, NUVIA Inc. All rights reserved.<BR>
+  Copyright (c) 2021, NUVIA Inc. All rights reserved.<BR>
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -101,4 +101,21 @@ ArmHasSecurityExtensions (
   )
 {
   return ((ArmReadIdPfr1 () & ARM_PFR1_SEC) != 0);
+}
+
+/** Checks if CCIDX is implemented.
+
+   @retval TRUE  CCIDX is implemented.
+   @retval FALSE CCIDX is not implemented.
+**/
+BOOLEAN
+EFIAPI
+ArmHasCcidx (
+  VOID
+  )
+{
+  UINTN Mmfr4;
+
+  Mmfr4 = ArmReadIdMmfr4 ();
+  return (((Mmfr4 >> 24) & 0xF) == 1) ? TRUE : FALSE;
 }

--- a/ArmPkg/Library/ArmLib/Arm/ArmV7Lib.h
+++ b/ArmPkg/Library/ArmLib/Arm/ArmV7Lib.h
@@ -48,9 +48,13 @@ ArmCleanInvalidateDataCacheEntryBySetWay (
   IN  UINTN   SetWayFormat
   );
 
-UINTN
+/** Reads the ID_MMFR4 register.
+
+   @return The contents of the ID_MMFR4 register.
+**/
+UINT32
 EFIAPI
-ArmReadIdPfr0 (
+ArmReadIdMmfr4 (
   VOID
   );
 

--- a/ArmPkg/Library/ArmLib/ArmLibPrivate.h
+++ b/ArmPkg/Library/ArmLib/ArmLibPrivate.h
@@ -61,7 +61,14 @@ CPSRRead (
   VOID
   );
 
-UINT32
+/** Reads the CCSIDR register for the specified cache.
+
+  @param CSSELR The CSSELR cache selection register value.
+
+  @return The contents of the CCSIDR_EL1 register for the specified cache, when in AARCH64 mode.
+          Returns the contents of the CCSIDR register in AARCH32 mode.
+**/
+UINTN
 ReadCCSIDR (
   IN UINT32 CSSELR
   );

--- a/ArmPkg/Library/ArmLib/ArmLibPrivate.h
+++ b/ArmPkg/Library/ArmLib/ArmLibPrivate.h
@@ -170,6 +170,17 @@ ReadCCSIDR (
   IN UINT32 CSSELR
   );
 
+/** Reads the CCSIDR2 for the specified cache.
+
+  @param CSSELR The CSSELR cache selection register value
+
+  @return The contents of the CCSIDR2 register for the specified cache.
+**/
+UINT32
+ReadCCSIDR2 (
+  IN UINT32 CSSELR
+  );
+
 UINT32
 ReadCLIDR (
   VOID

--- a/ArmPkg/Library/ArmLib/ArmLibPrivate.h
+++ b/ArmPkg/Library/ArmLib/ArmLibPrivate.h
@@ -1,5 +1,7 @@
 /** @file
+  ArmLibPrivate.h
 
+  Copyright (c) 2020, NUVIA Inc. All rights reserved.<BR>
   Copyright (c) 2008 - 2009, Apple Inc. All rights reserved.<BR>
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -49,6 +51,101 @@
 #define CACHE_ARCHITECTURE(x)                 (((x) >> 24) & 0x01)
 #define CACHE_ARCHITECTURE_UNIFIED            (0UL)
 #define CACHE_ARCHITECTURE_SEPARATE           (1UL)
+
+
+/// Defines the structure of the CSSELR (Cache Size Selection) register
+typedef union {
+  struct {
+    UINT32    InD       :1;  ///< Instruction not Data bit
+    UINT32    Level     :3;  ///< Cache level (zero based)
+    UINT32    TnD       :1;  ///< Allocation not Data bit
+    UINT32    Reserved  :27; ///< Reserved, RES0
+  } Bits; ///< Bitfield definition of the register
+  UINT32 Data; ///< The entire 32-bit value
+} CSSELR_DATA;
+
+/// The cache type values for the InD field of the CSSELR register
+typedef enum
+{
+  /// Select the data or unified cache
+  CsselrCacheTypeDataOrUnified = 0,
+  /// Select the instruction cache
+  CsselrCacheTypeInstruction,
+  CsselrCacheTypeMax
+} CSSELR_CACHE_TYPE;
+
+/// Defines the structure of the CCSIDR (Current Cache Size ID) register
+typedef union {
+  struct {
+    UINT64    LineSize           :3;  ///< Line size (Log2(Num bytes in cache) - 4)
+    UINT64    Associativity      :10; ///< Associativity - 1
+    UINT64    NumSets            :15; ///< Number of sets in the cache -1
+    UINT64    Unknown            :4;  ///< Reserved, UNKNOWN
+    UINT64    Reserved           :32; ///< Reserved, RES0
+  } BitsNonCcidx; ///< Bitfield definition of the register when FEAT_CCIDX is not supported.
+  struct {
+    UINT64    LineSize           :3;  ///< Line size (Log2(Num bytes in cache) - 4)
+    UINT64    Associativity      :21; ///< Associativity - 1
+    UINT64    Reserved1          :8;  ///< Reserved, RES0
+    UINT64    NumSets            :24; ///< Number of sets in the cache -1
+    UINT64    Reserved2          :8;  ///< Reserved, RES0
+  } BitsCcidxAA64; ///< Bitfield definition of the register when FEAT_IDX is supported.
+  struct {
+    UINT64    LineSize           : 3;
+    UINT64    Associativity      : 21;
+    UINT64    Reserved           : 8;
+    UINT64    Unallocated        : 32;
+  } BitsCcidxAA32;
+  UINT64 Data; ///< The entire 64-bit value
+} CCSIDR_DATA;
+
+/// Defines the structure of the AARCH32 CCSIDR2 register.
+typedef union {
+  struct {
+    UINT32 NumSets               :24; ///< Number of sets in the cache - 1
+    UINT32 Reserved              :8;  ///< Reserved, RES0
+  } Bits; ///< Bitfield definition of the register
+  UINT32 Data; ///< The entire 32-bit value
+} CCSIDR2_DATA;
+
+/** Defines the structure of the CLIDR (Cache Level ID) register.
+ *
+ * The lower 32 bits are the same for both AARCH32 and AARCH64
+ * so we can use the same structure for both.
+**/
+typedef union {
+  struct {
+    UINT32    Ctype1   : 3; ///< Level 1 cache type
+    UINT32    Ctype2   : 3; ///< Level 2 cache type
+    UINT32    Ctype3   : 3; ///< Level 3 cache type
+    UINT32    Ctype4   : 3; ///< Level 4 cache type
+    UINT32    Ctype5   : 3; ///< Level 5 cache type
+    UINT32    Ctype6   : 3; ///< Level 6 cache type
+    UINT32    Ctype7   : 3; ///< Level 7 cache type
+    UINT32    LoUIS    : 3; ///< Level of Unification Inner Shareable
+    UINT32    LoC      : 3; ///< Level of Coherency
+    UINT32    LoUU     : 3; ///< Level of Unification Uniprocessor
+    UINT32    Icb      : 3; ///< Inner Cache Boundary
+  } Bits; ///< Bitfield definition of the register
+  UINT32 Data; ///< The entire 32-bit value
+} CLIDR_DATA;
+
+/// The cache types reported in the CLIDR register.
+typedef enum {
+  /// No cache is present
+  ClidrCacheTypeNone = 0,
+  /// There is only an instruction cache
+  ClidrCacheTypeInstructionOnly,
+  /// There is only a data cache
+  ClidrCacheTypeDataOnly,
+  /// There are separate data and instruction caches
+  ClidrCacheTypeSeparate,
+  /// There is a unified cache
+  ClidrCacheTypeUnified,
+  ClidrCacheTypeMax
+} CLIDR_CACHE_TYPE;
+
+#define CLIDR_GET_CACHE_TYPE(x, level) ((x >> (3 * (level))) & 0b111)
 
 VOID
 CPSRMaskInsert (

--- a/ArmPkg/Universal/Smbios/OemMiscLibNull/OemMiscLib.c
+++ b/ArmPkg/Universal/Smbios/OemMiscLibNull/OemMiscLib.c
@@ -1,0 +1,144 @@
+/** @file
+*  OemMiscLib.c
+*
+*  Copyright (c) 2021, NUVIA Inc. All rights reserved.
+*  Copyright (c) 2018, Hisilicon Limited. All rights reserved.
+*  Copyright (c) 2018, Linaro Limited. All rights reserved.
+*
+*  SPDX-License-Identifier: BSD-2-Clause-Patent
+*
+**/
+
+#include <Uefi.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/HiiLib.h>
+
+#include <Library/OemMiscLib.h>
+
+
+/** Gets the CPU frequency of the specified processor.
+
+  @param ProcessorIndex Index of the processor to get the frequency for.
+
+  @return               CPU frequency in Hz
+**/
+EFIAPI
+UINTN
+OemGetCpuFreq (
+  IN UINT8 ProcessorIndex
+  )
+{
+  ASSERT (FALSE);
+  return 0;
+}
+
+/** Gets information about the specified processor and stores it in
+    the structures provided.
+
+  @param ProcessorIndex  Index of the processor to get the information for.
+  @param ProcessorStatus Processor status.
+  @param ProcessorCharacteristics Processor characteritics.
+  @param MiscProcessorData        Miscellaneous processor information.
+
+  @return  TRUE on success, FALSE on failure.
+**/
+EFIAPI
+BOOLEAN
+OemGetProcessorInformation (
+  IN UINTN ProcessorIndex,
+  IN OUT PROCESSOR_STATUS_DATA *ProcessorStatus,
+  IN OUT PROCESSOR_CHARACTERISTIC_FLAGS *ProcessorCharacteristics,
+  IN OUT OEM_MISC_PROCESSOR_DATA *MiscProcessorData
+  )
+{
+  ASSERT (FALSE);
+  return TRUE;
+}
+
+/** Gets information about the cache at the specified cache level.
+
+  @param ProcessorIndex The processor to get information for.
+  @param CacheLevel The cache level to get information for.
+  @param DataCache  Whether the cache is a data cache.
+  @param UnifiedCache Whether the cache is a unified cache.
+  @param SmbiosCacheTable The SMBIOS Type7 cache information structure.
+
+  @return TRUE on success, FALSE on failure.
+**/
+EFIAPI
+BOOLEAN
+OemGetCacheInformation (
+  IN UINT8   ProcessorIndex,
+  IN UINT8   CacheLevel,
+  IN BOOLEAN DataCache,
+  IN BOOLEAN UnifiedCache,
+  IN OUT SMBIOS_TABLE_TYPE7 *SmbiosCacheTable
+  )
+{
+  ASSERT (FALSE);
+  return TRUE;
+}
+
+/** Gets the maximum number of sockets supported by the platform.
+
+  @return The maximum number of sockets.
+**/
+EFIAPI
+UINT8
+OemGetProcessorMaxSockets (
+  VOID
+  )
+{
+  ASSERT (FALSE);
+  return 1;
+}
+
+/** Gets the type of chassis for the system.
+
+  @param ChassisType The type of the chassis.
+
+  @retval EFI_SUCCESS The chassis type was fetched successfully.
+**/
+EFI_STATUS
+EFIAPI
+OemGetChassisType (
+  UINT8 *ChassisType
+  )
+{
+  ASSERT (FALSE);
+  *ChassisType = MiscChassisTypeUnknown;
+  return EFI_SUCCESS;
+}
+
+/** Returns whether the specified processor is present or not.
+
+  @param ProcessIndex The processor index to check.
+
+  @return TRUE is the processor is present, FALSE otherwise.
+**/
+EFIAPI
+BOOLEAN
+OemIsSocketPresent (
+  IN UINTN ProcessorIndex
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/** Updates the HII string for the specified field.
+
+  @param mHiiHandle    The HII handle.
+  @param TokenToUpdate The string to update.
+  @param Offset        The field to get information about.
+**/
+EFIAPI
+VOID
+OemUpdateSmbiosInfo (
+  IN EFI_HII_HANDLE mHiiHandle,
+  IN EFI_STRING_ID TokenToUpdate,
+  IN OEM_MISC_SMBIOS_HII_STRING_FIELD Offset
+  )
+{
+  ASSERT (FALSE);
+}

--- a/ArmPkg/Universal/Smbios/OemMiscLibNull/OemMiscLibNull.inf
+++ b/ArmPkg/Universal/Smbios/OemMiscLibNull/OemMiscLibNull.inf
@@ -1,0 +1,31 @@
+#/** @file
+#    OemMiscLib.inf
+#
+#    Copyright (c) 2021, NUVIA Inc. All rights reserved.
+#    Copyright (c) 2018, Hisilicon Limited. All rights reserved.
+#    Copyright (c) 2018, Linaro Limited. All rights reserved.
+#
+#    SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+#**/
+
+[Defines]
+  INF_VERSION                    = 1.29
+  BASE_NAME                      = OemMiscLibNull
+  FILE_GUID                      = e80b8e6b-fffb-4c39-b433-41de67c9d7b8
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = OemMiscLib
+
+[Sources.common]
+  OemMiscLib.c
+
+[Packages]
+  ArmPkg/ArmPkg.dec
+  EmbeddedPkg/EmbeddedPkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  MdePkg/MdePkg.dec
+
+[LibraryClasses]
+  BaseMemoryLib
+

--- a/ArmPkg/Universal/Smbios/ProcessorSubClassDxe/ProcessorSubClass.c
+++ b/ArmPkg/Universal/Smbios/ProcessorSubClassDxe/ProcessorSubClass.c
@@ -1,0 +1,752 @@
+/** @file
+  ProcessorSubClass.c
+
+  Copyright (c) 2021, NUVIA Inc. All rights reserved.<BR>
+  Copyright (c) 2015, Hisilicon Limited. All rights reserved.
+  Copyright (c) 2015, Linaro Limited. All rights reserved.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Uefi.h>
+#include <Protocol/Smbios.h>
+#include <IndustryStandard/ArmStdSmc.h>
+#include <IndustryStandard/SmBios.h>
+#include <Library/ArmLib.h>
+#include <Library/ArmSmcLib.h>
+#include <Library/ArmLib/ArmLibPrivate.h>
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
+#include <Library/HiiLib.h>
+#include <Library/IoLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/OemMiscLib.h>
+#include <Library/PcdLib.h>
+#include <Library/PrintLib.h>
+#include <Library/UefiBootServicesTableLib.h>
+#include <Library/UefiLib.h>
+
+#include "SmbiosProcessor.h"
+
+extern UINT8 ProcessorSubClassStrings[];
+
+#define CACHE_SOCKETED_SHIFT       3
+#define CACHE_LOCATION_SHIFT       5
+#define CACHE_ENABLED_SHIFT        7
+#define CACHE_OPERATION_MODE_SHIFT 8
+
+typedef enum {
+  CacheModeWriteThrough = 0,  ///< Cache is write-through
+  CacheModeWriteBack,         ///< Cache is write-back
+  CacheModeVariesWithAddress, ///< Cache mode varies by address
+  CacheModeUnknown,           ///< Cache mode is unknown
+  CacheModeMax
+} CACHE_OPERATION_MODE;
+
+typedef enum {
+  CacheLocationInternal = 0, ///< Cache is internal to the processor
+  CacheLocationExternal,     ///< Cache is external to the processor
+  CacheLocationReserved,     ///< Reserved
+  CacheLocationUnknown,      ///< Cache location is unknown
+  CacheLocationMax
+} CACHE_LOCATION;
+
+EFI_HII_HANDLE       mHiiHandle;
+
+EFI_SMBIOS_PROTOCOL  *mSmbios;
+
+SMBIOS_TABLE_TYPE4 mSmbiosProcessorTableTemplate = {
+    {                         // Hdr
+      EFI_SMBIOS_TYPE_PROCESSOR_INFORMATION, // Type
+      sizeof (SMBIOS_TABLE_TYPE4), // Length
+      0                       // Handle
+    },
+    1,                        // Socket
+    CentralProcessor,         // ProcessorType
+    ProcessorFamilyIndicatorFamily2, // ProcessorFamily
+    2,                        // ProcessorManufacture
+    {                         // ProcessorId
+      {                       // Signature
+        0
+      },
+      {                       // FeatureFlags
+        0
+      }
+    },
+    3,                        // ProcessorVersion
+    {                         // Voltage
+      0
+    },
+    0,                        // ExternalClock
+    0,                        // MaxSpeed
+    0,                        // CurrentSpeed
+    0,                        // Status
+    ProcessorUpgradeUnknown,  // ProcessorUpgrade
+    0xFFFF,                   // L1CacheHandle
+    0xFFFF,                   // L2CacheHandle
+    0xFFFF,                   // L3CacheHandle
+    4,                        // SerialNumber
+    5,                        // AssetTag
+    6,                        // PartNumber
+    0,                        // CoreCount
+    0,                        //EnabledCoreCount
+    0,                        // ThreadCount
+    0,                        // ProcessorCharacteristics
+    ProcessorFamilyARM,       // ProcessorFamily2
+    0,                        // CoreCount2
+    0,                        // EnabledCoreCount2
+    0                         // ThreadCount2
+};
+
+/** Sets the HII variable `StringId` is `Pcd` isn't empty.
+
+    @param Pcd       The FixedAtBuild PCD that contains the string to fetch.
+    @param StringId  The string identifier to set.
+**/
+#define SET_HII_STRING_IF_PCD_NOT_EMPTY(Pcd, StringId) \
+  do { \
+    CHAR16 *Str; \
+    Str = (CHAR16*)PcdGetPtr (Pcd); \
+    if (StrLen (Str) > 0) { \
+      HiiSetString (mHiiHandle, StringId, Str, NULL); \
+    } \
+  } while (0)
+
+/** Fetches the specified processor's frequency in Hz.
+
+  @param ProcessorNumber The processor number
+
+  @return The clock frequency in MHz
+
+**/
+UINT16
+GetCpuFrequency (
+  IN  UINT8 ProcessorNumber
+  )
+{
+  return (UINT16)(OemGetCpuFreq (ProcessorNumber) / 1000 / 1000);
+}
+
+/** Gets a description of the specified cache.
+
+  @param[in] CacheLevel       Zero-based cache level (e.g. L1 cache is 0).
+  @param[in] DataCache        Cache is a data cache.
+  @param[in] UnifiedCache     Cache is a unified cache.
+  @param[out] CacheSocketStr  The description of the specified cache
+
+  @return The number of Unicode characters in CacheSocketStr not including the
+          terminating NUL.
+**/
+UINTN
+GetCacheSocketStr (
+  IN  UINT8   CacheLevel,
+  IN  BOOLEAN DataCache,
+  IN  BOOLEAN UnifiedCache,
+  OUT CHAR16  *CacheSocketStr
+  )
+{
+  UINTN CacheSocketStrLen;
+
+  if (CacheLevel == CpuCacheL1 && !DataCache && !UnifiedCache) {
+    CacheSocketStrLen = UnicodeSPrint (
+                          CacheSocketStr,
+                          SMBIOS_STRING_MAX_LENGTH - 1,
+                          L"L%x Instruction Cache",
+                          CacheLevel);
+  } else if (CacheLevel == CpuCacheL1 && DataCache) {
+    CacheSocketStrLen = UnicodeSPrint (CacheSocketStr,
+                          SMBIOS_STRING_MAX_LENGTH - 1,
+                          L"L%x Data Cache",
+                          CacheLevel);
+  } else {
+    CacheSocketStrLen = UnicodeSPrint (CacheSocketStr,
+                          SMBIOS_STRING_MAX_LENGTH - 1,
+                          L"L%x Cache",
+                          CacheLevel);
+  }
+
+  return CacheSocketStrLen;
+}
+
+/** Fills in the Type 7 record with the cache architecture information
+    read from the CPU registers.
+
+  @param[in]  CacheLevel       Cache level (e.g. L1, L2).
+  @param[in]  DataCache        Cache is a data cache.
+  @param[in]  UnifiedCache     Cache is a unified cache.
+  @param[out] Type7Record      The Type 7 record to fill in.
+
+**/
+VOID
+ConfigureCacheArchitectureInformation (
+  IN     UINT8                CacheLevel,
+  IN     BOOLEAN              DataCache,
+  IN     BOOLEAN              UnifiedCache,
+  OUT    SMBIOS_TABLE_TYPE7   *Type7Record
+  )
+{
+  UINT8        Associativity;
+  UINT32       CacheSize32;
+  UINT16       CacheSize16;
+  UINT64       CacheSize64;
+
+  if (!DataCache && !UnifiedCache) {
+    Type7Record->SystemCacheType = CacheTypeInstruction;
+  } else if (DataCache) {
+    Type7Record->SystemCacheType = CacheTypeData;
+  } else if (UnifiedCache) {
+    Type7Record->SystemCacheType = CacheTypeUnified;
+  } else {
+    ASSERT(FALSE);
+  }
+
+  CacheSize64 = SmbiosProcessorGetCacheSize (CacheLevel,
+                                             DataCache,
+                                             UnifiedCache
+                                             );
+
+  Associativity = SmbiosProcessorGetCacheAssociativity (CacheLevel,
+                                                        DataCache,
+                                                        UnifiedCache
+                                                        );
+
+  CacheSize64 /= 1024; // Minimum granularity is 1K
+
+  // Encode the cache size into the format SMBIOS wants
+  if (CacheSize64 < MAX_INT16) {
+    CacheSize16 = CacheSize64;
+    CacheSize32 = CacheSize16;
+  } else if ((CacheSize64 / 64) < MAX_INT16) {
+    CacheSize16 = (1 << 15) | (CacheSize64 / 64);
+    CacheSize32 = CacheSize16;
+  } else {
+    if ((CacheSize64 / 1024) <= 2047) {
+      CacheSize32 = CacheSize64;
+    } else {
+      CacheSize32 = (1 << 31) | (CacheSize64 / 64);
+    }
+
+    CacheSize16 = -1;
+  }
+
+  Type7Record->MaximumCacheSize = CacheSize16;
+  Type7Record->InstalledSize = CacheSize16;
+  Type7Record->MaximumCacheSize2 = CacheSize32;
+  Type7Record->InstalledSize2 = CacheSize32;
+
+  switch (Associativity) {
+    case 2:
+      Type7Record->Associativity = CacheAssociativity2Way;
+      break;
+    case 4:
+      Type7Record->Associativity = CacheAssociativity4Way;
+      break;
+    case 8:
+      Type7Record->Associativity = CacheAssociativity8Way;
+      break;
+    case 12:
+      Type7Record->Associativity = CacheAssociativity12Way;
+      break;
+    case 16:
+      Type7Record->Associativity = CacheAssociativity16Way;
+      break;
+    case 20:
+      Type7Record->Associativity = CacheAssociativity20Way;
+      break;
+    case 24:
+      Type7Record->Associativity = CacheAssociativity24Way;
+      break;
+    case 32:
+      Type7Record->Associativity = CacheAssociativity32Way;
+      break;
+    case 48:
+      Type7Record->Associativity = CacheAssociativity48Way;
+      break;
+    case 64:
+      Type7Record->Associativity = CacheAssociativity64Way;
+      break;
+    default:
+      Type7Record->Associativity = CacheAssociativityOther;
+      break;
+  }
+
+  Type7Record->CacheConfiguration = (CacheModeUnknown << CACHE_OPERATION_MODE_SHIFT) |
+                                    (1 << CACHE_ENABLED_SHIFT) |
+                                    (CacheLocationUnknown << CACHE_LOCATION_SHIFT) |
+                                    (0 << CACHE_SOCKETED_SHIFT) |
+                                    (CacheLevel - 1);
+}
+
+
+/** Allocates and initializes an SMBIOS_TABLE_TYPE7 structure.
+
+  @param[in]  CacheLevel       The cache level (L1-L7).
+  @param[in]  DataCache        Cache is a data cache.
+  @param[in]  UnifiedCache     Cache is a unified cache.
+
+  @return A pointer to the Type 7 structure. Returns NULL on failure.
+**/
+SMBIOS_TABLE_TYPE7 *
+AllocateAndInitCacheInformation (
+  IN UINT8   CacheLevel,
+  IN BOOLEAN DataCache,
+  IN BOOLEAN UnifiedCache
+  )
+{
+  SMBIOS_TABLE_TYPE7  *Type7Record;
+  EFI_STRING          CacheSocketStr;
+  UINTN               CacheSocketStrLen;
+  UINTN               StringBufferSize;
+  CHAR8               *OptionalStrStart;
+  UINTN               TableSize;
+
+  // Allocate and fetch the cache description
+  StringBufferSize = sizeof (CHAR16) * SMBIOS_STRING_MAX_LENGTH;
+  CacheSocketStr = AllocateZeroPool (StringBufferSize);
+  if (CacheSocketStr == NULL) {
+    return NULL;
+  }
+
+  CacheSocketStrLen = GetCacheSocketStr (CacheLevel,
+                                         DataCache,
+                                         UnifiedCache,
+                                         CacheSocketStr);
+
+  TableSize = sizeof (SMBIOS_TABLE_TYPE7) + CacheSocketStrLen + 1 + 1;
+  Type7Record = AllocateZeroPool (TableSize);
+  if (Type7Record == NULL) {
+    FreePool(CacheSocketStr);
+    return NULL;
+  }
+
+  Type7Record->Hdr.Type = EFI_SMBIOS_TYPE_CACHE_INFORMATION;
+  Type7Record->Hdr.Length = sizeof (SMBIOS_TABLE_TYPE7);
+  Type7Record->Hdr.Handle = SMBIOS_HANDLE_PI_RESERVED;
+
+  Type7Record->SocketDesignation = 1;
+
+  Type7Record->SupportedSRAMType.Unknown = 1;
+  Type7Record->CurrentSRAMType.Unknown = 1;
+  Type7Record->CacheSpeed = 0;
+  Type7Record->ErrorCorrectionType = CacheErrorUnknown;
+
+  OptionalStrStart = (CHAR8 *)(Type7Record + 1);
+  UnicodeStrToAsciiStrS (CacheSocketStr, OptionalStrStart, CacheSocketStrLen + 1);
+  FreePool (CacheSocketStr);
+
+  return Type7Record;
+}
+
+/**
+  Add Type 7 SMBIOS Record for Cache Information.
+
+  @param[in]    ProcessorIndex      Processor number of specified processor.
+  @param[out]   L1CacheHandle       Pointer to the handle of the L1 Cache SMBIOS record.
+  @param[out]   L2CacheHandle       Pointer to the handle of the L2 Cache SMBIOS record.
+  @param[out]   L3CacheHandle       Pointer to the handle of the L3 Cache SMBIOS record.
+
+**/
+VOID
+AddSmbiosCacheTypeTable (
+  IN UINTN                  ProcessorIndex,
+  OUT EFI_SMBIOS_HANDLE     *L1CacheHandle,
+  OUT EFI_SMBIOS_HANDLE     *L2CacheHandle,
+  OUT EFI_SMBIOS_HANDLE     *L3CacheHandle
+  )
+{
+  EFI_STATUS                  Status;
+  SMBIOS_TABLE_TYPE7          *Type7Record;
+  EFI_SMBIOS_HANDLE           SmbiosHandle;
+  UINT8                       CacheLevel;
+  UINT8                       MaxCacheLevel;
+  BOOLEAN                     DataCacheType;
+  BOOLEAN                     SeparateCaches;
+
+  Status = EFI_SUCCESS;
+
+  MaxCacheLevel = 0;
+
+  // See if there's an L1 cache present.
+  MaxCacheLevel = SmbiosProcessorGetMaxCacheLevel ();
+
+  if (MaxCacheLevel < 1) {
+    return;
+  }
+
+  for (CacheLevel = 1; CacheLevel <= MaxCacheLevel; CacheLevel++) {
+    Type7Record = NULL;
+
+    SeparateCaches = SmbiosProcessorHasSeparateCaches (CacheLevel);
+
+    // At each level of cache, we can have a single type (unified, instruction or data),
+    // or two types - separate data and instruction caches. If we have separate
+    // instruction and data caches, then on the first iteration (CacheSubLevel = 0)
+    // process the instruction cache.
+    for (DataCacheType = 0; DataCacheType <= 1; DataCacheType++) {
+      // If there's no separate data/instruction cache, skip the second iteration
+      if (DataCacheType == 1 && !SeparateCaches) {
+        continue;
+      }
+
+      Type7Record = AllocateAndInitCacheInformation (CacheLevel,
+                                                     DataCacheType,
+                                                     !SeparateCaches
+                                                     );
+      if (Type7Record == NULL) {
+        continue;
+      }
+
+      ConfigureCacheArchitectureInformation(CacheLevel,
+                                            DataCacheType,
+                                            !SeparateCaches,
+                                            Type7Record
+                                            );
+
+      // Allow the platform to fill in other information such as speed, SRAM type etc.
+      if (!OemGetCacheInformation (ProcessorIndex, CacheLevel,
+                                   DataCacheType, !SeparateCaches, Type7Record)) {
+        continue;
+      }
+
+      SmbiosHandle = SMBIOS_HANDLE_PI_RESERVED;
+      // Finally, install the table
+      Status = mSmbios->Add (mSmbios, NULL, &SmbiosHandle,
+                             (EFI_SMBIOS_TABLE_HEADER *)Type7Record);
+      if (EFI_ERROR (Status)) {
+        continue;
+      }
+
+      // Config L1/L2/L3 Cache Handle
+      switch (CacheLevel) {
+        case CpuCacheL1:
+          *L1CacheHandle = SmbiosHandle;
+          break;
+        case CpuCacheL2:
+          *L2CacheHandle = SmbiosHandle;
+          break;
+        case CpuCacheL3:
+          *L3CacheHandle = SmbiosHandle;
+          break;
+        default:
+          break;
+      }
+    }
+  }
+}
+
+/** Allocates a Type 4 Processor Information structure and sets the
+    strings following the data fields.
+
+  @param[out] Type4Record    The Type 4 structure to allocate and initialize
+  @param[in]  ProcessorIndex The index of the processor socket
+  @param[in]  Populated      Whether the specified processor socket is
+                             populated.
+
+  @retval EFI_SUCCESS          The Type 4 structure was successfully
+                               allocated and the strings initialized.
+  @retval EFI_OUT_OF_RESOURCES Could not allocate memory needed.
+**/
+EFI_STATUS
+AllocateType4AndSetProcessorInformationStrings (
+  SMBIOS_TABLE_TYPE4 **Type4Record,
+  UINT8 ProcessorIndex,
+  BOOLEAN Populated
+  )
+{
+  EFI_STATUS      Status;
+  EFI_STRING_ID   ProcessorManu;
+  EFI_STRING_ID   ProcessorVersion;
+  EFI_STRING_ID   SerialNumber;
+  EFI_STRING_ID   AssetTag;
+  EFI_STRING_ID   PartNumber;
+  EFI_STRING      ProcessorSocketStr;
+  EFI_STRING      ProcessorManuStr;
+  EFI_STRING      ProcessorVersionStr;
+  EFI_STRING      SerialNumberStr;
+  EFI_STRING      AssetTagStr;
+  EFI_STRING      PartNumberStr;
+  CHAR8           *OptionalStrStart;
+  CHAR8           *StrStart;
+  UINTN           ProcessorSocketStrLen;
+  UINTN           ProcessorManuStrLen;
+  UINTN           ProcessorVersionStrLen;
+  UINTN           SerialNumberStrLen;
+  UINTN           AssetTagStrLen;
+  UINTN           PartNumberStrLen;
+  UINTN           TotalSize;
+  UINTN           StringBufferSize;
+
+  Status = EFI_SUCCESS;
+
+  ProcessorManuStr    = NULL;
+  ProcessorVersionStr = NULL;
+  SerialNumberStr     = NULL;
+  AssetTagStr         = NULL;
+  PartNumberStr       = NULL;
+
+  ProcessorManu       = STRING_TOKEN (STR_PROCESSOR_MANUFACTURE);
+  ProcessorVersion    = STRING_TOKEN (STR_PROCESSOR_VERSION);
+  SerialNumber        = STRING_TOKEN (STR_PROCESSOR_SERIAL_NUMBER);
+  AssetTag            = STRING_TOKEN (STR_PROCESSOR_ASSET_TAG);
+  PartNumber          = STRING_TOKEN (STR_PROCESSOR_PART_NUMBER);
+
+  SET_HII_STRING_IF_PCD_NOT_EMPTY (PcdProcessorManufacturer, ProcessorManu);
+  SET_HII_STRING_IF_PCD_NOT_EMPTY (PcdProcessorVersion, ProcessorVersion);
+  SET_HII_STRING_IF_PCD_NOT_EMPTY (PcdProcessorSerialNumber, SerialNumber);
+  SET_HII_STRING_IF_PCD_NOT_EMPTY (PcdProcessorAssetTag, AssetTag);
+  SET_HII_STRING_IF_PCD_NOT_EMPTY (PcdProcessorPartNumber, PartNumber);
+
+  // Processor Socket Designation
+  StringBufferSize = sizeof (CHAR16) * SMBIOS_STRING_MAX_LENGTH;
+  ProcessorSocketStr = AllocateZeroPool (StringBufferSize);
+  if (ProcessorSocketStr == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  ProcessorSocketStrLen = UnicodeSPrint (ProcessorSocketStr, StringBufferSize,
+                                         L"CPU%02d", ProcessorIndex + 1);
+
+  // Processor Manufacture
+  ProcessorManuStr = HiiGetPackageString (&gEfiCallerIdGuid, ProcessorManu, NULL);
+  ProcessorManuStrLen = StrLen (ProcessorManuStr);
+
+  // Processor Version
+  ProcessorVersionStr = HiiGetPackageString (&gEfiCallerIdGuid, ProcessorVersion, NULL);
+  ProcessorVersionStrLen = StrLen (ProcessorVersionStr);
+
+  // Serial Number
+  SerialNumberStr = HiiGetPackageString (&gEfiCallerIdGuid, SerialNumber, NULL);
+  SerialNumberStrLen = StrLen (SerialNumberStr);
+
+  // Asset Tag
+  AssetTagStr = HiiGetPackageString (&gEfiCallerIdGuid, AssetTag, NULL);
+  AssetTagStrLen = StrLen (AssetTagStr);
+
+  // Part Number
+  PartNumberStr = HiiGetPackageString (&gEfiCallerIdGuid, PartNumber, NULL);
+  PartNumberStrLen = StrLen (PartNumberStr);
+
+  TotalSize = sizeof (SMBIOS_TABLE_TYPE4) +
+              ProcessorSocketStrLen  + 1 +
+              ProcessorManuStrLen    + 1 +
+              ProcessorVersionStrLen + 1 +
+              SerialNumberStrLen     + 1 +
+              AssetTagStrLen         + 1 +
+              PartNumberStrLen       + 1 + 1;
+
+  *Type4Record = AllocateZeroPool (TotalSize);
+  if (*Type4Record == NULL) {
+    Status = EFI_OUT_OF_RESOURCES;
+    goto Exit;
+  }
+
+  CopyMem (*Type4Record, &mSmbiosProcessorTableTemplate, sizeof (SMBIOS_TABLE_TYPE4));
+
+  OptionalStrStart = (CHAR8 *)(*Type4Record + 1);
+  UnicodeStrToAsciiStrS (
+    ProcessorSocketStr,
+    OptionalStrStart,
+    ProcessorSocketStrLen + 1
+    );
+
+  StrStart = OptionalStrStart + ProcessorSocketStrLen + 1;
+  UnicodeStrToAsciiStrS (
+    ProcessorManuStr,
+    StrStart,
+    ProcessorManuStrLen + 1
+    );
+
+  StrStart += ProcessorManuStrLen + 1;
+  UnicodeStrToAsciiStrS (
+    ProcessorVersionStr,
+    StrStart,
+    ProcessorVersionStrLen + 1
+    );
+
+  StrStart += ProcessorVersionStrLen + 1;
+  UnicodeStrToAsciiStrS (
+    SerialNumberStr,
+    StrStart,
+    SerialNumberStrLen + 1
+    );
+
+  StrStart += SerialNumberStrLen + 1;
+  UnicodeStrToAsciiStrS (
+    AssetTagStr,
+    StrStart,
+    AssetTagStrLen + 1
+    );
+
+  StrStart += AssetTagStrLen + 1;
+  UnicodeStrToAsciiStrS (
+    PartNumberStr,
+    StrStart,
+    PartNumberStrLen + 1
+    );
+
+Exit:
+  FreePool (ProcessorSocketStr);
+  FreePool (ProcessorManuStr);
+  FreePool (ProcessorVersionStr);
+  FreePool (SerialNumberStr);
+  FreePool (AssetTagStr);
+  FreePool (PartNumberStr);
+
+  return Status;
+}
+
+/**
+  Add Type 4 SMBIOS Record for Processor Information.
+
+  @param[in]    ProcessorIndex     Processor index of specified processor.
+
+**/
+EFI_STATUS
+AddSmbiosProcessorTypeTable (
+  IN UINTN                  ProcessorIndex
+  )
+{
+  EFI_STATUS                  Status;
+  SMBIOS_TABLE_TYPE4          *Type4Record;
+  EFI_SMBIOS_HANDLE           SmbiosHandle;
+  EFI_SMBIOS_HANDLE           L1CacheHandle;
+  EFI_SMBIOS_HANDLE           L2CacheHandle;
+  EFI_SMBIOS_HANDLE           L3CacheHandle;
+  UINT8                       *LegacyVoltage;
+  PROCESSOR_STATUS_DATA       ProcessorStatus;
+  UINT64                      *ProcessorId;
+  PROCESSOR_CHARACTERISTIC_FLAGS ProcessorCharacteristics;
+  OEM_MISC_PROCESSOR_DATA     MiscProcessorData;
+  BOOLEAN                     SocketPopulated;
+
+  Type4Record         = NULL;
+
+  MiscProcessorData.Voltage         = 0;
+  MiscProcessorData.CurrentSpeed    = 0;
+  MiscProcessorData.CoreCount       = 0;
+  MiscProcessorData.CoresEnabled    = 0;
+  MiscProcessorData.ThreadCount     = 0;
+  MiscProcessorData.MaxSpeed        = 0;
+  L1CacheHandle       = 0xFFFF;
+  L2CacheHandle       = 0xFFFF;
+  L3CacheHandle       = 0xFFFF;
+
+  SocketPopulated = OemIsSocketPresent(ProcessorIndex);
+
+  Status = AllocateType4AndSetProcessorInformationStrings (
+             &Type4Record,
+             ProcessorIndex,
+             SocketPopulated
+             );
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  OemGetProcessorInformation (ProcessorIndex,
+                              &ProcessorStatus,
+                              (PROCESSOR_CHARACTERISTIC_FLAGS*)
+                                &Type4Record->ProcessorCharacteristics,
+                              &MiscProcessorData);
+
+  if (SocketPopulated) {
+    AddSmbiosCacheTypeTable (ProcessorIndex, &L1CacheHandle,
+                             &L2CacheHandle, &L3CacheHandle);
+  }
+
+  LegacyVoltage = (UINT8*)&Type4Record->Voltage;
+
+  *LegacyVoltage                    = MiscProcessorData.Voltage;
+  Type4Record->CurrentSpeed         = MiscProcessorData.CurrentSpeed;
+  Type4Record->MaxSpeed             = MiscProcessorData.MaxSpeed;
+  Type4Record->Status               = ProcessorStatus.Data;
+  Type4Record->L1CacheHandle        = L1CacheHandle;
+  Type4Record->L2CacheHandle        = L2CacheHandle;
+  Type4Record->L3CacheHandle        = L3CacheHandle;
+  Type4Record->CoreCount            = MiscProcessorData.CoreCount;
+  Type4Record->CoreCount2           = MiscProcessorData.CoreCount;
+  Type4Record->EnabledCoreCount     = MiscProcessorData.CoresEnabled;
+  Type4Record->EnabledCoreCount2    = MiscProcessorData.CoresEnabled;
+  Type4Record->ThreadCount          = MiscProcessorData.ThreadCount;
+  Type4Record->ThreadCount2         = MiscProcessorData.ThreadCount;
+
+  Type4Record->CurrentSpeed = GetCpuFrequency (ProcessorIndex);
+  Type4Record->ExternalClock =
+    (UINT16)(SmbiosGetExternalClockFrequency () / 1000 / 1000);
+
+  ProcessorId = (UINT64*)&Type4Record->ProcessorId;
+  *ProcessorId = SmbiosGetProcessorId ();
+
+  ProcessorCharacteristics = SmbiosGetProcessorCharacteristics ();
+  Type4Record->ProcessorCharacteristics |= *((UINT64*)&ProcessorCharacteristics);
+
+  Type4Record->ProcessorFamily = SmbiosGetProcessorFamily ();
+  Type4Record->ProcessorFamily2 = SmbiosGetProcessorFamily2 ();
+
+  SmbiosHandle = SMBIOS_HANDLE_PI_RESERVED;
+  Status = mSmbios->Add (mSmbios, NULL, &SmbiosHandle,
+                         (EFI_SMBIOS_TABLE_HEADER *)Type4Record);
+
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "[%a]:[%dL] Smbios Type04 Table Log Failed! %r \n",
+            __FUNCTION__, __LINE__, Status));
+  }
+  FreePool (Type4Record);
+
+  return Status;
+}
+
+/**
+   Standard EFI driver point.
+
+  @param  ImageHandle     Handle for the image of this driver
+  @param  SystemTable     Pointer to the EFI System Table
+
+  @retval  EFI_SUCCESS    The data was successfully stored.
+
+**/
+EFI_STATUS
+EFIAPI
+ProcessorSubClassEntryPoint(
+  IN EFI_HANDLE         ImageHandle,
+  IN EFI_SYSTEM_TABLE   *SystemTable
+  )
+{
+  EFI_STATUS    Status;
+  UINT32        SocketIndex;
+
+  //
+  // Locate dependent protocols
+  //
+  Status = gBS->LocateProtocol (&gEfiSmbiosProtocolGuid, NULL, (VOID**)&mSmbios);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "Could not locate SMBIOS protocol.  %r\n", Status));
+    return Status;
+  }
+
+  //
+  // Add our default strings to the HII database. They will be modified later.
+  //
+  mHiiHandle = HiiAddPackages (&gEfiCallerIdGuid,
+                               NULL,
+                               ProcessorSubClassStrings,
+                               NULL,
+                               NULL
+                              );
+  if (mHiiHandle == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  //
+  // Add SMBIOS tables for populated sockets.
+  //
+  for (SocketIndex = 0; SocketIndex < OemGetProcessorMaxSockets(); SocketIndex++) {
+    Status = AddSmbiosProcessorTypeTable (SocketIndex);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "Add Processor Type Table Failed!  %r.\n", Status));
+      return Status;
+    }
+  }
+
+  return Status;
+}

--- a/ArmPkg/Universal/Smbios/ProcessorSubClassDxe/ProcessorSubClassDxe.inf
+++ b/ArmPkg/Universal/Smbios/ProcessorSubClassDxe/ProcessorSubClassDxe.inf
@@ -1,0 +1,66 @@
+#/** @file
+#    ProcessorSubClassDxe.inf
+#
+#    Copyright (c) 2021, NUVIA Inc. All rights reserved.
+#    Copyright (c) 2015, Hisilicon Limited. All rights reserved.
+#    Copyright (c) 2015, Linaro Limited. All rights reserved.
+#
+#    SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+#**/
+
+
+[Defines]
+  INF_VERSION                    = 1.29
+  BASE_NAME                      = ProcessorSubClass
+  FILE_GUID                      = f3fe0e33-ea38-4069-9fb5-be23407207c7
+  MODULE_TYPE                    = DXE_DRIVER
+  VERSION_STRING                 = 1.0
+  ENTRY_POINT                    = ProcessorSubClassEntryPoint
+
+[Sources]
+  SmbiosProcessorArmCommon.c
+  ProcessorSubClass.c
+  ProcessorSubClassStrings.uni
+  SmbiosProcessor.h
+
+[Sources.AARCH64]
+  SmbiosProcessorAArch64.c
+
+[Sources.ARM]
+  SmbiosProcessorArm.c
+
+[Packages]
+  ArmPkg/ArmPkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  MdePkg/MdePkg.dec
+
+[LibraryClasses]
+  ArmLib
+  ArmSmcLib
+  BaseLib
+  BaseMemoryLib
+  DebugLib
+  HiiLib
+  IoLib
+  MemoryAllocationLib
+  OemMiscLib
+  PcdLib
+  PrintLib
+  UefiDriverEntryPoint
+
+[Protocols]
+  gEfiSmbiosProtocolGuid                       # PROTOCOL ALWAYS_CONSUMED
+
+[Pcd]
+  gArmTokenSpaceGuid.PcdProcessorManufacturer
+  gArmTokenSpaceGuid.PcdProcessorVersion
+  gArmTokenSpaceGuid.PcdProcessorSerialNumber
+  gArmTokenSpaceGuid.PcdProcessorAssetTag
+  gArmTokenSpaceGuid.PcdProcessorPartNumber
+
+[Guids]
+
+
+[Depex]
+  gEfiSmbiosProtocolGuid

--- a/ArmPkg/Universal/Smbios/ProcessorSubClassDxe/ProcessorSubClassStrings.uni
+++ b/ArmPkg/Universal/Smbios/ProcessorSubClassDxe/ProcessorSubClassStrings.uni
@@ -1,0 +1,24 @@
+/** @file
+  SMBIOS Type 4 strings
+
+  Copyright (c) 2021, NUVIA Inc. All rights reserved.
+  Copyright (c) 2015, Hisilicon Limited. All rights reserved.
+  Copyright (c) 2015, Linaro Limited. All rights reserved.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+/=#
+
+#langdef en-US "English"
+
+//
+// Processor Information
+//
+#string STR_PROCESSOR_SOCKET_DESIGNATION    #language en-US  "Not Specified"
+#string STR_PROCESSOR_MANUFACTURE           #language en-US  "Not Specified"
+#string STR_PROCESSOR_VERSION               #language en-US  "Not Specified"
+#string STR_PROCESSOR_SERIAL_NUMBER         #language en-US  "Not Specified"
+#string STR_PROCESSOR_ASSET_TAG             #language en-US  "Not Specified"
+#string STR_PROCESSOR_PART_NUMBER           #language en-US  "Not Specified"
+#string STR_PROCESSOR_UNKNOWN               #language en-US  "Unknown"

--- a/ArmPkg/Universal/Smbios/ProcessorSubClassDxe/SmbiosProcessor.h
+++ b/ArmPkg/Universal/Smbios/ProcessorSubClassDxe/SmbiosProcessor.h
@@ -1,0 +1,102 @@
+/** @file
+  SMBIOS Processor Related Functions.
+
+  Copyright (c) 2021, NUVIA Inc. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef SMBIOS_PROCESSOR_H_
+#define SMBIOS_PROCESSOR_H_
+
+#include <Uefi.h>
+#include <IndustryStandard/SmBios.h>
+
+/** Returns the maximum cache level implemented by the current CPU.
+
+    @return The maximum cache level implemented.
+**/
+UINT8
+SmbiosProcessorGetMaxCacheLevel (
+  VOID
+  );
+
+/** Returns whether or not the specified cache level has separate I/D caches.
+
+    @param CacheLevel The cache level (L1, L2 etc.).
+
+    @return TRUE if the cache level has separate I/D caches, FALSE otherwise.
+**/
+BOOLEAN
+SmbiosProcessorHasSeparateCaches (
+  UINT8 CacheLevel
+  );
+
+/** Gets the size of the specified cache.
+
+    @param CacheLevel       The cache level (L1, L2 etc.).
+    @param DataCache        Whether the cache is a dedicated data cache.
+    @param UnifiedCache     Whether the cache is a unified cache.
+
+    @return The cache size.
+**/
+UINT64
+SmbiosProcessorGetCacheSize (
+  IN UINT8   CacheLevel,
+  IN BOOLEAN DataCache,
+  IN BOOLEAN UnifiedCache
+  );
+
+/** Gets the associativity of the specified cache.
+
+    @param CacheLevel       The cache level (L1, L2 etc.).
+    @param DataCache        Whether the cache is a dedicated data cache.
+    @param UnifiedCache     Whether the cache is a unified cache.
+
+    @return The cache associativity.
+**/
+UINT32
+SmbiosProcessorGetCacheAssociativity (
+  IN UINT8   CacheLevel,
+  IN BOOLEAN DataCache,
+  IN BOOLEAN UnifiedCache
+  );
+
+/** Returns a value for the Processor ID field that conforms to SMBIOS
+    requirements.
+
+    @return Processor ID.
+**/
+UINT64
+SmbiosGetProcessorId (VOID);
+
+/** Returns the external clock frequency.
+
+    @return The external CPU clock frequency.
+**/
+UINTN
+SmbiosGetExternalClockFrequency (VOID);
+
+/** Returns the SMBIOS ProcessorFamily field value.
+
+    @return The value for the ProcessorFamily field.
+**/
+UINT8
+SmbiosGetProcessorFamily (VOID);
+
+/** Returns the ProcessorFamily2 field value.
+
+    @return The value for the ProcessorFamily2 field.
+**/
+UINT16
+SmbiosGetProcessorFamily2 (VOID);
+
+/** Returns the SMBIOS Processor Characteristics.
+
+    @return Processor Characteristics bitfield.
+**/
+PROCESSOR_CHARACTERISTIC_FLAGS
+SmbiosGetProcessorCharacteristics (VOID);
+
+#endif // SMBIOS_PROCESSOR_H_

--- a/ArmPkg/Universal/Smbios/ProcessorSubClassDxe/SmbiosProcessorAArch64.c
+++ b/ArmPkg/Universal/Smbios/ProcessorSubClassDxe/SmbiosProcessorAArch64.c
@@ -1,0 +1,93 @@
+/** @file
+  Functions for AARCH64 processor information
+
+  Copyright (c) 2021, NUVIA Inc. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Uefi.h>
+#include <Library/ArmLib.h>
+#include <Library/ArmLib/ArmLibPrivate.h>
+
+#include "SmbiosProcessor.h"
+
+/** Gets the size of the specified cache.
+
+    @param CacheLevel       The cache level (L1, L2 etc.).
+    @param DataCache        Whether the cache is a dedicated data cache.
+    @param UnifiedCache     Whether the cache is a unified cache.
+
+    @return The cache size.
+**/
+UINT64
+SmbiosProcessorGetCacheSize (
+  IN UINT8   CacheLevel,
+  IN BOOLEAN DataCache,
+  IN BOOLEAN UnifiedCache
+)
+{
+  CCSIDR_DATA Ccsidr;
+  CSSELR_DATA Csselr;
+  BOOLEAN     CcidxSupported;
+  UINT64      CacheSize;
+
+  Csselr.Data = 0;
+  Csselr.Bits.Level = CacheLevel - 1;
+  Csselr.Bits.InD = (!DataCache && !UnifiedCache);
+
+  Ccsidr.Data = ReadCCSIDR (Csselr.Data);
+
+  CcidxSupported = ArmHasCcidx ();
+
+  if (CcidxSupported) {
+    CacheSize = (1 << (Ccsidr.BitsCcidxAA64.LineSize + 4)) *
+                      (Ccsidr.BitsCcidxAA64.Associativity + 1) *
+                      (Ccsidr.BitsCcidxAA64.NumSets + 1);
+  } else {
+    CacheSize = (1 << (Ccsidr.BitsNonCcidx.LineSize + 4)) *
+                      (Ccsidr.BitsNonCcidx.Associativity + 1) *
+                      (Ccsidr.BitsNonCcidx.NumSets + 1);
+  }
+
+  return CacheSize;
+}
+
+/** Gets the associativity of the specified cache.
+
+    @param CacheLevel       The cache level (L1, L2 etc.).
+    @param DataCache        Whether the cache is a dedicated data cache.
+    @param UnifiedCache     Whether the cache is a unified cache.
+
+    @return The cache associativity.
+**/
+UINT32
+SmbiosProcessorGetCacheAssociativity (
+  IN UINT8   CacheLevel,
+  IN BOOLEAN DataCache,
+  IN BOOLEAN UnifiedCache
+  )
+{
+  CCSIDR_DATA Ccsidr;
+  CSSELR_DATA Csselr;
+  BOOLEAN     CcidxSupported;
+  UINT32      Associativity;
+
+  Csselr.Data = 0;
+  Csselr.Bits.Level = CacheLevel - 1;
+  Csselr.Bits.InD = (!DataCache && !UnifiedCache);
+
+  Ccsidr.Data = ReadCCSIDR (Csselr.Data);
+
+  CcidxSupported = ArmHasCcidx ();
+
+  if (CcidxSupported) {
+    Associativity = Ccsidr.BitsCcidxAA64.Associativity + 1;
+  } else {
+    Associativity = Ccsidr.BitsNonCcidx.Associativity + 1;
+  }
+
+  return Associativity;
+}
+

--- a/ArmPkg/Universal/Smbios/ProcessorSubClassDxe/SmbiosProcessorArm.c
+++ b/ArmPkg/Universal/Smbios/ProcessorSubClassDxe/SmbiosProcessorArm.c
@@ -1,0 +1,99 @@
+/** @file
+  Functions for ARM processor information
+
+  Copyright (c) 2021, NUVIA Inc. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Uefi.h>
+#include <Library/ArmLib.h>
+#include <Library/ArmLib/ArmLibPrivate.h>
+
+#include "SmbiosProcessor.h"
+
+/** Gets the size of the specified cache.
+
+    @param CacheLevel       The cache level (L1, L2 etc.).
+    @param DataCache        Whether the cache is a dedicated data cache.
+    @param UnifiedCache     Whether the cache is a unified cache.
+
+    @return The cache size.
+**/
+UINT64
+ArmGetCacheSize (
+  IN UINT8   CacheLevel,
+  IN BOOLEAN DataCache,
+  IN BOOLEAN UnifiedCache
+  )
+{
+  CCSIDR_DATA  Ccsidr;
+  CCSIDR2_DATA Ccsidr2;
+  CSSELR_DATA  Csselr;
+  BOOLEAN      CcidxSupported;
+  UINT64       CacheSize;
+
+  // Read the CCSIDR register to get the cache architecture
+  Csselr.Data = 0;
+  Csselr.Bits.Level = CacheLevel - 1;
+  Csselr.Bits.InD = (!DataCache && !UnifiedCache);
+
+  Ccsidr.Data = ReadCCSIDR (Csselr.Data);
+
+  CcidxSupported = ArmHasCcidx ();
+
+  if (CcidxSupported) {
+    Ccsidr2.Data = ReadCCSIDR2 (Csselr.Data);
+    CacheSize = (1 << (Ccsidr.BitsCcidxAA32.LineSize + 4)) *
+                      (Ccsidr.BitsCcidxAA32.Associativity + 1) *
+                      (Ccsidr2.Bits.NumSets + 1);
+  } else {
+    CacheSize = (1 << (Ccsidr.BitsNonCcidx.LineSize + 4)) *
+                      (Ccsidr.BitsNonCcidx.Associativity + 1) *
+                      (Ccsidr.BitsNonCcidx.NumSets + 1);
+  }
+
+  return CacheSize;
+}
+
+/** Gets the associativity of the specified cache.
+
+    @param CacheLevel       The cache level (L1, L2 etc.).
+    @param DataCache        Whether the cache is a dedicated data cache.
+    @param UnifiedCache     Whether the cache is a unified cache.
+
+    @return The cache associativity.
+**/
+UINT32
+ArmGetCacheAssociativity (
+  IN UINT8   CacheLevel,
+  IN BOOLEAN DataCache,
+  IN BOOLEAN UnifiedCache
+  )
+{
+  CCSIDR_DATA  Ccsidr;
+  CCSIDR2_DATA Ccsidr2;
+  CSSELR_DATA  Csselr;
+  BOOLEAN      CcidxSupported;
+  UINT32       Associativity;
+
+  // Read the CCSIDR register to get the cache architecture
+  Csselr.Data = 0;
+  Csselr.Bits.Level = CacheLevel - 1;
+  Csselr.Bits.InD = (!DataCache && !UnifiedCache);
+
+  Ccsidr.Data = ReadCCSIDR (Csselr.Data);
+
+  CcidxSupported = ArmHasCcidx ();
+
+  if (CcidxSupported) {
+    Ccsidr2.Data = ReadCCSIDR2 (Csselr.Data);
+    Associativity = Ccsidr.BitsCcidxAA32.Associativity + 1;
+  } else {
+    Associativity = Ccsidr.BitsNonCcidx.Associativity + 1;
+  }
+
+  return Associativity;
+}
+

--- a/ArmPkg/Universal/Smbios/ProcessorSubClassDxe/SmbiosProcessorArmCommon.c
+++ b/ArmPkg/Universal/Smbios/ProcessorSubClassDxe/SmbiosProcessorArmCommon.c
@@ -1,0 +1,249 @@
+/** @file
+  Functions for processor information common to ARM and AARCH64.
+
+  Copyright (c) 2021, NUVIA Inc. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Uefi.h>
+#include <IndustryStandard/ArmStdSmc.h>
+#include <IndustryStandard/SmBios.h>
+#include <Library/ArmLib.h>
+#include <Library/ArmLib/ArmLibPrivate.h>
+#include <Library/ArmSmcLib.h>
+#include <Library/BaseMemoryLib.h>
+
+#include "SmbiosProcessor.h"
+
+/** Returns the maximum cache level implemented by the current CPU.
+
+    @return The maximum cache level implemented.
+**/
+UINT8
+SmbiosProcessorGetMaxCacheLevel (
+  VOID
+  )
+{
+  CLIDR_DATA Clidr;
+  UINT8      CacheLevel;
+  UINT8      MaxCacheLevel;
+
+  MaxCacheLevel = 0;
+
+  // Read the CLIDR register to find out what caches are present.
+  Clidr.Data = ReadCLIDR ();
+
+  // Get the cache type for the L1 cache. If it's 0, there are no caches.
+  if (CLIDR_GET_CACHE_TYPE (Clidr.Data, 1) == ClidrCacheTypeNone) {
+    return 0;
+  }
+
+  for (CacheLevel = 1; CacheLevel <= MAX_ARM_CACHE_LEVEL; CacheLevel++) {
+    if (CLIDR_GET_CACHE_TYPE (Clidr.Data, CacheLevel) == ClidrCacheTypeNone) {
+      MaxCacheLevel = CacheLevel;
+      break;
+    }
+  }
+
+  return MaxCacheLevel;
+}
+
+/** Returns whether or not the specified cache level has separate I/D caches.
+
+    @param CacheLevel The cache level (L1, L2 etc.).
+
+    @return TRUE if the cache level has separate I/D caches, FALSE otherwise.
+**/
+BOOLEAN
+SmbiosProcessorHasSeparateCaches (
+  UINT8 CacheLevel
+  )
+{
+  CLIDR_CACHE_TYPE CacheType;
+  CLIDR_DATA       Clidr;
+  BOOLEAN          SeparateCaches;
+
+  SeparateCaches = FALSE;
+
+  Clidr.Data = ReadCLIDR ();
+
+  CacheType = CLIDR_GET_CACHE_TYPE (Clidr.Data, CacheLevel - 1);
+
+  if (CacheType == ClidrCacheTypeSeparate) {
+    SeparateCaches = TRUE;
+  }
+
+  return SeparateCaches;
+}
+
+/** Checks if ther ARM64 SoC ID SMC call is supported
+
+    @return Whether the ARM64 SoC ID call is supported.
+**/
+BOOLEAN
+HasSmcArm64SocId (
+  VOID
+  )
+{
+  ARM_SMC_ARGS                   Args;
+  INT32                          SmcCallStatus;
+  BOOLEAN                        Arm64SocIdSupported;
+
+  Arm64SocIdSupported = FALSE;
+
+  Args.Arg0 = SMCCC_VERSION;
+  ArmCallSmc (&Args);
+  SmcCallStatus = (INT32)Args.Arg0;
+
+  if (SmcCallStatus < 0 || (SmcCallStatus >> 16) >= 1) {
+    Args.Arg0 = SMCCC_ARCH_FEATURES;
+    Args.Arg1 = SMCCC_ARCH_SOC_ID;
+    ArmCallSmc (&Args);
+
+    if (Args.Arg0 >= 0) {
+      Arm64SocIdSupported = TRUE;
+    }
+  }
+
+  return Arm64SocIdSupported;
+}
+
+/** Fetches the JEP106 code and SoC Revision.
+
+    @param Jep106Code  JEP 106 code.
+    @param SocRevision SoC revision.
+
+    @retval EFI_SUCCESS Succeeded.
+    @retval EFI_UNSUPPORTED Failed.
+**/
+EFI_STATUS
+SmbiosGetSmcArm64SocId (
+  OUT INT32 *Jep106Code,
+  OUT INT32 *SocRevision
+  )
+{
+  ARM_SMC_ARGS  Args;
+  INT32         SmcCallStatus;
+  EFI_STATUS    Status;
+
+  Status = EFI_SUCCESS;
+
+  Args.Arg0 = SMCCC_ARCH_SOC_ID;
+  Args.Arg1 = 0;
+  ArmCallSmc (&Args);
+  SmcCallStatus = (INT32)Args.Arg0;
+
+  if (SmcCallStatus >= 0) {
+    *Jep106Code = (INT32)Args.Arg0;
+  } else {
+    Status = EFI_UNSUPPORTED;
+  }
+
+  Args.Arg0 = SMCCC_ARCH_SOC_ID;
+  Args.Arg1 = 1;
+  ArmCallSmc (&Args);
+  SmcCallStatus = (INT32)Args.Arg0;
+
+  if (SmcCallStatus >= 0) {
+    *SocRevision = (INT32)Args.Arg0;
+  } else {
+    Status = EFI_UNSUPPORTED;
+  }
+
+  return Status;
+}
+
+/** Returns a value for the Processor ID field that conforms to SMBIOS
+    requirements.
+
+    @return Processor ID.
+**/
+UINT64
+SmbiosGetProcessorId (
+  VOID
+  )
+{
+  INT32  Jep106Code;
+  INT32  SocRevision;
+  UINT64 ProcessorId;
+
+  if (HasSmcArm64SocId ()) {
+    SmbiosGetSmcArm64SocId (&Jep106Code, &SocRevision);
+    ProcessorId = ((UINT64)Jep106Code << 32) | SocRevision;
+  } else {
+    ProcessorId = ArmReadMidr ();
+  }
+
+  return ProcessorId;
+}
+
+/** Returns the external clock frequency.
+
+    @return The external clock frequency.
+**/
+UINTN
+SmbiosGetExternalClockFrequency (
+  VOID
+  )
+{
+  return ArmReadCntFrq ();
+}
+
+/** Returns the SMBIOS ProcessorFamily field value.
+
+    @return The value for the ProcessorFamily field.
+**/
+UINT8
+SmbiosGetProcessorFamily (
+  VOID
+  )
+{
+  return ProcessorFamilyIndicatorFamily2;
+}
+
+/** Returns the ProcessorFamily2 field value.
+
+    @return The value for the ProcessorFamily2 field.
+**/
+UINT16
+SmbiosGetProcessorFamily2 (
+  VOID
+  )
+{
+  UINTN  MainIdRegister;
+  UINT16 ProcessorFamily2;
+
+  MainIdRegister = ArmReadMidr ();
+
+  if (((MainIdRegister >> 16) & 0xF) < 8) {
+    ProcessorFamily2 = ProcessorFamilyARM;
+  } else {
+    if (sizeof (VOID*) == 4) {
+      ProcessorFamily2 = ProcessorFamilyARMv7;
+    } else {
+      ProcessorFamily2 = ProcessorFamilyARMv8;
+    }
+  }
+
+  return ProcessorFamily2;
+}
+
+/** Returns the SMBIOS Processor Characteristics.
+
+    @return Processor Characteristics bitfield.
+**/
+PROCESSOR_CHARACTERISTIC_FLAGS
+SmbiosGetProcessorCharacteristics (
+  VOID
+  )
+{
+  PROCESSOR_CHARACTERISTIC_FLAGS Characteristics;
+
+  ZeroMem (&Characteristics, sizeof (Characteristics));
+
+  Characteristics.ProcessorArm64SocId = HasSmcArm64SocId ();
+
+  return Characteristics;
+}

--- a/ArmPkg/Universal/Smbios/SmbiosMiscDxe/SmbiosMisc.h
+++ b/ArmPkg/Universal/Smbios/SmbiosMiscDxe/SmbiosMisc.h
@@ -1,0 +1,134 @@
+/** @file
+  Header file for the SmbiosMisc Driver.
+
+  Based on files under Nt32Pkg/MiscSubClassPlatformDxe/
+
+  Copyright (c) 2021, NUVIA Inc. All rights reserved.<BR>
+  Copyright (c) 2006 - 2011, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2015, Hisilicon Limited. All rights reserved.<BR>
+  Copyright (c) 2015, Linaro Limited. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef SMBIOS_MISC_H_
+#define SMBIOS_MISC_H_
+
+#include <Protocol/Smbios.h>
+#include <IndustryStandard/SmBios.h>
+
+//
+// Data table entry update function.
+//
+typedef EFI_STATUS (EFIAPI SMBIOS_MISC_DATA_FUNCTION) (
+  IN  VOID                 *RecordData,
+  IN  EFI_SMBIOS_PROTOCOL  *Smbios
+  );
+
+
+//
+// Data table entry definition.
+//
+typedef struct {
+  //
+  // intermediate input data for SMBIOS record
+  //
+  VOID                          *RecordData;
+  SMBIOS_MISC_DATA_FUNCTION     *Function;
+} SMBIOS_MISC_DATA_TABLE;
+
+
+//
+// SMBIOS table extern definitions
+//
+#define SMBIOS_MISC_TABLE_EXTERNS(NAME1, NAME2, NAME3) \
+extern NAME1 NAME2 ## Data; \
+extern SMBIOS_MISC_DATA_FUNCTION NAME3 ## Function;
+
+
+//
+// SMBIOS data table entries
+//
+// This is used to define a pair of table structure pointer and functions
+// in order to iterate through the list of tables, populate them and add
+// them into the system.
+#define SMBIOS_MISC_TABLE_ENTRY_DATA_AND_FUNCTION(NAME1, NAME2) \
+{ \
+  & NAME1 ## Data, \
+    NAME2 ## Function \
+}
+
+//
+// Global definition macros.
+//
+#define SMBIOS_MISC_TABLE_DATA(NAME1, NAME2) \
+  NAME1 NAME2 ## Data
+
+#define SMBIOS_MISC_TABLE_FUNCTION(NAME2) \
+  EFI_STATUS EFIAPI NAME2 ## Function( \
+  IN  VOID                  *RecordData, \
+  IN  EFI_SMBIOS_PROTOCOL   *Smbios \
+  )
+
+//
+// Data Table Array Entries
+//
+extern EFI_HII_HANDLE               mSmbiosMiscHiiHandle;
+
+typedef struct _SMBIOS_TYPE13_BIOS_LANGUAGE_INFORMATION_STRING{
+  UINT8                               *LanguageSignature;
+  EFI_STRING_ID                       InstallableLanguageLongString;
+  EFI_STRING_ID                       InstallableLanguageAbbreviateString;
+} SMBIOS_TYPE13_BIOS_LANGUAGE_INFORMATION_STRING;
+
+
+/**
+  Adds an SMBIOS record.
+
+  @param  Buffer        The data for the SMBIOS record.
+                        The format of the record is determined by
+                        EFI_SMBIOS_TABLE_HEADER.Type. The size of the
+                        formatted area is defined by EFI_SMBIOS_TABLE_HEADER.Length
+                        and either followed by a double-null (0x0000) or a set
+                        of null terminated strings and a null.
+  @param  SmbiosHandle  A unique handle will be assigned to the SMBIOS record
+                        if not NULL.
+
+  @retval EFI_SUCCESS           Record was added.
+  @retval EFI_OUT_OF_RESOURCES  Record was not added due to lack of system resources.
+  @retval EFI_ALREADY_STARTED   The SmbiosHandle passed in was already in use.
+
+**/
+EFI_STATUS
+SmbiosMiscAddRecord (
+  IN       UINT8                      *Buffer,
+  IN  OUT  EFI_SMBIOS_HANDLE          *SmbiosHandle OPTIONAL
+  );
+
+/**
+ Get Link Type Handle.
+
+ @param [in]   SmbiosType     Get this Type from SMBIOS table
+ @param [out]  HandleArray    Pointer to handle array which will be freed by caller
+ @param [out]  HandleCount    Pointer to handle count
+
+**/
+VOID
+SmbiosMiscGetLinkTypeHandle(
+  IN  UINT8                 SmbiosType,
+  OUT UINT16                **HandleArray,
+  OUT UINTN                 *HandleCount
+  );
+
+//
+// Data Table Array
+//
+extern SMBIOS_MISC_DATA_TABLE   mSmbiosMiscDataTable[];
+
+//
+// Data Table Array Entries
+//
+extern UINTN   mSmbiosMiscDataTableEntries;
+extern UINT8   mSmbiosMiscDxeStrings[];
+
+#endif // SMBIOS_MISC_H_

--- a/ArmPkg/Universal/Smbios/SmbiosMiscDxe/SmbiosMiscDataTable.c
+++ b/ArmPkg/Universal/Smbios/SmbiosMiscDxe/SmbiosMiscDataTable.c
@@ -1,0 +1,62 @@
+/** @file
+  This file provides SMBIOS Misc Type.
+
+  Based on files under Nt32Pkg/MiscSubClassPlatformDxe/
+
+  Copyright (c) 2021, NUVIA Inc. All rights reserved.<BR>
+  Copyright (c) 2006 - 2011, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2015, Hisilicon Limited. All rights reserved.<BR>
+  Copyright (c) 2015, Linaro Limited. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent\
+
+**/
+
+#include "SmbiosMisc.h"
+
+SMBIOS_MISC_TABLE_EXTERNS (SMBIOS_TABLE_TYPE0,
+                           MiscBiosVendor,
+                           MiscBiosVendor)
+SMBIOS_MISC_TABLE_EXTERNS (SMBIOS_TABLE_TYPE1,
+                           MiscSystemManufacturer,
+                           MiscSystemManufacturer)
+SMBIOS_MISC_TABLE_EXTERNS (SMBIOS_TABLE_TYPE3,
+                          MiscChassisManufacturer,
+                          MiscChassisManufacturer)
+SMBIOS_MISC_TABLE_EXTERNS (SMBIOS_TABLE_TYPE2,
+                           MiscBaseBoardManufacturer,
+                           MiscBaseBoardManufacturer)
+SMBIOS_MISC_TABLE_EXTERNS (SMBIOS_TABLE_TYPE13,
+                           MiscNumberOfInstallableLanguages,
+                           MiscNumberOfInstallableLanguages)
+SMBIOS_MISC_TABLE_EXTERNS (SMBIOS_TABLE_TYPE32,
+                           MiscBootInformation,
+                           MiscBootInformation)
+
+
+SMBIOS_MISC_DATA_TABLE mSmbiosMiscDataTable[] = {
+  // Type0
+  SMBIOS_MISC_TABLE_ENTRY_DATA_AND_FUNCTION (MiscBiosVendor,
+                                             MiscBiosVendor),
+  // Type1
+  SMBIOS_MISC_TABLE_ENTRY_DATA_AND_FUNCTION (MiscSystemManufacturer,
+                                             MiscSystemManufacturer),
+  // Type3
+  SMBIOS_MISC_TABLE_ENTRY_DATA_AND_FUNCTION (MiscChassisManufacturer,
+                                             MiscChassisManufacturer),
+  // Type2
+  SMBIOS_MISC_TABLE_ENTRY_DATA_AND_FUNCTION (MiscBaseBoardManufacturer,
+                                             MiscBaseBoardManufacturer),
+  // Type13
+  SMBIOS_MISC_TABLE_ENTRY_DATA_AND_FUNCTION (MiscNumberOfInstallableLanguages,
+                                             MiscNumberOfInstallableLanguages),
+  // Type32
+  SMBIOS_MISC_TABLE_ENTRY_DATA_AND_FUNCTION (MiscBootInformation,
+                                             MiscBootInformation),
+};
+
+
+//
+// Number of Data Table entries.
+//
+UINTN mSmbiosMiscDataTableEntries =
+  (sizeof (mSmbiosMiscDataTable)) / sizeof (SMBIOS_MISC_DATA_TABLE);

--- a/ArmPkg/Universal/Smbios/SmbiosMiscDxe/SmbiosMiscDxe.inf
+++ b/ArmPkg/Universal/Smbios/SmbiosMiscDxe/SmbiosMiscDxe.inf
@@ -1,0 +1,89 @@
+#/** @file
+# Component description file for SmbiosMisc instance.
+#
+# Parses the MiscSubclassDataTable and reports any generated data to the DataHub.
+#  All .uni file who tagged with "ToolCode="DUMMY"" in following file list is included by
+#  MiscSubclassDriver.uni file, the StrGather tool will expand MiscSubclassDriver.uni file
+#  and parse all .uni file.
+#
+# Copyright (c) 2021, NUVIA Inc. All rights reserved.<BR>
+# Copyright (c) 2006 - 2010, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2015, Hisilicon Limited. All rights reserved.<BR>
+# Copyright (c) 2015, Linaro Limited. All rights reserved.<BR>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+#
+# Based on files under Nt32Pkg/MiscSubClassPlatformDxe/
+#**/
+
+
+[Defines]
+  INF_VERSION                    = 1.29
+  BASE_NAME                      = SmbiosMiscDxe
+  FILE_GUID                      = 7e5e26d4-0be9-401f-b5e1-1c2bda7ca777
+  MODULE_TYPE                    = DXE_DRIVER
+  VERSION_STRING                 = 1.0
+  ENTRY_POINT                    = SmbiosMiscEntryPoint
+
+[Sources]
+  SmbiosMisc.h
+  SmbiosMiscDataTable.c
+  SmbiosMiscEntryPoint.c
+  SmbiosMiscDxeStrings.uni
+  Type00/MiscBiosVendorData.c
+  Type00/MiscBiosVendorFunction.c
+  Type01/MiscSystemManufacturerData.c
+  Type01/MiscSystemManufacturerFunction.c
+  Type02/MiscBaseBoardManufacturerData.c
+  Type02/MiscBaseBoardManufacturerFunction.c
+  Type03/MiscChassisManufacturerData.c
+  Type03/MiscChassisManufacturerFunction.c
+  Type13/MiscNumberOfInstallableLanguagesData.c
+  Type13/MiscNumberOfInstallableLanguagesFunction.c
+  Type32/MiscBootInformationData.c
+  Type32/MiscBootInformationFunction.c
+
+[Packages]
+  ArmPkg/ArmPkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  MdePkg/MdePkg.dec
+
+[LibraryClasses]
+  BaseLib
+  BaseMemoryLib
+  DebugLib
+  DevicePathLib
+  PcdLib
+  HiiLib
+  HobLib
+  MemoryAllocationLib
+  OemMiscLib
+  UefiBootServicesTableLib
+  UefiDriverEntryPoint
+  UefiLib
+  UefiRuntimeServicesTableLib
+
+[Protocols]
+  gEfiSmbiosProtocolGuid                       # PROTOCOL ALWAYS_CONSUMED
+
+[Pcd]
+  gArmTokenSpaceGuid.PcdFdSize
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFirmwareVendor
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFirmwareVersionString
+  gArmTokenSpaceGuid.PcdSystemBiosRelease
+  gArmTokenSpaceGuid.PcdEmbeddedControllerFirmwareRelease
+  gArmTokenSpaceGuid.PcdSystemProductName
+  gArmTokenSpaceGuid.PcdSystemVersion
+  gArmTokenSpaceGuid.PcdBaseBoardManufacturer
+  gArmTokenSpaceGuid.PcdBaseBoardProductName
+  gArmTokenSpaceGuid.PcdBaseBoardVersion
+  gArmTokenSpaceGuid.PcdFdBaseAddress
+
+[Guids]
+  gEfiGenericVariableGuid
+
+[Depex]
+  gEfiSmbiosProtocolGuid
+
+

--- a/ArmPkg/Universal/Smbios/SmbiosMiscDxe/SmbiosMiscDxeStrings.uni
+++ b/ArmPkg/Universal/Smbios/SmbiosMiscDxe/SmbiosMiscDxeStrings.uni
@@ -1,0 +1,22 @@
+/** @file
+ *  Based on files under Nt32Pkg/MiscSubClassPlatformDxe/
+ *
+ *  Copyright (c) 2021, NUVIA Inc. All rights reserved.<BR>
+ *  Copyright (c) 2006 - 2010, Intel Corporation. All rights reserved.<BR>
+ *  Copyright (c) 2015, Hisilicon Limited. All rights reserved.<BR>
+ *  Copyright (c) 2015, Linaro Limited. All rights reserved.<BR>
+ *  SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ *
+**/
+
+
+/=#
+
+#langdef en-US "English"
+
+#include "Type00/MiscBiosVendor.uni"
+#include "Type01/MiscSystemManufacturer.uni"
+#include "Type02/MiscBaseBoardManufacturer.uni"
+#include "Type03/MiscChassisManufacturer.uni"
+#include "Type13/MiscNumberOfInstallableLanguages.uni"

--- a/ArmPkg/Universal/Smbios/SmbiosMiscDxe/SmbiosMiscEntryPoint.c
+++ b/ArmPkg/Universal/Smbios/SmbiosMiscDxe/SmbiosMiscEntryPoint.c
@@ -1,0 +1,223 @@
+/** @file
+  This driver parses the mSmbiosMiscDataTable structure and reports
+  any generated data using SMBIOS protocol.
+
+  Based on files under Nt32Pkg/MiscSubClassPlatformDxe/
+
+  Copyright (c) 2021, NUVIA Inc. All rights reserved.<BR>
+  Copyright (c) 2006 - 2011, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2015, Hisilicon Limited. All rights reserved.<BR>
+  Copyright (c) 2015, Linaro Limited. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
+#include <Library/HiiLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/UefiBootServicesTableLib.h>
+
+#include "SmbiosMisc.h"
+
+
+STATIC EFI_HANDLE           mSmbiosMiscImageHandle;
+STATIC EFI_SMBIOS_PROTOCOL  *mSmbiosMiscSmbios = NULL;
+
+EFI_HII_HANDLE       mSmbiosMiscHiiHandle;
+
+/**
+  Standard EFI driver point.  This driver parses the mSmbiosMiscDataTable
+  structure and reports any generated data using SMBIOS protocol.
+
+  @param  ImageHandle     Handle for the image of this driver
+  @param  SystemTable     Pointer to the EFI System Table
+
+  @retval  EFI_SUCCESS    The data was successfully stored.
+
+**/
+EFI_STATUS
+EFIAPI
+SmbiosMiscEntryPoint(
+  IN EFI_HANDLE         ImageHandle,
+  IN EFI_SYSTEM_TABLE   *SystemTable
+  )
+{
+  UINTN                Index;
+  EFI_STATUS           EfiStatus;
+
+  mSmbiosMiscImageHandle = ImageHandle;
+
+  EfiStatus = gBS->LocateProtocol (&gEfiSmbiosProtocolGuid, NULL,
+                                   (VOID**)&mSmbiosMiscSmbios);
+  if (EFI_ERROR (EfiStatus)) {
+    DEBUG ((DEBUG_ERROR, "Could not locate SMBIOS protocol.  %r\n", EfiStatus));
+    return EfiStatus;
+  }
+
+  mSmbiosMiscHiiHandle = HiiAddPackages (&gEfiCallerIdGuid,
+                                         mSmbiosMiscImageHandle,
+                                         SmbiosMiscDxeStrings,
+                                         NULL
+                                         );
+  if (mSmbiosMiscHiiHandle == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  for (Index = 0; Index < mSmbiosMiscDataTableEntries; ++Index) {
+    //
+    // If the entry have a function pointer, just log the data.
+    //
+    if (mSmbiosMiscDataTable[Index].Function != NULL) {
+      EfiStatus = (*mSmbiosMiscDataTable[Index].Function)(mSmbiosMiscDataTable[Index].RecordData,
+                                                          mSmbiosMiscSmbios
+                                                          );
+
+      if (EFI_ERROR(EfiStatus)) {
+        DEBUG ((DEBUG_ERROR, "Misc smbios store error.  Index=%d,"
+                "ReturnStatus=%r\n", Index, EfiStatus));
+        return EfiStatus;
+      }
+    }
+  }
+
+  return EfiStatus;
+}
+
+
+/**
+  Adds an SMBIOS record.
+
+  @param  Buffer        The data for the SMBIOS record.
+                        The format of the record is determined by
+                        EFI_SMBIOS_TABLE_HEADER.Type. The size of the
+                        formatted area is defined by EFI_SMBIOS_TABLE_HEADER.Length
+                        and either followed by a double-null (0x0000) or a set
+                        of null terminated strings and a null.
+  @param  SmbiosHandle  A unique handle will be assigned to the SMBIOS record
+                        if not NULL.
+
+  @retval EFI_SUCCESS           Record was added.
+  @retval EFI_OUT_OF_RESOURCES  Record was not added due to lack of system resources.
+  @retval EFI_ALREADY_STARTED   The SmbiosHandle passed in was already in use.
+
+**/
+EFI_STATUS
+SmbiosMiscAddRecord (
+  IN  UINT8                 *Buffer,
+  IN OUT EFI_SMBIOS_HANDLE  *SmbiosHandle OPTIONAL
+  )
+{
+  EFI_STATUS         Status;
+  EFI_SMBIOS_HANDLE  Handle;
+
+  Handle = SMBIOS_HANDLE_PI_RESERVED;
+
+  if (SmbiosHandle != NULL) {
+    Handle = *SmbiosHandle;
+  }
+
+  Status = mSmbiosMiscSmbios->Add (
+             mSmbiosMiscSmbios,
+             NULL,
+             &Handle,
+             (EFI_SMBIOS_TABLE_HEADER *)Buffer
+             );
+
+  if (SmbiosHandle != NULL) {
+    *SmbiosHandle = Handle;
+  }
+
+  return Status;
+}
+
+
+/** Fetches the number of handles of the specified SMBIOS type.
+ *
+ *  @param SmbiosType The type of SMBIOS record to look for.
+ *
+ *  @return The number of handles
+ *
+**/
+STATIC
+UINTN
+GetHandleCount (
+  IN  UINT8 SmbiosType
+  )
+{
+  UINTN                    HandleCount;
+  EFI_STATUS               Status;
+  EFI_SMBIOS_HANDLE        SmbiosHandle;
+  EFI_SMBIOS_TABLE_HEADER  *Record;
+
+  HandleCount = 0;
+
+  // Iterate through entries to get the number
+  do {
+    Status = mSmbiosMiscSmbios->GetNext (mSmbiosMiscSmbios,
+                                         &SmbiosHandle,
+                                         &SmbiosType,
+                                         &Record,
+                                         NULL
+                                         );
+
+    if (Status == EFI_SUCCESS) {
+      HandleCount++;
+    }
+  } while (!EFI_ERROR (Status));
+
+  return HandleCount;
+}
+
+/**
+  Fetches a list of the specified SMBIOS table types.
+
+  @param[in]  SmbiosType    The type of table to fetch
+  @param[out] **HandleArray The array of handles
+  @param[out] *HandleCount  Number of handles in the array
+**/
+VOID
+SmbiosMiscGetLinkTypeHandle(
+  IN  UINT8                 SmbiosType,
+  OUT SMBIOS_HANDLE         **HandleArray,
+  OUT UINTN                 *HandleCount
+  )
+{
+  UINTN                    Index;
+  EFI_STATUS               Status;
+  EFI_SMBIOS_HANDLE        SmbiosHandle;
+  EFI_SMBIOS_TABLE_HEADER  *Record;
+
+  if (mSmbiosMiscSmbios == NULL) {
+    return;
+  }
+
+  SmbiosHandle = SMBIOS_HANDLE_PI_RESERVED;
+  *HandleCount = GetHandleCount (SmbiosType);
+
+  *HandleArray = AllocateZeroPool (sizeof (SMBIOS_HANDLE) * (*HandleCount));
+  if (*HandleArray == NULL) {
+    DEBUG ((DEBUG_ERROR, "HandleArray allocate memory resource failed.\n"));
+    *HandleCount = 0;
+    return;
+  }
+
+  SmbiosHandle = SMBIOS_HANDLE_PI_RESERVED;
+
+  for (Index = 0; Index < (*HandleCount); Index++) {
+    Status = mSmbiosMiscSmbios->GetNext (mSmbiosMiscSmbios,
+                                         &SmbiosHandle,
+                                         &SmbiosType,
+                                         &Record,
+                                         NULL
+                                         );
+
+    if (!EFI_ERROR (Status)) {
+      (*HandleArray)[Index] = Record->Handle;
+    } else {
+      break;
+    }
+  }
+}
+

--- a/ArmPkg/Universal/Smbios/SmbiosMiscDxe/Type00/MiscBiosVendor.uni
+++ b/ArmPkg/Universal/Smbios/SmbiosMiscDxe/Type00/MiscBiosVendor.uni
@@ -1,0 +1,18 @@
+/** @file
+  Based on files under Nt32Pkg/MiscSubClassPlatformDxe/
+
+  Copyright (c) 2021, NUVIA Inc. All rights reserved.<BR>
+  Copyright (c) 2006 - 2010, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2015, Hisilicon Limited. All rights reserved.<BR>
+  Copyright (c) 2015, Linaro Limited. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+/=#
+
+#string STR_MISC_BIOS_VENDOR           #language en-US  "Not Specified"
+#string STR_MISC_BIOS_VERSION          #language en-US  "Not Specified"
+#string STR_MISC_BIOS_RELEASE_DATE     #language en-US  "Not Specified"
+#string STR_MISC_BIOS_VENDOR           #language en-US  "Not Specified"
+#string STR_MISC_BIOS_RELEASE_DATE     #language en-US  "12/02/2020"

--- a/ArmPkg/Universal/Smbios/SmbiosMiscDxe/Type00/MiscBiosVendorData.c
+++ b/ArmPkg/Universal/Smbios/SmbiosMiscDxe/Type00/MiscBiosVendorData.c
@@ -1,0 +1,93 @@
+/** @file
+  This file provides Smbios Type0 Data
+
+  Based on the files under Nt32Pkg/MiscSubClassPlatformDxe/
+
+  Copyright (c) 2021, NUVIA Inc. All rights reserved.<BR>
+  Copyright (c) 2006 - 2009, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2015, Hisilicon Limited. All rights reserved.<BR>
+  Copyright (c) 2015, Linaro Limited. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+
+#include "SmbiosMisc.h"
+
+
+//
+// Static (possibly build generated) Bios Vendor data.
+//
+SMBIOS_MISC_TABLE_DATA(SMBIOS_TABLE_TYPE0, MiscBiosVendor) = {
+  {                                          // Hdr
+    EFI_SMBIOS_TYPE_BIOS_INFORMATION,          // Type,
+    0,                                         // Length,
+    0                                          // Handle
+  },
+  1,                                         // Vendor
+  2,                                         // BiosVersion
+  0xE000,                                    // BiosSegment
+  3,                                         // BiosReleaseDate
+  0,                                         // BiosSize
+  {                                          // BiosCharacteristics
+    0,                                         // Reserved                          :2
+    0,                                         // Unknown                           :1
+    0,                                         // BiosCharacteristicsNotSupported   :1
+    0,                                         // IsaIsSupported                    :1
+    0,                                         // McaIsSupported                    :1
+    0,                                         // EisaIsSupported                   :1
+    1,                                         // PciIsSupported                    :1
+    0,                                         // PcmciaIsSupported                 :1
+    1,                                         // PlugAndPlayIsSupported            :1
+    0,                                         // ApmIsSupported                    :1
+    1,                                         // BiosIsUpgradable                  :1
+    1,                                         // BiosShadowingAllowed              :1
+    0,                                         // VlVesaIsSupported                 :1
+    0,                                         // EscdSupportIsAvailable            :1
+    1,                                         // BootFromCdIsSupported             :1
+    1,                                         // SelectableBootIsSupported         :1
+    0,                                         // RomBiosIsSocketed                 :1
+    0,                                         // BootFromPcmciaIsSupported         :1
+    0,                                         // EDDSpecificationIsSupported       :1
+    0,                                         // JapaneseNecFloppyIsSupported      :1
+    0,                                         // JapaneseToshibaFloppyIsSupported  :1
+    0,                                         // Floppy525_360IsSupported          :1
+    0,                                         // Floppy525_12IsSupported           :1
+    0,                                         // Floppy35_720IsSupported           :1
+    0,                                         // Floppy35_288IsSupported           :1
+    0,                                         // PrintScreenIsSupported            :1
+    0,                                         // Keyboard8042IsSupported           :1
+    0,                                         // SerialIsSupported                 :1
+    0,                                         // PrinterIsSupported                :1
+    0,                                         // CgaMonoIsSupported                :1
+    0,                                         // NecPc98                           :1
+    0                                          // ReservedForVendor                 :32
+  },
+
+  {
+    0x01,                                        // BIOSCharacteristicsExtensionBytes[0]
+    //  {                                          // BiosReserved
+    //    1,                                         // AcpiIsSupported                   :1
+    //    0,                                         // UsbLegacyIsSupported              :1
+    //    0,                                         // AgpIsSupported                    :1
+    //    0,                                         // I20BootIsSupported                :1
+    //    0,                                         // Ls120BootIsSupported              :1
+    //    0,                                         // AtapiZipDriveBootIsSupported      :1
+    //    0,                                         // Boot1394IsSupported               :1
+    //    0                                          // SmartBatteryIsSupported           :1
+    //  },
+    0x0C                                         //BIOSCharacteristicsExtensionBytes[1]
+    //  {                                          //SystemReserved
+    //    0,                                         //BiosBootSpecIsSupported            :1
+    //    0,                                         //FunctionKeyNetworkBootIsSupported  :1
+    //    1,                                         //TargetContentDistributionEnabled   :1
+    //    1,                                         //UefiSpecificationSupported         :1
+    //    0,                                         //VirtualMachineSupported            :1
+    //    0                                          //ExtensionByte2Reserved             :3
+    //  },
+  },
+  0xFF,                                        // SystemBiosMajorRelease;
+  0xFF,                                        // SystemBiosMinorRelease;
+  0xFF,                                     // EmbeddedControllerFirmwareMajorRelease;
+  0xFF                                      // EmbeddedControllerFirmwareMinorRelease;
+};

--- a/ArmPkg/Universal/Smbios/SmbiosMiscDxe/Type00/MiscBiosVendorFunction.c
+++ b/ArmPkg/Universal/Smbios/SmbiosMiscDxe/Type00/MiscBiosVendorFunction.c
@@ -1,0 +1,296 @@
+/** @file
+
+  Copyright (c) 2021, NUVIA Inc. All rights reserved.<BR>
+  Copyright (c) 2009, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2015, Hisilicon Limited. All rights reserved.<BR>
+  Copyright (c) 2015, Linaro Limited. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
+#include <Library/HiiLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/PrintLib.h>
+#include <Library/UefiBootServicesTableLib.h>
+
+#include "SmbiosMisc.h"
+
+
+typedef struct {
+  CONST CHAR8* MonthStr;
+  UINT32       MonthInt;
+} MONTH_DESCRIPTION;
+
+STATIC CONST
+MONTH_DESCRIPTION mMonthDescription[] = {
+  { "Jan", 1 },
+  { "Feb", 2 },
+  { "Mar", 3 },
+  { "Apr", 4 },
+  { "May", 5 },
+  { "Jun", 6 },
+  { "Jul", 7 },
+  { "Aug", 8 },
+  { "Sep", 9 },
+  { "Oct", 10 },
+  { "Nov", 11 },
+  { "Dec", 12 },
+  { "???", 1 },  // Use 1 as default month
+};
+
+/**
+  Field Filling Function. Transform an EFI_EXP_BASE2_DATA to a byte, with '64k'
+  as the unit.
+
+  @param  Value              Pointer to Base2_Data
+
+  @retval
+
+**/
+UINT8
+Base2ToByteWith64KUnit (
+  IN  UINTN  Value
+  )
+{
+  UINT8 Size;
+
+  Size = ((Value + (SIZE_64KB - 1)) >> 16);
+
+  return Size;
+}
+
+/**
+  Returns the date and time this file (and firmware) was built.
+
+  @param[out] *Time Pointer to the EFI_TIME structure to fill in.
+**/
+VOID
+GetReleaseTime (
+  OUT EFI_TIME *Time
+  )
+{
+  CONST CHAR8      *ReleaseDate = __DATE__;
+  CONST CHAR8      *ReleaseTime = __TIME__;
+  UINTN            i;
+
+  for (i = 0; i < 12; i++) {
+    if (AsciiStrnCmp (ReleaseDate, mMonthDescription[i].MonthStr, 3) == 0) {
+      break;
+    }
+  }
+
+  Time->Month = mMonthDescription[i].MonthInt;
+  Time->Day = AsciiStrDecimalToUintn (ReleaseDate + 4);
+  Time->Year = AsciiStrDecimalToUintn (ReleaseDate + 7);
+  Time->Hour = AsciiStrDecimalToUintn (ReleaseTime);
+  Time->Minute = AsciiStrDecimalToUintn (ReleaseTime + 3);
+  Time->Second = AsciiStrDecimalToUintn (ReleaseTime + 6);
+}
+
+/**
+  Fetches the firmware ('BIOS') release date from the
+  FirmwareVersionInfo HOB.
+
+  @return The release date as a UTF-16 string
+**/
+CHAR16 *
+GetBiosReleaseDate (
+  VOID
+  )
+{
+  CHAR16      *ReleaseDate;
+  EFI_TIME    BuildTime;
+
+  ReleaseDate = AllocateZeroPool ((sizeof (CHAR16)) * SMBIOS_STRING_MAX_LENGTH);
+  if (ReleaseDate == NULL) {
+      return NULL;
+  }
+
+  GetReleaseTime (&BuildTime);
+
+  (VOID)UnicodeSPrintAsciiFormat (ReleaseDate,
+                                  (sizeof (CHAR16)) * SMBIOS_STRING_MAX_LENGTH,
+                                  "%02d/%02d/%4d",
+                                  BuildTime.Month,
+                                  BuildTime.Day,
+                                  BuildTime.Year
+                                  );
+
+  return ReleaseDate;
+}
+
+/**
+  Fetches the firmware ('BIOS') version from the
+  FirmwareVersionInfo HOB.
+
+  @return The version as a UTF-16 string
+**/
+CHAR16 *
+GetBiosVersion (
+  VOID
+  )
+{
+  CHAR16 *ReleaseString;
+
+  ReleaseString = (CHAR16 *)FixedPcdGetPtr (PcdFirmwareVersionString);
+
+  return ReleaseString;
+}
+
+
+/**
+  This function makes boot time changes to the contents of the
+  MiscBiosVendor (Type 0) record.
+
+  @param  RecordData                 Pointer to SMBIOS table with default values.
+  @param  Smbios                     SMBIOS protocol.
+
+  @retval EFI_SUCCESS                The SMBIOS table was successfully added.
+  @retval EFI_INVALID_PARAMETER      Invalid parameter was found.
+  @retval EFI_OUT_OF_RESOURCES       Failed to allocate required memory.
+
+**/
+SMBIOS_MISC_TABLE_FUNCTION (MiscBiosVendor)
+{
+  CHAR8                 *OptionalStrStart;
+  CHAR8                 *StrStart;
+  UINTN                 VendorStrLen;
+  UINTN                 VerStrLen;
+  UINTN                 DateStrLen;
+  UINTN                 BiosPhysicalSize;
+  CHAR16                *Vendor;
+  CHAR16                *Version;
+  CHAR16                *ReleaseDate;
+  CHAR16                *Char16String;
+  EFI_STATUS            Status;
+  EFI_STRING_ID         TokenToUpdate;
+  EFI_STRING_ID         TokenToGet;
+  SMBIOS_TABLE_TYPE0    *SmbiosRecord;
+  SMBIOS_TABLE_TYPE0    *InputData;
+
+  //
+  // First check for invalid parameters.
+  //
+  if (RecordData == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  InputData = (SMBIOS_TABLE_TYPE0 *)RecordData;
+
+  Vendor = (CHAR16 *) PcdGetPtr (PcdFirmwareVendor);
+
+  if (StrLen (Vendor) > 0) {
+    TokenToUpdate = STRING_TOKEN (STR_MISC_BIOS_VENDOR);
+    HiiSetString (mSmbiosMiscHiiHandle, TokenToUpdate, Vendor, NULL);
+  }
+
+  Version = GetBiosVersion();
+
+  if (StrLen (Version) > 0) {
+    TokenToUpdate = STRING_TOKEN (STR_MISC_BIOS_VERSION);
+    HiiSetString (mSmbiosMiscHiiHandle, TokenToUpdate, Version, NULL);
+  } else {
+    Version = (CHAR16 *) PcdGetPtr (PcdFirmwareVersionString);
+    if (StrLen (Version) > 0) {
+      TokenToUpdate = STRING_TOKEN (STR_MISC_BIOS_VERSION);
+      HiiSetString (mSmbiosMiscHiiHandle, TokenToUpdate, Version, NULL);
+    }
+  }
+
+  Char16String = GetBiosReleaseDate ();
+  if (StrLen(Char16String) > 0) {
+    TokenToUpdate = STRING_TOKEN (STR_MISC_BIOS_RELEASE_DATE);
+    HiiSetString (mSmbiosMiscHiiHandle, TokenToUpdate, Char16String, NULL);
+  }
+
+  TokenToGet = STRING_TOKEN (STR_MISC_BIOS_VENDOR);
+  Vendor = HiiGetPackageString (&gEfiCallerIdGuid, TokenToGet, NULL);
+  VendorStrLen = StrLen (Vendor);
+
+  TokenToGet = STRING_TOKEN (STR_MISC_BIOS_VERSION);
+  Version = HiiGetPackageString (&gEfiCallerIdGuid, TokenToGet, NULL);
+  VerStrLen = StrLen (Version);
+
+  TokenToGet = STRING_TOKEN (STR_MISC_BIOS_RELEASE_DATE);
+  ReleaseDate = HiiGetPackageString (&gEfiCallerIdGuid, TokenToGet, NULL);
+  DateStrLen = StrLen (ReleaseDate);
+
+  //
+  // Now update the BiosPhysicalSize
+  //
+  BiosPhysicalSize = FixedPcdGet32 (PcdFdSize);
+
+  //
+  // Two zeros following the last string.
+  //
+  SmbiosRecord = AllocateZeroPool (sizeof (SMBIOS_TABLE_TYPE0) + VendorStrLen + 1 +
+                                   VerStrLen + 1 +
+                                   DateStrLen + 1 + 1);
+  if (SmbiosRecord == NULL) {
+    Status = EFI_OUT_OF_RESOURCES;
+    goto Exit;
+  }
+
+  (VOID)CopyMem (SmbiosRecord, InputData, sizeof (SMBIOS_TABLE_TYPE0));
+
+  SmbiosRecord->Hdr.Length = sizeof (SMBIOS_TABLE_TYPE0);
+  SmbiosRecord->BiosSegment = (UINT16)(FixedPcdGet32 (PcdFdBaseAddress) / SIZE_64KB);
+  if (BiosPhysicalSize < SIZE_16MB) {
+    SmbiosRecord->BiosSize = Base2ToByteWith64KUnit (BiosPhysicalSize) - 1;
+    SmbiosRecord->ExtendedBiosSize.Size = BiosPhysicalSize / SIZE_1MB;
+    SmbiosRecord->ExtendedBiosSize.Unit = 0; // Size is in MB
+  } else {
+    SmbiosRecord->BiosSize = 0xFF;
+    if (BiosPhysicalSize > 0x3FFF) {
+      SmbiosRecord->ExtendedBiosSize.Size = BiosPhysicalSize / SIZE_1GB;
+      SmbiosRecord->ExtendedBiosSize.Unit = 1; // Size is in GB
+    }
+  }
+
+  SmbiosRecord->SystemBiosMajorRelease = (UINT8) (PcdGet16 (PcdSystemBiosRelease) >> 8);
+  SmbiosRecord->SystemBiosMinorRelease = (UINT8) (PcdGet16 (PcdSystemBiosRelease) & 0xFF);
+
+  SmbiosRecord->EmbeddedControllerFirmwareMajorRelease = (UINT16)
+    (PcdGet16 (PcdEmbeddedControllerFirmwareRelease) >> 8);
+  SmbiosRecord->EmbeddedControllerFirmwareMinorRelease = (UINT16)
+    (PcdGet16 (PcdEmbeddedControllerFirmwareRelease) & 0xFF);
+
+  OptionalStrStart = (CHAR8 *)(SmbiosRecord + 1);
+  UnicodeStrToAsciiStrS (Vendor, OptionalStrStart, VendorStrLen + 1);
+  StrStart = OptionalStrStart + VendorStrLen + 1;
+  UnicodeStrToAsciiStrS (Version, StrStart, VerStrLen + 1);
+  StrStart += VerStrLen + 1;
+  UnicodeStrToAsciiStrS (ReleaseDate, StrStart, DateStrLen + 1);
+  //
+  // Now we have got the full smbios record, call smbios protocol to add this record.
+  //
+  Status = SmbiosMiscAddRecord ((UINT8*)SmbiosRecord, NULL);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "[%a]:[%dL] Smbios Type00 Table Log Failed! %r \n",
+           __FUNCTION__, __LINE__, Status));
+  }
+
+  FreePool (SmbiosRecord);
+
+Exit:
+  if (Vendor != NULL) {
+    FreePool (Vendor);
+  }
+
+  if (Version != NULL) {
+    FreePool (Version);
+  }
+
+  if (ReleaseDate != NULL) {
+    FreePool (ReleaseDate);
+  }
+
+  if (Char16String != NULL) {
+    FreePool (Char16String);
+  }
+
+  return Status;
+}

--- a/ArmPkg/Universal/Smbios/SmbiosMiscDxe/Type01/MiscSystemManufacturer.uni
+++ b/ArmPkg/Universal/Smbios/SmbiosMiscDxe/Type01/MiscSystemManufacturer.uni
@@ -1,0 +1,20 @@
+/** @file
+  Based on files under Nt32Pkg/MiscSubClassPlatformDxe/
+
+  Copyright (c) 2021, NUVIA Inc. All rights reserved.<BR>
+  Copyright (c) 2006 - 2010, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2015, Hisilicon Limited. All rights reserved.<BR>
+  Copyright (c) 2015, Linaro Limited. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+/=#
+
+#string STR_MISC_SYSTEM_MANUFACTURER   #language en-US  "Not Specified"
+#string STR_MISC_SYSTEM_PRODUCT_NAME   #language en-US  "Not Specified"
+#string STR_MISC_SYSTEM_PRODUCT_NAME   #language en-US  "Not Specified"
+#string STR_MISC_SYSTEM_VERSION        #language en-US  "Not Specified"
+#string STR_MISC_SYSTEM_SERIAL_NUMBER  #language en-US  "Not Specified"
+#string STR_MISC_SYSTEM_SKU_NUMBER     #language en-US  "Not Specified"
+#string STR_MISC_SYSTEM_FAMILY         #language en-US  "Not Specified"

--- a/ArmPkg/Universal/Smbios/SmbiosMiscDxe/Type01/MiscSystemManufacturerData.c
+++ b/ArmPkg/Universal/Smbios/SmbiosMiscDxe/Type01/MiscSystemManufacturerData.c
@@ -1,0 +1,36 @@
+/** @file
+  This file provides Smbios Type1 Data
+
+  Based on files under Nt32Pkg/MiscSubClassPlatformDxe/
+
+  Copyright (c) 2021, NUVIA Inc. All rights reserved.<BR>
+  Copyright (c) 2006 - 2009, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2015, Hisilicon Limited. All rights reserved.<BR>
+  Copyright (c) 2015, Linaro Limited. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "SmbiosMisc.h"
+
+
+//
+// Static (possibly build generated) System Manufacturer data.
+//
+SMBIOS_MISC_TABLE_DATA(SMBIOS_TABLE_TYPE1, MiscSystemManufacturer) = {
+  {                                               // Hdr
+    EFI_SMBIOS_TYPE_SYSTEM_INFORMATION,             // Type,
+    0,                                              // Length,
+    0                                               // Handle
+  },
+  1,                                              // Manufacturer
+  2,                                              // ProductName
+  3,                                              // Version
+  4,                                              // SerialNumber
+  {                                               // Uuid
+    0x00000000, 0x0000, 0x0000, {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
+  },
+  SystemWakeupTypePowerSwitch,                    // SystemWakeupType
+  5,                                              // SKUNumber,
+  6                                               // Family
+};

--- a/ArmPkg/Universal/Smbios/SmbiosMiscDxe/Type01/MiscSystemManufacturerFunction.c
+++ b/ArmPkg/Universal/Smbios/SmbiosMiscDxe/Type01/MiscSystemManufacturerFunction.c
@@ -1,0 +1,196 @@
+/** @file
+  This driver parses the mMiscSubclassDataTable structure and reports
+  any generated data to smbios.
+
+  Based on files under Nt32Pkg/MiscSubClassPlatformDxe/
+
+  Copyright (c) 2021, NUVIA Inc. All rights reserved.<BR>
+  Copyright (c) 2006 - 2011, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2015, Hisilicon Limited. All rights reserved.<BR>
+  Copyright (c) 2015, Linaro Limited. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
+#include <Library/HiiLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/OemMiscLib.h>
+#include <Library/PrintLib.h>
+#include <Library/UefiBootServicesTableLib.h>
+
+#include "SmbiosMisc.h"
+
+/**
+  This function makes boot time changes to the contents of the
+  MiscSystemManufacturer (Type 1) record.
+
+  @param  RecordData                 Pointer to SMBIOS table with default values.
+  @param  Smbios                     SMBIOS protocol.
+
+  @retval EFI_SUCCESS                The SMBIOS table was successfully added.
+  @retval EFI_INVALID_PARAMETER      Invalid parameter was found.
+  @retval EFI_OUT_OF_RESOURCES       Failed to allocate required memory.
+
+**/
+SMBIOS_MISC_TABLE_FUNCTION(MiscSystemManufacturer)
+{
+  CHAR8                           *OptionalStrStart;
+  CHAR8                           *StrStart;
+  UINTN                           ManuStrLen;
+  UINTN                           VerStrLen;
+  UINTN                           PdNameStrLen;
+  UINTN                           SerialNumStrLen;
+  UINTN                           SKUNumStrLen;
+  UINTN                           FamilyStrLen;
+  UINTN                           RecordLength;
+  EFI_STRING                      Manufacturer;
+  EFI_STRING                      ProductName;
+  EFI_STRING                      Version;
+  EFI_STRING                      SerialNumber;
+  EFI_STRING                      SKUNumber;
+  EFI_STRING                      Family;
+  EFI_STRING_ID                   TokenToGet;
+  SMBIOS_TABLE_TYPE1              *SmbiosRecord;
+  SMBIOS_TABLE_TYPE1              *InputData;
+  EFI_STATUS                      Status;
+  EFI_STRING_ID                   TokenToUpdate;
+  CHAR16                          *Product;
+  CHAR16                          *pVersion;
+
+  Status = EFI_SUCCESS;
+
+  //
+  // First check for invalid parameters.
+  //
+  if (RecordData == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  InputData = (SMBIOS_TABLE_TYPE1 *)RecordData;
+
+  Product = (CHAR16 *) PcdGetPtr (PcdSystemProductName);
+  if (StrLen (Product) > 0) {
+    TokenToUpdate = STRING_TOKEN (STR_MISC_SYSTEM_PRODUCT_NAME);
+    HiiSetString (mSmbiosMiscHiiHandle, TokenToUpdate, Product, NULL);
+  }
+
+  pVersion = (CHAR16 *) PcdGetPtr (PcdSystemVersion);
+  if (StrLen (pVersion) > 0) {
+    TokenToUpdate = STRING_TOKEN (STR_MISC_SYSTEM_VERSION);
+    HiiSetString (mSmbiosMiscHiiHandle, TokenToUpdate, pVersion, NULL);
+  }
+
+  OemUpdateSmbiosInfo (mSmbiosMiscHiiHandle,
+                       STRING_TOKEN (STR_MISC_SYSTEM_SERIAL_NUMBER),
+                       SerialNumType01);
+  OemUpdateSmbiosInfo (mSmbiosMiscHiiHandle,
+                       STRING_TOKEN (STR_MISC_SYSTEM_MANUFACTURER),
+                       SystemManufacturerType01);
+  OemUpdateSmbiosInfo (mSmbiosMiscHiiHandle,
+                       STRING_TOKEN (STR_MISC_SYSTEM_SKU_NUMBER),
+                       SkuNumberType01);
+  OemUpdateSmbiosInfo (mSmbiosMiscHiiHandle,
+                       STRING_TOKEN (STR_MISC_SYSTEM_FAMILY),
+                       FamilyType01);
+
+  TokenToGet   = STRING_TOKEN (STR_MISC_SYSTEM_MANUFACTURER);
+  Manufacturer = HiiGetPackageString (&gEfiCallerIdGuid, TokenToGet, NULL);
+  ManuStrLen   = StrLen (Manufacturer);
+
+  TokenToGet   = STRING_TOKEN (STR_MISC_SYSTEM_PRODUCT_NAME);
+  ProductName  = HiiGetPackageString (&gEfiCallerIdGuid, TokenToGet, NULL);
+  PdNameStrLen = StrLen (ProductName);
+
+  TokenToGet = STRING_TOKEN (STR_MISC_SYSTEM_VERSION);
+  Version    = HiiGetPackageString (&gEfiCallerIdGuid, TokenToGet, NULL);
+  VerStrLen  = StrLen (Version);
+
+  TokenToGet      = STRING_TOKEN (STR_MISC_SYSTEM_SERIAL_NUMBER);
+  SerialNumber    = HiiGetPackageString (&gEfiCallerIdGuid, TokenToGet, NULL);
+  SerialNumStrLen = StrLen (SerialNumber);
+
+  TokenToGet   = STRING_TOKEN (STR_MISC_SYSTEM_SKU_NUMBER);
+  SKUNumber    = HiiGetPackageString (&gEfiCallerIdGuid, TokenToGet, NULL);
+  SKUNumStrLen = StrLen (SKUNumber);
+
+  TokenToGet   = STRING_TOKEN (STR_MISC_SYSTEM_FAMILY);
+  Family       = HiiGetPackageString (&gEfiCallerIdGuid, TokenToGet, NULL);
+  FamilyStrLen = StrLen (Family);
+
+  //
+  // Two zeros following the last string.
+  //
+  RecordLength = sizeof (SMBIOS_TABLE_TYPE1) +
+                 ManuStrLen      + 1 +
+                 PdNameStrLen    + 1 +
+                 VerStrLen       + 1 +
+                 SerialNumStrLen + 1 +
+                 SKUNumStrLen    + 1 +
+                 FamilyStrLen    + 1 + 1;
+  SmbiosRecord = AllocateZeroPool (RecordLength);
+
+  if (SmbiosRecord == NULL) {
+    Status = EFI_OUT_OF_RESOURCES;
+    goto Exit;
+  }
+
+  (VOID)CopyMem (SmbiosRecord, InputData, sizeof (SMBIOS_TABLE_TYPE1));
+
+  SmbiosRecord->Hdr.Length = sizeof (SMBIOS_TABLE_TYPE1);
+
+  CopyGuid(&SmbiosRecord->Uuid, &InputData->Uuid);
+
+  OptionalStrStart = (CHAR8 *)(SmbiosRecord + 1);
+  UnicodeStrToAsciiStrS (Manufacturer, OptionalStrStart, ManuStrLen + 1);
+  StrStart = OptionalStrStart + ManuStrLen + 1;
+  UnicodeStrToAsciiStrS (ProductName,  StrStart, PdNameStrLen + 1);
+  StrStart += PdNameStrLen + 1;
+  UnicodeStrToAsciiStrS (Version, StrStart, VerStrLen + 1);
+  StrStart += VerStrLen + 1;
+  UnicodeStrToAsciiStrS (SerialNumber, StrStart, SerialNumStrLen + 1);
+  StrStart += SerialNumStrLen + 1;
+  UnicodeStrToAsciiStrS (SKUNumber, StrStart, SKUNumStrLen + 1);
+  StrStart += SKUNumStrLen + 1;
+  UnicodeStrToAsciiStrS (Family, StrStart, FamilyStrLen + 1);
+
+  //
+  // Now we have got the full smbios record, call smbios protocol to add this record.
+  //
+  Status = SmbiosMiscAddRecord ((UINT8*)SmbiosRecord, NULL);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "[%a]:[%dL] Smbios Type01 Table Log Failed! %r \n",
+            __FUNCTION__, __LINE__, Status));
+  }
+
+  FreePool (SmbiosRecord);
+
+Exit:
+  if (Manufacturer != NULL) {
+    FreePool (Manufacturer);
+  }
+
+  if (ProductName != NULL) {
+    FreePool (ProductName);
+  }
+
+  if (Version != NULL) {
+    FreePool (Version);
+  }
+
+  if (SerialNumber != NULL) {
+    FreePool (SerialNumber);
+  }
+
+  if (SKUNumber != NULL) {
+    FreePool (SKUNumber);
+  }
+
+  if (Family != NULL) {
+    FreePool (Family);
+  }
+
+  return Status;
+}

--- a/ArmPkg/Universal/Smbios/SmbiosMiscDxe/Type02/MiscBaseBoardManufacturer.uni
+++ b/ArmPkg/Universal/Smbios/SmbiosMiscDxe/Type02/MiscBaseBoardManufacturer.uni
@@ -1,0 +1,20 @@
+/** @file
+  Based on files under Nt32Pkg/MiscSubClassPlatformDxe/
+
+  Copyright (c) 2021, NUVIA Inc. All rights reserved.<BR>
+  Copyright (c) 2006 - 2010, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2015, Hisilicon Limited. All rights reserved.<BR>
+  Copyright (c) 2015, Linaro Limited. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+/=#
+
+#string STR_MISC_BASE_BOARD_MANUFACTURER     #language en-US  "Not Specified"
+#string STR_MISC_BASE_BOARD_PRODUCT_NAME     #language en-US  "Not Specified"
+#string STR_MISC_BASE_BOARD_VERSION          #language en-US  "Not Specified"
+#string STR_MISC_BASE_BOARD_SERIAL_NUMBER    #language en-US  "Not Specified"
+#string STR_MISC_BASE_BOARD_ASSET_TAG        #language en-US  "Not Specified"
+#string STR_MISC_BASE_BOARD_CHASSIS_LOCATION #language en-US  "Not Specified"
+#string STR_MISC_BASE_BOARD_SKU_NUMBER       #language en-US  "Not Specified"

--- a/ArmPkg/Universal/Smbios/SmbiosMiscDxe/Type02/MiscBaseBoardManufacturerData.c
+++ b/ArmPkg/Universal/Smbios/SmbiosMiscDxe/Type02/MiscBaseBoardManufacturerData.c
@@ -1,0 +1,46 @@
+/** @file
+
+  This file provide OEM to define Smbios Type2 Data
+
+  Based on files under Nt32Pkg/MiscSubClassPlatformDxe/
+
+  Copyright (c) 2021, NUVIA Inc. All rights reserved.<BR>
+  Copyright (c) 2006 - 2009, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2015, Hisilicon Limited. All rights reserved.<BR>
+  Copyright (c) 2015, Linaro Limited. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "SmbiosMisc.h"
+
+//
+// Static (possibly build generated) Chassis Manufacturer data.
+//
+SMBIOS_MISC_TABLE_DATA(SMBIOS_TABLE_TYPE2, MiscBaseBoardManufacturer) = {
+  {                                                       // Hdr
+    EFI_SMBIOS_TYPE_BASEBOARD_INFORMATION,                // Type,
+    0,                                                    // Length,
+    0                                                     // Handle
+  },
+  1,                                                      // BaseBoardManufacturer
+  2,                                                      // BaseBoardProductName
+  3,                                                      // BaseBoardVersion
+  4,                                                      // BaseBoardSerialNumber
+  5,                                                      // BaseBoardAssetTag
+  {                                                       // FeatureFlag
+    1,                                                    // Motherboard           :1
+    0,                                                    // RequiresDaughterCard  :1
+    0,                                                    // Removable             :1
+    1,                                                    // Replaceable           :1
+    0,                                                    // HotSwappable          :1
+    0                                                     // Reserved              :3
+  },
+  6,                                                      // BaseBoardChassisLocation
+  0,                                                      // ChassisHandle;
+  BaseBoardTypeMotherBoard,                               // BoardType;
+  0,                                                      // NumberOfContainedObjectHandles;
+  {
+    0
+  }                                                       // ContainedObjectHandles[1];
+};

--- a/ArmPkg/Universal/Smbios/SmbiosMiscDxe/Type02/MiscBaseBoardManufacturerFunction.c
+++ b/ArmPkg/Universal/Smbios/SmbiosMiscDxe/Type02/MiscBaseBoardManufacturerFunction.c
@@ -1,0 +1,230 @@
+/** @file
+  This driver parses the mSmbiosMiscDataTable structure and reports
+  any generated data using SMBIOS protocol.
+
+  Based on files under Nt32Pkg/MiscSubClassPlatformDxe/
+
+  Copyright (c) 2021, NUVIA Inc. All rights reserved.<BR>
+  Copyright (c) 2009 - 2011, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2015, Hisilicon Limited. All rights reserved.<BR>
+  Copyright (c) 2015, Linaro Limited. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
+#include <Library/HiiLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/OemMiscLib.h>
+#include <Library/PrintLib.h>
+#include <Library/UefiBootServicesTableLib.h>
+
+#include "SmbiosMisc.h"
+
+
+/**
+  This function makes boot time changes to the contents of the
+  MiscBaseBoardManufacturer (Type 2) record.
+
+  @param  RecordData                 Pointer to SMBIOS table with default values.
+  @param  Smbios                     SMBIOS protocol.
+
+  @retval EFI_SUCCESS                The SMBIOS table was successfully added.
+  @retval EFI_INVALID_PARAMETER      Invalid parameter was found.
+  @retval EFI_OUT_OF_RESOURCES       Failed to allocate required memory.
+
+**/
+SMBIOS_MISC_TABLE_FUNCTION(MiscBaseBoardManufacturer)
+{
+  CHAR8                             *OptionalStrStart;
+  CHAR8                             *StrStart;
+  UINTN                             RecordLength;
+  UINTN                             ManuStrLen;
+  UINTN                             ProductNameStrLen;
+  UINTN                             VerStrLen;
+  UINTN                             SerialNumStrLen;
+  UINTN                             AssetTagStrLen;
+  UINTN                             ChassisLocaStrLen;
+  UINTN                             HandleCount;
+  UINT16                            *HandleArray;
+  CHAR16                            *BaseBoardManufacturer;
+  CHAR16                            *BaseBoardProductName;
+  CHAR16                            *Version;
+  EFI_STRING                        SerialNumber;
+  EFI_STRING                        AssetTag;
+  EFI_STRING                        ChassisLocation;
+  EFI_STRING_ID                     TokenToGet;
+  SMBIOS_TABLE_TYPE2                *SmbiosRecord;
+  SMBIOS_TABLE_TYPE2                *InputData;
+  EFI_STATUS                        Status;
+
+  EFI_STRING_ID                     TokenToUpdate;
+
+  HandleCount = 0;
+  HandleArray = NULL;
+  InputData = NULL;
+
+  //
+  // First check for invalid parameters.
+  //
+  if (RecordData == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  InputData = (SMBIOS_TABLE_TYPE2*)RecordData;
+
+  BaseBoardManufacturer = (CHAR16 *) PcdGetPtr (PcdBaseBoardManufacturer);
+  if (StrLen (BaseBoardManufacturer) > 0) {
+    TokenToUpdate = STRING_TOKEN (STR_MISC_BASE_BOARD_MANUFACTURER);
+    HiiSetString (mSmbiosMiscHiiHandle, TokenToUpdate, BaseBoardManufacturer, NULL);
+  }
+
+  BaseBoardProductName = (CHAR16 *) PcdGetPtr (PcdBaseBoardProductName);
+  if (StrLen (BaseBoardProductName) > 0) {
+    TokenToUpdate = STRING_TOKEN (STR_MISC_BASE_BOARD_PRODUCT_NAME);
+    HiiSetString (mSmbiosMiscHiiHandle, TokenToUpdate, BaseBoardProductName, NULL);
+  }
+
+  Version = (CHAR16 *) PcdGetPtr (PcdBaseBoardVersion);
+  if (StrLen (Version) > 0) {
+    TokenToUpdate = STRING_TOKEN (STR_MISC_BASE_BOARD_VERSION);
+    HiiSetString (mSmbiosMiscHiiHandle, TokenToUpdate, Version, NULL);
+  }
+
+  OemUpdateSmbiosInfo (mSmbiosMiscHiiHandle,
+    STRING_TOKEN (STR_MISC_BASE_BOARD_ASSET_TAG),
+    AssertTagType02
+    );
+  OemUpdateSmbiosInfo (mSmbiosMiscHiiHandle,
+    STRING_TOKEN (STR_MISC_BASE_BOARD_SERIAL_NUMBER),
+    SerialNumberType02
+    );
+  OemUpdateSmbiosInfo (mSmbiosMiscHiiHandle,
+    STRING_TOKEN (STR_MISC_BASE_BOARD_MANUFACTURER),
+    BoardManufacturerType02
+    );
+  OemUpdateSmbiosInfo (mSmbiosMiscHiiHandle,
+    STRING_TOKEN (STR_MISC_BASE_BOARD_SERIAL_NUMBER),
+    SerialNumberType02
+    );
+  OemUpdateSmbiosInfo (mSmbiosMiscHiiHandle,
+    STRING_TOKEN (STR_MISC_BASE_BOARD_SKU_NUMBER),
+    SerialNumberType02
+    );
+  OemUpdateSmbiosInfo (mSmbiosMiscHiiHandle,
+    STRING_TOKEN (STR_MISC_BASE_BOARD_CHASSIS_LOCATION),
+    ChassisLocationType02
+    );
+
+  TokenToGet = STRING_TOKEN (STR_MISC_BASE_BOARD_MANUFACTURER);
+  BaseBoardManufacturer = HiiGetPackageString (&gEfiCallerIdGuid, TokenToGet, NULL);
+  ManuStrLen = StrLen (BaseBoardManufacturer);
+
+  TokenToGet = STRING_TOKEN (STR_MISC_BASE_BOARD_PRODUCT_NAME);
+  BaseBoardProductName = HiiGetPackageString (&gEfiCallerIdGuid, TokenToGet, NULL);
+  ProductNameStrLen = StrLen (BaseBoardProductName);
+
+  TokenToGet = STRING_TOKEN (STR_MISC_BASE_BOARD_VERSION);
+  Version = HiiGetPackageString (&gEfiCallerIdGuid, TokenToGet, NULL);
+  VerStrLen = StrLen (Version);
+
+  TokenToGet = STRING_TOKEN (STR_MISC_BASE_BOARD_SERIAL_NUMBER);
+  SerialNumber = HiiGetPackageString (&gEfiCallerIdGuid, TokenToGet, NULL);
+  SerialNumStrLen = StrLen (SerialNumber);
+
+  TokenToGet = STRING_TOKEN (STR_MISC_BASE_BOARD_ASSET_TAG);
+  AssetTag = HiiGetPackageString (&gEfiCallerIdGuid, TokenToGet, NULL);
+  AssetTagStrLen = StrLen (AssetTag);
+
+  TokenToGet = STRING_TOKEN (STR_MISC_BASE_BOARD_CHASSIS_LOCATION);
+  ChassisLocation = HiiGetPackageString (&gEfiCallerIdGuid, TokenToGet, NULL);
+  ChassisLocaStrLen = StrLen (ChassisLocation);
+
+  //
+  // Two zeros following the last string.
+  //
+  RecordLength = sizeof (SMBIOS_TABLE_TYPE2) +
+                 ManuStrLen        + 1 +
+                 ProductNameStrLen + 1 +
+                 VerStrLen         + 1 +
+                 SerialNumStrLen   + 1 +
+                 AssetTagStrLen    + 1 +
+                 ChassisLocaStrLen + 1 + 1;
+  SmbiosRecord = AllocateZeroPool (RecordLength);
+  if (SmbiosRecord == NULL) {
+    Status = EFI_OUT_OF_RESOURCES;
+    goto Exit;
+  }
+
+  (VOID)CopyMem (SmbiosRecord, InputData, sizeof (SMBIOS_TABLE_TYPE2));
+  SmbiosRecord->Hdr.Length        = sizeof (SMBIOS_TABLE_TYPE2);
+
+  //
+  //  Update Contained objects Handle
+  //
+  SmbiosRecord->NumberOfContainedObjectHandles = 0;
+  SmbiosMiscGetLinkTypeHandle (EFI_SMBIOS_TYPE_SYSTEM_ENCLOSURE, &HandleArray,
+                               &HandleCount);
+  // It's assumed there's at most a single chassis
+  ASSERT (HandleCount < 2);
+  if (HandleCount > 0) {
+    SmbiosRecord->ChassisHandle = HandleArray[0];
+  }
+
+  FreePool (HandleArray);
+
+  OptionalStrStart = (CHAR8 *)(SmbiosRecord + 1);
+  UnicodeStrToAsciiStrS (BaseBoardManufacturer, OptionalStrStart, ManuStrLen + 1);
+
+  StrStart = OptionalStrStart + ManuStrLen + 1;
+  UnicodeStrToAsciiStrS (BaseBoardProductName, StrStart, ProductNameStrLen + 1);
+
+  StrStart += ProductNameStrLen + 1;
+  UnicodeStrToAsciiStrS (Version, StrStart, VerStrLen + 1);
+
+  StrStart += VerStrLen + 1;
+  UnicodeStrToAsciiStrS (SerialNumber, StrStart, SerialNumStrLen + 1);
+
+  StrStart += SerialNumStrLen + 1;
+  UnicodeStrToAsciiStrS (AssetTag, StrStart, AssetTagStrLen + 1);
+
+  StrStart += AssetTagStrLen + 1;
+  UnicodeStrToAsciiStrS (ChassisLocation, StrStart, ChassisLocaStrLen + 1);
+
+  Status = SmbiosMiscAddRecord ((UINT8 *)SmbiosRecord, NULL);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "[%a]:[%dL] Smbios Type02 Table Log Failed! %r \n",
+            __FUNCTION__, __LINE__, Status));
+  }
+
+  FreePool (SmbiosRecord);
+
+Exit:
+  if (BaseBoardManufacturer != NULL) {
+    FreePool (BaseBoardManufacturer);
+  }
+
+  if (BaseBoardProductName != NULL) {
+    FreePool (BaseBoardProductName);
+  }
+
+  if (Version != NULL) {
+    FreePool (Version);
+  }
+
+  if (SerialNumber != NULL) {
+    FreePool (SerialNumber);
+  }
+
+  if (AssetTag != NULL) {
+    FreePool (AssetTag);
+  }
+
+  if (ChassisLocation != NULL) {
+    FreePool (ChassisLocation);
+  }
+
+  return 0;
+}

--- a/ArmPkg/Universal/Smbios/SmbiosMiscDxe/Type03/MiscChassisManufacturer.uni
+++ b/ArmPkg/Universal/Smbios/SmbiosMiscDxe/Type03/MiscChassisManufacturer.uni
@@ -1,0 +1,18 @@
+/** @file
+  Based on files under Nt32Pkg/MiscSubClassPlatformDxe/
+
+  Copyright (c) 2021, NUVIA Inc. All rights reserved.<BR>
+  Copyright (c) 2006 - 2010, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2015, Hisilicon Limited. All rights reserved.<BR>
+  Copyright (c) 2015, Linaro Limited. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+/=#
+
+#string STR_MISC_CHASSIS_MANUFACTURER  #language en-US  "Not Specified"
+#string STR_MISC_CHASSIS_VERSION       #language en-US  "Not Specified"
+#string STR_MISC_CHASSIS_SERIAL_NUMBER #language en-US  "Not Specified"
+#string STR_MISC_CHASSIS_ASSET_TAG     #language en-US  "Not Specified"
+#string STR_MISC_CHASSIS_SKU_NUMBER    #language en-US  "Not Specified"

--- a/ArmPkg/Universal/Smbios/SmbiosMiscDxe/Type03/MiscChassisManufacturerData.c
+++ b/ArmPkg/Universal/Smbios/SmbiosMiscDxe/Type03/MiscChassisManufacturerData.c
@@ -1,0 +1,52 @@
+/** @file
+  This file provides Smbios Type3 Data
+
+  Based on files under Nt32Pkg/MiscSubClassPlatformDxe/
+
+  Copyright (c) 2021, NUVIA Inc. All rights reserved.<BR>
+  Copyright (c) 2006 - 2009, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2015, Hisilicon Limited. All rights reserved.<BR>
+  Copyright (c) 2015, Linaro Limited. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "SmbiosMisc.h"
+
+
+//
+// Static (possibly build generated) Chassis Manufacturer data.
+//
+SMBIOS_MISC_TABLE_DATA(SMBIOS_TABLE_TYPE3, MiscChassisManufacturer) = {
+  {                                                       // Hdr
+    EFI_SMBIOS_TYPE_SYSTEM_ENCLOSURE,                     // Type,
+    0,                                                    // Length,
+    0                                                     // Handle
+  },
+  1,                                                      // Manufactrurer
+  MiscChassisTypeMainServerChassis,                       // Type
+  2,                                                      // Version
+  3,                                                      // SerialNumber
+  4,                                                      // AssetTag
+  ChassisStateSafe,                                       // BootupState
+  ChassisStateSafe,                                       // PowerSupplyState
+  ChassisStateSafe,                                       // ThermalState
+  ChassisSecurityStatusNone,                              // SecurityState
+  {
+    0,                                                    // OemDefined[0]
+    0,                                                    // OemDefined[1]
+    0,                                                    // OemDefined[2]
+    0                                                     // OemDefined[3]
+  },
+  2,                                                      // Height
+  1,                                                      // NumberofPowerCords
+  0,                                                      // ContainedElementCount
+  0,                                                      // ContainedElementRecordLength
+  {                                                       // ContainedElements[0]
+    {
+      0,                                                    // ContainedElementType
+      0,                                                    // ContainedElementMinimum
+      0                                                     // ContainedElementMaximum
+    }
+  }
+};

--- a/ArmPkg/Universal/Smbios/SmbiosMiscDxe/Type03/MiscChassisManufacturerFunction.c
+++ b/ArmPkg/Universal/Smbios/SmbiosMiscDxe/Type03/MiscChassisManufacturerFunction.c
@@ -1,0 +1,224 @@
+/** @file
+  This driver parses the mMiscSubclassDataTable structure and reports
+  any generated data to smbios.
+
+  Based on files under Nt32Pkg/MiscSubClassPlatformDxe/
+
+  Copyright (c) 2021, NUVIA Inc. All rights reserved.<BR>
+  Copyright (c) 2009 - 2011, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2015, Hisilicon Limited. All rights reserved.<BR>
+  Copyright (c) 2015, Linaro Limited. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
+#include <Library/HiiLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/OemMiscLib.h>
+#include <Library/PrintLib.h>
+#include <Library/UefiBootServicesTableLib.h>
+
+#include "SmbiosMisc.h"
+
+/**
+ * Returns the chassis type in SMBIOS format.
+ *
+ * @return Chassis type
+**/
+UINT8
+GetChassisType (
+  VOID
+  )
+{
+  EFI_STATUS                      Status;
+  UINT8                           ChassisType;
+
+  Status = OemGetChassisType (&ChassisType);
+  if (EFI_ERROR (Status)) {
+    return 0;
+  }
+
+  return ChassisType;
+}
+
+/**
+  This function makes boot time changes to the contents of the
+  MiscChassisManufacturer (Type 3) record.
+
+  @param  RecordData                 Pointer to SMBIOS table with default values.
+  @param  Smbios                     SMBIOS protocol.
+
+  @retval EFI_SUCCESS                The SMBIOS table was successfully added.
+  @retval EFI_INVALID_PARAMETER      Invalid parameter was found.
+  @retval EFI_OUT_OF_RESOURCES       Failed to allocate required memory.
+
+**/
+SMBIOS_MISC_TABLE_FUNCTION(MiscChassisManufacturer)
+{
+  CHAR8                           *OptionalStrStart;
+  CHAR8                           *StrStart;
+  UINTN                           RecordLength;
+  UINTN                           ManuStrLen;
+  UINTN                           VerStrLen;
+  UINTN                           AssertTagStrLen;
+  UINTN                           SerialNumStrLen;
+  UINTN                           ChaNumStrLen;
+  EFI_STRING                      Manufacturer;
+  EFI_STRING                      Version;
+  EFI_STRING                      SerialNumber;
+  EFI_STRING                      AssertTag;
+  EFI_STRING                      ChassisSkuNumber;
+  EFI_STRING_ID                   TokenToGet;
+  SMBIOS_TABLE_TYPE3              *SmbiosRecord;
+  SMBIOS_TABLE_TYPE3              *InputData;
+  EFI_STATUS                      Status;
+
+  UINT8                           ContainedElementCount;
+  CONTAINED_ELEMENT               ContainedElements;
+  UINT8                           ExtendLength;
+
+  UINT8                           ChassisType;
+
+  ExtendLength = 0;
+
+  //
+  // First check for invalid parameters.
+  //
+  if (RecordData == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  InputData = (SMBIOS_TABLE_TYPE3 *)RecordData;
+
+  OemUpdateSmbiosInfo (
+    mSmbiosMiscHiiHandle,
+    STRING_TOKEN (STR_MISC_CHASSIS_ASSET_TAG),
+    AssetTagType03
+    );
+  OemUpdateSmbiosInfo (
+    mSmbiosMiscHiiHandle,
+    STRING_TOKEN (STR_MISC_CHASSIS_SERIAL_NUMBER),
+    SerialNumberType03
+    );
+  OemUpdateSmbiosInfo (
+    mSmbiosMiscHiiHandle,
+    STRING_TOKEN (STR_MISC_CHASSIS_VERSION),
+    VersionType03
+    );
+  OemUpdateSmbiosInfo (
+    mSmbiosMiscHiiHandle,
+    STRING_TOKEN (STR_MISC_CHASSIS_MANUFACTURER),
+    ManufacturerType03
+    );
+  OemUpdateSmbiosInfo (
+    mSmbiosMiscHiiHandle,
+    STRING_TOKEN (STR_MISC_CHASSIS_SKU_NUMBER),
+    SkuNumberType03
+    );
+
+  TokenToGet = STRING_TOKEN (STR_MISC_CHASSIS_MANUFACTURER);
+  Manufacturer = HiiGetPackageString (&gEfiCallerIdGuid, TokenToGet, NULL);
+  ManuStrLen = StrLen (Manufacturer);
+
+  TokenToGet = STRING_TOKEN (STR_MISC_CHASSIS_VERSION);
+  Version = HiiGetPackageString (&gEfiCallerIdGuid, TokenToGet, NULL);
+  VerStrLen = StrLen (Version);
+
+  TokenToGet = STRING_TOKEN (STR_MISC_CHASSIS_SERIAL_NUMBER);
+  SerialNumber = HiiGetPackageString (&gEfiCallerIdGuid, TokenToGet, NULL);
+  SerialNumStrLen = StrLen (SerialNumber);
+
+  TokenToGet = STRING_TOKEN (STR_MISC_CHASSIS_ASSET_TAG);
+  AssertTag = HiiGetPackageString (&gEfiCallerIdGuid, TokenToGet, NULL);
+  AssertTagStrLen = StrLen (AssertTag);
+
+  TokenToGet = STRING_TOKEN (STR_MISC_CHASSIS_SKU_NUMBER);
+  ChassisSkuNumber = HiiGetPackageString (&gEfiCallerIdGuid, TokenToGet, NULL);
+  ChaNumStrLen = StrLen (ChassisSkuNumber);
+
+  ContainedElementCount = InputData->ContainedElementCount;
+
+  if (ContainedElementCount > 1) {
+    ExtendLength = (ContainedElementCount - 1) * sizeof (CONTAINED_ELEMENT);
+  }
+
+  //
+  // Two zeros following the last string.
+  //
+  RecordLength = sizeof (SMBIOS_TABLE_TYPE3) +
+                 ExtendLength    + 1 +
+                 ManuStrLen      + 1 +
+                 VerStrLen       + 1 +
+                 SerialNumStrLen + 1 +
+                 AssertTagStrLen + 1 +
+                 ChaNumStrLen    + 1 + 1;
+  SmbiosRecord = AllocateZeroPool (RecordLength);
+  if (SmbiosRecord == NULL) {
+    Status = EFI_OUT_OF_RESOURCES;
+    goto Exit;
+  }
+
+  (VOID)CopyMem (SmbiosRecord, InputData, sizeof (SMBIOS_TABLE_TYPE3));
+
+  SmbiosRecord->Hdr.Length = sizeof (SMBIOS_TABLE_TYPE3) + ExtendLength + 1;
+
+  ChassisType = GetChassisType ();
+  if (ChassisType != 0) {
+    SmbiosRecord->Type  = ChassisType;
+  }
+
+  //ContainedElements
+  ASSERT (ContainedElementCount < 2);
+  (VOID)CopyMem (SmbiosRecord + 1, &ContainedElements, ExtendLength);
+
+  //ChassisSkuNumber
+  *((UINT8 *)SmbiosRecord + sizeof (SMBIOS_TABLE_TYPE3) + ExtendLength) = 5;
+
+  OptionalStrStart = (CHAR8 *)((UINT8 *)SmbiosRecord + sizeof (SMBIOS_TABLE_TYPE3) +
+                                        ExtendLength + 1);
+  UnicodeStrToAsciiStrS (Manufacturer, OptionalStrStart, ManuStrLen + 1);
+  StrStart = OptionalStrStart + ManuStrLen + 1;
+  UnicodeStrToAsciiStrS (Version, StrStart, VerStrLen + 1);
+  StrStart += VerStrLen + 1;
+  UnicodeStrToAsciiStrS (SerialNumber, StrStart, SerialNumStrLen + 1);
+  StrStart += SerialNumStrLen + 1;
+  UnicodeStrToAsciiStrS (AssertTag, StrStart, AssertTagStrLen + 1);
+  StrStart += AssertTagStrLen + 1;
+  UnicodeStrToAsciiStrS (ChassisSkuNumber, StrStart, ChaNumStrLen + 1);
+  //
+  // Now we have got the full smbios record, call smbios protocol to add this record.
+  //
+  Status = SmbiosMiscAddRecord ((UINT8*)SmbiosRecord, NULL);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "[%a]:[%dL] Smbios Type03 Table Log Failed! %r \n",
+            __FUNCTION__, __LINE__, Status));
+  }
+
+  FreePool (SmbiosRecord);
+
+Exit:
+  if (Manufacturer != NULL) {
+    FreePool (Manufacturer);
+  }
+
+  if (Version != NULL) {
+    FreePool (Version);
+  }
+
+  if (SerialNumber != NULL) {
+    FreePool (SerialNumber);
+  }
+
+  if (AssertTag != NULL) {
+    FreePool (AssertTag);
+  }
+
+  if (ChassisSkuNumber != NULL) {
+    FreePool (ChassisSkuNumber);
+  }
+
+  return 0;
+}

--- a/ArmPkg/Universal/Smbios/SmbiosMiscDxe/Type13/MiscNumberOfInstallableLanguages.uni
+++ b/ArmPkg/Universal/Smbios/SmbiosMiscDxe/Type13/MiscNumberOfInstallableLanguages.uni
@@ -1,0 +1,43 @@
+/** @file
+  Based on files under Nt32Pkg/MiscSubClassPlatformDxe/
+
+  Copyright (c) 2021, NUVIA Inc. All rights reserved.<BR>
+  Copyright (c) 2006 - 2010, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2015, Hisilicon Limited. All rights reserved.<BR>
+  Copyright (c) 2015, Linaro Limited. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+/=#
+
+/=#
+//
+// Language String (Long Format)
+//
+#string STR_MISC_BIOS_LANGUAGES_ENG_LONG        #language en-US  "en|US|iso8859-1"
+#string STR_MISC_BIOS_LANGUAGES_FRA_LONG        #language en-US  "fr|CA|iso8859-1"
+#string STR_MISC_BIOS_LANGUAGES_CHN_LONG        #language en-US  "zh|TW|unicode"
+#string STR_MISC_BIOS_LANGUAGES_JPN_LONG        #language en-US  "ja|JP|unicode"
+#string STR_MISC_BIOS_LANGUAGES_ITA_LONG        #language en-US  "it|IT|iso8859-1"
+#string STR_MISC_BIOS_LANGUAGES_SPA_LONG        #language en-US  "es|ES|iso8859-1"
+#string STR_MISC_BIOS_LANGUAGES_GER_LONG        #language en-US  "de|DE|iso8859-1"
+#string STR_MISC_BIOS_LANGUAGES_POR_LONG        #language en-US  "pt|PT|iso8859-1"
+
+
+//
+// Language String (Abbreviated Format)
+//
+#string STR_MISC_BIOS_LANGUAGES_ENG_ABBREVIATE  #language en-US  "enUS"
+#string STR_MISC_BIOS_LANGUAGES_FRA_ABBREVIATE  #language en-US  "frCA"
+#string STR_MISC_BIOS_LANGUAGES_CHN_ABBREVIATE  #language en-US  "zhTW"
+#string STR_MISC_BIOS_LANGUAGES_JPN_ABBREVIATE  #language en-US  "jaJP"
+#string STR_MISC_BIOS_LANGUAGES_ITA_ABBREVIATE  #language en-US  "itIT"
+#string STR_MISC_BIOS_LANGUAGES_SPA_ABBREVIATE  #language en-US  "esES"
+#string STR_MISC_BIOS_LANGUAGES_GER_ABBREVIATE  #language en-US  "deDE"
+#string STR_MISC_BIOS_LANGUAGES_POR_ABBREVIATE  #language en-US  "ptPT"
+
+#string STR_MISC_BIOS_LANGUAGES_SIMPLECH_ABBREVIATE  #language en-US  "zhCN"
+#string STR_MISC_BIOS_LANGUAGES_SIMPLECH_LONG        #language en-US  "zh|CN|unicode"
+
+

--- a/ArmPkg/Universal/Smbios/SmbiosMiscDxe/Type13/MiscNumberOfInstallableLanguagesData.c
+++ b/ArmPkg/Universal/Smbios/SmbiosMiscDxe/Type13/MiscNumberOfInstallableLanguagesData.c
@@ -1,0 +1,33 @@
+/** @file
+  This file provides Smbios Type13 Data
+
+  Based on files under Nt32Pkg/MiscSubClassPlatformDxe/
+
+  Copyright (c) 2021, NUVIA Inc. All rights reserved.<BR>
+  Copyright (c) 2006 - 2009, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2015, Hisilicon Limited. All rights reserved.<BR>
+  Copyright (c) 2015, Linaro Limited. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "SmbiosMisc.h"
+
+//
+// Static (possibly build generated) Bios Vendor data.
+//
+
+SMBIOS_MISC_TABLE_DATA(SMBIOS_TABLE_TYPE13, MiscNumberOfInstallableLanguages) =
+{
+  {                                                     // Hdr
+    EFI_SMBIOS_TYPE_BIOS_LANGUAGE_INFORMATION,            // Type,
+    0,                                                    // Length,
+    0                                                     // Handle
+  },
+  0,                                                    // InstallableLanguages
+  0,                                                    // Flags
+  {
+    0                                                   // Reserved[15]
+  },
+  1                                                     // CurrentLanguage
+};

--- a/ArmPkg/Universal/Smbios/SmbiosMiscDxe/Type13/MiscNumberOfInstallableLanguagesFunction.c
+++ b/ArmPkg/Universal/Smbios/SmbiosMiscDxe/Type13/MiscNumberOfInstallableLanguagesFunction.c
@@ -1,0 +1,166 @@
+/** @file
+  Based on files under Nt32Pkg/MiscSubClassPlatformDxe/
+
+  Copyright (c) 2021, NUVIA Inc. All rights reserved.<BR>
+  Copyright (c) 2009 - 2012, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2015, Hisilicon Limited. All rights reserved.<BR>
+  Copyright (c) 2015, Linaro Limited. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
+#include <Library/HiiLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/OemMiscLib.h>
+#include <Library/PrintLib.h>
+#include <Library/UefiBootServicesTableLib.h>
+
+#include "SmbiosMisc.h"
+
+/**
+  Get next language from language code list (with separator ';').
+
+  @param  LangCode       Input: point to first language in the list. On
+                         Otput: point to next language in the list, or
+                                NULL if no more language in the list.
+  @param  Lang           The first language in the list.
+
+**/
+VOID
+EFIAPI
+GetNextLanguage (
+  IN OUT CHAR8      **LangCode,
+  OUT CHAR8         *Lang
+  )
+{
+  UINTN  Index;
+  CHAR8  *StringPtr;
+
+  if (LangCode == NULL || *LangCode == NULL || Lang == NULL) {
+    return;
+  }
+
+  Index     = 0;
+  StringPtr = *LangCode;
+  while (StringPtr[Index] != 0 && StringPtr[Index] != ';') {
+    Index++;
+  }
+
+  (VOID)CopyMem (Lang, StringPtr, Index);
+  Lang[Index] = 0;
+
+  if (StringPtr[Index] == ';') {
+    Index++;
+  }
+  *LangCode = StringPtr + Index;
+}
+
+/**
+  This function returns the number of supported languages on HiiHandle.
+
+  @param   HiiHandle    The HII package list handle.
+
+  @retval  The number of supported languages.
+
+**/
+UINT16
+EFIAPI
+GetSupportedLanguageNumber (
+  IN EFI_HII_HANDLE    HiiHandle
+  )
+{
+  CHAR8   *Lang;
+  CHAR8   *Languages;
+  CHAR8   *LanguageString;
+  UINT16  LangNumber;
+
+  Languages = HiiGetSupportedLanguages (HiiHandle);
+  if (Languages == NULL) {
+    return 0;
+  }
+
+  LangNumber = 0;
+  Lang = AllocatePool (AsciiStrSize (Languages));
+  if (Lang != NULL) {
+    LanguageString = Languages;
+    while (*LanguageString != 0) {
+      GetNextLanguage (&LanguageString, Lang);
+      LangNumber++;
+    }
+    FreePool (Lang);
+  }
+  FreePool (Languages);
+  return LangNumber;
+}
+
+
+/**
+  This function makes boot time changes to the contents of the
+  MiscNumberOfInstallableLanguages (Type 13) record.
+
+  @param  RecordData                 Pointer to SMBIOS table with default values.
+  @param  Smbios                     SMBIOS protocol.
+
+  @retval EFI_SUCCESS                The SMBIOS table was successfully added.
+  @retval EFI_INVALID_PARAMETER      Invalid parameter was found.
+  @retval EFI_OUT_OF_RESOURCES       Failed to allocate required memory.
+
+**/
+SMBIOS_MISC_TABLE_FUNCTION(MiscNumberOfInstallableLanguages)
+{
+  UINTN                                     LangStrLen;
+  CHAR8                                     CurrentLang[SMBIOS_STRING_MAX_LENGTH + 1];
+  CHAR8                                     *OptionalStrStart;
+  EFI_STATUS                                Status;
+  SMBIOS_TABLE_TYPE13                       *SmbiosRecord;
+  SMBIOS_TABLE_TYPE13                       *InputData;
+
+  InputData = NULL;
+
+  //
+  // First check for invalid parameters.
+  //
+  if (RecordData == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  InputData = (SMBIOS_TABLE_TYPE13 *)RecordData;
+
+  InputData->InstallableLanguages = GetSupportedLanguageNumber (mSmbiosMiscHiiHandle);
+
+  //
+  // Try to check if current langcode matches with the langcodes in installed languages
+  //
+  ZeroMem (CurrentLang, SMBIOS_STRING_MAX_LENGTH - 1);
+  (VOID)AsciiStrCpyS (CurrentLang, SMBIOS_STRING_MAX_LENGTH - 1, "en|US|iso8859-1");
+  LangStrLen = AsciiStrLen (CurrentLang);
+
+  //
+  // Two zeros following the last string.
+  //
+  SmbiosRecord = AllocateZeroPool (sizeof (SMBIOS_TABLE_TYPE13) + LangStrLen + 1 + 1);
+  if (SmbiosRecord == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  (VOID)CopyMem (SmbiosRecord, InputData, sizeof (SMBIOS_TABLE_TYPE13));
+
+  SmbiosRecord->Hdr.Length = sizeof (SMBIOS_TABLE_TYPE13);
+
+  OptionalStrStart = (CHAR8 *)(SmbiosRecord + 1);
+  (VOID)AsciiStrCpyS (OptionalStrStart, SMBIOS_STRING_MAX_LENGTH - 1, CurrentLang);
+  //
+  // Now we have got the full smbios record, call smbios protocol to add this record.
+  //
+  Status = SmbiosMiscAddRecord ((UINT8*)SmbiosRecord, NULL);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "[%a]:[%dL] Smbios Type13 Table Log Failed! %r \n",
+            __FUNCTION__, __LINE__, Status));
+  }
+
+  FreePool (SmbiosRecord);
+  return Status;
+}

--- a/ArmPkg/Universal/Smbios/SmbiosMiscDxe/Type32/MiscBootInformationData.c
+++ b/ArmPkg/Universal/Smbios/SmbiosMiscDxe/Type32/MiscBootInformationData.c
@@ -1,0 +1,32 @@
+/** @file
+  Based on files under Nt32Pkg/MiscSubClassPlatformDxe/
+
+  Copyright (c) 2021, NUVIA Inc. All rights reserved.<BR>
+  Copyright (c) 2006 - 2009, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2015, Hisilicon Limited. All rights reserved.<BR>
+  Copyright (c) 2015, Linaro Limited. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "SmbiosMisc.h"
+
+//
+// Static (possibly build generated) Bios Vendor data.
+//
+SMBIOS_MISC_TABLE_DATA(SMBIOS_TABLE_TYPE32, MiscBootInformation) = {
+  {                                                     // Hdr
+    EFI_SMBIOS_TYPE_SYSTEM_BOOT_INFORMATION,              // Type,
+    0,                                                    // Length,
+    0                                                     // Handle
+  },
+  {                                                     // Reserved[6]
+    0,
+    0,
+    0,
+    0,
+    0,
+    0
+  },
+  BootInformationStatusNoError                          // BootInformationStatus
+};

--- a/ArmPkg/Universal/Smbios/SmbiosMiscDxe/Type32/MiscBootInformationFunction.c
+++ b/ArmPkg/Universal/Smbios/SmbiosMiscDxe/Type32/MiscBootInformationFunction.c
@@ -1,0 +1,73 @@
+/** @file
+  boot information boot time changes.
+  SMBIOS type 32.
+
+  Based on files under Nt32Pkg/MiscSubClassPlatformDxe/
+
+  Copyright (c) 2021, NUVIA Inc. All rights reserved.<BR>
+  Copyright (c) 2009 - 2011, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2015, Hisilicon Limited. All rights reserved.<BR>
+  Copyright (c) 2015, Linaro Limited. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/UefiBootServicesTableLib.h>
+
+#include "SmbiosMisc.h"
+
+/**
+  This function makes boot time changes to the contents of the
+  MiscBootInformation (Type 32) record.
+
+  @param  RecordData                 Pointer to SMBIOS table with default values.
+  @param  Smbios                     SMBIOS protocol.
+
+  @retval EFI_SUCCESS                The SMBIOS table was successfully added.
+  @retval EFI_INVALID_PARAMETER      Invalid parameter was found.
+  @retval EFI_OUT_OF_RESOURCES       Failed to allocate required memory.
+
+**/
+SMBIOS_MISC_TABLE_FUNCTION(MiscBootInformation)
+{
+  EFI_STATUS                         Status;
+  SMBIOS_TABLE_TYPE32                *SmbiosRecord;
+  SMBIOS_TABLE_TYPE32                *InputData;
+
+  //
+  // First check for invalid parameters.
+  //
+  if (RecordData == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  InputData = (SMBIOS_TABLE_TYPE32 *)RecordData;
+
+  //
+  // Two zeros following the last string.
+  //
+  SmbiosRecord = AllocateZeroPool (sizeof (SMBIOS_TABLE_TYPE32) + 1 + 1);
+  if (SmbiosRecord == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  (VOID)CopyMem (SmbiosRecord, InputData, sizeof (SMBIOS_TABLE_TYPE32));
+
+  SmbiosRecord->Hdr.Length = sizeof (SMBIOS_TABLE_TYPE32);
+
+  //
+  // Now we have got the full smbios record, call smbios protocol to add this record.
+  //
+  Status = SmbiosMiscAddRecord ((UINT8*)SmbiosRecord, NULL);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "[%a]:[%dL] Smbios Type32 Table Log Failed! %r \n",
+            __FUNCTION__, __LINE__, Status));
+  }
+
+  FreePool (SmbiosRecord);
+  return Status;
+}

--- a/MdePkg/Include/IndustryStandard/SmBios.h
+++ b/MdePkg/Include/IndustryStandard/SmBios.h
@@ -875,6 +875,19 @@ typedef struct {
   UINT16  ProcessorReserved2              :6;
 } PROCESSOR_CHARACTERISTIC_FLAGS;
 
+///
+/// Processor Information - Status
+///
+typedef union {
+  struct {
+    UINT8 CpuStatus       :3; ///< Indicates the status of the processor.
+    UINT8 Reserved1       :3; ///< Reserved for future use. Must be set to zero.
+    UINT8 SocketPopulated :1; ///< Indicates if the processor socket is populated or not.
+    UINT8 Reserved2       :1; ///< Reserved for future use. Must be set to zero.
+  } Bits;
+  UINT8 Data;
+} PROCESSOR_STATUS_DATA;
+
 typedef struct {
   PROCESSOR_SIGNATURE     Signature;
   PROCESSOR_FEATURE_FLAGS FeatureFlags;


### PR DESCRIPTION
Much of the data for the SMBIOS tables is generic, and need not be                                      
duplicated for each platform. This patch series introduces                                              
ArmPkg/Universal/Smbios, which is largely copied from                                                   
edk2-platforms/Silicon/HiSilicon/Drivers/Smbios and generates SMBIOS                                    
tables 0,1,2,3,4,7,13,32 and uses a combination of PCDs and calls into a                                
new OemMiscLib to get information which varies between platforms.