### PR TITLE
DxeMain: Fix the bug that StackGuard is not enabled

### DIFF
--- a/ArmPkg/Library/ArmExceptionLib/ArmExceptionLib.c
+++ b/ArmPkg/Library/ArmExceptionLib/ArmExceptionLib.c
@@ -4,6 +4,7 @@
 *  Copyright (c) 2008 - 2009, Apple Inc. All rights reserved.<BR>
 *  Copyright (c) 2011-2021, Arm Limited. All rights reserved.<BR>
 *  Copyright (c) 2016 HP Development Company, L.P.
+*  Copyright (c) 2022, Intel Corporation. All rights reserved.<BR>
 *
 *  SPDX-License-Identifier: BSD-2-Clause-Patent
 *
@@ -195,32 +196,6 @@ CopyExceptionHandlers (
 }
 
 /**
-Initializes all CPU interrupt/exceptions entries and provides the default interrupt/exception handlers.
-
-Caller should try to get an array of interrupt and/or exception vectors that are in use and need to
-persist by EFI_VECTOR_HANDOFF_INFO defined in PI 1.3 specification.
-If caller cannot get reserved vector list or it does not exists, set VectorInfo to NULL.
-If VectorInfo is not NULL, the exception vectors will be initialized per vector attribute accordingly.
-
-@param[in]  VectorInfo    Pointer to reserved vector list.
-
-@retval EFI_SUCCESS           All CPU interrupt/exception entries have been successfully initialized
-with default interrupt/exception handlers.
-@retval EFI_INVALID_PARAMETER VectorInfo includes the invalid content if VectorInfo is not NULL.
-@retval EFI_UNSUPPORTED       This function is not supported.
-
-**/
-EFI_STATUS
-EFIAPI
-InitializeCpuInterruptHandlers (
-  IN EFI_VECTOR_HANDOFF_INFO  *VectorInfo OPTIONAL
-  )
-{
-  // not needed, this is what the CPU driver is for
-  return EFI_UNSUPPORTED;
-}
-
-/**
 Registers a function to be called from the processor exception handler. (On ARM/AArch64 this only
 provides exception handlers, not interrupt handling which is provided through the Hardware Interrupt
 Protocol.)
@@ -229,8 +204,8 @@ This function registers and enables the handler specified by ExceptionHandler fo
 interrupt or exception type specified by ExceptionType. If ExceptionHandler is NULL, then the
 handler for the processor interrupt or exception type specified by ExceptionType is uninstalled.
 The installed handler is called once for each processor interrupt or exception.
-NOTE: This function should be invoked after InitializeCpuExceptionHandlers() or
-InitializeCpuInterruptHandlers() invoked, otherwise EFI_UNSUPPORTED returned.
+NOTE: This function should be invoked after InitializeCpuExceptionHandlers() is invoked,
+otherwise EFI_UNSUPPORTED returned.
 
 @param[in]  ExceptionType     Defines which interrupt or exception to hook.
 @param[in]  ExceptionHandler  A pointer to a function of type EFI_CPU_INTERRUPT_HANDLER that is called
@@ -312,33 +287,22 @@ CommonCExceptionHandler (
 }
 
 /**
-  Initializes all CPU exceptions entries with optional extra initializations.
+  Setup separate stacks for certain exception handlers.
 
-  By default, this method should include all functionalities implemented by
-  InitializeCpuExceptionHandlers(), plus extra initialization works, if any.
-  This could be done by calling InitializeCpuExceptionHandlers() directly
-  in this method besides the extra works.
+  InitData is optional and processor arch dependent.
 
-  InitData is optional and its use and content are processor arch dependent.
-  The typical usage of it is to convey resources which have to be reserved
-  elsewhere and are necessary for the extra initializations of exception.
+  @param[in]  InitData      Pointer to data optional for information about how
+                            to assign stacks for certain exception handlers.
 
-  @param[in]  VectorInfo    Pointer to reserved vector list.
-  @param[in]  InitData      Pointer to data optional for extra initializations
-                            of exception.
-
-  @retval EFI_SUCCESS             The exceptions have been successfully
-                                  initialized.
-  @retval EFI_INVALID_PARAMETER   VectorInfo or InitData contains invalid
-                                  content.
+  @retval EFI_SUCCESS             The stacks are assigned successfully.
+  @retval EFI_UNSUPPORTED         This function is not supported.
 
 **/
 EFI_STATUS
 EFIAPI
-InitializeCpuExceptionHandlersEx (
-  IN EFI_VECTOR_HANDOFF_INFO  *VectorInfo OPTIONAL,
+InitializeSeparateExceptionStacks (
   IN CPU_EXCEPTION_INIT_DATA  *InitData OPTIONAL
   )
 {
-  return InitializeCpuExceptionHandlers (VectorInfo);
+  return EFI_SUCCESS;
 }

--- a/MdeModulePkg/Core/Dxe/DxeMain/DxeMain.c
+++ b/MdeModulePkg/Core/Dxe/DxeMain/DxeMain.c
@@ -257,6 +257,14 @@ DxeMain (
   ASSERT_EFI_ERROR (Status);
 
   //
+  // Setup Stack Guard
+  //
+  if (PcdGetBool (PcdCpuStackGuard)) {
+    Status = InitializeSeparateExceptionStacks (NULL);
+    ASSERT_EFI_ERROR (Status);
+  }
+
+  //
   // Initialize Debug Agent to support source level debug in DXE phase
   //
   InitializeDebugAgent (DEBUG_AGENT_INIT_DXE_CORE, HobStart, NULL);


### PR DESCRIPTION
Commit e7abb94d1 removed InitializeCpuExceptionHandlersEx
and updated DxeMain to call InitializeCpuExceptionHandlers
for exception setup. But the old behavior that calls *Ex() sets
up the stack guard as well. To match the old behavior,
the patch calls InitializeSeparateExceptionStacks.

Signed-off-by: Ray Ni <ray.ni@intel.com>
Reviewed-by: Jian J Wang <jian.j.wang@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>