### PR TITLE
CryptoPkg/Crt: fix strcpy build on older VS compilers

### DIFF
--- a/CryptoPkg/Library/BaseCryptLib/SysCall/CrtWrapper.c
+++ b/CryptoPkg/Library/BaseCryptLib/SysCall/CrtWrapper.c
@@ -267,8 +267,8 @@ strcspn (
 
 char *
 strcpy (
-  char *restrict  strDest,
-  const char      *strSource
+  char        *strDest,
+  const char  *strSource
   )
 {
   AsciiStrCpyS (strDest, MAX_STRING_SIZE, strSource);

--- a/CryptoPkg/Library/Include/CrtLibSupport.h
+++ b/CryptoPkg/Library/Include/CrtLibSupport.h
@@ -397,8 +397,8 @@ inet_pton   (
 
 char *
 strcpy (
-  char *restrict  strDest,
-  const char      *strSource
+  char        *strDest,
+  const char  *strSource
   );
 
 //


### PR DESCRIPTION
Drop 'restrict' keyword which older visual studio compiler
versions complain about.

Fixes: fab6285a73c4 ("CryptoPkg/CrtLibSupport: fix strcpy")
Signed-off-by: Gerd Hoffmann <kraxel@redhat.com>
Reviewed-by: Jiewen Yao <jiewen.yao@intel.com>