### PR TITLE
UefiPayloadPkg: Always split page table entry to 4K if it covers stack.

### DIFF
--- a/UefiPayloadPkg/UefiPayloadEntry/X64/VirtualMemory.c
+++ b/UefiPayloadPkg/UefiPayloadEntry/X64/VirtualMemory.c
@@ -218,16 +218,8 @@ ToSplitPageTable (
     return TRUE;
   }
 
-  if (PcdGetBool (PcdCpuStackGuard)) {
-    if ((StackBase >= Address) && (StackBase < (Address + Size))) {
-      return TRUE;
-    }
-  }
-
-  if (PcdGetBool (PcdSetNxForStack)) {
-    if ((Address < StackBase + StackSize) && ((Address + Size) > StackBase)) {
-      return TRUE;
-    }
+  if ((Address < StackBase + StackSize) && ((Address + Size) > StackBase)) {
+    return TRUE;
   }
 
   if (GhcbBase != 0) {


### PR DESCRIPTION
We observed page fault in the following situation:
1.PayloadEntry uses 2M entry in page table to cover DXE stack range.
2.In DXE phase, image protection code needs to mark some sub-range in
this 2M entry as readonly. So the the 2M page table entry is split to
512 4K entries, and some of the entries are marked as readonly.
(the entries covering stack still remain R/W)
3.Page fault exception happens when trying to access stack.

Always split the page table entry to 4K if it covers stack to avoid this
issue.
More discussion about this issue can be seen at below link
https://edk2.groups.io/g/devel/topic/91446026

Cc: Guo Dong <guo.dong@intel.com>
Reviewed-by: Ray Ni <ray.ni@intel.com>
Cc: Maurice Ma <maurice.ma@intel.com>
Cc: Benjamin You <benjamin.you@intel.com>
Cc: Sean Rhodes <sean@starlabs.systems>
Cc: Gerd Hoffmann <kraxel@redhat.com>
Signed-off-by: Zhiguang Liu <zhiguang.liu@intel.com>