### PR TITLE
pip-requirements: Update Basetools pip module

### DIFF
--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -14,5 +14,5 @@
 
 edk2-pytool-library==0.10.*
 edk2-pytool-extensions~=0.13.3
-edk2-basetools==0.1.2
+edk2-basetools==0.1.6
 antlr4-python3-runtime==4.7.1


### PR DESCRIPTION
edk2-basetools 0.1.6 brings things update to date with
BaseTools/Source/Python as of commit:
97fdcbda4e69d6f085ec3f2bd9d29a04af2b50a4

Signed-off-by: Bret Barkelew <bret.barkelew@microsoft.com>