### PR TITLE
pip-requirement: Upgrade the edk2-basetools version from 0.1.24 to 0.…

### DIFF
--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -14,5 +14,5 @@
 
 edk2-pytool-library==0.11.2
 edk2-pytool-extensions~=0.16.0
-edk2-basetools==0.1.24
+edk2-basetools==0.1.28
 antlr4-python3-runtime==4.7.1


### PR DESCRIPTION
…1.28

features and bug fixes:
1. Fix the incremental build issue on Linux @176016387f
2. Fix DSC LibraryClass precedence rule @039bdb4d3e
3. INF should use latest Pcd value instead of default value @a512913
4. Support signtool input subject name to sign capsule @594b795

Signed-off-by: Bob Feng <bob.c.feng@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Yuwei Chen <yuwei.chen@intel.com>
Cc: Michael D Kinney <michael.d.kinney@intel.com>
Reviewed-by: Yuwei Chen <yuwei.chen@intel.com>