### PR TITLE
MdePkg/Include: Smbios Specification 3.4.0 changes

### DIFF
--- a/MdePkg/Include/IndustryStandard/SmBios.h
+++ b/MdePkg/Include/IndustryStandard/SmBios.h
@@ -1393,7 +1393,10 @@ typedef struct {
   UINT8  HotPlugDevicesSupported :1;
   UINT8  SmbusSignalSupported    :1;
   UINT8  BifurcationSupported    :1;
-  UINT8  Reserved                :4;  ///< Set to 0.
+  UINT8  AsyncSurpriseRemoval    :1;
+  UINT8  FlexbusSlotCxl10Capable :1;
+  UINT8  FlexbusSlotCxl20Capable :1;
+  UINT8  Reserved                :1;  ///< Set to 0.
 } MISC_SLOT_CHARACTERISTICS2;
 
 ///
@@ -1435,6 +1438,12 @@ typedef struct {
   UINT8                       DataBusWidth;
   UINT8                       PeerGroupingCount;
   MISC_SLOT_PEER_GROUP        PeerGroups[1];
+  //
+  // Add for smbios 3.4
+  //
+  UINT8                       SlotInformation;
+  UINT8                       SlotPhysicalWidth;
+  UINT16                      SlotPitch;
 } SMBIOS_TABLE_TYPE9;
 
 ///
@@ -1628,7 +1637,7 @@ typedef enum {
   MemoryArrayLocationPc98C24AddonCard      = 0xA1,
   MemoryArrayLocationPc98EAddonCard        = 0xA2,
   MemoryArrayLocationPc98LocalBusAddonCard = 0xA3,
-  MemoryArrayLocationCXLFlexbus10AddonCard = 0xA4
+  MemoryArrayLocationCXLAddonCard          = 0xA4
 } MEMORY_ARRAY_LOCATION;
 
 ///
@@ -1763,17 +1772,18 @@ typedef struct {
 /// Memory Device - Memory Technology
 ///
 typedef enum {
-  MemoryTechnologyOther                     = 0x01,
-  MemoryTechnologyUnknown                   = 0x02,
-  MemoryTechnologyDram                      = 0x03,
-  MemoryTechnologyNvdimmN                   = 0x04,
-  MemoryTechnologyNvdimmF                   = 0x05,
-  MemoryTechnologyNvdimmP                   = 0x06,
+  MemoryTechnologyOther                          = 0x01,
+  MemoryTechnologyUnknown                        = 0x02,
+  MemoryTechnologyDram                           = 0x03,
+  MemoryTechnologyNvdimmN                        = 0x04,
+  MemoryTechnologyNvdimmF                        = 0x05,
+  MemoryTechnologyNvdimmP                        = 0x06,
   //
   // This definition is updated to represent Intel
-  // Optane DC Presistent Memory in SMBIOS spec 3.3.0
+  // Optane DC Persistent Memory in SMBIOS spec 3.4.0
   //
-  MemoryTechnologyIntelPersistentMemory     = 0x07
+  MemoryTechnologyIntelOptanePersistentMemory    = 0x07
+
 } MEMORY_DEVICE_TECHNOLOGY;
 
 ///

--- a/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/QueryTable.c
+++ b/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/QueryTable.c
@@ -2300,8 +2300,8 @@ TABLE_ITEM  PMALocationTable[] = {
     L"  PC-98/Local bus add-on card"
   },
   {
-    MemoryArrayLocationCXLFlexbus10AddonCard,
-    L"  CXL Flexbus 1.0 add-on card"
+    MemoryArrayLocationCXLAddonCard,
+    L"  CXL add-on card"
   }
 };
 
@@ -2650,8 +2650,8 @@ TABLE_ITEM  MemoryDeviceMemoryTechnologyTable[] = {
     L" NVDIMM-P"
   },
   {
-    MemoryTechnologyIntelPersistentMemory,
-    L" Intel Optane DC Persistent Memory"
+    MemoryTechnologyIntelOptanePersistentMemory,
+    L" Intel Optane Persistent Memory"
   }
 };
 


### PR DESCRIPTION
The following changes were addressed,
1. Smbios specs 3.4.0 table-51 bit5&6, these fields moved
   from specific MemoryArrayLocationCXLFlexbus10AddonCard
   to generic MemoryArrayLocationCXLAddonCard
   to address both CXL1.0 and 2.0 CXL revisions.
2. Smbios specs 3.4.0 table-79, The memory technology name changed
   from MemoryTechnologyIntelPersistentMemory
   to MemoryTechnologyIntelOptanePersistentMemory.

Signed-off-by: Thotala Gopi <gopi.thotala@intel.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>