### PR TITLE
MdePkg: BuildMemoryAllocationHob is not checking it's Length paramete…

### DIFF
--- a/MdePkg/Library/PeiHobLib/HobLib.c
+++ b/MdePkg/Library/PeiHobLib/HobLib.c
@@ -846,7 +846,8 @@ BuildMemoryAllocationHob (
 {
   EFI_HOB_MEMORY_ALLOCATION  *Hob;
 
-  ASSERT (
+  ASSERT(Length != 0);
+  ASSERT(
     ((BaseAddress & (EFI_PAGE_SIZE - 1)) == 0) &&
     ((Length & (EFI_PAGE_SIZE - 1)) == 0)
     );


### PR DESCRIPTION
MdePkg: BuildMemoryAllocationHob is not checking it's Length parameter for bad / zero input

REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4351

function: BuildMemoryAllocationHob
Need to add ASSERT that prevent user to call this function with parameter: Length == 0