### PR TITLE
CryptoPkg: Fix pem heap-buffer-overflow due to BIO_snprintf() ver2

### DIFF
--- a/CryptoPkg/Library/BaseCryptLib/SysCall/CrtWrapper.c
+++ b/CryptoPkg/Library/BaseCryptLib/SysCall/CrtWrapper.c
@@ -476,27 +476,6 @@ fwrite (
 //  -- Dummy OpenSSL Support Routines --
 //
 
-int
-BIO_printf (
-  void        *bio,
-  const char  *format,
-  ...
-  )
-{
-  return 0;
-}
-
-int
-BIO_snprintf (
-  char        *buf,
-  size_t      n,
-  const char  *format,
-  ...
-  )
-{
-  return 0;
-}
-
 #ifdef __GNUC__
 
 typedef

--- a/CryptoPkg/Library/OpensslLib/OpensslLib.inf
+++ b/CryptoPkg/Library/OpensslLib/OpensslLib.inf
@@ -106,6 +106,7 @@
   $(OPENSSL_PATH)/crypto/async/async_wait.c
   $(OPENSSL_PATH)/crypto/bio/b_addr.c
   $(OPENSSL_PATH)/crypto/bio/b_dump.c
+  $(OPENSSL_PATH)/crypto/bio/b_print.c
   $(OPENSSL_PATH)/crypto/bio/b_sock.c
   $(OPENSSL_PATH)/crypto/bio/b_sock2.c
   $(OPENSSL_PATH)/crypto/bio/bf_buff.c

--- a/CryptoPkg/Library/OpensslLib/OpensslLibCrypto.inf
+++ b/CryptoPkg/Library/OpensslLib/OpensslLibCrypto.inf
@@ -106,6 +106,7 @@
   $(OPENSSL_PATH)/crypto/async/async_wait.c
   $(OPENSSL_PATH)/crypto/bio/b_addr.c
   $(OPENSSL_PATH)/crypto/bio/b_dump.c
+  $(OPENSSL_PATH)/crypto/bio/b_print.c
   $(OPENSSL_PATH)/crypto/bio/b_sock.c
   $(OPENSSL_PATH)/crypto/bio/b_sock2.c
   $(OPENSSL_PATH)/crypto/bio/bf_buff.c

--- a/CryptoPkg/Library/OpensslLib/OpensslLibX64.inf
+++ b/CryptoPkg/Library/OpensslLib/OpensslLibX64.inf
@@ -122,6 +122,7 @@
   $(OPENSSL_PATH)/crypto/async/async_wait.c
   $(OPENSSL_PATH)/crypto/bio/b_addr.c
   $(OPENSSL_PATH)/crypto/bio/b_dump.c
+  $(OPENSSL_PATH)/crypto/bio/b_print.c
   $(OPENSSL_PATH)/crypto/bio/b_sock.c
   $(OPENSSL_PATH)/crypto/bio/b_sock2.c
   $(OPENSSL_PATH)/crypto/bio/bf_buff.c

--- a/CryptoPkg/Library/OpensslLib/OpensslLibX64Gcc.inf
+++ b/CryptoPkg/Library/OpensslLib/OpensslLibX64Gcc.inf
@@ -122,6 +122,7 @@
   $(OPENSSL_PATH)/crypto/async/async_wait.c
   $(OPENSSL_PATH)/crypto/bio/b_addr.c
   $(OPENSSL_PATH)/crypto/bio/b_dump.c
+  $(OPENSSL_PATH)/crypto/bio/b_print.c
   $(OPENSSL_PATH)/crypto/bio/b_sock.c
   $(OPENSSL_PATH)/crypto/bio/b_sock2.c
   $(OPENSSL_PATH)/crypto/bio/bf_buff.c

--- a/CryptoPkg/Library/OpensslLib/process_files.pl
+++ b/CryptoPkg/Library/OpensslLib/process_files.pl
@@ -265,7 +265,6 @@ foreach my $product ((@{$unified_info{libraries}},
         foreach my $s (@{$unified_info{sources}->{$o}}) {
             # No need to add unused files in UEFI.
             # So it can reduce porting time, compile time, library size.
-            next if $s =~ "crypto/bio/b_print.c";
             next if $s =~ "crypto/rand/randfile.c";
             next if $s =~ "crypto/store/";
             next if $s =~ "crypto/err/err_all.c";


### PR DESCRIPTION
REF:

Add true implementation to OpensslLib, this will increase the 8kb DXE driver binary size.

Signed-off-by: Yi Li <yi1.li@intel.com>

Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Xiaoyu Lu <xiaoyu1.lu@intel.com>
Cc: Guomin Jiang <guomin.jiang@intel.com>