### PR TITLE
BaseTools: improve reproducibility

### DIFF
--- a/BaseTools/Source/C/GenFw/Elf64Convert.c
+++ b/BaseTools/Source/C/GenFw/Elf64Convert.c
@@ -15,6 +15,8 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #ifndef __GNUC__
 #include <windows.h>
 #include <io.h>
+#else
+#define _GNU_SOURCE
 #endif
 #include <assert.h>
 #include <stdio.h>
@@ -940,7 +942,7 @@ ScanSections64 (
   }
   mCoffOffset = mDebugOffset + sizeof(EFI_IMAGE_DEBUG_DIRECTORY_ENTRY) +
                 sizeof(EFI_IMAGE_DEBUG_CODEVIEW_NB10_ENTRY) +
-                strlen(mInImageName) + 1;
+                strlen(basename(mInImageName)) + 1;
 
   mCoffOffset = CoffAlign(mCoffOffset);
   if (SectionCount == 0) {
@@ -2200,7 +2202,7 @@ WriteDebug64 (
   EFI_IMAGE_DEBUG_DIRECTORY_ENTRY     *Dir;
   EFI_IMAGE_DEBUG_CODEVIEW_NB10_ENTRY *Nb10;
 
-  Len = strlen(mInImageName) + 1;
+  Len = strlen(basename(mInImageName)) + 1;
 
   Dir = (EFI_IMAGE_DEBUG_DIRECTORY_ENTRY*)(mCoffFile + mDebugOffset);
   Dir->Type = EFI_IMAGE_DEBUG_TYPE_CODEVIEW;
@@ -2210,7 +2212,7 @@ WriteDebug64 (
 
   Nb10 = (EFI_IMAGE_DEBUG_CODEVIEW_NB10_ENTRY*)(Dir + 1);
   Nb10->Signature = CODEVIEW_SIGNATURE_NB10;
-  strcpy ((char *)(Nb10 + 1), mInImageName);
+  strcpy ((char *)(Nb10 + 1), basename(mInImageName));
 
 
   NtHdr = (EFI_IMAGE_OPTIONAL_HEADER_UNION *)(mCoffFile + mNtHdrOffset);

--- a/BaseTools/Source/Python/AutoGen/BuildEngine.py
+++ b/BaseTools/Source/Python/AutoGen/BuildEngine.py
@@ -70,6 +70,9 @@ class TargetDescBlock(object):
         else:
             return str(Other) == self.Target.Path
 
+    def __lt__(self, other):
+        return str(self) < str(other)
+
     def AddInput(self, Input):
         if Input not in self.Inputs:
             self.Inputs.append(Input)

--- a/BaseTools/Source/Python/AutoGen/GenMake.py
+++ b/BaseTools/Source/Python/AutoGen/GenMake.py
@@ -575,7 +575,7 @@ cleanlib:
                 os.remove(RespFileList)
 
         # convert source files and binary files to build targets
-        self.ResultFileList = [str(T.Target) for T in MyAgo.CodaTargetList]
+        self.ResultFileList = sorted([str(T.Target) for T in MyAgo.CodaTargetList])
         if len(self.ResultFileList) == 0 and len(MyAgo.SourceFileList) != 0:
             EdkLogger.error("build", AUTOGEN_ERROR, "Nothing to build",
                             ExtraData="[%s]" % str(MyAgo))
@@ -726,7 +726,7 @@ cleanlib:
         OutputFile = ''
         DepsFileList = []
 
-        for Cmd in self.GenFfsList:
+        for Cmd in sorted(self.GenFfsList):
             if Cmd[2]:
                 for CopyCmd in Cmd[2]:
                     Src, Dst = CopyCmd
@@ -759,7 +759,7 @@ cleanlib:
             self.BuildTargetList.append('\t%s' % CmdString)
 
             self.ParseSecCmd(DepsFileList, Cmd[1])
-            for SecOutputFile, SecDepsFile, SecCmd in self.FfsOutputFileList :
+            for SecOutputFile, SecDepsFile, SecCmd in sorted(self.FfsOutputFileList):
                 self.BuildTargetList.append('%s : %s' % (self.ReplaceMacro(SecOutputFile), self.ReplaceMacro(SecDepsFile)))
                 self.BuildTargetList.append('\t%s' % self.ReplaceMacro(SecCmd))
             self.FfsOutputFileList = []
@@ -798,13 +798,13 @@ cleanlib:
 
     def CommandExceedLimit(self):
         FlagDict = {
-                    'CC'    :  { 'Macro' : '$(CC_FLAGS)',    'Value' : False},
-                    'PP'    :  { 'Macro' : '$(PP_FLAGS)',    'Value' : False},
-                    'APP'   :  { 'Macro' : '$(APP_FLAGS)',   'Value' : False},
-                    'ASLPP' :  { 'Macro' : '$(ASLPP_FLAGS)', 'Value' : False},
-                    'VFRPP' :  { 'Macro' : '$(VFRPP_FLAGS)', 'Value' : False},
-                    'ASM'   :  { 'Macro' : '$(ASM_FLAGS)',   'Value' : False},
-                    'ASLCC' :  { 'Macro' : '$(ASLCC_FLAGS)', 'Value' : False},
+                    'CC'    :  { 'Macro' : '$(CC_FLAGS)',    'Value' : True},
+                    'PP'    :  { 'Macro' : '$(PP_FLAGS)',    'Value' : True},
+                    'APP'   :  { 'Macro' : '$(APP_FLAGS)',   'Value' : True},
+                    'ASLPP' :  { 'Macro' : '$(ASLPP_FLAGS)', 'Value' : True},
+                    'VFRPP' :  { 'Macro' : '$(VFRPP_FLAGS)', 'Value' : True},
+                    'ASM'   :  { 'Macro' : '$(ASM_FLAGS)',   'Value' : True},
+                    'ASLCC' :  { 'Macro' : '$(ASLCC_FLAGS)', 'Value' : True},
                    }
 
         RespDict = {}
@@ -1007,9 +1007,9 @@ cleanlib:
                 if not self.ObjTargetDict.get(T.Target.SubDir):
                     self.ObjTargetDict[T.Target.SubDir] = set()
                 self.ObjTargetDict[T.Target.SubDir].add(NewFile)
-        for Type in self._AutoGenObject.Targets:
+        for Type in sorted(self._AutoGenObject.Targets):
             resp_file_number = 0
-            for T in self._AutoGenObject.Targets[Type]:
+            for T in sorted(self._AutoGenObject.Targets[Type]):
                 # Generate related macros if needed
                 if T.GenFileListMacro and T.FileListMacro not in self.FileListMacros:
                     self.FileListMacros[T.FileListMacro] = []

--- a/BaseTools/Source/Python/AutoGen/ModuleAutoGen.py
+++ b/BaseTools/Source/Python/AutoGen/ModuleAutoGen.py
@@ -1474,6 +1474,9 @@ class ModuleAutoGen(AutoGen):
             for File in Files:
                 if File.lower().endswith('.pdb'):
                     AsBuiltInfDict['binary_item'].append('DISPOSABLE|' + File)
+
+        AsBuiltInfDict['binary_item'] = sorted(AsBuiltInfDict['binary_item'])
+
         HeaderComments = self.Module.HeaderComments
         StartPos = 0
         for Index in range(len(HeaderComments)):
@@ -1749,7 +1752,7 @@ class ModuleAutoGen(AutoGen):
             if os.path.exists (self.TimeStampPath):
                 os.remove (self.TimeStampPath)
 
-            SaveFileOnChange(self.TimeStampPath, "\n".join(FileSet), False)
+            SaveFileOnChange(self.TimeStampPath, "\n".join(sorted(FileSet)), False)
 
         # Ignore generating makefile when it is a binary module
         if self.IsBinaryModule:


### PR DESCRIPTION
This patch fixes various things which make the build more reproducible. Some changes here only change intermediate artefacts but that means when you have two build trees giving differing results, the differences can be isolated more easily. The issues here usually become apparent with longer paths.

This was all debugged with:
TMPDIR = "${TOPDIR}/tmp"
vs.
TMPDIR = "${TOPDIR}/tmp-inital-mylongpath-mylongpath-mylongpath-mylongpath-mylongpath-mylongpath-mylongpath-mylongpath-mylongpath"

The patch specifically:

 * Sorts output in GNUmakefile
 * Always generates indirect flags files used to avoid pathlength issues else the compile commands suddenly change when using longer paths
 * Sorts the AutoGenTimeStamp file contents
 * Makes the TargetDescBlock objects from BuildEngine sortable to allow the makefile fix
 * Fix ElfConvert within GenFw so that only the basename of the binary being converted is used, else the output from "GenFw XXX.bin" differs from "GenFw /long/path/XXX.bin" with sufficiently long paths

Signed-off-by: Richard Purdie <richard.purdie@linuxfoundation.org>
Signed-off-by: Alexander Kanavin <alex.kanavin@gmail.com>