### PR TITLE
UefiPayloadPkg: Fix PciHostBridgeLib

### DIFF
--- a/MdeModulePkg/Library/UefiBootManagerLib/BmBoot.c
+++ b/MdeModulePkg/Library/UefiBootManagerLib/BmBoot.c
@@ -2214,8 +2214,14 @@ BmEnumerateBootOptions (
       //
       // Skip the fixed block io then the removable block io
       //
-      if (BlkIo->Media->RemovableMedia == ((Removable == 0) ? FALSE : TRUE)) {
-        continue;
+      if (FixedPcdGetBool (PcdPrioritizeInternal)) {
+        if (BlkIo->Media->RemovableMedia == (Removable == 0)) {
+          continue;
+        }
+      } else {
+        if (BlkIo->Media->RemovableMedia == ((Removable == 0) ? FALSE : TRUE)) {
+          continue;
+        }
       }
 
       Description = BmGetBootDescription (Handles[Index]);

--- a/MdeModulePkg/Library/UefiBootManagerLib/UefiBootManagerLib.inf
+++ b/MdeModulePkg/Library/UefiBootManagerLib/UefiBootManagerLib.inf
@@ -119,3 +119,4 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdBootManagerMenuFile                     ## CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdDriverHealthConfigureForm               ## SOMETIMES_CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdMaxRepairCount                          ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdPrioritizeInternal

--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -2108,6 +2108,9 @@
   # @ValidList  0x80000001 | 0
   gEfiMdeModulePkgTokenSpaceGuid.PcdLoadFixAddressSmmCodePageNumber|0|UINT32|0x0000002c
 
+  # Prioritise Internal Devices
+  gEfiMdeModulePkgTokenSpaceGuid.PcdPrioritizeInternal
+
 [PcdsDynamic, PcdsDynamicEx]
   ## This dynamic PCD hold an address to point to private data structure used in DxeS3BootScriptLib library
   #  instance which records the S3 boot script table start address, length, etc. To introduce this PCD is

--- a/UefiPayloadPkg/UefiPayloadPkg.dsc
+++ b/UefiPayloadPkg/UefiPayloadPkg.dsc
@@ -33,6 +33,7 @@
   DEFINE UNIVERSAL_PAYLOAD            = FALSE
   DEFINE SECURITY_STUB_ENABLE         = TRUE
   DEFINE SMM_SUPPORT                  = FALSE
+  DEFINE PRIORITIZE_INTERNAL          = FALSE
   #
   # SBL:      UEFI payload for Slim Bootloader
   # COREBOOT: UEFI payload for coreboot
@@ -398,6 +399,8 @@
 !if $(PERFORMANCE_MEASUREMENT_ENABLE)
   gEfiMdePkgTokenSpaceGuid.PcdPerformanceLibraryPropertyMask       | 0x1
 !endif
+  gEfiMdeModulePkgTokenSpaceGuid.PcdPrioritiseInternal|$(PRIORITIZE_INTERNAL)
+
 
 [PcdsPatchableInModule.X64]
   gPcAtChipsetPkgTokenSpaceGuid.PcdRtcIndexRegister|$(RTC_INDEX_REGISTER)


### PR DESCRIPTION
On modern platforms with TBT devices the coreboot resource allocator opens
large PCI bridge MMIO windows above 4GiB to place PCI bars there as they won't
fit below 4GiB. In addition modern GPGPU devices have very big PCI bars that must
be placed above 4GiB.

The PciHostBridgeLib made lots of assumptions about the coreboot resource allocator
that were not verified at runtime and are no longer true.

Remove all of the assumption and implement the same logic as OvmfPkg's ScanForRootBridges.
As a side effects, now that both PciHostBridgeLib implementations are indentical it will
be easier to move to a shared codebase.

Fixes assertion "ASSERT [PciHostBridgeDxe] Bridge->Mem.Limit < 0x0000000100000000ULL".

Tested on Intel ADL RVP with coreboot as bootloader that has PCI BARs above 4GiB.
Tested on Intel CFL with coreboot as bootloader that has no PCI BARs above 4GiB.

Signed-off-by: Patrick Rudolph <patrick.rudolph@9elements.com>