### PR TITLE
BaseTools: Switch to downloading the ARM and AARCH64 compilers from Arm's site

### DIFF
--- a/BaseTools/Bin/gcc_aarch64_linux_ext_dep.yaml
+++ b/BaseTools/Bin/gcc_aarch64_linux_ext_dep.yaml
@@ -1,5 +1,5 @@
 ## @file
-# Download GCC AARCH64 compiler from Linaro's release site
+# Download GCC AARCH64 compiler from Arm's release site
 # Set shell variable GCC5_AARCH64_INSTALL to this folder
 #
 # This is only downloaded when a build activates scope gcc_aarch64_linux
@@ -11,11 +11,11 @@
   "scope": "gcc_aarch64_linux",
   "type": "web",
   "name": "gcc_aarch64_linux",
-  "source": "http://releases.linaro.org/components/toolchain/binaries/7.4-2019.02/aarch64-linux-gnu/gcc-linaro-7.4.1-2019.02-x86_64_aarch64-linux-gnu.tar.xz",
-  "version": "7.4.1",
-  "sha256": "27f1dc2c491ed61ae8f0d4b0c11de59cd2f7dd9c94761ee7153006fcac1bf9ab",
+  "source": "https://developer.arm.com/-/media/Files/downloads/gnu-a/10.3-2021.07/binrel/gcc-arm-10.3-2021.07-x86_64-aarch64-none-linux-gnu.tar.xz",
+  "version": "10.3-2021.07",
+  "sha256": "1e33d53dea59c8de823bbdfe0798280bdcd138636c7060da9d77a97ded095a84",
   "compression_type": "tar",
-  "internal_path": "/gcc-linaro-7.4.1-2019.02-x86_64_aarch64-linux-gnu/",
+  "internal_path": "/gcc-arm-10.3-2021.07-x86_64-aarch64-none-linux-gnu/",
   "flags": ["set_shell_var", ],
   "var_name": "GCC5_AARCH64_INSTALL"
 }

--- a/BaseTools/Bin/gcc_arm_linux_ext_dep.yaml
+++ b/BaseTools/Bin/gcc_arm_linux_ext_dep.yaml
@@ -1,5 +1,5 @@
 ## @file
-# Download GCC ARM compiler from Linaro's release site
+# Download GCC ARM compiler from Arm's release site
 # Set shell variable GCC5_ARM_INSTALL to this folder
 #
 # This is only downloaded when a build activates scope gcc_arm_linux
@@ -11,11 +11,11 @@
   "scope": "gcc_arm_linux",
   "type": "web",
   "name": "gcc_arm_linux",
-  "source": "https://releases.linaro.org/components/toolchain/binaries/7.4-2019.02/arm-linux-gnueabihf/gcc-linaro-7.4.1-2019.02-x86_64_arm-linux-gnueabihf.tar.xz",
-  "version": "7.4.1",
-  "sha256": "3C951CF1941D0FA06D64CC0D5E88612B209D8123B273FA26C16D70BD7BC6B163",
+  "source": "https://developer.arm.com/-/media/Files/downloads/gnu-a/10.3-2021.07/binrel/gcc-arm-10.3-2021.07-x86_64-arm-none-linux-gnueabihf.tar.asc",
+  "version": "10.3-2021.07",
+  "sha256": "aa074fa8371a4f73fecbd16bd62c8b1945f23289e26414794f130d6ccdf8e39c",
   "compression_type": "tar",
-  "internal_path": "/gcc-linaro-7.4.1-2019.02-x86_64_arm-linux-gnueabihf/",
+  "internal_path": "/gcc-arm-10.3-2021.07-x86_64-arm-none-linux-gnueabihf/",
   "flags": ["set_shell_var", ],
   "var_name": "GCC5_ARM_INSTALL"
 }

--- a/BaseTools/Plugin/LinuxGcc5ToolChain/LinuxGcc5ToolChain.py
+++ b/BaseTools/Plugin/LinuxGcc5ToolChain/LinuxGcc5ToolChain.py
@@ -80,7 +80,7 @@ class LinuxGcc5ToolChain(IUefiBuildPlugin):
                 return 0
 
             # make GCC5_AARCH64_PREFIX to align with tools_def.txt
-            prefix = os.path.join(install_path, "bin", "aarch64-linux-gnu-")
+            prefix = os.path.join(install_path, "bin", "aarch64-none-linux-gnu-")
             shell_environment.GetEnvironment().set_shell_var("GCC5_AARCH64_PREFIX", prefix)
 
         # now confirm it exists

--- a/BaseTools/Plugin/LinuxGcc5ToolChain/LinuxGcc5ToolChain.py
+++ b/BaseTools/Plugin/LinuxGcc5ToolChain/LinuxGcc5ToolChain.py
@@ -57,7 +57,7 @@ class LinuxGcc5ToolChain(IUefiBuildPlugin):
                 return 0
 
             # make GCC5_ARM_PREFIX to align with tools_def.txt
-            prefix = os.path.join(install_path, "bin", "arm-linux-gnueabihf-")
+            prefix = os.path.join(install_path, "bin", "arm-none-linux-gnueabihf-")
             shell_environment.GetEnvironment().set_shell_var("GCC5_ARM_PREFIX", prefix)
 
         # now confirm it exists


### PR DESCRIPTION
BaseTools/Bin/gcc_[arm,aarch64]_linux_ext_dep.yaml downloads GCC releases from https://releases.linaro.org/components/toolchain/binaries/7.4-2019.02 . 

As indicated in the URL, those builds are from 2019 because Linaro no longer do GCC releases, with that task having moved to Arm. 

The Arm GCC page is https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-a/downloads,
with the latest release being 10.3-2021.07.

gcc_aarch64_linux_ext_dep.yaml is used when setting up a CI environment using the stuart tools.

BZ: https://bugzilla.tianocore.org/show_bug.cgi?id=3594
PR: https://github.com/tianocore/edk2/pull/1909
