### PR TITLE
NetworkPkg: Add Wi-Fi Wpa3 support in WifiConnectManager

### DIFF
--- a/NetworkPkg/WifiConnectionManagerDxe/WifiConnectionManagerDxe.vfr
+++ b/NetworkPkg/WifiConnectionManagerDxe/WifiConnectionManagerDxe.vfr
@@ -1,7 +1,7 @@
 /** @file
   Vfr files used in WiFi Connection Manager.
 
-  Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2019 - 2022, Intel Corporation. All rights reserved.<BR>
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -121,7 +121,8 @@ formset
         text   = STRING_TOKEN(STR_SECURITY_TYPE);          // TextTwo
 
 
-    suppressif NOT ideqval WIFI_MANAGER_IFR_NVDATA.SecurityType == SECURITY_TYPE_WPA2_PERSONAL;
+    suppressif NOT ideqval WIFI_MANAGER_IFR_NVDATA.SecurityType == SECURITY_TYPE_WPA2_PERSONAL
+      AND NOT ideqval WIFI_MANAGER_IFR_NVDATA.SecurityType == SECURITY_TYPE_WPA3_PERSONAL;
       password  varid    = WIFI_MANAGER_IFR_NVDATA.Password,
                 prompt   = STRING_TOKEN(STR_PASSWORD),
                 help     = STRING_TOKEN(STR_PASSWORD_HELP),
@@ -132,7 +133,8 @@ formset
       endpassword;
     endif;
 
-    suppressif NOT ideqval WIFI_MANAGER_IFR_NVDATA.SecurityType == SECURITY_TYPE_WPA2_ENTERPRISE;
+    suppressif NOT ideqval WIFI_MANAGER_IFR_NVDATA.SecurityType == SECURITY_TYPE_WPA2_ENTERPRISE
+      AND NOT ideqval WIFI_MANAGER_IFR_NVDATA.SecurityType == SECURITY_TYPE_WPA3_ENTERPRISE;
 
       oneof varid       = WIFI_MANAGER_IFR_NVDATA.EapAuthMethod,
             questionid  = KEY_EAP_AUTH_METHOD_CONNECT_NETWORK,

--- a/NetworkPkg/WifiConnectionManagerDxe/WifiConnectionMgrConfigNVDataStruct.h
+++ b/NetworkPkg/WifiConnectionManagerDxe/WifiConnectionMgrConfigNVDataStruct.h
@@ -1,7 +1,7 @@
 /** @file
   Define IFR NVData structures used by the WiFi Connection Manager.
 
-  Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2019 - 2022, Intel Corporation. All rights reserved.<BR>
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -119,8 +119,10 @@
 #define SECURITY_TYPE_WPA_PERSONAL     3
 #define SECURITY_TYPE_WPA2_PERSONAL    4
 #define SECURITY_TYPE_WEP              5
-#define SECURITY_TYPE_UNKNOWN          6
-#define SECURITY_TYPE_MAX              7
+#define SECURITY_TYPE_WPA3_PERSONAL    6
+#define SECURITY_TYPE_WPA3_ENTERPRISE  7
+#define SECURITY_TYPE_UNKNOWN          8
+#define SECURITY_TYPE_MAX              9
 
 #define EAP_AUTH_METHOD_TTLS  0
 #define EAP_AUTH_METHOD_PEAP  1

--- a/NetworkPkg/WifiConnectionManagerDxe/WifiConnectionMgrDxe.h
+++ b/NetworkPkg/WifiConnectionManagerDxe/WifiConnectionMgrDxe.h
@@ -1,7 +1,7 @@
 /** @file
   The miscellaneous structure definitions for WiFi connection driver.
 
-  Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2019 - 2022, Intel Corporation. All rights reserved.<BR>
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -82,6 +82,8 @@ typedef enum {
   Ieee80211PairwiseCipherSuiteCCMP                = 4,
   Ieee80211PairwiseCipherSuiteWEP104              = 5,
   Ieee80211PairwiseCipherSuiteBIP                 = 6,
+  Ieee80211PairwiseCipherSuiteGCMP                = 8,
+  Ieee80211PairwiseCipherSuiteGCMP256             = 9,
   // ...
 } IEEE_80211_PAIRWISE_CIPHER_SUITE;
 
@@ -91,19 +93,29 @@ typedef enum {
 #define IEEE_80211_PAIRWISE_CIPHER_SUITE_CCMP       (OUI_IEEE_80211I | (Ieee80211PairwiseCipherSuiteCCMP << 24))
 #define IEEE_80211_PAIRWISE_CIPHER_SUITE_WEP104     (OUI_IEEE_80211I | (Ieee80211PairwiseCipherSuiteWEP104 << 24))
 #define IEEE_80211_PAIRWISE_CIPHER_SUITE_BIP        (OUI_IEEE_80211I | (Ieee80211PairwiseCipherSuiteBIP << 24))
+#define IEEE_80211_PAIRWISE_CIPHER_SUITE_GCMP       (OUI_IEEE_80211I | (Ieee80211PairwiseCipherSuiteGCMP << 24))
+#define IEEE_80211_PAIRWISE_CIPHER_SUITE_GCMP256    (OUI_IEEE_80211I | (Ieee80211PairwiseCipherSuiteGCMP256 << 24))
 
 typedef enum {
   Ieee80211AkmSuite8021XOrPMKSA       = 1,
   Ieee80211AkmSuitePSK                = 2,
   Ieee80211AkmSuite8021XOrPMKSASHA256 = 5,
-  Ieee80211AkmSuitePSKSHA256          = 6
-                                        // ...
+  Ieee80211AkmSuitePSKSHA256          = 6,
+  Ieee80211AkmSuiteSAE                = 8,
+  Ieee80211AkmSuite8021XSuiteB        = 11,
+  Ieee80211AkmSuite8021XSuiteB192     = 12,
+  Ieee80211AkmSuiteOWE                = 18,
+  // ...
 } IEEE_80211_AKM_SUITE;
 
 #define IEEE_80211_AKM_SUITE_8021X_OR_PMKSA         (OUI_IEEE_80211I | (Ieee80211AkmSuite8021XOrPMKSA << 24))
 #define IEEE_80211_AKM_SUITE_PSK                    (OUI_IEEE_80211I | (Ieee80211AkmSuitePSK << 24))
 #define IEEE_80211_AKM_SUITE_8021X_OR_PMKSA_SHA256  (OUI_IEEE_80211I | (Ieee80211AkmSuite8021XOrPMKSASHA256 << 24))
 #define IEEE_80211_AKM_SUITE_PSK_SHA256             (OUI_IEEE_80211I | (Ieee80211AkmSuitePSKSHA256 << 24))
+#define IEEE_80211_AKM_SUITE_SAE                    (OUI_IEEE_80211I | (Ieee80211AkmSuiteSAE << 24))
+#define IEEE_80211_AKM_SUITE_8021X_SUITE_B          (OUI_IEEE_80211I | (Ieee80211AkmSuite8021XSuiteB << 24))
+#define IEEE_80211_AKM_SUITE_8021X_SUITE_B192       (OUI_IEEE_80211I | (Ieee80211AkmSuite8021XSuiteB192 << 24))
+#define IEEE_80211_AKM_SUITE_OWE                    (OUI_IEEE_80211I | (Ieee80211AkmSuiteOWE << 24))
 
 //
 // Protocol instances

--- a/NetworkPkg/WifiConnectionManagerDxe/WifiConnectionMgrImpl.c
+++ b/NetworkPkg/WifiConnectionManagerDxe/WifiConnectionMgrImpl.c
@@ -1,7 +1,7 @@
 /** @file
   The Mac Connection2 Protocol adapter functions for WiFi Connection Manager.
 
-  Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2019 - 2022, Intel Corporation. All rights reserved.<BR>
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -848,6 +848,7 @@ WifiMgrPrepareConnection (
   if (AKMSuiteSupported && CipherSuiteSupported) {
     switch (SecurityType) {
       case SECURITY_TYPE_WPA2_PERSONAL:
+      case SECURITY_TYPE_WPA3_PERSONAL:
 
         Status = WifiMgrConfigPassword (Nic, Profile);
         if (EFI_ERROR (Status)) {
@@ -863,6 +864,7 @@ WifiMgrPrepareConnection (
         break;
 
       case SECURITY_TYPE_WPA2_ENTERPRISE:
+      case SECURITY_TYPE_WPA3_ENTERPRISE:
 
         Status = WifiMgrConfigEap (Nic, Profile);
         if (EFI_ERROR (Status)) {


### PR DESCRIPTION
https://bugzilla.tianocore.org/show_bug.cgi?id=3961

Add below Wpa3 support:
    WPA3-Personal:
      Ieee80211AkmSuiteSAE                = 8
    WPA3-Enterprise:
      Ieee80211AkmSuite8021XSuiteB        = 11
      Ieee80211AkmSuite8021XSuiteB192     = 12
    Wi-Fi CERTIFIED Enhanced Open:
      Ieee80211AkmSuiteOWE                = 18

Cc: Maciej Rabeda <maciej.rabeda@linux.intel.com>
Cc: Fu Siyuan <siyuan.fu@intel.com>
Cc: Wu Jiaxin <jiaxin.wu@intel.com>
Signed-off-by: Heng Luo <heng.luo@intel.com>