### PR TITLE
Fix/Increase DXEFV Image Size from 12M to 16M for OvmfPkgIa32X64 and …

### DIFF
--- a/OvmfPkg/OvmfPkgIa32X64.fdf
+++ b/OvmfPkg/OvmfPkgIa32X64.fdf
@@ -62,10 +62,10 @@ FV = SECFV
 
 [FD.MEMFD]
 BaseAddress   = $(MEMFD_BASE_ADDRESS)
-Size          = 0xD00000
+Size          = 0x1100000
 ErasePolarity = 1
 BlockSize     = 0x10000
-NumBlocks     = 0xD0
+NumBlocks     = 0x110
 
 0x000000|0x006000
 gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSecPageTablesBase|gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSecPageTablesSize
@@ -86,7 +86,7 @@ gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSecPeiTempRamBase|gUefiOvmfPkgTokenSpaceGuid.P
 gUefiOvmfPkgTokenSpaceGuid.PcdOvmfPeiMemFvBase|gUefiOvmfPkgTokenSpaceGuid.PcdOvmfPeiMemFvSize
 FV = PEIFV
 
-0x100000|0xC00000
+0x100000|0x1000000
 gUefiOvmfPkgTokenSpaceGuid.PcdOvmfDxeMemFvBase|gUefiOvmfPkgTokenSpaceGuid.PcdOvmfDxeMemFvSize
 FV = DXEFV
 

--- a/OvmfPkg/OvmfPkgX64.fdf
+++ b/OvmfPkg/OvmfPkgX64.fdf
@@ -62,10 +62,10 @@ FV = SECFV
 
 [FD.MEMFD]
 BaseAddress   = $(MEMFD_BASE_ADDRESS)
-Size          = 0xD00000
+Size          = 0x1100000
 ErasePolarity = 1
 BlockSize     = 0x10000
-NumBlocks     = 0xD0
+NumBlocks     = 0x110
 
 0x000000|0x006000
 gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSecPageTablesBase|gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSecPageTablesSize
@@ -101,7 +101,7 @@ gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSecPeiTempRamBase|gUefiOvmfPkgTokenSpaceGuid.P
 gUefiOvmfPkgTokenSpaceGuid.PcdOvmfPeiMemFvBase|gUefiOvmfPkgTokenSpaceGuid.PcdOvmfPeiMemFvSize
 FV = PEIFV
 
-0x100000|0xC00000
+0x100000|0x1000000
 gUefiOvmfPkgTokenSpaceGuid.PcdOvmfDxeMemFvBase|gUefiOvmfPkgTokenSpaceGuid.PcdOvmfDxeMemFvSize
 FV = DXEFV
 


### PR DESCRIPTION
An attempt to build with following parameters:

1. BUILDTARGET:  `noopt`
2. TARGETARCH: `IA32X64` and `X64`
3. MACROS: `DEBUG_ON_SERIAL_PORT`, `SECURE_BOOT_ENABLE`, `SMM_REQUIRE`, `TPM2_ENABLE`, `TPM2_CONFIG_ENABLE`, `NETWORK_TLS_ENABLE`, `NETWORK_IP6_ENABLE`, `NETWORK_HTTP_BOOT_ENABLE`

which results in DXEFV build exceed the defined size of `0xc00000`
```
Generating FVMAIN_COMPACT FV

Generating PEIFV FV
####
Generating DXEFV FV
###### ['GenFv', '-F', 'FALSE', '-a', '/home/analyst/repos/git/github/fw/OVMF/edk2/Build/Ovmf3264/NOOPT_GCC5/FV/Ffs/DXEFV.inf', '-o', '/home/analyst/repos/git/github/fw/OVMF/edk2/Build/Ovmf3264/NOOPT_GCC5/FV/DXEFV.Fv', '-i', '/home/analyst/repos/git/github/fw/OVMF/edk2/Build/Ovmf3264/NOOPT_GCC5/FV/DXEFV.inf']
Return Value = 2
GenFv: ERROR 3000: Invalid
  the required fv image size 0xc1a468 exceeds the set fv image size 0xc00000




build.py...
 : error 7000: Failed to generate FV
```

Suggested working fix for `OvmfPkgIa32X64` and `OvmfPkgX64`:

1. `gUefiOvmfPkgTokenSpaceGuid.PcdOvmfDxeMemFvBase|gUefiOvmfPkgTokenSpaceGuid.PcdOvmfDxeMemFvSize` from `0x100000|0xC00000` to `0x100000|0x1000000`
2. `MEMFD` Size from `0xD00000` to `0x1100000`
3. `MEMFD` Number of Blocks from `0xD0` to `0x110`

Tried rebuild with the above changes and it successfully build.