### PR TITLE
ovmf platform pei misc

### DIFF
--- a/BaseTools/Conf/tools_def.template
+++ b/BaseTools/Conf/tools_def.template
@@ -1888,8 +1888,8 @@ DEFINE GCC_DEPS_FLAGS              = -MMD -MF $@.deps
 
 DEFINE GCC48_ALL_CC_FLAGS            = DEF(GCC_ALL_CC_FLAGS) -ffunction-sections -fdata-sections -DSTRING_ARRAY_NAME=$(BASE_NAME)Strings
 DEFINE GCC48_IA32_X64_DLINK_COMMON   = -nostdlib -Wl,-n,-q,--gc-sections -z common-page-size=0x20
-DEFINE GCC48_IA32_CC_FLAGS           = DEF(GCC48_ALL_CC_FLAGS) -m32 -march=i586 -malign-double -fno-stack-protector -D EFI32 -fno-asynchronous-unwind-tables -Wno-address
-DEFINE GCC48_X64_CC_FLAGS            = DEF(GCC48_ALL_CC_FLAGS) -m64 -fno-stack-protector "-DEFIAPI=__attribute__((ms_abi))" -maccumulate-outgoing-args -mno-red-zone -Wno-address -mcmodel=small -fpie -fno-asynchronous-unwind-tables -Wno-address
+DEFINE GCC48_IA32_CC_FLAGS           = DEF(GCC48_ALL_CC_FLAGS) -m32 -march=i586 -malign-double -fno-stack-protector -D EFI32 -fno-asynchronous-unwind-tables -Wno-address -fno-omit-frame-pointer
+DEFINE GCC48_X64_CC_FLAGS            = DEF(GCC48_ALL_CC_FLAGS) -m64 -fno-stack-protector "-DEFIAPI=__attribute__((ms_abi))" -maccumulate-outgoing-args -mno-red-zone -Wno-address -mcmodel=small -fpie -fno-asynchronous-unwind-tables -Wno-address  -fno-omit-frame-pointer
 DEFINE GCC48_IA32_X64_ASLDLINK_FLAGS = DEF(GCC48_IA32_X64_DLINK_COMMON) -Wl,--entry,ReferenceAcpiTable -u ReferenceAcpiTable
 DEFINE GCC48_IA32_X64_DLINK_FLAGS    = DEF(GCC48_IA32_X64_DLINK_COMMON) -Wl,--entry,$(IMAGE_ENTRY_POINT) -u $(IMAGE_ENTRY_POINT) -Wl,-Map,$(DEST_DIR_DEBUG)/$(BASE_NAME).map,--whole-archive
 DEFINE GCC48_IA32_DLINK2_FLAGS       = -Wl,--defsym=PECOFF_HEADER_SIZE=0x220 DEF(GCC_DLINK2_FLAGS_COMMON)

