### PR TITLE
Replace Opcode with the corresponding instructions.

### DIFF
--- a/MdeModulePkg/Universal/DebugSupportDxe/Ia32/AsmFuncs.nasm
+++ b/MdeModulePkg/Universal/DebugSupportDxe/Ia32/AsmFuncs.nasm
@@ -1,7 +1,7 @@
 ;/** @file
 ;  Low leve IA32 specific debug support functions.
 ;
-;  Copyright (c) 2006 - 2011, Intel Corporation. All rights reserved.<BR>
+;  Copyright (c) 2006 - 2021, Intel Corporation. All rights reserved.<BR>
 ;  SPDX-License-Identifier: BSD-2-Clause-Patent
 ;
 ;**/
@@ -26,20 +26,6 @@
 
 %define FXSTOR_FLAG 0x1000000         ; bit cpuid 24 of feature flags
 
-;; The FXSTOR and FXRSTOR commands are used for saving and restoring the x87,
-;; MMX, SSE, SSE2, etc registers.  The initialization of the debugsupport driver
-;; MUST check the CPUID feature flags to see that these instructions are available
-;; and fail to init if they are not.
-
-;; fxstor [edi]
-%macro FXSTOR_EDI 0
-                         db 0xf, 0xae, 00000111y ; mod = 00, reg/op = 000, r/m = 111 = [edi]
-%endmacro
-
-;; fxrstor [esi]
-%macro FXRSTOR_ESI 0
-                         db 0xf, 0xae, 00001110y ; mod = 00, reg/op = 001, r/m = 110 = [esi]
-%endmacro
 SECTION .data
 
 global ASM_PFX(OrigVector)
@@ -348,7 +334,7 @@ ExtraPushDone:
                 ; IMPORTANT!! The debug stack has been carefully constructed to
                 ; insure that esp and edi are 16 byte aligned when we get here.
                 ; They MUST be.  If they are not, a GP fault will occur.
-                FXSTOR_EDI
+                fxsave  [edi]
 
 ;; UEFI calling convention for IA32 requires that Direction flag in EFLAGs is clear
                 cld
@@ -372,7 +358,7 @@ ExtraPushDone:
 
 ;; FX_SAVE_STATE_IA32 FxSaveState;
                 mov     esi, esp
-                FXRSTOR_ESI
+                fxrstor [esi]
                 add     esp, 512
 
 ;; UINT32  Dr0, Dr1, Dr2, Dr3, Dr6, Dr7;

--- a/MdeModulePkg/Universal/DebugSupportDxe/X64/AsmFuncs.nasm
+++ b/MdeModulePkg/Universal/DebugSupportDxe/X64/AsmFuncs.nasm
@@ -1,7 +1,7 @@
 ;/** @file
 ;  Low level x64 routines used by the debug support driver.
 ;
-;  Copyright (c) 2007 - 2018, Intel Corporation. All rights reserved.<BR>
+;  Copyright (c) 2007 - 2021, Intel Corporation. All rights reserved.<BR>
 ;  SPDX-License-Identifier: BSD-2-Clause-Patent
 ;
 ;**/
@@ -25,21 +25,6 @@
 %define EXCPT64_SIMD 19
 
 %define FXSTOR_FLAG 0x1000000         ; bit cpuid 24 of feature flags
-
-;; The FXSTOR and FXRSTOR commands are used for saving and restoring the x87,
-;; MMX, SSE, SSE2, etc registers.  The initialization of the debugsupport driver
-;; MUST check the CPUID feature flags to see that these instructions are available
-;; and fail to init if they are not.
-
-;; fxstor [rdi]
-%macro FXSTOR_RDI 0
-                         db 0xf, 0xae, 00000111y ; mod = 00, reg/op = 000, r/m = 111 = [rdi]
-%endmacro
-
-;; fxrstor [rsi]
-%macro FXRSTOR_RSI 0
-                         db 0xf, 0xae, 00001110y ; mod = 00, reg/op = 001, r/m = 110 = [rsi]
-%endmacro
 
 SECTION .data
 
@@ -381,7 +366,7 @@ ExtraPushDone:
                 ; IMPORTANT!! The debug stack has been carefully constructed to
                 ; insure that rsp and rdi are 16 byte aligned when we get here.
                 ; They MUST be.  If they are not, a GP fault will occur.
-                FXSTOR_RDI
+                fxsave  [rdi]
 
 ;; UEFI calling convention for x64 requires that Direction flag in EFLAGs is clear
                 cld
@@ -404,7 +389,7 @@ ExtraPushDone:
 
 ;; FX_SAVE_STATE_X64 FxSaveState;
                 mov     rsi, rsp
-                FXRSTOR_RSI
+                fxrstor [rsi]
                 add     rsp, 512
 
 ;; UINT64  Dr0, Dr1, Dr2, Dr3, Dr6, Dr7;

--- a/MdePkg/Library/BaseLib/Ia32/EnablePaging64.nasm
+++ b/MdePkg/Library/BaseLib/Ia32/EnablePaging64.nasm
@@ -1,6 +1,6 @@
 ;------------------------------------------------------------------------------
 ;
-; Copyright (c) 2006, Intel Corporation. All rights reserved.<BR>
+; Copyright (c) 2006 - 2021, Intel Corporation. All rights reserved.<BR>
 ; SPDX-License-Identifier: BSD-2-Clause-Patent
 ;
 ; Module Name:
@@ -44,16 +44,12 @@ ASM_PFX(InternalX86EnablePaging64):
     mov     cr0, eax                    ; enable paging
     retf                                ; topmost 2 dwords hold the address
 .0:
-    DB      0x67, 0x48                    ; 32-bit address size, 64-bit operand size
-    mov     ebx, [esp]                  ; mov rbx, [esp]
-    DB      0x67, 0x48
-    mov     ecx, [esp + 8]              ; mov rcx, [esp + 8]
-    DB      0x67, 0x48
-    mov     edx, [esp + 0x10]            ; mov rdx, [esp + 10h]
-    DB      0x67, 0x48
-    mov     esp, [esp + 0x18]            ; mov rsp, [esp + 18h]
-    DB      0x48
-    add     esp, -0x20                   ; add rsp, -20h
-    call    ebx                         ; call rbx
+BITS 64
+    mov     rbx, [esp]
+    mov     rcx, [esp + 8]
+    mov     rdx, [esp + 0x10]
+    mov     rsp, [esp + 0x18]
+    add     rsp, -0x20
+    call    rbx
     hlt                                 ; no one should get here
 

--- a/MdePkg/Library/BaseLib/Ia32/LongJump.nasm
+++ b/MdePkg/Library/BaseLib/Ia32/LongJump.nasm
@@ -1,6 +1,6 @@
 ;------------------------------------------------------------------------------
 ;
-; Copyright (c) 2006 - 2019, Intel Corporation. All rights reserved.<BR>
+; Copyright (c) 2006 - 2021, Intel Corporation. All rights reserved.<BR>
 ; SPDX-License-Identifier: BSD-2-Clause-Patent
 ;
 ; Module Name:
@@ -39,12 +39,12 @@ ASM_PFX(InternalLongJump):
 
     mov     edx, [esp + 4]         ; edx = JumpBuffer
     mov     edx, [edx + 24]        ; edx = target SSP
-    READSSP_EAX
+    rdsspd  eax
     sub     edx, eax               ; edx = delta
     mov     eax, edx               ; eax = delta
 
     shr     eax, 2                 ; eax = delta/sizeof(UINT32)
-    INCSSP_EAX
+    incsspd eax
 
 CetDone:
 

--- a/MdePkg/Library/BaseLib/Ia32/Monitor.nasm
+++ b/MdePkg/Library/BaseLib/Ia32/Monitor.nasm
@@ -1,6 +1,6 @@
 ;------------------------------------------------------------------------------
 ;
-; Copyright (c) 2006, Intel Corporation. All rights reserved.<BR>
+; Copyright (c) 2006 - 2021, Intel Corporation. All rights reserved.<BR>
 ; SPDX-License-Identifier: BSD-2-Clause-Patent
 ;
 ; Module Name:
@@ -31,6 +31,6 @@ ASM_PFX(AsmMonitor):
     mov     eax, [esp + 4]
     mov     ecx, [esp + 8]
     mov     edx, [esp + 12]
-    DB      0xf, 1, 0xc8                ; monitor
+    monitor
     ret
 

--- a/MdePkg/Library/BaseLib/Ia32/Mwait.nasm
+++ b/MdePkg/Library/BaseLib/Ia32/Mwait.nasm
@@ -1,6 +1,6 @@
 ;------------------------------------------------------------------------------
 ;
