### PR TITLE
MdeModulePkg/RegularExpressionDxe: Fix Arm build error

### DIFF
--- a/MdeModulePkg/Universal/RegularExpressionDxe/OnigurumaUefiPort.c
+++ b/MdeModulePkg/Universal/RegularExpressionDxe/OnigurumaUefiPort.c
@@ -4,6 +4,7 @@
 
   (C) Copyright 2014-2021 Hewlett Packard Enterprise Development LP<BR>
   Copyright (c) 2020, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
@@ -109,6 +110,7 @@ realloc (
   return NULL;
 }
 
+#if !defined (MDE_CPU_ARM)
 void *
 memcpy (
   void          *dest,
@@ -119,14 +121,16 @@ memcpy (
   return CopyMem (dest, src, (UINTN)count);
 }
 
+#endif
+
 void *
 memset (
   void          *dest,
-  char          ch,
+  int           ch,
   unsigned int  count
   )
 {
-  return SetMem (dest, count, ch);
+  return SetMem (dest, (UINTN)count, (UINT8)ch);
 }
 
 void

--- a/MdeModulePkg/Universal/RegularExpressionDxe/OnigurumaUefiPort.h
+++ b/MdeModulePkg/Universal/RegularExpressionDxe/OnigurumaUefiPort.h
@@ -4,7 +4,7 @@
 
   (C) Copyright 2014-2021 Hewlett Packard Enterprise Development LP<BR>
   Copyright (c) 2020, Intel Corporation. All rights reserved.<BR>
-  Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
@@ -107,6 +107,7 @@ realloc (
   size_t  size
   );
 
+#if !defined (MDE_CPU_ARM)
 void *
 memcpy (
   void          *dest,
@@ -114,10 +115,12 @@ memcpy (
   unsigned int  count
   );
 
+#endif
+
 void *
 memset (
   void          *dest,
-  char          ch,
+  int           ch,
   unsigned int  count
   );
 


### PR DESCRIPTION
Arm CI build error:
- ArmPkg/Library/CompilerIntrinsicsLib/memset.c:39:1: warning: type of ‘memset’ does not match original declaration [-Wlto-type-mismatch] MdeModulePkg/Universal/RegularExpressionDxe/OnigurumaUefiPort.c:123:1: note: type ‘char’ should match type ‘int’
- multiple definition of `memcpy'; OnigurumaUefiPort.obj (symbol from plugin):(.text+0x0): first defined here

Fix:
- Update memset() implementation to match memset() definition in ArmPkg/Library/CompilerIntrinsicsLib.
- memcpy() is supported by ArmPkg/Library/CompilerIntrinsicsLib. Exclude it in OnigurumaUefiPort.c.


Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Nick Ramirez <nramirez@nvidia.com>