### PR TITLE
BaseTools: Fix for NOOPT CLANG38 compilation with clang-13

### DIFF
--- a/BaseTools/Source/C/GenFw/Elf32Convert.c
+++ b/BaseTools/Source/C/GenFw/Elf32Convert.c
@@ -779,6 +779,7 @@ WriteSections32 (
             *(UINT32 *)Targ = *(UINT32 *)Targ - SymShdr->sh_addr
               + mCoffSectionsOffset[Sym->st_shndx];
             break;
+          case R_386_PLT32:
           case R_386_PC32:
             //
             // Relative relocation: Symbol - Ip + Addend
@@ -900,6 +901,7 @@ WriteRelocations32 (
           if (mEhdr->e_machine == EM_386) {
             switch (ELF_R_TYPE(Rel->r_info)) {
             case R_386_NONE:
+            case R_386_PLT32:
             case R_386_PC32:
               //
               // No fixup entry required.
@@ -1168,5 +1170,3 @@ CleanUp32 (
     free (mCoffSectionsOffset);
   }
 }
-
-


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3715

We must treat not only R_X86_64_PLT32 as R_X86_64_PC32
(https://github.com/torvalds/linux/commit/
b21ebf2fb4cde1618915a97cc773e287ff49173e),
but also treat R_386_PLT32 relocation as R_386_PC32
(https://github.com/torvalds/linux/commit/
bb73d07148c405c293e576b40af37737faf23a6a).

Signed-off-by: Mikhail Krichanov <krichanov@ispras.ru>