### PR TITLE
ArmVirtPkg/ArmVirtQemu: Clear XIP flags instead of overriding them

### DIFF
--- a/ArmVirtPkg/ArmVirtQemu.dsc
+++ b/ArmVirtPkg/ArmVirtQemu.dsc
@@ -117,7 +117,7 @@
   UefiScsiLib|MdePkg/Library/UefiScsiLib/UefiScsiLib.inf
 
 [BuildOptions]
-  GCC:*_*_AARCH64_CC_XIPFLAGS = -mno-strict-align
+  GCC:*_*_AARCH64_CC_XIPFLAGS ==
 
 !include NetworkPkg/NetworkBuildOptions.dsc.inc
 


### PR DESCRIPTION
Clang does not support undoing the effects of -mstrict-align by passing the -mno-strict-align counterpart, so appending the latter to the compiler's XIPFLAGS does not work. Instead, clear the flags entirely.

This also removes -mgeneral-regs-only, but this is fine - we can tolerate SIMD codegen in PEIMs or BASE libraries as they run with the MMU and caches enabled.

Signed-off-by: Ard Biesheuvel <ardb@kernel.org>