### PR TITLE
UefiCpuPkg/PiSmmCpuDxeSmm: Fix S3 failure in SmmRestoreCpu

### DIFF
--- a/UefiCpuPkg/PiSmmCpuDxeSmm/CpuS3.c
+++ b/UefiCpuPkg/PiSmmCpuDxeSmm/CpuS3.c
@@ -823,19 +823,7 @@ SmmRestoreCpu (
     InitializeCpuBeforeRebase ();
   }
 
-  //
-  // Make sure the gSmmBaseHobGuid existence status is the same between normal and S3 boot.
-  //
-  ASSERT (mSmmRelocated == (BOOLEAN)(GetFirstGuidHob (&gSmmBaseHobGuid) != NULL));
-  if (mSmmRelocated != (BOOLEAN)(GetFirstGuidHob (&gSmmBaseHobGuid) != NULL)) {
-    DEBUG ((
-      DEBUG_ERROR,
-      "gSmmBaseHobGuid %a produced in normal boot but %a in S3 boot!",
-      mSmmRelocated ? "is" : "is not",
-      mSmmRelocated ? "is not" : "is"
-      ));
-    CpuDeadLoop ();
-  }
+  DEBUG ((DEBUG_INFO, "SmmRestoreCpu: mSmmRelocated is %d\n", mSmmRelocated));
 
   //
   // Check whether Smm Relocation is done or not.


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4368

This issue is caused by the commit:
ec07fd0e35d90dbcc36be300a9ceeac29c5de2ad

GetFirstGuidHob() should not be used after exit boot service.

Cc: Eric Dong <eric.dong@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Cc: Zeng Star <star.zeng@intel.com>
Cc: Laszlo Ersek <lersek@redhat.com>
Cc: Gerd Hoffmann <kraxel@redhat.com>

Reviewed-by: Star Zeng <star.zeng@intel.com>
Reviewed-by: Gerd Hoffmann <kraxel@redhat.com>
Tested-by: Gerd Hoffmann <kraxel@redhat.com>
Reviewed-by: Ray Ni <ray.ni@intel.com>