### PR TITLE
Pass ${DEBUG_PREFIX_MAP} to gcc commands

### DIFF
--- a/BaseTools/Conf/tools_def.template
+++ b/BaseTools/Conf/tools_def.template
@@ -1849,7 +1849,7 @@ NOOPT_*_*_OBJCOPY_ADDDEBUGFLAG     = --add-gnu-debuglink=$(DEBUG_DIR)/$(MODULE_N
 *_*_*_DTCPP_PATH                   = DEF(DTCPP_BIN)
 *_*_*_DTC_PATH                     = DEF(DTC_BIN)
 
-DEFINE GCC_ALL_CC_FLAGS            = -g -Os -fshort-wchar -fno-builtin -fno-strict-aliasing -Wall -Werror -Wno-array-bounds -include AutoGen.h -fno-common
+DEFINE GCC_ALL_CC_FLAGS            = -g -Os -fshort-wchar -fno-builtin -fno-strict-aliasing -Wall -Werror -Wno-array-bounds -include AutoGen.h -fno-common ENV(GCC_PREFIX_MAP)
 DEFINE GCC_ARM_CC_FLAGS            = DEF(GCC_ALL_CC_FLAGS) -mlittle-endian -mabi=aapcs -fno-short-enums -funsigned-char -ffunction-sections -fdata-sections -fomit-frame-pointer -Wno-address -mthumb -mfloat-abi=soft -fno-pic -fno-pie
 DEFINE GCC_LOONGARCH64_CC_FLAGS    = DEF(GCC_ALL_CC_FLAGS) -mabi=lp64d -fno-asynchronous-unwind-tables -fno-plt -Wno-address -fno-short-enums -fsigned-char -ffunction-sections -fdata-sections
 DEFINE GCC_ARM_CC_XIPFLAGS         = -mno-unaligned-access
@@ -1869,8 +1869,8 @@ DEFINE GCC_ARM_ASLDLINK_FLAGS      = DEF(GCC_ARM_DLINK_FLAGS) -Wl,--entry,Refere
 DEFINE GCC_AARCH64_ASLDLINK_FLAGS  = DEF(GCC_AARCH64_DLINK_FLAGS) -Wl,--entry,ReferenceAcpiTable -u $(IMAGE_ENTRY_POINT) DEF(GCC_ARM_AARCH64_ASLDLINK_FLAGS)
 DEFINE GCC_LOONGARCH64_ASLDLINK_FLAGS = DEF(GCC_LOONGARCH64_DLINK_FLAGS) -Wl,--entry,ReferenceAcpiTable -u $(IMAGE_ENTRY_POINT)
 DEFINE GCC_IA32_X64_DLINK_FLAGS    = DEF(GCC_IA32_X64_DLINK_COMMON) --entry _$(IMAGE_ENTRY_POINT) --file-alignment 0x20 --section-alignment 0x20 -Map $(DEST_DIR_DEBUG)/$(BASE_NAME).map
-DEFINE GCC_ASM_FLAGS               = -c -x assembler -imacros AutoGen.h
-DEFINE GCC_PP_FLAGS                = -E -x assembler-with-cpp -include AutoGen.h
+DEFINE GCC_ASM_FLAGS               = -c -x assembler -imacros AutoGen.h ENV(GCC_PREFIX_MAP)
+DEFINE GCC_PP_FLAGS                = -E -x assembler-with-cpp -include AutoGen.h ENV(GCC_PREFIX_MAP)
 DEFINE GCC_VFRPP_FLAGS             = -x c -E -P -DVFRCOMPILE --include $(MODULE_NAME)StrDefs.h
 DEFINE GCC_ASLPP_FLAGS             = -x c -E -include AutoGen.h
 DEFINE GCC_ASLCC_FLAGS             = -x c
@@ -2024,7 +2024,7 @@ DEFINE GCC_PP_FLAGS                        = -E -x assembler-with-cpp -include A
 *_GCC48_IA32_DLINK2_FLAGS         = DEF(GCC48_IA32_DLINK2_FLAGS)
 *_GCC48_IA32_RC_FLAGS             = DEF(GCC_IA32_RC_FLAGS)
 *_GCC48_IA32_OBJCOPY_FLAGS        =
-*_GCC48_IA32_NASM_FLAGS           = -f elf32
+*_GCC48_IA32_NASM_FLAGS           = -f elf32 ENV(NASM_PREFIX_MAP)
 
   DEBUG_GCC48_IA32_CC_FLAGS       = DEF(GCC48_IA32_CC_FLAGS) -Os
 RELEASE_GCC48_IA32_CC_FLAGS       = DEF(GCC48_IA32_CC_FLAGS) -Os -Wno-unused-but-set-variable
@@ -2052,7 +2052,7 @@ RELEASE_GCC48_IA32_CC_FLAGS       = DEF(GCC48_IA32_CC_FLAGS) -Os -Wno-unused-but
 *_GCC48_X64_DLINK2_FLAGS         = DEF(GCC48_X64_DLINK2_FLAGS)
 *_GCC48_X64_RC_FLAGS             = DEF(GCC_X64_RC_FLAGS)
 *_GCC48_X64_OBJCOPY_FLAGS        =
-*_GCC48_X64_NASM_FLAGS           = -f elf64
+*_GCC48_X64_NASM_FLAGS           = -f elf64 ENV(NASM_PREFIX_MAP)
 
   DEBUG_GCC48_X64_CC_FLAGS       = DEF(GCC48_X64_CC_FLAGS) -Os
 RELEASE_GCC48_X64_CC_FLAGS       = DEF(GCC48_X64_CC_FLAGS) -Os -Wno-unused-but-set-variable
@@ -2164,7 +2164,7 @@ RELEASE_GCC48_AARCH64_CC_FLAGS   = DEF(GCC48_AARCH64_CC_FLAGS) -Wno-unused-but-s
 *_GCC49_IA32_DLINK2_FLAGS         = DEF(GCC49_IA32_DLINK2_FLAGS)
 *_GCC49_IA32_RC_FLAGS             = DEF(GCC_IA32_RC_FLAGS)
 *_GCC49_IA32_OBJCOPY_FLAGS        =
-*_GCC49_IA32_NASM_FLAGS           = -f elf32
+*_GCC49_IA32_NASM_FLAGS           = -f elf32 ENV(NASM_PREFIX_MAP)
 
   DEBUG_GCC49_IA32_CC_FLAGS       = DEF(GCC49_IA32_CC_FLAGS) -Os
 RELEASE_GCC49_IA32_CC_FLAGS       = DEF(GCC49_IA32_CC_FLAGS) -Os -Wno-unused-but-set-variable -Wno-unused-const-variable
@@ -2192,7 +2192,7 @@ RELEASE_GCC49_IA32_CC_FLAGS       = DEF(GCC49_IA32_CC_FLAGS) -Os -Wno-unused-but
 *_GCC49_X64_DLINK2_FLAGS         = DEF(GCC49_X64_DLINK2_FLAGS)
 *_GCC49_X64_RC_FLAGS             = DEF(GCC_X64_RC_FLAGS)
 *_GCC49_X64_OBJCOPY_FLAGS        =
-*_GCC49_X64_NASM_FLAGS           = -f elf64
+*_GCC49_X64_NASM_FLAGS           = -f elf64 ENV(NASM_PREFIX_MAP)
 
   DEBUG_GCC49_X64_CC_FLAGS       = DEF(GCC49_X64_CC_FLAGS) -Os
 RELEASE_GCC49_X64_CC_FLAGS       = DEF(GCC49_X64_CC_FLAGS) -Os -Wno-unused-but-set-variable -Wno-unused-const-variable
@@ -2310,7 +2310,7 @@ RELEASE_GCC49_AARCH64_DLINK_XIPFLAGS = -z common-page-size=0x20
 *_GCC5_IA32_DLINK2_FLAGS         = DEF(GCC5_IA32_DLINK2_FLAGS) -no-pie
 *_GCC5_IA32_RC_FLAGS             = DEF(GCC_IA32_RC_FLAGS)
 *_GCC5_IA32_OBJCOPY_FLAGS        =
-*_GCC5_IA32_NASM_FLAGS           = -f elf32
+*_GCC5_IA32_NASM_FLAGS           = -f elf32 ENV(NASM_PREFIX_MAP)
 
   DEBUG_GCC5_IA32_CC_FLAGS       = DEF(GCC5_IA32_CC_FLAGS) -flto -Os
   DEBUG_GCC5_IA32_DLINK_FLAGS    = DEF(GCC5_IA32_X64_DLINK_FLAGS) -flto -Os -Wl,-m,elf_i386,--oformat=elf32-i386
@@ -2342,7 +2342,7 @@ RELEASE_GCC5_IA32_DLINK_FLAGS    = DEF(GCC5_IA32_X64_DLINK_FLAGS) -flto -Os -Wl,
 *_GCC5_X64_DLINK2_FLAGS          = DEF(GCC5_X64_DLINK2_FLAGS)
 *_GCC5_X64_RC_FLAGS              = DEF(GCC_X64_RC_FLAGS)
 *_GCC5_X64_OBJCOPY_FLAGS         =
-*_GCC5_X64_NASM_FLAGS            = -f elf64
+*_GCC5_X64_NASM_FLAGS            = -f elf64 ENV(NASM_PREFIX_MAP)
 
   DEBUG_GCC5_X64_CC_FLAGS        = DEF(GCC5_X64_CC_FLAGS) -flto -DUSING_LTO -Os
   DEBUG_GCC5_X64_DLINK_FLAGS     = DEF(GCC5_X64_DLINK_FLAGS) -flto -Os


### PR DESCRIPTION
We want to pass ${DEBUG_PREFIX_MAP} to gcc commands and also pass in
 --debug-prefix-map to nasm (we carry a patch to nasm for this). The
tools definitions file is built by ovmf-native so we need to pass this in at target build time when we know the right values so we use the environment.

By using determininistc file paths during the ovmf build, it removes the opportunitity for gcc/ld to change the output binaries due to path lengths overflowing section sizes and causing small changes in the binary output. Previously we relied on the stripped output being the same which isn't always the case if the size of the debug symbols varies.

Signed-off-by: Richard Purdie <richard.purdie@linuxfoundation.org>
Signed-off-by: Alexander Kanavin <alex.kanavin@gmail.com>