### PR TITLE
RedfishPkg/RedfishRestExDxe: Two PCDs for controlling the requests

### DIFF
--- a/RedfishPkg/RedfishPkg.dec
+++ b/RedfishPkg/RedfishPkg.dec
@@ -3,6 +3,7 @@
 #
 # Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
 # (C) Copyright 2021 Hewlett Packard Enterprise Development LP<BR>
+# Copyright (c) 2023, American Megatrends International LLC.
 #
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 ##
@@ -97,3 +98,13 @@
   # protocol instance.
   #
   gEfiRedfishPkgTokenSpaceGuid.PcdRedfishDiscoverAccessModeInBand|FALSE|BOOLEAN|0x00001002
+  #
+  # This PCD indicates if the EFI REST EX sends chunk request to Redfish service.
+  # Default is set to non chunk mode.
+  #
+  gEfiRedfishPkgTokenSpaceGuid.PcdRedfishRestExChunkRequestMode|FALSE|BOOLEAN|0x00001003
+  #
+  # This PCD indicates if the EFI REST EX adds Expect header to the POST, PATCH, PUT requests to Redfish service.
+  # Default is set to not add.
+  #
+  gEfiRedfishPkgTokenSpaceGuid.PcdRedfishRestExAddingExpect|FALSE|BOOLEAN|0x00001004

--- a/RedfishPkg/RedfishRestExDxe/RedfishRestExDxe.inf
+++ b/RedfishPkg/RedfishRestExDxe/RedfishRestExDxe.inf
@@ -3,6 +3,7 @@
 #
 #  Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
 #  (C) Copyright 2020 Hewlett Packard Enterprise Development LP<BR>
+#  Copyright (c) 2023, American Megatrends International LLC.
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -56,7 +57,9 @@
   gEfiDevicePathProtocolGuid                      ## TO_START
 
 [Pcd]
-  gEfiRedfishPkgTokenSpaceGuid.PcdRedfishRestExServiceAccessModeInBand   ## CONSUMES
+  gEfiRedfishPkgTokenSpaceGuid.PcdRedfishRestExServiceAccessModeInBand ## CONSUMES
+  gEfiRedfishPkgTokenSpaceGuid.PcdRedfishRestExChunkRequestMode        ## CONSUMES
+  gEfiRedfishPkgTokenSpaceGuid.PcdRedfishRestExAddingExpect            ## CONSUMES
 
 [UserExtensions.TianoCore."ExtraFiles"]
   RedfishRestExDxeExtra.uni


### PR DESCRIPTION
Since BIOS should work with different BMC implementation chunked requests as well as Expect header should be optional.
 - One PCD is used to enable/disable Expect header.
 - Another PCD is used to enable/disable chunked requests.

Reviewed-by: Abner Chang <abner.chang@amd.com>
Cc: Abner Chang <abner.chang@amd.com>
Cc: Nickle Wang <nicklew@nvidia.com>
Signed-off-by: Igor Kulchytskyy <igork@ami.com>