### PR TITLE
SecurityPkg: Remove enforcement of final GoIdle transition for CRB co…

### DIFF
--- a/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2Ptp.c
+++ b/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2Ptp.c
@@ -381,19 +381,6 @@ GoIdle_Exit:
   //
   MmioWrite32 ((UINTN)&CrbReg->CrbControlRequest, PTP_CRB_CONTROL_AREA_REQUEST_GO_IDLE);
 
-  //
-  // Only enforce Idle state transition if execution fails when CRBIdleBypass==1
-  // Leave regular Idle delay at the beginning of next command execution
-  //
-  if (GetCachedIdleByPass () == 1) {
-    Status = PtpCrbWaitRegisterBits (
-               &CrbReg->CrbControlStatus,
-               PTP_CRB_CONTROL_AREA_STATUS_TPM_IDLE,
-               0,
-               PTP_TIMEOUT_C
-               );
-  }
-
   return Status;
 }
 


### PR DESCRIPTION
…mmands

REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4077

Following the design described in the TCG specification, the driver implementation of the CRB protocol does not require enforcing completing the transition to goIdle at the end of a command sequence.

Signed-off-by: Rodrigo Gonzalez Del Cueto <rodrigo.gonzalez.del.cueto@intel.com>
Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Jian J Wang <jian.j.wang@intel.com>
Reviewed-by: Jian J Wang <jian.j.wang@intel.com>