### PR TITLE
MdeModulePkg/UfsPassThruDxe: Improve Device initialization polling Loop

### DIFF
--- a/MdeModulePkg/Bus/Ufs/UfsPassThruDxe/UfsPassThru.h
+++ b/MdeModulePkg/Bus/Ufs/UfsPassThruDxe/UfsPassThru.h
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2014 - 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2014 - 2021, Intel Corporation. All rights reserved.<BR>
   Copyright (c) Microsoft Corporation.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -40,6 +40,7 @@
 //
 #define UFS_MAX_LUNS                12
 #define UFS_WLUN_PREFIX             0xC1
+#define UFS_INIT_COMPLETION_TIMEOUT 600000
 
 typedef struct {
   UINT8    Lun[UFS_MAX_LUNS];


### PR DESCRIPTION
https://bugzilla.tianocore.org/show_bug.cgi?id=3217

Current Ufs Pass thru driver polls for 5us and return success even when
the timeout occurs.
There are cards that can take upto 600ms for Init and hence increased
the time out for fDeviceInit polling loop.

Signed-off-by: Bandaru <purna.chandra.rao.bandaru@intel.com>
Cc: Mateusz Albecki <mateusz.albecki@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Reviewed-by: Hao A Wu <hao.a.wu@intel.com>