-; Copyright (c) 2006, Intel Corporation. All rights reserved.<BR>
+; Copyright (c) 2006 - 2021, Intel Corporation. All rights reserved.<BR>
 ; SPDX-License-Identifier: BSD-2-Clause-Patent
 ;
 ; Module Name:
@@ -29,6 +29,6 @@ global ASM_PFX(AsmMwait)
 ASM_PFX(AsmMwait):
     mov     eax, [esp + 4]
     mov     ecx, [esp + 8]
-    DB      0xf, 1, 0xc9                ; mwait
+    mwait
     ret
 

--- a/MdePkg/Library/BaseLib/Ia32/RdRand.nasm
+++ b/MdePkg/Library/BaseLib/Ia32/RdRand.nasm
@@ -1,6 +1,6 @@
 ;------------------------------------------------------------------------------
 ;
-; Copyright (c) 2015 - 2016, Intel Corporation. All rights reserved.<BR>
+; Copyright (c) 2015 - 2021, Intel Corporation. All rights reserved.<BR>
 ; SPDX-License-Identifier: BSD-2-Clause-Patent
 ;
 ; Module Name:
@@ -25,9 +25,8 @@ SECTION .text
 ;------------------------------------------------------------------------------
 global ASM_PFX(InternalX86RdRand16)
 ASM_PFX(InternalX86RdRand16):
-    ; rdrand   ax                  ; generate a 16 bit RN into ax
+    rdrand eax                     ; generate a 16 bit RN into ax
                                    ; CF=1 if RN generated ok, otherwise CF=0
-    db     0xf, 0xc7, 0xf0         ; rdrand r16: "0f c7 /6  ModRM:r/m(w)"
     jc     rn16_ok                 ; jmp if CF=1
     xor    eax, eax                ; reg=0 if CF=0
     ret                            ; return with failure status
@@ -45,9 +44,8 @@ rn16_ok:
 ;------------------------------------------------------------------------------
 global ASM_PFX(InternalX86RdRand32)
 ASM_PFX(InternalX86RdRand32):
-    ; rdrand   eax                 ; generate a 32 bit RN into eax
+    rdrand eax                     ; generate a 32 bit RN into eax
                                    ; CF=1 if RN generated ok, otherwise CF=0
-    db     0xf, 0xc7, 0xf0         ; rdrand r32: "0f c7 /6  ModRM:r/m(w)"
     jc     rn32_ok                 ; jmp if CF=1
     xor    eax, eax                ; reg=0 if CF=0
     ret                            ; return with failure status
@@ -65,14 +63,13 @@ rn32_ok:
 ;------------------------------------------------------------------------------
 global ASM_PFX(InternalX86RdRand64)
 ASM_PFX(InternalX86RdRand64):
-    ; rdrand   eax                 ; generate a 32 bit RN into eax
+    rdrand eax                     ; generate a 32 bit RN into eax
                                    ; CF=1 if RN generated ok, otherwise CF=0
-    db     0xf, 0xc7, 0xf0         ; rdrand r32: "0f c7 /6  ModRM:r/m(w)"
     jnc    rn64_ret                ; jmp if CF=0
     mov    edx, dword [esp + 4]
     mov    [edx], eax
 
-    db     0xf, 0xc7, 0xf0         ; generate another 32 bit RN
+    rdrand eax                     ; generate another 32 bit RN
     jnc    rn64_ret                ; jmp if CF=0
     mov    [edx + 4], eax
 

--- a/MdePkg/Library/BaseLib/Ia32/ReadDr4.nasm
+++ b/MdePkg/Library/BaseLib/Ia32/ReadDr4.nasm
@@ -1,6 +1,6 @@
 ;------------------------------------------------------------------------------
 ;
-; Copyright (c) 2006, Intel Corporation. All rights reserved.<BR>
+; Copyright (c) 2006 - 2021, Intel Corporation. All rights reserved.<BR>
 ; SPDX-License-Identifier: BSD-2-Clause-Patent
 ;
 ; Module Name:
@@ -31,8 +31,8 @@ ASM_PFX(AsmReadDr4):
     ; this register will cause a #UD exception.
     ;
     ; MS assembler doesn't support this instruction since no one would use it
-    ; under normal circustances. Here opcode is used.
+    ; under normal circustances.
     ;
-    DB      0xf, 0x21, 0xe0
+    mov     eax, dr4
     ret
 

--- a/MdePkg/Library/BaseLib/Ia32/ReadDr5.nasm
+++ b/MdePkg/Library/BaseLib/Ia32/ReadDr5.nasm
@@ -1,6 +1,6 @@
 ;------------------------------------------------------------------------------
 ;
-; Copyright (c) 2006, Intel Corporation. All rights reserved.<BR>
+; Copyright (c) 2006 - 2021, Intel Corporation. All rights reserved.<BR>
 ; SPDX-License-Identifier: BSD-2-Clause-Patent
 ;
 ; Module Name:
@@ -31,8 +31,8 @@ ASM_PFX(AsmReadDr5):
     ; this register will cause a #UD exception.
     ;
     ; MS assembler doesn't support this instruction since no one would use it
-    ; under normal circustances. Here opcode is used.
+    ; under normal circustances.
     ;
-    DB      0xf, 0x21, 0xe8
+    mov     eax, dr5
     ret
 

--- a/MdePkg/Library/BaseLib/Ia32/SetJump.nasm
+++ b/MdePkg/Library/BaseLib/Ia32/SetJump.nasm
@@ -1,6 +1,6 @@
 ;------------------------------------------------------------------------------
 ;
-; Copyright (c) 2006 - 2019, Intel Corporation. All rights reserved.<BR>
+; Copyright (c) 2006 - 2021, Intel Corporation. All rights reserved.<BR>
 ; SPDX-License-Identifier: BSD-2-Clause-Patent
 ;
 ; Module Name:
@@ -46,8 +46,8 @@ ASM_PFX(SetJump):
     jnc     CetDone
 
     mov     eax, 1
-    INCSSP_EAX                     ; to read original SSP
-    READSSP_EAX
+    incsspd eax                    ; to read original SSP
+    rdsspd  eax
     mov     [edx + 0x24], eax      ; save SSP
 
 CetDone:

--- a/MdePkg/Library/BaseLib/Ia32/WriteDr4.nasm
+++ b/MdePkg/Library/BaseLib/Ia32/WriteDr4.nasm
@@ -1,6 +1,6 @@
 ;------------------------------------------------------------------------------
 ;
-; Copyright (c) 2006, Intel Corporation. All rights reserved.<BR>
+; Copyright (c) 2006 - 2021, Intel Corporation. All rights reserved.<BR>
 ; SPDX-License-Identifier: BSD-2-Clause-Patent
 ;
 ; Module Name:
@@ -32,8 +32,8 @@ ASM_PFX(AsmWriteDr4):
     ; this register will cause a #UD exception.
     ;
     ; MS assembler doesn't support this instruction since no one would use it
-    ; under normal circustances. Here opcode is used.
+    ; under normal circustances.
     ;
-    DB      0xf, 0x23, 0xe0
+    mov     dr4, eax
     ret
 

--- a/MdePkg/Library/BaseLib/Ia32/WriteDr5.nasm
+++ b/MdePkg/Library/BaseLib/Ia32/WriteDr5.nasm
@@ -1,6 +1,6 @@
 ;------------------------------------------------------------------------------
 ;
-; Copyright (c) 2006, Intel Corporation. All rights reserved.<BR>
+; Copyright (c) 2006 - 2021, Intel Corporation. All rights reserved.<BR>
 ; SPDX-License-Identifier: BSD-2-Clause-Patent
 ;
 ; Module Name:
@@ -32,8 +32,8 @@ ASM_PFX(AsmWriteDr5):
     ; this register will cause a #UD exception.
     ;
     ; MS assembler doesn't support this instruction since no one would use it
-    ; under normal circustances. Here opcode is used.
+    ; under normal circustances.
     ;
-    DB      0xf, 0x23, 0xe8
+    mov     dr5, eax
     ret
 

--- a/MdePkg/Library/BaseLib/X64/DisablePaging64.nasm
+++ b/MdePkg/Library/BaseLib/X64/DisablePaging64.nasm
@@ -1,6 +1,6 @@
 ;------------------------------------------------------------------------------
 ;
-; Copyright (c) 2006 - 2008, Intel Corporation. All rights reserved.<BR>
+; Copyright (c) 2006 - 2021, Intel Corporation. All rights reserved.<BR>
 ; SPDX-License-Identifier: BSD-2-Clause-Patent
 ;
 ; Module Name:
