### PR TITLE
MdeModulePkg/CapsuleApp: Fix typo in error message

### DIFF
--- a/MdeModulePkg/Application/CapsuleApp/CapsuleOnDisk.c
+++ b/MdeModulePkg/Application/CapsuleApp/CapsuleOnDisk.c
@@ -509,7 +509,7 @@ GetUpdateFileSystem (
     DevicePath = DuplicateDevicePath (MappedDevicePath);
     Status = GetEfiSysPartitionFromDevPath (DevicePath, &FullPath, Fs);
     if (EFI_ERROR (Status)) {
-      Print (L"Error: Cannot get EFI system partiion from '%s' - %r\n", Map, Status);
+      Print (L"Error: Cannot get EFI system partition from '%s' - %r\n", Map, Status);
       return EFI_NOT_FOUND;
     }
     Print (L"Warning: Cannot find Boot Option on '%s'!\n", Map);


### PR DESCRIPTION
Fix typo in error message in CapsuleApp.

Signed-off-by: Seonghyun Park <shpark1@protonmail.com>
Reviewed-by: Hao A Wu <hao.a.wu@intel.com>