### PR TITLE
IntelFsp2Pkg: Update Function header to support IA32/X64.

### DIFF
--- a/IntelFsp2Pkg/FspSecCore/SecFsp.h
+++ b/IntelFsp2Pkg/FspSecCore/SecFsp.h
@@ -70,7 +70,7 @@ FspDataPointerFixUp (
   @return   FSP binary base address.
 
 **/
-UINT32
+UINTN
 EFIAPI
 AsmGetFspBaseAddress (
   VOID
@@ -82,7 +82,7 @@ AsmGetFspBaseAddress (
   @return   FSP binary base address.
 
 **/
-UINT32
+UINTN
 EFIAPI
 AsmGetFspInfoHeader (
   VOID

--- a/IntelFsp2Pkg/Include/Library/FspSecPlatformLib.h
+++ b/IntelFsp2Pkg/Include/Library/FspSecPlatformLib.h
@@ -17,10 +17,10 @@
   The callee should not use XMM6/XMM7.
   The return address is saved in MM7.
 
-  @retval in saved in EAX - 0 means platform initialization success.
+  @retval in saved in EAX/RAX - 0 means platform initialization success.
                             other means platform initialization fail.
 **/
-UINT32
+UINTN
 EFIAPI
 SecPlatformInit (
   VOID
@@ -37,10 +37,10 @@ SecPlatformInit (
 
   @param[in] FsptUpdDataPtr     Address pointer to the FSPT_UPD data structure. It is saved in ESP.
 
-  @retval in saved in EAX - 0 means Microcode is loaded successfully.
+  @retval in saved in EAX/RAX - 0 means Microcode is loaded successfully.
                             other means Microcode is not loaded successfully.
 **/
-UINT32
+UINTN
 EFIAPI
 LoadMicrocode (
   IN  VOID  *FsptUpdDataPtr
@@ -56,10 +56,10 @@ LoadMicrocode (
 
   @param[in] FsptUpdDataPtr     Address pointer to the FSPT_UPD data structure. It is saved in ESP.
 
-  @retval in saved in EAX - 0 means CAR initialization success.
+  @retval in saved in EAX/RAX - 0 means CAR initialization success.
                             other means CAR initialization fail.
 **/
-UINT32
+UINTN
 EFIAPI
 SecCarInit (
   IN  VOID  *FsptUpdDataPtr


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4126

Common functions will have either 32bit or 64bit instances which having different return code size. Function header should support both scenarios.

Cc: Nate DeSimone <nathaniel.l.desimone@intel.com>
Cc: Star Zeng <star.zeng@intel.com>
Signed-off-by: Chasel Chiu <chasel.chiu@intel.com>
Reviewed-by: Nate DeSimone <nathaniel.l.desimone@intel.com>