### PR TITLE
IntelFsp2WrapperPkg : Remove EFIAPI from local functions.

### DIFF
--- a/IntelFsp2WrapperPkg/FspmWrapperPeim/FspmWrapperPeim.c
+++ b/IntelFsp2WrapperPkg/FspmWrapperPeim/FspmWrapperPeim.c
@@ -45,7 +45,6 @@ extern EFI_GUID  gFspHobGuid;
 **/
 
 UINTN
-EFIAPI
 GetFspmUpdDataAddress (
   VOID
   )

--- a/IntelFsp2WrapperPkg/FspsWrapperPeim/FspsWrapperPeim.c
+++ b/IntelFsp2WrapperPkg/FspsWrapperPeim/FspsWrapperPeim.c
@@ -188,7 +188,6 @@ FspSiliconInitDoneGetFspHobList (
 **/
 
 UINTN
-EFIAPI
 GetFspsUpdDataAddress (
   VOID
   )


### PR DESCRIPTION
REF:https://bugzilla.tianocore.org/show_bug.cgi?id=3642

Local functions do not need EFIAPI.

Cc: Nate DeSimone <nathaniel.l.desimone@intel.com>
Cc: Star Zeng <star.zeng@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Cc: Ashraf Ali S <ashraf.ali.s@intel.com>
Signed-off-by: Chasel Chiu <chasel.chiu@intel.com>
Reviewed-by: Star Zeng <star.zeng@intel.com>