### PR TITLE
UefiCpuPkg: To solve the issue that the top address is not mapped in

### DIFF
--- a/UefiCpuPkg/Library/MpInitLib/X64/MpFuncs.nasm
+++ b/UefiCpuPkg/Library/MpInitLib/X64/MpFuncs.nasm
@@ -315,6 +315,7 @@ MwaitCheckGeneric:
 MwaitLoopGeneric:
     cli
     mov        rax, rsp           ; Set Monitor Address
+    sub        eax, 8             ; To ensure the monitor address is in the page table
     xor        ecx, ecx           ; ecx = 0
     xor        edx, edx           ; edx = 0
     monitor


### PR DESCRIPTION
page table.

For the case CPU logic index is 0, RSP points to the very top of all AP stacks. That address is not mapped in page table.

Cc: Guo Dong <guo.dong@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Cc: Sean Rhodes <sean@starlabs.systems>
Cc: James Lu <james.lu@intel.com>
Cc: Gua Guo <gua.guo@intel.com>