### PR TITLE
OvmfPkg/ResetVector: cache the SEV status MSR value in workarea

### DIFF
--- a/OvmfPkg/Include/WorkArea.h
+++ b/OvmfPkg/Include/WorkArea.h
@@ -46,12 +46,20 @@ typedef struct _CONFIDENTIAL_COMPUTING_WORK_AREA_HEADER {
 // any changes must stay in sync with its usage.
 //
 typedef struct _SEC_SEV_ES_WORK_AREA {
-  UINT8     SevEsEnabled;
-  UINT8     Reserved1[7];
+  //
+  // Hold the SevStatus MSR value read by OvmfPkg/ResetVector/Ia32/AmdSev.c
+  //
+  UINT64    SevStatusMsrVal;
 
   UINT64    RandomData;
 
   UINT64    EncryptionMask;
+
+  //
+  // Indicator that the VC handler is called. It is used during the SevFeature
+  // detection in OvmfPkg/ResetVector/Ia32/AmdSev.c
+  //
+  UINT8     ReceivedVc;
 } SEC_SEV_ES_WORK_AREA;
 
 //

--- a/OvmfPkg/ResetVector/Ia32/Flat32ToFlat64.asm
+++ b/OvmfPkg/ResetVector/Ia32/Flat32ToFlat64.asm
@@ -42,7 +42,8 @@ Transition32FlatTo64Flat:
     ;
     xor     ebx, ebx
 
-    cmp     byte[SEV_ES_WORK_AREA], 0
+    mov     ecx, 1
+    bt      [SEV_ES_WORK_AREA_STATUS_MSR], ecx
     jz      EnablePaging
 
     ;

--- a/OvmfPkg/ResetVector/ResetVector.nasmb
+++ b/OvmfPkg/ResetVector/ResetVector.nasmb
@@ -100,8 +100,11 @@
   %define GHCB_BASE (FixedPcdGet32 (PcdOvmfSecGhcbBase))
   %define GHCB_SIZE (FixedPcdGet32 (PcdOvmfSecGhcbSize))
   %define SEV_ES_WORK_AREA (FixedPcdGet32 (PcdSevEsWorkAreaBase))
+  %define SEV_ES_WORK_AREA_SIZE 25
+  %define SEV_ES_WORK_AREA_STATUS_MSR (FixedPcdGet32 (PcdSevEsWorkAreaBase))
   %define SEV_ES_WORK_AREA_RDRAND (FixedPcdGet32 (PcdSevEsWorkAreaBase) + 8)
   %define SEV_ES_WORK_AREA_ENC_MASK (FixedPcdGet32 (PcdSevEsWorkAreaBase) + 16)
+  %define SEV_ES_WORK_AREA_RECEIVED_VC (FixedPcdGet32 (PcdSevEsWorkAreaBase) + 24)
   %define SEV_ES_VC_TOP_OF_STACK (FixedPcdGet32 (PcdOvmfSecPeiTempRamBase) + FixedPcdGet32 (PcdOvmfSecPeiTempRamSize))
   %define SEV_SNP_SECRETS_BASE  (FixedPcdGet32 (PcdOvmfSnpSecretsBase))
   %define SEV_SNP_SECRETS_SIZE  (FixedPcdGet32 (PcdOvmfSnpSecretsSize))

--- a/OvmfPkg/Sec/AmdSev.c
+++ b/OvmfPkg/Sec/AmdSev.c
@@ -278,7 +278,7 @@ SevEsIsEnabled (
 
   SevEsWorkArea = (SEC_SEV_ES_WORK_AREA *)FixedPcdGet32 (PcdSevEsWorkAreaBase);
 
-  return (SevEsWorkArea->SevEsEnabled != 0);
+  return ((SevEsWorkArea->SevStatusMsrVal & BIT1) != 0);
 }
 
 /**


### PR DESCRIPTION
In order to probe the SEV feature the BaseMemEncryptLib and Reset vector
reads the SEV_STATUS MSR. Cache the value in the first read in the
workarea. In the next patches the value saved in the workarea will
be used by the BaseMemEncryptLib. This not only eliminates the extra
MSR reads it also helps cleaning up the code in BaseMemEncryptLib.

Signed-off-by: Brijesh Singh <brijesh.singh@amd.com>