### PR TITLE
OvmfPkg/AcpiPlatformDxe: Measure ACPI table from QEMU in TDVF

### DIFF
--- a/OvmfPkg/AcpiPlatformDxe/AcpiPlatformDxe.inf
+++ b/OvmfPkg/AcpiPlatformDxe/AcpiPlatformDxe.inf
@@ -46,6 +46,7 @@
   UefiBootServicesTableLib
   UefiDriverEntryPoint
   HobLib
+  TpmMeasurementLib
 
 [Protocols]
   gEfiAcpiTableProtocolGuid                     # PROTOCOL ALWAYS_CONSUMED


### PR DESCRIPTION
https://bugzilla.tianocore.org/show_bug.cgi?id=4245

QEMU provides the following three files for guest to install the ACPI tables:
 - etc/acpi/rsdp
 - etc/acpi/tables
 - etc/table-loader

"etc/acpi/rsdp" and "etc/acpi/tables" are similar, they are only kept separate because they have different allocation requirements in SeaBIOS.

Both of these fw_cfg files contain preformatted ACPI payload. "etc/acpi/rsdp" contains only the RSDP table, while "etc/acpi/tables" contains all other tables, concatenated. To be noted, the tables in these two files have been filled in by qemu, but two kinds of fields are incomplete: pointers to other tables and checksums (which depend on the pointers).

"/etc/table-loader" is a linker/loader which provides the commands to "patch" the tables in "etc/acpi/tables" and then install them. "Patch" means to fill the pointers and compute the checksum.

From the security perspective these 3 files are the raw data downloaded from qemu. They should be measured and extended before they're consumed.

Cc: Erdem Aktas <erdemaktas@google.com>
Cc: James Bottomley <jejb@linux.ibm.com>
Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Gerd Hoffmann <kraxel@redhat.com>
Cc: Tom Lendacky <thomas.lendacky@amd.com>
Cc: Michael Roth <michael.roth@amd.com>
Signed-off-by: Min Xu <min.m.xu@intel.com>
Reviewed-by: Jiewen Yao <jiewen.yao@intel.com>
Acked-by: Gerd Hoffmann <kraxel@redhat.com>