### PR TITLE
MdeModulePkg/PCD: Pcd initialize DXE have assert

### DIFF
--- a/MdeModulePkg/Universal/PCD/Dxe/Service.c
+++ b/MdeModulePkg/Universal/PCD/Dxe/Service.c
@@ -817,6 +817,11 @@ UpdatePcdDatabase (
   //
   Index    = (mPcdDatabase.DxeDb->Length + 7) & (~7);
   SkuDelta = NULL;
+
+  if (Index == mDxePcdDbSize) {
+    return EFI_SUCCESS;
+  }
+
   while (Index < mDxePcdDbSize) {
     SkuDelta = (PCD_DATABASE_SKU_DELTA *)((UINT8 *)mDxePcdDbBinary + Index);
     if ((SkuDelta->SkuId == SkuId) && (SkuDelta->SkuIdCompared == 0)) {


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3917

When PlatformPkg.dsc has multiple SKU IDs but didn't exist delta PCD,
System will hang on BuildPcdDxeDataBase.

Ideally, if didn't exist delta PCD by different SKU ID,
UpdatePcdDatabase () shouldn't return EFI_NOT_FOUND.

Signed-off-by: Gua Guo <gua.guo@intel.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>