### PR TITLE
nasm_ext_dep.yaml: Remove leading zero in patch version

### DIFF
--- a/BaseTools/Bin/nasm_ext_dep.yaml
+++ b/BaseTools/Bin/nasm_ext_dep.yaml
@@ -13,6 +13,6 @@
   "type": "nuget",
   "name": "mu_nasm",
   "source": "https://api.nuget.org/v3/index.json",
-  "version": "2.15.05",
+  "version": "2.15.5",
   "flags": ["set_path", "host_specific"]
 }


### PR DESCRIPTION
The patch version is currently: "2.15.05"

When a formal semantic version validator is run against this version
it is recognized as being invalid due to the leading zero in the
patch which is not allowed per the Semantic Versioning Specification:

https://semver.org/#spec-item-2

The NuGet Gallery already reports the version without the leading
zero: https://www.nuget.org/packages/mu_nasm/2.15.5

This change simply removes the leading zero to prevent code such as
https://pypi.org/project/semantic-version/ from reporting a version error.

Cc: Bob Feng <bob.c.feng@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Yuwei Chen <yuwei.chen@intel.com>
Cc: Sean Brogan <sean.brogan@microsoft.com>
Cc: Michael D Kinney <michael.d.kinney@intel.com>
Signed-off-by: Michael Kubacki <mikuback@linux.microsoft.com>
Reviewed-by: Michael D Kinney <michael.d.kinney@intel.com>