### PR TITLE
CryptoPkg/BaseCryptLib:Remove redundant init

### DIFF
--- a/CryptoPkg/Library/BaseCryptLib/Pk/CryptPkcs7VerifyCommon.c
+++ b/CryptoPkg/Library/BaseCryptLib/Pk/CryptPkcs7VerifyCommon.c
@@ -502,8 +502,6 @@ Pkcs7GetCertificatesList (
   OldBuf       = NULL;
   Signers      = NULL;
 
-  ZeroMem (&CertCtx, sizeof (CertCtx));
-
   //
   // Parameter Checking
   //


### PR DESCRIPTION
CertCtx is used to be defined as a struct and ZeroMem is called to init this struct. But now CertCtx is defined as a point, so use ZeroMem (&CertCtx, sizeof (CertCtx)) is not correct any more.

Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Xiaoyu Lu <xiaoyu1.lu@intel.com>
Cc: Guomin Jiang <guomin.jiang@intel.com>
Signed-off-by: Wenyi Xie <xiewenyi2@huawei.com>
Reviewed-by: Jiewen Yao <jiewen.yao@intel.com>