### PR TITLE
MdeModulePkg: Enabling OS boot from SD card

### DIFF
--- a/MdeModulePkg/Bus/Pci/SdMmcPciHcDxe/EmmcDevice.c
+++ b/MdeModulePkg/Bus/Pci/SdMmcPciHcDxe/EmmcDevice.c
@@ -630,6 +630,7 @@ EmmcSwitchBusWidth (
   UINT8       Index;
   UINT8       Value;
   UINT8       CmdSet;
+  UINT32      DevStatus;
 
   //
   // Write Byte, the Value field is written into the byte pointed by Index.
@@ -655,9 +656,23 @@ EmmcSwitchBusWidth (
     return Status;
   }
 
+  Status = EmmcSendStatus (PassThru, Slot, Rca, &DevStatus);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "EmmcSwitchBusWidth: Send status fails with %r\n", Status));
+    return Status;
+  }
+
   Status = EmmcCheckSwitchStatus (PassThru, Slot, Rca);
   if (EFI_ERROR (Status)) {
     return Status;
+  }
+
+  //
+  // Check the switch operation is really successful or not.
+  //
+  if ((DevStatus & BIT7) != 0) {
+    DEBUG ((DEBUG_ERROR, "EmmcSwitchBusWidth: The switch operation fails as DevStatus is 0x%08x\n", DevStatus));
+    return EFI_DEVICE_ERROR;
   }
 
   Status = SdMmcHcSetBusWidth (PciIo, Slot, BusWidth);
@@ -699,9 +714,9 @@ EmmcSwitchBusTiming (
   UINT8                   Index;
   UINT8                   Value;
   UINT8                   CmdSet;
+  UINT32                  DevStatus;
   SD_MMC_HC_PRIVATE_DATA  *Private;
   UINT8                   HostCtrl1;
-  BOOLEAN                 DelaySendStatus;
 
   Private = SD_MMC_HC_PRIVATE_FROM_THIS (PassThru);
   //
@@ -725,7 +740,7 @@ EmmcSwitchBusTiming (
       Value = 0;
       break;
     default:
-      DEBUG ((DEBUG_ERROR, "EmmcSwitchBusTiming: Unsupported BusTiming(%d)\n", BusTiming));
+      DEBUG ((DEBUG_ERROR, "EmmcSwitchBusTiming: Unsupported BusTiming(%d\n)", BusTiming));
       return EFI_INVALID_PARAMETER;
   }
 
@@ -755,37 +770,41 @@ EmmcSwitchBusTiming (
   }
 
   //
-  // For cases when we switch bus timing to higher mode from current we want to
-  // send SEND_STATUS at current, lower, frequency then the target frequency to avoid
-  // stability issues. It has been observed that some designs are unable to process the
-  // SEND_STATUS at higher frequency during switch to HS200 @200MHz irrespective of the number of retries
-  // and only running the clock tuning is able to make them work at target frequency.
-  //
-  // For cases when we are downgrading the frequency and current high frequency is invalid
-  // we have to first change the frequency to target frequency and then send the SEND_STATUS.
-  //
-  if (Private->Slot[Slot].CurrentFreq < (ClockFreq * 1000)) {
-    Status = EmmcCheckSwitchStatus (PassThru, Slot, Rca);
-    if (EFI_ERROR (Status)) {
-      return Status;
-    }
-
-    DelaySendStatus = FALSE;
-  } else {
-    DelaySendStatus = TRUE;
-  }
-
-  //
   // Convert the clock freq unit from MHz to KHz.
   //
-  Status = SdMmcHcClockSupply (Private, Slot, BusTiming, FALSE, ClockFreq * 1000);
+  Status = SdMmcHcClockSupply (PciIo, Slot, ClockFreq * 1000, Private->BaseClkFreq[Slot], Private->ControllerVersion[Slot]);
   if (EFI_ERROR (Status)) {
     return Status;
   }
 
-  if (DelaySendStatus) {
-    Status = EmmcCheckSwitchStatus (PassThru, Slot, Rca);
+  Status = EmmcSendStatus (PassThru, Slot, Rca, &DevStatus);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "EmmcSwitchBusTiming: Send status fails with %r\n", Status));
+    return Status;
+  }
+
+  //
+  // Check the switch operation is really successful or not.
+  //
+  if ((DevStatus & BIT7) != 0) {
+    DEBUG ((DEBUG_ERROR, "EmmcSwitchBusTiming: The switch operation fails as DevStatus is 0x%08x\n", DevStatus));
+    return EFI_DEVICE_ERROR;
+  }
+
+  if ((mOverride != NULL) && (mOverride->NotifyPhase != NULL)) {
+    Status = mOverride->NotifyPhase (
+                          Private->ControllerHandle,
+                          Slot,
+                          EdkiiSdMmcSwitchClockFreqPost,
+                          &BusTiming
+                          );
     if (EFI_ERROR (Status)) {
+      DEBUG ((
+        DEBUG_ERROR,
+        "%a: SD/MMC switch clock freq post notifier callback failed - %r\n",
+        __FUNCTION__,
+        Status
+        ));
       return Status;
     }
   }

