### PR TITLE
MdePkg/Acpi62: Add type 7 NFIT Platform Capabilities Structure support

### DIFF
--- a/MdePkg/Include/IndustryStandard/Acpi62.h
+++ b/MdePkg/Include/IndustryStandard/Acpi62.h
@@ -1486,6 +1486,7 @@ typedef struct {
 #define EFI_ACPI_6_2_NFIT_NVDIMM_CONTROL_REGION_STRUCTURE_TYPE            4
 #define EFI_ACPI_6_2_NFIT_NVDIMM_BLOCK_DATA_WINDOW_REGION_STRUCTURE_TYPE  5
 #define EFI_ACPI_6_2_NFIT_FLUSH_HINT_ADDRESS_STRUCTURE_TYPE               6
+#define EFI_ACPI_6_2_NFIT_PLATFORM_CAPABILITIES_STRUCTURE_TYPE            7
 
 //
 // Definition for NFIT Structure Header
@@ -1637,6 +1638,18 @@ typedef struct {
   UINT8                              Reserved_10[6];
   // UINT64                                      FlushHintAddress[NumberOfFlushHintAddresses];
 } EFI_ACPI_6_2_NFIT_FLUSH_HINT_ADDRESS_STRUCTURE;
+
+//
+// Definition for Platform Capabilities Structure
+//
+typedef struct {
+  UINT16    Type;
+  UINT16    Length;
+  UINT8     HighestValidCapability;
+  UINT8     Reserved_5[3];
+  UINT32    Capabilities;
+  UINT8     Reserved_12[4];
+} EFI_ACPI_6_2_NFIT_PLATFORM_CAPABILITIES_STRUCTURE;
 
 ///
 /// Secure DEVices Table (SDEV)

--- a/MdePkg/Include/IndustryStandard/Acpi63.h
+++ b/MdePkg/Include/IndustryStandard/Acpi63.h
@@ -1450,6 +1450,7 @@ typedef struct {
 #define EFI_ACPI_6_3_NFIT_NVDIMM_CONTROL_REGION_STRUCTURE_TYPE            4
 #define EFI_ACPI_6_3_NFIT_NVDIMM_BLOCK_DATA_WINDOW_REGION_STRUCTURE_TYPE  5
 #define EFI_ACPI_6_3_NFIT_FLUSH_HINT_ADDRESS_STRUCTURE_TYPE               6
+#define EFI_ACPI_6_3_NFIT_PLATFORM_CAPABILITIES_STRUCTURE_TYPE            7
 
 //
 // Definition for NFIT Structure Header
@@ -1601,6 +1602,18 @@ typedef struct {
   UINT8                              Reserved_10[6];
   // UINT64                                      FlushHintAddress[NumberOfFlushHintAddresses];
 } EFI_ACPI_6_3_NFIT_FLUSH_HINT_ADDRESS_STRUCTURE;
+
+//
+// Definition for Platform Capabilities Structure
+//
+typedef struct {
+  UINT16    Type;
+  UINT16    Length;
+  UINT8     HighestValidCapability;
+  UINT8     Reserved_5[3];
+  UINT32    Capabilities;
+  UINT8     Reserved_12[4];
+} EFI_ACPI_6_3_NFIT_PLATFORM_CAPABILITIES_STRUCTURE;
 
 ///
 /// Secure DEVices Table (SDEV)

--- a/MdePkg/Include/IndustryStandard/Acpi64.h
+++ b/MdePkg/Include/IndustryStandard/Acpi64.h
@@ -1493,6 +1493,7 @@ typedef struct {
 #define EFI_ACPI_6_4_NFIT_NVDIMM_CONTROL_REGION_STRUCTURE_TYPE            4
 #define EFI_ACPI_6_4_NFIT_NVDIMM_BLOCK_DATA_WINDOW_REGION_STRUCTURE_TYPE  5
 #define EFI_ACPI_6_4_NFIT_FLUSH_HINT_ADDRESS_STRUCTURE_TYPE               6
+#define EFI_ACPI_6_4_NFIT_PLATFORM_CAPABILITIES_STRUCTURE_TYPE            7
 
 //
 // Definition for NFIT Structure Header
@@ -1650,6 +1651,18 @@ typedef struct {
   UINT8                              Reserved_10[6];
   // UINT64                                      FlushHintAddress[NumberOfFlushHintAddresses];
 } EFI_ACPI_6_4_NFIT_FLUSH_HINT_ADDRESS_STRUCTURE;
+
+//
+// Definition for Platform Capabilities Structure
+//
+typedef struct {
+  UINT16    Type;
+  UINT16    Length;
+  UINT8     HighestValidCapability;
+  UINT8     Reserved_5[3];
+  UINT32    Capabilities;
+  UINT8     Reserved_12[4];
+} EFI_ACPI_6_4_NFIT_PLATFORM_CAPABILITIES_STRUCTURE;
 
 ///
 /// Secure DEVices Table (SDEV)


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3915

This commit adds a definition type 7 Platform Capabilities Structure
and the struct definition for NFIT Table Structure Types.
The type has been added since ACPI Specification Version 6.2A.

Signed-off-by: Miki Shindo <miki.shindo@intel.com>
Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Zhiguang Liu <zhiguang.liu@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>