### PR TITLE
IntelFsp2Pkg: Fix GCC Compiler warning.

### DIFF
--- a/IntelFsp2Pkg/Library/BaseFspPlatformLib/FspPlatformNotify.c
+++ b/IntelFsp2Pkg/Library/BaseFspPlatformLib/FspPlatformNotify.c
@@ -296,6 +296,7 @@ FspTempRamExitDone2 (
 
 **/
 VOID
+EFIAPI
 FspWaitForNotify (
   VOID
   )


### PR DESCRIPTION
Function definition should match with declaration. [-Wlto-type-mismatch]

Cc: Chasel Chiu <chasel.chiu@intel.com>
Cc: Nate DeSimone <nathaniel.l.desimone@intel.com>
Cc: Sai Chaganty <rangasai.v.chaganty@intel.com>
Cc: Star Zeng <star.zeng@intel.com>

Reviewed-by: Chasel Chiu <chasel.chiu@intel.com>
Reviewed-by: Nate DeSimone <nathaniel.l.desimone@intel.com>
Reviewed-by: Sai Chaganty <rangasai.v.chaganty@intel.com>
Reviewed-by: Star Zeng <star.zeng@intel.com>