### PR TITLE
Bug 4392 add fdt lib v7

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -26,3 +26,6 @@
 [submodule "UnitTestFrameworkPkg/Library/SubhookLib/subhook"]
 	path = UnitTestFrameworkPkg/Library/SubhookLib/subhook
 	url = https://github.com/Zeex/subhook.git
+[submodule "MdePkg/Library/BaseFdtLib/libfdt"]
+	path = MdePkg/Library/BaseFdtLib/libfdt
+	url = https://github.com/devicetree-org/pylibfdt.git

--- a/.pytool/CISettings.py
+++ b/.pytool/CISettings.py
@@ -195,6 +195,8 @@ class Settings(CiBuildSettingsManager, UpdateSettingsManager, SetupSettingsManag
             "RedfishPkg/Library/JsonLib/jansson", False))
         rs.append(RequiredSubmodule(
             "UnitTestFrameworkPkg/Library/SubhookLib/subhook", False))
+        rs.append(RequiredSubmodule(
+            "MdePkg/Library/BaseFdtLib/libfdt", False))
         return rs
 
     def GetName(self):

--- a/MdePkg/Include/Library/FdtLib.h
+++ b/MdePkg/Include/Library/FdtLib.h
@@ -1,0 +1,401 @@
+/** @file
+  Flattened Device Tree Library.
+
+  All structure data are in big-endian format.
+  Functions are provided for converting data between
+  little-endian and big-endian.
+  For example:
+  Pushing data to FDT blob needs to convert data to
+  big-endian by CpuToFdt*().
+  Retrieving data from FDT blob needs to convert data to
+  little-endian by Fdt*ToCpu().
+  Refer to FDT specification: https://www.devicetree.org/specifications/
+
+  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef FDT_LIB_H_
+#define FDT_LIB_H_
+
+/**
+  Flattened Device Tree definition
+
+  The Devicetree Blob (DTB) format is a binary encoding with big-endian.
+  When producing or consuming the blob data, CpuToFdt*() or Fdt*ToCpu()
+  provided by this library may be called to convert data between
+  big-endian and little-endian.
+**/
+typedef struct {
+  UINT32    Magic;               /* magic word FDT_MAGIC */
+  UINT32    TotalSize;           /* total size of DT block */
+  UINT32    OffsetDtStruct;      /* offset to structure */
+  UINT32    OffsetDtStrings;     /* offset to strings */
+  UINT32    OffsetMemRsvmap;     /* offset to memory reserve map */
+  UINT32    Version;             /* format version */
+  UINT32    LastCompVersion;     /* last compatible version */
+
+  /* version 2 fields below */
+  UINT32    BootCpuidPhys;       /* Which physical CPU id we're
+                                    booting on */
+  /* version 3 fields below */
+  UINT32    SizeDtStrings;       /* size of the strings block */
+
+  /* version 17 fields below */
+  UINT32    SizeDtStruct;        /* size of the structure block */
+} FDT_HEADER;
+
+typedef struct {
+  UINT64    Address;
+  UINT64    Size;
+} FDT_RESERVE_ENTRY;
+
+typedef struct {
+  UINT32    Tag;
+  CHAR8     Name[];
+} FDT_NODE_HEADER;
+
+typedef struct {
+  UINT32    Tag;
+  UINT32    Length;
+  UINT32    NameOffset;
+  CHAR8     Data[];
+} FDT_PROPERTY;
+
+/**
+  Convert UINT16 data of the FDT blob to little-endian
+
+  @param[in] Value            The value to the blob data.
+
+  @return The value to be converted to little-endian.
+
+**/
+UINT16
+EFIAPI
+Fdt16ToCpu (
+  IN UINT16  Value
+  );
+
+/**
+  Convert UINT16 data to big-endian for aligned with the FDT blob
+
+  @param[in] Value            The value to align with the FDT blob.
+
+  @return The value to be converted to big-endian.
+
+**/
+UINT16
+EFIAPI
+CpuToFdt16 (
+  IN UINT16  Value
+  );
+
+/**
+  Convert UINT32 data of the FDT blob to little-endian
+
+  @param[in] Value            The value to the blob data.
+
+  @return The value to be converted to little-endian.
+
+**/
+UINT32
+EFIAPI
+Fdt32ToCpu (
+  IN UINT32  Value
+  );
+
+/**
+  Convert UINT32 data to big-endian for aligned with the FDT blob
+
+  @param[in] Value            The value to align with the FDT blob.
+
+  @return The value to be converted to big-endian.
+
+**/
+UINT32
+EFIAPI
+CpuToFdt32 (
+  IN UINT32  Value
+  );
+
+/**
+  Convert UINT64 data of the FDT blob to little-endian
+
+  @param[in] Value            The value to the blob data.
+
+  @return The value to be converted to little-endian.
+
+**/
+UINT64
+EFIAPI
+Fdt64ToCpu (
+  IN UINT64  Value
+  );
+
+/**
+  Convert UINT64 data to big-endian for aligned with the FDT blob
+
+  @param[in] Value            The value to align with the FDT blob.
+
+  @return The value to be converted to big-endian.
+
+**/
+UINT64
+EFIAPI
+CpuToFdt64 (
+  IN UINT64  Value
+  );
+
+/**
+  Verify the header of the Flattened Device Tree
+
+  @param[in] Fdt            The pointer to FDT blob.
+
+  @return Zero for successfully, otherwise failed.
+
+**/
+INT32
+EFIAPI
+FdtCheckHeader (
+  IN CONST VOID  *Fdt
+  );
+
+/**
+  Create a empty Flattened Device Tree.
+
+  @param[in] Buffer         The pointer to allocate a pool for FDT blob.
+  @param[in] BufferSize     The BufferSize to the pool size.
+
+  @return Zero for successfully, otherwise failed.
+
+**/
+INT32
+EFIAPI
+FdtCreateEmptyTree (
+  IN VOID    *Buffer,
+  IN UINT32  BufferSize
+  );
+
+/**
+  Returns a offset of next node from the given node.
+
+  @param[in] Fdt            The pointer to FDT blob.
+  @param[in] Offset         The offset to previous node.
+  @param[in] Depth          The depth to the level of tree hierarchy.
+
+  @return The offset to next node offset.
+
+**/
+INT32
+EFIAPI
+FdtNextNode (
+  IN CONST VOID  *Fdt,
+  IN INT32       Offset,
+  IN INT32       *Depth
+  );
+
+/**
+  Returns a offset of first node under the given node.
+
+  @param[in] Fdt            The pointer to FDT blob.
+  @param[in] Offset         The offset to previous node.
+
+  @return The offset to next node offset.
+
+**/
+INT32
+EFIAPI
+FdtFirstSubnode (
+  IN CONST VOID  *Fdt,
+  IN INT32       Offset
+  );
+
+/**
+  Returns a offset of next node from the given node.
+
+  @param[in] Fdt            The pointer to FDT blob.
+  @param[in] Offset         The offset to previous node.
+
+  @return The offset to next node offset.
+
+**/
+INT32
+EFIAPI
+FdtNextSubnode (
+  IN CONST VOID  *Fdt,
+  IN INT32       Offset
+  );
+
+/**
+  Returns a offset of first node which includes the given name.
+
+  @param[in] Fdt             The pointer to FDT blob.
+  @param[in] ParentOffset    The offset to the node which start find under.
+  @param[in] Name            The name to search the node with the name.
+  @param[in] NameLength      The length of the name to check only.
+
+  @return The offset to node offset with given node name.
+
+**/
+INT32
+EFIAPI
+FdtSubnodeOffsetNameLen (
+  IN CONST VOID   *Fdt,
+  IN INT32        ParentOffset,
+  IN CONST CHAR8  *Name,
+  IN INT32        NameLength
+  );
+
+/**
+  Returns a offset of first node which includes the given property name and value.
+
+  @param[in] Fdt             The pointer to FDT blob.
+  @param[in] StartOffset     The offset to the starting node to find.
+  @param[in] PropertyName    The property name to search the node including the named property.
+  @param[in] PropertyValue   The property value (big-endian) to check the same property value.
+  @param[in] PropertyLength  The length of the value in PropertValue.
+
+  @return The offset to node offset with given property.
+
+**/
+INT32
+EFIAPI
+FdtNodeOffsetByPropValue (
+  IN CONST VOID   *Fdt,
+  IN INT32        StartOffset,
+  IN CONST CHAR8  *PropertyName,
+  IN CONST VOID   *PropertyValue,
+  IN INT32        PropertyLength
+  );
+
+/**
+  Returns a property with the given name from the given node.
+
+  @param[in] Fdt            The pointer to FDT blob.
+  @param[in] NodeOffset     The offset to the given node.
+  @param[in] Name           The name to the property which need be searched
+  @param[in] Length         The length to the size of the property found.
+
+  @return The property to the structure of the found property. Since the data
+          come from FDT blob, it's encoding with big-endian.
+
+**/
+CONST FDT_PROPERTY *
+EFIAPI
+FdtGetProperty (
+  IN CONST VOID   *Fdt,
+  IN INT32        NodeOffset,
+  IN CONST CHAR8  *Name,
+  IN INT32        *Length
+  );
+
+/**
+  Returns a offset of first property in the given node.
+
+  @param[in] Fdt            The pointer to FDT blob.
+  @param[in] NodeOffset     The offset to the node which need be searched.
+
+  @return The offset to first property offset in the given node.
+
+**/
+INT32
+EFIAPI
+FdtFirstPropertyOffset (
+  IN CONST VOID  *Fdt,
+  IN INT32       NodeOffset
+  );
+
+/**
+  Returns a offset of next property from the given property.
+
+  @param[in] Fdt            The pointer to FDT blob.
+  @param[in] Offset         The offset to previous property.
+
+  @return The offset to next property offset.
+
+**/
+INT32
+EFIAPI
+FdtNextPropertyOffset (
+  IN CONST VOID  *Fdt,
+  IN INT32       Offset
+  );
+
+/**
+  Returns a property from the given offset of the property.
+
+  @param[in] Fdt            The pointer to FDT blob.
+  @param[in] Offset         The offset to the given offset of the property.
+  @param[in] Length         The length to the size of the property found.
+
+  @return The property to the structure of the given property offset.
+
+**/
+CONST FDT_PROPERTY *
+EFIAPI
+FdtGetPropertyByOffset (
+  IN CONST VOID  *Fdt,
+  IN INT32       Offset,
+  IN INT32       *Length
+  );
+
+/**
+  Returns a string by the given string offset.
+
+  @param[in] Fdt            The pointer to FDT blob.
+  @param[in] StrOffset      The offset to the location in the strings block of FDT.
+  @param[in] Length         The length to the size of string which need be retrieved.
+
+  @return The string to the given string offset.
+
+**/
+CONST CHAR8 *
+EFIAPI
+FdtGetString (
+  IN CONST VOID  *Fdt,
+  IN INT32       StrOffset,
+  IN INT32       *Length        OPTIONAL
+  );
+
+/**
+  Add a new node to the FDT.
+
+  @param[in] Fdt            The pointer to FDT blob.
+  @param[in] ParentOffset   The offset to the node offset which want to add in.
+  @param[in] Name           The name to name the node.
+
+  @return  The offset to the new node.
+
+**/
+INT32
+EFIAPI
+FdtAddSubnode (
+  IN VOID         *Fdt,
+  IN INT32        ParentOffset,
+  IN CONST CHAR8  *Name
+  );
+
+/**
+  Add or modify a property in the given node.
+
+  @param[in] Fdt            The pointer to FDT blob.
+  @param[in] NodeOffset     The offset to the node offset which want to add in.
+  @param[in] Name           The name to name the property.
+  @param[in] Value          The value (big-endian) to the property value.
+  @param[in] Length         The length to the size of the property.
+
+  @return  Zero for successfully, otherwise failed.
+
+**/
+INT32
+EFIAPI
+FdtSetProp (
+  IN VOID         *Fdt,
+  IN INT32        NodeOffset,
+  IN CONST CHAR8  *Name,
+  IN CONST VOID   *Value,
+  IN UINT32       Length
+  );
+
+#endif /* FDT_LIB_H_ */

