### PR TITLE
SecurityPkg: use SmmWaitForAllProcessor in TcgSmm and Tcg2Smm driver.

### DIFF
--- a/SecurityPkg/Tcg/Tcg2Smm/Tcg2Smm.h
+++ b/SecurityPkg/Tcg/Tcg2Smm/Tcg2Smm.h
@@ -1,7 +1,7 @@
 /** @file
   The header file for Tcg2 SMM driver.
 
-Copyright (c) 2015 - 2018, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2015 - 2022, Intel Corporation. All rights reserved.<BR>
 Copyright (c) Microsoft Corporation.
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -31,6 +31,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/IoLib.h>
 #include <Library/PcdLib.h>
 #include <Library/Tpm2DeviceLib.h>
+#include <Library/SmmCpuRendezvousLib.h>
 
 #include <IndustryStandard/TpmPtp.h>
 

--- a/SecurityPkg/Tcg/Tcg2Smm/Tcg2Smm.inf
+++ b/SecurityPkg/Tcg/Tcg2Smm/Tcg2Smm.inf
@@ -20,7 +20,7 @@
 #  This driver will have external input - variable and ACPINvs data in SMM mode.
 #  This external input must be validated carefully to avoid security issue.
 #
-# Copyright (c) 2015 - 2019, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2015 - 2022, Intel Corporation. All rights reserved.<BR>
 # Copyright (c) Microsoft Corporation.<BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -59,6 +59,7 @@
   Tcg2PhysicalPresenceLib
   PcdLib
   SmmMemLib
+  SmmCpuRendezvousLib
 
 [Guids]
   ## SOMETIMES_PRODUCES ## Variable:L"MemoryOverwriteRequestControl"

--- a/SecurityPkg/Tcg/Tcg2Smm/Tcg2StandaloneMm.inf
+++ b/SecurityPkg/Tcg/Tcg2Smm/Tcg2StandaloneMm.inf
@@ -55,6 +55,7 @@
   Tcg2PhysicalPresenceLib
   PcdLib
   MemLib
+  SmmCpuRendezvousLib
 
 [Guids]
   ## SOMETIMES_PRODUCES ## Variable:L"MemoryOverwriteRequestControl"

--- a/SecurityPkg/Tcg/TcgSmm/TcgSmm.c
+++ b/SecurityPkg/Tcg/TcgSmm/TcgSmm.c
@@ -8,7 +8,7 @@
 
   PhysicalPresenceCallback() and MemoryClearCallback() will receive untrusted input and do some check.
 
-Copyright (c) 2011 - 2018, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2011 - 2022, Intel Corporation. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -33,7 +33,7 @@ TCG_NVS                    *mTcgNvs;
   @param[in, out] CommBufferSize  The size of the CommBuffer.
 
   @retval EFI_SUCCESS             The interrupt was handled successfully.
-
+  @retval EFI_ABORTED             Fail to wait for all AP check in SMM.
 **/
 EFI_STATUS
 EFIAPI
@@ -90,6 +90,11 @@ PhysicalPresenceCallback (
       //
       mTcgNvs->PhysicalPresence.ReturnCode = TCG_PP_SUBMIT_REQUEST_TO_PREOS_NOT_IMPLEMENTED;
       return EFI_SUCCESS;
+    }
+
+    if (EFI_ERROR (SmmWaitForAllProcessor (TRUE))) {
+      DEBUG ((DEBUG_ERROR, "TPMPhysicalPresent: fail to wait for all AP check in SMM!\n"));
+      return EFI_ABORTED;
     }
 
     if (PpData.PPRequest != mTcgNvs->PhysicalPresence.Request) {
@@ -238,6 +243,7 @@ PhysicalPresenceCallback (
   @param[in, out] CommBufferSize  The size of the CommBuffer.
 
   @retval EFI_SUCCESS             The interrupt was handled successfully.
+  @retval EFI_ABORTED             Fail to wait for all AP check in SMM.
 
 **/
 EFI_STATUS
@@ -280,6 +286,11 @@ MemoryClearCallback (
     mTcgNvs->MemoryClear.ReturnCode = MOR_REQUEST_GENERAL_FAILURE;
     DEBUG ((DEBUG_ERROR, "[TPM] MOR Parameter error! Parameter = %x\n", mTcgNvs->MemoryClear.Parameter));
     return EFI_SUCCESS;
+  }
+
+  if (EFI_ERROR (SmmWaitForAllProcessor (TRUE))) {
+    DEBUG ((DEBUG_ERROR, " TpmMemoryClear: fail to wait for all AP check in SMM!\n"));
+    return EFI_ABORTED;
   }
 
   DataSize = sizeof (UINT8);

--- a/SecurityPkg/Tcg/TcgSmm/TcgSmm.h
+++ b/SecurityPkg/Tcg/TcgSmm/TcgSmm.h
@@ -1,7 +1,7 @@
 /** @file
   The header file for TCG SMM driver.
 
-Copyright (c) 2012 - 2018, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2012 - 2022, Intel Corporation. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -31,6 +31,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/TpmMeasurementLib.h>
 #include <Library/PcdLib.h>
 #include <Library/TcgPpVendorLib.h>
+#include <Library/SmmCpuRendezvousLib.h>
 
 #pragma pack(1)
 typedef struct {

--- a/SecurityPkg/Tcg/TcgSmm/TcgSmm.inf
+++ b/SecurityPkg/Tcg/TcgSmm/TcgSmm.inf
@@ -9,7 +9,7 @@
 #  This driver will have external input - variable and ACPINvs data in SMM mode.
 #  This external input must be validated carefully to avoid security issue.
 #
-# Copyright (c) 2011 - 2018, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2011 - 2022, Intel Corporation. All rights reserved.<BR>
 # Copyright (c) Microsoft Corporation.<BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -46,6 +46,7 @@
   TpmMeasurementLib
   PcdLib
   TcgPpVendorLib
+  SmmCpuRendezvousLib
 
 [Guids]
   ## SOMETIMES_PRODUCES ## Variable:L"PhysicalPresence"


### PR DESCRIPTION
REF： https://bugzilla.tianocore.org/show_bug.cgi?id=3855

In UefiCpuPkg, there are a new Protocol with the new service
SmmWaitForAllProcessor(), which can be used by SMI handler
to optionally wait for other APs to complete SMM rendezvous in
relaxed AP mode.

This patch use the new service to let TcgSmm and Tcg2Smm driver work
normally in relaxed AP mode.

Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Rahul Kumar <rahul1.kumar@intel.com>
Cc: Qi Zhang <qi1.zhang@intel.com>

Signed-off-by: Zhihao Li <zhihao.li@intel.com>