### PR TITLE
[Draft] MdePkg: Remove Itanium leftover data structure

### DIFF
--- a/MdePkg/Include/Ppi/SecPlatformInformation.h
+++ b/MdePkg/Include/Ppi/SecPlatformInformation.h
@@ -84,57 +84,16 @@ typedef union {
 
 typedef EFI_HEALTH_FLAGS X64_HANDOFF_STATUS;
 typedef EFI_HEALTH_FLAGS IA32_HANDOFF_STATUS;
-///
-/// The hand-off status structure for Itanium architecture.
-///
-typedef struct {
-  ///
-  /// SALE_ENTRY state : 3 = Recovery_Check
-  /// and 0 = RESET or Normal_Boot phase.
-  ///
-  UINT8     BootPhase;
-  ///
-  /// Firmware status on entry to SALE.
-  ///
-  UINT8     FWStatus;
-  UINT16    Reserved1;
-  UINT32    Reserved2;
-  ///
-  /// Geographically significant unique processor ID assigned by PAL.
-  ///
-  UINT16    ProcId;
-  UINT16    Reserved3;
-  UINT8     IdMask;
-  UINT8     EidMask;
-  UINT16    Reserved4;
-  ///
-  /// Address to make PAL calls.
-  ///
-  UINT64    PalCallAddress;
-  ///
-  /// If the entry state is RECOVERY_CHECK, this contains the PAL_RESET
-  /// return address, and if entry state is RESET, this contains
-  /// address for PAL_authentication call.
-  ///
-  UINT64    PalSpecialAddress;
-  ///
-  /// GR35 from PALE_EXIT state.
-  ///
-  UINT64    SelfTestStatus;
-  ///
-  /// GR37 from PALE_EXIT state.
-  ///
-  UINT64    SelfTestControl;
-  UINT64    MemoryBufferRequired;
-} ITANIUM_HANDOFF_STATUS;
 
 ///
 /// EFI_SEC_PLATFORM_INFORMATION_RECORD.
+/// ItaniumHealthFlags has been removed from this union due to Itanium support
+/// being deprecated. The union has now diverged from the definition
+/// in the PI Specification.
 ///
 typedef union {
   IA32_HANDOFF_STATUS       IA32HealthFlags;
   X64_HANDOFF_STATUS        x64HealthFlags;
-  ITANIUM_HANDOFF_STATUS    ItaniumHealthFlags;
 } EFI_SEC_PLATFORM_INFORMATION_RECORD;
 
 /**


### PR DESCRIPTION
Itanium support has been removed from EDK2 aroun 2019. ITANIUM_HANDOFF_STATUS data structure looks to be
some leftover from that process.

There is also positive sidefect of this data structure removal. Due to HOB allocation type used in PEI stage there is a limit how much data about virtual CPU can be hold. This limit result in only 1024 vCPU can be used by VM.
With Itanium related data structure removed more allocated space can be used for vCPU data and with current allocation limit will change from 1024 to around 8k vCPUs.

Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Zhiguang Liu <zhiguang.liu@intel.com>

Bugzilla: https://bugzilla.tianocore.org/show_bug.cgi?id=1560
GitHub: https://github.com/tianocore/edk2/commit/4e1daa60f5372c22a11503961061ffa569eaf873