### PR TITLE
UefiPayloadPkg/UefiPayloadPkg.ci.yaml: Remove duplicated entry

### DIFF
--- a/UefiPayloadPkg/UefiPayloadPkg.ci.yaml
+++ b/UefiPayloadPkg/UefiPayloadPkg.ci.yaml
@@ -20,7 +20,6 @@
         "IgnoreFiles": [
             "Include/Coreboot.h",
             "Library/CbParseLib/CbParseLib.c",
-            "Library/CbParseLib/CbParseLib.c",
             "PayloadLoaderPeim/ElfLib/ElfCommon.h",
             "PayloadLoaderPeim/ElfLib/Elf32.h",
             "PayloadLoaderPeim/ElfLib/Elf64.h"


### PR DESCRIPTION
Remove a duplicated entry to fix a CI error.

Cc: Guo Dong <guo.dong@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Cc: Maurice Ma <maurice.ma@intel.com>
Cc: Benjamin You <benjamin.you@intel.com>
Cc: Sean Rhodes <sean@starlabs.systems>
Signed-off-by: Patrick Rudolph <patrick.rudolph@9elements.com>
Reviewed-by: Guo Dong <guo.dong@intel.com>
Acked-by: Ray Ni <ray.ni@intel.com>
Reviewed-by: Dun Tan <dun.tan@intel.com>