### PR TITLE
Introduce CcProbe in MdePkg

### DIFF
--- a/MdePkg/Include/ConfidentialComputingGuestAttr.h
+++ b/MdePkg/Include/ConfidentialComputingGuestAttr.h
@@ -1,5 +1,5 @@
 /** @file
-Definitions for Confidential Computing Attribute
+Definitions for Confidential Computing Guest Attributes
 
 Copyright (c) 2021 AMD Inc. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -8,6 +8,15 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #ifndef CONFIDENTIAL_COMPUTING_GUEST_ATTR_H_
 #define CONFIDENTIAL_COMPUTING_GUEST_ATTR_H_
+
+//
+// Confidential computing guest type
+//
+typedef enum {
+  CcGuestTypeNonEncrypted = 0,
+  CcGuestTypeAmdSev,
+  CcGuestTypeIntelTdx,
+} CC_GUEST_TYPE;
 
 typedef enum {
   /* The guest is running with memory encryption disabled. */

--- a/MdePkg/Include/Library/CcProbeLib.h
+++ b/MdePkg/Include/Library/CcProbeLib.h
@@ -1,0 +1,26 @@
+/** @file
+
+Copyright (c) 2022, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef CC_PROBE_LIB_H_
+#define CC_PROBE_LIB_H_
+
+#include <ConfidentialComputingGuestAttr.h>
+
+/**
+  Probe the ConfidentialComputing Guest type. See defition of
+  CC_GUEST_TYPE in <ConfidentialComputingGuestAttr.h>.
+
+  @return The guest type
+
+**/
+UINT8
+EFIAPI
+CcProbe (
+  VOID
+  );
+
+#endif

--- a/MdePkg/Library/BaseIoLibIntrinsic/BaseIoLibIntrinsicSev.inf
+++ b/MdePkg/Library/BaseIoLibIntrinsic/BaseIoLibIntrinsicSev.inf
@@ -55,6 +55,7 @@
   DebugLib
   BaseLib
   RegisterFilterLib
+  CcProbeLib
 
 [LibraryClasses.X64]
   TdxLib

--- a/MdePkg/Library/BaseIoLibIntrinsic/IoLibInternalTdx.c
+++ b/MdePkg/Library/BaseIoLibIntrinsic/IoLibInternalTdx.c
@@ -10,6 +10,7 @@
 #include <Include/IndustryStandard/Tdx.h>
 #include <Library/TdxLib.h>
 #include <Register/Intel/Cpuid.h>
+#include <Library/CcProbeLib.h>
 #include "IoLibTdx.h"
 
 // Size of TDVMCALL Access, including IO and MMIO
@@ -21,9 +22,6 @@
 // Direction of TDVMCALL Access, including IO and MMIO
 #define TDVMCALL_ACCESS_READ   0
 #define TDVMCALL_ACCESS_WRITE  1
-
-BOOLEAN  mTdxEnabled = FALSE;
-BOOLEAN  mTdxProbed  = FALSE;
 
 /**
   Check if it is Tdx guest.
@@ -38,14 +36,7 @@ IsTdxGuest (
   VOID
   )
 {
-  if (mTdxProbed) {
-    return mTdxEnabled;
-  }
-
-  mTdxEnabled = TdIsEnabled ();
-  mTdxProbed  = TRUE;
-
-  return mTdxEnabled;
+  return CcProbe () == CcGuestTypeIntelTdx;
 }
 
 /**

--- a/MdePkg/Library/CcProbeLibNull/CcProbeLibNull.c
+++ b/MdePkg/Library/CcProbeLibNull/CcProbeLibNull.c
@@ -1,0 +1,26 @@
+/** @file
+
+  Null stub of CcProbeLib
+
+  Copyright (c) 2022, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Library/CcProbeLib.h>
+
+/**
+  Probe the ConfidentialComputing Guest type. See defition of
+  CC_GUEST_TYPE in <ConfidentialComputingGuestAttr.h>.
+
+  @return The guest type
+
+**/
+UINT8
+EFIAPI
+CcProbe (
+  VOID
+  )
+{
+  return CcGuestTypeNonEncrypted;
+}

