### PR TITLE
DynamicTablesPkg: add validation for PcdNonBsaCompliant16550SerialHid

### DIFF
--- a/DynamicTablesPkg/Include/Library/TableHelperLib.h
+++ b/DynamicTablesPkg/Include/Library/TableHelperLib.h
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2017 - 2020, Arm Limited. All rights reserved.<BR>
+  Copyright (c) 2017 - 2021, Arm Limited. All rights reserved.<BR>
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -11,6 +11,18 @@
 
 #ifndef TABLE_HELPER_LIB_H_
 #define TABLE_HELPER_LIB_H_
+
+/** Is a character upper case
+*/
+#define IS_UPPER_CHAR(x) ((x >= 'A') && (x <= 'Z'))
+
+/** Is a character a decimal digit
+*/
+#define IS_DIGIT(x) ((x >= '0') && (x <= '9'))
+
+/** Is a character an upper case hexadecimal digit
+*/
+#define IS_UPPER_HEX(x) (((x >= 'A') && (x <= 'F')) || IS_DIGIT (x))
 
 /** The GetCgfMgrInfo function gets the CM_STD_OBJ_CONFIGURATION_MANAGER_INFO
     object from the Configuration Manager.
@@ -118,6 +130,30 @@ UINT8
 EFIAPI
 AsciiFromHex (
   IN  UINT8   x
+  );
+
+/** Check if a HID is a valid PNP ID.
+
+  @param     [in] Hid     The Hid to validate.
+
+  @retval    TRUE         The Hid is a valid PNP ID.
+  @retval    FALSE        The Hid is not a valid PNP ID.
+**/
+BOOLEAN
+IsValidPnpId (
+  IN  CONST CHAR8  * Hid
+  );
+
+/** Check if a HID is a valid ACPI ID.
+
+  @param     [in] Hid     The Hid to validate.
+
+  @retval    TRUE         The Hid is a valid ACPI ID.
+  @retval    FALSE        The Hid is not a valid ACPI ID.
+**/
+BOOLEAN
+IsValidAcpiId (
+  IN  CONST CHAR8  * Hid
   );
 
 #endif // TABLE_HELPER_LIB_H_

--- a/DynamicTablesPkg/Library/Common/SsdtSerialPortFixupLib/SsdtSerialPortFixupLib.c
+++ b/DynamicTablesPkg/Library/Common/SsdtSerialPortFixupLib/SsdtSerialPortFixupLib.c
@@ -148,6 +148,10 @@ FixupIds (
       // If there is a non-BSA compliant HID, use that.
       NonBsaHid = (CONST CHAR8*)PcdGetPtr (PcdNonBsaCompliant16550SerialHid);
       if ((NonBsaHid != NULL) && (AsciiStrLen (NonBsaHid) != 0)) {
+        if (!(IsValidPnpId (NonBsaHid) || IsValidAcpiId (NonBsaHid))) {
+          return EFI_INVALID_PARAMETER;
+        }
+
         HidString = NonBsaHid;
         CidString = "";
       } else {

--- a/DynamicTablesPkg/Library/Common/TableHelperLib/TableHelper.c
+++ b/DynamicTablesPkg/Library/Common/TableHelperLib/TableHelper.c
@@ -1,7 +1,7 @@
 /** @file
   Table Helper
 
-  Copyright (c) 2017 - 2020, Arm Limited. All rights reserved.<BR>
+  Copyright (c) 2017 - 2021, Arm Limited. All rights reserved.<BR>
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
@@ -269,4 +269,75 @@ AsciiFromHex (
 
   ASSERT (FALSE);
   return (UINT8)0;
+}
+
+/** Check if a HID is a valid PNP ID.
+
+  @param     [in] Hid     The Hid to validate.
+
+  @retval    TRUE         The Hid is a valid PNP ID.
+  @retval    FALSE        The Hid is not a valid PNP ID.
+**/
+BOOLEAN
+IsValidPnpId (
+  IN  CONST CHAR8  * Hid
+  )
+{
+  UINTN Index;
+
+  if (AsciiStrLen (Hid) != 7) {
+    return FALSE;
+  }
+
+  // A valid PNP ID must be of the form "AAA####"
+  // where A is an uppercase letter and # is a hex digit.
+  for (Index = 0; Index < 3; Index++) {
+    if (!IS_UPPER_CHAR (Hid[Index])) {
+      return FALSE;
+    }
+  }
+
+  for (Index = 3; Index < 7; Index++) {
+    if (!IS_UPPER_HEX (Hid[Index])) {
+      return FALSE;
+    }
+  }
+
+  return TRUE;
+}
+
+/** Check if a HID is a valid ACPI ID.
+
+  @param     [in] Hid     The Hid to validate.
+
+  @retval    TRUE         The Hid is a valid ACPI ID.
+  @retval    FALSE        The Hid is not a valid ACPI ID.
+**/
+BOOLEAN
+IsValidAcpiId (
+  IN  CONST CHAR8  * Hid
+  )
+{
+  UINTN Index;
+
+  if (AsciiStrLen (Hid) != 8) {
+    return FALSE;
+  }
+
+  // A valid ACPI ID must be of the form "NNNN####"
+  // where N is an uppercase letter or a digit ('0'-'9')
+  // and # is a hex digit.
+  for (Index = 0; Index < 4; Index++) {
+    if (!(IS_UPPER_CHAR (Hid[Index]) || IS_DIGIT (Hid[Index]))) {
+      return FALSE;
+    }
+  }
+
+  for (Index = 4; Index < 8; Index++) {
+    if (!IS_UPPER_HEX (Hid[Index])) {
+      return FALSE;
+    }
+  }
+
+  return TRUE;
 }


### PR DESCRIPTION
According to ACPI 6.4, 6.1.5 _HID states:

  - A valid PNP ID must be of the form "AAA####" where A is an uppercase
    letter and # is a hex digit.
  - A valid ACPI ID must be of the form "NNNN####" where N is an uppercase
    letter or a digit ('0'-'9') and # is a hex digit.

Signed-off-by: Joey Gouly <joey.goulyd@arm.com>
Reviewed-by: Sami Mujawar <sami.mujawar@arm.com>