### PR TITLE
UefiPayloadPkg/PayloadLoaderPeim: Force UINTN before save Ptr

### DIFF
--- a/UefiPayloadPkg/PayloadLoaderPeim/ElfLib/Elf64Lib.c
+++ b/UefiPayloadPkg/PayloadLoaderPeim/ElfLib/Elf64Lib.c
@@ -143,7 +143,7 @@ ProcessRelocation64 (
           DEBUG ((DEBUG_INFO, "Unsupported relocation type %02X\n", Type));
           ASSERT (FALSE);
         } else {
-          *Ptr += Delta;
+          *Ptr = *(UINTN *)Ptr + Delta;
         }
 
         break;
@@ -177,12 +177,12 @@ ProcessRelocation64 (
           // Calculation: B + A
           //
           if (RelaType == SHT_RELA) {
-            *Ptr = Delta + Rela->r_addend;
+            *Ptr = Delta + (UINTN)Rela->r_addend;
           } else {
             //
             // A is stored in the field of relocation for REL type.
             //
-            *Ptr = Delta + *Ptr;
+            *Ptr = Delta + *(UINTN *)Ptr;
           }
         } else {
           //


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3818

It will have some potential issue when memory larger than 2G because
the high memory address will be fill with 0xFFFFFFFF when do the
operation of UINT64 + INTN.

V2:
1. Force the data type to UINTN to avoid high dword be filled with
0xFFFFFFFF
2. Keep INTN because the offset may postive or negative.

Reviewed-by: Ray Ni <ray.ni@intel.com>
Reviewed-by: Maurice Ma <maurice.ma@intel.com>
Signed-off-by: Guomin Jiang <guomin.jiang@intel.com>