### PR TITLE
MdeModulePkg/DxeCorePerformanceLib:Variable Initial

### DIFF
--- a/MdeModulePkg/Library/DxeCorePerformanceLib/DxeCorePerformanceLib.c
+++ b/MdeModulePkg/Library/DxeCorePerformanceLib/DxeCorePerformanceLib.c
@@ -1373,6 +1373,8 @@ UpdateBootPerformanceTable (
   UINTN                            AppendSize;
   UINT8                            *FirmwarePerformanceTablePtr;
 
+  SmmBootRecordDataSize = 0;
+
   //
   // Get SMM performance data.
   //


### PR DESCRIPTION
SmmBootRecordDataSize is initialized in InternalGetSmmPerData,
but this function may fail. so to avoid using SmmBootRecordDataSize
without intialization, set it to 0 at first.

Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Dandan Bi <dandan.bi@intel.com>
Signed-off-by: Wenyi Xie <xiewenyi2@huawei.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>
Reviewed-by: Dandan Bi <dandan.bi@intel.com>