### PR TITLE
Enable Multi-core based lazy-accept for TDVF

### DIFF
--- a/OvmfPkg/AmdSev/AmdSevX64.dsc
+++ b/OvmfPkg/AmdSev/AmdSevX64.dsc
@@ -206,6 +206,7 @@
   BaseCryptLib|CryptoPkg/Library/BaseCryptLib/BaseCryptLib.inf
   CcExitLib|OvmfPkg/Library/CcExitLib/CcExitLib.inf
   TdxLib|MdePkg/Library/TdxLib/TdxLib.inf
+  TdxMailboxLib|OvmfPkg/Library/TdxMailboxLib/TdxMailboxLibNull.inf
 
 [LibraryClasses.common.SEC]
   TimerLib|OvmfPkg/Library/AcpiTimerLib/BaseRomAcpiTimerLib.inf

--- a/OvmfPkg/CloudHv/CloudHvX64.dsc
+++ b/OvmfPkg/CloudHv/CloudHvX64.dsc
@@ -253,6 +253,7 @@
   BaseCryptLib|CryptoPkg/Library/BaseCryptLib/BaseCryptLib.inf
   CcExitLib|OvmfPkg/Library/CcExitLib/CcExitLib.inf
   TdxLib|MdePkg/Library/TdxLib/TdxLib.inf
+  TdxMailboxLib|OvmfPkg/Library/TdxMailboxLib/TdxMailboxLibNull.inf
 
 [LibraryClasses.common.SEC]
   TimerLib|OvmfPkg/Library/AcpiTimerLib/BaseRomAcpiTimerLib.inf

--- a/OvmfPkg/Include/TdxCommondefs.inc
+++ b/OvmfPkg/Include/TdxCommondefs.inc
@@ -15,8 +15,8 @@ FirmwareArgsOffset                        equ       800h
 WakeupArgsRelocatedMailBox                equ       800h
 AcceptPageArgsPhysicalStart               equ       800h
 AcceptPageArgsPhysicalEnd                 equ       808h
-AcceptPageArgsChunkSize                   equ       810h
-AcceptPageArgsPageSize                    equ       818h
+AcceptPageArgsTopStackAddress             equ       810h
+AcceptPageArgsApStackSize                 equ       818h
 CpuArrivalOffset                          equ       900h
 CpusExitingOffset                         equ       0a00h
 TalliesOffset                             equ       0a08h

--- a/OvmfPkg/IntelTdx/Sec/X64/IntelTdxAPs.nasm
+++ b/OvmfPkg/IntelTdx/Sec/X64/IntelTdxAPs.nasm
@@ -1,0 +1,58 @@
+;------------------------------------------------------------------------------
+; @file
+; Intel TDX APs
+;
+; Copyright (c) 2021 - 2022, Intel Corporation. All rights reserved.<BR>
+; SPDX-License-Identifier: BSD-2-Clause-Patent
+;
+;------------------------------------------------------------------------------
+
+%include "TdxCommondefs.inc"
+
+    ;
+    ; Note: BSP never gets here. APs will be unblocked by DXE
+    ;
+    ; R8  [31:0]  NUM_VCPUS
+    ;     [63:32] MAX_VCPUS
+    ; R9  [31:0]  VCPU_INDEX
+    ;
+ParkAp:
+
+do_wait_loop:
+    ;
+    ; register itself in [rsp + CpuArrivalOffset]
+    ;
+    mov       rax, 1
+    lock xadd dword [rsp + CpuArrivalOffset], eax
+    inc       eax
+
+.check_arrival_cnt:
+    cmp       eax, r8d
+    je        .check_command
+    mov       eax, dword[rsp + CpuArrivalOffset]
+    jmp       .check_arrival_cnt
+
+.check_command:
+    mov     eax, dword[rsp + CommandOffset]
+    cmp     eax, MpProtectedModeWakeupCommandNoop
+    je      .check_command
+
+    cmp     eax, MpProtectedModeWakeupCommandWakeup
+    je      .do_wakeup
+
+    ; Don't support this command, so ignore
+    jmp     .check_command
+
+.do_wakeup:
+    ;
+    ; BSP sets these variables before unblocking APs
+    ;   RAX:  WakeupVectorOffset
+    ;   RBX:  Relocated mailbox address
+    ;   RBP:  vCpuId
+    ;
+    mov     rax, 0
+    mov     eax, dword[rsp + WakeupVectorOffset]
+    mov     rbx, [rsp + WakeupArgsRelocatedMailBox]
+    nop
+    jmp     rax
+    jmp     $

