### PR TITLE
UefiCpuPkg/MicrocodeMeasurementDxe: Fix exception

### DIFF
--- a/UefiCpuPkg/MicrocodeMeasurementDxe/MicrocodeMeasurementDxe.c
+++ b/UefiCpuPkg/MicrocodeMeasurementDxe/MicrocodeMeasurementDxe.c
@@ -238,7 +238,7 @@ MeasureMicrocodePatches (
        TotalMicrocodeSize)
       );
   } else {
-    DEBUG ((DEBUG_ERROR, "ERROR: TpmMeasureAndLogData failed with status %a!\n", Status));
+    DEBUG ((DEBUG_ERROR, "ERROR: TpmMeasureAndLogData failed with status %r!\n", Status));
   }
 
   FreePool (Offsets);


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4360

An incorrect format specifier is being used in a DEBUG print, specifically, a variable of type EFI_STATUS was being printed with the %a format specifier (pointer to an ASCII string), thus the value of the Status variable was being treated as the address of a string, leading to a CPU exception, when encountered this bug manifests itself as a hang near "Ready to Boot Event", with the last DEBUG print being "INFO: Got MicrocodePatchHob with microcode patches starting address" followed by a CPU Exception dump.


Reviewed-by: Jacob Narey <jacob.narey@intel.com>
Reviewed-by: Michael D Kinney <michael.d.kinney@intel.com>
Reviewed-by: Eric Dong <eric.dong@intel.com>