### PR TITLE
OvmfPkg: Add INVD case in #VE handler

### DIFF
--- a/OvmfPkg/Library/CcExitLib/CcExitVeHandler.c
+++ b/OvmfPkg/Library/CcExitLib/CcExitVeHandler.c
@@ -545,6 +545,7 @@ CcExitHandleVe (
     case EXIT_REASON_MONITOR_INSTRUCTION:
     case EXIT_REASON_WBINVD:
     case EXIT_REASON_RDPMC:
+    case EXIT_REASON_INVD:
       /* Handle as nops. */
       break;
 


### PR DESCRIPTION
According to the Intel GHCI specification document section 2.4.1, the goal for instructions that do not have a corresponding TDCALL is for the handler to treat the instruction as a NOP.

INVD does not have a corresponding TDCALL. This patch makes the #VE handler treat INVD as a NOP.

Signed-off-by: Ryan Afranji <afranji@google.com>
Reviewed-by: Jiewen Yao <jiewen.yao@intel.com>