### PR TITLE
CryptoPkg/BaseCryptLib: Eliminate extra buffer copy in Pkcs7Verify()

### DIFF
--- a/CryptoPkg/Library/BaseCryptLib/Pk/CryptPkcs7VerifyCommon.c
+++ b/CryptoPkg/Library/BaseCryptLib/Pk/CryptPkcs7VerifyCommon.c
@@ -864,12 +864,8 @@ Pkcs7Verify (
   // For generic PKCS#7 handling, InData may be NULL if the content is present
   // in PKCS#7 structure. So ignore NULL checking here.
   //
-  DataBio = BIO_new (BIO_s_mem ());
+  DataBio = BIO_new_mem_buf (InData, (int) DataLength);
   if (DataBio == NULL) {
-    goto _Exit;
-  }
-
-  if (BIO_write (DataBio, InData, (int) DataLength) <= 0) {
     goto _Exit;
   }
 


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3617

Create a read-only openSSL BIO wrapper for the existing input
buffer passed to Pkcs7Verify() instead of copying the buffer
into an empty writable BIO which causes memory allocations
within openSSL.

Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Xiaoyu Lu <xiaoyux.lu@intel.com>
Cc: Guomin Jiang <guomin.jiang@intel.com>
Signed-off-by: Bob Morgan <bobm@nvidia.com>
Reviewed-by: Jiewen Yao <jiewen.yao@intel.com>