### PR TITLE
ArmPkg/ArmScmiDxe: Fix the calculation of RequiredArraySize

### DIFF
--- a/ArmPkg/Drivers/ArmScmiDxe/ScmiClockProtocol.c
+++ b/ArmPkg/Drivers/ArmScmiDxe/ScmiClockProtocol.c
@@ -236,12 +236,7 @@ ClockDescribeRates (
       *TotalRates = NUM_RATES (DescribeRates->NumRatesFlags)
                     + NUM_REMAIN_RATES (DescribeRates->NumRatesFlags);
 
-      if (*Format == ScmiClockRateFormatDiscrete) {
-        RequiredArraySize = (*TotalRates) * sizeof (UINT64);
-      } else {
-        // We need to return triplet of 64 bit value for each rate
-        RequiredArraySize = (*TotalRates) * 3 * sizeof (UINT64);
-      }
+      RequiredArraySize = (*TotalRates) * sizeof (UINT64);
 
       if (RequiredArraySize > (*RateArraySize)) {
         *RateArraySize = RequiredArraySize;
@@ -259,23 +254,21 @@ ClockDescribeRates (
           ConvertTo64Bit (Rate->Low, Rate->High);
       }
     } else {
-      for (RateNo = 0; RateNo < NUM_RATES (DescribeRates->NumRatesFlags); RateNo++) {
-        // Linear clock rates from minimum to maximum in steps
-        // Minimum clock rate.
-        Rate                                    = &DescribeRates->Rates[RateOffset++];
-        RateArray[RateIndex].ContinuousRate.Min =
-          ConvertTo64Bit (Rate->Low, Rate->High);
+      // Linear clock rates from minimum to maximum in steps
+      // Minimum clock rate.
+      Rate                                    = &DescribeRates->Rates[RateOffset++];
+      RateArray[RateIndex].ContinuousRate.Min =
+        ConvertTo64Bit (Rate->Low, Rate->High);
 
-        Rate = &DescribeRates->Rates[RateOffset++];
-        // Maximum clock rate.
-        RateArray[RateIndex].ContinuousRate.Max =
-          ConvertTo64Bit (Rate->Low, Rate->High);
+      Rate = &DescribeRates->Rates[RateOffset++];
+      // Maximum clock rate.
+      RateArray[RateIndex].ContinuousRate.Max =
+        ConvertTo64Bit (Rate->Low, Rate->High);
 
-        Rate = &DescribeRates->Rates[RateOffset++];
-        // Step.
-        RateArray[RateIndex++].ContinuousRate.Step =
-          ConvertTo64Bit (Rate->Low, Rate->High);
-      }
+      Rate = &DescribeRates->Rates[RateOffset++];
+      // Step.
+      RateArray[RateIndex++].ContinuousRate.Step =
+        ConvertTo64Bit (Rate->Low, Rate->High);
     }
   } while (NUM_REMAIN_RATES (DescribeRates->NumRatesFlags) != 0);
 


### PR DESCRIPTION
As per the SCMI specification, section CLOCK_DESCRIBE_RATES mentions that the value of num_rates_flags[11:0] in the response must be 3 if the return format is the triplet. Due to the buggy firmware, this was not noticed for long time. The firmware is now fixed resulting in ClockDescribeRates() to fail with "Buffer Too Small" error as the RequiredArraySize gets miscalculated as 72 instead of 24.

Fix the issue by reusing the logic for both the return format which must work if num_rates_flags has correct value as expected from the specification.

Cc: Girish Pathak <girish.pathak@arm.com>
Cc: Jeff Brasen <jbrasen@nvidia.com>
Reviewed-by: Pierre Gondois <pierre.gondois@arm.com>
Tested-by: Pierre Gondois <pierre.gondois@arm.com>
Reported-by: Sami Mujawar <sami.mujawar@arm.com>
Signed-off-by: Sudeep Holla <sudeep.holla@arm.com>
Reviewed-by: Sami Mujawar <sami.mujawar@arm.com>
Tested-by: Sami Mujawar <sami.mujawar@arm.com>