### PR TITLE
Disable the TPM2 platform hierarchy

### DIFF
--- a/SecurityPkg/Include/Library/TpmPlatformHierarchyLib.h
+++ b/SecurityPkg/Include/Library/TpmPlatformHierarchyLib.h
@@ -1,0 +1,27 @@
+/** @file
+    TPM Platform Hierarchy configuration library.
+
+    This library provides functions for customizing the TPM's Platform Hierarchy
+    Authorization Value (platformAuth) and Platform Hierarchy Authorization
+    Policy (platformPolicy) can be defined through this function.
+
+Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
+Copyright (c) Microsoft Corporation.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef _TPM_PLATFORM_HIERARCHY_LIB_H_
+#define _TPM_PLATFORM_HIERARCHY_LIB_H_
+
+/**
+   This service will perform the TPM Platform Hierarchy configuration at the SmmReadyToLock event.
+
+**/
+VOID
+EFIAPI
+ConfigureTpmPlatformHierarchy (
+  VOID
+  );
+
+#endif

--- a/SecurityPkg/Library/PeiDxeTpmPlatformHierarchyLib/PeiDxeTpmPlatformHierarchyLib.c
+++ b/SecurityPkg/Library/PeiDxeTpmPlatformHierarchyLib/PeiDxeTpmPlatformHierarchyLib.c
@@ -1,0 +1,266 @@
+/** @file
+    TPM Platform Hierarchy configuration library.
+
+    This library provides functions for customizing the TPM's Platform Hierarchy
+    Authorization Value (platformAuth) and Platform Hierarchy Authorization
+    Policy (platformPolicy) can be defined through this function.
+
+    Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
+    Copyright (c) Microsoft Corporation.<BR>
+    SPDX-License-Identifier: BSD-2-Clause-Patent
+
+    @par Specification Reference:
+    https://trustedcomputinggroup.org/resource/tcg-tpm-v2-0-provisioning-guidance/
+**/
+
+#include <Uefi.h>
+
+#include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/PcdLib.h>
+#include <Library/RngLib.h>
+#include <Library/Tpm2CommandLib.h>
+#include <Library/Tpm2DeviceLib.h>
+
+//
+// The authorization value may be no larger than the digest produced by the hash
+//   algorithm used for context integrity.
+//
+#define      MAX_NEW_AUTHORIZATION_SIZE SHA512_DIGEST_SIZE
+
+UINT16       mAuthSize;
+
+/**
+  Generate high-quality entropy source through RDRAND.
+
+  @param[in]   Length        Size of the buffer, in bytes, to fill with.
+  @param[out]  Entropy       Pointer to the buffer to store the entropy data.
+
+  @retval EFI_SUCCESS        Entropy generation succeeded.
+  @retval EFI_NOT_READY      Failed to request random data.
+
+**/
+EFI_STATUS
+EFIAPI
+RdRandGenerateEntropy (
+  IN UINTN         Length,
+  OUT UINT8        *Entropy
+  )
+{
+  EFI_STATUS  Status;
+  UINTN       BlockCount;
+  UINT64      Seed[2];
+  UINT8       *Ptr;
+
+  Status = EFI_NOT_READY;
+  BlockCount = Length / 64;
+  Ptr = (UINT8 *)Entropy;
+
+  //
+  // Generate high-quality seed for DRBG Entropy
+  //
+  while (BlockCount > 0) {
+    Status = GetRandomNumber128 (Seed);
+    if (EFI_ERROR (Status)) {
+      return Status;
+    }
+    CopyMem (Ptr, Seed, 64);
+
+    BlockCount--;
+    Ptr = Ptr + 64;
+  }
+
+  //
+  // Populate the remained data as request.
+  //
+  Status = GetRandomNumber128 (Seed);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+  CopyMem (Ptr, Seed, (Length % 64));
+
+  return Status;
+}
+
+/**
+  This function returns the maximum size of TPM2B_AUTH; this structure is used for an authorization value
+  and limits an authValue to being no larger than the largest digest produced by a TPM.
+
+  @param[out] AuthSize                 Tpm2 Auth size
+
+  @retval EFI_SUCCESS                  Auth size returned.
+  @retval EFI_DEVICE_ERROR             Can not return platform auth due to device error.
+
+**/
+EFI_STATUS
+EFIAPI
+GetAuthSize (
+  OUT UINT16            *AuthSize
+  )
+{
+  EFI_STATUS            Status;
+  TPML_PCR_SELECTION    Pcrs;
+  UINTN                 Index;
+  UINT16                DigestSize;
+
+  Status = EFI_SUCCESS;
+
+  while (mAuthSize == 0) {
+
+    mAuthSize = SHA1_DIGEST_SIZE;
+    ZeroMem (&Pcrs, sizeof (TPML_PCR_SELECTION));
+    Status = Tpm2GetCapabilityPcrs (&Pcrs);
+
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "Tpm2GetCapabilityPcrs fail!\n"));
+      break;
+    }
+
+    DEBUG ((DEBUG_ERROR, "Tpm2GetCapabilityPcrs - %08x\n", Pcrs.count));
+
+    for (Index = 0; Index < Pcrs.count; Index++) {
+      DEBUG ((DEBUG_ERROR, "alg - %x\n", Pcrs.pcrSelections[Index].hash));
+
+      switch (Pcrs.pcrSelections[Index].hash) {
+      case TPM_ALG_SHA1:
+        DigestSize = SHA1_DIGEST_SIZE;
+        break;
+      case TPM_ALG_SHA256:
+        DigestSize = SHA256_DIGEST_SIZE;
+        break;
+      case TPM_ALG_SHA384:
+        DigestSize = SHA384_DIGEST_SIZE;
+        break;
+      case TPM_ALG_SHA512:
+        DigestSize = SHA512_DIGEST_SIZE;
+        break;
+      case TPM_ALG_SM3_256:
+        DigestSize = SM3_256_DIGEST_SIZE;
+        break;
+      default:
+        DigestSize = SHA1_DIGEST_SIZE;
+        break;
+      }
+
+      if (DigestSize > mAuthSize) {
+        mAuthSize = DigestSize;
+      }
+    }
+    break;
+  }
+
+  *AuthSize = mAuthSize;
+  return Status;
+}
+
+/**
+  Set PlatformAuth to random value.
+**/
+VOID
+RandomizePlatformAuth (
+  VOID
+  )
+{
+  EFI_STATUS                        Status;
+  UINT16                            AuthSize;
+  UINT8                             *Rand;
+  UINTN                             RandSize;
+  TPM2B_AUTH                        NewPlatformAuth;
+
+  //
+  // Send Tpm2HierarchyChange Auth with random value to avoid PlatformAuth being null
+  //
+
+  GetAuthSize (&AuthSize);
+
+  ZeroMem (NewPlatformAuth.buffer, AuthSize);
+  NewPlatformAuth.size = AuthSize;
+
+  //
+  // Allocate one buffer to store random data.
+  //
+  RandSize = MAX_NEW_AUTHORIZATION_SIZE;
+  Rand = AllocatePool (RandSize);
+
+  RdRandGenerateEntropy (RandSize, Rand);
+  CopyMem (NewPlatformAuth.buffer, Rand, AuthSize);
+
+  FreePool (Rand);
+
+  //
+  // Send Tpm2HierarchyChangeAuth command with the new Auth value
+  //
+  Status = Tpm2HierarchyChangeAuth (TPM_RH_PLATFORM, NULL, &NewPlatformAuth);
+  DEBUG ((DEBUG_INFO, "Tpm2HierarchyChangeAuth Result: - %r\n", Status));
+  ZeroMem (NewPlatformAuth.buffer, AuthSize);
+  ZeroMem (Rand, RandSize);
+}
+
+/**
+  Disable the TPM platform hierarchy.
+
+  @retval   EFI_SUCCESS       The TPM was disabled successfully.
+  @retval   Others            An error occurred attempting to disable the TPM platform hierarchy.
+
+**/
+EFI_STATUS
+DisableTpmPlatformHierarchy (
+  VOID
+  )
+{
+  EFI_STATUS  Status;
+
+  // Make sure that we have use of the TPM.
+  Status = Tpm2RequestUseTpm ();
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a:%a() - Tpm2RequestUseTpm Failed! %r\n", gEfiCallerBaseName, __FUNCTION__, Status));
+    ASSERT_EFI_ERROR (Status);
+    return Status;
+  }
+
+  // Let's do what we can to shut down the hierarchies.
+
+  // Disable the PH NV.
+  // IMPORTANT NOTE: We *should* be able to disable the PH NV here, but TPM parts have
+  //                 been known to store the EK cert in the PH NV. If we disable it, the
+  //                 EK cert will be unreadable.
+
+  // Disable the PH.
+  Status =  Tpm2HierarchyControl (
+              TPM_RH_PLATFORM,     // AuthHandle
+              NULL,                // AuthSession
+              TPM_RH_PLATFORM,     // Hierarchy
+              NO                   // State
+              );
+  DEBUG ((DEBUG_VERBOSE, "%a:%a() -  Disable PH = %r\n", gEfiCallerBaseName, __FUNCTION__, Status));
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a:%a() -  Disable PH Failed! %r\n", gEfiCallerBaseName, __FUNCTION__, Status));
+    ASSERT_EFI_ERROR (Status);
+  }
+
+  return Status;
+}
+
+/**
+   This service defines the configuration of the Platform Hierarchy Authorization Value (platformAuth)
+   and Platform Hierarchy Authorization Policy (platformPolicy)
+
+**/
+VOID
+EFIAPI
+ConfigureTpmPlatformHierarchy (
+  )
+{
+  if (PcdGetBool (PcdRandomizePlatformHierarchy)) {
+    //
+    // Send Tpm2HierarchyChange Auth with random value to avoid PlatformAuth being null
+    //
+    RandomizePlatformAuth ();
+  } else {
+    //
+    // Disable the hierarchy entirely (do not randomize it)
+    //
+    DisableTpmPlatformHierarchy ();
+  }
+}

