### PR TITLE
.github/dependabot.yml: Disable automatic rebasing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,7 @@ updates:
       - "makubacki"
       - "mdkinney"
       - "spbrogan"
+    rebase-strategy: "disabled"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -32,3 +33,4 @@ updates:
       - "makubacki"
       - "mdkinney"
       - "spbrogan"
+    rebase-strategy: "disabled"


### PR DESCRIPTION
Sets the rebase-strategy to "disabled" to prevent automatic rebasing.

Rebasing can be done manually in the dependabot PR either through the GitHub UI or the dependabot command.

Cc: Sean Brogan <sean.brogan@microsoft.com>
Cc: Michael D Kinney <michael.d.kinney@intel.com>
Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>
Reviewed-by: Sean Brogan <sean.brogan@microsoft.com>
Reviewed-by: Michael D Kinney <michael.d.kinney@intel.com>