### PR TITLE
BaseTools: Reset ERRORLEVEL in toolsetup.bat after edk2basetools check

### DIFF
--- a/BaseTools/toolsetup.bat
+++ b/BaseTools/toolsetup.bat
@@ -401,6 +401,8 @@ goto end
   if %ERRORLEVEL% EQU 0 (
     goto use_pip_basetools
   ) else (
+    REM reset ERRORLEVEL
+    type nul>nul
     goto use_builtin_basetools
   )
 


### PR DESCRIPTION
When using the in-source BaseTools, edksetup.bat will exit with an
ERRORLEVEL of 1 because the line in toolsetup.bat
"%PYTHON_COMMAND% -c "import edk2basetools" >NUL 2>NUL"
fails.

Ensure ERRORLEVEL is set to 0 when edksetup.bat or toolsetup.bat is
successfully run.

Signed-off-by: Rebecca Cran <rebecca@bsdio.com>
Reviewed-by: Bob Feng <bob.c.feng@intel.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>