### PR TITLE
UefiPayloadPkg: Fix ECC reported issues

### DIFF
--- a/UefiPayloadPkg/Include/Coreboot.h
+++ b/UefiPayloadPkg/Include/Coreboot.h
@@ -245,5 +245,6 @@ struct cb_cbmem_tab {
   (void *)(((UINT8 *) (_rec)) + sizeof(*(_rec)) \
     + (sizeof((_rec)->map[0]) * (_idx)))
 
+typedef struct cb_memory  CB_MEMORY;
 
 #endif // _COREBOOT_PEI_H_INCLUDED_

--- a/UefiPayloadPkg/Include/Guid/AcpiBoardInfoGuid.h
+++ b/UefiPayloadPkg/Include/Guid/AcpiBoardInfoGuid.h
@@ -6,8 +6,8 @@
 
 **/
 
-#ifndef __ACPI_BOARD_INFO_GUID_H__
-#define __ACPI_BOARD_INFO_GUID_H__
+#ifndef ACPI_BOARD_INFO_GUID_H_
+#define ACPI_BOARD_INFO_GUID_H_
 
 ///
 /// Board information GUID

--- a/UefiPayloadPkg/Include/Guid/MemoryMapInfoGuid.h
+++ b/UefiPayloadPkg/Include/Guid/MemoryMapInfoGuid.h
@@ -6,8 +6,8 @@
 
 **/
 
-#ifndef __MEMORY_MAP_INFO_GUID_H__
-#define __MEMORY_MAP_INFO_GUID_H__
+#ifndef MEMORY_MAP_INFO_GUID_H_
+#define MEMORY_MAP_INFO_GUID_H_
 
 #include <Library/PcdLib.h>
 

--- a/UefiPayloadPkg/Include/Guid/SerialPortInfoGuid.h
+++ b/UefiPayloadPkg/Include/Guid/SerialPortInfoGuid.h
@@ -6,8 +6,8 @@
 
 **/
 
-#ifndef __SERIAL_PORT_INFO_GUID_H__
-#define __SERIAL_PORT_INFO_GUID_H__
+#ifndef SERIAL_PORT_INFO_GUID_H_
+#define SERIAL_PORT_INFO_GUID_H_
 
 ///
 /// Serial Port Information GUID

--- a/UefiPayloadPkg/Include/Guid/SystemTableInfoGuid.h
+++ b/UefiPayloadPkg/Include/Guid/SystemTableInfoGuid.h
@@ -6,8 +6,8 @@
 
 **/
 
-#ifndef __SYSTEM_TABLE_INFO_GUID_H__
-#define __SYSTEM_TABLE_INFO_GUID_H__
+#ifndef SYSTEM_TABLE_INFO_GUID_H_
+#define SYSTEM_TABLE_INFO_GUID_H_
 
 ///
 /// System Table Information GUID

--- a/UefiPayloadPkg/Include/Library/BlParseLib.h
+++ b/UefiPayloadPkg/Include/Library/BlParseLib.h
@@ -6,15 +6,15 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
+#ifndef BOOTLOADER_PARSE_LIB_
+#define BOOTLOADER_PARSE_LIB_
+
 #include <PiPei.h>
 #include <Guid/GraphicsInfoHob.h>
 #include <Guid/MemoryMapInfoGuid.h>
 #include <Guid/SerialPortInfoGuid.h>
 #include <Guid/SystemTableInfoGuid.h>
 #include <Guid/AcpiBoardInfoGuid.h>
-
-#ifndef __BOOTLOADER_PARSE_LIB__
-#define __BOOTLOADER_PARSE_LIB__
 
 #define GET_BOOTLOADER_PARAMETER()      PcdGet64 (PcdBootloaderParameter)
 
@@ -73,7 +73,7 @@ ParseSystemTable (
 /**
   Find the serial port information
 
-  @param  SERIAL_PORT_INFO   Pointer to serial port info structure
+  @param  SerialPortInfo     Pointer to serial port info structure
 
   @retval RETURN_SUCCESS     Successfully find the serial port information.
   @retval RETURN_NOT_FOUND   Failed to find the serial port information .

--- a/UefiPayloadPkg/Include/Library/DxeHobListLib.h
+++ b/UefiPayloadPkg/Include/Library/DxeHobListLib.h
@@ -15,8 +15,8 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
 
-#ifndef __DXE_HOB_LIST_LIB_H__
-#define __DXE_HOB_LIST_LIB_H__
+#ifndef DXE_HOB_LIST_LIB_H_
+#define DXE_HOB_LIST_LIB_H_
 
 ///
 /// Cache copy of the start of HOB list

--- a/UefiPayloadPkg/Include/Library/PlatformSupportLib.h
+++ b/UefiPayloadPkg/Include/Library/PlatformSupportLib.h
@@ -8,8 +8,8 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
 
-#ifndef __BOOTLOADER_PLATFORM_SUPPORT_LIB__
-#define __BOOTLOADER_PLATFORM_SUPPORT_LIB__
+#ifndef BOOTLOADER_PLATFORM_SUPPORT_LIB_
+#define BOOTLOADER_PLATFORM_SUPPORT_LIB_
 
 /**
   Parse platform specific information from bootloader

--- a/UefiPayloadPkg/Library/CbParseLib/CbParseLib.c
+++ b/UefiPayloadPkg/Library/CbParseLib/CbParseLib.c
@@ -322,7 +322,7 @@ ParseCbMemTable (
   )
 {
   EFI_STATUS               Status;
-  struct cb_memory         *rec;
+  CB_MEMORY                *Rec;
   struct cb_memory_range   *Range;
   UINT64                   Start;
   UINT64                   Size;
@@ -339,13 +339,13 @@ ParseCbMemTable (
   //
   // Get the coreboot memory table
   //
-  rec = (struct cb_memory *)FindCbTag (CB_TAG_MEMORY);
-  if (rec == NULL) {
+  Rec = (CB_MEMORY *)FindCbTag (CB_TAG_MEMORY);
+  if (Rec == NULL) {
     return Status;
   }
 
-  for (Index = 0; Index < MEM_RANGE_COUNT(rec); Index++) {
-    Range = MEM_RANGE_PTR(rec, Index);
+  for (Index = 0; Index < MEM_RANGE_COUNT(Rec); Index++) {
+    Range = MEM_RANGE_PTR(Rec, Index);
     Start = cb_unpack64(Range->start);
     Size = cb_unpack64(Range->size);
 
@@ -380,7 +380,7 @@ ParseMemoryInfo (
   IN  VOID                  *Params
   )
 {
-  struct cb_memory         *rec;
+  CB_MEMORY                *Rec;
   struct cb_memory_range   *Range;
   UINTN                    Index;
   MEMORY_MAP_ENTRY         MemoryMap;
@@ -388,13 +388,13 @@ ParseMemoryInfo (
   //
   // Get the coreboot memory table
   //
-  rec = (struct cb_memory *)FindCbTag (CB_TAG_MEMORY);
-  if (rec == NULL) {
+  Rec = (CB_MEMORY *)FindCbTag (CB_TAG_MEMORY);
+  if (Rec == NULL) {
     return RETURN_NOT_FOUND;
   }
 
-  for (Index = 0; Index < MEM_RANGE_COUNT(rec); Index++) {
-    Range = MEM_RANGE_PTR(rec, Index);
+  for (Index = 0; Index < MEM_RANGE_COUNT(Rec); Index++) {
+    Range = MEM_RANGE_PTR(Rec, Index);
     MemoryMap.Base = cb_unpack64(Range->start);
     MemoryMap.Size = cb_unpack64(Range->size);
     MemoryMap.Type = (UINT8)Range->type;
@@ -449,7 +449,7 @@ ParseSystemTable (
 /**
   Find the serial port information
 
-  @param  SERIAL_PORT_INFO   Pointer to serial port info structure
+  @param  SerialPortInfo     Pointer to serial port info structure
 
   @retval RETURN_SUCCESS     Successfully find the serial port information.
   @retval RETURN_NOT_FOUND   Failed to find the serial port information .

--- a/UefiPayloadPkg/Library/DxeHobListLibNull/DxeHobListLibNull.c
+++ b/UefiPayloadPkg/Library/DxeHobListLibNull/DxeHobListLibNull.c
@@ -10,6 +10,12 @@
 
 #include <Uefi.h>
 
+/**
+  The dummy constructor for DxeHobListLib.
+
+  @retval  EFI_SUCCESS
+
+**/
 EFI_STATUS
 EFIAPI
 DxeHobListLibNullConstructor (

--- a/UefiPayloadPkg/Library/PayloadEntryHobLib/Hob.c
+++ b/UefiPayloadPkg/Library/PayloadEntryHobLib/Hob.c
@@ -168,31 +168,6 @@ BuildResourceDescriptorHob (
   Hob->ResourceLength    = NumberOfBytes;
 }
 
-VOID
-EFIAPI
-BuildFvHobs (
-  IN EFI_PHYSICAL_ADDRESS         PhysicalStart,
-  IN UINT64                       NumberOfBytes,
-  IN EFI_RESOURCE_ATTRIBUTE_TYPE  *ResourceAttribute
-  )
-{
-
-  EFI_RESOURCE_ATTRIBUTE_TYPE Resource;
-
-  BuildFvHob (PhysicalStart, NumberOfBytes);
-
-  if (ResourceAttribute == NULL) {
-    Resource = (EFI_RESOURCE_ATTRIBUTE_PRESENT    |
-                EFI_RESOURCE_ATTRIBUTE_INITIALIZED |
-                EFI_RESOURCE_ATTRIBUTE_TESTED |
-                EFI_RESOURCE_ATTRIBUTE_WRITE_BACK_CACHEABLE);
-  } else {
-    Resource = *ResourceAttribute;
-  }
-
-  BuildResourceDescriptorHob (EFI_RESOURCE_FIRMWARE_DEVICE, Resource, PhysicalStart, NumberOfBytes);
-}
-
 /**
   Returns the next instance of a HOB type from the starting HOB.
 
@@ -283,7 +258,8 @@ EFIAPI
 GetNextGuidHob (
   IN CONST EFI_GUID         *Guid,
   IN CONST VOID             *HobStart
-  ){
+  )
+{
   EFI_PEI_HOB_POINTERS  GuidHob;
 
   GuidHob.Raw = (UINT8 *) HobStart;

--- a/UefiPayloadPkg/Library/PciHostBridgeLib/PciHostBridge.h
+++ b/UefiPayloadPkg/Library/PciHostBridgeLib/PciHostBridge.h
@@ -8,8 +8,8 @@
 
 **/
 
-#ifndef _PCI_HOST_BRIDGE_H
-#define _PCI_HOST_BRIDGE_H
+#ifndef PCI_HOST_BRIDGE_H_
+#define PCI_HOST_BRIDGE_H_
 
 #include <UniversalPayload/PciRootBridges.h>
 

--- a/UefiPayloadPkg/Library/PciHostBridgeLib/PciHostBridgeLib.c
+++ b/UefiPayloadPkg/Library/PciHostBridgeLib/PciHostBridgeLib.c
@@ -210,8 +210,8 @@ PciHostBridgeGetRootBridges (
   Free the root bridge instances array returned from
   PciHostBridgeGetRootBridges().
 
-  @param  The root bridge instances array.
-  @param  The count of the array.
+  @param  Bridges    The root bridge instances array.
+  @param  Count      The count of the array.
 **/
 VOID
 EFIAPI

--- a/UefiPayloadPkg/Library/PciHostBridgeLib/PciHostBridgeSupport.c
+++ b/UefiPayloadPkg/Library/PciHostBridgeLib/PciHostBridgeSupport.c
@@ -205,7 +205,7 @@ PcatPciRootBridgeParseBars (
       //
       // IO Bar
       //
-      if (Command & EFI_PCI_COMMAND_IO_SPACE) {
+      if ((Command & EFI_PCI_COMMAND_IO_SPACE) != 0) {
         Mask = 0xfffffffc;
         Base = OriginalValue & Mask;
         Length = ((~(Value & Mask)) & Mask) + 0x04;
@@ -227,7 +227,7 @@ PcatPciRootBridgeParseBars (
       //
       // Mem Bar
       //
-      if (Command & EFI_PCI_COMMAND_MEMORY_SPACE) {
+      if ((Command & EFI_PCI_COMMAND_MEMORY_SPACE) != 0) {
 
         Mask = 0xfffffff0;
         Base = OriginalValue & Mask;
@@ -306,9 +306,14 @@ ScanForRootBridges (
   UINT64     Base;
   UINT64     Limit;
   UINT64     Value;
-  PCI_ROOT_BRIDGE_APERTURE Io, Mem, MemAbove4G, PMem, PMemAbove4G, *MemAperture;
-  PCI_ROOT_BRIDGE *RootBridges;
-  UINTN      BarOffsetEnd;
+  PCI_ROOT_BRIDGE_APERTURE Io;
+  PCI_ROOT_BRIDGE_APERTURE Mem;
+  PCI_ROOT_BRIDGE_APERTURE MemAbove4G;
+  PCI_ROOT_BRIDGE_APERTURE PMem;
+  PCI_ROOT_BRIDGE_APERTURE PMemAbove4G;
+  PCI_ROOT_BRIDGE_APERTURE *MemAperture;
+  PCI_ROOT_BRIDGE          *RootBridges;
+  UINTN                    BarOffsetEnd;
 
 
   *NumberOfRootBridges = 0;

--- a/UefiPayloadPkg/Library/PlatformBootManagerLib/PlatformBootManager.c
+++ b/UefiPayloadPkg/Library/PlatformBootManagerLib/PlatformBootManager.c
@@ -15,6 +15,10 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 UNIVERSAL_PAYLOAD_PLATFORM_BOOT_MANAGER_OVERRIDE_PROTOCOL  *mUniversalPayloadPlatformBootManagerOverrideInstance = NULL;
 
+/**
+  Signal EndOfDxe event and install SMM Ready to lock protocol.
+
+**/
 VOID
 InstallReadyToLock (
   VOID

--- a/UefiPayloadPkg/Library/PlatformBootManagerLib/PlatformBootManager.h
+++ b/UefiPayloadPkg/Library/PlatformBootManagerLib/PlatformBootManager.h
@@ -1,12 +1,12 @@
-/**@file
+/** @file
    Head file for BDS Platform specific code
 
 Copyright (c) 2015 - 2016, Intel Corporation. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
-#ifndef _PLATFORM_BOOT_MANAGER_H
-#define _PLATFORM_BOOT_MANAGER_H
+#ifndef PLATFORM_BOOT_MANAGER_H_
+#define PLATFORM_BOOT_MANAGER_H_
 
 #include <PiDxe.h>
 #include <Protocol/LoadedImage.h>

--- a/UefiPayloadPkg/Library/PlatformBootManagerLib/PlatformConsole.h
+++ b/UefiPayloadPkg/Library/PlatformBootManagerLib/PlatformConsole.h
@@ -5,8 +5,8 @@ Copyright (c) 2016, Intel Corporation. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
-#ifndef _PLATFORM_CONSOLE_H
-#define _PLATFORM_CONSOLE_H
+#ifndef PLATFORM_CONSOLE_H_
+#define PLATFORM_CONSOLE_H_
 
 #include <PiDxe.h>
 #include <IndustryStandard/Pci.h>

--- a/UefiPayloadPkg/Library/PlatformBootManagerLib/PlatformData.c
+++ b/UefiPayloadPkg/Library/PlatformBootManagerLib/PlatformData.c
@@ -1,4 +1,4 @@
-/**@file
+/** @file
   Defined the platform specific device path which will be filled to
   ConIn/ConOut variables.
 

--- a/UefiPayloadPkg/Library/ResetSystemLib/ResetSystemLib.c
+++ b/UefiPayloadPkg/Library/ResetSystemLib/ResetSystemLib.c
@@ -43,22 +43,6 @@ ResetSystemLibConstructor (
   return EFI_SUCCESS;
 }
 
-
-VOID
-AcpiPmControl (
-  UINTN   SuspendType
-  )
-{
-  UINTN              PmCtrlReg;
-
-  ASSERT (SuspendType <= 7);
-
-  PmCtrlReg = (UINTN)mAcpiBoardInfo.PmCtrlRegBase;
-  IoAndThenOr16 (PmCtrlReg, (UINT16) ~0x3c00, (UINT16) (SuspendType << 10));
-  IoOr16 (PmCtrlReg, BIT13);
-  CpuDeadLoop ();
-}
-
 /**
   Calling this function causes a system-wide reset. This sets
   all circuitry within the system to its initial state. This type of reset

--- a/UefiPayloadPkg/Library/SblParseLib/SblParseLib.c
+++ b/UefiPayloadPkg/Library/SblParseLib/SblParseLib.c
@@ -141,7 +141,7 @@ ParseSystemTable (
 /**
   Find the serial port information
 
-  @param  SERIAL_PORT_INFO   Pointer to serial port info structure
+  @param[out]  SerialPortInfo     Pointer to serial port info structure
 
   @retval RETURN_SUCCESS     Successfully find the serial port information.
   @retval RETURN_NOT_FOUND   Failed to find the serial port information .

--- a/UefiPayloadPkg/UefiPayloadEntry/LoadDxeCore.c
+++ b/UefiPayloadPkg/UefiPayloadEntry/LoadDxeCore.c
@@ -190,7 +190,7 @@ FvFindFileByTypeGuid (
 
   @param  FileHeader            A pointer to the file header that contains the set of sections to
                                 be searched.
-  @param  SearchType            The value of the section type to search.
+  @param  SectionType            The value of the section type to search.
   @param  SectionData           A pointer to the discovered section, if successful.
 
   @retval EFI_SUCCESS           The section was found.

--- a/UefiPayloadPkg/UefiPayloadEntry/PrintHob.c
+++ b/UefiPayloadPkg/UefiPayloadEntry/PrintHob.c
@@ -196,7 +196,10 @@ PrintResourceDiscriptorHob (
 
 /**
   Print the information in Acpi Guid Hob.
+
   @param[in] HobRaw          A pointer to the start of gUniversalPayloadAcpiTableGuid HOB.
+  @param[in] HobLength       The size of the HOB data buffer.
+
   @retval EFI_SUCCESS        If it completed successfully.
 **/
 EFI_STATUS
@@ -217,6 +220,8 @@ PrintAcpiGuidHob (
 /**
   Print the information in Serial Guid Hob.
   @param[in] HobRaw          A pointer to the start of gUniversalPayloadSerialPortInfoGuid HOB.
+  @param[in] HobLength       The size of the HOB data buffer.
+
   @retval EFI_SUCCESS        If it completed successfully.
 **/
 EFI_STATUS
@@ -240,6 +245,7 @@ PrintSerialGuidHob (
 /**
   Print the information in Smbios Guid Hob.
   @param[in] HobRaw          A pointer to the start of gUniversalPayloadSmbios3TableGuid HOB.
+  @param[in] HobLength       The size of the HOB data buffer.
   @retval EFI_SUCCESS        If it completed successfully.
 **/
 EFI_STATUS
@@ -260,6 +266,8 @@ PrintSmbios3GuidHob (
 /**
   Print the information in Smbios Guid Hob.
   @param[in] HobRaw          A pointer to the start of gUniversalPayloadSmbiosTableGuid HOB.
+  @param[in] HobLength       The size of the HOB data buffer.
+
   @retval EFI_SUCCESS        If it completed successfully.
 **/
 EFI_STATUS
@@ -280,6 +288,8 @@ PrintSmbiosTablGuidHob (
 /**
   Print the information in Acpi BoardInfo Guid Hob.
   @param[in] HobRaw          A pointer to the start of gUefiAcpiBoardInfoGuid HOB.
+  @param[in] HobLength       The size of the HOB data buffer.
+
   @retval EFI_SUCCESS        If it completed successfully.
 **/
 EFI_STATUS
@@ -307,6 +317,7 @@ PrintAcpiBoardInfoGuidHob (
 /**
   Print the information in Pci RootBridge Info Guid Hob.
   @param[in] HobRaw          A pointer to the start of gUniversalPayloadPciRootBridgeInfoGuid HOB.
+  @param[in] HobLength       The size of the HOB data buffer.
 
   @retval EFI_SUCCESS        If it completed successfully.
 **/
@@ -362,6 +373,8 @@ PrintPciRootBridgeInfoGuidHob (
 /**
   Print the information in Extra Data Guid Hob.
   @param[in]  HobRaw         A pointer to the start of gUniversalPayloadExtraDataGuid HOB.
+  @param[in] HobLength       The size of the HOB data buffer.
+
   @retval EFI_SUCCESS        If it completed successfully.
 **/
 EFI_STATUS
@@ -394,6 +407,8 @@ PrintExtraDataGuidHob (
 /**
   Print the information in MemoryTypeInfoGuidHob.
   @param[in] HobRaw          A pointer to the start of gEfiMemoryTypeInformationGuid HOB.
+  @param[in] HobLength       The size of the HOB data buffer.
+
   @retval EFI_SUCCESS        If it completed successfully.
 **/
 EFI_STATUS
@@ -414,7 +429,7 @@ PrintMemoryTypeInfoGuidHob (
 /**
   Print the information in EdkiiBootManagerMenuFileGuid.
   @param[in] HobRaw          A pointer to the start of gEdkiiBootManagerMenuFileGuid HOB.
-  @param[in] HobLength       The size of the data buffer.
+  @param[in] HobLength       The size of the HOB data buffer.
   @retval EFI_SUCCESS        If it completed successfully.
 **/
 EFI_STATUS

--- a/UefiPayloadPkg/UefiPayloadEntry/UefiPayloadEntry.c
+++ b/UefiPayloadPkg/UefiPayloadEntry/UefiPayloadEntry.c
@@ -389,6 +389,8 @@ BuildGenericHob (
 /**
   Entry point to the C language phase of UEFI payload.
 
+  @param[in]   BootloaderParameter    The starting address of bootloader parameter block.
+
   @retval      It will not return if SUCCESS, and return error when passing bootloader parameter.
 **/
 EFI_STATUS

--- a/UefiPayloadPkg/UefiPayloadEntry/UefiPayloadEntry.h
+++ b/UefiPayloadPkg/UefiPayloadEntry/UefiPayloadEntry.h
@@ -1,9 +1,9 @@
 /** @file
-*
-* Copyright (c) 2021, Intel Corporation. All rights reserved.<BR>
-*
-*  SPDX-License-Identifier: BSD-2-Clause-Patent
-*
+
+  Copyright (c) 2021, Intel Corporation. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
 **/
 
 #ifndef __UEFI_PAYLOAD_ENTRY_H__

--- a/UefiPayloadPkg/UefiPayloadEntry/UniversalPayloadEntry.c
+++ b/UefiPayloadPkg/UefiPayloadEntry/UniversalPayloadEntry.c
@@ -114,18 +114,19 @@ AddNewHob (
 }
 
 /**
-  Found the Resource Descriptor HOB that contains a range
+  Found the Resource Descriptor HOB that contains a range (Base, Top)
 
+  @param[in] HobList    Hob start address
   @param[in] Base       Memory start address
-  @param[in] Top        Memory Top.
+  @param[in] Top        Memory end address.
 
-  @return     The pointer to the Resource Descriptor HOB.
+  @retval     The pointer to the Resource Descriptor HOB.
 **/
 EFI_HOB_RESOURCE_DESCRIPTOR *
 FindResourceDescriptorByRange (
-  VOID                      *HobList,
-  EFI_PHYSICAL_ADDRESS      Base,
-  EFI_PHYSICAL_ADDRESS      Top
+  IN VOID                      *HobList,
+  IN EFI_PHYSICAL_ADDRESS      Base,
+  IN EFI_PHYSICAL_ADDRESS      Top
   )
 {
   EFI_PEI_HOB_POINTERS             Hob;
@@ -171,7 +172,7 @@ FindResourceDescriptorByRange (
   @param[in] MinimalNeededSize       Minimal needed size.
   @param[in] ExceptResourceHob       Ignore this Resource Descriptor.
 
-  @return     The pointer to the Resource Descriptor HOB.
+  @retval     The pointer to the Resource Descriptor HOB.
 **/
 EFI_HOB_RESOURCE_DESCRIPTOR *
 FindAnotherHighestBelow4GResourceDescriptor (
@@ -239,6 +240,9 @@ FindAnotherHighestBelow4GResourceDescriptor (
 
 /**
   It will build HOBs based on information from bootloaders.
+
+  @param[in]  BootloaderParameter   The starting memory address of bootloader parameter block.
+  @param[out] DxeFv                 The pointer to the DXE FV in memory.
 
   @retval EFI_SUCCESS        If it completed successfully.
   @retval Others             If it failed to build required HOBs.
@@ -375,6 +379,8 @@ BuildHobs (
 
 /**
   Entry point to the C language phase of UEFI payload.
+
+  @param[in]   BootloaderParameter    The starting address of bootloader parameter block.
 
   @retval      It will not return if SUCCESS, and return error when passing bootloader parameter.
 **/


### PR DESCRIPTION
ECC reported some issues on UefiPayloadPkg, this patch fixed
most of them except several files including ElfLib\Elf32.h,
coreboot.h, CbParseLib.c, etc.
It also removed unused functions in ResetSystemLib and Hob.c.

Signed-off-by: Guo Dong <guo.dong@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Cc: Maurice Ma <maurice.ma@intel.com>
Cc: Benjamin You <benjamin.you@intel.com>