### PR TITLE
EmbeddedPkg: Only print LibGetTime message about compile time epoch once

### DIFF
--- a/EmbeddedPkg/Library/VirtualRealTimeClockLib/VirtualRealTimeClockLib.c
+++ b/EmbeddedPkg/Library/VirtualRealTimeClockLib/VirtualRealTimeClockLib.c
@@ -88,10 +88,18 @@ LibGetTime (
     //
     EpochSeconds = BUILD_EPOCH;
     DEBUG ((
-      DEBUG_VERBOSE,
+      DEBUG_INFO,
       "LibGetTime: %s non volatile variable was not found - Using compilation time epoch.\n",
       mEpochVariableName
       ));
+
+    EfiSetVariable (
+      (CHAR16 *)mEpochVariableName,
+      &gEfiCallerIdGuid,
+      EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_RUNTIME_ACCESS,
+      sizeof (EpochSeconds),
+      &EpochSeconds
+      );
   }
   Counter = GetPerformanceCounter ();
   EpochSeconds += DivU64x64Remainder (Counter, Freq, &Remainder);


### PR DESCRIPTION
The message "LibGetTime: RtcEpochSeconds non volatile variable was not
found - Using compilation time epoch." can be printed a very large
number of times, causing log files to become excessively large. This is
because the RtcEpochSeconds variable only gets set if LibSetTime is
called, for example by running 'time 12:00' in the UEFI Shell.

Avoid this by setting RtcEpochSeconds to BUILD_EPOCH (EpochSeconds)
after printing the message. It's set to a volatile variable so the
message will be displayed on future boots and not hidden.

Commit 44ae214591e58af468eacb7b873eaa0bc187c4fa reduced the verbosity of
the message to DEBUG_VERBOSE. Revert it back to DEBUG_INFO so it's more
prominent now that it doesn't get printed so frequently.

Signed-off-by: Rebecca Cran <rebecca@nuviainc.com>