### PR TITLE
[edk2-devel] [URGENT PATCH] OvmfPkg/PlatformCI: bump QEMU choco package version to 2021.5.5 -- push

### DIFF
--- a/OvmfPkg/PlatformCI/.azurepipelines/Windows-VS2019.yml
+++ b/OvmfPkg/PlatformCI/.azurepipelines/Windows-VS2019.yml
@@ -134,7 +134,7 @@ jobs:
         build_flags: $(Build.Flags)
         run_flags: $(Run.Flags)
         extra_install_step:
-        - powershell: choco install qemu --version=2020.08.14; Write-Host "##vso[task.prependpath]c:\Program Files\qemu"
+        - powershell: choco install qemu --version=2021.5.5; Write-Host "##vso[task.prependpath]c:\Program Files\qemu"
           displayName: Install QEMU and Set QEMU on path # friendly name displayed in the UI
           condition: and(gt(variables.pkg_count, 0), succeeded())
 


### PR DESCRIPTION
msgid: <20210609155731.10431-1-lersek@redhat.com>
https://edk2.groups.io/g/devel/message/76283
https://listman.redhat.com/archives/edk2-devel-archive/2021-June/msg00403.html
~~~
We currently require QEMU choco package version 2020.08.14 (from commit
3ab9d60fcbe7), in "OvmfPkg/PlatformCI/.azurepipelines/Windows-VS2019.yml".
Said package version references the following URLs:

https://community.chocolatey.org/packages/Qemu/2020.08.14#files
-> https://qemu.weilnetz.de/w32/qemu-w32-setup-20200814.exe
-> https://qemu.weilnetz.de/w64/qemu-w64-setup-20200814.exe

These URLs no longer work; Stefan Weil seems to have moved the binaries to
the following archive directories:

- https://qemu.weilnetz.de/w32/2020/
- https://qemu.weilnetz.de/w64/2020/

In theory, the old QEMU choco packages should be fixed (their powershell
scripts should be updated to reference the new URLs on Stefan Weil's
website). However, this PlatformCI issue is blocking the merging of the
security fix for TianoCore#3356, so getting PlatformCI functional again is
urgent. Let's bump our QEMU choco package requirement to 2021.5.5, whose
URLs work, for now.

(Currently we cannot use any other choco package version, as Stefan's
directories <https://qemu.weilnetz.de/w32> and
<https://qemu.weilnetz.de/w64>, without any further subdirectories, only
offer the 20210505 EXE files.)

Cc: Ard Biesheuvel <ardb+tianocore@kernel.org>
Cc: Bret Barkelew <Bret.Barkelew@microsoft.com>
Cc: Jordan Justen <jordan.l.justen@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Philippe Mathieu-Daudé <philmd@redhat.com>
Cc: Sean Brogan <sean.brogan@microsoft.com>
Signed-off-by: Laszlo Ersek <lersek@redhat.com>
---
 OvmfPkg/PlatformCI/.azurepipelines/Windows-VS2019.yml | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
~~~