### PR TITLE
MdePkg/BaseLib: Fix out-of-bounds reads in SafeString

### DIFF
--- a/MdePkg/Library/BaseLib/SafeString.c
+++ b/MdePkg/Library/BaseLib/SafeString.c
@@ -863,6 +863,9 @@ StrHexToUintnS (
   OUT       UINTN   *Data
   )
 {
+  BOOLEAN  FoundLeadingZero;
+
+  FoundLeadingZero = FALSE;
   ASSERT (((UINTN)String & BIT0) == 0);
 
   //
@@ -892,12 +895,14 @@ StrHexToUintnS (
   //
   // Ignore leading Zeros after the spaces
   //
+
+  FoundLeadingZero = *String == L'0';
   while (*String == L'0') {
     String++;
   }
 
   if (CharToUpper (*String) == L'X') {
-    if (*(String - 1) != L'0') {
+    if (!FoundLeadingZero) {
       *Data = 0;
       return RETURN_SUCCESS;
     }
@@ -992,6 +997,9 @@ StrHexToUint64S (
   OUT       UINT64  *Data
   )
 {
+  BOOLEAN  FoundLeadingZero;
+
+  FoundLeadingZero = FALSE;
   ASSERT (((UINTN)String & BIT0) == 0);
 
   //
@@ -1021,12 +1029,13 @@ StrHexToUint64S (
   //
   // Ignore leading Zeros after the spaces
   //
+  FoundLeadingZero = *String == L'0';
   while (*String == L'0') {
     String++;
   }
 
   if (CharToUpper (*String) == L'X') {
-    if (*(String - 1) != L'0') {
+    if (!FoundLeadingZero) {
       *Data = 0;
       return RETURN_SUCCESS;
     }
@@ -2393,6 +2402,9 @@ AsciiStrHexToUintnS (
   OUT       UINTN  *Data
   )
 {
+  BOOLEAN  FoundLeadingZero;
+
+  FoundLeadingZero = FALSE;
   //
   // 1. Neither String nor Data shall be a null pointer.
   //
@@ -2420,12 +2432,13 @@ AsciiStrHexToUintnS (
   //
   // Ignore leading Zeros after the spaces
   //
+  FoundLeadingZero = *String == '0';
   while (*String == '0') {
     String++;
   }
 
   if (AsciiCharToUpper (*String) == 'X') {
-    if (*(String - 1) != '0') {
+    if (!FoundLeadingZero) {
       *Data = 0;
       return RETURN_SUCCESS;
     }
@@ -2517,6 +2530,9 @@ AsciiStrHexToUint64S (
   OUT       UINT64  *Data
   )
 {
+  BOOLEAN  FoundLeadingZero;
+
+  FoundLeadingZero = FALSE;
   //
   // 1. Neither String nor Data shall be a null pointer.
   //
@@ -2544,12 +2560,13 @@ AsciiStrHexToUint64S (
   //
   // Ignore leading Zeros after the spaces
   //
+  FoundLeadingZero = *String == '0';
   while (*String == '0') {
     String++;
   }
 
   if (AsciiCharToUpper (*String) == 'X') {
-    if (*(String - 1) != '0') {
+    if (!FoundLeadingZero) {
       *Data = 0;
       return RETURN_SUCCESS;
     }


### PR DESCRIPTION
There was a OOB access in *StrHexTo* functions, when passed strings like "XDEADBEEF".

OpenCore folks established an ASAN-equipped project to fuzz Ext4Dxe, which was able to catch these (mostly harmless) issues.

Cc: Vitaly Cheptsov <vit9696@protonmail.com>
Cc: Marvin H?user <mhaeuser@posteo.de>
Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Zhiguang Liu <zhiguang.liu@intel.com>
Signed-off-by: Pedro Falcato <pedro.falcato@gmail.com>
Acked-by: Michael D Kinney <michael.d.kinney@intel.com>
Reviewed-by: Jiewen Yao <Jiewen.yao@Intel.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>