### PR TITLE
ArmPkg/Drivers: ArmGicIsInterruptEnabled returns incorrect value

### DIFF
--- a/ArmPkg/Drivers/ArmGic/ArmGicLib.c
+++ b/ArmPkg/Drivers/ArmGic/ArmGicLib.c
@@ -366,10 +366,9 @@ ArmGicIsInterruptEnabled (
       FeaturePcdGet (PcdArmGicV3WithV2Legacy) ||
       SourceIsSpi (Source))
   {
-    Interrupts = ((MmioRead32 (
-                     GicDistributorBase + ARM_GIC_ICDISER + (4 * RegOffset)
-                     )
-                   & (1 << RegShift)) != 0);
+    Interrupts = MmioRead32 (
+                   GicDistributorBase + ARM_GIC_ICDISER + (4 * RegOffset)
+                   );
   } else {
     GicCpuRedistributorBase = GicGetCpuRedistributorBase (
                                 GicRedistributorBase,


### PR DESCRIPTION
The issue appears to have been introduced by:

41fb5d46 : ArmPkg/ArmGic: Use the GIC Redistributor instead of GIC Distributor for GICv3

The changes to ArmGicIsInterruptEnabled() introduced the error where the Boolean
result is assigned to Interrupts, but then the bit position check is performed
again (against the computed Boolean result instead of the interrupt mask) during
the return statement.

Fix removes erroneous test and relies on boolean test made at return.

Signed-off-by: Robbie King <robbiek@xsightlabs.com>
Reviewed-by: Ard Biesheuvel <ardb@kernel.org>