### PR TITLE
SecurityPkg/FvReportPei: remove redundant sizeof

### DIFF
--- a/SecurityPkg/FvReportPei/FvReportPei.c
+++ b/SecurityPkg/FvReportPei/FvReportPei.c
@@ -67,7 +67,7 @@ InstallPreHashFvPpi (
   HASH_INFO                                         *HashInfo;
 
   PpiSize = sizeof (EDKII_PEI_FIRMWARE_VOLUME_INFO_PREHASHED_FV_PPI)
-            + sizeof (sizeof (HASH_INFO))
+            + sizeof (HASH_INFO)
             + HashSize;
 
   PreHashedFvPpi = AllocatePool (PpiSize);


### PR DESCRIPTION
REF:https://bugzilla.tianocore.org/show_bug.cgi?id=3333

In function InstallPreHashFvPpi, when calculating the size
of struct HASH_INFO, sizeof is used twice. This bug does
not lead to buffer overflow, "sizeof (HASH_INFO)" is 4,
whereas "sizeof (sizeof (HASH_INFO))" is 4 or 8.

Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Laszlo Ersek <lersek@redhat.com>
Signed-off-by: Wenyi Xie <xiewenyi2@huawei.com>
Reviewed-by: Laszlo Ersek <lersek@redhat.com>
Reviewed-by: Jian J Wang <jian.j.wang@intel.com>
Acked-by: Jiewen Yao <Jiewen.yao@intel.com>