### PR TITLE
BaseTools: Add DTCPP_FLAGS for GCC5 RISCV64 toolchain

### DIFF
--- a/BaseTools/Conf/tools_def.template
+++ b/BaseTools/Conf/tools_def.template
@@ -2458,6 +2458,7 @@ RELEASE_GCC5_AARCH64_DLINK_XIPFLAGS = -z common-page-size=0x20
 *_GCC5_RISCV64_DLINK2_FLAGS         = DEF(GCC5_RISCV64_DLINK2_FLAGS)
 *_GCC5_RISCV64_RC_FLAGS             = DEF(GCC_RISCV64_RC_FLAGS)
 *_GCC5_RISCV64_OBJCOPY_FLAGS        =
+*_GCC5_RISCV64_DTCPP_FLAGS          = DEF(GCC_DTCPP_FLAGS)
 
 ####################################################################################
 #


### PR DESCRIPTION
Some/all platforms are going to require EDK2 to build a device tree and
use it in the early stages of boot.

Cc: Bob Feng <bob.c.feng@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Yuwei Chen <yuwei.chen@intel.com>
Cc: Abner Chang <abner.chang@hpe.com>
Signed-off-by: Daniel Schaefer <daniel.schaefer@hpe.com>
Reviewed-by: Abner Chang <abner.chang@hpe.com>
Reviewed-by: Bob Feng <bob.c.feng@intel.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>