### PR TITLE
MdePkg : Add IPMI Macro and Structure Defintions to resolve build errors

### DIFF
--- a/MdePkg/Include/IndustryStandard/IpmiNetFnChassis.h
+++ b/MdePkg/Include/IndustryStandard/IpmiNetFnChassis.h
@@ -186,6 +186,10 @@ typedef struct {
   UINT8                                  ParameterData[0];
 } IPMI_SET_BOOT_OPTIONS_REQUEST;
 
+typedef struct {
+  UINT8   CompletionCode:8;
+} IPMI_SET_BOOT_OPTIONS_RESPONSE;
+
 //
 //  Definitions for Get System Boot options command
 //

--- a/MdePkg/Include/IndustryStandard/IpmiNetFnFirmware.h
+++ b/MdePkg/Include/IndustryStandard/IpmiNetFnFirmware.h
@@ -17,4 +17,22 @@
 // All Firmware commands and their structure definitions to follow here
 //
 
+// ----------------------------------------------------------------------------------------
+//    Definitions for Get BMC Execution Context
+// ----------------------------------------------------------------------------------------
+#define IPMI_GET_BMC_EXECUTION_CONTEXT  0x23
+
+//
+//  Constants and Structure definitions for "Get Device ID" command to follow here
+//
+typedef struct {
+  UINT8   CurrentExecutionContext;
+  UINT8   PartitionPointer;
+} IPMI_MSG_GET_BMC_EXEC_RSP;
+
+//
+// Current Execution Context responses
+//
+#define IPMI_BMC_IN_FORCED_UPDATE_MODE  0x11
+
 #endif


### PR DESCRIPTION
Build error reported for missing structures IPMI_SET_BOOT_OPTIONS_RESPONSE,
EFI_IPMI_MSG_GET_BMC_EXEC_RSP, macro EFI_FIRMWARE_GET_BMC_EXECUTION_CONTEXT
EFI_FIRMWARE_BMC_IN_FULL_RUNTIME/EFI_FIRMWARE_BMC_IN_FORCED_UPDATE_MODE
when using edk2-platforms\Features\Intel\OutOfBandManagement\IpmiFeaturePkg

Rename EFI_IPMI_MSG_GET_BMC_EXEC_RSPB,
EFI_FIRMWARE_GET_BMC_EXECUTION_CONTEXT
EFI_FIRMWARE_BMC_IN_FORCED_UPDATE_MODE to
IPMI_MSG_GET_BMC_EXEC_RSPB,IPMI_GET_BMC_EXECUTION_CONTEXT
IPMI_BMC_IN_FORCED_UPDATE_MODE

Signed-off-by: Manickavasakam Karpagavinayagam <manickavasakamk@ami.com>
Reviewed-by: Isaac Oram <isaac.w.oram@intel.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>