### PR TITLE
EmbeddedPkg/libfdt: Add strcmp and strncpy to libfdt_env.h

### DIFF
--- a/EmbeddedPkg/Include/libfdt_env.h
+++ b/EmbeddedPkg/Include/libfdt_env.h
@@ -76,8 +76,16 @@ static inline size_t strnlen (const char* str, size_t strsz ) {
   return AsciiStrnLenS (str, strsz);
 }
 
+static inline size_t strcmp (const char* str1, const char* str2) {
+  return AsciiStrCmp (str1, str2);
+}
+
 static inline size_t strncmp (const char* str1, const char* str2, size_t strsz ) {
   return AsciiStrnCmp (str1, str2, strsz);
+}
+
+static inline size_t strncpy (char* dest, const char* source, size_t dest_max) {
+  return AsciiStrCpyS (dest, dest_max, source);
 }
 
 #endif /* _LIBFDT_ENV_H */


### PR DESCRIPTION
OpenSBI has started using those in v0.9. See:
https://github.com/riscv/opensbi/blob/v0.9/lib/utils/fdt/fdt_domain.c

Cc: Leif Lindholm <leif@nuviainc.com>
Cc: Ard Biesheuvel <ard.biesheuvel@arm.com>
Cc: Daniel Schaefer <daniel.schaefer@hpe.com>
Cc: Anup Patel <anup.patel@wdc.com>
Signed-off-by: Daniel Schaefer <daniel.schaefer@hpe.com>
Acked-by: Leif Lindholm <leif@nuviainc.com>