### PR TITLE
RedfishPkg/JsonLib: Fix JsonLib build failure

### DIFF
--- a/RedfishPkg/Library/JsonLib/JsonLib.c
+++ b/RedfishPkg/Library/JsonLib/JsonLib.c
@@ -6,6 +6,7 @@
 
   Copyright (c) 2018 - 2019, Intel Corporation. All rights reserved.<BR>
  (C) Copyright 2021 Hewlett Packard Enterprise Development LP<BR>
+ Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
     SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
@@ -569,6 +570,7 @@ JsonValueGetUnicodeString (
   CONST CHAR8  *Utf8Str;
   CHAR16       *Ucs2Str;
 
+  Ucs2Str = NULL;
   Utf8Str = json_string_value ((json_t *)Json);
   if (Utf8Str == NULL) {
     return NULL;


### PR DESCRIPTION
VS2019 reports build failure: "warning C4701: potentially uninitialized local variable 'Ucs2Str' used". Initial Ucs2Str to NULL at the beginning of function.

Cc: Abner Chang <abner.chang@amd.com>
Cc: Nick Ramirez <nramirez@nvidia.com>
Signed-off-by: Nickle Wang <nicklew@nvidia.com>
Reviewed-by: Abner Chang <abner.chang@amd.com>