### PR TITLE
ArmPkg/Smbios: Fix max cache size 2 wrong issue

### DIFF
--- a/ArmPkg/Universal/Smbios/ProcessorSubClassDxe/ProcessorSubClass.c
+++ b/ArmPkg/Universal/Smbios/ProcessorSubClassDxe/ProcessorSubClass.c
@@ -219,7 +219,7 @@ ConfigureCacheArchitectureInformation (
     CacheSize32 = CacheSize16;
   } else if ((CacheSize64 / 64) < MAX_INT16) {
     CacheSize16 = (1 << 15) | (CacheSize64 / 64);
-    CacheSize32 = CacheSize16;
+    CacheSize32 = (1 << 31) | (CacheSize64 / 64);
   } else {
     if ((CacheSize64 / 1024) <= 2047) {
       CacheSize32 = CacheSize64;


### PR DESCRIPTION
As SMBIOS spec, bit-31 of maximum cache size 2 should be 1
for 64K granularity.

Signed-off-by: Ming Huang <huangming@linux.alibaba.com>
Reviewed-by: Rebecca Cran <rebecca@nuviainc.com>
Acked-by: Leif Lindholm <leif@nuviainc.com>