### PR TITLE
DynamicTables: Fix DT PCI interrupt flags parsing

### DIFF
--- a/DynamicTablesPkg/Library/Acpi/Arm/AcpiSsdtPcieLibArm/SsdtPcieGenerator.c
+++ b/DynamicTablesPkg/Library/Acpi/Arm/AcpiSsdtPcieLibArm/SsdtPcieGenerator.c
@@ -449,7 +449,7 @@ GeneratePrt (
     if ((Index > 0)   &&
         (IrqMapInfo->IntcInterrupt.Interrupt >= 32)   &&
         (IrqMapInfo->IntcInterrupt.Interrupt < 1020)  &&
-        ((IrqMapInfo->IntcInterrupt.Flags & 0x3) != BIT0))
+        ((IrqMapInfo->IntcInterrupt.Flags & 0x3) != 0))
     {
       Status = EFI_INVALID_PARAMETER;
       ASSERT_EFI_ERROR (Status);

--- a/DynamicTablesPkg/Library/FdtHwInfoParserLib/FdtUtility.h
+++ b/DynamicTablesPkg/Library/FdtHwInfoParserLib/FdtUtility.h
@@ -60,7 +60,7 @@
 #define SPI_OFFSET  (32U)
 #define DT_PPI_IRQ  (1U)
 #define DT_SPI_IRQ  (0U)
-#define DT_IRQ_IS_EDGE_TRIGGERED(x)  ((((x) & (BIT0 | BIT2)) != 0))
+#define DT_IRQ_IS_EDGE_TRIGGERED(x)  ((((x) & (BIT0 | BIT1)) != 0))
 #define DT_IRQ_IS_ACTIVE_LOW(x)      ((((x) & (BIT1 | BIT3)) != 0))
 #define IRQ_TYPE_OFFSET    (0U)
 #define IRQ_NUMBER_OFFSET  (1U)


### PR DESCRIPTION
Device Tree PCI interrupt flags use the convention described at
linux/Documentation/devicetree/bindings/interrupt-controller/arm,gic.yaml

The 3rd cell is the flags, encoded as follows:
  bits[3:0] trigger type and level flags.
  1 = low-to-high edge triggered
  2 = high-to-low edge triggered (invalid for SPIs)
  4 = active high level-sensitive
  8 = active low level-sensitive (invalid for SPIs).

Fix the incorrect code.

Signed-off-by: Pierre Gondois <Pierre.Gondois@arm.com>