### PR TITLE
[Test] ArmPlatformPkg, ArmVirtPkg: Add early hello message

### DIFF
--- a/ArmPlatformPkg/ArmPlatformPkg.dec
+++ b/ArmPlatformPkg/ArmPlatformPkg.dec
@@ -122,6 +122,13 @@
   ## If set, this will swap settings for HDLCD RED_SELECT and BLUE_SELECT registers
   gArmPlatformTokenSpaceGuid.PcdArmHdLcdSwapBlueRedSelect|FALSE|BOOLEAN|0x00000045
 
+  #
+  # Early hello message (ASCII string), printed to the serial port.
+  # If set to the empty string, nothing is printed.
+  # Otherwise, a trailing CRLF should be specified explicitly.
+  #
+  gArmPlatformTokenSpaceGuid.PcdEarlyHelloMessage|""|VOID*|0x00000100
+
 [PcdsFixedAtBuild.common,PcdsDynamic.common]
   ## PL031 RealTimeClock
   gArmPlatformTokenSpaceGuid.PcdPL031RtcBase|0x0|UINT32|0x00000024

--- a/ArmPlatformPkg/PrePeiCore/MainMPCore.c
+++ b/ArmPlatformPkg/PrePeiCore/MainMPCore.c
@@ -116,6 +116,13 @@ PrimaryMain (
   UINTN                   TemporaryRamBase;
   UINTN                   TemporaryRamSize;
 
+  if (FixedPcdGetSize (PcdEarlyHelloMessage) > 1) {
+    SerialPortWrite (
+      FixedPcdGetPtr (PcdEarlyHelloMessage),
+      FixedPcdGetSize (PcdEarlyHelloMessage) - 1
+      );
+  }
+
   CreatePpiList (&PpiListSize, &PpiList);
 
   // Enable the GIC Distributor

--- a/ArmPlatformPkg/PrePeiCore/MainUniCore.c
+++ b/ArmPlatformPkg/PrePeiCore/MainUniCore.c
@@ -29,6 +29,13 @@ PrimaryMain (
   UINTN                   TemporaryRamBase;
   UINTN                   TemporaryRamSize;
 
+  if (FixedPcdGetSize (PcdEarlyHelloMessage) > 1) {
+    SerialPortWrite (
+      FixedPcdGetPtr (PcdEarlyHelloMessage),
+      FixedPcdGetSize (PcdEarlyHelloMessage) - 1
+      );
+  }
+
   CreatePpiList (&PpiListSize, &PpiList);
 
   // Adjust the Temporary Ram as the new Ppi List (Common + Platform Ppi Lists) is created at

--- a/ArmPlatformPkg/PrePeiCore/PrePeiCore.h
+++ b/ArmPlatformPkg/PrePeiCore/PrePeiCore.h
@@ -16,6 +16,7 @@
 #include <Library/DebugLib.h>
 #include <Library/IoLib.h>
 #include <Library/PcdLib.h>
+#include <Library/SerialPortLib.h>
 
 #include <PiPei.h>
 #include <Ppi/TemporaryRamSupport.h>

--- a/ArmPlatformPkg/PrePeiCore/PrePeiCoreMPCore.inf
+++ b/ArmPlatformPkg/PrePeiCore/PrePeiCoreMPCore.inf
@@ -66,6 +66,8 @@
   gArmPlatformTokenSpaceGuid.PcdCPUCorePrimaryStackSize
   gArmPlatformTokenSpaceGuid.PcdCPUCoreSecondaryStackSize
 
+  gArmPlatformTokenSpaceGuid.PcdEarlyHelloMessage
+
   gArmTokenSpaceGuid.PcdGicDistributorBase
   gArmTokenSpaceGuid.PcdGicInterruptInterfaceBase
   gArmTokenSpaceGuid.PcdGicSgiIntId

--- a/ArmPlatformPkg/PrePeiCore/PrePeiCoreUniCore.inf
+++ b/ArmPlatformPkg/PrePeiCore/PrePeiCoreUniCore.inf
@@ -64,4 +64,6 @@
   gArmPlatformTokenSpaceGuid.PcdCPUCorePrimaryStackSize
   gArmPlatformTokenSpaceGuid.PcdCPUCoreSecondaryStackSize
 
+  gArmPlatformTokenSpaceGuid.PcdEarlyHelloMessage
+
   gEfiMdeModulePkgTokenSpaceGuid.PcdInitValueInTempStack

--- a/ArmVirtPkg/ArmVirtQemu.dsc
+++ b/ArmVirtPkg/ArmVirtQemu.dsc
@@ -135,6 +135,7 @@
   gArmVirtTokenSpaceGuid.PcdTpm2SupportEnabled|$(TPM2_ENABLE)
 
 [PcdsFixedAtBuild.common]
+  gArmPlatformTokenSpaceGuid.PcdEarlyHelloMessage|"UEFI firmware starting.\r\n"
 !if $(ARCH) == AARCH64
   gArmTokenSpaceGuid.PcdVFPEnabled|1
 !endif


### PR DESCRIPTION
Add the ability to print an early hello message independent of debug
mask to the serial port when the firmware starts. Introduce a PCD entry
to set the message text (`ArmPlatformPkg`). If the message text is empty
(default) then nothing is printed.

The message is useful for debugging boot problems, especially with
silent firmware builds. It can take some seconds until the first line is
printed when booting the firmware, for example when running `ArmVirt` in
Qemu.

Use the above in `ArmVirtPkg` by defining a message text.

These changes have already been proposed by Laszlo Ersek in 2015.
I am reposting because I find this useful.


Example of a VM starting up, AARCH64, Qemu on X64). First line is the
new message. (Timestamp in seconds).
```
-VM start-
0000.094 | UEFI firmware starting.
00004.06 | BdsDxe: failed to load Boot0001 "UEFI Misc Device" from VenHw(93E34C7E-B50E-11DF-9223-2443DFD72085,00): Not Found
00004.08 | BdsDxe: loading Boot0002 "UEFI Misc Device 2" from PciRoot(0x0)/Pci(0x2,0x0)
00004.08 | BdsDxe: starting Boot0002 "UEFI Misc Device 2" from PciRoot(0x0)/Pci(0x2,0x0)
00004.11 | System BootOrder not found.  Initializing defaults.
00004.11 | Creating boot entry "Boot0005" with label "Red Hat Enterprise Linux" for file "\EFI\redhat\shimaa64.efi"
00004.15 |
00008.39 | EFI stub: Booting Linux Kernel...
[...]
````