### PR TITLE
MdeModulePkg/GraphicsConsole: don't draw cursor at 0,0

### DIFF
--- a/MdeModulePkg/Universal/Console/GraphicsConsoleDxe/GraphicsConsole.c
+++ b/MdeModulePkg/Universal/Console/GraphicsConsoleDxe/GraphicsConsole.c
@@ -1940,7 +1940,8 @@ FlushCursor (
 
   CurrentMode = This->Mode;
 
-  if (!CurrentMode->CursorVisible) {
+  if (!CurrentMode->CursorVisible ||
+      (CurrentMode->CursorColumn == 0 && CurrentMode->CursorRow == 0 )) {
     return EFI_SUCCESS;
   }
 


### PR DESCRIPTION
Prevents cursor from flashing on screen when
changing modes or clearing the screen.

Signed-off-by: Matt DeVillier <matt.devillier@gmail.com>
Signed-off-by: Sean Rhodes <sean@starlabs.systems>