### PR TITLE
MdeModulePkg/FPDT: Lock boot performance table address variable at En…

### DIFF
--- a/MdeModulePkg/Library/DxeCorePerformanceLib/DxeCorePerformanceLib.inf
+++ b/MdeModulePkg/Library/DxeCorePerformanceLib/DxeCorePerformanceLib.inf
@@ -9,7 +9,7 @@
 #  This library is mainly used by DxeCore to start performance logging to ensure that
 #  Performance and PerformanceEx Protocol are installed at the very beginning of DXE phase.
 #
-#  Copyright (c) 2006 - 2018, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2006 - 2021, Intel Corporation. All rights reserved.<BR>
 # (C) Copyright 2016 Hewlett Packard Enterprise Development LP<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -67,6 +67,7 @@
   gZeroGuid                                     ## SOMETIMES_CONSUMES ## GUID
   gEfiFirmwarePerformanceGuid                   ## SOMETIMES_PRODUCES ## UNDEFINED # StatusCode Data
   gEdkiiFpdtExtendedFirmwarePerformanceGuid     ## SOMETIMES_CONSUMES ## HOB # StatusCode Data
+  gEfiEndOfDxeEventGroupGuid                    ## CONSUMES           ## Event
   gEfiEventReadyToBootGuid                      ## CONSUMES           ## Event
   gEdkiiPiSmmCommunicationRegionTableGuid       ## SOMETIMES_CONSUMES    ## SystemTable
   gEdkiiPerformanceMeasurementProtocolGuid      ## PRODUCES           ## UNDEFINED # Install protocol

--- a/MdeModulePkg/Library/SmmCorePerformanceLib/SmmCorePerformanceLib.inf
+++ b/MdeModulePkg/Library/SmmCorePerformanceLib/SmmCorePerformanceLib.inf
@@ -8,7 +8,7 @@
 #  This library is mainly used by SMM Core to start performance logging to ensure that
 #  SMM Performance and PerformanceEx Protocol are installed at the very beginning of SMM phase.
 #
-#  Copyright (c) 2011 - 2018, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2011 - 2021, Intel Corporation. All rights reserved.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -58,14 +58,13 @@
 
 [Protocols]
   gEfiSmmBase2ProtocolGuid                  ## CONSUMES
-  gEdkiiSmmReadyToBootProtocolGuid          ## NOTIFY
 
 [Guids]
   ## PRODUCES ## SystemTable
   gPerformanceProtocolGuid
-  gEdkiiFpdtExtendedFirmwarePerformanceGuid ## SOMETIMES_PRODUCES ## UNDEFINED # StatusCode Data
   gZeroGuid                                 ## SOMETIMES_CONSUMES ## GUID
   gEdkiiSmmPerformanceMeasurementProtocolGuid             ## PRODUCES ## UNDEFINED # Install protocol
+  gEfiFirmwarePerformanceGuid               ## SOMETIMES_PRODUCES ## UNDEFINED # SmiHandlerRegister
 
 [Pcd]
   gEfiMdePkgTokenSpaceGuid.PcdPerformanceLibraryPropertyMask        ## CONSUMES

--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -1879,9 +1879,9 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdSmbiosEntryPointProvideMethod|0x3|UINT32|0x00010069
 
   ## This PCD specifies the additional pad size in FPDT Basic Boot Performance Table for
-  #  the extension FPDT boot records received after ReadyToBoot and before ExitBootService.
+  #  the extension FPDT boot records received after EndOfDxe and before ExitBootService.
   # @Prompt Pad size for extension FPDT boot records.
-  gEfiMdeModulePkgTokenSpaceGuid.PcdExtFpdtBootRecordPadSize|0x20000|UINT32|0x0001005F
+  gEfiMdeModulePkgTokenSpaceGuid.PcdExtFpdtBootRecordPadSize|0x30000|UINT32|0x0001005F
 
   ## Indicates if ConIn device are connected on demand.<BR><BR>
   #   TRUE  - ConIn device are not connected during BDS and ReadKeyStroke/ReadKeyStrokeEx produced

--- a/MdeModulePkg/Universal/Acpi/FirmwarePerformanceDataTableDxe/FirmwarePerformanceDxe.inf
+++ b/MdeModulePkg/Universal/Acpi/FirmwarePerformanceDataTableDxe/FirmwarePerformanceDxe.inf
@@ -5,7 +5,7 @@
 #  for Firmware Basic Boot Performance Record and other boot performance records,
 #  and install FPDT to ACPI table.
 #
