### PR TITLE
IntelFsp2Pkg: FSPM_ARCH2_UPD mismatching bug.

### DIFF
--- a/IntelFsp2Pkg/FspSecCore/Ia32/FspApiEntryM.nasm
+++ b/IntelFsp2Pkg/FspSecCore/Ia32/FspApiEntryM.nasm
@@ -40,12 +40,13 @@ struc FSPM_UPD_COMMON_FSP24
     .Revision:                  resb  1
     .Reserved:                  resb  3
     .Length                     resd  1
+    .NvsBufferPtr               resq  1
     .StackBase:                 resq  1
     .StackSize:                 resq  1
     .BootLoaderTolumSize:       resd  1
     .BootMode:                  resd  1
     .FspEventHandler            resq  1
-    .Reserved1:                 resb 24
+    .Reserved1:                 resb 16
     ; }
     .size:
 endstruc

--- a/IntelFsp2Pkg/FspSecCore/X64/FspApiEntryM.nasm
+++ b/IntelFsp2Pkg/FspSecCore/X64/FspApiEntryM.nasm
@@ -22,12 +22,13 @@ struc FSPM_UPD_COMMON_FSP24
     .Revision:                  resb  1
     .Reserved:                  resb  3
     .Length                     resd  1
+    .NvsBufferPtr               resq  1
     .StackBase:                 resq  1
     .StackSize:                 resq  1
     .BootLoaderTolumSize:       resd  1
     .BootMode:                  resd  1
     .FspEventHandler            resq  1
-    .Reserved1:                 resb 24
+    .Reserved1:                 resb 16
     ; }
     .size:
 endstruc


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4019

FSPM_ARCH2_UPD in FspApiEntryM.nasm was not up-to-date and
should be fixed for both IA32 and X64 builds.

Cc: Nate DeSimone <nathaniel.l.desimone@intel.com>
Cc: Star Zeng <star.zeng@intel.com>
Signed-off-by: Chasel Chiu <chasel.chiu@intel.com>
Reviewed-by: Star Zeng <star.zeng@intel.com>