### PR TITLE
MdeModulePkg/BmBoot: skip secondary eMMC entries

### DIFF
--- a/MdeModulePkg/Library/UefiBootManagerLib/BmBoot.c
+++ b/MdeModulePkg/Library/UefiBootManagerLib/BmBoot.c
@@ -2175,12 +2175,14 @@ BmEnumerateBootOptions (
   EFI_BLOCK_IO_PROTOCOL         *BlkIo;
   UINTN                         Removable;
   UINTN                         Index;
+  UINTN                         EmmcCount;
   CHAR16                        *Description;
 
   ASSERT (BootOptionCount != NULL);
 
   *BootOptionCount = 0;
   BootOptions      = NULL;
+  EmmcCount        = 0;
 
   //
   // Parse removable block io followed by fixed block io
@@ -2219,6 +2221,16 @@ BmEnumerateBootOptions (
       }
 
       Description = BmGetBootDescription (Handles[Index]);
+      //
+      // Skip secondary entries for internal eMMC devices
+      //
+      if (StrCmp (Description, L"eMMC Device") == 0) {
+        EmmcCount++;
+        if (EmmcCount > 1) {
+          continue;
+        }
+      }
+
       BootOptions = ReallocatePool (
                       sizeof (EFI_BOOT_MANAGER_LOAD_OPTION) * (*BootOptionCount),
                       sizeof (EFI_BOOT_MANAGER_LOAD_OPTION) * (*BootOptionCount + 1),


### PR DESCRIPTION
Internal eMMC devices often show multiple entries, so skip
any after the initial entry.

Signed-off-by: Matt DeVillier <matt.devillier@gmail.com>
Signed-off-by: Sean Rhodes <sean@starlabs.systems>