### PR TITLE
ArmPkg: Update SCMI Base Protocol version to 0x20000

### DIFF
--- a/ArmPkg/Drivers/ArmScmiDxe/ScmiDxe.c
+++ b/ArmPkg/Drivers/ArmScmiDxe/ScmiDxe.c
@@ -4,9 +4,9 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
-  System Control and Management Interface V1.0
-    http://infocenter.arm.com/help/topic/com.arm.doc.den0056a/
-    DEN0056A_System_Control_and_Management_Interface.pdf
+  @par Specification Reference:
+  - Arm System Control and Management Interface - Platform Design Document
+    (https://developer.arm.com/documentation/den0056/)
 **/
 
 #include <Base.h>
@@ -86,7 +86,9 @@ ArmScmiDxeEntryPoint (
     return Status;
   }
 
-  if (Version != BASE_PROTOCOL_VERSION) {
+  // Accept any version between SCMI v1.0 and SCMI v2.0
+  if ((Version < BASE_PROTOCOL_VERSION_V1) ||
+    (Version > BASE_PROTOCOL_VERSION_V2)) {
     ASSERT (FALSE);
     return EFI_UNSUPPORTED;
   }

--- a/ArmPkg/Include/Protocol/ArmScmiBaseProtocol.h
+++ b/ArmPkg/Include/Protocol/ArmScmiBaseProtocol.h
@@ -4,9 +4,9 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
-  System Control and Management Interface V1.0
-    http://infocenter.arm.com/help/topic/com.arm.doc.den0056a/
-    DEN0056A_System_Control_and_Management_Interface.pdf
+  @par Specification Reference:
+  - Arm System Control and Management Interface - Platform Design Document
+    (https://developer.arm.com/documentation/den0056/)
 **/
 
 #ifndef ARM_SCMI_BASE_PROTOCOL_H_
@@ -14,7 +14,8 @@
 
 #include <Protocol/ArmScmi.h>
 
-#define BASE_PROTOCOL_VERSION  0x10000
+#define BASE_PROTOCOL_VERSION_V1  0x10000
+#define BASE_PROTOCOL_VERSION_V2  0x20000
 
 #define NUM_PROTOCOL_MASK      0xFFU
 #define NUM_AGENT_MASK         0xFFU
@@ -165,4 +166,3 @@ typedef enum {
 } SCMI_MESSAGE_ID_BASE;
 
 #endif /* ARM_SCMI_BASE_PROTOCOL_H_ */
-


### PR DESCRIPTION
The SCP-firmware has moved to full support for SCMIv2 which means that
the base protocol can be either compliant with SCMI v1 or v2.

Allow any version between SCMI v1.0 and SCMI v2.0 to be compatible
with the current implementation.

Signed-off-by: Nicola Mazzucato <nicola.mazzucato@arm.com>
Signed-off-by: Pierre Gondois <Pierre.Gondois@arm.com>
Tested-by: Sami Mujawar <sami.mujawar@arm.com>
Reviewed-by: Sami Mujawar <sami.mujawar@arm.com>