### PR TITLE
FmpDevicePkg/FmpDxe: Update FmpDeviceCheckImageWithStatus() handling

### DIFF
--- a/FmpDevicePkg/Include/Library/FmpDeviceLib.h
+++ b/FmpDevicePkg/Include/Library/FmpDeviceLib.h
@@ -421,8 +421,7 @@ FmpDeviceCheckImage (
                                     IMAGE_UPDATABLE_VALID_WITH_VENDOR_CODE
   @param[out] LastAttemptStatus   A pointer to a UINT32 that holds the last attempt
                                   status to report back to the ESRT table in case
-                                  of error. This value will only be checked when this
-                                  function returns an error.
+                                  of error.
 
                                   The return status code must fall in the range of
                                   LAST_ATTEMPT_STATUS_DEVICE_LIBRARY_MIN_ERROR_CODE_VALUE to

--- a/FmpDevicePkg/Library/FmpDeviceLibNull/FmpDeviceLib.c
+++ b/FmpDevicePkg/Library/FmpDeviceLibNull/FmpDeviceLib.c
@@ -434,8 +434,7 @@ FmpDeviceCheckImage (
                                     IMAGE_UPDATABLE_VALID_WITH_VENDOR_CODE
   @param[out] LastAttemptStatus   A pointer to a UINT32 that holds the last attempt
                                   status to report back to the ESRT table in case
-                                  of error. This value will only be checked when this
-                                  function returns an error.
+                                  of error.
 
                                   The return status code must fall in the range of
                                   LAST_ATTEMPT_STATUS_DEVICE_LIBRARY_MIN_ERROR_CODE_VALUE to


### PR DESCRIPTION
Update the logic handling last attempt status codes from
FmpDeviceCheckImageWithStatus() implementations to account for
cases when the function return status code is EFI_SUCCESS
(since the image was checked successfully) but the ImageUpdatable
value is not valid.

In addition the following sentence is removed from the
LastAttemptStatus parameter definition for
FmpDeviceCheckImageWithStatus() since it can lead to confusion.
The expected status code value range is sufficient to implement
the library API.

  "This value will only be checked when this
   function returns an error."

Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Guomin Jiang <guomin.jiang@intel.com>
Cc: Wei6 Xu <wei6.xu@intel.com>
Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>
Reviewed-by: Guomin Jiang <guomin.jiang@intel.com>