### PR TITLE
MdeModulePkg: Disambiguate the meaning of PcdDxeIplSwitchToLongMode

### DIFF
--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -927,10 +927,8 @@
 
 [PcdsFeatureFlag.IA32, PcdsFeatureFlag.X64]
   ## Indicates if DxeIpl should switch to long mode to enter DXE phase.
-  #  It is assumed that 64-bit DxeCore is built in firmware if it is true; otherwise 32-bit DxeCore
-  #  is built in firmware.<BR><BR>
   #   TRUE  - DxeIpl will load a 64-bit DxeCore and switch to long mode to hand over to DxeCore.<BR>
-  #   FALSE - DxeIpl will load a 32-bit DxeCore and perform stack switch to hand over to DxeCore.<BR>
+  #   FALSE - DxeIpl will load a 32-bit or 64-bit DxeCore and perform stack switch to hand over to DxeCore.<BR>
   # @Prompt DxeIpl switch to long mode.
   gEfiMdeModulePkgTokenSpaceGuid.PcdDxeIplSwitchToLongMode|TRUE|BOOLEAN|0x0001003b
 


### PR DESCRIPTION
Literally, the meaning of PcdDxeIplSwitchToLongMode is clear, indicating whether need switch to long mode when loading DxeCore. However, the comments in dec are confusing for the case where PEI core and DXE core are both in 64-bit. This patch makes it clear. PcdDxeIplSwitchToLongMode is true only when PEI core is 32-bit, and switch to long mode to load 64-bit DXE core. In other cases, this PCD is false. This also aligns with current usage in OvmfPkg.

Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Ray Ni <ray.ni@intel.com>
Signed-off-by: Zhiguang Liu <zhiguang.liu@intel.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>
Reviewed-by: Ray Ni <ray.ni@intel.com>