### PR TITLE
MdePkg: Use ANSI colors to indicate debug message severity

### DIFF
--- a/MdePkg/Library/BaseDebugLibSerialPort/BaseDebugLibSerialPort.inf
+++ b/MdePkg/Library/BaseDebugLibSerialPort/BaseDebugLibSerialPort.inf
@@ -41,4 +41,4 @@
   gEfiMdePkgTokenSpaceGuid.PcdDebugClearMemoryValue  ## SOMETIMES_CONSUMES
   gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask      ## CONSUMES
   gEfiMdePkgTokenSpaceGuid.PcdFixedDebugPrintErrorLevel ## CONSUMES
-
+  gEfiMdePkgTokenSpaceGuid.PcdDebugAnsiSeqSupport       ## CONSUMES

--- a/MdePkg/Library/UefiDebugLibConOut/UefiDebugLibConOut.inf
+++ b/MdePkg/Library/UefiDebugLibConOut/UefiDebugLibConOut.inf
@@ -50,4 +50,4 @@
   gEfiMdePkgTokenSpaceGuid.PcdDebugClearMemoryValue        ## SOMETIMES_CONSUMES
   gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask            ## CONSUMES
   gEfiMdePkgTokenSpaceGuid.PcdFixedDebugPrintErrorLevel    ## CONSUMES
-
+  gEfiMdePkgTokenSpaceGuid.PcdDebugAnsiSeqSupport          ## CONSUMES

--- a/MdePkg/MdePkg.dec
+++ b/MdePkg/MdePkg.dec
@@ -4,6 +4,7 @@
 # It also provides the definitions(including PPIs/PROTOCOLs/GUIDs) of
 # EFI1.10/UEFI2.7/PI1.7 and some Industry Standards.
 #
+# Copyright (c) 2022, Qualcomm Innovation Center, Inc. All rights reserved.<BR>
 # Copyright (c) 2007 - 2022, Intel Corporation. All rights reserved.<BR>
 # Portions copyright (c) 2008 - 2009, Apple Inc. All rights reserved.<BR>
 # (C) Copyright 2016 - 2021 Hewlett Packard Enterprise Development LP<BR>
@@ -1972,6 +1973,11 @@
   #  testing purposes.
   # @Prompt Validate ORDERED_COLLECTION structure
   gEfiMdePkgTokenSpaceGuid.PcdValidateOrderedCollection|FALSE|BOOLEAN|0x0000002a
+
+  ## Indicates if DEBUG output should use ANSI sequences.<BR><BR>
+  #   TRUE  - Will use ANSI sequences in DEBUG output.<BR>
+  #   FALSE - Will not use ANSI sequences in DEBUG output.<BR>
+  gEfiMdePkgTokenSpaceGuid.PcdDebugAnsiSeqSupport|FALSE|BOOLEAN|0x0000002f
 
 [PcdsFixedAtBuild]
   ## Status code value for indicating a watchdog timer has expired.


### PR DESCRIPTION
There currently isn't a way to differentiate the different levels of DEBUG output: DEBUG_ERROR, DEBUG_WARN, DEBUG_INFO etc.

To improve this, wrap DEBUG_ERROR and DEBUG_WARN level messages in ANSI color code escape sequences. DEBUG_ERROR messages will be displayed in red text, and DEBUG_WARN in yellow.

Only enable this new functionality if the FeatureFlag gEfiMdePkgTokenSpaceGuid.PcdDebugAnsiSeqSupport
is set to TRUE. By default it's FALSE.

Signed-off-by: Rebecca Cran <rebecca@quicinc.com>