### PR TITLE
BaseTools: Fix error leg in DscBuildData.py

### DIFF
--- a/BaseTools/Source/Python/Workspace/DscBuildData.py
+++ b/BaseTools/Source/Python/Workspace/DscBuildData.py
@@ -3033,7 +3033,7 @@ class DscBuildData(PlatformBuildClassObject):
             returncode, StdOut, StdErr = DscBuildData.ExecuteCommand (Command)
             EdkLogger.verbose ('%s\n%s\n%s' % (Command, StdOut, StdErr))
             if returncode != 0:
-                EdkLogger.warn('Build', COMMAND_FAILURE, 'Can not collect output from command: %s\n%s\n' % (Command, StdOut, StdErr))
+                EdkLogger.warn('Build', COMMAND_FAILURE, 'Can not collect output from command: %s\n%s\n%s\n' % (Command, StdOut, StdErr))
 
         #start update structure pcd final value
         File = open (OutputValueFile, 'r')


### PR DESCRIPTION
Fix a Edk2Logger.warn() message format to match the arguments.

We ran into this after a failure in PcdValueInit.  The failure was
masked by a new exception, "TypeError: not all arguments converted
during string formatting".

Signed-off-by: Jake Garver <jake@nvidia.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>