### PR TITLE
[edk2-devel] [PATCH] UefiCpuPkg/CpuExceptionHandler: Add missing comma to exception name array -- push

### DIFF
--- a/UefiCpuPkg/Library/CpuExceptionHandlerLib/CpuExceptionCommon.c
+++ b/UefiCpuPkg/Library/CpuExceptionHandlerLib/CpuExceptionCommon.c
@@ -44,7 +44,7 @@ CONST CHAR8 *mExceptionNameStr[] = {
   "#MC - Machine-Check",
   "#XM - SIMD floating-point",
   "#VE - Virtualization",
-  "#CP - Control Protection"
+  "#CP - Control Protection",
   "Reserved",
   "Reserved",
   "Reserved",


### PR DESCRIPTION
https://bugzilla.tianocore.org/show_bug.cgi?id=3373
https://edk2.groups.io/g/devel/message/75097
https://listman.redhat.com/archives/edk2-devel-archive/2021-May/msg00413.html
msgid: <40e55bf6563ed8ea4962a1219efbe1ab77a56cc4.1620919615.git.thomas.lendacky@amd.com>
~~~
BZ: https://bugzilla.tianocore.org/show_bug.cgi?id=3373

An update to expand the mExceptionNameStr array failed to add a comma
after original last entry, therefore causing the #CP name to have extra
incorrect characters and the remaining entries to be indexed incorrectly
(off by 1).

Add a comma after the "#CP" entry to resolve this issue.

Fixes: 5277540e37e88a1a69f9517c4ad895051b4b3ed3
Cc: Allen Wynn <Allen_Wynn@Dell.com>
Cc: Eric Dong <eric.dong@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Cc: Laszlo Ersek <lersek@redhat.com>
Cc: Rahul Kumar <rahul1.kumar@intel.com>
Signed-off-by: Tom Lendacky <thomas.lendacky@amd.com>
---
 UefiCpuPkg/Library/CpuExceptionHandlerLib/CpuExceptionCommon.c | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
~~~