@@ -51,8 +51,7 @@ ASM_PFX(InternalX86DisablePaging64):
     sub     eax, 4                      ; eax <- One slot below transition code on the stack
     push    rcx                         ; push Cs to stack
     push    r10                         ; push address of tansition code on stack
-    DB      0x48                         ; prefix to composite "retq" with next "retf"
-    retf                                ; Use far return to load CS register from stack
+    retfq
 
 ; Start of transition code
 .0:

--- a/MdePkg/Library/BaseLib/X64/LongJump.nasm
+++ b/MdePkg/Library/BaseLib/X64/LongJump.nasm
@@ -1,6 +1,6 @@
 ;------------------------------------------------------------------------------
 ;
-; Copyright (c) 2006 - 2019, Intel Corporation. All rights reserved.<BR>
+; Copyright (c) 2006 - 2021, Intel Corporation. All rights reserved.<BR>
 ; SPDX-License-Identifier: BSD-2-Clause-Patent
 ;
 ; Module Name:
@@ -41,12 +41,12 @@ ASM_PFX(InternalLongJump):
     push    rdx                          ; save rdx
 
     mov     rdx, [rcx + 0xF8]            ; rdx = target SSP
-    READSSP_RAX
+    rdsspq  rax
     sub     rdx, rax                     ; rdx = delta
     mov     rax, rdx                     ; rax = delta
 
     shr     rax, 3                       ; rax = delta/sizeof(UINT64)
-    INCSSP_RAX
+    incsspq rax
 
     pop     rdx                          ; restore rdx
 CetDone:

--- a/MdePkg/Library/BaseLib/X64/Monitor.nasm
+++ b/MdePkg/Library/BaseLib/X64/Monitor.nasm
@@ -1,6 +1,6 @@
 ;------------------------------------------------------------------------------
 ;
-; Copyright (c) 2006, Intel Corporation. All rights reserved.<BR>
+; Copyright (c) 2006 - 2021, Intel Corporation. All rights reserved.<BR>
 ; SPDX-License-Identifier: BSD-2-Clause-Patent
 ;
 ; Module Name:
@@ -32,6 +32,6 @@ ASM_PFX(AsmMonitor):
     mov     eax, ecx
     mov     ecx, edx
     mov     edx, r8d
-    DB      0xf, 1, 0xc8                ; monitor
+    monitor
     ret
 

--- a/MdePkg/Library/BaseLib/X64/Mwait.nasm
+++ b/MdePkg/Library/BaseLib/X64/Mwait.nasm
@@ -1,6 +1,6 @@
 ;------------------------------------------------------------------------------
 ;
-; Copyright (c) 2006, Intel Corporation. All rights reserved.<BR>
+; Copyright (c) 2006 - 2021, Intel Corporation. All rights reserved.<BR>
 ; SPDX-License-Identifier: BSD-2-Clause-Patent
 ;
 ; Module Name:
@@ -30,6 +30,6 @@ global ASM_PFX(AsmMwait)
 ASM_PFX(AsmMwait):
     mov     eax, ecx
     mov     ecx, edx
-    DB      0xf, 1, 0xc9                ; mwait
+    mwait
     ret
 

--- a/MdePkg/Library/BaseLib/X64/RdRand.nasm
+++ b/MdePkg/Library/BaseLib/X64/RdRand.nasm
@@ -1,6 +1,6 @@
 ;------------------------------------------------------------------------------
 ;
-; Copyright (c) 2015 - 2016, Intel Corporation. All rights reserved.<BR>
+; Copyright (c) 2015 - 2021, Intel Corporation. All rights reserved.<BR>
 ; SPDX-License-Identifier: BSD-2-Clause-Patent
 ;
 ; Module Name:
@@ -26,9 +26,8 @@
 ;------------------------------------------------------------------------------
 global ASM_PFX(InternalX86RdRand16)
 ASM_PFX(InternalX86RdRand16):
-    ; rdrand   ax                  ; generate a 16 bit RN into eax,
+    rdrand eax                     ; generate a 16 bit RN into eax,
                                    ; CF=1 if RN generated ok, otherwise CF=0
-    db     0xf, 0xc7, 0xf0         ; rdrand r16: "0f c7 /6  ModRM:r/m(w)"
     jc     rn16_ok                 ; jmp if CF=1
     xor    rax, rax                ; reg=0 if CF=0
     ret                            ; return with failure status
@@ -45,9 +44,8 @@ rn16_ok:
 ;------------------------------------------------------------------------------
 global ASM_PFX(InternalX86RdRand32)
 ASM_PFX(InternalX86RdRand32):
-    ; rdrand   eax                 ; generate a 32 bit RN into eax,
+    rdrand eax                     ; generate a 32 bit RN into eax,
                                    ; CF=1 if RN generated ok, otherwise CF=0
-    db     0xf, 0xc7, 0xf0         ; rdrand r32: "0f c7 /6  ModRM:r/m(w)"
     jc     rn32_ok                 ; jmp if CF=1
     xor    rax, rax                ; reg=0 if CF=0
     ret                            ; return with failure status
@@ -64,9 +62,8 @@ rn32_ok:
 ;------------------------------------------------------------------------------
 global ASM_PFX(InternalX86RdRand64)
 ASM_PFX(InternalX86RdRand64):
-    ; rdrand   rax                 ; generate a 64 bit RN into rax,
+    rdrand rax                     ; generate a 64 bit RN into rax,
                                    ; CF=1 if RN generated ok, otherwise CF=0
-    db     0x48, 0xf, 0xc7, 0xf0   ; rdrand r64: "REX.W + 0f c7 /6 ModRM:r/m(w)"
     jc     rn64_ok                 ; jmp if CF=1
     xor    rax, rax                ; reg=0 if CF=0
     ret                            ; return with failure status

--- a/MdePkg/Library/BaseLib/X64/ReadDr4.nasm
+++ b/MdePkg/Library/BaseLib/X64/ReadDr4.nasm
@@ -1,6 +1,6 @@
 ;------------------------------------------------------------------------------
 ;
-; Copyright (c) 2006, Intel Corporation. All rights reserved.<BR>
+; Copyright (c) 2006 - 2021, Intel Corporation. All rights reserved.<BR>
 ; SPDX-License-Identifier: BSD-2-Clause-Patent
 ;
 ; Module Name:
@@ -31,6 +31,6 @@ ASM_PFX(AsmReadDr4):
     ; There's no obvious reason to access this register, since it's aliased to
     ; DR7 when DE=0 or an exception generated when DE=1
     ;
-    DB      0xf, 0x21, 0xe0
+    mov     rax, dr4
     ret
 

--- a/MdePkg/Library/BaseLib/X64/ReadDr5.nasm
+++ b/MdePkg/Library/BaseLib/X64/ReadDr5.nasm
@@ -1,6 +1,6 @@
 ;------------------------------------------------------------------------------
 ;
-; Copyright (c) 2006, Intel Corporation. All rights reserved.<BR>
+; Copyright (c) 2006 - 2021, Intel Corporation. All rights reserved.<BR>
 ; SPDX-License-Identifier: BSD-2-Clause-Patent
 ;
 ; Module Name:
@@ -31,6 +31,6 @@ ASM_PFX(AsmReadDr5):
     ; There's no obvious reason to access this register, since it's aliased to
     ; DR7 when DE=0 or an exception generated when DE=1
     ;
-    DB      0xf, 0x21, 0xe8
+    mov     rax, dr5
     ret
 

--- a/MdePkg/Library/BaseLib/X64/ReadMm0.nasm
+++ b/MdePkg/Library/BaseLib/X64/ReadMm0.nasm
@@ -1,6 +1,6 @@
 ;------------------------------------------------------------------------------
 ;
-; Copyright (c) 2006, Intel Corporation. All rights reserved.<BR>
+; Copyright (c) 2006 - 2021, Intel Corporation. All rights reserved.<BR>
 ; SPDX-License-Identifier: BSD-2-Clause-Patent
 ;
 ; Module Name:
@@ -27,9 +27,6 @@
 ;------------------------------------------------------------------------------
 global ASM_PFX(AsmReadMm0)
 ASM_PFX(AsmReadMm0):
-    ;
-    ; 64-bit MASM doesn't support MMX instructions, so use opcode here
-    ;
-    DB      0x48, 0xf, 0x7e, 0xc0
+    movq    rax, mm0
     ret
 

