### PR TITLE
MdeModulePkg/Variable: Attribute combination should return EFI_UNSUPP…

### DIFF
--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/Variable.c
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/Variable.c
@@ -2676,7 +2676,11 @@ VariableServiceSetVariable (
     //
     // Only EFI_VARIABLE_NON_VOLATILE attribute is invalid
     //
-    return EFI_INVALID_PARAMETER;
+    if ((Attributes & EFI_VARIABLE_AUTHENTICATED_WRITE_ACCESS) != 0) {
+      return EFI_UNSUPPORTED;
+    } else {
+      return EFI_INVALID_PARAMETER;
+    }
   } else if ((Attributes & VARIABLE_ATTRIBUTE_AT_AW) != 0) {
     if (!mVariableModuleGlobal->VariableGlobal.AuthSupport) {
       //


### PR DESCRIPTION
…ORTED

REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4341

Commit 21320ef66989 broke some tests in the AuthVar_Conf test in edk2-test.  There are 2 testcases that invoke SetVariable with the following attribute value:

(EFI_VARIABLE_NON_VOLATILE | EFI_VARIABLE_AUTHENTICATED_WRITE_ACCESS)

EFI_VARIABLE_AUTHENTICATED_WRITE_ACCESS is deprecated and the UEFI spec says this should return EFI_UNSUPPORTED.

Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Hao A Wu <hao.a.wu@intel.com>
Cc: Sunny Wang <Sunny.Wang@arm.com>


Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>
Reviewed-by: Sunny Wang <sunny.wang@arm.com>