### PR TITLE
Fix 2 issues in TDVF

### DIFF
--- a/OvmfPkg/Library/PeilessStartupLib/Hob.c
+++ b/OvmfPkg/Library/PeilessStartupLib/Hob.c
@@ -22,6 +22,8 @@
 #include <OvmfPlatforms.h>
 #include "PeilessStartupInternal.h"
 
+#define EFI_RESOURCE_MEMORY_UNACCEPTED  7
+
 /**
  * Construct the HobList in SEC phase.
  *
@@ -90,7 +92,7 @@ ConstructFwHobList (
   //
   while (!END_OF_HOB_LIST (Hob)) {
     if (Hob.Header->HobType == EFI_HOB_TYPE_RESOURCE_DESCRIPTOR) {
-      if (Hob.ResourceDescriptor->ResourceType == EFI_RESOURCE_SYSTEM_MEMORY) {
+      if (Hob.ResourceDescriptor->ResourceType == EFI_RESOURCE_MEMORY_UNACCEPTED) {
         PhysicalEnd    = Hob.ResourceDescriptor->PhysicalStart + Hob.ResourceDescriptor->ResourceLength;
         ResourceLength = Hob.ResourceDescriptor->ResourceLength;
 

--- a/OvmfPkg/TdxDxe/X64/ApRunLoop.nasm
+++ b/OvmfPkg/TdxDxe/X64/ApRunLoop.nasm
@@ -42,10 +42,11 @@ AsmRelocateApMailBoxLoopStart:
 
     mov         rax, TDVMCALL
     mov         rcx, TDVMCALL_EXPOSE_REGS_MASK
+    xor         r10, r10
     mov         r11, EXIT_REASON_CPUID
     mov         r12, 0xb
     tdcall
-    test        rax, rax
+    test        r10, r10
     jnz         Panic
     mov         r8, r15
 


### PR DESCRIPTION
From: Min Xu <min.m.xu@intel.com>
Date: 5/31/2022 10:31:15 PM
Subject: [PATCH 0/2] Fix 2 issues in TDVF

During the integration test with TDX upstreaming KVM/QEMU there are 2
issues are found. This patch-set are to fix these 2 issue.
 - Fix TDVMCALL error in ApRunLoop.nasm
 - Search EFI_RESOURCE_MEMORY_UNACCEPTED for Fw hoblist

Cc: Erdem Aktas <erdemaktas@google.com>
Cc: Gerd Hoffmann <kraxel@redhat.com>
Cc: James Bottomley <jejb@linux.ibm.com>
Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Tom Lendacky <thomas.lendacky@amd.com>
Signed-off-by: Min Xu <min.m.xu@intel.com>
*** BLURB HERE ***

Min Xu (2):
  OvmfPkg: Fix TDVMCALL error in ApRunLoop.nasm
  OvmfPkg: Search EFI_RESOURCE_MEMORY_UNACCEPTED for Fw hoblist

 OvmfPkg/Library/PeilessStartupLib/Hob.c | 4 +++-
 OvmfPkg/TdxDxe/X64/ApRunLoop.nasm       | 3 ++-
 2 files changed, 5 insertions(+), 2 deletions(-)
