### PR TITLE
MdeModulePkg/VariableSmm.c: add Ap rendezvous check before SmmSetVari…

### DIFF
--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmm.c
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmm.c
@@ -14,7 +14,7 @@
   VariableServiceSetVariable(), VariableServiceQueryVariableInfo(), ReclaimForOS(),
   SmmVariableGetStatistics() should also do validation based on its own knowledge.
 
-Copyright (c) 2010 - 2019, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2010 - 2023, Intel Corporation. All rights reserved.<BR>
 Copyright (c) 2018, Linaro, Ltd. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -28,6 +28,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #include <Library/MmServicesTableLib.h>
 #include <Library/VariablePolicyLib.h>
+#include <Library/SmmCpuRendezvousLib.h>
 
 #include <Guid/SmmVariableCommon.h>
 #include "Variable.h"
@@ -86,6 +87,13 @@ SmmVariableSetVariable (
   )
 {
   EFI_STATUS  Status;
+
+  //
+  // Need to wait for all Aps to arrive in Relaxed-AP Sync Mode
+  //
+  if (EFI_ERROR (SmmWaitForAllProcessor (TRUE))) {
+    DEBUG ((DEBUG_ERROR, "SetVariable: fail to wait for all AP check in SMM!\n"));
+  }
 
   //
   // Disable write protection when the calling SetVariable() through EFI_SMM_VARIABLE_PROTOCOL.

--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmm.inf
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmm.inf
@@ -18,7 +18,7 @@
 #  may not be modified without authorization. If platform fails to protect these resources,
 #  the authentication service provided in this driver will be broken, and the behavior is undefined.
 #
-# Copyright (c) 2010 - 2019, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2010 - 2023, Intel Corporation. All rights reserved.<BR>
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -84,6 +84,7 @@
   VariablePolicyLib
   VariablePolicyHelperLib
   SafeIntLib
+  SmmCpuRendezvousLib
 
 [Protocols]
   gEfiSmmFirmwareVolumeBlockProtocolGuid        ## CONSUMES

--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableStandaloneMm.inf
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableStandaloneMm.inf
@@ -18,7 +18,7 @@
 #  may not be modified without authorization. If platform fails to protect these resources,
 #  the authentication service provided in this driver will be broken, and the behavior is undefined.
 #
-# Copyright (c) 2010 - 2019, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2010 - 2023, Intel Corporation. All rights reserved.<BR>
 # Copyright (c) 2018, Linaro, Ltd. All rights reserved.<BR>
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -80,6 +80,7 @@
   VariableFlashInfoLib
   VariablePolicyLib
   VariablePolicyHelperLib
+  SmmCpuRendezvousLib
 
 [Protocols]
   gEfiSmmFirmwareVolumeBlockProtocolGuid        ## CONSUMES


### PR DESCRIPTION
…able.

REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4429

For Ap-Relaxed sync mode, SmmVariableSetVariable() need to let all Aps arrive to smm before it set the variable. If not, it would return EFI_ACCESS_DENIED.

Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>