### PR TITLE
Pytool: SpellCheck: Defer path expansion in cspell parameters

### DIFF
--- a/.pytool/Plugin/SpellCheck/SpellCheck.py
+++ b/.pytool/Plugin/SpellCheck/SpellCheck.py
@@ -134,7 +134,8 @@ class SpellCheck(ICiBuildPlugin):
         #
         relpath = os.path.relpath(abs_pkg_path)
         cpsell_paths = " ".join(
-            [f"{relpath}/**/{x}" for x in package_relative_paths_to_spell_check])
+            # Double quote each path to defer expansion to cspell parameters
+            [f'"{relpath}/**/{x}"' for x in package_relative_paths_to_spell_check])
 
         # Make the config file
         config_file_path = os.path.join(


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3454

On Linux the shell expands the wildcard paths and causes multiple files
to be missed. This change adds additional quotes to defer expansion in
order to bring parity in cspell result.

Cc: Sean Brogan <sean.brogan@microsoft.com>
Cc: Bret Barkelew <Bret.Barkelew@microsoft.com>
Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>

Signed-off-by: Sean Brogan <sean.brogan@microsoft.com>
Signed-off-by: Kun Qin <kuqin12@gmail.com>
Reviewed-by: Sean Brogan <sean.brogan@microsoft.com>
Reviewed-by: Bret Barkelew <bret.barkelew@microsoft.com>