### PR TITLE
[edk2-devel] [PATCH v2 1/1] Add missing EFIAPI to VirtioMmioSetQueueAddress -- push

### DIFF
--- a/OvmfPkg/Library/VirtioMmioDeviceLib/VirtioMmioDevice.h
+++ b/OvmfPkg/Library/VirtioMmioDeviceLib/VirtioMmioDevice.h
@@ -107,6 +107,7 @@ VirtioMmioSetQueueSel (
   );
 
 EFI_STATUS
+EFIAPI
 VirtioMmioSetQueueAddress (
   IN VIRTIO_DEVICE_PROTOCOL  *This,
   IN VRING                   *Ring,

--- a/OvmfPkg/Library/VirtioMmioDeviceLib/VirtioMmioDeviceFunctions.c
+++ b/OvmfPkg/Library/VirtioMmioDeviceLib/VirtioMmioDeviceFunctions.c
@@ -173,6 +173,7 @@ VirtioMmioSetQueueSel (
 }
 
 EFI_STATUS
+EFIAPI
 VirtioMmioSetQueueAddress (
   IN VIRTIO_DEVICE_PROTOCOL  *This,
   IN VRING                   *Ring,


### PR DESCRIPTION
https://edk2.groups.io/g/devel/message/75937
https://listman.redhat.com/archives/edk2-devel-archive/2021-June/msg00054.html
msgid: <20210602045935.762211-1-kraxel@redhat.com>
~~~
This error was found while compiling VirtioMmioDeviceLib for X64
with the GCC5 toolchain, where EFIAPI makes a difference.

Signed-off-by: Gerd Hoffmann <kraxel@redhat.com>
---
 OvmfPkg/Library/VirtioMmioDeviceLib/VirtioMmioDevice.h          | 1 +
 OvmfPkg/Library/VirtioMmioDeviceLib/VirtioMmioDeviceFunctions.c | 1 +
 2 files changed, 2 insertions(+)
~~~