### PR TITLE
Fixes for SEV-SNP CC blob and CPUID table handling

### DIFF
--- a/OvmfPkg/AmdSevDxe/AmdSevDxe.c
+++ b/OvmfPkg/AmdSevDxe/AmdSevDxe.c
@@ -28,15 +28,36 @@
 // Present, initialized, tested bits defined in MdeModulePkg/Core/Dxe/DxeMain.h
 #define EFI_MEMORY_INTERNAL_MASK  0x0700000000000000ULL
 
-STATIC CONFIDENTIAL_COMPUTING_SNP_BLOB_LOCATION  mSnpBootDxeTable = {
-  SIGNATURE_32 ('A',                                    'M', 'D', 'E'),
-  1,
-  0,
-  (UINT64)(UINTN)FixedPcdGet32 (PcdOvmfSnpSecretsBase),
-  FixedPcdGet32 (PcdOvmfSnpSecretsSize),
-  (UINT64)(UINTN)FixedPcdGet32 (PcdOvmfCpuidBase),
-  FixedPcdGet32 (PcdOvmfCpuidSize),
-};
+STATIC
+EFI_STATUS
+AllocateConfidentialComputingBlob (
+  OUT CONFIDENTIAL_COMPUTING_SNP_BLOB_LOCATION  **CcBlobPtr
+  )
+{
+  EFI_STATUS                                Status;
+  CONFIDENTIAL_COMPUTING_SNP_BLOB_LOCATION  *CcBlob;
+
+  Status = gBS->AllocatePool (
+                  EfiACPIReclaimMemory,
+                  sizeof (CONFIDENTIAL_COMPUTING_SNP_BLOB_LOCATION),
+                  (VOID **)&CcBlob
+                  );
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  CcBlob->Header                 = SIGNATURE_32 ('A', 'M', 'D', 'E');
+  CcBlob->Version                = 1;
+  CcBlob->Reserved1              = 0;
+  CcBlob->SecretsPhysicalAddress = (UINT64)(UINTN)FixedPcdGet32 (PcdOvmfSnpSecretsBase);
+  CcBlob->SecretsSize            = FixedPcdGet32 (PcdOvmfSnpSecretsSize);
+  CcBlob->CpuidPhysicalAddress   = (UINT64)(UINTN)FixedPcdGet32 (PcdOvmfCpuidBase);
+  CcBlob->CpuidLSize             = FixedPcdGet32 (PcdOvmfCpuidSize);
+
+  *CcBlobPtr = CcBlob;
+
+  return EFI_SUCCESS;
+}
 
 STATIC EFI_HANDLE  mAmdSevDxeHandle = NULL;
 
@@ -175,10 +196,11 @@ AmdSevDxeEntryPoint (
   IN EFI_SYSTEM_TABLE  *SystemTable
   )
 {
-  EFI_STATUS                       Status;
-  EFI_GCD_MEMORY_SPACE_DESCRIPTOR  *AllDescMap;
-  UINTN                            NumEntries;
-  UINTN                            Index;
+  EFI_STATUS                                Status;
+  EFI_GCD_MEMORY_SPACE_DESCRIPTOR           *AllDescMap;
+  UINTN                                     NumEntries;
+  UINTN                                     Index;
+  CONFIDENTIAL_COMPUTING_SNP_BLOB_LOCATION  *SnpBootDxeTable;
 
   //
   // Do nothing when SEV is not enabled
@@ -284,6 +306,18 @@ AmdSevDxeEntryPoint (
     }
   }
 
