### PR TITLE
EmulatorPkg/RedfishPlatformCredentialLib: Don't stop Redfish service

### DIFF
--- a/EmulatorPkg/Library/RedfishPlatformCredentialLib/RedfishPlatformCredentialLib.c
+++ b/EmulatorPkg/Library/RedfishPlatformCredentialLib/RedfishPlatformCredentialLib.c
@@ -223,7 +223,6 @@ LibCredentialExitBootServicesNotify (
   IN  EDKII_REDFISH_CREDENTIAL_PROTOCOL  *This
   )
 {
-  LibStopRedfishService (This, ServiceStopTypeExitBootService);
 }
 
 /**
@@ -237,5 +236,4 @@ LibCredentialEndOfDxeNotify (
   IN  EDKII_REDFISH_CREDENTIAL_PROTOCOL  *This
   )
 {
-  LibStopRedfishService (This, ServiceStopTypeSecureBootDisabled);
 }


### PR DESCRIPTION
https://bugzilla.tianocore.org/show_bug.cgi?id=3859

Platform Redfish credential library shouldn't stop the service at either EndOfDXE or ExitBootService notification. RedfishConfigureHandler UEFI driver is responsible to stop the Redfish service when EndOfDXE or ExitBootService event is triggered.

Signed-off-by: Abner Chang <abner.chang@hpe.com>
Cc: Nickle Wang <nickle.wang@hpe.com>
Cc: Andrew Fish <afish@apple.com>
Cc: Ray Ni <ray.ni@intel.com>
Reviewed-by: Nickle Wang <nickle.wang@hpe.com>