### PR TITLE
CryptoPkg/TlsLibNull: Remove MU_CHANGE comment markers

### DIFF
--- a/CryptoPkg/Library/TlsLibNull/TlsConfigNull.c
+++ b/CryptoPkg/Library/TlsLibNull/TlsConfigNull.c
@@ -130,8 +130,6 @@ TlsSetVerify (
   ASSERT (FALSE);
 }
 
-// MU_CHANGE - Proposed fixes for TCBZ960, invalid domain name (CN) accepted. [BEGIN]
-
 /**
   Set the specified host name to be verified.
 
@@ -155,8 +153,6 @@ TlsSetVerifyHost (
   ASSERT (FALSE);
   return EFI_UNSUPPORTED;
 }
-
-// MU_CHANGE - Proposed fixes for TCBZ960, invalid domain name (CN) accepted. [END]
 
 /**
   Sets a TLS/SSL session ID to be used during TLS/SSL connect.


### PR DESCRIPTION
MU_CHANGE tags are used in a different project (Project Mu) to
highlight deviations from Tianocore. Therefore, the comments are
not needed when the changes are present in a Tianocore repository.

Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Xiaoyu Lu <xiaoyu1.lu@intel.com>
Cc: Guomin Jiang <guomin.jiang@intel.com>
Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>
Reviewed-by: Jiewen Yao <jiewen.yao@intel.com>