--- a/SecurityPkg/Library/PeiDxeTpmPlatformHierarchyLib/PeiDxeTpmPlatformHierarchyLib.inf
+++ b/SecurityPkg/Library/PeiDxeTpmPlatformHierarchyLib/PeiDxeTpmPlatformHierarchyLib.inf
@@ -1,0 +1,45 @@
+### @file
+#
+#   TPM Platform Hierarchy configuration library.
+#
+#   This library provides functions for customizing the TPM's Platform Hierarchy
+#   Authorization Value (platformAuth) and Platform Hierarchy Authorization
+#   Policy (platformPolicy) can be defined through this function.
+#
+# Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) Microsoft Corporation.<BR>
+#
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+###
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = PeiDxeTpmPlatformHierarchyLib
+  FILE_GUID                      = 7794F92C-4E8E-4E57-9E4A-49A0764C7D73
+  MODULE_TYPE                    = PEIM
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = TpmPlatformHierarchyLib|PEIM DXE_DRIVER
+
+[LibraryClasses]
+  BaseLib
+  BaseMemoryLib
+  DebugLib
+  MemoryAllocationLib
+  PcdLib
+  RngLib
+  Tpm2CommandLib
+  Tpm2DeviceLib
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  SecurityPkg/SecurityPkg.dec
+  CryptoPkg/CryptoPkg.dec
+  MinPlatformPkg/MinPlatformPkg.dec
+
+[Sources]
+  PeiDxeTpmPlatformHierarchyLib.c
+
+[Pcd]
+  gMinPlatformPkgTokenSpaceGuid.PcdRandomizePlatformHierarchy

