### PR TITLE
[TEST] CI: use Ubuntu 22.04 image

### DIFF
--- a/ArmVirtPkg/PlatformCI/.azurepipelines/Ubuntu-GCC5.yml
+++ b/ArmVirtPkg/PlatformCI/.azurepipelines/Ubuntu-GCC5.yml
@@ -19,7 +19,7 @@ jobs:
   - job: Platform_CI
     variables:
       package: 'ArmVirtPkg'
-      vm_image: 'ubuntu-18.04'
+      vm_image: 'ubuntu-22.04'
       should_run: true
       run_flags: "MAKE_STARTUP_NSH=TRUE QEMU_HEADLESS=TRUE"
 

--- a/EmulatorPkg/PlatformCI/.azurepipelines/Ubuntu-GCC5.yml
+++ b/EmulatorPkg/PlatformCI/.azurepipelines/Ubuntu-GCC5.yml
@@ -19,7 +19,7 @@ jobs:
   - job: Platform_CI
     variables:
       package: 'EmulatorPkg'
-      vm_image: 'ubuntu-18.04'
+      vm_image: 'ubuntu-22.04'
       should_run: false
       run_flags: "MAKE_STARTUP_NSH=TRUE"
 

--- a/OvmfPkg/PlatformCI/.azurepipelines/Ubuntu-GCC5.yml
+++ b/OvmfPkg/PlatformCI/.azurepipelines/Ubuntu-GCC5.yml
@@ -19,7 +19,7 @@ jobs:
   - job: Platform_CI
     variables:
       package: 'OvmfPkg'
-      vm_image: 'ubuntu-18.04'
+      vm_image: 'ubuntu-22.04'
       should_run: true
       run_flags: "MAKE_STARTUP_NSH=TRUE QEMU_HEADLESS=TRUE"
 


### PR DESCRIPTION
The Azure Devops vm image "ubuntu-18.04" is deprecated and will go away soon.  Use Ubuntu 20.04 instead.