### PR TITLE
UefiPayloadPkg: Fix debug print error level hob not save correct

### DIFF
--- a/UefiPayloadPkg/Library/DebugPrintErrorLevelLibHob/DebugPrintErrorLevelLibHob.c
+++ b/UefiPayloadPkg/Library/DebugPrintErrorLevelLibHob/DebugPrintErrorLevelLibHob.c
@@ -46,7 +46,7 @@ GetDebugPrintErrorLevel (
       {
         if (GenericHeader->Revision == UEFI_PAYLOAD_DEBUG_PRINT_ERROR_LEVEL_REVISION) {
           DebugPrintErrorLevel =  (UEFI_PAYLOAD_DEBUG_PRINT_ERROR_LEVEL *)GET_GUID_HOB_DATA (GuidHob);
-          if (DebugPrintErrorLevel->Header.Length > UNIVERSAL_PAYLOAD_SIZEOF_THROUGH_FIELD (UEFI_PAYLOAD_DEBUG_PRINT_ERROR_LEVEL, ErrorLevel)) {
+          if (DebugPrintErrorLevel->Header.Length >= UNIVERSAL_PAYLOAD_SIZEOF_THROUGH_FIELD (UEFI_PAYLOAD_DEBUG_PRINT_ERROR_LEVEL, ErrorLevel)) {
             gDebugPrintErrorLevel = DebugPrintErrorLevel->ErrorLevel;
           }
         }


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4264 Fix debug print error level hob not save correct DebugPrintErrorlevel Should cover the case:
Header.Length == UNIVERSAL_PAYLOAD_SIZEOF_THROUGH_FIELD ()
Cc: Ray Ni <ray.ni@intel.com>
Cc: Sean Rhodes <sean@starlabs.systems>
Cc: James Lu <james.lu@intel.com>
Cc: Gua Guo <gua.guo@intel.com>
Signed-off-by: Ning Feng <ning.feng@intel.com>
Reviewed-by: Gua Guo <gua.guo@intel.com>