### PR TITLE
IntelFsp2Pkg: TempRamInit API should preserve EBX/RBX register.

### DIFF
--- a/IntelFsp2Pkg/FspSecCore/Ia32/SaveRestoreSseNasm.inc
+++ b/IntelFsp2Pkg/FspSecCore/Ia32/SaveRestoreSseNasm.inc
@@ -157,6 +157,9 @@ NextAddress:
             ; Use CpuId instruction (CPUID.01H:EDX.SSE[bit 25] = 1) to test
             ; whether the processor supports SSE instruction.
             ;
+            ; Save EBX to MM2
+            ;
+            movd    mm2, ebx
             mov     eax, 1
             cpuid
             bt      edx, 25
@@ -169,6 +172,10 @@ NextAddress:
             bt      ecx, 19
             jnc     SseError
 %endif
+            ;
+            ; Restore EBX from MM2
+            ;
+            movd    ebx, mm2
 
             ;
             ; Set OSFXSR bit (bit #9) & OSXMMEXCPT bit (bit #10)

--- a/IntelFsp2Pkg/Include/SaveRestoreSseAvxNasm.inc
+++ b/IntelFsp2Pkg/Include/SaveRestoreSseAvxNasm.inc
@@ -255,6 +255,10 @@ NextAddress:
             ; Use CpuId instruction (CPUID.01H:EDX.SSE[bit 25] = 1) to test
             ; whether the processor supports SSE instruction.
             ;
+            ; Save RBX to R11
+            ; Save RCX to R10
+            ;
+            mov     r11, rbx
             mov     r10, rcx
             mov     rax, 1
             cpuid
@@ -266,7 +270,12 @@ NextAddress:
             ;
             bt      ecx, 19
             jnc     SseError
-            mov     rcx,  r10
+            ;
+            ; Restore RBX from R11
+            ; Restore RCX from R10
+            ;
+            mov     rbx, r11
+            mov     rcx, r10
 
             ;
             ; Set OSFXSR bit (bit #9) & OSXMMEXCPT bit (bit #10)
@@ -284,6 +293,11 @@ NextAddress:
             %endmacro
 
 %macro ENABLE_AVX   0
+            ;
+            ; Save RBX to R11
+            ; Save RCX to R10
+            ;
+            mov     r11, rbx
             mov     r10, rcx
             mov     eax, 1
             cpuid
@@ -307,6 +321,11 @@ EnableAvx:
             xgetbv                 ; result in edx:eax
             or      eax, 00000006h ; Set XCR0 bit #1 and bit #2 to enable SSE state and AVX state
             xsetbv
+            ;
+            ; Restore RBX from R11
+            ; Restore RCX from R10
+            ;
+            mov     rbx, r11
             mov     rcx, r10
             %endmacro
 


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4395

FSP specification defines the TempRamInit API preserved register list which including EBX/RBX, however current implementation unexpectedly overriding EBX/RBX register that should be fixed.

Cc: Nate DeSimone <nathaniel.l.desimone@intel.com>
Cc: Star Zeng <star.zeng@intel.com>

Reviewed-by: Nate DeSimone <nathaniel.l.desimone@intel.com>