### PR TITLE
[edk2-devel] [PUBLIC edk2 PATCH v2 00/10] NetworkPkg/IScsiDxe: fix IScsiHexToBin() security and functionality bugs -- personal build with PlatformCI fix

### DIFF
--- a/NetworkPkg/IScsiDxe/IScsiCHAP.c
+++ b/NetworkPkg/IScsiDxe/IScsiCHAP.c
@@ -122,7 +122,7 @@ IScsiCHAPAuthTarget (
              AuthData->AuthConfig->ReverseCHAPSecret,
              SecretSize,
              AuthData->OutChallenge,
-             AuthData->OutChallengeLength,
+             ISCSI_CHAP_RSP_LEN,                      // ChallengeLength
              VerifyRsp
              );
 
@@ -490,7 +490,6 @@ IScsiCHAPToSendReq (
       // CHAP_C=<C>
       //
       IScsiGenRandom ((UINT8 *) AuthData->OutChallenge, ISCSI_CHAP_RSP_LEN);
-      AuthData->OutChallengeLength = ISCSI_CHAP_RSP_LEN;
       IScsiBinToHex (
         (UINT8 *) AuthData->OutChallenge,
         ISCSI_CHAP_RSP_LEN,

--- a/NetworkPkg/IScsiDxe/IScsiCHAP.c
+++ b/NetworkPkg/IScsiDxe/IScsiCHAP.c
@@ -289,7 +289,7 @@ IScsiCHAPOnRspReceived (
     }
 
     AuthData->InIdentifier      = (UINT32) Result;
-    AuthData->InChallengeLength = ISCSI_CHAP_AUTH_MAX_LEN;
+    AuthData->InChallengeLength = (UINT32) sizeof (AuthData->InChallenge);
     IScsiHexToBin (
       (UINT8 *) AuthData->InChallenge,
       &AuthData->InChallengeLength,

--- a/NetworkPkg/IScsiDxe/IScsiCHAP.c
+++ b/NetworkPkg/IScsiDxe/IScsiCHAP.c
@@ -391,6 +391,7 @@ IScsiCHAPToSendReq (
   UINT32                      RspLen;
   CHAR8                       *Challenge;
   UINT32                      ChallengeLen;
+  EFI_STATUS                  BinToHexStatus;
 
   ASSERT (Conn->CurrentStage == ISCSI_SECURITY_NEGOTIATION);
 
@@ -471,12 +472,13 @@ IScsiCHAPToSendReq (
     //
     // CHAP_R=<R>
     //
-    IScsiBinToHex (
-      (UINT8 *) AuthData->CHAPResponse,
-      ISCSI_CHAP_RSP_LEN,
-      Response,
-      &RspLen
-      );
+    BinToHexStatus = IScsiBinToHex (
+                       (UINT8 *) AuthData->CHAPResponse,
+                       ISCSI_CHAP_RSP_LEN,
+                       Response,
+                       &RspLen
+                       );
+    ASSERT_EFI_ERROR (BinToHexStatus);
     IScsiAddKeyValuePair (Pdu, ISCSI_KEY_CHAP_RESPONSE, Response);
 
     if (AuthData->AuthConfig->CHAPType == ISCSI_CHAP_MUTUAL) {
@@ -490,12 +492,13 @@ IScsiCHAPToSendReq (
       // CHAP_C=<C>
       //
       IScsiGenRandom ((UINT8 *) AuthData->OutChallenge, ISCSI_CHAP_RSP_LEN);
-      IScsiBinToHex (
-        (UINT8 *) AuthData->OutChallenge,
-        ISCSI_CHAP_RSP_LEN,
-        Challenge,
-        &ChallengeLen
-        );
+      BinToHexStatus = IScsiBinToHex (
+                         (UINT8 *) AuthData->OutChallenge,
+                         ISCSI_CHAP_RSP_LEN,
+                         Challenge,
+                         &ChallengeLen
+                         );
+      ASSERT_EFI_ERROR (BinToHexStatus);
       IScsiAddKeyValuePair (Pdu, ISCSI_KEY_CHAP_CHALLENGE, Challenge);
 
       Conn->AuthStep = ISCSI_CHAP_STEP_FOUR;

--- a/NetworkPkg/IScsiDxe/IScsiCHAP.c
+++ b/NetworkPkg/IScsiDxe/IScsiCHAP.c
@@ -290,11 +290,15 @@ IScsiCHAPOnRspReceived (
 
     AuthData->InIdentifier      = (UINT32) Result;
     AuthData->InChallengeLength = (UINT32) sizeof (AuthData->InChallenge);
-    IScsiHexToBin (
-      (UINT8 *) AuthData->InChallenge,
-      &AuthData->InChallengeLength,
-      Challenge
-      );
+    Status = IScsiHexToBin (
+               (UINT8 *) AuthData->InChallenge,
+               &AuthData->InChallengeLength,
+               Challenge
+               );
+    if (EFI_ERROR (Status)) {
+      Status = EFI_PROTOCOL_ERROR;
+      goto ON_EXIT;
+    }
     Status = IScsiCHAPCalculateResponse (
                AuthData->InIdentifier,
                AuthData->AuthConfig->CHAPSecret,
@@ -337,7 +341,11 @@ IScsiCHAPOnRspReceived (
     }
 
     RspLen = ISCSI_CHAP_RSP_LEN;
-    IScsiHexToBin (TargetRsp, &RspLen, Response);
+    Status = IScsiHexToBin (TargetRsp, &RspLen, Response);
+    if (EFI_ERROR (Status) || RspLen != ISCSI_CHAP_RSP_LEN) {
+      Status = EFI_PROTOCOL_ERROR;
+      goto ON_EXIT;
+    }
 
     //
     // Check the CHAP Name and Response replied by Target.

--- a/NetworkPkg/IScsiDxe/IScsiCHAP.c
+++ b/NetworkPkg/IScsiDxe/IScsiCHAP.c
@@ -1,5 +1,6 @@
 /** @file
-  This file is for Challenge-Handshake Authentication Protocol (CHAP) Configuration.
+  This file is for Challenge-Handshake Authentication Protocol (CHAP)
+  Configuration.
 
 Copyright (c) 2004 - 2018, Intel Corporation. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -18,9 +19,11 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
   @param[in]   ChallengeLength    The length of iSCSI CHAP challenge message.
   @param[out]  ChapResponse       The calculation of the expected hash value.
 
-  @retval EFI_SUCCESS             The expected hash value was calculatedly successfully.
-  @retval EFI_PROTOCOL_ERROR      The length of the secret should be at least the
-                                  length of the hash value for the hashing algorithm chosen.
+  @retval EFI_SUCCESS             The expected hash value was calculatedly
+                                  successfully.
+  @retval EFI_PROTOCOL_ERROR      The length of the secret should be at least
+                                  the length of the hash value for the hashing
+                                  algorithm chosen.
   @retval EFI_PROTOCOL_ERROR      MD5 hash operation fail.
   @retval EFI_OUT_OF_RESOURCES    Fail to allocate resource to complete MD5.
 
@@ -94,8 +97,10 @@ Exit:
   @param[in]   AuthData             iSCSI CHAP authentication data.
   @param[in]   TargetResponse       The response from target.
 
-  @retval EFI_SUCCESS               The response from target passed authentication.
-  @retval EFI_SECURITY_VIOLATION    The response from target was not expected value.
+  @retval EFI_SUCCESS               The response from target passed
+                                    authentication.
+  @retval EFI_SECURITY_VIOLATION    The response from target was not expected
+                                    value.
   @retval Others                    Other errors as indicated.
 
 **/
@@ -193,7 +198,10 @@ IScsiCHAPOnRspReceived (
     //
     // The first Login Response.
     //
-    Value = IScsiGetValueByKeyFromList (KeyValueList, ISCSI_KEY_TARGET_PORTAL_GROUP_TAG);
+    Value = IScsiGetValueByKeyFromList (
+              KeyValueList,
+              ISCSI_KEY_TARGET_PORTAL_GROUP_TAG
+              );
     if (Value == NULL) {
       goto ON_EXIT;
     }
@@ -205,13 +213,17 @@ IScsiCHAPOnRspReceived (
 
     Session->TargetPortalGroupTag = (UINT16) Result;
 
-    Value                         = IScsiGetValueByKeyFromList (KeyValueList, ISCSI_KEY_AUTH_METHOD);
+    Value                         = IScsiGetValueByKeyFromList (
+                                      KeyValueList,
+                                      ISCSI_KEY_AUTH_METHOD
+                                      );
     if (Value == NULL) {
       goto ON_EXIT;
     }
     //
-    // Initiator mandates CHAP authentication but target replies without "CHAP", or
-    // initiator suggets "None" but target replies with some kind of auth method.
+    // Initiator mandates CHAP authentication but target replies without
+    // "CHAP", or initiator suggets "None" but target replies with some kind of
+    // auth method.
     //
     if (Session->AuthType == ISCSI_AUTH_TYPE_NONE) {
       if (AsciiStrCmp (Value, ISCSI_KEY_VALUE_NONE) != 0) {
@@ -236,7 +248,10 @@ IScsiCHAPOnRspReceived (
     //
     // The Target replies with CHAP_A=<A> CHAP_I=<I> CHAP_C=<C>
     //
-    Value = IScsiGetValueByKeyFromList (KeyValueList, ISCSI_KEY_CHAP_ALGORITHM);
+    Value = IScsiGetValueByKeyFromList (
+              KeyValueList,
+              ISCSI_KEY_CHAP_ALGORITHM
+              );
     if (Value == NULL) {
       goto ON_EXIT;
     }
@@ -249,12 +264,18 @@ IScsiCHAPOnRspReceived (
       goto ON_EXIT;
     }
 
-    Identifier = IScsiGetValueByKeyFromList (KeyValueList, ISCSI_KEY_CHAP_IDENTIFIER);
+    Identifier = IScsiGetValueByKeyFromList (
+                   KeyValueList,
+                   ISCSI_KEY_CHAP_IDENTIFIER
+                   );
     if (Identifier == NULL) {
       goto ON_EXIT;
     }
 
-    Challenge = IScsiGetValueByKeyFromList (KeyValueList, ISCSI_KEY_CHAP_CHALLENGE);
+    Challenge = IScsiGetValueByKeyFromList (
+                  KeyValueList,
+                  ISCSI_KEY_CHAP_CHALLENGE
+                  );
     if (Challenge == NULL) {
       goto ON_EXIT;
     }
@@ -269,7 +290,11 @@ IScsiCHAPOnRspReceived (
 
     AuthData->InIdentifier      = (UINT32) Result;
     AuthData->InChallengeLength = ISCSI_CHAP_AUTH_MAX_LEN;
-    IScsiHexToBin ((UINT8 *) AuthData->InChallenge, &AuthData->InChallengeLength, Challenge);
+    IScsiHexToBin (
+      (UINT8 *) AuthData->InChallenge,
+      &AuthData->InChallengeLength,
+      Challenge
+      );
     Status = IScsiCHAPCalculateResponse (
                AuthData->InIdentifier,
                AuthData->AuthConfig->CHAPSecret,
@@ -303,7 +328,10 @@ IScsiCHAPOnRspReceived (
       goto ON_EXIT;
     }
 
-    Response = IScsiGetValueByKeyFromList (KeyValueList, ISCSI_KEY_CHAP_RESPONSE);
+    Response = IScsiGetValueByKeyFromList (
+                 KeyValueList,
+                 ISCSI_KEY_CHAP_RESPONSE
+                 );
     if (Response == NULL) {
       goto ON_EXIT;
     }
@@ -341,7 +369,8 @@ ON_EXIT:
   @param[in, out]  Pdu         The PDU to send out.
 
   @retval EFI_SUCCESS           All check passed and the phase-related CHAP
-                                authentication info is filled into the iSCSI PDU.
+                                authentication info is filled into the iSCSI
+                                PDU.
   @retval EFI_OUT_OF_RESOURCES  Failed to allocate memory.
   @retval EFI_PROTOCOL_ERROR    Some kind of protocol error occurred.
 
@@ -392,7 +421,11 @@ IScsiCHAPToSendReq (
     // It's the initial Login Request. Fill in the key=value pairs mandatory
     // for the initial Login Request.
     //
-    IScsiAddKeyValuePair (Pdu, ISCSI_KEY_INITIATOR_NAME, mPrivate->InitiatorName);
+    IScsiAddKeyValuePair (
+      Pdu,
+      ISCSI_KEY_INITIATOR_NAME,
+      mPrivate->InitiatorName
+      );
     IScsiAddKeyValuePair (Pdu, ISCSI_KEY_SESSION_TYPE, "Normal");
     IScsiAddKeyValuePair (
       Pdu,
@@ -413,7 +446,8 @@ IScsiCHAPToSendReq (
 
   case ISCSI_CHAP_STEP_ONE:
     //
-    // First step, send the Login Request with CHAP_A=<A1,A2...> key-value pair.
+    // First step, send the Login Request with CHAP_A=<A1,A2...> key-value
+    // pair.
     //
     AsciiSPrint (ValueStr, sizeof (ValueStr), "%d", ISCSI_CHAP_ALGORITHM_MD5);
     IScsiAddKeyValuePair (Pdu, ISCSI_KEY_CHAP_ALGORITHM, ValueStr);
@@ -429,11 +463,20 @@ IScsiCHAPToSendReq (
     //
     // CHAP_N=<N>
     //
-    IScsiAddKeyValuePair (Pdu, ISCSI_KEY_CHAP_NAME, (CHAR8 *) &AuthData->AuthConfig->CHAPName);
+    IScsiAddKeyValuePair (
+      Pdu,
+      ISCSI_KEY_CHAP_NAME,
+      (CHAR8 *) &AuthData->AuthConfig->CHAPName
+      );
     //
     // CHAP_R=<R>
     //
-    IScsiBinToHex ((UINT8 *) AuthData->CHAPResponse, ISCSI_CHAP_RSP_LEN, Response, &RspLen);
+    IScsiBinToHex (
+      (UINT8 *) AuthData->CHAPResponse,
+      ISCSI_CHAP_RSP_LEN,
+      Response,
+      &RspLen
+      );
     IScsiAddKeyValuePair (Pdu, ISCSI_KEY_CHAP_RESPONSE, Response);
 
     if (AuthData->AuthConfig->CHAPType == ISCSI_CHAP_MUTUAL) {
@@ -448,7 +491,12 @@ IScsiCHAPToSendReq (
       //
       IScsiGenRandom ((UINT8 *) AuthData->OutChallenge, ISCSI_CHAP_RSP_LEN);
       AuthData->OutChallengeLength = ISCSI_CHAP_RSP_LEN;
-      IScsiBinToHex ((UINT8 *) AuthData->OutChallenge, ISCSI_CHAP_RSP_LEN, Challenge, &ChallengeLen);
+      IScsiBinToHex (
+        (UINT8 *) AuthData->OutChallenge,
+        ISCSI_CHAP_RSP_LEN,
+        Challenge,
+        &ChallengeLen
+        );
       IScsiAddKeyValuePair (Pdu, ISCSI_KEY_CHAP_CHALLENGE, Challenge);
 
       Conn->AuthStep = ISCSI_CHAP_STEP_FOUR;

--- a/NetworkPkg/IScsiDxe/IScsiCHAP.h
+++ b/NetworkPkg/IScsiDxe/IScsiCHAP.h
@@ -49,7 +49,7 @@ typedef struct _ISCSI_CHAP_AUTH_CONFIG_NVDATA {
 typedef struct _ISCSI_CHAP_AUTH_DATA {
   ISCSI_CHAP_AUTH_CONFIG_NVDATA *AuthConfig;
   UINT32                        InIdentifier;
-  UINT8                         InChallenge[ISCSI_CHAP_AUTH_MAX_LEN];
+  UINT8                         InChallenge[1024];
   UINT32                        InChallengeLength;
   //
   // Calculated CHAP Response (CHAP_R) value.

--- a/NetworkPkg/IScsiDxe/IScsiCHAP.h
+++ b/NetworkPkg/IScsiDxe/IScsiCHAP.h
@@ -19,7 +19,6 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #define ISCSI_CHAP_ALGORITHM_MD5  5
 
-#define ISCSI_CHAP_AUTH_MAX_LEN   1024
 ///
 /// MD5_HASHSIZE
 ///
@@ -59,9 +58,13 @@ typedef struct _ISCSI_CHAP_AUTH_DATA {
   //
   // Auth-data to be sent out for mutual authentication.
   //
+  // While the challenge size is technically independent of the hashing
+  // algorithm, it is good practice to avoid hashing *fewer bytes* than the
+  // digest size. In other words, it's good practice to feed *at least as many
+  // bytes* to the hashing algorithm as the hashing algorithm will output.
+  //
   UINT32                        OutIdentifier;
-  UINT8                         OutChallenge[ISCSI_CHAP_AUTH_MAX_LEN];
-  UINT32                        OutChallengeLength;
+  UINT8                         OutChallenge[ISCSI_CHAP_RSP_LEN];
 } ISCSI_CHAP_AUTH_DATA;
 
 /**

--- a/NetworkPkg/IScsiDxe/IScsiCHAP.h
+++ b/NetworkPkg/IScsiDxe/IScsiCHAP.h
@@ -88,7 +88,8 @@ IScsiCHAPOnRspReceived (
   @param[in, out]  Pdu         The PDU to send out.
 
   @retval EFI_SUCCESS           All check passed and the phase-related CHAP
-                                authentication info is filled into the iSCSI PDU.
+                                authentication info is filled into the iSCSI
+                                PDU.
   @retval EFI_OUT_OF_RESOURCES  Failed to allocate memory.
   @retval EFI_PROTOCOL_ERROR    Some kind of protocol error occurred.
 

--- a/NetworkPkg/IScsiDxe/IScsiDxe.inf
+++ b/NetworkPkg/IScsiDxe/IScsiDxe.inf
@@ -65,6 +65,7 @@
   NetworkPkg/NetworkPkg.dec
 
 [LibraryClasses]
+  BaseCryptLib
   BaseLib
   BaseMemoryLib
   DebugLib
@@ -72,14 +73,13 @@
   HiiLib
   MemoryAllocationLib
   NetLib
-  TcpIoLib
   PrintLib
+  TcpIoLib
   UefiBootServicesTableLib
   UefiDriverEntryPoint
+  UefiHiiServicesLib
   UefiLib
   UefiRuntimeServicesTableLib
-  UefiHiiServicesLib
-  BaseCryptLib
 
 [Protocols]
   gEfiAcpiTableProtocolGuid                     ## SOMETIMES_CONSUMES ## SystemTable

--- a/NetworkPkg/IScsiDxe/IScsiDxe.inf
+++ b/NetworkPkg/IScsiDxe/IScsiDxe.inf
@@ -74,6 +74,7 @@
   MemoryAllocationLib
   NetLib
   PrintLib
+  SafeIntLib
   TcpIoLib
   UefiBootServicesTableLib
   UefiDriverEntryPoint

--- a/NetworkPkg/IScsiDxe/IScsiImpl.h
+++ b/NetworkPkg/IScsiDxe/IScsiImpl.h
@@ -35,21 +35,20 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Protocol/AdapterInformation.h>
 #include <Protocol/NetworkInterfaceIdentifier.h>
 
-#include <Library/HiiLib.h>
-#include <Library/UefiHiiServicesLib.h>
-#include <Library/DevicePathLib.h>
-#include <Library/DebugLib.h>
+#include <Library/BaseCryptLib.h>
 #include <Library/BaseLib.h>
 #include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
+#include <Library/DevicePathLib.h>
+#include <Library/HiiLib.h>
 #include <Library/MemoryAllocationLib.h>
-#include <Library/PrintLib.h>
-#include <Library/UefiBootServicesTableLib.h>
-#include <Library/UefiRuntimeServicesTableLib.h>
-#include <Library/UefiLib.h>
-#include <Library/DpcLib.h>
 #include <Library/NetLib.h>
+#include <Library/PrintLib.h>
 #include <Library/TcpIoLib.h>
-#include <Library/BaseCryptLib.h>
+#include <Library/UefiBootServicesTableLib.h>
+#include <Library/UefiHiiServicesLib.h>
+#include <Library/UefiLib.h>
+#include <Library/UefiRuntimeServicesTableLib.h>
 
 #include <Guid/MdeModuleHii.h>
 #include <Guid/EventGroup.h>

--- a/NetworkPkg/IScsiDxe/IScsiImpl.h
+++ b/NetworkPkg/IScsiDxe/IScsiImpl.h
@@ -44,6 +44,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/MemoryAllocationLib.h>
 #include <Library/NetLib.h>
 #include <Library/PrintLib.h>
+#include <Library/SafeIntLib.h>
 #include <Library/TcpIoLib.h>
 #include <Library/UefiBootServicesTableLib.h>
 #include <Library/UefiHiiServicesLib.h>

--- a/NetworkPkg/IScsiDxe/IScsiMisc.c
+++ b/NetworkPkg/IScsiDxe/IScsiMisc.c
@@ -370,14 +370,14 @@ IScsiBinToHex (
 /**
   Convert the hexadecimal string into a binary encoded buffer.
 
-  @param[in, out]  BinBuffer   The binary buffer.
-  @param[in, out]  BinLength   Length of the binary buffer.
-  @param[in]       HexStr      The hexadecimal string.
+  @param[in, out]  BinBuffer    The binary buffer.
+  @param[in, out]  BinLength    Length of the binary buffer.
+  @param[in]       HexStr       The hexadecimal string.
 
-  @retval EFI_SUCCESS          The hexadecimal string is converted into a binary
-                               encoded buffer.
-  @retval EFI_BUFFER_TOO_SMALL The binary buffer is too small to hold the converted data.
-
+  @retval EFI_SUCCESS           The hexadecimal string is converted into a
+                                binary encoded buffer.
+  @retval EFI_BUFFER_TOO_SMALL  The binary buffer is too small to hold the
+                                converted data.
 **/
 EFI_STATUS
 IScsiHexToBin (

--- a/NetworkPkg/IScsiDxe/IScsiMisc.c
+++ b/NetworkPkg/IScsiDxe/IScsiMisc.c
@@ -376,6 +376,7 @@ IScsiBinToHex (
 
   @retval EFI_SUCCESS           The hexadecimal string is converted into a
                                 binary encoded buffer.
+  @retval EFI_INVALID_PARAMETER Invalid hex encoding found in HexStr.
   @retval EFI_BUFFER_TOO_SMALL  The binary buffer is too small to hold the
                                 converted data.
 **/
@@ -402,14 +403,21 @@ IScsiHexToBin (
 
   Length = AsciiStrLen (HexStr);
 
+  //
+  // Reject an empty hex string; reject a stray nibble.
+  //
+  if (Length == 0 || Length % 2 != 0) {
+    return EFI_INVALID_PARAMETER;
+  }
+
   for (Index = 0; Index < Length; Index ++) {
     TemStr[0] = HexStr[Index];
     Digit = (UINT8) AsciiStrHexToUint64 (TemStr);
     if (Digit == 0 && TemStr[0] != '0') {
       //
-      // Invalid Lun Char.
+      // Invalid Hex Char.
       //
-      break;
+      return EFI_INVALID_PARAMETER;
     }
     if ((Index & 1) == 0) {
       BinBuffer [Index/2] = Digit;

--- a/NetworkPkg/IScsiDxe/IScsiMisc.c
+++ b/NetworkPkg/IScsiDxe/IScsiMisc.c
@@ -316,6 +316,7 @@ IScsiMacAddrToStr (
   @retval EFI_SUCCESS          The binary data is converted to the hexadecimal string
                                and the length of the string is updated.
   @retval EFI_BUFFER_TOO_SMALL The string is too small.
+  @retval EFI_BAD_BUFFER_SIZE  BinLength is too large for hex encoding.
   @retval EFI_INVALID_PARAMETER The IP string is malformatted.
 
 **/
@@ -327,18 +328,28 @@ IScsiBinToHex (
   IN OUT UINT32 *HexLength
   )
 {
-  UINTN Index;
+  UINT32 HexLengthMin;
+  UINT32 HexLengthProvided;
+  UINT32 Index;
 
   if ((HexStr == NULL) || (BinBuffer == NULL) || (BinLength == 0)) {
     return EFI_INVALID_PARAMETER;
   }
 
-  if (((*HexLength) - 3) < BinLength * 2) {
-    *HexLength = BinLength * 2 + 3;
+  //
+  // Safely calculate: HexLengthMin := BinLength * 2 + 3.
+  //
+  if (RETURN_ERROR (SafeUint32Mult (BinLength, 2, &HexLengthMin)) ||
+      RETURN_ERROR (SafeUint32Add (HexLengthMin, 3, &HexLengthMin))) {
+    return EFI_BAD_BUFFER_SIZE;
+  }
+
+  HexLengthProvided = *HexLength;
+  *HexLength = HexLengthMin;
+  if (HexLengthProvided < HexLengthMin) {
     return EFI_BUFFER_TOO_SMALL;
   }
 
-  *HexLength = BinLength * 2 + 3;
   //
   // Prefix for Hex String.
   //

--- a/NetworkPkg/IScsiDxe/IScsiMisc.h
+++ b/NetworkPkg/IScsiDxe/IScsiMisc.h
@@ -171,6 +171,7 @@ IScsiBinToHex (
 
   @retval EFI_SUCCESS           The hexadecimal string is converted into a
                                 binary encoded buffer.
+  @retval EFI_INVALID_PARAMETER Invalid hex encoding found in HexStr.
   @retval EFI_BUFFER_TOO_SMALL  The binary buffer is too small to hold the
                                 converted data.
 **/

--- a/NetworkPkg/IScsiDxe/IScsiMisc.h
+++ b/NetworkPkg/IScsiDxe/IScsiMisc.h
@@ -150,6 +150,7 @@ IScsiAsciiStrToIp (
   @retval EFI_SUCCESS          The binary data is converted to the hexadecimal string
                                and the length of the string is updated.
   @retval EFI_BUFFER_TOO_SMALL The string is too small.
+  @retval EFI_BAD_BUFFER_SIZE  BinLength is too large for hex encoding.
   @retval EFI_INVALID_PARAMETER The IP string is malformatted.
 
 **/

--- a/NetworkPkg/IScsiDxe/IScsiMisc.h
+++ b/NetworkPkg/IScsiDxe/IScsiMisc.h
@@ -165,14 +165,14 @@ IScsiBinToHex (
 /**
   Convert the hexadecimal string into a binary encoded buffer.
 
-  @param[in, out]  BinBuffer   The binary buffer.
-  @param[in, out]  BinLength   Length of the binary buffer.
-  @param[in]       HexStr      The hexadecimal string.
+  @param[in, out]  BinBuffer    The binary buffer.
+  @param[in, out]  BinLength    Length of the binary buffer.
+  @param[in]       HexStr       The hexadecimal string.
 
-  @retval EFI_SUCCESS          The hexadecimal string is converted into a binary
-                               encoded buffer.
-  @retval EFI_BUFFER_TOO_SMALL The binary buffer is too small to hold the converted data.
-
+  @retval EFI_SUCCESS           The hexadecimal string is converted into a
+                                binary encoded buffer.
+  @retval EFI_BUFFER_TOO_SMALL  The binary buffer is too small to hold the
+                                converted data.
 **/
 EFI_STATUS
 IScsiHexToBin (

--- a/NetworkPkg/IScsiDxe/IScsiMisc.h
+++ b/NetworkPkg/IScsiDxe/IScsiMisc.h
@@ -172,6 +172,9 @@ IScsiBinToHex (
   @retval EFI_SUCCESS           The hexadecimal string is converted into a
                                 binary encoded buffer.
   @retval EFI_INVALID_PARAMETER Invalid hex encoding found in HexStr.
+  @retval EFI_BAD_BUFFER_SIZE   The length of HexStr is too large for decoding:
+                                the decoded size cannot be expressed in
+                                BinLength on output.
   @retval EFI_BUFFER_TOO_SMALL  The binary buffer is too small to hold the
                                 converted data.
 **/

--- a/OvmfPkg/PlatformCI/.azurepipelines/Windows-VS2019.yml
+++ b/OvmfPkg/PlatformCI/.azurepipelines/Windows-VS2019.yml
@@ -134,7 +134,7 @@ jobs:
         build_flags: $(Build.Flags)
         run_flags: $(Run.Flags)
         extra_install_step:
-        - powershell: choco install qemu --version=2020.08.14; Write-Host "##vso[task.prependpath]c:\Program Files\qemu"
+        - powershell: choco install qemu --version=2021.5.5; Write-Host "##vso[task.prependpath]c:\Program Files\qemu"
           displayName: Install QEMU and Set QEMU on path # friendly name displayed in the UI
           condition: and(gt(variables.pkg_count, 0), succeeded())
 


### PR DESCRIPTION
https://bugzilla.tianocore.org/show_bug.cgi?id=3356
Message-Id: <20210608121259.32451-1-lersek@redhat.com>
https://listman.redhat.com/archives/edk2-devel-archive/2021-June/msg00316.html
https://edk2.groups.io/g/devel/message/76198
~~~
Bugzilla: https://bugzilla.tianocore.org/show_bug.cgi?id=3356
Repo:     https://pagure.io/lersek/edk2.git
Branch:   iscsi_overflow_bz3356

The main goal of this series is to fix a remotely exploitable buffer
overflow in the IScsiHexToBin() function.

This posting corresponds to:

  https://bugzilla.tianocore.org/show_bug.cgi?id=3356#c22

meaning that it corresponds to the v2 patches attached to, and tested
in,

  https://bugzilla.tianocore.org/show_bug.cgi?id=3356#c17

and that it carries Phil's and Maciej's R-b's that were given up to
comment#22.

Today is the Public Date for this embargoed security issue; I intend to
merge the patches tomorrow, based on Maciej's (already given) R-b.
(Simultaneously with this posting, I'm opening up the BZ publicly.) No
further review is required; the one day delay on the list is just to
give the community a (brief) opportunity to speak up, before the patches
are merged.

Cc: Jiaxin Wu <jiaxin.wu@intel.com>
Cc: Maciej Rabeda <maciej.rabeda@linux.intel.com>
Cc: Philippe Mathieu-Daudé <philmd@redhat.com>
Cc: Siyuan Fu <siyuan.fu@intel.com>

Thanks,
Laszlo

Laszlo Ersek (10):
  NetworkPkg/IScsiDxe: wrap IScsiCHAP source files to 80 characters
  NetworkPkg/IScsiDxe: simplify "ISCSI_CHAP_AUTH_DATA.InChallenge" size
  NetworkPkg/IScsiDxe: clean up
    "ISCSI_CHAP_AUTH_DATA.OutChallengeLength"
  NetworkPkg/IScsiDxe: clean up library class dependencies
  NetworkPkg/IScsiDxe: fix potential integer overflow in IScsiBinToHex()
  NetworkPkg/IScsiDxe: assert that IScsiBinToHex() always succeeds
  NetworkPkg/IScsiDxe: reformat IScsiHexToBin() leading comment block
  NetworkPkg/IScsiDxe: fix IScsiHexToBin() hex parsing
  NetworkPkg/IScsiDxe: fix IScsiHexToBin() buffer overflow
  NetworkPkg/IScsiDxe: check IScsiHexToBin() return values

 NetworkPkg/IScsiDxe/IScsiCHAP.c  | 108 +++++++++++++++-----
 NetworkPkg/IScsiDxe/IScsiCHAP.h  |  14 ++-
 NetworkPkg/IScsiDxe/IScsiDxe.inf |   7 +-
 NetworkPkg/IScsiDxe/IScsiImpl.h  |  18 ++--
 NetworkPkg/IScsiDxe/IScsiMisc.c  |  65 +++++++++---
 NetworkPkg/IScsiDxe/IScsiMisc.h  |  19 ++--
 6 files changed, 166 insertions(+), 65 deletions(-)
~~~