### PR TITLE
UefiPayloadPkg: Add PCI root bridge info hob support for SBL

### DIFF
--- a/UefiPayloadPkg/Include/Library/BlParseLib.h
+++ b/UefiPayloadPkg/Include/Library/BlParseLib.h
@@ -116,4 +116,18 @@ ParseGfxDeviceInfo (
   OUT EFI_PEI_GRAPHICS_DEVICE_INFO_HOB       *GfxDeviceInfo
   );
 
+/**
+  Parse and handle the misc info provided by bootloader
+
+  @retval RETURN_SUCCESS           The misc information was parsed successfully.
+  @retval RETURN_NOT_FOUND         Could not find required misc info.
+  @retval RETURN_OUT_OF_RESOURCES  Insufficant memory space.
+
+**/
+RETURN_STATUS
+EFIAPI
+ParseMiscInfo (
+  VOID
+  );
+
 #endif

--- a/UefiPayloadPkg/Library/CbParseLib/CbParseLib.c
+++ b/UefiPayloadPkg/Library/CbParseLib/CbParseLib.c
@@ -560,3 +560,19 @@ ParseGfxDeviceInfo (
   return RETURN_NOT_FOUND;
 }
 
+/**
+  Parse and handle the misc info provided by bootloader
+
+  @retval RETURN_SUCCESS           The misc information was parsed successfully.
+  @retval RETURN_NOT_FOUND         Could not find required misc info.
+  @retval RETURN_OUT_OF_RESOURCES  Insufficant memory space.
+
+**/
+RETURN_STATUS
+EFIAPI
+ParseMiscInfo (
+  VOID
+  )
+{
+  return RETURN_SUCCESS;
+}

--- a/UefiPayloadPkg/Library/SblParseLib/SblParseLib.inf
+++ b/UefiPayloadPkg/Library/SblParseLib/SblParseLib.inf
@@ -41,6 +41,7 @@
   gLoaderMemoryMapInfoGuid
   gEfiGraphicsInfoHobGuid
   gEfiGraphicsDeviceInfoHobGuid
+  gUniversalPayloadPciRootBridgeInfoGuid
 
 [Pcd]
   gUefiPayloadPkgTokenSpaceGuid.PcdBootloaderParameter

--- a/UefiPayloadPkg/UefiPayloadEntry/UefiPayloadEntry.c
+++ b/UefiPayloadPkg/UefiPayloadEntry/UefiPayloadEntry.c
@@ -322,6 +322,14 @@ BuildHobFromBl (
   }
 
   //
+  // Parse the misc info provided by bootloader
+  //
+  Status = ParseMiscInfo ();
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_WARN, "Error when parsing misc info, Status = %r\n", Status));
+  }
+
+  //
   // Parse platform specific information.
   //
   Status = ParsePlatformInfo ();


### PR DESCRIPTION
Current UefiPayloadPkg can suport PCI root bridge info HOB
provided by bootloader. For UniversalPayload, bootloader can
directly provide this HOB for payload consumption. However,
for legacy UEFI payload, it is required to migrate the HOB
information from bootloader HOB space to UEFI payload HOB
space. This patch added the missing part for the bootloader
ParseLib in order to support both legacy and universal UEFI
payload.

This patch was tested on Slim Bootloader with latest UEFI
payload, and it worked as expected.

Cc: Ray Ni <ray.ni@intel.com>
Cc: Guo Dong <guo.dong@intel.com>
Cc: Benjamin You <benjamin.you@intel.com>
Signed-off-by: Maurice Ma <maurice.ma@intel.com>
Reviewed-by: Guo Dong <guo.dong@intel.com>