### PR TITLE
UefiPayloadPkg: Fix PciHostBridgeLib

### DIFF
--- a/UefiPayloadPkg/Library/PciHostBridgeLib/PciHostBridgeSupport.c
+++ b/UefiPayloadPkg/Library/PciHostBridgeLib/PciHostBridgeSupport.c
@@ -354,14 +354,19 @@ ScanForRootBridges (
           Base  = ((UINT32)Pci.Bridge.PrefetchableMemoryBase & 0xfff0) << 16;
           Limit = (((UINT32)Pci.Bridge.PrefetchableMemoryLimit & 0xfff0)
                    << 16) | 0xfffff;
-          MemAperture = &Mem;
+
           if (Value == BIT0) {
-            Base       |= LShiftU64 (Pci.Bridge.PrefetchableBaseUpper32, 32);
-            Limit      |= LShiftU64 (Pci.Bridge.PrefetchableLimitUpper32, 32);
-            MemAperture = &MemAbove4G;
+            Base  |= LShiftU64 (Pci.Bridge.PrefetchableBaseUpper32, 32);
+            Limit |= LShiftU64 (Pci.Bridge.PrefetchableLimitUpper32, 32);
           }
 
           if ((Base > 0) && (Base < Limit)) {
+            if (Base < BASE_4GB) {
+              MemAperture = &Mem;
+            } else {
+              MemAperture = &MemAbove4G;
+            }
+
             if (MemAperture->Base > Base) {
               MemAperture->Base = Base;
             }


### PR DESCRIPTION
Don't assume a 64bit register always holds an address greater than 4GB.
Check the value in the register and decide which Aperature it should be
assigned to.

Fixes assertion
"ASSERT [PciHostBridgeDxe] Bridge->MemAbove4G.Base >= 0x0000000100000000ULL".

Tested with coreboot as bootloader on platforms that have PCI resource
above 4GiB and on platforms that don't have resource above 4GiB.

Cc: Guo Dong <guo.dong@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Cc: Maurice Ma <maurice.ma@intel.com>
Cc: Benjamin You <benjamin.you@intel.com>
Cc: Sean Rhodes <sean@starlabs.systems>
Signed-off-by: Patrick Rudolph <patrick.rudolph@9elements.com>
Reviewed-by Sean Rhodes <sean@starlabs.systems>
Reviewed-by: Guo Dong <guo.dong@intel.com>