### PR TITLE
MdePkg: Remove the restriction that SmmCpuRendezvousLibNull only supp…

### DIFF
--- a/MdePkg/Library/SmmCpuRendezvousLibNull/SmmCpuRendezvousLibNull.c
+++ b/MdePkg/Library/SmmCpuRendezvousLibNull/SmmCpuRendezvousLibNull.c
@@ -6,7 +6,7 @@
 
 **/
 
-#include <Library/DebugLib.h>
+#include <Uefi.h>
 #include <Library/SmmCpuRendezvousLib.h>
 
 /**

--- a/MdePkg/Library/SmmCpuRendezvousLibNull/SmmCpuRendezvousLibNull.inf
+++ b/MdePkg/Library/SmmCpuRendezvousLibNull/SmmCpuRendezvousLibNull.inf
@@ -13,8 +13,8 @@
   INF_VERSION                    = 0x00010005
   BASE_NAME                      = SmmCpuRendezvousLibNull
   FILE_GUID                      = 1e5790ea-d013-4d7b-9047-b4342a762027
-  MODULE_TYPE                    = DXE_SMM_DRIVER
-  LIBRARY_CLASS                  = SmmCpuRendezvousLib|MM_STANDALONE DXE_SMM_DRIVER
+  MODULE_TYPE                    = BASE
+  LIBRARY_CLASS                  = SmmCpuRendezvousLib
 
 [Sources]
   SmmCpuRendezvousLibNull.c


### PR DESCRIPTION
…ort MM_STANDALONE and DXE_SMM_DRIVER.

REF： https://bugzilla.tianocore.org/show_bug.cgi?id=4034

In the implementation of SmmCpuRendezvousLib null version, there is a restriction in [LIBRARY_CLASS] section.
So removing the restriction that other type driver can use SmmCpuRendezvousLib null version implemented.

Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>

Signed-off-by: Zhihao Li <zhihao.li@intel.com>