### PR TITLE
MdeModulePkg: Correct memory type in PrePiDxeCis.h

### DIFF
--- a/MdeModulePkg/Include/Pi/PrePiDxeCis.h
+++ b/MdeModulePkg/Include/Pi/PrePiDxeCis.h
@@ -20,6 +20,6 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 /// After this memory region is defined in PI spec, it should be a value in
 /// EFI_GCD_MEMORY_TYPE in PiDxeCis.h.
 ///
-#define  EFI_GCD_MEMORY_TYPE_UNACCEPTED  7
+#define  EFI_GCD_MEMORY_TYPE_UNACCEPTED  6
 
 #endif

--- a/MdePkg/Include/Pi/PiDxeCis.h
+++ b/MdePkg/Include/Pi/PiDxeCis.h
@@ -64,7 +64,7 @@ typedef enum {
   // /// EfiGcdMemoryTypeUnaccepted is defined in PrePiDxeCis.h because it has not been
   // /// defined in PI spec.
   // EfiGcdMemoryTypeUnaccepted,
-  EfiGcdMemoryTypeMaximum = 8
+  EfiGcdMemoryTypeMaximum = 7
 } EFI_GCD_MEMORY_TYPE;
 
 ///


### PR DESCRIPTION
The enumeration in MdePkg/Include/Pi/PiDxeCis.h has a duplicated entry, so the 8th position in the list doesn't count as index 7. The value EfiGcdMemoryTypeUnaccepted will have when added before EfiGcdMemoryTypeMaximum will be 6.

Signed-off-by: Dionna Glaze <dionnaglaze@google.com>
Reviewed-by: Min Xu <min.m.xu@intel.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>