### PR TITLE
OvmfPkg/PlatformInitLib: Add check to NvVarStoreFV HeaderLength

### DIFF
--- a/OvmfPkg/Library/PlatformInitLib/Platform.c
+++ b/OvmfPkg/Library/PlatformInitLib/Platform.c
@@ -653,6 +653,7 @@ PlatformValidateNvVarStore (
       (!CompareGuid (&FvHdrGUID, &NvVarStoreFvHeader->FileSystemGuid)) ||
       (NvVarStoreFvHeader->Signature != EFI_FVH_SIGNATURE) ||
       (NvVarStoreFvHeader->Attributes != 0x4feff) ||
+      ((NvVarStoreFvHeader->HeaderLength & 0x01) != 0) ||
       (NvVarStoreFvHeader->Revision != EFI_FVH_REVISION) ||
       (NvVarStoreFvHeader->FvLength != NvVarStoreSize)
       )


### PR DESCRIPTION
Add check to NvVarStoreFV HeaderLength that the length cannot be an odd number.

Cc: Erdem Aktas <erdemaktas@google.com>
Cc: James Bottomley <jejb@linux.ibm.com>
Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Gerd Hoffmann <kraxel@redhat.com>
Cc: Tom Lendacky <thomas.lendacky@amd.com>
Signed-off-by: Min Xu <min.m.xu@intel.com>