### PR TITLE
BaseTools: Enable GNU make parallel jobs by default

### DIFF
--- a/BaseTools/Conf/tools_def.template
+++ b/BaseTools/Conf/tools_def.template
@@ -2283,6 +2283,8 @@ RELEASE_GCC49_AARCH64_DLINK_XIPFLAGS = -z common-page-size=0x20
 *_GCC5_*_*_FAMILY                = GCC
 
 *_GCC5_*_MAKE_PATH               = DEF(GCC_HOST_PREFIX)make
+*_GCC5_*_GMAKE_FLAGS             = --jobs
+*_GCC5_*_NMAKE_FLAGS             = /nologo
 *_GCC5_*_*_DLL                   = ENV(GCC5_DLL)
 *_GCC5_*_ASL_PATH                = DEF(UNIX_IASL_BIN)
 
@@ -2742,6 +2744,8 @@ RELEASE_CLANG38_AARCH64_DLINK_FLAGS = DEF(CLANG38_AARCH64_DLINK_FLAGS) -flto -Wl
 *_CLANGPDB_*_*_FAMILY                = GCC
 *_CLANGPDB_*_*_BUILDRULEFAMILY       = CLANGPDB
 *_CLANGPDB_*_MAKE_PATH               = ENV(CLANG_HOST_BIN)make
+*_CLANGPDB_*_GMAKE_FLAGS             = --jobs
+*_CLANGPDB_*_NMAKE_FLAGS             = /nologo
 *_CLANGPDB_*_*_DLL                   = ENV(CLANGPDB_DLL)
 *_CLANGPDB_*_ASL_PATH                = DEF(UNIX_IASL_BIN)
 

--- a/BaseTools/Source/Python/AutoGen/GenMake.py
+++ b/BaseTools/Source/Python/AutoGen/GenMake.py
@@ -732,10 +732,11 @@ cleanlib:
                     Src, Dst = CopyCmd
                     Src = self.ReplaceMacro(Src)
                     Dst = self.ReplaceMacro(Dst)
+                    Efi = Src[:-3] + 'efi'
                     if Dst not in self.ResultFileList:
                         self.ResultFileList.append(Dst)
                     if '%s :' %(Dst) not in self.BuildTargetList:
-                        self.BuildTargetList.append("%s : %s" %(Dst,Src))
+                        self.BuildTargetList.append("%s : %s" %(Dst, Efi))
                         self.BuildTargetList.append('\t' + self._CP_TEMPLATE_[self._Platform] %{'Src': Src, 'Dst': Dst})
 
             FfsCmdList = Cmd[0]
@@ -778,7 +779,7 @@ cleanlib:
                                 SecDepsFileList.append(SecCmdList[index + 1])
                             index = index + 1
                         if CmdName == 'Trim':
-                            SecDepsFileList.append(os.path.join('$(DEBUG_DIR)', os.path.basename(OutputFile).replace('offset', 'efi')))
+                            SecDepsFileList.append(os.path.join('$(OUTPUT_DIR)', os.path.basename(OutputFile).replace('offset', 'efi')))
                         if OutputFile.endswith('.ui') or OutputFile.endswith('.ver'):
                             SecDepsFileList.append(os.path.join('$(MODULE_DIR)', '$(MODULE_FILE)'))
                         self.FfsOutputFileList.append((OutputFile, ' '.join(SecDepsFileList), SecCmdStr))

--- a/BaseTools/Source/Python/AutoGen/PlatformAutoGen.py
+++ b/BaseTools/Source/Python/AutoGen/PlatformAutoGen.py
@@ -893,7 +893,17 @@ class PlatformAutoGen(AutoGen):
                 RetVal[Tool] = OrderedDict()
             if Attr not in RetVal[Tool]:
                 RetVal[Tool][Attr] = Value
-
+        if 'NMAKE' in RetVal.keys() or 'GMAKE' in RetVal.keys():
+            if RetVal['MAKE']['PATH'] == "nmake":
+                if 'FLAGS' in RetVal['MAKE'].keys():
+                    RetVal['MAKE']['FLAGS'] += ' ' + RetVal['NMAKE']['FLAGS']
+                else:
+                    RetVal['MAKE']['FLAGS'] = RetVal['NMAKE']['FLAGS']
+            else:
+                if 'FLAGS' in RetVal['MAKE'].keys():
+                    RetVal['MAKE']['FLAGS'] += ' ' + RetVal['GMAKE']['FLAGS']
+                else:
+                    RetVal['MAKE']['FLAGS'] = RetVal['GMAKE']['FLAGS']
         ToolsDef = ''
         if GlobalData.gOptions.SilentMode and "MAKE" in RetVal:
             if "FLAGS" not in RetVal["MAKE"]:


### PR DESCRIPTION
BZ: https://bugzilla.tianocore.org/show_bug.cgi?id=3807

* Enable GNU make parallel jobs support(--jobs flag) by
  default in GCC5 and CLANGPDB toolchains. This gmake flag
  can save full features bios linux build time by +20%.
* Explictly distinguish and define the MS nmake flag and
  GNU gmake flag in the toolchain which might support
  both, e.g. CLANGPDB can use nmake in Windows and gmake
  in Linux. General make flags cannot work for such hybrid
  make usage scenario.

Signed-off-by: Steven Shi <steven.shi@intel.com>