### PR TITLE
UefiPayloadPkg: Add Macro to enable or disable some drivers.

### DIFF
--- a/UefiPayloadPkg/UefiPayloadPkg.dsc
+++ b/UefiPayloadPkg/UefiPayloadPkg.dsc
@@ -28,6 +28,8 @@
 
   DEFINE SOURCE_DEBUG_ENABLE          = FALSE
   DEFINE PS2_KEYBOARD_ENABLE          = FALSE
+  DEFINE RAM_DISK_ENABLE              = FALSE
+  DEFINE SIO_BUS_ENABLE               = FALSE
   DEFINE UNIVERSAL_PAYLOAD            = FALSE
 
   #
@@ -536,8 +538,10 @@
   MdeModulePkg/Bus/Scsi/ScsiBusDxe/ScsiBusDxe.inf
   MdeModulePkg/Bus/Scsi/ScsiDiskDxe/ScsiDiskDxe.inf
   MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressDxe.inf
-  MdeModulePkg/Universal/Disk/RamDiskDxe/RamDiskDxe.inf
 
+!if $(RAM_DISK_ENABLE) == TRUE
+  MdeModulePkg/Universal/Disk/RamDiskDxe/RamDiskDxe.inf
+!endif
   #
   # SD/eMMC Support
   #
@@ -562,8 +566,10 @@
 !if $(SERIAL_DRIVER_ENABLE) == TRUE
   MdeModulePkg/Universal/SerialDxe/SerialDxe.inf
 !endif
-!if $(PS2_KEYBOARD_ENABLE) == TRUE
+!if $(SIO_BUS_ENABLE) == TRUE
   OvmfPkg/SioBusDxe/SioBusDxe.inf
+!endif
+!if $(PS2_KEYBOARD_ENABLE) == TRUE
   MdeModulePkg/Bus/Isa/Ps2KeyboardDxe/Ps2KeyboardDxe.inf
 !endif
   MdeModulePkg/Bus/Isa/Ps2MouseDxe/Ps2MouseDxe.inf

--- a/UefiPayloadPkg/UefiPayloadPkg.fdf
+++ b/UefiPayloadPkg/UefiPayloadPkg.fdf
@@ -142,8 +142,10 @@ INF MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostBridgeDxe.inf
 !if $(SERIAL_DRIVER_ENABLE) == TRUE
 INF MdeModulePkg/Universal/SerialDxe/SerialDxe.inf
 !endif
-!if $(PS2_KEYBOARD_ENABLE) == TRUE
+!if $(SIO_BUS_ENABLE) == TRUE
 INF OvmfPkg/SioBusDxe/SioBusDxe.inf
+!endif
+!if $(PS2_KEYBOARD_ENABLE) == TRUE
 INF MdeModulePkg/Bus/Isa/Ps2KeyboardDxe/Ps2KeyboardDxe.inf
 !endif
 INF MdeModulePkg/Bus/Isa/Ps2MouseDxe/Ps2MouseDxe.inf
@@ -171,8 +173,9 @@ INF MdeModulePkg/Bus/Ata/AtaAtapiPassThru/AtaAtapiPassThru.inf
 INF MdeModulePkg/Bus/Scsi/ScsiBusDxe/ScsiBusDxe.inf
 INF MdeModulePkg/Bus/Scsi/ScsiDiskDxe/ScsiDiskDxe.inf
 INF MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressDxe.inf
+!if $(RAM_DISK_ENABLE) == TRUE
 INF MdeModulePkg/Universal/Disk/RamDiskDxe/RamDiskDxe.inf
-
+!endif
 INF FatPkg/EnhancedFatDxe/Fat.inf
 
 #


### PR DESCRIPTION
Add Macro to enable or disable RamDiskDxe and SioBusDxe drivers.

Cc: Guo Dong <guo.dong@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Cc: Maurice Ma <maurice.ma@intel.com>
Cc: Benjamin You <benjamin.you@intel.com>
Reviewed-by: Maurice Ma <maurice.ma@intel.com>
Signed-off-by: Zhiguang Liu <zhiguang.liu@intel.com>