### PR TITLE
openssl hash

### DIFF
--- a/CryptoPkg/Library/BaseCryptLib/Hash/CryptSha1.c
+++ b/CryptoPkg/Library/BaseCryptLib/Hash/CryptSha1.c
@@ -204,6 +204,8 @@ Sha1HashAll (
   OUT  UINT8       *HashValue
   )
 {
+  SHA_CTX  Context;
+
   //
   // Check input parameters.
   //
@@ -218,11 +220,19 @@ Sha1HashAll (
   //
   // OpenSSL SHA-1 Hash Computation.
   //
-  if (SHA1 (Data, DataSize, HashValue) == NULL) {
+  if (!SHA1_Init (&Context)) {
     return FALSE;
-  } else {
-    return TRUE;
   }
+
+  if (!SHA1_Update (&Context, Data, DataSize)) {
+    return FALSE;
+  }
+
+  if (!SHA1_Final (HashValue, &Context)) {
+    return FALSE;
+  }
+
+  return TRUE;
 }
 
 #endif

--- a/CryptoPkg/Library/BaseCryptLib/Hash/CryptSha256.c
+++ b/CryptoPkg/Library/BaseCryptLib/Hash/CryptSha256.c
@@ -202,6 +202,8 @@ Sha256HashAll (
   OUT  UINT8       *HashValue
   )
 {
+  SHA256_CTX  Context;
+
   //
   // Check input parameters.
   //
@@ -216,9 +218,17 @@ Sha256HashAll (
   //
   // OpenSSL SHA-256 Hash Computation.
   //
-  if (SHA256 (Data, DataSize, HashValue) == NULL) {
+  if (!SHA256_Init (&Context)) {
     return FALSE;
-  } else {
-    return TRUE;
   }
+
+  if (!SHA256_Update (&Context, Data, DataSize)) {
+    return FALSE;
+  }
+
+  if (!SHA256_Final (HashValue, &Context)) {
+    return FALSE;
+  }
+
+  return TRUE;
 }

--- a/CryptoPkg/Library/BaseCryptLib/Hash/CryptSha512.c
+++ b/CryptoPkg/Library/BaseCryptLib/Hash/CryptSha512.c
@@ -204,6 +204,8 @@ Sha384HashAll (
   OUT  UINT8       *HashValue
   )
 {
+  SHA512_CTX  Context;
+
   //
   // Check input parameters.
   //
@@ -218,11 +220,19 @@ Sha384HashAll (
   //
   // OpenSSL SHA-384 Hash Computation.
   //
-  if (SHA384 (Data, DataSize, HashValue) == NULL) {
+  if (!SHA384_Init (&Context)) {
     return FALSE;
-  } else {
-    return TRUE;
   }
+
+  if (!SHA384_Update (&Context, Data, DataSize)) {
+    return FALSE;
+  }
+
+  if (!SHA384_Final (HashValue, &Context)) {
+    return FALSE;
+  }
+
+  return TRUE;
 }
 
 /**

--- a/CryptoPkg/Library/BaseCryptLib/Hash/CryptSha512.c
+++ b/CryptoPkg/Library/BaseCryptLib/Hash/CryptSha512.c
@@ -430,6 +430,8 @@ Sha512HashAll (
   OUT  UINT8       *HashValue
   )
 {
+  SHA512_CTX  Context;
+
   //
   // Check input parameters.
   //
@@ -444,9 +446,17 @@ Sha512HashAll (
   //
   // OpenSSL SHA-512 Hash Computation.
   //
-  if (SHA512 (Data, DataSize, HashValue) == NULL) {
+  if (!SHA512_Init (&Context)) {
     return FALSE;
-  } else {
-    return TRUE;
   }
+
+  if (!SHA512_Update (&Context, Data, DataSize)) {
+    return FALSE;
+  }
+
+  if (!SHA512_Final (HashValue, &Context)) {
+    return FALSE;
+  }
+
+  return TRUE;
 }


### PR DESCRIPTION
- CryptoPkg/BaseCryptLib: avoid using SHA1()
- CryptoPkg/BaseCryptLib: avoid using SHA256()
- CryptoPkg/BaseCryptLib: avoid using SHA384()
- CryptoPkg/BaseCryptLib: avoid using SHA512()
