### PR TITLE
DynamicTablesPkg: Fix void pointer arithmetic

### DIFF
--- a/DynamicTablesPkg/Library/Common/TableHelperLib/ConfigurationManagerObjectParser.c
+++ b/DynamicTablesPkg/Library/Common/TableHelperLib/ConfigurationManagerObjectParser.c
@@ -641,7 +641,7 @@ PrintCmObjDesc (
         ));
     }
     DEBUG ((DEBUG_ERROR, "\n"));
-    Data += Parser[Index].Length;
+    Data = (UINT8*)Data + Parser[Index].Length;
   } // for
 }
 


### PR DESCRIPTION
Building the DynamicTablesPkg with the additional
-Wpointer-arith flag triggers the following error:
  "pointer of type ‘void *’ used in arithmetic
  [-Werror=pointer-arith]"

Cast the void pointer to fix the error.

Signed-off-by: Pierre Gondois <Pierre.Gondois@arm.com>
Reviewed-by: Sami Mujawar <sami.mujawar@arm.com>