### PR TITLE
[edk2-devel] [PATCH 0/2] Maintainers: create the "OvmfPkg: Confidential Computing" subsystem -- push

### DIFF
--- a/Maintainers.txt
+++ b/Maintainers.txt
@@ -456,14 +456,20 @@ R: Liran Alon <liran.alon@oracle.com>
 R: Nikita Leshenko <nikita.leshchenko@oracle.com>
 
 OvmfPkg: SEV-related modules
+F: OvmfPkg/AmdSev/
 F: OvmfPkg/AmdSevDxe/
+F: OvmfPkg/Include/Guid/ConfidentialComputingSecret.h
 F: OvmfPkg/Include/Library/MemEncryptSevLib.h
 F: OvmfPkg/IoMmuDxe/AmdSevIoMmu.*
 F: OvmfPkg/Library/BaseMemEncryptSevLib/
+F: OvmfPkg/Library/PlatformBootManagerLibGrub/
 F: OvmfPkg/Library/VmgExitLib/
 F: OvmfPkg/PlatformPei/AmdSev.c
+F: OvmfPkg/ResetVector/
+F: OvmfPkg/Sec/
 R: Tom Lendacky <thomas.lendacky@amd.com>
 R: Brijesh Singh <brijesh.singh@amd.com>
+R: James Bottomley <jejb@linux.ibm.com>
 
 OvmfPkg: TCG- and TPM2-related modules
 F: OvmfPkg/Include/IndustryStandard/QemuTpm.h

--- a/Maintainers.txt
+++ b/Maintainers.txt
@@ -445,17 +445,7 @@ OvmfPkg: CSM modules
 F: OvmfPkg/Csm/
 R: David Woodhouse <dwmw2@infradead.org>
 
-OvmfPkg: LsiScsi driver
-F: OvmfPkg/LsiScsiDxe/
-R: Gary Lin <glin@suse.com>
-
-OvmfPkg: MptScsi and PVSCSI driver
-F: OvmfPkg/MptScsiDxe/
-F: OvmfPkg/PvScsiDxe/
-R: Liran Alon <liran.alon@oracle.com>
-R: Nikita Leshenko <nikita.leshchenko@oracle.com>
-
-OvmfPkg: SEV-related modules
+OvmfPkg: Confidential Computing
 F: OvmfPkg/AmdSev/
 F: OvmfPkg/AmdSevDxe/
 F: OvmfPkg/Include/Guid/ConfidentialComputingSecret.h
@@ -467,9 +457,21 @@ F: OvmfPkg/Library/VmgExitLib/
 F: OvmfPkg/PlatformPei/AmdSev.c
 F: OvmfPkg/ResetVector/
 F: OvmfPkg/Sec/
-R: Tom Lendacky <thomas.lendacky@amd.com>
 R: Brijesh Singh <brijesh.singh@amd.com>
 R: James Bottomley <jejb@linux.ibm.com>
+R: Jiewen Yao <jiewen.yao@intel.com>
+R: Min Xu <min.m.xu@intel.com>
+R: Tom Lendacky <thomas.lendacky@amd.com>
+
+OvmfPkg: LsiScsi driver
+F: OvmfPkg/LsiScsiDxe/
+R: Gary Lin <glin@suse.com>
+
+OvmfPkg: MptScsi and PVSCSI driver
+F: OvmfPkg/MptScsiDxe/
+F: OvmfPkg/PvScsiDxe/
+R: Liran Alon <liran.alon@oracle.com>
+R: Nikita Leshenko <nikita.leshchenko@oracle.com>
 
 OvmfPkg: TCG- and TPM2-related modules
 F: OvmfPkg/Include/IndustryStandard/QemuTpm.h


### PR DESCRIPTION
msgid: <20210310185649.19801-1-lersek@redhat.com>
https://edk2.groups.io/g/devel/message/72637
https://listman.redhat.com/archives/edk2-devel-archive/2021-March/msg00384.html
~~~
Ref: https://bugzilla.tianocore.org/show_bug.cgi?id=2198
Ref: https://bugzilla.tianocore.org/show_bug.cgi?id=3077
Ref: https://bugzilla.tianocore.org/show_bug.cgi?id=3249

Generalize the current OVMF SEV subsystem entry, so that we can use it
for Intel TDX in the future, ensuring proper patch circulation for
reviews.

Cc: Andrew Fish <afish@apple.com>
Cc: Ard Biesheuvel <ardb+tianocore@kernel.org>
Cc: Brijesh Singh <brijesh.singh@amd.com>
Cc: James Bottomley <jejb@linux.ibm.com>
Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Jordan Justen <jordan.l.justen@intel.com>
Cc: Leif Lindholm <leif@nuviainc.com>
Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Min Xu <min.m.xu@intel.com>
Cc: Philippe Mathieu-Daudé <philmd@redhat.com>
Cc: Tom Lendacky <thomas.lendacky@amd.com>

Thanks
Laszlo

Laszlo Ersek (2):
  Maintainers: refresh the OVMF SEV subsystem after TianoCore #2198 and
    #3077
  Maintainers: rename the OVMF SEV subsystem to "Confidential Computing"

 Maintainers.txt | 28 +++++++++++++-------
 1 file changed, 18 insertions(+), 10 deletions(-)


base-commit: edd46cd407ea4a0adaa8d6ca86f550c2a4d5c507
~~~