### PR TITLE
.pytool/Plugin/EccCheck: Add PACKAGES_PATH support

### DIFF
--- a/.pytool/Plugin/EccCheck/EccCheck.py
+++ b/.pytool/Plugin/EccCheck/EccCheck.py
@@ -69,6 +69,13 @@ class EccCheck(ICiBuildPlugin):
         env.set_shell_var('PACKAGES_PATH', os.pathsep.join(Edk2pathObj.PackagePathList))
         self.ECC_PASS = True
 
+        abs_pkg_path = Edk2pathObj.GetAbsolutePathOnThisSystemFromEdk2RelativePath(packagename)
+
+        if abs_pkg_path is None:
+            tc.SetSkipped()
+            tc.LogStdError("No Package folder {0}".format(abs_pkg_path))
+            return 0
+
         # Create temp directory
         temp_path = os.path.join(workspace_path, 'Build', '.pytool', 'Plugin', 'EccCheck')
         try:
@@ -77,7 +84,7 @@ class EccCheck(ICiBuildPlugin):
                 shutil.rmtree(temp_path)
             # Copy package being scanned to temp_path
             shutil.copytree (
-              os.path.join(workspace_path, packagename),
+              abs_pkg_path,
               os.path.join(temp_path, packagename),
               symlinks=True
               )


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4326

EccBuild currently assumes all packages reside in WORKSPACE. However, this is obviously not the case for many setups. Most notably, Ext4Pkg is located in edk2-platforms/Features and thus cannot be in WORKSPACE in any reasonable setup.

Use Edk2Path to locate the package in WORKSPACE and PACKAGES_PATH.

Cc: Sean Brogan <sean.brogan@microsoft.com>
Cc: Michael Kubacki <mikuback@linux.microsoft.com>
Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Pedro Falcato <pedro.falcato@gmail.com>
Signed-off-by: Marvin H?user <mhaeuser@posteo.de>
Acked-by: Pedro Falcato <pedro.falcato@gmail.com>
Reviewed-by: Michael Kubacki <michael.kubacki@microsoft.com>