### PR TITLE
SecurityPkg/TdTcg2Dxe: td-guest shall halt when CcMeasurement install…

### DIFF
--- a/SecurityPkg/Tcg/TdTcg2Dxe/TdTcg2Dxe.c
+++ b/SecurityPkg/Tcg/TdTcg2Dxe/TdTcg2Dxe.c
@@ -2510,6 +2510,12 @@ DriverEntry (
     //
     // Create event callback to install CC EventLog ACPI Table
     EfiCreateProtocolNotifyEvent (&gEfiAcpiTableProtocolGuid, TPL_CALLBACK, InstallAcpiTable, NULL, &Registration);
+  } else {
+    //
+    // Cc measurement feature is crucial to a td-guest and it shall stop running immediately
+    // when it is failed to be installed.
+    DEBUG ((DEBUG_ERROR, "%a: CcMeasurement protocol failed to be installed - %r\n", __FUNCTION__, Status));
+    CpuDeadLoop ();
   }
 
   return Status;


### PR DESCRIPTION
… fail

BZ: https://bugzilla.tianocore.org/show_bug.cgi?id=4335

CcMeasurement protocol is installed when it is supported in a td-guest. If the installation of the protocol failed, the guest shall go into CpuDeadLoop. Because the measurement feature is crucial to a td-guest and it shall stop running immediately at this situation.

Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Jian J Wang <jian.j.wang@intel.com>
Signed-off-by: Min Xu <min.m.xu@intel.com>