### PR TITLE
SecurityPkg: TcgStorageOpalLib: Initialize SupportedAttributes parame…

### DIFF
--- a/SecurityPkg/Library/TcgStorageOpalLib/TcgStorageOpalCore.c
+++ b/SecurityPkg/Library/TcgStorageOpalLib/TcgStorageOpalCore.c
@@ -1,7 +1,7 @@
 /** @file
   Public API for Opal Core library.
 
-Copyright (c) 2016 - 2018, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2016 - 2021, Intel Corporation. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -1647,6 +1647,7 @@ OpalGetSupportedAttributesInfo(
   NULL_CHECK(OpalBaseComId);
 
   ZeroMem(Buffer, BUFFER_SIZE);
+  ZeroMem(SupportedAttributes, sizeof(OPAL_DISK_SUPPORT_ATTRIBUTE));
   ASSERT(sizeof(Buffer) >= sizeof(TCG_SUPPORTED_SECURITY_PROTOCOLS));
 
   //


### PR DESCRIPTION
…ter.

REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3408

The value of SupportedAttributes in OpalGetSupportedAttributesInfo ()
is left undetermined, if the caller doesn't initialize it.
Initialize it in the function entry.

Signed-off-by: Scottie Kuo <scottie.kuo@intel.com>
Cc: Qi Zhang <qi1.zhang@intel.com>
Cc: Rahul Kumar <rahul1.kumar@intel.com>
Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Maggie Chu <maggie.chu@intel.com>
Reviewed-by: Jiewen Yao <Jiewen.yao@intel.com>
Acked-by: Jian J Wang <jian.j.wang@intel.com>