### PR TITLE
IntelFsp2Pkg: Fix FspSecCoreI build failure.

### DIFF
--- a/IntelFsp2Pkg/FspSecCore/Ia32/FspApiEntryI.nasm
+++ b/IntelFsp2Pkg/FspSecCore/Ia32/FspApiEntryI.nasm
@@ -23,6 +23,17 @@ ASM_PFX(FspApiCommonContinue):
   jmp $
 
 ;----------------------------------------------------------------------------
+; TempRamInit API
+;
+; Empty function for WHOLEARCHIVE build option
+;
+;----------------------------------------------------------------------------
+global ASM_PFX(TempRamInitApi)
+ASM_PFX(TempRamInitApi):
+  jmp $
+  ret
+
+;----------------------------------------------------------------------------
 ; FspSmmInit API
 ;
 ; This FSP API will notify the FSP about the different phases in the boot

--- a/IntelFsp2Pkg/FspSecCore/X64/FspApiEntryI.nasm
+++ b/IntelFsp2Pkg/FspSecCore/X64/FspApiEntryI.nasm
@@ -23,6 +23,17 @@ ASM_PFX(FspApiCommonContinue):
   jmp $
 
 ;----------------------------------------------------------------------------
+; TempRamInit API
+;
+; Empty function for WHOLEARCHIVE build option
+;
+;----------------------------------------------------------------------------
+global ASM_PFX(TempRamInitApi)
+ASM_PFX(TempRamInitApi):
+  jmp $
+  ret
+
+;----------------------------------------------------------------------------
 ; FspSmmInit API
 ;
 ; This FSP API will notify the FSP about the different phases in the boot


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4049

Link error occurred in certain compiling environment when building FspSecCoreI: unresolved external symbol _TempRamInitApi.

Cc: Nate DeSimone <nathaniel.l.desimone@intel.com>
Cc: Star Zeng <star.zeng@intel.com>
Signed-off-by: Chasel Chiu <chasel.chiu@intel.com>
Reviewed-by: Nate DeSimone <nathaniel.l.desimone@intel.com>