### PR TITLE
ArmPlatformPkg/PrePeiCore: Print the firmware version early in boot

### DIFF
--- a/ArmPlatformPkg/PrePeiCore/PrePeiCoreMPCore.inf
+++ b/ArmPlatformPkg/PrePeiCore/PrePeiCoreMPCore.inf
@@ -57,6 +57,9 @@
   gEfiTemporaryRamSupportPpiGuid
   gArmMpCoreInfoPpiGuid
 
+[Pcd]
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFirmwareVersionString
+
 [FeaturePcd]
   gArmPlatformTokenSpaceGuid.PcdSendSgiToBringUpSecondaryCores
 

--- a/ArmPlatformPkg/PrePeiCore/PrePeiCoreUniCore.inf
+++ b/ArmPlatformPkg/PrePeiCore/PrePeiCoreUniCore.inf
@@ -55,6 +55,9 @@
 [Ppis]
   gEfiTemporaryRamSupportPpiGuid
 
+[Pcd]
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFirmwareVersionString
+
 [FeaturePcd]
   gArmPlatformTokenSpaceGuid.PcdSendSgiToBringUpSecondaryCores
 


### PR DESCRIPTION
Copy code from PrePi to PrePeiCore that prints the firmware version
and build date early in the boot process.

Signed-off-by: Rebecca Cran <quic_rcran@quicinc.com>