### PR TITLE
RedfishPkg/RefishCrtLib: Public RefishCrtLib

### DIFF
--- a/RedfishPkg/Include/Library/RedfishCrtLib.h
+++ b/RedfishPkg/Include/Library/RedfishCrtLib.h
@@ -2,7 +2,7 @@
   Redfish CRT wrapper functions.
 
   Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
-  (C) Copyright 2020 Hewlett Packard Enterprise Development LP<BR>
+  (C) Copyright 2021 Hewlett Packard Enterprise Development LP<BR>
 
     SPDX-License-Identifier: BSD-2-Clause-Patent
 

--- a/RedfishPkg/PrivateLibrary/RedfishLib/edk2libredfish/include/redfishPayload.h
+++ b/RedfishPkg/PrivateLibrary/RedfishLib/edk2libredfish/include/redfishPayload.h
@@ -17,7 +17,7 @@
 #ifndef LIBREDFISH_REDFISH_PAYLOAD_H_
 #define LIBREDFISH_REDFISH_PAYLOAD_H_
 
-#include <PrivateInclude/Library/RedfishCrtLib.h>
+#include <Include/Library/RedfishCrtLib.h>
 
 #include <jansson.h>
 #include <redfishService.h>

--- a/RedfishPkg/PrivateLibrary/RedfishLib/edk2libredfish/include/redfishService.h
+++ b/RedfishPkg/PrivateLibrary/RedfishLib/edk2libredfish/include/redfishService.h
@@ -30,7 +30,7 @@
 #include <Library/UefiRuntimeServicesTableLib.h>
 #include <Library/UefiBootServicesTableLib.h>
 
-#include <PrivateInclude/Library/RedfishCrtLib.h>
+#include <Include/Library/RedfishCrtLib.h>
 
 #include <Protocol/EdkIIRedfishConfigHandler.h>
 #include <Protocol/RestEx.h>

--- a/RedfishPkg/PrivateLibrary/RedfishLib/edk2libredfish/include/redpath.h
+++ b/RedfishPkg/PrivateLibrary/RedfishLib/edk2libredfish/include/redpath.h
@@ -17,7 +17,7 @@
 #ifndef LIBREDFISH_REDPATH_H_
 #define LIBREDFISH_REDPATH_H_
 
-#include <PrivateInclude/Library/RedfishCrtLib.h>
+#include <Include/Library/RedfishCrtLib.h>
 
 #include <jansson.h>
 

--- a/RedfishPkg/RedfishPkg.ci.yaml
+++ b/RedfishPkg/RedfishPkg.ci.yaml
@@ -34,8 +34,8 @@
             "PrivateInclude/Crt/stdlib.h",
             "PrivateInclude/Crt/string.h",
             "PrivateInclude/Crt/time.h",
-            "PrivateInclude/Library/RedfishCrtLib.h",
             "PrivateLibrary/RedfishCrtLib/RedfishCrtLib.c",
+            "Include/Library/RedfishCrtLib.h",
             ##
             ## For jansson library open source
             ## load.c is overrided from open source.

--- a/RedfishPkg/RedfishPkg.dec
+++ b/RedfishPkg/RedfishPkg.dec
@@ -60,7 +60,7 @@
   #   CRT library is currently used by edk2 JsonLib (open source
   #   jansson project) and edk2 RedfishLib (libredfish open source
   #   project).
-  RedfishCrtLib|PrivateInclude/Library/RedfishCrtLib.h
+  RedfishCrtLib|Include/Library/RedfishCrtLib.h
 
   ##  @libraryclass Redfish Helper Library
   #   Library provides Redfish helper functions.


### PR DESCRIPTION
Public the header file, move RefishCrtLib.h from PrivateInclude/
to Include/.
RefishCrtLib.lib will be public later. (Moved out from PrivateLibrary/)

Signed-off-by: Abner Chang <abner.chang@hpe.com>
Cc: Nickle Wang <nickle.wang@hpe.com>
Reviewed-by: Nickle Wang <nickle.wang@hpe.com>