### PR TITLE
Mergify Enhancements

### DIFF
--- a/.azurepipelines/templates/pr-gate-build-job.yml
+++ b/.azurepipelines/templates/pr-gate-build-job.yml
@@ -67,23 +67,3 @@ jobs:
       build_pkgs: $(Build.Pkgs)
       build_targets: $(Build.Targets)
       build_archs: ${{ parameters.arch_list }}
-
-- job: FINISHED
-  dependsOn: Build_${{ parameters.tool_chain_tag }}
-  condition: succeeded()
-  steps:
-  - checkout: none
-  - script: |
-      echo FINISHED
-      sleep 10
-    displayName: FINISHED
-
-- job: FAILED
-  dependsOn: Build_${{ parameters.tool_chain_tag }}
-  condition: failed()
-  steps:
-  - checkout: none
-  - script: |
-      echo FAILED
-      sleep 10
-    displayName: FAILED

--- a/.mergify/config.yml
+++ b/.mergify/config.yml
@@ -16,7 +16,7 @@
 # * This file must be checked into the 'default' branch of a repo.  Copies
 #   of this file on other branches of a repo are ignored by Mergify.
 #
-# Copyright (c) 2019 - 2020, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2019 - 2021, Intel Corporation. All rights reserved.<BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 # https://github.com/apps/mergify
@@ -24,74 +24,27 @@
 #
 ##
 
-pull_request_rules:
+queue_rules:
+  - name: default
+    conditions:
+      - base~=(^main|^master|^stable/)
+      - label=push
 
+pull_request_rules:
   - name: Automatically merge a PR when all required checks pass and 'push' label is present
     conditions:
-      - base~=(^master|^stable/)
+      - base~=(^main|^master|^stable/)
       - label=push
-      - author=@tianocore/edk-ii-maintainers
-      - status-success=tianocore.PatchCheck
-      - status-success=Ubuntu GCC5 PR
-      - status-success=Windows VS2019 PR
     actions:
-      merge:
-        strict: true
+      queue:
         method: rebase
-
-  - name: Automatically close a PR when all required checks pass and 'push' label is not present
-    conditions:
-      - base~=(^master|^stable/)
-      - -label=push
-      - -closed
-      - status-success=tianocore.PatchCheck
-      - status-success=Ubuntu GCC5 PR
-      - status-success=Windows VS2019 PR
-      - status-success=Ubuntu GCC5 PR (FINISHED)
-      - status-success=Windows VS2019 PR (FINISHED)
-    actions:
-      close:
-        message: All checks passed. Auto close personal build.
+        rebase_fallback: none
+        name: default
 
   - name: Post a comment on a PR that can not be merged due to a merge conflict
     conditions:
-      - base~=(^master|^stable/)
+      - base~=(^main|^master|^stable/)
       - conflict
     actions:
       comment:
         message: PR can not be merged due to conflict.  Please rebase and resubmit
-
-  - name: Automatically close a PR that fails the EDK II Maintainers membership check and 'push' label is present
-    conditions:
-      - base~=(^master|^stable/)
-      - label=push
-      - -author=@tianocore/edk-ii-maintainers
-    actions:
-      close:
-        message: PR submitter is not a member of the Tianocore EDK II Maintainers team
-
-  - name: Post a comment on a PR if PatchCheck fails
-    conditions:
-      - base~=(^master|^stable/)
-      - status-failure=tianocore.PatchCheck
-    actions:
-      comment:
-        message: PR can not be merged due to a PatchCheck failure.  Please resolve and resubmit
-
-  - name: Post a comment on a PR if Ubuntu GCC5 fails
-    conditions:
-      - base~=(^master|^stable/)
-      - status-failure=Ubuntu GCC5 PR
-      - status-success=Ubuntu GCC5 PR (FAILED)
-    actions:
-      comment:
-        message: PR can not be merged due to an Ubuntu GCC5 failure.  Please resolve and resubmit
-
-  - name: Post a comment on a PR if Windows VS2019 fails
-    conditions:
-      - base~=(^master|^stable/)
-      - status-failure=Windows VS2019 PR
-      - status-success=Windows VS2019 PR (FAILED)
-    actions:
-      comment:
-        message: PR can not be merged due to a Windows VS2019 failure.  Please resolve and resubmit

--- a/BaseTools/Scripts/PatchCheck.py
+++ b/BaseTools/Scripts/PatchCheck.py
@@ -1,7 +1,7 @@
 ## @file
 #  Check a patch for various format issues
 #
-#  Copyright (c) 2015 - 2020, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2015 - 2021, Intel Corporation. All rights reserved.<BR>
 #  Copyright (C) 2020, Red Hat, Inc.<BR>
 #  Copyright (c) 2020, ARM Ltd. All rights reserved.<BR>
 #
@@ -89,12 +89,17 @@ class EmailAddressCheck:
 class CommitMessageCheck:
     """Checks the contents of a git commit message."""
 
-    def __init__(self, subject, message):
+    def __init__(self, subject, message, author_email):
         self.ok = True
 
         if subject is None and  message is None:
             self.error('Commit message is missing!')
             return
+
+        MergifyMerge = False
+        if "mergify[bot]@users.noreply.github.com" in author_email:
+            if "Merge branch" in subject:
+                MergifyMerge = True
 
         self.subject = subject
         self.msg = message
@@ -102,9 +107,10 @@ class CommitMessageCheck:
         print (subject)
 
         self.check_contributed_under()
-        self.check_signed_off_by()
-        self.check_misc_signatures()
-        self.check_overall_format()
+        if not MergifyMerge:
+            self.check_signed_off_by()
+            self.check_misc_signatures()
+            self.check_overall_format()
         self.report_message_result()
 
     url = 'https://github.com/tianocore/tianocore.github.io/wiki/Commit-Message-Format'
@@ -522,7 +528,7 @@ class CheckOnePatch:
         email_check = EmailAddressCheck(self.author_email, 'Author')
         email_ok = email_check.ok
 
-        msg_check = CommitMessageCheck(self.commit_subject, self.commit_msg)
+        msg_check = CommitMessageCheck(self.commit_subject, self.commit_msg, self.author_email)
         msg_ok = msg_check.ok
 
         diff_ok = True


### PR DESCRIPTION
* Removed FINISHED and FAILED states with 10 second delays
* Update PatchCheck.py to ignore commit message format issues
  in merge commits added by Mergify
* Enable Mergify queue feature to support auto rebase when
  'push' label is set and guarantee that all EDK II CI checks
  are run before merging in changes with linear history.
* Use status checks configured in GitHub branch protections
* Allow non EDK II Maintainers to create a PR
  Requires an EDK II Maintainer to accept the change and
  request merge by adding 'push' label.  Only EDK II Maintainers
  have ability to set/clear labels.
* Do not automatically close PRs for personal builds.

Cc: Sean Brogan <sean.brogan@microsoft.com>
Cc: Bret Barkelew <Bret.Barkelew@microsoft.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Bob Feng <bob.c.feng@intel.com>
Cc: Yuwei Chen <yuwei.chen@intel.com>
Signed-off-by: Michael D Kinney <michael.d.kinney@intel.com>
