### PR TITLE
MdeModulePkg/BmBoot: Skip removable media if it is not present

### DIFF
--- a/MdeModulePkg/Library/UefiBootManagerLib/BmBoot.c
+++ b/MdeModulePkg/Library/UefiBootManagerLib/BmBoot.c
@@ -2218,6 +2218,15 @@ BmEnumerateBootOptions (
         continue;
       }
 
+      //
+      // Skip removable media if not present
+      //
+      if ((BlkIo->Media->RemovableMedia == TRUE) &&
+          (BlkIo->Media->MediaPresent == FALSE))
+      {
+        continue;
+      }
+
       Description = BmGetBootDescription (Handles[Index]);
       BootOptions = ReallocatePool (
                       sizeof (EFI_BOOT_MANAGER_LOAD_OPTION) * (*BootOptionCount),


### PR DESCRIPTION
Only enumerate devices that have media present.

Cc: Hao A Wu <hao.a.wu@intel.com>
Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Zhichao Gao <zhichao.gao@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Reviewed-by: Sean Rhodes <sean@starlabs.systems>

Reviewed-by: Ray Ni <ray.ni@intel.com>