### PR TITLE
ArmPkg: Add SMC helper functions

### DIFF
--- a/ArmPkg/Library/ArmSmcLib/ArmSmc.c
+++ b/ArmPkg/Library/ArmSmcLib/ArmSmc.c
@@ -1,44 +1,15 @@
 /** @file
-*
-*  Copyright (c) 2021, NUVIA Inc. All rights reserved.<BR>
-*  Copyright (c) 2012-2014, ARM Limited. All rights reserved.
-*
-*  SPDX-License-Identifier: BSD-2-Clause-Patent
-*
-**/
+  SMC helper functions.
 
-#ifndef ARM_SMC_LIB_H_
-#define ARM_SMC_LIB_H_
+  Copyright (c) 2021, NUVIA Inc. All rights reserved.<BR>
 
-/**
- * The size of the SMC arguments are different between AArch64 and AArch32.
- * The native size is used for the arguments.
- */
-typedef struct {
-  UINTN  Arg0;
-  UINTN  Arg1;
-  UINTN  Arg2;
-  UINTN  Arg3;
-  UINTN  Arg4;
-  UINTN  Arg5;
-  UINTN  Arg6;
-  UINTN  Arg7;
-} ARM_SMC_ARGS;
-
-/**
-  Trigger an SMC call
-
-  SMC calls can take up to 7 arguments and return up to 4 return values.
-  Therefore, the 4 first fields in the ARM_SMC_ARGS structure are used
-  for both input and output values.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
-VOID
-ArmCallSmc (
-  IN OUT ARM_SMC_ARGS *Args
-  );
 
-/** Trigger an SMC call with 3 arguments.
+#include <Library/ArmSmcLib.h>
+
+/** Triggers an SMC call with 3 arguments.
 
   @param Function The SMC function.
   @param Arg1     Argument/result.
@@ -46,7 +17,6 @@ ArmCallSmc (
   @param Arg3     Argument/result.
 
   @return The SMC error code.
-
 **/
 UINTN
 ArmCallSmc3 (
@@ -54,7 +24,39 @@ ArmCallSmc3 (
   IN OUT UINTN *Arg1,
   IN OUT UINTN *Arg2,
   IN OUT UINTN *Arg3
-  );
+  )
+{
+  ARM_SMC_ARGS Args;
+  UINTN        ErrorCode;
+
+  Args.Arg0 = Function;
+
+  if (Arg1 != NULL) {
+    Args.Arg1 = *Arg1;
+  }
+  if (Arg2 != NULL) {
+    Args.Arg2 = *Arg2;
+  }
+  if (Arg3 != NULL) {
+    Args.Arg3 = *Arg3;
+  }
+
+  ArmCallSmc (&Args);
+
+  ErrorCode = Args.Arg0;
+
+  if (Arg1 != NULL) {
+    *Arg1 = Args.Arg1;
+  }
+  if (Arg2 != NULL) {
+    *Arg2 = Args.Arg2;
+  }
+  if (Arg3 != NULL) {
+    *Arg3 = Args.Arg3;
+  }
+
+  return ErrorCode;
+}
 
 /** Trigger an SMC call with 2 arguments.
 
@@ -72,7 +74,10 @@ ArmCallSmc2 (
   IN OUT UINTN *Arg1,
   IN OUT UINTN *Arg2,
      OUT UINTN *Arg3
-  );
+  )
+{
+  return ArmCallSmc3 (Function, Arg1, Arg2, Arg3);
+}
 
 /** Trigger an SMC call with 1 argument.
 
@@ -90,7 +95,10 @@ ArmCallSmc1 (
   IN OUT UINTN *Arg1,
      OUT UINTN *Arg2,
      OUT UINTN *Arg3
-  );
+  )
+{
+  return ArmCallSmc3 (Function, Arg1, Arg2, Arg3);
+}
 
 /** Trigger an SMC call with 0 arguments.
 
@@ -108,6 +116,7 @@ ArmCallSmc0 (
      OUT UINTN *Arg1,
      OUT UINTN *Arg2,
      OUT UINTN *Arg3
-  );
-
-#endif // ARM_SMC_LIB_H_
+  )
+{
+  return ArmCallSmc3 (Function, Arg1, Arg2, Arg3);
+}

--- a/ArmPkg/Library/ArmSmcLib/ArmSmcLib.inf
+++ b/ArmPkg/Library/ArmSmcLib/ArmSmcLib.inf
@@ -20,6 +20,9 @@
 [Sources.AARCH64]
   AArch64/ArmSmc.S
 
+[Sources]
+  ArmSmc.c
+
 [Packages]
   MdePkg/MdePkg.dec
   ArmPkg/ArmPkg.dec

--- a/ArmPkg/Library/ArmSmcLibNull/ArmSmcLibNull.c
+++ b/ArmPkg/Library/ArmSmcLibNull/ArmSmcLibNull.c
@@ -1,4 +1,5 @@
 //
+//  Copyright (c) 2021, NUVIA Inc. All rights reserved.
 //  Copyright (c) 2016, Linaro Limited. All rights reserved.
 //
 //  SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -7,10 +8,94 @@
 
 #include <Base.h>
 #include <Library/ArmSmcLib.h>
+#include <IndustryStandard/ArmStdSmc.h>
 
 VOID
 ArmCallSmc (
   IN OUT ARM_SMC_ARGS *Args
   )
 {
+}
+
+/** Triggers an SMC call with 3 arguments.
+
+  @param Function The SMC function.
+  @param Arg1     Argument/result.
+  @param Arg2     Argument/result.
+  @param Arg3     Argument/result.
+
+  @return The SMC error code.
+**/
+UINTN
+ArmCallSmc3 (
+  IN     UINTN Function,
+  IN OUT UINTN *Arg1,
+  IN OUT UINTN *Arg2,
+  IN OUT UINTN *Arg3
+  )
+{
+  return SMC_ARCH_CALL_NOT_SUPPORTED;
+}
+
+/** Trigger an SMC call with 2 arguments.
+
+  @param Function The SMC function.
+  @param Arg1     Argument/result.
+  @param Arg2     Argument/result.
+  @param Arg3     Result.
+
+  @return The SMC error code.
+
+**/
+UINTN
+ArmCallSmc2 (
+  IN     UINTN Function,
+  IN OUT UINTN *Arg1,
+  IN OUT UINTN *Arg2,
+     OUT UINTN *Arg3
+  )
+{
+  return SMC_ARCH_CALL_NOT_SUPPORTED;
+}
+
+/** Trigger an SMC call with 1 argument.
+
+  @param Function The SMC function.
+  @param Arg1     Argument/result.
+  @param Arg2     Result.
+  @param Arg3     Result.
+
+  @return The SMC error code.
+
+**/
+UINTN
+ArmCallSmc1 (
+  IN     UINTN Function,
+  IN OUT UINTN *Arg1,
+     OUT UINTN *Arg2,
+     OUT UINTN *Arg3
+  )
+{
+  return SMC_ARCH_CALL_NOT_SUPPORTED;
+}
+
+/** Trigger an SMC call with 0 arguments.
+
+  @param Function The SMC function.
+  @param Arg1     Result.
+  @param Arg2     Result.
+  @param Arg3     Result.
+
+  @return The SMC error code.
+
+**/
+UINTN
+ArmCallSmc0 (
+  IN     UINTN Function,
+     OUT UINTN *Arg1,
+     OUT UINTN *Arg2,
+     OUT UINTN *Arg3
+  )
+{
+  return SMC_ARCH_CALL_NOT_SUPPORTED;
 }

