### PR TITLE
MdePkg: MmControl: Fix function and structure definition mismatches

### DIFF
--- a/MdePkg/Include/Ppi/MmControl.h
+++ b/MdePkg/Include/Ppi/MmControl.h
@@ -69,7 +69,7 @@ EFI_STATUS
 **/
 typedef
 EFI_STATUS
-(EFIAPI *PEI_MM_DEACTIVATE) (
+(EFIAPI *EFI_PEI_MM_DEACTIVATE) (
   IN EFI_PEI_SERVICES                      **PeiServices,
   IN EFI_PEI_MM_CONTROL_PPI                * This,
   IN BOOLEAN                               Periodic OPTIONAL
@@ -80,9 +80,9 @@ EFI_STATUS
 ///  platform hardware that generates an MMI. There are often I/O ports that, when accessed, will
 ///  generate the MMI. Also, the hardware optionally supports the periodic generation of these signals.
 ///
-struct _PEI_MM_CONTROL_PPI {
-  PEI_MM_ACTIVATE    Trigger;
-  PEI_MM_DEACTIVATE  Clear;
+struct _EFI_PEI_MM_CONTROL_PPI {
+  EFI_PEI_MM_ACTIVATE    Trigger;
+  EFI_PEI_MM_DEACTIVATE  Clear;
 };
 
 extern EFI_GUID gEfiPeiMmControlPpiGuid;


### PR DESCRIPTION
Current Ppi/MmControl.h file has structure definition of "struct
_PEI_MM_CONTROL_PPI". This name mismatches with its definition in PI
Specification v1.7 (Errata) as "struct _EFI_PEI_MM_CONTROL_PPI".

In addition, field types "PEI_MM_ACTIVATE" and "PEI_MM_DEACTIVATE" used
in "struct _PEI_MM_CONTROL_PPI" mismatches with the definition of
"EFI_PEI_MM_ACTIVATE" and "EFI_PEI_MM_DEACTIVATE" in the PI spec.

This change fixes these mismatches by using the PI spec defined names.

Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Zhiguang Liu <zhiguang.liu@intel.com>

Fixes: 6f33f7a262314af35e2b99c849e08928ea49aa55
Signed-off-by: Kun Qin <kuqin12@gmail.com>