--- a/MdeModulePkg/Bus/Pci/SdMmcPciHcDxe/SdDevice.c
+++ b/MdeModulePkg/Bus/Pci/SdMmcPciHcDxe/SdDevice.c
@@ -1167,9 +1167,27 @@ SdCardSetBusMode (
     return Status;
   }
 
-  Status = SdMmcHcClockSupply (Private, Slot, BusMode.BusTiming, FALSE, BusMode.ClockFreq * 1000);
+  Status = SdMmcHcClockSupply (PciIo, Slot, BusMode.ClockFreq * 1000, Private->BaseClkFreq[Slot], Private->ControllerVersion[Slot]);
   if (EFI_ERROR (Status)) {
     return Status;
+  }
+
+  if ((mOverride != NULL) && (mOverride->NotifyPhase != NULL)) {
+    Status = mOverride->NotifyPhase (
+                          Private->ControllerHandle,
+                          Slot,
+                          EdkiiSdMmcSwitchClockFreqPost,
+                          &BusMode.BusTiming
+                          );
+    if (EFI_ERROR (Status)) {
+      DEBUG ((
+        DEBUG_ERROR,
+        "%a: SD/MMC switch clock freq post notifier callback failed - %r\n",
+        __FUNCTION__,
+        Status
+        ));
+      return Status;
+    }
   }
 
   if ((BusMode.BusTiming == SdMmcUhsSdr104) || ((BusMode.BusTiming == SdMmcUhsSdr50) && (Capability->TuningSDR50 != 0))) {
@@ -1204,6 +1222,7 @@ SdCardIdentification (
   EFI_PCI_IO_PROTOCOL            *PciIo;
   EFI_SD_MMC_PASS_THRU_PROTOCOL  *PassThru;
   UINT32                         Ocr;
+  UINT32                         ResponseOcr;
   UINT16                         Rca;
   BOOLEAN                        Xpc;
   BOOLEAN                        S18r;
@@ -1213,167 +1232,198 @@ SdCardIdentification (
   UINT32                         PresentState;
   UINT8                          HostCtrl2;
   UINTN                          Retry;
+  BOOLEAN                        Force3p3v;
+
+  Force3p3v = FALSE;
 
   PciIo    = Private->PciIo;
   PassThru = &Private->PassThru;
-  //
-  // 1. Send Cmd0 to the device
-  //
-  Status = SdCardReset (PassThru, Slot);
-  if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_INFO, "SdCardIdentification: Executing Cmd0 fails with %r\n", Status));
-    return Status;
-  }
 
   //
-  // 2. Send Cmd8 to the device
+  // Step 12 of SD Host Controller Simplified Specification Version 3.00, 3.6.1 Signal Voltage Switch Procedure: Retry 3.3V if 1.8V fails
   //
