### PR TITLE
MdeModulePkg/PlatformDriOverrideDxe: Fix overflow condition check

### DIFF
--- a/MdeModulePkg/Universal/PlatformDriOverrideDxe/PlatDriOverrideLib.c
+++ b/MdeModulePkg/Universal/PlatformDriOverrideDxe/PlatDriOverrideLib.c
@@ -776,7 +776,7 @@ InitOverridesMapping (
         // Check buffer overflow
         //
         if ((DriverImageInfo->DriverImagePath == NULL) || (VariableIndex < (UINT8 *) DriverDevicePath) ||
-            (VariableIndex < (UINT8 *) VariableBuffer + BufferSize)) {
+            (VariableIndex > (UINT8 *) VariableBuffer + BufferSize)) {
           Corrupted = TRUE;
           break;
         }


### PR DESCRIPTION
Code mistake, VariableIndex is smaller normally than buffer+buffersize
so should not break loop.

Signed-off-by: Walon Li <walon.li@hpe.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>