--- a/OvmfPkg/Library/PlatformInitLib/PlatformInitLib.inf
+++ b/OvmfPkg/Library/PlatformInitLib/PlatformInitLib.inf
@@ -52,6 +52,7 @@
   PcdLib
   PciLib
   PeiHardwareInfoLib
+  TdxMailboxLib
 
 [LibraryClasses.X64]
   TdxLib

--- a/OvmfPkg/Library/TdxMailboxLib/TdxMailboxLib.inf
+++ b/OvmfPkg/Library/TdxMailboxLib/TdxMailboxLib.inf
@@ -1,6 +1,6 @@
 #/** @file
 #
-#  TBD
+#  TdxMailbox Library
 #
 #  Copyright (c) 2018, Intel Corporation. All rights reserved.<BR>
 #  Copyright (c) 2008, Apple Inc. All rights reserved.<BR>
@@ -19,11 +19,8 @@
   LIBRARY_CLASS                  = TdxMailboxLib
 
 #
-#  VALID_ARCHITECTURES           = X64 IA32
+#  VALID_ARCHITECTURES           = X64
 #
-
-[Sources.IA32]
-  TdxMailboxNull.c
 
 [Sources.X64]
   TdxMailbox.c

--- a/OvmfPkg/Library/TdxMailboxLib/TdxMailboxLibNull.inf
+++ b/OvmfPkg/Library/TdxMailboxLib/TdxMailboxLibNull.inf
@@ -1,0 +1,34 @@
+#/** @file
+#
+#  Null instance of TdxMailboxLib
+#
+#  Copyright (c) 2018, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2008, Apple Inc. All rights reserved.<BR>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+#
+#**/
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = TdxMailboxLibNull
+  FILE_GUID                      = 002a1265-a1a0-47cd-bc69-4342b147f57d
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = TdxMailboxLib
+
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  TdxMailboxNull.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  OvmfPkg/OvmfPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  DebugLib

--- a/OvmfPkg/Microvm/MicrovmX64.dsc
+++ b/OvmfPkg/Microvm/MicrovmX64.dsc
@@ -255,6 +255,7 @@
   FdtLib|EmbeddedPkg/Library/FdtLib/FdtLib.inf
   VirtioMmioDeviceLib|OvmfPkg/Library/VirtioMmioDeviceLib/VirtioMmioDeviceLib.inf
   TdxLib|MdePkg/Library/TdxLib/TdxLib.inf
+  TdxMailboxLib|OvmfPkg/Library/TdxMailboxLib/TdxMailboxLibNull.inf
 
 [LibraryClasses.common.SEC]
   QemuFwCfgLib|OvmfPkg/Library/QemuFwCfgLib/QemuFwCfgSecLib.inf

--- a/OvmfPkg/OvmfPkgIa32.dsc
+++ b/OvmfPkg/OvmfPkgIa32.dsc
@@ -257,6 +257,7 @@
 [LibraryClasses.common]
   BaseCryptLib|CryptoPkg/Library/BaseCryptLib/BaseCryptLib.inf
   CcExitLib|UefiCpuPkg/Library/CcExitLibNull/CcExitLibNull.inf
