### PR TITLE
BaseTools: Increase the DevicePath length for support more PCD value.

### DIFF
--- a/BaseTools/Source/C/DevicePath/DevicePath.c
+++ b/BaseTools/Source/C/DevicePath/DevicePath.c
@@ -170,7 +170,7 @@ int main(int argc, CHAR8 *argv[])
     fprintf(stderr, "Invalid option value, Device Path can't be NULL");
     return STATUS_ERROR;
   }
-  Str16 = (CHAR16 *)malloc(1024);
+  Str16 = (CHAR16 *)malloc((strlen (Str) + 1) * sizeof (CHAR16));
   if (Str16 == NULL) {
     fprintf(stderr, "Resource, memory cannot be allocated");
     return STATUS_ERROR;


### PR DESCRIPTION
Currently the PCD Value only support 13 Guid,When use more 13 pcd will cause the build tool fail,
Need calculate the required memory,then allocate it.

REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3718

Cc: Bob Feng <bob.c.feng@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Yuwei Chen <yuwei.chen@intel.com>

Signed-off-by: Xiaolu Jiang <xiaolu.jiang@intel.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>
Reviewed-by: Bob Feng <bob.c.feng@intel.com>