### PR TITLE
BaseTools/Tests: Use quotes around PYTHON_COMMAND

### DIFF
--- a/BaseTools/Tests/GNUmakefile
+++ b/BaseTools/Tests/GNUmakefile
@@ -8,7 +8,7 @@
 all: test
 
 test:
-	@if command -v ${PYTHON_COMMAND} >/dev/null 2>&1; then ${PYTHON_COMMAND} RunTests.py; else python RunTests.py; fi
+	@if command -v "${PYTHON_COMMAND}" >/dev/null 2>&1; then ${PYTHON_COMMAND} RunTests.py; else python RunTests.py; fi
 
 clean:
 	find . -name '*.pyc' -exec rm '{}' ';'


### PR DESCRIPTION
Commit ("2355f0c09c52 BaseTools: Fix check for ${PYTHON_COMMAND} in Tests/GNUmakefile") fixed a latent issue in the BaseTools/Tests Makefile, but inadvertently broke the BaseTools build for cases where PYTHON_COMMAND is not set. As it turns out, running 'command' without a command argument makes the invocation succeed, causing the empty variable to be evaluated and called later.

Let's put double quotes around PYTHON_COMMAND in the invocation of 'command' and force it to fail when PYTHON_COMMAND is not set.

Signed-off-by: Ard Biesheuvel <ardb@kernel.org>
Reviewed-by: Bob Feng <bob.c.feng@intel.com>