### PR TITLE
[CI Test] StandaloneMmPkg/StandaloneMmMemLib: Update AARCH64 address size

### DIFF
--- a/StandaloneMmPkg/Library/StandaloneMmMemLib/ArmStandaloneMmMemLibInternal.c
+++ b/StandaloneMmPkg/Library/StandaloneMmMemLib/ArmStandaloneMmMemLibInternal.c
@@ -21,7 +21,7 @@
 extern EFI_PHYSICAL_ADDRESS  mMmMemLibInternalMaximumSupportAddress;
 
 #ifdef MDE_CPU_AARCH64
-#define ARM_PHYSICAL_ADDRESS_BITS  36
+#define ARM_PHYSICAL_ADDRESS_BITS  52
 #endif
 #ifdef MDE_CPU_ARM
 #define ARM_PHYSICAL_ADDRESS_BITS  32


### PR DESCRIPTION
Enable StandaloneMmMemLib to use longer physical addresses than 36 bits.
According to ARM "Learn the architecture - AArch64 memory management"
since Armv8.2-A physical address size was extended to 52 bits.
https://developer.arm.com/documentation/101811/0102/Address-spaces

Signed-off-by: Damian Milosek <damian.milosek@intel.com>