### PR TITLE
UefiCpuPkg/CpuExceptionHandlerLib: Code optimization to allow bigger stack

### DIFF
--- a/UefiCpuPkg/Library/CpuExceptionHandlerLib/Ia32/ArchExceptionHandler.c
+++ b/UefiCpuPkg/Library/CpuExceptionHandlerLib/Ia32/ArchExceptionHandler.c
@@ -215,7 +215,10 @@ ArchSetupExceptionStack (
   // Fixup exception task descriptor and task-state segment
   //
   AsmGetTssTemplateMap (&TemplateMap);
-  StackTop = StackTop - CPU_STACK_ALIGNMENT;
+  //
+  // Plus 1 byte is for compact stack layout in case StackTop is already aligned.
+  //
+  StackTop = StackTop - CPU_STACK_ALIGNMENT + 1;
   StackTop = (UINTN)ALIGN_POINTER (StackTop, CPU_STACK_ALIGNMENT);
   IdtTable = (IA32_IDT_GATE_DESCRIPTOR  *)Idtr.Base;
   for (Index = 0; Index < CPU_STACK_SWITCH_EXCEPTION_NUMBER; ++Index) {

--- a/UefiCpuPkg/Library/CpuExceptionHandlerLib/X64/ArchExceptionHandler.c
+++ b/UefiCpuPkg/Library/CpuExceptionHandlerLib/X64/ArchExceptionHandler.c
@@ -223,7 +223,10 @@ ArchSetupExceptionStack (
   // Fixup exception task descriptor and task-state segment
   //
   ZeroMem (Tss, sizeof (*Tss));
-  StackTop = StackTop - CPU_STACK_ALIGNMENT;
+  //
+  // Plus 1 byte is for compact stack layout in case StackTop is already aligned.
+  //
+  StackTop = StackTop - CPU_STACK_ALIGNMENT + 1;
   StackTop = (UINTN)ALIGN_POINTER (StackTop, CPU_STACK_ALIGNMENT);
   IdtTable = (IA32_IDT_GATE_DESCRIPTOR  *)Idtr.Base;
   for (Index = 0; Index < CPU_STACK_SWITCH_EXCEPTION_NUMBER; ++Index) {


### PR DESCRIPTION
This commit is a code optimization to allow bigger seperate stack size in ArchSetupExceptionStack. In previous code logic, CPU_STACK_ALIGNMENT bytes will be wasted if StackTop is already CPU_STACK_ALIGNMENT aligned.
