### PR TITLE
MdeModulePkg/CoreDxe: Allow DXE Drivers to use untested memory

### DIFF
--- a/MdeModulePkg/Core/Dxe/Mem/Page.c
+++ b/MdeModulePkg/Core/Dxe/Mem/Page.c
@@ -1417,6 +1417,20 @@ CoreInternalAllocatePages (
     Status = CoreConvertPages (Start, NumberOfPages, MemoryType);
   }
 
+  if (EFI_ERROR (Status)) {
+    //
+    // If requested memory region is unavailable it may be untested memory
+    // Attempt to promote memory resources, then re-attempt the allocation
+    //
+    if (PromoteMemoryResource ()) {
+      if (NeedGuard) {
+        Status = CoreConvertPagesWithGuard (Start, NumberOfPages, MemoryType);
+      } else {
+        Status = CoreConvertPages (Start, NumberOfPages, MemoryType);
+      }
+    }
+  }
+
 Done:
   CoreReleaseMemoryLock ();
 


### PR DESCRIPTION
REF: https://https://bugzilla.tianocore.org/show_bug.cgi?id=3795
CC: Dandan Bi <dandan.bi@intel.com>
CC: Liming Gao <gaoliming@byosoft.com.cn>

Updated CoreInternalAllocatePages() to call PromoteMemoryResource() and
re-attempt the allocation if unable to convert the specified memory range

Signed-off-by: Stacy Howell <stacy.howell@intel.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>