### PR TITLE
MdeModulePkg/VariablePolicyLib: Remove status checking

### DIFF
--- a/MdeModulePkg/Library/VariablePolicyLib/VariablePolicyLib.c
+++ b/MdeModulePkg/Library/VariablePolicyLib/VariablePolicyLib.c
@@ -782,9 +782,7 @@ InitVariablePolicyLib (
     return EFI_ALREADY_STARTED;
   }
 
-  if (!EFI_ERROR (Status)) {
-    Status = VariablePolicyExtraInit ();
-  }
+  Status = VariablePolicyExtraInit ();
 
   if (!EFI_ERROR (Status)) {
     // Save an internal pointer to the GetVariableHelper.
@@ -841,9 +839,7 @@ DeinitVariablePolicyLib (
     return EFI_NOT_READY;
   }
 
-  if (!EFI_ERROR (Status)) {
-    Status = VariablePolicyExtraDeinit ();
-  }
+  Status = VariablePolicyExtraDeinit ();
 
   if (!EFI_ERROR (Status)) {
     mGetVariableHelper  = NULL;


### PR DESCRIPTION
Removing status checking as the status is always EFI_SUCCESS. No functional change.

Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Hao A Wu <hao.a.wu@intel.com>
Signed-off-by: Wenyi Xie <xiewenyi2@huawei.com>