--- a/MdePkg/Library/BaseLib/X64/ReadMm1.nasm
+++ b/MdePkg/Library/BaseLib/X64/ReadMm1.nasm
@@ -1,6 +1,6 @@
 ;------------------------------------------------------------------------------
 ;
-; Copyright (c) 2006, Intel Corporation. All rights reserved.<BR>
+; Copyright (c) 2006 - 2021, Intel Corporation. All rights reserved.<BR>
 ; SPDX-License-Identifier: BSD-2-Clause-Patent
 ;
 ; Module Name:
@@ -27,9 +27,6 @@
 ;------------------------------------------------------------------------------
 global ASM_PFX(AsmReadMm1)
 ASM_PFX(AsmReadMm1):
-    ;
-    ; 64-bit MASM doesn't support MMX instructions, so use opcode here
-    ;
-    DB      0x48, 0xf, 0x7e, 0xc8
+    movq    rax, mm1
     ret
 

--- a/MdePkg/Library/BaseLib/X64/ReadMm2.nasm
+++ b/MdePkg/Library/BaseLib/X64/ReadMm2.nasm
@@ -1,6 +1,6 @@
 ;------------------------------------------------------------------------------
 ;
-; Copyright (c) 2006, Intel Corporation. All rights reserved.<BR>
+; Copyright (c) 2006 - 2021, Intel Corporation. All rights reserved.<BR>
 ; SPDX-License-Identifier: BSD-2-Clause-Patent
 ;
 ; Module Name:
@@ -27,9 +27,6 @@
 ;------------------------------------------------------------------------------
 global ASM_PFX(AsmReadMm2)
 ASM_PFX(AsmReadMm2):
-    ;
-    ; 64-bit MASM doesn't support MMX instructions, so use opcode here
-    ;
-    DB      0x48, 0xf, 0x7e, 0xd0
+    movq    rax, mm2
     ret
 

--- a/MdePkg/Library/BaseLib/X64/ReadMm3.nasm
+++ b/MdePkg/Library/BaseLib/X64/ReadMm3.nasm
@@ -1,6 +1,6 @@
 ;------------------------------------------------------------------------------
 ;
-; Copyright (c) 2006, Intel Corporation. All rights reserved.<BR>
+; Copyright (c) 2006 - 2021, Intel Corporation. All rights reserved.<BR>
 ; SPDX-License-Identifier: BSD-2-Clause-Patent
 ;
 ; Module Name:
@@ -27,9 +27,6 @@
 ;------------------------------------------------------------------------------
 global ASM_PFX(AsmReadMm3)
 ASM_PFX(AsmReadMm3):
-    ;
-    ; 64-bit MASM doesn't support MMX instructions, so use opcode here
-    ;
-    DB      0x48, 0xf, 0x7e, 0xd8
+    movq    rax, mm3
     ret
 

--- a/MdePkg/Library/BaseLib/X64/ReadMm4.nasm
+++ b/MdePkg/Library/BaseLib/X64/ReadMm4.nasm
@@ -1,6 +1,6 @@
 ;------------------------------------------------------------------------------
 ;
-; Copyright (c) 2006, Intel Corporation. All rights reserved.<BR>
+; Copyright (c) 2006 - 2021, Intel Corporation. All rights reserved.<BR>
 ; SPDX-License-Identifier: BSD-2-Clause-Patent
 ;
 ; Module Name:
@@ -27,9 +27,6 @@
 ;------------------------------------------------------------------------------
 global ASM_PFX(AsmReadMm4)
 ASM_PFX(AsmReadMm4):
-    ;
-    ; 64-bit MASM doesn't support MMX instructions, so use opcode here
-    ;
-    DB      0x48, 0xf, 0x7e, 0xe0
+    movq    rax, mm4
     ret
 

--- a/MdePkg/Library/BaseLib/X64/ReadMm5.nasm
+++ b/MdePkg/Library/BaseLib/X64/ReadMm5.nasm
@@ -1,6 +1,6 @@
 ;------------------------------------------------------------------------------
 ;
-; Copyright (c) 2006, Intel Corporation. All rights reserved.<BR>
+; Copyright (c) 2006 - 2021, Intel Corporation. All rights reserved.<BR>
 ; SPDX-License-Identifier: BSD-2-Clause-Patent
 ;
 ; Module Name:
@@ -27,9 +27,6 @@
 ;------------------------------------------------------------------------------
 global ASM_PFX(AsmReadMm5)
 ASM_PFX(AsmReadMm5):
-    ;
-    ; 64-bit MASM doesn't support MMX instructions, so use opcode here
-    ;
-    DB      0x48, 0xf, 0x7e, 0xe8
+    movq    rax, mm5
     ret
 

--- a/MdePkg/Library/BaseLib/X64/ReadMm6.nasm
+++ b/MdePkg/Library/BaseLib/X64/ReadMm6.nasm
@@ -1,6 +1,6 @@
 ;------------------------------------------------------------------------------
 ;
-; Copyright (c) 2006, Intel Corporation. All rights reserved.<BR>
+; Copyright (c) 2006 - 2021, Intel Corporation. All rights reserved.<BR>
 ; SPDX-License-Identifier: BSD-2-Clause-Patent
 ;
 ; Module Name:
@@ -27,9 +27,6 @@
 ;------------------------------------------------------------------------------
 global ASM_PFX(AsmReadMm6)
 ASM_PFX(AsmReadMm6):
-    ;
-    ; 64-bit MASM doesn't support MMX instructions, so use opcode here
-    ;
-    DB      0x48, 0xf, 0x7e, 0xf0
+    movq    rax, mm6
     ret
 

--- a/MdePkg/Library/BaseLib/X64/ReadMm7.nasm
+++ b/MdePkg/Library/BaseLib/X64/ReadMm7.nasm
@@ -1,6 +1,6 @@
 ;------------------------------------------------------------------------------
 ;
-; Copyright (c) 2006, Intel Corporation. All rights reserved.<BR>
+; Copyright (c) 2006 - 2021, Intel Corporation. All rights reserved.<BR>
 ; SPDX-License-Identifier: BSD-2-Clause-Patent
 ;
 ; Module Name:
@@ -27,9 +27,6 @@
 ;------------------------------------------------------------------------------
 global ASM_PFX(AsmReadMm7)
 ASM_PFX(AsmReadMm7):
-    ;
-    ; 64-bit MASM doesn't support MMX instructions, so use opcode here
-    ;
-    DB      0x48, 0xf, 0x7e, 0xf8
+    movq    rax, mm7
     ret
 

--- a/MdePkg/Library/BaseLib/X64/SetJump.nasm
+++ b/MdePkg/Library/BaseLib/X64/SetJump.nasm
@@ -1,6 +1,6 @@
 ;------------------------------------------------------------------------------
 ;
-; Copyright (c) 2006 - 2019, Intel Corporation. All rights reserved.<BR>
+; Copyright (c) 2006 - 2021, Intel Corporation. All rights reserved.<BR>
 ; SPDX-License-Identifier: BSD-2-Clause-Patent
 ;
 ; Module Name:
@@ -48,8 +48,8 @@ ASM_PFX(SetJump):
     jnc     CetDone
 
     mov     rax, 1
-    INCSSP_RAX                           ; to read original SSP
-    READSSP_RAX
+    incsspq rax                          ; to read original SSP
+    rdsspq  rax
     mov     [rcx + 0xF8], rax            ; save SSP
 
 CetDone:

--- a/MdePkg/Library/BaseLib/X64/WriteDr4.nasm
+++ b/MdePkg/Library/BaseLib/X64/WriteDr4.nasm
@@ -1,6 +1,6 @@
 ;------------------------------------------------------------------------------
 ;
-; Copyright (c) 2006, Intel Corporation. All rights reserved.<BR>
+; Copyright (c) 2006 - 2021, Intel Corporation. All rights reserved.<BR>
 ; SPDX-License-Identifier: BSD-2-Clause-Patent
 ;
 ; Module Name:
@@ -31,7 +31,7 @@ ASM_PFX(AsmWriteDr4):
     ; There's no obvious reason to access this register, since it's aliased to
     ; DR6 when DE=0 or an exception generated when DE=1
     ;
-    DB      0xf, 0x23, 0xe1
+    mov     dr4, rcx
     mov     rax, rcx
     ret
 

--- a/MdePkg/Library/BaseLib/X64/WriteDr5.nasm
+++ b/MdePkg/Library/BaseLib/X64/WriteDr5.nasm
@@ -1,6 +1,6 @@
 ;------------------------------------------------------------------------------
 ;
