### PR TITLE
CryptoPkg updates for openssl 3.0

### DIFF
--- a/CryptoPkg/CryptoPkg.ci.yaml
+++ b/CryptoPkg/CryptoPkg.ci.yaml
@@ -36,6 +36,7 @@
             "Library/Include/CrtLibSupport.h",
             # This has OpenSSL interfaces that aren't UEFI spec compliant
             "Library/BaseCryptLib/Hash/CryptParallelHash.h",
+            "Library/Include/fcntl.h",
             # These directories contain auto-generated OpenSSL content
             "Library/OpensslLib",
             "Library/IntrinsicLib",

--- a/CryptoPkg/Library/BaseCryptLib/SysCall/CrtWrapper.c
+++ b/CryptoPkg/Library/BaseCryptLib/SysCall/CrtWrapper.c
@@ -265,6 +265,16 @@ strcspn (
   return Count;
 }
 
+char *
+strcpy (
+  char *restrict  strDest,
+  const char      *strSource
+  )
+{
+  AsciiStrCpyS (strDest, MAX_STRING_SIZE, strSource);
+  return strDest;
+}
+
 //
 // -- Character Classification Routines --
 //

--- a/CryptoPkg/Library/Include/CrtLibSupport.h
+++ b/CryptoPkg/Library/Include/CrtLibSupport.h
@@ -18,6 +18,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #define OPENSSLDIR  ""
 #define ENGINESDIR  ""
+#define MODULESDIR  ""
 
 #define MAX_STRING_SIZE  0x1000
 

--- a/CryptoPkg/Library/Include/CrtLibSupport.h
+++ b/CryptoPkg/Library/Include/CrtLibSupport.h
@@ -104,6 +104,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 // Basic types mapping
 //
 typedef UINTN   size_t;
+typedef UINTN   off_t;
 typedef UINTN   u_int;
 typedef INTN    ptrdiff_t;
 typedef INTN    ssize_t;

--- a/CryptoPkg/Library/Include/CrtLibSupport.h
+++ b/CryptoPkg/Library/Include/CrtLibSupport.h
@@ -82,6 +82,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #define INT_MIN       (-INT_MAX-1)    /* Minimum (signed) int value */
 #define LONG_MAX      0X7FFFFFFFL     /* max value for a long */
 #define LONG_MIN      (-LONG_MAX-1)   /* min value for a long */
+#define UINT_MAX      0xFFFFFFFF      /* Maximum unsigned int value */
 #define ULONG_MAX     0xFFFFFFFF      /* Maximum unsigned long value */
 #define CHAR_BIT      8               /* Number of bits in a char */
 

