### PR TITLE
ShellPkg/SmbiosView: Smbiosview tool is not show Extended Speed and E…

### DIFF
--- a/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/PrintInfo.c
+++ b/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/PrintInfo.c
@@ -878,6 +878,11 @@ SmbiosPrintStructure (
         }
       }
 
+      if (AE_SMBIOS_VERSION (0x3, 0x3) && (Struct->Hdr->Length > 0x54)) {
+        PRINT_STRUCT_VALUE_H (Struct, Type17, ExtendedSpeed);
+        PRINT_STRUCT_VALUE_H (Struct, Type17, ExtendedConfiguredMemorySpeed);
+      }
+
       break;
 
     //


### PR DESCRIPTION
…xtended Configured Memory Speed in type 17.

REF:https://bugzilla.tianocore.org/show_bug.cgi?id=4014

if Configured Memory Speed is 65,535 MT/s or greater,
and the actual speed is stored in the Extended Configured Memory Speed
field. but current Smbiosview have no this logic.

Signed-off-by: Shengfengx Xue <shengfengx.xue@intel.com>