### PR TITLE
ShellPkg: Improve "ping" output by adding equals sign after time

### DIFF
--- a/ShellPkg/Library/UefiShellNetwork1CommandsLib/UefiShellNetwork1CommandsLib.uni
+++ b/ShellPkg/Library/UefiShellNetwork1CommandsLib/UefiShellNetwork1CommandsLib.uni
@@ -52,7 +52,7 @@
 #string STR_PING_NOROUTE_FOUND       #language en-US "There is no route to the destination '%B%s%N' from the source '%B%s%N' was found.\r\n"
 #string STR_PING_START               #language en-US "Ping %s %d data bytes.\r\n"
 #string STR_PING_TIMEOUT             #language en-US "Echo request sequence %d timeout.\r\n"
-#string STR_PING_REPLY_INFO          #language en-US "%d bytes from %s : icmp_seq=%d ttl=%d time%d~%dms\r\n"
+#string STR_PING_REPLY_INFO          #language en-US "%d bytes from %s : icmp_seq=%d ttl=%d time=%d~%dms\r\n"
 #string STR_PING_STAT                #language en-US "\n%d packets transmitted, %d received, %d%% packet loss, time %dms\r\n"
 #string STR_PING_RTT                 #language en-US "\nRtt(round trip time) min=%d~%dms max=%d~%dms avg=%d~%dms\r\n"
 

--- a/ShellPkg/Library/UefiShellNetwork2CommandsLib/UefiShellNetwork2CommandsLib.uni
+++ b/ShellPkg/Library/UefiShellNetwork2CommandsLib/UefiShellNetwork2CommandsLib.uni
@@ -33,7 +33,7 @@
 #string STR_PING6_NOSOURCE_INDOMAIN        #language en-US  "No sources in %s's multicast domain.\r\n"
 #string STR_PING6_START                    #language en-US  "Ping %s %d data bytes\r\n"
 #string STR_PING6_TIMEOUT                  #language en-US  "Echo request sequence %d timeout.\r\n"
-#string STR_PING6_REPLY_INFO               #language en-US  "%d bytes from %s : icmp_seq=%d ttl=%d time%d~%dms\r\n"
+#string STR_PING6_REPLY_INFO               #language en-US  "%d bytes from %s : icmp_seq=%d ttl=%d time=%d~%dms\r\n"
 #string STR_PING6_STAT                     #language en-US  "\n%d packets transmitted, %d received, %d%% packet loss, time %dms\r\n"
 #string STR_PING6_RTT                      #language en-US  "\nRtt(round trip time) min=%d~%dms max=%d~%dms avg=%d~%dms\r\n"
 


### PR DESCRIPTION
The output of the "ping" command shows the time without a space between the label and the value. e.g.:

20 bytes from 192.168.0.1 : icmp_seq=1 ttl=1 time1~2ms

Improve the readability and consistency by adding an equals sign for the time value:

20 bytes from 192.168.0.1 : icmp_seq=1 ttl=1 time=1~2ms

Signed-off-by: Rebecca Cran <rebecca@quicinc.com>