### PR TITLE
CryptoPkg: Fix the build failure in CryptoPkg

### DIFF
--- a/CryptoPkg/Library/BaseCryptLib/SysCall/CrtWrapper.c
+++ b/CryptoPkg/Library/BaseCryptLib/SysCall/CrtWrapper.c
@@ -267,8 +267,8 @@ strcspn (
 
 char *
 strcpy (
-  char *restrict  strDest,
-  const char      *strSource
+  char        *strDest,
+  const char  *strSource
   )
 {
   AsciiStrCpyS (strDest, MAX_STRING_SIZE, strSource);

--- a/CryptoPkg/Library/Include/CrtLibSupport.h
+++ b/CryptoPkg/Library/Include/CrtLibSupport.h
@@ -397,8 +397,8 @@ inet_pton   (
 
 char *
 strcpy (
-  char *restrict  strDest,
-  const char      *strSource
+  char        *strDest,
+  const char  *strSource
   );
 
 //


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3908

Fix the build failure in CryptoPkg caused by this commit:
fab6285a73("CryptoPkg/CrtLibSupport: fix strcpy")
Remove the 'restrict' keyword which starts in VS2019.

Signed-off-by: Dun Tan <dun.tan@intel.com>
Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Xiaoyu Lu <xiaoyu1.lu@intel.com>
Cc: Guomin Jiang <guomin.jiang@intel.com>