### PR TITLE
BaseTools/VfrCompile: Correct Bit Field Flags for numeric/one of

### DIFF
--- a/BaseTools/Source/C/VfrCompile/VfrFormPkg.h
+++ b/BaseTools/Source/C/VfrCompile/VfrFormPkg.h
@@ -1455,7 +1455,7 @@ public:
       return Ret;
     }
 
-    if (LFlags & EFI_IFR_DISPLAY) {
+    if (LFlags & EDKII_IFR_DISPLAY_BIT) {
       mOneOf->Flags = LFlags;
     } else {
       mOneOf->Flags = LFlags | EDKII_IFR_DISPLAY_UINT_DEC_BIT;

--- a/BaseTools/Source/C/VfrCompile/VfrSyntax.g
+++ b/BaseTools/Source/C/VfrCompile/VfrSyntax.g
@@ -2930,6 +2930,7 @@ vfrNumericFlags [CIfrNumeric & NObj, UINT32 LineNum] :
                                                             }
                                                             _PCATCH(NObj.SetFlags (HFlags, LFlags, IsDisplaySpecified), LineNum);
                                                           } else if ((_GET_CURRQEST_VARTINFO().mVarStoreId != EFI_VARSTORE_ID_INVALID) && (_GET_CURRQEST_VARTINFO().mIsBitVar)) {
+                                                            LFlags &= EDKII_IFR_DISPLAY_BIT;
                                                             LFlags |= (EDKII_IFR_NUMERIC_SIZE_BIT & (_GET_CURRQEST_VARSIZE()));
                                                             _PCATCH(NObj.SetFlagsForBitField (HFlags, LFlags, IsDisplaySpecified), LineNum);
                                                           }
@@ -3105,6 +3106,8 @@ vfrOneofFlagsField [CIfrOneOf & OObj, UINT32 LineNum] :
                                                             }
                                                             _PCATCH(OObj.SetFlags (HFlags, LFlags), LineNum);
                                                           } else if (_GET_CURRQEST_VARTINFO().mVarStoreId != EFI_VARSTORE_ID_INVALID) {
+                                                            LFlags &= EDKII_IFR_DISPLAY_BIT;
+                                                            LFlags |= (EDKII_IFR_NUMERIC_SIZE_BIT & (_GET_CURRQEST_VARSIZE()));
                                                             _PCATCH(OObj.SetFlagsForBitField (HFlags, LFlags), LineNum);
                                                           }
                                                        >>


### PR DESCRIPTION
REF:https://bugzilla.tianocore.org/show_bug.cgi?id=3752

Add Bit mask to numeric/one of opcode to set correctly Flags for Bit Field.
VfrSyntax.g: Set "LFlags &= EDKII_IFR_DISPLAY_BIT" before "LFlags |= (EDKII_IFR_NUMERIC_SIZE_BIT & (_GET_CURRQEST_VARSIZE()));"
VfrFormPkg.h: update "if (LFlags & EFI_IFR_DISPLAY)" with "if (LFlags & EDKII_IFR_DISPLAY_BIT)" in SetFlagsForBitField()

Cc: Bob Feng <bob.c.feng@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Yuwei Chen <yuwei.chen@intel.com>
Cc: Dandan Bi <dandan.bi@intel.com>

Signed-off-by: Long1 Huang <long1.huang@intel.com>
Reviewed-by: Dandan Bi <dandan.bi@intel.com>