### PR TITLE
MdeModulePkg/UefiBootManagerLib: Convert BmLoadOption to Variable Policy

### DIFF
--- a/MdeModulePkg/Library/UefiBootManagerLib/InternalBm.h
+++ b/MdeModulePkg/Library/UefiBootManagerLib/InternalBm.h
@@ -39,7 +39,6 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Protocol/BootLogo.h>
 #include <Protocol/DriverHealth.h>
 #include <Protocol/FormBrowser2.h>
-#include <Protocol/VariableLock.h>
 #include <Protocol/RamDisk.h>
 #include <Protocol/DeferredImageLoad.h>
 #include <Protocol/PlatformBootManager.h>

--- a/MdeModulePkg/Library/UefiBootManagerLib/UefiBootManagerLib.inf
+++ b/MdeModulePkg/Library/UefiBootManagerLib/UefiBootManagerLib.inf
@@ -62,6 +62,7 @@
   PerformanceLib
   HiiLib
   SortLib
+  VariablePolicyHelperLib
 
 [Guids]
   ## SOMETIMES_CONSUMES ## SystemTable (The identifier of memory type information type in system table)
@@ -99,7 +100,7 @@
   gEfiDevicePathProtocolGuid                    ## SOMETIMES_CONSUMES
   gEfiBootLogoProtocolGuid                      ## SOMETIMES_CONSUMES
   gEfiSimpleTextInputExProtocolGuid             ## SOMETIMES_CONSUMES
-  gEdkiiVariableLockProtocolGuid                ## SOMETIMES_CONSUMES
+  gEdkiiVariablePolicyProtocolGuid              ## SOMETIMES_CONSUMES
   gEfiGraphicsOutputProtocolGuid                ## SOMETIMES_CONSUMES
   gEfiUsbIoProtocolGuid                         ## SOMETIMES_CONSUMES
   gEfiNvmExpressPassThruProtocolGuid            ## SOMETIMES_CONSUMES


### PR DESCRIPTION
Since the Variable Lock protocol is deprecated, convert locking of
PlatformRecovery#### in EfiBootManagerLoadOptionToVariable to use the
Variable Policy protocol.

Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Zhichao Gao <zhichao.gao@intel.com>
Cc: Ray Ni <ray.ni@intel.com>

Signed-off-by: Rebecca Cran <quic_rcran@quicinc.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>