### PR TITLE
UefiPayloadPkg: Move bdsdxe.inf from DXEFV to BDSFV

### DIFF
--- a/UefiPayloadPkg/UefiPayloadPkg.fdf
+++ b/UefiPayloadPkg/UefiPayloadPkg.fdf
@@ -59,8 +59,33 @@ INF UefiPayloadPkg/UefiPayloadEntry/UefiPayloadEntry.inf
 FILE FV_IMAGE = 4E35FD93-9C72-4c15-8C4B-E77F1DB2D793 {
     SECTION FV_IMAGE = DXEFV
 }
+FILE FV_IMAGE = FBE6C1E3-2F80-4770-88B0-494186E3346F {
+    SECTION FV_IMAGE = BDSFV
+}
 
 ################################################################################
+[FV.BDSFV]
+FvNameGuid         = CA5590AF-9558-4822-B5EA-BE2E876CD3EC
+BlockSize          = $(FD_BLOCK_SIZE)
+FvForceRebase      = FALSE
+FvAlignment        = 16
+ERASE_POLARITY     = 1
+MEMORY_MAPPED      = TRUE
+STICKY_WRITE       = TRUE
+LOCK_CAP           = TRUE
+LOCK_STATUS        = TRUE
+WRITE_DISABLED_CAP = TRUE
+WRITE_ENABLED_CAP  = TRUE
+WRITE_STATUS       = TRUE
+WRITE_LOCK_CAP     = TRUE
+WRITE_LOCK_STATUS  = TRUE
+READ_DISABLED_CAP  = TRUE
+READ_ENABLED_CAP   = TRUE
+READ_STATUS        = TRUE
+READ_LOCK_CAP      = TRUE
+READ_LOCK_STATUS   = TRUE
+
+INF MdeModulePkg/Universal/BdsDxe/BdsDxe.inf
 
 [FV.DXEFV]
 FvNameGuid         = 8063C21A-8E58-4576-95CE-089E87975D23
@@ -106,7 +131,7 @@ INF CryptoPkg/Driver/CryptoDxe.inf
 INF MdeModulePkg/Universal/SecurityStubDxe/SecurityStubDxe.inf
 !endif
 INF UefiCpuPkg/CpuDxe/CpuDxe.inf
-INF MdeModulePkg/Universal/BdsDxe/BdsDxe.inf
+
 INF RuleOverride = UI MdeModulePkg/Application/UiApp/UiApp.inf
 INF MdeModulePkg/Application/BootManagerMenuApp/BootManagerMenuApp.inf
 INF PcAtChipsetPkg/HpetTimerDxe/HpetTimerDxe.inf

--- a/UefiPayloadPkg/UniversalPayloadBuild.py
+++ b/UefiPayloadPkg/UniversalPayloadBuild.py
@@ -67,7 +67,8 @@ def BuildUniversalPayload(Args, MacroList):
 
     EntryModuleInf = os.path.normpath("UefiPayloadPkg/UefiPayloadEntry/UniversalPayloadEntry.inf")
     DscPath = os.path.normpath("UefiPayloadPkg/UefiPayloadPkg.dsc")
-    FvOutputDir = os.path.join(BuildDir, "{}_{}".format (BuildTarget, ToolChain), os.path.normpath("FV/DXEFV.Fv"))
+    DxeFvOutputDir = os.path.join(BuildDir, "{}_{}".format (BuildTarget, ToolChain), os.path.normpath("FV/DXEFV.Fv"))
+    BdsFvOutputDir = os.path.join(BuildDir, "{}_{}".format (BuildTarget, ToolChain), os.path.normpath("FV/BDSFV.Fv"))
     PayloadReportPath = os.path.join(BuildDir, "UefiUniversalPayload.txt")
     ModuleReportPath = os.path.join(BuildDir, "UefiUniversalPayloadEntry.txt")
     UpldInfoFile = os.path.join(BuildDir, "UniversalPayloadInfo.bin")
@@ -119,21 +120,22 @@ def BuildUniversalPayload(Args, MacroList):
     #
     # Copy the DXEFV as a section in elf format Universal Payload entry.
     #
-    remove_section = '"{}" -I {} -O {} --remove-section .upld_info --remove-section .upld.uefi_fv {}'.format (
+    remove_section = '"{}" -I {} -O {} --remove-section .upld_info --remove-section .upld.uefi_fv --remove-section .upld.bds_fv {}'.format (
                        LlvmObjcopyPath,
                        ObjCopyFlag,
                        ObjCopyFlag,
                        EntryOutputDir
                        )
-    add_section    = '"{}" -I {} -O {} --add-section .upld_info={} --add-section .upld.uefi_fv={} {}'.format (
+    add_section    = '"{}" -I {} -O {} --add-section .upld_info={} --add-section .upld.uefi_fv={} --add-section .upld.bds_fv={} {}'.format (
                        LlvmObjcopyPath,
                        ObjCopyFlag,
                        ObjCopyFlag,
                        UpldInfoFile,
-                       FvOutputDir,
+                       DxeFvOutputDir,
+                       BdsFvOutputDir,
                        EntryOutputDir
                        )
-    set_section    = '"{}" -I {} -O {} --set-section-alignment .upld_info=4 --set-section-alignment .upld.uefi_fv=16 {}'.format (
+    set_section    = '"{}" -I {} -O {} --set-section-alignment .upld_info=16 --set-section-alignment .upld.uefi_fv=16 --set-section-alignment .upld.bds_fv=16 {}'.format (
                        LlvmObjcopyPath,
                        ObjCopyFlag,
                        ObjCopyFlag,


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4196

Since UefiPayload had supported multiple fv,
move bdsdxe.inf to new firmware volume and
modify the script of UniversalPayloadPkgBuild.py to support bdsdxe fv in elf file

Cc: Guo Dong <guo.dong@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Cc: Sean Rhodes <sean@starlabs.systems>
Reviewed-by: James Lu <james.lu@intel.com>
Reviewed-by: Gua Guo <gua.guo@intel.com>

Signed-off-by: MarsX Lin <marsx.lin@intel.com>