### PR TITLE
BaseTools/Scripts/PatchCheck.py: Allow tab in Makefile

### DIFF
--- a/BaseTools/Scripts/PatchCheck.py
+++ b/BaseTools/Scripts/PatchCheck.py
@@ -383,6 +383,9 @@ class GitDiffCheck:
                     #
                     self.force_crlf = False
                     self.force_notabs = False
+                if os.path.basename(self.filename) == 'GNUmakefile' or \
+                   os.path.basename(self.filename) == 'Makefile':
+                    self.force_notabs = False
             elif len(line.rstrip()) != 0:
                 self.format_error("didn't find diff command")
             self.line_num += 1


### PR DESCRIPTION
The syntax for Makefiles requires that indented lines s tart with a tab, but not a space.

This change of PatchCheck.py make the patch for Makefile/GNUmakefile pass the PatchCheck.py.

Signed-off-by: Bob Feng <bob.c.feng@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Yuwei Chen <yuwei.chen@intel.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>