### PR TITLE
UefiCpuPkg: Calculate DisplayFamily correctly

### DIFF
--- a/UefiCpuPkg/Application/Cpuid/Cpuid.c
+++ b/UefiCpuPkg/Application/Cpuid/Cpuid.c
@@ -1,7 +1,7 @@
 /** @file
   UEFI Application to display CPUID leaf information.
 
-  Copyright (c) 2016 - 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2016 - 2023, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -217,12 +217,12 @@ CpuidVersionInfo (
 
   DisplayFamily = Eax.Bits.FamilyId;
   if (Eax.Bits.FamilyId == 0x0F) {
-    DisplayFamily |= (Eax.Bits.ExtendedFamilyId << 4);
+    DisplayFamily += Eax.Bits.ExtendedFamilyId;
   }
 
   DisplayModel = Eax.Bits.Model;
   if ((Eax.Bits.FamilyId == 0x06) || (Eax.Bits.FamilyId == 0x0f)) {
-    DisplayModel |= (Eax.Bits.ExtendedModelId << 4);
+    DisplayModel += (Eax.Bits.ExtendedModelId << 4);
   }
 
   Print (L"  Family = %x  Model = %x  Stepping = %x\n", DisplayFamily, DisplayModel, Eax.Bits.SteppingId);

--- a/UefiCpuPkg/Library/RegisterCpuFeaturesLib/CpuFeaturesInitialize.c
+++ b/UefiCpuPkg/Library/RegisterCpuFeaturesLib/CpuFeaturesInitialize.c
@@ -1,7 +1,7 @@
 /** @file
   CPU Features Initialize functions.
 
-  Copyright (c) 2017 - 2021, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017 - 2023, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -67,12 +67,12 @@ FillProcessorInfo (
 
   DisplayedFamily = Eax.Bits.FamilyId;
   if (Eax.Bits.FamilyId == 0x0F) {
-    DisplayedFamily |= (Eax.Bits.ExtendedFamilyId << 4);
+    DisplayedFamily += Eax.Bits.ExtendedFamilyId;
   }
 
   DisplayedModel = Eax.Bits.Model;
   if ((Eax.Bits.FamilyId == 0x06) || (Eax.Bits.FamilyId == 0x0f)) {
-    DisplayedModel |= (Eax.Bits.ExtendedModelId << 4);
+    DisplayedModel += (Eax.Bits.ExtendedModelId << 4);
   }
 
   CpuInfo->DisplayFamily              = DisplayedFamily;


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4348

Per SDM:
DisplayFamily = Extended_Family_ID + Family_ID.
DisplayModelID = (Extended_Model_ID << 4) + Family_ID. Correct the related code.

Cc: Eric Dong <eric.dong@intel.com>
Reviewed-by: Ray Ni <ray.ni@intel.com>
Cc: Rahul Kumar <rahul1.kumar@intel.com>
Acked-by: Gerd Hoffmann <kraxel@redhat.com>
Reviewed-by: Star Zeng <star.zeng@intel.com>
Cc: Mike Maslenkin <mike.maslenkin@gmail.com>