### PR TITLE
.azurepipelines/templates: Update max pipeline job time to 2 hours

### DIFF
--- a/.azurepipelines/templates/pr-gate-build-job.yml
+++ b/.azurepipelines/templates/pr-gate-build-job.yml
@@ -17,7 +17,7 @@ parameters:
 jobs:
 
 - job: Build_${{ parameters.tool_chain_tag }}
-
+  timeoutInMinutes: 120
   #Use matrix to speed up the build process
   strategy:
     matrix:


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3750

Large patches that modify a large number of files(e.g uncrustify)
take longer to process through CI checks such as ECC.  Increase
the max job time from 1 hour to 2 hours to accommodate larger patch
series.

Cc: Sean Brogan <sean.brogan@microsoft.com>
Cc: Bret Barkelew <Bret.Barkelew@microsoft.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Michael Kubacki <michael.kubacki@microsoft.com>
Signed-off-by: Michael D Kinney <michael.d.kinney@intel.com>