### PR TITLE
IntelFsp2Pkg/SplitFspBin.py: adopt FSP 2.3 specification.

### DIFF
--- a/IntelFsp2Pkg/Tools/SplitFspBin.py
+++ b/IntelFsp2Pkg/Tools/SplitFspBin.py
@@ -1,6 +1,6 @@
 ## @ FspTool.py
 #
-# Copyright (c) 2015 - 2020, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2015 - 2021, Intel Corporation. All rights reserved.<BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -103,26 +103,29 @@ class FSP_COMMON_HEADER(Structure):
 
 class FSP_INFORMATION_HEADER(Structure):
      _fields_ = [
-        ('Signature',            ARRAY(c_char, 4)),
-        ('HeaderLength',         c_uint32),
-        ('Reserved1',            c_uint16),
-        ('SpecVersion',          c_uint8),
-        ('HeaderRevision',       c_uint8),
-        ('ImageRevision',        c_uint32),
-        ('ImageId',              ARRAY(c_char, 8)),
-        ('ImageSize',            c_uint32),
-        ('ImageBase',            c_uint32),
-        ('ImageAttribute',       c_uint16),
-        ('ComponentAttribute',   c_uint16),
-        ('CfgRegionOffset',      c_uint32),
-        ('CfgRegionSize',        c_uint32),
-        ('Reserved2',            c_uint32),
-        ('TempRamInitEntryOffset',     c_uint32),
-        ('Reserved3',                  c_uint32),
-        ('NotifyPhaseEntryOffset',     c_uint32),
-        ('FspMemoryInitEntryOffset',   c_uint32),
-        ('TempRamExitEntryOffset',     c_uint32),
-        ('FspSiliconInitEntryOffset',  c_uint32)
+        ('Signature',                      ARRAY(c_char, 4)),
+        ('HeaderLength',                   c_uint32),
+        ('Reserved1',                      c_uint16),
+        ('SpecVersion',                    c_uint8),
+        ('HeaderRevision',                 c_uint8),
+        ('ImageRevision',                  c_uint32),
+        ('ImageId',                        ARRAY(c_char, 8)),
+        ('ImageSize',                      c_uint32),
+        ('ImageBase',                      c_uint32),
+        ('ImageAttribute',                 c_uint16),
+        ('ComponentAttribute',             c_uint16),
+        ('CfgRegionOffset',                c_uint32),
+        ('CfgRegionSize',                  c_uint32),
+        ('Reserved2',                      c_uint32),
+        ('TempRamInitEntryOffset',         c_uint32),
+        ('Reserved3',                      c_uint32),
+        ('NotifyPhaseEntryOffset',         c_uint32),
+        ('FspMemoryInitEntryOffset',       c_uint32),
+        ('TempRamExitEntryOffset',         c_uint32),
+        ('FspSiliconInitEntryOffset',      c_uint32),
+        ('FspMultiPhaseSiInitEntryOffset', c_uint32),
+        ('ExtendedImageRevision',          c_uint16),
+        ('Reserved4',                      c_uint16)
     ]
 
 class FSP_PATCH_TABLE(Structure):
@@ -390,7 +393,26 @@ def OutputStruct (obj, indent = 0, plen = 0):
             if IsStrType (val):
                 rep = HandleNameStr (val)
             elif IsIntegerType (val):
-                rep = '0x%X' % val
+                if (key == 'ImageRevision'):
+                    FspImageRevisionMajor       = ((val >> 24) & 0xFF)
+                    FspImageRevisionMinor       = ((val >> 16) & 0xFF)
+                    FspImageRevisionRevision    = ((val >> 8) & 0xFF)
+                    FspImageRevisionBuildNumber = (val & 0xFF)
+                    rep = '0x%08X' % val
+                elif (key == 'ExtendedImageRevision'):
+                    FspImageRevisionRevision    |= (val & 0xFF00)
+                    FspImageRevisionBuildNumber |= ((val << 8) & 0xFF00)
+                    rep = "0x%04X ('%02X.%02X.%04X.%04X')" % (val, FspImageRevisionMajor, FspImageRevisionMinor, FspImageRevisionRevision, FspImageRevisionBuildNumber)
+                elif field[1] == c_uint64:
+                    rep = '0x%016X' % val
+                elif field[1] == c_uint32:
+                    rep = '0x%08X' % val
+                elif field[1] == c_uint16:
+                    rep = '0x%04X' % val
+                elif field[1] == c_uint8:
+                    rep = '0x%02X' % val
+                else:
+                    rep = '0x%X' % val
             elif isinstance(val, c_uint24):
                 rep = '0x%X' % val.get_value()
             elif 'c_ubyte_Array' in str(type(val)):


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3705

FSP 2.3 has updated FSP_INFO_HEADER to support ExtendedImageRevision
and SplitFspBin.py needs to support it.

Also updated script to display integer value basing on length.

Cc: Maurice Ma <maurice.ma@intel.com>
Cc: Nate DeSimone <nathaniel.l.desimone@intel.com>
Cc: Star Zeng <star.zeng@intel.com>
Signed-off-by: Chasel Chiu <chasel.chiu@intel.com>
Reviewed-by: Maurice Ma <maurice.ma@intel.com>
Reviewed-by: Nate DeSimone <nathaniel.l.desimone@intel.com>
Reviewed-by: Star Zeng <star.zeng@intel.com>