### PR TITLE
Bug 3688 reproduce builds across source format changes v2

### DIFF
--- a/ArmPkg/Universal/Smbios/ProcessorSubClassDxe/ProcessorSubClass.c
+++ b/ArmPkg/Universal/Smbios/ProcessorSubClassDxe/ProcessorSubClass.c
@@ -689,7 +689,7 @@ AddSmbiosProcessorTypeTable (
 
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "[%a]:[%dL] Smbios Type04 Table Log Failed! %r \n",
-            __FUNCTION__, __LINE__, Status));
+            __FUNCTION__, DEBUG_LINE_NUMBER, Status));
   }
   FreePool (Type4Record);
 

--- a/ArmPkg/Universal/Smbios/SmbiosMiscDxe/Type00/MiscBiosVendorFunction.c
+++ b/ArmPkg/Universal/Smbios/SmbiosMiscDxe/Type00/MiscBiosVendorFunction.c
@@ -271,7 +271,7 @@ SMBIOS_MISC_TABLE_FUNCTION (MiscBiosVendor)
   Status = SmbiosMiscAddRecord ((UINT8*)SmbiosRecord, NULL);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "[%a]:[%dL] Smbios Type00 Table Log Failed! %r \n",
-           __FUNCTION__, __LINE__, Status));
+           __FUNCTION__, DEBUG_LINE_NUMBER, Status));
   }
 
   FreePool (SmbiosRecord);

--- a/ArmPkg/Universal/Smbios/SmbiosMiscDxe/Type01/MiscSystemManufacturerFunction.c
+++ b/ArmPkg/Universal/Smbios/SmbiosMiscDxe/Type01/MiscSystemManufacturerFunction.c
@@ -162,7 +162,7 @@ SMBIOS_MISC_TABLE_FUNCTION(MiscSystemManufacturer)
   Status = SmbiosMiscAddRecord ((UINT8*)SmbiosRecord, NULL);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "[%a]:[%dL] Smbios Type01 Table Log Failed! %r \n",
-            __FUNCTION__, __LINE__, Status));
+            __FUNCTION__, DEBUG_LINE_NUMBER, Status));
   }
 
   FreePool (SmbiosRecord);

--- a/ArmPkg/Universal/Smbios/SmbiosMiscDxe/Type02/MiscBaseBoardManufacturerFunction.c
+++ b/ArmPkg/Universal/Smbios/SmbiosMiscDxe/Type02/MiscBaseBoardManufacturerFunction.c
@@ -196,7 +196,7 @@ SMBIOS_MISC_TABLE_FUNCTION(MiscBaseBoardManufacturer)
   Status = SmbiosMiscAddRecord ((UINT8 *)SmbiosRecord, NULL);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "[%a]:[%dL] Smbios Type02 Table Log Failed! %r \n",
-            __FUNCTION__, __LINE__, Status));
+            __FUNCTION__, DEBUG_LINE_NUMBER, Status));
   }
 
   FreePool (SmbiosRecord);

--- a/ArmPkg/Universal/Smbios/SmbiosMiscDxe/Type03/MiscChassisManufacturerFunction.c
+++ b/ArmPkg/Universal/Smbios/SmbiosMiscDxe/Type03/MiscChassisManufacturerFunction.c
@@ -178,7 +178,7 @@ SMBIOS_MISC_TABLE_FUNCTION(MiscChassisManufacturer)
   Status = SmbiosMiscAddRecord ((UINT8*)SmbiosRecord, NULL);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "[%a]:[%dL] Smbios Type03 Table Log Failed! %r \n",
-            __FUNCTION__, __LINE__, Status));
+            __FUNCTION__, DEBUG_LINE_NUMBER, Status));
   }
 
   FreePool (SmbiosRecord);

--- a/ArmPkg/Universal/Smbios/SmbiosMiscDxe/Type13/MiscNumberOfInstallableLanguagesFunction.c
+++ b/ArmPkg/Universal/Smbios/SmbiosMiscDxe/Type13/MiscNumberOfInstallableLanguagesFunction.c
@@ -158,7 +158,7 @@ SMBIOS_MISC_TABLE_FUNCTION(MiscNumberOfInstallableLanguages)
   Status = SmbiosMiscAddRecord ((UINT8*)SmbiosRecord, NULL);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "[%a]:[%dL] Smbios Type13 Table Log Failed! %r \n",
