### PR TITLE
BZ 3694 - HttpBootDxe rejected bootloaders with upper-case file extensions

### DIFF
--- a/NetworkPkg/HttpBootDxe/HttpBootSupport.c
+++ b/NetworkPkg/HttpBootDxe/HttpBootSupport.c
@@ -681,11 +681,11 @@ HttpBootCheckImageType (
   }
 
   FilePost = FilePath + AsciiStrLen (FilePath) - 4;
-  if (AsciiStrCmp (FilePost, ".efi") == 0) {
+  if (AsciiStriCmp (FilePost, ".efi") == 0) {
     *ImageType = ImageTypeEfi;
-  } else if (AsciiStrCmp (FilePost, ".iso") == 0) {
+  } else if (AsciiStriCmp (FilePost, ".iso") == 0) {
     *ImageType = ImageTypeVirtualCd;
-  } else if (AsciiStrCmp (FilePost, ".img") == 0) {
+  } else if (AsciiStriCmp (FilePost, ".img") == 0) {
     *ImageType = ImageTypeVirtualDisk;
   } else {
     *ImageType = ImageTypeMax;


### PR DESCRIPTION
https://bugzilla.tianocore.org/show_bug.cgi?id=3694

HttpBootCheckImageType() was using the case-sensitive AsciiStrCmp() to
check the file extensions and this could reject the images with
upper-case file names. Using the case-insensitive AsciiStriCmp() to
avoid the issue.

Cc: Maciej Rabeda <maciej.rabeda@linux.intel.com>
Cc: Jiaxin Wu <jiaxin.wu@intel.com>
Cc: Siyuan Fu <siyuan.fu@intel.com>
Signed-off-by: Gary Lin <gary.lin@hpe.com>
Reviewed-by: Maciej Rabeda <maciej.rabeda@linux.intel.com>