### PR TITLE
MdeModulePkg/Sd: Corrections for Extra.uni files

### DIFF
--- a/MdeModulePkg/Bus/Sd/EmmcDxe/EmmcDxe.inf
+++ b/MdeModulePkg/Bus/Sd/EmmcDxe/EmmcDxe.inf
@@ -63,3 +63,5 @@
   ## BY_START
   gEfiDevicePathProtocolGuid
 
+[UserExtensions.TianoCore."ExtraFiles"]
+  EmmcDxeExtra.uni

--- a/MdeModulePkg/Bus/Sd/SdDxe/SdDxe.inf
+++ b/MdeModulePkg/Bus/Sd/SdDxe/SdDxe.inf
@@ -62,3 +62,5 @@
   ## BY_START
   gEfiDevicePathProtocolGuid
 
+[UserExtensions.TianoCore."ExtraFiles"]
+  SdDxeExtra.uni

--- a/MdeModulePkg/Bus/Sd/SdDxe/SdDxeExtra.uni
+++ b/MdeModulePkg/Bus/Sd/SdDxe/SdDxeExtra.uni
@@ -1,6 +1,5 @@
 // /** @file
-// SD memory card device driver to manage the SD memory card device and provide interface for upper layer
-// access.
+// SdDxe Localized Strings and Content
 //
 // Copyright (c) 2015, Intel Corporation. All rights reserved.<BR>
 //
@@ -8,8 +7,8 @@
 //
 // **/
 
+#string STR_PROPERTIES_MODULE_NAME
+#language en-US
+"SD Device Driver"
 
-#string STR_MODULE_ABSTRACT             #language en-US "SD device driver to manage the SD memory card device and provide interface for upper layer access"
-
-#string STR_MODULE_DESCRIPTION          #language en-US "This driver follows the UEFI driver model and layers on the SdMmcPassThru protocol. It installs BlockIo and BlockIo2 protocols on the SD device."
 


### PR DESCRIPTION
Add correct content to the 'SdDxeExtra.uni' file.
Include 'EmmcDxeExtra.uni' and 'SdDxeExtra.uni' files to their
appropriate INF files.

Signed-off-by: Konstantin Aladyshev <aladyshev22@gmail.com>
Reviewed-by: Hao A Wu <hao.a.wu@intel.com>