### PR TITLE
UefiPayloadPkg/PayloadLoaderPeim: Use INT64 as input parameter

### DIFF
--- a/UefiPayloadPkg/PayloadLoaderPeim/ElfLib/Elf64Lib.c
+++ b/UefiPayloadPkg/PayloadLoaderPeim/ElfLib/Elf64Lib.c
@@ -108,7 +108,7 @@ ProcessRelocation64 (
   IN  UINT64      RelaSize,
   IN  UINT64      RelaEntrySize,
   IN  UINT64      RelaType,
-  IN  INTN        Delta,
+  IN  INT64       Delta,
   IN  BOOLEAN     DynamicLinking
   )
 {


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3818

It will have some potential issue when memory larger than 2G because
the high memory address will be fill with 0xFFFFFFFF when do the
operation of INTN + INT64 but it is 32 bit normal data in fact.

Should use same data type INT64 + INT64.

V3:
1. Use INT64 as input parameter because all date type is 64 bit
V2:
1. Force the data type to UINTN to avoid high dword be filled with
0xFFFFFFFF
2. Keep INTN because the offset may postive or negative.

Reviewed-by: Guo Dong <guo.dong@intel.com>
Reviewed-by: Ray Ni <ray.ni@intel.com>
Signed-off-by: Guomin Jiang <guomin.jiang@intel.com>