### PR TITLE
[edk2-devel] [PATCH] Maintainers.txt: add Sami Mujawar as top-level ArmVirtPkg reviewer -- push

### DIFF
--- a/Maintainers.txt
+++ b/Maintainers.txt
@@ -146,6 +146,7 @@ W: https://github.com/tianocore/tianocore.github.io/wiki/ArmVirtPkg
 M: Laszlo Ersek <lersek@redhat.com>
 M: Ard Biesheuvel <ardb+tianocore@kernel.org>
 R: Leif Lindholm <leif@nuviainc.com>
+R: Sami Mujawar <sami.mujawar@arm.com>
 
 ArmVirtPkg: modules used on Xen
 F: ArmVirtPkg/ArmVirtXen.*
@@ -156,16 +157,6 @@ F: ArmVirtPkg/XenAcpiPlatformDxe/
 F: ArmVirtPkg/XenPlatformHasAcpiDtDxe/
 F: ArmVirtPkg/XenioFdtDxe/
 R: Julien Grall <julien@xen.org>
-
-ArmVirtPkg: Kvmtool emulated platform support
-F: ArmVirtPkg/ArmVirtKvmTool.*
-F: ArmVirtPkg/KvmtoolPlatformDxe/
-F: ArmVirtPkg/Library/Fdt16550SerialPortHookLib/
-F: ArmVirtPkg/Library/KvmtoolPlatformPeiLib/
-F: ArmVirtPkg/Library/KvmtoolRtcFdtClientLib/
-F: ArmVirtPkg/Library/KvmtoolVirtMemInfoLib/
-F: ArmVirtPkg/Library/NorFlashKvmtoolLib/
-R: Sami Mujawar <sami.mujawar@arm.com>
 
 BaseTools
 F: BaseTools/


### PR DESCRIPTION
https://edk2.groups.io/g/devel/message/75116
https://listman.redhat.com/archives/edk2-devel-archive/2021-May/msg00432.html
msgid: <20210514114857.12286-1-lersek@redhat.com>
~~~
For distributing ArmVirtPkg patch review tasks better, move Sami Mujawar
from the "ArmVirtPkg: Kvmtool" section to the top-level "ArmVirtPkg"
section.

Given that "ArmVirtPkg: Kvmtool" remains without a specific "R" role,
remove "ArmVirtPkg: Kvmtool" altogether.

Cc: Andrew Fish <afish@apple.com>
Cc: Ard Biesheuvel <ardb+tianocore@kernel.org>
Cc: Julien Grall <julien@xen.org>
Cc: Leif Lindholm <leif@nuviainc.com>
Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Philippe Mathieu-Daudé <philmd@redhat.com>
Cc: Sami Mujawar <sami.mujawar@arm.com>
Signed-off-by: Laszlo Ersek <lersek@redhat.com>
---
 Maintainers.txt | 11 +----------
 1 file changed, 1 insertion(+), 10 deletions(-)
~~~