--- a/SecurityPkg/Library/PeiDxeTpmPlatformHierarchyLib/PeiDxeTpmPlatformHierarchyLib.inf
+++ b/SecurityPkg/Library/PeiDxeTpmPlatformHierarchyLib/PeiDxeTpmPlatformHierarchyLib.inf
@@ -36,10 +36,9 @@
   MdeModulePkg/MdeModulePkg.dec
   SecurityPkg/SecurityPkg.dec
   CryptoPkg/CryptoPkg.dec
-  MinPlatformPkg/MinPlatformPkg.dec
 
 [Sources]
   PeiDxeTpmPlatformHierarchyLib.c
 
 [Pcd]
-  gMinPlatformPkgTokenSpaceGuid.PcdRandomizePlatformHierarchy
+  gEfiSecurityPkgTokenSpaceGuid.PcdRandomizePlatformHierarchy

--- a/SecurityPkg/SecurityPkg.dec
+++ b/SecurityPkg/SecurityPkg.dec
@@ -342,6 +342,12 @@
   # @Prompt Physical presence of the platform operator.
   gEfiSecurityPkgTokenSpaceGuid.PcdTpmPhysicalPresence|TRUE|BOOLEAN|0x00010001
 
+  ## Indicates whether the TPM2 platform hierarchy will be disabled by using
+  #  a random password or by disabling the hierarchy
+  #   TRUE  - A random password will be used
+  #   FALSE - The hierarchy will be disabled
+  gEfiSecurityPkgTokenSpaceGuid.PcdRandomizePlatformHierarchy|TRUE|BOOLEAN|0x00010024
+
 [PcdsFixedAtBuild, PcdsPatchableInModule, PcdsDynamic, PcdsDynamicEx]
   ## Indicates whether TPM physical presence is locked during platform initialization.
   #  Once it is locked, it can not be unlocked for TPM life time.<BR><BR>

