### PR TITLE
SecurityPkg/Tcg2Smm: Initialize local Status variable

### DIFF
--- a/SecurityPkg/Tcg/Tcg2Smm/Tcg2Smm.c
+++ b/SecurityPkg/Tcg/Tcg2Smm/Tcg2Smm.c
@@ -253,6 +253,8 @@ TcgMmReadyToLock (
 {
   EFI_STATUS Status;
 
+  Status = EFI_SUCCESS;
+
   if (mReadyToLockHandle != NULL) {
     Status = gMmst->MmiHandlerUnRegister (mReadyToLockHandle);
     mReadyToLockHandle = NULL;


### PR DESCRIPTION
REF:https://bugzilla.tianocore.org/show_bug.cgi?id=3277

Initializes the Status variable in TcgMmReadyToLock().

Fixes a Clang build failure:
Tcg2Smm.c - SecurityPkg\Tcg\Tcg2Smm\Tcg2Smm.c:254:7: error:
variable 'Status' is used uninitialized whenever 'if'
condition is false [-Werror,-Wsometimes-uninitialized]

Initializing this variable is required to address a practical
scenario in which the return value of TcgMmReadyToLock() is
undefined based on conditional evaluation in the function.

Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Qi Zhang <qi1.zhang@intel.com>
Cc: Rahul Kumar <rahul1.kumar@intel.com>
Cc: Kun Qin <kun.q@outlook.com>
Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>
Reviewed-by: Jiewen Yao <Jiewen.yao@intel.com>
Reviewed-by: Laszlo Ersek <lersek@redhat.com>