### PR TITLE
[PATCH v2] UefiCpuPkg: SecCoreNative without ResetVector

### DIFF
--- a/UefiCpuPkg/SecCore/SecCoreNative.inf
+++ b/UefiCpuPkg/SecCore/SecCoreNative.inf
@@ -1,0 +1,80 @@
+## @file
+#  SecCoreNative module that implements the SEC phase.
+#
+# This is the first module taking control after the reset vector.
+# The entry point function is _ModuleEntryPoint in PlatformSecLib.
+# The entry point function starts in 32bit protected mode or 64bit
+# mode depending on how resetvector is implemented, enables
+# temporary memory and calls into SecStartup().
+#
+#  Copyright (c) 2021, Intel Corporation. All rights reserved.<BR>
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = SecCoreNative
+  MODULE_UNI_FILE                = SecCore.uni
+  FILE_GUID                      = 43CA74CA-7D29-49A0-B3B9-20F84015B27D
+  MODULE_TYPE                    = SEC
+  VERSION_STRING                 = 1.0
+
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64 EBC
+#
+
+[Sources]
+  SecMain.c
+  SecMain.h
+  FindPeiCore.c
+  SecBist.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  UefiCpuPkg/UefiCpuPkg.dec
+
+[LibraryClasses]
+  BaseMemoryLib
+  DebugLib
+  PlatformSecLib
+  PcdLib
+  DebugAgentLib
+  UefiCpuLib
+  PeCoffGetEntryPointLib
+  PeCoffExtraActionLib
+  CpuExceptionHandlerLib
+  ReportStatusCodeLib
+  PeiServicesLib
+  PeiServicesTablePointerLib
+  HobLib
+
+[Ppis]
+  ## SOMETIMES_CONSUMES
+  ## PRODUCES
+  gEfiSecPlatformInformationPpiGuid
+  ## SOMETIMES_CONSUMES
+  ## SOMETIMES_PRODUCES
+  gEfiSecPlatformInformation2PpiGuid
+  gEfiTemporaryRamDonePpiGuid                          ## PRODUCES
+  ## NOTIFY
+  ## SOMETIMES_CONSUMES
+  gPeiSecPerformancePpiGuid
+  gEfiPeiCoreFvLocationPpiGuid
+  ## CONSUMES
+  gRepublishSecPpiPpiGuid
+
+[Guids]
+  ## SOMETIMES_PRODUCES   ## HOB
+  gEfiFirmwarePerformanceGuid
+
+[Pcd]
+  gUefiCpuPkgTokenSpaceGuid.PcdPeiTemporaryRamStackSize  ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdMigrateTemporaryRamFirmwareVolumes  ## CONSUMES
+
+[UserExtensions.TianoCore."ExtraFiles"]
+  SecCoreExtra.uni

--- a/UefiCpuPkg/UefiCpuPkg.dsc
+++ b/UefiCpuPkg/UefiCpuPkg.dsc
@@ -161,6 +161,7 @@
   UefiCpuPkg/PiSmmCommunication/PiSmmCommunicationPei.inf
   UefiCpuPkg/PiSmmCommunication/PiSmmCommunicationSmm.inf
   UefiCpuPkg/SecCore/SecCore.inf
+  UefiCpuPkg/SecCore/SecCoreNative.inf
   UefiCpuPkg/SecMigrationPei/SecMigrationPei.inf
   UefiCpuPkg/PiSmmCpuDxeSmm/PiSmmCpuDxeSmm.inf
   UefiCpuPkg/PiSmmCpuDxeSmm/PiSmmCpuDxeSmm.inf {


### PR DESCRIPTION
REF:https://bugzilla.tianocore.org/show_bug.cgi?id=3473

X64 Reset Vector Code can access the memory range till 4GB using the
Linear-Address Translation to a 2-MByte Page, when user wants to use
more than 4G using 2M Page it will leads to use more number of Page
table entries. using the 1-GByte Page table user can use more than
4G Memory by reducing the page table entries using 1-GByte Page,
this patch attached can access memory range till 512GByte via Linear-
Address Translation to a 1-GByte Page.

Build Tool: if the nasm is not found it will throw Build errors like
FileNotFoundError: [WinError 2]The system cannot find the file specified
run the command wil try except block to get meaningful error message

Test Result: Tested in both Simulation environment and Hardware
both works fine without any issues.

Cc: Ray Ni <ray.ni@intel.com>
Cc: Rahul Kumar <rahul1.kumar@intel.com>
Cc: Debkumar De <debkumar.de@intel.com>
Cc: Harry Han <harry.han@intel.com>
Cc: Catharine West <catharine.west@intel.com>
Cc: Sangeetha V <sangeetha.v@intel.com>
Cc: Rangasai V Chaganty <rangasai.v.chaganty@intel.com>
Cc: Sahil Dureja <sahil.dureja@intel.com>

Signed-off-by: Ashraf Ali S <ashraf.ali.s@intel.com>