### PR TITLE
RedfishPkg/JsonLib: Fix the mistake of removing code by a accident

### DIFF
--- a/RedfishPkg/Library/JsonLib/JsonLib.c
+++ b/RedfishPkg/Library/JsonLib/JsonLib.c
@@ -430,10 +430,10 @@ JsonValueGetAsciiString (
   IN    EDKII_JSON_VALUE    Json
   )
 {
-  CHAR8          *AsciiStr;
+  CONST CHAR8    *AsciiStr;
   UINTN          Index;
 
-  AsciiStr = (CHAR8 *)  ((json_t *) Json);
+  AsciiStr = json_string_value ((json_t *) Json);
   if (AsciiStr == NULL) {
     return NULL;
   }


### PR DESCRIPTION
json_string_value() in JsonValueGetAsciiString () is removed by a accident
when clean up the code.

Signed-off-by: Abner Chang <abner.chang@hpe.com>

Cc: Leif Lindholm <leif@nuviainc.com>
Cc: Nickle Wang <nickle.wang@hpe.com>
Cc: Michael D Kinney <michael.d.kinney@intel.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>
Reviewed-by: Nickle Wang <nickle.wang@hpe.com>