### PR TITLE
UefiPayloadPkg: The Universal Payload Information section is not alig…

### DIFF
--- a/UefiPayloadPkg/UniversalPayloadBuild.py
+++ b/UefiPayloadPkg/UniversalPayloadBuild.py
@@ -31,7 +31,7 @@ class UPLD_INFO_HEADER(LittleEndianStructure):
     def __init__(self):
         self.Identifier     =  b'PLDH'
         self.HeaderLength   = sizeof(UPLD_INFO_HEADER)
-        self.SpecRevision   = 0x0007
+        self.SpecRevision   = 0x0009
         self.Revision       = 0x0000010105
         self.ImageId        = b'UEFI'
         self.ProducerId     = b'INTEL'
@@ -133,7 +133,7 @@ def BuildUniversalPayload(Args, MacroList):
                        FvOutputDir,
                        EntryOutputDir
                        )
-    set_section    = '"{}" -I {} -O {} --set-section-alignment .upld.upld_info=16 --set-section-alignment .upld.uefi_fv=16 {}'.format (
+    set_section    = '"{}" -I {} -O {} --set-section-alignment .upld_info=4 --set-section-alignment .upld.uefi_fv=16 {}'.format (
                        LlvmObjcopyPath,
                        ObjCopyFlag,
                        ObjCopyFlag,


### PR DESCRIPTION
…ned at 4-byte boundary

REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4153

1.Upgrade spec revision to 0.9
2.Align .upld_info with 4-byte boundary by spec

Cc: Guo Dong <guo.dong@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Cc: James Lu <james.lu@intel.com>
Cc: Gua Guo <gua.guo@intel.com>
Signed-off-by: VictorX Hsu <victorx.hsu@intel.com>

Signed-off-by: VictorX Hsu <victorx.hsu@intel.com>