### PR TITLE
Fix cyclic dependency error on OptionROM build

### DIFF
--- a/BaseTools/Conf/build_rule.template
+++ b/BaseTools/Conf/build_rule.template
@@ -342,7 +342,6 @@
 
     <OutputFile>
         $(OUTPUT_DIR)(+)$(MODULE_NAME).efi
-        $(DEBUG_DIR)(+)$(MODULE_NAME).efi
         $(OUTPUT_DIR)(+)$(MODULE_NAME).map
 
     <Command.MSFT, Command.INTEL, Command.CLANGPDB>


### PR DESCRIPTION
EDKII build system supports OptionROM generation if particular PCI_* defines are present in the module INF file:
```
[Defines]
  ...
  PCI_VENDOR_ID                  = <...>
  PCI_DEVICE_ID                  = <...>
  PCI_CLASS_CODE                 = <...>
  PCI_REVISION                   = <...>
```
Although after the commit d372ab585a2cdc5348af5f701c56c631235fe698 ("BaseTools/Conf: Fix Dynamic-Library-File template") it is no longer possible.
The build system fails with the error:
```
Cyclic dependency detected while generating rule for
"<...>/DEBUG/<...>.efi" file
```
Remove "$(DEBUG_DIR)(+)$(MODULE_NAME).efi" from the 'dll' output files to fix the cyclic dependency.

Signed-off-by: Konstantin Aladyshev <aladyshev22@gmail.com>
Reviewed-by: Bob Feng <bob.c.feng@intel.com>