### PR TITLE
MdeModulePkg/ScsiDiskDxe: Update proper device name for ScsiDisk drive

### DIFF
--- a/MdeModulePkg/Bus/Scsi/ScsiDiskDxe/ScsiDisk.h
+++ b/MdeModulePkg/Bus/Scsi/ScsiDiskDxe/ScsiDisk.h
@@ -2,6 +2,7 @@
   Header file for SCSI Disk Driver.
 
 Copyright (c) 2004 - 2019, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 1985 - 2022, American Megatrends International LLC.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -30,6 +31,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/UefiScsiLib.h>
 #include <Library/UefiBootServicesTableLib.h>
 #include <Library/DevicePathLib.h>
+#include <Library/PrintLib.h>
 
 #include <IndustryStandard/Scsi.h>
 #include <IndustryStandard/Atapi.h>
@@ -178,6 +180,13 @@ extern EFI_COMPONENT_NAME2_PROTOCOL  gScsiDiskComponentName2;
 #define SCSI_COMMAND_VERSION_1  0x01
 #define SCSI_COMMAND_VERSION_2  0x02
 #define SCSI_COMMAND_VERSION_3  0x03
+
+// Per SCSI spec, EFI_SCSI_INQUIRY_DATA.Reserved_5_95[3 - 10] has the Vendor identification
+// EFI_SCSI_INQUIRY_DATA.Reserved_5_95[11 - 26] has the product identification
+#define VENDOR_IDENTIFICATION_OFFSET   3
+#define VENDOR_IDENTIFICATION_LENGTH   8
+#define PRODUCT_IDENTIFICATION_OFFSET  11
+#define PRODUCT_IDENTIFICATION_LENGTH  16
 
 //
 // SCSI Disk Timeout Experience Value

--- a/MdeModulePkg/Bus/Scsi/ScsiDiskDxe/ScsiDiskDxe.inf
+++ b/MdeModulePkg/Bus/Scsi/ScsiDiskDxe/ScsiDiskDxe.inf
@@ -4,6 +4,7 @@
 #  the device handle.
 #
 #  Copyright (c) 2006 - 2019, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 1985 - 2022, American Megatrends International LLC.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -46,6 +47,7 @@
   UefiDriverEntryPoint
   DebugLib
   DevicePathLib
+  PrintLib
 
 [Protocols]
   gEfiDiskInfoProtocolGuid                      ## BY_START


### PR DESCRIPTION
Patch sent at: https://edk2.groups.io/g/devel/message/95636

REF:https://bugzilla.tianocore.org/show_bug.cgi?id=4100

ScsiDiskDxe driver updates ControllerNameTable with common string "SCSI Disk Device" for all SCSI disks. Due to this, when multiple SCSI disk devices connected, facing difficulty in identifying correct SCSI disk device. As per SCSI spec, standard Inquiry Data is having the fields to know Vendor and Product information. Updated "ControllerNameTable" with Vendor and Product information. So that, device specific name can be retrieved using ComponentName protocol.

Cc: Vasudevan Sambandan <vasudevans@ami.com>
Cc: Sundaresan Selvaraj <sundaresans@ami.com>
Signed-off-by: Cheripally Gopi <gopic@ami.com>
Reviewed-by: Hao A Wu <hao.a.wu@intel.com>