### PR TITLE
MdePkg: Fix UINT64 and INT64 word length for LoongArch64

### DIFF
--- a/MdePkg/Include/LoongArch64/ProcessorBind.h
+++ b/MdePkg/Include/LoongArch64/ProcessorBind.h
@@ -28,17 +28,17 @@
 // Assume standard LoongArch 64-bit alignment.
 // Need to check portability of long long
 //
-typedef unsigned long   UINT64;
-typedef long            INT64;
-typedef unsigned int    UINT32;
-typedef int             INT32;
-typedef unsigned short  UINT16;
-typedef unsigned short  CHAR16;
-typedef short           INT16;
-typedef unsigned char   BOOLEAN;
-typedef unsigned char   UINT8;
-typedef char            CHAR8;
-typedef char            INT8;
+typedef unsigned long long  UINT64;
+typedef long long           INT64;
+typedef unsigned int        UINT32;
+typedef int                 INT32;
+typedef unsigned short      UINT16;
+typedef unsigned short      CHAR16;
+typedef short               INT16;
+typedef unsigned char       BOOLEAN;
+typedef unsigned char       UINT8;
+typedef char                CHAR8;
+typedef char                INT8;
 
 //
 // Unsigned value of native width.  (4 bytes on supported 32-bit processor instructions,


### PR DESCRIPTION
The UINT64 and INT64 should be defined as unsigned long long and long long in the linux64 bit environment, but now defined as unsigned long and long, so fix it.

BZ: https://bugzilla.tianocore.org/show_bug.cgi?id=4330

Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Zhiguang Liu <zhiguang.liu@intel.com>
Signed-off-by: Chao Li <lichao@loongson.cn>
Reviewed-by: Michael D Kinney <michael.d.kinney@intel.com>