### PR TITLE
EmbeddedPkg/MetronomeDxe: Update TickPeriod doc to remove mention of …

### DIFF
--- a/EmbeddedPkg/MetronomeDxe/Metronome.c
+++ b/EmbeddedPkg/MetronomeDxe/Metronome.c
@@ -43,10 +43,9 @@ WaitForTick (
 
   @param TickPeriod
   The period of platform's known time source in 100 nS units.
-  This value on any platform must be at least 10 uS, and must not
-  exceed 200 uS.  The value in this field is a constant that must
-  not be modified after the Metronome architectural protocol is
-  installed.  All consumers must treat this as a read-only field.
+  This value on any platform must not exceed 200 uS.  The value in this field
+  is a constant that must not be modified after the Metronome architectural
+  protocol is installed.  All consumers must treat this as a read-only field.
 
 **/
 EFI_METRONOME_ARCH_PROTOCOL  gMetronome = {


### PR DESCRIPTION
…lower bound

There was previously a lower bound on the value of TickPeriod such that it couldn't be less than 10 us. However, that was removed from the PI Specification in the 1.0 errata released in 2007. From the revision history:

"M171 Remove 10 us lower bound restriction for the TickPeriod in the Metronome"

Update the documentation of TickPeriod in MetronomeDxe/Metronome.c to remove mention of the lower bound.

Signed-off-by: Rebecca Cran <rebecca@quicinc.com>
Reviewed-by: Leif Lindholm <quic_llindhol@quicinc.com>