### PR TITLE
OvmfPkg/CI: Revert SMP mode

### DIFF
--- a/OvmfPkg/PlatformCI/PlatformBuildLib.py
+++ b/OvmfPkg/PlatformCI/PlatformBuildLib.py
@@ -196,7 +196,6 @@ class PlatformBuilder( UefiBuilder, BuildSettingsManager):
         args  = "-debugcon stdio"                                           # write messages to stdio
         args += " -global isa-debugcon.iobase=0x402"                        # debug messages out thru virtual io port
         args += " -net none"                                                # turn off network
-        args += " -smp 4"
         args += f" -drive file=fat:rw:{VirtualDrive},format=raw,media=disk" # Mount disk with startup.nsh
 
         if (self.env.GetValue("QEMU_HEADLESS").upper() == "TRUE"):


### PR DESCRIPTION
This is causing excessive boot times in the VS2019 IA32/X64 Full run to shell tasks (> 2 minutes) and blocking all edk2 CI.

This patch removes the change so it can be root caused separately without blocking other patches unrelated to OVMF.

Reverts f92a9dce10281c103b04d6b38283e0ff1d677b91

Cc: Ard Biesheuvel <ardb+tianocore@kernel.org>
Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Jordan Justen <jordan.l.justen@intel.com>
Cc: Gerd Hoffmann <kraxel@redhat.com>
Cc: Michael D Kinney <michael.d.kinney@intel.com>