### PR TITLE
OvmfPkg: raise DXEFV size to 13 MB

### DIFF
--- a/OvmfPkg/OvmfPkgIa32.fdf
+++ b/OvmfPkg/OvmfPkgIa32.fdf
@@ -62,10 +62,10 @@ FV = SECFV
 
 [FD.MEMFD]
 BaseAddress   = $(MEMFD_BASE_ADDRESS)
-Size          = 0xD00000
+Size          = 0xE00000
 ErasePolarity = 1
 BlockSize     = 0x10000
-NumBlocks     = 0xD0
+NumBlocks     = 0xE0
 
 0x000000|0x006000
 gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSecPageTablesBase|gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSecPageTablesSize
@@ -86,7 +86,7 @@ gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSecPeiTempRamBase|gUefiOvmfPkgTokenSpaceGuid.P
 gUefiOvmfPkgTokenSpaceGuid.PcdOvmfPeiMemFvBase|gUefiOvmfPkgTokenSpaceGuid.PcdOvmfPeiMemFvSize
 FV = PEIFV
 
-0x100000|0xC00000
+0x100000|0xD00000
 gUefiOvmfPkgTokenSpaceGuid.PcdOvmfDxeMemFvBase|gUefiOvmfPkgTokenSpaceGuid.PcdOvmfDxeMemFvSize
 FV = DXEFV
 

--- a/OvmfPkg/OvmfPkgIa32X64.fdf
+++ b/OvmfPkg/OvmfPkgIa32X64.fdf
@@ -62,10 +62,10 @@ FV = SECFV
 
 [FD.MEMFD]
 BaseAddress   = $(MEMFD_BASE_ADDRESS)
-Size          = 0xD00000
+Size          = 0xE00000
 ErasePolarity = 1
 BlockSize     = 0x10000
-NumBlocks     = 0xD0
+NumBlocks     = 0xE0
 
 0x000000|0x006000
 gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSecPageTablesBase|gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSecPageTablesSize
@@ -86,7 +86,7 @@ gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSecPeiTempRamBase|gUefiOvmfPkgTokenSpaceGuid.P
 gUefiOvmfPkgTokenSpaceGuid.PcdOvmfPeiMemFvBase|gUefiOvmfPkgTokenSpaceGuid.PcdOvmfPeiMemFvSize
 FV = PEIFV
 
-0x100000|0xC00000
+0x100000|0xD00000
 gUefiOvmfPkgTokenSpaceGuid.PcdOvmfDxeMemFvBase|gUefiOvmfPkgTokenSpaceGuid.PcdOvmfDxeMemFvSize
 FV = DXEFV
 

--- a/OvmfPkg/OvmfPkgX64.fdf
+++ b/OvmfPkg/OvmfPkgX64.fdf
@@ -62,10 +62,10 @@ FV = SECFV
 
 [FD.MEMFD]
 BaseAddress   = $(MEMFD_BASE_ADDRESS)
-Size          = 0xD00000
+Size          = 0xE00000
 ErasePolarity = 1
 BlockSize     = 0x10000
-NumBlocks     = 0xD0
+NumBlocks     = 0xE0
 
 0x000000|0x006000
 gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSecPageTablesBase|gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSecPageTablesSize
@@ -101,7 +101,7 @@ gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSecPeiTempRamBase|gUefiOvmfPkgTokenSpaceGuid.P
 gUefiOvmfPkgTokenSpaceGuid.PcdOvmfPeiMemFvBase|gUefiOvmfPkgTokenSpaceGuid.PcdOvmfPeiMemFvSize
 FV = PEIFV
 
-0x100000|0xC00000
+0x100000|0xD00000
 gUefiOvmfPkgTokenSpaceGuid.PcdOvmfDxeMemFvBase|gUefiOvmfPkgTokenSpaceGuid.PcdOvmfDxeMemFvSize
 FV = DXEFV
 


### PR DESCRIPTION
Similarly to the commit mentioned here https://github.com/tianocore/edk2/commit/5e75c4d1fe4fd641abc9c15404e65a1dffe70e3e
("OvmfPkg: raise DXEFV size to 12 MB", 2020-03-11), DXEFV outgrown again:

> ./build.sh -a IA32 -a X64 -b NOOPT -D DEBUG_ON_SERIAL_PORT \
> -D SECURE_BOOT_ENABLE -D SMM_REQUIRE -D TPM2_ENABLE \
> -D TPM2_CONFIG_ENABLE -D NETWORK_TLS_ENABLE -D NETWORK_IP6_ENABLE \
> -D NETWORK_HTTP_BOOT_ENABLE
>
> Generating FVMAIN_COMPACT FV
>
> Generating PEIFV FV
> ####
> Generating DXEFV FV
> ###### ['GenFv', '-F', 'FALSE', '-a',
> '<path>/edk2/Build/Ovmf3264/NOOPT_GCC5/FV/Ffs/DXEFV.inf',
> '-o', '<path>/edk2/Build/Ovmf3264/NOOPT_GCC5/FV/DXEFV.Fv', '-i',
> '<path>/edk2/Build/Ovmf3264/NOOPT_GCC5/FV/DXEFV.inf']
> Return Value = 2
> GenFv: ERROR 3000: Invalid
>  the required fv image size 0xc1a468 exceeds the set fv image size 0xc00000

Raising DXEFV to 13MB resolves issue.

Build results afer fix:
Build: NOOPT

Ia32 (x86):
FV Space Information
SECFV [25%Full] 212992 (0x34000) total, 53440 (0xd0c0) used, 159552 (0x26f40) free
PEIFV [75%Full] 917504 (0xe0000) total, 697208 (0xaa378) used, 220296 (0x35c88) free
DXEFV [81%Full] 13631488 (0xd00000) total, 11168088 (0xaa6958) used, 2463400 (0x2596a8) free
FVMAIN_COMPACT [60%Full] 3440640 (0x348000) total, 2064800 (0x1f81a0) used, 1375840 (0x14fe60) free

X64:
FV Space Information
SECFV [44%Full] 212992 (0x34000) total, 94912 (0x172c0) used, 118080 (0x1cd40) free
PEIFV [96%Full] 917504 (0xe0000) total, 886328 (0xd8638) used, 31176 (0x79c8) free
DXEFV [95%Full] 13631488 (0xd00000) total, 12999496 (0xc65b48) used, 631992 (0x9a4b8) free
FVMAIN_COMPACT [61%Full] 3440640 (0x348000) total, 2106880 (0x202600) used, 1333760 (0x145a00) free

Ia32X64:
FV Space Information
SECFV [25%Full] 212992 (0x34000) total, 53440 (0xd0c0) used, 159552 (0x26f40) free
PEIFV [75%Full] 917504 (0xe0000) total, 697208 (0xaa378) used, 220296 (0x35c88) free
DXEFV [93%Full] 13631488 (0xd00000) total, 12690536 (0xc1a468) used, 940952 (0xe5b98) free
FVMAIN_COMPACT [61%Full] 3440640 (0x348000) total, 2120456 (0x205b08) used, 1320184 (0x1424f8) free

Signed-off-by: Wayne Lee <waxyzne@gmail.com>