-  Status = SdCardVoltageCheck (PassThru, Slot, 0x1, 0xFF);
-  if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_INFO, "SdCardIdentification: Executing Cmd8 fails with %r\n", Status));
-    return Status;
-  }
-
-  //
-  // 3. Send SDIO Cmd5 to the device to the SDIO device OCR register.
-  //
-  Status = SdioSendOpCond (PassThru, Slot, 0, FALSE);
-  if (!EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_INFO, "SdCardIdentification: Found SDIO device, ignore it as we don't support\n"));
-    return EFI_DEVICE_ERROR;
-  }
-
-  //
-  // 4. Send Acmd41 with voltage window 0 to the device
-  //
-  Status = SdCardSendOpCond (PassThru, Slot, 0, 0, FALSE, FALSE, FALSE, &Ocr);
-  if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_INFO, "SdCardIdentification: Executing SdCardSendOpCond fails with %r\n", Status));
-    return EFI_DEVICE_ERROR;
-  }
-
-  if (Private->Capability[Slot].Voltage33 != 0) {
-    //
-    // Support 3.3V
-    //
-    MaxCurrent = ((UINT32)Private->MaxCurrent[Slot] & 0xFF) * 4;
-  } else if (Private->Capability[Slot].Voltage30 != 0) {
-    //
-    // Support 3.0V
-    //
-    MaxCurrent = (((UINT32)Private->MaxCurrent[Slot] >> 8) & 0xFF) * 4;
-  } else if (Private->Capability[Slot].Voltage18 != 0) {
-    //
-    // Support 1.8V
-    //
-    MaxCurrent = (((UINT32)Private->MaxCurrent[Slot] >> 16) & 0xFF) * 4;
-  } else {
-    ASSERT (FALSE);
-    return EFI_DEVICE_ERROR;
-  }
-
-  if (MaxCurrent >= 150) {
-    Xpc = TRUE;
-  } else {
-    Xpc = FALSE;
-  }
-
-  Status = SdMmcHcRwMmio (PciIo, Slot, SD_MMC_HC_CTRL_VER, TRUE, sizeof (ControllerVer), &ControllerVer);
-  if (EFI_ERROR (Status)) {
-    return Status;
-  }
-
-  if (((ControllerVer & 0xFF) >= SD_MMC_HC_CTRL_VER_300) &&
-      ((ControllerVer & 0xFF) <= SD_MMC_HC_CTRL_VER_420))
-  {
-    S18r = TRUE;
-  } else if (((ControllerVer & 0xFF) == SD_MMC_HC_CTRL_VER_100) || ((ControllerVer & 0xFF) == SD_MMC_HC_CTRL_VER_200)) {
-    S18r = FALSE;
-  } else {
-    ASSERT (FALSE);
-    return EFI_UNSUPPORTED;
-  }
-
-  //
-  // 5. Repeatly send Acmd41 with supply voltage window to the device.
-  //    Note here we only support the cards complied with SD physical
-  //    layer simplified spec version 2.0 and version 3.0 and above.
-  //
-  Ocr   = 0;
-  Retry = 0;
   do {
-    Status = SdCardSendOpCond (PassThru, Slot, 0, Ocr, S18r, Xpc, TRUE, &Ocr);
+    //
+    // 1. Send Cmd0 to the device
+    //
+    Status = SdCardReset (PassThru, Slot);
     if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_ERROR, "SdCardIdentification: SdCardSendOpCond fails with %r Ocr %x, S18r %x, Xpc %x\n", Status, Ocr, S18r, Xpc));
+      DEBUG ((DEBUG_INFO, "SdCardIdentification: Executing Cmd0 fails with %r\n", Status));
+      return Status;
+    }
+
+    //
+    // 2. Send Cmd8 to the device
+    //
+    Status = SdCardVoltageCheck (PassThru, Slot, 0x1, 0xFF);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_INFO, "SdCardIdentification: Executing Cmd8 fails with %r\n", Status));
+      return Status;
+    }
+
+    //
+    // 3. Send SDIO Cmd5 to the device to the SDIO device OCR register.
+    //
+    Status = SdioSendOpCond (PassThru, Slot, 0, FALSE);
+    if (!EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_INFO, "SdCardIdentification: Found SDIO device, ignore it as we don't support\n"));
       return EFI_DEVICE_ERROR;
     }
 
-    if (Retry++ == 100) {
-      DEBUG ((DEBUG_ERROR, "SdCardIdentification: SdCardSendOpCond fails too many times\n"));
+    //
+    // 4. Send Acmd41 with voltage window 0 to the device
+    //
+    Status = SdCardSendOpCond (PassThru, Slot, 0, 0, FALSE, FALSE, FALSE, &Ocr);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_INFO, "SdCardIdentification: Executing SdCardSendOpCond fails with %r\n", Status));
       return EFI_DEVICE_ERROR;
     }
 
