### PR TITLE
MdePkg: Add DEBUG_MANAGEABILITY print error level

### DIFF
--- a/MdePkg/Include/Library/DebugLib.h
+++ b/MdePkg/Include/Library/DebugLib.h
@@ -29,26 +29,28 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 //
 // Declare bits for PcdDebugPrintErrorLevel and the ErrorLevel parameter of DebugPrint()
 //
-#define DEBUG_INIT      0x00000001  // Initialization
-#define DEBUG_WARN      0x00000002  // Warnings
-#define DEBUG_LOAD      0x00000004  // Load events
-#define DEBUG_FS        0x00000008  // EFI File system
-#define DEBUG_POOL      0x00000010  // Alloc & Free (pool)
-#define DEBUG_PAGE      0x00000020  // Alloc & Free (page)
-#define DEBUG_INFO      0x00000040  // Informational debug messages
-#define DEBUG_DISPATCH  0x00000080  // PEI/DXE/SMM Dispatchers
-#define DEBUG_VARIABLE  0x00000100  // Variable
-#define DEBUG_BM        0x00000400  // Boot Manager
-#define DEBUG_BLKIO     0x00001000  // BlkIo Driver
-#define DEBUG_NET       0x00004000  // Network Io Driver
-#define DEBUG_UNDI      0x00010000  // UNDI Driver
-#define DEBUG_LOADFILE  0x00020000  // LoadFile
-#define DEBUG_EVENT     0x00080000  // Event messages
-#define DEBUG_GCD       0x00100000  // Global Coherency Database changes
-#define DEBUG_CACHE     0x00200000  // Memory range cachability changes
-#define DEBUG_VERBOSE   0x00400000  // Detailed debug messages that may
-                                    // significantly impact boot performance
-#define DEBUG_ERROR  0x80000000     // Error
+#define DEBUG_INIT      0x00000001       // Initialization
+#define DEBUG_WARN      0x00000002       // Warnings
+#define DEBUG_LOAD      0x00000004       // Load events
+#define DEBUG_FS        0x00000008       // EFI File system
+#define DEBUG_POOL      0x00000010       // Alloc & Free (pool)
+#define DEBUG_PAGE      0x00000020       // Alloc & Free (page)
+#define DEBUG_INFO      0x00000040       // Informational debug messages
+#define DEBUG_DISPATCH  0x00000080       // PEI/DXE/SMM Dispatchers
+#define DEBUG_VARIABLE  0x00000100       // Variable
+#define DEBUG_BM        0x00000400       // Boot Manager
+#define DEBUG_BLKIO     0x00001000       // BlkIo Driver
+#define DEBUG_NET       0x00004000       // Network Io Driver
+#define DEBUG_UNDI      0x00010000       // UNDI Driver
+#define DEBUG_LOADFILE  0x00020000       // LoadFile
+#define DEBUG_EVENT     0x00080000       // Event messages
+#define DEBUG_GCD       0x00100000       // Global Coherency Database changes
+#define DEBUG_CACHE     0x00200000       // Memory range cachability changes
+#define DEBUG_VERBOSE   0x00400000       // Detailed debug messages that may
+                                         // significantly impact boot performance
+#define DEBUG_MANAGEABILITY  0x00800000  // Detailed debug and payload message of manageability
+                                         // related modules, such Redfish, IPMI, MCTP and etc.
+#define DEBUG_ERROR  0x80000000          // Error
 
 //
 // Aliases of debug message mask bits

--- a/MdePkg/MdePkg.dec
+++ b/MdePkg/MdePkg.dec
@@ -2282,6 +2282,7 @@
   #  BIT20 - Global Coherency Database changes message.<BR>
   #  BIT21 - Memory range cachability changes message.<BR>
   #  BIT22 - Detailed debug message.<BR>
+  #  BIT23 - Manageability messages.<BR>
   #  BIT31 - Error message.<BR>
   # @Prompt Debug Message Print Level.
   # @Expression  0x80000002 | (gEfiMdePkgTokenSpaceGuid.PcdDebugPrintErrorLevel & 0x7F84AA00) == 0


### PR DESCRIPTION
Bug #4414

Add DEBUG_MANAGEABILITY print error lever to
output debug message of detailed manageability
related module information, such as
- RedfishPkg:
  - HTTP header/request/response
  - JSON plain text
  - Refish resource
  - Redfish Host interface information
  - Redfish credential information
  - Platform configuration to Redfish mapping
  - etc.
- ManageabilityPKg
  - Protocol payload of MCTP/PLDM/IPMI
  - Payload of transport interface transfers
  - IPMI BLOB transfer
  - etc.
- RedfishClinetPkg
  - Redfish feature driver dispatcher
  - Redfish BIOS attributes
  - Platform configuration (HII) to Redfish property information
  - Redfish C structure information
  - etc.


Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Zhiguang Liu <zhiguang.liu@intel.com>
Cc: Nickle Wang <nicklew@nvidia.com>
Cc: Igor Kulchytskyy <igork@ami.com>
Cc: Isaac Oram <isaac.w.oram@intel.com>
Cc: Abdul Lateef Attar <AbdulLateef.Attar@amd.com>
Cc: Tinh Nguyen <tinhnguyen@os.amperecomputing.com>