### PR TITLE
CryptPkg: Enable CryptoPkg BaseCryptLib ParallelHash for PEI and DXE

### DIFF
--- a/CryptoPkg/Library/BaseCryptLib/BaseCryptLib.inf
+++ b/CryptoPkg/Library/BaseCryptLib/BaseCryptLib.inf
@@ -35,7 +35,11 @@
   Hash/CryptSha256.c
   Hash/CryptSha512.c
   Hash/CryptSm3.c
-  Hash/CryptParallelHashNull.c
+  Hash/CryptSha3.c
+  Hash/CryptXkcp.c
+  Hash/CryptCShake256.c
+  Hash/CryptParallelHash.c
+  Hash/CryptDispatchApDxe.c
   Hmac/CryptHmac.c
   Kdf/CryptHkdf.c
   Cipher/CryptAes.c
@@ -93,6 +97,11 @@
   OpensslLib
   IntrinsicLib
   PrintLib
+  UefiBootServicesTableLib
+  SynchronizationLib
+
+[Protocols]
+  gEfiMpServiceProtocolGuid
 
 #
 # Remove these [BuildOptions] after this library is cleaned up

--- a/CryptoPkg/Library/BaseCryptLib/Hash/CryptDispatchApDxe.c
+++ b/CryptoPkg/Library/BaseCryptLib/Hash/CryptDispatchApDxe.c
@@ -1,0 +1,49 @@
+/** @file
+  Dispatch Block to Aps in Dxe phase for parallelhash algorithm.
+
+Copyright (c) 2022, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "CryptParallelHash.h"
+#include <Library/UefiBootServicesTableLib.h>
+#include <Protocol/MpService.h>
+
+/**
+  Dispatch the block task to each AP in PEI phase.
+
+**/
+VOID
+EFIAPI
+DispatchBlockToAp (
+  VOID
+  )
+{
+  EFI_STATUS                Status;
+  EFI_MP_SERVICES_PROTOCOL  *MpServices;
+
+  Status = gBS->LocateProtocol (
+                  &gEfiMpServiceProtocolGuid,
+                  NULL,
+                  (VOID **)&MpServices
+                  );
+  if (EFI_ERROR (Status)) {
+    //
+    // Failed to locate MpServices Protocol, do parallel hash by one core.
+    //
+    DEBUG ((DEBUG_ERROR, "[DispatchBlockToApDxe] Failed to locate MpServices Protocol. Status = %r\n", Status));
+    return;
+  }
+
+  Status = MpServices->StartupAllAPs (
+                         MpServices,
+                         ParallelHashApExecute,
+                         FALSE,
+                         NULL,
+                         0,
+                         NULL,
+                         NULL
+                         );
+  return;
+}

--- a/CryptoPkg/Library/BaseCryptLib/Hash/CryptDispatchApMm.c
+++ b/CryptoPkg/Library/BaseCryptLib/Hash/CryptDispatchApMm.c
@@ -1,0 +1,35 @@
+/** @file
+  Dispatch the block task to each AP in Smm mode for parallelhash algorithm.
+
+Copyright (c) 2022, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "CryptParallelHash.h"
+#include <Library/MmServicesTableLib.h>
+
+/**
+  Dispatch the block task to each AP in SMM mode.
+
+**/
+VOID
+EFIAPI
+DispatchBlockToAp (
+  VOID
+  )
+{
+  UINTN  Index;
+
+  if (gMmst == NULL) {
+    return;
+  }
+
+  for (Index = 0; Index < gMmst->NumberOfCpus; Index++) {
+    if (Index != gMmst->CurrentlyExecutingCpu) {
+      gMmst->MmStartupThisAp (ParallelHashApExecute, Index, NULL);
+    }
+  }
+
+  return;
+}

--- a/CryptoPkg/Library/BaseCryptLib/Hash/CryptDispatchApPei.c
+++ b/CryptoPkg/Library/BaseCryptLib/Hash/CryptDispatchApPei.c
@@ -1,0 +1,54 @@
+/** @file
+  Dispatch Block to Aps in Pei phase for parallelhash algorithm.
+
+Copyright (c) 2022, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "CryptParallelHash.h"
+#include <Library/PeiServicesTablePointerLib.h>
+#include <PiPei.h>
+#include <Ppi/MpServices.h>
+#include <Library/PeiServicesLib.h>
+
+/**
+  Dispatch the block task to each AP in PEI phase.
+
+**/
+VOID
+EFIAPI
+DispatchBlockToAp (
+  VOID
+  )
+{
+  EFI_STATUS               Status;
+  CONST EFI_PEI_SERVICES   **PeiServices;
+  EFI_PEI_MP_SERVICES_PPI  *MpServicesPpi;
+
+  PeiServices = GetPeiServicesTablePointer ();
+  Status      = (*PeiServices)->LocatePpi (
+                                  PeiServices,
+                                  &gEfiPeiMpServicesPpiGuid,
+                                  0,
+                                  NULL,
+                                  (VOID **)&MpServicesPpi
+                                  );
+  if (EFI_ERROR (Status)) {
+    //
+    // Failed to locate MpServices Ppi, do parallel hash by one core.
+    //
+    DEBUG ((DEBUG_ERROR, "[DispatchBlockToApPei] Failed to locate MpServices Ppi. Status = %r\n", Status));
+    return;
+  }
+
+  Status = MpServicesPpi->StartupAllAPs (
+                            (CONST EFI_PEI_SERVICES **)PeiServices,
+                            MpServicesPpi,
+                            ParallelHashApExecute,
+                            FALSE,
+                            0,
+                            NULL
+                            );
+  return;
+}