+  TdxMailboxLib|OvmfPkg/Library/TdxMailboxLib/TdxMailboxLibNull.inf
 
 [LibraryClasses.common.SEC]
   TimerLib|OvmfPkg/Library/AcpiTimerLib/BaseRomAcpiTimerLib.inf

--- a/OvmfPkg/OvmfPkgIa32X64.dsc
+++ b/OvmfPkg/OvmfPkgIa32X64.dsc
@@ -262,7 +262,7 @@
   BaseCryptLib|CryptoPkg/Library/BaseCryptLib/BaseCryptLib.inf
   CcExitLib|UefiCpuPkg/Library/CcExitLibNull/CcExitLibNull.inf
   TdxLib|MdePkg/Library/TdxLib/TdxLib.inf
-  TdxMailboxLib|OvmfPkg/Library/TdxMailboxLib/TdxMailboxLib.inf
+  TdxMailboxLib|OvmfPkg/Library/TdxMailboxLib/TdxMailboxLibNull.inf
 
 [LibraryClasses.common.SEC]
   TimerLib|OvmfPkg/Library/AcpiTimerLib/BaseRomAcpiTimerLib.inf

--- a/OvmfPkg/Sec/X64/SecEntry.nasm
+++ b/OvmfPkg/Sec/X64/SecEntry.nasm
@@ -10,7 +10,6 @@
 ;------------------------------------------------------------------------------
 
 #include <Base.h>
-%include "TdxCommondefs.inc"
 
 DEFAULT REL
 SECTION .text
@@ -49,6 +48,7 @@ ASM_PFX(_ModuleEntryPoint):
     cmp     byte[eax], VM_GUEST_TYPE_TDX
     jne     InitStack
 
+    %define TDCALL_TDINFO         1
     mov     rax, TDCALL_TDINFO
     tdcall
 
@@ -62,7 +62,9 @@ ASM_PFX(_ModuleEntryPoint):
     mov     rax, r9
     and     rax, 0xffff
     test    rax, rax
-    jne     ParkAp
+    jz      InitStack
+    mov     rsp, FixedPcdGet32 (PcdOvmfSecGhcbBackupBase)
+    jmp     ParkAp
 
 InitStack:
 
@@ -98,54 +100,4 @@ InitStack:
     sub     rsp, 0x20
     call    ASM_PFX(SecCoreStartupWithStack)
 
-    ;
-    ; Note: BSP never gets here. APs will be unblocked by DXE
-    ;
-    ; R8  [31:0]  NUM_VCPUS
-    ;     [63:32] MAX_VCPUS
-    ; R9  [31:0]  VCPU_INDEX
-    ;
-ParkAp:
-
-    mov     rbp,  r9
-
-.do_wait_loop:
-    mov     rsp, FixedPcdGet32 (PcdOvmfSecGhcbBackupBase)
-
-    ;
-    ; register itself in [rsp + CpuArrivalOffset]
-    ;
-    mov       rax, 1
-    lock xadd dword [rsp + CpuArrivalOffset], eax
-    inc       eax
-
-.check_arrival_cnt:
-    cmp       eax, r8d
-    je        .check_command
-    mov       eax, dword[rsp + CpuArrivalOffset]
-    jmp       .check_arrival_cnt
-
-.check_command:
-    mov     eax, dword[rsp + CommandOffset]
-    cmp     eax, MpProtectedModeWakeupCommandNoop
-    je      .check_command
-
-    cmp     eax, MpProtectedModeWakeupCommandWakeup
-    je      .do_wakeup
-
-    ; Don't support this command, so ignore
-    jmp     .check_command
-
-.do_wakeup:
-    ;
-    ; BSP sets these variables before unblocking APs
-    ;   RAX:  WakeupVectorOffset
-    ;   RBX:  Relocated mailbox address
-    ;   RBP:  vCpuId
-    ;
-    mov     rax, 0
-    mov     eax, dword[rsp + WakeupVectorOffset]
-    mov     rbx, [rsp + WakeupArgsRelocatedMailBox]
-    nop
-    jmp     rax
-    jmp     $
+%include "../../IntelTdx/Sec/X64/IntelTdxAPs.nasm"


