### PR TITLE
PlatformBdsConnectSequence before TryRunningQemuKernel

### DIFF
--- a/OvmfPkg/Library/PlatformBootManagerLib/BdsPlatform.c
+++ b/OvmfPkg/Library/PlatformBootManagerLib/BdsPlatform.c
@@ -1517,14 +1517,14 @@ PlatformBootManagerAfterConsole (
   Tcg2PhysicalPresenceLibProcessRequest (NULL);
 
   //
-  // Process QEMU's -kernel command line option
-  //
-  TryRunningQemuKernel ();
-
-  //
   // Perform some platform specific connect sequence
   //
   PlatformBdsConnectSequence ();
+  
+  //
+  // Process QEMU's -kernel command line option
+  //
+  TryRunningQemuKernel ();
 
   EfiBootManagerRefreshAllBootOption ();
 


### PR DESCRIPTION
This PR runs PlatformBdsConnectSequence() before TryRunningQemuKernel(). It reverses commit a34a886962561f6d8550b2a1bb193798ca456431 which claimed to improve UEFI boot time. Unfortunately that commit now results in boot failure when using qemu's -kernel option (and therefore -initrd & -append). The last releases which work correctly are vUDK2017 and vUDK2018. Such failures are seen in edk2-stable201808, edk2-stable201811, edk2-stable202105 and presumably all releases in between.

This PR has been tested with edk2-stable201808, edk2-stable201811, edk2-stable202105 as well as master (at 21/7/2021) and results in correct booting using the -kernel option. No measurable change in boot times was discernible compared with unaffected vUDK2017 & vUDK2018 releases.