### PR TITLE
OvmfPkg/Bhyve: Remove Xen remnants

### DIFF
--- a/OvmfPkg/Bhyve/AcpiPlatformDxe/AcpiPlatform.h
+++ b/OvmfPkg/Bhyve/AcpiPlatformDxe/AcpiPlatform.h
@@ -18,7 +18,6 @@
 #include <Library/DebugLib.h>
 #include <Library/PcdLib.h>
 #include <Library/UefiBootServicesTableLib.h>
-#include <Library/XenPlatformLib.h>
 #include <IndustryStandard/Acpi.h>
 
 typedef struct {
@@ -44,12 +43,6 @@ BhyveInstallAcpiTable(
   IN   VOID                          *AcpiTableBuffer,
   IN   UINTN                         AcpiTableBufferSize,
   OUT  UINTN                         *TableKey
-  );
-
-EFI_STATUS
-EFIAPI
-InstallXenTables (
-  IN   EFI_ACPI_TABLE_PROTOCOL       *AcpiProtocol
   );
 
 EFI_STATUS

--- a/OvmfPkg/Bhyve/BhyveX64.dsc
+++ b/OvmfPkg/Bhyve/BhyveX64.dsc
@@ -219,7 +219,6 @@
   S3BootScriptLib|MdeModulePkg/Library/PiDxeS3BootScriptLib/DxeS3BootScriptLib.inf
   SmbusLib|MdePkg/Library/BaseSmbusLibNull/BaseSmbusLibNull.inf
   OrderedCollectionLib|MdePkg/Library/BaseOrderedCollectionRedBlackTreeLib/BaseOrderedCollectionRedBlackTreeLib.inf
-  XenPlatformLib|OvmfPkg/Library/XenPlatformLib/XenPlatformLib.inf
 
 
 !if $(TPM_ENABLE) == TRUE

--- a/OvmfPkg/Bhyve/PlatformPei/Platform.h
+++ b/OvmfPkg/Bhyve/PlatformPei/Platform.h
@@ -98,25 +98,8 @@ InstallClearCacheCallback (
   VOID
   );
 
-EFI_STATUS
-InitializeXen (
-  VOID
-  );
-
-BOOLEAN
-XenDetect (
-  VOID
-  );
-
 VOID
 AmdSevInitialize (
-  VOID
-  );
-
-extern BOOLEAN mXen;
-
-VOID
-XenPublishRamRegions (
   VOID
   );
 


### PR DESCRIPTION
Several Xen remnants were left over from adapting the Ovmf code for
Bhyve. Remove them.

Signed-off-by: Rebecca Cran <rebecca@bsdio.com>