### PR TITLE
MdeModulePkg/PeiDxeDebugLibReportStatusCode:Support StandaloneMm Ins…

### DIFF
--- a/MdeModulePkg/Library/PeiDxeDebugLibReportStatusCode/PeiDxeDebugLibReportStatusCode.inf
+++ b/MdeModulePkg/Library/PeiDxeDebugLibReportStatusCode/PeiDxeDebugLibReportStatusCode.inf
@@ -16,7 +16,7 @@
   FILE_GUID                      = bda39d3a-451b-4350-8266-81ab10fa0523
   MODULE_TYPE                    = PEIM
   VERSION_STRING                 = 1.0
-  LIBRARY_CLASS                  = DebugLib|DXE_CORE DXE_DRIVER DXE_RUNTIME_DRIVER DXE_SMM_DRIVER SMM_CORE PEIM SEC PEI_CORE UEFI_APPLICATION UEFI_DRIVER
+  LIBRARY_CLASS                  = DebugLib|DXE_CORE DXE_DRIVER DXE_RUNTIME_DRIVER DXE_SMM_DRIVER SMM_CORE PEIM SEC PEI_CORE UEFI_APPLICATION UEFI_DRIVER MM_STANDALONE
 
 #
 # The following information is for reference only and not required by the build tools.


### PR DESCRIPTION
…tance

REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3633

Add MM_STANDALONE to the list of permitted module types of the
PeiDxeDebugLibReportStatusCode library implementation.

Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Signed-off-by: Xiaolu Jiang <xiaolu.jiang@intel.com>