--- a/BaseTools/Conf/tools_def.template
+++ b/BaseTools/Conf/tools_def.template
@@ -1850,8 +1850,6 @@ NOOPT_*_*_OBJCOPY_ADDDEBUGFLAG     = --add-gnu-debuglink=$(DEBUG_DIR)/$(MODULE_N
 *_*_*_DTC_PATH                     = DEF(DTC_BIN)
 
 DEFINE GCC_ALL_CC_FLAGS            = -g -Os -fshort-wchar -fno-builtin -fno-strict-aliasing -Wall -Werror -Wno-array-bounds -include AutoGen.h -fno-common
-DEFINE GCC_IA32_CC_FLAGS           = DEF(GCC_ALL_CC_FLAGS) -m32 -malign-double -freorder-blocks -freorder-blocks-and-partition -O2 -mno-stack-arg-probe
-DEFINE GCC_X64_CC_FLAGS            = DEF(GCC_ALL_CC_FLAGS) -mno-red-zone -Wno-address -mno-stack-arg-probe
 DEFINE GCC_ARM_CC_FLAGS            = DEF(GCC_ALL_CC_FLAGS) -mlittle-endian -mabi=aapcs -fno-short-enums -funsigned-char -ffunction-sections -fdata-sections -fomit-frame-pointer -Wno-address -mthumb -mfloat-abi=soft -fno-pic -fno-pie
 DEFINE GCC_LOONGARCH64_CC_FLAGS    = DEF(GCC_ALL_CC_FLAGS) -mabi=lp64d -fno-asynchronous-unwind-tables -fno-plt -Wno-address -fno-short-enums -fsigned-char -ffunction-sections -fdata-sections
 DEFINE GCC_ARM_CC_XIPFLAGS         = -mno-unaligned-access

--- a/OvmfPkg/AmdSev/AmdSevX64.dsc
+++ b/OvmfPkg/AmdSev/AmdSevX64.dsc
@@ -244,7 +244,7 @@
 !ifdef $(DEBUG_ON_SERIAL_PORT)
   DebugLib|MdePkg/Library/BaseDebugLibSerialPort/BaseDebugLibSerialPort.inf
 !else
-  DebugLib|OvmfPkg/Library/PlatformDebugLibIoPort/PlatformDebugLibIoPort.inf
+  DebugLib|OvmfPkg/Library/PlatformDebugLibIoPort/PlatformRomDebugLibIoPort.inf
 !endif
   PeCoffLib|MdePkg/Library/BasePeCoffLib/BasePeCoffLib.inf
 
@@ -260,7 +260,7 @@
 !ifdef $(DEBUG_ON_SERIAL_PORT)
   DebugLib|MdePkg/Library/BaseDebugLibSerialPort/BaseDebugLibSerialPort.inf
 !else
-  DebugLib|OvmfPkg/Library/PlatformDebugLibIoPort/PlatformDebugLibIoPort.inf
+  DebugLib|OvmfPkg/Library/PlatformDebugLibIoPort/PlatformRomDebugLibIoPort.inf
 !endif
   PeCoffLib|MdePkg/Library/BasePeCoffLib/BasePeCoffLib.inf
   ResourcePublicationLib|MdePkg/Library/PeiResourcePublicationLib/PeiResourcePublicationLib.inf

--- a/OvmfPkg/Bhyve/BhyveX64.dsc
+++ b/OvmfPkg/Bhyve/BhyveX64.dsc
@@ -265,7 +265,7 @@
 !ifdef $(DEBUG_ON_SERIAL_PORT)
   DebugLib|MdePkg/Library/BaseDebugLibSerialPort/BaseDebugLibSerialPort.inf
 !else
-  DebugLib|OvmfPkg/Library/PlatformDebugLibIoPort/PlatformDebugLibIoPort.inf
+  DebugLib|OvmfPkg/Library/PlatformDebugLibIoPort/PlatformRomDebugLibIoPort.inf
 !endif
   PeCoffLib|MdePkg/Library/BasePeCoffLib/BasePeCoffLib.inf
 
@@ -281,7 +281,7 @@
 !ifdef $(DEBUG_ON_SERIAL_PORT)
   DebugLib|MdePkg/Library/BaseDebugLibSerialPort/BaseDebugLibSerialPort.inf
 !else
-  DebugLib|OvmfPkg/Library/PlatformDebugLibIoPort/PlatformDebugLibIoPort.inf
+  DebugLib|OvmfPkg/Library/PlatformDebugLibIoPort/PlatformRomDebugLibIoPort.inf
 !endif
   PeCoffLib|MdePkg/Library/BasePeCoffLib/BasePeCoffLib.inf
   ResourcePublicationLib|MdePkg/Library/PeiResourcePublicationLib/PeiResourcePublicationLib.inf

--- a/OvmfPkg/Include/Library/PlatformInitLib.h
+++ b/OvmfPkg/Include/Library/PlatformInitLib.h
@@ -48,6 +48,8 @@ typedef struct {
 
   UINT32               S3AcpiReservedMemoryBase;
   UINT32               S3AcpiReservedMemorySize;
+
+  UINT64               FeatureControlValue;
 } EFI_HOB_PLATFORM_INFO;
 #pragma pack()
 

--- a/OvmfPkg/Include/Library/PlatformInitLib.h
+++ b/OvmfPkg/Include/Library/PlatformInitLib.h
@@ -50,6 +50,10 @@ typedef struct {
   UINT32               S3AcpiReservedMemorySize;
 
   UINT64               FeatureControlValue;
+
+  BOOLEAN              QemuFwCfgChecked;
+  BOOLEAN              QemuFwCfgSupported;
+  BOOLEAN              QemuFwCfgDmaSupported;
 } EFI_HOB_PLATFORM_INFO;
 #pragma pack()
 

--- a/OvmfPkg/Library/PlatformDebugLibIoPort/PlatformRomDebugLibIoPort.inf
+++ b/OvmfPkg/Library/PlatformDebugLibIoPort/PlatformRomDebugLibIoPort.inf
@@ -16,7 +16,7 @@
   FILE_GUID                      = CEB0D9D3-328F-4C24-8C02-28FA1986AE1B
   MODULE_TYPE                    = BASE
   VERSION_STRING                 = 1.0
-  LIBRARY_CLASS                  = DebugLib|SEC
+  LIBRARY_CLASS                  = DebugLib|SEC PEI_CORE PEIM
   CONSTRUCTOR                    = PlatformRomDebugLibIoPortConstructor
 
 #

--- a/OvmfPkg/Library/QemuFwCfgLib/QemuFwCfgPeiLib.inf
+++ b/OvmfPkg/Library/QemuFwCfgLib/QemuFwCfgPeiLib.inf
@@ -39,8 +39,12 @@
   BaseLib
   BaseMemoryLib
   DebugLib
+  HobLib
   IoLib
   MemoryAllocationLib
+
+[Guids]
+  gUefiOvmfPkgPlatformInfoGuid
 
 [Pcd]
   gUefiOvmfPkgTokenSpaceGuid.PcdOvmfWorkAreaBase

--- a/OvmfPkg/Library/QemuFwCfgLib/QemuFwCfgPeiLib.inf
+++ b/OvmfPkg/Library/QemuFwCfgLib/QemuFwCfgPeiLib.inf
@@ -41,7 +41,6 @@
   DebugLib
   IoLib
   MemoryAllocationLib
-  MemEncryptSevLib
 
 [Pcd]
   gUefiOvmfPkgTokenSpaceGuid.PcdOvmfWorkAreaBase

--- a/OvmfPkg/Microvm/MicrovmX64.dsc
+++ b/OvmfPkg/Microvm/MicrovmX64.dsc
@@ -292,7 +292,7 @@
 !ifdef $(DEBUG_ON_SERIAL_PORT)
   DebugLib|MdePkg/Library/BaseDebugLibSerialPort/BaseDebugLibSerialPort.inf
 !else
-  DebugLib|OvmfPkg/Library/PlatformDebugLibIoPort/PlatformDebugLibIoPort.inf
+  DebugLib|OvmfPkg/Library/PlatformDebugLibIoPort/PlatformRomDebugLibIoPort.inf
 !endif
   PeCoffLib|MdePkg/Library/BasePeCoffLib/BasePeCoffLib.inf
 
@@ -308,7 +308,7 @@
 !ifdef $(DEBUG_ON_SERIAL_PORT)
   DebugLib|MdePkg/Library/BaseDebugLibSerialPort/BaseDebugLibSerialPort.inf
 !else
-  DebugLib|OvmfPkg/Library/PlatformDebugLibIoPort/PlatformDebugLibIoPort.inf
+  DebugLib|OvmfPkg/Library/PlatformDebugLibIoPort/PlatformRomDebugLibIoPort.inf
 !endif
   PeCoffLib|MdePkg/Library/BasePeCoffLib/BasePeCoffLib.inf
   ResourcePublicationLib|MdePkg/Library/PeiResourcePublicationLib/PeiResourcePublicationLib.inf

--- a/OvmfPkg/OvmfPkgIa32.dsc
+++ b/OvmfPkg/OvmfPkgIa32.dsc
@@ -294,7 +294,7 @@
 !ifdef $(DEBUG_ON_SERIAL_PORT)
   DebugLib|MdePkg/Library/BaseDebugLibSerialPort/BaseDebugLibSerialPort.inf
 !else
-  DebugLib|OvmfPkg/Library/PlatformDebugLibIoPort/PlatformDebugLibIoPort.inf
+  DebugLib|OvmfPkg/Library/PlatformDebugLibIoPort/PlatformRomDebugLibIoPort.inf
 !endif
   PeCoffLib|MdePkg/Library/BasePeCoffLib/BasePeCoffLib.inf
 
@@ -310,7 +310,7 @@
 !ifdef $(DEBUG_ON_SERIAL_PORT)
   DebugLib|MdePkg/Library/BaseDebugLibSerialPort/BaseDebugLibSerialPort.inf
 !else
-  DebugLib|OvmfPkg/Library/PlatformDebugLibIoPort/PlatformDebugLibIoPort.inf
+  DebugLib|OvmfPkg/Library/PlatformDebugLibIoPort/PlatformRomDebugLibIoPort.inf
 !endif
   PeCoffLib|MdePkg/Library/BasePeCoffLib/BasePeCoffLib.inf
   ResourcePublicationLib|MdePkg/Library/PeiResourcePublicationLib/PeiResourcePublicationLib.inf

--- a/OvmfPkg/OvmfPkgIa32X64.dsc
+++ b/OvmfPkg/OvmfPkgIa32X64.dsc
@@ -300,7 +300,7 @@
 !ifdef $(DEBUG_ON_SERIAL_PORT)
   DebugLib|MdePkg/Library/BaseDebugLibSerialPort/BaseDebugLibSerialPort.inf
 !else
-  DebugLib|OvmfPkg/Library/PlatformDebugLibIoPort/PlatformDebugLibIoPort.inf
+  DebugLib|OvmfPkg/Library/PlatformDebugLibIoPort/PlatformRomDebugLibIoPort.inf
 !endif
   PeCoffLib|MdePkg/Library/BasePeCoffLib/BasePeCoffLib.inf
 
@@ -316,7 +316,7 @@
 !ifdef $(DEBUG_ON_SERIAL_PORT)
   DebugLib|MdePkg/Library/BaseDebugLibSerialPort/BaseDebugLibSerialPort.inf
 !else
-  DebugLib|OvmfPkg/Library/PlatformDebugLibIoPort/PlatformDebugLibIoPort.inf
+  DebugLib|OvmfPkg/Library/PlatformDebugLibIoPort/PlatformRomDebugLibIoPort.inf
 !endif
   PeCoffLib|MdePkg/Library/BasePeCoffLib/BasePeCoffLib.inf
   ResourcePublicationLib|MdePkg/Library/PeiResourcePublicationLib/PeiResourcePublicationLib.inf

--- a/OvmfPkg/OvmfPkgX64.dsc
+++ b/OvmfPkg/OvmfPkgX64.dsc
@@ -318,7 +318,7 @@
 !ifdef $(DEBUG_ON_SERIAL_PORT)
   DebugLib|MdePkg/Library/BaseDebugLibSerialPort/BaseDebugLibSerialPort.inf
 !else
-  DebugLib|OvmfPkg/Library/PlatformDebugLibIoPort/PlatformDebugLibIoPort.inf
+  DebugLib|OvmfPkg/Library/PlatformDebugLibIoPort/PlatformRomDebugLibIoPort.inf
 !endif
   PeCoffLib|MdePkg/Library/BasePeCoffLib/BasePeCoffLib.inf
   CcProbeLib|OvmfPkg/Library/CcProbeLib/SecPeiCcProbeLib.inf
@@ -335,7 +335,7 @@
 !ifdef $(DEBUG_ON_SERIAL_PORT)
   DebugLib|MdePkg/Library/BaseDebugLibSerialPort/BaseDebugLibSerialPort.inf
 !else
-  DebugLib|OvmfPkg/Library/PlatformDebugLibIoPort/PlatformDebugLibIoPort.inf
+  DebugLib|OvmfPkg/Library/PlatformDebugLibIoPort/PlatformRomDebugLibIoPort.inf
 !endif
   PeCoffLib|MdePkg/Library/BasePeCoffLib/BasePeCoffLib.inf
   ResourcePublicationLib|MdePkg/Library/PeiResourcePublicationLib/PeiResourcePublicationLib.inf

--- a/OvmfPkg/PlatformDxe/Platform.c
+++ b/OvmfPkg/PlatformDxe/Platform.c
@@ -931,6 +931,32 @@ GopInstalled (
   mGopTracker = NULL;
 }
 
+VOID
+DebugPeiFvCheck (
+  VOID
+  )
+{
+  UINT8   *Orig = (VOID *)(UINTN)PcdGet32 (PcdOvmfPeiMemFvBase);
+  UINT8   *Copy = (VOID *)(UINTN)0x420000;
+  UINT32  Size  = PcdGet32 (PcdOvmfPeiMemFvSize);
+  UINT32  Index;
+
+  for (Index = 0; Index < Size; Index++) {
+    if (Orig[Index] == Copy[Index]) {
+      continue;
+    }
+
+    DEBUG ((
+      DEBUG_INFO,
+      "%a: 0x%08x: 0x%02x (expected 0x%02x)\n",
+      __FUNCTION__,
+      PcdGet32 (PcdOvmfPeiMemFvBase) + Index,
+      Orig[Index],
+      Copy[Index]
+      ));
+  }
+}
+
 /**
   Entry point for this driver.
 
@@ -950,6 +976,8 @@ PlatformInit (
   )
 {
   EFI_STATUS  Status;
+
+  DebugPeiFvCheck ();
 
   ExecutePlatformConfig ();
 

--- a/OvmfPkg/PlatformDxe/Platform.inf
+++ b/OvmfPkg/PlatformDxe/Platform.inf
@@ -48,6 +48,8 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdVideoHorizontalResolution
   gEfiMdeModulePkgTokenSpaceGuid.PcdVideoVerticalResolution
   gUefiOvmfPkgTokenSpaceGuid.PcdVideoResolutionSource
+  gUefiOvmfPkgTokenSpaceGuid.PcdOvmfPeiMemFvBase
+  gUefiOvmfPkgTokenSpaceGuid.PcdOvmfPeiMemFvSize
 
 [Protocols]
   gEfiDevicePathProtocolGuid      ## PRODUCES

--- a/OvmfPkg/PlatformPei/AmdSev.c
+++ b/OvmfPkg/PlatformPei/AmdSev.c
@@ -201,7 +201,7 @@ GhcbRegister (
 STATIC
 VOID
 AmdSevEsInitialize (
-  VOID
+  IN EFI_HOB_PLATFORM_INFO  *PlatformInfoHob
   )
 {
   UINT8                *GhcbBase;
@@ -228,7 +228,7 @@ AmdSevEsInitialize (
   //   Since the pages must survive across the UEFI to OS transition
   //   make them reserved.
   //
-  GhcbPageCount = mPlatformInfoHob.PcdCpuMaxLogicalProcessorNumber * 2;
+  GhcbPageCount = PlatformInfoHob->PcdCpuMaxLogicalProcessorNumber * 2;
   GhcbBase      = AllocateReservedPages (GhcbPageCount);
   ASSERT (GhcbBase != NULL);
 
@@ -266,7 +266,7 @@ AmdSevEsInitialize (
   // Allocate #VC recursion backup pages. The number of backup pages needed is
   // one less than the maximum VC count.
   //
-  GhcbBackupPageCount = mPlatformInfoHob.PcdCpuMaxLogicalProcessorNumber * (VMGEXIT_MAXIMUM_VC_COUNT - 1);
+  GhcbBackupPageCount = PlatformInfoHob->PcdCpuMaxLogicalProcessorNumber * (VMGEXIT_MAXIMUM_VC_COUNT - 1);
   GhcbBackupBase      = AllocatePages (GhcbBackupPageCount);
   ASSERT (GhcbBackupBase != NULL);
 
@@ -320,7 +320,7 @@ AmdSevEsInitialize (
   **/
 VOID
 AmdSevInitialize (
-  VOID
+  IN OUT EFI_HOB_PLATFORM_INFO  *PlatformInfoHob
   )
 {
   UINT64         EncryptionMask;
@@ -367,7 +367,7 @@ AmdSevInitialize (
   // until after re-encryption, in order to prevent an information leak to the
   // hypervisor.
   //
-  if (mPlatformInfoHob.SmmSmramRequire && (mPlatformInfoHob.BootMode != BOOT_ON_S3_RESUME)) {
+  if (PlatformInfoHob->SmmSmramRequire && (PlatformInfoHob->BootMode != BOOT_ON_S3_RESUME)) {
     RETURN_STATUS  LocateMapStatus;
     UINTN          MapPagesBase;
     UINTN          MapPagesCount;
@@ -378,7 +378,7 @@ AmdSevInitialize (
                         );
     ASSERT_RETURN_ERROR (LocateMapStatus);
 
-    if (mPlatformInfoHob.Q35SmramAtDefaultSmbase) {
+    if (PlatformInfoHob->Q35SmramAtDefaultSmbase) {
       //
       // The initial SMRAM Save State Map has been covered as part of a larger
       // reserved memory allocation in InitializeRamRegions().
@@ -400,7 +400,7 @@ AmdSevInitialize (
   //
   // Check and perform SEV-ES initialization if required.
   //
-  AmdSevEsInitialize ();
+  AmdSevEsInitialize (PlatformInfoHob);
 
   //
   // Set the Confidential computing attr PCD to communicate which SEV

--- a/OvmfPkg/PlatformPei/Fv.c
+++ b/OvmfPkg/PlatformPei/Fv.c
@@ -22,7 +22,7 @@
 **/
 EFI_STATUS
 PeiFvInitialization (
-  VOID
+  IN EFI_HOB_PLATFORM_INFO  *PlatformInfoHob
   )
 {
   BOOLEAN  SecureS3Needed;
@@ -37,7 +37,7 @@ PeiFvInitialization (
   BuildMemoryAllocationHob (
     PcdGet32 (PcdOvmfPeiMemFvBase),
     PcdGet32 (PcdOvmfPeiMemFvSize),
-    mPlatformInfoHob.S3Supported ? EfiACPIMemoryNVS : EfiBootServicesData
+    PlatformInfoHob->S3Supported ? EfiACPIMemoryNVS : EfiBootServicesData
     );
 
   //
@@ -45,7 +45,7 @@ PeiFvInitialization (
   //
   BuildFvHob (PcdGet32 (PcdOvmfDxeMemFvBase), PcdGet32 (PcdOvmfDxeMemFvSize));
 
-  SecureS3Needed = mPlatformInfoHob.S3Supported && mPlatformInfoHob.SmmSmramRequire;
+  SecureS3Needed = PlatformInfoHob->S3Supported && PlatformInfoHob->SmmSmramRequire;
 
   //
   // Create a memory allocation HOB for the DXE FV.

--- a/OvmfPkg/PlatformPei/Fv.c
+++ b/OvmfPkg/PlatformPei/Fv.c
@@ -40,6 +40,13 @@ PeiFvInitialization (
     PlatformInfoHob->S3Supported ? EfiACPIMemoryNVS : EfiBootServicesData
     );
 
+  // register debug copy
+  BuildMemoryAllocationHob (
+    0x420000,
+    PcdGet32 (PcdOvmfPeiMemFvSize),
+    PlatformInfoHob->S3Supported ? EfiACPIMemoryNVS : EfiBootServicesData
+    );
+
   //
   // Let DXE know about the DXE FV
   //

--- a/OvmfPkg/PlatformPei/MemDetect.c
+++ b/OvmfPkg/PlatformPei/MemDetect.c
@@ -41,13 +41,13 @@ Module Name:
 
 VOID
 Q35TsegMbytesInitialization (
-  VOID
+  IN OUT EFI_HOB_PLATFORM_INFO  *PlatformInfoHob
   )
 {
   UINT16         ExtendedTsegMbytes;
   RETURN_STATUS  PcdStatus;
 
-  ASSERT (mPlatformInfoHob.HostBridgeDevId == INTEL_Q35_MCH_DEVICE_ID);
+  ASSERT (PlatformInfoHob->HostBridgeDevId == INTEL_Q35_MCH_DEVICE_ID);
 
   //
   // Check if QEMU offers an extended TSEG.
@@ -68,7 +68,7 @@ Q35TsegMbytesInitialization (
   PciWrite16 (DRAMC_REGISTER_Q35 (MCH_EXT_TSEG_MB), MCH_EXT_TSEG_MB_QUERY);
   ExtendedTsegMbytes = PciRead16 (DRAMC_REGISTER_Q35 (MCH_EXT_TSEG_MB));
   if (ExtendedTsegMbytes == MCH_EXT_TSEG_MB_QUERY) {
-    mPlatformInfoHob.Q35TsegMbytes = PcdGet16 (PcdQ35TsegMbytes);
+    PlatformInfoHob->Q35TsegMbytes = PcdGet16 (PcdQ35TsegMbytes);
     return;
   }
 
@@ -80,19 +80,19 @@ Q35TsegMbytesInitialization (
     ));
   PcdStatus = PcdSet16S (PcdQ35TsegMbytes, ExtendedTsegMbytes);
   ASSERT_RETURN_ERROR (PcdStatus);
-  mPlatformInfoHob.Q35TsegMbytes = ExtendedTsegMbytes;
+  PlatformInfoHob->Q35TsegMbytes = ExtendedTsegMbytes;
 }
 
 VOID
 Q35SmramAtDefaultSmbaseInitialization (
-  VOID
+  IN OUT EFI_HOB_PLATFORM_INFO  *PlatformInfoHob
   )
 {
   RETURN_STATUS  PcdStatus;
 
-  ASSERT (mPlatformInfoHob.HostBridgeDevId == INTEL_Q35_MCH_DEVICE_ID);
+  ASSERT (PlatformInfoHob->HostBridgeDevId == INTEL_Q35_MCH_DEVICE_ID);
 
-  mPlatformInfoHob.Q35SmramAtDefaultSmbase = FALSE;
+  PlatformInfoHob->Q35SmramAtDefaultSmbase = FALSE;
   if (FeaturePcdGet (PcdCsmEnable)) {
     DEBUG ((
       DEBUG_INFO,
@@ -106,19 +106,19 @@ Q35SmramAtDefaultSmbaseInitialization (
     CtlReg = DRAMC_REGISTER_Q35 (MCH_DEFAULT_SMBASE_CTL);
     PciWrite8 (CtlReg, MCH_DEFAULT_SMBASE_QUERY);
     CtlRegVal                                = PciRead8 (CtlReg);
-    mPlatformInfoHob.Q35SmramAtDefaultSmbase = (BOOLEAN)(CtlRegVal ==
+    PlatformInfoHob->Q35SmramAtDefaultSmbase = (BOOLEAN)(CtlRegVal ==
                                                          MCH_DEFAULT_SMBASE_IN_RAM);
     DEBUG ((
       DEBUG_INFO,
       "%a: SMRAM at default SMBASE %a\n",
       __FUNCTION__,
-      mPlatformInfoHob.Q35SmramAtDefaultSmbase ? "found" : "not found"
+      PlatformInfoHob->Q35SmramAtDefaultSmbase ? "found" : "not found"
       ));
   }
 
   PcdStatus = PcdSetBoolS (
                 PcdQ35SmramAtDefaultSmbase,
-                mPlatformInfoHob.Q35SmramAtDefaultSmbase
+                PlatformInfoHob->Q35SmramAtDefaultSmbase
                 );
   ASSERT_RETURN_ERROR (PcdStatus);
 }

--- a/OvmfPkg/PlatformPei/MemTypeInfo.c
+++ b/OvmfPkg/PlatformPei/MemTypeInfo.c
@@ -203,12 +203,12 @@ STATIC CONST EFI_PEI_NOTIFY_DESCRIPTOR  mReadOnlyVariable2Notify = {
 
 VOID
 MemTypeInfoInitialization (
-  VOID
+  IN OUT EFI_HOB_PLATFORM_INFO  *PlatformInfoHob
   )
 {
   EFI_STATUS  Status;
 
-  if (!mPlatformInfoHob.SmmSmramRequire) {
+  if (!PlatformInfoHob->SmmSmramRequire) {
     //
     // EFI_PEI_READ_ONLY_VARIABLE2_PPI will never be available; install
     // the default memory type information HOB right away.

--- a/OvmfPkg/PlatformPei/Platform.c
+++ b/OvmfPkg/PlatformPei/Platform.c
@@ -373,7 +373,7 @@ InitializePlatform (
     }
 
     PeiFvInitialization (&mPlatformInfoHob);
-    MemTypeInfoInitialization ();
+    MemTypeInfoInitialization (&mPlatformInfoHob);
     MemMapInitialization (&mPlatformInfoHob);
     NoexecDxeInitialization ();
   }

--- a/OvmfPkg/PlatformPei/Platform.c
+++ b/OvmfPkg/PlatformPei/Platform.c
@@ -372,7 +372,7 @@ InitializePlatform (
       ReserveEmuVariableNvStore ();
     }
 
-    PeiFvInitialization ();
+    PeiFvInitialization (&mPlatformInfoHob);
     MemTypeInfoInitialization ();
     MemMapInitialization (&mPlatformInfoHob);
     NoexecDxeInitialization ();

--- a/OvmfPkg/PlatformPei/Platform.c
+++ b/OvmfPkg/PlatformPei/Platform.c
@@ -357,8 +357,8 @@ InitializePlatform (
 
   if (mPlatformInfoHob.SmmSmramRequire) {
     Q35BoardVerification ();
-    Q35TsegMbytesInitialization ();
-    Q35SmramAtDefaultSmbaseInitialization ();
+    Q35TsegMbytesInitialization (&mPlatformInfoHob);
+    Q35SmramAtDefaultSmbaseInitialization (&mPlatformInfoHob);
   }
 
   PublishPeiMemory ();

--- a/OvmfPkg/PlatformPei/Platform.c
+++ b/OvmfPkg/PlatformPei/Platform.c
@@ -75,16 +75,17 @@ MemMapInitialization (
   ASSERT_RETURN_ERROR (PcdStatus);
 }
 
+STATIC
 VOID
 NoexecDxeInitialization (
-  VOID
+  IN OUT EFI_HOB_PLATFORM_INFO  *PlatformInfoHob
   )
 {
   RETURN_STATUS  Status;
 
-  Status = PlatformNoexecDxeInitialization (&mPlatformInfoHob);
+  Status = PlatformNoexecDxeInitialization (PlatformInfoHob);
   if (!RETURN_ERROR (Status)) {
-    Status = PcdSetBoolS (PcdSetNxForStack, mPlatformInfoHob.PcdSetNxForStack);
+    Status = PcdSetBoolS (PcdSetNxForStack, PlatformInfoHob->PcdSetNxForStack);
     ASSERT_RETURN_ERROR (Status);
   }
 }
@@ -375,7 +376,7 @@ InitializePlatform (
     PeiFvInitialization (&mPlatformInfoHob);
     MemTypeInfoInitialization (&mPlatformInfoHob);
     MemMapInitialization (&mPlatformInfoHob);
-    NoexecDxeInitialization ();
+    NoexecDxeInitialization (&mPlatformInfoHob);
   }
 
   InstallClearCacheCallback ();

--- a/OvmfPkg/PlatformPei/Platform.c
+++ b/OvmfPkg/PlatformPei/Platform.c
@@ -231,13 +231,14 @@ ReserveEmuVariableNvStore (
   ASSERT_RETURN_ERROR (PcdStatus);
 }
 
+STATIC
 VOID
 S3Verification (
-  VOID
+  IN EFI_HOB_PLATFORM_INFO  *PlatformInfoHob
   )
 {
  #if defined (MDE_CPU_X64)
-  if (mPlatformInfoHob.SmmSmramRequire && mPlatformInfoHob.S3Supported) {
+  if (PlatformInfoHob->SmmSmramRequire && PlatformInfoHob->S3Supported) {
     DEBUG ((
       DEBUG_ERROR,
       "%a: S3Resume2Pei doesn't support X64 PEI + SMM yet.\n",
@@ -260,12 +261,13 @@ S3Verification (
  #endif
 }
 
+STATIC
 VOID
 Q35BoardVerification (
-  VOID
+  IN EFI_HOB_PLATFORM_INFO  *PlatformInfoHob
   )
 {
-  if (mPlatformInfoHob.HostBridgeDevId == INTEL_Q35_MCH_DEVICE_ID) {
+  if (PlatformInfoHob->HostBridgeDevId == INTEL_Q35_MCH_DEVICE_ID) {
     return;
   }
 
@@ -274,7 +276,7 @@ Q35BoardVerification (
     "%a: no TSEG (SMRAM) on host bridge DID=0x%04x; "
     "only DID=0x%04x (Q35) is supported\n",
     __FUNCTION__,
-    mPlatformInfoHob.HostBridgeDevId,
+    PlatformInfoHob->HostBridgeDevId,
     INTEL_Q35_MCH_DEVICE_ID
     ));
   ASSERT (FALSE);
@@ -345,7 +347,7 @@ InitializePlatform (
     ASSERT_EFI_ERROR (Status);
   }
 
-  S3Verification ();
+  S3Verification (&mPlatformInfoHob);
   BootModeInitialization (&mPlatformInfoHob);
 
   //
@@ -357,7 +359,7 @@ InitializePlatform (
   MaxCpuCountInitialization (&mPlatformInfoHob);
 
   if (mPlatformInfoHob.SmmSmramRequire) {
-    Q35BoardVerification ();
+    Q35BoardVerification (&mPlatformInfoHob);
     Q35TsegMbytesInitialization (&mPlatformInfoHob);
     Q35SmramAtDefaultSmbaseInitialization (&mPlatformInfoHob);
   }

--- a/OvmfPkg/PlatformPei/Platform.c
+++ b/OvmfPkg/PlatformPei/Platform.c
@@ -361,7 +361,7 @@ InitializePlatform (
     Q35SmramAtDefaultSmbaseInitialization (&mPlatformInfoHob);
   }
 
-  PublishPeiMemory ();
+  PublishPeiMemory (&mPlatformInfoHob);
 
   PlatformQemuUc32BaseInitialization (&mPlatformInfoHob);
 

--- a/OvmfPkg/PlatformPei/Platform.c
+++ b/OvmfPkg/PlatformPei/Platform.c
@@ -396,7 +396,7 @@ InitializePlatform (
   }
 
   IntelTdxInitialize ();
-  InstallFeatureControlCallback ();
+  InstallFeatureControlCallback (PlatformInfoHob);
 
   return EFI_SUCCESS;
 }

--- a/OvmfPkg/PlatformPei/Platform.c
+++ b/OvmfPkg/PlatformPei/Platform.c
@@ -379,7 +379,7 @@ InitializePlatform (
   }
 
   InstallClearCacheCallback ();
-  AmdSevInitialize ();
+  AmdSevInitialize (&mPlatformInfoHob);
   if (mPlatformInfoHob.HostBridgeDevId == 0xffff) {
     MiscInitializationForMicrovm (&mPlatformInfoHob);
   } else {

--- a/OvmfPkg/PlatformPei/Platform.c
+++ b/OvmfPkg/PlatformPei/Platform.c
@@ -317,6 +317,32 @@ BuildPlatformInfoHob (
   return (EFI_HOB_PLATFORM_INFO *)GET_GUID_HOB_DATA (GuidHob);
 }
 
+VOID
+DebugPeiFvCheck (
+  VOID
+  )
+{
+  UINT8   *Orig = (VOID *)(UINTN)PcdGet32 (PcdOvmfPeiMemFvBase);
+  UINT8   *Copy = (VOID *)(UINTN)0x420000;
+  UINT32  Size  = PcdGet32 (PcdOvmfPeiMemFvSize);
+  UINT32  Index;
+
+  for (Index = 0; Index < Size; Index++) {
+    if (Orig[Index] == Copy[Index]) {
+      continue;
+    }
+
+    DEBUG ((
+      DEBUG_INFO,
+      "%a: 0x%08x: 0x%02x (expected 0x%02x)\n",
+      __FUNCTION__,
+      PcdGet32 (PcdOvmfPeiMemFvBase) + Index,
+      Orig[Index],
+      Copy[Index]
+      ));
+  }
+}
+
 /**
   Perform Platform PEI initialization.
 
@@ -397,6 +423,8 @@ InitializePlatform (
 
   IntelTdxInitialize ();
   InstallFeatureControlCallback (PlatformInfoHob);
+
+  DebugPeiFvCheck ();
 
   return EFI_SUCCESS;
 }

--- a/OvmfPkg/PlatformPei/Platform.h
+++ b/OvmfPkg/PlatformPei/Platform.h
@@ -22,12 +22,12 @@ AddressWidthInitialization (
 
 VOID
 Q35TsegMbytesInitialization (
-  VOID
+  IN OUT EFI_HOB_PLATFORM_INFO  *PlatformInfoHob
   );
 
 VOID
 Q35SmramAtDefaultSmbaseInitialization (
-  VOID
+  IN OUT EFI_HOB_PLATFORM_INFO  *PlatformInfoHob
   );
 
 EFI_STATUS

--- a/OvmfPkg/PlatformPei/Platform.h
+++ b/OvmfPkg/PlatformPei/Platform.h
@@ -13,8 +13,6 @@
 #include <Library/PlatformInitLib.h>
 #include <IndustryStandard/IntelTdx.h>
 
-extern EFI_HOB_PLATFORM_INFO  mPlatformInfoHob;
-
 VOID
 AddressWidthInitialization (
   IN OUT EFI_HOB_PLATFORM_INFO  *PlatformInfoHob
@@ -98,7 +96,7 @@ IntelTdxInitialize (
 /**
  * @brief Builds PlatformInfo Hob
  */
-VOID
+EFI_HOB_PLATFORM_INFO *
 BuildPlatformInfoHob (
   VOID
   );

--- a/OvmfPkg/PlatformPei/Platform.h
+++ b/OvmfPkg/PlatformPei/Platform.h
@@ -82,7 +82,7 @@ InstallClearCacheCallback (
 
 VOID
 AmdSevInitialize (
-  VOID
+  IN EFI_HOB_PLATFORM_INFO  *PlatformInfoHob
   );
 
 /**

--- a/OvmfPkg/PlatformPei/Platform.h
+++ b/OvmfPkg/PlatformPei/Platform.h
@@ -62,7 +62,7 @@ MaxCpuCountInitialization (
 
 EFI_STATUS
 PeiFvInitialization (
-  VOID
+  IN EFI_HOB_PLATFORM_INFO  *PlatformInfoHob
   );
 
 VOID

--- a/OvmfPkg/PlatformPei/Platform.h
+++ b/OvmfPkg/PlatformPei/Platform.h
@@ -70,7 +70,7 @@ MemTypeInfoInitialization (
 
 VOID
 InstallFeatureControlCallback (
-  VOID
+  IN OUT EFI_HOB_PLATFORM_INFO  *PlatformInfoHob
   );
 
 VOID

--- a/OvmfPkg/PlatformPei/Platform.h
+++ b/OvmfPkg/PlatformPei/Platform.h
@@ -32,7 +32,7 @@ Q35SmramAtDefaultSmbaseInitialization (
 
 EFI_STATUS
 PublishPeiMemory (
-  VOID
+  IN OUT EFI_HOB_PLATFORM_INFO  *PlatformInfoHob
   );
 
 VOID

--- a/OvmfPkg/PlatformPei/Platform.h
+++ b/OvmfPkg/PlatformPei/Platform.h
@@ -67,7 +67,7 @@ PeiFvInitialization (
 
 VOID
 MemTypeInfoInitialization (
-  VOID
+  IN OUT EFI_HOB_PLATFORM_INFO  *PlatformInfoHob
   );
 
 VOID

--- a/OvmfPkg/Sec/SecMain.c
+++ b/OvmfPkg/Sec/SecMain.c
@@ -431,6 +431,10 @@ DecompressMemFvs (
   PeiMemFv = (EFI_FIRMWARE_VOLUME_HEADER *)(UINTN)PcdGet32 (PcdOvmfPeiMemFvBase);
   CopyMem (PeiMemFv, (VOID *)(FvSection + 1), PcdGet32 (PcdOvmfPeiMemFvSize));
 
+  CopyMem ((VOID *)0x420000, (VOID *)(FvSection + 1), PcdGet32 (PcdOvmfPeiMemFvSize));
+  DEBUG ((DEBUG_INFO, "PeiFv: 0x%08x +0x%08x\n", PeiMemFv, PcdGet32 (PcdOvmfPeiMemFvSize)));
+  DEBUG ((DEBUG_INFO, "PeiFv: 0x%08x (copy)\n", 0x420000));
+
   if (PeiMemFv->Signature != EFI_FVH_SIGNATURE) {
     DEBUG ((DEBUG_ERROR, "Extracted FV at %p does not have FV header signature\n", PeiMemFv));
     CpuDeadLoop ();


### PR DESCRIPTION
- tools_def: remove GCC_IA32_CC_FLAGS/GCC_X64_CC_FLAGS
- tools_def: add -fno-omit-frame-pointer to GCC48_{IA32,X64}_CC_FLAGS
- OvmfPkg/PlatformPei: AmdSev: stop using mPlatformInfoHob
- OvmfPkg/PlatformPei: PeiFv: stop using mPlatformInfoHob
- OvmfPkg/PlatformPei Q35 SMM helpers: stop using mPlatformInfoHob
- OvmfPkg/PlatformPei: PeiMemory: stop using mPlatformInfoHob
- OvmfPkg/PlatformPei: MemTypeInfo: stop using mPlatformInfoHob
- OvmfPkg/PlatformPei: NoExec: stop using mPlatformInfoHob
- OvmfPkg/PlatformPei: Verification: stop using mPlatformInfoHob
- OvmfPkg/PlatformPei: BuildPlatformInfoHob: stop using mPlatformInfoHob
- OvmfPkg/PlatformPei: remove mPlatformInfoHob
- OvmfPkg/PlatformPei: remove mFeatureControlValue
- OvmfPkg/QemuFwCfgLib: no DMA support for PEI
- OvmfPkg/QemuFwCfgLib: rewrite fw_cfg probe
- OvmfPkg/QemuFwCfgLib: ditch mQemuFwCfgSupported
- OvmfPkg/DebugLibIoPort: use Rom version for PEI
- [debug] store peifv copy
- [debug] register peifv copy
- [debug] DebugPeiFvCheck()
