### PR TITLE
MdeModulePkg/XhciSched: Fix missing DEBUG arguments

### DIFF
--- a/MdeModulePkg/Bus/Pci/XhciDxe/XhciSched.c
+++ b/MdeModulePkg/Bus/Pci/XhciDxe/XhciSched.c
@@ -2299,7 +2299,7 @@ XhcInitializeDeviceSlot (
     DEBUG ((EFI_D_INFO, "    Address %d assigned successfully\n", DeviceAddress));
     Xhc->UsbDevContext[SlotId].XhciDevAddr = DeviceAddress;
   } else {
-    DEBUG ((DEBUG_INFO, "    Address %d assigned unsuccessfully\n"));
+    DEBUG ((DEBUG_ERROR, "    Slot %d address not assigned successfully. Status = %r\n", SlotId, Status));
     XhcDisableSlotCmd (Xhc, SlotId);
   }
 
@@ -2512,7 +2512,7 @@ XhcInitializeDeviceSlot64 (
     DEBUG ((EFI_D_INFO, "    Address %d assigned successfully\n", DeviceAddress));
     Xhc->UsbDevContext[SlotId].XhciDevAddr = DeviceAddress;
   } else {
-    DEBUG ((DEBUG_INFO, "    Address %d assigned unsuccessfully\n"));
+    DEBUG ((DEBUG_ERROR, "    Slot %d address not assigned successfully. Status = %r\n", SlotId, Status));
     XhcDisableSlotCmd64 (Xhc, SlotId);
   }
 


### PR DESCRIPTION
REF:https://bugzilla.tianocore.org/show_bug.cgi?id=3662

Two DEBUG macros in XhciDxe/XhciSched.c are missing the argument
that should be passed for the print specifier.

In addition, this change updates the print level to "DEBUG_ERROR"
and prints the status as well.

Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Hao A Wu <hao.a.wu@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>
Reviewed-by: Hao A Wu <hao.a.wu@intel.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>