### PR TITLE
UefiPayloadPkg: Return PciRootBridges instead of NULL

### DIFF
--- a/UefiPayloadPkg/Library/PciHostBridgeLib/PciHostBridgeSupport.c
+++ b/UefiPayloadPkg/Library/PciHostBridgeLib/PciHostBridgeSupport.c
@@ -549,6 +549,7 @@ RetrieveRootBridgeInfoFromHob (
   }
 
   if (PciRootBridgeInfo->Count == 0) {
+    PcdSetBoolS (PcdPciDisableBusEnumeration, FALSE);
     return NULL;
   }
 
@@ -589,9 +590,8 @@ RetrieveRootBridgeInfoFromHob (
   if (PciRootBridgeInfo->ResourceAssigned) {
     PcdSetBoolS (PcdPciDisableBusEnumeration, TRUE);
   } else {
-    DEBUG ((DEBUG_ERROR, "There is root bridge whose ResourceAssigned is FALSE\n"));
+    DEBUG ((DEBUG_INFO, "There is root bridge whose ResourceAssigned is FALSE\n"));
     PcdSetBoolS (PcdPciDisableBusEnumeration, FALSE);
-    return NULL;
   }
 
   return PciRootBridges;


### PR DESCRIPTION
Return PciRootBridges instead of NULL and set
PcdPciDisableBusEnumeration to FALSE when
root bridge count is zero.

Reviewed-by: Guo Dong <guo.dong@intel.com>
Reviewed-by: Gua Guo <gua.guo@intel.com>
Signed-off-by: Kavya <k.kavyax.sravanthi@intel.com>