### PR TITLE
BaseTools: Add support for version 3 of FMP Image Header structure

### DIFF
--- a/BaseTools/Source/Python/Capsule/GenerateCapsule.py
+++ b/BaseTools/Source/Python/Capsule/GenerateCapsule.py
@@ -561,6 +561,7 @@ if __name__ == '__main__':
                 print ('GenerateCapsule: error:' + str(Msg))
                 sys.exit (1)
         for SinglePayloadDescriptor in PayloadDescriptorList:
+            ImageCapsuleSupport = 0x0000000000000000
             Result = SinglePayloadDescriptor.Payload
             try:
                 FmpPayloadHeader.FwVersion              = SinglePayloadDescriptor.FwVersion
@@ -575,6 +576,7 @@ if __name__ == '__main__':
             if SinglePayloadDescriptor.UseDependency:
                 CapsuleDependency.Payload = Result
                 CapsuleDependency.DepexExp = SinglePayloadDescriptor.DepexExp
+                ImageCapsuleSupport        |= FmpCapsuleHeader.CAPSULE_SUPPORT_DEPENDENCY
                 Result = CapsuleDependency.Encode ()
                 if args.Verbose:
                     CapsuleDependency.DumpInfo ()
@@ -607,13 +609,14 @@ if __name__ == '__main__':
                     FmpAuthHeader.MonotonicCount = SinglePayloadDescriptor.MonotonicCount
                     FmpAuthHeader.CertData       = CertData
                     FmpAuthHeader.Payload        = Result
+                    ImageCapsuleSupport          |= FmpCapsuleHeader.CAPSULE_SUPPORT_AUTHENTICATION
                     Result = FmpAuthHeader.Encode ()
                     if args.Verbose:
                         FmpAuthHeader.DumpInfo ()
                 except:
                     print ('GenerateCapsule: error: can not encode FMP Auth Header')
                     sys.exit (1)
-            FmpCapsuleHeader.AddPayload (SinglePayloadDescriptor.Guid, Result, HardwareInstance = SinglePayloadDescriptor.HardwareInstance, UpdateImageIndex = SinglePayloadDescriptor.UpdateImageIndex)
+            FmpCapsuleHeader.AddPayload (SinglePayloadDescriptor.Guid, Result, HardwareInstance = SinglePayloadDescriptor.HardwareInstance, UpdateImageIndex = SinglePayloadDescriptor.UpdateImageIndex, CapsuleSupport = ImageCapsuleSupport)
         try:
             for EmbeddedDriver in EmbeddedDriverDescriptorList:
                 FmpCapsuleHeader.AddEmbeddedDriver(EmbeddedDriver)


### PR DESCRIPTION
Add support for the ImageCapsuleSupport field, introduced in version 3
of the EFI_FIRMWARE_MANAGEMENT_CAPSULE_IMAGE_HEADER structure. This
structure member is used to indicate if the corresponding payload has
support for authentication and dependency.

Signed-off-by: Sughosh Ganu <sughosh.ganu@linaro.org>
Reviewed-by: Michael D Kinney <michael.d.kinney@intel.com>
Reviewed-by: Bob Feng <bob.c.feng@intel.com>