### PR TITLE
MdeModulePkg/DxeCapsuleLibFmp: Capsule on Disk file name capsule

### DIFF
--- a/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleLib.inf
+++ b/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleLib.inf
@@ -68,6 +68,9 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdCodRelocationDevPath                     ## SOMETIMES_CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdCoDRelocationFileName                    ## CONSUMES
 
+[FeaturePcd]
+  gEfiMdeModulePkgTokenSpaceGuid.PcdSupportUpdateCapsuleReset ## CONSUMES
+
 [Protocols]
   gEsrtManagementProtocolGuid                   ## CONSUMES
   gEfiFirmwareManagementProtocolGuid            ## CONSUMES


### PR DESCRIPTION
Enhance RelocateCapsuleToRam() to skip creation of the Capsule on Disk
file name capsule if PcdSupportUpdateCapsuleReset feature is not enabled.
This avoids an EFI_UNSUPPORTED return status from UpdateCapsule() when the
file name capsule is encountered and PcdSupportUpdateCapsuleReset is FALSE.

Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Guomin Jiang <guomin.jiang@intel.com>
Signed-off-by: Bob Morgan <bobm@nvidia.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>