### PR TITLE
BaseTools: 64bit FSP FV map file cannot be created correctly

### DIFF
--- a/BaseTools/Source/C/GenFv/GenFvInternalLib.c
+++ b/BaseTools/Source/C/GenFv/GenFvInternalLib.c
@@ -1004,7 +1004,7 @@ Returns:
       if (IsUseClang) {
         sscanf (Line, "%llx %s %s %s", &TempLongAddress, KeyWord, KeyWord2, FunctionTypeName);
         FunctionAddress = (UINT64) TempLongAddress;
-        if (FunctionTypeName [0] == '_' ) {
+        if (FunctionTypeName [0] != '/' && FunctionTypeName [0] != '.' && FunctionTypeName [1] != ':') {
           fprintf (FvMapFile, "  0x%010llx    ", (unsigned long long) (ImageBaseAddress + FunctionAddress - LinkTimeBaseAddress));
           fprintf (FvMapFile, "%s\n", FunctionTypeName);
         }


### PR DESCRIPTION
https://bugzilla.tianocore.org/show_bug.cgi?id=4035 64bit FSP FV map file cannot be created correctly when using CLANG compiler. When compiling 64bit FSP with CLANG, there is no prefix symbol '_' added to function name. Hence FSP FV map file cannot be created properly. Updated the if condition for CLANG in GenFv to get the issue fixed.

Cc: Bob Feng <bob.c.feng@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Yuwei Chen <yuwei.chen@intel.com>
Cc: Lee Hamel <lee.m.hamel@intel.com>
Signed-off-by: Ted Kuo <ted.kuo@intel.com>
Reviewed-by: Bob Feng <bob.c.feng@intel.com>