### PR TITLE
BaseTools/Source/C/GenSec: Fix EFI_SECTION_FREEFORM_SUBTYPE_GUID header

### DIFF
--- a/BaseTools/Source/C/GenSec/GenSec.c
+++ b/BaseTools/Source/C/GenSec/GenSec.c
@@ -1112,7 +1112,7 @@ Returns:
   //
   if (TotalLength >= MAX_SECTION_SIZE) {
     SubtypeGuidSect2 = (EFI_FREEFORM_SUBTYPE_GUID_SECTION2 *) FileBuffer;
-    SubtypeGuidSect2->CommonHeader.Type     = EFI_SECTION_GUID_DEFINED;
+    SubtypeGuidSect2->CommonHeader.Type     = EFI_SECTION_FREEFORM_SUBTYPE_GUID;
     SubtypeGuidSect2->CommonHeader.Size[0]  = (UINT8) 0xff;
     SubtypeGuidSect2->CommonHeader.Size[1]  = (UINT8) 0xff;
     SubtypeGuidSect2->CommonHeader.Size[2]  = (UINT8) 0xff;


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4021

When the size of a EFI_SECTION_FREEFORM_SUBTYPE_GUID section required
the use of EFI_FREEFORM_SUBTYPE_GUID_SECTION2 header, set the section
type to EFI_SECTION_FREEFORM_SUBTYPE_GUID.

Cc: Konstantin Aladyshev <aladyshev22@gmail.com>
Cc: Bob Feng <bob.c.feng@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Yuwei Chen <yuwei.chen@intel.com>
Signed-off-by: Michael D Kinney <michael.d.kinney@intel.com>
Acked-by: Konstantin Aladyshev <aladyshev22@gmail.com>
Reviewed-by: Bob Feng <bob.c.feng@intel.com>