### PR TITLE
Fsptempraminitx64

### DIFF
--- a/IntelFsp2Pkg/Include/SaveRestoreSseAvxNasm.inc
+++ b/IntelFsp2Pkg/Include/SaveRestoreSseAvxNasm.inc
@@ -178,6 +178,30 @@
             %endmacro
 
 ;
+; Upper half of YMM10 to save/restore RCX
+;
+;
+; Save RCX to YMM10[128:191]
+; Modified: XMM5 and YMM10
+;
+
+%macro SAVE_RCX     0
+            LYMMN   ymm10, xmm5, 1
+            SXMMN   xmm5, 0, rcx
+            SYMMN   ymm10, 1, xmm5
+            %endmacro
+
+;
+; Restore RCX from YMM10[128:191]
+; Modified: XMM5 and RCX
+;
+
+%macro LOAD_RCX     0
+            LYMMN   ymm10, xmm5, 1
+            movq    rcx,  xmm5
+            %endmacro
+
+;
 ; YMM7[128:191] for calling stack
 ; arg 1:Entry
 ; Modified: RSI, XMM5, YMM7
@@ -231,6 +255,7 @@ NextAddress:
             ; Use CpuId instruction (CPUID.01H:EDX.SSE[bit 25] = 1) to test
             ; whether the processor supports SSE instruction.
             ;
+            mov     r10, rcx
             mov     rax, 1
             cpuid
             bt      rdx, 25
@@ -241,6 +266,7 @@ NextAddress:
             ;
             bt      ecx, 19
             jnc     SseError
+            mov     rcx,  r10
 
             ;
             ; Set OSFXSR bit (bit #9) & OSXMMEXCPT bit (bit #10)
@@ -258,6 +284,7 @@ NextAddress:
             %endmacro
 
 %macro ENABLE_AVX   0
+            mov     r10, rcx
             mov     eax, 1
             cpuid
             and     ecx, 10000000h
@@ -280,5 +307,6 @@ EnableAvx:
             xgetbv                 ; result in edx:eax
             or      eax, 00000006h ; Set XCR0 bit #1 and bit #2 to enable SSE state and AVX state
             xsetbv
+            mov     rcx, r10
             %endmacro
 

--- a/IntelFsp2WrapperPkg/Library/SecFspWrapperPlatformSecLibSample/X64/SecEntry.nasm
+++ b/IntelFsp2WrapperPkg/Library/SecFspWrapperPlatformSecLibSample/X64/SecEntry.nasm
@@ -130,6 +130,9 @@ FspHeaderFound:
   mov     eax, dword [edi + FSP_HEADER_IMAGEBASE_OFFSET]
   add     eax, dword [edi + FSP_HEADER_TEMPRAMINIT_OFFSET]
 
+  ; Pass Fsp T Upd pointer as Input parameter
+  mov     rcx, ASM_PFX(FsptUpdDataPtr)
+
   ; Setup the hardcode stack
   mov     rsp, TempRamInitStack
 
@@ -167,5 +170,4 @@ FspApiFailed:
 align 10h
 TempRamInitStack:
     DQ  TempRamInitDone
-    DQ  ASM_PFX(FsptUpdDataPtr)         ; TempRamInitParams
 


### PR DESCRIPTION
[IntelFsp2Pkg: FSP_TEMP_RAM_INIT call must follow X64 Calling Convention](https://github.com/tianocore/edk2/commit/18eb92c5ff5e5f64226732f164ddad62e244fe76) 

REF:https://bugzilla.tianocore.org/show_bug.cgi?id=3926
This API accept one parameter using RCX and this is consumed
in mutiple sub functions.

Cc: Chasel Chiu <chasel.chiu@intel.com>
Cc: Nate DeSimone <nathaniel.l.desimone@intel.com>
Cc: Star Zeng <star.zeng@intel.com>
Cc: Ashraf Ali S <ashraf.ali.s@intel.com>
Signed-off-by: cbduggap <chinni.b.duggapu@intel.com>
Reviewed-by: Chasel Chiu <chasel.chiu@intel.com>