### PR TITLE
[Draft] MdeModulePkg: TerminalDxe: set xterm resolution on mode change

### DIFF
--- a/ArmVirtPkg/ArmVirtQemu.dsc
+++ b/ArmVirtPkg/ArmVirtQemu.dsc
@@ -299,6 +299,8 @@
   gEfiSecurityPkgTokenSpaceGuid.PcdTpmBaseAddress|0x0
 !endif
 
+  gEfiMdeModulePkgTokenSpaceGuid.PcdResizeXterm|FALSE
+
 [PcdsDynamicHii]
   gArmVirtTokenSpaceGuid.PcdForceNoAcpi|L"ForceNoAcpi"|gArmVirtVariableGuid|0x0|FALSE|NV,BS
 
@@ -413,7 +415,10 @@
   MdeModulePkg/Universal/Console/ConPlatformDxe/ConPlatformDxe.inf
   MdeModulePkg/Universal/Console/ConSplitterDxe/ConSplitterDxe.inf
   MdeModulePkg/Universal/Console/GraphicsConsoleDxe/GraphicsConsoleDxe.inf
-  MdeModulePkg/Universal/Console/TerminalDxe/TerminalDxe.inf
+  MdeModulePkg/Universal/Console/TerminalDxe/TerminalDxe.inf {
+    <LibraryClasses>
+      NULL|ArmVirtPkg/Library/TerminalPcdProducerLib/TerminalPcdProducerLib.inf
+  }
   MdeModulePkg/Universal/SerialDxe/SerialDxe.inf
 
   MdeModulePkg/Universal/HiiDatabaseDxe/HiiDatabaseDxe.inf

