### PR TITLE
ShellPkg: Fix incorrect PPTT FlagName dereference

### DIFF
--- a/ShellPkg/Library/UefiShellAcpiViewCommandLib/Parsers/Pptt/PpttParser.c
+++ b/ShellPkg/Library/UefiShellAcpiViewCommandLib/Parsers/Pptt/PpttParser.c
@@ -40,9 +40,9 @@ LogCacheFlagError (
   IncrementErrorCount ();
   Print (
     L"\nERROR: On Arm based systems, all cache properties must be"
-    L"provided in the cache type structure."
-    L"Missing '%s' flag.",
-    *FlagName
+    L" provided in the cache type structure."
+    L" Missing '%s' flag.",
+    FlagName
     );
 }
 


### PR DESCRIPTION
Bugzilla: 3770 (https://bugzilla.tianocore.org/show_bug.cgi?id=3770)

The PPTT parser in AcpiView incorrectly dereferences a pointer to
FlagName when trying to log an error with the PPTT cache flags, which
can lead to random crashes and other errors.

Also fix some spacing in the error message to ensure the message is
printed cleanly.

Signed-off-by: Chris Jones <christopher.jones@arm.com>
Reviewed-by: Rebecca Cran <rebecca@nuviainc.com>
Reviewed-by: Sami Mujawar <sami.mujawar@arm.com>