### PR TITLE
OvmfPkg/VirtioSerialDxe: fix RELEASE build error

### DIFF
--- a/OvmfPkg/VirtioSerialDxe/VirtioSerial.c
+++ b/OvmfPkg/VirtioSerialDxe/VirtioSerial.c
@@ -25,6 +25,7 @@
 
 STATIC LIST_ENTRY  mVirtioSerialList;
 
+#if !defined (MDEPKG_NDEBUG)
 STATIC CONST CHAR8  *EventNames[] = {
   [VIRTIO_SERIAL_DEVICE_READY]  = "device-ready",
   [VIRTIO_SERIAL_DEVICE_ADD]    = "device-add",
@@ -35,6 +36,7 @@ STATIC CONST CHAR8  *EventNames[] = {
   [VIRTIO_SERIAL_PORT_OPEN]     = "port-open",
   [VIRTIO_SERIAL_PORT_NAME]     = "port-name",
 };
+#endif
 
 VOID
 EFIAPI


### PR DESCRIPTION
EventNames is used to pretty-print debug log messages. Add #ifdef to only include it in debug builds.
Fixes a clang build failure.

Reported-by: Rebecca Cran <rebecca@bsdio.com>