### PR TITLE
MdeModulePkg: Fix spelling error in PciSioSerialDxe

### DIFF
--- a/MdeModulePkg/Bus/Pci/PciSioSerialDxe/Serial.c
+++ b/MdeModulePkg/Bus/Pci/PciSioSerialDxe/Serial.c
@@ -138,7 +138,7 @@ InitializePciSioSerial (
   ASSERT_EFI_ERROR (Status);
 
   //
-  // Initialize UART default setting in gSerialDevTempate
+  // Initialize UART default setting in gSerialDevTemplate
   //
   gSerialDevTemplate.SerialMode.BaudRate     = PcdGet64 (PcdUartDefaultBaudRate);
   gSerialDevTemplate.SerialMode.DataBits     = PcdGet8 (PcdUartDefaultDataBits);


### PR DESCRIPTION
gSerialDevTempate should be gSerialDevTemplate

Cc: Ray Ni <ray.ni@intel.com>
Cc: Zhichao Gao <zhichao.gao@intel.com>
Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Michael D Kinney <michael.d.kinney@intel.com>
Signed-off-by: Nate DeSimone <nathaniel.l.desimone@intel.com>
Reviewed-by: Michael D Kinney <michael.d.kinney@intel.com>