--- a/MdePkg/Library/BaseFdtLib/BaseFdtLib.inf
+++ b/MdePkg/Library/BaseFdtLib/BaseFdtLib.inf
@@ -1,0 +1,62 @@
+## @file
+# Flattened Device Tree Library.
+#
+# Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x0001001B
+  BASE_NAME                      = BaseFdtLib
+  MODULE_UNI_FILE                = BaseFdtLib.uni
+  FILE_GUID                      = C64DCB01-B037-4FF6-9CF3-E8CEC206DE04
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = FdtLib
+
+  DEFINE FDT_LIB_PATH            = libfdt/libfdt
+
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  FdtLib.c
+  LibFdtWrapper.c
+  # header Wrapper files
+  limits.h
+  stdbool.h
+  stddef.h
+  stdint.h
+  stdlib.h
+  string.h
+
+  $(FDT_LIB_PATH)/fdt.c
+  $(FDT_LIB_PATH)/fdt.h
+  $(FDT_LIB_PATH)/fdt_addresses.c
+  $(FDT_LIB_PATH)/fdt_check.c
+  $(FDT_LIB_PATH)/fdt_empty_tree.c
+  $(FDT_LIB_PATH)/fdt_overlay.c
+  $(FDT_LIB_PATH)/fdt_ro.c
+  $(FDT_LIB_PATH)/fdt_rw.c
+  $(FDT_LIB_PATH)/fdt_strerror.c
+  $(FDT_LIB_PATH)/fdt_sw.c
+  $(FDT_LIB_PATH)/fdt_wip.c
+  $(FDT_LIB_PATH)/libfdt.h
+  $(FDT_LIB_PATH)/libfdt_env.h
+  $(FDT_LIB_PATH)/libfdt_internal.h
+
+[Packages]
+  MdePkg/MdePkg.dec
+
+[LibraryClasses]
+  BaseLib
+  BaseMemoryLib
+
+[BuildOptions]
+  MSFT:*_*_IA32_CC_FLAGS = /wd4146 /wd4245
+  MSFT:*_*_X64_CC_FLAGS  = /wd4146 /wd4244 /wd4245 /wd4267
+

