### PR TITLE
ArmPkg/ArmTrngLib: Remove ASSERT in GetArmTrngVersion()

### DIFF
--- a/ArmPkg/Library/ArmTrngLib/ArmTrngLib.c
+++ b/ArmPkg/Library/ArmTrngLib/ArmTrngLib.c
@@ -344,7 +344,6 @@ ArmTrngLibConstructor (
 
   Status = GetArmTrngVersion (&MajorRev, &MinorRev);
   if (RETURN_ERROR (Status)) {
-    ASSERT_RETURN_ERROR (Status);
     goto ErrorHandler;
   }
 


### PR DESCRIPTION
BZ: https://bugzilla.tianocore.org/show_bug.cgi?id=4150

GetArmTrngVersion() is used to check the presence of an Arm Trng. If not found, an ASSERT prevents from booting in DEBUG builds.
Remove this ASSERT.

Reported-by: Sami Mujawar <sami.mujawar@arm.com>
Signed-off-by: Pierre Gondois <Pierre.Gondois@arm.com>
Acked-by: Ard Biesheuvel <ardb@kernel.org>
Reviewed-by: Sami Mujawar <sami.mujawar@arm.com>