### PR TITLE
UefiPayloadPkg: Align Attribute value with UPL spec

### DIFF
--- a/UefiPayloadPkg/UniversalPayloadBuild.py
+++ b/UefiPayloadPkg/UniversalPayloadBuild.py
@@ -111,6 +111,7 @@ def BuildUniversalPayload(Args, MacroList):
     #
     upld_info_hdr = UPLD_INFO_HEADER()
     upld_info_hdr.ImageId = Args.ImageId.encode()[:16]
+    upld_info_hdr.Attribute |= 1 if BuildTarget == "DEBUG" else 0
     fp = open(UpldInfoFile, 'wb')
     fp.write(bytearray(upld_info_hdr))
     fp.close()


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3963

Based on UPL spec 2.12.2. Universal Payload Information Section,
it defines item "Attribute" on UPLD_INFO_HEADER for Debug build
should be "1", and Release build should be "0".

Currently, The value of item "Attribute" is always "0"

Cc: Guo Dong <guo.dong@intel.com>
Reviewed-by: Ray Ni <ray.ni@intel.com>
Cc: James Lu <james.lu@intel.com>
Signed-off-by: Gua Guo <gua.guo@intel.com>