### PR TITLE
CryptoPkg: Fix integer overflow

### DIFF
--- a/CryptoPkg/Library/BaseCryptLib/SysCall/TimerWrapper.c
+++ b/CryptoPkg/Library/BaseCryptLib/SysCall/TimerWrapper.c
@@ -118,7 +118,7 @@ gmtime (
 {
   struct tm  *GmTime;
   UINT16     DayNo;
-  UINT16     DayRemainder;
+  UINT32     DayRemainder;
   time_t     Year;
   time_t     YearNo;
   UINT16     TotalDays;
@@ -136,7 +136,7 @@ gmtime (
   ZeroMem ((VOID *)GmTime, (UINTN)sizeof (struct tm));
 
   DayNo        = (UINT16)(*timer / SECSPERDAY);
-  DayRemainder = (UINT16)(*timer % SECSPERDAY);
+  DayRemainder = (UINT32)(*timer % SECSPERDAY);
 
   GmTime->tm_sec  = (int)(DayRemainder % SECSPERMIN);
   GmTime->tm_min  = (int)((DayRemainder % SECSPERHOUR) / SECSPERMIN);


### PR DESCRIPTION
SECSPERDAY is 86400 which exceeds the limit of a UINT16 which is 65536. Therefore DayRemainder cannot use UINT16. This patch makes it UINT32.

Cc: Ard Biesheuvel <ardb+tianocore@kernel.org>
Cc: Jordan Justen <jordan.l.justen@intel.com>
Cc: Laszlo Ersek <lersek@redhat.com>
Cc: Anthony Perard <anthony.perard@citrix.com>
Cc: Julien Grall <julien@xen.org>

Signed-off-by: Yuan Yu <yuanyu@google.com>
Reviewed-by: Ard Biesheuvel <ardb+tianocore@kernel.org>
Reviewed-by: Jiewen Yao <jiewen.yao@intel.com>