### PR TITLE
Azurepipeline: SpellCheck: Enforce Node dependency to use version 14.x

### DIFF
--- a/.azurepipelines/templates/spell-check-prereq-steps.yml
+++ b/.azurepipelines/templates/spell-check-prereq-steps.yml
@@ -13,7 +13,7 @@ parameters:
 steps:
 - task: NodeTool@0
   inputs:
-    versionSpec: '10.x'
+    versionSpec: '14.x'
     #checkLatest: false # Optional
   condition: and(gt(variables.pkg_count, 0), succeeded())
 


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3445

Per update from Cspell tool, the minimal requirement of Cspell 5.x
regarding Node is 12 and above. This has caused multple Cspell failures
during CI build validation:
"Failed to process "**.c" TypeError: text.matchAll(...) is not a function
or its return value is not iterable"

This change updates the lowest required node version to 14.x to support
Cspell functionalities.

Cc: Sean Brogan <sean.brogan@microsoft.com>
Cc: Bret Barkelew <Bret.Barkelew@microsoft.com>
Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>

Signed-off-by: Kun Qin <kuqin12@gmail.com>
Reviewed-by: Ard Biesheuvel <ardb@kernel.org>
Acked-by: Liming Gao <gaoliming@byosoft.com.cn>
Reviewed-by: Sean Brogan <sean.brogan@microsoft.com>