### PR TITLE
RedfishPkg/RedfishDiscoverDxe: Install EFI_DISCOVER_PROTOCOL on each …

### DIFF
--- a/RedfishPkg/RedfishDiscoverDxe/RedfishDiscoverInternal.h
+++ b/RedfishPkg/RedfishDiscoverDxe/RedfishDiscoverInternal.h
@@ -2,6 +2,7 @@
   This file defines the EFI Redfish Discover Protocol interface.
 
   (C) Copyright 2021 Hewlett Packard Enterprise Development LP<BR>
+  Copyright (c) 2022, AMD Incorporated. All rights reserved.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -107,6 +108,12 @@ typedef struct {
                                                                                ///< NETWORK_INTERFACE_PROTOCOL_TYPE.
   REDFISH_DISCOVER_NETWORK_INTERFACE_PROTOCOL    NetworkInterfaceProtocolInfo; ///< Network interface protocol information.
   EFI_HANDLE                                     RestExHandle;                 ///< REST EX handle associated with this network interface.
+  //
+  // EFI_REDFISH_DISCOVER_PROTOCOL instance installed
+  // on this network interface.
+  //
+  EFI_HANDLE                                     EfiRedfishDiscoverProtocolHandle; ///< EFI_REDFISH_DISCOVER_PROTOTOCOL instance installed
+                                                                                   ///< on this network interface.
 } EFI_REDFISH_DISCOVER_NETWORK_INTERFACE_INTERNAL;
 
 //


### PR DESCRIPTION
…network interface

BZ 4037:
Install EFI_DISCOVER_PROTOCOL on each network interface.

This fixes the issue that causes the high-level Redfish driver
on the network interface is stopped when:
1. EFI_DISCOVER_PROTOCOL is reinstalled on a new-found network
   interface, or
2. EFI_DISCOVER_PROTOCOL is stopped on the network interface
   other than the one which is used to communicate with Redfish
   service.

Cc: Nickle Wang <nickle@csie.io>
Cc: Igor Kulchytskyy <igork@ami.com>
Signed-off-by: Abner Chang <abner.chang@amd.com>
Reviewed-by: Nickle Wang <nickle@csie.io>
Reviewed-by: Igor Kulchytskyy <igork@ami.com>