### PR TITLE
MdeModulePkg/RegularExpressionDxe: Fix memory assert in FreePool()

### DIFF
--- a/MdeModulePkg/Universal/RegularExpressionDxe/OnigurumaUefiPort.c
+++ b/MdeModulePkg/Universal/RegularExpressionDxe/OnigurumaUefiPort.c
@@ -2,7 +2,7 @@
 
   Module to rewrite stdlib references within Oniguruma
 
-  (C) Copyright 2014-2015 Hewlett Packard Enterprise Development LP<BR>
+  (C) Copyright 2014-2021 Hewlett Packard Enterprise Development LP<BR>
   Copyright (c) 2020, Intel Corporation. All rights reserved.<BR>
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -96,3 +96,20 @@ void* memset (void *dest, char ch, unsigned int count)
   return SetMem (dest, count, ch);
 }
 
+void free(void *ptr)
+{
+  VOID         *EvalOnce;
+  ONIGMEM_HEAD *PoolHdr;
+
+  EvalOnce = ptr;
+  if (EvalOnce == NULL) {
+    return;
+  }
+
+  PoolHdr = (ONIGMEM_HEAD *)EvalOnce - 1;
+  if (PoolHdr->Signature == ONIGMEM_HEAD_SIGNATURE) {
+    FreePool (PoolHdr);
+  } else {
+    FreePool (EvalOnce);
+  }
+}

--- a/MdeModulePkg/Universal/RegularExpressionDxe/OnigurumaUefiPort.h
+++ b/MdeModulePkg/Universal/RegularExpressionDxe/OnigurumaUefiPort.h
@@ -2,7 +2,7 @@
 
   Module to rewrite stdlib references within Oniguruma
 
-  (C) Copyright 2014-2015 Hewlett Packard Enterprise Development LP<BR>
+  (C) Copyright 2014-2021 Hewlett Packard Enterprise Development LP<BR>
   Copyright (c) 2020, Intel Corporation. All rights reserved.<BR>
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -46,17 +46,6 @@ typedef INTN        intptr_t;
 #endif
 
 #define calloc(n,s) AllocateZeroPool((n)*(s))
-
-#define free(p)             \
-  do {                      \
-    VOID *EvalOnce;         \
-                            \
-    EvalOnce = (p);         \
-    if (EvalOnce != NULL) { \
-      FreePool (EvalOnce);  \
-    }                       \
-  } while (FALSE)
-
 #define xmemmove(Dest,Src,Length) CopyMem(Dest,Src,Length)
 #define xmemcpy(Dest,Src,Length) CopyMem(Dest,Src,Length)
 #define xmemset(Buffer,Value,Length) SetMem(Buffer,Length,Value)
@@ -98,6 +87,7 @@ void* malloc(size_t size);
 void* realloc(void *ptr, size_t size);
 void* memcpy (void *dest, const void *src, unsigned int count);
 void* memset (void *dest, char ch, unsigned int count);
+void free(void *ptr);
 
 #define exit(n) ASSERT(FALSE);
 


### PR DESCRIPTION
Memory buffer that is allocated by malloc() and realloc() will be
shifted by 8 bytes because Oniguruma keeps its memory signature. This 8
bytes shift is not handled while calling free() to release memory. Add
free() function to check Oniguruma signature before release memory
because memory buffer is not touched when using calloc().

Signed-off-by: Nickle Wang <nickle.wang@hpe.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>