### PR TITLE
Enable Core CI for UefiPayloadPkg 

### DIFF
--- a/.azurepipelines/templates/pr-gate-build-job.yml
+++ b/.azurepipelines/templates/pr-gate-build-job.yml
@@ -48,6 +48,9 @@ jobs:
       TARGET_SECURITY:
         Build.Pkgs: 'SecurityPkg'
         Build.Targets: 'DEBUG,RELEASE,NO-TARGET'
+      TARGET_UEFIPAYLOAD:
+        Build.Pkgs: 'UefiPayloadPkg'
+        Build.Targets: 'DEBUG,RELEASE,NO-TARGET'
       TARGET_PLATFORMS:
         # For Platforms only check code. Leave it to Platform CI
         # to build them.

--- a/.pytool/CISettings.py
+++ b/.pytool/CISettings.py
@@ -67,7 +67,8 @@ class Settings(CiBuildSettingsManager, UpdateSettingsManager, SetupSettingsManag
                 "CryptoPkg",
                 "UnitTestFrameworkPkg",
                 "OvmfPkg",
-                "RedfishPkg"
+                "RedfishPkg",
+                "UefiPayloadPkg"
                 )
 
     def GetArchitecturesSupported(self):

--- a/UefiPayloadPkg/Library/PayloadEntryHobLib/Hob.c
+++ b/UefiPayloadPkg/Library/PayloadEntryHobLib/Hob.c
@@ -77,9 +77,9 @@ HobConstructor (
   Hob->Version             = EFI_HOB_HANDOFF_TABLE_VERSION;
   Hob->BootMode            = BOOT_WITH_FULL_CONFIGURATION;
 
-  Hob->EfiMemoryTop        = (EFI_PHYSICAL_ADDRESS) EfiMemoryTop;
-  Hob->EfiMemoryBottom     = (EFI_PHYSICAL_ADDRESS) EfiMemoryBottom;
-  Hob->EfiFreeMemoryTop    = (EFI_PHYSICAL_ADDRESS) EfiFreeMemoryTop;
+  Hob->EfiMemoryTop        = (EFI_PHYSICAL_ADDRESS) (UINTN) EfiMemoryTop;
+  Hob->EfiMemoryBottom     = (EFI_PHYSICAL_ADDRESS) (UINTN) EfiMemoryBottom;
+  Hob->EfiFreeMemoryTop    = (EFI_PHYSICAL_ADDRESS) (UINTN) EfiFreeMemoryTop;
   Hob->EfiFreeMemoryBottom = (EFI_PHYSICAL_ADDRESS) (UINTN) (HobEnd+1);
   Hob->EfiEndOfHobList     = (EFI_PHYSICAL_ADDRESS) (UINTN) HobEnd;
 

--- a/UefiPayloadPkg/UefiPayloadPkg.ci.yaml
+++ b/UefiPayloadPkg/UefiPayloadPkg.ci.yaml
@@ -1,0 +1,90 @@
+## @file
+# Core CI configuration for UefiPayloadPkg
+#
+# Copyright (c) 2021, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+{
+    ## options defined .pytool/Plugin/LicenseCheck
+    "LicenseCheck": {
+        "IgnoreFiles": []
+    },
+    "EccCheck": {
+        ## Exception sample looks like below:
+        ## "ExceptionList": [
+        ##     "<ErrorID>", "<KeyWord>"
+        ## ]
+        "ExceptionList": [
+        ],
+        ## Both file path and directory path are accepted.
+        "IgnoreFiles": [
+        ]
+    },
+    ## options defined .pytool/Plugin/CompilerPlugin
+    "CompilerPlugin": {
+        "DscPath": "UefiPayloadPkg.dsc"
+    },
+
+    ## options defined .pytool/Plugin/HostUnitTestCompilerPlugin
+    "HostUnitTestCompilerPlugin": {
+        "DscPath": "" # Don't support this test
+    },
+
+    ## options defined .pytool/Plugin/CharEncodingCheck
+    "CharEncodingCheck": {
+        "IgnoreFiles": []
+    },
+
+    ## options defined .pytool/Plugin/DependencyCheck
+    "DependencyCheck": {
+        "AcceptableDependencies": [],
+        # For host based unit tests
+        "AcceptableDependencies-HOST_APPLICATION":[],
+        # For UEFI shell based apps
+        "AcceptableDependencies-UEFI_APPLICATION":[],
+        "IgnoreInf": [],
+        "skip": True
+    },
+
+    ## options defined .pytool/Plugin/DscCompleteCheck
+    "DscCompleteCheck": {
+        "IgnoreInf": [""],
+        "DscPath": ""  # Don't support this test
+    },
+
+    ## options defined .pytool/Plugin/HostUnitTestDscCompleteCheck
+    "HostUnitTestDscCompleteCheck": {
+        "IgnoreInf": [""],
+        "DscPath": "" # Don't support this test
+    },
+
+    ## options defined .pytool/Plugin/GuidCheck
+    "GuidCheck": {
+        "IgnoreGuidName": [],
+        "IgnoreGuidValue": [],
+        "IgnoreFoldersAndFiles": [],
+        "IgnoreDuplicates": [],
+    },
+
+    ## options defined .pytool/Plugin/LibraryClassCheck
+    "LibraryClassCheck": {
+        "IgnoreHeaderFile": [],
+        "skip": True
+    },
+
+    ## options defined .pytool/Plugin/SpellCheck
+    "SpellCheck": {
+        "AuditOnly": True,           # Fails right now with over 270 errors
+        "IgnoreFiles": [],           # use gitignore syntax to ignore errors in matching files
+        "ExtendWords": [],           # words to extend to the dictionary for this package
+        "IgnoreStandardPaths": [],   # Standard Plugin defined paths that should be ignore
+        "AdditionalIncludePaths": [] # Additional paths to spell check (wildcards supported)
+    },
+
+    "Defines": {
+        "BLD_*_UNIVERSAL_PAYLOAD": "TRUE",
+        "BLD_*_EMU_VARIABLE_ENABLE": "FALSE",
+        "BLD_*_DISABLE_RESET_SYSTEM": "TRUE",
+        "BLD_*_SERIAL_DRIVER_ENABLE": "FALSE",
+    }
+}

