### PR TITLE
MdeModulePkg: Memory Corruption Error in CapsuleRuntimeDxe

### DIFF
--- a/MdeModulePkg/Universal/CapsuleRuntimeDxe/X64/SaveLongModeContext.c
+++ b/MdeModulePkg/Universal/CapsuleRuntimeDxe/X64/SaveLongModeContext.c
@@ -59,7 +59,15 @@ AllocateReservedMemoryBelow4G (
                   Pages,
                   &Address
                   );
-  ASSERT_EFI_ERROR (Status);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "ERROR AllocateReservedMemoryBelow4G(): %r\n", Status));
+    return NULL;
+  }
+
+  if (Address == 0) {
+    DEBUG ((DEBUG_ERROR, "ERROR AllocateReservedMemoryBelow4G(): AllocatePages() returned NULL"));
+    return NULL;
+  }
 
   Buffer = (VOID *)(UINTN)Address;
   ZeroMem (Buffer, Size);
@@ -159,14 +167,23 @@ PrepareContextForCapsulePei (
   DEBUG ((DEBUG_INFO, "CapsuleRuntimeDxe X64 TotalPagesNum - 0x%x pages\n", TotalPagesNum));
 
   LongModeBuffer.PageTableAddress = (EFI_PHYSICAL_ADDRESS)(UINTN)AllocateReservedMemoryBelow4G (EFI_PAGES_TO_SIZE (TotalPagesNum));
-  ASSERT (LongModeBuffer.PageTableAddress != 0);
+  if (LongModeBuffer.PageTableAddress == 0) {
+    DEBUG ((DEBUG_ERROR, "FATAL ERROR: CapsuleLongModeBuffer cannot be saved, "));
+    DEBUG ((DEBUG_ERROR, "PageTableAddress allocation failed. Capsule in PEI may fail!\n"));
+    return;
+  }
 
   //
   // Allocate stack
   //
   LongModeBuffer.StackSize        = PcdGet32 (PcdCapsulePeiLongModeStackSize);
   LongModeBuffer.StackBaseAddress = (EFI_PHYSICAL_ADDRESS)(UINTN)AllocateReservedMemoryBelow4G (PcdGet32 (PcdCapsulePeiLongModeStackSize));
-  ASSERT (LongModeBuffer.StackBaseAddress != 0);
+  if (LongModeBuffer.StackBaseAddress == 0) {
+    DEBUG ((DEBUG_ERROR, "FATAL ERROR: CapsuleLongModeBuffer cannot be saved, "));
+    DEBUG ((DEBUG_ERROR, "StackBaseAddress allocation failed. Capsule in PEI may fail!\n"));
+    gBS->FreePages (LongModeBuffer.PageTableAddress, TotalPagesNum);
+    return;
+  }
 
   Status = gRT->SetVariable (
                   EFI_CAPSULE_LONG_MODE_BUFFER_NAME,
@@ -189,6 +206,7 @@ PrepareContextForCapsulePei (
       );
   } else {
     DEBUG ((DEBUG_ERROR, "FATAL ERROR: CapsuleLongModeBuffer cannot be saved: %r. Capsule in PEI may fail!\n", Status));
+    gBS->FreePages (LongModeBuffer.PageTableAddress, TotalPagesNum);
     gBS->FreePages (LongModeBuffer.StackBaseAddress, EFI_SIZE_TO_PAGES (LongModeBuffer.StackSize));
   }
 }


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4112

In AllocateReservedMemoryBelow4G(), if gBS->AllocatePages() returns an error, and ASSERTs are disabled, then the function will overwrite memory from 0xFFFFFFFF -> (0xFFFFFFFF + Size).

Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Guomin Jiang <guomin.jiang@intel.com>
Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Michael D Kinney <michael.d.kinney@intel.com>
Signed-off-by: Nate DeSimone <nathaniel.l.desimone@intel.com>