### PR TITLE
Change ReallocatePool to use calloc

### DIFF
--- a/UnitTestFrameworkPkg/Library/Posix/MemoryAllocationLibPosix/MemoryAllocationLibPosix.c
+++ b/UnitTestFrameworkPkg/Library/Posix/MemoryAllocationLibPosix/MemoryAllocationLibPosix.c
@@ -538,7 +538,7 @@ ReallocatePool (
 {
   VOID  *NewBuffer;
 
-  NewBuffer = malloc (NewSize);
+  NewBuffer = calloc (1, NewSize);
   if ((NewBuffer != NULL) && (OldBuffer != NULL)) {
     memcpy (NewBuffer, OldBuffer, MIN (OldSize, NewSize));
   }


### PR DESCRIPTION
ReallocatePool incorrectly uses malloc, which does not zero the
allocated memory as the documentation specifies. This change uses
calloc instead, which does zero the memory.

Signed-off-by: Nolan Hergert <nolan.hergert@intel.com>