### PR TITLE
UefiPayloadPkg: Fix Coverity report defect

### DIFF
--- a/UefiPayloadPkg/Library/PciHostBridgeLib/PciHostBridgeLib.c
+++ b/UefiPayloadPkg/Library/PciHostBridgeLib/PciHostBridgeLib.c
@@ -232,11 +232,11 @@ PciHostBridgeFreeRootBridges (
   UINTN            Count
   )
 {
-  if ((Bridges == NULL) && (Count == 0)) {
+  if ((Bridges == NULL) || (Count == 0)) {
     return;
   }
 
-  ASSERT (Bridges != NULL && Count > 0);
+  ASSERT (Bridges != NULL || Count > 0);
 
   do {
     --Count;

--- a/UefiPayloadPkg/PayloadLoaderPeim/ElfLib/ElfLib.c
+++ b/UefiPayloadPkg/PayloadLoaderPeim/ElfLib/ElfLib.c
@@ -149,7 +149,7 @@ CalculateElfFileSize (
     FileSize2 = Elf32Hdr->e_shoff + Elf32Hdr->e_shentsize * Elf32Hdr->e_shnum;
   } else if (ElfCt->EiClass == ELFCLASS64) {
     Elf64Hdr  = (Elf64_Ehdr *)ElfCt->FileBase;
-    FileSize2 = (UINTN)(Elf64Hdr->e_shoff + Elf64Hdr->e_shentsize * Elf64Hdr->e_shnum);
+    FileSize2 = ((UINTN)Elf64Hdr->e_shoff + (UINTN)(Elf64Hdr->e_shentsize * Elf64Hdr->e_shnum));
   }
 
   *FileSize = MAX (FileSize1, FileSize2);

--- a/UefiPayloadPkg/UefiPayloadEntry/X64/VirtualMemory.c
+++ b/UefiPayloadPkg/UefiPayloadEntry/X64/VirtualMemory.c
@@ -778,9 +778,9 @@ CreateIdentityMappingPageTables (
   // Pre-allocate big pages to avoid later allocations.
   //
   if (!Page1GSupport) {
-    TotalPagesNum = ((NumberOfPdpEntriesNeeded + 1) * NumberOfPml4EntriesNeeded + 1) * NumberOfPml5EntriesNeeded + 1;
+    TotalPagesNum = (UINTN)((NumberOfPdpEntriesNeeded + 1) * NumberOfPml4EntriesNeeded + 1) * NumberOfPml5EntriesNeeded + 1;
   } else {
-    TotalPagesNum = (NumberOfPml4EntriesNeeded + 1) * NumberOfPml5EntriesNeeded + 1;
+    TotalPagesNum = (UINTN)(NumberOfPml4EntriesNeeded + 1) * NumberOfPml5EntriesNeeded + 1;
   }
 
   //


### PR DESCRIPTION
https://bugzilla.tianocore.org/show_bug.cgi?id=4018
Coverity report FORWARD_NULL and OVERFLOW_BEFORE_WIDEN potential defect
in UefiPayloadPkg.

Signed-off-by: Gregx Yeh <gregx.yeh@intel.com>
Reviewed-by: Guo Dong <guo.dong@intel.com>
Reviewed-by: James Lu <james.lu@intel.com>