### PR TITLE
RedfishPkg: Remove overlapping private include path in DEC file

### DIFF
--- a/RedfishPkg/RedfishPkg.dec
+++ b/RedfishPkg/RedfishPkg.dec
@@ -17,7 +17,6 @@
   Include
 
 [Includes.Common.Private]
-  PrivateInclude                # Private header files for C RTL.
   PrivateInclude/Crt            # Private header files for C RTL.
   Library/JsonLib               # Private header files for jansson
                                 # configuration files.


### PR DESCRIPTION
Update ReadfishPkg.dec to remove PrivateInclude from the [Includes.Common.Private] section.  The PrivateInclude directory does not contain any include files, and the PrivateInclude/Crt include path remaining in the [Includes.Common.Private] section providing the include path required to access the CRT related include files by components within the RedfishPkg.

Without this update, there are two forms of #include statements that can be used to include the CRT related include files. Include files should only be available using one form of #include statements.

Cc: Abner Chang <abner.chang@amd.com>
Cc: Nickle Wang <nicklew@nvidia.com>
Cc: Igor Kulchytskyy <igork@ami.com>
Signed-off-by: Michael D Kinney <michael.d.kinney@intel.com>