### PR TITLE
MdeModulePkg: Handle InitialVFs=0 case for SR-IOV

### DIFF
--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciEnumeratorSupport.c
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciEnumeratorSupport.c
@@ -2416,13 +2416,17 @@ CreatePciIoDevice (
       //
       // Calculate LastVF
       //
-      PFRid  = EFI_PCI_RID (Bus, Device, Func);
-      LastVF = PFRid + FirstVFOffset + (PciIoDevice->InitialVFs - 1) * VFStride;
+      if (PciIoDevice->InitialVFs == 0) {
+        PciIoDevice->ReservedBusNum = 0;
+      } else {
+        PFRid  = EFI_PCI_RID (Bus, Device, Func);
+        LastVF = PFRid + FirstVFOffset + (PciIoDevice->InitialVFs - 1) * VFStride;
 
-      //
-      // Calculate ReservedBusNum for this PF
-      //
-      PciIoDevice->ReservedBusNum = (UINT16)(EFI_PCI_BUS_OF_RID (LastVF) - Bus + 1);
+        //
+        // Calculate ReservedBusNum for this PF
+        //
+        PciIoDevice->ReservedBusNum = (UINT16)(EFI_PCI_BUS_OF_RID (LastVF) - Bus + 1);
+      }
 
       DEBUG ((
         DEBUG_INFO,


### PR DESCRIPTION
Per the section 3.3.5 SR-IOV spec v1.1, InitialVFs (0ch). InitialVFs indicates to SR-PCIM the number of VFs that are initially associated with the PF. The minimum value of InitialVFs is 0.

Below code is used to calculate SR-IOV reserved bus number, if InitialVFs =0, it maybe calculate the wrong bus number in this case.
  LastVF = PFRid + FirstVFOffset + (PciIoDevice->InitialVFs - 1) * VFStride

we can fix it with below code:
 if (PciIoDevice->InitialVFs == 0) {
 PciIoDevice->ReservedBusNum = 0;
} else {
PFRid  = EFI_PCI_RID (Bus, Device, Func);
 LastVF = PFRid + FirstVFOffset + (PciIoDevice->InitialVFs - 1) * VFStride;
//
// Calculate ReservedBusNum for this PF
//
PciIoDevice->ReservedBusNum = (UINT16)(EFI_PCI_BUS_OF_RID (LastVF) - Bus + 1); //
 // Calculate ReservedBusNum for this PF
//
 PciIoDevice->ReservedBusNum = (UINT16)(EFI_PCI_BUS_OF_RID (LastVF) - Bus + 1);
}

https://bugzilla.tianocore.org/show_bug.cgi?id=4069

Signed-off-by: Foster Nong <foster.nong@intel.com>
Reviewed-by: Ray Ni <ray.ni@intel.com>