### PR TITLE
Bug xxx unit test framework pkg code coverage

### DIFF
--- a/.azurepipelines/Ubuntu-GCC5.yml
+++ b/.azurepipelines/Ubuntu-GCC5.yml
@@ -19,4 +19,7 @@ jobs:
     tool_chain_tag: 'GCC5'
     vm_image: 'ubuntu-latest'
     arch_list: "IA32,X64,ARM,AARCH64,RISCV64,LOONGARCH64"
-
+    extra_install_step:
+    - bash: sudo apt-get install -y lcov
+      displayName: Install Code Coverage Tools
+      condition: and(gt(variables.pkg_count, 0), succeeded())

--- a/.azurepipelines/Windows-VS2019.yml
+++ b/.azurepipelines/Windows-VS2019.yml
@@ -18,3 +18,8 @@ jobs:
     tool_chain_tag: 'VS2019'
     vm_image: 'windows-2019'
     arch_list: "IA32,X64"
+    extra_install_step:
+    - powershell: choco install opencppcoverage; Write-Host "##vso[task.prependpath]C:\Program Files\OpenCppCoverage"
+      displayName: Install Code Coverage Tool
+      condition: and(gt(variables.pkg_count, 0), succeeded())
+

--- a/.azurepipelines/templates/pr-gate-build-job.yml
+++ b/.azurepipelines/templates/pr-gate-build-job.yml
@@ -12,6 +12,7 @@ parameters:
   tool_chain_tag: ''
   vm_image: ''
   arch_list: ''
+  extra_install_step: []
 
 # Build step
 jobs:
@@ -77,3 +78,4 @@ jobs:
       build_pkgs: $(Build.Pkgs)
       build_targets: $(Build.Targets)
       build_archs: ${{ parameters.arch_list }}
+      extra_install_step: ${{ parameters.extra_install_step }}

--- a/.azurepipelines/templates/pr-gate-steps.yml
+++ b/.azurepipelines/templates/pr-gate-steps.yml
@@ -12,6 +12,7 @@ parameters:
   build_pkgs: ''
   build_targets: ''
   build_archs: ''
+  extra_install_step: []
 
 steps:
 - checkout: self
@@ -36,6 +37,8 @@ steps:
 - script: git fetch origin $(System.PullRequest.targetBranch)
   displayName: fetch target branch
   condition: eq(variables['Build.Reason'], 'PullRequest')
+
+- ${{ parameters.extra_install_step }}
 
 # trim the package list if this is a PR
 - task: CmdLine@1
@@ -125,6 +128,7 @@ steps:
       TestSuites.xml
       **/BUILD_TOOLS_REPORT.html
       **/OVERRIDELOG.TXT
+      coverage.xml
     flattenFolders: true
   condition: succeededOrFailed()
 

--- a/BaseTools/Plugin/HostBasedUnitTestRunner/HostBasedUnitTestRunner.py
+++ b/BaseTools/Plugin/HostBasedUnitTestRunner/HostBasedUnitTestRunner.py
@@ -115,4 +115,104 @@ class HostBasedUnitTestRunner(IUefiBuildPlugin):
                                             "  %s - %s" % (case.attrib['name'], result.text))
                                         failure_count += 1
 
+            if thebuilder.env.GetValue("CODE_COVERAGE") != "FALSE":
+                if thebuilder.env.GetValue("TOOL_CHAIN_TAG") == "GCC5":
+                    self.gen_code_coverage_gcc(thebuilder)
+                elif thebuilder.env.GetValue("TOOL_CHAIN_TAG").startswith ("VS"):
+                    self.gen_code_coverage_msvc(thebuilder)
+                else:
+                    logging.info("Skipping code coverage. Currently, support GCC and MSVC compiler.")
+
         return failure_count
