### PR TITLE
.pytool/Plugin/UncrustifyCheck: Output file diffs by default

### DIFF
--- a/.pytool/Plugin/UncrustifyCheck/Readme.md
+++ b/.pytool/Plugin/UncrustifyCheck/Readme.md
@@ -42,7 +42,7 @@ The plugin can be configured with a few optional configuration options.
       "AuditOnly": False,           # Don't fail the build if there are errors.  Just log them.
       "ConfigFilePath": "",         # Custom path to an Uncrustify config file.
       "IgnoreStandardPaths": [],    # Standard Plugin defined paths that should be ignored.
-      "OutputFileDiffs": False,     # Output chunks of formatting diffs in the test case log.
+      "OutputFileDiffs": True,      # Output chunks of formatting diffs in the test case log.
                                     # This can significantly slow down the plugin on very large packages.
       "SkipGitExclusions": False    # Don't exclude git ignored files and files in git submodules.
   }
@@ -82,7 +82,7 @@ to be ignored.
 
 ### `OutputFileDiffs`
 
-`Boolean` - Default is `False`.
+`Boolean` - Default is `True`.
 
 If `True`, output diffs of formatting changes into the test case log. This is helpful to exactly understand what changes
 need to be made to the source code in order to fix a coding standard compliance issue.

--- a/.pytool/Plugin/UncrustifyCheck/UncrustifyCheck.py
+++ b/.pytool/Plugin/UncrustifyCheck/UncrustifyCheck.py
@@ -494,13 +494,13 @@ class UncrustifyCheck(ICiBuildPlugin):
         Initializes options that influence test case output.
         """
         self._audit_only_mode = False
-        self._output_file_diffs = False
+        self._output_file_diffs = True
 
         if "AuditOnly" in self._package_config and self._package_config["AuditOnly"]:
             self._audit_only_mode = True
 
-        if "OutputFileDiffs" in self._package_config and self._package_config["OutputFileDiffs"]:
-            self._output_file_diffs = True
+        if "OutputFileDiffs" in self._package_config and not self._package_config["OutputFileDiffs"]:
+            self._output_file_diffs = False
 
     def _log_uncrustify_app_info(self) -> None:
         """


### PR DESCRIPTION
REF:https://bugzilla.tianocore.org/show_bug.cgi?id=3808

Changes the default for the "OutputFileDiffs" configuration option
to "True" so the formatting suggestions detected by Uncrustify
will be output in the test case log. The diff is printed in unified
diff format.

This was disabled by default during the initial enabling of
Uncrustify to reduce overall execution time of the plugin against
the codebase due to the large number of changes detected.

Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Sean Brogan <sean.brogan@microsoft.com>
Cc: Bret Barkelew <Bret.Barkelew@microsoft.com>
Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>
Reviewed-by: Rebecca Cran <quic_rcran@quicinc.com>
Reviewed-by: Michael D Kinney <michael.d.kinney@intel.com>