### PR TITLE
Fix possible uninitialized uses

### DIFF
--- a/CryptoPkg/Library/BaseCryptLib/Pk/CryptRsaPss.c
+++ b/CryptoPkg/Library/BaseCryptLib/Pk/CryptRsaPss.c
@@ -82,6 +82,7 @@ RsaPssVerify (
   EVP_PKEY_CTX *KeyCtx;
   CONST EVP_MD  *HashAlg;
 
+  Result = FALSE;
   EvpRsaKey = NULL;
   EvpVerifyCtx = NULL;
   KeyCtx = NULL;

--- a/CryptoPkg/Library/BaseCryptLib/Pk/CryptRsaPssSign.c
+++ b/CryptoPkg/Library/BaseCryptLib/Pk/CryptRsaPssSign.c
@@ -97,6 +97,7 @@ RsaPssSign (
   EVP_PKEY_CTX          *KeyCtx;
   CONST EVP_MD          *HashAlg;
 
+  Result = FALSE;
   EvpRsaKey = NULL;
   EvpVerifyCtx = NULL;
   KeyCtx = NULL;

--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciLib.c
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciLib.c
@@ -1778,10 +1778,9 @@ PciProgramResizableBar (
 
     if (ResizableBarOp == PciResizableBarMax) {
       Bit = HighBitSet64(Capabilities);
-    } else if (ResizableBarOp == PciResizableBarMin) {
-      Bit = LowBitSet64(Capabilities);
     } else {
-      ASSERT ((ResizableBarOp == PciResizableBarMax) || (ResizableBarOp == PciResizableBarMin));
+      ASSERT (ResizableBarOp == PciResizableBarMin);
+      Bit = LowBitSet64(Capabilities);
     }
 
     ASSERT (Bit >= 0);

--- a/ShellPkg/DynamicCommand/HttpDynamicCommand/Http.c
+++ b/ShellPkg/DynamicCommand/HttpDynamicCommand/Http.c
@@ -1524,6 +1524,7 @@ GetResponse (
   Context->ResponseToken.Message = &ResponseMessage;
   Context->ContentLength = 0;
   Context->Status = REQ_OK;
+  Status = EFI_SUCCESS;
   MsgParser = NULL;
   ResponseData.StatusCode = HTTP_STATUS_UNSUPPORTED_STATUS;
   ResponseMessage.Data.Response = &ResponseData;


### PR DESCRIPTION
Compiling for IA32 target with gcc-5.5.0 emits "maybe-uninitialized" warnings.
Compilation command: build -a IA32 -p OvmfPkg/OvmfPkgIa32.dsc -t GCC49

Unlike other cases mentioned in
https://bugzilla.tianocore.org/show_bug.cgi?id=3228
these seem to be actual issues in the code.  Read patches for specifics.
