### PR TITLE
OvmfPkg/PlatformInitLib: pass through reservations from qemu

### DIFF
--- a/OvmfPkg/Library/PlatformInitLib/MemDetect.c
+++ b/OvmfPkg/Library/PlatformInitLib/MemDetect.c
@@ -228,6 +228,22 @@ PlatformScanOrAdd64BitE820Ram (
             ));
         }
       }
+    } else if (E820Entry.Type == EfiAcpiAddressRangeReserved) {
+      if (AddHighHob) {
+        DEBUG ((
+          DEBUG_INFO,
+          "%a: Reserved: Base=0x%Lx Length=0x%Lx\n",
+          __FUNCTION__,
+          E820Entry.BaseAddr,
+          E820Entry.Length
+          ));
+        BuildResourceDescriptorHob (
+          EFI_RESOURCE_MEMORY_RESERVED,
+          0,
+          E820Entry.BaseAddr,
+          E820Entry.Length
+          );
+      }
     }
   }
 


### PR DESCRIPTION
qemu uses the etc/e820 fw_cfg file not only for memory, but
also for reservations.  Handle reservations by adding resource
descriptor hobs for them.

A typical qemu configuration has a small reservation between
lapic and flash:

  # sudo cat /proc/iomem
  [ ... ]
  fee00000-fee00fff : Local APIC
  feffc000-feffffff : Reserved          <= HERE
  ffc00000-ffffffff : Reserved
  [ ... ]

Signed-off-by: Gerd Hoffmann <kraxel@redhat.com>
