### PR TITLE
UefiPayloadPkg: Move Network modules from Dxe FV to Network FV in elf

### DIFF
--- a/UefiPayloadPkg/UefiPayloadPkg.fdf
+++ b/UefiPayloadPkg/UefiPayloadPkg.fdf
@@ -60,6 +60,35 @@ FILE FV_IMAGE = 4E35FD93-9C72-4c15-8C4B-E77F1DB2D793 {
     SECTION FV_IMAGE = DXEFV
 }
 
+!if $(NETWORK_DRIVER_ENABLE) == TRUE
+################################################################################
+[FV.NETWORKFV]
+FvNameGuid         = 3CF5CB69-C439-4B84-AF11-8167B22D7221
+BlockSize          = $(FD_BLOCK_SIZE)
+FvForceRebase      = FALSE
+FvAlignment        = 16
+ERASE_POLARITY     = 1
+MEMORY_MAPPED      = TRUE
+STICKY_WRITE       = TRUE
+LOCK_CAP           = TRUE
+LOCK_STATUS        = TRUE
+WRITE_DISABLED_CAP = TRUE
+WRITE_ENABLED_CAP  = TRUE
+WRITE_STATUS       = TRUE
+WRITE_LOCK_CAP     = TRUE
+WRITE_LOCK_STATUS  = TRUE
+READ_DISABLED_CAP  = TRUE
+READ_ENABLED_CAP   = TRUE
+READ_STATUS        = TRUE
+READ_LOCK_CAP      = TRUE
+READ_LOCK_STATUS   = TRUE
+
+#
+# UEFI network modules
+#
+!include NetworkPkg/Network.fdf.inc
+!endif
+
 ################################################################################
 [FV.BDSFV]
 FvNameGuid         = CA5590AF-9558-4822-B5EA-BE2E876CD3EC
@@ -276,13 +305,12 @@ INF  MdeModulePkg/Universal/Acpi/BootGraphicsResourceTableDxe/BootGraphicsResour
 
 !if $(UNIVERSAL_PAYLOAD) == FALSE
 INF MdeModulePkg/Universal/BdsDxe/BdsDxe.inf
-!endif
-
 #
 # UEFI network modules
 #
 !if $(NETWORK_DRIVER_ENABLE) == TRUE
   !include NetworkPkg/Network.fdf.inc
+!endif
 !endif
 
 #

--- a/UefiPayloadPkg/UniversalPayloadBuild.py
+++ b/UefiPayloadPkg/UniversalPayloadBuild.py
@@ -108,6 +108,7 @@ def BuildUniversalPayload(Args, MacroList):
     DscPath = os.path.normpath("UefiPayloadPkg/UefiPayloadPkg.dsc")
     DxeFvOutputDir = os.path.join(BuildDir, "{}_{}".format (BuildTarget, ToolChain), os.path.normpath("FV/DXEFV.Fv"))
     BdsFvOutputDir = os.path.join(BuildDir, "{}_{}".format (BuildTarget, ToolChain), os.path.normpath("FV/BDSFV.Fv"))
+    NetworkFvOutputDir = os.path.join(BuildDir, "{}_{}".format (BuildTarget, ToolChain), os.path.normpath("FV/NETWORKFV.Fv"))
     PayloadReportPath = os.path.join(BuildDir, "UefiUniversalPayload.txt")
     ModuleReportPath = os.path.join(BuildDir, "UefiUniversalPayloadEntry.txt")
     UpldInfoFile = os.path.join(BuildDir, "UniversalPayloadInfo.bin")
@@ -185,6 +186,17 @@ def BuildUniversalPayload(Args, MacroList):
                            ObjCopyFlag,
                            EntryOutputDir
                            )
+        #
+        # Append network fv to sections if exists
+        #
+        if os.path.isfile(NetworkFvOutputDir):
+            index = remove_section.find(EntryOutputDir)
+            remove_section = remove_section[:index] + '--remove-section .upld.network_fv ' + remove_section[index:]
+            index = add_section.find(EntryOutputDir)
+            add_section = add_section[:index] + '--add-section .upld.network_fv=' + NetworkFvOutputDir + ' ' + add_section[index:]
+            index = set_section.find(EntryOutputDir)
+            set_section = set_section[:index] + '--set-section-alignment .upld.network_fv=16 ' + set_section[index:]
+
         RunCommand(remove_section)
         RunCommand(add_section)
         RunCommand(set_section)


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4417

Since UefiPayload had supported multiple FV,
move Network.fdf.inc to new firmware volume and
add this network FV into elf file.

Cc: Guo Dong <guo.dong@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Cc: Sean Rhodes <sean@starlabs.systems>
Cc: James Lu <james.lu@intel.com>

Reviewed-by: Gua Guo <gua.guo@intel.com>