### PR TITLE
BaseTools/GenFw: Enhance GenFw to support PRM GCC build

### DIFF
--- a/BaseTools/Source/C/GenFw/ElfConvert.c
+++ b/BaseTools/Source/C/GenFw/ElfConvert.c
@@ -224,6 +224,14 @@ ConvertElf (
   ElfFunctions.WriteDebug ();
 
   //
+  // For PRM Driver to Write export info.
+  //
+  if (mExportFlag) {
+    VerboseMsg ("Write export info.");
+    ElfFunctions.WriteExport ();
+  }
+
+  //
   // Make sure image size is correct before returning the new image.
   //
   VerboseMsg ("Set image size.");

--- a/BaseTools/Source/C/GenFw/ElfConvert.h
+++ b/BaseTools/Source/C/GenFw/ElfConvert.h
@@ -24,6 +24,7 @@ extern UINT8  *mCoffFile;
 extern UINT32 mTableOffset;
 extern UINT32 mOutImageType;
 extern UINT32 mFileBufferSize;
+extern BOOLEAN mExportFlag;
 
 //
 // Common EFI specific data.
@@ -31,6 +32,44 @@ extern UINT32 mFileBufferSize;
 #define ELF_HII_SECTION_NAME ".hii"
 #define ELF_STRTAB_SECTION_NAME ".strtab"
 #define MAX_COFF_ALIGNMENT 0x10000
+#define ELF_SYMBOL_SECTION_NAME ".symtab"
+
+//
+// Platform Runtime Mechanism (PRM) specific data.
+//
+#define PRM_MODULE_EXPORT_SYMBOL_NUM 256
+
+// <to-do> to include PRM header directly once PrmPkg is in main repo
+#define PRM_HANDLER_NAME_MAXIMUM_LENGTH 128
+
+#define PRM_MODULE_EXPORT_DESCRIPTOR_NAME         "PrmModuleExportDescriptor"
+#define PRM_MODULE_EXPORT_DESCRIPTOR_SIGNATURE    SIGNATURE_64 ('P', 'R', 'M', '_', 'M', 'E', 'D', 'T')
+#define PRM_MODULE_EXPORT_REVISION                0x0
+
+//
+// Platform Runtime Mechanism (PRM) Export Descriptor Structures
+//
+#pragma pack(push, 1)
+
+typedef struct {
+  EFI_GUID                              PrmHandlerGuid;
+  CHAR8                                 PrmHandlerName[PRM_HANDLER_NAME_MAXIMUM_LENGTH];
+} PRM_HANDLER_EXPORT_DESCRIPTOR_STRUCT;
+
+typedef struct {
+  UINT64                                Signature;
+  UINT16                                Revision;
+  UINT16                                NumberPrmHandlers;
+  EFI_GUID                              PlatformGuid;
+  EFI_GUID                              ModuleGuid;
+} PRM_MODULE_EXPORT_DESCRIPTOR_STRUCT_HEADER;
+
+typedef struct {
+  PRM_MODULE_EXPORT_DESCRIPTOR_STRUCT_HEADER  Header;
+  PRM_HANDLER_EXPORT_DESCRIPTOR_STRUCT        PrmHandlerExportDescriptors[1];
+} PRM_MODULE_EXPORT_DESCRIPTOR_STRUCT;
+
+#pragma pack(pop)
 
 //
 // Filter Types
@@ -38,7 +77,8 @@ extern UINT32 mFileBufferSize;
 typedef enum {
   SECTION_TEXT,
   SECTION_HII,
-  SECTION_DATA
+  SECTION_DATA,
+  SECTION_SYMBOL
 
 } SECTION_FILTER_TYPES;
 
@@ -50,6 +90,7 @@ typedef struct {
   BOOLEAN (*WriteSections) (SECTION_FILTER_TYPES  FilterType);
   VOID    (*WriteRelocations) ();
   VOID    (*WriteDebug) ();
+  VOID    (*WriteExport) ();
   VOID    (*SetImageSize) ();
   VOID    (*CleanUp) ();
 

--- a/BaseTools/Source/C/GenFw/GenFw.c
+++ b/BaseTools/Source/C/GenFw/GenFw.c
@@ -87,7 +87,7 @@ UINT32 mImageTimeStamp = 0;
 UINT32 mImageSize = 0;
 UINT32 mOutImageType = FW_DUMMY_IMAGE;
 BOOLEAN mIsConvertXip = FALSE;
-
+BOOLEAN mExportFlag = FALSE;
 
 STATIC
 EFI_STATUS
@@ -279,6 +279,10 @@ Returns:
                         except for -o or -r option. It is a action option.\n\
                         If it is combined with other action options, the later\n\
                         input action option will override the previous one.\n");
+  fprintf (stdout, "  --prm                 Scan symbol section from ELF image and \n\
+                        write export table into PE-COFF.\n\
+                        This option can be used together with -e.\n\
+                        It doesn't work for other options.\n");
   fprintf (stdout, "  -v, --verbose         Turn on verbose output with informational messages.\n");
   fprintf (stdout, "  -q, --quiet           Disable all messages except key message and fatal error\n");
   fprintf (stdout, "  -d, --debug level     Enable debug messages, at input debug level.\n");
@@ -1431,6 +1435,20 @@ Returns:
 
     if (stricmp (argv[0], "--hiibinpackage") == 0) {
       mOutImageType = FW_HII_PACKAGE_LIST_BINIMAGE;
+      argc --;
+      argv ++;
+      continue;
+    }
+
+    if (stricmp (argv[0], "--prm") == 0) {
+      if (stricmp (ModuleType, "DXE_RUNTIME_DRIVER") != 0 ){
+        Error (NULL, 0, 1001, "Invalid", "--prm option only supports DXE RUNTIME driver.");
+        goto Finish;
+      }
+
+      if (!mExportFlag) {
+        mExportFlag = TRUE;
+      }
       argc --;
       argv ++;
       continue;

--- a/BaseTools/Source/C/Include/IndustryStandard/PeImage.h
+++ b/BaseTools/Source/C/Include/IndustryStandard/PeImage.h
@@ -571,6 +571,13 @@ typedef struct {
   UINT32  AddressOfNameOrdinals;
 } EFI_IMAGE_EXPORT_DIRECTORY;
 
+//
+// Based export types.
+//
+#define EFI_IMAGE_EXPORT_ORDINAL_BASE     1
+#define EFI_IMAGE_EXPORT_ADDR_SIZE        4
+#define EFI_IMAGE_EXPORT_ORDINAL_SIZE     2
+
 ///
 /// DLL support.
 /// Import Format


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3802

Since PRM module needs to support export table in PE-COFF, we'll
enhance GenFw tool to support this.

Add one export flag in GenFw tool. If export flag is set:
Step1: Scan ELF symbol table based on PRM module descriptor to get
descriptor offset address;
Step2: Find PRM handlers number and name in COFF file based on the
address from step1;
Step3: Write PRM info such as handler name and export RVA into COFF
export table.

PRM option currently only supports DXE RUNTIME driver and X64 arch.

Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Bob Feng <bob.c.feng@intel.com>
Cc: Yuwei Chen <yuwei.chen@intel.com>
Signed-off-by: Lixia Huang <lisa.huang@intel.com>
Reviewed-by: Bob Feng <bob.c.feng@intel.com>