### PR TITLE
BaseTools/VrfCompile: Fix uninitialized field from unnamed field

### DIFF
--- a/BaseTools/Source/C/VfrCompile/VfrUtilityLib.cpp
+++ b/BaseTools/Source/C/VfrCompile/VfrUtilityLib.cpp
@@ -1135,6 +1135,8 @@ CVfrVarDataTypeDB::DataTypeAddBitField (
   if (FieldName != NULL) {
     strncpy (pNewField->mFieldName, FieldName, MAX_NAME_LEN - 1);
     pNewField->mFieldName[MAX_NAME_LEN - 1] = 0;
+  } else {
+    strncpy (pNewField->mFieldName, "", MAX_NAME_LEN - 1);
   }
   pNewField->mFieldType    = pFieldType;
   pNewField->mIsBitField   = TRUE;
@@ -3916,5 +3918,3 @@ CVfrStringDB::GetUnicodeStringTextSize (
 CVfrVarDataTypeDB gCVfrVarDataTypeDB;
 CVfrDefaultStore  gCVfrDefaultStore;
 CVfrDataStorage  gCVfrDataStorage;
-
-


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3687

If a C structure parsed by the VFR compiler contains an unnamed
field, then mFieldName is left uninitialized, which generates
random data in the VFR compiler output file.

If the FieldName is NULL, then initialize pNewField->mFieldName
to a Null-terminated empty string.

Cc: Bob Feng <bob.c.feng@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Yuwei Chen <yuwei.chen@intel.com>
Signed-off-by: Michael D Kinney <michael.d.kinney@intel.com>