### PR TITLE
UnitTestFrameworkPkg: Modify APIs in UnitTestPersistenceLib

### DIFF
--- a/UnitTestFrameworkPkg/Include/Library/UnitTestPersistenceLib.h
+++ b/UnitTestFrameworkPkg/Include/Library/UnitTestPersistenceLib.h
@@ -4,7 +4,7 @@
   (eg. a reboot-based test).
 
   Copyright (c) Microsoft Corporation.<BR>
-  Copyright (c) 2019 - 2020, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2019 - 2022, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -12,7 +12,7 @@
 #ifndef _UNIT_TEST_PERSISTENCE_LIB_H_
 #define _UNIT_TEST_PERSISTENCE_LIB_H_
 
-#include <UnitTestFrameworkTypes.h>
+#include <Library/UnitTestLib.h>
 
 #define UNIT_TEST_PERSISTENCE_LIB_VERSION  1
 
@@ -40,6 +40,7 @@ DoesCacheExist (
   @param[in]  FrameworkHandle   A pointer to the framework that is being persisted.
   @param[in]  SaveData          A pointer to the buffer containing the serialized
                                 framework internal state.
+  @param[in]  SaveStateSize     The size of SaveData in bytes.
 
   @retval     EFI_SUCCESS   Data is persisted and the test can be safely quit.
   @retval     Others        Data is not persisted and test cannot be resumed upon exit.
@@ -49,7 +50,8 @@ EFI_STATUS
 EFIAPI
 SaveUnitTestCache (
   IN UNIT_TEST_FRAMEWORK_HANDLE  FrameworkHandle,
-  IN UNIT_TEST_SAVE_HEADER       *SaveData
+  IN VOID                        *SaveData,
+  IN UINTN                       SaveStateSize
   );
 
 /**
@@ -57,8 +59,9 @@ SaveUnitTestCache (
   Will allocate a buffer to hold the loaded data.
 
   @param[in]  FrameworkHandle   A pointer to the framework that is being persisted.
-  @param[in]  SaveData          A pointer pointer that will be updated with the address
+  @param[out] SaveData          A pointer pointer that will be updated with the address
                                 of the loaded data buffer.
+  @param[out] SaveStateSize     Return the size of SaveData in bytes.
 
   @retval     EFI_SUCCESS       Data has been loaded successfully and SaveData is updated
                                 with a pointer to the buffer.
@@ -70,7 +73,8 @@ EFI_STATUS
 EFIAPI
 LoadUnitTestCache (
   IN  UNIT_TEST_FRAMEWORK_HANDLE  FrameworkHandle,
-  OUT UNIT_TEST_SAVE_HEADER       **SaveData
+  OUT VOID                        **SaveData,
+  OUT UINTN                       *SaveStateSize
   );
 
 #endif

--- a/UnitTestFrameworkPkg/Library/UnitTestLib/UnitTestLib.c
+++ b/UnitTestFrameworkPkg/Library/UnitTestLib/UnitTestLib.c
@@ -2,6 +2,7 @@
   Implement UnitTestLib
 
   Copyright (c) Microsoft Corporation.
+  Copyright (c) 2022, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
@@ -210,6 +211,7 @@ InitUnitTestFramework (
   EFI_STATUS                  Status;
   UNIT_TEST_FRAMEWORK_HANDLE  NewFrameworkHandle;
   UNIT_TEST_FRAMEWORK         *NewFramework;
+  UINTN                       SaveStateSize;
 
   Status       = EFI_SUCCESS;
   NewFramework = NULL;
@@ -267,7 +269,7 @@ InitUnitTestFramework (
   // If there is a persisted context, load it now.
   //
   if (DoesCacheExist (NewFrameworkHandle)) {
-    Status = LoadUnitTestCache (NewFrameworkHandle, (UNIT_TEST_SAVE_HEADER **)(&NewFramework->SavedState));
+    Status = LoadUnitTestCache (NewFrameworkHandle, (VOID **)(&NewFramework->SavedState), &SaveStateSize);
     if (EFI_ERROR (Status)) {
       //
       // Don't actually report it as an error, but emit a warning.
@@ -852,7 +854,7 @@ SaveFrameworkState (
   //
   // All that should be left to do is save it using the associated persistence lib.
   //
-  Status = SaveUnitTestCache (FrameworkHandle, Header);
+  Status = SaveUnitTestCache (FrameworkHandle, Header, Header->SaveStateSize);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a - Could not save state! %r\n", __FUNCTION__, Status));
     Status = EFI_DEVICE_ERROR;

--- a/UnitTestFrameworkPkg/Library/UnitTestPersistenceLibNull/UnitTestPersistenceLibNull.c
+++ b/UnitTestFrameworkPkg/Library/UnitTestPersistenceLibNull/UnitTestPersistenceLibNull.c
@@ -2,6 +2,7 @@
   This is an instance of the Unit Test Persistence Lib that does nothing.
 
   Copyright (c) Microsoft Corporation.<BR>
+  Copyright (c) 2022, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
@@ -35,6 +36,7 @@ DoesCacheExist (
   @param[in]  FrameworkHandle  A pointer to the framework that is being persisted.
   @param[in]  SaveData         A pointer to the buffer containing the serialized
                                framework internal state.
+  @param[in]  SaveStateSize    The size of SaveData in bytes.
 
   @retval  EFI_SUCCESS  Data is persisted and the test can be safely quit.
   @retval  Others       Data is not persisted and test cannot be resumed upon exit.
@@ -44,7 +46,8 @@ EFI_STATUS
 EFIAPI
 SaveUnitTestCache (
   IN UNIT_TEST_FRAMEWORK_HANDLE  FrameworkHandle,
-  IN UNIT_TEST_SAVE_HEADER       *SaveData
+  IN VOID                        *SaveData,
+  IN UINTN                       SaveStateSize
   )
 {
   return EFI_UNSUPPORTED;
@@ -55,8 +58,9 @@ SaveUnitTestCache (
   Will allocate a buffer to hold the loaded data.
 
   @param[in]  FrameworkHandle  A pointer to the framework that is being persisted.
-  @param[in]  SaveData         A pointer pointer that will be updated with the address
+  @param[out] SaveData         A pointer pointer that will be updated with the address
                                of the loaded data buffer.
+  @param[out] SaveStateSize    Return the size of SaveData in bytes.
 
   @retval  EFI_SUCCESS  Data has been loaded successfully and SaveData is updated
                         with a pointer to the buffer.
@@ -68,7 +72,8 @@ EFI_STATUS
 EFIAPI
 LoadUnitTestCache (
   IN  UNIT_TEST_FRAMEWORK_HANDLE  FrameworkHandle,
-  OUT UNIT_TEST_SAVE_HEADER       **SaveData
+  OUT VOID                        **SaveData,
+  OUT UINTN                       *SaveStateSize
   )
 {
   return EFI_UNSUPPORTED;


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4183

UnitTestPersistenceLib now consumes private struct definition. Modify APIs in UnitTestPersistenceLib to make it easy to become a public library.

Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Michael Kubacki <mikuback@linux.microsoft.com>
Cc: Sean Brogan <sean.brogan@microsoft.com>
Signed-off-by: Zhiguang Liu <zhiguang.liu@intel.com>