-; Copyright (c) 2006 - 2008, Intel Corporation. All rights reserved.<BR>
+; Copyright (c) 2006 - 2021, Intel Corporation. All rights reserved.<BR>
 ; SPDX-License-Identifier: BSD-2-Clause-Patent
 ;
 ; Module Name:
@@ -31,7 +31,7 @@ ASM_PFX(AsmWriteDr5):
     ; There's no obvious reason to access this register, since it's aliased to
     ; DR7 when DE=0 or an exception generated when DE=1
     ;
-    DB      0xf, 0x23, 0xe9
+    mov     dr5, rcx
     mov     rax, rcx
     ret
 

--- a/MdePkg/Library/BaseLib/X64/WriteMm0.nasm
+++ b/MdePkg/Library/BaseLib/X64/WriteMm0.nasm
@@ -1,6 +1,6 @@
 ;------------------------------------------------------------------------------
 ;
-; Copyright (c) 2006, Intel Corporation. All rights reserved.<BR>
+; Copyright (c) 2006 - 2021, Intel Corporation. All rights reserved.<BR>
 ; SPDX-License-Identifier: BSD-2-Clause-Patent
 ;
 ; Module Name:
@@ -27,9 +27,6 @@
 ;------------------------------------------------------------------------------
 global ASM_PFX(AsmWriteMm0)
 ASM_PFX(AsmWriteMm0):
-    ;
-    ; 64-bit MASM doesn't support MMX instructions, so use opcode here
-    ;
-    DB      0x48, 0xf, 0x6e, 0xc1
+    movq    mm0, rcx
     ret
 

--- a/MdePkg/Library/BaseLib/X64/WriteMm1.nasm
+++ b/MdePkg/Library/BaseLib/X64/WriteMm1.nasm
@@ -1,6 +1,6 @@
 ;------------------------------------------------------------------------------
 ;
-; Copyright (c) 2006, Intel Corporation. All rights reserved.<BR>
+; Copyright (c) 2006 - 2021, Intel Corporation. All rights reserved.<BR>
 ; SPDX-License-Identifier: BSD-2-Clause-Patent
 ;
 ; Module Name:
@@ -27,9 +27,6 @@
 ;------------------------------------------------------------------------------
 global ASM_PFX(AsmWriteMm1)
 ASM_PFX(AsmWriteMm1):
-    ;
-    ; 64-bit MASM doesn't support MMX instructions, so use opcode here
-    ;
-    DB      0x48, 0xf, 0x6e, 0xc9
+    movq    mm1, rcx
     ret
 

--- a/MdePkg/Library/BaseLib/X64/WriteMm2.nasm
+++ b/MdePkg/Library/BaseLib/X64/WriteMm2.nasm
@@ -1,6 +1,6 @@
 ;------------------------------------------------------------------------------
 ;
-; Copyright (c) 2006, Intel Corporation. All rights reserved.<BR>
+; Copyright (c) 2006 - 2021, Intel Corporation. All rights reserved.<BR>
 ; SPDX-License-Identifier: BSD-2-Clause-Patent
 ;
 ; Module Name:
@@ -27,9 +27,6 @@
 ;------------------------------------------------------------------------------
 global ASM_PFX(AsmWriteMm2)
 ASM_PFX(AsmWriteMm2):
-    ;
-    ; 64-bit MASM doesn't support MMX instructions, so use opcode here
-    ;
-    DB      0x48, 0xf, 0x6e, 0xd1
+    movq    mm2, rcx
     ret
 

--- a/MdePkg/Library/BaseLib/X64/WriteMm3.nasm
+++ b/MdePkg/Library/BaseLib/X64/WriteMm3.nasm
@@ -1,6 +1,6 @@
 ;------------------------------------------------------------------------------
 ;
-; Copyright (c) 2006, Intel Corporation. All rights reserved.<BR>
+; Copyright (c) 2006 - 2021, Intel Corporation. All rights reserved.<BR>
 ; SPDX-License-Identifier: BSD-2-Clause-Patent
 ;
 ; Module Name:
@@ -27,9 +27,6 @@
 ;------------------------------------------------------------------------------
 global ASM_PFX(AsmWriteMm3)
 ASM_PFX(AsmWriteMm3):
-    ;
-    ; 64-bit MASM doesn't support MMX instructions, so use opcode here
-    ;
-    DB      0x48, 0xf, 0x6e, 0xd9
+    movq    mm3, rcx
     ret
 

--- a/MdePkg/Library/BaseLib/X64/WriteMm4.nasm
+++ b/MdePkg/Library/BaseLib/X64/WriteMm4.nasm
@@ -1,6 +1,6 @@
 ;------------------------------------------------------------------------------
 ;
-; Copyright (c) 2006, Intel Corporation. All rights reserved.<BR>
+; Copyright (c) 2006 - 2021, Intel Corporation. All rights reserved.<BR>
 ; SPDX-License-Identifier: BSD-2-Clause-Patent
 ;
 ; Module Name:
@@ -27,9 +27,6 @@
 ;------------------------------------------------------------------------------
 global ASM_PFX(AsmWriteMm4)
 ASM_PFX(AsmWriteMm4):
-    ;
-    ; 64-bit MASM doesn't support MMX instructions, so use opcode here
-    ;
-    DB      0x48, 0xf, 0x6e, 0xe1
+    movq    mm4, rcx
     ret
 

--- a/MdePkg/Library/BaseLib/X64/WriteMm5.nasm
+++ b/MdePkg/Library/BaseLib/X64/WriteMm5.nasm
@@ -1,6 +1,6 @@
 ;------------------------------------------------------------------------------
 ;
-; Copyright (c) 2006, Intel Corporation. All rights reserved.<BR>
+; Copyright (c) 2006 - 2021, Intel Corporation. All rights reserved.<BR>
 ; SPDX-License-Identifier: BSD-2-Clause-Patent
 ;
 ; Module Name:
@@ -27,9 +27,6 @@
 ;------------------------------------------------------------------------------
 global ASM_PFX(AsmWriteMm5)
 ASM_PFX(AsmWriteMm5):
-    ;
-    ; 64-bit MASM doesn't support MMX instructions, so use opcode here
-    ;
-    DB      0x48, 0xf, 0x6e, 0xe9
+    movq    mm5, rcx
     ret
 

--- a/MdePkg/Library/BaseLib/X64/WriteMm6.nasm
+++ b/MdePkg/Library/BaseLib/X64/WriteMm6.nasm
@@ -1,6 +1,6 @@
 ;------------------------------------------------------------------------------
 ;
-; Copyright (c) 2006, Intel Corporation. All rights reserved.<BR>
+; Copyright (c) 2006 - 2021, Intel Corporation. All rights reserved.<BR>
 ; SPDX-License-Identifier: BSD-2-Clause-Patent
 ;
 ; Module Name:
@@ -27,9 +27,6 @@
 ;------------------------------------------------------------------------------
 global ASM_PFX(AsmWriteMm6)
 ASM_PFX(AsmWriteMm6):
-    ;
-    ; 64-bit MASM doesn't support MMX instructions, so use opcode here
-    ;
-    DB      0x48, 0xf, 0x6e, 0xf1
+    movq    mm6, rcx
     ret
 

--- a/MdePkg/Library/BaseLib/X64/WriteMm7.nasm
+++ b/MdePkg/Library/BaseLib/X64/WriteMm7.nasm
@@ -1,6 +1,6 @@
 ;------------------------------------------------------------------------------
 ;
-; Copyright (c) 2006, Intel Corporation. All rights reserved.<BR>
+; Copyright (c) 2006 - 2021, Intel Corporation. All rights reserved.<BR>
 ; SPDX-License-Identifier: BSD-2-Clause-Patent
 ;
 ; Module Name:
@@ -27,9 +27,6 @@
 ;------------------------------------------------------------------------------
 global ASM_PFX(AsmWriteMm7)
 ASM_PFX(AsmWriteMm7):
-    ;
-    ; 64-bit MASM doesn't support MMX instructions, so use opcode here
-    ;
-    DB      0x48, 0xf, 0x6e, 0xf9
+    movq    mm7, rcx
     ret
 

--- a/MdePkg/Library/BaseMemoryLibMmx/X64/CopyMem.nasm
+++ b/MdePkg/Library/BaseMemoryLibMmx/X64/CopyMem.nasm
@@ -1,6 +1,6 @@
 ;------------------------------------------------------------------------------
 ;
-; Copyright (c) 2006, Intel Corporation. All rights reserved.<BR>
+; Copyright (c) 2006 - 2021, Intel Corporation. All rights reserved.<BR>
 ; SPDX-License-Identifier: BSD-2-Clause-Patent
 ;
 ; Module Name:
