### PR TITLE
IntelFsp2Pkg/FspSecCore: Add FSP-I API for SMM support.

### DIFF
--- a/IntelFsp2Pkg/FspSecCore/FspSecCoreI.inf
+++ b/IntelFsp2Pkg/FspSecCore/FspSecCoreI.inf
@@ -1,0 +1,54 @@
+## @file
+#  Sec Core for FSP
+#
+#  Copyright (c) 2022, Intel Corporation. All rights reserved.<BR>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = FspSecCoreI
+  FILE_GUID                      = 558782b5-782d-415e-ab9e-0ceb79dc3425
+  MODULE_TYPE                    = SEC
+  VERSION_STRING                 = 1.0
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  SecFspApiChk.c
+  SecFsp.h
+
+[Sources.X64]
+  X64/FspApiEntryI.nasm
+  X64/FspApiEntryCommon.nasm
+  X64/FspHelper.nasm
+
+[Sources.IA32]
+  Ia32/FspApiEntryI.nasm
+  Ia32/FspApiEntryCommon.nasm
+  Ia32/FspHelper.nasm
+
+[Binaries.Ia32]
+  RAW|Vtf0/Bin/ResetVec.ia32.raw |GCC
+
+[Packages]
+  MdePkg/MdePkg.dec
+  IntelFsp2Pkg/IntelFsp2Pkg.dec
+
+[LibraryClasses]
+  BaseMemoryLib
+  DebugLib
+  BaseLib
+  PciCf8Lib
+  SerialPortLib
+  FspSwitchStackLib
+  FspCommonLib
+  FspSecPlatformLib
+
+

--- a/IntelFsp2Pkg/FspSecCore/Ia32/FspApiEntryI.nasm
+++ b/IntelFsp2Pkg/FspSecCore/Ia32/FspApiEntryI.nasm
@@ -1,0 +1,44 @@
+;; @file
+;  Provide FSP API entry points.
+;
+; Copyright (c) 2022, Intel Corporation. All rights reserved.<BR>
+; SPDX-License-Identifier: BSD-2-Clause-Patent
+;;
+
+    SECTION .text
+
+;
+; Following functions will be provided in C
+;
+extern ASM_PFX(FspApiCommon)
+
+;----------------------------------------------------------------------------
+; FspApiCommonContinue API
+;
+; This is the FSP API common entry point to resume the FSP execution
+;
+;----------------------------------------------------------------------------
+global ASM_PFX(FspApiCommonContinue)
+ASM_PFX(FspApiCommonContinue):
+  jmp $
+
+;----------------------------------------------------------------------------
+; FspSmmInit API
+;
+; This FSP API will notify the FSP about the different phases in the boot
+; process
+;
+;----------------------------------------------------------------------------
+global ASM_PFX(FspSmmInitApi)
+ASM_PFX(FspSmmInitApi):
+  mov    eax,  7 ; FSP_API_INDEX.FspSmmInitApiIndex
+  jmp    ASM_PFX(FspApiCommon)
+
+;----------------------------------------------------------------------------
+; Module Entrypoint API
+;----------------------------------------------------------------------------
+global ASM_PFX(_ModuleEntryPoint)
+ASM_PFX(_ModuleEntryPoint):
+  jmp  $
+  ; Add reference to APIs so that it will not be optimized by compiler
+  jmp  ASM_PFX(FspSmmInitApi)

--- a/IntelFsp2Pkg/FspSecCore/SecFspApiChk.c
+++ b/IntelFsp2Pkg/FspSecCore/SecFspApiChk.c
@@ -71,6 +71,19 @@ FspApiCallingCheck (
         Status = EFI_INVALID_PARAMETER;
       }
     }
