### PR TITLE
.azurepipelines/templates: Increase run to shell timeout

### DIFF
--- a/.azurepipelines/templates/platform-build-run-steps.yml
+++ b/.azurepipelines/templates/platform-build-run-steps.yml
@@ -116,7 +116,7 @@ steps:
     filename: stuart_build
     arguments: -c ${{ parameters.build_file }} TOOL_CHAIN_TAG=${{ parameters.tool_chain_tag}} TARGET=${{ parameters.build_target}} -a ${{ parameters.build_arch}} ${{ parameters.build_flags}} ${{ parameters.run_flags }} --FlashOnly
   condition: and(and(gt(variables.pkg_count, 0), succeeded()), eq(variables['Run'], true))
-  timeoutInMinutes: 1
+  timeoutInMinutes: 2
 
 # Copy the build logs to the artifact staging directory
 - task: CopyFiles@2


### PR DESCRIPTION
Increase the CI agent timeout to boot to UEFI Shell from 1 minute to 2 minutes.  There have been a few cases where the boot to shell in QEMU has not quite completed in 1 minute and it is failing the CI check and preventing a PR from being merged.

Cc: Sean Brogan <sean.brogan@microsoft.com>
Cc: Michael Kubacki <mikuback@linux.microsoft.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Signed-off-by: Michael D Kinney <michael.d.kinney@intel.com>