--- a/MdePkg/Library/CcProbeLibNull/CcProbeLibNull.inf
+++ b/MdePkg/Library/CcProbeLibNull/CcProbeLibNull.inf
@@ -1,0 +1,21 @@
+## @file
+# CcProbeLib null instance.
+#
+#  Copyright (c) 2022, Intel Corporation. All rights reserved.<BR>
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = CcProbeLibNull
+  FILE_GUID                      = B15D67FE-0DAC-4316-8E26-8A6b85E43782
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = CcProbeLib
+
+[Sources]
+  CcProbeLibNull.c
+
+[Packages]
+  MdePkg/MdePkg.dec

--- a/MdePkg/MdePkg.dec
+++ b/MdePkg/MdePkg.dec
@@ -267,6 +267,11 @@
   #
   RegisterFilterLib|Include/Library/RegisterFilterLib.h
 
+  ##  @libraryclass  This library provides interfances to probe ConfidentialComputing guest type.
+  #
+  #
+  CcProbeLib|Include/Library/CcProbeLib.h
+
 [LibraryClasses.IA32, LibraryClasses.X64, LibraryClasses.AARCH64]
   ##  @libraryclass  Provides services to generate random number.
   #

--- a/MdePkg/MdePkg.dsc
+++ b/MdePkg/MdePkg.dsc
@@ -130,6 +130,7 @@
   MdePkg/Library/StandaloneMmServicesTableLib/StandaloneMmServicesTableLib.inf
 
   MdePkg/Library/RegisterFilterLibNull/RegisterFilterLibNull.inf
+  MdePkg/Library/CcProbeLibNull/CcProbeLibNull.inf
 
 [Components.IA32, Components.X64, Components.ARM, Components.AARCH64]
   #

--- a/OvmfPkg/AmdSev/AmdSevX64.dsc
+++ b/OvmfPkg/AmdSev/AmdSevX64.dsc
@@ -149,6 +149,7 @@
   PciCapLib|OvmfPkg/Library/BasePciCapLib/BasePciCapLib.inf
   PciCapPciSegmentLib|OvmfPkg/Library/BasePciCapPciSegmentLib/BasePciCapPciSegmentLib.inf
   PciCapPciIoLib|OvmfPkg/Library/UefiPciCapPciIoLib/UefiPciCapPciIoLib.inf
+  CcProbeLib|MdePkg/Library/CcProbeLibNull/CcProbeLibNull.inf
   IoLib|MdePkg/Library/BaseIoLibIntrinsic/BaseIoLibIntrinsicSev.inf
   OemHookStatusCodeLib|MdeModulePkg/Library/OemHookStatusCodeLibNull/OemHookStatusCodeLibNull.inf
   SerialPortLib|PcAtChipsetPkg/Library/SerialIoLib/SerialIoLib.inf

--- a/OvmfPkg/Bhyve/BhyveX64.dsc
+++ b/OvmfPkg/Bhyve/BhyveX64.dsc
@@ -146,6 +146,7 @@
   PciCapLib|OvmfPkg/Library/BasePciCapLib/BasePciCapLib.inf
   PciCapPciSegmentLib|OvmfPkg/Library/BasePciCapPciSegmentLib/BasePciCapPciSegmentLib.inf
   PciCapPciIoLib|OvmfPkg/Library/UefiPciCapPciIoLib/UefiPciCapPciIoLib.inf
+  CcProbeLib|MdePkg/Library/CcProbeLibNull/CcProbeLibNull.inf
   IoLib|MdePkg/Library/BaseIoLibIntrinsic/BaseIoLibIntrinsicSev.inf
   OemHookStatusCodeLib|MdeModulePkg/Library/OemHookStatusCodeLibNull/OemHookStatusCodeLibNull.inf
   SerialPortLib|PcAtChipsetPkg/Library/SerialIoLib/SerialIoLib.inf

--- a/OvmfPkg/CloudHv/CloudHvX64.dsc
+++ b/OvmfPkg/CloudHv/CloudHvX64.dsc
@@ -158,6 +158,7 @@
   PciCapLib|OvmfPkg/Library/BasePciCapLib/BasePciCapLib.inf
   PciCapPciSegmentLib|OvmfPkg/Library/BasePciCapPciSegmentLib/BasePciCapPciSegmentLib.inf
   PciCapPciIoLib|OvmfPkg/Library/UefiPciCapPciIoLib/UefiPciCapPciIoLib.inf
