### PR TITLE
ArmPkg: add DebugLib to OemMiscLibNull

### DIFF
--- a/ArmPkg/Universal/Smbios/OemMiscLibNull/OemMiscLib.c
+++ b/ArmPkg/Universal/Smbios/OemMiscLibNull/OemMiscLib.c
@@ -11,6 +11,7 @@
 
 #include <Uefi.h>
 #include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
 #include <Library/HiiLib.h>
 
 #include <Library/OemMiscLib.h>

--- a/ArmPkg/Universal/Smbios/OemMiscLibNull/OemMiscLibNull.inf
+++ b/ArmPkg/Universal/Smbios/OemMiscLibNull/OemMiscLibNull.inf
@@ -28,4 +28,4 @@
 
 [LibraryClasses]
   BaseMemoryLib
-
+  DebugLib


### PR DESCRIPTION
The just added OemMiscLibNull fails to build due to DebugLib.h not
being included, missing the ASSERT definition. Add the include and the
library dependency.

Cc: Rebecca Cran <rebecca@nuviainc.com>
Cc: Ard Biesheuvel <ardb+tianocore@kernel.org>
Signed-off-by: Leif Lindholm <leif@nuviainc.com>
Reviewed-by: Rebecca Cran <rebecca@nuviainc.com>
Acked-by: Ard Biesheuvel <ardb@kernel.org>