+
+    def gen_code_coverage_gcc(self, thebuilder):
+        logging.info("Generating UnitTest code coverage")
+
+        buildOutputBase = thebuilder.env.GetValue("BUILD_OUTPUT_BASE")
+        workspace = thebuilder.env.GetValue("WORKSPACE")
+
+        # Generate base code coverage for all source files
+        ret = RunCmd("lcov", f"--no-external --capture --initial --directory {buildOutputBase} --output-file {buildOutputBase}/cov-base.info --rc lcov_branch_coverage=1")
+        if(ret != 0):
+            logging.error("UnitTest Coverage: Failed to build initial coverage data.")
+            return 1
+
+        # Coverage data for tested files only
+        ret = RunCmd("lcov", f"--capture --directory {buildOutputBase}/ --output-file {buildOutputBase}/coverage-test.info --rc lcov_branch_coverage=1")
+        if(ret != 0):
+            logging.error("UnitTest Coverage: Failed to build coverage data for tested files.")
+            return 1
+
+        # Aggregate all coverage data
+        ret = RunCmd("lcov", f"--add-tracefile {buildOutputBase}/cov-base.info --add-tracefile {buildOutputBase}/coverage-test.info --output-file {buildOutputBase}/total-coverage.info --rc lcov_branch_coverage=1")
+        if(ret != 0):
+            logging.error("UnitTest Coverage: Failed to aggregate coverage data.")
+            return 1
+
+        # Generate coverage XML
+        ret = RunCmd("lcov_cobertura",f"{buildOutputBase}/total-coverage.info -o {buildOutputBase}/compare.xml")
+        if(ret != 0):
+            logging.error("UnitTest Coverage: Failed to generate coverage XML.")
+            return 1
+
+        # Filter out auto-generated and test code
+        ret = RunCmd("lcov_cobertura",f"{buildOutputBase}/total-coverage.info --excludes ^.*UnitTest\|^.*MU\|^.*Mock\|^.*DEBUG -o {buildOutputBase}/coverage.xml")
+        if(ret != 0):
+            logging.error("UnitTest Coverage: Failed generate filtered coverage XML.")
+            return 1
+
+        # Generate all coverage file
+        testCoverageList = glob.glob (f"{workspace}/Build/**/total-coverage.info", recursive=True)
+
+        coverageFile = ""
+        for testCoverage in testCoverageList:
+            coverageFile += " --add-tracefile " + testCoverage
+        ret = RunCmd("lcov", f"{coverageFile} --output-file {workspace}/Build/all-coverage.info --rc lcov_branch_coverage=1")
+        if(ret != 0):
+            logging.error("UnitTest Coverage: Failed generate all coverage file.")
+            return 1
+
+        # Generate and XML file if requested.for all package
+        if os.path.isfile(f"{workspace}/Build/coverage.xml"):
+            os.remove(f"{workspace}/Build/coverage.xml")
+        ret = RunCmd("lcov_cobertura",f"{workspace}/Build/all-coverage.info --excludes ^.*UnitTest\|^.*MU\|^.*Mock\|^.*DEBUG -o {workspace}/Build/coverage.xml")
+
+        return 0
+
+
+    def gen_code_coverage_msvc(self, thebuilder):
+        logging.info("Generating UnitTest code coverage")
+
+
+        buildOutputBase = thebuilder.env.GetValue("BUILD_OUTPUT_BASE")
+        testList = glob.glob(os.path.join(buildOutputBase, "**","*Test*.exe"), recursive=True)
+        workspace = thebuilder.env.GetValue("WORKSPACE")
+        workspace = (workspace + os.sep) if workspace[-1] != os.sep else workspace
+        # Generate coverage file
+        coverageFile = ""
+        for testFile in testList:
+            ret = RunCmd("OpenCppCoverage", f"--source {workspace} --export_type binary:{testFile}.cov -- {testFile}")
+            coverageFile += " --input_coverage=" + testFile + ".cov"
+            if(ret != 0):
+                logging.error("UnitTest Coverage: Failed to collect coverage data.")
+                return 1
+
+        DiskName = workspace[:workspace.find (":\\") + 2]
+        # Generate and XML file if requested.by each package
+        ret = RunCmd("OpenCppCoverage", f"--export_type cobertura:{os.path.join(buildOutputBase, 'coverage.xml')} --working_dir={workspace}Build {coverageFile}")
+        if(ret != 0):
+            logging.error("UnitTest Coverage: Failed to generate cobertura format xml in single package.")
+            return 1
+
+        # Generate total report XML file for all package
+        testCoverageList = glob.glob(os.path.join(workspace, "Build", "**","*Test*.exe.cov"), recursive=True)
+        coverageFile = ""
+        for testCoverage in testCoverageList:
+            coverageFile += " --input_coverage=" + testCoverage
+
+        ret = RunCmd("OpenCppCoverage", f"--export_type cobertura:{workspace}Build/coverage.xml --working_dir={workspace}Build {coverageFile}")
+        if(ret != 0):
+            logging.error("UnitTest Coverage: Failed to generate cobertura format xml.")
+            return 1
+
+        return 0

--- a/UnitTestFrameworkPkg/ReadMe.md
+++ b/UnitTestFrameworkPkg/ReadMe.md
@@ -115,7 +115,7 @@ you should be good to go.
 
 See this example in 'SampleUnitTestUefiShell.inf'...
 
