### PR TITLE
Ap relaxed variable smm

### DIFF
--- a/MdeModulePkg/Include/Library/SmmCpuRendezvousLib.h
+++ b/MdeModulePkg/Include/Library/SmmCpuRendezvousLib.h
@@ -1,0 +1,27 @@
+/** @file
+  SMM CPU Rendezvous library header file.
+
+  Copyright (c) 2022, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef SMM_CPU_RENDEZVOUS_H_
+#define SMM_CPU_RENDEZVOUS_H_
+
+/**
+  This routine wait for all AP processors to arrive in SMM.
+
+  @param[in]  BlockingMode  Blocking mode or non-blocking mode.
+
+  @retval EFI_SUCCESS       All processors checked in to SMM.
+  @retval EFI_TIMEOUT       Wait for all APs until timeout.
+
+**/
+EFI_STATUS
+EFIAPI
+SmmWaitForAllProcessor (
+  IN  BOOLEAN  BlockingMode
+  );
+
+#endif

--- a/MdeModulePkg/Library/SmmCpuRendezvousLibNull/SmmCpuRendezvousLibNull.c
+++ b/MdeModulePkg/Library/SmmCpuRendezvousLibNull/SmmCpuRendezvousLibNull.c
@@ -1,0 +1,29 @@
+/** @file
+  SMM CPU Rendezvous sevice implement.
+
+  Copyright (c) 2022, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Library/DebugLib.h>
+#include <Library/SmmCpuRendezvousLib.h>
+
+/**
+  This routine wait for all AP processors to arrive in SMM.
+
+  @param[in] BlockingMode  Blocking mode or non-blocking mode.
+
+  @retval EFI_SUCCESS  All avaiable APs arrived.
+  @retval EFI_TIMEOUT  Wait for all APs until timeout.
+  @retval OTHER        Fail to register SMM CPU Rendezvous service Protocol.
+**/
+EFI_STATUS
+EFIAPI
+SmmWaitForAllProcessor (
+  IN BOOLEAN  BlockingMode
+  )
+{
+  ASSERT (FALSE);
+  return EFI_SUCCESS;
+}

--- a/MdeModulePkg/Library/SmmCpuRendezvousLibNull/SmmCpuRendezvousLibNull.inf
+++ b/MdeModulePkg/Library/SmmCpuRendezvousLibNull/SmmCpuRendezvousLibNull.inf
@@ -1,0 +1,27 @@
+## @file
+# SMM CPU Rendezvous service lib.
+#
+# This is SMM CPU rendezvous service lib that wait for all
+# APs to enter SMM mode.
+#
+# Copyright (c) 2022, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = SmmCpuRendezvousLibNull
+  FILE_GUID                      = 1e5790ea-d013-4d7b-9047-b4342a762027
+  MODULE_TYPE                    = DXE_SMM_DRIVER
+  LIBRARY_CLASS                  = SmmCpuRendezvousLib|MM_STANDALONE DXE_SMM_DRIVER
+
+[Sources]
+  SmmCpuRendezvousLibNull.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+
+[LibraryClasses]
+  DebugLib

--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -4,7 +4,7 @@
 # and libraries instances, which are used for those modules.
 #
 # Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
-# Copyright (c) 2007 - 2021, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2007 - 2022, Intel Corporation. All rights reserved.<BR>
 # Copyright (c) 2016, Linaro Ltd. All rights reserved.<BR>
 # (C) Copyright 2016 - 2019 Hewlett Packard Enterprise Development LP<BR>
 # Copyright (c) 2017, AMD Incorporated. All rights reserved.<BR>
@@ -153,6 +153,9 @@
   #   registering new policies with the VariablePolicy infrastructure.
   #
   VariablePolicyHelperLib|Include/Library/VariablePolicyHelperLib.h
+
+  ## @libraryclass  Provides function for SMM CPU Rendezvous Library.
+  SmmCpuRendezvousLib|Include/Library/SmmCpuRendezvousLib.h
 
 [Guids]
   ## MdeModule package token space guid

--- a/MdeModulePkg/MdeModulePkg.dsc
+++ b/MdeModulePkg/MdeModulePkg.dsc
@@ -2,7 +2,7 @@
 # EFI/PI Reference Module Package for All Architectures
 #
 # (C) Copyright 2014 Hewlett-Packard Development Company, L.P.<BR>
