### PR TITLE
SecurityPkg/FvReportPei: Remove the ASSERT to allow neither M nor V

### DIFF
--- a/SecurityPkg/FvReportPei/FvReportPei.c
+++ b/SecurityPkg/FvReportPei/FvReportPei.c
@@ -150,10 +150,12 @@ VerifyHashedFv (
   FvHashValue = HashValue;
   for (FvIndex = 0; FvIndex < FvNumber; ++FvIndex) {
     //
-    // FV must be meant for verified boot and/or measured boot.
+    // Not meant for verified boot and/or measured boot?
     //
-    ASSERT ((FvInfo[FvIndex].Flag & HASHED_FV_FLAG_VERIFIED_BOOT) != 0 ||
-            (FvInfo[FvIndex].Flag & HASHED_FV_FLAG_MEASURED_BOOT) != 0);
+    if ((FvInfo[FvIndex].Flag & HASHED_FV_FLAG_VERIFIED_BOOT) == 0 &&
+          (FvInfo[FvIndex].Flag & HASHED_FV_FLAG_MEASURED_BOOT) == 0) {
+      continue;
+    }
 
     //
     // Skip any FV not meant for current boot mode.


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=2673

M mean that Measured Boot, V mean that Verified Boot.

The FvReport do below:
1. Do nothing if neither M nor V
2. Allocate pages to save the firmware volume and use it to install
   firmware info Ppi
3. Install PreHashFv Ppi if the FV need measurement.
4. Verify the Hash if the FV need verification

Notes:
1. The component is used to verify the FV or measure the FV
2. Copy action is just for security purpose but not main purpose.
3. If you use this component, Doesn't need to copy in other compoent
   which result time consumption.

Signed-off-by: Guomin Jiang <guomin.jiang@intel.com>
Reviewed-by: Jian J Wang <jian.j.wang@intel.com>