### PR TITLE
OvmfPkg/RiscVVirt: Add Stack HOB

### DIFF
--- a/OvmfPkg/RiscVVirt/Sec/SecMain.c
+++ b/OvmfPkg/RiscVVirt/Sec/SecMain.c
@@ -55,6 +55,7 @@ SecStartup (
   EFI_STATUS                  Status;
   UINT64                      UefiMemoryBase;
   UINT64                      StackBase;
+  UINT32                      StackSize;
 
   //
   // Report Status Code to indicate entering SEC core
@@ -71,9 +72,9 @@ SecStartup (
   FirmwareContext.FlattenedDeviceTree = (UINT64)DeviceTreeAddress;
   SetFirmwareContextPointer (&FirmwareContext);
 
-  StackBase = (UINT64)FixedPcdGet32 (PcdOvmfSecPeiTempRamBase) +
-              FixedPcdGet32 (PcdOvmfSecPeiTempRamSize);
-  UefiMemoryBase = StackBase - SIZE_32MB;
+  StackBase      = (UINT64)FixedPcdGet32 (PcdOvmfSecPeiTempRamBase);
+  StackSize      = FixedPcdGet32 (PcdOvmfSecPeiTempRamSize);
+  UefiMemoryBase = StackBase + StackSize - SIZE_32MB;
 
   // Declare the PI/UEFI memory region
   HobList = HobConstructor (
@@ -85,6 +86,8 @@ SecStartup (
   PrePeiSetHobList (HobList);
 
   SecInitializePlatform ();
+
+  BuildStackHob (StackBase, StackSize);
 
   //
   // Process all libraries constructor function linked to SecMain.


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4350

Currently, stack HOB is not created for the stack memory. This causes stack memory to be treated as free memory and any memory allocation which happens at this address causes random memory corruption. Fix this by creating the stack HOB which marks the memory as BS data.

Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Andrei Warkentin <andrei.warkentin@intel.com>
Cc: Ard Biesheuvel <ardb+tianocore@kernel.org>
Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Jordan Justen <jordan.l.justen@intel.com>
Cc: Gerd Hoffmann <kraxel@redhat.com>

Reported-by: Andrei Warkentin <andrei.warkentin@intel.com>
Tested-by: Andrei Warkentin <andrei.warkentin@intel.com>
Reviewed-by: Andrei Warkentin <andrei.warkentin@intel.com>