### PR TITLE
DynamicTablesPkg: FdtHwInfoParserLib: Fix compatible string

### DIFF
--- a/DynamicTablesPkg/Library/FdtHwInfoParserLib/Gic/ArmGicCParser.c
+++ b/DynamicTablesPkg/Library/FdtHwInfoParserLib/Gic/ArmGicCParser.c
@@ -23,6 +23,7 @@
 STATIC CONST COMPATIBILITY_STR  CpuCompatibleStr[] = {
   { "arm,arm-v7"     },
   { "arm,arm-v8"     },
+  { "arm,armv8"      },
   { "arm,cortex-a15" },
   { "arm,cortex-a7"  },
   { "arm,cortex-a57" }


### PR DESCRIPTION
Linux's cpu DT bindings call out arm,armv8 while the code previously used arm,arm-v8, add second entry to support the arm,armv8 case.

Cc: Sami Mujawar <sami.mujawar@arm.com>
Fixes: e366a41ef0 ("DynamicTablesPkg: FdtHwInfoParser: Add GICC parser")
Signed-off-by: Moritz Fischer <moritzf@google.com>
Reviewed-by: Sami Mujawar <sami.mujawar@arm.com>