### PR TITLE
ArmPlatformPkg/PrePeiCore: Print the firmware version early in boot

### DIFF
--- a/ArmPlatformPkg/PrePeiCore/PrePeiCore.c
+++ b/ArmPlatformPkg/PrePeiCore/PrePeiCore.c
@@ -11,6 +11,8 @@
 #include <Library/CacheMaintenanceLib.h>
 #include <Library/DebugAgentLib.h>
 #include <Library/ArmLib.h>
+#include <Library/PrintLib.h>
+#include <Library/SerialPortLib.h>
 
 #include "PrePeiCore.h"
 
@@ -50,6 +52,31 @@ CreatePpiList (
 
   *PpiList     = (EFI_PEI_PPI_DESCRIPTOR *)ListBase;
   *PpiListSize = sizeof (gCommonPpiTable) + PlatformPpiListSize;
+}
+
+/**
+
+ Prints firmware version and build time to serial console.
+
+**/
+STATIC
+VOID
+PrintFirmwareVersion (
+  VOID
+  )
+{
+  CHAR8  Buffer[100];
+  UINTN  CharCount;
+
+  CharCount = AsciiSPrint (
+                Buffer,
+                sizeof (Buffer),
+                "UEFI firmware (version %s built at %a on %a)\n\r",
+                (CHAR16 *)PcdGetPtr (PcdFirmwareVersionString),
+                __TIME__,
+                __DATE__
+                );
+  SerialPortWrite ((UINT8 *)Buffer, CharCount);
 }
 
 VOID
@@ -95,6 +122,8 @@ CEntryPoint (
     // Invoke "ProcessLibraryConstructorList" to have all library constructors
     // called.
     ProcessLibraryConstructorList ();
+
+    PrintFirmwareVersion ();
 
     // Initialize the Debug Agent for Source Level Debugging
     InitializeDebugAgent (DEBUG_AGENT_INIT_POSTMEM_SEC, NULL, NULL);

--- a/ArmPlatformPkg/PrePeiCore/PrePeiCoreMPCore.inf
+++ b/ArmPlatformPkg/PrePeiCore/PrePeiCoreMPCore.inf
@@ -54,6 +54,9 @@
   gEfiTemporaryRamSupportPpiGuid
   gArmMpCoreInfoPpiGuid
 
+[Pcd]
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFirmwareVersionString
+
 [FeaturePcd]
   gArmPlatformTokenSpaceGuid.PcdSendSgiToBringUpSecondaryCores
 

--- a/ArmPlatformPkg/PrePeiCore/PrePeiCoreUniCore.inf
+++ b/ArmPlatformPkg/PrePeiCore/PrePeiCoreUniCore.inf
@@ -52,6 +52,9 @@
 [Ppis]
   gEfiTemporaryRamSupportPpiGuid
 
+[Pcd]
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFirmwareVersionString
+
 [FeaturePcd]
   gArmPlatformTokenSpaceGuid.PcdSendSgiToBringUpSecondaryCores
 


### PR DESCRIPTION
Copy code from PrePi to PrePeiCore that prints the firmware version and build date early in the boot process.

Signed-off-by: Rebecca Cran <rebecca@quicinc.com>
Reviewed-by: Sami Mujawar <sami.mujawar@arm.com>
Tested-by: Oliver Steffen <osteffen@redhat.com>
Reviewed-by: Leif Lindholm <quic_llindhol@quicinc.com>