### PR TITLE
UefiPayloadPkg/PlatformBootManagerLib: Evenly space boot prompt

### DIFF
--- a/UefiPayloadPkg/Library/PlatformBootManagerLib/PlatformBootManager.c
+++ b/UefiPayloadPkg/Library/PlatformBootManagerLib/PlatformBootManager.c
@@ -263,15 +263,15 @@ PlatformBootManagerAfterConsole (
   if (FixedPcdGetBool (PcdBootManagerEscape)) {
     Print (
       L"\n"
-      L"Esc or Down      to enter Boot Manager Menu.\n"
-      L"ENTER           to boot directly.\n"
+      L"    Esc or Down      to enter Boot Manager Menu.\n"
+      L"    ENTER           to boot directly.\n"
       L"\n"
       );
   } else {
     Print (
       L"\n"
-      L"F2 or Down      to enter Boot Manager Menu.\n"
-      L"ENTER           to boot directly.\n"
+      L"    F2 or Down      to enter Boot Manager Menu.\n"
+      L"    ENTER           to boot directly.\n"
       L"\n"
       );
   }


### PR DESCRIPTION
Add 4 spaces before the boot prompt "F2 or Down..." so that the
spacing is equadistant from the top, which is spaced with a `\n`,
and the left.

Cc: Guo Dong <guo.dong@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Cc: Maurice Ma <maurice.ma@intel.com>
Cc: Benjamin You <benjamin.you@intel.com>
Signed-off-by: Sean Rhodes <sean@starlabs.systems>
Reviewed-by: Guo Dong <guo.dong@intel.com>