--- a/CryptoPkg/Library/BaseCryptLib/Hash/CryptParallelHash.c
+++ b/CryptoPkg/Library/BaseCryptLib/Hash/CryptParallelHash.c
@@ -7,7 +7,6 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
 #include "CryptParallelHash.h"
-#include <Library/MmServicesTableLib.h>
 #include <Library/SynchronizationLib.h>
 
 #define PARALLELHASH_CUSTOMIZATION  "ParallelHash"
@@ -67,27 +66,6 @@ ParallelHashApExecute (
       ReleaseSpinLock (&mSpinLockList[Index]);
     }
   }
-}
-
-/**
-  Dispatch the block task to each AP in SMM mode.
-
-**/
-VOID
-EFIAPI
-MmDispatchBlockToAP (
-  VOID
-  )
-{
-  UINTN  Index;
-
-  for (Index = 0; Index < gMmst->NumberOfCpus; Index++) {
-    if (Index != gMmst->CurrentlyExecutingCpu) {
-      gMmst->MmStartupThisAp (ParallelHashApExecute, Index, NULL);
-    }
-  }
-
-  return;
 }
 
 /**
@@ -197,9 +175,7 @@ ParallelHash256HashAll (
   //
   // Dispatch blocklist to each AP.
   //
-  if (gMmst != NULL) {
-    MmDispatchBlockToAP ();
-  }
+  DispatchBlockToAp ();
 
   //
   // Wait until all block hash completed.

--- a/CryptoPkg/Library/BaseCryptLib/Hash/CryptParallelHash.h
+++ b/CryptoPkg/Library/BaseCryptLib/Hash/CryptParallelHash.h
@@ -201,3 +201,26 @@ CShake256HashAll (
   IN   UINTN       CustomizationLen,
   OUT  UINT8       *HashValue
   );
+
+/**
+  Complete computation of digest of each block.
+
+  Each AP perform the function called by BSP.
+
+  @param[in] ProcedureArgument Argument of the procedure.
+**/
+VOID
+EFIAPI
+ParallelHashApExecute (
+  IN VOID  *ProcedureArgument
+  );
+
+/**
+  Dispatch the block task to each AP.
+
+**/
+VOID
+EFIAPI
+DispatchBlockToAp (
+  VOID
+  );

--- a/CryptoPkg/Library/BaseCryptLib/PeiCryptLib.inf
+++ b/CryptoPkg/Library/BaseCryptLib/PeiCryptLib.inf
@@ -40,7 +40,11 @@
   Hash/CryptSha256.c
   Hash/CryptSm3.c
   Hash/CryptSha512.c
-  Hash/CryptParallelHashNull.c
+  Hash/CryptSha3.c
+  Hash/CryptXkcp.c
+  Hash/CryptCShake256.c
+  Hash/CryptParallelHash.c
+  Hash/CryptDispatchApPei.c
   Hmac/CryptHmac.c
   Kdf/CryptHkdf.c
   Cipher/CryptAesNull.c
@@ -80,7 +84,12 @@
   OpensslLib
   IntrinsicLib
   PrintLib
+  PeiServicesTablePointerLib
+  PeiServicesLib
+  SynchronizationLib
 
+[Ppis]
+  gEfiPeiMpServicesPpiGuid
 #
 # Remove these [BuildOptions] after this library is cleaned up
 #

--- a/CryptoPkg/Library/BaseCryptLib/SmmCryptLib.inf
+++ b/CryptoPkg/Library/BaseCryptLib/SmmCryptLib.inf
@@ -42,6 +42,7 @@
   Hash/CryptXkcp.c
   Hash/CryptCShake256.c
   Hash/CryptParallelHash.c
+  Hash/CryptDispatchApMm.c
   Hmac/CryptHmac.c
   Kdf/CryptHkdfNull.c
   Cipher/CryptAes.c


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4097

The BaseCryptLib in the CryptoPkg currently supports ParallelHash algorithm for SMM. The MP Services PPI and MP Services Protocol could be used to enable ParallelHash in PEI and DXE versions of the BaseCryptLib.

Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Jian J Wang <jian.j.wang@intel.com>

Signed-off-by: Zhihao Li <zhihao.li@intel.com>