### PR TITLE
Add Volatile Keyword to NvmExpress Passthru CQs

### DIFF
--- a/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressPassthru.c
+++ b/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressPassthru.c
@@ -460,7 +460,7 @@ NvmExpressPassThru (
   EFI_STATUS                     PreviousStatus;
   EFI_PCI_IO_PROTOCOL            *PciIo;
   NVME_SQ                        *Sq;
-  NVME_CQ                        *Cq;
+  volatile NVME_CQ               *Cq;
   UINT16                         QueueId;
   UINT16                         QueueSize;
   UINT32                         Bytes;
@@ -815,14 +815,14 @@ NvmExpressPassThru (
       // Dump every completion entry status for debugging.
       //
       DEBUG_CODE_BEGIN ();
-      NvmeDumpStatus (Cq);
+      NvmeDumpStatus ((NVME_CQ *)Cq);
       DEBUG_CODE_END ();
     }
 
     //
     // Copy the Respose Queue entry for this command to the callers response buffer
     //
-    CopyMem (Packet->NvmeCompletion, Cq, sizeof (EFI_NVM_EXPRESS_COMPLETION));
+    CopyMem (Packet->NvmeCompletion, (VOID *)Cq, sizeof (EFI_NVM_EXPRESS_COMPLETION));
   } else {
     //
     // Timeout occurs for an NVMe command. Reset the controller to abort the

--- a/MdeModulePkg/Bus/Pci/NvmExpressPei/NvmExpressPeiPassThru.c
+++ b/MdeModulePkg/Bus/Pci/NvmExpressPei/NvmExpressPeiPassThru.c
@@ -115,7 +115,7 @@ NvmeCreatePrpList (
 **/
 EFI_STATUS
 NvmeCheckCqStatus (
-  IN NVME_CQ  *Cq
+  IN volatile NVME_CQ  *Cq
   )
 {
   if ((Cq->Sct == 0x0) && (Cq->Sc == 0x0)) {
@@ -344,7 +344,7 @@ NvmePassThruExecute (
 {
   EFI_STATUS             Status;
   NVME_SQ                *Sq;
-  NVME_CQ                *Cq;
+  volatile NVME_CQ       *Cq;
   UINT8                  QueueId;
   UINTN                  SqSize;
   UINTN                  CqSize;
@@ -617,7 +617,7 @@ NvmePassThruExecute (
   //
   // Copy the Respose Queue entry for this command to the callers response buffer
   //
-  CopyMem (Packet->NvmeCompletion, Cq, sizeof (EFI_NVM_EXPRESS_COMPLETION));
+  CopyMem (Packet->NvmeCompletion, (VOID *)Cq, sizeof (EFI_NVM_EXPRESS_COMPLETION));
 
   //
   // Check the NVMe cmd execution result


### PR DESCRIPTION
Cover-letter is at: https://edk2.groups.io/g/devel/message/103725

NVMe CQs are hardware queues mapped to EFI memory.
In the NVMExpress Passthru implementations in PEI and DXE,
it has been observed that NVMe CQs are not marked
volatile, meaning the compiler has significant leeway
to optimize accesses to these structures.

This led to an issue where the passthru driver waited
for a timeout period for an NVMe CQ to mark that it was
finished with a transaction, but the compiler had
optimized away the read to the actual HW mapped memory,
so the transaction had completed but the timeout continued.

Marking the CQs as volatile fixes this issue as the reads
happen to the actual HW.

Personal GitHub PR: https://github.com/tianocore/edk2/pull/4320
Github branch: https://github.com/os-d/edk2/tree/osde/volatile_cq_v2

Changes v1 => v2:
=================
- Remove volatile keyword from SQ

Cc: Hao A Wu <[hao.a.wu@intel.com](mailto:hao.a.wu@intel.com)>
Cc: Ray Ni <[ray.ni@intel.com](mailto:ray.ni@intel.com)>
Cc: Jian J Wang <[jian.j.wang@intel.com](mailto:jian.j.wang@intel.com)>
Cc: Liming Gao <[gaoliming@byosoft.com.cn](mailto:gaoliming@byosoft.com.cn)>
Cc: Michael Kubacki <[mikuback@linux.microsoft.com](mailto:mikuback@linux.microsoft.com)>
Cc: Sean Brogan <[sean.brogan@microsoft.com](mailto:sean.brogan@microsoft.com)>


Oliver Smith-Denny (2):
  Add the volatile keyword to NvmExpressDxe's Passthru CQ
  Add volatile keyword to NvmExpressPei's Passthru CQ

 MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressPassthru.c    | 6 +++---
 MdeModulePkg/Bus/Pci/NvmExpressPei/NvmExpressPeiPassThru.c | 6 +++---
 2 files changed, 6 insertions(+), 6 deletions(-)