### PR TITLE
ArmPkg/ProcessorSubClassDxe: Fix the format of ProcessorId

### DIFF
--- a/ArmPkg/Universal/Smbios/ProcessorSubClassDxe/SmbiosProcessorArmCommon.c
+++ b/ArmPkg/Universal/Smbios/ProcessorSubClassDxe/SmbiosProcessorArmCommon.c
@@ -2,6 +2,7 @@
   Functions for processor information common to ARM and AARCH64.
 
   Copyright (c) 2021, NUVIA Inc. All rights reserved.<BR>
+  Copyright (c) 2021, Ampere Computing LLC. All rights reserved.<BR>
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -171,7 +172,7 @@ SmbiosGetProcessorId (
 
   if (HasSmcArm64SocId ()) {
     SmbiosGetSmcArm64SocId (&Jep106Code, &SocRevision);
-    ProcessorId = ((UINT64)Jep106Code << 32) | SocRevision;
+    ProcessorId = ((UINT64)SocRevision << 32) | Jep106Code;
   } else {
     ProcessorId = ArmReadMidr ();
   }


### PR DESCRIPTION
According to SMBIOS 3.4, section 7.5.3.3 ARM64-class CPUs, if
SMCCC_ARCH_SOC_ID is supported, the first DWORD is the JEP-106 code and
the second DWORD is the SoC revision value. But in the current
implementation, they are set in reverse. This patch is to correct it.

Cc: Leif Lindholm <leif@nuviainc.com>
Cc: Ard Biesheuvel <ardb+tianocore@kernel.org>
Cc: Rebecca Cran <rebecca@nuviainc.com>
Signed-off-by: Nhi Pham <nhi@os.amperecomputing.com>
Reviewed-by: Rebecca Cran <rebecca@nuviainc.com>
Acked-by: Leif Lindholm <leif@nuviainc.com>