### PR TITLE
EmulatorPkg/RedfishPlatformCredentialLib: Check EFI_SECURE_BOOT_MODE_…

### DIFF
--- a/EmulatorPkg/Library/RedfishPlatformCredentialLib/RedfishPlatformCredentialLib.c
+++ b/EmulatorPkg/Library/RedfishPlatformCredentialLib/RedfishPlatformCredentialLib.c
@@ -165,6 +165,9 @@ LibStopRedfishService (
   IN EDKII_REDFISH_CREDENTIAL_STOP_SERVICE_TYPE  ServiceStopType
   )
 {
+  EFI_STATUS  Status;
+  UINT8       *SecureBootVar;
+
   if (ServiceStopType >= ServiceStopTypeMax) {
     return EFI_INVALID_PARAMETER;
   }
@@ -177,8 +180,18 @@ LibStopRedfishService (
     if (!PcdGetBool (PcdRedfishServieStopIfSecureBootDisabled)) {
       return EFI_UNSUPPORTED;
     } else {
-      mStopRedfishService = TRUE;
-      DEBUG ((DEBUG_INFO, "EFI Redfish service is stopped due to SecureBoot is disabled!!\n"));
+      //
+      // Check Secure Boot status and lock Redfish service if Secure Boot is disabled.
+      //
+      Status = GetVariable2 (EFI_SECURE_BOOT_MODE_NAME, &gEfiGlobalVariableGuid, (VOID **)&SecureBootVar, NULL);
+      if (EFI_ERROR (Status) || (*SecureBootVar != SECURE_BOOT_MODE_ENABLE)) {
+        //
+        // Secure Boot is disabled
+        //
+        mSecureBootDisabled = TRUE;
+        mStopRedfishService = TRUE;
+        DEBUG ((DEBUG_INFO, "EFI Redfish service is stopped due to SecureBoot is disabled!!\n"));
+      }
     }
   } else if (ServiceStopType == ServiceStopTypeExitBootService) {
     //
@@ -224,18 +237,5 @@ LibCredentialEndOfDxeNotify (
   IN  EDKII_REDFISH_CREDENTIAL_PROTOCOL  *This
   )
 {
-  EFI_STATUS  Status;
-  UINT8       *SecureBootVar;
-
-  //
-  // Check Secure Boot status and lock Redfish service if Secure Boot is disabled.
-  //
-  Status = GetVariable2 (EFI_SECURE_BOOT_MODE_NAME, &gEfiGlobalVariableGuid, (VOID **)&SecureBootVar, NULL);
-  if (EFI_ERROR (Status) || (*SecureBootVar != SECURE_BOOT_MODE_ENABLE)) {
-    //
-    // Secure Boot is disabled
-    //
-    mSecureBootDisabled = TRUE;
-    LibStopRedfishService (This, ServiceStopTypeSecureBootDisabled);
-  }
+  LibStopRedfishService (This, ServiceStopTypeSecureBootDisabled);
 }


### PR DESCRIPTION
…NAME

https://bugzilla.tianocore.org/show_bug.cgi?id=3858

Check EFI_SECURE_BOOT_MODE_NAME before setting the flags to
prohibit acquiring Redfish service credential and using Redfish
service.

Signed-off-by: Abner Chang <abner.chang@hpe.com>
Cc: Nickle Wang <nickle.wang@hpe.com>
Cc: Andrew Fish <afish@apple.com>
Cc: Ray Ni <ray.ni@intel.com>
Reviewed-by: Nickle Wang <nickle.wang@hpe.com>