### PR TITLE
MdeModulePkg/SetupBrowserDxe:Follow spec'd way to reconnect driver

### DIFF
--- a/MdeModulePkg/Universal/SetupBrowserDxe/Presentation.c
+++ b/MdeModulePkg/Universal/SetupBrowserDxe/Presentation.c
@@ -2,7 +2,7 @@
 Utility functions for UI presentation.
 
 Copyright (c) 2004 - 2018, Intel Corporation. All rights reserved.<BR>
-(C) Copyright 2015 Hewlett Packard Enterprise Development LP<BR>
+(C) Copyright 2015 - 2022 Hewlett Packard Enterprise Development LP<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -21,7 +21,6 @@ LIST_ENTRY                mRefreshEventList  = INITIALIZE_LIST_HEAD_VARIABLE (mR
 UINT16                    mCurFakeQestId;
 FORM_DISPLAY_ENGINE_FORM  gDisplayFormData;
 BOOLEAN                   mFinishRetrieveCall = FALSE;
-BOOLEAN                   mDynamicFormUpdated = FALSE;
 
 /**
   Check whether the ConfigAccess protocol is available.
@@ -1791,7 +1790,6 @@ FormUpdateNotify (
   )
 {
   mHiiPackageListUpdated = TRUE;
-  mDynamicFormUpdated    = TRUE;
 
   return EFI_SUCCESS;
 }

--- a/MdeModulePkg/Universal/SetupBrowserDxe/Setup.c
+++ b/MdeModulePkg/Universal/SetupBrowserDxe/Setup.c
@@ -2,7 +2,7 @@
 Entry and initialization module for the browser.
 
 Copyright (c) 2007 - 2018, Intel Corporation. All rights reserved.<BR>
-(C) Copyright 2020 Hewlett Packard Enterprise Development LP<BR>
+(C) Copyright 2020 - 2022 Hewlett Packard Enterprise Development LP<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -68,7 +68,6 @@ extern EFI_GUID                  mCurrentFormSetGuid;
 extern EFI_HII_HANDLE            mCurrentHiiHandle;
 extern UINT16                    mCurrentFormId;
 extern FORM_DISPLAY_ENGINE_FORM  gDisplayFormData;
-extern BOOLEAN                   mDynamicFormUpdated;
 
 /**
   Create a menu with specified formset GUID and form ID, and add it as a child
@@ -539,7 +538,6 @@ SendForm (
 
       Selection->FormSet  = FormSet;
       mSystemLevelFormSet = FormSet;
-      mDynamicFormUpdated = FALSE;
 
       //
       // Display this formset
@@ -552,10 +550,9 @@ SendForm (
       mSystemLevelFormSet = NULL;
 
       //
-      // If callback update form dynamically, it's not exiting of the formset for user so system do not reconnect driver hanlde
-      // this time.
+      // Check incoming formset whether is same with previous. If yes, that means action is not exiting of formset so do not reconnect controller.
       //
-      if (!mDynamicFormUpdated && (gFlagReconnect || gCallbackReconnect)) {
+      if ((gFlagReconnect || gCallbackReconnect) && !CompareGuid (&FormSet->Guid, &Selection->FormSetGuid)) {
         RetVal = ReconnectController (FormSet->DriverHandle);
         if (!RetVal) {
           PopupErrorMessage (BROWSER_RECONNECT_FAIL, NULL, NULL, NULL);


### PR DESCRIPTION
REF:https://bugzilla.tianocore.org/show_bug.cgi?id=3952

In UEFI spec, it defines reconnect timing that will be activated upon
exiting of the formset or the browser. However, we did't use this kind
of way to check reconnect conditioncode. Code only blocks reconnect if
page is updated dynamically. That's not matched spec'd way. We should
check current formset whether is exiting, then reconnect driver.

Signed-off-by: Walon Li <walon.li@hpe.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>