### PR TITLE
BaseTools/Source/Python: New Target/ToolChain/Arch in DSC [BuildOptions]

### DIFF
--- a/BaseTools/Source/Python/AutoGen/ModuleAutoGenHelper.py
+++ b/BaseTools/Source/Python/AutoGen/ModuleAutoGenHelper.py
@@ -173,17 +173,30 @@ class AutoGenInfo(object):
             Family = Key[0]
             Target, Tag, Arch, Tool, Attr = Key[1].split("_")
             # if tool chain family doesn't match, skip it
-            if Tool in ToolDef and Family != "":
-                FamilyIsNull = False
-                if ToolDef[Tool].get(TAB_TOD_DEFINES_BUILDRULEFAMILY, "") != "":
-                    if Family != ToolDef[Tool][TAB_TOD_DEFINES_BUILDRULEFAMILY]:
-                        continue
-                else:
-                    if ToolDef[Tool].get(TAB_TOD_DEFINES_FAMILY, "") == "":
-                        continue
-                    if Family != ToolDef[Tool][TAB_TOD_DEFINES_FAMILY]:
-                        continue
-                FamilyMatch = True
+            if Family != "":
+                Found = False
+                if Tool in ToolDef:
+                    FamilyIsNull = False
+                    if TAB_TOD_DEFINES_BUILDRULEFAMILY in ToolDef[Tool]:
+                        if Family == ToolDef[Tool][TAB_TOD_DEFINES_BUILDRULEFAMILY]:
+                            FamilyMatch = True
+                            Found = True
+                    if TAB_TOD_DEFINES_FAMILY in ToolDef[Tool]:
+                        if Family == ToolDef[Tool][TAB_TOD_DEFINES_FAMILY]:
+                            FamilyMatch = True
+                            Found = True
+                if TAB_STAR in ToolDef:
+                    FamilyIsNull = False
+                    if TAB_TOD_DEFINES_BUILDRULEFAMILY in ToolDef[TAB_STAR]:
+                        if Family == ToolDef[TAB_STAR][TAB_TOD_DEFINES_BUILDRULEFAMILY]:
+                            FamilyMatch = True
+                            Found = True
+                    if TAB_TOD_DEFINES_FAMILY in ToolDef[TAB_STAR]:
+                        if Family == ToolDef[TAB_STAR][TAB_TOD_DEFINES_FAMILY]:
+                            FamilyMatch = True
+                            Found = True
+                if not Found:
+                    continue
             # expand any wildcard
             if Target == TAB_STAR or Target == self.BuildTarget:
                 if Tag == TAB_STAR or Tag == self.ToolChain:
@@ -213,12 +226,19 @@ class AutoGenInfo(object):
             Family = Key[0]
             Target, Tag, Arch, Tool, Attr = Key[1].split("_")
             # if tool chain family doesn't match, skip it
-            if Tool not in ToolDef or Family == "":
+            if Family == "":
                 continue
             # option has been added before
-            if TAB_TOD_DEFINES_FAMILY not in ToolDef[Tool]:
-                continue
-            if Family != ToolDef[Tool][TAB_TOD_DEFINES_FAMILY]:
+            Found = False
+            if Tool in ToolDef:
+                if TAB_TOD_DEFINES_FAMILY in ToolDef[Tool]:
+                    if Family == ToolDef[Tool][TAB_TOD_DEFINES_FAMILY]:
+                        Found = True
+            if TAB_STAR in ToolDef:
+                if TAB_TOD_DEFINES_FAMILY in ToolDef[TAB_STAR]:
+                    if Family == ToolDef[TAB_STAR][TAB_TOD_DEFINES_FAMILY]:
+                        Found = True
+            if not Found:
                 continue
 
             # expand any wildcard

--- a/BaseTools/Source/Python/AutoGen/PlatformAutoGen.py
+++ b/BaseTools/Source/Python/AutoGen/PlatformAutoGen.py
@@ -841,6 +841,12 @@ class PlatformAutoGen(AutoGen):
         DllPathList = set()
         for Def in ToolDefinition:
             Target, Tag, Arch, Tool, Attr = Def.split("_")
+            if Target == TAB_STAR:
+                Target = self.BuildTarget
+            if Tag == TAB_STAR:
+                Tag = self.ToolChain
+            if Arch == TAB_STAR:
+                Arch = self.Arch
             if Target != self.BuildTarget or Tag != self.ToolChain or Arch != self.Arch:
                 continue
 
@@ -850,9 +856,14 @@ class PlatformAutoGen(AutoGen):
                 DllPathList.add(Value)
                 continue
 
+            #
+            # ToolDefintion is sorted from highest priority to lowest priority.
+            # Only add the first(highest priority) match to RetVal
+            #
             if Tool not in RetVal:
                 RetVal[Tool] = OrderedDict()
-            RetVal[Tool][Attr] = Value
+            if Attr not in RetVal[Tool]:
+                RetVal[Tool][Attr] = Value
 
         ToolsDef = ''
         if GlobalData.gOptions.SilentMode and "MAKE" in RetVal:
