### PR TITLE
virtio-gpu host resolution

### DIFF
--- a/OvmfPkg/Include/IndustryStandard/VirtioGpu.h
+++ b/OvmfPkg/Include/IndustryStandard/VirtioGpu.h
@@ -37,6 +37,7 @@ typedef enum {
   //
   // - create/release a host-side 2D resource,
   //
+  VirtioGpuCmdGetDisplayInfo   = 0x0100,
   VirtioGpuCmdResourceCreate2d = 0x0101,
   VirtioGpuCmdResourceUnref    = 0x0102,
   //
@@ -64,7 +65,8 @@ typedef enum {
   //
   // Success code for all of the above commands.
   //
-  VirtioGpuRespOkNodata = 0x1100,
+  VirtioGpuRespOkNodata      = 0x1100,
+  VirtioGpuRespOkDisplayInfo = 0x1101,
 } VIRTIO_GPU_CONTROL_TYPE;
 
 //
@@ -205,6 +207,21 @@ typedef struct {
   UINT32                       ResourceId;
   UINT32                       Padding;
 } VIRTIO_GPU_RESOURCE_FLUSH;
+#pragma pack ()
+
+//
+// Response structure for VirtioGpuCmdGetDisplayInfo
+//
+#define VIRTIO_GPU_MAX_SCANOUTS  16
+#pragma pack (1)
+typedef struct {
+  VIRTIO_GPU_CONTROL_HEADER    Header;
+  struct {
+    VIRTIO_GPU_RECTANGLE    Rectangle;
+    UINT32                  Enabled;
+    UINT32                  Flags;
+  } Pmodes[VIRTIO_GPU_MAX_SCANOUTS];
+} VIRTIO_GPU_RESP_DISPLAY_INFO;
 #pragma pack ()
 
 #endif // _VIRTIO_GPU_H_

--- a/OvmfPkg/VirtioGpuDxe/Commands.c
+++ b/OvmfPkg/VirtioGpuDxe/Commands.c
@@ -393,6 +393,14 @@ VirtioGpuExitBoot (
   @param[in] RequestSize  Size of the entire caller-allocated request object,
                           including the leading VIRTIO_GPU_CONTROL_HEADER.
 
+  @param[in] ResponseType The type of the response (VirtioGpuResp*).
+
+  @param[in,out] Response Pointer to the caller-allocated response object. The
+                          request must start with VIRTIO_GPU_CONTROL_HEADER.
+
+  @param[in] ResponseSize Size of the entire caller-allocated response object,
+                          including the leading VIRTIO_GPU_CONTROL_HEADER.
+
   @retval EFI_SUCCESS            Operation successful.
 
   @retval EFI_DEVICE_ERROR       The host rejected the request. The host error
@@ -404,22 +412,24 @@ VirtioGpuExitBoot (
 **/
 STATIC
 EFI_STATUS
-VirtioGpuSendCommand (
+VirtioGpuSendCommandWithReply (
   IN OUT VGPU_DEV                            *VgpuDev,
   IN     VIRTIO_GPU_CONTROL_TYPE             RequestType,
   IN     BOOLEAN                             Fence,
   IN OUT volatile VIRTIO_GPU_CONTROL_HEADER  *Header,
-  IN     UINTN                               RequestSize
+  IN     UINTN                               RequestSize,
+  IN     VIRTIO_GPU_CONTROL_TYPE             ResponseType,
+  IN OUT volatile VIRTIO_GPU_CONTROL_HEADER  *Response,
+  IN     UINTN                               ResponseSize
   )
 {
-  DESC_INDICES                        Indices;
-  volatile VIRTIO_GPU_CONTROL_HEADER  Response;
-  EFI_STATUS                          Status;
-  UINT32                              ResponseSize;
-  EFI_PHYSICAL_ADDRESS                RequestDeviceAddress;
-  VOID                                *RequestMap;
-  EFI_PHYSICAL_ADDRESS                ResponseDeviceAddress;
-  VOID                                *ResponseMap;
+  DESC_INDICES          Indices;
+  EFI_STATUS            Status;
+  UINT32                ResponseSizeRet;
+  EFI_PHYSICAL_ADDRESS  RequestDeviceAddress;
+  VOID                  *RequestMap;
+  EFI_PHYSICAL_ADDRESS  ResponseDeviceAddress;
+  VOID                  *ResponseMap;
 
   //
   // Initialize Header.
@@ -457,8 +467,8 @@ VirtioGpuSendCommand (
   Status = VirtioMapAllBytesInSharedBuffer (
              VgpuDev->VirtIo,
              VirtioOperationBusMasterWrite,
-             (VOID *)&Response,
-             sizeof Response,
+             (VOID *)Response,
+             ResponseSize,
              &ResponseDeviceAddress,
              &ResponseMap
              );
@@ -480,7 +490,7 @@ VirtioGpuSendCommand (
   VirtioAppendDesc (
     &VgpuDev->Ring,
     ResponseDeviceAddress,
-    (UINT32)sizeof Response,
+    (UINT32)ResponseSize,
     VRING_DESC_F_WRITE,
     &Indices
     );
@@ -493,7 +503,7 @@ VirtioGpuSendCommand (
              VIRTIO_GPU_CONTROL_QUEUE,
              &VgpuDev->Ring,
              &Indices,
-             &ResponseSize
+             &ResponseSizeRet
              );
   if (EFI_ERROR (Status)) {
     goto UnmapResponse;
@@ -502,7 +512,7 @@ VirtioGpuSendCommand (
   //
   // Verify response size.
   //
-  if (ResponseSize != sizeof Response) {
+  if (ResponseSize != ResponseSizeRet) {
     DEBUG ((
       DEBUG_ERROR,
       "%a: malformed response to Request=0x%x\n",
@@ -531,16 +541,17 @@ VirtioGpuSendCommand (
   //
   // Parse the response.
   //
-  if (Response.Type == VirtioGpuRespOkNodata) {
+  if (Response->Type == (UINT32)ResponseType) {
     return EFI_SUCCESS;
   }
 
   DEBUG ((
     DEBUG_ERROR,
-    "%a: Request=0x%x Response=0x%x\n",
+    "%a: Request=0x%x Response=0x%x (expected 0x%x)\n",
     __FUNCTION__,
     (UINT32)RequestType,
-    Response.Type
+    Response->Type,
+    ResponseType
     ));
   return EFI_DEVICE_ERROR;
 
@@ -551,6 +562,34 @@ UnmapRequest:
   VgpuDev->VirtIo->UnmapSharedBuffer (VgpuDev->VirtIo, RequestMap);
 
   return Status;
+}
+
+/**
+  Simplified version of VirtioGpuSendCommandWithReply() for commands
+  which do not send back any data.
+**/
+STATIC
+EFI_STATUS
+VirtioGpuSendCommand (
+  IN OUT VGPU_DEV                            *VgpuDev,
+  IN     VIRTIO_GPU_CONTROL_TYPE             RequestType,
+  IN     BOOLEAN                             Fence,
+  IN OUT volatile VIRTIO_GPU_CONTROL_HEADER  *Header,
+  IN     UINTN                               RequestSize
+  )
+{
+  volatile VIRTIO_GPU_CONTROL_HEADER  Response;
+
+  return VirtioGpuSendCommandWithReply (
+           VgpuDev,
+           RequestType,
+           Fence,
+           Header,
+           RequestSize,
+           VirtioGpuRespOkNodata,
+           &Response,
+           sizeof (Response)
+           );
 }
 
 /**

--- a/OvmfPkg/VirtioGpuDxe/Commands.c
+++ b/OvmfPkg/VirtioGpuDxe/Commands.c
@@ -828,3 +828,23 @@ VirtioGpuResourceFlush (
            sizeof Request
            );
 }
+
+EFI_STATUS
+VirtioGpuGetDisplayInfo (
+  IN OUT VGPU_DEV                        *VgpuDev,
+  volatile VIRTIO_GPU_RESP_DISPLAY_INFO  *Response
+  )
+{
+  volatile VIRTIO_GPU_CONTROL_HEADER  Request;
+
+  return VirtioGpuSendCommandWithReply (
+           VgpuDev,
+           VirtioGpuCmdGetDisplayInfo,
+           FALSE,                     // Fence
+           &Request,
+           sizeof Request,
+           VirtioGpuRespOkDisplayInfo,
+           &Response->Header,
+           sizeof *Response
+           );
+}

--- a/OvmfPkg/VirtioGpuDxe/VirtioGpu.h
+++ b/OvmfPkg/VirtioGpuDxe/VirtioGpu.h
@@ -151,6 +151,12 @@ struct VGPU_GOP_STRUCT {
   // BackingStore is non-NULL.
   //
   VOID                                    *BackingStoreMap;
+
+  //
+  // native display resolution
+  //
+  UINT32                                  NativeXRes;
+  UINT32                                  NativeYRes;
 };
 
 //

--- a/OvmfPkg/VirtioGpuDxe/VirtioGpu.h
+++ b/OvmfPkg/VirtioGpuDxe/VirtioGpu.h
@@ -366,6 +366,12 @@ VirtioGpuResourceFlush (
   IN     UINT32    ResourceId
   );
 
+EFI_STATUS
+VirtioGpuGetDisplayInfo (
+  IN OUT VGPU_DEV                        *VgpuDev,
+  volatile VIRTIO_GPU_RESP_DISPLAY_INFO  *Response
+  );
+
 /**
   Release guest-side and host-side resources that are related to an initialized
   VGPU_GOP.Gop.

--- a/OvmfPkg/VirtioGpuDxe/VirtioGpu.inf
+++ b/OvmfPkg/VirtioGpuDxe/VirtioGpu.inf
@@ -25,6 +25,7 @@
 
 [Packages]
   MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
   OvmfPkg/OvmfPkg.dec
 
 [LibraryClasses]
@@ -43,3 +44,8 @@
   gEfiGraphicsOutputProtocolGuid ## BY_START
   gEfiPciIoProtocolGuid          ## TO_START
   gVirtioDeviceProtocolGuid      ## TO_START
+
+[Pcd]
+  gUefiOvmfPkgTokenSpaceGuid.PcdVideoResolutionSource
+  gEfiMdeModulePkgTokenSpaceGuid.PcdVideoHorizontalResolution
+  gEfiMdeModulePkgTokenSpaceGuid.PcdVideoVerticalResolution


### PR DESCRIPTION
- OvmfPkg/VirtioGpuDxe: add VirtioGpuSendCommandWithReply
- OvmfPkg/VirtioGpuDxe: add GetDisplayInfo to virtio-gpu spec header.
- OvmfPkg/VirtioGpuDxe: VirtioGpuGetDisplayInfo
- OvmfPkg/VirtioGpuDxe: use GopQueryMode in GopSetMode
- OvmfPkg/VirtioGpuDxe: move code to GopInitialize
- OvmfPkg/VirtioGpuDxe: query native display resolution from host
- OvmfPkg/VirtioGpuDxe: log GopSetMode() calls.
