### PR TITLE
UefiCpuPkg/CpuCommonFeaturesLib: Correct the CPU location check

### DIFF
--- a/UefiCpuPkg/Library/CpuCommonFeaturesLib/C1e.c
+++ b/UefiCpuPkg/Library/CpuCommonFeaturesLib/C1e.c
@@ -63,9 +63,9 @@ C1eInitialize (
 {
   //
   // The scope of C1EEnable bit in the MSR_NEHALEM_POWER_CTL is Package, only program
-  // MSR_FEATURE_CONFIG for thread 0 core 0 in each package.
+  // MSR_NEHALEM_POWER_CTL once for each package.
   //
-  if ((CpuInfo->ProcessorInfo.Location.Thread != 0) || (CpuInfo->ProcessorInfo.Location.Core != 0)) {
+  if ((CpuInfo->First.Thread == 0) || (CpuInfo->First.Core == 0)) {
   return RETURN_SUCCESS;
   }
 

--- a/UefiCpuPkg/Library/CpuCommonFeaturesLib/MachineCheck.c
+++ b/UefiCpuPkg/Library/CpuCommonFeaturesLib/MachineCheck.c
@@ -152,10 +152,10 @@ McaInitialize (
 
   //
   // The scope of MSR_IA32_MC*_CTL/MSR_IA32_MC*_STATUS is package for below processor type, only program
-  // MSR_IA32_MC*_CTL/MSR_IA32_MC*_STATUS for thread 0 core 0 in each package.
+  // MSR_IA32_MC*_CTL/MSR_IA32_MC*_STATUS once for each package.
   //
   if (IS_NEHALEM_PROCESSOR (CpuInfo->DisplayFamily, CpuInfo->DisplayModel)) {
-    if ((CpuInfo->ProcessorInfo.Location.Thread != 0) || (CpuInfo->ProcessorInfo.Location.Core != 0)) {
+    if ((CpuInfo->First.Thread == 0) || (CpuInfo->First.Core == 0)) {
       return RETURN_SUCCESS;
     }
   }

--- a/UefiCpuPkg/Library/CpuCommonFeaturesLib/Ppin.c
+++ b/UefiCpuPkg/Library/CpuCommonFeaturesLib/Ppin.c
@@ -130,10 +130,10 @@ PpinInitialize (
   // Support function already check the processor which support PPIN feature, so this function not need
   // to check the processor again.
   //
-  // The scope of the MSR_IVY_BRIDGE_PPIN_CTL is package level, only program MSR_IVY_BRIDGE_PPIN_CTL for
-  // thread 0 core 0 in each package.
+  // The scope of the MSR_IVY_BRIDGE_PPIN_CTL is package level, only program MSR_IVY_BRIDGE_PPIN_CTL
+  // once for each package.
   //
-  if ((CpuInfo->ProcessorInfo.Location.Thread != 0) || (CpuInfo->ProcessorInfo.Location.Core != 0)) {
+  if ((CpuInfo->First.Thread == 0) || (CpuInfo->First.Core == 0)) {
     return RETURN_SUCCESS;
   }
 


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3424

Processor location information check needs to updated
When Core 0 is disabled.

In C1e.c, change MSR_FEATURE_CONFIG to MSR_NEHALEM_POWER_CTL in comments
to match the correct MSR name.

Signed-off-by: Daoxiang Li <daoxiang.li@intel.com>
Cc: Eric Dong <eric.dong@intel.com>
Reviewed-by: Ray Ni <ray.ni@intel.com>
Cc: Laszlo Ersek <lersek@redhat.com>
Cc: Rahul Kumar <rahul1.kumar@intel.com>