### PR TITLE
UefiPayloadPkg: Fix PciHostBridgeLib

### DIFF
--- a/OvmfPkg/Library/PciHostBridgeLibScan/ScanForRootBridges.c
+++ b/OvmfPkg/Library/PciHostBridgeLibScan/ScanForRootBridges.c
@@ -331,14 +331,18 @@ ScanForRootBridges (
           Base  = ((UINT32)Pci.Bridge.PrefetchableMemoryBase & 0xfff0) << 16;
           Limit = (((UINT32)Pci.Bridge.PrefetchableMemoryLimit & 0xfff0)
                    << 16) | 0xfffff;
-          MemAperture = &Mem;
           if (Value == BIT0) {
-            Base       |= LShiftU64 (Pci.Bridge.PrefetchableBaseUpper32, 32);
-            Limit      |= LShiftU64 (Pci.Bridge.PrefetchableLimitUpper32, 32);
-            MemAperture = &MemAbove4G;
+            Base  |= LShiftU64 (Pci.Bridge.PrefetchableBaseUpper32, 32);
+            Limit |= LShiftU64 (Pci.Bridge.PrefetchableLimitUpper32, 32);
           }
 
           if (Base < Limit) {
+            if (Base < BASE_4GB) {
+              MemAperture = &Mem;
+            } else {
+              MemAperture = &MemAbove4G;
+            }
+
             if (MemAperture->Base > Base) {
               MemAperture->Base = Base;
             }

--- a/UefiPayloadPkg/Library/PciHostBridgeLib/PciHostBridgeSupport.c
+++ b/UefiPayloadPkg/Library/PciHostBridgeLib/PciHostBridgeSupport.c
@@ -354,14 +354,19 @@ ScanForRootBridges (
           Base  = ((UINT32)Pci.Bridge.PrefetchableMemoryBase & 0xfff0) << 16;
           Limit = (((UINT32)Pci.Bridge.PrefetchableMemoryLimit & 0xfff0)
                    << 16) | 0xfffff;
-          MemAperture = &Mem;
+
           if (Value == BIT0) {
-            Base       |= LShiftU64 (Pci.Bridge.PrefetchableBaseUpper32, 32);
-            Limit      |= LShiftU64 (Pci.Bridge.PrefetchableLimitUpper32, 32);
-            MemAperture = &MemAbove4G;
+            Base  |= LShiftU64 (Pci.Bridge.PrefetchableBaseUpper32, 32);
+            Limit |= LShiftU64 (Pci.Bridge.PrefetchableLimitUpper32, 32);
           }
 
           if ((Base > 0) && (Base < Limit)) {
+            if (Base < BASE_4GB) {
+              MemAperture = &Mem;
+            } else {
+              MemAperture = &MemAbove4G;
+            }
+
             if (MemAperture->Base > Base) {
               MemAperture->Base = Base;
             }


### PR DESCRIPTION
On modern platforms with TBT devices the coreboot resource allocator
opens large PCI bridge MMIO windows above 4GiB to place hotplugable
PCI BARs there as they won't fit below 4GiB. In addition modern
GPGPU devices have very big PCI bars that doesn't fit below 4GiB.

The PciHostBridgeLib made lots of assumptions about the coreboot
resource allocator that were not verified at runtime and are no
longer true.

Remove all of the 'coreboot specific' code and simply merge the
memory regions below 4GiB to Mem and everything else to MemAbove4G.
This is similar to what OvmfPkg does.

Fixes assertion
"ASSERT [PciHostBridgeDxe] Bridge->Mem.Limit < 0x0000000100000000ULL".

Tested with coreboot as bootloader on platforms that have PCI resource
above 4GiB and on platforms that don't have resource above 4GiB.

Signed-off-by: Patrick Rudolph <patrick.rudolph@9elements.com>