### PR TITLE
BaseTools: Add double quote around CLANG_BIN path string

### DIFF
--- a/edksetup.bat
+++ b/edksetup.bat
@@ -120,7 +120,7 @@ if not defined CLANG_BIN (
     @echo.
     @echo !!! WARNING !!! CLANG_BIN environment variable is not set
     @if exist "C:\Program Files\LLVM\bin\clang.exe" (
-        @set CLANG_BIN=C:\Program Files\LLVM\bin\
+        @set "CLANG_BIN=C:\Program Files\LLVM\bin\"
         @echo   Found LLVM, setting CLANG_BIN environment variable to C:\Program Files\LLVM\bin\
     )
 )


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3341

Current CLANG_BIN env variable is set without double quote
around the LLVM default installation path string in windows,
which causes some CI build service cannot find the LLVM path
in windows.
This patch enhance it to add double quote around it.

Signed-off-by: Steven Shi <steven.shi@intel.com>
Cc: Bob Feng <bob.c.feng@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>
Reviewed-by: Bob Feng <bob.c.feng@intel.com>