### PR TITLE
UefiPayloadPkg: Add ".upld_info" in universal payload

### DIFF
--- a/UefiPayloadPkg/UniversalPayloadBuild.py
+++ b/UefiPayloadPkg/UniversalPayloadBuild.py
@@ -10,6 +10,31 @@ import subprocess
 import os
 import shutil
 import sys
+from   ctypes import *
+
+sys.dont_write_bytecode = True
+
+class UPLD_INFO_HEADER(LittleEndianStructure):
+    _pack_ = 1
+    _fields_ = [
+        ('Identifier',           ARRAY(c_char, 4)),
+        ('HeaderLength',         c_uint32),
+        ('SpecRevision',         c_uint16),
+        ('Reserved',             c_uint16),
+        ('Revision',             c_uint32),
+        ('Attribute',            c_uint32),
+        ('Capability',           c_uint32),
+        ('ProducerId',           ARRAY(c_char, 16)),
+        ('ImageId',              ARRAY(c_char, 16)),
+        ]
+
+    def __init__(self):
+        self.Identifier     =  b'UPLD'
+        self.HeaderLength   = sizeof(UPLD_INFO_HEADER)
+        self.HeaderRevision = 0x0075
+        self.Revision       = 0x0000010105
+        self.ImageId        = b'UEFI'
+        self.ProducerId     = b'INTEL'
 
 def RunCommand(cmd):
     print(cmd)
@@ -37,6 +62,7 @@ def BuildUniversalPayload(Args, MacroList):
     EntryOutputDir = os.path.join(BuildDir, f"{BuildTarget}_{ElfToolChain}", os.path.normpath("X64/UefiPayloadPkg/UefiPayloadEntry/UniversalPayloadEntry/DEBUG/UniversalPayloadEntry.dll"))
     PayloadReportPath = os.path.join(BuildDir, "UefiUniversalPayload.txt")
     ModuleReportPath = os.path.join(BuildDir, "UefiUniversalPayloadEntry.txt")
+    UpldInfoFile = os.path.join(BuildDir, "UniversalPayloadInfo.bin")
 
     if "CLANG_BIN" in os.environ:
         LlvmObjcopyPath = os.path.join(os.environ["CLANG_BIN"], "llvm-objcopy")
@@ -66,11 +92,20 @@ def BuildUniversalPayload(Args, MacroList):
     RunCommand(BuildModule)
 
     #
+    # Buid Universal Payload Information Section ".upld_info"
+    #
+    upld_info_hdr = UPLD_INFO_HEADER()
+    upld_info_hdr.ImageId = Args.ImageId.encode()[:16]
+    fp = open(UpldInfoFile, 'wb')
+    fp.write(bytearray(upld_info_hdr))
+    fp.close()
+
+    #
     # Copy the DXEFV as a section in elf format Universal Payload entry.
     #
-    remove_section = '"%s" -I elf64-x86-64 -O elf64-x86-64 --remove-section .upld.uefi_fv %s'%(LlvmObjcopyPath, EntryOutputDir)
-    add_section = '"%s" -I elf64-x86-64 -O elf64-x86-64 --add-section .upld.uefi_fv=%s %s'%(LlvmObjcopyPath, FvOutputDir, EntryOutputDir)
-    set_section = '"%s" -I elf64-x86-64 -O elf64-x86-64 --set-section-alignment .upld.uefi_fv=16 %s'%(LlvmObjcopyPath, EntryOutputDir)
+    remove_section = '"%s" -I elf64-x86-64 -O elf64-x86-64 --remove-section .upld_info --remove-section .upld.uefi_fv %s'%(LlvmObjcopyPath, EntryOutputDir)
+    add_section    = '"%s" -I elf64-x86-64 -O elf64-x86-64 --add-section .upld_info=%s --add-section .upld.uefi_fv=%s %s'%(LlvmObjcopyPath, UpldInfoFile, FvOutputDir, EntryOutputDir)
+    set_section    = '"%s" -I elf64-x86-64 -O elf64-x86-64 --set-section-alignment .upld.upld_info=16 --set-section-alignment .upld.uefi_fv=16 %s'%(LlvmObjcopyPath, EntryOutputDir)
     RunCommand(remove_section)
     RunCommand(add_section)
     RunCommand(set_section)
@@ -82,6 +117,7 @@ def main():
     parser.add_argument('-t', '--ToolChain')
     parser.add_argument('-b', '--Target', default='DEBUG')
     parser.add_argument("-D", "--Macro", action="append", default=["UNIVERSAL_PAYLOAD=TRUE"])
+    parser.add_argument('-i', '--ImageId', type=str, help='Specify payload ID (16 bytes maximal).', default ='UEFI')
     MacroList = {}
     args = parser.parse_args()
     if args.Macro is not None:


### PR DESCRIPTION
From the universal scalable firmware payload requirement V0.75,
Payload must have Universal Payload Information Section ".upld_info"
So update the build tool to add this section.

Cc: Ray Ni <ray.ni@intel.com>
Cc: Maurice Ma <maurice.ma@intel.com>
Cc: Benjamin You <benjamin.you@intel.com>
Signed-off-by: Guo Dong <guo.dong@intel.com>