### PR TITLE
UefiCpuPkg: Clean up save state boundary checks and comments.

### DIFF
--- a/UefiCpuPkg/PiSmmCpuDxeSmm/SmramSaveState.c
+++ b/UefiCpuPkg/PiSmmCpuDxeSmm/SmramSaveState.c
@@ -315,12 +315,12 @@ ReadSaveStateRegisterByIndex (
     }
 
     //
-    // Write lower 32-bits of return buffer
+    // Write at most 4 of the lower bytes of the return buffer
     //
     CopyMem(Buffer, (UINT8 *)CpuSaveState + mSmmCpuWidthOffset[RegisterIndex].Offset64Lo, MIN(4, Width));
-    if (Width >= 4) {
+    if (Width > 4) {
       //
-      // Write upper 32-bits of return buffer
+      // Write at most 4 of the upper bytes of the return buffer
       //
       CopyMem((UINT8 *)Buffer + 4, (UINT8 *)CpuSaveState + mSmmCpuWidthOffset[RegisterIndex].Offset64Hi, Width - 4);
     }
@@ -546,12 +546,12 @@ WriteSaveStateRegister (
     }
 
     //
-    // Write lower 32-bits of SMM State register
+    // Write at most 4 of the lower bytes of SMM State register
     //
     CopyMem((UINT8 *)CpuSaveState + mSmmCpuWidthOffset[RegisterIndex].Offset64Lo, Buffer, MIN (4, Width));
-    if (Width >= 4) {
+    if (Width > 4) {
       //
-      // Write upper 32-bits of SMM State register
+      // Write at most 4 of the upper bytes of SMM State register
       //
       CopyMem((UINT8 *)CpuSaveState + mSmmCpuWidthOffset[RegisterIndex].Offset64Hi, (UINT8 *)Buffer + 4, Width - 4);
     }


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=2956

In functions ReadSaveStateRegisterByIndex and WriteSaveStateRegister:
* check width > 4 instead of >= 4 when writing upper 32 bytes.
  - This improves the code but will not affect functionality.

Cc: Eric Dong <eric.dong@intel.com>
Reviewed-by: Ray Ni <ray.ni@intel.com>
Signed-off-by: Mark Wilson <Mark.Wilson@amd.com>