### PR TITLE
[PATCH] Update FvLength to UINTN from UINT32 in FirmwareVolumeInfo

### DIFF
--- a/EmulatorPkg/Library/SecPeiServicesLib/PeiServicesLib.c
+++ b/EmulatorPkg/Library/SecPeiServicesLib/PeiServicesLib.c
@@ -545,7 +545,7 @@ EFIAPI
 PeiServicesInstallFvInfoPpi (
   IN CONST EFI_GUID  *FvFormat  OPTIONAL,
   IN CONST VOID      *FvInfo,
-  IN       UINT32    FvInfoSize,
+  IN       UINTN     FvInfoSize,
   IN CONST EFI_GUID  *ParentFvName  OPTIONAL,
   IN CONST EFI_GUID  *ParentFileName OPTIONAL
   )

--- a/IntelFsp2WrapperPkg/FspmWrapperPeim/FspmWrapperPeim.c
+++ b/IntelFsp2WrapperPkg/FspmWrapperPeim/FspmWrapperPeim.c
@@ -195,7 +195,7 @@ FspmWrapperInit (
     PeiServicesInstallFvInfoPpi (
       NULL,
       (VOID *)(UINTN)PcdGet32 (PcdFspmBaseAddress),
-      (UINT32)((EFI_FIRMWARE_VOLUME_HEADER *)(UINTN)PcdGet32 (PcdFspmBaseAddress))->FvLength,
+      (UINTN) ((EFI_FIRMWARE_VOLUME_HEADER *)(UINTN)PcdGet32 (PcdFspmBaseAddress))->FvLength,
       NULL,
       NULL
       );

--- a/IntelFsp2WrapperPkg/FspsWrapperPeim/FspsWrapperPeim.c
+++ b/IntelFsp2WrapperPkg/FspsWrapperPeim/FspsWrapperPeim.c
@@ -426,7 +426,7 @@ FspsWrapperInitDispatchMode (
   PeiServicesInstallFvInfoPpi (
     NULL,
     (VOID *)(UINTN)PcdGet32 (PcdFspsBaseAddress),
-    (UINT32)((EFI_FIRMWARE_VOLUME_HEADER *)(UINTN)PcdGet32 (PcdFspsBaseAddress))->FvLength,
+    (UINTN) ((EFI_FIRMWARE_VOLUME_HEADER *)(UINTN)PcdGet32 (PcdFspsBaseAddress))->FvLength,
     NULL,
     NULL
     );

--- a/MdeModulePkg/Core/Pei/FwVol/FwVol.c
+++ b/MdeModulePkg/Core/Pei/FwVol/FwVol.c
@@ -1542,7 +1542,7 @@ ProcessFvFile (
     PeiServicesInstallFvInfo2Ppi (
       &FvHeader->FileSystemGuid,
       (VOID **)FvHeader,
-      (UINT32)FvHeader->FvLength,
+      (UINTN) FvHeader->FvLength,
       &ParentFvImageInfo.FvName,
       &FileInfo.FileName,
       AuthenticationStatus
@@ -1551,7 +1551,7 @@ ProcessFvFile (
     PeiServicesInstallFvInfoPpi (
       &FvHeader->FileSystemGuid,
       (VOID **)FvHeader,
-      (UINT32)FvHeader->FvLength,
+      (UINTN) FvHeader->FvLength,
       &ParentFvImageInfo.FvName,
       &FileInfo.FileName
       );

--- a/MdeModulePkg/Core/Pei/PeiMain.h
+++ b/MdeModulePkg/Core/Pei/PeiMain.h
@@ -151,7 +151,7 @@ typedef struct {
 typedef struct {
   EFI_GUID                     FvFormat;
   VOID                         *FvInfo;
-  UINT32                       FvInfoSize;
+  UINTN                        FvInfoSize;
   UINT32                       AuthenticationStatus;
   EFI_PEI_NOTIFY_DESCRIPTOR    NotifyDescriptor;
 } PEI_CORE_UNKNOW_FORMAT_FV_INFO;

--- a/MdePkg/Include/Library/PeiServicesLib.h
+++ b/MdePkg/Include/Library/PeiServicesLib.h
@@ -485,7 +485,7 @@ EFIAPI
 PeiServicesInstallFvInfoPpi (
   IN CONST EFI_GUID  *FvFormat  OPTIONAL,
   IN CONST VOID      *FvInfo,
-  IN       UINT32    FvInfoSize,
+  IN       UINTN     FvInfoSize,
   IN CONST EFI_GUID  *ParentFvName  OPTIONAL,
   IN CONST EFI_GUID  *ParentFileName OPTIONAL
   );
@@ -525,7 +525,7 @@ EFIAPI
 PeiServicesInstallFvInfo2Ppi (
   IN CONST EFI_GUID  *FvFormat  OPTIONAL,
   IN CONST VOID      *FvInfo,
-  IN       UINT32    FvInfoSize,
+  IN       UINTN     FvInfoSize,
   IN CONST EFI_GUID  *ParentFvName  OPTIONAL,
   IN CONST EFI_GUID  *ParentFileName  OPTIONAL,
   IN       UINT32    AuthenticationStatus

--- a/MdePkg/Include/Ppi/FirmwareVolumeInfo.h
+++ b/MdePkg/Include/Ppi/FirmwareVolumeInfo.h
@@ -39,7 +39,7 @@ struct _EFI_PEI_FIRMWARE_VOLUME_INFO_PPI {
   /// Size of the data provided by FvInfo. For memory-mapped firmware volumes,
   /// this is typically the size of the firmware volume.
   ///
-  UINT32      FvInfoSize;
+  UINTN       FvInfoSize;
   ///
   /// If the firmware volume originally came from a firmware file, then these
   /// point to the parent firmware volume name and firmware volume file.

--- a/MdePkg/Include/Ppi/FirmwareVolumeInfo2.h
+++ b/MdePkg/Include/Ppi/FirmwareVolumeInfo2.h
@@ -39,7 +39,7 @@ struct _EFI_PEI_FIRMWARE_VOLUME_INFO2_PPI {
   /// Size of the data provided by FvInfo. For memory-mapped firmware volumes,
   /// this is typically the size of the firmware volume.
   ///
-  UINT32      FvInfoSize;
+  UINTN       FvInfoSize;
   ///
   /// If the firmware volume originally came from a firmware file, then these
   /// point to the parent firmware volume name and firmware volume file.

--- a/MdePkg/Library/PeiServicesLib/PeiServicesLib.c
+++ b/MdePkg/Library/PeiServicesLib/PeiServicesLib.c
@@ -622,7 +622,7 @@ InternalPeiServicesInstallFvInfoPpi (
   IN       BOOLEAN   InstallFvInfoPpi,
   IN CONST EFI_GUID  *FvFormat  OPTIONAL,
   IN CONST VOID      *FvInfo,
-  IN       UINT32    FvInfoSize,
+  IN       UINTN     FvInfoSize,
   IN CONST EFI_GUID  *ParentFvName  OPTIONAL,
   IN CONST EFI_GUID  *ParentFileName  OPTIONAL,
   IN       UINT32    AuthenticationStatus
@@ -729,7 +729,7 @@ EFIAPI
 PeiServicesInstallFvInfoPpi (
   IN CONST EFI_GUID  *FvFormat  OPTIONAL,
   IN CONST VOID      *FvInfo,
-  IN       UINT32    FvInfoSize,
+  IN       UINTN     FvInfoSize,
   IN CONST EFI_GUID  *ParentFvName  OPTIONAL,
   IN CONST EFI_GUID  *ParentFileName OPTIONAL
   )
@@ -773,7 +773,7 @@ EFIAPI
 PeiServicesInstallFvInfo2Ppi (
   IN CONST EFI_GUID  *FvFormat  OPTIONAL,
   IN CONST VOID      *FvInfo,
-  IN       UINT32    FvInfoSize,
+  IN       UINTN     FvInfoSize,
   IN CONST EFI_GUID  *ParentFvName  OPTIONAL,
   IN CONST EFI_GUID  *ParentFileName  OPTIONAL,
   IN       UINT32    AuthenticationStatus

--- a/OvmfPkg/Bhyve/PlatformPei/Fv.c
+++ b/OvmfPkg/Bhyve/PlatformPei/Fv.c
@@ -83,7 +83,7 @@ PeiFvInitialization (
   PeiServicesInstallFvInfoPpi (
     NULL,
     (VOID *)(UINTN)PcdGet32 (PcdOvmfDxeMemFvBase),
-    PcdGet32 (PcdOvmfDxeMemFvSize),
+    (UINTN) PcdGet32 (PcdOvmfDxeMemFvSize),
     NULL,
     NULL
     );

--- a/OvmfPkg/PlatformPei/Fv.c
+++ b/OvmfPkg/PlatformPei/Fv.c
@@ -83,7 +83,7 @@ PeiFvInitialization (
   PeiServicesInstallFvInfoPpi (
     NULL,
     (VOID *)(UINTN)PcdGet32 (PcdOvmfDxeMemFvBase),
-    PcdGet32 (PcdOvmfDxeMemFvSize),
+    (UINTN) PcdGet32 (PcdOvmfDxeMemFvSize),
     NULL,
     NULL
     );

--- a/OvmfPkg/XenPlatformPei/Fv.c
+++ b/OvmfPkg/XenPlatformPei/Fv.c
@@ -65,7 +65,7 @@ PeiFvInitialization (
   PeiServicesInstallFvInfoPpi (
     NULL,
     (VOID *)(UINTN)PcdGet32 (PcdOvmfDxeMemFvBase),
-    PcdGet32 (PcdOvmfDxeMemFvSize),
+    (UINTN) PcdGet32 (PcdOvmfDxeMemFvSize),
     NULL,
     NULL
     );

--- a/SecurityPkg/FvReportPei/FvReportPei.c
+++ b/SecurityPkg/FvReportPei/FvReportPei.c
@@ -275,7 +275,7 @@ ReportHashedFv (
     PeiServicesInstallFvInfoPpi (
       FvFormat,
       (VOID *)(UINTN)FvInfo->Base,
-      (UINT32)FvInfo->Length,
+      (UINTN) FvInfo->Length,
       NULL,
       NULL
       );

--- a/SignedCapsulePkg/Universal/RecoveryModuleLoadPei/RecoveryModuleLoadPei.c
+++ b/SignedCapsulePkg/Universal/RecoveryModuleLoadPei/RecoveryModuleLoadPei.c
@@ -483,7 +483,7 @@ CreateHobForRecoveryCapsule (
   PeiServicesInstallFvInfoPpi (
     &FvHeader->FileSystemGuid,
     (VOID *)FvHeader,
-    (UINT32)FvHeader->FvLength,
+    (UINTN) FvHeader->FvLength,
     NULL,
     NULL
     );


### PR DESCRIPTION
Pi/PiFirmwareVolume FvLength has been assigned as UINT64, and
Ppi/FirmwareVolumeInfo FvLength has mentioned as UINT32 which will
break the X64 build, updating the FvLenth to UINTN will support for both

Cc: Rangasai V Chaganty <rangasai.v.chaganty@intel.com>
Cc: Digant H Solanki <digant.h.solanki@intel.com>
Cc: Sangeetha V <sangeetha.v@intel.com>
Cc: Ray Ni <ray.ni@intel.com>

Signed-off-by: Ashraf Ali S <ashraf.ali.s@intel.com>