### PR TITLE
SecurityPkg: EDK2 TCG and HDD Drivers must transition to Variable Policy

### DIFF
--- a/SecurityPkg/HddPassword/HddPasswordDxe.c
+++ b/SecurityPkg/HddPassword/HddPasswordDxe.c
@@ -9,6 +9,7 @@
 **/
 
 #include "HddPasswordDxe.h"
+#include <Library/VariablePolicyHelperLib.h>
 
 EFI_GUID    mHddPasswordVendorGuid          = HDD_PASSWORD_CONFIG_GUID;
 CHAR16      mHddPasswordVendorStorageName[] = L"HDD_PASSWORD_CONFIG";
@@ -2818,11 +2819,11 @@ HddPasswordDxeInit (
   IN EFI_SYSTEM_TABLE  *SystemTable
   )
 {
-  EFI_STATUS                     Status;
-  HDD_PASSWORD_DXE_PRIVATE_DATA  *Private;
-  VOID                           *Registration;
-  EFI_EVENT                      EndOfDxeEvent;
-  EDKII_VARIABLE_LOCK_PROTOCOL   *VariableLock;
+  EFI_STATUS                      Status;
+  HDD_PASSWORD_DXE_PRIVATE_DATA   *Private;
+  VOID                            *Registration;
+  EFI_EVENT                       EndOfDxeEvent;
+  EDKII_VARIABLE_POLICY_PROTOCOL  *VariablePolicy;
 
   Private = NULL;
 
@@ -2858,13 +2859,19 @@ HddPasswordDxeInit (
   //
   // Make HDD_PASSWORD_VARIABLE_NAME variable read-only.
   //
-  Status = gBS->LocateProtocol (&gEdkiiVariableLockProtocolGuid, NULL, (VOID **)&VariableLock);
+  Status = gBS->LocateProtocol (&gEdkiiVariablePolicyProtocolGuid, NULL, (VOID **)&VariablePolicy);
+  DEBUG ((DEBUG_INFO, "Locate Variable Policy protocol - %r\n", Status));
   if (!EFI_ERROR (Status)) {
-    Status = VariableLock->RequestToLock (
-                             VariableLock,
-                             HDD_PASSWORD_VARIABLE_NAME,
-                             &mHddPasswordVendorGuid
-                             );
+    Status = RegisterBasicVariablePolicy (
+               VariablePolicy,
+               &mHddPasswordVendorGuid,
+               HDD_PASSWORD_VARIABLE_NAME,
+               VARIABLE_POLICY_NO_MIN_SIZE,
+               VARIABLE_POLICY_NO_MAX_SIZE,
+               VARIABLE_POLICY_NO_MUST_ATTR,
+               VARIABLE_POLICY_NO_CANT_ATTR,
+               VARIABLE_POLICY_TYPE_LOCK_NOW
+               );
     DEBUG ((DEBUG_INFO, "%a(): Lock %s variable (%r)\n", __FUNCTION__, HDD_PASSWORD_VARIABLE_NAME, Status));
     ASSERT_EFI_ERROR (Status);
   }

--- a/SecurityPkg/HddPassword/HddPasswordDxe.inf
+++ b/SecurityPkg/HddPassword/HddPasswordDxe.inf
@@ -53,6 +53,7 @@
   S3BootScriptLib
   PciLib
   BaseCryptLib
+  VariablePolicyHelperLib
 
 [Guids]
   gEfiIfrTianoGuid                              ## CONSUMES ## GUID
@@ -63,7 +64,7 @@
   gEfiHiiConfigAccessProtocolGuid               ## PRODUCES
   gEfiAtaPassThruProtocolGuid                   ## CONSUMES
   gEfiPciIoProtocolGuid                         ## CONSUMES
-  gEdkiiVariableLockProtocolGuid                ## CONSUMES
+  gEdkiiVariablePolicyProtocolGuid              ## CONSUMES
 
 [Pcd]
   gEfiSecurityPkgTokenSpaceGuid.PcdSkipHddPasswordPrompt  ## CONSUMES

--- a/SecurityPkg/Library/DxeTcg2PhysicalPresenceLib/DxeTcg2PhysicalPresenceLib.inf
+++ b/SecurityPkg/Library/DxeTcg2PhysicalPresenceLib/DxeTcg2PhysicalPresenceLib.inf
@@ -50,10 +50,11 @@
   HobLib
   Tpm2CommandLib
   Tcg2PpVendorLib
+  VariablePolicyHelperLib
 
 [Protocols]
   gEfiTcg2ProtocolGuid                 ## SOMETIMES_CONSUMES
-  gEdkiiVariableLockProtocolGuid       ## SOMETIMES_CONSUMES
+  gEdkiiVariablePolicyProtocolGuid     ## SOMETIMES_CONSUMES
 
 [Pcd]
   gEfiSecurityPkgTokenSpaceGuid.PcdTcg2PhysicalPresenceFlags       ## SOMETIMES_CONSUMES

--- a/SecurityPkg/Library/DxeTcgPhysicalPresenceLib/DxeTcgPhysicalPresenceLib.c
+++ b/SecurityPkg/Library/DxeTcgPhysicalPresenceLib/DxeTcgPhysicalPresenceLib.c
@@ -29,6 +29,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Guid/EventGroup.h>
 #include <Guid/PhysicalPresenceData.h>
 #include <Library/TcgPpVendorLib.h>
+#include <Library/VariablePolicyHelperLib.h>
 
 #define CONFIRM_BUFFER_SIZE  4096
 
@@ -1183,14 +1184,14 @@ TcgPhysicalPresenceLibProcessRequest (
   VOID
   )
 {
-  EFI_STATUS                    Status;
-  BOOLEAN                       LifetimeLock;
-  BOOLEAN                       CmdEnable;
-  UINTN                         DataSize;
-  EFI_PHYSICAL_PRESENCE         TcgPpData;
-  EFI_TCG_PROTOCOL              *TcgProtocol;
-  EDKII_VARIABLE_LOCK_PROTOCOL  *VariableLockProtocol;
-  EFI_PHYSICAL_PRESENCE_FLAGS   PpiFlags;
+  EFI_STATUS                      Status;
+  BOOLEAN                         LifetimeLock;
+  BOOLEAN                         CmdEnable;
+  UINTN                           DataSize;
+  EFI_PHYSICAL_PRESENCE           TcgPpData;
+  EFI_TCG_PROTOCOL                *TcgProtocol;
+  EDKII_VARIABLE_POLICY_PROTOCOL  *VariablePolicy;
+  EFI_PHYSICAL_PRESENCE_FLAGS     PpiFlags;
 
   Status = gBS->LocateProtocol (&gEfiTcgProtocolGuid, NULL, (VOID **)&TcgProtocol);
   if (EFI_ERROR (Status)) {
@@ -1229,13 +1230,18 @@ TcgPhysicalPresenceLibProcessRequest (
   // This flags variable controls whether physical presence is required for TPM command.
   // It should be protected from malicious software. We set it as read-only variable here.
   //
-  Status = gBS->LocateProtocol (&gEdkiiVariableLockProtocolGuid, NULL, (VOID **)&VariableLockProtocol);
+  Status = gBS->LocateProtocol (&gEdkiiVariablePolicyProtocolGuid, NULL, (VOID **)&VariablePolicy);
   if (!EFI_ERROR (Status)) {
-    Status = VariableLockProtocol->RequestToLock (
-                                     VariableLockProtocol,
-                                     PHYSICAL_PRESENCE_FLAGS_VARIABLE,
-                                     &gEfiPhysicalPresenceGuid
-                                     );
+    Status = RegisterBasicVariablePolicy (
+               VariablePolicy,
+               &gEfiPhysicalPresenceGuid,
+               PHYSICAL_PRESENCE_FLAGS_VARIABLE,
+               VARIABLE_POLICY_NO_MIN_SIZE,
+               VARIABLE_POLICY_NO_MAX_SIZE,
+               VARIABLE_POLICY_NO_MUST_ATTR,
+               VARIABLE_POLICY_NO_CANT_ATTR,
+               VARIABLE_POLICY_TYPE_LOCK_NOW
+               );
     if (EFI_ERROR (Status)) {
       DEBUG ((DEBUG_ERROR, "[TPM] Error when lock variable %s, Status = %r\n", PHYSICAL_PRESENCE_FLAGS_VARIABLE, Status));
       ASSERT_EFI_ERROR (Status);

--- a/SecurityPkg/Library/DxeTcgPhysicalPresenceLib/DxeTcgPhysicalPresenceLib.inf
+++ b/SecurityPkg/Library/DxeTcgPhysicalPresenceLib/DxeTcgPhysicalPresenceLib.inf
@@ -50,10 +50,11 @@
   PrintLib
   HiiLib
   TcgPpVendorLib
+  VariablePolicyHelperLib
 
 [Protocols]
   gEfiTcgProtocolGuid                   ## SOMETIMES_CONSUMES
-  gEdkiiVariableLockProtocolGuid        ## SOMETIMES_CONSUMES
+  gEdkiiVariablePolicyProtocolGuid      ## SOMETIMES_CONSUMES
 
 [Guids]
   ## SOMETIMES_CONSUMES ## HII

--- a/SecurityPkg/SecurityPkg.dsc
+++ b/SecurityPkg/SecurityPkg.dsc
@@ -72,6 +72,7 @@
   MmUnblockMemoryLib|MdePkg/Library/MmUnblockMemoryLib/MmUnblockMemoryLibNull.inf
   SecureBootVariableLib|SecurityPkg/Library/SecureBootVariableLib/SecureBootVariableLib.inf
   SecureBootVariableProvisionLib|SecurityPkg/Library/SecureBootVariableProvisionLib/SecureBootVariableProvisionLib.inf
+  VariablePolicyHelperLib|MdeModulePkg/Library/VariablePolicyHelperLib/VariablePolicyHelperLib.inf
 
 [LibraryClasses.ARM, LibraryClasses.AARCH64]
   #

--- a/SecurityPkg/Tcg/Tcg2Config/Tcg2ConfigDxe.inf
+++ b/SecurityPkg/Tcg/Tcg2Config/Tcg2ConfigDxe.inf
@@ -54,6 +54,7 @@
   Tpm2CommandLib
   Tcg2PhysicalPresenceLib
   IoLib
+  VariablePolicyHelperLib
 
 [Guids]
   ## PRODUCES           ## HII
@@ -66,7 +67,7 @@
 [Protocols]
   gEfiHiiConfigAccessProtocolGuid               ## PRODUCES
   gEfiDevicePathProtocolGuid                    ## PRODUCES
-  gEdkiiVariableLockProtocolGuid                ## SOMETIMES_CONSUMES
+  gEdkiiVariablePolicyProtocolGuid              ## SOMETIMES_CONSUMES
   gEfiTcg2ProtocolGuid                          ## CONSUMES
 
 [Pcd]


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3774

Current we can see the warning message "VariableLockRequestToLock() will
go away soon" in log. Variable Lock should be deprecated from Tianocore,
and transited to Variable Policy.

Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Min Xu <min.m.xu@intel.com>
Cc: Qi Zhang <qi1.zhang@intel.com>
Cc: Rahul Kumar <rahul1.kumar@intel.com>
Signed-off-by: Longlong Yang <longlong.yang@intel.com>