### PR TITLE
BaseTools: INF should use latest Pcd value instead of default value

### DIFF
--- a/BaseTools/Source/Python/Workspace/InfBuildData.py
+++ b/BaseTools/Source/Python/Workspace/InfBuildData.py
@@ -1084,7 +1084,9 @@ class InfBuildData(ModuleBuildClassObject):
         else:
             for Name, Guid in self.Pcds:
                 if self.Pcds[(Name, Guid)].Type == 'FeatureFlag' or self.Pcds[(Name, Guid)].Type == 'FixedAtBuild':
-                    Pcds['%s.%s' % (Guid, Name)] = self.Pcds[(Name, Guid)].DefaultValue
+                    PcdFullName = '%s.%s' % (Guid, Name);
+                    if not PcdFullName in Pcds:
+                        Pcds[PcdFullName] = self.Pcds[(Name, Guid)].DefaultValue
             try:
                 Value = ValueExpression(Instance, Pcds)()
                 if Value == True:


### PR DESCRIPTION
This patch is a bug fix about FeatureFlagExpression in INF file:
 INF [Source] section now unconditionally use Pcd default value in DEC
 when handling FeatureFlagExpression, it is wrong.
 If a Pcd value has been set in the DSC file, we should use latest
 value in DSC instead of default value.

Cc: Bob Feng <bob.c.feng@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>

Signed-off-by: Yi Li <yi1.li@intel.com>