### PR TITLE
MdePkg: Fix a buffer overread.

### DIFF
--- a/MdePkg/Library/UefiDevicePathLib/DevicePathToText.c
+++ b/MdePkg/Library/UefiDevicePathLib/DevicePathToText.c
@@ -1003,8 +1003,9 @@ DevPathToTextUsbWWID (
     //
     // In case no NULL terminator in SerialNumber, create a new one with NULL terminator
     //
-    NewStr = AllocateCopyPool ((Length + 1) * sizeof (CHAR16), SerialNumberStr);
+    NewStr = AllocatePool ((Length + 1) * sizeof (CHAR16));
     ASSERT (NewStr != NULL);
+    CopyMem (NewStr, SerialNumberStr, Length * sizeof (CHAR16));
     NewStr[Length]  = 0;
     SerialNumberStr = NewStr;
   }


### PR DESCRIPTION
DevPathToTextUsbWWID allocates a separate copy of the SerialNumber string to append a null terminator if the original string is not null terminated.  However, by using AllocateCopyPool, it tries to copy 'Length + 1' words from the existing string containing 'Length' characters into the target string.  Split the copy out to only copy 'Length' characters instead.

This was reported by GCC's -Wstringop-overread when compiling a copy of this routine included in a library on FreeBSD.

Signed-off-by: John Baldwin <jhb@FreeBSD.org>