-#  Copyright (c) 2011 - 2018, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2011 - 2021, Intel Corporation. All rights reserved.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -46,12 +46,14 @@
   HobLib
   LockBoxLib
   UefiLib
+  VariablePolicyHelperLib
 
 [Protocols]
   gEfiAcpiTableProtocolGuid                     ## CONSUMES
   gEfiRscHandlerProtocolGuid                    ## CONSUMES
   gEfiVariableArchProtocolGuid                  ## CONSUMES
   gEfiLockBoxProtocolGuid                       ## CONSUMES
+  gEdkiiVariablePolicyProtocolGuid              ## CONSUMES
 
 [Guids]
   gEfiEventExitBootServicesGuid                 ## CONSUMES             ## Event
@@ -63,6 +65,7 @@
   gEfiFirmwarePerformanceGuid
   gEdkiiFpdtExtendedFirmwarePerformanceGuid     ## SOMETIMES_CONSUMES ## UNDEFINED # StatusCode Data
   gFirmwarePerformanceS3PointerGuid             ## PRODUCES ## UNDEFINED # SaveLockBox
+  gEfiEndOfDxeEventGroupGuid                    ## CONSUMES ## Event
 
 [Pcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdProgressCodeOsLoaderLoad    ## CONSUMES
@@ -72,6 +75,7 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdAcpiDefaultOemRevision      ## CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdAcpiDefaultCreatorId        ## CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdAcpiDefaultCreatorRevision  ## CONSUMES
+  gEfiMdePkgTokenSpaceGuid.PcdPerformanceLibraryPropertyMask    ## CONSUMES
 
 [FeaturePcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdFirmwarePerformanceDataTableS3Support   ## CONSUMES

--- a/MdeModulePkg/Universal/Acpi/FirmwarePerformanceDataTableSmm/FirmwarePerformanceCommon.c
+++ b/MdeModulePkg/Universal/Acpi/FirmwarePerformanceDataTableSmm/FirmwarePerformanceCommon.c
@@ -11,7 +11,7 @@
 
   FpdtSmiHandler() will receive untrusted input and do basic validation.
 
-  Copyright (c) 2011 - 2018, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2011 - 2021, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -29,20 +29,12 @@
 #include <Library/LockBoxLib.h>
 #include <Library/PcdLib.h>
 #include <Library/BaseMemoryLib.h>
-#include <Library/MemoryAllocationLib.h>
-#include <Library/SynchronizationLib.h>
 #include "FirmwarePerformanceCommon.h"
 
-SMM_BOOT_PERFORMANCE_TABLE    *mMmBootPerformanceTable = NULL;
 
 EFI_MM_RSC_HANDLER_PROTOCOL   *mRscHandlerProtocol    = NULL;
 UINT64                        mSuspendStartTime       = 0;
 BOOLEAN                       mS3SuspendLockBoxSaved  = FALSE;
-UINT32                        mBootRecordSize = 0;
-UINT8                         *mBootRecordBuffer = NULL;
-
-SPIN_LOCK                     mMmFpdtLock;
-BOOLEAN                       mMmramIsOutOfResource = FALSE;
 
 /**
   Report status code listener for MM. This is used to record the performance
@@ -82,21 +74,6 @@ FpdtStatusCodeListenerMm (
   //
   if ((CodeType & EFI_STATUS_CODE_TYPE_MASK) != EFI_PROGRESS_CODE) {
     return EFI_UNSUPPORTED;
-  }
-
-  //
-  // Collect one or more Boot records in boot time
-  //
-  if (Data != NULL && CompareGuid (&Data->Type, &gEdkiiFpdtExtendedFirmwarePerformanceGuid)) {
-    AcquireSpinLock (&mMmFpdtLock);
-    //
-    // Get the boot performance data.
-    //
-    CopyMem (&mMmBootPerformanceTable, Data + 1, Data->Size);
-    mBootRecordBuffer = ((UINT8 *) (mMmBootPerformanceTable)) + sizeof (SMM_BOOT_PERFORMANCE_TABLE);
-
-    ReleaseSpinLock (&mMmFpdtLock);
-    return EFI_SUCCESS;
   }
 
   if (Data != NULL && CompareGuid (&Data->Type, &gEfiFirmwarePerformanceGuid)) {
@@ -154,118 +131,6 @@ FpdtStatusCodeListenerMm (
 }
 
 /**
-  Communication service SMI Handler entry.
-
-  This SMI handler provides services for report MM boot records.
-
-  Caution: This function may receive untrusted input.
-  Communicate buffer and buffer size are external input, so this function will do basic validation.
-
-  @param[in]     DispatchHandle  The unique handle assigned to this handler by SmiHandlerRegister().
-  @param[in]     RegisterContext Points to an optional handler context which was specified when the
-                                 handler was registered.
-  @param[in, out] CommBuffer     A pointer to a collection of data in memory that will
-                                 be conveyed from a non-MM environment into an MM environment.
-  @param[in, out] CommBufferSize The size of the CommBuffer.
-
-  @retval EFI_SUCCESS                         The interrupt was handled and quiesced. No other handlers
-                                              should still be called.
-  @retval EFI_WARN_INTERRUPT_SOURCE_QUIESCED  The interrupt has been quiesced but other handlers should
-                                              still be called.
-  @retval EFI_WARN_INTERRUPT_SOURCE_PENDING   The interrupt is still pending and other handlers should still
-                                              be called.
-  @retval EFI_INTERRUPT_PENDING               The interrupt could not be quiesced.
-
-**/
-EFI_STATUS
-EFIAPI
-FpdtSmiHandler (
-  IN     EFI_HANDLE                   DispatchHandle,
-  IN     CONST VOID                   *RegisterContext,
-  IN OUT VOID                         *CommBuffer,
-  IN OUT UINTN                        *CommBufferSize
-  )
-{
-  EFI_STATUS                   Status;
-  SMM_BOOT_RECORD_COMMUNICATE  *SmmCommData;
-  UINTN                        BootRecordOffset;
-  UINTN                        BootRecordSize;
-  VOID                         *BootRecordData;
-  UINTN                        TempCommBufferSize;
-
-  //
-  // If input is invalid, stop processing this SMI
-  //
-  if (CommBuffer == NULL || CommBufferSize == NULL) {
-    return EFI_SUCCESS;
-  }
-
-  TempCommBufferSize = *CommBufferSize;
-
-  if(TempCommBufferSize < sizeof (SMM_BOOT_RECORD_COMMUNICATE)) {
-    return EFI_SUCCESS;
-  }
-
-  if (!IsBufferOutsideMmValid ((UINTN)CommBuffer, TempCommBufferSize)) {
-    DEBUG ((DEBUG_ERROR, "FpdtSmiHandler: MM communication data buffer in MMRAM or overflow!\n"));
-    return EFI_SUCCESS;
-  }
-
-  SmmCommData = (SMM_BOOT_RECORD_COMMUNICATE*)CommBuffer;
-
-  Status = EFI_SUCCESS;
-
-  switch (SmmCommData->Function) {
-    case SMM_FPDT_FUNCTION_GET_BOOT_RECORD_SIZE :
-      if (mMmBootPerformanceTable != NULL) {
-        mBootRecordSize = mMmBootPerformanceTable->Header.Length - sizeof (SMM_BOOT_PERFORMANCE_TABLE);
-      }
-      SmmCommData->BootRecordSize = mBootRecordSize;
-      break;
-
-    case SMM_FPDT_FUNCTION_GET_BOOT_RECORD_DATA :
-      Status = EFI_UNSUPPORTED;
-      break;
-
-    case SMM_FPDT_FUNCTION_GET_BOOT_RECORD_DATA_BY_OFFSET :
-      BootRecordOffset = SmmCommData->BootRecordOffset;
-      BootRecordData   = SmmCommData->BootRecordData;
-      BootRecordSize   = SmmCommData->BootRecordSize;
-      if (BootRecordData == NULL || BootRecordOffset >= mBootRecordSize) {
-        Status = EFI_INVALID_PARAMETER;
-        break;
-      }
-
-      //
-      // Sanity check
-      //
-      if (BootRecordSize > mBootRecordSize - BootRecordOffset) {
-        BootRecordSize = mBootRecordSize - BootRecordOffset;
-      }
-      SmmCommData->BootRecordSize = BootRecordSize;
-      if (!IsBufferOutsideMmValid ((UINTN)BootRecordData, BootRecordSize)) {
-        DEBUG ((DEBUG_ERROR, "FpdtSmiHandler: MM Data buffer in MMRAM or overflow!\n"));
-        Status = EFI_ACCESS_DENIED;
-        break;
-      }
-
-      CopyMem (
-       (UINT8*)BootRecordData,
-       mBootRecordBuffer + BootRecordOffset,
-       BootRecordSize
-       );
-      break;
-
-    default:
-      Status = EFI_UNSUPPORTED;
-  }
-
-  SmmCommData->ReturnStatus = Status;
-
-  return EFI_SUCCESS;
-}
-
-/**
   The module Entry Point of the Firmware Performance Data Table MM driver.
 
   @retval EFI_SUCCESS    The entry point is executed successfully.
@@ -278,12 +143,6 @@ FirmwarePerformanceCommonEntryPoint (
   )
 {
   EFI_STATUS                Status;
-  EFI_HANDLE                Handle;
-
-  //
-  // Initialize spin lock
-  //
-  InitializeSpinLock (&mMmFpdtLock);
 
   //
   // Get MM Report Status Code Handler Protocol.
@@ -299,13 +158,6 @@ FirmwarePerformanceCommonEntryPoint (
   // Register report status code listener for BootRecords and S3 Suspend Start and End.
   //
   Status = mRscHandlerProtocol->Register (FpdtStatusCodeListenerMm);
-  ASSERT_EFI_ERROR (Status);
-
-  //
-  // Register SMI handler.
-  //
-  Handle = NULL;
-  Status = gMmst->MmiHandlerRegister (FpdtSmiHandler, &gEfiFirmwarePerformanceGuid, &Handle);
   ASSERT_EFI_ERROR (Status);
 
   return Status;

--- a/MdeModulePkg/Universal/Acpi/FirmwarePerformanceDataTableSmm/FirmwarePerformanceCommon.h
+++ b/MdeModulePkg/Universal/Acpi/FirmwarePerformanceDataTableSmm/FirmwarePerformanceCommon.h
@@ -11,7 +11,7 @@
 
   FpdtSmiHandler() will receive untrusted input and do basic validation.
 
-  Copyright (c) 2011 - 2018, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2011 - 2021, Intel Corporation. All rights reserved.<BR>
   Copyright (c), Microsoft Corporation.
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -19,21 +19,6 @@
 
 #ifndef _FW_PERF_COMMON_H_
 #define _FW_PERF_COMMON_H_
-
-/**
-  This function is an abstraction layer for implementation specific Mm buffer validation routine.
-
-  @param Buffer  The buffer start address to be checked.
-  @param Length  The buffer length to be checked.
-
-  @retval TRUE  This buffer is valid per processor architecture and not overlap with SMRAM.
-  @retval FALSE This buffer is not valid per processor architecture or overlap with SMRAM.
-**/
-BOOLEAN
-IsBufferOutsideMmValid (
-  IN EFI_PHYSICAL_ADDRESS  Buffer,
-  IN UINT64                Length
-  );
 
 /**
   The module Entry Point of the Firmware Performance Data Table MM driver.

--- a/MdeModulePkg/Universal/Acpi/FirmwarePerformanceDataTableSmm/FirmwarePerformanceSmm.inf
+++ b/MdeModulePkg/Universal/Acpi/FirmwarePerformanceDataTableSmm/FirmwarePerformanceSmm.inf
@@ -4,7 +4,7 @@
 #  This module registers report status code listener to collect performance data
 #  for SMM boot performance records and S3 Suspend Performance Record.
 #
-#  Copyright (c) 2011 - 2018, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2011 - 2021, Intel Corporation. All rights reserved.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -52,10 +52,8 @@
 
 [Guids]
   ## SOMETIMES_PRODUCES   ## UNDEFINED # SaveLockBox
-  ## PRODUCES             ## UNDEFINED # SmiHandlerRegister
   ## SOMETIMES_CONSUMES   ## UNDEFINED # StatusCode Data
   gEfiFirmwarePerformanceGuid
-  gEdkiiFpdtExtendedFirmwarePerformanceGuid  ## SOMETIMES_PRODUCES ## UNDEFINED # StatusCode Data
 
 [Pcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdProgressCodeS3SuspendStart  ## CONSUMES

--- a/MdeModulePkg/Universal/Acpi/FirmwarePerformanceDataTableSmm/FirmwarePerformanceStandaloneMm.c
+++ b/MdeModulePkg/Universal/Acpi/FirmwarePerformanceDataTableSmm/FirmwarePerformanceStandaloneMm.c
@@ -11,7 +11,7 @@
 
   FpdtSmiHandler() will receive untrusted input and do basic validation.
 
-  Copyright (c) 2011 - 2018, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2011 - 2021, Intel Corporation. All rights reserved.<BR>
   Copyright (c), Microsoft Corporation.
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -19,26 +19,7 @@
 
 #include <PiMm.h>
 
-#include <Library/StandaloneMmMemLib.h>
 #include "FirmwarePerformanceCommon.h"
-
-/**
-  This function is an abstraction layer for implementation specific Mm buffer validation routine.
-
-  @param Buffer  The buffer start address to be checked.
-  @param Length  The buffer length to be checked.
-
-  @retval TRUE  This buffer is valid per processor architecture and not overlap with SMRAM.
-  @retval FALSE This buffer is not valid per processor architecture or overlap with SMRAM.
-**/
-BOOLEAN
-IsBufferOutsideMmValid (
-  IN EFI_PHYSICAL_ADDRESS  Buffer,
-  IN UINT64                Length
-  )
-{
-  return MmIsBufferOutsideMmValid (Buffer, Length);
-}
 
 /**
   The module Entry Point of the Firmware Performance Data Table MM driver.

--- a/MdeModulePkg/Universal/Acpi/FirmwarePerformanceDataTableSmm/FirmwarePerformanceStandaloneMm.inf
+++ b/MdeModulePkg/Universal/Acpi/FirmwarePerformanceDataTableSmm/FirmwarePerformanceStandaloneMm.inf
@@ -4,7 +4,7 @@
 #  This module registers report status code listener to collect performance data
 #  for SMM boot performance records and S3 Suspend Performance Record.
 #
-#  Copyright (c) 2011 - 2018, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2011 - 2021, Intel Corporation. All rights reserved.<BR>
 #  Copyright (c) Microsoft Corporation.
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -53,10 +53,8 @@
 
 [Guids]
   ## SOMETIMES_PRODUCES   ## UNDEFINED # SaveLockBox
-  ## PRODUCES             ## UNDEFINED # SmiHandlerRegister
   ## SOMETIMES_CONSUMES   ## UNDEFINED # StatusCode Data
   gEfiFirmwarePerformanceGuid
-  gEdkiiFpdtExtendedFirmwarePerformanceGuid  ## SOMETIMES_PRODUCES ## UNDEFINED # StatusCode Data
 
 [Pcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdProgressCodeS3SuspendStart  ## CONSUMES

--- a/MdeModulePkg/Universal/Acpi/FirmwarePerformanceDataTableSmm/FirmwarePerformanceTraditional.c
+++ b/MdeModulePkg/Universal/Acpi/FirmwarePerformanceDataTableSmm/FirmwarePerformanceTraditional.c
@@ -11,7 +11,7 @@
 
   FpdtSmiHandler() will receive untrusted input and do basic validation.
 
-  Copyright (c) 2011 - 2018, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2011 - 2021, Intel Corporation. All rights reserved.<BR>
   Copyright (c), Microsoft Corporation.
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -19,26 +19,7 @@
 
 #include <PiSmm.h>
 
-#include <Library/SmmMemLib.h>
 #include "FirmwarePerformanceCommon.h"
-
-/**
-  This function is an abstraction layer for implementation specific Mm buffer validation routine.
-
-  @param Buffer  The buffer start address to be checked.
-  @param Length  The buffer length to be checked.
-
-  @retval TRUE  This buffer is valid per processor architecture and not overlap with SMRAM.
-  @retval FALSE This buffer is not valid per processor architecture or overlap with SMRAM.
-**/
-BOOLEAN
-IsBufferOutsideMmValid (
-  IN EFI_PHYSICAL_ADDRESS  Buffer,
-  IN UINT64                Length
-  )
-{
-  return SmmIsBufferOutsideSmmValid (Buffer, Length);
-}
 
 /**
   The module Entry Point of the Firmware Performance Data Table MM driver.


### PR DESCRIPTION
…dOfDxe

REF: https://bugzilla.tianocore.org/show_bug.cgi?id=2957

1. Allocate performance data table at EndOfDxe and then lock the varible
   which store the table address at EndOfDxe.

2. Enlarge PCD gEfiMdeModulePkgTokenSpaceGuid.PcdExtFpdtBootRecordPadSize
   from 0x20000 to 0x30000 in order to hold the Delta performance data
   between EndOfDxe and ReadyToBoot.

3. SMM performance data is collected by DXE modules through SMM communication
   at ReadyToBoot before.
   Now to do SMM communication twice, one for allocating the performance
   size at EndOfDxe, another is at ReadyToBoot to get SMM performance data.

4. Make SmmCorePerformanceLib rather than FirmwarePerformanceSmm to communicate
   with DxeCorePerformanceLib for SMM performance data and size.

Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Hao A Wu <hao.a.wu@intel.com>
Cc: Jian J Wang <jian.j.wang@intel.com>
Signed-off-by: Dandan Bi <dandan.bi@intel.com>
Reviewed-by: Hao A Wu <hao.a.wu@intel.com>