### PR TITLE
MdePkg/BaseLib: Add support for the XSETBV instruction

### DIFF
--- a/MdePkg/Include/Library/BaseLib.h
+++ b/MdePkg/Include/Library/BaseLib.h
@@ -2,7 +2,7 @@
   Provides string functions, linked list functions, math functions, synchronization
   functions, file path functions, and CPU architecture-specific functions.
 
-Copyright (c) 2006 - 2019, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2006 - 2021, Intel Corporation. All rights reserved.<BR>
 Portions copyright (c) 2008 - 2009, Apple Inc. All rights reserved.<BR>
 Copyright (c) Microsoft Corporation.<BR>
 Portions Copyright (c) 2020, Hewlett Packard Enterprise Development LP. All rights reserved.<BR>
@@ -7438,6 +7438,29 @@ AsmXGetBv (
   IN UINT32  Index
   );
 
+/**
+  Executes a XSETBV instruction to write a 64-bit value to a Extended Control
+  Register(XCR), and returns the value.
+
+  Writes the 64-bit value specified by Value to the XCR specified by Index. The
+  64-bit value written to the XCR is returned. No parameter checking is
+  performed on Index or Value, and some of these may cause CPU exceptions. The
+  caller must either guarantee that Index and Value are valid, or the caller
+  must establish proper exception handlers. This function is only available on
+  IA-32 and x64.
+
+  @param  Index The 32-bit XCR index to write.
+  @param  Value The 64-bit value to write to the XCR.
+
+  @return Value
+
+**/
+UINT64
+EFIAPI
+AsmXSetBv (
+  IN UINT32  Index,
+  IN UINT64  Value
+  );
 
 /**
   Executes a VMGEXIT instruction (VMMCALL with a REP prefix)

--- a/MdePkg/Library/BaseLib/BaseLib.inf
+++ b/MdePkg/Library/BaseLib/BaseLib.inf
@@ -1,7 +1,7 @@
 ## @file
 #  Base Library implementation.
 #
-#  Copyright (c) 2007 - 2020, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2007 - 2021, Intel Corporation. All rights reserved.<BR>
 #  Portions copyright (c) 2008 - 2009, Apple Inc. All rights reserved.<BR>
 #  Portions copyright (c) 2011 - 2013, ARM Ltd. All rights reserved.<BR>
 #  Copyright (c) 2020, Hewlett Packard Enterprise Development LP. All rights reserved.<BR>
@@ -184,6 +184,7 @@
   Ia32/DisableCache.nasm| GCC
   Ia32/RdRand.nasm
   Ia32/XGetBv.nasm
+  Ia32/XSetBv.nasm
   Ia32/VmgExit.nasm
 
   Ia32/DivS64x64Remainder.c
@@ -318,6 +319,7 @@
   X64/DisablePaging64.nasm
   X64/RdRand.nasm
   X64/XGetBv.nasm
+  X64/XSetBv.nasm
   X64/VmgExit.nasm
   ChkStkGcc.c  | GCC
 

--- a/MdePkg/Library/BaseLib/Ia32/XSetBv.nasm
+++ b/MdePkg/Library/BaseLib/Ia32/XSetBv.nasm
@@ -1,0 +1,34 @@
+;------------------------------------------------------------------------------
+;
+; Copyright (c) 2021, Intel Corporation. All rights reserved.<BR>
+; SPDX-License-Identifier: BSD-2-Clause-Patent
+;
+; Module Name:
+;
+;   XSetBv.nasm
+;
+; Abstract:
+;
+;   AsmXSetBv function
+;
+; Notes:
+;
+;------------------------------------------------------------------------------
+
+    SECTION .text
+
+;------------------------------------------------------------------------------
+; UINT64
+; EFIAPI
+; AsmXSetBv (
+;   IN UINT32  Index,
+;   IN UINT64  Value
+;   );
+;------------------------------------------------------------------------------
+global ASM_PFX(AsmXSetBv)
+ASM_PFX(AsmXSetBv):
+    mov     edx, [esp + 12]
+    mov     eax, [esp + 8]
+    mov     ecx, [esp + 4]
+    xsetbv
+    ret

--- a/MdePkg/Library/BaseLib/X64/XSetBv.nasm
+++ b/MdePkg/Library/BaseLib/X64/XSetBv.nasm
@@ -1,0 +1,34 @@
+;------------------------------------------------------------------------------
+;
+; Copyright (c) 2021, Intel Corporation. All rights reserved.<BR>
+; SPDX-License-Identifier: BSD-2-Clause-Patent
+;
+; Module Name:
+;
+;   XSetBv.nasm
+;
+; Abstract:
+;
+;   AsmXSetBv function
+;
+; Notes:
+;
+;------------------------------------------------------------------------------
+
+    DEFAULT REL
+    SECTION .text
+
+;------------------------------------------------------------------------------
+; UINT64
+; EFIAPI
+; AsmXSetBv (
+;   IN UINT32  Index,
+;   IN UINT64  Value
+;   );
+;------------------------------------------------------------------------------
+global ASM_PFX(AsmXSetBv)
+ASM_PFX(AsmXSetBv):
+    mov     rax, rdx                    ; meanwhile, rax <- return value
+    shr     rdx, 0x20                    ; edx:eax contains the value to write
+    xsetbv
+    ret


### PR DESCRIPTION
*v2: refine the coding format.

https://bugzilla.tianocore.org/show_bug.cgi?id=3284

This patch is to support XSETBV instruction so as to support
Extended Control Register(XCR) write.

Extended Control Register(XCR) read has already been supported
by below commit to support XGETBV instruction:
9b3ca509abd4e45439bbdfe2c2fa8780c950320a

Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Zhiguang Liu <zhiguang.liu@intel.com>
Cc: Ni Ray <ray.ni@intel.com>
Cc: Yao Jiewen <jiewen.yao@intel.com>
Signed-off-by: Jiaxin Wu <Jiaxin.wu@intel.com>
Signed-off-by: Zhang Hongbin1 <hongbin1.zhang@intel.com>
Reviewed-by: Ray Ni <ray.ni@intel.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>