### PR TITLE
[edk2-stable202105 PATCH] MdeModulePkg/VariableLock: downgrade compatibility warnings to DEBUG_WARN -- push

### DIFF
--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableLockRequestToLock.c
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableLockRequestToLock.c
@@ -48,9 +48,9 @@ VariableLockRequestToLock (
   EFI_STATUS             Status;
   VARIABLE_POLICY_ENTRY  *NewPolicy;
 
-  DEBUG ((DEBUG_ERROR, "!!! DEPRECATED INTERFACE !!! %a() will go away soon!\n", __FUNCTION__));
-  DEBUG ((DEBUG_ERROR, "!!! DEPRECATED INTERFACE !!! Please move to use Variable Policy!\n"));
-  DEBUG ((DEBUG_ERROR, "!!! DEPRECATED INTERFACE !!! Variable: %g %s\n", VendorGuid, VariableName));
+  DEBUG ((DEBUG_WARN, "!!! DEPRECATED INTERFACE !!! %a() will go away soon!\n", __FUNCTION__));
+  DEBUG ((DEBUG_WARN, "!!! DEPRECATED INTERFACE !!! Please move to use Variable Policy!\n"));
+  DEBUG ((DEBUG_WARN, "!!! DEPRECATED INTERFACE !!! Variable: %g %s\n", VendorGuid, VariableName));
 
   NewPolicy = NULL;
   Status = CreateBasicVariablePolicy(
@@ -69,13 +69,13 @@ VariableLockRequestToLock (
     //
     // If the error returned is EFI_ALREADY_STARTED, we need to check the
     // current database for the variable and see whether it's locked. If it's
-    // locked, we're still fine, but also generate a DEBUG_ERROR message so the
+    // locked, we're still fine, but also generate a DEBUG_WARN message so the
     // duplicate lock can be removed.
     //
     if (Status == EFI_ALREADY_STARTED) {
       Status = ValidateSetVariable (VariableName, VendorGuid, 0, 0, NULL);
       if (Status == EFI_WRITE_PROTECTED) {
-        DEBUG ((DEBUG_ERROR, "  Variable: %g %s is already locked!\n", VendorGuid, VariableName));
+        DEBUG ((DEBUG_WARN, "  Variable: %g %s is already locked!\n", VendorGuid, VariableName));
         Status = EFI_SUCCESS;
       } else {
         DEBUG ((DEBUG_ERROR, "  Variable: %g %s can not be locked!\n", VendorGuid, VariableName));


### PR DESCRIPTION
https://bugzilla.tianocore.org/show_bug.cgi?id=3410
Message-Id: <20210521204037.11980-1-lersek@redhat.com>
https://listman.redhat.com/archives/edk2-devel-archive/2021-May/msg00764.html
https://edk2.groups.io/g/devel/message/75449
~~~
Commit a18a9bde36d2 ("MdeModulePkg/Variable/RuntimeDxe: Restore Variable
Lock Protocol behavior", 2020-12-15), for bug 3111, added two such sets of
debug messages that:

(a) are relevant for developers,

(b) yet should not necessarily poke end-users, because no functionality
suffers in practice.

Both message sets are in function VariableLockRequestToLock(): the first
is a generic interface deprecation warning; the second is the
double-locking situation, which we permit for compatibility (return status
EFI_SUCCESS).

Both message sets should be emitted with the DEBUG_WARN mask, not the most
serious DEBUG_ERROR mask. On some platforms, the serial console carries
both terminal traffic, and grave (DEBUG_ERROR-only) log messages. On such
platforms, both message sets may be perceived as a nuisance by end-users,
as there is nothing they can do, and there's nothing they *should* do --
in practice, nothing malfunctions.

(Such a platform is ArmVirtQemu, built with "-D
DEBUG_PRINT_ERROR_LEVEL=0x80000000".)

Cc: Bret Barkelew <bret.barkelew@microsoft.com>
Cc: Hao A Wu <hao.a.wu@intel.com>
Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Philippe Mathieu-Daudé <philmd@redhat.com>
Ref: https://bugzilla.tianocore.org/show_bug.cgi?id=3410
Fixes: a18a9bde36d2ffc12df29cdced1efa1f8f9f2021
Signed-off-by: Laszlo Ersek <lersek@redhat.com>
---
 MdeModulePkg/Universal/Variable/RuntimeDxe/VariableLockRequestToLock.c | 10 +++++-----
 1 file changed, 5 insertions(+), 5 deletions(-)
~~~