### PR TITLE
UefiCpuPkg/PiSmmCpuDxeSmm: Use SMM Interrupt Shadow Stack

### DIFF
--- a/UefiCpuPkg/PiSmmCpuDxeSmm/PiSmmCpuDxeSmm.h
+++ b/UefiCpuPkg/PiSmmCpuDxeSmm/PiSmmCpuDxeSmm.h
@@ -558,6 +558,20 @@ InitializeIDTSmmStackGuard (
   );
 
 /**
+  Initialize IDT IST Field.
+
+  @param[in]  ExceptionType       Exception type.
+  @param[in]  Ist                 IST value.
+
+**/
+VOID
+EFIAPI
+InitializeIdtIst (
+  IN EFI_EXCEPTION_TYPE            ExceptionType,
+  IN UINT8                         Ist
+  );
+
+/**
   Initialize Gdt for all processors.
 
   @param[in]   Cr3          CR3 value.

--- a/UefiCpuPkg/PiSmmCpuDxeSmm/X64/PageTbl.c
+++ b/UefiCpuPkg/PiSmmCpuDxeSmm/X64/PageTbl.c
@@ -481,7 +481,17 @@ SmmInitPageTable (
   // Additional SMM IDT initialization for SMM stack guard
   //
   if (FeaturePcdGet (PcdCpuSmmStackGuard)) {
-    InitializeIDTSmmStackGuard ();
+    DEBUG ((DEBUG_INFO, "Initialize IDT IST field for SMM Stack Guard\n"));
+    InitializeIdtIst (EXCEPT_IA32_PAGE_FAULT, 1);
+  }
+
+  //
+  // Additional SMM IDT initialization for SMM CET shadow stack
+  //
+  if ((PcdGet32 (PcdControlFlowEnforcementPropertyMask) != 0) && mCetSupported) {
+    DEBUG ((DEBUG_INFO, "Initialize IDT IST field for SMM Shadow Stack\n"));
+    InitializeIdtIst (EXCEPT_IA32_PAGE_FAULT, 1);
+    InitializeIdtIst (EXCEPT_IA32_MACHINE_CHECK, 1);
   }
 
   //


### PR DESCRIPTION
When CET shadow stack feature is enabled, it needs to use IST for the
 exceptions, and uses interrupt shadow stack for the stack switch.
Shadow stack should be 32 bytes aligned.
Check IST field, when clear shadow stack token busy bit when using retf.

REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3728

Signed-off-by: Sheng Wei <w.sheng@intel.com>
Cc: Eric Dong <eric.dong@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Cc: Rahul Kumar <rahul1.kumar@intel.com>
Reviewed-by: Ray Ni <ray.ni@intel.com>