### PR TITLE
PrmPkg/PrmSsdtInstallDxe: Update PRMT Device CID to PNP0C02.

### DIFF
--- a/PrmPkg/PrmSsdtInstallDxe/Prm.asl
+++ b/PrmPkg/PrmSsdtInstallDxe/Prm.asl
@@ -22,7 +22,7 @@ DefinitionBlock (
         Device (PRMT)
         {
             Name (_HID, "80860223")
-            Name (_CID, "80860223")
+            Name (_CID, EisaId ("PNP0C02"))
             Name (_DDN, "PRM Test Device")
 
             //PRM operation region format


### PR DESCRIPTION
REF:https://bugzilla.tianocore.org/show_bug.cgi?id=4141

PRMT device is an unknown device in Device Manager if there is no Windows Driver installed for it. It will cause WHQL Signed Driver test failure.
To complete WHQL certification, update PRMT Device CID to PNP0C02. In this way, PRMT Device will be a Motherboard Resources when no real driver is loaded (default), but will be shown as the actual device name when a legitimate Windows Driver is loaded.

Cc: Michael Kubacki <michael.kubacki@microsoft.com>
Cc: Nate DeSimone <nathaniel.l.desimone@intel.com>
Cc: Ankit Sinha <ankit.sinha@intel.com>
Signed-off-by: Wei6 Xu <wei6.xu@intel.com>