### PR TITLE
CryptoPkg/BaseCryptLib:time overflow

### DIFF
--- a/CryptoPkg/Library/Include/CrtLibSupport.h
+++ b/CryptoPkg/Library/Include/CrtLibSupport.h
@@ -109,7 +109,7 @@ typedef UINTN   off_t;
 typedef UINTN   u_int;
 typedef INTN    ptrdiff_t;
 typedef INTN    ssize_t;
-typedef INT32   time_t;
+typedef INT64   time_t;
 typedef UINT8   __uint8_t;
 typedef UINT8   sa_family_t;
 typedef UINT8   u_char;


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4167

In CrtLibSupport.h, time_t is defined as INT32, and its maximum value is 2147483647. That is, the corresponding maximum timestamp is 2038-01-19 11:14:07. Therefore, overflow occurs when the test time exceeds 2038-01-19 11:14:07. So change the type of time_t to INT64 and also change the type of variables in function gmtime which calculated with time_t.

Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Xiaoyu Lu <xiaoyu1.lu@intel.com>
Cc: Guomin Jiang <guomin.jiang@intel.com>
Signed-off-by: Zihong Yi <yizihong@huawei.com>