### PR TITLE
BaseSynchronizationLib: Fix RISC-V helper name

### DIFF
--- a/MdePkg/Library/BaseSynchronizationLib/BaseSynchronizationLib.inf
+++ b/MdePkg/Library/BaseSynchronizationLib/BaseSynchronizationLib.inf
@@ -81,7 +81,7 @@
 
 [Sources.RISCV64]
   Synchronization.c
-  RiscV64/Synchronization.S
+  RiscV64/Synchronization.S     | GCC
 
 [Sources.LOONGARCH64]
   Synchronization.c

--- a/MdePkg/Library/BaseSynchronizationLib/RiscV64/Synchronization.S
+++ b/MdePkg/Library/BaseSynchronizationLib/RiscV64/Synchronization.S
@@ -36,8 +36,6 @@ exit:
     mv    a0, a3
     ret
 
-.global ASM_PFX(InternalSyncCompareExchange64)
-
 //
 // Compare and xchange a 64-bit value.
 //
@@ -45,7 +43,7 @@ exit:
 // @param a1 : Compare value.
 // @param a2 : Exchange value.
 //
-ASM_PFX (SyncCompareExchange64):
+ASM_PFX (InternalSyncCompareExchange64):
     lr.d  a3, (a0)       // Load the value from a0 and make
                          // the reservation of address.
     bne   a3, a1, exit


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4143

Fix the name of InternalSyncCompareExchange64() function.

Signed-off-by: Sunil V L <sunilvl@ventanamicro.com>
Reported-by: Zhihao Li <zhihao.li@intel.com>
Tested-by: Zhihao Li <zhihao.li@intel.com>

Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Zhiguang Liu <zhiguang.liu@intel.com>
Cc: Daniel Schaefer <git@danielschaefer.me>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>