### PR TITLE
BaseTools: Fix DSC override of Guided tool

### DIFF
--- a/BaseTools/Source/Python/AutoGen/PlatformAutoGen.py
+++ b/BaseTools/Source/Python/AutoGen/PlatformAutoGen.py
@@ -918,9 +918,12 @@ class PlatformAutoGen(AutoGen):
                 if Tool in self._BuildOptionWithToolDef(RetVal) and Attr in self._BuildOptionWithToolDef(RetVal)[Tool]:
                     # check if override is indicated
                     if self._BuildOptionWithToolDef(RetVal)[Tool][Attr].startswith('='):
-                        Value = self._BuildOptionWithToolDef(RetVal)[Tool][Attr][1:]
+                        Value = self._BuildOptionWithToolDef(RetVal)[Tool][Attr][1:].strip()
+                        Def = '_'.join([self.BuildTarget, self.ToolChain, self.Arch, Tool, Attr])
+                        self.Workspace.ToolDef.ToolsDefTxtDictionary[Def] = Value
                     else:
-                        if Attr != 'PATH':
+                        # Do not append PATH or GUID
+                        if Attr != 'PATH' and Attr != 'GUID':
                             Value += " " + self._BuildOptionWithToolDef(RetVal)[Tool][Attr]
                         else:
                             Value = self._BuildOptionWithToolDef(RetVal)[Tool][Attr]


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3359

If the DSC file provides an override of a Guided tool path
and/or Guided tool GUID value, then make sure the one from the
DSC file is used if it is higher priority than the Guided tool
in the tools_def.txt file.

Cc: Bob Feng <bob.c.feng@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Yuwei Chen <yuwei.chen@intel.com>
Signed-off-by: Michael D Kinney <michael.d.kinney@intel.com>