@@ -44,15 +44,15 @@ ASM_PFX(InternalMemCopyMem):
     and     r8, 7
     shr     rcx, 3                      ; rcx <- # of Qwords to copy
     jz      @CopyBytes
-    DB      0x49, 0xf, 0x7e, 0xc2         ; movd r10, mm0 (Save mm0 in r10)
+    movq    r10, mm0
 .1:
-    DB      0xf, 0x6f, 0x6               ; movd mm0, [rsi]
-    DB      0xf, 0xe7, 0x7              ; movntq [rdi], mm0
+    movq    mm0, [rsi]
+    movntq  [rdi], mm0
     add     rsi, 8
     add     rdi, 8
     loop    .1
     mfence
-    DB      0x49, 0xf, 0x6e, 0xc2         ; movd mm0, r10 (Restore mm0)
+    movq    mm0, r10
     jmp     @CopyBytes
 @CopyBackward:
     mov     rsi, r9                     ; rsi <- End of Source

--- a/MdePkg/Library/BaseMemoryLibMmx/X64/SetMem.nasm
+++ b/MdePkg/Library/BaseMemoryLibMmx/X64/SetMem.nasm
@@ -1,6 +1,6 @@
 ;------------------------------------------------------------------------------
 ;
-; Copyright (c) 2006, Intel Corporation. All rights reserved.<BR>
+; Copyright (c) 2006 - 2021, Intel Corporation. All rights reserved.<BR>
 ; SPDX-License-Identifier: BSD-2-Clause-Patent
 ;
 ; Module Name:
@@ -32,16 +32,16 @@ ASM_PFX(InternalMemSetMem):
     push    rdi
     mov     rax, r8
     mov     ah, al
-    DB      0x48, 0xf, 0x6e, 0xc0         ; movd mm0, rax
+    movq    mm0, rax
     mov     r8, rcx
     mov     rdi, r8                     ; rdi <- Buffer
     mov     rcx, rdx
     and     edx, 7
     shr     rcx, 3
     jz      @SetBytes
-    DB      0xf, 0x70, 0xC0, 0x0         ; pshufw mm0, mm0, 0h
+    pshufw  mm0, mm0, 0
 .0:
-    DB      0xf, 0xe7, 0x7              ; movntq [rdi], mm0
+    movntq  [rdi], mm0
     add     rdi, 8
     loop    .0
     mfence

--- a/MdePkg/Library/BaseMemoryLibMmx/X64/SetMem16.nasm
+++ b/MdePkg/Library/BaseMemoryLibMmx/X64/SetMem16.nasm
@@ -1,6 +1,6 @@
 ;------------------------------------------------------------------------------
 ;
-; Copyright (c) 2006, Intel Corporation. All rights reserved.<BR>
+; Copyright (c) 2006 - 2021, Intel Corporation. All rights reserved.<BR>
 ; SPDX-License-Identifier: BSD-2-Clause-Patent
 ;
 ; Module Name:
@@ -31,16 +31,16 @@ global ASM_PFX(InternalMemSetMem16)
 ASM_PFX(InternalMemSetMem16):
     push    rdi
     mov     rax, r8
-    DB      0x48, 0xf, 0x6e, 0xc0         ; movd mm0, rax
+    movq    mm0, rax
     mov     r8, rcx
     mov     rdi, r8
     mov     rcx, rdx
     and     edx, 3
     shr     rcx, 2
     jz      @SetWords
-    DB      0xf, 0x70, 0xC0, 0x0         ; pshufw mm0, mm0, 0h
+    pshufw  mm0, mm0, 0
 .0:
-    DB      0xf, 0xe7, 0x7              ; movntq [rdi], mm0
+    movntq  [rdi], mm0
     add     rdi, 8
     loop    .0
     mfence

--- a/MdePkg/Library/BaseMemoryLibMmx/X64/SetMem32.nasm
+++ b/MdePkg/Library/BaseMemoryLibMmx/X64/SetMem32.nasm
@@ -1,6 +1,6 @@
 ;------------------------------------------------------------------------------
 ;
-; Copyright (c) 2006, Intel Corporation. All rights reserved.<BR>
+; Copyright (c) 2006 - 2021, Intel Corporation. All rights reserved.<BR>
 ; SPDX-License-Identifier: BSD-2-Clause-Patent
 ;
 ; Module Name:
@@ -28,20 +28,20 @@
 ;------------------------------------------------------------------------------
 global ASM_PFX(InternalMemSetMem32)
 ASM_PFX(InternalMemSetMem32):
-    DB      0x49, 0xf, 0x6e, 0xc0         ; movd mm0, r8 (Value)
+    movq    mm0, r8
     mov     rax, rcx                    ; rax <- Buffer
     xchg    rcx, rdx                    ; rcx <- Count  rdx <- Buffer
     shr     rcx, 1                      ; rcx <- # of qwords to set
     jz      @SetDwords
-    DB      0xf, 0x70, 0xC0, 0x44         ; pshufw mm0, mm0, 44h
+    pshufw  mm0, mm0, 44h
 .0:
-    DB      0xf, 0xe7, 0x2              ; movntq [rdx], mm0
+    movntq  [rdx], mm0
     lea     rdx, [rdx + 8]              ; use "lea" to avoid flag changes
     loop    .0
     mfence
 @SetDwords:
     jnc     .1
-    DB      0xf, 0x7e, 0x2               ; movd [rdx], mm0
+    movd    [rdx], mm0
 .1:
     ret
 

--- a/MdePkg/Library/BaseMemoryLibMmx/X64/SetMem64.nasm
+++ b/MdePkg/Library/BaseMemoryLibMmx/X64/SetMem64.nasm
@@ -1,6 +1,6 @@
 ;------------------------------------------------------------------------------
 ;
-; Copyright (c) 2006, Intel Corporation. All rights reserved.<BR>
+; Copyright (c) 2006 - 2021, Intel Corporation. All rights reserved.<BR>
 ; SPDX-License-Identifier: BSD-2-Clause-Patent
 ;
 ; Module Name:
@@ -28,11 +28,11 @@
 ;------------------------------------------------------------------------------
 global ASM_PFX(InternalMemSetMem64)
 ASM_PFX(InternalMemSetMem64):
-    DB      0x49, 0xf, 0x6e, 0xc0         ; movd mm0, r8 (Value)
+    movq    mm0, r8
     mov     rax, rcx                    ; rax <- Buffer
     xchg    rcx, rdx                    ; rcx <- Count
 .0:
-    DB      0xf, 0xe7, 0x2              ; movntq  [rdx], mm0
+    movntq  [rdx], mm0
     add     rdx, 8
     loop    .0
     mfence

--- a/MdePkg/Library/BaseMemoryLibMmx/X64/ZeroMem.nasm
+++ b/MdePkg/Library/BaseMemoryLibMmx/X64/ZeroMem.nasm
@@ -1,6 +1,6 @@
 ;------------------------------------------------------------------------------
 ;
-; Copyright (c) 2006, Intel Corporation. All rights reserved.<BR>
+; Copyright (c) 2006 - 2021, Intel Corporation. All rights reserved.<BR>
 ; SPDX-License-Identifier: BSD-2-Clause-Patent
 ;
 ; Module Name:
@@ -34,12 +34,12 @@ ASM_PFX(InternalMemZeroMem):
     and     edx, 7
     shr     rcx, 3
     jz      @ZeroBytes
-    DB      0xf, 0xef, 0xc0             ; pxor mm0, mm0
+    pxor    mm0, mm0
 .0:
-    DB      0xf, 0xe7, 7                ; movntq [rdi], mm0
+    movntq  [rdi], mm0
     add     rdi, 8
     loop    .0
-    DB      0xf, 0xae, 0xf0             ; mfence
+    mfence
 @ZeroBytes:
     xor     eax, eax
     mov     ecx, edx

--- a/SourceLevelDebugPkg/Library/DebugAgent/DebugAgentCommon/Ia32/AsmFuncs.nasm
+++ b/SourceLevelDebugPkg/Library/DebugAgent/DebugAgentCommon/Ia32/AsmFuncs.nasm
@@ -1,6 +1,6 @@
 ;------------------------------------------------------------------------------
 ;
-; Copyright (c) 2010 - 2015, Intel Corporation. All rights reserved.<BR>
+; Copyright (c) 2010 - 2021, Intel Corporation. All rights reserved.<BR>
 ; SPDX-License-Identifier: BSD-2-Clause-Patent
 ;
 ; Module Name:
