### PR TITLE
DynamicTablesPkg: Fix serial port namespace path in DBG2

### DIFF
--- a/DynamicTablesPkg/Library/Acpi/Arm/AcpiDbg2LibArm/Dbg2Generator.c
+++ b/DynamicTablesPkg/Library/Acpi/Arm/AcpiDbg2LibArm/Dbg2Generator.c
@@ -1,7 +1,7 @@
 /** @file
   DBG2 Table Generator
 
-  Copyright (c) 2017 - 2021, Arm Limited. All rights reserved.<BR>
+  Copyright (c) 2017 - 2022, Arm Limited. All rights reserved.<BR>
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -55,13 +55,17 @@ Requirements:
 */
 #define NAME_STR_DBG_PORT0  "COM0"
 
+/** A string representing the full path name of the debug port 0.
+*/
+#define NAMESPACE_STR_DBG_PORT0  "\\_SB_.COM0"
+
 /** An UID representing the debug port 0.
 */
 #define UID_DBG_PORT0  0
 
 /** The length of the namespace string.
 */
-#define DBG2_NAMESPACESTRING_FIELD_SIZE  sizeof (NAME_STR_DBG_PORT0)
+#define DBG2_NAMESPACESTRING_FIELD_SIZE  sizeof (NAMESPACE_STR_DBG_PORT0)
 
 /** The PL011 UART address range length.
 */
@@ -166,7 +170,7 @@ DBG2_TABLE  AcpiDbg2 = {
       0,                    // {Template}: Serial Port Subtype
       0,                    // {Template}: Serial Port Base Address
       PL011_UART_LENGTH,
-      NAME_STR_DBG_PORT0
+      NAMESPACE_STR_DBG_PORT0
       )
   }
 };


### PR DESCRIPTION
According to the Debug Port Table 2 (DBG2) specification,
February 17, 2021, the NamespaceString is a NULL terminated
ASCII string that consists of a fully qualified reference
to the object that represents the serial port device in the
ACPI namespace.

The DBG2 table generator did not populate the full device
path for the serial port device, and this results in a FWTS
test failure.

Therefore, populate the full namespace device path for the
serial port in DBG2 table.

Signed-off-by: Sami Mujawar <sami.mujawar@arm.com>
Reviewed-by: Pierre Gondois <pierre.gondois@arm.com>
Tested-by: Jagadeesh Ujja <Jagadeesh.Ujja@arm.com>
Tested-by: Sunny Wang <sunny.wang@arm.com>