+  Status = AllocateConfidentialComputingBlob (&SnpBootDxeTable);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: AllocateConfidentialComputingBlob(): %r\n",
+      __func__,
+      Status
+      ));
+    ASSERT (FALSE);
+    CpuDeadLoop ();
+  }
+
   if (MemEncryptSevSnpIsEnabled ()) {
     //
     // Memory acceptance began being required in SEV-SNP, so install the
@@ -321,7 +355,7 @@ AmdSevDxeEntryPoint (
     //
     return gBS->InstallConfigurationTable (
                   &gConfidentialComputingSevSnpBlobGuid,
-                  &mSnpBootDxeTable
+                  SnpBootDxeTable
                   );
   }
 

--- a/OvmfPkg/AmdSevDxe/AmdSevDxe.c
+++ b/OvmfPkg/AmdSevDxe/AmdSevDxe.c
@@ -48,11 +48,13 @@ AllocateConfidentialComputingBlob (
 
   CcBlob->Header                 = SIGNATURE_32 ('A', 'M', 'D', 'E');
   CcBlob->Version                = 1;
-  CcBlob->Reserved1              = 0;
+  CcBlob->Reserved               = 0;
   CcBlob->SecretsPhysicalAddress = (UINT64)(UINTN)FixedPcdGet32 (PcdOvmfSnpSecretsBase);
   CcBlob->SecretsSize            = FixedPcdGet32 (PcdOvmfSnpSecretsSize);
+  CcBlob->Reserved1              = 0;
   CcBlob->CpuidPhysicalAddress   = (UINT64)(UINTN)FixedPcdGet32 (PcdOvmfCpuidBase);
   CcBlob->CpuidLSize             = FixedPcdGet32 (PcdOvmfCpuidSize);
+  CcBlob->Reserved2              = 0;
 
   *CcBlobPtr = CcBlob;
 

--- a/OvmfPkg/Include/Guid/ConfidentialComputingSevSnpBlob.h
+++ b/OvmfPkg/Include/Guid/ConfidentialComputingSevSnpBlob.h
@@ -18,14 +18,16 @@
     { 0x85, 0x54, 0x93, 0xd7, 0x77, 0x91, 0x2d, 0x42 }, \
   }
 
-typedef struct {
+typedef PACKED struct {
   UINT32    Header;
   UINT16    Version;
-  UINT16    Reserved1;
+  UINT16    Reserved;
   UINT64    SecretsPhysicalAddress;
   UINT32    SecretsSize;
+  UINT32    Reserved1;
   UINT64    CpuidPhysicalAddress;
   UINT32    CpuidLSize;
+  UINT32    Reserved2;
 } CONFIDENTIAL_COMPUTING_SNP_BLOB_LOCATION;
 
 extern EFI_GUID  gConfidentialComputingSevSnpBlobGuid;

--- a/OvmfPkg/Library/CcExitLib/CcExitVcHandler.c
+++ b/OvmfPkg/Library/CcExitLib/CcExitVcHandler.c
@@ -1114,8 +1114,6 @@ SnpEnabled (
 
   @param[in]      XFeaturesEnabled  Bit-mask of enabled XSAVE features/areas as
                                     indicated by XCR0/MSR_IA32_XSS bits
-  @param[in]      XSaveBaseSize     Base/legacy XSAVE area size (e.g. when
-                                    XCR0 is 1)
   @param[in, out] XSaveSize         Pointer to storage for calculated XSAVE area
                                     size
   @param[in]      Compacted         Whether or not the calculation is for the
@@ -1130,7 +1128,6 @@ STATIC
 BOOLEAN
 GetCpuidXSaveSize (
   IN     UINT64   XFeaturesEnabled,
-  IN     UINT32   XSaveBaseSize,
   IN OUT UINT32   *XSaveSize,
   IN     BOOLEAN  Compacted
   )
@@ -1139,7 +1136,10 @@ GetCpuidXSaveSize (
   UINT64              XFeaturesFound = 0;
   UINT32              Idx;
 
-  *XSaveSize = XSaveBaseSize;
+  //
+  // The base/legacy XSave size is documented to be 0x240 in the APM.
+  //
+  *XSaveSize = 0x240;
   CpuidInfo  = (SEV_SNP_CPUID_INFO *)(UINT64)PcdGet32 (PcdOvmfCpuidBase);
 
   for (Idx = 0; Idx < CpuidInfo->Count; Idx++) {
@@ -1355,7 +1355,6 @@ GetCpuidFw (
 
     if (!GetCpuidXSaveSize (
            XCr0 | XssMsr.Uint64,
-           *Ebx,
            &XSaveSize,
            Compacted
            ))

--- a/OvmfPkg/Library/CcExitLib/CcExitVcHandler.c
+++ b/OvmfPkg/Library/CcExitLib/CcExitVcHandler.c
@@ -1145,9 +1145,7 @@ GetCpuidXSaveSize (
   for (Idx = 0; Idx < CpuidInfo->Count; Idx++) {
     SEV_SNP_CPUID_FUNCTION  *CpuidFn = &CpuidInfo->function[Idx];
 
-    if (!((CpuidFn->EaxIn == 0xD) &&
-          ((CpuidFn->EcxIn == 0) || (CpuidFn->EcxIn == 1))))
-    {
+    if (!((CpuidFn->EaxIn == 0xD) && (CpuidFn->EcxIn > 1))) {
       continue;
     }
 


### PR DESCRIPTION
From: Michael Roth <michael.roth@amd.com>
Date: 4/26/2023 4:32:54 AM
Subject: [PATCH v2 0/4] Fixes for SEV-SNP CC blob and CPUID table handling

(Mainly a resend of v1, but rolled in Gerd's Acked-by's, addressed
new coding style check in the CI, and updated Cc list)

Here are a number of fixes related to OVMF handling of the SEV-SNP
Confidential Computing blob and CPUID table.

Patch #1 is a fix for recently-reported issue that can cause
significant problems with some SEV-SNP guest operating systems.
Please consider applying this patch directly if the other
patches in this series are held up for any reason.

Patches 2-4 are minor changes for things that aren't currently
triggered in practice, but make OVMF's SEV-SNP implementation more
robust for different build/hypervisor environments in the future.
Patch #2 was submitted previously, but refreshed here to apply
cleanly on top of Patch #1, with no other functional changes since
the initial review.

v2:
 - rebased/retested on latest master
 - replaced usage of __FUNCTION__ with __func__ to comply with new CI
   test cases

----------------------------------------------------------------
Michael Roth (4):
      OvmfPkg/AmdSevDxe: Allocate SEV-SNP CC blob as EfiACPIReclaimMemory
      OvmfPkg/AmdSevDxe: Update ConfidentialComputing blob struct definition
      OvmfPkg/CcExitLib: Fix SEV-SNP XSave area size calculation
      OvmfPkg/CcExitLib: Use documented XSave area base size for SEV-SNP

 OvmfPkg/AmdSevDxe/AmdSevDxe.c                          | 64 ++++++++++++++++++++++++++++++++++++++++++++++++++--------------
 OvmfPkg/Include/Guid/ConfidentialComputingSevSnpBlob.h |  6 ++++--
 OvmfPkg/Library/CcExitLib/CcExitVcHandler.c            | 13 +++++--------
 3 files changed, 59 insertions(+), 24 deletions(-)


