### PR TITLE
OvmfPkg/VirtioSerialDxe: fix RELEASE build error

### DIFF
--- a/OvmfPkg/VirtioSerialDxe/VirtioSerial.c
+++ b/OvmfPkg/VirtioSerialDxe/VirtioSerial.c
@@ -25,6 +25,7 @@
 
 STATIC LIST_ENTRY  mVirtioSerialList;
 
+#if !defined (MDEPKG_NDEBUG)
 STATIC CONST CHAR8  *EventNames[] = {
   [VIRTIO_SERIAL_DEVICE_READY]  = "device-ready",
   [VIRTIO_SERIAL_DEVICE_ADD]    = "device-add",
@@ -35,6 +36,7 @@ STATIC CONST CHAR8  *EventNames[] = {
   [VIRTIO_SERIAL_PORT_OPEN]     = "port-open",
   [VIRTIO_SERIAL_PORT_NAME]     = "port-name",
 };
+#endif
 
 VOID
 EFIAPI
@@ -120,6 +122,7 @@ VirtioSerialRxControl (
 
     CopyMem (&Control, Data, sizeof (Control));
 
+ #if !defined (MDEPKG_NDEBUG)
     if (Control.Event < ARRAY_SIZE (EventNames)) {
       DEBUG ((
         DEBUG_INFO,
@@ -139,6 +142,8 @@ VirtioSerialRxControl (
         Control.Event
         ));
     }
+
+ #endif
 
     switch (Control.Event) {
       case VIRTIO_SERIAL_DEVICE_ADD:


### PR DESCRIPTION
EventNames is used to pretty-print debug log messages.
Add #ifdef to only include it in debug builds.
Fixes a clang build failure.

Reported-by: Rebecca Cran <rebecca@bsdio.com>
Signed-off-by: Gerd Hoffmann <kraxel@redhat.com>