@@ -321,7 +321,7 @@ NoExtrPush:
     test    edx, BIT24  ; Test for FXSAVE/FXRESTOR support.
                         ; edx still contains result from CPUID above
     jz      .2
-    db 0xf, 0xae, 00000111y ;fxsave [edi]
+    fxsave  [edi]
 .2:
 
     ;; save the exception data
@@ -342,7 +342,7 @@ NoExtrPush:
     cpuid               ; use CPUID to determine if FXSAVE/FXRESTOR are supported
     test    edx, BIT24  ; Test for FXSAVE/FXRESTOR support
     jz      .3
-    db 0xf, 0xae, 00001110y ; fxrstor [esi]
+    fxrstor [esi]
 .3:
     add esp, 512
 

--- a/SourceLevelDebugPkg/Library/DebugAgent/DebugAgentCommon/X64/AsmFuncs.nasm
+++ b/SourceLevelDebugPkg/Library/DebugAgent/DebugAgentCommon/X64/AsmFuncs.nasm
@@ -1,6 +1,6 @@
 ;------------------------------------------------------------------------------
 ;
-; Copyright (c) 2016, Intel Corporation. All rights reserved.<BR>
+; Copyright (c) 2016 - 2021, Intel Corporation. All rights reserved.<BR>
 ; SPDX-License-Identifier: BSD-2-Clause-Patent
 ;
 ; Module Name:
@@ -293,7 +293,7 @@ NoExtrPush:
     rep     stosq
     pop     rcx
     mov     rdi, rsp
-    db 0xf, 0xae, 00000111y ;fxsave [rdi]
+    fxsave  [rdi]
 
     ;; save the exception data
     push    qword [rbp + 16]
@@ -314,7 +314,7 @@ NoExtrPush:
     add     rsp, 8
 
     mov     rsi, rsp
-    db 0xf, 0xae, 00001110y ; fxrstor [rsi]
+    fxrstor [rsi]
     add     rsp, 512
 
     ;; UINT64  Dr0, Dr1, Dr2, Dr3, Dr6, Dr7;

--- a/UefiCpuPkg/CpuDxe/X64/CpuAsm.nasm
+++ b/UefiCpuPkg/CpuDxe/X64/CpuAsm.nasm
@@ -1,6 +1,6 @@
 ;------------------------------------------------------------------------------
 ;*
-;*   Copyright (c) 2016, Intel Corporation. All rights reserved.<BR>
+;*   Copyright (c) 2016 - 2021, Intel Corporation. All rights reserved.<BR>
 ;*   SPDX-License-Identifier: BSD-2-Clause-Patent
 ;*
 ;*    CpuAsm.nasm
@@ -23,7 +23,7 @@ ASM_PFX(SetCodeSelector):
     push    rcx
     lea     rax, [setCodeSelectorLongJump]
     push    rax
-    o64 retf
+    retfq
 setCodeSelectorLongJump:
     ret
 

--- a/UefiCpuPkg/Library/CpuExceptionHandlerLib/Ia32/ExceptionHandlerAsm.nasm
+++ b/UefiCpuPkg/Library/CpuExceptionHandlerLib/Ia32/ExceptionHandlerAsm.nasm
@@ -1,5 +1,5 @@
 ;------------------------------------------------------------------------------ ;
-; Copyright (c) 2016, Intel Corporation. All rights reserved.<BR>
+; Copyright (c) 2016 - 2021, Intel Corporation. All rights reserved.<BR>
 ; SPDX-License-Identifier: BSD-2-Clause-Patent
 ;
 ; Module Name:
@@ -32,12 +32,13 @@ ALIGN   8
 ; exception handler stub table
 ;
 AsmIdtVectorBegin:
+%assign Vector 0
 %rep  32
-    db      0x6a        ; push  #VectorNum
-    db      ($ - AsmIdtVectorBegin) / ((AsmIdtVectorEnd - AsmIdtVectorBegin) / 32) ; VectorNum
+    push    byte %[Vector];
     push    eax
     mov     eax, ASM_PFX(CommonInterruptEntry)
     jmp     eax
+%assign Vector Vector+1
 %endrep
 AsmIdtVectorEnd:
 
@@ -287,7 +288,7 @@ ErrorCodeAndVectorOnStack:
     test    edx, BIT24  ; Test for FXSAVE/FXRESTOR support.
                         ; edx still contains result from CPUID above
     jz      .3
-    db      0xf, 0xae, 0x7 ;fxsave [edi]
+    fxsave  [edi]
 .3:
 
 ;; UEFI calling convention for IA32 requires that Direction flag in EFLAGs is clear
@@ -320,7 +321,7 @@ ErrorCodeAndVectorOnStack:
                         ; are supported
     test    edx, BIT24  ; Test for FXSAVE/FXRESTOR support
     jz      .4
-    db      0xf, 0xae, 0xe ; fxrstor [esi]
+    fxrstor [esi]
 .4:
     add     esp, 512
 

--- a/UefiCpuPkg/Library/CpuExceptionHandlerLib/Ia32/ExceptionTssEntryAsm.nasm
+++ b/UefiCpuPkg/Library/CpuExceptionHandlerLib/Ia32/ExceptionTssEntryAsm.nasm
@@ -1,5 +1,5 @@
 ;------------------------------------------------------------------------------ ;
-; Copyright (c) 2017, Intel Corporation. All rights reserved.<BR>
+; Copyright (c) 2017 - 2021, Intel Corporation. All rights reserved.<BR>
 ; SPDX-License-Identifier: BSD-2-Clause-Patent
 ;
 ; Module Name:
@@ -79,8 +79,7 @@ AsmExceptionEntryBegin:
 DoIret%[Vector]:
     iretd
 ASM_PFX(ExceptionTaskSwtichEntry%[Vector]):
-    db      0x6a        ; push  #VectorNum
-    db      %[Vector]
+    push    byte %[Vector]
     mov     eax, ASM_PFX(CommonTaskSwtichEntryPoint)
     call    eax
     mov     esp, eax    ; Restore stack top
@@ -244,7 +243,7 @@ ASM_PFX(CommonTaskSwtichEntryPoint):
     clts
     sub     esp, 512
     mov     edi, esp
-    db      0xf, 0xae, 0x7 ;fxsave [edi]
+    fxsave  [edi]
 .3:
 
 ;; UINT32  ExceptionData;
@@ -277,7 +276,7 @@ ASM_PFX(CommonTaskSwtichEntryPoint):
     test    edx, BIT24      ; Test for FXSAVE/FXRESTOR support
     jz      .4
     mov     esi, esp
-    db      0xf, 0xae, 0xe  ; fxrstor [esi]
+    fxrstor [esi]
 .4:
     add     esp, 512
 

--- a/UefiCpuPkg/Library/CpuExceptionHandlerLib/X64/ExceptionHandlerAsm.nasm
+++ b/UefiCpuPkg/Library/CpuExceptionHandlerLib/X64/ExceptionHandlerAsm.nasm
@@ -1,5 +1,5 @@
 ;------------------------------------------------------------------------------ ;
-; Copyright (c) 2012 - 2018, Intel Corporation. All rights reserved.<BR>
+; Copyright (c) 2012 - 2021, Intel Corporation. All rights reserved.<BR>
 ; SPDX-License-Identifier: BSD-2-Clause-Patent
 ;
 ; Module Name:
@@ -32,12 +32,13 @@ SECTION .text
 ALIGN   8
 
 AsmIdtVectorBegin:
+%assign Vector 0
 %rep  32
-    db      0x6a        ; push  #VectorNum
-    db      ($ - AsmIdtVectorBegin) / ((AsmIdtVectorEnd - AsmIdtVectorBegin) / 32) ; VectorNum
+    push    byte %[Vector]
     push    rax
     mov     rax, ASM_PFX(CommonInterruptEntry)
     jmp     rax
+%assign Vector Vector+1
 %endrep
 AsmIdtVectorEnd:
 
@@ -257,7 +258,7 @@ DrFinish:
 ;; FX_SAVE_STATE_X64 FxSaveState;
     sub rsp, 512
     mov rdi, rsp
-    db 0xf, 0xae, 0x7 ;fxsave [rdi]
+    fxsave [rdi]
 
 ;; UEFI calling convention for x64 requires that Direction flag in EFLAGs is clear
     cld
@@ -284,7 +285,7 @@ DrFinish:
 ;; FX_SAVE_STATE_X64 FxSaveState;
 
     mov rsi, rsp
