### PR TITLE
BaseTools: build: Set ReturnCode on POSTBUILD fail

### DIFF
--- a/BaseTools/Source/Python/build/build.py
+++ b/BaseTools/Source/Python/build/build.py
@@ -2757,6 +2757,7 @@ def Main():
             Conclusion = "Done"
         except:
             Conclusion = "Failed"
+            ReturnCode = POSTBUILD_ERROR
     elif ReturnCode == ABORT_ERROR:
         Conclusion = "Aborted"
     else:


### PR DESCRIPTION
When build.by POSTBUILD handling section returns other than 0, set
ReturnCode to POSTBUILD_ERROR so build.py exits with return code other
than 0.

Fix for https://bugzilla.tianocore.org/show_bug.cgi?id=1977

Cc: Bob Feng <bob.c.feng@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Yuwei Chen <yuwei.chen@intel.com>

Signed-off-by: Garrett Kirkendall <garrett.kirkendall@amd.com>