### PR TITLE
CI test only: UefiCpuPkg: Store SEV-SNP AP jump table in the secrets page

### DIFF
--- a/MdePkg/Include/Register/Amd/SnpSecretsPage.h
+++ b/MdePkg/Include/Register/Amd/SnpSecretsPage.h
@@ -1,0 +1,56 @@
+/** @file
+Definitions for AMD SEV-SNP Secrets Page
+
+Copyright (c) 2022 AMD Inc. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef __SNP_SECRETS_PAGE_H_
+#define __SNP_SECRETS_PAGE_H_
+
+//
+// OS-defined area of secrets page
+//
+// As defined by "SEV-ES Guest-Hypervisor Communication Block Standardization",
+// revision 2.01, section 2.7, "SEV-SNP Secrets Page".
+//
+typedef PACKED struct _SNP_SECRETS_OS_AREA {
+  UINT32    Vmpl0MsgSeqNumLo;
+  UINT32    Vmpl1MsgSeqNumLo;
+  UINT32    Vmpl2MsgSeqNumLo;
+  UINT32    Vmpl3MsgSeqNumLo;
+  UINT64    ApJumpTablePa;
+  UINT32    Vmpl0MsgSeqNumHi;
+  UINT32    Vmpl1MsgSeqNumHi;
+  UINT32    Vmpl2MsgSeqNumHi;
+  UINT32    Vmpl3MsgSeqNumHi;
+  UINT8     Reserved2[22];
+  UINT16    Version;
+  UINT8     GuestUsage[32];
+} SNP_SECRETS_OS_AREA;
+
+#define VMPCK_KEY_LEN  32
+
+//
+// SEV-SNP Secrets page
+//
+// As defined by "SEV-SNP Firmware ABI", revision 1.51, section 8.17.2.5,
+// "PAGE_TYPE_SECRETS".
+//
+typedef PACKED struct _SNP_SECRETS_PAGE {
+  UINT32                 Version;
+  UINT32                 ImiEn    : 1,
+                         Reserved : 31;
+  UINT32                 Fms;
+  UINT32                 Reserved2;
+  UINT8                  Gosvw[16];
+  UINT8                  Vmpck0[VMPCK_KEY_LEN];
+  UINT8                  Vmpck1[VMPCK_KEY_LEN];
+  UINT8                  Vmpck2[VMPCK_KEY_LEN];
+  UINT8                  Vmpck3[VMPCK_KEY_LEN];
+  SNP_SECRETS_OS_AREA    OsArea;
+  UINT8                  Reserved3[3840];
+} SNP_SECRETS_PAGE;
+
+#endif

--- a/MdePkg/MdePkg.dec
+++ b/MdePkg/MdePkg.dec
@@ -2417,5 +2417,9 @@
   # @Prompt Memory encryption attribute
   gEfiMdePkgTokenSpaceGuid.PcdConfidentialComputingGuestAttr|0|UINT64|0x0000002e
 
+  ## This dynamic PCD indicates the location of the SEV-SNP secrets page.
+  # @Prompt SEV-SNP secrets page address
+  gEfiMdePkgTokenSpaceGuid.PcdSevSnpSecretsAddress|0|UINT64|0x0000002f
+
 [UserExtensions.TianoCore."ExtraFiles"]
   MdePkgExtra.uni

--- a/OvmfPkg/AmdSev/AmdSevX64.dsc
+++ b/OvmfPkg/AmdSev/AmdSevX64.dsc
@@ -575,6 +575,9 @@
   # Set ConfidentialComputing defaults
   gEfiMdePkgTokenSpaceGuid.PcdConfidentialComputingGuestAttr|0
 
+  # Set SEV-SNP Secrets page address default
+  gEfiMdePkgTokenSpaceGuid.PcdSevSnpSecretsAddress|0
+
 !include OvmfPkg/OvmfTpmPcds.dsc.inc
 
   gEfiMdePkgTokenSpaceGuid.PcdFSBClock|100000000

--- a/OvmfPkg/CloudHv/CloudHvX64.dsc
+++ b/OvmfPkg/CloudHv/CloudHvX64.dsc
@@ -630,6 +630,9 @@
   # Set ConfidentialComputing defaults
   gEfiMdePkgTokenSpaceGuid.PcdConfidentialComputingGuestAttr|0
 
+  # Set SEV-SNP Secrets page address default
+  gEfiMdePkgTokenSpaceGuid.PcdSevSnpSecretsAddress|0
+
 [PcdsDynamicHii]
 !include OvmfPkg/OvmfTpmPcdsHii.dsc.inc
 

--- a/OvmfPkg/IntelTdx/IntelTdxX64.dsc
+++ b/OvmfPkg/IntelTdx/IntelTdxX64.dsc
@@ -512,6 +512,9 @@
 
   gEfiMdePkgTokenSpaceGuid.PcdFSBClock|100000000
 
+  # Set SEV-SNP Secrets page address default
+  gEfiMdePkgTokenSpaceGuid.PcdSevSnpSecretsAddress|0
+
 ################################################################################
 #
 # Components Section - list of all EDK II Modules needed by this Platform.

--- a/OvmfPkg/Microvm/MicrovmX64.dsc
+++ b/OvmfPkg/Microvm/MicrovmX64.dsc
@@ -613,6 +613,9 @@
   # Set ConfidentialComputing defaults
   gEfiMdePkgTokenSpaceGuid.PcdConfidentialComputingGuestAttr|0
 
+  # Set SEV-SNP Secrets page address default
+  gEfiMdePkgTokenSpaceGuid.PcdSevSnpSecretsAddress|0
+
 ################################################################################
 #
 # Components Section - list of all EDK II Modules needed by this Platform.

--- a/OvmfPkg/OvmfPkgIa32.dsc
+++ b/OvmfPkg/OvmfPkgIa32.dsc
@@ -649,6 +649,9 @@
   # Set ConfidentialComputing defaults
   gEfiMdePkgTokenSpaceGuid.PcdConfidentialComputingGuestAttr|0
 
+  # Set SEV-SNP Secrets page address default
+  gEfiMdePkgTokenSpaceGuid.PcdSevSnpSecretsAddress|0
+
 !if $(CSM_ENABLE) == FALSE
   gEfiMdePkgTokenSpaceGuid.PcdFSBClock|100000000
 !endif

--- a/OvmfPkg/OvmfPkgIa32X64.dsc
+++ b/OvmfPkg/OvmfPkgIa32X64.dsc
@@ -657,6 +657,9 @@
   # Set ConfidentialComputing defaults
   gEfiMdePkgTokenSpaceGuid.PcdConfidentialComputingGuestAttr|0
 
+  # Set SEV-SNP Secrets page address default
+  gEfiMdePkgTokenSpaceGuid.PcdSevSnpSecretsAddress|0
+
 !if $(CSM_ENABLE) == FALSE
   gEfiMdePkgTokenSpaceGuid.PcdFSBClock|100000000
 !endif

--- a/OvmfPkg/OvmfPkgX64.dsc
+++ b/OvmfPkg/OvmfPkgX64.dsc
@@ -680,6 +680,9 @@
   # Set ConfidentialComputing defaults
   gEfiMdePkgTokenSpaceGuid.PcdConfidentialComputingGuestAttr|0
 
+  # Set SEV-SNP Secrets page address default
+  gEfiMdePkgTokenSpaceGuid.PcdSevSnpSecretsAddress|0
+
 !if $(CSM_ENABLE) == FALSE
   gEfiMdePkgTokenSpaceGuid.PcdFSBClock|100000000
 !endif

--- a/OvmfPkg/PlatformPei/AmdSev.c
+++ b/OvmfPkg/PlatformPei/AmdSev.c
@@ -408,6 +408,11 @@ AmdSevInitialize (
   //
   if (MemEncryptSevSnpIsEnabled ()) {
     PcdStatus = PcdSet64S (PcdConfidentialComputingGuestAttr, CCAttrAmdSevSnp);
+    ASSERT_RETURN_ERROR (PcdStatus);
+    PcdStatus = PcdSet64S (
+                  PcdSevSnpSecretsAddress,
+                  (UINT64)(UINTN)PcdGet32 (PcdOvmfSnpSecretsBase)
+                  );
   } else if (MemEncryptSevEsIsEnabled ()) {
     PcdStatus = PcdSet64S (PcdConfidentialComputingGuestAttr, CCAttrAmdSevEs);
   } else {

--- a/OvmfPkg/PlatformPei/PlatformPei.inf
+++ b/OvmfPkg/PlatformPei/PlatformPei.inf
@@ -114,6 +114,7 @@
   gEfiMdePkgTokenSpaceGuid.PcdConfidentialComputingGuestAttr
   gUefiCpuPkgTokenSpaceGuid.PcdGhcbHypervisorFeatures
   gEfiMdeModulePkgTokenSpaceGuid.PcdTdxSharedBitMask
+  gEfiMdePkgTokenSpaceGuid.PcdSevSnpSecretsAddress
 
 [FixedPcd]
   gUefiOvmfPkgTokenSpaceGuid.PcdOvmfCpuidBase

--- a/UefiCpuPkg/Library/MpInitLib/DxeMpInitLib.inf
+++ b/UefiCpuPkg/Library/MpInitLib/DxeMpInitLib.inf
@@ -80,3 +80,4 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdCpuStackGuard                      ## CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdGhcbBase                           ## CONSUMES
   gEfiMdePkgTokenSpaceGuid.PcdConfidentialComputingGuestAttr           ## CONSUMES
+  gEfiMdePkgTokenSpaceGuid.PcdSevSnpSecretsAddress                     ## CONSUMES

--- a/UefiCpuPkg/Library/MpInitLib/DxeMpLib.c
+++ b/UefiCpuPkg/Library/MpInitLib/DxeMpLib.c
@@ -15,6 +15,7 @@
 #include <Library/VmgExitLib.h>
 #include <Register/Amd/Fam17Msr.h>
 #include <Register/Amd/Ghcb.h>
+#include <Register/Amd/SnpSecretsPage.h>
 
 #include <Protocol/Timer.h>
 
@@ -215,6 +216,14 @@ GetSevEsAPMemory (
   ASSERT_EFI_ERROR (Status);
 
   DEBUG ((DEBUG_INFO, "Dxe: SevEsAPMemory = %lx\n", (UINTN)StartAddress));
+
+  if (ConfidentialComputingGuestHas (CCAttrAmdSevSnp)) {
+    SNP_SECRETS_PAGE  *Secrets = (SNP_SECRETS_PAGE *)(INTN)PcdGet64 (PcdSevSnpSecretsAddress);
+
+    Secrets->OsArea.ApJumpTablePa = (UINT64)(UINTN)StartAddress;
+
+    return (UINTN)StartAddress;
+  }
 
   //
   // Save the SevEsAPMemory as the AP jump table.


### PR DESCRIPTION
CI test only.

A full-featured SEV-SNP guest will not rely on the AP jump table, and
will instead use the AP Creation interface defined by the GHCB. However,
a guest is still allowed to use the AP jump table if desired.

However, unlike with SEV-ES guests, SEV-SNP guests should not
store/retrieve the jump table address via GHCB requests to the
hypervisor, they should instead store/retrieve it via the SEV-SNP
secrets page. Implement the store side of this for OVMF.

Suggested-by: Tom Lendacky <thomas.lendacky@amd.com>
Signed-off-by: Michael Roth <michael.roth@amd.com>