### PR TITLE
[edk2-devel] [PATCH] OvmfPkg/XenPlatformPei: Relocate shared_info page mapping -- push

### DIFF
--- a/OvmfPkg/XenPlatformPei/Xen.c
+++ b/OvmfPkg/XenPlatformPei/Xen.c
@@ -569,7 +569,7 @@ CalibrateLapicTimer (
   EFI_STATUS            Status;
 
 
-  SharedInfo = (VOID*)((1ULL << mPhysMemAddressWidth) - EFI_PAGE_SIZE);
+  SharedInfo = (VOID*)((UINTN)PcdGet32 (PcdCpuLocalApicBaseAddress) + SIZE_1MB);
   Status = PhysicalAddressIdentityMapping ((EFI_PHYSICAL_ADDRESS)SharedInfo);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR,


### PR DESCRIPTION
http://mid.mail-archive.com/20210628132337.46345-1-anthony.perard@citrix.com
https://edk2.groups.io/g/devel/message/77183
https://listman.redhat.com/archives/edk2-devel-archive/2021-June/msg01297.html
~~~
From: Anthony PERARD <anthony.perard@citrix.com>

Unfortunately, Xen isn't ready to deal with mapping at the top of the
physical address space, so we relocate the mapping after the LAPIC
location.

See this thread about the issue with the mapping:
- https://lore.kernel.org/xen-devel/f8c4151a-6dac-d87c-ef46-eb35ada07bd9@suse.com/

The PhysicalAddressIdentityMapping() call isn't going to do anything
anymore since everything under 4GB is already mapped, but there is no
need to remove the call.

CC: Jan Beulich <JBeulich@suse.com>
CC: Andrew Cooper <andrew.cooper3@citrix.com>
Signed-off-by: Anthony PERARD <anthony.perard@citrix.com>
---
 OvmfPkg/XenPlatformPei/Xen.c | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
~~~