### PR TITLE
Maintainers.txt: Update maintainers list

### DIFF
--- a/Maintainers.txt
+++ b/Maintainers.txt
@@ -544,6 +544,7 @@ RedfishPkg: Redfish related modules
 F: RedfishPkg/
 M: Abner Chang <abner.chang@amd.com> [changab]
 M: Nickle Wang <nicklew@nvidia.com> [nicklela]
+R: Igor Kulchytskyy <igork@ami.com> [igorkulchytskyy]
 
 SecurityPkg
 F: SecurityPkg/


### PR DESCRIPTION
Update maintainers.txt to add Igor from AMI
as the reviewer of RedfishPkg.

Signed-off-by: Abner Chang <abner.chang@amd.com>
Cc: Andrew Fish <afish@apple.com>
Cc: Leif Lindholm <quic_llindhol@quicinc.com>
Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Nickle Wang <nickle@csie.io>
Cc: Igor Kulchytskyy <igork@ami.com>