### PR TITLE
BaseTools: Add quotes around OBJCOPY cmd in build_rule.template

### DIFF
--- a/BaseTools/Conf/build_rule.template
+++ b/BaseTools/Conf/build_rule.template
@@ -352,12 +352,12 @@
         -$(CP) $(DEBUG_DIR)(+)*.pdb $(OUTPUT_DIR) 
     <Command.GCC>
         $(CP) ${src} $(DEBUG_DIR)(+)$(MODULE_NAME).debug
-        $(OBJCOPY) $(OBJCOPY_STRIPFLAG) ${src}
+        "$(OBJCOPY)" $(OBJCOPY_STRIPFLAG) ${src}
 
         #
         #The below 2 lines are only needed for UNIXGCC tool chain, which generates PE image directly
         #
-        -$(OBJCOPY) $(OBJCOPY_ADDDEBUGFLAG) ${src}
+        -"$(OBJCOPY)" $(OBJCOPY_ADDDEBUGFLAG) ${src}
         -$(CP) $(DEBUG_DIR)(+)$(MODULE_NAME).debug $(BIN_DIR)(+)$(MODULE_NAME_GUID).debug
 
         "$(GENFW)" -e $(MODULE_TYPE) -o ${dst} ${src} $(GENFW_FLAGS)


### PR DESCRIPTION
Add quotes around the OBJCOPY command in build_rule.template to fix the case where LLVM is installed on Windows in a path with spaces such as C:\Program Files\LLVM.