### PR TITLE
IntelFsp2Pkg: NvsBufferPtr is missing in Fsp24ApiEntryM.nasm

### DIFF
--- a/IntelFsp2Pkg/FspSecCore/Ia32/Fsp24ApiEntryM.nasm
+++ b/IntelFsp2Pkg/FspSecCore/Ia32/Fsp24ApiEntryM.nasm
@@ -40,12 +40,13 @@ struc FSPM_UPD_COMMON_FSP24
     .Revision:                  resb  1
     .Reserved:                  resb  3
     .Length                     resd  1
+    .NvsBufferPtr               resq  1
     .StackBase:                 resq  1
     .StackSize:                 resq  1
     .BootLoaderTolumSize:       resd  1
     .BootMode:                  resd  1
     .FspEventHandler            resq  1
-    .Reserved1:                 resb 24
+    .Reserved1:                 resb 16
     ; }
     .size:
 endstruc

--- a/IntelFsp2Pkg/FspSecCore/X64/Fsp24ApiEntryM.nasm
+++ b/IntelFsp2Pkg/FspSecCore/X64/Fsp24ApiEntryM.nasm
@@ -22,12 +22,13 @@ struc FSPM_UPD_COMMON_FSP24
     .Revision:                  resb  1
     .Reserved:                  resb  3
     .Length                     resd  1
+    .NvsBufferPtr               resq  1
     .StackBase:                 resq  1
     .StackSize:                 resq  1
     .BootLoaderTolumSize:       resd  1
     .BootMode:                  resd  1
     .FspEventHandler            resq  1
-    .Reserved1:                 resb 24
+    .Reserved1:                 resb 16
     ; }
     .size:
 endstruc


### PR DESCRIPTION
REF:https://bugzilla.tianocore.org/show_bug.cgi?id=4063 Added NvsBufferPtr to FSPM_UPD_COMMON_FSP24 in Fsp24ApiEntryM.nasm to align with FSP 2.4 SPEC.

Cc: Chasel Chiu <chasel.chiu@intel.com>
Cc: Nate DeSimone <nathaniel.l.desimone@intel.com>
Cc: Star Zeng <star.zeng@intel.com>
Cc: Ashraf Ali S <ashraf.ali.s@intel.com>
Cc: Chinni B Duggapu <chinni.b.duggapu@intel.com>
Signed-off-by: Ted Kuo <ted.kuo@intel.com>
Reviewed-by: Chasel Chiu <chasel.chiu@intel.com>