### PR TITLE
MdeModulePkg: Improve formatting of DEBUG messages in UsbBusDxe

### DIFF
--- a/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbBus.c
+++ b/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbBus.c
@@ -838,7 +838,7 @@ UsbIoPortReset (
   if (EFI_ERROR (Status)) {
     DEBUG ((
       DEBUG_ERROR,
-      "UsbIoPortReset: failed to reset hub port %d@hub  %d, %r \n",
+      "UsbIoPortReset: failed to reset hub port %d@hub  %d - %r\n",
       Dev->ParentPort,
       Dev->ParentAddr,
       Status
@@ -945,7 +945,7 @@ UsbBusBuildProtocol (
                   );
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "UsbBusStart: Failed to open device path %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "UsbBusStart: Failed to open device path - %r\n", Status));
 
     FreePool (UsbBus);
     return Status;
@@ -978,7 +978,7 @@ UsbBusBuildProtocol (
                    );
 
   if (EFI_ERROR (Status) && EFI_ERROR (Status2)) {
-    DEBUG ((DEBUG_ERROR, "UsbBusStart: Failed to open USB_HC/USB2_HC %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "UsbBusStart: Failed to open USB_HC/USB2_HC - %r\n", Status));
 
     Status = EFI_DEVICE_ERROR;
     goto CLOSE_HC;
@@ -1006,7 +1006,7 @@ UsbBusBuildProtocol (
                   );
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "UsbBusStart: Failed to install bus protocol %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "UsbBusStart: Failed to install bus protocol - %r\n", Status));
     goto CLOSE_HC;
   }
 
@@ -1054,7 +1054,7 @@ UsbBusBuildProtocol (
   Status = mUsbRootHubApi.Init (RootIf);
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "UsbBusStart: Failed to init root hub %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "UsbBusStart: Failed to init root hub - %r\n", Status));
     goto FREE_ROOTHUB;
   }
 
@@ -1102,7 +1102,7 @@ CLOSE_HC:
          );
   FreePool (UsbBus);
 
-  DEBUG ((DEBUG_ERROR, "UsbBusStart: Failed to start bus driver %r\n", Status));
+  DEBUG ((DEBUG_ERROR, "UsbBusStart: Failed to start bus driver - %r\n", Status));
   return Status;
 }
 

--- a/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbDesc.c
+++ b/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbDesc.c
@@ -761,7 +761,7 @@ UsbGetOneConfig (
   if (EFI_ERROR (Status)) {
     DEBUG ((
       DEBUG_ERROR,
-      "UsbGetOneConfig: failed to get descript length(%d) %r\n",
+      "UsbGetOneConfig: failed to get descript length(%d) - %r\n",
       Desc.TotalLength,
       Status
       ));
@@ -787,7 +787,7 @@ UsbGetOneConfig (
   Status = UsbCtrlGetDesc (UsbDev, USB_DESC_TYPE_CONFIG, Index, 0, Buf, Desc.TotalLength);
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "UsbGetOneConfig: failed to get full descript %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "UsbGetOneConfig: failed to get full descript - %r\n", Status));
 
     FreePool (Buf);
     return NULL;
@@ -891,7 +891,7 @@ UsbBuildDescTable (
   Status = UsbBuildLangTable (UsbDev);
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_INFO, "UsbBuildDescTable: get language ID table %r\n", Status));
+    DEBUG ((DEBUG_INFO, "UsbBuildDescTable: get language ID table - %r\n", Status));
   }
 
   return EFI_SUCCESS;

--- a/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbEnumer.c
+++ b/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbEnumer.c
@@ -440,7 +440,7 @@ UsbSelectConfig (
     if (EFI_ERROR (Status)) {
       DEBUG ((
         DEBUG_WARN,
-        "UsbSelectConfig: failed to connect driver %r, ignored\n",
+        "UsbSelectConfig: failed to connect driver - %r, ignored\n",
         Status
         ));
     }

--- a/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbHub.c
+++ b/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbHub.c
@@ -609,7 +609,7 @@ UsbHubInit (
   Status  = UsbHubReadDesc (HubDev, HubDesc);
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "UsbHubInit: failed to read HUB descriptor %r\n", Status));
+    DEBUG ((DEBUG_ERROR, "UsbHubInit: failed to read HUB descriptor - %r\n", Status));
     return Status;
   }
 


### PR DESCRIPTION
Patch sent at: https://edk2.groups.io/g/devel/message/100475

Improve the formatting of DEBUG messages in UsbBusDxe by adding a hyphen to separate the EFI_STATUS code.

Reviewed-by: Hao A Wu <hao.a.wu@intel.com>