### PR TITLE
UefiPayloadPkg/PayloadLoaderPeim: Remove GCC build warning

### DIFF
--- a/UefiPayloadPkg/PayloadLoaderPeim/PayloadLoaderPeim.c
+++ b/UefiPayloadPkg/PayloadLoaderPeim/PayloadLoaderPeim.c
@@ -44,19 +44,18 @@ PeiLoadFileLoadPayload (
   OUT    UINT32                       *AuthenticationState
   )
 {
-  EFI_STATUS                     Status;
-  VOID                           *Elf;
-  UNIVERSAL_PAYLOAD_EXTRA_DATA   *ExtraData;
-  ELF_IMAGE_CONTEXT              Context;
-  UNIVERSAL_PAYLOAD_INFO_HEADER  *PldInfo;
-  UINT32                         Index;
-  UINT16                         ExtraDataIndex;
-  CHAR8                          *SectionName;
-  UINTN                          Offset;
-  UINTN                          Size;
-  UINT32                         ExtraDataCount;
-  UINTN                          Instance;
-  UINTN                          Length;
+  EFI_STATUS                    Status;
+  VOID                          *Elf;
+  UNIVERSAL_PAYLOAD_EXTRA_DATA  *ExtraData;
+  ELF_IMAGE_CONTEXT             Context;
+  UINT32                        Index;
+  UINT16                        ExtraDataIndex;
+  CHAR8                         *SectionName;
+  UINTN                         Offset;
+  UINTN                         Size;
+  UINT32                        ExtraDataCount;
+  UINTN                         Instance;
+  UINTN                         Length;
 
   //
   // ELF is added to file as RAW section for EDKII bootloader.
@@ -85,7 +84,6 @@ PeiLoadFileLoadPayload (
   //
   // Get UNIVERSAL_PAYLOAD_INFO_HEADER and number of additional PLD sections.
   //
-  PldInfo        = NULL;
   ExtraDataCount = 0;
   for (Index = 0; Index < Context.ShNum; Index++) {
     Status = GetElfSectionName (&Context, Index, &SectionName);
@@ -96,9 +94,6 @@ PeiLoadFileLoadPayload (
     DEBUG ((DEBUG_INFO, "Payload Section[%d]: %a\n", Index, SectionName));
     if (AsciiStrCmp (SectionName, UNIVERSAL_PAYLOAD_INFO_SEC_NAME) == 0) {
       Status = GetElfSectionPos (&Context, Index, &Offset, &Size);
-      if (!EFI_ERROR (Status)) {
-        PldInfo = (UNIVERSAL_PAYLOAD_INFO_HEADER *)(Context.FileBase + Offset);
-      }
     } else if (AsciiStrnCmp (SectionName, UNIVERSAL_PAYLOAD_EXTRA_SEC_NAME_PREFIX, UNIVERSAL_PAYLOAD_EXTRA_SEC_NAME_PREFIX_LENGTH) == 0) {
       Status = GetElfSectionPos (&Context, Index, &Offset, &Size);
       if (!EFI_ERROR (Status)) {


### PR DESCRIPTION
Fix the gcc build warning:
variable PldInfo set but not used [-Wunused-but-set-variable]

Reviewed-by: James Lu <james.lu@intel.com>
Reviewed-by: Zhiguang Liu <zhiguang.liu@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>

Signed-off-by: Gang Chen <gang.c.chen@intel.com>