### PR TITLE
UefiCpuPkg: Reset a parameter when BSP Exit in CPU relaxed mode.

### DIFF
--- a/UefiCpuPkg/PiSmmCpuDxeSmm/CpuService.c
+++ b/UefiCpuPkg/PiSmmCpuDxeSmm/CpuService.c
@@ -421,11 +421,18 @@ SmmCpuRendezvous (
     goto ON_EXIT;
   }
 
-  //
-  // There are some APs outside SMM, Wait for all avaiable APs to arrive.
-  //
-  SmmWaitForApArrival ();
-  Status = mSmmMpSyncData->AllApArrivedWithException ? EFI_SUCCESS : EFI_TIMEOUT;
+  if ((mSmmMpSyncData->EffectiveSyncMode != SmmCpuSyncModeTradition) && !SmmCpuFeaturesNeedConfigureMtrrs ()) {
+    //
+    // There are some APs outside SMM, Wait for all avaiable APs to arrive.
+    //
+    SmmWaitForApArrival ();
+    Status = mSmmMpSyncData->AllApArrivedWithException ? EFI_SUCCESS : EFI_TIMEOUT;
+  } else {
+    //
+    // BSP has already waitted for APs to arrive SMM if SmmCpuSyncMode selected or need config MTRR.
+    //
+    Status = EFI_TIMEOUT;
+  }
 
 ON_EXIT:
   if (!mSmmMpSyncData->AllApArrivedWithException) {

--- a/UefiCpuPkg/PiSmmCpuDxeSmm/MpService.c
+++ b/UefiCpuPkg/PiSmmCpuDxeSmm/MpService.c
@@ -696,8 +696,9 @@ BSPHandler (
   //
   // Allow APs to check in from this point on
   //
-  *mSmmMpSyncData->Counter       = 0;
-  *mSmmMpSyncData->AllCpusInSync = FALSE;
+  *mSmmMpSyncData->Counter                  = 0;
+  *mSmmMpSyncData->AllCpusInSync            = FALSE;
+  mSmmMpSyncData->AllApArrivedWithException = FALSE;
 }
 
 /**


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4083

In CPU relaxed mode, it doesn't reset the value of mSmmMpSyncData->AllApArrivedWithException when BSP exit smm mode. So this patch will reset this variable. Modified the flow of SmmCpuRendezvous to avoid enter SmmWaitForApArrival repeatedly.

Cc: Eric Dong <eric.dong@intel.com>
Cc: Ray Ni <ray.ni@intel.com>

Signed-off-by: Zhihao Li <zhihao.li@intel.com>