### PR TITLE
[edk2-devel] [PATCH v3 0/5] UefiCpuPkg/StandaloneMmCpuFeaturesLib: Add Standalone MM support -- push

### DIFF
--- a/UefiCpuPkg/Library/SmmCpuFeaturesLib/CpuFeaturesLib.h
+++ b/UefiCpuPkg/Library/SmmCpuFeaturesLib/CpuFeaturesLib.h
@@ -10,6 +10,18 @@
 #define CPU_FEATURES_LIB_H_
 
 /**
+  Performs library initialization.
+
+  This initialization function contains common functionality shared betwen all
+  library instance constructors.
+
+**/
+VOID
+CpuFeaturesLibInitialization (
+  VOID
+  );
+
+/**
   Internal worker function that is called to complete CPU initialization at the
   end of SmmCpuFeaturesInitializeProcessor().
 

--- a/UefiCpuPkg/Library/SmmCpuFeaturesLib/CpuFeaturesLib.h
+++ b/UefiCpuPkg/Library/SmmCpuFeaturesLib/CpuFeaturesLib.h
@@ -1,0 +1,22 @@
+/** @file
+  Internal library function definitions.
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef CPU_FEATURES_LIB_H_
+#define CPU_FEATURES_LIB_H_
+
+/**
+  Internal worker function that is called to complete CPU initialization at the
+  end of SmmCpuFeaturesInitializeProcessor().
+
+**/
+VOID
+FinishSmmCpuFeaturesInitializeProcessor (
+  VOID
+  );
+
+#endif

--- a/UefiCpuPkg/Library/SmmCpuFeaturesLib/CpuFeaturesLib.h
+++ b/UefiCpuPkg/Library/SmmCpuFeaturesLib/CpuFeaturesLib.h
@@ -31,4 +31,18 @@ FinishSmmCpuFeaturesInitializeProcessor (
   VOID
   );
 
+/**
+  Gets the maximum number of logical processors from the PCD PcdCpuMaxLogicalProcessorNumber.
+
+  This access is abstracted from the PCD services to enforce that the PCD be
+  FixedAtBuild in the Standalone MM build of this driver.
+
+  @return  The value of PcdCpuMaxLogicalProcessorNumber.
+
+**/
+UINT32
+GetCpuMaxLogicalProcessorNumber (
+  VOID
+  );
+
 #endif

--- a/UefiCpuPkg/Library/SmmCpuFeaturesLib/Ia32/SmmStmSupport.c
+++ b/UefiCpuPkg/Library/SmmCpuFeaturesLib/Ia32/SmmStmSupport.c
@@ -6,7 +6,7 @@
 
 **/
 
-#include <PiSmm.h>
+#include <PiMm.h>
 #include <Library/DebugLib.h>
 
 #include "SmmStm.h"

--- a/UefiCpuPkg/Library/SmmCpuFeaturesLib/SmmCpuFeaturesLib.c
+++ b/UefiCpuPkg/Library/SmmCpuFeaturesLib/SmmCpuFeaturesLib.c
@@ -15,6 +15,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/DebugLib.h>
 #include <Register/Intel/Cpuid.h>
 #include <Register/Intel/SmramSaveStateMap.h>
+#include "CpuFeaturesLib.h"
 
 //
 // Machine Specific Registers (MSRs)
@@ -34,16 +35,6 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 //
 #define SMM_FEATURES_LIB_IA32_MCA_CAP              0x17D
 #define   SMM_CODE_ACCESS_CHK_BIT                  BIT58
-
-/**
-  Internal worker function that is called to complete CPU initialization at the
-  end of SmmCpuFeaturesInitializeProcessor().
-
-**/
-VOID
-FinishSmmCpuFeaturesInitializeProcessor (
-  VOID
-  );
 
 //
 // Set default value to assume SMRR is not supported

--- a/UefiCpuPkg/Library/SmmCpuFeaturesLib/SmmCpuFeaturesLib.c
+++ b/UefiCpuPkg/Library/SmmCpuFeaturesLib/SmmCpuFeaturesLib.c
@@ -6,7 +6,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
 
