### PR TITLE
OvmfPkg/Library/ResetSystemLib: Fix Microvm VS2019 NOOPT build issue

### DIFF
--- a/OvmfPkg/Library/ResetSystemLib/ResetSystemLibMicrovm.c
+++ b/OvmfPkg/Library/ResetSystemLib/ResetSystemLibMicrovm.c
@@ -18,7 +18,7 @@
 
 static UINTN MicrovmGedBase (VOID)
 {
-  VOID *Address = (VOID*) MICROVM_GED_MMIO_BASE_REGS;
+  VOID *Address = (VOID*)(UINTN) MICROVM_GED_MMIO_BASE_REGS;
 
   if (EfiGoneVirtual ()) {
     EfiConvertPointer (0, &Address);


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3731

Fix VS2019 NOOPT build issues with OvmfPkg/Microvm/MicrovmX64.dsc
by fixing typecast of MICROVM_GED_MMIO_BASE_REGS to a VOID *.

Cc: Gerd Hoffmann <kraxel@redhat.com>
Cc: Ard Biesheuvel <ardb+tianocore@kernel.org>
Cc: Jiewen Yao <jiewen.yao@intel.com>
Signed-off-by: Michael D Kinney <michael.d.kinney@intel.com>