### PR TITLE
OvmfPkg: fix PlatformConfig

### DIFF
--- a/OvmfPkg/PlatformDxe/Platform.c
+++ b/OvmfPkg/PlatformDxe/Platform.c
@@ -258,7 +258,7 @@ ExtractConfig (
       !HiiIsConfigHdrMatch (
          Request,
          &gOvmfPlatformConfigGuid,
-         mVariableName
+         mHiiFormName
          )
       )
   {
@@ -447,7 +447,7 @@ RouteConfig (
       !HiiIsConfigHdrMatch (
          Configuration,
          &gOvmfPlatformConfigGuid,
-         mVariableName
+         mHiiFormName
          )
       )
   {

--- a/OvmfPkg/PlatformDxe/PlatformConfig.c
+++ b/OvmfPkg/PlatformDxe/PlatformConfig.c
@@ -22,6 +22,7 @@
 // Name of the UEFI variable that we use for persistent storage.
 //
 CHAR16  mVariableName[] = L"PlatformConfig";
+CHAR16  mHiiFormName[]  = L"MainFormState";
 
 /**
   Serialize and persistently save platform configuration.

--- a/OvmfPkg/PlatformDxe/PlatformConfig.h
+++ b/OvmfPkg/PlatformDxe/PlatformConfig.h
@@ -51,5 +51,6 @@ PlatformConfigLoad (
 #define PLATFORM_CONFIG_F_DOWNGRADE            BIT63
 
 extern CHAR16  mVariableName[];
+extern CHAR16  mHiiFormName[];
 
 #endif // _PLATFORM_CONFIG_H_


### PR DESCRIPTION
The Hii form is named "MainFormState" and the EFI variable is named
"PlatformConfig".  Take into account the different names.

Fixes: aefcc91805fd ("OvmfPkg/PlatformDxe: Handle all requests in ExtractConfig and RouteConfig")
Signed-off-by: Gerd Hoffmann <kraxel@redhat.com>