--- a/SecurityPkg/Tcg/Tcg2PlatformDxe/Tcg2PlatformDxe.c
+++ b/SecurityPkg/Tcg/Tcg2PlatformDxe/Tcg2PlatformDxe.c
@@ -1,0 +1,85 @@
+/** @file
+  Platform specific TPM2 component for configuring the Platform Hierarchy.
+
+  Copyright (c) 2017 - 2019, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <PiDxe.h>
+
+#include <Library/DebugLib.h>
+#include <Library/UefiBootServicesTableLib.h>
+#include <Library/UefiLib.h>
+#include <Library/TpmPlatformHierarchyLib.h>
+#include <Protocol/DxeSmmReadyToLock.h>
+
+/**
+   This callback function will run at the SmmReadyToLock event.
+
+   Configuration of the TPM's Platform Hierarchy Authorization Value (platformAuth)
+   and Platform Hierarchy Authorization Policy (platformPolicy) can be defined through this function.
+
+  @param  Event   Pointer to this event
+  @param  Context Event hanlder private data
+ **/
+VOID
+EFIAPI
+SmmReadyToLockEventCallBack (
+  IN EFI_EVENT  Event,
+  IN VOID       *Context
+  )
+{
+  EFI_STATUS   Status;
+  VOID         *Interface;
+
+  //
+  // Try to locate it because EfiCreateProtocolNotifyEvent will trigger it once when registration.
+  // Just return if it is not found.
+  //
+  Status = gBS->LocateProtocol (
+                  &gEfiDxeSmmReadyToLockProtocolGuid,
+                  NULL,
+                  &Interface
+                  );
+  if (EFI_ERROR (Status)) {
+    return ;
+  }
+
+  ConfigureTpmPlatformHierarchy ();
+
+  gBS->CloseEvent (Event);
+}
+
+/**
+   The driver's entry point. Will register a function for callback during SmmReadyToLock event to
+   configure the TPM's platform authorization.
+
+   @param[in] ImageHandle  The firmware allocated handle for the EFI image.
+   @param[in] SystemTable  A pointer to the EFI System Table.
+
+   @retval EFI_SUCCESS     The entry point is executed successfully.
+   @retval other           Some error occurs when executing this entry point.
+**/
+EFI_STATUS
+EFIAPI
+Tcg2PlatformDxeEntryPoint (
+  IN    EFI_HANDLE                  ImageHandle,
+  IN    EFI_SYSTEM_TABLE            *SystemTable
+  )
+{
+  VOID       *Registration;
+  EFI_EVENT  Event;
+
+  Event = EfiCreateProtocolNotifyEvent (
+            &gEfiDxeSmmReadyToLockProtocolGuid,
+            TPL_CALLBACK,
+            SmmReadyToLockEventCallBack,
+            NULL,
+            &Registration
+            );
+
+  ASSERT (Event != NULL);
+
+  return EFI_SUCCESS;
+}