-    gBS->Stall (10 * 1000);
-  } while ((Ocr & BIT31) == 0);
-
-  //
-  // 6. If the S18A bit is set and the Host Controller supports 1.8V signaling
-  //    (One of support bits is set to 1: SDR50, SDR104 or DDR50 in the
-  //    Capabilities register), switch its voltage to 1.8V.
-  //
-  if (((Private->Capability[Slot].Sdr50 != 0) ||
-       (Private->Capability[Slot].Sdr104 != 0) ||
-       (Private->Capability[Slot].Ddr50 != 0)) &&
-      ((Ocr & BIT24) != 0))
-  {
-    Status = SdCardVoltageSwitch (PassThru, Slot);
-    if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_ERROR, "SdCardIdentification: Executing SdCardVoltageSwitch fails with %r\n", Status));
-      Status = EFI_DEVICE_ERROR;
-      goto Error;
+    if (Private->Capability[Slot].Voltage33 != 0) {
+      //
+      // Support 3.3V
+      //
+      MaxCurrent = ((UINT32)Private->MaxCurrent[Slot] & 0xFF) * 4;
+    } else if (Private->Capability[Slot].Voltage30 != 0) {
+      //
+      // Support 3.0V
+      //
+      MaxCurrent = (((UINT32)Private->MaxCurrent[Slot] >> 8) & 0xFF) * 4;
+    } else if (Private->Capability[Slot].Voltage18 != 0) {
+      //
+      // Support 1.8V
+      //
+      MaxCurrent = (((UINT32)Private->MaxCurrent[Slot] >> 16) & 0xFF) * 4;
     } else {
-      Status = SdMmcHcStopClock (PciIo, Slot);
-      if (EFI_ERROR (Status)) {
-        Status = EFI_DEVICE_ERROR;
-        goto Error;
-      }
-
-      SdMmcHcRwMmio (PciIo, Slot, SD_MMC_HC_PRESENT_STATE, TRUE, sizeof (PresentState), &PresentState);
-      if (((PresentState >> 20) & 0xF) != 0) {
-        DEBUG ((DEBUG_ERROR, "SdCardIdentification: SwitchVoltage fails with PresentState = 0x%x\n", PresentState));
-        Status = EFI_DEVICE_ERROR;
-        goto Error;
-      }
-
-      HostCtrl2 = BIT3;
-      SdMmcHcOrMmio (PciIo, Slot, SD_MMC_HC_HOST_CTRL2, sizeof (HostCtrl2), &HostCtrl2);
-
-      gBS->Stall (5000);
-
-      SdMmcHcRwMmio (PciIo, Slot, SD_MMC_HC_HOST_CTRL2, TRUE, sizeof (HostCtrl2), &HostCtrl2);
-      if ((HostCtrl2 & BIT3) == 0) {
-        DEBUG ((DEBUG_ERROR, "SdCardIdentification: SwitchVoltage fails with HostCtrl2 = 0x%x\n", HostCtrl2));
-        Status = EFI_DEVICE_ERROR;
-        goto Error;
-      }
-
-      Status = SdMmcHcStartSdClock (PciIo, Slot);
-      if (EFI_ERROR (Status)) {
-        goto Error;
-      }
-
-      gBS->Stall (1000);
-
-      SdMmcHcRwMmio (PciIo, Slot, SD_MMC_HC_PRESENT_STATE, TRUE, sizeof (PresentState), &PresentState);
-      if (((PresentState >> 20) & 0xF) != 0xF) {
-        DEBUG ((DEBUG_ERROR, "SdCardIdentification: SwitchVoltage fails with PresentState = 0x%x, It should be 0xF\n", PresentState));
-        Status = EFI_DEVICE_ERROR;
-        goto Error;
-      }
+      ASSERT (FALSE);
+      return EFI_DEVICE_ERROR;
     }
 
