### PR TITLE
Fix Tpm2ReadPublic unmarshaling bug

### DIFF
--- a/SecurityPkg/Library/Tpm2CommandLib/Tpm2Object.c
+++ b/SecurityPkg/Library/Tpm2CommandLib/Tpm2Object.c
@@ -167,6 +167,7 @@ Tpm2ReadPublic (
     default:
       return EFI_UNSUPPORTED;
     }
+    break;
   case TPM_ALG_SYMCIPHER:
     OutPublic->publicArea.parameters.symDetail.algorithm = SwapBytes16 (ReadUnaligned16 ((UINT16 *)Buffer));
     Buffer += sizeof(UINT16);


### PR DESCRIPTION
switch-case for TPM_ALG_KEYEDHASH is missing the break statement at the end, causing the code execution to flow to the next case (TPM_ALG_SYMCIPHER). This means a keyed hash object would eventually be unmarshaled as a symmetric key object.

Signed-off-by: Mingjie Wang <wjuetoqe3f@outlook.com>