### PR TITLE
RedfishPkg/RestJsonStructureDxe: Fix typo in function header

### DIFF
--- a/MdePkg/Include/Protocol/RestJsonStructure.h
+++ b/MdePkg/Include/Protocol/RestJsonStructure.h
@@ -132,7 +132,7 @@ EFI_STATUS
                                          supports.
   @param[in]    ToStructure              The function to convert REST JSON resource to structure.
   @param[in]    ToJson                   The function to convert REST JSON structure to JSON in text format.
-  @param[out]    DestroyStructure         Destroy REST JSON structure returned in ToStructure() function.
+  @param[in]    DestroyStructure         Destroy REST JSON structure returned in ToStructure() function.
 
   @retval EFI_SUCCESS             Register successfully.
   @retval Others                  Fail to register.


### PR DESCRIPTION
In v2, BZ reference is added.

BZ#:3030
Fix the typo [in]/[out] of parameter DestroyStructure in
function header.

Signed-off-by: Abner Chang <abner.chang@hpe.com>
Cc: Nickle Wang <nickle.wang@hpe.com>
Reviewed-by: Nickle Wang <nickle.wang@hpe.com>