### PR TITLE
UefiCpuPkg: Extend measurement of microcode patches to TPM

### DIFF
--- a/UefiCpuPkg/MicrocodeMeasurementDxe/MicrocodeMeasurementDxe.c
+++ b/UefiCpuPkg/MicrocodeMeasurementDxe/MicrocodeMeasurementDxe.c
@@ -1,0 +1,252 @@
+/** @file
+  This driver measures Microcode Patches to TPM.
+
+Copyright (c) 2021, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <IndustryStandard/UefiTcgPlatform.h>
+#include <Guid/EventGroup.h>
+#include <Guid/MicrocodePatchHob.h>
+#include <Library/DebugLib.h>
+#include <Library/UefiDriverEntryPoint.h>
+#include <Library/UefiLib.h>
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/UefiBootServicesTableLib.h>
+#include <Library/PrintLib.h>
+#include <Library/SortLib.h>
+#include <Library/HobLib.h>
+#include <Library/MicrocodeLib.h>
+#include <Library/TpmMeasurementLib.h>
+
+
+#define CPU_MICROCODE_MEASUREMENT_DESCRIPTION  "Microcode Measurement"
+#define CPU_MICROCODE_MEASUREMENT_EVENT_LOG_DESCRIPTION_LEN  sizeof(CPU_MICROCODE_MEASUREMENT_DESCRIPTION)
+
+#pragma pack(1)
+typedef struct {
+  UINTN    Address;
+  UINTN    Size;
+}MICROCODE_PATCH_TYPE;
+
+typedef struct {
+  UINT8    Description[CPU_MICROCODE_MEASUREMENT_EVENT_LOG_DESCRIPTION_LEN];
+  UINTN    NumberOfMicrocodePatchesMeasured;
+  UINTN    SizeOfMicrocodePatchesMeasured;
+}CPU_MICROCODE_MEASUREMENT_EVENT_LOG;
+#pragma pack()
+
+STATIC BOOLEAN mMicrocodeMeasured = FALSE;
+
+/**
+  Helper Function. Microcode patches list comparison function instance for PerformQuickSort.
+
+  @param[in] Buffer1                  The pointer to first buffer.
+  @param[in] Buffer2                  The pointer to second buffer.
+
+  @return 0                           Buffer1 equal to Buffer2.
+  @return <0                          Buffer1 is less than Buffer2.
+  @return >0                          Buffer1 is greater than Buffer2.
+**/
+INTN
+EFIAPI
+MicrocodePatchesListSortFunction (
+  IN CONST VOID                 *Buffer1,
+  IN CONST VOID                 *Buffer2
+  )
+{
+  return ((MICROCODE_PATCH_TYPE*)Buffer2)->Address - ((MICROCODE_PATCH_TYPE*)Buffer1)->Address;
+}
+
+/**
+  Measure Microcode Patches Binary Blob with EV_CPU_MICROCODE to PCR[1].
+
+  @param[in] Event      Event whose notification function is being invoked.
+  @param[in] Context    Pointer to the notification function's context.
+
+**/
+VOID
+EFIAPI
+MeasureMicrocodePatches (
+  IN      EFI_EVENT                 Event,
+  IN      VOID                      *Context
+  )
+{
+  EFI_STATUS                            Status;
+  UINT32                                PCRIndex;
+  UINT32                                EventType;
+  CPU_MICROCODE_MEASUREMENT_EVENT_LOG   EventLog;
+  UINT32                                EventLogSize;
+  EFI_HOB_GUID_TYPE                     *GuidHob;
+  EDKII_MICROCODE_PATCH_HOB             *MicrocodePatchHob;
+  UINTN                                 SumOfAllPatchesSizeInMicrocodePatchHob;
+  UINT32                                Index;
+  MICROCODE_PATCH_TYPE                  *MicrocodePatchesList;
+  UINTN                                 LastPackedMicrocodeAddress;
+  UINT8                                 *MicrocodePatchesBlob;
+  UINT64                                MicrocodePatchesBlobSize;
+
+
+  PCRIndex  = 1;
+  EventType = EV_CPU_MICROCODE;
+  AsciiSPrint (
+               (CHAR8 *)EventLog.Description,
+               CPU_MICROCODE_MEASUREMENT_EVENT_LOG_DESCRIPTION_LEN,
+               CPU_MICROCODE_MEASUREMENT_DESCRIPTION
+               );
+  EventLog.NumberOfMicrocodePatchesMeasured = 0;
+  EventLog.SizeOfMicrocodePatchesMeasured   = 0;
+  EventLogSize                              = sizeof (CPU_MICROCODE_MEASUREMENT_EVENT_LOG);
+  SumOfAllPatchesSizeInMicrocodePatchHob    = 0;
+  LastPackedMicrocodeAddress                = 0;
+  MicrocodePatchesBlob                      = NULL;
+  MicrocodePatchesBlobSize                  = 0;
+
+
+  if (TRUE == mMicrocodeMeasured) {
+    DEBUG((DEBUG_INFO, "INFO: mMicrocodeMeasured = TRUE, Skip.\n"));
+    return;
+  }
+
+  GuidHob = GetFirstGuidHob (&gEdkiiMicrocodePatchHobGuid);
+  if (NULL == GuidHob) {
+    DEBUG((DEBUG_ERROR, "ERROR: GetFirstGuidHob (&gEdkiiMicrocodePatchHobGuid) failed.\n"));
+    return;
+  }
+
+  MicrocodePatchHob = GET_GUID_HOB_DATA (GuidHob);
+  DEBUG ((DEBUG_INFO, "INFO: Got MicrocodePatchHob with microcode patches starting address:0x%x, microcode patches region size:0x%x, Processor Count:0x%x\n", MicrocodePatchHob->MicrocodePatchAddress, MicrocodePatchHob->MicrocodePatchRegionSize, MicrocodePatchHob->ProcessorCount));
+
+  //
+  // Extract all microcode patches to a list from MicrocodePatchHob
+  //
+  MicrocodePatchesList = AllocatePool (MicrocodePatchHob->ProcessorCount * sizeof (MICROCODE_PATCH_TYPE));
+  if (NULL == MicrocodePatchesList) {
+    DEBUG ((DEBUG_ERROR, "ERROR: AllocatePool to MicrocodePatchesList Failed!\n"));
+    return;
+  }
+  for (Index = 0; Index < MicrocodePatchHob->ProcessorCount; Index++) {
+    if (MAX_UINT64 == MicrocodePatchHob->ProcessorSpecificPatchOffset[Index]) {
+      //
+      // If no microcode patch was found in a slot, set the address of the microcode patch
+      // in that slot to MAX_UINT32, and the size to 0, thus indicates no patch in that slot.
+      //
+      MicrocodePatchesList[Index].Address = MAX_UINT32;
+      MicrocodePatchesList[Index].Size    = 0;
+
+      DEBUG ((DEBUG_INFO, "INFO: Processor#%d: detected no microcode patch\n", Index));
+    } else {
+      MicrocodePatchesList[Index].Address     = (UINTN)(MicrocodePatchHob->MicrocodePatchAddress + MicrocodePatchHob->ProcessorSpecificPatchOffset[Index]);
+      MicrocodePatchesList[Index].Size        = ((CPU_MICROCODE_HEADER*)((UINTN)(MicrocodePatchHob->MicrocodePatchAddress + MicrocodePatchHob->ProcessorSpecificPatchOffset[Index])))->TotalSize;
+      SumOfAllPatchesSizeInMicrocodePatchHob  += MicrocodePatchesList[Index].Size;
+
+      DEBUG ((DEBUG_INFO, "INFO: Processor#%d: Microcode patch address: 0x%x, size: 0x%x\n", Index, MicrocodePatchesList[Index].Address, MicrocodePatchesList[Index].Size));
+    }
+  }
+
+  //
+  // The order matters when pack all microcode patches to a binary blob. Therefore do
+  // Sorting before packing.
+  // NOTE: We assumed that the order of addresses of all unique microcode patch in RAM
+  // is the same with the order of those in the Microcode Firmware Volume. If any future
+  // updates made this assumption untenable, then please find a new solution to measure
+  // microcode patches.
+  //
+  PerformQuickSort (
+               MicrocodePatchesList,
+               MicrocodePatchHob->ProcessorCount,
+               sizeof (MICROCODE_PATCH_TYPE),
+               MicrocodePatchesListSortFunction
+               );
+  for (Index = 0; Index < MicrocodePatchHob->ProcessorCount; Index++) {
+    DEBUG ((DEBUG_INFO, "INFO: After sorting: Processor#%d: Microcode patch address: 0x%x, size: 0x%x\n", Index, MicrocodePatchesList[Index].Address, MicrocodePatchesList[Index].Size));
+  }
+
+  MicrocodePatchesBlob = AllocateZeroPool (SumOfAllPatchesSizeInMicrocodePatchHob);
+  if (NULL == MicrocodePatchesBlob) {
+    DEBUG ((DEBUG_ERROR, "ERROR - AllocateZeroPool to MicrocodePatchesBlob failed!\n"));
+    FreePool (MicrocodePatchesList);
+    return;
+  }
+
+  //
+  // LastPackedMicrocodeAddress is used to skip duplicate microcode patch here.
+  //
+  for (Index = 0; Index < MicrocodePatchHob->ProcessorCount; Index++) {
+    if (MicrocodePatchesList[Index].Address != LastPackedMicrocodeAddress &&
+        MicrocodePatchesList[Index].Address != MAX_UINT32) {
+
+      CopyMem (
+               (VOID *)(MicrocodePatchesBlob + MicrocodePatchesBlobSize),
+               (VOID *)(MicrocodePatchesList[Index].Address),
+               (UINTN)(MicrocodePatchesList[Index].Size)
+               );
+      MicrocodePatchesBlobSize                  += MicrocodePatchesList[Index].Size;
+      LastPackedMicrocodeAddress                = MicrocodePatchesList[Index].Address;
+      EventLog.NumberOfMicrocodePatchesMeasured += 1;
+      EventLog.SizeOfMicrocodePatchesMeasured   += MicrocodePatchesList[Index].Size;
+
+    }
+  }
+  
+  if (0 == MicrocodePatchesBlobSize) {
+    DEBUG ((DEBUG_INFO, "INFO: No Microcode Patches Was Applied"));
+    FreePool (MicrocodePatchesList);
+    FreePool (MicrocodePatchesBlob);
+    return;
+  }
+
+  Status = TpmMeasureAndLogData (
+               PCRIndex,                  // PCRIndex
+               EventType,                 // EventType
+               &EventLog,                 // EventLog
+               EventLogSize,              // LogLen
+               MicrocodePatchesBlob,      // HashData
+               MicrocodePatchesBlobSize   // HashDataLen
+               );
+  if (!EFI_ERROR (Status)) {
+    mMicrocodeMeasured = TRUE;
+    gBS->CloseEvent (Event);
+  } else {
+    FreePool (MicrocodePatchesList);
+    FreePool (MicrocodePatchesBlob);
+    DEBUG ((DEBUG_ERROR, "ERROR - TpmMeasureAndLogData failed with %a!\n", Status));
+  }
+
+  return;
+}
+
+/**
+
+  Driver to produce Microcode measurement.
+
+  @param ImageHandle     Module's image handle
+  @param SystemTable     Pointer of EFI_SYSTEM_TABLE
+
+  @return EFI_SUCCESS     This function always complete successfully.
+
+**/
+EFI_STATUS
+EFIAPI
+MicrocodeMeasurementDriverEntryPoint (
+  IN EFI_HANDLE           ImageHandle,
+  IN EFI_SYSTEM_TABLE     *SystemTable
+  )
+{
+  EFI_EVENT             Event;
+
+  //
+  // Measure Microcode patches
+  //
+  EfiCreateEventReadyToBootEx (
+             TPL_CALLBACK,
+             MeasureMicrocodePatches,
+             NULL,
+             &Event
+             );
+
+  return EFI_SUCCESS;
+}

