### PR TITLE
pip-requirements.txt: Update basetools version to 0.1.17

### DIFF
--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -14,5 +14,5 @@
 
 edk2-pytool-library==0.11.2
 edk2-pytool-extensions~=0.16.0
-edk2-basetools==0.1.13
+edk2-basetools==0.1.17
 antlr4-python3-runtime==4.7.1


### PR DESCRIPTION
Synced the basetools patch from edk2 repo to
edk2-basetools repo. Update the basetools pip module version
to the latest.

Signed-off-by: Bob Feng <bob.c.feng@intel.com>