### PR TITLE
MdeModulePkg/Variable: Make only EFI_VARIABLE_NON_VOLATILE invalid

### DIFF
--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/Variable.c
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/Variable.c
@@ -19,6 +19,7 @@
 Copyright (c) 2006 - 2020, Intel Corporation. All rights reserved.<BR>
 (C) Copyright 2015-2018 Hewlett Packard Enterprise Development LP<BR>
 Copyright (c) Microsoft Corporation.<BR>
+Copyright (c) 2022, ARM Limited. All rights reserved.<BR>
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -2660,14 +2661,22 @@ VariableServiceSetVariable (
   }
 
   //
-  //  Make sure if runtime bit is set, boot service bit is set also.
+  // Check if the combination of attribute bits is valid.
   //
   if ((Attributes & (EFI_VARIABLE_RUNTIME_ACCESS | EFI_VARIABLE_BOOTSERVICE_ACCESS)) == EFI_VARIABLE_RUNTIME_ACCESS) {
+    //
+    // Make sure if runtime bit is set, boot service bit is set also.
+    //
     if ((Attributes & EFI_VARIABLE_AUTHENTICATED_WRITE_ACCESS) != 0) {
       return EFI_UNSUPPORTED;
     } else {
       return EFI_INVALID_PARAMETER;
     }
+  } else if ((Attributes & EFI_VARIABLE_ATTRIBUTES_MASK) == EFI_VARIABLE_NON_VOLATILE) {
+    //
+    // Only EFI_VARIABLE_NON_VOLATILE attribute is invalid
+    //
+    return EFI_INVALID_PARAMETER;
   } else if ((Attributes & VARIABLE_ATTRIBUTE_AT_AW) != 0) {
     if (!mVariableModuleGlobal->VariableGlobal.AuthSupport) {
       //
@@ -3142,6 +3151,11 @@ VariableServiceQueryVariableInfo (
     // Make sure the Attributes combination is supported by the platform.
     //
     return EFI_UNSUPPORTED;
+  } else if ((Attributes & EFI_VARIABLE_ATTRIBUTES_MASK) == EFI_VARIABLE_NON_VOLATILE) {
+    //
+    // Only EFI_VARIABLE_NON_VOLATILE attribute is invalid
+    //
+    return EFI_INVALID_PARAMETER;
   } else if ((Attributes & (EFI_VARIABLE_RUNTIME_ACCESS | EFI_VARIABLE_BOOTSERVICE_ACCESS)) == EFI_VARIABLE_RUNTIME_ACCESS) {
     //
     // Make sure if runtime bit is set, boot service bit is set also.


### PR DESCRIPTION
Only EFI_VARIABLE_NON_VOLATILE attribute is an invalid combination
of attribute bits, so update the variable driver to return
EFI_INVALID_PARAMETER so that we can prevent the invalid variable
being created.

This change also fixes the SCT failure below:
 - RT.QueryVariableInfo - With being an invalid combination -- FAILURE

For details, please check the threads below:
 - https://edk2.groups.io/g/devel/topic/86486174
 - https://edk2.groups.io/g/devel/message/82466

Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Heinrich Schuchardt <heinrich.schuchardt@canonical.com>
Cc: G Edhaya Chandran <edhaya.chandran@arm.com>
Cc: Samer El-Haj-Mahmoud <samer.el-haj-mahmoud@arm.com>

Signed-off-by: Sunny Wang <sunny.wang@arm.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>