### PR TITLE
pip-requirement: Upgrade the edk2-basetools version from

### DIFF
--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -14,5 +14,5 @@
 
 edk2-pytool-library==0.11.2
 edk2-pytool-extensions~=0.16.0
-edk2-basetools==0.1.29
+edk2-basetools==0.1.32
 antlr4-python3-runtime==4.7.1


### PR DESCRIPTION
 0.1.29 to 0.1.32

features and bug fixes:
1. BaseTools: Correct BPDG tool error prints
2. BaseTools: Remove duplicated words in Python tools

Signed-off-by: Bob Feng <bob.c.feng@intel.com>