### PR TITLE
BaseTools: output the intermediate library instance when error occurs

### DIFF
--- a/BaseTools/Source/Python/Workspace/WorkspaceCommon.py
+++ b/BaseTools/Source/Python/Workspace/WorkspaceCommon.py
@@ -150,7 +150,9 @@ def GetModuleLibInstances(Module, Platform, BuildDatabase, Arch, Target, Toolcha
                         EdkLogger.error("build", OPTION_MISSING,
                                         "Module type [%s] is not supported by library instance [%s]" \
                                         % (ModuleType, LibraryPath), File=FileName,
-                                        ExtraData="consumed by [%s]" % str(Module))
+                                        ExtraData="consumed by library instance [%s] which is consumed by module [%s]" \
+                                        % (str(M), str(Module))
+                                        )
                     else:
                         return []
 


### PR DESCRIPTION
When a module "Module" depends on a library instance "Lib1" which
depends on "Lib2" which depends on "Lib3" ... depends on "LibN",
but "LibN" doesn't support the type (e.g.: SEC) of the "Module", the
following error messages are printed by build tool:

<DSC path>(...): error 1001: Module by library instance [<LibN path>]
        consumed by [<Module path>]

But it's unclear to user how LibN is consumed by the Module.

With the patch, following errors are printed:

<DSC path>(...): error 1001: Module by library instance [<LibN path>]
        consumed by library instance [<Lib N-1 path>] which is
        consumed by module[<Module path>]

It doesn't print all the intermediate library instances between the
Module and LibN but at least the path of Lib N-1 can help users
to help how to fix the build errors.

I hope this patch can be a trigger point that a better solution could
be developed by tool experts to print all the library instances
between the Module and LibN.

Signed-off-by: Ray Ni <ray.ni@intel.com>
Cc: Bob Feng <bob.c.feng@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Yuwei Chen <yuwei.chen@intel.com>