### PR TITLE
ShellPkg: Add revision check for DSDT Header on Arm

### DIFF
--- a/ShellPkg/Library/UefiShellAcpiViewCommandLib/Parsers/Dsdt/DsdtParser.c
+++ b/ShellPkg/Library/UefiShellAcpiViewCommandLib/Parsers/Dsdt/DsdtParser.c
@@ -1,7 +1,7 @@
 /** @file
   DSDT table parser
 
-  Copyright (c) 2016 - 2018, ARM Limited. All rights reserved.
+  Copyright (c) 2016 - 2022, ARM Limited. All rights reserved.
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
   @par Reference(s):
@@ -39,4 +39,20 @@ ParseAcpiDsdt (
   }
 
   DumpAcpiHeader (Ptr);
+
+  // As per 19.6.29 in the version 6.4 of the ACPI spec, a revision less than 2
+  // restricts integers to 32 bit width. This may not be intended, raise a
+  // warning
+ #if defined (MDE_CPU_AARCH64) || defined (MDE_CPU_ARM)
+  if (AcpiTableRevision < 2) {
+    IncrementWarningCount ();
+    Print (
+      L"WARNING: DSDT Table Revision less than 2. Integer width restricted to "
+      L"32 bits. Table Revision = %d.\n",
+      AcpiTableRevision
+      );
+    return;
+  }
+
+ #endif
 }


### PR DESCRIPTION
Bugzilla: 3995 (https://bugzilla.tianocore.org/show_bug.cgi?id=3995)

ACPI 6.4 spec states that if the revision field in the DSDT header is less
than 2, then all integers are restricted in width to 32 bits, including in
SSDTs.

Arm Base boot requirements state that platforms must conform to ACPI 6.3
or later, and that legacy tables are not supported.

Adds a check for this field and raise warning if revision is less
than 2 on arm.

Signed-off-by: Edward Pickup <edward.pickup@arm.com>
Reviewed-by: Zhichao Gao <zhichao.gao@intel.com>