-#include <PiSmm.h>
+#include <PiMm.h>
 #include "CpuFeaturesLib.h"
 
 /**

--- a/UefiCpuPkg/Library/SmmCpuFeaturesLib/SmmCpuFeaturesLib.c
+++ b/UefiCpuPkg/Library/SmmCpuFeaturesLib/SmmCpuFeaturesLib.c
@@ -1,0 +1,31 @@
+/** @file
+Implementation specific to the SmmCpuFeatureLib library instance.
+
+Copyright (c) Microsoft Corporation.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <PiSmm.h>
+#include "CpuFeaturesLib.h"
+
+/**
+  The constructor function for the Traditional MM library instance without STM.
+
+  @param[in]  ImageHandle  The firmware allocated handle for the EFI image.
+  @param[in]  SystemTable  A pointer to the EFI System Table.
+
+  @retval EFI_SUCCESS      The constructor always returns EFI_SUCCESS.
+
+**/
+EFI_STATUS
+EFIAPI
+SmmCpuFeaturesLibConstructor (
+  IN EFI_HANDLE        ImageHandle,
+  IN EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  CpuFeaturesLibInitialization ();
+
+  return EFI_SUCCESS;
+}

--- a/UefiCpuPkg/Library/SmmCpuFeaturesLib/SmmCpuFeaturesLib.inf
+++ b/UefiCpuPkg/Library/SmmCpuFeaturesLib/SmmCpuFeaturesLib.inf
@@ -18,6 +18,7 @@
 
 [Sources]
   CpuFeaturesLib.h
+  SmmCpuFeaturesLib.c
   SmmCpuFeaturesLibCommon.c
   SmmCpuFeaturesLibNoStm.c
 

--- a/UefiCpuPkg/Library/SmmCpuFeaturesLib/SmmCpuFeaturesLib.inf
+++ b/UefiCpuPkg/Library/SmmCpuFeaturesLib/SmmCpuFeaturesLib.inf
@@ -21,6 +21,7 @@
   SmmCpuFeaturesLib.c
   SmmCpuFeaturesLibCommon.c
   SmmCpuFeaturesLibNoStm.c
+  TraditionalMmCpuFeaturesLib.c
 
 [Packages]
   MdePkg/MdePkg.dec

--- a/UefiCpuPkg/Library/SmmCpuFeaturesLib/SmmCpuFeaturesLib.inf
+++ b/UefiCpuPkg/Library/SmmCpuFeaturesLib/SmmCpuFeaturesLib.inf
@@ -17,6 +17,7 @@
   CONSTRUCTOR                    = SmmCpuFeaturesLibConstructor
 
 [Sources]
+  CpuFeaturesLib.h
   SmmCpuFeaturesLib.c
   SmmCpuFeaturesLibNoStm.c
 

--- a/UefiCpuPkg/Library/SmmCpuFeaturesLib/SmmCpuFeaturesLib.inf
+++ b/UefiCpuPkg/Library/SmmCpuFeaturesLib/SmmCpuFeaturesLib.inf
@@ -18,7 +18,7 @@
 
 [Sources]
   CpuFeaturesLib.h
-  SmmCpuFeaturesLib.c
+  SmmCpuFeaturesLibCommon.c
   SmmCpuFeaturesLibNoStm.c
 
 [Packages]

--- a/UefiCpuPkg/Library/SmmCpuFeaturesLib/SmmCpuFeaturesLibCommon.c
+++ b/UefiCpuPkg/Library/SmmCpuFeaturesLib/SmmCpuFeaturesLibCommon.c
@@ -157,7 +157,7 @@ CpuFeaturesLibInitialization (
   //
   // Allocate array for state of SMRR enable on all CPUs
   //
-  mSmrrEnabled = (BOOLEAN *)AllocatePool (sizeof (BOOLEAN) * PcdGet32 (PcdCpuMaxLogicalProcessorNumber));
+  mSmrrEnabled = (BOOLEAN *)AllocatePool (sizeof (BOOLEAN) * GetCpuMaxLogicalProcessorNumber ());
   ASSERT (mSmrrEnabled != NULL);
 }
 

