### PR TITLE
UnitTestFrameworkPkg: Sample unit test hangs when running in OVMF/QEMU

### DIFF
--- a/UnitTestFrameworkPkg/Library/UnitTestLib/Assert.c
+++ b/UnitTestFrameworkPkg/Library/UnitTestLib/Assert.c
@@ -42,6 +42,7 @@ AddUnitTestFailure (
 
 STATIC
 VOID
+EFIAPI
 UnitTestLogFailure (
   IN FAILURE_TYPE  FailureType,
   IN CONST CHAR8   *Format,

--- a/UnitTestFrameworkPkg/Library/UnitTestResultReportLib/UnitTestResultReportLib.c
+++ b/UnitTestFrameworkPkg/Library/UnitTestResultReportLib/UnitTestResultReportLib.c
@@ -11,6 +11,7 @@
 #include <Library/DebugLib.h>
 
 VOID
+EFIAPI
 ReportPrint (
   IN CONST CHAR8  *Format,
   ...

--- a/UnitTestFrameworkPkg/Library/UnitTestResultReportLib/UnitTestResultReportLibConOut.c
+++ b/UnitTestFrameworkPkg/Library/UnitTestResultReportLib/UnitTestResultReportLibConOut.c
@@ -12,6 +12,7 @@
 #include <Library/DebugLib.h>
 
 VOID
+EFIAPI
 ReportPrint (
   IN CONST CHAR8  *Format,
   ...

--- a/UnitTestFrameworkPkg/Library/UnitTestResultReportLib/UnitTestResultReportLibDebugLib.c
+++ b/UnitTestFrameworkPkg/Library/UnitTestResultReportLib/UnitTestResultReportLibDebugLib.c
@@ -11,6 +11,7 @@
 #include <Library/DebugLib.h>
 
 VOID
+EFIAPI
 ReportPrint (
   IN CONST CHAR8  *Format,
   ...


### PR DESCRIPTION
Sample unit tests in UnitTestFrameworkPkg hangs when running in OVMF/QEMU
environment. Build target is X64/GCC5. Fixing this issue by adding EFIAPI
to ReportPrint() function that use VA_ARGS.

Signed-off-by: Getnat Ejigu <getnatejigu@gmail.com>
Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Sean Brogan <sean.brogan@microsoft.com>
Cc: Bret Barkelew <Bret.Barkelew@microsoft.com>
Reviewed-by: Bret Barkelew <bret.barkelew@microsoft.com>
Reviewed-by: Michael D Kinney <michael.d.kinney@intel.com>