### PR TITLE
ShellPkg/SmbiosView: Update ProcessorUpgradeTable

### DIFF
--- a/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/QueryTable.c
+++ b/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/QueryTable.c
@@ -601,6 +601,42 @@ TABLE_ITEM  ProcessorUpgradeTable[] = {
   {
     0x3F,
     L"Socket LGA4677"
+  },
+  {
+    0x40,
+    L"Socket LGA1700"
+  },
+  {
+    0x41,
+    L"Socket BGA1744"
+  },
+  {
+    0x42,
+    L"Socket BGA1781"
+  },
+  {
+    0x43,
+    L"Socket BGA1211"
+  },
+  {
+    0x44,
+    L"Socket BGA2422"
+  },
+  {
+    0x45,
+    L"Socket LGA1211"
+  },
+  {
+    0x46,
+    L"Socket LGA2422"
+  },
+  {
+    0x47,
+    L"Socket LGA5773"
+  },
+  {
+    0x48,
+    L"Socket BGA5773"
   }
 };
 


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4156

Refer to the latest SMBIOS v3.6, SMBIOS Socket not completely defined.

SMBIOS v3.6:
https://www.dmtf.org/sites/default/files/standards/documents/ DSP0134_3.6.0.pdf

Signed-off-by: JuX Zhang <jux.zhang@intel.com>
Cc: Zhichao Gao <zhichao.gao@intel.com>
Cc: Jiaxin Wu <jiaxin.wu@intel.com>
Reviewed-by: Zhichao Gao <zhichao.gao@intel.com>
Reviewed-by: Jiaxin Wu <jiaxin.wu@intel.com>