### PR TITLE
MdeModulePkg: ScsiDiskDxe: clean up comment in ScsiDisk.c

### DIFF
--- a/MdeModulePkg/Bus/Scsi/ScsiDiskDxe/ScsiDisk.c
+++ b/MdeModulePkg/Bus/Scsi/ScsiDiskDxe/ScsiDisk.c
@@ -3,10 +3,6 @@
 
 Copyright (c) 2006 - 2019, Intel Corporation. All rights reserved.<BR>
 Copyright (c) 1985 - 2022, American Megatrends International LLC.<BR>
-<<<<<<< HEAD
-=======
-
->>>>>>> ace365b4e0 (MdeModulePkg/scsi :Coverity scan flags multiple issues in edk2-stable202205)
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/


### PR DESCRIPTION
Patch sent at: https://edk2.groups.io/g/devel/message/99387

Comment of MdeModulePkg/Bus/Scsi/ScsiDiskDxe/ScsiDisk.c was polluted by some previous merge. This patch clean it up.

Cc: Ard Biesheuvel <ardb+tianocore@kernel.org>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Hao A Wu <hao.a.wu@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Cc: Sivaparvathi chellaiah <sivaparvathic@ami.com>

Signed-off-by: Yuan Yu <yuanyu@google.com>
Reviewed-by: Hao A Wu <hao.a.wu@intel.com>