### PR TITLE
UefiPayloadPkg: Fix the build error when enable Core ci for UefiPaylo…

### DIFF
--- a/UefiPayloadPkg/Library/PayloadEntryHobLib/Hob.c
+++ b/UefiPayloadPkg/Library/PayloadEntryHobLib/Hob.c
@@ -77,9 +77,9 @@ HobConstructor (
   Hob->Version             = EFI_HOB_HANDOFF_TABLE_VERSION;
   Hob->BootMode            = BOOT_WITH_FULL_CONFIGURATION;
 
-  Hob->EfiMemoryTop        = (EFI_PHYSICAL_ADDRESS) EfiMemoryTop;
-  Hob->EfiMemoryBottom     = (EFI_PHYSICAL_ADDRESS) EfiMemoryBottom;
-  Hob->EfiFreeMemoryTop    = (EFI_PHYSICAL_ADDRESS) EfiFreeMemoryTop;
+  Hob->EfiMemoryTop        = (EFI_PHYSICAL_ADDRESS) (UINTN) EfiMemoryTop;
+  Hob->EfiMemoryBottom     = (EFI_PHYSICAL_ADDRESS) (UINTN) EfiMemoryBottom;
+  Hob->EfiFreeMemoryTop    = (EFI_PHYSICAL_ADDRESS) (UINTN) EfiFreeMemoryTop;
   Hob->EfiFreeMemoryBottom = (EFI_PHYSICAL_ADDRESS) (UINTN) (HobEnd+1);
   Hob->EfiEndOfHobList     = (EFI_PHYSICAL_ADDRESS) (UINTN) HobEnd;
 

--- a/UefiPayloadPkg/UefiPayloadPkg.dsc
+++ b/UefiPayloadPkg/UefiPayloadPkg.dsc
@@ -415,7 +415,7 @@
 #
 ################################################################################
 
-!if "IA32" in $(ARCH)
+!if "IA32" in "$(ARCH)"
   [Components.IA32]
   !if $(UNIVERSAL_PAYLOAD) == TRUE
     UefiPayloadPkg/UefiPayloadEntry/UniversalPayloadEntry.inf

--- a/UefiPayloadPkg/UefiPayloadPkg.fdf
+++ b/UefiPayloadPkg/UefiPayloadPkg.fdf
@@ -201,22 +201,6 @@ INF ShellPkg/DynamicCommand/DpDynamicCommand/DpDynamicCommand.inf
 INF ShellPkg/Application/Shell/Shell.inf
 !endif
 
-!if $(SHELL_TYPE) == MIN_BIN
-!if $(ARCH) == IA32
-INF  RuleOverride = BINARY USE = IA32 ShellBinPkg/MinUefiShell/MinUefiShell.inf
-!else
-INF  RuleOverride = BINARY USE = X64 ShellBinPkg/MinUefiShell/MinUefiShell.inf
-!endif
-!endif
-
-!if $(SHELL_TYPE) == UEFI_BIN
-!if $(ARCH) == IA32
-INF  RuleOverride = BINARY USE = IA32 ShellBinPkg/UefiShell/UefiShell.inf
-!else
-INF  RuleOverride = BINARY USE = X64 ShellBinPkg/UefiShell/UefiShell.inf
-!endif
-!endif
-
 
 ################################################################################
 #


### PR DESCRIPTION
…adPkg

V1: Add quotes when using $(ARCH) in .dsc and .fdf file.
The quotes are added due to the way by which Core ci parse the .dsc file.
Add UINTN in Hob.c to fix cast from pointer to integer of different size error.
V2: Delete lines which reference ShellBinPkg.The pkg doesn't exist in edk2.

Cc: Guo Dong <guo.dong@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Cc: Maurice Ma <maurice.ma@intel.com>
Cc: Benjamin You <benjamin.you@intel.com>
Signed-off-by: DunTan <dun.tan@intel.com>
Reviewed-by: Ray Ni <ray.ni@intel.com>