### PR TITLE
StandaloneMmPkg: Support CLANGPDB builds

### DIFF
--- a/StandaloneMmPkg/Core/StandaloneMmCore.inf
+++ b/StandaloneMmPkg/Core/StandaloneMmCore.inf
@@ -76,6 +76,14 @@
   gEfiEventExitBootServicesGuid
   gEfiEventReadyToBootGuid
 
+#
+# This configuration fails for CLANGPDB, which does not support PIE in the GCC
+# sense. Such however is required for ARM family StandaloneMmCore
+# self-relocation, and thus the CLANGPDB toolchain is unsupported for ARM and
+# AARCH64 for this module.
+#
 [BuildOptions]
-  GCC:*_*_*_CC_FLAGS = -fpie
-  GCC:*_*_*_DLINK_FLAGS = -Wl,-z,text,-Bsymbolic,-pie
+  GCC:*_*_ARM_CC_FLAGS = -fpie
+  GCC:*_*_ARM_DLINK_FLAGS = -Wl,-z,text,-Bsymbolic,-pie
+  GCC:*_*_AARCH64_CC_FLAGS = -fpie
+  GCC:*_*_AARCH64_DLINK_FLAGS = -Wl,-z,text,-Bsymbolic,-pie

--- a/StandaloneMmPkg/Library/StandaloneMmCoreEntryPoint/StandaloneMmCoreEntryPoint.inf
+++ b/StandaloneMmPkg/Library/StandaloneMmCoreEntryPoint/StandaloneMmCoreEntryPoint.inf
@@ -54,5 +54,12 @@
 [FeaturePcd.ARM, FeaturePcd.AARCH64]
   gArmTokenSpaceGuid.PcdFfaEnable
 
+#
+# This configuration fails for CLANGPDB, which does not support PIE in the GCC
+# sense. Such however is required for ARM family StandaloneMmCore
+# self-relocation, and thus the CLANGPDB toolchain is unsupported for ARM and
+# AARCH64 for this module.
+#
 [BuildOptions]
-  GCC:*_*_*_CC_FLAGS = -fpie
+  GCC:*_*_ARM_CC_FLAGS = -fpie
+  GCC:*_*_AARCH64_CC_FLAGS = -fpie


### PR DESCRIPTION
Currently, the flag "-fpie" is passed for all builds with a GCC
family toolchain, including CLANGPDB. CLANGPDB however does not
support this flag as it generates PE/COFF files directly.

As the flag is mostly required for ARM-specific self-relocation, drop
it for other architectures and document the limitation to enable e.g.
X64 CLANGPDB builds of StandaloneMmCore.

Signed-off-by: Marvin Häuser <mhaeuser@posteo.de>
Acked-by: Shi Steven <steven.shi@intel.com>