### PR TITLE
[edk2-devel] [PATCH v2] OvmfPkg/README: Fix typo in README -- push

### DIFF
--- a/OvmfPkg/README
+++ b/OvmfPkg/README
@@ -59,7 +59,7 @@ https://github.com/tianocore/tianocore.github.io/wiki/How%20to%20build%20OVMF
 
 === RUNNING OVMF on QEMU ===
 
-* Be sure to use qemu-system-x86_64, if you are using and X64 firmware.
+* Be sure to use qemu-system-x86_64, if you are using an X64 firmware.
   (qemu-system-x86_64 works for the IA32 firmware as well, of course.)
 * Use OVMF for QEMU firmware (3 options available)
   - Option 1: Use QEMU -pflash parameter


### PR DESCRIPTION
https://edk2.groups.io/g/devel/message/76102
https://listman.redhat.com/archives/edk2-devel-archive/2021-June/msg00222.html
msgid: <20210605171712.GA16976@kaaira-HP-Pavilion-Notebook>
~~~
Fix typographical error in the OvmfPkg/README by correcting the 'an'
mistyped as 'and'.

Cc: Laszlo Ersek <lersek@redhat.com>
Cc: Ard Biesheuvel <ardb+tianocore@kernel.org>
Cc: Jordan Justen <jordan.l.justen@intel.com>
Cc: mikuback@linux.microsoft.com
Cc: ray.ni@intel.com
Signed-off-by: Kaaira Gupta <kaaira7319@gmail.com>
---
Changes in v2:
	- Rebase on commit ae4aa4a
	- Improve commit message.

 OvmfPkg/README | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
~~~