### PR TITLE
BaseTools GenFw: Fix regression issue to convert the image to ACPI data

### DIFF
--- a/BaseTools/Source/C/GenFw/Elf32Convert.c
+++ b/BaseTools/Source/C/GenFw/Elf32Convert.c
@@ -435,7 +435,7 @@ ScanSections32 (
     }
   }
 
-  if (!FoundSection) {
+  if (!FoundSection && mOutImageType != FW_ACPI_IMAGE) {
     Error (NULL, 0, 3000, "Invalid", "Did not find any '.text' section.");
     assert (FALSE);
   }

--- a/BaseTools/Source/C/GenFw/Elf64Convert.c
+++ b/BaseTools/Source/C/GenFw/Elf64Convert.c
@@ -714,7 +714,7 @@ ScanSections64 (
     }
   }
 
-  if (!FoundSection) {
+  if (!FoundSection && mOutImageType != FW_ACPI_IMAGE) {
     Error (NULL, 0, 3000, "Invalid", "Did not find any '.text' section.");
     assert (FALSE);
   }


### PR DESCRIPTION
Commit c6b872c updates GenFw base code attribute to find .text section.
With GCC49 tool chain, aslc file is compiled into elf image.
But, its text section has no CODE attribute. So, it can't be detected
by new GenFw tool.For this type file. its text section is not required.
Its data section will be converted to acpi table.

This fix is to remove assert check when the generated image is ACPI data.

Signed-off-by: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Ray Ni <ray.ni@intel.com>
Cc: Leif Lindholm <leif@nuviainc.com>
Cc: Bob Feng <bob.c.feng@intel.com>
Reviewed-by: Bob Feng <bob.c.feng@intel.com>
Tested-by: Leif Lindholm <leif@nuviainc.com>