### PR TITLE
pip-requirement: Upgrade the edk2-basetools version from

### DIFF
--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -14,5 +14,5 @@
 
 edk2-pytool-library==0.11.2
 edk2-pytool-extensions~=0.16.0
-edk2-basetools==0.1.29
+edk2-basetools==0.1.39
 antlr4-python3-runtime==4.7.1


### PR DESCRIPTION
 0.1.28 to 0.1.39

features and bug fixes:
1. Revert "BaseTools: Fix DSC LibraryClass precedence rule"
2. BaseTools: Correct BPDG tool error prints
3. BaseTools: Remove duplicated words in Python tools
4. BaseTools/FMMT: Add Extract FV function
5. BaseTools/FMMT: Add Shrink Fv function
6. BaseTools: Add support for SUBTYPE_GUID section generation
7. BaseTools: Support COMPAT16 section generation
8. BaseTools/GenFds: Correct file type set for the PIC section
9. BaseTools: Correct initialization data size check for array PCDs
10. BaseTools: Add missing spaces for PCD expression values in AutoGenC

Signed-off-by: Bob Feng <bob.c.feng@intel.com>