### PR TITLE
ShellPkg: Improved Smbios Type 9 data under smbiosview

### DIFF
--- a/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/PrintInfo.c
+++ b/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/PrintInfo.c
@@ -638,12 +638,18 @@ SmbiosPrintStructure (
             ShellPrintHiiEx (-1, -1, NULL, STRING_TOKEN (STR_SMBIOSVIEW_PRINTINFO_DATA_BUS_WIDTH), gShellDebug1HiiHandle, PeerGroupPtr[Index].DataBusWidth);
           }
 
-          // Since PeerGroups has a variable number of entries, new fields added after PeerGroups are defined in
-          // a extended structure. Those fields can be referenced using SMBIOS_TABLE_TYPE9_EXTENDED structure.
-          Type9ExtendedStruct = (SMBIOS_TABLE_TYPE9_EXTENDED *)((UINT8 *)PeerGroupPtr + (PeerGroupCount * sizeof (MISC_SLOT_PEER_GROUP)));
-          DisplaySystemSlotHeight (Type9ExtendedStruct->SlotHeight, Option);
-          DisplaySystemSlotPhysicalWidth (Type9ExtendedStruct->SlotPhysicalWidth, Option);
-          DisplaySystemSlotInformation (Type9ExtendedStruct->SlotInformation, Option);
+
+          if (AE_SMBIOS_VERSION (0x3, 0x4)) {
+              // Since PeerGroups has a variable number of entries, new fields added after PeerGroups are defined in
+              // a extended structure. Those fields can be referenced using SMBIOS_TABLE_TYPE9_EXTENDED structure.
+              Type9ExtendedStruct = (SMBIOS_TABLE_TYPE9_EXTENDED *)((UINT8 *)PeerGroupPtr + (PeerGroupCount * sizeof (MISC_SLOT_PEER_GROUP)));
+              DisplaySystemSlotInformation (Type9ExtendedStruct->SlotInformation, Option);
+              DisplaySystemSlotPhysicalWidth (Type9ExtendedStruct->SlotPhysicalWidth, Option);
+              ShellPrintHiiEx (-1, -1, NULL, STRING_TOKEN (STR_SMBIOSVIEW_QUERYTABLE_SYSTEM_SLOT_PITCH), gShellDebug1HiiHandle, Type9ExtendedStruct->SlotPitch);
+              if (AE_SMBIOS_VERSION (0x3, 0x5)) {
+                  DisplaySystemSlotHeight (Type9ExtendedStruct->SlotHeight, Option);
+              }
+          }
         }
       }
 

--- a/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/SmbiosViewStrings.uni
+++ b/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/SmbiosViewStrings.uni
@@ -1,6 +1,7 @@
 // /**
 //
 // Copyright (c) 2005 - 2018, Intel Corporation. All rights reserved.<BR>
+// Copyright (c) 1985 - 2022, American Megatrends International LLC.<BR>
 // (C) Copyright 2014-2015 Hewlett-Packard Development Company, L.P.<BR>
 // (C) Copyright 2015-2019 Hewlett Packard Enterprise Development LP<BR>
 // SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -417,6 +418,7 @@
 #string STR_SMBIOSVIEW_QUERYTABLE_SYSTEM_SLOT_INFORMATION       #language en-US "System Slot Information: "
 #string STR_SMBIOSVIEW_QUERYTABLE_SYSTEM_SLOT_HEIGHT            #language en-US "System Slot Height: "
 #string STR_SMBIOSVIEW_QUERYTABLE_SYSTEM_SLOT_PHYSICAL_WIDTH    #language en-US "System Slot Physical Width: "
+#string STR_SMBIOSVIEW_QUERYTABLE_SYSTEM_SLOT_PITCH             #language en-US "System Slot Pitch: %d\r\n"
 #string STR_SMBIOSVIEW_QUERYTABLE_ONBOARD_DEVICE_TYPE           #language en-US "Onboard Device Type: "
 #string STR_SMBIOSVIEW_QUERYTABLE_SYSTEM_EVENT_LOG_TYPE         #language en-US "System Event Log Type: "
 #string STR_SMBIOSVIEW_QUERYTABLE_EVENT_LOG_VAR_DATA_FORMAT     #language en-US "Event Log Variable Data Format Types: "


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4135

Added spec version check while publishing Type 9 fields, added Slot Pitch field which was missing and corrected the publishing order as per Smbios spec.

Signed-off-by: Sainadh Nagolu <sainadhn@ami.com>

CC: Vasudevan S <vasudevans@ami.com>
CC: Sundaresan S <sundaresans@ami.com>

