### PR TITLE
Upl remove arch spec initialization

### DIFF
--- a/UefiPayloadPkg/UefiPayloadEntry/Ia32/DxeLoadFunc.c
+++ b/UefiPayloadPkg/UefiPayloadEntry/Ia32/DxeLoadFunc.c
@@ -268,6 +268,9 @@ HandOffToDxeCore (
   UINT32                   Index;
   X64_IDT_TABLE            *IdtTableForX64;
 
+  // Initialize floating point operating environment to be compliant with UEFI spec.
+  InitializeFloatingPointUnits ();
+
   //
   // Mask off all legacy 8259 interrupt sources
   //

--- a/UefiPayloadPkg/UefiPayloadEntry/Ia32/DxeLoadFunc.c
+++ b/UefiPayloadPkg/UefiPayloadEntry/Ia32/DxeLoadFunc.c
@@ -269,6 +269,12 @@ HandOffToDxeCore (
   X64_IDT_TABLE            *IdtTableForX64;
 
   //
+  // Mask off all legacy 8259 interrupt sources
+  //
+  IoWrite8 (LEGACY_8259_MASK_REGISTER_MASTER, 0xFF);
+  IoWrite8 (LEGACY_8259_MASK_REGISTER_SLAVE, 0xFF);
+
+  //
   // Clear page 0 and mark it as allocated if NULL pointer detection is enabled.
   //
   if (IsNullDetectionEnabled ()) {

--- a/UefiPayloadPkg/UefiPayloadEntry/UniversalPayloadEntry.c
+++ b/UefiPayloadPkg/UefiPayloadEntry/UniversalPayloadEntry.c
@@ -481,12 +481,6 @@ _ModuleEntryPoint (
   Status = UniversalLoadDxeCore (DxeFv, &DxeCoreEntryPoint);
   ASSERT_EFI_ERROR (Status);
 
-  //
-  // Mask off all legacy 8259 interrupt sources
-  //
-  IoWrite8 (LEGACY_8259_MASK_REGISTER_MASTER, 0xFF);
-  IoWrite8 (LEGACY_8259_MASK_REGISTER_SLAVE, 0xFF);
-
   Hob.HandoffInformationTable = (EFI_HOB_HANDOFF_INFO_TABLE *)GetFirstHob (EFI_HOB_TYPE_HANDOFF);
   HandOffToDxeCore (DxeCoreEntryPoint, Hob);
 

--- a/UefiPayloadPkg/UefiPayloadEntry/UniversalPayloadEntry.c
+++ b/UefiPayloadPkg/UefiPayloadEntry/UniversalPayloadEntry.c
@@ -470,9 +470,6 @@ _ModuleEntryPoint (
     PrintHob (mHobList);
     );
 
-  // Initialize floating point operating environment to be compliant with UEFI spec.
-  InitializeFloatingPointUnits ();
-
   // Build HOB based on information from Bootloader
   Status = BuildHobs (BootloaderParameter, &DxeFv);
   ASSERT_EFI_ERROR (Status);


### PR DESCRIPTION
Looking at adding support for Risc-V for UPL. In the process I realised there are several initialisation sequences which need not be part of common UPL entry flow. The flow should be agnostic to both BL and Arch with required hooks provided along the boot path. This patch set addresses 2 such instances related to 8259 interrupt and FP programming. To be on a safer side for now just moving this init to arch folders.