### PR TITLE
MdeModulePkg: Fix typo of "memory" in RamDiskDxe debug message

### DIFF
--- a/MdeModulePkg/Universal/Disk/RamDiskDxe/RamDiskProtocol.c
+++ b/MdeModulePkg/Universal/Disk/RamDiskDxe/RamDiskProtocol.c
@@ -195,7 +195,7 @@ RamDiskPublishNfit (
       MemoryFound = TRUE;
       DEBUG ((
         EFI_D_INFO,
-        "RamDiskPublishNfit: RAM disk with reserved meomry type, will publish to NFIT.\n"
+        "RamDiskPublishNfit: RAM disk with reserved memory type, will publish to NFIT.\n"
         ));
       break;
     }


### PR DESCRIPTION
Patch sent at: https://edk2.groups.io/g/devel/message/79960

Fix a typo of "memory" in a debug message in RamDiskProtocol.c.

Signed-off-by: Rebecca Cran <rebecca@bsdio.com>
Reviewed-by: Hao A Wu <hao.a.wu@intel.com>
Reviewed-by: Philippe Mathieu-Daude <philmd@redhat.com>