### PR TITLE
UefiCpuPkg: Restore HpetTimer after CpuExceptionHandlerLib test

### DIFF
--- a/UefiCpuPkg/Library/CpuExceptionHandlerLib/UnitTest/DxeCpuExceptionHandlerLibUnitTest.inf
+++ b/UefiCpuPkg/Library/CpuExceptionHandlerLib/UnitTest/DxeCpuExceptionHandlerLibUnitTest.inf
@@ -53,6 +53,7 @@
 
 [Protocols]
   gEfiMpServiceProtocolGuid
+  gEfiTimerArchProtocolGuid
 
 [Depex]
   gEfiMpServiceProtocolGuid


### PR DESCRIPTION
Disable/Restore HpetTimer before and after running the Dxe CpuExceptionHandlerLib unit test module. During the UnitTest, a new Idt is initialized for the test. There is no handler for timer intrrupt in this new idt. After the test module, HpetTimer does not work any more since the comparator value register and main counter value register for timer does not match. To fix this issue, disable/restore HpetTimer before and after Unit Test if HpetTimer driver has been dispatched. Besides, send Apic EOI before restore HpetTimer.

Signed-off-by: Dun Tan <dun.tan@intel.com>
Cc: Eric Dong <eric.dong@intel.com>
Reviewed-by: Ray Ni <ray.ni@intel.com>
Cc: Rahul Kumar <rahul1.kumar@intel.com>