### PR TITLE
BaseTools/GenMake: Sort generated makefile tool definitions

### DIFF
--- a/BaseTools/Source/Python/AutoGen/GenMake.py
+++ b/BaseTools/Source/Python/AutoGen/GenMake.py
@@ -1,7 +1,7 @@
 ## @file
 # Create makefile for MS nmake and GNU make
 #
-# Copyright (c) 2007 - 2020, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2007 - 2021, Intel Corporation. All rights reserved.<BR>
 # Copyright (c) 2020, ARM Limited. All rights reserved.<BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -519,13 +519,15 @@ cleanlib:
         # tools definitions
         ToolsDef = []
         IncPrefix = self._INC_FLAG_[MyAgo.ToolChainFamily]
-        for Tool in MyAgo.BuildOption:
-            for Attr in MyAgo.BuildOption[Tool]:
+        for Tool in sorted(list(MyAgo.BuildOption)):
+            Appended = False
+            for Attr in sorted(list(MyAgo.BuildOption[Tool])):
                 Value = MyAgo.BuildOption[Tool][Attr]
                 if Attr == "FAMILY":
                     continue
                 elif Attr == "PATH":
                     ToolsDef.append("%s = %s" % (Tool, Value))
+                    Appended = True
                 else:
                     # Don't generate MAKE_FLAGS in makefile. It's put in environment variable.
                     if Tool == "MAKE":
@@ -542,7 +544,9 @@ cleanlib:
                                 Value = ' '.join(ValueList)
 
                     ToolsDef.append("%s_%s = %s" % (Tool, Attr, Value))
-            ToolsDef.append("")
+                    Appended = True
+            if Appended:
+                ToolsDef.append("")
 
         # generate the Response file and Response flag
         RespDict = self.CommandExceedLimit()


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3353

Sort the tool definition content of generated makefiles to help
verify that makefile contents have not changed after BaseTools
code changes.

Cc: Bob Feng <bob.c.feng@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Yuwei Chen <yuwei.chen@intel.com>
Signed-off-by: Michael D Kinney <michael.d.kinney@intel.com>