### PR TITLE
Pytool: SpellCheck: Fix incorrect file mask across package matrices

### DIFF
--- a/.pytool/Plugin/SpellCheck/SpellCheck.py
+++ b/.pytool/Plugin/SpellCheck/SpellCheck.py
@@ -37,12 +37,12 @@ class SpellCheck(ICiBuildPlugin):
     #
     # A package can remove any of these using IgnoreStandardPaths
     #
-    STANDARD_PLUGIN_DEFINED_PATHS = ["*.c", "*.h",
+    STANDARD_PLUGIN_DEFINED_PATHS = ("*.c", "*.h",
                                      "*.nasm", "*.asm", "*.masm", "*.s",
                                      "*.asl",
                                      "*.dsc", "*.dec", "*.fdf", "*.inf",
                                      "*.md", "*.txt"
-                                     ]
+                                     )
 
     def GetTestName(self, packagename: str, environment: VarDict) -> tuple:
         """ Provide the testcase name and classname for use in reporting
@@ -107,7 +107,8 @@ class SpellCheck(ICiBuildPlugin):
         version_aggregator.GetVersionAggregator().ReportVersion(
             "CSpell", cspell_version, version_aggregator.VersionTypes.INFO)
 
-        package_relative_paths_to_spell_check = SpellCheck.STANDARD_PLUGIN_DEFINED_PATHS
+        # copy the default as a list
+        package_relative_paths_to_spell_check = list(SpellCheck.STANDARD_PLUGIN_DEFINED_PATHS)
 
         #
         # Allow the ci.yaml to remove any of the above standard paths


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3443

Existing implementation could modify class global data that causes
potential incorrect file mask to be used for execution of plugin.

This change switches class variable to be tuple so that it cannot be
accidently modified. Local usage of STANDARD_PLUGIN_DEFINED_PATHS is also
changed to copy to new list before modification.

Cc: Sean Brogan <sean.brogan@microsoft.com>
Cc: Bret Barkelew <Bret.Barkelew@microsoft.com>
Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>

Signed-off-by: Sean Brogan <sean.brogan@microsoft.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>