### PR TITLE
(origin) Enable CI for WhiskeylakeOpenBoard in Edk2platforms

### DIFF
--- a/.azurepipelines/edk2-platforms.yml
+++ b/.azurepipelines/edk2-platforms.yml
@@ -1,0 +1,71 @@
+## @file
+# Azure Pipeline build file for WhiskeylakeOpenBoard in Edk2platforms on windows and ubuntu
+#
+# Copyright (c) 2021, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+trigger:
+  - master
+  - stable/*
+pr:
+  branches:
+    include:
+    - master
+    - stable/*
+  paths:
+    include:
+    - BaseTools
+    - CryptoPkg
+    - FatPkg
+    - IntelFsp2WrapperPkg
+    - MdeModulePkg
+    - MdePkg
+    - NetworkPkg
+    - PcAtChipsetPkg
+    - SecurityPkg
+    - ShellPkg
+    - UefiCpuPkg
+
+resources:
+  repositories:
+  - repository: edk2-platforms
+    type: github
+    endpoint: tianocore
+    name: tianocore/edk2-platforms
+  - repository: edk2-non-osi
+    type: github
+    endpoint: tianocore
+    name: tianocore/edk2-non-osi
+  - repository: FSP
+    type: github
+    endpoint: tianocore
+    name: intel/FSP
+
+jobs:
+  - job: Edk2Platform_CI_Windows
+    pool:
+      vmImage: 'windows-latest'
+    strategy:
+      matrix:
+        WhiskeylakeOpenBoard_WhiskeylakeURvp:
+          Board.Name: "WhiskeylakeURvp"
+        WhiskeylakeOpenBoard_UpXtreme:
+          Board.Name: "UpXtreme"
+    steps:
+    - template: edk2platforms-run-steps.yml
+      parameters:
+        board_name: $(Board.Name)
+        pool_name: 'windows-latest'
+
+  - job: Edk2Platform_CI_Linux
+    pool:
+      vmImage: 'ubuntu-latest'
+    strategy:
+      matrix:
+          WhiskeylakeOpenBoard_WhiskeylakeURvp:
+            Board.Name: "WhiskeylakeURvp"
+    steps:
+    - template: edk2platforms-run-steps.yml
+      parameters:
+        board_name: $(Board.Name)
+        pool_name: 'ubuntu-latest'

--- a/.azurepipelines/edk2platforms-run-steps.yml
+++ b/.azurepipelines/edk2platforms-run-steps.yml
@@ -1,0 +1,72 @@
+## @file
+# File templates/edk2platforms-run-steps.yml
+#
+# template file containing the steps to build
+#
+# Copyright (c) 2021, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+parameters:
+- name: board_name
+  type: string
+  default: ''
+- name: pool_name
+  type: string
+  default: ''
+
+steps:
+- checkout: self
+  submodules: true
+- checkout: edk2-non-osi
+- checkout: FSP
+- checkout: edk2-platforms
+
+- task: UsePythonVersion@0
+  inputs:
+    versionSpec: "3.8.x"
+    architecture: "x64"
+
+- ${{ if contains(parameters.pool_name, 'ubuntu') }}:
+  - bash: |
+      sudo apt-get update
+      sudo apt-get install gcc g++ make uuid-dev nasm iasl
+    displayName: Update apt and Install required tools
+  - script: |
+      source edksetup.sh
+      echo "##vso[task.setvariable variable=PATH;]$PATH"
+    displayName: Set env Path
+    workingDirectory: edk2/
+
+- ${{ if contains(parameters.pool_name, 'windows') }}:
+  - powershell: |
+      choco install iasl -y --version=2017.11.10
+      echo "##vso[task.setvariable variable=IASL_PREFIX;]C:\tools\ASL\"
+      choco install nasm -y
+      echo "##vso[task.setvariable variable=NASM_PREFIX;]C:\Program Files\NASM\"
+    displayName: Windows EDK II Prerequisites
+
+# Build WhiskeylakeOpenBoard in edk2platforms
+- script: python build_bios.py --platform ${{ parameters.board_name}}
+  displayName: Build platform ${{ parameters.board_name}}
+  workingDirectory: edk2-platforms/Platform/Intel
+
+# Copy the build logs to the artifact staging directory
+- task: CopyFiles@2
+  displayName: "Copy build logs"
+  inputs:
+    targetFolder: "$(Build.ArtifactStagingDirectory)"
+    SourceFolder:
+    contents: |
+      Build.log
+      BuildReport.log
+    flattenFolders: true
+  condition: succeededOrFailed()
+
+# Publish build artifacts to Azure Artifacts/TFS or a file share
+- task: PublishBuildArtifacts@1
+  continueOnError: true
+  displayName: "Publish build logs"
+  inputs:
+    pathtoPublish: "$(Build.ArtifactStagingDirectory)"
+    artifactName: "Build Logs $(System.JobName)"
+  condition: succeededOrFailed()


### PR DESCRIPTION
The edk2-platforms.yml contains the necessary github repo that will be
checked out, the platform name to build and the folders in edk2 which
will trigger the CI. The edk2platforms-run-steps.yml contains the main
steps to build WhiskeylakeOpenBoard.

Cc: Sean Brogan <sean.brogan@microsoft.com>
Cc: Bret Barkelew <Bret.Barkelew@microsoft.com>
Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Ray Ni <ray.ni@intel.com>

Signed-off-by: Dun Tan <dun.tan@intel.com>