### PR TITLE
MdeModulePkg/Frontpage: Get SMBIOS Data from table directly

### DIFF
--- a/MdeModulePkg/Application/UiApp/UiApp.inf
+++ b/MdeModulePkg/Application/UiApp/UiApp.inf
@@ -58,6 +58,7 @@
 [Guids]
   gEfiIfrTianoGuid                              ## CONSUMES ## GUID (Extended IFR Guid Opcode)
   gEfiIfrFrontPageGuid                          ## CONSUMES ## GUID
+  gEfiSmbiosTableGuid                           ## CONSUMES ## GUID
 
 [Protocols]
   gEfiSmbiosProtocolGuid                        ## CONSUMES
@@ -77,6 +78,7 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdSetupVideoVerticalResolution    ## CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdFirmwareVersionString           ## CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdTestKeyUsed                     ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdCoreboot                        ## CONSUMES
 
 [UserExtensions.TianoCore."ExtraFiles"]
   UiAppExtra.uni

--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -1076,6 +1076,8 @@
   #   FALSE - UEFI Stack Guard will be disabled.<BR>
   # @Prompt Enable UEFI Stack Guard.
   gEfiMdeModulePkgTokenSpaceGuid.PcdCpuStackGuard|FALSE|BOOLEAN|0x30001055
+  # Build Type
+  gEfiMdeModulePkgTokenSpaceGuid.PcdCoreboot|FALSE|BOOLEAN|0x00000027
 
 [PcdsFixedAtBuild, PcdsPatchableInModule]
   ## Dynamic type PCD can be registered callback function for Pcd setting action.

--- a/UefiPayloadPkg/UefiPayloadPkg.dsc
+++ b/UefiPayloadPkg/UefiPayloadPkg.dsc
@@ -399,6 +399,12 @@
   gEfiMdePkgTokenSpaceGuid.PcdPerformanceLibraryPropertyMask       | 0x1
 !endif
 
+!if $(BOOTLOADER) == "COREBOOT"
+  gEfiMdeModulePkgTokenSpaceGuid.PcdCoreboot|TRUE
+!else
+  gEfiMdeModulePkgTokenSpaceGuid.PcdCoreboot|FALSE
+!endif
+
 [PcdsPatchableInModule.X64]
   gPcAtChipsetPkgTokenSpaceGuid.PcdRtcIndexRegister|$(RTC_INDEX_REGISTER)
   gPcAtChipsetPkgTokenSpaceGuid.PcdRtcTargetRegister|$(RTC_TARGET_REGISTER)


### PR DESCRIPTION
Gather information from SMBIOS table rather than getting it
from the EFI SMBIOS protocol for coreboot builds.

Signed-off-by: Matt DeVillier <matt.devillier@gmail.com>
Signed-off-by: Sean Rhodes <sean@starlabs.systems>