### PR TITLE
ShellPkg: Display SMBIOS Type38 fields in smbiosview command in formatted manner

### DIFF
--- a/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/PrintInfo.c
+++ b/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/PrintInfo.c
@@ -1177,10 +1177,31 @@ SmbiosPrintStructure (
     //
     case 38:
       DisplayIPMIDIBMCInterfaceType (Struct->Type38->InterfaceType, Option);
-      PRINT_STRUCT_VALUE_H (Struct, Type38, IPMISpecificationRevision);
+
+      ShellPrintHiiEx (
+        -1,
+        -1,
+        NULL,
+        STRING_TOKEN (STR_SMBIOSVIEW_PRINTINFO_IPMI_SPECIFICATION_REVISION),
+        gShellDebug1HiiHandle,
+        RShiftU64 ((UINT64)Struct->Type38->IPMISpecificationRevision, 4), \
+        Struct->Type38->IPMISpecificationRevision & 0x0F
+        );
+
       PRINT_STRUCT_VALUE_H (Struct, Type38, I2CSlaveAddress);
-      PRINT_STRUCT_VALUE_H (Struct, Type38, NVStorageDeviceAddress);
-      PRINT_STRUCT_VALUE_LH (Struct, Type38, BaseAddress);
+
+      if (Struct->Type38->NVStorageDeviceAddress == 0xFF) {
+        ShellPrintHiiEx (-1, -1, NULL, STRING_TOKEN (STR_SMBIOSVIEW_PRINTINFO_NV_STORAGE_DEVICE_NOT_PRESENT), gShellDebug1HiiHandle);
+      } else {
+        PRINT_STRUCT_VALUE_H (Struct, Type38, NVStorageDeviceAddress);
+      }
+
+      if (Struct->Type38->InterfaceType == IPMIDeviceInfoInterfaceTypeSSIF) {
+        ShellPrintHiiEx (-1, -1, NULL, STRING_TOKEN (STR_SMBIOSVIEW_PRINTINFO_BASE_ADDRESS), gShellDebug1HiiHandle, RShiftU64 ((UINT64)Struct->Type38->BaseAddress, 1));
+      } else {
+        PRINT_STRUCT_VALUE_LH (Struct, Type38, BaseAddress);
+      }
+
       break;
 
     //

--- a/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/SmbiosViewStrings.uni
+++ b/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/SmbiosViewStrings.uni
@@ -506,4 +506,7 @@
 #string STR_SMBIOSVIEW_PRINTINFO_TPM_DEVICE_CONFIG_PLAT_SW      #language en-US "Family configurable via platform software support\r\n"
 #string STR_SMBIOSVIEW_PRINTINFO_TPM_DEVICE_CONFIG_OEM          #language en-US "Family configurable via OEM proprietary mechanism\r\n"
 #string STR_SMBIOSVIEW_PRINTINFO_BITS_06_63                     #language en-US "Bits 6:63 are reserved\r\n"
+#string STR_SMBIOSVIEW_PRINTINFO_IPMI_SPECIFICATION_REVISION    #language en-US "IPMISpecificationRevision: %d.%d\n"
+#string STR_SMBIOSVIEW_PRINTINFO_NV_STORAGE_DEVICE_NOT_PRESENT  #language en-US "NVStorageDevice: Not Present\n"
+#string STR_SMBIOSVIEW_PRINTINFO_BASE_ADDRESS                   #language en-US "BaseAddress: 0x%x\n"
 


### PR DESCRIPTION
In smbiosview command in shell, below are the fields of SMBIOS Type38 table which can be displayed in formatted manner.
1. Base Address
1. IPMI Specification Version.
2. NV Storage Device Address. 
Base Address:
As per spec, the value in Base Address field of SMBIOS type38 table should be right shifted by 1 if the interface type is SSIF. IPMI Specification Version:
If the value in IPMI Specification Version field is 15H, it should be displayed 1.5.
NV Storage Device Address:
If the value in NV Storage Device Address field is 0xFF, it should be displayed as "No storage device is Present".

Cc: Vasudevan Sambandan <vasudevans@ami.com>
Cc: Sundaresan Selvaraj <sundaresans@ami.com>
Cc: Gayathri Thunuguntla <gayathrit@ami.com>
Signed-off-by: Prakash K <prakashk@ami.com>