### PR TITLE
BaseTools: Update the NASM CI dependency

### DIFF
--- a/BaseTools/Bin/nasm_ext_dep.yaml
+++ b/BaseTools/Bin/nasm_ext_dep.yaml
@@ -13,6 +13,6 @@
   "type": "nuget",
   "name": "mu_nasm",
   "source": "https://api.nuget.org/v3/index.json",
-  "version": "2.14.02",
+  "version": "2.15.05",
   "flags": ["set_path", "host_specific"]
 }


### PR DESCRIPTION
Update the external dependency (consumed by Edk2Tools) version for NASM,
as agreed in recent community meetings:
https://edk2.groups.io/g/devel/message/71289
https://edk2.groups.io/g/devel/message/71070

This is primarily used by CI builds, but may also be used by platforms.

Signed-off-by: Bret Barkelew <Bret.Barkelew@microsoft.com>
Cc: Bob Feng <bob.c.feng@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Yuwei Chen <yuwei.chen@intel.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>