--- a/ArmPkg/Library/ArmSmcPsciResetSystemLib/ArmSmcPsciResetSystemLib.c
+++ b/ArmPkg/Library/ArmSmcPsciResetSystemLib/ArmSmcPsciResetSystemLib.c
@@ -31,11 +31,8 @@ ResetCold (
   VOID
   )
 {
-  ARM_SMC_ARGS ArmSmcArgs;
-
   // Send a PSCI 0.2 SYSTEM_RESET command
-  ArmSmcArgs.Arg0 = ARM_SMC_ID_PSCI_SYSTEM_RESET;
-  ArmCallSmc (&ArmSmcArgs);
+  ArmCallSmc0 (ARM_SMC_ID_PSCI_SYSTEM_RESET, NULL, NULL, NULL);
 }
 
 /**
@@ -66,11 +63,8 @@ ResetShutdown (
   VOID
   )
 {
-  ARM_SMC_ARGS ArmSmcArgs;
-
   // Send a PSCI 0.2 SYSTEM_OFF command
-  ArmSmcArgs.Arg0 = ARM_SMC_ID_PSCI_SYSTEM_OFF;
-  ArmCallSmc (&ArmSmcArgs);
+  ArmCallSmc0 (ARM_SMC_ID_PSCI_SYSTEM_OFF, NULL, NULL, NULL);
 }
 
 /**

--- a/ArmPkg/Universal/Smbios/ProcessorSubClassDxe/SmbiosProcessorArmCommon.c
+++ b/ArmPkg/Universal/Smbios/ProcessorSubClassDxe/SmbiosProcessorArmCommon.c
@@ -88,22 +88,19 @@ HasSmcArm64SocId (
   VOID
   )
 {
-  ARM_SMC_ARGS                   Args;
   INT32                          SmcCallStatus;
   BOOLEAN                        Arm64SocIdSupported;
+  UINTN                          SmcParam;
 
   Arm64SocIdSupported = FALSE;
 
-  Args.Arg0 = SMCCC_VERSION;
-  ArmCallSmc (&Args);
-  SmcCallStatus = (INT32)Args.Arg0;
+  SmcCallStatus = ArmCallSmc0 (SMCCC_VERSION, NULL, NULL, NULL);
 
   if (SmcCallStatus < 0 || (SmcCallStatus >> 16) >= 1) {
-    Args.Arg0 = SMCCC_ARCH_FEATURES;
-    Args.Arg1 = SMCCC_ARCH_SOC_ID;
-    ArmCallSmc (&Args);
+    SmcParam = SMCCC_ARCH_SOC_ID;
+    SmcCallStatus = (INT32)ArmCallSmc1 (SMCCC_ARCH_FEATURES, &SmcParam, NULL, NULL);
 
-    if (Args.Arg0 >= 0) {
+    if (SmcCallStatus >= 0) {
       Arm64SocIdSupported = TRUE;
     }
   }
@@ -125,30 +122,26 @@ SmbiosGetSmcArm64SocId (
   OUT INT32 *SocRevision
   )
 {
-  ARM_SMC_ARGS  Args;
   INT32         SmcCallStatus;
   EFI_STATUS    Status;
+  UINTN         SmcParam;
 
   Status = EFI_SUCCESS;
 
-  Args.Arg0 = SMCCC_ARCH_SOC_ID;
-  Args.Arg1 = 0;
-  ArmCallSmc (&Args);
-  SmcCallStatus = (INT32)Args.Arg0;
+  SmcParam = 0;
+  SmcCallStatus = (INT32)ArmCallSmc1 (SMCCC_ARCH_SOC_ID, &SmcParam, NULL, NULL);
 
   if (SmcCallStatus >= 0) {
-    *Jep106Code = (INT32)Args.Arg0;
+    *Jep106Code = (INT32)SmcParam;
   } else {
     Status = EFI_UNSUPPORTED;
   }
 
-  Args.Arg0 = SMCCC_ARCH_SOC_ID;
-  Args.Arg1 = 1;
-  ArmCallSmc (&Args);
-  SmcCallStatus = (INT32)Args.Arg0;
+  SmcParam = 1;
+  SmcCallStatus = (INT32)ArmCallSmc1 (SMCCC_ARCH_SOC_ID, &SmcParam, NULL, NULL);
 
   if (SmcCallStatus >= 0) {
-    *SocRevision = (INT32)Args.Arg0;
+    *SocRevision = (INT32)SmcParam;
   } else {
     Status = EFI_UNSUPPORTED;
   }


### PR DESCRIPTION
Add functions ArmCallSmc0/1/2/3 to do SMC calls with 0, 1, 2 or 3
arguments.
The functions return up to 3 values.

Signed-off-by: Rebecca Cran <rebecca@nuviainc.com>