### PR TITLE
UefiPayloadPkg: Fix the non-ascii character in UniversalPayloadEntry.c

### DIFF
--- a/UefiPayloadPkg/UefiPayloadEntry/UniversalPayloadEntry.c
+++ b/UefiPayloadPkg/UefiPayloadEntry/UniversalPayloadEntry.c
@@ -38,7 +38,7 @@ PrintHob (
 /**
   Some bootloader may pass a pcd database, and UPL also contain a PCD database.
   Dxe PCD driver has the assumption that the two PCD database can be catenated and
-  the local token number should be successive。
+  the local token number should be successive.
   This function will fix up the UPL PCD database to meet that assumption.
 
   @param[in]   DxeFv         The FV where to find the Universal PCD database.


### PR DESCRIPTION
Fix the non-ascii character in UniversalPayloadEntry.c

Cc: Guo Dong <guo.dong@intel.com>
Reviewed-by: Ray Ni <ray.ni@intel.com>
Cc: Maurice Ma <maurice.ma@intel.com>
Cc: Benjamin You <benjamin.you@intel.com>

Signed-off-by: DunTan <dun.tan@intel.com>