### PR TITLE
MdeModulePkg: fix check for NVM command set in NVMe drivers

### DIFF
--- a/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressHci.c
+++ b/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressHci.c
@@ -761,7 +761,7 @@ NvmeControllerInit (
     return Status;
   }
 
-  if (Private->Cap.Css != 0x01) {
+  if ((Private->Cap.Css & BIT0) == 0) {
     DEBUG ((DEBUG_INFO, "NvmeControllerInit: the controller doesn't support NVMe command set\n"));
     return EFI_UNSUPPORTED;
   }

--- a/MdeModulePkg/Bus/Pci/NvmExpressPei/NvmExpressPeiHci.c
+++ b/MdeModulePkg/Bus/Pci/NvmExpressPei/NvmExpressPeiHci.c
@@ -571,7 +571,7 @@ NvmeControllerInit (
   // Read the controller Capabilities register and verify that the NVM command set is supported
   //
   NVME_GET_CAP (Private, &Private->Cap);
-  if (Private->Cap.Css != 0x01) {
+  if ((Private->Cap.Css & BIT0) == 0) {
     DEBUG ((DEBUG_ERROR, "%a: The NVME controller doesn't support NVMe command set.\n", __FUNCTION__));
     return EFI_UNSUPPORTED;
   }


### PR DESCRIPTION
Fix the check for NVMe command set being supported by the controller.

Was problematic with qemu (6.2.0, Debian 1:6.2+dfsg-3), which sets 0xC1
in that register, making the OVMF think the NVMe controller does not
support NVMe.

Uncovered by commit 9dd14fc91c174eae87fd122c7ac70073a363527f, which
changed the number of bits included in the Css register from 4 to 8.

Signed-off-by: Mara Sophie Grosch <littlefox@lf-net.org>