### PR TITLE
OvmfPkg: restore CompatImageLoaderDxe chunk

### DIFF
--- a/OvmfPkg/OvmfPkgIa32.dsc
+++ b/OvmfPkg/OvmfPkgIa32.dsc
@@ -1007,3 +1007,6 @@
   #
 !include OvmfPkg/OvmfTpmComponentsDxe.dsc.inc
 
+!if $(LOAD_X64_ON_IA32_ENABLE) == TRUE
+  OvmfPkg/CompatImageLoaderDxe/CompatImageLoaderDxe.inf
+!endif


### PR DESCRIPTION
Was dropped by accident.

Fixes: b47575801e19 ("OvmfPkg: move tcg configuration to dsc and fdf include files")
Signed-off-by: Gerd Hoffmann <kraxel@redhat.com>