### PR TITLE
PrmPkg/DxePrmContextBufferLib: Fix unit test GCC compilation errors

### DIFF
--- a/PrmPkg/Library/DxePrmContextBufferLib/UnitTest/DxePrmContextBufferLibUnitTest.c
+++ b/PrmPkg/Library/DxePrmContextBufferLib/UnitTest/DxePrmContextBufferLibUnitTest.c
@@ -237,17 +237,17 @@ NullPointerArgumentsShouldFailGracefully (
   PRM_MODULE_CONTEXT_BUFFERS  *ModuleContextBuffersPtr;
 
   UT_ASSERT_EQUAL (FindContextBufferInModuleBuffers (NULL, NULL, NULL), EFI_INVALID_PARAMETER);
-  UT_ASSERT_EQUAL (FindContextBufferInModuleBuffers (NULL, &ModuleContextBuffers, &ContextBufferPtr), EFI_INVALID_PARAMETER);
-  UT_ASSERT_EQUAL (FindContextBufferInModuleBuffers (&Guid, NULL, &ContextBufferPtr), EFI_INVALID_PARAMETER);
+  UT_ASSERT_EQUAL (FindContextBufferInModuleBuffers (NULL, &ModuleContextBuffers, (CONST PRM_CONTEXT_BUFFER **)&ContextBufferPtr), EFI_INVALID_PARAMETER);
+  UT_ASSERT_EQUAL (FindContextBufferInModuleBuffers (&Guid, NULL, (CONST PRM_CONTEXT_BUFFER **)&ContextBufferPtr), EFI_INVALID_PARAMETER);
   UT_ASSERT_EQUAL (FindContextBufferInModuleBuffers (&Guid, &ModuleContextBuffers, NULL), EFI_INVALID_PARAMETER);
 
   UT_ASSERT_EQUAL (GetModuleContextBuffers (ByModuleGuid, NULL, NULL), EFI_INVALID_PARAMETER);
-  UT_ASSERT_EQUAL (GetModuleContextBuffers (ByModuleGuid, NULL, &ModuleContextBuffersPtr), EFI_INVALID_PARAMETER);
+  UT_ASSERT_EQUAL (GetModuleContextBuffers (ByModuleGuid, NULL, (CONST PRM_MODULE_CONTEXT_BUFFERS **)&ModuleContextBuffersPtr), EFI_INVALID_PARAMETER);
   UT_ASSERT_EQUAL (GetModuleContextBuffers (ByModuleGuid, &Guid, NULL), EFI_INVALID_PARAMETER);
 
   UT_ASSERT_EQUAL (GetContextBuffer (NULL, NULL, NULL), EFI_INVALID_PARAMETER);
-  UT_ASSERT_EQUAL (GetContextBuffer (NULL, &ModuleContextBuffers, &ContextBufferPtr), EFI_INVALID_PARAMETER);
-  UT_ASSERT_EQUAL (GetContextBuffer (&Guid, NULL, &ContextBufferPtr), EFI_NOT_FOUND);
+  UT_ASSERT_EQUAL (GetContextBuffer (NULL, &ModuleContextBuffers, (CONST PRM_CONTEXT_BUFFER **)&ContextBufferPtr), EFI_INVALID_PARAMETER);
+  UT_ASSERT_EQUAL (GetContextBuffer (&Guid, NULL, (CONST PRM_CONTEXT_BUFFER **)&ContextBufferPtr), EFI_NOT_FOUND);
   UT_ASSERT_EQUAL (GetContextBuffer (&Guid, &ModuleContextBuffers, NULL), EFI_INVALID_PARAMETER);
 
   return UNIT_TEST_PASSED;
@@ -322,7 +322,7 @@ InitializeFunctionalCorrectness (
 
 **/
 STATIC
-UNIT_TEST_STATUS
+VOID
 EFIAPI
 DeInitializeFunctionalCorrectness (
   IN  UNIT_TEST_CONTEXT  Context
@@ -332,7 +332,6 @@ DeInitializeFunctionalCorrectness (
   PRM_CONFIG_PROTOCOL               *PrmConfigProtocol;
   PRM_CONTEXT_BUFFERS_TEST_CONTEXT  *TestContext;
 
-  UT_ASSERT_NOT_NULL (Context);
   TestContext = (PRM_CONTEXT_BUFFERS_TEST_CONTEXT *)Context;
 
   Status = gBS->HandleProtocol (
@@ -340,7 +339,6 @@ DeInitializeFunctionalCorrectness (
                   &gPrmConfigProtocolGuid,
                   (VOID **)&PrmConfigProtocol
                   );
-  UT_ASSERT_NOT_EFI_ERROR (Status);
 
   if (!EFI_ERROR (Status)) {
     Status =  gBS->UninstallProtocolInterface (
@@ -348,13 +346,10 @@ DeInitializeFunctionalCorrectness (
                      &gPrmConfigProtocolGuid,
                      PrmConfigProtocol
                      );
-    UT_ASSERT_NOT_EFI_ERROR (Status);
     if (!EFI_ERROR (Status)) {
       FreePool (PrmConfigProtocol);
     }
   }
-
-  return UNIT_TEST_PASSED;
 }
 
 /**
@@ -382,7 +377,7 @@ VerifyGetModuleContextBuffers (
   ContextBuffers = NULL;
   TestContext    = (PRM_CONTEXT_BUFFERS_TEST_CONTEXT *)Context;
 
-  Status = GetModuleContextBuffers (TestContext->GuidSearchType, TestContext->Guid, &ContextBuffers);
+  Status = GetModuleContextBuffers (TestContext->GuidSearchType, TestContext->Guid, (CONST PRM_MODULE_CONTEXT_BUFFERS **)&ContextBuffers);
   UT_ASSERT_STATUS_EQUAL (Status, TestContext->ExpectedStatus);
 
   if (!EFI_ERROR (TestContext->ExpectedStatus)) {
@@ -419,14 +414,12 @@ VerifyFindContextBufferInModuleBuffers (
 {
   EFI_STATUS                       Status;
   PRM_CONTEXT_BUFFER               *FoundContextBuffer;
-  PRM_MODULE_CONTEXT_BUFFERS       *ContextBuffers;
   PRM_CONTEXT_BUFFER_TEST_CONTEXT  *TestContext;
 
-  ContextBuffers     = NULL;
   FoundContextBuffer = NULL;
   TestContext        = (PRM_CONTEXT_BUFFER_TEST_CONTEXT *)Context;
 
-  Status = FindContextBufferInModuleBuffers (TestContext->HandlerGuid, TestContext->ContextBuffers, &FoundContextBuffer);
+  Status = FindContextBufferInModuleBuffers (TestContext->HandlerGuid, TestContext->ContextBuffers, (CONST PRM_CONTEXT_BUFFER **)&FoundContextBuffer);
   UT_ASSERT_STATUS_EQUAL (Status, TestContext->ExpectedStatus);
 
   if (!EFI_ERROR (TestContext->ExpectedStatus)) {
@@ -465,14 +458,13 @@ VerifyGetContextBuffer (
 {
   EFI_STATUS                       Status;
   PRM_CONTEXT_BUFFER               *FoundContextBuffer;
-  PRM_MODULE_CONTEXT_BUFFERS       *ContextBuffers;
   PRM_CONTEXT_BUFFER_TEST_CONTEXT  *TestContext;
 
-  ContextBuffers     = NULL;
   FoundContextBuffer = NULL;
   TestContext        = (PRM_CONTEXT_BUFFER_TEST_CONTEXT *)Context;
 
-  Status = GetContextBuffer (TestContext->HandlerGuid, TestContext->ContextBuffers, &FoundContextBuffer);
+  Status = GetContextBuffer (TestContext->HandlerGuid, TestContext->ContextBuffers, (CONST PRM_CONTEXT_BUFFER **)&FoundContextBuffer);
+
   UT_ASSERT_STATUS_EQUAL (Status, TestContext->ExpectedStatus);
 
   if (!EFI_ERROR (TestContext->ExpectedStatus)) {


### PR DESCRIPTION
https://bugzilla.tianocore.org/show_bug.cgi?id=3905

Fixes GCC compilation errors in DxePrmContextBufferLibUnitTest.c.

Cc: Michael Kubacki <mikuback@linux.microsoft.com>
Cc: Nate DeSimone <nathaniel.l.desimone@intel.com>
Cc: Ankit Sinha <ankit.sinha@intel.com>
Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>
Reviewed-by: Ankit Sinha <ankit.sinha@intel.com>