### PR TITLE
ArmPkg/ArmTrngLib: Remove ASSERT in GetArmTrngVersion()

### DIFF
--- a/ArmPkg/Library/ArmTrngLib/ArmTrngLib.c
+++ b/ArmPkg/Library/ArmTrngLib/ArmTrngLib.c
@@ -344,7 +344,6 @@ ArmTrngLibConstructor (
 
   Status = GetArmTrngVersion (&MajorRev, &MinorRev);
   if (RETURN_ERROR (Status)) {
-    ASSERT_RETURN_ERROR (Status);
     goto ErrorHandler;
   }
 

--- a/SecurityPkg/RandomNumberGenerator/RngDxe/ArmRngDxe.c
+++ b/SecurityPkg/RandomNumberGenerator/RngDxe/ArmRngDxe.c
@@ -76,7 +76,6 @@ RngGetRNG (
   )
 {
   EFI_STATUS  Status;
-  UINTN       Index;
 
   if ((This == NULL) || (RNGValueLength == 0) || (RNGValue == NULL)) {
     return EFI_INVALID_PARAMETER;
@@ -86,21 +85,13 @@ RngGetRNG (
     //
     // Use the default RNG algorithm if RNGAlgorithm is NULL.
     //
-    for (Index = 0; Index < mAvailableAlgoArrayCount; Index++) {
-      if (!IsZeroGuid (&mAvailableAlgoArray[Index])) {
-        RNGAlgorithm = &mAvailableAlgoArray[Index];
-        goto FoundAlgo;
-      }
-    }
-
-    if (Index == mAvailableAlgoArrayCount) {
-      // No algorithm available.
-      ASSERT (Index != mAvailableAlgoArrayCount);
+    if (mAvailableAlgoArrayCount != 0) {
+      RNGAlgorithm = &mAvailableAlgoArray[0];
+    } else {
       return EFI_DEVICE_ERROR;
     }
   }
 
-FoundAlgo:
   if (CompareGuid (RNGAlgorithm, PcdGetPtr (PcdCpuRngSupportedAlgorithm))) {
     Status = RngGetBytes (RNGValueLength, RNGValue);
     return Status;

--- a/SecurityPkg/RandomNumberGenerator/RngDxe/RngDxe.c
+++ b/SecurityPkg/RandomNumberGenerator/RngDxe/RngDxe.c
@@ -21,6 +21,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #include <Library/BaseLib.h>
 #include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
 #include <Library/UefiBootServicesTableLib.h>
 #include <Library/RngLib.h>
 #include <Protocol/Rng.h>
@@ -80,7 +81,12 @@ RngDriverEntry (
   //
   // Get the list of available algorithm.
   //
-  return GetAvailableAlgorithms ();
+  Status = GetAvailableAlgorithms ();
+  if (mAvailableAlgoArrayCount == 0) {
+    DEBUG ((DEBUG_WARN, "No Rng algorithm found in RngDxe.\n"));
+  }
+
+  return Status;
 }
 
 /**


### PR DESCRIPTION
BZ: https://bugzilla.tianocore.org/show_bug.cgi?id=4150

GetArmTrngVersion() is used to check the presence of an Arm Trng. If not found, an ASSERT prevents from booting in DEBUG builds.
Remove this ASSERT.

Reported-by: Sami Mujawar <sami.mujawar@arm.com>
Signed-off-by: Pierre Gondois <Pierre.Gondois@arm.com>