### PR TITLE
UefiPayloadPkg: Add option to follow BGRT spec

### DIFF
--- a/MdeModulePkg/Library/BootLogoLib/BootLogoLib.c
+++ b/MdeModulePkg/Library/BootLogoLib/BootLogoLib.c
@@ -176,7 +176,12 @@ BootLogoEnableLogo (
         break;
       case EdkiiPlatformLogoDisplayAttributeCenter:
         DestX = (SizeOfX - Image.Width) / 2;
-        DestY = (SizeOfY - Image.Height) / 2;
+        if (FixedPcdGetBool (PcdFollowBGRTSpec) == TRUE) {
+          DestY = (SizeOfY * 382) / 1000 - Image.Height / 2;
+        } else {
+          DestY = (SizeOfY - Image.Height) / 2;
+        }
+
         break;
       case EdkiiPlatformLogoDisplayAttributeCenterRight:
         DestX = SizeOfX - Image.Width;

--- a/MdeModulePkg/Library/BootLogoLib/BootLogoLib.inf
+++ b/MdeModulePkg/Library/BootLogoLib/BootLogoLib.inf
@@ -48,5 +48,8 @@
   gEfiUserManagerProtocolGuid                   ## CONSUMES
   gEdkiiPlatformLogoProtocolGuid                ## CONSUMES
 
+[Pcd]
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFollowBGRTSpec
+
 [FeaturePcd]
   gEfiMdePkgTokenSpaceGuid.PcdUgaConsumeSupport ## CONSUMES

--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -2079,6 +2079,9 @@
   # @Prompt Enable PCIe Resizable BAR Capability support.
   gEfiMdeModulePkgTokenSpaceGuid.PcdPcieResizableBarSupport|FALSE|BOOLEAN|0x10000024
 
+  # Follow BGRT Specifcation
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFollowBGRTSpec|FALSE|BOOLEAN|0x00000025
+
 [PcdsPatchableInModule]
   ## Specify memory size with page number for PEI code when
   #  Loading Module at Fixed Address feature is enabled.

--- a/UefiPayloadPkg/UefiPayloadPkg.dsc
+++ b/UefiPayloadPkg/UefiPayloadPkg.dsc
@@ -33,6 +33,7 @@
   DEFINE UNIVERSAL_PAYLOAD            = FALSE
   DEFINE SECURITY_STUB_ENABLE         = TRUE
   DEFINE SMM_SUPPORT                  = FALSE
+  DEFINE FOLLOW_BGRT_SPEC             = TRUE
   #
   # SBL:      UEFI payload for Slim Bootloader
   # COREBOOT: UEFI payload for coreboot
@@ -398,6 +399,7 @@
 !if $(PERFORMANCE_MEASUREMENT_ENABLE)
   gEfiMdePkgTokenSpaceGuid.PcdPerformanceLibraryPropertyMask       | 0x1
 !endif
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFollowBGRTSpec|$(FOLLOW_BGRT_SPEC)
 
 [PcdsPatchableInModule.X64]
   gPcAtChipsetPkgTokenSpaceGuid.PcdRtcIndexRegister|$(RTC_INDEX_REGISTER)


### PR DESCRIPTION
Add option to centre the Boot Logo 38.2% from the top of screen, following
the BGRT specification.

Signed-off-by: Sean Rhodes <sean@starlabs.systems>