### PR TITLE
pip-requirements.txt: Bump pytool extensions and library

### DIFF
--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -12,7 +12,7 @@
 # https://www.python.org/dev/peps/pep-0440/#version-specifiers
 ##
 
-edk2-pytool-library==0.11.2
-edk2-pytool-extensions~=0.16.0
+edk2-pytool-library==0.11.6
+edk2-pytool-extensions~=0.19.1
 edk2-basetools==0.1.39
 antlr4-python3-runtime==4.7.1


### PR DESCRIPTION
Fixes edk2 CI failure due to VM images being updated to Python 3.11 and the old pip modules not being compatible with Python 3.11.

Updates the following pip modules:

  - edk2-pytool-library from 0.11.2 to 0.11.6
  - edk2-pytool-extensions from 0.16 to 0.19.1

Needed to fix an issue with Python 3.11 compatibility.

Cc: Sean Brogan <sean.brogan@microsoft.com>
Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Chasel Chiu <chasel.chiu@intel.com>
Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>
Reviewed-by: Michael D Kinney <michael.d.kinney@intel.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>