### PR TITLE
CryptoPkg: Declare PcdEcEnabled in Library consuming OpensslLib

### DIFF
--- a/CryptoPkg/Library/BaseCryptLib/BaseCryptLib.inf
+++ b/CryptoPkg/Library/BaseCryptLib/BaseCryptLib.inf
@@ -88,6 +88,9 @@
   IntrinsicLib
   PrintLib
 
+[FixedPcd]
+  gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+
 #
 # Remove these [BuildOptions] after this library is cleaned up
 #

--- a/CryptoPkg/Library/BaseCryptLib/PeiCryptLib.inf
+++ b/CryptoPkg/Library/BaseCryptLib/PeiCryptLib.inf
@@ -77,6 +77,9 @@
   OpensslLib
   IntrinsicLib
 
+[FixedPcd]
+  gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+
 #
 # Remove these [BuildOptions] after this library is cleaned up
 #

--- a/CryptoPkg/Library/BaseCryptLib/RuntimeCryptLib.inf
+++ b/CryptoPkg/Library/BaseCryptLib/RuntimeCryptLib.inf
@@ -93,6 +93,9 @@
   IntrinsicLib
   PrintLib
 
+[FixedPcd]
+  gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+
 #
 # Remove these [BuildOptions] after this library is cleaned up
 #

--- a/CryptoPkg/Library/BaseCryptLib/SmmCryptLib.inf
+++ b/CryptoPkg/Library/BaseCryptLib/SmmCryptLib.inf
@@ -92,6 +92,9 @@
   MmServicesTableLib
   SynchronizationLib
 
+[FixedPcd]
+  gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+
 #
 # Remove these [BuildOptions] after this library is cleaned up
 #

--- a/CryptoPkg/Library/BaseCryptLib/UnitTestHostBaseCryptLib.inf
+++ b/CryptoPkg/Library/BaseCryptLib/UnitTestHostBaseCryptLib.inf
@@ -72,6 +72,9 @@
   DebugLib
   OpensslLib
 
+[FixedPcd]
+  gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+
 #
 # Remove these [BuildOptions] after this library is cleaned up
 #

--- a/CryptoPkg/Library/OpensslLib/OpensslLib.inf
+++ b/CryptoPkg/Library/OpensslLib/OpensslLib.inf
@@ -633,7 +633,7 @@
 [LibraryClasses.ARM]
   ArmSoftFloatLib
 
-[Pcd]
+[FixedPcd]
   gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled      ## CONSUMES
 
 [BuildOptions]

--- a/CryptoPkg/Library/OpensslLib/OpensslLibCrypto.inf
+++ b/CryptoPkg/Library/OpensslLib/OpensslLibCrypto.inf
@@ -582,7 +582,7 @@
 [LibraryClasses.ARM]
   ArmSoftFloatLib
 
-[Pcd]
+[FixedPcd]
   gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled      ## CONSUMES
 
 [BuildOptions]

--- a/CryptoPkg/Library/TlsLib/TlsLib.inf
+++ b/CryptoPkg/Library/TlsLib/TlsLib.inf
@@ -41,6 +41,9 @@
   OpensslLib
   SafeIntLib
 
+[FixedPcd]
+  gEfiCryptoPkgTokenSpaceGuid.PcdEcEnabled
+
 [BuildOptions]
   #
   # suppress the following warnings so we do not break the build with warnings-as-errors:


### PR DESCRIPTION
REF:https://bugzilla.tianocore.org/show_bug.cgi?id=3679
REF:https://bugzilla.tianocore.org/show_bug.cgi?id=3828

Tls/Base/Pei/Smm/RuntimeCryptLib.inf will use OpensslLib,
and the opensslconf.h in openssllib will use PcdEcEnabled,
but it is not declared in the inf file now,
it will cause warnings in some compilers.

Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Jian J Wang <jian.j.wang@intel.com>
Signed-off-by: Yi Li <yi1.li@intel.com>
Reviewed-by: Jiewen Yao <jiewen.yao@intel.com>