--- a/UefiCpuPkg/MicrocodeMeasurementDxe/MicrocodeMeasurementDxe.inf
+++ b/UefiCpuPkg/MicrocodeMeasurementDxe/MicrocodeMeasurementDxe.inf
@@ -1,0 +1,58 @@
+## @file
+#  This driver measures Microcode Patches to TPM.
+#
+#  This driver consumes gEdkiiMicrocodePatchHobGuid, packs all unique
+#  microcode patch found in gEdkiiMicrocodePatchHobGuid to a binary blob,
+#  and measures the binary blob to TPM.
+#
+#  Copyright (c) 2021, Intel Corporation. All rights reserved.<BR>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = MicrocodeMeasurementDxe
+  MODULE_UNI_FILE                = MicrocodeMeasurementDxe.uni
+  FILE_GUID                      = 0A32A803-ACDF-4C89-8293-91011548CD91
+  MODULE_TYPE                    = DXE_DRIVER
+  VERSION_STRING                 = 1.0
+  ENTRY_POINT                    = MicrocodeMeasurementDriverEntryPoint
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64 EBC ARM AARCH64
+#
+
+[Sources]
+  MicrocodeMeasurementDxe.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  UefiCpuPkg/UefiCpuPkg.dec
+
+[LibraryClasses]
+  UefiBootServicesTableLib
+  MemoryAllocationLib
+  BaseMemoryLib
+  BaseLib
+  UefiLib
+  UefiDriverEntryPoint
+  DebugLib
+  PrintLib
+  SortLib
+  HobLib
+  MicrocodeLib
+  TpmMeasurementLib
+
+[Guids]
+  gEdkiiMicrocodePatchHobGuid           ## CONSUMES ## HOB
+
+[UserExtensions.TianoCore."ExtraFiles"]
+  MicrocodeMeasurementDxeExtra.uni
+
+[Depex]
+  TRUE

