### PR TITLE
ShellPkg: DpDynamicCommand: Add ResetEnd support in DP command

### DIFF
--- a/ShellPkg/DynamicCommand/DpDynamicCommand/Dp.c
+++ b/ShellPkg/DynamicCommand/DpDynamicCommand/Dp.c
@@ -57,6 +57,7 @@ UINT8    *mBootPerformanceTable;
 UINTN    mBootPerformanceTableSize;
 BOOLEAN  mPeiPhase = FALSE;
 BOOLEAN  mDxePhase = FALSE;
+UINT64   mResetEnd = 0;
 
 PERF_SUMMARY_DATA   SummaryData       = { 0 }; ///< Create the SummaryData structure and init. to ZERO.
 MEASUREMENT_RECORD  *mMeasurementList = NULL;
@@ -542,6 +543,8 @@ BuildMeasurementList (
 {
   EFI_ACPI_5_0_FPDT_PERFORMANCE_RECORD_HEADER  *RecordHeader;
   UINT8                                        *PerformanceTablePtr;
+  UINT8                                        *BasicBootTablePtr;
+  UINT64                                       ResetEnd;
   UINT16                                       StartProgressId;
   UINTN                                        TableLength;
   UINT8                                        *StartRecordEvent;
@@ -550,6 +553,17 @@ BuildMeasurementList (
   mMeasurementList = AllocateZeroPool (mBootPerformanceTableSize);
   if (mMeasurementList == NULL) {
     return EFI_OUT_OF_RESOURCES;
+  }
+
+  //
+  // Update the ResetEnd which was logged at the beginning of firmware image execution
+  //
+  TableLength       = sizeof (EFI_ACPI_5_0_FPDT_PERFORMANCE_TABLE_HEADER);
+  BasicBootTablePtr = (mBootPerformanceTable + TableLength);
+  ResetEnd          = ((EFI_ACPI_5_0_FPDT_FIRMWARE_BASIC_BOOT_RECORD *)BasicBootTablePtr)->ResetEnd;
+
+  if (ResetEnd > 0) {
+    mResetEnd = ResetEnd;
   }
 
   TableLength         = sizeof (BOOT_PERFORMANCE_TABLE);

--- a/ShellPkg/DynamicCommand/DpDynamicCommand/Dp.uni
+++ b/ShellPkg/DynamicCommand/DpDynamicCommand/Dp.uni
@@ -41,6 +41,7 @@
 #string STR_DP_TIMER_PROPERTIES        #language en-US  "System Performance Timer counts %s from 0x%Lx to 0x%Lx\n"
 #string STR_DP_VERBOSE_THRESHOLD       #language en-US  "Measurements less than %,Ld microseconds are not displayed.\n"
 #string STR_DP_SECTION_PHASES          #language en-US  "Major Phases"
+#string STR_DP_RESET_END               #language en-US  "  Reset End:               %L8d (us)\n"
 #string STR_DP_SEC_PHASE               #language en-US  "  SEC Phase Duration:      %L8d (us)\n"
 #string STR_DP_PHASE_BDSTO             #language en-US  "         BDS Timeout:   %L8d (ms) included in BDS Duration\n"
 #string STR_DP_PHASE_DURATION          #language en-US  "%5a Phase Duration:   %L8d (ms)\n"

--- a/ShellPkg/DynamicCommand/DpDynamicCommand/DpInternal.h
+++ b/ShellPkg/DynamicCommand/DpDynamicCommand/DpInternal.h
@@ -28,6 +28,7 @@ extern UINT8               *mBootPerformanceTable;
 extern UINTN               mBootPerformanceTableLength;
 extern MEASUREMENT_RECORD  *mMeasurementList;
 extern UINTN               mMeasurementNum;
+extern UINT64              mResetEnd;
 
 extern PERF_SUMMARY_DATA  SummaryData;    ///< Create the SummaryData structure and init. to ZERO.
 

--- a/ShellPkg/DynamicCommand/DpDynamicCommand/DpTrace.c
+++ b/ShellPkg/DynamicCommand/DpDynamicCommand/DpTrace.c
@@ -548,6 +548,15 @@ ProcessPhases (
 
   Total = 0;
 
+  // print Reset End if it's valid
+  //
+  if (SecTime > mResetEnd) {
+    SecTime = SecTime - mResetEnd;                    // Calculate sec time duration start from the beginning of firmware image execution
+    ElapsedTime = DurationInMicroSeconds (mResetEnd); // Calculate elapsed time in microseconds
+    Total      += DivU64x32 (ElapsedTime, 1000);      // Accumulate time in milliseconds
+    ShellPrintHiiEx (-1, -1, NULL, STRING_TOKEN (STR_DP_RESET_END), mDpHiiHandle, ElapsedTime);
+  }
+
   // print SEC phase duration time
   //
   if (SecTime > 0) {


### PR DESCRIPTION
DP command should be able to parse the FPDT ACPI table and dump the ResetEnd which was logged at the beginning of the firmware image execution. So that DP can calculate SEC phase time duration start from the beginning of firmware image execution.

Cc: Ray Ni <ray.ni@intel.com>
Cc: Zhichao Gao <zhichao.gao@intel.com>
Signed-off-by: zhenhuay <zhenhua.yang@intel.com>