--- a/UefiCpuPkg/Library/SmmCpuFeaturesLib/SmmCpuFeaturesLibCommon.c
+++ b/UefiCpuPkg/Library/SmmCpuFeaturesLib/SmmCpuFeaturesLibCommon.c
@@ -1,5 +1,5 @@
 /** @file
-The CPU specific programming for PiSmmCpuDxeSmm module.
+Implementation shared across all library instances.
 
 Copyright (c) 2010 - 2019, Intel Corporation. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent

--- a/UefiCpuPkg/Library/SmmCpuFeaturesLib/SmmCpuFeaturesLibCommon.c
+++ b/UefiCpuPkg/Library/SmmCpuFeaturesLib/SmmCpuFeaturesLibCommon.c
@@ -7,7 +7,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
 
-#include <PiSmm.h>
+#include <PiMm.h>
 #include <Library/SmmCpuFeaturesLib.h>
 #include <Library/BaseLib.h>
 #include <Library/MtrrLib.h>

--- a/UefiCpuPkg/Library/SmmCpuFeaturesLib/SmmCpuFeaturesLibCommon.c
+++ b/UefiCpuPkg/Library/SmmCpuFeaturesLib/SmmCpuFeaturesLibCommon.c
@@ -2,6 +2,7 @@
 Implementation shared across all library instances.
 
 Copyright (c) 2010 - 2019, Intel Corporation. All rights reserved.<BR>
+Copyright (c) Microsoft Corporation.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -63,19 +64,15 @@ BOOLEAN  mNeedConfigureMtrrs = TRUE;
 BOOLEAN  *mSmrrEnabled;
 
 /**
-  The constructor function
+  Performs library initialization.
 
-  @param[in]  ImageHandle  The firmware allocated handle for the EFI image.
-  @param[in]  SystemTable  A pointer to the EFI System Table.
-
-  @retval EFI_SUCCESS      The constructor always returns EFI_SUCCESS.
+  This initialization function contains common functionality shared betwen all
+  library instance constructors.
 
 **/
