### PR TITLE
BaseTools: Fix DevicePath tool build failure issue

### DIFF
--- a/BaseTools/Source/C/DevicePath/GNUmakefile
+++ b/BaseTools/Source/C/DevicePath/GNUmakefile
@@ -13,8 +13,13 @@ OBJECTS = DevicePath.o UefiDevicePathLib.o DevicePathFromText.o  DevicePathUtili
 
 include $(MAKEROOT)/Makefiles/app.makefile
 
+GCCVERSION = $(shell gcc -dumpversion | awk -F'.' '{print $$1}')
+ifneq ("$(GCCVERSION)", "5")
+ifneq ($(CXX), llvm)
 # gcc 12 trips over device path handling
 BUILD_CFLAGS += -Wno-error=stringop-overflow
+endif
+endif
 
 LIBS = -lCommon
 ifeq ($(CYGWIN), CYGWIN)


### PR DESCRIPTION
Fix the DevicePath tool build failure that was introduced by
the fixes: 22130dcd98b4 ("Basetools: turn off gcc12 warning").
Failure cases are:
1. clang 13.1.6 on macOS
2. gcc5.4

Reported-by: Rebecca Cran <rebecca@bsdio.com>
Reported-by: Yuwei Chen <yuwei.chen@intel.com>
Signed-off-by: Gerd Hoffmann <kraxel@redhat.com>
Signed-off-by: Bob Feng <bob.c.feng@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Yuwei Chen <yuwei.chen@intel.com>
Cc: Rebecca Cran <rebecca@bsdio.com>
Reviewed-by: Yuwei Chen <yuwei.chen@intel.com>