### PR TITLE
MdePkg/Include: Add IPMI KCS definitions

### DIFF
--- a/MdePkg/Include/IndustryStandard/IpmiKcs.h
+++ b/MdePkg/Include/IndustryStandard/IpmiKcs.h
@@ -1,0 +1,76 @@
+/** @file
+  IPMI KCS Register Definitions
+
+  Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+  @par Revision Reference:
+  IPMI Specification
+  Version 2.0, Rev. 1.1
+  https://www.intel.com/content/www/us/en/products/docs/servers/ipmi/ipmi-second-gen-interface-spec-v2-rev1-1.html
+**/
+
+#ifndef IPMI_KCS_H_
+#define IPMI_KCS_H_
+
+#define IPMI_KCS_STATUS_REGISTER_OFFSET    1
+#define IPMI_KCS_COMMAND_REGISTER_OFFSET   1
+#define IPMI_KCS_DATA_OUT_REGISTER_OFFSET  0
+#define IPMI_KCS_DATA_IN_REGISTER_OFFSET   0
+
+///
+/// IPMI KCS Interface Status Bits
+///
+#define IPMI_KCS_OBF           BIT0
+#define IPMI_KCS_IBF           BIT1
+#define IPMI_KCS_SMS_ATN       BIT2
+#define IPMI_KCS_COMMAND_DATA  BIT3
+#define IPMI_KCS_OEM1          BIT4
+#define IPMI_KCS_OEM2          BIT5
+#define IPMI_KCS_S0            BIT6
+#define IPMI_KCS_S1            BIT7
+
+///
+/// IPMI KCS Interface Control Codes
+///
+#define IPMI_KCS_CONTROL_CODE_GET_STATUS_ABORT  0x60
+#define IPMI_KCS_CONTROL_CODE_WRITE_START       0x61
+#define IPMI_KCS_CONTROL_CODE_WRITE_END         0x62
+#define IPMI_KCS_CONTROL_CODE_READ              0x68
+
+///
+/// Status Codes
+///
+#define IPMI_KCS_STATUS_NO_ERROR      0x00
+#define IPMI_KCS_STATUS_ABORT         0x01
+#define IPMI_KCS_STATUS_ILLEGAL       0x02
+#define IPMI_KCS_STATUS_LENGTH_ERROR  0x06
+#define IPMI_KCS_STATUS_UNSPECIFIED   0xFF
+
+///
+/// KCS Interface State Bit
+///
+typedef enum {
+  IpmiKcsIdleState = 0,
+  IpmiKcsReadState,
+  IpmiKcsWriteState,
+  IpmiKcsErrorState
+} IPMI_KCS_STATE;
+
+///
+/// IPMI KCS Interface Request Format
+///
+typedef struct {
+  UINT8    NetFunc;
+  UINT8    Command;
+  UINT8    Data[];
+} IPMI_KCS_REQUEST_HEADER;
+
+///
+/// IPMI KCS Interface Response Format
+///
+typedef struct {
+  UINT8    NetFunc;
+  UINT8    Command;
+} IPMI_KCS_RESPONSE_HEADER;
+#endif

--- a/MdePkg/MdePkg.dec
+++ b/MdePkg/MdePkg.dec
@@ -9,6 +9,7 @@
 # (C) Copyright 2016 - 2021 Hewlett Packard Enterprise Development LP<BR>
 # Copyright (c) 2022, Loongson Technology Corporation Limited. All rights reserved.<BR>
 # Copyright (c) 2021 - 2022, Arm Limited. All rights reserved.<BR>
+# Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.<BR>
 #
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -2341,6 +2342,11 @@
   #  The required memory space is decided by the value of PcdMaximumGuidedExtractHandler.
   # @Prompt Memory Address of GuidedExtractHandler Table.
   gEfiMdePkgTokenSpaceGuid.PcdGuidedExtractHandlerTableAddress|0x1000000|UINT64|0x30001015
+
+  ## This value is the IPMI KCS Interface I/O base address used to transmit IPMI commands.
+  #  The value of 0xca2 is the default I/O base address defined in IPMI specification.
+  # @Prompt IPMI KCS Interface I/O Base Address
+  gEfiMdePkgTokenSpaceGuid.PcdIpmiKcsIoBaseAddress|0xca2|UINT16|0x00000031
 
 [PcdsFixedAtBuild, PcdsPatchableInModule, PcdsDynamic, PcdsDynamicEx]
   ## This value is used to set the base address of PCI express hierarchy.


### PR DESCRIPTION
BZ #4354
This change adds definitions for IPMI KCS.

Spec ref:
https://www.intel.com/content/www/us/en/products/docs/servers/ipmi/ipmi-second-gen-interface-spec-v2-rev1-1.html


Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Zhiguang Liu <zhiguang.liu@intel.com>
Cc: Nickle Wang <nicklew@nvidia.com>
Cc: Igor Kulchytskyy <igork@ami.com>
Cc: Isaac Oram <isaac.w.oram@intel.com>
Cc: Abdul Lateef Attar <AbdulLateef.Attar@amd.com>
Acked-by: Isaac Oram <isaac.w.oram@intel.com>
Reviewed-by: Michael D Kinney <michael.d.kinney@intel.com>
Reviewed-by: Tinh Nguyen <tinhnguyen@os.amperecomputing.com>