### PR TITLE
UnitTestFrameworkPkg: CI YAML: Grant cmockery spell check exception

### DIFF
--- a/UnitTestFrameworkPkg/UnitTestFrameworkPkg.ci.yaml
+++ b/UnitTestFrameworkPkg/UnitTestFrameworkPkg.ci.yaml
@@ -89,6 +89,7 @@
             "pytool",
             "pytools",
             "NOFAILURE",
+            "cmockery",
             "DHAVE", # build flag for cmocka in the INF
             "corthon",      # Contact GitHub account in Readme
             "mdkinney",     # Contact GitHub account in Readme


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3798

UnitTestFrameworkPkg.dec contains cmockery folder from cmocka submodule.
However, the term "cmockery" is unrecognized by cspell tool.

This change grants spell check exception to "cmockery" to prevent
pipeline building failure.

Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Sean Brogan <sean.brogan@microsoft.com>
Cc: Bret Barkelew <Bret.Barkelew@microsoft.com>

Signed-off-by: Kun Qin <kuqin12@gmail.com>