### PR TITLE
MdeModulePkg PCD: Reinstall PCD service PPIS when memory available

### DIFF
--- a/MdeModulePkg/Universal/PCD/Pei/Pcd.c
+++ b/MdeModulePkg/Universal/PCD/Pei/Pcd.c
@@ -1,7 +1,7 @@
 /** @file
   All Pcd Ppi services are implemented here.
 
-Copyright (c) 2006 - 2018, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2006 - 2021, Intel Corporation. All rights reserved.<BR>
 (C) Copyright 2016 Hewlett Packard Enterprise Development LP<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -338,6 +338,75 @@ PcdPeimInit (
   )
 {
   EFI_STATUS Status;
+
+  Status = PeiServicesRegisterForShadow (FileHandle);
+  if (Status == EFI_ALREADY_STARTED) {
+    //
+    // This is now starting in memory, the second time starting.
+    //
+    EFI_PEI_PPI_DESCRIPTOR *OldPpiList;
+    EFI_PEI_PPI_DESCRIPTOR *OldPpiList2;
+    VOID *Ppi;
+    VOID *Ppi2;
+
+    OldPpiList = NULL;
+    Status = PeiServicesLocatePpi (
+               &gPcdPpiGuid,
+               0,
+               &OldPpiList,
+               &Ppi
+               );
+    ASSERT_EFI_ERROR (Status);
+
+    if (OldPpiList != NULL) {
+      Status = PeiServicesReInstallPpi (OldPpiList, &mPpiList[0]);
+      ASSERT_EFI_ERROR (Status);
+    }
+
+    OldPpiList2 = NULL;
+    Status = PeiServicesLocatePpi (
+               &gGetPcdInfoPpiGuid,
+               0,
+               &OldPpiList2,
+               &Ppi2
+               );
+    ASSERT_EFI_ERROR (Status);
+
+    if (OldPpiList2 != NULL) {
+      Status = PeiServicesReInstallPpi (OldPpiList2, &mPpiList2[0]);
+      ASSERT_EFI_ERROR (Status);
+    }
+
+    OldPpiList = NULL;
+    Status = PeiServicesLocatePpi (
+               &gEfiPeiPcdPpiGuid,
+               0,
+               &OldPpiList,
+               &Ppi
+               );
+    ASSERT_EFI_ERROR (Status);
+
+    if (OldPpiList != NULL) {
+      Status = PeiServicesReInstallPpi (OldPpiList, &mPpiList[1]);
+      ASSERT_EFI_ERROR (Status);
+    }
+
+    OldPpiList2 = NULL;
+    Status = PeiServicesLocatePpi (
+               &gEfiGetPcdInfoPpiGuid,
+               0,
+               &OldPpiList2,
+               &Ppi2
+               );
+    ASSERT_EFI_ERROR (Status);
+
+    if (OldPpiList2 != NULL) {
+      Status = PeiServicesReInstallPpi (OldPpiList2, &mPpiList2[1]);
+      ASSERT_EFI_ERROR (Status);
+    }
+
+    return Status;
+  }
 
   BuildPcdDatabase (FileHandle);
 


### PR DESCRIPTION
https://bugzilla.tianocore.org/show_bug.cgi?id=3525

After PciSegmentLib using Dynamic PCD for Pcie base address such
long delay found in FSP. The root cause is some of the PCD service
PPIs not shadowed to memory and flash cache may have been disabled
in NotifyPhase stage. Solution is to shadow all PCD service PPIs
to memory.

Signed-off-by: GregX Yeh <gregx.yeh@intel.com>
Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Hao A Wu <hao.a.wu@intel.com>
Cc: Dandan Bi <dandan.bi@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Reviewed-by: Dandan Bi <dandan.bi@intel.com>
Reviewed-by: Jian J Wang <jian.j.wang@intel.com>