### PR TITLE
BaseTools: Fix spelling of "overwrite" and "overwriting" in toolset.bat

### DIFF
--- a/BaseTools/toolsetup.bat
+++ b/BaseTools/toolsetup.bat
@@ -227,7 +227,7 @@ if NOT exist %CONF_PATH% (
 ) else (
   if defined RECONFIG (
     echo.
-    echo  Over-writing the files in the CONF_PATH directory
+    echo  Overwriting the files in the CONF_PATH directory
     echo  using the default template files
     echo.
   )
@@ -240,7 +240,7 @@ if NOT exist %CONF_PATH%\target.txt (
   )
   copy %EDK_TOOLS_PATH%\Conf\target.template %CONF_PATH%\target.txt > nul
 ) else (
-  if defined RECONFIG echo over-write ... target.template to %CONF_PATH%\target.txt
+  if defined RECONFIG echo overwrite ... target.template to %CONF_PATH%\target.txt
   if defined RECONFIG copy /Y %EDK_TOOLS_PATH%\Conf\target.template %CONF_PATH%\target.txt > nul
 )
 
@@ -251,7 +251,7 @@ if NOT exist %CONF_PATH%\tools_def.txt (
   )
   copy %EDK_TOOLS_PATH%\Conf\tools_def.template %CONF_PATH%\tools_def.txt > nul
 ) else (
-  if defined RECONFIG echo over-write ... tools_def.template to %CONF_PATH%\tools_def.txt
+  if defined RECONFIG echo overwrite ... tools_def.template to %CONF_PATH%\tools_def.txt
   if defined RECONFIG copy /Y %EDK_TOOLS_PATH%\Conf\tools_def.template %CONF_PATH%\tools_def.txt > nul
 )
 


### PR DESCRIPTION
The words "overwrite" and "overwriting" are one word and shouldn't have
hyphens.

Signed-off-by: Rebecca Cran <rebecca@bsdio.com>
Reviewed-by: Bob Feng <bob.c.feng@intel.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>