### PR TITLE
ArmPkg: Fix several issues in OemMiscLib

### DIFF
--- a/ArmPkg/Include/Library/OemMiscLib.h
+++ b/ArmPkg/Include/Library/OemMiscLib.h
@@ -128,14 +128,12 @@ OemGetMaxProcessors (
 
 /** Gets the type of chassis for the system.
 
-  @param ChassisType The type of the chassis.
-
-  @retval EFI_SUCCESS The chassis type was fetched successfully.
+  @retval The type of the chassis.
 **/
-EFI_STATUS
+MISC_CHASSIS_TYPE
 EFIAPI
 OemGetChassisType (
-  OUT UINT8 *ChassisType
+  VOID
   );
 
 /** Returns whether the specified processor is present or not.

--- a/ArmPkg/Include/Library/OemMiscLib.h
+++ b/ArmPkg/Include/Library/OemMiscLib.h
@@ -116,13 +116,13 @@ OemGetCacheInformation (
   IN OUT SMBIOS_TABLE_TYPE7 *SmbiosCacheTable
   );
 
-/** Gets the maximum number of sockets supported by the platform.
+/** Gets the maximum number of processors supported by the platform.
 
-  @return The maximum number of sockets.
+  @return The maximum number of processors.
 **/
 UINT8
 EFIAPI
-OemGetProcessorMaxSockets (
+OemGetMaxProcessors (
   VOID
   );
 
@@ -146,22 +146,22 @@ OemGetChassisType (
 **/
 BOOLEAN
 EFIAPI
-OemIsSocketPresent (
+OemIsProcessorPresent (
   IN UINTN ProcessorIndex
   );
 
 /** Updates the HII string for the specified field.
 
-  @param mHiiHandle    The HII handle.
+  @param HiiHandle     The HII handle.
   @param TokenToUpdate The string to update.
-  @param Offset        The field to get information about.
+  @param Field         The field to get information about.
 **/
 VOID
 EFIAPI
 OemUpdateSmbiosInfo (
   IN EFI_HII_HANDLE    HiiHandle,
   IN EFI_STRING_ID     TokenToUpdate,
-  IN OEM_MISC_SMBIOS_HII_STRING_FIELD Offset
+  IN OEM_MISC_SMBIOS_HII_STRING_FIELD Field
   );
 
 #endif // OEM_MISC_LIB_H_

--- a/ArmPkg/Include/Library/OemMiscLib.h
+++ b/ArmPkg/Include/Library/OemMiscLib.h
@@ -71,8 +71,8 @@ typedef enum
 
   @return               CPU frequency in Hz
 **/
-EFIAPI
 UINTN
+EFIAPI
 OemGetCpuFreq (
   IN UINT8 ProcessorIndex
   );
@@ -87,8 +87,8 @@ OemGetCpuFreq (
 
   @return  TRUE on success, FALSE on failure.
 **/
-EFIAPI
 BOOLEAN
+EFIAPI
 OemGetProcessorInformation (
   IN UINTN ProcessorIndex,
   IN OUT PROCESSOR_STATUS_DATA *ProcessorStatus,
@@ -106,8 +106,8 @@ OemGetProcessorInformation (
 
   @return TRUE on success, FALSE on failure.
 **/
-EFIAPI
 BOOLEAN
+EFIAPI
 OemGetCacheInformation (
   IN UINT8   ProcessorIndex,
   IN UINT8   CacheLevel,
@@ -120,8 +120,8 @@ OemGetCacheInformation (
 
   @return The maximum number of sockets.
 **/
-EFIAPI
 UINT8
+EFIAPI
 OemGetProcessorMaxSockets (
   VOID
   );
@@ -132,8 +132,8 @@ OemGetProcessorMaxSockets (
 
   @retval EFI_SUCCESS The chassis type was fetched successfully.
 **/
-EFIAPI
 EFI_STATUS
+EFIAPI
 OemGetChassisType (
   OUT UINT8 *ChassisType
   );
@@ -144,8 +144,8 @@ OemGetChassisType (
 
   @return TRUE is the processor is present, FALSE otherwise.
 **/
-EFIAPI
 BOOLEAN
+EFIAPI
 OemIsSocketPresent (
   IN UINTN ProcessorIndex
   );
@@ -156,8 +156,8 @@ OemIsSocketPresent (
   @param TokenToUpdate The string to update.
   @param Offset        The field to get information about.
 **/
-EFIAPI
 VOID
+EFIAPI
 OemUpdateSmbiosInfo (
   IN EFI_HII_HANDLE    HiiHandle,
   IN EFI_STRING_ID     TokenToUpdate,

--- a/ArmPkg/Universal/Smbios/OemMiscLibNull/OemMiscLib.c
+++ b/ArmPkg/Universal/Smbios/OemMiscLibNull/OemMiscLib.c
@@ -23,8 +23,8 @@
 
   @return               CPU frequency in Hz
 **/
-EFIAPI
 UINTN
+EFIAPI
 OemGetCpuFreq (
   IN UINT8 ProcessorIndex
   )
@@ -43,8 +43,8 @@ OemGetCpuFreq (
 
   @return  TRUE on success, FALSE on failure.
 **/
-EFIAPI
 BOOLEAN
+EFIAPI
 OemGetProcessorInformation (
   IN UINTN ProcessorIndex,
   IN OUT PROCESSOR_STATUS_DATA *ProcessorStatus,
@@ -66,8 +66,8 @@ OemGetProcessorInformation (
 
   @return TRUE on success, FALSE on failure.
 **/
-EFIAPI
 BOOLEAN
+EFIAPI
 OemGetCacheInformation (
   IN UINT8   ProcessorIndex,
   IN UINT8   CacheLevel,
@@ -84,8 +84,8 @@ OemGetCacheInformation (
 
   @return The maximum number of sockets.
 **/
-EFIAPI
 UINT8
+EFIAPI
 OemGetProcessorMaxSockets (
   VOID
   )
@@ -117,8 +117,8 @@ OemGetChassisType (
 
   @return TRUE is the processor is present, FALSE otherwise.
 **/
-EFIAPI
 BOOLEAN
+EFIAPI
 OemIsSocketPresent (
   IN UINTN ProcessorIndex
   )
@@ -133,8 +133,8 @@ OemIsSocketPresent (
   @param TokenToUpdate The string to update.
   @param Offset        The field to get information about.
 **/
-EFIAPI
 VOID
+EFIAPI
 OemUpdateSmbiosInfo (
   IN EFI_HII_HANDLE mHiiHandle,
   IN EFI_STRING_ID TokenToUpdate,

--- a/ArmPkg/Universal/Smbios/OemMiscLibNull/OemMiscLib.c
+++ b/ArmPkg/Universal/Smbios/OemMiscLibNull/OemMiscLib.c
@@ -95,19 +95,16 @@ OemGetMaxProcessors (
 
 /** Gets the type of chassis for the system.
 
-  @param ChassisType The type of the chassis.
-
-  @retval EFI_SUCCESS The chassis type was fetched successfully.
+  @retval The type of the chassis.
 **/
-EFI_STATUS
+MISC_CHASSIS_TYPE
 EFIAPI
 OemGetChassisType (
-  UINT8 *ChassisType
+  VOID
   )
 {
   ASSERT (FALSE);
-  *ChassisType = MiscChassisTypeUnknown;
-  return EFI_SUCCESS;
+  return MiscChassisTypeUnknown;
 }
 
 /** Returns whether the specified processor is present or not.

--- a/ArmPkg/Universal/Smbios/OemMiscLibNull/OemMiscLib.c
+++ b/ArmPkg/Universal/Smbios/OemMiscLibNull/OemMiscLib.c
@@ -13,7 +13,6 @@
 #include <Library/BaseMemoryLib.h>
 #include <Library/DebugLib.h>
 #include <Library/HiiLib.h>
-
 #include <Library/OemMiscLib.h>
 
 
@@ -80,13 +79,13 @@ OemGetCacheInformation (
   return TRUE;
 }
 
-/** Gets the maximum number of sockets supported by the platform.
+/** Gets the maximum number of processors supported by the platform.
 
-  @return The maximum number of sockets.
+  @return The maximum number of processors.
 **/
 UINT8
 EFIAPI
-OemGetProcessorMaxSockets (
+OemGetMaxProcessors (
   VOID
   )
 {
@@ -119,7 +118,7 @@ OemGetChassisType (
 **/
 BOOLEAN
 EFIAPI
-OemIsSocketPresent (
+OemIsProcessorPresent (
   IN UINTN ProcessorIndex
   )
 {
@@ -129,16 +128,16 @@ OemIsSocketPresent (
 
 /** Updates the HII string for the specified field.
 
-  @param mHiiHandle    The HII handle.
+  @param HiiHandle     The HII handle.
   @param TokenToUpdate The string to update.
-  @param Offset        The field to get information about.
+  @param Field         The field to get information about.
 **/
 VOID
 EFIAPI
 OemUpdateSmbiosInfo (
-  IN EFI_HII_HANDLE mHiiHandle,
+  IN EFI_HII_HANDLE HiiHandle,
   IN EFI_STRING_ID TokenToUpdate,
-  IN OEM_MISC_SMBIOS_HII_STRING_FIELD Offset
+  IN OEM_MISC_SMBIOS_HII_STRING_FIELD Field
   )
 {
   ASSERT (FALSE);

--- a/ArmPkg/Universal/Smbios/SmbiosMiscDxe/Type03/MiscChassisManufacturerFunction.c
+++ b/ArmPkg/Universal/Smbios/SmbiosMiscDxe/Type03/MiscChassisManufacturerFunction.c
@@ -24,27 +24,6 @@
 #include "SmbiosMisc.h"
 
 /**
- * Returns the chassis type in SMBIOS format.
- *
- * @return Chassis type
-**/
-UINT8
-GetChassisType (
-  VOID
-  )
-{
-  EFI_STATUS                      Status;
-  UINT8                           ChassisType;
-
-  Status = OemGetChassisType (&ChassisType);
-  if (EFI_ERROR (Status)) {
-    return 0;
-  }
-
-  return ChassisType;
-}
-
-/**
   This function makes boot time changes to the contents of the
   MiscChassisManufacturer (Type 3) record.
 
@@ -79,8 +58,6 @@ SMBIOS_MISC_TABLE_FUNCTION(MiscChassisManufacturer)
   UINT8                           ContainedElementCount;
   CONTAINED_ELEMENT               ContainedElements;
   UINT8                           ExtendLength;
-
-  UINT8                           ChassisType;
 
   ExtendLength = 0;
 
@@ -165,10 +142,7 @@ SMBIOS_MISC_TABLE_FUNCTION(MiscChassisManufacturer)
 
   SmbiosRecord->Hdr.Length = sizeof (SMBIOS_TABLE_TYPE3) + ExtendLength + 1;
 
-  ChassisType = GetChassisType ();
-  if (ChassisType != 0) {
-    SmbiosRecord->Type  = ChassisType;
-  }
+  SmbiosRecord->Type = OemGetChassisType ();
 
   //ContainedElements
   ASSERT (ContainedElementCount < 2);


### PR DESCRIPTION
Update OemMiscLib with the following changes:                                                           
                                                                                                        
o Fixed ordering of return type and EFIAPI specifier.                                                   
o Renamed 'mHiiHandle' parameter in OemUpdateSmbiosInfo to 'HiiHandle'.                                 
o Renamed 'Offset' parameter in OemUpdateSmbiosInfo to 'Field'.                                         
o Renamed OemGetProcessorMaxSockets to OemGetMaxProcessors.                                             
o Renamed OemIsSocketPresent to OemIsProcessorPresent.                                                  
o Updated OemGetChassisType to return MISC_CHASSIS_TYPE instead of                                      
  EFI_STATUS, which matches other OemMiscLib functions.