### PR TITLE
MdeModulePkg/BdsDxe: Update BdsEntry to use Variable Policy

### DIFF
--- a/MdeModulePkg/Universal/BdsDxe/Bds.h
+++ b/MdeModulePkg/Universal/BdsDxe/Bds.h
@@ -17,7 +17,6 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #include <Protocol/Bds.h>
 #include <Protocol/LoadedImage.h>
-#include <Protocol/VariableLock.h>
 #include <Protocol/DeferredImageLoad.h>
 
 #include <Library/UefiDriverEntryPoint.h>

--- a/MdeModulePkg/Universal/BdsDxe/BdsDxe.inf
+++ b/MdeModulePkg/Universal/BdsDxe/BdsDxe.inf
@@ -50,6 +50,7 @@
   BaseMemoryLib
   DebugLib
   UefiBootManagerLib
+  VariablePolicyHelperLib
   PlatformBootManagerLib
   PcdLib
   PrintLib
@@ -77,7 +78,7 @@
 [Protocols]
   gEfiBdsArchProtocolGuid                       ## PRODUCES
   gEfiSimpleTextInputExProtocolGuid             ## CONSUMES
-  gEdkiiVariableLockProtocolGuid                ## SOMETIMES_CONSUMES
+  gEdkiiVariablePolicyProtocolGuid              ## SOMETIMES_CONSUMES
   gEfiDeferredImageLoadProtocolGuid             ## CONSUMES
 
 [FeaturePcd]


### PR DESCRIPTION
Changed BdsEntry.c to use Variable Policy instead of Variable Lock
as Variable Lock will be Deprecated eventually

Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Hao A Wu <hao.a.wu@intel.com>
Cc: Zhichao Gao <zhichao.gao@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>

Signed-off-by: Kenneth Lautner <kenlautner3@gmail.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>