### PR TITLE
ArmPlatformPkg: Remove overly verbose DEBUG lines in LcdGraphicsBlt

### DIFF
--- a/ArmPlatformPkg/Drivers/LcdGraphicsOutputDxe/LcdGraphicsOutputBlt.c
+++ b/ArmPlatformPkg/Drivers/LcdGraphicsOutputDxe/LcdGraphicsOutputBlt.c
@@ -815,18 +815,6 @@ LcdGraphicsBlt (
   HorizontalResolution = This->Mode->Info->HorizontalResolution;
   VerticalResolution   = This->Mode->Info->VerticalResolution;
 
-  DEBUG ((
-    DEBUG_INFO,
-    "LcdGraphicsBlt (BltOperation:%d,DestX:%d,DestY:%d,Width:%d,Height:%d) res(%d,%d)\n",
-    BltOperation,
-    DestinationX,
-    DestinationY,
-    Width,
-    Height,
-    HorizontalResolution,
-    VerticalResolution
-    ));
-
   // Check we have reasonable parameters
   if ((Width == 0) || (Height == 0)) {
     DEBUG ((DEBUG_ERROR, "LcdGraphicsBlt: ERROR - Invalid dimension: Zero size area.\n"));


### PR DESCRIPTION
The DEBUG output in LcdGraphicsBlt is overly verbose, and makes using
the console difficult, for example when using the UiApp.

Since the extra output should no longer be needed, delete the DEBUG
lines.

Signed-off-by: Rebecca Cran <rebecca@bsdio.com>
Reviewed-by: Sami Mujawar <sami.mujawar@arm.com>