### PR TITLE
IntelFsp2Pkg: LoadMicrocodeDefault() causing unnecessary delay.

### DIFF
--- a/IntelFsp2Pkg/FspSecCore/X64/FspApiEntryT.nasm
+++ b/IntelFsp2Pkg/FspSecCore/X64/FspApiEntryT.nasm
@@ -141,6 +141,22 @@ ASM_PFX(LoadMicrocodeDefault):
    jz     ParamError
    mov    rsp, rcx
 
+   ;
+   ; If microcode already loaded before this function, exit this function with SUCCESS.
+   ;
+   mov   ecx, MSR_IA32_BIOS_SIGN_ID
+   xor   eax, eax               ; Clear EAX
+   xor   edx, edx               ; Clear EDX
+   wrmsr                        ; Load 0 to MSR at 8Bh
+
+   mov   eax, 1
+   cpuid
+   mov   ecx, MSR_IA32_BIOS_SIGN_ID
+   rdmsr                         ; Get current microcode signature
+   xor   rax, rax
+   test  edx, edx
+   jnz   Exit2
+
    ; skip loading Microcode if the MicrocodeCodeSize is zero
    ; and report error if size is less than 2k
    ; first check UPD header revision
@@ -198,7 +214,7 @@ CheckMainHeader:
    cmp   ebx, dword [esi + MicrocodeHdr.MicrocodeHdrProcessor]
    jne   LoadMicrocodeDefault1
    test  edx, dword [esi + MicrocodeHdr.MicrocodeHdrFlags ]
-   jnz   LoadCheck  ; Jif signature and platform ID match
+   jnz   LoadMicrocode  ; Jif signature and platform ID match
 
 LoadMicrocodeDefault1:
    ; Check if extended header exists
@@ -231,7 +247,7 @@ CheckExtSig:
    cmp   dword [edi + ExtSig.ExtSigProcessor], ebx
    jne   LoadMicrocodeDefault2
    test  dword [edi + ExtSig.ExtSigFlags], edx
-   jnz   LoadCheck      ; Jif signature and platform ID match
+   jnz   LoadMicrocode      ; Jif signature and platform ID match
 LoadMicrocodeDefault2:
    ; Check if any more extended signatures exist
    add   edi, ExtSig.size
@@ -276,22 +292,7 @@ LoadMicrocodeDefault4:
    ; Is valid Microcode start point ?
    cmp   dword [esi + MicrocodeHdr.MicrocodeHdrVersion], 0ffffffffh
    jz    Done
-
-LoadCheck:
-   ; Get the revision of the current microcode update loaded
-   mov   ecx, MSR_IA32_BIOS_SIGN_ID
-   xor   eax, eax               ; Clear EAX
-   xor   edx, edx               ; Clear EDX
-   wrmsr                        ; Load 0 to MSR at 8Bh
-
-   mov   eax, 1
-   cpuid
-   mov   ecx, MSR_IA32_BIOS_SIGN_ID
-   rdmsr                        ; Get current microcode signature
-
-   ; Verify this microcode update is not already loaded
-   cmp   dword [esi + MicrocodeHdr.MicrocodeHdrRevision], edx
-   je    Continue
+   jmp   CheckMainHeader
 
 LoadMicrocode:
    ; EAX contains the linear address of the start of the Update Data
@@ -306,10 +307,12 @@ LoadMicrocode:
    mov   eax, 1
    cpuid
 
-Continue:
-   jmp   NextMicrocode
-
 Done:
+   mov   ecx, MSR_IA32_BIOS_SIGN_ID
+   xor   eax, eax               ; Clear EAX
+   xor   edx, edx               ; Clear EDX
+   wrmsr                        ; Load 0 to MSR at 8Bh
+
    mov   eax, 1
    cpuid
    mov   ecx, MSR_IA32_BIOS_SIGN_ID


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4391

FSP should support the scenario that CPU microcode already loaded before calling LoadMicrocodeDefault(), in this case it should return directly without spending more time.
Also the LoadMicrocodeDefault() should only attempt to load one version of the microcode for current CPU and return directly without parsing rest of the microcode in FV.

This patch also removed unnecessary LoadCheck code after supporting CPU microcode already loaded scenario.

Cc: Nate DeSimone <nathaniel.l.desimone@intel.com>
Cc: Star Zeng <star.zeng@intel.com>
Cc: Ray Ni <ray.ni@intel.com>

Reviewed-by: Ted Kuo <ted.kuo@intel.com>
Reviewed-by: Nate DeSimone <nathaniel.l.desimone@intel.com>
Reviewed-by: Ray Ni <ray.ni@intel.com>