### PR TITLE
MdeModulePkg: Initialize temp variable in VarCheckPolicyLib

### DIFF
--- a/MdeModulePkg/Library/VarCheckPolicyLib/VarCheckPolicyLib.c
+++ b/MdeModulePkg/Library/VarCheckPolicyLib/VarCheckPolicyLib.c
@@ -216,6 +216,7 @@ VarCheckPolicyLibMmiHandler (
         DumpParamsOut->TotalSize = 0;
         DumpParamsOut->PageSize = 0;
         DumpParamsOut->HasMore = FALSE;
+        TempSize = 0;
         SubCommandStatus = DumpVariablePolicy (NULL, &TempSize);
         if (SubCommandStatus == EFI_BUFFER_TOO_SMALL && TempSize > 0) {
           mCurrentPaginationCommand = VAR_CHECK_POLICY_COMMAND_DUMP;


### PR DESCRIPTION
DumpVariablePolicy() will return EFI_INVALID_PARAMETER if the Buffer
pointer is NULL and the indirect Size is anything but 0. Since this
TempSize was not being initialized it is very likely that this sequence
would not return the total buffer size as expected.

Bugzilla: https://bugzilla.tianocore.org/show_bug.cgi?id=3310

Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Hao A Wu <hao.a.wu@intel.com>
Signed-off-by: Bret Barkelew <bret.barkelew@microsoft.com>
Reviewed-by: Hao A Wu <hao.a.wu@intel.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>