### PR TITLE
SecurityPkg: Add constraints on PK strength

### DIFF
--- a/SecurityPkg/VariableAuthenticated/SecureBootConfigDxe/SecureBootConfigImpl.h
+++ b/SecurityPkg/VariableAuthenticated/SecureBootConfigDxe/SecureBootConfigImpl.h
@@ -93,6 +93,27 @@ extern  EFI_IFR_GUID_LABEL         *mEndLabel;
 #define HASHALG_RAW                            0x00000004
 #define HASHALG_MAX                            0x00000004
 
+//
+// Certificate public key minimum size (bytes)
+//
+#define CER_PUBKEY_MIN_SIZE     256
+
+//
+// Types of errors may occur during certificate enrollment.
+//
+typedef enum {
+  None_Error = 0,
+  //
+  // Unsupported_type indicates the certificate type is not supported.
+  //
+  Unsupported_Type,
+  //
+  // Unqualified_key indicates the key strength of certificate is not
+  // strong enough.
+  //
+  Unqualified_Key,
+  Enroll_Error_Max
+}ENROLL_KEY_ERROR;
 
 typedef struct {
   UINTN             Signature;


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3293

Add constraints on the key strength of enrolled platform key(PK), which
must be greater than or equal to 2048 bit. PK key strength is required
by Intel SDL and MSFT, etc. This limitation prevents user from using
weak keys as PK.

The original code to check the certificate file type is placed in a new
function CheckX509Certificate(), which checks if the X.509 certificate
meets the requirements of encode type, RSA-Key strengh, etc.

Cc: Min Xu <min.m.xu@intel.com>
Cc: Jiewen Yao <jiewen.yao@intel.com>
Signed-off-by: Jiaqi Gao <jiaqi.gao@intel.com>
Reviewed-by: Min Xu <min.m.xu@intel.com>
Acked-by: Jiewen Yao <jiewen.yao@intel.com>