### PR TITLE
UefiCpuPkg/SmmCpuRendezvousLib: Separate the processing logic of MM_S…

### DIFF
--- a/UefiCpuPkg/Library/SmmCpuRendezvousLib/SmmCpuRendezvousLibStandaloneMm.c
+++ b/UefiCpuPkg/Library/SmmCpuRendezvousLib/SmmCpuRendezvousLibStandaloneMm.c
@@ -1,0 +1,110 @@
+/** @file
+SMM CPU Rendezvous library header file.
+
+Copyright (c) 2021, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Base.h>
+#include <Uefi.h>
+#include <Library/BaseLib.h>
+#include <Library/DebugLib.h>
+#include <Library/MmServicesTableLib.h>
+#include <Protocol/SmmCpuService.h>
+#include <Library/SmmCpuRendezvousLib.h>
+
+STATIC EDKII_SMM_CPU_RENDEZVOUS_PROTOCOL  *mSmmCpuRendezvous = NULL;
+
+/**
+  This routine wait for all AP processors to arrive in SMM.
+
+  @param[in] BlockingMode  Blocking mode or non-blocking mode.
+
+  @retval EFI_SUCCESS  All avaiable APs arrived.
+  @retval EFI_TIMEOUT  Wait for all APs until timeout.
+  @retval OTHER        Fail to register SMM CPU Rendezvous service Protocol.
+**/
+EFI_STATUS
+EFIAPI
+SmmWaitForAllProcessor (
+  IN BOOLEAN  BlockingMode
+  )
+{
+  EFI_STATUS  Status;
+
+  //
+  // The platform have not set up. It doesn't need smm cpu rendezvous.
+  //
+  if (mSmmCpuRendezvous == NULL) {
+    return EFI_SUCCESS;
+  }
+
+  Status = mSmmCpuRendezvous->WaitForAllProcessor (
+                                mSmmCpuRendezvous,
+                                BlockingMode
+                                );
+
+  return Status;
+}
+
+/**
+  Register status code callback function only when Report Status Code protocol
+  is installed.
+
+  @param Protocol       Points to the protocol's unique identifier.
+  @param Interface      Points to the interface instance.
+  @param Handle         The handle on which the interface was installed.
+
+  @retval EFI_SUCCESS   Notification runs successfully.
+
+**/
+EFI_STATUS
+EFIAPI
+SmmCpuRendezvousProtocolNotify (
+  IN CONST EFI_GUID  *Protocol,
+  IN VOID            *Interface,
+  IN EFI_HANDLE      Handle
+  )
+{
+  EFI_STATUS  Status;
+
+  Status = gMmst->MmLocateProtocol (
+                    &gEdkiiSmmCpuRendezvousProtocolGuid,
+                    NULL,
+                    (VOID **)&mSmmCpuRendezvous
+                    );
+
+  return EFI_SUCCESS;
+}
+
+/**
+  The constructor function
+
+  @param[in]  ImageHandle  The firmware allocated handle for the EFI image.
+  @param[in]  SystemTable  A pointer to the EFI System Table.
+
+  @retval EFI_SUCCESS      The constructor always returns EFI_SUCCESS.
+
+**/
+EFI_STATUS
+EFIAPI
+SmmCpuRendezvousLibStandaloneConstructor (
+  IN EFI_HANDLE           ImageHandle,
+  IN EFI_MM_SYSTEM_TABLE  *SystemTable
+  )
+{
+  EFI_STATUS  Status;
+  VOID        *Registration;
+
+  Status = gMmst->MmLocateProtocol (&gEdkiiSmmCpuRendezvousProtocolGuid, NULL, (VOID **)&mSmmCpuRendezvous);
+  if (EFI_ERROR (Status)) {
+    Status = gMmst->MmRegisterProtocolNotify (
+                      &gEdkiiSmmCpuRendezvousProtocolGuid,
+                      SmmCpuRendezvousProtocolNotify,
+                      &Registration
+                      );
+  }
+
+  return EFI_SUCCESS;
+}

--- a/UefiCpuPkg/Library/SmmCpuRendezvousLib/SmmCpuRendezvousLibStandaloneMm.inf
+++ b/UefiCpuPkg/Library/SmmCpuRendezvousLib/SmmCpuRendezvousLibStandaloneMm.inf
@@ -10,14 +10,16 @@
 ##
 
 [Defines]