@@ -860,9 +871,21 @@ class PlatformAutoGen(AutoGen):
                 RetVal["MAKE"]["FLAGS"] = ""
             RetVal["MAKE"]["FLAGS"] += " -s"
         MakeFlags = ''
-        for Tool in RetVal:
-            for Attr in RetVal[Tool]:
-                Value = RetVal[Tool][Attr]
+
+        ToolList = list(RetVal.keys())
+        ToolList.sort()
+        for Tool in ToolList:
+            if Tool == TAB_STAR:
+                continue
+            AttrList = list(RetVal[Tool].keys())
+            if TAB_STAR in ToolList:
+                AttrList += list(RetVal[TAB_STAR])
+            AttrList.sort()
+            for Attr in AttrList:
+                if Attr in RetVal[Tool]:
+                    Value = RetVal[Tool][Attr]
+                else:
+                    Value = RetVal[TAB_STAR][Attr]
                 if Tool in self._BuildOptionWithToolDef(RetVal) and Attr in self._BuildOptionWithToolDef(RetVal)[Tool]:
                     # check if override is indicated
                     if self._BuildOptionWithToolDef(RetVal)[Tool][Attr].startswith('='):
@@ -877,7 +900,7 @@ class PlatformAutoGen(AutoGen):
                 if Attr == "PATH":
                     # Don't put MAKE definition in the file
                     if Tool != "MAKE":
-                        ToolsDef += "%s = %s\n" % (Tool, Value)
+                        ToolsDef += "%s_%s = %s\n" % (Tool, Attr, Value)
                 elif Attr != "DLL":
                     # Don't put MAKE definition in the file
                     if Tool == "MAKE":
@@ -1469,17 +1492,31 @@ class PlatformAutoGen(AutoGen):
             Family = Key[0]
             Target, Tag, Arch, Tool, Attr = Key[1].split("_")
             # if tool chain family doesn't match, skip it
-            if Tool in ToolDef and Family != "":
-                FamilyIsNull = False
-                if ToolDef[Tool].get(TAB_TOD_DEFINES_BUILDRULEFAMILY, "") != "":
-                    if Family != ToolDef[Tool][TAB_TOD_DEFINES_BUILDRULEFAMILY]:
-                        continue
-                else:
-                    if ToolDef[Tool].get(TAB_TOD_DEFINES_FAMILY, "") == "":
-                        continue
-                    if Family != ToolDef[Tool][TAB_TOD_DEFINES_FAMILY]:
-                        continue
-                FamilyMatch = True
+            if Family != "":
+                Found = False
+                if Tool in ToolDef:
+                    FamilyIsNull = False
+                    if TAB_TOD_DEFINES_BUILDRULEFAMILY in ToolDef[Tool]:
+                        if Family == ToolDef[Tool][TAB_TOD_DEFINES_BUILDRULEFAMILY]:
+                            FamilyMatch = True
+                            Found = True
+                    if TAB_TOD_DEFINES_FAMILY in ToolDef[Tool]:
+                        if Family == ToolDef[Tool][TAB_TOD_DEFINES_FAMILY]:
+                            FamilyMatch = True
+                            Found = True
+                if TAB_STAR in ToolDef:
+                    FamilyIsNull = False
+                    if TAB_TOD_DEFINES_BUILDRULEFAMILY in ToolDef[TAB_STAR]:
+                        if Family == ToolDef[TAB_STAR][TAB_TOD_DEFINES_BUILDRULEFAMILY]:
+                            FamilyMatch = True
+                            Found = True
+                    if TAB_TOD_DEFINES_FAMILY in ToolDef[TAB_STAR]:
+                        if Family == ToolDef[TAB_STAR][TAB_TOD_DEFINES_FAMILY]:
+                            FamilyMatch = True
+                            Found = True
+                if not Found:
+                    continue
+
             # expand any wildcard
             if Target == TAB_STAR or Target == self.BuildTarget:
                 if Tag == TAB_STAR or Tag == self.ToolChain:
@@ -1509,12 +1546,19 @@ class PlatformAutoGen(AutoGen):
             Family = Key[0]
             Target, Tag, Arch, Tool, Attr = Key[1].split("_")
             # if tool chain family doesn't match, skip it
-            if Tool not in ToolDef or Family == "":
+            if Family == "":
                 continue
             # option has been added before
-            if TAB_TOD_DEFINES_FAMILY not in ToolDef[Tool]:
-                continue
-            if Family != ToolDef[Tool][TAB_TOD_DEFINES_FAMILY]:
+            Found = False
+            if Tool in ToolDef:
+                if TAB_TOD_DEFINES_FAMILY in ToolDef[Tool]:
+                    if Family == ToolDef[Tool][TAB_TOD_DEFINES_FAMILY]:
+                        Found = True
+            if TAB_STAR in ToolDef:
+                if TAB_TOD_DEFINES_FAMILY in ToolDef[TAB_STAR]:
+                    if Family == ToolDef[TAB_STAR][TAB_TOD_DEFINES_FAMILY]:
+                        Found = True
+            if not Found:
                 continue
 
             # expand any wildcard

