### PR TITLE
.pytool: UncrustifyCheck: Set IgnoreFiles path relative to package path

### DIFF
--- a/.pytool/Plugin/UncrustifyCheck/UncrustifyCheck.py
+++ b/.pytool/Plugin/UncrustifyCheck/UncrustifyCheck.py
@@ -290,7 +290,7 @@ class UncrustifyCheck(ICiBuildPlugin):
         # This information is only used for reporting (not used here) and
         # the ignore lines are being passed directly as they are given to
         # this plugin.
-        return parse_gitignore_lines(ignored_files, "Package configuration file", self._abs_workspace_path)
+        return parse_gitignore_lines(ignored_files, "Package configuration file", self._abs_package_path)
 
     def _get_git_ignored_paths(self) -> List[str]:
         """"


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3942

`IgnoreFiles` tag is specified in the CI YAML files in each individual
packages. The current logic for UncrustifyCheck script bases specified
file paths from workspace, which requires the package name to be included
in each entry.

This change updates the ignore checking logic to be based on current
package path in order to reduce redundancy. It also keeps the consistency
of `IgnoreFiles` field other pytools such as SpellCheck and EccCheck.

Cc: Sean Brogan <sean.brogan@microsoft.com>
Cc: Bret Barkelew <Bret.Barkelew@microsoft.com>
Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Michael Kubacki <mikuback@linux.microsoft.com>

Signed-off-by: Kun Qin <kuqin12@gmail.com>