### PR TITLE
CryptoPkg: Enable ECC in openssllib by a customize-able way

### DIFF
--- a/CryptoPkg/CryptoPkg.dec
+++ b/CryptoPkg/CryptoPkg.dec
@@ -81,5 +81,9 @@
   # @ValidList 0x80000001 | 0x00000001, 0x00000002, 0x00000004, 0x00000008, 0x00000010
   gEfiCryptoPkgTokenSpaceGuid.PcdHashApiLibPolicy|0x00000002|UINT32|0x00000001
 
+  ## Enable/Disable the ECC feature in openssl library. The default is disabled.
+  #  If ECC feature is disabled, all related source files will not be compiled.
+  gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled|FALSE|BOOLEAN|0x0000003
+
 [UserExtensions.TianoCore."ExtraFiles"]
   CryptoPkgExtra.uni

--- a/CryptoPkg/Library/Include/openssl/opensslconf.h
+++ b/CryptoPkg/Library/Include/openssl/opensslconf.h
@@ -9,7 +9,7 @@
  * in the file LICENSE in the source distribution or at
  * https://www.openssl.org/source/license.html
  */
-
+#include <Library/PcdLib.h>
 #include <openssl/opensslv.h>
 
 #ifdef  __cplusplus
@@ -54,6 +54,11 @@ extern "C" {
 #endif
 #ifndef OPENSSL_NO_DSA
 #define OPENSSL_NO_DSA
+#endif
+#if !FixedPcdGetBool (PcdEcEnabled)
+  #ifndef OPENSSL_NO_EC
+#define OPENSSL_NO_EC
+  #endif
 #endif
 #ifndef OPENSSL_NO_IDEA
 #define OPENSSL_NO_IDEA

--- a/CryptoPkg/Library/Include/openssl/opensslconf.h
+++ b/CryptoPkg/Library/Include/openssl/opensslconf.h
@@ -55,9 +55,6 @@ extern "C" {
 #ifndef OPENSSL_NO_DSA
 #define OPENSSL_NO_DSA
 #endif
-#ifndef OPENSSL_NO_EC
-#define OPENSSL_NO_EC
-#endif
 #ifndef OPENSSL_NO_IDEA
 #define OPENSSL_NO_IDEA
 #endif

--- a/CryptoPkg/Library/IntrinsicLib/Ia32/MathLlmul.asm
+++ b/CryptoPkg/Library/IntrinsicLib/Ia32/MathLlmul.asm
@@ -1,0 +1,98 @@
+;***
+;llmul.asm - long multiply routine
+;
+;       Copyright (c) Microsoft Corporation. All rights reserved.
+;       SPDX-License-Identifier: BSD-2-Clause-Patent
+;
+;Purpose:
+;       Defines long multiply routine
+;       Both signed and unsigned routines are the same, since multiply's
+;       work out the same in 2's complement
+;       creates the following routine:
+;           __allmul
+;
+;Original Implemenation: MSVC 14.12.25827
+;
+;*******************************************************************************
+    .686
+    .model  flat,C
+    .code
+
+
+;***
+;llmul - long multiply routine
+;
+;Purpose:
+;       Does a long multiply (same for signed/unsigned)
+;       Parameters are not changed.
+;
+;Entry:
+;       Parameters are passed on the stack:
+;               1st pushed: multiplier (QWORD)
+;               2nd pushed: multiplicand (QWORD)
+;
+;Exit:
+;       EDX:EAX - product of multiplier and multiplicand
+;       NOTE: parameters are removed from the stack
+;
+;Uses:
+;       ECX
+;
+;Exceptions:
+;
+;*******************************************************************************
+_allmul PROC NEAR
+
+A       EQU     [esp + 4]       ; stack address of a
+B       EQU     [esp + 12]      ; stack address of b
+
+HIGH_PART  EQU     [4]             ;
+LOW_PART   EQU     [0]
+
+;
+;       AHI, BHI : upper 32 bits of A and B
+;       ALO, BLO : lower 32 bits of A and B
+;
+;             ALO * BLO
+;       ALO * BHI
+; +     BLO * AHI
+; ---------------------
+;
+
+        mov     eax,HIGH_PART(A)
+        mov     ecx,HIGH_PART(B)
+        or      ecx,eax         ;test for both high dwords zero.
+        mov     ecx,LOW_PART(B)
+        jnz     short hard      ;both are zero, just mult ALO and BLO
+
+        mov     eax,LOW_PART(A)
+        mul     ecx
+
+        ret     16              ; callee restores the stack
+
+hard:
+        push    ebx
+
+; must redefine A and B since esp has been altered
+
+A2      EQU     [esp + 8]       ; stack address of a
+B2      EQU     [esp + 16]      ; stack address of b
+
+        mul     ecx             ;eax has AHI, ecx has BLO, so AHI * BLO
+        mov     ebx,eax         ;save result
+
+        mov     eax,LOW_PART(A2)
+        mul     dword ptr HIGH_PART(B2) ;ALO * BHI
+        add     ebx,eax         ;ebx = ((ALO * BHI) + (AHI * BLO))
+
+        mov     eax,LOW_PART(A2);ecx = BLO
+        mul     ecx             ;so edx:eax = ALO*BLO
+        add     edx,ebx         ;now edx has all the LO*HI stuff
+
+        pop     ebx
+
+        ret     16              ; callee restores the stack
+
+_allmul ENDP
+
+        end

--- a/CryptoPkg/Library/IntrinsicLib/Ia32/MathLlshr.asm
+++ b/CryptoPkg/Library/IntrinsicLib/Ia32/MathLlshr.asm
@@ -1,0 +1,78 @@
+;***
+;llshr.asm - long shift right
+;
+;       Copyright (c) Microsoft Corporation. All rights reserved.
+;       SPDX-License-Identifier: BSD-2-Clause-Patent
+;
+;Purpose:
+;       define signed long shift right routine
+;           __allshr
+;
+;Original Implemenation: MSVC 14.12.25827
+;
+;*******************************************************************************
+    .686
+    .model  flat,C
+    .code
+
+
+
+;***
+;llshr - long shift right
+;
+;Purpose:
+;       Does a signed Long Shift Right
+;       Shifts a long right any number of bits.
+;
+;Entry:
+;       EDX:EAX - long value to be shifted
+;       CL    - number of bits to shift by
+;
+;Exit:
+;       EDX:EAX - shifted value
+;
+;Uses:
+;       CL is destroyed.
+;
+;Exceptions:
+;
+;*******************************************************************************
+_allshr PROC NEAR
+
+;
+; Handle shifts of 64 bits or more (if shifting 64 bits or more, the result
+; depends only on the high order bit of edx).
+;
+        cmp     cl,64
+        jae     short RETSIGN
+
+;
+; Handle shifts of between 0 and 31 bits
+;
+        cmp     cl, 32
+        jae     short MORE32
+        shrd    eax,edx,cl
+        sar     edx,cl
+        ret
+
+;
+; Handle shifts of between 32 and 63 bits
+;
+MORE32:
+        mov     eax,edx
+        sar     edx,31
+        and     cl,31
+        sar     eax,cl
+        ret
+
+;
+; Return double precision 0 or -1, depending on the sign of edx
+;
+RETSIGN:
+        sar     edx,31
+        mov     eax,edx
+        ret
+
+_allshr ENDP
+
+        end

--- a/CryptoPkg/Library/IntrinsicLib/IntrinsicLib.inf
+++ b/CryptoPkg/Library/IntrinsicLib/IntrinsicLib.inf
@@ -30,6 +30,8 @@
   Ia32/MathLShiftS64.c      | MSFT
   Ia32/MathRShiftU64.c      | MSFT
   Ia32/MathFtol.c           | MSFT
+  Ia32/MathLlmul.asm        | MSFT
+  Ia32/MathLlshr.asm        | MSFT
 
   Ia32/MathLShiftS64.c      | INTEL
   Ia32/MathRShiftU64.c      | INTEL

--- a/CryptoPkg/Library/OpensslLib/OpensslLib.inf
+++ b/CryptoPkg/Library/OpensslLib/OpensslLib.inf
@@ -199,43 +199,43 @@
   $(OPENSSL_PATH)/crypto/dso/dso_vms.c
   $(OPENSSL_PATH)/crypto/dso/dso_win32.c
   $(OPENSSL_PATH)/crypto/ebcdic.c
-  $(OPENSSL_PATH)/crypto/ec/curve25519.c
-  $(OPENSSL_PATH)/crypto/ec/curve448/arch_32/f_impl.c
-  $(OPENSSL_PATH)/crypto/ec/curve448/curve448.c
-  $(OPENSSL_PATH)/crypto/ec/curve448/curve448_tables.c
-  $(OPENSSL_PATH)/crypto/ec/curve448/eddsa.c
-  $(OPENSSL_PATH)/crypto/ec/curve448/f_generic.c
-  $(OPENSSL_PATH)/crypto/ec/curve448/scalar.c
-  $(OPENSSL_PATH)/crypto/ec/ec2_oct.c
-  $(OPENSSL_PATH)/crypto/ec/ec2_smpl.c
-  $(OPENSSL_PATH)/crypto/ec/ec_ameth.c
-  $(OPENSSL_PATH)/crypto/ec/ec_asn1.c
-  $(OPENSSL_PATH)/crypto/ec/ec_check.c
-  $(OPENSSL_PATH)/crypto/ec/ec_curve.c
-  $(OPENSSL_PATH)/crypto/ec/ec_cvt.c
-  $(OPENSSL_PATH)/crypto/ec/ec_err.c
-  $(OPENSSL_PATH)/crypto/ec/ec_key.c
-  $(OPENSSL_PATH)/crypto/ec/ec_kmeth.c
-  $(OPENSSL_PATH)/crypto/ec/ec_lib.c
-  $(OPENSSL_PATH)/crypto/ec/ec_mult.c
-  $(OPENSSL_PATH)/crypto/ec/ec_oct.c
-  $(OPENSSL_PATH)/crypto/ec/ec_pmeth.c
-  $(OPENSSL_PATH)/crypto/ec/ec_print.c
-  $(OPENSSL_PATH)/crypto/ec/ecdh_kdf.c
-  $(OPENSSL_PATH)/crypto/ec/ecdh_ossl.c
-  $(OPENSSL_PATH)/crypto/ec/ecdsa_ossl.c
-  $(OPENSSL_PATH)/crypto/ec/ecdsa_sign.c
-  $(OPENSSL_PATH)/crypto/ec/ecdsa_vrf.c
-  $(OPENSSL_PATH)/crypto/ec/eck_prn.c
-  $(OPENSSL_PATH)/crypto/ec/ecp_mont.c
-  $(OPENSSL_PATH)/crypto/ec/ecp_nist.c
-  $(OPENSSL_PATH)/crypto/ec/ecp_nistp224.c
-  $(OPENSSL_PATH)/crypto/ec/ecp_nistp256.c
-  $(OPENSSL_PATH)/crypto/ec/ecp_nistp521.c
-  $(OPENSSL_PATH)/crypto/ec/ecp_nistputil.c
-  $(OPENSSL_PATH)/crypto/ec/ecp_oct.c
-  $(OPENSSL_PATH)/crypto/ec/ecp_smpl.c
-  $(OPENSSL_PATH)/crypto/ec/ecx_meth.c
+  $(OPENSSL_PATH)/crypto/ec/curve25519.c      |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/curve448/arch_32/f_impl.c     |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/curve448/curve448.c     |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/curve448/curve448_tables.c      |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/curve448/eddsa.c      |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/curve448/f_generic.c      |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/curve448/scalar.c     |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/ec2_oct.c     |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/ec2_smpl.c      |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/ec_ameth.c      |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/ec_asn1.c     |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/ec_check.c      |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/ec_curve.c      |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/ec_cvt.c      |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/ec_err.c      |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/ec_key.c      |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/ec_kmeth.c      |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/ec_lib.c     |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/ec_mult.c     |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/ec_oct.c      |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/ec_pmeth.c      |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/ec_print.c      |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/ecdh_kdf.c      |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/ecdh_ossl.c     |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/ecdsa_ossl.c      |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/ecdsa_sign.c      |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/ecdsa_vrf.c     |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/eck_prn.c     |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/ecp_mont.c      |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/ecp_nist.c      |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/ecp_nistp224.c      |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/ecp_nistp256.c      |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/ecp_nistp521.c      |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/ecp_nistputil.c     |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/ecp_oct.c     |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/ecp_smpl.c      |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/ecx_meth.c      |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
   $(OPENSSL_PATH)/crypto/err/err.c
   $(OPENSSL_PATH)/crypto/err/err_prn.c
   $(OPENSSL_PATH)/crypto/evp/bio_b64.c
@@ -533,15 +533,15 @@
   $(OPENSSL_PATH)/crypto/conf/conf_local.h
   $(OPENSSL_PATH)/crypto/dh/dh_local.h
   $(OPENSSL_PATH)/crypto/dso/dso_local.h
-  $(OPENSSL_PATH)/crypto/ec/ec_local.h
-  $(OPENSSL_PATH)/crypto/ec/curve448/curve448_local.h
-  $(OPENSSL_PATH)/crypto/ec/curve448/curve448utils.h
-  $(OPENSSL_PATH)/crypto/ec/curve448/ed448.h
-  $(OPENSSL_PATH)/crypto/ec/curve448/field.h
-  $(OPENSSL_PATH)/crypto/ec/curve448/point_448.h
-  $(OPENSSL_PATH)/crypto/ec/curve448/word.h
-  $(OPENSSL_PATH)/crypto/ec/curve448/arch_32/arch_intrinsics.h
-  $(OPENSSL_PATH)/crypto/ec/curve448/arch_32/f_impl.h
+  $(OPENSSL_PATH)/crypto/ec/ec_local.h      |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/curve448/curve448_local.h     |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/curve448/curve448utils.h      |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/curve448/ed448.h      |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/curve448/field.h      |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/curve448/point_448.h      |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/curve448/word.h     |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/curve448/arch_32/arch_intrinsics.h      |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/curve448/arch_32/f_impl.h     |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
   $(OPENSSL_PATH)/crypto/evp/evp_local.h
   $(OPENSSL_PATH)/crypto/hmac/hmac_local.h
   $(OPENSSL_PATH)/crypto/lhash/lhash_local.h
@@ -632,6 +632,9 @@
 
 [LibraryClasses.ARM]
   ArmSoftFloatLib
+
+[Pcd]
+  gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled      ## CONSUMES
 
 [BuildOptions]
   #

--- a/CryptoPkg/Library/OpensslLib/OpensslLib.inf
+++ b/CryptoPkg/Library/OpensslLib/OpensslLib.inf
@@ -199,6 +199,43 @@
   $(OPENSSL_PATH)/crypto/dso/dso_vms.c
   $(OPENSSL_PATH)/crypto/dso/dso_win32.c
   $(OPENSSL_PATH)/crypto/ebcdic.c
+  $(OPENSSL_PATH)/crypto/ec/curve25519.c
+  $(OPENSSL_PATH)/crypto/ec/curve448/arch_32/f_impl.c
+  $(OPENSSL_PATH)/crypto/ec/curve448/curve448.c
+  $(OPENSSL_PATH)/crypto/ec/curve448/curve448_tables.c
+  $(OPENSSL_PATH)/crypto/ec/curve448/eddsa.c
+  $(OPENSSL_PATH)/crypto/ec/curve448/f_generic.c
+  $(OPENSSL_PATH)/crypto/ec/curve448/scalar.c
+  $(OPENSSL_PATH)/crypto/ec/ec2_oct.c
+  $(OPENSSL_PATH)/crypto/ec/ec2_smpl.c
+  $(OPENSSL_PATH)/crypto/ec/ec_ameth.c
+  $(OPENSSL_PATH)/crypto/ec/ec_asn1.c
+  $(OPENSSL_PATH)/crypto/ec/ec_check.c
+  $(OPENSSL_PATH)/crypto/ec/ec_curve.c
+  $(OPENSSL_PATH)/crypto/ec/ec_cvt.c
+  $(OPENSSL_PATH)/crypto/ec/ec_err.c
+  $(OPENSSL_PATH)/crypto/ec/ec_key.c
+  $(OPENSSL_PATH)/crypto/ec/ec_kmeth.c
+  $(OPENSSL_PATH)/crypto/ec/ec_lib.c
+  $(OPENSSL_PATH)/crypto/ec/ec_mult.c
+  $(OPENSSL_PATH)/crypto/ec/ec_oct.c
+  $(OPENSSL_PATH)/crypto/ec/ec_pmeth.c
+  $(OPENSSL_PATH)/crypto/ec/ec_print.c
+  $(OPENSSL_PATH)/crypto/ec/ecdh_kdf.c
+  $(OPENSSL_PATH)/crypto/ec/ecdh_ossl.c
+  $(OPENSSL_PATH)/crypto/ec/ecdsa_ossl.c
+  $(OPENSSL_PATH)/crypto/ec/ecdsa_sign.c
+  $(OPENSSL_PATH)/crypto/ec/ecdsa_vrf.c
+  $(OPENSSL_PATH)/crypto/ec/eck_prn.c
+  $(OPENSSL_PATH)/crypto/ec/ecp_mont.c
+  $(OPENSSL_PATH)/crypto/ec/ecp_nist.c
+  $(OPENSSL_PATH)/crypto/ec/ecp_nistp224.c
+  $(OPENSSL_PATH)/crypto/ec/ecp_nistp256.c
+  $(OPENSSL_PATH)/crypto/ec/ecp_nistp521.c
+  $(OPENSSL_PATH)/crypto/ec/ecp_nistputil.c
+  $(OPENSSL_PATH)/crypto/ec/ecp_oct.c
+  $(OPENSSL_PATH)/crypto/ec/ecp_smpl.c
+  $(OPENSSL_PATH)/crypto/ec/ecx_meth.c
   $(OPENSSL_PATH)/crypto/err/err.c
   $(OPENSSL_PATH)/crypto/err/err_prn.c
   $(OPENSSL_PATH)/crypto/evp/bio_b64.c
@@ -496,6 +533,15 @@
   $(OPENSSL_PATH)/crypto/conf/conf_local.h
   $(OPENSSL_PATH)/crypto/dh/dh_local.h
   $(OPENSSL_PATH)/crypto/dso/dso_local.h
+  $(OPENSSL_PATH)/crypto/ec/ec_local.h
+  $(OPENSSL_PATH)/crypto/ec/curve448/curve448_local.h
+  $(OPENSSL_PATH)/crypto/ec/curve448/curve448utils.h
+  $(OPENSSL_PATH)/crypto/ec/curve448/ed448.h
+  $(OPENSSL_PATH)/crypto/ec/curve448/field.h
+  $(OPENSSL_PATH)/crypto/ec/curve448/point_448.h
+  $(OPENSSL_PATH)/crypto/ec/curve448/word.h
+  $(OPENSSL_PATH)/crypto/ec/curve448/arch_32/arch_intrinsics.h
+  $(OPENSSL_PATH)/crypto/ec/curve448/arch_32/f_impl.h
   $(OPENSSL_PATH)/crypto/evp/evp_local.h
   $(OPENSSL_PATH)/crypto/hmac/hmac_local.h
   $(OPENSSL_PATH)/crypto/lhash/lhash_local.h

--- a/CryptoPkg/Library/OpensslLib/OpensslLibCrypto.inf
+++ b/CryptoPkg/Library/OpensslLib/OpensslLibCrypto.inf
@@ -199,43 +199,43 @@
   $(OPENSSL_PATH)/crypto/dso/dso_vms.c
   $(OPENSSL_PATH)/crypto/dso/dso_win32.c
   $(OPENSSL_PATH)/crypto/ebcdic.c
-  $(OPENSSL_PATH)/crypto/ec/curve25519.c
-  $(OPENSSL_PATH)/crypto/ec/curve448/arch_32/f_impl.c
-  $(OPENSSL_PATH)/crypto/ec/curve448/curve448.c
-  $(OPENSSL_PATH)/crypto/ec/curve448/curve448_tables.c
-  $(OPENSSL_PATH)/crypto/ec/curve448/eddsa.c
-  $(OPENSSL_PATH)/crypto/ec/curve448/f_generic.c
-  $(OPENSSL_PATH)/crypto/ec/curve448/scalar.c
-  $(OPENSSL_PATH)/crypto/ec/ec2_oct.c
-  $(OPENSSL_PATH)/crypto/ec/ec2_smpl.c
-  $(OPENSSL_PATH)/crypto/ec/ec_ameth.c
-  $(OPENSSL_PATH)/crypto/ec/ec_asn1.c
-  $(OPENSSL_PATH)/crypto/ec/ec_check.c
-  $(OPENSSL_PATH)/crypto/ec/ec_curve.c
-  $(OPENSSL_PATH)/crypto/ec/ec_cvt.c
-  $(OPENSSL_PATH)/crypto/ec/ec_err.c
-  $(OPENSSL_PATH)/crypto/ec/ec_key.c
-  $(OPENSSL_PATH)/crypto/ec/ec_kmeth.c
-  $(OPENSSL_PATH)/crypto/ec/ec_lib.c
-  $(OPENSSL_PATH)/crypto/ec/ec_mult.c
-  $(OPENSSL_PATH)/crypto/ec/ec_oct.c
-  $(OPENSSL_PATH)/crypto/ec/ec_pmeth.c
-  $(OPENSSL_PATH)/crypto/ec/ec_print.c
-  $(OPENSSL_PATH)/crypto/ec/ecdh_kdf.c
-  $(OPENSSL_PATH)/crypto/ec/ecdh_ossl.c
-  $(OPENSSL_PATH)/crypto/ec/ecdsa_ossl.c
-  $(OPENSSL_PATH)/crypto/ec/ecdsa_sign.c
-  $(OPENSSL_PATH)/crypto/ec/ecdsa_vrf.c
-  $(OPENSSL_PATH)/crypto/ec/eck_prn.c
-  $(OPENSSL_PATH)/crypto/ec/ecp_mont.c
-  $(OPENSSL_PATH)/crypto/ec/ecp_nist.c
-  $(OPENSSL_PATH)/crypto/ec/ecp_nistp224.c
-  $(OPENSSL_PATH)/crypto/ec/ecp_nistp256.c
-  $(OPENSSL_PATH)/crypto/ec/ecp_nistp521.c
-  $(OPENSSL_PATH)/crypto/ec/ecp_nistputil.c
-  $(OPENSSL_PATH)/crypto/ec/ecp_oct.c
-  $(OPENSSL_PATH)/crypto/ec/ecp_smpl.c
-  $(OPENSSL_PATH)/crypto/ec/ecx_meth.c
+  $(OPENSSL_PATH)/crypto/ec/curve25519.c    |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/curve448/arch_32/f_impl.c   |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/curve448/curve448.c   |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/curve448/curve448_tables.c    |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/curve448/eddsa.c    |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/curve448/f_generic.c    |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/curve448/scalar.c   |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/ec2_oct.c   |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/ec2_smpl.c    |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/ec_ameth.c    |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/ec_asn1.c   |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/ec_check.c    |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/ec_curve.c    |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/ec_cvt.c    |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/ec_err.c    |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/ec_key.c    |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/ec_kmeth.c    |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/ec_lib.c    |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/ec_mult.c   |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/ec_oct.c    |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/ec_pmeth.c    |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/ec_print.c    |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/ecdh_kdf.c    |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/ecdh_ossl.c   |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/ecdsa_ossl.c    |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/ecdsa_sign.c    |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/ecdsa_vrf.c   |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/eck_prn.c   |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/ecp_mont.c    |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/ecp_nist.c    |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/ecp_nistp224.c    |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/ecp_nistp256.c    |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/ecp_nistp521.c    |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/ecp_nistputil.c   |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/ecp_oct.c   |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/ecp_smpl.c    |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/ecx_meth.c    |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
   $(OPENSSL_PATH)/crypto/err/err.c
   $(OPENSSL_PATH)/crypto/err/err_prn.c
   $(OPENSSL_PATH)/crypto/evp/bio_b64.c
@@ -533,15 +533,15 @@
   $(OPENSSL_PATH)/crypto/conf/conf_local.h
   $(OPENSSL_PATH)/crypto/dh/dh_local.h
   $(OPENSSL_PATH)/crypto/dso/dso_local.h
-  $(OPENSSL_PATH)/crypto/ec/ec_local.h
-  $(OPENSSL_PATH)/crypto/ec/curve448/curve448_local.h
-  $(OPENSSL_PATH)/crypto/ec/curve448/curve448utils.h
-  $(OPENSSL_PATH)/crypto/ec/curve448/ed448.h
-  $(OPENSSL_PATH)/crypto/ec/curve448/field.h
-  $(OPENSSL_PATH)/crypto/ec/curve448/point_448.h
-  $(OPENSSL_PATH)/crypto/ec/curve448/word.h
-  $(OPENSSL_PATH)/crypto/ec/curve448/arch_32/arch_intrinsics.h
-  $(OPENSSL_PATH)/crypto/ec/curve448/arch_32/f_impl.h
+  $(OPENSSL_PATH)/crypto/ec/ec_local.h    |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/curve448/curve448_local.h   |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/curve448/curve448utils.h    |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/curve448/ed448.h    |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/curve448/field.h    |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/curve448/point_448.h    |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/curve448/word.h   |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/curve448/arch_32/arch_intrinsics.h    |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+  $(OPENSSL_PATH)/crypto/ec/curve448/arch_32/f_impl.h   |*|*|*|gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
   $(OPENSSL_PATH)/crypto/evp/evp_local.h
   $(OPENSSL_PATH)/crypto/hmac/hmac_local.h
   $(OPENSSL_PATH)/crypto/lhash/lhash_local.h
@@ -581,6 +581,9 @@
 
 [LibraryClasses.ARM]
   ArmSoftFloatLib
+
+[Pcd]
+  gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled      ## CONSUMES
 
 [BuildOptions]
   #

--- a/CryptoPkg/Library/OpensslLib/OpensslLibCrypto.inf
+++ b/CryptoPkg/Library/OpensslLib/OpensslLibCrypto.inf
@@ -199,6 +199,43 @@
   $(OPENSSL_PATH)/crypto/dso/dso_vms.c
   $(OPENSSL_PATH)/crypto/dso/dso_win32.c
   $(OPENSSL_PATH)/crypto/ebcdic.c
+  $(OPENSSL_PATH)/crypto/ec/curve25519.c
+  $(OPENSSL_PATH)/crypto/ec/curve448/arch_32/f_impl.c
+  $(OPENSSL_PATH)/crypto/ec/curve448/curve448.c
+  $(OPENSSL_PATH)/crypto/ec/curve448/curve448_tables.c
+  $(OPENSSL_PATH)/crypto/ec/curve448/eddsa.c
+  $(OPENSSL_PATH)/crypto/ec/curve448/f_generic.c
+  $(OPENSSL_PATH)/crypto/ec/curve448/scalar.c
+  $(OPENSSL_PATH)/crypto/ec/ec2_oct.c
+  $(OPENSSL_PATH)/crypto/ec/ec2_smpl.c
+  $(OPENSSL_PATH)/crypto/ec/ec_ameth.c
+  $(OPENSSL_PATH)/crypto/ec/ec_asn1.c
+  $(OPENSSL_PATH)/crypto/ec/ec_check.c
+  $(OPENSSL_PATH)/crypto/ec/ec_curve.c
+  $(OPENSSL_PATH)/crypto/ec/ec_cvt.c
+  $(OPENSSL_PATH)/crypto/ec/ec_err.c
+  $(OPENSSL_PATH)/crypto/ec/ec_key.c
+  $(OPENSSL_PATH)/crypto/ec/ec_kmeth.c
+  $(OPENSSL_PATH)/crypto/ec/ec_lib.c
+  $(OPENSSL_PATH)/crypto/ec/ec_mult.c
+  $(OPENSSL_PATH)/crypto/ec/ec_oct.c
+  $(OPENSSL_PATH)/crypto/ec/ec_pmeth.c
+  $(OPENSSL_PATH)/crypto/ec/ec_print.c
+  $(OPENSSL_PATH)/crypto/ec/ecdh_kdf.c
+  $(OPENSSL_PATH)/crypto/ec/ecdh_ossl.c
+  $(OPENSSL_PATH)/crypto/ec/ecdsa_ossl.c
+  $(OPENSSL_PATH)/crypto/ec/ecdsa_sign.c
+  $(OPENSSL_PATH)/crypto/ec/ecdsa_vrf.c
+  $(OPENSSL_PATH)/crypto/ec/eck_prn.c
+  $(OPENSSL_PATH)/crypto/ec/ecp_mont.c
+  $(OPENSSL_PATH)/crypto/ec/ecp_nist.c
+  $(OPENSSL_PATH)/crypto/ec/ecp_nistp224.c
+  $(OPENSSL_PATH)/crypto/ec/ecp_nistp256.c
+  $(OPENSSL_PATH)/crypto/ec/ecp_nistp521.c
+  $(OPENSSL_PATH)/crypto/ec/ecp_nistputil.c
+  $(OPENSSL_PATH)/crypto/ec/ecp_oct.c
+  $(OPENSSL_PATH)/crypto/ec/ecp_smpl.c
+  $(OPENSSL_PATH)/crypto/ec/ecx_meth.c
   $(OPENSSL_PATH)/crypto/err/err.c
   $(OPENSSL_PATH)/crypto/err/err_prn.c
   $(OPENSSL_PATH)/crypto/evp/bio_b64.c
@@ -496,6 +533,15 @@
   $(OPENSSL_PATH)/crypto/conf/conf_local.h
   $(OPENSSL_PATH)/crypto/dh/dh_local.h
   $(OPENSSL_PATH)/crypto/dso/dso_local.h
+  $(OPENSSL_PATH)/crypto/ec/ec_local.h
+  $(OPENSSL_PATH)/crypto/ec/curve448/curve448_local.h
+  $(OPENSSL_PATH)/crypto/ec/curve448/curve448utils.h
+  $(OPENSSL_PATH)/crypto/ec/curve448/ed448.h
+  $(OPENSSL_PATH)/crypto/ec/curve448/field.h
+  $(OPENSSL_PATH)/crypto/ec/curve448/point_448.h
+  $(OPENSSL_PATH)/crypto/ec/curve448/word.h
+  $(OPENSSL_PATH)/crypto/ec/curve448/arch_32/arch_intrinsics.h
+  $(OPENSSL_PATH)/crypto/ec/curve448/arch_32/f_impl.h
   $(OPENSSL_PATH)/crypto/evp/evp_local.h
   $(OPENSSL_PATH)/crypto/hmac/hmac_local.h
   $(OPENSSL_PATH)/crypto/lhash/lhash_local.h

--- a/CryptoPkg/Library/OpensslLib/process_files.pl
+++ b/CryptoPkg/Library/OpensslLib/process_files.pl
@@ -169,7 +169,6 @@ BEGIN {
                 "no-dgram",
                 "no-dsa",
                 "no-dynamic-engine",
-                "no-ec",
                 "no-ec2m",
                 "no-engine",
                 "no-err",


### PR DESCRIPTION

EDK2 has Enabled a feature which allow SOURCE section in INF files to
use Pcd to customize source files list. If Pcd equal to FALSE, this 
file will not be compiled.
https://github.com/tianocore/edk2/commit/
bf9230a9f3dde065c3c8b4175ccd32e44e8f0362
The patches add a customizable EC feature to CryptoPkg by this feature.

If Pcd equal to FALSE(Diabled), the binary size will not be changed.

Size diff(Bytes):
         | CryptDxe.efi | CryptPei.efi | CryptSmm.efi |
Before   |   815,616    |   540,544    |   563,712    |
Diabled  |   815,616    |   540,544    |   563,712    |
Enabled  |   1,008,352  |   721,408    |   744,832    |

Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Jian J Wang <jian.j.wang@intel.com>
Signed-off-by: yi1 li <yi1.li@intel.com>
Reviewed-by: Jiewen Yao <jiewen.yao@intel.com>

yi1 li (3):
  CryptoPkg: Add instrinsics to support building ECC on IA32 windows
  CryptoPkg: Reconfigure OpensslLib to add EC algorithms
  CryptoPkg: Make EC source file config-able

 CryptoPkg/CryptoPkg.dec                       |  4 +
 .../Library/Include/openssl/opensslconf.h     | 10 +-
 .../Library/IntrinsicLib/Ia32/MathLlmul.asm   | 98 +++++++++++++++++++
 .../Library/IntrinsicLib/Ia32/MathLlshr.asm   | 78 +++++++++++++++
 .../Library/IntrinsicLib/IntrinsicLib.inf     |  2 +
 CryptoPkg/Library/OpensslLib/OpensslLib.inf   | 50 ++++++++++
 .../Library/OpensslLib/OpensslLibCrypto.inf   | 50 ++++++++++
 CryptoPkg/Library/OpensslLib/process_files.pl |  2 +-
 8 files changed, 289 insertions(+), 5 deletions(-)
 create mode 100644 CryptoPkg/Library/IntrinsicLib/Ia32/MathLlmul.asm
 create mode 100644 CryptoPkg/Library/IntrinsicLib/Ia32/MathLlshr.asm
