### PR TITLE
OvmfPkg/VirtioNetDxe: Check ChildHandle argument in GetControllerName

### DIFF
--- a/OvmfPkg/VirtioNetDxe/ComponentName.c
+++ b/OvmfPkg/VirtioNetDxe/ComponentName.c
@@ -130,6 +130,13 @@ VirtioNetGetControllerName (
   }
 
   //
+  // This is a device driver, so ChildHandle must be NULL.
+  //
+  if (ChildHandle != NULL) {
+    return EFI_UNSUPPORTED;
+  }
+
+  //
   // confirm that the device is managed by this driver, using the VirtIo
   // Protocol
   //


### PR DESCRIPTION
Per the UEFI specification, a device driver implementation should return EFI_UNSUPPORTED if the ChildHandle argument in
EFI_COMPONENT_NAME2_PROTOCOL.GetControllerName() is not NULL.

Signed-off-by: Dimitrije Pavlov <Dimitrije.Pavlov@arm.com>
Reviewed-By: Samer El-Haj-Mahmoud <Samer.El-Haj-Mahmoud@arm.com>
Reviewed-by: Sunny Wang <sunny.wang@arm.com>