### PR TITLE
MdeModulePkg: ScsiBusDxe: Refactor DiscoverScsiDevice()

### DIFF
--- a/MdeModulePkg/Bus/Scsi/ScsiBusDxe/ScsiBus.h
+++ b/MdeModulePkg/Bus/Scsi/ScsiBusDxe/ScsiBus.h
@@ -455,7 +455,8 @@ ScsiExecuteSCSICommand (
 
   @retval EFI_SUCCESS           Successfully to discover the device and attach
                                 ScsiIoProtocol to it.
-  @retval EFI_OUT_OF_RESOURCES  Fail to discover the device.
+  @retval EFI_NOT_FOUND         Fail to discover the device.
+  @retval EFI_OUT_OF_RESOURCES  Fail to allocate memory resources.
 
 **/
 EFI_STATUS
@@ -473,11 +474,12 @@ ScsiScanCreateDevice (
 
   @param  ScsiIoDevice    The pointer of SCSI_IO_DEV
 
-  @retval  TRUE   Find SCSI Device and verify it.
-  @retval  FALSE  Unable to find SCSI Device.
+  @retval EFI_SUCCESS           Find SCSI Device and verify it.
+  @retval EFI_NOT_FOUND         Unable to find SCSI Device.
+  @retval EFI_OUT_OF_RESOURCES  Fail to allocate memory resources.
 
 **/
-BOOLEAN
+EFI_STATUS
 DiscoverScsiDevice (
   IN  OUT  SCSI_IO_DEV  *ScsiIoDevice
   );


### PR DESCRIPTION
Patch sent at: https://edk2.groups.io/g/devel/message/99340

Currently DiscoverScsiDevice() returns a boolean which cannot distinguish a "not found" situation from a real problem like memory allocation failures.

This patch changes the return value to an EFI_STATUS so that when memory allocation fails, it will return EFI_OUT_OF_RESOURCES.

Without this change, any FALSE returned by DiscoverScsiDevice() will result in EFI_OUT_OF_RESOURCES being returned by ScsiScanCreateDevice(), which will cause a while loop in SCSIBusDriverBindingStart() to abort before other possible Puns in the SCSI channel are scanned, which means good devices may not have a chance to be discovered.  If this good device is the boot device, boot will fail.

Cc: Ard Biesheuvel <ardb+tianocore@kernel.org>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Hao A Wu <hao.a.wu@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Cc: Sivaparvathi chellaiah <sivaparvathic@ami.com>

Signed-off-by: Yuan Yu <yuanyu@google.com>
Reviewed-by: Hao A Wu <hao.a.wu@intel.com>