### PR TITLE
BaseTools/Scripts/PatchCheck.py: Check for *.makefile

### DIFF
--- a/BaseTools/Scripts/PatchCheck.py
+++ b/BaseTools/Scripts/PatchCheck.py
@@ -383,7 +383,8 @@ class GitDiffCheck:
                     self.force_crlf = False
                     self.force_notabs = False
                 if os.path.basename(self.filename) == 'GNUmakefile' or \
-                   os.path.basename(self.filename) == 'Makefile':
+                   os.path.basename(self.filename).lower() == 'makefile' or \
+                   os.path.splitext(self.filename)[1] == ".makefile":
                     self.force_notabs = False
             elif len(line.rstrip()) != 0:
                 self.format_error("didn't find diff command")


### PR DESCRIPTION
When checking for Makefiles, in addition to Makefile and GNUmakefile, also check for *.makefile: this allows {header,footer,app,lib}.makefile in BaseTools/Source/C/Makefiles to be detected and avoid having PatchCheck.py complain about tab characters.