### PR TITLE
CryptoPkg: Redefinition bug in CrtLibSupport.h.

### DIFF
--- a/CryptoPkg/Library/BaseCryptLib/Hash/CryptParallelHash.h
+++ b/CryptoPkg/Library/BaseCryptLib/Hash/CryptParallelHash.h
@@ -25,6 +25,8 @@ http://creativecommons.org/publicdomain/zero/1.0/
 
 #define KECCAK1600_WIDTH  1600
 
+typedef UINT64 uint64_t;
+
 //
 // This struct referring to m_sha3.c from opessl and modified its type name.
 //

--- a/CryptoPkg/Library/Include/CrtLibSupport.h
+++ b/CryptoPkg/Library/Include/CrtLibSupport.h
@@ -111,7 +111,6 @@ typedef UINT8   u_char;
 typedef UINT32  uid_t;
 typedef UINT32  gid_t;
 typedef CHAR16  wchar_t;
-typedef UINT64  uint64_t;
 
 //
 // File operations are not required for EFI building,


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3885

Parallel hash patch redefines uint_64 type in CrtLibSupport.h
which has been defined in openssl/include/openssl/e_os2.h.
CryptMd5.c including e_os2.h cause redefinition bug.

Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Xiaoyu Lu <xiaoyu1.lu@intel.com>
Cc: Guomin Jiang <guomin.jiang@intel.com>
Cc: Siyuan Fu <siyuan.fu@intel.com>

Signed-off-by: Zhihao Li <zhihao.li@intel.com>
Reviewed-by: Jiewen Yao <jiewen.yao@intel.com>