### PR TITLE
MdeModulePkg/RamDiskDxe: Init list head before registering RamDisk protocol

### DIFF
--- a/MdeModulePkg/Universal/Disk/RamDiskDxe/RamDiskDriver.c
+++ b/MdeModulePkg/Universal/Disk/RamDiskDxe/RamDiskDriver.c
@@ -155,6 +155,12 @@ RamDiskDxeEntryPoint (
   }
 
   //
+  // Initialize the list of registered RAM disks maintained by the driver
+  // before installing the protocol
+  //
+  InitializeListHead (&RegisteredRamDisks);
+
+  //
   // Install the EFI_RAM_DISK_PROTOCOL and RAM disk private data onto a
   // new handle
   //
@@ -169,11 +175,6 @@ RamDiskDxeEntryPoint (
   if (EFI_ERROR (Status)) {
     goto ErrorExit;
   }
-
-  //
-  // Initialize the list of registered RAM disks maintained by the driver
-  //
-  InitializeListHead (&RegisteredRamDisks);
 
   Status = EfiCreateEventReadyToBootEx (
              TPL_CALLBACK,


### PR DESCRIPTION
**Patch sent at:** https://edk2.groups.io/g/devel/message/77723
**Cover letter:** https://edk2.groups.io/g/devel/message/77722
Sending this patch on behalf of Trammell, who asked me to do so, so that he doesn't have to set up git-send-email config.
See his PR: https://github.com/tianocore/edk2/pull/1810

Trammell Hudson (1):
  RamDiskDxe: initialize list head before registering ram disk protocol

 MdeModulePkg/Universal/Disk/RamDiskDxe/RamDiskDriver.c | 11 ++++++-----
 1 file changed, 6 insertions(+), 5 deletions(-)

**Commit message:**
REF:https://bugzilla.tianocore.org/show_bug.cgi?id=3483

This patch initializes the linked list RegisteredRamDisks in
RamDiskDxeEntryPoint before the registration of gEfiRamDiskProtocolGuid
with InstallMultipleProtocolInterfaces, allowing ramdisks to be created
via a callback installed with RegisterProtocolNotify as soon as the
protocol is registered.

Without this, calling RamDisk->Register() in the callback causes a crash:

ASSERT [RamDiskDxe] MdePkg/Library/BaseLib/LinkedList.c(75): List->ForwardLink != ((void *) 0)

Signed-off-by: Trammell Hudson <hudson@trmm.net>
Cc: Daniel Schaefer <daniel.schaefer@hpe.com>
Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Hao A Wu <hao.a.wu@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Cc: Zhichao Gao <zhichao.gao@intel.com>
Reviewed-by: Hao A Wu <hao.a.wu@intel.com>