### PR TITLE
MdePkg/BaseLib: Fix AsmReadSs() with GCC toolchain

### DIFF
--- a/MdePkg/Library/BaseLib/Ia32/GccInlinePriv.c
+++ b/MdePkg/Library/BaseLib/Ia32/GccInlinePriv.c
@@ -902,7 +902,7 @@ AsmReadSs (
   UINT16  Data;
 
   __asm__ __volatile__ (
-    "mov  %%ds, %0"
+    "mov  %%ss, %0"
     :"=a" (Data)
     );
 

--- a/MdePkg/Library/BaseLib/X64/GccInlinePriv.c
+++ b/MdePkg/Library/BaseLib/X64/GccInlinePriv.c
@@ -911,7 +911,7 @@ AsmReadSs (
   UINT16  Data;
 
   __asm__ __volatile__ (
-    "mov  %%ds, %0"
+    "mov  %%ss, %0"
     :"=a" (Data)
     );
 


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3405

AsmReadSs() in Ia32/GccInlinePriv.c and X64/GccInlinePriv.c return the
DS segment selector value instead of SS.

Signed-off-by: Satoshi Tanda <tanda.sat@gmail.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>
Reviewed-by: Laszlo Ersek <lersek@redhat.com>