### PR TITLE
MdeModulePkg/DxeCore: Use correct type for alignment mask

### DIFF
--- a/MdeModulePkg/Core/Dxe/Mem/Page.c
+++ b/MdeModulePkg/Core/Dxe/Mem/Page.c
@@ -1097,7 +1097,7 @@ CoreFindFreePagesI (
       DescEnd = MaxAddress;
     }
 
-    DescEnd = ((DescEnd + 1) & (~(Alignment - 1))) - 1;
+    DescEnd = ((DescEnd + 1) & (~((UINT64)Alignment - 1))) - 1;
 
     // Skip if DescEnd is less than DescStart after alignment clipping
     if (DescEnd < DescStart) {


### PR DESCRIPTION
The page allocator code in CoreFindFreePagesI() uses a mask derived from its UINTN Alignment argument to align the descriptor end address of a MEMORY_MAP entry to the requested alignment, in order to check whether the descriptor covers enough sufficiently aligned area to satisfy the request.

However, on 32-bit architectures, 'Alignment' is a 32-bit type, whereas DescEnd is a 64-bit type, and so the resulting operation performed on the end address comes down to masking with 0xfffff000 instead of the intended 0xffffffff_fffff000. Given the -1 at the end of the expression, the resulting address is 0xffffffff_fffffffff for any descriptor that ends on a 4G aligned boundary, and this is certainly not what was intended.

So cast Alignment to UINT64 to ensure that the mask has the right size.

Signed-off-by: Ard Biesheuvel <ardb@kernel.org>
Reported-by: Nathan Chancellor <nathan@kernel.org>
Reviewed-by: Michael D Kinney <michael.d.kinney@intel.com>