### PR TITLE
MdePkg/AcpiXX.h: Update Error Severity type for Generic Error Status Block

### DIFF
--- a/MdePkg/Include/IndustryStandard/Acpi40.h
+++ b/MdePkg/Include/IndustryStandard/Acpi40.h
@@ -1,7 +1,7 @@
 /** @file
   ACPI 4.0 definitions from the ACPI Specification Revision 4.0a April 5, 2010
 
-  Copyright (c) 2010 - 2018, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2010 - 2022, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
@@ -690,6 +690,7 @@ typedef struct {
 // Boot Error Severity types
 //
 #define EFI_ACPI_4_0_ERROR_SEVERITY_CORRECTABLE  0x00
+#define EFI_ACPI_4_0_ERROR_SEVERITY_RECOVERABLE  0x00
 #define EFI_ACPI_4_0_ERROR_SEVERITY_FATAL        0x01
 #define EFI_ACPI_4_0_ERROR_SEVERITY_CORRECTED    0x02
 #define EFI_ACPI_4_0_ERROR_SEVERITY_NONE         0x03

--- a/MdePkg/Include/IndustryStandard/Acpi50.h
+++ b/MdePkg/Include/IndustryStandard/Acpi50.h
@@ -2,7 +2,7 @@
   ACPI 5.0 definitions from the ACPI Specification Revision 5.0a November 13, 2013.
 
   Copyright (c) 2014 Hewlett-Packard Development Company, L.P.<BR>
-  Copyright (c) 2011 - 2018, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2011 - 2022, Intel Corporation. All rights reserved.<BR>
   Copyright (c) 2020, ARM Ltd. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
@@ -1361,6 +1361,7 @@ typedef struct {
 // Boot Error Severity types
 //
 #define EFI_ACPI_5_0_ERROR_SEVERITY_CORRECTABLE  0x00
+#define EFI_ACPI_5_0_ERROR_SEVERITY_RECOVERABLE  0x00
 #define EFI_ACPI_5_0_ERROR_SEVERITY_FATAL        0x01
 #define EFI_ACPI_5_0_ERROR_SEVERITY_CORRECTED    0x02
 #define EFI_ACPI_5_0_ERROR_SEVERITY_NONE         0x03

--- a/MdePkg/Include/IndustryStandard/Acpi51.h
+++ b/MdePkg/Include/IndustryStandard/Acpi51.h
@@ -2,7 +2,7 @@
   ACPI 5.1 definitions from the ACPI Specification Revision 5.1 Errata B January, 2016.
 
   Copyright (c) 2014 Hewlett-Packard Development Company, L.P.<BR>
-  Copyright (c) 2014 - 2018, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2014 - 2022, Intel Corporation. All rights reserved.<BR>
   (C) Copyright 2015 Hewlett Packard Enterprise Development LP<BR>
   Copyright (c) 2020, ARM Ltd. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -1376,10 +1376,16 @@ typedef struct {
 //
 // Boot Error Severity types
 //
-#define EFI_ACPI_5_1_ERROR_SEVERITY_CORRECTABLE  0x00
+#define EFI_ACPI_5_1_ERROR_SEVERITY_RECOVERABLE  0x00
 #define EFI_ACPI_5_1_ERROR_SEVERITY_FATAL        0x01
 #define EFI_ACPI_5_1_ERROR_SEVERITY_CORRECTED    0x02
 #define EFI_ACPI_5_1_ERROR_SEVERITY_NONE         0x03
+//
+// The term 'Correctable' is no longer being used as an error severity of the
+// reported error since ACPI Specification Version 5.1 Errata B.
+// The below macro is considered as deprecated and should no longer be used.
+//
+#define EFI_ACPI_5_1_ERROR_SEVERITY_CORRECTABLE  0x00
 
 ///
 /// Generic Error Data Entry Definition

--- a/MdePkg/Include/IndustryStandard/Acpi60.h
+++ b/MdePkg/Include/IndustryStandard/Acpi60.h
@@ -1,7 +1,7 @@
 /** @file
   ACPI 6.0 definitions from the ACPI Specification Revision 6.0 Errata A January, 2016.
 
-  Copyright (c) 2015 - 2018, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2015 - 2022, Intel Corporation. All rights reserved.<BR>
   (C) Copyright 2015-2016 Hewlett Packard Enterprise Development LP<BR>
   Copyright (c) 2020, ARM Ltd. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -1560,10 +1560,16 @@ typedef struct {
 //
 // Boot Error Severity types
 //
-#define EFI_ACPI_6_0_ERROR_SEVERITY_CORRECTABLE  0x00
+#define EFI_ACPI_6_0_ERROR_SEVERITY_RECOVERABLE  0x00
 #define EFI_ACPI_6_0_ERROR_SEVERITY_FATAL        0x01
 #define EFI_ACPI_6_0_ERROR_SEVERITY_CORRECTED    0x02
 #define EFI_ACPI_6_0_ERROR_SEVERITY_NONE         0x03
+//
+// The term 'Correctable' is no longer being used as an error severity of the
+// reported error since ACPI Specification Version 5.1 Errata B.
+// The below macro is considered as deprecated and should no longer be used.
+//
+#define EFI_ACPI_6_0_ERROR_SEVERITY_CORRECTABLE  0x00
 
 ///
 /// Generic Error Data Entry Definition

--- a/MdePkg/Include/IndustryStandard/Acpi61.h
+++ b/MdePkg/Include/IndustryStandard/Acpi61.h
@@ -1,7 +1,7 @@
 /** @file
   ACPI 6.1 definitions from the ACPI Specification Revision 6.1 January, 2016.
 
-  Copyright (c) 2016 - 2018, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2016 - 2022, Intel Corporation. All rights reserved.<BR>
  (C) Copyright 2016 Hewlett Packard Enterprise Development LP<BR>
   Copyright (c) 2020, ARM Ltd. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -1566,10 +1566,16 @@ typedef struct {
 //
 // Boot Error Severity types
 //
-#define EFI_ACPI_6_1_ERROR_SEVERITY_CORRECTABLE  0x00
+#define EFI_ACPI_6_1_ERROR_SEVERITY_RECOVERABLE  0x00
 #define EFI_ACPI_6_1_ERROR_SEVERITY_FATAL        0x01
 #define EFI_ACPI_6_1_ERROR_SEVERITY_CORRECTED    0x02
 #define EFI_ACPI_6_1_ERROR_SEVERITY_NONE         0x03
+//
+// The term 'Correctable' is no longer being used as an error severity of the
+// reported error since ACPI Specification Version 5.1 Errata B.
+// The below macro is considered as deprecated and should no longer be used.
+//
+#define EFI_ACPI_6_1_ERROR_SEVERITY_CORRECTABLE  0x00
 
 ///
 /// Generic Error Data Entry Definition

--- a/MdePkg/Include/IndustryStandard/Acpi62.h
+++ b/MdePkg/Include/IndustryStandard/Acpi62.h
@@ -1,7 +1,7 @@
 /** @file
   ACPI 6.2 definitions from the ACPI Specification Revision 6.2 May, 2017.
 
-  Copyright (c) 2017, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017 - 2022, Intel Corporation. All rights reserved.<BR>
   Copyright (c) 2020, ARM Ltd. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
@@ -1738,10 +1738,16 @@ typedef struct {
 //
 // Boot Error Severity types
 //
-#define EFI_ACPI_6_2_ERROR_SEVERITY_CORRECTABLE  0x00
+#define EFI_ACPI_6_2_ERROR_SEVERITY_RECOVERABLE  0x00
 #define EFI_ACPI_6_2_ERROR_SEVERITY_FATAL        0x01
 #define EFI_ACPI_6_2_ERROR_SEVERITY_CORRECTED    0x02
 #define EFI_ACPI_6_2_ERROR_SEVERITY_NONE         0x03
+//
+// The term 'Correctable' is no longer being used as an error severity of the
+// reported error since ACPI Specification Version 5.1 Errata B.
+// The below macro is considered as deprecated and should no longer be used.
+//
+#define EFI_ACPI_6_2_ERROR_SEVERITY_CORRECTABLE  0x00
 
 ///
 /// Generic Error Data Entry Definition

--- a/MdePkg/Include/IndustryStandard/Acpi63.h
+++ b/MdePkg/Include/IndustryStandard/Acpi63.h
@@ -1,7 +1,7 @@
 /** @file
   ACPI 6.3 definitions from the ACPI Specification Revision 6.3 Jan, 2019.
 
-  Copyright (c) 2017, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017 - 2022, Intel Corporation. All rights reserved.<BR>
   Copyright (c) 2019 - 2020, ARM Ltd. All rights reserved.<BR>
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -1702,10 +1702,16 @@ typedef struct {
 //
 // Boot Error Severity types
 //
-#define EFI_ACPI_6_3_ERROR_SEVERITY_CORRECTABLE  0x00
+#define EFI_ACPI_6_3_ERROR_SEVERITY_RECOVERABLE  0x00
 #define EFI_ACPI_6_3_ERROR_SEVERITY_FATAL        0x01
 #define EFI_ACPI_6_3_ERROR_SEVERITY_CORRECTED    0x02
 #define EFI_ACPI_6_3_ERROR_SEVERITY_NONE         0x03
+//
+// The term 'Correctable' is no longer being used as an error severity of the
+// reported error since ACPI Specification Version 5.1 Errata B.
+// The below macro is considered as deprecated and should no longer be used.
+//
+#define EFI_ACPI_6_3_ERROR_SEVERITY_CORRECTABLE  0x00
 
 ///
 /// Generic Error Data Entry Definition

--- a/MdePkg/Include/IndustryStandard/Acpi64.h
+++ b/MdePkg/Include/IndustryStandard/Acpi64.h
@@ -1,7 +1,7 @@
 /** @file
   ACPI 6.4 definitions from the ACPI Specification Revision 6.4 Jan, 2021.
 
-  Copyright (c) 2017, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017 - 2022, Intel Corporation. All rights reserved.<BR>
   Copyright (c) 2019 - 2021, ARM Ltd. All rights reserved.<BR>
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -1783,10 +1783,16 @@ typedef struct {
 //
 // Boot Error Severity types
 //
-#define EFI_ACPI_6_4_ERROR_SEVERITY_CORRECTABLE  0x00
+#define EFI_ACPI_6_4_ERROR_SEVERITY_RECOVERABLE  0x00
 #define EFI_ACPI_6_4_ERROR_SEVERITY_FATAL        0x01
 #define EFI_ACPI_6_4_ERROR_SEVERITY_CORRECTED    0x02
 #define EFI_ACPI_6_4_ERROR_SEVERITY_NONE         0x03
+//
+// The term 'Correctable' is no longer being used as an error severity of the
+// reported error since ACPI Specification Version 5.1 Errata B.
+// The below macro is considered as deprecated and should no longer be used.
+//
+#define EFI_ACPI_6_4_ERROR_SEVERITY_CORRECTABLE  0x00
 
 ///
 /// Generic Error Data Entry Definition


### PR DESCRIPTION
Patch sent at: https://edk2.groups.io/g/devel/message/87344

Starting from ACPI Specification Version 5.1 Errata B, the term
'Correctable' is no longer being used as an error severity of the
reported error in Chapter 18 APEI.

This commit will
a) For Acpi40.h & Acpi50.h
Add new macro EFI_ACPI_X_X_ERROR_SEVERITY_RECOVERABLE, since both the
terms 'Correctable' and 'Recoverable' are used to denote the same error
severity.

b) Header files starting from Acpi51.h to Acpi64.h
Add new macro EFI_ACPI_X_X_ERROR_SEVERITY_RECOVERABLE.
Keeps the origin EFI_ACPI_X_X_ERROR_SEVERITY_CORRECTABLE for compatibility
consideration, but add comments to mark it as deprecated and should no
longer be used.

Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Zhiguang Liu <zhiguang.liu@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Signed-off-by: Hao A Wu <hao.a.wu@intel.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>