### PR TITLE
UefiPayloadPkg: Add gUefiAcpiBoardInfoGuid support

### DIFF
--- a/UefiPayloadPkg/UefiPayloadEntry/UniversalPayloadEntry.c
+++ b/UefiPayloadPkg/UefiPayloadEntry/UniversalPayloadEntry.c
@@ -422,9 +422,12 @@ BuildHobs (
   //
   GuidHob = GetFirstGuidHob (&gUniversalPayloadAcpiTableGuid);
   if (GuidHob != NULL) {
-    AcpiTable     = (UNIVERSAL_PAYLOAD_ACPI_TABLE *)GET_GUID_HOB_DATA (GuidHob);
-    AcpiBoardInfo = BuildHobFromAcpi ((UINT64)AcpiTable->Rsdp);
-    ASSERT (AcpiBoardInfo != NULL);
+    AcpiTable = (UNIVERSAL_PAYLOAD_ACPI_TABLE *)GET_GUID_HOB_DATA (GuidHob);
+    GuidHob   = GetFirstGuidHob (&gUefiAcpiBoardInfoGuid);
+    if (GuidHob == NULL) {
+      AcpiBoardInfo = BuildHobFromAcpi ((UINT64)AcpiTable->Rsdp);
+      ASSERT (AcpiBoardInfo != NULL);
+    }
   }
 
   //


### PR DESCRIPTION
if system both exist gUefiAcpiBoardInfoGuid and rsdp, we may need to use gUefiAcpiBoardInfoGuid as final config to have backward support.

Cc: Guo Dong <guo.dong@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Cc: Sean Rhodes <sean@starlabs.systems>
Reviewed-by: James Lu <james.lu@intel.com>