### PR TITLE
MdeModulePkg/UefiBootManagerLib: Use hob size to process MemoryTypeInfo

### DIFF
--- a/MdeModulePkg/Library/UefiBootManagerLib/BmMisc.c
+++ b/MdeModulePkg/Library/UefiBootManagerLib/BmMisc.c
@@ -140,6 +140,7 @@ BmSetMemoryTypeInformationVariable (
   UINT32                       Current;
   UINT32                       Next;
   EFI_HOB_GUID_TYPE            *GuidHob;
+  UINTN                        NoOfEntries;
   BOOLEAN                      MemoryTypeInformationModified;
   BOOLEAN                      MemoryTypeInformationVariableExists;
   EFI_BOOT_MODE                BootMode;
@@ -200,6 +201,7 @@ BmSetMemoryTypeInformationVariable (
   }
 
   VariableSize                  = GET_GUID_HOB_DATA_SIZE (GuidHob);
+  NoOfEntries                   = VariableSize / sizeof(EFI_MEMORY_TYPE_INFORMATION);
   PreviousMemoryTypeInformation = AllocateCopyPool (VariableSize, GET_GUID_HOB_DATA (GuidHob));
   if (PreviousMemoryTypeInformation == NULL) {
     return;
@@ -212,8 +214,8 @@ BmSetMemoryTypeInformationVariable (
   DEBUG ((DEBUG_INFO, " Type    Pages     Pages     Pages  \n"));
   DEBUG ((DEBUG_INFO, "======  ========  ========  ========\n"));
 
-  for (Index = 0; PreviousMemoryTypeInformation[Index].Type != EfiMaxMemoryType; Index++) {
-    for (Index1 = 0; CurrentMemoryTypeInformation[Index1].Type != EfiMaxMemoryType; Index1++) {
+  for (Index = 0; Index < NoOfEntries; Index++) {
+    for (Index1 = 0; Index1 < NoOfEntries; Index1++) {
       if (PreviousMemoryTypeInformation[Index].Type == CurrentMemoryTypeInformation[Index1].Type) {
         break;
       }


### PR DESCRIPTION
Current code relies on last entry in hob to be MaxMemoryType enum value which keeps changing on new memory type definition. If the HOB is created by binaries built with older Edk2, current code leads to hang which could be avoided by using hob size.

Signed-off-by: Baraneedharan Anbazhagan <anbazhagan@hp.com>