### PR TITLE
EmbeddedPkg/PrePiLib: Drop unused PCD PcdPrePiCpuIoSize

### DIFF
--- a/EmbeddedPkg/Library/PrePiLib/PrePiLib.inf
+++ b/EmbeddedPkg/Library/PrePiLib/PrePiLib.inf
@@ -58,8 +58,6 @@
 
 
 [FixedPcd.common]
-  gEmbeddedTokenSpaceGuid.PcdPrePiCpuIoSize
-
   gEmbeddedTokenSpaceGuid.PcdMemoryTypeEfiACPIReclaimMemory
   gEmbeddedTokenSpaceGuid.PcdMemoryTypeEfiACPIMemoryNVS
   gEmbeddedTokenSpaceGuid.PcdMemoryTypeEfiReservedMemoryType


### PR DESCRIPTION
The code never references the PCD so the INF should not reference it either. The last reference was moved to PrePiHobLib in commit 05e48e00834b32e4bd2 (dated 2011!) and dropped from there as well in commit 97106391955337155e7.

Cc: Leif Lindholm <quic_llindhol@quicinc.com>
Cc: Abner Chang <abner.chang@amd.com>
Cc: Daniel Schaefer <git@danielschaefer.me>
Reported-by: Sunil V L <sunilvl@ventanamicro.com>
Signed-off-by: Ard Biesheuvel <ardb@kernel.org>
Reviewed-by: Sunil V L <sunilvl@ventanamicro.com>