### PR TITLE
EmbeddedPkg: Fix a build error in FwVol.c in X64 arch

### DIFF
--- a/EmbeddedPkg/Library/PrePiLib/FwVol.c
+++ b/EmbeddedPkg/Library/PrePiLib/FwVol.c
@@ -291,7 +291,7 @@ FfsProcessSection (
   UINT16                    SectionAttribute;
   UINT32                    AuthenticationStatus;
   CHAR8                     *CompressedData;
-  UINTN                     CompressedDataLength;
+  UINT32                    CompressedDataLength;
 
   *OutputBuffer = NULL;
   ParsedLength  = 0;
@@ -320,7 +320,7 @@ FfsProcessSection (
           }
 
           CompressedData       = (CHAR8 *)((EFI_COMPRESSION_SECTION2 *)Section + 1);
-          CompressedDataLength = (UINT32)SectionLength - sizeof (EFI_COMPRESSION_SECTION2);
+          CompressedDataLength = SectionLength - sizeof (EFI_COMPRESSION_SECTION2);
         } else {
           CompressionSection = (EFI_COMPRESSION_SECTION *)Section;
           SectionLength      = SECTION_SIZE (Section);
@@ -330,7 +330,7 @@ FfsProcessSection (
           }
 
           CompressedData       = (CHAR8 *)((EFI_COMPRESSION_SECTION *)Section + 1);
-          CompressedDataLength = (UINT32)SectionLength - sizeof (EFI_COMPRESSION_SECTION);
+          CompressedDataLength = SectionLength - sizeof (EFI_COMPRESSION_SECTION);
         }
 
         Status = UefiDecompressGetInfo (


### PR DESCRIPTION
BZ: https://bugzilla.tianocore.org/show_bug.cgi?id=3814

CompressedDataLength is declared as UINTN which is UINT64 in X64 arch.
But the second parameter of UefiDecompressGetInfo() is declared as
UINT32. So a build error is triggered. To declare CompressedDataLength
as UINT32 to fix the build error.

Cc: Leif Lindholm <leif@nuviainc.com>
Cc: Ard Biesheuvel <ardb+tianocore@kernel.org>
Cc: Abner Chang <abner.chang@hpe.com>
Cc: Daniel Schaefer <daniel.schaefer@hpe.com>
Signed-off-by: Min Xu <min.m.xu@intel.com>