### PR TITLE
BaseTools: add edk2-test repo to SetupGit.py

### DIFF
--- a/BaseTools/Scripts/SetupGit.py
+++ b/BaseTools/Scripts/SetupGit.py
@@ -46,7 +46,10 @@ UPSTREAMS = [
      'list': 'devel@edk2.groups.io', 'prefix': 'edk2-platforms'},
     {'name': 'edk2-non-osi',
      'repo': 'https://github.com/tianocore/edk2-non-osi.git',
-     'list': 'devel@edk2.groups.io', 'prefix': 'edk2-non-osi'}
+     'list': 'devel@edk2.groups.io', 'prefix': 'edk2-non-osi'},
+    {'name': 'edk2-test',
+     'repo': 'https://github.com/tianocore/edk2-test.git',
+     'list': 'devel@edk2.groups.io', 'prefix': 'edk2-test'}
     ]
 
 # The minimum version required for all of the below options to work


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3066

The SctPkg is managed in repository
https://github.com/tianocore/edk2-test.

Make SetupGit.py usable for this repository.

Signed-off-by: Heinrich Schuchardt <xypron.glpk@gmx.de>
Reviewed-by: Yuwei Chen <yuwei.chen@intel.com>
Reviewed-by: Bob Feng <bob.c.feng@intel.com>