### PR TITLE
IntelFsp2WrapperPkg: Add header for PlatformMultiPhaseLib.

### DIFF
--- a/IntelFsp2WrapperPkg/Include/Library/FspWrapperMultiPhaseProcessLib.h
+++ b/IntelFsp2WrapperPkg/Include/Library/FspWrapperMultiPhaseProcessLib.h
@@ -10,24 +10,6 @@
 #define __FSP_WRAPPER_MULTI_PHASE_PROCESS_LIB_H__
 
 /**
-  FSP Wrapper Platform MultiPhase Handler
-
-  @param[in] FspHobListPtr        - Pointer to FSP HobList (valid after FSP-M completed)
-  @param[in] ComponentIndex       - FSP Component which executing MultiPhase initialization.
-  @param[in] PhaseIndex           - Indicates current execution phase of FSP MultiPhase initialization.
-
-  @retval EFI_STATUS        Always return EFI_SUCCESS
-
-**/
-VOID
-EFIAPI
-FspWrapperPlatformMultiPhaseHandler (
-  IN OUT VOID  **FspHobListPtr,
-  IN UINT8     ComponentIndex,
-  IN UINT32    PhaseIndex
-  );
-
-/**
   FSP Wrapper Variable Request Handler
 
   @param[in] FspHobListPtr        - Pointer to FSP HobList (valid after FSP-M completed)

--- a/IntelFsp2WrapperPkg/Include/Library/FspWrapperPlatformMultiPhaseLib.h
+++ b/IntelFsp2WrapperPkg/Include/Library/FspWrapperPlatformMultiPhaseLib.h
@@ -1,0 +1,30 @@
+/** @file
+  Provide FSP wrapper Platform MultiPhase handling functions.
+
+  Copyright (c) 2022, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef __FSP_WRAPPER_PLATFORM_MULTI_PHASE_PROCESS_LIB_H__
+#define __FSP_WRAPPER_PLATFORM_MULTI_PHASE_PROCESS_LIB_H__
+
+/**
+  FSP Wrapper Platform MultiPhase Handler
+
+  @param[in] FspHobListPtr        - Pointer to FSP HobList (valid after FSP-M completed)
+  @param[in] ComponentIndex       - FSP Component which executing MultiPhase initialization.
+  @param[in] PhaseIndex           - Indicates current execution phase of FSP MultiPhase initialization.
+
+  @retval EFI_STATUS        Always return EFI_SUCCESS
+
+**/
+VOID
+EFIAPI
+FspWrapperPlatformMultiPhaseHandler (
+  IN OUT VOID  **FspHobListPtr,
+  IN UINT8     ComponentIndex,
+  IN UINT32    PhaseIndex
+  );
+
+#endif

--- a/IntelFsp2WrapperPkg/IntelFsp2WrapperPkg.dec
+++ b/IntelFsp2WrapperPkg/IntelFsp2WrapperPkg.dec
@@ -33,7 +33,7 @@
   FspWrapperMultiPhaseProcessLib|Include/Library/FspWrapperMultiPhaseProcessLib.h
 
   ##  @libraryclass  Provide MultiPhase platform actions related functions.
-  FspWrapperPlatformMultiPhaseLib|Include/Library/FspWrapperMultiPhaseProcessLib.h
+  FspWrapperPlatformMultiPhaseLib|Include/Library/FspWrapperPlatformMultiPhaseLib.h
 
 
 [Guids]

--- a/IntelFsp2WrapperPkg/Library/FspWrapperMultiPhaseProcessLib/PeiFspWrapperMultiPhaseProcessLib.c
+++ b/IntelFsp2WrapperPkg/Library/FspWrapperMultiPhaseProcessLib/PeiFspWrapperMultiPhaseProcessLib.c
@@ -16,7 +16,7 @@
 #include <Ppi/ReadOnlyVariable2.h>
 #include <Ppi/Variable.h>
 #include <Library/PeiServicesLib.h>
-#include <Library/FspWrapperMultiPhaseProcessLib.h>
+#include <Library/FspWrapperPlatformMultiPhaseLib.h>
 
 /**
   Execute 32-bit FSP API entry code.


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4092

To comply with coding style rule each library class should have its own header even if it is just a private child library instance consumed by parent public library in the same package.

Cc: Nate DeSimone <nathaniel.l.desimone@intel.com>
Cc: Star Zeng <star.zeng@intel.com>
Signed-off-by: Chasel Chiu <chasel.chiu@intel.com>
Reviewed-by: Nate DeSimone <nathaniel.l.desimone@intel.com>