### PR TITLE
RedfishPkg: RedfishRestExDxe: PCD introduced to disable chunked reguest

### DIFF
--- a/RedfishPkg/RedfishPkg.dec
+++ b/RedfishPkg/RedfishPkg.dec
@@ -17,6 +17,7 @@
   Include
 
 [Includes.Common.Private]
+  PrivateInclude                # Private header files for C RTL.
   PrivateInclude/Crt            # Private header files for C RTL.
   Library/JsonLib               # Private header files for jansson
                                 # configuration files.
@@ -97,3 +98,9 @@
   # protocol instance.
   #
   gEfiRedfishPkgTokenSpaceGuid.PcdRedfishDiscoverAccessModeInBand|FALSE|BOOLEAN|0x00001002
+  #
+  # This PCD indicates if the EFI REST EX sends chunk request to Redfish service.
+  # Default is set to non chunk mode.
+  #
+  gEfiRedfishPkgTokenSpaceGuid.PcdRedfishRestExChunkRequestMode|FALSE|BOOLEAN|0x00001003
+  

--- a/RedfishPkg/RedfishRestExDxe/RedfishRestExDxe.inf
+++ b/RedfishPkg/RedfishRestExDxe/RedfishRestExDxe.inf
@@ -57,6 +57,7 @@
 
 [Pcd]
   gEfiRedfishPkgTokenSpaceGuid.PcdRedfishRestExServiceAccessModeInBand   ## CONSUMES
+  gEfiRedfishPkgTokenSpaceGuid.PcdRedfishRestExChunkRequestMode   ## CONSUMES
 
 [UserExtensions.TianoCore."ExtraFiles"]
   RedfishRestExDxeExtra.uni


### PR DESCRIPTION
BIOS should be able to work with different BMC implementation. Some BMC does not support the chunked requests.
So, this feature should be optional.
Build time PCD was introduced to enable/disable chunked request.

Cc: Abner Chang <abner.chang@amd.com>
Cc: Nickle Wang <nickle.wang@hpe.com>
Signed-off-by: Igor Kulchytskyy <igork@ami.com>