### PR TITLE
MdeModulePkg: Add BootDiscoveryPolicyOld variable.

### DIFF
--- a/MdeModulePkg/Include/Guid/BootDiscoveryPolicy.h
+++ b/MdeModulePkg/Include/Guid/BootDiscoveryPolicy.h
@@ -18,5 +18,6 @@
 #define BOOT_DISCOVERY_POLICY_MGR_FORMSET_GUID  { 0x5b6f7107, 0xbb3c, 0x4660, { 0x92, 0xcd, 0x54, 0x26, 0x90, 0x28, 0x0b, 0xbd } }
 
 #define BOOT_DISCOVERY_POLICY_VAR L"BootDiscoveryPolicy"
+#define BOOT_DISCOVERY_POLICY_OLD_VAR L"BootDiscoveryPolicyOld"
 
 #endif


### PR DESCRIPTION
Patch sent at: https://edk2.groups.io/g/devel/message/79471

This variable is needed to track the change to
BootDiscoveryPolicy variable. Boot options should
be refreshed only if BootDiscoveryPolicy has been
changed.

Signed-off-by: Grzegorz Bernacki <gjb@semihalf.com>
Reviewed-by: Samer El-Haj-Mahmoud <Samer.El-Haj-Mahmoud@arm.com>
Acked-by: Hao A Wu <hao.a.wu@intel.com>