### PR TITLE
OvmfPkg/VmgExitLib: Fix uninitialized variable warning with XCODE5

### DIFF
--- a/OvmfPkg/Library/VmgExitLib/VmgExitVcHandler.c
+++ b/OvmfPkg/Library/VmgExitLib/VmgExitVcHandler.c
@@ -1872,6 +1872,7 @@ GetCpuidFw (
     UINT32                 XSaveSize;
 
     XssMsr.Uint64 = 0;
+    Compacted     = 0;
     if (EcxIn == 1) {
       /*
        * The PPR and APM aren't clear on what size should be encoded in


### PR DESCRIPTION
XCODE5 reported the following warning:

OvmfPkg/Library/VmgExitLib/VmgExitVcHandler.c:1895:12: note:
uninitialized use occurs here
           Compacted
           ^^^^^^^^^

Initialize the 'Compacted' variable to fix the warning.

Signed-off-by: Rebecca Cran <quic_rcran@quicinc.com>