-            __FUNCTION__, __LINE__, Status));
+            __FUNCTION__, DEBUG_LINE_NUMBER, Status));
   }
 
   FreePool (SmbiosRecord);

--- a/ArmPkg/Universal/Smbios/SmbiosMiscDxe/Type32/MiscBootInformationFunction.c
+++ b/ArmPkg/Universal/Smbios/SmbiosMiscDxe/Type32/MiscBootInformationFunction.c
@@ -68,7 +68,7 @@ SMBIOS_MISC_TABLE_FUNCTION(MiscBootInformation)
   Status = SmbiosMiscAddRecord ((UINT8*)SmbiosRecord, NULL);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "[%a]:[%dL] Smbios Type32 Table Log Failed! %r \n",
-            __FUNCTION__, __LINE__, Status));
+            __FUNCTION__, DEBUG_LINE_NUMBER, Status));
   }
 
   FreePool (SmbiosRecord);

--- a/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostBridge.c
+++ b/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostBridge.c
@@ -874,7 +874,7 @@ NotifyPhase (
           Translation = GetTranslationByResourceType (RootBridge, Index);
           if ((Translation & Alignment) != 0) {
             DEBUG ((DEBUG_ERROR, "[%a:%d] Translation %lx is not aligned to %lx!\n",
-              __FUNCTION__, __LINE__, Translation, Alignment
+              __FUNCTION__, DEBUG_LINE_NUMBER, Translation, Alignment
               ));
             ASSERT ((Translation & Alignment) == 0);
             //

--- a/MdeModulePkg/Library/UefiBootManagerLib/BmDriverHealth.c
+++ b/MdeModulePkg/Library/UefiBootManagerLib/BmDriverHealth.c
@@ -574,7 +574,7 @@ BmRepairAllControllers (
       BmRepairAllControllers (ReconnectRepairCount + 1);
     } else {
       DEBUG ((DEBUG_ERROR, "[%a:%d] Repair failed after %d retries.\n",
-        __FUNCTION__, __LINE__, ReconnectRepairCount));
+        __FUNCTION__, DEBUG_LINE_NUMBER, ReconnectRepairCount));
     }
   }
 

--- a/MdePkg/Include/Library/DebugLib.h
+++ b/MdePkg/Include/Library/DebugLib.h
@@ -71,6 +71,41 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #define EFI_D_VERBOSE   DEBUG_VERBOSE
 #define EFI_D_ERROR     DEBUG_ERROR
 