+  CcProbeLib|MdePkg/Library/CcProbeLibNull/CcProbeLibNull.inf
   IoLib|MdePkg/Library/BaseIoLibIntrinsic/BaseIoLibIntrinsicSev.inf
   OemHookStatusCodeLib|MdeModulePkg/Library/OemHookStatusCodeLibNull/OemHookStatusCodeLibNull.inf
   SerialPortLib|PcAtChipsetPkg/Library/SerialIoLib/SerialIoLib.inf

--- a/OvmfPkg/Include/WorkArea.h
+++ b/OvmfPkg/Include/WorkArea.h
@@ -10,14 +10,7 @@
 #ifndef __OVMF_WORK_AREA_H__
 #define __OVMF_WORK_AREA_H__
 
-//
-// Guest type for the work area
-//
-typedef enum {
-  GUEST_TYPE_NON_ENCRYPTED,
-  GUEST_TYPE_AMD_SEV,
-  GUEST_TYPE_INTEL_TDX,
-} GUEST_TYPE;
+#include <ConfidentialComputingGuestAttr.h>
 
 //
 // Confidential computing work area header definition. Any change

--- a/OvmfPkg/IntelTdx/IntelTdxX64.dsc
+++ b/OvmfPkg/IntelTdx/IntelTdxX64.dsc
@@ -135,6 +135,7 @@
   PciCapLib|OvmfPkg/Library/BasePciCapLib/BasePciCapLib.inf
   PciCapPciSegmentLib|OvmfPkg/Library/BasePciCapPciSegmentLib/BasePciCapPciSegmentLib.inf
   PciCapPciIoLib|OvmfPkg/Library/UefiPciCapPciIoLib/UefiPciCapPciIoLib.inf
+  CcProbeLib|OvmfPkg/Library/CcProbeLib/CcProbeLib.inf
   IoLib|MdePkg/Library/BaseIoLibIntrinsic/BaseIoLibIntrinsicSev.inf
   OemHookStatusCodeLib|MdeModulePkg/Library/OemHookStatusCodeLibNull/OemHookStatusCodeLibNull.inf
   SerialPortLib|PcAtChipsetPkg/Library/SerialIoLib/SerialIoLib.inf

--- a/OvmfPkg/IntelTdx/Sec/SecMain.c
+++ b/OvmfPkg/IntelTdx/Sec/SecMain.c
@@ -25,7 +25,7 @@
 #include <Library/CpuExceptionHandlerLib.h>
 #include <IndustryStandard/Tdx.h>
 #include <Library/PlatformInitLib.h>
-
+#include <Library/CcProbeLib.h>
 #include <Library/PeilessStartupLib.h>
 
 #define SEC_IDT_ENTRY_COUNT  34
