### PR TITLE
ArmPkg/ArmGicLib: fix maximum interrupts supported

### DIFF
--- a/ArmPkg/Drivers/ArmGic/ArmGicLib.c
+++ b/ArmPkg/Drivers/ArmGic/ArmGicLib.c
@@ -120,7 +120,10 @@ ArmGicGetMaxNumInterrupts (
   IN  INTN          GicDistributorBase
   )
 {
-  return 32 * ((MmioRead32 (GicDistributorBase + ARM_GIC_ICDICTR) & 0x1F) + 1);
+  UINT32 ITLinesNumber;
+
+  ITLinesNumber = MmioRead32 (GicDistributorBase + ARM_GIC_ICDICTR) & 0x1F;
+  return MIN (32 * (ITLinesNumber+ 1), 1020);
 }
 
 VOID


### PR DESCRIPTION
The maximum number of interrupts supported is determined as
32 * (GICD_TYPER.ITLinesNumber + 1).

When GICD_TYPER.ITLinesNumber = 0b11111, the maximum number of
interrupts supported is 1024. However, both GICv2 and GICv3 reserve
INTIDs 1020-1023 for special purposes.

This results in runtime crashes because:
  (1) ArmGicLib functions do not guard against special interrupts.
  (2) ArmGicGetMaxNumInterrupts number includes special interrupts.
  (2) ArmGicV*Dxe relies on ArmGicGetMaxNumInterrupts, and thus
      programs special interrupts through ArmGicLib.

ArmGicGetMaxNumInterrupts now does not include special interrupts.
It reports 1020 instead of 1024 when GICD_TYPER.ITLinesNumber = 0b11111.
This avoids the overhead of guarding ArmGicLib functions while not
requiring to modify the drivers code.

Signed-off-by: Adrián Herrera <adr.her.arc.95@gmail.com>