### PR TITLE
MdeModulePkg/Bus/Ata/AhciPei: Fix DEADCODE Coverity issue

### DIFF
--- a/MdeModulePkg/Bus/Ata/AhciPei/AhciPeiS3.c
+++ b/MdeModulePkg/Bus/Ata/AhciPei/AhciPeiS3.c
@@ -66,10 +66,6 @@ AhciS3GetEumeratePorts (
     }
   }
 
-  if (S3InitDevices == NULL) {
-    return 0;
-  }
-
   //
   // Only enumerate the ports that exist in the device list.
   //


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4201

The code can reach line 69 only through the else path above at line 57. The else path already has the same NULL check at line 59 and hence the duplicate code lines are totally redundant which can be deleted.

Signed-off-by: Ranbir Singh <Ranbir.Singh3@Dell.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>