--- a/MdePkg/Library/BaseFdtLib/BaseFdtLib.uni
+++ b/MdePkg/Library/BaseFdtLib/BaseFdtLib.uni
@@ -1,0 +1,14 @@
+// /** @file
+// Flattened Device Tree Library.
+//
+// Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+// **/
+
+
+#string STR_MODULE_ABSTRACT             #language en-US "Instance of FDT Library"
+
+#string STR_MODULE_DESCRIPTION          #language en-US "This module provides FDT Library implementation."
+

--- a/MdePkg/Library/BaseFdtLib/FdtLib.c
+++ b/MdePkg/Library/BaseFdtLib/FdtLib.c
@@ -1,0 +1,404 @@
+/** @file
+  Flattened Device Tree Library.
+
+  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <libfdt/libfdt/libfdt.h>
+
+/**
+  Convert UINT16 data of the FDT blob to little-endian
+
+  @param[in] Value            The value to the blob data.
+
+  @return The value to be converted to little-endian.
+
+**/
+UINT16
+EFIAPI
+Fdt16ToCpu (
+  IN UINT16  Value
+  )
+{
+  return fdt16_to_cpu (Value);
+}
+
+/**
+  Convert UINT16 data to big-endian for aligned with the FDT blob
+
+  @param[in] Value            The value to align with the FDT blob.
+
+  @return The value to be converted to big-endian.
+
+**/
+UINT16
+EFIAPI
+CpuToFdt16 (
+  IN UINT16  Value
+  )
+{
+  return cpu_to_fdt16 (Value);
+}
+
+/**
+  Convert UINT32 data of the FDT blob to little-endian
+
+  @param[in] Value            The value to the blob data.
+
+  @return The value to be converted to little-endian.
+
+**/
+UINT32
+EFIAPI
+Fdt32ToCpu (
+  IN UINT32  Value
+  )
+{
+  return fdt32_to_cpu (Value);
+}
+
+/**
+  Convert UINT32 data to big-endian for aligned with the FDT blob
+
+  @param[in] Value            The value to align with the FDT blob.
+
+  @return The value to be converted to big-endian.
+
+**/
+UINT32
+EFIAPI
+CpuToFdt32 (
+  IN UINT32  Value
+  )
+{
+  return cpu_to_fdt32 (Value);
+}
+
+/**
+  Convert UINT64 data of the FDT blob to little-endian
+
+  @param[in] Value            The value to the blob data.
+
+  @return The value to be converted to little-endian.
+
+**/
+UINT64
+EFIAPI
+Fdt64ToCpu (
+  IN UINT64  Value
+  )
+{
+  return fdt64_to_cpu (Value);
+}
+
+/**
+  Convert UINT64 data to big-endian for aligned with the FDT blob
+
+  @param[in] Value            The value to align with the FDT blob.
+
+  @return The value to be converted to big-endian.
+
+**/
+UINT64
+EFIAPI
+CpuToFdt64 (
+  IN UINT64  Value
+  )
+{
+  return cpu_to_fdt64 (Value);
+}
+
+/**
+  Verify the header of the Flattened Device Tree
+
+  @param[in] Fdt            The pointer to FDT blob.
+
+  @return Zero for successfully, otherwise failed.
+
+**/
+INT32
+EFIAPI
+FdtCheckHeader (
+  IN CONST VOID  *Fdt
+  )
+{
+  return fdt_check_header (Fdt);
+}
+
+/**
+  Create a empty Flattened Device Tree.
+
+  @param[in] Buffer         The pointer to allocate a pool for FDT blob.
+  @param[in] BufferSize     The BufferSize to the pool size.
+
+  @return Zero for successfully, otherwise failed.
+
+**/
+INT32
+EFIAPI
+FdtCreateEmptyTree (
+  IN VOID    *Buffer,
+  IN UINT32  BufferSize
+  )
+{
+  return fdt_create_empty_tree (Buffer, (int)BufferSize);
+}
+
+/**
+  Returns a offset of next node from the given node.
+
+  @param[in] Fdt            The pointer to FDT blob.
+  @param[in] Offset         The offset to previous node.
+  @param[in] Depth          The depth to the level of tree hierarchy.
+
+  @return The offset to next node offset.
+
+**/
+INT32
+EFIAPI
+FdtNextNode (
+  IN CONST VOID  *Fdt,
+  IN INT32       Offset,
+  IN INT32       *Depth
+  )
+{
+  return fdt_next_node (Fdt, Offset, Depth);
+}
+
+/**
+  Returns a offset of first node under the given node.
+
+  @param[in] Fdt            The pointer to FDT blob.
+  @param[in] Offset         The offset to previous node.
+
+  @return The offset to next node offset.
+
+**/
+INT32
+EFIAPI
+FdtFirstSubnode (
+  IN CONST VOID  *Fdt,
+  IN INT32       Offset
+  )
+{
+  return fdt_first_subnode (Fdt, Offset);
+}
+
+/**
+  Returns a offset of next node from the given node.
+
+  @param[in] Fdt            The pointer to FDT blob.
+  @param[in] Offset         The offset to previous node.
+
+  @return The offset to next node offset.
+
+**/
+INT32
+EFIAPI
+FdtNextSubnode (
+  IN CONST VOID  *Fdt,
+  IN INT32       Offset
+  )
+{
+  return fdt_next_subnode (Fdt, Offset);
+}
+
+/**
+  Returns a offset of first node which includes the given name.
+
+  @param[in] Fdt             The pointer to FDT blob.
+  @param[in] ParentOffset    The offset to the node which start find under.
+  @param[in] Name            The name to search the node with the name.
+  @param[in] NameLength      The length of the name to check only.
+
+  @return The offset to node offset with given node name.
+
+**/
+INT32
+EFIAPI
+FdtSubnodeOffsetNameLen (
+  IN CONST VOID   *Fdt,
+  IN INT32        ParentOffset,
+  IN CONST CHAR8  *Name,
+  IN INT32        NameLength
+  )
+{
+  return fdt_subnode_offset_namelen (Fdt, ParentOffset, Name, NameLength);
+}
+
+/**
+  Returns a offset of first node which includes the given property name and value.
+
+  @param[in] Fdt             The pointer to FDT blob.
+  @param[in] StartOffset     The offset to the starting node to find.
+  @param[in] PropertyName    The property name to search the node including the named property.
+  @param[in] PropertyValue   The property value (big-endian) to check the same property value.
+  @param[in] PropertyLength  The length of the value in PropertValue.
+
+  @return The offset to node offset with given property.
+
+**/
+INT32
+EFIAPI
+FdtNodeOffsetByPropValue (
+  IN CONST VOID   *Fdt,
+  IN INT32        StartOffset,
+  IN CONST CHAR8  *PropertyName,
+  IN CONST VOID   *PropertyValue,
+  IN INT32        PropertyLength
+  )
+{
+  return fdt_node_offset_by_prop_value (Fdt, StartOffset, PropertyName, PropertyValue, PropertyLength);
+}
+
+/**
+  Returns a property with the given name from the given node.
+
+  @param[in] Fdt            The pointer to FDT blob.
+  @param[in] NodeOffset     The offset to the given node.
+  @param[in] Name           The name to the property which need be searched
+  @param[in] Length         The length to the size of the property found.
+
+  @return The property to the structure of the found property. Since the data
+          come from FDT blob, it's encoding with big-endian.
+
+**/
+CONST struct fdt_property *
+EFIAPI
+FdtGetProperty (
+  IN CONST VOID   *Fdt,
+  IN INT32        NodeOffset,
+  IN CONST CHAR8  *Name,
+  IN INT32        *Length
+  )
+{
+  return fdt_get_property (Fdt, NodeOffset, Name, Length);
+}
+
+/**
+  Returns a offset of first property in the given node.
+
+  @param[in] Fdt            The pointer to FDT blob.
+  @param[in] NodeOffset     The offset to the node which need be searched.
+
+  @return The offset to first property offset in the given node.
+
+**/
+INT32
+EFIAPI
+FdtFirstPropertyOffset (
+  IN CONST VOID  *Fdt,
+  IN INT32       NodeOffset
+  )
+{
+  return fdt_first_property_offset (Fdt, NodeOffset);
+}
+
+/**
+  Returns a offset of next property from the given property.
+
+  @param[in] Fdt            The pointer to FDT blob.
+  @param[in] Offset         The offset to previous property.
+
+  @return The offset to next property offset.
+
+**/
+INT32
+EFIAPI
+FdtNextPropertyOffset (
+  IN CONST VOID  *Fdt,
+  IN INT32       Offset
+  )
+{
+  return fdt_next_property_offset (Fdt, Offset);
+}
+
+/**
+  Returns a property from the given offset of the property.
+
+  @param[in] Fdt            The pointer to FDT blob.
+  @param[in] Offset         The offset to the given offset of the property.
+  @param[in] Length         The length to the size of the property found.
+
+  @return The property to the structure of the given property offset.
+
+**/
+CONST struct fdt_property *
+EFIAPI
+FdtGetPropertyByOffset (
+  IN CONST VOID  *Fdt,
+  IN INT32       Offset,
+  IN INT32       *Length
+  )
+{
+  return fdt_get_property_by_offset (Fdt, Offset, Length);
+}
+
+/**
+  Returns a string by the given string offset.
+
+  @param[in] Fdt            The pointer to FDT blob.
+  @param[in] StrOffset      The offset to the location in the strings block of FDT.
+  @param[in] Length         The length to the size of string which need be retrieved.
+
+  @return The string to the given string offset.
+
+**/
+CONST CHAR8 *
+EFIAPI
+FdtGetString (
+  IN CONST VOID  *Fdt,
+  IN INT32       StrOffset,
+  IN INT32       *Length        OPTIONAL
+  )
+{
+  return fdt_get_string (Fdt, StrOffset, Length);
+}
+
+/**
+  Add a new node to the FDT.
+
+  @param[in] Fdt            The pointer to FDT blob.
+  @param[in] ParentOffset   The offset to the node offset which want to add in.
+  @param[in] Name           The name to name the node.
+
+  @return  The offset to the new node.
+
+**/
+INT32
+EFIAPI
+FdtAddSubnode (
+  IN VOID         *Fdt,
+  IN INT32        ParentOffset,
+  IN CONST CHAR8  *Name
+  )
+{
+  return fdt_add_subnode (Fdt, ParentOffset, Name);
+}
+
+/**
+  Add or modify a property in the given node.
+
+  @param[in] Fdt            The pointer to FDT blob.
+  @param[in] NodeOffset     The offset to the node offset which want to add in.
+  @param[in] Name           The name to name the property.
+  @param[in] Value          The value (big-endian) to the property value.
+  @param[in] Length         The length to the size of the property.
+
+  @return  Zero for successfully, otherwise failed.
+
+**/
+INT32
+EFIAPI
+FdtSetProp (
+  IN VOID         *Fdt,
+  IN INT32        NodeOffset,
+  IN CONST CHAR8  *Name,
+  IN CONST VOID   *Value,
+  IN UINT32       Length
+  )
+{
+  return fdt_setprop (Fdt, NodeOffset, Name, Value, (int)Length);
+}

