### PR TITLE
.mergify/config.yml: Remove rebase_fallback attribute (deprecated)

### DIFF
--- a/.mergify/config.yml
+++ b/.mergify/config.yml
@@ -38,7 +38,6 @@ pull_request_rules:
     actions:
       queue:
         method: rebase
-        rebase_fallback: none
         name: default
 
   - name: Post a comment on a PR that can not be merged due to a merge conflict


### PR DESCRIPTION
PR builds and CI are currently broken due to a mergify brownout
today because edk2 uses the `rebase_fallback` attribute of the
`queue` action.

Message from Mergify/Summary:

```
  The configuration uses the deprecated rebase_fallback attribute
  of the queue action.

  A brownout is planned on February 13th, 2023.

  This option will be removed on March 13th, 2023.
  For more information: https://docs.mergify.com/actions/queue/
```

Therefore, this change removes the attribute per the guidance in
the following changelog message to retain existing behavior.

https://changelog.mergify.com/changelog/rebasefallback-is-deprecated

```
  The option rebase_fallback is now deprecated and should not be
  used anymore.

  Mergify will always report errors in the future if a rebase merge
  is impossible.
```

Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Sean Brogan <sean.brogan@microsoft.com>
Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>
