### PR TITLE
EmulatorPkg/PosixFileSystem: Add NULL check on memory allocation

### DIFF
--- a/EmulatorPkg/Unix/Host/PosixFileSystem.c
+++ b/EmulatorPkg/Unix/Host/PosixFileSystem.c
@@ -1187,7 +1187,7 @@ PosixFileSetInfo (
   }
 
   OldFileName = malloc (AsciiStrSize (PrivateFile->FileName));
-  if (OldFileInfo == NULL) {
+  if (OldFileName == NULL) {
     goto Done;
   }
 


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4001

This commit adds NULL check on memory allocation of the size
for FileName in ASCII string format at PosixFileSetInfo().

Signed-off-by: Miki Shindo <miki.shindo@intel.com>
Cc: Andrew Fish <afish@apple.com>
Reviewed-by: Ray Ni <ray.ni@intel.com>