### PR TITLE
OvmfPkg: TdxDxe: Fix AsmRelocateApMailBoxLoop

### DIFF
--- a/OvmfPkg/TdxDxe/X64/ApRunLoop.nasm
+++ b/OvmfPkg/TdxDxe/X64/ApRunLoop.nasm
@@ -69,7 +69,7 @@ MailBoxWakeUp:
     mov        rax, [rbx + WakeupVectorOffset]
     ; OS sends a wakeup command for a given APIC ID, firmware is supposed to reset
     ; the command field back to zero as acknowledgement.
-    mov        qword [rbx + WakeupVectorOffset], 0
+    mov        qword [rbx + CommandOffset], 0
     jmp        rax
 MailBoxSleep:
     jmp       $


### PR DESCRIPTION
In TDX, Application Processor busy-loops on Mailbox for OS to issue
MpProtectedModeWakeupCommandWakeup command to UEFI.  As the AP acking to
it, it clears the command member according to ACPI spec 6.4, 5.2.12.19
Multiprocessor Wakeup Structure: "The application processor need clear the
command to Noop(0) as the acknowledgement that the command is received."
However, AsmRelocateApMailBoxLoop wrongly clears WakeupVector.  Correctly
clear command instead of WakeupVector.

Without this patch, TD guest kernel fails to boot APs.

Fixes: fae5c1464d ("OvmfPkg: Add TdxDxe driver")

Cc: Min Xu <min.m.xu@intel.com>
Signed-off-by: Isaku Yamahata <isaku.yamahata@intel.com>
Reviewed-by: Jiewen Yao <jiewen.yao@intel.com>
Reviewed-by: Min Xu <min.m.xu@intel.com>