### PR TITLE
OvmfPkg: Report proper address space width for Cloud Hypervisor

### DIFF
--- a/OvmfPkg/Library/PlatformInitLib/MemDetect.c
+++ b/OvmfPkg/Library/PlatformInitLib/MemDetect.c
@@ -838,6 +838,7 @@ PlatformAddressWidthInitialization (
 {
   UINT8       PhysMemAddressWidth;
   EFI_STATUS  Status;
+  BOOLEAN     QemuQuirk;
 
   if (PlatformInfoHob->HostBridgeDevId == 0xffff /* microvm */) {
     PlatformAddressWidthFromCpuid (PlatformInfoHob, FALSE);
@@ -863,7 +864,13 @@ PlatformAddressWidthInitialization (
     PlatformGetFirstNonAddress (PlatformInfoHob);
   }
 
-  PlatformAddressWidthFromCpuid (PlatformInfoHob, TRUE);
+  if (PlatformInfoHob->HostBridgeDevId == CLOUDHV_DEVICE_ID) {
+    QemuQuirk = FALSE;
+  } else {
+    QemuQuirk = TRUE;
+  }
+
+  PlatformAddressWidthFromCpuid (PlatformInfoHob, QemuQuirk);
   if (PlatformInfoHob->PhysMemAddressWidth != 0) {
     // physical address width is known
     PlatformDynamicMmioWindow (PlatformInfoHob);


### PR DESCRIPTION
The address space width isn't properly calculated when the platform is Cloud Hypervisor. The function PlatformAddressWidthFromCpuid() must not be invoked with the QemuQuirk boolean set to true in the Cloud Hypervisor case.

Relying on the host bridge identifier, we can set the QemuQuirk to the appropriate value, which results in the address space size to be correctly returned for Cloud Hypervisor.

Having the correct address space width allows the code to calculate dynamically the MMIO space available for devices in the 64-bit address space, preventing it to fallback onto the default value (32GiB).

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>