### PR TITLE
MdeModulePkg/Include: Long debug string is truncated to 104 char

### DIFF
--- a/MdeModulePkg/Include/Guid/StatusCodeDataTypeDebug.h
+++ b/MdeModulePkg/Include/Guid/StatusCodeDataTypeDebug.h
@@ -10,6 +10,8 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #ifndef _STATUS_CODE_DATA_TYPE_DEBUG_H_
 #define _STATUS_CODE_DATA_TYPE_DEBUG_H_
 
+#include <Pi/PiStatusCode.h>
+
 ///
 /// The Global ID used to identify a structure of type EFI_DEBUG_INFO.
 ///
@@ -21,7 +23,13 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 ///
 /// The maximum size of an EFI_DEBUG_INFO structure.
 ///
-#define EFI_STATUS_CODE_DATA_MAX_SIZE  200
+#define EFI_STATUS_CODE_DATA_MAX_SIZE  0x200
+
+///
+/// Define the maximum extended data size that is supported when a
+/// status code is reported.
+///
+#define MAX_EXTENDED_DATA_SIZE  (EFI_STATUS_CODE_DATA_MAX_SIZE + sizeof(EFI_STATUS_CODE_DATA))
 
 ///
 /// This structure contains the ErrorLevel passed into the DEBUG() macro, followed

--- a/MdeModulePkg/Library/DxeReportStatusCodeLib/ReportStatusCodeLib.c
+++ b/MdeModulePkg/Library/DxeReportStatusCodeLib/ReportStatusCodeLib.c
@@ -19,12 +19,6 @@
 #include <Guid/StatusCodeDataTypeId.h>
 #include <Guid/StatusCodeDataTypeDebug.h>
 
-//
-// Define the maximum extended data size that is supported when a status code is
-// reported at TPL_HIGH_LEVEL.
-//
-#define MAX_EXTENDED_DATA_SIZE  0x200
-
 EFI_STATUS_CODE_PROTOCOL  *mReportStatusCodeLibStatusCodeProtocol = NULL;
 
 /**

--- a/MdeModulePkg/Library/PeiReportStatusCodeLib/ReportStatusCodeLib.c
+++ b/MdeModulePkg/Library/PeiReportStatusCodeLib/ReportStatusCodeLib.c
@@ -17,11 +17,6 @@
 #include <Library/OemHookStatusCodeLib.h>
 #include <Library/PcdLib.h>
 
-//
-// Define the maximum extended data size that is supported in the PEI phase
-//
-#define MAX_EXTENDED_DATA_SIZE  0x200
-
 /**
   Internal worker function that reports a status code through the PEI Status Code Service or
   OEM Hook Status Code Library.

--- a/MdeModulePkg/Library/RuntimeDxeReportStatusCodeLib/ReportStatusCodeLib.c
+++ b/MdeModulePkg/Library/RuntimeDxeReportStatusCodeLib/ReportStatusCodeLib.c
@@ -21,11 +21,6 @@
 #include <Guid/StatusCodeDataTypeDebug.h>
 #include <Guid/EventGroup.h>
 
-//
-// Define the maximum extended data size that is supported when a status code is reported.
-//
-#define MAX_EXTENDED_DATA_SIZE  0x200
-
 EFI_STATUS_CODE_PROTOCOL  *mReportStatusCodeLibStatusCodeProtocol = NULL;
 EFI_EVENT                 mReportStatusCodeLibVirtualAddressChangeEvent;
 EFI_EVENT                 mReportStatusCodeLibExitBootServicesEvent;


### PR DESCRIPTION
From: Cosmo Lai <cosmo.lai@intel.com>

REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3986

The EFI_STATUS_CODE_DATA_MAX_SIZE is defined as 200 in MdeModulePkg.
After reducing 96byte buffer for variable parameters it is limited to
only 104 char debug string. This is a non-necessary limitation.
This change sets EFI_STATUS_CODE_DATA_MAX_SIZE to 0x200, and moves
MAX_EXTENDED_DATA_SIZE definition to the same header file with value
of EFI_STATUS_CODE_DATA_MAX_SIZE + sizeof (EFI_STATUS_CODE_DATA)
which is used in ReportStatusCodeLib to support longer debug string.

Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Dandan Bi <dandan.bi@intel.com>

Signed-off-by: Cosmo Lai <cosmo.lai@intel.com>