### PR TITLE
[Test] OvmfPkg: increase max debug message length to 512

### DIFF
--- a/OvmfPkg/Library/PlatformDebugLibIoPort/DebugLib.c
+++ b/OvmfPkg/Library/PlatformDebugLibIoPort/DebugLib.c
@@ -21,7 +21,7 @@
 //
 // Define the maximum debug and assert message length that this library supports
 //
-#define MAX_DEBUG_MESSAGE_LENGTH  0x100
+#define MAX_DEBUG_MESSAGE_LENGTH  0x200
 
 //
 // VA_LIST can not initialize to NULL for all compiler, so we use this to


### PR DESCRIPTION
Increase the maximum line length for debug messages.
While log messages should be short, they can still
get quite long, for example when printing device paths
or config strings in HII routing.
512 chars is an empirically good value.

Signed-off-by: Laszlo Ersek <lersek@redhat.com>
Signed-off-by: Oliver Steffen <osteffen@redhat.com>