### PR TITLE
ArmPkg: SmbiosMiscDxe: Don't populate ExtendedBiosSize when size < 16MB

### DIFF
--- a/ArmPkg/Universal/Smbios/SmbiosMiscDxe/Type00/MiscBiosVendorFunction.c
+++ b/ArmPkg/Universal/Smbios/SmbiosMiscDxe/Type00/MiscBiosVendorFunction.c
@@ -240,11 +240,12 @@ SMBIOS_MISC_TABLE_FUNCTION (MiscBiosVendor)
   SmbiosRecord->BiosSegment = (UINT16)(FixedPcdGet32 (PcdFdBaseAddress) / SIZE_64KB);
   if (BiosPhysicalSize < SIZE_16MB) {
     SmbiosRecord->BiosSize = Base2ToByteWith64KUnit (BiosPhysicalSize) - 1;
-    SmbiosRecord->ExtendedBiosSize.Size = BiosPhysicalSize / SIZE_1MB;
-    SmbiosRecord->ExtendedBiosSize.Unit = 0; // Size is in MB
   } else {
     SmbiosRecord->BiosSize = 0xFF;
-    if (BiosPhysicalSize > 0x3FFF) {
+    if (BiosPhysicalSize < SIZE_16GB) {
+      SmbiosRecord->ExtendedBiosSize.Size = BiosPhysicalSize / SIZE_1MB;
+      SmbiosRecord->ExtendedBiosSize.Unit = 0; // Size is in MB
+    } else {
       SmbiosRecord->ExtendedBiosSize.Size = BiosPhysicalSize / SIZE_1GB;
       SmbiosRecord->ExtendedBiosSize.Unit = 1; // Size is in GB
     }


### PR DESCRIPTION
According to the SMBIOS specification, the ExtendedBiosSize field should
be zero when the BIOS size is less than 16MB:

"Size (n) where 64K * (n+1) is the size of the
physical device containing the BIOS, in
bytes.
FFh - size is 16MB or greater, see Extended
BIOS ROM Size for actual size."

Fix the code in MiscBiosVendorFunction.c to only populate the
ExtendedBiosSize field if the BIOS size is greater than 16MB.

Fix the code to correctly populate the ExtendedBiosSize field with the
unit bits set to MB if the size is between 16MB and 16GB.

Signed-off-by: Rebecca Cran <rebecca@nuviainc.com>