### PR TITLE
OvmfPkg/PlatformBootManagerLib: use utf8 for the serial console.

### DIFF
--- a/OvmfPkg/Library/PlatformBootManagerLib/BdsPlatform.h
+++ b/OvmfPkg/Library/PlatformBootManagerLib/BdsPlatform.h
@@ -126,7 +126,7 @@ extern VENDOR_DEVICE_PATH        gTerminalTypeDeviceNode;
     1 \
   }
 
-#define gPcAnsiTerminal \
+#define gVtUtf8Terminal \
   { \
     { \
       MESSAGING_DEVICE_PATH, \
@@ -136,7 +136,7 @@ extern VENDOR_DEVICE_PATH        gTerminalTypeDeviceNode;
         (UINT8) ((sizeof (VENDOR_DEVICE_PATH)) >> 8) \
       } \
     }, \
-    DEVICE_PATH_MESSAGING_PC_ANSI \
+    DEVICE_PATH_MESSAGING_VT_UTF8 \
   }
 
 #define gEndEntire \

--- a/OvmfPkg/Library/PlatformBootManagerLib/PlatformData.c
+++ b/OvmfPkg/Library/PlatformBootManagerLib/PlatformData.c
@@ -47,7 +47,7 @@ typedef struct {
 ACPI_HID_DEVICE_PATH  gPnpPs2KeyboardDeviceNode  = gPnpPs2Keyboard;
 ACPI_HID_DEVICE_PATH  gPnp16550ComPortDeviceNode = gPnp16550ComPort;
 UART_DEVICE_PATH      gUartDeviceNode            = gUart;
-VENDOR_DEVICE_PATH    gTerminalTypeDeviceNode    = gPcAnsiTerminal;
+VENDOR_DEVICE_PATH    gTerminalTypeDeviceNode    = gVtUtf8Terminal;
 
 //
 // Platform specific keyboard device path
@@ -83,7 +83,7 @@ VENDOR_UART_DEVICE_PATH  gDebugAgentUartDevicePath = {
     0,  // Parity   - Default
     0,  // StopBits - Default
   },
-  gPcAnsiTerminal,
+  gVtUtf8Terminal,
   gEndEntire
 };
 
@@ -168,7 +168,7 @@ STATIC VENDOR_UART_DEVICE_PATH  gXenConsoleDevicePath = {
     FixedPcdGet8 (PcdUartDefaultParity),
     FixedPcdGet8 (PcdUartDefaultStopBits),
   },
-  gPcAnsiTerminal,
+  gVtUtf8Terminal,
   gEndEntire
 };
 


### PR DESCRIPTION
Time to leave behind relics from the last century and arrive in the modern world.  Drop PC-ANSI Terminal Type for the serial console, use UTF-8 instead.