### PR TITLE
MdeModulePkg/Core/Pei: Migration improvements and fixes

### DIFF
--- a/MdeModulePkg/Core/Pei/Dispatcher/Dispatcher.c
+++ b/MdeModulePkg/Core/Pei/Dispatcher/Dispatcher.c
@@ -958,7 +958,7 @@ PeiCheckAndSwitchStack (
   @param PeimFileHandle       Pointer to the FFS file header of the image.
   @param MigratedFileHandle   Pointer to the FFS file header of the migrated image.
 
-  @retval EFI_SUCCESS         Sucessfully migrated the PEIM to permanent memory.
+  @retval EFI_SUCCESS         Successfully migrated the PEIM to permanent memory.
 
 **/
 EFI_STATUS
@@ -1120,7 +1120,7 @@ MigratePeimsInFv (
                          environment, such as the size and location of temporary RAM, the stack location and
                          the BFV location.
 
-  @retval EFI_SUCCESS           Succesfully migrated installed FVs from temporary RAM to permanent memory.
+  @retval EFI_SUCCESS           Successfully migrated installed FVs from temporary RAM to permanent memory.
   @retval EFI_OUT_OF_RESOURCES  Insufficient memory exists to allocate needed pages.
 
 **/

--- a/MdeModulePkg/Core/Pei/Dispatcher/Dispatcher.c
+++ b/MdeModulePkg/Core/Pei/Dispatcher/Dispatcher.c
@@ -993,7 +993,7 @@ MigratePeim (
         AsciiString[Index] = 0;
       }
     }
-    DEBUG ((DEBUG_INFO, "%a", AsciiString));
+    DEBUG ((DEBUG_VERBOSE, "%a", AsciiString));
     DEBUG_CODE_END ();
 
     Pe32Data = (VOID *) ((UINTN) ImageAddress - (UINTN) MigratedFileHandle + (UINTN) FileHandle);

--- a/MdeModulePkg/Core/Pei/Dispatcher/Dispatcher.c
+++ b/MdeModulePkg/Core/Pei/Dispatcher/Dispatcher.c
@@ -1135,6 +1135,7 @@ EvacuateTempRam (
   volatile UINTN                FvIndex;
   volatile UINTN                FvChildIndex;
   UINTN                         ChildFvOffset;
+  EFI_PHYSICAL_ADDRESS          FvHeaderAddress;
   EFI_FIRMWARE_VOLUME_HEADER    *FvHeader;
   EFI_FIRMWARE_VOLUME_HEADER    *ChildFvHeader;
   EFI_FIRMWARE_VOLUME_HEADER    *MigratedFvHeader;
@@ -1186,9 +1187,10 @@ EvacuateTempRam (
       Status =  PeiServicesAllocatePages (
                   EfiBootServicesCode,
                   EFI_SIZE_TO_PAGES ((UINTN) FvHeader->FvLength),
-                  (EFI_PHYSICAL_ADDRESS *) &MigratedFvHeader
+                  &FvHeaderAddress
                   );
       ASSERT_EFI_ERROR (Status);
+      MigratedFvHeader = (EFI_FIRMWARE_VOLUME_HEADER *)(UINTN)FvHeaderAddress;
 
       //
       // Allocate pool to save the raw PEIMs, which is used to keep consistent context across
@@ -1197,9 +1199,10 @@ EvacuateTempRam (
       Status =  PeiServicesAllocatePages (
                   EfiBootServicesCode,
                   EFI_SIZE_TO_PAGES ((UINTN) FvHeader->FvLength),
-                  (EFI_PHYSICAL_ADDRESS *) &RawDataFvHeader
+                  &FvHeaderAddress
                   );
       ASSERT_EFI_ERROR (Status);
+      RawDataFvHeader = (EFI_FIRMWARE_VOLUME_HEADER *)(UINTN)FvHeaderAddress;
 
       DEBUG ((
         DEBUG_VERBOSE,

--- a/MdeModulePkg/Core/Pei/PeiMain.h
+++ b/MdeModulePkg/Core/Pei/PeiMain.h
@@ -419,7 +419,7 @@ MigratePeim (
                          environment, such as the size and location of temporary RAM, the stack location and
                          the BFV location.
 
-  @retval EFI_SUCCESS           Succesfully migrated installed FVs from temporary RAM to permanent memory.
+  @retval EFI_SUCCESS           Successfully migrated installed FVs from temporary RAM to permanent memory.
   @retval EFI_OUT_OF_RESOURCES  Insufficient memory exists to allocate needed pages.
 
 **/


### PR DESCRIPTION
REF:https://bugzilla.tianocore.org/show_bug.cgi?id=3512

This patch series contains three patches. The first two are for
relatively minor improvments - a typo fix in function descriptions
and changing the error level of a debug print. The third patch
fixes a pointer size mismatch.
