### PR TITLE
IntelFsp2Pkg/FspSecCore: ExtendedImageRevision was not printed.

### DIFF
--- a/IntelFsp2Pkg/FspSecCore/SecFsp.c
+++ b/IntelFsp2Pkg/FspSecCore/SecFsp.c
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2014 - 2020, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2014 - 2021, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -199,8 +199,12 @@ FspGlobalDataInit (
     ImageId, \
     (PeiFspData->FspInfoHeader->ImageRevision >> 24) & 0xFF, \
     (PeiFspData->FspInfoHeader->ImageRevision >> 16) & 0xFF, \
-    (PeiFspData->FspInfoHeader->ImageRevision >> 8) & 0xFF, \
-    PeiFspData->FspInfoHeader->ImageRevision & 0xFF
+    (PeiFspData->FspInfoHeader->HeaderRevision >= 6) ? \
+      (((PeiFspData->FspInfoHeader->ImageRevision >> 8) & 0xFF) | (PeiFspData->FspInfoHeader->ExtendedImageRevision & 0xFF00)) :\
+        ((PeiFspData->FspInfoHeader->ImageRevision >> 8) & 0xFF), \
+    (PeiFspData->FspInfoHeader->HeaderRevision >= 6) ? \
+      ((PeiFspData->FspInfoHeader->ImageRevision & 0xFF) | ((PeiFspData->FspInfoHeader->ExtendedImageRevision & 0xFF) << 8)): \
+        (PeiFspData->FspInfoHeader->ImageRevision & 0xFF)
     ));
 }
 


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3791

ExtendedImageRevision should be printed when Header revision >= 6.

Cc: Maurice Ma <maurice.ma@intel.com>
Cc: Nate DeSimone <nathaniel.l.desimone@intel.com>
Cc: Star Zeng <star.zeng@intel.com>
Signed-off-by: Chasel Chiu <chasel.chiu@intel.com>
Reviewed-by: Star Zeng <star.zeng@intel.com>