### PR TITLE
RedfishPkg/RedfishDiscoverDxe: Fix memory free issue

### DIFF
--- a/RedfishPkg/RedfishDiscoverDxe/RedfishDiscoverDxe.c
+++ b/RedfishPkg/RedfishDiscoverDxe/RedfishDiscoverDxe.c
@@ -261,6 +261,7 @@ Tcp6GetSubnetInfo (
 
   Tcp6 = (EFI_TCP6_PROTOCOL *)Instance->NetworkInterfaceProtocolInfo.NetworkProtocolInterface;
 
+  ZeroMem ((VOID *)&IpModedata, sizeof (EFI_IP6_MODE_DATA));
   Status = Tcp6->GetModeData (Tcp6, NULL, NULL, &IpModedata, NULL, NULL);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a: Can't get IP mode data information\n", __FUNCTION__));
@@ -282,12 +283,15 @@ Tcp6GetSubnetInfo (
   }
 
   Instance->SubnetAddrInfoIPv6Number = IpModedata.AddressCount;
-  CopyMem (
-    (VOID *)Instance->SubnetAddrInfoIPv6,
-    (VOID *)&IpModedata.AddressList,
-    IpModedata.AddressCount * sizeof (EFI_IP6_ADDRESS_INFO)
-    );
-  FreePool (IpModedata.AddressList);
+  if ((IpModedata.AddressCount != 0) && (IpModedata.AddressList != NULL)) {
+    CopyMem (
+      (VOID *)Instance->SubnetAddrInfoIPv6,
+      (VOID *)&IpModedata.AddressList,
+      IpModedata.AddressCount * sizeof (EFI_IP6_ADDRESS_INFO)
+      );
+    FreePool (IpModedata.AddressList);
+  }
+
   return EFI_SUCCESS;
 }
 


### PR DESCRIPTION
Check the memory block pointer before freeing it.

Cc: Nickle Wang <nicklew@nvidia.com>
Cc: Igor Kulchytskyy <igork@ami.com>
Signed-off-by: Abner Chang <abner.chang@amd.com>
Reviewed-by: Nickle Wang <nicklew@nvidia.com>