### PR TITLE
ArmPkg: Enable boot discovery policy for ARM package.

### DIFF
--- a/ArmPkg/Library/PlatformBootManagerLib/PlatformBootManagerLib.inf
+++ b/ArmPkg/Library/PlatformBootManagerLib/PlatformBootManagerLib.inf
@@ -65,11 +65,15 @@
 
 [Pcd]
   gEfiMdePkgTokenSpaceGuid.PcdPlatformBootTimeOut
+  gEfiMdeModulePkgTokenSpaceGuid.PcdBootDiscoveryPolicy
 
 [Guids]
+  gBootDiscoveryPolicyMgrFormsetGuid
   gEdkiiNonDiscoverableEhciDeviceGuid
   gEdkiiNonDiscoverableUhciDeviceGuid
   gEdkiiNonDiscoverableXhciDeviceGuid
+  gEfiBootManagerPolicyNetworkGuid
+  gEfiBootManagerPolicyConnectAllGuid
   gEfiFileInfoGuid
   gEfiFileSystemInfoGuid
   gEfiFileSystemVolumeLabelInfoIdGuid
@@ -79,6 +83,7 @@
 
 [Protocols]
   gEdkiiNonDiscoverableDeviceProtocolGuid
+  gEfiBootManagerPolicyProtocolGuid
   gEfiDevicePathProtocolGuid
   gEfiGraphicsOutputProtocolGuid
   gEfiLoadedImageProtocolGuid


### PR DESCRIPTION
This commit adds code which check BootDiscoveryPolicy variable and
calls Boot Policy Manager Protocol to connect device specified by
the variable. To enable that mechanism for platform
EfiMdeModulePkgTokenSpaceGuid.PcdBootDiscoveryPolicy PCD must be
added to DSC file and BootDiscoveryPolicyUiLib should be added to
UiApp libraries.

Signed-off-by: Grzegorz Bernacki <gjb@semihalf.com>
Reviewed-by: Sunny Wang <sunny.wang@arm.com>
Reviewed-by: Sami Mujawar <sami.mujawar@arm.com>