### PR TITLE
MdeModulePkg: fixed comment typo in variable.h

### DIFF
--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/Variable.h
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/Variable.h
@@ -286,7 +286,7 @@ InitializeLock (
 /**
   Acquires lock only at boot time. Simply returns at runtime.
 
-  This is a temperary function that will be removed when
+  This is a temporary function that will be removed when
   EfiAcquireLock() in UefiLib can handle the call in UEFI
   Runtimer driver in RT phase.
   It calls EfiAcquireLock() at boot time, and simply returns
@@ -303,7 +303,7 @@ AcquireLockOnlyAtBootTime (
 /**
   Releases lock only at boot time. Simply returns at runtime.
 
-  This is a temperary function which will be removed when
+  This is a temporary function which will be removed when
   EfiReleaseLock() in UefiLib can handle the call in UEFI
   Runtimer driver in RT phase.
   It calls EfiReleaseLock() at boot time and simply returns
@@ -401,7 +401,7 @@ VariableWriteServiceInitialize (
   );
 
 /**
-  Retrieve the SMM Fault Tolerent Write protocol interface.
+  Retrieve the SMM Fault Tolerant Write protocol interface.
 
   @param[out] FtwProtocol       The interface of SMM Ftw protocol
 


### PR DESCRIPTION
fixed 3 comment typos in MdeModulePkg/Universal/Variable/RuntimeDxe/Variable.h