### PR TITLE
Update proper device name in ScsiDisk driver

### DIFF
--- a/MdeModulePkg/Bus/Scsi/ScsiDiskDxe/ScsiDisk.c
+++ b/MdeModulePkg/Bus/Scsi/ScsiDiskDxe/ScsiDisk.c
@@ -68,6 +68,32 @@ FreeAlignedBuffer (
 }
 
 /**
+  Remove trailing spaces from the string
+
+  @param String   The ASCII string to remove the trailing spaces
+
+  @retval the new length of the string
+**/
+UINTN
+RemoveTrailingSpaces (
+  IN OUT CHAR8   *String
+)
+{
+  UINTN  Length = AsciiStrLen (String);
+
+  if (Length == 0) {
+    return 0;
+  }
+
+  while ((Length > 0) && (String[Length-1] == ' ')) {
+    Length--;
+  }
+
+  String[Length] = 0;
+  return Length;
+}
+
+/**
   The user Entry Point for module ScsiDisk.
 
   The user code starts with this function.
@@ -203,6 +229,9 @@ ScsiDiskDriverBindingStart (
   UINT8                 MaxRetry;
   BOOLEAN               NeedRetry;
   BOOLEAN               MustReadCapacity;
+  CHAR8                 VendorStr[VENDOR_IDENTIFICATION_LENGTH + 1];
+  CHAR8                 ProductStr[PRODUCT_IDENTIFICATION_LENGTH + 1];
+  CHAR16                DeviceStr[VENDOR_IDENTIFICATION_LENGTH + PRODUCT_IDENTIFICATION_LENGTH + 2];
 
   MustReadCapacity = TRUE;
 
@@ -354,19 +383,35 @@ ScsiDiskDriverBindingStart (
           }
         }
 
+        CopyMem (
+            VendorStr,
+            &ScsiDiskDevice->InquiryData.Reserved_5_95[VENDOR_IDENTIFICATION_OFFSET],
+            VENDOR_IDENTIFICATION_LENGTH);
+        VendorStr[VENDOR_IDENTIFICATION_LENGTH] = 0;
+        RemoveTrailingSpaces (VendorStr);
+
+        CopyMem (
+            ProductStr,
+            &ScsiDiskDevice->InquiryData.Reserved_5_95[PRODUCT_IDENTIFICATION_OFFSET],
+            PRODUCT_IDENTIFICATION_LENGTH);
+        ProductStr[PRODUCT_IDENTIFICATION_LENGTH] = 0;
+        RemoveTrailingSpaces (ProductStr);
+
+        UnicodeSPrint (DeviceStr, sizeof (DeviceStr), L"%a %a", VendorStr, ProductStr);
+
         ScsiDiskDevice->ControllerNameTable = NULL;
         AddUnicodeString2 (
           "eng",
           gScsiDiskComponentName.SupportedLanguages,
           &ScsiDiskDevice->ControllerNameTable,
-          L"SCSI Disk Device",
+          DeviceStr,
           TRUE
           );
         AddUnicodeString2 (
           "en",
           gScsiDiskComponentName2.SupportedLanguages,
           &ScsiDiskDevice->ControllerNameTable,
-          L"SCSI Disk Device",
+          DeviceStr,
           FALSE
           );
         return EFI_SUCCESS;

--- a/MdeModulePkg/Bus/Scsi/ScsiDiskDxe/ScsiDisk.h
+++ b/MdeModulePkg/Bus/Scsi/ScsiDiskDxe/ScsiDisk.h
@@ -30,6 +30,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/UefiScsiLib.h>
 #include <Library/UefiBootServicesTableLib.h>
 #include <Library/DevicePathLib.h>
+#include <Library/PrintLib.h>
 
 #include <IndustryStandard/Scsi.h>
 #include <IndustryStandard/Atapi.h>
@@ -178,6 +179,13 @@ extern EFI_COMPONENT_NAME2_PROTOCOL  gScsiDiskComponentName2;
 #define SCSI_COMMAND_VERSION_1  0x01
 #define SCSI_COMMAND_VERSION_2  0x02
 #define SCSI_COMMAND_VERSION_3  0x03
+
+// Per SCSI spec, EFI_SCSI_INQUIRY_DATA.Reserved_5_95[3 - 10] has the Vendor identification
+// EFI_SCSI_INQUIRY_DATA.Reserved_5_95[11 - 26] has the product identification
+#define VENDOR_IDENTIFICATION_OFFSET   3
+#define VENDOR_IDENTIFICATION_LENGTH   8
+#define PRODUCT_IDENTIFICATION_OFFSET  11
+#define PRODUCT_IDENTIFICATION_LENGTH  16
 
 //
 // SCSI Disk Timeout Experience Value

--- a/MdeModulePkg/Bus/Scsi/ScsiDiskDxe/ScsiDiskDxe.inf
+++ b/MdeModulePkg/Bus/Scsi/ScsiDiskDxe/ScsiDiskDxe.inf
@@ -46,6 +46,7 @@
   UefiDriverEntryPoint
   DebugLib
   DevicePathLib
+  PrintLib
 
 [Protocols]
   gEfiDiskInfoProtocolGuid                      ## BY_START


### PR DESCRIPTION
ScsiDiskDxe driver updates ControllerNameTable with common string 
"SCSI Disk Device" for all SCSI disk. Due to this, when multiple
SCSI disk devices connected, facing difficulty in identifying correct SCSI
disk device. As per SCSI spec, standard Inquiry Data is having the fields
to know Vendor and Product information. Updated "ControllerNameTable" with
Vendor and Product information. So that, device specific name can be
retrieved using ComponentName protocol.

Signed-off-by: Cheripally Gopi <gopic@ami.com>

Cc: Vasudevan Sambandan <vasudevans@ami.com>
Cc: Sundaresan Selvaraj <sundaresans@ami.com>