### PR TITLE
 .pytool/Plugin/UncrustifyCheck: Add Azure DevOps UI debug instructions

### DIFF
--- a/.pytool/Plugin/UncrustifyCheck/UncrustifyCheck.py
+++ b/.pytool/Plugin/UncrustifyCheck/UncrustifyCheck.py
@@ -562,6 +562,11 @@ class UncrustifyCheck(ICiBuildPlugin):
         self._formatted_file_error_count = len(formatted_files)
 
         if self._formatted_file_error_count > 0:
+            logging.error(
+                "Visit the following instructions to learn "
+                "how to find the detailed formatting errors in Azure "
+                "DevOps CI: "
+                "https://github.com/tianocore/tianocore.github.io/wiki/EDK-II-Code-Formatting#how-to-find-uncrustify-formatting-errors-in-continuous-integration-ci")
             self._tc.LogStdError("Files with formatting errors:\n")
 
             if self._output_file_diffs:


### PR DESCRIPTION
Adds a link to the log output that contains instructions on how find
detailed file formatting errors in the Azure DevOps UI.

Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Sean Brogan <sean.brogan@microsoft.com>
Cc: Bret Barkelew <Bret.Barkelew@microsoft.com>
Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>
Reviewed-by: Sean Brogan <sean.brogan@microsoft.com>