### PR TITLE
pip-requirements.txt: bump edk2-basetools to 0.1.43

### DIFF
--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -14,7 +14,7 @@
 
 edk2-pytool-library==0.14.0
 edk2-pytool-extensions~=0.21.8
-edk2-basetools==0.1.39
+edk2-basetools==0.1.43
 antlr4-python3-runtime==4.7.1
 lcov-cobertura==2.0.2
 


### PR DESCRIPTION
Bump the version of edk2-basetools in pip-requirements.txt to 0.1.43. This version contains the update to generate makefiles with both CFLAGS and BUILD_CFLAGS.


Reviewed-by: Michael D Kinney <michael.d.kinney@intel.com>