### PR TITLE
ShellPkg/Shell: Do not set end device path if already end

### DIFF
--- a/ShellPkg/Application/Shell/ShellProtocol.c
+++ b/ShellPkg/Application/Shell/ShellProtocol.c
@@ -294,7 +294,13 @@ EfiShellGetMapFromDevicePath (
       *DevicePath = NextDevicePathNode (*DevicePath);
     }
 
-    SetDevicePathEndNode (*DevicePath);
+    //
+    // Do not call SetDevicePathEndNode() if the device path node is already the
+    // end of an entire device path.
+    //
+    if (!IsDevicePathEnd (*DevicePath)) {
+      SetDevicePathEndNode (*DevicePath);
+    }
   }
 
   /*


### PR DESCRIPTION
Update Shell Protocol EfiShellGetMapFromDevicePath() to not set the end if the device path if it is already an end of entire device path.  This removes a write oprtation that can cause failures if the Device Path Protocol is mapped to read-only memory.  In general Device Path Protocols should not be modified unless the API explicitly states that the device path is modified.

Cc: Ard Biesheuvel <ardb@kernel.org>
Cc: Ray Ni <ray.ni@intel.com>
Cc: Zhichao Gao <zhichao.gao@intel.com>
Signed-off-by: Michael D Kinney <michael.d.kinney@intel.com>