--- a/MdePkg/Library/BaseFdtLib/LibFdtSupport.h
+++ b/MdePkg/Library/BaseFdtLib/LibFdtSupport.h
@@ -1,0 +1,99 @@
+/** @file
+  Root include file of C runtime library to support building the third-party
+  libfdt library.
+
+  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef FDT_LIB_SUPPORT_H_
+#define FDT_LIB_SUPPORT_H_
+
+#include <Base.h>
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+
+typedef UINT8    uint8_t;
+typedef UINT16   uint16_t;
+typedef INT32    int32_t;
+typedef UINT32   uint32_t;
+typedef UINT64   uint64_t;
+typedef UINTN    uintptr_t;
+typedef UINTN    size_t;
+typedef BOOLEAN  bool;
+
+#define true   (1 == 1)
+#define false  (1 == 0)
+
+//
+// Definitions for global constants used by libfdt library routines
+//
+#define INT_MAX     0x7FFFFFFF           /* Maximum (signed) int value */
+#define INT32_MAX   0x7FFFFFFF           /* Maximum (signed) int32 value */
+#define UINT32_MAX  0xFFFFFFFF           /* Maximum unsigned int32 value */
+
+//
+// Function prototypes of libfdt Library routines
+//
+void *
+memset     (
+  void *,
+  int,
+  size_t
+  );
+
+int
+memcmp      (
+  const void *,
+  const void *,
+  size_t
+  );
+
+int
+strcmp      (
+  const char *,
+  const char *
+  );
+
+char *
+strchr     (
+  const char *,
+  int
+  );
+
+char *
+strrchr    (
+  const char *,
+  int
+  );
+
+unsigned long
+strtoul     (
+  const char *,
+  char **,
+  int
+  );
+
+char *
+strcpy (
+  char        *strDest,
+  const char  *strSource
+  );
+
+//
+// Macros that directly map functions to BaseLib, BaseMemoryLib, and DebugLib functions
+//
+#define memcpy(dest, source, count)         CopyMem(dest,source, (UINTN)(count))
+#define memset(dest, ch, count)             SetMem(dest, (UINTN)(count),(UINT8)(ch))
+#define memchr(buf, ch, count)              ScanMem8(buf, (UINTN)(count),(UINT8)ch)
+#define memcmp(buf1, buf2, count)           (int)(CompareMem(buf1, buf2, (UINTN)(count)))
+#define memmove(dest, source, count)        CopyMem(dest, source, (UINTN)(count))
+#define strlen(str)                         (size_t)(AsciiStrLen(str))
+#define strnlen(str, count)                 (size_t)(AsciiStrnLenS(str, count))
+#define strncpy(strDest, strSource, count)  AsciiStrnCpyS(strDest, MAX_STRING_SIZE, strSource, (UINTN)count)
+#define strcat(strDest, strSource)          AsciiStrCatS(strDest, MAX_STRING_SIZE, strSource)
+#define strcmp(string1, string2, count)     (int)(AsciiStrCmp(string1, string2))
+#define strncmp(string1, string2, count)    (int)(AsciiStrnCmp(string1, string2, (UINTN)(count)))
+
+#endif /* FDT_LIB_SUPPORT_H_ */

