### PR TITLE
DynamicTablesPkg: Fix unitialized variable use

### DIFF
--- a/DynamicTablesPkg/Library/Common/AmlLib/CodeGen/AmlResourceDataCodeGen.c
+++ b/DynamicTablesPkg/Library/Common/AmlLib/CodeGen/AmlResourceDataCodeGen.c
@@ -91,7 +91,7 @@ LinkRdNode (
     *NewRdNode = RdNode;
   }
 
-  return Status;
+  return EFI_SUCCESS;
 
 error_handler:
   Status1 = AmlDeleteTree ((AML_NODE_HEADER*)RdNode);


### PR DESCRIPTION
In the success case we should return EFI_SUCCESS rather than returning
a potentially unitialized value of Status.

Cc: Sami Mujawar <Sami.Mujawar@arm.com>
Cc: Alexei Fedorov <Alexei.Fedorov@arm.com>
Signed-off-by: Moritz Fischer <moritzf@google.com>