### PR TITLE
NetworkPkg: Enable WLAN Recovery Wifi Profile Sync feature.

### DIFF
--- a/NetworkPkg/Include/Protocol/WifiProfileSyncProtocol.h
+++ b/NetworkPkg/Include/Protocol/WifiProfileSyncProtocol.h
@@ -1,0 +1,80 @@
+/** @file
+  Intel One Click Recovery WiFi Profile Sync Profile Protocol.
+
+  Copyright (c) 2022, Intel Corporation. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+#ifndef _WIFI_PROFILE_SYNC_PROTOCOL_H_
+#define _WIFI_PROFILE_SYNC_PROTOCOL_H_
+
+#include <WifiConnectionManagerDxe/WifiConnectionMgrConfig.h>
+
+//
+//  WiFi Profile Sync Protocol GUID variable.
+//
+extern EFI_GUID   gEfiWiFiProfileSyncProtocolGuid;
+
+/**
+  Used by the WiFi connection manager to get the WiFi profile that ASF shared
+  and was stored in WiFi profile protocol. Aligns the ASF WiFi profile data to
+  the WCM profile structure.
+
+  @param[in, out]  WcmProfile       WiFi Connection Manager profile structure
+  @param[in, out]  MacAddress       MAC address from AMT saved to NiC MAC address
+
+  @return EFI_SUCCESS               Profiles returned
+  @return EFI_UNSUPPORTED           Profile protocol sharing not supported or enabled
+  @return EFI_NOT_FOUND             No profiles returned
+  @return Others                    Error Occurred
+**/
+typedef
+EFI_STATUS
+(EFIAPI *WIFI_PROFILE_GET) (
+  IN OUT  WIFI_MGR_NETWORK_PROFILE  *Profile,
+  IN OUT  EFI_80211_MAC_ADDRESS     MacAddress
+  );
+
+/**
+  Sets the WiFi connection status recieved by the WiFiConnectionManager.
+  Input as EFI_80211_CONNECT_NETWORK_RESULT_CODE then converted and stored
+  as EFI_STATUS type.
+
+  @param[in] ConnectionStatus     WiFi connection attempt results
+**/
+typedef
+VOID
+(EFIAPI *WIFI_SET_CONNECT_STATE) (
+  IN EFI_80211_CONNECT_NETWORK_RESULT_CODE  ConnectionStatus
+  );
+
+/**
+  Retrieves the WiFi connection status when in either KVM OR OCR WLAN recovery.
+
+  @return EFI_SUCCESS               WiFi connection completed succesfully
+  @return Others                    Error Occurred
+**/
+typedef
+EFI_STATUS
+(EFIAPI *WIFI_GET_CONNECT_STATE) (
+  VOID
+  );
+
+//
+//  WiFi Profile Sync Protocol structure.
+//
+typedef struct {
+  UINT32                      Revision;
+  WIFI_SET_CONNECT_STATE      WifiProfileSyncSetConnectState;
+  WIFI_GET_CONNECT_STATE      WifiProfileSyncGetConnectState;
+  WIFI_PROFILE_GET            WifiProfileSyncGetProfile;
+} EFI_WIFI_PROFILE_SYNC_PROTOCOL;
+
+/**
+  Intel WiFi Profile Protocol revision number.
+
+  Revision 1:   Initial version
+**/
+#define  EFI_WIFI_PROFILE_SYNC_PROTOCOL_REVISION     1
+
+#endif

--- a/NetworkPkg/NetworkPkg.dec
+++ b/NetworkPkg/NetworkPkg.dec
@@ -3,7 +3,7 @@
 #
 # This package provides network modules that conform to UEFI 2.4 specification.
 #
-# Copyright (c) 2009 - 2021, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2009 - 2022, Intel Corporation. All rights reserved.<BR>
 # (C) Copyright 2015-2020 Hewlett Packard Enterprise Development LP<BR>
 #
 # SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -90,6 +90,9 @@
 
   ## Include/Protocol/HttpCallback.h
   gEdkiiHttpCallbackProtocolGuid  = {0x611114f1, 0xa37b, 0x4468, {0xa4, 0x36, 0x5b, 0xdd, 0xa1, 0x6a, 0xa2, 0x40}}