--- a/MdePkg/Library/BaseFdtLib/LibFdtWrapper.c
+++ b/MdePkg/Library/BaseFdtLib/LibFdtWrapper.c
@@ -1,0 +1,173 @@
+/** @file
+  ISO C implementations of strchr, strrchr and strtoul.
+
+  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2023 Pedro Falcato All rights reserved.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Base.h>
+
+#define ULONG_MAX  0xFFFFFFFF            /* Maximum unsigned long value */
+
+// Very quick notes:
+// We only go through the string once for both functions
+// They are minimal implementations (not speed optimized) of ISO C semantics
+// strchr and strrchr also include the null terminator as part of the string
+// so the code gets a bit clunky to handle that case specifically.
+
+char *
+strchr (
+  const char  *Str,
+  int         Char
+  )
+{
+  char  *S;
+
+  S = (char *)Str;
+
+  for ( ; ; S++) {
+    if (*S == Char) {
+      return S;
+    }
+
+    if (*S == '\0') {
+      return NULL;
+    }
+  }
+}
+
+char *
+strrchr (
+  const char  *Str,
+  int         Char
+  )
+{
+  char  *S, *last;
+
+  S    = (char *)Str;
+  last = NULL;
+
+  for ( ; ; S++) {
+    if (*S == Char) {
+      last = S;
+    }
+
+    if (*S == '\0') {
+      return last;
+    }
+  }
+}
+
+STATIC
+int
+__isspace (
+  int  ch
+  )
+{
+  // basic ASCII ctype.h:isspace(). Not efficient
+  return ch == '\r' || ch == '\n' || ch == ' ' || ch == '\t' || ch == '\v' || ch == '\f';
+}
+
+unsigned long
+strtoul (
+  const char  *Nptr,
+  char        **EndPtr,
+  int         Base
+  )
+{
+  BOOLEAN        Negate;
+  BOOLEAN        Overflow;
+  unsigned long  Val;
+
+  Negate   = FALSE;
+  Overflow = FALSE;
+  Val      = 0;
+
+  // Reject bad numeric bases
+  if ((Base < 0) || (Base == 1) || (Base > 36)) {
+    return 0;
+  }
+
+  // Skip whitespace
+  while (__isspace (*Nptr)) {
+    Nptr++;
+  }
+
+  // Check for + or - prefixes
+  if (*Nptr == '-') {
+    Negate = TRUE;
+    Nptr++;
+  } else if (*Nptr == '+') {
+    Nptr++;
+  }
+
+  // Consume the start, autodetecting base if needed
+  if ((Nptr[0] == '0') && ((Nptr[1] == 'x') || (Nptr[1] == 'X')) && ((Base == 0) || (Base == 16))) {
+    // Hex
+    Nptr += 2;
+    Base  = 16;
+  } else if ((Nptr[0] == '0') && ((Nptr[1] == 'b') || (Nptr[1] == 'B')) && ((Base == 0) || (Base == 2))) {
+    // Binary (standard pending C23)
+    Nptr += 2;
+    Base  = 2;
+  } else if ((Nptr[0] == '0') && ((Base == 0) || (Base == 8))) {
+    // Octal
+    Nptr++;
+    Base = 8;
+  } else {
+    if (Base == 0) {
+      // Assume decimal
+      Base = 10;
+    }
+  }
+
+  while (TRUE) {
+    int            Digit;
+    char           C;
+    unsigned long  NewVal;
+
+    C     = *Nptr;
+    Digit = -1;
+
+    if ((C >= '0') && (C <= '9')) {
+      Digit = C - '0';
+    } else if ((C >= 'a') && (C <= 'z')) {
+      Digit = C - 'a' + 10;
+    } else if ((C >= 'A') && (C <= 'Z')) {
+      Digit = C - 'A' + 10;
+    }
+
+    if ((Digit == -1) || (Digit >= Base)) {
+      // Note that this case also handles the \0
+      if (EndPtr) {
+        *EndPtr = (char *)Nptr;
+      }
+
+      break;
+    }
+
+    NewVal = Val * Base + Digit;
+
+    if (NewVal < Val) {
+      // Overflow
+      Overflow = TRUE;
+    }
+
+    Val = NewVal;
+
+    Nptr++;
+  }
+
+  if (Negate) {
+    Val = -Val;
+  }
+
+  if (Overflow) {
+    Val = ULONG_MAX;
+  }
+
+  // TODO: We're lacking errno here.
+  return Val;
+}

