### PR TITLE
MdePkg Cpuid.h: Define CPUID.(EAX=7,ECX=0):EDX[30]

### DIFF
--- a/MdePkg/Include/Register/Intel/Cpuid.h
+++ b/MdePkg/Include/Register/Intel/Cpuid.h
@@ -1587,9 +1587,9 @@ typedef union {
     ///
     UINT32  EnumeratesSupportForCapability:1;
     ///
-    /// [Bit 30] Reserved.
+    /// [Bit 30] Enumerates support for the IA32_CORE_CAPABILITIES MSR.
     ///
-    UINT32  Reserved3:1;
+    UINT32  EnumeratesSupportForCoreCapabilitiesMsr:1;
     ///
     /// [Bit 31] Enumerates support for Speculative Store Bypass Disable (SSBD).
     /// Processors that set this bit sup-port the IA32_SPEC_CTRL MSR. They allow


### PR DESCRIPTION
This patch follows new Intel SDM to define CPUID.(EAX=7,ECX=0):EDX[30].

Signed-off-by: Star Zeng <star.zeng@intel.com>
Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Zhiguang Liu <zhiguang.liu@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>
Reviewed-by: Ray Ni <ray.ni@intel.com>