### PR TITLE
UefiCpuPkg: Fix typo in filenames in Test/UnitTest/EfiMpServicesPpiPr…

### DIFF
--- a/UefiCpuPkg/Test/UnitTest/EfiMpServicesPpiProtocol/EdkiiPeiMpServices2PpiPeiUnitTest.inf
+++ b/UefiCpuPkg/Test/UnitTest/EfiMpServicesPpiProtocol/EdkiiPeiMpServices2PpiPeiUnitTest.inf
@@ -21,8 +21,8 @@
 #
 
 [Sources]
-  EfiMpServicesUnitTestCommom.c
-  EfiMpServicesUnitTestCommom.h
+  EfiMpServicesUnitTestCommon.c
+  EfiMpServicesUnitTestCommon.h
   EdkiiPeiMpServices2PpiUnitTest.c
 
 [Packages]

--- a/UefiCpuPkg/Test/UnitTest/EfiMpServicesPpiProtocol/EdkiiPeiMpServices2PpiUnitTest.c
+++ b/UefiCpuPkg/Test/UnitTest/EfiMpServicesPpiProtocol/EdkiiPeiMpServices2PpiUnitTest.c
@@ -9,7 +9,7 @@
 
 #include <Library/PeimEntryPoint.h>
 #include <Library/PeiServicesLib.h>
-#include "EfiMpServicesUnitTestCommom.h"
+#include "EfiMpServicesUnitTestCommon.h"
 
 #define UNIT_TEST_NAME     "EdkiiPeiMpServices2Ppi Unit Test"
 #define UNIT_TEST_VERSION  "0.1"

--- a/UefiCpuPkg/Test/UnitTest/EfiMpServicesPpiProtocol/EfiMpServiceProtocolDxeUnitTest.inf
+++ b/UefiCpuPkg/Test/UnitTest/EfiMpServicesPpiProtocol/EfiMpServiceProtocolDxeUnitTest.inf
@@ -21,8 +21,8 @@
 #
 
 [Sources]
-  EfiMpServicesUnitTestCommom.c
-  EfiMpServicesUnitTestCommom.h
+  EfiMpServicesUnitTestCommon.c
+  EfiMpServicesUnitTestCommon.h
   EfiMpServiceProtocolUnitTest.c
 
 [Packages]

--- a/UefiCpuPkg/Test/UnitTest/EfiMpServicesPpiProtocol/EfiMpServiceProtocolDynamicCmdUnitTest.c
+++ b/UefiCpuPkg/Test/UnitTest/EfiMpServicesPpiProtocol/EfiMpServiceProtocolDynamicCmdUnitTest.c
@@ -9,7 +9,7 @@
 
 #include <Library/UefiBootServicesTableLib.h>
 #include <Protocol/ShellDynamicCommand.h>
-#include "EfiMpServicesUnitTestCommom.h"
+#include "EfiMpServicesUnitTestCommon.h"
 
 CHAR16  *mMpProtocolUnitTestCommandHelp = L".TH MpProtocolUnitTest 0\r\n.SH NAME\r\nDisplay unit test results of EFI MP services protocol.\r\n";
 

--- a/UefiCpuPkg/Test/UnitTest/EfiMpServicesPpiProtocol/EfiMpServiceProtocolDynamicCmdUnitTest.inf
+++ b/UefiCpuPkg/Test/UnitTest/EfiMpServicesPpiProtocol/EfiMpServiceProtocolDynamicCmdUnitTest.inf
@@ -16,8 +16,8 @@
   UNLOAD_IMAGE    = MpProtocolUnitTestUnload
 
 [Sources]
-  EfiMpServicesUnitTestCommom.c
-  EfiMpServicesUnitTestCommom.h
+  EfiMpServicesUnitTestCommon.c
+  EfiMpServicesUnitTestCommon.h
   EfiMpServiceProtocolUnitTest.c
   EfiMpServiceProtocolDynamicCmdUnitTest.c
 

--- a/UefiCpuPkg/Test/UnitTest/EfiMpServicesPpiProtocol/EfiMpServiceProtocolShellUnitTest.inf
+++ b/UefiCpuPkg/Test/UnitTest/EfiMpServicesPpiProtocol/EfiMpServiceProtocolShellUnitTest.inf
@@ -21,8 +21,8 @@
 #
 
 [Sources]
-  EfiMpServicesUnitTestCommom.c
-  EfiMpServicesUnitTestCommom.h
+  EfiMpServicesUnitTestCommon.c
+  EfiMpServicesUnitTestCommon.h
   EfiMpServiceProtocolUnitTest.c
 
 [Packages]

--- a/UefiCpuPkg/Test/UnitTest/EfiMpServicesPpiProtocol/EfiMpServiceProtocolUnitTest.c
+++ b/UefiCpuPkg/Test/UnitTest/EfiMpServicesPpiProtocol/EfiMpServiceProtocolUnitTest.c
@@ -9,7 +9,7 @@
 
 #include <PiDxe.h>
 #include <Library/UefiBootServicesTableLib.h>
-#include "EfiMpServicesUnitTestCommom.h"
+#include "EfiMpServicesUnitTestCommon.h"
 
 #define UNIT_TEST_NAME     "EfiMpServiceProtocol Unit Test"
 #define UNIT_TEST_VERSION  "0.1"

--- a/UefiCpuPkg/Test/UnitTest/EfiMpServicesPpiProtocol/EfiMpServicesUnitTestCommon.c
+++ b/UefiCpuPkg/Test/UnitTest/EfiMpServicesPpiProtocol/EfiMpServicesUnitTestCommon.c
@@ -7,7 +7,7 @@
 
 **/
 
-#include "EfiMpServicesUnitTestCommom.h"
+#include "EfiMpServicesUnitTestCommon.h"
 
 /**
   Prep routine for Unit test function.

--- a/UefiCpuPkg/Test/UnitTest/EfiMpServicesPpiProtocol/EfiMpServicesUnitTestCommon.h
+++ b/UefiCpuPkg/Test/UnitTest/EfiMpServicesPpiProtocol/EfiMpServicesUnitTestCommon.h
@@ -7,8 +7,8 @@
 
 **/
 
-#ifndef EFI_MP_SERVICES_UNIT_TEST_COMMOM_H_
-#define EFI_MP_SERVICES_UNIT_TEST_COMMOM_H_
+#ifndef EFI_MP_SERVICES_UNIT_TEST_COMMON_H_
+#define EFI_MP_SERVICES_UNIT_TEST_COMMON_H_
 
 #include <PiPei.h>
 #include <Ppi/MpServices2.h>


### PR DESCRIPTION
…otocol

Fix the spelling of EfiMpServicesUnitTestCommon in Test/UnitTest/EfiMpServicesPpiProtocol.

Signed-off-by: Rebecca Cran <rebecca@quicinc.com>