### PR TITLE
MdeModulePkg/PartitionDxe: Add break to handle invalid LBA0 in MBR

### DIFF
--- a/MdeModulePkg/Universal/Disk/PartitionDxe/Mbr.c
+++ b/MdeModulePkg/Universal/Disk/PartitionDxe/Mbr.c
@@ -293,6 +293,13 @@ PartitionInstallMbrChildHandles (
           (Mbr->Partition[0].OSIndicator == EXTENDED_WINDOWS_PARTITION))
       {
         ExtMbrStartingLba = UNPACK_UINT32 (Mbr->Partition[0].StartingLBA);
+        //
+        // A value of 0 is invalid for StartingLBA
+        //
+        if (ExtMbrStartingLba == 0) {
+          break;
+        }
+
         continue;
       }
 


### PR DESCRIPTION
Patch sent at: https://edk2.groups.io/g/devel/message/85289

Read Disk does a modification of ExtMbrStartingLba with the code MultU64x32
(ExtMbrStartingLba, BlockSize) Error detection to see if ExtMbrStartingLBA
has a value of 0. This is invalid as LBA 0 = MBR. After modification, the
next time ExtMbrStartingLba is in this function if ExtMbrStartingLba is set
to 0 in the MBR it never passes the while/do evaluation It is multiplied by
0 by read disk , set to 0 by an invalid MBR and goes back to evaluation
This condition will also cause Ws19 and WS22 to hang, however Microsoft has
developed a hotfix patch that will be released in 2022

Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Hao A Wu <hao.a.wu@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Cc: Zhichao Gao <zhichao.gao@intel.com>

Signed-off-by: Craig Edwards <craig.edwards@dell.com>
Reviewed-by: Hao A Wu <hao.a.wu@intel.com>