### PR TITLE
[edk2-devel] [PATCH v1 0/2] "maybe-uninitialized" warnings emitted by -- push

### DIFF
--- a/OvmfPkg/VirtioFsDxe/SimpleFsOpen.c
+++ b/OvmfPkg/VirtioFsDxe/SimpleFsOpen.c
@@ -333,6 +333,12 @@ VirtioFsSimpleFileOpen (
   }
 
   //
+  // Set CreateDirectoryIfCreating to suppress incorrect compiler/analyzer
+  // warnings.
+  //
+  CreateDirectoryIfCreating = FALSE;
+
+  //
   // Validate the Attributes requested for the case when the file ends up being
   // created, provided creation is permitted.
   //
@@ -425,6 +431,11 @@ VirtioFsSimpleFileOpen (
   if (EFI_ERROR (Status)) {
     goto FreeNewCanonicalPath;
   }
+
+  //
+  // Set NewNodeIsDirectory to suppress incorrect compiler/analyzer warnings.
+  //
+  NewNodeIsDirectory = FALSE;
 
   //
   // Try to open LastComponent directly under DirNodeId, as an existent regular

--- a/ShellPkg/Library/UefiShellCommandLib/UefiShellCommandLib.c
+++ b/ShellPkg/Library/UefiShellCommandLib/UefiShellCommandLib.c
@@ -2129,6 +2129,11 @@ ShellSortFileList (
   }
 
   //
+  // Set Dupes to suppress incorrect compiler/analyzer warnings.
+  //
+  Dupes = NULL;
+
+  //
   // If separation of duplicates has been requested, allocate the list for
   // them.
   //


### PR DESCRIPTION
https://bugzilla.tianocore.org/show_bug.cgi?id=3228
https://edk2.groups.io/g/devel/message/75045
https://listman.redhat.com/archives/edk2-devel-archive/2021-May/msg00411.html
msgid: <20210511225616.5942-1-sergei@posteo.net>
~~~
Compiling for IA32 target with gcc-5.5.0 emits "maybe-uninitialized" warnings.
Compilation command: build -a IA32 -p OvmfPkg/OvmfPkgIa32.dsc -t GCC49

Sergei Dmitrouk (2):
  ShellPkg/UefiShellCommandLib: suppress incorrect gcc warning
  OvmfPkg/VirtioFsDxe: suppress incorrect gcc warnings

 OvmfPkg/VirtioFsDxe/SimpleFsOpen.c                    | 11 +++++++++++
 .../Library/UefiShellCommandLib/UefiShellCommandLib.c |  5 +++++
 2 files changed, 16 insertions(+)
~~~