### PR TITLE
Fix CET shadow stack token busy bit clear issue

### DIFF
--- a/MdePkg/Include/Ia32/Nasm.inc
+++ b/MdePkg/Include/Ia32/Nasm.inc
@@ -9,6 +9,18 @@
 ;
 ;------------------------------------------------------------------------------
 
+%macro SAVEPREVSSP     0
+    DB 0xF3, 0x0F, 0x01, 0xEA
+%endmacro
+
+%macro CLRSSBSY_EAX    0
+    DB 0x67, 0xF3, 0x0F, 0xAE, 0x30
+%endmacro
+
+%macro RSTORSSP_EAX    0
+    DB 0x67, 0xF3, 0x0F, 0x01, 0x28
+%endmacro
+
 %macro SETSSBSY        0
     DB 0xF3, 0x0F, 0x01, 0xE8
 %endmacro

--- a/MdePkg/Include/X64/Nasm.inc
+++ b/MdePkg/Include/X64/Nasm.inc
@@ -9,6 +9,18 @@
 ;
 ;------------------------------------------------------------------------------
 
+%macro SAVEPREVSSP     0
+    DB 0xF3, 0x0F, 0x01, 0xEA
+%endmacro
+
+%macro CLRSSBSY_RAX    0
+    DB 0xF3, 0x0F, 0xAE, 0x30
+%endmacro
+
+%macro RSTORSSP_RAX    0
+    DB 0xF3, 0x0F, 0x01, 0x28
+%endmacro
+
 %macro SETSSBSY        0
     DB 0xF3, 0x0F, 0x01, 0xE8
 %endmacro

--- a/UefiCpuPkg/Library/CpuExceptionHandlerLib/DxeCpuExceptionHandlerLib.inf
+++ b/UefiCpuPkg/Library/CpuExceptionHandlerLib/DxeCpuExceptionHandlerLib.inf
@@ -43,6 +43,9 @@
   gUefiCpuPkgTokenSpaceGuid.PcdCpuStackSwitchExceptionList
   gUefiCpuPkgTokenSpaceGuid.PcdCpuKnownGoodStackSize
 
+[FeaturePcd]
+  gUefiCpuPkgTokenSpaceGuid.PcdCpuSmmStackGuard                    ## CONSUMES
+
 [Packages]
   MdePkg/MdePkg.dec
   MdeModulePkg/MdeModulePkg.dec

