### PR TITLE
Fix two issue in ArmGicLib

### DIFF
--- a/ArmPkg/Drivers/ArmGic/ArmGicLib.c
+++ b/ArmPkg/Drivers/ArmGic/ArmGicLib.c
@@ -25,10 +25,10 @@
                                            + ARM_GICR_SGI_RESERVED_FRAME_SIZE)
 
 #define ISENABLER_ADDRESS(base,offset) ((base) + \
-          ARM_GICR_CTLR_FRAME_SIZE +  ARM_GICR_ISENABLER + (4 * offset))
+          ARM_GICR_CTLR_FRAME_SIZE + ARM_GICR_ISENABLER + 4 * (offset))
 
 #define ICENABLER_ADDRESS(base,offset) ((base) + \
-          ARM_GICR_CTLR_FRAME_SIZE +  ARM_GICR_ICENABLER + (4 * offset))
+          ARM_GICR_CTLR_FRAME_SIZE + ARM_GICR_ICENABLER + 4 * (offset))
 
 /**
  *

--- a/ArmPkg/Drivers/ArmGic/ArmGicLib.c
+++ b/ArmPkg/Drivers/ArmGic/ArmGicLib.c
@@ -30,6 +30,9 @@
 #define ICENABLER_ADDRESS(base,offset) ((base) + \
           ARM_GICR_CTLR_FRAME_SIZE + ARM_GICR_ICENABLER + 4 * (offset))
 
+#define IPRIORITY_ADDRESS(base,offset) ((base) + \
+          ARM_GICR_CTLR_FRAME_SIZE + ARM_GIC_ICDIPR + 4 * (offset))
+
 /**
  *
  * Return whether the Source interrupt index refers to a shared interrupt (SPI)
@@ -236,7 +239,7 @@ ArmGicSetInterruptPriority (
     }
 
     MmioAndThenOr32 (
-      GicCpuRedistributorBase + ARM_GIC_ICDIPR + (4 * RegOffset),
+      IPRIORITY_ADDRESS (GicCpuRedistributorBase, RegOffset),
       ~(0xff << RegShift),
       Priority << RegShift
       );


### PR DESCRIPTION
The first patch is prepare for the second one.
                                
Ming Huang (2):
  ArmPkg/ArmGicLib: Fix two macros issue for offset parameter
  ArmPkg/ArmGicLib: Fix GICR_IPRIORITYR address wrong issue

 ArmPkg/Drivers/ArmGic/ArmGicLib.c | 9 ++++++---
 1 file changed, 6 insertions(+), 3 deletions(-)

This resolves https://bugzilla.tianocore.org/show_bug.cgi?id=3236