### PR TITLE
Remove duplicate type declarations in MdePkg and CryptoPkg

### DIFF
--- a/CryptoPkg/Private/Protocol/Crypto.h
+++ b/CryptoPkg/Private/Protocol/Crypto.h
@@ -2,7 +2,7 @@
   This Protocol provides Crypto services to DXE modules
 
   Copyright (C) Microsoft Corporation. All rights reserved.
-  Copyright (c) 2020, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2020 - 2021, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -1104,32 +1104,6 @@ BOOLEAN
   IN  UINTN                         HashSize,
   IN  CONST UINT8                  *Signature,
   IN  UINTN                         SigSize
-  );
-
-/**
-  Retrieve the RSA Public Key from one DER-encoded X509 certificate.
-
-  If Cert is NULL, then return FALSE.
-  If RsaContext is NULL, then return FALSE.
-  If this interface is not supported, then return FALSE.
-
-  @param[in]  Cert         Pointer to the DER-encoded X509 certificate.
-  @param[in]  CertSize     Size of the X509 certificate in bytes.
-  @param[out] RsaContext   Pointer to new-generated RSA context which contain the retrieved
-                           RSA public key component. Use RsaFree() function to free the
-                           resource.
-
-  @retval  TRUE   RSA Public Key was retrieved successfully.
-  @retval  FALSE  Fail to retrieve RSA public key from X509 certificate.
-  @retval  FALSE  This interface is not supported.
-
-**/
-typedef
-BOOLEAN
-(EFIAPI *EDKII_CRYPTO_RSA_GET_PUBLIC_KEY_FROM_X509) (
-  IN   CONST UINT8  *Cert,
-  IN   UINTN        CertSize,
-  OUT  VOID         **RsaContext
   );
 
 /**

--- a/MdePkg/Include/Protocol/HiiPopup.h
+++ b/MdePkg/Include/Protocol/HiiPopup.h
@@ -2,7 +2,7 @@
   This protocol provides services to display a popup window.
   The protocol is typically produced by the forms browser and consumed by a driver callback handler.
 
-  Copyright (c) 2017-2018, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017-2021, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
   @par Revision Reference:
@@ -67,10 +67,10 @@ EFI_STATUS
   OUT EFI_HII_POPUP_SELECTION *UserSelection OPTIONAL
 );
 
-typedef struct _EFI_HII_POPUP_PROTOCOL {
+struct _EFI_HII_POPUP_PROTOCOL {
   UINT64                Revision;
   EFI_HII_CREATE_POPUP  CreatePopup;
-} EFI_HII_POPUP_PROTOCOL;
+};
 
 extern EFI_GUID gEfiHiiPopupProtocolGuid;
 

--- a/MdePkg/Include/Protocol/ResetNotification.h
+++ b/MdePkg/Include/Protocol/ResetNotification.h
@@ -2,7 +2,7 @@
   EFI Reset Notification Protocol as defined in UEFI 2.7.
   This protocol provides services to register for a notification when ResetSystem is called.
 
-  Copyright (c) 2017, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017 - 2021, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
   @par Revision Reference:
@@ -68,10 +68,10 @@ EFI_STATUS
   IN EFI_RESET_SYSTEM                ResetFunction
 );
 
-typedef struct _EFI_RESET_NOTIFICATION_PROTOCOL {
+struct _EFI_RESET_NOTIFICATION_PROTOCOL {
   EFI_REGISTER_RESET_NOTIFY   RegisterResetNotify;
   EFI_UNREGISTER_RESET_NOTIFY UnregisterResetNotify;
-} EFI_RESET_NOTIFICATION_PROTOCOL;
+};
 
 
 extern EFI_GUID gEfiResetNotificationProtocolGuid;


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3287
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3286
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3285

Remove duplicate declarations of the following types that may
generate compiler warnings or errors:
* EFI_HII_POPUP_PROTOCOL
* EFI_RESET_NOTIFICATION_PROTOCOL
* EDKII_CRYPTO_RSA_GET_PUBLIC_KEY_FROM_X509

Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Zhiguang Liu <zhiguang.liu@intel.com>
Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Xiaoyu Lu <xiaoyux.lu@intel.com>
Cc: Guomin Jiang <guomin.jiang@intel.com>
Signed-off-by: Michael D Kinney <michael.d.kinney@intel.com>