### PR TITLE
BaseTools: remove useless header inclusion

### DIFF
--- a/BaseTools/Source/C/GenFv/GenFvInternalLib.c
+++ b/BaseTools/Source/C/GenFv/GenFvInternalLib.c
@@ -14,11 +14,6 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 // Include files
 //
 
-#if defined(__FreeBSD__)
-#include <uuid.h>
-#elif defined(__GNUC__)
-#include <uuid/uuid.h>
-#endif
 #ifdef __GNUC__
 #include <sys/stat.h>
 #endif


### PR DESCRIPTION
GenFvInternalLib.c: useless inclusion and dependency on uuid.h.

From 6c0ba96fa11390750e102ebd277f59ef38970394 Mon Sep 17 00:00:00 2001
From: Thierry LARONDE <tlaronde@polynum.com>
Date: Thu, 26 Jan 2023 10:49:12 +0100
Subject: [PATCH] Remove useless uuid.h include.

Signed-off-by: Thierry LARONDE <tlaronde@polynum.com>