### PR TITLE
Bug3704 - MdePkg: DebugLib: Compilation fix for clang-13.

### DIFF
--- a/ArmPkg/Library/DebugPeCoffExtraActionLib/DebugPeCoffExtraActionLib.c
+++ b/ArmPkg/Library/DebugPeCoffExtraActionLib/DebugPeCoffExtraActionLib.c
@@ -71,7 +71,7 @@ PeCoffLoaderRelocateImageExtraAction (
   IN OUT PE_COFF_LOADER_IMAGE_CONTEXT  *ImageContext
   )
 {
- #if !defined (MDEPKG_NDEBUG)
+ #if defined (__CC_ARM) || defined (__GNUC__)
   CHAR8  Temp[512];
  #endif
 
@@ -111,7 +111,7 @@ PeCoffLoaderUnloadImageExtraAction (
   IN OUT PE_COFF_LOADER_IMAGE_CONTEXT  *ImageContext
   )
 {
- #if !defined (MDEPKG_NDEBUG)
+ #if defined (__CC_ARM) || defined (__GNUC__)
   CHAR8  Temp[512];
  #endif
 

--- a/ArmPkg/Library/DefaultExceptionHandlerLib/AArch64/DefaultExceptionHandler.c
+++ b/ArmPkg/Library/DefaultExceptionHandlerLib/AArch64/DefaultExceptionHandler.c
@@ -151,7 +151,6 @@ DescribeExceptionSyndrome (
   DEBUG ((DEBUG_ERROR, "\n %a \n", Message));
 }
 
-#ifndef MDEPKG_NDEBUG
 STATIC
 CONST CHAR8 *
 BaseName (
@@ -170,8 +169,6 @@ BaseName (
 
   return Str;
 }
-
-#endif
 
 /**
   This is the default action to take on an unexpected exception

--- a/MdePkg/Include/Library/DebugLib.h
+++ b/MdePkg/Include/Library/DebugLib.h
@@ -398,7 +398,12 @@ UnitTestDebugAssert (
       }                             \
     } while (FALSE)
 #else
-#define ASSERT(Expression)
+#define ASSERT(Expression)       \
+    do {                           \
+      if ((FALSE)) {               \
+        (VOID) (Expression);       \
+      }                            \
+    } while (FALSE)
 #endif
 
 /**
@@ -419,6 +424,16 @@ UnitTestDebugAssert (
       if (DebugPrintEnabled ()) {  \
         _DEBUG (Expression);       \
       }                            \
+    } while (FALSE)
+#elif defined (__GNUC__) || defined (__clang__)
+#define DEBUG(Expression)                                \
+    do {                                                   \
+      _Pragma("GCC diagnostic push")                       \
+      _Pragma("GCC diagnostic ignored \"-Wunused-value\"") \
+      if ((FALSE)) {                                       \
+        (VOID) Expression;                                 \
+      }                                                    \
+      _Pragma("GCC diagnostic pop")                        \
     } while (FALSE)
 #else
 #define DEBUG(Expression)
@@ -447,7 +462,12 @@ UnitTestDebugAssert (
       }                                                                                  \
     } while (FALSE)
 #else
-#define ASSERT_EFI_ERROR(StatusParameter)
+#define ASSERT_EFI_ERROR(StatusParameter)                                             \
+    do {                                                                                \
+      if ((FALSE)) {                                                                    \
+        (VOID) (StatusParameter);                                                       \
+      }                                                                                 \
+    } while (FALSE)
 #endif
 
 /**
@@ -474,7 +494,12 @@ UnitTestDebugAssert (
       }                                                                 \
     } while (FALSE)
 #else
-#define ASSERT_RETURN_ERROR(StatusParameter)
+#define ASSERT_RETURN_ERROR(StatusParameter)                          \
+    do {                                                                \
+      if ((FALSE)) {                                                    \
+        (VOID) (StatusParameter);                                       \
+      }                                                                 \
+    } while (FALSE)
 #endif
 
 /**


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3704

build -a X64 -t CLANG38 -b RELEASE -p OvmfPkg/OvmfPkgX64.dsc
results in
UDK/MdeModulePkg/Library/UefiBootManagerLib/BmBoot.c:1284:31:
error: variable 'Status' set but not used [-Werror,-Wunused-but-set-variable]
  EFI_STATUS                  Status;

Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Zhiguang Liu <zhiguang.liu@intel.com>
Signed-off-by: Mikhail Krichanov <krichanov@ispras.ru>