### PR TITLE
MdeModulePkg/HiiDatabaseDxe:remove dead code block

### DIFF
--- a/MdeModulePkg/Universal/HiiDatabaseDxe/ConfigRouting.c
+++ b/MdeModulePkg/Universal/HiiDatabaseDxe/ConfigRouting.c
@@ -2871,9 +2871,6 @@ ParseIfrData (
         //
         if ((BlockData->Name == NULL) && ((BlockData->Offset + BlockData->Width) > VarStorageData->Size)) {
           Status = EFI_INVALID_PARAMETER;
-          if (BlockData->Name != NULL) {
-            FreePool (BlockData->Name);
-          }
           FreePool (BlockData);
           goto Done;
         }


### PR DESCRIPTION
As the if statement outside has confirmed that
BlockData->Name == NULL, so the if statement inside
is always false.

Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Hao A Wu <hao.a.wu@intel.com>
Cc: Dandan Bi <dandan.bi@intel.com>
Cc: Eric Dong <eric.dong@intel.com>
Signed-off-by: Wenyi Xie <xiewenyi2@huawei.com>
Reviewed-by: Dandan Bi <dandan.bi@intel.com>