### PR TITLE
DynamicTablesPkg: Fix using RmrNodeCount unitlitialised

### DIFF
--- a/DynamicTablesPkg/Library/Acpi/Arm/AcpiIortLibArm/IortGenerator.c
+++ b/DynamicTablesPkg/Library/Acpi/Arm/AcpiIortLibArm/IortGenerator.c
@@ -2107,6 +2107,8 @@ BuildIortTable (
   ASSERT (AcpiTableInfo->TableGeneratorId == This->GeneratorID);
   ASSERT (AcpiTableInfo->AcpiTableSignature == This->AcpiTableSignature);
 
+  RmrNodeCount = 0;
+
   if ((AcpiTableInfo->AcpiTableRevision < This->MinAcpiTableRevision) ||
       (AcpiTableInfo->AcpiTableRevision > This->AcpiTableRevision))
   {
@@ -2714,7 +2716,10 @@ BuildIortTable (
     }
   }
 
-  if (RmrNodeCount > 0) {
+  if ((AcpiTableInfo->AcpiTableRevision >=
+       EFI_ACPI_IO_REMAPPING_TABLE_REVISION_05) &&
+      (RmrNodeCount > 0))
+  {
     Status = AddRmrNodes (
                This,
                CfgMgrProtocol,


### PR DESCRIPTION
Fix using RmrNodeCount uninitliased by initliasing it to zero. Also, add
an additional check for ACPI version. This fixes a crash running on
kvmtool.

Signed-off-by: Edward Pickup <edward.pickup@arm.com>
Reviewed-by: Sami Mujawar <sami.mujawar@arm.com>