+  } else if (ApiIdx == FspSmmInitApiIndex) {
+    //
+    // FspSmmInitApiIndex check
+    //
+    if ((FspData == NULL) || ((UINTN)FspData == MAX_ADDRESS) || ((UINTN)FspData == MAX_UINT32)) {
+      Status = EFI_UNSUPPORTED;
+    } else {
+      if (FspData->Signature != FSP_GLOBAL_DATA_SIGNATURE) {
+        Status = EFI_UNSUPPORTED;
+      } else if (EFI_ERROR (FspUpdSignatureCheck (FspSmmInitApiIndex, ApiParam))) {
+        Status = EFI_INVALID_PARAMETER;
+      }
+    }
   } else {
     Status = EFI_UNSUPPORTED;
   }

--- a/IntelFsp2Pkg/FspSecCore/X64/Fsp22ApiEntryS.nasm
+++ b/IntelFsp2Pkg/FspSecCore/X64/Fsp22ApiEntryS.nasm
@@ -24,7 +24,7 @@ STACK_SAVED_RAX_OFFSET       EQU   8 * 7 ; size of a general purpose register * 
 ;----------------------------------------------------------------------------
 global ASM_PFX(NotifyPhaseApi)
 ASM_PFX(NotifyPhaseApi):
-  mov    eax,  2 ; FSP_API_INDEX.NotifyPhaseApiIndex
+  mov    rax,  2 ; FSP_API_INDEX.NotifyPhaseApiIndex
   jmp    ASM_PFX(FspApiCommon)
 
 ;----------------------------------------------------------------------------
@@ -36,7 +36,7 @@ ASM_PFX(NotifyPhaseApi):
 ;----------------------------------------------------------------------------
 global ASM_PFX(FspSiliconInitApi)
 ASM_PFX(FspSiliconInitApi):
-  mov    eax,  5 ; FSP_API_INDEX.FspSiliconInitApiIndex
+  mov    rax,  5 ; FSP_API_INDEX.FspSiliconInitApiIndex
   jmp    ASM_PFX(FspApiCommon)
 
 ;----------------------------------------------------------------------------
@@ -54,7 +54,7 @@ ASM_PFX(FspSiliconInitApi):
 
 global ASM_PFX(FspMultiPhaseSiInitApi)
 ASM_PFX(FspMultiPhaseSiInitApi):
-  mov    eax,  6 ; FSP_API_INDEX.FspMultiPhaseSiInitApiIndex
+  mov    rax,  6 ; FSP_API_INDEX.FspMultiPhaseSiInitApiIndex
   jmp    ASM_PFX(FspApiCommon)
 
 ;----------------------------------------------------------------------------
@@ -68,7 +68,7 @@ ASM_PFX(FspApiCommonContinue):
   ;
   ; Handle FspMultiPhaseSiInitApiIndex API
   ;
-  cmp    eax, 6
+  cmp    rax, 6 ; FSP_API_INDEX.FspMultiPhaseSiInitApiIndex
   jnz    NotMultiPhaseSiInitApi
 
   PUSHA_64

--- a/IntelFsp2Pkg/FspSecCore/X64/FspApiEntryI.nasm
+++ b/IntelFsp2Pkg/FspSecCore/X64/FspApiEntryI.nasm
@@ -1,0 +1,44 @@
+;; @file
+;  Provide FSP API entry points.
+;
+; Copyright (c) 2022, Intel Corporation. All rights reserved.<BR>
+; SPDX-License-Identifier: BSD-2-Clause-Patent
+;;
+
+    SECTION .text
+
+;
+; Following functions will be provided in C
+;
+extern ASM_PFX(FspApiCommon)
+
+;----------------------------------------------------------------------------
+; FspApiCommonContinue API
+;
+; This is the FSP API common entry point to resume the FSP execution
+;
+;----------------------------------------------------------------------------
+global ASM_PFX(FspApiCommonContinue)
+ASM_PFX(FspApiCommonContinue):
+  jmp $
+
+;----------------------------------------------------------------------------
+; FspSmmInit API
+;
+; This FSP API will notify the FSP about the different phases in the boot
+; process
+;
+;----------------------------------------------------------------------------
+global ASM_PFX(FspSmmInitApi)
+ASM_PFX(FspSmmInitApi):
+  mov    rax,  7 ; FSP_API_INDEX.FspSmmInitApiIndex
+  jmp    ASM_PFX(FspApiCommon)
+
+;----------------------------------------------------------------------------
+; Module Entrypoint API
+;----------------------------------------------------------------------------
+global ASM_PFX(_ModuleEntryPoint)
+ASM_PFX(_ModuleEntryPoint):
+  jmp  $
+  ; Add reference to APIs so that it will not be optimized by compiler
+  jmp  ASM_PFX(FspSmmInitApi)

