### PR TITLE
BaseTools/Brotli: update to latest brotli submodule

### DIFF
--- a/BaseTools/Source/C/BrotliCompress/GNUmakefile
+++ b/BaseTools/Source/C/BrotliCompress/GNUmakefile
@@ -10,8 +10,12 @@ APPNAME = BrotliCompress
 
 OBJECTS = \
   BrotliCompress.o \
+  brotli/c/common/constants.o \
+  brotli/c/common/context.o \
   brotli/c/common/dictionary.o \
   brotli/c/common/transform.o \
+  brotli/c/common/platform.o \
+  brotli/c/common/shared_dictionary.o \
   brotli/c/dec/bit_reader.o \
   brotli/c/dec/decode.o \
   brotli/c/dec/huffman.o \
@@ -22,12 +26,15 @@ OBJECTS = \
   brotli/c/enc/block_splitter.o \
   brotli/c/enc/brotli_bit_stream.o \
   brotli/c/enc/cluster.o \
+  brotli/c/enc/compound_dictionary.o \
   brotli/c/enc/compress_fragment.o \
   brotli/c/enc/compress_fragment_two_pass.o \
+  brotli/c/enc/command.o \
   brotli/c/enc/dictionary_hash.o \
   brotli/c/enc/encode.o \
   brotli/c/enc/encoder_dict.o \
   brotli/c/enc/entropy_encode.o \
+  brotli/c/enc/fast_log.o \
   brotli/c/enc/histogram.o \
   brotli/c/enc/literal_cost.o \
   brotli/c/enc/memory.o \

--- a/BaseTools/Source/C/BrotliCompress/Makefile
+++ b/BaseTools/Source/C/BrotliCompress/Makefile
@@ -13,7 +13,13 @@ APPNAME = BrotliCompress
 
 #LIBS = $(LIB_PATH)\Common.lib
 
-COMMON_OBJ = brotli\c\common\dictionary.obj brotli\c\common\transform.obj
+COMMON_OBJ = \
+  brotli\c\common\constants.obj \
+  brotli\c\common\context.obj \
+  brotli\c\common\dictionary.obj \
+  brotli\c\common\transform.obj \
+  brotli\c\common\platform.obj \
+  brotli\c\common\shared_dictionary.obj
 DEC_OBJ = \
   brotli\c\dec\bit_reader.obj \
   brotli\c\dec\decode.obj \
@@ -26,12 +32,15 @@ ENC_OBJ = \
   brotli\c\enc\block_splitter.obj \
   brotli\c\enc\brotli_bit_stream.obj \
   brotli\c\enc\cluster.obj \
+  brotli\c\enc\compound_dictionary.obj \
   brotli\c\enc\compress_fragment.obj \
   brotli\c\enc\compress_fragment_two_pass.obj \
+  brotli\c\enc\command.obj \
   brotli\c\enc\dictionary_hash.obj \
   brotli\c\enc\encode.obj \
   brotli\c\enc\encoder_dict.obj \
   brotli\c\enc\entropy_encode.obj \
+  brotli\c\enc\fast_log.obj \
   brotli\c\enc\histogram.obj \
   brotli\c\enc\literal_cost.obj \
   brotli\c\enc\memory.obj \


### PR DESCRIPTION
Update to the latest Brotli commit, and extend the makefiles as needed.

Specifically, this is needed for 0a3944 in brotli, to fix VLA parameter
warnings with new compilers.

Signed-off-by: Ross Burton <ross.burton@arm.com>