### PR TITLE
OvmfPkg/QemuVideoDxe: fix bochs mode init

### DIFF
--- a/OvmfPkg/QemuVideoDxe/Driver.c
+++ b/OvmfPkg/QemuVideoDxe/Driver.c
@@ -984,6 +984,33 @@ VgaOutb (
   }
 }
 
+UINT8
+VgaInb (
+  QEMU_VIDEO_PRIVATE_DATA  *Private,
+  UINTN                    Reg
+  )
+{
+  EFI_STATUS  Status;
+  UINT8       Data;
+
+  if (Private->Variant == QEMU_VIDEO_BOCHS_MMIO) {
+    Data   = 0;
+    Status = Private->PciIo->Mem.Read (
+                                   Private->PciIo,
+                                   EfiPciIoWidthUint8,
+                                   PCI_BAR_IDX2,
+                                   0x400 - 0x3c0 + Reg,
+                                   1,
+                                   &Data
+                                   );
+    ASSERT_EFI_ERROR (Status);
+  } else {
+    Data = inb (Private, Reg);
+  }
+
+  return Data;
+}
+
 VOID
 InitializeBochsGraphicsMode (
   QEMU_VIDEO_PRIVATE_DATA  *Private,
@@ -998,7 +1025,11 @@ InitializeBochsGraphicsMode (
     ModeData->ColorDepth
     ));
 
-  /* unblank */
+  /* set color mode */
+  VgaOutb (Private, MISC_OUTPUT_REGISTER, 0x01);
+
+  /* reset flip flop + unblank */
+  VgaInb (Private, INPUT_STATUS_1_REGISTER);
   VgaOutb (Private, ATT_ADDRESS_REGISTER, 0x20);
 
   BochsWrite (Private, VBE_DISPI_INDEX_ENABLE, 0);


### PR DESCRIPTION
Add VgaInb() helper function to read vga registers.  With that in place
fix the unblanking.  We need to put the ATT_ADDRESS_REGISTER flip flop
into a known state, which is done by reading the
INPUT_STATUS_1_REGISTER.  Reading the INPUT_STATUS_1_REGISTER only works
when the device is in color mode, so make sure that bit (0x01) is set in
MISC_OUTPUT_REGISTER.

Currently the mode setting works more by luck because
ATT_ADDRESS_REGISTER flip flop happens to be in the state we need.

Signed-off-by: Gerd Hoffmann <kraxel@redhat.com>
