### PR TITLE
OvmfPkg/CcExitLib: Initialize Status in IoExit

### DIFF
--- a/OvmfPkg/Library/CcExitLib/CcExitVeHandler.c
+++ b/OvmfPkg/Library/CcExitLib/CcExitVeHandler.c
@@ -109,10 +109,11 @@ IoExit (
   UINT64   RepCnt;
   UINT64   Status;
 
-  Val   = 0;
-  Write = Veinfo->ExitQualification.Io.Direction ? FALSE : TRUE;
-  Size  = Veinfo->ExitQualification.Io.Size + 1;
-  Port  = Veinfo->ExitQualification.Io.Port;
+  Val    = 0;
+  Status = 0;
+  Write  = Veinfo->ExitQualification.Io.Direction ? FALSE : TRUE;
+  Size   = Veinfo->ExitQualification.Io.Size + 1;
+  Port   = Veinfo->ExitQualification.Io.Port;
 
   if (Veinfo->ExitQualification.Io.String) {
     //


### PR DESCRIPTION
Status should be initialized otherwise it may return unexpected value.

Cc: Erdem Aktas <erdemaktas@google.com>
Cc: James Bottomley <jejb@linux.ibm.com>
Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Gerd Hoffmann <kraxel@redhat.com>
Cc: Tom Lendacky <thomas.lendacky@amd.com>
Cc: Michael Roth <michael.roth@amd.com>
Reviewed-by: Jiewen Yao <jiewen.yao@intel.com>
Signed-off-by: Min Xu <min.m.xu@intel.com>