### PR TITLE
MdeModulePkg/Bus/Pci/PciBusDxe: Support platform PCI ROM override

### DIFF
--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciRomTable.c
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciRomTable.c
@@ -58,10 +58,9 @@ PciRomAddImageMapping (
     {
       //
       // Expect once RomImage and RomSize are recorded, they will be passed in
-      // later when updating ImageHandle
+      // later when updating ImageHandle. They may also be updated with new
+      // values if the platform provides an override of RomImage and RomSize.
       //
-      ASSERT ((mRomImageTable[Index].RomImage == NULL) || (RomImage == mRomImageTable[Index].RomImage));
-      ASSERT ((mRomImageTable[Index].RomSize  == 0) || (RomSize  == mRomImageTable[Index].RomSize));
       break;
     }
   }


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3811

Remove ASSERT() statements that are triggered if a platform provides
an override of PCI ROM attached to a PCI Controller.  The PCI Platform
Protocol allows the platform to provide a PCI ROM image for a PCI
Controller.  This works for PCI Controllers that do not have an attached
PCI ROM, but the platform is not allowed to replace the PCI ROM for a
PCI Controller that has its own PCI ROM.  Removing these ASSERT()
statements enables this additional use case.

Cc: Hao A Wu <hao.a.wu@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Cc: Star Zeng <star.zeng@intel.com>
Signed-off-by: Michael D Kinney <michael.d.kinney@intel.com>
Reviewed-by: Star Zeng <star.zeng@intel.com>
Reviewed-by: Ray Ni <ray.ni@intel.com>
Acked-by: Ard Biesheuvel <ardb@kernel.org>