### PR TITLE
MdeModulePkg/Usb/Keyboard.c: don't request protocol before setting

### DIFF
--- a/MdeModulePkg/Bus/Isa/Ps2KeyboardDxe/Ps2KbdCtrller.c
+++ b/MdeModulePkg/Bus/Isa/Ps2KeyboardDxe/Ps2KbdCtrller.c
@@ -1731,13 +1731,7 @@ InitKeyboard (
     //
     // wait for BAT completion code
     //
-    mWaitForValueTimeOut = KEYBOARD_BAT_TIMEOUT;
-
-    Status = KeyboardWaitForValue (ConsoleIn, KEYBOARD_8048_RETURN_8042_BAT_SUCCESS);
-    if (EFI_ERROR (Status)) {
-      KeyboardError (ConsoleIn, L"Keyboard self test failed!\n\r");
-      goto Done;
-    }
+    KeyboardWaitForValue (ConsoleIn, KEYBOARD_8048_RETURN_8042_BAT_SUCCESS);
 
     mWaitForValueTimeOut = KEYBOARD_WAITFORVALUE_TIMEOUT;
 


### PR DESCRIPTION
No need to check the interface protocol then conditionally setting,
just set it to BOOT_PROTOCOL and check for error.

This is what Linux does for HID devices as some don't follow the USB spec.
One example is the Aspeed BMC HID keyboard device, which adds a massive
boot delay without this patch as it doesn't respond to 'GetProtocolRequest'.

Signed-off-by: Matt DeVillier <matt.devillier@gmail.com>
Signed-off-by: Patrick Rudolph <patrick.rudolph@9elements.com>