### PR TITLE
RamDiskDxe: initialize list head before registering ram disk protocol

### DIFF
--- a/MdeModulePkg/Universal/Disk/RamDiskDxe/RamDiskDriver.c
+++ b/MdeModulePkg/Universal/Disk/RamDiskDxe/RamDiskDriver.c
@@ -155,6 +155,12 @@ RamDiskDxeEntryPoint (
   }
 
   //
+  // Initialize the list of registered RAM disks maintained by the driver
+  // before installing the protocol
+  //
+  InitializeListHead (&RegisteredRamDisks);
+
+  //
   // Install the EFI_RAM_DISK_PROTOCOL and RAM disk private data onto a
   // new handle
   //
@@ -169,11 +175,6 @@ RamDiskDxeEntryPoint (
   if (EFI_ERROR (Status)) {
     goto ErrorExit;
   }
-
-  //
-  // Initialize the list of registered RAM disks maintained by the driver
-  //
-  InitializeListHead (&RegisteredRamDisks);
 
   Status = EfiCreateEventReadyToBootEx (
              TPL_CALLBACK,


### PR DESCRIPTION
This patch initializes the linked list `RegisteredRamDisks` in `RamDiskDxeEntryPoint()` before the registration of `gEfiRamDiskProtocolGuid` with `gBS->InstallMultipleProtocolInterfaces()`, allowing ramdisks to be created via a callback installed with `RegisterProtocolNotify` as soon as the protocol is registered.

Without this, calling `RamDisk->Register()` in the callback causes a crash:

```
ASSERT [RamDiskDxe] MdePkg/Library/BaseLib/LinkedList.c(75): List->ForwardLink != ((void *) 0)
```

Signed-off-by: Trammell Hudson <hudson@trmm.net>