### PR TITLE
UefiPayloadPkg: Increase the PcdMaximumUnicodeStringLength

### DIFF
--- a/UefiPayloadPkg/UefiPayloadPkg.dsc
+++ b/UefiPayloadPkg/UefiPayloadPkg.dsc
@@ -410,6 +410,7 @@
 
   gUefiPayloadPkgTokenSpaceGuid.PcdDispatchModuleAbove4GMemory|$(ABOVE_4G_MEMORY)
   gUefiPayloadPkgTokenSpaceGuid.PcdBootManagerEscape|$(BOOT_MANAGER_ESCAPE)
+  gEfiMdePkgTokenSpaceGuid.PcdMaximumUnicodeStringLength|1800000
 
 [PcdsPatchableInModule.X64]
   gPcAtChipsetPkgTokenSpaceGuid.PcdRtcIndexRegister|$(RTC_INDEX_REGISTER)


### PR DESCRIPTION
The maximum Unicode string could be as large as 1800000 in certain
platforms when HII code builds the configuration strings.
This causes assertion in PrintLib.
The patch increases the PcdMaximumUnicodeStringLength to 1800000 to
avoid the assertion.

Signed-off-by: Yuanhao Xie <yuanhao.xie@intel.com>
Cc: Guo Dong <guo.dong@intel.com>
Reviewed-by: Ray Ni <ray.ni@intel.com>
Cc: Maurice Ma <maurice.ma@intel.com>
Cc: Benjamin You <benjamin.you@intel.com>