### PR TITLE
IntelFsp2Pkg: BaseCacheLib EfiProgramMtrr MtrrNumber Should be UINT32

### DIFF
--- a/IntelFsp2Pkg/Library/BaseCacheLib/BaseCacheLib.inf
+++ b/IntelFsp2Pkg/Library/BaseCacheLib/BaseCacheLib.inf
@@ -1,7 +1,7 @@
 ## @file
 #  Instance of BaseCache.
 #
-#  Copyright (c) 2014 - 2017, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2014 - 2021, Intel Corporation. All rights reserved.<BR>
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -15,7 +15,7 @@
   VERSION_STRING                 = 1.0
   LIBRARY_CLASS                  = CacheLib
 
-[Sources.IA32]
+[Sources]
   CacheLib.c
   CacheLibInternal.h
 

--- a/IntelFsp2Pkg/Library/BaseCacheLib/CacheLib.c
+++ b/IntelFsp2Pkg/Library/BaseCacheLib/CacheLib.c
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2014 - 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2014 - 2021, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -164,7 +164,7 @@ EfiRecoverCacheMtrr (
 **/
 VOID
 EfiProgramMtrr (
-  IN  UINTN                     MtrrNumber,
+  IN  UINT32                    MtrrNumber,
   IN  EFI_PHYSICAL_ADDRESS      MemoryAddress,
   IN  UINT64                    MemoryLength,
   IN  EFI_MEMORY_CACHE_TYPE     MemoryCacheType,


### PR DESCRIPTION
REF:https://bugzilla.tianocore.org/show_bug.cgi?id=3485

CacheLib EfiProgramMtrr Function takes MTRR number as a input parameter,
in the function the parameter is defined as UINTN were as the caller
calling MTTR number in UINT32.

Signed-off-by: Ashraf Ali S <ashraf.ali.s@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Cc: Chasel Chiu <chasel.chiu@intel.com>
Cc: Nate DeSimone <nathaniel.l.desimone@intel.com>
Cc: Star Zeng <star.zeng@intel.com>
Cc: Digant H Solanki <digant.h.solanki@intel.com>
Cc: Sangeetha V <sangeetha.v@intel.com>
Reviewed-by: Chasel Chiu <chasel.chiu@intel.com>