### PR TITLE
CryptoPkg: Enable DXE_CORE support in DxeCryptLib.inf

### DIFF
--- a/CryptoPkg/Library/BaseCryptLibOnProtocolPpi/DxeCryptLib.inf
+++ b/CryptoPkg/Library/BaseCryptLibOnProtocolPpi/DxeCryptLib.inf
@@ -16,7 +16,7 @@
   FILE_GUID                      = B38CBDA6-8017-4111-8232-9E8328DE82F6
   VERSION_STRING                 = 1.0
   MODULE_TYPE                    = DXE_DRIVER
-  LIBRARY_CLASS                  = BaseCryptLib | DXE_DRIVER UEFI_DRIVER UEFI_APPLICATION
+  LIBRARY_CLASS                  = BaseCryptLib | DXE_DRIVER UEFI_DRIVER UEFI_APPLICATION DXE_CORE
   LIBRARY_CLASS                  = TlsLib       | DXE_DRIVER UEFI_DRIVER UEFI_APPLICATION
   CONSTRUCTOR                    = DxeCryptLibConstructor
 


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4413

Make the DXE_CORE module able to call the crypto protocol, which can reduce FV size on platforms using the Crypto Binaries.

Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Xiaoyu Lu <xiaoyu1.lu@intel.com>
Cc: Guomin Jiang <guomin.jiang@intel.com>

Reviewed-by: Jiewen Yao <jiewen.yao@intel.com>