### PR TITLE
BaseTools/Conf: Fix Dynamic-Library-File template

### DIFF
--- a/BaseTools/Conf/build_rule.template
+++ b/BaseTools/Conf/build_rule.template
@@ -366,6 +366,8 @@
 
     <OutputFile>
         $(OUTPUT_DIR)(+)$(MODULE_NAME).efi
+        $(DEBUG_DIR)(+)$(MODULE_NAME).efi
+        $(OUTPUT_DIR)(+)$(MODULE_NAME).map
 
     <Command.MSFT, Command.INTEL, Command.RVCT, Command.CLANGPDB>
         "$(GENFW)" -e $(MODULE_TYPE) -o ${dst} ${src} $(GENFW_FLAGS)


### PR DESCRIPTION
In the Dynamic-Library-File template, add missing output file
declarations.  These files are generated by the template and other rules
explicitly depend on them.

This change resolves missing dependency issues we encountered while
running a recursive make with job control.

Signed-off-by: Jake Garver <jake@nvidia.com>
Reviewed-by: Bob Feng <bob.c.feng@intel.com>