### PR TITLE
UefiPayloadPkg: Fix RelaAddress type always mismatch in if condition

### DIFF
--- a/UefiPayloadPkg/PayloadLoaderPeim/ElfLib/Elf32Lib.c
+++ b/UefiPayloadPkg/PayloadLoaderPeim/ElfLib/Elf32Lib.c
@@ -292,7 +292,7 @@ RelocateElf32Dynamic (
     }
   }
 
-  if (RelaAddress == MAX_UINT64) {
+  if (RelaAddress == MAX_UINT32) {
     ASSERT (RelaCount     == 0);
     ASSERT (RelaEntrySize == 0);
     ASSERT (RelaSize      == 0);


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3984

Under function RolocateElfDynamic() in Elf32Lib.c
if (RelaAddress == MAX_UINT64) is always FALSE while RelaAddress is UINT32
Fix is to  modify if condition check to "if (RelaAddress == MAX_UINT32)"

Cc: Ray Ni <ray.ni@intel.com>
Cc: Guo Dong <guo.dong@intel.com>
Cc: Gua Guo <gua.guo@intel.com>
Signed-off-by: James Lu <james.lu@intel.com>
Reviewed-by: Guo Dong <guo.dong@intel.com>