### PR TITLE
BaseTools: Fix New Target/ToolChain/Arch in DSC [BuildOptions] issues

### DIFF
--- a/BaseTools/Source/Python/AutoGen/ModuleAutoGenHelper.py
+++ b/BaseTools/Source/Python/AutoGen/ModuleAutoGenHelper.py
@@ -181,18 +181,10 @@ class AutoGenInfo(object):
                         if Family == ToolDef[Tool][TAB_TOD_DEFINES_BUILDRULEFAMILY]:
                             FamilyMatch = True
                             Found = True
-                    if TAB_TOD_DEFINES_FAMILY in ToolDef[Tool]:
-                        if Family == ToolDef[Tool][TAB_TOD_DEFINES_FAMILY]:
-                            FamilyMatch = True
-                            Found = True
                 if TAB_STAR in ToolDef:
                     FamilyIsNull = False
                     if TAB_TOD_DEFINES_BUILDRULEFAMILY in ToolDef[TAB_STAR]:
                         if Family == ToolDef[TAB_STAR][TAB_TOD_DEFINES_BUILDRULEFAMILY]:
-                            FamilyMatch = True
-                            Found = True
-                    if TAB_TOD_DEFINES_FAMILY in ToolDef[TAB_STAR]:
-                        if Family == ToolDef[TAB_STAR][TAB_TOD_DEFINES_FAMILY]:
                             FamilyMatch = True
                             Found = True
                 if not Found:
@@ -640,14 +632,19 @@ class PlatformInfo(AutoGenInfo):
                     if Attr == TAB_TOD_DEFINES_BUILDRULEORDER:
                         continue
                     Value = Options[Tool][Attr]
-                    # check if override is indicated
-                    if Value.startswith('='):
-                        BuildOptions[Tool][Attr] = mws.handleWsMacro(Value[1:])
-                    else:
-                        if Attr != 'PATH':
-                            BuildOptions[Tool][Attr] += " " + mws.handleWsMacro(Value)
+                    ToolList = [Tool]
+                    if Tool == TAB_STAR:
+                        ToolList = list(AllTools)
+                        ToolList.remove(TAB_STAR)
+                    for ExpandedTool in ToolList:
+                        # check if override is indicated
+                        if Value.startswith('='):
+                            BuildOptions[ExpandedTool][Attr] = mws.handleWsMacro(Value[1:])
                         else:
-                            BuildOptions[Tool][Attr] = mws.handleWsMacro(Value)
+                            if Attr != 'PATH':
+                                BuildOptions[ExpandedTool][Attr] += " " + mws.handleWsMacro(Value)
+                            else:
+                                BuildOptions[ExpandedTool][Attr] = mws.handleWsMacro(Value)
 
         return BuildOptions, BuildRuleOrder
 

--- a/BaseTools/Source/Python/AutoGen/PlatformAutoGen.py
+++ b/BaseTools/Source/Python/AutoGen/PlatformAutoGen.py
@@ -1391,14 +1391,19 @@ class PlatformAutoGen(AutoGen):
                     if Attr == TAB_TOD_DEFINES_BUILDRULEORDER:
                         continue
                     Value = Options[Tool][Attr]
-                    # check if override is indicated
-                    if Value.startswith('='):
-                        BuildOptions[Tool][Attr] = mws.handleWsMacro(Value[1:])
-                    else:
-                        if Attr != 'PATH':
-                            BuildOptions[Tool][Attr] += " " + mws.handleWsMacro(Value)
+                    ToolList = [Tool]
+                    if Tool == TAB_STAR:
+                        ToolList = list(AllTools)
+                        ToolList.remove(TAB_STAR)
+                    for ExpandedTool in ToolList:
+                        # check if override is indicated
+                        if Value.startswith('='):
+                            BuildOptions[ExpandedTool][Attr] = mws.handleWsMacro(Value[1:])
                         else:
-                            BuildOptions[Tool][Attr] = mws.handleWsMacro(Value)
+                            if Attr != 'PATH':
+                                BuildOptions[ExpandedTool][Attr] += " " + mws.handleWsMacro(Value)
+                            else:
+                                BuildOptions[ExpandedTool][Attr] = mws.handleWsMacro(Value)
 
         return BuildOptions, BuildRuleOrder
 
@@ -1529,18 +1534,10 @@ class PlatformAutoGen(AutoGen):
                         if Family == ToolDef[Tool][TAB_TOD_DEFINES_BUILDRULEFAMILY]:
                             FamilyMatch = True
                             Found = True
-                    if TAB_TOD_DEFINES_FAMILY in ToolDef[Tool]:
-                        if Family == ToolDef[Tool][TAB_TOD_DEFINES_FAMILY]:
-                            FamilyMatch = True
-                            Found = True
                 if TAB_STAR in ToolDef:
                     FamilyIsNull = False
                     if TAB_TOD_DEFINES_BUILDRULEFAMILY in ToolDef[TAB_STAR]:
                         if Family == ToolDef[TAB_STAR][TAB_TOD_DEFINES_BUILDRULEFAMILY]:
-                            FamilyMatch = True
-                            Found = True
-                    if TAB_TOD_DEFINES_FAMILY in ToolDef[TAB_STAR]:
-                        if Family == ToolDef[TAB_STAR][TAB_TOD_DEFINES_FAMILY]:
                             FamilyMatch = True
                             Found = True
                 if not Found:

--- a/BaseTools/Source/Python/build/build.py
+++ b/BaseTools/Source/Python/build/build.py
@@ -897,6 +897,7 @@ class Build():
     # $(TARGET), $(TOOLCHAIN), $(TOOLCHAIN_TAG), or $(ARCH) operands.
     #
     def GetToolChainAndFamilyFromDsc (self, File):
+        SavedGlobalDefines = GlobalData.gGlobalDefines.copy()
         for BuildTarget in self.BuildTargetList:
             GlobalData.gGlobalDefines['TARGET'] = BuildTarget
             for BuildToolChain in self.ToolChainList:
@@ -929,6 +930,7 @@ class Build():
                             self.ToolDef.ToolsDefTxtDatabase[TAB_TOD_DEFINES_TOOL_CHAIN_TAG] = []
                         if ToolChain not in self.ToolDef.ToolsDefTxtDatabase[TAB_TOD_DEFINES_TOOL_CHAIN_TAG]:
                             self.ToolDef.ToolsDefTxtDatabase[TAB_TOD_DEFINES_TOOL_CHAIN_TAG].append(ToolChain)
+        GlobalData.gGlobalDefines = SavedGlobalDefines
 
     ## Load configuration
     #


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3359

* Save/Restore global state in GetToolChainAndFamilyFromDsc()
  This resolves an issue where the multi-arch build for
  UefiPayloadPkg would skip the autogen and build of IA32
  components.
* Expand tools wildcard.
  This resolves the issue where autogen makefile contents
  would have a BUIDLRULEFAMILY tools definitions with an
  '*' in the tool field that breaks the build from invalid
  makefile syntax.
* Build rule family higher priority than Family.
  This resolves the issue where flags were appended from
  both the BUILDRULEFAMILY and FAMILY when only
  BUILDRULEFAMILY should be appended when present.

Cc: Bob Feng <bob.c.feng@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Yuwei Chen <yuwei.chen@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Cc: Steven Shi <steven.shi@intel.com>
Signed-off-by: Michael D Kinney <michael.d.kinney@intel.com>
Acked-by: Rebecca Cran <rebecca@bsdio.com>
Reviewed-by: Andrew Fish <afish@apple.com>