### PR TITLE
OvmfPkg/VirtioGpuDxe: replace struct copy with CopyMem call

### DIFF
--- a/OvmfPkg/VirtioGpuDxe/Gop.c
+++ b/OvmfPkg/VirtioGpuDxe/Gop.c
@@ -509,7 +509,7 @@ GopSetMode (
   // Populate Mode and ModeInfo (mutable fields only).
   //
   VgpuGop->GopMode.Mode = ModeNumber;
-  VgpuGop->GopModeInfo  = *GopModeInfo;
+  CopyMem (&VgpuGop->GopModeInfo, GopModeInfo, sizeof VgpuGop->GopModeInfo);
   FreePool (GopModeInfo);
   return EFI_SUCCESS;
 


### PR DESCRIPTION
Build fix for `-t CLANG38 -b NOOPT -p OvmfPkg/OvmfPkgX64.dsc`.

Fixes: 5f6ecaa398ba ("OvmfPkg/VirtioGpuDxe: use GopQueryMode in GopSetMode")
Reported-by: Rebecca Cran <quic_rcran@quicinc.com>
Signed-off-by: Gerd Hoffmann <kraxel@redhat.com>