### PR TITLE
SecurityPkg/TdTcg2Dxe: Extend EFI boot variable to PCR[1]

### DIFF
--- a/SecurityPkg/Tcg/TdTcg2Dxe/TdTcg2Dxe.c
+++ b/SecurityPkg/Tcg/TdTcg2Dxe/TdTcg2Dxe.c
@@ -1873,12 +1873,8 @@ ReadAndMeasureBootVariable (
   OUT     VOID      **VarData
   )
 {
-  //
-  // Boot variables are measured into (PCR[5]) RTMR[1],
-  // details in section 8.1 of TDVF design guide.
-  //
   return ReadAndMeasureVariable (
-           MapPcrToMrIndex (5),
+           MapPcrToMrIndex (1),
            EV_EFI_VARIABLE_BOOT,
            VarName,
            VendorGuid,


### PR DESCRIPTION
According to TCG PC Client PFP spec 0021 Section 2.4.4.2 EFI boot variable should be measured and extended to PCR[1], not PCR[5]. This patch is proposed to fix this error.

Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Jian J Wang <jian.j.wang@intel.com>
Reviewed-by: Jiewen Yao <jiewen.yao@intel.com>
Signed-off-by: Min Xu <min.m.xu@intel.com>