### PR TITLE
UefiCpuPkg: Fix nasm warning "signed byte value exceeds"

### DIFF
--- a/UefiCpuPkg/Library/CpuExceptionHandlerLib/CpuExceptionCommon.h
+++ b/UefiCpuPkg/Library/CpuExceptionHandlerLib/CpuExceptionCommon.h
@@ -22,7 +22,7 @@
 
 #define  CPU_EXCEPTION_NUM    32
 #define  CPU_INTERRUPT_NUM    256
-#define  HOOKAFTER_STUB_SIZE  16
+#define  HOOKAFTER_STUB_SIZE  18
 
 //
 // Exception Error Code of Page-Fault Exception

--- a/UefiCpuPkg/Library/CpuExceptionHandlerLib/Ia32/ExceptionHandlerAsm.nasm
+++ b/UefiCpuPkg/Library/CpuExceptionHandlerLib/Ia32/ExceptionHandlerAsm.nasm
@@ -34,7 +34,7 @@ ALIGN   8
 AsmIdtVectorBegin:
 %assign Vector 0
 %rep  256
-    push    byte %[Vector];
+    push    strict dword %[Vector];
     push    eax
     mov     eax, ASM_PFX(CommonInterruptEntry)
     jmp     eax
@@ -43,9 +43,8 @@ AsmIdtVectorBegin:
 AsmIdtVectorEnd:
 
 HookAfterStubBegin:
-    db      0x6a        ; push
+    push    strict dword 0  ; 0 will be fixed
 VectorNum:
-    db      0          ; 0 will be fixed
     push    eax
     mov     eax, HookAfterStubHeaderEnd
     jmp     eax
@@ -453,5 +452,5 @@ global ASM_PFX(AsmVectorNumFixup)
 ASM_PFX(AsmVectorNumFixup):
     mov     eax, dword [esp + 8]
     mov     ecx, [esp + 4]
-    mov     [ecx + (VectorNum - HookAfterStubBegin)], al
+    mov     [ecx + (VectorNum - 4 - HookAfterStubBegin)], al
     ret

--- a/UefiCpuPkg/Library/CpuExceptionHandlerLib/X64/Xcode5ExceptionHandlerAsm.nasm
+++ b/UefiCpuPkg/Library/CpuExceptionHandlerLib/X64/Xcode5ExceptionHandlerAsm.nasm
@@ -57,18 +57,17 @@ ALIGN   8
 AsmIdtVectorBegin:
 %assign Vector 0
 %rep  256
-    push    byte %[Vector]
+    push    strict dword %[Vector] ; This instruction pushes sign-extended 8-byte value on stack
     push    rax
-    mov     rax, strict qword 0 ;    mov     rax, ASM_PFX(CommonInterruptEntry)
+    mov     rax, strict qword 0    ; mov     rax, ASM_PFX(CommonInterruptEntry)
     jmp     rax
 %assign Vector Vector+1
 %endrep
 AsmIdtVectorEnd:
 
 HookAfterStubHeaderBegin:
-    db      0x6a        ; push
-@VectorNum:
-    db      0          ; 0 will be fixed
+    push    strict dword 0      ; 0 will be fixed
+VectorNum:
     push    rax
     mov     rax, strict qword 0 ;     mov     rax, HookAfterStubHeaderEnd
 JmpAbsoluteAddress:
@@ -478,6 +477,6 @@ ASM_PFX(AsmGetTemplateAddressMap):
 global ASM_PFX(AsmVectorNumFixup)
 ASM_PFX(AsmVectorNumFixup):
     mov     rax, rdx
-    mov     [rcx + (@VectorNum - HookAfterStubHeaderBegin)], al
+    mov     [rcx + (VectorNum - 4 - HookAfterStubHeaderBegin)], al
     ret
 


### PR DESCRIPTION
Currently, "push byte %[Vector]" causes nasm warning when Vector is larger
than 0x7F. This is because push accepts a signed value, and byte means
signed int8. Maximum signed int8 is 0x7F.
When Vector is larger the 0x7F, for example, when Vector is 255, byte 255
turns to -1, and causes the warning "signed byte value exceeds".
To avoid such warning, use dword instead of byte, this will increase 3 bytes
for each IdtVector.
For IA32, the size of IdtVector will increase from 10 bytes to 13 bytes.
For X64, the size of IdtVector will increase from 15 bytes to 18 bytes.

Cc: Eric Dong <eric.dong@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Cc: Rahul Kumar <rahul1.kumar@intel.com>
Cc: Debkumar De <debkumar.de@intel.com>
Cc: Harry Han <harry.han@intel.com>
Cc: Catharine West <catharine.west@intel.com>
Reviewed-by: Ray Ni <ray.ni@intel.com>
Signed-off-by: Zhiguang Liu <zhiguang.liu@intel.com>