### PR TITLE
OvmfPkg: catch QEMU's CPU hotplug reg block regression (TianoCore#4250, PlatformInitLib bugcheck + PlatformCI VS2019 exception) -- push

### DIFF
--- a/OvmfPkg/PlatformCI/.azurepipelines/Windows-VS2019.yml
+++ b/OvmfPkg/PlatformCI/.azurepipelines/Windows-VS2019.yml
@@ -24,7 +24,7 @@ jobs:
       package: 'OvmfPkg'
       vm_image: 'windows-2019'
       should_run: true
-      run_flags: "MAKE_STARTUP_NSH=TRUE QEMU_HEADLESS=TRUE"
+      run_flags: "MAKE_STARTUP_NSH=TRUE QEMU_HEADLESS=TRUE QEMU_CPUHP_QUIRK=TRUE"
 
     #Use matrix to speed up the build process
     strategy:

--- a/OvmfPkg/PlatformCI/PlatformBuildLib.py
+++ b/OvmfPkg/PlatformCI/PlatformBuildLib.py
@@ -170,6 +170,7 @@ class PlatformBuilder( UefiBuilder, BuildSettingsManager):
         self.env.SetValue("PRODUCT_NAME", "OVMF", "Platform Hardcoded")
         self.env.SetValue("MAKE_STARTUP_NSH", "FALSE", "Default to false")
         self.env.SetValue("QEMU_HEADLESS", "FALSE", "Default to false")
+        self.env.SetValue("QEMU_CPUHP_QUIRK", "FALSE", "Default to false")
         return 0
 
     def PlatformPreBuild(self):
@@ -210,6 +211,17 @@ class PlatformBuilder( UefiBuilder, BuildSettingsManager):
         else:
             args += " -pflash " + os.path.join(OutputPath_FV, "OVMF.fd")    # path to firmware
 
+
+        ###
+        ### NOTE This is a temporary workaround to allow platform CI to cope with
+        ###      a QEMU bug in the CPU hotplug code. Once the CI environment has
+        ###      been updated to carry a fixed version of QEMU, this can be
+        ###      removed again
+        ###
+        ### Bugzilla: https://bugzilla.tianocore.org/show_bug.cgi?id=4250
+        ###
+        if (self.env.GetValue("QEMU_CPUHP_QUIRK").upper() == "TRUE"):
+            args += "  -fw_cfg name=opt/org.tianocore/X-Cpuhp-Bugcheck-Override,string=yes"
 
         if (self.env.GetValue("MAKE_STARTUP_NSH").upper() == "TRUE"):
             f = open(os.path.join(VirtualDrive, "startup.nsh"), "w")


### PR DESCRIPTION
This pull request contains two, logically coherent, patch sets, in the following order:

(**1**) [RFC PATCH] OvmfPkg/PlatformCI VS2019: Enable temporary workaround for cpuhp bugfix
http://mid.mail-archive.com/20230119134302.1524569-1-ardb@kernel.org
https://listman.redhat.com/archives/edk2-devel-archive/2023-January/058197.html
https://edk2.groups.io/g/devel/message/98899
~~~
QEMU for x86 has a nasty CPU hotplug bug of which the ramifications are
difficult to oversee, even though KVM acceleration seems to be
unaffected. This has been addressed in QEMU mainline, and will percolate
through the ecosystem at its usual pace. In the mean time, due to the
potential impact on production workloads, we will be updating OVMF to
abort the boot when it detects a QEMU build that is affected.

Tiancore's platform CI uses QEMU in TCG mode, and is therefore impacted
by this mitigation, unless its QEMU builds are updated. This has been
done for Ubuntu-GCC5, but Windows-VS2019 still uses a QEMU build that is
affected.

Aborting the boot upon detecting the QEMU issue will render all boot
tests carried out on Windows-VS2019 broken unless we implement the
'escape hatch' that enables proceed-at-your-own-risk mode, and permits
the boot to proceed even if the QEMU issue is detected.

So let's enable this for Windows-VS2019, and remove it again once it is
no longer needed.

Cc: Laszlo Ersek <lersek@redhat.com>
Cc: Gerd Hoffmann <kraxel@redhat.com>
Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Michael Brown <mcb30@ipxe.org>
Cc: Oliver Steffen <osteffen@redhat.com>
Cc: Michael Kubacki <michael.kubacki@microsoft.com>

Bugzilla: https://bugzilla.tianocore.org/show_bug.cgi?id=4250
Signed-off-by: Ard Biesheuvel <ardb@kernel.org>
---
 OvmfPkg/PlatformCI/.azurepipelines/Windows-VS2019.yml |  2 +-
 OvmfPkg/PlatformCI/PlatformBuildLib.py                | 12 ++++++++++++
 2 files changed, 13 insertions(+), 1 deletion(-)
