### PR TITLE
.github/codeql/edk2.qls: Enable CWE 120, 787, and 805 queries (test only)

### DIFF
--- a/.github/codeql/edk2.qls
+++ b/.github/codeql/edk2.qls
@@ -9,6 +9,32 @@
 # Enable individual queries below.
 
 - include:
+    id: cpp/potential-buffer-overflow
+- include:
+    id: cpp/toctou-race-condition
+- include:
+    id: cpp/unclear-array-index-validation
+- include:
+    id: cpp/unsafe-strncat
+- include:
+    id: cpp/use-after-free
+- include:
+    id: cpp/user-controlled-null-termination-tainted
+- include:
+    id: cpp/wrong-number-format-arguments
+- include:
+    id: cpp/wrong-type-format-argument
+- include:
+    id: cpp/conditionallyuninitializedvariable
+- include:
     id: cpp/infinite-loop-with-unsatisfiable-exit-condition
 - include:
     id: cpp/overflow-buffer
+- include:
+    id: cpp/overrunning-write
+- include:
+    id: cpp/overrunning-write-with-float
+- include:
+    id: cpp/pointer-overflow-check
+- include:
+    id: cpp/very-likely-overrunning-write


### PR DESCRIPTION
As recommended by CodeQL this change replaces
cpp/potential-buffer-overflow with cpp/overrunning-write-with-float and cpp/overrunning-write.

Enables:

1. cpp/overrunning-write
   - @name Likely overrunning write
   - @description Buffer write operations that do not control the length data written may overflow
   - @kind problem
   - @problem.severity error
   - @security-severity 9.3
   - @precision high
   - @id cpp/very-likely-overrunning-write
   - @tags reliability
     - security
     - external/cwe/cwe-120 - external/cwe/cwe-787 - external/cwe/cwe-805
2. cpp/overrunning-write-with-float
   - @name Potentially overrunning write with float to string conversion
   - @description Buffer write operations that do not control the length of data written may overflow when floating point inputs take extreme values.
   - @kind problem
   - @problem.severity error
   - @security-severity 9.3
   - @precision medium
   - @id cpp/overrunning-write-with-float
   - @tags reliability
     - security
     - external/cwe/cwe-120 - external/cwe/cwe-787 - external/cwe/cwe-805
3. cpp/very-likely-overrunning-write
   - @name Likely overrunning write
   - @description Buffer write operations that do not control the length of data written may overflow
   - @kind problem
   - @problem.severity error
   - @security-severity 9.3
   - @precision high
   - @id cpp/very-likely-overrunning-write
   - @tags reliability
     - security
     - external/cwe/cwe-120 - external/cwe/cwe-787 - external/cwe/cwe-805

- CWEs:
  - https://cwe.mitre.org/data/definitions/120.html
  - https://cwe.mitre.org/data/definitions/787.html
  - https://cwe.mitre.org/data/definitions/805.html

1. cpp/conditionallyuninitializedvariable
   - CWE: https://cwe.mitre.org/data/definitions/457.html
   - @name Conditionally uninitialized variable
   - @description An initialization function is used to initialize a local variable, but the returned status code is not checked. The variable may be left in an uninitialized state, and reading the variable may result in undefined behavior.
   - @kind problem
   - @problem.severity warning
   - @security-severity 7.8
   - @id cpp/conditionally-uninitialized-variable
   - @tags security
     - external/cwe/cwe-457
2. cpp/pointer-overflow-check
   - CWE: https://cwe.mitre.org/data/definitions/758.html
   - @name Pointer overflow check
   - @description Adding a value to a pointer to check if it overflows relies on undefined behavior and may lead to memory corruption.
   - @kind problem
   - @problem.severity error
   - @security-severity 2.1
   - @precision high
   - @id cpp/pointer-overflow-check
   - @tags reliability
     - security
     - external/cwe/cwe-758
3. cpp/potential-buffer-overflow
   - CWE: https://cwe.mitre.org/data/definitions/676.html
   - @name Potential buffer overflow
   - @description Using a library function that does not check buffer bounds requires the surrounding program to be very carefully written to avoid buffer overflows.
   - @kind problem
   - @id cpp/potential-buffer-overflow
   - @problem.severity warning
   - @security-severity 10.0
   - @tags reliability
     - security
     - external/cwe/cwe-676
   - @deprecated This query is deprecated, use Potentially overrunning write (`cpp/overrunning-write`) and Potentially overrunning write with float to string conversion (`cpp/overrunning-write-with-float`) instead.

Note that cpp/potential-buffer-overflow is deprecated. This query will be updated to the succeeding queries in the next commit. The query is used in this commit to show that we considered and tested the query in history.

Cc: Sean Brogan <sean.brogan@microsoft.com>
Cc: Michael Kubacki <mikuback@linux.microsoft.com>
Cc: Michael D Kinney <michael.d.kinney@intel.com>
Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>