### PR TITLE
MdeModulePkg:Avoid Xhc cross 64K boundary

### DIFF
--- a/MdeModulePkg/Bus/Pci/XhciDxe/XhciSched.c
+++ b/MdeModulePkg/Bus/Pci/XhciDxe/XhciSched.c
@@ -891,8 +891,14 @@ CreateTransferRing (
   VOID                  *Buf;
   LINK_TRB              *EndTrb;
   EFI_PHYSICAL_ADDRESS  PhyAddr;
+  VOID                  *NewBuf;
 
   Buf = UsbHcAllocateMem (Xhc->MemPool, sizeof (TRB_TEMPLATE) * TrbNum);
+  if((((UINTN)Buf & ((1<<16)-1)) + sizeof (TRB_TEMPLATE) * TrbNum) & (1<<16)) {
+    NewBuf = UsbHcAllocateMem (Xhc->MemPool,sizeof(TRB_TEMPLATE) * TrbNum);
+    UsbHcFreeMem(Xhc->MemPool,Buf,sizeof(TRB_TEMPLATE)*TrbNum);
+    Buf = NewBuf;
+  }
   ASSERT (Buf != NULL);
   ASSERT (((UINTN)Buf & 0x3F) == 0);
   ZeroMem (Buf, sizeof (TRB_TEMPLATE) * TrbNum);


### PR DESCRIPTION
The current xhc implementation may exceed the 64K boundary,
so must restrictions need to be added.

Cc: Ray Ni <ray.ni@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Wang Jian J <jian.j.wang@intel.com>
Reviewed-by: Wu Hao A <hao.a.wu@intel.com>
Signed-off-by: Cheng Zhou <zhoucheng@phytium.com.cn>