### PR TITLE
MdeModulePkg SmbiosMeasurementDxe: Add Type4 CurrentSpeed field to fi…

### DIFF
--- a/MdeModulePkg/Universal/SmbiosMeasurementDxe/SmbiosMeasurementDxe.c
+++ b/MdeModulePkg/Universal/SmbiosMeasurementDxe/SmbiosMeasurementDxe.c
@@ -1,7 +1,7 @@
 /** @file
   This driver measures SMBIOS table to TPM.
 
-Copyright (c) 2015 - 2019, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2015 - 2022, Intel Corporation. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -66,6 +66,7 @@ SMBIOS_FILTER_TABLE  mSmbiosFilterType4BlackList[] = {
   { 0x04, OFFSET_OF (SMBIOS_TABLE_TYPE4, EnabledCoreCount2), FIELD_SIZE_OF (SMBIOS_TABLE_TYPE4, EnabledCoreCount2), 0                                  },
   { 0x04, OFFSET_OF (SMBIOS_TABLE_TYPE4, ThreadCount2),      FIELD_SIZE_OF (SMBIOS_TABLE_TYPE4, ThreadCount2),      0                                  },
   { 0x04, OFFSET_OF (SMBIOS_TABLE_TYPE4, Voltage),           FIELD_SIZE_OF (SMBIOS_TABLE_TYPE4, Voltage),           0                                  },
+  { 0x04, OFFSET_OF (SMBIOS_TABLE_TYPE4, CurrentSpeed),      FIELD_SIZE_OF (SMBIOS_TABLE_TYPE4, CurrentSpeed),      0                                  },
 };
 SMBIOS_FILTER_TABLE  mSmbiosFilterType17BlackList[] = {
   { 0x11, OFFSET_OF (SMBIOS_TABLE_TYPE17, SerialNumber), FIELD_SIZE_OF (SMBIOS_TABLE_TYPE17, SerialNumber), SMBIOS_FILTER_TABLE_FLAG_IS_STRING },


### PR DESCRIPTION
MdeModulePkg SmbiosMeasurementDxe: Add Type4 CurrentSpeed to filter t…
…able

REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4051

The Type4 CurrentSpeed field may be various.
So this patch adds it into the filter table.

Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Zhiguang Liu <zhiguang.liu@intel.com>
Cc: Dandan Bi <dandan.bi@intel.com>
Cc: Star Zeng <star.zeng@intel.com>
Cc: Zhichao Gao <zhichao.gao@intel.com>
Signed-off-by: Heng Luo <heng.luo@intel.com>
Reviewed-by: Jiewen Yao <Jiewen.yao@intel.com>
Reviewed-by: James Lu <james.lu@intel.com>
Reviewed-by: Zhichao Gao <zhichao.gao@intel.com>