### PR TITLE
BaseTools: Add the FeatureFlagExpression usage to the Source Section

### DIFF
--- a/BaseTools/Source/Python/Common/Expression.py
+++ b/BaseTools/Source/Python/Common/Expression.py
@@ -43,7 +43,7 @@ ERR_IN_OPERAND          = 'Macro after IN operator can only be: $(FAMILY), $(ARC
 __ValidString = re.compile(r'[_a-zA-Z][_0-9a-zA-Z]*$')
 _ReLabel = re.compile('LABEL\((\w+)\)')
 _ReOffset = re.compile('OFFSET_OF\((\w+)\)')
-PcdPattern = re.compile(r'[_a-zA-Z][0-9A-Za-z_]*\.[_a-zA-Z][0-9A-Za-z_]*$')
+PcdPattern = re.compile(r'^[_a-zA-Z][0-9A-Za-z_]*\.[_a-zA-Z][0-9A-Za-z_]*$')
 
 ## SplitString
 #  Split string to list according double quote

--- a/BaseTools/Source/Python/Common/GlobalData.py
+++ b/BaseTools/Source/Python/Common/GlobalData.py
@@ -18,6 +18,7 @@ gGlobalDefines = {}
 gPlatformDefines = {}
 # PCD name and value pair for fixed at build and feature flag
 gPlatformPcds = {}
+gPlatformFinalPcds = {}
 # PCDs with type that are not fixed at build and feature flag
 gPlatformOtherPcds = {}
 gActivePlatform = None

--- a/BaseTools/Source/Python/Workspace/InfBuildData.py
+++ b/BaseTools/Source/Python/Workspace/InfBuildData.py
@@ -14,6 +14,7 @@ from types import *
 from .MetaFileParser import *
 from collections import OrderedDict
 from Workspace.BuildClassObject import ModuleBuildClassObject, LibraryClassObject, PcdClassObject
+from Common.Expression import ValueExpressionEx, PcdPattern
 
 ## Get Protocol value from given packages
 #
@@ -528,11 +529,17 @@ class InfBuildData(ModuleBuildClassObject):
         for Record in RecordList:
             LineNo = Record[-1]
             ToolChainFamily = Record[1]
-            TagName = Record[2]
-            ToolCode = Record[3]
-
+            # OptionsList := [TagName, ToolCode, FeatureFlag]
+            OptionsList = ['', '', '']
+            TokenList = GetSplitValueList(Record[2], TAB_VALUE_SPLIT)
+            for Index in range(len(TokenList)):
+                OptionsList[Index] = TokenList[Index]
+            if OptionsList[2]:
+                FeaturePcdExpression = self.CheckFeatureFlagPcd(OptionsList[2])
+                if not FeaturePcdExpression:
+                    continue
             File = PathClass(NormPath(Record[0], Macros), self._ModuleDir, '',
-                             '', False, self._Arch, ToolChainFamily, '', TagName, ToolCode)
+                             '', False, self._Arch, ToolChainFamily, '', OptionsList[0], OptionsList[1])
             # check the file validation
             ErrorCode, ErrorInfo = File.Validate()
             if ErrorCode != 0:
@@ -1046,6 +1053,43 @@ class InfBuildData(ModuleBuildClassObject):
         if (self.Binaries and not self.Sources) or GlobalData.gIgnoreSource:
             return True
         return False
