### PR TITLE
UefiPayloadPkg: Fixed that The UPL info section is not aligned at 4-b…

### DIFF
--- a/UefiPayloadPkg/UniversalPayloadBuild.py
+++ b/UefiPayloadPkg/UniversalPayloadBuild.py
@@ -135,7 +135,7 @@ def BuildUniversalPayload(Args, MacroList):
                        BdsFvOutputDir,
                        EntryOutputDir
                        )
-    set_section    = '"{}" -I {} -O {} --set-section-alignment .upld_info=16 --set-section-alignment .upld.uefi_fv=16 --set-section-alignment .upld.bds_fv=16 {}'.format (
+    set_section    = '"{}" -I {} -O {} --set-section-alignment .upld_info=4 --set-section-alignment .upld.uefi_fv=16 --set-section-alignment .upld.bds_fv=16 {}'.format (
                        LlvmObjcopyPath,
                        ObjCopyFlag,
                        ObjCopyFlag,


### PR DESCRIPTION
…yte boundary

REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4196

Align .upld_info with 4-byte boundary by spec

Cc: Guo Dong <guo.dong@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Cc: Sean Rhodes <sean@starlabs.systems>
Reviewed-by: James Lu <james.lu@intel.com>
Reviewed-by: Gua Guo <gua.guo@intel.com>