### PR TITLE
IntelFsp2Pkg: BaseFspDebugLibSerialPort Support for X64

### DIFF
--- a/IntelFsp2Pkg/Library/BaseFspDebugLibSerialPort/BaseFspDebugLibSerialPort.inf
+++ b/IntelFsp2Pkg/Library/BaseFspDebugLibSerialPort/BaseFspDebugLibSerialPort.inf
@@ -16,7 +16,7 @@
   LIBRARY_CLASS                  = DebugLib
 
 #
-#  VALID_ARCHITECTURES           = IA32
+#  VALID_ARCHITECTURES           = IA32 X64
 #
 
 [Sources]
@@ -24,6 +24,9 @@
 
 [Sources.Ia32]
   Ia32/FspDebug.nasm
+
+[Sources.X64]
+  X64/FspDebug.nasm
 
 [Packages]
   MdePkg/MdePkg.dec

--- a/IntelFsp2Pkg/Library/BaseFspDebugLibSerialPort/X64/FspDebug.nasm
+++ b/IntelFsp2Pkg/Library/BaseFspDebugLibSerialPort/X64/FspDebug.nasm
@@ -1,0 +1,25 @@
+;------------------------------------------------------------------------------
+;
+; Copyright (c) 2022, Intel Corporation. All rights reserved.<BR>
+; SPDX-License-Identifier: BSD-2-Clause-Patent
+;
+; Abstract:
+;
+;   FSP Debug functions
+;
+;------------------------------------------------------------------------------
+
+    SECTION .text
+
+;------------------------------------------------------------------------------
+; UINT32 *
+; EFIAPI
+; GetStackFramePointer (
+;   VOID
+;   );
+;------------------------------------------------------------------------------
+global ASM_PFX(GetStackFramePointer)
+ASM_PFX(GetStackFramePointer):
+    mov     rax, rbp
+    ret
+


### PR DESCRIPTION
REF:https://bugzilla.tianocore.org/show_bug.cgi?id=3833
Add BaseFspDebugLibSerialPort Support for X64.

Cc: Chasel Chiu <chasel.chiu@intel.com>
Cc: Nate DeSimone <nathaniel.l.desimone@intel.com>
Cc: Star Zeng <star.zeng@intel.com>
Cc: Ashraf Ali S <ashraf.ali.s@intel.com>
Cc: Ted Kuo <ted.kuo@intel.com>
Signed-off-by: Ted Kuo <ted.kuo@intel.com>
Reviewed-by: Chasel Chiu <chasel.chiu@intel.com>