### PR TITLE
CryptoPkg/BaseCryptLib: avoid certain openssl library calls

### DIFF
--- a/CryptoPkg/Library/BaseCryptLib/Hash/CryptSha1.c
+++ b/CryptoPkg/Library/BaseCryptLib/Hash/CryptSha1.c
@@ -204,6 +204,8 @@ Sha1HashAll (
   OUT  UINT8       *HashValue
   )
 {
+  SHA_CTX  Context;
+
   //
   // Check input parameters.
   //
@@ -218,11 +220,19 @@ Sha1HashAll (
   //
   // OpenSSL SHA-1 Hash Computation.
   //
-  if (SHA1 (Data, DataSize, HashValue) == NULL) {
+  if (!SHA1_Init (&Context)) {
     return FALSE;
-  } else {
-    return TRUE;
   }
+
+  if (!SHA1_Update (&Context, Data, DataSize)) {
+    return FALSE;
+  }
+
+  if (!SHA1_Final (HashValue, &Context)) {
+    return FALSE;
+  }
+
+  return TRUE;
 }
 
 #endif

--- a/CryptoPkg/Library/BaseCryptLib/Hash/CryptSha256.c
+++ b/CryptoPkg/Library/BaseCryptLib/Hash/CryptSha256.c
@@ -202,6 +202,8 @@ Sha256HashAll (
   OUT  UINT8       *HashValue
   )
 {
+  SHA256_CTX  Context;
+
   //
   // Check input parameters.
   //
@@ -216,9 +218,17 @@ Sha256HashAll (
   //
   // OpenSSL SHA-256 Hash Computation.
   //
-  if (SHA256 (Data, DataSize, HashValue) == NULL) {
+  if (!SHA256_Init (&Context)) {
     return FALSE;
-  } else {
-    return TRUE;
   }
+
+  if (!SHA256_Update (&Context, Data, DataSize)) {
+    return FALSE;
+  }
+
+  if (!SHA256_Final (HashValue, &Context)) {
+    return FALSE;
+  }
+
+  return TRUE;
 }

--- a/CryptoPkg/Library/BaseCryptLib/Hash/CryptSha512.c
+++ b/CryptoPkg/Library/BaseCryptLib/Hash/CryptSha512.c
@@ -204,6 +204,8 @@ Sha384HashAll (
   OUT  UINT8       *HashValue
   )
 {
+  SHA512_CTX  Context;
+
   //
   // Check input parameters.
   //
@@ -218,11 +220,19 @@ Sha384HashAll (
   //
   // OpenSSL SHA-384 Hash Computation.
   //
-  if (SHA384 (Data, DataSize, HashValue) == NULL) {
+  if (!SHA384_Init (&Context)) {
     return FALSE;
-  } else {
-    return TRUE;
   }
+
+  if (!SHA384_Update (&Context, Data, DataSize)) {
+    return FALSE;
+  }
+
+  if (!SHA384_Final (HashValue, &Context)) {
+    return FALSE;
+  }
+
+  return TRUE;
 }
 
 /**

--- a/CryptoPkg/Library/BaseCryptLib/Hash/CryptSha512.c
+++ b/CryptoPkg/Library/BaseCryptLib/Hash/CryptSha512.c
@@ -430,6 +430,8 @@ Sha512HashAll (
   OUT  UINT8       *HashValue
   )
 {
+  SHA512_CTX  Context;
+
   //
   // Check input parameters.
   //
@@ -444,9 +446,17 @@ Sha512HashAll (
   //
   // OpenSSL SHA-512 Hash Computation.
   //
-  if (SHA512 (Data, DataSize, HashValue) == NULL) {
+  if (!SHA512_Init (&Context)) {
     return FALSE;
-  } else {
-    return TRUE;
   }
+
+  if (!SHA512_Update (&Context, Data, DataSize)) {
+    return FALSE;
+  }
+
+  if (!SHA512_Final (HashValue, &Context)) {
+    return FALSE;
+  }
+
+  return TRUE;
 }


### PR DESCRIPTION

In preparation for the openssl 3.0 switch ...

openssl 3.0 sneak preview (WIP still, does not yet pass CI) is at
https://github.com/kraxel/edk2/commits/openssl3

Gerd Hoffmann (4):
  CryptoPkg/BaseCryptLib: avoid using SHA1()
  CryptoPkg/BaseCryptLib: avoid using SHA256()
  CryptoPkg/BaseCryptLib: avoid using SHA384()
  CryptoPkg/BaseCryptLib: avoid using SHA512()

 .../Library/BaseCryptLib/Hash/CryptSha1.c     | 16 ++++++++--
 .../Library/BaseCryptLib/Hash/CryptSha256.c   | 16 ++++++++--
 .../Library/BaseCryptLib/Hash/CryptSha512.c   | 32 +++++++++++++++----
 3 files changed, 52 insertions(+), 12 deletions(-)

-- 
2.39.1



-=-=-=-=-=-=-=-=-=-=-=-
Groups.io Links: You receive all messages sent to this group.
View/Reply Online (#100123): https://edk2.groups.io/g/devel/message/100123
Mute This Topic: https://groups.io/mt/96943599/1772286
Group Owner: devel+owner@edk2.groups.io
Unsubscribe: https://edk2.groups.io/g/devel/unsub [jiewen.yao@intel.com]
-=-=-=-=-=-=-=-=-=-=-=-
