### PR TITLE
MdeModulePkg/UefiSortLib:Add UefiSortLib unit test

### DIFF
--- a/RedfishPkg/RedfishRestExDxe/RedfishRestExImpl.c
+++ b/RedfishPkg/RedfishRestExDxe/RedfishRestExImpl.c
@@ -44,7 +44,7 @@ ResetHttpTslSession (
 }
 
 /**
-  This function check
+  This function check Http receive status
 
   @param[in]  Instance             Pointer to EFI_REST_EX_PROTOCOL instance for a particular
                                    REST service.
@@ -67,37 +67,33 @@ RedfishCheckHttpReceiveStatus (
 
   if (!EFI_ERROR (HttpIoReceiveStatus)) {
     ReturnStatus = EFI_SUCCESS;
-  } else if (EFI_ERROR (HttpIoReceiveStatus) && (HttpIoReceiveStatus != EFI_CONNECTION_FIN)) {
+  } else if (HttpIoReceiveStatus != EFI_CONNECTION_FIN) {
     if ((Instance->Flags & RESTEX_INSTANCE_FLAGS_TCP_ERROR_RETRY) == 0) {
       DEBUG ((DEBUG_ERROR, "%a: TCP error, reset HTTP session.\n", __FUNCTION__));
       Instance->Flags |= RESTEX_INSTANCE_FLAGS_TCP_ERROR_RETRY;
       gBS->Stall (500);
       Status = ResetHttpTslSession (Instance);
-      if (EFI_ERROR (Status)) {
-        DEBUG ((DEBUG_ERROR, "%a: Reset HTTP instance fail.\n", __FUNCTION__));
-        ReturnStatus = EFI_DEVICE_ERROR;
-      } else {
+      if (!EFI_ERROR (Status)) {
         return EFI_NOT_READY;
       }
-    } else {
+      DEBUG ((DEBUG_ERROR, "%a: Reset HTTP instance fail.\n", __FUNCTION__));
+    }
+
+    ReturnStatus = EFI_DEVICE_ERROR;
+  } else {
+    if ((Instance->Flags & RESTEX_INSTANCE_FLAGS_TLS_RETRY) != 0) {
+      DEBUG ((DEBUG_ERROR, "%a: REST_EX Send and receive fail even with a new TLS session.\n", __FUNCTION__));
       ReturnStatus = EFI_DEVICE_ERROR;
     }
-  } else {
-    if (HttpIoReceiveStatus == EFI_CONNECTION_FIN) {
-      if ((Instance->Flags & RESTEX_INSTANCE_FLAGS_TLS_RETRY) != 0) {
-        DEBUG ((DEBUG_ERROR, "%a: REST_EX Send and receive fail even with a new TLS session.\n", __FUNCTION__));
-        ReturnStatus = EFI_DEVICE_ERROR;
-      }
 
-      Instance->Flags |= RESTEX_INSTANCE_FLAGS_TLS_RETRY;
-      Status           = ResetHttpTslSession (Instance);
-      if (EFI_ERROR (Status)) {
-        DEBUG ((DEBUG_ERROR, "%a: Reset HTTP instance fail.\n", __FUNCTION__));
-        ReturnStatus = EFI_DEVICE_ERROR;
-      }
-
-      return EFI_NOT_READY;
+    Instance->Flags |= RESTEX_INSTANCE_FLAGS_TLS_RETRY;
+    Status           = ResetHttpTslSession (Instance);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a: Reset HTTP instance fail.\n", __FUNCTION__));
+      ReturnStatus = EFI_DEVICE_ERROR;
     }
+
+    return EFI_NOT_READY;
   }
 
   //


### PR DESCRIPTION
Adding two unit test case for UefiSortLib. One is a test on
sorting an array of UINT32 by using PerformQuickSort, another
is a test on comparing the same buffer by using StringCompare.

Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Hao A Wu <hao.a.wu@intel.com>
Signed-off-by: Wenyi Xie <xiewenyi2@huawei.com>