### PR TITLE
BaseTools: Fix check for ${PYTHON_COMMAND} in Tests/GNUmakefile

### DIFF
--- a/BaseTools/Tests/GNUmakefile
+++ b/BaseTools/Tests/GNUmakefile
@@ -8,7 +8,7 @@
 all: test
 
 test:
-	@if command -v $(PYTHON_COMMAND) >/dev/null 1; then $(PYTHON_COMMAND) RunTests.py; else python RunTests.py; fi
+	@if command -v ${PYTHON_COMMAND} >/dev/null 2>&1; then ${PYTHON_COMMAND} RunTests.py; else python RunTests.py; fi
 
 clean:
 	find . -name '*.pyc' -exec rm '{}' ';'


### PR DESCRIPTION
When checking if $PYTHON_COMMAND exists, curly braces should be used instead of parentheses.

Also, "1" causes an error on FreeBSD: it's likely supposed to be 2>&1 like other scripts.

Signed-off-by: Rebecca Cran <rebecca@bsdio.com>
Reviewed-by: Bob Feng <bob.c.feng@intel.com>