### PR TITLE
ArmPkg/ArmTrngLib: Fix incorrect GUID reference in DEBUG() output

### DIFF
--- a/ArmPkg/Library/ArmTrngLib/ArmTrngLib.c
+++ b/ArmPkg/Library/ArmTrngLib/ArmTrngLib.c
@@ -375,7 +375,7 @@ ArmTrngLibConstructor (
     "FW-TRNG: Version %d.%d, GUID {%g}\n",
     MajorRev,
     MinorRev,
-    Guid
+    &Guid
     ));
 
   DEBUG_CODE_END ();


### PR DESCRIPTION
ArmTrngLib crashes when run in DEBUG mode due to the fact that it passed the [truncated] GUID value to a DEBUG() print statement instead of a pointer to the GUID which is what the %g conversion expects.

Signed-off-by: Ard Biesheuvel <ardb@kernel.org>
Reviewed-by: Sami Mujawar <sami.mujawar@arm.com>