### PR TITLE
Add Cloud Hypervisor support for x86

### DIFF
--- a/ArmVirtPkg/ArmVirtQemu.dsc
+++ b/ArmVirtPkg/ArmVirtQemu.dsc
@@ -543,7 +543,7 @@
   ArmVirtPkg/PlatformHasAcpiDtDxe/PlatformHasAcpiDtDxe.inf
 [Components.AARCH64]
   MdeModulePkg/Universal/Acpi/BootGraphicsResourceTableDxe/BootGraphicsResourceTableDxe.inf
-  OvmfPkg/AcpiPlatformDxe/QemuFwCfgAcpiPlatformDxe.inf {
+  OvmfPkg/AcpiPlatformDxe/AcpiPlatformDxe.inf {
     <LibraryClasses>
       NULL|OvmfPkg/Fdt/FdtPciPcdProducerLib/FdtPciPcdProducerLib.inf
   }

--- a/ArmVirtPkg/ArmVirtQemuFvMain.fdf.inc
+++ b/ArmVirtPkg/ArmVirtQemuFvMain.fdf.inc
@@ -145,7 +145,7 @@ READ_LOCK_STATUS   = TRUE
 !if $(ARCH) == AARCH64
   INF MdeModulePkg/Universal/Acpi/AcpiTableDxe/AcpiTableDxe.inf
   INF MdeModulePkg/Universal/Acpi/BootGraphicsResourceTableDxe/BootGraphicsResourceTableDxe.inf
-  INF OvmfPkg/AcpiPlatformDxe/QemuFwCfgAcpiPlatformDxe.inf
+  INF OvmfPkg/AcpiPlatformDxe/AcpiPlatformDxe.inf
 
   #
   # EBC support

--- a/ArmVirtPkg/ArmVirtQemuKernel.dsc
+++ b/ArmVirtPkg/ArmVirtQemuKernel.dsc
@@ -458,7 +458,7 @@
   ArmVirtPkg/PlatformHasAcpiDtDxe/PlatformHasAcpiDtDxe.inf
 [Components.AARCH64]
   MdeModulePkg/Universal/Acpi/BootGraphicsResourceTableDxe/BootGraphicsResourceTableDxe.inf
-  OvmfPkg/AcpiPlatformDxe/QemuFwCfgAcpiPlatformDxe.inf {
+  OvmfPkg/AcpiPlatformDxe/AcpiPlatformDxe.inf {
     <LibraryClasses>
       NULL|OvmfPkg/Fdt/FdtPciPcdProducerLib/FdtPciPcdProducerLib.inf
   }

--- a/OvmfPkg/AcpiPlatformDxe/AcpiPlatform.c
+++ b/OvmfPkg/AcpiPlatformDxe/AcpiPlatform.c
@@ -7,6 +7,8 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
+#include <OvmfPlatforms.h> // CLOUDHV_DEVICE_ID
+
 #include "AcpiPlatform.h"
 
 /**
@@ -27,7 +29,14 @@ InstallAcpiTables (
   )
 {
   EFI_STATUS  Status;
+  UINT16      HostBridgeDevId;
 
-  Status = InstallQemuFwCfgTables (AcpiTable);
+  HostBridgeDevId = PcdGet16 (PcdOvmfHostBridgePciDevId);
+  if (HostBridgeDevId == CLOUDHV_DEVICE_ID) {
+    Status = InstallCloudHvTables (AcpiTable);
+  } else {
+    Status = InstallQemuFwCfgTables (AcpiTable);
+  }
+
   return Status;
 }

--- a/OvmfPkg/AcpiPlatformDxe/AcpiPlatform.c
+++ b/OvmfPkg/AcpiPlatformDxe/AcpiPlatform.c
@@ -1,5 +1,5 @@
 /** @file
-  OVMF ACPI Platform Driver using QEMU's fw-cfg interface
+  OVMF ACPI Platform Driver
 
   Copyright (C) 2015, Red Hat, Inc.
   Copyright (c) 2008 - 2014, Intel Corporation. All rights reserved.<BR>
@@ -10,7 +10,7 @@
 #include "AcpiPlatform.h"
 
 /**
-  Effective entrypoint of QEMU fw-cfg Acpi Platform driver.
+  Effective entrypoint of Acpi Platform driver.
 
   @param  ImageHandle
   @param  SystemTable

--- a/OvmfPkg/AcpiPlatformDxe/AcpiPlatform.h
+++ b/OvmfPkg/AcpiPlatformDxe/AcpiPlatform.h
@@ -21,6 +21,12 @@ typedef struct S3_CONTEXT S3_CONTEXT;
 
 EFI_STATUS
 EFIAPI
+InstallCloudHvTables (
+  IN   EFI_ACPI_TABLE_PROTOCOL  *AcpiProtocol
+  );
+
+EFI_STATUS
+EFIAPI
 InstallQemuFwCfgTables (
   IN   EFI_ACPI_TABLE_PROTOCOL  *AcpiProtocol
   );

--- a/OvmfPkg/AcpiPlatformDxe/AcpiPlatformDxe.inf
+++ b/OvmfPkg/AcpiPlatformDxe/AcpiPlatformDxe.inf
@@ -1,5 +1,5 @@
 ## @file
-#  OVMF ACPI Platform Driver using QEMU's fw-cfg interface
+#  OVMF ACPI Platform Driver
 #
 #  Copyright (c) 2008 - 2014, Intel Corporation. All rights reserved.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -21,12 +21,12 @@
 #
 
 [Sources]
+  AcpiPlatform.c
   AcpiPlatform.h
   BootScript.c
   EntryPoint.c
   PciDecoding.c
   QemuFwCfgAcpi.c
-  QemuFwCfgAcpiPlatform.c
 
 [Packages]
   MdeModulePkg/MdeModulePkg.dec

--- a/OvmfPkg/AcpiPlatformDxe/AcpiPlatformDxe.inf
+++ b/OvmfPkg/AcpiPlatformDxe/AcpiPlatformDxe.inf
@@ -24,6 +24,7 @@
   AcpiPlatform.c
   AcpiPlatform.h
   BootScript.c
+  CloudHvAcpi.c
   EntryPoint.c
   PciDecoding.c
   QemuFwCfgAcpi.c
@@ -54,6 +55,7 @@
 
 [Pcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdPciDisableBusEnumeration
+  gUefiOvmfPkgTokenSpaceGuid.PcdOvmfHostBridgePciDevId
 
 [Depex]
   gEfiAcpiTableProtocolGuid

--- a/OvmfPkg/AcpiPlatformDxe/CloudHvAcpi.c
+++ b/OvmfPkg/AcpiPlatformDxe/CloudHvAcpi.c
@@ -1,0 +1,118 @@
+/** @file
+  OVMF ACPI Cloud Hypervisor support
+
+  Copyright (c) 2021, Intel Corporation. All rights reserved.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <IndustryStandard/CloudHv.h> // CLOUDHV_RSDP_ADDRESS
+#include <Library/BaseLib.h>          // CpuDeadLoop()
+#include <Library/DebugLib.h>         // DEBUG()
+
+#include "AcpiPlatform.h"
+
+// Get the ACPI tables from EBDA start
+EFI_STATUS
+EFIAPI
+InstallCloudHvTables (
+  IN   EFI_ACPI_TABLE_PROTOCOL  *AcpiProtocol
+  )
+{
+  EFI_STATUS  Status;
+  UINTN       TableHandle;
+
+  EFI_ACPI_DESCRIPTION_HEADER                *Xsdt;
+  VOID                                       *CurrentTableEntry;
+  UINTN                                      CurrentTablePointer;
+  EFI_ACPI_DESCRIPTION_HEADER                *CurrentTable;
+  UINTN                                      Index;
+  UINTN                                      NumberOfTableEntries;
+  EFI_ACPI_2_0_FIXED_ACPI_DESCRIPTION_TABLE  *Fadt2Table;
+  EFI_ACPI_DESCRIPTION_HEADER                *DsdtTable;
+
+  Fadt2Table           = NULL;
+  DsdtTable            = NULL;
+  TableHandle          = 0;
+  NumberOfTableEntries = 0;
+  EFI_ACPI_2_0_ROOT_SYSTEM_DESCRIPTION_POINTER  *AcpiRsdpStructurePtr = (VOID *)CLOUDHV_RSDP_ADDRESS;
+
+  // If XSDT table is found, just install its tables.
+  // Otherwise, try to find and install the RSDT tables.
+  //
+  if (AcpiRsdpStructurePtr->XsdtAddress) {
+    //
+    // Retrieve the addresses of XSDT and
+    // calculate the number of its table entries.
+    //
+    Xsdt = (EFI_ACPI_DESCRIPTION_HEADER *)(UINTN)
+           AcpiRsdpStructurePtr->XsdtAddress;
+    NumberOfTableEntries = (Xsdt->Length -
+                            sizeof (EFI_ACPI_DESCRIPTION_HEADER)) /
+                           sizeof (UINT64);
+
+    //
+    // Install ACPI tables found in XSDT.
+    //
+    for (Index = 0; Index < NumberOfTableEntries; Index++) {
+      //
+      // Get the table entry from XSDT
+      //
+      CurrentTableEntry = (VOID *)((UINT8 *)Xsdt +
+                                   sizeof (EFI_ACPI_DESCRIPTION_HEADER) +
+                                   Index * sizeof (UINT64));
+      CurrentTablePointer = (UINTN)*(UINT64 *)CurrentTableEntry;
+      CurrentTable        = (EFI_ACPI_DESCRIPTION_HEADER *)CurrentTablePointer;
+
+      //
+      // Install the XSDT tables
+      //
+      Status = AcpiProtocol->InstallAcpiTable (
+                               AcpiProtocol,
+                               CurrentTable,
+                               CurrentTable->Length,
+                               &TableHandle
+                               );
+
+      if (EFI_ERROR (Status)) {
+        ASSERT_EFI_ERROR (Status);
+        return Status;
+      }
+
+      //
+      // Get the X-DSDT table address from the table FADT
+      //
+      if (!AsciiStrnCmp ((CHAR8 *)&CurrentTable->Signature, "FACP", 4)) {
+        Fadt2Table = (EFI_ACPI_2_0_FIXED_ACPI_DESCRIPTION_TABLE *)
+                     (UINTN)CurrentTablePointer;
+        DsdtTable = (EFI_ACPI_DESCRIPTION_HEADER *)(UINTN)Fadt2Table->XDsdt;
+      }
+    }
+  } else {
+    return EFI_NOT_FOUND;
+  }
+
+  //
+  // Install DSDT table. If we reached this point without finding the DSDT,
+  // then we're out of sync with the hypervisor, and cannot continue.
+  //
+  if (DsdtTable == NULL) {
+    DEBUG ((DEBUG_ERROR, "%a: no DSDT found\n", __FUNCTION__));
+    ASSERT (FALSE);
+    CpuDeadLoop ();
+  }
+
+  Status = AcpiProtocol->InstallAcpiTable (
+                           AcpiProtocol,
+                           DsdtTable,
+                           DsdtTable->Length,
+                           &TableHandle
+                           );
+  if (EFI_ERROR (Status)) {
+    ASSERT_EFI_ERROR (Status);
+    return Status;
+  }
+
+  return EFI_SUCCESS;
+}

--- a/OvmfPkg/AmdSev/AmdSevX64.dsc
+++ b/OvmfPkg/AmdSev/AmdSevX64.dsc
@@ -775,7 +775,7 @@
   # ACPI Support
   #
   MdeModulePkg/Universal/Acpi/AcpiTableDxe/AcpiTableDxe.inf
-  OvmfPkg/AcpiPlatformDxe/QemuFwCfgAcpiPlatformDxe.inf
+  OvmfPkg/AcpiPlatformDxe/AcpiPlatformDxe.inf
   MdeModulePkg/Universal/Acpi/BootGraphicsResourceTableDxe/BootGraphicsResourceTableDxe.inf
 
   #

--- a/OvmfPkg/AmdSev/AmdSevX64.fdf
+++ b/OvmfPkg/AmdSev/AmdSevX64.fdf
@@ -270,7 +270,7 @@ INF  MdeModulePkg/Universal/SmbiosDxe/SmbiosDxe.inf
 INF  OvmfPkg/SmbiosPlatformDxe/SmbiosPlatformDxe.inf
 
 INF  MdeModulePkg/Universal/Acpi/AcpiTableDxe/AcpiTableDxe.inf
-INF  OvmfPkg/AcpiPlatformDxe/QemuFwCfgAcpiPlatformDxe.inf
+INF  OvmfPkg/AcpiPlatformDxe/AcpiPlatformDxe.inf
 INF  MdeModulePkg/Universal/Acpi/BootGraphicsResourceTableDxe/BootGraphicsResourceTableDxe.inf
 
 INF  FatPkg/EnhancedFatDxe/Fat.inf

--- a/OvmfPkg/Include/IndustryStandard/CloudHv.h
+++ b/OvmfPkg/Include/IndustryStandard/CloudHv.h
@@ -38,4 +38,9 @@
 //
 #define CLOUDHV_SMBIOS_ADDRESS  0xf0000
 
+//
+// RSDP address
+//
+#define CLOUDHV_RSDP_ADDRESS  0xa0000
+
 #endif // __CLOUDHV_H__

--- a/OvmfPkg/Include/IndustryStandard/CloudHv.h
+++ b/OvmfPkg/Include/IndustryStandard/CloudHv.h
@@ -33,4 +33,9 @@
 //
 #define CLOUDHV_MMIO_HOLE_SIZE  0x38000000
 
+//
+// SMBIOS address
+//
+#define CLOUDHV_SMBIOS_ADDRESS  0xf0000
+
 #endif // __CLOUDHV_H__

--- a/OvmfPkg/Include/IndustryStandard/CloudHv.h
+++ b/OvmfPkg/Include/IndustryStandard/CloudHv.h
@@ -1,0 +1,36 @@
+/** @file
+  Various defines related to Cloud Hypervisor
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef __CLOUDHV_H__
+#define __CLOUDHV_H__
+
+//
+// Host Bridge Device ID
+//
+#define CLOUDHV_DEVICE_ID  0x0d57
+
+//
+// ACPI timer address
+//
+#define CLOUDHV_ACPI_TIMER_IO_ADDRESS  0xb008
+
+//
+// ACPI shutdown device address
+//
+#define CLOUDHV_ACPI_SHUTDOWN_IO_ADDRESS  0x03c0
+
+//
+// 32-bit MMIO memory hole base address
+//
+#define CLOUDHV_MMIO_HOLE_ADDRESS  0xc0000000
+
+//
+// 32-bit MMIO memory hole size
+//
+#define CLOUDHV_MMIO_HOLE_SIZE  0x38000000
+
+#endif // __CLOUDHV_H__

--- a/OvmfPkg/Include/OvmfPlatforms.h
+++ b/OvmfPkg/Include/OvmfPlatforms.h
@@ -16,6 +16,7 @@
 #include <IndustryStandard/I440FxPiix4.h>
 #include <IndustryStandard/Bhyve.h>
 #include <IndustryStandard/Microvm.h>
+#include <IndustryStandard/CloudHv.h>
 
 //
 // OVMF Host Bridge DID Address

--- a/OvmfPkg/Library/AcpiTimerLib/BaseAcpiTimerLib.c
+++ b/OvmfPkg/Library/AcpiTimerLib/BaseAcpiTimerLib.c
@@ -55,6 +55,9 @@ AcpiTimerLibConstructor (
       AcpiCtlReg = POWER_MGMT_REGISTER_Q35 (ICH9_ACPI_CNTL);
       AcpiEnBit  = ICH9_ACPI_CNTL_ACPI_EN;
       break;
+    case CLOUDHV_DEVICE_ID:
+      mAcpiTimerIoAddr =  CLOUDHV_ACPI_TIMER_IO_ADDRESS;
+      return RETURN_SUCCESS;
     default:
       DEBUG ((
         DEBUG_ERROR,

--- a/OvmfPkg/Library/AcpiTimerLib/BaseRomAcpiTimerLib.c
+++ b/OvmfPkg/Library/AcpiTimerLib/BaseRomAcpiTimerLib.c
@@ -53,6 +53,8 @@ AcpiTimerLibConstructor (
       AcpiCtlReg = POWER_MGMT_REGISTER_Q35 (ICH9_ACPI_CNTL);
       AcpiEnBit  = ICH9_ACPI_CNTL_ACPI_EN;
       break;
+    case CLOUDHV_DEVICE_ID:
+      return RETURN_SUCCESS;
     default:
       DEBUG ((
         DEBUG_ERROR,
@@ -111,6 +113,8 @@ InternalAcpiGetTimerTick (
     case INTEL_Q35_MCH_DEVICE_ID:
       Pmba = POWER_MGMT_REGISTER_Q35 (ICH9_PMBASE);
       break;
+    case CLOUDHV_DEVICE_ID:
+      return IoRead32 (CLOUDHV_ACPI_TIMER_IO_ADDRESS);
     default:
       DEBUG ((
         DEBUG_ERROR,

--- a/OvmfPkg/Library/AcpiTimerLib/DxeAcpiTimerLib.c
+++ b/OvmfPkg/Library/AcpiTimerLib/DxeAcpiTimerLib.c
@@ -50,6 +50,9 @@ AcpiTimerLibConstructor (
     case INTEL_Q35_MCH_DEVICE_ID:
       Pmba = POWER_MGMT_REGISTER_Q35 (ICH9_PMBASE);
       break;
+    case CLOUDHV_DEVICE_ID:
+      mAcpiTimerIoAddr = CLOUDHV_ACPI_TIMER_IO_ADDRESS;
+      return RETURN_SUCCESS;
     default:
       DEBUG ((
         DEBUG_ERROR,

--- a/OvmfPkg/Library/PlatformBootManagerLib/BdsPlatform.c
+++ b/OvmfPkg/Library/PlatformBootManagerLib/BdsPlatform.c
@@ -1390,6 +1390,7 @@ PciAcpiInitialization (
       PciWrite8 (PCI_LIB_ADDRESS (0, 0x1f, 0, 0x6b), PciHostIrqs[3]); // H
       break;
     case MICROVM_PSEUDO_DEVICE_ID:
+    case CLOUDHV_DEVICE_ID:
       return;
     default:
       if (XenDetected ()) {

--- a/OvmfPkg/Library/ResetSystemLib/BaseResetShutdown.c
+++ b/OvmfPkg/Library/ResetSystemLib/BaseResetShutdown.c
@@ -40,6 +40,9 @@ ResetShutdown (
     case INTEL_Q35_MCH_DEVICE_ID:
       AcpiPmBaseAddress = ICH9_PMBASE_VALUE;
       break;
+    case CLOUDHV_DEVICE_ID:
+      IoWrite8 (CLOUDHV_ACPI_SHUTDOWN_IO_ADDRESS, 5 << 2 | 1 << 5);
+      CpuDeadLoop ();
     default:
       ASSERT (FALSE);
       CpuDeadLoop ();

--- a/OvmfPkg/Library/ResetSystemLib/DxeResetShutdown.c
+++ b/OvmfPkg/Library/ResetSystemLib/DxeResetShutdown.c
@@ -16,6 +16,7 @@
 #include <OvmfPlatforms.h>          // PIIX4_PMBA_VALUE
 
 STATIC UINT16  mAcpiPmBaseAddress;
+STATIC UINT16  mAcpiHwReducedSleepCtl;
 
 EFI_STATUS
 EFIAPI
@@ -33,6 +34,9 @@ DxeResetInit (
       break;
     case INTEL_Q35_MCH_DEVICE_ID:
       mAcpiPmBaseAddress = ICH9_PMBASE_VALUE;
+      break;
+    case CLOUDHV_DEVICE_ID:
+      mAcpiHwReducedSleepCtl = CLOUDHV_ACPI_SHUTDOWN_IO_ADDRESS;
       break;
     default:
       ASSERT (FALSE);
@@ -56,7 +60,12 @@ ResetShutdown (
   VOID
   )
 {
-  IoBitFieldWrite16 (mAcpiPmBaseAddress + 4, 10, 13, 0);
-  IoOr16 (mAcpiPmBaseAddress + 4, BIT13);
+  if (mAcpiHwReducedSleepCtl) {
+    IoWrite8 (mAcpiHwReducedSleepCtl, 5 << 2 | 1 << 5);
+  } else {
+    IoBitFieldWrite16 (mAcpiPmBaseAddress + 4, 10, 13, 0);
+    IoOr16 (mAcpiPmBaseAddress + 4, BIT13);
+  }
+
   CpuDeadLoop ();
 }

--- a/OvmfPkg/Microvm/MicrovmX64.dsc
+++ b/OvmfPkg/Microvm/MicrovmX64.dsc
@@ -750,7 +750,7 @@
   # ACPI Support
   #
   MdeModulePkg/Universal/Acpi/AcpiTableDxe/AcpiTableDxe.inf
-  OvmfPkg/AcpiPlatformDxe/QemuFwCfgAcpiPlatformDxe.inf
+  OvmfPkg/AcpiPlatformDxe/AcpiPlatformDxe.inf
   MdeModulePkg/Universal/Acpi/S3SaveStateDxe/S3SaveStateDxe.inf
   MdeModulePkg/Universal/Acpi/BootScriptExecutorDxe/BootScriptExecutorDxe.inf
   MdeModulePkg/Universal/Acpi/BootGraphicsResourceTableDxe/BootGraphicsResourceTableDxe.inf

--- a/OvmfPkg/Microvm/MicrovmX64.fdf
+++ b/OvmfPkg/Microvm/MicrovmX64.fdf
@@ -267,7 +267,7 @@ INF  MdeModulePkg/Universal/SmbiosDxe/SmbiosDxe.inf
 INF  OvmfPkg/SmbiosPlatformDxe/SmbiosPlatformDxe.inf
 
 INF  MdeModulePkg/Universal/Acpi/AcpiTableDxe/AcpiTableDxe.inf
-INF  OvmfPkg/AcpiPlatformDxe/QemuFwCfgAcpiPlatformDxe.inf
+INF  OvmfPkg/AcpiPlatformDxe/AcpiPlatformDxe.inf
 INF  MdeModulePkg/Universal/Acpi/S3SaveStateDxe/S3SaveStateDxe.inf
 INF  MdeModulePkg/Universal/Acpi/BootScriptExecutorDxe/BootScriptExecutorDxe.inf
 INF  MdeModulePkg/Universal/Acpi/BootGraphicsResourceTableDxe/BootGraphicsResourceTableDxe.inf

--- a/OvmfPkg/OvmfPkgIa32.dsc
+++ b/OvmfPkg/OvmfPkgIa32.dsc
@@ -873,7 +873,7 @@
   # ACPI Support
   #
   MdeModulePkg/Universal/Acpi/AcpiTableDxe/AcpiTableDxe.inf
-  OvmfPkg/AcpiPlatformDxe/QemuFwCfgAcpiPlatformDxe.inf
+  OvmfPkg/AcpiPlatformDxe/AcpiPlatformDxe.inf
   MdeModulePkg/Universal/Acpi/S3SaveStateDxe/S3SaveStateDxe.inf
   MdeModulePkg/Universal/Acpi/BootScriptExecutorDxe/BootScriptExecutorDxe.inf
   MdeModulePkg/Universal/Acpi/BootGraphicsResourceTableDxe/BootGraphicsResourceTableDxe.inf

--- a/OvmfPkg/OvmfPkgIa32.fdf
+++ b/OvmfPkg/OvmfPkgIa32.fdf
@@ -280,7 +280,7 @@ INF  MdeModulePkg/Universal/SmbiosDxe/SmbiosDxe.inf
 INF  OvmfPkg/SmbiosPlatformDxe/SmbiosPlatformDxe.inf
 
 INF  MdeModulePkg/Universal/Acpi/AcpiTableDxe/AcpiTableDxe.inf
-INF  OvmfPkg/AcpiPlatformDxe/QemuFwCfgAcpiPlatformDxe.inf
+INF  OvmfPkg/AcpiPlatformDxe/AcpiPlatformDxe.inf
 INF  MdeModulePkg/Universal/Acpi/S3SaveStateDxe/S3SaveStateDxe.inf
 INF  MdeModulePkg/Universal/Acpi/BootScriptExecutorDxe/BootScriptExecutorDxe.inf
 INF  MdeModulePkg/Universal/Acpi/BootGraphicsResourceTableDxe/BootGraphicsResourceTableDxe.inf

--- a/OvmfPkg/OvmfPkgIa32X64.dsc
+++ b/OvmfPkg/OvmfPkgIa32X64.dsc
@@ -887,7 +887,7 @@
   # ACPI Support
   #
   MdeModulePkg/Universal/Acpi/AcpiTableDxe/AcpiTableDxe.inf
-  OvmfPkg/AcpiPlatformDxe/QemuFwCfgAcpiPlatformDxe.inf
+  OvmfPkg/AcpiPlatformDxe/AcpiPlatformDxe.inf
   MdeModulePkg/Universal/Acpi/S3SaveStateDxe/S3SaveStateDxe.inf
   MdeModulePkg/Universal/Acpi/BootScriptExecutorDxe/BootScriptExecutorDxe.inf
   MdeModulePkg/Universal/Acpi/BootGraphicsResourceTableDxe/BootGraphicsResourceTableDxe.inf

--- a/OvmfPkg/OvmfPkgIa32X64.fdf
+++ b/OvmfPkg/OvmfPkgIa32X64.fdf
@@ -284,7 +284,7 @@ INF  MdeModulePkg/Universal/SmbiosDxe/SmbiosDxe.inf
 INF  OvmfPkg/SmbiosPlatformDxe/SmbiosPlatformDxe.inf
 
 INF  MdeModulePkg/Universal/Acpi/AcpiTableDxe/AcpiTableDxe.inf
-INF  OvmfPkg/AcpiPlatformDxe/QemuFwCfgAcpiPlatformDxe.inf
+INF  OvmfPkg/AcpiPlatformDxe/AcpiPlatformDxe.inf
 INF  MdeModulePkg/Universal/Acpi/S3SaveStateDxe/S3SaveStateDxe.inf
 INF  MdeModulePkg/Universal/Acpi/BootScriptExecutorDxe/BootScriptExecutorDxe.inf
 INF  MdeModulePkg/Universal/Acpi/BootGraphicsResourceTableDxe/BootGraphicsResourceTableDxe.inf

--- a/OvmfPkg/OvmfPkgX64.dsc
+++ b/OvmfPkg/OvmfPkgX64.dsc
@@ -884,7 +884,7 @@
   # ACPI Support
   #
   MdeModulePkg/Universal/Acpi/AcpiTableDxe/AcpiTableDxe.inf
-  OvmfPkg/AcpiPlatformDxe/QemuFwCfgAcpiPlatformDxe.inf
+  OvmfPkg/AcpiPlatformDxe/AcpiPlatformDxe.inf
   MdeModulePkg/Universal/Acpi/S3SaveStateDxe/S3SaveStateDxe.inf
   MdeModulePkg/Universal/Acpi/BootScriptExecutorDxe/BootScriptExecutorDxe.inf
   MdeModulePkg/Universal/Acpi/BootGraphicsResourceTableDxe/BootGraphicsResourceTableDxe.inf

--- a/OvmfPkg/OvmfPkgX64.fdf
+++ b/OvmfPkg/OvmfPkgX64.fdf
@@ -306,7 +306,7 @@ INF  MdeModulePkg/Universal/SmbiosDxe/SmbiosDxe.inf
 INF  OvmfPkg/SmbiosPlatformDxe/SmbiosPlatformDxe.inf
 
 INF  MdeModulePkg/Universal/Acpi/AcpiTableDxe/AcpiTableDxe.inf
-INF  OvmfPkg/AcpiPlatformDxe/QemuFwCfgAcpiPlatformDxe.inf
+INF  OvmfPkg/AcpiPlatformDxe/AcpiPlatformDxe.inf
 INF  MdeModulePkg/Universal/Acpi/S3SaveStateDxe/S3SaveStateDxe.inf
 INF  MdeModulePkg/Universal/Acpi/BootScriptExecutorDxe/BootScriptExecutorDxe.inf
 INF  MdeModulePkg/Universal/Acpi/BootGraphicsResourceTableDxe/BootGraphicsResourceTableDxe.inf

--- a/OvmfPkg/PlatformPei/MemDetect.c
+++ b/OvmfPkg/PlatformPei/MemDetect.c
@@ -16,6 +16,7 @@ Module Name:
 #include <IndustryStandard/E820.h>
 #include <IndustryStandard/I440FxPiix4.h>
 #include <IndustryStandard/Q35MchIch9.h>
+#include <IndustryStandard/CloudHv.h>
 #include <PiPei.h>
 #include <Register/Intel/SmramSaveStateMap.h>
 
@@ -156,6 +157,12 @@ QemuUc32BaseInitialization (
     //
     ASSERT (FixedPcdGet64 (PcdPciExpressBaseAddress) <= MAX_UINT32);
     mQemuUc32Base = (UINT32)FixedPcdGet64 (PcdPciExpressBaseAddress);
+    return;
+  }
+
+  if (mHostBridgeDevId == CLOUDHV_DEVICE_ID) {
+    Uc32Size      = CLOUDHV_MMIO_HOLE_SIZE;
+    mQemuUc32Base = CLOUDHV_MMIO_HOLE_ADDRESS;
     return;
   }
 
@@ -819,7 +826,7 @@ QemuInitializeRam (
   // practically any alignment, and we may not have enough variable MTRRs to
   // cover it exactly.
   //
-  if (IsMtrrSupported ()) {
+  if (IsMtrrSupported () && (mHostBridgeDevId != CLOUDHV_DEVICE_ID)) {
     MtrrGetAllMtrrs (&MtrrSettings);
 
     //

--- a/OvmfPkg/PlatformPei/Platform.c
+++ b/OvmfPkg/PlatformPei/Platform.c
@@ -374,6 +374,14 @@ MiscInitialization (
                     );
       ASSERT_RETURN_ERROR (PcdStatus);
       return;
+    case CLOUDHV_DEVICE_ID:
+      DEBUG ((DEBUG_INFO, "%a: Cloud Hypervisor host bridge\n", __FUNCTION__));
+      PcdStatus = PcdSet16S (
+                    PcdOvmfHostBridgePciDevId,
+                    CLOUDHV_DEVICE_ID
+                    );
+      ASSERT_RETURN_ERROR (PcdStatus);
+      return;
     default:
       DEBUG ((
         DEBUG_ERROR,

--- a/OvmfPkg/SmbiosPlatformDxe/CloudHv.c
+++ b/OvmfPkg/SmbiosPlatformDxe/CloudHv.c
@@ -1,0 +1,33 @@
+/** @file
+  Find Cloud Hypervisor SMBIOS data.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <IndustryStandard/CloudHv.h> // CLOUDHV_SMBIOS_ADDRESS
+#include <IndustryStandard/SmBios.h>  // SMBIOS_TABLE_3_0_ENTRY_POINT
+
+/**
+  Locates and extracts Cloud Hypervisor SMBIOS data
+
+  @return                 Address of extracted Cloud Hypervisor SMBIOS data
+
+**/
+UINT8 *
+GetCloudHvSmbiosTables (
+  VOID
+  )
+{
+  SMBIOS_TABLE_3_0_ENTRY_POINT  *CloudHvTables = (VOID *)CLOUDHV_SMBIOS_ADDRESS;
+
+  if ((CloudHvTables->AnchorString[0] == '_') &&
+      (CloudHvTables->AnchorString[1] == 'S') &&
+      (CloudHvTables->AnchorString[2] == 'M') &&
+      (CloudHvTables->AnchorString[3] == '3') &&
+      (CloudHvTables->AnchorString[4] == '_'))
+  {
+    return (UINT8 *)(UINTN)CloudHvTables->TableAddress;
+  }
+
+  return NULL;
+}

--- a/OvmfPkg/SmbiosPlatformDxe/EntryPoint.c
+++ b/OvmfPkg/SmbiosPlatformDxe/EntryPoint.c
@@ -5,6 +5,7 @@
 **/
 
 #include <Library/MemoryAllocationLib.h> // FreePool()
+#include <OvmfPlatforms.h>               // CLOUDHV_DEVICE_ID
 
 #include "SmbiosPlatformDxe.h"
 
@@ -27,15 +28,24 @@ SmbiosTablePublishEntry (
 {
   EFI_STATUS  Status;
   UINT8       *SmbiosTables;
+  UINT16      HostBridgeDevId;
 
   Status = EFI_NOT_FOUND;
   //
-  // Add QEMU SMBIOS data if found
+  // Add SMBIOS data if found
   //
-  SmbiosTables = GetQemuSmbiosTables ();
-  if (SmbiosTables != NULL) {
-    Status = InstallAllStructures (SmbiosTables);
-    FreePool (SmbiosTables);
+  HostBridgeDevId = PcdGet16 (PcdOvmfHostBridgePciDevId);
+  if (HostBridgeDevId == CLOUDHV_DEVICE_ID) {
+    SmbiosTables = GetCloudHvSmbiosTables ();
+    if (SmbiosTables != NULL) {
+      Status = InstallAllStructures (SmbiosTables);
+    }
+  } else {
+    SmbiosTables = GetQemuSmbiosTables ();
+    if (SmbiosTables != NULL) {
+      Status = InstallAllStructures (SmbiosTables);
+      FreePool (SmbiosTables);
+    }
   }
 
   return Status;

--- a/OvmfPkg/SmbiosPlatformDxe/EntryPoint.c
+++ b/OvmfPkg/SmbiosPlatformDxe/EntryPoint.c
@@ -1,0 +1,42 @@
+/** @file
+  Find and extract SMBIOS data.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <Library/MemoryAllocationLib.h> // FreePool()
+
+#include "SmbiosPlatformDxe.h"
+
+/**
+  Installs SMBIOS information for OVMF
+
+  @param ImageHandle     Module's image handle
+  @param SystemTable     Pointer of EFI_SYSTEM_TABLE
+
+  @retval EFI_SUCCESS    Smbios data successfully installed
+  @retval Other          Smbios data was not installed
+
+**/
+EFI_STATUS
+EFIAPI
+SmbiosTablePublishEntry (
+  IN EFI_HANDLE        ImageHandle,
+  IN EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  EFI_STATUS  Status;
+  UINT8       *SmbiosTables;
+
+  Status = EFI_NOT_FOUND;
+  //
+  // Add QEMU SMBIOS data if found
+  //
+  SmbiosTables = GetQemuSmbiosTables ();
+  if (SmbiosTables != NULL) {
+    Status = InstallAllStructures (SmbiosTables);
+    FreePool (SmbiosTables);
+  }
+
+  return Status;
+}

--- a/OvmfPkg/SmbiosPlatformDxe/Qemu.c
+++ b/OvmfPkg/SmbiosPlatformDxe/Qemu.c
@@ -11,8 +11,6 @@
 #include <Library/PcdLib.h>              // PcdGetBool()
 #include <Library/QemuFwCfgLib.h>        // QemuFwCfgFindFile()
 
-#include "SmbiosPlatformDxe.h"
-
 /**
   Locates and extracts the QEMU SMBIOS data if present in fw_cfg
 
@@ -50,37 +48,4 @@ GetQemuSmbiosTables (
   QemuFwCfgReadBytes (TablesSize, QemuTables);
 
   return QemuTables;
-}
-
-/**
-  Installs SMBIOS information for OVMF
-
-  @param ImageHandle     Module's image handle
-  @param SystemTable     Pointer of EFI_SYSTEM_TABLE
-
-  @retval EFI_SUCCESS    Smbios data successfully installed
-  @retval Other          Smbios data was not installed
-
-**/
-EFI_STATUS
-EFIAPI
-SmbiosTablePublishEntry (
-  IN EFI_HANDLE        ImageHandle,
-  IN EFI_SYSTEM_TABLE  *SystemTable
-  )
-{
-  EFI_STATUS  Status;
-  UINT8       *SmbiosTables;
-
-  Status = EFI_NOT_FOUND;
-  //
-  // Add QEMU SMBIOS data if found
-  //
-  SmbiosTables = GetQemuSmbiosTables ();
-  if (SmbiosTables != NULL) {
-    Status = InstallAllStructures (SmbiosTables);
-    FreePool (SmbiosTables);
-  }
-
-  return Status;
 }

--- a/OvmfPkg/SmbiosPlatformDxe/SmbiosPlatformDxe.h
+++ b/OvmfPkg/SmbiosPlatformDxe/SmbiosPlatformDxe.h
@@ -22,4 +22,15 @@ InstallAllStructures (
   IN UINT8  *TableAddress
   );
 
+/**
+  Locates and extracts the QEMU SMBIOS data if present in fw_cfg
+
+  @return                 Address of extracted QEMU SMBIOS data
+
+**/
+UINT8 *
+GetQemuSmbiosTables (
+  VOID
+  );
+
 #endif

--- a/OvmfPkg/SmbiosPlatformDxe/SmbiosPlatformDxe.h
+++ b/OvmfPkg/SmbiosPlatformDxe/SmbiosPlatformDxe.h
@@ -33,4 +33,15 @@ GetQemuSmbiosTables (
   VOID
   );
 
+/**
+  Locates and extracts Cloud Hypervisor SMBIOS data
+
+  @return                 Address of extracted Cloud Hypervisor SMBIOS data
+
+**/
+UINT8 *
+GetCloudHvSmbiosTables (
+  VOID
+  );
+
 #endif

--- a/OvmfPkg/SmbiosPlatformDxe/SmbiosPlatformDxe.inf
+++ b/OvmfPkg/SmbiosPlatformDxe/SmbiosPlatformDxe.inf
@@ -24,6 +24,7 @@
 #
 
 [Sources]
+  EntryPoint.c
   Qemu.c
   SmbiosPlatformDxe.c
   SmbiosPlatformDxe.h

--- a/OvmfPkg/SmbiosPlatformDxe/SmbiosPlatformDxe.inf
+++ b/OvmfPkg/SmbiosPlatformDxe/SmbiosPlatformDxe.inf
@@ -24,6 +24,7 @@
 #
 
 [Sources]
+  CloudHv.c
   EntryPoint.c
   Qemu.c
   SmbiosPlatformDxe.c
@@ -42,6 +43,7 @@
   UefiDriverEntryPoint
 
 [Pcd]
+  gUefiOvmfPkgTokenSpaceGuid.PcdOvmfHostBridgePciDevId
   gUefiOvmfPkgTokenSpaceGuid.PcdQemuSmbiosValidated
 
 [Protocols]


### PR DESCRIPTION

From: Sebastien Boeuf <sebastien.boeuf@intel.com>

This series aims at adding the support for the Cloud Hypervisor platform
to the OVMF firmware for x86 architecture.

The goal is to allow the same binary to be used either by QEMU or Cloud
Hypervisor, using the Cloud Hypervisor way as a fallback if the fw_cfg
mechanism is not present.

Sebastien Boeuf (5):
  OvmfPkg: Handle Cloud Hypervisor host bridge
  OvmfPkg: Create global entry point for SMBIOS parsing
  OvmfPkg: Retrieve SMBIOS from Cloud Hypervisor
  OvmfPkg: Generalize AcpiPlatformDxe
  OvmfPkg: Install ACPI tables for Cloud Hypervisor

 ArmVirtPkg/ArmVirtQemu.dsc                    |   2 +-
 ArmVirtPkg/ArmVirtQemuFvMain.fdf.inc          |   2 +-
 ArmVirtPkg/ArmVirtQemuKernel.dsc              |   2 +-
 ...QemuFwCfgAcpiPlatform.c => AcpiPlatform.c} |  15 ++-
 OvmfPkg/AcpiPlatformDxe/AcpiPlatform.h        |   6 +
 ...cpiPlatformDxe.inf => AcpiPlatformDxe.inf} |   6 +-
 OvmfPkg/AcpiPlatformDxe/CloudHvAcpi.c         | 118 ++++++++++++++++++
 OvmfPkg/AmdSev/AmdSevX64.dsc                  |   2 +-
 OvmfPkg/AmdSev/AmdSevX64.fdf                  |   2 +-
 OvmfPkg/Include/IndustryStandard/CloudHv.h    |  46 +++++++
 OvmfPkg/Include/OvmfPlatforms.h               |   1 +
 .../Library/AcpiTimerLib/BaseAcpiTimerLib.c   |   3 +
 .../AcpiTimerLib/BaseRomAcpiTimerLib.c        |   4 +
 .../Library/AcpiTimerLib/DxeAcpiTimerLib.c    |   3 +
 .../PlatformBootManagerLib/BdsPlatform.c      |   1 +
 .../ResetSystemLib/BaseResetShutdown.c        |   3 +
 .../Library/ResetSystemLib/DxeResetShutdown.c |  13 +-
 OvmfPkg/Microvm/MicrovmX64.dsc                |   2 +-
 OvmfPkg/Microvm/MicrovmX64.fdf                |   2 +-
 OvmfPkg/OvmfPkgIa32.dsc                       |   2 +-
 OvmfPkg/OvmfPkgIa32.fdf                       |   2 +-
 OvmfPkg/OvmfPkgIa32X64.dsc                    |   2 +-
 OvmfPkg/OvmfPkgIa32X64.fdf                    |   2 +-
 OvmfPkg/OvmfPkgX64.dsc                        |   2 +-
 OvmfPkg/OvmfPkgX64.fdf                        |   2 +-
 OvmfPkg/PlatformPei/MemDetect.c               |   9 +-
 OvmfPkg/PlatformPei/Platform.c                |   8 ++
 OvmfPkg/SmbiosPlatformDxe/CloudHv.c           |  33 +++++
 OvmfPkg/SmbiosPlatformDxe/EntryPoint.c        |  52 ++++++++
 OvmfPkg/SmbiosPlatformDxe/Qemu.c              |  35 ------
 OvmfPkg/SmbiosPlatformDxe/SmbiosPlatformDxe.h |  22 ++++
 .../SmbiosPlatformDxe/SmbiosPlatformDxe.inf   |   3 +
 32 files changed, 351 insertions(+), 56 deletions(-)
 rename OvmfPkg/AcpiPlatformDxe/{QemuFwCfgAcpiPlatform.c => AcpiPlatform.c} (52%)
 rename OvmfPkg/AcpiPlatformDxe/{QemuFwCfgAcpiPlatformDxe.inf => AcpiPlatformDxe.inf} (87%)
 create mode 100644 OvmfPkg/AcpiPlatformDxe/CloudHvAcpi.c
 create mode 100644 OvmfPkg/Include/IndustryStandard/CloudHv.h
 create mode 100644 OvmfPkg/SmbiosPlatformDxe/CloudHv.c
 create mode 100644 OvmfPkg/SmbiosPlatformDxe/EntryPoint.c
