### PR TITLE
UefiCpuPkg: Fix SMM code hangs when InitPaging

### DIFF
--- a/UefiCpuPkg/PiSmmCpuDxeSmm/SmmProfile.c
+++ b/UefiCpuPkg/PiSmmCpuDxeSmm/SmmProfile.c
@@ -1,7 +1,7 @@
 /** @file
 Enable SMM profile.
 
-Copyright (c) 2012 - 2019, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2012 - 2023, Intel Corporation. All rights reserved.<BR>
 Copyright (c) 2017 - 2020, AMD Incorporated. All rights reserved.<BR>
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -587,13 +587,18 @@ InitPaging (
     }
 
     SizeOfMemorySpace = HighBitSet64 (gPhyMask) + 1;
+    ASSERT (SizeOfMemorySpace <= 52);
+
     //
-    // Calculate the table entries of PML4E and PDPTE.
+    // Calculate the table entries of PML5E, PML4E and PDPTE.
     //
     NumberOfPml5Entries = 1;
     if (SizeOfMemorySpace > 48) {
-      NumberOfPml5Entries = (UINTN)LShiftU64 (1, SizeOfMemorySpace - 48);
-      SizeOfMemorySpace   = 48;
+      if (Enable5LevelPaging) {
+        NumberOfPml5Entries = (UINTN)LShiftU64 (1, SizeOfMemorySpace - 48);
+      }
+
+      SizeOfMemorySpace = 48;
     }
 
     NumberOfPml4Entries = 1;


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4246

In function InitPaging, NumberOfPml5Entries is calculated by below code NumberOfPml5Entries = (UINTN)LShiftU64 (1, SizeOfMemorySpace - 48); If the SizeOfMemorySpace is larger than 48, NumberOfPml5Entries will be larger than 1. However, this doesn't make sense if the hardware doesn't support 5 level page table.

Cc: Gerd Hoffmann <kraxel@redhat.com>
Cc: Rahul Kumar <rahul1.kumar@intel.com>
Reviewed-by: Star Zeng <star.zeng@intel.com>
Reviewed-by: Wu, Jiaxin <jiaxin.wu@intel.com>
Reviewed-by: Ray Ni <ray.ni@intel.com>
Acked-by: Gerd Hoffmann <kraxel@redhat.com>
Signed-off-by: Eric Dong <eric.dong@intel.com>
Signed-off-by: Zhiguang Liu <zhiguang.liu@intel.com>