### PR TITLE
MdeModulePkg/Pci: Display more information of PCIe devices

### DIFF
--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciEnumeratorSupport.c
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciEnumeratorSupport.c
@@ -3,6 +3,7 @@
 
 Copyright (c) 2006 - 2021, Intel Corporation. All rights reserved.<BR>
 (C) Copyright 2015 Hewlett Packard Enterprise Development LP<BR>
+Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -227,13 +228,15 @@ PciSearchDevice (
 
   DEBUG ((
     DEBUG_INFO,
-    "PciBus: Discovered %s @ [%02x|%02x|%02x]\n",
+    "PciBus: Discovered %s @ [%02x|%02x|%02x]  [VID = 0x%x, DID = 0x%0x]\n",
     IS_PCI_BRIDGE (Pci) ?     L"PPB" :
     IS_CARDBUS_BRIDGE (Pci) ? L"P2C" :
     L"PCI",
     Bus,
     Device,
-    Func
+    Func,
+    Pci->Hdr.VendorId,
+    Pci->Hdr.DeviceId
     ));
 
   if (!IS_PCI_BRIDGE (Pci)) {


### PR DESCRIPTION
In V4: Update the copyright to 2023.
In V3: Add AMD copyright.
In V2: Remove the signed-off-by: Abner Chang

Display PCIe Vendor ID and Device ID in DEBUG message.


Cc: Hao A Wu <hao.a.wu@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Cc: Garrett Kirkendall <garrett.kirkendall@amd.com>
Cc: Abner Chang <abner.chang@amd.com>
Reviewed-by: Ray Ni <ray.ni@intel.com>
Acked-by: Michael D Kinney <michael.d.kinney@intel.com>