### PR TITLE
MdeModulePkg/Ufs: bRefClkFreq attribute be programmed after fDeviceInit

### DIFF
--- a/MdeModulePkg/Bus/Ufs/UfsPassThruDxe/UfsPassThru.c
+++ b/MdeModulePkg/Bus/Ufs/UfsPassThruDxe/UfsPassThru.c
@@ -919,6 +919,23 @@ UfsPassThruDriverBindingStart (
     goto Error;
   }
 
+  //
+  // UFS 2.0 spec Section 13.1.3.3:
+  // At the end of the UFS Interconnect Layer initialization on both host and device side,
+  // the host shall send a NOP OUT UPIU to verify that the device UTP Layer is ready.
+  //
+  Status = UfsExecNopCmds (Private);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "Ufs Sending NOP IN command Error, Status = %r\n", Status));
+    goto Error;
+  }
+
+  Status = UfsFinishDeviceInitialization (Private);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "Device failed to finish initialization, Status = %r\n", Status));
+    goto Error;
+  }
+
   if ((mUfsHcPlatform != NULL) &&
       ((mUfsHcPlatform->RefClkFreq == EdkiiUfsCardRefClkFreq19p2Mhz) ||
        (mUfsHcPlatform->RefClkFreq == EdkiiUfsCardRefClkFreq26Mhz) ||
@@ -965,23 +982,6 @@ UfsPassThruDriverBindingStart (
         );
       return Status;
     }
-  }
-
-  //
-  // UFS 2.0 spec Section 13.1.3.3:
-  // At the end of the UFS Interconnect Layer initialization on both host and device side,
-  // the host shall send a NOP OUT UPIU to verify that the device UTP Layer is ready.
-  //
-  Status = UfsExecNopCmds (Private);
-  if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "Ufs Sending NOP IN command Error, Status = %r\n", Status));
-    goto Error;
-  }
-
-  Status = UfsFinishDeviceInitialization (Private);
-  if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "Device failed to finish initialization, Status = %r\n", Status));
-    goto Error;
   }
 
   //


### PR DESCRIPTION
Patch sent at: https://edk2.groups.io/g/devel/message/88028

REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3886

bRefClkFreq UFS card attribute need to be read and written after successful
fDeviceInit and NOP response so that link will be stable.

Cc: Wu Hao A <hao.a.wu@intel.com>
Cc: Albecki Mateusz <mateusz.albecki@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Zhiguang Liu <zhiguang.liu@intel.com>

Signed-off-by: Purna Chandra Rao Bandaru <purna.chandra.rao.bandaru@intel.com>
Reviewed-by: Hao A Wu <hao.a.wu@intel.com>