### PR TITLE
OvmfPkg: Update I/O port related to ACPI devices for CloudHv

### DIFF
--- a/OvmfPkg/Include/IndustryStandard/CloudHv.h
+++ b/OvmfPkg/Include/IndustryStandard/CloudHv.h
@@ -16,12 +16,12 @@
 //
 // ACPI timer address
 //
-#define CLOUDHV_ACPI_TIMER_IO_ADDRESS  0xb008
+#define CLOUDHV_ACPI_TIMER_IO_ADDRESS  0x0608
 
 //
 // ACPI shutdown device address
 //
-#define CLOUDHV_ACPI_SHUTDOWN_IO_ADDRESS  0x03c0
+#define CLOUDHV_ACPI_SHUTDOWN_IO_ADDRESS  0x0600
 
 //
 // 32-bit MMIO memory hole base address


### PR DESCRIPTION
Both ACPI shutdown and ACPI PM timer devices has been moved to different
port addresses in the latest version of Cloud Hypervisor. These changes
need to be reflected on the OVMF firmware.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>