### PR TITLE
BaseTools: Fix DSC LibraryClass precedence rule

### DIFF
--- a/BaseTools/Source/Python/Workspace/DscBuildData.py
+++ b/BaseTools/Source/Python/Workspace/DscBuildData.py
@@ -872,7 +872,7 @@ class DscBuildData(PlatformBuildClassObject):
                 if ModuleType != TAB_COMMON and ModuleType not in SUP_MODULE_LIST:
                     EdkLogger.error('build', OPTION_UNKNOWN, "Unknown module type [%s]" % ModuleType,
                                     File=self.MetaFile, ExtraData=LibraryInstance, Line=LineNo)
-                LibraryClassDict[Arch, ModuleType, LibraryClass] = LibraryInstance
+                LibraryClassDict[ModuleType, Arch, LibraryClass] = LibraryInstance
                 if LibraryInstance not in self._LibraryInstances:
                     self._LibraryInstances.append(LibraryInstance)
 
@@ -881,7 +881,7 @@ class DscBuildData(PlatformBuildClassObject):
             for LibraryClass in LibraryClassSet:
                 # try all possible module types
                 for ModuleType in SUP_MODULE_LIST:
-                    LibraryInstance = LibraryClassDict[self._Arch, ModuleType, LibraryClass]
+                    LibraryInstance = LibraryClassDict[ModuleType, self._Arch, LibraryClass]
                     if LibraryInstance is None:
                         continue
                     self._LibraryClasses[LibraryClass, ModuleType] = LibraryInstance


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3965

Currently DSC LibraryClass precedence rule is not align with DSC Spec.

The expectation rule should be:
[LibraryClasses.$(ARCH)] < [LibraryClasses.Common.$(MODULE_TYPE)]

The actual behavior is:
[LibraryClasses.$(ARCH)] > [LibraryClasses.Common.$(MODULE_TYPE)]

This patch fixes the issue.

Cc: Bob Feng <bob.c.feng@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Long1 Huang <long1.huang@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Signed-off-by: Yuwei Chen <yuwei.chen@intel.com>
Reviewed-by: Bob Feng <bob.c.feng@intel.com>