### PR TITLE
RedfishPkg: fix memory leak issue

### DIFF
--- a/RedfishPkg/PrivateLibrary/RedfishLib/edk2libredfish/src/payload.c
+++ b/RedfishPkg/PrivateLibrary/RedfishLib/edk2libredfish/src/payload.c
@@ -620,6 +620,7 @@ collectionEvalOp (
   if (((*StatusCode == NULL) && (members == NULL)) ||
       ((*StatusCode != NULL) && ((**StatusCode < HTTP_STATUS_200_OK) || (**StatusCode > HTTP_STATUS_206_PARTIAL_CONTENT))))
   {
+    free (valid);
     return members;
   }
 
@@ -633,6 +634,7 @@ collectionEvalOp (
     if (((*StatusCode == NULL) && (tmp == NULL)) ||
         ((*StatusCode != NULL) && ((**StatusCode < HTTP_STATUS_200_OK) || (**StatusCode > HTTP_STATUS_206_PARTIAL_CONTENT))))
     {
+      free (valid);
       return tmp;
     }
 
@@ -658,19 +660,15 @@ collectionEvalOp (
 
   cleanupPayload (members);
   if (validCount == 0) {
-    free (valid);
-    return NULL;
-  }
-
-  if (validCount == 1) {
+    ret = NULL;
+  } else if (validCount == 1) {
     ret = valid[0];
-    free (valid);
-    return ret;
   } else {
     ret = createCollection (payload->service, validCount, valid);
-    free (valid);
-    return ret;
   }
+
+  free (valid);
+  return ret;
 }
 
 static redfishPayload *


### PR DESCRIPTION
The calloc memory is not free when function collectionEvalOp
return in the halfway.

Cc: Abner Chang <abner.chang@hpe.com>
Cc: Nickle Wang <nickle.wang@hpe.com>

Signed-off-by: Wenyi Xie <xiewenyi2@huawei.com>
Reviewed-by: Abner Chang <abner.chang@hpe.com>