### PR TITLE
RedfishPkg: Remove the Discover Token global variables

### DIFF
--- a/RedfishPkg/RedfishDiscoverDxe/RedfishDiscoverDxe.c
+++ b/RedfishPkg/RedfishDiscoverDxe/RedfishDiscoverDxe.c
@@ -1095,8 +1095,11 @@ RedfishServiceGetNetworkInterface (
 {
   EFI_REDFISH_DISCOVER_NETWORK_INTERFACE_INTERNAL  *ThisNetworkInterfaceIntn;
   EFI_REDFISH_DISCOVER_NETWORK_INTERFACE           *ThisNetworkInterface;
+  EFI_REDFISH_DISCOVER_REST_EX_INSTANCE_INTERNAL   *RestExInstance;
 
-  if ((NetworkIntfInstances == NULL) || (NumberOfNetworkIntfs == NULL) || (ImageHandle == NULL)) {
+  if ((This == NULL) || (NetworkIntfInstances == NULL) || (NumberOfNetworkIntfs == NULL) ||
+      (ImageHandle == NULL))
+  {
     return EFI_INVALID_PARAMETER;
   }
 
@@ -1107,12 +1110,26 @@ RedfishServiceGetNetworkInterface (
     return EFI_NOT_FOUND;
   }
 
+  RestExInstance = EFI_REDFISH_DISOVER_DATA_FROM_DISCOVER_PROTOCOL (This);
+
+  //
+  // Check the new found network interface.
+  //
+  if (RestExInstance->NetworkInterfaceInstances != NULL) {
+    FreePool (RestExInstance->NetworkInterfaceInstances);
+    RestExInstance->NetworkInterfaceInstances = NULL;
+  }
+
   ThisNetworkInterface = (EFI_REDFISH_DISCOVER_NETWORK_INTERFACE *)AllocateZeroPool (sizeof (EFI_REDFISH_DISCOVER_NETWORK_INTERFACE) * mNumNetworkInterface);
   if (ThisNetworkInterface == NULL) {
     return EFI_OUT_OF_RESOURCES;
   }
 
-  *NetworkIntfInstances    = ThisNetworkInterface;
+  *NetworkIntfInstances = ThisNetworkInterface;
+
+  RestExInstance->NetworkInterfaceInstances = ThisNetworkInterface;
+  RestExInstance->NumberOfNetworkInterfaces = 0;
+
   ThisNetworkInterfaceIntn = (EFI_REDFISH_DISCOVER_NETWORK_INTERFACE_INTERNAL *)GetFirstNode (&mEfiRedfishDiscoverNetworkInterface);
   while (TRUE) {
     ThisNetworkInterface->IsIpv6 = FALSE;
@@ -1130,7 +1147,7 @@ RedfishServiceGetNetworkInterface (
 
     ThisNetworkInterface->SubnetPrefixLength = ThisNetworkInterfaceIntn->SubnetPrefixLength;
     ThisNetworkInterface->VlanId             = ThisNetworkInterfaceIntn->VlanId;
-    (*NumberOfNetworkIntfs)++;
+    RestExInstance->NumberOfNetworkInterfaces++;
     if (IsNodeAtEnd (&mEfiRedfishDiscoverNetworkInterface, &ThisNetworkInterfaceIntn->Entry)) {
       break;
     }
@@ -1138,6 +1155,8 @@ RedfishServiceGetNetworkInterface (
     ThisNetworkInterfaceIntn = (EFI_REDFISH_DISCOVER_NETWORK_INTERFACE_INTERNAL *)GetNextNode (&mEfiRedfishDiscoverNetworkInterface, &ThisNetworkInterfaceIntn->Entry);
     ThisNetworkInterface++;
   }
+
+  *NumberOfNetworkIntfs = RestExInstance->NumberOfNetworkInterfaces;
 
   return EFI_SUCCESS;
 }
@@ -1178,7 +1197,6 @@ RedfishServiceAcquireService (
 {
   EFI_REDFISH_DISCOVERED_INTERNAL_INSTANCE         *Instance;
   EFI_STATUS                                       Status1;
-  EFI_STATUS                                       Status2;
   BOOLEAN                                          NewInstance;
   UINTN                                            NumNetworkInterfaces;
   UINTN                                            NetworkInterfacesIndex;
@@ -1215,7 +1233,6 @@ RedfishServiceAcquireService (
 
   for (NetworkInterfacesIndex = 0; NetworkInterfacesIndex < NumNetworkInterfaces; NetworkInterfacesIndex++) {
     Status1     = EFI_SUCCESS;
-    Status2     = EFI_SUCCESS;
     NewInstance = FALSE;
     Instance    = GetInstanceByOwner (ImageHandle, TargetNetworkInterfaceInternal, Flags & ~EFI_REDFISH_DISCOVER_VALIDATION); // Check if we can re-use previous instance.
     if (Instance == NULL) {
@@ -1223,6 +1240,7 @@ RedfishServiceAcquireService (
       Instance = (EFI_REDFISH_DISCOVERED_INTERNAL_INSTANCE *)AllocateZeroPool (sizeof (EFI_REDFISH_DISCOVERED_INTERNAL_INSTANCE));
       if (Instance == NULL) {
         DEBUG ((DEBUG_ERROR, "%a:Memory allocation fail.\n", __func__));
+        return EFI_OUT_OF_RESOURCES;
       }
 
       InitializeListHead (&Instance->Entry);
@@ -1258,9 +1276,12 @@ RedfishServiceAcquireService (
       DEBUG ((DEBUG_ERROR, "%a:Redfish service discovery through SSDP is not supported\n", __func__));
       return EFI_UNSUPPORTED;
     } else {
-      if (EFI_ERROR (Status1) && EFI_ERROR (Status2)) {
-        FreePool ((VOID *)Instance);
-        DEBUG ((DEBUG_ERROR, "%a:Something wrong on Redfish service discovery Status1=%x, Status2=%x.\n", __func__, Status1, Status2));
+      if (EFI_ERROR (Status1)) {
+        if (NewInstance) {
+          FreePool ((VOID *)Instance);
+        }
+
+        DEBUG ((DEBUG_ERROR, "%a:Something wrong on Redfish service discovery Status1=%r.\n", __func__, Status1));
       } else {
         if (NewInstance) {
           InsertTailList (&mRedfishDiscoverList, &Instance->Entry);
@@ -1386,13 +1407,6 @@ ReleaseNext:;
     return EFI_SUCCESS;
   }
 }
-
-EFI_REDFISH_DISCOVER_PROTOCOL  mRedfishDiscover = {
-  RedfishServiceGetNetworkInterface,
-  RedfishServiceAcquireService,
-  RedfishServiceAbortAcquire,
-  RedfishServiceReleaseService
-};
 
 /**
   This function create an EFI_REDFISH_DISCOVER_NETWORK_INTERFACE_INTERNAL for the
@@ -1713,12 +1727,20 @@ BuildupNetworkInterface (
 
           NewNetworkInterfaceInstalled                       = FALSE;
           NetworkInterface->EfiRedfishDiscoverProtocolHandle = NULL;
-          Status                                             = gBS->InstallProtocolInterface (
-                                                                      &NetworkInterface->EfiRedfishDiscoverProtocolHandle,
-                                                                      &gEfiRedfishDiscoverProtocolGuid,
-                                                                      EFI_NATIVE_INTERFACE,
-                                                                      (VOID *)&mRedfishDiscover
-                                                                      );
+
+          RestExInstance->Signature = EFI_REDFISH_DISCOVER_DATA_SIGNATURE;
+
+          RestExInstance->RedfishDiscoverProtocol.GetNetworkInterfaceList    = RedfishServiceGetNetworkInterface;
+          RestExInstance->RedfishDiscoverProtocol.AcquireRedfishService      = RedfishServiceAcquireService;
+          RestExInstance->RedfishDiscoverProtocol.AbortAcquireRedfishService = RedfishServiceAbortAcquire;
+          RestExInstance->RedfishDiscoverProtocol.ReleaseRedfishService      = RedfishServiceReleaseService;
+
+          Status = gBS->InstallProtocolInterface (
+                          &NetworkInterface->EfiRedfishDiscoverProtocolHandle,
+                          &gEfiRedfishDiscoverProtocolGuid,
+                          EFI_NATIVE_INTERFACE,
+                          (VOID *)&RestExInstance->RedfishDiscoverProtocol
+                          );
           if (EFI_ERROR (Status)) {
             DEBUG ((DEBUG_ERROR, "%a: Fail to install EFI_REDFISH_DISCOVER_PROTOCOL\n", __func__));
           }
@@ -1815,6 +1837,7 @@ StopServiceOnNetworkInterface (
   EFI_HANDLE                                       DiscoverProtocolHandle;
   EFI_REDFISH_DISCOVER_NETWORK_INTERFACE_INTERNAL  *ThisNetworkInterface;
   EFI_REDFISH_DISCOVER_REST_EX_INSTANCE_INTERNAL   *RestExInstance;
+  EFI_REDFISH_DISCOVER_PROTOCOL                    *RedfishDiscoverProtocol;
 
   for (Index = 0; Index < (sizeof (gRequiredProtocol) / sizeof (REDFISH_DISCOVER_REQUIRED_PROTOCOL)); Index++) {
     Status = gBS->HandleProtocol (
@@ -1854,12 +1877,28 @@ StopServiceOnNetworkInterface (
             // client which uses .EFI Redfish discover protocol.
             //
             if (DiscoverProtocolHandle != NULL) {
-              gBS->DisconnectController (DiscoverProtocolHandle, NULL, NULL);
-              Status = gBS->UninstallProtocolInterface (
+              Status = gBS->HandleProtocol (
                               DiscoverProtocolHandle,
                               &gEfiRedfishDiscoverProtocolGuid,
-                              (VOID *)&mRedfishDiscover
+                              (VOID **)&RedfishDiscoverProtocol
                               );
+              if (!EFI_ERROR (Status)) {
+                RestExInstance = EFI_REDFISH_DISOVER_DATA_FROM_DISCOVER_PROTOCOL (RedfishDiscoverProtocol);
+                //
+                // Stop Redfish service discovery.
+                //
+                RedfishDiscoverProtocol->AbortAcquireRedfishService (
+                                           RedfishDiscoverProtocol,
+                                           RestExInstance->NetworkInterfaceInstances
+                                           );
+
+                gBS->DisconnectController (DiscoverProtocolHandle, NULL, NULL);
+                Status = gBS->UninstallProtocolInterface (
+                                DiscoverProtocolHandle,
+                                &gEfiRedfishDiscoverProtocolGuid,
+                                (VOID *)&RestExInstance->RedfishDiscoverProtocol
+                                );
+              }
             }
 
             return Status;

--- a/RedfishPkg/RedfishDiscoverDxe/RedfishDiscoverInternal.h
+++ b/RedfishPkg/RedfishDiscoverDxe/RedfishDiscoverInternal.h
@@ -118,16 +118,30 @@ typedef struct {
 } EFI_REDFISH_DISCOVER_NETWORK_INTERFACE_INTERNAL;
 
 //
+// Redfish Discover Instance signature
+//
+
+#define EFI_REDFISH_DISCOVER_DATA_SIGNATURE  SIGNATURE_32 ('E', 'R', 'D', 'D')
+
+#define EFI_REDFISH_DISOVER_DATA_FROM_DISCOVER_PROTOCOL(a) \
+  CR (a, EFI_REDFISH_DISCOVER_REST_EX_INSTANCE_INTERNAL, RedfishDiscoverProtocol, EFI_REDFISH_DISCOVER_DATA_SIGNATURE)
+
+//
 // Internal structure used to maintain REST EX properties.
 //
 typedef struct {
-  LIST_ENTRY              Entry;                      ///< Link list entry.
-  EFI_HANDLE              OpenDriverAgentHandle;      ///< The agent to open network protocol.
-  EFI_HANDLE              OpenDriverControllerHandle; ///< The controller handle to open network protocol.
-  EFI_HANDLE              RestExChildHandle;          ///< The child handle created through REST EX Service Protocol.
-  EFI_HANDLE              RestExControllerHandle;     ///< The controller handle which provide REST EX protocol.
-  EFI_REST_EX_PROTOCOL    *RestExProtocolInterface;   ///< Pointer to EFI_REST_EX_PROTOCOL.
-  UINT32                  RestExId;                   ///< The identifier installed on REST EX controller handle.
+  LIST_ENTRY                                Entry;                      ///< Link list entry.
+  UINT32                                    Signature;                  ///< Instance signature.
+  EFI_HANDLE                                OpenDriverAgentHandle;      ///< The agent to open network protocol.
+  EFI_HANDLE                                OpenDriverControllerHandle; ///< The controller handle to open network protocol.
+  EFI_HANDLE                                RestExChildHandle;          ///< The child handle created through REST EX Service Protocol.
+  EFI_HANDLE                                RestExControllerHandle;     ///< The controller handle which provide REST EX protocol.
+  EFI_REST_EX_PROTOCOL                      *RestExProtocolInterface;   ///< Pointer to EFI_REST_EX_PROTOCOL.
+  UINT32                                    RestExId;                   ///< The identifier installed on REST EX controller handle.
+  UINTN                                     NumberOfNetworkInterfaces;  ///< Number of network interfaces can do Redfish service discovery.
+  EFI_REDFISH_DISCOVER_NETWORK_INTERFACE    *NetworkInterfaceInstances; ///< Network interface instances. It's an array of instances. The number of entries
+                                                                        ///< in array is indicated by NumberOfNetworkInterfaces.
+  EFI_REDFISH_DISCOVER_PROTOCOL             RedfishDiscoverProtocol;    ///< EFI_REDFISH_DISCOVER_PROTOCOL protocol.
 } EFI_REDFISH_DISCOVER_REST_EX_INSTANCE_INTERNAL;
 
 /**


### PR DESCRIPTION
gRedfishDiscoveredToken may be allocated several times, if multiple NIC installed on the system.
To avoid this issue Discover Token related global variables replaced with the local variables.

Cc: Abner Chang <abner.chang@amd.com>
Cc: Nickle Wang <nicklew@nvidia.com>
Cc: Igor Kulchytskyy <igork@ami.com>