### PR TITLE
OvmfPkg: Reserve the Ovmf work area as RT_DATA

### DIFF
--- a/OvmfPkg/Library/PlatformInitLib/IntelTdx.c
+++ b/OvmfPkg/Library/PlatformInitLib/IntelTdx.c
@@ -557,7 +557,7 @@ PlatformTdxPublishRamRegions (
     BuildMemoryAllocationHob (
       (EFI_PHYSICAL_ADDRESS)(UINTN)FixedPcdGet32 (PcdOvmfWorkAreaBase),
       (UINT64)(UINTN)FixedPcdGet32 (PcdOvmfWorkAreaSize),
-      EfiBootServicesData
+      EfiRuntimeServicesData
       );
   }
 }

--- a/OvmfPkg/Library/PlatformInitLib/MemDetect.c
+++ b/OvmfPkg/Library/PlatformInitLib/MemDetect.c
@@ -1022,7 +1022,7 @@ PlatformQemuInitializeRamForS3 (
       BuildMemoryAllocationHob (
         (EFI_PHYSICAL_ADDRESS)(UINTN)FixedPcdGet32 (PcdOvmfWorkAreaBase),
         (UINT64)(UINTN)FixedPcdGet32 (PcdOvmfWorkAreaSize),
-        PlatformInfoHob->S3Supported ? EfiACPIMemoryNVS : EfiBootServicesData
+        PlatformInfoHob->S3Supported ? EfiACPIMemoryNVS : EfiRuntimeServicesData
         );
     }
 


### PR DESCRIPTION
BZ: https://bugzilla.tianocore.org/show_bug.cgi?id=3974

Ovmf work-area (PcdOvmfWorkArea) was designed to store the Confidential
Computing guest information, including the CC guest type. This
information will be probed by CcProbeLib so that the CC guest type can
be determined in run-time. But the Ovmf work-area was reserved as
BT_Data so that it cannot be accessed after ExitBootService. Please see
the detailed analysis in BZ#3974.

RH also reports a similar bug. Please see:
https://bugzilla.redhat.com/show_bug.cgi?id=2114858

This patch reserves the work-area as RT_Data to fix this bug.

Cc: Erdem Aktas <erdemaktas@google.com>
Cc: James Bottomley <jejb@linux.ibm.com>
Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Gerd Hoffmann <kraxel@redhat.com>
Cc: Tom Lendacky <thomas.lendacky@amd.com>
Signed-off-by: Min Xu <min.m.xu@intel.com>