### PR TITLE
BaseTools: Update antlr makefile to use cc by default

### DIFF
--- a/BaseTools/Source/C/VfrCompile/Pccts/antlr/makefile
+++ b/BaseTools/Source/C/VfrCompile/Pccts/antlr/makefile
@@ -164,11 +164,6 @@ PCCTS_H=../h
 #
 #   UNIX  (default)
 #
-ifneq ($(CLANG),)
-CC?=$(CLANG_BIN)clang
-else ifeq ($(origin CC),default)
-CC=gcc
-endif
 COPT=-O
 ANTLR=${BIN_DIR}/antlr
 DLG=${BIN_DIR}/dlg


### PR DESCRIPTION
Update the antlr makefile to remove the explicit setting of CC to either
clang or gcc. This causes it to use /usr/bin/cc or whatever the user has
set $(CC) to.

This removes the last dependency on gcc for BaseTools.

Signed-off-by: Rebecca Cran <rebecca@bsdio.com>