### PR TITLE
CryptoPkg: BaseCryptLib: Update Salt length requirement for RSA-PSS s…

### DIFF
--- a/CryptoPkg/Include/Library/BaseCryptLib.h
+++ b/CryptoPkg/Include/Library/BaseCryptLib.h
@@ -1376,7 +1376,7 @@ RsaPkcs1Verify (
   If Message is NULL, then return FALSE.
   If MsgSize is zero or > INT_MAX, then return FALSE.
   If DigestLen is NOT 32, 48 or 64, return FALSE.
-  If SaltLen is < DigestLen, then return FALSE.
+  If SaltLen is not equal to DigestLen, then return FALSE.
   If SigSize is large enough but Signature is NULL, then return FALSE.
   If this interface is not supported, then return FALSE.
 
@@ -1411,7 +1411,7 @@ RsaPssSign (
   Verifies the RSA signature with RSASSA-PSS signature scheme defined in RFC 8017.
   Implementation determines salt length automatically from the signature encoding.
   Mask generation function is the same as the message digest algorithm.
-  Salt length should atleast be equal to digest length.
+  Salt length should be equal to digest length.
 
   @param[in]  RsaContext      Pointer to RSA context for signature verification.
   @param[in]  Message         Pointer to octet message to be verified.

--- a/CryptoPkg/Library/BaseCryptLib/Pk/CryptRsaPss.c
+++ b/CryptoPkg/Library/BaseCryptLib/Pk/CryptRsaPss.c
@@ -50,7 +50,7 @@ GetEvpMD (
   Verifies the RSA signature with RSASSA-PSS signature scheme defined in RFC 8017.
   Implementation determines salt length automatically from the signature encoding.
   Mask generation function is the same as the message digest algorithm.
-  Salt length should atleast be equal to digest length.
+  Salt length should be equal to digest length.
 
   @param[in]  RsaContext      Pointer to RSA context for signature verification.
   @param[in]  Message         Pointer to octet message to be verified.
@@ -97,7 +97,7 @@ RsaPssVerify (
   if (Signature == NULL || SigSize == 0 || SigSize > INT_MAX) {
     return FALSE;
   }
-  if (SaltLen < DigestLen) {
+  if (SaltLen != DigestLen) {
     return FALSE;
   }
 

--- a/CryptoPkg/Library/BaseCryptLib/Pk/CryptRsaPssNull.c
+++ b/CryptoPkg/Library/BaseCryptLib/Pk/CryptRsaPssNull.c
@@ -15,7 +15,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
   Verifies the RSA signature with RSASSA-PSS signature scheme defined in RFC 8017.
   Implementation determines salt length automatically from the signature encoding.
   Mask generation function is the same as the message digest algorithm.
-  Salt length should atleast be equal to digest length.
+  Salt length should be equal to digest length.
 
   @param[in]  RsaContext      Pointer to RSA context for signature verification.
   @param[in]  Message         Pointer to octet message to be verified.

--- a/CryptoPkg/Library/BaseCryptLib/Pk/CryptRsaPssSign.c
+++ b/CryptoPkg/Library/BaseCryptLib/Pk/CryptRsaPssSign.c
@@ -59,7 +59,7 @@ GetEvpMD (
   If Message is NULL, then return FALSE.
   If MsgSize is zero or > INT_MAX, then return FALSE.
   If DigestLen is NOT 32, 48 or 64, return FALSE.
-  If SaltLen is < DigestLen, then return FALSE.
+  If SaltLen is not equal to DigestLen, then return FALSE.
   If SigSize is large enough but Signature is NULL, then return FALSE.
   If this interface is not supported, then return FALSE.
 
@@ -120,7 +120,7 @@ RsaPssSign (
     return FALSE;
   }
 
-  if (SaltLen < DigestLen) {
+  if (SaltLen != DigestLen) {
     return FALSE;
   }
 

--- a/CryptoPkg/Library/BaseCryptLib/Pk/CryptRsaPssSignNull.c
+++ b/CryptoPkg/Library/BaseCryptLib/Pk/CryptRsaPssSignNull.c
@@ -24,7 +24,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
   If Message is NULL, then return FALSE.
   If MsgSize is zero or > INT_MAX, then return FALSE.
   If DigestLen is NOT 32, 48 or 64, return FALSE.
-  If SaltLen is < DigestLen, then return FALSE.
+  If SaltLen is not equal to DigestLen, then return FALSE.
   If SigSize is large enough but Signature is NULL, then return FALSE.
   If this interface is not supported, then return FALSE.
 

--- a/CryptoPkg/Library/BaseCryptLibNull/Pk/CryptRsaPssNull.c
+++ b/CryptoPkg/Library/BaseCryptLibNull/Pk/CryptRsaPssNull.c
@@ -15,7 +15,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
   Verifies the RSA signature with RSASSA-PSS signature scheme defined in RFC 8017.
   Implementation determines salt length automatically from the signature encoding.
   Mask generation function is the same as the message digest algorithm.
-  Salt length should atleast be equal to digest length.
+  Salt length should be equal to digest length.
 
   @param[in]  RsaContext      Pointer to RSA context for signature verification.
   @param[in]  Message         Pointer to octet message to be verified.

--- a/CryptoPkg/Library/BaseCryptLibNull/Pk/CryptRsaPssSignNull.c
+++ b/CryptoPkg/Library/BaseCryptLibNull/Pk/CryptRsaPssSignNull.c
@@ -24,7 +24,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
   If Message is NULL, then return FALSE.
   If MsgSize is zero or > INT_MAX, then return FALSE.
   If DigestLen is NOT 32, 48 or 64, return FALSE.
-  If SaltLen is < DigestLen, then return FALSE.
+  If SaltLen is not equal to DigestLen, then return FALSE.
   If SigSize is large enough but Signature is NULL, then return FALSE.
   If this interface is not supported, then return FALSE.
 

--- a/CryptoPkg/Library/BaseCryptLibOnProtocolPpi/CryptLib.c
+++ b/CryptoPkg/Library/BaseCryptLibOnProtocolPpi/CryptLib.c
@@ -1556,7 +1556,7 @@ RsaPkcs1Verify (
   Verifies the RSA signature with RSASSA-PSS signature scheme defined in RFC 8017.
   Implementation determines salt length automatically from the signature encoding.
   Mask generation function is the same as the message digest algorithm.
-  Salt length should atleast be equal to digest length.
+  Salt length should be equal to digest length.
 
   @param[in]  RsaContext      Pointer to RSA context for signature verification.
   @param[in]  Message         Pointer to octet message to be verified.
@@ -1591,6 +1591,14 @@ RsaPssVerify (
   Mask generation function is the same as the message digest algorithm.
   If the Signature buffer is too small to hold the contents of signature, FALSE
   is returned and SigSize is set to the required buffer size to obtain the signature.
+
+  If RsaContext is NULL, then return FALSE.
+  If Message is NULL, then return FALSE.
+  If MsgSize is zero or > INT_MAX, then return FALSE.
+  If DigestLen is NOT 32, 48 or 64, return FALSE.
+  If SaltLen is not equal to DigestLen, then return FALSE.
+  If SigSize is large enough but Signature is NULL, then return FALSE.
+  If this interface is not supported, then return FALSE.
 
   @param[in]      RsaContext   Pointer to RSA context for signature generation.
   @param[in]      Message      Pointer to octet message to be signed.

--- a/CryptoPkg/Private/Protocol/Crypto.h
+++ b/CryptoPkg/Private/Protocol/Crypto.h
@@ -3421,7 +3421,7 @@ EFI_STATUS
   If Message is NULL, then return FALSE.
   If MsgSize is zero or > INT_MAX, then return FALSE.
   If DigestLen is NOT 32, 48 or 64, return FALSE.
-  If SaltLen is < DigestLen, then return FALSE.
+  If SaltLen is not equal to DigestLen, then return FALSE.
   If SigSize is large enough but Signature is NULL, then return FALSE.
   If this interface is not supported, then return FALSE.
 
@@ -3456,7 +3456,7 @@ BOOLEAN
   Verifies the RSA signature with RSASSA-PSS signature scheme defined in RFC 8017.
   Implementation determines salt length automatically from the signature encoding.
   Mask generation function is the same as the message digest algorithm.
-  Salt length should atleast be equal to digest length.
+  Salt length should be equal to digest length.
 
   @param[in]  RsaContext      Pointer to RSA context for signature verification.
   @param[in]  Message         Pointer to octet message to be verified.


### PR DESCRIPTION
…cheme.

REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3455

Enforce salt length to be equal to digest length for RSA-PSS
encoding scheme.

Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Xiaoyu Lu <xiaoyux.lu@intel.com>
Cc: Guomin Jiang <guomin.jiang@intel.com>

Signed-off-by: Sachin Agrawal <sachin.agrawal@intel.com>
Reviewed-by: Jiewen Yao <Jiewen.yao@intel.com>