### PR TITLE
Ps2KbdCtrller: Make wait for SUCCESS after BAT non-fatal

### DIFF
--- a/MdeModulePkg/Bus/Isa/Ps2KeyboardDxe/Ps2KbdCtrller.c
+++ b/MdeModulePkg/Bus/Isa/Ps2KeyboardDxe/Ps2KbdCtrller.c
@@ -1733,11 +1733,7 @@ InitKeyboard (
     //
     mWaitForValueTimeOut = KEYBOARD_BAT_TIMEOUT;
 
-    Status = KeyboardWaitForValue (ConsoleIn, KEYBOARD_8048_RETURN_8042_BAT_SUCCESS);
-    if (EFI_ERROR (Status)) {
-      KeyboardError (ConsoleIn, L"Keyboard self test failed!\n\r");
-      goto Done;
-    }
+    KeyboardWaitForValue (ConsoleIn, KEYBOARD_8048_RETURN_8042_BAT_SUCCESS);
 
     mWaitForValueTimeOut = KEYBOARD_WAITFORVALUE_TIMEOUT;
 

--- a/MdeModulePkg/Bus/Isa/Ps2KeyboardDxe/Ps2Keyboard.h
+++ b/MdeModulePkg/Bus/Isa/Ps2KeyboardDxe/Ps2Keyboard.h
@@ -157,7 +157,7 @@ InstallPs2KeyboardDriver (
 #define KEYBOARD_MAX_TRY                 256     // 256
 #define KEYBOARD_TIMEOUT                 65536   // 0.07s
 #define KEYBOARD_WAITFORVALUE_TIMEOUT    1000000 // 1s
-#define KEYBOARD_BAT_TIMEOUT             4000000 // 4s
+#define KEYBOARD_BAT_TIMEOUT             1000000 // 1s
 #define KEYBOARD_TIMER_INTERVAL          200000  // 0.02s
 #define SCANCODE_EXTENDED0               0xE0
 #define SCANCODE_EXTENDED1               0xE1


### PR DESCRIPTION
Recent model Chromebooks only return ACK, but not
BAT_SUCCESS, which causes hanging and failed ps2k init.
To mitigate this, make the absence of BAT_SUCCESS reply
non-fatal, and reduce the no-reply timeout from 4s to 1s.

Tested on google/dracia and purism/librem_14

Cc: Hao A Wu <hao.a.wu@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Signed-off-by: Matt DeVillier <matt.devillier@gmail.com>
Signed-off-by: Sean Rhodes <sean@starlabs.systems>