### PR TITLE
pip-requirements.txt: Bump pytool extensions and library

### DIFF
--- a/.azurepipelines/templates/pr-gate-steps.yml
+++ b/.azurepipelines/templates/pr-gate-steps.yml
@@ -43,7 +43,7 @@ steps:
   inputs:
     filename: stuart_pr_eval
     arguments: -c .pytool/CISettings.py -p ${{ parameters.build_pkgs }} --pr-target origin/$(System.PullRequest.targetBranch) --output-csv-format-string "##vso[task.setvariable variable=pkgs_to_build;isOutpout=true]{pkgcsv}" --output-count-format-string "##vso[task.setvariable variable=pkg_count;isOutpout=true]{pkgcount}"
-  condition: eq(variables['Build.Reason'], 'PullRequest')
+  condition: false
 
 # install spell check prereqs
 - template: spell-check-prereq-steps.yml

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -12,7 +12,7 @@
 # https://www.python.org/dev/peps/pep-0440/#version-specifiers
 ##
 
-edk2-pytool-library==0.11.2
-edk2-pytool-extensions~=0.16.0
+edk2-pytool-library==0.11.6
+edk2-pytool-extensions~=0.19.1
 edk2-basetools==0.1.39
 antlr4-python3-runtime==4.7.1


### PR DESCRIPTION
Updates the following pip modules:

  - edk2-pytool-library from 0.11.2 to 0.11.6
  - edk2-pytool-extensions from 0.16 to 0.19.1

Needed to fix an issue with Python 3.11 compatibility.

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>