### PR TITLE
OvmfPkg/AmdSev/SecretDxe: Allocate secret location as EfiACPIReclaimM…

### DIFF
--- a/OvmfPkg/AmdSev/SecretDxe/SecretDxe.c
+++ b/OvmfPkg/AmdSev/SecretDxe/SecretDxe.c
@@ -8,11 +8,6 @@
 #include <Library/UefiBootServicesTableLib.h>
 #include <Guid/ConfidentialComputingSecret.h>
 
-STATIC CONFIDENTIAL_COMPUTING_SECRET_LOCATION  mSecretDxeTable = {
-  FixedPcdGet32 (PcdSevLaunchSecretBase),
-  FixedPcdGet32 (PcdSevLaunchSecretSize),
-};
-
 EFI_STATUS
 EFIAPI
 InitializeSecretDxe (
@@ -20,8 +15,23 @@ InitializeSecretDxe (
   IN EFI_SYSTEM_TABLE  *SystemTable
   )
 {
+  EFI_STATUS                              Status;
+  CONFIDENTIAL_COMPUTING_SECRET_LOCATION  *SecretDxeTable;
+
+  Status = gBS->AllocatePool (
+                  EfiACPIReclaimMemory,
+                  sizeof (CONFIDENTIAL_COMPUTING_SECRET_LOCATION),
+                  (VOID **)&SecretDxeTable
+                  );
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  SecretDxeTable->Base = FixedPcdGet32 (PcdSevLaunchSecretBase);
+  SecretDxeTable->Size = FixedPcdGet32 (PcdSevLaunchSecretSize);
+
   return gBS->InstallConfigurationTable (
                 &gConfidentialComputingSecretGuid,
-                &mSecretDxeTable
+                SecretDxeTable
                 );
 }


### PR DESCRIPTION
…emory

BZ: https://bugzilla.tianocore.org/show_bug.cgi?id=4186

Commit 079a58276b98 ("OvmfPkg/AmdSev/SecretPei: Mark SEV launch secret area as reserved") marked the launch secret area itself (1 page) as reserved so the guest OS can use it during the lifetime of the OS. However, the address and size of the secret area held in the CONFIDENTIAL_COMPUTING_SECRET_LOCATION struct are declared as STATIC in OVMF (in AmdSev/SecretDxe); therefore there's no guarantee that it will not be written over by OS data.

Fix this by allocating the memory for the
CONFIDENTIAL_COMPUTING_SECRET_LOCATION struct with the EfiACPIReclaimMemory memory type to ensure the guest OS will not reuse this memory.

Fixes: 079a58276b98 ("OvmfPkg/AmdSev/SecretPei: Mark SEV launch secret ...")
Signed-off-by: Dov Murik <dovmurik@linux.ibm.com>
Reviewed-by: Ard Biesheuvel <ardb@kernel.org>