### PR TITLE
ShellPkg: Fix smbiosview system enclosure type table

### DIFF
--- a/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/QueryTable.c
+++ b/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/QueryTable.c
@@ -188,19 +188,19 @@ TABLE_ITEM  SystemEnclosureTypeTable[] = {
   },
   {
     0x10,
-    L"  Main Server Chassis"
+    L"  Lunch Box"
   },
   {
     0x11,
-    L"  Expansion Chassis"
+    L"  Main Server Chassis"
   },
   {
     0x12,
-    L"  SubChassis"
+    L"  Expansion Chassis"
   },
   {
     0x13,
-    L"  Sub Notebook"
+    L"  SubChassis"
   },
   {
     0x14,


### PR DESCRIPTION
The SystemEnclosureTypeTable in QueryTable.c contained a couple
of errors: value 0x10 is "Lunch Box" not "Main Server Chassis", and
the Sub Notebook value was repeated as 0x13 when that entry is for
"SubChassis". The entries in-between needed adjusted.

Signed-off-by: Rebecca Cran <rebecca@nuviainc.com>
Reviewed-by: Zhichao Gao <zhichao.gao@intel.com>