--- a/UefiCpuPkg/Library/CpuExceptionHandlerLib/PeiCpuExceptionHandlerLib.inf
+++ b/UefiCpuPkg/Library/CpuExceptionHandlerLib/PeiCpuExceptionHandlerLib.inf
@@ -57,3 +57,6 @@
 [Pcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdCpuStackGuard    # CONSUMES
 
+[FeaturePcd]
+  gUefiCpuPkgTokenSpaceGuid.PcdCpuSmmStackGuard                    ## CONSUMES
+

--- a/UefiCpuPkg/Library/CpuExceptionHandlerLib/SecPeiCpuExceptionHandlerLib.inf
+++ b/UefiCpuPkg/Library/CpuExceptionHandlerLib/SecPeiCpuExceptionHandlerLib.inf
@@ -49,3 +49,7 @@
   LocalApicLib
   PeCoffGetEntryPointLib
   VmgExitLib
+
+[FeaturePcd]
+  gUefiCpuPkgTokenSpaceGuid.PcdCpuSmmStackGuard                    ## CONSUMES
+

--- a/UefiCpuPkg/Library/CpuExceptionHandlerLib/SmmCpuExceptionHandlerLib.inf
+++ b/UefiCpuPkg/Library/CpuExceptionHandlerLib/SmmCpuExceptionHandlerLib.inf
@@ -53,3 +53,6 @@
   DebugLib
   VmgExitLib
 
+[FeaturePcd]
+  gUefiCpuPkgTokenSpaceGuid.PcdCpuSmmStackGuard                    ## CONSUMES
+

--- a/UefiCpuPkg/Library/CpuExceptionHandlerLib/X64/Xcode5ExceptionHandlerAsm.nasm
+++ b/UefiCpuPkg/Library/CpuExceptionHandlerLib/X64/Xcode5ExceptionHandlerAsm.nasm
@@ -13,6 +13,7 @@
 ; Notes:
 ;
 ;------------------------------------------------------------------------------
+%include "Nasm.inc"
 
 ;
 ; CommonExceptionHandler()
@@ -23,6 +24,7 @@
 extern ASM_PFX(mErrorCodeFlag)    ; Error code flags for exceptions
 extern ASM_PFX(mDoFarReturnFlag)  ; Do far return flag
 extern ASM_PFX(CommonExceptionHandler)
+extern ASM_PFX(FeaturePcdGet (PcdCpuSmmStackGuard))
 
 SECTION .data
 
@@ -371,8 +373,48 @@ DoReturn:
     push    qword [rax + 0x18]       ; save EFLAGS in new location
     mov     rax, [rax]        ; restore rax
     popfq                     ; restore EFLAGS
-    DB      0x48               ; prefix to composite "retq" with next "retf"
-    retf                      ; far return
+
+    ; The follow algorithm is used for clear shadow stack token busy bit.
+    ; The comment is based on the sample shadow stack.
+    ; The sample shadow stack layout :
+    ; Address | Context
+    ;         +-------------------------+
+    ;  0xFD0  |   FREE                  | it is 0xFD8|0x02|(LMA & CS.L), after SAVEPREVSSP.
+    ;         +-------------------------+
+    ;  0xFD8  |  Prev SSP               |
+    ;         +-------------------------+
+    ;  0xFE0  |   RIP                   |
+    ;         +-------------------------+
+    ;  0xFE8  |   CS                    |
+    ;         +-------------------------+
+    ;  0xFF0  |  0xFF0 | BUSY           | BUSY flag cleared after CLRSSBSY
+    ;         +-------------------------+
+    ;  0xFF8  | 0xFD8|0x02|(LMA & CS.L) |
+    ;         +-------------------------+
+    ; Instructions for Intel Control Flow Enforcement Technology (CET) are supported since NASM version 2.15.01.
+    push     rax                ; SSP should be 0xFD8 at this point
+    cmp      byte [dword ASM_PFX(FeaturePcdGet (PcdCpuSmmStackGuard))], 0
+    jz       CetDone
+    mov      rax, cr4
+    and      rax, 0x800000      ; check if CET is enabled
+    jz       CetDone
+    mov      rax, 0x04          ; advance past cs:lip:prevssp;supervisor shadow stack token
+    INCSSP_RAX                  ; After this SSP should be 0xFF8
+    SAVEPREVSSP                 ; now the shadow stack restore token will be created at 0xFD0
+    READSSP_RAX                 ; Read new SSP, SSP should be 0x1000
+    push     rax
+    sub      rax, 0x10
+    CLRSSBSY_RAX                ; Clear token at 0xFF0, SSP should be 0 after this
+    sub      rax, 0x20
+    RSTORSSP_RAX                ; Restore to token at 0xFD0, new SSP will be 0xFD0
+    pop      rax
+    mov      rax, 0x01          ; Pop off the new save token created
+    INCSSP_RAX                  ; SSP should be 0xFD8 now
+CetDone:
+    pop      rax                ; restore rax
+
+    DB       0x48               ; prefix to composite "retq" with next "retf"
+    retf                        ; far return
 DoIret:
     iretq
 

--- a/UefiCpuPkg/Library/CpuExceptionHandlerLib/Xcode5SecPeiCpuExceptionHandlerLib.inf
+++ b/UefiCpuPkg/Library/CpuExceptionHandlerLib/Xcode5SecPeiCpuExceptionHandlerLib.inf
@@ -54,3 +54,7 @@
   LocalApicLib
   PeCoffGetEntryPointLib
   VmgExitLib
+
+[FeaturePcd]
+  gUefiCpuPkgTokenSpaceGuid.PcdCpuSmmStackGuard                    ## CONSUMES
+

--- a/UefiCpuPkg/PiSmmCpuDxeSmm/MpService.c
+++ b/UefiCpuPkg/PiSmmCpuDxeSmm/MpService.c
@@ -23,6 +23,8 @@ SPIN_LOCK                                   *mPFLock = NULL;
 SMM_CPU_SYNC_MODE                           mCpuSmmSyncMode;
 BOOLEAN                                     mMachineCheckSupported = FALSE;
 
+extern UINTN mSmmShadowStackSize;
+
 /**
   Performs an atomic compare exchange operation to get semaphore.
   The compare exchange operation must be performed using
@@ -920,7 +922,7 @@ Gen4GPageTable (
     // Add two more pages for known good stack and stack guard page,
     // then find the lower 2MB aligned address.
     //
-    High2MBoundary = (mSmmStackArrayEnd - mSmmStackSize + EFI_PAGE_SIZE * 2) & ~(SIZE_2MB-1);
+    High2MBoundary = (mSmmStackArrayEnd - mSmmStackSize - mSmmShadowStackSize + EFI_PAGE_SIZE * 2) & ~(SIZE_2MB-1);
     PagesNeeded = ((High2MBoundary - Low2MBoundary) / SIZE_2MB) + 1;
   }
   //
@@ -971,7 +973,7 @@ Gen4GPageTable (
           // Mark the guard page as non-present
           //
           Pte[Index] = PageAddress | mAddressEncMask;
-          GuardPage += mSmmStackSize;
+          GuardPage += (mSmmStackSize + mSmmShadowStackSize);
           if (GuardPage > mSmmStackArrayEnd) {
             GuardPage = 0;
           }

--- a/UefiCpuPkg/PiSmmCpuDxeSmm/X64/PageTbl.c
+++ b/UefiCpuPkg/PiSmmCpuDxeSmm/X64/PageTbl.c
@@ -13,6 +13,8 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #define PAGE_TABLE_PAGES            8
 #define ACC_MAX_BIT                 BIT3
 
+extern UINTN mSmmShadowStackSize;
+
 LIST_ENTRY                          mPagePool = INITIALIZE_LIST_HEAD_VARIABLE (mPagePool);
 BOOLEAN                             m1GPageTableSupport = FALSE;
 BOOLEAN                             mCpuSmmRestrictedMemoryAccess;
@@ -1037,7 +1039,7 @@ SmiPFHandler (
       (PFAddress < (mCpuHotPlugData.SmrrBase + mCpuHotPlugData.SmrrSize))) {
     DumpCpuContext (InterruptType, SystemContext);
     CpuIndex = GetCpuIndex ();
-    GuardPageAddress = (mSmmStackArrayBase + EFI_PAGE_SIZE + CpuIndex * mSmmStackSize);
+    GuardPageAddress = (mSmmStackArrayBase + EFI_PAGE_SIZE + CpuIndex * (mSmmStackSize + mSmmShadowStackSize));
     if ((FeaturePcdGet (PcdCpuSmmStackGuard)) &&
         (PFAddress >= GuardPageAddress) &&
         (PFAddress < (GuardPageAddress + EFI_PAGE_SIZE))) {

--- a/UefiCpuPkg/PiSmmCpuDxeSmm/X64/SmmFuncsArch.c
+++ b/UefiCpuPkg/PiSmmCpuDxeSmm/X64/SmmFuncsArch.c
@@ -173,6 +173,7 @@ InitShadowStack (
 {
   UINTN       SmmShadowStackSize;
   UINT64      *InterruptSspTable;
+  UINT32      InterruptSsp;
 
   if ((PcdGet32 (PcdControlFlowEnforcementPropertyMask) != 0) && mCetSupported) {
     SmmShadowStackSize = EFI_PAGES_TO_SIZE (EFI_SIZE_TO_PAGES (PcdGet32 (PcdCpuSmmShadowStackSize)));
@@ -191,7 +192,19 @@ InitShadowStack (
         ASSERT (mSmmInterruptSspTables != 0);
         DEBUG ((DEBUG_INFO, "mSmmInterruptSspTables - 0x%x\n", mSmmInterruptSspTables));
       }
-      mCetInterruptSsp = (UINT32)((UINTN)ShadowStack + EFI_PAGES_TO_SIZE(1) - sizeof(UINT64));
+
+      //
+      // The highest address on the stack (0xFF8) is a save-previous-ssp token pointing to a location that is 40 bytes away - 0xFD0.
+      // The supervisor shadow stack token is just above it at address 0xFF0. This is where the interrupt SSP table points.
+      // So when an interrupt of exception occurs, we can use SAVESSP/RESTORESSP/CLEARSSBUSY for the supervisor shadow stack,
+      // due to the reason the RETF in SMM exception handler cannot clear the BUSY flag with same CPL.
+      // (only IRET or RETF with different CPL can clear BUSY flag)
+      // Please refer to UefiCpuPkg/Library/CpuExceptionHandlerLib/X64 for the full stack frame at runtime.
+      //
+      InterruptSsp = (UINT32)((UINTN)ShadowStack + EFI_PAGES_TO_SIZE(1) - sizeof(UINT64));
+      *(UINT32 *)(UINTN)InterruptSsp = (InterruptSsp - sizeof(UINT64) * 4) | 0x2;
+      mCetInterruptSsp = InterruptSsp - sizeof(UINT64);
+
       mCetInterruptSspTable = (UINT32)(UINTN)(mSmmInterruptSspTables + sizeof(UINT64) * 8 * CpuIndex);
       InterruptSspTable = (UINT64 *)(UINTN)mCetInterruptSspTable;
       InterruptSspTable[1] = mCetInterruptSsp;

--- a/UefiCpuPkg/PiSmmCpuDxeSmm/X64/SmmFuncsArch.c
+++ b/UefiCpuPkg/PiSmmCpuDxeSmm/X64/SmmFuncsArch.c
@@ -93,7 +93,7 @@ InitGdt (
       //
       // Setup top of known good stack as IST1 for each processor.
       //
-      *(UINTN *)(TssBase + TSS_X64_IST1_OFFSET) = (mSmmStackArrayBase + EFI_PAGE_SIZE + Index * mSmmStackSize);
+      *(UINTN *)(TssBase + TSS_X64_IST1_OFFSET) = (mSmmStackArrayBase + EFI_PAGE_SIZE + Index * (mSmmStackSize + mSmmShadowStackSize));
     }
   }
 


### PR DESCRIPTION
If CET shadows stack feature enabled in SMM and stack switch is enabled.
When code execute from SMM handler to SMM exception, CPU will check SMM
exception shadow stack token busy bit if it is cleared or not.
If it is set, it will trigger #DF exception.
If it is not set, CPU will set the busy bit when enter SMM exception.
So, the busy bit should be cleared when return back form SMM exception to
SMM handler. Otherwise, keeping busy bit 1 will cause to trigger #DF
exception when enter SMM exception next time.
So, we use instruction SAVEPREVSSP, CLRSSBSY and RSTORSSP to clear the
shadow stack token busy bit before RETF instruction in SMM exception.
Since open CI is using NASM 2.14.02, it has not supported CET instructions
yet. DB-encoded CET instructions will to be removed after open CI update to
 NASM 2.15.01.
In function InitGdt(), SmiPFHandler() and Gen4GPageTable(), it uses
 CpuIndex * mSmmStackSize to get the SMM stack address offset for
 multi processor. It misses the SMM Shadow Stack Size. Each processor
 will use mSmmStackSize + mSmmShadowStackSize in the memory.
It should use CpuIndex * (mSmmStackSize + mSmmShadowStackSize) to get
 this SMM stack address offset. If mSmmShadowStackSize > 0 and multi
 processor enabled, it will get the wrong offset value.
CET shadow stack feature will set the value of mSmmShadowStackSize.
