### PR TITLE
UefiCpuPkg/SmmCommunication: Remove out-dated comments

### DIFF
--- a/UefiCpuPkg/PiSmmCommunication/PiSmmCommunicationPei.c
+++ b/UefiCpuPkg/PiSmmCommunication/PiSmmCommunicationPei.c
@@ -1,7 +1,7 @@
 /** @file
 PiSmmCommunication PEI Driver.
 
-Copyright (c) 2010 - 2015, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2010 - 2021, Intel Corporation. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -47,16 +47,10 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
   +----------------------------------+<--
   | EFI_SMM_COMMUNICATION_CONTEXT    |
   |   SwSmiNumber                    | <- SMRAM
-  |   BufferPtrAddress               |----------------
-  +----------------------------------+                |
-                                                      |
-  +----------------------------------+                |
-  | EFI_SMM_COMMUNICATION_ACPI_TABLE |                |
-  |   SwSmiNumber                    | <- AcpiTable   |
-  |   BufferPtrAddress               |---             |
-  +----------------------------------+   |            |
-                                         |            |
-  +----------------------------------+<---------------
+  |   BufferPtrAddress               |---
+  +----------------------------------+   |
+                                         |
+  +----------------------------------+<--
   | Communication Buffer Pointer     | <- AcpiNvs
   +----------------------------------+---
                                          |


### PR DESCRIPTION
The comments in PiSmmCommunicationPei.c describe the whole memory
layout of the SMRAM regarding the SMM communication.

But SHA-1: 8b1d14939053b63d80355465649c50f9f391a64a
PiSmmCommunicationSmm: Deprecate SMM Communication ACPI Table
removed the code that produces the ACPI Table.

This change updates the accordingly comments.

Signed-off-by: Ray Ni <ray.ni@intel.com>
Reviewed-by: Eric Dong <eric.dong@intel.com>
Acked-by: Laszlo Ersek <lersek@redhat.com>
Cc: Rahul Kumar <rahul1.kumar@intel.com>