### PR TITLE
UefiPayloadPkg: Invoke GetPhysicalAddressBits() and remove the duplic…

### DIFF
--- a/UefiPayloadPkg/UefiPayloadEntry/UefiPayloadEntry.c
+++ b/UefiPayloadPkg/UefiPayloadEntry/UefiPayloadEntry.c
@@ -4,6 +4,7 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
+#include <Library/UefiCpuLib.h>
 
 #include <Guid/MemoryTypeInformation.h>
 #include "UefiPayloadEntry.h"
@@ -375,7 +376,6 @@ BuildGenericHob (
   VOID
   )
 {
-  UINT32                       RegEax;
   UINT8                        PhysicalAddressBits;
   EFI_RESOURCE_ATTRIBUTE_TYPE  ResourceAttribute;
 
@@ -385,13 +385,7 @@ BuildGenericHob (
   //
   // Build CPU memory space and IO space hob
   //
-  AsmCpuid (0x80000000, &RegEax, NULL, NULL, NULL);
-  if (RegEax >= 0x80000008) {
-    AsmCpuid (0x80000008, &RegEax, NULL, NULL, NULL);
-    PhysicalAddressBits = (UINT8)RegEax;
-  } else {
-    PhysicalAddressBits = 36;
-  }
+  PhysicalAddressBits = GetPhysicalAddressBits(NULL, NULL);
 
   BuildCpuHob (PhysicalAddressBits, 16);
 

--- a/UefiPayloadPkg/UefiPayloadEntry/X64/VirtualMemory.c
+++ b/UefiPayloadPkg/UefiPayloadEntry/X64/VirtualMemory.c
@@ -25,6 +25,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <PiPei.h>
 #include <Library/BaseLib.h>
 #include <Library/DebugLib.h>
+#include <Library/UefiCpuLib.h>
 #include <Library/BaseMemoryLib.h>
 #include <Library/MemoryAllocationLib.h>
 #include <Library/PcdLib.h>
@@ -738,13 +739,7 @@ CreateIdentityMappingPageTables (
   if (Hob != NULL) {
     PhysicalAddressBits = ((EFI_HOB_CPU *)Hob)->SizeOfMemorySpace;
   } else {
-    AsmCpuid (0x80000000, &RegEax, NULL, NULL, NULL);
-    if (RegEax >= 0x80000008) {
-      AsmCpuid (0x80000008, &RegEax, NULL, NULL, NULL);
-      PhysicalAddressBits = (UINT8)RegEax;
-    } else {
-      PhysicalAddressBits = 36;
-    }
+    PhysicalAddressBits = GetPhysicalAddressBits (NULL, NULL);
   }
 
   //


### PR DESCRIPTION
…ated code

REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3394

Invoke GetPhysicalAddressBits() defined in UefiCpuPkg for CPU physical address
mask calculation and remove the duplicated code in UefiPayloadPkg\UefiPayloadEntry

Cc: Guo Dong <guo.dong@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Signed-off-by: Yu Pu <yu.pu@intel.com>
Reviewed-by: Guo Dong <guo.dong@intel.com>