### PR TITLE
MdeModulePkg/BaseBmpSupportLib: Fix ColorMap issue

### DIFF
--- a/MdeModulePkg/Library/BaseBmpSupportLib/BmpSupportLib.c
+++ b/MdeModulePkg/Library/BaseBmpSupportLib/BmpSupportLib.c
@@ -236,6 +236,12 @@ TranslateBmpToGopBlt (
     return RETURN_UNSUPPORTED;
   }
 
+  if ((BmpHeader->ImageOffset == sizeof (BMP_IMAGE_HEADER)) &&
+      ((BmpHeader->BitPerPixel & 0x0D) != 0))
+  {
+    return RETURN_UNSUPPORTED;
+  }
+
   if (BmpHeader->ImageOffset > sizeof (BMP_IMAGE_HEADER)) {
     switch (BmpHeader->BitPerPixel) {
       case 1:


### PR DESCRIPTION
When BitPerPixel is 1,4,8, there should be a color map in bmp file. But if the format of bmp file is error, it maybe has no color map when BitPerPixel is 1,4,8. The condition checking now can not catch this issue.

Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Zhichao Gao <zhichao.gao@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Signed-off-by: Wenyi Xie <xiewenyi2@huawei.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>