+//
+// Source file line number.
+// Default is use the to compiler provided __LINE__ macro value. The __LINE__
+// mapping can be overriden by predefining DEBUG_LINE_NUMBER
+//
+// Defining DEBUG_LINE_NUMBER to a fixed value is useful when comparing builds
+// across source code formatting changes that may add/remove lines in a source
+// file.
+//
+#ifdef DEBUG_LINE_NUMBER
+#else
+#define DEBUG_LINE_NUMBER  __LINE__
+#endif
+
+/**
+  Macro that converts a Boolean expression to a Null-terminated ASCII string.
+
+  The default is to use the C pre-processor stringizing operator '#' to add
+  quotes around the C expression. If DEBUG_EXPRESSION_STRING_VALUE is defined
+  then the C expression is converted to the fixed string value.
+
+  Defining DEBUG_EXPRESSION_STRING_VALUE to a fixed value is useful when
+  comparing builds across source code formatting changes that may make
+  changes to spaces or parenthesis in a Boolean expression.
+
+  @param  Expression  Boolean expression.
+
+**/
+
+#ifdef DEBUG_EXPRESSION_STRING_VALUE
+#define DEBUG_EXPRESSION_STRING(Expression)  DEBUG_EXPRESSION_STRING_VALUE
+#else
+#define DEBUG_EXPRESSION_STRING(Expression)  #Expression
+#endif
+
 /**
   Prints a debug message to the debug output device if the specified error level is enabled.
 
@@ -310,15 +345,15 @@ UnitTestDebugAssert (
   );
 
 #if defined(__clang__) && defined(__FILE_NAME__)
-#define _ASSERT(Expression)  UnitTestDebugAssert (__FILE_NAME__, __LINE__, #Expression)
+#define _ASSERT(Expression)  UnitTestDebugAssert (__FILE_NAME__, DEBUG_LINE_NUMBER, DEBUG_EXPRESSION_STRING (Expression))
 #else
-#define _ASSERT(Expression)  UnitTestDebugAssert (__FILE__, __LINE__, #Expression)
+#define _ASSERT(Expression)  UnitTestDebugAssert (__FILE__, DEBUG_LINE_NUMBER, DEBUG_EXPRESSION_STRING (Expression))
 #endif
 #else
 #if defined(__clang__) && defined(__FILE_NAME__)
-#define _ASSERT(Expression)  DebugAssert (__FILE_NAME__, __LINE__, #Expression)
+#define _ASSERT(Expression)  DebugAssert (__FILE_NAME__, DEBUG_LINE_NUMBER, DEBUG_EXPRESSION_STRING (Expression))
 #else
-#define _ASSERT(Expression)  DebugAssert (__FILE__, __LINE__, #Expression)
+#define _ASSERT(Expression)  DebugAssert (__FILE__, DEBUG_LINE_NUMBER, DEBUG_EXPRESSION_STRING (Expression))
 #endif
 #endif
 

--- a/MdePkg/Include/Library/UnitTestLib.h
+++ b/MdePkg/Include/Library/UnitTestLib.h
@@ -347,9 +347,9 @@ SaveFrameworkState (
 
   @param[in]  Expression  Expression to be evaluated for TRUE.
 **/
