### PR TITLE
.gitignore: Ignore build tools build logs

### DIFF
--- a/BaseTools/.gitignore
+++ b/BaseTools/.gitignore
@@ -18,3 +18,4 @@ Source/C/bin/
 Source/C/libs/
 Bin/Win32
 Lib
+BaseToolsBuild/


### PR DESCRIPTION
The python BaseTools/Edk2ToolsBuild.py creates files in
BaseTools/BaseToolsBuild and should be ignored.

Signed-off-by: Jeff Brasen <jbrasen@nvidia.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>