### PR TITLE
CryptoPkg: Sha1 functions causing build errors

### DIFF
--- a/CryptoPkg/Library/BaseHashApiLib/BaseHashApiLib.c
+++ b/CryptoPkg/Library/BaseHashApiLib/BaseHashApiLib.c
@@ -6,7 +6,7 @@
   This API, when called, will calculate the Hash using the
   hashing algorithm specified by PcdHashApiLibPolicy.
 
-  Copyright (c) 2020, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2020-2022, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -33,9 +33,11 @@ HashApiGetContextSize (
   )
 {
   switch (PcdGet32 (PcdHashApiLibPolicy)) {
+ #ifndef DISABLE_SHA1_DEPRECATED_INTERFACES
     case HASH_ALG_SHA1:
       return Sha1GetContextSize ();
       break;
+ #endif
 
     case HASH_ALG_SHA256:
       return Sha256GetContextSize ();
@@ -75,9 +77,11 @@ HashApiInit (
   )
 {
   switch (PcdGet32 (PcdHashApiLibPolicy)) {
+ #ifndef DISABLE_SHA1_DEPRECATED_INTERFACES
     case HASH_ALG_SHA1:
       return Sha1Init (HashContext);
       break;
+ #endif
 
     case HASH_ALG_SHA256:
       return Sha256Init (HashContext);
@@ -119,9 +123,11 @@ HashApiDuplicate (
   )
 {
   switch (PcdGet32 (PcdHashApiLibPolicy)) {
+ #ifndef DISABLE_SHA1_DEPRECATED_INTERFACES
     case HASH_ALG_SHA1:
       return Sha1Duplicate (HashContext, NewHashContext);
       break;
+ #endif
 
     case HASH_ALG_SHA256:
       return Sha256Duplicate (HashContext, NewHashContext);
@@ -165,9 +171,11 @@ HashApiUpdate (
   )
 {
   switch (PcdGet32 (PcdHashApiLibPolicy)) {
+ #ifndef DISABLE_SHA1_DEPRECATED_INTERFACES
     case HASH_ALG_SHA1:
       return Sha1Update (HashContext, DataToHash, DataToHashLen);
       break;
+ #endif
 
     case HASH_ALG_SHA256:
       return Sha256Update (HashContext, DataToHash, DataToHashLen);
@@ -209,9 +217,11 @@ HashApiFinal (
   )
 {
   switch (PcdGet32 (PcdHashApiLibPolicy)) {
+ #ifndef DISABLE_SHA1_DEPRECATED_INTERFACES
     case HASH_ALG_SHA1:
       return Sha1Final (HashContext, Digest);
       break;
+ #endif
 
     case HASH_ALG_SHA256:
       return Sha256Final (HashContext, Digest);
@@ -255,9 +265,11 @@ HashApiHashAll (
   )
 {
   switch (PcdGet32 (PcdHashApiLibPolicy)) {
+ #ifndef DISABLE_SHA1_DEPRECATED_INTERFACES
     case HASH_ALG_SHA1:
       return Sha1HashAll (DataToHash, DataToHashLen, Digest);
       break;
+ #endif
 
     case HASH_ALG_SHA256:
       return Sha256HashAll (DataToHash, DataToHashLen, Digest);


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3991

Fix build issue when DiSABLE_SHA1_DEPRECATED_INTERFACES is defined. Percolate the #ifndef DiSABLE_SHA1_DEPRECATED_INTERFACES to all the Sha1 functions.

Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Xiaoyu Lu <xiaoyux.lu@intel.com>
Cc: Guomin Jiang <guomin.jiang@intel.com>
Cc: Nishant C Mistry <nishant.c.mistry@intel.com>
Signed-off-by: Jian J Wang <jian.j.wang@intel.com>
Signed-off-by: Nishant C Mistry <nishant.c.mistry@intel.com>
Signed-off-by: Judah Vang <judah.vang@intel.com>