### PR TITLE
OvmfPkg/BhyvePkg: use correct PlatformSecureLib

### DIFF
--- a/OvmfPkg/Bhyve/BhyveX64.dsc
+++ b/OvmfPkg/Bhyve/BhyveX64.dsc
@@ -198,7 +198,7 @@
   RngLib|MdePkg/Library/BaseRngLibTimerLib/BaseRngLibTimerLib.inf
 
 !if $(SECURE_BOOT_ENABLE) == TRUE
-  PlatformSecureLib|OvmfPkg/Bhyve/Library/PlatformSecureLib/PlatformSecureLib.inf
+  PlatformSecureLib|OvmfPkg/Library/PlatformSecureLib/PlatformSecureLib.inf
   AuthVariableLib|SecurityPkg/Library/AuthVariableLib/AuthVariableLib.inf
   SecureBootVariableLib|SecurityPkg/Library/SecureBootVariableLib/SecureBootVariableLib.inf
   PlatformPKProtectionLib|SecurityPkg/Library/PlatformPKProtectionLibVarPolicy/PlatformPKProtectionLibVarPolicy.inf


### PR DESCRIPTION
There's no bhyve specific PlatformSecureLib any more. Use the default
one of OvmfPkg which works too.

Signed-off-by: Corvin Köhne <c.koehne@beckhoff.com>
CC: Ard Biesheuvel <ardb+tianocore@kernel.org>
CC: Jiewen Yao <jiewen.yao@intel.com>
CC: Jordan Justen <jordan.l.justen@intel.com>
CC: Gerd Hoffmann <kraxel@redhat.com>
CC: Rebecca Cran <rebecca@bsdio.com>
CC: Peter Grehan <grehan@freebsd.org>
CC: devel@edk2.groups.io