### PR TITLE
.github/dependabot.yml: Enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,34 @@
+## @file
+# Dependabot configuration file to enable GitHub services for managing and updating
+# dependencies.
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+##
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "pip"
+    reviewers:
+      - "makubacki"
+      - "mdkinney"
+      - "spbrogan"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "GitHub Action"
+    reviewers:
+      - "makubacki"
+      - "mdkinney"
+      - "spbrogan"


### PR DESCRIPTION
Enables dependabot in this repo so we can better alerted when
dependency updates are available.

This GitHub action will automatically create pull requests and
summarize the dependency details. Because it is a pull request,
the CI system will validate the dependency update in the pull
request.

Configures dependabot for:
1. PIP module updates
2. Submodule updates
3. GitHub action updates

The maintainers/reviewers of the .github directory were added as
pull request reviewers so they can be notified the pull request
is available.

    Note to Maintainers:
      After this change is committed, PRs from dependabot will be
      automatically created in the edk2 repo.  Never set the 'push' label
      directly on these PRs. If a dependency identified by dependedabot
      looks like one that should be updated in the edk2 repo, then copy
      the PR generated by dependabot to your personal fork and update the
      commit message to follow the edk2 commit message requirements and
      send as a normal code review.

Cc: Sean Brogan <sean.brogan@microsoft.com>
Cc: Michael D Kinney <michael.d.kinney@intel.com>
Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>
Reviewed-by: Michael D Kinney <michael.d.kinney@intel.com>
Reviewed-by: Sean Brogan <sean.brogan@microsoft.com>