### PR TITLE
add support for virtio-mmio 1.0

### DIFF
--- a/OvmfPkg/Include/IndustryStandard/Virtio10.h
+++ b/OvmfPkg/Include/IndustryStandard/Virtio10.h
@@ -81,4 +81,16 @@ typedef struct {
 #define VIRTIO_F_VERSION_1      BIT32
 #define VIRTIO_F_IOMMU_PLATFORM BIT33
 
+//
+// MMIO VirtIo Header Offsets
+//
+#define VIRTIO_MMIO_OFFSET_QUEUE_READY                0x44
+#define VIRTIO_MMIO_OFFSET_QUEUE_DESC_LO              0x80
+#define VIRTIO_MMIO_OFFSET_QUEUE_DESC_HI              0x84
+#define VIRTIO_MMIO_OFFSET_QUEUE_AVAIL_LO             0x90
+#define VIRTIO_MMIO_OFFSET_QUEUE_AVAIL_HI             0x94
+#define VIRTIO_MMIO_OFFSET_QUEUE_USED_LO              0xa0
+#define VIRTIO_MMIO_OFFSET_QUEUE_USED_HI              0xa4
+#define VIRTIO_MMIO_OFFSET_CONFIG_GENERATION          0xfc
+
 #endif // _VIRTIO_1_0_H_

--- a/OvmfPkg/Library/VirtioMmioDeviceLib/VirtioMmioDevice.c
+++ b/OvmfPkg/Library/VirtioMmioDeviceLib/VirtioMmioDevice.c
@@ -58,7 +58,6 @@ VirtioMmioInit (
   )
 {
   UINT32     MagicValue;
-  UINT32     Version;
 
   //
   // Initialize VirtIo Mmio Device
@@ -66,7 +65,6 @@ VirtioMmioInit (
   CopyMem (&Device->VirtioDevice, &mMmioDeviceProtocolTemplate,
         sizeof (VIRTIO_DEVICE_PROTOCOL));
   Device->BaseAddress = BaseAddress;
-  Device->VirtioDevice.Revision = VIRTIO_SPEC_REVISION (0, 9, 5);
   Device->VirtioDevice.SubSystemDeviceId =
           MmioRead32 (BaseAddress + VIRTIO_MMIO_OFFSET_DEVICE_ID);
 
@@ -78,8 +76,19 @@ VirtioMmioInit (
     return EFI_UNSUPPORTED;
   }
 
-  Version = VIRTIO_CFG_READ (Device, VIRTIO_MMIO_OFFSET_VERSION);
-  if (Version != 1) {
+  Device->Version = VIRTIO_CFG_READ (Device, VIRTIO_MMIO_OFFSET_VERSION);
+  switch (Device->Version) {
+  case VIRTIO_MMIO_DEVICE_VERSION_0_95:
+    DEBUG ((DEBUG_INFO, "%a virtio 0.9.5, id %d\n", __FUNCTION__,
+            Device->VirtioDevice.SubSystemDeviceId));
+    Device->VirtioDevice.Revision = VIRTIO_SPEC_REVISION (0, 9, 5);
+    break;
+  case VIRTIO_MMIO_DEVICE_VERSION_1_00:
+    DEBUG ((DEBUG_INFO, "%a virtio 1.0, id %d\n", __FUNCTION__,
+            Device->VirtioDevice.SubSystemDeviceId));
+    Device->VirtioDevice.Revision = VIRTIO_SPEC_REVISION (1, 0, 0);
+    return EFI_UNSUPPORTED;
+  default:
     return EFI_UNSUPPORTED;
   }
 

--- a/OvmfPkg/Library/VirtioMmioDeviceLib/VirtioMmioDevice.c
+++ b/OvmfPkg/Library/VirtioMmioDeviceLib/VirtioMmioDevice.c
@@ -87,7 +87,7 @@ VirtioMmioInit (
     DEBUG ((DEBUG_INFO, "%a virtio 1.0, id %d\n", __FUNCTION__,
             Device->VirtioDevice.SubSystemDeviceId));
     Device->VirtioDevice.Revision = VIRTIO_SPEC_REVISION (1, 0, 0);
-    return EFI_UNSUPPORTED;
+    break;
   default:
     return EFI_UNSUPPORTED;
   }

--- a/OvmfPkg/Library/VirtioMmioDeviceLib/VirtioMmioDevice.h
+++ b/OvmfPkg/Library/VirtioMmioDeviceLib/VirtioMmioDevice.h
@@ -30,6 +30,7 @@
 typedef struct {
   UINT32                 Signature;
   UINT32                 Version;
+  UINT16                 QueueNum;
   VIRTIO_DEVICE_PROTOCOL VirtioDevice;
   PHYSICAL_ADDRESS       BaseAddress;
 } VIRTIO_MMIO_DEVICE;

--- a/OvmfPkg/Library/VirtioMmioDeviceLib/VirtioMmioDevice.h
+++ b/OvmfPkg/Library/VirtioMmioDeviceLib/VirtioMmioDevice.h
@@ -23,9 +23,13 @@
 #include <Library/MemoryAllocationLib.h>
 
 #define VIRTIO_MMIO_DEVICE_SIGNATURE  SIGNATURE_32 ('V', 'M', 'I', 'O')
+#define VIRTIO_MMIO_DEVICE_VERSION_0_95  1
+#define VIRTIO_MMIO_DEVICE_VERSION_1_00  2
+
 
 typedef struct {
   UINT32                 Signature;
+  UINT32                 Version;
   VIRTIO_DEVICE_PROTOCOL VirtioDevice;
   PHYSICAL_ADDRESS       BaseAddress;
 } VIRTIO_MMIO_DEVICE;

--- a/OvmfPkg/Library/VirtioMmioDeviceLib/VirtioMmioDeviceFunctions.c
+++ b/OvmfPkg/Library/VirtioMmioDeviceLib/VirtioMmioDeviceFunctions.c
@@ -183,13 +183,36 @@ VirtioMmioSetQueueAddress (
   )
 {
   VIRTIO_MMIO_DEVICE *Device;
+  UINT64 Address;
 
   ASSERT (RingBaseShift == 0);
 
   Device = VIRTIO_MMIO_DEVICE_FROM_VIRTIO_DEVICE (This);
 
-  VIRTIO_CFG_WRITE (Device, VIRTIO_MMIO_OFFSET_QUEUE_PFN,
-    (UINT32)((UINTN)Ring->Base >> EFI_PAGE_SHIFT));
+  if (Device->Version == VIRTIO_MMIO_DEVICE_VERSION_0_95) {
+    VIRTIO_CFG_WRITE (Device, VIRTIO_MMIO_OFFSET_QUEUE_PFN,
+      (UINT32)((UINTN)Ring->Base >> EFI_PAGE_SHIFT));
+  } else {
+    Address = (UINTN)Ring->Base;
+    VIRTIO_CFG_WRITE (Device, VIRTIO_MMIO_OFFSET_QUEUE_DESC_LO,
+                      (UINT32)Address);
+    VIRTIO_CFG_WRITE (Device, VIRTIO_MMIO_OFFSET_QUEUE_DESC_HI,
+                      (UINT32)RShiftU64(Address, 32));
+
+    Address = (UINTN)Ring->Avail.Flags;
+    VIRTIO_CFG_WRITE (Device, VIRTIO_MMIO_OFFSET_QUEUE_AVAIL_LO,
+                      (UINT32)Address);
+    VIRTIO_CFG_WRITE (Device, VIRTIO_MMIO_OFFSET_QUEUE_AVAIL_HI,
+                      (UINT32)RShiftU64(Address, 32));
+
+    Address = (UINTN)Ring->Used.Flags;
+    VIRTIO_CFG_WRITE (Device, VIRTIO_MMIO_OFFSET_QUEUE_USED_LO,
+                      (UINT32)Address);
+    VIRTIO_CFG_WRITE (Device, VIRTIO_MMIO_OFFSET_QUEUE_USED_HI,
+                      (UINT32)RShiftU64(Address, 32));
+
+    VIRTIO_CFG_WRITE (Device, VIRTIO_MMIO_OFFSET_QUEUE_READY, 1);
+  }
 
   return EFI_SUCCESS;
 }

--- a/OvmfPkg/Library/VirtioMmioDeviceLib/VirtioMmioDeviceFunctions.c
+++ b/OvmfPkg/Library/VirtioMmioDeviceLib/VirtioMmioDeviceFunctions.c
@@ -83,7 +83,11 @@ VirtioMmioSetQueueSize (
 
   Device = VIRTIO_MMIO_DEVICE_FROM_VIRTIO_DEVICE (This);
 
-  VIRTIO_CFG_WRITE (Device, VIRTIO_MMIO_OFFSET_QUEUE_NUM, QueueSize);
+  if (Device->Version == VIRTIO_MMIO_DEVICE_VERSION_0_95) {
+    VIRTIO_CFG_WRITE (Device, VIRTIO_MMIO_OFFSET_QUEUE_NUM, QueueSize);
+  } else {
+    Device->QueueNum = QueueSize;
+  }
 
   return EFI_SUCCESS;
 }
@@ -171,6 +175,10 @@ VirtioMmioSetQueueSel (
 
   VIRTIO_CFG_WRITE (Device, VIRTIO_MMIO_OFFSET_QUEUE_SEL, Sel);
 
+  if (Device->Version == VIRTIO_MMIO_DEVICE_VERSION_0_95) {
+    Device->QueueNum = VIRTIO_CFG_READ (Device, VIRTIO_MMIO_OFFSET_QUEUE_NUM_MAX) & 0xFFFF;
+  }
+
   return EFI_SUCCESS;
 }
 
@@ -193,6 +201,8 @@ VirtioMmioSetQueueAddress (
     VIRTIO_CFG_WRITE (Device, VIRTIO_MMIO_OFFSET_QUEUE_PFN,
       (UINT32)((UINTN)Ring->Base >> EFI_PAGE_SHIFT));
   } else {
+    VIRTIO_CFG_WRITE (Device, VIRTIO_MMIO_OFFSET_QUEUE_NUM, Device->QueueNum);
+
     Address = (UINTN)Ring->Base;
     VIRTIO_CFG_WRITE (Device, VIRTIO_MMIO_OFFSET_QUEUE_DESC_LO,
                       (UINT32)Address);

--- a/OvmfPkg/Library/VirtioMmioDeviceLib/VirtioMmioDeviceFunctions.c
+++ b/OvmfPkg/Library/VirtioMmioDeviceLib/VirtioMmioDeviceFunctions.c
@@ -151,7 +151,9 @@ VirtioMmioSetPageSize (
 
   Device = VIRTIO_MMIO_DEVICE_FROM_VIRTIO_DEVICE (This);
 
-  VIRTIO_CFG_WRITE (Device, VIRTIO_MMIO_OFFSET_GUEST_PAGE_SIZE, PageSize);
+  if (Device->Version == VIRTIO_MMIO_DEVICE_VERSION_0_95) {
+    VIRTIO_CFG_WRITE (Device, VIRTIO_MMIO_OFFSET_GUEST_PAGE_SIZE, PageSize);
+  }
 
   return EFI_SUCCESS;
 }


### PR DESCRIPTION

This little series adds virtio 1.0 support for the virtio-mmio
transport.  For the mmio transport the difference between 0.9.5 and 1.0
is rather small (when compared to the pci transport), it is just a bunch
of new registers for the changed virtio queue initialization.  So the
patch series is small too ...

v2 changes:
 - Added review tags for patches #1 + #2.
 - Add a patch to make sure we have a valid QueueNum.
 - Add a patch to support all 64 virtio 1.0 feature bits.
v3 changes:
 - Add #defines for virtio-mmio version field.
v4 changes:
 - split patches into smaller ones.
 - enable virtio 1.0 at the end when everything is in place.
v5 changes:
 - Added review tags.
 - Fixed 32bit arm build failure.
