### PR TITLE
Balance CI Execution Times

### DIFF
--- a/.azurepipelines/templates/pr-gate-build-job.yml
+++ b/.azurepipelines/templates/pr-gate-build-job.yml
@@ -49,9 +49,12 @@ jobs:
       TARGET_FMP_FAT_TEST:
         Build.Pkgs: 'FmpDevicePkg,FatPkg,UnitTestFrameworkPkg,DynamicTablesPkg'
         Build.Targets: 'DEBUG,RELEASE,NO-TARGET,NOOPT'
-      TARGET_CRYPTO:
+      TARGET_CRYPTO_DEBUG:
         Build.Pkgs: 'CryptoPkg'
-        Build.Targets: 'DEBUG,RELEASE,NO-TARGET,NOOPT'
+        Build.Targets: 'DEBUG,NOOPT'
+      TARGET_CRYPTO_RELEASE:
+        Build.Pkgs: 'CryptoPkg'
+        Build.Targets: 'RELEASE,NO-TARGET'
       TARGET_FSP:
         Build.Pkgs: 'IntelFsp2Pkg,IntelFsp2WrapperPkg'
         Build.Targets: 'DEBUG,RELEASE,NO-TARGET,NOOPT'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,25 +39,45 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        package: [
-          "ArmPkg",
-          "CryptoPkg",
-          "DynamicTablesPkg",
-          "FatPkg",
-          "FmpDevicePkg",
-          "IntelFsp2Pkg",
-          "IntelFsp2WrapperPkg",
-          "MdeModulePkg",
-          "MdePkg",
-          "PcAtChipsetPkg",
-          "PrmPkg",
-          "SecurityPkg",
-          "ShellPkg",
-          "SourceLevelDebugPkg",
-          "StandaloneMmPkg",
-          "UefiCpuPkg",
-          "UnitTestFrameworkPkg"]
-
+        include:
+          - Package: "ArmPkg"
+            ArchList: "IA32,X64"
+          - Package: "CryptoPkg"
+            ArchList: "IA32"
+          - Package: "CryptoPkg"
+            ArchList: "X64"
+          - Package: "DynamicTablesPkg"
+            ArchList: "IA32,X64"
+          - Package: "FatPkg"
+            ArchList: "IA32,X64"
+          - Package: "FmpDevicePkg"
+            ArchList: "IA32,X64"
+          - Package: "IntelFsp2Pkg"
+            ArchList: "IA32,X64"
+          - Package: "IntelFsp2WrapperPkg"
+            ArchList: "IA32,X64"
+          - Package: "MdeModulePkg"
+            ArchList: "IA32"
+          - Package: "MdeModulePkg"
+            ArchList: "X64"
+          - Package: "MdePkg"
+            ArchList: "IA32,X64"
+          - Package: "PcAtChipsetPkg"
+            ArchList: "IA32,X64"
+          - Package: "PrmPkg"
+            ArchList: "IA32,X64"
+          - Package: "SecurityPkg"
+            ArchList: "IA32,X64"
+          - Package: "ShellPkg"
+            ArchList: "IA32,X64"
+          - Package: "SourceLevelDebugPkg"
+            ArchList: "IA32,X64"
+          - Package: "StandaloneMmPkg"
+            ArchList: "IA32,X64"
+          - Package: "UefiCpuPkg"
+            ArchList: "IA32,X64"
+          - Package: "UnitTestFrameworkPkg"
+            ArchList: "IA32,X64"
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3
@@ -83,16 +103,16 @@ jobs:
       run: pip install -r pip-requirements.txt --upgrade
 
     - name: Setup
-      run: stuart_setup -c .pytool/CISettings.py -t DEBUG -a IA32,X64 TOOL_CHAIN_TAG=VS2019
+      run: stuart_setup -c .pytool/CISettings.py -t DEBUG -a ${{ matrix.ArchList }} TOOL_CHAIN_TAG=VS2019
 
     - name: Update
-      run: stuart_update -c .pytool/CISettings.py -t DEBUG -a IA32,X64 TOOL_CHAIN_TAG=VS2019
+      run: stuart_update -c .pytool/CISettings.py -t DEBUG -a ${{ matrix.ArchList }} TOOL_CHAIN_TAG=VS2019
 
     - name: Build Tools From Source
       run: python BaseTools/Edk2ToolsBuild.py -t VS2019
 
     - name: CI Build
-      run: stuart_ci_build -c .pytool/CISettings.py -p ${{ matrix.package }} -t DEBUG -a IA32,X64 TOOL_CHAIN_TAG=VS2019
+      run: stuart_ci_build -c .pytool/CISettings.py -p ${{ matrix.Package }} -t DEBUG -a ${{ matrix.ArchList }} TOOL_CHAIN_TAG=VS2019
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
MdeModulePkg and CryptoPkg have double the CodeQL analysis
time of all other packages.  Split these packages up to perform
separate analysis of IA32 and X64.

CryptoPkg has double the build time of all other packages.
Split CryptoPkg up matching the style applied to MdeModulePkg.

Cc: Sean Brogan <[sean.brogan@microsoft.com](mailto:sean.brogan@microsoft.com)>
Cc: Michael Kubacki <[mikuback@linux.microsoft.com](mailto:mikuback@linux.microsoft.com)>
Cc: Liming Gao <[gaoliming@byosoft.com.cn](mailto:gaoliming@byosoft.com.cn)>
Signed-off-by: Michael D Kinney <[michael.d.kinney@intel.com](mailto:michael.d.kinney@intel.com)>
