### PR TITLE
MdeModulePkg/PciBusDxe: Improve the flow of testing support attributes

### DIFF
--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciEnumeratorSupport.c
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciEnumeratorSupport.c
@@ -933,6 +933,7 @@ PciTestSupportedAttribute (
   )
 {
   EFI_TPL OldTpl;
+  UINT16  CommandValue;
 
   //
   // Preserve the original value
@@ -943,10 +944,12 @@ PciTestSupportedAttribute (
   // Raise TPL to high level to disable timer interrupt while the BAR is probed
   //
   OldTpl = gBS->RaiseTPL (TPL_HIGH_LEVEL);
+  CommandValue = *Command | *OldCommand;
 
-  PCI_SET_COMMAND_REGISTER (PciIoDevice, *Command);
-  PCI_READ_COMMAND_REGISTER (PciIoDevice, Command);
+  PCI_SET_COMMAND_REGISTER (PciIoDevice, CommandValue);
+  PCI_READ_COMMAND_REGISTER (PciIoDevice, &CommandValue);
 
+  *Command = *Command & CommandValue;
   //
   // Write back the original value
   //


### PR DESCRIPTION
https://bugzilla.tianocore.org/show_bug.cgi?id=3635

Currently, in order to test the supported attributes,
the PciTestSupportedAttribute() will set the command register
to 0x27 (EFI_PCI_COMMAND_IO_SPACE, EFI_PCI_COMMAND_MEMORY_SPACE,
EFI_PCI_COMMAND_BUS_MASTER, EFI_PCI_COMMAND_VGA_PALETTE_SNOOP) firstly,
and then read back to check whether these attributes are
set successfully in the device.
This will cause the other enabled bits
 (other than EFI_PCI_COMMAND_IO_SPACE,EFI_PCI_COMMAND_MEMORY_SPACE,
 EFI_PCI_COMMAND_BUS_MASTER,EFI_PCI_COMMAND_VGA_PALETTE_SNOOP)
 be cleared for a short of time
 This patch fixes this issue by keeping the origina
 enabled bits when setting 0x27.

Signed-off-by: xueshengfeng <xueshengfeng@byosoft.com.cn>
Reviewed-by: Ray <ray.ni@intel.com>