### PR TITLE
RedfishPkg: Fix typos of the .inc filenames

### DIFF
--- a/RedfishPkg/Redfish.fdf.inc
+++ b/RedfishPkg/Redfish.fdf.inc
@@ -2,7 +2,7 @@
 # Redfish FDF include file for [FV*] section of all Architectures.
 #
 # This file can be included to the [FV*] section(s) of a platform FDF file
-# by using "!include RedfishPkg/RedfisLibs.fdf.inc" to specify the module instances
+# by using "!include RedfishPkg/Redfish.fdf.inc" to specify the module instances
 # to be built in the firmware volume.
 #
 # (C) Copyright 2020-2021 Hewlett Packard Enterprise Development LP<BR>

--- a/RedfishPkg/RedfishLibs.dsc.inc
+++ b/RedfishPkg/RedfishLibs.dsc.inc
@@ -2,7 +2,7 @@
 # Redfish DSC include file for [LibraryClasses*] section of all Architectures.
 #
 # This file can be included to the [LibraryClasses*] section(s) of a platform DSC file
-# by using "!include RedfishPkg/RedfisLibs.dsc.inc" to specify the library instances
+# by using "!include RedfishPkg/RedfishLibs.dsc.inc" to specify the library instances
 # of EDKII network library classes.
 #
 # (C) Copyright 2021 Hewlett Packard Enterprise Development LP<BR>


### PR DESCRIPTION
Fix a typo of "RedfishLibs.dsc.inc" in RedfishLibs.dsc.inc, and correct the name of the .fdf.inc filename in Redfish.fdf.inc.

Signed-off-by: Rebecca Cran <rebecca@quicinc.com>
Reviewed-by: Nickle Wang <nicklew@nvidia.com>
Reviewed-by: Abner Chang <abner.chang@amd.com>