### PR TITLE
EmbeddedPkg/NonCoherentDmaLib: Avoid dereferencing unset Map field

### DIFF
--- a/EmbeddedPkg/Library/NonCoherentDmaLib/NonCoherentDmaLib.c
+++ b/EmbeddedPkg/Library/NonCoherentDmaLib/NonCoherentDmaLib.c
@@ -224,7 +224,7 @@ DmaMap (
       goto FreeMapInfo;
     }
 
-    if (Map->Operation == MapOperationBusMasterRead) {
+    if (Operation == MapOperationBusMasterRead) {
       CopyMem (Map->BufferAddress, (VOID *)(UINTN)HostAddress, *NumberOfBytes);
     }
     mCpu->FlushDataCache (mCpu, (UINTN)Map->BufferAddress, AllocSize,


### PR DESCRIPTION
Map->Operation is used to select whether a DMA region that
is being bounced has the source buffer copied to it. Except
Map->Operation isn't yet set, so the behavior is somewhat
random. Instead use the passed in Operation parameter.

Signed-off-by: Jeremy Linton <jeremy.linton@arm.com>
Reviewed-by: Ard Biesheuvel <ardb@kernel.org>