### PR TITLE
UefiCpuPkg/PiSmmCpuDxeSmm: add Ap Rendezvous check in PerformRemainingTasks() when Smm ready to lock.

### DIFF
--- a/UefiCpuPkg/PiSmmCpuDxeSmm/PiSmmCpuDxeSmm.c
+++ b/UefiCpuPkg/PiSmmCpuDxeSmm/PiSmmCpuDxeSmm.c
@@ -1,7 +1,7 @@
 /** @file
 Agent Module to load other modules to deploy SMM Entry Vector for X86 CPU.
 
-Copyright (c) 2009 - 2019, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2009 - 2023, Intel Corporation. All rights reserved.<BR>
 Copyright (c) 2017, AMD Incorporated. All rights reserved.<BR>
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -1441,6 +1441,14 @@ PerformRemainingTasks (
   )
 {
   if (mSmmReadyToLock) {
+    //
+    // Check if all Aps enter SMM. In Relaxed-AP Sync Mode, BSP will not wait for
+    // all Aps arrive. Howawever, SmmReadyToLock needs all Aps to arrive.
+    //
+    if (EFI_ERROR (SmmCpuRendezvous (NULL, TRUE))) {
+      DEBUG ((DEBUG_ERROR, "PerformRemainingTasks: fail to wait for all AP check in SMM!\n"));
+    }
+
     //
     // Start SMM Profile feature
     //


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4424

In Relaxed-AP Sync Mode, BSP will not wait for all Aps arrive. However, SmmReadyToLock needs all Aps to arrive to set memmap Attributes and check config Smm code access in PerformRemainingTasks. 

Cc: Eric Dong <eric.dong@intel.com>
Cc: Ray Ni <ray.ni@intel.com>

Signed-off-by: Zhihao Li <zhihao.li@intel.com>
