### PR TITLE
UefiCpuPkg/CpuCacheInfoLib: Sort CpuCacheInfo array

### DIFF
--- a/UefiCpuPkg/Include/Library/CpuCacheInfoLib.h
+++ b/UefiCpuPkg/Include/Library/CpuCacheInfoLib.h
@@ -59,7 +59,7 @@ typedef struct {
 } CPU_CACHE_INFO;
 
 /**
-  Get CpuCacheInfo data array.
+  Get CpuCacheInfo data array. The array is sorted by CPU package ID, core type, cache level and cache type.
 
   @param[in, out] CpuCacheInfo        Pointer to the CpuCacheInfo array.
   @param[in, out] CpuCacheInfoCount   As input, point to the length of response CpuCacheInfo array.

--- a/UefiCpuPkg/Library/CpuCacheInfoLib/DxeCpuCacheInfoLib.inf
+++ b/UefiCpuPkg/Library/CpuCacheInfoLib/DxeCpuCacheInfoLib.inf
@@ -3,7 +3,7 @@
 #
 #  Provides cache info for each package, core type, cache level and cache type.
 #
-#  Copyright (c) 2020, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2020 - 2021, Intel Corporation. All rights reserved.<BR>
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -25,6 +25,7 @@
 
 [Packages]
   MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
   UefiCpuPkg/UefiCpuPkg.dec
 
 [LibraryClasses]
@@ -33,6 +34,7 @@
   BaseMemoryLib
   MemoryAllocationLib
   UefiBootServicesTableLib
+  SortLib
 
 [Protocols]
   gEfiMpServiceProtocolGuid

--- a/UefiCpuPkg/Library/CpuCacheInfoLib/InternalCpuCacheInfoLib.h
+++ b/UefiCpuPkg/Library/CpuCacheInfoLib/InternalCpuCacheInfoLib.h
@@ -17,7 +17,34 @@
 #include <Library/DebugLib.h>
 #include <Library/BaseMemoryLib.h>
 #include <Library/MemoryAllocationLib.h>
+#include <Library/SortLib.h>
 #include <Library/CpuCacheInfoLib.h>
+
+typedef union {
+  struct {
+    //
+    // Type of the cache that this package's this type of logical processor corresponds to.
+    // Value = CPUID.04h:EAX[04:00]
+    //
+    UINT32        CacheType : 5;
+    //
+    // Level of the cache that this package's this type of logical processor corresponds to.
+    // Value = CPUID.04h:EAX[07:05]
+    //
+    UINT32        CacheLevel : 3;
+    //
+    // Core type of logical processor.
+    // Value = CPUID.1Ah:EAX[31:24]
+    //
+    UINT32        CoreType : 8;
+    UINT32        Reserved : 16;
+    //
+    // Package number.
+    //
+    UINT32        Package;
+  } Bits;
+  UINT64        Uint64;
+} CPU_CACHE_INFO_COMPARATOR;
 
 typedef struct {
   //

--- a/UefiCpuPkg/Library/CpuCacheInfoLib/PeiCpuCacheInfoLib.inf
+++ b/UefiCpuPkg/Library/CpuCacheInfoLib/PeiCpuCacheInfoLib.inf
@@ -3,7 +3,7 @@
 #
 #  Provides cache info for each package, core type, cache level and cache type.
 #
-#  Copyright (c) 2020, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2020 - 2021, Intel Corporation. All rights reserved.<BR>
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -25,6 +25,7 @@
 
 [Packages]
   MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
   UefiCpuPkg/UefiCpuPkg.dec
 
 [LibraryClasses]
@@ -33,6 +34,7 @@
   BaseMemoryLib
   MemoryAllocationLib
   PeiServicesTablePointerLib
+  SortLib
 
 [Ppis]
   gEdkiiPeiMpServices2PpiGuid


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3508

Sort the CpuCacheInfo array by CPU package ID, core type, cache level
and cache type.

Signed-off-by: Jason Lou <yun.lou@intel.com>
Reviewed-by: Ray Ni <ray.ni@intel.com>
Cc: Eric Dong <eric.dong@intel.com>
Cc: Laszlo Ersek <lersek@redhat.com>
Cc: Rahul Kumar <rahul1.kumar@intel.com>