--- a/ArmVirtPkg/Library/TerminalPcdProducerLib/TerminalPcdProducerLib.c
+++ b/ArmVirtPkg/Library/TerminalPcdProducerLib/TerminalPcdProducerLib.c
@@ -1,0 +1,41 @@
+/** @file
+
+   Copyright (c) 2015-2020, Red Hat, Inc.
+   Copyright (c) 2014, Linaro Ltd. All rights reserved.<BR>
+
+   SPDX-License-Identifier: BSD-2-Clause-Patent
+
+   Plugin library for setting up dynamic PCDs for TerminalDxe, from fw_cfg
+
+**/
+
+#include <Library/DebugLib.h>
+#include <Library/PcdLib.h>
+#include <Library/QemuFwCfgSimpleParserLib.h>
+
+#define UPDATE_BOOLEAN_PCD_FROM_FW_CFG(TokenName)                             \
+          do {                                                                \
+            BOOLEAN       Setting;                                            \
+            RETURN_STATUS PcdStatus;                                          \
+                                                                              \
+            if (!RETURN_ERROR (QemuFwCfgParseBool (                           \
+                    "opt/org.tianocore.edk2.aavmf/" #TokenName, &Setting))) { \
+              PcdStatus = PcdSetBoolS (TokenName, Setting);                   \
+              ASSERT_RETURN_ERROR (PcdStatus);                                \
+            }                                                                 \
+          } while (0)
+
+/**
+   Update PCD configuration variable from firmware config.
+
+   @return  Always returns RETURN_SUCCESS
+**/
+RETURN_STATUS
+EFIAPI
+TerminalPcdProducerLibConstructor (
+  VOID
+  )
+{
+  UPDATE_BOOLEAN_PCD_FROM_FW_CFG (PcdResizeXterm);
+  return RETURN_SUCCESS;
+}

--- a/ArmVirtPkg/Library/TerminalPcdProducerLib/TerminalPcdProducerLib.inf
+++ b/ArmVirtPkg/Library/TerminalPcdProducerLib/TerminalPcdProducerLib.inf
@@ -1,0 +1,33 @@
+## @file
+#  Plugin library for setting up dynamic PCDs for TerminalDxe, from fw_cfg
+#
+#  Copyright (c) 2015-2020, Red Hat, Inc.
+#  Copyright (c) 2014, Linaro Ltd. All rights reserved.<BR>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = TerminalPcdProducerLib
+  FILE_GUID                      = 4a0c5ed7-8c42-4c01-8f4c-7bf258316a96
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = NULL
+  CONSTRUCTOR                    = TerminalPcdProducerLibConstructor
+
+[Sources]
+  TerminalPcdProducerLib.c
+
+[Packages]
+  MdeModulePkg/MdeModulePkg.dec
+  MdePkg/MdePkg.dec
+  OvmfPkg/OvmfPkg.dec
+
+[LibraryClasses]
+  DebugLib
+  PcdLib
+  QemuFwCfgSimpleParserLib
+
+[Pcd]
+  gEfiMdeModulePkgTokenSpaceGuid.PcdResizeXterm ## SOMETIMES_PRODUCES

--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -2102,6 +2102,10 @@
   # @Prompt The shared bit mask when Intel Tdx is enabled.
   gEfiMdeModulePkgTokenSpaceGuid.PcdTdxSharedBitMask|0x0|UINT64|0x10000025
 
+  ## Controls whether TerminalDxe outputs an XTerm resize sequence on terminal
+  #  mode change.
+  gEfiMdeModulePkgTokenSpaceGuid.PcdResizeXterm|FALSE|BOOLEAN|0x00010080
+
 [PcdsPatchableInModule]
   ## Specify memory size with page number for PEI code when
   #  Loading Module at Fixed Address feature is enabled.

--- a/MdeModulePkg/Universal/Console/TerminalDxe/TerminalDxe.inf
+++ b/MdeModulePkg/Universal/Console/TerminalDxe/TerminalDxe.inf
@@ -55,6 +55,7 @@
   DebugLib
   PcdLib
   BaseLib
+  PrintLib
 
 [Guids]
   ## SOMETIMES_PRODUCES ## Variable:L"ConInDev"
@@ -87,6 +88,7 @@
 [Pcd]
   gEfiMdePkgTokenSpaceGuid.PcdDefaultTerminalType           ## SOMETIMES_CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdErrorCodeSetVariable    ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdResizeXterm             ## CONSUMES
 
 # [Event]
 # # Relative timer event set by UnicodeToEfiKey(), used to be one 2 seconds input timeout.

--- a/OvmfPkg/AmdSev/AmdSevX64.dsc
+++ b/OvmfPkg/AmdSev/AmdSevX64.dsc
@@ -475,6 +475,7 @@
 [PcdsDynamicDefault]
   gEfiMdeModulePkgTokenSpaceGuid.PcdEmuVariableNvStoreReserved|0
 
+  gEfiMdeModulePkgTokenSpaceGuid.PcdResizeXterm|FALSE
   gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageVariableBase64|0
   gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwWorkingBase64|0
   gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwSpareBase64|0

--- a/OvmfPkg/CloudHv/CloudHvX64.dsc
+++ b/OvmfPkg/CloudHv/CloudHvX64.dsc
@@ -582,6 +582,7 @@
   #   ($(SMM_REQUIRE) == FALSE)
   gEfiMdeModulePkgTokenSpaceGuid.PcdEmuVariableNvStoreReserved|0
 
+  gEfiMdeModulePkgTokenSpaceGuid.PcdResizeXterm|FALSE
 !if $(SMM_REQUIRE) == FALSE
   gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageVariableBase64|0
   gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwWorkingBase64|0

--- a/OvmfPkg/IntelTdx/IntelTdxX64.dsc
+++ b/OvmfPkg/IntelTdx/IntelTdxX64.dsc
@@ -474,6 +474,7 @@
   #   ($(SMM_REQUIRE) == FALSE)
   gEfiMdeModulePkgTokenSpaceGuid.PcdEmuVariableNvStoreReserved|0
 
+  gEfiMdeModulePkgTokenSpaceGuid.PcdResizeXterm|FALSE
   gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageVariableBase64|0
   gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwWorkingBase64|0
   gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwSpareBase64|0

--- a/OvmfPkg/Microvm/MicrovmX64.dsc
+++ b/OvmfPkg/Microvm/MicrovmX64.dsc
@@ -579,7 +579,7 @@
   # only set when
   #   ($(SMM_REQUIRE) == FALSE)
   gEfiMdeModulePkgTokenSpaceGuid.PcdEmuVariableNvStoreReserved|0
-
+  gEfiMdeModulePkgTokenSpaceGuid.PcdResizeXterm|FALSE
   gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageVariableBase64|0
   gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwWorkingBase64|0
   gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwSpareBase64|0

--- a/OvmfPkg/OvmfPkgIa32.dsc
+++ b/OvmfPkg/OvmfPkgIa32.dsc
@@ -601,6 +601,7 @@
   #   ($(SMM_REQUIRE) == FALSE)
   gEfiMdeModulePkgTokenSpaceGuid.PcdEmuVariableNvStoreReserved|0
 
+  gEfiMdeModulePkgTokenSpaceGuid.PcdResizeXterm|FALSE
 !if $(SMM_REQUIRE) == FALSE
   gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageVariableBase64|0
   gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwWorkingBase64|0

--- a/OvmfPkg/OvmfPkgIa32X64.dsc
+++ b/OvmfPkg/OvmfPkgIa32X64.dsc
@@ -609,6 +609,7 @@
   #   ($(SMM_REQUIRE) == FALSE)
   gEfiMdeModulePkgTokenSpaceGuid.PcdEmuVariableNvStoreReserved|0
 
+  gEfiMdeModulePkgTokenSpaceGuid.PcdResizeXterm|FALSE
 !if $(SMM_REQUIRE) == FALSE
   gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageVariableBase64|0
   gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwWorkingBase64|0

--- a/OvmfPkg/OvmfPkgX64.dsc
+++ b/OvmfPkg/OvmfPkgX64.dsc
@@ -631,6 +631,7 @@
   #   ($(SMM_REQUIRE) == FALSE)
   gEfiMdeModulePkgTokenSpaceGuid.PcdEmuVariableNvStoreReserved|0
 
+  gEfiMdeModulePkgTokenSpaceGuid.PcdResizeXterm|FALSE
 !if $(SMM_REQUIRE) == FALSE
   gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageVariableBase64|0
   gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwWorkingBase64|0

--- a/OvmfPkg/PlatformPei/Platform.c
+++ b/OvmfPkg/PlatformPei/Platform.c
@@ -41,6 +41,18 @@
 
 #include "Platform.h"
 
+#define UPDATE_BOOLEAN_PCD_FROM_FW_CFG(TokenName)                   \
+          do {                                                      \
+            BOOLEAN       Setting;                                  \
+            RETURN_STATUS PcdStatus;                                \
+                                                                    \
+            if (!RETURN_ERROR (QemuFwCfgParseBool (                 \
+                              "opt/ovmf/" #TokenName, &Setting))) { \
+              PcdStatus = PcdSetBoolS (TokenName, Setting);         \
+              ASSERT_RETURN_ERROR (PcdStatus);                      \
+            }                                                       \
+          } while (0)
+
 EFI_HOB_PLATFORM_INFO  mPlatformInfoHob = { 0 };
 
 EFI_PEI_PPI_DESCRIPTOR  mPpiBootMode[] = {
@@ -376,6 +388,7 @@ InitializePlatform (
     MemTypeInfoInitialization ();
     MemMapInitialization (&mPlatformInfoHob);
     NoexecDxeInitialization ();
+    UPDATE_BOOLEAN_PCD_FROM_FW_CFG (PcdResizeXterm);
   }
 
   InstallClearCacheCallback ();

--- a/OvmfPkg/PlatformPei/PlatformPei.inf
+++ b/OvmfPkg/PlatformPei/PlatformPei.inf
@@ -99,6 +99,7 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwSpareSize
   gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageVariableSize
   gEfiMdeModulePkgTokenSpaceGuid.PcdEmuVariableNvStoreReserved
+  gEfiMdeModulePkgTokenSpaceGuid.PcdResizeXterm
   gEfiMdeModulePkgTokenSpaceGuid.PcdDxeIplSwitchToLongMode
   gEfiMdeModulePkgTokenSpaceGuid.PcdUse1GPageTable
   gEfiMdeModulePkgTokenSpaceGuid.PcdSetNxForStack


### PR DESCRIPTION
Allow TerminalDxe outputs an XTerm resize sequence on terminal mode change
Reference: <http://rtfm.etla.org/xterm/ctlseq.html>

Signed-off-by: Laszlo Ersek <lersek@redhat.com>

Pawel Polawski: Updated commit message for re-submission

Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>

Signed-off-by: Paweł Poławski <ppolawsk@redhat.com>