### PR TITLE
BaseTools: Modify struct parser for StructPcd

### DIFF
--- a/BaseTools/Scripts/ConvertFceToStructurePcd.py
+++ b/BaseTools/Scripts/ConvertFceToStructurePcd.py
@@ -197,6 +197,8 @@ class parser_lst(object):
     efitxt = efivarstore_format.findall(self.text)
     for i in efitxt:
       struct = struct_re.findall(i.replace(' ',''))
+      if struct[0] in self._ignore:
+          continue
       name = name_re.findall(i.replace(' ',''))
       if struct and name:
         efivarstore_dict[name[0]]=struct[0]


### PR DESCRIPTION
Currently the struct parser for StructPcd Generation does not
filter the types such as UINT8 which should be ignored successfully.
This patch modifies this issue.

Cc: Bob Feng <bob.c.feng@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Signed-off-by: Yuwei Chen <yuwei.chen@intel.com>
Reviewed-by: Bob Feng <bob.c.feng@intel.com>