### PR TITLE
Bug 2853 update cmocka submodule to fix log length limit

### DIFF
--- a/MdeModulePkg/Library/DxeResetSystemLib/UnitTest/DxeResetSystemLibUnitTest.c
+++ b/MdeModulePkg/Library/DxeResetSystemLib/UnitTest/DxeResetSystemLibUnitTest.c
@@ -10,6 +10,7 @@
 #include <string.h>
 #include <stdarg.h>
 #include <stddef.h>
+#include <stdint.h>
 #include <setjmp.h>
 #include <cmocka.h>
 

--- a/MdeModulePkg/Library/UefiSortLib/UnitTest/UefiSortLibUnitTest.c
+++ b/MdeModulePkg/Library/UefiSortLib/UnitTest/UefiSortLibUnitTest.c
@@ -10,6 +10,7 @@
 #include <string.h>
 #include <stdarg.h>
 #include <stddef.h>
+#include <stdint.h>
 #include <setjmp.h>
 #include <cmocka.h>
 

--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/RuntimeDxeUnitTest/VariableLockRequestToLockUnitTest.c
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/RuntimeDxeUnitTest/VariableLockRequestToLockUnitTest.c
@@ -10,6 +10,7 @@
 #include <string.h>
 #include <stdarg.h>
 #include <stddef.h>
+#include <stdint.h>
 #include <setjmp.h>
 #include <cmocka.h>
 

--- a/UefiCpuPkg/Library/MtrrLib/UnitTest/MtrrLibUnitTest.h
+++ b/UefiCpuPkg/Library/MtrrLib/UnitTest/MtrrLibUnitTest.h
@@ -13,6 +13,7 @@
 #include <string.h>
 #include <stdarg.h>
 #include <stddef.h>
+#include <stdint.h>
 #include <setjmp.h>
 #include <cmocka.h>
 #include <time.h>

--- a/UnitTestFrameworkPkg/Library/UnitTestLib/AssertCmocka.c
+++ b/UnitTestFrameworkPkg/Library/UnitTestLib/AssertCmocka.c
@@ -9,6 +9,7 @@
 #include <string.h>
 #include <stdarg.h>
 #include <stddef.h>
+#include <stdint.h>
 #include <setjmp.h>
 #include <cmocka.h>
 

--- a/UnitTestFrameworkPkg/Library/UnitTestLib/RunTestsCmocka.c
+++ b/UnitTestFrameworkPkg/Library/UnitTestLib/RunTestsCmocka.c
@@ -9,6 +9,7 @@
 #include <string.h>
 #include <stdarg.h>
 #include <stddef.h>
+#include <stdint.h>
 #include <setjmp.h>
 #include <cmocka.h>
 

--- a/UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+++ b/UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
@@ -20,7 +20,6 @@
 
 [Includes.Common.Private]
   PrivateInclude
-  Library/CmockaLib/cmocka/include/cmockery
 
 [LibraryClasses.Common.Private]
   ## @libraryclass Allows save and restore unit test internal state


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=2853

cmocka issue and commit that increases the log message length:
* https://gitlab.com/cmocka/cmocka/-/issues/51
* https://gitlab.com/cmocka/cmocka/-/commit/36c85066dee0113e0b743d886c001ae76ca1fea9

Update cmocka to a version that supports longer log messages.
This update requires <stdint.h> to be included before <cmocka.h>.

The legacy cmockery feature has been removed, so the private
include path to cmockery in the DEC file is no longer required.

Cc: Sean Brogan <sean.brogan@microsoft.com>
Cc: Bret Barkelew <Bret.Barkelew@microsoft.com>
Cc: Eric Dong <eric.dong@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Cc: Rahul Kumar <rahul1.kumar@intel.com>
Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Signed-off-by: Michael D Kinney <michael.d.kinney@intel.com>