### PR TITLE
NetworkPkg: Add PCDs for HTTP DNS RetryCount and RetryInterval

### DIFF
--- a/NetworkPkg/HttpDxe/HttpDns.c
+++ b/NetworkPkg/HttpDxe/HttpDns.c
@@ -108,6 +108,8 @@ HttpDns4 (
   Dns4CfgData.DnsServerListCount = DnsServerListCount;
   Dns4CfgData.DnsServerList      = DnsServerList;
   Dns4CfgData.UseDefaultSetting  = HttpInstance->IPv4Node.UseDefaultAddress;
+  Dns4CfgData.RetryInterval      = PcdGet32 (PcdHttpDnsRetryInterval);
+  Dns4CfgData.RetryCount         = PcdGet32 (PcdHttpDnsRetryCount);
   if (!Dns4CfgData.UseDefaultSetting) {
     IP4_COPY_ADDRESS (&Dns4CfgData.StationIp, &HttpInstance->IPv4Node.LocalAddress);
     IP4_COPY_ADDRESS (&Dns4CfgData.SubnetMask, &HttpInstance->IPv4Node.LocalSubnet);
@@ -315,6 +317,8 @@ HttpDns6 (
   Dns6ConfigData.DnsServerList  = DnsServerList;
   Dns6ConfigData.EnableDnsCache = TRUE;
   Dns6ConfigData.Protocol       = EFI_IP_PROTO_UDP;
+  Dns6ConfigData.RetryInterval  = PcdGet32 (PcdHttpDnsRetryInterval);
+  Dns6ConfigData.RetryCount     = PcdGet32 (PcdHttpDnsRetryCount);
   IP6_COPY_ADDRESS (&Dns6ConfigData.StationIp, &HttpInstance->Ipv6Node.LocalAddress);
   Status = Dns6->Configure (
                    Dns6,

--- a/NetworkPkg/HttpDxe/HttpDxe.inf
+++ b/NetworkPkg/HttpDxe/HttpDxe.inf
@@ -75,6 +75,8 @@
 [Pcd]
   gEfiNetworkPkgTokenSpaceGuid.PcdAllowHttpConnections       ## CONSUMES
   gEfiNetworkPkgTokenSpaceGuid.PcdHttpIoTimeout              ## CONSUMES
+  gEfiNetworkPkgTokenSpaceGuid.PcdHttpDnsRetryInterval       ## CONSUMES
+  gEfiNetworkPkgTokenSpaceGuid.PcdHttpDnsRetryCount          ## CONSUMES
 
 [UserExtensions.TianoCore."ExtraFiles"]
   HttpDxeExtra.uni

--- a/NetworkPkg/NetworkPkg.dec
+++ b/NetworkPkg/NetworkPkg.dec
@@ -163,5 +163,14 @@
   # @Prompt The Timeout value of HTTP Io. Default value is 5000.
   gEfiNetworkPkgTokenSpaceGuid.PcdHttpIoTimeout|5000|UINT32|0x0000000F
 
+  ## The Retry Interval of HTTP DNS in seconds. If the Retry Interval is less than
+  # DNS_DEFAULT_TIMEOUT, then use the DNS_DEFAULT_TIMEOUT.
+  # @Prompt The value of Retry Interval. Default value is 0
+  gEfiNetworkPkgTokenSpaceGuid.PcdHttpDnsRetryInterval|0|UINT32|0x00000010
+
+  ## The Retry Count of HTTP DNS if no DNS response received after Retry Interval.
+  # @Prompt The value of Retry Count,  Default value is 0.
+  gEfiNetworkPkgTokenSpaceGuid.PcdHttpDnsRetryCount|0|UINT32|0x00000011
+
 [UserExtensions.TianoCore."ExtraFiles"]
   NetworkPkgExtra.uni

--- a/NetworkPkg/NetworkPkg.uni
+++ b/NetworkPkg/NetworkPkg.uni
@@ -111,3 +111,14 @@
 #string STR_gEfiNetworkPkgTokenSpaceGuid_PcdHttpIoTimeout_HELP  #language en-US "This value is used to configure the request and response timeout when getting "
                                                                                "the recovery image from the remote source during an HTTP recovery boot."
                                                                                "The default value set is 5 seconds."
+
+#string STR_gEfiNetworkPkgTokenSpaceGuid_PcdHttpDnsRetryInterval_PROMPT  #language en-US "Retry Interval of HTTP DNS"
+
+#string STR_gEfiNetworkPkgTokenSpaceGuid_PcdHttpDnsRetryInterval_HELP  #language en-US "This value is used to configure the retry Interval of HTTP DNS."
+                                                                                "The default value set is 0 second. If the value is less than"
+                                                                                "DNS_DEFAULT_TIMEOUT, then use the DNS_DEFAULT_TIMEOUT."
+
+#string STR_gEfiNetworkPkgTokenSpaceGuid_PcdHttpDnsRetryCount_PROMPT  #language en-US "Retry Count of HTTP DNS"
+
+#string STR_gEfiNetworkPkgTokenSpaceGuid_PcdHttpDnsRetryCount_HELP  #language en-US "This value is used to configure the Retry Count of HTTP DNS if "
+                                                                                "no DNS response received after Retry Interval. The default value set is 0."


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3889

Currently the HTTP DNS Retry Interval is 2 second and no retry attempt.
If DNS response can't arrive in 2 second, the DNS request is failed,
and then HTTP boot is failed.
In order to resolve this issue, Add PCDs to support RetryCount
and RetryInterval configurated in Platform.

Cc: Maciej Rabeda <maciej.rabeda@linux.intel.com>
Cc: Fu Siyuan <siyuan.fu@intel.com>
Cc: Wu Jiaxin <jiaxin.wu@intel.com>
Signed-off-by: Heng Luo <heng.luo@intel.com>