### PR TITLE
BaseTools/Ecc: Make Ecc only check first include guard

### DIFF
--- a/BaseTools/Source/Python/Ecc/Check.py
+++ b/BaseTools/Source/Python/Ecc/Check.py
@@ -1437,11 +1437,13 @@ class Check(object):
 
             SqlCommand = """select ID, Value from %s where Model = %s""" % (FileTable, MODEL_IDENTIFIER_MACRO_IFNDEF)
             RecordSet = EccGlobalData.gDb.TblFile.Exec(SqlCommand)
-            for Record in RecordSet:
-                Name = Record[1].replace('#ifndef', '').strip()
+            if RecordSet:
+                # Only check the first ifndef statement of the file
+                FirstDefine = sorted(RecordSet, key=lambda Record: Record[0])[0]
+                Name = FirstDefine[1].replace('#ifndef', '').strip()
                 if Name[0] == '_' or Name[-1] != '_' or Name[-2] == '_':
                     if not EccGlobalData.gException.IsException(ERROR_NAMING_CONVENTION_CHECK_IFNDEF_STATEMENT, Name):
-                        EccGlobalData.gDb.TblReport.Insert(ERROR_NAMING_CONVENTION_CHECK_IFNDEF_STATEMENT, OtherMsg="The #ifndef name [%s] does not follow the rules" % (Name), BelongsToTable=FileTable, BelongsToItem=Record[0])
+                        EccGlobalData.gDb.TblReport.Insert(ERROR_NAMING_CONVENTION_CHECK_IFNDEF_STATEMENT, OtherMsg="The #ifndef name [%s] does not follow the rules" % (Name), BelongsToTable=FileTable, BelongsToItem=FirstDefine[0])
 
     # Rule for path name, variable name and function name
     # 1. First character should be upper case


### PR DESCRIPTION
The Ecc tool checks the format of the include guard. This check is
currently done on all the names following the '#ifndef' statement.
It should only be done on the first include guard.

REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3252
Signed-off-by: Pierre Gondois <Pierre.Gondois@arm.com>
Reviewed-by: Liming Gao <liming.gao@intel.com>
Reviewed-by: Bob Feng <bob.c.feng@intel.com>