### PR TITLE
pip-requirements.txt: Update basetools version to 0.1.24

### DIFF
--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -14,5 +14,5 @@
 
 edk2-pytool-library==0.11.2
 edk2-pytool-extensions~=0.16.0
-edk2-basetools==0.1.17
+edk2-basetools==0.1.24
 antlr4-python3-runtime==4.7.1


### PR DESCRIPTION
Upgrade the edk2-basetools version from 0.1.17 to 0.1.24

features and bug fixes:
1. Add FMMT Python Tool
2. Remove RVCT support
3. Fix dependency issue in PcdValueInit
4. Output the intermediate library instance when error occurs
5. Ecc: Fix grammar in Ecc error message
6. Fix the GenMake bug for .cpp source file

Signed-off-by: Bob Feng <bob.c.feng@intel.com>
Reviewed-by: Michael D Kinney <michael.d.kinney@intel.com>
Acked-by: Michael Kubacki <michael.kubacki@microsoft.com>