### PR TITLE
MdePkg: use CpuPause() in CpuDeadLoop()

### DIFF
--- a/MdePkg/Library/BaseLib/CpuDeadLoop.c
+++ b/MdePkg/Library/BaseLib/CpuDeadLoop.c
@@ -28,5 +28,7 @@ CpuDeadLoop (
 {
   volatile UINTN  Index;
 
-  for (Index = 0; Index == 0;);
+  for (Index = 0; Index == 0;) {
+    CpuPause();
+  }
 }


### PR DESCRIPTION
CpuPause() might allow the CPU to go into a lower power state
state while we spin.

On X86, CpuPause() executes a PAUSE instruction which the Intel
and AMD specs describe as follows:

Intel:
  "PAUSE: An additional function of the PAUSE instruction is to reduce
  the power consumed by a processor while executing a spin loop. A
  processor can execute a spin-wait loop extremely quickly, causing the
  processor to consume a lot of power while it waits for the resource it
  is spinning on to become available. Inserting a pause instruction in a
  spin-wait loop greatly reduces the processor?s power consumption."

AMD:
  "PAUSE: Improves the performance of spin loops, by providing a hint to
  the processor that the current code is in a spin loop. The processor
  may use this to optimize power consumption while in the spin loop.
  Architecturally, this instruction behaves like a NOP instruction."

On RISC-V and ARM64, CpuPause() executes a NOP, which is no worse than
the tight loop we have.

Cc: Liming Gao <gaoliming@byosoft.com.cn>
Signed-off-by: Ankur Arora <ankur.a.arora@oracle.com>
Reviewed-by: Michael D Kinney <michael.d.kinney@intel.com>
Reviewed-by: Laszlo Ersek <lersek@redhat.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>