### PR TITLE
AndroidBootImgLib improvements

### DIFF
--- a/EmbeddedPkg/EmbeddedPkg.dec
+++ b/EmbeddedPkg/EmbeddedPkg.dec
@@ -86,6 +86,7 @@
 [PcdsFeatureFlag.common]
   gEmbeddedTokenSpaceGuid.PcdPrePiProduceMemoryTypeInformationHob|FALSE|BOOLEAN|0x0000001b
   gEmbeddedTokenSpaceGuid.PcdGdbSerial|FALSE|BOOLEAN|0x00000053
+  gEmbeddedTokenSpaceGuid.PcdAndroidBootLoadFile2|FALSE|BOOLEAN|0x0000005b
 
 [PcdsFixedAtBuild.common]
   gEmbeddedTokenSpaceGuid.PcdPrePiStackBase|0|UINT32|0x0000000b

--- a/EmbeddedPkg/Library/AndroidBootImgLib/AndroidBootImgLib.c
+++ b/EmbeddedPkg/Library/AndroidBootImgLib/AndroidBootImgLib.c
@@ -16,8 +16,6 @@
 #include <Protocol/AndroidBootImg.h>
 #include <Protocol/LoadedImage.h>
 
-#include <libfdt.h>
-
 #define FDT_ADDITIONAL_ENTRIES_SIZE 0x400
 
 typedef struct {

--- a/EmbeddedPkg/Library/AndroidBootImgLib/AndroidBootImgLib.c
+++ b/EmbeddedPkg/Library/AndroidBootImgLib/AndroidBootImgLib.c
@@ -349,12 +349,13 @@ AndroidBootImgUpdateFdt (
     if (EFI_ERROR (Status)) {
       goto Fdt_Exit;
     }
-
-    Status = gBS->InstallConfigurationTable (
-                    &gFdtTableGuid,
-                    (VOID *)(UINTN)NewFdtBase
-                    );
+  } else {
+    NewFdtBase = UpdatedFdtBase;
   }
+  Status = gBS->InstallConfigurationTable (
+                  &gFdtTableGuid,
+                  (VOID *)(UINTN)NewFdtBase
+                  );
 
   if (!EFI_ERROR (Status)) {
     return EFI_SUCCESS;

--- a/EmbeddedPkg/Library/AndroidBootImgLib/AndroidBootImgLib.inf
+++ b/EmbeddedPkg/Library/AndroidBootImgLib/AndroidBootImgLib.inf
@@ -39,6 +39,11 @@
 [Protocols]
   gAndroidBootImgProtocolGuid
   gEfiLoadedImageProtocolGuid
+  gEfiLoadFile2ProtocolGuid
 
 [Guids]
+  gEfiAcpiTableGuid
   gFdtTableGuid
+
+[FeaturePcd]
+  gEmbeddedTokenSpaceGuid.PcdAndroidBootLoadFile2


### PR DESCRIPTION
Added support for using loadfile2 approach for passing ramdisk to linux.                                                                             
Created patch series for general error handling improvments based on                                                                                 
review feedback.                                                                                                                                     
If ACPI tables are in system table or PCD is defined the LoadFile2 method                                                                            
of passing initrd will be used.                                                                                                                      
                                                                                                                                                     
[v3]                                                                                                                                                 
-Code review cleanup                                                                                                                                 
-Removed duplicate header file                                                                                                                       
-Added change to allow FDT to install if UpdateDtb function is not defined                                                                           
-Added specific ACPI check                                                                                                                           
-Moved install functions to subfunctions                                                                                                             
                                                                                                                                                     
[v2]                                                                                                                                                 
-Added review feedback                                                                                                                               
-General improvements to error handling                                                                                                              
                                                                                                                                                     
[v1]                                                                                                                                                 
- Intial revision                                                                                                                                    
                                                                                                                                                     
                                                                                                                                                     
Jeff Brasen (4):                                                                                                                                     
  EmbeddedPkg: Remove duplicate libfdt.h include                                                                                                     
  EmbeddedPkg: AndroidBootImgBoot error handling updates                                                                                             
  EmbeddedPkg: Install FDT if UpdateDtb is not present                                                                                               
  EmbeddedPkg: Add LoadFile2 for linux initrd