### PR TITLE
BaseTools: Correct BPDG tool error prints

### DIFF
--- a/BaseTools/Source/Python/Common/VpdInfoFile.py
+++ b/BaseTools/Source/Python/Common/VpdInfoFile.py
@@ -248,8 +248,8 @@ def CallExtenalBPDGTool(ToolPath, VpdFileName):
         PopenObject.wait()
 
     if PopenObject.returncode != 0:
-        EdkLogger.debug(EdkLogger.DEBUG_1, "Fail to call BPDG tool", str(error))
+        EdkLogger.debug(EdkLogger.DEBUG_1, "Fail to call BPDG tool", str(error.decode()))
         EdkLogger.error("BPDG", BuildToolError.COMMAND_FAILURE, "Fail to execute BPDG tool with exit code: %d, the error message is: \n %s" % \
-                            (PopenObject.returncode, str(error)))
+                            (PopenObject.returncode, str(error.decode())))
 
     return PopenObject.returncode

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -14,5 +14,5 @@
 
 edk2-pytool-library==0.11.2
 edk2-pytool-extensions~=0.16.0
-edk2-basetools==0.1.29
+edk2-basetools==0.1.31
 antlr4-python3-runtime==4.7.1


### PR DESCRIPTION
Popen communication returns bytestrings. It is necessary to perform decode on these strings before passing them to the EdkLogger that works with ordinary strings.

Signed-off-by: Konstantin Aladyshev <aladyshev22@gmail.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>
Reviewed-by: Bob Feng <bob.c.feng@intel.com>