### PR TITLE
MdeModulePkg/RegularExpressionDxe: Fix GCC build error

### DIFF
--- a/MdeModulePkg/Universal/RegularExpressionDxe/OnigurumaUefiPort.h
+++ b/MdeModulePkg/Universal/RegularExpressionDxe/OnigurumaUefiPort.h
@@ -4,6 +4,7 @@
 
   (C) Copyright 2014-2021 Hewlett Packard Enterprise Development LP<BR>
   Copyright (c) 2020, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
@@ -36,11 +37,9 @@ typedef INTN    intptr_t;
 #define offsetof  OFFSET_OF
 #endif
 
-#ifdef MDE_CPU_IA32
+#if defined (MDE_CPU_IA32) || defined (MDE_CPU_ARM) || defined (MDE_CPU_EBC)
 #define SIZEOF_VOIDP  4
-#endif
-
-#ifdef MDE_CPU_X64
+#else
 #define SIZEOF_VOIDP  8
 #endif
 


### PR DESCRIPTION
Fix GCC build error on AARCH64 system.


Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Nick Ramirez <nramirez@nvidia.com>