-# Copyright (c) 2007 - 2021, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2007 - 2022, Intel Corporation. All rights reserved.<BR>
 # Copyright (c) Microsoft Corporation.
 #
 #    SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -152,6 +152,7 @@
   SmmServicesTableLib|MdePkg/Library/SmmServicesTableLib/SmmServicesTableLib.inf
   LockBoxLib|MdeModulePkg/Library/SmmLockBoxLib/SmmLockBoxSmmLib.inf
   SmmMemLib|MdePkg/Library/SmmMemLib/SmmMemLib.inf
+  SmmCpuRendezvousLib|MdeModulePkg/Library/SmmCpuRendezvousLibNull/SmmCpuRendezvousLibNull.inf
 
 [LibraryClasses.common.UEFI_DRIVER]
   HobLib|MdePkg/Library/DxeHobLib/DxeHobLib.inf
@@ -172,6 +173,7 @@
   MmServicesTableLib|MdePkg/Library/StandaloneMmServicesTableLib/StandaloneMmServicesTableLib.inf
   LockBoxLib|MdeModulePkg/Library/SmmLockBoxLib/SmmLockBoxStandaloneMmLib.inf
   MemLib|StandaloneMmPkg/Library/StandaloneMmMemLib/StandaloneMmMemLib.inf
+  SmmCpuRendezvousLib|MdeModulePkg/Library/SmmCpuRendezvousLibNull/SmmCpuRendezvousLibNull.inf
 
 [LibraryClasses.ARM, LibraryClasses.AARCH64]
   ArmLib|ArmPkg/Library/ArmLib/ArmBaseLib.inf
@@ -459,6 +461,7 @@
   MdeModulePkg/Universal/FaultTolerantWriteDxe/FaultTolerantWriteStandaloneMm.inf
   MdeModulePkg/Universal/Variable/RuntimeDxe/VariableStandaloneMm.inf
 !endif
+  MdeModulePkg/Library/SmmCpuRendezvousLibNull/SmmCpuRendezvousLibNull.inf
 
 [Components.IA32, Components.X64]
   MdeModulePkg/Universal/DebugSupportDxe/DebugSupportDxe.inf

--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmm.inf
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmm.inf
@@ -18,7 +18,7 @@
 #  may not be modified without authorization. If platform fails to protect these resources,
 #  the authentication service provided in this driver will be broken, and the behavior is undefined.
 #
-# Copyright (c) 2010 - 2019, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2010 - 2022, Intel Corporation. All rights reserved.<BR>
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -82,6 +82,7 @@
   UefiBootServicesTableLib
   VariablePolicyLib
   VariablePolicyHelperLib
+  SmmCpuRendezvousLib
 
 [Protocols]
   gEfiSmmFirmwareVolumeBlockProtocolGuid        ## CONSUMES

--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableStandaloneMm.inf
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableStandaloneMm.inf
@@ -18,7 +18,7 @@
 #  may not be modified without authorization. If platform fails to protect these resources,
 #  the authentication service provided in this driver will be broken, and the behavior is undefined.
 #
-# Copyright (c) 2010 - 2019, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2010 - 2022, Intel Corporation. All rights reserved.<BR>
 # Copyright (c) 2018, Linaro, Ltd. All rights reserved.<BR>
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -78,6 +78,7 @@
   VarCheckLib
   VariablePolicyLib
   VariablePolicyHelperLib
+  SmmCpuRendezvousLib
 
 [Protocols]
   gEfiSmmFirmwareVolumeBlockProtocolGuid        ## CONSUMES

--- a/UefiCpuPkg/Include/Library/SmmCpuRendezvousLib.h
+++ b/UefiCpuPkg/Include/Library/SmmCpuRendezvousLib.h
@@ -1,0 +1,27 @@
+/** @file
+  SMM CPU Rendezvous library header file.
+
+  Copyright (c) 2022, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef SMM_CPU_RENDEZVOUS_H_
+#define SMM_CPU_RENDEZVOUS_H_
+
+/**
+  This routine wait for all AP processors to arrive in SMM.
+
+  @param[in]  BlockingMode  Blocking mode or non-blocking mode.
+
+  @retval EFI_SUCCESS       All processors checked in to SMM.
+  @retval EFI_TIMEOUT       Wait for all APs until timeout.
+
+**/
+EFI_STATUS
+EFIAPI
+SmmWaitForAllProcessor (
+  IN  BOOLEAN  BlockingMode
+  );
+
+#endif

