### PR TITLE
ShellPkg: Add a condition to print accurate type0 Bios Size in smbios…

### DIFF
--- a/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/PrintInfo.c
+++ b/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/PrintInfo.c
@@ -339,7 +339,9 @@ SmbiosPrintStructure (
       ShellPrintEx (-1, -1, L"BIOS Version: %a\n", LibGetSmbiosString (Struct, Struct->Type0->BiosVersion));
       ShellPrintEx (-1, -1, L"BIOS Starting Address Segment: 0x%x\n", Struct->Type0->BiosSegment);
       ShellPrintEx (-1, -1, L"BIOS Release Date: %a\n", LibGetSmbiosString (Struct, Struct->Type0->BiosReleaseDate));
-      ShellPrintHiiEx (-1, -1, NULL, STRING_TOKEN (STR_SMBIOSVIEW_PRINTINFO_BIOS_SIZE), gShellDebug1HiiHandle, 64 * (Struct->Type0->BiosSize + 1));
+      if ((Struct->Type0->BiosSize != 0xFF) || !(AE_SMBIOS_VERSION (0x3, 0x1))) {
+        ShellPrintHiiEx (-1, -1, NULL, STRING_TOKEN (STR_SMBIOSVIEW_PRINTINFO_BIOS_SIZE), gShellDebug1HiiHandle, 64 * (Struct->Type0->BiosSize + 1));
+      }
 
       DisplayBiosCharacteristics (ReadUnaligned64 ((UINT64 *)(UINTN)&(Struct->Type0->BiosCharacteristics)), Option);
 


### PR DESCRIPTION
…view. (for CI check test only)

As per the SMBIOS spec, in smbios type0 table, if the Bios size is greater than 16MB, extended bios size is used to update size information and bios size is set to 0xff. when this data is printed by smbiosview, both bios size and extended bios size is printed if the smbios version is beyond 3.1, which is incorrect as Bios size is set to 0xff when rom size is more than 16MB.

To fix this bug, added a condition to print bios size only when it is not set to 0xff or if the smbios version is older than 3.1.