### PR TITLE
MdeModulePkg: Improve formatting of warning DEBUG in UsbSelectConfig

### DIFF
--- a/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbEnumer.c
+++ b/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbEnumer.c
@@ -440,7 +440,7 @@ UsbSelectConfig (
     if (EFI_ERROR (Status)) {
       DEBUG ((
         DEBUG_WARN,
-        "UsbSelectConfig: failed to connect driver %r, ignored\n",
+        "UsbSelectConfig: failed to connect driver (%r), ignored\n",
         Status
         ));
     }


### PR DESCRIPTION
Improve the formatting of a warning in UsbSelectConfig by adding parentheses around the EFI_STATUS value.

Signed-off-by: Rebecca Cran <rebecca@quicinc.com>