### PR TITLE
RedfishPkg/JsonLib: Ignore the build error of conditional expression.

### DIFF
--- a/RedfishPkg/Library/JsonLib/JsonLib.inf
+++ b/RedfishPkg/Library/JsonLib/JsonLib.inf
@@ -75,12 +75,13 @@
   #   C4244: conversion from type1 to type2, possible loss of data
   #   C4334: 32-bit shift implicitly converted to 64-bit
   #   C4204: nonstandard extension used: non-constant aggregate initializer
+  #   C4706: assignment within conditional expression
   #
   # Define macro HAVE_CONFIG_H to include jansson_private_config.h to build.
   # Undefined _WIN32, WIN64, _MSC_VER macros
   # On GCC, no error on the unused-function and unused-but-set-variable.
   #
-  MSFT:*_*_X64_CC_FLAGS = /wd4204 /wd4244 /wd4090 /wd4334 /DHAVE_CONFIG_H=1 /U_WIN32 /UWIN64 /U_MSC_VER
-  MSFT:*_*_IA32_CC_FLAGS = /wd4204 /wd4244 /wd4090 /DHAVE_CONFIG_H=1 /U_WIN32 /UWIN64 /U_MSC_VER
+  MSFT:*_*_X64_CC_FLAGS = /wd4204 /wd4244 /wd4090 /wd4334 /wd4706 /DHAVE_CONFIG_H=1 /U_WIN32 /UWIN64 /U_MSC_VER
+  MSFT:*_*_IA32_CC_FLAGS = /wd4204 /wd4244 /wd4090 /wd4706 /DHAVE_CONFIG_H=1 /U_WIN32 /UWIN64 /U_MSC_VER
   GCC:*_*_*_CC_FLAGS = -Wno-unused-function -Wno-unused-but-set-variable
 


### PR DESCRIPTION
Ignore the build error of assignment within conditional expression.
Add build option to ignore the build error of "assignment within
conditional expression".
This build error is caused by the macros defined in open source
project jansson header file jansson.h.

- json_object_foreach
- json_object_foreach_safe
- json_array_foreach

We use build option to avoid the build errors on Visual Studio
(GCC doesn't havvve this problem) for now. Already sent an email
to jansson open source community to revise these macro as Leif's
suggestion as below,

for (key = json_object_iter_key(json_object_iter(object));    \
       key;                                                   \
       key = json_object_iter_key(                            \
            json_object_iter_next(object,
json_object_key_to_iter(key)))) { \
       value =
json_object_iter_value(json_object_key_to_iter(key));         \
      if (!value) \
        break; \
  } \

We will remove this build option once the patch is accepted and
upstreamed.

Signed-off-by: Abner Chang <abner.chang@hpe.com>

Cc: Leif Lindholm <leif@nuviainc.com>
Cc: Nickle Wang <nickle.wang@hpe.com>
Cc: Michael D Kinney <michael.d.kinney@intel.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>
Reviewed-by: Nickle Wang <nickle.wang@hpe.com>