### PR TITLE
ArmPkg/PlatformBootManagerLib: Add path to boot UEFI Shell over UiApp

### DIFF
--- a/ArmPkg/ArmPkg.dec
+++ b/ArmPkg/ArmPkg.dec
@@ -2,7 +2,7 @@
 # ARM processor package.
 #
 # Copyright (c) 2009 - 2010, Apple Inc. All rights reserved.<BR>
-# Copyright (c) 2011 - 2022, ARM Limited. All rights reserved.
+# Copyright (c) 2011 - 2023, ARM Limited. All rights reserved.
 # Copyright (c) 2021, Ampere Computing LLC. All rights reserved.
 #
 #    SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -220,6 +220,13 @@
   # offsets.
   #
   gArmTokenSpaceGuid.PcdArmDmaDeviceOffset|0x0|UINT64|0x0000044
+
+  #
+  # Boot the Uefi Shell instead of UiApp when no valid boot option is found.
+  # This is useful in CI environment so that startup.nsh can be launched.
+  # The default value is FALSE.
+  #
+  gArmTokenSpaceGuid.PcdUefiShellDefaultBootEnable|FALSE|BOOLEAN|0x0000052
 
 [PcdsFixedAtBuild.common, PcdsPatchableInModule.common]
   gArmTokenSpaceGuid.PcdFdBaseAddress|0|UINT64|0x0000002B

--- a/ArmPkg/Library/PlatformBootManagerLib/PlatformBootManagerLib.inf
+++ b/ArmPkg/Library/PlatformBootManagerLib/PlatformBootManagerLib.inf
@@ -2,7 +2,7 @@
 #  Implementation for PlatformBootManagerLib library class interfaces.
 #
 #  Copyright (C) 2015-2016, Red Hat, Inc.
-#  Copyright (c) 2014, ARM Ltd. All rights reserved.<BR>
+#  Copyright (c) 2014 - 2023, Arm Ltd. All rights reserved.<BR>
 #  Copyright (c) 2007 - 2014, Intel Corporation. All rights reserved.<BR>
 #  Copyright (c) 2016, Linaro Ltd. All rights reserved.<BR>
 #
@@ -29,6 +29,7 @@
   PlatformBm.h
 
 [Packages]
+  ArmPkg/ArmPkg.dec
   EmbeddedPkg/EmbeddedPkg.dec
   MdeModulePkg/MdeModulePkg.dec
   MdePkg/MdePkg.dec
@@ -55,6 +56,7 @@
   gEfiMdePkgTokenSpaceGuid.PcdUgaConsumeSupport
 
 [FixedPcd]
+  gArmTokenSpaceGuid.PcdUefiShellDefaultBootEnable
   gEfiMdeModulePkgTokenSpaceGuid.PcdEmuVariableNvModeEnable
   gEfiMdeModulePkgTokenSpaceGuid.PcdFirmwareVersionString
   gEfiMdePkgTokenSpaceGuid.PcdUartDefaultBaudRate


### PR DESCRIPTION
The UEFI Shell is a non-active boot option, at the opposite of UiApp. If no valid boot option is found, UiApp is selected. UiApp requires a human interaction. When installing a new EDKII image in CIs or when scripting is required, this is problematic.

If no valid boot option is discovered, add a path to directly go to the UEFI Shell where the startup.nsh script is automatically executed. The UEFI Shell is launched after connecting possible devices, but before the reset that is meant to automatically make them visible.

The new PcdUefiShellDefaultBootEnable must be set to TRUE to enable this behaviour. The Pcd is set to false by default.