-  INF_VERSION                    = 0x00010005
-  BASE_NAME                      = SmmCpuRendezvousLib
-  FILE_GUID                      = 1509Bb36-9Ba4-438B-B195-Ac5914Db14E2
-  MODULE_TYPE                    = DXE_SMM_DRIVER
+  INF_VERSION                    = 0x0001001B
+  BASE_NAME                      = SmmCpuRendezvousLibStandaloneMm
+  FILE_GUID                      = 3BBBBFA9-5DEB-6793-C6F4-F16B6565EB45
+  MODULE_TYPE                    = MM_STANDALONE
   LIBRARY_CLASS                  = SmmCpuRendezvousLib
+  PI_SPECIFICATION_VERSION       = 0x00010032
+  CONSTRUCTOR                    = SmmCpuRendezvousLibStandaloneConstructor
 
 [Sources]
-  SmmCpuRendezvousLib.c
+  SmmCpuRendezvousLibStandaloneMm.c
 
 [Packages]
   MdePkg/MdePkg.dec

--- a/UefiCpuPkg/UefiCpuPkg.dsc
+++ b/UefiCpuPkg/UefiCpuPkg.dsc
@@ -61,7 +61,6 @@
   TpmMeasurementLib|MdeModulePkg/Library/TpmMeasurementLibNull/TpmMeasurementLibNull.inf
   VmgExitLib|UefiCpuPkg/Library/VmgExitLibNull/VmgExitLibNull.inf
   MicrocodeLib|UefiCpuPkg/Library/MicrocodeLib/MicrocodeLib.inf
-  SmmCpuRendezvousLib|UefiCpuPkg/Library/SmmCpuRendezvousLib/SmmCpuRendezvousLib.inf
   CpuPageTableLib|UefiCpuPkg/Library/CpuPageTableLib/CpuPageTableLib.inf
 
 [LibraryClasses.common.SEC]
@@ -101,9 +100,11 @@
   MemoryAllocationLib|MdePkg/Library/SmmMemoryAllocationLib/SmmMemoryAllocationLib.inf
   HobLib|MdePkg/Library/DxeHobLib/DxeHobLib.inf
   CpuExceptionHandlerLib|UefiCpuPkg/Library/CpuExceptionHandlerLib/SmmCpuExceptionHandlerLib.inf
+  SmmCpuRendezvousLib|UefiCpuPkg/Library/SmmCpuRendezvousLib/SmmCpuRendezvousLib.inf
 
 [LibraryClasses.common.MM_STANDALONE]
   MmServicesTableLib|MdePkg/Library/StandaloneMmServicesTableLib/StandaloneMmServicesTableLib.inf
+  SmmCpuRendezvousLib|UefiCpuPkg/Library/SmmCpuRendezvousLib/SmmCpuRendezvousLibStandaloneMm.inf
 
 [LibraryClasses.common.UEFI_APPLICATION]
   UefiApplicationEntryPoint|MdePkg/Library/UefiApplicationEntryPoint/UefiApplicationEntryPoint.inf
@@ -177,6 +178,7 @@
   UefiCpuPkg/ResetVector/Vtf0/Bin/ResetVector.inf
   UefiCpuPkg/Library/SmmCpuRendezvousLib/SmmCpuRendezvousLib.inf
   UefiCpuPkg/Library/CpuPageTableLib/CpuPageTableLib.inf
+  UefiCpuPkg/Library/SmmCpuRendezvousLib/SmmCpuRendezvousLibStandaloneMm.inf
 
 [BuildOptions]
   *_*_*_CC_FLAGS = -D DISABLE_NEW_DEPRECATED_INTERFACES


### PR DESCRIPTION
…TANDALONE and DXE_SMM_DRIVER customers.

REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4044

MM_STANDALONE and DXE_SMM_DRIVER has different work flow after using SmmCpuRendezvousLib. The smm rendezvous protocol
instance also has different lifecycle. So separate SmmCpuRendezvousLib for MM_STANDALONE out will be more reasonable.

Cc: Eric Dong <eric.dong@intel.com>
Cc: Ray Ni <ray.ni@intel.com>

Signed-off-by: Zhihao Li <zhihao.li@intel.com>