--- a/CryptoPkg/Library/Include/CrtLibSupport.h
+++ b/CryptoPkg/Library/Include/CrtLibSupport.h
@@ -405,6 +405,7 @@ inet_pton   (
 #define strcat(strDest, strSource)          AsciiStrCatS(strDest,MAX_STRING_SIZE,strSource)
 #define strncmp(string1, string2, count)    (int)(AsciiStrnCmp(string1,string2,(UINTN)(count)))
 #define strcasecmp(str1, str2)              (int)AsciiStriCmp(str1,str2)
+#define strstr(s1, s2)                      AsciiStrStr(s1,s2)
 #define sprintf(buf, ...)                   AsciiSPrint(buf,MAX_STRING_SIZE,__VA_ARGS__)
 #define localtime(timer)                    NULL
 #define assert(expression)

--- a/CryptoPkg/Library/Include/CrtLibSupport.h
+++ b/CryptoPkg/Library/Include/CrtLibSupport.h
@@ -79,6 +79,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #define EINVAL        22              /* Invalid argument */
 #define EAFNOSUPPORT  47              /* Address family not supported by protocol family */
 #define INT_MAX       0x7FFFFFFF      /* Maximum (signed) int value */
+#define INT_MIN       (-INT_MAX-1)    /* Minimum (signed) int value */
 #define LONG_MAX      0X7FFFFFFFL     /* max value for a long */
 #define LONG_MIN      (-LONG_MAX-1)   /* min value for a long */
 #define ULONG_MAX     0xFFFFFFFF      /* Maximum unsigned long value */

--- a/CryptoPkg/Library/Include/CrtLibSupport.h
+++ b/CryptoPkg/Library/Include/CrtLibSupport.h
@@ -395,6 +395,12 @@ inet_pton   (
   void *
   );
 
+char *
+strcpy (
+  char *restrict  strDest,
+  const char      *strSource
+  );
+
 //
 // Macros that directly map functions to BaseLib, BaseMemoryLib, and DebugLib functions
 //
@@ -404,7 +410,6 @@ inet_pton   (
 #define memcmp(buf1, buf2, count)           (int)(CompareMem(buf1,buf2,(UINTN)(count)))
 #define memmove(dest, source, count)        CopyMem(dest,source,(UINTN)(count))
 #define strlen(str)                         (size_t)(AsciiStrnLenS(str,MAX_STRING_SIZE))
-#define strcpy(strDest, strSource)          AsciiStrCpyS(strDest,MAX_STRING_SIZE,strSource)
 #define strncpy(strDest, strSource, count)  AsciiStrnCpyS(strDest,MAX_STRING_SIZE,strSource,(UINTN)count)
 #define strcat(strDest, strSource)          AsciiStrCatS(strDest,MAX_STRING_SIZE,strSource)
 #define strncmp(string1, string2, count)    (int)(AsciiStrnCmp(string1,string2,(UINTN)(count)))

--- a/CryptoPkg/Library/Include/fcntl.h
+++ b/CryptoPkg/Library/Include/fcntl.h
@@ -1,0 +1,9 @@
+/** @file
+  Include file to support building the third-party cryptographic library.
+
+Copyright (c) 2010 - 2017, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <CrtLibSupport.h>

--- a/CryptoPkg/Test/UnitTest/Library/BaseCryptLib/DhTests.c
+++ b/CryptoPkg/Test/UnitTest/Library/BaseCryptLib/DhTests.c
@@ -53,7 +53,7 @@ TestVerifyDhGenerateKey (
   UNIT_TEST_CONTEXT  Context
   )
 {
-  UINT8    Prime[64];
+  UINT8    Prime[512];
   UINT8    PublicKey1[64];
   UINTN    PublicKey1Length;
   UINT8    PublicKey2[64];
@@ -72,10 +72,10 @@ TestVerifyDhGenerateKey (
   Key1Length       = sizeof (Key1);
   Key2Length       = sizeof (Key2);
 
-  Status = DhGenerateParameter (mDh1, 2, 64, Prime);
+  Status = DhGenerateParameter (mDh1, 2, sizeof (Prime), Prime);
   UT_ASSERT_TRUE (Status);
 
-  Status = DhSetParameter (mDh2, 2, 64, Prime);
+  Status = DhSetParameter (mDh2, 2, sizeof (Prime), Prime);
   UT_ASSERT_TRUE (Status);
 
   Status = DhGenerateKey (mDh1, PublicKey1, &PublicKey1Length);


### PR DESCRIPTION

First batch of patches which update CrtLibSupport so it has everything
needed to build openssl3.  Also a testcase update for openssl3.

This does not update the openssl submodule, that'll happen in a
followup patch series.

v3:
 - move strcpy() from .h to .c file.
 - pick up review tags
v2:
 - rebase to latest master.
 - add codestyle exception for fcntl.h.

Gerd Hoffmann (8):
  CryptoPkg/CrtLibSupport: add fcntl.h
  CryptoPkg/CrtLibSupport: add strstr()
  CryptoPkg/CrtLibSupport: add INT_MIN
  CryptoPkg/CrtLibSupport: add UINT_MAX
  CryptoPkg/CrtLibSupport: add MODULESDIR
  CryptoPkg/CrtLibSupport: add off_t
  CryptoPkg/CrtLibSupport: fix strcpy
  CryptoPkg/UnitTest: fix DH testcase

 CryptoPkg/Library/Include/CrtLibSupport.h            | 12 +++++++++++-
 CryptoPkg/Library/Include/fcntl.h                    |  9 +++++++++
 CryptoPkg/Library/BaseCryptLib/SysCall/CrtWrapper.c  | 10 ++++++++++
 .../Test/UnitTest/Library/BaseCryptLib/DhTests.c     |  6 +++---
 CryptoPkg/CryptoPkg.ci.yaml                          |  1 +
 5 files changed, 34 insertions(+), 4 deletions(-)
 create mode 100644 CryptoPkg/Library/Include/fcntl.h