--- a/UefiCpuPkg/MicrocodeMeasurementDxe/MicrocodeMeasurementDxe.uni
+++ b/UefiCpuPkg/MicrocodeMeasurementDxe/MicrocodeMeasurementDxe.uni
@@ -1,0 +1,15 @@
+// /** @file
+// This driver measures Microcode Patches to TPM.
+//
+// This driver consumes gEdkiiMicrocodePatchHobGuid, packs all uniquemicrocode patch found in gEdkiiMicrocodePatchHobGuid to a binary blob, and measures the binary blob to TPM.
+//
+// Copyright (c) 2021, Intel Corporation. All rights reserved.<BR>
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+// **/
+
+
+#string STR_MODULE_ABSTRACT             #language en-US "This driver measures Microcode Patches to TPM."
+
+#string STR_MODULE_DESCRIPTION          #language en-US "This driver consumes gEdkiiMicrocodePatchHobGuid, packs all microcode patch found in gEdkiiMicrocodePatchHobGuid to a binary blob, and measure the binary blob to TPM."

--- a/UefiCpuPkg/MicrocodeMeasurementDxe/MicrocodeMeasurementDxeExtra.uni
+++ b/UefiCpuPkg/MicrocodeMeasurementDxe/MicrocodeMeasurementDxeExtra.uni
@@ -1,0 +1,12 @@
+// /** @file
+// MicrocodeMeasurementDxe Localized Strings and Content
+//
+// Copyright (c) 2021, Intel Corporation. All rights reserved.<BR>
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+// **/
+
+#string STR_PROPERTIES_MODULE_NAME
+#language en-US
+"Microcode Patches Measurement DXE Driver"

