### PR TITLE
MdePkg: Label CreateEvent NotifyFunction and NotifyContext optional

### DIFF
--- a/MdePkg/Include/Uefi/UefiSpec.h
+++ b/MdePkg/Include/Uefi/UefiSpec.h
@@ -465,8 +465,8 @@ EFI_STATUS
 (EFIAPI *EFI_CREATE_EVENT)(
   IN  UINT32                       Type,
   IN  EFI_TPL                      NotifyTpl,
-  IN  EFI_EVENT_NOTIFY             NotifyFunction,
-  IN  VOID                         *NotifyContext,
+  IN  EFI_EVENT_NOTIFY             NotifyFunction OPTIONAL,
+  IN  VOID                         *NotifyContext OPTIONAL,
   OUT EFI_EVENT                    *Event
   );
 


### PR DESCRIPTION
According to the UEFI 2.10 Specification, the EFI_BOOT_SERVICES_TABLE CreateEvent function has the following signature:

typedef
EFI_STATUS
(EFIAPI *EFI_CREATE_EVENT) (
  IN UINT32           Type,
  IN EFI_TPL          NotifyTpl,
  IN EFI_EVENT_NOTIFY NotifyFunction, OPTIONAL
  IN VOID             *NotifyContext, OPTIONAL
  OUT EFI_EVENT       *Event
);

Fix the prototype in UefiSpec.h to match, by labeling the NotifyFunction and NotifyContext parameters as OPTIONAL.

Signed-off-by: Rebecca Cran <rebecca@bsdio.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>