### PR TITLE
EmbeddedPkg/VirtualRealTimeClockLib: Reduce DEBUG message verbosity

### DIFF
--- a/EmbeddedPkg/Library/VirtualRealTimeClockLib/VirtualRealTimeClockLib.c
+++ b/EmbeddedPkg/Library/VirtualRealTimeClockLib/VirtualRealTimeClockLib.c
@@ -88,7 +88,7 @@ LibGetTime (
     //
     EpochSeconds = BUILD_EPOCH;
     DEBUG ((
-      DEBUG_INFO,
+      DEBUG_VERBOSE,
       "LibGetTime: %s non volatile variable was not found - Using compilation time epoch.\n",
       mEpochVariableName
       ));


### PR DESCRIPTION
The DEBUG message for using compilation time epoch is appearing very
frequently on DEBUG firmware builds, for example during UEFI SCT runs.
Reduce verbosity to avoid the annoying repetitive message.

Signed-off-by: Samer El-Haj-Mahmoud <Samer.El-Haj-Mahmoud@arm.com>
Reviewed-by: Ard Biesheuvel <ardb@kernel.org>