### PR TITLE
PR for VolInfo patch set

### DIFF
--- a/BaseTools/Source/C/VolInfo/VolInfo.c
+++ b/BaseTools/Source/C/VolInfo/VolInfo.c
@@ -2019,8 +2019,8 @@ Returns:
         Status =
           PutFileImage (
             ToolInputFile,
-            (CHAR8*) SectionBuffer + DataOffset,
-            BufferLength - DataOffset
+            (CHAR8*)Ptr + DataOffset,
+            SectionLength - DataOffset
             );
 
         system (SystemCommand);
@@ -2065,8 +2065,8 @@ Returns:
         //
         printf ("/------------ Encapsulation section start -----------------\\\n");
         Status = ParseSection (
-                  SectionBuffer + DataOffset,
-                  BufferLength - DataOffset
+                  Ptr + DataOffset,
+                  SectionLength - DataOffset
                   );
         if (EFI_ERROR (Status)) {
           Error (NULL, 0, 0003, "parse of CRC32 GUIDED section failed", NULL);

--- a/BaseTools/Source/C/VolInfo/VolInfo.c
+++ b/BaseTools/Source/C/VolInfo/VolInfo.c
@@ -2009,6 +2009,13 @@ Returns:
           );
         free (ExtractionTool);
 
+        if (!CompareGuid (
+               EfiGuid,
+               &gEfiCrc32GuidedSectionExtractionProtocolGuid
+               )
+           ) {
+          DataOffset -= 4;
+        }
         Status =
           PutFileImage (
             ToolInputFile,

--- a/BaseTools/Source/C/VolInfo/VolInfo.c
+++ b/BaseTools/Source/C/VolInfo/VolInfo.c
@@ -685,11 +685,11 @@ Returns:
     //
     // 0x17
     //
-    "EFI_SECTION_FIRMWARE_VOLUME_IMAGE ",
+    "EFI_SECTION_FIRMWARE_VOLUME_IMAGE",
     //
     // 0x18
     //
-    "EFI_SECTION_FREEFORM_SUBTYPE_GUID ",
+    "EFI_SECTION_FREEFORM_SUBTYPE_GUID",
     //
     // 0x19
     //
@@ -705,7 +705,7 @@ Returns:
     //
     // 0x1C
     //
-    "EFI_SECTION_SMM_DEPEX",
+    "EFI_SECTION_MM_DEPEX",
     //
     // 0x1C+
     //
@@ -1338,7 +1338,7 @@ Returns:
     break;
 
   case EFI_FV_FILETYPE_SMM:
-    printf ("EFI_FV_FILETYPE_SMM\n");
+    printf ("EFI_FV_FILETYPE_MM\n");
     break;
 
   case EFI_FV_FILETYPE_FIRMWARE_VOLUME_IMAGE:
@@ -1346,11 +1346,11 @@ Returns:
     break;
 
   case EFI_FV_FILETYPE_COMBINED_SMM_DXE:
-    printf ("EFI_FV_FILETYPE_COMBINED_SMM_DXE\n");
+    printf ("EFI_FV_FILETYPE_COMBINED_MM_DXE\n");
     break;
 
   case EFI_FV_FILETYPE_SMM_CORE:
-    printf ("EFI_FV_FILETYPE_SMM_CORE\n");
+    printf ("EFI_FV_FILETYPE_MM_CORE\n");
     break;
 
   case EFI_FV_FILETYPE_MM_STANDALONE:

--- a/BaseTools/Source/C/VolInfo/VolInfo.c
+++ b/BaseTools/Source/C/VolInfo/VolInfo.c
@@ -51,15 +51,13 @@ EFI_GUID  gEfiCrc32GuidedSectionExtractionProtocolGuid = EFI_CRC32_GUIDED_SECTIO
 
 #define EFI_SECTION_ERROR EFIERR (100)
 
-#define MAX_BASENAME_LEN  60  // not good to hardcode, but let's be reasonable
-
 //
 // Structure to keep a list of guid-to-basenames
 //
 typedef struct _GUID_TO_BASENAME {
   struct _GUID_TO_BASENAME  *Next;
   INT8                      Guid[PRINTED_GUID_BUFFER_SIZE];
-  INT8                      BaseName[MAX_BASENAME_LEN];
+  INT8                      BaseName[MAX_LINE_LEN];
 } GUID_TO_BASENAME;
 
 static GUID_TO_BASENAME *mGuidBaseNameList = NULL;

--- a/BaseTools/Source/C/VolInfo/VolInfo.c
+++ b/BaseTools/Source/C/VolInfo/VolInfo.c
@@ -2,6 +2,7 @@
 The tool dumps the contents of a firmware volume
 
 Copyright (c) 1999 - 2018, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2022, Konstantin Aladyshev <aladyshev22@gmail.com><BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/


### PR DESCRIPTION
1. BaseTools/VolInfo: Correct buffer for GenCrc32 tool
2. BaseTools/VolInfo: Fix EFI_SECTION_GUID_DEFINED parsing
3. BaseTools/VolInfo: Increase GUID base name string
4. BaseTools/VolInfo: Parse apriori files
5. BaseTools/VolInfo: Update copyright information
6. BaseTools/VolInfo: Update file and section type strings
