### PR TITLE
MdeModulePkg AtaAtapiPassThru: Skip the potential NULL pointer access

### DIFF
--- a/MdeModulePkg/Bus/Ata/AtaAtapiPassThru/AhciMode.c
+++ b/MdeModulePkg/Bus/Ata/AtaAtapiPassThru/AhciMode.c
@@ -886,6 +886,13 @@ AhciPrintStatusBlock (
   )
 {
   //
+  // Skip NULL pointer
+  //
+  if (AtaStatusBlock == NULL) {
+    return;
+  }
+
+  //
   // Only print status and error since we have all of the rest printed as
   // a part of command block print.
   //


### PR DESCRIPTION
BZ: https://bugzilla.tianocore.org/show_bug.cgi?id=3732
Recent change c9742578 exposes this potential issue.

Signed-off-by: Liming Gao <gaoliming@byosoft.com.cn>
Acked-by: Rebecca Cran <rebecca@nuviainc.com>
Reviewed-by: Hao A Wu <hao.a.wu@intel.com>