### PR TITLE
OvmfPkg/QemuVideoDxe: Zero out PixelInformation in QueryMode

### DIFF
--- a/OvmfPkg/QemuVideoDxe/Gop.c
+++ b/OvmfPkg/QemuVideoDxe/Gop.c
@@ -31,7 +31,14 @@ QemuVideoCompleteModeInfo (
     Info->PixelInformation.ReservedMask = 0;
   } else if (ModeData->ColorDepth == 32) {
     DEBUG ((DEBUG_INFO, "PixelBlueGreenRedReserved8BitPerColor\n"));
-    Info->PixelFormat = PixelBlueGreenRedReserved8BitPerColor;
+    Info->PixelFormat                   = PixelBlueGreenRedReserved8BitPerColor;
+    Info->PixelInformation.RedMask      = 0;
+    Info->PixelInformation.GreenMask    = 0;
+    Info->PixelInformation.BlueMask     = 0;
+    Info->PixelInformation.ReservedMask = 0;
+  } else {
+    DEBUG ((DEBUG_ERROR, "%a: Invalid ColorDepth %u", __FUNCTION__, ModeData->ColorDepth));
+    ASSERT (FALSE);
   }
 
   Info->PixelsPerScanLine = Info->HorizontalResolution;


### PR DESCRIPTION
Ensure that the PixelInformation field of the
EFI_GRAPHICS_OUTPUT_MODE_INFORMATION structure is zeroed out in
EFI_GRAPHICS_OUTPUT_PROTOCOL.QueryMode() and
EFI_GRAPHICS_OUTPUT_PROTOCOL.SetMode() when PixelFormat is
PixelBlueGreenRedReserved8BitPerColor.

According to UEFI 2.9 Section 12.9, PixelInformation field of the
EFI_GRAPHICS_OUTPUT_MODE_INFORMATION structure is valid only if
PixelFormat is PixelBitMask. This means that firmware is not required
to fill out the PixelInformation field for other PixelFormat types,
which implies that the QemuVideoDxe implementation is technically
correct.

However, not zeroing out those fields will leak the contents of the
memory returned by the memory allocator, so it is better to explicitly
set them to zero.

In addition, the SCT test suite relies on PixelInformation always
having a consistent value, which causes failures.

Signed-off-by: Dimitrije Pavlov <Dimitrije.Pavlov@arm.com>
Acked-by: Gerd Hoffmann <kraxel@redhat.com>