### PR TITLE
BaseTools/Plugin: Clarify code coverage failure message

### DIFF
--- a/BaseTools/Plugin/HostBasedUnitTestRunner/HostBasedUnitTestRunner.py
+++ b/BaseTools/Plugin/HostBasedUnitTestRunner/HostBasedUnitTestRunner.py
@@ -16,6 +16,7 @@ import edk2toollib.windows.locate_tools as locate_tools
 from edk2toolext.environment import shell_environment
 from edk2toollib.utility_functions import RunCmd
 from edk2toollib.utility_functions import GetHostInfo
+from textwrap import dedent
 
 
 class HostBasedUnitTestRunner(IUefiBuildPlugin):
@@ -83,6 +84,18 @@ class HostBasedUnitTestRunner(IUefiBuildPlugin):
                 testList = glob.glob(os.path.join(cp, "*Test*.exe"))
             else:
                 raise NotImplementedError("Unsupported Operating System")
+
+            if not testList:
+                logging.warning(dedent("""
+                    UnitTest Coverage:
+                      No unit tests discovered. Test coverage will not be generated.
+
+                      Prevent this message by:
+                      1. Adding host-based unit tests to this package
+                      2. Ensuring tests have the word "Test" in their name
+                      3. Disabling HostUnitTestCompilerPlugin in the package CI YAML file
+                    """).strip())
+                return 0
 
             for test in testList:
                 # Configure output name if test uses cmocka.


### PR DESCRIPTION
HostBasedUnitTestRunner.py is a build plugin responsible for locating and executing host-based unit tests.

Recently, commit 6bb00aa introduced support for the plugin to generate code coverage reports via lcov and OpenCppCoverage.

The plugin has discovered unit tests by searching for executables with "Test" in the name for a while. However, the test coverage change makes assumptions about test presence when crafting the OpenCppCoverage command that ultimately fails with an ambiguous error message if no host-based unit tests are discovered (see "ERROR").

```
SECTION - Run Host based Unit Tests
SUBSECTION - Testing for architecture: X64
ERROR - UnitTest Coverage: Failed to generate cobertura format xml in
        single package.
PROGRESS - --->Test Success: Host Unit Test Compiler Plugin NOOPT
```

This change preempts that message with a check in the plugin to determine if any host-based tests were discovered. If not, a message is printed with more guidance about how the developer should proceed to either (1) fix their tests so code coverage is generated as expected or (2) prevent the error message.

New message:

```
SECTION - Run Host based Unit Tests
SUBSECTION - Testing for architecture: X64
WARNING - UnitTest Coverage:
  No unit tests discovered. Test coverage will not be generated.

  Prevent this message by:
  1. Adding host-based unit tests to this package
  2. Ensuring tests have the word "Test" in their name
  3. Disabling HostUnitTestCompilerPlugin in the package CI YAML file
PROGRESS - --->Test Success: Host Unit Test Compiler Plugin NOOPT
```

Cc: Rebecca Cran <rebecca@bsdio.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Bob Feng <bob.c.feng@intel.com>
Cc: Yuwei Chen <yuwei.chen@intel.com>
Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>
Reviewed-by: Rebecca Cran <rebecca@bsdio.com>