### PR DESCRIPTION

BZ: https://bugzilla.tianocore.org/show_bug.cgi?id=4172

TDVF once accepts memory only by BSP. To improve the boot performance
this patch-set introduce the multi-core accpet memory. Multi-core means
BSP and APs work together to accept memory.

TDVF leverages mailbox to wake up APs. It is not enabled in MpInitLib
(Which requires SIPI). So multi-core accept memory cannot leverages
MpInitLib to coordinate BSP and APs to work together.

So TDVF split the accept memory into 2 phases.
- AcceptMemoryForAPsStack:
  BSP accepts a small piece of memory which is then used by APs to setup
  stack. We assign a 16KB stack for each AP. So a td-guest with 256 vCPU
  requires 255*16KB = 4080KB.
- AcceptMemory:
  After above small piece of memory is accepted, BSP commands APs to
  accept memory by sending AcceptPages command in td-mailbox. Together
  with the command and accpet-function, the APsStack address is send
  as well. APs then set the stack and jump to accept-function to accept
  memory.

Patch 1-3:
  TdxMailboxLib is refactored to help multi-core lazy accept.
Patch 4-5:
  Refactor APs' logical to support accpet page.
Patch 6:
  Implement multi-core accept in TDVF.

Code: https://github.com/mxu9/edk2/tree/Multi-Core-Lazy-Accept.v2

v2 changes:
 - Fix an override error when vCPU number is larger than 64.

Cc: Erdem Aktas <erdemaktas@google.com>
Cc: Gerd Hoffmann <kraxel@redhat.com>
Cc: James Bottomley <jejb@linux.ibm.com>
Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Tom Lendacky <thomas.lendacky@amd.com>
Signed-off-by: Min Xu <min.m.xu@intel.com>

Min M Xu (6):
  OvmfPkg/TdxMailboxLib: Delete global variables
  OvmfPkg/TdxMailboxLib: Add NULL instance of TdxMailboxLib
  OvmfPkg: Add TdxMailboxLibNull in some platform dsc
  OvmfPkg/Sec: Move TDX APs related nasm code to IntelTdxAPs.nasm
  OvmfPkg: Enable APs to accept memory for TDVF
  OvmfPkg/PlatformInitLib: Implement multi-core accept memory for TDVF

 OvmfPkg/AmdSev/AmdSevX64.dsc                  |   1 +
 OvmfPkg/CloudHv/CloudHvX64.dsc                |   1 +
 OvmfPkg/Include/TdxCommondefs.inc             |   4 +-
 OvmfPkg/IntelTdx/Sec/X64/IntelTdxAPs.nasm     | 119 +++++
 OvmfPkg/IntelTdx/Sec/X64/SecEntry.nasm        |  58 +--
 OvmfPkg/Library/PlatformInitLib/IntelTdx.c    | 411 +++++++++++++++---
 .../PlatformInitLib/PlatformInitLib.inf       |   1 +
 OvmfPkg/Library/TdxMailboxLib/TdxMailbox.c    |  22 +-
 .../Library/TdxMailboxLib/TdxMailboxLib.inf   |   7 +-
 .../TdxMailboxLib/TdxMailboxLibNull.inf       |  34 ++
 OvmfPkg/Microvm/MicrovmX64.dsc                |   1 +
 OvmfPkg/OvmfPkgIa32.dsc                       |   1 +
 OvmfPkg/OvmfPkgIa32X64.dsc                    |   2 +-
 OvmfPkg/Sec/X64/SecEntry.nasm                 |  58 +--
 14 files changed, 545 insertions(+), 175 deletions(-)
 create mode 100644 OvmfPkg/IntelTdx/Sec/X64/IntelTdxAPs.nasm
 create mode 100644 OvmfPkg/Library/TdxMailboxLib/TdxMailboxLibNull.inf
