### PR TITLE
Decoding comments should skip Tag and Length, rather than Tag only.

### DIFF
--- a/CryptoPkg/Library/BaseCryptLib/Pk/CryptAuthenticode.c
+++ b/CryptoPkg/Library/BaseCryptLib/Pk/CryptAuthenticode.c
@@ -136,7 +136,7 @@ AuthenticodeVerify (
     //
     ContentSize = (UINTN)(Asn1Byte & 0x7F);
     //
-    // Skip the SEQUENCE Tag;
+    // Skip the SEQUENCE Tag and the Length;
     //
     SpcIndirectDataContent += 2;
   } else if ((Asn1Byte & 0x81) == 0x81) {
@@ -145,7 +145,7 @@ AuthenticodeVerify (
     //
     ContentSize = (UINTN)(*(UINT8 *)(SpcIndirectDataContent + 2));
     //
-    // Skip the SEQUENCE Tag;
+    // Skip the SEQUENCE Tag and the Length;
     //
     SpcIndirectDataContent += 3;
   } else if ((Asn1Byte & 0x82) == 0x82) {
@@ -155,7 +155,7 @@ AuthenticodeVerify (
     ContentSize = (UINTN)(*(UINT8 *)(SpcIndirectDataContent + 2));
     ContentSize = (ContentSize << 8) + (UINTN)(*(UINT8 *)(SpcIndirectDataContent + 3));
     //
-    // Skip the SEQUENCE Tag;
+    // Skip the SEQUENCE Tag and the Length;
     //
     SpcIndirectDataContent += 4;
   } else {


### PR DESCRIPTION
Actually, in CryptAuthenticode.c
```
SpcIndirectDataContent += 2;
SpcIndirectDataContent += 3;
SpcIndirectDataContent += 4;
```
will skip Tag and Length fields simultaneously, rather then just skip Tag.
Hence, these related comments were modified for easier tracing thereafter.