### PR TITLE
MdeModulePkg/DxeCapsuleLibFmp: Use new Variable Lock interface

### DIFF
--- a/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleLib.inf
+++ b/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleLib.inf
@@ -3,7 +3,7 @@
 #
 #  Capsule library instance for DXE_DRIVER module types.
 #
-#  Copyright (c) 2016 - 2019, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2016 - 2021, Intel Corporation. All rights reserved.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -51,6 +51,7 @@
   DisplayUpdateProgressLib
   FileHandleLib
   UefiBootManagerLib
+  VariablePolicyHelperLib
 
 [Pcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdCapsuleMax                               ## CONSUMES
@@ -74,11 +75,11 @@
 [Protocols]
   gEsrtManagementProtocolGuid                   ## CONSUMES
   gEfiFirmwareManagementProtocolGuid            ## CONSUMES
-  gEdkiiVariableLockProtocolGuid                ## SOMETIMES_CONSUMES
   gEdkiiFirmwareManagementProgressProtocolGuid  ## SOMETIMES_CONSUMES
   gEfiSimpleFileSystemProtocolGuid              ## SOMETIMES_CONSUMES
   gEfiBlockIoProtocolGuid                       ## CONSUMES
   gEfiDiskIoProtocolGuid                        ## CONSUMES
+  gEdkiiVariablePolicyProtocolGuid              ## CONSUMES
 
 [Guids]
   gEfiFmpCapsuleGuid                      ## SOMETIMES_CONSUMES ## GUID


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3699
The code in MdeModulePkg\Library\DxeCapsuleLibFmp call the deprecated
interface VariableLockRequestToLock.c. So I changed the code in
FmpDevicePkg using RegisterBasicVariablePolicy, instead of the
deprecated interface.

Signed-off-by: Yang Jie <jie.yang@intel.com>
Cc: Guomin Jiang <guomin.jiang@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Jian J Wang <jian.j.wang@intel.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>
Reviewed-by: Jian J Wang <jian.j.wang@intel.com>