### PR TITLE
EmulatorPkg/PeiTimerLib: Bug fix in NanoSecondDelay

### DIFF
--- a/EmulatorPkg/Include/Protocol/EmuThunk.h
+++ b/EmulatorPkg/Include/Protocol/EmuThunk.h
@@ -130,7 +130,7 @@ UINT64
 typedef
 VOID
 (EFIAPI *EMU_SLEEP)(
-  IN  UINT64    Milliseconds
+  IN  UINT64    Nanoseconds
   );
 
 typedef

--- a/EmulatorPkg/Library/PeiTimerLib/PeiTimerLib.c
+++ b/EmulatorPkg/Library/PeiTimerLib/PeiTimerLib.c
@@ -1,7 +1,7 @@
 /** @file
   A non-functional instance of the Timer Library.
 
-  Copyright (c) 2007 - 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2007 - 2023, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -65,7 +65,7 @@ NanoSecondDelay (
              );
   if (!EFI_ERROR (Status)) {
     Thunk = (EMU_THUNK_PROTOCOL *)ThunkPpi->Thunk ();
-    Thunk->Sleep (NanoSeconds * 100);
+    Thunk->Sleep (NanoSeconds);
     return NanoSeconds;
   }
 


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4339

Thunk->Sleep is expecting nanoseconds, no need to multiply by 100.

Cc: Andrew Fish <afish@apple.com>
Cc: Ray Ni <ray.ni@intel.com>
Signed-off-by: Deric Cole <deric.cole@intel.com>
Reviewed-by: Michael D Kinney <michael.d.kinney@intel.com>