### PR TITLE
IntelFsp2Pkg: YAML script bug fix

### DIFF
--- a/IntelFsp2Pkg/Tools/FspDscBsf2Yaml.py
+++ b/IntelFsp2Pkg/Tools/FspDscBsf2Yaml.py
@@ -46,6 +46,13 @@ def Bytes2Val(Bytes):
     return reduce(lambda x, y: (x << 8) | y, Bytes[::-1])
 
 
+def Str2Bytes(Value, Blen):
+    Result = bytearray(Value[1:-1], 'utf-8')  # Excluding quotes
+    if len(Result) < Blen:
+        Result.extend(b'\x00' * (Blen - len(Result)))
+    return Result
+
+
 class CFspBsf2Dsc:
 
     def __init__(self, bsf_file):
@@ -108,7 +115,8 @@ class CFspBsf2Dsc:
                 cfg_item['find'] = prefix
                 cfg_item['cname'] = 'Signature'
                 cfg_item['length'] = len(finds[0][1])
-                cfg_item['value'] = '0x%X' % Bytes2Val(finds[0][1].encode('UTF-8'))
+                str2byte = Str2Bytes("'" + finds[0][1] + "'", len(finds[0][1]))
+                cfg_item['value'] = '0x%X' % Bytes2Val(str2byte)
                 cfg_list.append(dict(cfg_item))
                 cfg_item = dict(cfg_temp)
                 find_list.pop(0)
@@ -291,7 +299,6 @@ class CFspDsc2Yaml():
                 raise Exception('DSC variable creation error !')
         else:
             raise Exception('Unsupported file "%s" !' % file_name)
-        gen_cfg_data.UpdateDefaultValue()
         self.gen_cfg_data = gen_cfg_data
 
     def print_dsc_line(self):

--- a/IntelFsp2Pkg/Tools/GenCfgOpt.py
+++ b/IntelFsp2Pkg/Tools/GenCfgOpt.py
@@ -708,7 +708,8 @@ EndList
                             for Page in PageList:
                                 Page  = Page.strip()
                                 Match = re.match("(\w+):\"(.+)\"", Page)
-                                self._CfgPageDict[Match.group(1)] = Match.group(2)
+                                if Match != None:
+                                    self._CfgPageDict[Match.group(1)] = Match.group(2)
 
                         Match = re.match("(?:^|.+\s+)BLOCK:{NAME:\"(.+)\"\s*,\s*VER:\"(.+)\"\s*}", Remaining)
                         if Match:


### PR DESCRIPTION
REF:https://bugzilla.tianocore.org/show_bug.cgi?id=3395

This patch fixes the issue observed during
BSF file to YAML file conversion. It also
addresses the issue during multibyte array
data conversion check, for example the data
representation of 0xFFFF instead of 0xFF, 0xFF
would be thrown exception "Array size is not
proper" without this patch.

Cc: Maurice Ma <maurice.ma@intel.com>
Cc: Nate DeSimone <nathaniel.l.desimone@intel.com>
Cc: Star Zeng <star.zeng@intel.com>
Cc: Chasel Chiu <chasel.chiu@intel.com>
Signed-off-by: Loo Tung Lun <tung.lun.loo@intel.com>
Reviewed-by: Chasel Chiu <chasel.chiu@intel.com>