### PR TITLE
Remove fixed CPU architecture list assumptions V2

### DIFF
--- a/BaseTools/Source/C/GenFw/Elf32Convert.c
+++ b/BaseTools/Source/C/GenFw/Elf32Convert.c
@@ -1,7 +1,7 @@
 /** @file
 Elf32 Convert solution
 
-Copyright (c) 2010 - 2018, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2010 - 2021, Intel Corporation. All rights reserved.<BR>
 Portions copyright (c) 2013, ARM Ltd. All rights reserved.<BR>
 Portions Copyright (c) 2020, Hewlett Packard Enterprise Development LP. All rights reserved.<BR>
 
@@ -143,8 +143,7 @@ InitializeElf32 (
     return FALSE;
   }
   if (!((mEhdr->e_machine == EM_386) || (mEhdr->e_machine == EM_ARM) || (mEhdr->e_machine == EM_RISCV))) {
-    Error (NULL, 0, 3000, "Unsupported", "ELF e_machine is not Elf32 machine.");
-    return FALSE;
+    Warning (NULL, 0, 3000, "Unsupported", "ELF e_machine is not Elf32 machine.");
   }
   if (mEhdr->e_version != EV_CURRENT) {
     Error (NULL, 0, 3000, "Unsupported", "ELF e_version (%u) not EV_CURRENT (%d)", (unsigned) mEhdr->e_version, EV_CURRENT);

--- a/BaseTools/Source/C/GenFw/Elf64Convert.c
+++ b/BaseTools/Source/C/GenFw/Elf64Convert.c
@@ -1,7 +1,7 @@
 /** @file
 Elf64 convert solution
 
-Copyright (c) 2010 - 2018, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2010 - 2021, Intel Corporation. All rights reserved.<BR>
 Portions copyright (c) 2013-2014, ARM Ltd. All rights reserved.<BR>
 Portions Copyright (c) 2020, Hewlett Packard Enterprise Development LP. All rights reserved.<BR>
 
@@ -162,8 +162,7 @@ InitializeElf64 (
     return FALSE;
   }
   if (!((mEhdr->e_machine == EM_X86_64) || (mEhdr->e_machine == EM_AARCH64) || (mEhdr->e_machine == EM_RISCV64))) {
-    Error (NULL, 0, 3000, "Unsupported", "ELF e_machine is not Elf64 machine.");
-    return FALSE;
+    Warning (NULL, 0, 3000, "Unsupported", "ELF e_machine is not Elf64 machine.");
   }
   if (mEhdr->e_version != EV_CURRENT) {
     Error (NULL, 0, 3000, "Unsupported", "ELF e_version (%u) not EV_CURRENT (%d)", (unsigned) mEhdr->e_version, EV_CURRENT);

--- a/BaseTools/Source/Python/GenFds/FdfParser.py
+++ b/BaseTools/Source/Python/GenFds/FdfParser.py
@@ -1,7 +1,7 @@
 ## @file
 # parse FDF file
 #
-#  Copyright (c) 2007 - 2018, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2007 - 2021, Intel Corporation. All rights reserved.<BR>
 #  Copyright (c) 2015, Hewlett Packard Enterprise Development, L.P.<BR>
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -3504,8 +3504,6 @@ class FdfParser:
             raise Warning.Expected("'.'", self.FileName, self.CurrentLineNumber)
 
         Arch = self._SkippedChars.rstrip(TAB_SPLIT)
-        if Arch.upper() not in ARCH_SET_FULL:
-            raise Warning("Unknown Arch '%s'" % Arch, self.FileName, self.CurrentLineNumber)
 
         ModuleType = self._GetModuleType()
 

--- a/BaseTools/Source/Python/TargetTool/TargetTool.py
+++ b/BaseTools/Source/Python/TargetTool/TargetTool.py
@@ -1,7 +1,7 @@
 ## @file
 # Target Tool Parser
 #
-#  Copyright (c) 2007 - 2018, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2007 - 2021, Intel Corporation. All rights reserved.<BR>
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -197,7 +197,7 @@ def RangeCheckCallback(option, opt_str, value, parser):
 
 def MyOptionParser():
     parser = OptionParser(version=__version__, prog="TargetTool.exe", usage=__usage__, description=__copyright__)
-    parser.add_option("-a", "--arch", action="append", type="choice", choices=['IA32', 'X64', 'EBC', 'ARM', 'AARCH64', '0'], dest="TARGET_ARCH",
+    parser.add_option("-a", "--arch", action="append", dest="TARGET_ARCH",
         help="ARCHS is one of list: IA32, X64, ARM, AARCH64 or EBC, which replaces target.txt's TARGET_ARCH definition. To specify more archs, please repeat this option. 0 will clear this setting in target.txt and can't combine with other value.")
     parser.add_option("-p", "--platform", action="callback", type="string", dest="DSCFILE", callback=SingleCheckCallback,
         help="Specify a DSC file, which replace target.txt's ACTIVE_PLATFORM definition. 0 will clear this setting in target.txt and can't combine with other value.")

--- a/BaseTools/Source/Python/build/buildoptions.py
+++ b/BaseTools/Source/Python/build/buildoptions.py
@@ -2,7 +2,7 @@
 # build a platform or a module
 #
 #  Copyright (c) 2014, Hewlett-Packard Development Company, L.P.<BR>
-#  Copyright (c) 2007 - 2019, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2007 - 2021, Intel Corporation. All rights reserved.<BR>
 #  Copyright (c) 2018 - 2020, Hewlett Packard Enterprise Development, L.P.<BR>
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -40,7 +40,7 @@ class MyOptionParser():
 
     def GetOption(self):
         Parser = OptionParser(description=__copyright__, version=__version__, prog="build.exe", usage="%prog [options] [all|fds|genc|genmake|clean|cleanall|cleanlib|modules|libraries|run]")
-        Parser.add_option("-a", "--arch", action="append", type="choice", choices=['IA32', 'X64', 'EBC', 'ARM', 'AARCH64', 'RISCV64'], dest="TargetArch",
+        Parser.add_option("-a", "--arch", action="append", dest="TargetArch",
             help="ARCHS is one of list: IA32, X64, ARM, AARCH64, RISCV64 or EBC, which overrides target.txt's TARGET_ARCH definition. To specify more archs, please repeat this option.")
         Parser.add_option("-p", "--platform", action="callback", type="string", dest="PlatformFile", callback=SingleCheckCallback,
             help="Build the platform specified by the DSC file name argument, overriding target.txt's ACTIVE_PLATFORM definition.")

--- a/CryptoPkg/Library/Include/CrtLibSupport.h
+++ b/CryptoPkg/Library/Include/CrtLibSupport.h
@@ -2,7 +2,7 @@
   Root include file of C runtime library to support building the third-party
   cryptographic library.
 
-Copyright (c) 2010 - 2019, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2010 - 2021, Intel Corporation. All rights reserved.<BR>
 Copyright (c) 2020, Hewlett Packard Enterprise Development LP. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -44,6 +44,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #define CONFIG_HEADER_BN_H
 
+#if !defined(SIXTY_FOUR_BIT) && !defined (THIRTY_TWO_BIT)
 #if defined(MDE_CPU_X64) || defined(MDE_CPU_AARCH64) || defined(MDE_CPU_IA64) || defined(MDE_CPU_RISCV64)
 //
 // With GCC we would normally use SIXTY_FOUR_BIT_LONG, but MSVC needs
@@ -55,6 +56,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #define THIRTY_TWO_BIT
 #else
 #error Unknown target architecture
+#endif
 #endif
 
 //

--- a/MdePkg/Include/Uefi/UefiBaseType.h
+++ b/MdePkg/Include/Uefi/UefiBaseType.h
@@ -1,7 +1,7 @@
 /** @file
   Defines data types and constants introduced in UEFI.
 
-Copyright (c) 2006 - 2018, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2006 - 2021, Intel Corporation. All rights reserved.<BR>
 Portions copyright (c) 2011 - 2016, ARM Ltd. All rights reserved.<BR>
 Copyright (c) 2020, Hewlett Packard Enterprise Development LP. All rights reserved.<BR>
 
@@ -248,6 +248,7 @@ typedef union {
 #define EFI_IMAGE_MACHINE_RISCV64   0x5064
 #define EFI_IMAGE_MACHINE_RISCV128  0x5128
 
+#if !defined(EFI_IMAGE_MACHINE_TYPE_VALUE) && !defined(EFI_IMAGE_MACHINE_CROSS_TYPE_VALUE)
 #if   defined (MDE_CPU_IA32)
 
 #define EFI_IMAGE_MACHINE_TYPE_SUPPORTED(Machine) \
@@ -293,6 +294,18 @@ typedef union {
 
 #else
 #error Unknown Processor Type
+#endif
+#else
+#if defined (EFI_IMAGE_MACHINE_TYPE_VALUE)
+#define EFI_IMAGE_MACHINE_TYPE_SUPPORTED(Machine) ((Machine) == EFI_IMAGE_MACHINE_TYPE_VALUE)
+#else
+#define EFI_IMAGE_MACHINE_TYPE_SUPPORTED(Machine) (FALSE)
+#endif
+#if defined (EFI_IMAGE_MACHINE_CROSS_TYPE_VALUE)
+#define EFI_IMAGE_MACHINE_CROSS_TYPE_SUPPORTED(Machine) ((Machine) == EFI_IMAGE_MACHINE_CROSS_TYPE_VALUE)
+#else
+#define EFI_IMAGE_MACHINE_CROSS_TYPE_SUPPORTED(Machine) (FALSE)
+#endif
 #endif
 
 #endif

--- a/MdePkg/Include/Uefi/UefiSpec.h
+++ b/MdePkg/Include/Uefi/UefiSpec.h
@@ -5,7 +5,7 @@
   If a code construct is defined in the UEFI 2.7 specification it must be included
   by this include file.
 
-Copyright (c) 2006 - 2019, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2006 - 2021, Intel Corporation. All rights reserved.<BR>
 Portions Copyright (c) 2020, Hewlett Packard Enterprise Development LP. All rights reserved.<BR>
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -2211,6 +2211,7 @@ typedef struct {
 #define EFI_REMOVABLE_MEDIA_FILE_NAME_AARCH64 L"\\EFI\\BOOT\\BOOTAA64.EFI"
 #define EFI_REMOVABLE_MEDIA_FILE_NAME_RISCV64 L"\\EFI\\BOOT\\BOOTRISCV64.EFI"
 
+#if !defined(EFI_REMOVABLE_MEDIA_FILE_NAME)
 #if   defined (MDE_CPU_IA32)
   #define EFI_REMOVABLE_MEDIA_FILE_NAME   EFI_REMOVABLE_MEDIA_FILE_NAME_IA32
 #elif defined (MDE_CPU_X64)
@@ -2224,6 +2225,7 @@ typedef struct {
   #define EFI_REMOVABLE_MEDIA_FILE_NAME   EFI_REMOVABLE_MEDIA_FILE_NAME_RISCV64
 #else
   #error Unknown Processor Type
+#endif
 #endif
 
 //


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3308

New in V2
=======
* Support all combinations of EFI_IMAGE_MACHINE_TYPE_SUPPORTED and
  EFI_IMAGE_MACHINE_CROSS_TYPE_SUPPORTED.  Also update the way these
  macros are supported that is compatible with all toolchains by introducing
  two new optional #defines called EFI_IMAGE_MACHINE_TYPE_VALUE and
  EFI_IMAGE_MACHINE_CROSS_TYPE_VALUE
* Missing copyright update in CryptoPkg
* Split BaseTools patch into 2 patches.  One for C code and one for Python.

The EDK II Build Specifications do not restrict the set of
CPU architectures that can be supported.  Remove places in
the EDK II that assume a fixed set of CPU architectures.

Remove build breaks in the following tools and DEFINES when a check against
a fixed set of CPU architectures is made.

* Build
* GenFds
* TargetTool
* GenFw
* SIXTY_FOUR_BIT and THIRTY_TWO_BIT
* EFI_IMAGE_MACHINE_TYPE_SUPPORTED
* EFI_IMAGE_MACHINE_CROSS_TYPE_SUPPORTED
* EFI_REMOVABLE_MEDIA_FILE_NAME

Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Xiaoyu Lu <xiaoyux.lu@intel.com>Cc
Cc: Guomin Jiang <guomin.jiang@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Zhiguang Liu <zhiguang.liu@intel.com>
Cc: Bob Feng <bob.c.feng@intel.com>
Cc: Yuwei Chen <yuwei.chen@intel.com>
Cc: Andrew Fish <afish@apple.com>
Cc: Abner Chang <abner.chang@hpe.com>
Signed-off-by: Michael D Kinney <michael.d.kinney@intel.com>