--- a/UefiCpuPkg/UefiCpuPkg.dsc
+++ b/UefiCpuPkg/UefiCpuPkg.dsc
@@ -61,6 +61,7 @@
   TpmMeasurementLib|MdeModulePkg/Library/TpmMeasurementLibNull/TpmMeasurementLibNull.inf
   VmgExitLib|UefiCpuPkg/Library/VmgExitLibNull/VmgExitLibNull.inf
   MicrocodeLib|UefiCpuPkg/Library/MicrocodeLib/MicrocodeLib.inf
+  SortLib|MdeModulePkg/Library/UefiSortLib/UefiSortLib.inf
 
 [LibraryClasses.common.SEC]
   PlatformSecLib|UefiCpuPkg/Library/PlatformSecLibNull/PlatformSecLibNull.inf
@@ -119,6 +120,7 @@
   UefiCpuPkg/Library/CpuTimerLib/BaseCpuTimerLib.inf
   UefiCpuPkg/Library/CpuCacheInfoLib/PeiCpuCacheInfoLib.inf
   UefiCpuPkg/Library/CpuCacheInfoLib/DxeCpuCacheInfoLib.inf
+  UefiCpuPkg/MicrocodeMeasurementDxe/MicrocodeMeasurementDxe.inf
 
 [Components.IA32, Components.X64]
   UefiCpuPkg/CpuDxe/CpuDxe.inf


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3683

TCG specification says BIOS should extend measurement of microcode to TPM.
However, reference BIOS is not doing this. BIOS shall extend measurement of
microcode to TPM.

Cc: Eric Dong <eric.dong@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Cc: Rahul Kumar <rahul1.kumar@intel.com>
Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Min M Xu <min.m.xu@intel.com>
Cc: Qi Zhang <qi1.zhang@intel.com>
Signed-off-by: Longlong Yang <longlong.yang@intel.com>