### PR TITLE
MdeModulePkg/UefiBootManagerLib: Put BootMenu at the end of BootOrder

### DIFF
--- a/MdeModulePkg/Library/UefiBootManagerLib/BmBoot.c
+++ b/MdeModulePkg/Library/UefiBootManagerLib/BmBoot.c
@@ -3,7 +3,7 @@
 
 Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
 Copyright (c) 2011 - 2020, Intel Corporation. All rights reserved.<BR>
-(C) Copyright 2015-2016 Hewlett Packard Enterprise Development LP<BR>
+(C) Copyright 2015-2021 Hewlett Packard Enterprise Development LP<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -2505,7 +2505,7 @@ BmRegisterBootManagerMenu (
     EfiBootManagerFreeLoadOptions (BootOptions, BootOptionCount);
     );
 
-  return EfiBootManagerAddLoadOptionVariable (BootOption, 0);
+  return EfiBootManagerAddLoadOptionVariable (BootOption, (UINTN) -1);
 }
 
 /**


### PR DESCRIPTION
REF:https://bugzilla.tianocore.org/show_bug.cgi?id=3135

When Boot Menu does not exist in the BootOrder, BmRegisterBootManagerMenu
will create one into list. However, it should be put at the "end" of
BootOrder instead of "start" of BootOrder. Replace 0 by -1 to adjust
order of load options.

Signed-off-by: Walon Li <walon.li@hpe.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>