--- a/UefiCpuPkg/Include/Protocol/SmmCpuService.h
+++ b/UefiCpuPkg/Include/Protocol/SmmCpuService.h
@@ -1,7 +1,7 @@
 /** @file
 SMM CPU Service protocol definition.
 
-Copyright (c) 2013 - 2015, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2013 - 2022, Intel Corporation. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -199,5 +199,39 @@ struct _EFI_SMM_CPU_SERVICE_PROTOCOL {
 };
 
 extern EFI_GUID  gEfiSmmCpuServiceProtocolGuid;
+
+//
+//  EDKII_SMM_CPU_RENDEZVOUS_PROTOCOL provide SMM CPU
+//  rendezvous service support.
+//
+#define EDKII_SMM_CPU_RENDEZVOUS_PROTOCOL_GUID \
+  { \
+    0xaa00d50b, 0x4911, 0x428f, { 0xb9, 0x1a, 0xa5, 0x9d, 0xdb, 0x13, 0xe2, 0x4c } \
+  }
+
+typedef struct _EDKII_SMM_CPU_RENDEZVOUS_PROTOCOL EDKII_SMM_CPU_RENDEZVOUS_PROTOCOL;
+
+/**
+  Wait for all APs to arrive SMM mode in given timeout constraint.
+
+  @param[in]  This                  A pointer to the EDKII_SMM_CPU_RENDEZVOUS_PROTOCOL instance.
+  @param[in]  BlockingMode          Block or non-block mode.
+
+  @retval EFI_SUCCESS               All APs have arrived SMM mode except SMI disabled APs.
+  @retval EFI_TIMEOUT               There are APs not in SMM mode in given timeout constraint.
+
+**/
+typedef
+EFI_STATUS
+(EFIAPI *EDKII_WAIT_FOR_ALL_PROCESSOR)(
+  IN  EDKII_SMM_CPU_RENDEZVOUS_PROTOCOL  *This,
+  IN  BOOLEAN                            BlockingMode
+  );
+
+struct _EDKII_SMM_CPU_RENDEZVOUS_PROTOCOL {
+  EDKII_WAIT_FOR_ALL_PROCESSOR    WaitForAllProcessor;
+};
+
+extern EFI_GUID  gEdkiiSmmCpuRendezvousProtocolGuid;
 
 #endif

