### PR TITLE
BaseTools: Edk2ToolsBuild: Fixing pipeline build due to path too long

### DIFF
--- a/BaseTools/Edk2ToolsBuild.py
+++ b/BaseTools/Edk2ToolsBuild.py
@@ -122,7 +122,7 @@ class Edk2ToolsBuild(BaseAbstractInvocable):
             for key in vc_vars.keys():
                 logging.debug(f"Var - {key} = {vc_vars[key]}")
                 if key.lower() == 'path':
-                    shell_env.insert_path(vc_vars[key])
+                    shell_env.set_path(vc_vars[key])
                 else:
                     shell_env.set_shell_var(key, vc_vars[key])
 


### PR DESCRIPTION
Current implementation of looking up toolchain will _insert_ the findings from vsvarsall.bat to existing path and potentially stuff the variable to exceed the length of maximal path length accepted by Windows.

This change updated the logic to use the discovered shell varialbes to replace the existing path, which is desirable in the specific use case.

Cc: Bob Feng <bob.c.feng@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Yuwei Chen <yuwei.chen@intel.com>

Co-authored-by: Sean Brogan <sean.brogan@microsoft.com>
Signed-off-by: Kun Qin <kuqin12@gmail.com>
Reviewed-by:  Sean Brogan <sean.brogan@microsoft.com>
Reviewed-by: Bob Feng <bob.c.feng@intel.com>