### PR TITLE
BaseTools/Conf: Add new macro for customizing dll file reduction.

### DIFF
--- a/BaseTools/Conf/build_rule.template
+++ b/BaseTools/Conf/build_rule.template
@@ -375,7 +375,7 @@
         -$(CP) $(DEBUG_DIR)(+)*.pdb $(OUTPUT_DIR) 
     <Command.GCC>
         $(CP) ${src} $(DEBUG_DIR)(+)$(MODULE_NAME).debug
-        $(OBJCOPY) --strip-unneeded -R .eh_frame ${src}
+        $(OBJCOPY) $(OBJCOPY_STRIPFLAG) ${src}
 
         #
         #The below 2 lines are only needed for UNIXGCC tool chain, which generates PE image directly

--- a/BaseTools/Conf/tools_def.template
+++ b/BaseTools/Conf/tools_def.template
@@ -1862,6 +1862,7 @@ NOOPT_VS2019_AARCH64_DLINK_FLAGS   = /NOLOGO /NODEFAULTLIB /IGNORE:4001 /OPT:REF
 DEBUG_*_*_OBJCOPY_ADDDEBUGFLAG     = --add-gnu-debuglink=$(DEBUG_DIR)/$(MODULE_NAME).debug
 RELEASE_*_*_OBJCOPY_ADDDEBUGFLAG   =
 NOOPT_*_*_OBJCOPY_ADDDEBUGFLAG     = --add-gnu-debuglink=$(DEBUG_DIR)/$(MODULE_NAME).debug
+*_*_*_OBJCOPY_STRIPFLAG            = --strip-unneeded -R .eh_frame
 *_*_*_DTC_FLAGS                    = -H epapr
 *_*_*_DTCPP_PATH                   = DEF(DTCPP_BIN)
 *_*_*_DTC_PATH                     = DEF(DTC_BIN)


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3810

New macro OBJCOPY_STRIPFLAG is added in build_rule.template to replace
'--strip-unneeded -R .eh_frame', so that module can have some unique
objcopy flags for its own purpose.
In tools_def.template, set '--strip-unneeded -R .eh_frame' as default
value of OBJCOPY_STRIPFLAG.

Cc: Bob Feng <bob.c.feng@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Yuwei Chen <yuwei.chen@intel.com>
Signed-off-by: Wei6 Xu <wei6.xu@intel.com>