### PR TITLE
Maintainers.txt: designate Gerd Hoffmann as UefiCpuPkg reviewer

### DIFF
--- a/Maintainers.txt
+++ b/Maintainers.txt
@@ -604,6 +604,7 @@ W: https://github.com/tianocore/tianocore.github.io/wiki/UefiCpuPkg
 M: Eric Dong <eric.dong@intel.com> [ydong10]
 M: Ray Ni <ray.ni@intel.com> [niruiyu]
 R: Rahul Kumar <rahul1.kumar@intel.com> [rahul1-kumar]
+R: Gerd Hoffmann <kraxel@redhat.com> [kraxel]
 
 UefiCpuPkg: Sec related modules
 F: UefiCpuPkg/SecCore/


### PR DESCRIPTION
https://listman.redhat.com/archives/edk2-devel-archive/2023-January/057182.html
https://edk2.groups.io/g/devel/message/97884
http://mid.mail-archive.com/20230103160539.87830-1-lersek@redhat.com
~~~
Maintainers.txt: designate Gerd Hoffmann as UefiCpuPkg reviewer

I suggest that Gerd be notified about all UefiCpuPkg patches, so he may
take a quick look at, or (by his preference) even test, the proposed
change, in a genuine QEMU/KVM environment.

Assuming this patch is accepted -- subsequently, please *wait* for Gerd's
approval on UefiCpuPkg patches, before merging them.

Notes:

- It's perfectly fine for a reviewer to give an A-b just so the review
  process be unblocked, if they don't have anything to add, or don't have
  time to review or test in detail. The point is that someone outside of
  Intel should *consistently get a chance* to raise concerns about
  UefiCpuPkg patches before they are merged.

- My A-b's and R-b's on UefiCpuPkg patches were never supposed to be
  "sufficient", only "necessary", for merging. The intent is the same
  here, with Gerd's designation as a reviewer.

Cc: Andrew Fish <afish@apple.com>
Cc: Eric Dong <eric.dong@intel.com>
Cc: Gerd Hoffmann <kraxel@redhat.com>
Cc: Leif Lindholm <quic_llindhol@quicinc.com>
Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Rahul Kumar <rahul1.kumar@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Signed-off-by: Laszlo Ersek <lersek@redhat.com>
Message-Id: <20230103160539.87830-1-lersek@redhat.com>
Acked-by: Gerd Hoffmann <kraxel@redhat.com>
Reviewed-by: Ray Ni <ray.ni@intel.com>
~~~