### PR TITLE
Push nvme capacity

### DIFF
--- a/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressHci.c
+++ b/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressHci.c
@@ -931,6 +931,8 @@ NvmeControllerInit (
   DEBUG ((EFI_D_INFO, "    SN        : %a\n",   Sn));
   DEBUG ((EFI_D_INFO, "    MN        : %a\n",   Mn));
   DEBUG ((EFI_D_INFO, "    FR        : 0x%x\n", *((UINT64*)Private->ControllerData->Fr)));
+  DEBUG ((DEBUG_INFO, "    TNVMCAP (high 8-byte) : 0x%lx\n", *((UINT64*)(Private->ControllerData->Tnvmcap + 8))));
+  DEBUG ((DEBUG_INFO, "    TNVMCAP (low 8-byte)  : 0x%lx\n", *((UINT64*)Private->ControllerData->Tnvmcap)));
   DEBUG ((EFI_D_INFO, "    RAB       : 0x%x\n", Private->ControllerData->Rab));
   DEBUG ((EFI_D_INFO, "    IEEE      : 0x%x\n", *(UINT32*)Private->ControllerData->Ieee_oui));
   DEBUG ((EFI_D_INFO, "    AERL      : 0x%x\n", Private->ControllerData->Aerl));

--- a/MdePkg/Include/IndustryStandard/Nvme.h
+++ b/MdePkg/Include/IndustryStandard/Nvme.h
@@ -353,7 +353,16 @@ typedef struct {
   UINT8  Npss;                /* Number of Power States Support */
   UINT8  Avscc;               /* Admin Vendor Specific Command Configuration */
   UINT8  Apsta;               /* Autonomous Power State Transition Attributes */
-  UINT8  Rsvd2[246];          /* Reserved as of Nvm Express 1.1 Spec */
+  //
+  // Below fields before Rsvd2 are defined in NVM Express 1.3 Spec
+  //
+  UINT16 Wctemp;              /* Warning Composite Temperature Threshold */
+  UINT16 Cctemp;              /* Critical Composite Temperature Threshold */
+  UINT16 Mtfa;                /* Maximum Time for Firmware Activation */
+  UINT32 Hmpre;               /* Host Memory Buffer Preferred Size */
+  UINT32 Hmmin;               /* Host Memory Buffer Minimum Size */
+  UINT8  Tnvmcap[16];         /* Total NVM Capacity */
+  UINT8  Rsvd2[216];          /* Reserved as of NVM Express */
   //
   // NVM Command Set Attributes
   //


### PR DESCRIPTION
**Cover-letter:** https://edk2.groups.io/g/devel/message/79565
MdePkg:Update IndustryStandard/Nvme.h with Nvme amdin controller data

Add the definition of Nvme total capacity in Nvme structure.

zhoucheng (2):
  MdePkg:Update IndustryStandard/Nvme.h with Nvme amdin controller data
  MdeModulePkg:Increase Nvme capacity display

 MdePkg/Include/IndustryStandard/Nvme.h             | 11 ++++++++++-
 MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressHci.c |  2 ++
 2 files changed, 12 insertions(+), 1 deletion(-)

Patches are sent at:
https://edk2.groups.io/g/devel/message/79564
https://edk2.groups.io/g/devel/message/79563