### PR TITLE
OvmfPkg: set a default value for the WorkAreaHeader PCD

### DIFF
--- a/OvmfPkg/Include/WorkArea.h
+++ b/OvmfPkg/Include/WorkArea.h
@@ -25,6 +25,11 @@ typedef enum {
 // to the structure need to be kept in sync with the
 // PcdOvmfConfidentialComputingWorkAreaHeader.
 //
+// PcdOvmfConfidentialComputingWorkAreaHeader ==
+//   sizeof (CONFIDENTIAL_COMPUTING_WORK_AREA_HEADER)
+// PcdOvmfConfidentialComputingWorkAreaHeader defined in:
+//   OvmfPkg/OvmfPkg.dec
+//   OvmfPkg/OvmfPkgDefines.fdf.inc
 typedef struct _CONFIDENTIAL_COMPUTING_WORK_AREA_HEADER {
   UINT8                   GuestType;
   UINT8                   Reserved1[3];

--- a/OvmfPkg/OvmfPkg.dec
+++ b/OvmfPkg/OvmfPkg.dec
@@ -338,7 +338,7 @@
   # The size of this header is used early boot, and is provided through
   # a fixed PCD. It need to be kept in sync with any changes to the
   # header definition.
-  gUefiOvmfPkgTokenSpaceGuid.PcdOvmfConfidentialComputingWorkAreaHeader|0|UINT32|0x51
+  gUefiOvmfPkgTokenSpaceGuid.PcdOvmfConfidentialComputingWorkAreaHeader|4|UINT32|0x51
 
 
 [PcdsDynamic, PcdsDynamicEx]


### PR DESCRIPTION
SEC checks in IsSevGuest if the PCD defined WorkAreaHeader size
matches the size of the WorkAreaHeader struct definition. Set a
default value for the PCD to avoid unnecessary DSC/FDF file
changes in all OVMF DSC/FDF files.

Signed-off-by: Corvin Köhne <c.koehne@beckhoff.com>
Reviewed-by: Jiewen Yao <jiewen.yao@intel.com>