### PR TITLE
SecurityPkg/MemoryOverwriteControl: Add missing argument to DEBUG print

### DIFF
--- a/SecurityPkg/Tcg/MemoryOverwriteControl/TcgMor.c
+++ b/SecurityPkg/Tcg/MemoryOverwriteControl/TcgMor.c
@@ -52,7 +52,7 @@ OnReadyToBoot (
                &mMorControl
                );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "TcgMor: Clear MOR_CLEAR_MEMORY_BIT failure, Status = %r\n"));
+    DEBUG ((DEBUG_ERROR, "TcgMor: Clear MOR_CLEAR_MEMORY_BIT failure, Status = %r\n", Status));
   }
 }
 


### PR DESCRIPTION
REF:https://bugzilla.tianocore.org/show_bug.cgi?id=3605

The error message is missing the argument for the status code
print specifier.

Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Qi Zhang <qi1.zhang@intel.com>
Cc: Rahul Kumar <rahul1.kumar@intel.com>
Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>
Reviewed-by: Jiewen Yao <jiewen.yao@intel.com>