### PR TITLE
Update pytool pip versions

### DIFF
--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -12,7 +12,7 @@
 # https://www.python.org/dev/peps/pep-0440/#version-specifiers
 ##
 
-edk2-pytool-library==0.12.0
+edk2-pytool-library==0.12.1
 edk2-pytool-extensions~=0.19.1
 edk2-basetools==0.1.39
 antlr4-python3-runtime==4.7.1

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -13,6 +13,6 @@
 ##
 
 edk2-pytool-library==0.12.1
-edk2-pytool-extensions~=0.19.1
+edk2-pytool-extensions~=0.20.0
 edk2-basetools==0.1.39
 antlr4-python3-runtime==4.7.1


### PR DESCRIPTION
**Patch 1:**

    pip-requirements.txt: Update to edk2-pytool-library 0.12.1

    Updates edk2-pytool-library to pick up a minor bug fix release:

    0.12.0 to 0.12.1 changes:

      - path_utilities.py: Prevent path case modification in
        GetContainingModules()

    That change prevents the case of paths from being set to lower case
    when returned from the function to avoid impacting case-sensitive
    callers.

    Release notes:

    https://github.com/tianocore/edk2-pytool-library/releases/tag/v0.12.1

**Patch 2:**

    pip-requirements.txt: Update to edk2-pytool-extensions 0.20.0

    Updates edk2-pytool-extensions to pick up a major version release:

    0.19.1 to 0.20.0 changes:

    - .vscode/settings.json: Enable flake8 linting
    - Add Pydocstyle
    - Move dependabot.yml location
    - Fix typos in robot files
    - Pydocstyle Updates
    - Plugin Loader Updates
    - edk2_stuart_pr_eval: Improve robustness of path comparisons
    - edk2_pr_eval.py: Build all packages on file change outside package
    - Allow build wrappers