### PR TITLE
.pytools/Plugin/LicenseCheck: Use temp directory for git diff output

### DIFF
--- a/.pytool/Plugin/LicenseCheck/LicenseCheck.py
+++ b/.pytool/Plugin/LicenseCheck/LicenseCheck.py
@@ -5,6 +5,7 @@
 ##
 
 import os
+import shutil
 import logging
 import re
 from io import StringIO
@@ -61,12 +62,19 @@ class LicenseCheck(ICiBuildPlugin):
     #   - Junit Logger
     #   - output_stream the StringIO output stream from this plugin via logging
     def RunBuildPlugin(self, packagename, Edk2pathObj, pkgconfig, environment, PLM, PLMHelper, tc, output_stream=None):
-        return_buffer = StringIO()
-        params = "diff --unified=0 origin/master HEAD"
-        RunCmd("git", params, outstream=return_buffer)
-        p = return_buffer.getvalue().strip()
-        patch = p.split("\n")
-        return_buffer.close()
+        # Create temp directory
+        temp_path = os.path.join(Edk2pathObj.WorkspacePath, 'Build', '.pytool', 'Plugin', 'LicenseCheck')
+        if not os.path.exists(temp_path):
+            os.makedirs(temp_path)
+        # Output file to use for git diff operations
+        temp_diff_output = os.path.join (temp_path, 'diff.txt')
+        params = "diff --output={} --unified=0 origin/master HEAD".format(temp_diff_output)
+        RunCmd("git", params)
+        with open(temp_diff_output) as file:
+            patch = file.read().strip().split("\n")
+        # Delete temp directory
+        if os.path.exists(temp_path):
+            shutil.rmtree(temp_path)
 
         ignore_files = []
         if "IgnoreFiles" in pkgconfig:


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3746

Use --output option in git diff command to remove code diffs
from build log on stdout when LicenseCheck plugin is run.
Instead, create a temp directory for the diff output file and
remove the temp directory after the diff output is processed.

Cc: Sean Brogan <sean.brogan@microsoft.com>
Cc: Bret Barkelew <Bret.Barkelew@microsoft.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Michael Kubacki <michael.kubacki@microsoft.com>
Signed-off-by: Michael D Kinney <michael.d.kinney@intel.com>