### PR TITLE
Maintainers.txt: remove Laszlo Ersek's entries

### DIFF
--- a/Maintainers.txt
+++ b/Maintainers.txt
@@ -69,7 +69,6 @@ Tianocore Stewards
 ------------------
 F: *
 M: Andrew Fish <afish@apple.com>
-M: Laszlo Ersek <lersek@redhat.com>
 M: Leif Lindholm <leif@nuviainc.com>
 M: Michael D Kinney <michael.d.kinney@intel.com>
 
@@ -143,7 +142,6 @@ M: Ard Biesheuvel <ardb+tianocore@kernel.org>
 ArmVirtPkg
 F: ArmVirtPkg/
 W: https://github.com/tianocore/tianocore.github.io/wiki/ArmVirtPkg
-M: Laszlo Ersek <lersek@redhat.com>
 M: Ard Biesheuvel <ardb+tianocore@kernel.org>
 R: Leif Lindholm <leif@nuviainc.com>
 R: Sami Mujawar <sami.mujawar@arm.com>
@@ -421,7 +419,6 @@ R: Siyuan Fu <siyuan.fu@intel.com>
 OvmfPkg
 F: OvmfPkg/
 W: http://www.tianocore.org/ovmf/
-M: Laszlo Ersek <lersek@redhat.com>
 M: Ard Biesheuvel <ardb+tianocore@kernel.org>
 R: Jordan Justen <jordan.l.justen@intel.com>
 S: Maintained
@@ -567,7 +564,6 @@ F: UefiCpuPkg/
 W: https://github.com/tianocore/tianocore.github.io/wiki/UefiCpuPkg
 M: Eric Dong <eric.dong@intel.com>
 M: Ray Ni <ray.ni@intel.com>
-R: Laszlo Ersek <lersek@redhat.com>
 R: Rahul Kumar <rahul1.kumar@intel.com>
 
 UefiCpuPkg: Sec related modules


### PR DESCRIPTION
I'm relinquishing all my roles listed in "Maintainers.txt", for personal
reasons.

My email address <lersek@redhat.com> remains functional.

To my understanding, my employer is working to assign others engineers to
the edk2 project (at their discretion).

Cc: Andrew Fish <afish@apple.com>
Cc: Ard Biesheuvel <ardb+tianocore@kernel.org>
Cc: Eric Dong <eric.dong@intel.com>
Cc: Jordan Justen <jordan.l.justen@intel.com>
Cc: Leif Lindholm <leif@nuviainc.com>
Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Philippe Mathieu-Daud? <philmd@redhat.com>
Cc: Rahul Kumar <rahul1.kumar@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Cc: Sami Mujawar <sami.mujawar@arm.com>
Signed-off-by: Laszlo Ersek <lersek@redhat.com>
Reviewed-by: Andrew Fish <afish@apple.com>
Reviewed-by: Leif Lindholm <leif@nuviainc.com>
Reviewed-by: Michael D Kinney <michael.d.kinney@intel.com>
Reviewed-by: Philippe Mathieu-Daude <philmd@redhat.com>
Reviewed-by: Ard Biesheuvel <ardb@kernel.org>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>