### PR TITLE
MdePkg: Remove "assert" from SmmCpuRendevousLibNull.c

### DIFF
--- a/MdePkg/Library/SmmCpuRendezvousLibNull/SmmCpuRendezvousLibNull.c
+++ b/MdePkg/Library/SmmCpuRendezvousLibNull/SmmCpuRendezvousLibNull.c
@@ -24,6 +24,5 @@ SmmWaitForAllProcessor (
   IN BOOLEAN  BlockingMode
   )
 {
-  ASSERT (FALSE);
   return EFI_SUCCESS;
 }


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3931

Some drivers will break down when they use
SmmWaitForAllProcessor() which from SmmCpuRendezvousLibNull.c.
Removing the code "ASSERT(False)" will make consumer
work normally if they keep default setting for sync mode.

Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>

Signed-off-by: Zhihao Li <zhihao.li@intel.com>