### PR TITLE
UefiCpuPkg/CpuTimerLib: Update LIBRARY_CLASS of Base instance.

### DIFF
--- a/UefiCpuPkg/Library/CpuTimerLib/BaseCpuTimerLib.inf
+++ b/UefiCpuPkg/Library/CpuTimerLib/BaseCpuTimerLib.inf
@@ -4,7 +4,7 @@
 #  Provides basic timer support using CPUID Leaf 0x15 XTAL frequency. The performance
 #  counter features are provided by the processors time stamp counter.
 #
-#  Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2021, Intel Corporation. All rights reserved.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -15,7 +15,7 @@
   FILE_GUID                      = F10B5B91-D15A-496C-B044-B5235721AA08
   MODULE_TYPE                    = BASE
   VERSION_STRING                 = 1.0
-  LIBRARY_CLASS                  = TimerLib|SEC PEI_CORE PEIM
+  LIBRARY_CLASS                  = TimerLib
   MODULE_UNI_FILE                = BaseCpuTimerLib.uni
 
 [Sources]


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=2832

Update LIBRARY_CLASS of BaseCpuTimerLib to remove the usage limitation,
otherwise the Base instance cannot be used in some types of modules.

Signed-off-by: Jason Lou <yun.lou@intel.com>
Reviewed-by: Ray Ni <ray.ni@intel.com>
Cc: Eric Dong <eric.dong@intel.com>
Cc: Laszlo Ersek <lersek@redhat.com>
Cc: Rahul Kumar <rahul1.kumar@intel.com>