### PR TITLE
OvmfPkg/AcpiPlatformDxe: Measure ACPI table from QEMU in TDVF

### DIFF
--- a/OvmfPkg/AcpiPlatformDxe/AcpiPlatformDxe.inf
+++ b/OvmfPkg/AcpiPlatformDxe/AcpiPlatformDxe.inf
@@ -46,6 +46,7 @@
   UefiBootServicesTableLib
   UefiDriverEntryPoint
   HobLib
+  TpmMeasurementLib
 
 [Protocols]
   gEfiAcpiTableProtocolGuid                     # PROTOCOL ALWAYS_CONSUMED


### PR DESCRIPTION
https://bugzilla.tianocore.org/show_bug.cgi?id=4245

The ACPI tables are downloaded from QEMU. From the security perspective they should be measured and extended before installation. So that they can be audited later.

Cc: Erdem Aktas <erdemaktas@google.com>
Cc: James Bottomley <jejb@linux.ibm.com>
Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Gerd Hoffmann <kraxel@redhat.com>
Cc: Tom Lendacky <thomas.lendacky@amd.com>
Cc: Michael Roth <michael.roth@amd.com>
Signed-off-by: Min Xu <min.m.xu@intel.com>