--- a/IntelFsp2Pkg/FspSecCore/X64/FspApiEntryM.nasm
+++ b/IntelFsp2Pkg/FspSecCore/X64/FspApiEntryM.nasm
@@ -55,7 +55,7 @@ FSP_HEADER_CFGREG_OFFSET     EQU   24h
 ;----------------------------------------------------------------------------
 global ASM_PFX(FspMemoryInitApi)
 ASM_PFX(FspMemoryInitApi):
-  mov    eax,  3 ; FSP_API_INDEX.FspMemoryInitApiIndex
+  mov    rax,  3 ; FSP_API_INDEX.FspMemoryInitApiIndex
   jmp    ASM_PFX(FspApiCommon)
 
 ;----------------------------------------------------------------------------
@@ -66,7 +66,7 @@ ASM_PFX(FspMemoryInitApi):
 ;----------------------------------------------------------------------------
 global ASM_PFX(TempRamExitApi)
 ASM_PFX(TempRamExitApi):
-  mov    eax,  4 ; FSP_API_INDEX.TempRamExitApiIndex
+  mov    rax,  4 ; FSP_API_INDEX.TempRamExitApiIndex
   jmp    ASM_PFX(FspApiCommon)
 
 ;----------------------------------------------------------------------------

--- a/IntelFsp2Pkg/FspSecCore/X64/FspApiEntryS.nasm
+++ b/IntelFsp2Pkg/FspSecCore/X64/FspApiEntryS.nasm
@@ -21,7 +21,7 @@ extern ASM_PFX(FspApiCommon)
 ;----------------------------------------------------------------------------
 global ASM_PFX(NotifyPhaseApi)
 ASM_PFX(NotifyPhaseApi):
-  mov    eax,  2 ; FSP_API_INDEX.NotifyPhaseApiIndex
+  mov    rax,  2 ; FSP_API_INDEX.NotifyPhaseApiIndex
   jmp    ASM_PFX(FspApiCommon)
 
 ;----------------------------------------------------------------------------
@@ -33,7 +33,7 @@ ASM_PFX(NotifyPhaseApi):
 ;----------------------------------------------------------------------------
 global ASM_PFX(FspSiliconInitApi)
 ASM_PFX(FspSiliconInitApi):
-  mov    eax,  5 ; FSP_API_INDEX.FspSiliconInitApiIndex
+  mov    rax,  5 ; FSP_API_INDEX.FspSiliconInitApiIndex
   jmp    ASM_PFX(FspApiCommon)
 
 ;----------------------------------------------------------------------------

--- a/IntelFsp2Pkg/Include/FspEas/FspApi.h
+++ b/IntelFsp2Pkg/Include/FspEas/FspApi.h
@@ -614,4 +614,23 @@ EFI_STATUS
   IN FSP_MULTI_PHASE_PARAMS     *MultiPhaseSiInitParamPtr
   );
 
+/**
+  This FSP API initializes SMM and provide any OS runtime silicon services,
+  including Reliability, Availability, and Serviceability (RAS) features implemented by the CPU.
+
+  @param[in] FspiUpdDataPtr     Pointer to the FSPI_UPD data structure.
+                                If NULL, FSP will use the default parameters.
+
+  @retval EFI_SUCCESS                 FSP execution environment was initialized successfully.
+  @retval EFI_INVALID_PARAMETER       Input parameters are invalid.
+  @retval EFI_UNSUPPORTED             The FSP calling conditions were not met.
+  @retval EFI_DEVICE_ERROR            FSP initialization failed.
+  @retval FSP_STATUS_RESET_REQUIREDx  A reset is required. These status codes will not be returned during S3.
+**/
+typedef
+EFI_STATUS
+(EFIAPI *FSP_SMM_INIT)(
+  IN VOID          *FspiUpdDataPtr
+  );
+
 #endif

