### PR TITLE
StandaloneMmPkg/FvLib.h: Add EFIAPI to FfsFindSection()

### DIFF
--- a/StandaloneMmPkg/Include/Library/FvLib.h
+++ b/StandaloneMmPkg/Include/Library/FvLib.h
@@ -50,6 +50,7 @@ FfsFindNextFile (
   @retval  EFI_SUCCESS
 **/
 EFI_STATUS
+EFIAPI
 FfsFindSection (
   IN EFI_SECTION_TYPE              SectionType,
   IN EFI_FFS_FILE_HEADER           *FfsFileHeader,


### PR DESCRIPTION
REF:https://bugzilla.tianocore.org/show_bug.cgi?id=3203

The EFIAPI modifier is present in the function definition in
FvLib.c but missing in FvLib.h. Causes a GCC build error.

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>
Reviewed-by: Sami Mujawar <sami.mujawar@arm.com>