### PR TITLE
MdeModulePkg/RuntimeDxe: clear mVirtualMapMaxIndex

### DIFF
--- a/MdeModulePkg/Core/RuntimeDxe/Runtime.c
+++ b/MdeModulePkg/Core/RuntimeDxe/Runtime.c
@@ -365,7 +365,8 @@ RuntimeDriverSetVirtualAddressMap (
   //
   // mVirtualMap is only valid during SetVirtualAddressMap() call
   //
-  mVirtualMap = NULL;
+  mVirtualMap         = NULL;
+  mVirtualMapMaxIndex = 0;
 
   return EFI_SUCCESS;
 }


### PR DESCRIPTION
When setting mVirtualMap to NULL also set mVirtualMapMaxIndex to 0.
Without that RuntimeDriverConvertPointer() will go search the ZeroPage
for EFI_MEMORY_DESCRIPTOR entries.

In case mVirtualMapMaxIndex happens to be small small enough that'll go
unnoticed, the search will not find anything and EFI_NOT_FOUND will be
returned.

In case mVirtualMapMaxIndex is big enough the search will reach the end
of the ZeroPage and trigger a page fault.

Signed-off-by: Gerd Hoffmann <kraxel@redhat.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>