### PR TITLE
UefiCpuPkg/UefiCpuLib: Add GetCpuFamilyModel and GetCpuSteppingId

### DIFF
--- a/UefiCpuPkg/Include/Library/UefiCpuLib.h
+++ b/UefiCpuPkg/Include/Library/UefiCpuLib.h
@@ -4,7 +4,7 @@
   This library class defines some routines that are generic for IA32 family CPU
   to be UEFI specification compliant.
 
-  Copyright (c) 2009, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2009 - 2021, Intel Corporation. All rights reserved.<BR>
   Copyright (c) 2020, AMD Inc. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -40,6 +40,27 @@ InitializeFloatingPointUnits (
 BOOLEAN
 EFIAPI
 StandardSignatureIsAuthenticAMD (
+  VOID
+  );
+
+/**
+  Return the 32bit CPU family and model value.
+
+  @return CPUID[01h].EAX with Processor Type and Stepping ID cleared.
+**/
+UINT32
+EFIAPI
+GetCpuFamilyModel (
+  VOID
+  );
+
+/**
+  Return the CPU stepping ID.
+  @return CPU stepping ID value in CPUID[01h].EAX.
+**/
+UINT8
+EFIAPI
+GetCpuSteppingId (
   VOID
   );
 

--- a/UefiCpuPkg/Library/BaseUefiCpuLib/BaseUefiCpuLib.c
+++ b/UefiCpuPkg/Library/BaseUefiCpuLib/BaseUefiCpuLib.c
@@ -4,6 +4,7 @@
   The library routines are UEFI specification compliant.
 
   Copyright (c) 2020, AMD Inc. All rights reserved.<BR>
+  Copyright (c) 2021, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -35,4 +36,46 @@ StandardSignatureIsAuthenticAMD (
   return (RegEbx == CPUID_SIGNATURE_AUTHENTIC_AMD_EBX &&
           RegEcx == CPUID_SIGNATURE_AUTHENTIC_AMD_ECX &&
           RegEdx == CPUID_SIGNATURE_AUTHENTIC_AMD_EDX);
+}
+
+/**
+  Return the 32bit CPU family and model value.
+
+  @return CPUID[01h].EAX with Processor Type and Stepping ID cleared.
+**/
+UINT32
+EFIAPI
+GetCpuFamilyModel (
+  VOID
+  )
+{
+  CPUID_VERSION_INFO_EAX  Eax;
+
+  AsmCpuid (CPUID_VERSION_INFO, &Eax.Uint32, NULL, NULL, NULL);
+
+  //
+  // Mask other fields than Family and Model.
+  //
+  Eax.Bits.SteppingId    = 0;
+  Eax.Bits.ProcessorType = 0;
+  Eax.Bits.Reserved1     = 0;
+  Eax.Bits.Reserved2     = 0;
+  return Eax.Uint32;
+}
+
+/**
+  Return the CPU stepping ID.
+  @return CPU stepping ID value in CPUID[01h].EAX.
+**/
+UINT8
+EFIAPI
+GetCpuSteppingId (
+  VOID
+  )
+{
+  CPUID_VERSION_INFO_EAX  Eax;
+
+  AsmCpuid (CPUID_VERSION_INFO, &Eax.Uint32, NULL, NULL, NULL);
+
+  return (UINT8) Eax.Bits.SteppingId;
 }


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3698

Lots of code relies on CPU Family/Model/Stepping for different logics.

The change adds two APIs for such needs.

Signed-off-by: Ray Ni <ray.ni@intel.com>
Reviewed-by: Eric Dong <eric.dong@intel.com>
Cc: Rahul Kumar <rahul1.kumar@intel.com>