### PR TITLE
MdeModulePkg: Initialize local variable value before they are used

### DIFF
--- a/MdeModulePkg/Bus/Ata/AtaAtapiPassThru/AhciMode.c
+++ b/MdeModulePkg/Bus/Ata/AtaAtapiPassThru/AhciMode.c
@@ -1128,6 +1128,11 @@ AhciDmaTransfer (
   }
 
   //
+  // Set Status to suppress incorrect compiler/analyzer warnings
+  //
+  Status = EFI_SUCCESS;
+
+  //
   // DMA buffer allocation. Needs to be done only once for both sync and async
   // DMA transfers irrespective of number of retries.
   //

--- a/MdeModulePkg/Library/VariablePolicyHelperLib/VariablePolicyHelperLib.c
+++ b/MdeModulePkg/Library/VariablePolicyHelperLib/VariablePolicyHelperLib.c
@@ -115,6 +115,11 @@ CreateBasicVariablePolicy (
     return EFI_INVALID_PARAMETER;
   }
 
+  //
+  // Set NameSize to suppress incorrect compiler/analyzer warnings
+  //
+  NameSize  = 0;
+
   // Now we've gotta determine the total size of the buffer required for
   // the VariablePolicy structure.
   TotalSize = sizeof( VARIABLE_POLICY_ENTRY );


### PR DESCRIPTION
This change is to fix the compiler error (false report) on GCC49 release build.

Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Hao A Wu <hao.a.wu@intel.com>
Signed-off-by: Liming Gao <gaoliming@byosoft.com.cn>
Reviewed-by: Hao A Wu <hao.a.wu@intel.com>