### PR TITLE
[Test PR] MdeModulePkg: Add a check for metadata size in NvmExpress Driver

### DIFF
--- a/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpress.c
+++ b/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpress.c
@@ -137,8 +137,23 @@ EnumerateNvmeDevNamespace (
     Device->Media.WriteCaching     = FALSE;
     Device->Media.IoAlign          = Private->PassThruMode.IoAlign;
 
-    Flbas                   = NamespaceData->Flbas;
-    LbaFmtIdx               = Flbas & 0xF;
+    Flbas     = NamespaceData->Flbas;
+    LbaFmtIdx = Flbas & 0xF;
+
+    //
+    // Currently this NVME driver only suport Metadata Size == 0
+    //
+    if (NamespaceData->LbaFormat[LbaFmtIdx].Ms != 0) {
+      DEBUG ((
+        DEBUG_ERROR,
+        "NVME IDENTIFY NAMESPACE [%d] Ms(%d) is not supported.\n",
+        NamespaceId,
+        NamespaceData->LbaFormat[LbaFmtIdx].Ms
+        ));
+      Status = EFI_UNSUPPORTED;
+      goto Exit;
+    }
+
     Lbads                   = NamespaceData->LbaFormat[LbaFmtIdx].Lbads;
     Device->Media.BlockSize = (UINT32)1 << Lbads;
 

--- a/MdeModulePkg/Bus/Pci/NvmExpressPei/NvmExpressPei.c
+++ b/MdeModulePkg/Bus/Pci/NvmExpressPei/NvmExpressPei.c
@@ -104,7 +104,22 @@ EnumerateNvmeDevNamespace (
   //
   Flbas     = NamespaceData->Flbas;
   LbaFmtIdx = Flbas & 0xF;
-  Lbads     = NamespaceData->LbaFormat[LbaFmtIdx].Lbads;
+
+  //
+  // Currently this NVME driver only suport Metadata Size == 0
+  //
+  if (NamespaceData->LbaFormat[LbaFmtIdx].Ms != 0) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "NVME IDENTIFY NAMESPACE [%d] Ms(%d) is not supported.\n",
+      NamespaceId,
+      NamespaceData->LbaFormat[LbaFmtIdx].Ms
+      ));
+    Status = EFI_UNSUPPORTED;
+    goto Exit;
+  }
+
+  Lbads = NamespaceData->LbaFormat[LbaFmtIdx].Lbads;
 
   NamespaceInfo->Media.InterfaceType  = MSG_NVME_NAMESPACE_DP;
   NamespaceInfo->Media.RemovableMedia = FALSE;


### PR DESCRIPTION
Ref: https://bugzilla.tianocore.org/show_bug.cgi?id=3856

Currently this NvmeExpress Driver do not support metadata handling.
According to the NVME specs, metadata may be transferred to the host after
the logical block data. It can overrun the input buffer which may only
be the size of logical block data.

Add a check to return not support for the namespaces formatted with
metadata.

v2 changes:
 - Change debug log level from INFO to ERROR
 - Change to if (NamespaceData->LbaFormat[LbaFmtIdx].Ms != 0)

v1: https://edk2.groups.io/g/devel/message/87242

Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Hao A Wu <hao.a.wu@intel.com>
Cc: Ray Ni <ray.ni@intel.com>

Signed-off-by: Hua Ma <hua.ma@intel.com>