### PR TITLE
NetworkPkg: Fix invalid pointer for DNS response token on error

### DIFF
--- a/NetworkPkg/DnsDxe/DnsImpl.c
+++ b/NetworkPkg/DnsDxe/DnsImpl.c
@@ -1700,6 +1700,7 @@ ON_EXIT:
           }
 
           FreePool (Dns4TokenEntry->Token->RspData.H2AData);
+          Dns4TokenEntry->Token->RspData.H2AData = NULL;
         }
       }
     }
@@ -1731,6 +1732,7 @@ ON_EXIT:
           }
 
           FreePool (Dns6TokenEntry->Token->RspData.H2AData);
+          Dns6TokenEntry->Token->RspData.H2AData = NULL;
         }
       }
     }


### PR DESCRIPTION
Ref: https://bugzilla.tianocore.org/show_bug.cgi?id=3719

This issue is introduced by the commit 43d7e607.
Token->RspData.H2AData is de-allocated on error but it is not
set to NULL. HTTP module attempts to free again and cause assert.

Signed-off-by: Baraneedharan Anbazhagan <anbazhagan@hp.com>
Reviewed-by: Wu Jiaxin <jiaxin.wu@intel.com>