-#define UT_ASSERT_TRUE(Expression)                                                        \
-  if(!UnitTestAssertTrue ((Expression), __FUNCTION__, __LINE__, __FILE__, #Expression)) { \
-    return UNIT_TEST_ERROR_TEST_FAILED;                                                   \
+#define UT_ASSERT_TRUE(Expression)                                                                 \
+  if(!UnitTestAssertTrue ((Expression), __FUNCTION__, DEBUG_LINE_NUMBER, __FILE__, #Expression)) { \
+    return UNIT_TEST_ERROR_TEST_FAILED;                                                            \
   }
 
 /**
@@ -359,9 +359,9 @@ SaveFrameworkState (
 
   @param[in]  Expression  Expression to be evaluated for FALSE.
 **/
-#define UT_ASSERT_FALSE(Expression)                                                        \
-  if(!UnitTestAssertFalse ((Expression), __FUNCTION__, __LINE__, __FILE__, #Expression)) { \
-    return UNIT_TEST_ERROR_TEST_FAILED;                                                    \
+#define UT_ASSERT_FALSE(Expression)                                                                 \
+  if(!UnitTestAssertFalse ((Expression), __FUNCTION__, DEBUG_LINE_NUMBER, __FILE__, #Expression)) { \
+    return UNIT_TEST_ERROR_TEST_FAILED;                                                             \
   }
 
 /**
@@ -373,7 +373,7 @@ SaveFrameworkState (
   @param[in]  ValueB  Value to be compared for equality (64-bit comparison).
 **/
 #define UT_ASSERT_EQUAL(ValueA, ValueB)                                                                           \
-  if(!UnitTestAssertEqual ((UINT64)(ValueA), (UINT64)(ValueB), __FUNCTION__, __LINE__, __FILE__, #ValueA, #ValueB)) { \
+  if(!UnitTestAssertEqual ((UINT64)(ValueA), (UINT64)(ValueB), __FUNCTION__, DEBUG_LINE_NUMBER, __FILE__, #ValueA, #ValueB)) { \
     return UNIT_TEST_ERROR_TEST_FAILED;                                                                           \
   }
 
@@ -386,9 +386,9 @@ SaveFrameworkState (
   @param[in]  BufferB  Pointer to a buffer for comparison.
   @param[in]  Length   Number of bytes to compare in BufferA and BufferB.
 **/
-#define UT_ASSERT_MEM_EQUAL(BufferA, BufferB, Length)                                                                               \
-  if(!UnitTestAssertMemEqual ((VOID *)(UINTN)(BufferA), (VOID *)(UINTN)(BufferB), (UINTN)Length, __FUNCTION__, __LINE__, __FILE__, #BufferA, #BufferB)) { \
-    return UNIT_TEST_ERROR_TEST_FAILED;                                                                                           \
+#define UT_ASSERT_MEM_EQUAL(BufferA, BufferB, Length)                                                                                                              \
+  if(!UnitTestAssertMemEqual ((VOID *)(UINTN)(BufferA), (VOID *)(UINTN)(BufferB), (UINTN)Length, __FUNCTION__, DEBUG_LINE_NUMBER, __FILE__, #BufferA, #BufferB)) { \
+    return UNIT_TEST_ERROR_TEST_FAILED;                                                                                                                            \
   }
 
 /**
@@ -399,9 +399,9 @@ SaveFrameworkState (
   @param[in]  ValueA  Value to be compared for inequality (64-bit comparison).
   @param[in]  ValueB  Value to be compared for inequality (64-bit comparison).
 **/
-#define UT_ASSERT_NOT_EQUAL(ValueA, ValueB)                                                                          \
-  if(!UnitTestAssertNotEqual ((UINT64)(ValueA), (UINT64)(ValueB), __FUNCTION__, __LINE__, __FILE__, #ValueA, #ValueB)) { \
-    return UNIT_TEST_ERROR_TEST_FAILED;                                                                              \
+#define UT_ASSERT_NOT_EQUAL(ValueA, ValueB)                                                                                       \
+  if(!UnitTestAssertNotEqual ((UINT64)(ValueA), (UINT64)(ValueB), __FUNCTION__, DEBUG_LINE_NUMBER, __FILE__, #ValueA, #ValueB)) { \
+    return UNIT_TEST_ERROR_TEST_FAILED;                                                                                           \
   }
 
 /**
@@ -411,9 +411,9 @@ SaveFrameworkState (
 
   @param[in]  Status  EFI_STATUS value to check.
 **/
-#define UT_ASSERT_NOT_EFI_ERROR(Status)                                                \
-  if(!UnitTestAssertNotEfiError ((Status), __FUNCTION__, __LINE__, __FILE__, #Status)) { \
-    return UNIT_TEST_ERROR_TEST_FAILED;                                                \
+#define UT_ASSERT_NOT_EFI_ERROR(Status)                                                           \
+  if(!UnitTestAssertNotEfiError ((Status), __FUNCTION__, DEBUG_LINE_NUMBER, __FILE__, #Status)) { \
+    return UNIT_TEST_ERROR_TEST_FAILED;                                                           \
   }
 
 /**
@@ -424,9 +424,9 @@ SaveFrameworkState (
   @param[in]  Status    EFI_STATUS values to compare for equality.
   @param[in]  Expected  EFI_STATUS values to compare for equality.
 **/
-#define UT_ASSERT_STATUS_EQUAL(Status, Expected)                                                 \
-  if(!UnitTestAssertStatusEqual ((Status), (Expected), __FUNCTION__, __LINE__, __FILE__, #Status)) { \
-    return UNIT_TEST_ERROR_TEST_FAILED;                                                          \
+#define UT_ASSERT_STATUS_EQUAL(Status, Expected)                                                              \
+  if(!UnitTestAssertStatusEqual ((Status), (Expected), __FUNCTION__, DEBUG_LINE_NUMBER, __FILE__, #Status)) { \
+    return UNIT_TEST_ERROR_TEST_FAILED;                                                                       \
   }
 
 /**
@@ -436,9 +436,9 @@ SaveFrameworkState (
 
   @param[in]  Pointer  Pointer to be checked against NULL.
 **/
-#define UT_ASSERT_NOT_NULL(Pointer)                                                  \
-  if(!UnitTestAssertNotNull ((Pointer), __FUNCTION__, __LINE__, __FILE__, #Pointer)) { \
-    return UNIT_TEST_ERROR_TEST_FAILED;                                              \
+#define UT_ASSERT_NOT_NULL(Pointer)                                                             \
+  if(!UnitTestAssertNotNull ((Pointer), __FUNCTION__, DEBUG_LINE_NUMBER, __FILE__, #Pointer)) { \
+    return UNIT_TEST_ERROR_TEST_FAILED;                                                         \
   }
 
 /**
@@ -482,7 +482,7 @@ SaveFrameworkState (
       }                                                                \
       if (!UnitTestExpectAssertFailure (                               \
              UnitTestJumpStatus,                                       \
-             __FUNCTION__, __LINE__, __FILE__,                         \
+             __FUNCTION__, DEBUG_LINE_NUMBER, __FILE__,                \
              #FunctionCall, Status)) {                                 \
         return UNIT_TEST_ERROR_TEST_FAILED;                            \
       }                                                                \

--- a/MdePkg/Library/BaseLib/SafeString.c
+++ b/MdePkg/Library/BaseLib/SafeString.c
@@ -17,7 +17,7 @@
     if (!(Expression)) { \
       DEBUG ((DEBUG_VERBOSE, \
         "%a(%d) %a: SAFE_STRING_CONSTRAINT_CHECK(%a) failed.  Return %r\n", \
-        __FILE__, __LINE__, __FUNCTION__, #Expression, Status)); \
+        __FILE__, DEBUG_LINE_NUMBER, __FUNCTION__, DEBUG_EXPRESSION_STRING (Expression), Status)); \
       return Status; \
     } \
   } while (FALSE)

--- a/NetworkPkg/Include/Library/NetLib.h
+++ b/NetworkPkg/Include/Library/NetLib.h
@@ -277,7 +277,7 @@ typedef struct {
     NETDEBUG_LEVEL_TRACE, \
     Module, \
     __FILE__, \
-    __LINE__, \
+    DEBUG_LINE_NUMBER, \
     NetDebugASPrint PrintArg \
     )
 
@@ -286,7 +286,7 @@ typedef struct {
     NETDEBUG_LEVEL_WARNING, \
     Module, \
     __FILE__, \
-    __LINE__, \
+    DEBUG_LINE_NUMBER, \
     NetDebugASPrint PrintArg \
     )
 
@@ -295,7 +295,7 @@ typedef struct {
     NETDEBUG_LEVEL_ERROR, \
     Module, \
     __FILE__, \
-    __LINE__, \
+    DEBUG_LINE_NUMBER, \
     NetDebugASPrint PrintArg \
     )
 
@@ -311,7 +311,7 @@ typedef struct {
            NETDEBUG_LEVEL_TRACE,
            "Tcp",
            __FILE__,
-           __LINE__,
+           DEBUG_LINE_NUMBER,
            NetDebugASPrint ("State transit to %a\n", Name)
          )
 

--- a/NetworkPkg/Library/DxeNetLib/DxeNetLib.c
+++ b/NetworkPkg/Library/DxeNetLib/DxeNetLib.c
@@ -434,7 +434,7 @@ SyslogBuildPacket (
            NETDEBUG_LEVEL_TRACE,
            "Tcp",
            __FILE__,
-           __LINE__,
+           DEBUG_LINE_NUMBER,
            NetDebugASPrint ("State transit to %a\n", Name)
          )
 

--- a/OvmfPkg/Csm/LegacyBiosDxe/LegacyPci.c
+++ b/OvmfPkg/Csm/LegacyBiosDxe/LegacyPci.c
@@ -2321,7 +2321,7 @@ LegacyBiosInstallRom (
                     );
 
     if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_ERROR, "return LegacyBiosInstallRom(%d): EFI_OUT_OF_RESOURCES (no more space for OpROM)\n", __LINE__));
+      DEBUG ((DEBUG_ERROR, "return LegacyBiosInstallRom(%d): EFI_OUT_OF_RESOURCES (no more space for OpROM)\n", DEBUG_LINE_NUMBER));
       //
       // Report Status Code to indicate that there is no enough space for OpROM
       //
@@ -2337,7 +2337,7 @@ LegacyBiosInstallRom (
     //
     RuntimeAddress = Private->OptionRom;
     if (RuntimeAddress + *RuntimeImageLength > MaxRomAddr) {
-      DEBUG ((DEBUG_ERROR, "return LegacyBiosInstallRom(%d): EFI_OUT_OF_RESOURCES (no more space for OpROM)\n", __LINE__));
+      DEBUG ((DEBUG_ERROR, "return LegacyBiosInstallRom(%d): EFI_OUT_OF_RESOURCES (no more space for OpROM)\n", DEBUG_LINE_NUMBER));
       gBS->FreePages (PhysicalAddress, EFI_SIZE_TO_PAGES (ImageSize));
       //
       // Report Status Code to indicate that there is no enough space for OpROM
@@ -2355,7 +2355,7 @@ LegacyBiosInstallRom (
     //
     InitAddress    = PCI_START_ADDRESS (Private->OptionRom);
     if (InitAddress + ImageSize > MaxRomAddr) {
-      DEBUG ((DEBUG_ERROR, "return LegacyBiosInstallRom(%d): EFI_OUT_OF_RESOURCES (no more space for OpROM)\n", __LINE__));
+      DEBUG ((DEBUG_ERROR, "return LegacyBiosInstallRom(%d): EFI_OUT_OF_RESOURCES (no more space for OpROM)\n", DEBUG_LINE_NUMBER));
       //
       // Report Status Code to indicate that there is no enough space for OpROM
       //

--- a/OvmfPkg/Library/PlatformBootManagerLib/BdsPlatform.c
+++ b/OvmfPkg/Library/PlatformBootManagerLib/BdsPlatform.c
@@ -624,7 +624,7 @@ PrepareLpcBridgeDevicePath (
     DEBUG((
       DEBUG_INFO,
       "BdsPlatform.c+%d: COM%d DevPath: %s\n",
-      __LINE__,
+      DEBUG_LINE_NUMBER,
       gPnp16550ComPortDeviceNode.UID + 1,
       DevPathStr
       ));
@@ -656,7 +656,7 @@ PrepareLpcBridgeDevicePath (
     DEBUG((
       DEBUG_INFO,
       "BdsPlatform.c+%d: COM%d DevPath: %s\n",
-      __LINE__,
+      DEBUG_LINE_NUMBER,
       gPnp16550ComPortDeviceNode.UID + 1,
       DevPathStr
       ));

--- a/OvmfPkg/Library/PlatformBootManagerLibBhyve/BdsPlatform.c
+++ b/OvmfPkg/Library/PlatformBootManagerLibBhyve/BdsPlatform.c
@@ -586,7 +586,7 @@ PrepareLpcBridgeDevicePath (
     DEBUG((
       DEBUG_INFO,
       "BdsPlatform.c+%d: COM%d DevPath: %s\n",
-      __LINE__,
+      DEBUG_LINE_NUMBER,
       gPnp16550ComPortDeviceNode.UID + 1,
       DevPathStr
       ));

--- a/OvmfPkg/Library/PlatformBootManagerLibGrub/BdsPlatform.c
+++ b/OvmfPkg/Library/PlatformBootManagerLibGrub/BdsPlatform.c
@@ -556,7 +556,7 @@ PrepareLpcBridgeDevicePath (
     DEBUG((
       DEBUG_INFO,
       "BdsPlatform.c+%d: COM%d DevPath: %s\n",
-      __LINE__,
+      DEBUG_LINE_NUMBER,
       gPnp16550ComPortDeviceNode.UID + 1,
       DevPathStr
       ));
@@ -588,7 +588,7 @@ PrepareLpcBridgeDevicePath (
     DEBUG((
       DEBUG_INFO,
       "BdsPlatform.c+%d: COM%d DevPath: %s\n",
-      __LINE__,
+      DEBUG_LINE_NUMBER,
       gPnp16550ComPortDeviceNode.UID + 1,
       DevPathStr
       ));

--- a/SecurityPkg/Include/Library/TcgStorageCoreLib.h
+++ b/SecurityPkg/Include/Library/TcgStorageCoreLib.h
@@ -16,13 +16,13 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #include <IndustryStandard/TcgStorageCore.h>
 
-#define ERROR_CHECK(arg)                                                         \
-  {                                                                              \
-    TCG_RESULT ret = (arg);                                                      \
-    if (ret != TcgResultSuccess) {                                               \
-      DEBUG ((DEBUG_INFO, "ERROR_CHECK failed at %a:%u\n", __FILE__, __LINE__)); \
-      return ret;                                                                \
-    }                                                                            \
+#define ERROR_CHECK(arg)                                                                  \
+  {                                                                                       \
+    TCG_RESULT ret = (arg);                                                               \
+    if (ret != TcgResultSuccess) {                                                        \
+      DEBUG ((DEBUG_INFO, "ERROR_CHECK failed at %a:%u\n", __FILE__, DEBUG_LINE_NUMBER)); \
+      return ret;                                                                         \
+    }                                                                                     \
   }
 
 #define METHOD_STATUS_ERROR_CHECK(arg, failRet)                                                  \
@@ -31,12 +31,12 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
     return (failRet);                                                                            \
   }
 
-#define NULL_CHECK(arg)                                                                   \
-  do {                                                                                    \
-    if ((arg) == NULL) {                                                                  \
-      DEBUG ((DEBUG_INFO, "NULL_CHECK(%a) failed at %a:%u\n", #arg, __FILE__, __LINE__)); \
-      return TcgResultFailureNullPointer;                                                 \
-    }                                                                                     \
+#define NULL_CHECK(arg)                                                                            \
+  do {                                                                                             \
+    if ((arg) == NULL) {                                                                           \
+      DEBUG ((DEBUG_INFO, "NULL_CHECK(%a) failed at %a:%u\n", #arg, __FILE__, DEBUG_LINE_NUMBER)); \
+      return TcgResultFailureNullPointer;                                                          \
+    }                                                                                              \
   } while (0)
 
 #pragma pack(1)


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3688

New in V2
=======
* Split MdePkg DebugLib class enhancements out into its own commit
* Address ECC failures
* Align macro continuation marks in same column

This change is required to help verify that source code formatting
changes such as the use of uncrustify and line ending corrections
do not have any functional differences.  Source format changes may
add or remove line endings that change the source file line numbers
of C statements or may change the use of spaces in C expressions 
used in an ASSERT() statements.  These types of changes can impact
the generated binaries when DEBUG() and ASSERT() macros are 
enabled.  The following set of changes adds 2 defines that can be used
to override the use of `__LINE__` in DEBUG() macros and the use of
#Expression in ASSERT() macros.

* Add DEBUG_LINE_NUMBER define to DebugLib.h that is
  by default mapped to `__LINE__`.  A build can pre-define
  DEBUG_LINE_NUMBER to use a fixed value.
* Add DEBUG_EXPRESSION_STRING(Expression) macros to
  DebugLib.h that is by default mapped to #Expression.
  A build can define DEBUG_EXPRESSION_STRING_VALUE to
  set all expression strings to a fixed string value.
* Use DEBUG_LINE_NUMBER instead of `__LINE__`.
* Use DEBUG_EXPRESSION_STRING instead of #Expression.

Submodules that use `__LINE__` are not updated.  These do not
currently impact build reproducibility unless the debug features
of those submodules are enabled.

The one exception is the UnitTestFrameworkPkg cmocka submodule
that uses `__LINE__`.  This means that the binaries generated by host
based unit tests that use cmocka features may not be identical across
a source format change.

Cc: Ard Biesheuvel <ardb+tianocore@kernel.org>
Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Jordan Justen <jordan.l.justen@intel.com>
Cc: Gerd Hoffmann <kraxel@redhat.com>
Cc: Michael Kubacki <michael.kubacki@microsoft.com>
Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Maciej Rabeda <maciej.rabeda@linux.intel.com>
Cc: Jiaxin Wu <jiaxin.wu@intel.com>
Cc: Siyuan Fu <siyuan.fu@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Leif Lindholm <leif@nuviainc.com>
Cc: Zhiguang Liu <zhiguang.liu@intel.com>
Signed-off-by: Michael D Kinney <michael.d.kinney@intel.com>