### PR TITLE
OvmfPkg/VmgExitLib: Fix uninitialized variable warning

### DIFF
--- a/OvmfPkg/Library/VmgExitLib/VmgExitVcHandler.c
+++ b/OvmfPkg/Library/VmgExitLib/VmgExitVcHandler.c
@@ -1872,6 +1872,7 @@ GetCpuidFw (
     UINT32                 XSaveSize;
 
     XssMsr.Uint64 = 0;
+    Compacted = FALSE;
     if (EcxIn == 1) {
       /*
        * The PPR and APM aren't clear on what size should be encoded in


### PR DESCRIPTION
The XCODE5 reported the below warning

OvmfPkg/Library/VmgExitLib/VmgExitVcHandler.c:1895:12: note: uninitialized use occurs here
           Compacted
           ^^^^^^^^^

Initialize the 'Compacted' variable to fix the warning.

Fixes: d2b998fbdca4 (OvmfPkg/VmgExitLib: use SEV-SNP-validated CPUID values)
Cc: James Bottomley <jejb@linux.ibm.com>
Cc: Min Xu <min.m.xu@intel.com>
Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Tom Lendacky <thomas.lendacky@amd.com>
Cc: Jordan Justen <jordan.l.justen@intel.com>
Cc: Ard Biesheuvel <ardb+tianocore@kernel.org>
Cc: Erdem Aktas <erdemaktas@google.com>
Cc: Gerd Hoffmann <kraxel@redhat.com>
Cc: Rebecca Cran <rebecca@bsdio.com>
Cc: Michael Roth <Michael.Roth@amd.com>
Signed-off-by: Brijesh Singh <brijesh.singh@amd.com>
Reviewed-by: Jiewen Yao <jiewen.yao@intel.com>