### PR TITLE
Add CpuLib to module INFs that depend on UefiCpuLib.

### DIFF
--- a/IntelFsp2Pkg/FspSecCore/FspSecCoreM.inf
+++ b/IntelFsp2Pkg/FspSecCore/FspSecCoreM.inf
@@ -58,6 +58,7 @@
   FspSwitchStackLib
   FspCommonLib
   FspSecPlatformLib
+  CpuLib
   UefiCpuLib
 
 [Pcd]

--- a/IntelFsp2Pkg/FspSecCore/SecMain.h
+++ b/IntelFsp2Pkg/FspSecCore/SecMain.h
@@ -20,6 +20,7 @@
 #include <Library/SerialPortLib.h>
 #include <Library/FspSwitchStackLib.h>
 #include <Library/FspCommonLib.h>
+#include <Library/CpuLib.h>
 #include <Library/UefiCpuLib.h>
 #include <FspEas.h>
 

--- a/IntelFsp2WrapperPkg/FspmWrapperPeim/FspmWrapperPeim.inf
+++ b/IntelFsp2WrapperPkg/FspmWrapperPeim/FspmWrapperPeim.inf
@@ -37,6 +37,7 @@
   HobLib
   FspWrapperPlatformLib
   FspWrapperHobProcessLib
+  CpuLib
   UefiCpuLib
   PeCoffGetEntryPointLib
   PeCoffExtraActionLib

--- a/IntelFsp2WrapperPkg/FspsWrapperPeim/FspsWrapperPeim.inf
+++ b/IntelFsp2WrapperPkg/FspsWrapperPeim/FspsWrapperPeim.inf
@@ -38,6 +38,7 @@
   MemoryAllocationLib
   FspWrapperPlatformLib
   FspWrapperHobProcessLib
+  CpuLib
   UefiCpuLib
   PeCoffGetEntryPointLib
   PeCoffExtraActionLib

--- a/MdePkg/MdeLibs.dsc.inc
+++ b/MdePkg/MdeLibs.dsc.inc
@@ -13,3 +13,4 @@
 
 [LibraryClasses]
   RegisterFilterLib|MdePkg/Library/RegisterFilterLibNull/RegisterFilterLibNull.inf
+  CpuLib|MdePkg/Library/BaseCpuLib/BaseCpuLib.inf

--- a/OvmfPkg/Sec/SecMain.c
+++ b/OvmfPkg/Sec/SecMain.c
@@ -17,6 +17,7 @@
 #include <Library/BaseMemoryLib.h>
 #include <Library/PeiServicesLib.h>
 #include <Library/PcdLib.h>
+#include <Library/CpuLib.h>
 #include <Library/UefiCpuLib.h>
 #include <Library/DebugAgentLib.h>
 #include <Library/IoLib.h>

--- a/OvmfPkg/Sec/SecMain.inf
+++ b/OvmfPkg/Sec/SecMain.inf
@@ -44,6 +44,7 @@
   BaseMemoryLib
   PeiServicesLib
   PcdLib
+  CpuLib
   UefiCpuLib
   DebugAgentLib
   IoLib

--- a/UefiCpuPkg/Library/BaseXApicLib/BaseXApicLib.c
+++ b/UefiCpuPkg/Library/BaseXApicLib/BaseXApicLib.c
@@ -21,6 +21,7 @@
 #include <Library/IoLib.h>
 #include <Library/TimerLib.h>
 #include <Library/PcdLib.h>
+#include <Library/CpuLib.h>
 #include <Library/UefiCpuLib.h>
 
 //

--- a/UefiCpuPkg/Library/BaseXApicLib/BaseXApicLib.inf
+++ b/UefiCpuPkg/Library/BaseXApicLib/BaseXApicLib.inf
@@ -38,6 +38,7 @@
   TimerLib
   IoLib
   PcdLib
+  CpuLib
   UefiCpuLib
 
 [Pcd]

--- a/UefiCpuPkg/Library/BaseXApicX2ApicLib/BaseXApicX2ApicLib.c
+++ b/UefiCpuPkg/Library/BaseXApicX2ApicLib/BaseXApicX2ApicLib.c
@@ -22,6 +22,7 @@
 #include <Library/IoLib.h>
 #include <Library/TimerLib.h>
 #include <Library/PcdLib.h>
