### PR TITLE
IntelFsp2Pkg/Tools: Enhance PathFv.py to patch Fd file directly

### DIFF
--- a/IntelFsp2Pkg/Tools/PatchFv.py
+++ b/IntelFsp2Pkg/Tools/PatchFv.py
@@ -164,6 +164,16 @@ class Symbols:
         #
         if not os.path.isdir(fvDir):
             raise Exception ("'%s' is not a valid directory!" % fvDir)
+        #
+        # if user provided fd name as a input, skip rest of the flow to
+        # patch fd directly
+        #
+        fdFile =  os.path.join(fvDir,fvNames + ".fd")
+        if os.path.exists(fdFile):
+            print("Tool identified Fd file as a input to patch '%s'" %fdFile)
+            self.fdFile = fdFile
+            self.fdSize = os.path.getsize(fdFile)
+            return 0
 
         #
         # If the Guid.xref is not existing in fvDir, then raise an exception
@@ -848,8 +858,9 @@ class Symbols:
 #  Print out the usage
 #
 def Usage():
-    print ("PatchFv Version 0.50")
+    print ("PatchFv Version 0.60")
     print ("Usage: \n\tPatchFv FvBuildDir [FvFileBaseNames:]FdFileBaseNameToPatch \"Offset, Value\"")
+    print ("\tPatchFv FdFileDir FdFileName \"Offset, Value\"")
 
 def main():
     #

--- a/IntelFsp2Pkg/Tools/UserManuals/PatchFvUserManual.md
+++ b/IntelFsp2Pkg/Tools/UserManuals/PatchFvUserManual.md
@@ -1,11 +1,18 @@
 #Name
 **_PatchFv.py_** - The python script that patches the firmware volumes (**FV**)
 with in the flash device (**FD**) file post FSP build.
+From version 0.60, script is capable of patching flash device (**FD**) directly.
 
 #Synopsis
 
 ```
 PatchFv FvBuildDir [FvFileBaseNames:]FdFileBaseNameToPatch ["Offset, Value"]+
+  | ["Offset, Value, @Comment"]+
+  | ["Offset, Value, $Command"]+
+  | ["Offset, Value, $Command, @Comment"]+
+```
+```
+PatchFv FdFileDir FdFileName ["Offset, Value"]+
   | ["Offset, Value, @Comment"]+
   | ["Offset, Value, $Command"]+
   | ["Offset, Value, $Command, @Comment"]+
@@ -101,6 +108,19 @@ ModuleGuid:Offset
   { } Convert an offset {expr} into an absolute address (FSP_BASE + expr)
   < > Convert absolute address <expr> into an image offset (expr & FSP_SIZE)
 
+```
+From version 0.60 tool allows to pass flash device file path as Argument 1 and
+flash device name as Argument 2 and rules for passing offset & value are same
+as explained in the previous sections.
+
+####Example usage:
+Argument 1
+```
+ YouPlatformFspBinPkg\
+```
+Argument 2
+```
+ Fsp_Rebased_T
 ```
 
 ###Special Commands:


### PR DESCRIPTION
IntelFsp2Pkg/Tools: Enhance PathFv.py to patch Fd file directly

https://bugzilla.tianocore.org/show_bug.cgi?id=4412

After shrinking the FSP (FV) component using FMMT, Image size in FSP info header is not in sync with the FV length in FV header. This enhancement helps to patch the FSP image size offset with correct length & can be used to patch any offset directly on the FSP Component Fd.

Cc: Chasel Chiu <chasel.chiu@intel.com>
Cc: Nate DeSimone <nathaniel.l.desimone@intel.com>
Cc: Star Zeng <star.zeng@intel.com>
Cc: Ted Kuo <ted.kuo@intel.com>