### PR TITLE
MdeModulePkg PciBusDxe: Increase the width of data read during oprom …

### DIFF
--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciOptionRomSupport.c
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciOptionRomSupport.c
@@ -521,9 +521,9 @@ LoadOpRomImage (
     //
     PciDevice->PciRootBridgeIo->Mem.Read (
                                       PciDevice->PciRootBridgeIo,
-                                      EfiPciWidthUint8,
+                                      EfiPciWidthUint32,
                                       RomBar,
-                                      (UINT32) RomImageSize,
+                                      (UINT32) RomImageSize/sizeof(UINT32),
                                       Image
                                       );
     RomInMemory = Image;


### PR DESCRIPTION
…shadow

REF: https://bugzilla.tianocore.org/show_bug.cgi?id=2989

Long times spent on shadowing oprom from graphics card to system memory.
We are currently using 8 bit read cycles. This needs to be wider,
at least 32bit reads to reduce the time for oprom shadow.

Signed-off-by: Sumana Venur <sumana.venur@intel.com>
Reviewed-by: Ray Ni <ray.ni@intel.com>