### PR TITLE
EmbeddedPkg/PrePiHobLib: replace duplicate GUID

### DIFF
--- a/EmbeddedPkg/Library/PrePiHobLib/PrePiHobLib.inf
+++ b/EmbeddedPkg/Library/PrePiHobLib/PrePiHobLib.inf
@@ -12,7 +12,7 @@
 [Defines]
   INF_VERSION                    = 0x00010005
   BASE_NAME                      = PrePiHobLib
-  FILE_GUID                      = 1F3A3278-82EB-4C0D-86F1-5BCDA5846CB2
+  FILE_GUID                      = AEF7D85A-6A91-4ACD-9A28-193DEFB325FB
   MODULE_TYPE                    = BASE
   VERSION_STRING                 = 1.0
   LIBRARY_CLASS                  = HobLib


### PR DESCRIPTION
Currently there is a duplicate GUID shared by two INFs.
This rolls the INF for the PrePiHobLib.

Ref: https://bugzilla.tianocore.org/show_bug.cgi?id=2381
Signed-off-by: Matthew Carlson <matthewfcarlson@gmail.com>
Reviewed-by: Ard Biesheuvel <ardb@kernel.org>