### PR TITLE
MdeModulePkg/EbcDxe: Mitigate memcpy intrinsics

### DIFF
--- a/MdeModulePkg/Universal/EbcDxe/EbcDebugger/Edb.c
+++ b/MdeModulePkg/Universal/EbcDxe/EbcDebugger/Edb.c
@@ -219,7 +219,11 @@ EdbCheckBreakpoint (
       //
       // If hit, record current breakpoint
       //
-      DebuggerPrivate->DebuggerBreakpointContext[EFI_DEBUGGER_BREAKPOINT_MAX] = DebuggerPrivate->DebuggerBreakpointContext[Index];
+      CopyMem (
+        &DebuggerPrivate->DebuggerBreakpointContext[EFI_DEBUGGER_BREAKPOINT_MAX],
+        &DebuggerPrivate->DebuggerBreakpointContext[Index],
+        sizeof (DebuggerPrivate->DebuggerBreakpointContext[EFI_DEBUGGER_BREAKPOINT_MAX])
+        );
       DebuggerPrivate->DebuggerBreakpointContext[EFI_DEBUGGER_BREAKPOINT_MAX].State = TRUE;
       //
       // Do not set Breakpoint flag. We record the address here just let it not patch breakpoint address when de-init.

--- a/MdeModulePkg/Universal/EbcDxe/EbcDebugger/EdbCmdBreakpoint.c
+++ b/MdeModulePkg/Universal/EbcDxe/EbcDebugger/EdbCmdBreakpoint.c
@@ -158,7 +158,11 @@ DebuggerBreakpointDel (
   // Delete this breakpoint
   //
   for (BpIndex = Index; BpIndex < DebuggerPrivate->DebuggerBreakpointCount - 1; BpIndex++) {
-    DebuggerPrivate->DebuggerBreakpointContext[BpIndex] = DebuggerPrivate->DebuggerBreakpointContext[BpIndex + 1];
+    CopyMem (
+      &DebuggerPrivate->DebuggerBreakpointContext[BpIndex],
+      &DebuggerPrivate->DebuggerBreakpointContext[BpIndex + 1],
+      sizeof (DebuggerPrivate->DebuggerBreakpointContext[BpIndex])
+      );
   }
   ZeroMem (
     &DebuggerPrivate->DebuggerBreakpointContext[BpIndex],

--- a/MdeModulePkg/Universal/EbcDxe/EbcDebugger/EdbHook.c
+++ b/MdeModulePkg/Universal/EbcDxe/EbcDebugger/EdbHook.c
@@ -230,7 +230,11 @@ EbcDebuggerPushTraceDestEntry (
     //
     ASSERT (mDebuggerPrivate.TraceEntry[EFI_DEBUGGER_TRACE_MAX].Type == Type);
     for (Index = 0; Index < EFI_DEBUGGER_TRACE_MAX; Index++) {
-      mDebuggerPrivate.TraceEntry[Index] = mDebuggerPrivate.TraceEntry[Index + 1];
+      CopyMem (
+        &mDebuggerPrivate.TraceEntry[Index],
+        &mDebuggerPrivate.TraceEntry[Index + 1],
+        sizeof (mDebuggerPrivate.TraceEntry[Index])
+        );
     }
     mDebuggerPrivate.TraceEntry[EFI_DEBUGGER_CALLSTACK_MAX - 1].DestAddress = DestEntry;
     mDebuggerPrivate.TraceEntryCount = EFI_DEBUGGER_TRACE_MAX;


### PR DESCRIPTION
Patch sent at: https://edk2.groups.io/g/devel/message/79317

Assignments of structure values cause the emission of memcpy()
intrinsics by the CLANG38 toolchain. Substitute the assignments with
calls to CopyMem() to mitigate the issue.

Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Hao A Wu <hao.a.wu@intel.com>
Cc: Vitaly Cheptsov <vit9696@protonmail.com>
Signed-off-by: Marvin H?user <mhaeuser@posteo.de>
Reviewed-by: Hao A Wu <hao.a.wu@intel.com>