### PR TITLE
MdeModulePkg: Update the SMBIOS version by UPL

### DIFF
--- a/MdeModulePkg/Universal/SmbiosDxe/SmbiosDxe.h
+++ b/MdeModulePkg/Universal/SmbiosDxe/SmbiosDxe.h
@@ -136,7 +136,9 @@ BOOLEAN
 IsValidSmbios30Table (
   IN  VOID   *TableEntry,
   OUT VOID   **TableAddress,
-  OUT UINTN  *TableMaximumSize
+  OUT UINTN  *TableMaximumSize,
+  OUT UINT8  *MajorVersion,
+  OUT UINT8  *MinorVersion
   );
 
 /**
@@ -155,7 +157,9 @@ BOOLEAN
 IsValidSmbios20Table (
   IN  VOID   *TableEntry,
   OUT VOID   **TableAddress,
-  OUT UINTN  *TableMaximumSize
+  OUT UINTN  *TableMaximumSize,
+  OUT UINT8  *MajorVersion,
+  OUT UINT8  *MinorVersion
   );
 
 /**
@@ -174,7 +178,9 @@ BOOLEAN
 (*IS_SMBIOS_TABLE_VALID) (
   IN  VOID   *TableEntry,
   OUT VOID   **TableAddress,
-  OUT UINTN  *TableMaximumSize
+  OUT UINTN  *TableMaximumSize,
+  OUT UINT8  *MajorVersion,
+  OUT UINT8  *MinorVersion
   );
 typedef struct {
   EFI_GUID                 *Guid;


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4013

For the SMBIOS version can be update by UPL,we create
the gUniversalPayloadSmbios3TableGuid HOB to store
the value then updated version.

Cc: Guo Dong <guo.dong@intel.com>
Reviewed-by: Ray Ni <ray.ni@intel.com>
Cc: James Lu <james.lu@intel.com>
Reviewed-by: Gua Guo <gua.guo@intel.com>
Signed-off-by: KasimX Liu <kasimx.liu@intel.com>