### PR TITLE
UefiPayloadPkg: Use dummy constructor for PlatformHookLib

### DIFF
--- a/UefiPayloadPkg/Library/UniversalPayloadPlatformHookLib/PlatformHookLib.c
+++ b/UefiPayloadPkg/Library/UniversalPayloadPlatformHookLib/PlatformHookLib.c
@@ -13,6 +13,23 @@
 #include <Library/PcdLib.h>
 #include <Library/HobLib.h>
 
+
+/** Library Constructor
+
+  @retval RETURN_SUCCESS  Success.
+**/
+EFI_STATUS
+EFIAPI
+PlatformHookSerialPortConstructor (
+  VOID
+  )
+{
+  // Nothing to do here. This constructor is added to
+  // enable the chain of constructor invocation for
+  // dependent libraries.
+  return RETURN_SUCCESS;
+}
+
 /**
   Performs platform specific initialization required for the CPU to access
   the hardware associated with a SerialPortLib instance.  This function does

--- a/UefiPayloadPkg/Library/UniversalPayloadPlatformHookLib/PlatformHookLib.inf
+++ b/UefiPayloadPkg/Library/UniversalPayloadPlatformHookLib/PlatformHookLib.inf
@@ -14,7 +14,7 @@
   MODULE_TYPE                    = BASE
   VERSION_STRING                 = 1.0
   LIBRARY_CLASS                  = PlatformHookLib
-  CONSTRUCTOR                    = PlatformHookSerialPortInitialize
+  CONSTRUCTOR                    = PlatformHookSerialPortConstructor
 
 [Sources]
   PlatformHookLib.c


### PR DESCRIPTION
The Library constructor is only used for library dependency.
So use a dummy function to make it clear instead of using an
actual function.

Cc: Ray Ni <ray.ni@intel.com>
Cc: Maurice Ma <maurice.ma@intel.com>
Cc: Benjamin You <benjamin.you@intel.com>
Signed-off-by: Guo Dong <guo.dong@intel.com>