### PR TITLE
BaseTools: Remove non-ascii character of StructurePcd comment

### DIFF
--- a/BaseTools/Scripts/ConvertFceToStructurePcd.py
+++ b/BaseTools/Scripts/ConvertFceToStructurePcd.py
@@ -284,7 +284,15 @@ class Config(object):
         line=x.split('\n')[0]
         comment_list = value_re.findall(line) # the string \\... in "Q...." line
         comment_list[0] = comment_list[0].replace('//', '')
-        comment = comment_list[0].strip()
+        comment_ori = comment_list[0].strip()
+        comment = ""
+        for each in comment_ori:
+            if each != " " and "\x21" > each or each > "\x7E":
+                if bytes(each, 'utf-16') == b'\xff\xfe\xae\x00':
+                    each = '(R)'
+                else:
+                    each = ""
+            comment += each
         line=value_re.sub('',line) #delete \\... in "Q...." line
         list1=line.split(' ')
         value=self.value_parser(list1)


### PR DESCRIPTION
Currently, the ConvertFceToStructurePcd.py tool generate
StructurePcd dsc file with comments from UNI file including
non-ascii character. Following DSC spec, there should not have
non-ascii character in DSC file. This patch removes the non-ascii
character when adding the comment and changes the circle R to (R).

Signed-off-by: Yuwei Chen <yuwei.chen@intel.com>
Cc: Bob Feng <bob.c.feng@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Reviewed-by: Bob Feng <bob.c.feng@intel.com>