### PR TITLE
UefiPayloadPkg: Fix the build failure for non-universal payload

### DIFF
--- a/UefiPayloadPkg/UefiPayloadEntry/UefiPayloadEntry.c
+++ b/UefiPayloadPkg/UefiPayloadEntry/UefiPayloadEntry.c
@@ -103,7 +103,7 @@ MemInfoCallbackMmio (
 **/
 EFI_STATUS
 FindToludCallback (
-  IN MEMROY_MAP_ENTRY          *MemoryMapEntry,
+  IN MEMORY_MAP_ENTRY          *MemoryMapEntry,
   IN VOID                      *Params
   )
 {
@@ -168,7 +168,7 @@ FindToludCallback (
 **/
 EFI_STATUS
 MemInfoCallback (
-  IN MEMROY_MAP_ENTRY          *MemoryMapEntry,
+  IN MEMORY_MAP_ENTRY          *MemoryMapEntry,
   IN VOID                      *Params
   )
 {


### PR DESCRIPTION
Applied an old patch which caused non-universal payload build failed
since that code was added after the old patch.
This patch fixed the build failure.

Signed-off-by: Guo Dong <guo.dong@intel.com>