### PR TITLE
BaseTools: Fix the bug of --cmd-len build option

### DIFF
--- a/BaseTools/Source/Python/AutoGen/AutoGenWorker.py
+++ b/BaseTools/Source/Python/AutoGen/AutoGenWorker.py
@@ -198,6 +198,7 @@ class AutoGenWorkerInProcess(mp.Process):
             self.Wa._SrcTimeStamp = self.data_pipe.Get("Workspace_timestamp")
             GlobalData.gGlobalDefines = self.data_pipe.Get("G_defines")
             GlobalData.gCommandLineDefines = self.data_pipe.Get("CL_defines")
+            GlobalData.gCommandMaxLength = self.data_pipe.Get('gCommandMaxLength')
             os.environ._data = self.data_pipe.Get("Env_Var")
             GlobalData.gWorkspace = workspacedir
             GlobalData.gDisableIncludePathCheck = False

--- a/BaseTools/Source/Python/AutoGen/DataPipe.py
+++ b/BaseTools/Source/Python/AutoGen/DataPipe.py
@@ -148,6 +148,8 @@ class MemoryDataPipe(DataPipe):
 
         self.DataContainer = {"CL_defines": GlobalData.gCommandLineDefines}
 
+        self.DataContainer = {"gCommandMaxLength": GlobalData.gCommandMaxLength}
+
         self.DataContainer = {"Env_Var": {k:v for k, v in os.environ.items()}}
 
         self.DataContainer = {"PackageList": [(dec.MetaFile,dec.Arch) for dec in PlatformInfo.PackageList]}


### PR DESCRIPTION
currently the --cmd-len build option does not work.
This patch is going to fix this bug.

Signed-off-by: Bob Feng <bob.c.feng@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Yuwei Chen <yuwei.chen@intel.com>
Reviewed-by: Yuwei Chen <yuwei.chen@intel.com>