### PR TITLE
EmbeddedPkg/RealTimeClockRuntimeDxe: Improve GetWakeupTime

### DIFF
--- a/EmbeddedPkg/RealTimeClockRuntimeDxe/RealTimeClock.c
+++ b/EmbeddedPkg/RealTimeClockRuntimeDxe/RealTimeClock.c
@@ -143,6 +143,17 @@ GetWakeupTime (
   OUT EFI_TIME    *Time
   )
 {
+  if (Time == NULL || Enabled == NULL || Pending == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  //
+  // Set these first so the RealTimeClockLib implementation
+  // can override them based on its own settings.
+  //
+  Time->TimeZone = mTimeSettings.TimeZone;
+  Time->Daylight = mTimeSettings.Daylight;
+
   return LibGetWakeupTime (Enabled, Pending, Time);
 }
 


### PR DESCRIPTION
GetWakeupTime should return full time information, including
the daylight/timezone. Make use of the existing non-volatile
variables for that purpose. Moreover add an error checking
of possibly invalid parameters.
This partially fixes FWTS and SCT Set/GetWakeupTime tests on
Marvell platforms.

Signed-off-by: Marcin Wojtas <mw@semihalf.com>
Reviewed-by: Ard Biesheuvel <ardb@kernel.org>