--- a/IntelFsp2Pkg/Include/FspGlobalData.h
+++ b/IntelFsp2Pkg/Include/FspGlobalData.h
@@ -10,9 +10,9 @@
 
 #include <FspEas.h>
 
-#define FSP_IN_API_MODE         0
-#define FSP_IN_DISPATCH_MODE    1
-#define FSP_GLOBAL_DATA_VERSION 1
+#define FSP_IN_API_MODE          0
+#define FSP_IN_DISPATCH_MODE     1
+#define FSP_GLOBAL_DATA_VERSION  1
 
 #pragma pack(1)
 
@@ -24,16 +24,17 @@ typedef enum {
   TempRamExitApiIndex,
   FspSiliconInitApiIndex,
   FspMultiPhaseSiInitApiIndex,
+  FspSmmInitApiIndex,
   FspApiIndexMax
 } FSP_API_INDEX;
 
 typedef struct  {
-  VOID      *DataPtr;
-  UINTN     MicrocodeRegionBase;
-  UINTN     MicrocodeRegionSize;
-  UINTN     CodeRegionBase;
-  UINTN     CodeRegionSize;
-  UINTN     Reserved;
+  VOID     *DataPtr;
+  UINTN    MicrocodeRegionBase;
+  UINTN    MicrocodeRegionSize;
+  UINTN    CodeRegionBase;
+  UINTN    CodeRegionSize;
+  UINTN    Reserved;
 } FSP_PLAT_DATA;
 
 #define FSP_GLOBAL_DATA_SIGNATURE        SIGNATURE_32 ('F', 'S', 'P', 'D')
