### PR TITLE
DynamicTablesPkg: Fix generated _HID value for SBSA

### DIFF
--- a/DynamicTablesPkg/Library/Common/SsdtSerialPortFixupLib/SsdtSerialPortFixupLib.c
+++ b/DynamicTablesPkg/Library/Common/SsdtSerialPortFixupLib/SsdtSerialPortFixupLib.c
@@ -8,6 +8,7 @@
   @par Reference(s):
   - Arm Server Base Boot Requirements (SBBR), s4.2.1.8 "SPCR".
   - Microsoft Debug Port Table 2 (DBG2) Specification - December 10, 2015.
+  - ACPI for Arm Components 1.0 - 2020
 **/
 
 #include <IndustryStandard/DebugPort2Table.h>
@@ -176,7 +177,7 @@ FixupIds (
     case EFI_ACPI_DBG2_PORT_SUBTYPE_SERIAL_ARM_SBSA_GENERIC_UART:
     case EFI_ACPI_DBG2_PORT_SUBTYPE_SERIAL_ARM_SBSA_GENERIC_UART_2X:
     {
-      HidString = "ARMH0011";
+      HidString = "ARMHB000";
       CidString = "";
       break;
     }


### PR DESCRIPTION
SSDT tables describing an SBSA compatible serial port receive an '_HID'
value of 'ARMH0011'. This value represents a PL011 serial port.

This patch:
 - Generates an 'ARMHB000' instead
 - References the 'ACPI for Arm Components 1.0 - 2020' document
   specifying the '_HID' values to use.

Signed-off-by: Pierre Gondois <Pierre.Gondois@arm.com>
Reviewed-by: Sami Mujawar <sami.mujawar@arm.com>