### PR TITLE
UnitTestFrameworkPkg: Use TianoCore mirror of cmocka repository

### DIFF
--- a/.azurepipelines/templates/platform-build-run-steps.yml
+++ b/.azurepipelines/templates/platform-build-run-steps.yml
@@ -51,9 +51,6 @@ steps:
 # Set default
 - bash: echo "##vso[task.setvariable variable=pkg_count]${{ 1 }}"
 
-# Use altername cmocka repo
-- bash: git config --global url.https://github.com/neverware-mirrors/cmocka.git.insteadOf https://git.cryptomilk.org/projects/cmocka.git
-
 # Fetch the target branch so that pr_eval can diff them.
 # Seems like azure pipelines/github changed checkout process in nov 2020.
 - script: git fetch origin $(System.PullRequest.targetBranch)

--- a/.azurepipelines/templates/pr-gate-steps.yml
+++ b/.azurepipelines/templates/pr-gate-steps.yml
@@ -31,9 +31,6 @@ steps:
     echo "##vso[task.setvariable variable=pkgs_to_build]${{ parameters.build_pkgs }}"
     echo "##vso[task.setvariable variable=pkg_count]${{ 1 }}"
 
-# Use altername cmocka repo
-- bash: git config --global url.https://github.com/neverware-mirrors/cmocka.git.insteadOf https://git.cryptomilk.org/projects/cmocka.git
-
 # Fetch the target branch so that pr_eval can diff them.
 # Seems like azure pipelines/github changed checkout process in nov 2020.
 - script: git fetch origin $(System.PullRequest.targetBranch)

--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	url = https://github.com/ucb-bar/berkeley-softfloat-3.git
 [submodule "UnitTestFrameworkPkg/Library/CmockaLib/cmocka"]
 	path = UnitTestFrameworkPkg/Library/CmockaLib/cmocka
-	url = https://git.cryptomilk.org/projects/cmocka.git
+	url = https://github.com/tianocore/edk2-cmocka.git
 [submodule "MdeModulePkg/Universal/RegularExpressionDxe/oniguruma"]
 	path = MdeModulePkg/Universal/RegularExpressionDxe/oniguruma
 	url = https://github.com/kkos/oniguruma

--- a/ReadMe.rst
+++ b/ReadMe.rst
@@ -92,7 +92,7 @@ that are covered by additional licenses.
 -  `CryptoPkg/Library/OpensslLib/openssl <https://github.com/openssl/openssl/blob/e2e09d9fba1187f8d6aafaa34d4172f56f1ffb72/LICENSE>`__
 -  `MdeModulePkg/Library/BrotliCustomDecompressLib/brotli <https://github.com/google/brotli/blob/666c3280cc11dc433c303d79a83d4ffbdd12cc8d/LICENSE>`__
 -  `MdeModulePkg/Universal/RegularExpressionDxe/oniguruma <https://github.com/kkos/oniguruma/blob/abfc8ff81df4067f309032467785e06975678f0d/COPYING>`__
--  `UnitTestFrameworkPkg/Library/CmockaLib/cmocka <https://git.cryptomilk.org/projects/cmocka.git/tree/COPYING?h=cmocka-1.1.5&id=f5e2cd77c88d9f792562888d2b70c5a396bfbf7a>`__
+-  `UnitTestFrameworkPkg/Library/CmockaLib/cmocka <https://github.com/tianocore/edk2-cmocka/blob/f5e2cd77c88d9f792562888d2b70c5a396bfbf7a/COPYING>`__
 -  `RedfishPkg/Library/JsonLib/jansson <https://github.com/akheron/jansson/blob/2882ead5bb90cf12a01b07b2c2361e24960fae02/LICENSE>`__
 
 The EDK II Project is composed of packages. The maintainers for each package


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3301

The cmocka repository https://git.cryptomilk.org/projects/cmocka.git
has gone down a few times in past year.  When it is down, it blocks
EDK II CI.  A mirror of this repository has been created in the
TianoCore organization at https://github.com/tianocore/edk2-cmocka.git
and uses a GitHub Action to auto-sync changes from
https://git.cryptomilk.org/projects/cmocka.git.

* Update .gitmodules to use https://github.com/tianocore/edk2-cmocka.git
  instead of https://git.cryptomilk.org/projects/cmocka.git.

* Update README.rst to reference the COPYING file in
  https://github.com/tianocore/edk2-cmocka.git with the cmocka license.

* Update Azure Pipelines YML files to remove a temporary workaround that
  used an alternate GitHub mirror of cmocka.  With the workaround removed,
  EDK II CI always uses the TianoCore mirror of cmocka.

Cc: Sean Brogan <sean.brogan@microsoft.com>
Cc: Bret Barkelew <Bret.Barkelew@microsoft.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Andrew Fish <afish@apple.com>
Cc: Laszlo Ersek <lersek@redhat.com>
Cc: Leif Lindholm <leif@nuviainc.com>
Signed-off-by: Michael D Kinney <michael.d.kinney@intel.com>