--- a/UefiCpuPkg/Library/SmmCpuRendezvousLib/SmmCpuRendezvousLib.c
+++ b/UefiCpuPkg/Library/SmmCpuRendezvousLib/SmmCpuRendezvousLib.c
@@ -1,0 +1,103 @@
+/** @file
+  SMM CPU Rendezvous sevice implement.
+
+  Copyright (c) 2022, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Base.h>
+#include <Uefi.h>
+#include <Library/BaseLib.h>
+#include <Library/DebugLib.h>
+#include <Library/MmServicesTableLib.h>
+#include <Protocol/SmmCpuService.h>
+#include <Library/SmmCpuRendezvousLib.h>
+
+STATIC EDKII_SMM_CPU_RENDEZVOUS_PROTOCOL  *mSmmCpuRendezvous = NULL;
+STATIC VOID                               *mRegistration     = NULL;
+
+/**
+  Callback function to wait Smm cpu rendezvous service located.
+
+  SmmCpuRendezvousLib need to support MM_STANDALONE and DXE_SMM_DRIVER driver.
+  So do not use library constructor to locate the protocol.
+
+  @param[in] Protocol   Points to the protocol's unique identifier.
+  @param[in] Interface  Points to the interface instance.
+  @param[in] Handle     The handle on which the interface was installed.
+
+  @retval EFI_SUCCESS  Notification runs successfully.
+
+**/
+EFI_STATUS
+EFIAPI
+SmmCpuRendezvousProtocolNotify (
+  IN CONST EFI_GUID    *Protocol,
+  IN       VOID        *Interface,
+  IN       EFI_HANDLE  Handle
+  )
+{
+  EFI_STATUS  Status;
+
+  Status = gMmst->MmLocateProtocol (
+                    &gEdkiiSmmCpuRendezvousProtocolGuid,
+                    NULL,
+                    (VOID **)&mSmmCpuRendezvous
+                    );
+  ASSERT_EFI_ERROR (Status);
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This routine wait for all AP processors to arrive in SMM.
+
+  @param[in] BlockingMode  Blocking mode or non-blocking mode.
+
+  @retval EFI_SUCCESS  All avaiable APs arrived.
+  @retval EFI_TIMEOUT  Wait for all APs until timeout.
+  @retval OTHER        Fail to register SMM CPU Rendezvous service Protocol.
+**/
+EFI_STATUS
+EFIAPI
+SmmWaitForAllProcessor (
+  IN BOOLEAN  BlockingMode
+  )
+{
+  EFI_STATUS  Status;
+
+  if ((mRegistration == NULL) && (mSmmCpuRendezvous == NULL)) {
+    //
+    // Locate SMM cpu rendezvous protocol for the first time execute the function.
+    //
+    Status = gMmst->MmLocateProtocol (
+                      &gEdkiiSmmCpuRendezvousProtocolGuid,
+                      NULL,
+                      (VOID **)&mSmmCpuRendezvous
+                      );
+    if (EFI_ERROR (Status)) {
+      Status = gMmst->MmRegisterProtocolNotify (
+                        &gEdkiiSmmCpuRendezvousProtocolGuid,
+                        SmmCpuRendezvousProtocolNotify,
+                        &mRegistration
+                        );
+      if (EFI_ERROR (Status)) {
+        return Status;
+      }
+    }
+  }
+
+  //
+  // The platform have not set up. It doesn't need smm cpu rendezvous.
+  //
+  if (mSmmCpuRendezvous == NULL) {
+    return EFI_SUCCESS;
+  }
+
+  Status = mSmmCpuRendezvous->WaitForAllProcessor (
+                                mSmmCpuRendezvous,
+                                BlockingMode
+                                );
+  return Status;
+}

--- a/UefiCpuPkg/Library/SmmCpuRendezvousLib/SmmCpuRendezvousLib.inf
+++ b/UefiCpuPkg/Library/SmmCpuRendezvousLib/SmmCpuRendezvousLib.inf
@@ -1,0 +1,35 @@
+## @file
+# SMM CPU Rendezvous service lib.
+#
+# This is SMM CPU rendezvous service lib that wait for all
+# APs to enter SMM mode.
+#
+# Copyright (c) 2022, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = SmmCpuRendezvousLib
+  FILE_GUID                      = 1509Bb36-9Ba4-438B-B195-Ac5914Db14E2
+  MODULE_TYPE                    = DXE_SMM_DRIVER
+  LIBRARY_CLASS                  = SmmCpuRendezvousLib|MM_STANDALONE DXE_SMM_DRIVER
+
+[Sources]
+  SmmCpuRendezvousLib.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  UefiCpuPkg/UefiCpuPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  DebugLib
+  MmServicesTableLib
+
+[Pcd]
+  gUefiCpuPkgTokenSpaceGuid.PcdCpuSmmApSyncTimeout                 ## CONSUMES
+
+[Protocols]
+  gEdkiiSmmCpuRendezvousProtocolGuid

--- a/UefiCpuPkg/PiSmmCpuDxeSmm/MpService.c
+++ b/UefiCpuPkg/PiSmmCpuDxeSmm/MpService.c
@@ -1,7 +1,7 @@
 /** @file
 SMM MP service implementation
 
-Copyright (c) 2009 - 2021, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2009 - 2022, Intel Corporation. All rights reserved.<BR>
 Copyright (c) 2017, AMD Incorporated. All rights reserved.<BR>
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -293,10 +293,14 @@ SmmWaitForApArrival (
   // Sync with APs 1st timeout
   //
   for (Timer = StartSyncTimer ();
-       !IsSyncTimerTimeout (Timer) && !(LmceEn && LmceSignal) &&
-       !AllCpusInSmmWithExceptions (ARRIVAL_EXCEPTION_BLOCKED | ARRIVAL_EXCEPTION_SMI_DISABLED);
+       !IsSyncTimerTimeout (Timer) && !(LmceEn && LmceSignal);
        )
   {
+    mSmmMpSyncData->AllApArrivedWithException = AllCpusInSmmWithExceptions (ARRIVAL_EXCEPTION_BLOCKED | ARRIVAL_EXCEPTION_SMI_DISABLED);
+    if (mSmmMpSyncData->AllApArrivedWithException) {
+      break;
+    }
+
     CpuPause ();
   }
 
@@ -330,10 +334,14 @@ SmmWaitForApArrival (
     // Sync with APs 2nd timeout.
     //
     for (Timer = StartSyncTimer ();
-         !IsSyncTimerTimeout (Timer) &&
-         !AllCpusInSmmWithExceptions (ARRIVAL_EXCEPTION_BLOCKED | ARRIVAL_EXCEPTION_SMI_DISABLED);
+         !IsSyncTimerTimeout (Timer);
          )
     {
+      mSmmMpSyncData->AllApArrivedWithException = AllCpusInSmmWithExceptions (ARRIVAL_EXCEPTION_BLOCKED | ARRIVAL_EXCEPTION_SMI_DISABLED);
+      if (mSmmMpSyncData->AllApArrivedWithException) {
+        break;
+      }
+
       CpuPause ();
     }
   }
@@ -1886,6 +1894,8 @@ InitializeMpSyncData (
     *mSmmMpSyncData->Counter       = 0;
     *mSmmMpSyncData->InsideSmm     = FALSE;
     *mSmmMpSyncData->AllCpusInSync = FALSE;
+
+    mSmmMpSyncData->AllApArrivedWithException = FALSE;
 
     for (CpuIndex = 0; CpuIndex < gSmmCpuPrivate->SmmCoreEntryContext.NumberOfCpus; CpuIndex++) {
       mSmmMpSyncData->CpuData[CpuIndex].Busy =

--- a/UefiCpuPkg/PiSmmCpuDxeSmm/PiSmmCpuDxeSmm.h
+++ b/UefiCpuPkg/PiSmmCpuDxeSmm/PiSmmCpuDxeSmm.h
@@ -1,7 +1,7 @@
 /** @file
 Agent Module to load other modules to deploy SMM Entry Vector for X86 CPU.
 
-Copyright (c) 2009 - 2020, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2009 - 2022, Intel Corporation. All rights reserved.<BR>
 Copyright (c) 2017, AMD Incorporated. All rights reserved.<BR>
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -428,6 +428,7 @@ typedef struct {
   volatile SMM_CPU_SYNC_MODE    EffectiveSyncMode;
   volatile BOOLEAN              SwitchBsp;
   volatile BOOLEAN              *CandidateBsp;
+  volatile BOOLEAN              AllApArrivedWithException;
   EFI_AP_PROCEDURE              StartupProcedure;
   VOID                          *StartupProcArgs;
 } SMM_DISPATCHER_MP_SYNC_DATA;
@@ -1485,6 +1486,32 @@ InitializeDataForMmMp (
 **/
 BOOLEAN
 IsRestrictedMemoryAccess (
+  VOID
+  );
+
+/**
+  Choose blocking or non-blocking mode to Wait for all APs.
+
+  @param[in]  This                  A pointer to the EDKII_SMM_CPU_RENDEZVOUS_PROTOCOL instance.
+  @param[in]  BlockingMode          Blocking or non-blocking mode.
+
+  @retval EFI_SUCCESS               All APs have arrived SMM mode except SMI disabled APs.
+  @retval EFI_TIMEOUT               There are APs not in SMM mode in given timeout constraint.
+
+**/
+EFI_STATUS
+EFIAPI
+SmmCpuRendezvous (
+  IN  EDKII_SMM_CPU_RENDEZVOUS_PROTOCOL  *This,
+  IN  BOOLEAN                            BlockingMode
+  );
+
+/**
+  Insure when this function returns, no AP will execute normal mode code before entering SMM, except SMI disabled APs.
+
+**/
+VOID
+SmmWaitForApArrival (
   VOID
   );
 

--- a/UefiCpuPkg/PiSmmCpuDxeSmm/PiSmmCpuDxeSmm.inf
+++ b/UefiCpuPkg/PiSmmCpuDxeSmm/PiSmmCpuDxeSmm.inf
@@ -4,7 +4,7 @@
 # This SMM driver performs SMM initialization, deploy SMM Entry Vector,
 # provides CPU specific services in SMM.
 #
-# Copyright (c) 2009 - 2021, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2009 - 2022, Intel Corporation. All rights reserved.<BR>
 # Copyright (c) 2017, AMD Incorporated. All rights reserved.<BR>
 #
 # SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -107,7 +107,8 @@
   gEfiSmmReadyToLockProtocolGuid           ## NOTIFY
   gEfiSmmCpuServiceProtocolGuid            ## PRODUCES
   gEdkiiSmmMemoryAttributeProtocolGuid     ## PRODUCES
-  gEfiMmMpProtocolGuid                    ## PRODUCES
+  gEfiMmMpProtocolGuid                     ## PRODUCES
+  gEdkiiSmmCpuRendezvousProtocolGuid       ## PRODUCES
 
 [Guids]
   gEfiAcpiVariableGuid                     ## SOMETIMES_CONSUMES ## HOB # it is used for S3 boot.

--- a/UefiCpuPkg/UefiCpuPkg.dec
+++ b/UefiCpuPkg/UefiCpuPkg.dec
@@ -1,7 +1,7 @@
 ## @file  UefiCpuPkg.dec
 # This Package provides UEFI compatible CPU modules and libraries.
 #
-# Copyright (c) 2007 - 2021, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2007 - 2022, Intel Corporation. All rights reserved.<BR>
 #
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -62,6 +62,9 @@
   ##  @libraryclass  Provides function for loading microcode.
   MicrocodeLib|Include/Library/MicrocodeLib.h
 
+  ## @libraryclass  Provides function for SMM CPU Rendezvous Library.
+  SmmCpuRendezvousLib|Include/Library/SmmCpuRendezvousLib.h
+
 [Guids]
   gUefiCpuPkgTokenSpaceGuid      = { 0xac05bf33, 0x995a, 0x4ed4, { 0xaa, 0xb8, 0xef, 0x7a, 0xe8, 0xf, 0x5c, 0xb0 }}
   gMsegSmramGuid                 = { 0x5802bce4, 0xeeee, 0x4e33, { 0xa1, 0x30, 0xeb, 0xad, 0x27, 0xf0, 0xe4, 0x39 }}
@@ -77,7 +80,8 @@
 
 [Protocols]
   ## Include/Protocol/SmmCpuService.h
-  gEfiSmmCpuServiceProtocolGuid  = { 0x1d202cab, 0xc8ab, 0x4d5c, { 0x94, 0xf7, 0x3c, 0xfc, 0xc0, 0xd3, 0xd3, 0x35 }}
+  gEfiSmmCpuServiceProtocolGuid   = { 0x1d202cab, 0xc8ab, 0x4d5c, { 0x94, 0xf7, 0x3c, 0xfc, 0xc0, 0xd3, 0xd3, 0x35 }}
+  gEdkiiSmmCpuRendezvousProtocolGuid = { 0xaa00d50b, 0x4911, 0x428f, { 0xb9, 0x1a, 0xa5, 0x9d, 0xdb, 0x13, 0xe2, 0x4c }}
 
   ## Include/Protocol/SmMonitorInit.h
   gEfiSmMonitorInitProtocolGuid  = { 0x228f344d, 0xb3de, 0x43bb, { 0xa4, 0xd7, 0xea, 0x20, 0xb, 0x1b, 0x14, 0x82 }}

--- a/UefiCpuPkg/UefiCpuPkg.dsc
+++ b/UefiCpuPkg/UefiCpuPkg.dsc
@@ -61,6 +61,7 @@
   TpmMeasurementLib|MdeModulePkg/Library/TpmMeasurementLibNull/TpmMeasurementLibNull.inf
   VmgExitLib|UefiCpuPkg/Library/VmgExitLibNull/VmgExitLibNull.inf
   MicrocodeLib|UefiCpuPkg/Library/MicrocodeLib/MicrocodeLib.inf
+  SmmCpuRendezvousLib|UefiCpuPkg/Library/SmmCpuRendezvousLib/SmmCpuRendezvousLib.inf
 
 [LibraryClasses.common.SEC]
   PlatformSecLib|UefiCpuPkg/Library/PlatformSecLibNull/PlatformSecLibNull.inf
@@ -173,6 +174,7 @@
   }
   UefiCpuPkg/Universal/Acpi/S3Resume2Pei/S3Resume2Pei.inf
   UefiCpuPkg/ResetVector/Vtf0/Bin/ResetVector.inf
+  UefiCpuPkg/Library/SmmCpuRendezvousLib/SmmCpuRendezvousLib.inf
 
 [BuildOptions]
   *_*_*_CC_FLAGS = -D DISABLE_NEW_DEPRECATED_INTERFACES


### PR DESCRIPTION
In UefiCpuPkg, there are a new Protocol with the new service
SmmWaitForAllProcessor(), which can be used by SMI handler
to optionally wait for other APs to complete SMM rendezvous in
relaxed AP mode.

This patch use the new service to let VariableSmm driver work
normally in relaxed AP mode.