### PR TITLE
OvmfPkg/OvmfPkgX64: Use different CcProbeLib when SMM is on or off

### DIFF
--- a/OvmfPkg/OvmfPkgX64.dsc
+++ b/OvmfPkg/OvmfPkgX64.dsc
@@ -171,7 +171,6 @@
   PciCapLib|OvmfPkg/Library/BasePciCapLib/BasePciCapLib.inf
   PciCapPciSegmentLib|OvmfPkg/Library/BasePciCapPciSegmentLib/BasePciCapPciSegmentLib.inf
   PciCapPciIoLib|OvmfPkg/Library/UefiPciCapPciIoLib/UefiPciCapPciIoLib.inf
-  CcProbeLib|OvmfPkg/Library/CcProbeLib/CcProbeLib.inf
   IoLib|MdePkg/Library/BaseIoLibIntrinsic/BaseIoLibIntrinsicSev.inf
   OemHookStatusCodeLib|MdeModulePkg/Library/OemHookStatusCodeLibNull/OemHookStatusCodeLibNull.inf
   SerialPortLib|PcAtChipsetPkg/Library/SerialIoLib/SerialIoLib.inf
@@ -198,6 +197,9 @@
 
 !if $(SMM_REQUIRE) == FALSE
   LockBoxLib|OvmfPkg/Library/LockBoxLib/LockBoxBaseLib.inf
+  CcProbeLib|OvmfPkg/Library/CcProbeLib/CcProbeLib.inf
+!else
+  CcProbeLib|MdePkg/Library/CcProbeLibNull/CcProbeLibNull.inf
 !endif
   CustomizedDisplayLib|MdeModulePkg/Library/CustomizedDisplayLib/CustomizedDisplayLib.inf
   FrameBufferBltLib|MdeModulePkg/Library/FrameBufferBltLib/FrameBufferBltLib.inf


### PR DESCRIPTION
BZ: https://bugzilla.tianocore.org/show_bug.cgi?id=3930

CcProbeLib is designed to check the vm guest type. The OvmfPkg/CcProbeLib
reads the OvmfWorkArea (0x80B000) to get the vm guest type which is
written by each guest (SEV or TDX guest). But in SMM drivers the access
to OvmfWorkArea is illegal. PiSmmCpuDxeSmm.inf is an example. It uses
IoLib which in OvmfPkgX64 BaseIoLibIntrinsicSev.inf is included. The
IoLib probes if the working guest is td guest by calling CcProbe().

So CcProbeLibNull will be included when SMM_REQUIRE is set. Currently
only TDVF uses CcProbe to check the guest type, and TDVF doesn't
support SMM, so this fix has no side-effect.

Cc: Andrew Fish <afish@apple.com>
Cc: Leif Lindholm <quic_llindhol@quicinc.com>
Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Dann Frazier <dann.frazier@canonical.com>
Cc: Erdem Aktas <erdemaktas@google.com>
Cc: James Bottomley <jejb@linux.ibm.com>
Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Tom Lendacky <thomas.lendacky@amd.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Tested-by: dann frazier <dann.frazier@canonical.com>
Reviewed-by: Jiewen Yao <Jiewen.yao@intel.com>
Signed-off-by: Min Xu <min.m.xu@intel.com>