### PR TITLE
SecurityPkg: Reallocate TPM Active PCRs based on platform support

### DIFF
--- a/SecurityPkg/Library/HashLibBaseCryptoRouter/HashLibBaseCryptoRouterDxe.c
+++ b/SecurityPkg/Library/HashLibBaseCryptoRouter/HashLibBaseCryptoRouterDxe.c
@@ -3,7 +3,7 @@
   hash handler registered, such as SHA1, SHA256.
   Platform can use PcdTpm2HashMask to mask some hash engines.
 
-Copyright (c) 2013 - 2018, Intel Corporation. All rights reserved. <BR>
+Copyright (c) 2013 - 2021, Intel Corporation. All rights reserved. <BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -234,13 +234,18 @@ RegisterHashInterfaceLib (
 {
   UINTN       Index;
   UINT32      HashMask;
+  UINT32      Tpm2HashMask;
   EFI_STATUS  Status;
 
   //
   // Check allow
   //
-  HashMask = Tpm2GetHashMaskFromAlgo (&HashInterface->HashGuid);
-  if ((HashMask & PcdGet32 (PcdTpm2HashMask)) == 0) {
+  HashMask     = Tpm2GetHashMaskFromAlgo (&HashInterface->HashGuid);
+  Tpm2HashMask = PcdGet32 (PcdTpm2HashMask);
+
+  if ((Tpm2HashMask != 0) &&
+      ((HashMask & Tpm2HashMask) == 0))
+  {
     return EFI_UNSUPPORTED;
   }
 

--- a/SecurityPkg/Library/HashLibBaseCryptoRouter/HashLibBaseCryptoRouterPei.c
+++ b/SecurityPkg/Library/HashLibBaseCryptoRouter/HashLibBaseCryptoRouterPei.c
@@ -3,7 +3,7 @@
   hash handler registered, such as SHA1, SHA256.
   Platform can use PcdTpm2HashMask to mask some hash engines.
 
-Copyright (c) 2013 - 2018, Intel Corporation. All rights reserved. <BR>
+Copyright (c) 2013 - 2021, Intel Corporation. All rights reserved. <BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -330,13 +330,18 @@ RegisterHashInterfaceLib (
   UINTN               Index;
   HASH_INTERFACE_HOB  *HashInterfaceHob;
   UINT32              HashMask;
+  UINT32              Tpm2HashMask;
   EFI_STATUS          Status;
 
   //
   // Check allow
   //
-  HashMask = Tpm2GetHashMaskFromAlgo (&HashInterface->HashGuid);
-  if ((HashMask & PcdGet32 (PcdTpm2HashMask)) == 0) {
+  HashMask     = Tpm2GetHashMaskFromAlgo (&HashInterface->HashGuid);
+  Tpm2HashMask = PcdGet32 (PcdTpm2HashMask);
+
+  if ((Tpm2HashMask != 0) &&
+      ((HashMask & Tpm2HashMask) == 0))
+  {
     return EFI_UNSUPPORTED;
   }
 

--- a/SecurityPkg/Tcg/Tcg2Pei/Tcg2Pei.inf
+++ b/SecurityPkg/Tcg/Tcg2Pei/Tcg2Pei.inf
@@ -86,6 +86,7 @@
   ## SOMETIMES_CONSUMES
   ## SOMETIMES_PRODUCES
   gEfiSecurityPkgTokenSpaceGuid.PcdTpm2HashMask
+  gEfiSecurityPkgTokenSpaceGuid.PcdTcg2HashAlgorithmBitmap                  ## CONSUMES
 
 [Depex]
   gEfiPeiMasterBootModePpiGuid AND


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3515

In V4: Fixed patch format and uncrustify cleanup

In V3: Cleaned up comments, debug prints and updated patch to use the
new debug ENUM definitions.

- Replaced EFI_D_INFO with DEBUG_INFO.
- Replaced EFI_D_VERBOSE with DEBUG_VERBOSE.

In V2: Add case to RegisterHashInterfaceLib logic

RegisterHashInterfaceLib needs to correctly handle registering the HashLib
instance supported algorithm bitmap when PcdTpm2HashMask is set to zero.

The current implementation of SyncPcrAllocationsAndPcrMask() triggers
PCR bank reallocation only based on the intersection between
TpmActivePcrBanks and PcdTpm2HashMask.

When the software HashLibBaseCryptoRouter solution is used, no PCR bank
reallocation is occurring based on the supported hashing algorithms
registered by the HashLib instances.

Need to have an additional check for the intersection between the
TpmActivePcrBanks and the PcdTcg2HashAlgorithmBitmap populated by the
HashLib instances present on the platform's BIOS.

Signed-off-by: Rodrigo Gonzalez del Cueto <rodrigo.gonzalez.del.cueto@intel.com>
Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Jiewen Yao <jiewen.yao@intel.com>