--- a/UefiPayloadPkg/UefiPayloadPkg.dsc
+++ b/UefiPayloadPkg/UefiPayloadPkg.dsc
@@ -415,7 +415,7 @@
 #
 ################################################################################
 
-!if "IA32" in $(ARCH)
+!if "IA32" in "$(ARCH)"
   [Components.IA32]
   !if $(UNIVERSAL_PAYLOAD) == TRUE
     UefiPayloadPkg/UefiPayloadEntry/UniversalPayloadEntry.inf

--- a/UefiPayloadPkg/UefiPayloadPkg.fdf
+++ b/UefiPayloadPkg/UefiPayloadPkg.fdf
@@ -201,22 +201,6 @@ INF ShellPkg/DynamicCommand/DpDynamicCommand/DpDynamicCommand.inf
 INF ShellPkg/Application/Shell/Shell.inf
 !endif
 
-!if $(SHELL_TYPE) == MIN_BIN
-!if $(ARCH) == IA32
-INF  RuleOverride = BINARY USE = IA32 ShellBinPkg/MinUefiShell/MinUefiShell.inf
-!else
-INF  RuleOverride = BINARY USE = X64 ShellBinPkg/MinUefiShell/MinUefiShell.inf
-!endif
-!endif
-
-!if $(SHELL_TYPE) == UEFI_BIN
-!if $(ARCH) == IA32
-INF  RuleOverride = BINARY USE = IA32 ShellBinPkg/UefiShell/UefiShell.inf
-!else
-INF  RuleOverride = BINARY USE = X64 ShellBinPkg/UefiShell/UefiShell.inf
-!endif
-!endif
-
 
 ################################################################################
 #


### PR DESCRIPTION
Enable Core CI for UefiPayloadPkg.

Fix the build error when enable Core ci for UefiPayloadPkg
Create .yaml file in UefiPayloadPkg.
Add UefiPayloadPkg in gate-build-job.yml and CISetting.py
Signed-off-by: DunTan <dun.tan@intel.com>