### PR TITLE
[edk2-devel] [PATCH v9 00/10] support CPU hot-unplug -- push

### DIFF
--- a/OvmfPkg/CpuHotplugSmm/CpuHotplug.c
+++ b/OvmfPkg/CpuHotplugSmm/CpuHotplug.c
@@ -18,6 +18,7 @@
 #include <Pcd/CpuHotEjectData.h>             // CPU_HOT_EJECT_DATA
 #include <Protocol/MmCpuIo.h>                // EFI_MM_CPU_IO_PROTOCOL
 #include <Protocol/SmmCpuService.h>          // EFI_SMM_CPU_SERVICE_PROTOCOL
+#include <Register/Intel/ArchitecturalMsr.h> // MSR_IA32_APIC_BASE_REGISTER
 #include <Uefi/UefiBaseType.h>               // EFI_STATUS
 
 #include "ApicId.h"                          // APIC_ID
@@ -193,12 +194,40 @@ RevokeNewSlot:
 }
 
 /**
+  EjectCpu needs to know the BSP at SMI exit at a point when
+  some of the EFI_SMM_CPU_SERVICE_PROTOCOL state has been torn
+  down.
+  Reuse the logic from OvmfPkg::PlatformSmmBspElection() to
+  do that.
+
+  @retval TRUE   If the CPU executing this function is the BSP.
+
+  @retval FALSE  If the CPU executing this function is an AP.
+**/
+STATIC
+BOOLEAN
+CheckIfBsp (
+  VOID
+  )
+{
+  MSR_IA32_APIC_BASE_REGISTER ApicBaseMsr;
+  BOOLEAN                     IsBsp;
+
+  ApicBaseMsr.Uint64 = AsmReadMsr64 (MSR_IA32_APIC_BASE);
+  IsBsp = (BOOLEAN)(ApicBaseMsr.Bits.BSP == 1);
+  return IsBsp;
+}
+
+/**
   CPU Hot-eject handler, called from SmmCpuFeaturesRendezvousExit()
   on each CPU at exit from SMM.
 
-  If, the executing CPU is not being ejected, nothing to be done.
+  If, the executing CPU is neither the BSP, nor being ejected, nothing
+  to be done.
   If, the executing CPU is being ejected, wait in a halted loop
   until ejected.
+  If, the executing CPU is the BSP, set QEMU CPU status to eject
+  for CPUs being ejected.
 
   @param[in] ProcessorNum      ProcessorNum denotes the CPU exiting SMM,
                                and will be used as an index into
@@ -214,6 +243,81 @@ EjectCpu (
 {
   UINT64 QemuSelector;
 
+  if (CheckIfBsp ()) {
+    UINT32 Idx;
+
+    for (Idx = 0; Idx < mCpuHotEjectData->ArrayLength; Idx++) {
+      QemuSelector = mCpuHotEjectData->QemuSelectorMap[Idx];
+
+      if (QemuSelector != CPU_EJECT_QEMU_SELECTOR_INVALID) {
+        //
+        // This to-be-ejected-CPU has already received the BSP's SMI exit
+        // signal and will execute SmmCpuFeaturesRendezvousExit()
+        // followed by this callback or is already penned in the
+        // CpuSleep() loop below.
+        //
+        // Tell QEMU to context-switch it out.
+        //
+        QemuCpuhpWriteCpuSelector (mMmCpuIo, (UINT32) QemuSelector);
+        QemuCpuhpWriteCpuStatus (mMmCpuIo, QEMU_CPUHP_STAT_EJECT);
+
+        //
+        // Now that we've ejected the CPU corresponding to QemuSelectorMap[Idx],
+        // clear its eject status to ensure that an invalid future SMI does
+        // not end up trying a spurious eject or a newly hotplugged CPU does
+        // not get penned in the CpuSleep() loop.
+        //
+        // Note that the QemuCpuhpWriteCpuStatus() command above is a write to
+        // a different address space and uses the EFI_MM_CPU_IO_PROTOCOL.
+        //
+        // This means that we are guaranteed that the following assignment
+        // will not be reordered before the eject. And, so we can safely
+        // do this write here.
+        //
+        mCpuHotEjectData->QemuSelectorMap[Idx] =
+          CPU_EJECT_QEMU_SELECTOR_INVALID;
+
+        DEBUG ((DEBUG_INFO, "%a: Unplugged ProcessorNum %u, "
+          "QemuSelector %Lu\n", __FUNCTION__, Idx, QemuSelector));
+      }
+    }
+
+    //
+    // We are done until the next hot-unplug; clear the handler.
+    //
+    // mCpuHotEjectData->Handler is a NOP for any CPU not under ejection.
+    // So, once we are done with all the ejections, we can safely reset it
+    // here since any CPU dereferencing it would only see either the old
+    // or the new value (since it is aligned at a natural boundary.)
+    //
+    mCpuHotEjectData->Handler = NULL;
+    return;
+  }
+
+  //
+  // Reached only on APs
+  //
+
+  //
+  // mCpuHotEjectData->QemuSelectorMap[ProcessorNum] is updated
+  // on the BSP in the ongoing SMI at two places:
+  //
+  // - UnplugCpus() where the BSP determines if a CPU is under ejection
+  //   or not. As a comment in UnplugCpus() at set-up, and in
+  //   SmmCpuFeaturesRendezvousExit() where it is dereferenced describe,
+  //   any such updates are guaranteed to be ordered-before the
+  //   dereference below.
+  //
+  // - EjectCpu() on the BSP (above) updates QemuSelectorMap[ProcessorNum]
+  //   for a CPU once it's ejected.
+  //
+  //   The CPU under ejection: might be executing anywhere between the
+  //   AllCpusInSync loop in SmiRendezvous(), to about to dereference
+  //   QemuSelectorMap[ProcessorNum].
+  //   As described in the comment above where we do the reset, this
+  //   is not a problem since the ejected CPU never sees the after value.
+  //   CPUs not-under ejection: never see any changes so they are fine.
+  //
   QemuSelector = mCpuHotEjectData->QemuSelectorMap[ProcessorNum];
   if (QemuSelector == CPU_EJECT_QEMU_SELECTOR_INVALID) {
     return;
@@ -493,11 +597,6 @@ CpuHotplugMmi (
              &ToUnplugCount
              );
   if (EFI_ERROR (Status)) {
-    goto Fatal;
-  }
-  if (ToUnplugCount > 0) {
-    DEBUG ((DEBUG_ERROR, "%a: hot-unplug is not supported yet\n",
-      __FUNCTION__));
     goto Fatal;
   }
 

--- a/OvmfPkg/CpuHotplugSmm/CpuHotplugSmm.inf
+++ b/OvmfPkg/CpuHotplugSmm/CpuHotplugSmm.inf
@@ -40,6 +40,7 @@
 [LibraryClasses]
   BaseLib
   BaseMemoryLib
+  CpuLib
   DebugLib
   LocalApicLib
   MmServicesTableLib
@@ -54,6 +55,7 @@
 
 [Pcd]
   gUefiCpuPkgTokenSpaceGuid.PcdCpuHotPlugDataAddress                ## CONSUMES
+  gUefiOvmfPkgTokenSpaceGuid.PcdCpuHotEjectDataAddress              ## CONSUMES
   gUefiOvmfPkgTokenSpaceGuid.PcdQ35SmramAtDefaultSmbase             ## CONSUMES
 
 [FeaturePcd]

--- a/OvmfPkg/CpuHotplugSmm/QemuCpuhp.c
+++ b/OvmfPkg/CpuHotplugSmm/QemuCpuhp.c
@@ -114,6 +114,28 @@ QemuCpuhpWriteCpuSelector (
 }
 
 VOID
+QemuCpuhpWriteCpuStatus (
+  IN CONST EFI_MM_CPU_IO_PROTOCOL *MmCpuIo,
+  IN UINT8                        CpuStatus
+  )
+{
+  EFI_STATUS Status;
+
+  Status = MmCpuIo->Io.Write (
+                         MmCpuIo,
+                         MM_IO_UINT8,
+                         ICH9_CPU_HOTPLUG_BASE + QEMU_CPUHP_R_CPU_STAT,
+                         1,
+                         &CpuStatus
+                         );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: %r\n", __FUNCTION__, Status));
+    ASSERT (FALSE);
+    CpuDeadLoop ();
+  }
+}
+
+VOID
 QemuCpuhpWriteCommand (
   IN CONST EFI_MM_CPU_IO_PROTOCOL *MmCpuIo,
   IN UINT8                        Command

--- a/OvmfPkg/CpuHotplugSmm/QemuCpuhp.c
+++ b/OvmfPkg/CpuHotplugSmm/QemuCpuhp.c
@@ -145,27 +145,30 @@ QemuCpuhpWriteCommand (
 
   On error, the contents of the output parameters are undefined.
 
-  @param[in] MmCpuIo           The EFI_MM_CPU_IO_PROTOCOL instance for
-                               accessing IO Ports.
+  @param[in] MmCpuIo             The EFI_MM_CPU_IO_PROTOCOL instance for
+                                 accessing IO Ports.
 
-  @param[in] PossibleCpuCount  The number of possible CPUs in the system. Must
-                               be positive.
+  @param[in] PossibleCpuCount    The number of possible CPUs in the system. Must
+                                 be positive.
 
-  @param[in] ApicIdCount       The number of elements each one of the
-                               PluggedApicIds and ToUnplugApicIds arrays can
-                               accommodate. Must be positive.
+  @param[in] ApicIdCount         The number of elements each one of the
+                                 PluggedApicIds and ToUnplugApicIds arrays can
+                                 accommodate. Must be positive.
 
-  @param[out] PluggedApicIds   The APIC IDs of the CPUs that have been
-                               hot-plugged.
+  @param[out] PluggedApicIds     The APIC IDs of the CPUs that have been
+                                 hot-plugged.
 
-  @param[out] PluggedCount     The number of filled-in APIC IDs in
-                               PluggedApicIds.
+  @param[out] PluggedCount       The number of filled-in APIC IDs in
+                                 PluggedApicIds.
 
-  @param[out] ToUnplugApicIds  The APIC IDs of the CPUs that are about to be
-                               hot-unplugged.
+  @param[out] ToUnplugApicIds    The APIC IDs of the CPUs that are about to be
+                                 hot-unplugged.
 
-  @param[out] ToUnplugCount    The number of filled-in APIC IDs in
-                               ToUnplugApicIds.
+  @param[out] ToUnplugSelectors  The QEMU Selectors of the CPUs that are about
+                                 to be hot-unplugged.
+
+  @param[out] ToUnplugCount      The number of filled-in APIC IDs in
+                                 ToUnplugApicIds.
 
   @retval EFI_INVALID_PARAMETER  PossibleCpuCount is zero, or ApicIdCount is
                                  zero.
@@ -187,6 +190,7 @@ QemuCpuhpCollectApicIds (
   OUT APIC_ID                      *PluggedApicIds,
   OUT UINT32                       *PluggedCount,
   OUT APIC_ID                      *ToUnplugApicIds,
+  OUT UINT32                       *ToUnplugSelectors,
   OUT UINT32                       *ToUnplugCount
   )
 {
@@ -204,6 +208,7 @@ QemuCpuhpCollectApicIds (
     UINT32  PendingSelector;
     UINT8   CpuStatus;
     APIC_ID *ExtendIds;
+    UINT32  *ExtendSels;
     UINT32  *ExtendCount;
     APIC_ID NewApicId;
 
@@ -245,10 +250,10 @@ QemuCpuhpCollectApicIds (
     if ((CpuStatus & QEMU_CPUHP_STAT_INSERT) != 0) {
       //
       // The "insert" event guarantees the "enabled" status; plus it excludes
-      // the "remove" event.
+      // the "fw_remove" event.
       //
       if ((CpuStatus & QEMU_CPUHP_STAT_ENABLED) == 0 ||
-          (CpuStatus & QEMU_CPUHP_STAT_REMOVE) != 0) {
+          (CpuStatus & QEMU_CPUHP_STAT_FW_REMOVE) != 0) {
         DEBUG ((DEBUG_ERROR, "%a: CurrentSelector=%u CpuStatus=0x%x: "
           "inconsistent CPU status\n", __FUNCTION__, CurrentSelector,
           CpuStatus));
@@ -259,33 +264,63 @@ QemuCpuhpCollectApicIds (
         CurrentSelector));
 
       ExtendIds   = PluggedApicIds;
+      ExtendSels  = NULL;
       ExtendCount = PluggedCount;
-    } else if ((CpuStatus & QEMU_CPUHP_STAT_REMOVE) != 0) {
-      DEBUG ((DEBUG_VERBOSE, "%a: CurrentSelector=%u: remove\n", __FUNCTION__,
-        CurrentSelector));
+    } else if ((CpuStatus & QEMU_CPUHP_STAT_FW_REMOVE) != 0) {
+      //
+      // "fw_remove" event guarantees "enabled".
+      //
+      if ((CpuStatus & QEMU_CPUHP_STAT_ENABLED) == 0) {
+        DEBUG ((DEBUG_ERROR, "%a: CurrentSelector=%u CpuStatus=0x%x: "
+          "inconsistent CPU status\n", __FUNCTION__, CurrentSelector,
+          CpuStatus));
+        return EFI_PROTOCOL_ERROR;
+      }
+
+      DEBUG ((DEBUG_VERBOSE, "%a: CurrentSelector=%u: fw_remove\n",
+        __FUNCTION__, CurrentSelector));
 
       ExtendIds   = ToUnplugApicIds;
+      ExtendSels  = ToUnplugSelectors;
       ExtendCount = ToUnplugCount;
+    } else if ((CpuStatus & QEMU_CPUHP_STAT_REMOVE) != 0) {
+      //
+      // Let the OSPM deal with the "remove" event.
+      //
+      DEBUG ((DEBUG_VERBOSE, "%a: CurrentSelector=%u: remove (ignored)\n",
+        __FUNCTION__, CurrentSelector));
+
+      ExtendIds   = NULL;
+      ExtendSels  = NULL;
+      ExtendCount = NULL;
     } else {
       DEBUG ((DEBUG_VERBOSE, "%a: CurrentSelector=%u: no event\n",
         __FUNCTION__, CurrentSelector));
       break;
     }
 
-    //
-    // Save the APIC ID of the CPU with the pending event, to the corresponding
-    // APIC ID array.
-    //
-    if (*ExtendCount == ApicIdCount) {
-      DEBUG ((DEBUG_ERROR, "%a: APIC ID array too small\n", __FUNCTION__));
-      return EFI_BUFFER_TOO_SMALL;
-    }
-    QemuCpuhpWriteCommand (MmCpuIo, QEMU_CPUHP_CMD_GET_ARCH_ID);
-    NewApicId = QemuCpuhpReadCommandData (MmCpuIo);
-    DEBUG ((DEBUG_VERBOSE, "%a: ApicId=" FMT_APIC_ID "\n", __FUNCTION__,
-      NewApicId));
-    ExtendIds[(*ExtendCount)++] = NewApicId;
+    ASSERT ((ExtendIds == NULL) == (ExtendCount == NULL));
+    ASSERT ((ExtendSels == NULL) || (ExtendIds != NULL));
 
+    if (ExtendIds != NULL) {
+      //
+      // Save the APIC ID of the CPU with the pending event, to the
+      // corresponding APIC ID array.
+      // For unplug events, also save the CurrentSelector.
+      //
+      if (*ExtendCount == ApicIdCount) {
+        DEBUG ((DEBUG_ERROR, "%a: APIC ID array too small\n", __FUNCTION__));
+        return EFI_BUFFER_TOO_SMALL;
+      }
+      QemuCpuhpWriteCommand (MmCpuIo, QEMU_CPUHP_CMD_GET_ARCH_ID);
+      NewApicId = QemuCpuhpReadCommandData (MmCpuIo);
+      DEBUG ((DEBUG_VERBOSE, "%a: ApicId=" FMT_APIC_ID "\n", __FUNCTION__,
+        NewApicId));
+      if (ExtendSels != NULL) {
+        ExtendSels[(*ExtendCount)] = CurrentSelector;
+      }
+      ExtendIds[(*ExtendCount)++] = NewApicId;
+    }
     //
     // We've processed the CPU with (known) pending events, but we must never
     // clear events. Therefore we need to advance past this CPU manually;

--- a/OvmfPkg/CpuHotplugSmm/QemuCpuhp.h
+++ b/OvmfPkg/CpuHotplugSmm/QemuCpuhp.h
@@ -42,6 +42,12 @@ QemuCpuhpWriteCpuSelector (
   );
 
 VOID
+QemuCpuhpWriteCpuStatus (
+  IN CONST EFI_MM_CPU_IO_PROTOCOL *MmCpuIo,
+  IN UINT8                        CpuStatus
+  );
+
+VOID
 QemuCpuhpWriteCommand (
   IN CONST EFI_MM_CPU_IO_PROTOCOL *MmCpuIo,
   IN UINT8                        Command

--- a/OvmfPkg/CpuHotplugSmm/QemuCpuhp.h
+++ b/OvmfPkg/CpuHotplugSmm/QemuCpuhp.h
@@ -55,6 +55,7 @@ QemuCpuhpCollectApicIds (
   OUT APIC_ID                      *PluggedApicIds,
   OUT UINT32                       *PluggedCount,
   OUT APIC_ID                      *ToUnplugApicIds,
+  OUT UINT32                       *ToUnplugSelectors,
   OUT UINT32                       *ToUnplugCount
   );
 

--- a/OvmfPkg/Include/IndustryStandard/QemuCpuHotplug.h
+++ b/OvmfPkg/Include/IndustryStandard/QemuCpuHotplug.h
@@ -34,6 +34,7 @@
 #define QEMU_CPUHP_STAT_ENABLED                BIT0
 #define QEMU_CPUHP_STAT_INSERT                 BIT1
 #define QEMU_CPUHP_STAT_REMOVE                 BIT2
+#define QEMU_CPUHP_STAT_FW_REMOVE              BIT4
 
 #define QEMU_CPUHP_RW_CMD_DATA               0x8
 

--- a/OvmfPkg/Include/IndustryStandard/QemuCpuHotplug.h
+++ b/OvmfPkg/Include/IndustryStandard/QemuCpuHotplug.h
@@ -34,6 +34,7 @@
 #define QEMU_CPUHP_STAT_ENABLED                BIT0
 #define QEMU_CPUHP_STAT_INSERT                 BIT1
 #define QEMU_CPUHP_STAT_REMOVE                 BIT2
+#define QEMU_CPUHP_STAT_EJECT                  BIT3
 #define QEMU_CPUHP_STAT_FW_REMOVE              BIT4
 
 #define QEMU_CPUHP_RW_CMD_DATA               0x8

--- a/OvmfPkg/Include/Pcd/CpuHotEjectData.h
+++ b/OvmfPkg/Include/Pcd/CpuHotEjectData.h
@@ -1,0 +1,60 @@
+/** @file
+  Definition for the CPU_HOT_EJECT_DATA structure, which shares
+  CPU hot-eject state between OVMF's SmmCpuFeaturesLib instance in
+  PiSmmCpuDxeSmm, and CpuHotplugSmm.
+
+  CPU_HOT_EJECT_DATA is allocated in SMRAM, and pointed-to by
+  PcdCpuHotEjectDataAddress.
+
+  PcdCpuHotEjectDataAddress is valid when SMM_REQUIRE is TRUE
+  and PcdCpuMaxLogicalProcessorNumber > 1.
+
+  Copyright (C) 2021, Oracle Corporation.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef CPU_HOT_EJECT_DATA_H_
+#define CPU_HOT_EJECT_DATA_H_
+
+/**
+  CPU Hot-eject handler, called from SmmCpuFeaturesRendezvousExit()
+  on each CPU at exit from SMM.
+
+  @param[in] ProcessorNum      ProcessorNum denotes the CPU exiting SMM,
+                               and will be used as an index into
+                               CPU_HOT_EJECT_DATA->QemuSelectorMap. It is
+                               identical to the processor handle in
+                               EFI_SMM_CPU_SERVICE_PROTOCOL.
+**/
+typedef
+VOID
+(EFIAPI *CPU_HOT_EJECT_HANDLER) (
+  IN UINTN  ProcessorNum
+  );
+
+//
+// CPU_EJECT_QEMU_SELECTOR_INVALID marks CPUs not being ejected in
+// CPU_HOT_EJECT_DATA->QemuSelectorMap.
+//
+// QEMU CPU Selector is UINT32, so we choose an invalid value larger
+// than that type.
+//
+#define CPU_EJECT_QEMU_SELECTOR_INVALID       (MAX_UINT64)
+
+typedef struct {
+  //
+  // Maps ProcessorNum -> QemuSelector for pending hot-ejects
+  //
+  volatile UINT64 *QemuSelectorMap;
+  //
+  // Handler to do the CPU ejection
+  //
+  volatile CPU_HOT_EJECT_HANDLER Handler;
+  //
+  // Entries in the QemuSelectorMap
+  //
+  UINT32 ArrayLength;
+} CPU_HOT_EJECT_DATA;
+
+#endif // CPU_HOT_EJECT_DATA_H_

