### PR TITLE
ArmVirtPkg: can't find gUefiOvmfPkgTokenSpaceGuid

### DIFF
--- a/ArmVirtPkg/CloudHvPlatformHasAcpiDtDxe/CloudHvHasAcpiDtDxe.inf
+++ b/ArmVirtPkg/CloudHvPlatformHasAcpiDtDxe/CloudHvHasAcpiDtDxe.inf
@@ -23,6 +23,7 @@
   EmbeddedPkg/EmbeddedPkg.dec
   MdeModulePkg/MdeModulePkg.dec
   MdePkg/MdePkg.dec
+  OvmfPkg/OvmfPkg.dec
 
 [LibraryClasses]
   BaseLib


### PR DESCRIPTION
commit f13264b34 introduces a bug for CloudHv as OvmfPkg/OvmfPkg.dec is missing in CloudHvHasAcpiDtDxe.inf which leads to
gUefiOvmfPkgTokenSpaceGuid found nowhere when build.

Reviewed-by: Ard Biesheuvel <ardb@kernel.org>
Reviewed-by: Sunil V L <sunilvl@ventanamicro.com>
Reviewed-by: Sami Mujawar <sami.mujawar@arm.com>