--- a/MdePkg/Library/BaseFdtLib/limits.h
+++ b/MdePkg/Library/BaseFdtLib/limits.h
@@ -1,0 +1,10 @@
+/** @file
+  Include file to support building the third-party libfdt library.
+
+Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <LibFdtSupport.h>
+

--- a/MdePkg/Library/BaseFdtLib/stdbool.h
+++ b/MdePkg/Library/BaseFdtLib/stdbool.h
@@ -1,0 +1,10 @@
+/** @file
+  Include file to support building the third-party libfdt library.
+
+Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <LibFdtSupport.h>
+

--- a/MdePkg/Library/BaseFdtLib/stddef.h
+++ b/MdePkg/Library/BaseFdtLib/stddef.h
@@ -1,0 +1,10 @@
+/** @file
+  Include file to support building the third-party libfdt library.
+
+Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <LibFdtSupport.h>
+

--- a/MdePkg/Library/BaseFdtLib/stdint.h
+++ b/MdePkg/Library/BaseFdtLib/stdint.h
@@ -1,0 +1,10 @@
+/** @file
+  Include file to support building the third-party libfdt library.
+
+Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <LibFdtSupport.h>
+

--- a/MdePkg/Library/BaseFdtLib/stdlib.h
+++ b/MdePkg/Library/BaseFdtLib/stdlib.h
@@ -1,0 +1,10 @@
+/** @file
+  Include file to support building the third-party libfdt library.
+
+Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <LibFdtSupport.h>
+

--- a/MdePkg/Library/BaseFdtLib/string.h
+++ b/MdePkg/Library/BaseFdtLib/string.h
@@ -1,0 +1,10 @@
+/** @file
+  Include file to support building the third-party libfdt library.
+
+Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <LibFdtSupport.h>
+

--- a/MdePkg/MdePkg.ci.yaml
+++ b/MdePkg/MdePkg.ci.yaml
@@ -67,7 +67,8 @@
             "Include/Library/PcdLib.h",
             "Include/Library/SafeIntLib.h",
             "Include/Protocol/DebugSupport.h",
-            "Test/UnitTest/Library/BaseSafeIntLib/TestBaseSafeIntLib.c"
+            "Test/UnitTest/Library/BaseSafeIntLib/TestBaseSafeIntLib.c",
+            "Library/BaseFdtLib"
         ]
     },
     ## options defined ci/Plugin/CompilerPlugin
@@ -164,5 +165,17 @@
         "ExtendWords": [],           # words to extend to the dictionary for this package
         "IgnoreStandardPaths": [],   # Standard Plugin defined paths that should be ignore
         "AdditionalIncludePaths": [] # Additional paths to spell check (wildcards supported)
+    },
+    # options defined in .pytool/Plugin/UncrustifyCheck
+    "UncrustifyCheck": {
+        "IgnoreFiles": [
+            "Library/BaseFdtLib/libfdt",
+            "Library/BaseFdtLib/limits.h",
+            "Library/BaseFdtLib/stdbool.h",
+            "Library/BaseFdtLib/stddef.h",
+            "Library/BaseFdtLib/stdint.h",
+            "Library/BaseFdtLib/stdlib.h",
+            "Library/BaseFdtLib/string.h"
+        ]
     }
 }

--- a/MdePkg/MdePkg.dec
+++ b/MdePkg/MdePkg.dec
@@ -289,6 +289,10 @@
   #
   ArmTrngLib|Include/Library/ArmTrngLib.h
 
+  ##  @libraryclass  Provides APIs for third-party library libfdt.
+  #
+  FdtLib|Include/Library/FdtLib.h
+
 [LibraryClasses.IA32, LibraryClasses.X64, LibraryClasses.AARCH64]
   ##  @libraryclass  Provides services to generate random number.
   #

--- a/MdePkg/MdePkg.dsc
+++ b/MdePkg/MdePkg.dsc
@@ -137,6 +137,7 @@
   MdePkg/Library/SmmCpuRendezvousLibNull/SmmCpuRendezvousLibNull.inf
 
   MdePkg/Library/JedecJep106Lib/JedecJep106Lib.inf
+  MdePkg/Library/BaseFdtLib/BaseFdtLib.inf
 
 [Components.IA32, Components.X64, Components.ARM, Components.AARCH64]
   #

--- a/ReadMe.rst
+++ b/ReadMe.rst
@@ -96,6 +96,7 @@ that are covered by additional licenses.
 -  `UnitTestFrameworkPkg/Library/GoogleTestLib/googletest <https://github.com/google/googletest/blob/86add13493e5c881d7e4ba77fb91c1f57752b3a4/LICENSE>`__
 -  `UnitTestFrameworkPkg/Library/SubhookLib/subhook <https://github.com/Zeex/subhook/blob/83d4e1ebef3588fae48b69a7352cc21801cb70bc/LICENSE.txt>`__
 -  `RedfishPkg/Library/JsonLib/jansson <https://github.com/akheron/jansson/blob/2882ead5bb90cf12a01b07b2c2361e24960fae02/LICENSE>`__
+-  `MdePkg/Library/BaseFdtLib/libfdt <https://github.com/devicetree-org/pylibfdt/blob/f39368a217496d32c4091a2dba4045b60649e3a5/BSD-2-Clause>`__
 
 The EDK II Project is composed of packages. The maintainers for each package
 are listed in `Maintainers.txt <Maintainers.txt>`__.


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4392
Add FDT support in EDK2 by submodule 3rd party libfdt
(https://github.com/devicetree-org/pylibfdt/tree/main/libfdt)
and refer to LibcLib implementation by Pedro.

Cc: Michael D Kinney <[michael.d.kinney@intel.com](mailto:michael.d.kinney@intel.com)>
Cc: Liming Gao <[gaoliming@byosoft.com.cn](mailto:gaoliming@byosoft.com.cn)>
Cc: Zhiguang Liu <[zhiguang.liu@intel.com](mailto:zhiguang.liu@intel.com)>
Cc: Sean Brogan <[sean.brogan@microsoft.com](mailto:sean.brogan@microsoft.com)>
Cc: Michael Kubacki <[mikuback@linux.microsoft.com](mailto:mikuback@linux.microsoft.com)>
Acked-by: Pedro Falcato <[pedro.falcato@gmail.com](mailto:pedro.falcato@gmail.com)>
Signed-off-by: Benny Lin <[benny.lin@intel.com](mailto:benny.lin@intel.com)>


V7:
Update FdtLib.h comments to replace SwapBytes*() with CpuToFdt*()
and Fdt*ToCpu() provided by current library.