--- a/OvmfPkg/Library/SmmCpuFeaturesLib/SmmCpuFeaturesLib.c
+++ b/OvmfPkg/Library/SmmCpuFeaturesLib/SmmCpuFeaturesLib.c
@@ -11,10 +11,13 @@
 #include <Library/BaseMemoryLib.h>
 #include <Library/DebugLib.h>
 #include <Library/MemEncryptSevLib.h>
+#include <Library/MemoryAllocationLib.h>
 #include <Library/PcdLib.h>
+#include <Library/SafeIntLib.h>
 #include <Library/SmmCpuFeaturesLib.h>
 #include <Library/SmmServicesTableLib.h>
 #include <Library/UefiBootServicesTableLib.h>
+#include <Pcd/CpuHotEjectData.h>
 #include <PiSmm.h>
 #include <Register/Intel/SmramSaveStateMap.h>
 #include <Register/QemuSmramSaveStateMap.h>
@@ -171,6 +174,77 @@ SmmCpuFeaturesHookReturnFromSmm (
   return OriginalInstructionPointer;
 }
 
+STATIC CPU_HOT_EJECT_DATA *mCpuHotEjectData = NULL;
+
+/**
+  Initialize mCpuHotEjectData if PcdCpuMaxLogicalProcessorNumber > 1.
+
+  Also setup the corresponding PcdCpuHotEjectDataAddress.
+**/
+STATIC
+VOID
+InitCpuHotEjectData (
+  VOID
+  )
+{
+  UINTN          Size;
+  UINT32         Idx;
+  UINT32         MaxNumberOfCpus;
+  RETURN_STATUS  PcdStatus;
+
+  MaxNumberOfCpus = PcdGet32 (PcdCpuMaxLogicalProcessorNumber);
+  if (MaxNumberOfCpus == 1) {
+    return;
+  }
+
+  //
+  // We allocate CPU_HOT_EJECT_DATA and CPU_HOT_EJECT_DATA->QemuSelectorMap[]
+  // in a single allocation, and explicitly align the QemuSelectorMap[] (which
+  // is a UINT64 array) at its natural boundary.
+  // Accordingly, allocate:
+  //   sizeof(*mCpuHotEjectData) + (MaxNumberOfCpus * sizeof(UINT64))
+  // and, add sizeof(UINT64) - 1 to use as padding if needed.
+  //
+
+  if (RETURN_ERROR (SafeUintnMult (MaxNumberOfCpus, sizeof (UINT64), &Size)) ||
+      RETURN_ERROR (SafeUintnAdd (Size, sizeof (*mCpuHotEjectData), &Size)) ||
+      RETURN_ERROR (SafeUintnAdd (Size, sizeof (UINT64) - 1, &Size))) {
+    DEBUG ((DEBUG_ERROR, "%a: invalid CPU_HOT_EJECT_DATA\n", __FUNCTION__));
+    goto Fatal;
+  }
+
+  mCpuHotEjectData = AllocatePool (Size);
+  if (mCpuHotEjectData == NULL) {
+    ASSERT (mCpuHotEjectData != NULL);
+    goto Fatal;
+  }
+
+  mCpuHotEjectData->Handler = NULL;
+  mCpuHotEjectData->ArrayLength = MaxNumberOfCpus;
+
+  mCpuHotEjectData->QemuSelectorMap = ALIGN_POINTER (mCpuHotEjectData + 1,
+                                        sizeof (UINT64));
+  //
+  // We use mCpuHotEjectData->QemuSelectorMap to map
+  // ProcessorNum -> QemuSelector. Initialize to invalid values.
+  //
+  for (Idx = 0; Idx < mCpuHotEjectData->ArrayLength; Idx++) {
+    mCpuHotEjectData->QemuSelectorMap[Idx] = CPU_EJECT_QEMU_SELECTOR_INVALID;
+  }
+
+  //
+  // Expose address of CPU Hot eject Data structure
+  //
+  PcdStatus = PcdSet64S (PcdCpuHotEjectDataAddress,
+                (UINTN)(VOID *)mCpuHotEjectData);
+  ASSERT_RETURN_ERROR (PcdStatus);
+
+  return;
+
+Fatal:
+  CpuDeadLoop ();
+}
+
 /**
   Hook point in normal execution mode that allows the one CPU that was elected
   as monarch during System Management Mode initialization to perform additional
@@ -187,6 +261,9 @@ SmmCpuFeaturesSmmRelocationComplete (
   EFI_STATUS Status;
   UINTN      MapPagesBase;
   UINTN      MapPagesCount;
+
+
+  InitCpuHotEjectData ();
 
   if (!MemEncryptSevIsEnabled ()) {
     return;

--- a/OvmfPkg/Library/SmmCpuFeaturesLib/SmmCpuFeaturesLib.inf
+++ b/OvmfPkg/Library/SmmCpuFeaturesLib/SmmCpuFeaturesLib.inf
@@ -30,9 +30,13 @@
   BaseMemoryLib
   DebugLib
   MemEncryptSevLib
+  MemoryAllocationLib
   PcdLib
+  SafeIntLib
   SmmServicesTableLib
   UefiBootServicesTableLib
 
 [Pcd]
+  gUefiCpuPkgTokenSpaceGuid.PcdCpuMaxLogicalProcessorNumber
+  gUefiOvmfPkgTokenSpaceGuid.PcdCpuHotEjectDataAddress
   gUefiOvmfPkgTokenSpaceGuid.PcdQ35SmramAtDefaultSmbase

--- a/OvmfPkg/OvmfPkg.dec
+++ b/OvmfPkg/OvmfPkg.dec
@@ -352,6 +352,10 @@
   #  This PCD is only accessed if PcdSmmSmramRequire is TRUE (see below).
   gUefiOvmfPkgTokenSpaceGuid.PcdQ35SmramAtDefaultSmbase|FALSE|BOOLEAN|0x34
 
+  ## This PCD adds a communication channel between OVMF's SmmCpuFeaturesLib
+  #  instance in PiSmmCpuDxeSmm, and CpuHotplugSmm.
+  gUefiOvmfPkgTokenSpaceGuid.PcdCpuHotEjectDataAddress|0|UINT64|0x46
+
 [PcdsFeatureFlag]
   gUefiOvmfPkgTokenSpaceGuid.PcdQemuBootOrderPciTranslation|TRUE|BOOLEAN|0x1c
   gUefiOvmfPkgTokenSpaceGuid.PcdQemuBootOrderMmioTranslation|FALSE|BOOLEAN|0x1d

--- a/OvmfPkg/SmmControl2Dxe/SmiFeatures.c
+++ b/OvmfPkg/SmmControl2Dxe/SmiFeatures.c
@@ -28,6 +28,12 @@
 // "etc/smi/supported-features" and "etc/smi/requested-features" fw_cfg files.
 //
 #define ICH9_LPC_SMI_F_CPU_HOTPLUG BIT1
+//
+// The following bit value stands for "enable CPU hot-unplug, and inject an SMI
+// with control value ICH9_APM_CNT_CPU_HOTPLUG upon hot-unplug", in the
+// "etc/smi/supported-features" and "etc/smi/requested-features" fw_cfg files.
+//
+#define ICH9_LPC_SMI_F_CPU_HOT_UNPLUG BIT2
 
 //
 // Provides a scratch buffer (allocated in EfiReservedMemoryType type memory)
@@ -112,7 +118,8 @@ NegotiateSmiFeatures (
   QemuFwCfgReadBytes (sizeof mSmiFeatures, &mSmiFeatures);
 
   //
-  // We want broadcast SMI, SMI on CPU hotplug, and nothing else.
+  // We want broadcast SMI, SMI on CPU hotplug, SMI on CPU hot-unplug
+  // and nothing else.
   //
   RequestedFeaturesMask = ICH9_LPC_SMI_F_BROADCAST;
   if (!MemEncryptSevIsEnabled ()) {
@@ -120,6 +127,7 @@ NegotiateSmiFeatures (
     // For now, we only support hotplug with SEV disabled.
     //
     RequestedFeaturesMask |= ICH9_LPC_SMI_F_CPU_HOTPLUG;
+    RequestedFeaturesMask |= ICH9_LPC_SMI_F_CPU_HOT_UNPLUG;
   }
   mSmiFeatures &= RequestedFeaturesMask;
   QemuFwCfgSelectItem (mRequestedFeaturesItem);
@@ -163,6 +171,13 @@ NegotiateSmiFeatures (
     DEBUG ((DEBUG_INFO, "%a: CPU hotplug not negotiated\n", __FUNCTION__));
   } else {
     DEBUG ((DEBUG_INFO, "%a: CPU hotplug with SMI negotiated\n",
+      __FUNCTION__));
+  }
+
+  if ((mSmiFeatures & ICH9_LPC_SMI_F_CPU_HOT_UNPLUG) == 0) {
+    DEBUG ((DEBUG_INFO, "%a: CPU hot-unplug not negotiated\n", __FUNCTION__));
+  } else {
+    DEBUG ((DEBUG_INFO, "%a: CPU hot-unplug with SMI negotiated\n",
       __FUNCTION__));
   }
 


### PR DESCRIPTION
https://bugzilla.tianocore.org/show_bug.cgi?id=3132
msgid: <20210312062656.2477515-1-ankur.a.arora@oracle.com>
https://edk2.groups.io/g/devel/message/72702
https://listman.redhat.com/archives/edk2-devel-archive/2021-March/msg00449.html
~~~
Hi,

This series adds OVMF support for CPU hot-unplug.

QEMU secureboot hot-unplug logic corresponding to this is in upstream.
Also posted here:
  https://lore.kernel.org/qemu-devel/20201207140739.3829993-1-imammedo@redhat.com/

Testing (with QEMU 5.2.50):
 - Stable with randomized CPU plug/unplug (guest maxcpus=33,128)
 - Synthetic tests with simultaneous multi CPU hot-unplug

Also at:
  github.com/terminus/edk2/ hot-unplug-v9

Changelog:

v9:
  - Rebased on top of edd46cd407ea
  - Clarify comments around memory-barriers in patches 7, 8, 9
  - Address other review comments from v8

v8:
  - Fixes a couple of ECC issues in the code (in patches 7, 9)
  URL: https://patchew.org/EDK2/20210222071928.1401820-1-ankur.a.arora@oracle.com/

v7:
  - Address review comments from v6.
  - Fix ejection bug where we were using APIC ID to do the ejection
    rather than the Qemu Selector.
  - Describes safety properties and ordering needed for concurrent
    accesses to CPU_HOT_EJECT_DATA->QemuSelectorMap, and
    CPU_HOT_EJECT_DATA->Handler.
  URL: https://patchew.org/EDK2/20210219090444.1332380-1-ankur.a.arora@oracle.com/

v6:
  - addresses v5 review comments.
  URL: https://patchew.org/EDK2/20210129005950.467638-1-ankur.a.arora@oracle.com/

v5:
  - fixes ECC errors (all but one in "OvmfPkg/CpuHotplugSmm: add
    add Qemu Cpu Status helper").
  URL: https://patchew.org/EDK2/20210126064440.299596-1-ankur.a.arora@oracle.com/

v4:
  - Gets rid of unnecessary UefiCpuPkg changes
  URL: https://patchew.org/EDK2/20210118063457.358581-1-ankur.a.arora@oracle.com/

v3:
  - Use a saner PCD based interface to share state between PiSmmCpuDxeSmm
    and OvmfPkg/CpuHotplugSmm
  - Cleaner split of the hot-unplug code
  URL: https://patchew.org/EDK2/20210115074533.277448-1-ankur.a.arora@oracle.com/

v2:
  - Do the ejection via SmmCpuFeaturesRendezvousExit()
  URL: https://patchew.org/EDK2/20210107195515.106158-1-ankur.a.arora@oracle.com/

RFC:
  URL: https://patchew.org/EDK2/20201208053432.2690694-1-ankur.a.arora@oracle.com/

Please review.

Thanks
Ankur

Ankur Arora (10):
  OvmfPkg/CpuHotplugSmm: refactor hotplug logic
  OvmfPkg/CpuHotplugSmm: collect hot-unplug events
  OvmfPkg/CpuHotplugSmm: add Qemu Cpu Status helper
  OvmfPkg/CpuHotplugSmm: introduce UnplugCpus()
  OvmfPkg: define CPU_HOT_EJECT_DATA
  OvmfPkg/SmmCpuFeaturesLib: init CPU ejection state
  OvmfPkg/SmmCpuFeaturesLib: call CPU hot-eject handler
  OvmfPkg/CpuHotplugSmm: add EjectCpu()
  OvmfPkg/CpuHotplugSmm: do actual CPU hot-eject
  OvmfPkg/SmmControl2Dxe: negotiate CPU hot-unplug

 OvmfPkg/OvmfPkg.dec                                |   4 +
 OvmfPkg/CpuHotplugSmm/CpuHotplugSmm.inf            |   2 +
 .../SmmCpuFeaturesLib/SmmCpuFeaturesLib.inf        |   4 +
 OvmfPkg/CpuHotplugSmm/QemuCpuhp.h                  |   7 +
 OvmfPkg/Include/IndustryStandard/QemuCpuHotplug.h  |   2 +
 OvmfPkg/Include/Pcd/CpuHotEjectData.h              |  60 +++
 OvmfPkg/CpuHotplugSmm/CpuHotplug.c                 | 576 +++++++++++++++++----
 OvmfPkg/CpuHotplugSmm/QemuCpuhp.c                  | 123 +++--
 .../Library/SmmCpuFeaturesLib/SmmCpuFeaturesLib.c  | 111 ++++
 OvmfPkg/SmmControl2Dxe/SmiFeatures.c               |  18 +-
 10 files changed, 775 insertions(+), 132 deletions(-)
 create mode 100644 OvmfPkg/Include/Pcd/CpuHotEjectData.h
~~~