-    db 0xf, 0xae, 0xE ; fxrstor [rsi]
+    fxrstor [rsi]
     add rsp, 512
 
 ;; UINT64  Dr0, Dr1, Dr2, Dr3, Dr6, Dr7;
@@ -371,8 +372,7 @@ DoReturn:
     push    qword [rax + 0x18]       ; save EFLAGS in new location
     mov     rax, [rax]        ; restore rax
     popfq                     ; restore EFLAGS
-    DB      0x48               ; prefix to composite "retq" with next "retf"
-    retf                      ; far return
+    retfq
 DoIret:
     iretq
 

--- a/UefiCpuPkg/Library/CpuExceptionHandlerLib/X64/Xcode5ExceptionHandlerAsm.nasm
+++ b/UefiCpuPkg/Library/CpuExceptionHandlerLib/X64/Xcode5ExceptionHandlerAsm.nasm
@@ -1,5 +1,5 @@
 ;------------------------------------------------------------------------------ ;
-; Copyright (c) 2012 - 2018, Intel Corporation. All rights reserved.<BR>
+; Copyright (c) 2012 - 2021, Intel Corporation. All rights reserved.<BR>
 ; SPDX-License-Identifier: BSD-2-Clause-Patent
 ;
 ; Module Name:
@@ -54,12 +54,13 @@ SECTION .text
 ALIGN   8
 
 AsmIdtVectorBegin:
+%assign Vector 0
 %rep  32
-    db      0x6a        ; push  #VectorNum
-    db      ($ - AsmIdtVectorBegin) / ((AsmIdtVectorEnd - AsmIdtVectorBegin) / 32) ; VectorNum
+    push    byte %[Vector]
     push    rax
     mov     rax, strict qword 0 ;    mov     rax, ASM_PFX(CommonInterruptEntry)
     jmp     rax
+%assign Vector Vector+1
 %endrep
 AsmIdtVectorEnd:
 
@@ -280,7 +281,7 @@ DrFinish:
 ;; FX_SAVE_STATE_X64 FxSaveState;
     sub rsp, 512
     mov rdi, rsp
-    db 0xf, 0xae, 0x7 ;fxsave [rdi]
+    fxsave [rdi]
 
 ;; UEFI calling convention for x64 requires that Direction flag in EFLAGs is clear
     cld
@@ -335,15 +336,15 @@ DrFinish:
     jz      CetDone
                                 ; SSP should be 0xFC0 at this point
     mov     rax, 0x04           ; advance past cs:lip:prevssp;supervisor shadow stack token
-    INCSSP_RAX                  ; After this SSP should be 0xFE0
-    SAVEPREVSSP                 ; now the shadow stack restore token will be created at 0xFB8
-    READSSP_RAX                 ; Read new SSP, SSP should be 0xFE8
+    incsspq rax                 ; After this SSP should be 0xFE0
+    saveprevssp                 ; now the shadow stack restore token will be created at 0xFB8
+    rdsspq  rax                 ; Read new SSP, SSP should be 0xFE8
     sub     rax, 0x10
-    CLRSSBSY_RAX                ; Clear token at 0xFD8, SSP should be 0 after this
+    clrssbsy [rax]              ; Clear token at 0xFD8, SSP should be 0 after this
     sub     rax, 0x20
-    RSTORSSP_RAX                ; Restore to token at 0xFB8, new SSP will be 0xFB8
+    rstorssp [rax]              ; Restore to token at 0xFB8, new SSP will be 0xFB8
     mov     rax, 0x01           ; Pop off the new save token created
-    INCSSP_RAX                  ; SSP should be 0xFC0 now
+    incsspq rax                 ; SSP should be 0xFC0 now
 CetDone:
 
     cli
@@ -353,7 +354,7 @@ CetDone:
 ;; FX_SAVE_STATE_X64 FxSaveState;
 
     mov rsi, rsp
-    db 0xf, 0xae, 0xE ; fxrstor [rsi]
+    fxrstor [rsi]
     add rsp, 512
 
 ;; UINT64  Dr0, Dr1, Dr2, Dr3, Dr6, Dr7;
@@ -440,8 +441,7 @@ DoReturn:
     push    qword [rax + 0x18]       ; save EFLAGS in new location
     mov     rax, [rax]        ; restore rax
     popfq                     ; restore EFLAGS
-    DB      0x48                ; prefix to composite "retq" with next "retf"
-    retf                        ; far return
+    retfq
 DoIret:
     iretq
 

--- a/UefiCpuPkg/Library/MpInitLib/X64/MpFuncs.nasm
+++ b/UefiCpuPkg/Library/MpInitLib/X64/MpFuncs.nasm
@@ -345,7 +345,7 @@ BITS 64
     ;
     ; Far return into 32-bit mode
     ;
-o64 retf
+    retfq
 
 BITS 32
 CompatMode:
@@ -507,7 +507,7 @@ NoSevEs:
     ;
     ; Far return into 32-bit mode
     ;
-o64 retf
+    retfq
 
 BITS 32
 PmEntry:

--- a/UefiCpuPkg/PiSmmCpuDxeSmm/Ia32/Cet.nasm
+++ b/UefiCpuPkg/PiSmmCpuDxeSmm/Ia32/Cet.nasm
@@ -1,5 +1,5 @@
 ;------------------------------------------------------------------------------ ;
-; Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
+; Copyright (c) 2019 - 2021, Intel Corporation. All rights reserved.<BR>
 ; SPDX-License-Identifier: BSD-2-Clause-Patent
 ;
 ;-------------------------------------------------------------------------------
@@ -13,7 +13,7 @@ ASM_PFX(DisableCet):
 
     ; Skip the pushed data for call
     mov     eax, 1
-    INCSSP_EAX
+    incsspd eax
 
     mov     eax, cr4
     btr     eax, 23                      ; clear CET

--- a/UefiCpuPkg/PiSmmCpuDxeSmm/Ia32/SmiEntry.nasm
+++ b/UefiCpuPkg/PiSmmCpuDxeSmm/Ia32/SmiEntry.nasm
@@ -1,5 +1,5 @@
 ;------------------------------------------------------------------------------ ;
-; Copyright (c) 2016 - 2019, Intel Corporation. All rights reserved.<BR>
+; Copyright (c) 2016 - 2021, Intel Corporation. All rights reserved.<BR>
 ; Copyright (c) 2020, AMD Incorporated. All rights reserved.<BR>
 ; SPDX-License-Identifier: BSD-2-Clause-Patent
 ;
@@ -252,7 +252,7 @@ CetInterruptDone:
     mov     eax, 0x668 | CR4_CET
     mov     cr4, eax
 
-    SETSSBSY
+    setssbsy
 
 CetDone:
 

--- a/UefiCpuPkg/PiSmmCpuDxeSmm/X64/Cet.nasm
+++ b/UefiCpuPkg/PiSmmCpuDxeSmm/X64/Cet.nasm
@@ -1,5 +1,5 @@
 ;------------------------------------------------------------------------------ ;
-; Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
+; Copyright (c) 2019 - 2021, Intel Corporation. All rights reserved.<BR>
 ; SPDX-License-Identifier: BSD-2-Clause-Patent
 ;
 ;-------------------------------------------------------------------------------
@@ -14,7 +14,7 @@ ASM_PFX(DisableCet):
 
     ; Skip the pushed data for call
     mov     rax, 1
-    INCSSP_RAX
+    incsspq rax
 
     mov     rax, cr4
     btr     eax, 23                      ; clear CET

--- a/UefiCpuPkg/PiSmmCpuDxeSmm/X64/SmiEntry.nasm
+++ b/UefiCpuPkg/PiSmmCpuDxeSmm/X64/SmiEntry.nasm
@@ -1,5 +1,5 @@
 ;------------------------------------------------------------------------------ ;
-; Copyright (c) 2016 - 2019, Intel Corporation. All rights reserved.<BR>
+; Copyright (c) 2016 - 2021, Intel Corporation. All rights reserved.<BR>
 ; Copyright (c) 2020, AMD Incorporated. All rights reserved.<BR>
 ; SPDX-License-Identifier: BSD-2-Clause-Patent
 ;
@@ -279,7 +279,7 @@ CetInterruptDone:
     mov     eax, 0x668 | CR4_CET
     mov     cr4, rax
 
-    SETSSBSY
+    setssbsy
 
 CetDone:
 


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3790

Replace Opcode with the corresponding instructions.
The code changes have been verified with CompareBuild.py tool, which can be used to compare the results of two different EDK II builds to determine if they generate the same binaries. (the tool link: https://github.com/mdkinney/edk2)