### PR TITLE
MdeModulePkg/Ahci: Skip retry for non-transient errors

### DIFF
--- a/MdeModulePkg/Bus/Ata/AtaAtapiPassThru/AhciMode.h
+++ b/MdeModulePkg/Bus/Ata/AtaAtapiPassThru/AhciMode.h
@@ -146,7 +146,8 @@ typedef union {
 #define   EFI_AHCI_PORT_TFD_BSY           BIT7
 #define   EFI_AHCI_PORT_TFD_DRQ           BIT3
 #define   EFI_AHCI_PORT_TFD_ERR           BIT0
-#define   EFI_AHCI_PORT_TFD_ERR_MASK      0x00FF00
+#define   EFI_AHCI_PORT_TFD_ERR_MASK      0x00FF00 // ERROR field is specified by ATA/ATAPI Command Set specification
+#define   EFI_AHCI_PORT_TFD_ERR_INT_CRC   BIT15
 #define EFI_AHCI_PORT_SIG                 0x0024
 #define EFI_AHCI_PORT_SSTS                0x0028
 #define   EFI_AHCI_PORT_SSTS_DET_MASK     0x000F


### PR DESCRIPTION
Patch sent at: https://edk2.groups.io/g/devel/message/101980
Cover-letter (contains general patch description and test information) is at: https://edk2.groups.io/g/devel/message/101979

bugzilla: https://bugzilla.tianocore.org/show_bug.cgi?id=4011

Currently AHCI driver will try to retry all failed packets regardless of the failure cause. This is a problem in password unlock flow where number of password retries is tracked by the device. If user passes a wrong password Ahci driver will try to send the wrong password multiple times which will exhaust number of password retries and force the user to restart the machine. This commit introduces a logic to check for the cause of packet failure and only retry packets which failed due to transient conditions on the link. With this patch only packets for which CRC error is flagged are retried.

Cc: Hao A Wu <hao.a.wu@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Cc: Hunter Chang <hunter.chang@intel.com>
Cc: Baraneedharan Anbazhagan <anbazhagan@hp.com>

Reviewed-by: Hao A Wu <hao.a.wu@intel.com>
Reviewed-by: Baraneedharan Anbazhagan <anbazhagan@hp.com>