+
+  ## Include/Protocol/WiFiProfileSyncProtocol.h
+  gEfiWiFiProfileSyncProtocolGuid = {0x399a2b8a, 0xc267, 0x44aa, {0x9a, 0xb4, 0x30, 0x58, 0x8c, 0xd2, 0x2d, 0xcc}}
 
 [PcdsFixedAtBuild]
   ## The max attempt number will be created by iSCSI driver.

--- a/NetworkPkg/WifiConnectionManagerDxe/WifiConnectionManagerDxe.inf
+++ b/NetworkPkg/WifiConnectionManagerDxe/WifiConnectionManagerDxe.inf
@@ -9,7 +9,7 @@
 #  2). WPA2 Personal Network
 #  3). EAP Networks (EAP-TLS, EAP-TTLS/MSCHAPv2 and PEAPv0/MSCHAPv2)
 #
-#  Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2019 - 2022, Intel Corporation. All rights reserved.<BR>
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -71,6 +71,7 @@
   gEfiAdapterInformationProtocolGuid            ## SOMETIMES_CONSUMES
   gEfiSupplicantProtocolGuid                    ## SOMETIMES_CONSUMES
   gEfiEapConfigurationProtocolGuid              ## SOMETIMES_CONSUMES
+  gEfiWiFiProfileSyncProtocolGuid               ## SOMETIMES_CONSUMES
 
 [Guids]
   gWifiConfigGuid                               ## PRODUCES  ## GUID

--- a/NetworkPkg/WifiConnectionManagerDxe/WifiConnectionMgrDriver.c
+++ b/NetworkPkg/WifiConnectionManagerDxe/WifiConnectionMgrDriver.c
@@ -39,6 +39,11 @@ EFI_GUID  mWifiConfigNetworkListRefreshGuid = WIFI_CONFIG_NETWORK_LIST_REFRESH_G
 EFI_GUID  mWifiConfigConnectFormRefreshGuid = WIFI_CONFIG_CONNECT_FORM_REFRESH_GUID;
 EFI_GUID  mWifiConfigMainFormRefreshGuid    = WIFI_CONFIG_MAIN_FORM_REFRESH_GUID;
 
