### PR TITLE
Add 10s stall to `HelloWorld.c`

### DIFF
--- a/MdeModulePkg/Application/HelloWorld/HelloWorld.c
+++ b/MdeModulePkg/Application/HelloWorld/HelloWorld.c
@@ -11,6 +11,7 @@
 #include <Library/PcdLib.h>
 #include <Library/UefiLib.h>
 #include <Library/UefiApplicationEntryPoint.h>
+#include <Library/UefiBootServicesTableLib.h>
 
 //
 // String token ID of help message text.
@@ -53,6 +54,7 @@ UefiMain (
       // Use UefiLib Print API to print string to UEFI console
       //
       Print ((CHAR16 *)PcdGetPtr (PcdHelloWorldPrintString));
+      gBS->Stall (10000000);
     }
   }
 


### PR DESCRIPTION
Hi everyone, UEFI newbie & first-time contributor here.
While trying how to understand EDK 2 and UEFI, I tried building and running the HelloWorld application from this repository.
This worked, but there was one thing which confused me and cost me some time: answering why the _UEFI Hello World!_ message did not stay on the screen longer. From that, this small PR came about which adds a 10s stall after printing the message.
I can imagine there are reasons not to bring this change in, or that the PR might require modifications, but just in case, I thought I'd send the work your way.
Any feedback would be highly appreciated.