### PR TITLE
Bug 3739 use correct debug level define names

### DIFF
--- a/ArmPkg/Library/ArmArchTimerLib/ArmArchTimerLib.c
+++ b/ArmPkg/Library/ArmArchTimerLib/ArmArchTimerLib.c
@@ -70,7 +70,7 @@ TimerConstructor (
     ASSERT (ArmGenericTimerGetTimerFreq () != 0);
 
   } else {
-    DEBUG ((EFI_D_ERROR, "ARM Architectural Timer is not available in the CPU, hence this library cannot be used.\n"));
+    DEBUG ((DEBUG_ERROR, "ARM Architectural Timer is not available in the CPU, hence this library cannot be used.\n"));
     ASSERT (0);
   }
 

--- a/ArmPkg/Library/ArmExceptionLib/ArmExceptionLib.c
+++ b/ArmPkg/Library/ArmExceptionLib/ArmExceptionLib.c
@@ -309,7 +309,7 @@ CommonCExceptionHandler(
     }
   }
   else {
-    DEBUG((EFI_D_ERROR, "Unknown exception type %d\n", ExceptionType));
+    DEBUG((DEBUG_ERROR, "Unknown exception type %d\n", ExceptionType));
     ASSERT(FALSE);
   }
 
@@ -347,4 +347,3 @@ InitializeCpuExceptionHandlersEx (
 {
   return InitializeCpuExceptionHandlers (VectorInfo);
 }
-

--- a/ArmPkg/Library/ArmMmuLib/AArch64/ArmMmuPeiLibConstructor.c
+++ b/ArmPkg/Library/ArmMmuLib/AArch64/ArmMmuPeiLibConstructor.c
@@ -40,9 +40,9 @@ ArmMmuPeiLibConstructor (
   if ((UINTN)FileInfo.Buffer <= (UINTN)ArmReplaceLiveTranslationEntry &&
       ((UINTN)FileInfo.Buffer + FileInfo.BufferSize >=
        (UINTN)ArmReplaceLiveTranslationEntry + ArmReplaceLiveTranslationEntrySize)) {
-    DEBUG ((EFI_D_INFO, "ArmMmuLib: skipping cache maintenance on XIP PEIM\n"));
+    DEBUG ((DEBUG_INFO, "ArmMmuLib: skipping cache maintenance on XIP PEIM\n"));
   } else {
-    DEBUG ((EFI_D_INFO, "ArmMmuLib: performing cache maintenance on shadowed PEIM\n"));
+    DEBUG ((DEBUG_INFO, "ArmMmuLib: performing cache maintenance on shadowed PEIM\n"));
     //
     // The ArmReplaceLiveTranslationEntry () helper function may be invoked
     // with the MMU off so we have to ensure that it gets cleaned to the PoC

--- a/ArmPkg/Library/ArmPsciResetSystemLib/ArmPsciResetSystemLib.c
+++ b/ArmPkg/Library/ArmPsciResetSystemLib/ArmPsciResetSystemLib.c
@@ -65,7 +65,7 @@ LibResetSystem (
   ArmCallSmc (&ArmSmcArgs);
 
   // We should never be here
-  DEBUG ((EFI_D_ERROR, "%a: PSCI Reset failed\n", __FUNCTION__));
+  DEBUG ((DEBUG_ERROR, "%a: PSCI Reset failed\n", __FUNCTION__));
   CpuDeadLoop ();
   return EFI_UNSUPPORTED;
 }

--- a/ArmPkg/Library/DebugPeCoffExtraActionLib/DebugPeCoffExtraActionLib.c
+++ b/ArmPkg/Library/DebugPeCoffExtraActionLib/DebugPeCoffExtraActionLib.c
@@ -81,19 +81,19 @@ PeCoffLoaderRelocateImageExtraAction (
 #ifdef __CC_ARM
 #if (__ARMCC_VERSION < 500000)
     // Print out the command for the RVD debugger to load symbols for this image
-    DEBUG ((EFI_D_LOAD | EFI_D_INFO, "load /a /ni /np %a &0x%p\n", DeCygwinPathIfNeeded (ImageContext->PdbPointer, Temp, sizeof (Temp)), (UINTN)(ImageContext->ImageAddress + ImageContext->SizeOfHeaders)));
+    DEBUG ((DEBUG_LOAD | DEBUG_INFO, "load /a /ni /np %a &0x%p\n", DeCygwinPathIfNeeded (ImageContext->PdbPointer, Temp, sizeof (Temp)), (UINTN)(ImageContext->ImageAddress + ImageContext->SizeOfHeaders)));
 #else
     // Print out the command for the DS-5 to load symbols for this image
-    DEBUG ((EFI_D_LOAD | EFI_D_INFO, "add-symbol-file %a 0x%p\n", DeCygwinPathIfNeeded (ImageContext->PdbPointer, Temp, sizeof (Temp)), (UINTN)(ImageContext->ImageAddress + ImageContext->SizeOfHeaders)));
+    DEBUG ((DEBUG_LOAD | DEBUG_INFO, "add-symbol-file %a 0x%p\n", DeCygwinPathIfNeeded (ImageContext->PdbPointer, Temp, sizeof (Temp)), (UINTN)(ImageContext->ImageAddress + ImageContext->SizeOfHeaders)));
 #endif
 #elif __GNUC__
     // This may not work correctly if you generate PE/COFF directly as then the Offset would not be required
-    DEBUG ((EFI_D_LOAD | EFI_D_INFO, "add-symbol-file %a 0x%p\n", DeCygwinPathIfNeeded (ImageContext->PdbPointer, Temp, sizeof (Temp)), (UINTN)(ImageContext->ImageAddress + ImageContext->SizeOfHeaders)));
+    DEBUG ((DEBUG_LOAD | DEBUG_INFO, "add-symbol-file %a 0x%p\n", DeCygwinPathIfNeeded (ImageContext->PdbPointer, Temp, sizeof (Temp)), (UINTN)(ImageContext->ImageAddress + ImageContext->SizeOfHeaders)));
 #else
-    DEBUG ((EFI_D_LOAD | EFI_D_INFO, "Loading driver at 0x%11p EntryPoint=0x%11p\n", (VOID *)(UINTN) ImageContext->ImageAddress, FUNCTION_ENTRY_POINT (ImageContext->EntryPoint)));
+    DEBUG ((DEBUG_LOAD | DEBUG_INFO, "Loading driver at 0x%11p EntryPoint=0x%11p\n", (VOID *)(UINTN) ImageContext->ImageAddress, FUNCTION_ENTRY_POINT (ImageContext->EntryPoint)));
 #endif
   } else {
-    DEBUG ((EFI_D_LOAD | EFI_D_INFO, "Loading driver at 0x%11p EntryPoint=0x%11p\n", (VOID *)(UINTN) ImageContext->ImageAddress, FUNCTION_ENTRY_POINT (ImageContext->EntryPoint)));
+    DEBUG ((DEBUG_LOAD | DEBUG_INFO, "Loading driver at 0x%11p EntryPoint=0x%11p\n", (VOID *)(UINTN) ImageContext->ImageAddress, FUNCTION_ENTRY_POINT (ImageContext->EntryPoint)));
   }
 }
 

--- a/ArmPkg/Library/DefaultExceptionHandlerLib/AArch64/DefaultExceptionHandler.c
+++ b/ArmPkg/Library/DefaultExceptionHandlerLib/AArch64/DefaultExceptionHandler.c
@@ -84,7 +84,7 @@ DescribeInstructionOrDataAbort (
     default: AbortCause = ""; break;
   }
 
-  DEBUG ((EFI_D_ERROR, "\n%a: %a\n", AbortType, AbortCause));
+  DEBUG ((DEBUG_ERROR, "\n%a: %a\n", AbortType, AbortCause));
 }
 
 STATIC
@@ -111,7 +111,7 @@ DescribeExceptionSyndrome (
     default: return;
   }
 
-  DEBUG ((EFI_D_ERROR, "\n %a \n", Message));
+  DEBUG ((DEBUG_ERROR, "\n %a \n", Message));
 }
 
 #ifndef MDEPKG_NDEBUG
@@ -180,11 +180,11 @@ DefaultExceptionHandler (
 
     PrevPdb = Pdb = GetImageName (SystemContext.SystemContextAArch64->ELR, &ImageBase, &PeCoffSizeOfHeader);
     if (Pdb != NULL) {
-      DEBUG ((EFI_D_ERROR, "PC 0x%012lx (0x%012lx+0x%08x) [ 0] %a\n",
+      DEBUG ((DEBUG_ERROR, "PC 0x%012lx (0x%012lx+0x%08x) [ 0] %a\n",
         SystemContext.SystemContextAArch64->ELR, ImageBase,
         SystemContext.SystemContextAArch64->ELR - ImageBase, BaseName (Pdb)));
     } else {
-      DEBUG ((EFI_D_ERROR, "PC 0x%012lx\n", SystemContext.SystemContextAArch64->ELR));
+      DEBUG ((DEBUG_ERROR, "PC 0x%012lx\n", SystemContext.SystemContextAArch64->ELR));
     }
 
     if ((UINT64 *)SystemContext.SystemContextAArch64->FP != 0) {
@@ -203,65 +203,65 @@ DefaultExceptionHandler (
             Idx++;
             PrevPdb = Pdb;
           }
-          DEBUG ((EFI_D_ERROR, "PC 0x%012lx (0x%012lx+0x%08x) [% 2d] %a\n",
+          DEBUG ((DEBUG_ERROR, "PC 0x%012lx (0x%012lx+0x%08x) [% 2d] %a\n",
             Fp[1], ImageBase, Fp[1] - ImageBase, Idx, BaseName (Pdb)));
         } else {
-          DEBUG ((EFI_D_ERROR, "PC 0x%012lx\n", Fp[1]));
+          DEBUG ((DEBUG_ERROR, "PC 0x%012lx\n", Fp[1]));
         }
       }
       PrevPdb = Pdb = GetImageName (SystemContext.SystemContextAArch64->ELR, &ImageBase, &PeCoffSizeOfHeader);
       if (Pdb != NULL) {
-        DEBUG ((EFI_D_ERROR, "\n[ 0] %a\n", Pdb));
+        DEBUG ((DEBUG_ERROR, "\n[ 0] %a\n", Pdb));
       }
 
       Idx = 0;
       for (Fp = RootFp; Fp[0] != 0; Fp = (UINT64 *)Fp[0]) {
         Pdb = GetImageName (Fp[1], &ImageBase, &PeCoffSizeOfHeader);
         if (Pdb != NULL && Pdb != PrevPdb) {
-          DEBUG ((EFI_D_ERROR, "[% 2d] %a\n", ++Idx, Pdb));
+          DEBUG ((DEBUG_ERROR, "[% 2d] %a\n", ++Idx, Pdb));
           PrevPdb = Pdb;
         }
       }
     }
   DEBUG_CODE_END ();
 
-  DEBUG ((EFI_D_ERROR, "\n  X0 0x%016lx   X1 0x%016lx   X2 0x%016lx   X3 0x%016lx\n", SystemContext.SystemContextAArch64->X0, SystemContext.SystemContextAArch64->X1, SystemContext.SystemContextAArch64->X2, SystemContext.SystemContextAArch64->X3));
-  DEBUG ((EFI_D_ERROR, "  X4 0x%016lx   X5 0x%016lx   X6 0x%016lx   X7 0x%016lx\n", SystemContext.SystemContextAArch64->X4, SystemContext.SystemContextAArch64->X5, SystemContext.SystemContextAArch64->X6, SystemContext.SystemContextAArch64->X7));
-  DEBUG ((EFI_D_ERROR, "  X8 0x%016lx   X9 0x%016lx  X10 0x%016lx  X11 0x%016lx\n", SystemContext.SystemContextAArch64->X8, SystemContext.SystemContextAArch64->X9, SystemContext.SystemContextAArch64->X10, SystemContext.SystemContextAArch64->X11));
-  DEBUG ((EFI_D_ERROR, " X12 0x%016lx  X13 0x%016lx  X14 0x%016lx  X15 0x%016lx\n", SystemContext.SystemContextAArch64->X12, SystemContext.SystemContextAArch64->X13, SystemContext.SystemContextAArch64->X14, SystemContext.SystemContextAArch64->X15));
-  DEBUG ((EFI_D_ERROR, " X16 0x%016lx  X17 0x%016lx  X18 0x%016lx  X19 0x%016lx\n", SystemContext.SystemContextAArch64->X16, SystemContext.SystemContextAArch64->X17, SystemContext.SystemContextAArch64->X18, SystemContext.SystemContextAArch64->X19));
-  DEBUG ((EFI_D_ERROR, " X20 0x%016lx  X21 0x%016lx  X22 0x%016lx  X23 0x%016lx\n", SystemContext.SystemContextAArch64->X20, SystemContext.SystemContextAArch64->X21, SystemContext.SystemContextAArch64->X22, SystemContext.SystemContextAArch64->X23));
-  DEBUG ((EFI_D_ERROR, " X24 0x%016lx  X25 0x%016lx  X26 0x%016lx  X27 0x%016lx\n", SystemContext.SystemContextAArch64->X24, SystemContext.SystemContextAArch64->X25, SystemContext.SystemContextAArch64->X26, SystemContext.SystemContextAArch64->X27));
-  DEBUG ((EFI_D_ERROR, " X28 0x%016lx   FP 0x%016lx   LR 0x%016lx  \n", SystemContext.SystemContextAArch64->X28, SystemContext.SystemContextAArch64->FP, SystemContext.SystemContextAArch64->LR));
+  DEBUG ((DEBUG_ERROR, "\n  X0 0x%016lx   X1 0x%016lx   X2 0x%016lx   X3 0x%016lx\n", SystemContext.SystemContextAArch64->X0, SystemContext.SystemContextAArch64->X1, SystemContext.SystemContextAArch64->X2, SystemContext.SystemContextAArch64->X3));
+  DEBUG ((DEBUG_ERROR, "  X4 0x%016lx   X5 0x%016lx   X6 0x%016lx   X7 0x%016lx\n", SystemContext.SystemContextAArch64->X4, SystemContext.SystemContextAArch64->X5, SystemContext.SystemContextAArch64->X6, SystemContext.SystemContextAArch64->X7));
+  DEBUG ((DEBUG_ERROR, "  X8 0x%016lx   X9 0x%016lx  X10 0x%016lx  X11 0x%016lx\n", SystemContext.SystemContextAArch64->X8, SystemContext.SystemContextAArch64->X9, SystemContext.SystemContextAArch64->X10, SystemContext.SystemContextAArch64->X11));
+  DEBUG ((DEBUG_ERROR, " X12 0x%016lx  X13 0x%016lx  X14 0x%016lx  X15 0x%016lx\n", SystemContext.SystemContextAArch64->X12, SystemContext.SystemContextAArch64->X13, SystemContext.SystemContextAArch64->X14, SystemContext.SystemContextAArch64->X15));
+  DEBUG ((DEBUG_ERROR, " X16 0x%016lx  X17 0x%016lx  X18 0x%016lx  X19 0x%016lx\n", SystemContext.SystemContextAArch64->X16, SystemContext.SystemContextAArch64->X17, SystemContext.SystemContextAArch64->X18, SystemContext.SystemContextAArch64->X19));
+  DEBUG ((DEBUG_ERROR, " X20 0x%016lx  X21 0x%016lx  X22 0x%016lx  X23 0x%016lx\n", SystemContext.SystemContextAArch64->X20, SystemContext.SystemContextAArch64->X21, SystemContext.SystemContextAArch64->X22, SystemContext.SystemContextAArch64->X23));
+  DEBUG ((DEBUG_ERROR, " X24 0x%016lx  X25 0x%016lx  X26 0x%016lx  X27 0x%016lx\n", SystemContext.SystemContextAArch64->X24, SystemContext.SystemContextAArch64->X25, SystemContext.SystemContextAArch64->X26, SystemContext.SystemContextAArch64->X27));
+  DEBUG ((DEBUG_ERROR, " X28 0x%016lx   FP 0x%016lx   LR 0x%016lx  \n", SystemContext.SystemContextAArch64->X28, SystemContext.SystemContextAArch64->FP, SystemContext.SystemContextAArch64->LR));
 
   /* We save these as 128bit numbers, but have to print them as two 64bit numbers,
      so swap the 64bit words to correctly represent a 128bit number.  */
-  DEBUG ((EFI_D_ERROR, "\n  V0 0x%016lx %016lx   V1 0x%016lx %016lx\n", SystemContext.SystemContextAArch64->V0[1], SystemContext.SystemContextAArch64->V0[0], SystemContext.SystemContextAArch64->V1[1], SystemContext.SystemContextAArch64->V1[0]));
-  DEBUG ((EFI_D_ERROR, "  V2 0x%016lx %016lx   V3 0x%016lx %016lx\n", SystemContext.SystemContextAArch64->V2[1], SystemContext.SystemContextAArch64->V2[0], SystemContext.SystemContextAArch64->V3[1], SystemContext.SystemContextAArch64->V3[0]));
-  DEBUG ((EFI_D_ERROR, "  V4 0x%016lx %016lx   V5 0x%016lx %016lx\n", SystemContext.SystemContextAArch64->V4[1], SystemContext.SystemContextAArch64->V4[0], SystemContext.SystemContextAArch64->V5[1], SystemContext.SystemContextAArch64->V5[0]));
-  DEBUG ((EFI_D_ERROR, "  V6 0x%016lx %016lx   V7 0x%016lx %016lx\n", SystemContext.SystemContextAArch64->V6[1], SystemContext.SystemContextAArch64->V6[0], SystemContext.SystemContextAArch64->V7[1], SystemContext.SystemContextAArch64->V7[0]));
-  DEBUG ((EFI_D_ERROR, "  V8 0x%016lx %016lx   V9 0x%016lx %016lx\n", SystemContext.SystemContextAArch64->V8[1], SystemContext.SystemContextAArch64->V8[0], SystemContext.SystemContextAArch64->V9[1], SystemContext.SystemContextAArch64->V9[0]));
-  DEBUG ((EFI_D_ERROR, " V10 0x%016lx %016lx  V11 0x%016lx %016lx\n", SystemContext.SystemContextAArch64->V10[1], SystemContext.SystemContextAArch64->V10[0], SystemContext.SystemContextAArch64->V11[1], SystemContext.SystemContextAArch64->V11[0]));
-  DEBUG ((EFI_D_ERROR, " V12 0x%016lx %016lx  V13 0x%016lx %016lx\n", SystemContext.SystemContextAArch64->V12[1], SystemContext.SystemContextAArch64->V12[0], SystemContext.SystemContextAArch64->V13[1], SystemContext.SystemContextAArch64->V13[0]));
-  DEBUG ((EFI_D_ERROR, " V14 0x%016lx %016lx  V15 0x%016lx %016lx\n", SystemContext.SystemContextAArch64->V14[1], SystemContext.SystemContextAArch64->V14[0], SystemContext.SystemContextAArch64->V15[1], SystemContext.SystemContextAArch64->V15[0]));
-  DEBUG ((EFI_D_ERROR, " V16 0x%016lx %016lx  V17 0x%016lx %016lx\n", SystemContext.SystemContextAArch64->V16[1], SystemContext.SystemContextAArch64->V16[0], SystemContext.SystemContextAArch64->V17[1], SystemContext.SystemContextAArch64->V17[0]));
-  DEBUG ((EFI_D_ERROR, " V18 0x%016lx %016lx  V19 0x%016lx %016lx\n", SystemContext.SystemContextAArch64->V18[1], SystemContext.SystemContextAArch64->V18[0], SystemContext.SystemContextAArch64->V19[1], SystemContext.SystemContextAArch64->V19[0]));
-  DEBUG ((EFI_D_ERROR, " V20 0x%016lx %016lx  V21 0x%016lx %016lx\n", SystemContext.SystemContextAArch64->V20[1], SystemContext.SystemContextAArch64->V20[0], SystemContext.SystemContextAArch64->V21[1], SystemContext.SystemContextAArch64->V21[0]));
-  DEBUG ((EFI_D_ERROR, " V22 0x%016lx %016lx  V23 0x%016lx %016lx\n", SystemContext.SystemContextAArch64->V22[1], SystemContext.SystemContextAArch64->V22[0], SystemContext.SystemContextAArch64->V23[1], SystemContext.SystemContextAArch64->V23[0]));
-  DEBUG ((EFI_D_ERROR, " V24 0x%016lx %016lx  V25 0x%016lx %016lx\n", SystemContext.SystemContextAArch64->V24[1], SystemContext.SystemContextAArch64->V24[0], SystemContext.SystemContextAArch64->V25[1], SystemContext.SystemContextAArch64->V25[0]));
-  DEBUG ((EFI_D_ERROR, " V26 0x%016lx %016lx  V27 0x%016lx %016lx\n", SystemContext.SystemContextAArch64->V26[1], SystemContext.SystemContextAArch64->V26[0], SystemContext.SystemContextAArch64->V27[1], SystemContext.SystemContextAArch64->V27[0]));
-  DEBUG ((EFI_D_ERROR, " V28 0x%016lx %016lx  V29 0x%016lx %016lx\n", SystemContext.SystemContextAArch64->V28[1], SystemContext.SystemContextAArch64->V28[0], SystemContext.SystemContextAArch64->V29[1], SystemContext.SystemContextAArch64->V29[0]));
-  DEBUG ((EFI_D_ERROR, " V30 0x%016lx %016lx  V31 0x%016lx %016lx\n", SystemContext.SystemContextAArch64->V30[1], SystemContext.SystemContextAArch64->V30[0], SystemContext.SystemContextAArch64->V31[1], SystemContext.SystemContextAArch64->V31[0]));
+  DEBUG ((DEBUG_ERROR, "\n  V0 0x%016lx %016lx   V1 0x%016lx %016lx\n", SystemContext.SystemContextAArch64->V0[1], SystemContext.SystemContextAArch64->V0[0], SystemContext.SystemContextAArch64->V1[1], SystemContext.SystemContextAArch64->V1[0]));
+  DEBUG ((DEBUG_ERROR, "  V2 0x%016lx %016lx   V3 0x%016lx %016lx\n", SystemContext.SystemContextAArch64->V2[1], SystemContext.SystemContextAArch64->V2[0], SystemContext.SystemContextAArch64->V3[1], SystemContext.SystemContextAArch64->V3[0]));
+  DEBUG ((DEBUG_ERROR, "  V4 0x%016lx %016lx   V5 0x%016lx %016lx\n", SystemContext.SystemContextAArch64->V4[1], SystemContext.SystemContextAArch64->V4[0], SystemContext.SystemContextAArch64->V5[1], SystemContext.SystemContextAArch64->V5[0]));
+  DEBUG ((DEBUG_ERROR, "  V6 0x%016lx %016lx   V7 0x%016lx %016lx\n", SystemContext.SystemContextAArch64->V6[1], SystemContext.SystemContextAArch64->V6[0], SystemContext.SystemContextAArch64->V7[1], SystemContext.SystemContextAArch64->V7[0]));
+  DEBUG ((DEBUG_ERROR, "  V8 0x%016lx %016lx   V9 0x%016lx %016lx\n", SystemContext.SystemContextAArch64->V8[1], SystemContext.SystemContextAArch64->V8[0], SystemContext.SystemContextAArch64->V9[1], SystemContext.SystemContextAArch64->V9[0]));
+  DEBUG ((DEBUG_ERROR, " V10 0x%016lx %016lx  V11 0x%016lx %016lx\n", SystemContext.SystemContextAArch64->V10[1], SystemContext.SystemContextAArch64->V10[0], SystemContext.SystemContextAArch64->V11[1], SystemContext.SystemContextAArch64->V11[0]));
+  DEBUG ((DEBUG_ERROR, " V12 0x%016lx %016lx  V13 0x%016lx %016lx\n", SystemContext.SystemContextAArch64->V12[1], SystemContext.SystemContextAArch64->V12[0], SystemContext.SystemContextAArch64->V13[1], SystemContext.SystemContextAArch64->V13[0]));
+  DEBUG ((DEBUG_ERROR, " V14 0x%016lx %016lx  V15 0x%016lx %016lx\n", SystemContext.SystemContextAArch64->V14[1], SystemContext.SystemContextAArch64->V14[0], SystemContext.SystemContextAArch64->V15[1], SystemContext.SystemContextAArch64->V15[0]));
+  DEBUG ((DEBUG_ERROR, " V16 0x%016lx %016lx  V17 0x%016lx %016lx\n", SystemContext.SystemContextAArch64->V16[1], SystemContext.SystemContextAArch64->V16[0], SystemContext.SystemContextAArch64->V17[1], SystemContext.SystemContextAArch64->V17[0]));
+  DEBUG ((DEBUG_ERROR, " V18 0x%016lx %016lx  V19 0x%016lx %016lx\n", SystemContext.SystemContextAArch64->V18[1], SystemContext.SystemContextAArch64->V18[0], SystemContext.SystemContextAArch64->V19[1], SystemContext.SystemContextAArch64->V19[0]));
+  DEBUG ((DEBUG_ERROR, " V20 0x%016lx %016lx  V21 0x%016lx %016lx\n", SystemContext.SystemContextAArch64->V20[1], SystemContext.SystemContextAArch64->V20[0], SystemContext.SystemContextAArch64->V21[1], SystemContext.SystemContextAArch64->V21[0]));
+  DEBUG ((DEBUG_ERROR, " V22 0x%016lx %016lx  V23 0x%016lx %016lx\n", SystemContext.SystemContextAArch64->V22[1], SystemContext.SystemContextAArch64->V22[0], SystemContext.SystemContextAArch64->V23[1], SystemContext.SystemContextAArch64->V23[0]));
+  DEBUG ((DEBUG_ERROR, " V24 0x%016lx %016lx  V25 0x%016lx %016lx\n", SystemContext.SystemContextAArch64->V24[1], SystemContext.SystemContextAArch64->V24[0], SystemContext.SystemContextAArch64->V25[1], SystemContext.SystemContextAArch64->V25[0]));
+  DEBUG ((DEBUG_ERROR, " V26 0x%016lx %016lx  V27 0x%016lx %016lx\n", SystemContext.SystemContextAArch64->V26[1], SystemContext.SystemContextAArch64->V26[0], SystemContext.SystemContextAArch64->V27[1], SystemContext.SystemContextAArch64->V27[0]));
+  DEBUG ((DEBUG_ERROR, " V28 0x%016lx %016lx  V29 0x%016lx %016lx\n", SystemContext.SystemContextAArch64->V28[1], SystemContext.SystemContextAArch64->V28[0], SystemContext.SystemContextAArch64->V29[1], SystemContext.SystemContextAArch64->V29[0]));
+  DEBUG ((DEBUG_ERROR, " V30 0x%016lx %016lx  V31 0x%016lx %016lx\n", SystemContext.SystemContextAArch64->V30[1], SystemContext.SystemContextAArch64->V30[0], SystemContext.SystemContextAArch64->V31[1], SystemContext.SystemContextAArch64->V31[0]));
 
-  DEBUG ((EFI_D_ERROR, "\n  SP 0x%016lx  ELR 0x%016lx  SPSR 0x%08lx  FPSR 0x%08lx\n ESR 0x%08lx          FAR 0x%016lx\n", SystemContext.SystemContextAArch64->SP, SystemContext.SystemContextAArch64->ELR, SystemContext.SystemContextAArch64->SPSR, SystemContext.SystemContextAArch64->FPSR, SystemContext.SystemContextAArch64->ESR, SystemContext.SystemContextAArch64->FAR));
+  DEBUG ((DEBUG_ERROR, "\n  SP 0x%016lx  ELR 0x%016lx  SPSR 0x%08lx  FPSR 0x%08lx\n ESR 0x%08lx          FAR 0x%016lx\n", SystemContext.SystemContextAArch64->SP, SystemContext.SystemContextAArch64->ELR, SystemContext.SystemContextAArch64->SPSR, SystemContext.SystemContextAArch64->FPSR, SystemContext.SystemContextAArch64->ESR, SystemContext.SystemContextAArch64->FAR));
 
-  DEBUG ((EFI_D_ERROR, "\n ESR : EC 0x%02x  IL 0x%x  ISS 0x%08x\n", (SystemContext.SystemContextAArch64->ESR & 0xFC000000) >> 26, (SystemContext.SystemContextAArch64->ESR >> 25) & 0x1, SystemContext.SystemContextAArch64->ESR & 0x1FFFFFF ));
+  DEBUG ((DEBUG_ERROR, "\n ESR : EC 0x%02x  IL 0x%x  ISS 0x%08x\n", (SystemContext.SystemContextAArch64->ESR & 0xFC000000) >> 26, (SystemContext.SystemContextAArch64->ESR >> 25) & 0x1, SystemContext.SystemContextAArch64->ESR & 0x1FFFFFF ));
 
   DescribeExceptionSyndrome (SystemContext.SystemContextAArch64->ESR);
 
-  DEBUG ((EFI_D_ERROR, "\nStack dump:\n"));
+  DEBUG ((DEBUG_ERROR, "\nStack dump:\n"));
   for (Offset = -256; Offset < 256; Offset += 32) {
-    DEBUG  ((EFI_D_ERROR, "%c %013lx: %016lx %016lx %016lx %016lx\n",
+    DEBUG  ((DEBUG_ERROR, "%c %013lx: %016lx %016lx %016lx %016lx\n",
       Offset == 0 ? '>' : ' ',
       SystemContext.SystemContextAArch64->SP + Offset,
       *(UINT64 *)(SystemContext.SystemContextAArch64->SP + Offset),

--- a/ArmPkg/Library/DefaultExceptionHandlerLib/Arm/DefaultExceptionHandler.c
+++ b/ArmPkg/Library/DefaultExceptionHandlerLib/Arm/DefaultExceptionHandler.c
@@ -210,12 +210,12 @@ DefaultExceptionHandler (
     UINT32  ItBlock;
 
     CpsrString (SystemContext.SystemContextArm->CPSR, CpsrStr);
-    DEBUG ((EFI_D_ERROR, "%a\n", CpsrStr));
+    DEBUG ((DEBUG_ERROR, "%a\n", CpsrStr));
 
     Pdb = GetImageName (SystemContext.SystemContextArm->PC, &ImageBase, &PeCoffSizeOfHeader);
     Offset = SystemContext.SystemContextArm->PC - ImageBase;
     if (Pdb != NULL) {
-      DEBUG ((EFI_D_ERROR, "%a\n", Pdb));
+      DEBUG ((DEBUG_ERROR, "%a\n", Pdb));
 
       //
       // A PE/COFF image loads its headers into memory so the headers are
@@ -225,13 +225,13 @@ DefaultExceptionHandler (
       // you need to subtract out the size of the PE/COFF header to get
       // get the offset that matches the link map.
       //
-      DEBUG ((EFI_D_ERROR, "loaded at 0x%08x (PE/COFF offset) 0x%x (ELF or Mach-O offset) 0x%x", ImageBase, Offset, Offset - PeCoffSizeOfHeader));
+      DEBUG ((DEBUG_ERROR, "loaded at 0x%08x (PE/COFF offset) 0x%x (ELF or Mach-O offset) 0x%x", ImageBase, Offset, Offset - PeCoffSizeOfHeader));
 
       // If we come from an image it is safe to show the instruction. We know it should not fault
       DisAsm = (UINT8 *)(UINTN)SystemContext.SystemContextArm->PC;
       ItBlock = 0;
       DisassembleInstruction (&DisAsm, (SystemContext.SystemContextArm->CPSR & BIT5) == BIT5, TRUE, &ItBlock, Buffer, sizeof (Buffer));
-      DEBUG ((EFI_D_ERROR, "\n%a", Buffer));
+      DEBUG ((DEBUG_ERROR, "\n%a", Buffer));
 
       switch (ExceptionType) {
       case EXCEPT_ARM_UNDEFINED_INSTRUCTION:
@@ -248,25 +248,25 @@ DefaultExceptionHandler (
 
     }
   DEBUG_CODE_END ();
-  DEBUG ((EFI_D_ERROR, "\n  R0 0x%08x   R1 0x%08x   R2 0x%08x   R3 0x%08x\n", SystemContext.SystemContextArm->R0, SystemContext.SystemContextArm->R1, SystemContext.SystemContextArm->R2, SystemContext.SystemContextArm->R3));
-  DEBUG ((EFI_D_ERROR, "  R4 0x%08x   R5 0x%08x   R6 0x%08x   R7 0x%08x\n", SystemContext.SystemContextArm->R4, SystemContext.SystemContextArm->R5, SystemContext.SystemContextArm->R6, SystemContext.SystemContextArm->R7));
-  DEBUG ((EFI_D_ERROR, "  R8 0x%08x   R9 0x%08x  R10 0x%08x  R11 0x%08x\n", SystemContext.SystemContextArm->R8, SystemContext.SystemContextArm->R9, SystemContext.SystemContextArm->R10, SystemContext.SystemContextArm->R11));
-  DEBUG ((EFI_D_ERROR, " R12 0x%08x   SP 0x%08x   LR 0x%08x   PC 0x%08x\n", SystemContext.SystemContextArm->R12, SystemContext.SystemContextArm->SP, SystemContext.SystemContextArm->LR, SystemContext.SystemContextArm->PC));
-  DEBUG ((EFI_D_ERROR, "DFSR 0x%08x DFAR 0x%08x IFSR 0x%08x IFAR 0x%08x\n", SystemContext.SystemContextArm->DFSR, SystemContext.SystemContextArm->DFAR, SystemContext.SystemContextArm->IFSR, SystemContext.SystemContextArm->IFAR));
+  DEBUG ((DEBUG_ERROR, "\n  R0 0x%08x   R1 0x%08x   R2 0x%08x   R3 0x%08x\n", SystemContext.SystemContextArm->R0, SystemContext.SystemContextArm->R1, SystemContext.SystemContextArm->R2, SystemContext.SystemContextArm->R3));
+  DEBUG ((DEBUG_ERROR, "  R4 0x%08x   R5 0x%08x   R6 0x%08x   R7 0x%08x\n", SystemContext.SystemContextArm->R4, SystemContext.SystemContextArm->R5, SystemContext.SystemContextArm->R6, SystemContext.SystemContextArm->R7));
+  DEBUG ((DEBUG_ERROR, "  R8 0x%08x   R9 0x%08x  R10 0x%08x  R11 0x%08x\n", SystemContext.SystemContextArm->R8, SystemContext.SystemContextArm->R9, SystemContext.SystemContextArm->R10, SystemContext.SystemContextArm->R11));
+  DEBUG ((DEBUG_ERROR, " R12 0x%08x   SP 0x%08x   LR 0x%08x   PC 0x%08x\n", SystemContext.SystemContextArm->R12, SystemContext.SystemContextArm->SP, SystemContext.SystemContextArm->LR, SystemContext.SystemContextArm->PC));
+  DEBUG ((DEBUG_ERROR, "DFSR 0x%08x DFAR 0x%08x IFSR 0x%08x IFAR 0x%08x\n", SystemContext.SystemContextArm->DFSR, SystemContext.SystemContextArm->DFAR, SystemContext.SystemContextArm->IFSR, SystemContext.SystemContextArm->IFAR));
 
   // Bit10 is Status[4] Bit3:0 is Status[3:0]
   DfsrStatus = (SystemContext.SystemContextArm->DFSR & 0xf) | ((SystemContext.SystemContextArm->DFSR >> 6) & 0x10);
   DfsrWrite = (SystemContext.SystemContextArm->DFSR & BIT11) != 0;
   if (DfsrStatus != 0x00) {
-    DEBUG ((EFI_D_ERROR, " %a: %a 0x%08x\n", FaultStatusToString (DfsrStatus), DfsrWrite ? "write to" : "read from", SystemContext.SystemContextArm->DFAR));
+    DEBUG ((DEBUG_ERROR, " %a: %a 0x%08x\n", FaultStatusToString (DfsrStatus), DfsrWrite ? "write to" : "read from", SystemContext.SystemContextArm->DFAR));
   }
 
   IfsrStatus = (SystemContext.SystemContextArm->IFSR & 0xf) | ((SystemContext.SystemContextArm->IFSR >> 6) & 0x10);
   if (IfsrStatus != 0) {
-    DEBUG ((EFI_D_ERROR, " Instruction %a at 0x%08x\n", FaultStatusToString (SystemContext.SystemContextArm->IFSR & 0xf), SystemContext.SystemContextArm->IFAR));
+    DEBUG ((DEBUG_ERROR, " Instruction %a at 0x%08x\n", FaultStatusToString (SystemContext.SystemContextArm->IFSR & 0xf), SystemContext.SystemContextArm->IFAR));
   }
 
-  DEBUG ((EFI_D_ERROR, "\n"));
+  DEBUG ((DEBUG_ERROR, "\n"));
   ASSERT (FALSE);
 
   CpuDeadLoop ();   // may return if executing under a debugger

--- a/ArmPkg/Library/PlatformBootManagerLib/PlatformBm.c
+++ b/ArmPkg/Library/PlatformBootManagerLib/PlatformBm.c
@@ -190,7 +190,7 @@ FilterAndProcess (
     //
     // This is not an error, just an informative condition.
     //
-    DEBUG ((EFI_D_VERBOSE, "%a: %g: %r\n", __FUNCTION__, ProtocolGuid,
+    DEBUG ((DEBUG_VERBOSE, "%a: %g: %r\n", __FUNCTION__, ProtocolGuid,
       Status));
     return;
   }
@@ -251,7 +251,7 @@ IsPciDisplay (
   Status = PciIo->Pci.Read (PciIo, EfiPciIoWidthUint32, 0 /* Offset */,
                         sizeof Pci / sizeof (UINT32), &Pci);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: %s: %r\n", __FUNCTION__, ReportText, Status));
+    DEBUG ((DEBUG_ERROR, "%a: %s: %r\n", __FUNCTION__, ReportText, Status));
     return FALSE;
   }
 
@@ -310,7 +310,7 @@ Connect (
                   NULL,   // RemainingDevicePath -- produce all children
                   FALSE   // Recursive
                   );
-  DEBUG ((EFI_ERROR (Status) ? EFI_D_ERROR : EFI_D_VERBOSE, "%a: %s: %r\n",
+  DEBUG ((EFI_ERROR (Status) ? DEBUG_ERROR : DEBUG_VERBOSE, "%a: %s: %r\n",
     __FUNCTION__, ReportText, Status));
 }
 
@@ -332,26 +332,26 @@ AddOutput (
 
   DevicePath = DevicePathFromHandle (Handle);
   if (DevicePath == NULL) {
-    DEBUG ((EFI_D_ERROR, "%a: %s: handle %p: device path not found\n",
+    DEBUG ((DEBUG_ERROR, "%a: %s: handle %p: device path not found\n",
       __FUNCTION__, ReportText, Handle));
     return;
   }
 
   Status = EfiBootManagerUpdateConsoleVariable (ConOut, DevicePath, NULL);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: %s: adding to ConOut: %r\n", __FUNCTION__,
+    DEBUG ((DEBUG_ERROR, "%a: %s: adding to ConOut: %r\n", __FUNCTION__,
       ReportText, Status));
     return;
   }
 
   Status = EfiBootManagerUpdateConsoleVariable (ErrOut, DevicePath, NULL);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: %s: adding to ErrOut: %r\n", __FUNCTION__,
+    DEBUG ((DEBUG_ERROR, "%a: %s: adding to ErrOut: %r\n", __FUNCTION__,
       ReportText, Status));
     return;
   }
 
-  DEBUG ((EFI_D_VERBOSE, "%a: %s: added to ConOut and ErrOut\n", __FUNCTION__,
+  DEBUG ((DEBUG_VERBOSE, "%a: %s: added to ConOut and ErrOut\n", __FUNCTION__,
     ReportText));
 }
 

--- a/ArmPlatformPkg/Drivers/NorFlashDxe/NorFlashDxe.c
+++ b/ArmPlatformPkg/Drivers/NorFlashDxe/NorFlashDxe.c
@@ -201,7 +201,7 @@ NorFlashUnlockAndEraseSingleBlock (
   } while ((Index < NOR_FLASH_ERASE_RETRY) && (Status == EFI_WRITE_PROTECTED));
 
   if (Index == NOR_FLASH_ERASE_RETRY) {
-    DEBUG((EFI_D_ERROR,"EraseSingleBlock(BlockAddress=0x%08x: Block Locked Error (try to erase %d times)\n", BlockAddress,Index));
+    DEBUG((DEBUG_ERROR,"EraseSingleBlock(BlockAddress=0x%08x: Block Locked Error (try to erase %d times)\n", BlockAddress,Index));
   }
 
   if (!EfiAtRuntime ()) {
@@ -249,7 +249,7 @@ NorFlashWriteFullBlock (
 
   Status = NorFlashUnlockAndEraseSingleBlock (Instance, BlockAddress);
   if (EFI_ERROR(Status)) {
-    DEBUG((EFI_D_ERROR, "WriteSingleBlock: ERROR - Failed to Unlock and Erase the single block at 0x%X\n", BlockAddress));
+    DEBUG((DEBUG_ERROR, "WriteSingleBlock: ERROR - Failed to Unlock and Erase the single block at 0x%X\n", BlockAddress));
     goto EXIT;
   }
 
@@ -310,7 +310,7 @@ EXIT:
   }
 
   if (EFI_ERROR(Status)) {
-    DEBUG((EFI_D_ERROR, "NOR FLASH Programming [WriteSingleBlock] failed at address 0x%08x. Exit Status = \"%r\".\n", WordAddress, Status));
+    DEBUG((DEBUG_ERROR, "NOR FLASH Programming [WriteSingleBlock] failed at address 0x%08x. Exit Status = \"%r\".\n", WordAddress, Status));
   }
   return Status;
 }
@@ -329,13 +329,13 @@ NorFlashInitialise (
 
   Status = NorFlashPlatformInitialization ();
   if (EFI_ERROR(Status)) {
-    DEBUG((EFI_D_ERROR,"NorFlashInitialise: Fail to initialize Nor Flash devices\n"));
+    DEBUG((DEBUG_ERROR,"NorFlashInitialise: Fail to initialize Nor Flash devices\n"));
     return Status;
   }
 
   Status = NorFlashPlatformGetDevices (&NorFlashDevices, &mNorFlashDeviceCount);
   if (EFI_ERROR(Status)) {
-    DEBUG((EFI_D_ERROR,"NorFlashInitialise: Fail to get Nor Flash devices\n"));
+    DEBUG((DEBUG_ERROR,"NorFlashInitialise: Fail to get Nor Flash devices\n"));
     return Status;
   }
 
@@ -366,7 +366,7 @@ NorFlashInitialise (
       &mNorFlashInstances[Index]
     );
     if (EFI_ERROR(Status)) {
-      DEBUG((EFI_D_ERROR,"NorFlashInitialise: Fail to create instance for NorFlash[%d]\n",Index));
+      DEBUG((DEBUG_ERROR,"NorFlashInitialise: Fail to create instance for NorFlash[%d]\n",Index));
     }
   }
 

--- a/ArmPlatformPkg/Drivers/NorFlashDxe/NorFlashFvb.c
+++ b/ArmPlatformPkg/Drivers/NorFlashDxe/NorFlashFvb.c
@@ -187,14 +187,14 @@ ValidateFvHeader (
       || (FwVolHeader->FvLength  != FvLength)
       )
   {
-    DEBUG ((EFI_D_INFO, "%a: No Firmware Volume header present\n",
+    DEBUG ((DEBUG_INFO, "%a: No Firmware Volume header present\n",
       __FUNCTION__));
     return EFI_NOT_FOUND;
   }
 
   // Check the Firmware Volume Guid
   if( CompareGuid (&FwVolHeader->FileSystemGuid, &gEfiSystemNvDataFvGuid) == FALSE ) {
-    DEBUG ((EFI_D_INFO, "%a: Firmware Volume Guid non-compatible\n",
+    DEBUG ((DEBUG_INFO, "%a: Firmware Volume Guid non-compatible\n",
       __FUNCTION__));
     return EFI_NOT_FOUND;
   }
@@ -202,7 +202,7 @@ ValidateFvHeader (
   // Verify the header checksum
   Checksum = CalculateSum16((UINT16*)FwVolHeader, FwVolHeader->HeaderLength);
   if (Checksum != 0) {
-    DEBUG ((EFI_D_INFO, "%a: FV checksum is invalid (Checksum:0x%X)\n",
+    DEBUG ((DEBUG_INFO, "%a: FV checksum is invalid (Checksum:0x%X)\n",
       __FUNCTION__, Checksum));
     return EFI_NOT_FOUND;
   }
@@ -212,14 +212,14 @@ ValidateFvHeader (
   // Check the Variable Store Guid
   if (!CompareGuid (&VariableStoreHeader->Signature, &gEfiVariableGuid) &&
       !CompareGuid (&VariableStoreHeader->Signature, &gEfiAuthenticatedVariableGuid)) {
-    DEBUG ((EFI_D_INFO, "%a: Variable Store Guid non-compatible\n",
+    DEBUG ((DEBUG_INFO, "%a: Variable Store Guid non-compatible\n",
       __FUNCTION__));
     return EFI_NOT_FOUND;
   }
 
   VariableStoreLength = PcdGet32 (PcdFlashNvStorageVariableSize) - FwVolHeader->HeaderLength;
   if (VariableStoreHeader->Size != VariableStoreLength) {
-    DEBUG ((EFI_D_INFO, "%a: Variable Store Length does not match\n",
+    DEBUG ((DEBUG_INFO, "%a: Variable Store Length does not match\n",
       __FUNCTION__));
     return EFI_NOT_FOUND;
   }
@@ -386,7 +386,7 @@ FvbGetBlockSize (
   DEBUG ((DEBUG_BLKIO, "FvbGetBlockSize(Lba=%ld, BlockSize=0x%x, LastBlock=%ld)\n", Lba, Instance->Media.BlockSize, Instance->Media.LastBlock));
 
   if (Lba > Instance->Media.LastBlock) {
-    DEBUG ((EFI_D_ERROR, "FvbGetBlockSize: ERROR - Parameter LBA %ld is beyond the last Lba (%ld).\n", Lba, Instance->Media.LastBlock));
+    DEBUG ((DEBUG_ERROR, "FvbGetBlockSize: ERROR - Parameter LBA %ld is beyond the last Lba (%ld).\n", Lba, Instance->Media.LastBlock));
     Status = EFI_INVALID_PARAMETER;
   } else {
     // This is easy because in this platform each NorFlash device has equal sized blocks.
@@ -472,7 +472,7 @@ FvbRead (
   if ((Offset               >= BlockSize) ||
       (*NumBytes            >  BlockSize) ||
       ((Offset + *NumBytes) >  BlockSize)) {
-    DEBUG ((EFI_D_ERROR, "FvbRead: ERROR - EFI_BAD_BUFFER_SIZE: (Offset=0x%x + NumBytes=0x%x) > BlockSize=0x%x\n", Offset, *NumBytes, BlockSize ));
+    DEBUG ((DEBUG_ERROR, "FvbRead: ERROR - EFI_BAD_BUFFER_SIZE: (Offset=0x%x + NumBytes=0x%x) > BlockSize=0x%x\n", Offset, *NumBytes, BlockSize ));
     return EFI_BAD_BUFFER_SIZE;
   }
 
@@ -635,7 +635,7 @@ FvbEraseBlocks (
   // Detect WriteDisabled state
   if (Instance->Media.ReadOnly == TRUE) {
     // Firmware volume is in WriteDisabled state
-    DEBUG ((EFI_D_ERROR, "FvbEraseBlocks: ERROR - Device is in WriteDisabled state.\n"));
+    DEBUG ((DEBUG_ERROR, "FvbEraseBlocks: ERROR - Device is in WriteDisabled state.\n"));
     return EFI_ACCESS_DENIED;
   }
 
@@ -665,7 +665,7 @@ FvbEraseBlocks (
       ));
     if ((NumOfLba == 0) || ((Instance->StartLba + StartingLba + NumOfLba - 1) > Instance->Media.LastBlock)) {
       VA_END (Args);
-      DEBUG ((EFI_D_ERROR, "FvbEraseBlocks: ERROR - Lba range goes past the last Lba.\n"));
+      DEBUG ((DEBUG_ERROR, "FvbEraseBlocks: ERROR - Lba range goes past the last Lba.\n"));
       Status = EFI_INVALID_PARAMETER;
       goto EXIT;
     }
@@ -737,4 +737,3 @@ FvbVirtualNotifyEvent (
   EfiConvertPointer (0x0, (VOID**)&mFlashNvStorageVariableBase);
   return;
 }
-

--- a/ArmPlatformPkg/Drivers/PL061GpioDxe/PL061Gpio.c
+++ b/ArmPlatformPkg/Drivers/PL061GpioDxe/PL061Gpio.c
@@ -47,7 +47,7 @@ PL061Locate (
       return EFI_SUCCESS;
     }
   }
-  DEBUG ((EFI_D_ERROR, "%a, failed to locate gpio %d\n", __func__, Gpio));
+  DEBUG ((DEBUG_ERROR, "%a, failed to locate gpio %d\n", __func__, Gpio));
   return EFI_INVALID_PARAMETER;
 }
 
@@ -375,7 +375,7 @@ PL061InstallProtocol (
     // Create the mPL061PlatformGpio
     mPL061PlatformGpio = (PLATFORM_GPIO_CONTROLLER *)AllocateZeroPool (sizeof (PLATFORM_GPIO_CONTROLLER) + sizeof (GPIO_CONTROLLER));
     if (mPL061PlatformGpio == NULL) {
-      DEBUG ((EFI_D_ERROR, "%a: failed to allocate PLATFORM_GPIO_CONTROLLER\n", __func__));
+      DEBUG ((DEBUG_ERROR, "%a: failed to allocate PLATFORM_GPIO_CONTROLLER\n", __func__));
       return EFI_BAD_BUFFER_SIZE;
     }
 

--- a/ArmPlatformPkg/Library/PL111Lcd/PL111Lcd.c
+++ b/ArmPlatformPkg/Library/PL111Lcd/PL111Lcd.c
@@ -26,7 +26,7 @@ LcdIdentify (
   VOID
   )
 {
-  DEBUG ((EFI_D_WARN, "Probing ID registers at 0x%lx for a PL111\n",
+  DEBUG ((DEBUG_WARN, "Probing ID registers at 0x%lx for a PL111\n",
     PL111_REG_CLCD_PERIPH_ID_0));
 
   // Check if this is a PL111

--- a/ArmPlatformPkg/MemoryInitPei/MemoryInitPeiLib.c
+++ b/ArmPlatformPkg/MemoryInitPei/MemoryInitPeiLib.c
@@ -35,7 +35,7 @@ InitMmu (
   //      DRAM (even at the top of DRAM as it is the first permanent memory allocation)
   Status = ArmConfigureMmu (MemoryTable, &TranslationTableBase, &TranslationTableSize);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "Error: Failed to enable MMU\n"));
+    DEBUG ((DEBUG_ERROR, "Error: Failed to enable MMU\n"));
   }
 }
 

--- a/ArmPlatformPkg/MemoryInitPei/MemoryInitPeim.c
+++ b/ArmPlatformPkg/MemoryInitPei/MemoryInitPeim.c
@@ -95,7 +95,7 @@ InitializeMemory (
   UINTN                                 FdTop;
   UINTN                                 UefiMemoryBase;
 
-  DEBUG ((EFI_D_LOAD | EFI_D_INFO, "Memory Init PEIM Loaded\n"));
+  DEBUG ((DEBUG_LOAD | DEBUG_INFO, "Memory Init PEIM Loaded\n"));
 
   // Ensure PcdSystemMemorySize has been set
   ASSERT (PcdGet64 (PcdSystemMemorySize) != 0);

--- a/ArmPlatformPkg/PlatformPei/PlatformPeim.c
+++ b/ArmPlatformPkg/PlatformPei/PlatformPeim.c
@@ -79,7 +79,7 @@ InitializePlatformPeim (
   EFI_STATUS                    Status;
   EFI_BOOT_MODE                 BootMode;
 
-  DEBUG ((EFI_D_LOAD | EFI_D_INFO, "Platform PEIM Loaded\n"));
+  DEBUG ((DEBUG_LOAD | DEBUG_INFO, "Platform PEIM Loaded\n"));
 
   Status = PeiServicesSetBootMode (ArmPlatformGetBootMode ());
   ASSERT_EFI_ERROR (Status);

--- a/ArmVirtPkg/Library/ArmVirtGicArchLib/ArmVirtGicArchLib.c
+++ b/ArmVirtPkg/Library/ArmVirtGicArchLib/ArmVirtGicArchLib.c
@@ -85,7 +85,7 @@ ArmVirtGicArchLibConstructor (
     PcdStatus = PcdSet64S (PcdGicRedistributorsBase, RedistBase);
     ASSERT_RETURN_ERROR (PcdStatus);
 
-    DEBUG ((EFI_D_INFO, "Found GIC v3 (re)distributor @ 0x%Lx (0x%Lx)\n",
+    DEBUG ((DEBUG_INFO, "Found GIC v3 (re)distributor @ 0x%Lx (0x%Lx)\n",
       DistBase, RedistBase));
 
     //
@@ -127,13 +127,13 @@ ArmVirtGicArchLibConstructor (
     PcdStatus = PcdSet64S (PcdGicInterruptInterfaceBase, CpuBase);
     ASSERT_RETURN_ERROR (PcdStatus);
 
-    DEBUG ((EFI_D_INFO, "Found GIC @ 0x%Lx/0x%Lx\n", DistBase, CpuBase));
+    DEBUG ((DEBUG_INFO, "Found GIC @ 0x%Lx/0x%Lx\n", DistBase, CpuBase));
 
     mGicArchRevision = ARM_GIC_ARCH_REVISION_2;
     break;
 
   default:
-    DEBUG ((EFI_D_ERROR, "%a: No GIC revision specified!\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: No GIC revision specified!\n", __FUNCTION__));
     return RETURN_NOT_FOUND;
   }
   return RETURN_SUCCESS;

--- a/ArmVirtPkg/Library/ArmVirtMemoryInitPeiLib/ArmVirtMemoryInitPeiLib.c
+++ b/ArmVirtPkg/Library/ArmVirtMemoryInitPeiLib/ArmVirtMemoryInitPeiLib.c
@@ -39,7 +39,7 @@ InitMmu (
   //      DRAM (even at the top of DRAM as it is the first permanent memory allocation)
   Status = ArmConfigureMmu (MemoryTable, &TranslationTableBase, &TranslationTableSize);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "Error: Failed to enable MMU\n"));
+    DEBUG ((DEBUG_ERROR, "Error: Failed to enable MMU\n"));
   }
 }
 

--- a/ArmVirtPkg/Library/ArmVirtPL031FdtClientLib/ArmVirtPL031FdtClientLib.c
+++ b/ArmVirtPkg/Library/ArmVirtPL031FdtClientLib/ArmVirtPL031FdtClientLib.c
@@ -36,7 +36,7 @@ ArmVirtPL031FdtClientLibConstructor (
 
   Status = FdtClient->FindCompatibleNode (FdtClient, "arm,pl031", &Node);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_WARN, "%a: No 'arm,pl031' compatible DT node found\n",
+    DEBUG ((DEBUG_WARN, "%a: No 'arm,pl031' compatible DT node found\n",
       __FUNCTION__));
     return EFI_SUCCESS;
   }
@@ -44,7 +44,7 @@ ArmVirtPL031FdtClientLibConstructor (
   Status = FdtClient->GetNodeProperty (FdtClient, Node, "reg",
                         (CONST VOID **)&Reg, &RegSize);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_WARN,
+    DEBUG ((DEBUG_WARN,
       "%a: No 'reg' property found in 'arm,pl031' compatible DT node\n",
       __FUNCTION__));
     return EFI_SUCCESS;
@@ -58,7 +58,7 @@ ArmVirtPL031FdtClientLibConstructor (
   PcdStatus = PcdSet32S (PcdPL031RtcBase, (UINT32)RegBase);
   ASSERT_RETURN_ERROR (PcdStatus);
 
-  DEBUG ((EFI_D_INFO, "Found PL031 RTC @ 0x%Lx\n", RegBase));
+  DEBUG ((DEBUG_INFO, "Found PL031 RTC @ 0x%Lx\n", RegBase));
 
   //
   // UEFI takes ownership of the RTC hardware, and exposes its functionality
@@ -69,7 +69,7 @@ ArmVirtPL031FdtClientLibConstructor (
   Status = FdtClient->SetNodeProperty (FdtClient, Node, "status",
                         "disabled", sizeof ("disabled"));
   if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_WARN, "Failed to set PL031 status to 'disabled'\n"));
+      DEBUG ((DEBUG_WARN, "Failed to set PL031 status to 'disabled'\n"));
   }
 
   return EFI_SUCCESS;

--- a/ArmVirtPkg/Library/ArmVirtPsciResetSystemLib/ArmVirtPsciResetSystemLib.c
+++ b/ArmVirtPkg/Library/ArmVirtPsciResetSystemLib/ArmVirtPsciResetSystemLib.c
@@ -54,7 +54,7 @@ ArmPsciResetSystemLibConstructor (
   } else if (AsciiStrnCmp (Prop, "smc", 3) == 0) {
     mArmPsciMethod = 2;
   } else {
-    DEBUG ((EFI_D_ERROR, "%a: Unknown PSCI method \"%a\"\n", __FUNCTION__,
+    DEBUG ((DEBUG_ERROR, "%a: Unknown PSCI method \"%a\"\n", __FUNCTION__,
       Prop));
     return EFI_NOT_FOUND;
   }
@@ -92,7 +92,7 @@ ResetCold (
     break;
 
   default:
-    DEBUG ((EFI_D_ERROR, "%a: no PSCI method defined\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: no PSCI method defined\n", __FUNCTION__));
   }
 }
 
@@ -141,7 +141,7 @@ ResetShutdown (
     break;
 
   default:
-    DEBUG ((EFI_D_ERROR, "%a: no PSCI method defined\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: no PSCI method defined\n", __FUNCTION__));
   }
 }
 

--- a/ArmVirtPkg/Library/ArmVirtTimerFdtClientLib/ArmVirtTimerFdtClientLib.c
+++ b/ArmVirtPkg/Library/ArmVirtTimerFdtClientLib/ArmVirtTimerFdtClientLib.c
@@ -70,7 +70,7 @@ ArmVirtTimerFdtClientLibConstructor (
   HypIntrNum = PropSize < 48 ? 0 : SwapBytes32 (InterruptProp[3].Number)
                                    + (InterruptProp[3].Type ? 16 : 0);
 
-  DEBUG ((EFI_D_INFO, "Found Timer interrupts %d, %d, %d, %d\n",
+  DEBUG ((DEBUG_INFO, "Found Timer interrupts %d, %d, %d, %d\n",
     SecIntrNum, IntrNum, VirtIntrNum, HypIntrNum));
 
   PcdStatus = PcdSet32S (PcdArmArchTimerSecIntrNum, SecIntrNum);

--- a/ArmVirtPkg/Library/PlatformBootManagerLib/PlatformBm.c
+++ b/ArmVirtPkg/Library/PlatformBootManagerLib/PlatformBm.c
@@ -186,7 +186,7 @@ FilterAndProcess (
     //
     // This is not an error, just an informative condition.
     //
-    DEBUG ((EFI_D_VERBOSE, "%a: %g: %r\n", __FUNCTION__, ProtocolGuid,
+    DEBUG ((DEBUG_VERBOSE, "%a: %g: %r\n", __FUNCTION__, ProtocolGuid,
       Status));
     return;
   }
@@ -247,7 +247,7 @@ IsPciDisplay (
   Status = PciIo->Pci.Read (PciIo, EfiPciIoWidthUint32, 0 /* Offset */,
                         sizeof Pci / sizeof (UINT32), &Pci);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: %s: %r\n", __FUNCTION__, ReportText, Status));
+    DEBUG ((DEBUG_ERROR, "%a: %s: %r\n", __FUNCTION__, ReportText, Status));
     return FALSE;
   }
 
@@ -390,7 +390,7 @@ Connect (
                   NULL,   // RemainingDevicePath -- produce all children
                   FALSE   // Recursive
                   );
-  DEBUG ((EFI_ERROR (Status) ? EFI_D_ERROR : EFI_D_VERBOSE, "%a: %s: %r\n",
+  DEBUG ((EFI_ERROR (Status) ? DEBUG_ERROR : DEBUG_VERBOSE, "%a: %s: %r\n",
     __FUNCTION__, ReportText, Status));
 }
 
@@ -412,26 +412,26 @@ AddOutput (
 
   DevicePath = DevicePathFromHandle (Handle);
   if (DevicePath == NULL) {
-    DEBUG ((EFI_D_ERROR, "%a: %s: handle %p: device path not found\n",
+    DEBUG ((DEBUG_ERROR, "%a: %s: handle %p: device path not found\n",
       __FUNCTION__, ReportText, Handle));
     return;
   }
 
   Status = EfiBootManagerUpdateConsoleVariable (ConOut, DevicePath, NULL);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: %s: adding to ConOut: %r\n", __FUNCTION__,
+    DEBUG ((DEBUG_ERROR, "%a: %s: adding to ConOut: %r\n", __FUNCTION__,
       ReportText, Status));
     return;
   }
 
   Status = EfiBootManagerUpdateConsoleVariable (ErrOut, DevicePath, NULL);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: %s: adding to ErrOut: %r\n", __FUNCTION__,
+    DEBUG ((DEBUG_ERROR, "%a: %s: adding to ErrOut: %r\n", __FUNCTION__,
       ReportText, Status));
     return;
   }
 
-  DEBUG ((EFI_D_VERBOSE, "%a: %s: added to ConOut and ErrOut\n", __FUNCTION__,
+  DEBUG ((DEBUG_VERBOSE, "%a: %s: added to ConOut and ErrOut\n", __FUNCTION__,
     ReportText));
 }
 
@@ -611,7 +611,7 @@ RemoveStaleFvFileOptions (
       DevicePathString = ConvertDevicePathToText(BootOptions[Index].FilePath,
                            FALSE, FALSE);
       DEBUG ((
-        EFI_ERROR (Status) ? EFI_D_WARN : EFI_D_VERBOSE,
+        EFI_ERROR (Status) ? DEBUG_WARN : DEBUG_VERBOSE,
         "%a: removing stale Boot#%04x %s: %r\n",
         __FUNCTION__,
         (UINT32)BootOptions[Index].OptionNumber,

--- a/ArmVirtPkg/Library/PlatformPeiLib/PlatformPeiLib.c
+++ b/ArmVirtPkg/Library/PlatformPeiLib/PlatformPeiLib.c
@@ -111,7 +111,7 @@ PlatformPeim (
 
         UartBase = fdt64_to_cpu (ReadUnaligned64 (RegProp));
 
-        DEBUG ((EFI_D_INFO, "%a: PL011 UART @ 0x%lx\n", __FUNCTION__, UartBase));
+        DEBUG ((DEBUG_INFO, "%a: PL011 UART @ 0x%lx\n", __FUNCTION__, UartBase));
 
         *UartHobData = UartBase;
         break;

--- a/ArmVirtPkg/XenAcpiPlatformDxe/XenAcpiPlatformDxe.c
+++ b/ArmVirtPkg/XenAcpiPlatformDxe/XenAcpiPlatformDxe.c
@@ -57,7 +57,7 @@ GetXenArmAcpiRsdp (
                         (CONST VOID **)&Reg, &AddressCells, &SizeCells,
                         &RegSize);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_WARN, "%a: No 'xen,guest-acpi' compatible DT node found\n",
+    DEBUG ((DEBUG_WARN, "%a: No 'xen,guest-acpi' compatible DT node found\n",
       __FUNCTION__));
     return EFI_NOT_FOUND;
   }
@@ -127,7 +127,7 @@ InstallXenArmTables (
   //
   Status = GetXenArmAcpiRsdp (&XenAcpiRsdpStructurePtr);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_INFO, "%a: No RSDP table found\n", __FUNCTION__));
+    DEBUG ((DEBUG_INFO, "%a: No RSDP table found\n", __FUNCTION__));
     return Status;
   }
 

--- a/ArmVirtPkg/XenioFdtDxe/XenioFdtDxe.c
+++ b/ArmVirtPkg/XenioFdtDxe/XenioFdtDxe.c
@@ -38,7 +38,7 @@ InitializeXenioFdtDxe (
                         (CONST VOID **)&Reg, &AddressCells, &SizeCells,
                         &RegSize);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_WARN, "%a: No 'xen,xen' compatible DT node found\n",
+    DEBUG ((DEBUG_WARN, "%a: No 'xen,xen' compatible DT node found\n",
       __FUNCTION__));
     return EFI_UNSUPPORTED;
   }
@@ -55,12 +55,12 @@ InitializeXenioFdtDxe (
   Handle = NULL;
   Status = XenIoMmioInstall (&Handle, RegBase);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: XenIoMmioInstall () failed on a new handle "
+    DEBUG ((DEBUG_ERROR, "%a: XenIoMmioInstall () failed on a new handle "
       "(Status == %r)\n", __FUNCTION__, Status));
     return Status;
   }
 
-  DEBUG ((EFI_D_INFO, "Found Xen node with Grant table @ 0x%Lx\n", RegBase));
+  DEBUG ((DEBUG_INFO, "Found Xen node with Grant table @ 0x%Lx\n", RegBase));
 
   return EFI_SUCCESS;
 }

--- a/EmbeddedPkg/Application/AndroidFastboot/AndroidFastbootApp.c
+++ b/EmbeddedPkg/Application/AndroidFastboot/AndroidFastbootApp.c
@@ -161,7 +161,7 @@ HandleFlash (
   } else if (EFI_ERROR (Status)) {
     SEND_LITERAL ("FAILError flashing partition.");
     mTextOut->OutputString (mTextOut, L"Error flashing partition.\r\n");
-    DEBUG ((EFI_D_ERROR, "Couldn't flash image:  %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "Couldn't flash image:  %r\n", Status));
   } else {
     mTextOut->OutputString (mTextOut, L"Done.\r\n");
     SEND_LITERAL ("OKAY");
@@ -184,7 +184,7 @@ HandleErase (
   Status = mPlatform->ErasePartition (PartitionName);
   if (EFI_ERROR (Status)) {
     SEND_LITERAL ("FAILCheck device console.");
-    DEBUG ((EFI_D_ERROR, "Couldn't erase image:  %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "Couldn't erase image:  %r\n", Status));
   } else {
     SEND_LITERAL ("OKAY");
   }
@@ -212,7 +212,7 @@ HandleBoot (
 
   Status = BootAndroidBootImg (mNumDataBytes, mDataBuffer);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "Failed to boot downloaded image: %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "Failed to boot downloaded image: %r\n", Status));
   }
   // We shouldn't get here
 }
@@ -286,13 +286,13 @@ AcceptCmd (
     gRT->ResetSystem (EfiResetCold, EFI_SUCCESS, 0, NULL);
 
     // Shouldn't get here
-    DEBUG ((EFI_D_ERROR, "Fastboot: gRT->ResetSystem didn't work\n"));
+    DEBUG ((DEBUG_ERROR, "Fastboot: gRT->ResetSystem didn't work\n"));
   } else if (MATCH_CMD_LITERAL ("powerdown", Command)) {
     SEND_LITERAL ("OKAY");
     gRT->ResetSystem (EfiResetShutdown, EFI_SUCCESS, 0, NULL);
 
     // Shouldn't get here
-    DEBUG ((EFI_D_ERROR, "Fastboot: gRT->ResetSystem didn't work\n"));
+    DEBUG ((DEBUG_ERROR, "Fastboot: gRT->ResetSystem didn't work\n"));
   } else if (MATCH_CMD_LITERAL ("oem", Command)) {
     // The "oem" command isn't in the specification, but it was observed in the
     // wild, followed by a space, followed by the actual command.
@@ -430,25 +430,25 @@ FastbootAppEntryPoint (
     (VOID **) &mTransport
     );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "Fastboot: Couldn't open Fastboot Transport Protocol: %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "Fastboot: Couldn't open Fastboot Transport Protocol: %r\n", Status));
     return Status;
   }
 
   Status = gBS->LocateProtocol (&gAndroidFastbootPlatformProtocolGuid, NULL, (VOID **) &mPlatform);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "Fastboot: Couldn't open Fastboot Platform Protocol: %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "Fastboot: Couldn't open Fastboot Platform Protocol: %r\n", Status));
     return Status;
   }
 
   Status = mPlatform->Init ();
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "Fastboot: Couldn't initialise Fastboot Platform Protocol: %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "Fastboot: Couldn't initialise Fastboot Platform Protocol: %r\n", Status));
     return Status;
   }
 
   Status = gBS->LocateProtocol (&gEfiSimpleTextOutProtocolGuid, NULL, (VOID **) &mTextOut);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR,
+    DEBUG ((DEBUG_ERROR,
       "Fastboot: Couldn't open Text Output Protocol: %r\n", Status
       ));
     return Status;
@@ -456,14 +456,14 @@ FastbootAppEntryPoint (
 
   Status = gBS->LocateProtocol (&gEfiSimpleTextInProtocolGuid, NULL, (VOID **) &TextIn);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "Fastboot: Couldn't open Text Input Protocol: %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "Fastboot: Couldn't open Text Input Protocol: %r\n", Status));
     return Status;
   }
 
   // Disable watchdog
   Status = gBS->SetWatchdogTimer (0, 0x10000, 0, NULL);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "Fastboot: Couldn't disable watchdog timer: %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "Fastboot: Couldn't disable watchdog timer: %r\n", Status));
   }
 
   // Create event for receipt of data from the host
@@ -497,7 +497,7 @@ FastbootAppEntryPoint (
     ReceiveEvent
     );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "Fastboot: Couldn't start transport: %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "Fastboot: Couldn't start transport: %r\n", Status));
     return Status;
   }
 
@@ -521,7 +521,7 @@ FastbootAppEntryPoint (
 
   mTransport->Stop ();
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "Warning: Fastboot Transport Stop: %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "Warning: Fastboot Transport Stop: %r\n", Status));
   }
   mPlatform->UnInit ();
 

--- a/EmbeddedPkg/Application/AndroidFastboot/Arm/BootAndroidBootImg.c
+++ b/EmbeddedPkg/Application/AndroidFastboot/Arm/BootAndroidBootImg.c
@@ -162,14 +162,14 @@ BootAndroidBootImg (
              StrSize (LoadOptions),
              LoadOptions);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "Couldn't Boot Linux: %d\n", Status));
+    DEBUG ((DEBUG_ERROR, "Couldn't Boot Linux: %d\n", Status));
     Status = EFI_DEVICE_ERROR;
     goto FreeLoadOptions;
   }
 
   // If we got here we do a confused face because BootLinuxFdt returned,
   // reporting success.
-  DEBUG ((EFI_D_ERROR, "WARNING: BdsBootLinuxFdt returned EFI_SUCCESS.\n"));
+  DEBUG ((DEBUG_ERROR, "WARNING: BdsBootLinuxFdt returned EFI_SUCCESS.\n"));
   return EFI_SUCCESS;
 
 FreeLoadOptions:

--- a/EmbeddedPkg/Drivers/AndroidFastbootTransportTcpDxe/FastbootTransportTcp.c
+++ b/EmbeddedPkg/Drivers/AndroidFastbootTransportTcpDxe/FastbootTransportTcp.c
@@ -99,7 +99,7 @@ SubmitRecieveToken (
   FragmentBuffer = AllocatePool (RX_FRAGMENT_SIZE);
   ASSERT (FragmentBuffer != NULL);
   if (FragmentBuffer == NULL) {
-    DEBUG ((EFI_D_ERROR, "TCP Fastboot out of resources"));
+    DEBUG ((DEBUG_ERROR, "TCP Fastboot out of resources"));
     return EFI_OUT_OF_RESOURCES;
   }
 
@@ -109,7 +109,7 @@ SubmitRecieveToken (
 
   Status = mTcpConnection->Receive (mTcpConnection, &mReceiveToken[mNextSubmitIndex]);
    if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "TCP Receive: %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "TCP Receive: %r\n", Status));
     FreePool (FragmentBuffer);
   }
 
@@ -140,7 +140,7 @@ ConnectionClosed (
 
   Status = mTcpListener->Accept (mTcpListener, &mAcceptToken);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "TCP Accept: %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "TCP Accept: %r\n", Status));
   }
 }
 
@@ -195,7 +195,7 @@ DataReceived (
 
   NewEntry = AllocatePool (sizeof (FASTBOOT_TCP_PACKET_LIST));
   if (NewEntry == NULL) {
-    DEBUG ((EFI_D_ERROR, "TCP Fastboot: Out of resources\n"));
+    DEBUG ((DEBUG_ERROR, "TCP Fastboot: Out of resources\n"));
     return;
   }
 
@@ -215,7 +215,7 @@ DataReceived (
     NewEntry->Buffer = NULL;
     NewEntry->BufferSize = 0;
 
-    DEBUG ((EFI_D_ERROR, "\nTCP Fastboot Receive error: %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "\nTCP Fastboot Receive error: %r\n", Status));
   }
 
   InsertTailList (&mPacketListHead, &NewEntry->Link);
@@ -244,10 +244,10 @@ ConnectionAccepted (
   Status = AcceptToken->CompletionToken.Status;
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "TCP Fastboot: Connection Error: %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "TCP Fastboot: Connection Error: %r\n", Status));
     return;
   }
-  DEBUG ((EFI_D_ERROR, "TCP Fastboot: Connection Received.\n"));
+  DEBUG ((DEBUG_ERROR, "TCP Fastboot: Connection Received.\n"));
 
   //
   // Accepting a new TCP connection creates a new instance of the TCP protocol.
@@ -263,7 +263,7 @@ ConnectionAccepted (
                   EFI_OPEN_PROTOCOL_GET_PROTOCOL
                   );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "Open TCP Connection: %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "Open TCP Connection: %r\n", Status));
     return;
   }
 
@@ -335,7 +335,7 @@ TcpFastbootTransportStart (
                   &HandleBuffer
                   );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "Find TCP Service Binding: %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "Find TCP Service Binding: %r\n", Status));
     return Status;
   }
 
@@ -351,13 +351,13 @@ TcpFastbootTransportStart (
                     EFI_OPEN_PROTOCOL_GET_PROTOCOL
                     );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "Open TCP Service Binding: %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "Open TCP Service Binding: %r\n", Status));
     return Status;
   }
 
   Status = mTcpServiceBinding->CreateChild (mTcpServiceBinding, &mTcpHandle);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "TCP ServiceBinding Create: %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "TCP ServiceBinding Create: %r\n", Status));
     return Status;
   }
 
@@ -370,7 +370,7 @@ TcpFastbootTransportStart (
                     EFI_OPEN_PROTOCOL_GET_PROTOCOL
                     );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "Open TCP Protocol: %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "Open TCP Protocol: %r\n", Status));
   }
 
   //
@@ -423,7 +423,7 @@ TcpFastbootTransportStart (
     } while (!Ip4ModeData.IsConfigured);
     Status = mTcpListener->Configure (mTcpListener, &TcpConfigData);
   } else if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "TCP Configure: %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "TCP Configure: %r\n", Status));
     return Status;
   }
 
@@ -443,7 +443,7 @@ TcpFastbootTransportStart (
 
   Status = mTcpListener->Accept (mTcpListener, &mAcceptToken);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "TCP Accept: %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "TCP Accept: %r\n", Status));
     return Status;
   }
 
@@ -539,7 +539,7 @@ DataSent (
 
   Status = mTransmitToken.CompletionToken.Status;
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "TCP Fastboot transmit result: %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "TCP Fastboot transmit result: %r\n", Status));
     gBS->SignalEvent (*(EFI_EVENT *) Context);
   }
 
@@ -584,7 +584,7 @@ TcpFastbootTransportSend (
 
   Status = mTcpConnection->Transmit (mTcpConnection, &mTransmitToken);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "TCP Transmit: %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "TCP Transmit: %r\n", Status));
     return Status;
   }
 
@@ -642,7 +642,7 @@ TcpFastbootTransportEntryPoint (
     (VOID **) &mTextOut
     );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "Fastboot: Open Text Output Protocol: %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "Fastboot: Open Text Output Protocol: %r\n", Status));
     return Status;
   }
 
@@ -653,7 +653,7 @@ TcpFastbootTransportEntryPoint (
                   &mTransportProtocol
                   );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "Fastboot: Install transport Protocol: %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "Fastboot: Install transport Protocol: %r\n", Status));
   }
 
   return Status;

--- a/EmbeddedPkg/Drivers/FdtClientDxe/FdtClientDxe.c
+++ b/EmbeddedPkg/Drivers/FdtClientDxe/FdtClientDxe.c
@@ -208,7 +208,7 @@ FindCompatibleNodeReg (
   }
 
   if ((*RegSize % 16) != 0) {
-    DEBUG ((EFI_D_ERROR,
+    DEBUG ((DEBUG_ERROR,
       "%a: '%a' compatible node has invalid 'reg' property (size == 0x%x)\n",
       __FUNCTION__, CompatibleString, *RegSize));
     return EFI_NOT_FOUND;
@@ -261,13 +261,13 @@ FindNextMemoryNodeReg (
       //
       Status = GetNodeProperty (This, Next, "reg", Reg, RegSize);
       if (EFI_ERROR (Status)) {
-        DEBUG ((EFI_D_WARN,
+        DEBUG ((DEBUG_WARN,
           "%a: ignoring memory node with no 'reg' property\n",
           __FUNCTION__));
         continue;
       }
       if ((*RegSize % 16) != 0) {
-        DEBUG ((EFI_D_WARN,
+        DEBUG ((DEBUG_WARN,
           "%a: ignoring memory node with invalid 'reg' property (size == 0x%x)\n",
           __FUNCTION__, *RegSize));
         continue;
@@ -391,14 +391,14 @@ InitializeFdtClientDxe (
   DeviceTreeBase = (VOID *)(UINTN)*(UINT64 *)GET_GUID_HOB_DATA (Hob);
 
   if (fdt_check_header (DeviceTreeBase) != 0) {
-    DEBUG ((EFI_D_ERROR, "%a: No DTB found @ 0x%p\n", __FUNCTION__,
+    DEBUG ((DEBUG_ERROR, "%a: No DTB found @ 0x%p\n", __FUNCTION__,
       DeviceTreeBase));
     return EFI_NOT_FOUND;
   }
 
   mDeviceTreeBase = DeviceTreeBase;
 
-  DEBUG ((EFI_D_INFO, "%a: DTB @ 0x%p\n", __FUNCTION__, mDeviceTreeBase));
+  DEBUG ((DEBUG_INFO, "%a: DTB @ 0x%p\n", __FUNCTION__, mDeviceTreeBase));
 
   //
   // Register a protocol notify for the EDKII Platform Has Device Tree

--- a/EmbeddedPkg/GdbStub/Arm/Processor.c
+++ b/EmbeddedPkg/GdbStub/Arm/Processor.c
@@ -416,7 +416,7 @@ AddSingleStep (
   }
 
   InvalidateInstructionCacheRange ((VOID *)mSingleStepPC, mSingleStepDataSize);
-  //DEBUG((EFI_D_ERROR, "AddSingleStep at 0x%08x (was: 0x%08x is:0x%08x)\n", SystemContext.SystemContextArm->PC, mSingleStepData, *(UINT32 *)mSingleStepPC));
+  //DEBUG((DEBUG_ERROR, "AddSingleStep at 0x%08x (was: 0x%08x is:0x%08x)\n", SystemContext.SystemContextArm->PC, mSingleStepData, *(UINT32 *)mSingleStepPC));
 }
 
 
@@ -437,7 +437,7 @@ RemoveSingleStep (
   if (mSingleStepDataSize == sizeof (UINT16)) {
     *(UINT16 *)mSingleStepPC = (UINT16)mSingleStepData;
   } else {
-    //DEBUG((EFI_D_ERROR, "RemoveSingleStep at 0x%08x (was: 0x%08x is:0x%08x)\n", SystemContext.SystemContextArm->PC, *(UINT32 *)mSingleStepPC, mSingleStepData));
+    //DEBUG((DEBUG_ERROR, "RemoveSingleStep at 0x%08x (was: 0x%08x is:0x%08x)\n", SystemContext.SystemContextArm->PC, *(UINT32 *)mSingleStepPC, mSingleStepData));
     *(UINT32 *)mSingleStepPC = mSingleStepData;
   }
   InvalidateInstructionCacheRange ((VOID *)mSingleStepPC, mSingleStepDataSize);
@@ -556,7 +556,7 @@ SetBreakpoint (
   *(UINT32 *)Address = GDB_ARM_BKPT;
   InvalidateInstructionCacheRange ((VOID *)Address, 4);
 
-  //DEBUG((EFI_D_ERROR, "SetBreakpoint at 0x%08x (was: 0x%08x is:0x%08x)\n", Address, Breakpoint->Instruction, *(UINT32 *)Address));
+  //DEBUG((DEBUG_ERROR, "SetBreakpoint at 0x%08x (was: 0x%08x is:0x%08x)\n", Address, Breakpoint->Instruction, *(UINT32 *)Address));
 }
 
 VOID
@@ -579,7 +579,7 @@ ClearBreakpoint (
   *(UINT32 *)Address = Breakpoint->Instruction;
   InvalidateInstructionCacheRange ((VOID *)Address, 4);
 
-  //DEBUG((EFI_D_ERROR, "ClearBreakpoint at 0x%08x (was: 0x%08x is:0x%08x)\n", Address, GDB_ARM_BKPT, *(UINT32 *)Address));
+  //DEBUG((DEBUG_ERROR, "ClearBreakpoint at 0x%08x (was: 0x%08x is:0x%08x)\n", Address, GDB_ARM_BKPT, *(UINT32 *)Address));
 
   FreePool (Breakpoint);
 }
@@ -607,7 +607,7 @@ InsertBreakPoint (
       break;
 
     default  :
-      DEBUG((EFI_D_ERROR, "Insert breakpoint default: %x\n", Type));
+      DEBUG((DEBUG_ERROR, "Insert breakpoint default: %x\n", Type));
       SendError (GDB_EINVALIDBRKPOINTTYPE);
       return;
   }
@@ -694,4 +694,3 @@ ValidateException (
 
   return TRUE;
 }
-

--- a/EmbeddedPkg/GdbStub/GdbStub.c
+++ b/EmbeddedPkg/GdbStub/GdbStub.c
@@ -91,7 +91,7 @@ GdbStubEntry (
                   &Handles
                   );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "Debug Support Protocol not found\n"));
+    DEBUG ((DEBUG_ERROR, "Debug Support Protocol not found\n"));
 
     return Status;
   }
@@ -116,7 +116,7 @@ GdbStubEntry (
   FreePool (Handles);
 
   if (!IsaSupported) {
-    DEBUG ((EFI_D_ERROR, "Debug Support Protocol does not support our ISA\n"));
+    DEBUG ((DEBUG_ERROR, "Debug Support Protocol does not support our ISA\n"));
 
     return EFI_NOT_FOUND;
   }
@@ -124,8 +124,8 @@ GdbStubEntry (
   Status = DebugSupport->GetMaximumProcessorIndex (DebugSupport, &gMaxProcessorIndex);
   ASSERT_EFI_ERROR (Status);
 
-  DEBUG ((EFI_D_INFO, "Debug Support Protocol ISA %x\n", DebugSupport->Isa));
-  DEBUG ((EFI_D_INFO, "Debug Support Protocol Processor Index %d\n", gMaxProcessorIndex));
+  DEBUG ((DEBUG_INFO, "Debug Support Protocol ISA %x\n", DebugSupport->Isa));
+  DEBUG ((DEBUG_INFO, "Debug Support Protocol Processor Index %d\n", gMaxProcessorIndex));
 
   // Call processor-specific init routine
   InitializeProcessor ();

--- a/EmbeddedPkg/Library/AcpiLib/AcpiLib.c
+++ b/EmbeddedPkg/Library/AcpiLib/AcpiLib.c
@@ -108,7 +108,7 @@ LocateAndInstallAcpiFromFvConditional (
         AcpiTableSize = ((EFI_ACPI_DESCRIPTION_HEADER *) AcpiTable)->Length;
         ASSERT (SectionSize >= AcpiTableSize);
 
-        DEBUG ((EFI_D_ERROR, "- Found '%c%c%c%c' ACPI Table\n",
+        DEBUG ((DEBUG_ERROR, "- Found '%c%c%c%c' ACPI Table\n",
             (((EFI_ACPI_DESCRIPTION_HEADER *) AcpiTable)->Signature & 0xFF),
             ((((EFI_ACPI_DESCRIPTION_HEADER *) AcpiTable)->Signature >> 8) & 0xFF),
             ((((EFI_ACPI_DESCRIPTION_HEADER *) AcpiTable)->Signature >> 16) & 0xFF),

--- a/EmbeddedPkg/Library/GdbSerialLib/GdbSerialLib.c
+++ b/EmbeddedPkg/Library/GdbSerialLib/GdbSerialLib.c
@@ -199,8 +199,8 @@ GdbGetChar (
 
   Char = IoRead8 (gPort);
 
-  // Make this an EFI_D_INFO after we get everything debugged.
-  DEBUG ((EFI_D_ERROR, "<%c<", Char));
+  // Make this an DEBUG_INFO after we get everything debugged.
+  DEBUG ((DEBUG_ERROR, "<%c<", Char));
   return Char;
 }
 
@@ -221,8 +221,8 @@ GdbPutChar (
 {
   UINT8   Data;
 
-  // Make this an EFI_D_INFO after we get everything debugged.
-  DEBUG ((EFI_D_ERROR, ">%c>", Char));
+  // Make this an DEBUG_INFO after we get everything debugged.
+  DEBUG ((DEBUG_ERROR, ">%c>", Char));
 
   // Wait for the serial port to be ready
   do {
@@ -250,7 +250,3 @@ GdbPutString (
     String++;
   }
 }
-
-
-
-

--- a/EmbeddedPkg/Library/PrePiLib/FwVol.c
+++ b/EmbeddedPkg/Library/PrePiLib/FwVol.c
@@ -361,7 +361,7 @@ FfsProcessSection (
         //
         // GetInfo failed
         //
-        DEBUG ((EFI_D_ERROR, "Decompress GetInfo Failed - %r\n", Status));
+        DEBUG ((DEBUG_ERROR, "Decompress GetInfo Failed - %r\n", Status));
         return EFI_NOT_FOUND;
       }
       //
@@ -415,7 +415,7 @@ FfsProcessSection (
         //
         // Decompress failed
         //
-        DEBUG ((EFI_D_ERROR, "Decompress Failed - %r\n", Status));
+        DEBUG ((DEBUG_ERROR, "Decompress Failed - %r\n", Status));
         return EFI_NOT_FOUND;
       } else {
         return FfsProcessSection (
@@ -874,5 +874,3 @@ FfsProcessFvFile (
 
   return EFI_SUCCESS;
 }
-
-

--- a/EmbeddedPkg/Library/PrePiLib/PrePiLib.c
+++ b/EmbeddedPkg/Library/PrePiLib/PrePiLib.c
@@ -154,7 +154,7 @@ LoadDxeCoreFromFfsFile (
 
   BuildModuleHob (&FvFileInfo.FileName, (EFI_PHYSICAL_ADDRESS)(UINTN)ImageAddress, EFI_SIZE_TO_PAGES ((UINT32) ImageSize) * EFI_PAGE_SIZE, EntryPoint);
 
-  DEBUG ((EFI_D_INFO | EFI_D_LOAD, "Loading DxeCore at 0x%10p EntryPoint=0x%10p\n", (VOID *)(UINTN)ImageAddress, (VOID *)(UINTN)EntryPoint));
+  DEBUG ((DEBUG_INFO | DEBUG_LOAD, "Loading DxeCore at 0x%10p EntryPoint=0x%10p\n", (VOID *)(UINTN)ImageAddress, (VOID *)(UINTN)EntryPoint));
 
   Hob = GetHobList ();
   if (StackSize == 0) {
@@ -191,7 +191,7 @@ LoadDxeCoreFromFfsFile (
   }
 
   // Should never get here as DXE Core does not return
-  DEBUG ((EFI_D_ERROR, "DxeCore returned\n"));
+  DEBUG ((DEBUG_ERROR, "DxeCore returned\n"));
   ASSERT (FALSE);
 
   return EFI_DEVICE_ERROR;
@@ -247,5 +247,3 @@ DecompressFirstFv (
 
   return Status;
 }
-
-

--- a/EmbeddedPkg/Universal/MmcDxe/Diagnostics.c
+++ b/EmbeddedPkg/Universal/MmcDxe/Diagnostics.c
@@ -74,8 +74,8 @@ CompareBuffer (
 
   for (i = 0; i < (BufferSize >> 3); i++) {
     if (*BufferA64 != *BufferB64) {
-      DEBUG ((EFI_D_ERROR, "CompareBuffer: Error at %i", i));
-      DEBUG ((EFI_D_ERROR, "(0x%lX) != (0x%lX)\n", *BufferA64, *BufferB64));
+      DEBUG ((DEBUG_ERROR, "CompareBuffer: Error at %i", i));
+      DEBUG ((DEBUG_ERROR, "(0x%lX) != (0x%lX)\n", *BufferA64, *BufferB64));
       return FALSE;
     }
     BufferA64++;

--- a/EmbeddedPkg/Universal/MmcDxe/Mmc.h
+++ b/EmbeddedPkg/Universal/MmcDxe/Mmc.h
@@ -21,7 +21,7 @@
 #include <Library/DebugLib.h>
 #include <Library/UefiBootServicesTableLib.h>
 
-#define MMC_TRACE(txt)  DEBUG((EFI_D_BLKIO, "MMC: " txt "\n"))
+#define MMC_TRACE(txt)  DEBUG((DEBUG_BLKIO, "MMC: " txt "\n"))
 
 #define MMC_IOBLOCKS_READ       0
 #define MMC_IOBLOCKS_WRITE      1

--- a/EmbeddedPkg/Universal/MmcDxe/MmcBlockIo.c
+++ b/EmbeddedPkg/Universal/MmcDxe/MmcBlockIo.c
@@ -43,7 +43,7 @@ MmcGetCardStatus (
     CmdArg = MmcHostInstance->CardInfo.RCA << 16;
     Status = MmcHost->SendCommand (MmcHost, MMC_CMD13, CmdArg);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "MmcGetCardStatus(MMC_CMD13): Error and Status = %r\n", Status));
+      DEBUG ((DEBUG_ERROR, "MmcGetCardStatus(MMC_CMD13): Error and Status = %r\n", Status));
       return Status;
     }
 
@@ -163,7 +163,7 @@ MmcTransferBlock (
 
   Status = MmcHost->SendCommand (MmcHost, Cmd, CmdArg);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a(MMC_CMD%d): Error %r\n", __func__, Cmd, Status));
+    DEBUG ((DEBUG_ERROR, "%a(MMC_CMD%d): Error %r\n", __func__, Cmd, Status));
     return Status;
   }
 
@@ -171,20 +171,20 @@ MmcTransferBlock (
     // Read Data
     Status = MmcHost->ReadBlockData (MmcHost, Lba, BufferSize, Buffer);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_BLKIO, "%a(): Error Read Block Data and Status = %r\n", __func__, Status));
+      DEBUG ((DEBUG_BLKIO, "%a(): Error Read Block Data and Status = %r\n", __func__, Status));
       MmcStopTransmission (MmcHost);
       return Status;
     }
     Status = MmcNotifyState (MmcHostInstance, MmcProgrammingState);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "%a() : Error MmcProgrammingState\n", __func__));
+      DEBUG ((DEBUG_ERROR, "%a() : Error MmcProgrammingState\n", __func__));
       return Status;
     }
   } else {
     // Write Data
     Status = MmcHost->WriteBlockData (MmcHost, Lba, BufferSize, Buffer);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_BLKIO, "%a(): Error Write Block Data and Status = %r\n", __func__, Status));
+      DEBUG ((DEBUG_BLKIO, "%a(): Error Write Block Data and Status = %r\n", __func__, Status));
       MmcStopTransmission (MmcHost);
       return Status;
     }
@@ -209,14 +209,14 @@ MmcTransferBlock (
   if (BufferSize > This->Media->BlockSize) {
     Status = MmcHost->SendCommand (MmcHost, MMC_CMD12, 0);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_BLKIO, "%a(): Error and Status:%r\n", __func__, Status));
+      DEBUG ((DEBUG_BLKIO, "%a(): Error and Status:%r\n", __func__, Status));
     }
     MmcHost->ReceiveResponse (MmcHost, MMC_RESPONSE_TYPE_R1b, Response);
   }
 
   Status = MmcNotifyState (MmcHostInstance, MmcTransferState);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "MmcIoBlocks() : Error MmcTransferState\n"));
+    DEBUG ((DEBUG_ERROR, "MmcIoBlocks() : Error MmcTransferState\n"));
     return Status;
   }
   return Status;
@@ -318,7 +318,7 @@ MmcIoBlocks (
     }
 
     if (0 == Timeout) {
-      DEBUG ((EFI_D_ERROR, "The Card is busy\n"));
+      DEBUG ((DEBUG_ERROR, "The Card is busy\n"));
       return EFI_NOT_READY;
     }
 
@@ -346,7 +346,7 @@ MmcIoBlocks (
     }
     Status = MmcTransferBlock (This, Cmd, Transfer, MediaId, Lba, ConsumeSize, Buffer);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "%a(): Failed to transfer block and Status:%r\n", __func__, Status));
+      DEBUG ((DEBUG_ERROR, "%a(): Failed to transfer block and Status:%r\n", __func__, Status));
     }
 
     RemainingBlock -= BlockCount;

--- a/EmbeddedPkg/Universal/MmcDxe/MmcDebug.c
+++ b/EmbeddedPkg/Universal/MmcDxe/MmcDebug.c
@@ -20,12 +20,12 @@ PrintCID (
   IN UINT32* Cid
   )
 {
-  DEBUG ((EFI_D_ERROR, "- PrintCID\n"));
-  DEBUG ((EFI_D_ERROR, "\t- Manufacturing date: %d/%d\n", (Cid[0] >> 8) & 0xF, (Cid[0] >> 12) & 0xFF));
-  DEBUG ((EFI_D_ERROR, "\t- Product serial number: 0x%X%X\n", Cid[1] & 0xFFFFFF, (Cid[0] >> 24) & 0xFF));
-  DEBUG ((EFI_D_ERROR, "\t- Product revision: %d\n", Cid[1] >> 24));
-  //DEBUG ((EFI_D_ERROR, "\t- Product name: %s\n", (char*)(Cid + 2)));
-  DEBUG ((EFI_D_ERROR, "\t- OEM ID: %c%c\n", (Cid[3] >> 8) & 0xFF, (Cid[3] >> 16) & 0xFF));
+  DEBUG ((DEBUG_ERROR, "- PrintCID\n"));
+  DEBUG ((DEBUG_ERROR, "\t- Manufacturing date: %d/%d\n", (Cid[0] >> 8) & 0xF, (Cid[0] >> 12) & 0xFF));
+  DEBUG ((DEBUG_ERROR, "\t- Product serial number: 0x%X%X\n", Cid[1] & 0xFFFFFF, (Cid[0] >> 24) & 0xFF));
+  DEBUG ((DEBUG_ERROR, "\t- Product revision: %d\n", Cid[1] >> 24));
+  //DEBUG ((DEBUG_ERROR, "\t- Product name: %s\n", (char*)(Cid + 2)));
+  DEBUG ((DEBUG_ERROR, "\t- OEM ID: %c%c\n", (Cid[3] >> 8) & 0xFF, (Cid[3] >> 16) & 0xFF));
 }
 
 
@@ -37,31 +37,31 @@ PrintCSD (
   UINTN Value;
 
   if (((Csd[2] >> 30) & 0x3) == 0) {
-    DEBUG ((EFI_D_ERROR, "- PrintCSD Version 1.01-1.10/Version 2.00/Standard Capacity\n"));
+    DEBUG ((DEBUG_ERROR, "- PrintCSD Version 1.01-1.10/Version 2.00/Standard Capacity\n"));
   } else if (((Csd[2] >> 30) & 0x3) == 1) {
-    DEBUG ((EFI_D_ERROR, "- PrintCSD Version 2.00/High Capacity\n"));
+    DEBUG ((DEBUG_ERROR, "- PrintCSD Version 2.00/High Capacity\n"));
   } else {
-    DEBUG ((EFI_D_ERROR, "- PrintCSD Version Higher than v3.3\n"));
+    DEBUG ((DEBUG_ERROR, "- PrintCSD Version Higher than v3.3\n"));
   }
 
-  DEBUG ((EFI_D_ERROR, "\t- Supported card command class: 0x%X\n", MMC_CSD_GET_CCC (Csd)));
-  DEBUG ((EFI_D_ERROR, "\t- Speed: %a %a\n",mStrValue[(MMC_CSD_GET_TRANSPEED (Csd) >> 3) & 0xF],mStrUnit[MMC_CSD_GET_TRANSPEED (Csd) & 7]));
-  DEBUG ((EFI_D_ERROR, "\t- Maximum Read Data Block: %d\n",2 << (MMC_CSD_GET_READBLLEN (Csd)-1)));
-  DEBUG ((EFI_D_ERROR, "\t- Maximum Write Data Block: %d\n",2 << (MMC_CSD_GET_WRITEBLLEN (Csd)-1)));
+  DEBUG ((DEBUG_ERROR, "\t- Supported card command class: 0x%X\n", MMC_CSD_GET_CCC (Csd)));
+  DEBUG ((DEBUG_ERROR, "\t- Speed: %a %a\n",mStrValue[(MMC_CSD_GET_TRANSPEED (Csd) >> 3) & 0xF],mStrUnit[MMC_CSD_GET_TRANSPEED (Csd) & 7]));
+  DEBUG ((DEBUG_ERROR, "\t- Maximum Read Data Block: %d\n",2 << (MMC_CSD_GET_READBLLEN (Csd)-1)));
+  DEBUG ((DEBUG_ERROR, "\t- Maximum Write Data Block: %d\n",2 << (MMC_CSD_GET_WRITEBLLEN (Csd)-1)));
 
   if (!MMC_CSD_GET_FILEFORMATGRP (Csd)) {
     Value = MMC_CSD_GET_FILEFORMAT (Csd);
     if (Value == 0) {
-      DEBUG ((EFI_D_ERROR, "\t- Format (0): Hard disk-like file system with partition table\n"));
+      DEBUG ((DEBUG_ERROR, "\t- Format (0): Hard disk-like file system with partition table\n"));
     } else if (Value == 1) {
-      DEBUG ((EFI_D_ERROR, "\t- Format (1): DOS FAT (floppy-like) with boot sector only (no partition table)\n"));
+      DEBUG ((DEBUG_ERROR, "\t- Format (1): DOS FAT (floppy-like) with boot sector only (no partition table)\n"));
     } else if (Value == 2) {
-      DEBUG ((EFI_D_ERROR, "\t- Format (2): Universal File Format\n"));
+      DEBUG ((DEBUG_ERROR, "\t- Format (2): Universal File Format\n"));
     } else {
-      DEBUG ((EFI_D_ERROR, "\t- Format (3): Others/Unknown\n"));
+      DEBUG ((DEBUG_ERROR, "\t- Format (3): Others/Unknown\n"));
     }
   } else {
-    DEBUG ((EFI_D_ERROR, "\t- Format: Reserved\n"));
+    DEBUG ((DEBUG_ERROR, "\t- Format: Reserved\n"));
   }
 }
 
@@ -70,9 +70,9 @@ PrintRCA (
   IN UINT32 Rca
   )
 {
-  DEBUG ((EFI_D_ERROR, "- PrintRCA: 0x%X\n", Rca));
-  DEBUG ((EFI_D_ERROR, "\t- Status: 0x%X\n", Rca & 0xFFFF));
-  DEBUG ((EFI_D_ERROR, "\t- RCA: 0x%X\n", (Rca >> 16) & 0xFFFF));
+  DEBUG ((DEBUG_ERROR, "- PrintRCA: 0x%X\n", Rca));
+  DEBUG ((DEBUG_ERROR, "\t- Status: 0x%X\n", Rca & 0xFFFF));
+  DEBUG ((DEBUG_ERROR, "\t- RCA: 0x%X\n", (Rca >> 16) & 0xFFFF));
 }
 
 VOID
@@ -102,18 +102,18 @@ PrintOCR (
     Volts++;
   }
 
-  DEBUG ((EFI_D_ERROR, "- PrintOCR Ocr (0x%X)\n",Ocr));
-  DEBUG ((EFI_D_ERROR, "\t- Card operating voltage: %d.%d to %d.%d\n", MinV/10, MinV % 10, MaxV/10, MaxV % 10));
+  DEBUG ((DEBUG_ERROR, "- PrintOCR Ocr (0x%X)\n",Ocr));
+  DEBUG ((DEBUG_ERROR, "\t- Card operating voltage: %d.%d to %d.%d\n", MinV/10, MinV % 10, MaxV/10, MaxV % 10));
   if (((Ocr >> 29) & 3) == 0) {
-    DEBUG ((EFI_D_ERROR, "\t- AccessMode: Byte Mode\n"));
+    DEBUG ((DEBUG_ERROR, "\t- AccessMode: Byte Mode\n"));
   } else {
-    DEBUG ((EFI_D_ERROR, "\t- AccessMode: Block Mode (0x%X)\n", ((Ocr >> 29) & 3)));
+    DEBUG ((DEBUG_ERROR, "\t- AccessMode: Block Mode (0x%X)\n", ((Ocr >> 29) & 3)));
   }
 
   if (Ocr & MMC_OCR_POWERUP) {
-    DEBUG ((EFI_D_ERROR, "\t- PowerUp\n"));
+    DEBUG ((DEBUG_ERROR, "\t- PowerUp\n"));
   } else {
-    DEBUG ((EFI_D_ERROR, "\t- Voltage Not Supported\n"));
+    DEBUG ((DEBUG_ERROR, "\t- Voltage Not Supported\n"));
   }
 }
 
@@ -122,41 +122,41 @@ PrintResponseR1 (
   IN  UINT32 Response
   )
 {
-  DEBUG ((EFI_D_INFO, "Response: 0x%X\n", Response));
+  DEBUG ((DEBUG_INFO, "Response: 0x%X\n", Response));
   if (Response & MMC_R0_READY_FOR_DATA) {
-    DEBUG ((EFI_D_INFO, "\t- READY_FOR_DATA\n"));
+    DEBUG ((DEBUG_INFO, "\t- READY_FOR_DATA\n"));
   }
 
   switch ((Response >> 9) & 0xF) {
   case 0:
-    DEBUG ((EFI_D_INFO, "\t- State: Idle\n"));
+    DEBUG ((DEBUG_INFO, "\t- State: Idle\n"));
     break;
   case 1:
-    DEBUG ((EFI_D_INFO, "\t- State: Ready\n"));
+    DEBUG ((DEBUG_INFO, "\t- State: Ready\n"));
     break;
   case 2:
-    DEBUG ((EFI_D_INFO, "\t- State: Ident\n"));
+    DEBUG ((DEBUG_INFO, "\t- State: Ident\n"));
     break;
   case 3:
-    DEBUG ((EFI_D_INFO, "\t- State: StandBy\n"));
+    DEBUG ((DEBUG_INFO, "\t- State: StandBy\n"));
     break;
   case 4:
-    DEBUG ((EFI_D_INFO, "\t- State: Tran\n"));
+    DEBUG ((DEBUG_INFO, "\t- State: Tran\n"));
     break;
   case 5:
-    DEBUG ((EFI_D_INFO, "\t- State: Data\n"));
+    DEBUG ((DEBUG_INFO, "\t- State: Data\n"));
     break;
   case 6:
-    DEBUG ((EFI_D_INFO, "\t- State: Rcv\n"));
+    DEBUG ((DEBUG_INFO, "\t- State: Rcv\n"));
     break;
   case 7:
-    DEBUG ((EFI_D_INFO, "\t- State: Prg\n"));
+    DEBUG ((DEBUG_INFO, "\t- State: Prg\n"));
     break;
   case 8:
-    DEBUG ((EFI_D_INFO, "\t- State: Dis\n"));
+    DEBUG ((DEBUG_INFO, "\t- State: Dis\n"));
     break;
   default:
-    DEBUG ((EFI_D_INFO, "\t- State: Reserved\n"));
+    DEBUG ((DEBUG_INFO, "\t- State: Reserved\n"));
     break;
   }
 }

--- a/EmbeddedPkg/Universal/MmcDxe/MmcIdentification.c
+++ b/EmbeddedPkg/Universal/MmcDxe/MmcIdentification.c
@@ -81,16 +81,16 @@ EmmcGetDeviceState (
   RCA = MmcHostInstance->CardInfo.RCA << RCA_SHIFT_OFFSET;
   Status = Host->SendCommand (Host, MMC_CMD13, RCA);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "EmmcGetDeviceState(): Failed to get card status, Status=%r.\n", Status));
+    DEBUG ((DEBUG_ERROR, "EmmcGetDeviceState(): Failed to get card status, Status=%r.\n", Status));
     return Status;
   }
   Status = Host->ReceiveResponse (Host, MMC_RESPONSE_TYPE_R1, &Data);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "EmmcGetDeviceState(): Failed to get response of CMD13, Status=%r.\n", Status));
+    DEBUG ((DEBUG_ERROR, "EmmcGetDeviceState(): Failed to get response of CMD13, Status=%r.\n", Status));
     return Status;
   }
   if (Data & EMMC_SWITCH_ERROR) {
-    DEBUG ((EFI_D_ERROR, "EmmcGetDeviceState(): Failed to switch expected mode, Status=%r.\n", Status));
+    DEBUG ((DEBUG_ERROR, "EmmcGetDeviceState(): Failed to switch expected mode, Status=%r.\n", Status));
     return EFI_DEVICE_ERROR;
   }
   *State = DEVICE_STATE(Data);
@@ -116,14 +116,14 @@ EmmcSetEXTCSD (
              EMMC_CMD6_ARG_VALUE(Value) | EMMC_CMD6_ARG_CMD_SET(1);
   Status = Host->SendCommand (Host, MMC_CMD6, Argument);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "EmmcSetEXTCSD(): Failed to send CMD6, Status=%r.\n", Status));
+    DEBUG ((DEBUG_ERROR, "EmmcSetEXTCSD(): Failed to send CMD6, Status=%r.\n", Status));
     return Status;
   }
   // Make sure device exiting prog mode
   do {
     Status = EmmcGetDeviceState (MmcHostInstance, &State);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "EmmcSetEXTCSD(): Failed to get device state, Status=%r.\n", Status));
+      DEBUG ((DEBUG_ERROR, "EmmcSetEXTCSD(): Failed to get device state, Status=%r.\n", Status));
       return Status;
     }
   } while (State == EMMC_PRG_STATE);
@@ -150,13 +150,13 @@ EmmcIdentificationMode (
   // Fetch card identity register
   Status = Host->SendCommand (Host, MMC_CMD2, 0);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "EmmcIdentificationMode(): Failed to send CMD2, Status=%r.\n", Status));
+    DEBUG ((DEBUG_ERROR, "EmmcIdentificationMode(): Failed to send CMD2, Status=%r.\n", Status));
     return Status;
   }
 
   Status = Host->ReceiveResponse (Host, MMC_RESPONSE_TYPE_R2, (UINT32 *)&(MmcHostInstance->CardInfo.CIDData));
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "EmmcIdentificationMode(): CID retrieval error, Status=%r.\n", Status));
+    DEBUG ((DEBUG_ERROR, "EmmcIdentificationMode(): CID retrieval error, Status=%r.\n", Status));
     return Status;
   }
 
@@ -165,41 +165,41 @@ EmmcIdentificationMode (
   RCA = MmcHostInstance->CardInfo.RCA << RCA_SHIFT_OFFSET;
   Status = Host->SendCommand (Host, MMC_CMD3, RCA);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "EmmcIdentificationMode(): RCA set error, Status=%r.\n", Status));
+    DEBUG ((DEBUG_ERROR, "EmmcIdentificationMode(): RCA set error, Status=%r.\n", Status));
     return Status;
   }
 
   // Fetch card specific data
   Status = Host->SendCommand (Host, MMC_CMD9, RCA);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "EmmcIdentificationMode(): Failed to send CMD9, Status=%r.\n", Status));
+    DEBUG ((DEBUG_ERROR, "EmmcIdentificationMode(): Failed to send CMD9, Status=%r.\n", Status));
     return Status;
   }
 
   Status = Host->ReceiveResponse (Host, MMC_RESPONSE_TYPE_R2, (UINT32 *)&(MmcHostInstance->CardInfo.CSDData));
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "EmmcIdentificationMode(): CSD retrieval error, Status=%r.\n", Status));
+    DEBUG ((DEBUG_ERROR, "EmmcIdentificationMode(): CSD retrieval error, Status=%r.\n", Status));
     return Status;
   }
 
   // Select the card
   Status = Host->SendCommand (Host, MMC_CMD7, RCA);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "EmmcIdentificationMode(): Card selection error, Status=%r.\n", Status));
+    DEBUG ((DEBUG_ERROR, "EmmcIdentificationMode(): Card selection error, Status=%r.\n", Status));
   }
 
   if (MMC_HOST_HAS_SETIOS(Host)) {
     // Set 1-bit bus width
     Status = Host->SetIos (Host, 0, 1, EMMCBACKWARD);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "EmmcIdentificationMode(): Set 1-bit bus width error, Status=%r.\n", Status));
+      DEBUG ((DEBUG_ERROR, "EmmcIdentificationMode(): Set 1-bit bus width error, Status=%r.\n", Status));
       return Status;
     }
 
     // Set 1-bit bus width for EXTCSD
     Status = EmmcSetEXTCSD (MmcHostInstance, EXTCSD_BUS_WIDTH, EMMC_BUS_WIDTH_1BIT);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "EmmcIdentificationMode(): Set extcsd bus width error, Status=%r.\n", Status));
+      DEBUG ((DEBUG_ERROR, "EmmcIdentificationMode(): Set extcsd bus width error, Status=%r.\n", Status));
       return Status;
     }
   }
@@ -211,12 +211,12 @@ EmmcIdentificationMode (
   }
   Status = Host->SendCommand (Host, MMC_CMD8, 0);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "EmmcIdentificationMode(): ECSD fetch error, Status=%r.\n", Status));
+    DEBUG ((DEBUG_ERROR, "EmmcIdentificationMode(): ECSD fetch error, Status=%r.\n", Status));
   }
 
   Status = Host->ReadBlockData (Host, 0, 512, (UINT32 *)MmcHostInstance->CardInfo.ECSDData);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "EmmcIdentificationMode(): ECSD read error, Status=%r.\n", Status));
+    DEBUG ((DEBUG_ERROR, "EmmcIdentificationMode(): ECSD read error, Status=%r.\n", Status));
     goto FreePageExit;
   }
 
@@ -224,7 +224,7 @@ EmmcIdentificationMode (
   do {
     Status = EmmcGetDeviceState (MmcHostInstance, &State);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "EmmcIdentificationMode(): Failed to get device state, Status=%r.\n", Status));
+      DEBUG ((DEBUG_ERROR, "EmmcIdentificationMode(): Failed to get device state, Status=%r.\n", Status));
       goto FreePageExit;
     }
   } while (State == EMMC_DATA_STATE);
@@ -353,14 +353,14 @@ InitializeSdMmcDevice (
   CmdArg = MmcHostInstance->CardInfo.RCA << 16;
   Status = MmcHost->SendCommand (MmcHost, MMC_CMD9, CmdArg);
   if (EFI_ERROR (Status)) {
-    DEBUG((EFI_D_ERROR, "InitializeSdMmcDevice(MMC_CMD9): Error, Status=%r\n", Status));
+    DEBUG((DEBUG_ERROR, "InitializeSdMmcDevice(MMC_CMD9): Error, Status=%r\n", Status));
     return Status;
   }
 
   // Read Response
   Status = MmcHost->ReceiveResponse (MmcHost, MMC_RESPONSE_TYPE_CSD, Response);
   if (EFI_ERROR (Status)) {
-    DEBUG((EFI_D_ERROR, "InitializeSdMmcDevice(): Failed to receive CSD, Status=%r\n", Status));
+    DEBUG((DEBUG_ERROR, "InitializeSdMmcDevice(): Failed to receive CSD, Status=%r\n", Status));
     return Status;
   }
   PrintCSD (Response);
@@ -395,7 +395,7 @@ InitializeSdMmcDevice (
   CmdArg = MmcHostInstance->CardInfo.RCA << 16;
   Status = MmcHost->SendCommand (MmcHost, MMC_CMD7, CmdArg);
   if (EFI_ERROR (Status)) {
-    DEBUG((EFI_D_ERROR, "InitializeSdMmcDevice(MMC_CMD7): Error and Status = %r\n", Status));
+    DEBUG((DEBUG_ERROR, "InitializeSdMmcDevice(MMC_CMD7): Error and Status = %r\n", Status));
     return Status;
   }
 
@@ -416,38 +416,38 @@ InitializeSdMmcDevice (
   /* SCR */
   Status = MmcHost->SendCommand (MmcHost, MMC_ACMD51, 0);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a(MMC_ACMD51): Error and Status = %r\n", __func__, Status));
+    DEBUG ((DEBUG_ERROR, "%a(MMC_ACMD51): Error and Status = %r\n", __func__, Status));
     return Status;
   } else {
     Status = MmcHost->ReadBlockData (MmcHost, 0, 8, Buffer);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "%a(MMC_ACMD51): ReadBlockData Error and Status = %r\n", __func__, Status));
+      DEBUG ((DEBUG_ERROR, "%a(MMC_ACMD51): ReadBlockData Error and Status = %r\n", __func__, Status));
       return Status;
     }
     CopyMem (&Scr, Buffer, 8);
     if (Scr.SD_SPEC == 2) {
       if (Scr.SD_SPEC3 == 1) {
-	if (Scr.SD_SPEC4 == 1) {
-          DEBUG ((EFI_D_INFO, "Found SD Card for Spec Version 4.xx\n"));
-	} else {
-          DEBUG ((EFI_D_INFO, "Found SD Card for Spec Version 3.0x\n"));
-	}
+  if (Scr.SD_SPEC4 == 1) {
+          DEBUG ((DEBUG_INFO, "Found SD Card for Spec Version 4.xx\n"));
+  } else {
+          DEBUG ((DEBUG_INFO, "Found SD Card for Spec Version 3.0x\n"));
+  }
       } else {
-	if (Scr.SD_SPEC4 == 0) {
-          DEBUG ((EFI_D_INFO, "Found SD Card for Spec Version 2.0\n"));
-	} else {
-	  DEBUG ((EFI_D_ERROR, "Found invalid SD Card\n"));
-	}
+  if (Scr.SD_SPEC4 == 0) {
+          DEBUG ((DEBUG_INFO, "Found SD Card for Spec Version 2.0\n"));
+  } else {
+    DEBUG ((DEBUG_ERROR, "Found invalid SD Card\n"));
+  }
       }
     } else {
       if ((Scr.SD_SPEC3 == 0) && (Scr.SD_SPEC4 == 0)) {
         if (Scr.SD_SPEC == 1) {
-	  DEBUG ((EFI_D_INFO, "Found SD Card for Spec Version 1.10\n"));
-	} else {
-	  DEBUG ((EFI_D_INFO, "Found SD Card for Spec Version 1.0\n"));
-	}
+    DEBUG ((DEBUG_INFO, "Found SD Card for Spec Version 1.10\n"));
+  } else {
+    DEBUG ((DEBUG_INFO, "Found SD Card for Spec Version 1.0\n"));
+  }
       } else {
-        DEBUG ((EFI_D_ERROR, "Found invalid SD Card\n"));
+        DEBUG ((DEBUG_ERROR, "Found invalid SD Card\n"));
       }
     }
   }
@@ -543,19 +543,19 @@ MmcIdentificationMode (
     // Initialize the MMC Host HW
     Status = MmcNotifyState (MmcHostInstance, MmcHwInitializationState);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "MmcIdentificationMode() : Error MmcHwInitializationState, Status=%r.\n", Status));
+      DEBUG ((DEBUG_ERROR, "MmcIdentificationMode() : Error MmcHwInitializationState, Status=%r.\n", Status));
       return Status;
     }
   }
 
   Status = MmcHost->SendCommand (MmcHost, MMC_CMD0, 0);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "MmcIdentificationMode(MMC_CMD0): Error, Status=%r.\n", Status));
+    DEBUG ((DEBUG_ERROR, "MmcIdentificationMode(MMC_CMD0): Error, Status=%r.\n", Status));
     return Status;
   }
   Status = MmcNotifyState (MmcHostInstance, MmcIdleState);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "MmcIdentificationMode() : Error MmcIdleState, Status=%r.\n", Status));
+    DEBUG ((DEBUG_ERROR, "MmcIdentificationMode() : Error MmcIdleState, Status=%r.\n", Status));
     return Status;
   }
 
@@ -568,14 +568,14 @@ MmcIdentificationMode (
       break;
     Status = MmcHost->ReceiveResponse (MmcHost, MMC_RESPONSE_TYPE_OCR, (UINT32 *)&OcrResponse);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "MmcIdentificationMode() : Failed to receive OCR, Status=%r.\n", Status));
+      DEBUG ((DEBUG_ERROR, "MmcIdentificationMode() : Failed to receive OCR, Status=%r.\n", Status));
       return Status;
     }
     Timeout--;
   } while (!OcrResponse.Ocr.PowerUp && (Timeout > 0));
   if (Status == EFI_SUCCESS) {
     if (!OcrResponse.Ocr.PowerUp) {
-      DEBUG ((EFI_D_ERROR, "MmcIdentificationMode(MMC_CMD1): Card initialisation failure, Status=%r.\n", Status));
+      DEBUG ((DEBUG_ERROR, "MmcIdentificationMode(MMC_CMD1): Card initialisation failure, Status=%r.\n", Status));
       return EFI_DEVICE_ERROR;
     }
     OcrResponse.Ocr.PowerUp = 0;
@@ -595,7 +595,7 @@ MmcIdentificationMode (
   // Are we using SDIO ?
   Status = MmcHost->SendCommand (MmcHost, MMC_CMD5, 0);
   if (Status == EFI_SUCCESS) {
-    DEBUG ((EFI_D_ERROR, "MmcIdentificationMode(MMC_CMD5): Error - SDIO not supported, Status=%r.\n", Status));
+    DEBUG ((DEBUG_ERROR, "MmcIdentificationMode(MMC_CMD5): Error - SDIO not supported, Status=%r.\n", Status));
     return EFI_UNSUPPORTED;
   }
 
@@ -603,21 +603,21 @@ MmcIdentificationMode (
   CmdArg = (0x0UL << 12 | BIT8 | 0xCEUL << 0);
   Status = MmcHost->SendCommand (MmcHost, MMC_CMD8, CmdArg);
   if (Status == EFI_SUCCESS) {
-    DEBUG ((EFI_D_ERROR, "Card is SD2.0 => Supports high capacity\n"));
+    DEBUG ((DEBUG_ERROR, "Card is SD2.0 => Supports high capacity\n"));
     IsHCS = TRUE;
     Status = MmcHost->ReceiveResponse (MmcHost, MMC_RESPONSE_TYPE_R7, Response);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "MmcIdentificationMode() : Failed to receive response to CMD8, Status=%r.\n", Status));
+      DEBUG ((DEBUG_ERROR, "MmcIdentificationMode() : Failed to receive response to CMD8, Status=%r.\n", Status));
       return Status;
     }
     PrintResponseR1 (Response[0]);
     // Check if it is valid response
     if (Response[0] != CmdArg) {
-      DEBUG ((EFI_D_ERROR, "The Card is not usable\n"));
+      DEBUG ((DEBUG_ERROR, "The Card is not usable\n"));
       return EFI_UNSUPPORTED;
     }
   } else {
-    DEBUG ((EFI_D_ERROR, "Not a SD2.0 Card\n"));
+    DEBUG ((DEBUG_ERROR, "Not a SD2.0 Card\n"));
   }
 
   // We need to wait for the MMC or SD card is ready => (gCardInfo.OCRData.PowerUp == 1)
@@ -626,7 +626,7 @@ MmcIdentificationMode (
     // SD Card or MMC Card ? CMD55 indicates to the card that the next command is an application specific command
     Status = MmcHost->SendCommand (MmcHost, MMC_CMD55, 0);
     if (Status == EFI_SUCCESS) {
-      DEBUG ((EFI_D_INFO, "Card should be SD\n"));
+      DEBUG ((DEBUG_INFO, "Card should be SD\n"));
       if (IsHCS) {
         MmcHostInstance->CardInfo.CardType = SD_CARD_2;
       } else {
@@ -642,20 +642,20 @@ MmcIdentificationMode (
       if (!EFI_ERROR (Status)) {
         Status = MmcHost->ReceiveResponse (MmcHost, MMC_RESPONSE_TYPE_OCR, Response);
         if (EFI_ERROR (Status)) {
-          DEBUG ((EFI_D_ERROR, "MmcIdentificationMode() : Failed to receive OCR, Status=%r.\n", Status));
+          DEBUG ((DEBUG_ERROR, "MmcIdentificationMode() : Failed to receive OCR, Status=%r.\n", Status));
           return Status;
         }
         ((UINT32 *) &(MmcHostInstance->CardInfo.OCRData))[0] = Response[0];
       }
     } else {
-      DEBUG ((EFI_D_INFO, "Card should be MMC\n"));
+      DEBUG ((DEBUG_INFO, "Card should be MMC\n"));
       MmcHostInstance->CardInfo.CardType = MMC_CARD;
 
       Status = MmcHost->SendCommand (MmcHost, MMC_CMD1, 0x800000);
       if (!EFI_ERROR (Status)) {
         Status = MmcHost->ReceiveResponse (MmcHost, MMC_RESPONSE_TYPE_OCR, Response);
         if (EFI_ERROR (Status)) {
-          DEBUG ((EFI_D_ERROR, "MmcIdentificationMode() : Failed to receive OCR, Status=%r.\n", Status));
+          DEBUG ((DEBUG_ERROR, "MmcIdentificationMode() : Failed to receive OCR, Status=%r.\n", Status));
           return Status;
         }
         ((UINT32 *) &(MmcHostInstance->CardInfo.OCRData))[0] = Response[0];
@@ -669,7 +669,7 @@ MmcIdentificationMode (
       } else {
         if ((MmcHostInstance->CardInfo.CardType == SD_CARD_2) && (MmcHostInstance->CardInfo.OCRData.AccessMode & BIT1)) {
           MmcHostInstance->CardInfo.CardType = SD_CARD_2_HIGH;
-          DEBUG ((EFI_D_ERROR, "High capacity card.\n"));
+          DEBUG ((DEBUG_ERROR, "High capacity card.\n"));
         }
         break;  // The MMC/SD card is ready. Continue the Identification Mode
       }
@@ -680,7 +680,7 @@ MmcIdentificationMode (
   }
 
   if (Timeout == 0) {
-    DEBUG ((EFI_D_ERROR, "MmcIdentificationMode(): No Card\n"));
+    DEBUG ((DEBUG_ERROR, "MmcIdentificationMode(): No Card\n"));
     return EFI_NO_MEDIA;
   } else {
     PrintOCR (Response[0]);
@@ -688,18 +688,18 @@ MmcIdentificationMode (
 
   Status = MmcNotifyState (MmcHostInstance, MmcReadyState);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "MmcIdentificationMode() : Error MmcReadyState\n"));
+    DEBUG ((DEBUG_ERROR, "MmcIdentificationMode() : Error MmcReadyState\n"));
     return Status;
   }
 
   Status = MmcHost->SendCommand (MmcHost, MMC_CMD2, 0);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "MmcIdentificationMode(MMC_CMD2): Error\n"));
+    DEBUG ((DEBUG_ERROR, "MmcIdentificationMode(MMC_CMD2): Error\n"));
     return Status;
   }
   Status = MmcHost->ReceiveResponse (MmcHost, MMC_RESPONSE_TYPE_CID, Response);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "MmcIdentificationMode() : Failed to receive CID, Status=%r.\n", Status));
+    DEBUG ((DEBUG_ERROR, "MmcIdentificationMode() : Failed to receive CID, Status=%r.\n", Status));
     return Status;
   }
 
@@ -707,7 +707,7 @@ MmcIdentificationMode (
 
   Status = MmcHost->NotifyState (MmcHost, MmcIdentificationState);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "MmcIdentificationMode() : Error MmcIdentificationState\n"));
+    DEBUG ((DEBUG_ERROR, "MmcIdentificationMode() : Error MmcIdentificationState\n"));
     return Status;
   }
 
@@ -719,13 +719,13 @@ MmcIdentificationMode (
   CmdArg = 1;
   Status = MmcHost->SendCommand (MmcHost, MMC_CMD3, CmdArg);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "MmcIdentificationMode(MMC_CMD3): Error\n"));
+    DEBUG ((DEBUG_ERROR, "MmcIdentificationMode(MMC_CMD3): Error\n"));
     return Status;
   }
 
   Status = MmcHost->ReceiveResponse (MmcHost, MMC_RESPONSE_TYPE_RCA, Response);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "MmcIdentificationMode() : Failed to receive RCA, Status=%r.\n", Status));
+    DEBUG ((DEBUG_ERROR, "MmcIdentificationMode() : Failed to receive RCA, Status=%r.\n", Status));
     return Status;
   }
   PrintRCA (Response[0]);
@@ -738,7 +738,7 @@ MmcIdentificationMode (
   }
   Status = MmcNotifyState (MmcHostInstance, MmcStandByState);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "MmcIdentificationMode() : Error MmcStandByState\n"));
+    DEBUG ((DEBUG_ERROR, "MmcIdentificationMode() : Error MmcStandByState\n"));
     return Status;
   }
 
@@ -759,13 +759,13 @@ InitializeMmcDevice (
 
   Status = MmcIdentificationMode (MmcHostInstance);
   if (EFI_ERROR (Status)) {
-    DEBUG((EFI_D_ERROR, "InitializeMmcDevice(): Error in Identification Mode, Status=%r\n", Status));
+    DEBUG((DEBUG_ERROR, "InitializeMmcDevice(): Error in Identification Mode, Status=%r\n", Status));
     return Status;
   }
 
   Status = MmcNotifyState (MmcHostInstance, MmcTransferState);
   if (EFI_ERROR (Status)) {
-    DEBUG((EFI_D_ERROR, "InitializeMmcDevice(): Error MmcTransferState, Status=%r\n", Status));
+    DEBUG((DEBUG_ERROR, "InitializeMmcDevice(): Error MmcTransferState, Status=%r\n", Status));
     return Status;
   }
 
@@ -781,7 +781,7 @@ InitializeMmcDevice (
   // Set Block Length
   Status = MmcHost->SendCommand (MmcHost, MMC_CMD16, MmcHostInstance->BlockIo.Media->BlockSize);
   if (EFI_ERROR (Status)) {
-    DEBUG((EFI_D_ERROR, "InitializeMmcDevice(MMC_CMD16): Error MmcHostInstance->BlockIo.Media->BlockSize: %d and Error = %r\n",
+    DEBUG((DEBUG_ERROR, "InitializeMmcDevice(MMC_CMD16): Error MmcHostInstance->BlockIo.Media->BlockSize: %d and Error = %r\n",
                         MmcHostInstance->BlockIo.Media->BlockSize, Status));
     return Status;
   }
@@ -790,7 +790,7 @@ InitializeMmcDevice (
   if (MmcHostInstance->CardInfo.CardType == MMC_CARD) {
     Status = MmcHost->SendCommand (MmcHost, MMC_CMD23, BlockCount);
     if (EFI_ERROR (Status)) {
-      DEBUG((EFI_D_ERROR, "InitializeMmcDevice(MMC_CMD23): Error, Status=%r\n", Status));
+      DEBUG((DEBUG_ERROR, "InitializeMmcDevice(MMC_CMD23): Error, Status=%r\n", Status));
       return Status;
     }
   }

--- a/EmulatorPkg/AutoScanPei/AutoScanPei.c
+++ b/EmulatorPkg/AutoScanPei/AutoScanPei.c
@@ -47,7 +47,7 @@ Returns:
   EFI_RESOURCE_ATTRIBUTE_TYPE Attributes;
 
 
-  DEBUG ((EFI_D_ERROR, "Emu Autoscan PEIM Loaded\n"));
+  DEBUG ((DEBUG_ERROR, "Emu Autoscan PEIM Loaded\n"));
 
   //
   // Get the PEI UNIX Autoscan PPI

--- a/EmulatorPkg/BootModePei/BootModePei.c
+++ b/EmulatorPkg/BootModePei/BootModePei.c
@@ -69,7 +69,7 @@ Returns:
   EFI_STATUS    Status;
   EFI_BOOT_MODE BootMode;
 
-  DEBUG ((EFI_D_ERROR, "Emu Boot Mode PEIM Loaded\n"));
+  DEBUG ((DEBUG_ERROR, "Emu Boot Mode PEIM Loaded\n"));
 
   BootMode  = FixedPcdGet32 (PcdEmuBootMode);
 

--- a/EmulatorPkg/FirmwareVolumePei/FirmwareVolumePei.c
+++ b/EmulatorPkg/FirmwareVolumePei/FirmwareVolumePei.c
@@ -44,7 +44,7 @@ Returns:
   UINT64                      FdSize;
   UINTN                       Index;
 
-  DEBUG ((EFI_D_ERROR, "Unix Firmware Volume PEIM Loaded\n"));
+  DEBUG ((DEBUG_ERROR, "Unix Firmware Volume PEIM Loaded\n"));
 
   //
   // Get the Fwh Information PPI

--- a/EmulatorPkg/FlashMapPei/FlashMapPei.c
+++ b/EmulatorPkg/FlashMapPei/FlashMapPei.c
@@ -48,7 +48,7 @@ Returns:
   EFI_PHYSICAL_ADDRESS    FdFixUp;
   UINT64                  FdSize;
 
-  DEBUG ((EFI_D_ERROR, "EmulatorPkg Flash Map PEIM Loaded\n"));
+  DEBUG ((DEBUG_ERROR, "EmulatorPkg Flash Map PEIM Loaded\n"));
 
   //
   // Get the Fwh Information PPI

--- a/EmulatorPkg/Sec/Sec.c
+++ b/EmulatorPkg/Sec/Sec.c
@@ -80,7 +80,7 @@ _ModuleEntryPoint (
   EMU_MAGIC_PAGE()->PpiList = PpiList;
   ProcessLibraryConstructorList ();
 
-  DEBUG ((EFI_D_ERROR, "SEC Has Started\n"));
+  DEBUG ((DEBUG_ERROR, "SEC Has Started\n"));
 
   //
   // Add Our PPIs to the list
@@ -136,5 +136,3 @@ _ModuleEntryPoint (
   ASSERT (FALSE);
   return;
 }
-
-

--- a/EmulatorPkg/ThunkPpiToProtocolPei/ThunkPpiToProtocolPei.c
+++ b/EmulatorPkg/ThunkPpiToProtocolPei/ThunkPpiToProtocolPei.c
@@ -47,7 +47,7 @@ Returns:
   EMU_THUNK_PPI           *Thunk;
   VOID                    *Ptr;
 
-  DEBUG ((EFI_D_ERROR, "Emu Thunk PEIM Loaded\n"));
+  DEBUG ((DEBUG_ERROR, "Emu Thunk PEIM Loaded\n"));
 
   Status = PeiServicesLocatePpi (
               &gEmuThunkPpiGuid,        // GUID

--- a/EmulatorPkg/Unix/Host/BlockIo.c
+++ b/EmulatorPkg/Unix/Host/BlockIo.c
@@ -166,7 +166,7 @@ EmuBlockIoOpenDevice (
     }
   }
 
-  DEBUG ((EFI_D_INIT, "%HEmuOpenBlock: opened %a%N\n", Private->Filename));
+  DEBUG ((DEBUG_INIT, "%HEmuOpenBlock: opened %a%N\n", Private->Filename));
   Status = EFI_SUCCESS;
 
 Done:
@@ -282,7 +282,7 @@ EmuBlockIoReadWriteCommon (
   }
 
   if (!Private->Media->MediaPresent) {
-    DEBUG ((EFI_D_INIT, "%s: No Media\n", CallerName));
+    DEBUG ((DEBUG_INIT, "%s: No Media\n", CallerName));
     return EFI_NO_MEDIA;
   }
 
@@ -299,18 +299,18 @@ EmuBlockIoReadWriteCommon (
   //
   BlockSize = Private->Media->BlockSize;
   if (BufferSize == 0) {
-    DEBUG ((EFI_D_INIT, "%s: Zero length read\n", CallerName));
+    DEBUG ((DEBUG_INIT, "%s: Zero length read\n", CallerName));
     return EFI_SUCCESS;
   }
 
   if ((BufferSize % BlockSize) != 0) {
-    DEBUG ((EFI_D_INIT, "%s: Invalid read size\n", CallerName));
+    DEBUG ((DEBUG_INIT, "%s: Invalid read size\n", CallerName));
     return EFI_BAD_BUFFER_SIZE;
   }
 
   LastBlock = Lba + (BufferSize / BlockSize) - 1;
   if (LastBlock > Private->Media->LastBlock) {
-    DEBUG ((EFI_D_INIT, "ReadBlocks: Attempted to read off end of device\n"));
+    DEBUG ((DEBUG_INIT, "ReadBlocks: Attempted to read off end of device\n"));
     return EFI_INVALID_PARAMETER;
   }
   //
@@ -320,7 +320,7 @@ EmuBlockIoReadWriteCommon (
   Status = SetFilePointer64 (Private, DistanceToMove, &DistanceMoved, SEEK_SET);
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_INIT, "WriteBlocks: SetFilePointer failed\n"));
+    DEBUG ((DEBUG_INIT, "WriteBlocks: SetFilePointer failed\n"));
     return EmuBlockIoError (Private);
   }
 
@@ -384,7 +384,7 @@ EmuBlockIoReadBlocks (
 
   len = read (Private->fd, Buffer, BufferSize);
   if (len != BufferSize) {
-    DEBUG ((EFI_D_INIT, "ReadBlocks: ReadFile failed.\n"));
+    DEBUG ((DEBUG_INIT, "ReadBlocks: ReadFile failed.\n"));
     Status = EmuBlockIoError (Private);
     goto Done;
   }
@@ -462,7 +462,7 @@ EmuBlockIoWriteBlocks (
 
   len = write (Private->fd, Buffer, BufferSize);
   if (len != BufferSize) {
-    DEBUG ((EFI_D_INIT, "ReadBlocks: WriteFile failed.\n"));
+    DEBUG ((DEBUG_INIT, "ReadBlocks: WriteFile failed.\n"));
     Status = EmuBlockIoError (Private);
     goto Done;
   }
@@ -698,5 +698,3 @@ EMU_IO_THUNK_PROTOCOL gBlockIoThunkIo = {
   GasketBlockIoThunkClose,
   NULL
 };
-
-

--- a/EmulatorPkg/Win/Host/WinBlockIo.c
+++ b/EmulatorPkg/Win/Host/WinBlockIo.c
@@ -106,7 +106,7 @@ WinNtBlockIoOpenDevice (
   );
 
   if (Private->NtHandle == INVALID_HANDLE_VALUE) {
-    DEBUG ((EFI_D_INFO, "OpenBlock: Could not open %S, %x\n", Private->FileName, GetLastError ()));
+    DEBUG ((DEBUG_INFO, "OpenBlock: Could not open %S, %x\n", Private->FileName, GetLastError ()));
     Media->MediaPresent = FALSE;
     Status = EFI_NO_MEDIA;
     goto Done;
@@ -118,14 +118,14 @@ WinNtBlockIoOpenDevice (
   Status = SetFilePointer64 (Private, 0, &FileSize, FILE_END);
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "OpenBlock: Could not get filesize of %s\n", Private->FileName));
+    DEBUG ((DEBUG_ERROR, "OpenBlock: Could not get filesize of %s\n", Private->FileName));
     Status = EFI_UNSUPPORTED;
     goto Done;
   }
 
   Media->LastBlock = DivU64x32 (FileSize, (UINT32)Private->BlockSize) - 1;
 
-  DEBUG ((EFI_D_INIT, "OpenBlock: opened %S\n", Private->FileName));
+  DEBUG ((DEBUG_INIT, "OpenBlock: opened %S\n", Private->FileName));
   Status = EFI_SUCCESS;
 
 Done:
@@ -310,7 +310,7 @@ WinNtBlockIoReadBlocks (
   Status = SetFilePointer64 (Private, DistanceToMove, &DistanceMoved, FILE_BEGIN);
 
   if (EFI_ERROR (Status) || (DistanceToMove != DistanceMoved)) {
-    DEBUG ((EFI_D_INIT, "ReadBlocks: SetFilePointer failed\n"));
+    DEBUG ((DEBUG_INIT, "ReadBlocks: SetFilePointer failed\n"));
     return WinNtBlockIoError (Private->Media);
   }
 
@@ -381,7 +381,7 @@ WinNtBlockIoWriteBlocks (
   Status = SetFilePointer64 (Private, DistanceToMove, &DistanceMoved, FILE_BEGIN);
 
   if (EFI_ERROR (Status) || (DistanceToMove != DistanceMoved)) {
-    DEBUG ((EFI_D_INIT, "WriteBlocks: SetFilePointer failed\n"));
+    DEBUG ((DEBUG_INIT, "WriteBlocks: SetFilePointer failed\n"));
     return WinNtBlockIoError (Private->Media);
   }
 
@@ -553,5 +553,3 @@ EMU_IO_THUNK_PROTOCOL mWinNtBlockIoThunkIo = {
   WinNtBlockIoThunkClose,
   NULL
 };
-
-

--- a/FatPkg/EnhancedFatDxe/DirectoryManage.c
+++ b/FatPkg/EnhancedFatDxe/DirectoryManage.c
@@ -1064,7 +1064,7 @@ FatCreateDirEnt (
   FatAddDirEnt (ODir, DirEnt);
   DirEnt->Entry.Attributes = Attributes;
   *PtrDirEnt               = DirEnt;
-  DEBUG ((EFI_D_INFO, "FSOpen: Created new directory entry '%S'\n", DirEnt->FileString));
+  DEBUG ((DEBUG_INFO, "FSOpen: Created new directory entry '%S'\n", DirEnt->FileString));
   return FatStoreDirEnt (OFile, DirEnt);
 
 Done:
@@ -1388,4 +1388,3 @@ FatLocateOFile (
   *PtrOFile = OFile;
   return EFI_SUCCESS;
 }
-

--- a/FatPkg/EnhancedFatDxe/DiskCache.c
+++ b/FatPkg/EnhancedFatDxe/DiskCache.c
@@ -125,7 +125,7 @@ FatExchangeCachePage (
     RealSize  = (UINTN)1 << PageAlignment;
     MaxSize   = DiskCache->LimitAddress - EntryPos;
     if (MaxSize < RealSize) {
-      DEBUG ((EFI_D_INFO, "FatDiskIo: Cache Page OutBound occurred! \n"));
+      DEBUG ((DEBUG_INFO, "FatDiskIo: Cache Page OutBound occurred! \n"));
       RealSize = (UINTN) MaxSize;
     }
   }

--- a/FatPkg/EnhancedFatDxe/FileSpace.c
+++ b/FatPkg/EnhancedFatDxe/FileSpace.c
@@ -244,7 +244,7 @@ FatFreeClusters (
   while (!FAT_END_OF_FAT_CHAIN (Cluster)) {
     if (Cluster == FAT_CLUSTER_FREE || Cluster >= FAT_CLUSTER_SPECIAL) {
 
-      DEBUG ((EFI_D_INIT | EFI_D_ERROR, "FatShrinkEof: cluster chain corrupt\n"));
+      DEBUG ((DEBUG_INIT | DEBUG_ERROR, "FatShrinkEof: cluster chain corrupt\n"));
       return EFI_VOLUME_CORRUPTED;
     }
 
@@ -374,7 +374,7 @@ FatShrinkEof (
     for (CurSize = 0; CurSize < NewSize; CurSize++) {
       if (Cluster == FAT_CLUSTER_FREE || Cluster >= FAT_CLUSTER_SPECIAL) {
 
-        DEBUG ((EFI_D_INIT | EFI_D_ERROR, "FatShrinkEof: cluster chain corrupt\n"));
+        DEBUG ((DEBUG_INIT | DEBUG_ERROR, "FatShrinkEof: cluster chain corrupt\n"));
         return EFI_VOLUME_CORRUPTED;
       }
 
@@ -464,7 +464,7 @@ FatGrowEof (
         if (Cluster < FAT_MIN_CLUSTER || Cluster > Volume->MaxCluster + 1) {
 
           DEBUG (
-            (EFI_D_INIT | EFI_D_ERROR,
+            (DEBUG_INIT | DEBUG_ERROR,
             "FatGrowEof: cluster chain corrupt\n")
             );
           Status = EFI_VOLUME_CORRUPTED;
@@ -478,7 +478,7 @@ FatGrowEof (
 
       if (ClusterCount != CurSize) {
         DEBUG (
-          (EFI_D_INIT | EFI_D_ERROR,
+          (DEBUG_INIT | DEBUG_ERROR,
           "FatGrowEof: cluster chain size does not match file size\n")
           );
         Status = EFI_VOLUME_CORRUPTED;
@@ -604,7 +604,7 @@ FatOFilePosition (
     while (StartPos + ClusterSize <= Position) {
       StartPos += ClusterSize;
       if (Cluster == FAT_CLUSTER_FREE || (Cluster >= FAT_CLUSTER_SPECIAL)) {
-        DEBUG ((EFI_D_INIT | EFI_D_ERROR, "FatOFilePosition:"" cluster chain corrupt\n"));
+        DEBUG ((DEBUG_INIT | DEBUG_ERROR, "FatOFilePosition:"" cluster chain corrupt\n"));
         return EFI_VOLUME_CORRUPTED;
       }
 
@@ -668,7 +668,7 @@ FatPhysicalDirSize (
     while (!FAT_END_OF_FAT_CHAIN (Cluster)) {
       if (Cluster == FAT_CLUSTER_FREE || Cluster >= FAT_CLUSTER_SPECIAL) {
         DEBUG (
-          (EFI_D_INIT | EFI_D_ERROR,
+          (DEBUG_INIT | DEBUG_ERROR,
           "FATDirSize: cluster chain corrupt\n")
           );
         return 0;

--- a/FatPkg/EnhancedFatDxe/Init.c
+++ b/FatPkg/EnhancedFatDxe/Init.c
@@ -90,7 +90,7 @@ FatAllocateVolume (
   //
   // Volume installed
   //
-  DEBUG ((EFI_D_INIT, "Installed Fat filesystem on %p\n", Handle));
+  DEBUG ((DEBUG_INIT, "Installed Fat filesystem on %p\n", Handle));
   Volume->Valid = TRUE;
 
 Done:
@@ -217,7 +217,7 @@ FatOpenDevice (
   Status  = DiskIo->ReadDisk (DiskIo, Volume->MediaId, 0, sizeof (FatBs), &FatBs);
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_INIT, "FatOpenDevice: read of part_lba failed %r\n", Status));
+    DEBUG ((DEBUG_INIT, "FatOpenDevice: read of part_lba failed %r\n", Status));
     return Status;
   }
 

--- a/FatPkg/EnhancedFatDxe/Misc.c
+++ b/FatPkg/EnhancedFatDxe/Misc.c
@@ -377,7 +377,7 @@ FatDiskIo (
 
   if (EFI_ERROR (Status)) {
     Volume->DiskError = TRUE;
-    DEBUG ((EFI_D_ERROR, "FatDiskIo: error %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "FatDiskIo: error %r\n", Status));
   }
 
   return Status;

--- a/FatPkg/EnhancedFatDxe/Open.c
+++ b/FatPkg/EnhancedFatDxe/Open.c
@@ -168,7 +168,7 @@ FatOFileOpen (
 
   (*NewIFile)->ReadOnly = (BOOLEAN)!WriteMode;
 
-  DEBUG ((EFI_D_INFO, "FSOpen: Open '%S' %r\n", FileName, Status));
+  DEBUG ((DEBUG_INFO, "FSOpen: Open '%S' %r\n", FileName, Status));
   return FatOFileFlush (OFile);
 }
 

--- a/MdeModulePkg/Application/MemoryProfileInfo/MemoryProfileInfo.c
+++ b/MdeModulePkg/Application/MemoryProfileInfo/MemoryProfileInfo.c
@@ -1027,7 +1027,7 @@ GetUefiMemoryProfileData (
 
   Status = gBS->LocateProtocol (&gEdkiiMemoryProfileGuid, NULL, (VOID **) &ProfileProtocol);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "UefiMemoryProfile: Locate MemoryProfile protocol - %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "UefiMemoryProfile: Locate MemoryProfile protocol - %r\n", Status));
     return Status;
   }
 
@@ -1136,7 +1136,7 @@ GetSmramProfileData (
 
   Status = gBS->LocateProtocol (&gEfiSmmCommunicationProtocolGuid, NULL, (VOID **) &SmmCommunication);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "SmramProfile: Locate SmmCommunication protocol - %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "SmramProfile: Locate SmmCommunication protocol - %r\n", Status));
     return Status;
   }
 
@@ -1157,7 +1157,7 @@ GetSmramProfileData (
              (VOID **) &PiSmmCommunicationRegionTable
              );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "SmramProfile: Get PiSmmCommunicationRegionTable - %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "SmramProfile: Get PiSmmCommunicationRegionTable - %r\n", Status));
     return Status;
   }
   ASSERT (PiSmmCommunicationRegionTable != NULL);
@@ -1193,7 +1193,7 @@ GetSmramProfileData (
   CommSize = sizeof (EFI_GUID) + sizeof (UINTN) + CommHeader->MessageLength;
   Status = SmmCommunication->Communicate (SmmCommunication, CommBuffer, &CommSize);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "SmramProfile: SmmCommunication - %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "SmramProfile: SmmCommunication - %r\n", Status));
     return Status;
   }
 
@@ -1349,12 +1349,12 @@ UefiMain (
 
   Status = GetUefiMemoryProfileData ();
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "GetUefiMemoryProfileData - %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "GetUefiMemoryProfileData - %r\n", Status));
   }
 
   Status = GetSmramProfileData ();
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "GetSmramProfileData - %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "GetSmramProfileData - %r\n", Status));
   }
 
   return EFI_SUCCESS;

--- a/MdeModulePkg/Bus/Ata/AtaAtapiPassThru/AhciMode.c
+++ b/MdeModulePkg/Bus/Ata/AtaAtapiPassThru/AhciMode.c
@@ -1716,7 +1716,7 @@ AhciAtaSmartReturnStatusCheck (
       //
       // The threshold exceeded condition is not detected by the device
       //
-      DEBUG ((EFI_D_INFO, "The S.M.A.R.T threshold exceeded condition is not detected\n"));
+      DEBUG ((DEBUG_INFO, "The S.M.A.R.T threshold exceeded condition is not detected\n"));
       REPORT_STATUS_CODE (
             EFI_PROGRESS_CODE,
             (EFI_IO_BUS_ATA_ATAPI | EFI_IOB_ATA_BUS_SMART_UNDERTHRESHOLD)
@@ -1725,7 +1725,7 @@ AhciAtaSmartReturnStatusCheck (
       //
       // The threshold exceeded condition is detected by the device
       //
-      DEBUG ((EFI_D_INFO, "The S.M.A.R.T threshold exceeded condition is detected\n"));
+      DEBUG ((DEBUG_INFO, "The S.M.A.R.T threshold exceeded condition is detected\n"));
       REPORT_STATUS_CODE (
            EFI_PROGRESS_CODE,
            (EFI_IO_BUS_ATA_ATAPI | EFI_IOB_ATA_BUS_SMART_OVERTHRESHOLD)
@@ -1768,7 +1768,7 @@ AhciAtaSmartSupport (
     //
     // S.M.A.R.T is not supported by the device
     //
-    DEBUG ((EFI_D_INFO, "S.M.A.R.T feature is not supported at port [%d] PortMultiplier [%d]!\n",
+    DEBUG ((DEBUG_INFO, "S.M.A.R.T feature is not supported at port [%d] PortMultiplier [%d]!\n",
             Port, PortMultiplier));
     REPORT_STATUS_CODE (
       EFI_ERROR_CODE | EFI_ERROR_MINOR,
@@ -1844,7 +1844,7 @@ AhciAtaSmartSupport (
       AtaStatusBlock
       );
 
-    DEBUG ((EFI_D_INFO, "Enabled S.M.A.R.T feature at port [%d] PortMultiplier [%d]!\n",
+    DEBUG ((DEBUG_INFO, "Enabled S.M.A.R.T feature at port [%d] PortMultiplier [%d]!\n",
             Port, PortMultiplier));
   }
 
@@ -2778,7 +2778,7 @@ AhciModeInitialization (
                       NULL
                       );
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_WARN,
+      DEBUG ((DEBUG_WARN,
         "AhciModeInitialization: failed to enable 64-bit DMA on 64-bit capable controller (%r)\n",
         Status));
     }
@@ -2984,7 +2984,7 @@ AhciModeInitialization (
                           &SupportedModes
                           );
       if (EFI_ERROR (Status)) {
-        DEBUG ((EFI_D_ERROR, "Calculate Mode Fail, Status = %r\n", Status));
+        DEBUG ((DEBUG_ERROR, "Calculate Mode Fail, Status = %r\n", Status));
         continue;
       }
 
@@ -3015,7 +3015,7 @@ AhciModeInitialization (
 
       Status = AhciDeviceSetFeature (PciIo, AhciRegisters, Port, 0, 0x03, (UINT32)(*(UINT8 *)&TransferMode), ATA_ATAPI_TIMEOUT);
       if (EFI_ERROR (Status)) {
-        DEBUG ((EFI_D_ERROR, "Set transfer Mode Fail, Status = %r\n", Status));
+        DEBUG ((DEBUG_ERROR, "Set transfer Mode Fail, Status = %r\n", Status));
         continue;
       }
 
@@ -3054,4 +3054,3 @@ AhciModeInitialization (
 
   return EFI_SUCCESS;
 }
-

--- a/MdeModulePkg/Bus/Ata/AtaAtapiPassThru/AtaAtapiPassThru.c
+++ b/MdeModulePkg/Bus/Ata/AtaAtapiPassThru/AtaAtapiPassThru.c
@@ -682,7 +682,7 @@ AtaAtapiPassThruStart (
   Instance              = NULL;
   OriginalPciAttributes = 0;
 
-  DEBUG ((EFI_D_INFO, "==AtaAtapiPassThru Start== Controller = %x\n", Controller));
+  DEBUG ((DEBUG_INFO, "==AtaAtapiPassThru Start== Controller = %x\n", Controller));
 
   Status  = gBS->OpenProtocol (
                    Controller,
@@ -694,7 +694,7 @@ AtaAtapiPassThruStart (
                    );
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "Open Ide_Controller_Init Error, Status=%r", Status));
+    DEBUG ((DEBUG_ERROR, "Open Ide_Controller_Init Error, Status=%r", Status));
     goto ErrorExit;
   }
 
@@ -707,7 +707,7 @@ AtaAtapiPassThruStart (
                   EFI_OPEN_PROTOCOL_GET_PROTOCOL
                   );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "Get Pci_Io Protocol Error, Status=%r", Status));
+    DEBUG ((DEBUG_ERROR, "Get Pci_Io Protocol Error, Status=%r", Status));
     goto ErrorExit;
   }
 
@@ -872,7 +872,7 @@ AtaAtapiPassThruStop (
   EFI_PCI_IO_PROTOCOL               *PciIo;
   EFI_AHCI_REGISTERS                *AhciRegisters;
 
-  DEBUG ((EFI_D_INFO, "==AtaAtapiPassThru Stop== Controller = %x\n", Controller));
+  DEBUG ((DEBUG_INFO, "==AtaAtapiPassThru Stop== Controller = %x\n", Controller));
 
   Status = gBS->OpenProtocol (
                   Controller,
@@ -2646,4 +2646,3 @@ Exit:
 
   return EFI_SUCCESS;
 }
-

--- a/MdeModulePkg/Bus/Ata/AtaAtapiPassThru/IdeMode.c
+++ b/MdeModulePkg/Bus/Ata/AtaAtapiPassThru/IdeMode.c
@@ -252,36 +252,36 @@ DumpAllIdeRegisters (
 
   DEBUG_CODE_BEGIN ();
   if ((StatusBlock.AtaStatus & ATA_STSREG_DWF) != 0) {
-    DEBUG ((EFI_D_ERROR, "CheckRegisterStatus()-- %02x : Error : Write Fault\n", StatusBlock.AtaStatus));
+    DEBUG ((DEBUG_ERROR, "CheckRegisterStatus()-- %02x : Error : Write Fault\n", StatusBlock.AtaStatus));
   }
 
   if ((StatusBlock.AtaStatus & ATA_STSREG_CORR) != 0) {
-    DEBUG ((EFI_D_ERROR, "CheckRegisterStatus()-- %02x : Error : Corrected Data\n", StatusBlock.AtaStatus));
+    DEBUG ((DEBUG_ERROR, "CheckRegisterStatus()-- %02x : Error : Corrected Data\n", StatusBlock.AtaStatus));
   }
 
   if ((StatusBlock.AtaStatus & ATA_STSREG_ERR) != 0) {
     if ((StatusBlock.AtaError & ATA_ERRREG_BBK) != 0) {
-      DEBUG ((EFI_D_ERROR, "CheckRegisterStatus()-- %02x : Error : Bad Block Detected\n", StatusBlock.AtaError));
+      DEBUG ((DEBUG_ERROR, "CheckRegisterStatus()-- %02x : Error : Bad Block Detected\n", StatusBlock.AtaError));
     }
 
     if ((StatusBlock.AtaError & ATA_ERRREG_UNC) != 0) {
-      DEBUG ((EFI_D_ERROR, "CheckRegisterStatus()-- %02x : Error : Uncorrectable Data\n", StatusBlock.AtaError));
+      DEBUG ((DEBUG_ERROR, "CheckRegisterStatus()-- %02x : Error : Uncorrectable Data\n", StatusBlock.AtaError));
     }
 
     if ((StatusBlock.AtaError & ATA_ERRREG_MC) != 0) {
-      DEBUG ((EFI_D_ERROR, "CheckRegisterStatus()-- %02x : Error : Media Change\n", StatusBlock.AtaError));
+      DEBUG ((DEBUG_ERROR, "CheckRegisterStatus()-- %02x : Error : Media Change\n", StatusBlock.AtaError));
     }
 
     if ((StatusBlock.AtaError & ATA_ERRREG_ABRT) != 0) {
-      DEBUG ((EFI_D_ERROR, "CheckRegisterStatus()-- %02x : Error : Abort\n", StatusBlock.AtaError));
+      DEBUG ((DEBUG_ERROR, "CheckRegisterStatus()-- %02x : Error : Abort\n", StatusBlock.AtaError));
     }
 
     if ((StatusBlock.AtaError & ATA_ERRREG_TK0NF) != 0) {
-      DEBUG ((EFI_D_ERROR, "CheckRegisterStatus()-- %02x : Error : Track 0 Not Found\n", StatusBlock.AtaError));
+      DEBUG ((DEBUG_ERROR, "CheckRegisterStatus()-- %02x : Error : Track 0 Not Found\n", StatusBlock.AtaError));
     }
 
     if ((StatusBlock.AtaError & ATA_ERRREG_AMNF) != 0) {
-      DEBUG ((EFI_D_ERROR, "CheckRegisterStatus()-- %02x : Error : Address Mark Not Found\n", StatusBlock.AtaError));
+      DEBUG ((DEBUG_ERROR, "CheckRegisterStatus()-- %02x : Error : Address Mark Not Found\n", StatusBlock.AtaError));
     }
   }
   DEBUG_CODE_END ();
@@ -1162,7 +1162,7 @@ AtaUdmStatusWait (
     IoPortForBmis = (UINT16) (IdeRegisters->BusMasterBaseAddr + BMIS_OFFSET);
     RegisterValue = IdeReadPortB (PciIo, IoPortForBmis);
     if (((RegisterValue & BMIS_ERROR) != 0) || (Timeout == 0)) {
-      DEBUG ((EFI_D_ERROR, "ATA UDMA operation fails\n"));
+      DEBUG ((DEBUG_ERROR, "ATA UDMA operation fails\n"));
       Status = EFI_DEVICE_ERROR;
       break;
     }
@@ -1217,7 +1217,7 @@ AtaUdmStatusCheck (
   RegisterValue = IdeReadPortB (PciIo, IoPortForBmis);
 
   if ((RegisterValue & BMIS_ERROR) != 0) {
-    DEBUG ((EFI_D_ERROR, "ATA UDMA operation fails\n"));
+    DEBUG ((DEBUG_ERROR, "ATA UDMA operation fails\n"));
     return EFI_DEVICE_ERROR;
   }
 
@@ -2077,7 +2077,7 @@ IdeAtaSmartReturnStatusCheck (
     //
     // The threshold exceeded condition is not detected by the device
     //
-    DEBUG ((EFI_D_INFO, "The S.M.A.R.T threshold exceeded condition is not detected\n"));
+    DEBUG ((DEBUG_INFO, "The S.M.A.R.T threshold exceeded condition is not detected\n"));
     REPORT_STATUS_CODE (
           EFI_PROGRESS_CODE,
           (EFI_IO_BUS_ATA_ATAPI | EFI_IOB_ATA_BUS_SMART_UNDERTHRESHOLD)
@@ -2086,7 +2086,7 @@ IdeAtaSmartReturnStatusCheck (
     //
     // The threshold exceeded condition is detected by the device
     //
-    DEBUG ((EFI_D_INFO, "The S.M.A.R.T threshold exceeded condition is detected\n"));
+    DEBUG ((DEBUG_INFO, "The S.M.A.R.T threshold exceeded condition is detected\n"));
     REPORT_STATUS_CODE (
          EFI_PROGRESS_CODE,
          (EFI_IO_BUS_ATA_ATAPI | EFI_IOB_ATA_BUS_SMART_OVERTHRESHOLD)
@@ -2126,7 +2126,7 @@ IdeAtaSmartSupport (
     //
     // S.M.A.R.T is not supported by the device
     //
-    DEBUG ((EFI_D_INFO, "S.M.A.R.T feature is not supported at [%a] channel [%a] device!\n",
+    DEBUG ((DEBUG_INFO, "S.M.A.R.T feature is not supported at [%a] channel [%a] device!\n",
             (Channel == 1) ? "secondary" : "primary", (Device == 1) ? "slave" : "master"));
     REPORT_STATUS_CODE (
       EFI_ERROR_CODE | EFI_ERROR_MINOR,
@@ -2195,7 +2195,7 @@ IdeAtaSmartSupport (
       }
     }
 
-    DEBUG ((EFI_D_INFO, "Enabled S.M.A.R.T feature at [%a] channel [%a] device!\n",
+    DEBUG ((DEBUG_INFO, "Enabled S.M.A.R.T feature at [%a] channel [%a] device!\n",
            (Channel == 1) ? "secondary" : "primary", (Device == 1) ? "slave" : "master"));
 
   }
@@ -2392,7 +2392,7 @@ DetectAndConfigIdeDevice (
 
     Status = WaitForBSYClear (PciIo, IdeRegisters, 350000000);
     if (EFI_ERROR (Status)) {
-      DEBUG((EFI_D_ERROR, "New detecting method: Send Execute Diagnostic Command: WaitForBSYClear: Status: %d\n", Status));
+      DEBUG((DEBUG_ERROR, "New detecting method: Send Execute Diagnostic Command: WaitForBSYClear: Status: %d\n", Status));
       continue;
     }
 
@@ -2453,7 +2453,7 @@ DetectAndConfigIdeDevice (
       continue;
     }
 
-    DEBUG ((EFI_D_INFO, "[%a] channel [%a] [%a] device\n",
+    DEBUG ((DEBUG_INFO, "[%a] channel [%a] [%a] device\n",
             (IdeChannel == 1) ? "secondary" : "primary  ", (IdeDevice == 1) ? "slave " : "master",
             DeviceType == EfiIdeCdrom ? "cdrom   " : "harddisk"));
     //
@@ -2484,7 +2484,7 @@ DetectAndConfigIdeDevice (
                         &SupportedModes
                         );
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "Calculate Mode Fail, Status = %r\n", Status));
+      DEBUG ((DEBUG_ERROR, "Calculate Mode Fail, Status = %r\n", Status));
       continue;
     }
 
@@ -2503,7 +2503,7 @@ DetectAndConfigIdeDevice (
       Status = SetDeviceTransferMode (Instance, IdeChannel, IdeDevice, &TransferMode, NULL);
 
       if (EFI_ERROR (Status)) {
-        DEBUG ((EFI_D_ERROR, "Set transfer Mode Fail, Status = %r\n", Status));
+        DEBUG ((DEBUG_ERROR, "Set transfer Mode Fail, Status = %r\n", Status));
         continue;
       }
     }
@@ -2520,7 +2520,7 @@ DetectAndConfigIdeDevice (
       Status = SetDeviceTransferMode (Instance, IdeChannel, IdeDevice, &TransferMode, NULL);
 
       if (EFI_ERROR (Status)) {
-        DEBUG ((EFI_D_ERROR, "Set transfer Mode Fail, Status = %r\n", Status));
+        DEBUG ((DEBUG_ERROR, "Set transfer Mode Fail, Status = %r\n", Status));
         continue;
       }
     } else if (SupportedModes->MultiWordDmaMode.Valid) {
@@ -2529,7 +2529,7 @@ DetectAndConfigIdeDevice (
       Status = SetDeviceTransferMode (Instance, IdeChannel, IdeDevice, &TransferMode, NULL);
 
       if (EFI_ERROR (Status)) {
-        DEBUG ((EFI_D_ERROR, "Set transfer Mode Fail, Status = %r\n", Status));
+        DEBUG ((DEBUG_ERROR, "Set transfer Mode Fail, Status = %r\n", Status));
         continue;
       }
     }
@@ -2619,7 +2619,7 @@ IdeModeInitialization (
                         &MaxDevices
                         );
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "[GetChannel, Status=%x]", Status));
+      DEBUG ((DEBUG_ERROR, "[GetChannel, Status=%x]", Status));
       continue;
     }
 
@@ -2658,4 +2658,3 @@ IdeModeInitialization (
 ErrorExit:
   return Status;
 }
-

--- a/MdeModulePkg/Bus/Ata/AtaBusDxe/AtaBus.c
+++ b/MdeModulePkg/Bus/Ata/AtaBusDxe/AtaBus.c
@@ -358,7 +358,7 @@ RegisterAtaDevice (
   // If yes, then install Storage Security Protocol at the ata device handle.
   //
   if ((AtaDevice->IdentifyData->trusted_computing_support & BIT0) != 0) {
-    DEBUG ((EFI_D_INFO, "Found TCG support in Port %x PortMultiplierPort %x\n", Port, PortMultiplierPort));
+    DEBUG ((DEBUG_INFO, "Found TCG support in Port %x PortMultiplierPort %x\n", Port, PortMultiplierPort));
     Status = gBS->InstallProtocolInterface (
                     &AtaDevice->Handle,
                     &gEfiStorageSecurityCommandProtocolGuid,
@@ -368,7 +368,7 @@ RegisterAtaDevice (
     if (EFI_ERROR (Status)) {
       goto Done;
     }
-    DEBUG ((EFI_D_INFO, "Successfully Install Storage Security Protocol on the ATA device\n"));
+    DEBUG ((DEBUG_INFO, "Successfully Install Storage Security Protocol on the ATA device\n"));
   }
 
   gBS->OpenProtocol (
@@ -387,7 +387,7 @@ Done:
 
   if (EFI_ERROR (Status) && (AtaDevice != NULL)) {
     ReleaseAtaResources (AtaDevice);
-    DEBUG ((EFI_D_ERROR | EFI_D_INIT, "Failed to initialize Port %x PortMultiplierPort %x, status = %r\n", Port, PortMultiplierPort, Status));
+    DEBUG ((DEBUG_ERROR | DEBUG_INIT, "Failed to initialize Port %x PortMultiplierPort %x, status = %r\n", Port, PortMultiplierPort, Status));
   }
   return Status;
 }
@@ -1537,7 +1537,7 @@ AtaStorageSecurityReceiveData (
   ATA_DEVICE                       *Private;
   EFI_TPL                          OldTpl;
 
-  DEBUG ((EFI_D_INFO, "EFI Storage Security Protocol - Read\n"));
+  DEBUG ((DEBUG_INFO, "EFI Storage Security Protocol - Read\n"));
   if ((PayloadBuffer == NULL || PayloadTransferSize == NULL) && PayloadBufferSize != 0) {
     return EFI_INVALID_PARAMETER;
   }
@@ -1647,7 +1647,7 @@ AtaStorageSecuritySendData (
   ATA_DEVICE                       *Private;
   EFI_TPL                          OldTpl;
 
-  DEBUG ((EFI_D_INFO, "EFI Storage Security Protocol - Send\n"));
+  DEBUG ((DEBUG_INFO, "EFI Storage Security Protocol - Send\n"));
   if ((PayloadBuffer == NULL) && (PayloadBufferSize != 0)) {
     return EFI_INVALID_PARAMETER;
   }
@@ -1709,4 +1709,3 @@ InitializeAtaBus(
 
   return Status;
 }
-

--- a/MdeModulePkg/Bus/Ata/AtaBusDxe/AtaPassThruExecute.c
+++ b/MdeModulePkg/Bus/Ata/AtaBusDxe/AtaPassThruExecute.c
@@ -309,7 +309,7 @@ IdentifyAtaDevice (
     return EFI_UNSUPPORTED;
   }
 
-  DEBUG ((EFI_D_INFO, "AtaBus - Identify Device: Port %x PortMultiplierPort %x\n", AtaDevice->Port, AtaDevice->PortMultiplierPort));
+  DEBUG ((DEBUG_INFO, "AtaBus - Identify Device: Port %x PortMultiplierPort %x\n", AtaDevice->Port, AtaDevice->PortMultiplierPort));
 
   //
   // Check whether the WORD 88 (supported UltraDMA by drive) is valid
@@ -674,7 +674,7 @@ AtaNonBlockingCallBack (
   }
 
   DEBUG ((
-    EFI_D_BLKIO,
+    DEBUG_BLKIO,
     "NON-BLOCKING EVENT FINISHED!- STATUS = %r\n",
     Task->Token->TransactionStatus
     ));
@@ -683,7 +683,7 @@ AtaNonBlockingCallBack (
   // Reduce the SubEventCount, till it comes to zero.
   //
   (*Task->UnsignalledEventCount) --;
-  DEBUG ((EFI_D_BLKIO, "UnsignalledEventCount = %d\n", *Task->UnsignalledEventCount));
+  DEBUG ((DEBUG_BLKIO, "UnsignalledEventCount = %d\n", *Task->UnsignalledEventCount));
 
   //
   // Remove the SubTask from the Task list.
@@ -696,7 +696,7 @@ AtaNonBlockingCallBack (
     //
     if (!(*Task->IsError)) {
       gBS->SignalEvent (Task->Token->Event);
-      DEBUG ((EFI_D_BLKIO, "Signal the upper layer event!\n"));
+      DEBUG ((DEBUG_BLKIO, "Signal the upper layer event!\n"));
     }
 
     FreePool (Task->UnsignalledEventCount);
@@ -709,8 +709,8 @@ AtaNonBlockingCallBack (
     if (!IsListEmpty (&AtaDevice->AtaTaskList)) {
       Entry   = GetFirstNode (&AtaDevice->AtaTaskList);
       AtaTask = ATA_ASYN_TASK_FROM_ENTRY (Entry);
-      DEBUG ((EFI_D_BLKIO, "Start to embark a new Ata Task\n"));
-      DEBUG ((EFI_D_BLKIO, "AtaTask->NumberOfBlocks = %x; AtaTask->Token=%x\n", AtaTask->NumberOfBlocks, AtaTask->Token));
+      DEBUG ((DEBUG_BLKIO, "Start to embark a new Ata Task\n"));
+      DEBUG ((DEBUG_BLKIO, "AtaTask->NumberOfBlocks = %x; AtaTask->Token=%x\n", AtaTask->NumberOfBlocks, AtaTask->Token));
       Status = AccessAtaDevice (
                  AtaTask->AtaDevice,
                  AtaTask->Buffer,
@@ -729,7 +729,7 @@ AtaNonBlockingCallBack (
   }
 
   DEBUG ((
-    EFI_D_BLKIO,
+    DEBUG_BLKIO,
     "PACKET INFO: Write=%s, Length=%x, LowCylinder=%x, HighCylinder=%x, SectionNumber=%x\n",
     Task->Packet.OutDataBuffer != NULL ? L"YES" : L"NO",
     Task->Packet.OutDataBuffer != NULL ? Task->Packet.OutTransferLength : Task->Packet.InTransferLength,
@@ -838,13 +838,13 @@ AccessAtaDevice(
       FreePool (EventCount);
       return EFI_OUT_OF_RESOURCES;
     }
-    DEBUG ((EFI_D_BLKIO, "Allocation IsError Addr=%x\n", IsError));
+    DEBUG ((DEBUG_BLKIO, "Allocation IsError Addr=%x\n", IsError));
     *IsError = FALSE;
     TempCount   = (NumberOfBlocks + MaxTransferBlockNumber - 1) / MaxTransferBlockNumber;
     *EventCount = TempCount;
-    DEBUG ((EFI_D_BLKIO, "AccessAtaDevice, NumberOfBlocks=%x\n", NumberOfBlocks));
-    DEBUG ((EFI_D_BLKIO, "AccessAtaDevice, MaxTransferBlockNumber=%x\n", MaxTransferBlockNumber));
-    DEBUG ((EFI_D_BLKIO, "AccessAtaDevice, EventCount=%x\n", TempCount));
+    DEBUG ((DEBUG_BLKIO, "AccessAtaDevice, NumberOfBlocks=%x\n", NumberOfBlocks));
+    DEBUG ((DEBUG_BLKIO, "AccessAtaDevice, MaxTransferBlockNumber=%x\n", MaxTransferBlockNumber));
+    DEBUG ((DEBUG_BLKIO, "AccessAtaDevice, EventCount=%x\n", TempCount));
   } else {
     while (!IsListEmpty (&AtaDevice->AtaTaskList) || !IsListEmpty (&AtaDevice->AtaSubTaskList)) {
       //
@@ -906,7 +906,7 @@ AccessAtaDevice(
       //
       // Blocking Mode.
       //
-      DEBUG ((EFI_D_BLKIO, "Blocking AccessAtaDevice, TransferBlockNumber=%x; StartLba = %x\n", TransferBlockNumber, StartLba));
+      DEBUG ((DEBUG_BLKIO, "Blocking AccessAtaDevice, TransferBlockNumber=%x; StartLba = %x\n", TransferBlockNumber, StartLba));
       Status = TransferAtaDevice (AtaDevice, NULL, Buffer, StartLba, (UINT32) TransferBlockNumber, IsWrite, NULL);
     }
 

--- a/MdeModulePkg/Bus/I2c/I2cDxe/I2cBus.c
+++ b/MdeModulePkg/Bus/I2c/I2cDxe/I2cBus.c
@@ -312,7 +312,7 @@ CheckRemainingDevicePath (
                   ((!SystemHasControllerNode) && (RemainingHasControllerNode)  && (RemainingControllerNumber == 0)) ||
                   ((SystemHasControllerNode)  && (RemainingHasControllerNode)  && (SystemControllerNumber == RemainingControllerNumber)) ||
                   ((!SystemHasControllerNode) && (!RemainingHasControllerNode))) {
-                  DEBUG ((EFI_D_ERROR, "This I2C device has been already started.\n"));
+                  DEBUG ((DEBUG_ERROR, "This I2C device has been already started.\n"));
                   Status = EFI_UNSUPPORTED;
                   break;
               }
@@ -572,7 +572,7 @@ I2cBusDriverStart (
                   EFI_OPEN_PROTOCOL_BY_DRIVER
                   );
   if (EFI_ERROR (Status) && (Status != EFI_ALREADY_STARTED)) {
-    DEBUG ((EFI_D_ERROR, "I2cBus: open I2C host error, Status = %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "I2cBus: open I2C host error, Status = %r\n", Status));
     return Status;
   }
 
@@ -586,7 +586,7 @@ I2cBusDriverStart (
                     EFI_OPEN_PROTOCOL_GET_PROTOCOL
                     );
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "I2cBus: open private protocol error, Status = %r.\n", Status));
+      DEBUG ((DEBUG_ERROR, "I2cBus: open private protocol error, Status = %r.\n", Status));
       return Status;
     }
   }
@@ -603,7 +603,7 @@ I2cBusDriverStart (
                   EFI_OPEN_PROTOCOL_BY_DRIVER
                   );
   if (EFI_ERROR (Status) && (Status != EFI_ALREADY_STARTED)) {
-    DEBUG ((EFI_D_ERROR, "I2cBus: open I2C enumerate error, Status = %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "I2cBus: open I2C enumerate error, Status = %r\n", Status));
     goto Error;
   }
 
@@ -616,7 +616,7 @@ I2cBusDriverStart (
                    EFI_OPEN_PROTOCOL_BY_DRIVER
                    );
   if (EFI_ERROR (Status) && (Status != EFI_ALREADY_STARTED)) {
-    DEBUG ((EFI_D_ERROR, "I2cBus: open device path error, Status = %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "I2cBus: open device path error, Status = %r\n", Status));
     goto Error;
   }
 
@@ -637,7 +637,7 @@ I2cBusDriverStart (
     //
     I2cBusContext = AllocateZeroPool (sizeof (I2C_BUS_CONTEXT));
     if (I2cBusContext == NULL) {
-      DEBUG ((EFI_D_ERROR, "I2cBus: there is no enough memory to allocate.\n"));
+      DEBUG ((DEBUG_ERROR, "I2cBus: there is no enough memory to allocate.\n"));
       Status = EFI_OUT_OF_RESOURCES;
       goto Error;
     }
@@ -676,7 +676,7 @@ I2cBusDriverStart (
                     NULL
                     );
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "I2cBus: install private protocol error, Status = %r.\n", Status));
+      DEBUG ((DEBUG_ERROR, "I2cBus: install private protocol error, Status = %r.\n", Status));
       goto Error;
     }
   }
@@ -690,7 +690,7 @@ I2cBusDriverStart (
 
 Error:
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "I2cBus: Start() function failed, Status = %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "I2cBus: Start() function failed, Status = %r\n", Status));
     if (ParentDevicePath != NULL) {
       gBS->CloseProtocol (
             Controller,
@@ -921,7 +921,7 @@ RegisterI2cDevice (
     //  Determine if the device info is valid
     //
     if ((Device->DeviceGuid == NULL) || (Device->SlaveAddressCount == 0) || (Device->SlaveAddressArray == NULL)) {
-      DEBUG ((EFI_D_ERROR, "Invalid EFI_I2C_DEVICE reported by I2c Enumerate protocol.\n"));
+      DEBUG ((DEBUG_ERROR, "Invalid EFI_I2C_DEVICE reported by I2c Enumerate protocol.\n"));
       continue;
     }
 

--- a/MdeModulePkg/Bus/I2c/I2cDxe/I2cHost.c
+++ b/MdeModulePkg/Bus/I2c/I2cDxe/I2cHost.c
@@ -343,7 +343,7 @@ I2cHostDriverStart (
                   EFI_OPEN_PROTOCOL_BY_DRIVER
                   );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "I2cHost: Open I2C bus configuration error, Status = %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "I2cHost: Open I2C bus configuration error, Status = %r\n", Status));
     return Status;
   }
 
@@ -359,7 +359,7 @@ I2cHostDriverStart (
                   EFI_OPEN_PROTOCOL_GET_PROTOCOL
                   );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "I2cHost: Open I2C master error, Status = %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "I2cHost: Open I2C master error, Status = %r\n", Status));
     goto Exit;
   }
 
@@ -368,7 +368,7 @@ I2cHostDriverStart (
   //
   I2cHostContext = AllocateZeroPool (sizeof (I2C_HOST_CONTEXT));
   if (I2cHostContext == NULL) {
-    DEBUG ((EFI_D_ERROR, "I2cHost: there is no enough memory to allocate.\n"));
+    DEBUG ((DEBUG_ERROR, "I2cHost: there is no enough memory to allocate.\n"));
     Status = EFI_OUT_OF_RESOURCES;
     goto Exit;
   }
@@ -387,7 +387,7 @@ I2cHostDriverStart (
   //
   Status = I2cMaster->Reset (I2cMaster);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "I2cHost: I2C controller reset failed!\n"));
+    DEBUG ((DEBUG_ERROR, "I2cHost: I2C controller reset failed!\n"));
     goto Exit;
   }
 
@@ -402,7 +402,7 @@ I2cHostDriverStart (
                   &I2cHostContext->I2cEvent
                   );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "I2cHost: create complete event error, Status = %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "I2cHost: create complete event error, Status = %r\n", Status));
     goto Exit;
   }
 
@@ -417,7 +417,7 @@ I2cHostDriverStart (
                   &I2cHostContext->I2cBusConfigurationEvent
                   );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "I2cHost: create bus available event error, Status = %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "I2cHost: create bus available event error, Status = %r\n", Status));
     goto Exit;
   }
 
@@ -438,7 +438,7 @@ I2cHostDriverStart (
                   );
 Exit:
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "I2cHost: Start() function failed, Status = %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "I2cHost: Start() function failed, Status = %r\n", Status));
     if (I2cBusConfigurationManagement != NULL) {
       gBS->CloseProtocol (
                       Controller,
@@ -514,7 +514,7 @@ I2cHostDriverStop (
 
   TplPrevious = EfiGetCurrentTpl ();
   if (TplPrevious > TPL_I2C_SYNC) {
-    DEBUG ((EFI_D_ERROR, "I2cHost: TPL %d is too high in Stop.\n", TplPrevious));
+    DEBUG ((DEBUG_ERROR, "I2cHost: TPL %d is too high in Stop.\n", TplPrevious));
     return EFI_DEVICE_ERROR;
   }
 
@@ -982,7 +982,7 @@ I2cHostQueueRequest (
   //
   TplPrevious = EfiGetCurrentTpl ();
   if ((TplPrevious > TPL_I2C_SYNC) || ((Event == NULL) && (TplPrevious > TPL_CALLBACK))) {
-    DEBUG ((EFI_D_ERROR, "ERROR - TPL %d is too high!\n", TplPrevious));
+    DEBUG ((DEBUG_ERROR, "ERROR - TPL %d is too high!\n", TplPrevious));
     return EFI_INVALID_PARAMETER;
   }
 
@@ -991,7 +991,7 @@ I2cHostQueueRequest (
   //
   I2cRequest = AllocateZeroPool (sizeof (I2C_REQUEST));
   if (I2cRequest == NULL) {
-    DEBUG ((EFI_D_ERROR, "WARNING - Failed to allocate I2C_REQUEST!\n"));
+    DEBUG ((DEBUG_ERROR, "WARNING - Failed to allocate I2C_REQUEST!\n"));
     return EFI_OUT_OF_RESOURCES;
   }
 

--- a/MdeModulePkg/Bus/Pci/EhciDxe/Ehci.c
+++ b/MdeModulePkg/Bus/Pci/EhciDxe/Ehci.c
@@ -85,7 +85,7 @@ EhcGetCapability (
   *PortNumber     = (UINT8) (Ehc->HcStructParams & HCSP_NPORTS);
   *Is64BitCapable = (UINT8) Ehc->Support64BitDma;
 
-  DEBUG ((EFI_D_INFO, "EhcGetCapability: %d ports, 64 bit %d\n", *PortNumber, *Is64BitCapable));
+  DEBUG ((DEBUG_INFO, "EhcGetCapability: %d ports, 64 bit %d\n", *PortNumber, *Is64BitCapable));
 
   gBS->RestoreTPL (OldTpl);
   return EFI_SUCCESS;
@@ -181,7 +181,7 @@ EhcReset (
   }
 
 ON_EXIT:
-  DEBUG ((EFI_D_INFO, "EhcReset: exit status %r\n", Status));
+  DEBUG ((DEBUG_INFO, "EhcReset: exit status %r\n", Status));
   gBS->RestoreTPL (OldTpl);
   return Status;
 }
@@ -225,7 +225,7 @@ EhcGetState (
 
   gBS->RestoreTPL (OldTpl);
 
-  DEBUG ((EFI_D_INFO, "EhcGetState: current state %d\n", *State));
+  DEBUG ((DEBUG_INFO, "EhcGetState: current state %d\n", *State));
   return EFI_SUCCESS;
 }
 
@@ -299,7 +299,7 @@ EhcSetState (
     Status = EFI_INVALID_PARAMETER;
   }
 
-  DEBUG ((EFI_D_INFO, "EhcSetState: exit status %r\n", Status));
+  DEBUG ((DEBUG_INFO, "EhcSetState: exit status %r\n", Status));
   gBS->RestoreTPL (OldTpl);
   return Status;
 }
@@ -470,7 +470,7 @@ EhcSetRootHubPortFeature (
       Status = EhcRunHC (Ehc, EHC_GENERIC_TIMEOUT);
 
       if (EFI_ERROR (Status)) {
-        DEBUG ((EFI_D_INFO, "EhcSetRootHubPortFeature :failed to start HC - %r\n", Status));
+        DEBUG ((DEBUG_INFO, "EhcSetRootHubPortFeature :failed to start HC - %r\n", Status));
         break;
       }
     }
@@ -503,7 +503,7 @@ EhcSetRootHubPortFeature (
   }
 
 ON_EXIT:
-  DEBUG ((EFI_D_INFO, "EhcSetRootHubPortFeature: exit status %r\n", Status));
+  DEBUG ((DEBUG_INFO, "EhcSetRootHubPortFeature: exit status %r\n", Status));
 
   gBS->RestoreTPL (OldTpl);
   return Status;
@@ -638,7 +638,7 @@ EhcClearRootHubPortFeature (
   }
 
 ON_EXIT:
-  DEBUG ((EFI_D_INFO, "EhcClearRootHubPortFeature: exit status %r\n", Status));
+  DEBUG ((DEBUG_INFO, "EhcClearRootHubPortFeature: exit status %r\n", Status));
   gBS->RestoreTPL (OldTpl);
   return Status;
 }
@@ -729,7 +729,7 @@ EhcControlTransfer (
   *TransferResult = EFI_USB_ERR_SYSTEM;
 
   if (EhcIsHalt (Ehc) || EhcIsSysError (Ehc)) {
-    DEBUG ((EFI_D_ERROR, "EhcControlTransfer: HC halted at entrance\n"));
+    DEBUG ((DEBUG_ERROR, "EhcControlTransfer: HC halted at entrance\n"));
 
     EhcAckAllInterrupt (Ehc);
     goto ON_EXIT;
@@ -765,7 +765,7 @@ EhcControlTransfer (
           );
 
   if (Urb == NULL) {
-    DEBUG ((EFI_D_ERROR, "EhcControlTransfer: failed to create URB"));
+    DEBUG ((DEBUG_ERROR, "EhcControlTransfer: failed to create URB"));
 
     Status = EFI_OUT_OF_RESOURCES;
     goto ON_EXIT;
@@ -794,7 +794,7 @@ ON_EXIT:
   gBS->RestoreTPL (OldTpl);
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "EhcControlTransfer: error - %r, transfer - %x\n", Status, *TransferResult));
+    DEBUG ((DEBUG_ERROR, "EhcControlTransfer: error - %r, transfer - %x\n", Status, *TransferResult));
   }
 
   return Status;
@@ -878,7 +878,7 @@ EhcBulkTransfer (
   Status          = EFI_DEVICE_ERROR;
 
   if (EhcIsHalt (Ehc) || EhcIsSysError (Ehc)) {
-    DEBUG ((EFI_D_ERROR, "EhcBulkTransfer: HC is halted\n"));
+    DEBUG ((DEBUG_ERROR, "EhcBulkTransfer: HC is halted\n"));
 
     EhcAckAllInterrupt (Ehc);
     goto ON_EXIT;
@@ -908,7 +908,7 @@ EhcBulkTransfer (
           );
 
   if (Urb == NULL) {
-    DEBUG ((EFI_D_ERROR, "EhcBulkTransfer: failed to create URB\n"));
+    DEBUG ((DEBUG_ERROR, "EhcBulkTransfer: failed to create URB\n"));
 
     Status = EFI_OUT_OF_RESOURCES;
     goto ON_EXIT;
@@ -934,7 +934,7 @@ ON_EXIT:
   gBS->RestoreTPL (OldTpl);
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "EhcBulkTransfer: error - %r, transfer - %x\n", Status, *TransferResult));
+    DEBUG ((DEBUG_ERROR, "EhcBulkTransfer: error - %r, transfer - %x\n", Status, *TransferResult));
   }
 
   return Status;
@@ -1023,14 +1023,14 @@ EhcAsyncInterruptTransfer (
   if (!IsNewTransfer) {
     Status = EhciDelAsyncIntTransfer (Ehc, DeviceAddress, EndPointAddress, DataToggle);
 
-    DEBUG ((EFI_D_INFO, "EhcAsyncInterruptTransfer: remove old transfer - %r\n", Status));
+    DEBUG ((DEBUG_INFO, "EhcAsyncInterruptTransfer: remove old transfer - %r\n", Status));
     goto ON_EXIT;
   }
 
   Status = EFI_SUCCESS;
 
   if (EhcIsHalt (Ehc) || EhcIsSysError (Ehc)) {
-    DEBUG ((EFI_D_ERROR, "EhcAsyncInterruptTransfer: HC is halt\n"));
+    DEBUG ((DEBUG_ERROR, "EhcAsyncInterruptTransfer: HC is halt\n"));
     EhcAckAllInterrupt (Ehc);
 
     Status = EFI_DEVICE_ERROR;
@@ -1139,7 +1139,7 @@ EhcSyncInterruptTransfer (
   Status          = EFI_DEVICE_ERROR;
 
   if (EhcIsHalt (Ehc) || EhcIsSysError (Ehc)) {
-    DEBUG ((EFI_D_ERROR, "EhcSyncInterruptTransfer: HC is halt\n"));
+    DEBUG ((DEBUG_ERROR, "EhcSyncInterruptTransfer: HC is halt\n"));
 
     EhcAckAllInterrupt (Ehc);
     goto ON_EXIT;
@@ -1165,7 +1165,7 @@ EhcSyncInterruptTransfer (
           );
 
   if (Urb == NULL) {
-    DEBUG ((EFI_D_ERROR, "EhcSyncInterruptTransfer: failed to create URB\n"));
+    DEBUG ((DEBUG_ERROR, "EhcSyncInterruptTransfer: failed to create URB\n"));
 
     Status = EFI_OUT_OF_RESOURCES;
     goto ON_EXIT;
@@ -1189,7 +1189,7 @@ ON_EXIT:
   gBS->RestoreTPL (OldTpl);
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "EhcSyncInterruptTransfer: error - %r, transfer - %x\n", Status, *TransferResult));
+    DEBUG ((DEBUG_ERROR, "EhcSyncInterruptTransfer: error - %r, transfer - %x\n", Status, *TransferResult));
   }
 
   return Status;
@@ -1562,7 +1562,7 @@ EhcCreateUsb2Hc (
   Ehc->HcCapParams    = EhcReadCapRegister (Ehc, EHC_HCCPARAMS_OFFSET);
   Ehc->CapLen         = EhcReadCapRegister (Ehc, EHC_CAPLENGTH_OFFSET) & 0x0FF;
 
-  DEBUG ((EFI_D_INFO, "EhcCreateUsb2Hc: capability length %d\n", Ehc->CapLen));
+  DEBUG ((DEBUG_INFO, "EhcCreateUsb2Hc: capability length %d\n", Ehc->CapLen));
 
   //
   // EHCI Controllers with a CapLen of 0 are ignored.
@@ -1723,7 +1723,7 @@ EhcDriverBindingStart (
   }
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "EhcDriverBindingStart: failed to enable controller\n"));
+    DEBUG ((DEBUG_ERROR, "EhcDriverBindingStart: failed to enable controller\n"));
     goto CLOSE_PCIIO;
   }
 
@@ -1834,7 +1834,7 @@ EhcDriverBindingStart (
   Ehc = EhcCreateUsb2Hc (PciIo, HcDevicePath, OriginalPciAttributes);
 
   if (Ehc == NULL) {
-    DEBUG ((EFI_D_ERROR, "EhcDriverBindingStart: failed to create USB2_HC\n"));
+    DEBUG ((DEBUG_ERROR, "EhcDriverBindingStart: failed to create USB2_HC\n"));
 
     Status = EFI_OUT_OF_RESOURCES;
     goto CLOSE_PCIIO;
@@ -1854,7 +1854,7 @@ EhcDriverBindingStart (
     if (!EFI_ERROR (Status)) {
       Ehc->Support64BitDma = TRUE;
     } else {
-      DEBUG ((EFI_D_WARN,
+      DEBUG ((DEBUG_WARN,
         "%a: failed to enable 64-bit DMA on 64-bit capable controller @ %p (%r)\n",
         __FUNCTION__, Controller, Status));
     }
@@ -1868,7 +1868,7 @@ EhcDriverBindingStart (
                   );
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "EhcDriverBindingStart: failed to install USB2_HC Protocol\n"));
+    DEBUG ((DEBUG_ERROR, "EhcDriverBindingStart: failed to install USB2_HC Protocol\n"));
     goto FREE_POOL;
   }
 
@@ -1887,7 +1887,7 @@ EhcDriverBindingStart (
   Status = EhcInitHC (Ehc);
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "EhcDriverBindingStart: failed to init host controller\n"));
+    DEBUG ((DEBUG_ERROR, "EhcDriverBindingStart: failed to init host controller\n"));
     goto UNINSTALL_USBHC;
   }
 
@@ -1897,7 +1897,7 @@ EhcDriverBindingStart (
   Status = gBS->SetTimer (Ehc->PollTimer, TimerPeriodic, EHC_ASYNC_POLL_INTERVAL);
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "EhcDriverBindingStart: failed to start async interrupt monitor\n"));
+    DEBUG ((DEBUG_ERROR, "EhcDriverBindingStart: failed to start async interrupt monitor\n"));
 
     EhcHaltHC (Ehc, EHC_GENERIC_TIMEOUT);
     goto UNINSTALL_USBHC;
@@ -1938,7 +1938,7 @@ EhcDriverBindingStart (
     );
 
 
-  DEBUG ((EFI_D_INFO, "EhcDriverBindingStart: EHCI started for controller @ %p\n", Controller));
+  DEBUG ((DEBUG_INFO, "EhcDriverBindingStart: EHCI started for controller @ %p\n", Controller));
   return EFI_SUCCESS;
 
 UNINSTALL_USBHC:
@@ -2083,4 +2083,3 @@ EhcDriverBindingStop (
 
   return EFI_SUCCESS;
 }
-

--- a/MdeModulePkg/Bus/Pci/EhciDxe/EhciDebug.c
+++ b/MdeModulePkg/Bus/Pci/EhciDxe/EhciDebug.c
@@ -23,38 +23,38 @@ EhcDumpStatus (
   )
 {
   if (EHC_BIT_IS_SET (State, QTD_STAT_DO_PING)) {
-    DEBUG ((EFI_D_VERBOSE, "  Do_Ping"));
+    DEBUG ((DEBUG_VERBOSE, "  Do_Ping"));
   } else {
-    DEBUG ((EFI_D_VERBOSE, "  Do_Out"));
+    DEBUG ((DEBUG_VERBOSE, "  Do_Out"));
   }
 
   if (EHC_BIT_IS_SET (State, QTD_STAT_DO_CS)) {
-    DEBUG ((EFI_D_VERBOSE, "  Do_CS"));
+    DEBUG ((DEBUG_VERBOSE, "  Do_CS"));
   } else {
-    DEBUG ((EFI_D_VERBOSE, "  Do_SS"));
+    DEBUG ((DEBUG_VERBOSE, "  Do_SS"));
   }
 
   if (EHC_BIT_IS_SET (State, QTD_STAT_TRANS_ERR)) {
-    DEBUG ((EFI_D_VERBOSE, "  Transfer_Error"));
+    DEBUG ((DEBUG_VERBOSE, "  Transfer_Error"));
   }
 
   if (EHC_BIT_IS_SET (State, QTD_STAT_BABBLE_ERR)) {
-    DEBUG ((EFI_D_VERBOSE, "  Babble_Error"));
+    DEBUG ((DEBUG_VERBOSE, "  Babble_Error"));
   }
 
   if (EHC_BIT_IS_SET (State, QTD_STAT_BUFF_ERR)) {
-    DEBUG ((EFI_D_VERBOSE, "  Buffer_Error"));
+    DEBUG ((DEBUG_VERBOSE, "  Buffer_Error"));
   }
 
   if (EHC_BIT_IS_SET (State, QTD_STAT_HALTED)) {
-    DEBUG ((EFI_D_VERBOSE, "  Halted"));
+    DEBUG ((DEBUG_VERBOSE, "  Halted"));
   }
 
   if (EHC_BIT_IS_SET (State, QTD_STAT_ACTIVE)) {
-    DEBUG ((EFI_D_VERBOSE, "  Active"));
+    DEBUG ((DEBUG_VERBOSE, "  Active"));
   }
 
-  DEBUG ((EFI_D_VERBOSE, "\n"));
+  DEBUG ((DEBUG_VERBOSE, "\n"));
 }
 
 
@@ -75,37 +75,37 @@ EhcDumpQtd (
   UINTN                   Index;
 
   if (Msg != NULL) {
-    DEBUG ((EFI_D_VERBOSE, Msg));
+    DEBUG ((DEBUG_VERBOSE, Msg));
   }
 
-  DEBUG ((EFI_D_VERBOSE, "Queue TD @ 0x%p, data length %d\n", Qtd, (UINT32)Qtd->DataLen));
+  DEBUG ((DEBUG_VERBOSE, "Queue TD @ 0x%p, data length %d\n", Qtd, (UINT32)Qtd->DataLen));
 
   QtdHw = &Qtd->QtdHw;
 
-  DEBUG ((EFI_D_VERBOSE, "Next QTD     : %x\n", QtdHw->NextQtd));
-  DEBUG ((EFI_D_VERBOSE, "AltNext QTD  : %x\n", QtdHw->AltNext));
-  DEBUG ((EFI_D_VERBOSE, "Status       : %x\n", QtdHw->Status));
+  DEBUG ((DEBUG_VERBOSE, "Next QTD     : %x\n", QtdHw->NextQtd));
+  DEBUG ((DEBUG_VERBOSE, "AltNext QTD  : %x\n", QtdHw->AltNext));
+  DEBUG ((DEBUG_VERBOSE, "Status       : %x\n", QtdHw->Status));
   EhcDumpStatus (QtdHw->Status);
 
   if (QtdHw->Pid == QTD_PID_SETUP) {
-    DEBUG ((EFI_D_VERBOSE, "PID          : Setup\n"));
+    DEBUG ((DEBUG_VERBOSE, "PID          : Setup\n"));
 
   } else if (QtdHw->Pid == QTD_PID_INPUT) {
-    DEBUG ((EFI_D_VERBOSE, "PID          : IN\n"));
+    DEBUG ((DEBUG_VERBOSE, "PID          : IN\n"));
 
   } else if (QtdHw->Pid == QTD_PID_OUTPUT) {
-    DEBUG ((EFI_D_VERBOSE, "PID          : OUT\n"));
+    DEBUG ((DEBUG_VERBOSE, "PID          : OUT\n"));
 
   }
 
-  DEBUG ((EFI_D_VERBOSE, "Error Count  : %d\n", QtdHw->ErrCnt));
-  DEBUG ((EFI_D_VERBOSE, "Current Page : %d\n", QtdHw->CurPage));
-  DEBUG ((EFI_D_VERBOSE, "IOC          : %d\n", QtdHw->Ioc));
-  DEBUG ((EFI_D_VERBOSE, "Total Bytes  : %d\n", QtdHw->TotalBytes));
-  DEBUG ((EFI_D_VERBOSE, "Data Toggle  : %d\n", QtdHw->DataToggle));
+  DEBUG ((DEBUG_VERBOSE, "Error Count  : %d\n", QtdHw->ErrCnt));
+  DEBUG ((DEBUG_VERBOSE, "Current Page : %d\n", QtdHw->CurPage));
+  DEBUG ((DEBUG_VERBOSE, "IOC          : %d\n", QtdHw->Ioc));
+  DEBUG ((DEBUG_VERBOSE, "Total Bytes  : %d\n", QtdHw->TotalBytes));
+  DEBUG ((DEBUG_VERBOSE, "Data Toggle  : %d\n", QtdHw->DataToggle));
 
   for (Index = 0; Index < 5; Index++) {
-    DEBUG ((EFI_D_VERBOSE, "Page[%d]      : 0x%x\n", (UINT32)Index, QtdHw->Page[Index]));
+    DEBUG ((DEBUG_VERBOSE, "Page[%d]      : 0x%x\n", (UINT32)Index, QtdHw->Page[Index]));
   }
 }
 
@@ -131,60 +131,60 @@ EhcDumpQh (
   UINTN                   Index;
 
   if (Msg != NULL) {
-    DEBUG ((EFI_D_VERBOSE, Msg));
+    DEBUG ((DEBUG_VERBOSE, Msg));
   }
 
-  DEBUG ((EFI_D_VERBOSE, "Queue head @ 0x%p, interval %ld, next qh %p\n",
+  DEBUG ((DEBUG_VERBOSE, "Queue head @ 0x%p, interval %ld, next qh %p\n",
                                 Qh, (UINT64)Qh->Interval, Qh->NextQh));
 
   QhHw = &Qh->QhHw;
 
-  DEBUG ((EFI_D_VERBOSE, "Hoziontal link: %x\n", QhHw->HorizonLink));
-  DEBUG ((EFI_D_VERBOSE, "Device address: %d\n", QhHw->DeviceAddr));
-  DEBUG ((EFI_D_VERBOSE, "Inactive      : %d\n", QhHw->Inactive));
-  DEBUG ((EFI_D_VERBOSE, "EP number     : %d\n", QhHw->EpNum));
-  DEBUG ((EFI_D_VERBOSE, "EP speed      : %d\n", QhHw->EpSpeed));
-  DEBUG ((EFI_D_VERBOSE, "DT control    : %d\n", QhHw->DtCtrl));
-  DEBUG ((EFI_D_VERBOSE, "Reclaim head  : %d\n", QhHw->ReclaimHead));
-  DEBUG ((EFI_D_VERBOSE, "Max packet len: %d\n", QhHw->MaxPacketLen));
-  DEBUG ((EFI_D_VERBOSE, "Ctrl EP       : %d\n", QhHw->CtrlEp));
-  DEBUG ((EFI_D_VERBOSE, "Nak reload    : %d\n", QhHw->NakReload));
+  DEBUG ((DEBUG_VERBOSE, "Hoziontal link: %x\n", QhHw->HorizonLink));
+  DEBUG ((DEBUG_VERBOSE, "Device address: %d\n", QhHw->DeviceAddr));
+  DEBUG ((DEBUG_VERBOSE, "Inactive      : %d\n", QhHw->Inactive));
+  DEBUG ((DEBUG_VERBOSE, "EP number     : %d\n", QhHw->EpNum));
+  DEBUG ((DEBUG_VERBOSE, "EP speed      : %d\n", QhHw->EpSpeed));
+  DEBUG ((DEBUG_VERBOSE, "DT control    : %d\n", QhHw->DtCtrl));
+  DEBUG ((DEBUG_VERBOSE, "Reclaim head  : %d\n", QhHw->ReclaimHead));
+  DEBUG ((DEBUG_VERBOSE, "Max packet len: %d\n", QhHw->MaxPacketLen));
+  DEBUG ((DEBUG_VERBOSE, "Ctrl EP       : %d\n", QhHw->CtrlEp));
+  DEBUG ((DEBUG_VERBOSE, "Nak reload    : %d\n", QhHw->NakReload));
 
-  DEBUG ((EFI_D_VERBOSE, "SMask         : %x\n", QhHw->SMask));
-  DEBUG ((EFI_D_VERBOSE, "CMask         : %x\n", QhHw->CMask));
-  DEBUG ((EFI_D_VERBOSE, "Hub address   : %d\n", QhHw->HubAddr));
-  DEBUG ((EFI_D_VERBOSE, "Hub port      : %d\n", QhHw->PortNum));
-  DEBUG ((EFI_D_VERBOSE, "Multiplier    : %d\n", QhHw->Multiplier));
+  DEBUG ((DEBUG_VERBOSE, "SMask         : %x\n", QhHw->SMask));
+  DEBUG ((DEBUG_VERBOSE, "CMask         : %x\n", QhHw->CMask));
+  DEBUG ((DEBUG_VERBOSE, "Hub address   : %d\n", QhHw->HubAddr));
+  DEBUG ((DEBUG_VERBOSE, "Hub port      : %d\n", QhHw->PortNum));
+  DEBUG ((DEBUG_VERBOSE, "Multiplier    : %d\n", QhHw->Multiplier));
 
-  DEBUG ((EFI_D_VERBOSE, "Cur QTD       : %x\n", QhHw->CurQtd));
+  DEBUG ((DEBUG_VERBOSE, "Cur QTD       : %x\n", QhHw->CurQtd));
 
-  DEBUG ((EFI_D_VERBOSE, "Next QTD      : %x\n", QhHw->NextQtd));
-  DEBUG ((EFI_D_VERBOSE, "AltNext QTD   : %x\n", QhHw->AltQtd));
-  DEBUG ((EFI_D_VERBOSE, "Status        : %x\n", QhHw->Status));
+  DEBUG ((DEBUG_VERBOSE, "Next QTD      : %x\n", QhHw->NextQtd));
+  DEBUG ((DEBUG_VERBOSE, "AltNext QTD   : %x\n", QhHw->AltQtd));
+  DEBUG ((DEBUG_VERBOSE, "Status        : %x\n", QhHw->Status));
 
   EhcDumpStatus (QhHw->Status);
 
   if (QhHw->Pid == QTD_PID_SETUP) {
-    DEBUG ((EFI_D_VERBOSE, "PID           : Setup\n"));
+    DEBUG ((DEBUG_VERBOSE, "PID           : Setup\n"));
 
   } else if (QhHw->Pid == QTD_PID_INPUT) {
-    DEBUG ((EFI_D_VERBOSE, "PID           : IN\n"));
+    DEBUG ((DEBUG_VERBOSE, "PID           : IN\n"));
 
   } else if (QhHw->Pid == QTD_PID_OUTPUT) {
-    DEBUG ((EFI_D_VERBOSE, "PID           : OUT\n"));
+    DEBUG ((DEBUG_VERBOSE, "PID           : OUT\n"));
   }
 
-  DEBUG ((EFI_D_VERBOSE, "Error Count   : %d\n", QhHw->ErrCnt));
-  DEBUG ((EFI_D_VERBOSE, "Current Page  : %d\n", QhHw->CurPage));
-  DEBUG ((EFI_D_VERBOSE, "IOC           : %d\n", QhHw->Ioc));
-  DEBUG ((EFI_D_VERBOSE, "Total Bytes   : %d\n", QhHw->TotalBytes));
-  DEBUG ((EFI_D_VERBOSE, "Data Toggle   : %d\n", QhHw->DataToggle));
+  DEBUG ((DEBUG_VERBOSE, "Error Count   : %d\n", QhHw->ErrCnt));
+  DEBUG ((DEBUG_VERBOSE, "Current Page  : %d\n", QhHw->CurPage));
+  DEBUG ((DEBUG_VERBOSE, "IOC           : %d\n", QhHw->Ioc));
+  DEBUG ((DEBUG_VERBOSE, "Total Bytes   : %d\n", QhHw->TotalBytes));
+  DEBUG ((DEBUG_VERBOSE, "Data Toggle   : %d\n", QhHw->DataToggle));
 
   for (Index = 0; Index < 5; Index++) {
-    DEBUG ((EFI_D_VERBOSE, "Page[%d]       : 0x%x\n", Index, QhHw->Page[Index]));
+    DEBUG ((DEBUG_VERBOSE, "Page[%d]       : 0x%x\n", Index, QhHw->Page[Index]));
   }
 
-  DEBUG ((EFI_D_VERBOSE, "\n"));
+  DEBUG ((DEBUG_VERBOSE, "\n"));
 
   BASE_LIST_FOR_EACH (Entry, &Qh->Qtds) {
     Qtd = EFI_LIST_CONTAINER (Entry, EHC_QTD, QtdList);
@@ -214,13 +214,11 @@ EhcDumpBuf (
 
   for (Index = 0; Index < Len; Index++) {
     if (Index % 16 == 0) {
-      DEBUG ((EFI_D_VERBOSE,"\n"));
+      DEBUG ((DEBUG_VERBOSE,"\n"));
     }
 
-    DEBUG ((EFI_D_VERBOSE, "%02x ", Buf[Index]));
+    DEBUG ((DEBUG_VERBOSE, "%02x ", Buf[Index]));
   }
 
-  DEBUG ((EFI_D_VERBOSE, "\n"));
+  DEBUG ((DEBUG_VERBOSE, "\n"));
 }
-
-

--- a/MdeModulePkg/Bus/Pci/EhciDxe/EhciReg.c
+++ b/MdeModulePkg/Bus/Pci/EhciDxe/EhciReg.c
@@ -40,7 +40,7 @@ EhcReadCapRegister (
                              );
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "EhcReadCapRegister: Pci Io read error - %r at %d\n", Status, Offset));
+    DEBUG ((DEBUG_ERROR, "EhcReadCapRegister: Pci Io read error - %r at %d\n", Status, Offset));
     Data = 0xFFFF;
   }
 
@@ -76,7 +76,7 @@ EhcReadDbgRegister (
                              );
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "EhcReadDbgRegister: Pci Io read error - %r at %d\n", Status, Offset));
+    DEBUG ((DEBUG_ERROR, "EhcReadDbgRegister: Pci Io read error - %r at %d\n", Status, Offset));
     Data = 0xFFFF;
   }
 
@@ -168,7 +168,7 @@ EhcReadOpReg (
                              );
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "EhcReadOpReg: Pci Io Read error - %r at %d\n", Status, Offset));
+    DEBUG ((DEBUG_ERROR, "EhcReadOpReg: Pci Io Read error - %r at %d\n", Status, Offset));
     Data = 0xFFFF;
   }
 
@@ -205,7 +205,7 @@ EhcWriteOpReg (
                              );
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "EhcWriteOpReg: Pci Io Write error: %r at %d\n", Status, Offset));
+    DEBUG ((DEBUG_ERROR, "EhcWriteOpReg: Pci Io Write error: %r at %d\n", Status, Offset));
   }
 }
 
@@ -310,7 +310,7 @@ EhcClearLegacySupport (
   UINT32                    Value;
   UINT32                    TimeOut;
 
-  DEBUG ((EFI_D_INFO, "EhcClearLegacySupport: called to clear legacy support\n"));
+  DEBUG ((DEBUG_INFO, "EhcClearLegacySupport: called to clear legacy support\n"));
 
   PciIo     = Ehc->PciIo;
   ExtendCap = (Ehc->HcCapParams >> 8) & 0xFF;
@@ -654,14 +654,14 @@ EhcInitHC (
   Status = EhcEnablePeriodSchd (Ehc, EHC_GENERIC_TIMEOUT);
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "EhcInitHC: failed to enable period schedule\n"));
+    DEBUG ((DEBUG_ERROR, "EhcInitHC: failed to enable period schedule\n"));
     return Status;
   }
 
   Status = EhcEnableAsyncSchd (Ehc, EHC_GENERIC_TIMEOUT);
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "EhcInitHC: failed to enable async schedule\n"));
+    DEBUG ((DEBUG_ERROR, "EhcInitHC: failed to enable async schedule\n"));
     return Status;
   }
 

--- a/MdeModulePkg/Bus/Pci/EhciDxe/EhciSched.c
+++ b/MdeModulePkg/Bus/Pci/EhciDxe/EhciSched.c
@@ -377,7 +377,7 @@ EhcUnlinkQhFromAsync (
   Status = EhcSetAndWaitDoorBell (Ehc, EHC_GENERIC_TIMEOUT);
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "EhcUnlinkQhFromAsync: Failed to synchronize with doorbell\n"));
+    DEBUG ((DEBUG_ERROR, "EhcUnlinkQhFromAsync: Failed to synchronize with doorbell\n"));
   }
 }
 
@@ -636,13 +636,13 @@ EhcCheckUrbResult (
         //
         PciAddr = UsbHcGetPciAddressForHostMem (Ehc->MemPool, Ehc->ShortReadStop, sizeof (EHC_QTD));
         if (QtdHw->AltNext == QTD_LINK (PciAddr, FALSE)) {
-          DEBUG ((EFI_D_VERBOSE, "EhcCheckUrbResult: Short packet read, break\n"));
+          DEBUG ((DEBUG_VERBOSE, "EhcCheckUrbResult: Short packet read, break\n"));
 
           Finished = TRUE;
           goto ON_EXIT;
         }
 
-        DEBUG ((EFI_D_VERBOSE, "EhcCheckUrbResult: Short packet read, continue\n"));
+        DEBUG ((DEBUG_VERBOSE, "EhcCheckUrbResult: Short packet read, continue\n"));
       }
     }
   }
@@ -713,13 +713,13 @@ EhcExecTransfer (
   }
 
   if (!Finished) {
-    DEBUG ((EFI_D_ERROR, "EhcExecTransfer: transfer not finished in %dms\n", (UINT32)TimeOut));
+    DEBUG ((DEBUG_ERROR, "EhcExecTransfer: transfer not finished in %dms\n", (UINT32)TimeOut));
     EhcDumpQh (Urb->Qh, NULL, FALSE);
 
     Status = EFI_TIMEOUT;
 
   } else if (Urb->Result != EFI_USB_NOERROR) {
-    DEBUG ((EFI_D_ERROR, "EhcExecTransfer: transfer failed with %x\n", Urb->Result));
+    DEBUG ((DEBUG_ERROR, "EhcExecTransfer: transfer failed with %x\n", Urb->Result));
     EhcDumpQh (Urb->Qh, NULL, FALSE);
 
     Status = EFI_DEVICE_ERROR;
@@ -1069,7 +1069,7 @@ EhcMonitorAsyncRequests (
     //
     Status = EhcFlushAsyncIntMap (Ehc, Urb);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "EhcMonitorAsyncRequests: Fail to Flush AsyncInt Mapped Memeory\n"));
+      DEBUG ((DEBUG_ERROR, "EhcMonitorAsyncRequests: Fail to Flush AsyncInt Mapped Memeory\n"));
     }
 
     //

--- a/MdeModulePkg/Bus/Pci/EhciDxe/UsbHcMem.c
+++ b/MdeModulePkg/Bus/Pci/EhciDxe/UsbHcMem.c
@@ -470,7 +470,7 @@ UsbHcAllocateMem (
   NewBlock = UsbHcAllocMemBlock (Pool, Pages);
 
   if (NewBlock == NULL) {
-    DEBUG ((EFI_D_ERROR, "UsbHcAllocateMem: failed to allocate block\n"));
+    DEBUG ((DEBUG_ERROR, "UsbHcAllocateMem: failed to allocate block\n"));
     return NULL;
   }
 

--- a/MdeModulePkg/Bus/Pci/IdeBusPei/AtapiPeim.c
+++ b/MdeModulePkg/Bus/Pci/IdeBusPei/AtapiPeim.c
@@ -76,7 +76,7 @@ AtapiPeimEntry (
   AtapiBlkIoDev->PpiDescriptor2.Guid                 = &gEfiPeiVirtualBlockIo2PpiGuid;
   AtapiBlkIoDev->PpiDescriptor2.Ppi                  = &AtapiBlkIoDev->AtapiBlkIo2;
 
-  DEBUG ((EFI_D_INFO, "Atatpi Device Count is %d\n", AtapiBlkIoDev->DeviceCount));
+  DEBUG ((DEBUG_INFO, "Atatpi Device Count is %d\n", AtapiBlkIoDev->DeviceCount));
   if (AtapiBlkIoDev->DeviceCount != 0) {
     Status = PeiServicesInstallPpi (&AtapiBlkIoDev->PpiDescriptor);
     if (EFI_ERROR (Status)) {
@@ -189,11 +189,11 @@ AtapiGetBlockDeviceMediaInfo (
   //
   // probe media and retrieve latest media information
   //
-  DEBUG ((EFI_D_INFO, "Atatpi GetInfo DevicePosition is %d\n", AtapiBlkIoDev->DeviceInfo[Index].DevicePosition));
-  DEBUG ((EFI_D_INFO, "Atatpi GetInfo DeviceType is   %d\n", AtapiBlkIoDev->DeviceInfo[Index].MediaInfo.DeviceType));
-  DEBUG ((EFI_D_INFO, "Atatpi GetInfo MediaPresent is %d\n", AtapiBlkIoDev->DeviceInfo[Index].MediaInfo.MediaPresent));
-  DEBUG ((EFI_D_INFO, "Atatpi GetInfo BlockSize is  0x%x\n", AtapiBlkIoDev->DeviceInfo[Index].MediaInfo.BlockSize));
-  DEBUG ((EFI_D_INFO, "Atatpi GetInfo LastBlock is  0x%x\n", AtapiBlkIoDev->DeviceInfo[Index].MediaInfo.LastBlock));
+  DEBUG ((DEBUG_INFO, "Atatpi GetInfo DevicePosition is %d\n", AtapiBlkIoDev->DeviceInfo[Index].DevicePosition));
+  DEBUG ((DEBUG_INFO, "Atatpi GetInfo DeviceType is   %d\n", AtapiBlkIoDev->DeviceInfo[Index].MediaInfo.DeviceType));
+  DEBUG ((DEBUG_INFO, "Atatpi GetInfo MediaPresent is %d\n", AtapiBlkIoDev->DeviceInfo[Index].MediaInfo.MediaPresent));
+  DEBUG ((DEBUG_INFO, "Atatpi GetInfo BlockSize is  0x%x\n", AtapiBlkIoDev->DeviceInfo[Index].MediaInfo.BlockSize));
+  DEBUG ((DEBUG_INFO, "Atatpi GetInfo LastBlock is  0x%x\n", AtapiBlkIoDev->DeviceInfo[Index].MediaInfo.LastBlock));
 
   Status = DetectMedia (
              AtapiBlkIoDev,
@@ -205,11 +205,11 @@ AtapiGetBlockDeviceMediaInfo (
     return EFI_DEVICE_ERROR;
   }
 
-  DEBUG ((EFI_D_INFO, "Atatpi GetInfo DevicePosition is %d\n", AtapiBlkIoDev->DeviceInfo[Index].DevicePosition));
-  DEBUG ((EFI_D_INFO, "Atatpi GetInfo DeviceType is   %d\n", AtapiBlkIoDev->DeviceInfo[Index].MediaInfo.DeviceType));
-  DEBUG ((EFI_D_INFO, "Atatpi GetInfo MediaPresent is %d\n", AtapiBlkIoDev->DeviceInfo[Index].MediaInfo.MediaPresent));
-  DEBUG ((EFI_D_INFO, "Atatpi GetInfo BlockSize is  0x%x\n", AtapiBlkIoDev->DeviceInfo[Index].MediaInfo.BlockSize));
-  DEBUG ((EFI_D_INFO, "Atatpi GetInfo LastBlock is  0x%x\n", AtapiBlkIoDev->DeviceInfo[Index].MediaInfo.LastBlock));
+  DEBUG ((DEBUG_INFO, "Atatpi GetInfo DevicePosition is %d\n", AtapiBlkIoDev->DeviceInfo[Index].DevicePosition));
+  DEBUG ((DEBUG_INFO, "Atatpi GetInfo DeviceType is   %d\n", AtapiBlkIoDev->DeviceInfo[Index].MediaInfo.DeviceType));
+  DEBUG ((DEBUG_INFO, "Atatpi GetInfo MediaPresent is %d\n", AtapiBlkIoDev->DeviceInfo[Index].MediaInfo.MediaPresent));
+  DEBUG ((DEBUG_INFO, "Atatpi GetInfo BlockSize is  0x%x\n", AtapiBlkIoDev->DeviceInfo[Index].MediaInfo.BlockSize));
+  DEBUG ((DEBUG_INFO, "Atatpi GetInfo LastBlock is  0x%x\n", AtapiBlkIoDev->DeviceInfo[Index].MediaInfo.LastBlock));
 
   //
   // Get media info from AtapiBlkIoDev
@@ -549,7 +549,7 @@ AtapiEnumerateDevices (
   // Allow SATA Devices to spin-up. This is needed if
   // SEC and PEI phase is too short, for example Release Build.
   //
-  DEBUG ((EFI_D_INFO, "Delay for %d seconds for SATA devices to spin-up\n", PcdGet16 (PcdSataSpinUpDelayInSecForRecoveryPath)));
+  DEBUG ((DEBUG_INFO, "Delay for %d seconds for SATA devices to spin-up\n", PcdGet16 (PcdSataSpinUpDelayInSecForRecoveryPath)));
   MicroSecondDelay (PcdGet16 (PcdSataSpinUpDelayInSecForRecoveryPath) * 1000 * 1000); //
 
   //
@@ -600,10 +600,10 @@ AtapiEnumerateDevices (
         CopyMem (&(AtapiBlkIoDev->DeviceInfo[DeviceCount].MediaInfo), &MediaInfo, sizeof (MediaInfo));
         CopyMem (&(AtapiBlkIoDev->DeviceInfo[DeviceCount].MediaInfo2), &MediaInfo2, sizeof (MediaInfo2));
 
-        DEBUG ((EFI_D_INFO, "Atatpi Device Position is %d\n", DevicePosition));
-        DEBUG ((EFI_D_INFO, "Atatpi DeviceType is   %d\n", MediaInfo.DeviceType));
-        DEBUG ((EFI_D_INFO, "Atatpi MediaPresent is %d\n", MediaInfo.MediaPresent));
-        DEBUG ((EFI_D_INFO, "Atatpi BlockSize is  0x%x\n", MediaInfo.BlockSize));
+        DEBUG ((DEBUG_INFO, "Atatpi Device Position is %d\n", DevicePosition));
+        DEBUG ((DEBUG_INFO, "Atatpi DeviceType is   %d\n", MediaInfo.DeviceType));
+        DEBUG ((DEBUG_INFO, "Atatpi MediaPresent is %d\n", MediaInfo.MediaPresent));
+        DEBUG ((DEBUG_INFO, "Atatpi BlockSize is  0x%x\n", MediaInfo.BlockSize));
 
         if (EFI_ERROR (Status)) {
           AtapiBlkIoDev->DeviceInfo[DeviceCount].MediaInfo.MediaPresent = FALSE;
@@ -1764,7 +1764,7 @@ DetectMedia (
               SenseBuffers,
               &SenseCounts
               );
-    DEBUG ((EFI_D_INFO, "Atapi Request Sense Count is %d\n", SenseCounts));
+    DEBUG ((DEBUG_INFO, "Atapi Request Sense Count is %d\n", SenseCounts));
     if (IsDeviceStateUnclear (SenseBuffers, SenseCounts) || IsNoMedia (SenseBuffers, SenseCounts)) {
       //
       // We are not sure whether the media is present or not, try again

--- a/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpress.c
+++ b/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpress.c
@@ -271,11 +271,11 @@ EnumerateNvmeDevNamespace (
     //
     // Dump NvmExpress Identify Namespace Data
     //
-    DEBUG ((EFI_D_INFO, " == NVME IDENTIFY NAMESPACE [%d] DATA ==\n", NamespaceId));
-    DEBUG ((EFI_D_INFO, "    NSZE        : 0x%x\n", NamespaceData->Nsze));
-    DEBUG ((EFI_D_INFO, "    NCAP        : 0x%x\n", NamespaceData->Ncap));
-    DEBUG ((EFI_D_INFO, "    NUSE        : 0x%x\n", NamespaceData->Nuse));
-    DEBUG ((EFI_D_INFO, "    LBAF0.LBADS : 0x%x\n", (NamespaceData->LbaFormat[0].Lbads)));
+    DEBUG ((DEBUG_INFO, " == NVME IDENTIFY NAMESPACE [%d] DATA ==\n", NamespaceId));
+    DEBUG ((DEBUG_INFO, "    NSZE        : 0x%x\n", NamespaceData->Nsze));
+    DEBUG ((DEBUG_INFO, "    NCAP        : 0x%x\n", NamespaceData->Ncap));
+    DEBUG ((DEBUG_INFO, "    NUSE        : 0x%x\n", NamespaceData->Nuse));
+    DEBUG ((DEBUG_INFO, "    LBAF0.LBADS : 0x%x\n", (NamespaceData->LbaFormat[0].Lbads)));
 
     //
     // Build controller name for Component Name (2) protocol.
@@ -906,7 +906,7 @@ NvmExpressDriverBindingStart (
   UINTN                               Bytes;
   EFI_NVM_EXPRESS_PASS_THRU_PROTOCOL  *Passthru;
 
-  DEBUG ((EFI_D_INFO, "NvmExpressDriverBindingStart: start\n"));
+  DEBUG ((DEBUG_INFO, "NvmExpressDriverBindingStart: start\n"));
 
   Private          = NULL;
   Passthru         = NULL;
@@ -944,7 +944,7 @@ NvmExpressDriverBindingStart (
     Private = AllocateZeroPool (sizeof (NVME_CONTROLLER_PRIVATE_DATA));
 
     if (Private == NULL) {
-      DEBUG ((EFI_D_ERROR, "NvmExpressDriverBindingStart: allocating pool for Nvme Private Data failed!\n"));
+      DEBUG ((DEBUG_ERROR, "NvmExpressDriverBindingStart: allocating pool for Nvme Private Data failed!\n"));
       Status = EFI_OUT_OF_RESOURCES;
       goto Exit;
     }
@@ -1084,7 +1084,7 @@ NvmExpressDriverBindingStart (
     }
   }
 
-  DEBUG ((EFI_D_INFO, "NvmExpressDriverBindingStart: end successfully\n"));
+  DEBUG ((DEBUG_INFO, "NvmExpressDriverBindingStart: end successfully\n"));
   return EFI_SUCCESS;
 
 Exit:
@@ -1122,7 +1122,7 @@ Exit:
          Controller
          );
 
-  DEBUG ((EFI_D_INFO, "NvmExpressDriverBindingStart: end with %r\n", Status));
+  DEBUG ((DEBUG_INFO, "NvmExpressDriverBindingStart: end with %r\n", Status));
 
   return Status;
 }

--- a/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressHci.c
+++ b/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressHci.c
@@ -128,13 +128,13 @@ WriteNvmeControllerConfiguration (
     return Status;
   }
 
-  DEBUG ((EFI_D_INFO, "Cc.En: %d\n", Cc->En));
-  DEBUG ((EFI_D_INFO, "Cc.Css: %d\n", Cc->Css));
-  DEBUG ((EFI_D_INFO, "Cc.Mps: %d\n", Cc->Mps));
-  DEBUG ((EFI_D_INFO, "Cc.Ams: %d\n", Cc->Ams));
-  DEBUG ((EFI_D_INFO, "Cc.Shn: %d\n", Cc->Shn));
-  DEBUG ((EFI_D_INFO, "Cc.Iosqes: %d\n", Cc->Iosqes));
-  DEBUG ((EFI_D_INFO, "Cc.Iocqes: %d\n", Cc->Iocqes));
+  DEBUG ((DEBUG_INFO, "Cc.En: %d\n", Cc->En));
+  DEBUG ((DEBUG_INFO, "Cc.Css: %d\n", Cc->Css));
+  DEBUG ((DEBUG_INFO, "Cc.Mps: %d\n", Cc->Mps));
+  DEBUG ((DEBUG_INFO, "Cc.Ams: %d\n", Cc->Ams));
+  DEBUG ((DEBUG_INFO, "Cc.Shn: %d\n", Cc->Shn));
+  DEBUG ((DEBUG_INFO, "Cc.Iosqes: %d\n", Cc->Iosqes));
+  DEBUG ((DEBUG_INFO, "Cc.Iocqes: %d\n", Cc->Iocqes));
 
   return EFI_SUCCESS;
 }
@@ -214,8 +214,8 @@ WriteNvmeAdminQueueAttributes (
     return Status;
   }
 
-  DEBUG ((EFI_D_INFO, "Aqa.Asqs: %d\n", Aqa->Asqs));
-  DEBUG ((EFI_D_INFO, "Aqa.Acqs: %d\n", Aqa->Acqs));
+  DEBUG ((DEBUG_INFO, "Aqa.Asqs: %d\n", Aqa->Asqs));
+  DEBUG ((DEBUG_INFO, "Aqa.Acqs: %d\n", Aqa->Acqs));
 
   return EFI_SUCCESS;
 }
@@ -257,7 +257,7 @@ WriteNvmeAdminSubmissionQueueBaseAddress (
     return Status;
   }
 
-  DEBUG ((EFI_D_INFO, "Asq: %lx\n", *Asq));
+  DEBUG ((DEBUG_INFO, "Asq: %lx\n", *Asq));
 
   return EFI_SUCCESS;
 }
@@ -300,7 +300,7 @@ WriteNvmeAdminCompletionQueueBaseAddress (
     return Status;
   }
 
-  DEBUG ((EFI_D_INFO, "Acq: %lxh\n", *Acq));
+  DEBUG ((DEBUG_INFO, "Acq: %lxh\n", *Acq));
 
   return EFI_SUCCESS;
 }
@@ -379,7 +379,7 @@ NvmeDisableController (
       );
   }
 
-  DEBUG ((EFI_D_INFO, "NVMe controller is disabled with status [%r].\n", Status));
+  DEBUG ((DEBUG_INFO, "NVMe controller is disabled with status [%r].\n", Status));
   return Status;
 }
 
@@ -453,7 +453,7 @@ NvmeEnableController (
       );
   }
 
-  DEBUG ((EFI_D_INFO, "NVMe controller is enabled with status [%r].\n", Status));
+  DEBUG ((DEBUG_INFO, "NVMe controller is enabled with status [%r].\n", Status));
   return Status;
 }
 
@@ -764,7 +764,7 @@ NvmeControllerInit (
   }
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_INFO, "NvmeControllerInit: failed to enable controller\n"));
+    DEBUG ((DEBUG_INFO, "NvmeControllerInit: failed to enable controller\n"));
     return Status;
   }
 
@@ -778,7 +778,7 @@ NvmeControllerInit (
                     NULL
                     );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_WARN, "NvmeControllerInit: failed to enable 64-bit DMA (%r)\n", Status));
+    DEBUG ((DEBUG_WARN, "NvmeControllerInit: failed to enable 64-bit DMA (%r)\n", Status));
   }
 
   //
@@ -790,7 +790,7 @@ NvmeControllerInit (
   }
 
   if (Private->Cap.Css != 0x01) {
-    DEBUG ((EFI_D_INFO, "NvmeControllerInit: the controller doesn't support NVMe command set\n"));
+    DEBUG ((DEBUG_INFO, "NvmeControllerInit: the controller doesn't support NVMe command set\n"));
     return EFI_UNSUPPORTED;
   }
 
@@ -854,15 +854,15 @@ NvmeControllerInit (
   Private->CqBuffer[2]        = (NVME_CQ *)(UINTN)(Private->Buffer + 5 * EFI_PAGE_SIZE);
   Private->CqBufferPciAddr[2] = (NVME_CQ *)(UINTN)(Private->BufferPciAddr + 5 * EFI_PAGE_SIZE);
 
-  DEBUG ((EFI_D_INFO, "Private->Buffer = [%016X]\n", (UINT64)(UINTN)Private->Buffer));
-  DEBUG ((EFI_D_INFO, "Admin     Submission Queue size (Aqa.Asqs) = [%08X]\n", Aqa.Asqs));
-  DEBUG ((EFI_D_INFO, "Admin     Completion Queue size (Aqa.Acqs) = [%08X]\n", Aqa.Acqs));
-  DEBUG ((EFI_D_INFO, "Admin     Submission Queue (SqBuffer[0]) = [%016X]\n", Private->SqBuffer[0]));
-  DEBUG ((EFI_D_INFO, "Admin     Completion Queue (CqBuffer[0]) = [%016X]\n", Private->CqBuffer[0]));
-  DEBUG ((EFI_D_INFO, "Sync  I/O Submission Queue (SqBuffer[1]) = [%016X]\n", Private->SqBuffer[1]));
-  DEBUG ((EFI_D_INFO, "Sync  I/O Completion Queue (CqBuffer[1]) = [%016X]\n", Private->CqBuffer[1]));
-  DEBUG ((EFI_D_INFO, "Async I/O Submission Queue (SqBuffer[2]) = [%016X]\n", Private->SqBuffer[2]));
-  DEBUG ((EFI_D_INFO, "Async I/O Completion Queue (CqBuffer[2]) = [%016X]\n", Private->CqBuffer[2]));
+  DEBUG ((DEBUG_INFO, "Private->Buffer = [%016X]\n", (UINT64)(UINTN)Private->Buffer));
+  DEBUG ((DEBUG_INFO, "Admin     Submission Queue size (Aqa.Asqs) = [%08X]\n", Aqa.Asqs));
+  DEBUG ((DEBUG_INFO, "Admin     Completion Queue size (Aqa.Acqs) = [%08X]\n", Aqa.Acqs));
+  DEBUG ((DEBUG_INFO, "Admin     Submission Queue (SqBuffer[0]) = [%016X]\n", Private->SqBuffer[0]));
+  DEBUG ((DEBUG_INFO, "Admin     Completion Queue (CqBuffer[0]) = [%016X]\n", Private->CqBuffer[0]));
+  DEBUG ((DEBUG_INFO, "Sync  I/O Submission Queue (SqBuffer[1]) = [%016X]\n", Private->SqBuffer[1]));
+  DEBUG ((DEBUG_INFO, "Sync  I/O Completion Queue (CqBuffer[1]) = [%016X]\n", Private->CqBuffer[1]));
+  DEBUG ((DEBUG_INFO, "Async I/O Submission Queue (SqBuffer[2]) = [%016X]\n", Private->SqBuffer[2]));
+  DEBUG ((DEBUG_INFO, "Async I/O Completion Queue (CqBuffer[2]) = [%016X]\n", Private->CqBuffer[2]));
 
   //
   // Program admin queue attributes.
@@ -925,20 +925,20 @@ NvmeControllerInit (
   Sn[20] = 0;
   CopyMem (Mn, Private->ControllerData->Mn, sizeof (Private->ControllerData->Mn));
   Mn[40] = 0;
-  DEBUG ((EFI_D_INFO, " == NVME IDENTIFY CONTROLLER DATA ==\n"));
-  DEBUG ((EFI_D_INFO, "    PCI VID   : 0x%x\n", Private->ControllerData->Vid));
-  DEBUG ((EFI_D_INFO, "    PCI SSVID : 0x%x\n", Private->ControllerData->Ssvid));
-  DEBUG ((EFI_D_INFO, "    SN        : %a\n",   Sn));
-  DEBUG ((EFI_D_INFO, "    MN        : %a\n",   Mn));
-  DEBUG ((EFI_D_INFO, "    FR        : 0x%x\n", *((UINT64*)Private->ControllerData->Fr)));
+  DEBUG ((DEBUG_INFO, " == NVME IDENTIFY CONTROLLER DATA ==\n"));
+  DEBUG ((DEBUG_INFO, "    PCI VID   : 0x%x\n", Private->ControllerData->Vid));
+  DEBUG ((DEBUG_INFO, "    PCI SSVID : 0x%x\n", Private->ControllerData->Ssvid));
+  DEBUG ((DEBUG_INFO, "    SN        : %a\n",   Sn));
+  DEBUG ((DEBUG_INFO, "    MN        : %a\n",   Mn));
+  DEBUG ((DEBUG_INFO, "    FR        : 0x%x\n", *((UINT64*)Private->ControllerData->Fr)));
   DEBUG ((DEBUG_INFO, "    TNVMCAP (high 8-byte) : 0x%lx\n", *((UINT64*)(Private->ControllerData->Tnvmcap + 8))));
   DEBUG ((DEBUG_INFO, "    TNVMCAP (low 8-byte)  : 0x%lx\n", *((UINT64*)Private->ControllerData->Tnvmcap)));
-  DEBUG ((EFI_D_INFO, "    RAB       : 0x%x\n", Private->ControllerData->Rab));
-  DEBUG ((EFI_D_INFO, "    IEEE      : 0x%x\n", *(UINT32*)Private->ControllerData->Ieee_oui));
-  DEBUG ((EFI_D_INFO, "    AERL      : 0x%x\n", Private->ControllerData->Aerl));
-  DEBUG ((EFI_D_INFO, "    SQES      : 0x%x\n", Private->ControllerData->Sqes));
-  DEBUG ((EFI_D_INFO, "    CQES      : 0x%x\n", Private->ControllerData->Cqes));
-  DEBUG ((EFI_D_INFO, "    NN        : 0x%x\n", Private->ControllerData->Nn));
+  DEBUG ((DEBUG_INFO, "    RAB       : 0x%x\n", Private->ControllerData->Rab));
+  DEBUG ((DEBUG_INFO, "    IEEE      : 0x%x\n", *(UINT32*)Private->ControllerData->Ieee_oui));
+  DEBUG ((DEBUG_INFO, "    AERL      : 0x%x\n", Private->ControllerData->Aerl));
+  DEBUG ((DEBUG_INFO, "    SQES      : 0x%x\n", Private->ControllerData->Sqes));
+  DEBUG ((DEBUG_INFO, "    CQES      : 0x%x\n", Private->ControllerData->Cqes));
+  DEBUG ((DEBUG_INFO, "    NN        : 0x%x\n", Private->ControllerData->Nn));
 
   //
   // Create two I/O completion queues.

--- a/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressPassthru.c
+++ b/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressPassthru.c
@@ -21,80 +21,80 @@ NvmeDumpStatus (
   IN NVME_CQ             *Cq
   )
 {
-  DEBUG ((EFI_D_VERBOSE, "Dump NVMe Completion Entry Status from [0x%x]:\n", Cq));
+  DEBUG ((DEBUG_VERBOSE, "Dump NVMe Completion Entry Status from [0x%x]:\n", Cq));
 
-  DEBUG ((EFI_D_VERBOSE, "  SQ Identifier : [0x%x], Phase Tag : [%d], Cmd Identifier : [0x%x]\n", Cq->Sqid, Cq->Pt, Cq->Cid));
+  DEBUG ((DEBUG_VERBOSE, "  SQ Identifier : [0x%x], Phase Tag : [%d], Cmd Identifier : [0x%x]\n", Cq->Sqid, Cq->Pt, Cq->Cid));
 
-  DEBUG ((EFI_D_VERBOSE, "  NVMe Cmd Execution Result - "));
+  DEBUG ((DEBUG_VERBOSE, "  NVMe Cmd Execution Result - "));
 
   switch (Cq->Sct) {
     case 0x0:
       switch (Cq->Sc) {
         case 0x0:
-          DEBUG ((EFI_D_VERBOSE, "Successful Completion\n"));
+          DEBUG ((DEBUG_VERBOSE, "Successful Completion\n"));
           break;
         case 0x1:
-          DEBUG ((EFI_D_VERBOSE, "Invalid Command Opcode\n"));
+          DEBUG ((DEBUG_VERBOSE, "Invalid Command Opcode\n"));
           break;
         case 0x2:
-          DEBUG ((EFI_D_VERBOSE, "Invalid Field in Command\n"));
+          DEBUG ((DEBUG_VERBOSE, "Invalid Field in Command\n"));
           break;
         case 0x3:
-          DEBUG ((EFI_D_VERBOSE, "Command ID Conflict\n"));
+          DEBUG ((DEBUG_VERBOSE, "Command ID Conflict\n"));
           break;
         case 0x4:
-          DEBUG ((EFI_D_VERBOSE, "Data Transfer Error\n"));
+          DEBUG ((DEBUG_VERBOSE, "Data Transfer Error\n"));
           break;
         case 0x5:
-          DEBUG ((EFI_D_VERBOSE, "Commands Aborted due to Power Loss Notification\n"));
+          DEBUG ((DEBUG_VERBOSE, "Commands Aborted due to Power Loss Notification\n"));
           break;
         case 0x6:
-          DEBUG ((EFI_D_VERBOSE, "Internal Device Error\n"));
+          DEBUG ((DEBUG_VERBOSE, "Internal Device Error\n"));
           break;
         case 0x7:
-          DEBUG ((EFI_D_VERBOSE, "Command Abort Requested\n"));
+          DEBUG ((DEBUG_VERBOSE, "Command Abort Requested\n"));
           break;
         case 0x8:
-          DEBUG ((EFI_D_VERBOSE, "Command Aborted due to SQ Deletion\n"));
+          DEBUG ((DEBUG_VERBOSE, "Command Aborted due to SQ Deletion\n"));
           break;
         case 0x9:
-          DEBUG ((EFI_D_VERBOSE, "Command Aborted due to Failed Fused Command\n"));
+          DEBUG ((DEBUG_VERBOSE, "Command Aborted due to Failed Fused Command\n"));
           break;
         case 0xA:
-          DEBUG ((EFI_D_VERBOSE, "Command Aborted due to Missing Fused Command\n"));
+          DEBUG ((DEBUG_VERBOSE, "Command Aborted due to Missing Fused Command\n"));
           break;
         case 0xB:
-          DEBUG ((EFI_D_VERBOSE, "Invalid Namespace or Format\n"));
+          DEBUG ((DEBUG_VERBOSE, "Invalid Namespace or Format\n"));
           break;
         case 0xC:
-          DEBUG ((EFI_D_VERBOSE, "Command Sequence Error\n"));
+          DEBUG ((DEBUG_VERBOSE, "Command Sequence Error\n"));
           break;
         case 0xD:
-          DEBUG ((EFI_D_VERBOSE, "Invalid SGL Last Segment Descriptor\n"));
+          DEBUG ((DEBUG_VERBOSE, "Invalid SGL Last Segment Descriptor\n"));
           break;
         case 0xE:
-          DEBUG ((EFI_D_VERBOSE, "Invalid Number of SGL Descriptors\n"));
+          DEBUG ((DEBUG_VERBOSE, "Invalid Number of SGL Descriptors\n"));
           break;
         case 0xF:
-          DEBUG ((EFI_D_VERBOSE, "Data SGL Length Invalid\n"));
+          DEBUG ((DEBUG_VERBOSE, "Data SGL Length Invalid\n"));
           break;
         case 0x10:
-          DEBUG ((EFI_D_VERBOSE, "Metadata SGL Length Invalid\n"));
+          DEBUG ((DEBUG_VERBOSE, "Metadata SGL Length Invalid\n"));
           break;
         case 0x11:
-          DEBUG ((EFI_D_VERBOSE, "SGL Descriptor Type Invalid\n"));
+          DEBUG ((DEBUG_VERBOSE, "SGL Descriptor Type Invalid\n"));
           break;
         case 0x80:
-          DEBUG ((EFI_D_VERBOSE, "LBA Out of Range\n"));
+          DEBUG ((DEBUG_VERBOSE, "LBA Out of Range\n"));
           break;
         case 0x81:
-          DEBUG ((EFI_D_VERBOSE, "Capacity Exceeded\n"));
+          DEBUG ((DEBUG_VERBOSE, "Capacity Exceeded\n"));
           break;
         case 0x82:
-          DEBUG ((EFI_D_VERBOSE, "Namespace Not Ready\n"));
+          DEBUG ((DEBUG_VERBOSE, "Namespace Not Ready\n"));
           break;
         case 0x83:
-          DEBUG ((EFI_D_VERBOSE, "Reservation Conflict\n"));
+          DEBUG ((DEBUG_VERBOSE, "Reservation Conflict\n"));
           break;
       }
       break;
@@ -102,61 +102,61 @@ NvmeDumpStatus (
     case 0x1:
       switch (Cq->Sc) {
         case 0x0:
-          DEBUG ((EFI_D_VERBOSE, "Completion Queue Invalid\n"));
+          DEBUG ((DEBUG_VERBOSE, "Completion Queue Invalid\n"));
           break;
         case 0x1:
-          DEBUG ((EFI_D_VERBOSE, "Invalid Queue Identifier\n"));
+          DEBUG ((DEBUG_VERBOSE, "Invalid Queue Identifier\n"));
           break;
         case 0x2:
-          DEBUG ((EFI_D_VERBOSE, "Maximum Queue Size Exceeded\n"));
+          DEBUG ((DEBUG_VERBOSE, "Maximum Queue Size Exceeded\n"));
           break;
         case 0x3:
-          DEBUG ((EFI_D_VERBOSE, "Abort Command Limit Exceeded\n"));
+          DEBUG ((DEBUG_VERBOSE, "Abort Command Limit Exceeded\n"));
           break;
         case 0x5:
-          DEBUG ((EFI_D_VERBOSE, "Asynchronous Event Request Limit Exceeded\n"));
+          DEBUG ((DEBUG_VERBOSE, "Asynchronous Event Request Limit Exceeded\n"));
           break;
         case 0x6:
-          DEBUG ((EFI_D_VERBOSE, "Invalid Firmware Slot\n"));
+          DEBUG ((DEBUG_VERBOSE, "Invalid Firmware Slot\n"));
           break;
         case 0x7:
-          DEBUG ((EFI_D_VERBOSE, "Invalid Firmware Image\n"));
+          DEBUG ((DEBUG_VERBOSE, "Invalid Firmware Image\n"));
           break;
         case 0x8:
-          DEBUG ((EFI_D_VERBOSE, "Invalid Interrupt Vector\n"));
+          DEBUG ((DEBUG_VERBOSE, "Invalid Interrupt Vector\n"));
           break;
         case 0x9:
-          DEBUG ((EFI_D_VERBOSE, "Invalid Log Page\n"));
+          DEBUG ((DEBUG_VERBOSE, "Invalid Log Page\n"));
           break;
         case 0xA:
-          DEBUG ((EFI_D_VERBOSE, "Invalid Format\n"));
+          DEBUG ((DEBUG_VERBOSE, "Invalid Format\n"));
           break;
         case 0xB:
-          DEBUG ((EFI_D_VERBOSE, "Firmware Application Requires Conventional Reset\n"));
+          DEBUG ((DEBUG_VERBOSE, "Firmware Application Requires Conventional Reset\n"));
           break;
         case 0xC:
-          DEBUG ((EFI_D_VERBOSE, "Invalid Queue Deletion\n"));
+          DEBUG ((DEBUG_VERBOSE, "Invalid Queue Deletion\n"));
           break;
         case 0xD:
-          DEBUG ((EFI_D_VERBOSE, "Feature Identifier Not Saveable\n"));
+          DEBUG ((DEBUG_VERBOSE, "Feature Identifier Not Saveable\n"));
           break;
         case 0xE:
-          DEBUG ((EFI_D_VERBOSE, "Feature Not Changeable\n"));
+          DEBUG ((DEBUG_VERBOSE, "Feature Not Changeable\n"));
           break;
         case 0xF:
-          DEBUG ((EFI_D_VERBOSE, "Feature Not Namespace Specific\n"));
+          DEBUG ((DEBUG_VERBOSE, "Feature Not Namespace Specific\n"));
           break;
         case 0x10:
-          DEBUG ((EFI_D_VERBOSE, "Firmware Application Requires NVM Subsystem Reset\n"));
+          DEBUG ((DEBUG_VERBOSE, "Firmware Application Requires NVM Subsystem Reset\n"));
           break;
         case 0x80:
-          DEBUG ((EFI_D_VERBOSE, "Conflicting Attributes\n"));
+          DEBUG ((DEBUG_VERBOSE, "Conflicting Attributes\n"));
           break;
         case 0x81:
-          DEBUG ((EFI_D_VERBOSE, "Invalid Protection Information\n"));
+          DEBUG ((DEBUG_VERBOSE, "Invalid Protection Information\n"));
           break;
         case 0x82:
-          DEBUG ((EFI_D_VERBOSE, "Attempted Write to Read Only Range\n"));
+          DEBUG ((DEBUG_VERBOSE, "Attempted Write to Read Only Range\n"));
           break;
       }
       break;
@@ -164,25 +164,25 @@ NvmeDumpStatus (
     case 0x2:
       switch (Cq->Sc) {
         case 0x80:
-          DEBUG ((EFI_D_VERBOSE, "Write Fault\n"));
+          DEBUG ((DEBUG_VERBOSE, "Write Fault\n"));
           break;
         case 0x81:
-          DEBUG ((EFI_D_VERBOSE, "Unrecovered Read Error\n"));
+          DEBUG ((DEBUG_VERBOSE, "Unrecovered Read Error\n"));
           break;
         case 0x82:
-          DEBUG ((EFI_D_VERBOSE, "End-to-end Guard Check Error\n"));
+          DEBUG ((DEBUG_VERBOSE, "End-to-end Guard Check Error\n"));
           break;
         case 0x83:
-          DEBUG ((EFI_D_VERBOSE, "End-to-end Application Tag Check Error\n"));
+          DEBUG ((DEBUG_VERBOSE, "End-to-end Application Tag Check Error\n"));
           break;
         case 0x84:
-          DEBUG ((EFI_D_VERBOSE, "End-to-end Reference Tag Check Error\n"));
+          DEBUG ((DEBUG_VERBOSE, "End-to-end Reference Tag Check Error\n"));
           break;
         case 0x85:
-          DEBUG ((EFI_D_VERBOSE, "Compare Failure\n"));
+          DEBUG ((DEBUG_VERBOSE, "Compare Failure\n"));
           break;
         case 0x86:
-          DEBUG ((EFI_D_VERBOSE, "Access Denied\n"));
+          DEBUG ((DEBUG_VERBOSE, "Access Denied\n"));
           break;
       }
       break;
@@ -268,7 +268,7 @@ NvmeCreatePrpList (
                     );
 
   if (EFI_ERROR (Status) || (Bytes != EFI_PAGES_TO_SIZE (*PrpListNo))) {
-    DEBUG ((EFI_D_ERROR, "NvmeCreatePrpList: create PrpList failure!\n"));
+    DEBUG ((DEBUG_ERROR, "NvmeCreatePrpList: create PrpList failure!\n"));
     goto EXIT;
   }
   //
@@ -578,7 +578,7 @@ NvmExpressPassThru (
   //
   ASSERT (Sq->Psdt == 0);
   if (Sq->Psdt != 0) {
-    DEBUG ((EFI_D_ERROR, "NvmExpressPassThru: doesn't support SGL mechanism\n"));
+    DEBUG ((DEBUG_ERROR, "NvmExpressPassThru: doesn't support SGL mechanism\n"));
     return EFI_UNSUPPORTED;
   }
 
@@ -1182,4 +1182,3 @@ Exit:
 
   return Status;
 }
-

--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciEnumerator.c
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciEnumerator.c
@@ -1003,7 +1003,7 @@ PciHostBridgeAdjustAllocation (
     Status = RejectPciDevice (PciResNode->PciDev);
     if (Status == EFI_SUCCESS) {
       DEBUG ((
-        EFI_D_ERROR,
+        DEBUG_ERROR,
         "PciBus: [%02x|%02x|%02x] was rejected due to resource confliction.\n",
         PciResNode->PciDev->BusNumber, PciResNode->PciDev->DeviceNumber, PciResNode->PciDev->FunctionNumber
         ));
@@ -2207,4 +2207,3 @@ AddHostBridgeEnumerator (
 
   return EFI_SUCCESS;
 }
-

--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciEnumeratorSupport.c
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciEnumeratorSupport.c
@@ -231,7 +231,7 @@ PciSearchDevice (
   PciIoDevice = NULL;
 
   DEBUG ((
-    EFI_D_INFO,
+    DEBUG_INFO,
     "PciBus: Discovered %s @ [%02x|%02x|%02x]\n",
     IS_PCI_BRIDGE (Pci) ?     L"PPB" :
     IS_CARDBUS_BRIDGE (Pci) ? L"P2C" :
@@ -398,7 +398,7 @@ DumpPpbPaddingResource (
 
     if ((Type != PciBarTypeUnknown) && ((ResourceType == PciBarTypeUnknown) || (ResourceType == Type))) {
       DEBUG ((
-        EFI_D_INFO,
+        DEBUG_INFO,
         "   Padding: Type = %s; Alignment = 0x%lx;\tLength = 0x%lx\n",
         mBarTypeStr[Type], Descriptor->AddrRangeMax, Descriptor->AddrLen
         ));
@@ -425,7 +425,7 @@ DumpPciBars (
     }
 
     DEBUG ((
-      EFI_D_INFO,
+      DEBUG_INFO,
       "   BAR[%d]: Type = %s; Alignment = 0x%lx;\tLength = 0x%lx;\tOffset = 0x%02x\n",
       Index, mBarTypeStr[MIN (PciIoDevice->PciBar[Index].BarType, PciBarTypeMaxType)],
       PciIoDevice->PciBar[Index].Alignment, PciIoDevice->PciBar[Index].Length, PciIoDevice->PciBar[Index].Offset
@@ -438,13 +438,13 @@ DumpPciBars (
     }
 
     DEBUG ((
-      EFI_D_INFO,
+      DEBUG_INFO,
       " VFBAR[%d]: Type = %s; Alignment = 0x%lx;\tLength = 0x%lx;\tOffset = 0x%02x\n",
       Index, mBarTypeStr[MIN (PciIoDevice->VfPciBar[Index].BarType, PciBarTypeMaxType)],
       PciIoDevice->VfPciBar[Index].Alignment, PciIoDevice->VfPciBar[Index].Length, PciIoDevice->VfPciBar[Index].Offset
       ));
   }
-  DEBUG ((EFI_D_INFO, "\n"));
+  DEBUG ((DEBUG_INFO, "\n"));
 }
 
 /**
@@ -1903,7 +1903,7 @@ PciParseBar (
       // Fix the length to support some special 64 bit BAR
       //
       if (Value == 0) {
-        DEBUG ((EFI_D_INFO, "[PciBus]BAR probing for upper 32bit of MEM64 BAR returns 0, change to 0xFFFFFFFF.\n"));
+        DEBUG ((DEBUG_INFO, "[PciBus]BAR probing for upper 32bit of MEM64 BAR returns 0, change to 0xFFFFFFFF.\n"));
         Value = (UINT32) -1;
       } else {
         Value |= ((UINT32)(-1) << HighBitSet32 (Value));
@@ -2282,7 +2282,7 @@ CreatePciIoDevice (
                               &Data32
                               );
           DEBUG ((
-            EFI_D_INFO,
+            DEBUG_INFO,
             " ARI: forwarding enabled for PPB[%02x:%02x:%02x]\n",
             Bridge->BusNumber,
             Bridge->DeviceNumber,
@@ -2291,7 +2291,7 @@ CreatePciIoDevice (
         }
       }
 
-      DEBUG ((EFI_D_INFO, " ARI: CapOffset = 0x%x\n", PciIoDevice->AriCapabilityOffset));
+      DEBUG ((DEBUG_INFO, " ARI: CapOffset = 0x%x\n", PciIoDevice->AriCapabilityOffset));
     }
   }
 
@@ -2401,12 +2401,12 @@ CreatePciIoDevice (
       PciIoDevice->ReservedBusNum = (UINT16)(EFI_PCI_BUS_OF_RID (LastVF) - Bus + 1);
 
       DEBUG ((
-        EFI_D_INFO,
+        DEBUG_INFO,
         " SR-IOV: SupportedPageSize = 0x%x; SystemPageSize = 0x%x; FirstVFOffset = 0x%x;\n",
         SupportedPageSize, PciIoDevice->SystemPageSize >> 12, FirstVFOffset
         ));
       DEBUG ((
-        EFI_D_INFO,
+        DEBUG_INFO,
         "         InitialVFs = 0x%x; ReservedBusNum = 0x%x; CapOffset = 0x%x\n",
         PciIoDevice->InitialVFs, PciIoDevice->ReservedBusNum, PciIoDevice->SrIovCapabilityOffset
         ));
@@ -2421,7 +2421,7 @@ CreatePciIoDevice (
                NULL
                );
     if (!EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_INFO, " MR-IOV: CapOffset = 0x%x\n", PciIoDevice->MrIovCapabilityOffset));
+      DEBUG ((DEBUG_INFO, " MR-IOV: CapOffset = 0x%x\n", PciIoDevice->MrIovCapabilityOffset));
     }
   }
 
@@ -2869,4 +2869,3 @@ ResetAllPpbBusNumber (
     }
   }
 }
-

--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciLib.c
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciLib.c
@@ -215,7 +215,7 @@ DumpBridgeResource (
 
   if ((BridgeResource != NULL) && (BridgeResource->Length != 0)) {
     DEBUG ((
-      EFI_D_INFO, "Type = %s; Base = 0x%lx;\tLength = 0x%lx;\tAlignment = 0x%lx\n",
+      DEBUG_INFO, "Type = %s; Base = 0x%lx;\tLength = 0x%lx;\tAlignment = 0x%lx\n",
       mBarTypeStr[MIN (BridgeResource->ResType, PciBarTypeMaxType)],
       BridgeResource->PciDev->PciBar[BridgeResource->Bar].BaseAddress,
       BridgeResource->Length, BridgeResource->Alignment
@@ -228,7 +228,7 @@ DumpBridgeResource (
       if (Resource->ResourceUsage == PciResUsageTypical) {
         Bar = Resource->Virtual ? Resource->PciDev->VfPciBar : Resource->PciDev->PciBar;
         DEBUG ((
-          EFI_D_INFO, "   Base = 0x%lx;\tLength = 0x%lx;\tAlignment = 0x%lx;\tOwner = %s [%02x|%02x|%02x:",
+          DEBUG_INFO, "   Base = 0x%lx;\tLength = 0x%lx;\tAlignment = 0x%lx;\tOwner = %s [%02x|%02x|%02x:",
           Bar[Resource->Bar].BaseAddress, Resource->Length, Resource->Alignment,
           IS_PCI_BRIDGE (&Resource->PciDev->Pci)     ? L"PPB" :
           IS_CARDBUS_BRIDGE (&Resource->PciDev->Pci) ? L"P2C" :
@@ -244,20 +244,20 @@ DumpBridgeResource (
           //
           // The resource requirement comes from the device itself.
           //
-          DEBUG ((EFI_D_INFO, "%02x]", Bar[Resource->Bar].Offset));
+          DEBUG ((DEBUG_INFO, "%02x]", Bar[Resource->Bar].Offset));
         } else {
           //
           // The resource requirement comes from the subordinate devices.
           //
-          DEBUG ((EFI_D_INFO, "**]"));
+          DEBUG ((DEBUG_INFO, "**]"));
         }
       } else {
-        DEBUG ((EFI_D_INFO, "   Base = Padding;\tLength = 0x%lx;\tAlignment = 0x%lx", Resource->Length, Resource->Alignment));
+        DEBUG ((DEBUG_INFO, "   Base = Padding;\tLength = 0x%lx;\tAlignment = 0x%lx", Resource->Length, Resource->Alignment));
       }
       if (BridgeResource->ResType != Resource->ResType) {
-        DEBUG ((EFI_D_INFO, "; Type = %s", mBarTypeStr[MIN (Resource->ResType, PciBarTypeMaxType)]));
+        DEBUG ((DEBUG_INFO, "; Type = %s", mBarTypeStr[MIN (Resource->ResType, PciBarTypeMaxType)]));
       }
-      DEBUG ((EFI_D_INFO, "\n"));
+      DEBUG ((DEBUG_INFO, "\n"));
     }
   }
 }
@@ -321,7 +321,7 @@ DumpResourceMap (
   PCI_RESOURCE_NODE    **ChildResources;
   UINTN                ChildResourceCount;
 
-  DEBUG ((EFI_D_INFO, "PciBus: Resource Map for "));
+  DEBUG ((DEBUG_INFO, "PciBus: Resource Map for "));
 
   Status = gBS->OpenProtocol (
                   Bridge->Handle,
@@ -333,7 +333,7 @@ DumpResourceMap (
                   );
   if (EFI_ERROR (Status)) {
     DEBUG ((
-      EFI_D_INFO, "Bridge [%02x|%02x|%02x]\n",
+      DEBUG_INFO, "Bridge [%02x|%02x|%02x]\n",
       Bridge->BusNumber, Bridge->DeviceNumber, Bridge->FunctionNumber
       ));
   } else {
@@ -342,7 +342,7 @@ DumpResourceMap (
             FALSE,
             FALSE
             );
-    DEBUG ((EFI_D_INFO, "Root Bridge %s\n", Str != NULL ? Str : L""));
+    DEBUG ((DEBUG_INFO, "Root Bridge %s\n", Str != NULL ? Str : L""));
     if (Str != NULL) {
       FreePool (Str);
     }
@@ -351,7 +351,7 @@ DumpResourceMap (
   for (Index = 0; Index < ResourceCount; Index++) {
     DumpBridgeResource (Resources[Index]);
   }
-  DEBUG ((EFI_D_INFO, "\n"));
+  DEBUG ((DEBUG_INFO, "\n"));
 
   for ( Link = Bridge->ChildList.ForwardLink
       ; Link != &Bridge->ChildList
@@ -622,7 +622,7 @@ PciHostBridgeResourceAllocator (
         // If SubmitResources returns error, PciBus isn't able to start.
         // It's a fatal error so assertion is added.
         //
-        DEBUG ((EFI_D_INFO, "PciBus: HostBridge->SubmitResources() - %r\n", Status));
+        DEBUG ((DEBUG_INFO, "PciBus: HostBridge->SubmitResources() - %r\n", Status));
         ASSERT_EFI_ERROR (Status);
       }
 
@@ -654,7 +654,7 @@ PciHostBridgeResourceAllocator (
     // Notify platform to start to program the resource
     //
     Status = NotifyPhase (PciResAlloc, EfiPciHostBridgeAllocateResources);
-    DEBUG ((EFI_D_INFO, "PciBus: HostBridge->NotifyPhase(AllocateResources) - %r\n", Status));
+    DEBUG ((DEBUG_INFO, "PciBus: HostBridge->NotifyPhase(AllocateResources) - %r\n", Status));
     if (!FeaturePcdGet (PcdPciBusHotplugDeviceSupport)) {
       //
       // If Hot Plug is not supported
@@ -1340,9 +1340,9 @@ PciScanBus (
             TempReservedBusNum = PciDevice->ReservedBusNum;
 
             if (Func == 0) {
-              DEBUG ((EFI_D_INFO, "PCI-IOV ScanBus - SubBusNumber - 0x%x\n", *SubBusNumber));
+              DEBUG ((DEBUG_INFO, "PCI-IOV ScanBus - SubBusNumber - 0x%x\n", *SubBusNumber));
             } else {
-              DEBUG ((EFI_D_INFO, "PCI-IOV ScanBus - SubBusNumber - 0x%x (Update)\n", *SubBusNumber));
+              DEBUG ((DEBUG_INFO, "PCI-IOV ScanBus - SubBusNumber - 0x%x (Update)\n", *SubBusNumber));
             }
           }
         }
@@ -1522,7 +1522,7 @@ PciHostBridgeEnumerator (
     return Status;
   }
 
-  DEBUG((EFI_D_INFO, "PCI Bus First Scanning\n"));
+  DEBUG((DEBUG_INFO, "PCI Bus First Scanning\n"));
   RootBridgeHandle = NULL;
   while (PciResAlloc->GetNextRootBridge (PciResAlloc, &RootBridgeHandle) == EFI_SUCCESS) {
 
@@ -1601,7 +1601,7 @@ PciHostBridgeEnumerator (
     Status = AllRootHPCInitialized (STALL_1_SECOND * 15);
 
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "Some root HPC failed to initialize\n"));
+      DEBUG ((DEBUG_ERROR, "Some root HPC failed to initialize\n"));
       return Status;
     }
 
@@ -1614,7 +1614,7 @@ PciHostBridgeEnumerator (
       return Status;
     }
 
-    DEBUG((EFI_D_INFO, "PCI Bus Second Scanning\n"));
+    DEBUG((DEBUG_INFO, "PCI Bus Second Scanning\n"));
     RootBridgeHandle = NULL;
     while (PciResAlloc->GetNextRootBridge (PciResAlloc, &RootBridgeHandle) == EFI_SUCCESS) {
 

--- a/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostBridge.c
+++ b/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostBridge.c
@@ -119,13 +119,13 @@ IntersectIoDescriptor (
     Status = gDS->AddIoSpace (EfiGcdIoTypeIo, IntersectionBase,
                     IntersectionEnd - IntersectionBase);
 
-    DEBUG ((EFI_ERROR (Status) ? EFI_D_ERROR : EFI_D_VERBOSE,
+    DEBUG ((EFI_ERROR (Status) ? DEBUG_ERROR : DEBUG_VERBOSE,
       "%a: %a: add [%Lx, %Lx): %r\n", gEfiCallerBaseName, __FUNCTION__,
       IntersectionBase, IntersectionEnd, Status));
     return Status;
   }
 
-  DEBUG ((EFI_D_ERROR, "%a: %a: desc [%Lx, %Lx) type %u conflicts with "
+  DEBUG ((DEBUG_ERROR, "%a: %a: desc [%Lx, %Lx) type %u conflicts with "
     "aperture [%Lx, %Lx)\n", gEfiCallerBaseName, __FUNCTION__,
     Descriptor->BaseAddress, Descriptor->BaseAddress + Descriptor->Length,
     (UINT32)Descriptor->GcdIoType, Base, Base + Length));
@@ -155,7 +155,7 @@ AddIoSpace (
 
   Status = gDS->GetIoSpaceMap (&NumberOfDescriptors, &IoSpaceMap);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: %a: GetIoSpaceMap(): %r\n",
+    DEBUG ((DEBUG_ERROR, "%a: %a: GetIoSpaceMap(): %r\n",
       gEfiCallerBaseName, __FUNCTION__, Status));
     return Status;
   }
@@ -263,13 +263,13 @@ IntersectMemoryDescriptor (
                     IntersectionBase, IntersectionEnd - IntersectionBase,
                     Capabilities);
 
-    DEBUG ((EFI_ERROR (Status) ? EFI_D_ERROR : EFI_D_VERBOSE,
+    DEBUG ((EFI_ERROR (Status) ? DEBUG_ERROR : DEBUG_VERBOSE,
       "%a: %a: add [%Lx, %Lx): %r\n", gEfiCallerBaseName, __FUNCTION__,
       IntersectionBase, IntersectionEnd, Status));
     return Status;
   }
 
-  DEBUG ((EFI_D_ERROR, "%a: %a: desc [%Lx, %Lx) type %u cap %Lx conflicts "
+  DEBUG ((DEBUG_ERROR, "%a: %a: desc [%Lx, %Lx) type %u cap %Lx conflicts "
     "with aperture [%Lx, %Lx) cap %Lx\n", gEfiCallerBaseName, __FUNCTION__,
     Descriptor->BaseAddress, Descriptor->BaseAddress + Descriptor->Length,
     (UINT32)Descriptor->GcdMemoryType, Descriptor->Capabilities,
@@ -302,7 +302,7 @@ AddMemoryMappedIoSpace (
 
   Status = gDS->GetMemorySpaceMap (&NumberOfDescriptors, &MemorySpaceMap);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: %a: GetMemorySpaceMap(): %r\n",
+    DEBUG ((DEBUG_ERROR, "%a: %a: GetMemorySpaceMap(): %r\n",
       gEfiCallerBaseName, __FUNCTION__, Status));
     return Status;
   }
@@ -828,7 +828,7 @@ NotifyPhase (
       }
     }
 
-    DEBUG ((EFI_D_INFO, "PciHostBridge: NotifyPhase (AllocateResources)\n"));
+    DEBUG ((DEBUG_INFO, "PciHostBridge: NotifyPhase (AllocateResources)\n"));
     for (Link = GetFirstNode (&HostBridge->RootBridges)
          ; !IsNull (&HostBridge->RootBridges, Link)
          ; Link = GetNextNode (&HostBridge->RootBridges, Link)
@@ -838,7 +838,7 @@ NotifyPhase (
       }
 
       RootBridge = ROOT_BRIDGE_FROM_LINK (Link);
-      DEBUG ((EFI_D_INFO, " RootBridge: %s\n", RootBridge->DevicePathStr));
+      DEBUG ((DEBUG_INFO, " RootBridge: %s\n", RootBridge->DevicePathStr));
 
       for (Index1 = TypeIo; Index1 < TypeBus; Index1++) {
         if (RootBridge->ResAllocNode[Index1].Status == ResNone) {
@@ -1360,7 +1360,7 @@ SubmitResources (
        ) {
     RootBridge = ROOT_BRIDGE_FROM_LINK (Link);
     if (RootBridgeHandle == RootBridge->Handle) {
-      DEBUG ((EFI_D_INFO, "PciHostBridge: SubmitResources for %s\n", RootBridge->DevicePathStr));
+      DEBUG ((DEBUG_INFO, "PciHostBridge: SubmitResources for %s\n", RootBridge->DevicePathStr));
       //
       // Check the resource descriptors.
       // If the Configuration includes one or more invalid resource descriptors, all the resource
@@ -1371,11 +1371,11 @@ SubmitResources (
           return EFI_INVALID_PARAMETER;
         }
 
-        DEBUG ((EFI_D_INFO, " %s: Granularity/SpecificFlag = %ld / %02x%s\n",
+        DEBUG ((DEBUG_INFO, " %s: Granularity/SpecificFlag = %ld / %02x%s\n",
                 mAcpiAddressSpaceTypeStr[Descriptor->ResType], Descriptor->AddrSpaceGranularity, Descriptor->SpecificFlag,
                 (Descriptor->SpecificFlag & EFI_ACPI_MEMORY_RESOURCE_SPECIFIC_FLAG_CACHEABLE_PREFETCHABLE) != 0 ? L" (Prefetchable)" : L""
                 ));
-        DEBUG ((EFI_D_INFO, "      Length/Alignment = 0x%lx / 0x%lx\n", Descriptor->AddrLen, Descriptor->AddrRangeMax));
+        DEBUG ((DEBUG_INFO, "      Length/Alignment = 0x%lx / 0x%lx\n", Descriptor->AddrLen, Descriptor->AddrRangeMax));
         switch (Descriptor->ResType) {
         case ACPI_ADDRESS_SPACE_TYPE_MEM:
           if (Descriptor->AddrSpaceGranularity != 32 && Descriptor->AddrSpaceGranularity != 64) {

--- a/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciRootBridgeIo.c
+++ b/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciRootBridgeIo.c
@@ -71,17 +71,17 @@ CreateRootBridge (
 
   DevicePathStr = NULL;
 
-  DEBUG ((EFI_D_INFO, "RootBridge: "));
-  DEBUG ((EFI_D_INFO, "%s\n", DevicePathStr = ConvertDevicePathToText (Bridge->DevicePath, FALSE, FALSE)));
-  DEBUG ((EFI_D_INFO, "  Support/Attr: %lx / %lx\n", Bridge->Supports, Bridge->Attributes));
-  DEBUG ((EFI_D_INFO, "    DmaAbove4G: %s\n", Bridge->DmaAbove4G ? L"Yes" : L"No"));
-  DEBUG ((EFI_D_INFO, "NoExtConfSpace: %s\n", Bridge->NoExtendedConfigSpace ? L"Yes" : L"No"));
-  DEBUG ((EFI_D_INFO, "     AllocAttr: %lx (%s%s)\n", Bridge->AllocationAttributes,
+  DEBUG ((DEBUG_INFO, "RootBridge: "));
+  DEBUG ((DEBUG_INFO, "%s\n", DevicePathStr = ConvertDevicePathToText (Bridge->DevicePath, FALSE, FALSE)));
+  DEBUG ((DEBUG_INFO, "  Support/Attr: %lx / %lx\n", Bridge->Supports, Bridge->Attributes));
+  DEBUG ((DEBUG_INFO, "    DmaAbove4G: %s\n", Bridge->DmaAbove4G ? L"Yes" : L"No"));
+  DEBUG ((DEBUG_INFO, "NoExtConfSpace: %s\n", Bridge->NoExtendedConfigSpace ? L"Yes" : L"No"));
+  DEBUG ((DEBUG_INFO, "     AllocAttr: %lx (%s%s)\n", Bridge->AllocationAttributes,
           (Bridge->AllocationAttributes & EFI_PCI_HOST_BRIDGE_COMBINE_MEM_PMEM) != 0 ? L"CombineMemPMem " : L"",
           (Bridge->AllocationAttributes & EFI_PCI_HOST_BRIDGE_MEM64_DECODE) != 0 ? L"Mem64Decode" : L""
           ));
   DEBUG ((
-    EFI_D_INFO, "           Bus: %lx - %lx Translation=%lx\n",
+    DEBUG_INFO, "           Bus: %lx - %lx Translation=%lx\n",
     Bridge->Bus.Base, Bridge->Bus.Limit, Bridge->Bus.Translation
     ));
   //

--- a/MdeModulePkg/Bus/Pci/PciSioSerialDxe/Serial.c
+++ b/MdeModulePkg/Bus/Pci/PciSioSerialDxe/Serial.c
@@ -943,7 +943,7 @@ SerialControllerDriverStart (
         Node = NextDevicePathNode (Node);
       } while (!IsDevicePathEnd (Node));
       Status = CreateSerialDevice (Controller, Uart, ParentDevicePath, FALSE, Acpi->UID, ParentIo, NULL, NULL);
-      DEBUG ((EFI_D_INFO, "PciSioSerial: Create SIO child serial device - %r\n", Status));
+      DEBUG ((DEBUG_INFO, "PciSioSerial: Create SIO child serial device - %r\n", Status));
     }
   } else {
     Status = ParentIo.PciIo->Pci.Read (ParentIo.PciIo, EfiPciIoWidthUint8, 0, sizeof (Pci), &Pci);
@@ -1024,7 +1024,7 @@ SerialControllerDriverStart (
           }
 
           Status = CreateSerialDevice (Controller, Uart, ParentDevicePath, FALSE, 0, ParentIo, PciSerialParameter, PciDeviceInfo);
-          DEBUG ((EFI_D_INFO, "PciSioSerial: Create PCI child serial device (single) - %r\n", Status));
+          DEBUG ((DEBUG_INFO, "PciSioSerial: Create PCI child serial device (single) - %r\n", Status));
           if (!EFI_ERROR (Status)) {
             PciDeviceInfo->ChildCount++;
           }
@@ -1045,7 +1045,7 @@ SerialControllerDriverStart (
               //
               Status = CreateSerialDevice (Controller, Uart, ParentDevicePath, TRUE, PciSerialCount, ParentIo, PciSerialParameter, PciDeviceInfo);
               PciSerialCount++;
-              DEBUG ((EFI_D_INFO, "PciSioSerial: Create PCI child serial device (multiple) - %r\n", Status));
+              DEBUG ((DEBUG_INFO, "PciSioSerial: Create PCI child serial device (multiple) - %r\n", Status));
               if (!EFI_ERROR (Status)) {
                 PciDeviceInfo->ChildCount++;
               }

--- a/MdeModulePkg/Bus/Pci/PciSioSerialDxe/SerialIo.c
+++ b/MdeModulePkg/Bus/Pci/PciSioSerialDxe/SerialIo.c
@@ -134,9 +134,9 @@ VerifyUartParameters (
   }
 
   Percent = DivU64x32 (MultU64x32 (BaudRate, 100), ComputedBaudRate);
-  DEBUG ((EFI_D_INFO, "ClockRate = %d\n",  ClockRate));
-  DEBUG ((EFI_D_INFO, "Divisor   = %ld\n", ComputedDivisor));
-  DEBUG ((EFI_D_INFO, "BaudRate/Actual (%ld/%d) = %d%%\n", BaudRate, ComputedBaudRate, Percent));
+  DEBUG ((DEBUG_INFO, "ClockRate = %d\n",  ClockRate));
+  DEBUG ((DEBUG_INFO, "Divisor   = %ld\n", ComputedDivisor));
+  DEBUG ((DEBUG_INFO, "BaudRate/Actual (%ld/%d) = %d%%\n", BaudRate, ComputedBaudRate, Percent));
 
   //
   // If the requested BaudRate is not supported:
@@ -176,9 +176,9 @@ VerifyUartParameters (
     return FALSE;
   }
 
-  DEBUG ((EFI_D_INFO, "ClockRate = %d\n",  ClockRate));
-  DEBUG ((EFI_D_INFO, "Divisor   = %ld\n", ComputedDivisor));
-  DEBUG ((EFI_D_INFO, "BaudRate/Actual (%ld/%d) = %d%%\n", BaudRate, ComputedBaudRate, Percent));
+  DEBUG ((DEBUG_INFO, "ClockRate = %d\n",  ClockRate));
+  DEBUG ((DEBUG_INFO, "Divisor   = %ld\n", ComputedDivisor));
+  DEBUG ((DEBUG_INFO, "BaudRate/Actual (%ld/%d) = %d%%\n", BaudRate, ComputedBaudRate, Percent));
 
   if (ActualBaudRate != NULL) {
     *ActualBaudRate = ComputedBaudRate;

--- a/MdeModulePkg/Bus/Pci/SataControllerDxe/SataController.c
+++ b/MdeModulePkg/Bus/Pci/SataControllerDxe/SataController.c
@@ -89,7 +89,7 @@ CalculateBestPioMode (
   if ((IdentifyData->AtaData.field_validity & 0x02) == 0x02) {
 
     AdvancedPioMode = IdentifyData->AtaData.advanced_pio_modes;
-    DEBUG ((EFI_D_INFO, "CalculateBestPioMode: AdvancedPioMode = %x\n", AdvancedPioMode));
+    DEBUG ((DEBUG_INFO, "CalculateBestPioMode: AdvancedPioMode = %x\n", AdvancedPioMode));
 
     for (Index = 0; Index < 8; Index++) {
       if ((AdvancedPioMode & 0x01) != 0) {
@@ -203,7 +203,7 @@ CalculateBestUdmaMode (
   }
 
   DeviceUDmaMode = IdentifyData->AtaData.ultra_dma_mode;
-  DEBUG ((EFI_D_INFO, "CalculateBestUdmaMode: DeviceUDmaMode = %x\n", DeviceUDmaMode));
+  DEBUG ((DEBUG_INFO, "CalculateBestUdmaMode: DeviceUDmaMode = %x\n", DeviceUDmaMode));
   DeviceUDmaMode &= 0x3f;
   TempMode = 0;                 // initialize it to UDMA-0
 
@@ -362,7 +362,7 @@ SataControllerStart (
   UINT64                            Supports;
   UINT8                             MaxPortNumber;
 
-  DEBUG ((EFI_D_INFO, "SataControllerStart start\n"));
+  DEBUG ((DEBUG_INFO, "SataControllerStart start\n"));
 
   Private = NULL;
 
@@ -378,7 +378,7 @@ SataControllerStart (
                   EFI_OPEN_PROTOCOL_BY_DRIVER
                   );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "SataControllerStart error. return status = %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "SataControllerStart error. return status = %r\n", Status));
     return Status;
   }
 
@@ -419,7 +419,7 @@ SataControllerStart (
   }
 
   DEBUG ((
-    EFI_D_INFO,
+    DEBUG_INFO,
     "Original PCI Attributes = 0x%llx\n",
     Private->OriginalPciAttributes
     ));
@@ -434,7 +434,7 @@ SataControllerStart (
     goto Done;
   }
 
-  DEBUG ((EFI_D_INFO, "Supported PCI Attributes = 0x%llx\n", Supports));
+  DEBUG ((DEBUG_INFO, "Supported PCI Attributes = 0x%llx\n", Supports));
 
   Supports &= (UINT64)EFI_PCI_DEVICE_ENABLE;
   Status = PciIo->Attributes (
@@ -447,7 +447,7 @@ SataControllerStart (
     goto Done;
   }
 
-  DEBUG ((EFI_D_INFO, "Enabled PCI Attributes = 0x%llx\n", Supports));
+  DEBUG ((DEBUG_INFO, "Enabled PCI Attributes = 0x%llx\n", Supports));
   Private->PciAttributesChanged = TRUE;
 
   Status = PciIo->Pci.Read (
@@ -561,7 +561,7 @@ Done:
     }
   }
 
-  DEBUG ((EFI_D_INFO, "SataControllerStart end with %r\n", Status));
+  DEBUG ((DEBUG_INFO, "SataControllerStart end with %r\n", Status));
 
   return Status;
 }
@@ -1048,7 +1048,7 @@ IdeInitCalculateMode (
   } else {
     (*SupportedModes)->PioMode.Valid = FALSE;
   }
-  DEBUG ((EFI_D_INFO, "IdeInitCalculateMode: PioMode = %x\n", (*SupportedModes)->PioMode.Mode));
+  DEBUG ((DEBUG_INFO, "IdeInitCalculateMode: PioMode = %x\n", (*SupportedModes)->PioMode.Mode));
 
   Status = CalculateBestUdmaMode (
             IdentifyData,
@@ -1063,7 +1063,7 @@ IdeInitCalculateMode (
   } else {
     (*SupportedModes)->UdmaMode.Valid = FALSE;
   }
-  DEBUG ((EFI_D_INFO, "IdeInitCalculateMode: UdmaMode = %x\n", (*SupportedModes)->UdmaMode.Mode));
+  DEBUG ((DEBUG_INFO, "IdeInitCalculateMode: UdmaMode = %x\n", (*SupportedModes)->UdmaMode.Mode));
 
   //
   // The modes other than PIO and UDMA are not supported
@@ -1105,4 +1105,3 @@ IdeInitSetTiming (
 {
   return EFI_SUCCESS;
 }
-

--- a/MdeModulePkg/Bus/Pci/SdMmcPciHcPei/SdMmcPciHcPei.c
+++ b/MdeModulePkg/Bus/Pci/SdMmcPciHcPei/SdMmcPciHcPei.c
@@ -108,7 +108,7 @@ InitializeSdMmcHcPeim (
 
   Private = (SD_MMC_HC_PEI_PRIVATE_DATA *) AllocateZeroPool (sizeof (SD_MMC_HC_PEI_PRIVATE_DATA));
   if (Private == NULL) {
-    DEBUG ((EFI_D_ERROR, "Failed to allocate memory for SD_MMC_HC_PEI_PRIVATE_DATA! \n"));
+    DEBUG ((DEBUG_ERROR, "Failed to allocate memory for SD_MMC_HC_PEI_PRIVATE_DATA! \n"));
     return EFI_OUT_OF_RESOURCES;
   }
 

--- a/MdeModulePkg/Bus/Pci/UfsPciHcPei/UfsPciHcPei.c
+++ b/MdeModulePkg/Bus/Pci/UfsPciHcPei/UfsPciHcPei.c
@@ -99,7 +99,7 @@ InitializeUfsHcPeim (
 
   Private = (UFS_HC_PEI_PRIVATE_DATA *) AllocateZeroPool (sizeof (UFS_HC_PEI_PRIVATE_DATA));
   if (Private == NULL) {
-    DEBUG ((EFI_D_ERROR, "Failed to allocate memory for UFS_HC_PEI_PRIVATE_DATA! \n"));
+    DEBUG ((DEBUG_ERROR, "Failed to allocate memory for UFS_HC_PEI_PRIVATE_DATA! \n"));
     return EFI_OUT_OF_RESOURCES;
   }
 

--- a/MdeModulePkg/Bus/Pci/UhciDxe/Uhci.c
+++ b/MdeModulePkg/Bus/Pci/UhciDxe/Uhci.c
@@ -323,7 +323,7 @@ Uhci2GetCapability (
 
   Uhc->RootPorts = *PortNumber;
 
-  DEBUG ((EFI_D_INFO, "Uhci2GetCapability: %d ports\n", (UINT32)Uhc->RootPorts));
+  DEBUG ((DEBUG_INFO, "Uhci2GetCapability: %d ports\n", (UINT32)Uhc->RootPorts));
   return EFI_SUCCESS;
 }
 
@@ -378,7 +378,7 @@ Uhci2GetRootHubPortStatus (
   }
 
   if ((PortSC & USBPORTSC_SUSP) != 0) {
-    DEBUG ((EFI_D_INFO, "Uhci2GetRootHubPortStatus: port %d is suspended\n", PortNumber));
+    DEBUG ((DEBUG_INFO, "Uhci2GetRootHubPortStatus: port %d is suspended\n", PortNumber));
     PortStatus->PortStatus |= USB_PORT_STAT_SUSPEND;
   }
 
@@ -1880,4 +1880,3 @@ UhciDriverBindingStop (
 
   return EFI_SUCCESS;
 }
-

--- a/MdeModulePkg/Bus/Pci/UhciDxe/UhciDebug.c
+++ b/MdeModulePkg/Bus/Pci/UhciDxe/UhciDebug.c
@@ -20,12 +20,12 @@ UhciDumpQh (
   IN UHCI_QH_SW    *QhSw
   )
 {
-  DEBUG ((EFI_D_VERBOSE, "&QhSw @ 0x%p\n", QhSw));
-  DEBUG ((EFI_D_VERBOSE, "QhSw.NextQh    - 0x%p\n", QhSw->NextQh));
-  DEBUG ((EFI_D_VERBOSE, "QhSw.TDs       - 0x%p\n", QhSw->TDs));
-  DEBUG ((EFI_D_VERBOSE, "QhSw.QhHw:\n"));
-  DEBUG ((EFI_D_VERBOSE, " Horizon  Link - %x\n", QhSw->QhHw.HorizonLink));
-  DEBUG ((EFI_D_VERBOSE, " Vertical Link - %x\n\n", QhSw->QhHw.VerticalLink));
+  DEBUG ((DEBUG_VERBOSE, "&QhSw @ 0x%p\n", QhSw));
+  DEBUG ((DEBUG_VERBOSE, "QhSw.NextQh    - 0x%p\n", QhSw->NextQh));
+  DEBUG ((DEBUG_VERBOSE, "QhSw.TDs       - 0x%p\n", QhSw->TDs));
+  DEBUG ((DEBUG_VERBOSE, "QhSw.QhHw:\n"));
+  DEBUG ((DEBUG_VERBOSE, " Horizon  Link - %x\n", QhSw->QhHw.HorizonLink));
+  DEBUG ((DEBUG_VERBOSE, " Vertical Link - %x\n\n", QhSw->QhHw.VerticalLink));
 }
 
 
@@ -45,27 +45,26 @@ UhciDumpTds (
   CurTdSw = TdSw;
 
   while (CurTdSw != NULL) {
-    DEBUG ((EFI_D_VERBOSE, "TdSw @ 0x%p\n",           CurTdSw));
-    DEBUG ((EFI_D_VERBOSE, "TdSw.NextTd   - 0x%p\n",  CurTdSw->NextTd));
-    DEBUG ((EFI_D_VERBOSE, "TdSw.DataLen  - %d\n",    CurTdSw->DataLen));
-    DEBUG ((EFI_D_VERBOSE, "TdSw.Data     - 0x%p\n",  CurTdSw->Data));
-    DEBUG ((EFI_D_VERBOSE, "TdHw:\n"));
-    DEBUG ((EFI_D_VERBOSE, " NextLink     - 0x%x\n",  CurTdSw->TdHw.NextLink));
-    DEBUG ((EFI_D_VERBOSE, " ActualLen    - %d\n",    CurTdSw->TdHw.ActualLen));
-    DEBUG ((EFI_D_VERBOSE, " Status       - 0x%x\n",  CurTdSw->TdHw.Status));
-    DEBUG ((EFI_D_VERBOSE, " IOC          - %d\n",    CurTdSw->TdHw.IntOnCpl));
-    DEBUG ((EFI_D_VERBOSE, " IsIsoCh      - %d\n",    CurTdSw->TdHw.IsIsoch));
-    DEBUG ((EFI_D_VERBOSE, " LowSpeed     - %d\n",    CurTdSw->TdHw.LowSpeed));
-    DEBUG ((EFI_D_VERBOSE, " ErrorCount   - %d\n",    CurTdSw->TdHw.ErrorCount));
-    DEBUG ((EFI_D_VERBOSE, " ShortPacket  - %d\n",    CurTdSw->TdHw.ShortPacket));
-    DEBUG ((EFI_D_VERBOSE, " PidCode      - 0x%x\n",  CurTdSw->TdHw.PidCode));
-    DEBUG ((EFI_D_VERBOSE, " DevAddr      - %d\n",    CurTdSw->TdHw.DeviceAddr));
-    DEBUG ((EFI_D_VERBOSE, " EndPoint     - %d\n",    CurTdSw->TdHw.EndPoint));
-    DEBUG ((EFI_D_VERBOSE, " DataToggle   - %d\n",    CurTdSw->TdHw.DataToggle));
-    DEBUG ((EFI_D_VERBOSE, " MaxPacketLen - %d\n",    CurTdSw->TdHw.MaxPacketLen));
-    DEBUG ((EFI_D_VERBOSE, " DataBuffer   - 0x%x\n\n",CurTdSw->TdHw.DataBuffer));
+    DEBUG ((DEBUG_VERBOSE, "TdSw @ 0x%p\n",           CurTdSw));
+    DEBUG ((DEBUG_VERBOSE, "TdSw.NextTd   - 0x%p\n",  CurTdSw->NextTd));
+    DEBUG ((DEBUG_VERBOSE, "TdSw.DataLen  - %d\n",    CurTdSw->DataLen));
+    DEBUG ((DEBUG_VERBOSE, "TdSw.Data     - 0x%p\n",  CurTdSw->Data));
+    DEBUG ((DEBUG_VERBOSE, "TdHw:\n"));
+    DEBUG ((DEBUG_VERBOSE, " NextLink     - 0x%x\n",  CurTdSw->TdHw.NextLink));
+    DEBUG ((DEBUG_VERBOSE, " ActualLen    - %d\n",    CurTdSw->TdHw.ActualLen));
+    DEBUG ((DEBUG_VERBOSE, " Status       - 0x%x\n",  CurTdSw->TdHw.Status));
+    DEBUG ((DEBUG_VERBOSE, " IOC          - %d\n",    CurTdSw->TdHw.IntOnCpl));
+    DEBUG ((DEBUG_VERBOSE, " IsIsoCh      - %d\n",    CurTdSw->TdHw.IsIsoch));
+    DEBUG ((DEBUG_VERBOSE, " LowSpeed     - %d\n",    CurTdSw->TdHw.LowSpeed));
+    DEBUG ((DEBUG_VERBOSE, " ErrorCount   - %d\n",    CurTdSw->TdHw.ErrorCount));
+    DEBUG ((DEBUG_VERBOSE, " ShortPacket  - %d\n",    CurTdSw->TdHw.ShortPacket));
+    DEBUG ((DEBUG_VERBOSE, " PidCode      - 0x%x\n",  CurTdSw->TdHw.PidCode));
+    DEBUG ((DEBUG_VERBOSE, " DevAddr      - %d\n",    CurTdSw->TdHw.DeviceAddr));
+    DEBUG ((DEBUG_VERBOSE, " EndPoint     - %d\n",    CurTdSw->TdHw.EndPoint));
+    DEBUG ((DEBUG_VERBOSE, " DataToggle   - %d\n",    CurTdSw->TdHw.DataToggle));
+    DEBUG ((DEBUG_VERBOSE, " MaxPacketLen - %d\n",    CurTdSw->TdHw.MaxPacketLen));
+    DEBUG ((DEBUG_VERBOSE, " DataBuffer   - 0x%x\n\n",CurTdSw->TdHw.DataBuffer));
 
     CurTdSw = CurTdSw->NextTd;
   }
 }
-

--- a/MdeModulePkg/Bus/Pci/UhciDxe/UhciReg.c
+++ b/MdeModulePkg/Bus/Pci/UhciDxe/UhciReg.c
@@ -38,7 +38,7 @@ UhciReadReg (
                       );
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "UhciReadReg: PciIo Io.Read error: %r at offset %d\n", Status, Offset));
+    DEBUG ((DEBUG_ERROR, "UhciReadReg: PciIo Io.Read error: %r at offset %d\n", Status, Offset));
 
     Data = 0xFFFF;
   }
@@ -74,7 +74,7 @@ UhciWriteReg (
                       );
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "UhciWriteReg: PciIo Io.Write error: %r at offset %d\n", Status, Offset));
+    DEBUG ((DEBUG_ERROR, "UhciWriteReg: PciIo Io.Write error: %r at offset %d\n", Status, Offset));
   }
 }
 
@@ -144,7 +144,7 @@ UhciAckAllInterrupt (
   // is a temporary error status.
   //
   if (!UhciIsHcWorking (Uhc->PciIo)) {
-    DEBUG ((EFI_D_ERROR, "UhciAckAllInterrupt: re-enable the UHCI from system error\n"));
+    DEBUG ((DEBUG_ERROR, "UhciAckAllInterrupt: re-enable the UHCI from system error\n"));
     Uhc->Usb2Hc.SetState (&Uhc->Usb2Hc, EfiUsbHcStateOperational);
   }
 }
@@ -208,7 +208,7 @@ UhciIsHcWorking (
   UsbSts = UhciReadReg (PciIo, USBSTS_OFFSET);
 
   if ((UsbSts & (USBSTS_HCPE | USBSTS_HSE | USBSTS_HCH)) != 0) {
-    DEBUG ((EFI_D_ERROR, "UhciIsHcWorking: current USB state is %x\n", UsbSts));
+    DEBUG ((DEBUG_ERROR, "UhciIsHcWorking: current USB state is %x\n", UsbSts));
     return FALSE;
   }
 
@@ -245,7 +245,7 @@ UhciSetFrameListBaseAddr (
                        );
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "UhciSetFrameListBaseAddr: PciIo Io.Write error: %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "UhciSetFrameListBaseAddr: PciIo Io.Write error: %r\n", Status));
   }
 }
 

--- a/MdeModulePkg/Bus/Pci/UhciDxe/UhciSched.c
+++ b/MdeModulePkg/Bus/Pci/UhciDxe/UhciSched.c
@@ -600,14 +600,14 @@ UhciExecuteTransfer (
   }
 
   if (!Finished) {
-    DEBUG ((EFI_D_ERROR, "UhciExecuteTransfer: execution not finished for %dms\n", (UINT32)TimeOut));
+    DEBUG ((DEBUG_ERROR, "UhciExecuteTransfer: execution not finished for %dms\n", (UINT32)TimeOut));
     UhciDumpQh (Qh);
     UhciDumpTds (Td);
 
     Status = EFI_TIMEOUT;
 
   } else if (QhResult->Result != EFI_USB_NOERROR) {
-    DEBUG ((EFI_D_ERROR, "UhciExecuteTransfer: execution failed with result %x\n", QhResult->Result));
+    DEBUG ((DEBUG_ERROR, "UhciExecuteTransfer: execution failed with result %x\n", QhResult->Result));
     UhciDumpQh (Qh);
     UhciDumpTds (Td);
 

--- a/MdeModulePkg/Bus/Pci/UhciDxe/UsbHcMem.c
+++ b/MdeModulePkg/Bus/Pci/UhciDxe/UsbHcMem.c
@@ -468,7 +468,7 @@ UsbHcAllocateMem (
   NewBlock = UsbHcAllocMemBlock (Pool, Pages);
 
   if (NewBlock == NULL) {
-    DEBUG ((EFI_D_INFO, "UsbHcAllocateMem: failed to allocate block\n"));
+    DEBUG ((DEBUG_INFO, "UsbHcAllocateMem: failed to allocate block\n"));
     return NULL;
   }
 

--- a/MdeModulePkg/Bus/Pci/XhciDxe/UsbHcMem.c
+++ b/MdeModulePkg/Bus/Pci/XhciDxe/UsbHcMem.c
@@ -503,7 +503,7 @@ UsbHcAllocateMem (
   NewBlock = UsbHcAllocMemBlock (Pool, Pages);
 
   if (NewBlock == NULL) {
-    DEBUG ((EFI_D_ERROR, "UsbHcAllocateMem: failed to allocate block\n"));
+    DEBUG ((DEBUG_ERROR, "UsbHcAllocateMem: failed to allocate block\n"));
     return NULL;
   }
 

--- a/MdeModulePkg/Bus/Pci/XhciDxe/Xhci.c
+++ b/MdeModulePkg/Bus/Pci/XhciDxe/Xhci.c
@@ -120,7 +120,7 @@ XhcGetCapability (
   *MaxSpeed       = EFI_USB_SPEED_SUPER;
   *PortNumber     = (UINT8) (Xhc->HcSParams1.Data.MaxPorts);
   *Is64BitCapable = (UINT8) Xhc->Support64BitDma;
-  DEBUG ((EFI_D_INFO, "XhcGetCapability: %d ports, 64 bit %d\n", *PortNumber, *Is64BitCapable));
+  DEBUG ((DEBUG_INFO, "XhcGetCapability: %d ports, 64 bit %d\n", *PortNumber, *Is64BitCapable));
 
   gBS->RestoreTPL (OldTpl);
 
@@ -216,7 +216,7 @@ XhcReset (
   }
 
 ON_EXIT:
-  DEBUG ((EFI_D_INFO, "XhcReset: status %r\n", Status));
+  DEBUG ((DEBUG_INFO, "XhcReset: status %r\n", Status));
   gBS->RestoreTPL (OldTpl);
 
   return Status;
@@ -260,7 +260,7 @@ XhcGetState (
     *State = EfiUsbHcStateOperational;
   }
 
-  DEBUG ((EFI_D_INFO, "XhcGetState: current state %d\n", *State));
+  DEBUG ((DEBUG_INFO, "XhcGetState: current state %d\n", *State));
   gBS->RestoreTPL (OldTpl);
 
   return EFI_SUCCESS;
@@ -336,7 +336,7 @@ XhcSetState (
     Status = EFI_INVALID_PARAMETER;
   }
 
-  DEBUG ((EFI_D_INFO, "XhcSetState: status %r\n", Status));
+  DEBUG ((DEBUG_INFO, "XhcSetState: status %r\n", Status));
   gBS->RestoreTPL (OldTpl);
 
   return Status;
@@ -530,7 +530,7 @@ XhcSetRootHubPortFeature (
     break;
 
   case EfiUsbPortReset:
-    DEBUG ((EFI_D_INFO, "XhcUsbPortReset!\n"));
+    DEBUG ((DEBUG_INFO, "XhcUsbPortReset!\n"));
     //
     // Make sure Host Controller not halt before reset it
     //
@@ -538,7 +538,7 @@ XhcSetRootHubPortFeature (
       Status = XhcRunHC (Xhc, XHC_GENERIC_TIMEOUT);
 
       if (EFI_ERROR (Status)) {
-        DEBUG ((EFI_D_INFO, "XhcSetRootHubPortFeature :failed to start HC - %r\n", Status));
+        DEBUG ((DEBUG_INFO, "XhcSetRootHubPortFeature :failed to start HC - %r\n", Status));
         break;
       }
     }
@@ -571,7 +571,7 @@ XhcSetRootHubPortFeature (
   }
 
 ON_EXIT:
-  DEBUG ((EFI_D_INFO, "XhcSetRootHubPortFeature: status %r\n", Status));
+  DEBUG ((DEBUG_INFO, "XhcSetRootHubPortFeature: status %r\n", Status));
   gBS->RestoreTPL (OldTpl);
 
   return Status;
@@ -706,7 +706,7 @@ XhcClearRootHubPortFeature (
   }
 
 ON_EXIT:
-  DEBUG ((EFI_D_INFO, "XhcClearRootHubPortFeature: status %r\n", Status));
+  DEBUG ((DEBUG_INFO, "XhcClearRootHubPortFeature: status %r\n", Status));
   gBS->RestoreTPL (OldTpl);
 
   return Status;
@@ -914,7 +914,7 @@ XhcControlTransfer (
   Len             = 0;
 
   if (XhcIsHalt (Xhc) || XhcIsSysError (Xhc)) {
-    DEBUG ((EFI_D_ERROR, "XhcControlTransfer: HC halted at entrance\n"));
+    DEBUG ((DEBUG_ERROR, "XhcControlTransfer: HC halted at entrance\n"));
     goto ON_EXIT;
   }
 
@@ -1043,7 +1043,7 @@ XhcControlTransfer (
         // Don't support multi-TT feature for super speed hub now.
         //
         MTT = 0;
-        DEBUG ((EFI_D_ERROR, "XHCI: Don't support multi-TT feature for Hub now. (force to disable MTT)\n"));
+        DEBUG ((DEBUG_ERROR, "XHCI: Don't support multi-TT feature for Hub now. (force to disable MTT)\n"));
       } else {
         MTT = 0;
       }
@@ -1162,7 +1162,7 @@ XhcControlTransfer (
 
 ON_EXIT:
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "XhcControlTransfer: error - %r, transfer - %x\n", Status, *TransferResult));
+    DEBUG ((DEBUG_ERROR, "XhcControlTransfer: error - %r, transfer - %x\n", Status, *TransferResult));
   }
 
   gBS->RestoreTPL (OldTpl);
@@ -1250,7 +1250,7 @@ XhcBulkTransfer (
   Status          = EFI_DEVICE_ERROR;
 
   if (XhcIsHalt (Xhc) || XhcIsSysError (Xhc)) {
-    DEBUG ((EFI_D_ERROR, "XhcBulkTransfer: HC is halted\n"));
+    DEBUG ((DEBUG_ERROR, "XhcBulkTransfer: HC is halted\n"));
     goto ON_EXIT;
   }
 
@@ -1282,7 +1282,7 @@ XhcBulkTransfer (
 
 ON_EXIT:
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "XhcBulkTransfer: error - %r, transfer - %x\n", Status, *TransferResult));
+    DEBUG ((DEBUG_ERROR, "XhcBulkTransfer: error - %r, transfer - %x\n", Status, *TransferResult));
   }
   gBS->RestoreTPL (OldTpl);
 
@@ -1386,14 +1386,14 @@ XhcAsyncInterruptTransfer (
     }
 
     Status = XhciDelAsyncIntTransfer (Xhc, DeviceAddress, EndPointAddress);
-    DEBUG ((EFI_D_INFO, "XhcAsyncInterruptTransfer: remove old transfer for addr %d, Status = %r\n", DeviceAddress, Status));
+    DEBUG ((DEBUG_INFO, "XhcAsyncInterruptTransfer: remove old transfer for addr %d, Status = %r\n", DeviceAddress, Status));
     goto ON_EXIT;
   }
 
   Status = EFI_SUCCESS;
 
   if (XhcIsHalt (Xhc) || XhcIsSysError (Xhc)) {
-    DEBUG ((EFI_D_ERROR, "XhcAsyncInterruptTransfer: HC is halt\n"));
+    DEBUG ((DEBUG_ERROR, "XhcAsyncInterruptTransfer: HC is halt\n"));
     Status = EFI_DEVICE_ERROR;
     goto ON_EXIT;
   }
@@ -1508,7 +1508,7 @@ XhcSyncInterruptTransfer (
   Status          = EFI_DEVICE_ERROR;
 
   if (XhcIsHalt (Xhc) || XhcIsSysError (Xhc)) {
-    DEBUG ((EFI_D_ERROR, "EhcSyncInterruptTransfer: HC is halt\n"));
+    DEBUG ((DEBUG_ERROR, "EhcSyncInterruptTransfer: HC is halt\n"));
     goto ON_EXIT;
   }
 
@@ -1536,7 +1536,7 @@ XhcSyncInterruptTransfer (
 
 ON_EXIT:
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "XhcSyncInterruptTransfer: error - %r, transfer - %x\n", Status, *TransferResult));
+    DEBUG ((DEBUG_ERROR, "XhcSyncInterruptTransfer: error - %r, transfer - %x\n", Status, *TransferResult));
   }
   gBS->RestoreTPL (OldTpl);
 
@@ -1805,14 +1805,14 @@ XhcCreateUsbHc (
   Xhc->UsbLegSupOffset = XhcGetCapabilityAddr (Xhc, XHC_CAP_USB_LEGACY);
   Xhc->DebugCapSupOffset = XhcGetCapabilityAddr (Xhc, XHC_CAP_USB_DEBUG);
 
-  DEBUG ((EFI_D_INFO, "XhcCreateUsb3Hc: Capability length 0x%x\n", Xhc->CapLength));
-  DEBUG ((EFI_D_INFO, "XhcCreateUsb3Hc: HcSParams1 0x%x\n", Xhc->HcSParams1));
-  DEBUG ((EFI_D_INFO, "XhcCreateUsb3Hc: HcSParams2 0x%x\n", Xhc->HcSParams2));
-  DEBUG ((EFI_D_INFO, "XhcCreateUsb3Hc: HcCParams 0x%x\n", Xhc->HcCParams));
-  DEBUG ((EFI_D_INFO, "XhcCreateUsb3Hc: DBOff 0x%x\n", Xhc->DBOff));
-  DEBUG ((EFI_D_INFO, "XhcCreateUsb3Hc: RTSOff 0x%x\n", Xhc->RTSOff));
-  DEBUG ((EFI_D_INFO, "XhcCreateUsb3Hc: UsbLegSupOffset 0x%x\n", Xhc->UsbLegSupOffset));
-  DEBUG ((EFI_D_INFO, "XhcCreateUsb3Hc: DebugCapSupOffset 0x%x\n", Xhc->DebugCapSupOffset));
+  DEBUG ((DEBUG_INFO, "XhcCreateUsb3Hc: Capability length 0x%x\n", Xhc->CapLength));
+  DEBUG ((DEBUG_INFO, "XhcCreateUsb3Hc: HcSParams1 0x%x\n", Xhc->HcSParams1));
+  DEBUG ((DEBUG_INFO, "XhcCreateUsb3Hc: HcSParams2 0x%x\n", Xhc->HcSParams2));
+  DEBUG ((DEBUG_INFO, "XhcCreateUsb3Hc: HcCParams 0x%x\n", Xhc->HcCParams));
+  DEBUG ((DEBUG_INFO, "XhcCreateUsb3Hc: DBOff 0x%x\n", Xhc->DBOff));
+  DEBUG ((DEBUG_INFO, "XhcCreateUsb3Hc: RTSOff 0x%x\n", Xhc->RTSOff));
+  DEBUG ((DEBUG_INFO, "XhcCreateUsb3Hc: UsbLegSupOffset 0x%x\n", Xhc->UsbLegSupOffset));
+  DEBUG ((DEBUG_INFO, "XhcCreateUsb3Hc: DebugCapSupOffset 0x%x\n", Xhc->DebugCapSupOffset));
 
   //
   // Create AsyncRequest Polling Timer
@@ -1972,7 +1972,7 @@ XhcDriverBindingStart (
   }
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "XhcDriverBindingStart: failed to enable controller\n"));
+    DEBUG ((DEBUG_ERROR, "XhcDriverBindingStart: failed to enable controller\n"));
     goto CLOSE_PCIIO;
   }
 
@@ -1982,7 +1982,7 @@ XhcDriverBindingStart (
   Xhc = XhcCreateUsbHc (PciIo, HcDevicePath, OriginalPciAttributes);
 
   if (Xhc == NULL) {
-    DEBUG ((EFI_D_ERROR, "XhcDriverBindingStart: failed to create USB2_HC\n"));
+    DEBUG ((DEBUG_ERROR, "XhcDriverBindingStart: failed to create USB2_HC\n"));
     return EFI_OUT_OF_RESOURCES;
   }
 
@@ -2000,7 +2000,7 @@ XhcDriverBindingStart (
     if (!EFI_ERROR (Status)) {
       Xhc->Support64BitDma = TRUE;
     } else {
-      DEBUG ((EFI_D_WARN,
+      DEBUG ((DEBUG_WARN,
         "%a: failed to enable 64-bit DMA on 64-bit capable controller @ %p (%r)\n",
         __FUNCTION__, Controller, Status));
     }
@@ -2032,7 +2032,7 @@ XhcDriverBindingStart (
   //
   Status = gBS->SetTimer (Xhc->PollTimer, TimerPeriodic, XHC_ASYNC_TIMER_INTERVAL);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "XhcDriverBindingStart: failed to start async interrupt monitor\n"));
+    DEBUG ((DEBUG_ERROR, "XhcDriverBindingStart: failed to start async interrupt monitor\n"));
     XhcHaltHC (Xhc, XHC_GENERIC_TIMEOUT);
     goto FREE_POOL;
   }
@@ -2078,11 +2078,11 @@ XhcDriverBindingStart (
                   &Xhc->Usb2Hc
                   );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "XhcDriverBindingStart: failed to install USB2_HC Protocol\n"));
+    DEBUG ((DEBUG_ERROR, "XhcDriverBindingStart: failed to install USB2_HC Protocol\n"));
     goto FREE_POOL;
   }
 
-  DEBUG ((EFI_D_INFO, "XhcDriverBindingStart: XHCI started for controller @ %x\n", Controller));
+  DEBUG ((DEBUG_INFO, "XhcDriverBindingStart: XHCI started for controller @ %x\n", Controller));
   return EFI_SUCCESS;
 
 FREE_POOL:
@@ -2233,4 +2233,3 @@ XhcDriverBindingStop (
 
   return EFI_SUCCESS;
 }
-

--- a/MdeModulePkg/Bus/Pci/XhciDxe/XhciReg.c
+++ b/MdeModulePkg/Bus/Pci/XhciDxe/XhciReg.c
@@ -38,7 +38,7 @@ XhcReadCapReg8 (
                              );
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "XhcReadCapReg: Pci Io read error - %r at %d\n", Status, Offset));
+    DEBUG ((DEBUG_ERROR, "XhcReadCapReg: Pci Io read error - %r at %d\n", Status, Offset));
     Data = 0xFF;
   }
 
@@ -74,7 +74,7 @@ XhcReadCapReg (
                              );
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "XhcReadCapReg: Pci Io read error - %r at %d\n", Status, Offset));
+    DEBUG ((DEBUG_ERROR, "XhcReadCapReg: Pci Io read error - %r at %d\n", Status, Offset));
     Data = 0xFFFFFFFF;
   }
 
@@ -112,7 +112,7 @@ XhcReadOpReg (
                              );
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "XhcReadOpReg: Pci Io Read error - %r at %d\n", Status, Offset));
+    DEBUG ((DEBUG_ERROR, "XhcReadOpReg: Pci Io Read error - %r at %d\n", Status, Offset));
     Data = 0xFFFFFFFF;
   }
 
@@ -148,7 +148,7 @@ XhcWriteOpReg (
                              );
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "XhcWriteOpReg: Pci Io Write error: %r at %d\n", Status, Offset));
+    DEBUG ((DEBUG_ERROR, "XhcWriteOpReg: Pci Io Write error: %r at %d\n", Status, Offset));
   }
 }
 
@@ -185,7 +185,7 @@ XhcWriteDoorBellReg (
                              );
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "XhcWriteOpReg: Pci Io Write error: %r at %d\n", Status, Offset));
+    DEBUG ((DEBUG_ERROR, "XhcWriteOpReg: Pci Io Write error: %r at %d\n", Status, Offset));
   }
 }
 
@@ -219,7 +219,7 @@ XhcReadRuntimeReg (
                              );
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "XhcReadRuntimeReg: Pci Io Read error - %r at %d\n", Status, Offset));
+    DEBUG ((DEBUG_ERROR, "XhcReadRuntimeReg: Pci Io Read error - %r at %d\n", Status, Offset));
     Data = 0xFFFFFFFF;
   }
 
@@ -255,7 +255,7 @@ XhcWriteRuntimeReg (
                              );
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "XhcWriteRuntimeReg: Pci Io Write error: %r at %d\n", Status, Offset));
+    DEBUG ((DEBUG_ERROR, "XhcWriteRuntimeReg: Pci Io Write error: %r at %d\n", Status, Offset));
   }
 }
 
@@ -289,7 +289,7 @@ XhcReadExtCapReg (
                              );
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "XhcReadExtCapReg: Pci Io Read error - %r at %d\n", Status, Offset));
+    DEBUG ((DEBUG_ERROR, "XhcReadExtCapReg: Pci Io Read error - %r at %d\n", Status, Offset));
     Data = 0xFFFFFFFF;
   }
 
@@ -325,7 +325,7 @@ XhcWriteExtCapReg (
                              );
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "XhcWriteExtCapReg: Pci Io Write error: %r at %d\n", Status, Offset));
+    DEBUG ((DEBUG_ERROR, "XhcWriteExtCapReg: Pci Io Write error: %r at %d\n", Status, Offset));
   }
 }
 
@@ -508,7 +508,7 @@ XhcSetBiosOwnership (
     return;
   }
 
-  DEBUG ((EFI_D_INFO, "XhcSetBiosOwnership: called to set BIOS ownership\n"));
+  DEBUG ((DEBUG_INFO, "XhcSetBiosOwnership: called to set BIOS ownership\n"));
 
   Buffer = XhcReadExtCapReg (Xhc, Xhc->UsbLegSupOffset);
   Buffer = ((Buffer & (~USBLEGSP_OS_SEMAPHORE)) | USBLEGSP_BIOS_SEMAPHORE);
@@ -532,7 +532,7 @@ XhcClearBiosOwnership (
     return;
   }
 
-  DEBUG ((EFI_D_INFO, "XhcClearBiosOwnership: called to clear BIOS ownership\n"));
+  DEBUG ((DEBUG_INFO, "XhcClearBiosOwnership: called to clear BIOS ownership\n"));
 
   Buffer = XhcReadExtCapReg (Xhc, Xhc->UsbLegSupOffset);
   Buffer = ((Buffer & (~USBLEGSP_BIOS_SEMAPHORE)) | USBLEGSP_OS_SEMAPHORE);
@@ -666,7 +666,7 @@ XhcResetHC (
 
   Status = EFI_SUCCESS;
 
-  DEBUG ((EFI_D_INFO, "XhcResetHC!\n"));
+  DEBUG ((DEBUG_INFO, "XhcResetHC!\n"));
   //
   // Host can only be reset when it is halt. If not so, halt it
   //
@@ -748,4 +748,3 @@ XhcRunHC (
   Status = XhcWaitOpRegBit (Xhc, XHC_USBSTS_OFFSET, XHC_USBSTS_HALT, FALSE, Timeout);
   return Status;
 }
-

--- a/MdeModulePkg/Bus/Pci/XhciDxe/XhciSched.c
+++ b/MdeModulePkg/Bus/Pci/XhciDxe/XhciSched.c
@@ -82,7 +82,7 @@ XhcCmdTransfer (
   Status = EFI_DEVICE_ERROR;
 
   if (XhcIsHalt (Xhc) || XhcIsSysError (Xhc)) {
-    DEBUG ((EFI_D_ERROR, "XhcCmdTransfer: HC is halted\n"));
+    DEBUG ((DEBUG_ERROR, "XhcCmdTransfer: HC is halted\n"));
     goto ON_EXIT;
   }
 
@@ -92,7 +92,7 @@ XhcCmdTransfer (
   Urb = XhcCreateCmdTrb (Xhc, CmdTrb);
 
   if (Urb == NULL) {
-    DEBUG ((EFI_D_ERROR, "XhcCmdTransfer: failed to create URB\n"));
+    DEBUG ((DEBUG_ERROR, "XhcCmdTransfer: failed to create URB\n"));
     Status = EFI_OUT_OF_RESOURCES;
     goto ON_EXIT;
   }
@@ -172,7 +172,7 @@ XhcCreateUrb (
   Status = XhcCreateTransferTrb (Xhc, Urb);
   ASSERT_EFI_ERROR (Status);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "XhcCreateUrb: XhcCreateTransferTrb Failed, Status = %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "XhcCreateUrb: XhcCreateTransferTrb Failed, Status = %r\n", Status));
     FreePool (Urb);
     Urb = NULL;
   }
@@ -269,7 +269,7 @@ XhcCreateTransferTrb (
     Status  = Xhc->PciIo->Map (Xhc->PciIo, MapOp, Urb->Data, &Len, &PhyAddr, &Map);
 
     if (EFI_ERROR (Status) || (Len != Urb->DataLen)) {
-      DEBUG ((EFI_D_ERROR, "XhcCreateTransferTrb: Fail to map Urb->Data.\n"));
+      DEBUG ((DEBUG_ERROR, "XhcCreateTransferTrb: Fail to map Urb->Data.\n"));
       return EFI_OUT_OF_RESOURCES;
     }
 
@@ -446,7 +446,7 @@ XhcCreateTransferTrb (
       break;
 
     default:
-      DEBUG ((EFI_D_INFO, "Not supported EPType 0x%x!\n",EPType));
+      DEBUG ((DEBUG_INFO, "Not supported EPType 0x%x!\n",EPType));
       ASSERT (FALSE);
       break;
   }
@@ -582,7 +582,7 @@ XhcInitSched (
   XhcWriteOpReg (Xhc, XHC_DCBAAP_OFFSET, XHC_LOW_32BIT(DcbaaPhy));
   XhcWriteOpReg (Xhc, XHC_DCBAAP_OFFSET + 4, XHC_HIGH_32BIT (DcbaaPhy));
 
-  DEBUG ((EFI_D_INFO, "XhcInitSched:DCBAA=0x%x\n", (UINT64)(UINTN)Xhc->DCBAA));
+  DEBUG ((DEBUG_INFO, "XhcInitSched:DCBAA=0x%x\n", (UINT64)(UINTN)Xhc->DCBAA));
 
   //
   // Define the Command Ring Dequeue Pointer by programming the Command Ring Control Register
@@ -660,14 +660,14 @@ XhcRecoverHaltedEndpoint (
   Dci = XhcEndpointToDci (Urb->Ep.EpAddr, (UINT8)(Urb->Ep.Direction));
   ASSERT (Dci < 32);
 
-  DEBUG ((EFI_D_INFO, "Recovery Halted Slot = %x,Dci = %x\n", SlotId, Dci));
+  DEBUG ((DEBUG_INFO, "Recovery Halted Slot = %x,Dci = %x\n", SlotId, Dci));
 
   //
   // 1) Send Reset endpoint command to transit from halt to stop state
   //
   Status = XhcResetEndpoint(Xhc, SlotId, Dci);
   if (EFI_ERROR(Status)) {
-    DEBUG ((EFI_D_ERROR, "XhcRecoverHaltedEndpoint: Reset Endpoint Failed, Status = %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "XhcRecoverHaltedEndpoint: Reset Endpoint Failed, Status = %r\n", Status));
     goto Done;
   }
 
@@ -676,7 +676,7 @@ XhcRecoverHaltedEndpoint (
   //
   Status = XhcSetTrDequeuePointer(Xhc, SlotId, Dci, Urb);
   if (EFI_ERROR(Status)) {
-    DEBUG ((EFI_D_ERROR, "XhcRecoverHaltedEndpoint: Set Transfer Ring Dequeue Pointer Failed, Status = %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "XhcRecoverHaltedEndpoint: Set Transfer Ring Dequeue Pointer Failed, Status = %r\n", Status));
     goto Done;
   }
 
@@ -722,14 +722,14 @@ XhcDequeueTrbFromEndpoint (
   Dci = XhcEndpointToDci (Urb->Ep.EpAddr, (UINT8)(Urb->Ep.Direction));
   ASSERT (Dci < 32);
 
-  DEBUG ((EFI_D_INFO, "Stop Slot = %x,Dci = %x\n", SlotId, Dci));
+  DEBUG ((DEBUG_INFO, "Stop Slot = %x,Dci = %x\n", SlotId, Dci));
 
   //
   // 1) Send Stop endpoint command to stop xHC from executing of the TDs on the endpoint
   //
   Status = XhcStopEndpoint(Xhc, SlotId, Dci, Urb);
   if (EFI_ERROR(Status)) {
-    DEBUG ((EFI_D_ERROR, "XhcDequeueTrbFromEndpoint: Stop Endpoint Failed, Status = %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "XhcDequeueTrbFromEndpoint: Stop Endpoint Failed, Status = %r\n", Status));
     goto Done;
   }
 
@@ -1159,25 +1159,25 @@ XhcCheckUrbResult (
       case TRB_COMPLETION_STALL_ERROR:
         CheckedUrb->Result  |= EFI_USB_ERR_STALL;
         CheckedUrb->Finished = TRUE;
-        DEBUG ((EFI_D_ERROR, "XhcCheckUrbResult: STALL_ERROR! Completecode = %x\n",EvtTrb->Completecode));
+        DEBUG ((DEBUG_ERROR, "XhcCheckUrbResult: STALL_ERROR! Completecode = %x\n",EvtTrb->Completecode));
         goto EXIT;
 
       case TRB_COMPLETION_BABBLE_ERROR:
         CheckedUrb->Result  |= EFI_USB_ERR_BABBLE;
         CheckedUrb->Finished = TRUE;
-        DEBUG ((EFI_D_ERROR, "XhcCheckUrbResult: BABBLE_ERROR! Completecode = %x\n",EvtTrb->Completecode));
+        DEBUG ((DEBUG_ERROR, "XhcCheckUrbResult: BABBLE_ERROR! Completecode = %x\n",EvtTrb->Completecode));
         goto EXIT;
 
       case TRB_COMPLETION_DATA_BUFFER_ERROR:
         CheckedUrb->Result  |= EFI_USB_ERR_BUFFER;
         CheckedUrb->Finished = TRUE;
-        DEBUG ((EFI_D_ERROR, "XhcCheckUrbResult: ERR_BUFFER! Completecode = %x\n",EvtTrb->Completecode));
+        DEBUG ((DEBUG_ERROR, "XhcCheckUrbResult: ERR_BUFFER! Completecode = %x\n",EvtTrb->Completecode));
         goto EXIT;
 
       case TRB_COMPLETION_USB_TRANSACTION_ERROR:
         CheckedUrb->Result  |= EFI_USB_ERR_TIMEOUT;
         CheckedUrb->Finished = TRUE;
-        DEBUG ((EFI_D_ERROR, "XhcCheckUrbResult: TRANSACTION_ERROR! Completecode = %x\n",EvtTrb->Completecode));
+        DEBUG ((DEBUG_ERROR, "XhcCheckUrbResult: TRANSACTION_ERROR! Completecode = %x\n",EvtTrb->Completecode));
         goto EXIT;
 
       case TRB_COMPLETION_STOPPED:
@@ -1193,7 +1193,7 @@ XhcCheckUrbResult (
       case TRB_COMPLETION_SHORT_PACKET:
       case TRB_COMPLETION_SUCCESS:
         if (EvtTrb->Completecode == TRB_COMPLETION_SHORT_PACKET) {
-          DEBUG ((EFI_D_VERBOSE, "XhcCheckUrbResult: short packet happens!\n"));
+          DEBUG ((DEBUG_VERBOSE, "XhcCheckUrbResult: short packet happens!\n"));
         }
 
         TRBType = (UINT8) (TRBPtr->Type);
@@ -1206,7 +1206,7 @@ XhcCheckUrbResult (
         break;
 
       default:
-        DEBUG ((EFI_D_ERROR, "Transfer Default Error Occur! Completecode = 0x%x!\n",EvtTrb->Completecode));
+        DEBUG ((DEBUG_ERROR, "Transfer Default Error Occur! Completecode = 0x%x!\n",EvtTrb->Completecode));
         CheckedUrb->Result  |= EFI_USB_ERR_TIMEOUT;
         CheckedUrb->Finished = TRUE;
         goto EXIT;
@@ -1396,7 +1396,7 @@ XhciDelAsyncIntTransfer (
       //
       Status = XhcDequeueTrbFromEndpoint (Xhc, Urb);
       if (EFI_ERROR (Status)) {
-        DEBUG ((EFI_D_ERROR, "XhciDelAsyncIntTransfer: XhcDequeueTrbFromEndpoint failed\n"));
+        DEBUG ((DEBUG_ERROR, "XhciDelAsyncIntTransfer: XhcDequeueTrbFromEndpoint failed\n"));
       }
 
       RemoveEntryList (&Urb->UrbList);
@@ -1434,7 +1434,7 @@ XhciDelAllAsyncIntTransfers (
     //
     Status = XhcDequeueTrbFromEndpoint (Xhc, Urb);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "XhciDelAllAsyncIntTransfers: XhcDequeueTrbFromEndpoint failed\n"));
+      DEBUG ((DEBUG_ERROR, "XhciDelAllAsyncIntTransfers: XhcDequeueTrbFromEndpoint failed\n"));
     }
 
     RemoveEntryList (&Urb->UrbList);
@@ -1644,7 +1644,7 @@ XhcMonitorAsyncRequests (
     //
     Status = XhcFlushAsyncIntMap (Xhc, Urb);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "XhcMonitorAsyncRequests: Fail to Flush AsyncInt Mapped Memeory\n"));
+      DEBUG ((DEBUG_ERROR, "XhcMonitorAsyncRequests: Fail to Flush AsyncInt Mapped Memeory\n"));
     }
 
     //
@@ -2139,11 +2139,11 @@ XhcInitializeDeviceSlot (
               (TRB_TEMPLATE **) (UINTN) &EvtTrb
               );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "XhcInitializeDeviceSlot: Enable Slot Failed, Status = %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "XhcInitializeDeviceSlot: Enable Slot Failed, Status = %r\n", Status));
     return Status;
   }
   ASSERT (EvtTrb->SlotId <= Xhc->MaxSlotsEn);
-  DEBUG ((EFI_D_INFO, "Enable Slot Successfully, The Slot ID = 0x%x\n", EvtTrb->SlotId));
+  DEBUG ((DEBUG_INFO, "Enable Slot Successfully, The Slot ID = 0x%x\n", EvtTrb->SlotId));
   SlotId = (UINT8)EvtTrb->SlotId;
   ASSERT (SlotId != 0);
 
@@ -2296,7 +2296,7 @@ XhcInitializeDeviceSlot (
              );
   if (!EFI_ERROR (Status)) {
     DeviceAddress = (UINT8) ((DEVICE_CONTEXT *) OutputContext)->Slot.DeviceAddress;
-    DEBUG ((EFI_D_INFO, "    Address %d assigned successfully\n", DeviceAddress));
+    DEBUG ((DEBUG_INFO, "    Address %d assigned successfully\n", DeviceAddress));
     Xhc->UsbDevContext[SlotId].XhciDevAddr = DeviceAddress;
   } else {
     DEBUG ((DEBUG_ERROR, "    Slot %d address not assigned successfully. Status = %r\n", SlotId, Status));
@@ -2352,11 +2352,11 @@ XhcInitializeDeviceSlot64 (
               (TRB_TEMPLATE **) (UINTN) &EvtTrb
               );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "XhcInitializeDeviceSlot64: Enable Slot Failed, Status = %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "XhcInitializeDeviceSlot64: Enable Slot Failed, Status = %r\n", Status));
     return Status;
   }
   ASSERT (EvtTrb->SlotId <= Xhc->MaxSlotsEn);
-  DEBUG ((EFI_D_INFO, "Enable Slot Successfully, The Slot ID = 0x%x\n", EvtTrb->SlotId));
+  DEBUG ((DEBUG_INFO, "Enable Slot Successfully, The Slot ID = 0x%x\n", EvtTrb->SlotId));
   SlotId = (UINT8)EvtTrb->SlotId;
   ASSERT (SlotId != 0);
 
@@ -2509,7 +2509,7 @@ XhcInitializeDeviceSlot64 (
              );
   if (!EFI_ERROR (Status)) {
     DeviceAddress = (UINT8) ((DEVICE_CONTEXT_64 *) OutputContext)->Slot.DeviceAddress;
-    DEBUG ((EFI_D_INFO, "    Address %d assigned successfully\n", DeviceAddress));
+    DEBUG ((DEBUG_INFO, "    Address %d assigned successfully\n", DeviceAddress));
     Xhc->UsbDevContext[SlotId].XhciDevAddr = DeviceAddress;
   } else {
     DEBUG ((DEBUG_ERROR, "    Slot %d address not assigned successfully. Status = %r\n", SlotId, Status));
@@ -2556,7 +2556,7 @@ XhcDisableSlotCmd (
     Status = XhcDisableSlotCmd (Xhc, Xhc->UsbDevContext[Index + 1].SlotId);
 
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "XhcDisableSlotCmd: failed to disable child, ignore error\n"));
+      DEBUG ((DEBUG_ERROR, "XhcDisableSlotCmd: failed to disable child, ignore error\n"));
       Xhc->UsbDevContext[Index + 1].SlotId = 0;
     }
   }
@@ -2564,7 +2564,7 @@ XhcDisableSlotCmd (
   //
   // Construct the disable slot command
   //
-  DEBUG ((EFI_D_INFO, "Disable device slot %d!\n", SlotId));
+  DEBUG ((DEBUG_INFO, "Disable device slot %d!\n", SlotId));
 
   ZeroMem (&CmdTrbDisSlot, sizeof (CmdTrbDisSlot));
   CmdTrbDisSlot.CycleBit = 1;
@@ -2577,7 +2577,7 @@ XhcDisableSlotCmd (
              (TRB_TEMPLATE **) (UINTN) &EvtTrb
              );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "XhcDisableSlotCmd: Disable Slot Command Failed, Status = %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "XhcDisableSlotCmd: Disable Slot Command Failed, Status = %r\n", Status));
     return Status;
   }
   //
@@ -2663,7 +2663,7 @@ XhcDisableSlotCmd64 (
     Status = XhcDisableSlotCmd64 (Xhc, Xhc->UsbDevContext[Index + 1].SlotId);
 
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "XhcDisableSlotCmd: failed to disable child, ignore error\n"));
+      DEBUG ((DEBUG_ERROR, "XhcDisableSlotCmd: failed to disable child, ignore error\n"));
       Xhc->UsbDevContext[Index + 1].SlotId = 0;
     }
   }
@@ -2671,7 +2671,7 @@ XhcDisableSlotCmd64 (
   //
   // Construct the disable slot command
   //
-  DEBUG ((EFI_D_INFO, "Disable device slot %d!\n", SlotId));
+  DEBUG ((DEBUG_INFO, "Disable device slot %d!\n", SlotId));
 
   ZeroMem (&CmdTrbDisSlot, sizeof (CmdTrbDisSlot));
   CmdTrbDisSlot.CycleBit = 1;
@@ -2684,7 +2684,7 @@ XhcDisableSlotCmd64 (
              (TRB_TEMPLATE **) (UINTN) &EvtTrb
              );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "XhcDisableSlotCmd: Disable Slot Command Failed, Status = %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "XhcDisableSlotCmd: Disable Slot Command Failed, Status = %r\n", Status));
     return Status;
   }
   //
@@ -2851,7 +2851,7 @@ XhcInitializeEndpointContext (
         //
         // Do not support isochronous transfer now.
         //
-        DEBUG ((EFI_D_INFO, "XhcInitializeEndpointContext: Unsupport ISO EP found, Transfer ring is not allocated.\n"));
+        DEBUG ((DEBUG_INFO, "XhcInitializeEndpointContext: Unsupport ISO EP found, Transfer ring is not allocated.\n"));
         EpDesc = (USB_ENDPOINT_DESCRIPTOR *)((UINTN)EpDesc + EpDesc->Length);
         continue;
       case USB_ENDPOINT_INTERRUPT:
@@ -2903,9 +2903,9 @@ XhcInitializeEndpointContext (
         //
         // Do not support control transfer now.
         //
-        DEBUG ((EFI_D_INFO, "XhcInitializeEndpointContext: Unsupport Control EP found, Transfer ring is not allocated.\n"));
+        DEBUG ((DEBUG_INFO, "XhcInitializeEndpointContext: Unsupport Control EP found, Transfer ring is not allocated.\n"));
       default:
-        DEBUG ((EFI_D_INFO, "XhcInitializeEndpointContext: Unknown EP found, Transfer ring is not allocated.\n"));
+        DEBUG ((DEBUG_INFO, "XhcInitializeEndpointContext: Unknown EP found, Transfer ring is not allocated.\n"));
         EpDesc = (USB_ENDPOINT_DESCRIPTOR *)((UINTN)EpDesc + EpDesc->Length);
         continue;
     }
@@ -3043,7 +3043,7 @@ XhcInitializeEndpointContext64 (
         //
         // Do not support isochronous transfer now.
         //
-        DEBUG ((EFI_D_INFO, "XhcInitializeEndpointContext64: Unsupport ISO EP found, Transfer ring is not allocated.\n"));
+        DEBUG ((DEBUG_INFO, "XhcInitializeEndpointContext64: Unsupport ISO EP found, Transfer ring is not allocated.\n"));
         EpDesc = (USB_ENDPOINT_DESCRIPTOR *)((UINTN)EpDesc + EpDesc->Length);
         continue;
       case USB_ENDPOINT_INTERRUPT:
@@ -3095,9 +3095,9 @@ XhcInitializeEndpointContext64 (
         //
         // Do not support control transfer now.
         //
-        DEBUG ((EFI_D_INFO, "XhcInitializeEndpointContext64: Unsupport Control EP found, Transfer ring is not allocated.\n"));
+        DEBUG ((DEBUG_INFO, "XhcInitializeEndpointContext64: Unsupport Control EP found, Transfer ring is not allocated.\n"));
       default:
-        DEBUG ((EFI_D_INFO, "XhcInitializeEndpointContext64: Unknown EP found, Transfer ring is not allocated.\n"));
+        DEBUG ((DEBUG_INFO, "XhcInitializeEndpointContext64: Unknown EP found, Transfer ring is not allocated.\n"));
         EpDesc = (USB_ENDPOINT_DESCRIPTOR *)((UINTN)EpDesc + EpDesc->Length);
         continue;
     }
@@ -3192,7 +3192,7 @@ XhcSetConfigCmd (
   CmdTrbCfgEP.CycleBit = 1;
   CmdTrbCfgEP.Type     = TRB_TYPE_CON_ENDPOINT;
   CmdTrbCfgEP.SlotId   = Xhc->UsbDevContext[SlotId].SlotId;
-  DEBUG ((EFI_D_INFO, "Configure Endpoint\n"));
+  DEBUG ((DEBUG_INFO, "Configure Endpoint\n"));
   Status = XhcCmdTransfer (
              Xhc,
              (TRB_TEMPLATE *) (UINTN) &CmdTrbCfgEP,
@@ -3200,7 +3200,7 @@ XhcSetConfigCmd (
              (TRB_TEMPLATE **) (UINTN) &EvtTrb
              );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "XhcSetConfigCmd: Config Endpoint Failed, Status = %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "XhcSetConfigCmd: Config Endpoint Failed, Status = %r\n", Status));
   } else {
     Xhc->UsbDevContext[SlotId].ActiveConfiguration = ConfigDesc->ConfigurationValue;
   }
@@ -3282,7 +3282,7 @@ XhcSetConfigCmd64 (
   CmdTrbCfgEP.CycleBit = 1;
   CmdTrbCfgEP.Type     = TRB_TYPE_CON_ENDPOINT;
   CmdTrbCfgEP.SlotId   = Xhc->UsbDevContext[SlotId].SlotId;
-  DEBUG ((EFI_D_INFO, "Configure Endpoint\n"));
+  DEBUG ((DEBUG_INFO, "Configure Endpoint\n"));
   Status = XhcCmdTransfer (
              Xhc,
              (TRB_TEMPLATE *) (UINTN) &CmdTrbCfgEP,
@@ -3290,7 +3290,7 @@ XhcSetConfigCmd64 (
              (TRB_TEMPLATE **) (UINTN) &EvtTrb
              );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "XhcSetConfigCmd64: Config Endpoint Failed, Status = %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "XhcSetConfigCmd64: Config Endpoint Failed, Status = %r\n", Status));
   } else {
     Xhc->UsbDevContext[SlotId].ActiveConfiguration = ConfigDesc->ConfigurationValue;
   }
@@ -3323,7 +3323,7 @@ XhcStopEndpoint (
   EVT_TRB_COMMAND_COMPLETION    *EvtTrb;
   CMD_TRB_STOP_ENDPOINT         CmdTrbStopED;
 
-  DEBUG ((EFI_D_INFO, "XhcStopEndpoint: Slot = 0x%x, Dci = 0x%x\n", SlotId, Dci));
+  DEBUG ((DEBUG_INFO, "XhcStopEndpoint: Slot = 0x%x, Dci = 0x%x\n", SlotId, Dci));
 
   //
   // When XhcCheckUrbResult waits for the Stop_Endpoint completion, it also checks
@@ -3363,7 +3363,7 @@ XhcStopEndpoint (
              (TRB_TEMPLATE **) (UINTN) &EvtTrb
              );
   if (EFI_ERROR(Status)) {
-    DEBUG ((EFI_D_ERROR, "XhcStopEndpoint: Stop Endpoint Failed, Status = %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "XhcStopEndpoint: Stop Endpoint Failed, Status = %r\n", Status));
   }
 
   Xhc->PendingUrb = NULL;
@@ -3394,7 +3394,7 @@ XhcResetEndpoint (
   EVT_TRB_COMMAND_COMPLETION  *EvtTrb;
   CMD_TRB_RESET_ENDPOINT      CmdTrbResetED;
 
-  DEBUG ((EFI_D_INFO, "XhcResetEndpoint: Slot = 0x%x, Dci = 0x%x\n", SlotId, Dci));
+  DEBUG ((DEBUG_INFO, "XhcResetEndpoint: Slot = 0x%x, Dci = 0x%x\n", SlotId, Dci));
 
   //
   // Send stop endpoint command to transit Endpoint from running to stop state
@@ -3411,7 +3411,7 @@ XhcResetEndpoint (
              (TRB_TEMPLATE **) (UINTN) &EvtTrb
              );
   if (EFI_ERROR(Status)) {
-    DEBUG ((EFI_D_ERROR, "XhcResetEndpoint: Reset Endpoint Failed, Status = %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "XhcResetEndpoint: Reset Endpoint Failed, Status = %r\n", Status));
   }
 
   return Status;
@@ -3444,7 +3444,7 @@ XhcSetTrDequeuePointer (
   CMD_SET_TR_DEQ_POINTER      CmdSetTRDeq;
   EFI_PHYSICAL_ADDRESS        PhyAddr;
 
-  DEBUG ((EFI_D_INFO, "XhcSetTrDequeuePointer: Slot = 0x%x, Dci = 0x%x, Urb = 0x%x\n", SlotId, Dci, Urb));
+  DEBUG ((DEBUG_INFO, "XhcSetTrDequeuePointer: Slot = 0x%x, Dci = 0x%x, Urb = 0x%x\n", SlotId, Dci, Urb));
 
   //
   // Send stop endpoint command to transit Endpoint from running to stop state
@@ -3464,7 +3464,7 @@ XhcSetTrDequeuePointer (
              (TRB_TEMPLATE **) (UINTN) &EvtTrb
              );
   if (EFI_ERROR(Status)) {
-    DEBUG ((EFI_D_ERROR, "XhcSetTrDequeuePointer: Set TR Dequeue Pointer Failed, Status = %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "XhcSetTrDequeuePointer: Set TR Dequeue Pointer Failed, Status = %r\n", Status));
   }
 
   return Status;
@@ -3652,7 +3652,7 @@ XhcSetInterface (
     CmdTrbCfgEP.CycleBit = 1;
     CmdTrbCfgEP.Type     = TRB_TYPE_CON_ENDPOINT;
     CmdTrbCfgEP.SlotId   = Xhc->UsbDevContext[SlotId].SlotId;
-    DEBUG ((EFI_D_INFO, "SetInterface: Configure Endpoint\n"));
+    DEBUG ((DEBUG_INFO, "SetInterface: Configure Endpoint\n"));
     Status = XhcCmdTransfer (
                Xhc,
                (TRB_TEMPLATE *) (UINTN) &CmdTrbCfgEP,
@@ -3660,7 +3660,7 @@ XhcSetInterface (
                (TRB_TEMPLATE **) (UINTN) &EvtTrb
                );
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "SetInterface: Config Endpoint Failed, Status = %r\n", Status));
+      DEBUG ((DEBUG_ERROR, "SetInterface: Config Endpoint Failed, Status = %r\n", Status));
     } else {
       //
       // Update the active AlternateSetting.
@@ -3854,7 +3854,7 @@ XhcSetInterface64 (
     CmdTrbCfgEP.CycleBit = 1;
     CmdTrbCfgEP.Type     = TRB_TYPE_CON_ENDPOINT;
     CmdTrbCfgEP.SlotId   = Xhc->UsbDevContext[SlotId].SlotId;
-    DEBUG ((EFI_D_INFO, "SetInterface64: Configure Endpoint\n"));
+    DEBUG ((DEBUG_INFO, "SetInterface64: Configure Endpoint\n"));
     Status = XhcCmdTransfer (
                Xhc,
                (TRB_TEMPLATE *) (UINTN) &CmdTrbCfgEP,
@@ -3862,7 +3862,7 @@ XhcSetInterface64 (
                (TRB_TEMPLATE **) (UINTN) &EvtTrb
                );
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "SetInterface64: Config Endpoint Failed, Status = %r\n", Status));
+      DEBUG ((DEBUG_ERROR, "SetInterface64: Config Endpoint Failed, Status = %r\n", Status));
     } else {
       //
       // Update the active AlternateSetting.
@@ -3916,7 +3916,7 @@ XhcEvaluateContext (
   CmdTrbEvalu.CycleBit = 1;
   CmdTrbEvalu.Type     = TRB_TYPE_EVALU_CONTXT;
   CmdTrbEvalu.SlotId   = Xhc->UsbDevContext[SlotId].SlotId;
-  DEBUG ((EFI_D_INFO, "Evaluate context\n"));
+  DEBUG ((DEBUG_INFO, "Evaluate context\n"));
   Status = XhcCmdTransfer (
              Xhc,
              (TRB_TEMPLATE *) (UINTN) &CmdTrbEvalu,
@@ -3924,7 +3924,7 @@ XhcEvaluateContext (
              (TRB_TEMPLATE **) (UINTN) &EvtTrb
              );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "XhcEvaluateContext: Evaluate Context Failed, Status = %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "XhcEvaluateContext: Evaluate Context Failed, Status = %r\n", Status));
   }
   return Status;
 }
@@ -3971,7 +3971,7 @@ XhcEvaluateContext64 (
   CmdTrbEvalu.CycleBit = 1;
   CmdTrbEvalu.Type     = TRB_TYPE_EVALU_CONTXT;
   CmdTrbEvalu.SlotId   = Xhc->UsbDevContext[SlotId].SlotId;
-  DEBUG ((EFI_D_INFO, "Evaluate context\n"));
+  DEBUG ((DEBUG_INFO, "Evaluate context\n"));
   Status = XhcCmdTransfer (
              Xhc,
              (TRB_TEMPLATE *) (UINTN) &CmdTrbEvalu,
@@ -3979,7 +3979,7 @@ XhcEvaluateContext64 (
              (TRB_TEMPLATE **) (UINTN) &EvtTrb
              );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "XhcEvaluateContext64: Evaluate Context Failed, Status = %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "XhcEvaluateContext64: Evaluate Context Failed, Status = %r\n", Status));
   }
   return Status;
 }
@@ -4040,7 +4040,7 @@ XhcConfigHubContext (
   CmdTrbCfgEP.CycleBit = 1;
   CmdTrbCfgEP.Type     = TRB_TYPE_CON_ENDPOINT;
   CmdTrbCfgEP.SlotId   = Xhc->UsbDevContext[SlotId].SlotId;
-  DEBUG ((EFI_D_INFO, "Configure Hub Slot Context\n"));
+  DEBUG ((DEBUG_INFO, "Configure Hub Slot Context\n"));
   Status = XhcCmdTransfer (
               Xhc,
               (TRB_TEMPLATE *) (UINTN) &CmdTrbCfgEP,
@@ -4048,7 +4048,7 @@ XhcConfigHubContext (
               (TRB_TEMPLATE **) (UINTN) &EvtTrb
               );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "XhcConfigHubContext: Config Endpoint Failed, Status = %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "XhcConfigHubContext: Config Endpoint Failed, Status = %r\n", Status));
   }
   return Status;
 }
@@ -4108,7 +4108,7 @@ XhcConfigHubContext64 (
   CmdTrbCfgEP.CycleBit = 1;
   CmdTrbCfgEP.Type     = TRB_TYPE_CON_ENDPOINT;
   CmdTrbCfgEP.SlotId   = Xhc->UsbDevContext[SlotId].SlotId;
-  DEBUG ((EFI_D_INFO, "Configure Hub Slot Context\n"));
+  DEBUG ((DEBUG_INFO, "Configure Hub Slot Context\n"));
   Status = XhcCmdTransfer (
               Xhc,
               (TRB_TEMPLATE *) (UINTN) &CmdTrbCfgEP,
@@ -4116,9 +4116,7 @@ XhcConfigHubContext64 (
               (TRB_TEMPLATE **) (UINTN) &EvtTrb
               );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "XhcConfigHubContext64: Config Endpoint Failed, Status = %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "XhcConfigHubContext64: Config Endpoint Failed, Status = %r\n", Status));
   }
   return Status;
 }
-
-

--- a/MdeModulePkg/Bus/Pci/XhciPei/XhcPeim.c
+++ b/MdeModulePkg/Bus/Pci/XhciPei/XhcPeim.c
@@ -386,7 +386,7 @@ XhcPeiResetHC (
   MicroSecondDelay (1000);
   Status = XhcPeiWaitOpRegBit (Xhc, XHC_USBCMD_OFFSET, XHC_USBCMD_RESET, FALSE, Timeout);
 ON_EXIT:
-  DEBUG ((EFI_D_INFO, "XhcPeiResetHC: %r\n", Status));
+  DEBUG ((DEBUG_INFO, "XhcPeiResetHC: %r\n", Status));
   return Status;
 }
 
@@ -410,7 +410,7 @@ XhcPeiHaltHC (
 
   XhcPeiClearOpRegBit (Xhc, XHC_USBCMD_OFFSET, XHC_USBCMD_RUN);
   Status = XhcPeiWaitOpRegBit (Xhc, XHC_USBSTS_OFFSET, XHC_USBSTS_HALT, TRUE, Timeout);
-  DEBUG ((EFI_D_INFO, "XhcPeiHaltHC: %r\n", Status));
+  DEBUG ((DEBUG_INFO, "XhcPeiHaltHC: %r\n", Status));
   return Status;
 }
 
@@ -434,7 +434,7 @@ XhcPeiRunHC (
 
   XhcPeiSetOpRegBit (Xhc, XHC_USBCMD_OFFSET, XHC_USBCMD_RUN);
   Status = XhcPeiWaitOpRegBit (Xhc, XHC_USBSTS_OFFSET, XHC_USBSTS_HALT, FALSE, Timeout);
-  DEBUG ((EFI_D_INFO, "XhcPeiRunHC: %r\n", Status));
+  DEBUG ((DEBUG_INFO, "XhcPeiRunHC: %r\n", Status));
   return Status;
 }
 
@@ -544,7 +544,7 @@ XhcPeiControlTransfer (
   Len             = 0;
 
   if (XhcPeiIsHalt (Xhc) || XhcPeiIsSysError (Xhc)) {
-    DEBUG ((EFI_D_ERROR, "XhcPeiControlTransfer: HC is halted or has system error\n"));
+    DEBUG ((DEBUG_ERROR, "XhcPeiControlTransfer: HC is halted or has system error\n"));
     goto ON_EXIT;
   }
 
@@ -611,7 +611,7 @@ XhcPeiControlTransfer (
           );
 
   if (Urb == NULL) {
-    DEBUG ((EFI_D_ERROR, "XhcPeiControlTransfer: failed to create URB"));
+    DEBUG ((DEBUG_ERROR, "XhcPeiControlTransfer: failed to create URB"));
     Status = EFI_OUT_OF_RESOURCES;
     goto ON_EXIT;
   }
@@ -631,7 +631,7 @@ XhcPeiControlTransfer (
     //
     RecoveryStatus = XhcPeiDequeueTrbFromEndpoint(Xhc, Urb);
     if (EFI_ERROR(RecoveryStatus)) {
-      DEBUG((EFI_D_ERROR, "XhcPeiControlTransfer: XhcPeiDequeueTrbFromEndpoint failed\n"));
+      DEBUG((DEBUG_ERROR, "XhcPeiControlTransfer: XhcPeiDequeueTrbFromEndpoint failed\n"));
     }
     XhcPeiFreeUrb (Xhc, Urb);
     goto ON_EXIT;
@@ -641,7 +641,7 @@ XhcPeiControlTransfer (
     } else if ((*TransferResult == EFI_USB_ERR_STALL) || (*TransferResult == EFI_USB_ERR_BABBLE)) {
       RecoveryStatus = XhcPeiRecoverHaltedEndpoint(Xhc, Urb);
       if (EFI_ERROR (RecoveryStatus)) {
-        DEBUG ((EFI_D_ERROR, "XhcPeiControlTransfer: XhcPeiRecoverHaltedEndpoint failed\n"));
+        DEBUG ((DEBUG_ERROR, "XhcPeiControlTransfer: XhcPeiRecoverHaltedEndpoint failed\n"));
       }
       Status = EFI_DEVICE_ERROR;
       XhcPeiFreeUrb (Xhc, Urb);
@@ -718,7 +718,7 @@ XhcPeiControlTransfer (
         // Don't support multi-TT feature for super speed hub now.
         //
         MTT = 0;
-        DEBUG ((EFI_D_ERROR, "XHCI: Don't support multi-TT feature for Hub now. (force to disable MTT)\n"));
+        DEBUG ((DEBUG_ERROR, "XHCI: Don't support multi-TT feature for Hub now. (force to disable MTT)\n"));
       } else {
         MTT = 0;
       }
@@ -825,7 +825,7 @@ XhcPeiControlTransfer (
 ON_EXIT:
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "XhcPeiControlTransfer: error - %r, transfer - %x\n", Status, *TransferResult));
+    DEBUG ((DEBUG_ERROR, "XhcPeiControlTransfer: error - %r, transfer - %x\n", Status, *TransferResult));
   }
 
   return Status;
@@ -911,7 +911,7 @@ XhcPeiBulkTransfer (
   Status          = EFI_DEVICE_ERROR;
 
   if (XhcPeiIsHalt (Xhc) || XhcPeiIsSysError (Xhc)) {
-    DEBUG ((EFI_D_ERROR, "XhcPeiBulkTransfer: HC is halted or has system error\n"));
+    DEBUG ((DEBUG_ERROR, "XhcPeiBulkTransfer: HC is halted or has system error\n"));
     goto ON_EXIT;
   }
 
@@ -942,7 +942,7 @@ XhcPeiBulkTransfer (
           );
 
   if (Urb == NULL) {
-    DEBUG ((EFI_D_ERROR, "XhcPeiBulkTransfer: failed to create URB\n"));
+    DEBUG ((DEBUG_ERROR, "XhcPeiBulkTransfer: failed to create URB\n"));
     Status = EFI_OUT_OF_RESOURCES;
     goto ON_EXIT;
   }
@@ -958,7 +958,7 @@ XhcPeiBulkTransfer (
     //
     RecoveryStatus = XhcPeiDequeueTrbFromEndpoint(Xhc, Urb);
     if (EFI_ERROR(RecoveryStatus)) {
-      DEBUG((EFI_D_ERROR, "XhcPeiBulkTransfer: XhcPeiDequeueTrbFromEndpoint failed\n"));
+      DEBUG((DEBUG_ERROR, "XhcPeiBulkTransfer: XhcPeiDequeueTrbFromEndpoint failed\n"));
     }
   } else {
     if (*TransferResult == EFI_USB_NOERROR) {
@@ -966,7 +966,7 @@ XhcPeiBulkTransfer (
     } else if ((*TransferResult == EFI_USB_ERR_STALL) || (*TransferResult == EFI_USB_ERR_BABBLE)) {
       RecoveryStatus = XhcPeiRecoverHaltedEndpoint(Xhc, Urb);
       if (EFI_ERROR (RecoveryStatus)) {
-        DEBUG ((EFI_D_ERROR, "XhcPeiBulkTransfer: XhcPeiRecoverHaltedEndpoint failed\n"));
+        DEBUG ((DEBUG_ERROR, "XhcPeiBulkTransfer: XhcPeiRecoverHaltedEndpoint failed\n"));
       }
       Status = EFI_DEVICE_ERROR;
     }
@@ -977,7 +977,7 @@ XhcPeiBulkTransfer (
 ON_EXIT:
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "XhcPeiBulkTransfer: error - %r, transfer - %x\n", Status, *TransferResult));
+    DEBUG ((DEBUG_ERROR, "XhcPeiBulkTransfer: error - %r, transfer - %x\n", Status, *TransferResult));
   }
 
   return Status;
@@ -1011,7 +1011,7 @@ XhcPeiGetRootHubPortNumber (
   }
 
   *PortNumber = XhcDev->HcSParams1.Data.MaxPorts;
-  DEBUG ((EFI_D_INFO, "XhcPeiGetRootHubPortNumber: PortNumber = %x\n", *PortNumber));
+  DEBUG ((DEBUG_INFO, "XhcPeiGetRootHubPortNumber: PortNumber = %x\n", *PortNumber));
   return EFI_SUCCESS;
 }
 
@@ -1054,7 +1054,7 @@ XhcPeiClearRootHubPortFeature (
 
   Offset = (UINT32) (XHC_PORTSC_OFFSET + (0x10 * PortNumber));
   State = XhcPeiReadOpReg (Xhc, Offset);
-  DEBUG ((EFI_D_INFO, "XhcPeiClearRootHubPortFeature: Port: %x State: %x\n", PortNumber, State));
+  DEBUG ((DEBUG_INFO, "XhcPeiClearRootHubPortFeature: Port: %x State: %x\n", PortNumber, State));
 
   //
   // Mask off the port status change bits, these bits are
@@ -1148,7 +1148,7 @@ XhcPeiClearRootHubPortFeature (
   }
 
 ON_EXIT:
-  DEBUG ((EFI_D_INFO, "XhcPeiClearRootHubPortFeature: PortFeature: %x Status = %r\n", PortFeature, Status));
+  DEBUG ((DEBUG_INFO, "XhcPeiClearRootHubPortFeature: PortFeature: %x Status = %r\n", PortFeature, Status));
   return Status;
 }
 
@@ -1189,7 +1189,7 @@ XhcPeiSetRootHubPortFeature (
 
   Offset = (UINT32) (XHC_PORTSC_OFFSET + (0x10 * PortNumber));
   State = XhcPeiReadOpReg (Xhc, Offset);
-  DEBUG ((EFI_D_INFO, "XhcPeiSetRootHubPortFeature: Port: %x State: %x\n", PortNumber, State));
+  DEBUG ((DEBUG_INFO, "XhcPeiSetRootHubPortFeature: Port: %x State: %x\n", PortNumber, State));
 
   //
   // Mask off the port status change bits, these bits are
@@ -1256,7 +1256,7 @@ XhcPeiSetRootHubPortFeature (
   }
 
 ON_EXIT:
-  DEBUG ((EFI_D_INFO, "XhcPeiSetRootHubPortFeature: PortFeature: %x Status = %r\n", PortFeature, Status));
+  DEBUG ((DEBUG_INFO, "XhcPeiSetRootHubPortFeature: PortFeature: %x Status = %r\n", PortFeature, Status));
   return Status;
 }
 
@@ -1307,7 +1307,7 @@ XhcPeiGetRootHubPortStatus (
 
   Offset                        = (UINT32) (XHC_PORTSC_OFFSET + (0x10 * PortNumber));
   State                         = XhcPeiReadOpReg (Xhc, Offset);
-  DEBUG ((EFI_D_INFO, "XhcPeiGetRootHubPortStatus: Port: %x State: %x\n", PortNumber, State));
+  DEBUG ((DEBUG_INFO, "XhcPeiGetRootHubPortStatus: Port: %x State: %x\n", PortNumber, State));
 
   //
   // According to XHCI 1.1 spec November 2017,
@@ -1371,7 +1371,7 @@ XhcPeiGetRootHubPortStatus (
   ParentRouteChart.Dword = 0;
   XhcPeiPollPortStatusChange (Xhc, ParentRouteChart, PortNumber, PortStatus);
 
-  DEBUG ((EFI_D_INFO, "XhcPeiGetRootHubPortStatus: PortChangeStatus: %x PortStatus: %x\n", PortStatus->PortChangeStatus, PortStatus->PortStatus));
+  DEBUG ((DEBUG_INFO, "XhcPeiGetRootHubPortStatus: PortChangeStatus: %x PortStatus: %x\n", PortStatus->PortChangeStatus, PortStatus->PortStatus));
   return EFI_SUCCESS;
 }
 
@@ -1501,14 +1501,14 @@ XhcPeimEntry (
     PageSize         = XhcPeiReadOpReg (XhcDev, XHC_PAGESIZE_OFFSET) & XHC_PAGESIZE_MASK;
     XhcDev->PageSize = 1 << (HighBitSet32 (PageSize) + 12);
 
-    DEBUG ((EFI_D_INFO, "XhciPei: UsbHostControllerBaseAddress: %x\n", XhcDev->UsbHostControllerBaseAddress));
-    DEBUG ((EFI_D_INFO, "XhciPei: CapLength:                    %x\n", XhcDev->CapLength));
-    DEBUG ((EFI_D_INFO, "XhciPei: HcSParams1:                   %x\n", XhcDev->HcSParams1.Dword));
-    DEBUG ((EFI_D_INFO, "XhciPei: HcSParams2:                   %x\n", XhcDev->HcSParams2.Dword));
-    DEBUG ((EFI_D_INFO, "XhciPei: HcCParams:                    %x\n", XhcDev->HcCParams.Dword));
-    DEBUG ((EFI_D_INFO, "XhciPei: DBOff:                        %x\n", XhcDev->DBOff));
-    DEBUG ((EFI_D_INFO, "XhciPei: RTSOff:                       %x\n", XhcDev->RTSOff));
-    DEBUG ((EFI_D_INFO, "XhciPei: PageSize:                     %x\n", XhcDev->PageSize));
+    DEBUG ((DEBUG_INFO, "XhciPei: UsbHostControllerBaseAddress: %x\n", XhcDev->UsbHostControllerBaseAddress));
+    DEBUG ((DEBUG_INFO, "XhciPei: CapLength:                    %x\n", XhcDev->CapLength));
+    DEBUG ((DEBUG_INFO, "XhciPei: HcSParams1:                   %x\n", XhcDev->HcSParams1.Dword));
+    DEBUG ((DEBUG_INFO, "XhciPei: HcSParams2:                   %x\n", XhcDev->HcSParams2.Dword));
+    DEBUG ((DEBUG_INFO, "XhciPei: HcCParams:                    %x\n", XhcDev->HcCParams.Dword));
+    DEBUG ((DEBUG_INFO, "XhciPei: DBOff:                        %x\n", XhcDev->DBOff));
+    DEBUG ((DEBUG_INFO, "XhciPei: RTSOff:                       %x\n", XhcDev->RTSOff));
+    DEBUG ((DEBUG_INFO, "XhciPei: PageSize:                     %x\n", XhcDev->PageSize));
 
     XhcPeiResetHC (XhcDev, XHC_RESET_TIMEOUT);
     ASSERT (XhcPeiIsHalt (XhcDev));
@@ -1551,4 +1551,3 @@ XhcPeimEntry (
 
   return EFI_SUCCESS;
 }
-

--- a/MdeModulePkg/Bus/Pci/XhciPei/XhciSched.c
+++ b/MdeModulePkg/Bus/Pci/XhciPei/XhciSched.c
@@ -81,7 +81,7 @@ XhcPeiCmdTransfer (
   Status = EFI_DEVICE_ERROR;
 
   if (XhcPeiIsHalt (Xhc) || XhcPeiIsSysError (Xhc)) {
-    DEBUG ((EFI_D_ERROR, "XhcPeiCmdTransfer: HC is halted or has system error\n"));
+    DEBUG ((DEBUG_ERROR, "XhcPeiCmdTransfer: HC is halted or has system error\n"));
     goto ON_EXIT;
   }
 
@@ -90,7 +90,7 @@ XhcPeiCmdTransfer (
   //
   Urb = XhcPeiCreateCmdTrb (Xhc, CmdTrb);
   if (Urb == NULL) {
-    DEBUG ((EFI_D_ERROR, "XhcPeiCmdTransfer: failed to create URB\n"));
+    DEBUG ((DEBUG_ERROR, "XhcPeiCmdTransfer: failed to create URB\n"));
     Status = EFI_OUT_OF_RESOURCES;
     goto ON_EXIT;
   }
@@ -168,7 +168,7 @@ XhcPeiCreateUrb (
 
   Status = XhcPeiCreateTransferTrb (Xhc, Urb);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "XhcPeiCreateUrb: XhcPeiCreateTransferTrb Failed, Status = %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "XhcPeiCreateUrb: XhcPeiCreateTransferTrb Failed, Status = %r\n", Status));
     FreePool (Urb);
     Urb = NULL;
   }
@@ -439,7 +439,7 @@ XhcPeiCreateTransferTrb (
       break;
 
     default:
-      DEBUG ((EFI_D_INFO, "Not supported EPType 0x%x!\n",EPType));
+      DEBUG ((DEBUG_INFO, "Not supported EPType 0x%x!\n",EPType));
       ASSERT (FALSE);
       break;
   }
@@ -478,14 +478,14 @@ XhcPeiRecoverHaltedEndpoint (
   }
   Dci = XhcPeiEndpointToDci (Urb->Ep.EpAddr, (UINT8) (Urb->Ep.Direction));
 
-  DEBUG ((EFI_D_INFO, "XhcPeiRecoverHaltedEndpoint: Recovery Halted Slot = %x, Dci = %x\n", SlotId, Dci));
+  DEBUG ((DEBUG_INFO, "XhcPeiRecoverHaltedEndpoint: Recovery Halted Slot = %x, Dci = %x\n", SlotId, Dci));
 
   //
   // 1) Send Reset endpoint command to transit from halt to stop state
   //
   Status = XhcPeiResetEndpoint (Xhc, SlotId, Dci);
   if (EFI_ERROR(Status)) {
-    DEBUG ((EFI_D_ERROR, "XhcPeiRecoverHaltedEndpoint: Reset Endpoint Failed, Status = %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "XhcPeiRecoverHaltedEndpoint: Reset Endpoint Failed, Status = %r\n", Status));
     goto Done;
   }
 
@@ -494,7 +494,7 @@ XhcPeiRecoverHaltedEndpoint (
   //
   Status = XhcPeiSetTrDequeuePointer (Xhc, SlotId, Dci, Urb);
   if (EFI_ERROR(Status)) {
-    DEBUG ((EFI_D_ERROR, "XhcPeiRecoverHaltedEndpoint: Set Dequeue Pointer Failed, Status = %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "XhcPeiRecoverHaltedEndpoint: Set Dequeue Pointer Failed, Status = %r\n", Status));
     goto Done;
   }
 
@@ -537,14 +537,14 @@ XhcPeiDequeueTrbFromEndpoint (
   }
   Dci = XhcPeiEndpointToDci (Urb->Ep.EpAddr, (UINT8) (Urb->Ep.Direction));
 
-  DEBUG ((EFI_D_INFO, "XhcPeiDequeueTrbFromEndpoint: Stop Slot = %x, Dci = %x\n", SlotId, Dci));
+  DEBUG ((DEBUG_INFO, "XhcPeiDequeueTrbFromEndpoint: Stop Slot = %x, Dci = %x\n", SlotId, Dci));
 
   //
   // 1) Send Stop endpoint command to stop endpoint.
   //
   Status = XhcPeiStopEndpoint (Xhc, SlotId, Dci);
   if (EFI_ERROR(Status)) {
-    DEBUG ((EFI_D_ERROR, "XhcPeiDequeueTrbFromEndpoint: Stop Endpoint Failed, Status = %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "XhcPeiDequeueTrbFromEndpoint: Stop Endpoint Failed, Status = %r\n", Status));
     goto Done;
   }
 
@@ -553,7 +553,7 @@ XhcPeiDequeueTrbFromEndpoint (
   //
   Status = XhcPeiSetTrDequeuePointer (Xhc, SlotId, Dci, Urb);
   if (EFI_ERROR(Status)) {
-    DEBUG ((EFI_D_ERROR, "XhcPeiDequeueTrbFromEndpoint: Set Dequeue Pointer Failed, Status = %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "XhcPeiDequeueTrbFromEndpoint: Set Dequeue Pointer Failed, Status = %r\n", Status));
     goto Done;
   }
 
@@ -683,31 +683,31 @@ XhcPeiCheckUrbResult (
       case TRB_COMPLETION_STALL_ERROR:
         CheckedUrb->Result  |= EFI_USB_ERR_STALL;
         CheckedUrb->Finished = TRUE;
-        DEBUG ((EFI_D_ERROR, "XhcPeiCheckUrbResult: STALL_ERROR! Completecode = %x\n", EvtTrb->Completecode));
+        DEBUG ((DEBUG_ERROR, "XhcPeiCheckUrbResult: STALL_ERROR! Completecode = %x\n", EvtTrb->Completecode));
         goto EXIT;
 
       case TRB_COMPLETION_BABBLE_ERROR:
         CheckedUrb->Result  |= EFI_USB_ERR_BABBLE;
         CheckedUrb->Finished = TRUE;
-        DEBUG ((EFI_D_ERROR, "XhcPeiCheckUrbResult: BABBLE_ERROR! Completecode = %x\n", EvtTrb->Completecode));
+        DEBUG ((DEBUG_ERROR, "XhcPeiCheckUrbResult: BABBLE_ERROR! Completecode = %x\n", EvtTrb->Completecode));
         goto EXIT;
 
       case TRB_COMPLETION_DATA_BUFFER_ERROR:
         CheckedUrb->Result  |= EFI_USB_ERR_BUFFER;
         CheckedUrb->Finished = TRUE;
-        DEBUG ((EFI_D_ERROR, "XhcPeiCheckUrbResult: ERR_BUFFER! Completecode = %x\n", EvtTrb->Completecode));
+        DEBUG ((DEBUG_ERROR, "XhcPeiCheckUrbResult: ERR_BUFFER! Completecode = %x\n", EvtTrb->Completecode));
         goto EXIT;
 
       case TRB_COMPLETION_USB_TRANSACTION_ERROR:
         CheckedUrb->Result  |= EFI_USB_ERR_TIMEOUT;
         CheckedUrb->Finished = TRUE;
-        DEBUG ((EFI_D_ERROR, "XhcPeiCheckUrbResult: TRANSACTION_ERROR! Completecode = %x\n", EvtTrb->Completecode));
+        DEBUG ((DEBUG_ERROR, "XhcPeiCheckUrbResult: TRANSACTION_ERROR! Completecode = %x\n", EvtTrb->Completecode));
         goto EXIT;
 
       case TRB_COMPLETION_SHORT_PACKET:
       case TRB_COMPLETION_SUCCESS:
         if (EvtTrb->Completecode == TRB_COMPLETION_SHORT_PACKET) {
-          DEBUG ((EFI_D_VERBOSE, "XhcPeiCheckUrbResult: short packet happens!\n"));
+          DEBUG ((DEBUG_VERBOSE, "XhcPeiCheckUrbResult: short packet happens!\n"));
         }
 
         TRBType = (UINT8) (TRBPtr->Type);
@@ -720,7 +720,7 @@ XhcPeiCheckUrbResult (
         break;
 
       default:
-        DEBUG ((EFI_D_ERROR, "XhcPeiCheckUrbResult: Transfer Default Error Occur! Completecode = 0x%x!\n", EvtTrb->Completecode));
+        DEBUG ((DEBUG_ERROR, "XhcPeiCheckUrbResult: Transfer Default Error Occur! Completecode = 0x%x!\n", EvtTrb->Completecode));
         CheckedUrb->Result  |= EFI_USB_ERR_TIMEOUT;
         CheckedUrb->Finished = TRUE;
         goto EXIT;
@@ -859,7 +859,7 @@ XhcPeiPollPortStatusChange (
   UINT8             SlotId;
   USB_DEV_ROUTE     RouteChart;
 
-  DEBUG ((EFI_D_INFO, "XhcPeiPollPortStatusChange: PortChangeStatus: %x PortStatus: %x\n", PortState->PortChangeStatus, PortState->PortStatus));
+  DEBUG ((DEBUG_INFO, "XhcPeiPollPortStatusChange: PortChangeStatus: %x PortStatus: %x\n", PortState->PortChangeStatus, PortState->PortStatus));
 
   Status = EFI_SUCCESS;
 
@@ -1081,11 +1081,11 @@ XhcPeiInitializeDeviceSlot (
              (TRB_TEMPLATE **) (UINTN) &EvtTrb
              );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "XhcPeiInitializeDeviceSlot: Enable Slot Failed, Status = %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "XhcPeiInitializeDeviceSlot: Enable Slot Failed, Status = %r\n", Status));
     return Status;
   }
   ASSERT (EvtTrb->SlotId <= Xhc->MaxSlotsEn);
-  DEBUG ((EFI_D_INFO, "XhcPeiInitializeDeviceSlot: Enable Slot Successfully, The Slot ID = 0x%x\n", EvtTrb->SlotId));
+  DEBUG ((DEBUG_INFO, "XhcPeiInitializeDeviceSlot: Enable Slot Successfully, The Slot ID = 0x%x\n", EvtTrb->SlotId));
   SlotId = (UINT8) EvtTrb->SlotId;
   ASSERT (SlotId != 0);
 
@@ -1238,11 +1238,11 @@ XhcPeiInitializeDeviceSlot (
              );
   if (!EFI_ERROR (Status)) {
     DeviceAddress = (UINT8) OutputContext->Slot.DeviceAddress;
-    DEBUG ((EFI_D_INFO, "XhcPeiInitializeDeviceSlot: Address %d assigned successfully\n", DeviceAddress));
+    DEBUG ((DEBUG_INFO, "XhcPeiInitializeDeviceSlot: Address %d assigned successfully\n", DeviceAddress));
     Xhc->UsbDevContext[SlotId].XhciDevAddr = DeviceAddress;
   }
 
-  DEBUG ((EFI_D_INFO, "XhcPeiInitializeDeviceSlot: Enable Slot, Status = %r\n", Status));
+  DEBUG ((DEBUG_INFO, "XhcPeiInitializeDeviceSlot: Enable Slot, Status = %r\n", Status));
   return Status;
 }
 
@@ -1292,11 +1292,11 @@ XhcPeiInitializeDeviceSlot64 (
              (TRB_TEMPLATE **) (UINTN) &EvtTrb
              );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "XhcPeiInitializeDeviceSlot64: Enable Slot Failed, Status = %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "XhcPeiInitializeDeviceSlot64: Enable Slot Failed, Status = %r\n", Status));
     return Status;
   }
   ASSERT (EvtTrb->SlotId <= Xhc->MaxSlotsEn);
-  DEBUG ((EFI_D_INFO, "XhcPeiInitializeDeviceSlot64: Enable Slot Successfully, The Slot ID = 0x%x\n", EvtTrb->SlotId));
+  DEBUG ((DEBUG_INFO, "XhcPeiInitializeDeviceSlot64: Enable Slot Successfully, The Slot ID = 0x%x\n", EvtTrb->SlotId));
   SlotId = (UINT8)EvtTrb->SlotId;
   ASSERT (SlotId != 0);
 
@@ -1449,11 +1449,11 @@ XhcPeiInitializeDeviceSlot64 (
              );
   if (!EFI_ERROR (Status)) {
     DeviceAddress = (UINT8) OutputContext->Slot.DeviceAddress;
-    DEBUG ((EFI_D_INFO, "XhcPeiInitializeDeviceSlot64: Address %d assigned successfully\n", DeviceAddress));
+    DEBUG ((DEBUG_INFO, "XhcPeiInitializeDeviceSlot64: Address %d assigned successfully\n", DeviceAddress));
     Xhc->UsbDevContext[SlotId].XhciDevAddr = DeviceAddress;
   }
 
-  DEBUG ((EFI_D_INFO, "XhcPeiInitializeDeviceSlot64: Enable Slot, Status = %r\n", Status));
+  DEBUG ((DEBUG_INFO, "XhcPeiInitializeDeviceSlot64: Enable Slot, Status = %r\n", Status));
   return Status;
 }
 
@@ -1493,7 +1493,7 @@ XhcPeiDisableSlotCmd (
     Status = XhcPeiDisableSlotCmd (Xhc, Xhc->UsbDevContext[Index + 1].SlotId);
 
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "XhcPeiDisableSlotCmd: failed to disable child, ignore error\n"));
+      DEBUG ((DEBUG_ERROR, "XhcPeiDisableSlotCmd: failed to disable child, ignore error\n"));
       Xhc->UsbDevContext[Index + 1].SlotId = 0;
     }
   }
@@ -1501,7 +1501,7 @@ XhcPeiDisableSlotCmd (
   //
   // Construct the disable slot command
   //
-  DEBUG ((EFI_D_INFO, "XhcPeiDisableSlotCmd: Disable device slot %d!\n", SlotId));
+  DEBUG ((DEBUG_INFO, "XhcPeiDisableSlotCmd: Disable device slot %d!\n", SlotId));
 
   ZeroMem (&CmdTrbDisSlot, sizeof (CmdTrbDisSlot));
   CmdTrbDisSlot.CycleBit = 1;
@@ -1514,7 +1514,7 @@ XhcPeiDisableSlotCmd (
              (TRB_TEMPLATE **) (UINTN) &EvtTrb
              );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "XhcPeiDisableSlotCmd: Disable Slot Command Failed, Status = %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "XhcPeiDisableSlotCmd: Disable Slot Command Failed, Status = %r\n", Status));
     return Status;
   }
   //
@@ -1557,7 +1557,7 @@ XhcPeiDisableSlotCmd (
   Xhc->UsbDevContext[SlotId].Enabled = FALSE;
   Xhc->UsbDevContext[SlotId].SlotId  = 0;
 
-  DEBUG ((EFI_D_INFO, "XhcPeiDisableSlotCmd: Disable Slot Command, Status = %r\n", Status));
+  DEBUG ((DEBUG_INFO, "XhcPeiDisableSlotCmd: Disable Slot Command, Status = %r\n", Status));
   return Status;
 }
 
@@ -1596,7 +1596,7 @@ XhcPeiDisableSlotCmd64 (
     Status = XhcPeiDisableSlotCmd64 (Xhc, Xhc->UsbDevContext[Index + 1].SlotId);
 
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "XhcPeiDisableSlotCmd64: failed to disable child, ignore error\n"));
+      DEBUG ((DEBUG_ERROR, "XhcPeiDisableSlotCmd64: failed to disable child, ignore error\n"));
       Xhc->UsbDevContext[Index + 1].SlotId = 0;
     }
   }
@@ -1604,7 +1604,7 @@ XhcPeiDisableSlotCmd64 (
   //
   // Construct the disable slot command
   //
-  DEBUG ((EFI_D_INFO, "XhcPeiDisableSlotCmd64: Disable device slot %d!\n", SlotId));
+  DEBUG ((DEBUG_INFO, "XhcPeiDisableSlotCmd64: Disable device slot %d!\n", SlotId));
 
   ZeroMem (&CmdTrbDisSlot, sizeof (CmdTrbDisSlot));
   CmdTrbDisSlot.CycleBit = 1;
@@ -1617,7 +1617,7 @@ XhcPeiDisableSlotCmd64 (
              (TRB_TEMPLATE **) (UINTN) &EvtTrb
              );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "XhcPeiDisableSlotCmd64: Disable Slot Command Failed, Status = %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "XhcPeiDisableSlotCmd64: Disable Slot Command Failed, Status = %r\n", Status));
     return Status;
   }
   //
@@ -1660,7 +1660,7 @@ XhcPeiDisableSlotCmd64 (
   Xhc->UsbDevContext[SlotId].Enabled = FALSE;
   Xhc->UsbDevContext[SlotId].SlotId  = 0;
 
-  DEBUG ((EFI_D_INFO, "XhcPeiDisableSlotCmd64: Disable Slot Command, Status = %r\n", Status));
+  DEBUG ((DEBUG_INFO, "XhcPeiDisableSlotCmd64: Disable Slot Command, Status = %r\n", Status));
   return Status;
 }
 
@@ -1790,7 +1790,7 @@ XhcPeiSetConfigCmd (
           //
           // Do not support isochronous transfer now.
           //
-          DEBUG ((EFI_D_INFO, "XhcPeiSetConfigCmd: Unsupport ISO EP found, Transfer ring is not allocated.\n"));
+          DEBUG ((DEBUG_INFO, "XhcPeiSetConfigCmd: Unsupport ISO EP found, Transfer ring is not allocated.\n"));
           EpDesc = (USB_ENDPOINT_DESCRIPTOR *)((UINTN)EpDesc + EpDesc->Length);
           continue;
         case USB_ENDPOINT_INTERRUPT:
@@ -1833,9 +1833,9 @@ XhcPeiSetConfigCmd (
           //
           // Do not support control transfer now.
           //
-          DEBUG ((EFI_D_INFO, "XhcPeiSetConfigCmd: Unsupport Control EP found, Transfer ring is not allocated.\n"));
+          DEBUG ((DEBUG_INFO, "XhcPeiSetConfigCmd: Unsupport Control EP found, Transfer ring is not allocated.\n"));
         default:
-          DEBUG ((EFI_D_INFO, "XhcPeiSetConfigCmd: Unknown EP found, Transfer ring is not allocated.\n"));
+          DEBUG ((DEBUG_INFO, "XhcPeiSetConfigCmd: Unknown EP found, Transfer ring is not allocated.\n"));
           EpDesc = (USB_ENDPOINT_DESCRIPTOR *)((UINTN)EpDesc + EpDesc->Length);
           continue;
       }
@@ -1867,7 +1867,7 @@ XhcPeiSetConfigCmd (
   CmdTrbCfgEP.CycleBit = 1;
   CmdTrbCfgEP.Type     = TRB_TYPE_CON_ENDPOINT;
   CmdTrbCfgEP.SlotId   = Xhc->UsbDevContext[SlotId].SlotId;
-  DEBUG ((EFI_D_INFO, "XhcSetConfigCmd: Configure Endpoint\n"));
+  DEBUG ((DEBUG_INFO, "XhcSetConfigCmd: Configure Endpoint\n"));
   Status = XhcPeiCmdTransfer (
              Xhc,
              (TRB_TEMPLATE *) (UINTN) &CmdTrbCfgEP,
@@ -1875,7 +1875,7 @@ XhcPeiSetConfigCmd (
              (TRB_TEMPLATE **) (UINTN) &EvtTrb
              );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "XhcSetConfigCmd: Config Endpoint Failed, Status = %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "XhcSetConfigCmd: Config Endpoint Failed, Status = %r\n", Status));
   }
   return Status;
 }
@@ -2007,7 +2007,7 @@ XhcPeiSetConfigCmd64 (
           //
           // Do not support isochronous transfer now.
           //
-          DEBUG ((EFI_D_INFO, "XhcPeiSetConfigCmd64: Unsupport ISO EP found, Transfer ring is not allocated.\n"));
+          DEBUG ((DEBUG_INFO, "XhcPeiSetConfigCmd64: Unsupport ISO EP found, Transfer ring is not allocated.\n"));
           EpDesc = (USB_ENDPOINT_DESCRIPTOR *)((UINTN)EpDesc + EpDesc->Length);
           continue;
         case USB_ENDPOINT_INTERRUPT:
@@ -2050,9 +2050,9 @@ XhcPeiSetConfigCmd64 (
           //
           // Do not support control transfer now.
           //
-          DEBUG ((EFI_D_INFO, "XhcPeiSetConfigCmd64: Unsupport Control EP found, Transfer ring is not allocated.\n"));
+          DEBUG ((DEBUG_INFO, "XhcPeiSetConfigCmd64: Unsupport Control EP found, Transfer ring is not allocated.\n"));
         default:
-          DEBUG ((EFI_D_INFO, "XhcPeiSetConfigCmd64: Unknown EP found, Transfer ring is not allocated.\n"));
+          DEBUG ((DEBUG_INFO, "XhcPeiSetConfigCmd64: Unknown EP found, Transfer ring is not allocated.\n"));
           EpDesc = (USB_ENDPOINT_DESCRIPTOR *)((UINTN)EpDesc + EpDesc->Length);
           continue;
       }
@@ -2086,7 +2086,7 @@ XhcPeiSetConfigCmd64 (
   CmdTrbCfgEP.CycleBit = 1;
   CmdTrbCfgEP.Type     = TRB_TYPE_CON_ENDPOINT;
   CmdTrbCfgEP.SlotId   = Xhc->UsbDevContext[SlotId].SlotId;
-  DEBUG ((EFI_D_INFO, "XhcSetConfigCmd64: Configure Endpoint\n"));
+  DEBUG ((DEBUG_INFO, "XhcSetConfigCmd64: Configure Endpoint\n"));
   Status = XhcPeiCmdTransfer (
              Xhc,
              (TRB_TEMPLATE *) (UINTN) &CmdTrbCfgEP,
@@ -2094,7 +2094,7 @@ XhcPeiSetConfigCmd64 (
              (TRB_TEMPLATE **) (UINTN) &EvtTrb
              );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "XhcSetConfigCmd64: Config Endpoint Failed, Status = %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "XhcSetConfigCmd64: Config Endpoint Failed, Status = %r\n", Status));
   }
 
   return Status;
@@ -2142,7 +2142,7 @@ XhcPeiEvaluateContext (
   CmdTrbEvalu.CycleBit = 1;
   CmdTrbEvalu.Type     = TRB_TYPE_EVALU_CONTXT;
   CmdTrbEvalu.SlotId   = Xhc->UsbDevContext[SlotId].SlotId;
-  DEBUG ((EFI_D_INFO, "XhcEvaluateContext: Evaluate context\n"));
+  DEBUG ((DEBUG_INFO, "XhcEvaluateContext: Evaluate context\n"));
   Status = XhcPeiCmdTransfer (
              Xhc,
              (TRB_TEMPLATE *) (UINTN) &CmdTrbEvalu,
@@ -2150,7 +2150,7 @@ XhcPeiEvaluateContext (
              (TRB_TEMPLATE **) (UINTN) &EvtTrb
              );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "XhcEvaluateContext: Evaluate Context Failed, Status = %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "XhcEvaluateContext: Evaluate Context Failed, Status = %r\n", Status));
   }
   return Status;
 }
@@ -2196,7 +2196,7 @@ XhcPeiEvaluateContext64 (
   CmdTrbEvalu.CycleBit = 1;
   CmdTrbEvalu.Type     = TRB_TYPE_EVALU_CONTXT;
   CmdTrbEvalu.SlotId   = Xhc->UsbDevContext[SlotId].SlotId;
-  DEBUG ((EFI_D_INFO, "XhcEvaluateContext64: Evaluate context 64\n"));
+  DEBUG ((DEBUG_INFO, "XhcEvaluateContext64: Evaluate context 64\n"));
   Status = XhcPeiCmdTransfer (
              Xhc,
              (TRB_TEMPLATE *) (UINTN) &CmdTrbEvalu,
@@ -2204,7 +2204,7 @@ XhcPeiEvaluateContext64 (
              (TRB_TEMPLATE **) (UINTN) &EvtTrb
              );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "XhcEvaluateContext64: Evaluate Context Failed, Status = %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "XhcEvaluateContext64: Evaluate Context Failed, Status = %r\n", Status));
   }
   return Status;
 }
@@ -2264,7 +2264,7 @@ XhcPeiConfigHubContext (
   CmdTrbCfgEP.CycleBit = 1;
   CmdTrbCfgEP.Type     = TRB_TYPE_CON_ENDPOINT;
   CmdTrbCfgEP.SlotId   = Xhc->UsbDevContext[SlotId].SlotId;
-  DEBUG ((EFI_D_INFO, "Configure Hub Slot Context\n"));
+  DEBUG ((DEBUG_INFO, "Configure Hub Slot Context\n"));
   Status = XhcPeiCmdTransfer (
              Xhc,
              (TRB_TEMPLATE *) (UINTN) &CmdTrbCfgEP,
@@ -2272,7 +2272,7 @@ XhcPeiConfigHubContext (
              (TRB_TEMPLATE **) (UINTN) &EvtTrb
              );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "XhcConfigHubContext: Config Endpoint Failed, Status = %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "XhcConfigHubContext: Config Endpoint Failed, Status = %r\n", Status));
   }
   return Status;
 }
@@ -2332,7 +2332,7 @@ XhcPeiConfigHubContext64 (
   CmdTrbCfgEP.CycleBit = 1;
   CmdTrbCfgEP.Type     = TRB_TYPE_CON_ENDPOINT;
   CmdTrbCfgEP.SlotId   = Xhc->UsbDevContext[SlotId].SlotId;
-  DEBUG ((EFI_D_INFO, "Configure Hub Slot Context 64\n"));
+  DEBUG ((DEBUG_INFO, "Configure Hub Slot Context 64\n"));
   Status = XhcPeiCmdTransfer (
              Xhc,
              (TRB_TEMPLATE *) (UINTN) &CmdTrbCfgEP,
@@ -2340,7 +2340,7 @@ XhcPeiConfigHubContext64 (
              (TRB_TEMPLATE **) (UINTN) &EvtTrb
              );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "XhcConfigHubContext64: Config Endpoint Failed, Status = %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "XhcConfigHubContext64: Config Endpoint Failed, Status = %r\n", Status));
   }
   return Status;
 }
@@ -2368,7 +2368,7 @@ XhcPeiStopEndpoint (
   EVT_TRB_COMMAND_COMPLETION    *EvtTrb;
   CMD_TRB_STOP_ENDPOINT         CmdTrbStopED;
 
-  DEBUG ((EFI_D_INFO, "XhcPeiStopEndpoint: Slot = 0x%x, Dci = 0x%x\n", SlotId, Dci));
+  DEBUG ((DEBUG_INFO, "XhcPeiStopEndpoint: Slot = 0x%x, Dci = 0x%x\n", SlotId, Dci));
 
   //
   // Send stop endpoint command to transit Endpoint from running to stop state
@@ -2385,7 +2385,7 @@ XhcPeiStopEndpoint (
              (TRB_TEMPLATE **) (UINTN) &EvtTrb
              );
   if (EFI_ERROR(Status)) {
-    DEBUG ((EFI_D_ERROR, "XhcPeiStopEndpoint: Stop Endpoint Failed, Status = %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "XhcPeiStopEndpoint: Stop Endpoint Failed, Status = %r\n", Status));
   }
 
   return Status;
@@ -2414,7 +2414,7 @@ XhcPeiResetEndpoint (
   EVT_TRB_COMMAND_COMPLETION  *EvtTrb;
   CMD_TRB_RESET_ENDPOINT      CmdTrbResetED;
 
-  DEBUG ((EFI_D_INFO, "XhcPeiResetEndpoint: Slot = 0x%x, Dci = 0x%x\n", SlotId, Dci));
+  DEBUG ((DEBUG_INFO, "XhcPeiResetEndpoint: Slot = 0x%x, Dci = 0x%x\n", SlotId, Dci));
 
   //
   // Send stop endpoint command to transit Endpoint from running to stop state
@@ -2431,7 +2431,7 @@ XhcPeiResetEndpoint (
              (TRB_TEMPLATE **) (UINTN) &EvtTrb
              );
   if (EFI_ERROR(Status)) {
-    DEBUG ((EFI_D_ERROR, "XhcPeiResetEndpoint: Reset Endpoint Failed, Status = %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "XhcPeiResetEndpoint: Reset Endpoint Failed, Status = %r\n", Status));
   }
 
   return Status;
@@ -2464,7 +2464,7 @@ XhcPeiSetTrDequeuePointer (
   CMD_SET_TR_DEQ_POINTER      CmdSetTRDeq;
   EFI_PHYSICAL_ADDRESS        PhyAddr;
 
-  DEBUG ((EFI_D_INFO, "XhcPeiSetTrDequeuePointer: Slot = 0x%x, Dci = 0x%x, Urb = 0x%x\n", SlotId, Dci, Urb));
+  DEBUG ((DEBUG_INFO, "XhcPeiSetTrDequeuePointer: Slot = 0x%x, Dci = 0x%x, Urb = 0x%x\n", SlotId, Dci, Urb));
 
   //
   // Send stop endpoint command to transit Endpoint from running to stop state
@@ -2484,7 +2484,7 @@ XhcPeiSetTrDequeuePointer (
              (TRB_TEMPLATE **) (UINTN) &EvtTrb
              );
   if (EFI_ERROR(Status)) {
-    DEBUG ((EFI_D_ERROR, "XhcPeiSetTrDequeuePointer: Set TR Dequeue Pointer Failed, Status = %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "XhcPeiSetTrDequeuePointer: Set TR Dequeue Pointer Failed, Status = %r\n", Status));
   }
 
   return Status;
@@ -2938,7 +2938,7 @@ XhcPeiInitSched (
   XhcPeiWriteOpReg (Xhc, XHC_DCBAAP_OFFSET, XHC_LOW_32BIT (DcbaaPhy));
   XhcPeiWriteOpReg (Xhc, XHC_DCBAAP_OFFSET + 4, XHC_HIGH_32BIT (DcbaaPhy));
 
-  DEBUG ((EFI_D_INFO, "XhcPeiInitSched:DCBAA=0x%x\n", Xhc->DCBAA));
+  DEBUG ((DEBUG_INFO, "XhcPeiInitSched:DCBAA=0x%x\n", Xhc->DCBAA));
 
   //
   // Define the Command Ring Dequeue Pointer by programming the Command Ring Control Register
@@ -2962,7 +2962,7 @@ XhcPeiInitSched (
   XhcPeiWriteOpReg (Xhc, XHC_CRCR_OFFSET, XHC_LOW_32BIT (CmdRingPhy));
   XhcPeiWriteOpReg (Xhc, XHC_CRCR_OFFSET + 4, XHC_HIGH_32BIT (CmdRingPhy));
 
-  DEBUG ((EFI_D_INFO, "XhcPeiInitSched:XHC_CRCR=0x%x\n", Xhc->CmdRing.RingSeg0));
+  DEBUG ((DEBUG_INFO, "XhcPeiInitSched:XHC_CRCR=0x%x\n", Xhc->CmdRing.RingSeg0));
 
   //
   // Disable the 'interrupter enable' bit in USB_CMD
@@ -2978,7 +2978,7 @@ XhcPeiInitSched (
   // Allocate EventRing for Cmd, Ctrl, Bulk, Interrupt, AsynInterrupt transfer
   //
   XhcPeiCreateEventRing (Xhc, &Xhc->EventRing);
-  DEBUG ((EFI_D_INFO, "XhcPeiInitSched:XHC_EVENTRING=0x%x\n", Xhc->EventRing.EventRingSeg0));
+  DEBUG ((DEBUG_INFO, "XhcPeiInitSched:XHC_EVENTRING=0x%x\n", Xhc->EventRing.EventRingSeg0));
 }
 
 /**
@@ -3031,4 +3031,3 @@ XhcPeiFreeSched (
     Xhc->MemPool = NULL;
   }
 }
-

--- a/MdeModulePkg/Bus/Scsi/ScsiDiskDxe/ScsiDisk.c
+++ b/MdeModulePkg/Bus/Scsi/ScsiDiskDxe/ScsiDisk.c
@@ -1420,7 +1420,7 @@ ScsiDiskAsyncUnmapNotify (
   Status = CheckHostAdapterStatus (CommandPacket->HostAdapterStatus);
   if (EFI_ERROR(Status)) {
     DEBUG ((
-      EFI_D_ERROR,
+      DEBUG_ERROR,
       "ScsiDiskAsyncUnmapNotify: Host adapter indicating error status 0x%x.\n",
       CommandPacket->HostAdapterStatus
       ));
@@ -1432,7 +1432,7 @@ ScsiDiskAsyncUnmapNotify (
   Status = CheckTargetStatus (CommandPacket->TargetStatus);
   if (EFI_ERROR(Status)) {
     DEBUG ((
-      EFI_D_ERROR,
+      DEBUG_ERROR,
       "ScsiDiskAsyncUnmapNotify: Target indicating error status 0x%x.\n",
       CommandPacket->HostAdapterStatus
       ));
@@ -1614,7 +1614,7 @@ ScsiDiskUnmap (
   Status = CheckHostAdapterStatus (CommandPacket->HostAdapterStatus);
   if (EFI_ERROR(Status)) {
     DEBUG ((
-      EFI_D_ERROR,
+      DEBUG_ERROR,
       "ScsiDiskUnmap: Host adapter indicating error status 0x%x.\n",
       CommandPacket->HostAdapterStatus
       ));
@@ -1626,7 +1626,7 @@ ScsiDiskUnmap (
   Status = CheckTargetStatus (CommandPacket->TargetStatus);
   if (EFI_ERROR(Status)) {
     DEBUG ((
-      EFI_D_ERROR,
+      DEBUG_ERROR,
       "ScsiDiskUnmap: Target indicating error status 0x%x.\n",
       CommandPacket->HostAdapterStatus
       ));
@@ -2510,7 +2510,7 @@ ScsiDiskInquiryDevice (
         // Sanity checks for coping with broken devices
         //
         if (PageLength > sizeof SupportedVpdPages->SupportedVpdPageList) {
-          DEBUG ((EFI_D_WARN,
+          DEBUG ((DEBUG_WARN,
             "%a: invalid PageLength (%u) in Supported VPD Pages page\n",
             __FUNCTION__, (UINT32)PageLength));
           PageLength = 0;
@@ -2519,7 +2519,7 @@ ScsiDiskInquiryDevice (
         if ((PageLength > 0) &&
             (SupportedVpdPages->SupportedVpdPageList[0] !=
              EFI_SCSI_PAGE_CODE_SUPPORTED_VPD)) {
-          DEBUG ((EFI_D_WARN,
+          DEBUG ((DEBUG_WARN,
             "%a: Supported VPD Pages page doesn't start with code 0x%02x\n",
             __FUNCTION__, EFI_SCSI_PAGE_CODE_SUPPORTED_VPD));
           PageLength = 0;
@@ -2535,7 +2535,7 @@ ScsiDiskInquiryDevice (
           if ((Index > 0) &&
               (SupportedVpdPages->SupportedVpdPageList[Index] <=
                SupportedVpdPages->SupportedVpdPageList[Index - 1])) {
-            DEBUG ((EFI_D_WARN,
+            DEBUG ((DEBUG_WARN,
               "%a: non-ascending code in Supported VPD Pages page @ %u\n",
               __FUNCTION__, Index));
             Index = 0;
@@ -2861,30 +2861,30 @@ DetectMediaParsingSenseKeys (
     ScsiDiskDevice->BlkIo.Media->MediaPresent = FALSE;
     ScsiDiskDevice->BlkIo.Media->LastBlock    = 0;
     *Action = ACTION_NO_ACTION;
-    DEBUG ((EFI_D_VERBOSE, "ScsiDisk: ScsiDiskIsNoMedia\n"));
+    DEBUG ((DEBUG_VERBOSE, "ScsiDisk: ScsiDiskIsNoMedia\n"));
     return EFI_SUCCESS;
   }
 
   if (ScsiDiskIsMediaChange (SenseData, NumberOfSenseKeys)) {
     ScsiDiskDevice->BlkIo.Media->MediaId++;
-    DEBUG ((EFI_D_VERBOSE, "ScsiDisk: ScsiDiskIsMediaChange!\n"));
+    DEBUG ((DEBUG_VERBOSE, "ScsiDisk: ScsiDiskIsMediaChange!\n"));
     return EFI_SUCCESS;
   }
 
   if (ScsiDiskIsResetBefore (SenseData, NumberOfSenseKeys)) {
     *Action = ACTION_RETRY_COMMAND_LATER;
-    DEBUG ((EFI_D_VERBOSE, "ScsiDisk: ScsiDiskIsResetBefore!\n"));
+    DEBUG ((DEBUG_VERBOSE, "ScsiDisk: ScsiDiskIsResetBefore!\n"));
     return EFI_SUCCESS;
   }
 
   if (ScsiDiskIsMediaError (SenseData, NumberOfSenseKeys)) {
-    DEBUG ((EFI_D_VERBOSE, "ScsiDisk: ScsiDiskIsMediaError\n"));
+    DEBUG ((DEBUG_VERBOSE, "ScsiDisk: ScsiDiskIsMediaError\n"));
     *Action = ACTION_RETRY_WITH_BACKOFF_ALGO;
     return EFI_DEVICE_ERROR;
   }
 
   if (ScsiDiskIsHardwareError (SenseData, NumberOfSenseKeys)) {
-    DEBUG ((EFI_D_VERBOSE, "ScsiDisk: ScsiDiskIsHardwareError\n"));
+    DEBUG ((DEBUG_VERBOSE, "ScsiDisk: ScsiDiskIsHardwareError\n"));
     *Action = ACTION_RETRY_WITH_BACKOFF_ALGO;
     return EFI_DEVICE_ERROR;
   }
@@ -2892,7 +2892,7 @@ DetectMediaParsingSenseKeys (
   if (!ScsiDiskIsDriveReady (SenseData, NumberOfSenseKeys, &RetryLater)) {
     if (RetryLater) {
       *Action = ACTION_RETRY_COMMAND_LATER;
-      DEBUG ((EFI_D_VERBOSE, "ScsiDisk: ScsiDiskDriveNotReady!\n"));
+      DEBUG ((DEBUG_VERBOSE, "ScsiDisk: ScsiDiskDriveNotReady!\n"));
       return EFI_SUCCESS;
     }
     *Action = ACTION_NO_ACTION;
@@ -2900,7 +2900,7 @@ DetectMediaParsingSenseKeys (
   }
 
   *Action = ACTION_RETRY_WITH_BACKOFF_ALGO;
-  DEBUG ((EFI_D_VERBOSE, "ScsiDisk: Sense Key = 0x%x ASC = 0x%x!\n", SenseData->Sense_Key, SenseData->Addnl_Sense_Code));
+  DEBUG ((DEBUG_VERBOSE, "ScsiDisk: Sense Key = 0x%x ASC = 0x%x!\n", SenseData->Sense_Key, SenseData->Addnl_Sense_Code));
   return EFI_SUCCESS;
 }
 
@@ -4206,7 +4206,7 @@ BackOff:
   }
 
   if ((TargetStatus == EFI_EXT_SCSI_STATUS_TARGET_CHECK_CONDITION) || (EFI_ERROR (ReturnStatus))) {
-    DEBUG ((EFI_D_ERROR, "ScsiDiskRead10: Check Condition happened!\n"));
+    DEBUG ((DEBUG_ERROR, "ScsiDiskRead10: Check Condition happened!\n"));
     Status = DetectMediaParsingSenseKeys (ScsiDiskDevice, ScsiDiskDevice->SenseData, SenseDataLength / sizeof (EFI_SCSI_SENSE_DATA), &Action);
     if (Action == ACTION_RETRY_COMMAND_LATER) {
       *NeedRetry = TRUE;
@@ -4330,7 +4330,7 @@ BackOff:
   }
 
   if ((TargetStatus == EFI_EXT_SCSI_STATUS_TARGET_CHECK_CONDITION) || (EFI_ERROR (ReturnStatus))) {
-    DEBUG ((EFI_D_ERROR, "ScsiDiskWrite10: Check Condition happened!\n"));
+    DEBUG ((DEBUG_ERROR, "ScsiDiskWrite10: Check Condition happened!\n"));
     Status = DetectMediaParsingSenseKeys (ScsiDiskDevice, ScsiDiskDevice->SenseData, SenseDataLength / sizeof (EFI_SCSI_SENSE_DATA), &Action);
     if (Action == ACTION_RETRY_COMMAND_LATER) {
       *NeedRetry = TRUE;
@@ -4453,7 +4453,7 @@ BackOff:
   }
 
   if ((TargetStatus == EFI_EXT_SCSI_STATUS_TARGET_CHECK_CONDITION) || (EFI_ERROR (ReturnStatus))) {
-    DEBUG ((EFI_D_ERROR, "ScsiDiskRead16: Check Condition happened!\n"));
+    DEBUG ((DEBUG_ERROR, "ScsiDiskRead16: Check Condition happened!\n"));
     Status = DetectMediaParsingSenseKeys (ScsiDiskDevice, ScsiDiskDevice->SenseData, SenseDataLength / sizeof (EFI_SCSI_SENSE_DATA), &Action);
     if (Action == ACTION_RETRY_COMMAND_LATER) {
       *NeedRetry = TRUE;
@@ -4577,7 +4577,7 @@ BackOff:
   }
 
   if ((TargetStatus == EFI_EXT_SCSI_STATUS_TARGET_CHECK_CONDITION) || (EFI_ERROR (ReturnStatus))) {
-    DEBUG ((EFI_D_ERROR, "ScsiDiskWrite16: Check Condition happened!\n"));
+    DEBUG ((DEBUG_ERROR, "ScsiDiskWrite16: Check Condition happened!\n"));
     Status = DetectMediaParsingSenseKeys (ScsiDiskDevice, ScsiDiskDevice->SenseData, SenseDataLength / sizeof (EFI_SCSI_SENSE_DATA), &Action);
     if (Action == ACTION_RETRY_COMMAND_LATER) {
       *NeedRetry = TRUE;
@@ -4686,7 +4686,7 @@ ScsiDiskNotify (
   }
 
   if (Request->TargetStatus == EFI_EXT_SCSI_STATUS_TARGET_CHECK_CONDITION) {
-    DEBUG ((EFI_D_ERROR, "ScsiDiskNotify: Check Condition happened!\n"));
+    DEBUG ((DEBUG_ERROR, "ScsiDiskNotify: Check Condition happened!\n"));
 
     Status = DetectMediaParsingSenseKeys (
                ScsiDiskDevice,
@@ -5948,7 +5948,7 @@ DetermineInstallEraseBlock (
     if (((CapacityData16->LowestAlignLogic2 & BIT7) == 0) ||
         ((CapacityData16->LowestAlignLogic2 & BIT6) == 0)) {
       DEBUG ((
-        EFI_D_VERBOSE,
+        DEBUG_VERBOSE,
         "ScsiDisk EraseBlock: Either TPE or TPRZ is not set: 0x%x.\n",
         CapacityData16->LowestAlignLogic2
         ));
@@ -5958,7 +5958,7 @@ DetermineInstallEraseBlock (
     }
   } else {
     DEBUG ((
-      EFI_D_VERBOSE,
+      DEBUG_VERBOSE,
       "ScsiDisk EraseBlock: ReadCapacity16 failed with status %r.\n",
       CommandStatus
       ));
@@ -5973,7 +5973,7 @@ DetermineInstallEraseBlock (
   if ((ScsiDiskDevice->UnmapInfo.MaxLbaCnt == 0) ||
       (ScsiDiskDevice->UnmapInfo.MaxBlkDespCnt == 0)) {
     DEBUG ((
-      EFI_D_VERBOSE,
+      DEBUG_VERBOSE,
       "ScsiDisk EraseBlock: The device server does not implement the UNMAP command.\n"
       ));
 

--- a/MdeModulePkg/Bus/Sd/EmmcBlockIoPei/EmmcBlockIoPei.c
+++ b/MdeModulePkg/Bus/Sd/EmmcBlockIoPei/EmmcBlockIoPei.c
@@ -741,7 +741,7 @@ InitializeEmmcBlockIoPeim (
         continue;
       }
       if (Capability.SlotType != 0x1) {
-        DEBUG ((EFI_D_INFO, "The slot at 0x%x is not embedded slot type\n", MmioBase[Index]));
+        DEBUG ((DEBUG_INFO, "The slot at 0x%x is not embedded slot type\n", MmioBase[Index]));
         Status = EFI_UNSUPPORTED;
         continue;
       }
@@ -773,12 +773,12 @@ InitializeEmmcBlockIoPeim (
 
       ExtCsd = &Slot->ExtCsd;
       if (ExtCsd->ExtCsdRev < 5) {
-        DEBUG ((EFI_D_ERROR, "The EMMC device version is too low, we don't support!!!\n"));
+        DEBUG ((DEBUG_ERROR, "The EMMC device version is too low, we don't support!!!\n"));
         Status = EFI_UNSUPPORTED;
         continue;
       }
       if ((ExtCsd->PartitioningSupport & BIT0) != BIT0) {
-        DEBUG ((EFI_D_ERROR, "The EMMC device doesn't support Partition Feature!!!\n"));
+        DEBUG ((DEBUG_ERROR, "The EMMC device doesn't support Partition Feature!!!\n"));
         Status = EFI_UNSUPPORTED;
         continue;
       }

--- a/MdeModulePkg/Bus/Sd/EmmcBlockIoPei/EmmcHci.c
+++ b/MdeModulePkg/Bus/Sd/EmmcBlockIoPei/EmmcHci.c
@@ -304,7 +304,7 @@ EmmcPeimHcReset (
   Status  = EmmcPeimHcRwMmio (Bar + EMMC_HC_SW_RST, FALSE, sizeof (SwReset), &SwReset);
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "EmmcPeimHcReset: write full 1 fails: %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "EmmcPeimHcReset: write full 1 fails: %r\n", Status));
     return Status;
   }
 
@@ -316,7 +316,7 @@ EmmcPeimHcReset (
              EMMC_TIMEOUT
              );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_INFO, "EmmcPeimHcReset: reset done with %r\n", Status));
+    DEBUG ((DEBUG_INFO, "EmmcPeimHcReset: reset done with %r\n", Status));
     return Status;
   }
   //
@@ -556,7 +556,7 @@ EmmcPeimHcClockSupply (
     }
   }
 
-  DEBUG ((EFI_D_INFO, "BaseClkFreq %dMHz Divisor %d ClockFreq %dKhz\n", BaseClkFreq, Divisor, ClockFreq));
+  DEBUG ((DEBUG_INFO, "BaseClkFreq %dMHz Divisor %d ClockFreq %dKhz\n", BaseClkFreq, Divisor, ClockFreq));
 
   Status = EmmcPeimHcRwMmio (Bar + EMMC_HC_CTRL_VER, TRUE, sizeof (ControllerVer), &ControllerVer);
   if (EFI_ERROR (Status)) {
@@ -578,7 +578,7 @@ EmmcPeimHcClockSupply (
     ASSERT (Divisor <= 0x80);
     ClockCtrl = (Divisor & 0xFF) << 8;
   } else {
-    DEBUG ((EFI_D_ERROR, "Unknown SD Host Controller Spec version [0x%x]!!!\n", ControllerVer));
+    DEBUG ((DEBUG_ERROR, "Unknown SD Host Controller Spec version [0x%x]!!!\n", ControllerVer));
     return EFI_UNSUPPORTED;
   }
 
@@ -596,7 +596,7 @@ EmmcPeimHcClockSupply (
   ClockCtrl |= BIT0;
   Status = EmmcPeimHcRwMmio (Bar + EMMC_HC_CLOCK_CTRL, FALSE, sizeof (ClockCtrl), &ClockCtrl);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "Set SDCLK Frequency Select and Internal Clock Enable fields fails\n"));
+    DEBUG ((DEBUG_ERROR, "Set SDCLK Frequency Select and Internal Clock Enable fields fails\n"));
     return Status;
   }
 
@@ -936,7 +936,7 @@ BuildAdmaDescTable (
   // for 32-bit address descriptor table.
   //
   if ((Data & (BIT0 | BIT1)) != 0) {
-    DEBUG ((EFI_D_INFO, "The buffer [0x%x] to construct ADMA desc is not aligned to 4 bytes boundary!\n", Data));
+    DEBUG ((DEBUG_INFO, "The buffer [0x%x] to construct ADMA desc is not aligned to 4 bytes boundary!\n", Data));
   }
 
   Entries = DivU64x32 ((DataLen + ADMA_MAX_DATA_PER_LINE - 1), ADMA_MAX_DATA_PER_LINE);
@@ -2330,7 +2330,7 @@ EmmcPeimTuningClkForHs200 (
     }
   } while (++Retry < 40);
 
-  DEBUG ((EFI_D_ERROR, "EmmcPeimTuningClkForHs200: Send tuning block fails at %d times with HostCtrl2 %02x\n", Retry, HostCtrl2));
+  DEBUG ((DEBUG_ERROR, "EmmcPeimTuningClkForHs200: Send tuning block fails at %d times with HostCtrl2 %02x\n", Retry, HostCtrl2));
   //
   // Abort the tuning procedure and reset the tuning circuit.
   //
@@ -2720,7 +2720,7 @@ EmmcPeimSetBusMode (
 
   Status = EmmcPeimGetCsd (Slot, Rca, &Slot->Csd);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "EmmcPeimSetBusMode: EmmcPeimGetCsd fails with %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "EmmcPeimSetBusMode: EmmcPeimGetCsd fails with %r\n", Status));
     return Status;
   }
 
@@ -2732,13 +2732,13 @@ EmmcPeimSetBusMode (
 
   Status = EmmcPeimSelect (Slot, Rca);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "EmmcPeimSetBusMode: EmmcPeimSelect fails with %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "EmmcPeimSetBusMode: EmmcPeimSelect fails with %r\n", Status));
     return Status;
   }
 
   Status = EmmcPeimHcGetCapability (Slot->EmmcHcBase, &Capability);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "EmmcPeimSetBusMode: EmmcPeimHcGetCapability fails with %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "EmmcPeimSetBusMode: EmmcPeimHcGetCapability fails with %r\n", Status));
     return Status;
   }
 
@@ -2756,7 +2756,7 @@ EmmcPeimSetBusMode (
   //
   Status = EmmcPeimGetExtCsd (Slot, &Slot->ExtCsd);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "EmmcPeimSetBusMode: EmmcPeimGetExtCsd fails with %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "EmmcPeimSetBusMode: EmmcPeimGetExtCsd fails with %r\n", Status));
     return Status;
   }
   //
@@ -2802,7 +2802,7 @@ EmmcPeimSetBusMode (
     return EFI_SUCCESS;
   }
 
-  DEBUG ((EFI_D_INFO, "HsTiming %d ClockFreq %d BusWidth %d Ddr %a\n", HsTiming, ClockFreq, BusWidth, IsDdr ? "TRUE":"FALSE"));
+  DEBUG ((DEBUG_INFO, "HsTiming %d ClockFreq %d BusWidth %d Ddr %a\n", HsTiming, ClockFreq, BusWidth, IsDdr ? "TRUE":"FALSE"));
 
   if (HsTiming == 3) {
     //
@@ -2847,7 +2847,7 @@ EmmcPeimIdentification (
 
   Status = EmmcPeimReset (Slot);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "EmmcPeimIdentification: EmmcPeimReset fails with %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "EmmcPeimIdentification: EmmcPeimReset fails with %r\n", Status));
     return Status;
   }
 
@@ -2856,12 +2856,12 @@ EmmcPeimIdentification (
   do {
     Status = EmmcPeimGetOcr (Slot, &Ocr);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "EmmcPeimIdentification: EmmcPeimGetOcr fails with %r\n", Status));
+      DEBUG ((DEBUG_ERROR, "EmmcPeimIdentification: EmmcPeimGetOcr fails with %r\n", Status));
       return Status;
     }
 
     if (Retry++ == 100) {
-      DEBUG ((EFI_D_ERROR, "EmmcPeimIdentification: EmmcPeimGetOcr fails too many times\n"));
+      DEBUG ((DEBUG_ERROR, "EmmcPeimIdentification: EmmcPeimGetOcr fails too many times\n"));
       return EFI_DEVICE_ERROR;
     }
     MicroSecondDelay (10 * 1000);
@@ -2869,7 +2869,7 @@ EmmcPeimIdentification (
 
   Status = EmmcPeimGetAllCid (Slot);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "EmmcPeimIdentification: EmmcPeimGetAllCid fails with %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "EmmcPeimIdentification: EmmcPeimGetAllCid fails with %r\n", Status));
     return Status;
   }
   //
@@ -2879,16 +2879,15 @@ EmmcPeimIdentification (
   Rca    = 1;
   Status = EmmcPeimSetRca (Slot, Rca);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "EmmcPeimIdentification: EmmcPeimSetRca fails with %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "EmmcPeimIdentification: EmmcPeimSetRca fails with %r\n", Status));
     return Status;
   }
   //
   // Enter Data Tranfer Mode.
   //
-  DEBUG ((EFI_D_INFO, "Found a EMMC device at slot [%d], RCA [%d]\n", Slot, Rca));
+  DEBUG ((DEBUG_INFO, "Found a EMMC device at slot [%d], RCA [%d]\n", Slot, Rca));
 
   Status = EmmcPeimSetBusMode (Slot, Rca);
 
   return Status;
 }
-

--- a/MdeModulePkg/Bus/Sd/EmmcDxe/EmmcBlockIo.c
+++ b/MdeModulePkg/Bus/Sd/EmmcDxe/EmmcBlockIo.c
@@ -34,7 +34,7 @@ AsyncIoCallback (
   Request = (EMMC_REQUEST *) Context;
 
   DEBUG_CODE_BEGIN ();
-    DEBUG ((EFI_D_INFO, "Emmc Async Request: CmdIndex[%d] Arg[%08x] %r\n",
+    DEBUG ((DEBUG_INFO, "Emmc Async Request: CmdIndex[%d] Arg[%08x] %r\n",
             Request->SdMmcCmdBlk.CommandIndex, Request->SdMmcCmdBlk.CommandArgument,
             Request->Packet.TransactionStatus));
   DEBUG_CODE_END ();
@@ -2158,4 +2158,3 @@ EmmcEraseBlocks (
 
   return Status;
 }
-

--- a/MdeModulePkg/Bus/Sd/EmmcDxe/EmmcDxe.c
+++ b/MdeModulePkg/Bus/Sd/EmmcDxe/EmmcDxe.c
@@ -314,12 +314,12 @@ DiscoverAllPartitions (
   DumpExtCsd (ExtCsd);
 
   if (ExtCsd->ExtCsdRev < 5) {
-    DEBUG ((EFI_D_ERROR, "The EMMC device version is too low, we don't support!!!\n"));
+    DEBUG ((DEBUG_ERROR, "The EMMC device version is too low, we don't support!!!\n"));
     return EFI_UNSUPPORTED;
   }
 
   if ((ExtCsd->PartitioningSupport & BIT0) != BIT0) {
-    DEBUG ((EFI_D_ERROR, "The EMMC device doesn't support Partition Feature!!!\n"));
+    DEBUG ((DEBUG_ERROR, "The EMMC device doesn't support Partition Feature!!!\n"));
     return EFI_UNSUPPORTED;
   }
 
@@ -1202,4 +1202,3 @@ InitializeEmmcDxe (
 
   return Status;
 }
-

--- a/MdeModulePkg/Bus/Sd/SdBlockIoPei/SdBlockIoPei.c
+++ b/MdeModulePkg/Bus/Sd/SdBlockIoPei/SdBlockIoPei.c
@@ -588,7 +588,7 @@ InitializeSdBlockIoPeim (
         continue;
       }
       if (Capability.SlotType != 0x1) {
-        DEBUG ((EFI_D_INFO, "The slot at 0x%x is not embedded slot type\n", MmioBase[Index]));
+        DEBUG ((DEBUG_INFO, "The slot at 0x%x is not embedded slot type\n", MmioBase[Index]));
         Status = EFI_UNSUPPORTED;
         continue;
       }

--- a/MdeModulePkg/Bus/Sd/SdBlockIoPei/SdHci.c
+++ b/MdeModulePkg/Bus/Sd/SdBlockIoPei/SdHci.c
@@ -304,7 +304,7 @@ SdPeimHcReset (
   Status  = SdPeimHcRwMmio (Bar + SD_HC_SW_RST, FALSE, sizeof (SwReset), &SwReset);
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "SdPeimHcReset: write full 1 fails: %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "SdPeimHcReset: write full 1 fails: %r\n", Status));
     return Status;
   }
 
@@ -316,7 +316,7 @@ SdPeimHcReset (
              SD_TIMEOUT
              );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_INFO, "SdPeimHcReset: reset done with %r\n", Status));
+    DEBUG ((DEBUG_INFO, "SdPeimHcReset: reset done with %r\n", Status));
     return Status;
   }
   //
@@ -556,7 +556,7 @@ SdPeimHcClockSupply (
     }
   }
 
-  DEBUG ((EFI_D_INFO, "BaseClkFreq %dMHz Divisor %d ClockFreq %dKhz\n", BaseClkFreq, Divisor, ClockFreq));
+  DEBUG ((DEBUG_INFO, "BaseClkFreq %dMHz Divisor %d ClockFreq %dKhz\n", BaseClkFreq, Divisor, ClockFreq));
 
   Status = SdPeimHcRwMmio (Bar + SD_HC_CTRL_VER, TRUE, sizeof (ControllerVer), &ControllerVer);
   if (EFI_ERROR (Status)) {
@@ -578,7 +578,7 @@ SdPeimHcClockSupply (
     ASSERT (Divisor <= 0x80);
     ClockCtrl = (Divisor & 0xFF) << 8;
   } else {
-    DEBUG ((EFI_D_ERROR, "Unknown SD Host Controller Spec version [0x%x]!!!\n", ControllerVer));
+    DEBUG ((DEBUG_ERROR, "Unknown SD Host Controller Spec version [0x%x]!!!\n", ControllerVer));
     return EFI_UNSUPPORTED;
   }
 
@@ -596,7 +596,7 @@ SdPeimHcClockSupply (
   ClockCtrl |= BIT0;
   Status = SdPeimHcRwMmio (Bar + SD_HC_CLOCK_CTRL, FALSE, sizeof (ClockCtrl), &ClockCtrl);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "Set SDCLK Frequency Select and Internal Clock Enable fields fails\n"));
+    DEBUG ((DEBUG_ERROR, "Set SDCLK Frequency Select and Internal Clock Enable fields fails\n"));
     return Status;
   }
 
@@ -936,7 +936,7 @@ BuildAdmaDescTable (
   // for 32-bit address descriptor table.
   //
   if ((Data & (BIT0 | BIT1)) != 0) {
-    DEBUG ((EFI_D_INFO, "The buffer [0x%x] to construct ADMA desc is not aligned to 4 bytes boundary!\n", Data));
+    DEBUG ((DEBUG_INFO, "The buffer [0x%x] to construct ADMA desc is not aligned to 4 bytes boundary!\n", Data));
   }
 
   Entries = DivU64x32 ((DataLen + ADMA_MAX_DATA_PER_LINE - 1), ADMA_MAX_DATA_PER_LINE);
@@ -2549,7 +2549,7 @@ SdPeimTuningClock (
     }
   } while (++Retry < 40);
 
-  DEBUG ((EFI_D_ERROR, "SdPeimTuningClock: Send tuning block fails at %d times with HostCtrl2 %02x\n", Retry, HostCtrl2));
+  DEBUG ((DEBUG_ERROR, "SdPeimTuningClock: Send tuning block fails at %d times with HostCtrl2 %02x\n", Retry, HostCtrl2));
   //
   // Abort the tuning procedure and reset the tuning circuit.
   //
@@ -2638,7 +2638,7 @@ SdPeimSetBusMode (
 
   Status = SdPeimGetCsd (Slot, Rca, &Slot->Csd);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "SdPeimSetBusMode: SdPeimGetCsd fails with %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "SdPeimSetBusMode: SdPeimGetCsd fails with %r\n", Status));
     return Status;
   }
 
@@ -2649,14 +2649,14 @@ SdPeimSetBusMode (
 
   Status = SdPeimSelect (Slot, Rca);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "SdPeimSetBusMode: SdPeimSelect fails with %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "SdPeimSetBusMode: SdPeimSelect fails with %r\n", Status));
     return Status;
   }
 
   BusWidth = 4;
   Status = SdPeimSwitchBusWidth (Slot, Rca, BusWidth);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "SdPeimSetBusMode: SdPeimSwitchBusWidth fails with %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "SdPeimSetBusMode: SdPeimSwitchBusWidth fails with %r\n", Status));
     return Status;
   }
 
@@ -2689,16 +2689,16 @@ SdPeimSetBusMode (
     AccessMode = 0;
   }
 
-  DEBUG ((EFI_D_INFO, "SdPeimSetBusMode: AccessMode %d ClockFreq %d BusWidth %d\n", AccessMode, ClockFreq, BusWidth));
+  DEBUG ((DEBUG_INFO, "SdPeimSetBusMode: AccessMode %d ClockFreq %d BusWidth %d\n", AccessMode, ClockFreq, BusWidth));
 
   Status = SdPeimSwitch (Slot, AccessMode, 0xF, 0xF, 0xF, TRUE, SwitchResp);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "SdPeimSetBusMode: SdPeimSwitch fails with %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "SdPeimSetBusMode: SdPeimSwitch fails with %r\n", Status));
     return Status;
   }
 
   if ((SwitchResp[16] & 0xF) != AccessMode) {
-    DEBUG ((EFI_D_ERROR, "SdPeimSetBusMode: SdPeimSwitch to AccessMode %d ClockFreq %d BusWidth %d fails! The Switch response is 0x%1x\n", AccessMode, ClockFreq, BusWidth, SwitchResp[16] & 0xF));
+    DEBUG ((DEBUG_ERROR, "SdPeimSetBusMode: SdPeimSwitch to AccessMode %d ClockFreq %d BusWidth %d fails! The Switch response is 0x%1x\n", AccessMode, ClockFreq, BusWidth, SwitchResp[16] & 0xF));
     return EFI_DEVICE_ERROR;
   }
   //
@@ -2725,19 +2725,19 @@ SdPeimSetBusMode (
 
   Status = SdPeimHcClockSupply (Slot->SdHcBase, ClockFreq * 1000);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "SdPeimSetBusMode: SdPeimHcClockSupply %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "SdPeimSetBusMode: SdPeimHcClockSupply %r\n", Status));
     return Status;
   }
 
   if ((AccessMode == 3) || ((AccessMode == 2) && (Capability.TuningSDR50 != 0))) {
     Status = SdPeimTuningClock (Slot);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "SdPeimSetBusMode: SdPeimTuningClock fails with %r\n", Status));
+      DEBUG ((DEBUG_ERROR, "SdPeimSetBusMode: SdPeimTuningClock fails with %r\n", Status));
       return Status;
     }
   }
 
-  DEBUG ((EFI_D_INFO, "SdPeimSetBusMode: SdPeimSetBusMode %r\n", Status));
+  DEBUG ((DEBUG_INFO, "SdPeimSetBusMode: SdPeimSetBusMode %r\n", Status));
 
   return Status;
 }
@@ -2776,7 +2776,7 @@ SdPeimIdentification (
   //
   Status = SdPeimReset (Slot);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "SdPeimIdentification: Executing Cmd0 fails with %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "SdPeimIdentification: Executing Cmd0 fails with %r\n", Status));
     return Status;
   }
   //
@@ -2784,7 +2784,7 @@ SdPeimIdentification (
   //
   Status = SdPeimVoltageCheck (Slot, 0x1, 0xFF);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "SdPeimIdentification: Executing Cmd8 fails with %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "SdPeimIdentification: Executing Cmd8 fails with %r\n", Status));
     return Status;
   }
   //
@@ -2792,7 +2792,7 @@ SdPeimIdentification (
   //
   Status = SdioSendOpCond (Slot, 0, FALSE);
   if (!EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "SdPeimIdentification: Found SDIO device, ignore it as we don't support\n"));
+    DEBUG ((DEBUG_ERROR, "SdPeimIdentification: Found SDIO device, ignore it as we don't support\n"));
     return EFI_DEVICE_ERROR;
   }
   //
@@ -2800,7 +2800,7 @@ SdPeimIdentification (
   //
   Status = SdPeimSendOpCond (Slot, 0, 0, FALSE, FALSE, FALSE, &Ocr);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "SdPeimIdentification: Executing SdPeimSendOpCond fails with %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "SdPeimIdentification: Executing SdPeimSendOpCond fails with %r\n", Status));
     return EFI_DEVICE_ERROR;
   }
 
@@ -2863,12 +2863,12 @@ SdPeimIdentification (
   do {
     Status = SdPeimSendOpCond (Slot, 0, Ocr, S18r, Xpc, TRUE, &Ocr);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "SdPeimIdentification: SdPeimSendOpCond fails with %r Ocr %x, S18r %x, Xpc %x\n", Status, Ocr, S18r, Xpc));
+      DEBUG ((DEBUG_ERROR, "SdPeimIdentification: SdPeimSendOpCond fails with %r Ocr %x, S18r %x, Xpc %x\n", Status, Ocr, S18r, Xpc));
       return EFI_DEVICE_ERROR;
     }
 
     if (Retry++ == 100) {
-      DEBUG ((EFI_D_ERROR, "SdPeimIdentification: SdPeimSendOpCond fails too many times\n"));
+      DEBUG ((DEBUG_ERROR, "SdPeimIdentification: SdPeimSendOpCond fails too many times\n"));
       return EFI_DEVICE_ERROR;
     }
     MicroSecondDelay (10 * 1000);
@@ -2885,7 +2885,7 @@ SdPeimIdentification (
        ((Ocr & BIT24) != 0)) {
     Status = SdPeimVoltageSwitch (Slot);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "SdPeimIdentification: Executing SdPeimVoltageSwitch fails with %r\n", Status));
+      DEBUG ((DEBUG_ERROR, "SdPeimIdentification: Executing SdPeimVoltageSwitch fails with %r\n", Status));
       Status = EFI_DEVICE_ERROR;
       goto Error;
     } else {
@@ -2897,7 +2897,7 @@ SdPeimIdentification (
 
       SdPeimHcRwMmio (Slot->SdHcBase + SD_HC_PRESENT_STATE, TRUE, sizeof (PresentState), &PresentState);
       if (((PresentState >> 20) & 0xF) != 0) {
-        DEBUG ((EFI_D_ERROR, "SdPeimIdentification: SwitchVoltage fails with PresentState = 0x%x\n", PresentState));
+        DEBUG ((DEBUG_ERROR, "SdPeimIdentification: SwitchVoltage fails with PresentState = 0x%x\n", PresentState));
         Status = EFI_DEVICE_ERROR;
         goto Error;
       }
@@ -2908,7 +2908,7 @@ SdPeimIdentification (
 
       SdPeimHcRwMmio (Slot->SdHcBase + SD_HC_HOST_CTRL2, TRUE, sizeof (HostCtrl2), &HostCtrl2);
       if ((HostCtrl2 & BIT3) == 0) {
-        DEBUG ((EFI_D_ERROR, "SdPeimIdentification: SwitchVoltage fails with HostCtrl2 = 0x%x\n", HostCtrl2));
+        DEBUG ((DEBUG_ERROR, "SdPeimIdentification: SwitchVoltage fails with HostCtrl2 = 0x%x\n", HostCtrl2));
         Status = EFI_DEVICE_ERROR;
         goto Error;
       }
@@ -2919,29 +2919,29 @@ SdPeimIdentification (
 
       SdPeimHcRwMmio (Slot->SdHcBase + SD_HC_PRESENT_STATE, TRUE, sizeof (PresentState), &PresentState);
       if (((PresentState >> 20) & 0xF) != 0xF) {
-        DEBUG ((EFI_D_ERROR, "SdPeimIdentification: SwitchVoltage fails with PresentState = 0x%x, It should be 0xF\n", PresentState));
+        DEBUG ((DEBUG_ERROR, "SdPeimIdentification: SwitchVoltage fails with PresentState = 0x%x, It should be 0xF\n", PresentState));
         Status = EFI_DEVICE_ERROR;
         goto Error;
       }
     }
-    DEBUG ((EFI_D_INFO, "SdPeimIdentification: Switch to 1.8v signal voltage success\n"));
+    DEBUG ((DEBUG_INFO, "SdPeimIdentification: Switch to 1.8v signal voltage success\n"));
   }
 
   Status = SdPeimAllSendCid (Slot);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "SdPeimIdentification: Executing SdPeimAllSendCid fails with %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "SdPeimIdentification: Executing SdPeimAllSendCid fails with %r\n", Status));
     return Status;
   }
 
   Status = SdPeimSetRca (Slot, &Rca);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "SdPeimIdentification: Executing SdPeimSetRca fails with %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "SdPeimIdentification: Executing SdPeimSetRca fails with %r\n", Status));
     return Status;
   }
   //
   // Enter Data Tranfer Mode.
   //
-  DEBUG ((EFI_D_INFO, "Found a SD device at slot [%d]\n", Slot));
+  DEBUG ((DEBUG_INFO, "Found a SD device at slot [%d]\n", Slot));
 
   Status = SdPeimSetBusMode (Slot, Rca, ((Ocr & BIT24) != 0));
 

--- a/MdeModulePkg/Bus/Sd/SdDxe/SdBlockIo.c
+++ b/MdeModulePkg/Bus/Sd/SdDxe/SdBlockIo.c
@@ -30,7 +30,7 @@ AsyncIoCallback (
   Request = (SD_REQUEST *) Context;
 
   DEBUG_CODE_BEGIN ();
-    DEBUG ((EFI_D_INFO, "Sd Async Request: CmdIndex[%d] Arg[%08x] %r\n",
+    DEBUG ((DEBUG_INFO, "Sd Async Request: CmdIndex[%d] Arg[%08x] %r\n",
             Request->SdMmcCmdBlk.CommandIndex, Request->SdMmcCmdBlk.CommandArgument,
             Request->Packet.TransactionStatus));
   DEBUG_CODE_END ();
@@ -86,7 +86,7 @@ SdSetRca (
 
   Status = PassThru->PassThru (PassThru, Device->Slot, &Packet, NULL);
   if (!EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_INFO, "Set RCA succeeds with Resp0 = 0x%x\n", SdMmcStatusBlk.Resp0));
+    DEBUG ((DEBUG_INFO, "Set RCA succeeds with Resp0 = 0x%x\n", SdMmcStatusBlk.Resp0));
     *Rca = (UINT16)(SdMmcStatusBlk.Resp0 >> 16);
   }
 
@@ -1378,4 +1378,3 @@ SdEraseBlocks (
 
   return Status;
 }
-

--- a/MdeModulePkg/Bus/Sd/SdDxe/SdDxe.c
+++ b/MdeModulePkg/Bus/Sd/SdDxe/SdDxe.c
@@ -201,7 +201,7 @@ DiscoverUserArea (
 
   Status = SdSetRca (Device, &Rca);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "DiscoverUserArea(): Assign new Rca = 0x%x fails with %r\n", Rca, Status));
+    DEBUG ((DEBUG_ERROR, "DiscoverUserArea(): Assign new Rca = 0x%x fails with %r\n", Rca, Status));
     return Status;
   }
 
@@ -221,7 +221,7 @@ DiscoverUserArea (
 
   Status = SdSelect (Device, Rca);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "DiscoverUserArea(): Reselect the device 0x%x fails with %r\n", Rca, Status));
+    DEBUG ((DEBUG_ERROR, "DiscoverUserArea(): Reselect the device 0x%x fails with %r\n", Rca, Status));
     return Status;
   }
 
@@ -905,4 +905,3 @@ InitializeSdDxe (
 
   return Status;
 }
-

--- a/MdeModulePkg/Bus/Ufs/UfsBlockIoPei/UfsBlockIoPei.c
+++ b/MdeModulePkg/Bus/Ufs/UfsBlockIoPei/UfsBlockIoPei.c
@@ -441,21 +441,21 @@ UfsPeimParsingSenseKeys (
       (SenseData->Addnl_Sense_Code == EFI_SCSI_ASC_NO_MEDIA)) {
     Media->MediaPresent = FALSE;
     *NeedRetry = FALSE;
-    DEBUG ((EFI_D_VERBOSE, "UfsBlockIoPei: Is No Media\n"));
+    DEBUG ((DEBUG_VERBOSE, "UfsBlockIoPei: Is No Media\n"));
     return EFI_DEVICE_ERROR;
   }
 
   if ((SenseData->Sense_Key == EFI_SCSI_SK_UNIT_ATTENTION) &&
       (SenseData->Addnl_Sense_Code == EFI_SCSI_ASC_MEDIA_CHANGE)) {
     *NeedRetry = TRUE;
-    DEBUG ((EFI_D_VERBOSE, "UfsBlockIoPei: Is Media Change\n"));
+    DEBUG ((DEBUG_VERBOSE, "UfsBlockIoPei: Is Media Change\n"));
     return EFI_SUCCESS;
   }
 
   if ((SenseData->Sense_Key == EFI_SCSI_SK_UNIT_ATTENTION) &&
       (SenseData->Addnl_Sense_Code == EFI_SCSI_ASC_RESET)) {
     *NeedRetry = TRUE;
-    DEBUG ((EFI_D_VERBOSE, "UfsBlockIoPei: Was Reset Before\n"));
+    DEBUG ((DEBUG_VERBOSE, "UfsBlockIoPei: Was Reset Before\n"));
     return EFI_SUCCESS;
   }
 
@@ -463,13 +463,13 @@ UfsPeimParsingSenseKeys (
       ((SenseData->Sense_Key == EFI_SCSI_SK_NOT_READY) &&
       (SenseData->Addnl_Sense_Code == EFI_SCSI_ASC_MEDIA_UPSIDE_DOWN))) {
     *NeedRetry = FALSE;
-    DEBUG ((EFI_D_VERBOSE, "UfsBlockIoPei: Media Error\n"));
+    DEBUG ((DEBUG_VERBOSE, "UfsBlockIoPei: Media Error\n"));
     return EFI_DEVICE_ERROR;
   }
 
   if (SenseData->Sense_Key == EFI_SCSI_SK_HARDWARE_ERROR) {
     *NeedRetry = FALSE;
-    DEBUG ((EFI_D_VERBOSE, "UfsBlockIoPei: Hardware Error\n"));
+    DEBUG ((DEBUG_VERBOSE, "UfsBlockIoPei: Hardware Error\n"));
     return EFI_DEVICE_ERROR;
   }
 
@@ -477,12 +477,12 @@ UfsPeimParsingSenseKeys (
       (SenseData->Addnl_Sense_Code == EFI_SCSI_ASC_NOT_READY) &&
       (SenseData->Addnl_Sense_Code_Qualifier == EFI_SCSI_ASCQ_IN_PROGRESS)) {
     *NeedRetry = TRUE;
-    DEBUG ((EFI_D_VERBOSE, "UfsBlockIoPei: Was Reset Before\n"));
+    DEBUG ((DEBUG_VERBOSE, "UfsBlockIoPei: Was Reset Before\n"));
     return EFI_SUCCESS;
   }
 
   *NeedRetry = FALSE;
-  DEBUG ((EFI_D_VERBOSE, "UfsBlockIoPei: Sense Key = 0x%x ASC = 0x%x!\n", SenseData->Sense_Key, SenseData->Addnl_Sense_Code));
+  DEBUG ((DEBUG_VERBOSE, "UfsBlockIoPei: Sense Key = 0x%x ASC = 0x%x!\n", SenseData->Sense_Key, SenseData->Addnl_Sense_Code));
   return EFI_DEVICE_ERROR;
 }
 
@@ -1097,7 +1097,7 @@ InitializeUfsBlockIoPeim (
     //
     Status = UfsControllerInit (Private);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "UfsDevicePei: Host Controller Initialization Error, Status = %r\n", Status));
+      DEBUG ((DEBUG_ERROR, "UfsDevicePei: Host Controller Initialization Error, Status = %r\n", Status));
       Controller++;
       continue;
     }
@@ -1109,7 +1109,7 @@ InitializeUfsBlockIoPeim (
     //
     Status = UfsExecNopCmds (Private);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "Ufs Sending NOP IN command Error, Status = %r\n", Status));
+      DEBUG ((DEBUG_ERROR, "Ufs Sending NOP IN command Error, Status = %r\n", Status));
       Controller++;
       continue;
     }
@@ -1119,7 +1119,7 @@ InitializeUfsBlockIoPeim (
     //
     Status = UfsSetFlag (Private, UfsFlagDevInit);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "Ufs Set fDeviceInit Flag Error, Status = %r\n", Status));
+      DEBUG ((DEBUG_ERROR, "Ufs Set fDeviceInit Flag Error, Status = %r\n", Status));
       Controller++;
       continue;
     }
@@ -1129,7 +1129,7 @@ InitializeUfsBlockIoPeim (
     //
     Status = UfsRwDeviceDesc (Private, TRUE, UfsConfigDesc, 0, 0, &Config, sizeof (UFS_CONFIG_DESC));
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "Ufs Get Configuration Descriptor Error, Status = %r\n", Status));
+      DEBUG ((DEBUG_ERROR, "Ufs Get Configuration Descriptor Error, Status = %r\n", Status));
       Controller++;
       continue;
     }
@@ -1137,7 +1137,7 @@ InitializeUfsBlockIoPeim (
     for (Index = 0; Index < UFS_PEIM_MAX_LUNS; Index++) {
       if (Config.UnitDescConfParams[Index].LunEn != 0) {
         Private->Luns.BitMask |= (BIT0 << Index);
-        DEBUG ((EFI_D_INFO, "Ufs %d Lun %d is enabled\n", Controller, Index));
+        DEBUG ((DEBUG_INFO, "Ufs %d Lun %d is enabled\n", Controller, Index));
       }
     }
 

--- a/MdeModulePkg/Bus/Ufs/UfsBlockIoPei/UfsHci.c
+++ b/MdeModulePkg/Bus/Ufs/UfsBlockIoPei/UfsHci.c
@@ -80,34 +80,34 @@ DumpUicCmdExecResult (
       case 0x00:
         break;
       case 0x01:
-        DEBUG ((EFI_D_VERBOSE, "UIC configuration command fails - INVALID_MIB_ATTRIBUTE\n"));
+        DEBUG ((DEBUG_VERBOSE, "UIC configuration command fails - INVALID_MIB_ATTRIBUTE\n"));
         break;
       case 0x02:
-        DEBUG ((EFI_D_VERBOSE, "UIC configuration command fails - INVALID_MIB_ATTRIBUTE_VALUE\n"));
+        DEBUG ((DEBUG_VERBOSE, "UIC configuration command fails - INVALID_MIB_ATTRIBUTE_VALUE\n"));
         break;
       case 0x03:
-        DEBUG ((EFI_D_VERBOSE, "UIC configuration command fails - READ_ONLY_MIB_ATTRIBUTE\n"));
+        DEBUG ((DEBUG_VERBOSE, "UIC configuration command fails - READ_ONLY_MIB_ATTRIBUTE\n"));
         break;
       case 0x04:
-        DEBUG ((EFI_D_VERBOSE, "UIC configuration command fails - WRITE_ONLY_MIB_ATTRIBUTE\n"));
+        DEBUG ((DEBUG_VERBOSE, "UIC configuration command fails - WRITE_ONLY_MIB_ATTRIBUTE\n"));
         break;
       case 0x05:
-        DEBUG ((EFI_D_VERBOSE, "UIC configuration command fails - BAD_INDEX\n"));
+        DEBUG ((DEBUG_VERBOSE, "UIC configuration command fails - BAD_INDEX\n"));
         break;
       case 0x06:
-        DEBUG ((EFI_D_VERBOSE, "UIC configuration command fails - LOCKED_MIB_ATTRIBUTE\n"));
+        DEBUG ((DEBUG_VERBOSE, "UIC configuration command fails - LOCKED_MIB_ATTRIBUTE\n"));
         break;
       case 0x07:
-        DEBUG ((EFI_D_VERBOSE, "UIC configuration command fails - BAD_TEST_FEATURE_INDEX\n"));
+        DEBUG ((DEBUG_VERBOSE, "UIC configuration command fails - BAD_TEST_FEATURE_INDEX\n"));
         break;
       case 0x08:
-        DEBUG ((EFI_D_VERBOSE, "UIC configuration command fails - PEER_COMMUNICATION_FAILURE\n"));
+        DEBUG ((DEBUG_VERBOSE, "UIC configuration command fails - PEER_COMMUNICATION_FAILURE\n"));
         break;
       case 0x09:
-        DEBUG ((EFI_D_VERBOSE, "UIC configuration command fails - BUSY\n"));
+        DEBUG ((DEBUG_VERBOSE, "UIC configuration command fails - BUSY\n"));
         break;
       case 0x0A:
-        DEBUG ((EFI_D_VERBOSE, "UIC configuration command fails - DME_FAILURE\n"));
+        DEBUG ((DEBUG_VERBOSE, "UIC configuration command fails - DME_FAILURE\n"));
         break;
       default :
         ASSERT (FALSE);
@@ -118,7 +118,7 @@ DumpUicCmdExecResult (
       case 0x00:
         break;
       case 0x01:
-        DEBUG ((EFI_D_VERBOSE, "UIC control command fails - FAILURE\n"));
+        DEBUG ((DEBUG_VERBOSE, "UIC control command fails - FAILURE\n"));
         break;
       default :
         ASSERT (FALSE);
@@ -140,34 +140,34 @@ DumpQueryResponseResult (
 {
   switch (Result) {
     case 0xF6:
-      DEBUG ((EFI_D_VERBOSE, "Query Response with Parameter Not Readable\n"));
+      DEBUG ((DEBUG_VERBOSE, "Query Response with Parameter Not Readable\n"));
       break;
     case 0xF7:
-      DEBUG ((EFI_D_VERBOSE, "Query Response with Parameter Not Writeable\n"));
+      DEBUG ((DEBUG_VERBOSE, "Query Response with Parameter Not Writeable\n"));
       break;
     case 0xF8:
-      DEBUG ((EFI_D_VERBOSE, "Query Response with Parameter Already Written\n"));
+      DEBUG ((DEBUG_VERBOSE, "Query Response with Parameter Already Written\n"));
       break;
     case 0xF9:
-      DEBUG ((EFI_D_VERBOSE, "Query Response with Invalid Length\n"));
+      DEBUG ((DEBUG_VERBOSE, "Query Response with Invalid Length\n"));
       break;
     case 0xFA:
-      DEBUG ((EFI_D_VERBOSE, "Query Response with Invalid Value\n"));
+      DEBUG ((DEBUG_VERBOSE, "Query Response with Invalid Value\n"));
       break;
     case 0xFB:
-      DEBUG ((EFI_D_VERBOSE, "Query Response with Invalid Selector\n"));
+      DEBUG ((DEBUG_VERBOSE, "Query Response with Invalid Selector\n"));
       break;
     case 0xFC:
-      DEBUG ((EFI_D_VERBOSE, "Query Response with Invalid Index\n"));
+      DEBUG ((DEBUG_VERBOSE, "Query Response with Invalid Index\n"));
       break;
     case 0xFD:
-      DEBUG ((EFI_D_VERBOSE, "Query Response with Invalid Idn\n"));
+      DEBUG ((DEBUG_VERBOSE, "Query Response with Invalid Idn\n"));
       break;
     case 0xFE:
-      DEBUG ((EFI_D_VERBOSE, "Query Response with Invalid Opcode\n"));
+      DEBUG ((DEBUG_VERBOSE, "Query Response with Invalid Opcode\n"));
       break;
     case 0xFF:
-      DEBUG ((EFI_D_VERBOSE, "Query Response with General Failure\n"));
+      DEBUG ((DEBUG_VERBOSE, "Query Response with General Failure\n"));
       break;
     default :
       ASSERT (FALSE);
@@ -325,7 +325,7 @@ UfsInitUtpPrdt (
 
   if ((BufferSize & (BIT0 | BIT1)) != 0) {
     BufferSize &= ~(BIT0 | BIT1);
-    DEBUG ((EFI_D_WARN, "UfsInitUtpPrdt: The BufferSize [%d] is not dword-aligned!\n", BufferSize));
+    DEBUG ((DEBUG_WARN, "UfsInitUtpPrdt: The BufferSize [%d] is not dword-aligned!\n", BufferSize));
   }
 
   if (BufferSize == 0) {
@@ -1190,7 +1190,7 @@ UfsExecScsiCmds (
   // Check the transfer request result.
   //
   if (Response->Response != 0) {
-    DEBUG ((EFI_D_ERROR, "UfsExecScsiCmds() fails with Target Failure\n"));
+    DEBUG ((DEBUG_ERROR, "UfsExecScsiCmds() fails with Target Failure\n"));
     Status = EFI_DEVICE_ERROR;
     goto Exit;
   }
@@ -1324,7 +1324,7 @@ UfsExecUicCommands (
     return EFI_NOT_FOUND;
   }
 
-  DEBUG ((EFI_D_INFO, "UfsblockioPei: found a attached UFS device\n"));
+  DEBUG ((DEBUG_INFO, "UfsblockioPei: found a attached UFS device\n"));
 
   return EFI_SUCCESS;
 }
@@ -1577,25 +1577,25 @@ UfsControllerInit (
 
   Status = UfsEnableHostController (Private);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "UfsDevicePei: Enable Host Controller Fails, Status = %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "UfsDevicePei: Enable Host Controller Fails, Status = %r\n", Status));
     return Status;
   }
 
   Status = UfsDeviceDetection (Private);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "UfsDevicePei: Device Detection Fails, Status = %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "UfsDevicePei: Device Detection Fails, Status = %r\n", Status));
     return Status;
   }
 
   Status = UfsInitTaskManagementRequestList (Private);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "UfsDevicePei: Task management list initialization Fails, Status = %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "UfsDevicePei: Task management list initialization Fails, Status = %r\n", Status));
     return Status;
   }
 
   Status = UfsInitTransferRequestList (Private);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "UfsDevicePei: Transfer list initialization Fails, Status = %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "UfsDevicePei: Transfer list initialization Fails, Status = %r\n", Status));
 
     if (Private->TmrlMapping != NULL) {
       IoMmuFreeBuffer (
@@ -1609,7 +1609,7 @@ UfsControllerInit (
     return Status;
   }
 
-  DEBUG ((EFI_D_INFO, "UfsDevicePei Finished\n"));
+  DEBUG ((DEBUG_INFO, "UfsDevicePei Finished\n"));
   return EFI_SUCCESS;
 }
 
@@ -1661,8 +1661,7 @@ UfsControllerStop (
     return EFI_DEVICE_ERROR;
   }
 
-  DEBUG ((EFI_D_INFO, "UfsDevicePei: Stop the UFS Host Controller\n"));
+  DEBUG ((DEBUG_INFO, "UfsDevicePei: Stop the UFS Host Controller\n"));
 
   return EFI_SUCCESS;
 }
-

--- a/MdeModulePkg/Bus/Usb/UsbBotPei/PeiAtapi.c
+++ b/MdeModulePkg/Bus/Usb/UsbBotPei/PeiAtapi.c
@@ -270,7 +270,7 @@ PeiUsbReadCapacity (
   LastBlock = ((UINT32) Data.LastLba3 << 24) | (Data.LastLba2 << 16) | (Data.LastLba1 << 8) | Data.LastLba0;
 
   if (LastBlock == 0xFFFFFFFF) {
-    DEBUG ((EFI_D_INFO, "The usb device LBA count is larger than 0xFFFFFFFF!\n"));
+    DEBUG ((DEBUG_INFO, "The usb device LBA count is larger than 0xFFFFFFFF!\n"));
   }
 
   PeiBotDevice->Media.LastBlock    = LastBlock;
@@ -341,7 +341,7 @@ PeiUsbReadFormattedCapacity (
   } else {
     LastBlock = ((UINT32) FormatData.LastLba3 << 24) | (FormatData.LastLba2 << 16) | (FormatData.LastLba1 << 8) | FormatData.LastLba0;
     if (LastBlock == 0xFFFFFFFF) {
-      DEBUG ((EFI_D_INFO, "The usb device LBA count is larger than 0xFFFFFFFF!\n"));
+      DEBUG ((DEBUG_INFO, "The usb device LBA count is larger than 0xFFFFFFFF!\n"));
     }
 
     PeiBotDevice->Media.LastBlock = LastBlock;

--- a/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbBus.c
+++ b/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbBus.c
@@ -168,7 +168,7 @@ UsbIoControlTransfer (
 
       goto ON_EXIT;
     }
-    DEBUG ((EFI_D_INFO, "UsbIoControlTransfer: configure changed!!! Do NOT use old UsbIo!!!\n"));
+    DEBUG ((DEBUG_INFO, "UsbIoControlTransfer: configure changed!!! Do NOT use old UsbIo!!!\n"));
 
     if (Dev->ActiveConfig != NULL) {
       UsbRemoveConfig (Dev);
@@ -837,7 +837,7 @@ UsbIoPortReset (
   Status = HubIf->HubApi->ResetPort (HubIf, Dev->ParentPort);
 
   if (EFI_ERROR (Status)) {
-    DEBUG (( EFI_D_ERROR, "UsbIoPortReset: failed to reset hub port %d@hub  %d, %r \n",
+    DEBUG (( DEBUG_ERROR, "UsbIoPortReset: failed to reset hub port %d@hub  %d, %r \n",
                 Dev->ParentPort, Dev->ParentAddr, Status));
 
     goto ON_EXIT;
@@ -861,13 +861,13 @@ UsbIoPortReset (
     //
     // It may fail due to device disconnection or other reasons.
     //
-    DEBUG (( EFI_D_ERROR, "UsbIoPortReset: failed to set address for device %d - %r\n",
+    DEBUG (( DEBUG_ERROR, "UsbIoPortReset: failed to set address for device %d - %r\n",
                 Dev->Address, Status));
 
     goto ON_EXIT;
   }
 
-  DEBUG (( EFI_D_INFO, "UsbIoPortReset: device is now ADDRESSED at %d\n", Dev->Address));
+  DEBUG (( DEBUG_INFO, "UsbIoPortReset: device is now ADDRESSED at %d\n", Dev->Address));
 
   //
   // Reset the current active configure, after this device
@@ -877,7 +877,7 @@ UsbIoPortReset (
     Status = UsbSetConfig (Dev, Dev->ActiveConfig->Desc.ConfigurationValue);
 
     if (EFI_ERROR (Status)) {
-      DEBUG (( EFI_D_ERROR, "UsbIoPortReset: failed to set configure for device %d - %r\n",
+      DEBUG (( DEBUG_ERROR, "UsbIoPortReset: failed to set configure for device %d - %r\n",
                   Dev->Address, Status));
     }
   }
@@ -934,7 +934,7 @@ UsbBusBuildProtocol (
                   );
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "UsbBusStart: Failed to open device path %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "UsbBusStart: Failed to open device path %r\n", Status));
 
     FreePool (UsbBus);
     return Status;
@@ -967,7 +967,7 @@ UsbBusBuildProtocol (
                    );
 
   if (EFI_ERROR (Status) && EFI_ERROR (Status2)) {
-    DEBUG ((EFI_D_ERROR, "UsbBusStart: Failed to open USB_HC/USB2_HC %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "UsbBusStart: Failed to open USB_HC/USB2_HC %r\n", Status));
 
     Status = EFI_DEVICE_ERROR;
     goto CLOSE_HC;
@@ -995,7 +995,7 @@ UsbBusBuildProtocol (
                   );
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "UsbBusStart: Failed to install bus protocol %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "UsbBusStart: Failed to install bus protocol %r\n", Status));
     goto CLOSE_HC;
   }
 
@@ -1043,13 +1043,13 @@ UsbBusBuildProtocol (
   Status                  = mUsbRootHubApi.Init (RootIf);
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "UsbBusStart: Failed to init root hub %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "UsbBusStart: Failed to init root hub %r\n", Status));
     goto FREE_ROOTHUB;
   }
 
   UsbBus->Devices[0] = RootHub;
 
-  DEBUG ((EFI_D_INFO, "UsbBusStart: usb bus started on %p, root hub %p\n", Controller, RootIf));
+  DEBUG ((DEBUG_INFO, "UsbBusStart: usb bus started on %p, root hub %p\n", Controller, RootIf));
   return EFI_SUCCESS;
 
 FREE_ROOTHUB:
@@ -1088,7 +1088,7 @@ CLOSE_HC:
          );
   FreePool (UsbBus);
 
-  DEBUG ((EFI_D_ERROR, "UsbBusStart: Failed to start bus driver %r\n", Status));
+  DEBUG ((DEBUG_ERROR, "UsbBusStart: Failed to start bus driver %r\n", Status));
   return Status;
 }
 
@@ -1448,7 +1448,7 @@ UsbBusControllerDriverStop (
     return ReturnStatus;
   }
 
-  DEBUG (( EFI_D_INFO, "UsbBusStop: usb bus stopped on %p\n", Controller));
+  DEBUG (( DEBUG_INFO, "UsbBusStop: usb bus stopped on %p\n", Controller));
 
   //
   // Locate USB_BUS for the current host controller

--- a/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbDesc.c
+++ b/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbDesc.c
@@ -272,7 +272,7 @@ UsbParseInterfaceDesc (
   Setting   = UsbCreateDesc (DescBuf, Len, USB_DESC_TYPE_INTERFACE, &Used);
 
   if (Setting == NULL) {
-    DEBUG (( EFI_D_ERROR, "UsbParseInterfaceDesc: failed to create interface descriptor\n"));
+    DEBUG (( DEBUG_ERROR, "UsbParseInterfaceDesc: failed to create interface descriptor\n"));
     return NULL;
   }
 
@@ -283,7 +283,7 @@ UsbParseInterfaceDesc (
   //
   NumEp  = Setting->Desc.NumEndpoints;
 
-  DEBUG (( EFI_D_INFO, "UsbParseInterfaceDesc: interface %d(setting %d) has %d endpoints\n",
+  DEBUG (( DEBUG_INFO, "UsbParseInterfaceDesc: interface %d(setting %d) has %d endpoints\n",
               Setting->Desc.InterfaceNumber, Setting->Desc.AlternateSetting, (UINT32)NumEp));
 
   if (NumEp == 0) {
@@ -303,7 +303,7 @@ UsbParseInterfaceDesc (
     Ep = UsbCreateDesc (DescBuf + Offset, Len - Offset, USB_DESC_TYPE_ENDPOINT, &Used);
 
     if (Ep == NULL) {
-      DEBUG (( EFI_D_ERROR, "UsbParseInterfaceDesc: failed to create endpoint(index %d)\n", (UINT32)Index));
+      DEBUG (( DEBUG_ERROR, "UsbParseInterfaceDesc: failed to create endpoint(index %d)\n", (UINT32)Index));
       goto ON_ERROR;
     }
 
@@ -362,7 +362,7 @@ UsbParseConfigDesc (
     goto ON_ERROR;
   }
 
-  DEBUG (( EFI_D_INFO, "UsbParseConfigDesc: config %d has %d interfaces\n",
+  DEBUG (( DEBUG_INFO, "UsbParseConfigDesc: config %d has %d interfaces\n",
                 Config->Desc.ConfigurationValue, (UINT32)NumIf));
 
   for (Index = 0; Index < NumIf; Index++) {
@@ -394,7 +394,7 @@ UsbParseConfigDesc (
     Setting = UsbParseInterfaceDesc (DescBuf, Len, &Consumed);
 
     if (Setting == NULL) {
-      DEBUG (( EFI_D_ERROR, "UsbParseConfigDesc: warning: failed to get interface setting, stop parsing now.\n"));
+      DEBUG (( DEBUG_ERROR, "UsbParseConfigDesc: warning: failed to get interface setting, stop parsing now.\n"));
       break;
 
     } else if (Setting->Desc.InterfaceNumber >= NumIf) {
@@ -765,13 +765,13 @@ UsbGetOneConfig (
   Status = UsbCtrlGetDesc (UsbDev, USB_DESC_TYPE_CONFIG, Index, 0, &Desc, 8);
 
   if (EFI_ERROR (Status)) {
-    DEBUG (( EFI_D_ERROR, "UsbGetOneConfig: failed to get descript length(%d) %r\n",
+    DEBUG (( DEBUG_ERROR, "UsbGetOneConfig: failed to get descript length(%d) %r\n",
                 Desc.TotalLength, Status));
 
     return NULL;
   }
 
-  DEBUG (( EFI_D_INFO, "UsbGetOneConfig: total length is %d\n", Desc.TotalLength));
+  DEBUG (( DEBUG_INFO, "UsbGetOneConfig: total length is %d\n", Desc.TotalLength));
 
   //
   // Reject if TotalLength even cannot cover itself.
@@ -789,7 +789,7 @@ UsbGetOneConfig (
   Status = UsbCtrlGetDesc (UsbDev, USB_DESC_TYPE_CONFIG, Index, 0, Buf, Desc.TotalLength);
 
   if (EFI_ERROR (Status)) {
-    DEBUG (( EFI_D_ERROR, "UsbGetOneConfig: failed to get full descript %r\n", Status));
+    DEBUG (( DEBUG_ERROR, "UsbGetOneConfig: failed to get full descript %r\n", Status));
 
     FreePool (Buf);
     return NULL;
@@ -829,7 +829,7 @@ UsbBuildDescTable (
   Status = UsbGetDevDesc (UsbDev);
 
   if (EFI_ERROR (Status)) {
-    DEBUG (( EFI_D_ERROR, "UsbBuildDescTable: failed to get device descriptor - %r\n", Status));
+    DEBUG (( DEBUG_ERROR, "UsbBuildDescTable: failed to get device descriptor - %r\n", Status));
     return Status;
   }
 
@@ -844,7 +844,7 @@ UsbBuildDescTable (
     return EFI_OUT_OF_RESOURCES;
   }
 
-  DEBUG (( EFI_D_INFO, "UsbBuildDescTable: device has %d configures\n", NumConfig));
+  DEBUG (( DEBUG_INFO, "UsbBuildDescTable: device has %d configures\n", NumConfig));
 
   //
   // Read each configurations, then parse them
@@ -853,7 +853,7 @@ UsbBuildDescTable (
     Config = UsbGetOneConfig (UsbDev, Index);
 
     if (Config == NULL) {
-      DEBUG (( EFI_D_ERROR, "UsbBuildDescTable: failed to get configure (index %d)\n", Index));
+      DEBUG (( DEBUG_ERROR, "UsbBuildDescTable: failed to get configure (index %d)\n", Index));
 
       //
       // If we can get the default descriptor, it is likely that the
@@ -871,7 +871,7 @@ UsbBuildDescTable (
     FreePool (Config);
 
     if (ConfigDesc == NULL) {
-      DEBUG (( EFI_D_ERROR, "UsbBuildDescTable: failed to parse configure (index %d)\n", Index));
+      DEBUG (( DEBUG_ERROR, "UsbBuildDescTable: failed to parse configure (index %d)\n", Index));
 
       //
       // If we can get the default descriptor, it is likely that the
@@ -894,7 +894,7 @@ UsbBuildDescTable (
   Status = UsbBuildLangTable (UsbDev);
 
   if (EFI_ERROR (Status)) {
-    DEBUG (( EFI_D_INFO, "UsbBuildDescTable: get language ID table %r\n", Status));
+    DEBUG (( DEBUG_INFO, "UsbBuildDescTable: get language ID table %r\n", Status));
   }
 
   return EFI_SUCCESS;

--- a/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbEnumer.c
+++ b/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbEnumer.c
@@ -132,7 +132,7 @@ UsbCreateInterface (
   UsbIf->DevicePath = AppendDevicePathNode (HubIf->DevicePath, &UsbNode.Header);
 
   if (UsbIf->DevicePath == NULL) {
-    DEBUG ((EFI_D_ERROR, "UsbCreateInterface: failed to create device path\n"));
+    DEBUG ((DEBUG_ERROR, "UsbCreateInterface: failed to create device path\n"));
 
     Status = EFI_OUT_OF_RESOURCES;
     goto ON_ERROR;
@@ -148,7 +148,7 @@ UsbCreateInterface (
                   );
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "UsbCreateInterface: failed to install UsbIo - %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "UsbCreateInterface: failed to install UsbIo - %r\n", Status));
     goto ON_ERROR;
   }
 
@@ -167,7 +167,7 @@ UsbCreateInterface (
            NULL
            );
 
-    DEBUG ((EFI_D_ERROR, "UsbCreateInterface: failed to open host for child - %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "UsbCreateInterface: failed to open host for child - %r\n", Status));
     goto ON_ERROR;
   }
 
@@ -262,7 +262,7 @@ UsbConnectDriver (
   // connect drivers with this interface
   //
   if (UsbIsHubInterface (UsbIf)) {
-    DEBUG ((EFI_D_INFO, "UsbConnectDriver: found a hub device\n"));
+    DEBUG ((DEBUG_INFO, "UsbConnectDriver: found a hub device\n"));
     Status = mUsbHubApi.Init (UsbIf);
 
   } else {
@@ -279,14 +279,14 @@ UsbConnectDriver (
     //
     if (UsbBusIsWantedUsbIO (UsbIf->Device->Bus, UsbIf)) {
       OldTpl            = UsbGetCurrentTpl ();
-      DEBUG ((EFI_D_INFO, "UsbConnectDriver: TPL before connect is %d, %p\n", (UINT32)OldTpl, UsbIf->Handle));
+      DEBUG ((DEBUG_INFO, "UsbConnectDriver: TPL before connect is %d, %p\n", (UINT32)OldTpl, UsbIf->Handle));
 
       gBS->RestoreTPL (TPL_CALLBACK);
 
       Status            = gBS->ConnectController (UsbIf->Handle, NULL, NULL, TRUE);
       UsbIf->IsManaged  = (BOOLEAN)!EFI_ERROR (Status);
 
-      DEBUG ((EFI_D_INFO, "UsbConnectDriver: TPL after connect is %d\n", (UINT32)UsbGetCurrentTpl()));
+      DEBUG ((DEBUG_INFO, "UsbConnectDriver: TPL after connect is %d\n", (UINT32)UsbGetCurrentTpl()));
       ASSERT (UsbGetCurrentTpl () == TPL_CALLBACK);
 
       gBS->RaiseTPL (OldTpl);
@@ -340,7 +340,7 @@ UsbSelectSetting (
   IfDesc->ActiveIndex = Index;
 
   ASSERT (Setting != NULL);
-  DEBUG ((EFI_D_INFO, "UsbSelectSetting: setting %d selected for interface %d\n",
+  DEBUG ((DEBUG_INFO, "UsbSelectSetting: setting %d selected for interface %d\n",
               Alternate, Setting->Desc.InterfaceNumber));
 
   //
@@ -399,7 +399,7 @@ UsbSelectConfig (
 
   Device->ActiveConfig = ConfigDesc;
 
-  DEBUG ((EFI_D_INFO, "UsbSelectConfig: config %d selected for device %d\n",
+  DEBUG ((DEBUG_INFO, "UsbSelectConfig: config %d selected for device %d\n",
               ConfigValue, Device->Address));
 
   //
@@ -479,7 +479,7 @@ UsbDisconnectDriver (
     // or disconnect at CALLBACK.
     //
     OldTpl           = UsbGetCurrentTpl ();
-    DEBUG ((EFI_D_INFO, "UsbDisconnectDriver: old TPL is %d, %p\n", (UINT32)OldTpl, UsbIf->Handle));
+    DEBUG ((DEBUG_INFO, "UsbDisconnectDriver: old TPL is %d, %p\n", (UINT32)OldTpl, UsbIf->Handle));
 
     gBS->RestoreTPL (TPL_CALLBACK);
 
@@ -488,7 +488,7 @@ UsbDisconnectDriver (
       UsbIf->IsManaged = FALSE;
     }
 
-    DEBUG (( EFI_D_INFO, "UsbDisconnectDriver: TPL after disconnect is %d, %d\n", (UINT32)UsbGetCurrentTpl(), Status));
+    DEBUG (( DEBUG_INFO, "UsbDisconnectDriver: TPL after disconnect is %d, %d\n", (UINT32)UsbGetCurrentTpl(), Status));
     ASSERT (UsbGetCurrentTpl () == TPL_CALLBACK);
 
     gBS->RaiseTPL (OldTpl);
@@ -586,7 +586,7 @@ UsbRemoveDevice (
     } else {
       Bus->Devices[Index]->DisconnectFail = TRUE;
       ReturnStatus = Status;
-      DEBUG ((EFI_D_INFO, "UsbRemoveDevice: failed to remove child %p at parent %p\n", Child, Device));
+      DEBUG ((DEBUG_INFO, "UsbRemoveDevice: failed to remove child %p at parent %p\n", Child, Device));
     }
   }
 
@@ -597,7 +597,7 @@ UsbRemoveDevice (
   Status = UsbRemoveConfig (Device);
 
   if (!EFI_ERROR (Status)) {
-    DEBUG (( EFI_D_INFO, "UsbRemoveDevice: device %d removed\n", Device->Address));
+    DEBUG (( DEBUG_INFO, "UsbRemoveDevice: device %d removed\n", Device->Address));
 
     ASSERT (Device->Address < Bus->MaxDevices);
     Bus->Devices[Device->Address] = NULL;
@@ -691,13 +691,13 @@ UsbEnumerateNewDev (
   if (ResetIsNeeded) {
     Status = HubApi->ResetPort (HubIf, Port);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "UsbEnumerateNewDev: failed to reset port %d - %r\n", Port, Status));
+      DEBUG ((DEBUG_ERROR, "UsbEnumerateNewDev: failed to reset port %d - %r\n", Port, Status));
 
       return Status;
     }
-    DEBUG (( EFI_D_INFO, "UsbEnumerateNewDev: hub port %d is reset\n", Port));
+    DEBUG (( DEBUG_INFO, "UsbEnumerateNewDev: hub port %d is reset\n", Port));
   } else {
-    DEBUG (( EFI_D_INFO, "UsbEnumerateNewDev: hub port %d reset is skipped\n", Port));
+    DEBUG (( DEBUG_INFO, "UsbEnumerateNewDev: hub port %d reset is skipped\n", Port));
   }
 
   Child = UsbCreateDevice (HubIf, Port);
@@ -713,12 +713,12 @@ UsbEnumerateNewDev (
   Status = HubApi->GetPortStatus (HubIf, Port, &PortState);
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "UsbEnumerateNewDev: failed to get speed of port %d\n", Port));
+    DEBUG ((DEBUG_ERROR, "UsbEnumerateNewDev: failed to get speed of port %d\n", Port));
     goto ON_ERROR;
   }
 
   if (!USB_BIT_IS_SET (PortState.PortStatus, USB_PORT_STAT_CONNECTION)) {
-    DEBUG ((EFI_D_ERROR, "UsbEnumerateNewDev: No device present at port %d\n", Port));
+    DEBUG ((DEBUG_ERROR, "UsbEnumerateNewDev: No device present at port %d\n", Port));
     Status = EFI_NOT_FOUND;
     goto ON_ERROR;
   } else if (USB_BIT_IS_SET (PortState.PortStatus, USB_PORT_STAT_SUPER_SPEED)){
@@ -735,7 +735,7 @@ UsbEnumerateNewDev (
     Child->MaxPacket0 = 8;
   }
 
-  DEBUG (( EFI_D_INFO, "UsbEnumerateNewDev: device is of %d speed\n", Child->Speed));
+  DEBUG (( DEBUG_INFO, "UsbEnumerateNewDev: device is of %d speed\n", Child->Speed));
 
   if (((Child->Speed == EFI_USB_SPEED_LOW) || (Child->Speed == EFI_USB_SPEED_FULL)) &&
       (Parent->Speed == EFI_USB_SPEED_HIGH)) {
@@ -751,7 +751,7 @@ UsbEnumerateNewDev (
   } else {
     Child->Translator = Parent->Translator;
   }
-  DEBUG (( EFI_D_INFO, "UsbEnumerateNewDev: device uses translator (%d, %d)\n",
+  DEBUG (( DEBUG_INFO, "UsbEnumerateNewDev: device uses translator (%d, %d)\n",
            Child->Translator.TranslatorHubAddress,
            Child->Translator.TranslatorPortNumber));
 
@@ -775,7 +775,7 @@ UsbEnumerateNewDev (
   }
 
   if (Address >= Bus->MaxDevices) {
-    DEBUG ((EFI_D_ERROR, "UsbEnumerateNewDev: address pool is full for port %d\n", Port));
+    DEBUG ((DEBUG_ERROR, "UsbEnumerateNewDev: address pool is full for port %d\n", Port));
 
     Status = EFI_ACCESS_DENIED;
     goto ON_ERROR;
@@ -786,13 +786,13 @@ UsbEnumerateNewDev (
   Bus->Devices[Address] = Child;
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "UsbEnumerateNewDev: failed to set device address - %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "UsbEnumerateNewDev: failed to set device address - %r\n", Status));
     goto ON_ERROR;
   }
 
   gBS->Stall (USB_SET_DEVICE_ADDRESS_STALL);
 
-  DEBUG ((EFI_D_INFO, "UsbEnumerateNewDev: device is now ADDRESSED at %d\n", Address));
+  DEBUG ((DEBUG_INFO, "UsbEnumerateNewDev: device is now ADDRESSED at %d\n", Address));
 
   //
   // Host sends a Get_Descriptor request to learn the max packet
@@ -801,11 +801,11 @@ UsbEnumerateNewDev (
   Status = UsbGetMaxPacketSize0 (Child);
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "UsbEnumerateNewDev: failed to get max packet for EP 0 - %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "UsbEnumerateNewDev: failed to get max packet for EP 0 - %r\n", Status));
     goto ON_ERROR;
   }
 
-  DEBUG (( EFI_D_INFO, "UsbEnumerateNewDev: max packet size for EP 0 is %d\n", Child->MaxPacket0));
+  DEBUG (( DEBUG_INFO, "UsbEnumerateNewDev: max packet size for EP 0 is %d\n", Child->MaxPacket0));
 
   //
   // Host learns about the device's abilities by requesting device's
@@ -814,7 +814,7 @@ UsbEnumerateNewDev (
   Status = UsbBuildDescTable (Child);
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "UsbEnumerateNewDev: failed to build descriptor table - %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "UsbEnumerateNewDev: failed to build descriptor table - %r\n", Status));
     goto ON_ERROR;
   }
 
@@ -826,11 +826,11 @@ UsbEnumerateNewDev (
   Status = UsbSetConfig (Child, Config);
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "UsbEnumerateNewDev: failed to set configure %d - %r\n", Config, Status));
+    DEBUG ((DEBUG_ERROR, "UsbEnumerateNewDev: failed to set configure %d - %r\n", Config, Status));
     goto ON_ERROR;
   }
 
-  DEBUG (( EFI_D_INFO, "UsbEnumerateNewDev: device %d is now in CONFIGED state\n", Address));
+  DEBUG (( DEBUG_INFO, "UsbEnumerateNewDev: device %d is now in CONFIGED state\n", Address));
 
   //
   // Host assigns and loads a device driver.
@@ -838,7 +838,7 @@ UsbEnumerateNewDev (
   Status = UsbSelectConfig (Child, Config);
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "UsbEnumerateNewDev: failed to create interfaces - %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "UsbEnumerateNewDev: failed to create interfaces - %r\n", Status));
     goto ON_ERROR;
   }
 
@@ -902,7 +902,7 @@ UsbEnumeratePort (
   Status = HubApi->GetPortStatus (HubIf, Port, &PortState);
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "UsbEnumeratePort: failed to get state of port %d\n", Port));
+    DEBUG ((DEBUG_ERROR, "UsbEnumeratePort: failed to get state of port %d\n", Port));
     return Status;
   }
 
@@ -914,7 +914,7 @@ UsbEnumeratePort (
     return EFI_SUCCESS;
   }
 
-  DEBUG (( EFI_D_INFO, "UsbEnumeratePort: port %d state - %02x, change - %02x on %p\n",
+  DEBUG (( DEBUG_INFO, "UsbEnumeratePort: port %d state - %02x, change - %02x on %p\n",
               Port, PortState.PortStatus, PortState.PortChangeStatus, HubIf));
 
   //
@@ -932,7 +932,7 @@ UsbEnumeratePort (
       //   which probably is caused by short circuit. It has to wait system hardware
       //   to perform recovery.
       //
-      DEBUG (( EFI_D_ERROR, "UsbEnumeratePort: Critical Over Current\n", Port));
+      DEBUG (( DEBUG_ERROR, "UsbEnumeratePort: Critical Over Current\n", Port));
       return EFI_DEVICE_ERROR;
 
     }
@@ -942,7 +942,7 @@ UsbEnumeratePort (
     //   over current. As a result, all ports are nearly power-off, so
     //   it's necessary to detach and enumerate all ports again.
     //
-    DEBUG (( EFI_D_ERROR, "UsbEnumeratePort: 2.0 device Recovery Over Current\n", Port));
+    DEBUG (( DEBUG_ERROR, "UsbEnumeratePort: 2.0 device Recovery Over Current\n", Port));
   }
 
   if (USB_BIT_IS_SET (PortState.PortChangeStatus, USB_PORT_STAT_C_ENABLE)) {
@@ -952,7 +952,7 @@ UsbEnumeratePort (
     //   on 2.0 roothub does. When over-current has influence on 1.1 device, the port
     //   would be disabled, so it's also necessary to detach and enumerate again.
     //
-    DEBUG (( EFI_D_ERROR, "UsbEnumeratePort: 1.1 device Recovery Over Current\n", Port));
+    DEBUG (( DEBUG_ERROR, "UsbEnumeratePort: 1.1 device Recovery Over Current\n", Port));
   }
 
   if (USB_BIT_IS_SET (PortState.PortChangeStatus, USB_PORT_STAT_C_CONNECTION)) {
@@ -960,7 +960,7 @@ UsbEnumeratePort (
     // Case4:
     //   Device connected or disconnected normally.
     //
-    DEBUG ((EFI_D_INFO, "UsbEnumeratePort: Device Connect/Disconnect Normally\n", Port));
+    DEBUG ((DEBUG_INFO, "UsbEnumeratePort: Device Connect/Disconnect Normally\n", Port));
   }
 
   //
@@ -969,7 +969,7 @@ UsbEnumeratePort (
   Child = UsbFindChild (HubIf, Port);
 
   if (Child != NULL) {
-    DEBUG (( EFI_D_INFO, "UsbEnumeratePort: device at port %d removed from root hub %p\n", Port, HubIf));
+    DEBUG (( DEBUG_INFO, "UsbEnumeratePort: device at port %d removed from root hub %p\n", Port, HubIf));
     UsbRemoveDevice (Child);
   }
 
@@ -977,7 +977,7 @@ UsbEnumeratePort (
     //
     // Now, new device connected, enumerate and configure the device
     //
-    DEBUG (( EFI_D_INFO, "UsbEnumeratePort: new device connected at port %d\n", Port));
+    DEBUG (( DEBUG_INFO, "UsbEnumeratePort: new device connected at port %d\n", Port));
     if (USB_BIT_IS_SET (PortState.PortChangeStatus, USB_PORT_STAT_C_RESET)) {
       Status = UsbEnumerateNewDev (HubIf, Port, FALSE);
     } else {
@@ -985,7 +985,7 @@ UsbEnumeratePort (
     }
 
   } else {
-    DEBUG (( EFI_D_INFO, "UsbEnumeratePort: device disconnected event on port %d\n", Port));
+    DEBUG (( DEBUG_INFO, "UsbEnumeratePort: device disconnected event on port %d\n", Port));
   }
 
   HubApi->ClearPortChange (HubIf, Port);
@@ -1020,7 +1020,7 @@ UsbHubEnumeration (
   for (Index = 0; Index < HubIf->NumOfPort; Index++) {
     Child = UsbFindChild (HubIf, Index);
     if ((Child != NULL) && (Child->DisconnectFail == TRUE)) {
-      DEBUG (( EFI_D_INFO, "UsbEnumeratePort: The device disconnect fails at port %d from hub %p, try again\n", Index, HubIf));
+      DEBUG (( DEBUG_INFO, "UsbEnumeratePort: The device disconnect fails at port %d from hub %p, try again\n", Index, HubIf));
       UsbRemoveDevice (Child);
     }
   }
@@ -1074,7 +1074,7 @@ UsbRootHubEnumeration (
   for (Index = 0; Index < RootHub->NumOfPort; Index++) {
     Child = UsbFindChild (RootHub, Index);
     if ((Child != NULL) && (Child->DisconnectFail == TRUE)) {
-      DEBUG (( EFI_D_INFO, "UsbEnumeratePort: The device disconnect fails at port %d from root hub %p, try again\n", Index, RootHub));
+      DEBUG (( DEBUG_INFO, "UsbEnumeratePort: The device disconnect fails at port %d from root hub %p, try again\n", Index, RootHub));
       UsbRemoveDevice (Child);
     }
 

--- a/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbHub.c
+++ b/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbHub.c
@@ -516,7 +516,7 @@ UsbOnHubInterrupt (
                       );
 
     if (EFI_ERROR (Status)) {
-      DEBUG (( EFI_D_ERROR, "UsbOnHubInterrupt: failed to remove async transfer - %r\n", Status));
+      DEBUG (( DEBUG_ERROR, "UsbOnHubInterrupt: failed to remove async transfer - %r\n", Status));
       return Status;
     }
 
@@ -531,7 +531,7 @@ UsbOnHubInterrupt (
                       );
 
     if (EFI_ERROR (Status)) {
-      DEBUG (( EFI_D_ERROR, "UsbOnHubInterrupt: failed to submit new async transfer - %r\n", Status));
+      DEBUG (( DEBUG_ERROR, "UsbOnHubInterrupt: failed to submit new async transfer - %r\n", Status));
     }
 
     return Status;
@@ -608,7 +608,7 @@ UsbHubInit (
   }
 
   if (Index == NumEndpoints) {
-    DEBUG (( EFI_D_ERROR, "UsbHubInit: no interrupt endpoint found for hub %d\n", HubDev->Address));
+    DEBUG (( DEBUG_ERROR, "UsbHubInit: no interrupt endpoint found for hub %d\n", HubDev->Address));
     return EFI_DEVICE_ERROR;
   }
 
@@ -620,13 +620,13 @@ UsbHubInit (
   Status = UsbHubReadDesc (HubDev, HubDesc);
 
   if (EFI_ERROR (Status)) {
-    DEBUG (( EFI_D_ERROR, "UsbHubInit: failed to read HUB descriptor %r\n", Status));
+    DEBUG (( DEBUG_ERROR, "UsbHubInit: failed to read HUB descriptor %r\n", Status));
     return Status;
   }
 
   HubIf->NumOfPort = HubDesc->NumPorts;
 
-  DEBUG (( EFI_D_INFO, "UsbHubInit: hub %d has %d ports\n", HubDev->Address,HubIf->NumOfPort));
+  DEBUG (( DEBUG_INFO, "UsbHubInit: hub %d has %d ports\n", HubDev->Address,HubIf->NumOfPort));
 
   //
   // OK, set IsHub to TRUE. Now usb bus can handle this device
@@ -640,7 +640,7 @@ UsbHubInit (
 
   if (HubIf->Device->Speed == EFI_USB_SPEED_SUPER) {
     Depth = (UINT16)(HubIf->Device->Tier - 1);
-    DEBUG ((EFI_D_INFO, "UsbHubInit: Set Hub Depth as 0x%x\n", Depth));
+    DEBUG ((DEBUG_INFO, "UsbHubInit: Set Hub Depth as 0x%x\n", Depth));
     UsbHubCtrlSetHubDepth (HubIf->Device, Depth);
 
     for (Index = 0; Index < HubDesc->NumPorts; Index++) {
@@ -676,7 +676,7 @@ UsbHubInit (
                   );
 
   if (EFI_ERROR (Status)) {
-    DEBUG (( EFI_D_ERROR, "UsbHubInit: failed to create signal for hub %d - %r\n",
+    DEBUG (( DEBUG_ERROR, "UsbHubInit: failed to create signal for hub %d - %r\n",
                 HubDev->Address, Status));
 
     return Status;
@@ -701,7 +701,7 @@ UsbHubInit (
                     );
 
   if (EFI_ERROR (Status)) {
-    DEBUG (( EFI_D_ERROR, "UsbHubInit: failed to queue interrupt transfer for hub %d - %r\n",
+    DEBUG (( DEBUG_ERROR, "UsbHubInit: failed to queue interrupt transfer for hub %d - %r\n",
                 HubDev->Address, Status));
 
     gBS->CloseEvent (HubIf->HubNotify);
@@ -710,7 +710,7 @@ UsbHubInit (
     return Status;
   }
 
-  DEBUG (( EFI_D_INFO, "UsbHubInit: hub %d initialized\n", HubDev->Address));
+  DEBUG (( DEBUG_INFO, "UsbHubInit: hub %d initialized\n", HubDev->Address));
   return Status;
 }
 
@@ -935,7 +935,7 @@ UsbHubRelease (
   HubIf->HubEp      = NULL;
   HubIf->HubNotify  = NULL;
 
-  DEBUG (( EFI_D_INFO, "UsbHubRelease: hub device %d released\n", HubIf->Device->Address));
+  DEBUG (( DEBUG_INFO, "UsbHubRelease: hub device %d released\n", HubIf->Device->Address));
   return EFI_SUCCESS;
 }
 
@@ -966,7 +966,7 @@ UsbRootHubInit (
     return Status;
   }
 
-  DEBUG (( EFI_D_INFO, "UsbRootHubInit: root hub %p - max speed %d, %d ports\n",
+  DEBUG (( DEBUG_INFO, "UsbRootHubInit: root hub %p - max speed %d, %d ports\n",
               HubIf, MaxSpeed, NumOfPort));
 
   HubIf->IsHub      = TRUE;
@@ -1168,7 +1168,7 @@ UsbRootHubResetPort (
   Status  = UsbHcSetRootHubPortFeature (Bus, Port, EfiUsbPortReset);
 
   if (EFI_ERROR (Status)) {
-    DEBUG (( EFI_D_ERROR, "UsbRootHubResetPort: failed to start reset on port %d\n", Port));
+    DEBUG (( DEBUG_ERROR, "UsbRootHubResetPort: failed to start reset on port %d\n", Port));
     return Status;
   }
 
@@ -1181,7 +1181,7 @@ UsbRootHubResetPort (
   Status = UsbHcClearRootHubPortFeature (Bus, Port, EfiUsbPortReset);
 
   if (EFI_ERROR (Status)) {
-    DEBUG (( EFI_D_ERROR, "UsbRootHubResetPort: failed to clear reset on port %d\n", Port));
+    DEBUG (( DEBUG_ERROR, "UsbRootHubResetPort: failed to clear reset on port %d\n", Port));
     return Status;
   }
 
@@ -1208,7 +1208,7 @@ UsbRootHubResetPort (
   }
 
   if (Index == USB_WAIT_PORT_STS_CHANGE_LOOP) {
-    DEBUG ((EFI_D_ERROR, "UsbRootHubResetPort: reset not finished in time on port %d\n", Port));
+    DEBUG ((DEBUG_ERROR, "UsbRootHubResetPort: reset not finished in time on port %d\n", Port));
     return EFI_TIMEOUT;
   }
 
@@ -1220,7 +1220,7 @@ UsbRootHubResetPort (
     // automatically enable the port, we need to enable it manually.
     //
     if (RootIf->MaxSpeed == EFI_USB_SPEED_HIGH) {
-      DEBUG (( EFI_D_ERROR, "UsbRootHubResetPort: release low/full speed device (%d) to UHCI\n", Port));
+      DEBUG (( DEBUG_ERROR, "UsbRootHubResetPort: release low/full speed device (%d) to UHCI\n", Port));
 
       UsbRootHubSetPortFeature (RootIf, Port, EfiUsbPortOwner);
       return EFI_NOT_FOUND;
@@ -1230,7 +1230,7 @@ UsbRootHubResetPort (
       Status = UsbRootHubSetPortFeature (RootIf, Port, EfiUsbPortEnable);
 
       if (EFI_ERROR (Status)) {
-        DEBUG (( EFI_D_ERROR, "UsbRootHubResetPort: failed to enable port %d for UHCI\n", Port));
+        DEBUG (( DEBUG_ERROR, "UsbRootHubResetPort: failed to enable port %d for UHCI\n", Port));
         return Status;
       }
 
@@ -1256,7 +1256,7 @@ UsbRootHubRelease (
   IN USB_INTERFACE        *HubIf
   )
 {
-  DEBUG (( EFI_D_INFO, "UsbRootHubRelease: root hub released for hub %p\n", HubIf));
+  DEBUG (( DEBUG_INFO, "UsbRootHubRelease: root hub released for hub %p\n", HubIf));
 
   gBS->SetTimer (HubIf->HubNotify, TimerCancel, USB_ROOTHUB_POLL_INTERVAL);
   gBS->CloseEvent (HubIf->HubNotify);

--- a/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbUtility.c
+++ b/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbUtility.c
@@ -1212,10 +1212,10 @@ UsbBusRecursivelyConnectWantedUsbIo (
         //
         // Recursively connect the wanted Usb Io handle
         //
-        DEBUG ((EFI_D_INFO, "UsbBusRecursivelyConnectWantedUsbIo: TPL before connect is %d\n", (UINT32)UsbGetCurrentTpl ()));
+        DEBUG ((DEBUG_INFO, "UsbBusRecursivelyConnectWantedUsbIo: TPL before connect is %d\n", (UINT32)UsbGetCurrentTpl ()));
         Status            = gBS->ConnectController (UsbIf->Handle, NULL, NULL, TRUE);
         UsbIf->IsManaged  = (BOOLEAN)!EFI_ERROR (Status);
-        DEBUG ((EFI_D_INFO, "UsbBusRecursivelyConnectWantedUsbIo: TPL after connect is %d\n", (UINT32)UsbGetCurrentTpl()));
+        DEBUG ((DEBUG_INFO, "UsbBusRecursivelyConnectWantedUsbIo: TPL after connect is %d\n", (UINT32)UsbGetCurrentTpl()));
       }
     }
   }
@@ -1224,4 +1224,3 @@ UsbBusRecursivelyConnectWantedUsbIo (
 
   return EFI_SUCCESS;
 }
-

--- a/MdeModulePkg/Bus/Usb/UsbBusPei/HubPeim.c
+++ b/MdeModulePkg/Bus/Usb/UsbBusPei/HubPeim.c
@@ -409,7 +409,7 @@ PeiDoHubConfig (
   PeiUsbDevice->DownStreamPortNo = HubDescriptor->NbrPorts;
 
   if (PeiUsbDevice->DeviceSpeed == EFI_USB_SPEED_SUPER) {
-    DEBUG ((EFI_D_INFO, "PeiDoHubConfig: Set Hub Depth as 0x%x\n", PeiUsbDevice->Tier));
+    DEBUG ((DEBUG_INFO, "PeiDoHubConfig: Set Hub Depth as 0x%x\n", PeiUsbDevice->Tier));
     PeiUsbHubCtrlSetHubDepth (
       PeiServices,
       PeiUsbDevice,
@@ -427,12 +427,12 @@ PeiDoHubConfig (
                 EfiUsbPortPower
                 );
       if (EFI_ERROR (Status)) {
-        DEBUG (( EFI_D_ERROR, "PeiDoHubConfig: PeiHubSetPortFeature EfiUsbPortPower failed %x\n", Index));
+        DEBUG (( DEBUG_ERROR, "PeiDoHubConfig: PeiHubSetPortFeature EfiUsbPortPower failed %x\n", Index));
         continue;
       }
     }
 
-    DEBUG (( EFI_D_INFO, "PeiDoHubConfig: HubDescriptor.PwrOn2PwrGood: 0x%x\n", HubDescriptor->PwrOn2PwrGood));
+    DEBUG (( DEBUG_INFO, "PeiDoHubConfig: HubDescriptor.PwrOn2PwrGood: 0x%x\n", HubDescriptor->PwrOn2PwrGood));
     if (HubDescriptor->PwrOn2PwrGood > 0) {
       MicroSecondDelay (HubDescriptor->PwrOn2PwrGood * USB_SET_PORT_POWER_STALL);
     }
@@ -536,7 +536,7 @@ PeiResetHubPort (
   }
 
   if (Index == USB_WAIT_PORT_STS_CHANGE_LOOP) {
-    DEBUG ((EFI_D_ERROR, "PeiResetHubPort: reset not finished in time on port %d\n", PortNum));
+    DEBUG ((DEBUG_ERROR, "PeiResetHubPort: reset not finished in time on port %d\n", PortNum));
     return;
   }
 

--- a/MdeModulePkg/Bus/Usb/UsbBusPei/UsbIoPeim.c
+++ b/MdeModulePkg/Bus/Usb/UsbBusPei/UsbIoPeim.c
@@ -119,7 +119,7 @@ PeiUsbControlTransfer (
     }
   }
 
-  DEBUG ((EFI_D_INFO, "PeiUsbControlTransfer: %r\n", Status));
+  DEBUG ((DEBUG_INFO, "PeiUsbControlTransfer: %r\n", Status));
   return Status;
 }
 
@@ -232,7 +232,7 @@ PeiUsbBulkTransfer (
     PeiUsbDev->DataToggle = (UINT16) (PeiUsbDev->DataToggle ^ (1 << EndpointIndex));
   }
 
-  DEBUG ((EFI_D_INFO, "PeiUsbBulkTransfer: %r\n", Status));
+  DEBUG ((DEBUG_INFO, "PeiUsbBulkTransfer: %r\n", Status));
   return Status;
 }
 

--- a/MdeModulePkg/Bus/Usb/UsbBusPei/UsbPeim.c
+++ b/MdeModulePkg/Bus/Usb/UsbBusPei/UsbPeim.c
@@ -221,7 +221,7 @@ PeiHubEnumeration (
 
   UsbIoPpi    = &PeiUsbDevice->UsbIoPpi;
 
-  DEBUG ((EFI_D_INFO, "PeiHubEnumeration: DownStreamPortNo: %x\n", PeiUsbDevice->DownStreamPortNo));
+  DEBUG ((DEBUG_INFO, "PeiHubEnumeration: DownStreamPortNo: %x\n", PeiUsbDevice->DownStreamPortNo));
 
   for (Index = 0; Index < PeiUsbDevice->DownStreamPortNo; Index++) {
 
@@ -236,7 +236,7 @@ PeiHubEnumeration (
       continue;
     }
 
-    DEBUG ((EFI_D_INFO, "USB Status --- Port: %x ConnectChange[%04x] Status[%04x]\n", Index, PortStatus.PortChangeStatus, PortStatus.PortStatus));
+    DEBUG ((DEBUG_INFO, "USB Status --- Port: %x ConnectChange[%04x] Status[%04x]\n", Index, PortStatus.PortChangeStatus, PortStatus.PortStatus));
     //
     // Only handle connection/enable/overcurrent/reset change.
     //
@@ -305,7 +305,7 @@ PeiHubEnumeration (
         }
 
         NewPeiUsbDevice->DeviceSpeed = (UINT8) PeiUsbGetDeviceSpeed (PortStatus.PortStatus);
-        DEBUG ((EFI_D_INFO, "Device Speed =%d\n", PeiUsbDevice->DeviceSpeed));
+        DEBUG ((DEBUG_INFO, "Device Speed =%d\n", PeiUsbDevice->DeviceSpeed));
 
         if (USB_BIT_IS_SET (PortStatus.PortStatus, USB_PORT_STAT_SUPER_SPEED)){
           NewPeiUsbDevice->MaxPacketSize0 = 512;
@@ -339,7 +339,7 @@ PeiHubEnumeration (
         if (EFI_ERROR (Status)) {
           continue;
         }
-        DEBUG ((EFI_D_INFO, "PeiHubEnumeration: PeiConfigureUsbDevice Success\n"));
+        DEBUG ((DEBUG_INFO, "PeiHubEnumeration: PeiConfigureUsbDevice Success\n"));
 
         Status = PeiServicesInstallPpi (&NewPeiUsbDevice->UsbIoPpiList);
 
@@ -445,7 +445,7 @@ PeiUsbEnumeration (
     return EFI_INVALID_PARAMETER;
   }
 
-  DEBUG ((EFI_D_INFO, "PeiUsbEnumeration: NumOfRootPort: %x\n", NumOfRootPort));
+  DEBUG ((DEBUG_INFO, "PeiUsbEnumeration: NumOfRootPort: %x\n", NumOfRootPort));
 
   for (Index = 0; Index < NumOfRootPort; Index++) {
     //
@@ -466,7 +466,7 @@ PeiUsbEnumeration (
                   &PortStatus
                   );
     }
-    DEBUG ((EFI_D_INFO, "USB Status --- Port: %x ConnectChange[%04x] Status[%04x]\n", Index, PortStatus.PortChangeStatus, PortStatus.PortStatus));
+    DEBUG ((DEBUG_INFO, "USB Status --- Port: %x ConnectChange[%04x] Status[%04x]\n", Index, PortStatus.PortChangeStatus, PortStatus.PortStatus));
     //
     // Only handle connection/enable/overcurrent/reset change.
     //
@@ -555,7 +555,7 @@ PeiUsbEnumeration (
         }
 
         PeiUsbDevice->DeviceSpeed = (UINT8) PeiUsbGetDeviceSpeed (PortStatus.PortStatus);
-        DEBUG ((EFI_D_INFO, "Device Speed =%d\n", PeiUsbDevice->DeviceSpeed));
+        DEBUG ((DEBUG_INFO, "Device Speed =%d\n", PeiUsbDevice->DeviceSpeed));
 
         if (USB_BIT_IS_SET (PortStatus.PortStatus, USB_PORT_STAT_SUPER_SPEED)){
           PeiUsbDevice->MaxPacketSize0 = 512;
@@ -580,7 +580,7 @@ PeiUsbEnumeration (
         if (EFI_ERROR (Status)) {
           continue;
         }
-        DEBUG ((EFI_D_INFO, "PeiUsbEnumeration: PeiConfigureUsbDevice Success\n"));
+        DEBUG ((DEBUG_INFO, "PeiUsbEnumeration: PeiConfigureUsbDevice Success\n"));
 
         Status = PeiServicesInstallPpi (&PeiUsbDevice->UsbIoPpiList);
 
@@ -685,13 +685,13 @@ PeiConfigureUsbDevice (
                );
 
     if (!EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_INFO, "PeiUsbGet Device Descriptor the %d time Success\n", Retry));
+      DEBUG ((DEBUG_INFO, "PeiUsbGet Device Descriptor the %d time Success\n", Retry));
       break;
     }
   }
 
   if (Retry == 3) {
-    DEBUG ((EFI_D_ERROR, "PeiUsbGet Device Descriptor fail: %x %r\n", Retry, Status));
+    DEBUG ((DEBUG_ERROR, "PeiUsbGet Device Descriptor fail: %x %r\n", Retry, Status));
     return Status;
   }
 
@@ -710,7 +710,7 @@ PeiConfigureUsbDevice (
             );
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "PeiUsbSetDeviceAddress Failed: %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "PeiUsbSetDeviceAddress Failed: %r\n", Status));
     return Status;
   }
   MicroSecondDelay (USB_SET_DEVICE_ADDRESS_STALL);
@@ -730,7 +730,7 @@ PeiConfigureUsbDevice (
             );
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "PeiUsbGetDescriptor First Failed\n"));
+    DEBUG ((DEBUG_ERROR, "PeiUsbGetDescriptor First Failed\n"));
     return Status;
   }
 
@@ -801,7 +801,7 @@ PeiUsbGetAllConfiguration (
             );
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "PeiUsbGet Config Descriptor First Failed\n"));
+    DEBUG ((DEBUG_ERROR, "PeiUsbGet Config Descriptor First Failed\n"));
     return Status;
   }
   MicroSecondDelay (USB_GET_CONFIG_DESCRIPTOR_STALL);
@@ -836,7 +836,7 @@ PeiUsbGetAllConfiguration (
             );
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "PeiUsbGet Config Descriptor all Failed\n"));
+    DEBUG ((DEBUG_ERROR, "PeiUsbGet Config Descriptor all Failed\n"));
     return Status;
   }
   //
@@ -1046,7 +1046,7 @@ ResetRootPort (
                          );
 
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "SetRootHubPortFeature EfiUsbPortReset Failed\n"));
+      DEBUG ((DEBUG_ERROR, "SetRootHubPortFeature EfiUsbPortReset Failed\n"));
       return;
     }
 
@@ -1067,7 +1067,7 @@ ResetRootPort (
                          );
 
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "ClearRootHubPortFeature EfiUsbPortReset Failed\n"));
+      DEBUG ((DEBUG_ERROR, "ClearRootHubPortFeature EfiUsbPortReset Failed\n"));
       return;
     }
 
@@ -1098,7 +1098,7 @@ ResetRootPort (
     }
 
     if (Index == USB_WAIT_PORT_STS_CHANGE_LOOP) {
-      DEBUG ((EFI_D_ERROR, "ResetRootPort: reset not finished in time on port %d\n", PortNum));
+      DEBUG ((DEBUG_ERROR, "ResetRootPort: reset not finished in time on port %d\n", PortNum));
       return;
     }
 
@@ -1148,7 +1148,7 @@ ResetRootPort (
                          );
 
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "SetRootHubPortFeature EfiUsbPortReset Failed\n"));
+      DEBUG ((DEBUG_ERROR, "SetRootHubPortFeature EfiUsbPortReset Failed\n"));
       return;
     }
 
@@ -1169,7 +1169,7 @@ ResetRootPort (
                          );
 
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "ClearRootHubPortFeature EfiUsbPortReset Failed\n"));
+      DEBUG ((DEBUG_ERROR, "ClearRootHubPortFeature EfiUsbPortReset Failed\n"));
       return;
     }
 
@@ -1200,7 +1200,7 @@ ResetRootPort (
     }
 
     if (Index == USB_WAIT_PORT_STS_CHANGE_LOOP) {
-      DEBUG ((EFI_D_ERROR, "ResetRootPort: reset not finished in time on port %d\n", PortNum));
+      DEBUG ((DEBUG_ERROR, "ResetRootPort: reset not finished in time on port %d\n", PortNum));
       return;
     }
 
@@ -1239,5 +1239,3 @@ ResetRootPort (
   }
   return;
 }
-
-

--- a/MdeModulePkg/Bus/Usb/UsbMassStorageDxe/UsbMassBoot.c
+++ b/MdeModulePkg/Bus/Usb/UsbMassStorageDxe/UsbMassBoot.c
@@ -58,7 +58,7 @@ UsbBootRequestSense (
                         &CmdResult
                         );
   if (EFI_ERROR (Status) || CmdResult != USB_MASS_CMD_SUCCESS) {
-    DEBUG ((EFI_D_ERROR, "UsbBootRequestSense: (%r) CmdResult=0x%x\n", Status, CmdResult));
+    DEBUG ((DEBUG_ERROR, "UsbBootRequestSense: (%r) CmdResult=0x%x\n", Status, CmdResult));
     if (!EFI_ERROR (Status)) {
       Status = EFI_DEVICE_ERROR;
     }
@@ -131,7 +131,7 @@ UsbBootRequestSense (
     break;
   }
 
-  DEBUG ((EFI_D_INFO, "UsbBootRequestSense: (%r) with error code (%x) sense key %x/%x/%x\n",
+  DEBUG ((DEBUG_INFO, "UsbBootRequestSense: (%r) with error code (%x) sense key %x/%x/%x\n",
           Status,
           SenseData.ErrorCode,
           USB_BOOT_SENSE_KEY (SenseData.SenseKey),
@@ -191,7 +191,7 @@ UsbBootExecCmd (
                            );
 
   if (Status == EFI_TIMEOUT) {
-    DEBUG ((EFI_D_ERROR, "UsbBootExecCmd: %r to Exec 0x%x Cmd\n", Status, *(UINT8 *)Cmd));
+    DEBUG ((DEBUG_ERROR, "UsbBootExecCmd: %r to Exec 0x%x Cmd\n", Status, *(UINT8 *)Cmd));
     return EFI_TIMEOUT;
   }
 
@@ -206,7 +206,7 @@ UsbBootExecCmd (
   //
   // If command execution failed, then retrieve error info via sense request.
   //
-  DEBUG ((EFI_D_ERROR, "UsbBootExecCmd: %r to Exec 0x%x Cmd (Result = %x)\n", Status, *(UINT8 *)Cmd, CmdResult));
+  DEBUG ((DEBUG_ERROR, "UsbBootExecCmd: %r to Exec 0x%x Cmd (Result = %x)\n", Status, *(UINT8 *)Cmd, CmdResult));
   return UsbBootRequestSense (UsbMass);
 }
 
@@ -631,7 +631,7 @@ UsbBootGetParams (
 
   Status = UsbBootInquiry (UsbMass);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "UsbBootGetParams: UsbBootInquiry (%r)\n", Status));
+    DEBUG ((DEBUG_ERROR, "UsbBootGetParams: UsbBootInquiry (%r)\n", Status));
     return Status;
   }
 
@@ -643,7 +643,7 @@ UsbBootGetParams (
        (UsbMass->Pdt != USB_PDT_CDROM) &&
        (UsbMass->Pdt != USB_PDT_OPTICAL) &&
        (UsbMass->Pdt != USB_PDT_SIMPLE_DIRECT)) {
-    DEBUG ((EFI_D_ERROR, "UsbBootGetParams: Found an unsupported peripheral type[%d]\n", UsbMass->Pdt));
+    DEBUG ((DEBUG_ERROR, "UsbBootGetParams: Found an unsupported peripheral type[%d]\n", UsbMass->Pdt));
     return EFI_UNSUPPORTED;
   }
 
@@ -695,7 +695,7 @@ UsbBootDetectMedia (
 
   Status = UsbBootIsUnitReady (UsbMass);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "UsbBootDetectMedia: UsbBootIsUnitReady (%r)\n", Status));
+    DEBUG ((DEBUG_ERROR, "UsbBootDetectMedia: UsbBootIsUnitReady (%r)\n", Status));
   }
 
   //
@@ -719,7 +719,7 @@ UsbBootDetectMedia (
 
     Status = UsbBootReadCapacity (UsbMass);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "UsbBootDetectMedia: UsbBootReadCapacity (%r)\n", Status));
+      DEBUG ((DEBUG_ERROR, "UsbBootDetectMedia: UsbBootReadCapacity (%r)\n", Status));
     }
   }
 

--- a/MdeModulePkg/Bus/Usb/UsbMassStorageDxe/UsbMassBot.c
+++ b/MdeModulePkg/Bus/Usb/UsbMassStorageDxe/UsbMassBot.c
@@ -266,13 +266,13 @@ UsbBotDataTransfer (
                             );
   if (EFI_ERROR (Status)) {
     if (USB_IS_ERROR (Result, EFI_USB_ERR_STALL)) {
-      DEBUG ((EFI_D_INFO, "UsbBotDataTransfer: (%r)\n", Status));
-      DEBUG ((EFI_D_INFO, "UsbBotDataTransfer: DataIn Stall\n"));
+      DEBUG ((DEBUG_INFO, "UsbBotDataTransfer: (%r)\n", Status));
+      DEBUG ((DEBUG_INFO, "UsbBotDataTransfer: DataIn Stall\n"));
       UsbClearEndpointStall (UsbBot->UsbIo, Endpoint->EndpointAddress);
     } else if (USB_IS_ERROR (Result, EFI_USB_ERR_NAK)) {
       Status = EFI_NOT_READY;
     } else {
-      DEBUG ((EFI_D_ERROR, "UsbBotDataTransfer: (%r)\n", Status));
+      DEBUG ((DEBUG_ERROR, "UsbBotDataTransfer: (%r)\n", Status));
     }
     if(Status == EFI_TIMEOUT){
       UsbBotResetDevice(UsbBot, FALSE);
@@ -416,7 +416,7 @@ UsbBotExecCommand (
   //
   Status = UsbBotSendCommand (UsbBot, Cmd, CmdLen, DataDir, DataLen, Lun);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "UsbBotExecCommand: UsbBotSendCommand (%r)\n", Status));
+    DEBUG ((DEBUG_ERROR, "UsbBotExecCommand: UsbBotSendCommand (%r)\n", Status));
     return Status;
   }
 
@@ -433,7 +433,7 @@ UsbBotExecCommand (
   //
   Status = UsbBotGetStatus (UsbBot, DataLen, &Result);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "UsbBotExecCommand: UsbBotGetStatus (%r)\n", Status));
+    DEBUG ((DEBUG_ERROR, "UsbBotExecCommand: UsbBotGetStatus (%r)\n", Status));
     return Status;
   }
 
@@ -604,4 +604,3 @@ UsbBotCleanUp (
   FreePool (Context);
   return EFI_SUCCESS;
 }
-

--- a/MdeModulePkg/Bus/Usb/UsbMassStorageDxe/UsbMassCbi.c
+++ b/MdeModulePkg/Bus/Usb/UsbMassStorageDxe/UsbMassCbi.c
@@ -451,7 +451,7 @@ UsbCbiExecCommand (
   Status = UsbCbiSendCommand (UsbCbi, Cmd, CmdLen, Timeout);
   if (EFI_ERROR (Status)) {
     gBS->Stall(10 * USB_MASS_1_MILLISECOND);
-    DEBUG ((EFI_D_ERROR, "UsbCbiExecCommand: UsbCbiSendCommand (%r)\n",Status));
+    DEBUG ((DEBUG_ERROR, "UsbCbiExecCommand: UsbCbiSendCommand (%r)\n",Status));
     return Status;
   }
 
@@ -463,7 +463,7 @@ UsbCbiExecCommand (
 
   Status   = UsbCbiDataTransfer (UsbCbi, DataDir, Data, &TransLen, Timeout);
   if (UsbCbi->InterruptEndpoint == NULL) {
-    DEBUG ((EFI_D_ERROR, "UsbCbiExecCommand: UsbCbiDataTransfer (%r)\n",Status));
+    DEBUG ((DEBUG_ERROR, "UsbCbiExecCommand: UsbCbiDataTransfer (%r)\n",Status));
     return Status;
   }
 
@@ -472,7 +472,7 @@ UsbCbiExecCommand (
   //
   Status = UsbCbiGetStatus (UsbCbi, Timeout, &Result);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "UsbCbiExecCommand: UsbCbiGetStatus (%r)\n",Status));
+    DEBUG ((DEBUG_ERROR, "UsbCbiExecCommand: UsbCbiGetStatus (%r)\n",Status));
     return Status;
   }
 

--- a/MdeModulePkg/Bus/Usb/UsbMassStorageDxe/UsbMassImpl.c
+++ b/MdeModulePkg/Bus/Usb/UsbMassStorageDxe/UsbMassImpl.c
@@ -172,7 +172,7 @@ UsbMassReadBlocks (
   }
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "UsbMassReadBlocks: UsbBootReadBlocks (%r) -> Reset\n", Status));
+    DEBUG ((DEBUG_ERROR, "UsbMassReadBlocks: UsbBootReadBlocks (%r) -> Reset\n", Status));
     UsbMassReset (This, TRUE);
   }
 
@@ -292,7 +292,7 @@ UsbMassWriteBlocks (
   }
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "UsbMassWriteBlocks: UsbBootWriteBlocks (%r) -> Reset\n", Status));
+    DEBUG ((DEBUG_ERROR, "UsbMassWriteBlocks: UsbBootWriteBlocks (%r) -> Reset\n", Status));
     UsbMassReset (This, TRUE);
   }
 
@@ -491,7 +491,7 @@ UsbMassInitMultiLun (
 
   for (Index = 0; Index <= MaxLun; Index++) {
 
-    DEBUG ((EFI_D_INFO, "UsbMassInitMultiLun: Start to initialize No.%d logic unit\n", Index));
+    DEBUG ((DEBUG_INFO, "UsbMassInitMultiLun: Start to initialize No.%d logic unit\n", Index));
 
     UsbIo   = NULL;
     UsbMass = AllocateZeroPool (sizeof (USB_MASS_DEVICE));
@@ -514,7 +514,7 @@ UsbMassInitMultiLun (
     //
     Status = UsbMassInitMedia (UsbMass);
     if ((EFI_ERROR (Status)) && (Status != EFI_NO_MEDIA)) {
-      DEBUG ((EFI_D_ERROR, "UsbMassInitMultiLun: UsbMassInitMedia (%r)\n", Status));
+      DEBUG ((DEBUG_ERROR, "UsbMassInitMultiLun: UsbMassInitMedia (%r)\n", Status));
       FreePool (UsbMass);
       continue;
     }
@@ -531,7 +531,7 @@ UsbMassInitMultiLun (
     UsbMass->DevicePath = AppendDevicePathNode (DevicePath, &LunNode.Header);
 
     if (UsbMass->DevicePath == NULL) {
-      DEBUG ((EFI_D_ERROR, "UsbMassInitMultiLun: failed to create device logic unit device path\n"));
+      DEBUG ((DEBUG_ERROR, "UsbMassInitMultiLun: failed to create device logic unit device path\n"));
       Status = EFI_OUT_OF_RESOURCES;
       FreePool (UsbMass);
       continue;
@@ -554,7 +554,7 @@ UsbMassInitMultiLun (
                     );
 
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "UsbMassInitMultiLun: InstallMultipleProtocolInterfaces (%r)\n", Status));
+      DEBUG ((DEBUG_ERROR, "UsbMassInitMultiLun: InstallMultipleProtocolInterfaces (%r)\n", Status));
       FreePool (UsbMass->DevicePath);
       FreePool (UsbMass);
       continue;
@@ -573,7 +573,7 @@ UsbMassInitMultiLun (
                     );
 
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "UsbMassInitMultiLun: OpenUsbIoProtocol By Child (%r)\n", Status));
+      DEBUG ((DEBUG_ERROR, "UsbMassInitMultiLun: OpenUsbIoProtocol By Child (%r)\n", Status));
       gBS->UninstallMultipleProtocolInterfaces (
              UsbMass->Controller,
              &gEfiDevicePathProtocolGuid,
@@ -589,7 +589,7 @@ UsbMassInitMultiLun (
       continue;
     }
     ReturnStatus = EFI_SUCCESS;
-    DEBUG ((EFI_D_INFO, "UsbMassInitMultiLun: Success to initialize No.%d logic unit\n", Index));
+    DEBUG ((DEBUG_INFO, "UsbMassInitMultiLun: Success to initialize No.%d logic unit\n", Index));
   }
 
   return ReturnStatus;
@@ -633,7 +633,7 @@ UsbMassInitNonLun (
                   );
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "UsbMassInitNonLun: OpenUsbIoProtocol By Driver (%r)\n", Status));
+    DEBUG ((DEBUG_ERROR, "UsbMassInitNonLun: OpenUsbIoProtocol By Driver (%r)\n", Status));
     goto ON_ERROR;
   }
 
@@ -654,7 +654,7 @@ UsbMassInitNonLun (
   //
   Status = UsbMassInitMedia (UsbMass);
   if ((EFI_ERROR (Status)) && (Status != EFI_NO_MEDIA)) {
-    DEBUG ((EFI_D_ERROR, "UsbMassInitNonLun: UsbMassInitMedia (%r)\n", Status));
+    DEBUG ((DEBUG_ERROR, "UsbMassInitNonLun: UsbMassInitMedia (%r)\n", Status));
     goto ON_ERROR;
   }
 
@@ -810,7 +810,7 @@ USBMassDriverBindingStart (
   Status = UsbMassInitTransport (This, Controller, &Transport, &Context, &MaxLun);
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "USBMassDriverBindingStart: UsbMassInitTransport (%r)\n", Status));
+    DEBUG ((DEBUG_ERROR, "USBMassDriverBindingStart: UsbMassInitTransport (%r)\n", Status));
     goto Exit;
   }
   if (MaxLun == 0) {
@@ -819,7 +819,7 @@ USBMassDriverBindingStart (
     //
     Status = UsbMassInitNonLun (This, Controller, Transport, Context);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "USBMassDriverBindingStart: UsbMassInitNonLun (%r)\n", Status));
+      DEBUG ((DEBUG_ERROR, "USBMassDriverBindingStart: UsbMassInitNonLun (%r)\n", Status));
     }
   } else {
     //
@@ -835,7 +835,7 @@ USBMassDriverBindingStart (
                     );
 
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "USBMassDriverBindingStart: OpenDevicePathProtocol By Driver (%r)\n", Status));
+      DEBUG ((DEBUG_ERROR, "USBMassDriverBindingStart: OpenDevicePathProtocol By Driver (%r)\n", Status));
       goto Exit;
     }
 
@@ -849,7 +849,7 @@ USBMassDriverBindingStart (
                     );
 
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "USBMassDriverBindingStart: OpenUsbIoProtocol By Driver (%r)\n", Status));
+      DEBUG ((DEBUG_ERROR, "USBMassDriverBindingStart: OpenUsbIoProtocol By Driver (%r)\n", Status));
       gBS->CloseProtocol (
              Controller,
              &gEfiDevicePathProtocolGuid,
@@ -877,7 +877,7 @@ USBMassDriverBindingStart (
               This->DriverBindingHandle,
               Controller
               );
-      DEBUG ((EFI_D_ERROR, "USBMassDriverBindingStart: UsbMassInitMultiLun (%r) with Maxlun=%d\n", Status, MaxLun));
+      DEBUG ((DEBUG_ERROR, "USBMassDriverBindingStart: UsbMassInitMultiLun (%r) with Maxlun=%d\n", Status, MaxLun));
     }
   }
 Exit:
@@ -953,7 +953,7 @@ USBMassDriverBindingStop (
             This->DriverBindingHandle,
             Controller
             );
-      DEBUG ((EFI_D_INFO, "Success to stop multi-lun root handle\n"));
+      DEBUG ((DEBUG_INFO, "Success to stop multi-lun root handle\n"));
       return EFI_SUCCESS;
     }
 
@@ -989,7 +989,7 @@ USBMassDriverBindingStop (
     UsbMass->Transport->CleanUp (UsbMass->Context);
     FreePool (UsbMass);
 
-    DEBUG ((EFI_D_INFO, "Success to stop non-multi-lun root handle\n"));
+    DEBUG ((DEBUG_INFO, "Success to stop non-multi-lun root handle\n"));
     return EFI_SUCCESS;
   }
 
@@ -1012,7 +1012,7 @@ USBMassDriverBindingStop (
                     );
     if (EFI_ERROR (Status)) {
       AllChildrenStopped = FALSE;
-      DEBUG ((EFI_D_ERROR, "Fail to stop No.%d multi-lun child handle when opening blockio\n", (UINT32)Index));
+      DEBUG ((DEBUG_ERROR, "Fail to stop No.%d multi-lun child handle when opening blockio\n", (UINT32)Index));
       continue;
     }
 
@@ -1041,7 +1041,7 @@ USBMassDriverBindingStop (
       // Fail to uninstall Block I/O Protocol and Device Path Protocol, so re-open USB I/O Protocol by child.
       //
       AllChildrenStopped = FALSE;
-      DEBUG ((EFI_D_ERROR, "Fail to stop No.%d multi-lun child handle when uninstalling blockio and devicepath\n", (UINT32)Index));
+      DEBUG ((DEBUG_ERROR, "Fail to stop No.%d multi-lun child handle when uninstalling blockio and devicepath\n", (UINT32)Index));
 
       gBS->OpenProtocol (
              Controller,
@@ -1066,7 +1066,7 @@ USBMassDriverBindingStop (
     return EFI_DEVICE_ERROR;
   }
 
-  DEBUG ((EFI_D_INFO, "Success to stop all %d multi-lun children handles\n", (UINT32) NumberOfChildren));
+  DEBUG ((DEBUG_INFO, "Success to stop all %d multi-lun children handles\n", (UINT32) NumberOfChildren));
   return EFI_SUCCESS;
 }
 

--- a/MdeModulePkg/Core/Dxe/Dispatcher/Dispatcher.c
+++ b/MdeModulePkg/Core/Dxe/Dispatcher/Dispatcher.c
@@ -769,7 +769,7 @@ FvIsBeingProcessed (
     for (Link = mFvHandleList.ForwardLink; Link != &mFvHandleList; Link = Link->ForwardLink) {
       KnownHandle = CR(Link, KNOWN_HANDLE, Link, KNOWN_HANDLE_SIGNATURE);
       if (CompareGuid (&FvNameGuid, &KnownHandle->FvNameGuid)) {
-        DEBUG ((EFI_D_ERROR, "FvImage on FvHandle %p and %p has the same FvNameGuid %g.\n", FvHandle, KnownHandle->Handle, &FvNameGuid));
+        DEBUG ((DEBUG_ERROR, "FvImage on FvHandle %p and %p has the same FvNameGuid %g.\n", FvHandle, KnownHandle->Handle, &FvNameGuid));
         return NULL;
       }
     }

--- a/MdeModulePkg/Core/Dxe/Event/Tpl.c
+++ b/MdeModulePkg/Core/Dxe/Event/Tpl.c
@@ -60,7 +60,7 @@ CoreRaiseTpl (
 
   OldTpl = gEfiCurrentTpl;
   if (OldTpl > NewTpl) {
-    DEBUG ((EFI_D_ERROR, "FATAL ERROR - RaiseTpl with OldTpl(0x%x) > NewTpl(0x%x)\n", OldTpl, NewTpl));
+    DEBUG ((DEBUG_ERROR, "FATAL ERROR - RaiseTpl with OldTpl(0x%x) > NewTpl(0x%x)\n", OldTpl, NewTpl));
     ASSERT (FALSE);
   }
   ASSERT (VALID_TPL (NewTpl));
@@ -101,7 +101,7 @@ CoreRestoreTpl (
 
   OldTpl = gEfiCurrentTpl;
   if (NewTpl > OldTpl) {
-    DEBUG ((EFI_D_ERROR, "FATAL ERROR - RestoreTpl with NewTpl(0x%x) > OldTpl(0x%x)\n", NewTpl, OldTpl));
+    DEBUG ((DEBUG_ERROR, "FATAL ERROR - RestoreTpl with NewTpl(0x%x) > OldTpl(0x%x)\n", NewTpl, OldTpl));
     ASSERT (FALSE);
   }
   ASSERT (VALID_TPL (NewTpl));

--- a/MdeModulePkg/Core/Dxe/FwVol/FwVol.c
+++ b/MdeModulePkg/Core/Dxe/FwVol/FwVol.c
@@ -463,7 +463,7 @@ FvCheck (
           (FileState == EFI_FILE_HEADER_CONSTRUCTION)) {
         if (IS_FFS_FILE2 (FfsHeader)) {
           if (!FvDevice->IsFfs3Fv) {
-            DEBUG ((EFI_D_ERROR, "Found a FFS3 formatted file: %g in a non-FFS3 formatted FV.\n", &FfsHeader->Name));
+            DEBUG ((DEBUG_ERROR, "Found a FFS3 formatted file: %g in a non-FFS3 formatted FV.\n", &FfsHeader->Name));
           }
           FfsHeader = (EFI_FFS_FILE_HEADER *) ((UINT8 *) FfsHeader + sizeof (EFI_FFS_FILE_HEADER2));
         } else {
@@ -508,7 +508,7 @@ FvCheck (
     if (IS_FFS_FILE2 (CacheFfsHeader)) {
       ASSERT (FFS_FILE2_SIZE (CacheFfsHeader) > 0x00FFFFFF);
       if (!FvDevice->IsFfs3Fv) {
-        DEBUG ((EFI_D_ERROR, "Found a FFS3 formatted file: %g in a non-FFS3 formatted FV.\n", &CacheFfsHeader->Name));
+        DEBUG ((DEBUG_ERROR, "Found a FFS3 formatted file: %g in a non-FFS3 formatted FV.\n", &CacheFfsHeader->Name));
         FfsHeader = (EFI_FFS_FILE_HEADER *) ((UINT8 *) FfsHeader + FFS_FILE2_SIZE (CacheFfsHeader));
         //
         // Adjust pointer to the next 8-byte aligned boundary.
@@ -725,5 +725,3 @@ FwVolDriverInit (
                           );
   return EFI_SUCCESS;
 }
-
-

--- a/MdeModulePkg/Core/Dxe/Gcd/Gcd.c
+++ b/MdeModulePkg/Core/Dxe/Gcd/Gcd.c
@@ -2384,8 +2384,8 @@ CoreInitializeMemoryServices (
     }
   }
 
-  DEBUG ((EFI_D_INFO, "CoreInitializeMemoryServices:\n"));
-  DEBUG ((EFI_D_INFO, "  BaseAddress - 0x%lx Length - 0x%lx MinimalMemorySizeNeeded - 0x%lx\n", BaseAddress, Length, MinimalMemorySizeNeeded));
+  DEBUG ((DEBUG_INFO, "CoreInitializeMemoryServices:\n"));
+  DEBUG ((DEBUG_INFO, "  BaseAddress - 0x%lx Length - 0x%lx MinimalMemorySizeNeeded - 0x%lx\n", BaseAddress, Length, MinimalMemorySizeNeeded));
 
   //
   // If no memory regions are found that are big enough to initialize the DXE core, then ASSERT().

--- a/MdeModulePkg/Core/Dxe/Image/Image.c
+++ b/MdeModulePkg/Core/Dxe/Image/Image.c
@@ -485,7 +485,7 @@ GetPeCoffImageFixLoadingAssignedAddress(
      }
      SectionHeaderOffset += sizeof (EFI_IMAGE_SECTION_HEADER);
    }
-   DEBUG ((EFI_D_INFO|EFI_D_LOAD, "LOADING MODULE FIXED INFO: Loading module at fixed address 0x%11p. Status = %r \n", (VOID *)(UINTN)(ImageContext->ImageAddress), Status));
+   DEBUG ((DEBUG_INFO|DEBUG_LOAD, "LOADING MODULE FIXED INFO: Loading module at fixed address 0x%11p. Status = %r \n", (VOID *)(UINTN)(ImageContext->ImageAddress), Status));
    return Status;
 }
 
@@ -648,7 +648,7 @@ CoreLoadPeImage (
           //
           // If the code memory is not ready, invoke CoreAllocatePage with AllocateAnyPages to load the driver.
           //
-          DEBUG ((EFI_D_INFO|EFI_D_LOAD, "LOADING MODULE FIXED ERROR: Loading module at fixed address failed since specified memory is not available.\n"));
+          DEBUG ((DEBUG_INFO|DEBUG_LOAD, "LOADING MODULE FIXED ERROR: Loading module at fixed address failed since specified memory is not available.\n"));
 
           Status = CoreAllocatePages (
                      AllocateAnyPages,
@@ -1587,8 +1587,8 @@ CoreStartImage (
     // Do not ASSERT here, because image might be loaded via EFI_IMAGE_MACHINE_CROSS_TYPE_SUPPORTED
     // But it can not be started.
     //
-    DEBUG ((EFI_D_ERROR, "Image type %s can't be started ", GetMachineTypeName(Image->Machine)));
-    DEBUG ((EFI_D_ERROR, "on %s UEFI system.\n", GetMachineTypeName(mDxeCoreImageMachineType)));
+    DEBUG ((DEBUG_ERROR, "Image type %s can't be started ", GetMachineTypeName(Image->Machine)));
+    DEBUG ((DEBUG_ERROR, "on %s UEFI system.\n", GetMachineTypeName(mDxeCoreImageMachineType)));
     return EFI_UNSUPPORTED;
   }
 

--- a/MdeModulePkg/Core/Dxe/Mem/MemoryProfileRecord.c
+++ b/MdeModulePkg/Core/Dxe/Mem/MemoryProfileRecord.c
@@ -611,7 +611,7 @@ MemoryProfileInit (
 
   RegisterDxeCore (HobStart, &mMemoryProfileContext);
 
-  DEBUG ((EFI_D_INFO, "MemoryProfileInit MemoryProfileContext - 0x%x\n", &mMemoryProfileContext));
+  DEBUG ((DEBUG_INFO, "MemoryProfileInit MemoryProfileContext - 0x%x\n", &mMemoryProfileContext));
 }
 
 /**

--- a/MdeModulePkg/Core/Dxe/Misc/DebugImageInfo.c
+++ b/MdeModulePkg/Core/Dxe/Misc/DebugImageInfo.c
@@ -66,7 +66,7 @@ CoreInitializeDebugImageInfoTable (
              );
   if (EFI_ERROR (Status)) {
     if (PcdGet64 (PcdMaxEfiSystemTablePointerAddress) != 0) {
-      DEBUG ((EFI_D_INFO, "Allocate memory for EFI_SYSTEM_TABLE_POINTER below PcdMaxEfiSystemTablePointerAddress failed. \
+      DEBUG ((DEBUG_INFO, "Allocate memory for EFI_SYSTEM_TABLE_POINTER below PcdMaxEfiSystemTablePointerAddress failed. \
                           Retry to allocate memroy as close to the top of memory as feasible.\n"));
     }
     //
@@ -278,5 +278,3 @@ CoreRemoveDebugImageInfoEntry (
   }
   mDebugInfoTableHeader.UpdateStatus &= ~EFI_DEBUG_IMAGE_INFO_UPDATE_IN_PROGRESS;
 }
-
-

--- a/MdeModulePkg/Core/Dxe/Misc/MemoryAttributesTable.c
+++ b/MdeModulePkg/Core/Dxe/Misc/MemoryAttributesTable.c
@@ -120,7 +120,7 @@ InstallMemoryAttributesTable (
 
   if (!mMemoryAttributesTableEnable) {
     DEBUG ((DEBUG_VERBOSE, "Cannot install Memory Attributes Table "));
-    DEBUG ((EFI_D_VERBOSE, "because Runtime Driver Section Alignment is not %dK.\n", RUNTIME_PAGE_ALLOCATION_GRANULARITY >> 10));
+    DEBUG ((DEBUG_VERBOSE, "because Runtime Driver Section Alignment is not %dK.\n", RUNTIME_PAGE_ALLOCATION_GRANULARITY >> 10));
     return ;
   }
 
@@ -182,10 +182,10 @@ InstallMemoryAttributesTable (
   MemoryAttributesTable->NumberOfEntries = RuntimeEntryCount;
   MemoryAttributesTable->DescriptorSize  = (UINT32)DescriptorSize;
   MemoryAttributesTable->Reserved        = 0;
-  DEBUG ((EFI_D_VERBOSE, "MemoryAttributesTable:\n"));
-  DEBUG ((EFI_D_VERBOSE, "  Version              - 0x%08x\n", MemoryAttributesTable->Version));
-  DEBUG ((EFI_D_VERBOSE, "  NumberOfEntries      - 0x%08x\n", MemoryAttributesTable->NumberOfEntries));
-  DEBUG ((EFI_D_VERBOSE, "  DescriptorSize       - 0x%08x\n", MemoryAttributesTable->DescriptorSize));
+  DEBUG ((DEBUG_VERBOSE, "MemoryAttributesTable:\n"));
+  DEBUG ((DEBUG_VERBOSE, "  Version              - 0x%08x\n", MemoryAttributesTable->Version));
+  DEBUG ((DEBUG_VERBOSE, "  NumberOfEntries      - 0x%08x\n", MemoryAttributesTable->NumberOfEntries));
+  DEBUG ((DEBUG_VERBOSE, "  DescriptorSize       - 0x%08x\n", MemoryAttributesTable->DescriptorSize));
   MemoryAttributesEntry = (EFI_MEMORY_DESCRIPTOR *)(MemoryAttributesTable + 1);
   MemoryMap = MemoryMapStart;
   for (Index = 0; Index < MemoryMapSize/DescriptorSize; Index++) {
@@ -194,12 +194,12 @@ InstallMemoryAttributesTable (
     case EfiRuntimeServicesData:
       CopyMem (MemoryAttributesEntry, MemoryMap, DescriptorSize);
       MemoryAttributesEntry->Attribute &= (EFI_MEMORY_RO|EFI_MEMORY_XP|EFI_MEMORY_RUNTIME);
-      DEBUG ((EFI_D_VERBOSE, "Entry (0x%x)\n", MemoryAttributesEntry));
-      DEBUG ((EFI_D_VERBOSE, "  Type              - 0x%x\n", MemoryAttributesEntry->Type));
-      DEBUG ((EFI_D_VERBOSE, "  PhysicalStart     - 0x%016lx\n", MemoryAttributesEntry->PhysicalStart));
-      DEBUG ((EFI_D_VERBOSE, "  VirtualStart      - 0x%016lx\n", MemoryAttributesEntry->VirtualStart));
-      DEBUG ((EFI_D_VERBOSE, "  NumberOfPages     - 0x%016lx\n", MemoryAttributesEntry->NumberOfPages));
-      DEBUG ((EFI_D_VERBOSE, "  Attribute         - 0x%016lx\n", MemoryAttributesEntry->Attribute));
+      DEBUG ((DEBUG_VERBOSE, "Entry (0x%x)\n", MemoryAttributesEntry));
+      DEBUG ((DEBUG_VERBOSE, "  Type              - 0x%x\n", MemoryAttributesEntry->Type));
+      DEBUG ((DEBUG_VERBOSE, "  PhysicalStart     - 0x%016lx\n", MemoryAttributesEntry->PhysicalStart));
+      DEBUG ((DEBUG_VERBOSE, "  VirtualStart      - 0x%016lx\n", MemoryAttributesEntry->VirtualStart));
+      DEBUG ((DEBUG_VERBOSE, "  NumberOfPages     - 0x%016lx\n", MemoryAttributesEntry->NumberOfPages));
+      DEBUG ((DEBUG_VERBOSE, "  Attribute         - 0x%016lx\n", MemoryAttributesEntry->Attribute));
       MemoryAttributesEntry = NEXT_MEMORY_DESCRIPTOR(MemoryAttributesEntry, DescriptorSize);
       break;
     }

--- a/MdeModulePkg/Core/DxeIplPeim/Ia32/DxeLoadFunc.c
+++ b/MdeModulePkg/Core/DxeIplPeim/Ia32/DxeLoadFunc.c
@@ -378,7 +378,7 @@ HandOffToDxeCore (
                (VOID **)&VectorHandoffInfoPpi
                );
     if (Status == EFI_SUCCESS) {
-      DEBUG ((EFI_D_INFO, "Vector Hand-off Info PPI is gotten, GUIDed HOB is created!\n"));
+      DEBUG ((DEBUG_INFO, "Vector Hand-off Info PPI is gotten, GUIDed HOB is created!\n"));
       VectorInfo = VectorHandoffInfoPpi->Info;
       Index = 1;
       while (VectorInfo->Attribute != EFI_VECTOR_HANDOFF_LAST_ENTRY) {
@@ -462,4 +462,3 @@ HandOffToDxeCore (
     }
   }
 }
-

--- a/MdeModulePkg/Core/DxeIplPeim/X64/DxeLoadFunc.c
+++ b/MdeModulePkg/Core/DxeIplPeim/X64/DxeLoadFunc.c
@@ -56,7 +56,7 @@ HandOffToDxeCore (
              (VOID **)&VectorHandoffInfoPpi
              );
   if (Status == EFI_SUCCESS) {
-    DEBUG ((EFI_D_INFO, "Vector Hand-off Info PPI is gotten, GUIDed HOB is created!\n"));
+    DEBUG ((DEBUG_INFO, "Vector Hand-off Info PPI is gotten, GUIDed HOB is created!\n"));
     VectorInfo = VectorHandoffInfoPpi->Info;
     Index = 1;
     while (VectorInfo->Attribute != EFI_VECTOR_HANDOFF_LAST_ENTRY) {

--- a/MdeModulePkg/Core/Pei/Dispatcher/Dispatcher.c
+++ b/MdeModulePkg/Core/Pei/Dispatcher/Dispatcher.c
@@ -302,10 +302,10 @@ PeiLoadFixAddressHook(
   //
   TotalReservedMemorySize += PeiMemorySize;
 
-  DEBUG ((EFI_D_INFO, "LOADING MODULE FIXED INFO: PcdLoadFixAddressRuntimeCodePageNumber= 0x%x.\n", PcdGet32(PcdLoadFixAddressRuntimeCodePageNumber)));
-  DEBUG ((EFI_D_INFO, "LOADING MODULE FIXED INFO: PcdLoadFixAddressBootTimeCodePageNumber= 0x%x.\n", PcdGet32(PcdLoadFixAddressBootTimeCodePageNumber)));
-  DEBUG ((EFI_D_INFO, "LOADING MODULE FIXED INFO: PcdLoadFixAddressPeiCodePageNumber= 0x%x.\n", PcdGet32(PcdLoadFixAddressPeiCodePageNumber)));
-  DEBUG ((EFI_D_INFO, "LOADING MODULE FIXED INFO: Total Reserved Memory Size = 0x%lx.\n", TotalReservedMemorySize));
+  DEBUG ((DEBUG_INFO, "LOADING MODULE FIXED INFO: PcdLoadFixAddressRuntimeCodePageNumber= 0x%x.\n", PcdGet32(PcdLoadFixAddressRuntimeCodePageNumber)));
+  DEBUG ((DEBUG_INFO, "LOADING MODULE FIXED INFO: PcdLoadFixAddressBootTimeCodePageNumber= 0x%x.\n", PcdGet32(PcdLoadFixAddressBootTimeCodePageNumber)));
+  DEBUG ((DEBUG_INFO, "LOADING MODULE FIXED INFO: PcdLoadFixAddressPeiCodePageNumber= 0x%x.\n", PcdGet32(PcdLoadFixAddressPeiCodePageNumber)));
+  DEBUG ((DEBUG_INFO, "LOADING MODULE FIXED INFO: Total Reserved Memory Size = 0x%lx.\n", TotalReservedMemorySize));
   //
   // Loop through the system memory typed HOB to merge the adjacent memory range
   //
@@ -433,12 +433,12 @@ PeiLoadFixAddressHook(
     // The LMFA feature is enabled as load module at fixed absolute address.
     //
     TopLoadingAddress = (EFI_PHYSICAL_ADDRESS)PcdGet64(PcdLoadModuleAtFixAddressEnable);
-    DEBUG ((EFI_D_INFO, "LOADING MODULE FIXED INFO: Loading module at fixed absolute address.\n"));
+    DEBUG ((DEBUG_INFO, "LOADING MODULE FIXED INFO: Loading module at fixed absolute address.\n"));
     //
     // validate the Address. Loop the resource descriptor HOB to make sure the address is in valid memory range
     //
     if ((TopLoadingAddress & EFI_PAGE_MASK) != 0) {
-      DEBUG ((EFI_D_INFO, "LOADING MODULE FIXED ERROR:Top Address 0x%lx is invalid since top address should be page align. \n", TopLoadingAddress));
+      DEBUG ((DEBUG_INFO, "LOADING MODULE FIXED ERROR:Top Address 0x%lx is invalid since top address should be page align. \n", TopLoadingAddress));
       ASSERT (FALSE);
     }
     //
@@ -470,11 +470,11 @@ PeiLoadFixAddressHook(
       }
     }
     if (CurrentResourceHob != NULL) {
-      DEBUG ((EFI_D_INFO, "LOADING MODULE FIXED INFO:Top Address 0x%lx is valid \n",  TopLoadingAddress));
+      DEBUG ((DEBUG_INFO, "LOADING MODULE FIXED INFO:Top Address 0x%lx is valid \n",  TopLoadingAddress));
       TopLoadingAddress += MINIMUM_INITIAL_MEMORY_SIZE;
     } else {
-      DEBUG ((EFI_D_INFO, "LOADING MODULE FIXED ERROR:Top Address 0x%lx is invalid \n",  TopLoadingAddress));
-      DEBUG ((EFI_D_INFO, "LOADING MODULE FIXED ERROR:The recommended Top Address for the platform is: \n"));
+      DEBUG ((DEBUG_INFO, "LOADING MODULE FIXED ERROR:Top Address 0x%lx is invalid \n",  TopLoadingAddress));
+      DEBUG ((DEBUG_INFO, "LOADING MODULE FIXED ERROR:The recommended Top Address for the platform is: \n"));
       //
       // Print the recommended Top address range.
       //
@@ -494,7 +494,7 @@ PeiLoadFixAddressHook(
               // See if Top address specified by user is valid.
               //
               if (ResourceHob->ResourceLength > TotalReservedMemorySize && PeiLoadFixAddressIsMemoryRangeAvailable(PrivateData, ResourceHob)) {
-                 DEBUG ((EFI_D_INFO, "(0x%lx, 0x%lx)\n",
+                 DEBUG ((DEBUG_INFO, "(0x%lx, 0x%lx)\n",
                           (ResourceHob->PhysicalStart + TotalReservedMemorySize -MINIMUM_INITIAL_MEMORY_SIZE),
                           (ResourceHob->PhysicalStart + ResourceHob->ResourceLength -MINIMUM_INITIAL_MEMORY_SIZE)
                         ));
@@ -541,7 +541,7 @@ PeiLoadFixAddressHook(
       }
     }
     if (CurrentResourceHob == NULL) {
-      DEBUG ((EFI_D_INFO, "LOADING MODULE FIXED ERROR:The System Memory is too small\n"));
+      DEBUG ((DEBUG_INFO, "LOADING MODULE FIXED ERROR:The System Memory is too small\n"));
       //
       // Assert here
       //
@@ -613,7 +613,7 @@ PeiLoadFixAddressHook(
   // Cache the top address for Loading Module at Fixed Address feature
   //
   PrivateData->LoadModuleAtFixAddressTopAddress = TopLoadingAddress - MINIMUM_INITIAL_MEMORY_SIZE;
-  DEBUG ((EFI_D_INFO, "LOADING MODULE FIXED INFO: Top address = 0x%lx\n",  PrivateData->LoadModuleAtFixAddressTopAddress));
+  DEBUG ((DEBUG_INFO, "LOADING MODULE FIXED INFO: Top address = 0x%lx\n",  PrivateData->LoadModuleAtFixAddressTopAddress));
   //
   // reinstall the PEI memory relative to TopLoadingAddress
   //
@@ -732,7 +732,7 @@ PeiCheckAndSwitchStack (
       // If Loading Module at Fixed Address is enabled, Allocating memory range for Pei code range.
       //
       LoadFixPeiCodeBegin = AllocatePages((UINTN)PcdGet32(PcdLoadFixAddressPeiCodePageNumber));
-      DEBUG ((EFI_D_INFO, "LOADING MODULE FIXED INFO: PeiCodeBegin = 0x%lX, PeiCodeTop= 0x%lX\n", (UINT64)(UINTN)LoadFixPeiCodeBegin, (UINT64)((UINTN)LoadFixPeiCodeBegin + PcdGet32(PcdLoadFixAddressPeiCodePageNumber) * EFI_PAGE_SIZE)));
+      DEBUG ((DEBUG_INFO, "LOADING MODULE FIXED INFO: PeiCodeBegin = 0x%lX, PeiCodeTop= 0x%lX\n", (UINT64)(UINTN)LoadFixPeiCodeBegin, (UINT64)((UINTN)LoadFixPeiCodeBegin + PcdGet32(PcdLoadFixAddressPeiCodePageNumber) * EFI_PAGE_SIZE)));
     }
 
     //
@@ -746,7 +746,7 @@ PeiCheckAndSwitchStack (
     NewStackSize = RShiftU64 (Private->PhysicalMemoryLength, 1);
     NewStackSize = ALIGN_VALUE (NewStackSize, EFI_PAGE_SIZE);
     NewStackSize = MIN (PcdGet32(PcdPeiCoreMaxPeiStackSize), NewStackSize);
-    DEBUG ((EFI_D_INFO, "Old Stack size %d, New stack size %d\n", (UINT32)SecCoreData->StackSize, (UINT32)NewStackSize));
+    DEBUG ((DEBUG_INFO, "Old Stack size %d, New stack size %d\n", (UINT32)SecCoreData->StackSize, (UINT32)NewStackSize));
     ASSERT (NewStackSize >= SecCoreData->StackSize);
 
     //
@@ -768,7 +768,7 @@ PeiCheckAndSwitchStack (
     //
     // Build Stack HOB that describes the permanent memory stack
     //
-    DEBUG ((EFI_D_INFO, "Stack Hob: BaseAddress=0x%lX Length=0x%lX\n", TopOfNewStack - NewStackSize, NewStackSize));
+    DEBUG ((DEBUG_INFO, "Stack Hob: BaseAddress=0x%lX Length=0x%lX\n", TopOfNewStack - NewStackSize, NewStackSize));
     BuildStackHob (TopOfNewStack - NewStackSize, NewStackSize);
 
     //
@@ -803,7 +803,7 @@ PeiCheckAndSwitchStack (
         Private->HeapOffset = (UINTN)((UINTN)SecCoreData->PeiTemporaryRamBase - BaseOfNewHeap);
       }
 
-      DEBUG ((EFI_D_INFO, "Heap Offset = 0x%lX Stack Offset = 0x%lX\n", (UINT64) Private->HeapOffset, (UINT64) Private->StackOffset));
+      DEBUG ((DEBUG_INFO, "Heap Offset = 0x%lX Stack Offset = 0x%lX\n", (UINT64) Private->HeapOffset, (UINT64) Private->StackOffset));
 
       //
       // Calculate new HandOffTable and PrivateData address in permanent memory's stack
@@ -871,7 +871,7 @@ PeiCheckAndSwitchStack (
         Private->HeapOffset = (UINTN)((UINTN)SecCoreData->PeiTemporaryRamBase - BaseOfNewHeap);
       }
 
-      DEBUG ((EFI_D_INFO, "Heap Offset = 0x%lX Stack Offset = 0x%lX\n", (UINT64) Private->HeapOffset, (UINT64) Private->StackOffset));
+      DEBUG ((DEBUG_INFO, "Heap Offset = 0x%lX Stack Offset = 0x%lX\n", (UINT64) Private->HeapOffset, (UINT64) Private->StackOffset));
 
       //
       // Migrate Heap
@@ -1730,6 +1730,3 @@ PeiRegisterForShadow (
 
   return EFI_SUCCESS;
 }
-
-
-

--- a/MdeModulePkg/Core/Pei/FwVol/FwVol.c
+++ b/MdeModulePkg/Core/Pei/FwVol/FwVol.c
@@ -317,7 +317,7 @@ FindFileEx (
   } else {
     if (IS_FFS_FILE2 (*FileHeader)) {
       if (!IsFfs3Fv) {
-        DEBUG ((EFI_D_ERROR, "It is a FFS3 formatted file: %g in a non-FFS3 formatted FV.\n", &(*FileHeader)->Name));
+        DEBUG ((DEBUG_ERROR, "It is a FFS3 formatted file: %g in a non-FFS3 formatted FV.\n", &(*FileHeader)->Name));
       }
       FileLength = FFS_FILE2_SIZE (*FileHeader);
       ASSERT (FileLength > 0x00FFFFFF);
@@ -345,7 +345,7 @@ FindFileEx (
     case EFI_FILE_HEADER_INVALID:
       if (IS_FFS_FILE2 (FfsFileHeader)) {
         if (!IsFfs3Fv) {
-          DEBUG ((EFI_D_ERROR, "Found a FFS3 formatted file: %g in a non-FFS3 formatted FV.\n", &FfsFileHeader->Name));
+          DEBUG ((DEBUG_ERROR, "Found a FFS3 formatted file: %g in a non-FFS3 formatted FV.\n", &FfsFileHeader->Name));
         }
         FileOffset    += sizeof (EFI_FFS_FILE_HEADER2);
         FfsFileHeader =  (EFI_FFS_FILE_HEADER *) ((UINT8 *) FfsFileHeader + sizeof (EFI_FFS_FILE_HEADER2));
@@ -368,7 +368,7 @@ FindFileEx (
         ASSERT (FileLength > 0x00FFFFFF);
         FileOccupiedSize = GET_OCCUPIED_SIZE (FileLength, 8);
         if (!IsFfs3Fv) {
-          DEBUG ((EFI_D_ERROR, "Found a FFS3 formatted file: %g in a non-FFS3 formatted FV.\n", &FfsFileHeader->Name));
+          DEBUG ((DEBUG_ERROR, "Found a FFS3 formatted file: %g in a non-FFS3 formatted FV.\n", &FfsFileHeader->Name));
           FileOffset += FileOccupiedSize;
           FfsFileHeader = (EFI_FFS_FILE_HEADER *) ((UINT8 *) FfsFileHeader + FileOccupiedSize);
           break;
@@ -424,7 +424,7 @@ FindFileEx (
     case EFI_FILE_DELETED:
       if (IS_FFS_FILE2 (FfsFileHeader)) {
         if (!IsFfs3Fv) {
-          DEBUG ((EFI_D_ERROR, "Found a FFS3 formatted file: %g in a non-FFS3 formatted FV.\n", &FfsFileHeader->Name));
+          DEBUG ((DEBUG_ERROR, "Found a FFS3 formatted file: %g in a non-FFS3 formatted FV.\n", &FfsFileHeader->Name));
         }
         FileLength = FFS_FILE2_SIZE (FfsFileHeader);
         ASSERT (FileLength > 0x00FFFFFF);
@@ -509,7 +509,7 @@ PeiInitializeFv (
   PrivateData->Fv[PrivateData->FvCount].FvHandle = FvHandle;
   PrivateData->Fv[PrivateData->FvCount].AuthenticationStatus = 0;
   DEBUG ((
-    EFI_D_INFO,
+    DEBUG_INFO,
     "The %dth FV start address is 0x%11p, size is 0x%08x, handle is 0x%p\n",
     (UINT32) PrivateData->FvCount,
     (VOID *) BfvHeader,
@@ -607,7 +607,7 @@ FirmwareVolumeInfoPpiNotifyCallback (
     //
     Status = FvPpi->ProcessVolume (FvPpi, FvInfo2Ppi.FvInfo, FvInfo2Ppi.FvInfoSize, &FvHandle);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "Fail to process new found FV, FV may be corrupted!\n"));
+      DEBUG ((DEBUG_ERROR, "Fail to process new found FV, FV may be corrupted!\n"));
       return Status;
     }
 
@@ -618,7 +618,7 @@ FirmwareVolumeInfoPpiNotifyCallback (
       if (PrivateData->Fv[FvIndex].FvHandle == FvHandle) {
         if (IsFvInfo2 && (FvInfo2Ppi.AuthenticationStatus != PrivateData->Fv[FvIndex].AuthenticationStatus)) {
           PrivateData->Fv[FvIndex].AuthenticationStatus = FvInfo2Ppi.AuthenticationStatus;
-          DEBUG ((EFI_D_INFO, "Update AuthenticationStatus of the %dth FV to 0x%x!\n", FvIndex, FvInfo2Ppi.AuthenticationStatus));
+          DEBUG ((DEBUG_INFO, "Update AuthenticationStatus of the %dth FV to 0x%x!\n", FvIndex, FvInfo2Ppi.AuthenticationStatus));
         }
         DEBUG ((DEBUG_INFO, "The FV %p has already been processed!\n", FvInfo2Ppi.FvInfo));
         return EFI_SUCCESS;
@@ -651,7 +651,7 @@ FirmwareVolumeInfoPpiNotifyCallback (
     PrivateData->Fv[PrivateData->FvCount].AuthenticationStatus = FvInfo2Ppi.AuthenticationStatus;
     CurFvCount = PrivateData->FvCount;
     DEBUG ((
-      EFI_D_INFO,
+      DEBUG_INFO,
       "The %dth FV start address is 0x%11p, size is 0x%08x, handle is 0x%p\n",
       (UINT32) CurFvCount,
       (VOID *) FvInfo2Ppi.FvInfo,
@@ -687,12 +687,12 @@ FirmwareVolumeInfoPpiNotifyCallback (
           }
         }
 
-        DEBUG ((EFI_D_INFO, "Found firmware volume Image File %p in FV[%d] %p\n", FileHandle, CurFvCount, FvHandle));
+        DEBUG ((DEBUG_INFO, "Found firmware volume Image File %p in FV[%d] %p\n", FileHandle, CurFvCount, FvHandle));
         ProcessFvFile (PrivateData, &PrivateData->Fv[CurFvCount], FileHandle);
       }
     } while (FileHandle != NULL);
   } else {
-    DEBUG ((EFI_D_ERROR, "Fail to process FV %p because no corresponding EFI_FIRMWARE_VOLUME_PPI is found!\n", FvInfo2Ppi.FvInfo));
+    DEBUG ((DEBUG_ERROR, "Fail to process FV %p because no corresponding EFI_FIRMWARE_VOLUME_PPI is found!\n", FvInfo2Ppi.FvInfo));
 
     AddUnknownFormatFvInfo (PrivateData, &FvInfo2Ppi);
   }
@@ -808,7 +808,7 @@ ProcessSection (
     if (IS_SECTION2 (Section)) {
       ASSERT (SECTION2_SIZE (Section) > 0x00FFFFFF);
       if (!IsFfs3Fv) {
-        DEBUG ((EFI_D_ERROR, "Found a FFS3 formatted section in a non-FFS3 formatted FV.\n"));
+        DEBUG ((DEBUG_ERROR, "Found a FFS3 formatted section in a non-FFS3 formatted FV.\n"));
         SectionLength = SECTION2_SIZE (Section);
         //
         // SectionLength is adjusted it is 4 byte aligned.
@@ -1404,7 +1404,7 @@ ProcessFvFile (
       //
       // this FILE has been dispatched, it will not be dispatched again.
       //
-      DEBUG ((EFI_D_INFO, "FV file %p has been dispatched!\r\n", ParentFvFileHandle));
+      DEBUG ((DEBUG_INFO, "FV file %p has been dispatched!\r\n", ParentFvFileHandle));
       return EFI_SUCCESS;
     }
     HobPtr.Raw = GET_NEXT_HOB (HobPtr);
@@ -1628,7 +1628,7 @@ PeiFfsFvPpiProcessVolume (
   //
   Status = VerifyFv ((EFI_FIRMWARE_VOLUME_HEADER*) Buffer);
   if (EFI_ERROR(Status)) {
-    DEBUG ((EFI_D_ERROR, "Fail to verify FV which address is 0x%11p", Buffer));
+    DEBUG ((DEBUG_ERROR, "Fail to verify FV which address is 0x%11p", Buffer));
     return EFI_VOLUME_CORRUPTED;
   }
 
@@ -1810,7 +1810,7 @@ PeiFfsFvPpiGetFileInfo (
   if (IS_FFS_FILE2 (FileHeader)) {
     ASSERT (FFS_FILE2_SIZE (FileHeader) > 0x00FFFFFF);
     if (!FwVolInstance->IsFfs3Fv) {
-      DEBUG ((EFI_D_ERROR, "It is a FFS3 formatted file: %g in a non-FFS3 formatted FV.\n", &FileHeader->Name));
+      DEBUG ((DEBUG_ERROR, "It is a FFS3 formatted file: %g in a non-FFS3 formatted FV.\n", &FileHeader->Name));
       return EFI_INVALID_PARAMETER;
     }
     FileInfo->BufferSize = FFS_FILE2_SIZE (FileHeader) - sizeof (EFI_FFS_FILE_HEADER2);
@@ -2029,7 +2029,7 @@ PeiFfsFvPpiFindSectionByType2 (
   if (IS_FFS_FILE2 (FfsFileHeader)) {
     ASSERT (FFS_FILE2_SIZE (FfsFileHeader) > 0x00FFFFFF);
     if (!FwVolInstance->IsFfs3Fv) {
-      DEBUG ((EFI_D_ERROR, "It is a FFS3 formatted file: %g in a non-FFS3 formatted FV.\n", &FfsFileHeader->Name));
+      DEBUG ((DEBUG_ERROR, "It is a FFS3 formatted file: %g in a non-FFS3 formatted FV.\n", &FfsFileHeader->Name));
       return EFI_NOT_FOUND;
     }
     Section = (EFI_COMMON_SECTION_HEADER *) ((UINT8 *) FfsFileHeader + sizeof (EFI_FFS_FILE_HEADER2));
@@ -2344,7 +2344,7 @@ ThirdPartyFvPpiNotifyCallback (
     //
     Status = FvPpi->ProcessVolume (FvPpi, FvInfo, FvInfoSize, &FvHandle);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "Fail to process the FV 0x%p, FV may be corrupted!\n", FvInfo));
+      DEBUG ((DEBUG_ERROR, "Fail to process the FV 0x%p, FV may be corrupted!\n", FvInfo));
       continue;
     }
 
@@ -2390,7 +2390,7 @@ ThirdPartyFvPpiNotifyCallback (
     PrivateData->Fv[PrivateData->FvCount].AuthenticationStatus = AuthenticationStatus;
     CurFvCount = PrivateData->FvCount;
     DEBUG ((
-      EFI_D_INFO,
+      DEBUG_INFO,
       "The %dth FV start address is 0x%11p, size is 0x%08x, handle is 0x%p\n",
       (UINT32) CurFvCount,
       (VOID *) FvInfo,
@@ -2426,7 +2426,7 @@ ThirdPartyFvPpiNotifyCallback (
           }
         }
 
-        DEBUG ((EFI_D_INFO, "Found firmware volume Image File %p in FV[%d] %p\n", FileHandle, CurFvCount, FvHandle));
+        DEBUG ((DEBUG_INFO, "Found firmware volume Image File %p in FV[%d] %p\n", FileHandle, CurFvCount, FvHandle));
         ProcessFvFile (PrivateData, &PrivateData->Fv[CurFvCount], FileHandle);
       }
     } while (FileHandle != NULL);

--- a/MdeModulePkg/Core/Pei/Hob/Hob.c
+++ b/MdeModulePkg/Core/Pei/Hob/Hob.c
@@ -95,9 +95,9 @@ PeiCreateHob (
                HandOffHob->EfiFreeMemoryBottom;
 
   if (FreeMemory < Length) {
-    DEBUG ((EFI_D_ERROR, "PeiCreateHob fail: Length - 0x%08x\n", (UINTN)Length));
-    DEBUG ((EFI_D_ERROR, "  FreeMemoryTop    - 0x%08x\n", (UINTN)HandOffHob->EfiFreeMemoryTop));
-    DEBUG ((EFI_D_ERROR, "  FreeMemoryBottom - 0x%08x\n", (UINTN)HandOffHob->EfiFreeMemoryBottom));
+    DEBUG ((DEBUG_ERROR, "PeiCreateHob fail: Length - 0x%08x\n", (UINTN)Length));
+    DEBUG ((DEBUG_ERROR, "  FreeMemoryTop    - 0x%08x\n", (UINTN)HandOffHob->EfiFreeMemoryTop));
+    DEBUG ((DEBUG_ERROR, "  FreeMemoryBottom - 0x%08x\n", (UINTN)HandOffHob->EfiFreeMemoryBottom));
     return EFI_OUT_OF_RESOURCES;
   }
 

--- a/MdeModulePkg/Core/Pei/Image/Image.c
+++ b/MdeModulePkg/Core/Pei/Image/Image.c
@@ -235,7 +235,7 @@ GetPeCoffImageFixLoadingAssignedAddress(
      }
      SectionHeaderOffset += sizeof (EFI_IMAGE_SECTION_HEADER);
    }
-   DEBUG ((EFI_D_INFO|EFI_D_LOAD, "LOADING MODULE FIXED INFO: Loading module at fixed address 0x%11p. Status= %r \n", (VOID *)(UINTN)FixLoadingAddress, Status));
+   DEBUG ((DEBUG_INFO|DEBUG_LOAD, "LOADING MODULE FIXED INFO: Loading module at fixed address 0x%11p. Status= %r \n", (VOID *)(UINTN)FixLoadingAddress, Status));
    return Status;
 }
 /**
@@ -333,7 +333,7 @@ LoadAndRelocatePeCoffImage (
        (!IsS3Boot && (PcdGetBool (PcdShadowPeimOnBoot) || IsRegisterForShadow)) ||
        (IsS3Boot && PcdGetBool (PcdShadowPeimOnS3Boot)))
      ) {
-    DEBUG ((EFI_D_INFO|EFI_D_LOAD, "The image at 0x%08x without reloc section can't be loaded into memory\n", (UINTN) Pe32Data));
+    DEBUG ((DEBUG_INFO|DEBUG_LOAD, "The image at 0x%08x without reloc section can't be loaded into memory\n", (UINTN) Pe32Data));
   }
 
   //
@@ -367,7 +367,7 @@ LoadAndRelocatePeCoffImage (
     if (PcdGet64(PcdLoadModuleAtFixAddressEnable) != 0 && (Private->HobList.HandoffInformationTable->BootMode != BOOT_ON_S3_RESUME)) {
       Status = GetPeCoffImageFixLoadingAssignedAddress(&ImageContext, Private);
       if (EFI_ERROR (Status)){
-        DEBUG ((EFI_D_INFO|EFI_D_LOAD, "LOADING MODULE FIXED ERROR: Failed to load module at fixed address. \n"));
+        DEBUG ((DEBUG_INFO|DEBUG_LOAD, "LOADING MODULE FIXED ERROR: Failed to load module at fixed address. \n"));
         //
         // The PEIM is not assigned valid address, try to allocate page to load it.
         //
@@ -697,12 +697,12 @@ PeiLoadImageLoadImage (
     // Print debug message: Loading PEIM at 0x12345678 EntryPoint=0x12345688 Driver.efi
     //
     if (Machine != EFI_IMAGE_MACHINE_IA64) {
-      DEBUG ((EFI_D_INFO | EFI_D_LOAD, "Loading PEIM at 0x%11p EntryPoint=0x%11p ", (VOID *)(UINTN)ImageAddress, (VOID *)(UINTN)*EntryPoint));
+      DEBUG ((DEBUG_INFO | DEBUG_LOAD, "Loading PEIM at 0x%11p EntryPoint=0x%11p ", (VOID *)(UINTN)ImageAddress, (VOID *)(UINTN)*EntryPoint));
     } else {
       //
       // For IPF Image, the real entry point should be print.
       //
-      DEBUG ((EFI_D_INFO | EFI_D_LOAD, "Loading PEIM at 0x%11p EntryPoint=0x%11p ", (VOID *)(UINTN)ImageAddress, (VOID *)(UINTN)(*(UINT64 *)(UINTN)*EntryPoint)));
+      DEBUG ((DEBUG_INFO | DEBUG_LOAD, "Loading PEIM at 0x%11p EntryPoint=0x%11p ", (VOID *)(UINTN)ImageAddress, (VOID *)(UINTN)(*(UINT64 *)(UINTN)*EntryPoint)));
     }
 
     //
@@ -741,12 +741,12 @@ PeiLoadImageLoadImage (
         EfiFileName[Index] = 0;
       }
 
-      DEBUG ((EFI_D_INFO | EFI_D_LOAD, "%a", EfiFileName));
+      DEBUG ((DEBUG_INFO | DEBUG_LOAD, "%a", EfiFileName));
     }
 
   DEBUG_CODE_END ();
 
-  DEBUG ((EFI_D_INFO | EFI_D_LOAD, "\n"));
+  DEBUG ((DEBUG_INFO | DEBUG_LOAD, "\n"));
 
   return EFI_SUCCESS;
 
@@ -961,7 +961,3 @@ InitializeImageServices (
     PeiServicesReInstallPpi (PrivateData->XipLoadFile, &gPpiLoadFilePpiList);
   }
 }
-
-
-
-

--- a/MdeModulePkg/Core/Pei/Memory/MemoryServices.c
+++ b/MdeModulePkg/Core/Pei/Memory/MemoryServices.c
@@ -80,7 +80,7 @@ PeiInstallPeiMemory (
 {
   PEI_CORE_INSTANCE                     *PrivateData;
 
-  DEBUG ((EFI_D_INFO, "PeiInstallPeiMemory MemoryBegin 0x%LX, MemoryLength 0x%LX\n", MemoryBegin, MemoryLength));
+  DEBUG ((DEBUG_INFO, "PeiInstallPeiMemory MemoryBegin 0x%LX, MemoryLength 0x%LX\n", MemoryBegin, MemoryLength));
   PrivateData = PEI_CORE_INSTANCE_FROM_PS_THIS (PeiServices);
 
   //
@@ -89,7 +89,7 @@ PeiInstallPeiMemory (
   // simply return EFI_SUCCESS in release tip to ignore it.
   //
   if (PrivateData->PeiMemoryInstalled) {
-    DEBUG ((EFI_D_ERROR, "ERROR: PeiInstallPeiMemory is called more than once!\n"));
+    DEBUG ((DEBUG_ERROR, "ERROR: PeiInstallPeiMemory is called more than once!\n"));
     ASSERT (FALSE);
     return EFI_SUCCESS;
   }
@@ -676,8 +676,8 @@ PeiAllocatePages (
     if (!EFI_ERROR (Status)) {
       return Status;
     }
-    DEBUG ((EFI_D_ERROR, "AllocatePages failed: No 0x%lx Pages is available.\n", (UINT64) Pages));
-    DEBUG ((EFI_D_ERROR, "There is only left 0x%lx pages memory resource to be allocated.\n", (UINT64) RemainingPages));
+    DEBUG ((DEBUG_ERROR, "AllocatePages failed: No 0x%lx Pages is available.\n", (UINT64) Pages));
+    DEBUG ((DEBUG_ERROR, "There is only left 0x%lx pages memory resource to be allocated.\n", (UINT64) RemainingPages));
     return  EFI_OUT_OF_RESOURCES;
   } else {
     //

--- a/MdeModulePkg/Core/Pei/PeiMain/PeiMain.c
+++ b/MdeModulePkg/Core/Pei/PeiMain/PeiMain.c
@@ -508,7 +508,7 @@ PeiCore (
   //
   // Enter DxeIpl to load Dxe core.
   //
-  DEBUG ((EFI_D_INFO, "DXE IPL Entry\n"));
+  DEBUG ((DEBUG_INFO, "DXE IPL Entry\n"));
   Status = TempPtr.DxeIpl->Entry (
                              TempPtr.DxeIpl,
                              &PrivateData.Ps,

--- a/MdeModulePkg/Core/Pei/Ppi/Ppi.c
+++ b/MdeModulePkg/Core/Pei/Ppi/Ppi.c
@@ -474,7 +474,7 @@ InternalPeiInstallPpi (
     //
     if ((PpiList->Flags & EFI_PEI_PPI_DESCRIPTOR_PPI) == 0) {
       PpiListPointer->CurrentCount = LastCount;
-      DEBUG((EFI_D_ERROR, "ERROR -> InstallPpi: %g %p\n", PpiList->Guid, PpiList->Ppi));
+      DEBUG((DEBUG_ERROR, "ERROR -> InstallPpi: %g %p\n", PpiList->Guid, PpiList->Ppi));
       return  EFI_INVALID_PARAMETER;
     }
 
@@ -495,7 +495,7 @@ InternalPeiInstallPpi (
       PpiListPointer->MaxCount = PpiListPointer->MaxCount + PPI_GROWTH_STEP;
     }
 
-    DEBUG((EFI_D_INFO, "Install PPI: %g\n", PpiList->Guid));
+    DEBUG((DEBUG_INFO, "Install PPI: %g\n", PpiList->Guid));
     PpiListPointer->PpiPtrs[Index].Ppi = (EFI_PEI_PPI_DESCRIPTOR *) PpiList;
     Index++;
     PpiListPointer->CurrentCount++;
@@ -613,7 +613,7 @@ PeiReInstallPpi (
   //
   // Replace the old PPI with the new one.
   //
-  DEBUG((EFI_D_INFO, "Reinstall PPI: %g\n", NewPpi->Guid));
+  DEBUG((DEBUG_INFO, "Reinstall PPI: %g\n", NewPpi->Guid));
   PrivateData->PpiData.PpiList.PpiPtrs[Index].Ppi = (EFI_PEI_PPI_DESCRIPTOR *) NewPpi;
 
   //
@@ -807,7 +807,7 @@ InternalPeiNotifyPpi (
       DispatchNotifyListPointer->CurrentCount++;
     }
 
-    DEBUG((EFI_D_INFO, "Register PPI Notify: %g\n", NotifyList->Guid));
+    DEBUG((DEBUG_INFO, "Register PPI Notify: %g\n", NotifyList->Guid));
 
     if (Single) {
       //
@@ -978,7 +978,7 @@ ProcessNotify (
           (((INT32 *)SearchGuid)[1] == ((INT32 *)CheckGuid)[1]) &&
           (((INT32 *)SearchGuid)[2] == ((INT32 *)CheckGuid)[2]) &&
           (((INT32 *)SearchGuid)[3] == ((INT32 *)CheckGuid)[3])) {
-        DEBUG ((EFI_D_INFO, "Notify: PPI Guid: %g, Peim notify entry point: %p\n",
+        DEBUG ((DEBUG_INFO, "Notify: PPI Guid: %g, Peim notify entry point: %p\n",
           SearchGuid,
           NotifyDescriptor->Notify
           ));
@@ -1115,4 +1115,3 @@ ConvertPeiCorePpiPointers (
     ConvertPpiPointersFv (PrivateData, (UINTN) OrgImageBase, (UINTN) MigratedImageBase, PeiCoreModuleSize);
   }
 }
-

--- a/MdeModulePkg/Core/PiSmmCore/Dispatcher.c
+++ b/MdeModulePkg/Core/PiSmmCore/Dispatcher.c
@@ -283,7 +283,7 @@ GetPeCoffImageFixLoadingAssignedAddress(
     }
     SectionHeaderOffset += sizeof (EFI_IMAGE_SECTION_HEADER);
   }
-  DEBUG ((EFI_D_INFO|EFI_D_LOAD, "LOADING MODULE FIXED INFO: Loading module at fixed address %x, Status = %r\n", FixLoadingAddress, Status));
+  DEBUG ((DEBUG_INFO|DEBUG_LOAD, "LOADING MODULE FIXED INFO: Loading module at fixed address %x, Status = %r\n", FixLoadingAddress, Status));
   return Status;
 }
 /**
@@ -464,7 +464,7 @@ SmmLoadImage (
       PageCount = 0;
       DstBuffer = (UINTN)gLoadModuleAtFixAddressSmramBase;
     } else {
-       DEBUG ((EFI_D_INFO|EFI_D_LOAD, "LOADING MODULE FIXED ERROR: Failed to load module at fixed address. \n"));
+       DEBUG ((DEBUG_INFO|DEBUG_LOAD, "LOADING MODULE FIXED ERROR: Failed to load module at fixed address. \n"));
        //
        // allocate the memory to load the SMM driver
        //

--- a/MdeModulePkg/Core/PiSmmCore/PiSmmCore.c
+++ b/MdeModulePkg/Core/PiSmmCore/PiSmmCore.c
@@ -439,7 +439,7 @@ SmmEndOfDxeHandler (
   EFI_SMM_SX_REGISTER_CONTEXT       EntryRegisterContext;
   EFI_HANDLE                        S3EntryHandle;
 
-  DEBUG ((EFI_D_INFO, "SmmEndOfDxeHandler\n"));
+  DEBUG ((DEBUG_INFO, "SmmEndOfDxeHandler\n"));
 
   //
   // Install SMM EndOfDxe protocol

--- a/MdeModulePkg/Core/PiSmmCore/PiSmmIpl.c
+++ b/MdeModulePkg/Core/PiSmmCore/PiSmmIpl.c
@@ -991,7 +991,7 @@ GetPeCoffImageFixLoadingAssignedAddress(
      }
      SectionHeaderOffset += sizeof (EFI_IMAGE_SECTION_HEADER);
    }
-   DEBUG ((EFI_D_INFO|EFI_D_LOAD, "LOADING MODULE FIXED INFO: Loading module at fixed address %x, Status = %r \n", FixLoadingAddress, Status));
+   DEBUG ((DEBUG_INFO|DEBUG_LOAD, "LOADING MODULE FIXED INFO: Loading module at fixed address %x, Status = %r \n", FixLoadingAddress, Status));
    return Status;
 }
 /**
@@ -1068,7 +1068,7 @@ ExecuteSmmCoreFromSmram (
       //
       gSmmCorePrivate->SmramRangeCount --;
     } else {
-      DEBUG ((EFI_D_INFO, "LOADING MODULE FIXED ERROR: Loading module at fixed address at address failed\n"));
+      DEBUG ((DEBUG_INFO, "LOADING MODULE FIXED ERROR: Loading module at fixed address at address failed\n"));
       //
       // Allocate memory for the image being loaded from the EFI_SRAM_DESCRIPTOR
       // specified by SmramRange
@@ -1749,7 +1749,7 @@ SmmIplEntry (
         //
         // Print the SMRAM base
         //
-        DEBUG ((EFI_D_INFO, "LOADING MODULE FIXED INFO: TSEG BASE is %x. \n", mLMFAConfigurationTable->SmramBase));
+        DEBUG ((DEBUG_INFO, "LOADING MODULE FIXED INFO: TSEG BASE is %x. \n", mLMFAConfigurationTable->SmramBase));
       }
 
       //

--- a/MdeModulePkg/Core/PiSmmCore/SmramProfileRecord.c
+++ b/MdeModulePkg/Core/PiSmmCore/SmramProfileRecord.c
@@ -676,7 +676,7 @@ SmramProfileInit (
 
   RegisterSmmCore (&mSmramProfileContext);
 
-  DEBUG ((EFI_D_INFO, "SmramProfileInit SmramProfileContext - 0x%x\n", &mSmramProfileContext));
+  DEBUG ((DEBUG_INFO, "SmramProfileInit SmramProfileContext - 0x%x\n", &mSmramProfileContext));
 }
 
 /**
@@ -1530,7 +1530,7 @@ SmramProfileReadyToLock (
     return;
   }
 
-  DEBUG ((EFI_D_INFO, "SmramProfileReadyToLock\n"));
+  DEBUG ((DEBUG_INFO, "SmramProfileReadyToLock\n"));
   mSmramReadyToLock = TRUE;
 }
 
@@ -2168,7 +2168,7 @@ SmramProfileHandlerGetData (
   // Sanity check
   //
   if (!SmmIsBufferOutsideSmmValid ((UINTN) SmramProfileGetData.ProfileBuffer, (UINTN) ProfileSize)) {
-    DEBUG ((EFI_D_ERROR, "SmramProfileHandlerGetData: SMM ProfileBuffer in SMRAM or overflow!\n"));
+    DEBUG ((DEBUG_ERROR, "SmramProfileHandlerGetData: SMM ProfileBuffer in SMRAM or overflow!\n"));
     SmramProfileParameterGetData->ProfileSize = ProfileSize;
     SmramProfileParameterGetData->Header.ReturnStatus = (UINT64) (INT64) (INTN) EFI_ACCESS_DENIED;
     goto Done;
@@ -2219,7 +2219,7 @@ SmramProfileHandlerGetDataByOffset (
   // Sanity check
   //
   if (!SmmIsBufferOutsideSmmValid ((UINTN) SmramProfileGetDataByOffset.ProfileBuffer, (UINTN) SmramProfileGetDataByOffset.ProfileSize)) {
-    DEBUG ((EFI_D_ERROR, "SmramProfileHandlerGetDataByOffset: SMM ProfileBuffer in SMRAM or overflow!\n"));
+    DEBUG ((DEBUG_ERROR, "SmramProfileHandlerGetDataByOffset: SMM ProfileBuffer in SMRAM or overflow!\n"));
     SmramProfileParameterGetDataByOffset->Header.ReturnStatus = (UINT64) (INT64) (INTN) EFI_ACCESS_DENIED;
     goto Done;
   }
@@ -2261,7 +2261,7 @@ SmramProfileHandler (
   UINTN                                    TempCommBufferSize;
   SMRAM_PROFILE_PARAMETER_RECORDING_STATE  *ParameterRecordingState;
 
-  DEBUG ((EFI_D_ERROR, "SmramProfileHandler Enter\n"));
+  DEBUG ((DEBUG_ERROR, "SmramProfileHandler Enter\n"));
 
   //
   // If input is invalid, stop processing this SMI
@@ -2273,12 +2273,12 @@ SmramProfileHandler (
   TempCommBufferSize = *CommBufferSize;
 
   if (TempCommBufferSize < sizeof (SMRAM_PROFILE_PARAMETER_HEADER)) {
-    DEBUG ((EFI_D_ERROR, "SmramProfileHandler: SMM communication buffer size invalid!\n"));
+    DEBUG ((DEBUG_ERROR, "SmramProfileHandler: SMM communication buffer size invalid!\n"));
     return EFI_SUCCESS;
   }
 
   if (mSmramReadyToLock && !SmmIsBufferOutsideSmmValid ((UINTN)CommBuffer, TempCommBufferSize)) {
-    DEBUG ((EFI_D_ERROR, "SmramProfileHandler: SMM communication buffer in SMRAM or overflow!\n"));
+    DEBUG ((DEBUG_ERROR, "SmramProfileHandler: SMM communication buffer in SMRAM or overflow!\n"));
     return EFI_SUCCESS;
   }
 
@@ -2293,33 +2293,33 @@ SmramProfileHandler (
 
   switch (SmramProfileParameterHeader->Command) {
   case SMRAM_PROFILE_COMMAND_GET_PROFILE_INFO:
-    DEBUG ((EFI_D_ERROR, "SmramProfileHandlerGetInfo\n"));
+    DEBUG ((DEBUG_ERROR, "SmramProfileHandlerGetInfo\n"));
     if (TempCommBufferSize != sizeof (SMRAM_PROFILE_PARAMETER_GET_PROFILE_INFO)) {
-      DEBUG ((EFI_D_ERROR, "SmramProfileHandler: SMM communication buffer size invalid!\n"));
+      DEBUG ((DEBUG_ERROR, "SmramProfileHandler: SMM communication buffer size invalid!\n"));
       return EFI_SUCCESS;
     }
     SmramProfileHandlerGetInfo ((SMRAM_PROFILE_PARAMETER_GET_PROFILE_INFO *) (UINTN) CommBuffer);
     break;
   case SMRAM_PROFILE_COMMAND_GET_PROFILE_DATA:
-    DEBUG ((EFI_D_ERROR, "SmramProfileHandlerGetData\n"));
+    DEBUG ((DEBUG_ERROR, "SmramProfileHandlerGetData\n"));
     if (TempCommBufferSize != sizeof (SMRAM_PROFILE_PARAMETER_GET_PROFILE_DATA)) {
-      DEBUG ((EFI_D_ERROR, "SmramProfileHandler: SMM communication buffer size invalid!\n"));
+      DEBUG ((DEBUG_ERROR, "SmramProfileHandler: SMM communication buffer size invalid!\n"));
       return EFI_SUCCESS;
     }
     SmramProfileHandlerGetData ((SMRAM_PROFILE_PARAMETER_GET_PROFILE_DATA *) (UINTN) CommBuffer);
     break;
   case SMRAM_PROFILE_COMMAND_GET_PROFILE_DATA_BY_OFFSET:
-    DEBUG ((EFI_D_ERROR, "SmramProfileHandlerGetDataByOffset\n"));
+    DEBUG ((DEBUG_ERROR, "SmramProfileHandlerGetDataByOffset\n"));
     if (TempCommBufferSize != sizeof (SMRAM_PROFILE_PARAMETER_GET_PROFILE_DATA_BY_OFFSET)) {
-      DEBUG ((EFI_D_ERROR, "SmramProfileHandler: SMM communication buffer size invalid!\n"));
+      DEBUG ((DEBUG_ERROR, "SmramProfileHandler: SMM communication buffer size invalid!\n"));
       return EFI_SUCCESS;
     }
     SmramProfileHandlerGetDataByOffset ((SMRAM_PROFILE_PARAMETER_GET_PROFILE_DATA_BY_OFFSET *) (UINTN) CommBuffer);
     break;
   case SMRAM_PROFILE_COMMAND_GET_RECORDING_STATE:
-    DEBUG ((EFI_D_ERROR, "SmramProfileHandlerGetRecordingState\n"));
+    DEBUG ((DEBUG_ERROR, "SmramProfileHandlerGetRecordingState\n"));
     if (TempCommBufferSize != sizeof (SMRAM_PROFILE_PARAMETER_RECORDING_STATE)) {
-      DEBUG ((EFI_D_ERROR, "SmramProfileHandler: SMM communication buffer size invalid!\n"));
+      DEBUG ((DEBUG_ERROR, "SmramProfileHandler: SMM communication buffer size invalid!\n"));
       return EFI_SUCCESS;
     }
     ParameterRecordingState = (SMRAM_PROFILE_PARAMETER_RECORDING_STATE *) (UINTN) CommBuffer;
@@ -2327,9 +2327,9 @@ SmramProfileHandler (
     ParameterRecordingState->Header.ReturnStatus = 0;
     break;
   case SMRAM_PROFILE_COMMAND_SET_RECORDING_STATE:
-    DEBUG ((EFI_D_ERROR, "SmramProfileHandlerSetRecordingState\n"));
+    DEBUG ((DEBUG_ERROR, "SmramProfileHandlerSetRecordingState\n"));
     if (TempCommBufferSize != sizeof (SMRAM_PROFILE_PARAMETER_RECORDING_STATE)) {
-      DEBUG ((EFI_D_ERROR, "SmramProfileHandler: SMM communication buffer size invalid!\n"));
+      DEBUG ((DEBUG_ERROR, "SmramProfileHandler: SMM communication buffer size invalid!\n"));
       return EFI_SUCCESS;
     }
     ParameterRecordingState = (SMRAM_PROFILE_PARAMETER_RECORDING_STATE *) (UINTN) CommBuffer;
@@ -2350,7 +2350,7 @@ SmramProfileHandler (
     break;
   }
 
-  DEBUG ((EFI_D_ERROR, "SmramProfileHandler Exit\n"));
+  DEBUG ((DEBUG_ERROR, "SmramProfileHandler Exit\n"));
 
   return EFI_SUCCESS;
 }
@@ -2402,20 +2402,20 @@ DumpSmramRange (
   SmramProfileGettingStatus = mSmramProfileGettingStatus;
   mSmramProfileGettingStatus = TRUE;
 
-  DEBUG ((EFI_D_INFO, "FullSmramRange address - 0x%08x\n", mFullSmramRanges));
+  DEBUG ((DEBUG_INFO, "FullSmramRange address - 0x%08x\n", mFullSmramRanges));
 
-  DEBUG ((EFI_D_INFO, "======= SmramProfile begin =======\n"));
+  DEBUG ((DEBUG_INFO, "======= SmramProfile begin =======\n"));
 
-  DEBUG ((EFI_D_INFO, "FullSmramRange:\n"));
+  DEBUG ((DEBUG_INFO, "FullSmramRange:\n"));
   for (Index = 0; Index < mFullSmramRangeCount; Index++) {
-    DEBUG ((EFI_D_INFO, "  FullSmramRange (0x%x)\n", Index));
-    DEBUG ((EFI_D_INFO, "    PhysicalStart      - 0x%016lx\n", mFullSmramRanges[Index].PhysicalStart));
-    DEBUG ((EFI_D_INFO, "    CpuStart           - 0x%016lx\n", mFullSmramRanges[Index].CpuStart));
-    DEBUG ((EFI_D_INFO, "    PhysicalSize       - 0x%016lx\n", mFullSmramRanges[Index].PhysicalSize));
-    DEBUG ((EFI_D_INFO, "    RegionState        - 0x%016lx\n", mFullSmramRanges[Index].RegionState));
+    DEBUG ((DEBUG_INFO, "  FullSmramRange (0x%x)\n", Index));
+    DEBUG ((DEBUG_INFO, "    PhysicalStart      - 0x%016lx\n", mFullSmramRanges[Index].PhysicalStart));
+    DEBUG ((DEBUG_INFO, "    CpuStart           - 0x%016lx\n", mFullSmramRanges[Index].CpuStart));
+    DEBUG ((DEBUG_INFO, "    PhysicalSize       - 0x%016lx\n", mFullSmramRanges[Index].PhysicalSize));
+    DEBUG ((DEBUG_INFO, "    RegionState        - 0x%016lx\n", mFullSmramRanges[Index].RegionState));
   }
 
-  DEBUG ((EFI_D_INFO, "======= SmramProfile end =======\n"));
+  DEBUG ((DEBUG_INFO, "======= SmramProfile end =======\n"));
 
   mSmramProfileGettingStatus = SmramProfileGettingStatus;
 }
@@ -2444,20 +2444,20 @@ DumpFreePagesList (
   SmramProfileGettingStatus = mSmramProfileGettingStatus;
   mSmramProfileGettingStatus = TRUE;
 
-  DEBUG ((EFI_D_INFO, "======= SmramProfile begin =======\n"));
+  DEBUG ((DEBUG_INFO, "======= SmramProfile begin =======\n"));
 
-  DEBUG ((EFI_D_INFO, "FreePagesList:\n"));
+  DEBUG ((DEBUG_INFO, "FreePagesList:\n"));
   FreePageList = &mSmmMemoryMap;
   for (Node = FreePageList->BackLink, Index = 0;
        Node != FreePageList;
        Node = Node->BackLink, Index++) {
     Pages = BASE_CR (Node, FREE_PAGE_LIST, Link);
-    DEBUG ((EFI_D_INFO, "  Index - 0x%x\n", Index));
-    DEBUG ((EFI_D_INFO, "    PhysicalStart - 0x%016lx\n", (PHYSICAL_ADDRESS) (UINTN) Pages));
-    DEBUG ((EFI_D_INFO, "    NumberOfPages - 0x%08x\n", Pages->NumberOfPages));
+    DEBUG ((DEBUG_INFO, "  Index - 0x%x\n", Index));
+    DEBUG ((DEBUG_INFO, "    PhysicalStart - 0x%016lx\n", (PHYSICAL_ADDRESS) (UINTN) Pages));
+    DEBUG ((DEBUG_INFO, "    NumberOfPages - 0x%08x\n", Pages->NumberOfPages));
   }
 
-  DEBUG ((EFI_D_INFO, "======= SmramProfile end =======\n"));
+  DEBUG ((DEBUG_INFO, "======= SmramProfile end =======\n"));
 
   mSmramProfileGettingStatus = SmramProfileGettingStatus;
 }
@@ -2646,21 +2646,21 @@ DumpSmramProfile (
   mSmramProfileGettingStatus = TRUE;
 
   Context = &ContextData->Context;
-  DEBUG ((EFI_D_INFO, "======= SmramProfile begin =======\n"));
-  DEBUG ((EFI_D_INFO, "MEMORY_PROFILE_CONTEXT\n"));
+  DEBUG ((DEBUG_INFO, "======= SmramProfile begin =======\n"));
+  DEBUG ((DEBUG_INFO, "MEMORY_PROFILE_CONTEXT\n"));
 
-  DEBUG ((EFI_D_INFO, "  CurrentTotalUsage     - 0x%016lx\n", Context->CurrentTotalUsage));
-  DEBUG ((EFI_D_INFO, "  PeakTotalUsage        - 0x%016lx\n", Context->PeakTotalUsage));
+  DEBUG ((DEBUG_INFO, "  CurrentTotalUsage     - 0x%016lx\n", Context->CurrentTotalUsage));
+  DEBUG ((DEBUG_INFO, "  PeakTotalUsage        - 0x%016lx\n", Context->PeakTotalUsage));
   for (TypeIndex = 0; TypeIndex < sizeof (Context->CurrentTotalUsageByType) / sizeof (Context->CurrentTotalUsageByType[0]); TypeIndex++) {
     if ((Context->CurrentTotalUsageByType[TypeIndex] != 0) ||
         (Context->PeakTotalUsageByType[TypeIndex] != 0)) {
-      DEBUG ((EFI_D_INFO, "  CurrentTotalUsage[0x%02x]  - 0x%016lx (%a)\n", TypeIndex, Context->CurrentTotalUsageByType[TypeIndex], ProfileMemoryTypeToStr (TypeIndex)));
-      DEBUG ((EFI_D_INFO, "  PeakTotalUsage[0x%02x]     - 0x%016lx (%a)\n", TypeIndex, Context->PeakTotalUsageByType[TypeIndex], ProfileMemoryTypeToStr (TypeIndex)));
+      DEBUG ((DEBUG_INFO, "  CurrentTotalUsage[0x%02x]  - 0x%016lx (%a)\n", TypeIndex, Context->CurrentTotalUsageByType[TypeIndex], ProfileMemoryTypeToStr (TypeIndex)));
+      DEBUG ((DEBUG_INFO, "  PeakTotalUsage[0x%02x]     - 0x%016lx (%a)\n", TypeIndex, Context->PeakTotalUsageByType[TypeIndex], ProfileMemoryTypeToStr (TypeIndex)));
     }
   }
-  DEBUG ((EFI_D_INFO, "  TotalImageSize        - 0x%016lx\n", Context->TotalImageSize));
-  DEBUG ((EFI_D_INFO, "  ImageCount            - 0x%08x\n", Context->ImageCount));
-  DEBUG ((EFI_D_INFO, "  SequenceCount         - 0x%08x\n", Context->SequenceCount));
+  DEBUG ((DEBUG_INFO, "  TotalImageSize        - 0x%016lx\n", Context->TotalImageSize));
+  DEBUG ((DEBUG_INFO, "  ImageCount            - 0x%08x\n", Context->ImageCount));
+  DEBUG ((DEBUG_INFO, "  SequenceCount         - 0x%08x\n", Context->SequenceCount));
 
   SmramDriverInfoList = ContextData->DriverInfoList;
   for (DriverLink = SmramDriverInfoList->ForwardLink, DriverIndex = 0;
@@ -2673,23 +2673,23 @@ DumpSmramProfile (
                    MEMORY_PROFILE_DRIVER_INFO_SIGNATURE
                    );
     DriverInfo = &DriverInfoData->DriverInfo;
-    DEBUG ((EFI_D_INFO, "  MEMORY_PROFILE_DRIVER_INFO (0x%x)\n", DriverIndex));
-    DEBUG ((EFI_D_INFO, "    FileName            - %g\n", &DriverInfo->FileName));
-    DEBUG ((EFI_D_INFO, "    ImageBase           - 0x%016lx\n", DriverInfo->ImageBase));
-    DEBUG ((EFI_D_INFO, "    ImageSize           - 0x%016lx\n", DriverInfo->ImageSize));
-    DEBUG ((EFI_D_INFO, "    EntryPoint          - 0x%016lx\n", DriverInfo->EntryPoint));
-    DEBUG ((EFI_D_INFO, "    ImageSubsystem      - 0x%04x\n", DriverInfo->ImageSubsystem));
-    DEBUG ((EFI_D_INFO, "    FileType            - 0x%02x\n", DriverInfo->FileType));
-    DEBUG ((EFI_D_INFO, "    CurrentUsage        - 0x%016lx\n", DriverInfo->CurrentUsage));
-    DEBUG ((EFI_D_INFO, "    PeakUsage           - 0x%016lx\n", DriverInfo->PeakUsage));
+    DEBUG ((DEBUG_INFO, "  MEMORY_PROFILE_DRIVER_INFO (0x%x)\n", DriverIndex));
+    DEBUG ((DEBUG_INFO, "    FileName            - %g\n", &DriverInfo->FileName));
+    DEBUG ((DEBUG_INFO, "    ImageBase           - 0x%016lx\n", DriverInfo->ImageBase));
+    DEBUG ((DEBUG_INFO, "    ImageSize           - 0x%016lx\n", DriverInfo->ImageSize));
+    DEBUG ((DEBUG_INFO, "    EntryPoint          - 0x%016lx\n", DriverInfo->EntryPoint));
+    DEBUG ((DEBUG_INFO, "    ImageSubsystem      - 0x%04x\n", DriverInfo->ImageSubsystem));
+    DEBUG ((DEBUG_INFO, "    FileType            - 0x%02x\n", DriverInfo->FileType));
+    DEBUG ((DEBUG_INFO, "    CurrentUsage        - 0x%016lx\n", DriverInfo->CurrentUsage));
+    DEBUG ((DEBUG_INFO, "    PeakUsage           - 0x%016lx\n", DriverInfo->PeakUsage));
     for (TypeIndex = 0; TypeIndex < sizeof (DriverInfo->CurrentUsageByType) / sizeof (DriverInfo->CurrentUsageByType[0]); TypeIndex++) {
       if ((DriverInfo->CurrentUsageByType[TypeIndex] != 0) ||
           (DriverInfo->PeakUsageByType[TypeIndex] != 0)) {
-        DEBUG ((EFI_D_INFO, "    CurrentUsage[0x%02x]     - 0x%016lx (%a)\n", TypeIndex, DriverInfo->CurrentUsageByType[TypeIndex], ProfileMemoryTypeToStr (TypeIndex)));
-        DEBUG ((EFI_D_INFO, "    PeakUsage[0x%02x]        - 0x%016lx (%a)\n", TypeIndex, DriverInfo->PeakUsageByType[TypeIndex], ProfileMemoryTypeToStr (TypeIndex)));
+        DEBUG ((DEBUG_INFO, "    CurrentUsage[0x%02x]     - 0x%016lx (%a)\n", TypeIndex, DriverInfo->CurrentUsageByType[TypeIndex], ProfileMemoryTypeToStr (TypeIndex)));
+        DEBUG ((DEBUG_INFO, "    PeakUsage[0x%02x]        - 0x%016lx (%a)\n", TypeIndex, DriverInfo->PeakUsageByType[TypeIndex], ProfileMemoryTypeToStr (TypeIndex)));
       }
     }
-    DEBUG ((EFI_D_INFO, "    AllocRecordCount    - 0x%08x\n", DriverInfo->AllocRecordCount));
+    DEBUG ((DEBUG_INFO, "    AllocRecordCount    - 0x%08x\n", DriverInfo->AllocRecordCount));
 
     AllocInfoList = DriverInfoData->AllocInfoList;
     for (AllocLink = AllocInfoList->ForwardLink, AllocIndex = 0;
@@ -2702,25 +2702,25 @@ DumpSmramProfile (
                      MEMORY_PROFILE_ALLOC_INFO_SIGNATURE
                      );
       AllocInfo = &AllocInfoData->AllocInfo;
-      DEBUG ((EFI_D_INFO, "    MEMORY_PROFILE_ALLOC_INFO (0x%x)\n", AllocIndex));
-      DEBUG ((EFI_D_INFO, "      CallerAddress  - 0x%016lx (Offset: 0x%08x)\n", AllocInfo->CallerAddress, AllocInfo->CallerAddress - DriverInfo->ImageBase));
-      DEBUG ((EFI_D_INFO, "      SequenceId     - 0x%08x\n", AllocInfo->SequenceId));
+      DEBUG ((DEBUG_INFO, "    MEMORY_PROFILE_ALLOC_INFO (0x%x)\n", AllocIndex));
+      DEBUG ((DEBUG_INFO, "      CallerAddress  - 0x%016lx (Offset: 0x%08x)\n", AllocInfo->CallerAddress, AllocInfo->CallerAddress - DriverInfo->ImageBase));
+      DEBUG ((DEBUG_INFO, "      SequenceId     - 0x%08x\n", AllocInfo->SequenceId));
       if ((AllocInfo->Action & MEMORY_PROFILE_ACTION_USER_DEFINED_MASK) != 0) {
         if (AllocInfoData->ActionString != NULL) {
-          DEBUG ((EFI_D_INFO, "      Action         - 0x%08x (%a)\n", AllocInfo->Action, AllocInfoData->ActionString));
+          DEBUG ((DEBUG_INFO, "      Action         - 0x%08x (%a)\n", AllocInfo->Action, AllocInfoData->ActionString));
         } else {
-          DEBUG ((EFI_D_INFO, "      Action         - 0x%08x (UserDefined-0x%08x)\n", AllocInfo->Action, AllocInfo->Action));
+          DEBUG ((DEBUG_INFO, "      Action         - 0x%08x (UserDefined-0x%08x)\n", AllocInfo->Action, AllocInfo->Action));
         }
       } else {
-        DEBUG ((EFI_D_INFO, "      Action         - 0x%08x (%a)\n", AllocInfo->Action, ProfileActionToStr (AllocInfo->Action)));
+        DEBUG ((DEBUG_INFO, "      Action         - 0x%08x (%a)\n", AllocInfo->Action, ProfileActionToStr (AllocInfo->Action)));
       }
-      DEBUG ((EFI_D_INFO, "      MemoryType     - 0x%08x (%a)\n", AllocInfo->MemoryType, ProfileMemoryTypeToStr (AllocInfo->MemoryType)));
-      DEBUG ((EFI_D_INFO, "      Buffer         - 0x%016lx\n", AllocInfo->Buffer));
-      DEBUG ((EFI_D_INFO, "      Size           - 0x%016lx\n", AllocInfo->Size));
+      DEBUG ((DEBUG_INFO, "      MemoryType     - 0x%08x (%a)\n", AllocInfo->MemoryType, ProfileMemoryTypeToStr (AllocInfo->MemoryType)));
+      DEBUG ((DEBUG_INFO, "      Buffer         - 0x%016lx\n", AllocInfo->Buffer));
+      DEBUG ((DEBUG_INFO, "      Size           - 0x%016lx\n", AllocInfo->Size));
     }
   }
 
-  DEBUG ((EFI_D_INFO, "======= SmramProfile end =======\n"));
+  DEBUG ((DEBUG_INFO, "======= SmramProfile end =======\n"));
 
   mSmramProfileGettingStatus = SmramProfileGettingStatus;
 }
@@ -2743,4 +2743,3 @@ DumpSmramInfo (
     }
   );
 }
-

--- a/MdeModulePkg/Library/BootMaintenanceManagerUiLib/BootOption.c
+++ b/MdeModulePkg/Library/BootMaintenanceManagerUiLib/BootOption.c
@@ -611,7 +611,7 @@ BOpt_GetOptionNumber (
       continue;
     }
     UnicodeSPrint (StrTemp, sizeof (StrTemp), L"%s%04x", Type, (UINTN) OptionNumber);
-    DEBUG((EFI_D_ERROR,"Option = %s\n", StrTemp));
+    DEBUG((DEBUG_ERROR,"Option = %s\n", StrTemp));
     GetEfiGlobalVariable2 (StrTemp, (VOID **) &OptionBuffer, &OptionSize);
     if (NULL == OptionBuffer) {
       //
@@ -1002,4 +1002,3 @@ CreateDriverOptionFromFile (
 {
   return ReSendForm(FilePath, FORM_DRV_ADD_FILE_ID);
 }
-

--- a/MdeModulePkg/Library/BootManagerUiLib/BootManager.c
+++ b/MdeModulePkg/Library/BootManagerUiLib/BootManager.c
@@ -380,7 +380,7 @@ GroupMultipleLegacyBootOption4SameType (
       //
       // Legacy Boot Option
       //
-      DEBUG ((EFI_D_ERROR, "[BootManagerDxe] ==== Find Legacy Boot Option  0x%x! ==== \n", Index));
+      DEBUG ((DEBUG_ERROR, "[BootManagerDxe] ==== Find Legacy Boot Option  0x%x! ==== \n", Index));
       ASSERT ((((BBS_BBS_DEVICE_PATH *) BootOption.FilePath)->DeviceType & 0xF) < ARRAY_SIZE (DeviceTypeIndex));
       NextIndex = &DeviceTypeIndex[((BBS_BBS_DEVICE_PATH *) BootOption.FilePath)->DeviceType & 0xF];
 
@@ -926,4 +926,3 @@ BootManagerUiLibDestructor (
 
   return EFI_SUCCESS;
 }
-

--- a/MdeModulePkg/Library/DxeIpmiLibIpmiProtocol/DxeIpmiLibIpmiProtocol.c
+++ b/MdeModulePkg/Library/DxeIpmiLibIpmiProtocol/DxeIpmiLibIpmiProtocol.c
@@ -54,7 +54,7 @@ IpmiSubmitCommand (
       //
       // Dxe Ipmi Protocol is not installed. So, IPMI device is not present.
       //
-      DEBUG ((EFI_D_ERROR, "IpmiSubmitCommand in Dxe Phase under SMS Status - %r\n", Status));
+      DEBUG ((DEBUG_ERROR, "IpmiSubmitCommand in Dxe Phase under SMS Status - %r\n", Status));
       return EFI_NOT_FOUND;
     }
   }

--- a/MdeModulePkg/Library/FrameBufferBltLib/FrameBufferBltLib.c
+++ b/MdeModulePkg/Library/FrameBufferBltLib/FrameBufferBltLib.c
@@ -209,17 +209,17 @@ FrameBufferBltLibVideoFill (
   // BltBuffer to Video: Source is BltBuffer, destination is Video
   //
   if (DestinationY + Height > Configure->Height) {
-    DEBUG ((EFI_D_VERBOSE, "VideoFill: Past screen (Y)\n"));
+    DEBUG ((DEBUG_VERBOSE, "VideoFill: Past screen (Y)\n"));
     return RETURN_INVALID_PARAMETER;
   }
 
   if (DestinationX + Width > Configure->Width) {
-    DEBUG ((EFI_D_VERBOSE, "VideoFill: Past screen (X)\n"));
+    DEBUG ((DEBUG_VERBOSE, "VideoFill: Past screen (X)\n"));
     return RETURN_INVALID_PARAMETER;
   }
 
   if (Width == 0 || Height == 0) {
-    DEBUG ((EFI_D_VERBOSE, "VideoFill: Width or Height is 0\n"));
+    DEBUG ((DEBUG_VERBOSE, "VideoFill: Width or Height is 0\n"));
     return RETURN_INVALID_PARAMETER;
   }
 
@@ -235,7 +235,7 @@ FrameBufferBltLibVideoFill (
       (((Uint32 << Configure->PixelShl[2]) >> Configure->PixelShr[2]) &
        Configure->PixelMasks.BlueMask)
       );
-  DEBUG ((EFI_D_VERBOSE, "VideoFill: color=0x%x, wide-fill=0x%x\n",
+  DEBUG ((DEBUG_VERBOSE, "VideoFill: color=0x%x, wide-fill=0x%x\n",
           Uint32, WideFill));
 
   //
@@ -267,7 +267,7 @@ FrameBufferBltLibVideoFill (
   }
 
   if (UseWideFill && (DestinationX == 0) && (Width == Configure->PixelsPerScanLine)) {
-    DEBUG ((EFI_D_VERBOSE, "VideoFill (wide, one-shot)\n"));
+    DEBUG ((DEBUG_VERBOSE, "VideoFill (wide, one-shot)\n"));
     Offset = DestinationY * Configure->PixelsPerScanLine;
     Offset = Configure->BytesPerPixel * Offset;
     Destination = Configure->FrameBuffer + Offset;
@@ -288,7 +288,7 @@ FrameBufferBltLibVideoFill (
       Destination = Configure->FrameBuffer + Offset;
 
       if (UseWideFill && (((UINTN) Destination & 7) == 0)) {
-        DEBUG ((EFI_D_VERBOSE, "VideoFill (wide)\n"));
+        DEBUG ((DEBUG_VERBOSE, "VideoFill (wide)\n"));
         SizeInBytes = WidthInBytes;
         if (SizeInBytes >= 8) {
           SetMem64 (Destination, SizeInBytes & ~7, WideFill);
@@ -299,7 +299,7 @@ FrameBufferBltLibVideoFill (
           CopyMem (Destination, &WideFill, SizeInBytes);
         }
       } else {
-        DEBUG ((EFI_D_VERBOSE, "VideoFill (not wide)\n"));
+        DEBUG ((DEBUG_VERBOSE, "VideoFill (not wide)\n"));
         if (!LineBufferReady) {
           CopyMem (Configure->LineBuffer, &WideFill, Configure->BytesPerPixel);
           for (IndexX = 1; IndexX < Width; ) {

--- a/MdeModulePkg/Library/PciHostBridgeLibNull/PciHostBridgeLibNull.c
+++ b/MdeModulePkg/Library/PciHostBridgeLibNull/PciHostBridgeLibNull.c
@@ -73,24 +73,24 @@ PciHostBridgeResourceConflict (
 {
   EFI_ACPI_ADDRESS_SPACE_DESCRIPTOR *Descriptor;
   UINTN                             RootBridgeIndex;
-  DEBUG ((EFI_D_ERROR, "PciHostBridge: Resource conflict happens!\n"));
+  DEBUG ((DEBUG_ERROR, "PciHostBridge: Resource conflict happens!\n"));
 
   RootBridgeIndex = 0;
   Descriptor = (EFI_ACPI_ADDRESS_SPACE_DESCRIPTOR *) Configuration;
   while (Descriptor->Desc == ACPI_ADDRESS_SPACE_DESCRIPTOR) {
-    DEBUG ((EFI_D_ERROR, "RootBridge[%d]:\n", RootBridgeIndex++));
+    DEBUG ((DEBUG_ERROR, "RootBridge[%d]:\n", RootBridgeIndex++));
     for (; Descriptor->Desc == ACPI_ADDRESS_SPACE_DESCRIPTOR; Descriptor++) {
       ASSERT (Descriptor->ResType <
               (sizeof (mPciHostBridgeLibAcpiAddressSpaceTypeStr) /
                sizeof (mPciHostBridgeLibAcpiAddressSpaceTypeStr[0])
                )
               );
-      DEBUG ((EFI_D_ERROR, " %s: Length/Alignment = 0x%lx / 0x%lx\n",
+      DEBUG ((DEBUG_ERROR, " %s: Length/Alignment = 0x%lx / 0x%lx\n",
               mPciHostBridgeLibAcpiAddressSpaceTypeStr[Descriptor->ResType],
               Descriptor->AddrLen, Descriptor->AddrRangeMax
               ));
       if (Descriptor->ResType == ACPI_ADDRESS_SPACE_TYPE_MEM) {
-        DEBUG ((EFI_D_ERROR, "     Granularity/SpecificFlag = %ld / %02x%s\n",
+        DEBUG ((DEBUG_ERROR, "     Granularity/SpecificFlag = %ld / %02x%s\n",
                 Descriptor->AddrSpaceGranularity, Descriptor->SpecificFlag,
                 ((Descriptor->SpecificFlag &
                   EFI_ACPI_MEMORY_RESOURCE_SPECIFIC_FLAG_CACHEABLE_PREFETCHABLE

--- a/MdeModulePkg/Library/PeiIpmiLibIpmiPpi/PeiIpmiLibIpmiPpi.c
+++ b/MdeModulePkg/Library/PeiIpmiLibIpmiPpi/PeiIpmiLibIpmiPpi.c
@@ -55,7 +55,7 @@ IpmiSubmitCommand (
     //
     // Ipmi Ppi is not installed. So, IPMI device is not present.
     //
-    DEBUG ((EFI_D_ERROR, "IpmiSubmitCommand in Pei Phase under SMS Status - %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "IpmiSubmitCommand in Pei Phase under SMS Status - %r\n", Status));
     return EFI_NOT_FOUND;
   }
 

--- a/MdeModulePkg/Library/PeiReportStatusCodeLib/ReportStatusCodeLib.c
+++ b/MdeModulePkg/Library/PeiReportStatusCodeLib/ReportStatusCodeLib.c
@@ -468,7 +468,7 @@ ReportStatusCodeEx (
     // The local variable Buffer not large enough to hold the extended data associated
     // with the status code being reported.
     //
-    DEBUG ((EFI_D_ERROR, "Status code extended data is too large to be reported!\n"));
+    DEBUG ((DEBUG_ERROR, "Status code extended data is too large to be reported!\n"));
     return EFI_OUT_OF_RESOURCES;
   }
   StatusCodeData = (EFI_STATUS_CODE_DATA  *) Buffer;

--- a/MdeModulePkg/Library/PiDxeS3BootScriptLib/BootScriptExecute.c
+++ b/MdeModulePkg/Library/PiDxeS3BootScriptLib/BootScriptExecute.c
@@ -62,51 +62,51 @@ InternalSmbusExecute (
 
   switch (Operation) {
     case EfiSmbusQuickRead:
-      DEBUG ((EFI_D_INFO, "EfiSmbusQuickRead - 0x%08x\n", SmbusAddress));
+      DEBUG ((DEBUG_INFO, "EfiSmbusQuickRead - 0x%08x\n", SmbusAddress));
       SmBusQuickRead (SmbusAddress, &Status);
       break;
     case EfiSmbusQuickWrite:
-      DEBUG ((EFI_D_INFO, "EfiSmbusQuickWrite - 0x%08x\n", SmbusAddress));
+      DEBUG ((DEBUG_INFO, "EfiSmbusQuickWrite - 0x%08x\n", SmbusAddress));
       SmBusQuickWrite (SmbusAddress, &Status);
       break;
     case EfiSmbusReceiveByte:
-      DEBUG ((EFI_D_INFO, "EfiSmbusReceiveByte - 0x%08x\n", SmbusAddress));
+      DEBUG ((DEBUG_INFO, "EfiSmbusReceiveByte - 0x%08x\n", SmbusAddress));
       SmBusReceiveByte (SmbusAddress, &Status);
       break;
     case EfiSmbusSendByte:
-      DEBUG ((EFI_D_INFO, "EfiSmbusSendByte - 0x%08x (0x%02x)\n", SmbusAddress, (UINTN)*(UINT8 *) Buffer));
+      DEBUG ((DEBUG_INFO, "EfiSmbusSendByte - 0x%08x (0x%02x)\n", SmbusAddress, (UINTN)*(UINT8 *) Buffer));
       SmBusSendByte (SmbusAddress, *(UINT8 *) Buffer, &Status);
       break;
     case EfiSmbusReadByte:
-      DEBUG ((EFI_D_INFO, "EfiSmbusReadByte - 0x%08x\n", SmbusAddress));
+      DEBUG ((DEBUG_INFO, "EfiSmbusReadByte - 0x%08x\n", SmbusAddress));
       SmBusReadDataByte (SmbusAddress, &Status);
       break;
     case EfiSmbusWriteByte:
-      DEBUG ((EFI_D_INFO, "EfiSmbusWriteByte - 0x%08x (0x%02x)\n", SmbusAddress, (UINTN)*(UINT8 *) Buffer));
+      DEBUG ((DEBUG_INFO, "EfiSmbusWriteByte - 0x%08x (0x%02x)\n", SmbusAddress, (UINTN)*(UINT8 *) Buffer));
       SmBusWriteDataByte (SmbusAddress, *(UINT8 *) Buffer, &Status);
       break;
     case EfiSmbusReadWord:
-      DEBUG ((EFI_D_INFO, "EfiSmbusReadWord - 0x%08x\n", SmbusAddress));
+      DEBUG ((DEBUG_INFO, "EfiSmbusReadWord - 0x%08x\n", SmbusAddress));
       SmBusReadDataWord (SmbusAddress, &Status);
       break;
     case EfiSmbusWriteWord:
-      DEBUG ((EFI_D_INFO, "EfiSmbusWriteWord - 0x%08x (0x%04x)\n", SmbusAddress, (UINTN)*(UINT16 *) Buffer));
+      DEBUG ((DEBUG_INFO, "EfiSmbusWriteWord - 0x%08x (0x%04x)\n", SmbusAddress, (UINTN)*(UINT16 *) Buffer));
       SmBusWriteDataWord (SmbusAddress, *(UINT16 *) Buffer, &Status);
       break;
     case EfiSmbusProcessCall:
-      DEBUG ((EFI_D_INFO, "EfiSmbusProcessCall - 0x%08x (0x%04x)\n", SmbusAddress, (UINTN)*(UINT16 *) Buffer));
+      DEBUG ((DEBUG_INFO, "EfiSmbusProcessCall - 0x%08x (0x%04x)\n", SmbusAddress, (UINTN)*(UINT16 *) Buffer));
       SmBusProcessCall (SmbusAddress, *(UINT16 *) Buffer, &Status);
       break;
     case EfiSmbusReadBlock:
-      DEBUG ((EFI_D_INFO, "EfiSmbusReadBlock - 0x%08x\n", SmbusAddress));
+      DEBUG ((DEBUG_INFO, "EfiSmbusReadBlock - 0x%08x\n", SmbusAddress));
       SmBusReadBlock (SmbusAddress, WorkBuffer, &Status);
       break;
     case EfiSmbusWriteBlock:
-      DEBUG ((EFI_D_INFO, "EfiSmbusWriteBlock - 0x%08x\n", SmbusAddress));
+      DEBUG ((DEBUG_INFO, "EfiSmbusWriteBlock - 0x%08x\n", SmbusAddress));
       SmBusWriteBlock ((SmbusAddress + SMBUS_LIB_ADDRESS (0, 0, (*Length), FALSE)), Buffer, &Status);
       break;
     case EfiSmbusBWBRProcessCall:
-      DEBUG ((EFI_D_INFO, "EfiSmbusBWBRProcessCall - 0x%08x\n", SmbusAddress));
+      DEBUG ((DEBUG_INFO, "EfiSmbusBWBRProcessCall - 0x%08x\n", SmbusAddress));
       SmBusBlockProcessCall ((SmbusAddress + SMBUS_LIB_ADDRESS (0, 0, (*Length), FALSE)), Buffer, WorkBuffer, &Status);
       break;
     default:
@@ -206,54 +206,54 @@ ScriptIoRead (
     switch (Width) {
 
     case S3BootScriptWidthUint8:
-      DEBUG ((EFI_D_INFO, "S3BootScriptWidthUint8 - 0x%08x\n", (UINTN) Address));
+      DEBUG ((DEBUG_INFO, "S3BootScriptWidthUint8 - 0x%08x\n", (UINTN) Address));
       *Out.Uint8 = IoRead8 ((UINTN) Address);
       break;
     case S3BootScriptWidthFifoUint8:
-      DEBUG ((EFI_D_INFO, "S3BootScriptWidthFifoUint8 - 0x%08x\n", (UINTN) Address));
+      DEBUG ((DEBUG_INFO, "S3BootScriptWidthFifoUint8 - 0x%08x\n", (UINTN) Address));
       *Out.Uint8 = IoRead8 ((UINTN) Address);
       break;
     case S3BootScriptWidthFillUint8:
-      DEBUG ((EFI_D_INFO, "S3BootScriptWidthFillUint8 - 0x%08x\n", (UINTN) Address));
+      DEBUG ((DEBUG_INFO, "S3BootScriptWidthFillUint8 - 0x%08x\n", (UINTN) Address));
       *Out.Uint8 = IoRead8 ((UINTN) Address);
       break;
 
     case S3BootScriptWidthUint16:
-      DEBUG ((EFI_D_INFO, "S3BootScriptWidthUint16 - 0x%08x\n", (UINTN) Address));
+      DEBUG ((DEBUG_INFO, "S3BootScriptWidthUint16 - 0x%08x\n", (UINTN) Address));
       *Out.Uint16 = IoRead16 ((UINTN) Address);
       break;
     case S3BootScriptWidthFifoUint16:
-      DEBUG ((EFI_D_INFO, "S3BootScriptWidthFifoUint16 - 0x%08x\n", (UINTN) Address));
+      DEBUG ((DEBUG_INFO, "S3BootScriptWidthFifoUint16 - 0x%08x\n", (UINTN) Address));
       *Out.Uint16 = IoRead16 ((UINTN) Address);
       break;
     case S3BootScriptWidthFillUint16:
-      DEBUG ((EFI_D_INFO, "S3BootScriptWidthFillUint16 - 0x%08x\n", (UINTN) Address));
+      DEBUG ((DEBUG_INFO, "S3BootScriptWidthFillUint16 - 0x%08x\n", (UINTN) Address));
       *Out.Uint16 = IoRead16 ((UINTN) Address);
       break;
 
     case S3BootScriptWidthUint32:
-      DEBUG ((EFI_D_INFO, "S3BootScriptWidthUint32 - 0x%08x\n", (UINTN) Address));
+      DEBUG ((DEBUG_INFO, "S3BootScriptWidthUint32 - 0x%08x\n", (UINTN) Address));
       *Out.Uint32 = IoRead32 ((UINTN) Address);
       break;
     case S3BootScriptWidthFifoUint32:
-      DEBUG ((EFI_D_INFO, "S3BootScriptWidthFifoUint32 - 0x%08x\n", (UINTN) Address));
+      DEBUG ((DEBUG_INFO, "S3BootScriptWidthFifoUint32 - 0x%08x\n", (UINTN) Address));
       *Out.Uint32 = IoRead32 ((UINTN) Address);
       break;
     case S3BootScriptWidthFillUint32:
-      DEBUG ((EFI_D_INFO, "S3BootScriptWidthFillUint32 - 0x%08x\n", (UINTN) Address));
+      DEBUG ((DEBUG_INFO, "S3BootScriptWidthFillUint32 - 0x%08x\n", (UINTN) Address));
       *Out.Uint32 = IoRead32 ((UINTN) Address);
       break;
 
     case S3BootScriptWidthUint64:
-      DEBUG ((EFI_D_INFO, "S3BootScriptWidthUint64 - 0x%08x\n", (UINTN) Address));
+      DEBUG ((DEBUG_INFO, "S3BootScriptWidthUint64 - 0x%08x\n", (UINTN) Address));
       *Out.Uint64 = IoRead64 ((UINTN) Address);
       break;
     case S3BootScriptWidthFifoUint64:
-      DEBUG ((EFI_D_INFO, "S3BootScriptWidthFifoUint64 - 0x%08x\n", (UINTN) Address));
+      DEBUG ((DEBUG_INFO, "S3BootScriptWidthFifoUint64 - 0x%08x\n", (UINTN) Address));
       *Out.Uint64 = IoRead64 ((UINTN) Address);
       break;
     case S3BootScriptWidthFillUint64:
-      DEBUG ((EFI_D_INFO, "S3BootScriptWidthFillUint64 - 0x%08x\n", (UINTN) Address));
+      DEBUG ((DEBUG_INFO, "S3BootScriptWidthFillUint64 - 0x%08x\n", (UINTN) Address));
       *Out.Uint64 = IoRead64 ((UINTN) Address);
       break;
 
@@ -313,51 +313,51 @@ ScriptIoWrite (
   for (; Count > 0; Count--, Address += AddressStride, In.Buf += BufferStride) {
     switch (Width) {
       case S3BootScriptWidthUint8:
-        DEBUG ((EFI_D_INFO, "S3BootScriptWidthUint8 - 0x%08x (0x%02x)\n", (UINTN)Address, (UINTN)*In.Uint8));
+        DEBUG ((DEBUG_INFO, "S3BootScriptWidthUint8 - 0x%08x (0x%02x)\n", (UINTN)Address, (UINTN)*In.Uint8));
         IoWrite8 ((UINTN) Address, *In.Uint8);
         break;
       case S3BootScriptWidthFifoUint8:
-        DEBUG ((EFI_D_INFO, "S3BootScriptWidthFifoUint8 - 0x%08x (0x%02x)\n", (UINTN)OriginalAddress, (UINTN)*In.Uint8));
+        DEBUG ((DEBUG_INFO, "S3BootScriptWidthFifoUint8 - 0x%08x (0x%02x)\n", (UINTN)OriginalAddress, (UINTN)*In.Uint8));
         IoWrite8 ((UINTN) OriginalAddress, *In.Uint8);
         break;
       case S3BootScriptWidthFillUint8:
-        DEBUG ((EFI_D_INFO, "S3BootScriptWidthFillUint8 - 0x%08x (0x%02x)\n", (UINTN)Address, (UINTN)*OriginalIn.Uint8));
+        DEBUG ((DEBUG_INFO, "S3BootScriptWidthFillUint8 - 0x%08x (0x%02x)\n", (UINTN)Address, (UINTN)*OriginalIn.Uint8));
         IoWrite8 ((UINTN) Address, *OriginalIn.Uint8);
         break;
       case S3BootScriptWidthUint16:
-        DEBUG ((EFI_D_INFO, "S3BootScriptWidthUint16 - 0x%08x (0x%04x)\n", (UINTN)Address, (UINTN)*In.Uint16));
+        DEBUG ((DEBUG_INFO, "S3BootScriptWidthUint16 - 0x%08x (0x%04x)\n", (UINTN)Address, (UINTN)*In.Uint16));
         IoWrite16 ((UINTN) Address, *In.Uint16);
         break;
       case S3BootScriptWidthFifoUint16:
-        DEBUG ((EFI_D_INFO, "S3BootScriptWidthFifoUint16 - 0x%08x (0x%04x)\n", (UINTN)OriginalAddress, (UINTN)*In.Uint16));
+        DEBUG ((DEBUG_INFO, "S3BootScriptWidthFifoUint16 - 0x%08x (0x%04x)\n", (UINTN)OriginalAddress, (UINTN)*In.Uint16));
         IoWrite16 ((UINTN) OriginalAddress, *In.Uint16);
         break;
       case S3BootScriptWidthFillUint16:
-        DEBUG ((EFI_D_INFO, "S3BootScriptWidthFillUint16 - 0x%08x (0x%04x)\n", (UINTN)Address, (UINTN)*OriginalIn.Uint16));
+        DEBUG ((DEBUG_INFO, "S3BootScriptWidthFillUint16 - 0x%08x (0x%04x)\n", (UINTN)Address, (UINTN)*OriginalIn.Uint16));
         IoWrite16 ((UINTN) Address, *OriginalIn.Uint16);
         break;
       case S3BootScriptWidthUint32:
-        DEBUG ((EFI_D_INFO, "S3BootScriptWidthUint32 - 0x%08x (0x%08x)\n", (UINTN)Address, (UINTN)*In.Uint32));
+        DEBUG ((DEBUG_INFO, "S3BootScriptWidthUint32 - 0x%08x (0x%08x)\n", (UINTN)Address, (UINTN)*In.Uint32));
         IoWrite32 ((UINTN) Address, *In.Uint32);
         break;
       case S3BootScriptWidthFifoUint32:
-        DEBUG ((EFI_D_INFO, "S3BootScriptWidthFifoUint32 - 0x%08x (0x%08x)\n", (UINTN)OriginalAddress, (UINTN)*In.Uint32));
+        DEBUG ((DEBUG_INFO, "S3BootScriptWidthFifoUint32 - 0x%08x (0x%08x)\n", (UINTN)OriginalAddress, (UINTN)*In.Uint32));
         IoWrite32 ((UINTN) OriginalAddress, *In.Uint32);
         break;
       case S3BootScriptWidthFillUint32:
-        DEBUG ((EFI_D_INFO, "S3BootScriptWidthFillUint32 - 0x%08x (0x%08x)\n", (UINTN)Address, (UINTN)*OriginalIn.Uint32));
+        DEBUG ((DEBUG_INFO, "S3BootScriptWidthFillUint32 - 0x%08x (0x%08x)\n", (UINTN)Address, (UINTN)*OriginalIn.Uint32));
         IoWrite32 ((UINTN) Address, *OriginalIn.Uint32);
         break;
       case S3BootScriptWidthUint64:
-        DEBUG ((EFI_D_INFO, "S3BootScriptWidthUint64 - 0x%08x (0x%016lx)\n", (UINTN)Address, *In.Uint64));
+        DEBUG ((DEBUG_INFO, "S3BootScriptWidthUint64 - 0x%08x (0x%016lx)\n", (UINTN)Address, *In.Uint64));
         IoWrite64 ((UINTN) Address, *In.Uint64);
         break;
       case S3BootScriptWidthFifoUint64:
-        DEBUG ((EFI_D_INFO, "S3BootScriptWidthFifoUint64 - 0x%08x (0x%016lx)\n", (UINTN)OriginalAddress, *In.Uint64));
+        DEBUG ((DEBUG_INFO, "S3BootScriptWidthFifoUint64 - 0x%08x (0x%016lx)\n", (UINTN)OriginalAddress, *In.Uint64));
         IoWrite64 ((UINTN) OriginalAddress, *In.Uint64);
         break;
       case S3BootScriptWidthFillUint64:
-        DEBUG ((EFI_D_INFO, "S3BootScriptWidthFillUint64 - 0x%08x (0x%016lx)\n", (UINTN)Address, *OriginalIn.Uint64));
+        DEBUG ((DEBUG_INFO, "S3BootScriptWidthFillUint64 - 0x%08x (0x%016lx)\n", (UINTN)Address, *OriginalIn.Uint64));
         IoWrite64 ((UINTN) Address, *OriginalIn.Uint64);
         break;
       default:
@@ -397,7 +397,7 @@ BootScriptExecuteIoWrite (
   Count = IoWrite.Count;
   Buffer = Script + sizeof (EFI_BOOT_SCRIPT_IO_WRITE);
 
-  DEBUG ((EFI_D_INFO, "BootScriptExecuteIoWrite - 0x%08x, 0x%08x, 0x%08x\n", (UINTN)Address, Count, (UINTN)Width));
+  DEBUG ((DEBUG_INFO, "BootScriptExecuteIoWrite - 0x%08x, 0x%08x, 0x%08x\n", (UINTN)Address, Count, (UINTN)Width));
   return ScriptIoWrite(Width, Address, Count, Buffer);
 }
 /**
@@ -441,54 +441,54 @@ ScriptMemoryRead (
   for (; Count > 0; Count--, Address += AddressStride, Out.Buf += BufferStride) {
     switch (Width) {
     case S3BootScriptWidthUint8:
-      DEBUG ((EFI_D_INFO, "S3BootScriptWidthUint8 - 0x%08x\n", (UINTN)Address));
+      DEBUG ((DEBUG_INFO, "S3BootScriptWidthUint8 - 0x%08x\n", (UINTN)Address));
       *Out.Uint8 = MmioRead8 ((UINTN) Address);
       break;
     case S3BootScriptWidthFifoUint8:
-      DEBUG ((EFI_D_INFO, "S3BootScriptWidthFifoUint8 - 0x%08x\n", (UINTN)Address));
+      DEBUG ((DEBUG_INFO, "S3BootScriptWidthFifoUint8 - 0x%08x\n", (UINTN)Address));
       *Out.Uint8 = MmioRead8 ((UINTN) Address);
       break;
     case S3BootScriptWidthFillUint8:
-      DEBUG ((EFI_D_INFO, "S3BootScriptWidthFillUint8 - 0x%08x\n", (UINTN)Address));
+      DEBUG ((DEBUG_INFO, "S3BootScriptWidthFillUint8 - 0x%08x\n", (UINTN)Address));
       *Out.Uint8 = MmioRead8 ((UINTN) Address);
       break;
 
     case S3BootScriptWidthUint16:
-      DEBUG ((EFI_D_INFO, "S3BootScriptWidthUint16 - 0x%08x\n", (UINTN)Address));
+      DEBUG ((DEBUG_INFO, "S3BootScriptWidthUint16 - 0x%08x\n", (UINTN)Address));
       *Out.Uint16 = MmioRead16 ((UINTN) Address);
       break;
     case S3BootScriptWidthFifoUint16:
-      DEBUG ((EFI_D_INFO, "S3BootScriptWidthFifoUint16 - 0x%08x\n", (UINTN)Address));
+      DEBUG ((DEBUG_INFO, "S3BootScriptWidthFifoUint16 - 0x%08x\n", (UINTN)Address));
       *Out.Uint16 = MmioRead16 ((UINTN) Address);
       break;
     case S3BootScriptWidthFillUint16:
-      DEBUG ((EFI_D_INFO, "S3BootScriptWidthFillUint16 - 0x%08x\n", (UINTN)Address));
+      DEBUG ((DEBUG_INFO, "S3BootScriptWidthFillUint16 - 0x%08x\n", (UINTN)Address));
       *Out.Uint16 = MmioRead16 ((UINTN) Address);
       break;
 
     case S3BootScriptWidthUint32:
-      DEBUG ((EFI_D_INFO, "S3BootScriptWidthUint32 - 0x%08x\n", (UINTN)Address));
+      DEBUG ((DEBUG_INFO, "S3BootScriptWidthUint32 - 0x%08x\n", (UINTN)Address));
       *Out.Uint32 = MmioRead32 ((UINTN) Address);
       break;
     case S3BootScriptWidthFifoUint32:
-      DEBUG ((EFI_D_INFO, "S3BootScriptWidthFifoUint32 - 0x%08x\n", (UINTN)Address));
+      DEBUG ((DEBUG_INFO, "S3BootScriptWidthFifoUint32 - 0x%08x\n", (UINTN)Address));
       *Out.Uint32 = MmioRead32 ((UINTN) Address);
       break;
     case S3BootScriptWidthFillUint32:
-      DEBUG ((EFI_D_INFO, "S3BootScriptWidthFillUint32 - 0x%08x\n", (UINTN)Address));
+      DEBUG ((DEBUG_INFO, "S3BootScriptWidthFillUint32 - 0x%08x\n", (UINTN)Address));
       *Out.Uint32 = MmioRead32 ((UINTN) Address);
       break;
 
     case S3BootScriptWidthUint64:
-      DEBUG ((EFI_D_INFO, "S3BootScriptWidthUint64 - 0x%08x\n", (UINTN)Address));
+      DEBUG ((DEBUG_INFO, "S3BootScriptWidthUint64 - 0x%08x\n", (UINTN)Address));
       *Out.Uint64 = MmioRead64 ((UINTN) Address);
       break;
     case S3BootScriptWidthFifoUint64:
-      DEBUG ((EFI_D_INFO, "S3BootScriptWidthFifoUint64 - 0x%08x\n", (UINTN)Address));
+      DEBUG ((DEBUG_INFO, "S3BootScriptWidthFifoUint64 - 0x%08x\n", (UINTN)Address));
       *Out.Uint64 = MmioRead64 ((UINTN) Address);
       break;
     case S3BootScriptWidthFillUint64:
-      DEBUG ((EFI_D_INFO, "S3BootScriptWidthFillUint64 - 0x%08x\n", (UINTN)Address));
+      DEBUG ((DEBUG_INFO, "S3BootScriptWidthFillUint64 - 0x%08x\n", (UINTN)Address));
       *Out.Uint64 = MmioRead64 ((UINTN) Address);
       break;
 
@@ -544,51 +544,51 @@ ScriptMemoryWrite (
   for (; Count > 0; Count--, Address += AddressStride, In.Buf += BufferStride) {
     switch (Width) {
       case S3BootScriptWidthUint8:
-        DEBUG ((EFI_D_INFO, "S3BootScriptWidthUint8 - 0x%08x (0x%02x)\n", (UINTN)Address, (UINTN)*In.Uint8));
+        DEBUG ((DEBUG_INFO, "S3BootScriptWidthUint8 - 0x%08x (0x%02x)\n", (UINTN)Address, (UINTN)*In.Uint8));
         MmioWrite8 ((UINTN) Address, *In.Uint8);
         break;
       case S3BootScriptWidthFifoUint8:
-        DEBUG ((EFI_D_INFO, "S3BootScriptWidthFifoUint8 - 0x%08x (0x%02x)\n", (UINTN)OriginalAddress, (UINTN)*In.Uint8));
+        DEBUG ((DEBUG_INFO, "S3BootScriptWidthFifoUint8 - 0x%08x (0x%02x)\n", (UINTN)OriginalAddress, (UINTN)*In.Uint8));
         MmioWrite8 ((UINTN) OriginalAddress, *In.Uint8);
         break;
       case S3BootScriptWidthFillUint8:
-        DEBUG ((EFI_D_INFO, "S3BootScriptWidthFillUint8 - 0x%08x (0x%02x)\n", (UINTN)Address, (UINTN)*OriginalIn.Uint8));
+        DEBUG ((DEBUG_INFO, "S3BootScriptWidthFillUint8 - 0x%08x (0x%02x)\n", (UINTN)Address, (UINTN)*OriginalIn.Uint8));
         MmioWrite8 ((UINTN) Address, *OriginalIn.Uint8);
         break;
       case S3BootScriptWidthUint16:
-        DEBUG ((EFI_D_INFO, "S3BootScriptWidthUint16 - 0x%08x (0x%04x)\n", (UINTN)Address, (UINTN)*In.Uint16));
+        DEBUG ((DEBUG_INFO, "S3BootScriptWidthUint16 - 0x%08x (0x%04x)\n", (UINTN)Address, (UINTN)*In.Uint16));
         MmioWrite16 ((UINTN) Address, *In.Uint16);
         break;
       case S3BootScriptWidthFifoUint16:
-        DEBUG ((EFI_D_INFO, "S3BootScriptWidthFifoUint16 - 0x%08x (0x%04x)\n", (UINTN)OriginalAddress, (UINTN)*In.Uint16));
+        DEBUG ((DEBUG_INFO, "S3BootScriptWidthFifoUint16 - 0x%08x (0x%04x)\n", (UINTN)OriginalAddress, (UINTN)*In.Uint16));
         MmioWrite16 ((UINTN) OriginalAddress, *In.Uint16);
         break;
       case S3BootScriptWidthFillUint16:
-        DEBUG ((EFI_D_INFO, "S3BootScriptWidthFillUint16 - 0x%08x (0x%04x)\n", (UINTN)Address, (UINTN)*OriginalIn.Uint16));
+        DEBUG ((DEBUG_INFO, "S3BootScriptWidthFillUint16 - 0x%08x (0x%04x)\n", (UINTN)Address, (UINTN)*OriginalIn.Uint16));
         MmioWrite16 ((UINTN) Address, *OriginalIn.Uint16);
         break;
       case S3BootScriptWidthUint32:
-        DEBUG ((EFI_D_INFO, "S3BootScriptWidthUint32 - 0x%08x (0x%08x)\n", (UINTN)Address, (UINTN)*In.Uint32));
+        DEBUG ((DEBUG_INFO, "S3BootScriptWidthUint32 - 0x%08x (0x%08x)\n", (UINTN)Address, (UINTN)*In.Uint32));
         MmioWrite32 ((UINTN) Address, *In.Uint32);
         break;
       case S3BootScriptWidthFifoUint32:
-        DEBUG ((EFI_D_INFO, "S3BootScriptWidthFifoUint32 - 0x%08x (0x%08x)\n", (UINTN)OriginalAddress, (UINTN)*In.Uint32));
+        DEBUG ((DEBUG_INFO, "S3BootScriptWidthFifoUint32 - 0x%08x (0x%08x)\n", (UINTN)OriginalAddress, (UINTN)*In.Uint32));
         MmioWrite32 ((UINTN) OriginalAddress, *In.Uint32);
         break;
       case S3BootScriptWidthFillUint32:
-        DEBUG ((EFI_D_INFO, "S3BootScriptWidthFillUint32 - 0x%08x (0x%08x)\n", (UINTN)Address, (UINTN)*OriginalIn.Uint32));
+        DEBUG ((DEBUG_INFO, "S3BootScriptWidthFillUint32 - 0x%08x (0x%08x)\n", (UINTN)Address, (UINTN)*OriginalIn.Uint32));
         MmioWrite32 ((UINTN) Address, *OriginalIn.Uint32);
         break;
       case S3BootScriptWidthUint64:
-        DEBUG ((EFI_D_INFO, "S3BootScriptWidthUint64 - 0x%08x (0x%016lx)\n", (UINTN)Address, *In.Uint64));
+        DEBUG ((DEBUG_INFO, "S3BootScriptWidthUint64 - 0x%08x (0x%016lx)\n", (UINTN)Address, *In.Uint64));
         MmioWrite64 ((UINTN) Address, *In.Uint64);
         break;
       case S3BootScriptWidthFifoUint64:
-        DEBUG ((EFI_D_INFO, "S3BootScriptWidthFifoUint64 - 0x%08x (0x%016lx)\n", (UINTN)OriginalAddress, *In.Uint64));
+        DEBUG ((DEBUG_INFO, "S3BootScriptWidthFifoUint64 - 0x%08x (0x%016lx)\n", (UINTN)OriginalAddress, *In.Uint64));
         MmioWrite64 ((UINTN) OriginalAddress, *In.Uint64);
         break;
       case S3BootScriptWidthFillUint64:
-        DEBUG ((EFI_D_INFO, "S3BootScriptWidthFillUint64 - 0x%08x (0x%016lx)\n", (UINTN)Address, *OriginalIn.Uint64));
+        DEBUG ((DEBUG_INFO, "S3BootScriptWidthFillUint64 - 0x%08x (0x%016lx)\n", (UINTN)Address, *OriginalIn.Uint64));
         MmioWrite64 ((UINTN) Address, *OriginalIn.Uint64);
         break;
       default:
@@ -627,7 +627,7 @@ BootScriptExecuteMemoryWrite (
   Count   = MemWrite.Count;
   Buffer  = Script + sizeof(EFI_BOOT_SCRIPT_MEM_WRITE);
 
-  DEBUG ((EFI_D_INFO, "BootScriptExecuteMemoryWrite - 0x%08x, 0x%08x, 0x%08x\n", (UINTN)Address, Count, (UINTN)Width));
+  DEBUG ((DEBUG_INFO, "BootScriptExecuteMemoryWrite - 0x%08x, 0x%08x, 0x%08x\n", (UINTN)Address, Count, (UINTN)Width));
   return ScriptMemoryWrite (Width,Address, Count,  Buffer);
 
 }
@@ -674,41 +674,41 @@ ScriptPciCfg2Read (
   for (; Count > 0; Count--, PciAddress += AddressStride, Out.Buf += BufferStride) {
     switch (Width) {
     case S3BootScriptWidthUint8:
-      DEBUG ((EFI_D_INFO, "S3BootScriptWidthUint8 - 0x%016lx\n", PciAddress));
+      DEBUG ((DEBUG_INFO, "S3BootScriptWidthUint8 - 0x%016lx\n", PciAddress));
       *Out.Uint8 = PciSegmentRead8 (PciAddress);
       break;
     case S3BootScriptWidthFifoUint8:
-      DEBUG ((EFI_D_INFO, "S3BootScriptWidthFifoUint8 - 0x%016lx\n", PciAddress));
+      DEBUG ((DEBUG_INFO, "S3BootScriptWidthFifoUint8 - 0x%016lx\n", PciAddress));
       *Out.Uint8 = PciSegmentRead8 (PciAddress);
       break;
     case S3BootScriptWidthFillUint8:
-      DEBUG ((EFI_D_INFO, "S3BootScriptWidthFillUint8 - 0x%016lx\n", PciAddress));
+      DEBUG ((DEBUG_INFO, "S3BootScriptWidthFillUint8 - 0x%016lx\n", PciAddress));
       *Out.Uint8 = PciSegmentRead8 (PciAddress);
       break;
 
     case S3BootScriptWidthUint16:
-      DEBUG ((EFI_D_INFO, "S3BootScriptWidthUint16 - 0x%016lx\n", PciAddress));
+      DEBUG ((DEBUG_INFO, "S3BootScriptWidthUint16 - 0x%016lx\n", PciAddress));
       *Out.Uint16 = PciSegmentRead16 (PciAddress);
       break;
     case S3BootScriptWidthFifoUint16:
-      DEBUG ((EFI_D_INFO, "S3BootScriptWidthFifoUint16 - 0x%016lx\n", PciAddress));
+      DEBUG ((DEBUG_INFO, "S3BootScriptWidthFifoUint16 - 0x%016lx\n", PciAddress));
       *Out.Uint16 = PciSegmentRead16 (PciAddress);
       break;
     case S3BootScriptWidthFillUint16:
-      DEBUG ((EFI_D_INFO, "S3BootScriptWidthFillUint16 - 0x%016lx\n", PciAddress));
+      DEBUG ((DEBUG_INFO, "S3BootScriptWidthFillUint16 - 0x%016lx\n", PciAddress));
       *Out.Uint16 = PciSegmentRead16 (PciAddress);
       break;
 
     case S3BootScriptWidthUint32:
-      DEBUG ((EFI_D_INFO, "S3BootScriptWidthUint32 - 0x%016lx\n", PciAddress));
+      DEBUG ((DEBUG_INFO, "S3BootScriptWidthUint32 - 0x%016lx\n", PciAddress));
       *Out.Uint32 = PciSegmentRead32 (PciAddress);
       break;
     case S3BootScriptWidthFifoUint32:
-      DEBUG ((EFI_D_INFO, "S3BootScriptWidthFifoUint32 - 0x%016lx\n", PciAddress));
+      DEBUG ((DEBUG_INFO, "S3BootScriptWidthFifoUint32 - 0x%016lx\n", PciAddress));
       *Out.Uint32 = PciSegmentRead32 (PciAddress);
       break;
     case S3BootScriptWidthFillUint32:
-      DEBUG ((EFI_D_INFO, "S3BootScriptWidthFillUint32 - 0x%016lx\n", PciAddress));
+      DEBUG ((DEBUG_INFO, "S3BootScriptWidthFillUint32 - 0x%016lx\n", PciAddress));
       *Out.Uint32 = PciSegmentRead32 (PciAddress);
       break;
 
@@ -766,39 +766,39 @@ ScriptPciCfg2Write (
   for (; Count > 0; Count--, PciAddress += AddressStride, In.Buf += BufferStride) {
     switch (Width) {
       case S3BootScriptWidthUint8:
-        DEBUG ((EFI_D_INFO, "S3BootScriptWidthUint8 - 0x%016lx (0x%02x)\n", PciAddress, (UINTN)*In.Uint8));
+        DEBUG ((DEBUG_INFO, "S3BootScriptWidthUint8 - 0x%016lx (0x%02x)\n", PciAddress, (UINTN)*In.Uint8));
         PciSegmentWrite8 (PciAddress, *In.Uint8);
         break;
       case S3BootScriptWidthFifoUint8:
-        DEBUG ((EFI_D_INFO, "S3BootScriptWidthFifoUint8 - 0x%016lx (0x%02x)\n", OriginalPciAddress, (UINTN)*In.Uint8));
+        DEBUG ((DEBUG_INFO, "S3BootScriptWidthFifoUint8 - 0x%016lx (0x%02x)\n", OriginalPciAddress, (UINTN)*In.Uint8));
         PciSegmentWrite8 (OriginalPciAddress, *In.Uint8);
         break;
       case S3BootScriptWidthFillUint8:
-        DEBUG ((EFI_D_INFO, "S3BootScriptWidthFillUint8 - 0x%016lx (0x%02x)\n", PciAddress, (UINTN)*OriginalIn.Uint8));
+        DEBUG ((DEBUG_INFO, "S3BootScriptWidthFillUint8 - 0x%016lx (0x%02x)\n", PciAddress, (UINTN)*OriginalIn.Uint8));
         PciSegmentWrite8 (PciAddress, *OriginalIn.Uint8);
         break;
       case S3BootScriptWidthUint16:
-        DEBUG ((EFI_D_INFO, "S3BootScriptWidthUint16 - 0x%016lx (0x%04x)\n", PciAddress, (UINTN)*In.Uint16));
+        DEBUG ((DEBUG_INFO, "S3BootScriptWidthUint16 - 0x%016lx (0x%04x)\n", PciAddress, (UINTN)*In.Uint16));
         PciSegmentWrite16 (PciAddress, *In.Uint16);
         break;
       case S3BootScriptWidthFifoUint16:
-        DEBUG ((EFI_D_INFO, "S3BootScriptWidthFifoUint16 - 0x%016lx (0x%04x)\n", OriginalPciAddress, (UINTN)*In.Uint16));
+        DEBUG ((DEBUG_INFO, "S3BootScriptWidthFifoUint16 - 0x%016lx (0x%04x)\n", OriginalPciAddress, (UINTN)*In.Uint16));
         PciSegmentWrite16 (OriginalPciAddress, *In.Uint16);
         break;
       case S3BootScriptWidthFillUint16:
-        DEBUG ((EFI_D_INFO, "S3BootScriptWidthFillUint16 - 0x%016lx (0x%04x)\n", PciAddress, (UINTN)*OriginalIn.Uint16));
+        DEBUG ((DEBUG_INFO, "S3BootScriptWidthFillUint16 - 0x%016lx (0x%04x)\n", PciAddress, (UINTN)*OriginalIn.Uint16));
         PciSegmentWrite16 (PciAddress, *OriginalIn.Uint16);
         break;
       case S3BootScriptWidthUint32:
-        DEBUG ((EFI_D_INFO, "S3BootScriptWidthUint32 - 0x%016lx (0x%08x)\n", PciAddress, (UINTN)*In.Uint32));
+        DEBUG ((DEBUG_INFO, "S3BootScriptWidthUint32 - 0x%016lx (0x%08x)\n", PciAddress, (UINTN)*In.Uint32));
         PciSegmentWrite32 (PciAddress, *In.Uint32);
         break;
       case S3BootScriptWidthFifoUint32:
-        DEBUG ((EFI_D_INFO, "S3BootScriptWidthFifoUint32 - 0x%016lx (0x%08x)\n", OriginalPciAddress, (UINTN)*In.Uint32));
+        DEBUG ((DEBUG_INFO, "S3BootScriptWidthFifoUint32 - 0x%016lx (0x%08x)\n", OriginalPciAddress, (UINTN)*In.Uint32));
         PciSegmentWrite32 (OriginalPciAddress, *In.Uint32);
         break;
       case S3BootScriptWidthFillUint32:
-        DEBUG ((EFI_D_INFO, "S3BootScriptWidthFillUint32 - 0x%016lx (0x%08x)\n", (UINTN)PciAddress, (UINTN)*OriginalIn.Uint32));
+        DEBUG ((DEBUG_INFO, "S3BootScriptWidthFillUint32 - 0x%016lx (0x%08x)\n", (UINTN)PciAddress, (UINTN)*OriginalIn.Uint32));
         PciSegmentWrite32 (PciAddress, *OriginalIn.Uint32);
         break;
       default:
@@ -883,7 +883,7 @@ BootScriptExecutePciCfgWrite (
   Count   = PciCfgWrite.Count;
   Buffer  = Script + sizeof(EFI_BOOT_SCRIPT_PCI_CONFIG_WRITE);
 
-  DEBUG ((EFI_D_INFO, "BootScriptExecutePciCfgWrite - 0x%016lx, 0x%08x, 0x%08x\n", PCI_ADDRESS_ENCODE (0, Address), Count, (UINTN)Width));
+  DEBUG ((DEBUG_INFO, "BootScriptExecutePciCfgWrite - 0x%016lx, 0x%08x, 0x%08x\n", PCI_ADDRESS_ENCODE (0, Address), Count, (UINTN)Width));
   return ScriptPciCfgWrite (Width, Address, Count, Buffer);
 }
 /**
@@ -911,7 +911,7 @@ BootScriptExecuteIoReadWrite (
 
   CopyMem((VOID*)&IoReadWrite, (VOID*)Script, sizeof(EFI_BOOT_SCRIPT_IO_READ_WRITE));
 
-  DEBUG ((EFI_D_INFO, "BootScriptExecuteIoReadWrite - 0x%08x, 0x%016lx, 0x%016lx\n", (UINTN)IoReadWrite.Address, AndMask, OrMask));
+  DEBUG ((DEBUG_INFO, "BootScriptExecuteIoReadWrite - 0x%08x, 0x%016lx, 0x%016lx\n", (UINTN)IoReadWrite.Address, AndMask, OrMask));
 
   Status = ScriptIoRead (
              (S3_BOOT_SCRIPT_LIB_WIDTH) IoReadWrite.Width,
@@ -955,7 +955,7 @@ BootScriptExecuteMemoryReadWrite (
 
   CopyMem((VOID*)&MemReadWrite, (VOID*)Script, sizeof(EFI_BOOT_SCRIPT_MEM_READ_WRITE));
 
-  DEBUG ((EFI_D_INFO, "BootScriptExecuteMemoryReadWrite - 0x%08x, 0x%016lx, 0x%016lx\n", (UINTN)MemReadWrite.Address, AndMask, OrMask));
+  DEBUG ((DEBUG_INFO, "BootScriptExecuteMemoryReadWrite - 0x%08x, 0x%016lx, 0x%016lx\n", (UINTN)MemReadWrite.Address, AndMask, OrMask));
 
   Status = ScriptMemoryRead (
              (S3_BOOT_SCRIPT_LIB_WIDTH) MemReadWrite.Width,
@@ -999,7 +999,7 @@ BootScriptExecutePciCfgReadWrite (
 
   CopyMem((VOID*)&PciCfgReadWrite, (VOID*)Script, sizeof(EFI_BOOT_SCRIPT_PCI_CONFIG_READ_WRITE));
 
-  DEBUG ((EFI_D_INFO, "BootScriptExecutePciCfgReadWrite - 0x%016lx, 0x%016lx, 0x%016lx\n", PCI_ADDRESS_ENCODE (0, PciCfgReadWrite.Address), AndMask, OrMask));
+  DEBUG ((DEBUG_INFO, "BootScriptExecutePciCfgReadWrite - 0x%016lx, 0x%016lx, 0x%016lx\n", PCI_ADDRESS_ENCODE (0, PciCfgReadWrite.Address), AndMask, OrMask));
 
   Status = ScriptPciCfgRead (
              (S3_BOOT_SCRIPT_LIB_WIDTH) PciCfgReadWrite.Width,
@@ -1042,7 +1042,7 @@ BootScriptExecuteSmbusExecute (
 
   CopyMem ((VOID*)&SmbusExecuteEntry, (VOID*)Script, sizeof(EFI_BOOT_SCRIPT_SMBUS_EXECUTE ));
 
-  DEBUG ((EFI_D_INFO, "BootScriptExecuteSmbusExecute - 0x%08x, 0x%08x\n", (UINTN)SmbusExecuteEntry.SmBusAddress, (UINTN)SmbusExecuteEntry.Operation));
+  DEBUG ((DEBUG_INFO, "BootScriptExecuteSmbusExecute - 0x%08x, 0x%08x\n", (UINTN)SmbusExecuteEntry.SmBusAddress, (UINTN)SmbusExecuteEntry.Operation));
 
   SmBusAddress = (UINTN)SmbusExecuteEntry.SmBusAddress;
   DataSize = (UINTN) SmbusExecuteEntry.DataSize;
@@ -1069,7 +1069,7 @@ BootScriptExecuteStall (
 
   CopyMem ((VOID*)&Stall, (VOID*)Script, sizeof(EFI_BOOT_SCRIPT_STALL));
 
-  DEBUG ((EFI_D_INFO, "BootScriptExecuteStall - 0x%08x\n", (UINTN)Stall.Duration));
+  DEBUG ((DEBUG_INFO, "BootScriptExecuteStall - 0x%08x\n", (UINTN)Stall.Duration));
 
   MicroSecondDelay ((UINTN) Stall.Duration);
   return EFI_SUCCESS;
@@ -1092,7 +1092,7 @@ BootScriptExecuteDispatch (
   CopyMem ((VOID*)&ScriptDispatch, (VOID*)Script, sizeof(EFI_BOOT_SCRIPT_DISPATCH));
   EntryFunc = (DISPATCH_ENTRYPOINT_FUNC) (UINTN) (ScriptDispatch.EntryPoint);
 
-  DEBUG ((EFI_D_INFO, "BootScriptExecuteDispatch - 0x%08x\n", (UINTN)ScriptDispatch.EntryPoint));
+  DEBUG ((DEBUG_INFO, "BootScriptExecuteDispatch - 0x%08x\n", (UINTN)ScriptDispatch.EntryPoint));
 
   Status    = EntryFunc (NULL, NULL);
 
@@ -1115,7 +1115,7 @@ BootScriptExecuteDispatch2 (
 
   CopyMem ((VOID*)&ScriptDispatch2, (VOID*)Script, sizeof(EFI_BOOT_SCRIPT_DISPATCH_2));
 
-  DEBUG ((EFI_D_INFO, "BootScriptExecuteDispatch2 - 0x%08x(0x%08x)\n", (UINTN)ScriptDispatch2.EntryPoint, (UINTN)ScriptDispatch2.Context));
+  DEBUG ((DEBUG_INFO, "BootScriptExecuteDispatch2 - 0x%08x(0x%08x)\n", (UINTN)ScriptDispatch2.EntryPoint, (UINTN)ScriptDispatch2.Context));
 
   EntryFunc = (DISPATCH_ENTRYPOINT_FUNC) (UINTN) (ScriptDispatch2.EntryPoint);
 
@@ -1149,7 +1149,7 @@ BootScriptExecuteMemPoll (
 
   CopyMem ((VOID*)&MemPoll, (VOID*)Script, sizeof(EFI_BOOT_SCRIPT_MEM_POLL));
 
-  DEBUG ((EFI_D_INFO, "BootScriptExecuteMemPoll - 0x%08x, 0x%016lx, 0x%016lx\n", (UINTN)MemPoll.Address, AndMask, OrMask));
+  DEBUG ((DEBUG_INFO, "BootScriptExecuteMemPoll - 0x%08x, 0x%016lx, 0x%016lx\n", (UINTN)MemPoll.Address, AndMask, OrMask));
 
   Data = 0;
   Status = ScriptMemoryRead (
@@ -1203,13 +1203,13 @@ BootScriptExecuteInformation (
   CopyMem ((VOID*)&Information, (VOID*)Script, sizeof(EFI_BOOT_SCRIPT_INFORMATION));
 
   InformationData = Script + sizeof (EFI_BOOT_SCRIPT_INFORMATION);
-  DEBUG ((EFI_D_INFO, "BootScriptExecuteInformation - 0x%08x\n", (UINTN) InformationData));
+  DEBUG ((DEBUG_INFO, "BootScriptExecuteInformation - 0x%08x\n", (UINTN) InformationData));
 
-  DEBUG ((EFI_D_INFO, "BootScriptInformation: "));
+  DEBUG ((DEBUG_INFO, "BootScriptInformation: "));
   for (Index = 0; Index < Information.InformationLength; Index++) {
-    DEBUG ((EFI_D_INFO, "%02x ", InformationData[Index]));
+    DEBUG ((DEBUG_INFO, "%02x ", InformationData[Index]));
   }
-  DEBUG ((EFI_D_INFO, "\n"));
+  DEBUG ((DEBUG_INFO, "\n"));
 }
 
 /**
@@ -1231,13 +1231,13 @@ BootScriptExecuteLabel (
   CopyMem ((VOID*)&Information, (VOID*)Script, sizeof(EFI_BOOT_SCRIPT_INFORMATION));
 
   InformationData = Script + sizeof (EFI_BOOT_SCRIPT_INFORMATION);
-  DEBUG ((EFI_D_INFO, "BootScriptExecuteLabel - 0x%08x\n", (UINTN) InformationData));
+  DEBUG ((DEBUG_INFO, "BootScriptExecuteLabel - 0x%08x\n", (UINTN) InformationData));
 
-  DEBUG ((EFI_D_INFO, "BootScriptLabel: "));
+  DEBUG ((DEBUG_INFO, "BootScriptLabel: "));
   for (Index = 0; Index < Information.InformationLength; Index++) {
-    DEBUG ((EFI_D_INFO, "%02x ", InformationData[Index]));
+    DEBUG ((DEBUG_INFO, "%02x ", InformationData[Index]));
   }
-  DEBUG ((EFI_D_INFO, "\n"));
+  DEBUG ((DEBUG_INFO, "\n"));
 }
 
 /**
@@ -1349,7 +1349,7 @@ BootScriptExecuteIoPoll (
 
   CopyMem ((VOID*)&IoPoll, (VOID*)Script, sizeof(EFI_BOOT_SCRIPT_IO_POLL));
 
-  DEBUG ((EFI_D_INFO, "BootScriptExecuteIoPoll - 0x%08x, 0x%016lx, 0x%016lx\n", (UINTN)IoPoll.Address, AndMask, OrMask));
+  DEBUG ((DEBUG_INFO, "BootScriptExecuteIoPoll - 0x%08x, 0x%016lx, 0x%016lx\n", (UINTN)IoPoll.Address, AndMask, OrMask));
 
   Data = 0;
   Status = ScriptIoRead (
@@ -1409,7 +1409,7 @@ BootScriptExecutePciCfg2Write (
   Count   = PciCfg2Write.Count;
   Buffer  = Script + sizeof(EFI_BOOT_SCRIPT_PCI_CONFIG2_WRITE);
 
-  DEBUG ((EFI_D_INFO, "BootScriptExecutePciCfg2Write - 0x%016lx, 0x%08x, 0x%08x\n", PCI_ADDRESS_ENCODE (Segment, Address), Count, (UINTN)Width));
+  DEBUG ((DEBUG_INFO, "BootScriptExecutePciCfg2Write - 0x%016lx, 0x%08x, 0x%08x\n", PCI_ADDRESS_ENCODE (Segment, Address), Count, (UINTN)Width));
   return ScriptPciCfg2Write (Width, Segment, Address, Count, Buffer);
 }
 
@@ -1439,7 +1439,7 @@ BootScriptExecutePciCfg2ReadWrite (
 
   CopyMem ((VOID*)&PciCfg2ReadWrite, (VOID*)Script, sizeof(EFI_BOOT_SCRIPT_PCI_CONFIG2_READ_WRITE));
 
-  DEBUG ((EFI_D_INFO, "BootScriptExecutePciCfg2ReadWrite - 0x%016lx, 0x%016lx, 0x%016lx\n", PCI_ADDRESS_ENCODE (PciCfg2ReadWrite.Segment, PciCfg2ReadWrite.Address), AndMask, OrMask));
+  DEBUG ((DEBUG_INFO, "BootScriptExecutePciCfg2ReadWrite - 0x%016lx, 0x%016lx, 0x%016lx\n", PCI_ADDRESS_ENCODE (PciCfg2ReadWrite.Segment, PciCfg2ReadWrite.Address), AndMask, OrMask));
 
   Status = ScriptPciCfg2Read (
              (S3_BOOT_SCRIPT_LIB_WIDTH) PciCfg2ReadWrite.Width,
@@ -1486,7 +1486,7 @@ BootScriptPciCfgPoll (
   EFI_BOOT_SCRIPT_PCI_CONFIG_POLL PciCfgPoll;
   CopyMem ((VOID*)&PciCfgPoll, (VOID*)Script, sizeof(EFI_BOOT_SCRIPT_PCI_CONFIG_POLL));
 
-  DEBUG ((EFI_D_INFO, "BootScriptPciCfgPoll - 0x%016lx, 0x%016lx, 0x%016lx\n", PCI_ADDRESS_ENCODE (0, PciCfgPoll.Address), AndMask, OrMask));
+  DEBUG ((DEBUG_INFO, "BootScriptPciCfgPoll - 0x%016lx, 0x%016lx, 0x%016lx\n", PCI_ADDRESS_ENCODE (0, PciCfgPoll.Address), AndMask, OrMask));
 
   Data = 0;
   Status = ScriptPciCfgRead (
@@ -1548,7 +1548,7 @@ BootScriptPciCfg2Poll (
   Data = 0;
   CopyMem ((VOID*)&PciCfg2Poll, (VOID*)Script, sizeof(EFI_BOOT_SCRIPT_PCI_CONFIG2_POLL));
 
-  DEBUG ((EFI_D_INFO, "BootScriptPciCfg2Poll - 0x%016lx, 0x%016lx, 0x%016lx\n", PCI_ADDRESS_ENCODE (PciCfg2Poll.Segment, PciCfg2Poll.Address), AndMask, OrMask));
+  DEBUG ((DEBUG_INFO, "BootScriptPciCfg2Poll - 0x%016lx, 0x%016lx, 0x%016lx\n", PCI_ADDRESS_ENCODE (PciCfg2Poll.Segment, PciCfg2Poll.Address), AndMask, OrMask));
 
   Status = ScriptPciCfg2Read (
              (S3_BOOT_SCRIPT_LIB_WIDTH) PciCfg2Poll.Width,
@@ -1613,12 +1613,12 @@ S3BootScriptExecute (
     return EFI_INVALID_PARAMETER;
   }
 
-  DEBUG ((EFI_D_INFO, "S3BootScriptExecute:\n"));
+  DEBUG ((DEBUG_INFO, "S3BootScriptExecute:\n"));
   if (TableHeader.OpCode != S3_BOOT_SCRIPT_LIB_TABLE_OPCODE) {
     return EFI_UNSUPPORTED;
   }
 
-  DEBUG ((EFI_D_INFO, "TableHeader - 0x%08x\n", Script));
+  DEBUG ((DEBUG_INFO, "TableHeader - 0x%08x\n", Script));
 
   StartAddress  = (UINTN) Script;
   TableLength   = TableHeader.TableLength;
@@ -1627,22 +1627,22 @@ S3BootScriptExecute (
   AndMask       = 0;
   OrMask        = 0;
 
-  DEBUG ((EFI_D_INFO, "TableHeader.Version - 0x%04x\n", (UINTN)TableHeader.Version));
-  DEBUG ((EFI_D_INFO, "TableHeader.TableLength - 0x%08x\n", (UINTN)TableLength));
+  DEBUG ((DEBUG_INFO, "TableHeader.Version - 0x%04x\n", (UINTN)TableHeader.Version));
+  DEBUG ((DEBUG_INFO, "TableHeader.TableLength - 0x%08x\n", (UINTN)TableLength));
 
   while ((UINTN) Script < (UINTN) (StartAddress + TableLength)) {
-    DEBUG ((EFI_D_INFO, "ExecuteBootScript - %08x\n", (UINTN)Script));
+    DEBUG ((DEBUG_INFO, "ExecuteBootScript - %08x\n", (UINTN)Script));
 
     CopyMem ((VOID*)&ScriptHeader, Script, sizeof(EFI_BOOT_SCRIPT_COMMON_HEADER));
     switch (ScriptHeader.OpCode) {
 
     case EFI_BOOT_SCRIPT_MEM_WRITE_OPCODE:
-      DEBUG ((EFI_D_INFO, "EFI_BOOT_SCRIPT_MEM_WRITE_OPCODE\n"));
+      DEBUG ((DEBUG_INFO, "EFI_BOOT_SCRIPT_MEM_WRITE_OPCODE\n"));
       Status = BootScriptExecuteMemoryWrite (Script);
       break;
 
     case EFI_BOOT_SCRIPT_MEM_READ_WRITE_OPCODE:
-      DEBUG ((EFI_D_INFO, "EFI_BOOT_SCRIPT_MEM_READ_WRITE_OPCODE\n"));
+      DEBUG ((DEBUG_INFO, "EFI_BOOT_SCRIPT_MEM_READ_WRITE_OPCODE\n"));
       CheckAndOrMask (&ScriptHeader, &AndMask, &OrMask, Script);
       Status = BootScriptExecuteMemoryReadWrite (
                  Script,
@@ -1652,17 +1652,17 @@ S3BootScriptExecute (
       break;
 
     case EFI_BOOT_SCRIPT_IO_WRITE_OPCODE:
-      DEBUG ((EFI_D_INFO, "EFI_BOOT_SCRIPT_IO_WRITE_OPCODE\n"));
+      DEBUG ((DEBUG_INFO, "EFI_BOOT_SCRIPT_IO_WRITE_OPCODE\n"));
       Status = BootScriptExecuteIoWrite (Script);
       break;
 
     case EFI_BOOT_SCRIPT_PCI_CONFIG_WRITE_OPCODE:
-      DEBUG ((EFI_D_INFO, "EFI_BOOT_SCRIPT_PCI_CONFIG_WRITE_OPCODE\n"));
+      DEBUG ((DEBUG_INFO, "EFI_BOOT_SCRIPT_PCI_CONFIG_WRITE_OPCODE\n"));
       Status = BootScriptExecutePciCfgWrite (Script);
       break;
 
     case EFI_BOOT_SCRIPT_PCI_CONFIG_READ_WRITE_OPCODE:
-      DEBUG ((EFI_D_INFO, "EFI_BOOT_SCRIPT_PCI_CONFIG_READ_WRITE_OPCODE\n"));
+      DEBUG ((DEBUG_INFO, "EFI_BOOT_SCRIPT_PCI_CONFIG_READ_WRITE_OPCODE\n"));
       CheckAndOrMask (&ScriptHeader, &AndMask, &OrMask, Script);
       Status = BootScriptExecutePciCfgReadWrite (
                  Script,
@@ -1671,12 +1671,12 @@ S3BootScriptExecute (
                  );
       break;
     case EFI_BOOT_SCRIPT_PCI_CONFIG2_WRITE_OPCODE:
-      DEBUG ((EFI_D_INFO, "EFI_BOOT_SCRIPT_PCI_CONFIG2_WRITE_OPCODE\n"));
+      DEBUG ((DEBUG_INFO, "EFI_BOOT_SCRIPT_PCI_CONFIG2_WRITE_OPCODE\n"));
       Status = BootScriptExecutePciCfg2Write (Script);
       break;
 
     case EFI_BOOT_SCRIPT_PCI_CONFIG2_READ_WRITE_OPCODE:
-      DEBUG ((EFI_D_INFO, "EFI_BOOT_SCRIPT_PCI_CONFIG2_READ_WRITE_OPCODE\n"));
+      DEBUG ((DEBUG_INFO, "EFI_BOOT_SCRIPT_PCI_CONFIG2_READ_WRITE_OPCODE\n"));
       CheckAndOrMask (&ScriptHeader, &AndMask, &OrMask, Script);
       Status = BootScriptExecutePciCfg2ReadWrite (
                  Script,
@@ -1685,27 +1685,27 @@ S3BootScriptExecute (
                  );
       break;
     case EFI_BOOT_SCRIPT_DISPATCH_OPCODE:
-      DEBUG ((EFI_D_INFO, "EFI_BOOT_SCRIPT_DISPATCH_OPCODE\n"));
+      DEBUG ((DEBUG_INFO, "EFI_BOOT_SCRIPT_DISPATCH_OPCODE\n"));
       Status = BootScriptExecuteDispatch (Script);
       break;
 
     case EFI_BOOT_SCRIPT_DISPATCH_2_OPCODE:
-      DEBUG ((EFI_D_INFO, "EFI_BOOT_SCRIPT_DISPATCH_2_OPCODE\n"));
+      DEBUG ((DEBUG_INFO, "EFI_BOOT_SCRIPT_DISPATCH_2_OPCODE\n"));
       Status = BootScriptExecuteDispatch2 (Script);
       break;
 
     case EFI_BOOT_SCRIPT_INFORMATION_OPCODE:
-      DEBUG ((EFI_D_INFO, "EFI_BOOT_SCRIPT_INFORMATION_OPCODE\n"));
+      DEBUG ((DEBUG_INFO, "EFI_BOOT_SCRIPT_INFORMATION_OPCODE\n"));
       BootScriptExecuteInformation (Script);
       break;
 
     case S3_BOOT_SCRIPT_LIB_TERMINATE_OPCODE:
-      DEBUG ((EFI_D_INFO, "S3_BOOT_SCRIPT_LIB_TERMINATE_OPCODE\n"));
-      DEBUG ((EFI_D_INFO, "S3BootScriptDone - %r\n", EFI_SUCCESS));
+      DEBUG ((DEBUG_INFO, "S3_BOOT_SCRIPT_LIB_TERMINATE_OPCODE\n"));
+      DEBUG ((DEBUG_INFO, "S3BootScriptDone - %r\n", EFI_SUCCESS));
       return EFI_SUCCESS;
 
     case EFI_BOOT_SCRIPT_IO_READ_WRITE_OPCODE:
-      DEBUG ((EFI_D_INFO, "EFI_BOOT_SCRIPT_IO_READ_WRITE_OPCODE\n"));
+      DEBUG ((DEBUG_INFO, "EFI_BOOT_SCRIPT_IO_READ_WRITE_OPCODE\n"));
       CheckAndOrMask (&ScriptHeader, &AndMask, &OrMask, Script);
       Status = BootScriptExecuteIoReadWrite (
                 Script,
@@ -1715,36 +1715,36 @@ S3BootScriptExecute (
       break;
 
     case EFI_BOOT_SCRIPT_SMBUS_EXECUTE_OPCODE:
-      DEBUG ((EFI_D_INFO, "EFI_BOOT_SCRIPT_SMBUS_EXECUTE_OPCODE\n"));
+      DEBUG ((DEBUG_INFO, "EFI_BOOT_SCRIPT_SMBUS_EXECUTE_OPCODE\n"));
       Status = BootScriptExecuteSmbusExecute (Script);
       break;
 
     case EFI_BOOT_SCRIPT_STALL_OPCODE:
-      DEBUG ((EFI_D_INFO, "EFI_BOOT_SCRIPT_STALL_OPCODE\n"));
+      DEBUG ((DEBUG_INFO, "EFI_BOOT_SCRIPT_STALL_OPCODE\n"));
       Status = BootScriptExecuteStall (Script);
       break;
 
     case EFI_BOOT_SCRIPT_MEM_POLL_OPCODE:
-      DEBUG ((EFI_D_INFO, "EFI_BOOT_SCRIPT_MEM_POLL_OPCODE\n"));
+      DEBUG ((DEBUG_INFO, "EFI_BOOT_SCRIPT_MEM_POLL_OPCODE\n"));
       CheckAndOrMask (&ScriptHeader, &AndMask, &OrMask, Script);
       Status = BootScriptExecuteMemPoll (Script, AndMask, OrMask);
 
       break;
 
     case EFI_BOOT_SCRIPT_IO_POLL_OPCODE:
-      DEBUG ((EFI_D_INFO, "EFI_BOOT_SCRIPT_IO_POLL_OPCODE\n"));
+      DEBUG ((DEBUG_INFO, "EFI_BOOT_SCRIPT_IO_POLL_OPCODE\n"));
       CheckAndOrMask (&ScriptHeader, &AndMask, &OrMask, Script);
       Status = BootScriptExecuteIoPoll (Script, AndMask, OrMask);
       break;
 
     case EFI_BOOT_SCRIPT_PCI_CONFIG_POLL_OPCODE:
-      DEBUG ((EFI_D_INFO, "EFI_BOOT_SCRIPT_PCI_CONFIG_POLL_OPCODE\n"));
+      DEBUG ((DEBUG_INFO, "EFI_BOOT_SCRIPT_PCI_CONFIG_POLL_OPCODE\n"));
       CheckAndOrMask (&ScriptHeader, &AndMask, &OrMask, Script);
       Status = BootScriptPciCfgPoll (Script, AndMask, OrMask);
       break;
 
     case EFI_BOOT_SCRIPT_PCI_CONFIG2_POLL_OPCODE:
-     DEBUG ((EFI_D_INFO, "EFI_BOOT_SCRIPT_PCI_CONFIG2_POLL_OPCODE\n"));
+     DEBUG ((DEBUG_INFO, "EFI_BOOT_SCRIPT_PCI_CONFIG2_POLL_OPCODE\n"));
      CheckAndOrMask (&ScriptHeader, &AndMask, &OrMask, Script);
      Status = BootScriptPciCfg2Poll (Script, AndMask, OrMask);
      break;
@@ -1753,24 +1753,23 @@ S3BootScriptExecute (
       //
       // For label
       //
-      DEBUG ((EFI_D_INFO, "S3_BOOT_SCRIPT_LIB_LABEL_OPCODE\n"));
+      DEBUG ((DEBUG_INFO, "S3_BOOT_SCRIPT_LIB_LABEL_OPCODE\n"));
       BootScriptExecuteLabel (Script);
       break;
     default:
-      DEBUG ((EFI_D_INFO, "S3BootScriptDone - %r\n", EFI_UNSUPPORTED));
+      DEBUG ((DEBUG_INFO, "S3BootScriptDone - %r\n", EFI_UNSUPPORTED));
       return EFI_UNSUPPORTED;
     }
 
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_INFO, "S3BootScriptDone - %r\n", Status));
+      DEBUG ((DEBUG_INFO, "S3BootScriptDone - %r\n", Status));
       return Status;
     }
 
     Script  = Script + ScriptHeader.Length;
   }
 
-  DEBUG ((EFI_D_INFO, "S3BootScriptDone - %r\n", Status));
+  DEBUG ((DEBUG_INFO, "S3BootScriptDone - %r\n", Status));
 
   return Status;
 }
-

--- a/MdeModulePkg/Library/PiDxeS3BootScriptLib/BootScriptSave.c
+++ b/MdeModulePkg/Library/PiDxeS3BootScriptLib/BootScriptSave.c
@@ -573,7 +573,7 @@ S3BootScriptLibDeinitialize (
     return RETURN_SUCCESS;
   }
 
-  DEBUG ((EFI_D_INFO, "%a() in %a module\n", __FUNCTION__, gEfiCallerBaseName));
+  DEBUG ((DEBUG_INFO, "%a() in %a module\n", __FUNCTION__, gEfiCallerBaseName));
 
   if (mEventDxeSmmReadyToLock != NULL) {
     //
@@ -834,7 +834,7 @@ S3BootScriptGetEntryAddAddress (
       // Add DEBUG ERROR, so that we can find it after SmmReadyToLock.
       // Do not use ASSERT, because we may have test to invoke this interface.
       //
-      DEBUG ((EFI_D_ERROR, "FATAL ERROR: Set boot script outside SMM after SmmReadyToLock!!!\n"));
+      DEBUG ((DEBUG_ERROR, "FATAL ERROR: Set boot script outside SMM after SmmReadyToLock!!!\n"));
       return NULL;
     }
 

--- a/MdeModulePkg/Library/PlatformVarCleanupLib/PlatVarCleanupLib.c
+++ b/MdeModulePkg/Library/PlatformVarCleanupLib/PlatVarCleanupLib.c
@@ -71,7 +71,7 @@ InternalGetVarErrorFlag (
                   &ErrorFlag
                   );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_INFO, "%s - not found\n", VAR_ERROR_FLAG_NAME));
+    DEBUG ((DEBUG_INFO, "%s - not found\n", VAR_ERROR_FLAG_NAME));
     return VAR_ERROR_FLAG_NO_ERROR;
   }
   return ErrorFlag;
@@ -115,16 +115,16 @@ IsUserVariable (
     //
     // No property, it is user variable.
     //
-    DEBUG ((EFI_D_INFO, "PlatformVarCleanup - User variable: %g:%s\n", Guid, Name));
+    DEBUG ((DEBUG_INFO, "PlatformVarCleanup - User variable: %g:%s\n", Guid, Name));
     return TRUE;
   }
 
-//  DEBUG ((EFI_D_INFO, "PlatformVarCleanup - Variable Property: %g:%s\n", Guid, Name));
-//  DEBUG ((EFI_D_INFO, "  Revision  - 0x%04x\n", Property.Revision));
-//  DEBUG ((EFI_D_INFO, "  Property  - 0x%04x\n", Property.Property));
-//  DEBUG ((EFI_D_INFO, "  Attribute - 0x%08x\n", Property.Attributes));
-//  DEBUG ((EFI_D_INFO, "  MinSize   - 0x%x\n", Property.MinSize));
-//  DEBUG ((EFI_D_INFO, "  MaxSize   - 0x%x\n", Property.MaxSize));
+//  DEBUG ((DEBUG_INFO, "PlatformVarCleanup - Variable Property: %g:%s\n", Guid, Name));
+//  DEBUG ((DEBUG_INFO, "  Revision  - 0x%04x\n", Property.Revision));
+//  DEBUG ((DEBUG_INFO, "  Property  - 0x%04x\n", Property.Property));
+//  DEBUG ((DEBUG_INFO, "  Attribute - 0x%08x\n", Property.Attributes));
+//  DEBUG ((DEBUG_INFO, "  MinSize   - 0x%x\n", Property.MinSize));
+//  DEBUG ((DEBUG_INFO, "  MaxSize   - 0x%x\n", Property.MaxSize));
 
   return FALSE;
 }
@@ -276,7 +276,7 @@ CreateUserVariableNode (
 
   mUserVariableCount = Index;
   ASSERT (mUserVariableCount <= MAX_USER_VARIABLE_COUNT);
-  DEBUG ((EFI_D_INFO, "PlatformVarCleanup - User variable count: 0x%04x\n", mUserVariableCount));
+  DEBUG ((DEBUG_INFO, "PlatformVarCleanup - User variable count: 0x%04x\n", mUserVariableCount));
 
   FreePool (VarName);
   FreePool (Data);
@@ -515,7 +515,7 @@ DeleteUserVariable (
       UserVariableNameNode = USER_VARIABLE_NAME_FROM_LINK (NameLink);
 
       if (!UserVariableNameNode->Deleted && (DeleteAll || ((VariableCleanupData != NULL) && (VariableCleanupData->UserVariable[UserVariableNameNode->Index] == TRUE)))) {
-        DEBUG ((EFI_D_INFO, "PlatformVarCleanup - Delete variable: %g:%s\n", &UserVariableNode->Guid, UserVariableNameNode->Name));
+        DEBUG ((DEBUG_INFO, "PlatformVarCleanup - Delete variable: %g:%s\n", &UserVariableNode->Guid, UserVariableNameNode->Name));
         if ((UserVariableNameNode->Attributes & EFI_VARIABLE_TIME_BASED_AUTHENTICATED_WRITE_ACCESS) != 0) {
           DataSize = 0;
           Data = NULL;
@@ -538,7 +538,7 @@ DeleteUserVariable (
         if (!EFI_ERROR (Status)) {
           UserVariableNameNode->Deleted = TRUE;
         } else {
-          DEBUG ((EFI_D_INFO, "PlatformVarCleanup - Delete variable fail: %g:%s\n", &UserVariableNode->Guid, UserVariableNameNode->Name));
+          DEBUG ((DEBUG_INFO, "PlatformVarCleanup - Delete variable fail: %g:%s\n", &UserVariableNode->Guid, UserVariableNameNode->Name));
         }
       }
     }
@@ -1052,8 +1052,8 @@ PlatformVarCleanup (
     //
     // This sample does not support system variables cleanup.
     //
-    DEBUG ((EFI_D_ERROR, "NOTICE - VAR_ERROR_FLAG_SYSTEM_ERROR\n"));
-    DEBUG ((EFI_D_ERROR, "Platform should have mechanism to reset system to manufacture mode\n"));
+    DEBUG ((DEBUG_ERROR, "NOTICE - VAR_ERROR_FLAG_SYSTEM_ERROR\n"));
+    DEBUG ((DEBUG_ERROR, "Platform should have mechanism to reset system to manufacture mode\n"));
     return EFI_UNSUPPORTED;
   }
 
@@ -1232,7 +1232,7 @@ PlatformVarCleanupLibConstructor (
   EFI_STATUS    Status;
 
   mLastVarErrorFlag = InternalGetVarErrorFlag ();
-  DEBUG ((EFI_D_INFO, "mLastVarErrorFlag - 0x%02x\n", mLastVarErrorFlag));
+  DEBUG ((DEBUG_INFO, "mLastVarErrorFlag - 0x%02x\n", mLastVarErrorFlag));
 
   //
   // Register EFI_END_OF_DXE_EVENT_GROUP_GUID event.

--- a/MdeModulePkg/Library/SmmIpmiLibSmmIpmiProtocol/SmmIpmiLibSmmIpmiProtocol.c
+++ b/MdeModulePkg/Library/SmmIpmiLibSmmIpmiProtocol/SmmIpmiLibSmmIpmiProtocol.c
@@ -55,7 +55,7 @@ IpmiSubmitCommand (
       //
       // Smm Ipmi Protocol is not installed. So, IPMI device is not present.
       //
-      DEBUG ((EFI_D_ERROR, "IpmiSubmitCommand for SMM Status - %r\n", Status));
+      DEBUG ((DEBUG_ERROR, "IpmiSubmitCommand for SMM Status - %r\n", Status));
       return EFI_NOT_FOUND;
     }
   }

--- a/MdeModulePkg/Library/UefiBootManagerLib/BmBoot.c
+++ b/MdeModulePkg/Library/UefiBootManagerLib/BmBoot.c
@@ -1807,7 +1807,7 @@ EfiBootManagerBoot (
     }
 
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "[Bds] Failed to create Boot#### for a temporary boot - %r!\n", Status));
+      DEBUG ((DEBUG_ERROR, "[Bds] Failed to create Boot#### for a temporary boot - %r!\n", Status));
       BootOption->Status = Status;
       return ;
     }
@@ -1830,7 +1830,7 @@ EfiBootManagerBoot (
   //    the boot option.
   //
   if (BmIsBootManagerMenuFilePath (BootOption->FilePath)) {
-    DEBUG ((EFI_D_INFO, "[Bds] Booting Boot Manager Menu.\n"));
+    DEBUG ((DEBUG_INFO, "[Bds] Booting Boot Manager Menu.\n"));
     BmStopHotkeyService (NULL, NULL);
   } else {
     EfiSignalEventReadyToBoot();
@@ -2440,7 +2440,7 @@ BmRegisterBootManagerMenu (
                &DevicePath
                );
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_WARN, "[Bds]BootManagerMenu FFS section can not be found, skip its boot option registration\n"));
+      DEBUG ((DEBUG_WARN, "[Bds]BootManagerMenu FFS section can not be found, skip its boot option registration\n"));
       return EFI_NOT_FOUND;
     }
     ASSERT (DevicePath != NULL);

--- a/MdeModulePkg/Library/UefiBootManagerLib/BmConsole.c
+++ b/MdeModulePkg/Library/UefiBootManagerLib/BmConsole.c
@@ -199,7 +199,7 @@ EfiBootManagerGetGopDevicePath (
           //
           // Recursively look for GOP child in this frame buffer handle
           //
-          DEBUG ((EFI_D_INFO, "[Bds] Looking for GOP child deeper ... \n"));
+          DEBUG ((DEBUG_INFO, "[Bds] Looking for GOP child deeper ... \n"));
           TempDevicePath = GopPool;
           ReturnDevicePath = EfiBootManagerGetGopDevicePath (OpenInfoBuffer[Index].ControllerHandle);
           GopPool = AppendDevicePathInstance (GopPool, ReturnDevicePath);
@@ -340,7 +340,7 @@ BmUpdateSystemTableConsole (
     //
     Instance  = GetNextDevicePathInstance (&VarConsole, &DevicePathSize);
     if (Instance == NULL) {
-      DEBUG ((EFI_D_ERROR, "[Bds] No valid console instance is found for %s!\n", VarName));
+      DEBUG ((DEBUG_ERROR, "[Bds] No valid console instance is found for %s!\n", VarName));
       // We should not ASSERT when all the console devices are removed.
       // ASSERT_EFI_ERROR (EFI_NOT_FOUND);
       FreePool (FullDevicePath);

--- a/MdeModulePkg/Library/UefiBootManagerLib/BmDriverHealth.c
+++ b/MdeModulePkg/Library/UefiBootManagerLib/BmDriverHealth.c
@@ -129,7 +129,7 @@ BmDisplayMessages (
                      DriverHealthInfo->ChildHandle
                      );
 
-  DEBUG ((EFI_D_INFO, "Controller: %s\n", ControllerName));
+  DEBUG ((DEBUG_INFO, "Controller: %s\n", ControllerName));
   Print (L"Controller: %s\n", ControllerName);
   for (Index = 0; DriverHealthInfo->MessageList[Index].HiiHandle != NULL; Index++) {
     String = HiiGetString (
@@ -139,7 +139,7 @@ BmDisplayMessages (
                );
     if (String != NULL) {
       Print (L"  %s\n", String);
-      DEBUG ((EFI_D_INFO, "  %s\n", String));
+      DEBUG ((DEBUG_INFO, "  %s\n", String));
       FreePool (String);
     }
   }
@@ -167,7 +167,7 @@ BmRepairNotify (
   IN UINTN        Limit
   )
 {
-  DEBUG ((EFI_D_INFO, "[BDS]RepairNotify: %d/%d\n", Value, Limit));
+  DEBUG ((DEBUG_INFO, "[BDS]RepairNotify: %d/%d\n", Value, Limit));
   Print (L"[BDS]RepairNotify: %d/%d\n", Value, Limit);
 
   return EFI_SUCCESS;
@@ -556,7 +556,7 @@ BmRepairAllControllers (
                          DriverHealthInfo[Index].ChildHandle
                          );
       DEBUG ((
-        EFI_D_INFO,
+        DEBUG_INFO,
         "%02d: %s - %s\n",
         Index,
         ControllerName,
@@ -579,7 +579,7 @@ BmRepairAllControllers (
   }
 
   if (RebootRequired) {
-    DEBUG ((EFI_D_INFO, "[BDS] One of the Driver Health instances requires rebooting.\n"));
+    DEBUG ((DEBUG_INFO, "[BDS] One of the Driver Health instances requires rebooting.\n"));
     gRT->ResetSystem (EfiResetWarm, EFI_SUCCESS, 0, NULL);
   }
 }

--- a/MdeModulePkg/Library/UefiBootManagerLib/BmHotkey.c
+++ b/MdeModulePkg/Library/UefiBootManagerLib/BmHotkey.c
@@ -353,7 +353,7 @@ BmHotkeyCallback (
     return EFI_SUCCESS;
   }
 
-  DEBUG ((EFI_D_INFO, "[Bds]BmHotkeyCallback: %04x:%04x\n", KeyData->Key.ScanCode, KeyData->Key.UnicodeChar));
+  DEBUG ((DEBUG_INFO, "[Bds]BmHotkeyCallback: %04x:%04x\n", KeyData->Key.ScanCode, KeyData->Key.UnicodeChar));
 
   EfiAcquireLock (&mBmHotkeyLock);
   for ( Link = GetFirstNode (&mBmHotkeyList)
@@ -399,12 +399,12 @@ BmHotkeyCallback (
             mBmLoadOptionName[LoadOptionTypeBoot], Hotkey->BootOption
             );
           Status = EfiBootManagerVariableToLoadOption (OptionName, &mBmHotkeyBootOption);
-          DEBUG ((EFI_D_INFO, "[Bds]Hotkey for %s pressed - %r\n", OptionName, Status));
+          DEBUG ((DEBUG_INFO, "[Bds]Hotkey for %s pressed - %r\n", OptionName, Status));
           if (EFI_ERROR (Status)) {
             mBmHotkeyBootOption.OptionNumber = LoadOptionNumberUnassigned;
           }
         } else {
-          DEBUG ((EFI_D_INFO, "[Bds]Continue key pressed!\n"));
+          DEBUG ((DEBUG_INFO, "[Bds]Continue key pressed!\n"));
         }
       }
     } else {
@@ -503,7 +503,7 @@ BmUnregisterHotkeyNotify (
                           );
       if (!EFI_ERROR (Status)) {
         Status = TxtInEx->UnregisterKeyNotify (TxtInEx, NotifyHandle);
-        DEBUG ((EFI_D_INFO, "[Bds]UnregisterKeyNotify: %04x/%04x %r\n", Hotkey->KeyData[KeyIndex].Key.ScanCode, Hotkey->KeyData[KeyIndex].Key.UnicodeChar, Status));
+        DEBUG ((DEBUG_INFO, "[Bds]UnregisterKeyNotify: %04x/%04x %r\n", Hotkey->KeyData[KeyIndex].Key.ScanCode, Hotkey->KeyData[KeyIndex].Key.UnicodeChar, Status));
       }
     }
   }
@@ -542,7 +542,7 @@ BmRegisterHotkeyNotify (
                         &NotifyHandle
                         );
     DEBUG ((
-      EFI_D_INFO,
+      DEBUG_INFO,
       "[Bds]RegisterKeyNotify: %04x/%04x %08x/%02x %r\n",
       Hotkey->KeyData[Index].Key.ScanCode,
       Hotkey->KeyData[Index].Key.UnicodeChar,
@@ -830,7 +830,7 @@ BmStopHotkeyService (
   LIST_ENTRY            *Link;
   BM_HOTKEY             *Hotkey;
 
-  DEBUG ((EFI_D_INFO, "[Bds]Stop Hotkey Service!\n"));
+  DEBUG ((DEBUG_INFO, "[Bds]Stop Hotkey Service!\n"));
   gBS->CloseEvent (Event);
 
   EfiAcquireLock (&mBmHotkeyLock);
@@ -873,7 +873,7 @@ EfiBootManagerStartHotkeyService (
   }
 
   if (mBmHotkeySupportCount == 0) {
-    DEBUG ((EFI_D_INFO, "Bds: BootOptionSupport NV variable forbids starting the hotkey service.\n"));
+    DEBUG ((DEBUG_INFO, "Bds: BootOptionSupport NV variable forbids starting the hotkey service.\n"));
     return EFI_UNSUPPORTED;
   }
 

--- a/MdeModulePkg/Library/UefiBootManagerLib/BmLoadOption.c
+++ b/MdeModulePkg/Library/UefiBootManagerLib/BmLoadOption.c
@@ -1081,7 +1081,7 @@ EfiBootManagerGetLoadOptions (
 
       Status = EfiBootManagerVariableToLoadOption (OptionName, &Options[OptionIndex]);
       if (EFI_ERROR (Status)) {
-        DEBUG ((EFI_D_INFO, "[Bds] %s doesn't exist - Update ****Order variable to remove the reference!!", OptionName));
+        DEBUG ((DEBUG_INFO, "[Bds] %s doesn't exist - Update ****Order variable to remove the reference!!", OptionName));
         EfiBootManagerDeleteLoadOptionVariable (OptionNumber, LoadOptionType);
       } else {
         ASSERT (Options[OptionIndex].OptionNumber == OptionNumber);

--- a/MdeModulePkg/Library/UefiBootManagerLib/BmMisc.c
+++ b/MdeModulePkg/Library/UefiBootManagerLib/BmMisc.c
@@ -208,9 +208,9 @@ BmSetMemoryTypeInformationVariable (
   //
   // Use a heuristic to adjust the Memory Type Information for the next boot
   //
-  DEBUG ((EFI_D_INFO, "Memory  Previous  Current    Next   \n"));
-  DEBUG ((EFI_D_INFO, " Type    Pages     Pages     Pages  \n"));
-  DEBUG ((EFI_D_INFO, "======  ========  ========  ========\n"));
+  DEBUG ((DEBUG_INFO, "Memory  Previous  Current    Next   \n"));
+  DEBUG ((DEBUG_INFO, " Type    Pages     Pages     Pages  \n"));
+  DEBUG ((DEBUG_INFO, "======  ========  ========  ========\n"));
 
   for (Index = 0; PreviousMemoryTypeInformation[Index].Type != EfiMaxMemoryType; Index++) {
 
@@ -253,7 +253,7 @@ BmSetMemoryTypeInformationVariable (
       MemoryTypeInformationModified = TRUE;
     }
 
-    DEBUG ((EFI_D_INFO, "  %02x    %08x  %08x  %08x\n", PreviousMemoryTypeInformation[Index].Type, Previous, Current, Next));
+    DEBUG ((DEBUG_INFO, "  %02x    %08x  %08x  %08x\n", PreviousMemoryTypeInformation[Index].Type, Previous, Current, Next));
   }
 
   //
@@ -276,14 +276,14 @@ BmSetMemoryTypeInformationVariable (
       // entry/resume cycle will not fail.
       //
       if (MemoryTypeInformationModified) {
-        DEBUG ((EFI_D_INFO, "Memory Type Information settings change.\n"));
+        DEBUG ((DEBUG_INFO, "Memory Type Information settings change.\n"));
         if (Boot && PcdGetBool (PcdResetOnMemoryTypeInformationChange)) {
-          DEBUG ((EFI_D_INFO, "...Warm Reset!!!\n"));
+          DEBUG ((DEBUG_INFO, "...Warm Reset!!!\n"));
           gRT->ResetSystem (EfiResetWarm, EFI_SUCCESS, 0, NULL);
         }
       }
     } else {
-      DEBUG ((EFI_D_ERROR, "Memory Type Information settings cannot be saved. OS S4 may fail!\n"));
+      DEBUG ((DEBUG_ERROR, "Memory Type Information settings cannot be saved. OS S4 may fail!\n"));
     }
   }
   FreePool (PreviousMemoryTypeInformation);
@@ -385,7 +385,7 @@ BmPrintDp (
   CHAR16                              *Str;
 
   Str = ConvertDevicePathToText (DevicePath, FALSE, FALSE);
-  DEBUG ((EFI_D_INFO, "%s", Str));
+  DEBUG ((DEBUG_INFO, "%s", Str));
   if (Str != NULL) {
     FreePool (Str);
   }

--- a/MdeModulePkg/Library/VarCheckLib/VarCheckLib.c
+++ b/MdeModulePkg/Library/VarCheckLib/VarCheckLib.c
@@ -280,7 +280,7 @@ VarCheckLibRegisterEndOfDxeCallback (
            (UINTN) Callback
            );
 
-  DEBUG ((EFI_D_INFO, "VarCheckLibRegisterEndOfDxeCallback - 0x%x %r\n", Callback, Status));
+  DEBUG ((DEBUG_INFO, "VarCheckLibRegisterEndOfDxeCallback - 0x%x %r\n", Callback, Status));
 
   return Status;
 }
@@ -412,7 +412,7 @@ VarCheckLibRegisterAddressPointer (
            (UINTN) AddressPointer
            );
 
-  DEBUG ((EFI_D_INFO, "VarCheckLibRegisterAddressPointer - 0x%x %r\n", AddressPointer, Status));
+  DEBUG ((DEBUG_INFO, "VarCheckLibRegisterAddressPointer - 0x%x %r\n", AddressPointer, Status));
 
   return Status;
 }
@@ -454,7 +454,7 @@ VarCheckLibRegisterSetVariableCheckHandler (
              (UINTN) Handler
              );
 
-  DEBUG ((EFI_D_INFO, "VarCheckLibRegisterSetVariableCheckHandler - 0x%x %r\n", Handler, Status));
+  DEBUG ((DEBUG_INFO, "VarCheckLibRegisterSetVariableCheckHandler - 0x%x %r\n", Handler, Status));
 
   return Status;
 }
@@ -627,7 +627,7 @@ VarCheckLibSetVariableCheck (
   //
   if ((Property != NULL) && (Property->Revision == VAR_CHECK_VARIABLE_PROPERTY_REVISION)) {
     if ((RequestSource != VarCheckFromTrusted) && ((Property->Property & VAR_CHECK_VARIABLE_PROPERTY_READ_ONLY) != 0)) {
-      DEBUG ((EFI_D_INFO, "Variable Check ReadOnly variable fail %r - %g:%s\n", EFI_WRITE_PROTECTED, VendorGuid, VariableName));
+      DEBUG ((DEBUG_INFO, "Variable Check ReadOnly variable fail %r - %g:%s\n", EFI_WRITE_PROTECTED, VendorGuid, VariableName));
       return EFI_WRITE_PROTECTED;
     }
     if (!((((Attributes & EFI_VARIABLE_APPEND_WRITE) == 0) && (DataSize == 0)) || (Attributes == 0))) {
@@ -635,12 +635,12 @@ VarCheckLibSetVariableCheck (
       // Not to delete variable.
       //
       if ((Property->Attributes != 0) && ((Attributes & (~EFI_VARIABLE_APPEND_WRITE)) != Property->Attributes)) {
-        DEBUG ((EFI_D_INFO, "Variable Check Attributes(0x%08x to 0x%08x) fail %r - %g:%s\n", Property->Attributes, Attributes, EFI_INVALID_PARAMETER, VendorGuid, VariableName));
+        DEBUG ((DEBUG_INFO, "Variable Check Attributes(0x%08x to 0x%08x) fail %r - %g:%s\n", Property->Attributes, Attributes, EFI_INVALID_PARAMETER, VendorGuid, VariableName));
         return EFI_INVALID_PARAMETER;
       }
       if (DataSize != 0) {
         if ((DataSize < Property->MinSize) || (DataSize > Property->MaxSize)) {
-          DEBUG ((EFI_D_INFO, "Variable Check DataSize fail(0x%x not in 0x%x - 0x%x) %r - %g:%s\n", DataSize, Property->MinSize, Property->MaxSize, EFI_INVALID_PARAMETER, VendorGuid, VariableName));
+          DEBUG ((DEBUG_INFO, "Variable Check DataSize fail(0x%x not in 0x%x - 0x%x) %r - %g:%s\n", DataSize, Property->MinSize, Property->MaxSize, EFI_INVALID_PARAMETER, VendorGuid, VariableName));
           return EFI_INVALID_PARAMETER;
         }
       }
@@ -663,7 +663,7 @@ VarCheckLibSetVariableCheck (
       continue;
     }
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_INFO, "Variable Check handler fail %r - %g:%s\n", Status, VendorGuid, VariableName));
+      DEBUG ((DEBUG_INFO, "Variable Check handler fail %r - %g:%s\n", Status, VendorGuid, VariableName));
       return Status;
     }
   }

--- a/MdeModulePkg/Library/VarCheckPcdLib/VarCheckPcdLibNullClass.c
+++ b/MdeModulePkg/Library/VarCheckPcdLib/VarCheckPcdLibNullClass.c
@@ -63,7 +63,7 @@ VarCheckPcdInternalDumpHex (
 
     Val[Index * 3]  = 0;
     Str[Index]      = 0;
-    DEBUG ((EFI_D_INFO, "%*a%08X: %-48a *%a*\r\n", Indent, "", Offset, Val, Str));
+    DEBUG ((DEBUG_INFO, "%*a%08X: %-48a *%a*\r\n", Indent, "", Offset, Val, Str));
 
     Data += Size;
     Offset += Size;
@@ -116,7 +116,7 @@ VarCheckPcdValidData (
         //
         // No match
         //
-        DEBUG ((EFI_D_INFO, "VarCheckPcdValidData fail: ValidList mismatch (0x%lx)\n", OneData));
+        DEBUG ((DEBUG_INFO, "VarCheckPcdValidData fail: ValidList mismatch (0x%lx)\n", OneData));
         DEBUG_CODE (VarCheckPcdInternalDumpHex (2, 0, PcdValidData->Length, (UINT8 *) PcdValidData););
         return FALSE;
       }
@@ -136,7 +136,7 @@ VarCheckPcdValidData (
           return TRUE;
         }
       }
-      DEBUG ((EFI_D_INFO, "VarCheckPcdValidData fail: ValidRange mismatch (0x%lx)\n", OneData));
+      DEBUG ((DEBUG_INFO, "VarCheckPcdValidData fail: ValidRange mismatch (0x%lx)\n", OneData));
       DEBUG_CODE (VarCheckPcdInternalDumpHex (2, 0, PcdValidData->Length, (UINT8 *) PcdValidData););
       return FALSE;
       break;
@@ -199,14 +199,14 @@ SetVariableCheckHandlerPcd (
       //
       // Found the Pcd Variable that could be used to do check.
       //
-      DEBUG ((EFI_D_INFO, "VarCheckPcdVariable - %s:%g with Attributes = 0x%08x Size = 0x%x\n", VariableName, VendorGuid, Attributes, DataSize));
+      DEBUG ((DEBUG_INFO, "VarCheckPcdVariable - %s:%g with Attributes = 0x%08x Size = 0x%x\n", VariableName, VendorGuid, Attributes, DataSize));
       if ((PcdVariable->Attributes != 0) && PcdVariable->Attributes != Attributes) {
-        DEBUG ((EFI_D_INFO, "VarCheckPcdVariable fail for Attributes - 0x%08x\n", PcdVariable->Attributes));
+        DEBUG ((DEBUG_INFO, "VarCheckPcdVariable fail for Attributes - 0x%08x\n", PcdVariable->Attributes));
         return EFI_SECURITY_VIOLATION;
       }
 
       if (DataSize == 0) {
-        DEBUG ((EFI_D_INFO, "VarCheckPcdVariable - CHECK PASS with DataSize == 0 !\n"));
+        DEBUG ((DEBUG_INFO, "VarCheckPcdVariable - CHECK PASS with DataSize == 0 !\n"));
         return EFI_SUCCESS;
       }
 
@@ -227,7 +227,7 @@ SetVariableCheckHandlerPcd (
         PcdValidData = (VAR_CHECK_PCD_VALID_DATA_HEADER *) HEADER_ALIGN (((UINTN) PcdValidData + PcdValidData->Length));
       }
 
-      DEBUG ((EFI_D_INFO, "VarCheckPcdVariable - ALL CHECK PASS!\n"));
+      DEBUG ((DEBUG_INFO, "VarCheckPcdVariable - ALL CHECK PASS!\n"));
       return EFI_SUCCESS;
     }
     //
@@ -257,11 +257,11 @@ DumpPcdValidData (
   UINT64    OneValue;
   UINT8     *Ptr;
 
-  DEBUG ((EFI_D_INFO, "  VAR_CHECK_PCD_VALID_DATA_HEADER\n"));
-  DEBUG ((EFI_D_INFO, "    Type          - 0x%02x\n", PcdValidData->Type));
-  DEBUG ((EFI_D_INFO, "    Length        - 0x%02x\n", PcdValidData->Length));
-  DEBUG ((EFI_D_INFO, "    VarOffset     - 0x%04x\n", PcdValidData->VarOffset));
-  DEBUG ((EFI_D_INFO, "    StorageWidth  - 0x%02x\n", PcdValidData->StorageWidth));
+  DEBUG ((DEBUG_INFO, "  VAR_CHECK_PCD_VALID_DATA_HEADER\n"));
+  DEBUG ((DEBUG_INFO, "    Type          - 0x%02x\n", PcdValidData->Type));
+  DEBUG ((DEBUG_INFO, "    Length        - 0x%02x\n", PcdValidData->Length));
+  DEBUG ((DEBUG_INFO, "    VarOffset     - 0x%04x\n", PcdValidData->VarOffset));
+  DEBUG ((DEBUG_INFO, "    StorageWidth  - 0x%02x\n", PcdValidData->StorageWidth));
 
   switch (PcdValidData->Type) {
     case VarCheckPcdValidList:
@@ -271,16 +271,16 @@ DumpPcdValidData (
         CopyMem (&OneValue, Ptr, PcdValidData->StorageWidth);
         switch (PcdValidData->StorageWidth) {
           case sizeof (UINT8):
-            DEBUG ((EFI_D_INFO, "    ValidList   - 0x%02x\n", OneValue));
+            DEBUG ((DEBUG_INFO, "    ValidList   - 0x%02x\n", OneValue));
             break;
           case sizeof (UINT16):
-            DEBUG ((EFI_D_INFO, "    ValidList   - 0x%04x\n", OneValue));
+            DEBUG ((DEBUG_INFO, "    ValidList   - 0x%04x\n", OneValue));
             break;
           case sizeof (UINT32):
-            DEBUG ((EFI_D_INFO, "    ValidList   - 0x%08x\n", OneValue));
+            DEBUG ((DEBUG_INFO, "    ValidList   - 0x%08x\n", OneValue));
             break;
           case sizeof (UINT64):
-            DEBUG ((EFI_D_INFO, "    ValidList   - 0x%016lx\n", OneValue));
+            DEBUG ((DEBUG_INFO, "    ValidList   - 0x%016lx\n", OneValue));
             break;
           default:
             ASSERT (FALSE);
@@ -302,20 +302,20 @@ DumpPcdValidData (
 
         switch (PcdValidData->StorageWidth) {
           case sizeof (UINT8):
-            DEBUG ((EFI_D_INFO, "    Minimum       - 0x%02x\n", Minimum));
-            DEBUG ((EFI_D_INFO, "    Maximum       - 0x%02x\n", Maximum));
+            DEBUG ((DEBUG_INFO, "    Minimum       - 0x%02x\n", Minimum));
+            DEBUG ((DEBUG_INFO, "    Maximum       - 0x%02x\n", Maximum));
             break;
           case sizeof (UINT16):
-            DEBUG ((EFI_D_INFO, "    Minimum       - 0x%04x\n", Minimum));
-            DEBUG ((EFI_D_INFO, "    Maximum       - 0x%04x\n", Maximum));
+            DEBUG ((DEBUG_INFO, "    Minimum       - 0x%04x\n", Minimum));
+            DEBUG ((DEBUG_INFO, "    Maximum       - 0x%04x\n", Maximum));
             break;
           case sizeof (UINT32):
-            DEBUG ((EFI_D_INFO, "    Minimum       - 0x%08x\n", Minimum));
-            DEBUG ((EFI_D_INFO, "    Maximum       - 0x%08x\n", Maximum));
+            DEBUG ((DEBUG_INFO, "    Minimum       - 0x%08x\n", Minimum));
+            DEBUG ((DEBUG_INFO, "    Maximum       - 0x%08x\n", Maximum));
             break;
           case sizeof (UINT64):
-            DEBUG ((EFI_D_INFO, "    Minimum       - 0x%016lx\n", Minimum));
-            DEBUG ((EFI_D_INFO, "    Maximum       - 0x%016lx\n", Maximum));
+            DEBUG ((DEBUG_INFO, "    Minimum       - 0x%016lx\n", Minimum));
+            DEBUG ((DEBUG_INFO, "    Maximum       - 0x%016lx\n", Maximum));
             break;
           default:
             ASSERT (FALSE);
@@ -343,14 +343,14 @@ DumpPcdVariable (
 {
   VAR_CHECK_PCD_VALID_DATA_HEADER *PcdValidData;
 
-  DEBUG ((EFI_D_INFO, "VAR_CHECK_PCD_VARIABLE_HEADER\n"));
-  DEBUG ((EFI_D_INFO, "  Revision        - 0x%04x\n", PcdVariable->Revision));
-  DEBUG ((EFI_D_INFO, "  HeaderLength    - 0x%04x\n", PcdVariable->HeaderLength));
-  DEBUG ((EFI_D_INFO, "  Length          - 0x%08x\n", PcdVariable->Length));
-  DEBUG ((EFI_D_INFO, "  Type            - 0x%02x\n", PcdVariable->Type));
-  DEBUG ((EFI_D_INFO, "  Attributes      - 0x%08x\n", PcdVariable->Attributes));
-  DEBUG ((EFI_D_INFO, "  Guid            - %g\n", &PcdVariable->Guid));
-  DEBUG ((EFI_D_INFO, "  Name            - %s\n", PcdVariable + 1));
+  DEBUG ((DEBUG_INFO, "VAR_CHECK_PCD_VARIABLE_HEADER\n"));
+  DEBUG ((DEBUG_INFO, "  Revision        - 0x%04x\n", PcdVariable->Revision));
+  DEBUG ((DEBUG_INFO, "  HeaderLength    - 0x%04x\n", PcdVariable->HeaderLength));
+  DEBUG ((DEBUG_INFO, "  Length          - 0x%08x\n", PcdVariable->Length));
+  DEBUG ((DEBUG_INFO, "  Type            - 0x%02x\n", PcdVariable->Type));
+  DEBUG ((DEBUG_INFO, "  Attributes      - 0x%08x\n", PcdVariable->Attributes));
+  DEBUG ((DEBUG_INFO, "  Guid            - %g\n", &PcdVariable->Guid));
+  DEBUG ((DEBUG_INFO, "  Name            - %s\n", PcdVariable + 1));
 
   //
   // For Pcd ValidData header align.
@@ -383,7 +383,7 @@ DumpVarCheckPcd (
 {
   VAR_CHECK_PCD_VARIABLE_HEADER     *PcdVariable;
 
-  DEBUG ((EFI_D_INFO, "DumpVarCheckPcd\n"));
+  DEBUG ((DEBUG_INFO, "DumpVarCheckPcd\n"));
 
   //
   // For Pcd Variable header align.
@@ -436,7 +436,7 @@ LocateVarCheckPcdBin (
     mVarCheckPcdBinSize = VarCheckPcdBinSize;
     FreePool (VarCheckPcdBin);
 
-    DEBUG ((EFI_D_INFO, "VarCheckPcdBin - at 0x%x size = 0x%x\n", mVarCheckPcdBin, mVarCheckPcdBinSize));
+    DEBUG ((DEBUG_INFO, "VarCheckPcdBin - at 0x%x size = 0x%x\n", mVarCheckPcdBin, mVarCheckPcdBinSize));
 
 #ifdef DUMP_VAR_CHECK_PCD
     DEBUG_CODE (
@@ -444,7 +444,7 @@ LocateVarCheckPcdBin (
     );
 #endif
   } else {
-    DEBUG ((EFI_D_INFO, "[VarCheckPcd] No VarCheckPcdBin found at the first RAW section\n"));
+    DEBUG ((DEBUG_INFO, "[VarCheckPcd] No VarCheckPcdBin found at the first RAW section\n"));
   }
 }
 

--- a/MdeModulePkg/Library/VarCheckUefiLib/VarCheckUefiLibNullClass.c
+++ b/MdeModulePkg/Library/VarCheckUefiLib/VarCheckUefiLibNullClass.c
@@ -836,7 +836,7 @@ SetVariableCheckHandlerUefiDefined (
         // only permit the creation of variables with a UEFI Specification-defined
         // VendorGuid when these variables are documented in the UEFI Specification.
         //
-        DEBUG ((EFI_D_INFO, "UEFI Variable Check fail %r - %s not in %g namespace\n", EFI_INVALID_PARAMETER, VariableName, VendorGuid));
+        DEBUG ((DEBUG_INFO, "UEFI Variable Check fail %r - %s not in %g namespace\n", EFI_INVALID_PARAMETER, VariableName, VendorGuid));
         return EFI_INVALID_PARAMETER;
       }
     }
@@ -855,7 +855,7 @@ SetVariableCheckHandlerUefiDefined (
                Data
                );
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_INFO, "UEFI Variable Check function fail %r - %g:%s\n", Status, VendorGuid, VariableName));
+      DEBUG ((DEBUG_INFO, "UEFI Variable Check function fail %r - %g:%s\n", Status, VendorGuid, VariableName));
       return Status;
     }
   }

--- a/MdeModulePkg/Universal/Acpi/AcpiTableDxe/AcpiSdt.c
+++ b/MdeModulePkg/Universal/Acpi/AcpiTableDxe/AcpiSdt.c
@@ -1048,9 +1048,9 @@ FindPath (
   }
 
   DEBUG_CODE_BEGIN ();
-  DEBUG ((EFI_D_ERROR, "AcpiSdt: FindPath - "));
+  DEBUG ((DEBUG_ERROR, "AcpiSdt: FindPath - "));
   AmlPrintNameString (AmlPath);
-  DEBUG ((EFI_D_ERROR, "\n"));
+  DEBUG ((DEBUG_ERROR, "\n"));
   DEBUG_CODE_END ();
 
   if (AmlHandle->Signature == EFI_AML_ROOT_HANDLE_SIGNATURE) {

--- a/MdeModulePkg/Universal/Acpi/AcpiTableDxe/AmlNamespace.c
+++ b/MdeModulePkg/Universal/Acpi/AcpiTableDxe/AmlNamespace.c
@@ -263,9 +263,9 @@ AmlInsertNodeToTree (
   //
   // Oops!!!, There must be something wrong.
   //
-  DEBUG ((EFI_D_ERROR, "AML: Override Happen - %a!\n", NameString));
-  DEBUG ((EFI_D_ERROR, "AML: Existing Node - %x\n", AmlNodeList->Buffer));
-  DEBUG ((EFI_D_ERROR, "AML: New Buffer - %x\n", Buffer));
+  DEBUG ((DEBUG_ERROR, "AML: Override Happen - %a!\n", NameString));
+  DEBUG ((DEBUG_ERROR, "AML: Existing Node - %x\n", AmlNodeList->Buffer));
+  DEBUG ((DEBUG_ERROR, "AML: New Buffer - %x\n", Buffer));
 
   return NULL;
 }
@@ -476,14 +476,14 @@ AmlDumpNodeInfo (
   CurrentLink = AmlParentNodeList->Children.ForwardLink;
 
   if (Level == 0) {
-    DEBUG ((EFI_D_ERROR, "\\"));
+    DEBUG ((DEBUG_ERROR, "\\"));
   } else {
     for (Index = 0; Index < Level; Index++) {
-      DEBUG ((EFI_D_ERROR, "    "));
+      DEBUG ((DEBUG_ERROR, "    "));
     }
     AmlPrintNameSeg (AmlParentNodeList->Name);
   }
-  DEBUG ((EFI_D_ERROR, "\n"));
+  DEBUG ((DEBUG_ERROR, "\n"));
 
   while (CurrentLink != &AmlParentNodeList->Children) {
     CurrentAmlNodeList = EFI_AML_NODE_LIST_FROM_LINK (CurrentLink);
@@ -543,7 +543,7 @@ AmlFindPath (
   }
 
   DEBUG_CODE_BEGIN ();
-  DEBUG ((EFI_D_ERROR, "AcpiSdt: NameSpace:\n"));
+  DEBUG ((DEBUG_ERROR, "AcpiSdt: NameSpace:\n"));
   AmlDumpNodeInfo (AmlRootNodeList, 0);
   DEBUG_CODE_END ();
 
@@ -579,9 +579,9 @@ AmlFindPath (
   //
   if (CurrentAmlNodeList != NULL) {
     DEBUG_CODE_BEGIN ();
-    DEBUG ((EFI_D_ERROR, "AcpiSdt: Search from: \\"));
+    DEBUG ((DEBUG_ERROR, "AcpiSdt: Search from: \\"));
     AmlPrintNameSeg (CurrentAmlNodeList->Name);
-    DEBUG ((EFI_D_ERROR, "\n"));
+    DEBUG ((DEBUG_ERROR, "\n"));
     DEBUG_CODE_END ();
     AmlNodeList = AmlFindNodeInTheTree (
                     AmlPath,

--- a/MdeModulePkg/Universal/Acpi/AcpiTableDxe/AmlString.c
+++ b/MdeModulePkg/Universal/Acpi/AcpiTableDxe/AmlString.c
@@ -457,19 +457,19 @@ AmlPrintNameSeg (
   IN UINT8              *Buffer
   )
 {
-  DEBUG ((EFI_D_ERROR, "%c", Buffer[0]));
+  DEBUG ((DEBUG_ERROR, "%c", Buffer[0]));
   if ((Buffer[1] == '_') && (Buffer[2] == '_') && (Buffer[3] == '_')) {
     return ;
   }
-  DEBUG ((EFI_D_ERROR, "%c", Buffer[1]));
+  DEBUG ((DEBUG_ERROR, "%c", Buffer[1]));
   if ((Buffer[2] == '_') && (Buffer[3] == '_')) {
     return ;
   }
-  DEBUG ((EFI_D_ERROR, "%c", Buffer[2]));
+  DEBUG ((DEBUG_ERROR, "%c", Buffer[2]));
   if (Buffer[3] == '_') {
     return ;
   }
-  DEBUG ((EFI_D_ERROR, "%c", Buffer[3]));
+  DEBUG ((DEBUG_ERROR, "%c", Buffer[3]));
   return ;
 }
 
@@ -491,14 +491,14 @@ AmlPrintNameString (
     // RootChar
     //
     Buffer ++;
-    DEBUG ((EFI_D_ERROR, "\\"));
+    DEBUG ((DEBUG_ERROR, "\\"));
   } else if (*Buffer == AML_PARENT_PREFIX_CHAR) {
     //
     // ParentPrefixChar
     //
     do {
       Buffer ++;
-      DEBUG ((EFI_D_ERROR, "^"));
+      DEBUG ((DEBUG_ERROR, "^"));
     } while (*Buffer == AML_PARENT_PREFIX_CHAR);
   }
 
@@ -530,7 +530,7 @@ AmlPrintNameString (
   AmlPrintNameSeg (Buffer);
   Buffer += AML_NAME_SEG_SIZE;
   for (Index = 0; Index < SegCount - 1; Index++) {
-    DEBUG ((EFI_D_ERROR, "."));
+    DEBUG ((DEBUG_ERROR, "."));
     AmlPrintNameSeg (Buffer);
     Buffer += AML_NAME_SEG_SIZE;
   }

--- a/MdeModulePkg/Universal/Acpi/BootScriptExecutorDxe/ScriptExecute.c
+++ b/MdeModulePkg/Universal/Acpi/BootScriptExecutorDxe/ScriptExecute.c
@@ -164,7 +164,7 @@ S3BootScriptExecutorEntryFunction (
           );
       } else {
         // Unsupported for 32bit DXE, 64bit OS vector
-        DEBUG (( EFI_D_ERROR, "Unsupported for 32bit DXE transfer to 64bit OS waking vector!\r\n"));
+        DEBUG (( DEBUG_ERROR, "Unsupported for 32bit DXE transfer to 64bit OS waking vector!\r\n"));
         ASSERT (FALSE);
       }
     } else {
@@ -494,4 +494,3 @@ BootScriptExecutorEntryPoint (
 
     return EFI_SUCCESS;
 }
-

--- a/MdeModulePkg/Universal/Acpi/FirmwarePerformanceDataTableDxe/FirmwarePerformanceDxe.c
+++ b/MdeModulePkg/Universal/Acpi/FirmwarePerformanceDataTableDxe/FirmwarePerformanceDxe.c
@@ -248,7 +248,7 @@ FpdtAllocateS3PerformanceTableMemory (
                                                              EFI_SIZE_TO_PAGES (sizeof (S3_PERFORMANCE_TABLE))
                                                              );
       }
-      DEBUG ((EFI_D_INFO, "FPDT: ACPI S3 Performance Table address = 0x%x\n", mAcpiS3PerformanceTable));
+      DEBUG ((DEBUG_INFO, "FPDT: ACPI S3 Performance Table address = 0x%x\n", mAcpiS3PerformanceTable));
       if (mAcpiS3PerformanceTable != NULL) {
         CopyMem (mAcpiS3PerformanceTable, &mS3PerformanceTableTemplate, sizeof (mS3PerformanceTableTemplate));
       }
@@ -526,11 +526,11 @@ FpdtStatusCodeListenerDxe (
     //
     // Dump FPDT Boot Performance record.
     //
-    DEBUG ((EFI_D_INFO, "FPDT: Boot Performance - ResetEnd                = %ld\n", mAcpiBootPerformanceTable->BasicBoot.ResetEnd));
-    DEBUG ((EFI_D_INFO, "FPDT: Boot Performance - OsLoaderLoadImageStart  = 0\n"));
-    DEBUG ((EFI_D_INFO, "FPDT: Boot Performance - OsLoaderStartImageStart = %ld\n", mAcpiBootPerformanceTable->BasicBoot.OsLoaderStartImageStart));
-    DEBUG ((EFI_D_INFO, "FPDT: Boot Performance - ExitBootServicesEntry   = 0\n"));
-    DEBUG ((EFI_D_INFO, "FPDT: Boot Performance - ExitBootServicesExit    = 0\n"));
+    DEBUG ((DEBUG_INFO, "FPDT: Boot Performance - ResetEnd                = %ld\n", mAcpiBootPerformanceTable->BasicBoot.ResetEnd));
+    DEBUG ((DEBUG_INFO, "FPDT: Boot Performance - OsLoaderLoadImageStart  = 0\n"));
+    DEBUG ((DEBUG_INFO, "FPDT: Boot Performance - OsLoaderStartImageStart = %ld\n", mAcpiBootPerformanceTable->BasicBoot.OsLoaderStartImageStart));
+    DEBUG ((DEBUG_INFO, "FPDT: Boot Performance - ExitBootServicesEntry   = 0\n"));
+    DEBUG ((DEBUG_INFO, "FPDT: Boot Performance - ExitBootServicesExit    = 0\n"));
   } else if (Data != NULL && CompareGuid (&Data->Type, &gEdkiiFpdtExtendedFirmwarePerformanceGuid)) {
     //
     // Get the Boot performance table and then install it to ACPI table.
@@ -615,10 +615,10 @@ FpdtExitBootServicesEventNotify (
   //
   // Dump FPDT Boot Performance record.
   //
-  DEBUG ((EFI_D_INFO, "FPDT: Boot Performance - ResetEnd                = %ld\n", mAcpiBootPerformanceTable->BasicBoot.ResetEnd));
-  DEBUG ((EFI_D_INFO, "FPDT: Boot Performance - OsLoaderLoadImageStart  = %ld\n", mAcpiBootPerformanceTable->BasicBoot.OsLoaderLoadImageStart));
-  DEBUG ((EFI_D_INFO, "FPDT: Boot Performance - OsLoaderStartImageStart = %ld\n", mAcpiBootPerformanceTable->BasicBoot.OsLoaderStartImageStart));
-  DEBUG ((EFI_D_INFO, "FPDT: Boot Performance - ExitBootServicesEntry   = %ld\n", mAcpiBootPerformanceTable->BasicBoot.ExitBootServicesEntry));
+  DEBUG ((DEBUG_INFO, "FPDT: Boot Performance - ResetEnd                = %ld\n", mAcpiBootPerformanceTable->BasicBoot.ResetEnd));
+  DEBUG ((DEBUG_INFO, "FPDT: Boot Performance - OsLoaderLoadImageStart  = %ld\n", mAcpiBootPerformanceTable->BasicBoot.OsLoaderLoadImageStart));
+  DEBUG ((DEBUG_INFO, "FPDT: Boot Performance - OsLoaderStartImageStart = %ld\n", mAcpiBootPerformanceTable->BasicBoot.OsLoaderStartImageStart));
+  DEBUG ((DEBUG_INFO, "FPDT: Boot Performance - ExitBootServicesEntry   = %ld\n", mAcpiBootPerformanceTable->BasicBoot.ExitBootServicesEntry));
   //
   // ExitBootServicesExit will be updated later, so don't dump it here.
   //

--- a/MdeModulePkg/Universal/Acpi/FirmwarePerformanceDataTablePei/FirmwarePerformancePei.c
+++ b/MdeModulePkg/Universal/Acpi/FirmwarePerformanceDataTablePei/FirmwarePerformancePei.c
@@ -100,7 +100,7 @@ FpdtStatusCodeListenerPei (
   AcpiS3PerformanceTable = (S3_PERFORMANCE_TABLE *) (UINTN) S3PerformanceTablePointer;
   ASSERT (AcpiS3PerformanceTable != NULL);
   if (AcpiS3PerformanceTable->Header.Signature != EFI_ACPI_5_0_FPDT_S3_PERFORMANCE_TABLE_SIGNATURE) {
-    DEBUG ((EFI_D_ERROR, "FPDT S3 performance data in ACPI memory get corrupted\n"));
+    DEBUG ((DEBUG_ERROR, "FPDT S3 performance data in ACPI memory get corrupted\n"));
     return EFI_ABORTED;
   }
   AcpiS3ResumeRecord = &AcpiS3PerformanceTable->S3Resume;
@@ -112,9 +112,9 @@ FpdtStatusCodeListenerPei (
   AcpiS3ResumeRecord->ResumeCount++;
   AcpiS3ResumeRecord->AverageResume = DivU64x32 (S3ResumeTotal + AcpiS3ResumeRecord->FullResume, AcpiS3ResumeRecord->ResumeCount);
 
-  DEBUG ((EFI_D_INFO, "FPDT: S3 Resume Performance - ResumeCount   = %d\n", AcpiS3ResumeRecord->ResumeCount));
-  DEBUG ((EFI_D_INFO, "FPDT: S3 Resume Performance - FullResume    = %ld\n", AcpiS3ResumeRecord->FullResume));
-  DEBUG ((EFI_D_INFO, "FPDT: S3 Resume Performance - AverageResume = %ld\n", AcpiS3ResumeRecord->AverageResume));
+  DEBUG ((DEBUG_INFO, "FPDT: S3 Resume Performance - ResumeCount   = %d\n", AcpiS3ResumeRecord->ResumeCount));
+  DEBUG ((DEBUG_INFO, "FPDT: S3 Resume Performance - FullResume    = %ld\n", AcpiS3ResumeRecord->FullResume));
+  DEBUG ((DEBUG_INFO, "FPDT: S3 Resume Performance - AverageResume = %ld\n", AcpiS3ResumeRecord->AverageResume));
 
   //
   // Update S3 Suspend Performance Record.
@@ -132,8 +132,8 @@ FpdtStatusCodeListenerPei (
   AcpiS3SuspendRecord->SuspendStart = S3SuspendRecord.SuspendStart;
   AcpiS3SuspendRecord->SuspendEnd   = S3SuspendRecord.SuspendEnd;
 
-  DEBUG ((EFI_D_INFO, "FPDT: S3 Suspend Performance - SuspendStart = %ld\n", AcpiS3SuspendRecord->SuspendStart));
-  DEBUG ((EFI_D_INFO, "FPDT: S3 Suspend Performance - SuspendEnd   = %ld\n", AcpiS3SuspendRecord->SuspendEnd));
+  DEBUG ((DEBUG_INFO, "FPDT: S3 Suspend Performance - SuspendStart = %ld\n", AcpiS3SuspendRecord->SuspendStart));
+  DEBUG ((DEBUG_INFO, "FPDT: S3 Suspend Performance - SuspendEnd   = %ld\n", AcpiS3SuspendRecord->SuspendEnd));
 
   Status = PeiServicesLocatePpi (
              &gEfiPeiReadOnlyVariable2PpiGuid,

--- a/MdeModulePkg/Universal/Acpi/S3SaveStateDxe/AcpiS3ContextSave.c
+++ b/MdeModulePkg/Universal/Acpi/S3SaveStateDxe/AcpiS3ContextSave.c
@@ -236,11 +236,11 @@ AcpiS3ContextSaveOnEndOfDxe (
   EFI_ACPI_4_0_FIRMWARE_ACPI_CONTROL_STRUCTURE  *Facs;
   VOID                                          *Interface;
 
-  DEBUG ((EFI_D_INFO, "AcpiS3ContextSave!\n"));
+  DEBUG ((DEBUG_INFO, "AcpiS3ContextSave!\n"));
 
   Status = gBS->LocateProtocol (&gEfiLockBoxProtocolGuid, NULL, &Interface);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_INFO | EFI_D_WARN, "ACPI S3 context can't be saved without LockBox!\n"));
+    DEBUG ((DEBUG_INFO | DEBUG_WARN, "ACPI S3 context can't be saved without LockBox!\n"));
     goto Done;
   }
 
@@ -291,12 +291,12 @@ AcpiS3ContextSaveOnEndOfDxe (
   AcpiS3Context->S3DebugBufferAddress = (EFI_PHYSICAL_ADDRESS)(UINTN)AllocateMemoryBelow4G (EfiReservedMemoryType, EFI_PAGE_SIZE);
   SetMem ((VOID *)(UINTN)AcpiS3Context->S3DebugBufferAddress, EFI_PAGE_SIZE, 0xff);
 
-  DEBUG((EFI_D_INFO, "AcpiS3Context: AcpiFacsTable is 0x%8x\n", AcpiS3Context->AcpiFacsTable));
-  DEBUG((EFI_D_INFO, "AcpiS3Context: IdtrProfile is 0x%8x\n", AcpiS3Context->IdtrProfile));
-  DEBUG((EFI_D_INFO, "AcpiS3Context: S3NvsPageTableAddress is 0x%8x\n", AcpiS3Context->S3NvsPageTableAddress));
-  DEBUG((EFI_D_INFO, "AcpiS3Context: S3DebugBufferAddress is 0x%8x\n", AcpiS3Context->S3DebugBufferAddress));
-  DEBUG((EFI_D_INFO, "AcpiS3Context: BootScriptStackBase is 0x%8x\n", AcpiS3Context->BootScriptStackBase));
-  DEBUG((EFI_D_INFO, "AcpiS3Context: BootScriptStackSize is 0x%8x\n", AcpiS3Context->BootScriptStackSize));
+  DEBUG((DEBUG_INFO, "AcpiS3Context: AcpiFacsTable is 0x%8x\n", AcpiS3Context->AcpiFacsTable));
+  DEBUG((DEBUG_INFO, "AcpiS3Context: IdtrProfile is 0x%8x\n", AcpiS3Context->IdtrProfile));
+  DEBUG((DEBUG_INFO, "AcpiS3Context: S3NvsPageTableAddress is 0x%8x\n", AcpiS3Context->S3NvsPageTableAddress));
+  DEBUG((DEBUG_INFO, "AcpiS3Context: S3DebugBufferAddress is 0x%8x\n", AcpiS3Context->S3DebugBufferAddress));
+  DEBUG((DEBUG_INFO, "AcpiS3Context: BootScriptStackBase is 0x%8x\n", AcpiS3Context->BootScriptStackBase));
+  DEBUG((DEBUG_INFO, "AcpiS3Context: BootScriptStackSize is 0x%8x\n", AcpiS3Context->BootScriptStackSize));
 
   Status = SaveLockBox (
              &gEfiAcpiVariableGuid,
@@ -322,4 +322,3 @@ Done:
   Status = gBS->CloseEvent (Event);
   ASSERT_EFI_ERROR (Status);
 }
-

--- a/MdeModulePkg/Universal/BdsDxe/BdsEntry.c
+++ b/MdeModulePkg/Universal/BdsDxe/BdsEntry.c
@@ -78,7 +78,7 @@ BdsDxeOnConnectConInCallBack (
     // Should not enter this case, if enter, the keyboard will not work.
     // May need platfrom policy to connect keyboard.
     //
-    DEBUG ((EFI_D_WARN, "[Bds] Connect ConIn failed - %r!!!\n", Status));
+    DEBUG ((DEBUG_WARN, "[Bds] Connect ConIn failed - %r!!!\n", Status));
   }
 }
 /**
@@ -315,11 +315,11 @@ BdsWait (
   EFI_STATUS            Status;
   UINT16                TimeoutRemain;
 
-  DEBUG ((EFI_D_INFO, "[Bds]BdsWait ...Zzzzzzzzzzzz...\n"));
+  DEBUG ((DEBUG_INFO, "[Bds]BdsWait ...Zzzzzzzzzzzz...\n"));
 
   TimeoutRemain = PcdGet16 (PcdPlatformBootTimeOut);
   while (TimeoutRemain != 0) {
-    DEBUG ((EFI_D_INFO, "[Bds]BdsWait(%d)..Zzzz...\n", (UINTN) TimeoutRemain));
+    DEBUG ((DEBUG_INFO, "[Bds]BdsWait(%d)..Zzzz...\n", (UINTN) TimeoutRemain));
     PlatformBootManagerWaitCallback (TimeoutRemain);
 
     BdsReadKeys (); // BUGBUG: Only reading can signal HotkeyTriggered
@@ -353,7 +353,7 @@ BdsWait (
   if (PcdGet16 (PcdPlatformBootTimeOut) != 0 && TimeoutRemain == 0) {
     PlatformBootManagerWaitCallback (0);
   }
-  DEBUG ((EFI_D_INFO, "[Bds]Exit the waiting!\n"));
+  DEBUG ((DEBUG_INFO, "[Bds]Exit the waiting!\n"));
 }
 
 /**
@@ -610,7 +610,7 @@ BdsFormalizeOSIndicationVariable (
       (Attributes != (EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_RUNTIME_ACCESS | EFI_VARIABLE_NON_VOLATILE))
      ){
 
-    DEBUG ((EFI_D_ERROR, "[Bds] Unformalized OsIndications variable exists. Delete it\n"));
+    DEBUG ((DEBUG_ERROR, "[Bds] Unformalized OsIndications variable exists. Delete it\n"));
     Status = gRT->SetVariable (
                     EFI_OS_INDICATIONS_VARIABLE_NAME,
                     &gEfiGlobalVariableGuid,
@@ -693,7 +693,7 @@ BdsEntry (
   //
   PERF_CROSSMODULE_END("DXE");
   PERF_CROSSMODULE_BEGIN("BDS");
-  DEBUG ((EFI_D_INFO, "[Bds] Entry...\n"));
+  DEBUG ((DEBUG_INFO, "[Bds] Entry...\n"));
 
   //
   // Fill in FirmwareVendor and FirmwareRevision from PCDs
@@ -943,17 +943,17 @@ BdsEntry (
 
   DEBUG_CODE (
     EFI_BOOT_MANAGER_LOAD_OPTION_TYPE LoadOptionType;
-    DEBUG ((EFI_D_INFO, "[Bds]OsIndication: %016x\n", OsIndication));
-    DEBUG ((EFI_D_INFO, "[Bds]=============Begin Load Options Dumping ...=============\n"));
+    DEBUG ((DEBUG_INFO, "[Bds]OsIndication: %016x\n", OsIndication));
+    DEBUG ((DEBUG_INFO, "[Bds]=============Begin Load Options Dumping ...=============\n"));
     for (LoadOptionType = 0; LoadOptionType < LoadOptionTypeMax; LoadOptionType++) {
       DEBUG ((
-        EFI_D_INFO, "  %s Options:\n",
+        DEBUG_INFO, "  %s Options:\n",
         mBdsLoadOptionName[LoadOptionType]
         ));
       LoadOptions = EfiBootManagerGetLoadOptions (&LoadOptionCount, LoadOptionType);
       for (Index = 0; Index < LoadOptionCount; Index++) {
         DEBUG ((
-          EFI_D_INFO, "    %s%04x: %s \t\t 0x%04x\n",
+          DEBUG_INFO, "    %s%04x: %s \t\t 0x%04x\n",
           mBdsLoadOptionName[LoadOptionType],
           LoadOptions[Index].OptionNumber,
           LoadOptions[Index].Description,
@@ -962,7 +962,7 @@ BdsEntry (
       }
       EfiBootManagerFreeLoadOptions (LoadOptions, LoadOptionCount);
     }
-    DEBUG ((EFI_D_INFO, "[Bds]=============End Load Options Dumping=============\n"));
+    DEBUG ((DEBUG_INFO, "[Bds]=============End Load Options Dumping=============\n"));
   );
 
   //
@@ -1092,7 +1092,7 @@ BdsEntry (
   }
   EfiBootManagerFreeLoadOption (&PlatformDefaultBootOption);
 
-  DEBUG ((EFI_D_ERROR, "[Bds] Unable to boot!\n"));
+  DEBUG ((DEBUG_ERROR, "[Bds] Unable to boot!\n"));
   PlatformBootManagerUnableToBoot ();
   CpuDeadLoop ();
 }

--- a/MdeModulePkg/Universal/CapsulePei/X64/X64Entry.c
+++ b/MdeModulePkg/Universal/CapsulePei/X64/X64Entry.c
@@ -168,7 +168,7 @@ PageFaultHandler (
   AddressEncMask = PageFaultContext->AddressEncMask;
 
   PFAddress = AsmReadCr2 ();
-  DEBUG ((EFI_D_ERROR, "CapsuleX64 - PageFaultHandler: Cr2 - %lx\n", PFAddress));
+  DEBUG ((DEBUG_ERROR, "CapsuleX64 - PageFaultHandler: Cr2 - %lx\n", PFAddress));
 
   if (PFAddress >= PhyMask + SIZE_4KB) {
     return PageFaultContext->OriginalHandler;

--- a/MdeModulePkg/Universal/CapsuleRuntimeDxe/X64/SaveLongModeContext.c
+++ b/MdeModulePkg/Universal/CapsuleRuntimeDxe/X64/SaveLongModeContext.c
@@ -186,7 +186,7 @@ PrepareContextForCapsulePei (
         &Registration
         );
   } else {
-      DEBUG ((EFI_D_ERROR, "FATAL ERROR: CapsuleLongModeBuffer cannot be saved: %r. Capsule in PEI may fail!\n", Status));
+      DEBUG ((DEBUG_ERROR, "FATAL ERROR: CapsuleLongModeBuffer cannot be saved: %r. Capsule in PEI may fail!\n", Status));
       gBS->FreePages (LongModeBuffer.StackBaseAddress, EFI_SIZE_TO_PAGES (LongModeBuffer.StackSize));
   }
 }

--- a/MdeModulePkg/Universal/Console/ConSplitterDxe/ConSplitter.c
+++ b/MdeModulePkg/Universal/Console/ConSplitterDxe/ConSplitter.c
@@ -330,7 +330,7 @@ ToggleStateSyncKeyNotify (
                                     );
     }
     mConIn.PhysicalKeyToggleState = KeyData->KeyState.KeyToggleState;
-    DEBUG ((EFI_D_INFO, "Current toggle state is 0x%02x\n", mConIn.PhysicalKeyToggleState));
+    DEBUG ((DEBUG_INFO, "Current toggle state is 0x%02x\n", mConIn.PhysicalKeyToggleState));
   }
 
   return EFI_SUCCESS;
@@ -3615,7 +3615,7 @@ ConSplitterTextInReadKeyStroke (
   // Signal ConnectConIn event on first call in Lazy ConIn mode
   //
   if (!mConInIsConnect && PcdGetBool (PcdConInConnectOnDemand)) {
-    DEBUG ((EFI_D_INFO, "Connect ConIn in first ReadKeyStoke in Lazy ConIn mode.\n"));
+    DEBUG ((DEBUG_INFO, "Connect ConIn in first ReadKeyStoke in Lazy ConIn mode.\n"));
     gBS->SignalEvent (Private->ConnectConInEvent);
     mConInIsConnect = TRUE;
   }
@@ -3809,7 +3809,7 @@ ConSplitterTextInReadKeyStrokeEx (
   // Signal ConnectConIn event on first call in Lazy ConIn mode
   //
   if (!mConInIsConnect && PcdGetBool (PcdConInConnectOnDemand)) {
-    DEBUG ((EFI_D_INFO, "Connect ConIn in first ReadKeyStoke in Lazy ConIn mode.\n"));
+    DEBUG ((DEBUG_INFO, "Connect ConIn in first ReadKeyStoke in Lazy ConIn mode.\n"));
     gBS->SignalEvent (Private->ConnectConInEvent);
     mConInIsConnect = TRUE;
   }

--- a/MdeModulePkg/Universal/Console/GraphicsConsoleDxe/GraphicsConsole.c
+++ b/MdeModulePkg/Universal/Console/GraphicsConsoleDxe/GraphicsConsole.c
@@ -337,7 +337,7 @@ InitializeGraphicsConsoleTextMode (
 
   DEBUG_CODE (
     for (Index = 0; Index < ValidCount; Index++) {
-      DEBUG ((EFI_D_INFO, "Graphics - Mode %d, Column = %d, Row = %d\n",
+      DEBUG ((DEBUG_INFO, "Graphics - Mode %d, Column = %d, Row = %d\n",
                            Index, NewModeBuffer[Index].Columns, NewModeBuffer[Index].Rows));
     }
   );
@@ -551,7 +551,7 @@ GraphicsConsoleControllerDriverStart (
     }
   }
 
-  DEBUG ((EFI_D_INFO, "GraphicsConsole video resolution %d x %d\n", HorizontalResolution, VerticalResolution));
+  DEBUG ((DEBUG_INFO, "GraphicsConsole video resolution %d x %d\n", HorizontalResolution, VerticalResolution));
 
   //
   // Initialize the mode which GraphicsConsole supports.
@@ -2132,5 +2132,3 @@ InitializeGraphicsConsole (
 
   return Status;
 }
-
-

--- a/MdeModulePkg/Universal/Console/GraphicsOutputDxe/GraphicsOutput.c
+++ b/MdeModulePkg/Universal/Console/GraphicsOutputDxe/GraphicsOutput.c
@@ -323,10 +323,10 @@ GraphicsOutputDriverBindingStart (
     // Use default device infomation when the device info HOB doesn't exist
     //
     DeviceInfo = &mDefaultGraphicsDeviceInfo;
-    DEBUG ((EFI_D_INFO, "[%a]: GraphicsDeviceInfo HOB doesn't exist!\n", gEfiCallerBaseName));
+    DEBUG ((DEBUG_INFO, "[%a]: GraphicsDeviceInfo HOB doesn't exist!\n", gEfiCallerBaseName));
   } else {
     DeviceInfo = (EFI_PEI_GRAPHICS_DEVICE_INFO_HOB *) (GET_GUID_HOB_DATA (HobStart));
-    DEBUG ((EFI_D_INFO, "[%a]: GraphicsDeviceInfo HOB:\n"
+    DEBUG ((DEBUG_INFO, "[%a]: GraphicsDeviceInfo HOB:\n"
             "  VendorId = %04x, DeviceId = %04x,\n"
             "  RevisionId = %02x, BarIndex = %x,\n"
             "  SubsystemVendorId = %04x, SubsystemId = %04x\n",
@@ -395,7 +395,7 @@ GraphicsOutputDriverBindingStart (
         }
         Status = PciIo->GetBarAttributes (PciIo, Index, NULL, (VOID**) &Resources);
         if (!EFI_ERROR (Status)) {
-          DEBUG ((EFI_D_INFO, "[%a]: BAR[%d]: Base = %lx, Length = %lx\n",
+          DEBUG ((DEBUG_INFO, "[%a]: BAR[%d]: Base = %lx, Length = %lx\n",
                   gEfiCallerBaseName, Index, Resources->AddrRangeMin, Resources->AddrLen));
           if ((Resources->Desc == ACPI_ADDRESS_SPACE_DESCRIPTOR) &&
             (Resources->Len == (UINT16) (sizeof (EFI_ACPI_ADDRESS_SPACE_DESCRIPTOR) - 3)) &&
@@ -403,7 +403,7 @@ GraphicsOutputDriverBindingStart (
               (Resources->AddrLen >= GraphicsInfo->FrameBufferSize)
               ) {
             FrameBufferBase = Resources->AddrRangeMin;
-            DEBUG ((EFI_D_INFO, "[%a]: ... matched!\n", gEfiCallerBaseName));
+            DEBUG ((DEBUG_INFO, "[%a]: ... matched!\n", gEfiCallerBaseName));
             break;
           }
         }

--- a/MdeModulePkg/Universal/Console/TerminalDxe/TerminalConIn.c
+++ b/MdeModulePkg/Universal/Console/TerminalDxe/TerminalConIn.c
@@ -2025,7 +2025,7 @@ UnicodeToEfiKey (
           continue;
         }
         else {
-          DEBUG ((EFI_D_ERROR, "Unexpected state in escape2\n"));
+          DEBUG ((DEBUG_ERROR, "Unexpected state in escape2\n"));
         }
       }
       TerminalDevice->ResetState = RESET_STATE_DEFAULT;

--- a/MdeModulePkg/Universal/Disk/CdExpressPei/PeiCdExpress.c
+++ b/MdeModulePkg/Universal/Disk/CdExpressPei/PeiCdExpress.c
@@ -231,9 +231,9 @@ UpdateBlocksAndVolumes (
             ) {
           continue;
         }
-        DEBUG ((EFI_D_INFO, "PeiCdExpress InterfaceType is %d\n", Media2.InterfaceType));
-        DEBUG ((EFI_D_INFO, "PeiCdExpress MediaPresent is %d\n", Media2.MediaPresent));
-        DEBUG ((EFI_D_INFO, "PeiCdExpress BlockSize is  0x%x\n", Media2.BlockSize));
+        DEBUG ((DEBUG_INFO, "PeiCdExpress InterfaceType is %d\n", Media2.InterfaceType));
+        DEBUG ((DEBUG_INFO, "PeiCdExpress MediaPresent is %d\n", Media2.MediaPresent));
+        DEBUG ((DEBUG_INFO, "PeiCdExpress BlockSize is  0x%x\n", Media2.BlockSize));
       } else {
         Status = BlockIoPpi->GetBlockDeviceMediaInfo (
                               PeiServices,
@@ -248,14 +248,14 @@ UpdateBlocksAndVolumes (
             ) {
           continue;
         }
-        DEBUG ((EFI_D_INFO, "PeiCdExpress DeviceType is %d\n", Media.DeviceType));
-        DEBUG ((EFI_D_INFO, "PeiCdExpress MediaPresent is %d\n", Media.MediaPresent));
-        DEBUG ((EFI_D_INFO, "PeiCdExpress BlockSize is  0x%x\n", Media.BlockSize));
+        DEBUG ((DEBUG_INFO, "PeiCdExpress DeviceType is %d\n", Media.DeviceType));
+        DEBUG ((DEBUG_INFO, "PeiCdExpress MediaPresent is %d\n", Media.MediaPresent));
+        DEBUG ((DEBUG_INFO, "PeiCdExpress BlockSize is  0x%x\n", Media.BlockSize));
       }
 
-      DEBUG ((EFI_D_INFO, "PeiCdExpress Status is %d\n", Status));
+      DEBUG ((DEBUG_INFO, "PeiCdExpress Status is %d\n", Status));
 
-      DEBUG ((EFI_D_INFO, "IndexBlockDevice is %d\n", IndexBlockDevice));
+      DEBUG ((DEBUG_INFO, "IndexBlockDevice is %d\n", IndexBlockDevice));
       PrivateData->CapsuleData[PrivateData->CapsuleCount].IndexBlock = IndexBlockDevice;
       if (BlockIo2) {
         PrivateData->CapsuleData[PrivateData->CapsuleCount].BlockIo2 = BlockIo2Ppi;
@@ -263,7 +263,7 @@ UpdateBlocksAndVolumes (
         PrivateData->CapsuleData[PrivateData->CapsuleCount].BlockIo  = BlockIoPpi;
       }
       Status = FindRecoveryCapsules (PrivateData);
-      DEBUG ((EFI_D_INFO, "Status is %d\n", Status));
+      DEBUG ((DEBUG_INFO, "Status is %d\n", Status));
 
       if (EFI_ERROR (Status)) {
         continue;

--- a/MdeModulePkg/Universal/Disk/DiskIoDxe/DiskIo.c
+++ b/MdeModulePkg/Universal/Disk/DiskIoDxe/DiskIo.c
@@ -492,7 +492,7 @@ DiskIoCreateSubtask (
     }
   }
   DEBUG ((
-    EFI_D_BLKIO,
+    DEBUG_BLKIO,
     "  %c:Lba/Offset/Length/WorkingBuffer/Buffer = %016lx/%08x/%08x/%08x/%08x\n",
     Write ? 'W': 'R', Lba, Offset, Length, WorkingBuffer, Buffer
     ));
@@ -540,7 +540,7 @@ DiskIoCreateSubtaskList (
   VOID                  *WorkingBuffer;
   LIST_ENTRY            *Link;
 
-  DEBUG ((EFI_D_BLKIO, "DiskIo: Create subtasks for task: Offset/BufferSize/Buffer = %016lx/%08x/%08x\n", Offset, BufferSize, Buffer));
+  DEBUG ((DEBUG_BLKIO, "DiskIo: Create subtasks for task: Offset/BufferSize/Buffer = %016lx/%08x/%08x\n", Offset, BufferSize, Buffer));
 
   BlockSize = Instance->BlockIo->Media->BlockSize;
   IoAlign   = Instance->BlockIo->Media->IoAlign;
@@ -668,7 +668,7 @@ DiskIoCreateSubtaskList (
           //
           // If there is not enough memory, downgrade to blocking access
           //
-          DEBUG ((EFI_D_VERBOSE, "DiskIo: No enough memory so downgrade to blocking access\n"));
+          DEBUG ((DEBUG_VERBOSE, "DiskIo: No enough memory so downgrade to blocking access\n"));
           if (!DiskIoCreateSubtaskList (Instance, Write, Offset, BufferSize, BufferPtr, TRUE, SharedWorkingBuffer, Subtasks)) {
             goto Done;
           }
@@ -970,7 +970,7 @@ DiskIo2ReadWriteDisk (
       // Task->Token should be set to NULL by the DiskIo2OnReadWriteComplete
       // It it's not, that means the non-blocking request was downgraded to blocking request.
       //
-      DEBUG ((EFI_D_VERBOSE, "DiskIo: Non-blocking request was downgraded to blocking request, signal event directly.\n"));
+      DEBUG ((DEBUG_VERBOSE, "DiskIo: Non-blocking request was downgraded to blocking request, signal event directly.\n"));
       Task->Token->TransactionStatus = Status;
       gBS->SignalEvent (Task->Token->Event);
     }

--- a/MdeModulePkg/Universal/Disk/PartitionDxe/ElTorito.c
+++ b/MdeModulePkg/Universal/Disk/PartitionDxe/ElTorito.c
@@ -141,7 +141,7 @@ PartitionInstallElToritoChildHandles (
                        Catalog
                        );
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "EltCheckDevice: error reading catalog %r\n", Status));
+      DEBUG ((DEBUG_ERROR, "EltCheckDevice: error reading catalog %r\n", Status));
       continue;
     }
     //
@@ -149,7 +149,7 @@ PartitionInstallElToritoChildHandles (
     // to make sure it looks like a Catalog header
     //
     if (Catalog->Catalog.Indicator != ELTORITO_ID_CATALOG || Catalog->Catalog.Id55AA != 0xAA55) {
-      DEBUG ((EFI_D_ERROR, "EltCheckBootCatalog: El Torito boot catalog header IDs not correct\n"));
+      DEBUG ((DEBUG_ERROR, "EltCheckBootCatalog: El Torito boot catalog header IDs not correct\n"));
       continue;
     }
 
@@ -160,7 +160,7 @@ PartitionInstallElToritoChildHandles (
     }
 
     if ((Check & 0xFFFF) != 0) {
-      DEBUG ((EFI_D_ERROR, "EltCheckBootCatalog: El Torito boot catalog header checksum failed\n"));
+      DEBUG ((DEBUG_ERROR, "EltCheckBootCatalog: El Torito boot catalog header checksum failed\n"));
       continue;
     }
 
@@ -203,7 +203,7 @@ PartitionInstallElToritoChildHandles (
         break;
 
       default:
-        DEBUG ((EFI_D_INIT, "EltCheckDevice: unsupported El Torito boot media type %x\n", Catalog->Boot.MediaType));
+        DEBUG ((DEBUG_INIT, "EltCheckDevice: unsupported El Torito boot media type %x\n", Catalog->Boot.MediaType));
         SectorCount   = 0;
         SubBlockSize  = Media->BlockSize;
         break;

--- a/MdeModulePkg/Universal/Disk/PartitionDxe/Gpt.c
+++ b/MdeModulePkg/Universal/Disk/PartitionDxe/Gpt.c
@@ -225,8 +225,8 @@ PartitionInstallGptChildHandles (
   LastBlock     = BlockIo->Media->LastBlock;
   MediaId       = BlockIo->Media->MediaId;
 
-  DEBUG ((EFI_D_INFO, " BlockSize : %d \n", BlockSize));
-  DEBUG ((EFI_D_INFO, " LastBlock : %lx \n", LastBlock));
+  DEBUG ((DEBUG_INFO, " BlockSize : %d \n", BlockSize));
+  DEBUG ((DEBUG_INFO, " LastBlock : %lx \n", LastBlock));
 
   GptValidStatus = EFI_NOT_FOUND;
 
@@ -291,43 +291,43 @@ PartitionInstallGptChildHandles (
   // Check primary and backup partition tables
   //
   if (!PartitionValidGptTable (BlockIo, DiskIo, PRIMARY_PART_HEADER_LBA, PrimaryHeader)) {
-    DEBUG ((EFI_D_INFO, " Not Valid primary partition table\n"));
+    DEBUG ((DEBUG_INFO, " Not Valid primary partition table\n"));
 
     if (!PartitionValidGptTable (BlockIo, DiskIo, LastBlock, BackupHeader)) {
-      DEBUG ((EFI_D_INFO, " Not Valid backup partition table\n"));
+      DEBUG ((DEBUG_INFO, " Not Valid backup partition table\n"));
       goto Done;
     } else {
-      DEBUG ((EFI_D_INFO, " Valid backup partition table\n"));
-      DEBUG ((EFI_D_INFO, " Restore primary partition table by the backup\n"));
+      DEBUG ((DEBUG_INFO, " Valid backup partition table\n"));
+      DEBUG ((DEBUG_INFO, " Restore primary partition table by the backup\n"));
       if (!PartitionRestoreGptTable (BlockIo, DiskIo, BackupHeader)) {
-        DEBUG ((EFI_D_INFO, " Restore primary partition table error\n"));
+        DEBUG ((DEBUG_INFO, " Restore primary partition table error\n"));
       }
 
       if (PartitionValidGptTable (BlockIo, DiskIo, BackupHeader->AlternateLBA, PrimaryHeader)) {
-        DEBUG ((EFI_D_INFO, " Restore backup partition table success\n"));
+        DEBUG ((DEBUG_INFO, " Restore backup partition table success\n"));
       }
     }
   } else if (!PartitionValidGptTable (BlockIo, DiskIo, PrimaryHeader->AlternateLBA, BackupHeader)) {
-    DEBUG ((EFI_D_INFO, " Valid primary and !Valid backup partition table\n"));
-    DEBUG ((EFI_D_INFO, " Restore backup partition table by the primary\n"));
+    DEBUG ((DEBUG_INFO, " Valid primary and !Valid backup partition table\n"));
+    DEBUG ((DEBUG_INFO, " Restore backup partition table by the primary\n"));
     if (!PartitionRestoreGptTable (BlockIo, DiskIo, PrimaryHeader)) {
-      DEBUG ((EFI_D_INFO, " Restore backup partition table error\n"));
+      DEBUG ((DEBUG_INFO, " Restore backup partition table error\n"));
     }
 
     if (PartitionValidGptTable (BlockIo, DiskIo, PrimaryHeader->AlternateLBA, BackupHeader)) {
-      DEBUG ((EFI_D_INFO, " Restore backup partition table success\n"));
+      DEBUG ((DEBUG_INFO, " Restore backup partition table success\n"));
     }
 
   }
 
-  DEBUG ((EFI_D_INFO, " Valid primary and Valid backup partition table\n"));
+  DEBUG ((DEBUG_INFO, " Valid primary and Valid backup partition table\n"));
 
   //
   // Read the EFI Partition Entries
   //
   PartEntry = AllocatePool (PrimaryHeader->NumberOfPartitionEntries * PrimaryHeader->SizeOfPartitionEntry);
   if (PartEntry == NULL) {
-    DEBUG ((EFI_D_ERROR, "Allocate pool error\n"));
+    DEBUG ((DEBUG_ERROR, "Allocate pool error\n"));
     goto Done;
   }
 
@@ -340,17 +340,17 @@ PartitionInstallGptChildHandles (
                      );
   if (EFI_ERROR (Status)) {
     GptValidStatus = Status;
-    DEBUG ((EFI_D_ERROR, " Partition Entry ReadDisk error\n"));
+    DEBUG ((DEBUG_ERROR, " Partition Entry ReadDisk error\n"));
     goto Done;
   }
 
-  DEBUG ((EFI_D_INFO, " Partition entries read block success\n"));
+  DEBUG ((DEBUG_INFO, " Partition entries read block success\n"));
 
-  DEBUG ((EFI_D_INFO, " Number of partition entries: %d\n", PrimaryHeader->NumberOfPartitionEntries));
+  DEBUG ((DEBUG_INFO, " Number of partition entries: %d\n", PrimaryHeader->NumberOfPartitionEntries));
 
   PEntryStatus = AllocateZeroPool (PrimaryHeader->NumberOfPartitionEntries * sizeof (EFI_PARTITION_ENTRY_STATUS));
   if (PEntryStatus == NULL) {
-    DEBUG ((EFI_D_ERROR, "Allocate pool error\n"));
+    DEBUG ((DEBUG_ERROR, "Allocate pool error\n"));
     goto Done;
   }
 
@@ -401,12 +401,12 @@ PartitionInstallGptChildHandles (
     }
     CopyMem (&PartitionInfo.Info.Gpt, Entry, sizeof (EFI_PARTITION_ENTRY));
 
-    DEBUG ((EFI_D_INFO, " Index : %d\n", (UINT32) Index));
-    DEBUG ((EFI_D_INFO, " Start LBA : %lx\n", (UINT64) HdDev.PartitionStart));
-    DEBUG ((EFI_D_INFO, " End LBA : %lx\n", (UINT64) Entry->EndingLBA));
-    DEBUG ((EFI_D_INFO, " Partition size: %lx\n", (UINT64) HdDev.PartitionSize));
-    DEBUG ((EFI_D_INFO, " Start : %lx", MultU64x32 (Entry->StartingLBA, BlockSize)));
-    DEBUG ((EFI_D_INFO, " End : %lx\n", MultU64x32 (Entry->EndingLBA, BlockSize)));
+    DEBUG ((DEBUG_INFO, " Index : %d\n", (UINT32) Index));
+    DEBUG ((DEBUG_INFO, " Start LBA : %lx\n", (UINT64) HdDev.PartitionStart));
+    DEBUG ((DEBUG_INFO, " End LBA : %lx\n", (UINT64) Entry->EndingLBA));
+    DEBUG ((DEBUG_INFO, " Partition size: %lx\n", (UINT64) HdDev.PartitionSize));
+    DEBUG ((DEBUG_INFO, " Start : %lx", MultU64x32 (Entry->StartingLBA, BlockSize)));
+    DEBUG ((DEBUG_INFO, " End : %lx\n", MultU64x32 (Entry->EndingLBA, BlockSize)));
 
     Status = PartitionInstallChildHandle (
                This,
@@ -425,7 +425,7 @@ PartitionInstallGptChildHandles (
                );
   }
 
-  DEBUG ((EFI_D_INFO, "Prepare to Free Pool\n"));
+  DEBUG ((DEBUG_INFO, "Prepare to Free Pool\n"));
 
 Done:
   if (ProtectiveMbr != NULL) {
@@ -481,7 +481,7 @@ PartitionValidGptTable (
   PartHdr   = AllocateZeroPool (BlockSize);
 
   if (PartHdr == NULL) {
-    DEBUG ((EFI_D_ERROR, "Allocate pool error\n"));
+    DEBUG ((DEBUG_ERROR, "Allocate pool error\n"));
     return FALSE;
   }
   //
@@ -504,7 +504,7 @@ PartitionValidGptTable (
       PartHdr->MyLBA != Lba ||
       (PartHdr->SizeOfPartitionEntry < sizeof (EFI_PARTITION_ENTRY))
       ) {
-    DEBUG ((EFI_D_INFO, "Invalid efi partition table header\n"));
+    DEBUG ((DEBUG_INFO, "Invalid efi partition table header\n"));
     FreePool (PartHdr);
     return FALSE;
   }
@@ -523,7 +523,7 @@ PartitionValidGptTable (
     return FALSE;
   }
 
-  DEBUG ((EFI_D_INFO, " Valid efi partition table header\n"));
+  DEBUG ((DEBUG_INFO, " Valid efi partition table header\n"));
   FreePool (PartHdr);
   return TRUE;
 }
@@ -557,7 +557,7 @@ PartitionCheckGptEntryArrayCRC (
   //
   Ptr = AllocatePool (PartHeader->NumberOfPartitionEntries * PartHeader->SizeOfPartitionEntry);
   if (Ptr == NULL) {
-    DEBUG ((EFI_D_ERROR, " Allocate pool error\n"));
+    DEBUG ((DEBUG_ERROR, " Allocate pool error\n"));
     return FALSE;
   }
 
@@ -577,7 +577,7 @@ PartitionCheckGptEntryArrayCRC (
 
   Status  = gBS->CalculateCrc32 (Ptr, Size, &Crc);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "CheckPEntryArrayCRC: Crc calculation failed\n"));
+    DEBUG ((DEBUG_ERROR, "CheckPEntryArrayCRC: Crc calculation failed\n"));
     FreePool (Ptr);
     return FALSE;
   }
@@ -623,7 +623,7 @@ PartitionRestoreGptTable (
   PartHdr   = AllocateZeroPool (BlockSize);
 
   if (PartHdr == NULL) {
-    DEBUG ((EFI_D_ERROR, "Allocate pool error\n"));
+    DEBUG ((DEBUG_ERROR, "Allocate pool error\n"));
     return FALSE;
   }
 
@@ -651,7 +651,7 @@ PartitionRestoreGptTable (
 
   Ptr = AllocatePool (PartHeader->NumberOfPartitionEntries * PartHeader->SizeOfPartitionEntry);
   if (Ptr == NULL) {
-    DEBUG ((EFI_D_ERROR, " Allocate pool error\n"));
+    DEBUG ((DEBUG_ERROR, " Allocate pool error\n"));
     Status = EFI_OUT_OF_RESOURCES;
     goto Done;
   }
@@ -715,7 +715,7 @@ PartitionCheckGptEntry (
   UINTN                Index1;
   UINTN                Index2;
 
-  DEBUG ((EFI_D_INFO, " start check partition entries\n"));
+  DEBUG ((DEBUG_INFO, " start check partition entries\n"));
   for (Index1 = 0; Index1 < PartHeader->NumberOfPartitionEntries; Index1++) {
     Entry = (EFI_PARTITION_ENTRY *) ((UINT8 *) PartEntry + Index1 * PartHeader->SizeOfPartitionEntry);
     if (CompareGuid (&Entry->PartitionTypeGUID, &gEfiPartTypeUnusedGuid)) {
@@ -758,7 +758,7 @@ PartitionCheckGptEntry (
     }
   }
 
-  DEBUG ((EFI_D_INFO, " End check partition entries\n"));
+  DEBUG ((DEBUG_INFO, " End check partition entries\n"));
 }
 
 
@@ -850,7 +850,7 @@ PartitionCheckCrcAltSize (
   }
 
   if ((MaxSize != 0) && (Size > MaxSize)) {
-    DEBUG ((EFI_D_ERROR, "CheckCrc32: Size > MaxSize\n"));
+    DEBUG ((DEBUG_ERROR, "CheckCrc32: Size > MaxSize\n"));
     return FALSE;
   }
   //
@@ -861,7 +861,7 @@ PartitionCheckCrcAltSize (
 
   Status      = gBS->CalculateCrc32 ((UINT8 *) Hdr, Size, &Crc);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "CheckCrc32: Crc calculation failed\n"));
+    DEBUG ((DEBUG_ERROR, "CheckCrc32: Crc calculation failed\n"));
     return FALSE;
   }
   //
@@ -874,7 +874,7 @@ PartitionCheckCrcAltSize (
   //
   DEBUG_CODE_BEGIN ();
     if (OrgCrc != Crc) {
-      DEBUG ((EFI_D_ERROR, "CheckCrc32: Crc check failed\n"));
+      DEBUG ((DEBUG_ERROR, "CheckCrc32: Crc check failed\n"));
     }
   DEBUG_CODE_END ();
 

--- a/MdeModulePkg/Universal/Disk/PartitionDxe/Mbr.c
+++ b/MdeModulePkg/Universal/Disk/PartitionDxe/Mbr.c
@@ -71,7 +71,7 @@ PartitionValidMbr (
       // with INT 13h
       //
 
-      DEBUG((EFI_D_INFO, "PartitionValidMbr: Bad MBR partition size EndingLBA(%1x) > LastLBA(%1x)\n", EndingLBA, LastLba));
+      DEBUG((DEBUG_INFO, "PartitionValidMbr: Bad MBR partition size EndingLBA(%1x) > LastLBA(%1x)\n", EndingLBA, LastLba));
 
       return FALSE;
     }

--- a/MdeModulePkg/Universal/Disk/PartitionDxe/Partition.c
+++ b/MdeModulePkg/Universal/Disk/PartitionDxe/Partition.c
@@ -417,7 +417,7 @@ PartitionDriverBindingStop (
     // bus driver. Hence, additional check is needed here.
     //
     if (HasChildren (ControllerHandle)) {
-      DEBUG((EFI_D_ERROR, "PartitionDriverBindingStop: Still has child.\n"));
+      DEBUG((DEBUG_ERROR, "PartitionDriverBindingStop: Still has child.\n"));
       return EFI_DEVICE_ERROR;
     }
 
@@ -486,7 +486,7 @@ PartitionDriverBindingStop (
 
     if (BlockIo2 != NULL) {
       Status = BlockIo2->FlushBlocksEx (BlockIo2, NULL);
-      DEBUG((EFI_D_ERROR, "PartitionDriverBindingStop: FlushBlocksEx returned with %r\n", Status));
+      DEBUG((DEBUG_ERROR, "PartitionDriverBindingStop: FlushBlocksEx returned with %r\n", Status));
     } else {
       Status = EFI_SUCCESS;
     }
@@ -1372,4 +1372,3 @@ HasChildren (
 
   return (BOOLEAN) (Index < EntryCount);
 }
-

--- a/MdeModulePkg/Universal/Disk/RamDiskDxe/RamDiskDriver.c
+++ b/MdeModulePkg/Universal/Disk/RamDiskDxe/RamDiskDriver.c
@@ -68,7 +68,7 @@ RamDiskAcpiCheck (
                   );
   if (EFI_ERROR (Status)) {
     DEBUG ((
-      EFI_D_INFO,
+      DEBUG_INFO,
       "RamDiskAcpiCheck: Cannot locate the EFI ACPI Table Protocol, "
       "unable to publish RAM disks to NFIT.\n"
       ));
@@ -85,7 +85,7 @@ RamDiskAcpiCheck (
                   );
   if (EFI_ERROR (Status)) {
     DEBUG ((
-      EFI_D_INFO,
+      DEBUG_INFO,
       "RamDiskAcpiCheck: Cannot locate the EFI ACPI Sdt Protocol, "
       "unable to publish RAM disks to NFIT.\n"
       ));
@@ -134,7 +134,7 @@ RamDiskDxeEntryPoint (
                   &DummyInterface
                   );
   if (!EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_INFO, "Driver already started!\n"));
+    DEBUG ((DEBUG_INFO, "Driver already started!\n"));
     return EFI_ALREADY_STARTED;
   }
 

--- a/MdeModulePkg/Universal/Disk/RamDiskDxe/RamDiskProtocol.c
+++ b/MdeModulePkg/Universal/Disk/RamDiskDxe/RamDiskProtocol.c
@@ -194,7 +194,7 @@ RamDiskPublishNfit (
          >= PrivateData->StartingAddr + PrivateData->Size)) {
       MemoryFound = TRUE;
       DEBUG ((
-        EFI_D_INFO,
+        DEBUG_INFO,
         "RamDiskPublishNfit: RAM disk with reserved memory type, will publish to NFIT.\n"
         ));
       break;
@@ -237,7 +237,7 @@ RamDiskPublishNfit (
     // A NFIT is already in the ACPI table.
     //
     DEBUG ((
-      EFI_D_INFO,
+      DEBUG_INFO,
       "RamDiskPublishNfit: A NFIT is already exist in the ACPI Table.\n"
       ));
 
@@ -300,7 +300,7 @@ RamDiskPublishNfit (
     // No NFIT is in the ACPI table, we will create one here.
     //
     DEBUG ((
-      EFI_D_INFO,
+      DEBUG_INFO,
       "RamDiskPublishNfit: No NFIT is in the ACPI Table, will create one.\n"
       ));
 

--- a/MdeModulePkg/Universal/DriverHealthManagerDxe/DriverHealthManagerDxe.c
+++ b/MdeModulePkg/Universal/DriverHealthManagerDxe/DriverHealthManagerDxe.c
@@ -523,7 +523,7 @@ DriverHealthManagerRepairNotify (
   IN UINTN        Limit
   )
 {
-  DEBUG ((EFI_D_INFO, "[DriverHealthManagement]RepairNotify: %d/%d\n", Value, Limit));
+  DEBUG ((DEBUG_INFO, "[DriverHealthManagement]RepairNotify: %d/%d\n", Value, Limit));
   return EFI_SUCCESS;
 }
 
@@ -958,7 +958,7 @@ DriverHealthManagerCallback (
     return EFI_INVALID_PARAMETER;
   }
 
-  DEBUG ((EFI_D_ERROR, "QuestionId = %x\n", QuestionId));
+  DEBUG ((DEBUG_ERROR, "QuestionId = %x\n", QuestionId));
 
   //
   // We will have returned from processing a callback - user either hit ESC to exit, or selected
@@ -983,5 +983,3 @@ DriverHealthManagerCallback (
 
   return EFI_SUCCESS;
 }
-
-

--- a/MdeModulePkg/Universal/EbcDxe/EbcInt.c
+++ b/MdeModulePkg/Universal/EbcDxe/EbcInt.c
@@ -988,51 +988,51 @@ CommonEbcExceptionHandler (
   // We print debug information to let user know what happen.
   //
   DEBUG ((
-    EFI_D_ERROR,
+    DEBUG_ERROR,
     "EBC Interrupter Version - 0x%016lx\n",
     (UINT64) (((VM_MAJOR_VERSION & 0xFFFF) << 16) | ((VM_MINOR_VERSION & 0xFFFF)))
     ));
   DEBUG ((
-    EFI_D_ERROR,
+    DEBUG_ERROR,
     "Exception Type - 0x%016lx\n",
     (UINT64)(UINTN)InterruptType
     ));
   DEBUG ((
-    EFI_D_ERROR,
+    DEBUG_ERROR,
     "  R0 - 0x%016lx, R1 - 0x%016lx\n",
     SystemContext.SystemContextEbc->R0,
     SystemContext.SystemContextEbc->R1
     ));
   DEBUG ((
-    EFI_D_ERROR,
+    DEBUG_ERROR,
     "  R2 - 0x%016lx, R3 - 0x%016lx\n",
     SystemContext.SystemContextEbc->R2,
     SystemContext.SystemContextEbc->R3
     ));
   DEBUG ((
-    EFI_D_ERROR,
+    DEBUG_ERROR,
     "  R4 - 0x%016lx, R5 - 0x%016lx\n",
     SystemContext.SystemContextEbc->R4,
     SystemContext.SystemContextEbc->R5
     ));
   DEBUG ((
-    EFI_D_ERROR,
+    DEBUG_ERROR,
     "  R6 - 0x%016lx, R7 - 0x%016lx\n",
     SystemContext.SystemContextEbc->R6,
     SystemContext.SystemContextEbc->R7
     ));
   DEBUG ((
-    EFI_D_ERROR,
+    DEBUG_ERROR,
     "  Flags - 0x%016lx\n",
     SystemContext.SystemContextEbc->Flags
     ));
   DEBUG ((
-    EFI_D_ERROR,
+    DEBUG_ERROR,
     "  ControlFlags - 0x%016lx\n",
     SystemContext.SystemContextEbc->ControlFlags
     ));
   DEBUG ((
-    EFI_D_ERROR,
+    DEBUG_ERROR,
     "  Ip - 0x%016lx\n\n",
     SystemContext.SystemContextEbc->Ip
     ));

--- a/MdeModulePkg/Universal/EsrtDxe/EsrtDxe.c
+++ b/MdeModulePkg/Universal/EsrtDxe/EsrtDxe.c
@@ -485,10 +485,10 @@ EsrtDxeLockEsrtRepository(
   Status = gBS->LocateProtocol (&gEdkiiVariableLockProtocolGuid, NULL, (VOID **) &VariableLock);
   if (!EFI_ERROR (Status)) {
     Status = VariableLock->RequestToLock (VariableLock, EFI_ESRT_FMP_VARIABLE_NAME, &gEfiCallerIdGuid);
-    DEBUG((EFI_D_INFO, "EsrtDxe Lock EsrtFmp Variable Status 0x%x", Status));
+    DEBUG((DEBUG_INFO, "EsrtDxe Lock EsrtFmp Variable Status 0x%x", Status));
 
     Status = VariableLock->RequestToLock (VariableLock, EFI_ESRT_NONFMP_VARIABLE_NAME, &gEfiCallerIdGuid);
-    DEBUG((EFI_D_INFO, "EsrtDxe Lock EsrtNonFmp Variable Status 0x%x", Status));
+    DEBUG((DEBUG_INFO, "EsrtDxe Lock EsrtNonFmp Variable Status 0x%x", Status));
   }
 
   return Status;
@@ -539,7 +539,7 @@ EsrtReadyToBootEventNotify (
   }
 
   if (NonFmpRepositorySize % sizeof(EFI_SYSTEM_RESOURCE_ENTRY) != 0) {
-    DEBUG((EFI_D_ERROR, "NonFmp Repository Corrupt. Need to rebuild NonFmp Repository.\n"));
+    DEBUG((DEBUG_ERROR, "NonFmp Repository Corrupt. Need to rebuild NonFmp Repository.\n"));
     NonFmpRepositorySize = 0;
   }
 
@@ -558,7 +558,7 @@ EsrtReadyToBootEventNotify (
   }
 
   if (FmpRepositorySize % sizeof(EFI_SYSTEM_RESOURCE_ENTRY) != 0) {
-    DEBUG((EFI_D_ERROR, "Fmp Repository Corrupt. Need to rebuild Fmp Repository.\n"));
+    DEBUG((DEBUG_ERROR, "Fmp Repository Corrupt. Need to rebuild Fmp Repository.\n"));
     FmpRepositorySize = 0;
   }
 
@@ -573,7 +573,7 @@ EsrtReadyToBootEventNotify (
 
   EsrtTable = AllocatePool(sizeof(EFI_SYSTEM_RESOURCE_TABLE) + NonFmpRepositorySize + FmpRepositorySize);
   if (EsrtTable == NULL) {
-    DEBUG ((EFI_D_ERROR, "Esrt table memory allocation failure\n"));
+    DEBUG ((DEBUG_ERROR, "Esrt table memory allocation failure\n"));
     goto EXIT;
   }
 

--- a/MdeModulePkg/Universal/EsrtDxe/EsrtImpl.c
+++ b/MdeModulePkg/Universal/EsrtDxe/EsrtImpl.c
@@ -56,7 +56,7 @@ GetEsrtEntry (
   }
 
   if (RepositorySize % sizeof(EFI_SYSTEM_RESOURCE_ENTRY) != 0) {
-    DEBUG((EFI_D_ERROR, "Repository Corrupt. Need to rebuild Repository.\n"));
+    DEBUG((DEBUG_ERROR, "Repository Corrupt. Need to rebuild Repository.\n"));
     Status = EFI_ABORTED;
     goto EXIT;
   }
@@ -137,7 +137,7 @@ InsertEsrtEntry(
     // if exist, update Esrt cache repository
     //
     if (RepositorySize % sizeof(EFI_SYSTEM_RESOURCE_ENTRY) != 0) {
-      DEBUG((EFI_D_ERROR, "Repository Corrupt. Need to rebuild Repository.\n"));
+      DEBUG((DEBUG_ERROR, "Repository Corrupt. Need to rebuild Repository.\n"));
       //
       // Repository is corrupt. Clear Repository before insert new entry
       //
@@ -245,7 +245,7 @@ DeleteEsrtEntry(
   }
 
   if ((RepositorySize % sizeof(EFI_SYSTEM_RESOURCE_ENTRY)) != 0) {
-    DEBUG((EFI_D_ERROR, "Repository Corrupt. Need to rebuild Repository.\n"));
+    DEBUG((DEBUG_ERROR, "Repository Corrupt. Need to rebuild Repository.\n"));
     //
     // Repository is corrupt. Clear Repository before insert new entry
     //
@@ -347,7 +347,7 @@ UpdateEsrtEntry(
     // if exist, update Esrt cache repository
     //
     if (RepositorySize % sizeof(EFI_SYSTEM_RESOURCE_ENTRY) != 0) {
-      DEBUG((EFI_D_ERROR, "Repository Corrupt. Need to rebuild Repository.\n"));
+      DEBUG((DEBUG_ERROR, "Repository Corrupt. Need to rebuild Repository.\n"));
       //
       // Repository is corrupt. Clear Repository before insert new entry
       //

--- a/MdeModulePkg/Universal/FaultTolerantWriteDxe/FaultTolerantWrite.c
+++ b/MdeModulePkg/Universal/FaultTolerantWriteDxe/FaultTolerantWrite.c
@@ -89,7 +89,7 @@ FtwAllocate (
   // Check if there is enough space for the coming allocation
   //
   if (FTW_WRITE_TOTAL_SIZE (NumberOfWrites, PrivateDataSize) > FtwDevice->FtwWorkSpaceHeader->WriteQueueSize) {
-    DEBUG ((EFI_D_ERROR, "Ftw: Allocate() request exceed Workspace, Caller: %g\n", CallerId));
+    DEBUG ((DEBUG_ERROR, "Ftw: Allocate() request exceed Workspace, Caller: %g\n", CallerId));
     return EFI_BUFFER_TOO_SMALL;
   }
   //
@@ -153,7 +153,7 @@ FtwAllocate (
   }
 
   DEBUG (
-    (EFI_D_INFO,
+    (DEBUG_INFO,
     "Ftw: Allocate() success, Caller:%g, # %d\n",
     CallerId,
     NumberOfWrites)
@@ -358,8 +358,8 @@ FtwWrite (
       // Ftw Write Header is not allocated
       // Additional private data is not NULL, the private data size can't be determined.
       //
-      DEBUG ((EFI_D_ERROR, "Ftw: no allocates space for write record!\n"));
-      DEBUG ((EFI_D_ERROR, "Ftw: Allocate service should be called before Write service!\n"));
+      DEBUG ((DEBUG_ERROR, "Ftw: no allocates space for write record!\n"));
+      DEBUG ((DEBUG_ERROR, "Ftw: Allocate service should be called before Write service!\n"));
       return EFI_NOT_READY;
     }
   }
@@ -396,7 +396,7 @@ FtwWrite (
 
   Status = Fvb->GetPhysicalAddress (Fvb, &FvbPhysicalAddress);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "Ftw: Write(), Get FVB physical address - %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "Ftw: Write(), Get FVB physical address - %r\n", Status));
     return EFI_ABORTED;
   }
 
@@ -405,12 +405,12 @@ FtwWrite (
   //
   Status = Fvb->GetBlockSize (Fvb, 0, &BlockSize, &NumberOfBlocks);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "Ftw: Write(), Get block size - %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "Ftw: Write(), Get block size - %r\n", Status));
     return EFI_ABORTED;
   }
 
   NumberOfWriteBlocks = FTW_BLOCKS (Offset + Length, BlockSize);
-  DEBUG ((EFI_D_INFO, "Ftw: Write(), BlockSize - 0x%x, NumberOfWriteBlock - 0x%x\n", BlockSize, NumberOfWriteBlocks));
+  DEBUG ((DEBUG_INFO, "Ftw: Write(), BlockSize - 0x%x, NumberOfWriteBlock - 0x%x\n", BlockSize, NumberOfWriteBlocks));
   WriteLength = NumberOfWriteBlocks * BlockSize;
 
   //
@@ -611,7 +611,7 @@ FtwWrite (
   FreePool (SpareBuffer);
 
   DEBUG (
-    (EFI_D_INFO,
+    (DEBUG_INFO,
     "Ftw: Write() success, (Lba:Offset)=(%lx:0x%x), Length: 0x%x\n",
     Lba,
     Offset,
@@ -674,7 +674,7 @@ FtwRestart (
   //
   Status = Fvb->GetBlockSize (Fvb, 0, &BlockSize, &NumberOfBlocks);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "Ftw: Restart(), Get block size - %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "Ftw: Restart(), Get block size - %r\n", Status));
     return EFI_ABORTED;
   }
 
@@ -714,7 +714,7 @@ FtwRestart (
     return EFI_ABORTED;
   }
 
-  DEBUG ((EFI_D_INFO, "%a(): success\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a(): success\n", __FUNCTION__));
   return EFI_SUCCESS;
 }
 
@@ -769,7 +769,7 @@ FtwAbort (
 
   FtwDevice->FtwLastWriteHeader->Complete = FTW_VALID_STATE;
 
-  DEBUG ((EFI_D_INFO, "%a(): success\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a(): success\n", __FUNCTION__));
   return EFI_SUCCESS;
 }
 
@@ -880,8 +880,7 @@ FtwGetLastWrite (
     Status = EFI_SUCCESS;
   }
 
-  DEBUG ((EFI_D_INFO, "%a(): success\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a(): success\n", __FUNCTION__));
 
   return Status;
 }
-

--- a/MdeModulePkg/Universal/FaultTolerantWriteDxe/FaultTolerantWriteSmm.c
+++ b/MdeModulePkg/Universal/FaultTolerantWriteDxe/FaultTolerantWriteSmm.c
@@ -324,13 +324,13 @@ SmmFaultTolerantWriteHandler (
   TempCommBufferSize = *CommBufferSize;
 
   if (TempCommBufferSize < SMM_FTW_COMMUNICATE_HEADER_SIZE) {
-    DEBUG ((EFI_D_ERROR, "SmmFtwHandler: SMM communication buffer size invalid!\n"));
+    DEBUG ((DEBUG_ERROR, "SmmFtwHandler: SMM communication buffer size invalid!\n"));
     return EFI_SUCCESS;
   }
   CommBufferPayloadSize = TempCommBufferSize - SMM_FTW_COMMUNICATE_HEADER_SIZE;
 
   if (!FtwSmmIsBufferOutsideSmmValid ((UINTN)CommBuffer, TempCommBufferSize)) {
-    DEBUG ((EFI_D_ERROR, "SmmFtwHandler: SMM communication buffer in SMRAM or overflow!\n"));
+    DEBUG ((DEBUG_ERROR, "SmmFtwHandler: SMM communication buffer in SMRAM or overflow!\n"));
     return EFI_SUCCESS;
   }
 
@@ -340,7 +340,7 @@ SmmFaultTolerantWriteHandler (
     //
     // It will be not safe to expose the operations after End Of Dxe.
     //
-    DEBUG ((EFI_D_ERROR, "SmmFtwHandler: Not safe to do the operation: %x after End Of Dxe, so access denied!\n", SmmFtwFunctionHeader->Function));
+    DEBUG ((DEBUG_ERROR, "SmmFtwHandler: Not safe to do the operation: %x after End Of Dxe, so access denied!\n", SmmFtwFunctionHeader->Function));
     SmmFtwFunctionHeader->ReturnStatus = EFI_ACCESS_DENIED;
     return EFI_SUCCESS;
   }
@@ -348,7 +348,7 @@ SmmFaultTolerantWriteHandler (
   switch (SmmFtwFunctionHeader->Function) {
     case FTW_FUNCTION_GET_MAX_BLOCK_SIZE:
       if (CommBufferPayloadSize < sizeof (SMM_FTW_GET_MAX_BLOCK_SIZE_HEADER)) {
-        DEBUG ((EFI_D_ERROR, "GetMaxBlockSize: SMM communication buffer size invalid!\n"));
+        DEBUG ((DEBUG_ERROR, "GetMaxBlockSize: SMM communication buffer size invalid!\n"));
         return EFI_SUCCESS;
       }
       SmmGetMaxBlockSizeHeader = (SMM_FTW_GET_MAX_BLOCK_SIZE_HEADER *) SmmFtwFunctionHeader->Data;
@@ -361,7 +361,7 @@ SmmFaultTolerantWriteHandler (
 
     case FTW_FUNCTION_ALLOCATE:
       if (CommBufferPayloadSize < sizeof (SMM_FTW_ALLOCATE_HEADER)) {
-        DEBUG ((EFI_D_ERROR, "Allocate: SMM communication buffer size invalid!\n"));
+        DEBUG ((DEBUG_ERROR, "Allocate: SMM communication buffer size invalid!\n"));
         return EFI_SUCCESS;
       }
       SmmFtwAllocateHeader = (SMM_FTW_ALLOCATE_HEADER *) SmmFtwFunctionHeader->Data;
@@ -375,7 +375,7 @@ SmmFaultTolerantWriteHandler (
 
     case FTW_FUNCTION_WRITE:
       if (CommBufferPayloadSize < OFFSET_OF (SMM_FTW_WRITE_HEADER, Data)) {
-        DEBUG ((EFI_D_ERROR, "Write: SMM communication buffer size invalid!\n"));
+        DEBUG ((DEBUG_ERROR, "Write: SMM communication buffer size invalid!\n"));
         return EFI_SUCCESS;
       }
       SmmFtwWriteHeader = (SMM_FTW_WRITE_HEADER *) SmmFtwFunctionHeader->Data;
@@ -395,7 +395,7 @@ SmmFaultTolerantWriteHandler (
       // SMRAM range check already covered before
       //
       if (InfoSize > CommBufferPayloadSize) {
-        DEBUG ((EFI_D_ERROR, "Write: Data size exceed communication buffer size limit!\n"));
+        DEBUG ((DEBUG_ERROR, "Write: Data size exceed communication buffer size limit!\n"));
         Status = EFI_ACCESS_DENIED;
         break;
       }
@@ -431,7 +431,7 @@ SmmFaultTolerantWriteHandler (
 
     case FTW_FUNCTION_RESTART:
       if (CommBufferPayloadSize < sizeof (SMM_FTW_RESTART_HEADER)) {
-        DEBUG ((EFI_D_ERROR, "Restart: SMM communication buffer size invalid!\n"));
+        DEBUG ((DEBUG_ERROR, "Restart: SMM communication buffer size invalid!\n"));
         return EFI_SUCCESS;
       }
       SmmFtwRestartHeader = (SMM_FTW_RESTART_HEADER *) SmmFtwFunctionHeader->Data;
@@ -451,7 +451,7 @@ SmmFaultTolerantWriteHandler (
 
     case FTW_FUNCTION_GET_LAST_WRITE:
       if (CommBufferPayloadSize < OFFSET_OF (SMM_FTW_GET_LAST_WRITE_HEADER, Data)) {
-        DEBUG ((EFI_D_ERROR, "GetLastWrite: SMM communication buffer size invalid!\n"));
+        DEBUG ((DEBUG_ERROR, "GetLastWrite: SMM communication buffer size invalid!\n"));
         return EFI_SUCCESS;
       }
       SmmFtwGetLastWriteHeader = (SMM_FTW_GET_LAST_WRITE_HEADER *) SmmFtwFunctionHeader->Data;
@@ -469,7 +469,7 @@ SmmFaultTolerantWriteHandler (
       // SMRAM range check already covered before
       //
       if (InfoSize > CommBufferPayloadSize) {
-        DEBUG ((EFI_D_ERROR, "Data size exceed communication buffer size limit!\n"));
+        DEBUG ((DEBUG_ERROR, "Data size exceed communication buffer size limit!\n"));
         Status = EFI_ACCESS_DENIED;
         break;
       }

--- a/MdeModulePkg/Universal/FaultTolerantWriteDxe/FtwMisc.c
+++ b/MdeModulePkg/Universal/FaultTolerantWriteDxe/FtwMisc.c
@@ -340,7 +340,7 @@ FlushSpareBlockToBootBlock (
   //
   Status = SarProtocol->GetSwapState (SarProtocol, &TopSwap);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "Ftw: Get Top Swapped status - %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "Ftw: Get Top Swapped status - %r\n", Status));
     FreePool (Buffer);
     return EFI_ABORTED;
   }
@@ -427,7 +427,7 @@ FlushSpareBlockToBootBlock (
                                         Ptr
                                         );
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "Ftw: FVB Write boot block - %r\n", Status));
+      DEBUG ((DEBUG_ERROR, "Ftw: FVB Write boot block - %r\n", Status));
       FreePool (Buffer);
       return Status;
     }
@@ -526,7 +526,7 @@ FlushSpareBlockToTargetBlock (
     Count   = BlockSize;
     Status  = FvBlock->Write (FvBlock, Lba + Index, 0, &Count, Ptr);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "Ftw: FVB Write block - %r\n", Status));
+      DEBUG ((DEBUG_ERROR, "Ftw: FVB Write block - %r\n", Status));
       FreePool (Buffer);
       return Status;
     }
@@ -667,7 +667,7 @@ FlushSpareBlockToWorkingBlock (
                                       Ptr
                                       );
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "Ftw: FVB Write block - %r\n", Status));
+      DEBUG ((DEBUG_ERROR, "Ftw: FVB Write block - %r\n", Status));
       FreePool (Buffer);
       return Status;
     }
@@ -984,7 +984,7 @@ InitFtwDevice (
   FtwDevice->WorkSpaceLength  = (UINTN) PcdGet32 (PcdFlashNvStorageFtwWorkingSize);
   FtwDevice->SpareAreaLength  = (UINTN) PcdGet32 (PcdFlashNvStorageFtwSpareSize);
   if ((FtwDevice->WorkSpaceLength == 0) || (FtwDevice->SpareAreaLength == 0)) {
-    DEBUG ((EFI_D_ERROR, "Ftw: Workspace or Spare block does not exist!\n"));
+    DEBUG ((DEBUG_ERROR, "Ftw: Workspace or Spare block does not exist!\n"));
     FreePool (FtwDevice);
     return EFI_INVALID_PARAMETER;
   }
@@ -1103,13 +1103,13 @@ FindFvbForFtw (
             //
             if (((FtwDevice->WorkSpaceAddress & (FtwDevice->WorkBlockSize - 1)) != 0) ||
                 ((FtwDevice->WorkSpaceLength & (FtwDevice->WorkBlockSize - 1)) != 0)) {
-              DEBUG ((EFI_D_ERROR, "Ftw: Work space address or length is not block size aligned when work space size is larger than one block size\n"));
+              DEBUG ((DEBUG_ERROR, "Ftw: Work space address or length is not block size aligned when work space size is larger than one block size\n"));
               FreePool (HandleBuffer);
               ASSERT (FALSE);
               return EFI_ABORTED;
             }
           } else if ((FtwDevice->FtwWorkSpaceBase + FtwDevice->FtwWorkSpaceSize) > FtwDevice->WorkBlockSize) {
-            DEBUG ((EFI_D_ERROR, "Ftw: The work space range should not span blocks when work space size is less than one block size\n"));
+            DEBUG ((DEBUG_ERROR, "Ftw: The work space range should not span blocks when work space size is less than one block size\n"));
             FreePool (HandleBuffer);
             ASSERT (FALSE);
             return EFI_ABORTED;
@@ -1138,7 +1138,7 @@ FindFvbForFtw (
           // Check the range of spare area to make sure that it's in FV range
           //
           if ((FtwDevice->FtwSpareLba + FtwDevice->NumberOfSpareBlock) > NumberOfBlocks) {
-            DEBUG ((EFI_D_ERROR, "Ftw: Spare area is out of FV range\n"));
+            DEBUG ((DEBUG_ERROR, "Ftw: Spare area is out of FV range\n"));
             FreePool (HandleBuffer);
             ASSERT (FALSE);
             return EFI_ABORTED;
@@ -1148,7 +1148,7 @@ FindFvbForFtw (
           //
           if (((FtwDevice->SpareAreaAddress & (FtwDevice->SpareBlockSize - 1)) != 0) ||
               ((FtwDevice->SpareAreaLength & (FtwDevice->SpareBlockSize - 1)) != 0)) {
-            DEBUG ((EFI_D_ERROR, "Ftw: Spare area address or length is not block size aligned\n"));
+            DEBUG ((DEBUG_ERROR, "Ftw: Spare area address or length is not block size aligned\n"));
             FreePool (HandleBuffer);
             //
             // Report Status Code EFI_SW_EC_ABORTED.
@@ -1168,8 +1168,8 @@ FindFvbForFtw (
     (FtwDevice->FtwWorkSpaceLba == (EFI_LBA) (-1)) || (FtwDevice->FtwSpareLba == (EFI_LBA) (-1))) {
     return EFI_ABORTED;
   }
-  DEBUG ((EFI_D_INFO, "Ftw: FtwWorkSpaceLba - 0x%lx, WorkBlockSize  - 0x%x, FtwWorkSpaceBase - 0x%x\n", FtwDevice->FtwWorkSpaceLba, FtwDevice->WorkBlockSize, FtwDevice->FtwWorkSpaceBase));
-  DEBUG ((EFI_D_INFO, "Ftw: FtwSpareLba     - 0x%lx, SpareBlockSize - 0x%x\n", FtwDevice->FtwSpareLba, FtwDevice->SpareBlockSize));
+  DEBUG ((DEBUG_INFO, "Ftw: FtwWorkSpaceLba - 0x%lx, WorkBlockSize  - 0x%x, FtwWorkSpaceBase - 0x%x\n", FtwDevice->FtwWorkSpaceLba, FtwDevice->WorkBlockSize, FtwDevice->FtwWorkSpaceBase));
+  DEBUG ((DEBUG_INFO, "Ftw: FtwSpareLba     - 0x%lx, SpareBlockSize - 0x%x\n", FtwDevice->FtwSpareLba, FtwDevice->SpareBlockSize));
 
   return EFI_SUCCESS;
 }
@@ -1225,7 +1225,7 @@ InitFtwProtocol (
     }
   }
   FtwDevice->FtwWorkBlockLba = FtwDevice->FtwWorkSpaceLba + FtwDevice->NumberOfWorkSpaceBlock - FtwDevice->NumberOfWorkBlock;
-  DEBUG ((EFI_D_INFO, "Ftw: NumberOfWorkBlock - 0x%x, FtwWorkBlockLba - 0x%lx\n", FtwDevice->NumberOfWorkBlock, FtwDevice->FtwWorkBlockLba));
+  DEBUG ((DEBUG_INFO, "Ftw: NumberOfWorkBlock - 0x%x, FtwWorkBlockLba - 0x%lx\n", FtwDevice->NumberOfWorkBlock, FtwDevice->FtwWorkBlockLba));
 
   //
   // Calcualte the LBA and base of work space in spare block.
@@ -1234,7 +1234,7 @@ InitFtwProtocol (
   WorkSpaceLbaOffset = FtwDevice->FtwWorkSpaceLba - FtwDevice->FtwWorkBlockLba;
   FtwDevice->FtwWorkSpaceLbaInSpare = (EFI_LBA) (((UINTN) WorkSpaceLbaOffset * FtwDevice->WorkBlockSize + FtwDevice->FtwWorkSpaceBase) / FtwDevice->SpareBlockSize);
   FtwDevice->FtwWorkSpaceBaseInSpare = ((UINTN) WorkSpaceLbaOffset * FtwDevice->WorkBlockSize + FtwDevice->FtwWorkSpaceBase) % FtwDevice->SpareBlockSize;
-  DEBUG ((EFI_D_INFO, "Ftw: WorkSpaceLbaInSpare - 0x%lx, WorkSpaceBaseInSpare - 0x%x\n", FtwDevice->FtwWorkSpaceLbaInSpare, FtwDevice->FtwWorkSpaceBaseInSpare));
+  DEBUG ((DEBUG_INFO, "Ftw: WorkSpaceLbaInSpare - 0x%lx, WorkSpaceBaseInSpare - 0x%x\n", FtwDevice->FtwWorkSpaceLbaInSpare, FtwDevice->FtwWorkSpaceBaseInSpare));
 
   //
   // Initialize other parameters, and set WorkSpace as FTW_ERASED_BYTE.
@@ -1274,7 +1274,7 @@ InitFtwProtocol (
     //
     if (IsValidWorkSpace (FtwDevice->FtwWorkSpaceHeader)) {
       Status = FlushSpareBlockToWorkingBlock (FtwDevice);
-      DEBUG ((EFI_D_INFO, "Ftw: Restart working block update in %a() - %r\n",
+      DEBUG ((DEBUG_INFO, "Ftw: Restart working block update in %a() - %r\n",
         __FUNCTION__, Status));
       FtwAbort (&FtwDevice->FtwInstance);
       //
@@ -1283,7 +1283,7 @@ InitFtwProtocol (
       Status = WorkSpaceRefresh (FtwDevice);
       ASSERT_EFI_ERROR (Status);
     } else {
-      DEBUG ((EFI_D_INFO,
+      DEBUG ((DEBUG_INFO,
         "Ftw: Both working and spare blocks are invalid, init workspace\n"));
       //
       // If both are invalid, then initialize work space.
@@ -1309,7 +1309,7 @@ InitFtwProtocol (
     (FtwDevice->FtwLastWriteRecord->SpareComplete != FTW_VALID_STATE) &&
     IsFirstRecordOfWrites (FtwDevice->FtwLastWriteHeader, FtwDevice->FtwLastWriteRecord)
     ) {
-    DEBUG ((EFI_D_ERROR, "Ftw: Init.. find first record not SpareCompleted, abort()\n"));
+    DEBUG ((DEBUG_ERROR, "Ftw: Init.. find first record not SpareCompleted, abort()\n"));
     FtwAbort (&FtwDevice->FtwInstance);
   }
   //
@@ -1320,7 +1320,7 @@ InitFtwProtocol (
     (FtwDevice->FtwLastWriteRecord->DestinationComplete == FTW_VALID_STATE) &&
     IsLastRecordOfWrites (FtwDevice->FtwLastWriteHeader, FtwDevice->FtwLastWriteRecord)
     ) {
-    DEBUG ((EFI_D_ERROR, "Ftw: Init.. find last record completed but header not, abort()\n"));
+    DEBUG ((DEBUG_ERROR, "Ftw: Init.. find last record completed but header not, abort()\n"));
     FtwAbort (&FtwDevice->FtwInstance);
   }
   //
@@ -1346,7 +1346,7 @@ InitFtwProtocol (
     ) {
     if (FtwDevice->FtwLastWriteRecord->BootBlockUpdate == FTW_VALID_STATE) {
       Status = FlushSpareBlockToBootBlock (FtwDevice);
-      DEBUG ((EFI_D_ERROR, "Ftw: Restart boot block update - %r\n", Status));
+      DEBUG ((DEBUG_ERROR, "Ftw: Restart boot block update - %r\n", Status));
       ASSERT_EFI_ERROR (Status);
       FtwAbort (&FtwDevice->FtwInstance);
     } else {
@@ -1357,7 +1357,7 @@ InitFtwProtocol (
       FvbHandle = GetFvbByAddress ((EFI_PHYSICAL_ADDRESS) (UINTN) ((INT64) FtwDevice->SpareAreaAddress + FtwDevice->FtwLastWriteRecord->RelativeOffset), &Fvb);
       if (FvbHandle != NULL) {
         Status = FtwRestart (&FtwDevice->FtwInstance, FvbHandle);
-        DEBUG ((EFI_D_ERROR, "Ftw: Restart last write - %r\n", Status));
+        DEBUG ((DEBUG_ERROR, "Ftw: Restart last write - %r\n", Status));
         ASSERT_EFI_ERROR (Status);
       }
       FtwAbort (&FtwDevice->FtwInstance);
@@ -1375,4 +1375,3 @@ InitFtwProtocol (
 
   return EFI_SUCCESS;
 }
-

--- a/MdeModulePkg/Universal/FaultTolerantWriteDxe/UpdateWorkingBlock.c
+++ b/MdeModulePkg/Universal/FaultTolerantWriteDxe/UpdateWorkingBlock.c
@@ -86,7 +86,7 @@ IsValidWorkSpace (
     return TRUE;
   }
 
-  DEBUG ((EFI_D_INFO, "Ftw: Work block header check mismatch\n"));
+  DEBUG ((DEBUG_INFO, "Ftw: Work block header check mismatch\n"));
   return FALSE;
 }
 
@@ -287,7 +287,7 @@ WorkSpaceRefresh (
             &FtwDevice->FtwLastWriteHeader
             );
   RemainingSpaceSize = FtwDevice->FtwWorkSpaceSize - ((UINTN) FtwDevice->FtwLastWriteHeader - (UINTN) FtwDevice->FtwWorkSpace);
-  DEBUG ((EFI_D_INFO, "Ftw: Remaining work space size - %x\n", RemainingSpaceSize));
+  DEBUG ((DEBUG_INFO, "Ftw: Remaining work space size - %x\n", RemainingSpaceSize));
   //
   // If FtwGetLastWriteHeader() returns error, or the remaining space size is even not enough to contain
   // one EFI_FAULT_TOLERANT_WRITE_HEADER + one EFI_FAULT_TOLERANT_WRITE_RECORD(It will cause that the header
@@ -300,7 +300,7 @@ WorkSpaceRefresh (
     //
     Status = FtwReclaimWorkSpace (FtwDevice, TRUE);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "Ftw: Reclaim workspace - %r\n", Status));
+      DEBUG ((DEBUG_ERROR, "Ftw: Reclaim workspace - %r\n", Status));
       return EFI_ABORTED;
     }
     //
@@ -370,7 +370,7 @@ FtwReclaimWorkSpace (
   UINT8                                   *Ptr;
   EFI_LBA                                 WorkSpaceLbaOffset;
 
-  DEBUG ((EFI_D_INFO, "Ftw: start to reclaim work space\n"));
+  DEBUG ((DEBUG_INFO, "Ftw: start to reclaim work space\n"));
 
   WorkSpaceLbaOffset = FtwDevice->FtwWorkSpaceLba - FtwDevice->FtwWorkBlockLba;
 
@@ -601,7 +601,7 @@ FtwReclaimWorkSpace (
 
   FreePool (SpareBuffer);
 
-  DEBUG ((EFI_D_INFO, "Ftw: reclaim work space successfully\n"));
+  DEBUG ((DEBUG_INFO, "Ftw: reclaim work space successfully\n"));
 
   return EFI_SUCCESS;
 }

--- a/MdeModulePkg/Universal/FaultTolerantWritePei/FaultTolerantWritePei.c
+++ b/MdeModulePkg/Universal/FaultTolerantWritePei/FaultTolerantWritePei.c
@@ -152,12 +152,12 @@ IsValidWorkSpace (
   }
 
   if ((WorkingHeader->WorkingBlockValid != FTW_VALID_STATE) || (WorkingHeader->WorkingBlockInvalid == FTW_VALID_STATE)) {
-    DEBUG ((EFI_D_ERROR, "FtwPei: Work block header valid bit check error\n"));
+    DEBUG ((DEBUG_ERROR, "FtwPei: Work block header valid bit check error\n"));
     return FALSE;
   }
 
   if (WorkingHeader->WriteQueueSize != (WorkingLength - sizeof (EFI_FAULT_TOLERANT_WORKING_BLOCK_HEADER))) {
-    DEBUG ((EFI_D_ERROR, "FtwPei: Work block header WriteQueueSize check error\n"));
+    DEBUG ((DEBUG_ERROR, "FtwPei: Work block header WriteQueueSize check error\n"));
     return FALSE;
   }
 
@@ -165,7 +165,7 @@ IsValidWorkSpace (
   // Check signature with gEdkiiWorkingBlockSignatureGuid
   //
   if (!CompareGuid (&gEdkiiWorkingBlockSignatureGuid, &WorkingHeader->Signature)) {
-    DEBUG ((EFI_D_ERROR, "FtwPei: Work block header signature check error, it should be gEdkiiWorkingBlockSignatureGuid\n"));
+    DEBUG ((DEBUG_ERROR, "FtwPei: Work block header signature check error, it should be gEdkiiWorkingBlockSignatureGuid\n"));
     //
     // To be compatible with old signature gEfiSystemNvDataFvGuid.
     //
@@ -174,7 +174,7 @@ IsValidWorkSpace (
     } else {
       Data = *(UINT8 *) (WorkingHeader + 1);
       if (Data != 0xff) {
-        DEBUG ((EFI_D_ERROR, "FtwPei: Old format FTW structure can't be handled\n"));
+        DEBUG ((DEBUG_ERROR, "FtwPei: Old format FTW structure can't be handled\n"));
         ASSERT (FALSE);
         return FALSE;
       }
@@ -261,7 +261,7 @@ PeimFaultTolerantWriteInitialize (
         FtwLastWrite.SpareAddress = SpareAreaAddress;
         FtwLastWrite.Length = SpareAreaLength;
         DEBUG ((
-          EFI_D_INFO,
+          DEBUG_INFO,
           "FtwPei last write data: TargetAddress - 0x%x SpareAddress - 0x%x Length - 0x%x\n",
           (UINTN) FtwLastWrite.TargetAddress,
           (UINTN) FtwLastWrite.SpareAddress,
@@ -280,7 +280,7 @@ PeimFaultTolerantWriteInitialize (
         //
         // Found the workspace.
         //
-        DEBUG ((EFI_D_INFO, "FtwPei: workspace in spare block is at 0x%x.\n", (UINTN) WorkSpaceInSpareArea));
+        DEBUG ((DEBUG_INFO, "FtwPei: workspace in spare block is at 0x%x.\n", (UINTN) WorkSpaceInSpareArea));
         FtwWorkingBlockHeader = (EFI_FAULT_TOLERANT_WORKING_BLOCK_HEADER *) (UINTN) WorkSpaceInSpareArea;
         break;
       }
@@ -294,7 +294,7 @@ PeimFaultTolerantWriteInitialize (
       FtwLastWrite.SpareAddress = SpareAreaAddress;
       FtwLastWrite.Length = SpareAreaLength;
       DEBUG ((
-        EFI_D_INFO,
+        DEBUG_INFO,
         "FtwPei last write data: TargetAddress - 0x%x SpareAddress - 0x%x Length - 0x%x\n",
         (UINTN) FtwLastWrite.TargetAddress,
         (UINTN) FtwLastWrite.SpareAddress,
@@ -304,7 +304,7 @@ PeimFaultTolerantWriteInitialize (
       //
       // Both are invalid.
       //
-      DEBUG ((EFI_D_ERROR, "FtwPei: Both working and spare block are invalid.\n"));
+      DEBUG ((DEBUG_ERROR, "FtwPei: Both working and spare block are invalid.\n"));
     }
   }
 

--- a/MdeModulePkg/Universal/HiiDatabaseDxe/ConfigKeywordHandler.c
+++ b/MdeModulePkg/Universal/HiiDatabaseDxe/ConfigKeywordHandler.c
@@ -2046,7 +2046,7 @@ ExtractConfigRequest (
       // Header->VarStoreId == 0 means no storage for this question.
       //
       ASSERT (Header->VarStoreId != 0);
-      DEBUG ((EFI_D_INFO, "Varstore Id: 0x%x\n", Header->VarStoreId));
+      DEBUG ((DEBUG_INFO, "Varstore Id: 0x%x\n", Header->VarStoreId));
 
       Storage = FindStorageFromVarId (FormPackage, Header->VarStoreId);
       ASSERT (Storage != NULL);
@@ -2149,7 +2149,7 @@ ExtractConfigResp (
       // Header->VarStoreId == 0 means no storage for this question.
       //
       ASSERT (Header->VarStoreId != 0);
-      DEBUG ((EFI_D_INFO, "Varstore Id: 0x%x\n", Header->VarStoreId));
+      DEBUG ((DEBUG_INFO, "Varstore Id: 0x%x\n", Header->VarStoreId));
 
       Storage = FindStorageFromVarId (FormPackage, Header->VarStoreId);
       ASSERT (Storage != NULL);

--- a/MdeModulePkg/Universal/LockBox/SmmLockBox/SmmLockBox.c
+++ b/MdeModulePkg/Universal/LockBox/SmmLockBox/SmmLockBox.c
@@ -54,7 +54,7 @@ SmmLockBoxSave (
   // Sanity check
   //
   if (mLocked) {
-    DEBUG ((EFI_D_ERROR, "SmmLockBox Locked!\n"));
+    DEBUG ((DEBUG_ERROR, "SmmLockBox Locked!\n"));
     LockBoxParameterSave->Header.ReturnStatus = (UINT64)EFI_ACCESS_DENIED;
     return ;
   }
@@ -65,7 +65,7 @@ SmmLockBoxSave (
   // Sanity check
   //
   if (!SmmIsBufferOutsideSmmValid ((UINTN)TempLockBoxParameterSave.Buffer, (UINTN)TempLockBoxParameterSave.Length)) {
-    DEBUG ((EFI_D_ERROR, "SmmLockBox Save address in SMRAM or buffer overflow!\n"));
+    DEBUG ((DEBUG_ERROR, "SmmLockBox Save address in SMRAM or buffer overflow!\n"));
     LockBoxParameterSave->Header.ReturnStatus = (UINT64)EFI_ACCESS_DENIED;
     return ;
   }
@@ -104,7 +104,7 @@ SmmLockBoxSetAttributes (
   // Sanity check
   //
   if (mLocked) {
-    DEBUG ((EFI_D_ERROR, "SmmLockBox Locked!\n"));
+    DEBUG ((DEBUG_ERROR, "SmmLockBox Locked!\n"));
     LockBoxParameterSetAttributes->Header.ReturnStatus = (UINT64)EFI_ACCESS_DENIED;
     return ;
   }
@@ -143,7 +143,7 @@ SmmLockBoxUpdate (
   // Sanity check
   //
   if (mLocked) {
-    DEBUG ((EFI_D_ERROR, "SmmLockBox Locked!\n"));
+    DEBUG ((DEBUG_ERROR, "SmmLockBox Locked!\n"));
     LockBoxParameterUpdate->Header.ReturnStatus = (UINT64)EFI_ACCESS_DENIED;
     return ;
   }
@@ -154,7 +154,7 @@ SmmLockBoxUpdate (
   // Sanity check
   //
   if (!SmmIsBufferOutsideSmmValid ((UINTN)TempLockBoxParameterUpdate.Buffer, (UINTN)TempLockBoxParameterUpdate.Length)) {
-    DEBUG ((EFI_D_ERROR, "SmmLockBox Update address in SMRAM or buffer overflow!\n"));
+    DEBUG ((DEBUG_ERROR, "SmmLockBox Update address in SMRAM or buffer overflow!\n"));
     LockBoxParameterUpdate->Header.ReturnStatus = (UINT64)EFI_ACCESS_DENIED;
     return ;
   }
@@ -200,7 +200,7 @@ SmmLockBoxRestore (
   // Sanity check
   //
   if (!SmmIsBufferOutsideSmmValid ((UINTN)TempLockBoxParameterRestore.Buffer, (UINTN)TempLockBoxParameterRestore.Length)) {
-    DEBUG ((EFI_D_ERROR, "SmmLockBox Restore address in SMRAM or buffer overflow!\n"));
+    DEBUG ((DEBUG_ERROR, "SmmLockBox Restore address in SMRAM or buffer overflow!\n"));
     LockBoxParameterRestore->Header.ReturnStatus = (UINT64)EFI_ACCESS_DENIED;
     return ;
   }
@@ -291,11 +291,11 @@ SmmLockBoxHandler (
   // Sanity check
   //
   if (TempCommBufferSize < sizeof(EFI_SMM_LOCK_BOX_PARAMETER_HEADER)) {
-    DEBUG ((EFI_D_ERROR, "SmmLockBox Command Buffer Size invalid!\n"));
+    DEBUG ((DEBUG_ERROR, "SmmLockBox Command Buffer Size invalid!\n"));
     return EFI_SUCCESS;
   }
   if (!SmmIsBufferOutsideSmmValid ((UINTN)CommBuffer, TempCommBufferSize)) {
-    DEBUG ((EFI_D_ERROR, "SmmLockBox Command Buffer in SMRAM or overflow!\n"));
+    DEBUG ((DEBUG_ERROR, "SmmLockBox Command Buffer in SMRAM or overflow!\n"));
     return EFI_SUCCESS;
   }
 
@@ -310,41 +310,41 @@ SmmLockBoxHandler (
   switch (LockBoxParameterHeader->Command) {
   case EFI_SMM_LOCK_BOX_COMMAND_SAVE:
     if (TempCommBufferSize < sizeof(EFI_SMM_LOCK_BOX_PARAMETER_SAVE)) {
-      DEBUG ((EFI_D_ERROR, "SmmLockBox Command Buffer Size for SAVE invalid!\n"));
+      DEBUG ((DEBUG_ERROR, "SmmLockBox Command Buffer Size for SAVE invalid!\n"));
       break;
     }
     SmmLockBoxSave ((EFI_SMM_LOCK_BOX_PARAMETER_SAVE *)(UINTN)LockBoxParameterHeader);
     break;
   case EFI_SMM_LOCK_BOX_COMMAND_UPDATE:
     if (TempCommBufferSize < sizeof(EFI_SMM_LOCK_BOX_PARAMETER_UPDATE)) {
-      DEBUG ((EFI_D_ERROR, "SmmLockBox Command Buffer Size for UPDATE invalid!\n"));
+      DEBUG ((DEBUG_ERROR, "SmmLockBox Command Buffer Size for UPDATE invalid!\n"));
       break;
     }
     SmmLockBoxUpdate ((EFI_SMM_LOCK_BOX_PARAMETER_UPDATE *)(UINTN)LockBoxParameterHeader);
     break;
   case EFI_SMM_LOCK_BOX_COMMAND_RESTORE:
     if (TempCommBufferSize < sizeof(EFI_SMM_LOCK_BOX_PARAMETER_RESTORE)) {
-      DEBUG ((EFI_D_ERROR, "SmmLockBox Command Buffer Size for RESTORE invalid!\n"));
+      DEBUG ((DEBUG_ERROR, "SmmLockBox Command Buffer Size for RESTORE invalid!\n"));
       break;
     }
     SmmLockBoxRestore ((EFI_SMM_LOCK_BOX_PARAMETER_RESTORE *)(UINTN)LockBoxParameterHeader);
     break;
   case EFI_SMM_LOCK_BOX_COMMAND_SET_ATTRIBUTES:
     if (TempCommBufferSize < sizeof(EFI_SMM_LOCK_BOX_PARAMETER_SET_ATTRIBUTES)) {
-      DEBUG ((EFI_D_ERROR, "SmmLockBox Command Buffer Size for SET_ATTRIBUTES invalid!\n"));
+      DEBUG ((DEBUG_ERROR, "SmmLockBox Command Buffer Size for SET_ATTRIBUTES invalid!\n"));
       break;
     }
     SmmLockBoxSetAttributes ((EFI_SMM_LOCK_BOX_PARAMETER_SET_ATTRIBUTES *)(UINTN)LockBoxParameterHeader);
     break;
   case EFI_SMM_LOCK_BOX_COMMAND_RESTORE_ALL_IN_PLACE:
     if (TempCommBufferSize < sizeof(EFI_SMM_LOCK_BOX_PARAMETER_RESTORE_ALL_IN_PLACE)) {
-      DEBUG ((EFI_D_ERROR, "SmmLockBox Command Buffer Size for RESTORE_ALL_IN_PLACE invalid!\n"));
+      DEBUG ((DEBUG_ERROR, "SmmLockBox Command Buffer Size for RESTORE_ALL_IN_PLACE invalid!\n"));
       break;
     }
     SmmLockBoxRestoreAllInPlace ((EFI_SMM_LOCK_BOX_PARAMETER_RESTORE_ALL_IN_PLACE *)(UINTN)LockBoxParameterHeader);
     break;
   default:
-    DEBUG ((EFI_D_ERROR, "SmmLockBox Command invalid!\n"));
+    DEBUG ((DEBUG_ERROR, "SmmLockBox Command invalid!\n"));
     break;
   }
 

--- a/MdeModulePkg/Universal/SmbiosDxe/SmbiosDxe.c
+++ b/MdeModulePkg/Universal/SmbiosDxe/SmbiosDxe.c
@@ -426,10 +426,10 @@ SmbiosAdd (
     //
     if ((EntryPointStructure != NULL) &&
         (EntryPointStructure->TableLength + StructureSize > SMBIOS_TABLE_MAX_LENGTH)) {
-      DEBUG ((EFI_D_INFO, "SmbiosAdd: Total length exceeds max 32-bit table length with type = %d size = 0x%x\n", Record->Type, StructureSize));
+      DEBUG ((DEBUG_INFO, "SmbiosAdd: Total length exceeds max 32-bit table length with type = %d size = 0x%x\n", Record->Type, StructureSize));
     } else {
       Smbios32BitTable = TRUE;
-      DEBUG ((EFI_D_INFO, "SmbiosAdd: Smbios type %d with size 0x%x is added to 32-bit table\n", Record->Type, StructureSize));
+      DEBUG ((DEBUG_INFO, "SmbiosAdd: Smbios type %d with size 0x%x is added to 32-bit table\n", Record->Type, StructureSize));
     }
   }
 
@@ -443,9 +443,9 @@ SmbiosAdd (
     //
     if ((Smbios30EntryPointStructure != NULL) &&
         (Smbios30EntryPointStructure->TableMaximumSize + StructureSize > SMBIOS_3_0_TABLE_MAX_LENGTH)) {
-      DEBUG ((EFI_D_INFO, "SmbiosAdd: Total length exceeds max 64-bit table length with type = %d size = 0x%x\n", Record->Type, StructureSize));
+      DEBUG ((DEBUG_INFO, "SmbiosAdd: Total length exceeds max 64-bit table length with type = %d size = 0x%x\n", Record->Type, StructureSize));
     } else {
-      DEBUG ((EFI_D_INFO, "SmbiosAdd: Smbios type %d with size 0x%x is added to 64-bit table\n", Record->Type, StructureSize));
+      DEBUG ((DEBUG_INFO, "SmbiosAdd: Smbios type %d with size 0x%x is added to 64-bit table\n", Record->Type, StructureSize));
       Smbios64BitTable = TRUE;
     }
   }
@@ -691,9 +691,9 @@ SmbiosUpdateString (
           // in the Structure Table Length field of the SMBIOS Structure Table Entry Point,
           // which is a WORD field limited to 65,535 bytes.
           //
-          DEBUG ((EFI_D_INFO, "SmbiosUpdateString: Total length exceeds max 32-bit table length\n"));
+          DEBUG ((DEBUG_INFO, "SmbiosUpdateString: Total length exceeds max 32-bit table length\n"));
         } else {
-          DEBUG ((EFI_D_INFO, "SmbiosUpdateString: New smbios record add to 32-bit table\n"));
+          DEBUG ((DEBUG_INFO, "SmbiosUpdateString: New smbios record add to 32-bit table\n"));
           SmbiosEntry->Smbios32BitTable = TRUE;
         }
       }
@@ -704,9 +704,9 @@ SmbiosUpdateString (
         //
         if ((Smbios30EntryPointStructure != NULL) &&
             (Smbios30EntryPointStructure->TableMaximumSize + InputStrLen - TargetStrLen > SMBIOS_3_0_TABLE_MAX_LENGTH)) {
-          DEBUG ((EFI_D_INFO, "SmbiosUpdateString: Total length exceeds max 64-bit table length\n"));
+          DEBUG ((DEBUG_INFO, "SmbiosUpdateString: Total length exceeds max 64-bit table length\n"));
         } else {
-          DEBUG ((EFI_D_INFO, "SmbiosUpdateString: New smbios record add to 64-bit table\n"));
+          DEBUG ((DEBUG_INFO, "SmbiosUpdateString: New smbios record add to 64-bit table\n"));
           SmbiosEntry->Smbios64BitTable = TRUE;
         }
       }
@@ -852,10 +852,10 @@ SmbiosRemove (
       // configuration table without depending on PI SMBIOS protocol.
       //
       if (SmbiosEntry->Smbios32BitTable) {
-        DEBUG ((EFI_D_INFO, "SmbiosRemove: remove from 32-bit table\n"));
+        DEBUG ((DEBUG_INFO, "SmbiosRemove: remove from 32-bit table\n"));
       }
       if (SmbiosEntry->Smbios64BitTable) {
-        DEBUG ((EFI_D_INFO, "SmbiosRemove: remove from 64-bit table\n"));
+        DEBUG ((DEBUG_INFO, "SmbiosRemove: remove from 64-bit table\n"));
       }
       //
       // Update the whole SMBIOS table again based on which table the removed SMBIOS record is in.
@@ -1058,7 +1058,7 @@ SmbiosCreateTable (
     // It should be done only once.
     // Allocate memory (below 4GB).
     //
-    DEBUG ((EFI_D_INFO, "SmbiosCreateTable: Initialize 32-bit entry point structure\n"));
+    DEBUG ((DEBUG_INFO, "SmbiosCreateTable: Initialize 32-bit entry point structure\n"));
     EntryPointStructureData.MajorVersion  = mPrivateData.Smbios.MajorVersion;
     EntryPointStructureData.MinorVersion  = mPrivateData.Smbios.MinorVersion;
     EntryPointStructureData.SmbiosBcdRevision = (UINT8) ((PcdGet16 (PcdSmbiosVersion) >> 4) & 0xf0) | (UINT8) (PcdGet16 (PcdSmbiosVersion) & 0x0f);
@@ -1070,7 +1070,7 @@ SmbiosCreateTable (
                     &PhysicalAddress
                     );
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "SmbiosCreateTable () could not allocate EntryPointStructure < 4GB\n"));
+      DEBUG ((DEBUG_ERROR, "SmbiosCreateTable () could not allocate EntryPointStructure < 4GB\n"));
       Status = gBS->AllocatePages (
                       AllocateAnyPages,
                       EfiRuntimeServicesData,
@@ -1143,7 +1143,7 @@ SmbiosCreateTable (
     // If new SMBIOS table size exceeds the previous allocated page,
     // it is time to re-allocate memory (below 4GB).
     //
-    DEBUG ((EFI_D_INFO, "%a() re-allocate SMBIOS 32-bit table\n",
+    DEBUG ((DEBUG_INFO, "%a() re-allocate SMBIOS 32-bit table\n",
       __FUNCTION__));
     if (EntryPointStructure->TableAddress != 0) {
       //
@@ -1165,7 +1165,7 @@ SmbiosCreateTable (
                     &PhysicalAddress
                     );
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "SmbiosCreateTable() could not allocate SMBIOS table < 4GB\n"));
+      DEBUG ((DEBUG_ERROR, "SmbiosCreateTable() could not allocate SMBIOS table < 4GB\n"));
       EntryPointStructure->TableAddress = 0;
       return EFI_OUT_OF_RESOURCES;
     } else {
@@ -1250,7 +1250,7 @@ SmbiosCreate64BitTable (
     // It should be done only once.
     // Allocate memory at any address.
     //
-    DEBUG ((EFI_D_INFO, "SmbiosCreateTable: Initialize 64-bit entry point structure\n"));
+    DEBUG ((DEBUG_INFO, "SmbiosCreateTable: Initialize 64-bit entry point structure\n"));
     Smbios30EntryPointStructureData.MajorVersion  = mPrivateData.Smbios.MajorVersion;
     Smbios30EntryPointStructureData.MinorVersion  = mPrivateData.Smbios.MinorVersion;
     Smbios30EntryPointStructureData.DocRev        = PcdGet8 (PcdSmbiosDocRev);
@@ -1261,7 +1261,7 @@ SmbiosCreate64BitTable (
                     &PhysicalAddress
                     );
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "SmbiosCreate64BitTable() could not allocate Smbios30EntryPointStructure\n"));
+      DEBUG ((DEBUG_ERROR, "SmbiosCreate64BitTable() could not allocate Smbios30EntryPointStructure\n"));
       return EFI_OUT_OF_RESOURCES;
     }
 
@@ -1312,7 +1312,7 @@ SmbiosCreate64BitTable (
     // If new SMBIOS table size exceeds the previous allocated page,
     // it is time to re-allocate memory at anywhere.
     //
-    DEBUG ((EFI_D_INFO, "%a() re-allocate SMBIOS 64-bit table\n",
+    DEBUG ((DEBUG_INFO, "%a() re-allocate SMBIOS 64-bit table\n",
       __FUNCTION__));
     if (Smbios30EntryPointStructure->TableAddress != 0) {
       //
@@ -1333,7 +1333,7 @@ SmbiosCreate64BitTable (
                     &PhysicalAddress
                     );
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "SmbiosCreateTable() could not allocate SMBIOS 64-bit table\n"));
+      DEBUG ((DEBUG_ERROR, "SmbiosCreateTable() could not allocate SMBIOS 64-bit table\n"));
       Smbios30EntryPointStructure->TableAddress = 0;
       return EFI_OUT_OF_RESOURCES;
     } else {

--- a/MdeModulePkg/Universal/SmbiosMeasurementDxe/SmbiosMeasurementDxe.c
+++ b/MdeModulePkg/Universal/SmbiosMeasurementDxe/SmbiosMeasurementDxe.c
@@ -137,7 +137,7 @@ InternalDumpData (
 {
   UINTN  Index;
   for (Index = 0; Index < Size; Index++) {
-    DEBUG ((EFI_D_VERBOSE, "%02x", (UINTN)Data[Index]));
+    DEBUG ((DEBUG_VERBOSE, "%02x", (UINTN)Data[Index]));
   }
 }
 
@@ -164,15 +164,15 @@ InternalDumpHex (
   Count = Size / COLUME_SIZE;
   Left  = Size % COLUME_SIZE;
   for (Index = 0; Index < Count; Index++) {
-    DEBUG ((EFI_D_VERBOSE, "%04x: ", Index * COLUME_SIZE));
+    DEBUG ((DEBUG_VERBOSE, "%04x: ", Index * COLUME_SIZE));
     InternalDumpData (Data + Index * COLUME_SIZE, COLUME_SIZE);
-    DEBUG ((EFI_D_VERBOSE, "\n"));
+    DEBUG ((DEBUG_VERBOSE, "\n"));
   }
 
   if (Left != 0) {
-    DEBUG ((EFI_D_VERBOSE, "%04x: ", Index * COLUME_SIZE));
+    DEBUG ((DEBUG_VERBOSE, "%04x: ", Index * COLUME_SIZE));
     InternalDumpData (Data + Index * COLUME_SIZE, Left);
-    DEBUG ((EFI_D_VERBOSE, "\n"));
+    DEBUG ((DEBUG_VERBOSE, "\n"));
   }
 }
 
@@ -282,7 +282,7 @@ FilterSmbiosEntry (
   CHAR8                 *String;
   UINTN                 StringLen;
 
-  DEBUG ((EFI_D_INFO, "Smbios Table (Type - %d):\n", ((SMBIOS_STRUCTURE *)TableEntry)->Type));
+  DEBUG ((DEBUG_INFO, "Smbios Table (Type - %d):\n", ((SMBIOS_STRUCTURE *)TableEntry)->Type));
   DEBUG_CODE (InternalDumpHex (TableEntry, TableEntrySize););
 
   //
@@ -310,7 +310,7 @@ FilterSmbiosEntry (
                 // set ' ' for string field
                 String = GetSmbiosStringById (TableEntry, StringId, &StringLen);
                 ASSERT (String != NULL);
-                //DEBUG ((EFI_D_INFO,"StrId(0x%x)-%a(%d)\n", StringId, String, StringLen));
+                //DEBUG ((DEBUG_INFO,"StrId(0x%x)-%a(%d)\n", StringId, String, StringLen));
                 SetMem (String, StringLen, ' ');
               }
             }
@@ -322,7 +322,7 @@ FilterSmbiosEntry (
     }
   }
 
-  DEBUG ((EFI_D_INFO, "Filter Smbios Table (Type - %d):\n", ((SMBIOS_STRUCTURE *)TableEntry)->Type));
+  DEBUG ((DEBUG_INFO, "Filter Smbios Table (Type - %d):\n", ((SMBIOS_STRUCTURE *)TableEntry)->Type));
   DEBUG_CODE (InternalDumpHex (TableEntry, TableEntrySize););
 }
 
@@ -494,22 +494,22 @@ MeasureSmbiosTable (
                (VOID **) &Smbios3Table
                );
     if (!EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_INFO, "Smbios3Table:\n"));
-      DEBUG ((EFI_D_INFO, "  AnchorString                - '%c%c%c%c%c'\n",
+      DEBUG ((DEBUG_INFO, "Smbios3Table:\n"));
+      DEBUG ((DEBUG_INFO, "  AnchorString                - '%c%c%c%c%c'\n",
         Smbios3Table->AnchorString[0],
         Smbios3Table->AnchorString[1],
         Smbios3Table->AnchorString[2],
         Smbios3Table->AnchorString[3],
         Smbios3Table->AnchorString[4]
         ));
-      DEBUG ((EFI_D_INFO, "  EntryPointStructureChecksum - 0x%02x\n", Smbios3Table->EntryPointStructureChecksum));
-      DEBUG ((EFI_D_INFO, "  EntryPointLength            - 0x%02x\n", Smbios3Table->EntryPointLength));
-      DEBUG ((EFI_D_INFO, "  MajorVersion                - 0x%02x\n", Smbios3Table->MajorVersion));
-      DEBUG ((EFI_D_INFO, "  MinorVersion                - 0x%02x\n", Smbios3Table->MinorVersion));
-      DEBUG ((EFI_D_INFO, "  DocRev                      - 0x%02x\n", Smbios3Table->DocRev));
-      DEBUG ((EFI_D_INFO, "  EntryPointRevision          - 0x%02x\n", Smbios3Table->EntryPointRevision));
-      DEBUG ((EFI_D_INFO, "  TableMaximumSize            - 0x%08x\n", Smbios3Table->TableMaximumSize));
-      DEBUG ((EFI_D_INFO, "  TableAddress                - 0x%016lx\n", Smbios3Table->TableAddress));
+      DEBUG ((DEBUG_INFO, "  EntryPointStructureChecksum - 0x%02x\n", Smbios3Table->EntryPointStructureChecksum));
+      DEBUG ((DEBUG_INFO, "  EntryPointLength            - 0x%02x\n", Smbios3Table->EntryPointLength));
+      DEBUG ((DEBUG_INFO, "  MajorVersion                - 0x%02x\n", Smbios3Table->MajorVersion));
+      DEBUG ((DEBUG_INFO, "  MinorVersion                - 0x%02x\n", Smbios3Table->MinorVersion));
+      DEBUG ((DEBUG_INFO, "  DocRev                      - 0x%02x\n", Smbios3Table->DocRev));
+      DEBUG ((DEBUG_INFO, "  EntryPointRevision          - 0x%02x\n", Smbios3Table->EntryPointRevision));
+      DEBUG ((DEBUG_INFO, "  TableMaximumSize            - 0x%08x\n", Smbios3Table->TableMaximumSize));
+      DEBUG ((DEBUG_INFO, "  TableAddress                - 0x%016lx\n", Smbios3Table->TableAddress));
     }
   }
 
@@ -519,38 +519,38 @@ MeasureSmbiosTable (
                (VOID **) &SmbiosTable
                );
     if (!EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_INFO, "SmbiosTable:\n"));
-      DEBUG ((EFI_D_INFO, "  AnchorString                - '%c%c%c%c'\n",
+      DEBUG ((DEBUG_INFO, "SmbiosTable:\n"));
+      DEBUG ((DEBUG_INFO, "  AnchorString                - '%c%c%c%c'\n",
         SmbiosTable->AnchorString[0],
         SmbiosTable->AnchorString[1],
         SmbiosTable->AnchorString[2],
         SmbiosTable->AnchorString[3]
         ));
-      DEBUG ((EFI_D_INFO, "  EntryPointStructureChecksum - 0x%02x\n", SmbiosTable->EntryPointStructureChecksum));
-      DEBUG ((EFI_D_INFO, "  EntryPointLength            - 0x%02x\n", SmbiosTable->EntryPointLength));
-      DEBUG ((EFI_D_INFO, "  MajorVersion                - 0x%02x\n", SmbiosTable->MajorVersion));
-      DEBUG ((EFI_D_INFO, "  MinorVersion                - 0x%02x\n", SmbiosTable->MinorVersion));
-      DEBUG ((EFI_D_INFO, "  MaxStructureSize            - 0x%08x\n", SmbiosTable->MaxStructureSize));
-      DEBUG ((EFI_D_INFO, "  EntryPointRevision          - 0x%02x\n", SmbiosTable->EntryPointRevision));
-      DEBUG ((EFI_D_INFO, "  FormattedArea               - '%c%c%c%c%c'\n",
+      DEBUG ((DEBUG_INFO, "  EntryPointStructureChecksum - 0x%02x\n", SmbiosTable->EntryPointStructureChecksum));
+      DEBUG ((DEBUG_INFO, "  EntryPointLength            - 0x%02x\n", SmbiosTable->EntryPointLength));
+      DEBUG ((DEBUG_INFO, "  MajorVersion                - 0x%02x\n", SmbiosTable->MajorVersion));
+      DEBUG ((DEBUG_INFO, "  MinorVersion                - 0x%02x\n", SmbiosTable->MinorVersion));
+      DEBUG ((DEBUG_INFO, "  MaxStructureSize            - 0x%08x\n", SmbiosTable->MaxStructureSize));
+      DEBUG ((DEBUG_INFO, "  EntryPointRevision          - 0x%02x\n", SmbiosTable->EntryPointRevision));
+      DEBUG ((DEBUG_INFO, "  FormattedArea               - '%c%c%c%c%c'\n",
         SmbiosTable->FormattedArea[0],
         SmbiosTable->FormattedArea[1],
         SmbiosTable->FormattedArea[2],
         SmbiosTable->FormattedArea[3],
         SmbiosTable->FormattedArea[4]
         ));
-      DEBUG ((EFI_D_INFO, "  IntermediateAnchorString    - '%c%c%c%c%c'\n",
+      DEBUG ((DEBUG_INFO, "  IntermediateAnchorString    - '%c%c%c%c%c'\n",
         SmbiosTable->IntermediateAnchorString[0],
         SmbiosTable->IntermediateAnchorString[1],
         SmbiosTable->IntermediateAnchorString[2],
         SmbiosTable->IntermediateAnchorString[3],
         SmbiosTable->IntermediateAnchorString[4]
         ));
-      DEBUG ((EFI_D_INFO, "  IntermediateChecksum        - 0x%02x\n", SmbiosTable->IntermediateChecksum));
-      DEBUG ((EFI_D_INFO, "  TableLength                 - 0x%04x\n", SmbiosTable->TableLength));
-      DEBUG ((EFI_D_INFO, "  TableAddress                - 0x%08x\n", SmbiosTable->TableAddress));
-      DEBUG ((EFI_D_INFO, "  NumberOfSmbiosStructures    - 0x%04x\n", SmbiosTable->NumberOfSmbiosStructures));
-      DEBUG ((EFI_D_INFO, "  SmbiosBcdRevision           - 0x%02x\n", SmbiosTable->SmbiosBcdRevision));
+      DEBUG ((DEBUG_INFO, "  IntermediateChecksum        - 0x%02x\n", SmbiosTable->IntermediateChecksum));
+      DEBUG ((DEBUG_INFO, "  TableLength                 - 0x%04x\n", SmbiosTable->TableLength));
+      DEBUG ((DEBUG_INFO, "  TableAddress                - 0x%08x\n", SmbiosTable->TableAddress));
+      DEBUG ((DEBUG_INFO, "  NumberOfSmbiosStructures    - 0x%04x\n", SmbiosTable->NumberOfSmbiosStructures));
+      DEBUG ((DEBUG_INFO, "  SmbiosBcdRevision           - 0x%02x\n", SmbiosTable->SmbiosBcdRevision));
     }
   }
 

--- a/MdeModulePkg/Universal/SmmCommunicationBufferDxe/SmmCommunicationBufferDxe.c
+++ b/MdeModulePkg/Universal/SmmCommunicationBufferDxe/SmmCommunicationBufferDxe.c
@@ -71,16 +71,16 @@ SmmCommunicationBufferEntryPoint (
   Entry->NumberOfPages = DEFAULT_COMMON_PI_SMM_COMMUNIATION_REGION_PAGES;
   Entry->Attribute     = 0;
 
-  DEBUG ((EFI_D_INFO, "PiSmmCommunicationRegionTable:(0x%x)\n", PiSmmCommunicationRegionTable));
-  DEBUG ((EFI_D_INFO, "  Version         - 0x%x\n", PiSmmCommunicationRegionTable->Version));
-  DEBUG ((EFI_D_INFO, "  NumberOfEntries - 0x%x\n", PiSmmCommunicationRegionTable->NumberOfEntries));
-  DEBUG ((EFI_D_INFO, "  DescriptorSize  - 0x%x\n", PiSmmCommunicationRegionTable->DescriptorSize));
-  DEBUG ((EFI_D_INFO, "Entry:(0x%x)\n", Entry));
-  DEBUG ((EFI_D_INFO, "  Type            - 0x%x\n", Entry->Type));
-  DEBUG ((EFI_D_INFO, "  PhysicalStart   - 0x%lx\n", Entry->PhysicalStart));
-  DEBUG ((EFI_D_INFO, "  VirtualStart    - 0x%lx\n", Entry->VirtualStart));
-  DEBUG ((EFI_D_INFO, "  NumberOfPages   - 0x%lx\n", Entry->NumberOfPages));
-  DEBUG ((EFI_D_INFO, "  Attribute       - 0x%lx\n", Entry->Attribute));
+  DEBUG ((DEBUG_INFO, "PiSmmCommunicationRegionTable:(0x%x)\n", PiSmmCommunicationRegionTable));
+  DEBUG ((DEBUG_INFO, "  Version         - 0x%x\n", PiSmmCommunicationRegionTable->Version));
+  DEBUG ((DEBUG_INFO, "  NumberOfEntries - 0x%x\n", PiSmmCommunicationRegionTable->NumberOfEntries));
+  DEBUG ((DEBUG_INFO, "  DescriptorSize  - 0x%x\n", PiSmmCommunicationRegionTable->DescriptorSize));
+  DEBUG ((DEBUG_INFO, "Entry:(0x%x)\n", Entry));
+  DEBUG ((DEBUG_INFO, "  Type            - 0x%x\n", Entry->Type));
+  DEBUG ((DEBUG_INFO, "  PhysicalStart   - 0x%lx\n", Entry->PhysicalStart));
+  DEBUG ((DEBUG_INFO, "  VirtualStart    - 0x%lx\n", Entry->VirtualStart));
+  DEBUG ((DEBUG_INFO, "  NumberOfPages   - 0x%lx\n", Entry->NumberOfPages));
+  DEBUG ((DEBUG_INFO, "  Attribute       - 0x%lx\n", Entry->Attribute));
 
   //
   // Publish this table, so that other driver can use the buffer.

--- a/MdeModulePkg/Universal/TimestampDxe/TimestampDxe.c
+++ b/MdeModulePkg/Universal/TimestampDxe/TimestampDxe.c
@@ -142,7 +142,7 @@ TimestampDriverInitialize (
     mTimestampProperties.EndValue = mTimerLibStartValue - mTimerLibEndValue;
   }
 
-  DEBUG ((EFI_D_INFO, "TimerFrequency:0x%lx, TimerLibStartTime:0x%lx, TimerLibEndtime:0x%lx\n", mTimestampProperties.Frequency, mTimerLibStartValue, mTimerLibEndValue));
+  DEBUG ((DEBUG_INFO, "TimerFrequency:0x%lx, TimerLibStartTime:0x%lx, TimerLibEndtime:0x%lx\n", mTimestampProperties.Frequency, mTimerLibStartValue, mTimerLibEndValue));
 
   //
   // Install the Timestamp Protocol onto a new handle

--- a/MdeModulePkg/Universal/Variable/Pei/Variable.c
+++ b/MdeModulePkg/Universal/Variable/Pei/Variable.c
@@ -608,14 +608,14 @@ GetVariableStore (
             // Let FvHeader point to spare block.
             //
             FvHeader = (EFI_FIRMWARE_VOLUME_HEADER *) (UINTN) FtwLastWriteData->SpareAddress;
-            DEBUG ((EFI_D_INFO, "PeiVariable: NV storage is backed up in spare block: 0x%x\n", (UINTN) FtwLastWriteData->SpareAddress));
+            DEBUG ((DEBUG_INFO, "PeiVariable: NV storage is backed up in spare block: 0x%x\n", (UINTN) FtwLastWriteData->SpareAddress));
           } else if ((FtwLastWriteData->TargetAddress > NvStorageBase) && (FtwLastWriteData->TargetAddress < (NvStorageBase + NvStorageSize))) {
             StoreInfo->FtwLastWriteData = FtwLastWriteData;
             //
             // Flash NV storage from the offset is backed up in spare block.
             //
             BackUpOffset = (UINT32) (FtwLastWriteData->TargetAddress - NvStorageBase);
-            DEBUG ((EFI_D_INFO, "PeiVariable: High partial NV storage from offset: %x is backed up in spare block: 0x%x\n", BackUpOffset, (UINTN) FtwLastWriteData->SpareAddress));
+            DEBUG ((DEBUG_INFO, "PeiVariable: High partial NV storage from offset: %x is backed up in spare block: 0x%x\n", BackUpOffset, (UINTN) FtwLastWriteData->SpareAddress));
             //
             // At least one block data in flash NV storage is still valid, so still leave FvHeader point to NV storage base.
             //
@@ -626,7 +626,7 @@ GetVariableStore (
         // Check if the Firmware Volume is not corrupted
         //
         if ((FvHeader->Signature != EFI_FVH_SIGNATURE) || (!CompareGuid (&gEfiSystemNvDataFvGuid, &FvHeader->FileSystemGuid))) {
-          DEBUG ((EFI_D_ERROR, "Firmware Volume for Variable Store is corrupted\n"));
+          DEBUG ((DEBUG_ERROR, "Firmware Volume for Variable Store is corrupted\n"));
           break;
         }
 

--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/Measurement.c
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/Measurement.c
@@ -121,8 +121,8 @@ MeasureVariable (
        );
   }
 
-  DEBUG ((EFI_D_INFO, "VariableDxe: MeasureVariable (Pcr - %x, EventType - %x, ", (UINTN)7, (UINTN)EV_EFI_VARIABLE_DRIVER_CONFIG));
-  DEBUG ((EFI_D_INFO, "VariableName - %s, VendorGuid - %g)\n", VarName, VendorGuid));
+  DEBUG ((DEBUG_INFO, "VariableDxe: MeasureVariable (Pcr - %x, EventType - %x, ", (UINTN)7, (UINTN)EV_EFI_VARIABLE_DRIVER_CONFIG));
+  DEBUG ((DEBUG_INFO, "VariableName - %s, VendorGuid - %g)\n", VarName, VendorGuid));
 
   Status = TpmMeasureAndLogData (
              7,
@@ -257,7 +257,7 @@ SecureBootHook (
              VariableData,
              VariableDataSize
              );
-  DEBUG ((EFI_D_INFO, "MeasureBootPolicyVariable - %r\n", Status));
+  DEBUG ((DEBUG_INFO, "MeasureBootPolicyVariable - %r\n", Status));
 
   if (VariableData != NULL) {
     FreePool (VariableData);

--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/Variable.c
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/Variable.c
@@ -281,15 +281,15 @@ RecordVarErrorFlag (
   VAR_ERROR_FLAG            TempFlag;
 
   DEBUG_CODE (
-    DEBUG ((EFI_D_ERROR, "RecordVarErrorFlag (0x%02x) %s:%g - 0x%08x - 0x%x\n", Flag, VariableName, VendorGuid, Attributes, VariableSize));
+    DEBUG ((DEBUG_ERROR, "RecordVarErrorFlag (0x%02x) %s:%g - 0x%08x - 0x%x\n", Flag, VariableName, VendorGuid, Attributes, VariableSize));
     if (Flag == VAR_ERROR_FLAG_SYSTEM_ERROR) {
       if (AtRuntime ()) {
-        DEBUG ((EFI_D_ERROR, "CommonRuntimeVariableSpace = 0x%x - CommonVariableTotalSize = 0x%x\n", mVariableModuleGlobal->CommonRuntimeVariableSpace, mVariableModuleGlobal->CommonVariableTotalSize));
+        DEBUG ((DEBUG_ERROR, "CommonRuntimeVariableSpace = 0x%x - CommonVariableTotalSize = 0x%x\n", mVariableModuleGlobal->CommonRuntimeVariableSpace, mVariableModuleGlobal->CommonVariableTotalSize));
       } else {
-        DEBUG ((EFI_D_ERROR, "CommonVariableSpace = 0x%x - CommonVariableTotalSize = 0x%x\n", mVariableModuleGlobal->CommonVariableSpace, mVariableModuleGlobal->CommonVariableTotalSize));
+        DEBUG ((DEBUG_ERROR, "CommonVariableSpace = 0x%x - CommonVariableTotalSize = 0x%x\n", mVariableModuleGlobal->CommonVariableSpace, mVariableModuleGlobal->CommonVariableTotalSize));
       }
     } else {
-      DEBUG ((EFI_D_ERROR, "CommonMaxUserVariableSpace = 0x%x - CommonUserVariableTotalSize = 0x%x\n", mVariableModuleGlobal->CommonMaxUserVariableSpace, mVariableModuleGlobal->CommonUserVariableTotalSize));
+      DEBUG ((DEBUG_ERROR, "CommonMaxUserVariableSpace = 0x%x - CommonUserVariableTotalSize = 0x%x\n", mVariableModuleGlobal->CommonMaxUserVariableSpace, mVariableModuleGlobal->CommonUserVariableTotalSize));
     }
   );
 
@@ -369,7 +369,7 @@ InitializeVarErrorFlag (
   }
 
   Flag = mCurrentBootVarErrFlag;
-  DEBUG ((EFI_D_INFO, "Initialize variable error flag (%02x)\n", Flag));
+  DEBUG ((DEBUG_INFO, "Initialize variable error flag (%02x)\n", Flag));
 
   Status = FindVariable (
              VAR_ERROR_FLAG_NAME,
@@ -1532,7 +1532,7 @@ AutoUpdateLangVariable (
                                    ISO_639_2_ENTRY_SIZE + 1, Attributes, 0, 0, &Variable, NULL);
         }
 
-        DEBUG ((EFI_D_INFO, "Variable Driver Auto Update PlatformLang, PlatformLang:%a, Lang:%a Status: %r\n", BestPlatformLang, BestLang, Status));
+        DEBUG ((DEBUG_INFO, "Variable Driver Auto Update PlatformLang, PlatformLang:%a, Lang:%a Status: %r\n", BestPlatformLang, BestLang, Status));
       }
     }
 
@@ -1581,7 +1581,7 @@ AutoUpdateLangVariable (
                                    AsciiStrSize (BestPlatformLang), Attributes, 0, 0, &Variable, NULL);
         }
 
-        DEBUG ((EFI_D_INFO, "Variable Driver Auto Update Lang, Lang:%a, PlatformLang:%a Status: %r\n", BestLang, BestPlatformLang, Status));
+        DEBUG ((DEBUG_INFO, "Variable Driver Auto Update Lang, Lang:%a, PlatformLang:%a Status: %r\n", BestLang, BestPlatformLang, Status));
       }
     }
   }
@@ -1659,14 +1659,14 @@ UpdateVariable (
       //
       // Trying to update NV variable prior to the installation of EFI_VARIABLE_WRITE_ARCH_PROTOCOL
       //
-      DEBUG ((EFI_D_ERROR, "Update NV variable before EFI_VARIABLE_WRITE_ARCH_PROTOCOL ready - %r\n", EFI_NOT_AVAILABLE_YET));
+      DEBUG ((DEBUG_ERROR, "Update NV variable before EFI_VARIABLE_WRITE_ARCH_PROTOCOL ready - %r\n", EFI_NOT_AVAILABLE_YET));
       return EFI_NOT_AVAILABLE_YET;
     } else if ((Attributes & VARIABLE_ATTRIBUTE_AT_AW) != 0) {
       //
       // Trying to update volatile authenticated variable prior to the installation of EFI_VARIABLE_WRITE_ARCH_PROTOCOL
       // The authenticated variable perhaps is not initialized, just return here.
       //
-      DEBUG ((EFI_D_ERROR, "Update AUTH variable before EFI_VARIABLE_WRITE_ARCH_PROTOCOL ready - %r\n", EFI_NOT_AVAILABLE_YET));
+      DEBUG ((DEBUG_ERROR, "Update AUTH variable before EFI_VARIABLE_WRITE_ARCH_PROTOCOL ready - %r\n", EFI_NOT_AVAILABLE_YET));
       return EFI_NOT_AVAILABLE_YET;
     }
   }
@@ -2764,7 +2764,7 @@ VariableServiceSetVariable (
       // 2. The only attribute differing is EFI_VARIABLE_APPEND_WRITE
       //
       Status = EFI_INVALID_PARAMETER;
-      DEBUG ((EFI_D_INFO, "[Variable]: Rewritten a preexisting variable(0x%08x) with different attributes(0x%08x) - %g:%s\n", Variable.CurrPtr->Attributes, Attributes, VendorGuid, VariableName));
+      DEBUG ((DEBUG_INFO, "[Variable]: Rewritten a preexisting variable(0x%08x) with different attributes(0x%08x) - %g:%s\n", Variable.CurrPtr->Attributes, Attributes, VendorGuid, VariableName));
       goto Done;
     }
   }
@@ -3264,7 +3264,7 @@ FlushHobVariableToFlash (
       //
       // All HOB variables have been flushed in flash.
       //
-      DEBUG ((EFI_D_INFO, "Variable driver: all HOB variables have been flushed in flash.\n"));
+      DEBUG ((DEBUG_INFO, "Variable driver: all HOB variables have been flushed in flash.\n"));
       if (mVariableModuleGlobal->VariableGlobal.VariableRuntimeCacheContext.HobFlushComplete != NULL) {
         *(mVariableModuleGlobal->VariableGlobal.VariableRuntimeCacheContext.HobFlushComplete) = TRUE;
       }
@@ -3333,7 +3333,7 @@ VariableWriteServiceInitialize (
                                             GetVariableHeaderSize (mVariableModuleGlobal->VariableGlobal.AuthFormat);
     Status = AuthVariableLibInitialize (&mAuthContextIn, &mAuthContextOut);
     if (!EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_INFO, "Variable driver will work with auth variable support!\n"));
+      DEBUG ((DEBUG_INFO, "Variable driver will work with auth variable support!\n"));
       mVariableModuleGlobal->VariableGlobal.AuthSupport = TRUE;
       if (mAuthContextOut.AuthVarEntry != NULL) {
         for (Index = 0; Index < mAuthContextOut.AuthVarEntryCount; Index++) {
@@ -3347,8 +3347,8 @@ VariableWriteServiceInitialize (
         }
       }
     } else if (Status == EFI_UNSUPPORTED) {
-      DEBUG ((EFI_D_INFO, "NOTICE - AuthVariableLibInitialize() returns %r!\n", Status));
-      DEBUG ((EFI_D_INFO, "Variable driver will continue to work without auth variable support!\n"));
+      DEBUG ((DEBUG_INFO, "NOTICE - AuthVariableLibInitialize() returns %r!\n", Status));
+      DEBUG ((DEBUG_INFO, "Variable driver will continue to work without auth variable support!\n"));
       mVariableModuleGlobal->VariableGlobal.AuthSupport = FALSE;
       Status = EFI_SUCCESS;
     }
@@ -3550,7 +3550,7 @@ GetHobVariableStore (
         return EFI_OUT_OF_RESOURCES;
       }
     } else {
-      DEBUG ((EFI_D_ERROR, "HOB Variable Store header is corrupted!\n"));
+      DEBUG ((DEBUG_ERROR, "HOB Variable Store header is corrupted!\n"));
     }
   }
 
@@ -3598,14 +3598,14 @@ VariableCommonInitialize (
   // has been initialized in InitNonVolatileVariableStore().
   //
   if (mVariableModuleGlobal->VariableGlobal.AuthFormat) {
-    DEBUG ((EFI_D_INFO, "Variable driver will work with auth variable format!\n"));
+    DEBUG ((DEBUG_INFO, "Variable driver will work with auth variable format!\n"));
     //
     // Set AuthSupport to FALSE first, VariableWriteServiceInitialize() will initialize it.
     //
     mVariableModuleGlobal->VariableGlobal.AuthSupport = FALSE;
     VariableGuid = &gEfiAuthenticatedVariableGuid;
   } else {
-    DEBUG ((EFI_D_INFO, "Variable driver will work without auth variable support!\n"));
+    DEBUG ((DEBUG_INFO, "Variable driver will work without auth variable support!\n"));
     mVariableModuleGlobal->VariableGlobal.AuthSupport = FALSE;
     VariableGuid = &gEfiVariableGuid;
   }
@@ -3750,4 +3750,3 @@ GetFvbInfoByAddress (
 
   return Status;
 }
-

--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableDxe.c
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableDxe.c
@@ -345,7 +345,7 @@ OnEndOfDxe (
 {
   EFI_STATUS    Status;
 
-  DEBUG ((EFI_D_INFO, "[Variable]END_OF_DXE is signaled\n"));
+  DEBUG ((DEBUG_INFO, "[Variable]END_OF_DXE is signaled\n"));
   MorLockInitAtEndOfDxe ();
   Status = LockVariablePolicy ();
   ASSERT_EFI_ERROR (Status);
@@ -638,4 +638,3 @@ VariableServiceInitialize (
 
   return EFI_SUCCESS;
 }
-

--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmm.c
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmm.c
@@ -489,17 +489,17 @@ SmmVariableHandler (
   TempCommBufferSize = *CommBufferSize;
 
   if (TempCommBufferSize < SMM_VARIABLE_COMMUNICATE_HEADER_SIZE) {
-    DEBUG ((EFI_D_ERROR, "SmmVariableHandler: SMM communication buffer size invalid!\n"));
+    DEBUG ((DEBUG_ERROR, "SmmVariableHandler: SMM communication buffer size invalid!\n"));
     return EFI_SUCCESS;
   }
   CommBufferPayloadSize = TempCommBufferSize - SMM_VARIABLE_COMMUNICATE_HEADER_SIZE;
   if (CommBufferPayloadSize > mVariableBufferPayloadSize) {
-    DEBUG ((EFI_D_ERROR, "SmmVariableHandler: SMM communication buffer payload size invalid!\n"));
+    DEBUG ((DEBUG_ERROR, "SmmVariableHandler: SMM communication buffer payload size invalid!\n"));
     return EFI_SUCCESS;
   }
 
   if (!VariableSmmIsBufferOutsideSmmValid ((UINTN)CommBuffer, TempCommBufferSize)) {
-    DEBUG ((EFI_D_ERROR, "SmmVariableHandler: SMM communication buffer in SMRAM or overflow!\n"));
+    DEBUG ((DEBUG_ERROR, "SmmVariableHandler: SMM communication buffer in SMRAM or overflow!\n"));
     return EFI_SUCCESS;
   }
 
@@ -507,7 +507,7 @@ SmmVariableHandler (
   switch (SmmVariableFunctionHeader->Function) {
     case SMM_VARIABLE_FUNCTION_GET_VARIABLE:
       if (CommBufferPayloadSize < OFFSET_OF(SMM_VARIABLE_COMMUNICATE_ACCESS_VARIABLE, Name)) {
-        DEBUG ((EFI_D_ERROR, "GetVariable: SMM communication buffer size invalid!\n"));
+        DEBUG ((DEBUG_ERROR, "GetVariable: SMM communication buffer size invalid!\n"));
         return EFI_SUCCESS;
       }
       //
@@ -530,7 +530,7 @@ SmmVariableHandler (
       // SMRAM range check already covered before
       //
       if (InfoSize > CommBufferPayloadSize) {
-        DEBUG ((EFI_D_ERROR, "GetVariable: Data size exceed communication buffer size limit!\n"));
+        DEBUG ((DEBUG_ERROR, "GetVariable: Data size exceed communication buffer size limit!\n"));
         Status = EFI_ACCESS_DENIED;
         goto EXIT;
       }
@@ -561,7 +561,7 @@ SmmVariableHandler (
 
     case SMM_VARIABLE_FUNCTION_GET_NEXT_VARIABLE_NAME:
       if (CommBufferPayloadSize < OFFSET_OF(SMM_VARIABLE_COMMUNICATE_GET_NEXT_VARIABLE_NAME, Name)) {
-        DEBUG ((EFI_D_ERROR, "GetNextVariableName: SMM communication buffer size invalid!\n"));
+        DEBUG ((DEBUG_ERROR, "GetNextVariableName: SMM communication buffer size invalid!\n"));
         return EFI_SUCCESS;
       }
       //
@@ -582,7 +582,7 @@ SmmVariableHandler (
       // SMRAM range check already covered before
       //
       if (InfoSize > CommBufferPayloadSize) {
-        DEBUG ((EFI_D_ERROR, "GetNextVariableName: Data size exceed communication buffer size limit!\n"));
+        DEBUG ((DEBUG_ERROR, "GetNextVariableName: Data size exceed communication buffer size limit!\n"));
         Status = EFI_ACCESS_DENIED;
         goto EXIT;
       }
@@ -606,7 +606,7 @@ SmmVariableHandler (
 
     case SMM_VARIABLE_FUNCTION_SET_VARIABLE:
       if (CommBufferPayloadSize < OFFSET_OF(SMM_VARIABLE_COMMUNICATE_ACCESS_VARIABLE, Name)) {
-        DEBUG ((EFI_D_ERROR, "SetVariable: SMM communication buffer size invalid!\n"));
+        DEBUG ((DEBUG_ERROR, "SetVariable: SMM communication buffer size invalid!\n"));
         return EFI_SUCCESS;
       }
       //
@@ -630,7 +630,7 @@ SmmVariableHandler (
       // Data buffer should not contain SMM range
       //
       if (InfoSize > CommBufferPayloadSize) {
-        DEBUG ((EFI_D_ERROR, "SetVariable: Data size exceed communication buffer size limit!\n"));
+        DEBUG ((DEBUG_ERROR, "SetVariable: Data size exceed communication buffer size limit!\n"));
         Status = EFI_ACCESS_DENIED;
         goto EXIT;
       }
@@ -660,7 +660,7 @@ SmmVariableHandler (
 
     case SMM_VARIABLE_FUNCTION_QUERY_VARIABLE_INFO:
       if (CommBufferPayloadSize < sizeof (SMM_VARIABLE_COMMUNICATE_QUERY_VARIABLE_INFO)) {
-        DEBUG ((EFI_D_ERROR, "QueryVariableInfo: SMM communication buffer size invalid!\n"));
+        DEBUG ((DEBUG_ERROR, "QueryVariableInfo: SMM communication buffer size invalid!\n"));
         return EFI_SUCCESS;
       }
       QueryVariableInfo = (SMM_VARIABLE_COMMUNICATE_QUERY_VARIABLE_INFO *) SmmVariableFunctionHeader->Data;
@@ -675,7 +675,7 @@ SmmVariableHandler (
 
     case SMM_VARIABLE_FUNCTION_GET_PAYLOAD_SIZE:
       if (CommBufferPayloadSize < sizeof (SMM_VARIABLE_COMMUNICATE_GET_PAYLOAD_SIZE)) {
-        DEBUG ((EFI_D_ERROR, "GetPayloadSize: SMM communication buffer size invalid!\n"));
+        DEBUG ((DEBUG_ERROR, "GetPayloadSize: SMM communication buffer size invalid!\n"));
         return EFI_SUCCESS;
       }
       GetPayloadSize = (SMM_VARIABLE_COMMUNICATE_GET_PAYLOAD_SIZE *) SmmVariableFunctionHeader->Data;
@@ -752,7 +752,7 @@ SmmVariableHandler (
       break;
     case SMM_VARIABLE_FUNCTION_VAR_CHECK_VARIABLE_PROPERTY_GET:
       if (CommBufferPayloadSize < OFFSET_OF (SMM_VARIABLE_COMMUNICATE_VAR_CHECK_VARIABLE_PROPERTY, Name)) {
-        DEBUG ((EFI_D_ERROR, "VarCheckVariablePropertyGet: SMM communication buffer size invalid!\n"));
+        DEBUG ((DEBUG_ERROR, "VarCheckVariablePropertyGet: SMM communication buffer size invalid!\n"));
         return EFI_SUCCESS;
       }
       //
@@ -773,7 +773,7 @@ SmmVariableHandler (
       // SMRAM range check already covered before
       //
       if (InfoSize > CommBufferPayloadSize) {
-        DEBUG ((EFI_D_ERROR, "VarCheckVariablePropertyGet: Data size exceed communication buffer size limit!\n"));
+        DEBUG ((DEBUG_ERROR, "VarCheckVariablePropertyGet: Data size exceed communication buffer size limit!\n"));
         Status = EFI_ACCESS_DENIED;
         goto EXIT;
       }
@@ -979,7 +979,7 @@ SmmEndOfDxeCallback (
 {
   EFI_STATUS    Status;
 
-  DEBUG ((EFI_D_INFO, "[Variable]SMM_END_OF_DXE is signaled\n"));
+  DEBUG ((DEBUG_INFO, "[Variable]SMM_END_OF_DXE is signaled\n"));
   MorLockInitAtEndOfDxe ();
   Status = LockVariablePolicy ();
   ASSERT_EFI_ERROR (Status);
@@ -1191,5 +1191,3 @@ MmVariableServiceInitialize (
 
   return EFI_SUCCESS;
 }
-
-

--- a/MdeModulePkg/Universal/WatchdogTimerDxe/WatchdogTimer.c
+++ b/MdeModulePkg/Universal/WatchdogTimerDxe/WatchdogTimer.c
@@ -69,7 +69,7 @@ WatchdogTimerDriverExpires (
     mWatchdogTimerNotifyFunction (mWatchdogTimerPeriod);
   }
 
-  DEBUG ((EFI_D_ERROR, "Watchdog Timer resetting system\n"));
+  DEBUG ((DEBUG_ERROR, "Watchdog Timer resetting system\n"));
 
   //
   // Reset the platform

--- a/MdePkg/Include/Library/DebugLib.h
+++ b/MdePkg/Include/Library/DebugLib.h
@@ -448,7 +448,7 @@ UnitTestDebugAssert (
     do {                                                                                 \
       if (DebugAssertEnabled ()) {                                                       \
         if (EFI_ERROR (StatusParameter)) {                                               \
-          DEBUG ((EFI_D_ERROR, "\nASSERT_EFI_ERROR (Status = %r)\n", StatusParameter));  \
+          DEBUG ((DEBUG_ERROR, "\nASSERT_EFI_ERROR (Status = %r)\n", StatusParameter));  \
           _ASSERT (!EFI_ERROR (StatusParameter));                                        \
         }                                                                                \
       }                                                                                  \

--- a/MdePkg/Library/BasePeCoffLib/Arm/PeCoffLoaderEx.c
+++ b/MdePkg/Library/BasePeCoffLib/Arm/PeCoffLoaderEx.c
@@ -235,10 +235,9 @@ PeHotRelocateImageEx (
     ASSERT (FALSE);
     // break omitted - ARM instruction encoding not implemented
   default:
-    DEBUG ((EFI_D_ERROR, "PeHotRelocateEx:unknown fixed type\n"));
+    DEBUG ((DEBUG_ERROR, "PeHotRelocateEx:unknown fixed type\n"));
     return RETURN_UNSUPPORTED;
   }
 
   return RETURN_SUCCESS;
 }
-

--- a/MdePkg/Library/BasePostCodeLibDebug/PostCode.c
+++ b/MdePkg/Library/BasePostCodeLibDebug/PostCode.c
@@ -36,7 +36,7 @@ PostCode (
   IN UINT32  Value
   )
 {
-  DEBUG((EFI_D_INFO, "POST %08x\n", Value));
+  DEBUG((DEBUG_INFO, "POST %08x\n", Value));
   return Value;
 }
 
@@ -72,7 +72,7 @@ PostCodeWithDescription (
   IN CONST CHAR8  *Description  OPTIONAL
   )
 {
-  DEBUG((EFI_D_INFO, "POST %08x - %s\n", Value, Description));
+  DEBUG((DEBUG_INFO, "POST %08x - %s\n", Value, Description));
   return Value;
 }
 

--- a/MdePkg/Library/DxeHstiLib/HstiDxe.c
+++ b/MdePkg/Library/DxeHstiLib/HstiDxe.c
@@ -161,15 +161,15 @@ InternalHstiIsValidTable (
   // basic check for header
   //
   if (HstiData == NULL) {
-    DEBUG ((EFI_D_ERROR, "HstiData == NULL\n"));
+    DEBUG ((DEBUG_ERROR, "HstiData == NULL\n"));
     return FALSE;
   }
   if (HstiSize < sizeof(ADAPTER_INFO_PLATFORM_SECURITY)) {
-    DEBUG ((EFI_D_ERROR, "HstiSize < sizeof(ADAPTER_INFO_PLATFORM_SECURITY)\n"));
+    DEBUG ((DEBUG_ERROR, "HstiSize < sizeof(ADAPTER_INFO_PLATFORM_SECURITY)\n"));
     return FALSE;
   }
   if (((HstiSize - sizeof(ADAPTER_INFO_PLATFORM_SECURITY)) / 3) < Hsti->SecurityFeaturesSize) {
-    DEBUG ((EFI_D_ERROR, "((HstiSize - sizeof(ADAPTER_INFO_PLATFORM_SECURITY)) / 3) < SecurityFeaturesSize\n"));
+    DEBUG ((DEBUG_ERROR, "((HstiSize - sizeof(ADAPTER_INFO_PLATFORM_SECURITY)) / 3) < SecurityFeaturesSize\n"));
     return FALSE;
   }
 
@@ -177,7 +177,7 @@ InternalHstiIsValidTable (
   // Check Version
   //
   if (Hsti->Version != PLATFORM_SECURITY_VERSION_VNEXTCS) {
-    DEBUG ((EFI_D_ERROR, "Version != PLATFORM_SECURITY_VERSION_VNEXTCS\n"));
+    DEBUG ((DEBUG_ERROR, "Version != PLATFORM_SECURITY_VERSION_VNEXTCS\n"));
     return FALSE;
   }
 
@@ -186,8 +186,8 @@ InternalHstiIsValidTable (
   //
   if ((Hsti->Role < PLATFORM_SECURITY_ROLE_PLATFORM_REFERENCE) ||
       (Hsti->Role > PLATFORM_SECURITY_ROLE_IMPLEMENTOR_ODM)) {
-    DEBUG ((EFI_D_ERROR, "Role < PLATFORM_SECURITY_ROLE_PLATFORM_REFERENCE ||\n"));
-    DEBUG ((EFI_D_ERROR, "Role > PLATFORM_SECURITY_ROLE_IMPLEMENTOR_ODM\n"));
+    DEBUG ((DEBUG_ERROR, "Role < PLATFORM_SECURITY_ROLE_PLATFORM_REFERENCE ||\n"));
+    DEBUG ((DEBUG_ERROR, "Role > PLATFORM_SECURITY_ROLE_IMPLEMENTOR_ODM\n"));
     return FALSE;
   }
 
@@ -200,7 +200,7 @@ InternalHstiIsValidTable (
     }
   }
   if (Index == sizeof(Hsti->ImplementationID)/sizeof(Hsti->ImplementationID[0])) {
-    DEBUG ((EFI_D_ERROR, "ImplementationID has no NUL CHAR\n"));
+    DEBUG ((DEBUG_ERROR, "ImplementationID has no NUL CHAR\n"));
     return FALSE;
   }
 
@@ -211,11 +211,11 @@ InternalHstiIsValidTable (
   // basic check for ErrorString
   //
   if (ErrorStringSize == 0) {
-    DEBUG ((EFI_D_ERROR, "ErrorStringSize == 0\n"));
+    DEBUG ((DEBUG_ERROR, "ErrorStringSize == 0\n"));
     return FALSE;
   }
   if ((ErrorStringSize & BIT0) != 0) {
-    DEBUG ((EFI_D_ERROR, "(ErrorStringSize & BIT0) != 0\n"));
+    DEBUG ((DEBUG_ERROR, "(ErrorStringSize & BIT0) != 0\n"));
     return FALSE;
   }
 
@@ -232,11 +232,11 @@ InternalHstiIsValidTable (
   // check the length of ErrorString
   //
   if (ErrorChar != 0) {
-    DEBUG ((EFI_D_ERROR, "ErrorString has no NUL CHAR\n"));
+    DEBUG ((DEBUG_ERROR, "ErrorString has no NUL CHAR\n"));
     return FALSE;
   }
   if (ErrorStringLength == (ErrorStringSize/2)) {
-    DEBUG ((EFI_D_ERROR, "ErrorString Length incorrect\n"));
+    DEBUG ((DEBUG_ERROR, "ErrorString Length incorrect\n"));
     return FALSE;
   }
 

--- a/MdePkg/Library/SmmMemLib/SmmMemLib.c
+++ b/MdePkg/Library/SmmMemLib/SmmMemLib.c
@@ -97,7 +97,7 @@ SmmMemLibInternalCalculateMaximumSupportAddress (
   // Save the maximum support address in one global variable
   //
   mSmmMemLibInternalMaximumSupportAddress = (EFI_PHYSICAL_ADDRESS)(UINTN)(LShiftU64 (1, PhysicalAddressBits) - 1);
-  DEBUG ((EFI_D_INFO, "mSmmMemLibInternalMaximumSupportAddress = 0x%lx\n", mSmmMemLibInternalMaximumSupportAddress));
+  DEBUG ((DEBUG_INFO, "mSmmMemLibInternalMaximumSupportAddress = 0x%lx\n", mSmmMemLibInternalMaximumSupportAddress));
 }
 
 /**
@@ -129,7 +129,7 @@ SmmIsBufferOutsideSmmValid (
     // Overflow happen
     //
     DEBUG ((
-      EFI_D_ERROR,
+      DEBUG_ERROR,
       "SmmIsBufferOutsideSmmValid: Overflow: Buffer (0x%lx) - Length (0x%lx), MaximumSupportAddress (0x%lx)\n",
       Buffer,
       Length,
@@ -142,13 +142,13 @@ SmmIsBufferOutsideSmmValid (
     if (((Buffer >= mSmmMemLibInternalSmramRanges[Index].CpuStart) && (Buffer < mSmmMemLibInternalSmramRanges[Index].CpuStart + mSmmMemLibInternalSmramRanges[Index].PhysicalSize)) ||
         ((mSmmMemLibInternalSmramRanges[Index].CpuStart >= Buffer) && (mSmmMemLibInternalSmramRanges[Index].CpuStart < Buffer + Length))) {
       DEBUG ((
-        EFI_D_ERROR,
+        DEBUG_ERROR,
         "SmmIsBufferOutsideSmmValid: Overlap: Buffer (0x%lx) - Length (0x%lx), ",
         Buffer,
         Length
         ));
       DEBUG ((
-        EFI_D_ERROR,
+        DEBUG_ERROR,
         "CpuStart (0x%lx) - PhysicalSize (0x%lx)\n",
         mSmmMemLibInternalSmramRanges[Index].CpuStart,
         mSmmMemLibInternalSmramRanges[Index].PhysicalSize
@@ -176,7 +176,7 @@ SmmIsBufferOutsideSmmValid (
 
     if (!InValidCommunicationRegion) {
       DEBUG ((
-        EFI_D_ERROR,
+        DEBUG_ERROR,
         "SmmIsBufferOutsideSmmValid: Not in ValidCommunicationRegion: Buffer (0x%lx) - Length (0x%lx)\n",
         Buffer,
         Length
@@ -191,7 +191,7 @@ SmmIsBufferOutsideSmmValid (
       if (((Buffer >= mSmmMemLibGcdMemSpace[Index].BaseAddress) && (Buffer < mSmmMemLibGcdMemSpace[Index].BaseAddress + mSmmMemLibGcdMemSpace[Index].Length)) ||
           ((mSmmMemLibGcdMemSpace[Index].BaseAddress >= Buffer) && (mSmmMemLibGcdMemSpace[Index].BaseAddress < Buffer + Length))) {
         DEBUG ((
-          EFI_D_ERROR,
+          DEBUG_ERROR,
           "SmmIsBufferOutsideSmmValid: In Untested Memory Region: Buffer (0x%lx) - Length (0x%lx)\n",
           Buffer,
           Length
@@ -213,7 +213,7 @@ SmmIsBufferOutsideSmmValid (
             if (((Buffer >= Entry->PhysicalStart) && (Buffer < Entry->PhysicalStart + LShiftU64 (Entry->NumberOfPages, EFI_PAGE_SHIFT))) ||
                 ((Entry->PhysicalStart >= Buffer) && (Entry->PhysicalStart < Buffer + Length))) {
               DEBUG ((
-                EFI_D_ERROR,
+                DEBUG_ERROR,
                 "SmmIsBufferOutsideSmmValid: In RuntimeCode Region: Buffer (0x%lx) - Length (0x%lx)\n",
                 Buffer,
                 Length
@@ -255,7 +255,7 @@ SmmCopyMemToSmram (
   )
 {
   if (!SmmIsBufferOutsideSmmValid ((EFI_PHYSICAL_ADDRESS)(UINTN)SourceBuffer, Length)) {
-    DEBUG ((EFI_D_ERROR, "SmmCopyMemToSmram: Security Violation: Source (0x%x), Length (0x%x)\n", SourceBuffer, Length));
+    DEBUG ((DEBUG_ERROR, "SmmCopyMemToSmram: Security Violation: Source (0x%x), Length (0x%x)\n", SourceBuffer, Length));
     return EFI_SECURITY_VIOLATION;
   }
   CopyMem (DestinationBuffer, SourceBuffer, Length);
@@ -288,7 +288,7 @@ SmmCopyMemFromSmram (
   )
 {
   if (!SmmIsBufferOutsideSmmValid ((EFI_PHYSICAL_ADDRESS)(UINTN)DestinationBuffer, Length)) {
-    DEBUG ((EFI_D_ERROR, "SmmCopyMemFromSmram: Security Violation: Destination (0x%x), Length (0x%x)\n", DestinationBuffer, Length));
+    DEBUG ((DEBUG_ERROR, "SmmCopyMemFromSmram: Security Violation: Destination (0x%x), Length (0x%x)\n", DestinationBuffer, Length));
     return EFI_SECURITY_VIOLATION;
   }
   CopyMem (DestinationBuffer, SourceBuffer, Length);
@@ -322,11 +322,11 @@ SmmCopyMem (
   )
 {
   if (!SmmIsBufferOutsideSmmValid ((EFI_PHYSICAL_ADDRESS)(UINTN)DestinationBuffer, Length)) {
-    DEBUG ((EFI_D_ERROR, "SmmCopyMem: Security Violation: Destination (0x%x), Length (0x%x)\n", DestinationBuffer, Length));
+    DEBUG ((DEBUG_ERROR, "SmmCopyMem: Security Violation: Destination (0x%x), Length (0x%x)\n", DestinationBuffer, Length));
     return EFI_SECURITY_VIOLATION;
   }
   if (!SmmIsBufferOutsideSmmValid ((EFI_PHYSICAL_ADDRESS)(UINTN)SourceBuffer, Length)) {
-    DEBUG ((EFI_D_ERROR, "SmmCopyMem: Security Violation: Source (0x%x), Length (0x%x)\n", SourceBuffer, Length));
+    DEBUG ((DEBUG_ERROR, "SmmCopyMem: Security Violation: Source (0x%x), Length (0x%x)\n", SourceBuffer, Length));
     return EFI_SECURITY_VIOLATION;
   }
   CopyMem (DestinationBuffer, SourceBuffer, Length);
@@ -358,7 +358,7 @@ SmmSetMem (
   )
 {
   if (!SmmIsBufferOutsideSmmValid ((EFI_PHYSICAL_ADDRESS)(UINTN)Buffer, Length)) {
-    DEBUG ((EFI_D_ERROR, "SmmSetMem: Security Violation: Source (0x%x), Length (0x%x)\n", Buffer, Length));
+    DEBUG ((DEBUG_ERROR, "SmmSetMem: Security Violation: Source (0x%x), Length (0x%x)\n", Buffer, Length));
     return EFI_SECURITY_VIOLATION;
   }
   SetMem (Buffer, Length, Value);

--- a/MdePkg/Library/UefiLib/UefiNotTiano.c
+++ b/MdePkg/Library/UefiLib/UefiNotTiano.c
@@ -80,7 +80,7 @@ EfiCreateEventLegacyBootEx (
   ASSERT (LegacyBootEvent != NULL);
 
   if (gST->Hdr.Revision < EFI_2_00_SYSTEM_TABLE_REVISION) {
-    DEBUG ((EFI_D_ERROR, "EFI1.1 can't support LegacyBootEvent!"));
+    DEBUG ((DEBUG_ERROR, "EFI1.1 can't support LegacyBootEvent!"));
     ASSERT (FALSE);
 
     return EFI_UNSUPPORTED;
@@ -175,7 +175,7 @@ EfiCreateEventReadyToBootEx (
   ASSERT (ReadyToBootEvent != NULL);
 
   if (gST->Hdr.Revision < EFI_2_00_SYSTEM_TABLE_REVISION) {
-    DEBUG ((EFI_D_ERROR, "EFI1.1 can't support ReadyToBootEvent!"));
+    DEBUG ((DEBUG_ERROR, "EFI1.1 can't support ReadyToBootEvent!"));
     ASSERT (FALSE);
 
     return EFI_UNSUPPORTED;
@@ -327,4 +327,3 @@ EfiInitializeFwVolDevicepathNode (
 
   CopyGuid (&FvDevicePathNode->FvFileName, NameGuid);
 }
-

--- a/NetworkPkg/ArpDxe/ArpDriver.c
+++ b/NetworkPkg/ArpDxe/ArpDriver.c
@@ -492,7 +492,7 @@ ArpDriverBindingStop (
                   EFI_OPEN_PROTOCOL_GET_PROTOCOL
                   );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "ArpDriverBindingStop: Open ArpSb failed, %r.\n", Status));
+    DEBUG ((DEBUG_ERROR, "ArpDriverBindingStop: Open ArpSb failed, %r.\n", Status));
     return EFI_DEVICE_ERROR;
   }
 
@@ -578,7 +578,7 @@ ArpServiceBindingCreateChild (
   //
   Instance = AllocateZeroPool (sizeof(ARP_INSTANCE_DATA));
   if (Instance == NULL) {
-    DEBUG ((EFI_D_ERROR, "ArpSBCreateChild: Failed to allocate memory for Instance.\n"));
+    DEBUG ((DEBUG_ERROR, "ArpSBCreateChild: Failed to allocate memory for Instance.\n"));
 
     return EFI_OUT_OF_RESOURCES;
   }
@@ -746,7 +746,7 @@ ArpServiceBindingDestroyChild (
                   NULL
                   );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "ArpSBDestroyChild: Failed to uninstall the arp protocol, %r.\n",
+    DEBUG ((DEBUG_ERROR, "ArpSBDestroyChild: Failed to uninstall the arp protocol, %r.\n",
       Status));
 
     Instance->InDestroy = FALSE;
@@ -808,4 +808,3 @@ ArpDriverEntryPoint (
            &gArpComponentName2
            );
 }
-

--- a/NetworkPkg/ArpDxe/ArpImpl.c
+++ b/NetworkPkg/ArpDxe/ArpImpl.c
@@ -306,7 +306,7 @@ RESTART_RECEIVE:
 
   DEBUG_CODE (
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "ArpOnFrameRcvd: ArpService->Mnp->Receive "
+      DEBUG ((DEBUG_ERROR, "ArpOnFrameRcvd: ArpService->Mnp->Receive "
         "failed, %r\n.", Status));
     }
   );
@@ -360,7 +360,7 @@ ArpOnFrameSentDpc (
 
   DEBUG_CODE (
     if (EFI_ERROR (TxToken->Status)) {
-      DEBUG ((EFI_D_ERROR, "ArpOnFrameSent: TxToken->Status, %r.\n", TxToken->Status));
+      DEBUG ((DEBUG_ERROR, "ArpOnFrameSent: TxToken->Status, %r.\n", TxToken->Status));
     }
   );
 
@@ -952,7 +952,7 @@ ArpConfigureInstance (
 
       OldConfigData->StationAddress = AllocatePool (OldConfigData->SwAddressLength);
       if (OldConfigData->StationAddress == NULL) {
-        DEBUG ((EFI_D_ERROR, "ArpConfigInstance: AllocatePool for the StationAddress "
+        DEBUG ((DEBUG_ERROR, "ArpConfigInstance: AllocatePool for the StationAddress "
           "failed.\n"));
         return EFI_OUT_OF_RESOURCES;
       }
@@ -1044,7 +1044,7 @@ ArpSendFrame (
   //
   TxToken = AllocatePool (sizeof(EFI_MANAGED_NETWORK_COMPLETION_TOKEN));
   if (TxToken == NULL) {
-    DEBUG ((EFI_D_ERROR, "ArpSendFrame: Allocate memory for TxToken failed.\n"));
+    DEBUG ((DEBUG_ERROR, "ArpSendFrame: Allocate memory for TxToken failed.\n"));
     return;
   }
 
@@ -1063,7 +1063,7 @@ ArpSendFrame (
                   &TxToken->Event
                   );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "ArpSendFrame: CreateEvent failed for TxToken->Event.\n"));
+    DEBUG ((DEBUG_ERROR, "ArpSendFrame: CreateEvent failed for TxToken->Event.\n"));
     goto CLEAN_EXIT;
   }
 
@@ -1072,7 +1072,7 @@ ArpSendFrame (
   //
   TxData = AllocatePool (sizeof(EFI_MANAGED_NETWORK_TRANSMIT_DATA));
   if (TxData == NULL) {
-    DEBUG ((EFI_D_ERROR, "ArpSendFrame: Allocate memory for TxData failed.\n"));
+    DEBUG ((DEBUG_ERROR, "ArpSendFrame: Allocate memory for TxData failed.\n"));
     goto CLEAN_EXIT;
   }
 
@@ -1091,7 +1091,7 @@ ArpSendFrame (
   //
   Packet = AllocatePool (TotalLength);
   if (Packet == NULL) {
-    DEBUG ((EFI_D_ERROR, "ArpSendFrame: Allocate memory for Packet failed.\n"));
+    DEBUG ((DEBUG_ERROR, "ArpSendFrame: Allocate memory for Packet failed.\n"));
     ASSERT (Packet != NULL);
   }
 
@@ -1189,7 +1189,7 @@ ArpSendFrame (
   //
   Status = ArpService->Mnp->Transmit (ArpService->Mnp, TxToken);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "Mnp->Transmit failed, %r.\n", Status));
+    DEBUG ((DEBUG_ERROR, "Mnp->Transmit failed, %r.\n", Status));
     goto CLEAN_EXIT;
   }
 
@@ -1604,7 +1604,7 @@ ArpFindCacheEntry (
   //
   FindData = AllocatePool (FoundCount * FoundEntryLength);
   if (FindData == NULL) {
-    DEBUG ((EFI_D_ERROR, "ArpFindCacheEntry: Failed to allocate memory.\n"));
+    DEBUG ((DEBUG_ERROR, "ArpFindCacheEntry: Failed to allocate memory.\n"));
     Status = EFI_OUT_OF_RESOURCES;
     goto CLEAN_EXIT;
   }
@@ -1664,4 +1664,3 @@ CLEAN_EXIT:
 
   return Status;
 }
-

--- a/NetworkPkg/ArpDxe/ArpMain.c
+++ b/NetworkPkg/ArpDxe/ArpMain.c
@@ -229,7 +229,7 @@ ArpAdd (
     CacheEntry = ArpAllocCacheEntry (Instance);
 
     if (CacheEntry == NULL) {
-      DEBUG ((EFI_D_ERROR, "ArpAdd: Failed to allocate pool for CacheEntry.\n"));
+      DEBUG ((DEBUG_ERROR, "ArpAdd: Failed to allocate pool for CacheEntry.\n"));
       Status = EFI_OUT_OF_RESOURCES;
       goto UNLOCK_EXIT;
     }
@@ -590,7 +590,7 @@ ArpRequest (
   //
   RequestContext = AllocatePool (sizeof(USER_REQUEST_CONTEXT));
   if (RequestContext == NULL) {
-    DEBUG ((EFI_D_ERROR, "ArpRequest: Allocate memory for RequestContext failed.\n"));
+    DEBUG ((DEBUG_ERROR, "ArpRequest: Allocate memory for RequestContext failed.\n"));
 
     Status = EFI_OUT_OF_RESOURCES;
     goto UNLOCK_EXIT;
@@ -621,7 +621,7 @@ ArpRequest (
     //
     CacheEntry = ArpAllocCacheEntry (Instance);
     if (CacheEntry == NULL) {
-      DEBUG ((EFI_D_ERROR, "ArpRequest: Allocate memory for CacheEntry failed.\n"));
+      DEBUG ((DEBUG_ERROR, "ArpRequest: Allocate memory for CacheEntry failed.\n"));
       FreePool (RequestContext);
 
       Status = EFI_OUT_OF_RESOURCES;

--- a/NetworkPkg/HttpBootDxe/HttpBootClient.c
+++ b/NetworkPkg/HttpBootDxe/HttpBootClient.c
@@ -231,7 +231,7 @@ HttpBootDhcp4ExtractUriInfo (
   //
   Status = HttpBootCheckUriScheme (Private->BootFileUri);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "HttpBootDhcp4ExtractUriInfo: %r.\n", Status));
+    DEBUG ((DEBUG_ERROR, "HttpBootDhcp4ExtractUriInfo: %r.\n", Status));
     if (Status == EFI_INVALID_PARAMETER) {
       AsciiPrint ("\n  Error: Invalid URI address.\n");
     } else if (Status == EFI_ACCESS_DENIED) {
@@ -371,7 +371,7 @@ HttpBootDhcp6ExtractUriInfo (
   //
   Status = HttpBootCheckUriScheme (Private->BootFileUri);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "HttpBootDhcp6ExtractUriInfo: %r.\n", Status));
+    DEBUG ((DEBUG_ERROR, "HttpBootDhcp6ExtractUriInfo: %r.\n", Status));
     if (Status == EFI_INVALID_PARAMETER) {
       AsciiPrint ("\n  Error: Invalid URI address.\n");
     } else if (Status == EFI_ACCESS_DENIED) {
@@ -1309,4 +1309,3 @@ ERROR_1:
 
   return Status;
 }
-

--- a/NetworkPkg/HttpBootDxe/HttpBootConfig.c
+++ b/NetworkPkg/HttpBootDxe/HttpBootConfig.c
@@ -489,7 +489,7 @@ HttpBootFormCallback (
 
       if (Status == EFI_INVALID_PARAMETER) {
 
-        DEBUG ((EFI_D_ERROR, "HttpBootFormCallback: %r.\n", Status));
+        DEBUG ((DEBUG_ERROR, "HttpBootFormCallback: %r.\n", Status));
 
         CreatePopUp (
           EFI_LIGHTGRAY | EFI_BACKGROUND_BLUE,
@@ -500,7 +500,7 @@ HttpBootFormCallback (
           );
       } else if (Status == EFI_ACCESS_DENIED) {
 
-        DEBUG ((EFI_D_ERROR, "HttpBootFormCallback: %r.\n", Status));
+        DEBUG ((DEBUG_ERROR, "HttpBootFormCallback: %r.\n", Status));
 
         CreatePopUp (
           EFI_LIGHTGRAY | EFI_BACKGROUND_BLUE,

--- a/NetworkPkg/HttpBootDxe/HttpBootSupport.c
+++ b/NetworkPkg/HttpBootDxe/HttpBootSupport.c
@@ -528,7 +528,7 @@ HttpBootCheckUriScheme (
   // Return EFI_INVALID_PARAMETER if the URI is not HTTP or HTTPS.
   //
   if ((AsciiStrnCmp (Uri, "http://", 7) != 0) && (AsciiStrnCmp (Uri, "https://", 8) != 0)) {
-    DEBUG ((EFI_D_ERROR, "HttpBootCheckUriScheme: Invalid Uri.\n"));
+    DEBUG ((DEBUG_ERROR, "HttpBootCheckUriScheme: Invalid Uri.\n"));
     return EFI_INVALID_PARAMETER;
   }
 
@@ -536,7 +536,7 @@ HttpBootCheckUriScheme (
   // HTTP is disabled, return EFI_ACCESS_DENIED if the URI is HTTP.
   //
   if (!PcdGetBool (PcdAllowHttpConnections) && (AsciiStrnCmp (Uri, "http://", 7) == 0)) {
-    DEBUG ((EFI_D_ERROR, "HttpBootCheckUriScheme: HTTP is disabled.\n"));
+    DEBUG ((DEBUG_ERROR, "HttpBootCheckUriScheme: HTTP is disabled.\n"));
     return EFI_ACCESS_DENIED;
   }
 
@@ -729,7 +729,7 @@ HttpBootRegisterRamDisk (
 
   Status = gBS->LocateProtocol (&gEfiRamDiskProtocolGuid, NULL, (VOID**) &RamDisk);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "HTTP Boot: Couldn't find the RAM Disk protocol - %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "HTTP Boot: Couldn't find the RAM Disk protocol - %r\n", Status));
     return Status;
   }
 
@@ -749,7 +749,7 @@ HttpBootRegisterRamDisk (
              &DevicePath
              );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "HTTP Boot: Failed to register RAM Disk - %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "HTTP Boot: Failed to register RAM Disk - %r\n", Status));
   }
 
   return Status;

--- a/NetworkPkg/HttpDxe/HttpImpl.c
+++ b/NetworkPkg/HttpDxe/HttpImpl.c
@@ -362,7 +362,7 @@ EfiHttpRequest (
     //
     if (!PcdGetBool (PcdAllowHttpConnections) && !(HttpInstance->UseHttps)) {
 
-      DEBUG ((EFI_D_ERROR, "EfiHttpRequest: HTTP is disabled.\n"));
+      DEBUG ((DEBUG_ERROR, "EfiHttpRequest: HTTP is disabled.\n"));
 
       return EFI_ACCESS_DENIED;
     }
@@ -531,7 +531,7 @@ EfiHttpRequest (
 
       FreePool (HostNameStr);
       if (EFI_ERROR (Status)) {
-        DEBUG ((EFI_D_ERROR, "Error: Could not retrieve the host address from DNS server.\n"));
+        DEBUG ((DEBUG_ERROR, "Error: Could not retrieve the host address from DNS server.\n"));
         goto Error1;
       }
     }

--- a/NetworkPkg/HttpDxe/HttpProto.c
+++ b/NetworkPkg/HttpDxe/HttpProto.c
@@ -145,7 +145,7 @@ HttpTcpReceiveNotifyDpc (
     Wrap->TcpWrap.Rx6Token.CompletionToken.Event = NULL;
 
     if (EFI_ERROR (Wrap->TcpWrap.Rx6Token.CompletionToken.Status)) {
-      DEBUG ((EFI_D_ERROR, "HttpTcpReceiveNotifyDpc: %r!\n", Wrap->TcpWrap.Rx6Token.CompletionToken.Status));
+      DEBUG ((DEBUG_ERROR, "HttpTcpReceiveNotifyDpc: %r!\n", Wrap->TcpWrap.Rx6Token.CompletionToken.Status));
       Wrap->HttpToken->Status = Wrap->TcpWrap.Rx6Token.CompletionToken.Status;
       gBS->SignalEvent (Wrap->HttpToken->Event);
 
@@ -165,7 +165,7 @@ HttpTcpReceiveNotifyDpc (
     Wrap->TcpWrap.Rx4Token.CompletionToken.Event = NULL;
 
     if (EFI_ERROR (Wrap->TcpWrap.Rx4Token.CompletionToken.Status)) {
-      DEBUG ((EFI_D_ERROR, "HttpTcpReceiveNotifyDpc: %r!\n", Wrap->TcpWrap.Rx4Token.CompletionToken.Status));
+      DEBUG ((DEBUG_ERROR, "HttpTcpReceiveNotifyDpc: %r!\n", Wrap->TcpWrap.Rx4Token.CompletionToken.Status));
       Wrap->HttpToken->Status = Wrap->TcpWrap.Rx4Token.CompletionToken.Status;
       gBS->SignalEvent (Wrap->HttpToken->Event);
 
@@ -968,7 +968,7 @@ HttpCreateConnection (
     Status = HttpInstance->Tcp4->Connect (HttpInstance->Tcp4, &HttpInstance->Tcp4ConnToken);
     HttpNotify (HttpEventConnectTcp, Status);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "HttpCreateConnection: Tcp4->Connect() = %r\n", Status));
+      DEBUG ((DEBUG_ERROR, "HttpCreateConnection: Tcp4->Connect() = %r\n", Status));
       return Status;
     }
 
@@ -984,7 +984,7 @@ HttpCreateConnection (
     Status = HttpInstance->Tcp6->Connect (HttpInstance->Tcp6, &HttpInstance->Tcp6ConnToken);
     HttpNotify (HttpEventConnectTcp, Status);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "HttpCreateConnection: Tcp6->Connect() = %r\n", Status));
+      DEBUG ((DEBUG_ERROR, "HttpCreateConnection: Tcp6->Connect() = %r\n", Status));
       return Status;
     }
 
@@ -1109,7 +1109,7 @@ HttpConfigureTcp4 (
 
   Status = HttpInstance->Tcp4->Configure (HttpInstance->Tcp4, Tcp4CfgData);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "HttpConfigureTcp4 - %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "HttpConfigureTcp4 - %r\n", Status));
     return Status;
   }
 
@@ -1179,7 +1179,7 @@ HttpConfigureTcp6 (
 
   Status = HttpInstance->Tcp6->Configure (HttpInstance->Tcp6, Tcp6CfgData);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "HttpConfigureTcp6 - %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "HttpConfigureTcp6 - %r\n", Status));
     return Status;
   }
 
@@ -1232,7 +1232,7 @@ HttpConnectTcp4 (
                                  NULL
                                  );
   if (EFI_ERROR(Status)){
-    DEBUG ((EFI_D_ERROR, "Tcp4 GetModeData fail - %x\n", Status));
+    DEBUG ((DEBUG_ERROR, "Tcp4 GetModeData fail - %x\n", Status));
     return Status;
   }
 
@@ -1244,7 +1244,7 @@ HttpConnectTcp4 (
 
   Status = HttpCreateConnection (HttpInstance);
   if (EFI_ERROR(Status)){
-    DEBUG ((EFI_D_ERROR, "Tcp4 Connection fail - %x\n", Status));
+    DEBUG ((DEBUG_ERROR, "Tcp4 Connection fail - %x\n", Status));
     return Status;
   }
 
@@ -1325,7 +1325,7 @@ HttpConnectTcp6 (
                                  );
 
   if (EFI_ERROR(Status)){
-     DEBUG ((EFI_D_ERROR, "Tcp6 GetModeData fail - %x\n", Status));
+     DEBUG ((DEBUG_ERROR, "Tcp6 GetModeData fail - %x\n", Status));
      return Status;
   }
 
@@ -1337,7 +1337,7 @@ HttpConnectTcp6 (
 
   Status = HttpCreateConnection (HttpInstance);
   if (EFI_ERROR(Status)){
-    DEBUG ((EFI_D_ERROR, "Tcp6 Connection fail - %x\n", Status));
+    DEBUG ((DEBUG_ERROR, "Tcp6 Connection fail - %x\n", Status));
     return Status;
   }
 
@@ -1587,7 +1587,7 @@ HttpTransmitTcp (
     Wrap->TcpWrap.IsTxDone = FALSE;
     Status  = Tcp4->Transmit (Tcp4, Tx4Token);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "Transmit failed: %r\n", Status));
+      DEBUG ((DEBUG_ERROR, "Transmit failed: %r\n", Status));
       goto ON_ERROR;
     }
 
@@ -1610,7 +1610,7 @@ HttpTransmitTcp (
     Wrap->TcpWrap.IsTxDone = FALSE;
     Status = Tcp6->Transmit (Tcp6, Tx6Token);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "Transmit failed: %r\n", Status));
+      DEBUG ((DEBUG_ERROR, "Transmit failed: %r\n", Status));
       goto ON_ERROR;
     }
   }
@@ -1875,7 +1875,7 @@ HttpTcpReceiveHeader (
         Rx4Token->Packet.RxData->FragmentTable[0].FragmentLength = DEF_BUF_LEN;
         Status = Tcp4->Receive (Tcp4, Rx4Token);
         if (EFI_ERROR (Status)) {
-          DEBUG ((EFI_D_ERROR, "Tcp4 receive failed: %r\n", Status));
+          DEBUG ((DEBUG_ERROR, "Tcp4 receive failed: %r\n", Status));
           return Status;
         }
 
@@ -1907,7 +1907,7 @@ HttpTcpReceiveHeader (
 
         Status = HttpsReceive (HttpInstance, &Fragment, Timeout);
         if (EFI_ERROR (Status)) {
-          DEBUG ((EFI_D_ERROR, "Tcp4 receive failed: %r\n", Status));
+          DEBUG ((DEBUG_ERROR, "Tcp4 receive failed: %r\n", Status));
           return Status;
         }
       }
@@ -1975,7 +1975,7 @@ HttpTcpReceiveHeader (
         Rx6Token->Packet.RxData->FragmentTable[0].FragmentLength = DEF_BUF_LEN;
         Status = Tcp6->Receive (Tcp6, Rx6Token);
         if (EFI_ERROR (Status)) {
-          DEBUG ((EFI_D_ERROR, "Tcp6 receive failed: %r\n", Status));
+          DEBUG ((DEBUG_ERROR, "Tcp6 receive failed: %r\n", Status));
           return Status;
         }
 
@@ -2007,7 +2007,7 @@ HttpTcpReceiveHeader (
 
         Status = HttpsReceive (HttpInstance, &Fragment, Timeout);
         if (EFI_ERROR (Status)) {
-          DEBUG ((EFI_D_ERROR, "Tcp6 receive failed: %r\n", Status));
+          DEBUG ((DEBUG_ERROR, "Tcp6 receive failed: %r\n", Status));
           return Status;
         }
       }
@@ -2111,7 +2111,7 @@ HttpTcpReceiveBody (
 
     Status = Tcp6->Receive (Tcp6, Rx6Token);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "Tcp6 receive failed: %r\n", Status));
+      DEBUG ((DEBUG_ERROR, "Tcp6 receive failed: %r\n", Status));
       return Status;
     }
   } else {
@@ -2123,7 +2123,7 @@ HttpTcpReceiveBody (
     Rx4Token->CompletionToken.Status = EFI_NOT_READY;
     Status = Tcp4->Receive (Tcp4, Rx4Token);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "Tcp4 receive failed: %r\n", Status));
+      DEBUG ((DEBUG_ERROR, "Tcp4 receive failed: %r\n", Status));
       return Status;
     }
   }

--- a/NetworkPkg/HttpDxe/HttpsSupport.c
+++ b/NetworkPkg/HttpDxe/HttpsSupport.c
@@ -680,7 +680,7 @@ TlsConfigureSession (
   //
   Status = TlsConfigCipherList (HttpInstance);
   if (EFI_ERROR (Status) && Status != EFI_NOT_FOUND) {
-    DEBUG ((EFI_D_ERROR, "TlsConfigCipherList: return %r error.\n", Status));
+    DEBUG ((DEBUG_ERROR, "TlsConfigCipherList: return %r error.\n", Status));
     return Status;
   }
 
@@ -689,7 +689,7 @@ TlsConfigureSession (
   //
   Status = TlsConfigCertificate (HttpInstance);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "TLS Certificate Config Error!\n"));
+    DEBUG ((DEBUG_ERROR, "TLS Certificate Config Error!\n"));
     return Status;
   }
 
@@ -1874,7 +1874,7 @@ HttpsReceive (
     FreePool (GetSessionDataBuffer);
 
     if(HttpInstance->TlsSessionState == EfiTlsSessionError) {
-      DEBUG ((EFI_D_ERROR, "TLS Session State Error!\n"));
+      DEBUG ((DEBUG_ERROR, "TLS Session State Error!\n"));
       return EFI_ABORTED;
     }
 
@@ -1887,4 +1887,3 @@ HttpsReceive (
 
   return Status;
 }
-

--- a/NetworkPkg/IScsiDxe/IScsiProto.c
+++ b/NetworkPkg/IScsiDxe/IScsiProto.c
@@ -260,7 +260,7 @@ IScsiCreateConnection (
     }
 
     if (EFI_ERROR(Status)) {
-      DEBUG ((EFI_D_ERROR, "The configuration of Target address or DNS server address is invalid!\n"));
+      DEBUG ((DEBUG_ERROR, "The configuration of Target address or DNS server address is invalid!\n"));
       FreePool (Conn);
       return NULL;
     }

--- a/NetworkPkg/Ip6Dxe/Ip6Driver.c
+++ b/NetworkPkg/Ip6Dxe/Ip6Driver.c
@@ -591,7 +591,7 @@ Ip6DriverBindingStart (
                          0,
                          NULL
                          );
-      DEBUG ((EFI_D_WARN, "Ip6DriverBindingStart: Clean the invalid ManualAddress configuration.\n"));
+      DEBUG ((DEBUG_WARN, "Ip6DriverBindingStart: Clean the invalid ManualAddress configuration.\n"));
     }
   }
 
@@ -616,7 +616,7 @@ Ip6DriverBindingStart (
                          0,
                          NULL
                          );
-      DEBUG ((EFI_D_WARN, "Ip6DriverBindingStart: Clean the invalid Gateway configuration.\n"));
+      DEBUG ((DEBUG_WARN, "Ip6DriverBindingStart: Clean the invalid Gateway configuration.\n"));
     }
   }
 

--- a/NetworkPkg/MnpDxe/MnpConfig.c
+++ b/NetworkPkg/MnpDxe/MnpConfig.c
@@ -67,7 +67,7 @@ MnpAddFreeNbuf (
   for (Index = 0; Index < Count; Index++) {
     Nbuf = NetbufAlloc (MnpDeviceData->BufferLength + MnpDeviceData->PaddingSize);
     if (Nbuf == NULL) {
-      DEBUG ((EFI_D_ERROR, "MnpAddFreeNbuf: NetBufAlloc failed.\n"));
+      DEBUG ((DEBUG_ERROR, "MnpAddFreeNbuf: NetBufAlloc failed.\n"));
 
       Status = EFI_OUT_OF_RESOURCES;
       break;
@@ -121,7 +121,7 @@ MnpAllocNbuf (
   if (FreeNbufQue->BufNum == 0) {
     if ((MnpDeviceData->NbufCnt + MNP_NET_BUFFER_INCREASEMENT) > MNP_MAX_NET_BUFFER_NUM) {
       DEBUG (
-        (EFI_D_ERROR,
+        (DEBUG_ERROR,
         "MnpAllocNbuf: The maximum NET_BUF size is reached for MNP driver instance %p.\n",
         MnpDeviceData)
         );
@@ -133,7 +133,7 @@ MnpAllocNbuf (
     Status = MnpAddFreeNbuf (MnpDeviceData, MNP_NET_BUFFER_INCREASEMENT);
     if (EFI_ERROR (Status)) {
       DEBUG (
-        (EFI_D_ERROR,
+        (DEBUG_ERROR,
         "MnpAllocNbuf: Failed to add NET_BUFs into the FreeNbufQue, %r.\n",
         Status)
         );
@@ -230,12 +230,12 @@ MnpAddFreeTxBuf (
   for (Index = 0; Index < Count; Index++) {
     TxBufWrap = (MNP_TX_BUF_WRAP*) AllocatePool (OFFSET_OF (MNP_TX_BUF_WRAP, TxBuf) + MnpDeviceData->BufferLength );
     if (TxBufWrap == NULL) {
-      DEBUG ((EFI_D_ERROR, "MnpAddFreeTxBuf: TxBuf Alloc failed.\n"));
+      DEBUG ((DEBUG_ERROR, "MnpAddFreeTxBuf: TxBuf Alloc failed.\n"));
 
       Status = EFI_OUT_OF_RESOURCES;
       break;
     }
-    DEBUG ((EFI_D_INFO, "MnpAddFreeTxBuf: Add TxBufWrap %p, TxBuf %p\n", TxBufWrap, TxBufWrap->TxBuf));
+    DEBUG ((DEBUG_INFO, "MnpAddFreeTxBuf: Add TxBufWrap %p, TxBuf %p\n", TxBufWrap, TxBufWrap->TxBuf));
     TxBufWrap->Signature = MNP_TX_BUF_WRAP_SIGNATURE;
     TxBufWrap->InUse     = FALSE;
     InsertTailList (&MnpDeviceData->FreeTxBufList, &TxBufWrap->WrapEntry);
@@ -288,7 +288,7 @@ MnpAllocTxBuf (
     if (IsListEmpty (&MnpDeviceData->FreeTxBufList)) {
       if ((MnpDeviceData->TxBufCount + MNP_TX_BUFFER_INCREASEMENT) > MNP_MAX_TX_BUFFER_NUM) {
         DEBUG (
-          (EFI_D_ERROR,
+          (DEBUG_ERROR,
           "MnpAllocTxBuf: The maximum TxBuf size is reached for MNP driver instance %p.\n",
           MnpDeviceData)
           );
@@ -300,7 +300,7 @@ MnpAllocTxBuf (
       Status = MnpAddFreeTxBuf (MnpDeviceData, MNP_TX_BUFFER_INCREASEMENT);
       if (IsListEmpty (&MnpDeviceData->FreeTxBufList)) {
         DEBUG (
-          (EFI_D_ERROR,
+          (DEBUG_ERROR,
           "MnpAllocNbuf: Failed to add TxBuf into the FreeTxBufList, %r.\n",
           Status)
           );
@@ -349,7 +349,7 @@ MnpFreeTxBuf (
   TxBufWrap = NET_LIST_USER_STRUCT (TxBuf, MNP_TX_BUF_WRAP, TxBuf);
   if (TxBufWrap->Signature != MNP_TX_BUF_WRAP_SIGNATURE) {
     DEBUG (
-      (EFI_D_ERROR,
+      (DEBUG_ERROR,
       "MnpFreeTxBuf: Signature check failed in MnpFreeTxBuf.\n")
       );
     return;
@@ -357,7 +357,7 @@ MnpFreeTxBuf (
 
   if (!TxBufWrap->InUse) {
     DEBUG (
-      (EFI_D_WARN,
+      (DEBUG_WARN,
       "MnpFreeTxBuf: Duplicated recycle report from SNP.\n")
       );
     return;
@@ -491,7 +491,7 @@ MnpInitializeDeviceData (
   NetbufQueInit (&MnpDeviceData->FreeNbufQue);
   Status = MnpAddFreeNbuf (MnpDeviceData, MNP_INIT_NET_BUFFER_NUM);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "MnpInitializeDeviceData: MnpAddFreeNbuf failed, %r.\n", Status));
+    DEBUG ((DEBUG_ERROR, "MnpInitializeDeviceData: MnpAddFreeNbuf failed, %r.\n", Status));
 
     goto ERROR;
   }
@@ -524,7 +524,7 @@ MnpInitializeDeviceData (
                   &MnpDeviceData->PollTimer
                   );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "MnpInitializeDeviceData: CreateEvent for poll timer failed.\n"));
+    DEBUG ((DEBUG_ERROR, "MnpInitializeDeviceData: CreateEvent for poll timer failed.\n"));
 
     goto ERROR;
   }
@@ -540,7 +540,7 @@ MnpInitializeDeviceData (
                   &MnpDeviceData->TimeoutCheckTimer
                   );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "MnpInitializeDeviceData: CreateEvent for packet timeout check failed.\n"));
+    DEBUG ((DEBUG_ERROR, "MnpInitializeDeviceData: CreateEvent for packet timeout check failed.\n"));
 
     goto ERROR;
   }
@@ -556,7 +556,7 @@ MnpInitializeDeviceData (
                   &MnpDeviceData->MediaDetectTimer
                   );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "MnpInitializeDeviceData: CreateEvent for media detection failed.\n"));
+    DEBUG ((DEBUG_ERROR, "MnpInitializeDeviceData: CreateEvent for media detection failed.\n"));
 
     goto ERROR;
   }
@@ -1222,7 +1222,7 @@ MnpStart (
       //
       Status = MnpStartSnp (MnpDeviceData->Snp);
       if (EFI_ERROR (Status)) {
-        DEBUG ((EFI_D_ERROR, "MnpStart: MnpStartSnp failed, %r.\n", Status));
+        DEBUG ((DEBUG_ERROR, "MnpStart: MnpStartSnp failed, %r.\n", Status));
 
         goto ErrorExit;
       }
@@ -1237,7 +1237,7 @@ MnpStart (
                       );
       if (EFI_ERROR (Status)) {
         DEBUG (
-          (EFI_D_ERROR,
+          (DEBUG_ERROR,
           "MnpStart, gBS->SetTimer for TimeoutCheckTimer %r.\n",
           Status)
           );
@@ -1255,7 +1255,7 @@ MnpStart (
                       );
       if (EFI_ERROR (Status)) {
         DEBUG (
-          (EFI_D_ERROR,
+          (DEBUG_ERROR,
           "MnpStart, gBS->SetTimer for MediaDetectTimer %r.\n",
           Status)
           );
@@ -1274,7 +1274,7 @@ MnpStart (
 
     Status      = gBS->SetTimer (MnpDeviceData->PollTimer, TimerOpType, MNP_SYS_POLL_INTERVAL);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "MnpStart: gBS->SetTimer for PollTimer failed, %r.\n", Status));
+      DEBUG ((DEBUG_ERROR, "MnpStart: gBS->SetTimer for PollTimer failed, %r.\n", Status));
 
       goto ErrorExit;
     }
@@ -1610,7 +1610,7 @@ MnpConfigReceiveFilters (
       MCastFilterCnt  = MnpDeviceData->GroupAddressCount;
       MCastFilter     = AllocatePool (sizeof (EFI_MAC_ADDRESS) * MCastFilterCnt);
       if (MCastFilter == NULL) {
-        DEBUG ((EFI_D_ERROR, "MnpConfigReceiveFilters: Failed to allocate memory resource for MCastFilter.\n"));
+        DEBUG ((DEBUG_ERROR, "MnpConfigReceiveFilters: Failed to allocate memory resource for MCastFilter.\n"));
 
         return EFI_OUT_OF_RESOURCES;
       }
@@ -1672,7 +1672,7 @@ MnpConfigReceiveFilters (
   DEBUG_CODE (
     if (EFI_ERROR (Status)) {
       DEBUG (
-        (EFI_D_ERROR,
+        (DEBUG_ERROR,
         "MnpConfigReceiveFilters: Snp->ReceiveFilters failed, %r.\n",
         Status)
         );
@@ -1729,7 +1729,7 @@ MnpGroupOpAddCtrlBlk (
     GroupAddress = AllocatePool (sizeof (MNP_GROUP_ADDRESS));
     if (GroupAddress == NULL) {
 
-      DEBUG ((EFI_D_ERROR, "MnpGroupOpFormCtrlBlk: Failed to allocate memory resource.\n"));
+      DEBUG ((DEBUG_ERROR, "MnpGroupOpFormCtrlBlk: Failed to allocate memory resource.\n"));
 
       return EFI_OUT_OF_RESOURCES;
     }
@@ -1861,7 +1861,7 @@ MnpGroupOp (
     //
     NewCtrlBlk = AllocatePool (sizeof (MNP_GROUP_CONTROL_BLOCK));
     if (NewCtrlBlk == NULL) {
-      DEBUG ((EFI_D_ERROR, "MnpGroupOp: Failed to allocate memory resource.\n"));
+      DEBUG ((DEBUG_ERROR, "MnpGroupOp: Failed to allocate memory resource.\n"));
 
       return EFI_OUT_OF_RESOURCES;
     }

--- a/NetworkPkg/MnpDxe/MnpDriver.c
+++ b/NetworkPkg/MnpDxe/MnpDriver.c
@@ -164,14 +164,14 @@ MnpDriverBindingStart (
   //
   MnpDeviceData = AllocateZeroPool (sizeof (MNP_DEVICE_DATA));
   if (MnpDeviceData == NULL) {
-    DEBUG ((EFI_D_ERROR, "MnpDriverBindingStart(): Failed to allocate the Mnp Device Data.\n"));
+    DEBUG ((DEBUG_ERROR, "MnpDriverBindingStart(): Failed to allocate the Mnp Device Data.\n"));
 
     return EFI_OUT_OF_RESOURCES;
   }
 
   Status = MnpInitializeDeviceData (MnpDeviceData, This->DriverBindingHandle, ControllerHandle);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "MnpDriverBindingStart: MnpInitializeDeviceData failed, %r.\n", Status));
+    DEBUG ((DEBUG_ERROR, "MnpDriverBindingStart: MnpInitializeDeviceData failed, %r.\n", Status));
 
     FreePool (MnpDeviceData);
     return Status;
@@ -342,7 +342,7 @@ MnpDriverBindingStop (
                     EFI_OPEN_PROTOCOL_GET_PROTOCOL
                     );
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "MnpDriverBindingStop: try to stop unknown Controller.\n"));
+      DEBUG ((DEBUG_ERROR, "MnpDriverBindingStop: try to stop unknown Controller.\n"));
       return EFI_DEVICE_ERROR;
     }
 
@@ -468,7 +468,7 @@ MnpServiceBindingCreateChild (
                   );
   if (EFI_ERROR (Status)) {
     DEBUG (
-      (EFI_D_ERROR,
+      (DEBUG_ERROR,
       "MnpServiceBindingCreateChild: Failed to install the MNP protocol, %r.\n",
       Status)
       );
@@ -614,7 +614,7 @@ MnpServiceBindingDestroyChild (
                   );
   if (EFI_ERROR (Status)) {
     DEBUG (
-      (EFI_D_ERROR,
+      (DEBUG_ERROR,
       "MnpServiceBindingDestroyChild: Failed to uninstall the ManagedNetwork protocol, %r.\n",
       Status)
       );

--- a/NetworkPkg/MnpDxe/MnpIo.c
+++ b/NetworkPkg/MnpDxe/MnpIo.c
@@ -40,7 +40,7 @@ MnpIsValidTxToken (
     // The token is invalid if the Event is NULL, or the TxData is NULL, or
     // the fragment count is zero.
     //
-    DEBUG ((EFI_D_WARN, "MnpIsValidTxToken: Invalid Token.\n"));
+    DEBUG ((DEBUG_WARN, "MnpIsValidTxToken: Invalid Token.\n"));
     return FALSE;
   }
 
@@ -49,7 +49,7 @@ MnpIsValidTxToken (
     // The token is invalid if the HeaderLength isn't zero while the DestinationAddress
     // is NULL (The destination address is already put into the packet).
     //
-    DEBUG ((EFI_D_WARN, "MnpIsValidTxToken: DestinationAddress isn't NULL, HeaderLength must be 0.\n"));
+    DEBUG ((DEBUG_WARN, "MnpIsValidTxToken: DestinationAddress isn't NULL, HeaderLength must be 0.\n"));
     return FALSE;
   }
 
@@ -61,7 +61,7 @@ MnpIsValidTxToken (
       //
       // The token is invalid if any FragmentLength is zero or any FragmentBuffer is NULL.
       //
-      DEBUG ((EFI_D_WARN, "MnpIsValidTxToken: Invalid FragmentLength or FragmentBuffer.\n"));
+      DEBUG ((DEBUG_WARN, "MnpIsValidTxToken: Invalid FragmentLength or FragmentBuffer.\n"));
       return FALSE;
     }
 
@@ -80,7 +80,7 @@ MnpIsValidTxToken (
     // The length calculated from the fragment information doesn't equal to the
     // sum of the DataLength and the HeaderLength.
     //
-    DEBUG ((EFI_D_WARN, "MnpIsValidTxData: Invalid Datalength compared with the sum of fragment length.\n"));
+    DEBUG ((DEBUG_WARN, "MnpIsValidTxData: Invalid Datalength compared with the sum of fragment length.\n"));
     return FALSE;
   }
 
@@ -88,7 +88,7 @@ MnpIsValidTxToken (
     //
     // The total length is larger than the MTU.
     //
-    DEBUG ((EFI_D_WARN, "MnpIsValidTxData: TxData->DataLength exceeds Mtu.\n"));
+    DEBUG ((DEBUG_WARN, "MnpIsValidTxData: TxData->DataLength exceeds Mtu.\n"));
     return FALSE;
   }
 
@@ -233,7 +233,7 @@ MnpSyncSendPacket (
     //
     // Media not present, skip packet transmit and report EFI_NO_MEDIA
     //
-    DEBUG ((EFI_D_WARN, "MnpSyncSendPacket: No network cable detected.\n"));
+    DEBUG ((DEBUG_WARN, "MnpSyncSendPacket: No network cable detected.\n"));
     Token->Status = EFI_NO_MEDIA;
     goto SIGNAL_TOKEN;
   }
@@ -338,7 +338,7 @@ MnpInstanceDeliverPacket (
     //
     DupNbuf = MnpAllocNbuf (MnpDeviceData);
     if (DupNbuf == NULL) {
-      DEBUG ((EFI_D_WARN, "MnpDeliverPacket: Failed to allocate a free Nbuf.\n"));
+      DEBUG ((DEBUG_WARN, "MnpDeliverPacket: Failed to allocate a free Nbuf.\n"));
 
       return EFI_OUT_OF_RESOURCES;
     }
@@ -488,7 +488,7 @@ MnpQueueRcvdPacket (
   //
   if (Instance->RcvdPacketQueueSize == MNP_MAX_RCVD_PACKET_QUE_SIZE) {
 
-    DEBUG ((EFI_D_WARN, "MnpQueueRcvdPacket: Drop one packet bcz queue size limit reached.\n"));
+    DEBUG ((DEBUG_WARN, "MnpQueueRcvdPacket: Drop one packet bcz queue size limit reached.\n"));
 
     //
     // Get the oldest packet.
@@ -724,7 +724,7 @@ MnpWrapRxData (
   //
   RxDataWrap = AllocatePool (sizeof (MNP_RXDATA_WRAP));
   if (RxDataWrap == NULL) {
-    DEBUG ((EFI_D_ERROR, "MnpDispatchPacket: Failed to allocate a MNP_RXDATA_WRAP.\n"));
+    DEBUG ((DEBUG_ERROR, "MnpDispatchPacket: Failed to allocate a MNP_RXDATA_WRAP.\n"));
     return NULL;
   }
 
@@ -746,7 +746,7 @@ MnpWrapRxData (
                   &RxDataWrap->RxData.RecycleEvent
                   );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "MnpDispatchPacket: gBS->CreateEvent failed, %r.\n", Status));
+    DEBUG ((DEBUG_ERROR, "MnpDispatchPacket: gBS->CreateEvent failed, %r.\n", Status));
 
     FreePool (RxDataWrap);
     return NULL;
@@ -900,7 +900,7 @@ MnpReceivePacket (
   if (EFI_ERROR (Status)) {
     DEBUG_CODE (
       if (Status != EFI_NOT_READY) {
-        DEBUG ((EFI_D_WARN, "MnpReceivePacket: Snp->Receive() = %r.\n", Status));
+        DEBUG ((DEBUG_WARN, "MnpReceivePacket: Snp->Receive() = %r.\n", Status));
       }
     );
 
@@ -912,7 +912,7 @@ MnpReceivePacket (
   //
   if ((HeaderSize != Snp->Mode->MediaHeaderSize) || (BufLen < HeaderSize)) {
     DEBUG (
-      (EFI_D_WARN,
+      (DEBUG_WARN,
       "MnpReceivePacket: Size error, HL:TL = %d:%d.\n",
       HeaderSize,
       BufLen)
@@ -970,7 +970,7 @@ MnpReceivePacket (
     Nbuf                       = MnpAllocNbuf (MnpDeviceData);
     MnpDeviceData->RxNbufCache = Nbuf;
     if (Nbuf == NULL) {
-      DEBUG ((EFI_D_ERROR, "MnpReceivePacket: Alloc packet for receiving cache failed.\n"));
+      DEBUG ((DEBUG_ERROR, "MnpReceivePacket: Alloc packet for receiving cache failed.\n"));
       return EFI_DEVICE_ERROR;
     }
 
@@ -1059,7 +1059,7 @@ MnpCheckPacketTimeout (
           //
           // Drop the timeout packet.
           //
-          DEBUG ((EFI_D_WARN, "MnpCheckPacketTimeout: Received packet timeout.\n"));
+          DEBUG ((DEBUG_WARN, "MnpCheckPacketTimeout: Received packet timeout.\n"));
           MnpRecycleRxData (NULL, RxDataWrap);
           Instance->RcvdPacketQueueSize--;
         }

--- a/NetworkPkg/Mtftp4Dxe/Mtftp4Impl.c
+++ b/NetworkPkg/Mtftp4Dxe/Mtftp4Impl.c
@@ -130,9 +130,9 @@ Mtftp4GetInfoCheckPacket (
   case EFI_MTFTP4_OPCODE_ERROR:
     ErrorHeader = (EFI_MTFTP4_ERROR_HEADER *) Packet;
     if (ErrorHeader->ErrorCode == EFI_MTFTP4_ERRORCODE_FILE_NOT_FOUND) {
-      DEBUG ((EFI_D_ERROR, "TFTP error code 1 (File Not Found)\n"));
+      DEBUG ((DEBUG_ERROR, "TFTP error code 1 (File Not Found)\n"));
     } else {
-      DEBUG ((EFI_D_ERROR, "TFTP error code %d\n", ErrorHeader->ErrorCode));
+      DEBUG ((DEBUG_ERROR, "TFTP error code %d\n", ErrorHeader->ErrorCode));
     }
     State->Status = EFI_TFTP_ERROR;
     break;

--- a/NetworkPkg/SnpDxe/Callback.c
+++ b/NetworkPkg/SnpDxe/Callback.c
@@ -246,7 +246,7 @@ SnpUndi32CallbackMap (
   }
 
   if (Index >= MAX_MAP_LENGTH) {
-    DEBUG ((EFI_D_INFO, "SNP maplist is FULL\n"));
+    DEBUG ((DEBUG_INFO, "SNP maplist is FULL\n"));
     *DevAddrPtr = 0;
     return ;
   }
@@ -306,7 +306,7 @@ SnpUndi32CallbackUnmap (
   }
 
   if (Index >= MAX_MAP_LENGTH) {
-    DEBUG ((EFI_D_ERROR, "SNP could not find a mapping, failed to unmap.\n"));
+    DEBUG ((DEBUG_ERROR, "SNP could not find a mapping, failed to unmap.\n"));
     return ;
   }
 

--- a/NetworkPkg/SnpDxe/Get_status.c
+++ b/NetworkPkg/SnpDxe/Get_status.c
@@ -71,13 +71,13 @@ PxeGetStatus (
   //
   // Issue UNDI command and check result.
   //
-  DEBUG ((EFI_D_NET, "\nSnp->undi.get_status()  "));
+  DEBUG ((DEBUG_NET, "\nSnp->undi.get_status()  "));
 
   (*Snp->IssueUndi32Command) ((UINT64)(UINTN) &Snp->Cdb);
 
   if (Snp->Cdb.StatCode != PXE_STATCODE_SUCCESS) {
     DEBUG (
-      (EFI_D_NET,
+      (DEBUG_NET,
       "\nSnp->undi.get_status()  %xh:%xh\n",
       Snp->Cdb.StatFlags,
       Snp->Cdb.StatCode)

--- a/NetworkPkg/SnpDxe/Initialize.c
+++ b/NetworkPkg/SnpDxe/Initialize.c
@@ -46,7 +46,7 @@ PxeInit (
 
     if (Status != EFI_SUCCESS) {
       DEBUG (
-        (EFI_D_ERROR,
+        (DEBUG_ERROR,
         "\nSnp->PxeInit()  AllocateBuffer  %xh (%r)\n",
         Status,
         Status)
@@ -91,7 +91,7 @@ PxeInit (
   Snp->Cdb.IFnum      = Snp->IfNum;
   Snp->Cdb.Control    = PXE_CONTROL_LAST_CDB_IN_LIST;
 
-  DEBUG ((EFI_D_NET, "\nSnp->undi.initialize()  "));
+  DEBUG ((DEBUG_NET, "\nSnp->undi.initialize()  "));
 
   (*Snp->IssueUndi32Command) ((UINT64)(UINTN) &Snp->Cdb);
 
@@ -121,7 +121,7 @@ PxeInit (
     Status            = EFI_SUCCESS;
   } else {
     DEBUG (
-      (EFI_D_WARN,
+      (DEBUG_WARN,
       "\nSnp->undi.initialize()  %xh:%xh\n",
       Snp->Cdb.StatFlags,
       Snp->Cdb.StatCode)

--- a/NetworkPkg/SnpDxe/Mcast_ip_to_mac.c
+++ b/NetworkPkg/SnpDxe/Mcast_ip_to_mac.c
@@ -55,7 +55,7 @@ PxeIp2Mac (
   //
   // Issue UNDI command and check result.
   //
-  DEBUG ((EFI_D_NET, "\nSnp->undi.mcast_ip_to_mac()  "));
+  DEBUG ((DEBUG_NET, "\nSnp->undi.mcast_ip_to_mac()  "));
 
   (*Snp->IssueUndi32Command) ((UINT64)(UINTN) &Snp->Cdb);
 
@@ -68,7 +68,7 @@ PxeIp2Mac (
 
   case PXE_STATCODE_UNSUPPORTED:
     DEBUG (
-      (EFI_D_NET,
+      (DEBUG_NET,
       "\nSnp->undi.mcast_ip_to_mac()  %xh:%xh\n",
       Snp->Cdb.StatFlags,
       Snp->Cdb.StatCode)
@@ -81,7 +81,7 @@ PxeIp2Mac (
     // to caller.
     //
     DEBUG (
-      (EFI_D_NET,
+      (DEBUG_NET,
       "\nSnp->undi.mcast_ip_to_mac()  %xh:%xh\n",
       Snp->Cdb.StatFlags,
       Snp->Cdb.StatCode)

--- a/NetworkPkg/SnpDxe/Nvdata.c
+++ b/NetworkPkg/SnpDxe/Nvdata.c
@@ -53,7 +53,7 @@ PxeNvDataRead (
   //
   // Issue UNDI command and check result.
   //
-  DEBUG ((EFI_D_NET, "\nsnp->undi.nvdata ()  "));
+  DEBUG ((DEBUG_NET, "\nsnp->undi.nvdata ()  "));
 
   (*Snp->IssueUndi32Command) ((UINT64)(UINTN) &Snp->Cdb);
 
@@ -63,7 +63,7 @@ PxeNvDataRead (
 
   case PXE_STATCODE_UNSUPPORTED:
     DEBUG (
-      (EFI_D_NET,
+      (DEBUG_NET,
       "\nsnp->undi.nvdata()  %xh:%xh\n",
       Snp->Cdb.StatFlags,
       Snp->Cdb.StatCode)
@@ -73,7 +73,7 @@ PxeNvDataRead (
 
   default:
     DEBUG (
-      (EFI_D_NET,
+      (DEBUG_NET,
       "\nsnp->undi.nvdata()  %xh:%xh\n",
       Snp->Cdb.StatFlags,
       Snp->Cdb.StatCode)

--- a/NetworkPkg/SnpDxe/Receive.c
+++ b/NetworkPkg/SnpDxe/Receive.c
@@ -76,7 +76,7 @@ PxeReceive (
   //
   // Issue UNDI command and check result.
   //
-  DEBUG ((EFI_D_NET, "\nsnp->undi.receive ()  "));
+  DEBUG ((DEBUG_NET, "\nsnp->undi.receive ()  "));
 
   (*Snp->IssueUndi32Command) ((UINT64)(UINTN) &Snp->Cdb);
 
@@ -86,7 +86,7 @@ PxeReceive (
 
   case PXE_STATCODE_NO_DATA:
     DEBUG (
-      (EFI_D_NET,
+      (DEBUG_NET,
       "\nsnp->undi.receive ()  %xh:%xh\n",
       Snp->Cdb.StatFlags,
       Snp->Cdb.StatCode)
@@ -96,7 +96,7 @@ PxeReceive (
 
   default:
     DEBUG (
-      (EFI_D_ERROR,
+      (DEBUG_ERROR,
       "\nsnp->undi.receive()  %xh:%xh\n",
       Snp->Cdb.StatFlags,
       Snp->Cdb.StatCode)

--- a/NetworkPkg/SnpDxe/Receive_filters.c
+++ b/NetworkPkg/SnpDxe/Receive_filters.c
@@ -73,7 +73,7 @@ PxeRecvFilterEnable (
   //
   // Issue UNDI command and check result.
   //
-  DEBUG ((EFI_D_NET, "\nsnp->undi.receive_filters()  "));
+  DEBUG ((DEBUG_NET, "\nsnp->undi.receive_filters()  "));
 
   (*Snp->IssueUndi32Command) ((UINT64)(UINTN) &Snp->Cdb);
 
@@ -82,7 +82,7 @@ PxeRecvFilterEnable (
     // UNDI command failed.  Return UNDI status to caller.
     //
     DEBUG (
-      (EFI_D_ERROR,
+      (DEBUG_ERROR,
       "\nsnp->undi.receive_filters()  %xh:%xh\n",
       Snp->Cdb.StatFlags,
       Snp->Cdb.StatCode)
@@ -161,7 +161,7 @@ PxeRecvFilterDisable (
   //
   // Issue UNDI command and check result.
   //
-  DEBUG ((EFI_D_NET, "\nsnp->undi.receive_filters()  "));
+  DEBUG ((DEBUG_NET, "\nsnp->undi.receive_filters()  "));
 
   (*Snp->IssueUndi32Command) ((UINT64)(UINTN) &Snp->Cdb);
 
@@ -170,7 +170,7 @@ PxeRecvFilterDisable (
     // UNDI command failed.  Return UNDI status to caller.
     //
     DEBUG (
-      (EFI_D_ERROR,
+      (DEBUG_ERROR,
       "\nsnp->undi.receive_filters()  %xh:%xh\n",
       Snp->Cdb.StatFlags,
       Snp->Cdb.StatCode)
@@ -213,7 +213,7 @@ PxeRecvFilterRead (
   Snp->Cdb.IFnum      = Snp->IfNum;
   Snp->Cdb.Control    = PXE_CONTROL_LAST_CDB_IN_LIST;
 
-  DEBUG ((EFI_D_NET, "\nsnp->undi.receive_filters()  "));
+  DEBUG ((DEBUG_NET, "\nsnp->undi.receive_filters()  "));
 
   (*Snp->IssueUndi32Command) ((UINT64)(UINTN) &Snp->Cdb);
 
@@ -222,7 +222,7 @@ PxeRecvFilterRead (
     // UNDI command failed.  Return UNDI status to caller.
     //
     DEBUG (
-      (EFI_D_ERROR,
+      (DEBUG_ERROR,
       "\nsnp->undi.receive_filters()  %xh:%xh\n",
       Snp->Cdb.StatFlags,
       Snp->Cdb.StatCode)

--- a/NetworkPkg/SnpDxe/Reset.c
+++ b/NetworkPkg/SnpDxe/Reset.c
@@ -37,13 +37,13 @@ PxeReset (
   //
   // Issue UNDI command and check result.
   //
-  DEBUG ((EFI_D_NET, "\nsnp->undi.reset()  "));
+  DEBUG ((DEBUG_NET, "\nsnp->undi.reset()  "));
 
   (*Snp->IssueUndi32Command) ((UINT64)(UINTN) &Snp->Cdb);
 
   if (Snp->Cdb.StatCode != PXE_STATCODE_SUCCESS) {
     DEBUG (
-      (EFI_D_WARN,
+      (DEBUG_WARN,
       "\nsnp->undi32.reset()  %xh:%xh\n",
       Snp->Cdb.StatFlags,
       Snp->Cdb.StatCode)
@@ -98,7 +98,7 @@ SnpUndi32Reset (
   // Resolve Warning 4 unreferenced parameter problem
   //
   ExtendedVerification = 0;
-  DEBUG ((EFI_D_WARN, "ExtendedVerification = %d is not implemented!\n", ExtendedVerification));
+  DEBUG ((DEBUG_WARN, "ExtendedVerification = %d is not implemented!\n", ExtendedVerification));
 
   if (This == NULL) {
     return EFI_INVALID_PARAMETER;

--- a/NetworkPkg/SnpDxe/Shutdown.c
+++ b/NetworkPkg/SnpDxe/Shutdown.c
@@ -37,7 +37,7 @@ PxeShutdown (
   //
   // Issue UNDI command and check result.
   //
-  DEBUG ((EFI_D_NET, "\nsnp->undi.shutdown()  "));
+  DEBUG ((DEBUG_NET, "\nsnp->undi.shutdown()  "));
 
   (*Snp->IssueUndi32Command) ((UINT64)(UINTN) &Snp->Cdb);
 
@@ -45,7 +45,7 @@ PxeShutdown (
     //
     // UNDI could not be shutdown. Return UNDI error.
     //
-    DEBUG ((EFI_D_WARN, "\nsnp->undi.shutdown()  %xh:%xh\n", Snp->Cdb.StatFlags, Snp->Cdb.StatCode));
+    DEBUG ((DEBUG_WARN, "\nsnp->undi.shutdown()  %xh:%xh\n", Snp->Cdb.StatFlags, Snp->Cdb.StatCode));
 
     return EFI_DEVICE_ERROR;
   }

--- a/NetworkPkg/SnpDxe/Snp.c
+++ b/NetworkPkg/SnpDxe/Snp.c
@@ -50,7 +50,7 @@ IssueHwUndiCommand (
   UINT64 Cdb
   )
 {
-  DEBUG ((EFI_D_ERROR, "\nIssueHwUndiCommand() - This should not be called!"));
+  DEBUG ((DEBUG_ERROR, "\nIssueHwUndiCommand() - This should not be called!"));
 
   if (Cdb == 0) {
     return EFI_INVALID_PARAMETER;
@@ -149,12 +149,12 @@ SimpleNetworkDriverSupported (
 
   if (EFI_ERROR (Status)) {
     if (Status == EFI_ALREADY_STARTED) {
-      DEBUG ((EFI_D_INFO, "Support(): Already Started. on handle %p\n", Controller));
+      DEBUG ((DEBUG_INFO, "Support(): Already Started. on handle %p\n", Controller));
     }
     return Status;
   }
 
-  DEBUG ((EFI_D_INFO, "Support(): UNDI3.1 found on handle %p\n", Controller));
+  DEBUG ((DEBUG_INFO, "Support(): UNDI3.1 found on handle %p\n", Controller));
 
   //
   // check the version, we don't want to connect to the undi16
@@ -167,7 +167,7 @@ SimpleNetworkDriverSupported (
   // Check to see if !PXE structure is valid. Paragraph alignment of !PXE structure is required.
   //
   if ((NiiProtocol->Id & 0x0F) != 0) {
-    DEBUG ((EFI_D_NET, "\n!PXE structure is not paragraph aligned.\n"));
+    DEBUG ((DEBUG_NET, "\n!PXE structure is not paragraph aligned.\n"));
     Status = EFI_UNSUPPORTED;
     goto Done;
   }
@@ -178,25 +178,25 @@ SimpleNetworkDriverSupported (
   //  Verify !PXE revisions.
   //
   if (Pxe->hw.Signature != PXE_ROMID_SIGNATURE) {
-    DEBUG ((EFI_D_NET, "\n!PXE signature is not valid.\n"));
+    DEBUG ((DEBUG_NET, "\n!PXE signature is not valid.\n"));
     Status = EFI_UNSUPPORTED;
     goto Done;
   }
 
   if (Pxe->hw.Rev < PXE_ROMID_REV) {
-    DEBUG ((EFI_D_NET, "\n!PXE.Rev is not supported.\n"));
+    DEBUG ((DEBUG_NET, "\n!PXE.Rev is not supported.\n"));
     Status = EFI_UNSUPPORTED;
     goto Done;
   }
 
   if (Pxe->hw.MajorVer < PXE_ROMID_MAJORVER) {
 
-    DEBUG ((EFI_D_NET, "\n!PXE.MajorVer is not supported.\n"));
+    DEBUG ((DEBUG_NET, "\n!PXE.MajorVer is not supported.\n"));
     Status = EFI_UNSUPPORTED;
     goto Done;
 
   } else if (Pxe->hw.MajorVer == PXE_ROMID_MAJORVER && Pxe->hw.MinorVer < PXE_ROMID_MINORVER) {
-    DEBUG ((EFI_D_NET, "\n!PXE.MinorVer is not supported."));
+    DEBUG ((DEBUG_NET, "\n!PXE.MinorVer is not supported."));
     Status = EFI_UNSUPPORTED;
     goto Done;
   }
@@ -205,20 +205,20 @@ SimpleNetworkDriverSupported (
   //
   if ((Pxe->hw.Implementation & PXE_ROMID_IMP_HW_UNDI) == 0) {
     if (Pxe->sw.EntryPoint < Pxe->sw.Len) {
-      DEBUG ((EFI_D_NET, "\n!PXE S/W entry point is not valid."));
+      DEBUG ((DEBUG_NET, "\n!PXE S/W entry point is not valid."));
       Status = EFI_UNSUPPORTED;
       goto Done;
     }
 
     if (Pxe->sw.BusCnt == 0) {
-      DEBUG ((EFI_D_NET, "\n!PXE.BusCnt is zero."));
+      DEBUG ((DEBUG_NET, "\n!PXE.BusCnt is zero."));
       Status = EFI_UNSUPPORTED;
       goto Done;
     }
   }
 
   Status = EFI_SUCCESS;
-  DEBUG ((EFI_D_INFO, "Support(): supported on %p\n", Controller));
+  DEBUG ((DEBUG_INFO, "Support(): supported on %p\n", Controller));
 
 Done:
   gBS->CloseProtocol (
@@ -271,7 +271,7 @@ SimpleNetworkDriverStart (
   BOOLEAN                                   FoundIoBar;
   BOOLEAN                                   FoundMemoryBar;
 
-  DEBUG ((EFI_D_NET, "\nSnpNotifyNetworkInterfaceIdentifier()  "));
+  DEBUG ((DEBUG_NET, "\nSnpNotifyNetworkInterfaceIdentifier()  "));
 
   Status = gBS->OpenProtocol (
                   Controller,
@@ -328,12 +328,12 @@ SimpleNetworkDriverStart (
     return Status;
   }
 
-  DEBUG ((EFI_D_INFO, "Start(): UNDI3.1 found\n"));
+  DEBUG ((DEBUG_INFO, "Start(): UNDI3.1 found\n"));
 
   Pxe = (PXE_UNDI *) (UINTN) (Nii->Id);
 
   if (Calc8BitCksum (Pxe, Pxe->hw.Len) != 0) {
-    DEBUG ((EFI_D_NET, "\n!PXE checksum is not correct.\n"));
+    DEBUG ((DEBUG_NET, "\n!PXE checksum is not correct.\n"));
     goto NiiError;
   }
 
@@ -348,7 +348,7 @@ SimpleNetworkDriverStart (
     //  broadcast support or we cannot do DHCP!
     //
   } else {
-    DEBUG ((EFI_D_NET, "\nUNDI does not have promiscuous or broadcast support."));
+    DEBUG ((DEBUG_NET, "\nUNDI does not have promiscuous or broadcast support."));
     goto NiiError;
   }
   //
@@ -365,7 +365,7 @@ SimpleNetworkDriverStart (
                     );
 
   if (Status != EFI_SUCCESS) {
-    DEBUG ((EFI_D_NET, "\nCould not allocate SNP_DRIVER structure.\n"));
+    DEBUG ((DEBUG_NET, "\nCould not allocate SNP_DRIVER structure.\n"));
     goto NiiError;
   }
 
@@ -452,7 +452,7 @@ SimpleNetworkDriverStart (
                     );
 
   if (Status != EFI_SUCCESS) {
-    DEBUG ((EFI_D_NET, "\nCould not allocate CPB and DB structures.\n"));
+    DEBUG ((DEBUG_NET, "\nCould not allocate CPB and DB structures.\n"));
     goto Error_DeleteSNP;
   }
 
@@ -519,7 +519,7 @@ SimpleNetworkDriverStart (
   Snp->Cdb.IFnum      = Snp->IfNum;
   Snp->Cdb.Control    = PXE_CONTROL_LAST_CDB_IN_LIST;
 
-  DEBUG ((EFI_D_NET, "\nSnp->undi.get_init_info()  "));
+  DEBUG ((DEBUG_NET, "\nSnp->undi.get_init_info()  "));
 
   (*Snp->IssueUndi32Command) ((UINT64)(UINTN) &Snp->Cdb);
 
@@ -529,7 +529,7 @@ SimpleNetworkDriverStart (
   InitStatFlags = Snp->Cdb.StatFlags;
 
   if (Snp->Cdb.StatCode != PXE_STATCODE_SUCCESS) {
-    DEBUG ((EFI_D_NET, "\nSnp->undi.init_info()  %xh:%xh\n", Snp->Cdb.StatFlags, Snp->Cdb.StatCode));
+    DEBUG ((DEBUG_NET, "\nSnp->undi.init_info()  %xh:%xh\n", Snp->Cdb.StatFlags, Snp->Cdb.StatCode));
     PxeStop (Snp);
     goto Error_DeleteSNP;
   }
@@ -627,7 +627,7 @@ SimpleNetworkDriverStart (
   Status = PxeGetStnAddr (Snp);
 
   if (Status != EFI_SUCCESS) {
-    DEBUG ((EFI_D_ERROR, "\nSnp->undi.get_station_addr() failed.\n"));
+    DEBUG ((DEBUG_ERROR, "\nSnp->undi.get_station_addr() failed.\n"));
     PxeShutdown (Snp);
     PxeStop (Snp);
     goto Error_DeleteSNP;

--- a/NetworkPkg/SnpDxe/Start.c
+++ b/NetworkPkg/SnpDxe/Start.c
@@ -66,7 +66,7 @@ PxeStart (
   //
   // Issue UNDI command and check result.
   //
-  DEBUG ((EFI_D_NET, "\nsnp->undi.start()  "));
+  DEBUG ((DEBUG_NET, "\nsnp->undi.start()  "));
 
   (*Snp->IssueUndi32Command) ((UINT64)(UINTN) &Snp->Cdb);
 
@@ -75,7 +75,7 @@ PxeStart (
     // UNDI could not be started. Return UNDI error.
     //
     DEBUG (
-      (EFI_D_ERROR,
+      (DEBUG_ERROR,
       "\nsnp->undi.start()  %xh:%xh\n",
       Snp->Cdb.StatCode,
       Snp->Cdb.StatFlags)

--- a/NetworkPkg/SnpDxe/Station_address.c
+++ b/NetworkPkg/SnpDxe/Station_address.c
@@ -44,13 +44,13 @@ PxeGetStnAddr (
   //
   // Issue UNDI command and check result.
   //
-  DEBUG ((EFI_D_NET, "\nsnp->undi.station_addr()  "));
+  DEBUG ((DEBUG_NET, "\nsnp->undi.station_addr()  "));
 
   (*Snp->IssueUndi32Command) ((UINT64)(UINTN) &Snp->Cdb);
 
   if (Snp->Cdb.StatCode != PXE_STATCODE_SUCCESS) {
     DEBUG (
-      (EFI_D_ERROR,
+      (DEBUG_ERROR,
       "\nsnp->undi.station_addr()  %xh:%xh\n",
       Snp->Cdb.StatFlags,
       Snp->Cdb.StatCode)
@@ -132,13 +132,13 @@ PxeSetStnAddr (
   //
   // Issue UNDI command and check result.
   //
-  DEBUG ((EFI_D_NET, "\nsnp->undi.station_addr()  "));
+  DEBUG ((DEBUG_NET, "\nsnp->undi.station_addr()  "));
 
   (*Snp->IssueUndi32Command) ((UINT64)(UINTN) &Snp->Cdb);
 
   if (Snp->Cdb.StatCode != PXE_STATCODE_SUCCESS) {
     DEBUG (
-      (EFI_D_ERROR,
+      (DEBUG_ERROR,
       "\nsnp->undi.station_addr()  %xh:%xh\n",
       Snp->Cdb.StatFlags,
       Snp->Cdb.StatCode)

--- a/NetworkPkg/SnpDxe/Statistics.c
+++ b/NetworkPkg/SnpDxe/Statistics.c
@@ -133,7 +133,7 @@ SnpUndi32Statistics (
   //
   // Issue UNDI command and check result.
   //
-  DEBUG ((EFI_D_NET, "\nsnp->undi.statistics()  "));
+  DEBUG ((DEBUG_NET, "\nsnp->undi.statistics()  "));
 
   (*Snp->IssueUndi32Command) ((UINT64)(UINTN) &Snp->Cdb);
 
@@ -143,7 +143,7 @@ SnpUndi32Statistics (
 
   case PXE_STATCODE_UNSUPPORTED:
     DEBUG (
-      (EFI_D_ERROR,
+      (DEBUG_ERROR,
       "\nsnp->undi.statistics()  %xh:%xh\n",
       Snp->Cdb.StatFlags,
       Snp->Cdb.StatCode)
@@ -154,7 +154,7 @@ SnpUndi32Statistics (
 
   default:
     DEBUG (
-      (EFI_D_ERROR,
+      (DEBUG_ERROR,
       "\nsnp->undi.statistics()  %xh:%xh\n",
       Snp->Cdb.StatFlags,
       Snp->Cdb.StatCode)

--- a/NetworkPkg/SnpDxe/Stop.c
+++ b/NetworkPkg/SnpDxe/Stop.c
@@ -37,13 +37,13 @@ PxeStop (
   //
   // Issue UNDI command
   //
-  DEBUG ((EFI_D_NET, "\nsnp->undi.stop()  "));
+  DEBUG ((DEBUG_NET, "\nsnp->undi.stop()  "));
 
   (*Snp->IssueUndi32Command) ((UINT64)(UINTN) &Snp->Cdb);
 
   if (Snp->Cdb.StatCode != PXE_STATCODE_SUCCESS) {
     DEBUG (
-      (EFI_D_WARN,
+      (DEBUG_WARN,
       "\nsnp->undi.stop()  %xh:%xh\n",
       Snp->Cdb.StatFlags,
       Snp->Cdb.StatCode)

--- a/NetworkPkg/SnpDxe/Transmit.c
+++ b/NetworkPkg/SnpDxe/Transmit.c
@@ -95,7 +95,7 @@ PxeFillHeader (
   //
   // Issue UNDI command and check result.
   //
-  DEBUG ((EFI_D_NET, "\nSnp->undi.fill_header()  "));
+  DEBUG ((DEBUG_NET, "\nSnp->undi.fill_header()  "));
 
   (*Snp->IssueUndi32Command) ((UINT64) (UINTN) &Snp->Cdb);
 
@@ -105,7 +105,7 @@ PxeFillHeader (
 
   case PXE_STATCODE_INVALID_PARAMETER:
     DEBUG (
-      (EFI_D_ERROR,
+      (DEBUG_ERROR,
       "\nSnp->undi.fill_header()  %xh:%xh\n",
       Snp->Cdb.StatFlags,
       Snp->Cdb.StatCode)
@@ -115,7 +115,7 @@ PxeFillHeader (
 
   default:
     DEBUG (
-      (EFI_D_ERROR,
+      (DEBUG_ERROR,
       "\nSnp->undi.fill_header()  %xh:%xh\n",
       Snp->Cdb.StatFlags,
       Snp->Cdb.StatCode)
@@ -171,15 +171,15 @@ PxeTransmit (
   //
   // Issue UNDI command and check result.
   //
-  DEBUG ((EFI_D_NET, "\nSnp->undi.transmit()  "));
-  DEBUG ((EFI_D_NET, "\nSnp->Cdb.OpCode  == %x", Snp->Cdb.OpCode));
-  DEBUG ((EFI_D_NET, "\nSnp->Cdb.CPBaddr == %LX", Snp->Cdb.CPBaddr));
-  DEBUG ((EFI_D_NET, "\nSnp->Cdb.DBaddr  == %LX", Snp->Cdb.DBaddr));
-  DEBUG ((EFI_D_NET, "\nCpb->FrameAddr   == %LX\n", Cpb->FrameAddr));
+  DEBUG ((DEBUG_NET, "\nSnp->undi.transmit()  "));
+  DEBUG ((DEBUG_NET, "\nSnp->Cdb.OpCode  == %x", Snp->Cdb.OpCode));
+  DEBUG ((DEBUG_NET, "\nSnp->Cdb.CPBaddr == %LX", Snp->Cdb.CPBaddr));
+  DEBUG ((DEBUG_NET, "\nSnp->Cdb.DBaddr  == %LX", Snp->Cdb.DBaddr));
+  DEBUG ((DEBUG_NET, "\nCpb->FrameAddr   == %LX\n", Cpb->FrameAddr));
 
   (*Snp->IssueUndi32Command) ((UINT64) (UINTN) &Snp->Cdb);
 
-  DEBUG ((EFI_D_NET, "\nexit Snp->undi.transmit()  "));
+  DEBUG ((DEBUG_NET, "\nexit Snp->undi.transmit()  "));
 
   //
   // we will unmap the buffers in get_status call, not here
@@ -193,7 +193,7 @@ PxeTransmit (
   case PXE_STATCODE_BUSY:
     Status = EFI_NOT_READY;
     DEBUG (
-      (EFI_D_NET,
+      (DEBUG_NET,
       "\nSnp->undi.transmit()  %xh:%xh\n",
       Snp->Cdb.StatFlags,
       Snp->Cdb.StatCode)
@@ -202,7 +202,7 @@ PxeTransmit (
 
   default:
     DEBUG (
-      (EFI_D_ERROR,
+      (DEBUG_ERROR,
       "\nSnp->undi.transmit()  %xh:%xh\n",
       Snp->Cdb.StatFlags,
       Snp->Cdb.StatCode)

--- a/NetworkPkg/TcpDxe/SockImpl.c
+++ b/NetworkPkg/TcpDxe/SockImpl.c
@@ -381,7 +381,7 @@ SockProcessTcpSndData (
 
   if (NULL == SndData) {
     DEBUG (
-      (EFI_D_ERROR,
+      (DEBUG_ERROR,
       "SockKProcessSndData: Failed to call NetBufferFromExt\n")
       );
 
@@ -516,7 +516,7 @@ SockWakeListenToken (
 
     Parent->ConnCnt--;
     DEBUG (
-      (EFI_D_NET,
+      (DEBUG_NET,
       "SockWakeListenToken: accept a socket, now conncnt is %d",
       Parent->ConnCnt)
       );
@@ -667,7 +667,7 @@ SockCreate (
 
   if ((Parent != NULL) && (Parent->ConnCnt == Parent->BackLog)) {
     DEBUG (
-      (EFI_D_ERROR,
+      (DEBUG_ERROR,
       "SockCreate: Socket parent has reached its connection limit with %d ConnCnt and %d BackLog\n",
       Parent->ConnCnt,
       Parent->BackLog)
@@ -679,7 +679,7 @@ SockCreate (
   Sock = AllocateZeroPool (sizeof (SOCKET));
   if (NULL == Sock) {
 
-    DEBUG ((EFI_D_ERROR, "SockCreate: No resource to create a new socket\n"));
+    DEBUG ((DEBUG_ERROR, "SockCreate: No resource to create a new socket\n"));
     return NULL;
   }
 
@@ -695,7 +695,7 @@ SockCreate (
   Sock->SndBuffer.DataQueue = NetbufQueAlloc ();
   if (NULL == Sock->SndBuffer.DataQueue) {
     DEBUG (
-      (EFI_D_ERROR,
+      (DEBUG_ERROR,
       "SockCreate: No resource to allocate SndBuffer for new socket\n")
       );
 
@@ -705,7 +705,7 @@ SockCreate (
   Sock->RcvBuffer.DataQueue = NetbufQueAlloc ();
   if (NULL == Sock->RcvBuffer.DataQueue) {
     DEBUG (
-      (EFI_D_ERROR,
+      (DEBUG_ERROR,
       "SockCreate: No resource to allocate RcvBuffer for new socket\n")
       );
 
@@ -751,7 +751,7 @@ SockCreate (
 
   if (EFI_ERROR (Status)) {
     DEBUG (
-      (EFI_D_ERROR,
+      (DEBUG_ERROR,
       "SockCreate: Install TCP protocol in socket failed with %r\n",
       Status)
       );
@@ -770,7 +770,7 @@ SockCreate (
     Parent->ConnCnt++;
 
     DEBUG (
-      (EFI_D_NET,
+      (DEBUG_NET,
       "SockCreate: Create a new socket and add to parent, now conncnt is %d\n",
       Parent->ConnCnt)
       );
@@ -850,7 +850,7 @@ SockDestroy (
     (Sock->Parent->ConnCnt)--;
 
     DEBUG (
-      (EFI_D_WARN,
+      (DEBUG_WARN,
       "SockDestroy: Delete a unaccepted socket from parent now conncnt is %d\n",
       Sock->Parent->ConnCnt)
       );
@@ -975,7 +975,7 @@ SockClone (
   ClonedSock               = SockCreate (&InitData);
 
   if (NULL == ClonedSock) {
-    DEBUG ((EFI_D_ERROR, "SockClone: no resource to create a cloned sock\n"));
+    DEBUG ((DEBUG_ERROR, "SockClone: no resource to create a cloned sock\n"));
     return NULL;
   }
 
@@ -1230,4 +1230,3 @@ SockNoMoreData (
 
   }
 }
-

--- a/NetworkPkg/TcpDxe/SockInterface.c
+++ b/NetworkPkg/TcpDxe/SockInterface.c
@@ -107,7 +107,7 @@ SockBufferToken (
   if (NULL == SockToken) {
 
     DEBUG (
-      (EFI_D_ERROR,
+      (DEBUG_ERROR,
       "SockBufferIOToken: No Memory to allocate SockToken\n")
       );
 
@@ -192,7 +192,7 @@ SockDestroyChild (
   if (EFI_ERROR (Status)) {
 
     DEBUG (
-      (EFI_D_ERROR,
+      (DEBUG_ERROR,
       "SockDestroyChild: Open protocol installed on socket failed with %r\n",
       Status)
       );
@@ -213,7 +213,7 @@ SockDestroyChild (
   if (EFI_ERROR (Status)) {
 
     DEBUG (
-      (EFI_D_ERROR,
+      (DEBUG_ERROR,
       "SockDestroyChild: Get the lock to access socket failed with %r\n",
       Status)
       );
@@ -229,7 +229,7 @@ SockDestroyChild (
   if (EFI_ERROR (Status)) {
 
     DEBUG (
-      (EFI_D_ERROR,
+      (DEBUG_ERROR,
       "SockDestroyChild: Protocol detach socket failed with %r\n",
       Status)
       );
@@ -280,7 +280,7 @@ SockCreateChild (
   if (NULL == Sock) {
 
     DEBUG (
-      (EFI_D_ERROR,
+      (DEBUG_ERROR,
       "SockCreateChild: No resource to create a new socket\n")
       );
 
@@ -291,7 +291,7 @@ SockCreateChild (
   if (EFI_ERROR (Status)) {
 
     DEBUG (
-      (EFI_D_ERROR,
+      (DEBUG_ERROR,
       "SockCreateChild: Get the lock to access socket failed with %r\n",
       Status)
       );
@@ -306,7 +306,7 @@ SockCreateChild (
   if (EFI_ERROR (Status)) {
 
     DEBUG (
-      (EFI_D_ERROR,
+      (DEBUG_ERROR,
       "SockCreateChild: Protocol failed to attach a socket with %r\n",
       Status)
       );
@@ -371,7 +371,7 @@ SockConfigure (
   if (EFI_ERROR (Status)) {
 
     DEBUG (
-      (EFI_D_ERROR,
+      (DEBUG_ERROR,
       "SockConfigure: Get the access for socket failed with %r",
       Status)
       );
@@ -425,7 +425,7 @@ SockConnect (
   if (EFI_ERROR (Status)) {
 
     DEBUG (
-      (EFI_D_ERROR,
+      (DEBUG_ERROR,
       "SockConnect: Get the access for socket failed with %r",
       Status)
       );
@@ -504,7 +504,7 @@ SockAccept (
   if (EFI_ERROR (Status)) {
 
     DEBUG (
-      (EFI_D_ERROR,
+      (DEBUG_ERROR,
       "SockAccept: Get the access for socket failed with %r",
       Status)
       );
@@ -557,7 +557,7 @@ SockAccept (
       Socket->Parent->ConnCnt--;
 
       DEBUG (
-        (EFI_D_NET,
+        (DEBUG_NET,
         "SockAccept: Accept a socket, now conncount is %d",
         Socket->Parent->ConnCnt)
         );
@@ -619,7 +619,7 @@ SockSend (
   if (EFI_ERROR (Status)) {
 
     DEBUG (
-      (EFI_D_ERROR,
+      (DEBUG_ERROR,
       "SockSend: Get the access for socket failed with %r",
       Status)
       );
@@ -686,7 +686,7 @@ SockSend (
 
     if (NULL == SockToken) {
       DEBUG (
-        (EFI_D_ERROR,
+        (DEBUG_ERROR,
         "SockSend: Failed to buffer IO token into socket processing SndToken List\n",
         Status)
         );
@@ -699,7 +699,7 @@ SockSend (
 
     if (EFI_ERROR (Status)) {
       DEBUG (
-        (EFI_D_ERROR,
+        (DEBUG_ERROR,
         "SockSend: Failed to process Snd Data\n",
         Status)
         );
@@ -750,7 +750,7 @@ SockRcv (
   if (EFI_ERROR (Status)) {
 
     DEBUG (
-      (EFI_D_ERROR,
+      (DEBUG_ERROR,
       "SockRcv: Get the access for socket failed with %r",
       Status)
       );
@@ -848,7 +848,7 @@ SockFlush (
   if (EFI_ERROR (Status)) {
 
     DEBUG (
-      (EFI_D_ERROR,
+      (DEBUG_ERROR,
       "SockFlush: Get the access for socket failed with %r",
       Status)
       );
@@ -866,7 +866,7 @@ SockFlush (
   if (EFI_ERROR (Status)) {
 
     DEBUG (
-      (EFI_D_ERROR,
+      (DEBUG_ERROR,
       "SockFlush: Protocol failed handling SOCK_FLUSH with %r",
       Status)
       );
@@ -919,7 +919,7 @@ SockClose (
   Status = EfiAcquireLockOrFail (&(Sock->Lock));
   if (EFI_ERROR (Status)) {
     DEBUG (
-      (EFI_D_ERROR,
+      (DEBUG_ERROR,
       "SockClose: Get the access for socket failed with %r",
       Status)
       );
@@ -990,7 +990,7 @@ SockCancel (
   Status = EfiAcquireLockOrFail (&(Sock->Lock));
   if (EFI_ERROR (Status)) {
     DEBUG (
-      (EFI_D_ERROR,
+      (DEBUG_ERROR,
       "SockCancel: Get the access for socket failed with %r",
       Status)
       );
@@ -1099,7 +1099,7 @@ SockRoute (
   Status = EfiAcquireLockOrFail (&(Sock->Lock));
   if (EFI_ERROR (Status)) {
     DEBUG (
-      (EFI_D_ERROR,
+      (DEBUG_ERROR,
       "SockRoute: Get the access for socket failed with %r",
       Status)
       );
@@ -1123,4 +1123,3 @@ Exit:
   EfiReleaseLock (&(Sock->Lock));
   return Status;
 }
-

--- a/NetworkPkg/TcpDxe/TcpDispatcher.c
+++ b/NetworkPkg/TcpDxe/TcpDispatcher.c
@@ -269,7 +269,7 @@ TcpBind (
       if (*RandomPort <= TCP_PORT_KNOWN) {
         if (Cycle) {
           DEBUG (
-            (EFI_D_ERROR,
+            (DEBUG_ERROR,
             "TcpBind: no port can be allocated for this pcb\n")
             );
           return EFI_OUT_OF_RESOURCES;
@@ -359,7 +359,7 @@ TcpAttachPcb (
 
   if (Tcb == NULL) {
 
-    DEBUG ((EFI_D_ERROR, "TcpConfigurePcb: failed to allocate a TCB\n"));
+    DEBUG ((DEBUG_ERROR, "TcpConfigurePcb: failed to allocate a TCB\n"));
 
     return EFI_OUT_OF_RESOURCES;
   }
@@ -540,7 +540,7 @@ TcpConfigurePcb (
 
   if (EFI_ERROR (Status)) {
     DEBUG (
-      (EFI_D_ERROR,
+      (DEBUG_ERROR,
       "TcpConfigurePcb: Bind endpoint failed with %r\n",
       Status)
       );

--- a/NetworkPkg/TcpDxe/TcpDriver.c
+++ b/NetworkPkg/TcpDxe/TcpDriver.c
@@ -905,7 +905,7 @@ TcpServiceBindingCreateChild (
   Sock = SockCreateChild (&mTcpDefaultSockData);
   if (NULL == Sock) {
     DEBUG (
-      (EFI_D_ERROR,
+      (DEBUG_ERROR,
       "TcpDriverBindingCreateChild: No resource to create a Tcp Child\n")
       );
 

--- a/NetworkPkg/TcpDxe/TcpInput.c
+++ b/NetworkPkg/TcpDxe/TcpInput.c
@@ -68,7 +68,7 @@ TcpFastRecover (
     Tcb->CWnd = Tcb->Ssthresh + 3 * Tcb->SndMss;
 
     DEBUG (
-      (EFI_D_NET,
+      (DEBUG_NET,
       "TcpFastRecover: enter fast retransmission for TCB %p, recover point is %d\n",
       Tcb,
       Tcb->Recover)
@@ -91,7 +91,7 @@ TcpFastRecover (
     //
     Tcb->CWnd += Tcb->SndMss;
     DEBUG (
-      (EFI_D_NET,
+      (DEBUG_NET,
       "TcpFastRecover: received another duplicated ACK (%d) for TCB %p\n",
       Seg->Ack,
       Tcb)
@@ -115,7 +115,7 @@ TcpFastRecover (
 
       Tcb->CongestState = TCP_CONGEST_OPEN;
       DEBUG (
-        (EFI_D_NET,
+        (DEBUG_NET,
         "TcpFastRecover: received a full ACK(%d) for TCB %p, exit fast recovery\n",
         Seg->Ack,
         Tcb)
@@ -144,7 +144,7 @@ TcpFastRecover (
       Tcb->CWnd -= Acked;
 
       DEBUG (
-        (EFI_D_NET,
+        (DEBUG_NET,
         "TcpFastRecover: received a partial ACK(%d) for TCB %p\n",
         Seg->Ack,
         Tcb)
@@ -182,7 +182,7 @@ TcpFastLossRecover (
       Tcb->CongestState = TCP_CONGEST_OPEN;
 
       DEBUG (
-        (EFI_D_NET,
+        (DEBUG_NET,
         "TcpFastLossRecover: received a full ACK(%d) for TCB %p\n",
         Seg->Ack,
         Tcb)
@@ -196,7 +196,7 @@ TcpFastLossRecover (
       //
       TcpRetransmit (Tcb, Seg->Ack);
       DEBUG (
-        (EFI_D_NET,
+        (DEBUG_NET,
         "TcpFastLossRecover: received a partial ACK(%d) for TCB %p\n",
         Seg->Ack,
         Tcb)
@@ -258,7 +258,7 @@ TcpComputeRtt (
   }
 
   DEBUG (
-    (EFI_D_NET,
+    (DEBUG_NET,
     "TcpComputeRtt: new RTT for TCB %p computed SRTT: %d RTTVAR: %d RTO: %d\n",
     Tcb,
     Tcb->SRtt,
@@ -423,7 +423,7 @@ TcpDeliverData (
 
     if (TcpVerifySegment (Nbuf) == 0) {
       DEBUG (
-        (EFI_D_ERROR,
+        (DEBUG_ERROR,
         "TcpToSendData: discard a broken segment for TCB %p\n",
         Tcb)
         );
@@ -454,7 +454,7 @@ TcpDeliverData (
       //
       if (!IsListEmpty (&Tcb->RcvQue)) {
         DEBUG (
-          (EFI_D_ERROR,
+          (DEBUG_ERROR,
           "TcpDeliverData: data received after FIN from peer of TCB %p, reset connection\n",
           Tcb)
           );
@@ -464,7 +464,7 @@ TcpDeliverData (
       }
 
       DEBUG (
-        (EFI_D_NET,
+        (DEBUG_NET,
         "TcpDeliverData: processing FIN from peer of TCB %p\n",
         Tcb)
         );
@@ -498,7 +498,7 @@ TcpDeliverData (
         } else {
 
           DEBUG (
-            (EFI_D_WARN,
+            (DEBUG_WARN,
             "Connection closed immediately because app disables TIME_WAIT timer for %p\n",
             Tcb)
             );
@@ -771,7 +771,7 @@ TcpInput (
   ASSERT (Head != NULL);
 
   if (Nbuf->TotalSize < sizeof (TCP_HEAD)) {
-    DEBUG ((EFI_D_NET, "TcpInput: received a malformed packet\n"));
+    DEBUG ((DEBUG_NET, "TcpInput: received a malformed packet\n"));
     goto DISCARD;
   }
 
@@ -779,7 +779,7 @@ TcpInput (
 
   if ((Head->HeadLen < 5) || (Len < 0)) {
 
-    DEBUG ((EFI_D_NET, "TcpInput: received a malformed packet\n"));
+    DEBUG ((DEBUG_NET, "TcpInput: received a malformed packet\n"));
 
     goto DISCARD;
   }
@@ -793,7 +793,7 @@ TcpInput (
   Checksum = TcpChecksum (Nbuf, Checksum);
 
   if (Checksum != 0) {
-    DEBUG ((EFI_D_ERROR, "TcpInput: received a checksum error packet\n"));
+    DEBUG ((DEBUG_ERROR, "TcpInput: received a checksum error packet\n"));
     goto DISCARD;
   }
 
@@ -815,7 +815,7 @@ TcpInput (
           );
 
   if ((Tcb == NULL) || (Tcb->State == TCP_CLOSED)) {
-    DEBUG ((EFI_D_NET, "TcpInput: send reset because no TCB found\n"));
+    DEBUG ((DEBUG_NET, "TcpInput: send reset because no TCB found\n"));
 
     Tcb = NULL;
     goto SEND_RESET;
@@ -829,7 +829,7 @@ TcpInput (
   //
   if (TcpParseOption (Nbuf->Tcp, &Option) == -1) {
     DEBUG (
-      (EFI_D_ERROR,
+      (DEBUG_ERROR,
       "TcpInput: reset the peer because of malformed option for TCB %p\n",
       Tcb)
       );
@@ -852,7 +852,7 @@ TcpInput (
     //
     if (TCP_FLG_ON (Seg->Flag, TCP_FLG_RST)) {
       DEBUG (
-        (EFI_D_WARN,
+        (DEBUG_WARN,
         "TcpInput: discard a reset segment for TCB %p in listening\n",
         Tcb)
         );
@@ -866,7 +866,7 @@ TcpInput (
     //
     if (TCP_FLG_ON (Seg->Flag, TCP_FLG_ACK)) {
       DEBUG (
-        (EFI_D_WARN,
+        (DEBUG_WARN,
         "TcpInput: send reset because of segment with ACK for TCB %p in listening\n",
         Tcb)
         );
@@ -886,7 +886,7 @@ TcpInput (
       Tcb     = TcpCloneTcb (Parent);
       if (Tcb == NULL) {
         DEBUG (
-          (EFI_D_ERROR,
+          (DEBUG_ERROR,
           "TcpInput: discard a segment because failed to clone a child for TCB %p\n",
           Tcb)
           );
@@ -895,7 +895,7 @@ TcpInput (
       }
 
       DEBUG (
-        (EFI_D_NET,
+        (DEBUG_NET,
         "TcpInput: create a child for TCB %p in listening\n",
         Tcb)
         );
@@ -915,7 +915,7 @@ TcpInput (
       TcpSetTimer (Tcb, TCP_TIMER_CONNECT, Tcb->ConnectTimeout);
       if (TcpTrimInWnd (Tcb, Nbuf) == 0) {
         DEBUG (
-          (EFI_D_ERROR,
+          (DEBUG_ERROR,
           "TcpInput: discard a broken segment for TCB %p\n",
           Tcb)
           );
@@ -935,7 +935,7 @@ TcpInput (
     if (TCP_FLG_ON (Seg->Flag, TCP_FLG_ACK) && (Seg->Ack != Tcb->Iss + 1)) {
 
       DEBUG (
-        (EFI_D_WARN,
+        (DEBUG_WARN,
         "TcpInput: send reset because of wrong ACK received for TCB %p in SYN_SENT\n",
         Tcb)
         );
@@ -951,7 +951,7 @@ TcpInput (
       if (TCP_FLG_ON (Seg->Flag, TCP_FLG_ACK)) {
 
         DEBUG (
-          (EFI_D_WARN,
+          (DEBUG_WARN,
           "TcpInput: connection reset by peer for TCB %p in SYN_SENT\n",
           Tcb)
           );
@@ -961,7 +961,7 @@ TcpInput (
       } else {
 
         DEBUG (
-          (EFI_D_WARN,
+          (DEBUG_WARN,
           "TcpInput: discard a reset segment because of no ACK for TCB %p in SYN_SENT\n",
           Tcb)
           );
@@ -1005,7 +1005,7 @@ TcpInput (
 
         if (TcpTrimInWnd (Tcb, Nbuf) == 0) {
           DEBUG (
-            (EFI_D_ERROR,
+            (DEBUG_ERROR,
             "TcpInput: discard a broken segment for TCB %p\n",
             Tcb)
             );
@@ -1016,7 +1016,7 @@ TcpInput (
         TCP_SET_FLG (Tcb->CtrlFlag, TCP_CTRL_ACK_NOW);
 
         DEBUG (
-          (EFI_D_NET,
+          (DEBUG_NET,
           "TcpInput: connection established for TCB %p in SYN_SENT\n",
           Tcb)
           );
@@ -1032,7 +1032,7 @@ TcpInput (
 
         if (TcpAdjustSndQue (Tcb, Tcb->SndNxt) == 0 || TcpTrimInWnd (Tcb, Nbuf) == 0) {
           DEBUG (
-            (EFI_D_ERROR,
+            (DEBUG_ERROR,
             "TcpInput: discard a broken segment for TCB %p\n",
             Tcb)
             );
@@ -1041,7 +1041,7 @@ TcpInput (
         }
 
         DEBUG (
-          (EFI_D_WARN,
+          (DEBUG_WARN,
           "TcpInput: simultaneous open for TCB %p in SYN_SENT\n",
           Tcb)
           );
@@ -1070,7 +1070,7 @@ TcpInput (
   //
   if (TcpSeqAcceptable (Tcb, Seg) == 0) {
     DEBUG (
-      (EFI_D_WARN,
+      (DEBUG_WARN,
       "TcpInput: sequence acceptance test failed for segment of TCB %p\n",
       Tcb)
       );
@@ -1095,7 +1095,7 @@ TcpInput (
   //
   if (TCP_FLG_ON (Seg->Flag, TCP_FLG_RST)) {
 
-    DEBUG ((EFI_D_WARN, "TcpInput: connection reset for TCB %p\n", Tcb));
+    DEBUG ((DEBUG_WARN, "TcpInput: connection reset for TCB %p\n", Tcb));
 
     if (Tcb->State == TCP_SYN_RCVD) {
 
@@ -1126,7 +1126,7 @@ TcpInput (
   //
   if (TcpTrimInWnd (Tcb, Nbuf) == 0) {
     DEBUG (
-      (EFI_D_ERROR,
+      (DEBUG_ERROR,
       "TcpInput: discard a broken segment for TCB %p\n",
       Tcb)
       );
@@ -1144,7 +1144,7 @@ TcpInput (
   if (TCP_FLG_ON (Seg->Flag, TCP_FLG_SYN)) {
 
     DEBUG (
-      (EFI_D_WARN,
+      (DEBUG_WARN,
       "TcpInput: connection reset because received extra SYN for TCB %p\n",
       Tcb)
       );
@@ -1157,7 +1157,7 @@ TcpInput (
   //
   if (!TCP_FLG_ON (Seg->Flag, TCP_FLG_ACK)) {
     DEBUG (
-      (EFI_D_WARN,
+      (DEBUG_WARN,
       "TcpInput: segment discard because of no ACK for connected TCB %p\n",
       Tcb)
       );
@@ -1186,7 +1186,7 @@ TcpInput (
       TcpDeliverData (Tcb);
 
       DEBUG (
-        (EFI_D_NET,
+        (DEBUG_NET,
         "TcpInput: connection established for TCB %p in SYN_RCVD\n",
         Tcb)
         );
@@ -1196,7 +1196,7 @@ TcpInput (
       //
     } else {
       DEBUG (
-        (EFI_D_WARN,
+        (DEBUG_WARN,
         "TcpInput: send reset because of wrong ACK for TCB %p in SYN_RCVD\n",
         Tcb)
         );
@@ -1208,7 +1208,7 @@ TcpInput (
   if (TCP_SEQ_LT (Seg->Ack, Tcb->SndUna)) {
 
     DEBUG (
-      (EFI_D_WARN,
+      (DEBUG_WARN,
       "TcpInput: ignore the out-of-data ACK for connected TCB %p\n",
       Tcb)
       );
@@ -1218,7 +1218,7 @@ TcpInput (
   } else if (TCP_SEQ_GT (Seg->Ack, Tcb->SndNxt)) {
 
     DEBUG (
-      (EFI_D_WARN,
+      (DEBUG_WARN,
       "TcpInput: discard segment for future ACK for connected TCB %p\n",
       Tcb)
       );
@@ -1309,7 +1309,7 @@ TcpInput (
 
     if (TcpAdjustSndQue (Tcb, Seg->Ack) == 0) {
       DEBUG (
-        (EFI_D_ERROR,
+        (DEBUG_ERROR,
         "TcpInput: discard a broken segment for TCB %p\n",
         Tcb)
         );
@@ -1347,7 +1347,7 @@ TcpInput (
       }
 
       DEBUG (
-        (EFI_D_WARN,
+        (DEBUG_WARN,
         "TcpInput: peer shrinks the window for connected TCB %p\n",
         Tcb)
         );
@@ -1375,14 +1375,14 @@ TcpInput (
         // 2^Rcv.Wind.Shift before moving the SndNxt to the left.
         //
         DEBUG (
-          (EFI_D_WARN,
+          (DEBUG_WARN,
           "TcpInput: peer advise negative useable window for connected TCB %p\n",
           Tcb)
           );
         Usable = TCP_SUB_SEQ (Tcb->SndNxt, Right);
         if ((Usable >> Tcb->SndWndScale) > 0) {
           DEBUG (
-            (EFI_D_WARN,
+            (DEBUG_WARN,
             "TcpInput: SndNxt is out of window by more than window scale for TCB %p\n",
             Tcb)
             );
@@ -1409,7 +1409,7 @@ NO_UPDATE:
   {
 
     DEBUG (
-      (EFI_D_NET,
+      (DEBUG_NET,
       "TcpInput: local FIN is ACKed by peer for connected TCB %p\n",
       Tcb)
       );
@@ -1452,7 +1452,7 @@ NO_UPDATE:
       } else {
 
         DEBUG (
-          (EFI_D_WARN,
+          (DEBUG_WARN,
           "Connection closed immediately because app disables TIME_WAIT timer for %p\n",
           Tcb)
           );
@@ -1481,7 +1481,7 @@ NO_UPDATE:
     } else {
 
       DEBUG (
-        (EFI_D_WARN,
+        (DEBUG_WARN,
         "Connection closed immediately because app disables TIME_WAIT timer for %p\n",
         Tcb)
         );
@@ -1505,7 +1505,7 @@ StepSix:
   if (TCP_FLG_ON (Seg->Flag, TCP_FLG_URG) && !TCP_FIN_RCVD (Tcb->State)) {
 
     DEBUG (
-      (EFI_D_NET,
+      (DEBUG_NET,
       "TcpInput: received urgent data from peer for connected TCB %p\n",
       Tcb)
       );
@@ -1531,7 +1531,7 @@ StepSix:
     if (TCP_FIN_RCVD (Tcb->State)) {
 
       DEBUG (
-        (EFI_D_WARN,
+        (DEBUG_WARN,
         "TcpInput: connection reset because data is lost for connected TCB %p\n",
         Tcb)
         );
@@ -1541,7 +1541,7 @@ StepSix:
 
     if (TCP_LOCAL_CLOSED (Tcb->State) && (Nbuf->TotalSize != 0)) {
       DEBUG (
-        (EFI_D_WARN,
+        (DEBUG_WARN,
         "TcpInput: connection reset because data is lost for connected TCB %p\n",
         Tcb)
         );
@@ -1551,7 +1551,7 @@ StepSix:
 
     if (TcpQueueData (Tcb, Nbuf) == 0) {
       DEBUG (
-        (EFI_D_ERROR,
+        (DEBUG_ERROR,
         "TcpInput: discard a broken segment for TCB %p\n",
         Tcb)
         );
@@ -1615,7 +1615,7 @@ DISCARD:
   //
   // Tcb is a child of Parent, and it doesn't survive
   //
-  DEBUG ((EFI_D_WARN, "TcpInput: Discard a packet\n"));
+  DEBUG ((DEBUG_WARN, "TcpInput: Discard a packet\n"));
   NetbufFree (Nbuf);
 
   if ((Parent != NULL) && (Tcb != NULL)) {

--- a/NetworkPkg/TcpDxe/TcpIo.c
+++ b/NetworkPkg/TcpDxe/TcpIo.c
@@ -80,7 +80,7 @@ TcpSendIpPacket (
     IpSender = IpIoFindSender (&IpIo, Version, Src);
 
     if (IpSender == NULL) {
-      DEBUG ((EFI_D_WARN, "TcpSendIpPacket: No appropriate IpSender.\n"));
+      DEBUG ((DEBUG_WARN, "TcpSendIpPacket: No appropriate IpSender.\n"));
       return -1;
     }
 
@@ -130,7 +130,7 @@ TcpSendIpPacket (
   Status = IpIoSend (IpIo, Nbuf, IpSender, NULL, NULL, Dest, &Override);
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "TcpSendIpPacket: return %r error\n", Status));
+    DEBUG ((DEBUG_ERROR, "TcpSendIpPacket: return %r error\n", Status));
     return -1;
   }
 
@@ -171,7 +171,7 @@ Tcp6RefreshNeighbor (
     IpIoFindSender (&IpIo, IP_VERSION_6, Neighbor);
 
     if (IpIo == NULL) {
-      DEBUG ((EFI_D_WARN, "Tcp6AddNeighbor: No appropriate IpIo.\n"));
+      DEBUG ((DEBUG_WARN, "Tcp6AddNeighbor: No appropriate IpIo.\n"));
       return EFI_NOT_STARTED;
     }
 
@@ -183,4 +183,3 @@ Tcp6RefreshNeighbor (
 
   return IpIoRefreshNeighbor (IpIo, Neighbor, Timeout);
 }
-

--- a/NetworkPkg/TcpDxe/TcpMisc.c
+++ b/NetworkPkg/TcpDxe/TcpMisc.c
@@ -501,7 +501,7 @@ TcpCloneTcb (
 
   Clone->Sk = SockClone (Tcb->Sk);
   if (Clone->Sk == NULL) {
-    DEBUG ((EFI_D_ERROR, "TcpCloneTcb: failed to clone a sock\n"));
+    DEBUG ((DEBUG_ERROR, "TcpCloneTcb: failed to clone a sock\n"));
     FreePool (Clone);
     return NULL;
   }
@@ -608,7 +608,7 @@ TcpSetState (
   ASSERT (State < (sizeof (mTcpStateName) / sizeof (CHAR16 *)));
 
   DEBUG (
-    (EFI_D_NET,
+    (DEBUG_NET,
     "Tcb (%p) state %s --> %s\n",
     Tcb,
     mTcpStateName[Tcb->State],
@@ -757,7 +757,7 @@ TcpOnAppClose (
   if (!IsListEmpty (&Tcb->RcvQue) || GET_RCV_DATASIZE (Tcb->Sk) != 0) {
 
     DEBUG (
-      (EFI_D_WARN,
+      (DEBUG_WARN,
       "TcpOnAppClose: connection reset because data is lost for TCB %p\n",
       Tcb)
       );
@@ -857,7 +857,7 @@ TcpOnAppConsume (
       if (TcpOld < Tcb->RcvMss) {
 
         DEBUG (
-          (EFI_D_NET,
+          (DEBUG_NET,
           "TcpOnAppConsume: send a window update for a window closed Tcb %p\n",
           Tcb)
           );
@@ -866,7 +866,7 @@ TcpOnAppConsume (
       } else if (Tcb->DelayedAck == 0) {
 
         DEBUG (
-          (EFI_D_NET,
+          (DEBUG_NET,
           "TcpOnAppConsume: scheduled a delayed ACK to update window for Tcb %p\n",
           Tcb)
           );
@@ -895,7 +895,7 @@ TcpOnAppAbort (
   )
 {
   DEBUG (
-    (EFI_D_WARN,
+    (DEBUG_WARN,
     "TcpOnAppAbort: connection reset issued by application for TCB %p\n",
     Tcb)
     );
@@ -1039,4 +1039,3 @@ TcpInstallDevicePath (
 
   return Status;
 }
-

--- a/NetworkPkg/TcpDxe/TcpOutput.c
+++ b/NetworkPkg/TcpDxe/TcpOutput.c
@@ -250,7 +250,7 @@ SetPersistTimer:
   if (!TCP_TIMER_ON (Tcb->EnabledTimer, TCP_TIMER_REXMIT)) {
 
     DEBUG (
-      (EFI_D_WARN,
+      (DEBUG_WARN,
       "TcpDataToSend: enter persistent state for TCB %p\n",
       Tcb)
       );
@@ -562,7 +562,7 @@ TcpGetSegmentSock (
 
   if (Nbuf == NULL) {
     DEBUG (
-      (EFI_D_ERROR,
+      (DEBUG_ERROR,
       "TcpGetSegmentSock: failed to allocate a netbuf for TCB %p\n",
       Tcb)
       );
@@ -678,7 +678,7 @@ TcpRetransmit (
       (TCP_SEQ_GT (Seq, Tcb->RetxmitSeqMax) || TCP_SEQ_BETWEEN (Tcb->SndWl2 + Tcb->SndWnd, Seq, Tcb->SndWl2 + Tcb->SndWnd + (1 << Tcb->SndWndScale)))) {
     Len = TCP_SUB_SEQ (Tcb->SndNxt, Seq);
     DEBUG (
-      (EFI_D_WARN,
+      (DEBUG_WARN,
       "TcpRetransmit: retransmission without regard to the receiver window for TCB %p\n",
       Tcb)
       );
@@ -688,7 +688,7 @@ TcpRetransmit (
 
   } else {
     DEBUG (
-      (EFI_D_WARN,
+      (DEBUG_WARN,
       "TcpRetransmit: retransmission cancelled because send window too small for TCB %p\n",
       Tcb)
       );
@@ -845,7 +845,7 @@ TcpToSendData (
 
     if (Nbuf == NULL) {
       DEBUG (
-        (EFI_D_ERROR,
+        (DEBUG_ERROR,
         "TcpToSendData: failed to get a segment for TCB %p\n",
         Tcb)
         );
@@ -874,7 +874,7 @@ TcpToSendData (
           TCP_SEQ_LT (End + 1, Tcb->SndWnd + Tcb->SndWl2)
             ) {
         DEBUG (
-          (EFI_D_NET,
+          (DEBUG_NET,
           "TcpToSendData: send FIN to peer for TCB %p in state %s\n",
           Tcb,
           mTcpStateName[Tcb->State])
@@ -892,7 +892,7 @@ TcpToSendData (
 
     if (TcpVerifySegment (Nbuf) == 0 || TcpCheckSndQue (&Tcb->SndQue) == 0) {
       DEBUG (
-        (EFI_D_ERROR,
+        (DEBUG_ERROR,
         "TcpToSendData: discard a broken segment for TCB %p\n",
         Tcb)
         );
@@ -904,7 +904,7 @@ TcpToSendData (
     //
     if (Seg->End == Seg->Seq) {
       DEBUG (
-        (EFI_D_WARN,
+        (DEBUG_WARN,
         "TcpToSendData: created a empty segment for TCB %p, free it now\n",
         Tcb)
         );
@@ -959,7 +959,7 @@ TcpToSendData (
     if ((Tcb->CongestState == TCP_CONGEST_OPEN) && !TCP_FLG_ON (Tcb->CtrlFlag, TCP_CTRL_RTT_ON)) {
 
       DEBUG (
-        (EFI_D_NET,
+        (DEBUG_NET,
         "TcpToSendData: set RTT measure sequence %d for TCB %p\n",
         Seq,
         Tcb)
@@ -1090,7 +1090,7 @@ TcpToSendAck (
   }
 
   DEBUG (
-    (EFI_D_NET,
+    (DEBUG_NET,
     "TcpToSendAck: scheduled a delayed ACK for TCB %p\n",
     Tcb)
     );
@@ -1248,4 +1248,3 @@ TcpVerifySegment (
 
   return 1;
 }
-

--- a/NetworkPkg/TcpDxe/TcpTimer.c
+++ b/NetworkPkg/TcpDxe/TcpTimer.c
@@ -148,7 +148,7 @@ TcpConnectTimeout (
 {
   if (!TCP_CONNECTED (Tcb->State)) {
     DEBUG (
-      (EFI_D_ERROR,
+      (DEBUG_ERROR,
       "TcpConnectTimeout: connection closed because connection timer timeout for TCB %p\n",
       Tcb)
       );
@@ -159,7 +159,7 @@ TcpConnectTimeout (
 
     if (TCP_SYN_RCVD == Tcb->State) {
       DEBUG (
-        (EFI_D_WARN,
+        (DEBUG_WARN,
         "TcpConnectTimeout: send reset because connection timer timeout for TCB %p\n",
         Tcb)
         );
@@ -187,7 +187,7 @@ TcpRexmitTimeout (
   UINT32  FlightSize;
 
   DEBUG (
-    (EFI_D_WARN,
+    (DEBUG_WARN,
     "TcpRexmitTimeout: transmission timeout for TCB %p\n",
     Tcb)
     );
@@ -207,7 +207,7 @@ TcpRexmitTimeout (
   if ((Tcb->LossTimes > Tcb->MaxRexmit) && !TCP_TIMER_ON (Tcb->EnabledTimer, TCP_TIMER_CONNECT)) {
 
     DEBUG (
-      (EFI_D_ERROR,
+      (DEBUG_ERROR,
       "TcpRexmitTimeout: connection closed because too many timeouts for TCB %p\n",
       Tcb)
       );
@@ -299,7 +299,7 @@ TcpFinwait2Timeout (
   )
 {
   DEBUG (
-    (EFI_D_WARN,
+    (DEBUG_WARN,
     "TcpFinwait2Timeout: connection closed because FIN_WAIT2 timer timeouts for TCB %p\n",
     Tcb)
     );
@@ -319,7 +319,7 @@ Tcp2MSLTimeout (
   )
 {
   DEBUG (
-    (EFI_D_WARN,
+    (DEBUG_WARN,
     "Tcp2MSLTimeout: connection closed because TIME_WAIT timer timeouts for TCB %p\n",
     Tcb)
     );
@@ -584,4 +584,3 @@ TcpTicking (
 {
   QueueDpc (TPL_CALLBACK, TcpTickingDpc, Context);
 }
-

--- a/NetworkPkg/TlsDxe/TlsImpl.c
+++ b/NetworkPkg/TlsDxe/TlsImpl.c
@@ -130,7 +130,7 @@ TlsEncryptPacket (
       //
       // No data was successfully encrypted, continue to encrypt other messages.
       //
-      DEBUG ((EFI_D_WARN, "TlsEncryptPacket: No data read from TLS object.\n"));
+      DEBUG ((DEBUG_WARN, "TlsEncryptPacket: No data read from TLS object.\n"));
 
       ThisMessageSize = 0;
     }
@@ -301,7 +301,7 @@ TlsDecryptPacket (
       //
       // No data was successfully decrypted, continue to decrypt other messages.
       //
-      DEBUG ((EFI_D_WARN, "TlsDecryptPacket: No data read from TLS object.\n"));
+      DEBUG ((DEBUG_WARN, "TlsDecryptPacket: No data read from TLS object.\n"));
 
       ThisPlainMessageSize = 0;
     }
@@ -346,4 +346,3 @@ ERROR:
 
   return Status;
 }
-

--- a/NetworkPkg/UefiPxeBcDxe/PxeBcDhcp4.c
+++ b/NetworkPkg/UefiPxeBcDxe/PxeBcDhcp4.c
@@ -314,7 +314,7 @@ PxeBcBuildDhcp4Options (
     //
     // Zero the Guid to indicate NOT programmable if failed to get system Guid.
     //
-    DEBUG ((EFI_D_WARN, "PXE: Failed to read system GUID from the smbios table!\n"));
+    DEBUG ((DEBUG_WARN, "PXE: Failed to read system GUID from the smbios table!\n"));
     ZeroMem (OptEnt.Uuid->Guid, sizeof (EFI_GUID));
   }
 
@@ -1277,7 +1277,7 @@ PxeBcDhcp4CallBack (
         //
         // Zero the Guid to indicate NOT programmable if failed to get system Guid.
         //
-        DEBUG ((EFI_D_WARN, "PXE: Failed to read system GUID from the smbios table!\n"));
+        DEBUG ((DEBUG_WARN, "PXE: Failed to read system GUID from the smbios table!\n"));
         ZeroMem (Packet->Dhcp4.Header.ClientHwAddr, sizeof (EFI_GUID));
       }
       Packet->Dhcp4.Header.HwAddrLen = (UINT8) sizeof (EFI_GUID);
@@ -1466,7 +1466,7 @@ PxeBcDhcp4Discover (
       //
       // Zero the Guid to indicate NOT programmable if failed to get system Guid.
       //
-      DEBUG ((EFI_D_WARN, "PXE: Failed to read system GUID from the smbios table!\n"));
+      DEBUG ((DEBUG_WARN, "PXE: Failed to read system GUID from the smbios table!\n"));
       ZeroMem (Token.Packet->Dhcp4.Header.ClientHwAddr, sizeof (EFI_GUID));
     }
     Token.Packet->Dhcp4.Header.HwAddrLen = (UINT8)  sizeof (EFI_GUID);

--- a/NetworkPkg/UefiPxeBcDxe/PxeBcImpl.c
+++ b/NetworkPkg/UefiPxeBcDxe/PxeBcImpl.c
@@ -1951,7 +1951,7 @@ EfiPxeBcSetParameters (
 
   if (NewSendGUID != NULL) {
     if (*NewSendGUID && EFI_ERROR (NetLibGetSystemGuid (&SystemGuid))) {
-      DEBUG ((EFI_D_WARN, "PXE: Failed to read system GUID from the smbios table!\n"));
+      DEBUG ((DEBUG_WARN, "PXE: Failed to read system GUID from the smbios table!\n"));
       return EFI_INVALID_PARAMETER;
     }
     Mode->SendGUID = *NewSendGUID;
@@ -2418,4 +2418,3 @@ EfiPxeLoadFile (
 }
 
 EFI_LOAD_FILE_PROTOCOL  gLoadFileProtocolTemplate = { EfiPxeLoadFile };
-

--- a/OvmfPkg/Fdt/FdtPciHostBridgeLib/FdtPciHostBridgeLib.c
+++ b/OvmfPkg/Fdt/FdtPciHostBridgeLib/FdtPciHostBridgeLib.c
@@ -121,7 +121,7 @@ ProcessPciHost (
   Status = FdtClient->FindCompatibleNode (FdtClient, "pci-host-ecam-generic",
                         &Node);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_INFO,
+    DEBUG ((DEBUG_INFO,
       "%a: No 'pci-host-ecam-generic' compatible DT node found\n",
       __FUNCTION__));
     return EFI_NOT_FOUND;
@@ -141,7 +141,7 @@ ProcessPciHost (
 
   Status = FdtClient->GetNodeProperty (FdtClient, Node, "reg", &Prop, &Len);
   if (EFI_ERROR (Status) || Len != 2 * sizeof (UINT64)) {
-    DEBUG ((EFI_D_ERROR, "%a: 'reg' property not found or invalid\n",
+    DEBUG ((DEBUG_ERROR, "%a: 'reg' property not found or invalid\n",
       __FUNCTION__));
     return EFI_PROTOCOL_ERROR;
   }
@@ -158,7 +158,7 @@ ProcessPciHost (
   Status = FdtClient->GetNodeProperty (FdtClient, Node, "bus-range", &Prop,
                         &Len);
   if (EFI_ERROR (Status) || Len != 2 * sizeof (UINT32)) {
-    DEBUG ((EFI_D_ERROR, "%a: 'bus-range' not found or invalid\n",
+    DEBUG ((DEBUG_ERROR, "%a: 'bus-range' not found or invalid\n",
       __FUNCTION__));
     return EFI_PROTOCOL_ERROR;
   }
@@ -171,7 +171,7 @@ ProcessPciHost (
   //
   if (*BusMax < *BusMin || *BusMax - *BusMin == MAX_UINT32 ||
       DivU64x32 (ConfigSize, SIZE_4KB * 8 * 32) < *BusMax - *BusMin + 1) {
-    DEBUG ((EFI_D_ERROR, "%a: invalid 'bus-range' and/or 'reg'\n",
+    DEBUG ((DEBUG_ERROR, "%a: invalid 'bus-range' and/or 'reg'\n",
       __FUNCTION__));
     return EFI_PROTOCOL_ERROR;
   }
@@ -182,7 +182,7 @@ ProcessPciHost (
   Status = FdtClient->GetNodeProperty (FdtClient, Node, "ranges", &Prop, &Len);
   if (EFI_ERROR (Status) || Len == 0 ||
       Len % sizeof (DTB_PCI_HOST_RANGE_RECORD) != 0) {
-    DEBUG ((EFI_D_ERROR, "%a: 'ranges' not found or invalid\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: 'ranges' not found or invalid\n", __FUNCTION__));
     return EFI_PROTOCOL_ERROR;
   }
 
@@ -207,14 +207,14 @@ ProcessPciHost (
 
       if (*Mmio32Base > MAX_UINT32 || *Mmio32Size > MAX_UINT32 ||
           *Mmio32Base + *Mmio32Size > SIZE_4GB) {
-        DEBUG ((EFI_D_ERROR, "%a: MMIO32 space invalid\n", __FUNCTION__));
+        DEBUG ((DEBUG_ERROR, "%a: MMIO32 space invalid\n", __FUNCTION__));
         return EFI_PROTOCOL_ERROR;
       }
 
       ASSERT (PcdGet64 (PcdPciMmio32Translation) == Mmio32Translation);
 
       if (Mmio32Translation != 0) {
-        DEBUG ((EFI_D_ERROR, "%a: unsupported nonzero MMIO32 translation "
+        DEBUG ((DEBUG_ERROR, "%a: unsupported nonzero MMIO32 translation "
           "0x%Lx\n", __FUNCTION__, Mmio32Translation));
         return EFI_UNSUPPORTED;
       }
@@ -229,7 +229,7 @@ ProcessPciHost (
       ASSERT (PcdGet64 (PcdPciMmio64Translation) == Mmio64Translation);
 
       if (Mmio64Translation != 0) {
-        DEBUG ((EFI_D_ERROR, "%a: unsupported nonzero MMIO64 translation "
+        DEBUG ((DEBUG_ERROR, "%a: unsupported nonzero MMIO64 translation "
           "0x%Lx\n", __FUNCTION__, Mmio64Translation));
         return EFI_UNSUPPORTED;
       }
@@ -238,7 +238,7 @@ ProcessPciHost (
     }
   }
   if (*IoSize == 0 || *Mmio32Size == 0) {
-    DEBUG ((EFI_D_ERROR, "%a: %a space empty\n", __FUNCTION__,
+    DEBUG ((DEBUG_ERROR, "%a: %a space empty\n", __FUNCTION__,
       (*IoSize == 0) ? "IO" : "MMIO32"));
     return EFI_PROTOCOL_ERROR;
   }
@@ -249,7 +249,7 @@ ProcessPciHost (
   //
   ASSERT (PcdGet64 (PcdPciExpressBaseAddress) == ConfigBase);
 
-  DEBUG ((EFI_D_INFO, "%a: Config[0x%Lx+0x%Lx) Bus[0x%x..0x%x] "
+  DEBUG ((DEBUG_INFO, "%a: Config[0x%Lx+0x%Lx) Bus[0x%x..0x%x] "
     "Io[0x%Lx+0x%Lx)@0x%Lx Mem32[0x%Lx+0x%Lx)@0x0 Mem64[0x%Lx+0x%Lx)@0x0\n",
     __FUNCTION__, ConfigBase, ConfigSize, *BusMin, *BusMax, *IoBase, *IoSize,
     IoTranslation, *Mmio32Base, *Mmio32Size, *Mmio64Base, *Mmio64Size));
@@ -301,7 +301,7 @@ PciHostBridgeGetRootBridges (
   PCI_ROOT_BRIDGE_APERTURE PMemAbove4G;
 
   if (PcdGet64 (PcdPciExpressBaseAddress) == 0) {
-    DEBUG ((EFI_D_INFO, "%a: PCI host bridge not present\n", __FUNCTION__));
+    DEBUG ((DEBUG_INFO, "%a: PCI host bridge not present\n", __FUNCTION__));
 
     *Count = 0;
     return NULL;
@@ -310,7 +310,7 @@ PciHostBridgeGetRootBridges (
   Status = ProcessPciHost (&IoBase, &IoSize, &Mmio32Base, &Mmio32Size,
              &Mmio64Base, &Mmio64Size, &BusMin, &BusMax);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a: failed to discover PCI host bridge: %r\n",
+    DEBUG ((DEBUG_ERROR, "%a: failed to discover PCI host bridge: %r\n",
       __FUNCTION__, Status));
     *Count = 0;
     return NULL;

--- a/OvmfPkg/Fdt/FdtPciPcdProducerLib/FdtPciPcdProducerLib.c
+++ b/OvmfPkg/Fdt/FdtPciPcdProducerLib/FdtPciPcdProducerLib.c
@@ -57,7 +57,7 @@ GetPciIoTranslation (
   Status = FdtClient->GetNodeProperty (FdtClient, Node, "ranges", &Prop, &Len);
   if (EFI_ERROR (Status) || Len == 0 ||
       Len % sizeof (DTB_PCI_HOST_RANGE_RECORD) != 0) {
-    DEBUG ((EFI_D_ERROR, "%a: 'ranges' not found or invalid\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: 'ranges' not found or invalid\n", __FUNCTION__));
     return RETURN_PROTOCOL_ERROR;
   }
 
@@ -135,7 +135,7 @@ FdtPciPcdProducerLibConstructor (
         // to abort in the general case. So leave it up to the actual driver to
         // complain about this if it wants to, and just issue a warning here.
         //
-        DEBUG ((EFI_D_WARN,
+        DEBUG ((DEBUG_WARN,
           "%a: 'pci-host-ecam-generic' device encountered with no I/O range\n",
           __FUNCTION__));
       }

--- a/OvmfPkg/Fdt/HighMemDxe/HighMemDxe.c
+++ b/OvmfPkg/Fdt/HighMemDxe/HighMemDxe.c
@@ -80,7 +80,7 @@ InitializeHighMemDxe (
                         CurSize, EFI_MEMORY_WB);
 
         if (EFI_ERROR (Status)) {
-          DEBUG ((EFI_D_ERROR,
+          DEBUG ((DEBUG_ERROR,
             "%a: Failed to add System RAM @ 0x%lx - 0x%lx (%r)\n",
             __FUNCTION__, CurBase, CurBase + CurSize - 1, Status));
           continue;
@@ -114,11 +114,11 @@ InitializeHighMemDxe (
         Status = Cpu->SetMemoryAttributes (Cpu, CurBase, CurSize, Attributes);
 
         if (EFI_ERROR (Status)) {
-          DEBUG ((EFI_D_ERROR,
+          DEBUG ((DEBUG_ERROR,
             "%a: Failed to set System RAM @ 0x%lx - 0x%lx attribute (%r)\n",
             __FUNCTION__, CurBase, CurBase + CurSize - 1, Status));
         } else {
-          DEBUG ((EFI_D_INFO, "%a: Add System RAM @ 0x%lx - 0x%lx\n",
+          DEBUG ((DEBUG_INFO, "%a: Add System RAM @ 0x%lx - 0x%lx\n",
             __FUNCTION__, CurBase, CurBase + CurSize - 1));
         }
       }

--- a/OvmfPkg/Fdt/VirtioFdtDxe/VirtioFdtDxe.c
+++ b/OvmfPkg/Fdt/VirtioFdtDxe/VirtioFdtDxe.c
@@ -57,7 +57,7 @@ InitializeVirtioFdtDxe (
     Status = FdtClient->GetNodeProperty (FdtClient, Node, "reg",
                           (CONST VOID **)&Reg, &RegSize);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "%a: GetNodeProperty () failed (Status == %r)\n",
+      DEBUG ((DEBUG_ERROR, "%a: GetNodeProperty () failed (Status == %r)\n",
         __FUNCTION__, Status));
       continue;
     }
@@ -73,7 +73,7 @@ InitializeVirtioFdtDxe (
                                   HW_VENDOR_DP,
                                   sizeof (VIRTIO_TRANSPORT_DEVICE_PATH));
     if (DevicePath == NULL) {
-      DEBUG ((EFI_D_ERROR, "%a: Out of memory\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a: Out of memory\n", __FUNCTION__));
       continue;
     }
 
@@ -88,7 +88,7 @@ InitializeVirtioFdtDxe (
                      &gEfiDevicePathProtocolGuid, EFI_NATIVE_INTERFACE,
                      DevicePath);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "%a: Failed to install the EFI_DEVICE_PATH "
+      DEBUG ((DEBUG_ERROR, "%a: Failed to install the EFI_DEVICE_PATH "
         "protocol on a new handle (Status == %r)\n",
         __FUNCTION__, Status));
       FreePool (DevicePath);
@@ -97,7 +97,7 @@ InitializeVirtioFdtDxe (
 
     Status = VirtioMmioInstallDevice (RegBase, Handle);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "%a: Failed to install VirtIO transport @ 0x%Lx "
+      DEBUG ((DEBUG_ERROR, "%a: Failed to install VirtIO transport @ 0x%Lx "
         "on handle %p (Status == %r)\n", __FUNCTION__, RegBase,
         Handle, Status));
 
@@ -110,7 +110,7 @@ InitializeVirtioFdtDxe (
   }
 
   if (EFI_ERROR (FindNodeStatus) && FindNodeStatus != EFI_NOT_FOUND) {
-     DEBUG ((EFI_D_ERROR, "%a: Error occurred while iterating DT nodes "
+     DEBUG ((DEBUG_ERROR, "%a: Error occurred while iterating DT nodes "
        "(FindNodeStatus == %r)\n", __FUNCTION__, FindNodeStatus));
   }
 

--- a/OvmfPkg/Library/PlatformBootManagerLibBhyve/BdsPlatform.c
+++ b/OvmfPkg/Library/PlatformBootManagerLibBhyve/BdsPlatform.c
@@ -253,7 +253,7 @@ RemoveStaleFvFileOptions (
       DevicePathString = ConvertDevicePathToText(BootOptions[Index].FilePath,
                            FALSE, FALSE);
       DEBUG ((
-        EFI_ERROR (Status) ? EFI_D_WARN : DEBUG_VERBOSE,
+        EFI_ERROR (Status) ? DEBUG_WARN : DEBUG_VERBOSE,
         "%a: removing stale Boot#%04x %s: %r\n",
         __FUNCTION__,
         (UINT32)BootOptions[Index].OptionNumber,

--- a/OvmfPkg/Library/QemuFwCfgLib/QemuFwCfgLibMmio.c
+++ b/OvmfPkg/Library/QemuFwCfgLib/QemuFwCfgLibMmio.c
@@ -125,7 +125,7 @@ QemuFwCfgInitialize (
                          (CONST VOID **)&Reg, &AddressCells, &SizeCells,
                          &RegSize);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_WARN,
+    DEBUG ((DEBUG_WARN,
       "%a: No 'qemu,fw-cfg-mmio' compatible DT node found (Status == %r)\n",
       __FUNCTION__, Status));
     return EFI_SUCCESS;
@@ -156,7 +156,7 @@ QemuFwCfgInitialize (
   mFwCfgSelectorAddress = FwCfgSelectorAddress;
   mFwCfgDataAddress     = FwCfgDataAddress;
 
-  DEBUG ((EFI_D_INFO, "Found FwCfg @ 0x%Lx/0x%Lx\n", FwCfgSelectorAddress,
+  DEBUG ((DEBUG_INFO, "Found FwCfg @ 0x%Lx/0x%Lx\n", FwCfgSelectorAddress,
     FwCfgDataAddress));
 
   if (SwapBytes64 (Reg[1]) >= 0x18) {
@@ -168,7 +168,7 @@ QemuFwCfgInitialize (
     //
     ASSERT (FwCfgDmaAddress <= MAX_UINTN - FwCfgDmaSize + 1);
 
-    DEBUG ((EFI_D_INFO, "Found FwCfg DMA @ 0x%Lx\n", FwCfgDmaAddress));
+    DEBUG ((DEBUG_INFO, "Found FwCfg DMA @ 0x%Lx\n", FwCfgDmaAddress));
   } else {
     FwCfgDmaAddress = 0;
   }

--- a/PcAtChipsetPkg/PcatRealTimeClockRuntimeDxe/PcRtc.c
+++ b/PcAtChipsetPkg/PcatRealTimeClockRuntimeDxe/PcRtc.c
@@ -1348,7 +1348,7 @@ PcRtcAcpiTableChangeCallback (
     if (!EFI_ERROR (Status)) {
       Century = (UINT8) (Time.Year / 100);
       Century = DecimalToBcd8 (Century);
-      DEBUG ((EFI_D_INFO, "PcRtc: Write 0x%x to CMOS location 0x%x\n", Century, mModuleGlobal.CenturyRtcAddress));
+      DEBUG ((DEBUG_INFO, "PcRtc: Write 0x%x to CMOS location 0x%x\n", Century, mModuleGlobal.CenturyRtcAddress));
       RtcWrite (mModuleGlobal.CenturyRtcAddress, Century);
     }
   }

--- a/SecurityPkg/Hash2DxeCrypto/Driver.c
+++ b/SecurityPkg/Hash2DxeCrypto/Driver.c
@@ -142,7 +142,7 @@ Hash2ServiceBindingDestroyChild (
     }
   }
   if (Instance == NULL) {
-    DEBUG ((EFI_D_ERROR, "Hash2ServiceBindingDestroyChild - Invalid handle\n"));
+    DEBUG ((DEBUG_ERROR, "Hash2ServiceBindingDestroyChild - Invalid handle\n"));
     return EFI_UNSUPPORTED;
   }
 

--- a/SecurityPkg/Library/AuthVariableLib/AuthService.c
+++ b/SecurityPkg/Library/AuthVariableLib/AuthService.c
@@ -1752,7 +1752,7 @@ CleanCertsFromDb (
                         AuthVariableInfo.Attributes | EFI_VARIABLE_NON_VOLATILE
                         );
         CertCleaned = TRUE;
-        DEBUG((EFI_D_INFO, "Recovery!! Cert for Auth Variable %s Guid %g is removed for consistency\n", VariableName, &AuthVarGuid));
+        DEBUG((DEBUG_INFO, "Recovery!! Cert for Auth Variable %s Guid %g is removed for consistency\n", VariableName, &AuthVarGuid));
         FreePool(VariableName);
         break;
       }

--- a/SecurityPkg/Library/AuthVariableLib/AuthVariableLib.c
+++ b/SecurityPkg/Library/AuthVariableLib/AuthVariableLib.c
@@ -153,9 +153,9 @@ AuthVariableLibInitialize (
 
   Status = AuthServiceInternalFindVariable (EFI_PLATFORM_KEY_NAME, &gEfiGlobalVariableGuid, (VOID **) &Data, &DataSize);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_INFO, "Variable %s does not exist.\n", EFI_PLATFORM_KEY_NAME));
+    DEBUG ((DEBUG_INFO, "Variable %s does not exist.\n", EFI_PLATFORM_KEY_NAME));
   } else {
-    DEBUG ((EFI_D_INFO, "Variable %s exists.\n", EFI_PLATFORM_KEY_NAME));
+    DEBUG ((DEBUG_INFO, "Variable %s exists.\n", EFI_PLATFORM_KEY_NAME));
   }
 
   //
@@ -238,9 +238,9 @@ AuthVariableLibInitialize (
     return Status;
   }
 
-  DEBUG ((EFI_D_INFO, "Variable %s is %x\n", EFI_SETUP_MODE_NAME, mPlatformMode));
-  DEBUG ((EFI_D_INFO, "Variable %s is %x\n", EFI_SECURE_BOOT_MODE_NAME, SecureBootMode));
-  DEBUG ((EFI_D_INFO, "Variable %s is %x\n", EFI_SECURE_BOOT_ENABLE_NAME, SecureBootEnable));
+  DEBUG ((DEBUG_INFO, "Variable %s is %x\n", EFI_SETUP_MODE_NAME, mPlatformMode));
+  DEBUG ((DEBUG_INFO, "Variable %s is %x\n", EFI_SECURE_BOOT_MODE_NAME, SecureBootMode));
+  DEBUG ((DEBUG_INFO, "Variable %s is %x\n", EFI_SECURE_BOOT_ENABLE_NAME, SecureBootEnable));
 
   //
   // Initialize "CustomMode" in STANDARD_SECURE_BOOT_MODE state.
@@ -257,7 +257,7 @@ AuthVariableLibInitialize (
     return Status;
   }
 
-  DEBUG ((EFI_D_INFO, "Variable %s is %x\n", EFI_CUSTOM_MODE_NAME, CustomMode));
+  DEBUG ((DEBUG_INFO, "Variable %s is %x\n", EFI_CUSTOM_MODE_NAME, CustomMode));
 
   //
   // Check "certdb" variable's existence.
@@ -289,7 +289,7 @@ AuthVariableLibInitialize (
     //
     Status = CleanCertsFromDb();
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "Clean up CertDB fail! Status %x\n", Status));
+      DEBUG ((DEBUG_ERROR, "Clean up CertDB fail! Status %x\n", Status));
       return Status;
     }
   }
@@ -347,7 +347,7 @@ AuthVariableLibInitialize (
     return Status;
   }
 
-  DEBUG ((EFI_D_INFO, "Variable %s is %x\n", EFI_VENDOR_KEYS_VARIABLE_NAME, mVendorKeyState));
+  DEBUG ((DEBUG_INFO, "Variable %s is %x\n", EFI_VENDOR_KEYS_VARIABLE_NAME, mVendorKeyState));
 
   AuthVarLibContextOut->StructVersion = AUTH_VAR_LIB_CONTEXT_OUT_STRUCT_VERSION;
   AuthVarLibContextOut->StructSize = sizeof (AUTH_VAR_LIB_CONTEXT_OUT);

--- a/SecurityPkg/Library/DxeImageVerificationLib/Measurement.c
+++ b/SecurityPkg/Library/DxeImageVerificationLib/Measurement.c
@@ -253,8 +253,8 @@ MeasureVariable (
      VarSize
      );
 
-  DEBUG ((EFI_D_INFO, "DxeImageVerification: MeasureVariable (Pcr - %x, EventType - %x, ", (UINTN)7, (UINTN)EV_EFI_VARIABLE_AUTHORITY));
-  DEBUG ((EFI_D_INFO, "VariableName - %s, VendorGuid - %g)\n", VarName, VendorGuid));
+  DEBUG ((DEBUG_INFO, "DxeImageVerification: MeasureVariable (Pcr - %x, EventType - %x, ", (UINTN)7, (UINTN)EV_EFI_VARIABLE_AUTHORITY));
+  DEBUG ((DEBUG_INFO, "VariableName - %s, VendorGuid - %g)\n", VarName, VendorGuid));
 
   Status = TpmMeasureAndLogData (
              7,
@@ -295,7 +295,7 @@ SecureBootHook (
   }
 
   if (IsDataMeasured (VariableName, VendorGuid, Data, DataSize)) {
-    DEBUG ((EFI_D_ERROR, "MeasureSecureAuthorityVariable - IsDataMeasured\n"));
+    DEBUG ((DEBUG_ERROR, "MeasureSecureAuthorityVariable - IsDataMeasured\n"));
     return ;
   }
 
@@ -305,7 +305,7 @@ SecureBootHook (
              Data,
              DataSize
              );
-  DEBUG ((EFI_D_INFO, "MeasureBootPolicyVariable - %r\n", Status));
+  DEBUG ((DEBUG_INFO, "MeasureBootPolicyVariable - %r\n", Status));
 
   if (!EFI_ERROR (Status)) {
     AddDataMeasured (VariableName, VendorGuid, Data, DataSize);

--- a/SecurityPkg/Library/DxeTcg2PhysicalPresenceLib/DxeTcg2PhysicalPresenceLib.c
+++ b/SecurityPkg/Library/DxeTcg2PhysicalPresenceLib/DxeTcg2PhysicalPresenceLib.c
@@ -84,15 +84,15 @@ Tpm2CommandClear (
     CopyMem (LocalAuthSession.hmac.buffer, PlatformAuth->buffer, PlatformAuth->size);
   }
 
-  DEBUG ((EFI_D_INFO, "Tpm2ClearControl ... \n"));
+  DEBUG ((DEBUG_INFO, "Tpm2ClearControl ... \n"));
   Status = Tpm2ClearControl (TPM_RH_PLATFORM, AuthSession, NO);
-  DEBUG ((EFI_D_INFO, "Tpm2ClearControl - %r\n", Status));
+  DEBUG ((DEBUG_INFO, "Tpm2ClearControl - %r\n", Status));
   if (EFI_ERROR (Status)) {
     goto Done;
   }
-  DEBUG ((EFI_D_INFO, "Tpm2Clear ... \n"));
+  DEBUG ((DEBUG_INFO, "Tpm2Clear ... \n"));
   Status = Tpm2Clear (TPM_RH_PLATFORM, AuthSession);
-  DEBUG ((EFI_D_INFO, "Tpm2Clear - %r\n", Status));
+  DEBUG ((DEBUG_INFO, "Tpm2Clear - %r\n", Status));
 
 Done:
   ZeroMem (&LocalAuthSession.hmac, sizeof(LocalAuthSession.hmac));
@@ -126,7 +126,7 @@ Tpm2CommandChangeEps (
   }
 
   Status = Tpm2ChangeEPS (TPM_RH_PLATFORM, AuthSession);
-  DEBUG ((EFI_D_INFO, "Tpm2ChangeEPS - %r\n", Status));
+  DEBUG ((DEBUG_INFO, "Tpm2ChangeEPS - %r\n", Status));
 
   ZeroMem(&LocalAuthSession.hmac, sizeof(LocalAuthSession.hmac));
   return Status;
@@ -913,7 +913,7 @@ Tcg2PhysicalPresenceLibProcessRequest (
                                      &gEfiTcg2PhysicalPresenceGuid
                                      );
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "[TPM2] Error when lock variable %s, Status = %r\n", TCG2_PHYSICAL_PRESENCE_FLAGS_VARIABLE, Status));
+      DEBUG ((DEBUG_ERROR, "[TPM2] Error when lock variable %s, Status = %r\n", TCG2_PHYSICAL_PRESENCE_FLAGS_VARIABLE, Status));
       ASSERT_EFI_ERROR (Status);
     }
   }
@@ -922,7 +922,7 @@ Tcg2PhysicalPresenceLibProcessRequest (
   // Check S4 resume
   //
   if (GetBootModeHob () == BOOT_ON_S4_RESUME) {
-    DEBUG ((EFI_D_INFO, "S4 Resume, Skip TPM PP process!\n"));
+    DEBUG ((DEBUG_INFO, "S4 Resume, Skip TPM PP process!\n"));
     return ;
   }
 
@@ -947,7 +947,7 @@ Tcg2PhysicalPresenceLibProcessRequest (
                       &PpiFlags
                       );
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "[TPM2] Set physical presence flag failed, Status = %r\n", Status));
+      DEBUG ((DEBUG_ERROR, "[TPM2] Set physical presence flag failed, Status = %r\n", Status));
       return ;
     }
     DEBUG((DEBUG_INFO, "[TPM2] Initial physical presence flags value is 0x%x\n", PpiFlags.PPFlags));
@@ -975,18 +975,18 @@ Tcg2PhysicalPresenceLibProcessRequest (
                       &TcgPpData
                       );
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "[TPM2] Set physical presence variable failed, Status = %r\n", Status));
+      DEBUG ((DEBUG_ERROR, "[TPM2] Set physical presence variable failed, Status = %r\n", Status));
       return ;
     }
   }
 
-  DEBUG ((EFI_D_INFO, "[TPM2] Flags=%x, PPRequest=%x (LastPPRequest=%x)\n", PpiFlags.PPFlags, TcgPpData.PPRequest, TcgPpData.LastPPRequest));
+  DEBUG ((DEBUG_INFO, "[TPM2] Flags=%x, PPRequest=%x (LastPPRequest=%x)\n", PpiFlags.PPFlags, TcgPpData.PPRequest, TcgPpData.LastPPRequest));
 
   //
   // Execute pending TPM request.
   //
   Tcg2ExecutePendingTpmRequest (PlatformAuth, &TcgPpData, &PpiFlags);
-  DEBUG ((EFI_D_INFO, "[TPM2] PPResponse = %x (LastPPRequest=%x, Flags=%x)\n", TcgPpData.PPResponse, TcgPpData.LastPPRequest, PpiFlags.PPFlags));
+  DEBUG ((DEBUG_INFO, "[TPM2] PPResponse = %x (LastPPRequest=%x, Flags=%x)\n", TcgPpData.PPResponse, TcgPpData.LastPPRequest, PpiFlags.PPFlags));
 
 }
 
@@ -1016,7 +1016,7 @@ Tcg2PhysicalPresenceLibNeedUserConfirm(
   // Check S4 resume
   //
   if (GetBootModeHob () == BOOT_ON_S4_RESUME) {
-    DEBUG ((EFI_D_INFO, "S4 Resume, Skip TPM PP process!\n"));
+    DEBUG ((DEBUG_INFO, "S4 Resume, Skip TPM PP process!\n"));
     return FALSE;
   }
 
@@ -1092,7 +1092,7 @@ Tcg2PhysicalPresenceLibReturnOperationResponseToOsFunction (
   UINTN                             DataSize;
   EFI_TCG2_PHYSICAL_PRESENCE        PpData;
 
-  DEBUG ((EFI_D_INFO, "[TPM2] ReturnOperationResponseToOsFunction\n"));
+  DEBUG ((DEBUG_INFO, "[TPM2] ReturnOperationResponseToOsFunction\n"));
 
   //
   // Get the Physical Presence variable
@@ -1108,7 +1108,7 @@ Tcg2PhysicalPresenceLibReturnOperationResponseToOsFunction (
   if (EFI_ERROR (Status)) {
     *MostRecentRequest = 0;
     *Response          = 0;
-    DEBUG ((EFI_D_ERROR, "[TPM2] Get PP variable failure! Status = %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "[TPM2] Get PP variable failure! Status = %r\n", Status));
     return TCG_PP_RETURN_TPM_OPERATION_RESPONSE_FAILURE;
   }
 
@@ -1143,7 +1143,7 @@ Tcg2PhysicalPresenceLibSubmitRequestToPreOSFunction (
   EFI_TCG2_PHYSICAL_PRESENCE        PpData;
   EFI_TCG2_PHYSICAL_PRESENCE_FLAGS  Flags;
 
-  DEBUG ((EFI_D_INFO, "[TPM2] SubmitRequestToPreOSFunction, Request = %x, %x\n", OperationRequest, RequestParameter));
+  DEBUG ((DEBUG_INFO, "[TPM2] SubmitRequestToPreOSFunction, Request = %x, %x\n", OperationRequest, RequestParameter));
 
   //
   // Get the Physical Presence variable
@@ -1157,7 +1157,7 @@ Tcg2PhysicalPresenceLibSubmitRequestToPreOSFunction (
                   &PpData
                   );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "[TPM2] Get PP variable failure! Status = %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "[TPM2] Get PP variable failure! Status = %r\n", Status));
     return TCG_PP_SUBMIT_REQUEST_TO_PREOS_GENERAL_FAILURE;
   }
 
@@ -1179,7 +1179,7 @@ Tcg2PhysicalPresenceLibSubmitRequestToPreOSFunction (
                     &PpData
                     );
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "[TPM2] Set PP variable failure! Status = %r\n", Status));
+      DEBUG ((DEBUG_ERROR, "[TPM2] Set PP variable failure! Status = %r\n", Status));
       return TCG_PP_SUBMIT_REQUEST_TO_PREOS_GENERAL_FAILURE;
     }
   }
@@ -1217,7 +1217,7 @@ Tcg2PhysicalPresenceLibGetManagementFlags (
   EFI_TCG2_PHYSICAL_PRESENCE_FLAGS  PpiFlags;
   UINTN                             DataSize;
 
-  DEBUG ((EFI_D_INFO, "[TPM2] GetManagementFlags\n"));
+  DEBUG ((DEBUG_INFO, "[TPM2] GetManagementFlags\n"));
 
   DataSize = sizeof (EFI_TCG2_PHYSICAL_PRESENCE_FLAGS);
   Status = gRT->GetVariable (

--- a/SecurityPkg/Library/DxeTcgPhysicalPresenceLib/DxeTcgPhysicalPresenceLib.c
+++ b/SecurityPkg/Library/DxeTcgPhysicalPresenceLib/DxeTcgPhysicalPresenceLib.c
@@ -1203,11 +1203,11 @@ TcgPhysicalPresenceLibProcessRequest (
                       &PpiFlags
                       );
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "[TPM] Set physical presence flag failed, Status = %r\n", Status));
+      DEBUG ((DEBUG_ERROR, "[TPM] Set physical presence flag failed, Status = %r\n", Status));
       return ;
     }
   }
-  DEBUG ((EFI_D_INFO, "[TPM] PpiFlags = %x\n", PpiFlags.PPFlags));
+  DEBUG ((DEBUG_INFO, "[TPM] PpiFlags = %x\n", PpiFlags.PPFlags));
 
   //
   // This flags variable controls whether physical presence is required for TPM command.
@@ -1221,7 +1221,7 @@ TcgPhysicalPresenceLibProcessRequest (
                                      &gEfiPhysicalPresenceGuid
                                      );
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "[TPM] Error when lock variable %s, Status = %r\n", PHYSICAL_PRESENCE_FLAGS_VARIABLE, Status));
+      DEBUG ((DEBUG_ERROR, "[TPM] Error when lock variable %s, Status = %r\n", PHYSICAL_PRESENCE_FLAGS_VARIABLE, Status));
       ASSERT_EFI_ERROR (Status);
     }
   }
@@ -1248,12 +1248,12 @@ TcgPhysicalPresenceLibProcessRequest (
                       &TcgPpData
                       );
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "[TPM] Set physical presence variable failed, Status = %r\n", Status));
+      DEBUG ((DEBUG_ERROR, "[TPM] Set physical presence variable failed, Status = %r\n", Status));
       return;
     }
   }
 
-  DEBUG ((EFI_D_INFO, "[TPM] Flags=%x, PPRequest=%x\n", PpiFlags.PPFlags, TcgPpData.PPRequest));
+  DEBUG ((DEBUG_INFO, "[TPM] Flags=%x, PPRequest=%x\n", PpiFlags.PPFlags, TcgPpData.PPRequest));
 
   if (TcgPpData.PPRequest == PHYSICAL_PRESENCE_NO_ACTION) {
     //
@@ -1292,7 +1292,7 @@ TcgPhysicalPresenceLibProcessRequest (
   // Execute pending TPM request.
   //
   ExecutePendingTpmRequest (TcgProtocol, &TcgPpData, PpiFlags);
-  DEBUG ((EFI_D_INFO, "[TPM] PPResponse = %x\n", TcgPpData.PPResponse));
+  DEBUG ((DEBUG_INFO, "[TPM] PPResponse = %x\n", TcgPpData.PPResponse));
 
   //
   // Lock physical presence.
@@ -1397,4 +1397,3 @@ TcgPhysicalPresenceLibNeedUserConfirm(
 
   return FALSE;
 }
-

--- a/SecurityPkg/Library/DxeTpm2MeasureBootLib/DxeTpm2MeasureBootLib.c
+++ b/SecurityPkg/Library/DxeTpm2MeasureBootLib/DxeTpm2MeasureBootLib.c
@@ -164,7 +164,7 @@ Tcg2MeasureGptTable (
                      (UINT8 *)PrimaryHeader
                      );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "Failed to Read Partition Table Header!\n"));
+    DEBUG ((DEBUG_ERROR, "Failed to Read Partition Table Header!\n"));
     FreePool (PrimaryHeader);
     return EFI_DEVICE_ERROR;
   }
@@ -334,7 +334,7 @@ Tcg2MeasurePeImage (
       break;
     default:
       DEBUG ((
-        EFI_D_ERROR,
+        DEBUG_ERROR,
         "Tcg2MeasurePeImage: Unknown subsystem type %d",
         ImageType
         ));
@@ -441,7 +441,7 @@ DxeTpm2MeasureBootHandler (
     // Tcg2 protocol is not installed. So, TPM2 is not present.
     // Don't do any measurement, and directly return EFI_SUCCESS.
     //
-    DEBUG ((EFI_D_VERBOSE, "DxeTpm2MeasureBootHandler - Tcg2 - %r\n", Status));
+    DEBUG ((DEBUG_VERBOSE, "DxeTpm2MeasureBootHandler - Tcg2 - %r\n", Status));
     return EFI_SUCCESS;
   }
 
@@ -454,7 +454,7 @@ DxeTpm2MeasureBootHandler (
     //
     // TPM device doesn't work or activate.
     //
-    DEBUG ((EFI_D_ERROR, "DxeTpm2MeasureBootHandler (%r) - TPMPresentFlag - %x\n", Status, ProtocolCapability.TPMPresentFlag));
+    DEBUG ((DEBUG_ERROR, "DxeTpm2MeasureBootHandler (%r) - TPMPresentFlag - %x\n", Status, ProtocolCapability.TPMPresentFlag));
     return EFI_SUCCESS;
   }
 
@@ -503,7 +503,7 @@ DxeTpm2MeasureBootHandler (
             // Measure GPT disk.
             //
             Status = Tcg2MeasureGptTable (Tcg2Protocol, Handle);
-            DEBUG ((EFI_D_INFO, "DxeTpm2MeasureBootHandler - Tcg2MeasureGptTable - %r\n", Status));
+            DEBUG ((DEBUG_INFO, "DxeTpm2MeasureBootHandler - Tcg2MeasureGptTable - %r\n", Status));
             if (!EFI_ERROR (Status)) {
               //
               // GPT disk check done.
@@ -654,7 +654,7 @@ DxeTpm2MeasureBootHandler (
                ImageContext.ImageType,
                DevicePathNode
                );
-    DEBUG ((EFI_D_INFO, "DxeTpm2MeasureBootHandler - Tcg2MeasurePeImage - %r\n", Status));
+    DEBUG ((DEBUG_INFO, "DxeTpm2MeasureBootHandler - Tcg2MeasurePeImage - %r\n", Status));
   }
 
   //
@@ -665,7 +665,7 @@ Finish:
     FreePool (OrigDevicePathNode);
   }
 
-  DEBUG ((EFI_D_INFO, "DxeTpm2MeasureBootHandler - %r\n", Status));
+  DEBUG ((DEBUG_INFO, "DxeTpm2MeasureBootHandler - %r\n", Status));
 
   return Status;
 }

--- a/SecurityPkg/Library/DxeTpmMeasureBootLib/DxeTpmMeasureBootLib.c
+++ b/SecurityPkg/Library/DxeTpmMeasureBootLib/DxeTpmMeasureBootLib.c
@@ -164,7 +164,7 @@ TcgMeasureGptTable (
                      (UINT8 *)PrimaryHeader
                      );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "Failed to Read Partition Table Header!\n"));
+    DEBUG ((DEBUG_ERROR, "Failed to Read Partition Table Header!\n"));
     FreePool (PrimaryHeader);
     return EFI_DEVICE_ERROR;
   }
@@ -355,7 +355,7 @@ TcgMeasurePeImage (
       break;
     default:
       DEBUG ((
-        EFI_D_ERROR,
+        DEBUG_ERROR,
         "TcgMeasurePeImage: Unknown subsystem type %d",
         ImageType
         ));

--- a/SecurityPkg/Library/HashLibTpm2/HashLibTpm2.c
+++ b/SecurityPkg/Library/HashLibTpm2/HashLibTpm2.c
@@ -237,7 +237,7 @@ HashAndExtend (
   TPM2B_EVENT        EventData;
   TPM2B_DIGEST       Result;
 
-  DEBUG((EFI_D_VERBOSE, "\n HashAndExtend Entry \n"));
+  DEBUG((DEBUG_VERBOSE, "\n HashAndExtend Entry \n"));
 
   SequenceHandle = 0xFFFFFFFF; // Know bad value
 
@@ -257,7 +257,7 @@ HashAndExtend (
   if (EFI_ERROR(Status)) {
     return EFI_DEVICE_ERROR;
   }
-  DEBUG((EFI_D_VERBOSE, "\n Tpm2HashSequenceStart Success \n"));
+  DEBUG((DEBUG_VERBOSE, "\n Tpm2HashSequenceStart Success \n"));
 
   Buffer = (UINT8 *)(UINTN)DataToHash;
   for (HashLen = DataToHashLen; HashLen > sizeof(HashBuffer.buffer); HashLen -= sizeof(HashBuffer.buffer)) {
@@ -271,7 +271,7 @@ HashAndExtend (
       return EFI_DEVICE_ERROR;
     }
   }
-  DEBUG((EFI_D_VERBOSE, "\n Tpm2SequenceUpdate Success \n"));
+  DEBUG((DEBUG_VERBOSE, "\n Tpm2SequenceUpdate Success \n"));
 
   HashBuffer.size = (UINT16)HashLen;
   CopyMem(HashBuffer.buffer, Buffer, (UINTN)HashLen);
@@ -289,7 +289,7 @@ HashAndExtend (
     if (EFI_ERROR(Status)) {
       return EFI_DEVICE_ERROR;
     }
-    DEBUG((EFI_D_VERBOSE, "\n Tpm2EventSequenceComplete Success \n"));
+    DEBUG((DEBUG_VERBOSE, "\n Tpm2EventSequenceComplete Success \n"));
   } else {
     Status = Tpm2SequenceComplete (
                SequenceHandle,
@@ -299,7 +299,7 @@ HashAndExtend (
     if (EFI_ERROR(Status)) {
       return EFI_DEVICE_ERROR;
     }
-    DEBUG((EFI_D_VERBOSE, "\n Tpm2SequenceComplete Success \n"));
+    DEBUG((DEBUG_VERBOSE, "\n Tpm2SequenceComplete Success \n"));
 
     DigestList->count = 1;
     DigestList->digests[0].hashAlg = AlgoId;
@@ -311,7 +311,7 @@ HashAndExtend (
     if (EFI_ERROR(Status)) {
       return EFI_DEVICE_ERROR;
     }
-    DEBUG((EFI_D_VERBOSE, "\n Tpm2PcrExtend Success \n"));
+    DEBUG((DEBUG_VERBOSE, "\n Tpm2PcrExtend Success \n"));
   }
 
   return EFI_SUCCESS;

--- a/SecurityPkg/Library/Tpm12CommandLib/Tpm12Pcr.c
+++ b/SecurityPkg/Library/Tpm12CommandLib/Tpm12Pcr.c
@@ -69,7 +69,7 @@ Tpm12Extend (
   }
 
   if (SwapBytes32(Response.Hdr.returnCode) != TPM_SUCCESS) {
-    DEBUG ((EFI_D_ERROR, "Tpm12Extend: Response Code error! 0x%08x\r\n", SwapBytes32(Response.Hdr.returnCode)));
+    DEBUG ((DEBUG_ERROR, "Tpm12Extend: Response Code error! 0x%08x\r\n", SwapBytes32(Response.Hdr.returnCode)));
     return EFI_DEVICE_ERROR;
   }
 

--- a/SecurityPkg/Library/Tpm12CommandLib/Tpm12PhysicalPresence.c
+++ b/SecurityPkg/Library/Tpm12CommandLib/Tpm12PhysicalPresence.c
@@ -58,7 +58,7 @@ Tpm12PhysicalPresence (
   }
 
   if (SwapBytes32(Response.returnCode) != TPM_SUCCESS) {
-    DEBUG ((EFI_D_ERROR, "Tpm12PhysicalPresence: Response Code error! 0x%08x\r\n", SwapBytes32(Response.returnCode)));
+    DEBUG ((DEBUG_ERROR, "Tpm12PhysicalPresence: Response Code error! 0x%08x\r\n", SwapBytes32(Response.returnCode)));
     return EFI_DEVICE_ERROR;
   }
 

--- a/SecurityPkg/Library/Tpm12DeviceLibDTpm/Tpm12Tis.c
+++ b/SecurityPkg/Library/Tpm12DeviceLibDTpm/Tpm12Tis.c
@@ -266,22 +266,22 @@ Tpm12TisTpmCommand (
   DEBUG_CODE (
     UINTN  DebugSize;
 
-    DEBUG ((EFI_D_VERBOSE, "Tpm12TisTpmCommand Send - "));
+    DEBUG ((DEBUG_VERBOSE, "Tpm12TisTpmCommand Send - "));
     if (SizeIn > 0x100) {
       DebugSize = 0x40;
     } else {
       DebugSize = SizeIn;
     }
     for (Index = 0; Index < DebugSize; Index++) {
-      DEBUG ((EFI_D_VERBOSE, "%02x ", BufferIn[Index]));
+      DEBUG ((DEBUG_VERBOSE, "%02x ", BufferIn[Index]));
     }
     if (DebugSize != SizeIn) {
-      DEBUG ((EFI_D_VERBOSE, "...... "));
+      DEBUG ((DEBUG_VERBOSE, "...... "));
       for (Index = SizeIn - 0x20; Index < SizeIn; Index++) {
-        DEBUG ((EFI_D_VERBOSE, "%02x ", BufferIn[Index]));
+        DEBUG ((DEBUG_VERBOSE, "%02x ", BufferIn[Index]));
       }
     }
-    DEBUG ((EFI_D_VERBOSE, "\n"));
+    DEBUG ((DEBUG_VERBOSE, "\n"));
   );
   TpmOutSize = 0;
 
@@ -352,11 +352,11 @@ Tpm12TisTpmCommand (
     }
   }
   DEBUG_CODE (
-    DEBUG ((EFI_D_VERBOSE, "Tpm12TisTpmCommand ReceiveHeader - "));
+    DEBUG ((DEBUG_VERBOSE, "Tpm12TisTpmCommand ReceiveHeader - "));
     for (Index = 0; Index < sizeof (TPM_RSP_COMMAND_HDR); Index++) {
-      DEBUG ((EFI_D_VERBOSE, "%02x ", BufferOut[Index]));
+      DEBUG ((DEBUG_VERBOSE, "%02x ", BufferOut[Index]));
     }
-    DEBUG ((EFI_D_VERBOSE, "\n"));
+    DEBUG ((DEBUG_VERBOSE, "\n"));
   );
   //
   // Check the response data header (tag, parasize and returncode)
@@ -364,7 +364,7 @@ Tpm12TisTpmCommand (
   CopyMem (&Data16, BufferOut, sizeof (UINT16));
   RspTag = SwapBytes16 (Data16);
   if (RspTag != TPM_TAG_RSP_COMMAND && RspTag != TPM_TAG_RSP_AUTH1_COMMAND && RspTag != TPM_TAG_RSP_AUTH2_COMMAND) {
-    DEBUG ((EFI_D_ERROR, "TPM12: Response tag error - current tag value is %x\n", RspTag));
+    DEBUG ((DEBUG_ERROR, "TPM12: Response tag error - current tag value is %x\n", RspTag));
     Status = EFI_UNSUPPORTED;
     goto Exit;
   }
@@ -396,11 +396,11 @@ Tpm12TisTpmCommand (
   }
 Exit:
   DEBUG_CODE (
-    DEBUG ((EFI_D_VERBOSE, "Tpm12TisTpmCommand Receive - "));
+    DEBUG ((DEBUG_VERBOSE, "Tpm12TisTpmCommand Receive - "));
     for (Index = 0; Index < TpmOutSize; Index++) {
-      DEBUG ((EFI_D_VERBOSE, "%02x ", BufferOut[Index]));
+      DEBUG ((DEBUG_VERBOSE, "%02x ", BufferOut[Index]));
     }
-    DEBUG ((EFI_D_VERBOSE, "\n"));
+    DEBUG ((DEBUG_VERBOSE, "\n"));
   );
   MmioWrite8((UINTN)&TisReg->Status, TIS_PC_STS_READY);
   return Status;

--- a/SecurityPkg/Library/Tpm12DeviceLibTcg/Tpm12DeviceLibTcg.c
+++ b/SecurityPkg/Library/Tpm12DeviceLibTcg/Tpm12DeviceLibTcg.c
@@ -47,7 +47,7 @@ Tpm12SubmitCommand (
       //
       // TCG protocol is not installed. So, TPM12 is not present.
       //
-      DEBUG ((EFI_D_ERROR, "Tpm12SubmitCommand - TCG - %r\n", Status));
+      DEBUG ((DEBUG_ERROR, "Tpm12SubmitCommand - TCG - %r\n", Status));
       return EFI_NOT_FOUND;
     }
   }
@@ -91,7 +91,7 @@ Tpm12RequestUseTpm (
       //
       // TCG protocol is not installed. So, TPM12 is not present.
       //
-      DEBUG ((EFI_D_ERROR, "Tpm12RequestUseTpm - TCG - %r\n", Status));
+      DEBUG ((DEBUG_ERROR, "Tpm12RequestUseTpm - TCG - %r\n", Status));
       return EFI_NOT_FOUND;
     }
   }

--- a/SecurityPkg/Library/Tpm2CommandLib/Tpm2Context.c
+++ b/SecurityPkg/Library/Tpm2CommandLib/Tpm2Context.c
@@ -67,14 +67,13 @@ Tpm2FlushContext (
   }
 
   if (RecvBufferSize < sizeof (TPM2_RESPONSE_HEADER)) {
-    DEBUG ((EFI_D_ERROR, "Tpm2FlushContext - RecvBufferSize Error - %x\n", RecvBufferSize));
+    DEBUG ((DEBUG_ERROR, "Tpm2FlushContext - RecvBufferSize Error - %x\n", RecvBufferSize));
     return EFI_DEVICE_ERROR;
   }
   if (SwapBytes32(RecvBuffer.Header.responseCode) != TPM_RC_SUCCESS) {
-    DEBUG ((EFI_D_ERROR, "Tpm2FlushContext - responseCode - %x\n", SwapBytes32(RecvBuffer.Header.responseCode)));
+    DEBUG ((DEBUG_ERROR, "Tpm2FlushContext - responseCode - %x\n", SwapBytes32(RecvBuffer.Header.responseCode)));
     return EFI_DEVICE_ERROR;
   }
 
   return EFI_SUCCESS;
 }
-

--- a/SecurityPkg/Library/Tpm2CommandLib/Tpm2DictionaryAttack.c
+++ b/SecurityPkg/Library/Tpm2CommandLib/Tpm2DictionaryAttack.c
@@ -102,12 +102,12 @@ Tpm2DictionaryAttackLockReset (
   }
 
   if (RecvBufferSize < sizeof (TPM2_RESPONSE_HEADER)) {
-    DEBUG ((EFI_D_ERROR, "Tpm2DictionaryAttackLockReset - RecvBufferSize Error - %x\n", RecvBufferSize));
+    DEBUG ((DEBUG_ERROR, "Tpm2DictionaryAttackLockReset - RecvBufferSize Error - %x\n", RecvBufferSize));
     Status = EFI_DEVICE_ERROR;
     goto Done;
   }
   if (SwapBytes32(RecvBuffer.Header.responseCode) != TPM_RC_SUCCESS) {
-    DEBUG ((EFI_D_ERROR, "Tpm2DictionaryAttackLockReset - responseCode - %x\n", SwapBytes32(RecvBuffer.Header.responseCode)));
+    DEBUG ((DEBUG_ERROR, "Tpm2DictionaryAttackLockReset - responseCode - %x\n", SwapBytes32(RecvBuffer.Header.responseCode)));
     Status = EFI_DEVICE_ERROR;
     goto Done;
   }
@@ -193,12 +193,12 @@ Tpm2DictionaryAttackParameters (
   }
 
   if (RecvBufferSize < sizeof (TPM2_RESPONSE_HEADER)) {
-    DEBUG ((EFI_D_ERROR, "Tpm2DictionaryAttackParameters - RecvBufferSize Error - %x\n", RecvBufferSize));
+    DEBUG ((DEBUG_ERROR, "Tpm2DictionaryAttackParameters - RecvBufferSize Error - %x\n", RecvBufferSize));
     Status = EFI_DEVICE_ERROR;
     goto Done;
   }
   if (SwapBytes32(RecvBuffer.Header.responseCode) != TPM_RC_SUCCESS) {
-    DEBUG ((EFI_D_ERROR, "Tpm2DictionaryAttackParameters - responseCode - %x\n", SwapBytes32(RecvBuffer.Header.responseCode)));
+    DEBUG ((DEBUG_ERROR, "Tpm2DictionaryAttackParameters - responseCode - %x\n", SwapBytes32(RecvBuffer.Header.responseCode)));
     Status = EFI_DEVICE_ERROR;
     goto Done;
   }

--- a/SecurityPkg/Library/Tpm2CommandLib/Tpm2EnhancedAuthorization.c
+++ b/SecurityPkg/Library/Tpm2CommandLib/Tpm2EnhancedAuthorization.c
@@ -159,12 +159,12 @@ Tpm2PolicySecret (
   }
 
   if (RecvBufferSize < sizeof (TPM2_RESPONSE_HEADER)) {
-    DEBUG ((EFI_D_ERROR, "Tpm2PolicySecret - RecvBufferSize Error - %x\n", RecvBufferSize));
+    DEBUG ((DEBUG_ERROR, "Tpm2PolicySecret - RecvBufferSize Error - %x\n", RecvBufferSize));
     Status = EFI_DEVICE_ERROR;
     goto Done;
   }
   if (SwapBytes32(RecvBuffer.Header.responseCode) != TPM_RC_SUCCESS) {
-    DEBUG ((EFI_D_ERROR, "Tpm2PolicySecret - responseCode - %x\n", SwapBytes32(RecvBuffer.Header.responseCode)));
+    DEBUG ((DEBUG_ERROR, "Tpm2PolicySecret - responseCode - %x\n", SwapBytes32(RecvBuffer.Header.responseCode)));
     Status = EFI_DEVICE_ERROR;
     goto Done;
   }
@@ -263,11 +263,11 @@ Tpm2PolicyOR (
   }
 
   if (RecvBufferSize < sizeof (TPM2_RESPONSE_HEADER)) {
-    DEBUG ((EFI_D_ERROR, "Tpm2PolicyOR - RecvBufferSize Error - %x\n", RecvBufferSize));
+    DEBUG ((DEBUG_ERROR, "Tpm2PolicyOR - RecvBufferSize Error - %x\n", RecvBufferSize));
     return EFI_DEVICE_ERROR;
   }
   if (SwapBytes32(RecvBuffer.Header.responseCode) != TPM_RC_SUCCESS) {
-    DEBUG ((EFI_D_ERROR, "Tpm2PolicyOR - responseCode - %x\n", SwapBytes32(RecvBuffer.Header.responseCode)));
+    DEBUG ((DEBUG_ERROR, "Tpm2PolicyOR - responseCode - %x\n", SwapBytes32(RecvBuffer.Header.responseCode)));
     return EFI_DEVICE_ERROR;
   }
 
@@ -318,11 +318,11 @@ Tpm2PolicyCommandCode (
   }
 
   if (RecvBufferSize < sizeof (TPM2_RESPONSE_HEADER)) {
-    DEBUG ((EFI_D_ERROR, "Tpm2PolicyCommandCode - RecvBufferSize Error - %x\n", RecvBufferSize));
+    DEBUG ((DEBUG_ERROR, "Tpm2PolicyCommandCode - RecvBufferSize Error - %x\n", RecvBufferSize));
     return EFI_DEVICE_ERROR;
   }
   if (SwapBytes32(RecvBuffer.Header.responseCode) != TPM_RC_SUCCESS) {
-    DEBUG ((EFI_D_ERROR, "Tpm2PolicyCommandCode - responseCode - %x\n", SwapBytes32(RecvBuffer.Header.responseCode)));
+    DEBUG ((DEBUG_ERROR, "Tpm2PolicyCommandCode - responseCode - %x\n", SwapBytes32(RecvBuffer.Header.responseCode)));
     return EFI_DEVICE_ERROR;
   }
 
@@ -373,11 +373,11 @@ Tpm2PolicyGetDigest (
   }
 
   if (RecvBufferSize < sizeof (TPM2_RESPONSE_HEADER)) {
-    DEBUG ((EFI_D_ERROR, "Tpm2PolicyGetDigest - RecvBufferSize Error - %x\n", RecvBufferSize));
+    DEBUG ((DEBUG_ERROR, "Tpm2PolicyGetDigest - RecvBufferSize Error - %x\n", RecvBufferSize));
     return EFI_DEVICE_ERROR;
   }
   if (SwapBytes32(RecvBuffer.Header.responseCode) != TPM_RC_SUCCESS) {
-    DEBUG ((EFI_D_ERROR, "Tpm2PolicyGetDigest - responseCode - %x\n", SwapBytes32(RecvBuffer.Header.responseCode)));
+    DEBUG ((DEBUG_ERROR, "Tpm2PolicyGetDigest - responseCode - %x\n", SwapBytes32(RecvBuffer.Header.responseCode)));
     return EFI_DEVICE_ERROR;
   }
 

--- a/SecurityPkg/Library/Tpm2CommandLib/Tpm2Help.c
+++ b/SecurityPkg/Library/Tpm2CommandLib/Tpm2Help.c
@@ -266,7 +266,7 @@ CopyDigestListToBuffer (
   Buffer = (UINT8 *)Buffer + sizeof(DigestList->count);
   for (Index = 0; Index < DigestList->count; Index++) {
     if (!IsHashAlgSupportedInHashAlgorithmMask(DigestList->digests[Index].hashAlg, HashAlgorithmMask)) {
-      DEBUG ((EFI_D_ERROR, "WARNING: TPM2 Event log has HashAlg unsupported by PCR bank (0x%x)\n", DigestList->digests[Index].hashAlg));
+      DEBUG ((DEBUG_ERROR, "WARNING: TPM2 Event log has HashAlg unsupported by PCR bank (0x%x)\n", DigestList->digests[Index].hashAlg));
       continue;
     }
     CopyMem (Buffer, &DigestList->digests[Index].hashAlg, sizeof(DigestList->digests[Index].hashAlg));

--- a/SecurityPkg/Library/Tpm2CommandLib/Tpm2Hierarchy.c
+++ b/SecurityPkg/Library/Tpm2CommandLib/Tpm2Hierarchy.c
@@ -184,12 +184,12 @@ Tpm2SetPrimaryPolicy (
   }
 
   if (RecvBufferSize < sizeof (TPM2_RESPONSE_HEADER)) {
-    DEBUG ((EFI_D_ERROR, "Tpm2SetPrimaryPolicy - RecvBufferSize Error - %x\n", RecvBufferSize));
+    DEBUG ((DEBUG_ERROR, "Tpm2SetPrimaryPolicy - RecvBufferSize Error - %x\n", RecvBufferSize));
     Status = EFI_DEVICE_ERROR;
     goto Done;
   }
   if (SwapBytes32(RecvBuffer.Header.responseCode) != TPM_RC_SUCCESS) {
-    DEBUG ((EFI_D_ERROR, "Tpm2SetPrimaryPolicy - responseCode - %x\n", SwapBytes32(RecvBuffer.Header.responseCode)));
+    DEBUG ((DEBUG_ERROR, "Tpm2SetPrimaryPolicy - responseCode - %x\n", SwapBytes32(RecvBuffer.Header.responseCode)));
     Status = EFI_DEVICE_ERROR;
     goto Done;
   }
@@ -252,7 +252,7 @@ Tpm2Clear (
   }
 
   if (ResultBufSize > sizeof(Res)) {
-    DEBUG ((EFI_D_ERROR, "Clear: Failed ExecuteCommand: Buffer Too Small\r\n"));
+    DEBUG ((DEBUG_ERROR, "Clear: Failed ExecuteCommand: Buffer Too Small\r\n"));
     Status = EFI_BUFFER_TOO_SMALL;
     goto Done;
   }
@@ -262,7 +262,7 @@ Tpm2Clear (
   //
   RespSize = SwapBytes32(Res.Header.paramSize);
   if (RespSize > sizeof(Res)) {
-    DEBUG ((EFI_D_ERROR, "Clear: Response size too large! %d\r\n", RespSize));
+    DEBUG ((DEBUG_ERROR, "Clear: Response size too large! %d\r\n", RespSize));
     Status = EFI_BUFFER_TOO_SMALL;
     goto Done;
   }
@@ -271,7 +271,7 @@ Tpm2Clear (
   // Fail if command failed
   //
   if (SwapBytes32(Res.Header.responseCode) != TPM_RC_SUCCESS) {
-    DEBUG ((EFI_D_ERROR, "Clear: Response Code error! 0x%08x\r\n", SwapBytes32(Res.Header.responseCode)));
+    DEBUG ((DEBUG_ERROR, "Clear: Response Code error! 0x%08x\r\n", SwapBytes32(Res.Header.responseCode)));
     Status = EFI_DEVICE_ERROR;
     goto Done;
   }
@@ -346,7 +346,7 @@ Tpm2ClearControl (
   }
 
   if (ResultBufSize > sizeof(Res)) {
-    DEBUG ((EFI_D_ERROR, "ClearControl: Failed ExecuteCommand: Buffer Too Small\r\n"));
+    DEBUG ((DEBUG_ERROR, "ClearControl: Failed ExecuteCommand: Buffer Too Small\r\n"));
     Status = EFI_BUFFER_TOO_SMALL;
     goto Done;
   }
@@ -356,7 +356,7 @@ Tpm2ClearControl (
   //
   RespSize = SwapBytes32(Res.Header.paramSize);
   if (RespSize > sizeof(Res)) {
-    DEBUG ((EFI_D_ERROR, "ClearControl: Response size too large! %d\r\n", RespSize));
+    DEBUG ((DEBUG_ERROR, "ClearControl: Response size too large! %d\r\n", RespSize));
     Status = EFI_BUFFER_TOO_SMALL;
     goto Done;
   }
@@ -365,7 +365,7 @@ Tpm2ClearControl (
   // Fail if command failed
   //
   if (SwapBytes32(Res.Header.responseCode) != TPM_RC_SUCCESS) {
-    DEBUG ((EFI_D_ERROR, "ClearControl: Response Code error! 0x%08x\r\n", SwapBytes32(Res.Header.responseCode)));
+    DEBUG ((DEBUG_ERROR, "ClearControl: Response Code error! 0x%08x\r\n", SwapBytes32(Res.Header.responseCode)));
     Status = EFI_DEVICE_ERROR;
     goto Done;
   }
@@ -459,7 +459,7 @@ Tpm2HierarchyChangeAuth (
   }
 
   if (ResultBufSize > sizeof(Res)) {
-    DEBUG ((EFI_D_ERROR, "HierarchyChangeAuth: Failed ExecuteCommand: Buffer Too Small\r\n"));
+    DEBUG ((DEBUG_ERROR, "HierarchyChangeAuth: Failed ExecuteCommand: Buffer Too Small\r\n"));
     Status = EFI_BUFFER_TOO_SMALL;
     goto Done;
   }
@@ -469,7 +469,7 @@ Tpm2HierarchyChangeAuth (
   //
   RespSize = SwapBytes32(Res.Header.paramSize);
   if (RespSize > sizeof(Res)) {
-    DEBUG ((EFI_D_ERROR, "HierarchyChangeAuth: Response size too large! %d\r\n", RespSize));
+    DEBUG ((DEBUG_ERROR, "HierarchyChangeAuth: Response size too large! %d\r\n", RespSize));
     Status = EFI_BUFFER_TOO_SMALL;
     goto Done;
   }
@@ -478,7 +478,7 @@ Tpm2HierarchyChangeAuth (
   // Fail if command failed
   //
   if (SwapBytes32(Res.Header.responseCode) != TPM_RC_SUCCESS) {
-    DEBUG((EFI_D_ERROR,"HierarchyChangeAuth: Response Code error! 0x%08x\r\n", SwapBytes32(Res.Header.responseCode)));
+    DEBUG((DEBUG_ERROR,"HierarchyChangeAuth: Response Code error! 0x%08x\r\n", SwapBytes32(Res.Header.responseCode)));
     Status = EFI_DEVICE_ERROR;
     goto Done;
   }
@@ -557,7 +557,7 @@ Tpm2ChangeEPS (
   }
 
   if (ResultBufSize > sizeof(Res)) {
-    DEBUG ((EFI_D_ERROR, "ChangeEPS: Failed ExecuteCommand: Buffer Too Small\r\n"));
+    DEBUG ((DEBUG_ERROR, "ChangeEPS: Failed ExecuteCommand: Buffer Too Small\r\n"));
     Status = EFI_BUFFER_TOO_SMALL;
     goto Done;
   }
@@ -567,7 +567,7 @@ Tpm2ChangeEPS (
   //
   RespSize = SwapBytes32(Res.Header.paramSize);
   if (RespSize > sizeof(Res)) {
-    DEBUG ((EFI_D_ERROR, "ChangeEPS: Response size too large! %d\r\n", RespSize));
+    DEBUG ((DEBUG_ERROR, "ChangeEPS: Response size too large! %d\r\n", RespSize));
     Status = EFI_BUFFER_TOO_SMALL;
     goto Done;
   }
@@ -576,7 +576,7 @@ Tpm2ChangeEPS (
   // Fail if command failed
   //
   if (SwapBytes32(Res.Header.responseCode) != TPM_RC_SUCCESS) {
-    DEBUG((EFI_D_ERROR,"ChangeEPS: Response Code error! 0x%08x\r\n", SwapBytes32(Res.Header.responseCode)));
+    DEBUG((DEBUG_ERROR,"ChangeEPS: Response Code error! 0x%08x\r\n", SwapBytes32(Res.Header.responseCode)));
     Status = EFI_DEVICE_ERROR;
     goto Done;
   }
@@ -655,7 +655,7 @@ Tpm2ChangePPS (
   }
 
   if (ResultBufSize > sizeof(Res)) {
-    DEBUG ((EFI_D_ERROR, "ChangePPS: Failed ExecuteCommand: Buffer Too Small\r\n"));
+    DEBUG ((DEBUG_ERROR, "ChangePPS: Failed ExecuteCommand: Buffer Too Small\r\n"));
     Status = EFI_BUFFER_TOO_SMALL;
     goto Done;
   }
@@ -665,7 +665,7 @@ Tpm2ChangePPS (
   //
   RespSize = SwapBytes32(Res.Header.paramSize);
   if (RespSize > sizeof(Res)) {
-    DEBUG ((EFI_D_ERROR, "ChangePPS: Response size too large! %d\r\n", RespSize));
+    DEBUG ((DEBUG_ERROR, "ChangePPS: Response size too large! %d\r\n", RespSize));
     Status = EFI_BUFFER_TOO_SMALL;
     goto Done;
   }
@@ -674,7 +674,7 @@ Tpm2ChangePPS (
   // Fail if command failed
   //
   if (SwapBytes32(Res.Header.responseCode) != TPM_RC_SUCCESS) {
-    DEBUG((EFI_D_ERROR,"ChangePPS: Response Code error! 0x%08x\r\n", SwapBytes32(Res.Header.responseCode)));
+    DEBUG((DEBUG_ERROR,"ChangePPS: Response Code error! 0x%08x\r\n", SwapBytes32(Res.Header.responseCode)));
     Status = EFI_DEVICE_ERROR;
     goto Done;
   }
@@ -763,7 +763,7 @@ Tpm2HierarchyControl (
   }
 
   if (ResultBufSize > sizeof(Res)) {
-    DEBUG ((EFI_D_ERROR, "HierarchyControl: Failed ExecuteCommand: Buffer Too Small\r\n"));
+    DEBUG ((DEBUG_ERROR, "HierarchyControl: Failed ExecuteCommand: Buffer Too Small\r\n"));
     Status = EFI_BUFFER_TOO_SMALL;
     goto Done;
   }
@@ -773,7 +773,7 @@ Tpm2HierarchyControl (
   //
   RespSize = SwapBytes32(Res.Header.paramSize);
   if (RespSize > sizeof(Res)) {
-    DEBUG ((EFI_D_ERROR, "HierarchyControl: Response size too large! %d\r\n", RespSize));
+    DEBUG ((DEBUG_ERROR, "HierarchyControl: Response size too large! %d\r\n", RespSize));
     Status = EFI_BUFFER_TOO_SMALL;
     goto Done;
   }
@@ -782,7 +782,7 @@ Tpm2HierarchyControl (
   // Fail if command failed
   //
   if (SwapBytes32(Res.Header.responseCode) != TPM_RC_SUCCESS) {
-    DEBUG((EFI_D_ERROR,"HierarchyControl: Response Code error! 0x%08x\r\n", SwapBytes32(Res.Header.responseCode)));
+    DEBUG((DEBUG_ERROR,"HierarchyControl: Response Code error! 0x%08x\r\n", SwapBytes32(Res.Header.responseCode)));
     Status = EFI_DEVICE_ERROR;
     goto Done;
   }

--- a/SecurityPkg/Library/Tpm2CommandLib/Tpm2Integrity.c
+++ b/SecurityPkg/Library/Tpm2CommandLib/Tpm2Integrity.c
@@ -130,7 +130,7 @@ Tpm2PcrExtend (
     Buffer += sizeof(UINT16);
     DigestSize = GetHashSizeFromAlgo (Digests->digests[Index].hashAlg);
     if (DigestSize == 0) {
-      DEBUG ((EFI_D_ERROR, "Unknown hash algorithm %d\r\n", Digests->digests[Index].hashAlg));
+      DEBUG ((DEBUG_ERROR, "Unknown hash algorithm %d\r\n", Digests->digests[Index].hashAlg));
       return EFI_DEVICE_ERROR;
     }
     CopyMem(
@@ -151,7 +151,7 @@ Tpm2PcrExtend (
   }
 
   if (ResultBufSize > sizeof(Res)) {
-    DEBUG ((EFI_D_ERROR, "Tpm2PcrExtend: Failed ExecuteCommand: Buffer Too Small\r\n"));
+    DEBUG ((DEBUG_ERROR, "Tpm2PcrExtend: Failed ExecuteCommand: Buffer Too Small\r\n"));
     return EFI_BUFFER_TOO_SMALL;
   }
 
@@ -160,7 +160,7 @@ Tpm2PcrExtend (
   //
   RespSize = SwapBytes32(Res.Header.paramSize);
   if (RespSize > sizeof(Res)) {
-    DEBUG ((EFI_D_ERROR, "Tpm2PcrExtend: Response size too large! %d\r\n", RespSize));
+    DEBUG ((DEBUG_ERROR, "Tpm2PcrExtend: Response size too large! %d\r\n", RespSize));
     return EFI_BUFFER_TOO_SMALL;
   }
 
@@ -168,7 +168,7 @@ Tpm2PcrExtend (
   // Fail if command failed
   //
   if (SwapBytes32(Res.Header.responseCode) != TPM_RC_SUCCESS) {
-    DEBUG ((EFI_D_ERROR, "Tpm2PcrExtend: Response Code error! 0x%08x\r\n", SwapBytes32(Res.Header.responseCode)));
+    DEBUG ((DEBUG_ERROR, "Tpm2PcrExtend: Response Code error! 0x%08x\r\n", SwapBytes32(Res.Header.responseCode)));
     return EFI_DEVICE_ERROR;
   }
 
@@ -246,7 +246,7 @@ Tpm2PcrEvent (
   }
 
   if (ResultBufSize > sizeof(Res)) {
-    DEBUG ((EFI_D_ERROR, "Tpm2PcrEvent: Failed ExecuteCommand: Buffer Too Small\r\n"));
+    DEBUG ((DEBUG_ERROR, "Tpm2PcrEvent: Failed ExecuteCommand: Buffer Too Small\r\n"));
     return EFI_BUFFER_TOO_SMALL;
   }
 
@@ -255,7 +255,7 @@ Tpm2PcrEvent (
   //
   RespSize = SwapBytes32(Res.Header.paramSize);
   if (RespSize > sizeof(Res)) {
-    DEBUG ((EFI_D_ERROR, "Tpm2PcrEvent: Response size too large! %d\r\n", RespSize));
+    DEBUG ((DEBUG_ERROR, "Tpm2PcrEvent: Response size too large! %d\r\n", RespSize));
     return EFI_BUFFER_TOO_SMALL;
   }
 
@@ -263,7 +263,7 @@ Tpm2PcrEvent (
   // Fail if command failed
   //
   if (SwapBytes32(Res.Header.responseCode) != TPM_RC_SUCCESS) {
-    DEBUG ((EFI_D_ERROR, "Tpm2PcrEvent: Response Code error! 0x%08x\r\n", SwapBytes32(Res.Header.responseCode)));
+    DEBUG ((DEBUG_ERROR, "Tpm2PcrEvent: Response Code error! 0x%08x\r\n", SwapBytes32(Res.Header.responseCode)));
     return EFI_DEVICE_ERROR;
   }
 
@@ -284,7 +284,7 @@ Tpm2PcrEvent (
     Buffer += sizeof(UINT16);
     DigestSize = GetHashSizeFromAlgo (Digests->digests[Index].hashAlg);
     if (DigestSize == 0) {
-      DEBUG ((EFI_D_ERROR, "Unknown hash algorithm %d\r\n", Digests->digests[Index].hashAlg));
+      DEBUG ((DEBUG_ERROR, "Unknown hash algorithm %d\r\n", Digests->digests[Index].hashAlg));
       return EFI_DEVICE_ERROR;
     }
     CopyMem(
@@ -353,11 +353,11 @@ Tpm2PcrRead (
   }
 
   if (RecvBufferSize < sizeof (TPM2_RESPONSE_HEADER)) {
-    DEBUG ((EFI_D_ERROR, "Tpm2PcrRead - RecvBufferSize Error - %x\n", RecvBufferSize));
+    DEBUG ((DEBUG_ERROR, "Tpm2PcrRead - RecvBufferSize Error - %x\n", RecvBufferSize));
     return EFI_DEVICE_ERROR;
   }
   if (SwapBytes32(RecvBuffer.Header.responseCode) != TPM_RC_SUCCESS) {
-    DEBUG ((EFI_D_ERROR, "Tpm2PcrRead - responseCode - %x\n", SwapBytes32(RecvBuffer.Header.responseCode)));
+    DEBUG ((DEBUG_ERROR, "Tpm2PcrRead - responseCode - %x\n", SwapBytes32(RecvBuffer.Header.responseCode)));
     return EFI_NOT_FOUND;
   }
 
@@ -369,7 +369,7 @@ Tpm2PcrRead (
   // PcrUpdateCounter
   //
   if (RecvBufferSize < sizeof (TPM2_RESPONSE_HEADER) + sizeof(RecvBuffer.PcrUpdateCounter)) {
-    DEBUG ((EFI_D_ERROR, "Tpm2PcrRead - RecvBufferSize Error - %x\n", RecvBufferSize));
+    DEBUG ((DEBUG_ERROR, "Tpm2PcrRead - RecvBufferSize Error - %x\n", RecvBufferSize));
     return EFI_DEVICE_ERROR;
   }
   *PcrUpdateCounter = SwapBytes32(RecvBuffer.PcrUpdateCounter);
@@ -378,7 +378,7 @@ Tpm2PcrRead (
   // PcrSelectionOut
   //
   if (RecvBufferSize < sizeof (TPM2_RESPONSE_HEADER) + sizeof(RecvBuffer.PcrUpdateCounter) + sizeof(RecvBuffer.PcrSelectionOut.count)) {
-    DEBUG ((EFI_D_ERROR, "Tpm2PcrRead - RecvBufferSize Error - %x\n", RecvBufferSize));
+    DEBUG ((DEBUG_ERROR, "Tpm2PcrRead - RecvBufferSize Error - %x\n", RecvBufferSize));
     return EFI_DEVICE_ERROR;
   }
   PcrSelectionOut->count = SwapBytes32(RecvBuffer.PcrSelectionOut.count);
@@ -388,7 +388,7 @@ Tpm2PcrRead (
   }
 
   if (RecvBufferSize < sizeof (TPM2_RESPONSE_HEADER) + sizeof(RecvBuffer.PcrUpdateCounter) + sizeof(RecvBuffer.PcrSelectionOut.count) + sizeof(RecvBuffer.PcrSelectionOut.pcrSelections[0]) * PcrSelectionOut->count) {
-    DEBUG ((EFI_D_ERROR, "Tpm2PcrRead - RecvBufferSize Error - %x\n", RecvBufferSize));
+    DEBUG ((DEBUG_ERROR, "Tpm2PcrRead - RecvBufferSize Error - %x\n", RecvBufferSize));
     return EFI_DEVICE_ERROR;
   }
   for (Index = 0; Index < PcrSelectionOut->count; Index++) {
@@ -513,7 +513,7 @@ Tpm2PcrAllocate (
   }
 
   if (ResultBufSize > sizeof(Res)) {
-    DEBUG ((EFI_D_ERROR, "Tpm2PcrAllocate: Failed ExecuteCommand: Buffer Too Small\r\n"));
+    DEBUG ((DEBUG_ERROR, "Tpm2PcrAllocate: Failed ExecuteCommand: Buffer Too Small\r\n"));
     Status = EFI_BUFFER_TOO_SMALL;
     goto Done;
   }
@@ -523,7 +523,7 @@ Tpm2PcrAllocate (
   //
   RespSize = SwapBytes32(Res.Header.paramSize);
   if (RespSize > sizeof(Res)) {
-    DEBUG ((EFI_D_ERROR, "Tpm2PcrAllocate: Response size too large! %d\r\n", RespSize));
+    DEBUG ((DEBUG_ERROR, "Tpm2PcrAllocate: Response size too large! %d\r\n", RespSize));
     Status = EFI_BUFFER_TOO_SMALL;
     goto Done;
   }
@@ -532,7 +532,7 @@ Tpm2PcrAllocate (
   // Fail if command failed
   //
   if (SwapBytes32(Res.Header.responseCode) != TPM_RC_SUCCESS) {
-    DEBUG((EFI_D_ERROR,"Tpm2PcrAllocate: Response Code error! 0x%08x\r\n", SwapBytes32(Res.Header.responseCode)));
+    DEBUG((DEBUG_ERROR,"Tpm2PcrAllocate: Response Code error! 0x%08x\r\n", SwapBytes32(Res.Header.responseCode)));
     Status = EFI_DEVICE_ERROR;
     goto Done;
   }
@@ -673,15 +673,15 @@ Tpm2PcrAllocateBanks (
              &SizeNeeded,
              &SizeAvailable
              );
-  DEBUG ((EFI_D_INFO, "Tpm2PcrAllocateBanks call Tpm2PcrAllocate - %r\n", Status));
+  DEBUG ((DEBUG_INFO, "Tpm2PcrAllocateBanks call Tpm2PcrAllocate - %r\n", Status));
   if (EFI_ERROR (Status)) {
     goto Done;
   }
 
-  DEBUG ((EFI_D_INFO, "AllocationSuccess - %02x\n", AllocationSuccess));
-  DEBUG ((EFI_D_INFO, "MaxPCR            - %08x\n", MaxPCR));
-  DEBUG ((EFI_D_INFO, "SizeNeeded        - %08x\n", SizeNeeded));
-  DEBUG ((EFI_D_INFO, "SizeAvailable     - %08x\n", SizeAvailable));
+  DEBUG ((DEBUG_INFO, "AllocationSuccess - %02x\n", AllocationSuccess));
+  DEBUG ((DEBUG_INFO, "MaxPCR            - %08x\n", MaxPCR));
+  DEBUG ((DEBUG_INFO, "SizeNeeded        - %08x\n", SizeNeeded));
+  DEBUG ((DEBUG_INFO, "SizeAvailable     - %08x\n", SizeAvailable));
 
 Done:
   ZeroMem(&LocalAuthSession.hmac, sizeof(LocalAuthSession.hmac));

--- a/SecurityPkg/Library/Tpm2CommandLib/Tpm2Miscellaneous.c
+++ b/SecurityPkg/Library/Tpm2CommandLib/Tpm2Miscellaneous.c
@@ -96,12 +96,12 @@ Tpm2SetAlgorithmSet (
   }
 
   if (RecvBufferSize < sizeof (TPM2_RESPONSE_HEADER)) {
-    DEBUG ((EFI_D_ERROR, "Tpm2SetAlgorithmSet - RecvBufferSize Error - %x\n", RecvBufferSize));
+    DEBUG ((DEBUG_ERROR, "Tpm2SetAlgorithmSet - RecvBufferSize Error - %x\n", RecvBufferSize));
     Status = EFI_DEVICE_ERROR;
     goto Done;
   }
   if (SwapBytes32(RecvBuffer.Header.responseCode) != TPM_RC_SUCCESS) {
-    DEBUG ((EFI_D_ERROR, "Tpm2SetAlgorithmSet - responseCode - %x\n", SwapBytes32(RecvBuffer.Header.responseCode)));
+    DEBUG ((DEBUG_ERROR, "Tpm2SetAlgorithmSet - responseCode - %x\n", SwapBytes32(RecvBuffer.Header.responseCode)));
     Status = EFI_DEVICE_ERROR;
     goto Done;
   }

--- a/SecurityPkg/Library/Tpm2CommandLib/Tpm2NVStorage.c
+++ b/SecurityPkg/Library/Tpm2CommandLib/Tpm2NVStorage.c
@@ -200,12 +200,12 @@ Tpm2NvReadPublic (
   }
 
   if (RecvBufferSize < sizeof (TPM2_RESPONSE_HEADER)) {
-    DEBUG ((EFI_D_ERROR, "Tpm2NvReadPublic - RecvBufferSize Error - %x\n", RecvBufferSize));
+    DEBUG ((DEBUG_ERROR, "Tpm2NvReadPublic - RecvBufferSize Error - %x\n", RecvBufferSize));
     return EFI_DEVICE_ERROR;
   }
   ResponseCode = SwapBytes32(RecvBuffer.Header.responseCode);
   if (ResponseCode != TPM_RC_SUCCESS) {
-    DEBUG ((EFI_D_ERROR, "Tpm2NvReadPublic - responseCode - %x\n", SwapBytes32(RecvBuffer.Header.responseCode)));
+    DEBUG ((DEBUG_ERROR, "Tpm2NvReadPublic - responseCode - %x\n", SwapBytes32(RecvBuffer.Header.responseCode)));
   }
   switch (ResponseCode) {
   case TPM_RC_SUCCESS:
@@ -220,7 +220,7 @@ Tpm2NvReadPublic (
   }
 
   if (RecvBufferSize <= sizeof (TPM2_RESPONSE_HEADER) + sizeof (UINT16) + sizeof(UINT16)) {
-    DEBUG ((EFI_D_ERROR, "Tpm2NvReadPublic - RecvBufferSize Error - %x\n", RecvBufferSize));
+    DEBUG ((DEBUG_ERROR, "Tpm2NvReadPublic - RecvBufferSize Error - %x\n", RecvBufferSize));
     return EFI_NOT_FOUND;
   }
 
@@ -240,7 +240,7 @@ Tpm2NvReadPublic (
   }
 
   if (RecvBufferSize != sizeof(TPM2_RESPONSE_HEADER) + sizeof(UINT16) + NvPublicSize + sizeof(UINT16) + NvNameSize) {
-    DEBUG ((EFI_D_ERROR, "Tpm2NvReadPublic - RecvBufferSize Error - NvPublicSize %x\n", RecvBufferSize));
+    DEBUG ((DEBUG_ERROR, "Tpm2NvReadPublic - RecvBufferSize Error - NvPublicSize %x\n", RecvBufferSize));
     return EFI_NOT_FOUND;
   }
 
@@ -354,14 +354,14 @@ Tpm2NvDefineSpace (
   }
 
   if (RecvBufferSize < sizeof (TPM2_RESPONSE_HEADER)) {
-    DEBUG ((EFI_D_ERROR, "Tpm2NvDefineSpace - RecvBufferSize Error - %x\n", RecvBufferSize));
+    DEBUG ((DEBUG_ERROR, "Tpm2NvDefineSpace - RecvBufferSize Error - %x\n", RecvBufferSize));
     Status = EFI_DEVICE_ERROR;
     goto Done;
   }
 
   ResponseCode = SwapBytes32(RecvBuffer.Header.responseCode);
   if (ResponseCode != TPM_RC_SUCCESS) {
-    DEBUG ((EFI_D_ERROR, "Tpm2NvDefineSpace - responseCode - %x\n", SwapBytes32(RecvBuffer.Header.responseCode)));
+    DEBUG ((DEBUG_ERROR, "Tpm2NvDefineSpace - responseCode - %x\n", SwapBytes32(RecvBuffer.Header.responseCode)));
   }
   switch (ResponseCode) {
   case TPM_RC_SUCCESS:
@@ -462,14 +462,14 @@ Tpm2NvUndefineSpace (
   }
 
   if (RecvBufferSize < sizeof (TPM2_RESPONSE_HEADER)) {
-    DEBUG ((EFI_D_ERROR, "Tpm2NvUndefineSpace - RecvBufferSize Error - %x\n", RecvBufferSize));
+    DEBUG ((DEBUG_ERROR, "Tpm2NvUndefineSpace - RecvBufferSize Error - %x\n", RecvBufferSize));
     Status = EFI_DEVICE_ERROR;
     goto Done;
   }
 
   ResponseCode = SwapBytes32(RecvBuffer.Header.responseCode);
   if (ResponseCode != TPM_RC_SUCCESS) {
-    DEBUG ((EFI_D_ERROR, "Tpm2NvUndefineSpace - responseCode - %x\n", SwapBytes32(RecvBuffer.Header.responseCode)));
+    DEBUG ((DEBUG_ERROR, "Tpm2NvUndefineSpace - responseCode - %x\n", SwapBytes32(RecvBuffer.Header.responseCode)));
   }
   switch (ResponseCode) {
   case TPM_RC_SUCCESS:
@@ -577,13 +577,13 @@ Tpm2NvRead (
   }
 
   if (RecvBufferSize < sizeof (TPM2_RESPONSE_HEADER)) {
-    DEBUG ((EFI_D_ERROR, "Tpm2NvRead - RecvBufferSize Error - %x\n", RecvBufferSize));
+    DEBUG ((DEBUG_ERROR, "Tpm2NvRead - RecvBufferSize Error - %x\n", RecvBufferSize));
     Status = EFI_DEVICE_ERROR;
     goto Done;
   }
   ResponseCode = SwapBytes32(RecvBuffer.Header.responseCode);
   if (ResponseCode != TPM_RC_SUCCESS) {
-    DEBUG ((EFI_D_ERROR, "Tpm2NvRead - responseCode - %x\n", ResponseCode));
+    DEBUG ((DEBUG_ERROR, "Tpm2NvRead - responseCode - %x\n", ResponseCode));
   }
   switch (ResponseCode) {
   case TPM_RC_SUCCESS:
@@ -723,13 +723,13 @@ Tpm2NvWrite (
   }
 
   if (RecvBufferSize < sizeof (TPM2_RESPONSE_HEADER)) {
-    DEBUG ((EFI_D_ERROR, "Tpm2NvWrite - RecvBufferSize Error - %x\n", RecvBufferSize));
+    DEBUG ((DEBUG_ERROR, "Tpm2NvWrite - RecvBufferSize Error - %x\n", RecvBufferSize));
     Status = EFI_DEVICE_ERROR;
     goto Done;
   }
   ResponseCode = SwapBytes32(RecvBuffer.Header.responseCode);
   if (ResponseCode != TPM_RC_SUCCESS) {
-    DEBUG ((EFI_D_ERROR, "Tpm2NvWrite - responseCode - %x\n", ResponseCode));
+    DEBUG ((DEBUG_ERROR, "Tpm2NvWrite - responseCode - %x\n", ResponseCode));
   }
   switch (ResponseCode) {
   case TPM_RC_SUCCESS:
@@ -843,14 +843,14 @@ Tpm2NvReadLock (
   }
 
   if (RecvBufferSize < sizeof (TPM2_RESPONSE_HEADER)) {
-    DEBUG ((EFI_D_ERROR, "Tpm2NvReadLock - RecvBufferSize Error - %x\n", RecvBufferSize));
+    DEBUG ((DEBUG_ERROR, "Tpm2NvReadLock - RecvBufferSize Error - %x\n", RecvBufferSize));
     Status = EFI_DEVICE_ERROR;
     goto Done;
   }
 
   ResponseCode = SwapBytes32(RecvBuffer.Header.responseCode);
   if (ResponseCode != TPM_RC_SUCCESS) {
-    DEBUG ((EFI_D_ERROR, "Tpm2NvReadLock - responseCode - %x\n", SwapBytes32(RecvBuffer.Header.responseCode)));
+    DEBUG ((DEBUG_ERROR, "Tpm2NvReadLock - responseCode - %x\n", SwapBytes32(RecvBuffer.Header.responseCode)));
   }
   switch (ResponseCode) {
   case TPM_RC_SUCCESS:
@@ -930,14 +930,14 @@ Tpm2NvWriteLock (
   }
 
   if (RecvBufferSize < sizeof (TPM2_RESPONSE_HEADER)) {
-    DEBUG ((EFI_D_ERROR, "Tpm2NvWriteLock - RecvBufferSize Error - %x\n", RecvBufferSize));
+    DEBUG ((DEBUG_ERROR, "Tpm2NvWriteLock - RecvBufferSize Error - %x\n", RecvBufferSize));
     Status = EFI_DEVICE_ERROR;
     goto Done;
   }
 
   ResponseCode = SwapBytes32(RecvBuffer.Header.responseCode);
   if (ResponseCode != TPM_RC_SUCCESS) {
-    DEBUG ((EFI_D_ERROR, "Tpm2NvWriteLock - responseCode - %x\n", SwapBytes32(RecvBuffer.Header.responseCode)));
+    DEBUG ((DEBUG_ERROR, "Tpm2NvWriteLock - responseCode - %x\n", SwapBytes32(RecvBuffer.Header.responseCode)));
   }
   switch (ResponseCode) {
   case TPM_RC_SUCCESS:
@@ -1014,14 +1014,14 @@ Tpm2NvGlobalWriteLock (
   }
 
   if (RecvBufferSize < sizeof (TPM2_RESPONSE_HEADER)) {
-    DEBUG ((EFI_D_ERROR, "Tpm2NvGlobalWriteLock - RecvBufferSize Error - %x\n", RecvBufferSize));
+    DEBUG ((DEBUG_ERROR, "Tpm2NvGlobalWriteLock - RecvBufferSize Error - %x\n", RecvBufferSize));
     Status = EFI_DEVICE_ERROR;
     goto Done;
   }
 
   ResponseCode = SwapBytes32(RecvBuffer.Header.responseCode);
   if (ResponseCode != TPM_RC_SUCCESS) {
-    DEBUG ((EFI_D_ERROR, "Tpm2NvGlobalWriteLock - responseCode - %x\n", SwapBytes32(RecvBuffer.Header.responseCode)));
+    DEBUG ((DEBUG_ERROR, "Tpm2NvGlobalWriteLock - responseCode - %x\n", SwapBytes32(RecvBuffer.Header.responseCode)));
   }
   switch (ResponseCode) {
   case TPM_RC_SUCCESS:

--- a/SecurityPkg/Library/Tpm2CommandLib/Tpm2Sequences.c
+++ b/SecurityPkg/Library/Tpm2CommandLib/Tpm2Sequences.c
@@ -134,7 +134,7 @@ Tpm2HashSequenceStart (
   }
 
   if (ResultBufSize > sizeof(Res)) {
-    DEBUG ((EFI_D_ERROR, "HashSequenceStart: Failed ExecuteCommand: Buffer Too Small\r\n"));
+    DEBUG ((DEBUG_ERROR, "HashSequenceStart: Failed ExecuteCommand: Buffer Too Small\r\n"));
     return EFI_BUFFER_TOO_SMALL;
   }
 
@@ -143,7 +143,7 @@ Tpm2HashSequenceStart (
   //
   RespSize = SwapBytes32(Res.Header.paramSize);
   if (RespSize > sizeof(Res)) {
-    DEBUG ((EFI_D_ERROR, "HashSequenceStart: Response size too large! %d\r\n", RespSize));
+    DEBUG ((DEBUG_ERROR, "HashSequenceStart: Response size too large! %d\r\n", RespSize));
     return EFI_BUFFER_TOO_SMALL;
   }
 
@@ -151,7 +151,7 @@ Tpm2HashSequenceStart (
   // Fail if command failed
   //
   if (SwapBytes32(Res.Header.responseCode) != TPM_RC_SUCCESS) {
-    DEBUG ((EFI_D_ERROR, "HashSequenceStart: Response Code error! 0x%08x\r\n", SwapBytes32(Res.Header.responseCode)));
+    DEBUG ((DEBUG_ERROR, "HashSequenceStart: Response Code error! 0x%08x\r\n", SwapBytes32(Res.Header.responseCode)));
     return EFI_DEVICE_ERROR;
   }
 
@@ -231,7 +231,7 @@ Tpm2SequenceUpdate (
   }
 
   if (ResultBufSize > sizeof(Res)) {
-    DEBUG ((EFI_D_ERROR, "SequenceUpdate: Failed ExecuteCommand: Buffer Too Small\r\n"));
+    DEBUG ((DEBUG_ERROR, "SequenceUpdate: Failed ExecuteCommand: Buffer Too Small\r\n"));
     return EFI_BUFFER_TOO_SMALL;
   }
 
@@ -240,7 +240,7 @@ Tpm2SequenceUpdate (
   //
   RespSize = SwapBytes32(Res.Header.paramSize);
   if (RespSize > sizeof(Res)) {
-    DEBUG ((EFI_D_ERROR, "SequenceUpdate: Response size too large! %d\r\n", RespSize));
+    DEBUG ((DEBUG_ERROR, "SequenceUpdate: Response size too large! %d\r\n", RespSize));
     return EFI_BUFFER_TOO_SMALL;
   }
 
@@ -248,7 +248,7 @@ Tpm2SequenceUpdate (
   // Fail if command failed
   //
   if (SwapBytes32(Res.Header.responseCode) != TPM_RC_SUCCESS) {
-    DEBUG ((EFI_D_ERROR, "SequenceUpdate: Response Code error! 0x%08x\r\n", SwapBytes32(Res.Header.responseCode)));
+    DEBUG ((DEBUG_ERROR, "SequenceUpdate: Response Code error! 0x%08x\r\n", SwapBytes32(Res.Header.responseCode)));
     return EFI_DEVICE_ERROR;
   }
 
@@ -340,7 +340,7 @@ Tpm2EventSequenceComplete (
   }
 
   if (ResultBufSize > sizeof(Res)) {
-    DEBUG ((EFI_D_ERROR, "EventSequenceComplete: Failed ExecuteCommand: Buffer Too Small\r\n"));
+    DEBUG ((DEBUG_ERROR, "EventSequenceComplete: Failed ExecuteCommand: Buffer Too Small\r\n"));
     return EFI_BUFFER_TOO_SMALL;
   }
 
@@ -349,7 +349,7 @@ Tpm2EventSequenceComplete (
   //
   RespSize = SwapBytes32(Res.Header.paramSize);
   if (RespSize > sizeof(Res)) {
-    DEBUG ((EFI_D_ERROR, "EventSequenceComplete: Response size too large! %d\r\n", RespSize));
+    DEBUG ((DEBUG_ERROR, "EventSequenceComplete: Response size too large! %d\r\n", RespSize));
     return EFI_BUFFER_TOO_SMALL;
   }
 
@@ -357,7 +357,7 @@ Tpm2EventSequenceComplete (
   // Fail if command failed
   //
   if (SwapBytes32(Res.Header.responseCode) != TPM_RC_SUCCESS) {
-    DEBUG ((EFI_D_ERROR, "EventSequenceComplete: Response Code error! 0x%08x\r\n", SwapBytes32(Res.Header.responseCode)));
+    DEBUG ((DEBUG_ERROR, "EventSequenceComplete: Response Code error! 0x%08x\r\n", SwapBytes32(Res.Header.responseCode)));
     return EFI_DEVICE_ERROR;
   }
 
@@ -382,7 +382,7 @@ Tpm2EventSequenceComplete (
 
     DigestSize = GetHashSizeFromAlgo (Results->digests[Index].hashAlg);
     if (DigestSize == 0) {
-      DEBUG ((EFI_D_ERROR, "EventSequenceComplete: Unknown hash algorithm %d\r\n", Results->digests[Index].hashAlg));
+      DEBUG ((DEBUG_ERROR, "EventSequenceComplete: Unknown hash algorithm %d\r\n", Results->digests[Index].hashAlg));
       return EFI_DEVICE_ERROR;
     }
     CopyMem(
@@ -466,7 +466,7 @@ Tpm2SequenceComplete (
   }
 
   if (ResultBufSize > sizeof(Res)) {
-    DEBUG ((EFI_D_ERROR, "SequenceComplete: Failed ExecuteCommand: Buffer Too Small\r\n"));
+    DEBUG ((DEBUG_ERROR, "SequenceComplete: Failed ExecuteCommand: Buffer Too Small\r\n"));
     return EFI_BUFFER_TOO_SMALL;
   }
 
@@ -475,7 +475,7 @@ Tpm2SequenceComplete (
   //
   RespSize = SwapBytes32(Res.Header.paramSize);
   if (RespSize > sizeof(Res)) {
-    DEBUG ((EFI_D_ERROR, "SequenceComplete: Response size too large! %d\r\n", RespSize));
+    DEBUG ((DEBUG_ERROR, "SequenceComplete: Response size too large! %d\r\n", RespSize));
     return EFI_BUFFER_TOO_SMALL;
   }
 
@@ -483,7 +483,7 @@ Tpm2SequenceComplete (
   // Fail if command failed
   //
   if (SwapBytes32(Res.Header.responseCode) != TPM_RC_SUCCESS) {
-    DEBUG ((EFI_D_ERROR, "SequenceComplete: Response Code error! 0x%08x\r\n", SwapBytes32(Res.Header.responseCode)));
+    DEBUG ((DEBUG_ERROR, "SequenceComplete: Response Code error! 0x%08x\r\n", SwapBytes32(Res.Header.responseCode)));
     return EFI_DEVICE_ERROR;
   }
 

--- a/SecurityPkg/Library/Tpm2CommandLib/Tpm2Session.c
+++ b/SecurityPkg/Library/Tpm2CommandLib/Tpm2Session.c
@@ -124,7 +124,7 @@ Tpm2StartAuthSession (
     break;
   default:
     ASSERT (FALSE);
-    DEBUG ((EFI_D_ERROR, "Tpm2StartAuthSession - Symmetric->algorithm - %x\n", Symmetric->algorithm));
+    DEBUG ((DEBUG_ERROR, "Tpm2StartAuthSession - Symmetric->algorithm - %x\n", Symmetric->algorithm));
     return EFI_UNSUPPORTED;
   }
 
@@ -144,11 +144,11 @@ Tpm2StartAuthSession (
   }
 
   if (RecvBufferSize < sizeof (TPM2_RESPONSE_HEADER)) {
-    DEBUG ((EFI_D_ERROR, "Tpm2StartAuthSession - RecvBufferSize Error - %x\n", RecvBufferSize));
+    DEBUG ((DEBUG_ERROR, "Tpm2StartAuthSession - RecvBufferSize Error - %x\n", RecvBufferSize));
     return EFI_DEVICE_ERROR;
   }
   if (SwapBytes32(RecvBuffer.Header.responseCode) != TPM_RC_SUCCESS) {
-    DEBUG ((EFI_D_ERROR, "Tpm2StartAuthSession - responseCode - %x\n", SwapBytes32(RecvBuffer.Header.responseCode)));
+    DEBUG ((DEBUG_ERROR, "Tpm2StartAuthSession - responseCode - %x\n", SwapBytes32(RecvBuffer.Header.responseCode)));
     return EFI_DEVICE_ERROR;
   }
 

--- a/SecurityPkg/Library/Tpm2CommandLib/Tpm2Startup.c
+++ b/SecurityPkg/Library/Tpm2CommandLib/Tpm2Startup.c
@@ -77,7 +77,7 @@ Tpm2Startup (
     DEBUG ((DEBUG_INFO, "TPM2Startup: TPM_RC_INITIALIZE\n"));
     return EFI_SUCCESS;
   default:
-    DEBUG ((EFI_D_ERROR, "Tpm2Startup: Response Code error! 0x%08x\r\n", ResponseCode));
+    DEBUG ((DEBUG_ERROR, "Tpm2Startup: Response Code error! 0x%08x\r\n", ResponseCode));
     return EFI_DEVICE_ERROR;
   }
 }
@@ -113,7 +113,7 @@ Tpm2Shutdown (
   }
 
   if (SwapBytes32(Res.Header.responseCode) != TPM_RC_SUCCESS) {
-    DEBUG ((EFI_D_ERROR, "Tpm2Shutdown: Response Code error! 0x%08x\r\n", SwapBytes32(Res.Header.responseCode)));
+    DEBUG ((DEBUG_ERROR, "Tpm2Shutdown: Response Code error! 0x%08x\r\n", SwapBytes32(Res.Header.responseCode)));
     return EFI_DEVICE_ERROR;
   }
 

--- a/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2Ptp.c
+++ b/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2Ptp.c
@@ -154,22 +154,22 @@ PtpCrbTpmCommand (
   DEBUG_CODE (
     UINTN  DebugSize;
 
-    DEBUG ((EFI_D_VERBOSE, "PtpCrbTpmCommand Send - "));
+    DEBUG ((DEBUG_VERBOSE, "PtpCrbTpmCommand Send - "));
     if (SizeIn > 0x100) {
       DebugSize = 0x40;
     } else {
       DebugSize = SizeIn;
     }
     for (Index = 0; Index < DebugSize; Index++) {
-      DEBUG ((EFI_D_VERBOSE, "%02x ", BufferIn[Index]));
+      DEBUG ((DEBUG_VERBOSE, "%02x ", BufferIn[Index]));
     }
     if (DebugSize != SizeIn) {
-      DEBUG ((EFI_D_VERBOSE, "...... "));
+      DEBUG ((DEBUG_VERBOSE, "...... "));
       for (Index = SizeIn - 0x20; Index < SizeIn; Index++) {
-        DEBUG ((EFI_D_VERBOSE, "%02x ", BufferIn[Index]));
+        DEBUG ((DEBUG_VERBOSE, "%02x ", BufferIn[Index]));
       }
     }
-    DEBUG ((EFI_D_VERBOSE, "\n"));
+    DEBUG ((DEBUG_VERBOSE, "\n"));
   );
   TpmOutSize         = 0;
 
@@ -286,11 +286,11 @@ PtpCrbTpmCommand (
     BufferOut[Index] = MmioRead8 ((UINTN)&CrbReg->CrbDataBuffer[Index]);
   }
   DEBUG_CODE (
-    DEBUG ((EFI_D_VERBOSE, "PtpCrbTpmCommand ReceiveHeader - "));
+    DEBUG ((DEBUG_VERBOSE, "PtpCrbTpmCommand ReceiveHeader - "));
     for (Index = 0; Index < sizeof (TPM2_RESPONSE_HEADER); Index++) {
-      DEBUG ((EFI_D_VERBOSE, "%02x ", BufferOut[Index]));
+      DEBUG ((DEBUG_VERBOSE, "%02x ", BufferOut[Index]));
     }
-    DEBUG ((EFI_D_VERBOSE, "\n"));
+    DEBUG ((DEBUG_VERBOSE, "\n"));
   );
   //
   // Check the response data header (tag, parasize and returncode)
@@ -298,7 +298,7 @@ PtpCrbTpmCommand (
   CopyMem (&Data16, BufferOut, sizeof (UINT16));
   // TPM2 should not use this RSP_COMMAND
   if (SwapBytes16 (Data16) == TPM_ST_RSP_COMMAND) {
-    DEBUG ((EFI_D_ERROR, "TPM2: TPM_ST_RSP error - %x\n", TPM_ST_RSP_COMMAND));
+    DEBUG ((DEBUG_ERROR, "TPM2: TPM_ST_RSP error - %x\n", TPM_ST_RSP_COMMAND));
     Status = EFI_UNSUPPORTED;
     goto GoIdle_Exit;
   }
@@ -321,11 +321,11 @@ PtpCrbTpmCommand (
   }
 
   DEBUG_CODE (
-    DEBUG ((EFI_D_VERBOSE, "PtpCrbTpmCommand Receive - "));
+    DEBUG ((DEBUG_VERBOSE, "PtpCrbTpmCommand Receive - "));
     for (Index = 0; Index < TpmOutSize; Index++) {
-      DEBUG ((EFI_D_VERBOSE, "%02x ", BufferOut[Index]));
+      DEBUG ((DEBUG_VERBOSE, "%02x ", BufferOut[Index]));
     }
-    DEBUG ((EFI_D_VERBOSE, "\n"));
+    DEBUG ((DEBUG_VERBOSE, "\n"));
   );
 
 GoReady_Exit:
@@ -494,36 +494,36 @@ DumpPtpInfo (
   //
   // Dump InterfaceId Register for PTP
   //
-  DEBUG ((EFI_D_INFO, "InterfaceId - 0x%08x\n", InterfaceId.Uint32));
-  DEBUG ((EFI_D_INFO, "  InterfaceType    - 0x%02x\n", InterfaceId.Bits.InterfaceType));
+  DEBUG ((DEBUG_INFO, "InterfaceId - 0x%08x\n", InterfaceId.Uint32));
+  DEBUG ((DEBUG_INFO, "  InterfaceType    - 0x%02x\n", InterfaceId.Bits.InterfaceType));
   if (InterfaceId.Bits.InterfaceType != PTP_INTERFACE_IDENTIFIER_INTERFACE_TYPE_TIS) {
-    DEBUG ((EFI_D_INFO, "  InterfaceVersion - 0x%02x\n", InterfaceId.Bits.InterfaceVersion));
-    DEBUG ((EFI_D_INFO, "  CapFIFO          - 0x%x\n", InterfaceId.Bits.CapFIFO));
-    DEBUG ((EFI_D_INFO, "  CapCRB           - 0x%x\n", InterfaceId.Bits.CapCRB));
+    DEBUG ((DEBUG_INFO, "  InterfaceVersion - 0x%02x\n", InterfaceId.Bits.InterfaceVersion));
+    DEBUG ((DEBUG_INFO, "  CapFIFO          - 0x%x\n", InterfaceId.Bits.CapFIFO));
+    DEBUG ((DEBUG_INFO, "  CapCRB           - 0x%x\n", InterfaceId.Bits.CapCRB));
   }
 
   //
   // Dump Capability Register for TIS and FIFO
   //
-  DEBUG ((EFI_D_INFO, "InterfaceCapability - 0x%08x\n", InterfaceCapability.Uint32));
+  DEBUG ((DEBUG_INFO, "InterfaceCapability - 0x%08x\n", InterfaceCapability.Uint32));
   if ((InterfaceId.Bits.InterfaceType == PTP_INTERFACE_IDENTIFIER_INTERFACE_TYPE_TIS) ||
       (InterfaceId.Bits.InterfaceType == PTP_INTERFACE_IDENTIFIER_INTERFACE_TYPE_FIFO)) {
-    DEBUG ((EFI_D_INFO, "  InterfaceVersion - 0x%x\n", InterfaceCapability.Bits.InterfaceVersion));
+    DEBUG ((DEBUG_INFO, "  InterfaceVersion - 0x%x\n", InterfaceCapability.Bits.InterfaceVersion));
   }
 
   //
   // Dump StatusEx Register for PTP FIFO
   //
-  DEBUG ((EFI_D_INFO, "StatusEx - 0x%02x\n", StatusEx));
+  DEBUG ((DEBUG_INFO, "StatusEx - 0x%02x\n", StatusEx));
   if (InterfaceCapability.Bits.InterfaceVersion == INTERFACE_CAPABILITY_INTERFACE_VERSION_PTP) {
-    DEBUG ((EFI_D_INFO, "  TpmFamily - 0x%x\n", (StatusEx & PTP_FIFO_STS_EX_TPM_FAMILY) >> PTP_FIFO_STS_EX_TPM_FAMILY_OFFSET));
+    DEBUG ((DEBUG_INFO, "  TpmFamily - 0x%x\n", (StatusEx & PTP_FIFO_STS_EX_TPM_FAMILY) >> PTP_FIFO_STS_EX_TPM_FAMILY_OFFSET));
   }
 
   Vid = 0xFFFF;
   Did = 0xFFFF;
   Rid = 0xFF;
   PtpInterface = GetCachedPtpInterface ();
-  DEBUG ((EFI_D_INFO, "PtpInterface - %x\n", PtpInterface));
+  DEBUG ((DEBUG_INFO, "PtpInterface - %x\n", PtpInterface));
   switch (PtpInterface) {
   case Tpm2PtpInterfaceCrb:
     Vid = MmioRead16 ((UINTN)&((PTP_CRB_REGISTERS *)Register)->Vid);
@@ -539,9 +539,9 @@ DumpPtpInfo (
   default:
     break;
   }
-  DEBUG ((EFI_D_INFO, "VID - 0x%04x\n", Vid));
-  DEBUG ((EFI_D_INFO, "DID - 0x%04x\n", Did));
-  DEBUG ((EFI_D_INFO, "RID - 0x%02x\n", Rid));
+  DEBUG ((DEBUG_INFO, "VID - 0x%04x\n", Vid));
+  DEBUG ((DEBUG_INFO, "DID - 0x%04x\n", Did));
+  DEBUG ((DEBUG_INFO, "RID - 0x%02x\n", Rid));
 }
 
 /**

--- a/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2Tis.c
+++ b/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2Tis.c
@@ -221,22 +221,22 @@ Tpm2TisTpmCommand (
   DEBUG_CODE (
     UINTN  DebugSize;
 
-    DEBUG ((EFI_D_VERBOSE, "Tpm2TisTpmCommand Send - "));
+    DEBUG ((DEBUG_VERBOSE, "Tpm2TisTpmCommand Send - "));
     if (SizeIn > 0x100) {
       DebugSize = 0x40;
     } else {
       DebugSize = SizeIn;
     }
     for (Index = 0; Index < DebugSize; Index++) {
-      DEBUG ((EFI_D_VERBOSE, "%02x ", BufferIn[Index]));
+      DEBUG ((DEBUG_VERBOSE, "%02x ", BufferIn[Index]));
     }
     if (DebugSize != SizeIn) {
-      DEBUG ((EFI_D_VERBOSE, "...... "));
+      DEBUG ((DEBUG_VERBOSE, "...... "));
       for (Index = SizeIn - 0x20; Index < SizeIn; Index++) {
-        DEBUG ((EFI_D_VERBOSE, "%02x ", BufferIn[Index]));
+        DEBUG ((DEBUG_VERBOSE, "%02x ", BufferIn[Index]));
       }
     }
-    DEBUG ((EFI_D_VERBOSE, "\n"));
+    DEBUG ((DEBUG_VERBOSE, "\n"));
   );
   TpmOutSize = 0;
 
@@ -333,11 +333,11 @@ Tpm2TisTpmCommand (
     }
   }
   DEBUG_CODE (
-    DEBUG ((EFI_D_VERBOSE, "Tpm2TisTpmCommand ReceiveHeader - "));
+    DEBUG ((DEBUG_VERBOSE, "Tpm2TisTpmCommand ReceiveHeader - "));
     for (Index = 0; Index < sizeof (TPM2_RESPONSE_HEADER); Index++) {
-      DEBUG ((EFI_D_VERBOSE, "%02x ", BufferOut[Index]));
+      DEBUG ((DEBUG_VERBOSE, "%02x ", BufferOut[Index]));
     }
-    DEBUG ((EFI_D_VERBOSE, "\n"));
+    DEBUG ((DEBUG_VERBOSE, "\n"));
   );
   //
   // Check the response data header (tag,parasize and returncode )
@@ -345,7 +345,7 @@ Tpm2TisTpmCommand (
   CopyMem (&Data16, BufferOut, sizeof (UINT16));
   // TPM2 should not use this RSP_COMMAND
   if (SwapBytes16 (Data16) == TPM_ST_RSP_COMMAND) {
-    DEBUG ((EFI_D_ERROR, "TPM2: TPM_ST_RSP error - %x\n", TPM_ST_RSP_COMMAND));
+    DEBUG ((DEBUG_ERROR, "TPM2: TPM_ST_RSP error - %x\n", TPM_ST_RSP_COMMAND));
     Status = EFI_UNSUPPORTED;
     goto Exit;
   }
@@ -377,11 +377,11 @@ Tpm2TisTpmCommand (
   }
 Exit:
   DEBUG_CODE (
-    DEBUG ((EFI_D_VERBOSE, "Tpm2TisTpmCommand Receive - "));
+    DEBUG ((DEBUG_VERBOSE, "Tpm2TisTpmCommand Receive - "));
     for (Index = 0; Index < TpmOutSize; Index++) {
-      DEBUG ((EFI_D_VERBOSE, "%02x ", BufferOut[Index]));
+      DEBUG ((DEBUG_VERBOSE, "%02x ", BufferOut[Index]));
     }
-    DEBUG ((EFI_D_VERBOSE, "\n"));
+    DEBUG ((DEBUG_VERBOSE, "\n"));
   );
   MmioWrite8((UINTN)&TisReg->Status, TIS_PC_STS_READY);
   return Status;

--- a/SecurityPkg/Library/Tpm2DeviceLibRouter/Tpm2DeviceLibRouterPei.c
+++ b/SecurityPkg/Library/Tpm2DeviceLibRouter/Tpm2DeviceLibRouterPei.c
@@ -123,7 +123,7 @@ Tpm2RegisterTpm2DeviceLib (
     //
     // In PEI phase, there will be shadow driver dispatched again.
     //
-    DEBUG ((EFI_D_INFO, "Tpm2RegisterTpm2DeviceLib - Override\n"));
+    DEBUG ((DEBUG_INFO, "Tpm2RegisterTpm2DeviceLib - Override\n"));
     CopyMem (Tpm2DeviceInterface, Tpm2Device, sizeof(*Tpm2Device));
     return EFI_SUCCESS;
   } else {

--- a/SecurityPkg/Library/Tpm2DeviceLibTcg2/Tpm2DeviceLibTcg2.c
+++ b/SecurityPkg/Library/Tpm2DeviceLibTcg2/Tpm2DeviceLibTcg2.c
@@ -46,7 +46,7 @@ Tpm2SubmitCommand (
       //
       // Tcg2 protocol is not installed. So, TPM2 is not present.
       //
-      DEBUG ((EFI_D_ERROR, "Tpm2SubmitCommand - Tcg2 - %r\n", Status));
+      DEBUG ((DEBUG_ERROR, "Tpm2SubmitCommand - Tcg2 - %r\n", Status));
       return EFI_NOT_FOUND;
     }
   }
@@ -90,7 +90,7 @@ Tpm2RequestUseTpm (
       //
       // Tcg2 protocol is not installed. So, TPM2 is not present.
       //
-      DEBUG ((EFI_D_ERROR, "Tpm2RequestUseTpm - Tcg2 - %r\n", Status));
+      DEBUG ((DEBUG_ERROR, "Tpm2RequestUseTpm - Tcg2 - %r\n", Status));
       return EFI_NOT_FOUND;
     }
   }

--- a/SecurityPkg/Tcg/MemoryOverwriteControl/TcgMor.c
+++ b/SecurityPkg/Tcg/MemoryOverwriteControl/TcgMor.c
@@ -40,7 +40,7 @@ OnReadyToBoot (
   //
   // Clear MOR_CLEAR_MEMORY_BIT
   //
-  DEBUG ((EFI_D_INFO, "TcgMor: Clear MorClearMemory bit\n"));
+  DEBUG ((DEBUG_INFO, "TcgMor: Clear MorClearMemory bit\n"));
   mMorControl &= 0xFE;
 
   DataSize = sizeof (mMorControl);
@@ -168,7 +168,7 @@ InitiateTPerReset (
       // Found a  TCG device.
       //
       TcgFlag = TRUE;
-      DEBUG ((EFI_D_INFO, "This device is a TCG protocol device\n"));
+      DEBUG ((DEBUG_INFO, "This device is a TCG protocol device\n"));
       break;
     }
 
@@ -177,13 +177,13 @@ InitiateTPerReset (
       // Found a IEEE 1667 device.
       //
       IeeeFlag = TRUE;
-      DEBUG ((EFI_D_INFO, "This device is a IEEE 1667 protocol device\n"));
+      DEBUG ((DEBUG_INFO, "This device is a IEEE 1667 protocol device\n"));
       break;
     }
   }
 
   if (!TcgFlag && !IeeeFlag) {
-    DEBUG ((EFI_D_INFO, "Neither a TCG nor IEEE 1667 protocol device is found\n"));
+    DEBUG ((DEBUG_INFO, "Neither a TCG nor IEEE 1667 protocol device is found\n"));
     goto Exit;
   }
 
@@ -203,9 +203,9 @@ InitiateTPerReset (
                     );
 
     if (!EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_INFO, "Send TPer Reset Command Successfully !\n"));
+      DEBUG ((DEBUG_INFO, "Send TPer Reset Command Successfully !\n"));
     } else {
-      DEBUG ((EFI_D_INFO, "Send TPer Reset Command Fail !\n"));
+      DEBUG ((DEBUG_INFO, "Send TPer Reset Command Fail !\n"));
     }
   }
 
@@ -213,7 +213,7 @@ InitiateTPerReset (
     //
     // TBD : Perform a TPer Reset via IEEE 1667 Protocol
     //
-    DEBUG ((EFI_D_INFO, "IEEE 1667 Protocol didn't support yet!\n"));
+    DEBUG ((DEBUG_INFO, "IEEE 1667 Protocol didn't support yet!\n"));
   }
 
 Exit:
@@ -336,7 +336,7 @@ MorDriverEntryPoint (
                     DataSize,
                     &mMorControl
                     );
-    DEBUG ((EFI_D_INFO, "TcgMor: Create MOR variable! Status = %r\n", Status));
+    DEBUG ((DEBUG_INFO, "TcgMor: Create MOR variable! Status = %r\n", Status));
   } else {
     //
     // Create a Ready To Boot Event and Clear the MorControl bit in the call back function.
@@ -355,7 +355,7 @@ MorDriverEntryPoint (
     //
     // Register EFI_END_OF_DXE_EVENT_GROUP_GUID event.
     //
-    DEBUG ((EFI_D_INFO, "TcgMor: Create EndofDxe Event for Mor TPer Reset!\n"));
+    DEBUG ((DEBUG_INFO, "TcgMor: Create EndofDxe Event for Mor TPer Reset!\n"));
     Status = gBS->CreateEventEx (
                     EVT_NOTIFY_SIGNAL,
                     TPL_CALLBACK,
@@ -371,5 +371,3 @@ MorDriverEntryPoint (
 
   return Status;
 }
-
-

--- a/SecurityPkg/Tcg/MemoryOverwriteRequestControlLock/TcgMorLockSmm.c
+++ b/SecurityPkg/Tcg/MemoryOverwriteRequestControlLock/TcgMorLockSmm.c
@@ -123,7 +123,7 @@ MorLockDriverEntryPointSmm (
   //
   // This driver link to Smm Variable driver
   //
-  DEBUG ((EFI_D_INFO, "MorLockDriverEntryPointSmm\n"));
+  DEBUG ((DEBUG_INFO, "MorLockDriverEntryPointSmm\n"));
 
   Status = gSmst->SmmLocateProtocol (
                   &gEfiSmmVariableProtocolGuid,
@@ -149,4 +149,3 @@ MorLockDriverEntryPointSmm (
 
   return Status;
 }
-

--- a/SecurityPkg/Tcg/Tcg2Config/Tcg2ConfigDriver.c
+++ b/SecurityPkg/Tcg/Tcg2Config/Tcg2ConfigDriver.c
@@ -355,7 +355,7 @@ Tcg2ConfigDriverEntryPoint (
                   &Tcg2DeviceDetection
                   );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "Tcg2ConfigDriver: Fail to set TCG2_DEVICE_DETECTION_NAME\n"));
+    DEBUG ((DEBUG_ERROR, "Tcg2ConfigDriver: Fail to set TCG2_DEVICE_DETECTION_NAME\n"));
     Status = gRT->SetVariable (
                     TCG2_DEVICE_DETECTION_NAME,
                     &gTcg2ConfigFormSetGuid,
@@ -377,7 +377,7 @@ Tcg2ConfigDriverEntryPoint (
                   &Tcg2Configuration
                   );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "Tcg2ConfigDriver: Fail to set TCG2_STORAGE_NAME\n"));
+    DEBUG ((DEBUG_ERROR, "Tcg2ConfigDriver: Fail to set TCG2_STORAGE_NAME\n"));
   }
 
   //

--- a/SecurityPkg/Tcg/Tcg2Config/Tcg2ConfigImpl.c
+++ b/SecurityPkg/Tcg/Tcg2Config/Tcg2ConfigImpl.c
@@ -960,7 +960,7 @@ InstallTcg2ConfigForm (
                   &Tcg2ConfigInfo
                   );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "Tcg2ConfigDriver: Fail to set TCG2_STORAGE_INFO_NAME\n"));
+    DEBUG ((DEBUG_ERROR, "Tcg2ConfigDriver: Fail to set TCG2_STORAGE_INFO_NAME\n"));
   }
 
   return EFI_SUCCESS;

--- a/SecurityPkg/Tcg/Tcg2Config/Tcg2ConfigPeim.c
+++ b/SecurityPkg/Tcg/Tcg2Config/Tcg2ConfigPeim.c
@@ -104,11 +104,11 @@ Tcg2ConfigPeimEntryPoint (
   //
   // Although we have SetupVariable info, we still need detect TPM device manually.
   //
-  DEBUG ((EFI_D_INFO, "Tcg2Configuration.TpmDevice from Setup: %x\n", Tcg2Configuration.TpmDevice));
+  DEBUG ((DEBUG_INFO, "Tcg2Configuration.TpmDevice from Setup: %x\n", Tcg2Configuration.TpmDevice));
 
   if (PcdGetBool (PcdTpmAutoDetection)) {
     TpmDevice = DetectTpmDevice (Tcg2Configuration.TpmDevice);
-    DEBUG ((EFI_D_INFO, "TpmDevice final: %x\n", TpmDevice));
+    DEBUG ((DEBUG_INFO, "TpmDevice final: %x\n", TpmDevice));
     if (TpmDevice != TPM_DEVICE_NULL) {
       Tcg2Configuration.TpmDevice = TpmDevice;
     }
@@ -129,7 +129,7 @@ Tcg2ConfigPeimEntryPoint (
       Size = sizeof(mTpmInstanceId[Index].TpmInstanceGuid);
       Status = PcdSetPtrS (PcdTpmInstanceGuid, &Size, &mTpmInstanceId[Index].TpmInstanceGuid);
       ASSERT_EFI_ERROR (Status);
-      DEBUG ((EFI_D_INFO, "TpmDevice PCD: %g\n", &mTpmInstanceId[Index].TpmInstanceGuid));
+      DEBUG ((DEBUG_INFO, "TpmDevice PCD: %g\n", &mTpmInstanceId[Index].TpmInstanceGuid));
       break;
     }
   }

--- a/SecurityPkg/Tcg/Tcg2Config/TpmDetection.c
+++ b/SecurityPkg/Tcg/Tcg2Config/TpmDetection.c
@@ -47,7 +47,7 @@ DetectTpmDevice (
   // In S3, we rely on normal boot Detection, because we save to ReadOnly Variable in normal boot.
   //
   if (BootMode == BOOT_ON_S3_RESUME) {
-    DEBUG ((EFI_D_INFO, "DetectTpmDevice: S3 mode\n"));
+    DEBUG ((DEBUG_INFO, "DetectTpmDevice: S3 mode\n"));
 
     Status = PeiServicesLocatePpi (&gEfiPeiReadOnlyVariable2PpiGuid, 0, NULL, (VOID **) &VariablePpi);
     ASSERT_EFI_ERROR (Status);
@@ -65,12 +65,12 @@ DetectTpmDevice (
     if (!EFI_ERROR (Status) &&
         (Tcg2DeviceDetection.TpmDeviceDetected >= TPM_DEVICE_MIN) &&
         (Tcg2DeviceDetection.TpmDeviceDetected <= TPM_DEVICE_MAX)) {
-      DEBUG ((EFI_D_ERROR, "TpmDevice from DeviceDetection: %x\n", Tcg2DeviceDetection.TpmDeviceDetected));
+      DEBUG ((DEBUG_ERROR, "TpmDevice from DeviceDetection: %x\n", Tcg2DeviceDetection.TpmDeviceDetected));
       return Tcg2DeviceDetection.TpmDeviceDetected;
     }
   }
 
-  DEBUG ((EFI_D_INFO, "DetectTpmDevice:\n"));
+  DEBUG ((DEBUG_INFO, "DetectTpmDevice:\n"));
 
   // dTPM available and not disabled by setup
   // We need check if it is TPM1.2 or TPM2.0

--- a/SecurityPkg/Tcg/Tcg2Dxe/Tcg2Dxe.c
+++ b/SecurityPkg/Tcg/Tcg2Dxe/Tcg2Dxe.c
@@ -158,7 +158,7 @@ InternalDumpData (
 {
   UINTN  Index;
   for (Index = 0; Index < Size; Index++) {
-    DEBUG ((EFI_D_INFO, "%02x", (UINTN)Data[Index]));
+    DEBUG ((DEBUG_INFO, "%02x", (UINTN)Data[Index]));
   }
 }
 
@@ -261,15 +261,15 @@ InternalDumpHex (
   Count = Size / COLUME_SIZE;
   Left  = Size % COLUME_SIZE;
   for (Index = 0; Index < Count; Index++) {
-    DEBUG ((EFI_D_INFO, "%04x: ", Index * COLUME_SIZE));
+    DEBUG ((DEBUG_INFO, "%04x: ", Index * COLUME_SIZE));
     InternalDumpData (Data + Index * COLUME_SIZE, COLUME_SIZE);
-    DEBUG ((EFI_D_INFO, "\n"));
+    DEBUG ((DEBUG_INFO, "\n"));
   }
 
   if (Left != 0) {
-    DEBUG ((EFI_D_INFO, "%04x: ", Index * COLUME_SIZE));
+    DEBUG ((DEBUG_INFO, "%04x: ", Index * COLUME_SIZE));
     InternalDumpData (Data + Index * COLUME_SIZE, Left);
-    DEBUG ((EFI_D_INFO, "\n"));
+    DEBUG ((DEBUG_INFO, "\n"));
   }
 }
 
@@ -402,7 +402,7 @@ Tcg2GetCapability (
         ProtocolCapability->StructureVersion.Minor = 0;
         ProtocolCapability->ProtocolVersion.Major = 1;
         ProtocolCapability->ProtocolVersion.Minor = 0;
-        DEBUG ((EFI_D_ERROR, "TreeGetCapability (Compatible) - %r\n", EFI_SUCCESS));
+        DEBUG ((DEBUG_ERROR, "TreeGetCapability (Compatible) - %r\n", EFI_SUCCESS));
         return EFI_SUCCESS;
       }
     }
@@ -427,15 +427,15 @@ DumpEvent (
 {
   UINTN                     Index;
 
-  DEBUG ((EFI_D_INFO, "  Event:\n"));
-  DEBUG ((EFI_D_INFO, "    PCRIndex  - %d\n", EventHdr->PCRIndex));
-  DEBUG ((EFI_D_INFO, "    EventType - 0x%08x\n", EventHdr->EventType));
-  DEBUG ((EFI_D_INFO, "    Digest    - "));
+  DEBUG ((DEBUG_INFO, "  Event:\n"));
+  DEBUG ((DEBUG_INFO, "    PCRIndex  - %d\n", EventHdr->PCRIndex));
+  DEBUG ((DEBUG_INFO, "    EventType - 0x%08x\n", EventHdr->EventType));
+  DEBUG ((DEBUG_INFO, "    Digest    - "));
   for (Index = 0; Index < sizeof(TCG_DIGEST); Index++) {
-    DEBUG ((EFI_D_INFO, "%02x ", EventHdr->Digest.digest[Index]));
+    DEBUG ((DEBUG_INFO, "%02x ", EventHdr->Digest.digest[Index]));
   }
-  DEBUG ((EFI_D_INFO, "\n"));
-  DEBUG ((EFI_D_INFO, "    EventSize - 0x%08x\n", EventHdr->EventSize));
+  DEBUG ((DEBUG_INFO, "\n"));
+  DEBUG ((DEBUG_INFO, "    EventSize - 0x%08x\n", EventHdr->EventSize));
   InternalDumpHex ((UINT8 *)(EventHdr + 1), EventHdr->EventSize);
 }
 
@@ -455,33 +455,33 @@ DumpTcgEfiSpecIdEventStruct (
   UINT8                            *VendorInfo;
   UINT32                           NumberOfAlgorithms;
 
-  DEBUG ((EFI_D_INFO, "  TCG_EfiSpecIDEventStruct:\n"));
-  DEBUG ((EFI_D_INFO, "    signature          - '"));
+  DEBUG ((DEBUG_INFO, "  TCG_EfiSpecIDEventStruct:\n"));
+  DEBUG ((DEBUG_INFO, "    signature          - '"));
   for (Index = 0; Index < sizeof(TcgEfiSpecIdEventStruct->signature); Index++) {
-    DEBUG ((EFI_D_INFO, "%c", TcgEfiSpecIdEventStruct->signature[Index]));
+    DEBUG ((DEBUG_INFO, "%c", TcgEfiSpecIdEventStruct->signature[Index]));
   }
-  DEBUG ((EFI_D_INFO, "'\n"));
-  DEBUG ((EFI_D_INFO, "    platformClass      - 0x%08x\n", TcgEfiSpecIdEventStruct->platformClass));
-  DEBUG ((EFI_D_INFO, "    specVersion        - %d.%d%d\n", TcgEfiSpecIdEventStruct->specVersionMajor, TcgEfiSpecIdEventStruct->specVersionMinor, TcgEfiSpecIdEventStruct->specErrata));
-  DEBUG ((EFI_D_INFO, "    uintnSize          - 0x%02x\n", TcgEfiSpecIdEventStruct->uintnSize));
+  DEBUG ((DEBUG_INFO, "'\n"));
+  DEBUG ((DEBUG_INFO, "    platformClass      - 0x%08x\n", TcgEfiSpecIdEventStruct->platformClass));
+  DEBUG ((DEBUG_INFO, "    specVersion        - %d.%d%d\n", TcgEfiSpecIdEventStruct->specVersionMajor, TcgEfiSpecIdEventStruct->specVersionMinor, TcgEfiSpecIdEventStruct->specErrata));
+  DEBUG ((DEBUG_INFO, "    uintnSize          - 0x%02x\n", TcgEfiSpecIdEventStruct->uintnSize));
 
   CopyMem (&NumberOfAlgorithms, TcgEfiSpecIdEventStruct + 1, sizeof(NumberOfAlgorithms));
-  DEBUG ((EFI_D_INFO, "    NumberOfAlgorithms - 0x%08x\n", NumberOfAlgorithms));
+  DEBUG ((DEBUG_INFO, "    NumberOfAlgorithms - 0x%08x\n", NumberOfAlgorithms));
 
   DigestSize = (TCG_EfiSpecIdEventAlgorithmSize *)((UINT8 *)TcgEfiSpecIdEventStruct + sizeof(*TcgEfiSpecIdEventStruct) + sizeof(NumberOfAlgorithms));
   for (Index = 0; Index < NumberOfAlgorithms; Index++) {
-    DEBUG ((EFI_D_INFO, "    digest(%d)\n", Index));
-    DEBUG ((EFI_D_INFO, "      algorithmId      - 0x%04x\n", DigestSize[Index].algorithmId));
-    DEBUG ((EFI_D_INFO, "      digestSize       - 0x%04x\n", DigestSize[Index].digestSize));
+    DEBUG ((DEBUG_INFO, "    digest(%d)\n", Index));
+    DEBUG ((DEBUG_INFO, "      algorithmId      - 0x%04x\n", DigestSize[Index].algorithmId));
+    DEBUG ((DEBUG_INFO, "      digestSize       - 0x%04x\n", DigestSize[Index].digestSize));
   }
   VendorInfoSize = (UINT8 *)&DigestSize[NumberOfAlgorithms];
-  DEBUG ((EFI_D_INFO, "    VendorInfoSize     - 0x%02x\n", *VendorInfoSize));
+  DEBUG ((DEBUG_INFO, "    VendorInfoSize     - 0x%02x\n", *VendorInfoSize));
   VendorInfo = VendorInfoSize + 1;
-  DEBUG ((EFI_D_INFO, "    VendorInfo         - "));
+  DEBUG ((DEBUG_INFO, "    VendorInfo         - "));
   for (Index = 0; Index < *VendorInfoSize; Index++) {
-    DEBUG ((EFI_D_INFO, "%02x ", VendorInfo[Index]));
+    DEBUG ((DEBUG_INFO, "%02x ", VendorInfo[Index]));
   }
-  DEBUG ((EFI_D_INFO, "\n"));
+  DEBUG ((DEBUG_INFO, "\n"));
 }
 
 /**
@@ -524,34 +524,34 @@ DumpEvent2 (
   UINT32                    EventSize;
   UINT8                     *EventBuffer;
 
-  DEBUG ((EFI_D_INFO, "  Event:\n"));
-  DEBUG ((EFI_D_INFO, "    PCRIndex  - %d\n", TcgPcrEvent2->PCRIndex));
-  DEBUG ((EFI_D_INFO, "    EventType - 0x%08x\n", TcgPcrEvent2->EventType));
+  DEBUG ((DEBUG_INFO, "  Event:\n"));
+  DEBUG ((DEBUG_INFO, "    PCRIndex  - %d\n", TcgPcrEvent2->PCRIndex));
+  DEBUG ((DEBUG_INFO, "    EventType - 0x%08x\n", TcgPcrEvent2->EventType));
 
-  DEBUG ((EFI_D_INFO, "    DigestCount: 0x%08x\n", TcgPcrEvent2->Digest.count));
+  DEBUG ((DEBUG_INFO, "    DigestCount: 0x%08x\n", TcgPcrEvent2->Digest.count));
 
   DigestCount = TcgPcrEvent2->Digest.count;
   HashAlgo = TcgPcrEvent2->Digest.digests[0].hashAlg;
   DigestBuffer = (UINT8 *)&TcgPcrEvent2->Digest.digests[0].digest;
   for (DigestIndex = 0; DigestIndex < DigestCount; DigestIndex++) {
-    DEBUG ((EFI_D_INFO, "      HashAlgo : 0x%04x\n", HashAlgo));
-    DEBUG ((EFI_D_INFO, "      Digest(%d): ", DigestIndex));
+    DEBUG ((DEBUG_INFO, "      HashAlgo : 0x%04x\n", HashAlgo));
+    DEBUG ((DEBUG_INFO, "      Digest(%d): ", DigestIndex));
     DigestSize = GetHashSizeFromAlgo (HashAlgo);
     for (Index = 0; Index < DigestSize; Index++) {
-      DEBUG ((EFI_D_INFO, "%02x ", DigestBuffer[Index]));
+      DEBUG ((DEBUG_INFO, "%02x ", DigestBuffer[Index]));
     }
-    DEBUG ((EFI_D_INFO, "\n"));
+    DEBUG ((DEBUG_INFO, "\n"));
     //
     // Prepare next
     //
     CopyMem (&HashAlgo, DigestBuffer + DigestSize, sizeof(TPMI_ALG_HASH));
     DigestBuffer = DigestBuffer + DigestSize + sizeof(TPMI_ALG_HASH);
   }
-  DEBUG ((EFI_D_INFO, "\n"));
+  DEBUG ((DEBUG_INFO, "\n"));
   DigestBuffer = DigestBuffer - sizeof(TPMI_ALG_HASH);
 
   CopyMem (&EventSize, DigestBuffer, sizeof(TcgPcrEvent2->EventSize));
-  DEBUG ((EFI_D_INFO, "    EventSize - 0x%08x\n", EventSize));
+  DEBUG ((DEBUG_INFO, "    EventSize - 0x%08x\n", EventSize));
   EventBuffer = DigestBuffer + sizeof(TcgPcrEvent2->EventSize);
   InternalDumpHex (EventBuffer, EventSize);
 }
@@ -617,7 +617,7 @@ DumpEventLog (
   TCG_EfiSpecIDEventStruct  *TcgEfiSpecIdEventStruct;
   UINTN                     NumberOfEvents;
 
-  DEBUG ((EFI_D_INFO, "EventLogFormat: (0x%x)\n", EventLogFormat));
+  DEBUG ((DEBUG_INFO, "EventLogFormat: (0x%x)\n", EventLogFormat));
 
   switch (EventLogFormat) {
   case EFI_TCG2_EVENT_LOG_FORMAT_TCG_1_2:
@@ -627,11 +627,11 @@ DumpEventLog (
       EventHdr = (TCG_PCR_EVENT_HDR *)((UINTN)EventHdr + sizeof(TCG_PCR_EVENT_HDR) + EventHdr->EventSize);
     }
     if (FinalEventsTable == NULL) {
-      DEBUG ((EFI_D_INFO, "FinalEventsTable: NOT FOUND\n"));
+      DEBUG ((DEBUG_INFO, "FinalEventsTable: NOT FOUND\n"));
     } else {
-      DEBUG ((EFI_D_INFO, "FinalEventsTable:    (0x%x)\n", FinalEventsTable));
-      DEBUG ((EFI_D_INFO, "  Version:           (0x%x)\n", FinalEventsTable->Version));
-      DEBUG ((EFI_D_INFO, "  NumberOfEvents:    (0x%x)\n", FinalEventsTable->NumberOfEvents));
+      DEBUG ((DEBUG_INFO, "FinalEventsTable:    (0x%x)\n", FinalEventsTable));
+      DEBUG ((DEBUG_INFO, "  Version:           (0x%x)\n", FinalEventsTable->Version));
+      DEBUG ((DEBUG_INFO, "  NumberOfEvents:    (0x%x)\n", FinalEventsTable->NumberOfEvents));
 
       EventHdr = (TCG_PCR_EVENT_HDR *)(UINTN)(FinalEventsTable + 1);
       for (NumberOfEvents = 0; NumberOfEvents < FinalEventsTable->NumberOfEvents; NumberOfEvents++) {
@@ -657,11 +657,11 @@ DumpEventLog (
     }
 
     if (FinalEventsTable == NULL) {
-      DEBUG ((EFI_D_INFO, "FinalEventsTable: NOT FOUND\n"));
+      DEBUG ((DEBUG_INFO, "FinalEventsTable: NOT FOUND\n"));
     } else {
-      DEBUG ((EFI_D_INFO, "FinalEventsTable:    (0x%x)\n", FinalEventsTable));
-      DEBUG ((EFI_D_INFO, "  Version:           (0x%x)\n", FinalEventsTable->Version));
-      DEBUG ((EFI_D_INFO, "  NumberOfEvents:    (0x%x)\n", FinalEventsTable->NumberOfEvents));
+      DEBUG ((DEBUG_INFO, "FinalEventsTable:    (0x%x)\n", FinalEventsTable));
+      DEBUG ((DEBUG_INFO, "  Version:           (0x%x)\n", FinalEventsTable->Version));
+      DEBUG ((DEBUG_INFO, "  NumberOfEvents:    (0x%x)\n", FinalEventsTable->NumberOfEvents));
 
       TcgPcrEvent2 = (TCG_PCR_EVENT2 *)(UINTN)(FinalEventsTable + 1);
       for (NumberOfEvents = 0; NumberOfEvents < FinalEventsTable->NumberOfEvents; NumberOfEvents++) {
@@ -704,7 +704,7 @@ Tcg2GetEventLog (
 {
   UINTN  Index;
 
-  DEBUG ((EFI_D_INFO, "Tcg2GetEventLog ... (0x%x)\n", EventLogFormat));
+  DEBUG ((DEBUG_INFO, "Tcg2GetEventLog ... (0x%x)\n", EventLogFormat));
 
   if (This == NULL) {
     return EFI_INVALID_PARAMETER;
@@ -739,7 +739,7 @@ Tcg2GetEventLog (
 
   if (EventLogLocation != NULL) {
     *EventLogLocation = mTcgDxeData.EventLogAreaStruct[Index].Lasa;
-    DEBUG ((EFI_D_INFO, "Tcg2GetEventLog (EventLogLocation - %x)\n", *EventLogLocation));
+    DEBUG ((DEBUG_INFO, "Tcg2GetEventLog (EventLogLocation - %x)\n", *EventLogLocation));
   }
 
   if (EventLogLastEntry != NULL) {
@@ -748,15 +748,15 @@ Tcg2GetEventLog (
     } else {
       *EventLogLastEntry = (EFI_PHYSICAL_ADDRESS)(UINTN)mTcgDxeData.EventLogAreaStruct[Index].LastEvent;
     }
-    DEBUG ((EFI_D_INFO, "Tcg2GetEventLog (EventLogLastEntry - %x)\n", *EventLogLastEntry));
+    DEBUG ((DEBUG_INFO, "Tcg2GetEventLog (EventLogLastEntry - %x)\n", *EventLogLastEntry));
   }
 
   if (EventLogTruncated != NULL) {
     *EventLogTruncated = mTcgDxeData.EventLogAreaStruct[Index].EventLogTruncated;
-    DEBUG ((EFI_D_INFO, "Tcg2GetEventLog (EventLogTruncated - %x)\n", *EventLogTruncated));
+    DEBUG ((DEBUG_INFO, "Tcg2GetEventLog (EventLogTruncated - %x)\n", *EventLogTruncated));
   }
 
-  DEBUG ((EFI_D_INFO, "Tcg2GetEventLog - %r\n", EFI_SUCCESS));
+  DEBUG ((DEBUG_INFO, "Tcg2GetEventLog - %r\n", EFI_SUCCESS));
 
   // Dump Event Log for debug purpose
   if ((EventLogLocation != NULL) && (EventLogLastEntry != NULL)) {
@@ -979,8 +979,8 @@ TcgDxeLogEvent (
       // Increase the NumberOfEvents in FinalEventsTable
       //
       (mTcgDxeData.FinalEventsTable[Index])->NumberOfEvents ++;
-      DEBUG ((EFI_D_INFO, "FinalEventsTable->NumberOfEvents - 0x%x\n", (mTcgDxeData.FinalEventsTable[Index])->NumberOfEvents));
-      DEBUG ((EFI_D_INFO, "  Size - 0x%x\n", (UINTN)EventLogAreaStruct->EventLogSize));
+      DEBUG ((DEBUG_INFO, "FinalEventsTable->NumberOfEvents - 0x%x\n", (mTcgDxeData.FinalEventsTable[Index])->NumberOfEvents));
+      DEBUG ((DEBUG_INFO, "  Size - 0x%x\n", (UINTN)EventLogAreaStruct->EventLogSize));
     }
   }
 
@@ -1100,12 +1100,12 @@ TcgDxeLogHashEvent (
   UINT8                             *DigestBuffer;
   UINT32                            *EventSizePtr;
 
-  DEBUG ((EFI_D_INFO, "SupportedEventLogs - 0x%08x\n", mTcgDxeData.BsCap.SupportedEventLogs));
+  DEBUG ((DEBUG_INFO, "SupportedEventLogs - 0x%08x\n", mTcgDxeData.BsCap.SupportedEventLogs));
 
   RetStatus = EFI_SUCCESS;
   for (Index = 0; Index < sizeof(mTcg2EventInfo)/sizeof(mTcg2EventInfo[0]); Index++) {
     if ((mTcgDxeData.BsCap.SupportedEventLogs & mTcg2EventInfo[Index].LogFormat) != 0) {
-      DEBUG ((EFI_D_INFO, "  LogFormat - 0x%08x\n", mTcg2EventInfo[Index].LogFormat));
+      DEBUG ((DEBUG_INFO, "  LogFormat - 0x%08x\n", mTcg2EventInfo[Index].LogFormat));
       switch (mTcg2EventInfo[Index].LogFormat) {
       case EFI_TCG2_EVENT_LOG_FORMAT_TCG_1_2:
         Status = GetDigestFromDigestList (TPM_ALG_SHA1, DigestList, &NewEventHdr->Digest);
@@ -1223,7 +1223,7 @@ TcgDxeHashLogExtendEvent (
   }
 
   if (Status == EFI_DEVICE_ERROR) {
-    DEBUG ((EFI_D_ERROR, "TcgDxeHashLogExtendEvent - %r. Disable TPM.\n", Status));
+    DEBUG ((DEBUG_ERROR, "TcgDxeHashLogExtendEvent - %r. Disable TPM.\n", Status));
     mTcgDxeData.BsCap.TPMPresentFlag = FALSE;
     REPORT_STATUS_CODE (
       EFI_ERROR_CODE | EFI_ERROR_MINOR,
@@ -1307,7 +1307,7 @@ Tcg2HashLogExtendEvent (
       }
     }
     if (Status == EFI_DEVICE_ERROR) {
-      DEBUG ((EFI_D_ERROR, "MeasurePeImageAndExtend - %r. Disable TPM.\n", Status));
+      DEBUG ((DEBUG_ERROR, "MeasurePeImageAndExtend - %r. Disable TPM.\n", Status));
       mTcgDxeData.BsCap.TPMPresentFlag = FALSE;
       REPORT_STATUS_CODE (
         EFI_ERROR_CODE | EFI_ERROR_MINOR,
@@ -1353,7 +1353,7 @@ Tcg2SubmitCommand (
 {
   EFI_STATUS    Status;
 
-  DEBUG ((EFI_D_INFO, "Tcg2SubmitCommand ...\n"));
+  DEBUG ((DEBUG_INFO, "Tcg2SubmitCommand ...\n"));
 
   if ((This == NULL) ||
       (InputParameterBlockSize == 0) || (InputParameterBlock == NULL) ||
@@ -1378,7 +1378,7 @@ Tcg2SubmitCommand (
              &OutputParameterBlockSize,
              OutputParameterBlock
              );
-  DEBUG ((EFI_D_INFO, "Tcg2SubmitCommand - %r\n", Status));
+  DEBUG ((DEBUG_INFO, "Tcg2SubmitCommand - %r\n", Status));
   return Status;
 }
 
@@ -1424,7 +1424,7 @@ Tcg2SetActivePCRBanks (
   EFI_STATUS  Status;
   UINT32      ReturnCode;
 
-  DEBUG ((EFI_D_INFO, "Tcg2SetActivePCRBanks ... (0x%x)\n", ActivePcrBanks));
+  DEBUG ((DEBUG_INFO, "Tcg2SetActivePCRBanks ... (0x%x)\n", ActivePcrBanks));
 
   if (ActivePcrBanks == 0) {
     return EFI_INVALID_PARAMETER;
@@ -1451,7 +1451,7 @@ Tcg2SetActivePCRBanks (
     Status = EFI_DEVICE_ERROR;
   }
 
-  DEBUG ((EFI_D_INFO, "Tcg2SetActivePCRBanks - %r\n", Status));
+  DEBUG ((DEBUG_INFO, "Tcg2SetActivePCRBanks - %r\n", Status));
 
   return Status;
 }
@@ -1532,7 +1532,7 @@ SetupEventLog (
   UINT32                          NumberOfAlgorithms;
   TCG_EfiStartupLocalityEvent     StartupLocalityEvent;
 
-  DEBUG ((EFI_D_INFO, "SetupEventLog\n"));
+  DEBUG ((DEBUG_INFO, "SetupEventLog\n"));
 
   //
   // 1. Create Log Area
@@ -1939,7 +1939,7 @@ MeasureSeparatorEvent (
   TCG_PCR_EVENT_HDR                 TcgEvent;
   UINT32                            EventData;
 
-  DEBUG ((EFI_D_INFO, "MeasureSeparatorEvent Pcr - %x\n", PCRIndex));
+  DEBUG ((DEBUG_INFO, "MeasureSeparatorEvent Pcr - %x\n", PCRIndex));
 
   EventData = 0;
   TcgEvent.PCRIndex  = PCRIndex;
@@ -1984,8 +1984,8 @@ MeasureVariable (
   UINTN                             VarNameLength;
   UEFI_VARIABLE_DATA                *VarLog;
 
-  DEBUG ((EFI_D_INFO, "Tcg2Dxe: MeasureVariable (Pcr - %x, EventType - %x, ", (UINTN)PCRIndex, (UINTN)EventType));
-  DEBUG ((EFI_D_INFO, "VariableName - %s, VendorGuid - %g)\n", VarName, VendorGuid));
+  DEBUG ((DEBUG_INFO, "Tcg2Dxe: MeasureVariable (Pcr - %x, EventType - %x, ", (UINTN)PCRIndex, (UINTN)EventType));
+  DEBUG ((DEBUG_INFO, "VariableName - %s, VendorGuid - %g)\n", VarName, VendorGuid));
 
   VarNameLength      = StrLen (VarName);
   TcgEvent.PCRIndex  = PCRIndex;
@@ -2335,11 +2335,11 @@ MeasureSecureBootPolicy (
 
   if (PcdGetBool (PcdFirmwareDebuggerInitialized)) {
     Status = MeasureLaunchOfFirmwareDebugger ();
-    DEBUG ((EFI_D_INFO, "MeasureLaunchOfFirmwareDebugger - %r\n", Status));
+    DEBUG ((DEBUG_INFO, "MeasureLaunchOfFirmwareDebugger - %r\n", Status));
   }
 
   Status = MeasureAllSecureVariables ();
-  DEBUG ((EFI_D_INFO, "MeasureAllSecureVariables - %r\n", Status));
+  DEBUG ((DEBUG_INFO, "MeasureAllSecureVariables - %r\n", Status));
 
   //
   // We need measure Separator(7) here, because this event must be between SecureBootPolicy (Configure)
@@ -2348,7 +2348,7 @@ MeasureSecureBootPolicy (
   // the Authority measurement happen before ReadToBoot event.
   //
   Status = MeasureSeparatorEvent (7);
-  DEBUG ((EFI_D_INFO, "MeasureSeparatorEvent - %r\n", Status));
+  DEBUG ((DEBUG_INFO, "MeasureSeparatorEvent - %r\n", Status));
   return ;
 }
 
@@ -2379,7 +2379,7 @@ OnReadyToBoot (
     //
     Status = MeasureHandoffTables ();
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "HOBs not Measured. Error!\n"));
+      DEBUG ((DEBUG_ERROR, "HOBs not Measured. Error!\n"));
     }
 
     //
@@ -2387,7 +2387,7 @@ OnReadyToBoot (
     //
     Status = MeasureAllBootVariables ();
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "Boot Variables not Measured. Error!\n"));
+      DEBUG ((DEBUG_ERROR, "Boot Variables not Measured. Error!\n"));
     }
 
     //
@@ -2398,7 +2398,7 @@ OnReadyToBoot (
                EFI_CALLING_EFI_APPLICATION
                );
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "%a not Measured. Error!\n", EFI_CALLING_EFI_APPLICATION));
+      DEBUG ((DEBUG_ERROR, "%a not Measured. Error!\n", EFI_CALLING_EFI_APPLICATION));
     }
 
     //
@@ -2432,7 +2432,7 @@ OnReadyToBoot (
                EFI_RETURNING_FROM_EFI_APPLICATION
                );
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "%a not Measured. Error!\n", EFI_RETURNING_FROM_EFI_APPLICATION));
+      DEBUG ((DEBUG_ERROR, "%a not Measured. Error!\n", EFI_RETURNING_FROM_EFI_APPLICATION));
     }
 
     //
@@ -2444,11 +2444,11 @@ OnReadyToBoot (
                EFI_CALLING_EFI_APPLICATION
                );
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "%a not Measured. Error!\n", EFI_CALLING_EFI_APPLICATION));
+      DEBUG ((DEBUG_ERROR, "%a not Measured. Error!\n", EFI_CALLING_EFI_APPLICATION));
     }
   }
 
-  DEBUG ((EFI_D_INFO, "TPM2 Tcg2Dxe Measure Data when ReadyToBoot\n"));
+  DEBUG ((DEBUG_INFO, "TPM2 Tcg2Dxe Measure Data when ReadyToBoot\n"));
   //
   // Increase boot attempt counter.
   //
@@ -2482,7 +2482,7 @@ OnExitBootServices (
              EFI_EXIT_BOOT_SERVICES_INVOCATION
              );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a not Measured. Error!\n", EFI_EXIT_BOOT_SERVICES_INVOCATION));
+    DEBUG ((DEBUG_ERROR, "%a not Measured. Error!\n", EFI_EXIT_BOOT_SERVICES_INVOCATION));
   }
 
   //
@@ -2493,7 +2493,7 @@ OnExitBootServices (
              EFI_EXIT_BOOT_SERVICES_SUCCEEDED
              );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a not Measured. Error!\n", EFI_EXIT_BOOT_SERVICES_SUCCEEDED));
+    DEBUG ((DEBUG_ERROR, "%a not Measured. Error!\n", EFI_EXIT_BOOT_SERVICES_SUCCEEDED));
   }
 }
 
@@ -2523,7 +2523,7 @@ OnExitBootServicesFailed (
              EFI_EXIT_BOOT_SERVICES_FAILED
              );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a not Measured. Error!\n", EFI_EXIT_BOOT_SERVICES_FAILED));
+    DEBUG ((DEBUG_ERROR, "%a not Measured. Error!\n", EFI_EXIT_BOOT_SERVICES_FAILED));
   }
 
 }
@@ -2646,13 +2646,13 @@ DriverEntry (
   }
 
   if (GetFirstGuidHob (&gTpmErrorHobGuid) != NULL) {
-    DEBUG ((EFI_D_ERROR, "TPM2 error!\n"));
+    DEBUG ((DEBUG_ERROR, "TPM2 error!\n"));
     return EFI_DEVICE_ERROR;
   }
 
   Status = Tpm2RequestUseTpm ();
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "TPM2 not detected!\n"));
+    DEBUG ((DEBUG_ERROR, "TPM2 not detected!\n"));
     return Status;
   }
 
@@ -2667,14 +2667,14 @@ DriverEntry (
   mTcgDxeData.BsCap.StructureVersion.Major = 1;
   mTcgDxeData.BsCap.StructureVersion.Minor = 1;
 
-  DEBUG ((EFI_D_INFO, "Tcg2.ProtocolVersion  - %02x.%02x\n", mTcgDxeData.BsCap.ProtocolVersion.Major, mTcgDxeData.BsCap.ProtocolVersion.Minor));
-  DEBUG ((EFI_D_INFO, "Tcg2.StructureVersion - %02x.%02x\n", mTcgDxeData.BsCap.StructureVersion.Major, mTcgDxeData.BsCap.StructureVersion.Minor));
+  DEBUG ((DEBUG_INFO, "Tcg2.ProtocolVersion  - %02x.%02x\n", mTcgDxeData.BsCap.ProtocolVersion.Major, mTcgDxeData.BsCap.ProtocolVersion.Minor));
+  DEBUG ((DEBUG_INFO, "Tcg2.StructureVersion - %02x.%02x\n", mTcgDxeData.BsCap.StructureVersion.Major, mTcgDxeData.BsCap.StructureVersion.Minor));
 
   Status = Tpm2GetCapabilityManufactureID (&mTcgDxeData.BsCap.ManufacturerID);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "Tpm2GetCapabilityManufactureID fail!\n"));
+    DEBUG ((DEBUG_ERROR, "Tpm2GetCapabilityManufactureID fail!\n"));
   } else {
-    DEBUG ((EFI_D_INFO, "Tpm2GetCapabilityManufactureID - %08x\n", mTcgDxeData.BsCap.ManufacturerID));
+    DEBUG ((DEBUG_INFO, "Tpm2GetCapabilityManufactureID - %08x\n", mTcgDxeData.BsCap.ManufacturerID));
   }
 
   DEBUG_CODE (
@@ -2683,19 +2683,19 @@ DriverEntry (
 
     Status = Tpm2GetCapabilityFirmwareVersion (&FirmwareVersion1, &FirmwareVersion2);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "Tpm2GetCapabilityFirmwareVersion fail!\n"));
+      DEBUG ((DEBUG_ERROR, "Tpm2GetCapabilityFirmwareVersion fail!\n"));
     } else {
-      DEBUG ((EFI_D_INFO, "Tpm2GetCapabilityFirmwareVersion - %08x %08x\n", FirmwareVersion1, FirmwareVersion2));
+      DEBUG ((DEBUG_INFO, "Tpm2GetCapabilityFirmwareVersion - %08x %08x\n", FirmwareVersion1, FirmwareVersion2));
     }
   );
 
   Status = Tpm2GetCapabilityMaxCommandResponseSize (&MaxCommandSize, &MaxResponseSize);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "Tpm2GetCapabilityMaxCommandResponseSize fail!\n"));
+    DEBUG ((DEBUG_ERROR, "Tpm2GetCapabilityMaxCommandResponseSize fail!\n"));
   } else {
     mTcgDxeData.BsCap.MaxCommandSize  = (UINT16)MaxCommandSize;
     mTcgDxeData.BsCap.MaxResponseSize = (UINT16)MaxResponseSize;
-    DEBUG ((EFI_D_INFO, "Tpm2GetCapabilityMaxCommandResponseSize - %08x, %08x\n", MaxCommandSize, MaxResponseSize));
+    DEBUG ((DEBUG_INFO, "Tpm2GetCapabilityMaxCommandResponseSize - %08x, %08x\n", MaxCommandSize, MaxResponseSize));
   }
 
   //
@@ -2722,7 +2722,7 @@ DriverEntry (
   } else {
     mTcgDxeData.BsCap.NumberOfPCRBanks = PcdGet32 (PcdTcg2NumberOfPCRBanks);
     if (PcdGet32 (PcdTcg2NumberOfPCRBanks) > NumberOfPCRBanks) {
-      DEBUG ((EFI_D_ERROR, "ERROR: PcdTcg2NumberOfPCRBanks(0x%x) > NumberOfPCRBanks(0x%x)\n", PcdGet32 (PcdTcg2NumberOfPCRBanks), NumberOfPCRBanks));
+      DEBUG ((DEBUG_ERROR, "ERROR: PcdTcg2NumberOfPCRBanks(0x%x) > NumberOfPCRBanks(0x%x)\n", PcdGet32 (PcdTcg2NumberOfPCRBanks), NumberOfPCRBanks));
       mTcgDxeData.BsCap.NumberOfPCRBanks = NumberOfPCRBanks;
     }
   }
@@ -2735,10 +2735,10 @@ DriverEntry (
     mTcgDxeData.BsCap.SupportedEventLogs &= ~EFI_TCG2_EVENT_LOG_FORMAT_TCG_1_2;
   }
 
-  DEBUG ((EFI_D_INFO, "Tcg2.SupportedEventLogs - 0x%08x\n", mTcgDxeData.BsCap.SupportedEventLogs));
-  DEBUG ((EFI_D_INFO, "Tcg2.HashAlgorithmBitmap - 0x%08x\n", mTcgDxeData.BsCap.HashAlgorithmBitmap));
-  DEBUG ((EFI_D_INFO, "Tcg2.NumberOfPCRBanks      - 0x%08x\n", mTcgDxeData.BsCap.NumberOfPCRBanks));
-  DEBUG ((EFI_D_INFO, "Tcg2.ActivePcrBanks        - 0x%08x\n", mTcgDxeData.BsCap.ActivePcrBanks));
+  DEBUG ((DEBUG_INFO, "Tcg2.SupportedEventLogs - 0x%08x\n", mTcgDxeData.BsCap.SupportedEventLogs));
+  DEBUG ((DEBUG_INFO, "Tcg2.HashAlgorithmBitmap - 0x%08x\n", mTcgDxeData.BsCap.HashAlgorithmBitmap));
+  DEBUG ((DEBUG_INFO, "Tcg2.NumberOfPCRBanks      - 0x%08x\n", mTcgDxeData.BsCap.NumberOfPCRBanks));
+  DEBUG ((DEBUG_INFO, "Tcg2.ActivePcrBanks        - 0x%08x\n", mTcgDxeData.BsCap.ActivePcrBanks));
 
   if (mTcgDxeData.BsCap.TPMPresentFlag) {
     //
@@ -2795,7 +2795,7 @@ DriverEntry (
   // Install Tcg2Protocol
   //
   Status = InstallTcg2 ();
-  DEBUG ((EFI_D_INFO, "InstallTcg2 - %r\n", Status));
+  DEBUG ((DEBUG_INFO, "InstallTcg2 - %r\n", Status));
 
   return Status;
 }

--- a/SecurityPkg/Tcg/Tcg2Pei/Tcg2Pei.c
+++ b/SecurityPkg/Tcg/Tcg2Pei/Tcg2Pei.c
@@ -267,7 +267,7 @@ SyncPcrAllocationsAndPcrMask (
   UINT32                            Tpm2PcrMask;
   UINT32                            NewTpm2PcrMask;
 
-  DEBUG ((EFI_D_ERROR, "SyncPcrAllocationsAndPcrMask!\n"));
+  DEBUG ((DEBUG_ERROR, "SyncPcrAllocationsAndPcrMask!\n"));
 
   //
   // Determine the current TPM support and the Platform PCR mask.
@@ -297,9 +297,9 @@ SyncPcrAllocationsAndPcrMask (
   if ((TpmActivePcrBanks & Tpm2PcrMask) != TpmActivePcrBanks) {
     NewTpmActivePcrBanks = TpmActivePcrBanks & Tpm2PcrMask;
 
-    DEBUG ((EFI_D_INFO, "%a - Reallocating PCR banks from 0x%X to 0x%X.\n", __FUNCTION__, TpmActivePcrBanks, NewTpmActivePcrBanks));
+    DEBUG ((DEBUG_INFO, "%a - Reallocating PCR banks from 0x%X to 0x%X.\n", __FUNCTION__, TpmActivePcrBanks, NewTpmActivePcrBanks));
     if (NewTpmActivePcrBanks == 0) {
-      DEBUG ((EFI_D_ERROR, "%a - No viable PCRs active! Please set a less restrictive value for PcdTpm2HashMask!\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a - No viable PCRs active! Please set a less restrictive value for PcdTpm2HashMask!\n", __FUNCTION__));
       ASSERT (FALSE);
     } else {
       Status = Tpm2PcrAllocateBanks (NULL, (UINT32)TpmHashAlgorithmBitmap, NewTpmActivePcrBanks);
@@ -307,7 +307,7 @@ SyncPcrAllocationsAndPcrMask (
         //
         // We can't do much here, but we hope that this doesn't happen.
         //
-        DEBUG ((EFI_D_ERROR, "%a - Failed to reallocate PCRs!\n", __FUNCTION__));
+        DEBUG ((DEBUG_ERROR, "%a - Failed to reallocate PCRs!\n", __FUNCTION__));
         ASSERT_EFI_ERROR (Status);
       }
       //
@@ -324,9 +324,9 @@ SyncPcrAllocationsAndPcrMask (
   if ((Tpm2PcrMask & TpmHashAlgorithmBitmap) != Tpm2PcrMask) {
     NewTpm2PcrMask = Tpm2PcrMask & TpmHashAlgorithmBitmap;
 
-    DEBUG ((EFI_D_INFO, "%a - Updating PcdTpm2HashMask from 0x%X to 0x%X.\n", __FUNCTION__, Tpm2PcrMask, NewTpm2PcrMask));
+    DEBUG ((DEBUG_INFO, "%a - Updating PcdTpm2HashMask from 0x%X to 0x%X.\n", __FUNCTION__, Tpm2PcrMask, NewTpm2PcrMask));
     if (NewTpm2PcrMask == 0) {
-      DEBUG ((EFI_D_ERROR, "%a - No viable PCRs supported! Please set a less restrictive value for PcdTpm2HashMask!\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a - No viable PCRs supported! Please set a less restrictive value for PcdTpm2HashMask!\n", __FUNCTION__));
       ASSERT (FALSE);
     }
 
@@ -365,7 +365,7 @@ LogHashEvent (
   RetStatus = EFI_SUCCESS;
   for (Index = 0; Index < sizeof(mTcg2EventInfo)/sizeof(mTcg2EventInfo[0]); Index++) {
     if ((SupportedEventLogs & mTcg2EventInfo[Index].LogFormat) != 0) {
-      DEBUG ((EFI_D_INFO, "  LogFormat - 0x%08x\n", mTcg2EventInfo[Index].LogFormat));
+      DEBUG ((DEBUG_INFO, "  LogFormat - 0x%08x\n", mTcg2EventInfo[Index].LogFormat));
       switch (mTcg2EventInfo[Index].LogFormat) {
       case EFI_TCG2_EVENT_LOG_FORMAT_TCG_1_2:
         Status = GetDigestFromDigestList (TPM_ALG_SHA1, DigestList, &NewEventHdr->Digest);
@@ -476,7 +476,7 @@ HashLogExtendEvent (
   }
 
   if (Status == EFI_DEVICE_ERROR) {
-    DEBUG ((EFI_D_ERROR, "HashLogExtendEvent - %r. Disable TPM.\n", Status));
+    DEBUG ((DEBUG_ERROR, "HashLogExtendEvent - %r. Disable TPM.\n", Status));
     BuildGuidHob (&gTpmErrorHobGuid,0);
     REPORT_STATUS_CODE (
       EFI_ERROR_CODE | EFI_ERROR_MINOR,
@@ -1011,7 +1011,7 @@ PeimEntryMA (
   }
 
   if (GetFirstGuidHob (&gTpmErrorHobGuid) != NULL) {
-    DEBUG ((EFI_D_ERROR, "TPM2 error!\n"));
+    DEBUG ((DEBUG_ERROR, "TPM2 error!\n"));
     return EFI_DEVICE_ERROR;
   }
 
@@ -1075,7 +1075,7 @@ PeimEntryMA (
       for (PcrIndex = 0; PcrIndex < 8; PcrIndex++) {
         Status = MeasureSeparatorEventWithError (PcrIndex);
         if (EFI_ERROR (Status)) {
-          DEBUG ((EFI_D_ERROR, "Separator Event with Error not Measured. Error!\n"));
+          DEBUG ((DEBUG_ERROR, "Separator Event with Error not Measured. Error!\n"));
         }
       }
     }
@@ -1106,7 +1106,7 @@ PeimEntryMA (
 
 Done:
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "TPM2 error! Build Hob\n"));
+    DEBUG ((DEBUG_ERROR, "TPM2 error! Build Hob\n"));
     BuildGuidHob (&gTpmErrorHobGuid,0);
     REPORT_STATUS_CODE (
       EFI_ERROR_CODE | EFI_ERROR_MINOR,

--- a/SecurityPkg/Tcg/Tcg2Smm/Tcg2Smm.c
+++ b/SecurityPkg/Tcg/Tcg2Smm/Tcg2Smm.c
@@ -203,7 +203,7 @@ MemoryClearCallback (
                              );
     if (EFI_ERROR (Status)) {
       mTcgNvs->MemoryClear.ReturnCode = MOR_REQUEST_GENERAL_FAILURE;
-      DEBUG ((EFI_D_ERROR, "[TPM] Get MOR variable failure! Status = %r\n", Status));
+      DEBUG ((DEBUG_ERROR, "[TPM] Get MOR variable failure! Status = %r\n", Status));
       return EFI_SUCCESS;
     }
 
@@ -213,7 +213,7 @@ MemoryClearCallback (
     MorControl &= ~MOR_CLEAR_MEMORY_BIT_MASK;
   } else {
     mTcgNvs->MemoryClear.ReturnCode = MOR_REQUEST_GENERAL_FAILURE;
-    DEBUG ((EFI_D_ERROR, "[TPM] MOR Parameter error! Parameter = %x\n", mTcgNvs->MemoryClear.Parameter));
+    DEBUG ((DEBUG_ERROR, "[TPM] MOR Parameter error! Parameter = %x\n", mTcgNvs->MemoryClear.Parameter));
     return EFI_SUCCESS;
   }
 
@@ -227,7 +227,7 @@ MemoryClearCallback (
                            );
   if (EFI_ERROR (Status)) {
     mTcgNvs->MemoryClear.ReturnCode = MOR_REQUEST_GENERAL_FAILURE;
-    DEBUG ((EFI_D_ERROR, "[TPM] Set MOR variable failure! Status = %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "[TPM] Set MOR variable failure! Status = %r\n", Status));
   }
 
   return EFI_SUCCESS;
@@ -285,7 +285,7 @@ InitializeTcgCommon (
   EFI_HANDLE                     NotifyHandle;
 
   if (!CompareGuid (PcdGetPtr(PcdTpmInstanceGuid), &gEfiTpmDeviceInstanceTpm20DtpmGuid)){
-    DEBUG ((EFI_D_ERROR, "No TPM2 DTPM instance required!\n"));
+    DEBUG ((DEBUG_ERROR, "No TPM2 DTPM instance required!\n"));
     return EFI_UNSUPPORTED;
   }
 
@@ -372,4 +372,3 @@ Cleanup:
 
   return Status;
 }
-

--- a/SecurityPkg/Tcg/TcgConfigDxe/TcgConfigDriver.c
+++ b/SecurityPkg/Tcg/TcgConfigDxe/TcgConfigDriver.c
@@ -33,13 +33,13 @@ TcgConfigDriverEntryPoint (
   EFI_TCG_PROTOCOL          *TcgProtocol;
 
   if (!CompareGuid (PcdGetPtr(PcdTpmInstanceGuid), &gEfiTpmDeviceInstanceTpm12Guid)){
-    DEBUG ((EFI_D_ERROR, "No TPM12 instance required!\n"));
+    DEBUG ((DEBUG_ERROR, "No TPM12 instance required!\n"));
     return EFI_UNSUPPORTED;
   }
 
   Status = Tpm12RequestUseTpm ();
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "TPM not detected!\n"));
+    DEBUG ((DEBUG_ERROR, "TPM not detected!\n"));
     return Status;
   }
 

--- a/SecurityPkg/Tcg/TcgDxe/TcgDxe.c
+++ b/SecurityPkg/Tcg/TcgDxe/TcgDxe.c
@@ -588,7 +588,7 @@ TcgDxeHashLogExtendEventI (
 
 Done:
   if ((Status == EFI_DEVICE_ERROR) || (Status == EFI_TIMEOUT)) {
-    DEBUG ((EFI_D_ERROR, "TcgDxeHashLogExtendEventI - %r. Disable TPM.\n", Status));
+    DEBUG ((DEBUG_ERROR, "TcgDxeHashLogExtendEventI - %r. Disable TPM.\n", Status));
     TcgData->BsCap.TPMPresentFlag = FALSE;
     REPORT_STATUS_CODE (
       EFI_ERROR_CODE | EFI_ERROR_MINOR,
@@ -1127,7 +1127,7 @@ OnReadyToBoot (
     //
     Status = MeasureHandoffTables ();
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "HOBs not Measured. Error!\n"));
+      DEBUG ((DEBUG_ERROR, "HOBs not Measured. Error!\n"));
     }
 
     //
@@ -1135,7 +1135,7 @@ OnReadyToBoot (
     //
     Status = MeasureAllBootVariables ();
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "Boot Variables not Measured. Error!\n"));
+      DEBUG ((DEBUG_ERROR, "Boot Variables not Measured. Error!\n"));
     }
 
     //
@@ -1145,7 +1145,7 @@ OnReadyToBoot (
                EFI_CALLING_EFI_APPLICATION
                );
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "%a not Measured. Error!\n", EFI_CALLING_EFI_APPLICATION));
+      DEBUG ((DEBUG_ERROR, "%a not Measured. Error!\n", EFI_CALLING_EFI_APPLICATION));
     }
 
     //
@@ -1177,11 +1177,11 @@ OnReadyToBoot (
                EFI_RETURNING_FROM_EFI_APPLICATION
                );
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "%a not Measured. Error!\n", EFI_RETURNING_FROM_EFI_APPLICATION));
+      DEBUG ((DEBUG_ERROR, "%a not Measured. Error!\n", EFI_RETURNING_FROM_EFI_APPLICATION));
     }
   }
 
-  DEBUG ((EFI_D_INFO, "TPM TcgDxe Measure Data when ReadyToBoot\n"));
+  DEBUG ((DEBUG_INFO, "TPM TcgDxe Measure Data when ReadyToBoot\n"));
   //
   // Increase boot attempt counter.
   //
@@ -1260,7 +1260,7 @@ InstallAcpiTable (
   }
 
   if (EFI_ERROR (Status)) {
-    DEBUG((EFI_D_ERROR, "Tcg Acpi Table installation failure"));
+    DEBUG((DEBUG_ERROR, "Tcg Acpi Table installation failure"));
   }
 }
 
@@ -1289,7 +1289,7 @@ OnExitBootServices (
              EFI_EXIT_BOOT_SERVICES_INVOCATION
              );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "%a not Measured. Error!\n", EFI_EXIT_BOOT_SERVICES_INVOCATION));
+    DEBUG ((DEBUG_ERROR, "%a not Measured. Error!\n", EFI_EXIT_BOOT_SERVICES_INVOCATION));
   }
 
   //
@@ -1299,7 +1299,7 @@ OnExitBootServices (
              EFI_EXIT_BOOT_SERVICES_SUCCEEDED
              );
   if (EFI_ERROR (Status)){
-    DEBUG ((EFI_D_ERROR, "%a not Measured. Error!\n", EFI_EXIT_BOOT_SERVICES_SUCCEEDED));
+    DEBUG ((DEBUG_ERROR, "%a not Measured. Error!\n", EFI_EXIT_BOOT_SERVICES_SUCCEEDED));
   }
 }
 
@@ -1328,7 +1328,7 @@ OnExitBootServicesFailed (
              EFI_EXIT_BOOT_SERVICES_FAILED
              );
   if (EFI_ERROR (Status)){
-    DEBUG ((EFI_D_ERROR, "%a not Measured. Error!\n", EFI_EXIT_BOOT_SERVICES_FAILED));
+    DEBUG ((DEBUG_ERROR, "%a not Measured. Error!\n", EFI_EXIT_BOOT_SERVICES_FAILED));
   }
 }
 
@@ -1381,25 +1381,25 @@ DriverEntry (
   VOID                              *Registration;
 
   if (!CompareGuid (PcdGetPtr(PcdTpmInstanceGuid), &gEfiTpmDeviceInstanceTpm12Guid)){
-    DEBUG ((EFI_D_ERROR, "No TPM12 instance required!\n"));
+    DEBUG ((DEBUG_ERROR, "No TPM12 instance required!\n"));
     return EFI_UNSUPPORTED;
   }
 
   if (GetFirstGuidHob (&gTpmErrorHobGuid) != NULL) {
-    DEBUG ((EFI_D_ERROR, "TPM error!\n"));
+    DEBUG ((DEBUG_ERROR, "TPM error!\n"));
     return EFI_DEVICE_ERROR;
   }
 
   Status = Tpm12RequestUseTpm ();
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "TPM not detected!\n"));
+    DEBUG ((DEBUG_ERROR, "TPM not detected!\n"));
     return Status;
   }
 
   Status = GetTpmStatus (&mTcgDxeData.BsCap.TPMDeactivatedFlag);
   if (EFI_ERROR (Status)) {
     DEBUG ((
-      EFI_D_ERROR,
+      DEBUG_ERROR,
       "DriverEntry: TPM not working properly\n"
       ));
     return Status;

--- a/SecurityPkg/Tcg/TcgPei/TcgPei.c
+++ b/SecurityPkg/Tcg/TcgPei/TcgPei.c
@@ -351,7 +351,7 @@ HashLogExtendEvent (
 
 Done:
   if ((Status == EFI_DEVICE_ERROR) || (Status == EFI_TIMEOUT)) {
-    DEBUG ((EFI_D_ERROR, "HashLogExtendEvent - %r. Disable TPM.\n", Status));
+    DEBUG ((DEBUG_ERROR, "HashLogExtendEvent - %r. Disable TPM.\n", Status));
     BuildGuidHob (&gTpmErrorHobGuid,0);
     REPORT_STATUS_CODE (
       EFI_ERROR_CODE | EFI_ERROR_MINOR,
@@ -844,12 +844,12 @@ PeimEntryMA (
   EFI_BOOT_MODE                     BootMode;
 
   if (!CompareGuid (PcdGetPtr(PcdTpmInstanceGuid), &gEfiTpmDeviceInstanceTpm12Guid)){
-    DEBUG ((EFI_D_ERROR, "No TPM12 instance required!\n"));
+    DEBUG ((DEBUG_ERROR, "No TPM12 instance required!\n"));
     return EFI_UNSUPPORTED;
   }
 
   if (GetFirstGuidHob (&gTpmErrorHobGuid) != NULL) {
-    DEBUG ((EFI_D_ERROR, "TPM error!\n"));
+    DEBUG ((DEBUG_ERROR, "TPM error!\n"));
     return EFI_DEVICE_ERROR;
   }
 
@@ -913,7 +913,7 @@ PeimEntryMA (
 
 Done:
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "TPM error! Build Hob\n"));
+    DEBUG ((DEBUG_ERROR, "TPM error! Build Hob\n"));
     BuildGuidHob (&gTpmErrorHobGuid,0);
     REPORT_STATUS_CODE (
       EFI_ERROR_CODE | EFI_ERROR_MINOR,

--- a/SecurityPkg/Tcg/TcgSmm/TcgSmm.c
+++ b/SecurityPkg/Tcg/TcgSmm/TcgSmm.c
@@ -62,13 +62,13 @@ PhysicalPresenceCallback (
                            &PpData
                            );
 
-  DEBUG ((EFI_D_INFO, "[TPM] PP callback, Parameter = %x\n", mTcgNvs->PhysicalPresence.Parameter));
+  DEBUG ((DEBUG_INFO, "[TPM] PP callback, Parameter = %x\n", mTcgNvs->PhysicalPresence.Parameter));
   if (mTcgNvs->PhysicalPresence.Parameter == ACPI_FUNCTION_RETURN_REQUEST_RESPONSE_TO_OS) {
     if (EFI_ERROR (Status)) {
       mTcgNvs->PhysicalPresence.ReturnCode  = PP_RETURN_TPM_OPERATION_RESPONSE_FAILURE;
       mTcgNvs->PhysicalPresence.LastRequest = 0;
       mTcgNvs->PhysicalPresence.Response    = 0;
-      DEBUG ((EFI_D_ERROR, "[TPM] Get PP variable failure! Status = %r\n", Status));
+      DEBUG ((DEBUG_ERROR, "[TPM] Get PP variable failure! Status = %r\n", Status));
       return EFI_SUCCESS;
     }
     mTcgNvs->PhysicalPresence.ReturnCode  = PP_RETURN_TPM_OPERATION_RESPONSE_SUCCESS;
@@ -78,7 +78,7 @@ PhysicalPresenceCallback (
           || (mTcgNvs->PhysicalPresence.Parameter == ACPI_FUNCTION_SUBMIT_REQUEST_TO_BIOS_2)) {
     if (EFI_ERROR (Status)) {
       mTcgNvs->PhysicalPresence.ReturnCode = TCG_PP_SUBMIT_REQUEST_TO_PREOS_GENERAL_FAILURE;
-      DEBUG ((EFI_D_ERROR, "[TPM] Get PP variable failure! Status = %r\n", Status));
+      DEBUG ((DEBUG_ERROR, "[TPM] Get PP variable failure! Status = %r\n", Status));
       return EFI_SUCCESS;
     }
     if (mTcgNvs->PhysicalPresence.Request == PHYSICAL_PRESENCE_SET_OPERATOR_AUTH) {
@@ -124,7 +124,7 @@ PhysicalPresenceCallback (
   } else if (mTcgNvs->PhysicalPresence.Parameter == ACPI_FUNCTION_GET_USER_CONFIRMATION_STATUS_FOR_REQUEST) {
     if (EFI_ERROR (Status)) {
       mTcgNvs->PhysicalPresence.ReturnCode = TCG_PP_GET_USER_CONFIRMATION_BLOCKED_BY_BIOS_CONFIGURATION;
-      DEBUG ((EFI_D_ERROR, "[TPM] Get PP variable failure! Status = %r\n", Status));
+      DEBUG ((DEBUG_ERROR, "[TPM] Get PP variable failure! Status = %r\n", Status));
       return EFI_SUCCESS;
     }
     //
@@ -140,7 +140,7 @@ PhysicalPresenceCallback (
                              );
     if (EFI_ERROR (Status)) {
       mTcgNvs->PhysicalPresence.ReturnCode = TCG_PP_GET_USER_CONFIRMATION_BLOCKED_BY_BIOS_CONFIGURATION;
-      DEBUG ((EFI_D_ERROR, "[TPM] Get PP flags failure! Status = %r\n", Status));
+      DEBUG ((DEBUG_ERROR, "[TPM] Get PP flags failure! Status = %r\n", Status));
       return EFI_SUCCESS;
     }
 
@@ -257,7 +257,7 @@ MemoryClearCallback (
                              );
     if (EFI_ERROR (Status)) {
       mTcgNvs->MemoryClear.ReturnCode = MOR_REQUEST_GENERAL_FAILURE;
-      DEBUG ((EFI_D_ERROR, "[TPM] Get MOR variable failure! Status = %r\n", Status));
+      DEBUG ((DEBUG_ERROR, "[TPM] Get MOR variable failure! Status = %r\n", Status));
       return EFI_SUCCESS;
     }
 
@@ -267,7 +267,7 @@ MemoryClearCallback (
     MorControl &= ~MOR_CLEAR_MEMORY_BIT_MASK;
   } else {
     mTcgNvs->MemoryClear.ReturnCode = MOR_REQUEST_GENERAL_FAILURE;
-    DEBUG ((EFI_D_ERROR, "[TPM] MOR Parameter error! Parameter = %x\n", mTcgNvs->MemoryClear.Parameter));
+    DEBUG ((DEBUG_ERROR, "[TPM] MOR Parameter error! Parameter = %x\n", mTcgNvs->MemoryClear.Parameter));
     return EFI_SUCCESS;
   }
 
@@ -281,7 +281,7 @@ MemoryClearCallback (
                            );
   if (EFI_ERROR (Status)) {
     mTcgNvs->MemoryClear.ReturnCode = MOR_REQUEST_GENERAL_FAILURE;
-    DEBUG ((EFI_D_ERROR, "[TPM] Set MOR variable failure! Status = %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "[TPM] Set MOR variable failure! Status = %r\n", Status));
   }
 
   return EFI_SUCCESS;
@@ -424,7 +424,7 @@ InitializeTcgSmm (
   EFI_HANDLE                     SwHandle;
 
   if (!CompareGuid (PcdGetPtr(PcdTpmInstanceGuid), &gEfiTpmDeviceInstanceTpm12Guid)){
-    DEBUG ((EFI_D_ERROR, "No TPM12 instance required!\n"));
+    DEBUG ((DEBUG_ERROR, "No TPM12 instance required!\n"));
     return EFI_UNSUPPORTED;
   }
 
@@ -460,4 +460,3 @@ InitializeTcgSmm (
 
   return EFI_SUCCESS;
 }
-

--- a/SecurityPkg/VariableAuthenticated/SecureBootConfigDxe/SecureBootConfigImpl.c
+++ b/SecurityPkg/VariableAuthenticated/SecureBootConfigDxe/SecureBootConfigImpl.c
@@ -458,7 +458,7 @@ EnrollPlatformKey (
   DataSize = PkCert->SignatureListSize;
   Status = CreateTimeBasedPayload (&DataSize, (UINT8**) &PkCert);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "Fail to create time-based data payload: %r", Status));
+    DEBUG ((DEBUG_ERROR, "Fail to create time-based data payload: %r", Status));
     goto ON_EXIT;
   }
 
@@ -471,7 +471,7 @@ EnrollPlatformKey (
                   );
   if (EFI_ERROR (Status)) {
     if (Status == EFI_OUT_OF_RESOURCES) {
-      DEBUG ((EFI_D_ERROR, "Enroll PK failed with out of resource.\n"));
+      DEBUG ((DEBUG_ERROR, "Enroll PK failed with out of resource.\n"));
     }
     goto ON_EXIT;
   }
@@ -600,7 +600,7 @@ EnrollRsa2048ToKek (
          | EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_TIME_BASED_AUTHENTICATED_WRITE_ACCESS;
   Status = CreateTimeBasedPayload (&KekSigListSize, (UINT8**) &KekSigList);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "Fail to create time-based data payload: %r", Status));
+    DEBUG ((DEBUG_ERROR, "Fail to create time-based data payload: %r", Status));
     goto ON_EXIT;
   }
 
@@ -724,7 +724,7 @@ EnrollX509ToKek (
           | EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_TIME_BASED_AUTHENTICATED_WRITE_ACCESS;
   Status = CreateTimeBasedPayload (&KekSigListSize, (UINT8**) &KekSigList);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "Fail to create time-based data payload: %r", Status));
+    DEBUG ((DEBUG_ERROR, "Fail to create time-based data payload: %r", Status));
     goto ON_EXIT;
   }
 
@@ -897,7 +897,7 @@ EnrollX509toSigDB (
           | EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_TIME_BASED_AUTHENTICATED_WRITE_ACCESS;
   Status = CreateTimeBasedPayload (&SigDBSize, (UINT8**) &Data);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "Fail to create time-based data payload: %r", Status));
+    DEBUG ((DEBUG_ERROR, "Fail to create time-based data payload: %r", Status));
     goto ON_EXIT;
   }
 
@@ -2243,7 +2243,7 @@ EnrollImageSignatureToSigDB (
           | EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_TIME_BASED_AUTHENTICATED_WRITE_ACCESS;
   Status = CreateTimeBasedPayload (&SigDBSize, (UINT8**) &Data);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "Fail to create time-based data payload: %r", Status));
+    DEBUG ((DEBUG_ERROR, "Fail to create time-based data payload: %r", Status));
     goto ON_EXIT;
   }
 
@@ -2700,7 +2700,7 @@ DeleteKeyExchangeKey (
   if ((Attr & EFI_VARIABLE_TIME_BASED_AUTHENTICATED_WRITE_ACCESS) != 0) {
     Status = CreateTimeBasedPayload (&DataSize, &OldData);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "Fail to create time-based data payload: %r", Status));
+      DEBUG ((DEBUG_ERROR, "Fail to create time-based data payload: %r", Status));
       goto ON_EXIT;
     }
   }
@@ -2901,7 +2901,7 @@ DeleteSignature (
   if ((Attr & EFI_VARIABLE_TIME_BASED_AUTHENTICATED_WRITE_ACCESS) != 0) {
     Status = CreateTimeBasedPayload (&DataSize, &OldData);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "Fail to create time-based data payload: %r", Status));
+      DEBUG ((DEBUG_ERROR, "Fail to create time-based data payload: %r", Status));
       goto ON_EXIT;
     }
   }

--- a/ShellPkg/DynamicCommand/DpDynamicCommand/DpUtilities.c
+++ b/ShellPkg/DynamicCommand/DpDynamicCommand/DpUtilities.c
@@ -69,7 +69,7 @@ GetDuration (
   Error = (BOOLEAN)(Duration > Measurement->EndTimeStamp);
 
   if (Error) {
-    DEBUG ((EFI_D_ERROR, ALit_TimerLibError));
+    DEBUG ((DEBUG_ERROR, ALit_TimerLibError));
     Duration = 0;
   }
   return Duration;

--- a/SourceLevelDebugPkg/Library/DebugAgent/DebugAgentCommon/DebugAgent.c
+++ b/SourceLevelDebugPkg/Library/DebugAgent/DebugAgentCommon/DebugAgent.c
@@ -283,8 +283,8 @@ VerifyMailboxChecksum (
   // and ToBeCheckSum field to validate the mail box.
   //
   if (CheckSum != Mailbox->CheckSum && CheckSum != Mailbox->ToBeCheckSum) {
-    DEBUG ((EFI_D_ERROR, "DebugAgent: Mailbox checksum error, stack or heap crashed!\n"));
-    DEBUG ((EFI_D_ERROR, "DebugAgent: CheckSum = %x, Mailbox->CheckSum = %x, Mailbox->ToBeCheckSum = %x\n", CheckSum, Mailbox->CheckSum, Mailbox->ToBeCheckSum));
+    DEBUG ((DEBUG_ERROR, "DebugAgent: Mailbox checksum error, stack or heap crashed!\n"));
+    DEBUG ((DEBUG_ERROR, "DebugAgent: CheckSum = %x, Mailbox->CheckSum = %x, Mailbox->ToBeCheckSum = %x\n", CheckSum, Mailbox->CheckSum, Mailbox->ToBeCheckSum));
     CpuDeadLoop ();
   }
 }
@@ -2637,4 +2637,3 @@ InterruptProcess (
 
   return;
 }
-

--- a/SourceLevelDebugPkg/Library/DebugAgent/DebugAgentCommon/DebugTimer.c
+++ b/SourceLevelDebugPkg/Library/DebugAgent/DebugAgentCommon/DebugTimer.c
@@ -48,10 +48,10 @@ InitializeDebugTimer (
   DisableApicTimerInterrupt ();
 
   if (DumpFlag) {
-    DEBUG ((EFI_D_INFO, "Debug Timer: FSB Clock    = %d\n", PcdGet32(PcdFSBClock)));
-    DEBUG ((EFI_D_INFO, "Debug Timer: Divisor      = %d\n", ApicTimerDivisor));
-    DEBUG ((EFI_D_INFO, "Debug Timer: Frequency    = %d\n", ApicTimerFrequency));
-    DEBUG ((EFI_D_INFO, "Debug Timer: InitialCount = %d\n", InitialCount));
+    DEBUG ((DEBUG_INFO, "Debug Timer: FSB Clock    = %d\n", PcdGet32(PcdFSBClock)));
+    DEBUG ((DEBUG_INFO, "Debug Timer: Divisor      = %d\n", ApicTimerDivisor));
+    DEBUG ((DEBUG_INFO, "Debug Timer: Frequency    = %d\n", ApicTimerFrequency));
+    DEBUG ((DEBUG_INFO, "Debug Timer: InitialCount = %d\n", InitialCount));
   }
   if (TimerFrequency != NULL) {
     *TimerFrequency = ApicTimerFrequency;
@@ -140,4 +140,3 @@ IsDebugTimerTimeout (
 
   return (BOOLEAN) (Delta >= TimeoutTicker);
 }
-

--- a/SourceLevelDebugPkg/Library/DebugAgent/DxeDebugAgent/DxeDebugAgentLib.c
+++ b/SourceLevelDebugPkg/Library/DebugAgent/DxeDebugAgent/DxeDebugAgentLib.c
@@ -73,7 +73,7 @@ InternalConstructorWorker (
     //
     Status = gBS->InstallConfigurationTable (&gEfiVectorHandoffTableGuid, (VOID *) &mVectorHandoffInfoDebugAgent[0]);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "DebugAgent: Cannot install configuration table for persisted vector handoff info!\n"));
+      DEBUG ((DEBUG_ERROR, "DebugAgent: Cannot install configuration table for persisted vector handoff info!\n"));
       CpuDeadLoop ();
     }
   }
@@ -91,7 +91,7 @@ InternalConstructorWorker (
                   &Address
                   );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "DebugAgent: Cannot install configuration table for mailbox!\n"));
+    DEBUG ((DEBUG_ERROR, "DebugAgent: Cannot install configuration table for mailbox!\n"));
     CpuDeadLoop ();
   }
 
@@ -115,7 +115,7 @@ InternalConstructorWorker (
 
   Status = gBS->InstallConfigurationTable (&gEfiDebugAgentGuid, (VOID *) mMailboxPointer);
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "DebugAgent: Failed to install configuration for mailbox!\n"));
+    DEBUG ((DEBUG_ERROR, "DebugAgent: Failed to install configuration for mailbox!\n"));
     CpuDeadLoop ();
   }
 }
@@ -402,7 +402,7 @@ InitializeDebugAgent (
     // Check if Debug Agent has been initialized before
     //
     if (IsDebugAgentInitialzed ()) {
-      DEBUG ((EFI_D_INFO, "Debug Agent: The former agent will be overwritten by the new one!\n"));
+      DEBUG ((DEBUG_INFO, "Debug Agent: The former agent will be overwritten by the new one!\n"));
     }
 
     mMultiProcessorDebugSupport = TRUE;
@@ -537,7 +537,7 @@ InitializeDebugAgent (
     // Only DEBUG_AGENT_INIT_PREMEM_SEC and DEBUG_AGENT_INIT_POSTMEM_SEC are allowed for this
     // Debug Agent library instance.
     //
-    DEBUG ((EFI_D_ERROR, "Debug Agent: The InitFlag value is not allowed!\n"));
+    DEBUG ((DEBUG_ERROR, "Debug Agent: The InitFlag value is not allowed!\n"));
     CpuDeadLoop ();
     break;
   }

--- a/SourceLevelDebugPkg/Library/DebugAgent/DxeDebugAgent/SerialIo.c
+++ b/SourceLevelDebugPkg/Library/DebugAgent/DxeDebugAgent/SerialIo.c
@@ -368,7 +368,7 @@ InstallSerialIo (
                   NULL
                   );
   if (EFI_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "Debug Agent: Failed to install EFI Serial IO Protocol on Debug Port!\n"));
+    DEBUG ((DEBUG_ERROR, "Debug Agent: Failed to install EFI Serial IO Protocol on Debug Port!\n"));
   }
 }
 

--- a/SourceLevelDebugPkg/Library/DebugAgent/SecPeiDebugAgent/SecPeiDebugAgentLib.c
+++ b/SourceLevelDebugPkg/Library/DebugAgent/SecPeiDebugAgent/SecPeiDebugAgentLib.c
@@ -411,7 +411,7 @@ InitializeDebugAgent (
     //
     // If reaches here, it means Debug Port initialization failed.
     //
-    DEBUG ((EFI_D_ERROR, "Debug Agent: Debug port initialization failed.\n"));
+    DEBUG ((DEBUG_ERROR, "Debug Agent: Debug port initialization failed.\n"));
 
     break;
 
@@ -432,7 +432,7 @@ InitializeDebugAgent (
     //
     Status = PeiServicesInstallPpi (&mVectorHandoffInfoPpiList[0]);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "DebugAgent: Failed to install Vector Handoff Info PPI!\n"));
+      DEBUG ((DEBUG_ERROR, "DebugAgent: Failed to install Vector Handoff Info PPI!\n"));
       CpuDeadLoop ();
     }
     //
@@ -464,7 +464,7 @@ InitializeDebugAgent (
                  &Address
                  );
       if (EFI_ERROR (Status)) {
-        DEBUG ((EFI_D_ERROR, "DebugAgent: Failed to allocate pages!\n"));
+        DEBUG ((DEBUG_ERROR, "DebugAgent: Failed to allocate pages!\n"));
         CpuDeadLoop ();
       }
       NewMailbox = (DEBUG_AGENT_MAILBOX *) (UINTN) Address;
@@ -494,14 +494,14 @@ InitializeDebugAgent (
 
   case DEBUG_AGENT_INIT_PEI:
     if (Context == NULL) {
-      DEBUG ((EFI_D_ERROR, "DebugAgent: Input parameter Context cannot be NULL!\n"));
+      DEBUG ((DEBUG_ERROR, "DebugAgent: Input parameter Context cannot be NULL!\n"));
       CpuDeadLoop ();
     }
     //
     // Check if Debug Agent has initialized before
     //
     if (IsDebugAgentInitialzed()) {
-      DEBUG ((EFI_D_WARN, "Debug Agent: It has already initialized in SEC Core!\n"));
+      DEBUG ((DEBUG_WARN, "Debug Agent: It has already initialized in SEC Core!\n"));
       break;
     }
     //
@@ -509,7 +509,7 @@ InitializeDebugAgent (
     //
     Status = PeiServicesInstallPpi (&mVectorHandoffInfoPpiList[0]);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "DebugAgent: Failed to install Vector Handoff Info PPI!\n"));
+      DEBUG ((DEBUG_ERROR, "DebugAgent: Failed to install Vector Handoff Info PPI!\n"));
       CpuDeadLoop ();
     }
     //
@@ -521,7 +521,7 @@ InitializeDebugAgent (
     //
     Mailbox = AllocateZeroPool (sizeof (DEBUG_AGENT_MAILBOX));
     if (Mailbox == NULL) {
-      DEBUG ((EFI_D_ERROR, "DebugAgent: Failed to allocate memory!\n"));
+      DEBUG ((DEBUG_ERROR, "DebugAgent: Failed to allocate memory!\n"));
       CpuDeadLoop ();
     } else {
       MailboxLocation = (UINT64)(UINTN)Mailbox;
@@ -550,7 +550,7 @@ InitializeDebugAgent (
     //
     Status = PeiServicesNotifyPpi (&mDebugAgentMemoryDiscoveredNotifyList[0]);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "DebugAgent: Failed to register memory discovered callback function!\n"));
+      DEBUG ((DEBUG_ERROR, "DebugAgent: Failed to register memory discovered callback function!\n"));
       CpuDeadLoop ();
     }
     //
@@ -571,7 +571,7 @@ InitializeDebugAgent (
 
   case DEBUG_AGENT_INIT_THUNK_PEI_IA32TOX64:
     if (Context == NULL) {
-      DEBUG ((EFI_D_ERROR, "DebugAgent: Input parameter Context cannot be NULL!\n"));
+      DEBUG ((DEBUG_ERROR, "DebugAgent: Input parameter Context cannot be NULL!\n"));
       CpuDeadLoop ();
     } else {
       Ia32Idtr =  (IA32_DESCRIPTOR *) Context;
@@ -604,7 +604,7 @@ InitializeDebugAgent (
     // Only DEBUG_AGENT_INIT_PREMEM_SEC and DEBUG_AGENT_INIT_POSTMEM_SEC are allowed for this
     // Debug Agent library instance.
     //
-    DEBUG ((EFI_D_ERROR, "Debug Agent: The InitFlag value is not allowed!\n"));
+    DEBUG ((DEBUG_ERROR, "Debug Agent: The InitFlag value is not allowed!\n"));
     CpuDeadLoop ();
     break;
   }

--- a/SourceLevelDebugPkg/Library/DebugAgent/SmmDebugAgent/SmmDebugAgentLib.c
+++ b/SourceLevelDebugPkg/Library/DebugAgent/SmmDebugAgent/SmmDebugAgentLib.c
@@ -203,7 +203,7 @@ InitializeDebugAgent (
                       sizeof (EFI_VECTOR_HANDOFF_INFO) * mVectorHandoffInfoCount
                       );
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "DebugAgent: Cannot install configuration table for persisted vector handoff info!\n"));
+      DEBUG ((DEBUG_ERROR, "DebugAgent: Cannot install configuration table for persisted vector handoff info!\n"));
       CpuDeadLoop ();
     }
     //
@@ -336,7 +336,7 @@ InitializeDebugAgent (
 
   case DEBUG_AGENT_INIT_THUNK_PEI_IA32TOX64:
     if (Context == NULL) {
-      DEBUG ((EFI_D_ERROR, "DebugAgent: Input parameter Context cannot be NULL!\n"));
+      DEBUG ((DEBUG_ERROR, "DebugAgent: Input parameter Context cannot be NULL!\n"));
       CpuDeadLoop ();
     } else {
       Ia32Idtr =  (IA32_DESCRIPTOR *) Context;
@@ -378,9 +378,8 @@ InitializeDebugAgent (
     // Only DEBUG_AGENT_INIT_PREMEM_SEC and DEBUG_AGENT_INIT_POSTMEM_SEC are allowed for this
     // Debug Agent library instance.
     //
-    DEBUG ((EFI_D_ERROR, "Debug Agent: The InitFlag value is not allowed!\n"));
+    DEBUG ((DEBUG_ERROR, "Debug Agent: The InitFlag value is not allowed!\n"));
     CpuDeadLoop ();
     break;
   }
 }
-

--- a/SourceLevelDebugPkg/Library/DebugCommunicationLibSerialPort/DebugCommunicationLibSerialPort.c
+++ b/SourceLevelDebugPkg/Library/DebugCommunicationLibSerialPort/DebugCommunicationLibSerialPort.c
@@ -59,7 +59,7 @@ DebugPortInitialize (
 
   Status = SerialPortInitialize ();
   if (RETURN_ERROR(Status)) {
-    DEBUG ((EFI_D_ERROR, "Debug Serial Port: Initialization failed!\n"));
+    DEBUG ((DEBUG_ERROR, "Debug Serial Port: Initialization failed!\n"));
   }
 
   if (Function != NULL) {
@@ -151,4 +151,3 @@ DebugPortPollBuffer (
 {
   return SerialPortPoll ();
 }
-

--- a/SourceLevelDebugPkg/Library/DebugCommunicationLibUsb/DebugCommunicationLibUsb.c
+++ b/SourceLevelDebugPkg/Library/DebugCommunicationLibUsb/DebugCommunicationLibUsb.c
@@ -617,7 +617,7 @@ InitializeUsbDebugHardware (
   if (((MmioRead32((UINTN)&UsbDebugPortRegister->ControlStatus) & (USB_DEBUG_PORT_OWNER | USB_DEBUG_PORT_IN_USE))
        != (USB_DEBUG_PORT_OWNER | USB_DEBUG_PORT_IN_USE)) || (Handle->Initialized == USBDBG_RESET)) {
     DEBUG ((
-      EFI_D_INFO,
+      DEBUG_INFO,
       "UsbDbg: Need to reset the host controller. ControlStatus = %08x\n",
       MmioRead32((UINTN)&UsbDebugPortRegister->ControlStatus)
       ));
@@ -625,7 +625,7 @@ InitializeUsbDebugHardware (
     // If the host controller is halted, then reset and restart it.
     //
     if ((MmioRead32((UINTN)UsbStatus) & BIT12) != 0) {
-      DEBUG ((EFI_D_INFO, "UsbDbg: Reset the host controller.\n"));
+      DEBUG ((DEBUG_INFO, "UsbDbg: Reset the host controller.\n"));
       //
       // reset the host controller.
       //
@@ -662,7 +662,7 @@ InitializeUsbDebugHardware (
 
   if (Handle->Initialized != USBDBG_INIT_DONE ||
       (MmioRead32 ((UINTN) &UsbDebugPortRegister->ControlStatus) & USB_DEBUG_PORT_ENABLE) == 0) {
-    DEBUG ((EFI_D_INFO, "UsbDbg: Reset the debug port.\n"));
+    DEBUG ((DEBUG_INFO, "UsbDbg: Reset the debug port.\n"));
     //
     // Reset the debug port
     //
@@ -1058,7 +1058,7 @@ DebugPortInitialize (
 
   Status = CalculateUsbDebugPortBar(&Handle.DebugPortOffset, &Handle.DebugPortBarNumber);
   if (RETURN_ERROR (Status)) {
-    DEBUG ((EFI_D_ERROR, "UsbDbg: the pci device pointed by PcdUsbEhciPciAddress is not EHCI host controller or does not support debug port capability!\n"));
+    DEBUG ((DEBUG_ERROR, "UsbDbg: the pci device pointed by PcdUsbEhciPciAddress is not EHCI host controller or does not support debug port capability!\n"));
     goto Exit;
   }
 
@@ -1085,10 +1085,10 @@ DebugPortInitialize (
   Handle.Initialized = USBDBG_RESET;
 
   if (NeedReinitializeHardware(&Handle)) {
-    DEBUG ((EFI_D_ERROR, "UsbDbg: Start EHCI debug port initialization!\n"));
+    DEBUG ((DEBUG_ERROR, "UsbDbg: Start EHCI debug port initialization!\n"));
     Status = InitializeUsbDebugHardware (&Handle);
     if (RETURN_ERROR(Status)) {
-      DEBUG ((EFI_D_ERROR, "UsbDbg: Failed, please check if USB debug cable is plugged into EHCI debug port correctly!\n"));
+      DEBUG ((DEBUG_ERROR, "UsbDbg: Failed, please check if USB debug cable is plugged into EHCI debug port correctly!\n"));
       goto Exit;
     }
   }
@@ -1103,4 +1103,3 @@ Exit:
 
   return (DEBUG_PORT_HANDLE)(UINTN)&mDebugCommunicationLibUsbDebugPortHandle;
 }
-

--- a/SourceLevelDebugPkg/Library/PeCoffExtraActionLibDebug/PeCoffExtraActionLib.c
+++ b/SourceLevelDebugPkg/Library/PeCoffExtraActionLibDebug/PeCoffExtraActionLib.c
@@ -64,7 +64,7 @@ PeCoffLoaderExtraActionCommon (
   ASSERT (ImageContext != NULL);
 
   if (ImageContext->PdbPointer != NULL) {
-    DEBUG((EFI_D_ERROR, "    PDB = %a\n", ImageContext->PdbPointer));
+    DEBUG((DEBUG_ERROR, "    PDB = %a\n", ImageContext->PdbPointer));
   }
 
   //

--- a/UefiCpuPkg/CpuIoPei/CpuIoPei.c
+++ b/UefiCpuPkg/CpuIoPei/CpuIoPei.c
@@ -900,7 +900,7 @@ CpuIoInitialize (
     //
     // Shadow completed and running from memory
     //
-    DEBUG ((EFI_D_INFO, "CpuIO PPI has been loaded into memory.  Reinstalled PPI=0x%x\n", &gCpuIoPpi));
+    DEBUG ((DEBUG_INFO, "CpuIO PPI has been loaded into memory.  Reinstalled PPI=0x%x\n", &gCpuIoPpi));
   } else {
     Status = PeiServicesInstallPpi (&gPpiList);
     ASSERT_EFI_ERROR (Status);

--- a/UefiCpuPkg/CpuMpPei/CpuBist.c
+++ b/UefiCpuPkg/CpuMpPei/CpuBist.c
@@ -227,7 +227,7 @@ CollectBistDataFromPpi (
       BspCpuInstance.InfoRecord.IA32HealthFlags.Uint32  = SecPlatformInformation->IA32HealthFlags.Uint32;
       CpuInstance = &BspCpuInstance;
     } else {
-      DEBUG ((EFI_D_INFO, "Does not find any stored CPU BIST information from PPI!\n"));
+      DEBUG ((DEBUG_INFO, "Does not find any stored CPU BIST information from PPI!\n"));
     }
   }
   for (ProcessorNumber = 0; ProcessorNumber < NumberOfProcessors; ProcessorNumber ++) {
@@ -250,7 +250,7 @@ CollectBistDataFromPpi (
         (EFI_COMPUTING_UNIT_HOST_PROCESSOR | EFI_CU_HP_EC_SELF_TEST)
         );
     }
-    DEBUG ((EFI_D_INFO, "  APICID - 0x%08x, BIST - 0x%08x\n",
+    DEBUG ((DEBUG_INFO, "  APICID - 0x%08x, BIST - 0x%08x\n",
             (UINT32) ProcessorInfo.ProcessorId,
             BistData
             ));
@@ -288,4 +288,3 @@ CollectBistDataFromPpi (
     ASSERT_EFI_ERROR(Status);
   }
 }
-

--- a/UefiCpuPkg/CpuS3DataDxe/CpuS3Data.c
+++ b/UefiCpuPkg/CpuS3DataDxe/CpuS3Data.c
@@ -126,7 +126,7 @@ CpuS3DataOnEndOfDxe (
                   );
   ASSERT_EFI_ERROR (Status);
 
-  DEBUG ((EFI_D_VERBOSE, "%a\n", __FUNCTION__));
+  DEBUG ((DEBUG_VERBOSE, "%a\n", __FUNCTION__));
   MtrrGetAllMtrrs (&AcpiCpuDataEx->MtrrTable);
 
   //

--- a/UefiCpuPkg/PiSmmCommunication/PiSmmCommunicationPei.c
+++ b/UefiCpuPkg/PiSmmCommunication/PiSmmCommunicationPei.c
@@ -197,8 +197,8 @@ InternalSmstGetVendorTableByGuid (
     // 32 PEI + 64 DXE
     //
     Smst64 = (EFI_SMM_SYSTEM_TABLE2_64 *)Smst;
-    DEBUG ((EFI_D_INFO, "InitCommunicationContext - SmmConfigurationTable: %x\n", Smst64->SmmConfigurationTable));
-    DEBUG ((EFI_D_INFO, "InitCommunicationContext - NumberOfTableEntries: %x\n", Smst64->NumberOfTableEntries));
+    DEBUG ((DEBUG_INFO, "InitCommunicationContext - SmmConfigurationTable: %x\n", Smst64->SmmConfigurationTable));
+    DEBUG ((DEBUG_INFO, "InitCommunicationContext - NumberOfTableEntries: %x\n", Smst64->NumberOfTableEntries));
     SmmConfigurationTable64 = (EFI_CONFIGURATION_TABLE64 *)(UINTN)Smst64->SmmConfigurationTable;
     NumberOfTableEntries = (UINTN)Smst64->NumberOfTableEntries;
     for (Index = 0; Index < NumberOfTableEntries; Index++) {
@@ -208,8 +208,8 @@ InternalSmstGetVendorTableByGuid (
     }
     return NULL;
   } else {
-    DEBUG ((EFI_D_INFO, "InitCommunicationContext - SmmConfigurationTable: %x\n", Smst->SmmConfigurationTable));
-    DEBUG ((EFI_D_INFO, "InitCommunicationContext - NumberOfTableEntries: %x\n", Smst->NumberOfTableEntries));
+    DEBUG ((DEBUG_INFO, "InitCommunicationContext - SmmConfigurationTable: %x\n", Smst->SmmConfigurationTable));
+    DEBUG ((DEBUG_INFO, "InitCommunicationContext - NumberOfTableEntries: %x\n", Smst->NumberOfTableEntries));
     SmmConfigurationTable = Smst->SmmConfigurationTable;
     NumberOfTableEntries = Smst->NumberOfTableEntries;
     for (Index = 0; Index < NumberOfTableEntries; Index++) {
@@ -239,8 +239,8 @@ InitCommunicationContext (
   SmramDescriptor = (EFI_SMRAM_DESCRIPTOR *) GET_GUID_HOB_DATA (GuidHob);
   SmmS3ResumeState = (SMM_S3_RESUME_STATE *)(UINTN)SmramDescriptor->CpuStart;
 
-  DEBUG ((EFI_D_INFO, "InitCommunicationContext - SmmS3ResumeState: %x\n", SmmS3ResumeState));
-  DEBUG ((EFI_D_INFO, "InitCommunicationContext - Smst: %x\n", SmmS3ResumeState->Smst));
+  DEBUG ((DEBUG_INFO, "InitCommunicationContext - SmmS3ResumeState: %x\n", SmmS3ResumeState));
+  DEBUG ((DEBUG_INFO, "InitCommunicationContext - Smst: %x\n", SmmS3ResumeState->Smst));
 
   SmmCommunicationContext = (EFI_SMM_COMMUNICATION_CONTEXT *)InternalSmstGetVendorTableByGuid (
                                                                SmmS3ResumeState->Signature,
@@ -283,7 +283,7 @@ Communicate (
   UINTN                            Size;
   EFI_SMM_COMMUNICATION_CONTEXT    *SmmCommunicationContext;
 
-  DEBUG ((EFI_D_INFO, "PiSmmCommunicationPei Communicate Enter\n"));
+  DEBUG ((DEBUG_INFO, "PiSmmCommunicationPei Communicate Enter\n"));
 
   if (CommBuffer == NULL) {
     return EFI_INVALID_PARAMETER;
@@ -316,18 +316,18 @@ Communicate (
   // Check SMRAM locked, it should be done after SMRAM lock.
   //
   if (!SmmAccess->LockState) {
-    DEBUG ((EFI_D_INFO, "PiSmmCommunicationPei LockState - %x\n", (UINTN)SmmAccess->LockState));
+    DEBUG ((DEBUG_INFO, "PiSmmCommunicationPei LockState - %x\n", (UINTN)SmmAccess->LockState));
     return EFI_NOT_STARTED;
   }
 
   SmmCommunicationContext = GetCommunicationContext ();
-  DEBUG ((EFI_D_INFO, "PiSmmCommunicationPei BufferPtrAddress - 0x%016lx, BufferPtr: 0x%016lx\n", SmmCommunicationContext->BufferPtrAddress, *(EFI_PHYSICAL_ADDRESS *)(UINTN)SmmCommunicationContext->BufferPtrAddress));
+  DEBUG ((DEBUG_INFO, "PiSmmCommunicationPei BufferPtrAddress - 0x%016lx, BufferPtr: 0x%016lx\n", SmmCommunicationContext->BufferPtrAddress, *(EFI_PHYSICAL_ADDRESS *)(UINTN)SmmCommunicationContext->BufferPtrAddress));
 
   //
   // No need to check if BufferPtr is 0, because it is in PEI phase.
   //
   *(EFI_PHYSICAL_ADDRESS *)(UINTN)SmmCommunicationContext->BufferPtrAddress = (EFI_PHYSICAL_ADDRESS)(UINTN)CommBuffer;
-  DEBUG ((EFI_D_INFO, "PiSmmCommunicationPei CommBuffer - %x\n", (UINTN)CommBuffer));
+  DEBUG ((DEBUG_INFO, "PiSmmCommunicationPei CommBuffer - %x\n", (UINTN)CommBuffer));
 
   //
   // Send command
@@ -349,7 +349,7 @@ Communicate (
   //
   *(EFI_PHYSICAL_ADDRESS *)(UINTN)SmmCommunicationContext->BufferPtrAddress = 0;
 
-  DEBUG ((EFI_D_INFO, "PiSmmCommunicationPei Communicate Exit\n"));
+  DEBUG ((DEBUG_INFO, "PiSmmCommunicationPei Communicate Exit\n"));
 
   return EFI_SUCCESS;
 }
@@ -394,7 +394,7 @@ PiSmmCommunicationPeiEntryPoint (
   // Check SMRAM locked, it should be done before SMRAM lock.
   //
   if (SmmAccess->LockState) {
-    DEBUG ((EFI_D_INFO, "PiSmmCommunicationPei LockState - %x\n", (UINTN)SmmAccess->LockState));
+    DEBUG ((DEBUG_INFO, "PiSmmCommunicationPei LockState - %x\n", (UINTN)SmmAccess->LockState));
     return EFI_ACCESS_DENIED;
   }
 

--- a/UefiCpuPkg/PiSmmCommunication/PiSmmCommunicationSmm.c
+++ b/UefiCpuPkg/PiSmmCommunication/PiSmmCommunicationSmm.c
@@ -71,24 +71,24 @@ PiSmmCommunicationHandler (
   EFI_SMM_COMMUNICATE_HEADER       *CommunicateHeader;
   EFI_PHYSICAL_ADDRESS             *BufferPtrAddress;
 
-  DEBUG ((EFI_D_INFO, "PiSmmCommunicationHandler Enter\n"));
+  DEBUG ((DEBUG_INFO, "PiSmmCommunicationHandler Enter\n"));
 
   BufferPtrAddress = (EFI_PHYSICAL_ADDRESS *)(UINTN)mSmmCommunicationContext.BufferPtrAddress;
   CommunicateHeader = (EFI_SMM_COMMUNICATE_HEADER *)(UINTN)*BufferPtrAddress;
-  DEBUG ((EFI_D_INFO, "PiSmmCommunicationHandler CommunicateHeader - %x\n", CommunicateHeader));
+  DEBUG ((DEBUG_INFO, "PiSmmCommunicationHandler CommunicateHeader - %x\n", CommunicateHeader));
   if (CommunicateHeader == NULL) {
-    DEBUG ((EFI_D_INFO, "PiSmmCommunicationHandler is NULL, needn't to call dispatch function\n"));
+    DEBUG ((DEBUG_INFO, "PiSmmCommunicationHandler is NULL, needn't to call dispatch function\n"));
     Status = EFI_SUCCESS;
   } else {
     if (!SmmIsBufferOutsideSmmValid ((UINTN)CommunicateHeader, OFFSET_OF (EFI_SMM_COMMUNICATE_HEADER, Data))) {
-      DEBUG ((EFI_D_INFO, "PiSmmCommunicationHandler CommunicateHeader invalid - 0x%x\n", CommunicateHeader));
+      DEBUG ((DEBUG_INFO, "PiSmmCommunicationHandler CommunicateHeader invalid - 0x%x\n", CommunicateHeader));
       Status = EFI_SUCCESS;
       goto Done;
     }
 
     CommSize = (UINTN)CommunicateHeader->MessageLength;
     if (!SmmIsBufferOutsideSmmValid ((UINTN)&CommunicateHeader->Data[0], CommSize)) {
-      DEBUG ((EFI_D_INFO, "PiSmmCommunicationHandler CommunicateData invalid - 0x%x\n", &CommunicateHeader->Data[0]));
+      DEBUG ((DEBUG_INFO, "PiSmmCommunicationHandler CommunicateData invalid - 0x%x\n", &CommunicateHeader->Data[0]));
       Status = EFI_SUCCESS;
       goto Done;
     }
@@ -96,7 +96,7 @@ PiSmmCommunicationHandler (
     //
     // Call dispatch function
     //
-    DEBUG ((EFI_D_INFO, "PiSmmCommunicationHandler Data - %x\n", &CommunicateHeader->Data[0]));
+    DEBUG ((DEBUG_INFO, "PiSmmCommunicationHandler Data - %x\n", &CommunicateHeader->Data[0]));
     Status = gSmst->SmiManage (
                       &CommunicateHeader->HeaderGuid,
                       NULL,
@@ -106,8 +106,8 @@ PiSmmCommunicationHandler (
   }
 
 Done:
-  DEBUG ((EFI_D_INFO, "PiSmmCommunicationHandler %r\n", Status));
-  DEBUG ((EFI_D_INFO, "PiSmmCommunicationHandler Exit\n"));
+  DEBUG ((DEBUG_INFO, "PiSmmCommunicationHandler %r\n", Status));
+  DEBUG ((DEBUG_INFO, "PiSmmCommunicationHandler Exit\n"));
 
   return (Status == EFI_SUCCESS) ? EFI_SUCCESS : EFI_INTERRUPT_PENDING;
 }
@@ -190,11 +190,11 @@ PiSmmCommunicationSmmEntryPoint (
                              );
   ASSERT_EFI_ERROR (Status);
 
-  DEBUG ((EFI_D_INFO, "SmmCommunication SwSmi: %x\n", (UINTN)SmmSwDispatchContext.SwSmiInputValue));
+  DEBUG ((DEBUG_INFO, "SmmCommunication SwSmi: %x\n", (UINTN)SmmSwDispatchContext.SwSmiInputValue));
 
   BufferPtrAddress = AllocateAcpiNvsMemoryBelow4G (sizeof(EFI_PHYSICAL_ADDRESS));
   ASSERT (BufferPtrAddress != NULL);
-  DEBUG ((EFI_D_INFO, "SmmCommunication BufferPtrAddress: 0x%016lx, BufferPtr: 0x%016lx\n", (EFI_PHYSICAL_ADDRESS)(UINTN)BufferPtrAddress, *BufferPtrAddress));
+  DEBUG ((DEBUG_INFO, "SmmCommunication BufferPtrAddress: 0x%016lx, BufferPtr: 0x%016lx\n", (EFI_PHYSICAL_ADDRESS)(UINTN)BufferPtrAddress, *BufferPtrAddress));
 
   //
   // Save context

--- a/UefiCpuPkg/PiSmmCpuDxeSmm/CpuS3.c
+++ b/UefiCpuPkg/PiSmmCpuDxeSmm/CpuS3.c
@@ -751,7 +751,7 @@ SmmRestoreCpu (
   IA32_IDT_GATE_DESCRIPTOR      IdtEntryTable[EXCEPTION_VECTOR_NUMBER];
   EFI_STATUS                    Status;
 
-  DEBUG ((EFI_D_INFO, "SmmRestoreCpu()\n"));
+  DEBUG ((DEBUG_INFO, "SmmRestoreCpu()\n"));
 
   mSmmS3Flag = TRUE;
 
@@ -759,7 +759,7 @@ SmmRestoreCpu (
   // See if there is enough context to resume PEI Phase
   //
   if (mSmmS3ResumeState == NULL) {
-    DEBUG ((EFI_D_ERROR, "No context to return to PEI Phase\n"));
+    DEBUG ((DEBUG_ERROR, "No context to return to PEI Phase\n"));
     CpuDeadLoop ();
   }
 
@@ -822,17 +822,17 @@ SmmRestoreCpu (
   //
   mRestoreSmmConfigurationInS3 = TRUE;
 
-  DEBUG (( EFI_D_INFO, "SMM S3 Return CS                = %x\n", SmmS3ResumeState->ReturnCs));
-  DEBUG (( EFI_D_INFO, "SMM S3 Return Entry Point       = %x\n", SmmS3ResumeState->ReturnEntryPoint));
-  DEBUG (( EFI_D_INFO, "SMM S3 Return Context1          = %x\n", SmmS3ResumeState->ReturnContext1));
-  DEBUG (( EFI_D_INFO, "SMM S3 Return Context2          = %x\n", SmmS3ResumeState->ReturnContext2));
-  DEBUG (( EFI_D_INFO, "SMM S3 Return Stack Pointer     = %x\n", SmmS3ResumeState->ReturnStackPointer));
+  DEBUG (( DEBUG_INFO, "SMM S3 Return CS                = %x\n", SmmS3ResumeState->ReturnCs));
+  DEBUG (( DEBUG_INFO, "SMM S3 Return Entry Point       = %x\n", SmmS3ResumeState->ReturnEntryPoint));
+  DEBUG (( DEBUG_INFO, "SMM S3 Return Context1          = %x\n", SmmS3ResumeState->ReturnContext1));
+  DEBUG (( DEBUG_INFO, "SMM S3 Return Context2          = %x\n", SmmS3ResumeState->ReturnContext2));
+  DEBUG (( DEBUG_INFO, "SMM S3 Return Stack Pointer     = %x\n", SmmS3ResumeState->ReturnStackPointer));
 
   //
   // If SMM is in 32-bit mode, then use SwitchStack() to resume PEI Phase
   //
   if (SmmS3ResumeState->Signature == SMM_S3_RESUME_SMM_32) {
-    DEBUG ((EFI_D_INFO, "Call SwitchStack() to return to S3 Resume in PEI Phase\n"));
+    DEBUG ((DEBUG_INFO, "Call SwitchStack() to return to S3 Resume in PEI Phase\n"));
 
     SwitchStack (
       (SWITCH_STACK_ENTRY_POINT)(UINTN)SmmS3ResumeState->ReturnEntryPoint,
@@ -846,7 +846,7 @@ SmmRestoreCpu (
   // If SMM is in 64-bit mode, then use AsmDisablePaging64() to resume PEI Phase
   //
   if (SmmS3ResumeState->Signature == SMM_S3_RESUME_SMM_64) {
-    DEBUG ((EFI_D_INFO, "Call AsmDisablePaging64() to return to S3 Resume in PEI Phase\n"));
+    DEBUG ((DEBUG_INFO, "Call AsmDisablePaging64() to return to S3 Resume in PEI Phase\n"));
     //
     // Disable interrupt of Debug timer, since new IDT table is for IA32 and will not work in long mode.
     //
@@ -867,7 +867,7 @@ SmmRestoreCpu (
   //
   // Can not resume PEI Phase
   //
-  DEBUG ((EFI_D_ERROR, "No context to return to PEI Phase\n"));
+  DEBUG ((DEBUG_ERROR, "No context to return to PEI Phase\n"));
   CpuDeadLoop ();
 }
 
@@ -904,8 +904,8 @@ InitSmmS3ResumeState (
   } else {
     SmramDescriptor = (EFI_SMRAM_DESCRIPTOR *) GET_GUID_HOB_DATA (GuidHob);
 
-    DEBUG ((EFI_D_INFO, "SMM S3 SMRAM Structure = %x\n", SmramDescriptor));
-    DEBUG ((EFI_D_INFO, "SMM S3 Structure = %x\n", SmramDescriptor->CpuStart));
+    DEBUG ((DEBUG_INFO, "SMM S3 SMRAM Structure = %x\n", SmramDescriptor));
+    DEBUG ((DEBUG_INFO, "SMM S3 Structure = %x\n", SmramDescriptor->CpuStart));
 
     SmmS3ResumeState = (SMM_S3_RESUME_STATE *)(UINTN)SmramDescriptor->CpuStart;
     ZeroMem (SmmS3ResumeState, sizeof (SMM_S3_RESUME_STATE));

--- a/UefiCpuPkg/PiSmmCpuDxeSmm/MpService.c
+++ b/UefiCpuPkg/PiSmmCpuDxeSmm/MpService.c
@@ -1788,8 +1788,8 @@ InitializeSmmCpuSemaphores (
   GlobalSemaphoresSize = (sizeof (SMM_CPU_SEMAPHORE_GLOBAL) / sizeof (VOID *)) * SemaphoreSize;
   CpuSemaphoresSize    = (sizeof (SMM_CPU_SEMAPHORE_CPU) / sizeof (VOID *)) * ProcessorCount * SemaphoreSize;
   TotalSize = GlobalSemaphoresSize + CpuSemaphoresSize;
-  DEBUG((EFI_D_INFO, "One Semaphore Size    = 0x%x\n", SemaphoreSize));
-  DEBUG((EFI_D_INFO, "Total Semaphores Size = 0x%x\n", TotalSize));
+  DEBUG((DEBUG_INFO, "One Semaphore Size    = 0x%x\n", SemaphoreSize));
+  DEBUG((DEBUG_INFO, "Total Semaphores Size = 0x%x\n", TotalSize));
   Pages = EFI_SIZE_TO_PAGES (TotalSize);
   SemaphoreBlock = AllocatePages (Pages);
   ASSERT (SemaphoreBlock != NULL);

--- a/UefiCpuPkg/PiSmmCpuDxeSmm/PiSmmCpuDxeSmm.c
+++ b/UefiCpuPkg/PiSmmCpuDxeSmm/PiSmmCpuDxeSmm.c
@@ -608,14 +608,14 @@ PiCpuSmmEntry (
   // Save the PcdCpuSmmCodeAccessCheckEnable value into a global variable.
   //
   mSmmCodeAccessCheckEnable = PcdGetBool (PcdCpuSmmCodeAccessCheckEnable);
-  DEBUG ((EFI_D_INFO, "PcdCpuSmmCodeAccessCheckEnable = %d\n", mSmmCodeAccessCheckEnable));
+  DEBUG ((DEBUG_INFO, "PcdCpuSmmCodeAccessCheckEnable = %d\n", mSmmCodeAccessCheckEnable));
 
   //
   // Save the PcdPteMemoryEncryptionAddressOrMask value into a global variable.
   // Make sure AddressEncMask is contained to smallest supported address field.
   //
   mAddressEncMask = PcdGet64 (PcdPteMemoryEncryptionAddressOrMask) & PAGING_1G_ADDRESS_MASK_64;
-  DEBUG ((EFI_D_INFO, "mAddressEncMask = 0x%lx\n", mAddressEncMask));
+  DEBUG ((DEBUG_INFO, "mAddressEncMask = 0x%lx\n", mAddressEncMask));
 
   //
   // If support CPU hot plug, we need to allocate resources for possibly hot-added processors
@@ -767,7 +767,7 @@ PiCpuSmmEntry (
   TileDataSize = ALIGN_VALUE(TileDataSize, SIZE_4KB);
   TileSize = TileDataSize + TileCodeSize - 1;
   TileSize = 2 * GetPowerOfTwo32 ((UINT32)TileSize);
-  DEBUG ((EFI_D_INFO, "SMRAM TileSize = 0x%08x (0x%08x, 0x%08x)\n", TileSize, TileCodeSize, TileDataSize));
+  DEBUG ((DEBUG_INFO, "SMRAM TileSize = 0x%08x (0x%08x, 0x%08x)\n", TileSize, TileCodeSize, TileDataSize));
 
   //
   // If the TileSize is larger than space available for the SMI Handler of
@@ -797,7 +797,7 @@ PiCpuSmmEntry (
     Buffer = AllocateAlignedCodePages (BufferPages, SIZE_4KB);
   }
   ASSERT (Buffer != NULL);
-  DEBUG ((EFI_D_INFO, "SMRAM SaveState Buffer (0x%08x, 0x%08x)\n", Buffer, EFI_PAGES_TO_SIZE(BufferPages)));
+  DEBUG ((DEBUG_INFO, "SMRAM SaveState Buffer (0x%08x, 0x%08x)\n", Buffer, EFI_PAGES_TO_SIZE(BufferPages)));
 
   //
   // Allocate buffer for pointers to array in  SMM_CPU_PRIVATE_DATA.
@@ -842,7 +842,7 @@ PiCpuSmmEntry (
       ASSERT_EFI_ERROR (Status);
       mCpuHotPlugData.ApicId[Index] = gSmmCpuPrivate->ProcessorInfo[Index].ProcessorId;
 
-      DEBUG ((EFI_D_INFO, "CPU[%03x]  APIC ID=%04x  SMBASE=%08x  SaveState=%08x  Size=%08x\n",
+      DEBUG ((DEBUG_INFO, "CPU[%03x]  APIC ID=%04x  SMBASE=%08x  SaveState=%08x  Size=%08x\n",
         Index,
         (UINT32)gSmmCpuPrivate->ProcessorInfo[Index].ProcessorId,
         mCpuHotPlugData.SmBase[Index],
@@ -1072,7 +1072,7 @@ PiCpuSmmEntry (
   GetAcpiS3EnableFlag ();
   InitSmmS3ResumeState (Cr3);
 
-  DEBUG ((EFI_D_INFO, "SMM CPU Module exit from SMRAM with EFI_SUCCESS\n"));
+  DEBUG ((DEBUG_INFO, "SMM CPU Module exit from SMRAM with EFI_SUCCESS\n"));
 
   return EFI_SUCCESS;
 }
@@ -1162,7 +1162,7 @@ FindSmramInfo (
     }
   } while (Found);
 
-  DEBUG ((EFI_D_INFO, "SMRR Base: 0x%x, SMRR Size: 0x%x\n", *SmrrBase, *SmrrSize));
+  DEBUG ((DEBUG_INFO, "SMRR Base: 0x%x, SMRR Size: 0x%x\n", *SmrrBase, *SmrrSize));
 }
 
 /**

--- a/UefiCpuPkg/PiSmmCpuDxeSmm/SmmProfile.c
+++ b/UefiCpuPkg/PiSmmCpuDxeSmm/SmmProfile.c
@@ -514,14 +514,14 @@ InitProtectedMemRange (
 
   mSplitMemRangeCount = NumberOfSpliteRange;
 
-  DEBUG ((EFI_D_INFO, "SMM Profile Memory Ranges:\n"));
+  DEBUG ((DEBUG_INFO, "SMM Profile Memory Ranges:\n"));
   for (Index = 0; Index < mProtectionMemRangeCount; Index++) {
-    DEBUG ((EFI_D_INFO, "mProtectionMemRange[%d].Base = %lx\n", Index, mProtectionMemRange[Index].Range.Base));
-    DEBUG ((EFI_D_INFO, "mProtectionMemRange[%d].Top  = %lx\n", Index, mProtectionMemRange[Index].Range.Top));
+    DEBUG ((DEBUG_INFO, "mProtectionMemRange[%d].Base = %lx\n", Index, mProtectionMemRange[Index].Range.Base));
+    DEBUG ((DEBUG_INFO, "mProtectionMemRange[%d].Top  = %lx\n", Index, mProtectionMemRange[Index].Range.Top));
   }
   for (Index = 0; Index < mSplitMemRangeCount; Index++) {
-    DEBUG ((EFI_D_INFO, "mSplitMemRange[%d].Base = %lx\n", Index, mSplitMemRange[Index].Base));
-    DEBUG ((EFI_D_INFO, "mSplitMemRange[%d].Top  = %lx\n", Index, mSplitMemRange[Index].Top));
+    DEBUG ((DEBUG_INFO, "mSplitMemRange[%d].Base = %lx\n", Index, mSplitMemRange[Index].Base));
+    DEBUG ((DEBUG_INFO, "mSplitMemRange[%d].Top  = %lx\n", Index, mSplitMemRange[Index].Top));
   }
 }
 
@@ -671,7 +671,7 @@ InitPaging (
   //
   // Go through page table and set several page table entries to absent or execute-disable.
   //
-  DEBUG ((EFI_D_INFO, "Patch page table start ...\n"));
+  DEBUG ((DEBUG_INFO, "Patch page table start ...\n"));
   for (Pml5Index = 0; Pml5Index < NumberOfPml5Entries; Pml5Index++) {
     if ((Pml5[Pml5Index] & IA32_PG_P) == 0) {
       //
@@ -760,7 +760,7 @@ InitPaging (
   // Flush TLB
   //
   CpuFlushTlb ();
-  DEBUG ((EFI_D_INFO, "Patch page table done!\n"));
+  DEBUG ((DEBUG_INFO, "Patch page table done!\n"));
   //
   // Set execute-disable flag
   //
@@ -786,7 +786,7 @@ GetSmiCommandPort (
   ASSERT (Fadt != NULL);
 
   mSmiCommandPort = Fadt->SmiCmd;
-  DEBUG ((EFI_D_INFO, "mSmiCommandPort = %x\n", mSmiCommandPort));
+  DEBUG ((DEBUG_INFO, "mSmiCommandPort = %x\n", mSmiCommandPort));
 }
 
 /**

--- a/UefiCpuPkg/Universal/Acpi/S3Resume2Pei/S3Resume.c
+++ b/UefiCpuPkg/Universal/Acpi/S3Resume2Pei/S3Resume.c
@@ -513,7 +513,7 @@ S3ResumeBootOs (
           EFI_ERROR_CODE | EFI_ERROR_MAJOR,
           (EFI_SOFTWARE_PEI_MODULE | EFI_SW_PEI_EC_S3_OS_WAKE_ERROR)
           );
-        DEBUG (( EFI_D_ERROR, "Unsupported for 32bit DXE transfer to 64bit OS waking vector!\r\n"));
+        DEBUG (( DEBUG_ERROR, "Unsupported for 32bit DXE transfer to 64bit OS waking vector!\r\n"));
         ASSERT (FALSE);
         CpuDeadLoop ();
         return ;
@@ -1136,4 +1136,3 @@ PeimS3ResumeEntryPoint (
 
   return EFI_SUCCESS;
 }
-


### PR DESCRIPTION
    REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3739

    Update all use of EFI_D_* defines in DEBUG() macros to DEBUG_* defines.

    Cc: Andrew Fish <afish@apple.com>
    Cc: Leif Lindholm <leif@nuviainc.com>
    Cc: Michael Kubacki <michael.kubacki@microsoft.com>
    Signed-off-by: Michael D Kinney <michael.d.kinney@intel.com>