### PR TITLE
pip-requirement: Upgrade the edk2-basetools version from 0.1.28 to 0.…

### DIFF
--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -14,5 +14,5 @@
 
 edk2-pytool-library==0.11.2
 edk2-pytool-extensions~=0.16.0
-edk2-basetools==0.1.28
+edk2-basetools==0.1.29
 antlr4-python3-runtime==4.7.1


### PR DESCRIPTION
…1.29

features and bug fixes:
1. Revert "BaseTools: Fix DSC LibraryClass precedence rule"

Signed-off-by: Bob Feng <bob.c.feng@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Yuwei Chen <yuwei.chen@intel.com>
Cc: Rebecca Cran <quic_rcran@quicinc.com>
Reviewed-by: Rebecca Cran <quic_rcran@quicinc.com>
Reviewed-by: Michael D Kinney <michael.d.kinney@intel.com>