### PR TITLE
edk2/MdeModulePkg/Debuglib: Add Standalone MM support

### DIFF
--- a/MdeModulePkg/Library/PeiDxeDebugLibReportStatusCode/PeiDxeDebugLibReportStatusCode.inf
+++ b/MdeModulePkg/Library/PeiDxeDebugLibReportStatusCode/PeiDxeDebugLibReportStatusCode.inf
@@ -2,7 +2,7 @@
 #  Debug Library based on report status code library
 #
 #  Debug Library for PEIMs and DXE drivers that sends debug messages to ReportStatusCode
-#  Copyright (c) 2006 - 2018, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2006 - 2022, Intel Corporation. All rights reserved.<BR>
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -16,7 +16,7 @@
   FILE_GUID                      = bda39d3a-451b-4350-8266-81ab10fa0523
   MODULE_TYPE                    = PEIM
   VERSION_STRING                 = 1.0
-  LIBRARY_CLASS                  = DebugLib|DXE_CORE DXE_DRIVER DXE_RUNTIME_DRIVER DXE_SMM_DRIVER SMM_CORE PEIM SEC PEI_CORE UEFI_APPLICATION UEFI_DRIVER
+  LIBRARY_CLASS                  = DebugLib|DXE_CORE DXE_DRIVER DXE_RUNTIME_DRIVER DXE_SMM_DRIVER SMM_CORE PEIM SEC PEI_CORE UEFI_APPLICATION UEFI_DRIVER MM_STANDALONE
 
 #
 # The following information is for reference only and not required by the build tools.


### PR DESCRIPTION
https://bugzilla.tianocore.org/show_bug.cgi?id=3844

This change added Standalone MM instance of DebugLib.

Reviewd-by: Jian J Wang <jian.j.wang@intel.com>
Reviewd-by: Liming Gao <gaoliming@byosoft.com.cn>

Signed-off-by: Xiaolu.Jiang <xiaolu.jiang@intel.com>