### PR TITLE
pip-requirements.txt: Update to edk2-pytool-library 0.12.1

### DIFF
--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -12,7 +12,7 @@
 # https://www.python.org/dev/peps/pep-0440/#version-specifiers
 ##
 
-edk2-pytool-library==0.12.0
+edk2-pytool-library==0.12.1
 edk2-pytool-extensions~=0.19.1
 edk2-basetools==0.1.39
 antlr4-python3-runtime==4.7.1


### PR DESCRIPTION
Updates edk2-pytool-library to pick up a minor bug fix release:

0.12.0 to 0.12.1 changes:

  - path_utilities.py: Prevent path case modification in
    GetContainingModules()

That change prevents the case of paths from being set to lower case
when returned from the function to avoid impacting case-sensitive
callers.

Release notes:

https://github.com/tianocore/edk2-pytool-library/releases/tag/v0.12.1

Cc: Sean Brogan <sean.brogan@microsoft.com>
Cc: Michael Kubacki <mikuback@linux.microsoft.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Andrew Fish <afish@apple.com>
Cc: Leif Lindholm <quic_llindhol@quicinc.com>
Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>