### PR TITLE
BaseTools: remove useless dependency on libuuid

### DIFF
--- a/BaseTools/Source/C/GenFv/GNUmakefile
+++ b/BaseTools/Source/C/GenFv/GNUmakefile
@@ -14,10 +14,6 @@ include $(MAKEROOT)/Makefiles/app.makefile
 
 LIBS = -lCommon
 ifeq ($(CYGWIN), CYGWIN)
-  LIBS += -L/lib/e2fsprogs -luuid
-endif
-
-ifeq ($(LINUX), Linux)
-  LIBS += -luuid
+  LIBS += -L/lib/e2fsprogs
 endif
 

--- a/BaseTools/Source/C/GenFv/GenFvInternalLib.c
+++ b/BaseTools/Source/C/GenFv/GenFvInternalLib.c
@@ -14,11 +14,6 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 // Include files
 //
 
-#if defined(__FreeBSD__)
-#include <uuid.h>
-#elif defined(__GNUC__)
-#include <uuid/uuid.h>
-#endif
 #ifdef __GNUC__
 #include <sys/stat.h>
 #endif


### PR DESCRIPTION
Signed-off-by: Thierry LARONDE <tlaronde@polynum.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>