### PR TITLE
OvmfPkg/RiscVVirt: Fix SCT memory allocation test case failure

### DIFF
--- a/OvmfPkg/RiscVVirt/Sec/SecMain.c
+++ b/OvmfPkg/RiscVVirt/Sec/SecMain.c
@@ -71,8 +71,9 @@ SecStartup (
   FirmwareContext.FlattenedDeviceTree = (UINT64)DeviceTreeAddress;
   SetFirmwareContextPointer (&FirmwareContext);
 
-  StackBase      = (UINT64)FixedPcdGet32 (PcdOvmfSecPeiTempRamBase);
-  UefiMemoryBase = StackBase +  FixedPcdGet32 (PcdOvmfSecPeiTempRamSize) - SIZE_32MB;
+  StackBase = (UINT64)FixedPcdGet32 (PcdOvmfSecPeiTempRamBase) +
+              FixedPcdGet32 (PcdOvmfSecPeiTempRamSize);
+  UefiMemoryBase = StackBase - SIZE_32MB;
 
   // Declare the PI/UEFI memory region
   HobList = HobConstructor (


### PR DESCRIPTION
Fix the UEFI memory range calculation by including the correct stack memory range. Without this fix, SCT hangs in MemoryAllocation test cases which call AllocateAddress().

Cc: Ard Biesheuvel <ardb+tianocore@kernel.org>
Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Jordan Justen <jordan.l.justen@intel.com>
Cc: Gerd Hoffmann <kraxel@redhat.com>
Cc: Andrei Warkentin <andrei.warkentin@intel.com>
Reported-by: Heinrich Schuchardt <heinrich.schuchardt@canonical.com>

Reviewed-by: Andrei Warkentin <andrei.warkentin@intel.com>