### PR TITLE
MdeModulePkg/UsbBusDxe: fix NOOPT build error

### DIFF
--- a/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbUtility.c
+++ b/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbUtility.c
@@ -267,7 +267,7 @@ UsbHcBulkTransfer (
   IN  UINT8                               DevSpeed,
   IN  UINTN                               MaxPacket,
   IN  UINT8                               BufferNum,
-  IN  OUT VOID                            *Data[EFI_USB_MAX_BULK_BUFFER_NUM],
+  IN  OUT VOID                            *Data[],
   IN  OUT UINTN                           *DataLength,
   IN  OUT UINT8                           *DataToggle,
   IN  UINTN                               TimeOut,

--- a/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbUtility.h
+++ b/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbUtility.h
@@ -148,7 +148,7 @@ UsbHcBulkTransfer (
   IN  UINT8                               DevSpeed,
   IN  UINTN                               MaxPacket,
   IN  UINT8                               BufferNum,
-  IN  OUT VOID                            *Data[EFI_USB_MAX_BULK_BUFFER_NUM],
+  IN  OUT VOID                            *Data[],
   IN  OUT UINTN                           *DataLength,
   IN  OUT UINT8                           *DataToggle,
   IN  UINTN                               TimeOut,


### PR DESCRIPTION
Patch sent at: https://edk2.groups.io/g/devel/message/85108

gcc-11 (fedora 35):

/home/kraxel/projects/edk2/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbBus.c: In function ?UsbIoBulkTransfer?:
/home/kraxel/projects/edk2/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbBus.c:277:12: error: ?UsbHcBulkTransfer? accessing 80 bytes in a region of size 8 [-Werror=stringop-overflow=]

Signed-off-by: Gerd Hoffmann <kraxel@redhat.com>
Reviewed-by: Hao A Wu <hao.a.wu@intel.com>