### PR TITLE
BaseTools/Source/Python: Verify TAB_TOD_DEFINES_FAMILY key present

### DIFF
--- a/BaseTools/Source/Python/AutoGen/ModuleAutoGenHelper.py
+++ b/BaseTools/Source/Python/AutoGen/ModuleAutoGenHelper.py
@@ -1,7 +1,7 @@
 ## @file
 # Create makefile for MS nmake and GNU make
 #
-# Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2019 - 2021, Intel Corporation. All rights reserved.<BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 from __future__ import absolute_import
@@ -178,8 +178,11 @@ class AutoGenInfo(object):
                 if ToolDef[Tool].get(TAB_TOD_DEFINES_BUILDRULEFAMILY, "") != "":
                     if Family != ToolDef[Tool][TAB_TOD_DEFINES_BUILDRULEFAMILY]:
                         continue
-                elif Family != ToolDef[Tool][TAB_TOD_DEFINES_FAMILY]:
-                    continue
+                else:
+                    if ToolDef[Tool].get(TAB_TOD_DEFINES_FAMILY, "") == "":
+                        continue
+                    if Family != ToolDef[Tool][TAB_TOD_DEFINES_FAMILY]:
+                        continue
                 FamilyMatch = True
             # expand any wildcard
             if Target == TAB_STAR or Target == self.BuildTarget:
@@ -213,6 +216,8 @@ class AutoGenInfo(object):
             if Tool not in ToolDef or Family == "":
                 continue
             # option has been added before
+            if TAB_TOD_DEFINES_FAMILY not in ToolDef[Tool]:
+                continue
             if Family != ToolDef[Tool][TAB_TOD_DEFINES_FAMILY]:
                 continue
 

--- a/BaseTools/Source/Python/AutoGen/PlatformAutoGen.py
+++ b/BaseTools/Source/Python/AutoGen/PlatformAutoGen.py
@@ -1474,8 +1474,11 @@ class PlatformAutoGen(AutoGen):
                 if ToolDef[Tool].get(TAB_TOD_DEFINES_BUILDRULEFAMILY, "") != "":
                     if Family != ToolDef[Tool][TAB_TOD_DEFINES_BUILDRULEFAMILY]:
                         continue
-                elif Family != ToolDef[Tool][TAB_TOD_DEFINES_FAMILY]:
-                    continue
+                else:
+                    if ToolDef[Tool].get(TAB_TOD_DEFINES_FAMILY, "") == "":
+                        continue
+                    if Family != ToolDef[Tool][TAB_TOD_DEFINES_FAMILY]:
+                        continue
                 FamilyMatch = True
             # expand any wildcard
             if Target == TAB_STAR or Target == self.BuildTarget:
@@ -1509,6 +1512,8 @@ class PlatformAutoGen(AutoGen):
             if Tool not in ToolDef or Family == "":
                 continue
             # option has been added before
+            if TAB_TOD_DEFINES_FAMILY not in ToolDef[Tool]:
+                continue
             if Family != ToolDef[Tool][TAB_TOD_DEFINES_FAMILY]:
                 continue
 


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3344

Veify that TAB_TOD_DEFINES_FAMILY key is present in ToolDef
dictionary before access.

Cc: Bob Feng <bob.c.feng@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Yuwei Chen <yuwei.chen@intel.com>
Signed-off-by: Michael D Kinney <michael.d.kinney@intel.com>
Reviewed-by: Bob Feng <bob.c.feng@intel.com>