### PR TITLE
.github/workflows/codeql-analysis.yml: Add PIP caching

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -66,6 +66,8 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: '3.10.6'
+        cache: 'pip'
+        cache-dependency-path: 'pip-requirements.txt'
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL


### PR DESCRIPTION
Adds caching of PIP dependencies. This reduces overall execution time and decreases likelihood of a network error reaching out pypi to get the dependencies.

Caching happens based on modules specified in pip-requirements.txt.

Cc: Sean Brogan <sean.brogan@microsoft.com>
Cc: Michael Kubacki <mikuback@linux.microsoft.com>
Cc: Michael D Kinney <michael.d.kinney@intel.com>
Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>
Reviewed-by: Michael D Kinney <michael.d.kinney@intel.com>