### PR TITLE
[Patch V2 0/7] Fix package build issues

### DIFF
--- a/DynamicTablesPkg/DynamicTablesPkg.dsc
+++ b/DynamicTablesPkg/DynamicTablesPkg.dsc
@@ -35,6 +35,7 @@
 
 [LibraryClasses.ARM, LibraryClasses.AARCH64]
   NULL|ArmPkg/Library/CompilerIntrinsicsLib/CompilerIntrinsicsLib.inf
+  NULL|MdePkg/Library/BaseStackCheckLib/BaseStackCheckLib.inf
   PL011UartLib|ArmPlatformPkg/Library/PL011UartLib/PL011UartLib.inf
 
 [Components.common]
@@ -51,4 +52,3 @@
   # Inhibit C6305: Potential mismatch between sizeof and countof quantities.
   *_VS2017_*_CC_FLAGS = /wd6305 /analyze
 !endif
-

--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/RuntimeDxeUnitTest/VariableLockRequestToLockUnitTest.c
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/RuntimeDxeUnitTest/VariableLockRequestToLockUnitTest.c
@@ -287,7 +287,7 @@ LockingAnUnlockedVariableShouldFail (
   // With a policy, make sure that writes still work, since the variable doesn't exist.
   will_return( StubGetVariableNull, TEST_POLICY_ATTRIBUTES_NULL );    // Attributes
   will_return( StubGetVariableNull, 0 );                              // Size
-  will_return( StubGetVariableNull, NULL );                           // DataPtr
+  will_return( StubGetVariableNull, (UINTN)NULL );                    // DataPtr
   will_return( StubGetVariableNull, EFI_NOT_FOUND);                   // Status
 
   Status = VariableLockRequestToLock (NULL, TEST_VAR_1_NAME, &mTestGuid1);
@@ -342,7 +342,7 @@ LockingALockedVariableWithMatchingDataShouldSucceed (
   Data = 1;
   will_return( StubGetVariableNull, TEST_POLICY_ATTRIBUTES_NULL );    // Attributes
   will_return( StubGetVariableNull, sizeof (Data) );                  // Size
-  will_return( StubGetVariableNull, &Data );                          // DataPtr
+  will_return( StubGetVariableNull, (UINTN)&Data );                   // DataPtr
   will_return( StubGetVariableNull, EFI_SUCCESS);                     // Status
 
   Status = VariableLockRequestToLock (NULL, TEST_VAR_1_NAME, &mTestGuid1);
@@ -397,7 +397,7 @@ LockingALockedVariableWithNonMatchingDataShouldFail (
   Data = 2;
   will_return( StubGetVariableNull, TEST_POLICY_ATTRIBUTES_NULL );    // Attributes
   will_return( StubGetVariableNull, sizeof (Data) );                  // Size
-  will_return( StubGetVariableNull, &Data );                          // DataPtr
+  will_return( StubGetVariableNull, (UINTN)&Data );                   // DataPtr
   will_return( StubGetVariableNull, EFI_SUCCESS);                     // Status
 
   Status = VariableLockRequestToLock (NULL, TEST_VAR_1_NAME, &mTestGuid1);

--- a/NetworkPkg/NetworkPkg.dsc
+++ b/NetworkPkg/NetworkPkg.dsc
@@ -79,6 +79,12 @@
   NULL|MdePkg/Library/BaseStackCheckLib/BaseStackCheckLib.inf
   ArmSoftFloatLib|ArmPkg/Library/ArmSoftFloatLib/ArmSoftFloatLib.inf
 
+[LibraryClasses.ARM]
+  RngLib|MdePkg/Library/BaseRngLibTimerLib/BaseRngLibTimerLib.inf
+
+[LibraryClasses.RISCV64]
+  RngLib|MdePkg/Library/BaseRngLibTimerLib/BaseRngLibTimerLib.inf
+
 [PcdsFeatureFlag]
   gEfiMdePkgTokenSpaceGuid.PcdComponentName2Disable|TRUE
   gEfiMdePkgTokenSpaceGuid.PcdDriverDiagnostics2Disable|TRUE

--- a/SecurityPkg/SecurityPkg.dsc
+++ b/SecurityPkg/SecurityPkg.dsc
@@ -84,6 +84,14 @@
   # Add support for GCC stack protector
   NULL|MdePkg/Library/BaseStackCheckLib/BaseStackCheckLib.inf
 
+  ArmSoftFloatLib|ArmPkg/Library/ArmSoftFloatLib/ArmSoftFloatLib.inf
+
+[LibraryClasses.ARM]
+  RngLib|MdePkg/Library/BaseRngLibTimerLib/BaseRngLibTimerLib.inf
+
+[LibraryClasses.RISCV64]
+  RngLib|MdePkg/Library/BaseRngLibTimerLib/BaseRngLibTimerLib.inf
+
 [LibraryClasses.common.PEIM]
   PeimEntryPoint|MdePkg/Library/PeimEntryPoint/PeimEntryPoint.inf
   PeiServicesLib|MdePkg/Library/PeiServicesLib/PeiServicesLib.inf
@@ -381,4 +389,3 @@
    MSFT:*_*_IA32_DLINK_FLAGS = /ALIGN:256
   INTEL:*_*_IA32_DLINK_FLAGS = /ALIGN:256
         *_*_*_CC_FLAGS       = -D DISABLE_NEW_DEPRECATED_INTERFACES
-

--- a/SignedCapsulePkg/SignedCapsulePkg.dsc
+++ b/SignedCapsulePkg/SignedCapsulePkg.dsc
@@ -93,6 +93,7 @@
   EdkiiSystemCapsuleLib|SignedCapsulePkg/Library/EdkiiSystemCapsuleLib/EdkiiSystemCapsuleLib.inf
   IniParsingLib|SignedCapsulePkg/Library/IniParsingLib/IniParsingLib.inf
   PlatformFlashAccessLib|SignedCapsulePkg/Library/PlatformFlashAccessLibNull/PlatformFlashAccessLibNull.inf
+  RngLib|MdePkg/Library/BaseRngLib/BaseRngLib.inf
 
 [LibraryClasses.ARM]
   ArmSoftFloatLib|ArmPkg/Library/ArmSoftFloatLib/ArmSoftFloatLib.inf
@@ -107,6 +108,12 @@
 
   # Add support for GCC stack protector
   NULL|MdePkg/Library/BaseStackCheckLib/BaseStackCheckLib.inf
+
+[LibraryClasses.ARM]
+  RngLib|MdePkg/Library/BaseRngLibTimerLib/BaseRngLibTimerLib.inf
+
+[LibraryClasses.RISCV64]
+  RngLib|MdePkg/Library/BaseRngLibTimerLib/BaseRngLibTimerLib.inf
 
 [LibraryClasses.common.PEI_CORE]
   HobLib|MdePkg/Library/PeiHobLib/PeiHobLib.inf

--- a/UefiCpuPkg/Library/MtrrLib/UnitTest/MtrrLibUnitTest.c
+++ b/UefiCpuPkg/Library/MtrrLib/UnitTest/MtrrLibUnitTest.c
@@ -599,7 +599,7 @@ UnitTestMtrrGetFixedMtrr (
     }
 
     Result = MtrrGetFixedMtrr (&FixedSettings);
-    UT_ASSERT_EQUAL (Result, &FixedSettings);
+    UT_ASSERT_EQUAL ((UINTN)Result, (UINTN)&FixedSettings);
     UT_ASSERT_MEM_EQUAL (&FixedSettings, &ExpectedFixedSettings, sizeof (FixedSettings));
   }
 
@@ -612,7 +612,7 @@ UnitTestMtrrGetFixedMtrr (
   ZeroMem (&FixedSettings, sizeof (FixedSettings));
   ZeroMem (&ExpectedFixedSettings, sizeof (ExpectedFixedSettings));
   Result = MtrrGetFixedMtrr (&FixedSettings);
-  UT_ASSERT_EQUAL (Result, &FixedSettings);
+  UT_ASSERT_EQUAL ((UINTN)Result, (UINTN)&FixedSettings);
   UT_ASSERT_MEM_EQUAL (&ExpectedFixedSettings, &FixedSettings, sizeof (ExpectedFixedSettings));
 
   return UNIT_TEST_PASSED;
@@ -653,7 +653,7 @@ UnitTestMtrrGetAllMtrrs (
     AsmWriteMsr64 (MSR_IA32_MTRR_PHYSMASK0 + (Index << 1), VariableMtrr[Index].Mask);
   }
   Result = MtrrGetAllMtrrs (&Mtrrs);
-  UT_ASSERT_EQUAL (Result, &Mtrrs);
+  UT_ASSERT_EQUAL ((UINTN)Result, (UINTN)&Mtrrs);
   UT_ASSERT_MEM_EQUAL (Mtrrs.Variables.Mtrr, VariableMtrr, sizeof (MTRR_VARIABLE_SETTING) * SystemParameter.VariableMtrrCount);
 
   //
@@ -665,7 +665,7 @@ UnitTestMtrrGetAllMtrrs (
   SystemParameter.MtrrSupported = FALSE;
   InitializeMtrrRegs (&SystemParameter);
   Result = MtrrGetAllMtrrs (&Mtrrs);
-  UT_ASSERT_EQUAL (Result, &Mtrrs);
+  UT_ASSERT_EQUAL ((UINTN)Result, (UINTN)&Mtrrs);
   UT_ASSERT_MEM_EQUAL (&ExpectedMtrrs, &Mtrrs, sizeof (ExpectedMtrrs));
 
   //
@@ -718,7 +718,7 @@ UnitTestMtrrSetAllMtrrs (
     GenerateRandomMtrrPair (SystemParameter.PhysicalAddressBits, GenerateRandomCacheType (), &Mtrrs.Variables.Mtrr[Index], NULL);
   }
   Result = MtrrSetAllMtrrs (&Mtrrs);
-  UT_ASSERT_EQUAL (Result, &Mtrrs);
+  UT_ASSERT_EQUAL ((UINTN)Result, (UINTN)&Mtrrs);
 
   UT_ASSERT_EQUAL (AsmReadMsr64 (MSR_IA32_MTRR_DEF_TYPE), Mtrrs.MtrrDefType);
   for (Index = 0; Index < SystemParameter.VariableMtrrCount; Index++) {


### PR DESCRIPTION
This patch series fixes a number of different package build
issues.  These were discovered when evaluating the source
format changes from uncrustify and there where valid
package builds that are not working before applying the
uncrustify changes. 

* Missing RngLib mappings
* Missing ArmSoftFloatLib mapping
* Missing BaseStackCheckLib instance
* Incorrect use of UT_ASSERT_EQUAL() with pointers
* Incorrect use of cmocka will_return*() with pointers

Cc: Hao A Wu <hao.a.wu@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Bret Barkelew <Bret.Barkelew@microsoft.com>
Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Ard Biesheuvel <ardb+tianocore@kernel.org>
Cc: Abner Chang <abner.chang@hpe.com>
Cc: Daniel Schaefer <daniel.schaefer@hpe.com>
Cc: Sami Mujawar <Sami.Mujawar@arm.com>
Cc: Alexei Fedorov <Alexei.Fedorov@arm.com>
Cc: Maciej Rabeda <maciej.rabeda@linux.intel.com>
Cc: Jiaxin Wu <jiaxin.wu@intel.com>
Cc: Siyuan Fu <siyuan.fu@intel.com>
Cc: Eric Dong <eric.dong@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Cc: Rahul Kumar <rahul1.kumar@intel.com>
Cc: Bob Feng <bob.c.feng@intel.com>
Cc: Yuwei Chen <yuwei.chen@intel.com>
Signed-off-by: Michael D Kinney <michael.d.kinney@intel.com>