-```
+```inf
 [Packages]
   MdePkg/MdePkg.dec
 
@@ -130,7 +130,7 @@ See this example in 'SampleUnitTestUefiShell.inf'...
 Also, if you want you test to automatically be picked up by the Test Runner plugin, you will need
 to make sure that the module `BASE_NAME` contains the word `Test`...
 
-```
+```inf
 [Defines]
   BASE_NAME      = SampleUnitTestUefiShell
 ```
@@ -582,6 +582,47 @@ GTEST_OUTPUT=xml:<absolute or relative path to output file>
 ```
 
 This mode is used by the test running plugin to aggregate the results for CI test status reporting in the web view.
+
+### Code Coverage
+
+Host based Unit Tests will automatically enable coverage data.
+
+For Windows, This is primarily leverage for pipeline builds, but this can be leveraged locally using the
+OpenCppCoverage windows tool to parse coverage data to cobertura xml format.
+
+- Windows Prerequisite
+  ```bash
+  Download and install https://github.com/OpenCppCoverage/OpenCppCoverage/releases
+  python -m pip install --upgrade -r ./pip-requirements.txt
+  stuart_ci_build -c .pytool/CISettings.py  -t NOOPT TOOL_CHAIN_TAG=VS2019 -p MdeModulePkg
+  Open Build/coverage.xml
+  ```
+
+  - How to see code coverage data on IDE Visual Studio
+    ```
+    Open Visual Studio VS2019 or above version
+    Click "Tools" -> "OpenCppCoverage Settings"
+    Fill your execute file into "Program to run:"
+    Click "Tools" -> "Run OpenCppCoverage"
+    ```
+
+
+For Linux, This is primarily leveraged for pipeline builds, but this can be leveraged locally using the
+lcov linux tool, and parsed using the lcov_cobertura python tool to parse it to cobertura xml format.
+
+- Linux Prerequisite
+  ```bash
+  sudo apt-get install -y lcov
+  python -m pip install --upgrade -r ./pip-requirements.txt
+  stuart_ci_build -c .pytool/CISettings.py  -t NOOPT TOOL_CHAIN_TAG=GCC5 -p MdeModulePkg
+  Open Build/coverage.xml
+  ```
+  - How to see code coverage data on IDE Visual Studio Code
+    ```
+    Download plugin "Coverage Gutters"
+    Press Hot Key "Ctrl + Shift + P" and click option "Coverage Gutters: Display Coverage"
+    ```
+
 
 ### Important Note
 

--- a/UnitTestFrameworkPkg/UnitTestFrameworkPkg.ci.yaml
+++ b/UnitTestFrameworkPkg/UnitTestFrameworkPkg.ci.yaml
@@ -91,6 +91,7 @@
             "pytools",
             "NOFAILURE",
             "cmockery",
+            "cobertura",
             "DHAVE", # build flag for cmocka in the INF
             "gtest", # file name in GoogleTestLib.inf
             "corthon",      # Contact GitHub account in Readme

--- a/UnitTestFrameworkPkg/UnitTestFrameworkPkgHost.dsc.inc
+++ b/UnitTestFrameworkPkg/UnitTestFrameworkPkgHost.dsc.inc
@@ -27,7 +27,8 @@
   GCC:*_*_*_CC_FLAGS   = -D UNIT_TESTING_DEBUG=1
   XCODE:*_*_*_CC_FLAGS = -D UNIT_TESTING_DEBUG=1
 !endif
-
+  GCC:*_GCC5_*_CC_FLAGS = --coverage
+  GCC:*_GCC5_*_DLINK_FLAGS = --coverage
 [BuildOptions.common.EDKII.HOST_APPLICATION]
   #
   # MSFT

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -16,3 +16,5 @@ edk2-pytool-library==0.12.1
 edk2-pytool-extensions~=0.20.0
 edk2-basetools==0.1.39
 antlr4-python3-runtime==4.7.1
+lcov-cobertura==2.0.2
+


### PR DESCRIPTION
From: Gua Guo <[gua.guo@intel.com](mailto:gua.guo@intel.com)>

V1: Add coverage option for GCC
V2: Add ReadMe.md for how to generate coverage report
V3: Add VS2019 and GCC code coverage support
V4: Add VS2019 and GCC Azure CI/CD support
V5: Fix some typo and some flow issue
V6: Remove html coverage information
  - Due to python 3.11 install lxml will be failure,
  pycobertura need it to convert cobertura format to
  html file.
  - Add section for developer how to use OpenCppCoverage
  on IDE Visual Studio