### PR TITLE
UefiCpuPkg: Reset a parameter when BSP Exit in CPU relaxed mode.

### DIFF
--- a/UefiCpuPkg/PiSmmCpuDxeSmm/MpService.c
+++ b/UefiCpuPkg/PiSmmCpuDxeSmm/MpService.c
@@ -696,8 +696,9 @@ BSPHandler (
   //
   // Allow APs to check in from this point on
   //
-  *mSmmMpSyncData->Counter       = 0;
-  *mSmmMpSyncData->AllCpusInSync = FALSE;
+  *mSmmMpSyncData->Counter                  = 0;
+  *mSmmMpSyncData->AllCpusInSync            = FALSE;
+  mSmmMpSyncData->AllApArrivedWithException = FALSE;
 }
 
 /**


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4083

In CPU relaxed mode, it doesn't reset the value of mSmmMpSyncData->AllApArrivedWithException when BSP exit smm mode. So this patch will reset this variable.

Cc: Eric Dong <eric.dong@intel.com>
Cc: Ray Ni <ray.ni@intel.com>

Signed-off-by: Zhihao Li <zhihao.li@intel.com>