~~~

**(2)** [PATCH v3 0/2] OvmfPkg/PlatformInitLib: catch QEMU's CPU hotplug reg block regression
http://mid.mail-archive.com/20230119110131.91923-1-lersek@redhat.com
https://listman.redhat.com/archives/edk2-devel-archive/2023-January/058184.html
https://edk2.groups.io/g/devel/message/98886
~~~
Repo:       https://pagure.io/lersek/edk2.git
Branch:     cpuhp-reg-catch-4250-v3
Test build: https://github.com/tianocore/edk2/pull/3930
Bugzilla:   https://bugzilla.tianocore.org/show_bug.cgi?id=4250

v2 was posted at:
- http://mid.mail-archive.com/20230112082845.128463-1-lersek@redhat.com
- https://edk2.groups.io/g/devel/message/98336
- https://listman.redhat.com/archives/edk2-devel-archive/2023-January/057634.html

Please see the Notes sections of the patches, regarding the updates.

The "PlatformCI_OvmfPkg_Windows_VS2019_PR" checks in test build linked
above time out again (as expected); now with the following debug log:

> PlatformCpuCountBugCheck: Present=0 Possible=1
> PlatformCpuCountBugCheck: Broken CPU hotplug register block found. Update QEMU to version 8+, or
> PlatformCpuCountBugCheck: to a stable release with commit dab30fbef389 backported. Refer to
> PlatformCpuCountBugCheck: <https://bugzilla.tianocore.org/show_bug.cgi?id=4250>.
> PlatformCpuCountBugCheck: Consequences of the QEMU bug may include, but are not limited to:
> PlatformCpuCountBugCheck: - all firmware logic, dependent on the CPU hotplug register block,
> PlatformCpuCountBugCheck:   being confused, for example, multiprocessing-related logic;
> PlatformCpuCountBugCheck: - guest OS data loss, including filesystem corruption, due to crash or
> PlatformCpuCountBugCheck:   hang during ACPI S3 resume;
> PlatformCpuCountBugCheck: - SMM privilege escalation, by a malicious guest OS or 3rd partty UEFI
> PlatformCpuCountBugCheck:   agent, against the platform firmware.
> PlatformCpuCountBugCheck: These symptoms need not necessarily be limited to the QEMU user
> PlatformCpuCountBugCheck: attempting to hot(un)plug a CPU.
> PlatformCpuCountBugCheck: The firmware will now stop (hang) deliberately, in order to prevent the
> PlatformCpuCountBugCheck: above symptoms.
> PlatformCpuCountBugCheck: You can forcibly override the hang, *at your own risk*, with the
> PlatformCpuCountBugCheck: following *experimental* QEMU command line option:
> PlatformCpuCountBugCheck:   -fw_cfg name=opt/org.tianocore/X-Cpuhp-Bugcheck-Override,string=yes
> PlatformCpuCountBugCheck: Please only report such bugs that you can reproduce *without* the
> PlatformCpuCountBugCheck: override.
> Select Item: 0x19
> ASSERT d:\a\1\s\OvmfPkg\Library\PlatformInitLib\Platform.c(520): ((BOOLEAN)(0==1))

The "PlatformCI_OvmfPkg_Ubuntu_GCC5_PR" checks succed, probably due to
edk2 commits ef0916009843 ("CI: Use Fedora 35 container (Linux only)",
2023-01-17) and 7fab007f33e9 ("OvmfPkg: CI: Use Fedora 35 container
(Linux only)", 2023-01-17), and due to
<https://github.com/tianocore/containers/commit/47addc9a4f20> applying
the upstream QEMU patch.

Laszlo

Cc: Ard Biesheuvel <ardb+tianocore@kernel.org>
Cc: Brijesh Singh <brijesh.singh@amd.com>
Cc: Erdem Aktas <erdemaktas@google.com>
Cc: Gerd Hoffmann <kraxel@redhat.com>
Cc: James Bottomley <jejb@linux.ibm.com>
Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Jordan Justen <jordan.l.justen@intel.com>
Cc: Michael Brown <mcb30@ipxe.org>
Cc: Min Xu <min.m.xu@intel.com>
Cc: Oliver Steffen <osteffen@redhat.com>
Cc: Sebastien Boeuf <sebastien.boeuf@intel.com>
Cc: Tom Lendacky <thomas.lendacky@amd.com>

Laszlo Ersek (2):
  OvmfPkg/PlatformInitLib: factor out PlatformCpuCountBugCheck()
  OvmfPkg/PlatformInitLib: catch QEMU's CPU hotplug reg block regression

 OvmfPkg/Library/PlatformInitLib/Platform.c | 168 +++++++++++++++++---
 1 file changed, 145 insertions(+), 23 deletions(-)
~~~