+//
+// The counter of Wifi Connection
+//
+extern UINT8 WifiConnectionCount;
+
 /**
   Tests to see if this driver supports a given controller. If a child device is provided,
   it further tests to see if this driver supports creating a handle for the specified child device.
@@ -167,7 +172,9 @@ WifiMgrDxeDriverBindingStart (
   EFI_WIRELESS_MAC_CONNECTION_II_PROTOCOL  *Wmp;
   EFI_SUPPLICANT_PROTOCOL                  *Supplicant;
   EFI_EAP_CONFIGURATION_PROTOCOL           *EapConfig;
+  EFI_WIFI_PROFILE_SYNC_PROTOCOL           *WiFiProfileSyncProtocol;
 
+  WifiConnectionCount = 0;
   Nic = NULL;
 
   //
@@ -236,47 +243,71 @@ WifiMgrDxeDriverBindingStart (
   InitializeListHead (&Nic->ProfileList);
 
   //
-  // Record the MAC address of the incoming NIC.
+  // Supporting OCR WLAN with profile sharing protocol check
   //
-  Status = NetLibGetMacAddress (
-             ControllerHandle,
-             (EFI_MAC_ADDRESS *)&Nic->MacAddress,
-             &AddressSize
-             );
-  if (EFI_ERROR (Status)) {
-    goto ERROR2;
-  }
-
-  //
-  // Create and start the timer for the status check
-  //
-  Status = gBS->CreateEvent (
-                  EVT_NOTIFY_SIGNAL | EVT_TIMER,
-                  TPL_CALLBACK,
-                  WifiMgrOnTimerTick,
-                  Nic,
-                  &Nic->TickTimer
+  Status = gBS->LocateProtocol (
+                  &gEfiWiFiProfileSyncProtocolGuid,
+                  NULL,
+                  (VOID **) &WiFiProfileSyncProtocol
                   );
-  if (EFI_ERROR (Status)) {
-    goto ERROR2;
+  if (!EFI_ERROR (Status)) {
+    Nic->ConnectPendingNetwork = (WIFI_MGR_NETWORK_PROFILE *) AllocateZeroPool (sizeof (WIFI_MGR_NETWORK_PROFILE));
+    if (Nic->ConnectPendingNetwork == NULL) {
+      Status = EFI_OUT_OF_RESOURCES;
+      goto ERROR1;
+    }
+    WiFiProfileSyncProtocol->WifiProfileSyncGetProfile (Nic->ConnectPendingNetwork, Nic->MacAddress);
+    if (Nic->ConnectPendingNetwork != NULL) {
+      Status = WifiMgrConnectToNetwork (Nic, Nic->ConnectPendingNetwork);
+      if (EFI_ERROR (Status)) {
+        WiFiProfileSyncProtocol->WifiProfileSyncSetConnectState (Status);
+      }
+    } else {
+      goto ERROR1;
+    }
+  } else {
+    //
+    // Record the MAC address of the incoming NIC.
+    //
+    Status = NetLibGetMacAddress (
+               ControllerHandle,
+               (EFI_MAC_ADDRESS *)&Nic->MacAddress,
+               &AddressSize
+               );
+    if (EFI_ERROR (Status)) {
+      goto ERROR2;
+    }
+
+    //
+    // Create and start the timer for the status check
+    //
+    Status = gBS->CreateEvent (
+                    EVT_NOTIFY_SIGNAL | EVT_TIMER,
+                    TPL_CALLBACK,
+                    WifiMgrOnTimerTick,
+                    Nic,
+                    &Nic->TickTimer
+                    );
+    if (EFI_ERROR (Status)) {
+      goto ERROR2;
+    }
+
+    Status = gBS->SetTimer (Nic->TickTimer, TimerPeriodic, EFI_TIMER_PERIOD_MILLISECONDS(500));
+    if (EFI_ERROR (Status)) {
+      goto ERROR3;
+    }
+
+    Nic->ConnectState = WifiMgrDisconnected;
+    Nic->ScanState    = WifiMgrScanFinished;
+
+    OldTpl = gBS->RaiseTPL (TPL_CALLBACK);
+    InsertTailList (&mPrivate->NicList, &Nic->Link);
+    Nic->NicIndex = mPrivate->NicCount ++;
+    if (mPrivate->CurrentNic == NULL) {
+      mPrivate->CurrentNic = Nic;
+    }
+    gBS->RestoreTPL (OldTpl);
   }
-
-  Status = gBS->SetTimer (Nic->TickTimer, TimerPeriodic, EFI_TIMER_PERIOD_MILLISECONDS (500));
-  if (EFI_ERROR (Status)) {
-    goto ERROR3;
-  }
-
-  Nic->ConnectState = WifiMgrDisconnected;
-  Nic->ScanState    = WifiMgrScanFinished;
-
-  OldTpl = gBS->RaiseTPL (TPL_CALLBACK);
-  InsertTailList (&mPrivate->NicList, &Nic->Link);
-  Nic->NicIndex = mPrivate->NicCount++;
-  if (mPrivate->CurrentNic == NULL) {
-    mPrivate->CurrentNic = Nic;
-  }
-
-  gBS->RestoreTPL (OldTpl);
 
   Status = gBS->InstallProtocolInterface (
                   &ControllerHandle,
@@ -385,10 +416,11 @@ WifiMgrDxeDriverBindingStop (
   IN EFI_HANDLE                   *ChildHandleBuffer OPTIONAL
   )
 {
-  EFI_STATUS                 Status;
-  EFI_TPL                    OldTpl;
-  WIFI_MGR_PRIVATE_PROTOCOL  *WifiMgrIdentifier;
-  WIFI_MGR_DEVICE_DATA       *Nic;
+  EFI_STATUS                       Status;
+  EFI_TPL                          OldTpl;
+  WIFI_MGR_PRIVATE_PROTOCOL        *WifiMgrIdentifier;
+  WIFI_MGR_DEVICE_DATA             *Nic;
+  EFI_WIFI_PROFILE_SYNC_PROTOCOL   *WiFiProfileSyncProtocol;
 
   Status = gBS->OpenProtocol (
                   ControllerHandle,
@@ -481,7 +513,14 @@ WifiMgrDxeDriverBindingStop (
   //
   OldTpl = gBS->RaiseTPL (TPL_CALLBACK);
 
-  RemoveEntryList (&Nic->Link);
+  Status = gBS->LocateProtocol (
+                  &gEfiWiFiProfileSyncProtocolGuid,
+                  NULL,
+                  (VOID **) &WiFiProfileSyncProtocol
+                  );
+  if (EFI_ERROR (Status)) {
+    RemoveEntryList (&Nic->Link);
+  }
   mPrivate->NicCount--;
   if (mPrivate->CurrentNic == Nic) {
     mPrivate->CurrentNic = NULL;

--- a/NetworkPkg/WifiConnectionManagerDxe/WifiConnectionMgrDxe.h
+++ b/NetworkPkg/WifiConnectionManagerDxe/WifiConnectionMgrDxe.h
@@ -47,6 +47,7 @@
 #include <Protocol/SimpleNetwork.h>
 #include <Protocol/SimpleFileSystem.h>
 #include <Protocol/EapConfiguration.h>
+#include <Protocol/WifiProfileSyncProtocol.h>
 
 //
 // Produced Protocols
@@ -74,6 +75,7 @@
 #define WIFI_MGR_DXE_VERSION  0xb
 
 #define OUI_IEEE_80211I  0xAC0F00
+#define MAX_WIFI_CONNETION_ATTEMPTS 3
 
 typedef enum {
   Ieee80211PairwiseCipherSuiteUseGroupCipherSuite = 0,

--- a/NetworkPkg/WifiConnectionManagerDxe/WifiConnectionMgrImpl.c
+++ b/NetworkPkg/WifiConnectionManagerDxe/WifiConnectionMgrImpl.c
@@ -19,6 +19,8 @@ EFI_EAP_TYPE  mEapSecondAuthMethod[] = {
   EFI_EAP_TYPE_MSCHAPV2
 };
 
+UINT8  WifiConnectionCount = 0;
+
 /**
   The callback function for scan operation. This function updates networks
   according to the latest scan result, and trigger UI refresh.
@@ -420,23 +422,32 @@ WifiMgrConfigPassword (
   //
   // Set password to supplicant
   //
+  if (Profile->Password[StrLen (Profile->Password)] != '\0') {
+    Profile->Password[StrLen (Profile->Password)] = L'\0';
+  }
   if (StrLen (Profile->Password) < PASSWORD_MIN_LEN) {
     return EFI_NOT_FOUND;
   }
+  if (StrLen (Profile->Password) > PASSWORD_STORAGE_SIZE) {
+    ASSERT (EFI_INVALID_PARAMETER);
+    return EFI_INVALID_PARAMETER;
+  }
 
-  AsciiPassword = AllocateZeroPool ((StrLen (Profile->Password) + 1) * sizeof (UINT8));
+  AsciiPassword = AllocateZeroPool ((StrLen (Profile->Password) + 1) * sizeof (CHAR8));
   if (AsciiPassword == NULL) {
     return EFI_OUT_OF_RESOURCES;
   }
 
-  UnicodeStrToAsciiStrS (Profile->Password, (CHAR8 *)AsciiPassword, PASSWORD_STORAGE_SIZE);
-  Status = Supplicant->SetData (
-                         Supplicant,
-                         EfiSupplicant80211PskPassword,
-                         AsciiPassword,
-                         (StrLen (Profile->Password) + 1) * sizeof (UINT8)
-                         );
-  ZeroMem (AsciiPassword, AsciiStrLen ((CHAR8 *)AsciiPassword) + 1);
+  Status = UnicodeStrToAsciiStrS (Profile->Password, (CHAR8 *) AsciiPassword, ((StrLen (Profile->Password) + 1) * sizeof (CHAR8)));
+  if (!EFI_ERROR (Status)) {
+    Status = Supplicant->SetData (
+               Supplicant,
+               EfiSupplicant80211PskPassword,
+               AsciiPassword,
+               (StrLen (Profile->Password) + 1) * sizeof (CHAR8)
+               );
+  }
+  ZeroMem (AsciiPassword, AsciiStrLen ((CHAR8 *) AsciiPassword) + 1);
   FreePool (AsciiPassword);
 
   return Status;
@@ -465,19 +476,20 @@ WifiMgrConfigEap (
   IN    WIFI_MGR_NETWORK_PROFILE  *Profile
   )
 {
-  EFI_STATUS                      Status;
-  EFI_EAP_CONFIGURATION_PROTOCOL  *EapConfig;
-  EFI_EAP_TYPE                    EapAuthMethod;
-  EFI_EAP_TYPE                    EapSecondAuthMethod;
-  EFI_EAP_TYPE                    *AuthMethodList;
-  CHAR8                           *Identity;
-  UINTN                           IdentitySize;
-  CHAR16                          *Password;
-  UINTN                           PasswordSize;
-  UINTN                           EncryptPasswordLen;
-  CHAR8                           *AsciiEncryptPassword;
-  UINTN                           AuthMethodListSize;
-  UINTN                           Index;
+  EFI_STATUS                        Status;
+  EFI_WIFI_PROFILE_SYNC_PROTOCOL    *WiFiProfileSyncProtocol;
+  EFI_EAP_CONFIGURATION_PROTOCOL    *EapConfig;
+  EFI_EAP_TYPE                      EapAuthMethod;
+  EFI_EAP_TYPE                      EapSecondAuthMethod;
+  EFI_EAP_TYPE                      *AuthMethodList;
+  CHAR8                             *Identity;
+  UINTN                             IdentitySize;
+  CHAR16                            *Password;
+  UINTN                             PasswordSize;
+  UINTN                             EncryptPasswordLen;
+  CHAR8                             *AsciiEncryptPassword;
+  UINTN                             AuthMethodListSize;
+  UINTN                             Index;
 
   if ((Nic == NULL) || (Nic->EapConfig == NULL) || (Profile == NULL)) {
     return EFI_INVALID_PARAMETER;
@@ -566,15 +578,20 @@ WifiMgrConfigEap (
     if (Identity == NULL) {
       return EFI_OUT_OF_RESOURCES;
     }
-
-    UnicodeStrToAsciiStrS (Profile->EapIdentity, Identity, IdentitySize);
+    Status = gBS->LocateProtocol (&gEfiWiFiProfileSyncProtocolGuid, NULL, (VOID **) &WiFiProfileSyncProtocol);
+    if (!EFI_ERROR (Status)) {
+      CopyMem (Identity, &Profile->EapIdentity, IdentitySize);
+    } else {
+      UnicodeStrToAsciiStrS (Profile->EapIdentity, Identity, IdentitySize);
+    }
     Status = EapConfig->SetData (
                           EapConfig,
                           EFI_EAP_TYPE_IDENTITY,
                           EfiEapConfigIdentityString,
-                          (VOID *)Identity,
+                          (VOID *) Identity,
                           IdentitySize - 1
                           );
+
     if (EFI_ERROR (Status)) {
       FreePool (Identity);
       return Status;
@@ -594,7 +611,7 @@ WifiMgrConfigEap (
                         EapConfig,
                         EFI_EAP_TYPE_ATTRIBUTE,
                         EfiEapConfigEapAuthMethod,
-                        (VOID *)&EapAuthMethod,
+                        (VOID *) &EapAuthMethod,
                         sizeof (EapAuthMethod)
                         );
   if (EFI_ERROR (Status)) {
@@ -606,7 +623,7 @@ WifiMgrConfigEap (
                           EapConfig,
                           EapAuthMethod,
                           EfiEapConfigEap2ndAuthMethod,
-                          (VOID *)&EapSecondAuthMethod,
+                          (VOID *) &EapSecondAuthMethod,
                           sizeof (EapSecondAuthMethod)
                           );
     if (EFI_ERROR (Status)) {
@@ -632,7 +649,7 @@ WifiMgrConfigEap (
                           EapConfig,
                           EFI_EAP_TYPE_MSCHAPV2,
                           EfiEapConfigEapMSChapV2Password,
-                          (VOID *)Password,
+                          (VOID *) Password,
                           PasswordSize
                           );
     ZeroMem (Password, PasswordSize);
@@ -726,7 +743,7 @@ WifiMgrConfigEap (
                             EapConfig,
                             EFI_EAP_TYPE_EAPTLS,
                             EfiEapConfigEapTlsClientPrivateKeyFilePassword,
-                            (VOID *)AsciiEncryptPassword,
+                            (VOID *) AsciiEncryptPassword,
                             EncryptPasswordLen + 1
                             );
       if (EFI_ERROR (Status)) {
@@ -777,7 +794,7 @@ WifiMgrGetLinkState (
   Status = gBS->OpenProtocol (
                   Nic->ControllerHandle,
                   &gEfiAdapterInformationProtocolGuid,
-                  (VOID **)&Aip,
+                  (VOID **) &Aip,
                   Nic->DriverHandle,
                   Nic->ControllerHandle,
                   EFI_OPEN_PROTOCOL_GET_PROTOCOL
@@ -790,7 +807,7 @@ WifiMgrGetLinkState (
   Status = Aip->GetInformation (
                   Aip,
                   &gEfiAdapterInfoMediaStateGuid,
-                  (VOID **)&UndiState,
+                  (VOID **) &UndiState,
                   &DataSize
                   );
   if (EFI_ERROR (Status)) {
@@ -893,6 +910,123 @@ WifiMgrPrepareConnection (
 }
 
 /**
+  Will reset NiC data, get profile from ProfileSync driver, and trigger another connection attempt.
+
+  @retval EFI_SUCCESS             The operation is completed.
+  @retval other                   Operation failure.
+
+**/
+EFI_STATUS
+ConnectionRetry (
+  IN   EFI_WIFI_PROFILE_SYNC_PROTOCOL       *WiFiProfileSyncProtocol
+  )
+{
+  EFI_STATUS                                Status;
+  WIFI_MGR_DEVICE_DATA                      *Nic;
+  EFI_WIRELESS_MAC_CONNECTION_II_PROTOCOL   *Wmp;
+  EFI_SUPPLICANT_PROTOCOL                   *Supplicant;
+  EFI_EAP_CONFIGURATION_PROTOCOL            *EapConfig;
+
+  Nic = NULL;
+
+  Status = gBS->LocateProtocol (
+                  &gEfiWiFi2ProtocolGuid,
+                  NULL,
+                  (VOID**) &Wmp
+                  );
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Status = gBS->LocateProtocol (
+                  &gEfiSupplicantProtocolGuid,
+                  NULL,
+                  (VOID**) &Supplicant
+                  );
+  if (EFI_ERROR (Status)) {
+    Supplicant = NULL;
+  }
+
+  Status = gBS->LocateProtocol (
+                  &gEfiEapConfigurationProtocolGuid,
+                  NULL,
+                  (VOID**) &EapConfig
+                  );
+  if (EFI_ERROR (Status)) {
+    EapConfig = NULL;
+  }
+
+  //
+  //Initialize Nic device data
+  //
+  Nic = AllocateZeroPool (sizeof (WIFI_MGR_DEVICE_DATA));
+  if (Nic == NULL) {
+    Status = EFI_OUT_OF_RESOURCES;
+    return Status;
+  }
+
+  Nic->Signature            = WIFI_MGR_DEVICE_DATA_SIGNATURE;
+  Nic->Private              = mPrivate;
+  Nic->Wmp                  = Wmp;
+  Nic->Supplicant           = Supplicant;
+  Nic->EapConfig            = EapConfig;
+  Nic->UserSelectedProfile  = NULL;
+  Nic->OneTimeScanRequest   = FALSE;
+
+  if (Nic->Supplicant != NULL) {
+    Status = WifiMgrGetSupportedSuites (Nic);
+  }
+
+  if (!EFI_ERROR (Status)) {
+    InitializeListHead (&Nic->ProfileList);
+
+    Nic->ConnectPendingNetwork = (WIFI_MGR_NETWORK_PROFILE *) AllocateZeroPool (sizeof (WIFI_MGR_NETWORK_PROFILE));
+    if (Nic->ConnectPendingNetwork == NULL) {
+      Status = EFI_OUT_OF_RESOURCES;
+      DEBUG ((DEBUG_ERROR, "[WiFi Connection Manager] Failed to allocate memory for ConnectPendingNetwork"));
+      goto ERROR;
+    }
+
+    Status = WiFiProfileSyncProtocol->WifiProfileSyncGetProfile (Nic->ConnectPendingNetwork, Nic->MacAddress);
+    if (!EFI_ERROR (Status) && (Nic->ConnectPendingNetwork != NULL)) {
+      Status = WifiMgrConnectToNetwork (Nic, Nic->ConnectPendingNetwork);
+      if (!EFI_ERROR (Status)) {
+        return Status;
+      }
+    } else {
+      DEBUG ((DEBUG_ERROR, "[WiFi Connection Manager] Failed to get WiFi profile with status %r", Status));
+    }
+  } else {
+    DEBUG ((DEBUG_ERROR, "[WiFi Connection Manager] Failed to get Supported suites with status %r", Status));
+  }
+
+  if (Nic->ConnectPendingNetwork != NULL) {
+    if (Nic->ConnectPendingNetwork->Network.AKMSuite != NULL) {
+      FreePool (Nic->ConnectPendingNetwork->Network.AKMSuite);
+    }
+    if (Nic->ConnectPendingNetwork->Network.CipherSuite != NULL) {
+      FreePool (Nic->ConnectPendingNetwork->Network.CipherSuite);
+    }
+    FreePool (Nic->ConnectPendingNetwork);
+  }
+
+ERROR:
+  if (Nic->Supplicant != NULL) {
+    if (Nic->SupportedSuites.SupportedAKMSuites != NULL) {
+      FreePool (Nic->SupportedSuites.SupportedAKMSuites);
+    }
+    if (Nic->SupportedSuites.SupportedSwCipherSuites != NULL) {
+      FreePool (Nic->SupportedSuites.SupportedSwCipherSuites);
+    }
+    if (Nic->SupportedSuites.SupportedHwCipherSuites != NULL) {
+      FreePool (Nic->SupportedSuites.SupportedHwCipherSuites);
+    }
+  }
+  FreePool (Nic);
+
+  return Status;
+}
+/**
   The callback function for connect operation.
 
   ASSERT when errors occur in config token.
@@ -908,12 +1042,13 @@ WifiMgrOnConnectFinished (
   IN  VOID       *Context
   )
 {
-  EFI_STATUS                 Status;
-  WIFI_MGR_MAC_CONFIG_TOKEN  *ConfigToken;
-  WIFI_MGR_NETWORK_PROFILE   *ConnectedProfile;
-  UINT8                      SecurityType;
-  UINT8                      SSIdLen;
-  CHAR8                      *AsciiSSId;
+  EFI_STATUS                        Status;
+  WIFI_MGR_MAC_CONFIG_TOKEN         *ConfigToken;
+  WIFI_MGR_NETWORK_PROFILE          *ConnectedProfile;
+  UINT8                             SecurityType;
+  UINT8                             SSIdLen;
+  CHAR8                             *AsciiSSId;
+  EFI_WIFI_PROFILE_SYNC_PROTOCOL    *WiFiProfileSyncProtocol;
 
   ASSERT (Context != NULL);
 
@@ -925,6 +1060,21 @@ WifiMgrOnConnectFinished (
   ASSERT (ConfigToken->Type == TokenTypeConnectNetworkToken);
 
   ASSERT (ConfigToken->Token.ConnectNetworkToken != NULL);
+
+  Status = gBS->LocateProtocol (&gEfiWiFiProfileSyncProtocolGuid, NULL, (VOID **) &WiFiProfileSyncProtocol);
+  if (!EFI_ERROR (Status)) {
+    WiFiProfileSyncProtocol->WifiProfileSyncSetConnectState (ConfigToken->Token.ConnectNetworkToken->ResultCode);
+    if ((WifiConnectionCount < MAX_WIFI_CONNETION_ATTEMPTS) &&
+        (ConfigToken->Token.ConnectNetworkToken->ResultCode != ConnectSuccess)) {
+      WifiConnectionCount++;
+      gBS->CloseEvent (Event);
+      Status = ConnectionRetry (WiFiProfileSyncProtocol);
+      if (!EFI_ERROR (Status)) {
+        return;
+      }
+      WiFiProfileSyncProtocol->WifiProfileSyncSetConnectState (Status);
+    }
+  }
   if (ConfigToken->Token.ConnectNetworkToken->Status != EFI_SUCCESS) {
     if (ConfigToken->Nic->OneTimeConnectRequest) {
       //

--- a/NetworkPkg/WifiConnectionManagerDxe/WifiConnectionMgrMisc.c
+++ b/NetworkPkg/WifiConnectionManagerDxe/WifiConnectionMgrMisc.c
@@ -672,10 +672,22 @@ WifiMgrCleanProfileSecrets (
   IN  WIFI_MGR_NETWORK_PROFILE  *Profile
   )
 {
+  EFI_STATUS                        Status;
+  EFI_WIFI_PROFILE_SYNC_PROTOCOL    *WiFiProfileSyncProtocol;
+
   ZeroMem (Profile->Password, sizeof (CHAR16) * PASSWORD_STORAGE_SIZE);
   ZeroMem (Profile->EapPassword, sizeof (CHAR16) * PASSWORD_STORAGE_SIZE);
   ZeroMem (Profile->PrivateKeyPassword, sizeof (CHAR16) * PASSWORD_STORAGE_SIZE);
 
+  //
+  // When EFI WiFi profile sync protocol is found the system is performing a recovery boot in secure
+  // boot mode. The profile sync driver will manage the CA certificate, client
+  // certificate, and key data, cleaning them at exit boot services.
+  //
+  Status = gBS->LocateProtocol (&gEfiWiFiProfileSyncProtocolGuid, NULL, (VOID **) &WiFiProfileSyncProtocol);
+  if (!EFI_ERROR (Status)) {
+    return;
+  }
   if (Profile->CACertData != NULL) {
     ZeroMem (Profile->CACertData, Profile->CACertSize);
     FreePool (Profile->CACertData);


### PR DESCRIPTION
Enables KVM and One Click Recovery WLAN capability with WiFi Profile
Sync feature and protocol. Adding WiFiProfileSyncProtocol, which
suppots the profilesync driver operations for transfering WiFi profiles
from AMT to the Supplicant. WiFiConnectionManager will check for the
WifiProfileSyncProtocol and if found will operate on the premise of a
One Click Recovery, or KVM flow with a Wifi profile provided by AMT.

bugzilla - https://bugzilla.tianocore.org/show_bug.cgi?id=3845

Signed-off-by: Zachary Clark-Williams <zachary.clark-williams@intel.com>