+    def CheckFeatureFlagPcd(self,Instance):
+        Pcds = {}
+        if GlobalData.gPlatformFinalPcds.get(self.Arch):
+            Pcds = GlobalData.gPlatformFinalPcds[self.Arch].copy()
+        if PcdPattern.search(Instance):
+            PcdTuple = tuple(Instance.split('.')[::-1])
+            if PcdTuple in self.Pcds:
+                if not (self.Pcds[PcdTuple].Type == 'FeatureFlag' or self.Pcds[PcdTuple].Type == 'FixedAtBuild') and Instance not in Pcds:
+                    EdkLogger.error('build', FORMAT_INVALID,
+                                    "\nit must be defined in a [PcdsFeatureFlag] or [PcdsFixedAtBuild] section of Dsc or Dec file or [FeaturePcd] or [FixedPcd] of Inf file",
+                                    File=str(self), ExtraData=Instance)
+                Pcds[Instance] = self.Pcds[PcdTuple].DefaultValue
+            if Instance in Pcds:
+                if Pcds[Instance] == '0':
+                    return False
+                elif Pcds[Instance] == '1':
+                    return True
+            try:
+                Value = ValueExpression(Instance, Pcds)()
+                if Value == True:
+                    return True
+                return False
+            except:
+                EdkLogger.warn('build', FORMAT_INVALID,"The FeatureFlagExpression cannot be evaluated", File=str(self), ExtraData=Instance)
+                return False
+        else:
+            for Name, Guid in self.Pcds:
+                if self.Pcds[(Name, Guid)].Type == 'FeatureFlag' or self.Pcds[(Name, Guid)].Type == 'FixedAtBuild':
+                    Pcds['%s.%s' % (Guid, Name)] = self.Pcds[(Name, Guid)].DefaultValue
+            try:
+                Value = ValueExpression(Instance, Pcds)()
+                if Value == True:
+                    return True
+                return False
+            except:
+                EdkLogger.warn('build', FORMAT_INVALID, "The FeatureFlagExpression cannot be evaluated", File=str(self), ExtraData=Instance)
+                return False
 def ExtendCopyDictionaryLists(CopyToDict, CopyFromDict):
     for Key in CopyFromDict:
         CopyToDict[Key].extend(CopyFromDict[Key])

--- a/BaseTools/Source/Python/Workspace/MetaFileParser.py
+++ b/BaseTools/Source/Python/Workspace/MetaFileParser.py
@@ -736,6 +736,10 @@ class InfParser(MetaFileParser):
     @ParseMacro
     def _SourceFileParser(self):
         TokenList = GetSplitValueList(self._CurrentLine, TAB_VALUE_SPLIT)
+        # Let TokenList[2] be TagName|ToolCode|FeatureFlag
+        if len(TokenList) > 3:
+            for extraToken in range(3, len(TokenList)):
+                TokenList[2] = TokenList[2] + '|' + TokenList[extraToken]
         self._ValueList[0:len(TokenList)] = TokenList
         Macros = self._Macros
         # For Acpi tables, remove macro like ' TABLE_NAME=Sata1'

--- a/BaseTools/Source/Python/Workspace/WorkspaceCommon.py
+++ b/BaseTools/Source/Python/Workspace/WorkspaceCommon.py
@@ -75,6 +75,11 @@ def GetDeclaredPcd(Platform, BuildDatabase, Arch, Target, Toolchain, additionalP
                         break
             if (PcdCName, PcdTokenName) not in DecPcds:
                 DecPcds[PcdCName, PcdTokenName] = Pkg.Pcds[Pcd]
+    if not GlobalData.gPlatformFinalPcds.get(Arch):
+        GlobalData.gPlatformFinalPcds[Arch] = OrderedDict()
+    for Name,Guid in DecPcds:
+        if DecPcds[Name,Guid].Type == 'FeatureFlag' or DecPcds[Name, Guid].Type == 'FixedAtBuild':
+            GlobalData.gPlatformFinalPcds[Arch]['%s.%s'%(Guid, Name)]=DecPcds[Name, Guid].DefaultValue
     return DecPcds, GuidDict
 
 ## Get all dependent libraries for a module


### PR DESCRIPTION
REF:https://bugzilla.tianocore.org/show_bug.cgi?id=3828

FeatureFlagExpression Support in Source section of INF file. The Pcd
value in the expression is from INF or DEC.
When a FeatureFlagExpression is present,if the expression evaluates
to TRUE,then the entry is valid. If the expression evaluates to FALSE,
then the EDK II build tools must ignore the entry.

This patch is going to add this feature.

Cc: Bob Feng <bob.c.feng@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Heng Luo <heng.luo@intel.com>
Reviewed-by: Bob Feng <bob.c.feng@intel.com>
Signed-off-by: Yi Li <yi1.li@intel.com>