### PR TITLE
CryptoPkg/OpensslLib: Upgrade OpenSSL to 1.1.1j

### DIFF
--- a/CryptoPkg/Library/Include/openssl/opensslconf.h
+++ b/CryptoPkg/Library/Include/openssl/opensslconf.h
@@ -2,7 +2,7 @@
  * WARNING: do not edit!
  * Generated from include/openssl/opensslconf.h.in
  *
- * Copyright 2016-2018 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2016-2020 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -268,6 +268,11 @@ extern "C" {
 #   undef DECLARE_DEPRECATED
 #   define DECLARE_DEPRECATED(f)    f __attribute__ ((deprecated));
 #  endif
+#elif defined(__SUNPRO_C)
+#if (__SUNPRO_C >= 0x5130)
+#undef DECLARE_DEPRECATED
+#define DECLARE_DEPRECATED(f)    f __attribute__ ((deprecated));
+#endif
 # endif
 #endif
 


### PR DESCRIPTION
Update openssl from 1.1.1g to 1.1.1j. Current OpenSSL version
1.1.1g contains the vulnerabilities of CVE-2021-23841 and
CVE-2021-23840. The related vulnerable API EVP_DecryptUpdate
are used in drivers.

REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3266

Besides, the opensslconf.h automatically generated by process_files.pl.
Cc: Jian J Wang <jian.j.wang@intel.com>
Signed-off-by: Liu Wei <weix.c.liu@intel.com>
Reviewed-by: Jian J Wang <jian.j.wang@intel.com>