### PR TITLE
[TEST] CI: Use Fedora 37, Qemu 8 (Linux)

### DIFF
--- a/.azurepipelines/templates/defaults.yml
+++ b/.azurepipelines/templates/defaults.yml
@@ -9,4 +9,4 @@
 
 variables:
   default_python_version: ">=3.10.6"
-  default_linux_image: "ghcr.io/tianocore/containers/fedora-37-test:3b3eb8f"
+  default_linux_image: "quay.io/osteffen/edk2-fedora-37-qemu-8:latest"


### PR DESCRIPTION
Use an updated Fedora 37 image incl. Qemu 8.0.0
for Linux jobs in the CI.

A test pulling images from quay.io