### PR TITLE
CryptoPkg/BaseCryptLib: Enabled CryptSha512 for Smm/Runtime drivers

### DIFF
--- a/CryptoPkg/Library/BaseCryptLib/RuntimeCryptLib.inf
+++ b/CryptoPkg/Library/BaseCryptLib/RuntimeCryptLib.inf
@@ -11,8 +11,8 @@
 #  functions, PKCS#7 SignedData sign functions, Diffie-Hellman functions, and
 #  authenticode signature verification functions are not supported in this instance.
 #
-#  Copyright (c) 2009 - 2020, Intel Corporation. All rights reserved.<BR>
-#  Copyright (c) 2020, Hewlett Packard Enterprise Development LP. All rights reserved.<BR>
+#  Copyright (c) 2009 - 2021, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2021, Hewlett Packard Enterprise Development LP. All rights reserved.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -39,7 +39,7 @@
   Hash/CryptSha1.c
   Hash/CryptSha256.c
   Hash/CryptSm3.c
-  Hash/CryptSha512Null.c
+  Hash/CryptSha512.c
   Hmac/CryptHmacSha256.c
   Kdf/CryptHkdf.c
   Cipher/CryptAes.c

--- a/CryptoPkg/Library/BaseCryptLib/SmmCryptLib.inf
+++ b/CryptoPkg/Library/BaseCryptLib/SmmCryptLib.inf
@@ -10,7 +10,7 @@
 #  RSA external functions, PKCS#7 SignedData sign functions, Diffie-Hellman functions, and
 #  authenticode signature verification functions are not supported in this instance.
 #
-#  Copyright (c) 2010 - 2020, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2010 - 2021, Intel Corporation. All rights reserved.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -37,7 +37,7 @@
   Hash/CryptSha1.c
   Hash/CryptSha256.c
   Hash/CryptSm3.c
-  Hash/CryptSha512Null.c
+  Hash/CryptSha512.c
   Hmac/CryptHmacSha256.c
   Kdf/CryptHkdfNull.c
   Cipher/CryptAes.c


### PR DESCRIPTION
Intel Platform utility Syscfg/sysfwupdt will trigger SMI
to enter BIOS interface. then BIOS invoke EncodePassword
in SMM mode to check password.
it's need sha384(in CryptSha512.c) in SMM mode.

the origin SmmCryptLib.lib size is 1389KB,
after changed, the size is 1391KB.

the origin RuntimeCryptLib.lib size is 911KB,
after changed,the size is 913KB.

in SmmCryptLib.inf and RuntimeCryptLib.inf,
change CryptSha512NULL.c to CryptSha512.c.

https://bugzilla.tianocore.org/show_bug.cgi?id=3423

Signed-off-by: xueshengfeng <xueshengfeng@byosoft.com.cn>
Reviewed-by: Jiewen Yao <Jiewen.yao@intel.com>