### PR TITLE
 Introduce Separate-Fv in OvmfPkg/IntelTdx

### DIFF
--- a/EmbeddedPkg/Include/Library/PrePiLib.h
+++ b/EmbeddedPkg/Include/Library/PrePiLib.h
@@ -53,10 +53,22 @@ FfsFindNextFile (
   );
 
 /**
-  This service enables discovery sections of a given type within a valid FFS file.
+ * This is a hook which is used to check if the section is the target one.
+ *
+ */
+typedef
+EFI_STATUS
+(EFIAPI *FFS_CHECK_SECTION_HOOK)(
+  IN EFI_COMMON_SECTION_HEADER *Section
+  );
 
-  @param  SearchType            The value of the section type to find.
-  @param  FfsFileHeader         A pointer to the file header that contains the set of sections to
+/**
+  This service enables discovery sections of a given type within a valid FFS file.
+  Caller also can provide a SectionCheckHook to do additional checking.
+
+  @param  SectionType           The value of the section type to find.
+  @param  SectionCheckHook      A hook which can check if the section is the target one.
+  @param  FileHeader            A pointer to the file header that contains the set of sections to
                                 be searched.
   @param  SectionData           A pointer to the discovered section, if successful.
 
@@ -67,9 +79,10 @@ FfsFindNextFile (
 EFI_STATUS
 EFIAPI
 FfsFindSectionData (
-  IN EFI_SECTION_TYPE     SectionType,
-  IN EFI_PEI_FILE_HANDLE  FileHandle,
-  OUT VOID                **SectionData
+  IN EFI_SECTION_TYPE        SectionType,
+  IN FFS_CHECK_SECTION_HOOK  SectionCheckHook,
+  IN EFI_PEI_FILE_HANDLE     FileHandle,
+  OUT VOID                   **SectionData
   );
 
 /**

--- a/EmbeddedPkg/Library/PrePiLib/PrePiLib.c
+++ b/EmbeddedPkg/Library/PrePiLib/PrePiLib.c
@@ -131,7 +131,7 @@ LoadDxeCoreFromFfsFile (
   VOID                  *Hob;
   EFI_FV_FILE_INFO      FvFileInfo;
 
-  Status = FfsFindSectionData (EFI_SECTION_PE32, FileHandle, &PeCoffImage);
+  Status = FfsFindSectionData (EFI_SECTION_PE32, NULL, FileHandle, &PeCoffImage);
   if (EFI_ERROR (Status)) {
     return Status;
   }

--- a/OvmfPkg/IntelTdx/IntelTdxX64.dsc
+++ b/OvmfPkg/IntelTdx/IntelTdxX64.dsc
@@ -32,6 +32,11 @@
   DEFINE SECURE_BOOT_ENABLE      = FALSE
 
   #
+  # Shell can be useful for debugging but should not be enabled for production
+  #
+  DEFINE BUILD_SHELL             = TRUE
+
+  #
   # Device drivers
   #
   DEFINE PVSCSI_ENABLE           = FALSE
@@ -204,7 +209,9 @@
   VariablePolicyHelperLib|MdeModulePkg/Library/VariablePolicyHelperLib/VariablePolicyHelperLib.inf
   VariableFlashInfoLib|MdeModulePkg/Library/BaseVariableFlashInfoLib/BaseVariableFlashInfoLib.inf
 
+!if $(BUILD_SHELL) == TRUE
   ShellLib|ShellPkg/Library/UefiShellLib/UefiShellLib.inf
+!endif
   ShellCEntryLib|ShellPkg/Library/UefiShellCEntryLib/UefiShellCEntryLib.inf
   S3BootScriptLib|MdeModulePkg/Library/PiDxeS3BootScriptLib/DxeS3BootScriptLib.inf
   SmbusLib|MdePkg/Library/BaseSmbusLibNull/BaseSmbusLibNull.inf
@@ -720,12 +727,13 @@
   MdeModulePkg/Bus/Usb/UsbKbDxe/UsbKbDxe.inf
   MdeModulePkg/Bus/Usb/UsbMassStorageDxe/UsbMassStorageDxe.inf
 
-!if $(TOOL_CHAIN_TAG) != "XCODE5"
+!if $(TOOL_CHAIN_TAG) != "XCODE5" && $(BUILD_SHELL) == TRUE
   OvmfPkg/LinuxInitrdDynamicShellCommand/LinuxInitrdDynamicShellCommand.inf {
     <PcdsFixedAtBuild>
       gEfiShellPkgTokenSpaceGuid.PcdShellLibAutoInitialize|FALSE
   }
 !endif
+!if $(BUILD_SHELL) == TRUE
   ShellPkg/Application/Shell/Shell.inf {
     <LibraryClasses>
       ShellCommandLib|ShellPkg/Library/UefiShellCommandLib/UefiShellCommandLib.inf
@@ -744,6 +752,7 @@
       gEfiShellPkgTokenSpaceGuid.PcdShellLibAutoInitialize|FALSE
       gEfiMdePkgTokenSpaceGuid.PcdUefiLibMaxPrintBufferSize|8000
   }
+!endif
 
 !if $(SECURE_BOOT_ENABLE) == TRUE
   SecurityPkg/VariableAuthenticated/SecureBootConfigDxe/SecureBootConfigDxe.inf

--- a/OvmfPkg/IntelTdx/IntelTdxX64.fdf
+++ b/OvmfPkg/IntelTdx/IntelTdxX64.fdf
@@ -97,9 +97,13 @@ gUefiOvmfPkgTokenSpaceGuid.PcdOvmfCpuidBase|gUefiOvmfPkgTokenSpaceGuid.PcdOvmfCp
 0x010000|0x010000
 gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSecPeiTempRamBase|gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSecPeiTempRamSize
 
-0x100000|0xC00000
+0x100000|0x700000
 gUefiOvmfPkgTokenSpaceGuid.PcdOvmfDxeMemFvBase|gUefiOvmfPkgTokenSpaceGuid.PcdOvmfDxeMemFvSize
 FV = DXEFV
+
+0x800000|0x500000
+gUefiOvmfPkgTokenSpaceGuid.PcdOvmfDxeNonCcFvBase|gUefiOvmfPkgTokenSpaceGuid.PcdOvmfDxeNonCcFvSize
+FV = NCCFV
 
 ##########################################################################################
 # Set the SEV-ES specific work area PCDs
@@ -183,7 +187,6 @@ INF  MdeModulePkg/Universal/PCD/Dxe/Pcd.inf
 
 INF  MdeModulePkg/Core/RuntimeDxe/RuntimeDxe.inf
 INF  MdeModulePkg/Universal/SecurityStubDxe/SecurityStubDxe.inf
-INF  MdeModulePkg/Universal/EbcDxe/EbcDxe.inf
 INF  UefiCpuPkg/CpuIo2Dxe/CpuIo2Dxe.inf
 
 INF  UefiCpuPkg/CpuDxe/CpuDxe.inf
@@ -201,6 +204,86 @@ INF  PcAtChipsetPkg/PcatRealTimeClockRuntimeDxe/PcatRealTimeClockRuntimeDxe.inf
 INF  OvmfPkg/VirtioPciDeviceDxe/VirtioPciDeviceDxe.inf
 INF  OvmfPkg/Virtio10Dxe/Virtio10.inf
 INF  OvmfPkg/VirtioBlkDxe/VirtioBlk.inf
+
+!if $(SECURE_BOOT_ENABLE) == TRUE
+  INF  SecurityPkg/VariableAuthenticated/SecureBootConfigDxe/SecureBootConfigDxe.inf
+!endif
+
+INF  MdeModulePkg/Universal/WatchdogTimerDxe/WatchdogTimer.inf
+INF  MdeModulePkg/Universal/MonotonicCounterRuntimeDxe/MonotonicCounterRuntimeDxe.inf
+INF  MdeModulePkg/Universal/CapsuleRuntimeDxe/CapsuleRuntimeDxe.inf
+INF  MdeModulePkg/Universal/Console/ConPlatformDxe/ConPlatformDxe.inf
+INF  MdeModulePkg/Universal/Console/ConSplitterDxe/ConSplitterDxe.inf
+INF  MdeModulePkg/Universal/Console/TerminalDxe/TerminalDxe.inf
+INF  MdeModulePkg/Universal/BdsDxe/BdsDxe.inf
+INF  MdeModulePkg/Application/UiApp/UiApp.inf
+INF  OvmfPkg/QemuKernelLoaderFsDxe/QemuKernelLoaderFsDxe.inf
+INF  MdeModulePkg/Universal/DevicePathDxe/DevicePathDxe.inf
+INF  MdeModulePkg/Universal/Disk/DiskIoDxe/DiskIoDxe.inf
+INF  MdeModulePkg/Universal/Disk/PartitionDxe/PartitionDxe.inf
+INF  MdeModulePkg/Universal/Disk/UnicodeCollation/EnglishDxe/EnglishDxe.inf
+INF  OvmfPkg/SataControllerDxe/SataControllerDxe.inf
+INF  MdeModulePkg/Bus/Ata/AtaAtapiPassThru/AtaAtapiPassThru.inf
+INF  MdeModulePkg/Bus/Ata/AtaBusDxe/AtaBusDxe.inf
+INF  MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressDxe.inf
+INF  MdeModulePkg/Universal/HiiDatabaseDxe/HiiDatabaseDxe.inf
+INF  MdeModulePkg/Universal/SetupBrowserDxe/SetupBrowserDxe.inf
+INF  MdeModulePkg/Universal/DisplayEngineDxe/DisplayEngineDxe.inf
+
+INF  OvmfPkg/SioBusDxe/SioBusDxe.inf
+INF  MdeModulePkg/Bus/Pci/PciSioSerialDxe/PciSioSerialDxe.inf
+
+INF  MdeModulePkg/Universal/SmbiosDxe/SmbiosDxe.inf
+INF  OvmfPkg/SmbiosPlatformDxe/SmbiosPlatformDxe.inf
+
+INF  MdeModulePkg/Universal/Acpi/AcpiTableDxe/AcpiTableDxe.inf
+INF  OvmfPkg/AcpiPlatformDxe/AcpiPlatformDxe.inf
+
+INF  FatPkg/EnhancedFatDxe/Fat.inf
+INF OvmfPkg/TdxDxe/TdxDxe.inf
+
+INF  OvmfPkg/IoMmuDxe/IoMmuDxe.inf
+
+#
+# Variable driver stack (non-SMM)
+#
+INF  OvmfPkg/QemuFlashFvbServicesRuntimeDxe/FvbServicesRuntimeDxe.inf
+INF  OvmfPkg/EmuVariableFvbRuntimeDxe/Fvb.inf
+INF  MdeModulePkg/Universal/FaultTolerantWriteDxe/FaultTolerantWriteDxe.inf
+INF  MdeModulePkg/Universal/Variable/RuntimeDxe/VariableRuntimeDxe.inf
+
+#
+# EFI_CC_MEASUREMENT_PROTOCOL
+#
+INF SecurityPkg/Tcg/TdTcg2Dxe/TdTcg2Dxe.inf
+
+################################################################################
+
+[FV.NCCFV]
+FvForceRebase      = FALSE
+FvNameGuid         = AE047C6D-BCE9-426C-AE03-A68E3B8A0488
+BlockSize          = 0x10000
+FvAlignment        = 16
+ERASE_POLARITY     = 1
+MEMORY_MAPPED      = TRUE
+STICKY_WRITE       = TRUE
+LOCK_CAP           = TRUE
+LOCK_STATUS        = TRUE
+WRITE_DISABLED_CAP = TRUE
+WRITE_ENABLED_CAP  = TRUE
+WRITE_STATUS       = TRUE
+WRITE_LOCK_CAP     = TRUE
+WRITE_LOCK_STATUS  = TRUE
+READ_DISABLED_CAP  = TRUE
+READ_ENABLED_CAP   = TRUE
+READ_STATUS        = TRUE
+READ_LOCK_CAP      = TRUE
+READ_LOCK_STATUS   = TRUE
+
+#
+# DXE Phase modules
+#
+INF  MdeModulePkg/Universal/EbcDxe/EbcDxe.inf
 INF  OvmfPkg/VirtioScsiDxe/VirtioScsi.inf
 INF  OvmfPkg/VirtioRngDxe/VirtioRng.inf
 !if $(PVSCSI_ENABLE) == TRUE
@@ -212,63 +295,27 @@ INF  OvmfPkg/MptScsiDxe/MptScsiDxe.inf
 !if $(LSI_SCSI_ENABLE) == TRUE
 INF  OvmfPkg/LsiScsiDxe/LsiScsiDxe.inf
 !endif
-
-!if $(SECURE_BOOT_ENABLE) == TRUE
-  INF  SecurityPkg/VariableAuthenticated/SecureBootConfigDxe/SecureBootConfigDxe.inf
-!endif
-
-INF  MdeModulePkg/Universal/WatchdogTimerDxe/WatchdogTimer.inf
-INF  MdeModulePkg/Universal/MonotonicCounterRuntimeDxe/MonotonicCounterRuntimeDxe.inf
-INF  MdeModulePkg/Universal/CapsuleRuntimeDxe/CapsuleRuntimeDxe.inf
-INF  MdeModulePkg/Universal/Console/ConPlatformDxe/ConPlatformDxe.inf
-INF  MdeModulePkg/Universal/Console/ConSplitterDxe/ConSplitterDxe.inf
 INF  MdeModulePkg/Universal/Console/GraphicsConsoleDxe/GraphicsConsoleDxe.inf
-INF  MdeModulePkg/Universal/Console/TerminalDxe/TerminalDxe.inf
 INF  MdeModulePkg/Universal/DriverHealthManagerDxe/DriverHealthManagerDxe.inf
-INF  MdeModulePkg/Universal/BdsDxe/BdsDxe.inf
-INF  MdeModulePkg/Application/UiApp/UiApp.inf
-INF  OvmfPkg/QemuKernelLoaderFsDxe/QemuKernelLoaderFsDxe.inf
-INF  MdeModulePkg/Universal/DevicePathDxe/DevicePathDxe.inf
-INF  MdeModulePkg/Universal/Disk/DiskIoDxe/DiskIoDxe.inf
-INF  MdeModulePkg/Universal/Disk/PartitionDxe/PartitionDxe.inf
 INF  MdeModulePkg/Universal/Disk/RamDiskDxe/RamDiskDxe.inf
-INF  MdeModulePkg/Universal/Disk/UnicodeCollation/EnglishDxe/EnglishDxe.inf
 INF  MdeModulePkg/Bus/Scsi/ScsiBusDxe/ScsiBusDxe.inf
 INF  MdeModulePkg/Bus/Scsi/ScsiDiskDxe/ScsiDiskDxe.inf
-INF  OvmfPkg/SataControllerDxe/SataControllerDxe.inf
-INF  MdeModulePkg/Bus/Ata/AtaAtapiPassThru/AtaAtapiPassThru.inf
-INF  MdeModulePkg/Bus/Ata/AtaBusDxe/AtaBusDxe.inf
-INF  MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressDxe.inf
-INF  MdeModulePkg/Universal/HiiDatabaseDxe/HiiDatabaseDxe.inf
-INF  MdeModulePkg/Universal/SetupBrowserDxe/SetupBrowserDxe.inf
-INF  MdeModulePkg/Universal/DisplayEngineDxe/DisplayEngineDxe.inf
 INF  MdeModulePkg/Universal/MemoryTest/NullMemoryTestDxe/NullMemoryTestDxe.inf
-
-INF  OvmfPkg/SioBusDxe/SioBusDxe.inf
-INF  MdeModulePkg/Bus/Pci/PciSioSerialDxe/PciSioSerialDxe.inf
 INF  MdeModulePkg/Bus/Isa/Ps2KeyboardDxe/Ps2KeyboardDxe.inf
-
-INF  MdeModulePkg/Universal/SmbiosDxe/SmbiosDxe.inf
-INF  OvmfPkg/SmbiosPlatformDxe/SmbiosPlatformDxe.inf
-
-INF  MdeModulePkg/Universal/Acpi/AcpiTableDxe/AcpiTableDxe.inf
-INF  OvmfPkg/AcpiPlatformDxe/AcpiPlatformDxe.inf
 INF  MdeModulePkg/Universal/Acpi/S3SaveStateDxe/S3SaveStateDxe.inf
 INF  MdeModulePkg/Universal/Acpi/BootScriptExecutorDxe/BootScriptExecutorDxe.inf
 INF  MdeModulePkg/Universal/Acpi/BootGraphicsResourceTableDxe/BootGraphicsResourceTableDxe.inf
-
-INF  FatPkg/EnhancedFatDxe/Fat.inf
 INF  MdeModulePkg/Universal/Disk/UdfDxe/UdfDxe.inf
 INF  OvmfPkg/VirtioFsDxe/VirtioFsDxe.inf
 
-!if $(TOOL_CHAIN_TAG) != "XCODE5"
+!if $(BUILD_SHELL) == TRUE && $(TOOL_CHAIN_TAG) != "XCODE5"
 INF  OvmfPkg/LinuxInitrdDynamicShellCommand/LinuxInitrdDynamicShellCommand.inf
 !endif
+!if $(BUILD_SHELL) == TRUE
 INF  ShellPkg/Application/Shell/Shell.inf
+!endif
 
 INF MdeModulePkg/Logo/LogoDxe.inf
-
-INF OvmfPkg/TdxDxe/TdxDxe.inf
 
 #
 # Usb Support
@@ -285,20 +332,6 @@ INF  OvmfPkg/QemuVideoDxe/QemuVideoDxe.inf
 INF  OvmfPkg/QemuRamfbDxe/QemuRamfbDxe.inf
 INF  OvmfPkg/VirtioGpuDxe/VirtioGpu.inf
 INF  OvmfPkg/PlatformDxe/Platform.inf
-INF  OvmfPkg/IoMmuDxe/IoMmuDxe.inf
-
-#
-# Variable driver stack (non-SMM)
-#
-INF  OvmfPkg/QemuFlashFvbServicesRuntimeDxe/FvbServicesRuntimeDxe.inf
-INF  OvmfPkg/EmuVariableFvbRuntimeDxe/Fvb.inf
-INF  MdeModulePkg/Universal/FaultTolerantWriteDxe/FaultTolerantWriteDxe.inf
-INF  MdeModulePkg/Universal/Variable/RuntimeDxe/VariableRuntimeDxe.inf
-
-#
-# EFI_CC_MEASUREMENT_PROTOCOL
-#
-INF SecurityPkg/Tcg/TdTcg2Dxe/TdTcg2Dxe.inf
 
 ################################################################################
 
@@ -329,6 +362,7 @@ FILE FV_IMAGE = 9E21FD93-9C72-4c15-8C4B-E77F1DB2D792 {
      # compression operation in order to achieve better overall compression.
      #
      SECTION FV_IMAGE = DXEFV
+     SECTION FV_IMAGE = NCCFV
    }
  }
 

--- a/OvmfPkg/Library/PeilessStartupLib/DxeLoad.c
+++ b/OvmfPkg/Library/PeilessStartupLib/DxeLoad.c
@@ -22,6 +22,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/ReportStatusCodeLib.h>
 
 #define STACK_SIZE  0x20000
+extern EFI_GUID  gEfiNonCcFvGuid;
 
 /**
    Transfers control to DxeCore.
@@ -137,6 +138,133 @@ FindDxeCore (
 }
 
 /**
+ * This is a FFS_CHECK_SECTION_HOOK which is defined by caller to check
+ * if the section is an EFI_SECTION_FIRMWARE_VOLUME_IMAGE and if it is
+ * a NonCc FV.
+ *
+ * @param Section       The section in which we're checking for the NonCc FV.
+ * @return EFI_STATUS   The section is the NonCc FV.
+ */
+EFI_STATUS
+EFIAPI
+CheckSectionHookForDxeNonCc (
+  IN EFI_COMMON_SECTION_HEADER  *Section
+  )
+{
+  VOID         *Buffer;
+  EFI_STATUS   Status;
+  EFI_FV_INFO  FvImageInfo;
+
+  if (Section->Type != EFI_SECTION_FIRMWARE_VOLUME_IMAGE) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (IS_SECTION2 (Section)) {
+    Buffer = (VOID *)((UINT8 *)Section + sizeof (EFI_COMMON_SECTION_HEADER2));
+  } else {
+    Buffer = (VOID *)((UINT8 *)Section + sizeof (EFI_COMMON_SECTION_HEADER));
+  }
+
+  ZeroMem (&FvImageInfo, sizeof (FvImageInfo));
+  Status = FfsGetVolumeInfo ((EFI_PEI_FV_HANDLE)(UINTN)Buffer, &FvImageInfo);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_INFO, "Cannot get volume info! %r\n", Status));
+    return Status;
+  }
+
+  return CompareGuid (&FvImageInfo.FvName, &gEfiNonCcFvGuid) ? EFI_SUCCESS : EFI_NOT_FOUND;
+}
+
+/**
+ * Find the NonCc FV.
+ *
+ * @param FvInstance    The FvInstance number.
+ * @return EFI_STATUS   Successfuly find the NonCc FV.
+ */
+EFI_STATUS
+EFIAPI
+FindDxeNonCc (
+  IN INTN  FvInstance
+  )
+{
+  EFI_STATUS           Status;
+  EFI_PEI_FV_HANDLE    VolumeHandle;
+  EFI_PEI_FILE_HANDLE  FileHandle;
+  EFI_PEI_FV_HANDLE    FvImageHandle;
+  EFI_FV_INFO          FvImageInfo;
+  UINT32               FvAlignment;
+  VOID                 *FvBuffer;
+
+  FileHandle = NULL;
+
+  //
+  // Caller passed in a specific FV to try, so only try that one
+  //
+  Status = FfsFindNextVolume (FvInstance, &VolumeHandle);
+  ASSERT (Status == EFI_SUCCESS);
+
+  Status = FfsFindNextFile (EFI_FV_FILETYPE_FIRMWARE_VOLUME_IMAGE, VolumeHandle, &FileHandle);
+  ASSERT (FileHandle != NULL);
+
+  //
+  // Find FvImage in FvFile
+  //
+  Status = FfsFindSectionData (EFI_SECTION_FIRMWARE_VOLUME_IMAGE, CheckSectionHookForDxeNonCc, FileHandle, (VOID **)&FvImageHandle);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  //
+  // Collect FvImage Info.
+  //
+  ZeroMem (&FvImageInfo, sizeof (FvImageInfo));
+  Status = FfsGetVolumeInfo (FvImageHandle, &FvImageInfo);
+  ASSERT_EFI_ERROR (Status);
+
+  //
+  // FvAlignment must be more than 8 bytes required by FvHeader structure.
+  //
+  FvAlignment = 1 << ((FvImageInfo.FvAttributes & EFI_FVB2_ALIGNMENT) >> 16);
+  if (FvAlignment < 8) {
+    FvAlignment = 8;
+  }
+
+  //
+  // Check FvImage
+  //
+  if ((UINTN)FvImageInfo.FvStart % FvAlignment != 0) {
+    FvBuffer = AllocateAlignedPages (EFI_SIZE_TO_PAGES ((UINT32)FvImageInfo.FvSize), FvAlignment);
+    if (FvBuffer == NULL) {
+      return EFI_OUT_OF_RESOURCES;
+    }
+
+    CopyMem (FvBuffer, FvImageInfo.FvStart, (UINTN)FvImageInfo.FvSize);
+    //
+    // Update FvImageInfo after reload FvImage to new aligned memory
+    //
+    FfsGetVolumeInfo ((EFI_PEI_FV_HANDLE)FvBuffer, &FvImageInfo);
+  }
+
+  //
+  // Inform HOB consumer phase, i.e. DXE core, the existence of this FV
+  //
+  BuildFvHob ((EFI_PHYSICAL_ADDRESS)(UINTN)FvImageInfo.FvStart, FvImageInfo.FvSize);
+
+  //
+  // Makes the encapsulated volume show up in DXE phase to skip processing of
+  // encapsulated file again.
+  //
+  BuildFv2Hob (
+    (EFI_PHYSICAL_ADDRESS)(UINTN)FvImageInfo.FvStart,
+    FvImageInfo.FvSize,
+    &FvImageInfo.FvName,
+    &(((EFI_FFS_FILE_HEADER *)FileHandle)->Name)
+    );
+
+  return Status;
+}
+
+/**
    This function finds DXE Core in the firmware volume and transfer the control to
    DXE core.
 
@@ -168,10 +296,14 @@ DxeLoadCore (
     return Status;
   }
 
+  if (!TdIsEnabled ()) {
+    FindDxeNonCc (FvInstance);
+  }
+
   //
   // Load the DXE Core from a Firmware Volume.
   //
-  Status = FfsFindSectionData (EFI_SECTION_PE32, FileHandle, &PeCoffImage);
+  Status = FfsFindSectionData (EFI_SECTION_PE32, NULL, FileHandle, &PeCoffImage);
   if (EFI_ERROR (Status)) {
     return Status;
   }

--- a/OvmfPkg/Library/PeilessStartupLib/PeilessStartupInternal.h
+++ b/OvmfPkg/Library/PeilessStartupLib/PeilessStartupInternal.h
@@ -21,6 +21,12 @@ DxeLoadCore (
   IN INTN  FvInstance
   );
 
+EFI_STATUS
+EFIAPI
+FindDxeNonCc (
+  IN INTN  FvInstance
+  );
+
 VOID
 EFIAPI
 TransferHobList (

--- a/OvmfPkg/Library/PeilessStartupLib/PeilessStartupLib.inf
+++ b/OvmfPkg/Library/PeilessStartupLib/PeilessStartupLib.inf
@@ -67,6 +67,7 @@
   gEfiMemoryTypeInformationGuid
   gPcdDataBaseHobGuid
   gCcEventEntryHobGuid
+  gEfiNonCcFvGuid
 
 [Pcd]
   gUefiOvmfPkgTokenSpaceGuid.PcdCfvBase

--- a/OvmfPkg/OvmfPkg.dec
+++ b/OvmfPkg/OvmfPkg.dec
@@ -156,6 +156,7 @@
   gUefiOvmfPkgPlatformInfoGuid          = {0xdec9b486, 0x1f16, 0x47c7, {0x8f, 0x68, 0xdf, 0x1a, 0x41, 0x88, 0x8b, 0xa5}}
   gVMMBootOrderGuid                     = {0x668f4529, 0x63d0, 0x4bb5, {0xb6, 0x5d, 0x6f, 0xbb, 0x9d, 0x36, 0xa4, 0x4a}}
   gUefiOvmfPkgTdxAcpiHobGuid            = {0x6a0c5870, 0xd4ed, 0x44f4, {0xa1, 0x35, 0xdd, 0x23, 0x8b, 0x6f, 0x0c, 0x8d}}
+  gEfiNonCcFvGuid                       = {0xae047c6d, 0xbce9, 0x426c, {0xae, 0x03, 0xa6, 0x8e, 0x3b, 0x8a, 0x04, 0x88}}
 
 [Ppis]
   # PPI whose presence in the PPI database signals that the TPM base address
@@ -192,6 +193,8 @@
   gUefiOvmfPkgTokenSpaceGuid.PcdOvmfPeiMemFvSize|0x0|UINT32|1
   gUefiOvmfPkgTokenSpaceGuid.PcdOvmfDxeMemFvBase|0x0|UINT32|0x15
   gUefiOvmfPkgTokenSpaceGuid.PcdOvmfDxeMemFvSize|0x0|UINT32|0x16
+  gUefiOvmfPkgTokenSpaceGuid.PcdOvmfDxeNonCcFvBase|0x0|UINT32|0x6a
+  gUefiOvmfPkgTokenSpaceGuid.PcdOvmfDxeNonCcFvSize|0x0|UINT32|0x6b
 
   ## This flag is used to control the destination port for PlatformDebugLibIoPort
   gUefiOvmfPkgTokenSpaceGuid.PcdDebugIoPort|0x402|UINT16|4


### PR DESCRIPTION

BZ: https://bugzilla.tianocore.org/show_bug.cgi?id=4152

In current DXE FV there are 100+ drivers. Some of the drivers are not
used in Td guest. (Such as USB support drivers, network related
drivers, etc).

From the security perspective if a driver is not used, we should prevent
it from being loaded/started. There are 2 benefits: 
1. Reduce the attack surface
2. Improve the boot performance

So we introduce Separate-Fv which separates DXEFV into 2 FVs: DXEFV
and NCCFV. All the drivers which are not needed by a Confidential
Computing guest are moved from DXEFV to NCCFV.

When booting a CC guest only the drivers in DXEFV will be loaded and
started. For a Non-CC guest both DXEFV and NCCFV drivers will be
loaded and started.

Patch#1 updates EmbeddedPkg/PrePiLib with FFS_CHECK_SECTION_HOOK.
Patch#2 adds PCDs/GUID for NCCFV.
Patch#3 moves cc-unused drivers to NCCFV.
Patch#4 update PeilessStartupLib to find NCCFV for non-cc guest.

Code: https://github.com/mxu9/edk2/tree/Separate-Fv.v3

v3 changes:
 - Rebase the code base to 7cd55f3009.

v2 changes:
 - Move shell from DXEFV to NCCFV.
 - Wrap shell into "!if $(BUILD_SHELL) == TRUE" for consistency with
   the other ovmf build variants.

Cc: Leif Lindholm <quic_llindhol@quicinc.com>
Cc: Ard Biesheuvel <ardb+tianocore@kernel.org>
Cc: Abner Chang <abner.chang@amd.com>
Cc: Daniel Schaefer <git@danielschaefer.me>
Cc: Gerd Hoffmann <kraxel@redhat.com>
Cc: Erdem Aktas <erdemaktas@google.com>
Cc: James Bottomley <jejb@linux.ibm.com>
Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Tom Lendacky <thomas.lendacky@amd.com>
Signed-off-by: Min Xu <min.m.xu@intel.com>

Min M Xu (4):
  EmbeddedPkg/PrePiLib: Add FFS_CHECK_SECTION_HOOK when finding section
  OvmfPkg: Add PCDs/GUID for NCCFV
  OvmfPkg/IntelTdx: Enable separate-fv in IntelTdx/IntelTdxX64.fdf
  OvmfPkg/PeilessStartupLib: Find NCCFV in non-td guest

 EmbeddedPkg/Include/Library/PrePiLib.h        |  23 ++-
 EmbeddedPkg/Library/PrePiLib/FwVol.c          |  42 ++++--
 EmbeddedPkg/Library/PrePiLib/PrePiLib.c       |   2 +-
 OvmfPkg/IntelTdx/IntelTdxX64.dsc              |  11 +-
 OvmfPkg/IntelTdx/IntelTdxX64.fdf              | 112 ++++++++++-----
 OvmfPkg/Library/PeilessStartupLib/DxeLoad.c   | 134 +++++++++++++++++-
 .../PeilessStartupInternal.h                  |   6 +
 .../PeilessStartupLib/PeilessStartupLib.inf   |   1 +
 OvmfPkg/OvmfPkg.dec                           |   3 +
 9 files changed, 275 insertions(+), 59 deletions(-)
