### PR TITLE
pip-requirements.txt: Update edk2-pytool-library to 0.12.0

### DIFF
--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -12,7 +12,7 @@
 # https://www.python.org/dev/peps/pep-0440/#version-specifiers
 ##
 
-edk2-pytool-library==0.11.6
+edk2-pytool-library==0.12.0
 edk2-pytool-extensions~=0.19.1
 edk2-basetools==0.1.39
 antlr4-python3-runtime==4.7.1


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4146

Update edk2-pytool-library to version 0.12.0 that adds support for the environment variable PYTOOL_TEMPORARILY_IGNORE_NESTED_EDK_PACKAGES that can be set to true to ignore nested packages instead of breaking the build with an exception. Nested packages are not allowed by the edk2 specifications.  This environment variable allows pytools to run with reduced functionality if nested packages are present giving downstream consumers of edk2 that use pytools time to resolve the use of nested packages and restore all features of pytools.

Cc: Sean Brogan <sean.brogan@microsoft.com>
Cc: Michael Kubacki <mikuback@linux.microsoft.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Andrew Fish <afish@apple.com>
Cc: Leif Lindholm <quic_llindhol@quicinc.com>
Signed-off-by: Michael D Kinney <michael.d.kinney@intel.com>