-    DEBUG ((DEBUG_INFO, "SdCardIdentification: Switch to 1.8v signal voltage success\n"));
-  }
+    if (MaxCurrent >= 150) {
+      Xpc = TRUE;
+    } else {
+      Xpc = FALSE;
+    }
+
+    Status = SdMmcHcRwMmio (PciIo, Slot, SD_MMC_HC_CTRL_VER, TRUE, sizeof (ControllerVer), &ControllerVer);
+    if (EFI_ERROR (Status)) {
+      return Status;
+    }
+
+    if (((ControllerVer & 0xFF) >= SD_MMC_HC_CTRL_VER_300) &&
+        ((ControllerVer & 0xFF) <= SD_MMC_HC_CTRL_VER_420))
+    {
+      S18r = TRUE;
+    } else if (((ControllerVer & 0xFF) == SD_MMC_HC_CTRL_VER_100) || ((ControllerVer & 0xFF) == SD_MMC_HC_CTRL_VER_200)) {
+      S18r = FALSE;
+    } else {
+      ASSERT (FALSE);
+      return EFI_UNSUPPORTED;
+    }
+
+    //
+    // 1.8V had failed in the previous run, forcing a retry with 3.3V instead
+    //
+    if (Force3p3v == TRUE) {
+      S18r      = FALSE;
+      Force3p3v = FALSE;
+    }
+
+    //
+    // 5. Repeatly send Acmd41 with supply voltage window to the device.
+    //    Note here we only support the cards complied with SD physical
+    //    layer simplified spec version 2.0 and version 3.0 and above.
+    //
+    DEBUG ((DEBUG_ERROR, "SdCardIdentification: First Ocr: 0x%X, S18r: 0x%X, Xpc: 0x%X\n", Ocr, S18r, Xpc));
+    ResponseOcr = Ocr;
+    Ocr         = 0;
+    Retry       = 0;
+    do {
+      Status = SdCardSendOpCond (PassThru, Slot, 0, ResponseOcr, S18r, Xpc, TRUE, &Ocr);
+      if (EFI_ERROR (Status)) {
+        DEBUG ((DEBUG_ERROR, "SdCardIdentification: SdCardSendOpCond fails with %r Ocr %x, S18r %x, Xpc %x\n", Status, Ocr, S18r, Xpc));
+        return EFI_DEVICE_ERROR;
+      }
+
+      if (Retry++ == 100) {
+        DEBUG ((DEBUG_ERROR, "SdCardIdentification: SdCardSendOpCond fails too many times\n"));
+        return EFI_DEVICE_ERROR;
+      }
+
+      gBS->Stall (10 * 1000);
+    } while ((Ocr & BIT31) == 0);
+
+    DEBUG ((DEBUG_ERROR, "SdCardIdentification: Second Ocr: 0x%X\n", Ocr));
+
+    //
+    // 6. If the S18A bit is set and the Host Controller supports 1.8V signaling
+    //    (One of support bits is set to 1: SDR50, SDR104 or DDR50 in the
+    //    Capabilities register), switch its voltage to 1.8V.
+    //
+    if (((Private->Capability[Slot].Sdr50 != 0) ||
+         (Private->Capability[Slot].Sdr104 != 0) ||
+         (Private->Capability[Slot].Ddr50 != 0)) &&
+        ((Ocr & BIT24) != 0))
+    {
+      Status = SdCardVoltageSwitch (PassThru, Slot);
+      if (EFI_ERROR (Status)) {
+        DEBUG ((DEBUG_ERROR, "SdCardIdentification: Executing SdCardVoltageSwitch fails with %r\n", Status));
+        Status = EFI_DEVICE_ERROR;
+        goto Error;
+      } else {
+        Status = SdMmcHcStopClock (PciIo, Slot);
+        if (EFI_ERROR (Status)) {
+          Status = EFI_DEVICE_ERROR;
+          goto Error;
+        }
+
+        SdMmcHcRwMmio (PciIo, Slot, SD_MMC_HC_PRESENT_STATE, TRUE, sizeof (PresentState), &PresentState);
+        if (((PresentState >> 20) & 0xF) != 0) {
+          DEBUG ((DEBUG_ERROR, "SdCardIdentification: SwitchVoltage fails with PresentState = 0x%x\n", PresentState));
+          Status = EFI_DEVICE_ERROR;
+          goto Error;
+        }
+
+        HostCtrl2 = BIT3;
+        SdMmcHcOrMmio (PciIo, Slot, SD_MMC_HC_HOST_CTRL2, sizeof (HostCtrl2), &HostCtrl2);
+
+        gBS->Stall (5000);
+
+        SdMmcHcRwMmio (PciIo, Slot, SD_MMC_HC_HOST_CTRL2, TRUE, sizeof (HostCtrl2), &HostCtrl2);
+        if ((HostCtrl2 & BIT3) == 0) {
+          DEBUG ((DEBUG_ERROR, "SdCardIdentification: SwitchVoltage fails with HostCtrl2 = 0x%x\n", HostCtrl2));
+          Status = EFI_DEVICE_ERROR;
+          goto Error;
+        }
+
+        //
+        // PCH:RestrictedBegin
+        //
+        // Workaround to add a delay of 100ms in order for clock to stabilize before turning on the SD clock again.
+        // HSDES ID: 1507602829
+        //
+        // PCH:RestrictedEnd
+        //
+        gBS->Stall (50000);
+        SdMmcHcInitClockFreq (PciIo, Slot, Private->BaseClkFreq[Slot], Private->ControllerVersion[Slot]);
+
+        gBS->Stall (1000);
+
+        SdMmcHcRwMmio (PciIo, Slot, SD_MMC_HC_PRESENT_STATE, TRUE, sizeof (PresentState), &PresentState);
+        if (((PresentState >> 20) & 0xF) != 0xF) {
+          DEBUG ((DEBUG_ERROR, "SdCardIdentification: SwitchVoltage fails with PresentState = 0x%x, It should be 0xF\n", PresentState));
+          Status    = SdMmcHcReset (Private, Slot);
+          Status    = SdMmcHcInitHost (Private, Slot);
+          Force3p3v = TRUE;
+          DEBUG ((DEBUG_ERROR, "SdCardIdentification: Switching to 1.8V had failed in the previous run, forcing a retry with 3.3V instead\n"));
+        }
+      }
+
+      if (((PresentState >> 20) & 0xF) == 0xF) {
+        DEBUG ((DEBUG_INFO, "SdCardIdentification: Switch to 1.8v signal voltage success\n"));
+      }
+    }
+  } while (Force3p3v);
 
   Status = SdCardAllSendCid (PassThru, Slot);
   if (EFI_ERROR (Status)) {

--- a/MdeModulePkg/Bus/Pci/SdMmcPciHcDxe/SdMmcPciHcDxe.h
+++ b/MdeModulePkg/Bus/Pci/SdMmcPciHcDxe/SdMmcPciHcDxe.h
@@ -83,7 +83,6 @@ typedef struct {
   BOOLEAN                              MediaPresent;
   BOOLEAN                              Initialized;
   SD_MMC_CARD_TYPE                     CardType;
-  UINT64                               CurrentFreq;
   EDKII_SD_MMC_OPERATING_PARAMETERS    OperatingParameters;
 } SD_MMC_HC_SLOT;
 
@@ -812,11 +811,11 @@ SdCardIdentification (
 
   Refer to SD Host Controller Simplified spec 3.0 Section 3.2.1 for details.
 
-  @param[in] Private         A pointer to the SD_MMC_HC_PRIVATE_DATA instance.
-  @param[in] Slot            The slot number of the SD card to send the command to.
-  @param[in] BusTiming       BusTiming at which the frequency change is done.
-  @param[in] FirstTimeSetup  Flag to indicate whether the clock is being setup for the first time.
-  @param[in] ClockFreq       The max clock frequency to be set. The unit is KHz.
+  @param[in] PciIo          The PCI IO protocol instance.
+  @param[in] Slot           The slot number of the SD card to send the command to.
+  @param[in] ClockFreq      The max clock frequency to be set. The unit is KHz.
+  @param[in] BaseClkFreq    The base clock frequency of host controller in MHz.
+  @param[in] ControllerVer  The version of host controller.
 
   @retval EFI_SUCCESS       The clock is supplied successfully.
   @retval Others            The clock isn't supplied successfully.
@@ -824,11 +823,11 @@ SdCardIdentification (
 **/
 EFI_STATUS
 SdMmcHcClockSupply (
-  IN SD_MMC_HC_PRIVATE_DATA  *Private,
-  IN UINT8                   Slot,
-  IN SD_MMC_BUS_MODE         BusTiming,
-  IN BOOLEAN                 FirstTimeSetup,
-  IN UINT64                  ClockFreq
+  IN EFI_PCI_IO_PROTOCOL  *PciIo,
+  IN UINT8                Slot,
+  IN UINT64               ClockFreq,
+  IN UINT32               BaseClkFreq,
+  IN UINT16               ControllerVer
   );
 
 /**

--- a/MdeModulePkg/Bus/Pci/SdMmcPciHcDxe/SdMmcPciHci.h
+++ b/MdeModulePkg/Bus/Pci/SdMmcPciHcDxe/SdMmcPciHci.h
@@ -129,6 +129,10 @@ typedef struct {
   UINT32    UpperAddress;
 } SD_MMC_HC_ADMA_64_V3_DESC_LINE;
 
+//
+// ADMA descriptor for 64b addressing.
+//
+
 typedef struct {
   UINT32    Valid       : 1;
   UINT32    End         : 1;
@@ -187,7 +191,6 @@ typedef struct {
   UINT32    Reserved5     : 7; // bit 56:62
   UINT32    Hs400         : 1; // bit 63
 } SD_MMC_HC_SLOT_CAP;
-
 //
 // SD Host controller version
 //
@@ -479,6 +482,30 @@ SdMmcHcStopClock (
   );
 
 /**
+  SD/MMC card clock supply.
+
+  Refer to SD Host Controller Simplified spec 3.0 Section 3.2.1 for details.
+
+  @param[in] PciIo          The PCI IO protocol instance.
+  @param[in] Slot           The slot number of the SD card to send the command to.
+  @param[in] ClockFreq      The max clock frequency to be set. The unit is KHz.
+  @param[in] BaseClkFreq    The base clock frequency of host controller in MHz.
+  @param[in] ControllerVer  The version of host controller.
+
+  @retval EFI_SUCCESS       The clock is supplied successfully.
+  @retval Others            The clock isn't supplied successfully.
+
+**/
+EFI_STATUS
+SdMmcHcClockSupply (
+  IN EFI_PCI_IO_PROTOCOL  *PciIo,
+  IN UINT8                Slot,
+  IN UINT64               ClockFreq,
+  IN UINT32               BaseClkFreq,
+  IN UINT16               ControllerVer
+  );
+
+/**
   Start the SD clock.
 
   @param[in] PciIo  The PCI IO protocol instance.
@@ -531,6 +558,26 @@ SdMmcHcSetBusWidth (
   IN EFI_PCI_IO_PROTOCOL  *PciIo,
   IN UINT8                Slot,
   IN UINT16               BusWidth
+  );
+
+/**
+  Supply SD/MMC card with lowest clock frequency at initialization.
+
+  @param[in] PciIo          The PCI IO protocol instance.
+  @param[in] Slot           The slot number of the SD card to send the command to.
+  @param[in] BaseClkFreq    The base clock frequency of host controller in MHz.
+  @param[in] ControllerVer  The version of host controller.
+
+  @retval EFI_SUCCESS       The clock is supplied successfully.
+  @retval Others            The clock isn't supplied successfully.
+
+**/
+EFI_STATUS
+SdMmcHcInitClockFreq (
+  IN EFI_PCI_IO_PROTOCOL  *PciIo,
+  IN UINT8                Slot,
+  IN UINT32               BaseClkFreq,
+  IN UINT16               ControllerVer
   );
 
 /**


### PR DESCRIPTION
There are few changes has been made:
   1. For SdMmmcHcInitClockFreq function, it modified on the input of the function.
      This is due, effecting on SD card detection.
   2. Some lines need to remove as dependency from ClockFreq function affecting on SD card initilization
      and card slot definition.
   3. Add 50ms delay during voltage switching from 3.3V to 1.8V.
   4. Add force 3.3V in a loop to identify card failed to power on for
      some cases.
Based on the changes, we enable to boot OS from SD card through
UEFI payload.

Signed-off-by: Aiman Rosli <muhammad.aiman.rosli@intel.com>