### PR TITLE
UefiPayloadPkg: Fix build error

### DIFF
--- a/UefiPayloadPkg/UefiPayloadPkg.dsc
+++ b/UefiPayloadPkg/UefiPayloadPkg.dsc
@@ -409,7 +409,9 @@
 [PcdsPatchableInModule.X64]
   gPcAtChipsetPkgTokenSpaceGuid.PcdRtcIndexRegister|$(RTC_INDEX_REGISTER)
   gPcAtChipsetPkgTokenSpaceGuid.PcdRtcTargetRegister|$(RTC_TARGET_REGISTER)
+!if $(NETWORK_DRIVER_ENABLE) == TRUE
   gEfiNetworkPkgTokenSpaceGuid.PcdAllowHttpConnections|TRUE
+!endif
 
 [PcdsPatchableInModule.common]
   gEfiMdeModulePkgTokenSpaceGuid.PcdBootManagerMenuFile|{ 0x21, 0xaa, 0x2c, 0x46, 0x14, 0x76, 0x03, 0x45, 0x83, 0x6e, 0x8a, 0xb6, 0xf4, 0x66, 0x23, 0x31 }
@@ -532,6 +534,8 @@
 # UEFI network modules
 #
 !if $(NETWORK_DRIVER_ENABLE) == TRUE
+[Defines]
+  DEFINE PLATFORMX64_ENABLE = TRUE
   !include NetworkPkg/Network.dsc.inc
 !endif
 


### PR DESCRIPTION
On windows build, need add "-DPLATFORMX64_ENABLE=TRUE" in the build
command line beside -DNETWORK_DRIVER_ENABLE=TRUE in order build
network features. So update DSC to set PLATFORMX64_ENABLE to TRUE
when building network feature.
On Linux build, DSC file should not have PcdAllowHttpConnections
without building network feature, else it would cause build error.

Signed-off-by: Guo Dong <guo.dong@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Cc: Maurice Ma <maurice.ma@intel.com>
Cc: Benjamin You <benjamin.you@intel.com>
Reviewed-by Sean Rhodes <sean@starlabs.systems>