### PR TITLE
Fix incorrect implementation in CcMeasurement

### DIFF
--- a/OvmfPkg/IntelTdx/TdTcg2Dxe/TdTcg2Dxe.c
+++ b/OvmfPkg/IntelTdx/TdTcg2Dxe/TdTcg2Dxe.c
@@ -2411,9 +2411,9 @@ DriverEntry (
 
   mTdxDxeData.BsCap.Size                   = sizeof (EFI_CC_BOOT_SERVICE_CAPABILITY);
   mTdxDxeData.BsCap.ProtocolVersion.Major  = 1;
-  mTdxDxeData.BsCap.ProtocolVersion.Minor  = 1;
+  mTdxDxeData.BsCap.ProtocolVersion.Minor  = 0;
   mTdxDxeData.BsCap.StructureVersion.Major = 1;
-  mTdxDxeData.BsCap.StructureVersion.Minor = 1;
+  mTdxDxeData.BsCap.StructureVersion.Minor = 0;
 
   //
   // Get supported PCR and current Active PCRs

--- a/SecurityPkg/Library/SecTpmMeasurementLib/SecTpmMeasurementLibTdx.c
+++ b/SecurityPkg/Library/SecTpmMeasurementLib/SecTpmMeasurementLibTdx.c
@@ -33,12 +33,11 @@ typedef struct {
 /**
   Get the mapped RTMR index based on the input PCRIndex.
   RTMR[0]  => PCR[1,7]
-  RTMR[1]  => PCR[2,3,4,5]
+  RTMR[1]  => PCR[2,3,4,5,6]
   RTMR[2]  => PCR[8~15]
   RTMR[3]  => NA
   Note:
     PCR[0] is mapped to MRTD and should not appear here.
-    PCR[6] is reserved for OEM. It is not used.
 
    @param[in] PCRIndex The input PCR index
 
@@ -51,7 +50,7 @@ GetMappedRtmrIndex (
 {
   UINT8  RtmrIndex;
 
-  if ((PCRIndex == 6) || (PCRIndex == 0) || (PCRIndex > 15)) {
+  if ((PCRIndex == 0) || (PCRIndex > 15)) {
     DEBUG ((DEBUG_ERROR, "Invalid PCRIndex(%d) map to MR Index.\n", PCRIndex));
     ASSERT (FALSE);
     return INVALID_PCR2MR_INDEX;
@@ -60,7 +59,7 @@ GetMappedRtmrIndex (
   RtmrIndex = 0;
   if ((PCRIndex == 1) || (PCRIndex == 7)) {
     RtmrIndex = 0;
-  } else if ((PCRIndex >= 2) && (PCRIndex < 6)) {
+  } else if ((PCRIndex >= 2) && (PCRIndex <= 6)) {
     RtmrIndex = 1;
   } else if ((PCRIndex >= 8) && (PCRIndex <= 15)) {
     RtmrIndex = 2;


### PR DESCRIPTION

BZ: https://bugzilla.tianocore.org/show_bug.cgi?id=4179
BZ: https://bugzilla.tianocore.org/show_bug.cgi?id=4184

This patch-set fix the incorrect implementation in CcMeasurement.

Patch#1:
  Incorrect protocol and structure version

Patch#2/3:
  Incorrect mapping between TPM PCR index and TDX Measurement Register
  index.

Code: https://github.com/mxu9/edk2/tree/CcMapping.v1

Cc: Erdem Aktas <erdemaktas@google.com> [ruleof2]
Cc: James Bottomley <jejb@linux.ibm.com> [jejb]
Cc: Jiewen Yao <jiewen.yao@intel.com> [jyao1]
Cc: Tom Lendacky <thomas.lendacky@amd.com> [tlendacky]
Cc: Arti Gupta <ARGU@microsoft.com>
Reported-by: Arti Gupta <ARGU@microsoft.com>
Signed-off-by: Min Xu <min.m.xu@intel.com>

Min M Xu (3):
  OvmfPkg/TdTcg2Dxe: Fix incorrect protocol and structure version
  OvmfPkg/TdTcg2Dxe: Fix the mapping error between PCR index and MR
    index
  OvmfPkg/SecTpmMeasurementLib: Fix the mapping error of PCR and RTMR
    index

 OvmfPkg/IntelTdx/TdTcg2Dxe/TdTcg2Dxe.c        | 93 ++++++++++++-------
 .../SecTpmMeasurementLibTdx.c                 |  7 +-
 2 files changed, 65 insertions(+), 35 deletions(-)
