### PR TITLE
MdePkg: BaseLib Fix AsmReadMsr64() and AsmWriteMsr64() with GCC toolc…

### DIFF
--- a/MdePkg/Library/BaseLib/X64/GccInlinePriv.c
+++ b/MdePkg/Library/BaseLib/X64/GccInlinePriv.c
@@ -80,7 +80,7 @@ AsmReadMsr64 (
   }
   FilterAfterMsrRead (Index, &Value);
 
-  return (((UINT64)HighData) << 32) | LowData;
+  return Value;
 }
 
 /**
@@ -111,11 +111,10 @@ AsmWriteMsr64 (
   UINT32 HighData;
   BOOLEAN Flag;
 
-  LowData  = (UINT32)(Value);
-  HighData = (UINT32)(Value >> 32);
-
   Flag = FilterBeforeMsrWrite (Index, &Value);
   if (Flag) {
+    LowData  = (UINT32)(Value);
+    HighData = (UINT32)(Value >> 32);
     __asm__ __volatile__ (
       "wrmsr"
       :


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3325

1. AsmReadMsr64() in X64/GccInlinePriv.c
AsmReadMsr64 can return uninitialized value if FilterBeforeMsrRead
returns False. This causes build error with the CLANG toolchain.

2. AsmWriteMsr64() in X64/GccInlinePriv.c
In the case that FilterBeforeMsrWrite changes Value and returns True,
The original Value, not the changed Value, is written to the MSR.
This behavior is different from the one of AsmWriteMsr64() in
X64/WriteMsr64.c for the MSFT toolchain.

Signed-off-by: Takuto Naito <naitaku@gmail.com>
Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Zhiguang Liu <zhiguang.liu@intel.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>