### PR TITLE
UefiCpuPkg: PiSmmCpuDxeSmm: Not to Change Bitwidth During Static Paging

### DIFF
--- a/UefiCpuPkg/PiSmmCpuDxeSmm/X64/PageTbl.c
+++ b/UefiCpuPkg/PiSmmCpuDxeSmm/X64/PageTbl.c
@@ -211,11 +211,13 @@ CalculateMaximumSupportAddress (
 /**
   Set static page table.
 
-  @param[in] PageTable     Address of page table.
+  @param[in] PageTable              Address of page table.
+  @param[in] PhysicalAddressBits    The maximum physical address bits supported.
 **/
 VOID
 SetStaticPageTable (
-  IN UINTN               PageTable
+  IN UINTN               PageTable,
+  IN UINT8               PhysicalAddressBits
   )
 {
   UINT64                                        PageAddress;
@@ -237,26 +239,26 @@ SetStaticPageTable (
   // IA-32e paging translates 48-bit linear addresses to 52-bit physical addresses
   //  when 5-Level Paging is disabled.
   //
-  ASSERT (mPhysicalAddressBits <= 52);
-  if (!m5LevelPagingNeeded && mPhysicalAddressBits > 48) {
-    mPhysicalAddressBits = 48;
+  ASSERT (PhysicalAddressBits <= 52);
+  if (!m5LevelPagingNeeded && PhysicalAddressBits > 48) {
+    PhysicalAddressBits = 48;
   }
 
   NumberOfPml5EntriesNeeded = 1;
-  if (mPhysicalAddressBits > 48) {
-    NumberOfPml5EntriesNeeded = (UINTN) LShiftU64 (1, mPhysicalAddressBits - 48);
-    mPhysicalAddressBits = 48;
+  if (PhysicalAddressBits > 48) {
+    NumberOfPml5EntriesNeeded = (UINTN) LShiftU64 (1, PhysicalAddressBits - 48);
+    PhysicalAddressBits = 48;
   }
 
   NumberOfPml4EntriesNeeded = 1;
-  if (mPhysicalAddressBits > 39) {
-    NumberOfPml4EntriesNeeded = (UINTN) LShiftU64 (1, mPhysicalAddressBits - 39);
-    mPhysicalAddressBits = 39;
+  if (PhysicalAddressBits > 39) {
+    NumberOfPml4EntriesNeeded = (UINTN) LShiftU64 (1, PhysicalAddressBits - 39);
+    PhysicalAddressBits = 39;
   }
 
   NumberOfPdpEntriesNeeded = 1;
-  ASSERT (mPhysicalAddressBits > 30);
-  NumberOfPdpEntriesNeeded = (UINTN) LShiftU64 (1, mPhysicalAddressBits - 30);
+  ASSERT (PhysicalAddressBits > 30);
+  NumberOfPdpEntriesNeeded = (UINTN) LShiftU64 (1, PhysicalAddressBits - 30);
 
   //
   // By architecture only one PageMapLevel4 exists - so lets allocate storage for it.
@@ -438,7 +440,7 @@ SmmInitPageTable (
     // When access to non-SMRAM memory is restricted, create page table
     // that covers all memory space.
     //
-    SetStaticPageTable ((UINTN)PTEntry);
+    SetStaticPageTable ((UINTN)PTEntry, mPhysicalAddressBits);
   } else {
     //
     // Add pages to page pool


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3300

Current implementation of SetStaticPageTable routine in PiSmmCpuDxeSmm
driver will check a global variable mPhysicalAddressBits, and eventually
cap any value larger than 39 at 39.

This global variable is used in ConvertMemoryPageAttributes, which backs
SmmSetMemoryAttributes and SmmClearMemoryAttributes. Thus for a processor
that supports more than 39 bits width, trying to mark page table regions
higher than 39-bit will always return EFI_UNSUPPROTED.

This change updated the interface of SetStaticPageTable function to take
PhysicalAddressBits as an input parameter, in order to avoid changing/
accessing the global variable.

Cc: Eric Dong <eric.dong@intel.com>
Reviewed-by: Ray Ni <ray.ni@intel.com>
Reviewed-by: Laszlo Ersek <lersek@redhat.com>
Cc: Rahul Kumar <rahul1.kumar@intel.com>

Fixes: 4eee0cc7cc0db74489b99c19eba056b53eda6358
Signed-off-by: Kun Qin <kuqin12@gmail.com>