### PR TITLE
ArmPlatformPkg: Add PCD for serial debug port interrupt

### DIFF
--- a/ArmPlatformPkg/ArmPlatformPkg.dec
+++ b/ArmPlatformPkg/ArmPlatformPkg.dec
@@ -94,6 +94,7 @@
   gArmPlatformTokenSpaceGuid.PcdSerialDbgRegisterBase|0x00000000|UINT64|0x00000030
   gArmPlatformTokenSpaceGuid.PcdSerialDbgUartBaudRate|0x00000000|UINT64|0x00000031
   gArmPlatformTokenSpaceGuid.PcdSerialDbgUartClkInHz|0x00000000|UINT32|0x00000032
+  gArmPlatformTokenSpaceGuid.PcdSerialDbgInterrupt|0x00000000|UINT32|0x00000041
 
   ## PL061 GPIO
   gArmPlatformTokenSpaceGuid.PcdPL061GpioBase|0x0|UINT32|0x00000025


### PR DESCRIPTION
For Arm platforms that support more that one serial port, one of the
serial port can be used for connecting debuggers such as WinDbg. There
are PCDs that allow the base address and clock rate to be specified for
this debug serial port but not its interrupt number. So add a PCD to
specify the interrupt number assigned to the serial debug port
controller.

Signed-off-by: Thomas Abraham <thomas.abraham@arm.com>
Reviewed-by: Ard Biesheuvel <ardb@kernel.org>