### PR TITLE
BaseTools: Move gPlatformFinalPcd to Datapipe and optimize size

### DIFF
--- a/BaseTools/Source/Python/AutoGen/AutoGenWorker.py
+++ b/BaseTools/Source/Python/AutoGen/AutoGenWorker.py
@@ -216,6 +216,7 @@ class AutoGenWorkerInProcess(mp.Process):
             GlobalData.gModuleHashFile = dict()
             GlobalData.gFileHashDict = dict()
             GlobalData.gEnableGenfdsMultiThread = self.data_pipe.Get("EnableGenfdsMultiThread")
+            GlobalData.gPlatformFinalPcds = self.data_pipe.Get("gPlatformFinalPcds")
             GlobalData.file_lock = self.file_lock
             CommandTarget = self.data_pipe.Get("CommandTarget")
             pcd_from_build_option = []

--- a/BaseTools/Source/Python/AutoGen/DataPipe.py
+++ b/BaseTools/Source/Python/AutoGen/DataPipe.py
@@ -169,3 +169,5 @@ class MemoryDataPipe(DataPipe):
         self.DataContainer = {"BinCacheDest":GlobalData.gBinCacheDest}
 
         self.DataContainer = {"EnableGenfdsMultiThread":GlobalData.gEnableGenfdsMultiThread}
+
+        self.DataContainer = {"gPlatformFinalPcds":GlobalData.gPlatformFinalPcds}

--- a/BaseTools/Source/Python/Workspace/DscBuildData.py
+++ b/BaseTools/Source/Python/Workspace/DscBuildData.py
@@ -976,6 +976,7 @@ class DscBuildData(PlatformBuildClassObject):
         if (TokenSpaceGuid + '.' + PcdCName) in GlobalData.gPlatformPcds:
             if GlobalData.gPlatformPcds[TokenSpaceGuid + '.' + PcdCName] != ValueList[Index]:
                 GlobalData.gPlatformPcds[TokenSpaceGuid + '.' + PcdCName] = ValueList[Index]
+            GlobalData.gPlatformFinalPcds[TokenSpaceGuid + '.' + PcdCName] = ValueList[Index]
         return ValueList
 
     def _FilterPcdBySkuUsage(self, Pcds):

--- a/BaseTools/Source/Python/Workspace/InfBuildData.py
+++ b/BaseTools/Source/Python/Workspace/InfBuildData.py
@@ -1054,17 +1054,20 @@ class InfBuildData(ModuleBuildClassObject):
             return True
         return False
     def CheckFeatureFlagPcd(self,Instance):
-        Pcds = {}
-        if GlobalData.gPlatformFinalPcds.get(self.Arch):
-            Pcds = GlobalData.gPlatformFinalPcds[self.Arch].copy()
+        Pcds = GlobalData.gPlatformFinalPcds.copy()
         if PcdPattern.search(Instance):
             PcdTuple = tuple(Instance.split('.')[::-1])
             if PcdTuple in self.Pcds:
-                if not (self.Pcds[PcdTuple].Type == 'FeatureFlag' or self.Pcds[PcdTuple].Type == 'FixedAtBuild') and Instance not in Pcds:
+                if not (self.Pcds[PcdTuple].Type == 'FeatureFlag' or self.Pcds[PcdTuple].Type == 'FixedAtBuild'):
                     EdkLogger.error('build', FORMAT_INVALID,
-                                    "\nit must be defined in a [PcdsFeatureFlag] or [PcdsFixedAtBuild] section of Dsc or Dec file or [FeaturePcd] or [FixedPcd] of Inf file",
+                                    "\nFeatureFlagPcd must be defined in a [PcdsFeatureFlag] or [PcdsFixedAtBuild] section of Dsc or Dec file",
                                     File=str(self), ExtraData=Instance)
-                Pcds[Instance] = self.Pcds[PcdTuple].DefaultValue
+                if not Instance in Pcds:
+                    Pcds[Instance] = self.Pcds[PcdTuple].DefaultValue
+            else: #if PcdTuple not in self.Pcds:
+                EdkLogger.error('build', FORMAT_INVALID,
+                                "\nFeatureFlagPcd must be defined in [FeaturePcd] or [FixedPcd] of Inf file",
+                                File=str(self), ExtraData=Instance)
             if Instance in Pcds:
                 if Pcds[Instance] == '0':
                     return False

--- a/BaseTools/Source/Python/Workspace/WorkspaceCommon.py
+++ b/BaseTools/Source/Python/Workspace/WorkspaceCommon.py
@@ -75,11 +75,6 @@ def GetDeclaredPcd(Platform, BuildDatabase, Arch, Target, Toolchain, additionalP
                         break
             if (PcdCName, PcdTokenName) not in DecPcds:
                 DecPcds[PcdCName, PcdTokenName] = Pkg.Pcds[Pcd]
-    if not GlobalData.gPlatformFinalPcds.get(Arch):
-        GlobalData.gPlatformFinalPcds[Arch] = OrderedDict()
-    for Name,Guid in DecPcds:
-        if DecPcds[Name,Guid].Type == 'FeatureFlag' or DecPcds[Name, Guid].Type == 'FixedAtBuild':
-            GlobalData.gPlatformFinalPcds[Arch]['%s.%s'%(Guid, Name)]=DecPcds[Name, Guid].DefaultValue
     return DecPcds, GuidDict
 
 ## Get all dependent libraries for a module


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3828

This is a bugfix of
bf9230a9f3dde065c3c8b4175ccd32e44e8f0362.

1.In the current code, gPlatformFinalPcd will save all PCDs used at
whole compile process, which wastes runtime memory and is unnecessary.

This patch makes gPlatformFinalPcd save only the PCDes which are
assigned in the DSC file, and the PCD that has not been assigned will
use the default value in DEC.

2.During the compilation process, gPlatformFinalPcd may be lost, and
the current code cannot selectively assign PCD in DSC by specifying ARCH.

This patch moves gPlatformFinalPcd into datapipe to fix this.

Cc: Bob Feng <bob.c.feng@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>

Signed-off-by: yi1 li <yi1.li@intel.com>