### PR TITLE
CryptoPkg: Fix pem heap-buffer-overflow due to BIO_snprintf()

### DIFF
--- a/CryptoPkg/Library/BaseCryptLib/SysCall/CrtWrapper.c
+++ b/CryptoPkg/Library/BaseCryptLib/SysCall/CrtWrapper.c
@@ -494,7 +494,9 @@ BIO_snprintf (
   ...
   )
 {
-  return 0;
+  // Because the function does not actually print anything to buf, it returns -1 as error.
+  // Otherwise, the consumer may think that the buf is valid and parse the buffer.
+  return -1;
 }
 
 #ifdef __GNUC__


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4075

Fake BIO_snprintf() does not actually print anything to buf, it should return -1 as error.
0 will be considered a correct return value, the consumer may think that the buf is valid and parse the buffer.
please refer to bugzilla link for details.

Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Xiaoyu Lu <xiaoyu1.lu@intel.com>
Cc: Guomin Jiang <guomin.jiang@intel.com>

Signed-off-by: Yi Li <yi1.li@intel.com>
reviewed-by: Jiewen Yao <Jiewen.yao@intel.com>