### PR TITLE
[edk2-devel] [PATCH] UefiCpuPkg/MpInitLib: Properly cast from PCD to SEV-ES jump table pointer -- push

### DIFF
--- a/UefiCpuPkg/Library/MpInitLib/MpLib.c
+++ b/UefiCpuPkg/Library/MpInitLib/MpLib.c
@@ -1265,7 +1265,7 @@ SetSevEsJumpTable (
   UINT32            Offset, InsnByte;
   UINT8             LoNib, HiNib;
 
-  JmpFar = (SEV_ES_AP_JMP_FAR *) FixedPcdGet32 (PcdSevEsWorkAreaBase);
+  JmpFar = (SEV_ES_AP_JMP_FAR *) (UINTN) FixedPcdGet32 (PcdSevEsWorkAreaBase);
   ASSERT (JmpFar != NULL);
 
   //


### PR DESCRIPTION
https://bugzilla.tianocore.org/show_bug.cgi?id=3385
https://edk2.groups.io/g/devel/message/74878
https://listman.redhat.com/archives/edk2-devel-archive/2021-May/msg00194.html
msgid: c89bc819856d448360430c32cb3833a9667f987b.1620656694.git.thomas.lendacky@amd.com
~~~
BZ: https://bugzilla.tianocore.org/show_bug.cgi?id=3385

A VS2012 build fails with a cast conversion warning when the SEV-ES work
area PCD is cast as a pointer to the SEV_ES_AP_JMP_FAR type.

When casting from a PCD value to a pointer, the cast should first be done
to a UINTN and then to the pointer. Update the code to perform a cast to
a UINTN before casting to a pointer to the SEV_ES_AP_JMP_FAR type.

Cc: Eric Dong <eric.dong@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Cc: Laszlo Ersek <lersek@redhat.com>
Cc: Rahul Kumar <rahul1.kumar@intel.com>
Signed-off-by: Tom Lendacky <thomas.lendacky@amd.com>
---
 UefiCpuPkg/Library/MpInitLib/MpLib.c | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
~~~