### PR TITLE
OvmfPkg/VirtioMmioDeviceLib: virtio 1.0: Fix SetQueueAlignment.

### DIFF
--- a/OvmfPkg/Library/VirtioMmioDeviceLib/VirtioMmioDeviceFunctions.c
+++ b/OvmfPkg/Library/VirtioMmioDeviceLib/VirtioMmioDeviceFunctions.c
@@ -144,7 +144,9 @@ VirtioMmioSetQueueAlignment (
 
   Device = VIRTIO_MMIO_DEVICE_FROM_VIRTIO_DEVICE (This);
 
-  VIRTIO_CFG_WRITE (Device, VIRTIO_MMIO_OFFSET_QUEUE_ALIGN, Alignment);
+  if (Device->Version == VIRTIO_MMIO_DEVICE_VERSION_0_95) {
+    VIRTIO_CFG_WRITE (Device, VIRTIO_MMIO_OFFSET_QUEUE_ALIGN, Alignment);
+  }
 
   return EFI_SUCCESS;
 }


### PR DESCRIPTION
Nothing to do here for virtio 1.0 devices


Reviewed-by: Gerd Hoffmann <kraxel@redhat.com>