### PR TITLE
UefiPayloadPkg: Set RTC dynamic PCD to PeiPCDdatabase

### DIFF
--- a/UefiPayloadPkg/PayloadLoaderPeim/PayloadLoaderPeim.inf
+++ b/UefiPayloadPkg/PayloadLoaderPeim/PayloadLoaderPeim.inf
@@ -37,6 +37,7 @@
 [Packages]
   MdePkg/MdePkg.dec
   MdeModulePkg/MdeModulePkg.dec
+  PcAtChipsetPkg/PcAtChipsetPkg.dec
   UefiPayloadPkg/UefiPayloadPkg.dec
 
 [LibraryClasses]
@@ -51,6 +52,10 @@
 
 [Ppis]
   gEfiPeiLoadFilePpiGuid                 ## PRODUCES
+
+[Pcd]
+  gPcAtChipsetPkgTokenSpaceGuid.PcdRtcIndexRegister
+  gPcAtChipsetPkgTokenSpaceGuid.PcdRtcTargetRegister
 
 [Guids]
   gUniversalPayloadExtraDataGuid         ## PRODUCES


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4193

In order to remove RTC_INDEX/RTC_TARGET from
the UplBuild macro list,change the RTC_INDEX
/RTC_TARGET type from PcdsFixedAtBuild to PcdsDynamicEx

Reviewed-by: Guo Dong <guo.dong@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Cc: James Lu <james.lu@intel.com>
Reviewed-by: Gua Guo <gua.guo@intel.com>
Signed-off-by: KasimX Liu <kasimx.liu@intel.com>