--- a/BaseTools/Source/Python/Common/ToolDefClassObject.py
+++ b/BaseTools/Source/Python/Common/ToolDefClassObject.py
@@ -1,7 +1,7 @@
 ## @file
 # This file is used to define each component of tools_def.txt file
 #
-# Copyright (c) 2007 - 2019, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2007 - 2021, Intel Corporation. All rights reserved.<BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 
@@ -85,23 +85,6 @@ class ToolDefClassObject(object):
         self.ToolsDefTxtDatabase[TAB_TOD_DEFINES_TOOL_CHAIN_TAG].sort()
         self.ToolsDefTxtDatabase[TAB_TOD_DEFINES_TARGET_ARCH].sort()
         self.ToolsDefTxtDatabase[TAB_TOD_DEFINES_COMMAND_TYPE].sort()
-
-        KeyList = [TAB_TOD_DEFINES_TARGET, TAB_TOD_DEFINES_TOOL_CHAIN_TAG, TAB_TOD_DEFINES_TARGET_ARCH, TAB_TOD_DEFINES_COMMAND_TYPE]
-        for Index in range(3, -1, -1):
-            # make a copy of the keys to enumerate over to prevent issues when
-            # adding/removing items from the original dict.
-            for Key in list(self.ToolsDefTxtDictionary.keys()):
-                List = Key.split('_')
-                if List[Index] == TAB_STAR:
-                    for String in self.ToolsDefTxtDatabase[KeyList[Index]]:
-                        List[Index] = String
-                        NewKey = '%s_%s_%s_%s_%s' % tuple(List)
-                        if NewKey not in self.ToolsDefTxtDictionary:
-                            self.ToolsDefTxtDictionary[NewKey] = self.ToolsDefTxtDictionary[Key]
-                    del self.ToolsDefTxtDictionary[Key]
-                elif List[Index] not in self.ToolsDefTxtDatabase[KeyList[Index]]:
-                    del self.ToolsDefTxtDictionary[Key]
-
 
     ## IncludeToolDefFile
     #

--- a/BaseTools/Source/Python/GenFds/GenFdsGlobalVariable.py
+++ b/BaseTools/Source/Python/GenFds/GenFdsGlobalVariable.py
@@ -1,7 +1,7 @@
 ## @file
 # Global variables for GenFds
 #
-#  Copyright (c) 2007 - 2018, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2007 - 2021, Intel Corporation. All rights reserved.<BR>
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -875,14 +875,27 @@ def FindExtendTool(KeyStringList, CurrentArchList, NameGuid):
     ToolOptionKey = None
     KeyList = None
     for tool_def in ToolDefinition.items():
-        if NameGuid.lower() == tool_def[1].lower():
-            KeyList = tool_def[0].split('_')
-            Key = KeyList[0] + \
-                  '_' + \
-                  KeyList[1] + \
-                  '_' + \
-                  KeyList[2]
-            if Key in KeyStringList and KeyList[4] == DataType.TAB_GUID:
+        KeyList = tool_def[0].split('_')
+        if len(KeyList) < 5:
+            continue
+        if KeyList[4] != DataType.TAB_GUID:
+            continue
+        if NameGuid.lower() != tool_def[1].lower():
+            continue
+        Key = KeyList[0] + \
+                '_' + \
+                KeyList[1] + \
+                '_' + \
+                KeyList[2]
+        for KeyString in KeyStringList:
+            KeyStringBuildTarget, KeyStringToolChain, KeyStringArch = KeyString.split('_')
+            if KeyList[0] == DataType.TAB_STAR:
+                KeyList[0] = KeyStringBuildTarget
+            if KeyList[1] == DataType.TAB_STAR:
+                KeyList[1] = KeyStringToolChain
+            if KeyList[2] == DataType.TAB_STAR:
+                KeyList[2] = KeyStringArch
+            if KeyList[0] == KeyStringBuildTarget and KeyList[1] == KeyStringToolChain and KeyList[2] == KeyStringArch:
                 ToolPathKey   = Key + '_' + KeyList[3] + '_PATH'
                 ToolOptionKey = Key + '_' + KeyList[3] + '_FLAGS'
                 ToolPath = ToolDefinition.get(ToolPathKey)


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3359

Update BaseTools to support new build targets, new tool chains,
and new architectures declared in DSC file [BuildOptions] sections.

* Do not expand '*' when tools_def.txt is parsed.  Only expand when
  both tools_def.txt and DSC [BuilsOptions] sections have been parsed.
  This also requires more flexible matching of tool keys that contain
  '*' in tool key fields.

* Pre-scan the platform DSC file for FAMILY and TOOLCHAIN declarations
  DSC in [BuildOptions] sections before the FAMILY and TOOLCHAIN need
  to be known.

Cc: Bob Feng <bob.c.feng@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Yuwei Chen <yuwei.chen@intel.com>
Signed-off-by: Michael D Kinney <michael.d.kinney@intel.com>