### PR TITLE
MdeModulePkg: Disable PciDegrade support for LoongArch64

### DIFF
--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -917,7 +917,7 @@
   # @Prompt Enable process non-reset capsule image at runtime.
   gEfiMdeModulePkgTokenSpaceGuid.PcdSupportProcessCapsuleAtRuntime|FALSE|BOOLEAN|0x00010079
 
-[PcdsFeatureFlag.IA32, PcdsFeatureFlag.ARM, PcdsFeatureFlag.AARCH64]
+[PcdsFeatureFlag.IA32, PcdsFeatureFlag.ARM, PcdsFeatureFlag.AARCH64, PcdsFeatureFlag.LOONGARCH64]
   gEfiMdeModulePkgTokenSpaceGuid.PcdPciDegradeResourceForOptionRom|FALSE|BOOLEAN|0x0001003a
 
 [PcdsFeatureFlag.IA32, PcdsFeatureFlag.X64]


### PR DESCRIPTION
LoongArch64: Pcie devices that come with OPROM may require large Mem Space,
and downgrading all 64 Bit Bars may result in insufficient space.

REF:https://bugzilla.tianocore.org/show_bug.cgi?id=4157

Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Ruiyu Ni <ruiyu.ni@intel.com>
Signed-off-by: Dongyan Qian <qiandongyan@loongson.cn>
Co-authored-by: Bo Zhu <zhubo@loongson.cn>
Co-authored-by: Chao Li <lichao@loongson.cn>