### PR TITLE
[TEST] CI: Use Fedora-37 (gcc12) image for Linux jobs

### DIFF
--- a/.azurepipelines/templates/defaults.yml
+++ b/.azurepipelines/templates/defaults.yml
@@ -9,4 +9,4 @@
 
 variables:
   default_python_version: ">=3.10.6"
-  default_linux_image: "ghcr.io/tianocore/containers/fedora-35-test:47addc9"
+  default_linux_image: "ghcr.io/tianocore/containers/fedora-37-test:3b3eb8f"


### PR DESCRIPTION
Switch to the new Fedora-37 CI docker image, and with it to gcc12, for Linux jobs.