### PR TITLE
OvmfPkg: Support BrotliCustomDecompressLib in PEI

### DIFF
--- a/MdeModulePkg/Library/BrotliCustomDecompressLib/BrotliCustomDecompressLib.inf
+++ b/MdeModulePkg/Library/BrotliCustomDecompressLib/BrotliCustomDecompressLib.inf
@@ -58,6 +58,10 @@
   brotli/c/dec/huffman.h
   brotli/c/dec/state.h
   brotli/c/dec/prefix.h
+  brotli/c/common/context.c
+  brotli/c/common/platform.c
+  brotli/c/common/constants.c
+  brotli/c/common/shared_dictionary.c
 
 [Packages]
   MdePkg/MdePkg.dec

--- a/OvmfPkg/OvmfPkgIa32.dsc
+++ b/OvmfPkg/OvmfPkgIa32.dsc
@@ -707,7 +707,10 @@
     <LibraryClasses>
       PcdLib|MdePkg/Library/BasePcdLibNull/BasePcdLibNull.inf
   }
-  MdeModulePkg/Core/DxeIplPeim/DxeIpl.inf
+  MdeModulePkg/Core/DxeIplPeim/DxeIpl.inf {
+    <LibraryClasses>
+    NULL|MdeModulePkg\Library\BrotliCustomDecompressLib\BrotliCustomDecompressLib.inf
+  }
 
   OvmfPkg/PlatformPei/PlatformPei.inf
   UefiCpuPkg/Universal/Acpi/S3Resume2Pei/S3Resume2Pei.inf {

--- a/OvmfPkg/OvmfPkgX64.dsc
+++ b/OvmfPkg/OvmfPkgX64.dsc
@@ -743,7 +743,10 @@
     <LibraryClasses>
       PcdLib|MdePkg/Library/BasePcdLibNull/BasePcdLibNull.inf
   }
-  MdeModulePkg/Core/DxeIplPeim/DxeIpl.inf
+  MdeModulePkg/Core/DxeIplPeim/DxeIpl.inf {
+    <LibraryClasses>
+    NULL|MdeModulePkg\Library\BrotliCustomDecompressLib\BrotliCustomDecompressLib.inf
+  }
 
   OvmfPkg/PlatformPei/PlatformPei.inf
   UefiCpuPkg/Universal/Acpi/S3Resume2Pei/S3Resume2Pei.inf {


### PR DESCRIPTION
This patch is for test only.

Signed-off-by: Liming Gao <gaoliming@byosoft.com.cn>