### PR TITLE
UefiPayloadPkg: Support IA32 Build

### DIFF
--- a/UefiPayloadPkg/UniversalPayloadBuild.py
+++ b/UefiPayloadPkg/UniversalPayloadBuild.py
@@ -53,6 +53,7 @@ def RunCommand(cmd):
 def BuildUniversalPayload(Args, MacroList):
     BuildTarget = Args.Target
     ToolChain = Args.ToolChain
+    BuildArch = "X64" if Args.Arch == 'X64' else "IA32 -a X64"
     ElfToolChain = 'CLANGDWARF'
 
     EntryModuleInf = os.path.normpath("UefiPayloadPkg/UefiPayloadEntry/UniversalPayloadEntry.inf")
@@ -87,7 +88,7 @@ def BuildUniversalPayload(Args, MacroList):
     #
     # Building Universal Payload entry.
     #
-    BuildModule = f"build -p {DscPath} -b {BuildTarget} -a X64 -m {EntryModuleInf} -t {ElfToolChain} -y {ModuleReportPath}"
+    BuildModule = f"build -p {DscPath} -b {BuildTarget} -a {BuildArch} -m {EntryModuleInf} -t {ElfToolChain} -y {ModuleReportPath}"
     BuildModule += Defines
     RunCommand(BuildModule)
 
@@ -116,6 +117,7 @@ def main():
     parser = argparse.ArgumentParser(description='For building Universal Payload')
     parser.add_argument('-t', '--ToolChain')
     parser.add_argument('-b', '--Target', default='DEBUG')
+    parser.add_argument('-a', '--Arch', choices=['IA32', 'X64'], help='Specify the ARCH for payload entry module. Default build X64 image.', default ='X64')
     parser.add_argument("-D", "--Macro", action="append", default=["UNIVERSAL_PAYLOAD=TRUE"])
     parser.add_argument('-i', '--ImageId', type=str, help='Specify payload ID (16 bytes maximal).', default ='UEFI')
     MacroList = {}


### PR DESCRIPTION
The payload entry module should support to build as IA32 image
beside X64 image so that it could work with 32bit bootloaders.

This patch adds a option build parameter for arch selection.

Signed-off-by: Guo Dong <guo.dong@intel.com>