### PR TITLE
ArmPkg: older assemblers may lack ID_AA64ISAR2_EL1

### DIFF
--- a/ArmPkg/Include/Chipset/AArch64.h
+++ b/ArmPkg/Include/Chipset/AArch64.h
@@ -112,6 +112,10 @@
 #define ARM_VECTOR_LOW_A32_FIQ   0x700
 #define ARM_VECTOR_LOW_A32_SERR  0x780
 
+// The ID_AA64ISAR2_EL1 register is not recognized by older
+// assemblers, we need to define it here.
+#define ID_AA64ISAR2_EL1  S3_0_C0_C6_2
+
 // The ID_AA64MMFR2_EL1 register was added in ARMv8.2. Since we
 // build for ARMv8.0, we need to define the register here.
 #define ID_AA64MMFR2_EL1  S3_0_C0_C7_2


### PR DESCRIPTION
ArmCpuInfo needs to be able to read ID_AA64ISAR2_EL1 system register. Older toolchains do not know it.

Same solution as one for QEMU:
https://www.mail-archive.com/qemu-devel@nongnu.org/msg929586.html


Reviewed-by: Leif Lindholm <quic_llindhol@quicinc.com>