--- a/SecurityPkg/Tcg/Tcg2PlatformDxe/Tcg2PlatformDxe.inf
+++ b/SecurityPkg/Tcg/Tcg2PlatformDxe/Tcg2PlatformDxe.inf
@@ -1,0 +1,44 @@
+### @file
+# Platform specific TPM2 component.
+#
+# Copyright (c) 2017 - 2019, Intel Corporation. All rights reserved.<BR>
+#
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+###
+
+[Defines]
+  INF_VERSION                    = 0x00010017
+  BASE_NAME                      = Tcg2PlatformDxe
+  FILE_GUID                      = 5CAB08D5-AD8F-4d8b-B828-D17A8D9FE977
+  VERSION_STRING                 = 1.0
+  MODULE_TYPE                    = DXE_DRIVER
+  ENTRY_POINT                    = Tcg2PlatformDxeEntryPoint
+#
+# The following information is for reference only and not required by the build tools.
+#
+# VALID_ARCHITECTURES = IA32 X64 IPF
+#
+
+[LibraryClasses]
+  BaseLib
+  UefiBootServicesTableLib
+  UefiDriverEntryPoint
+  DebugLib
+  UefiLib
+  TpmPlatformHierarchyLib
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  MinPlatformPkg/MinPlatformPkg.dec
+  SecurityPkg/SecurityPkg.dec
+
+[Sources]
+  Tcg2PlatformDxe.c
+
+[Protocols]
+  gEfiDxeSmmReadyToLockProtocolGuid             ## SOMETIMES_CONSUMES ## NOTIFY
+
+[Depex]
+  gEfiTcg2ProtocolGuid

--- a/SecurityPkg/Tcg/Tcg2PlatformDxe/Tcg2PlatformDxe.inf
+++ b/SecurityPkg/Tcg/Tcg2PlatformDxe/Tcg2PlatformDxe.inf
@@ -31,7 +31,6 @@
 [Packages]
   MdePkg/MdePkg.dec
   MdeModulePkg/MdeModulePkg.dec
-  MinPlatformPkg/MinPlatformPkg.dec
   SecurityPkg/SecurityPkg.dec
 
 [Sources]

--- a/SecurityPkg/Tcg/Tcg2PlatformPei/Tcg2PlatformPei.c
+++ b/SecurityPkg/Tcg/Tcg2PlatformPei/Tcg2PlatformPei.c
@@ -1,0 +1,107 @@
+/** @file
+
+Copyright (c) 2017, Intel Corporation. All rights reserved.<BR>
+Copyright (c) Microsoft Corporation.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <PiPei.h>
+#include <Library/PeiServicesLib.h>
+#include <Library/DebugLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/HobLib.h>
+#include <Library/Tpm2CommandLib.h>
+#include <Library/Tpm2DeviceLib.h>
+#include <Library/TpmPlatformHierarchyLib.h>
+#include <Library/RngLib.h>
+
+#include <Ppi/EndOfPeiPhase.h>
+
+#define MAX_NEW_AUTHORIZATION_SIZE        SHA512_DIGEST_SIZE
+
+/**
+  This function handles PlatformInit task at the end of PEI
+
+  @param[in]  PeiServices  Pointer to PEI Services Table.
+  @param[in]  NotifyDesc   Pointer to the descriptor for the Notification event that
+                           caused this function to execute.
+  @param[in]  Ppi          Pointer to the PPI data associated with this function.
+
+  @retval     EFI_SUCCESS  The function completes successfully
+  @retval     others
+**/
+EFI_STATUS
+EFIAPI
+PlatformInitEndOfPei (
+  IN CONST EFI_PEI_SERVICES     **PeiServices,
+  IN EFI_PEI_NOTIFY_DESCRIPTOR  *NotifyDescriptor,
+  IN VOID                       *Ppi
+  )
+{
+  VOID *TcgEventLog;
+
+  //
+  // Try to get TcgEventLog in S3 to see if S3 error is reported.
+  //
+  TcgEventLog = GetFirstGuidHob(&gTcgEventEntryHobGuid);
+  if (TcgEventLog == NULL) {
+    TcgEventLog = GetFirstGuidHob(&gTcgEvent2EntryHobGuid);
+  }
+
+  if (TcgEventLog == NULL) {
+    //
+    // no S3 error reported
+    //
+    return EFI_SUCCESS;
+  }
+
+  //
+  // If there is S3 error on TPM_SU_STATE and success on TPM_SU_CLEAR,
+  // configure the TPM Platform Hierarchy.
+  //
+  ConfigureTpmPlatformHierarchy ();
+
+  return EFI_SUCCESS;
+}
+
+static EFI_PEI_NOTIFY_DESCRIPTOR  mEndOfPeiNotifyList = {
+  (EFI_PEI_PPI_DESCRIPTOR_NOTIFY_CALLBACK | EFI_PEI_PPI_DESCRIPTOR_TERMINATE_LIST),
+  &gEfiEndOfPeiSignalPpiGuid,
+  (EFI_PEIM_NOTIFY_ENTRY_POINT)PlatformInitEndOfPei
+};
+
+/**
+  Main entry
+
+  @param[in]  FileHandle              Handle of the file being invoked.
+  @param[in]  PeiServices             Pointer to PEI Services table.
+
+  @retval EFI_SUCCESS Install function successfully.
+
+**/
+EFI_STATUS
+EFIAPI
+Tcg2PlatformPeiEntryPoint (
+  IN       EFI_PEI_FILE_HANDLE  FileHandle,
+  IN CONST EFI_PEI_SERVICES     **PeiServices
+  )
+{
+  EFI_STATUS               Status;
+  EFI_BOOT_MODE            BootMode;
+
+  Status = PeiServicesGetBootMode (&BootMode);
+  ASSERT_EFI_ERROR(Status);
+
+  if (BootMode != BOOT_ON_S3_RESUME) {
+    return EFI_SUCCESS;
+  }
+
+  //
+  // Performing PlatformInitEndOfPei after EndOfPei PPI produced
+  //
+  Status = PeiServicesNotifyPpi (&mEndOfPeiNotifyList);
+
+  return Status;
+}

