### PR TITLE
MdePkg/Cpuid.h: Define new element in CPUID Leaf(07h) data structure.

### DIFF
--- a/MdePkg/Include/Register/Intel/Cpuid.h
+++ b/MdePkg/Include/Register/Intel/Cpuid.h
@@ -6,7 +6,7 @@
   If a register returned is a single 32-bit value, then a data structure is
   not provided for that register.
 
-  Copyright (c) 2015 - 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2015 - 2021, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
   @par Specification Reference:
@@ -1550,9 +1550,17 @@ typedef union {
     ///
     UINT32  AVX512_4FMAPS:1;
     ///
-    /// [Bit 25:4] Reserved.
+    /// [Bit 14:4] Reserved.
     ///
-    UINT32  Reserved2:22;
+    UINT32  Reserved4:11;
+    ///
+    /// [Bit 15] Hybrid. If 1, the processor is identified as a hybrid part.
+    ///
+    UINT32  Hybrid:1;
+    ///
+    /// [Bit 25:16] Reserved.
+    ///
+    UINT32  Reserved5:10;
     ///
     /// [Bit 26] Enumerates support for indirect branch restricted speculation
     /// (IBRS) and the indirect branch pre-dictor barrier (IBPB). Processors


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3309

Define new element(Hybird) in CPUID_STRUCTURED_EXTENDED_FEATURE_FLAGS
(07h) data structure.

Signed-off-by: Jason Lou <yun.lou@intel.com>
Cc: Michael D Kinney <michael.d.kinney@intel.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Zhiguang Liu <zhiguang.liu@intel.com>
Reviewed: Ray Ni <ray.ni@intel.com>