### PR TITLE
SecurityPkg/DxeImageVerificationLib: Add AUTH_SIG_NOT_FOUND Action

### DIFF
--- a/SecurityPkg/Library/DxeImageVerificationLib/DxeImageVerificationLib.c
+++ b/SecurityPkg/Library/DxeImageVerificationLib/DxeImageVerificationLib.c
@@ -1993,6 +1993,7 @@ DxeImageVerificationHandler (
       if (!EFI_ERROR (DbStatus) && IsFound) {
         IsVerified = TRUE;
       } else {
+        Action = EFI_IMAGE_EXECUTION_AUTH_SIG_NOT_FOUND;
         DEBUG ((DEBUG_INFO, "DxeImageVerificationLib: Image is signed but signature is not allowed by DB and %s hash of image is not found in DB/DBX.\n", mHashTypeStr));
       }
     }


### PR DESCRIPTION
Add the AUTH_SIG_NOT_FOUND Action to the Image Execution Info Table when the Image is signed but signature is not allowed by DB and the hash of image is not found in DB/DBX.

This is documented in the UEFI spec 2.10, table 32.5.

This issue is found by the SIE SCT with the error message as follows: SecureBoot - TestImage1.bin in Image Execution Info Table with SIG_NOT_FOUND. --FAILURE
B3A670AA-0FBA-48CA-9D01-0EE9700965A9
SctPkg/TestCase/UEFI/EFI/RuntimeServices/SecureBoot/BlackBoxTest/ ImageLoadingBBTest.c:1079:Status Success


Reviewed-by: Min Xu <min.m.xu@intel.com>
Reviewed-by: Jiewen Yao <jiewen.yao@intel.com>