+#include <Library/CpuLib.h>
 #include <Library/UefiCpuLib.h>
 #include <IndustryStandard/Tdx.h>
 

--- a/UefiCpuPkg/Library/BaseXApicX2ApicLib/BaseXApicX2ApicLib.inf
+++ b/UefiCpuPkg/Library/BaseXApicX2ApicLib/BaseXApicX2ApicLib.inf
@@ -38,6 +38,7 @@
   TimerLib
   IoLib
   PcdLib
+  CpuLib
   UefiCpuLib
 
 [Pcd]

--- a/UefiCpuPkg/PiSmmCpuDxeSmm/PiSmmCpuDxeSmm.h
+++ b/UefiCpuPkg/PiSmmCpuDxeSmm/PiSmmCpuDxeSmm.h
@@ -43,6 +43,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/UefiLib.h>
 #include <Library/HobLib.h>
 #include <Library/LocalApicLib.h>
+#include <Library/CpuLib.h>
 #include <Library/UefiCpuLib.h>
 #include <Library/CpuExceptionHandlerLib.h>
 #include <Library/ReportStatusCodeLib.h>

--- a/UefiCpuPkg/SecCore/SecCore.inf
+++ b/UefiCpuPkg/SecCore/SecCore.inf
@@ -47,6 +47,7 @@
   PlatformSecLib
   PcdLib
   DebugAgentLib
+  CpuLib
   UefiCpuLib
   PeCoffGetEntryPointLib
   PeCoffExtraActionLib

--- a/UefiCpuPkg/SecCore/SecCoreNative.inf
+++ b/UefiCpuPkg/SecCore/SecCoreNative.inf
@@ -44,6 +44,7 @@
   PlatformSecLib
   PcdLib
   DebugAgentLib
+  CpuLib
   UefiCpuLib
   PeCoffGetEntryPointLib
   PeCoffExtraActionLib

--- a/UefiCpuPkg/SecCore/SecMain.h
+++ b/UefiCpuPkg/SecCore/SecMain.h
@@ -23,6 +23,7 @@
 #include <Library/PcdLib.h>
 #include <Library/BaseMemoryLib.h>
 #include <Library/PlatformSecLib.h>
+#include <Library/CpuLib.h>
 #include <Library/UefiCpuLib.h>
 #include <Library/PeCoffGetEntryPointLib.h>
 #include <Library/PeCoffExtraActionLib.h>

--- a/UefiPayloadPkg/UefiPayloadEntry/UefiPayloadEntry.h
+++ b/UefiPayloadPkg/UefiPayloadEntry/UefiPayloadEntry.h
@@ -23,6 +23,7 @@
 #include <Library/PeCoffLib.h>
 #include <Library/BlParseLib.h>
 #include <Library/PlatformSupportLib.h>
+#include <Library/CpuLib.h>
 #include <Library/UefiCpuLib.h>
 #include <IndustryStandard/Acpi.h>
 #include <IndustryStandard/MemoryMappedConfigurationSpaceAccessTable.h>

--- a/UefiPayloadPkg/UefiPayloadEntry/UefiPayloadEntry.inf
+++ b/UefiPayloadPkg/UefiPayloadEntry/UefiPayloadEntry.inf
@@ -54,6 +54,7 @@
   HobLib
   PeCoffLib
   PlatformSupportLib
+  CpuLib
   UefiCpuLib
 
 [Guids]

--- a/UefiPayloadPkg/UefiPayloadEntry/UniversalPayloadEntry.inf
+++ b/UefiPayloadPkg/UefiPayloadEntry/UniversalPayloadEntry.inf
@@ -52,6 +52,7 @@
   IoLib
   HobLib
   PeCoffLib
+  CpuLib
   UefiCpuLib
 
 [Guids]


### PR DESCRIPTION

There are two libraries: MdePkg/CpuLib and UefiCpuPkg/UefiCpuLib and
UefiCpuPkg/UefiCpuLib will be merged to MdePkg/CpuLib. To avoid build
failure, add CpuLib dependency to all modules that depend on UefiCpuLib.