### PR TITLE
[DRAFT] IntelFsp2WrapperPkg : FSPM/S UPD data address based on Build

### DIFF
--- a/IntelFsp2WrapperPkg/FspmWrapperPeim/FspmWrapperPeim.c
+++ b/IntelFsp2WrapperPkg/FspmWrapperPeim/FspmWrapperPeim.c
@@ -3,7 +3,7 @@
   register TemporaryRamDonePpi to call TempRamExit API, and register MemoryDiscoveredPpi
   notify to call FspSiliconInit API.
 
-  Copyright (c) 2014 - 2020, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2014 - 2021, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -68,7 +68,7 @@ PeiFspMemoryInit (
     return EFI_DEVICE_ERROR;
   }
 
-  if (PcdGet32 (PcdFspmUpdDataAddress) == 0 && (FspmHeaderPtr->CfgRegionSize != 0) && (FspmHeaderPtr->CfgRegionOffset != 0)) {
+  if (GetFspmUpdDataAddress () == 0 && (FspmHeaderPtr->CfgRegionSize != 0) && (FspmHeaderPtr->CfgRegionOffset != 0)) {
     //
     // Copy default FSP-M UPD data from Flash
     //
@@ -80,7 +80,7 @@ PeiFspMemoryInit (
     //
     // External UPD is ready, get the buffer from PCD pointer.
     //
-    FspmUpdDataPtr = (FSPM_UPD_COMMON *)PcdGet32 (PcdFspmUpdDataAddress);
+    FspmUpdDataPtr = (FSPM_UPD_COMMON *) GetFspmUpdDataAddress ();
     ASSERT (FspmUpdDataPtr != NULL);
   }
 

--- a/IntelFsp2WrapperPkg/FspmWrapperPeim/FspmWrapperPeim.inf
+++ b/IntelFsp2WrapperPkg/FspmWrapperPeim/FspmWrapperPeim.inf
@@ -6,7 +6,7 @@
 # register TemporaryRamDonePpi to call TempRamExit API, and register MemoryDiscoveredPpi
 # notify to call FspSiliconInit API.
 #
-#  Copyright (c) 2014 - 2020, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2014 - 2021, Intel Corporation. All rights reserved.<BR>
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -56,7 +56,6 @@
 
 [Pcd]
   gIntelFsp2WrapperTokenSpaceGuid.PcdFspmBaseAddress       ## CONSUMES
-  gIntelFsp2WrapperTokenSpaceGuid.PcdFspmUpdDataAddress    ## CONSUMES
   gIntelFsp2WrapperTokenSpaceGuid.PcdFspModeSelection      ## CONSUMES
   gIntelFsp2WrapperTokenSpaceGuid.PcdFsptBaseAddress       ## CONSUMES
   gIntelFsp2WrapperTokenSpaceGuid.PcdFspMeasurementConfig  ## CONSUMES

--- a/IntelFsp2WrapperPkg/FspsWrapperPeim/FspsWrapperPeim.c
+++ b/IntelFsp2WrapperPkg/FspsWrapperPeim/FspsWrapperPeim.c
@@ -3,7 +3,7 @@
   register TemporaryRamDonePpi to call TempRamExit API, and register MemoryDiscoveredPpi
   notify to call FspSiliconInit API.
 
-  Copyright (c) 2014 - 2020, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2014 - 2021, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -283,7 +283,7 @@ PeiMemoryDiscoveredNotify (
     return EFI_DEVICE_ERROR;
   }
 
-  if (PcdGet32 (PcdFspsUpdDataAddress) == 0 && (FspsHeaderPtr->CfgRegionSize != 0) && (FspsHeaderPtr->CfgRegionOffset != 0)) {
+  if (GetFspsUpdDataAddress () == 0 && (FspsHeaderPtr->CfgRegionSize != 0) && (FspsHeaderPtr->CfgRegionOffset != 0)) {
     //
     // Copy default FSP-S UPD data from Flash
     //
@@ -292,7 +292,7 @@ PeiMemoryDiscoveredNotify (
     SourceData = (UINTN *)((UINTN)FspsHeaderPtr->ImageBase + (UINTN)FspsHeaderPtr->CfgRegionOffset);
     CopyMem (FspsUpdDataPtr, SourceData, (UINTN)FspsHeaderPtr->CfgRegionSize);
   } else {
-    FspsUpdDataPtr = (FSPS_UPD_COMMON *)PcdGet32 (PcdFspsUpdDataAddress);
+    FspsUpdDataPtr = (FSPS_UPD_COMMON *) GetFspsUpdDataAddress ();
     ASSERT (FspsUpdDataPtr != NULL);
   }
 

--- a/IntelFsp2WrapperPkg/Include/Library/FspWrapperPlatformLib.h
+++ b/IntelFsp2WrapperPkg/Include/Library/FspWrapperPlatformLib.h
@@ -1,7 +1,7 @@
 /** @file
   Provide FSP wrapper platform related function.
 
-  Copyright (c) 2014 - 2016, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2014 - 2021, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -75,6 +75,28 @@ VOID
 EFIAPI
 CallFspWrapperResetSystem (
   IN UINT32    FspStatusResetType
+  );
+
+/**
+  Get the Fspm Upd Data Address from the PCD
+
+  @return FSPM UPD Data Address
+**/
+UINTN
+EFIAPI
+GetFspmUpdDataAddress (
+  VOID
+  );
+
+/**
+  Get the Fsps Upd Data Address from the PCD
+
+  @return FSPS UPD Data Address
+**/
+UINTN
+EFIAPI
+GetFspsUpdDataAddress (
+  VOID
   );
 
 #endif

--- a/IntelFsp2WrapperPkg/IntelFsp2WrapperPkg.dec
+++ b/IntelFsp2WrapperPkg/IntelFsp2WrapperPkg.dec
@@ -121,3 +121,5 @@
   #
   gIntelFsp2WrapperTokenSpaceGuid.PcdFspmUpdDataAddress|0x00000000|UINT32|0x50000000
   gIntelFsp2WrapperTokenSpaceGuid.PcdFspsUpdDataAddress|0x00000000|UINT32|0x50000001
+  gIntelFsp2WrapperTokenSpaceGuid.PcdFspmUpdDataAddress64|0x00000000|UINT64|0x50000002
+  gIntelFsp2WrapperTokenSpaceGuid.PcdFspsUpdDataAddress64|0x00000000|UINT64|0x50000003

--- a/IntelFsp2WrapperPkg/Library/BaseFspWrapperPlatformLibSample/BaseFspWrapperPlatformLibSample.inf
+++ b/IntelFsp2WrapperPkg/Library/BaseFspWrapperPlatformLibSample/BaseFspWrapperPlatformLibSample.inf
@@ -1,7 +1,7 @@
 ## @file
 #  Sample to provide FSP wrapper platform related function.
 #
-#  Copyright (c) 2014 - 2016, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2014 - 2021, Intel Corporation. All rights reserved.<BR>
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -35,6 +35,12 @@
 [Sources]
   FspWrapperPlatformLibSample.c
 
+[Sources.IA32]
+  IA32/FspHelper.c
+
+[Sources.X64]
+  IA32/FspHelper.c
+
 
 ################################################################################
 #
@@ -48,5 +54,14 @@
   IntelFsp2Pkg/IntelFsp2Pkg.dec
   IntelFsp2WrapperPkg/IntelFsp2WrapperPkg.dec
 
+[Pcd.IA32]
+  gIntelFsp2WrapperTokenSpaceGuid.PcdFspmUpdDataAddress    ## CONSUMES
+  gIntelFsp2WrapperTokenSpaceGuid.PcdFspsUpdDataAddress    ## CONSUMES
+
+[Pcd.X64]
+  gIntelFsp2WrapperTokenSpaceGuid.PcdFspmUpdDataAddress64  ## CONSUMES
+  gIntelFsp2WrapperTokenSpaceGuid.PcdFspsUpdDataAddress64  ## CONSUMES
+
 [LibraryClasses]
+  PcdLib
 

--- a/IntelFsp2WrapperPkg/Library/BaseFspWrapperPlatformLibSample/IA32/FspHelper.c
+++ b/IntelFsp2WrapperPkg/Library/BaseFspWrapperPlatformLibSample/IA32/FspHelper.c
@@ -1,0 +1,40 @@
+/** @file
+  Sample to provide FSP wrapper related function.
+
+  Copyright (c) 2021, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+
+#include <Library/PcdLib.h>
+#include <Library/FspWrapperPlatformLib.h>
+#include <Uefi/UefiBaseType.h>
+
+/**
+  Get the Fspm Upd Data Address from the PCD
+
+  @return FSPM UPD Data Address
+**/
+UINTN
+EFIAPI
+GetFspmUpdDataAddress (
+  VOID
+  )
+{
+  return PcdGet32 (PcdFspmUpdDataAddress);
+}
+
+/**
+  Get the Fsps Upd Data Address from the PCD
+
+  @return FSPS UPD Data Address
+**/
+UINTN
+EFIAPI
+GetFspsUpdDataAddress (
+  VOID
+  )
+{
+  return PcdGet32 (PcdFspsUpdDataAddress);
+}

--- a/IntelFsp2WrapperPkg/Library/BaseFspWrapperPlatformLibSample/X64/FspHelper.c
+++ b/IntelFsp2WrapperPkg/Library/BaseFspWrapperPlatformLibSample/X64/FspHelper.c
@@ -1,0 +1,40 @@
+/** @file
+  Sample to provide FSP wrapper related function.
+
+  Copyright (c) 2021, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+
+#include <Library/PcdLib.h>
+#include <Library/FspWrapperPlatformLib.h>
+#include <Uefi/UefiBaseType.h>
+
+/**
+  Get the Fspm Upd Data Address from the PCD
+
+  @return FSPM UPD Data Address
+**/
+UINTN
+EFIAPI
+GetFspmUpdDataAddress (
+  VOID
+  )
+{
+  return PcdGet64 (PcdFspmUpdDataAddress64);
+}
+
+/**
+  Get the Fsps Upd Data Address from the PCD
+
+  @return FSPS UPD Data Address
+**/
+UINTN
+EFIAPI
+GetFspsUpdDataAddress (
+  VOID
+  )
+{
+  return PcdGet64 (PcdFspsUpdDataAddress64);
+}


### PR DESCRIPTION
Type PcdFspmUpdDataAddress & PcdFspsUpdDataAddress always return 32bit value
when the a module which is not building in IA32 mode which will leads to
build error. Creating the API's to support different architecture

Signed-off-by: Ashraf Ali S <ashraf.ali.s@intel.com>