### PR TITLE
UefiCpuPkg/CpuService.c:check cpu sync mode in SmmCpuRendezvous()

### DIFF
--- a/UefiCpuPkg/PiSmmCpuDxeSmm/CpuService.c
+++ b/UefiCpuPkg/PiSmmCpuDxeSmm/CpuService.c
@@ -1,7 +1,7 @@
 /** @file
 Implementation of SMM CPU Services Protocol.
 
-Copyright (c) 2011 - 2022, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2011 - 2023, Intel Corporation. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -421,11 +421,18 @@ SmmCpuRendezvous (
     goto ON_EXIT;
   }
 
-  //
-  // There are some APs outside SMM, Wait for all avaiable APs to arrive.
-  //
-  SmmWaitForApArrival ();
-  Status = mSmmMpSyncData->AllApArrivedWithException ? EFI_SUCCESS : EFI_TIMEOUT;
+  if ((mSmmMpSyncData->EffectiveSyncMode != SmmCpuSyncModeTradition) && !SmmCpuFeaturesNeedConfigureMtrrs ()) {
+    //
+    // There are some APs outside SMM, Wait for all avaiable APs to arrive.
+    //
+    SmmWaitForApArrival ();
+    Status = mSmmMpSyncData->AllApArrivedWithException ? EFI_SUCCESS : EFI_TIMEOUT;
+  } else {
+    //
+    // BSP has already waitted for APs to arrive SMM if SmmCpuSyncMode selected or need config MTRR.
+    //
+    Status = EFI_TIMEOUT;
+  }
 
 ON_EXIT:
   if (!mSmmMpSyncData->AllApArrivedWithException) {


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4431

In Ap relaxed mode, some SMI handlers should call SmmWaitForApArrival() to let all ap arrive in SmmCpuRendezvous(). But in traditional mode, these SMI handlers don't need to call SmmWaitForApArrival() again. So it need to be check cpu sync mode before calling SmmWaitForApArrival().

Cc: Eric Dong <eric.dong@intel.com>
Cc: Ray Ni <ray.ni@intel.com>