### PR TITLE
MdePkg: Use ANSI colors to indicate debug message severity

### DIFF
--- a/MdePkg/Include/Library/PrintLib.h
+++ b/MdePkg/Include/Library/PrintLib.h
@@ -2,6 +2,7 @@
   Provides services to print a formatted string to a buffer. All combinations of
   Unicode and ASCII strings are supported.
 
+Copyright (c) 2022, Qualcomm Innovation Center, Inc. All rights reserved.<BR>
 Copyright (c) 2006 - 2018, Intel Corporation. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -929,6 +930,44 @@ EFIAPI
 SPrintLengthAsciiFormat (
   IN  CONST CHAR8  *FormatString,
   IN  VA_LIST      Marker
+  );
+
+/**
+  Wraps a message with ANSI color escape codes.
+
+  @param String     The string to wrap.
+  @param StringLen  The size of the String buffer in characters.
+  @param ErrorLevel The error level.
+
+  @retval RETURN_SUCCESS          The string was successfully updated.
+  @retval RETURN_BUFFER_TOO_SMALL The buffer is too small.
+
+**/
+RETURN_STATUS
+EFIAPI
+AsciiDebugGetColorString (
+  IN OUT CHAR8  *String,
+  IN UINTN      StringLen,
+  IN UINTN      ErrorLevel
+  );
+
+/**
+  Wraps a message with ANSI color escape codes.
+
+  @param String     The string to wrap.
+  @param StringLen  The size of the String buffer in Unicode characters.
+  @param ErrorLevel The error level.
+
+  @retval RETURN_SUCCESS          The string was successfully updated.
+  @retval RETURN_BUFFER_TOO_SMALL The buffer is too small.
+
+**/
+RETURN_STATUS
+EFIAPI
+UnicodeDebugGetColorString (
+  IN OUT CHAR16  *String,
+  IN UINTN       StringLen,
+  IN UINTN       ErrorLevel
   );
 
 #endif

--- a/MdePkg/Library/BaseDebugLibSerialPort/DebugLib.c
+++ b/MdePkg/Library/BaseDebugLibSerialPort/DebugLib.c
@@ -125,6 +125,8 @@ DebugPrintMarker (
     AsciiBSPrint (Buffer, sizeof (Buffer), Format, BaseListMarker);
   }
 
+  AsciiDebugGetColorString (Buffer, MAX_DEBUG_MESSAGE_LENGTH, ErrorLevel);
+
   //
   // Send the print string to a Serial Port
   //

--- a/MdePkg/Library/UefiDebugLibConOut/DebugLib.c
+++ b/MdePkg/Library/UefiDebugLibConOut/DebugLib.c
@@ -108,6 +108,8 @@ DebugPrintMarker (
       UnicodeBSPrintAsciiFormat (Buffer, sizeof (Buffer), Format, BaseListMarker);
     }
 
+    UnicodeDebugGetColorString (Buffer, MAX_DEBUG_MESSAGE_LENGTH, ErrorLevel);
+
     //
     // Send the print string to the Console Output device
     //


### PR DESCRIPTION
Indicate DEBUG_ERROR messages by printing them in red,
and DEBUG_WARN by printing them in yellow.

Signed-off-by: Rebecca Cran <rebecca@quicinc.com>