### PR TITLE
MdeModulePkg PCD: Print which PCD was unable to be found

### DIFF
--- a/MdeModulePkg/Universal/PCD/Dxe/Service.c
+++ b/MdeModulePkg/Universal/PCD/Dxe/Service.c
@@ -3,7 +3,7 @@
 
 Copyright (c) 2014, Hewlett-Packard Development Company, L.P.<BR>
 Copyright (c) 2006 - 2018, Intel Corporation. All rights reserved.<BR>
-(C) Copyright 2016 Hewlett Packard Enterprise Development LP<BR>
+(C) Copyright 2016-2021 Hewlett Packard Enterprise Development LP<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -1610,6 +1610,7 @@ GetExPcdTokenNumber (
     }
   }
 
+  DEBUG ((DEBUG_ERROR, "%a: Failed to find PCD with GUID: %g and token number: %d\n", __FUNCTION__, Guid, ExTokenNumber));
   ASSERT (FALSE);
 
   return 0;


### PR DESCRIPTION
**Cover-letter:** https://edk2.groups.io/g/devel/message/77759

When reaching the assert, it can't be debugged because the PCD is
unknown. Therefore the PCD's GUID and token number should be printed.

Signed-off-by: Daniel Schaefer <daniel.schaefer@hpe.com>
Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Hao A Wu <hao.a.wu@intel.com>
Cc: Dandan Bi <dandan.bi@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Reviewed-by: Hao A Wu <hao.a.wu@intel.com>