@@ -41,28 +42,28 @@ typedef struct  {
 #define FSP_PERFORMANCE_DATA_TIMER_MASK  0xFFFFFFFFFFFFFF
 
 typedef struct  {
-  UINT32             Signature;
-  UINT8              Version;
-  UINT8              Reserved1[3];
+  UINT32    Signature;
+  UINT8     Version;
+  UINT8     Reserved1[3];
   ///
   /// Offset 0x08
   ///
-  UINTN              CoreStack;
-  UINTN              Reserved2;
+  UINTN     CoreStack;
+  UINTN     Reserved2;
   ///
   /// IA32: Offset 0x10; X64: Offset 0x18
   ///
-  UINT32             StatusCode;
-  UINT8              ApiIdx;
+  UINT32    StatusCode;
+  UINT8     ApiIdx;
   ///
   /// 0: FSP in API mode; 1: FSP in DISPATCH mode
   ///
-  UINT8              FspMode;
-  UINT8              OnSeparateStack;
-  UINT8              Reserved3;
-  UINT32             NumberOfPhases;
-  UINT32             PhasesExecuted;
-  UINT32             Reserved4[8];
+  UINT8     FspMode;
+  UINT8     OnSeparateStack;
+  UINT8     Reserved3;
+  UINT32    NumberOfPhases;
+  UINT32    PhasesExecuted;
+  UINT32    Reserved4[8];
   ///
   /// IA32: Offset 0x40; X64: Offset 0x48
   /// Start of UINTN and pointer section
@@ -75,21 +76,23 @@ typedef struct  {
   VOID               *TempRamInitUpdPtr;
   VOID               *MemoryInitUpdPtr;
   VOID               *SiliconInitUpdPtr;
+  VOID               *SmmInitUpdPtr;
   ///
-  /// IA32: Offset 0x64; X64: Offset 0x90
+  /// IA32: Offset 0x68; X64: Offset 0x98
   /// To store function parameters pointer
   /// so it can be retrieved after stack switched.
   ///
   VOID               *FunctionParameterPtr;
   FSP_INFO_HEADER    *FspInfoHeader;
   VOID               *UpdDataPtr;
+  UINTN              Reserved5;
   ///
   /// End of UINTN and pointer section
   ///
-  UINT8              Reserved5[16];
+  UINT8              Reserved6[16];
   UINT32             PerfSig;
   UINT16             PerfLen;
-  UINT16             Reserved6;
+  UINT16             Reserved7;
   UINT32             PerfIdx;
   UINT64             PerfData[32];
 } FSP_GLOBAL_DATA;

--- a/IntelFsp2Pkg/Include/Guid/FspHeaderFile.h
+++ b/IntelFsp2Pkg/Include/Guid/FspHeaderFile.h
@@ -26,13 +26,13 @@
 
 #define FSP_INFO_HEADER_SIGNATURE  SIGNATURE_32 ('F', 'S', 'P', 'H')
 
-#define IMAGE_ATTRIBUTE_GRAPHICS_SUPPORT      BIT0
-#define IMAGE_ATTRIBUTE_DISPATCH_MODE_SUPPORT BIT1
-#define IMAGE_ATTRIBUTE_64BIT_MODE_SUPPORT    BIT2
-#define FSP_IA32                              0
-#define FSP_X64                               1
+#define IMAGE_ATTRIBUTE_GRAPHICS_SUPPORT       BIT0
+#define IMAGE_ATTRIBUTE_DISPATCH_MODE_SUPPORT  BIT1
+#define IMAGE_ATTRIBUTE_64BIT_MODE_SUPPORT     BIT2
+#define FSP_IA32                               0
+#define FSP_X64                                1
 
-#pragma pack(1)
+  #pragma pack(1)
 
 ///
 /// FSP Information Header as described in FSP v2.0 Spec section 5.1.1.
@@ -159,6 +159,14 @@ typedef struct {
   /// Byte 0x4E: Reserved4.
   ///
   UINT16    Reserved4;
+  ///
+  /// Byte 0x50: Offset for the API for the Multi-Phase memory initialization.
+  ///
+  UINT32    FspMultiPhaseMemInitEntryOffset;
+  ///
+  /// Byte 0x54: Offset for the API to initialize SMM.
+  ///
+  UINT32    FspSmmInitEntryOffset;
 } FSP_INFO_HEADER;
 
 ///
@@ -240,7 +248,7 @@ typedef struct {
   // UINT32  PatchData[];
 } FSP_PATCH_TABLE;
 
-#pragma pack()
+  #pragma pack()
 
 extern EFI_GUID  gFspHeaderFileGuid;
 

--- a/IntelFsp2Pkg/IntelFsp2Pkg.dsc
+++ b/IntelFsp2Pkg/IntelFsp2Pkg.dsc
@@ -68,6 +68,7 @@
   IntelFsp2Pkg/FspSecCore/FspSecCoreT.inf
   IntelFsp2Pkg/FspSecCore/FspSecCoreM.inf
   IntelFsp2Pkg/FspSecCore/FspSecCoreS.inf
+  IntelFsp2Pkg/FspSecCore/FspSecCoreI.inf
   IntelFsp2Pkg/FspSecCore/Fsp22SecCoreS.inf
   IntelFsp2Pkg/FspNotifyPhase/FspNotifyPhasePeim.inf
 

--- a/IntelFsp2Pkg/Tools/GenCfgOpt.py
+++ b/IntelFsp2Pkg/Tools/GenCfgOpt.py
@@ -953,8 +953,8 @@ EndList
         return NoFileChange
 
     def CreateSplitUpdTxt (self, UpdTxtFile):
-        GuidList = ['FSP_T_UPD_TOOL_GUID','FSP_M_UPD_TOOL_GUID','FSP_S_UPD_TOOL_GUID']
-        SignatureList = ['0x545F', '0x4D5F','0x535F']        #  _T, _M, and _S signature for FSPT, FSPM, FSPS
+        GuidList = ['FSP_T_UPD_TOOL_GUID','FSP_M_UPD_TOOL_GUID','FSP_S_UPD_TOOL_GUID','FSP_I_UPD_TOOL_GUID']
+        SignatureList = ['0x545F', '0x4D5F','0x535F','0x495F']        #  _T, _M, _S and _I signature for FSPT, FSPM, FSPS, FSPI
         for Index in range(len(GuidList)):
             UpdTxtFile = ''
             FvDir = self._FvDir
@@ -1288,19 +1288,21 @@ EndList
                    Chars.append(chr(Value & 0xFF))
                    Value = Value >> 8
                SignatureStr = ''.join(Chars)
-               # Signature will be _T / _M / _S for FSPT / FSPM / FSPS accordingly
+               # Signature will be _T / _M / _S / _I for FSPT / FSPM / FSPS /FSPI accordingly
                if '_T' in SignatureStr[6:6+2]:
                    TxtBody.append("#define FSPT_UPD_SIGNATURE               %s        /* '%s' */\n\n" % (Item['value'], SignatureStr))
                elif '_M' in SignatureStr[6:6+2]:
                    TxtBody.append("#define FSPM_UPD_SIGNATURE               %s        /* '%s' */\n\n" % (Item['value'], SignatureStr))
                elif '_S' in SignatureStr[6:6+2]:
                    TxtBody.append("#define FSPS_UPD_SIGNATURE               %s        /* '%s' */\n\n" % (Item['value'], SignatureStr))
+               elif '_I' in SignatureStr[6:6+2]:
+                   TxtBody.append("#define FSPI_UPD_SIGNATURE               %s        /* '%s' */\n\n" % (Item['value'], SignatureStr))
         TxtBody.append("\n")
 
         for Region in ['UPD']:
             UpdOffsetTable = []
-            UpdSignature = ['0x545F', '0x4D5F', '0x535F']   #['_T', '_M', '_S'] signature for FSPT, FSPM, FSPS
-            UpdStructure = ['FSPT_UPD', 'FSPM_UPD', 'FSPS_UPD']
+            UpdSignature = ['0x545F', '0x4D5F', '0x535F', '0x495F']   #['_T', '_M', '_S', '_I'] signature for FSPT, FSPM, FSPS, FSPI
+            UpdStructure = ['FSPT_UPD', 'FSPM_UPD', 'FSPS_UPD', 'FSPI_UPD']
             for Item in self._CfgItemList:
                 if Item["cname"] == 'Signature' and Item["value"][0:6] in UpdSignature:
                     Item["offset"] = 0 # re-initialize offset to 0 when new UPD structure starting
@@ -1393,11 +1395,12 @@ EndList
         HeaderTFileName = 'FsptUpd.h'
         HeaderMFileName = 'FspmUpd.h'
         HeaderSFileName = 'FspsUpd.h'
+        HeaderIFileName = 'FspiUpd.h'
 
-        UpdRegionCheck = ['FSPT', 'FSPM', 'FSPS']     # FSPX_UPD_REGION
-        UpdConfigCheck = ['FSP_T', 'FSP_M', 'FSP_S']  # FSP_X_CONFIG, FSP_X_TEST_CONFIG, FSP_X_RESTRICTED_CONFIG
-        UpdSignatureCheck = ['FSPT_UPD_SIGNATURE', 'FSPM_UPD_SIGNATURE', 'FSPS_UPD_SIGNATURE']
-        ExcludedSpecificUpd = ['FSPT_ARCH_UPD', 'FSPM_ARCH_UPD', 'FSPS_ARCH_UPD']
+        UpdRegionCheck = ['FSPT', 'FSPM', 'FSPS', 'FSPI']     # FSPX_UPD_REGION
+        UpdConfigCheck = ['FSP_T', 'FSP_M', 'FSP_S', 'FSP_I']  # FSP_X_CONFIG, FSP_X_TEST_CONFIG, FSP_X_RESTRICTED_CONFIG
+        UpdSignatureCheck = ['FSPT_UPD_SIGNATURE', 'FSPM_UPD_SIGNATURE', 'FSPS_UPD_SIGNATURE', 'FSPI_UPD_SIGNATURE']
+        ExcludedSpecificUpd = ['FSPT_ARCH_UPD', 'FSPM_ARCH_UPD', 'FSPS_ARCH_UPD', 'FSPI_ARCH_UPD']
         ExcludedSpecificUpd1 = ['FSPT_ARCH2_UPD', 'FSPM_ARCH2_UPD', 'FSPS_ARCH2_UPD']
 
         IncLines = []
@@ -1420,6 +1423,9 @@ EndList
             elif UpdRegionCheck[item] == 'FSPS':
                 HeaderFd = open(os.path.join(FvDir, HeaderSFileName), "w")
                 FileBase = os.path.basename(os.path.join(FvDir, HeaderSFileName))
+            elif UpdRegionCheck[item] == 'FSPI':
+                HeaderFd = open(os.path.join(FvDir, HeaderIFileName), "w")
+                FileBase = os.path.basename(os.path.join(FvDir, HeaderIFileName))
             FileName = FileBase.replace(".", "_").upper()
             HeaderFd.write("%s\n"   % (__copyright_h__ % date.today().year))
             HeaderFd.write("#ifndef __%s__\n"   % FileName)
@@ -1696,7 +1702,7 @@ EndList
 
 
 def Usage():
-    print ("GenCfgOpt Version 0.57")
+    print ("GenCfgOpt Version 0.58")
     print ("Usage:")
     print ("    GenCfgOpt  UPDTXT  PlatformDscFile BuildFvDir                 [-D Macros]")
     print ("    GenCfgOpt  HEADER  PlatformDscFile BuildFvDir  InputHFile     [-D Macros]")

--- a/IntelFsp2Pkg/Tools/SplitFspBin.py
+++ b/IntelFsp2Pkg/Tools/SplitFspBin.py
@@ -1,6 +1,6 @@
 ## @ SplitFspBin.py
 #
-# Copyright (c) 2015 - 2021, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2015 - 2022, Intel Corporation. All rights reserved.<BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -492,7 +492,7 @@ class FspImage:
         self.FihOffset = fihoff
         self.Offset    = offset
         self.FvIdxList = []
-        self.Type      = "XTMSXXXXOXXXXXXX"[(fih.ComponentAttribute >> 12) & 0x0F]
+        self.Type      = "XTMSIXXXXOXXXXXXX"[(fih.ComponentAttribute >> 12) & 0x0F]
         self.PatchList = patch
         self.PatchList.append(fihoff + 0x1C)
 
@@ -869,7 +869,7 @@ def main ():
     parser_rebase  = subparsers.add_parser('rebase',  help='rebase a FSP into a new base address')
     parser_rebase.set_defaults(which='rebase')
     parser_rebase.add_argument('-f',  '--fspbin' , dest='FspBinary',  type=str, help='FSP binary file path', required = True)
-    parser_rebase.add_argument('-c',  '--fspcomp', choices=['t','m','s','o'],  nargs='+', dest='FspComponent', type=str, help='FSP component to rebase', default = "['t']", required = True)
+    parser_rebase.add_argument('-c',  '--fspcomp', choices=['t','m','s','o','i'],  nargs='+', dest='FspComponent', type=str, help='FSP component to rebase', default = "['t']", required = True)
     parser_rebase.add_argument('-b',  '--newbase', dest='FspBase', nargs='+', type=str, help='Rebased FSP binary file name', default = '', required = True)
     parser_rebase.add_argument('-o',  '--outdir' , dest='OutputDir',  type=str, help='Output directory path', default = '.')
     parser_rebase.add_argument('-n',  '--outfile', dest='OutputFile', type=str, help='Rebased FSP binary file name', default = '')


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3993
Add FSP-I API entry point for SMM support.
Also update 64bit API entry code to assign ApiIdx to RAX
to avoid confusion.

Cc: Nate DeSimone <nathaniel.l.desimone@intel.com>
Cc: Star Zeng <star.zeng@intel.com>
Signed-off-by: Chasel Chiu <chasel.chiu@intel.com>
Signed-off-by: Hongbin1 Zhang <hongbin1.zhang@intel.com>
Reviewed-by: Nate DeSimone <nathaniel.l.desimone@intel.com>