### PR TITLE
BaseTools/GenSec: Fix typo

### DIFF
--- a/BaseTools/Source/C/GenSec/GenSec.c
+++ b/BaseTools/Source/C/GenSec/GenSec.c
@@ -191,7 +191,7 @@ Returns:
                         as 0, tool get alignment value from SectionFile. It is\n\
                         specified in same order that the section file is input.\n");
   fprintf (stdout, "  --dummy dummyfile\n\
-                        compare dummpyfile with input_file to decide whether\n\
+                        compare dummyfile with input_file to decide whether\n\
                         need to set PROCESSING_REQUIRED attribute.\n");
   fprintf (stdout, "  -v, --verbose         Turn on verbose output with informational messages.\n");
   fprintf (stdout, "  -q, --quiet           Disable all messages except key message and fatal error\n");


### PR DESCRIPTION
Fix typo in the help message.

Signed-off-by: Konstantin Aladyshev <aladyshev22@gmail.com>
Reviewed-by: Bob Feng <bob.c.feng@intel.com>