### PR TITLE
Don't enforce CRLF & tab check on .git* files

### DIFF
--- a/BaseTools/Scripts/PatchCheck.py
+++ b/BaseTools/Scripts/PatchCheck.py
@@ -374,7 +374,7 @@ class GitDiffCheck:
                     # they are identified by their path.
                     #
                     self.force_crlf = False
-                if self.filename == '.gitmodules' or \
+                if self.filename.startswith('.git') or \
                    self.filename == 'BaseTools/Conf/diff.order':
                     #
                     # .gitmodules and diff orderfiles are used internally by git


### PR DESCRIPTION
Files such as:
  .gitignore
  .gitlab-ci.yml
  .gitmodules
  etc..

Are used internally by git or in the case of .gitlab-ci.yml by GitLab.
Do not enforce no tabs and do not enforce CR/LF line endings.

Signed-off-by: John L. Villalovos <john@sodarock.com>