### PR TITLE
Bug 4021 4022 preserve gen sec behavior

### DIFF
--- a/BaseTools/Source/C/GenSec/GenSec.c
+++ b/BaseTools/Source/C/GenSec/GenSec.c
@@ -1112,7 +1112,7 @@ Returns:
   //
   if (TotalLength >= MAX_SECTION_SIZE) {
     SubtypeGuidSect2 = (EFI_FREEFORM_SUBTYPE_GUID_SECTION2 *) FileBuffer;
-    SubtypeGuidSect2->CommonHeader.Type     = EFI_SECTION_GUID_DEFINED;
+    SubtypeGuidSect2->CommonHeader.Type     = EFI_SECTION_FREEFORM_SUBTYPE_GUID;
     SubtypeGuidSect2->CommonHeader.Size[0]  = (UINT8) 0xff;
     SubtypeGuidSect2->CommonHeader.Size[1]  = (UINT8) 0xff;
     SubtypeGuidSect2->CommonHeader.Size[2]  = (UINT8) 0xff;

--- a/BaseTools/Source/C/GenSec/GenSec.c
+++ b/BaseTools/Source/C/GenSec/GenSec.c
@@ -1752,8 +1752,7 @@ Returns:
   // Check whether there is GUID for the SubtypeGuid section
   //
   if ((SectType == EFI_SECTION_FREEFORM_SUBTYPE_GUID) && (CompareGuid (&VendorGuid, &mZeroGuid) == 0)) {
-    Error (NULL, 0, 1001, "Missing options", "GUID");
-    goto Finish;
+    fprintf (stdout, "Warning: input guid value is required for section type %s\n", SectionName);
   }
 
   //
@@ -1825,13 +1824,25 @@ Returns:
     break;
 
   case EFI_SECTION_FREEFORM_SUBTYPE_GUID:
-    Status = GenSectionSubtypeGuidSection (
-              InputFileName,
-              InputFileAlign,
-              InputFileNum,
-              &VendorGuid,
-              &OutFileBuffer
-              );
+    if (CompareGuid (&VendorGuid, &mZeroGuid) == 0) {
+      //
+      // Preserve existing behavior when no GUID value is provided
+      //
+      Status = GenSectionCommonLeafSection (
+                InputFileName,
+                InputFileNum,
+                SectType,
+                &OutFileBuffer
+                );
+    } else {
+      Status = GenSectionSubtypeGuidSection (
+                InputFileName,
+                InputFileAlign,
+                InputFileNum,
+                &VendorGuid,
+                &OutFileBuffer
+                );
+    }
     break;
 
   case EFI_SECTION_VERSION:


### PR DESCRIPTION
BaseTools/Source/C/GenSec: Fix EFI_SECTION_FREEFORM_SUBTYPE_GUID header

REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4021
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4022

When the size of a EFI_SECTION_FREEFORM_SUBTYPE_GUID section required
the use of EFI_FREEFORM_SUBTYPE_GUID_SECTION2 header, set the section
type to EFI_SECTION_FREEFORM_SUBTYPE_GUID.

If no GUID value is provided with EFI_SECTION_FREEFORM_SUBTYPE_GUID
then preserve the prior behavior until all downstream platforms
are updated to pass in a GUID value.

Cc: Konstantin Aladyshev <aladyshev22@gmail.com>
Cc: Bob Feng <bob.c.feng@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Yuwei Chen <yuwei.chen@intel.com>
Signed-off-by: Michael D Kinney <michael.d.kinney@intel.com>