@@ -61,7 +61,7 @@ SecCoreStartupWithStack (
   UINT32                Index;
   volatile UINT8        *Table;
 
-  if (TdIsEnabled ()) {
+  if (CcProbe () == CcGuestTypeIntelTdx) {
     //
     // For Td guests, the memory map info is in TdHobLib. It should be processed
     // first so that the memory is accepted. Otherwise access to the unaccepted
@@ -119,7 +119,7 @@ SecCoreStartupWithStack (
   //
   AsmWriteIdtr (&IdtDescriptor);
 
-  if (TdIsEnabled ()) {
+  if (CcProbe () == CcGuestTypeIntelTdx) {
     //
     // InitializeCpuExceptionHandlers () should be called in Td guests so that
     // #VE exceptions can be handled correctly.

--- a/OvmfPkg/IntelTdx/Sec/SecMain.inf
+++ b/OvmfPkg/IntelTdx/Sec/SecMain.inf
@@ -49,6 +49,7 @@
   CpuExceptionHandlerLib
   PeilessStartupLib
   PlatformInitLib
+  CcProbeLib
 
 [Pcd]
   gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSecPageTablesBase

--- a/OvmfPkg/Library/BaseMemEncryptSevLib/PeiMemEncryptSevLibInternal.c
+++ b/OvmfPkg/Library/BaseMemEncryptSevLib/PeiMemEncryptSevLibInternal.c
@@ -36,7 +36,7 @@ GetSevEsWorkArea (
   //
   // If its not SEV guest then SevEsWorkArea is not valid.
   //
-  if ((WorkArea == NULL) || (WorkArea->Header.GuestType != GUEST_TYPE_AMD_SEV)) {
+  if ((WorkArea == NULL) || (WorkArea->Header.GuestType != CcGuestTypeAmdSev)) {
     return NULL;
   }
 

--- a/OvmfPkg/Library/BaseMemEncryptSevLib/SecMemEncryptSevLibInternal.c
+++ b/OvmfPkg/Library/BaseMemEncryptSevLib/SecMemEncryptSevLibInternal.c
@@ -36,7 +36,7 @@ GetSevEsWorkArea (
   //
   // If its not SEV guest then SevEsWorkArea is not valid.
   //
-  if ((WorkArea == NULL) || (WorkArea->Header.GuestType != GUEST_TYPE_AMD_SEV)) {
+  if ((WorkArea == NULL) || (WorkArea->Header.GuestType != CcGuestTypeAmdSev)) {
     return NULL;
   }
 

--- a/OvmfPkg/Library/CcProbeLib/CcProbeLib.c
+++ b/OvmfPkg/Library/CcProbeLib/CcProbeLib.c
@@ -1,0 +1,31 @@
+/** @file
+
+  CcProbeLib is used to probe the Confidential computing guest type.
+
+  Copyright (c) 2022, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Library/CcProbeLib.h>
+#include <WorkArea.h>
+
+/**
+  Probe the ConfidentialComputing Guest type. See defition of
+  CC_GUEST_TYPE in <ConfidentialComputingGuestAttr.h>.
+
+  @return The guest type
+
+**/
+UINT8
+EFIAPI
+CcProbe (
+  VOID
+  )
+{
+  OVMF_WORK_AREA  *WorkArea;
+
+  WorkArea = (OVMF_WORK_AREA *)FixedPcdGet32 (PcdOvmfWorkAreaBase);
+
+  return WorkArea != NULL ? WorkArea->Header.GuestType : CcGuestTypeNonEncrypted;
+}

--- a/OvmfPkg/Library/CcProbeLib/CcProbeLib.inf
+++ b/OvmfPkg/Library/CcProbeLib/CcProbeLib.inf
@@ -1,0 +1,25 @@
+## @file
+# CcProbeLib is used to probe Confidential Computing guest type.
+#
+#  Copyright (c) 2022, Intel Corporation. All rights reserved.<BR>
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = CcProbeLib
+  FILE_GUID                      = 05184ec9-abb0-4491-8584-e388639a7c48
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = CcProbeLib
+
+[Sources]
+  CcProbeLib.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  OvmfPkg/OvmfPkg.dec
+
+[Pcd]
+  gUefiOvmfPkgTokenSpaceGuid.PcdOvmfWorkAreaBase

--- a/OvmfPkg/Library/QemuFwCfgLib/QemuFwCfgPei.c
+++ b/OvmfPkg/Library/QemuFwCfgLib/QemuFwCfgPei.c
@@ -35,7 +35,7 @@ QemuFwCfgIsTdxGuest (
   CONFIDENTIAL_COMPUTING_WORK_AREA_HEADER  *CcWorkAreaHeader;
 
   CcWorkAreaHeader = (CONFIDENTIAL_COMPUTING_WORK_AREA_HEADER *)FixedPcdGet32 (PcdOvmfWorkAreaBase);
-  return (CcWorkAreaHeader != NULL && CcWorkAreaHeader->GuestType == GUEST_TYPE_INTEL_TDX);
+  return (CcWorkAreaHeader != NULL && CcWorkAreaHeader->GuestType == CcGuestTypeIntelTdx);
 }
 
 /**

--- a/OvmfPkg/Microvm/MicrovmX64.dsc
+++ b/OvmfPkg/Microvm/MicrovmX64.dsc
@@ -156,6 +156,7 @@
   PciCapLib|OvmfPkg/Library/BasePciCapLib/BasePciCapLib.inf
   PciCapPciSegmentLib|OvmfPkg/Library/BasePciCapPciSegmentLib/BasePciCapPciSegmentLib.inf
   PciCapPciIoLib|OvmfPkg/Library/UefiPciCapPciIoLib/UefiPciCapPciIoLib.inf
+  CcProbeLib|MdePkg/Library/CcProbeLibNull/CcProbeLibNull.inf
   IoLib|MdePkg/Library/BaseIoLibIntrinsic/BaseIoLibIntrinsicSev.inf
   OemHookStatusCodeLib|MdeModulePkg/Library/OemHookStatusCodeLibNull/OemHookStatusCodeLibNull.inf
   SerialPortLib|PcAtChipsetPkg/Library/SerialIoLib/SerialIoLib.inf

--- a/OvmfPkg/OvmfPkgIa32.dsc
+++ b/OvmfPkg/OvmfPkgIa32.dsc
@@ -154,6 +154,7 @@
   PciCapLib|OvmfPkg/Library/BasePciCapLib/BasePciCapLib.inf
   PciCapPciSegmentLib|OvmfPkg/Library/BasePciCapPciSegmentLib/BasePciCapPciSegmentLib.inf
   PciCapPciIoLib|OvmfPkg/Library/UefiPciCapPciIoLib/UefiPciCapPciIoLib.inf
+  CcProbeLib|MdePkg/Library/CcProbeLibNull/CcProbeLibNull.inf
   IoLib|MdePkg/Library/BaseIoLibIntrinsic/BaseIoLibIntrinsicSev.inf
   OemHookStatusCodeLib|MdeModulePkg/Library/OemHookStatusCodeLibNull/OemHookStatusCodeLibNull.inf
   SerialPortLib|PcAtChipsetPkg/Library/SerialIoLib/SerialIoLib.inf

--- a/OvmfPkg/OvmfPkgIa32X64.dsc
+++ b/OvmfPkg/OvmfPkgIa32X64.dsc
@@ -158,6 +158,7 @@
   PciCapLib|OvmfPkg/Library/BasePciCapLib/BasePciCapLib.inf
   PciCapPciSegmentLib|OvmfPkg/Library/BasePciCapPciSegmentLib/BasePciCapPciSegmentLib.inf
   PciCapPciIoLib|OvmfPkg/Library/UefiPciCapPciIoLib/UefiPciCapPciIoLib.inf
+  CcProbeLib|MdePkg/Library/CcProbeLibNull/CcProbeLibNull.inf
   IoLib|MdePkg/Library/BaseIoLibIntrinsic/BaseIoLibIntrinsicSev.inf
   OemHookStatusCodeLib|MdeModulePkg/Library/OemHookStatusCodeLibNull/OemHookStatusCodeLibNull.inf
   SerialPortLib|PcAtChipsetPkg/Library/SerialIoLib/SerialIoLib.inf

--- a/OvmfPkg/OvmfPkgX64.dsc
+++ b/OvmfPkg/OvmfPkgX64.dsc
@@ -165,6 +165,7 @@
   PciCapLib|OvmfPkg/Library/BasePciCapLib/BasePciCapLib.inf
   PciCapPciSegmentLib|OvmfPkg/Library/BasePciCapPciSegmentLib/BasePciCapPciSegmentLib.inf
   PciCapPciIoLib|OvmfPkg/Library/UefiPciCapPciIoLib/UefiPciCapPciIoLib.inf
+  CcProbeLib|OvmfPkg/Library/CcProbeLib/CcProbeLib.inf
   IoLib|MdePkg/Library/BaseIoLibIntrinsic/BaseIoLibIntrinsicSev.inf
   OemHookStatusCodeLib|MdeModulePkg/Library/OemHookStatusCodeLibNull/OemHookStatusCodeLibNull.inf
   SerialPortLib|PcAtChipsetPkg/Library/SerialIoLib/SerialIoLib.inf

--- a/OvmfPkg/OvmfXen.dsc
+++ b/OvmfPkg/OvmfXen.dsc
@@ -147,6 +147,7 @@
   PciCapLib|OvmfPkg/Library/BasePciCapLib/BasePciCapLib.inf
   PciCapPciSegmentLib|OvmfPkg/Library/BasePciCapPciSegmentLib/BasePciCapPciSegmentLib.inf
   PciCapPciIoLib|OvmfPkg/Library/UefiPciCapPciIoLib/UefiPciCapPciIoLib.inf
+  CcProbeLib|MdePkg/Library/CcProbeLibNull/CcProbeLibNull.inf
   IoLib|MdePkg/Library/BaseIoLibIntrinsic/BaseIoLibIntrinsicSev.inf
   OemHookStatusCodeLib|MdeModulePkg/Library/OemHookStatusCodeLibNull/OemHookStatusCodeLibNull.inf
   SerialPortLib|PcAtChipsetPkg/Library/SerialIoLib/SerialIoLib.inf

--- a/OvmfPkg/Sec/AmdSev.c
+++ b/OvmfPkg/Sec/AmdSev.c
@@ -251,7 +251,7 @@ IsSevGuest (
 
   WorkArea = (OVMF_WORK_AREA *)FixedPcdGet32 (PcdOvmfWorkAreaBase);
 
-  return ((WorkArea != NULL) && (WorkArea->Header.GuestType == GUEST_TYPE_AMD_SEV));
+  return ((WorkArea != NULL) && (WorkArea->Header.GuestType == CcGuestTypeAmdSev));
 }
 
 /**

--- a/OvmfPkg/Sec/SecMain.c
+++ b/OvmfPkg/Sec/SecMain.c
@@ -28,6 +28,7 @@
 #include <Library/CpuExceptionHandlerLib.h>
 #include <Ppi/TemporaryRamSupport.h>
 #include <Library/PlatformInitLib.h>
+#include <Library/CcProbeLib.h>
 #include "AmdSev.h"
 
 #define SEC_IDT_ENTRY_COUNT  34
@@ -738,7 +739,7 @@ SecCoreStartupWithStack (
   volatile UINT8        *Table;
 
  #if defined (TDX_GUEST_SUPPORTED)
-  if (TdIsEnabled ()) {
+  if (CcProbe () == CcGuestTypeIntelTdx) {
     //
     // For Td guests, the memory map info is in TdHobLib. It should be processed
     // first so that the memory is accepted. Otherwise access to the unaccepted
@@ -828,7 +829,7 @@ SecCoreStartupWithStack (
   }
 
  #if defined (TDX_GUEST_SUPPORTED)
-  if (TdIsEnabled ()) {
+  if (CcProbe () == CcGuestTypeIntelTdx) {
     //
     // InitializeCpuExceptionHandlers () should be called in Td guests so that
     // #VE exceptions can be handled correctly.

--- a/OvmfPkg/Sec/SecMain.inf
+++ b/OvmfPkg/Sec/SecMain.inf
@@ -54,6 +54,7 @@
   LocalApicLib
   MemEncryptSevLib
   CpuExceptionHandlerLib
+  CcProbeLib
 
 [Ppis]
   gEfiTemporaryRamSupportPpiGuid                # PPI ALWAYS_PRODUCED


### PR DESCRIPTION

BZ: https://bugzilla.tianocore.org/show_bug.cgi?id=3902

Bad IO performance in SEC phase is observed after TDX features was
introduced. (after commit b6b2de884864 - "MdePkg: Support mmio for
Tdx guest in BaseIoLibIntrinsic").

This is because IsTdxGuest() will be called in each MMIO operation.
It is trying to cache the result of the probe in the efi data segment.
However, that doesn't work in SEC, because the data segment is read only
(so the write seems to succeed but a read will always return the
original value), leading to us calling TdIsEnabled() check for every
mmio we do, which is causing the slowdown because it's very expensive.

CcProbe is introduced in this patch-set. It is called in
BaseIoLibIntrinsicSev instead of IsTdxGuest. There are 2 versions of
the CcProbeLib. Null instance of CcProbe always returns
CCGuestTypeNonEncrypted. Its OvmfPkg version checks the Ovmf work area
and returns the CC guest type.

In this patch-set another issue is fixed with CcProbe as well. If the
working guest is SEV and in the beginning of SecMain.c TdIsEnabled()
was called. At this point, exception handling is not established and
a CPUID instruction will generate a #VC and cause the booting SEV guest
to crash. Patch #7 is to fix this broken.

Code is at: https://github.com/mxu9/edk2/tree/cc_probe.v4

v4 changes:
 - Rename the field name in CC_GUEST_TYPE from CCXxx to CcXxx based
   on the community feedback.

v3 changes:
 - Fix the broken issue in SEV guest at SecMain.c. Please refer to
   Patch #7.

v2 changes:
 - Rename TdProbe to CcProbe to make the lib work for Confidential
   Computing guests.
 - Rename the GUEST_TYPE to CC_GUEST_TYPE and move it from
   WorkArea.h@OvmfPkg to ConfidentialComputingGuestAttr.h@MdePkg.
   This is because CcProbeLib is designed to return the CC Guest
   type and the lib is located at MdePkg.
 - Rename the CC_GUEST_TYPE's fields name to Camel style. See the
   commit message in patch #1.

Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Zhiguang Liu <zhiguang.liu@intel.com>
Cc: James Bottomley <jejb@linux.ibm.com>
Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Gerd Hoffmann <kraxel@redhat.com>
Cc: Brijesh Singh <brijesh.singh@amd.com>
Cc: Erdem Aktas <erdemaktas@google.com>
Cc: Tom Lendacky <thomas.lendacky@amd.com>
Signed-off-by: Min Xu <min.m.xu@intel.com>

Min Xu (7):
  MdePkg: Add CC_GUEST_TYPE in ConfidentialComputingGuestAttr.h
  OvmfPkg: Replace GUEST_TYPE with CC_GUEST_TYPE
  MdePkg: Add CcProbeLibNull
  OvmfPkg: Add CcProbeLib
  OvmfPkg: Add CcProbeLib in *.dsc
  MdePkg: Probe Cc guest in BaseIoLibIntrinsicSev
  OvmfPkg: Call CcProbe in SecMain.c instead of TsIsEnabled

 .../Include/ConfidentialComputingGuestAttr.h  | 11 ++++++-
 MdePkg/Include/Library/CcProbeLib.h           | 26 ++++++++++++++++
 .../BaseIoLibIntrinsicSev.inf                 |  1 +
 .../BaseIoLibIntrinsic/IoLibInternalTdx.c     | 13 ++------
 .../Library/CcProbeLibNull/CcProbeLibNull.c   | 26 ++++++++++++++++
 .../Library/CcProbeLibNull/CcProbeLibNull.inf | 21 +++++++++++++
 MdePkg/MdePkg.dec                             |  5 +++
 MdePkg/MdePkg.dsc                             |  1 +
 OvmfPkg/AmdSev/AmdSevX64.dsc                  |  1 +
 OvmfPkg/Bhyve/BhyveX64.dsc                    |  1 +
 OvmfPkg/CloudHv/CloudHvX64.dsc                |  1 +
 OvmfPkg/Include/WorkArea.h                    |  9 +-----
 OvmfPkg/IntelTdx/IntelTdxX64.dsc              |  1 +
 OvmfPkg/IntelTdx/Sec/SecMain.c                |  6 ++--
 OvmfPkg/IntelTdx/Sec/SecMain.inf              |  1 +
 .../PeiMemEncryptSevLibInternal.c             |  2 +-
 .../SecMemEncryptSevLibInternal.c             |  2 +-
 OvmfPkg/Library/CcProbeLib/CcProbeLib.c       | 31 +++++++++++++++++++
 OvmfPkg/Library/CcProbeLib/CcProbeLib.inf     | 25 +++++++++++++++
 OvmfPkg/Library/QemuFwCfgLib/QemuFwCfgPei.c   |  2 +-
 OvmfPkg/Microvm/MicrovmX64.dsc                |  1 +
 OvmfPkg/OvmfPkgIa32.dsc                       |  1 +
 OvmfPkg/OvmfPkgIa32X64.dsc                    |  1 +
 OvmfPkg/OvmfPkgX64.dsc                        |  1 +
 OvmfPkg/OvmfXen.dsc                           |  1 +
 OvmfPkg/Sec/AmdSev.c                          |  2 +-
 OvmfPkg/Sec/SecMain.c                         |  5 +--
 OvmfPkg/Sec/SecMain.inf                       |  1 +
 28 files changed, 170 insertions(+), 29 deletions(-)
 create mode 100644 MdePkg/Include/Library/CcProbeLib.h
 create mode 100644 MdePkg/Library/CcProbeLibNull/CcProbeLibNull.c
 create mode 100644 MdePkg/Library/CcProbeLibNull/CcProbeLibNull.inf
 create mode 100644 OvmfPkg/Library/CcProbeLib/CcProbeLib.c
 create mode 100644 OvmfPkg/Library/CcProbeLib/CcProbeLib.inf
