### PR TITLE
OvmfPkg/PlatformInitLib: Fix integrity checking failed of NvVarStore …

### DIFF
--- a/OvmfPkg/Library/PlatformInitLib/Platform.c
+++ b/OvmfPkg/Library/PlatformInitLib/Platform.c
@@ -702,10 +702,11 @@ PlatformValidateNvVarStore (
 
       VariableOffset = NvVarStoreHeader->Size - sizeof (VARIABLE_STORE_HEADER);
     } else {
-      if (!((VariableHeader->State == VAR_IN_DELETED_TRANSITION) ||
-            (VariableHeader->State == VAR_DELETED) ||
-            (VariableHeader->State == VAR_HEADER_VALID_ONLY) ||
-            (VariableHeader->State == VAR_ADDED)))
+      if (!((VariableHeader->State == VAR_HEADER_VALID_ONLY) ||
+            (VariableHeader->State == VAR_ADDED) ||
+            (VariableHeader->State == (VAR_ADDED & VAR_DELETED)) ||
+            (VariableHeader->State == (VAR_ADDED & VAR_IN_DELETED_TRANSITION)) ||
+            (VariableHeader->State == (VAR_ADDED & VAR_IN_DELETED_TRANSITION & VAR_DELETED))))
       {
         DEBUG ((DEBUG_ERROR, "NvVarStore Variable header State was invalid.\n"));
         return FALSE;


### PR DESCRIPTION
…in some cases

In the commit 4f173db8b4 "OvmfPkg/PlatformInitLib: Add functions for EmuVariableNvStore", it introduced a PlatformValidateNvVarStore() function for checking the integrity of NvVarStore.

In some cases when the VariableHeader->StartId is VARIABLE_DATA, the VariableHeader->State is not just one of the four primary states: VAR_IN_DELETED_TRANSITION, VAR_DELETED, VAR_HEADER_VALID_ONLY, VAR_ADDED. The state may combined two or three states, e.g.

    0x3C = (VAR_IN_DELETED_TRANSITION & VAR_ADDED) & VAR_DELETED
or
    0x3D = VAR_ADDED & VAR_DELETED

When the variable store has those variables, system booting/rebooting will hangs in a ASSERT:

NvVarStore Variable header State was invalid.
ASSERT
/mnt/working/source_code-git/edk2/OvmfPkg/Library/PlatformInitLib/Platform.c(819): ((BOOLEAN)(0==1))

Adding more log to UpdateVariable() and PlatformValidateNvVarStore(), we saw some variables which have 0x3C or 0x3D state in store. e.g.

UpdateVariable(), VariableName=BootOrder
L1871, State=0000003F        <-- VAR_ADDED
State &= VAR_DELETED=0000003D
FlushHobVariableToFlash(), VariableName=BootOrder
...
UpdateVariable(), VariableName=InitialAttemptOrder
L1977, State=0000003F
State &= VAR_IN_DELETED_TRANSITION=0000003E
L2376, State=0000003E
State &= VAR_DELETED=0000003C
FlushHobVariableToFlash(), VariableName=InitialAttemptOrder
...
UpdateVariable(), VariableName=ConIn
L1977, State=0000003F
State &= VAR_IN_DELETED_TRANSITION=0000003E
L2376, State=0000003E
State &= VAR_DELETED=0000003C
FlushHobVariableToFlash(), VariableName=ConIn
...

So, only allowing the four primary states is not enough. This patch changes the falid states list (Follow Jiewen Yao's suggestion):

1. VAR_HEADER_VALID_ONLY (0x7F) - Header added (*)
2. VAR_ADDED (0x3F) - Header + data added
3. VAR_ADDED & VAR_IN_DELETED_TRANSITION (0x3E) - marked as deleted, but still valid, before new data is added. (*)
4. VAR_ADDED & VAR_IN_DELETED_TRANSITION & VAR_DELETED (0x3C) - deleted, after new data is added.
5. VAR_ADDED & VAR_DELETED (0x3D) - deleted directly, without new data. (*) means to support surprise shutdown.

And removed (VAR_IN_DELETED_TRANSITION) and (VAR_DELETED) because they are invalid states.

v2:
Follow Jiewen Yao's suggestion to add the following valid states:
    VAR_ADDED & VAR_DELETED (0x3D)
    VAR_ADDED & VAR_IN_DELETED_TRANSITION (0x3E)
    VAR_ADDED & VAR_IN_DELETED_TRANSITION & VAR_DELETED (0x3C)
and removed the following invalid states:
    VAR_IN_DELETED_TRANSITION
    VAR_DELETED

Signed-off-by: Chun-Yi Lee <jlee@suse.com>
Reviewed-by: Jiewen Yao <jiewen.yao@intel.com>