### PR TITLE
IntelFsp2Pkg: BaseFspSwitchStackLib Support for X64

### DIFF
--- a/IntelFsp2Pkg/Include/PushPopRegsNasm.inc
+++ b/IntelFsp2Pkg/Include/PushPopRegsNasm.inc
@@ -1,0 +1,67 @@
+;------------------------------------------------------------------------------
+;
+; Copyright (c) 2022, Intel Corporation. All rights reserved.<BR>
+; SPDX-License-Identifier: BSD-2-Clause-Patent
+;
+; Abstract:
+;
+;   Provide macro to push/pop registers in X64
+;
+;------------------------------------------------------------------------------
+
+;-----------------------------------------------------------------------------
+;  Macro:        PUSHA_64
+;
+;  Description:  Saves all registers on stack
+;
+;  Input:        None
+;
+;  Output:       None
+;-----------------------------------------------------------------------------
+%macro PUSHA_64   0
+  push    r8
+  push    r9
+  push    r10
+  push    r11
+  push    r12
+  push    r13
+  push    r14
+  push    r15
+  push    rax
+  push    rcx
+  push    rdx
+  push    rbx
+  push    rsp
+  push    rbp
+  push    rsi
+  push    rdi
+%endmacro
+
+;-----------------------------------------------------------------------------
+;  Macro:        POPA_64
+;
+;  Description:  Restores all registers from stack
+;
+;  Input:        None
+;
+;  Output:       None
+;-----------------------------------------------------------------------------
+%macro POPA_64   0
+  pop    rdi
+  pop    rsi
+  pop    rbp
+  pop    rsp
+  pop    rbx
+  pop    rdx
+  pop    rcx
+  pop    rax
+  pop    r15
+  pop    r14
+  pop    r13
+  pop    r12
+  pop    r11
+  pop    r10
+  pop    r9
+  pop    r8
+%endmacro
+

--- a/IntelFsp2Pkg/Library/BaseFspSwitchStackLib/BaseFspSwitchStackLib.inf
+++ b/IntelFsp2Pkg/Library/BaseFspSwitchStackLib/BaseFspSwitchStackLib.inf
@@ -15,11 +15,14 @@
   VERSION_STRING                 = 1.0
   LIBRARY_CLASS                  = FspSwitchStackLib
 
-[Sources.IA32]
+[Sources]
   FspSwitchStackLib.c
 
 [Sources.IA32]
   Ia32/Stack.nasm
+
+[Sources.X64]
+  X64/Stack.nasm
 
 [Packages]
   MdePkg/MdePkg.dec

--- a/IntelFsp2Pkg/Library/BaseFspSwitchStackLib/FspSwitchStackLib.c
+++ b/IntelFsp2Pkg/Library/BaseFspSwitchStackLib/FspSwitchStackLib.c
@@ -20,16 +20,16 @@
 
 
 **/
-UINT32
+UINTN
 SwapStack (
-  IN  UINT32  NewStack
+  IN  UINTN  NewStack
   )
 {
   FSP_GLOBAL_DATA  *FspData;
-  UINT32           OldStack;
+  UINTN            OldStack;
 
   FspData            = GetFspGlobalDataPointer ();
   OldStack           = FspData->CoreStack;
-  FspData->CoreStack = NewStack;
+  FspData->CoreStack = (UINTN) NewStack;
   return OldStack;
 }

--- a/IntelFsp2Pkg/Library/BaseFspSwitchStackLib/X64/Stack.nasm
+++ b/IntelFsp2Pkg/Library/BaseFspSwitchStackLib/X64/Stack.nasm
@@ -1,0 +1,72 @@
+;------------------------------------------------------------------------------
+;
+; Copyright (c) 2022, Intel Corporation. All rights reserved.<BR>
+; SPDX-License-Identifier: BSD-2-Clause-Patent
+;
+; Abstract:
+;
+;   Switch the stack from temporary memory to permanent memory.
+;
+;------------------------------------------------------------------------------
+
+    SECTION .text
+
+%include    "PushPopRegsNasm.inc"
+
+extern ASM_PFX(SwapStack)
+
+;------------------------------------------------------------------------------
+; UINT32
+; EFIAPI
+; Pei2LoaderSwitchStack (
+;   VOID
+;   )
+;------------------------------------------------------------------------------
+global ASM_PFX(Pei2LoaderSwitchStack)
+ASM_PFX(Pei2LoaderSwitchStack):
+    xor     rax, rax
+    jmp     ASM_PFX(FspSwitchStack)
+
+;------------------------------------------------------------------------------
+; UINT32
+; EFIAPI
+; Loader2PeiSwitchStack (
+;   VOID
+;   )
+;------------------------------------------------------------------------------
+global ASM_PFX(Loader2PeiSwitchStack)
+ASM_PFX(Loader2PeiSwitchStack):
+    jmp     ASM_PFX(FspSwitchStack)
+
+;------------------------------------------------------------------------------
+; UINT32
+; EFIAPI
+; FspSwitchStack (
+;   VOID
+;   )
+;------------------------------------------------------------------------------
+global ASM_PFX(FspSwitchStack)
+ASM_PFX(FspSwitchStack):
+    ; Save current contexts
+    push    rdx     ; ApiParam2
+    push    rcx     ; ApiParam1
+    push    rax     ; FspInfoHeader
+    pushfq
+    cli
+    PUSHA_64
+    sub     rsp, 16
+    sidt    [rsp]
+
+    ; Load new stack
+    mov     rcx, rsp
+    call    ASM_PFX(SwapStack)
+    mov     rsp, rax
+
+    ; Restore previous contexts
+    lidt    [rsp]
+    add     rsp, 16
+    POPA_64
+    popfq
+    add     rsp, 24 ; FspInfoHeader + ApiParam[2]
+    ret
+


### PR DESCRIPTION
REF:https://bugzilla.tianocore.org/show_bug.cgi?id=3832
Add BaseFspSwitchStackLib Support for X64.

Cc: Chasel Chiu <chasel.chiu@intel.com>
Cc: Nate DeSimone <nathaniel.l.desimone@intel.com>
Cc: Star Zeng <star.zeng@intel.com>
Cc: Ashraf Ali S <ashraf.ali.s@intel.com>
Signed-off-by: Ted Kuo <ted.kuo@intel.com>
Reviewed-by: Chasel Chiu <chasel.chiu@intel.com>