### PR TITLE
BaseTools: Use BUILD_CC when checking gcc version in DevicePath

### DIFF
--- a/BaseTools/Source/C/DevicePath/GNUmakefile
+++ b/BaseTools/Source/C/DevicePath/GNUmakefile
@@ -13,7 +13,7 @@ OBJECTS = DevicePath.o UefiDevicePathLib.o DevicePathFromText.o  DevicePathUtili
 
 include $(MAKEROOT)/Makefiles/app.makefile
 
-GCCVERSION = $(shell gcc -dumpversion | awk -F'.' '{print $$1}')
+GCCVERSION = $(shell $(BUILD_CC) -dumpversion | awk -F'.' '{print $$1}')
 ifneq ("$(GCCVERSION)", "5")
 ifneq ($(CXX), llvm)
 ifneq ($(DARWIN),Darwin)


### PR DESCRIPTION
When checking the version in DevicePath's Makefile, use BUILD_CC instead of assuming "gcc".  BUILD_CC is set in header.makefile and is the compiler that will actually be used to build DevicePath.  It defaults to "gcc", but may be overridden.

Signed-off-by: Jake Garver <jake@nvidia.com>
Reviewed-by: Bob Feng <bob.c.feng@intel.com>