### PR TITLE
Fix some typos

### DIFF
--- a/ArmPkg/Drivers/ArmScmiDxe/ScmiDxe.c
+++ b/ArmPkg/Drivers/ArmScmiDxe/ScmiDxe.c
@@ -40,7 +40,7 @@ STATIC CONST SCMI_PROTOCOL_ENTRY  Protocols[] = {
                              install Base, Clock and Performance protocols.
   @param[in] SystemTable     A pointer to boot time system table.
 
-  @retval EFI_SUCCESS       Driver initalized successfully.
+  @retval EFI_SUCCESS       Driver initialized successfully.
   @retval EFI_UNSUPPORTED   If SCMI base protocol version is not supported.
   @retval !(EFI_SUCCESS)    Other errors.
 **/

--- a/ArmPkg/Include/Library/OemMiscLib.h
+++ b/ArmPkg/Include/Library/OemMiscLib.h
@@ -86,7 +86,7 @@ OemGetCpuFreq (
 
   @param ProcessorIndex  Index of the processor to get the information for.
   @param ProcessorStatus Processor status.
-  @param ProcessorCharacteristics Processor characteritics.
+  @param ProcessorCharacteristics Processor characteristics.
   @param MiscProcessorData        Miscellaneous processor information.
 
   @return  TRUE on success, FALSE on failure.

--- a/ArmPkg/Library/ArmDisassemblerLib/ThumbDisassembler.c
+++ b/ArmPkg/Library/ArmDisassemblerLib/ThumbDisassembler.c
@@ -663,9 +663,9 @@ DisassembleThumbInstruction (
           // ITSTATE = cond:mask   OpCode[7:4]:OpCode[3:0]
           // ITSTATE[7:5] == cond[3:1]
           // ITSTATE[4] == 1st Instruction cond[0]
-          // ITSTATE[3] == 2st Instruction cond[0]
-          // ITSTATE[2] == 3st Instruction cond[0]
-          // ITSTATE[1] == 4st Instruction cond[0]
+          // ITSTATE[3] == 2nd Instruction cond[0]
+          // ITSTATE[2] == 3rd Instruction cond[0]
+          // ITSTATE[1] == 4th Instruction cond[0]
           // ITSTATE[0] == 1 4 instruction IT block. 0 means 0,1,2 or 3 instructions
           // 1st one  in ITSTATE low bits defines the number of instructions
           Mask = (OpCode & 0xf);

--- a/ArmPkg/Library/ArmLib/AArch64/ArmLibSupport.S
+++ b/ArmPkg/Library/ArmLib/AArch64/ArmLibSupport.S
@@ -20,7 +20,7 @@ ASM_FUNC(ArmReadMidr)
   ret
 
 ASM_FUNC(ArmCacheInfo)
-  mrs     x0, ctr_el0         // Read from Cache Type Regiter (CTR)
+  mrs     x0, ctr_el0         // Read from Cache Type Register (CTR)
   ret
 
 ASM_FUNC(ArmGetInterruptState)

--- a/ArmPkg/Library/ArmLib/AArch64/ArmLibSupportV8.S
+++ b/ArmPkg/Library/ArmLib/AArch64/ArmLibSupportV8.S
@@ -23,7 +23,7 @@
 
 
 ASM_FUNC(ArmIsMpCore)
-  mrs   x0, mpidr_el1         // Read EL1 Multiprocessor Affinty Reg (MPIDR)
+  mrs   x0, mpidr_el1         // Read EL1 Multiprocessor Affinity Reg (MPIDR)
   and   x0, x0, #MPIDR_U_MASK // U Bit clear, the processor is part of a multiprocessor system
   lsr   x0, x0, #MPIDR_U_BIT
   eor   x0, x0, #1

--- a/ArmPkg/Library/SemihostLib/Arm/GccSemihost.S
+++ b/ArmPkg/Library/SemihostLib/Arm/GccSemihost.S
@@ -16,7 +16,7 @@
   BKPT 0xAB for ARMv7-M (Thumb-2 only)
 
   R0 - operation type
-  R1 - block containing all other parametes
+  R1 - block containing all other parameters
 
   lr - must be saved as svc instruction will cause an svc exception and write
        the svc lr register. That happens to be the one we are using, so we must

--- a/ArmPkg/Library/StandaloneMmMmuLib/ArmMmuStandaloneMmLib.c
+++ b/ArmPkg/Library/StandaloneMmMmuLib/ArmMmuStandaloneMmLib.c
@@ -31,7 +31,7 @@
                                 return it contains the response parameters.
   @param [out]      RetVal      Pointer to return the response value.
 
-  @retval EFI_SUCCESS           Request successfull.
+  @retval EFI_SUCCESS           Request successful.
   @retval EFI_INVALID_PARAMETER A parameter is invalid.
   @retval EFI_NOT_READY         Callee is busy or not in a state to handle
                                 this request.
@@ -134,7 +134,7 @@ SendMemoryPermissionRequest (
   @param [in]   BaseAddress          Base address for the memory region.
   @param [out]  MemoryAttributes     Pointer to return the memory attributes.
 
-  @retval EFI_SUCCESS             Request successfull.
+  @retval EFI_SUCCESS             Request successful.
   @retval EFI_INVALID_PARAMETER   A parameter is invalid.
   @retval EFI_NOT_READY           Callee is busy or not in a state to handle
                                   this request.
@@ -193,7 +193,7 @@ GetMemoryPermissions (
   @param [in]  Length          Length of the memory region.
   @param [in]  Permissions     Memory access controls attributes.
 
-  @retval EFI_SUCCESS             Request successfull.
+  @retval EFI_SUCCESS             Request successful.
   @retval EFI_INVALID_PARAMETER   A parameter is invalid.
   @retval EFI_NOT_READY           Callee is busy or not in a state to handle
                                   this request.

--- a/ArmPkg/Universal/Smbios/OemMiscLibNull/OemMiscLib.c
+++ b/ArmPkg/Universal/Smbios/OemMiscLibNull/OemMiscLib.c
@@ -39,7 +39,7 @@ OemGetCpuFreq (
 
   @param ProcessorIndex  Index of the processor to get the information for.
   @param ProcessorStatus Processor status.
-  @param ProcessorCharacteristics Processor characteritics.
+  @param ProcessorCharacteristics Processor characteristics.
   @param MiscProcessorData        Miscellaneous processor information.
 
   @return  TRUE on success, FALSE on failure.

--- a/ArmPkg/Universal/Smbios/ProcessorSubClassDxe/SmbiosProcessorArmCommon.c
+++ b/ArmPkg/Universal/Smbios/ProcessorSubClassDxe/SmbiosProcessorArmCommon.c
@@ -79,7 +79,7 @@ SmbiosProcessorHasSeparateCaches (
   return SeparateCaches;
 }
 
-/** Checks if ther ARM64 SoC ID SMC call is supported
+/** Checks if the ARM64 SoC ID SMC call is supported
 
     @return Whether the ARM64 SoC ID call is supported.
 **/

--- a/ArmPlatformPkg/ArmPlatformPkg.dec
+++ b/ArmPlatformPkg/ArmPlatformPkg.dec
@@ -97,7 +97,7 @@
   gArmPlatformTokenSpaceGuid.PcdPL111LcdBase|0x0|UINT32|0x00000026
   gArmPlatformTokenSpaceGuid.PcdArmHdLcdBase|0x0|UINT32|0x00000027
 
-  ## Default size for display modes upto 1920x1080 (1920 * 1080 * 4 Bytes Per Pixel)
+  ## Default size for display modes up to 1920x1080 (1920 * 1080 * 4 Bytes Per Pixel)
   gArmPlatformTokenSpaceGuid.PcdArmLcdDdrFrameBufferSize|0x7E9000|UINT32|0x00000043
   ## If set, framebuffer memory will be reserved and mapped in the system RAM
   gArmPlatformTokenSpaceGuid.PcdArmLcdDdrFrameBufferBase|0x0|UINT64|0x00000044

--- a/ArmPlatformPkg/Include/Library/LcdPlatformLib.h
+++ b/ArmPlatformPkg/Include/Library/LcdPlatformLib.h
@@ -220,7 +220,7 @@ typedef struct {
 
   @param[in] Handle              Handle to the LCD device instance.
 
-  @retval EFI_SUCCESS            Plaform library initialized successfully.
+  @retval EFI_SUCCESS            Platform library initialized successfully.
   @retval !(EFI_SUCCESS)         Other errors.
 **/
 EFI_STATUS

--- a/ArmPlatformPkg/Library/ArmMaliDp/ArmMaliDp.c
+++ b/ArmPlatformPkg/Library/ArmMaliDp/ArmMaliDp.c
@@ -287,7 +287,7 @@ LcdInitialize (
   return EFI_SUCCESS;
 }
 
-/** Set ARM Mali DP in cofiguration mode.
+/** Set ARM Mali DP in configuration mode.
 
   The ARM Mali DP must be in the configuration mode for
   configuration of the H_INTERVALS, V_INTERVALS, SYNC_CONTROL

--- a/ArmPlatformPkg/Library/PL111Lcd/PL111Lcd.c
+++ b/ArmPlatformPkg/Library/PL111Lcd/PL111Lcd.c
@@ -19,7 +19,7 @@
   @retval EFI_SUCCESS          Returns success if platform implements a
                                PL111 controller.
 
-  @retval EFI_NOT_FOUND        PL111 display controller not found the plaform.
+  @retval EFI_NOT_FOUND        PL111 display controller not found the platform.
 **/
 EFI_STATUS
 LcdIdentify (
@@ -73,7 +73,7 @@ LcdInitialize (
 
   @param[in] ModeNumbe           Display mode number.
 
-  @retval EFI_SUCCESS            Display mode set successfuly.
+  @retval EFI_SUCCESS            Display mode set successfully.
   @retval !(EFI_SUCCESS)         Other errors.
 **/
 EFI_STATUS


### PR DESCRIPTION
Hi all,

I sent the patch file to devel@edk2.groups.io via git send email 
on December 2, but I didn’t see my patch on the mailing list, 
so I submitted it again via PR on GitHub.

My focus was fixing typos in comments. Most of them
were found by spellchecker.

There are many similar spelling mistakes, so to avoid involving
too many modules at once, only the files in the 'ArmPkg',
'ArmPlatformPkg' and 'ArmVirtPkg' directories were modified this time.