### PR TITLE
[edk2-devel] [PATCH v1] OvmfPkg/X86QemuLoadImageLib: Handle allocation failure for CommandLine -- push

### DIFF
--- a/OvmfPkg/Library/X86QemuLoadImageLib/X86QemuLoadImageLib.c
+++ b/OvmfPkg/Library/X86QemuLoadImageLib/X86QemuLoadImageLib.c
@@ -161,6 +161,11 @@ QemuLoadLegacyImage (
     LoadedImage->CommandLine = LoadLinuxAllocateCommandLinePages (
                                  EFI_SIZE_TO_PAGES (
                                    LoadedImage->CommandLineSize));
+    if (LoadedImage->CommandLine == NULL) {
+      DEBUG ((DEBUG_ERROR, "Unable to allocate memory for kernel command line!\n"));
+      Status = EFI_OUT_OF_RESOURCES;
+      goto FreeImage;
+    }
     QemuFwCfgSelectItem (QemuFwCfgItemCommandLineData);
     QemuFwCfgReadBytes (LoadedImage->CommandLineSize, LoadedImage->CommandLine);
   }
@@ -178,6 +183,11 @@ QemuLoadLegacyImage (
     LoadedImage->InitrdData = LoadLinuxAllocateInitrdPages (
                                 LoadedImage->SetupBuf,
                                 EFI_SIZE_TO_PAGES (LoadedImage->InitrdSize));
+    if (LoadedImage->InitrdData == NULL) {
+      DEBUG ((DEBUG_ERROR, "Unable to allocate memory for initrd!\n"));
+      Status = EFI_OUT_OF_RESOURCES;
+      goto FreeImage;
+    }
     DEBUG ((DEBUG_INFO, "Initrd size: 0x%x\n",
       (UINT32)LoadedImage->InitrdSize));
     DEBUG ((DEBUG_INFO, "Reading initrd image ..."));


### PR DESCRIPTION
msgid: <YFPJsaGzVWQxoEU4@martin-ThinkPad-T440p>
https://edk2.groups.io/g/devel/message/73028
https://listman.redhat.com/archives/edk2-devel-archive/2021-March/msg00795.html
~~~
The CommandLine and InitrdData may be set to NULL if the provided
size is too large. Because the zero page is mapped, this would not
cause an immediate crash but can lead to memory corruption instead.
This patch just adds validation and returns error if either allocation
has failed.

Ref: https://github.com/martinradev/edk2/commit/6c0ce748b97393240c006e24b73652f30e597a05

Signed-off-by: Martin Radev <martin.b.radev@gmail.com>
---
 OvmfPkg/Library/X86QemuLoadImageLib/X86QemuLoadImageLib.c | 11 +++++++++++
 1 file changed, 11 insertions(+)
~~~