-EFI_STATUS
-EFIAPI
-SmmCpuFeaturesLibConstructor (
-  IN EFI_HANDLE        ImageHandle,
-  IN EFI_SYSTEM_TABLE  *SystemTable
+VOID
+CpuFeaturesLibInitialization (
+  VOID
   )
 {
   UINT32  RegEax;
@@ -162,8 +159,6 @@ SmmCpuFeaturesLibConstructor (
   //
   mSmrrEnabled = (BOOLEAN *)AllocatePool (sizeof (BOOLEAN) * PcdGet32 (PcdCpuMaxLogicalProcessorNumber));
   ASSERT (mSmrrEnabled != NULL);
-
-  return EFI_SUCCESS;
 }
 
 /**

--- a/UefiCpuPkg/Library/SmmCpuFeaturesLib/SmmCpuFeaturesLibNoStm.c
+++ b/UefiCpuPkg/Library/SmmCpuFeaturesLib/SmmCpuFeaturesLibNoStm.c
@@ -7,7 +7,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
 
-#include <PiSmm.h>
+#include <PiMm.h>
 #include <Library/SmmCpuFeaturesLib.h>
 #include "CpuFeaturesLib.h"
 

--- a/UefiCpuPkg/Library/SmmCpuFeaturesLib/SmmCpuFeaturesLibNoStm.c
+++ b/UefiCpuPkg/Library/SmmCpuFeaturesLib/SmmCpuFeaturesLibNoStm.c
@@ -9,6 +9,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #include <PiSmm.h>
 #include <Library/SmmCpuFeaturesLib.h>
+#include "CpuFeaturesLib.h"
 
 /**
   Internal worker function that is called to complete CPU initialization at the

--- a/UefiCpuPkg/Library/SmmCpuFeaturesLib/SmmCpuFeaturesLibStm.inf
+++ b/UefiCpuPkg/Library/SmmCpuFeaturesLib/SmmCpuFeaturesLibStm.inf
@@ -19,7 +19,7 @@
 
 [Sources]
   CpuFeaturesLib.h
-  SmmCpuFeaturesLib.c
+  SmmCpuFeaturesLibCommon.c
   SmmStm.c
   SmmStm.h
 

--- a/UefiCpuPkg/Library/SmmCpuFeaturesLib/SmmCpuFeaturesLibStm.inf
+++ b/UefiCpuPkg/Library/SmmCpuFeaturesLib/SmmCpuFeaturesLibStm.inf
@@ -22,6 +22,7 @@
   SmmCpuFeaturesLibCommon.c
   SmmStm.c
   SmmStm.h
+  TraditionalMmCpuFeaturesLib.c
 
 [Sources.Ia32]
   Ia32/SmmStmSupport.c

--- a/UefiCpuPkg/Library/SmmCpuFeaturesLib/SmmCpuFeaturesLibStm.inf
+++ b/UefiCpuPkg/Library/SmmCpuFeaturesLib/SmmCpuFeaturesLibStm.inf
@@ -18,6 +18,7 @@
   CONSTRUCTOR                    = SmmCpuFeaturesLibStmConstructor
 
 [Sources]
+  CpuFeaturesLib.h
   SmmCpuFeaturesLib.c
   SmmStm.c
   SmmStm.h

--- a/UefiCpuPkg/Library/SmmCpuFeaturesLib/SmmStm.c
+++ b/UefiCpuPkg/Library/SmmCpuFeaturesLib/SmmStm.c
@@ -21,6 +21,7 @@
 
 #include <Protocol/MpService.h>
 
+#include "CpuFeaturesLib.h"
 #include "SmmStm.h"
 
 #define TXT_EVTYPE_BASE                  0x400

--- a/UefiCpuPkg/Library/SmmCpuFeaturesLib/SmmStm.c
+++ b/UefiCpuPkg/Library/SmmCpuFeaturesLib/SmmStm.c
@@ -6,7 +6,7 @@
 
 **/
 
-#include <PiSmm.h>
+#include <PiMm.h>
 #include <Library/BaseLib.h>
 #include <Library/BaseMemoryLib.h>
 #include <Library/MemoryAllocationLib.h>

--- a/UefiCpuPkg/Library/SmmCpuFeaturesLib/SmmStm.c
+++ b/UefiCpuPkg/Library/SmmCpuFeaturesLib/SmmStm.c
@@ -30,22 +30,6 @@
 #define RDWR_ACCS             3
 #define FULL_ACCS             7
 
-/**
-  The constructor function
-
-  @param[in]  ImageHandle  The firmware allocated handle for the EFI image.
-  @param[in]  SystemTable  A pointer to the EFI System Table.
-
-  @retval EFI_SUCCESS      The constructor always returns EFI_SUCCESS.
-
-**/
-EFI_STATUS
-EFIAPI
-SmmCpuFeaturesLibConstructor (
-  IN EFI_HANDLE        ImageHandle,
-  IN EFI_SYSTEM_TABLE  *SystemTable
-  );
-
 EFI_HANDLE  mStmSmmCpuHandle = NULL;
 
 BOOLEAN mLockLoadMonitor = FALSE;
@@ -112,7 +96,7 @@ UINTN  mMsegSize = 0;
 BOOLEAN  mStmConfigurationTableInitialized = FALSE;
 
 /**
-  The constructor function
+  The constructor function for the Traditional MM library instance with STM.
 
   @param[in]  ImageHandle  The firmware allocated handle for the EFI image.
   @param[in]  SystemTable  A pointer to the EFI System Table.
@@ -138,10 +122,9 @@ SmmCpuFeaturesLibStmConstructor (
   SmmCpuFeaturesLibStmSmiEntryFixupAddress ();
 
   //
-  // Call the common constructor function
+  // Perform library initialization common across all instances
   //
-  Status = SmmCpuFeaturesLibConstructor (ImageHandle, SystemTable);
-  ASSERT_EFI_ERROR (Status);
+  CpuFeaturesLibInitialization ();
 
   //
   // Lookup the MP Services Protocol

--- a/UefiCpuPkg/Library/SmmCpuFeaturesLib/StandaloneMmCpuFeaturesLib.c
+++ b/UefiCpuPkg/Library/SmmCpuFeaturesLib/StandaloneMmCpuFeaturesLib.c
@@ -1,0 +1,50 @@
+/** @file
+Standalone MM CPU specific programming.
+
+Copyright (c) 2010 - 2019, Intel Corporation. All rights reserved.<BR>
+Copyright (c) Microsoft Corporation.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <PiMm.h>
+#include <Library/PcdLib.h>
+#include "CpuFeaturesLib.h"
+
+/**
+  Gets the maximum number of logical processors from the PCD PcdCpuMaxLogicalProcessorNumber.
+
+  This access is abstracted from the PCD services to enforce that the PCD be
+  FixedAtBuild in the Standalone MM build of this driver.
+
+  @return  The value of PcdCpuMaxLogicalProcessorNumber.
+
+**/
+UINT32
+GetCpuMaxLogicalProcessorNumber (
+  VOID
+  )
+{
+  return FixedPcdGet32 (PcdCpuMaxLogicalProcessorNumber);
+}
+
+/**
+  The Standalone MM library constructor.
+
+  @param[in] ImageHandle  Image handle of this driver.
+  @param[in] SystemTable  A Pointer to the EFI System Table.
+
+  @retval EFI_SUCCESS     This constructor always returns success.
+
+**/
+EFI_STATUS
+EFIAPI
+StandaloneMmCpuFeaturesLibConstructor (
+  IN EFI_HANDLE           ImageHandle,
+  IN EFI_MM_SYSTEM_TABLE  *SystemTable
+  )
+{
+  CpuFeaturesLibInitialization ();
+
+  return EFI_SUCCESS;
+}

--- a/UefiCpuPkg/Library/SmmCpuFeaturesLib/StandaloneMmCpuFeaturesLib.inf
+++ b/UefiCpuPkg/Library/SmmCpuFeaturesLib/StandaloneMmCpuFeaturesLib.inf
@@ -1,0 +1,38 @@
+## @file
+#  Standalone MM CPU specific programming.
+#
+#  Copyright (c) 2009 - 2016, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) Microsoft Corporation.<BR>
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = StandaloneMmCpuFeaturesLib
+  MODULE_UNI_FILE                = SmmCpuFeaturesLib.uni
+  FILE_GUID                      = BB554A2D-F5DF-41D3-8C62-46476A2B2B18
+  MODULE_TYPE                    = MM_STANDALONE
+  VERSION_STRING                 = 1.0
+  PI_SPECIFICATION_VERSION       = 0x00010032
+  LIBRARY_CLASS                  = SmmCpuFeaturesLib
+  CONSTRUCTOR                    = StandaloneMmCpuFeaturesLibConstructor
+
+[Sources]
+  CpuFeaturesLib.h
+  StandaloneMmCpuFeaturesLib.c
+  SmmCpuFeaturesLibCommon.c
+  SmmCpuFeaturesLibNoStm.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  UefiCpuPkg/UefiCpuPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  DebugLib
+  MemoryAllocationLib
+  PcdLib
+
+[FixedPcd]
+  gUefiCpuPkgTokenSpaceGuid.PcdCpuMaxLogicalProcessorNumber        ## SOMETIMES_CONSUMES

--- a/UefiCpuPkg/Library/SmmCpuFeaturesLib/TraditionalMmCpuFeaturesLib.c
+++ b/UefiCpuPkg/Library/SmmCpuFeaturesLib/TraditionalMmCpuFeaturesLib.c
@@ -1,0 +1,28 @@
+/** @file
+  Traditional MM CPU specific programming.
+
+  Copyright (c) Microsoft Corporation.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Base.h>
+#include <Library/PcdLib.h>
+#include "CpuFeaturesLib.h"
+
+/**
+  Gets the maximum number of logical processors from the PCD PcdCpuMaxLogicalProcessorNumber.
+
+  This access is abstracted from the PCD services to enforce that the PCD be
+  FixedAtBuild in the Standalone MM build of this driver.
+
+  @return  The value of PcdCpuMaxLogicalProcessorNumber.
+
+**/
+UINT32
+GetCpuMaxLogicalProcessorNumber (
+  VOID
+  )
+{
+  return PcdGet32 (PcdCpuMaxLogicalProcessorNumber);
+}

--- a/UefiCpuPkg/Library/SmmCpuFeaturesLib/X64/SmmStmSupport.c
+++ b/UefiCpuPkg/Library/SmmCpuFeaturesLib/X64/SmmStmSupport.c
@@ -6,7 +6,7 @@
 
 **/
 
-#include <PiSmm.h>
+#include <PiMm.h>
 #include <Library/DebugLib.h>
 
 #include "SmmStm.h"

--- a/UefiCpuPkg/UefiCpuPkg.dsc
+++ b/UefiCpuPkg/UefiCpuPkg.dsc
@@ -154,6 +154,7 @@
   UefiCpuPkg/Library/SmmCpuPlatformHookLibNull/SmmCpuPlatformHookLibNull.inf
   UefiCpuPkg/Library/SmmCpuFeaturesLib/SmmCpuFeaturesLib.inf
   UefiCpuPkg/Library/SmmCpuFeaturesLib/SmmCpuFeaturesLibStm.inf
+  UefiCpuPkg/Library/SmmCpuFeaturesLib/StandaloneMmCpuFeaturesLib.inf
   UefiCpuPkg/Library/VmgExitLibNull/VmgExitLibNull.inf
   UefiCpuPkg/PiSmmCommunication/PiSmmCommunicationPei.inf
   UefiCpuPkg/PiSmmCommunication/PiSmmCommunicationSmm.inf


### PR DESCRIPTION
https://bugzilla.tianocore.org/show_bug.cgi?id=3218
https://edk2.groups.io/g/devel/message/71751
message-id: <20210217213227.1277-1-mikuback@linux.microsoft.com>
https://listman.redhat.com/archives/edk2-devel-archive/2021-February/msg00803.html
~~~
From: Michael Kubacki <michael.kubacki@microsoft.com>

REF:https://bugzilla.tianocore.org/show_bug.cgi?id=3218

The present SmmCpuFeaturesLib implementation in UefiCpuPkg can be
useful for IA32/X64 platforms that need a library instance for
a Standalone MM environment. Much of the logic can be reused and a
new INF can isolate the differences unique to Standalone MM.

This patch series contains an initial set of changes for cleaning
up pre-existing design issues in the library. The final two patches
contain changes needed for Standalone MM support.

Here's an overview of how the three library instances are organized
that may be a useful reference (provided by Laszlo):

                    Traditional,  Traditional,  Standalone,
                    no STM        STM           no STM

Entry point type   DXE           DXE           MM

Lib inst. init.    basic         STM           basic

Processor init.    basic         STM           basic

PCD access         any           any           fixed

* Traditional no STM = SmmCpuFeaturesLib.inf
* Traditional STM = SmmCpuFeaturesLibStm.inf
* Standalone no STM = StandaloneMmCpuFeaturesLib.inf

V3 changes:

  PATCH v3 2/5 is a new patch in the series that renames the file
  SmmCpuFeaturesLib.c to SmmCpuFeaturesLibCommon.c to more clearly
  identify implementation in the file as shared between all library
  instances.

  PATCH v3 3/5 adds a new source file SmmCpuFeaturesLib.c that
  contains the constructor specific to the Traditional MM no
  STM library instance. This was previously implemented in a
  file built by the Standalone MM instance and while not
  harmful, it was not clean.

  PATCH v3 4/5 updates "@retval" to "@return" in the documentation
  for GetCpuMaxLogicalProcessorNumber() since it is not a constant
  return value.
  
  PATCH v3 5/5 contains a commit message update to note that all
  instances of "PiSmm.h" in the library source files have been
  updated to "PiMm.h" for consistency throughout the library.

V2 changes:

  Due to some pre-existing design issues in the library that
  affected a single v1 patch that add Standalone MM support,
  it was suggested to first address those issues and then add the
  new INF StandaloneMmCpuFeaturesLib.inf.

  To address these concerns, the following v1 patch was converted
  into a v2 patch series:
  https://edk2.groups.io/g/devel/message/71626

  The first two patches in v2 primarily addressed those concerns.

  PATCH v2 1/4 and PATCH v2 2/4 focused on fixing pre-existing
  design issues.

  PATCH v2 3/4 and PATCH v2 4/4 focused on the changes needed to add
  Standalone MM support.

Cc: Eric Dong <eric.dong@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Cc: Laszlo Ersek <lersek@redhat.com>
Cc: Rahul Kumar <rahul1.kumar@intel.com>
Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>

Michael Kubacki (5):
  UefiCpuPkg/SmmCpuFeaturesLib: Move multi-instance function decl to
    header
  UefiCpuPkg/SmmCpuFeaturesLib: Rename SmmCpuFeaturesLib.c
  UefiCpuPkg/SmmCpuFeaturesLib: Cleanup library constructors
  UefiCpuPkg/SmmCpuFeaturesLib: Abstract PcdCpuMaxLogicalProcessorNumber
  UefiCpuPkg/SmmCpuFeaturesLib: Add Standalone MM support

 UefiCpuPkg/Library/SmmCpuFeaturesLib/Ia32/SmmStmSupport.c                                      |   2 +-
 UefiCpuPkg/Library/SmmCpuFeaturesLib/SmmCpuFeaturesLib.c                                       | 608 +-------------------
 UefiCpuPkg/Library/SmmCpuFeaturesLib/{SmmCpuFeaturesLib.c => SmmCpuFeaturesLibCommon.c}        |  36 +-
 UefiCpuPkg/Library/SmmCpuFeaturesLib/SmmCpuFeaturesLibNoStm.c                                  |   3 +-
 UefiCpuPkg/Library/SmmCpuFeaturesLib/SmmStm.c                                                  |  26 +-
 UefiCpuPkg/Library/SmmCpuFeaturesLib/StandaloneMmCpuFeaturesLib.c                              |  50 ++
 UefiCpuPkg/Library/SmmCpuFeaturesLib/TraditionalMmCpuFeaturesLib.c                             |  28 +
 UefiCpuPkg/Library/SmmCpuFeaturesLib/X64/SmmStmSupport.c                                       |   2 +-
 UefiCpuPkg/Library/SmmCpuFeaturesLib/CpuFeaturesLib.h                                          |  48 ++
 UefiCpuPkg/Library/SmmCpuFeaturesLib/SmmCpuFeaturesLib.inf                                     |   3 +
 UefiCpuPkg/Library/SmmCpuFeaturesLib/SmmCpuFeaturesLibStm.inf                                  |   4 +-
 UefiCpuPkg/Library/SmmCpuFeaturesLib/{SmmCpuFeaturesLib.inf => StandaloneMmCpuFeaturesLib.inf} |  22 +-
 UefiCpuPkg/UefiCpuPkg.dsc                                                                      |   1 +
 13 files changed, 172 insertions(+), 661 deletions(-)
 copy UefiCpuPkg/Library/SmmCpuFeaturesLib/{SmmCpuFeaturesLib.c => SmmCpuFeaturesLibCommon.c} (93%)
 create mode 100644 UefiCpuPkg/Library/SmmCpuFeaturesLib/StandaloneMmCpuFeaturesLib.c
 create mode 100644 UefiCpuPkg/Library/SmmCpuFeaturesLib/TraditionalMmCpuFeaturesLib.c
 create mode 100644 UefiCpuPkg/Library/SmmCpuFeaturesLib/CpuFeaturesLib.h
 copy UefiCpuPkg/Library/SmmCpuFeaturesLib/{SmmCpuFeaturesLib.inf => StandaloneMmCpuFeaturesLib.inf} (53%)
~~~