### PR TITLE
DynamicTablesPkg: AcpiSsdtPcieLibArm : Add UID to slot creation

### DIFF
--- a/DynamicTablesPkg/Include/Library/SsdtPcieSupportLib.h
+++ b/DynamicTablesPkg/Include/Library/SsdtPcieSupportLib.h
@@ -54,9 +54,10 @@ AddOscMethod (
   used. It should be possible to enumerate them, but this is additional
   information.
 
-  @param [in]       PciInfo     Pci device information.
-  @param [in]  MappingTable     The mapping table structure.
-  @param [in, out]  PciNode     Pci node to amend.
+  @param [in]       PciInfo       Pci device information.
+  @param [in]       MappingTable  The mapping table structure.
+  @param [in]       Uid           Unique Id of the Pci device.
+  @param [in, out]  PciNode       Pci node to amend.
 
   @retval EFI_SUCCESS            Success.
   @retval EFI_INVALID_PARAMETER  Invalid parameter.
@@ -67,6 +68,7 @@ EFIAPI
 GeneratePciSlots (
   IN      CONST CM_ARM_PCI_CONFIG_SPACE_INFO  *PciInfo,
   IN      CONST MAPPING_TABLE                 *MappingTable,
+  IN            UINT32                        Uid,
   IN  OUT       AML_OBJECT_NODE_HANDLE        PciNode
   );
 

--- a/DynamicTablesPkg/Library/Acpi/Arm/AcpiSsdtPcieLibArm/SsdtPcieGenerator.c
+++ b/DynamicTablesPkg/Library/Acpi/Arm/AcpiSsdtPcieLibArm/SsdtPcieGenerator.c
@@ -298,6 +298,7 @@ GeneratePciDeviceInfo (
   @param [in]       CfgMgrProtocol  Pointer to the Configuration Manager
                                     Protocol interface.
   @param [in]       PciInfo         Pci device information.
+  @param [in]       Uid             Unique Id of the Pci device.
   @param [in, out]  PciNode         Pci node to amend.
 
   @retval EFI_SUCCESS             The function completed successfully.
@@ -311,6 +312,7 @@ GeneratePrt (
   IN            ACPI_PCI_GENERATOR                            *Generator,
   IN      CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST  CfgMgrProtocol,
   IN      CONST CM_ARM_PCI_CONFIG_SPACE_INFO                  *PciInfo,
+  IN            UINT32                                        Uid,
   IN  OUT       AML_OBJECT_NODE_HANDLE                        PciNode
   )
 {
@@ -419,7 +421,7 @@ GeneratePrt (
   PrtNode = NULL;
 
   // Generate the Pci slots once all the device have been added.
-  Status = GeneratePciSlots (PciInfo, &Generator->DeviceTable, PciNode);
+  Status = GeneratePciSlots (PciInfo, &Generator->DeviceTable, Uid, PciNode);
   if (EFI_ERROR (Status)) {
     ASSERT (0);
     goto exit_handler;
@@ -814,6 +816,7 @@ GeneratePciDevice (
                Generator,
                CfgMgrProtocol,
                PciInfo,
+               Uid,
                PciNode
                );
     if (EFI_ERROR (Status)) {

--- a/DynamicTablesPkg/Library/Common/SsdtPcieSupportLib/SsdtPcieSupportLib.c
+++ b/DynamicTablesPkg/Library/Common/SsdtPcieSupportLib/SsdtPcieSupportLib.c
@@ -41,9 +41,10 @@
   used. It should be possible to enumerate them, but this is additional
   information.
 
-  @param [in]       PciInfo     Pci device information.
-  @param [in]  MappingTable     The mapping table structure.
-  @param [in, out]  PciNode     Pci node to amend.
+  @param [in]       PciInfo       Pci device information.
+  @param [in]       MappingTable  The mapping table structure.
+  @param [in]       Uid           Unique Id of the Pci device.
+  @param [in, out]  PciNode       Pci node to amend.
 
   @retval EFI_SUCCESS            Success.
   @retval EFI_INVALID_PARAMETER  Invalid parameter.
@@ -54,6 +55,7 @@ EFIAPI
 GeneratePciSlots (
   IN      CONST CM_ARM_PCI_CONFIG_SPACE_INFO  *PciInfo,
   IN      CONST MAPPING_TABLE                 *MappingTable,
+  IN            UINT32                        Uid,
   IN  OUT       AML_OBJECT_NODE_HANDLE        PciNode
   )
 {


### PR DESCRIPTION
Expose the UID value to GeneratePciSlots().
This is needed for some cases for example:
https://docs.microsoft.com/en-us/windows-hardware/drivers/pci/dsd-for-pcie-root-ports#identifying-externally-exposed-pcie-root-ports

Name (_DSD, Package () {
  ToUUID("EFCC06CC-73AC-4BC3-BFF0-76143807C389"),
  Package () {
    Package (2) {"ExternalFacingPort", 1},
    Package (2) {"UID", 0},
  }
})

Signed-off-by: Jeff Brasen <jbrasen@nvidia.com>
Reviewed-by: Pierre Gondois <pierre.gondois@arm.com>
Reviewed-by: Sami Mujawar <sami.mujawar@arm.com>