### PR TITLE
SdMmcPciDxe: Reduce timeout for SD card reset

### DIFF
--- a/MdeModulePkg/Bus/Pci/SdMmcPciHcDxe/SdMmcPciHcDxe.h
+++ b/MdeModulePkg/Bus/Pci/SdMmcPciHcDxe/SdMmcPciHcDxe.h
@@ -49,7 +49,7 @@ extern EDKII_SD_MMC_OVERRIDE  *mOverride;
 //
 // Generic time out value, 1 microsecond as unit.
 //
-#define SD_MMC_HC_GENERIC_TIMEOUT  1 * 1000 * 1000
+#define SD_MMC_HC_GENERIC_TIMEOUT  1 * 1000 * 100
 
 //
 // SD/MMC async transfer timer interval, set by experience.


### PR DESCRIPTION
Previous 1s timeout causeed stalls on boot splash with no benefit.
Reduced to 100ms and no interruptions to boot when no SD card inserted.

Signed-off-by: Matt DeVillier <matt.devillier@gmail.com>