### PR TITLE
BaseTools: Remove check for Split.exe in toolset.bat

### DIFF
--- a/BaseTools/toolsetup.bat
+++ b/BaseTools/toolsetup.bat
@@ -299,7 +299,6 @@ IF NOT EXIST "%EDK_TOOLS_BIN%\GenFfs.exe" goto check_c_tools
 IF NOT EXIST "%EDK_TOOLS_BIN%\GenFv.exe" goto check_c_tools
 IF NOT EXIST "%EDK_TOOLS_BIN%\GenFw.exe" goto check_c_tools
 IF NOT EXIST "%EDK_TOOLS_BIN%\GenSec.exe" goto check_c_tools
-IF NOT EXIST "%EDK_TOOLS_BIN%\Split.exe" goto check_c_tools
 IF NOT EXIST "%EDK_TOOLS_BIN%\TianoCompress.exe" goto check_c_tools
 IF NOT EXIST "%EDK_TOOLS_BIN%\VfrCompile.exe" goto check_c_tools
 IF NOT EXIST "%EDK_TOOLS_BIN%\VolInfo.exe" goto check_c_tools


### PR DESCRIPTION
Split is now a Python tool, so BaseTools\Bin\Win32\Split.exe no longer
exists. Remove the check for it from toolsetup.bat to prevent the
erroneous claim that the binary C tools are missing.

Signed-off-by: Rebecca Cran <rebecca@bsdio.com>
Reviewed-by: Bob Feng <bob.c.feng@intel.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>