### PR TITLE
BaseTools: Fix DevicePath GNUmakefile for macOS

### DIFF
--- a/BaseTools/Source/C/DevicePath/GNUmakefile
+++ b/BaseTools/Source/C/DevicePath/GNUmakefile
@@ -16,8 +16,10 @@ include $(MAKEROOT)/Makefiles/app.makefile
 GCCVERSION = $(shell gcc -dumpversion | awk -F'.' '{print $$1}')
 ifneq ("$(GCCVERSION)", "5")
 ifneq ($(CXX), llvm)
+ifneq ($(DARWIN),Darwin)
 # gcc 12 trips over device path handling
 BUILD_CFLAGS += -Wno-error=stringop-overflow
+endif
 endif
 endif
 


### PR DESCRIPTION
On macOS, /usr/bin/gcc is clang, and so doesn't have
the -Wno-error=stringop-overflow flag that was added
for gcc 12.
Update the GNUmakefile for DevicePath to skip setting
that on macOS.

Signed-off-by: Rebecca Cran <rebecca@bsdio.com>
Reviewed-by: Michael D Kinney <michael.d.kinney@intel.com>