### PR TITLE
UefiPayloadPkg: Fix case of protocol

### DIFF
--- a/UefiPayloadPkg/BlSupportSmm/BlSupportSmm.h
+++ b/UefiPayloadPkg/BlSupportSmm/BlSupportSmm.h
@@ -22,7 +22,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/PciLib.h>
 #include <Protocol/SmmSwDispatch2.h>
 #include <Protocol/SmmAccess2.h>
-#include <protocol/MpService.h>
+#include <Protocol/MpService.h>
 #include <Library/UefiBootServicesTableLib.h>
 #include <Register/Intel/ArchitecturalMsr.h>
 #include <Guid/SmmRegisterInfoGuid.h>


### PR DESCRIPTION
Fix case match in <Protocol/MpService.h> to avoid build failure on
Linux.

Cc: Guo Dong <guo.dong@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Cc: Maurice Ma <maurice.ma@intel.com>
Cc: Benjamin You <benjamin.you@intel.com>
Signed-off-by: Sean Rhodes <sean@starlabs.systems>
Reviewed-by: Guo Dong <guo.dong@intel.com>