### PR TITLE
Maintainers.txt: Add missing Github IDs for OvmfPkg TPM/TGC modules

### DIFF
--- a/Maintainers.txt
+++ b/Maintainers.txt
@@ -495,8 +495,8 @@ F: OvmfPkg/Library/PlatformBootManagerLib/BdsPlatform.c
 F: OvmfPkg/Library/Tcg2PhysicalPresenceLib*/
 F: OvmfPkg/PlatformPei/ClearCache.c
 F: OvmfPkg/Tcg/
-R: Marc-André Lureau <marcandre.lureau@redhat.com>
-R: Stefan Berger <stefanb@linux.ibm.com>
+R: Marc-André Lureau <marcandre.lureau@redhat.com> [elmarco]
+R: Stefan Berger <stefanb@linux.ibm.com> [stefanberger]
 
 OvmfPkg: Xen-related modules
 F: OvmfPkg/Include/Guid/XenBusRootDevice.h


### PR DESCRIPTION
Cc: Ard Biesheuvel <ardb+tianocore@kernel.org>
Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Jordan Justen <jordan.l.justen@intel.com>
Cc: Gerd Hoffmann <kraxel@redhat.com>
Cc: Marc-André Lureau <marcandre.lureau@redhat.com>
Cc: Stefan Berger <stefanb@linux.ibm.com>
Signed-off-by: Michael D Kinney <michael.d.kinney@intel.com>
Acked-by: Ard Biesheuvel <ardb+tianocore@kernel.org>
Reviewed-by: Jiewen Yao <jiewen.yao@intel.com>