### PR TITLE
PcAtChipsetPkg: Add PCD for RTC default year

### DIFF
--- a/PcAtChipsetPkg/PcAtChipsetPkg.dec
+++ b/PcAtChipsetPkg/PcAtChipsetPkg.dec
@@ -76,6 +76,12 @@
   # @Expression 0x80000001 | gPcAtChipsetPkgTokenSpaceGuid.PcdMaximalValidYear < gPcAtChipsetPkgTokenSpaceGuid.PcdMinimalValidYear + 100
   gPcAtChipsetPkgTokenSpaceGuid.PcdMaximalValidYear|2097|UINT16|0x0000000E
 
+  ## This PCD specifies the RTC default year when the RTC is in an invalid state.
+  # @Prompt Default year in RTC.
+  # @Expression 0x80000001 | gPcAtChipsetPkgTokenSpaceGuid.PcdRtcDefaultYear >= gPcAtChipsetPkgTokenSpaceGuid.PcdMinimalValidYear
+  # @Expression 0x80000001 | gPcAtChipsetPkgTokenSpaceGuid.PcdRtcDefaultYear <= gPcAtChipsetPkgTokenSpaceGuid.PcdMaximalValidYear
+  gPcAtChipsetPkgTokenSpaceGuid.PcdRtcDefaultYear|gPcAtChipsetPkgTokenSpaceGuid.PcdMinimalValidYear|UINT16|0x0000000F
+
   ## Specifies RTC Index Register address in MMIO space.
   # @Prompt RTC Index Register address
   gPcAtChipsetPkgTokenSpaceGuid.PcdRtcIndexRegister64|0x0|UINT64|0x00000022

--- a/PcAtChipsetPkg/PcAtChipsetPkg.uni
+++ b/PcAtChipsetPkg/PcAtChipsetPkg.uni
@@ -79,6 +79,10 @@
 
 #string STR_gPcAtChipsetPkgTokenSpaceGuid_PcdMaximalValidYear_HELP    #language en-US "This PCD specifies the maximal valid year in RTC."
 
+#string STR_gPcAtChipsetPkgTokenSpaceGuid_PcdRtcDefaultYear_PROMPT  #language en-US "Default year in RTC"
+
+#string STR_gPcAtChipsetPkgTokenSpaceGuid_PcdRtcDefaultYear_HELP    #language en-US "This PCD specifies the RTC default year when the RTC is in an invalid state."
+
 #string STR_gPcAtChipsetPkgTokenSpaceGuid_PcdAcpiIoPortBaseAddressMask_PROMPT   #language en-US  "ACPI IO Port Base Address Mask"
 
 #string STR_gPcAtChipsetPkgTokenSpaceGuid_PcdAcpiIoPortBaseAddressMask_HELP     #language en-US  "Defines the bit mask to retrieve ACPI IO Port Base Address."

--- a/PcAtChipsetPkg/PcatRealTimeClockRuntimeDxe/PcRtc.c
+++ b/PcAtChipsetPkg/PcatRealTimeClockRuntimeDxe/PcRtc.c
@@ -317,7 +317,7 @@ PcRtcInit (
     Time.Hour       = RTC_INIT_HOUR;
     Time.Day        = RTC_INIT_DAY;
     Time.Month      = RTC_INIT_MONTH;
-    Time.Year       = PcdGet16 (PcdMinimalValidYear);
+    Time.Year       = PcdGet16 (PcdRtcDefaultYear);
     Time.Nanosecond = 0;
     Time.TimeZone   = EFI_UNSPECIFIED_TIMEZONE;
     Time.Daylight   = 0;
@@ -357,7 +357,7 @@ PcRtcInit (
   Time.Hour       = RTC_INIT_HOUR;
   Time.Day        = RTC_INIT_DAY;
   Time.Month      = RTC_INIT_MONTH;
-  Time.Year       = PcdGet16 (PcdMinimalValidYear);
+  Time.Year       = PcdGet16 (PcdRtcDefaultYear);
   Time.Nanosecond = 0;
   Time.TimeZone   = Global->SavedTimeZone;
   Time.Daylight   = Global->Daylight;

--- a/PcAtChipsetPkg/PcatRealTimeClockRuntimeDxe/PcatRealTimeClockRuntimeDxe.inf
+++ b/PcAtChipsetPkg/PcatRealTimeClockRuntimeDxe/PcatRealTimeClockRuntimeDxe.inf
@@ -76,6 +76,7 @@
   gPcAtChipsetPkgTokenSpaceGuid.PcdRealTimeClockUpdateTimeout   ## CONSUMES
   gPcAtChipsetPkgTokenSpaceGuid.PcdMinimalValidYear             ## CONSUMES
   gPcAtChipsetPkgTokenSpaceGuid.PcdMaximalValidYear             ## CONSUMES
+  gPcAtChipsetPkgTokenSpaceGuid.PcdRtcDefaultYear               ## CONSUMES
   gPcAtChipsetPkgTokenSpaceGuid.PcdRtcIndexRegister             ## CONSUMES
   gPcAtChipsetPkgTokenSpaceGuid.PcdRtcTargetRegister            ## CONSUMES
   gPcAtChipsetPkgTokenSpaceGuid.PcdRtcIndexRegister64           ## CONSUMES


### PR DESCRIPTION
Add PcdRtcDefaultYear to specify the default year to use when the RTC is in an invalid state. 
Make sure PcdRtcDefaultYear is >= PcdMinimalValidYear and <= PcdMaximalValidYear.  Set the
default value for this PCD to PcdMinimalValidYear to preserve the existing behavior. 
A platform DSC file can override this default value setting.

Cc: Ray Ni <ray.ni@intel.com>
 Signed-off-by: Michael D Kinney <michael.d.kinney@intel.com>