### PR TITLE
ShellPkg: Fix Ping GetTimerPeriod API failure

### DIFF
--- a/ShellPkg/Library/UefiShellNetwork1CommandsLib/Ping.c
+++ b/ShellPkg/Library/UefiShellNetwork1CommandsLib/Ping.c
@@ -259,9 +259,11 @@ GetTimerPeriod (
   EFI_EVENT   TimerEvent;
   UINT32      StallCounter;
   EFI_TPL     OldTpl;
+  UINT32      TimerPeriod;
 
   RttTimerTick = 0;
   StallCounter = 0;
+  TimerPeriod  = 0;
 
   Status = gBS->CreateEvent (
                   EVT_TIMER | EVT_NOTIFY_SIGNAL,
@@ -295,7 +297,12 @@ GetTimerPeriod (
   gBS->SetTimer (TimerEvent, TimerCancel, 0);
   gBS->CloseEvent (TimerEvent);
 
-  return StallCounter / RttTimerTick;
+  TimerPeriod = StallCounter / RttTimerTick;
+  if (TimerPeriod != 0) {
+    return TimerPeriod;
+  } else {
+    return 1;
+  }
 }
 
 /**


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3819

Ping GetTimerPeriod API returns sometime zero value when
StallCounter has smaller value than RttTimerTick (divide by zero)
which results some failure at ping UEFI shell command

Signed-off-by: MohammedX Rehan <mohammedx.rehan@intel.com>
Reviewed-by: Zhichao Gao <zhichao.gao@intel.com>
Reviewed-by: Ray Ni <ray.ni@intel.com>