### PR TITLE
MdeModulePkg: XHC and USB PEI drivers fixes

### DIFF
--- a/MdeModulePkg/Bus/Pci/XhciDxe/XhciSched.c
+++ b/MdeModulePkg/Bus/Pci/XhciDxe/XhciSched.c
@@ -4,6 +4,7 @@
 
 Copyright (c) 2011 - 2020, Intel Corporation. All rights reserved.<BR>
 Copyright (c) Microsoft Corporation.<BR>
+Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -2807,6 +2808,9 @@ XhcInitializeEndpointContext (
   MaxDci = 0;
 
   NumEp = IfDesc->NumEndpoints;
+  if (NumEp == 0) {
+    MaxDci = 1;
+  }
 
   EpDesc = (USB_ENDPOINT_DESCRIPTOR *)(IfDesc + 1);
   for (EpIndex = 0; EpIndex < NumEp; EpIndex++) {
@@ -3006,6 +3010,9 @@ XhcInitializeEndpointContext64 (
   MaxDci = 0;
 
   NumEp = IfDesc->NumEndpoints;
+  if (NumEp == 0) {
+    MaxDci = 1;
+  }
 
   EpDesc = (USB_ENDPOINT_DESCRIPTOR *)(IfDesc + 1);
   for (EpIndex = 0; EpIndex < NumEp; EpIndex++) {

--- a/MdeModulePkg/Bus/Pci/XhciPei/UsbHcMem.c
+++ b/MdeModulePkg/Bus/Pci/XhciPei/UsbHcMem.c
@@ -3,6 +3,7 @@ PEIM to produce gPeiUsb2HostControllerPpiGuid based on gPeiUsbControllerPpiGuid
 which is used to enable recovery function from USB Drivers.
 
 Copyright (c) 2014 - 2016, Intel Corporation. All rights reserved.<BR>
+Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.<BR>
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -366,6 +367,32 @@ UsbHcInitMemPool (
 }
 
 /**
+  Unlink the memory block from the pool's list.
+
+  @param  Head           The block list head of the memory's pool.
+  @param  BlockToUnlink  The memory block to unlink.
+
+**/
+VOID
+UsbHcUnlinkMemBlock (
+  IN USBHC_MEM_BLOCK  *Head,
+  IN USBHC_MEM_BLOCK  *BlockToUnlink
+  )
+{
+  USBHC_MEM_BLOCK  *Block;
+
+  ASSERT ((Head != NULL) && (BlockToUnlink != NULL));
+
+  for (Block = Head; Block != NULL; Block = Block->Next) {
+    if (Block->Next == BlockToUnlink) {
+      Block->Next         = BlockToUnlink->Next;
+      BlockToUnlink->Next = NULL;
+      break;
+    }
+  }
+}
+
+/**
   Release the memory management pool.
 
   @param  Pool          The USB memory pool to free.
@@ -386,7 +413,7 @@ UsbHcFreeMemPool (
   // first block.
   //
   for (Block = Pool->Head->Next; Block != NULL; Block = Pool->Head->Next) {
-    // UsbHcUnlinkMemBlock (Pool->Head, Block);
+    UsbHcUnlinkMemBlock (Pool->Head, Block);
     UsbHcFreeMemBlock (Pool, Block);
   }
 
@@ -532,7 +559,7 @@ UsbHcFreeMem (
   // Release the current memory block if it is empty and not the head
   //
   if ((Block != Head) && UsbHcIsMemBlockEmpty (Block)) {
-    // UsbHcUnlinkMemBlock (Head, Block);
+    UsbHcUnlinkMemBlock (Head, Block);
     UsbHcFreeMemBlock (Pool, Block);
   }
 }

--- a/MdeModulePkg/Bus/Pci/XhciPei/XhciSched.c
+++ b/MdeModulePkg/Bus/Pci/XhciPei/XhciSched.c
@@ -3,6 +3,7 @@ PEIM to produce gPeiUsb2HostControllerPpiGuid based on gPeiUsbControllerPpiGuid
 which is used to enable recovery function from USB Drivers.
 
 Copyright (c) 2014 - 2017, Intel Corporation. All rights reserved.<BR>
+Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.<BR>
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -1752,6 +1753,9 @@ XhcPeiSetConfigCmd (
     }
 
     NumEp = IfDesc->NumEndpoints;
+    if ((NumEp == 0) && (MaxDci == 0)) {
+      MaxDci = 1;
+    }
 
     EpDesc = (USB_ENDPOINT_DESCRIPTOR *)(IfDesc + 1);
     for (EpIndex = 0; EpIndex < NumEp; EpIndex++) {
@@ -1974,6 +1978,9 @@ XhcPeiSetConfigCmd64 (
     }
 
     NumEp = IfDesc->NumEndpoints;
+    if ((NumEp == 0) && (MaxDci == 0)) {
+      MaxDci = 1;
+    }
 
     EpDesc = (USB_ENDPOINT_DESCRIPTOR *)(IfDesc + 1);
     for (EpIndex = 0; EpIndex < NumEp; EpIndex++) {


### PR DESCRIPTION
Patch 1/3 "MdeModulePkg/Xhci: Initial XHCI DCI slot's Context value" sent at:
https://edk2.groups.io/g/devel/message/98267

Patch 2/3 "MdeModulePkg/Usb: Read a large number of blocks" sent at:
https://edk2.groups.io/g/devel/message/98268

Patch 3/3 "MdeModulePkg/XhciPei: Unlinked XhciPei memory block" sent at:
https://edk2.groups.io/g/devel/message/98269