### PR TITLE
UefiPayloadPkg: Add PcdAllowHttpConnections to dec [edk2-stable202202]

### DIFF
--- a/UefiPayloadPkg/UefiPayloadPkg.dsc
+++ b/UefiPayloadPkg/UefiPayloadPkg.dsc
@@ -402,7 +402,7 @@
 [PcdsPatchableInModule.X64]
   gPcAtChipsetPkgTokenSpaceGuid.PcdRtcIndexRegister|$(RTC_INDEX_REGISTER)
   gPcAtChipsetPkgTokenSpaceGuid.PcdRtcTargetRegister|$(RTC_TARGET_REGISTER)
-  gEfiNetworkPkgTokenSpaceGuid.PcdAllowHttpConnections|TRUE
+  gEfiNetworkPkgTokenSpaceGuid.PcdAllowHttpConnections|$(NETWORK_DRIVER_ENABLE)
 
 [PcdsPatchableInModule.common]
   gEfiMdeModulePkgTokenSpaceGuid.PcdBootManagerMenuFile|{ 0x21, 0xaa, 0x2c, 0x46, 0x14, 0x76, 0x03, 0x45, 0x83, 0x6e, 0x8a, 0xb6, 0xf4, 0x66, 0x23, 0x31 }

--- a/UefiPayloadPkg/UefiPayloadPkg.dsc
+++ b/UefiPayloadPkg/UefiPayloadPkg.dsc
@@ -521,14 +521,14 @@
   !endif
 !endif
 
-#
-# UEFI network modules
-#
+[Components.X64]
+  #
+  # UEFI network modules
+  #
 !if $(NETWORK_DRIVER_ENABLE) == TRUE
   !include NetworkPkg/Network.dsc.inc
 !endif
 
-[Components.X64]
   #
   # DXE Core
   #


### PR DESCRIPTION
This patch solves the build error of:
error F001: Pcd (gEfiNetworkPkgTokenSpaceGuid.PcdAllowHttpConnections) defined in DSC
is not declared in DEC files referenced in INF files in FDF. Arch: ['X64']

Signed-off-by: Sean Rhodes <sean@starlabs.systems>