### PR TITLE
MdeModulePkg/FaultTolerantWriteDxe: Don't check for address alignment

### DIFF
--- a/MdeModulePkg/Universal/FaultTolerantWriteDxe/FtwMisc.c
+++ b/MdeModulePkg/Universal/FaultTolerantWriteDxe/FtwMisc.c
@@ -1121,12 +1121,10 @@ FindFvbForFtw (
           FtwDevice->NumberOfWorkSpaceBlock = FTW_BLOCKS (FtwDevice->FtwWorkSpaceBase + FtwDevice->FtwWorkSpaceSize, FtwDevice->WorkBlockSize);
           if (FtwDevice->FtwWorkSpaceSize >= FtwDevice->WorkBlockSize) {
             //
-            // Check the alignment of work space address and length, they should be block size aligned when work space size is larger than one block size.
+            // Check the alignment of work space length, it should be block size aligned when work space size is larger than one block size.
             //
-            if (((FtwDevice->WorkSpaceAddress & (FtwDevice->WorkBlockSize - 1)) != 0) ||
-                ((FtwDevice->WorkSpaceLength & (FtwDevice->WorkBlockSize - 1)) != 0))
-            {
-              DEBUG ((DEBUG_ERROR, "Ftw: Work space address or length is not block size aligned when work space size is larger than one block size\n"));
+            if ((FtwDevice->WorkSpaceLength & (FtwDevice->WorkBlockSize - 1)) != 0) {
+              DEBUG ((DEBUG_ERROR, "Ftw: Work space length is not block size aligned when work space size is larger than one block size\n"));
               FreePool (HandleBuffer);
               ASSERT (FALSE);
               return EFI_ABORTED;
@@ -1171,11 +1169,9 @@ FindFvbForFtw (
           }
 
           //
-          // Check the alignment of spare area address and length, they should be block size aligned
+          // Check the alignment of spare area length, it should be block size aligned
           //
-          if (((FtwDevice->SpareAreaAddress & (FtwDevice->SpareBlockSize - 1)) != 0) ||
-              ((FtwDevice->SpareAreaLength & (FtwDevice->SpareBlockSize - 1)) != 0))
-          {
+          if ((FtwDevice->SpareAreaLength & (FtwDevice->SpareBlockSize - 1)) != 0) {
             DEBUG ((DEBUG_ERROR, "Ftw: Spare area address or length is not block size aligned\n"));
             FreePool (HandleBuffer);
             //


### PR DESCRIPTION
On Intel platforms, the address of the memory-mapped flash partition
is not necessarily aligned to FVB blocks (it is offset by the start
of the BIOS region in flash which can have odd constraints, e.g. on
Apollo Lake). All writes have to go through FVB which will take care
of any mapping quirks. So it's not necessary, actually rather obstruc-
tive, to check for alignment of the `WorkSpaceAddress`.

Signed-off-by: Sean Rhodes <sean@starlabs.systems>
Change-Id: Ia1c1f44b6a0e7f32cac0d7806e74d729e5d83a6d