--- a/SecurityPkg/Tcg/Tcg2PlatformPei/Tcg2PlatformPei.inf
+++ b/SecurityPkg/Tcg/Tcg2PlatformPei/Tcg2PlatformPei.inf
@@ -1,0 +1,52 @@
+### @file
+#
+# Copyright (c) 2017, Intel Corporation. All rights reserved.<BR>
+#
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+###
+
+[Defines]
+  INF_VERSION                    = 0x00010017
+  BASE_NAME                      = Tcg2PlatformPei
+  FILE_GUID                      = 47727552-A54B-4A84-8CC1-BFF23E239636
+  VERSION_STRING                 = 1.0
+  MODULE_TYPE                    = PEIM
+  ENTRY_POINT                    = Tcg2PlatformPeiEntryPoint
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+# VALID_ARCHITECTURES = IA32 X64 IPF EBC
+#
+
+[LibraryClasses]
+  PcdLib
+  BaseMemoryLib
+  MemoryAllocationLib
+  PeiServicesLib
+  PeimEntryPoint
+  DebugLib
+  Tpm2DeviceLib
+  Tpm2CommandLib
+  TpmPlatformHierarchyLib
+  RngLib
+
+[Packages]
+  MdePkg/MdePkg.dec
+  SecurityPkg/SecurityPkg.dec
+  MinPlatformPkg/MinPlatformPkg.dec
+
+[Sources]
+  Tcg2PlatformPei.c
+
+[Guids]
+  gTcgEventEntryHobGuid
+  gTcgEvent2EntryHobGuid
+
+[Ppis]
+  gEfiEndOfPeiSignalPpiGuid
+
+[Depex]
+  gEfiTpmDeviceSelectedGuid
+

--- a/SecurityPkg/Tcg/Tcg2PlatformPei/Tcg2PlatformPei.inf
+++ b/SecurityPkg/Tcg/Tcg2PlatformPei/Tcg2PlatformPei.inf
@@ -35,7 +35,6 @@
 [Packages]
   MdePkg/MdePkg.dec
   SecurityPkg/SecurityPkg.dec
-  MinPlatformPkg/MinPlatformPkg.dec
 
 [Sources]
   Tcg2PlatformPei.c


### PR DESCRIPTION
This series imports code from the edk2-platforms project related to
disabling the TPM2 platform hierarchy in Ovmf. It addresses the Ovmf
aspects of the following bugs:

https://bugzilla.tianocore.org/show_bug.cgi?id=3510
https://bugzilla.tianocore.org/show_bug.cgi?id=3499

I have patched the .dsc files and successfully test-built with most of
them. Some I could not build because they failed for other reasons
unrelated to this series.

I tested the changes with QEMU on x86 following the build of
OvmfPkgX64.dsc.

Neither one of the following commands should work anymore on first
try when run on Linux:

With IBM tss2 tools:
tsshierarchychangeauth -hi p -pwdn newpass

With Intel tss2 tools:
tpm2_changeauth -c platform newpass

Regards,
  Stefan

NOTE: This PR only checks in the security package update as basic core support.
There are still problems to be fixed in ovmf package. (e.g. when to trigger TCG PP)
That will be in next wave.

Jiewen Yao