### PR TITLE
ShellPkg: Export default shell delay as PCD

### DIFF
--- a/ShellPkg/Application/Shell/Shell.c
+++ b/ShellPkg/Application/Shell/Shell.c
@@ -990,7 +990,7 @@ ProcessCommandLine (
   ShellInfoObject.ShellInitSettings.BitUnion.Bits.Delay        = FALSE;
   ShellInfoObject.ShellInitSettings.BitUnion.Bits.Exit         = FALSE;
   ShellInfoObject.ShellInitSettings.BitUnion.Bits.NoNest       = FALSE;
-  ShellInfoObject.ShellInitSettings.Delay                      = 5;
+  ShellInfoObject.ShellInitSettings.Delay                      = PcdGet32 (PcdShellDefaultDelay);
 
   //
   // Start LoopVar at 0 to parse only optional arguments at Argv[0]

--- a/ShellPkg/Application/Shell/Shell.inf
+++ b/ShellPkg/Application/Shell/Shell.inf
@@ -103,3 +103,4 @@
   gEfiShellPkgTokenSpaceGuid.PcdShellForceConsole           ## CONSUMES
   gEfiShellPkgTokenSpaceGuid.PcdShellSupplier               ## CONSUMES
   gEfiShellPkgTokenSpaceGuid.PcdShellMaxHistoryCommandCount ## CONSUMES
+  gEfiShellPkgTokenSpaceGuid.PcdShellDefaultDelay           ## CONSUMES

--- a/ShellPkg/ShellPkg.dec
+++ b/ShellPkg/ShellPkg.dec
@@ -136,3 +136,7 @@
   # Up to this many bytes of vendor specific data will be used. Default is 0
   # (disabled).
   gEfiShellPkgTokenSpaceGuid.PcdShellVendorExtendedDecode|0|UINT32|0x00000013
+
+  ## Controls the default delay the shell will offer to the user at the
+  # start to check if the user wishes to cancel the script autostart
+  gEfiShellPkgTokenSpaceGuid.PcdShellDefaultDelay|5|UINT32|0x00000015


### PR DESCRIPTION
Create PcdShellDefaultDelay to configure the default delay the shell provides for the user at the start time if the user wishes to cancel the execution of a potential startup script.

The shell application already allows the user to override the delay default value by specifying the -delay cmdline argument. This however cannot be used when loading the shell application using direct boot or when integrating the shell into the platform firmware build.

Thus, a PCD can be easily configured by the developer either at build time, or even at runtime.

Cc: Ray Ni <ray.ni@intel.com>
Cc: Zhichao Gao <zhichao.gao@intel.com>
Signed-off-by: Tomas Pilar <tomas@quicinc.com>
Reviewed-by: Michael D Kinney <michael.d.kinney@intel.com>