### PR TITLE
MdeModulePkg/XhciDxe: Add access xHCI Extended Capabilities Pointer

### DIFF
--- a/MdeModulePkg/Bus/Pci/XhciDxe/Xhci.c
+++ b/MdeModulePkg/Bus/Pci/XhciDxe/Xhci.c
@@ -399,24 +399,31 @@ XhcGetRootHubPortStatus (
 
   //
   // According to XHCI 1.1 spec November 2017,
-  // bit 10~13 of the root port status register identifies the speed of the attached device.
+  // Section 7.2 xHCI Support Protocol Capability
   //
-  switch ((State & XHC_PORTSC_PS) >> 10) {
-    case 2:
-      PortStatus->PortStatus |= USB_PORT_STAT_LOW_SPEED;
-      break;
+  PortStatus->PortStatus = XhcCheckUsbPortSpeedUsedPsic (Xhc, ((State & XHC_PORTSC_PS) >> 10));
+  if (PortStatus->PortStatus == 0) {
+    //
+    // According to XHCI 1.1 spec November 2017,
+    // bit 10~13 of the root port status register identifies the speed of the attached device.
+    //
+    switch ((State & XHC_PORTSC_PS) >> 10) {
+      case 2:
+        PortStatus->PortStatus |= USB_PORT_STAT_LOW_SPEED;
+        break;
 
-    case 3:
-      PortStatus->PortStatus |= USB_PORT_STAT_HIGH_SPEED;
-      break;
+      case 3:
+        PortStatus->PortStatus |= USB_PORT_STAT_HIGH_SPEED;
+        break;
 
-    case 4:
-    case 5:
-      PortStatus->PortStatus |= USB_PORT_STAT_SUPER_SPEED;
-      break;
+      case 4:
+      case 5:
+        PortStatus->PortStatus |= USB_PORT_STAT_SUPER_SPEED;
+        break;
 
-    default:
-      break;
+      default:
+        break;
+    }
   }
 
   //
@@ -1826,6 +1833,8 @@ XhcCreateUsbHc (
   Xhc->ExtCapRegBase     = ExtCapReg << 2;
   Xhc->UsbLegSupOffset   = XhcGetCapabilityAddr (Xhc, XHC_CAP_USB_LEGACY);
   Xhc->DebugCapSupOffset = XhcGetCapabilityAddr (Xhc, XHC_CAP_USB_DEBUG);
+  Xhc->Usb2SupOffset     = XhcGetSupportedProtocolCapabilityAddr (Xhc, XHC_SUPPORTED_PROTOCOL_DW0_MAJOR_REVISION_USB2);
+  Xhc->Usb3SupOffset     = XhcGetSupportedProtocolCapabilityAddr (Xhc, XHC_SUPPORTED_PROTOCOL_DW0_MAJOR_REVISION_USB3);
 
   DEBUG ((DEBUG_INFO, "XhcCreateUsb3Hc: Capability length 0x%x\n", Xhc->CapLength));
   DEBUG ((DEBUG_INFO, "XhcCreateUsb3Hc: HcSParams1 0x%x\n", Xhc->HcSParams1));
@@ -1835,6 +1844,8 @@ XhcCreateUsbHc (
   DEBUG ((DEBUG_INFO, "XhcCreateUsb3Hc: RTSOff 0x%x\n", Xhc->RTSOff));
   DEBUG ((DEBUG_INFO, "XhcCreateUsb3Hc: UsbLegSupOffset 0x%x\n", Xhc->UsbLegSupOffset));
   DEBUG ((DEBUG_INFO, "XhcCreateUsb3Hc: DebugCapSupOffset 0x%x\n", Xhc->DebugCapSupOffset));
+  DEBUG ((DEBUG_INFO, "XhcCreateUsb3Hc: Usb2SupOffset 0x%x\n", Xhc->Usb2SupOffset));
+  DEBUG ((DEBUG_INFO, "XhcCreateUsb3Hc: Usb3SupOffset 0x%x\n", Xhc->Usb3SupOffset));
 
   //
   // Create AsyncRequest Polling Timer

--- a/MdeModulePkg/Bus/Pci/XhciDxe/Xhci.h
+++ b/MdeModulePkg/Bus/Pci/XhciDxe/Xhci.h
@@ -227,6 +227,8 @@ struct _USB_XHCI_INSTANCE {
   UINT32                      ExtCapRegBase;
   UINT32                      UsbLegSupOffset;
   UINT32                      DebugCapSupOffset;
+  UINT32                      Usb2SupOffset;
+  UINT32                      Usb3SupOffset;
   UINT64                      *DCBAA;
   VOID                        *DCBAAMap;
   UINT32                      MaxSlotsEn;

--- a/MdeModulePkg/Bus/Pci/XhciDxe/XhciReg.h
+++ b/MdeModulePkg/Bus/Pci/XhciDxe/XhciReg.h
@@ -25,8 +25,9 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #define USB_HUB_CLASS_CODE     0x09
 #define USB_HUB_SUBCLASS_CODE  0x00
 
-#define XHC_CAP_USB_LEGACY  0x01
-#define XHC_CAP_USB_DEBUG   0x0A
+#define XHC_CAP_USB_LEGACY              0x01
+#define XHC_CAP_USB_DEBUG               0x0A
+#define XHC_CAP_USB_SUPPORTED_PROTOCOL  0x02
 
 // ============================================//
 //           XHCI register offset             //
@@ -73,6 +74,18 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #define USBLEGSP_BIOS_SEMAPHORE  BIT16           // HC BIOS Owned Semaphore
 #define USBLEGSP_OS_SEMAPHORE    BIT24           // HC OS Owned Semaphore
+
+//
+// xHCI Supported Protocol Capability
+//
+#define XHC_SUPPORTED_PROTOCOL_DW0_MAJOR_REVISION_USB2  0x02
+#define XHC_SUPPORTED_PROTOCOL_DW0_MAJOR_REVISION_USB3  0x03
+#define XHC_SUPPORTED_PROTOCOL_NAME_STRING_OFFSET       0x04
+#define XHC_SUPPORTED_PROTOCOL_NAME_STRING_VALUE        0x20425355
+#define XHC_SUPPORTED_PROTOCOL_DW2_OFFSET               0x08
+#define XHC_SUPPORTED_PROTOCOL_PSI_OFFSET               0x10
+#define XHC_SUPPORTED_PROTOCOL_USB2_HIGH_SPEED_PSIM     480
+#define XHC_SUPPORTED_PROTOCOL_USB2_LOW_SPEED_PSIM      1500
 
 #pragma pack (1)
 typedef struct {
@@ -129,6 +142,52 @@ typedef union {
   UINT32       Dword;
   HCCPARAMS    Data;
 } XHC_HCCPARAMS;
+
+//
+// xHCI Supported Protocol Cabability
+//
+typedef struct {
+  UINT8    CapId;
+  UINT8    NextExtCapReg;
+  UINT8    RevMinor;
+  UINT8    RevMajor;
+} SUPPORTED_PROTOCOL_DW0;
+
+typedef union {
+  UINT32                    Dword;
+  SUPPORTED_PROTOCOL_DW0    Data;
+} XHC_SUPPORTED_PROTOCOL_DW0;
+
+typedef struct {
+  UINT32    NameString;
+} XHC_SUPPORTED_PROTOCOL_DW1;
+
+typedef struct {
+  UINT8     CompPortOffset;
+  UINT8     CompPortCount;
+  UINT16    ProtocolDef : 12;
+  UINT16    Psic        : 4;
+} SUPPORTED_PROTOCOL_DW2;
+
+typedef union {
+  UINT32                    Dword;
+  SUPPORTED_PROTOCOL_DW2    Data;
+} XHC_SUPPORTED_PROTOCOL_DW2;
+
+typedef struct {
+  UINT16    Psiv  : 4;
+  UINT16    Psie  : 2;
+  UINT16    Plt   : 2;
+  UINT16    Pfd   : 1;
+  UINT16    RsvdP : 5;
+  UINT16    Lp    : 2;
+  UINT16    Psim;
+} SUPPORTED_PROTOCOL_PROTOCOL_SPEED_ID;
+
+typedef union {
+  UINT32                                  Dword;
+  SUPPORTED_PROTOCOL_PROTOCOL_SPEED_ID    Data;
+} XHC_SUPPORTED_PROTOCOL_PROTOCOL_SPEED_ID;
 
 #pragma pack ()
 
@@ -544,6 +603,36 @@ UINT32
 XhcGetCapabilityAddr (
   IN USB_XHCI_INSTANCE  *Xhc,
   IN UINT8              CapId
+  );
+
+/**
+  Calculate the offset of the xHCI Supported Protocol Capability.
+
+  @param  Xhc           The XHCI Instance.
+  @param  MajorVersion  The USB Major Version in xHCI Support Protocol Capability Field
+
+  @return The offset of xHCI Supported Protocol capability register.
+
+**/
+UINT32
+XhcGetSupportedProtocolCapabilityAddr (
+  IN USB_XHCI_INSTANCE  *Xhc,
+  IN UINT8              MajorVersion
+  );
+
+/**
+  Find SpeedField value match with Port Speed ID value.
+
+  @param  Xhc    The XHCI Instance.
+  @param  Speed  The Port Speed filed in USB PortSc register
+
+  @return The USB Port Speed.
+
+**/
+UINT16
+XhcCheckUsbPortSpeedUsedPsic (
+  IN USB_XHCI_INSTANCE  *Xhc,
+  IN UINT8              Speed
   );
 
 #endif


### PR DESCRIPTION
Add support process Port Speed field value of PORTSC according to
Supported Protocol Capability (define in xHCI spec 1.1)

REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3914

The value of Port Speed field in PORTSC bit[10:13]
(xHCI spec 1.1 section 5.4.8) should be change to use this value to
query thru Protocol Speed ID (PSI) (xHCI spec 1.1 section 7.2.1)
in xHCI Supported Protocol Capability and return the value according
the Protocol Speed ID (PSIV) Dword.

With this mechanism may able to detect more kind of Protocol Speed
in USB3 and also compatiable with three kind of speed of USB2.

Cc: Jenny Huang <jenny.huang@intel.com>
Cc: More Shih <more.shih@intel.com>
Cc: Hao A Wu <hao.a.wu@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Signed-off-by: Ian Chiu <Ian.chiu@intel.com>
Reviewed-by: Hao A Wu <hao.a.wu@intel.com>