### PR TITLE
CI test only: OvmfPkg/AmdSevDxe: Update ConfidentialComputing blob struct definition

### DIFF
--- a/OvmfPkg/AmdSevDxe/AmdSevDxe.c
+++ b/OvmfPkg/AmdSevDxe/AmdSevDxe.c
@@ -27,8 +27,10 @@ STATIC CONFIDENTIAL_COMPUTING_SNP_BLOB_LOCATION  mSnpBootDxeTable = {
   0,
   (UINT64)(UINTN)FixedPcdGet32 (PcdOvmfSnpSecretsBase),
   FixedPcdGet32 (PcdOvmfSnpSecretsSize),
+  0,
   (UINT64)(UINTN)FixedPcdGet32 (PcdOvmfCpuidBase),
   FixedPcdGet32 (PcdOvmfCpuidSize),
+  0,
 };
 
 EFI_STATUS

--- a/OvmfPkg/Include/Guid/ConfidentialComputingSevSnpBlob.h
+++ b/OvmfPkg/Include/Guid/ConfidentialComputingSevSnpBlob.h
@@ -18,14 +18,16 @@
     { 0x85, 0x54, 0x93, 0xd7, 0x77, 0x91, 0x2d, 0x42 }, \
   }
 
-typedef struct {
+typedef PACKED struct {
   UINT32    Header;
   UINT16    Version;
-  UINT16    Reserved1;
+  UINT16    Reserved;
   UINT64    SecretsPhysicalAddress;
   UINT32    SecretsSize;
+  UINT32    Reserved1;
   UINT64    CpuidPhysicalAddress;
   UINT32    CpuidLSize;
+  UINT32    Reserved2;
 } CONFIDENTIAL_COMPUTING_SNP_BLOB_LOCATION;
 
 extern EFI_GUID  gConfidentialComputingSevSnpBlobGuid;


### PR DESCRIPTION
CI test only

The Confidential Computing blob defined here is intended to match the
definition defined by linux guest kernel. Previously, both definitions
relied on natural alignment, but that relies on both OVMF and kernel
being compiled as 64-bit. While there aren't currently any plans to
enable SNP support for 32-bit compilations, the kernel definition has
since been updated to use explicit padding/reserved fields to avoid
this dependency. Update OVMF to match that definition.

While at it, also fix up the Reserved fields to match the numbering
used in the kernel.

No functional changes (for currently-supported environments, at least).

Reviewed-by: Tom Lendacky <thomas.lendacky@amd.com>
Signed-off-by: Michael Roth <michael.roth@amd.com>