### PR TITLE
MdeModulePkg: Fix typo of "event" in a comment in Core/Dxe/Event/Event.c

### DIFF
--- a/MdeModulePkg/Core/Dxe/Event/Event.c
+++ b/MdeModulePkg/Core/Dxe/Event/Event.c
@@ -606,7 +606,7 @@ CoreCheckEvent (
   }
 
   //
-  // If the even looks signalled, get the lock and clear it
+  // If the event looks signalled, get the lock and clear it
   //
 
   if (Event->SignalCount != 0) {


### PR DESCRIPTION
Signed-off-by: Rebecca Cran <rebecca@bsdio.com>