### PR TITLE
SecurityPkg: Add missing break in Tpm2TestParms

### DIFF
--- a/SecurityPkg/Library/Tpm2CommandLib/Tpm2Capability.c
+++ b/SecurityPkg/Library/Tpm2CommandLib/Tpm2Capability.c
@@ -743,6 +743,7 @@ Tpm2TestParms (
           return EFI_INVALID_PARAMETER;
       }
 
+      break;
     case TPM_ALG_SYMCIPHER:
       WriteUnaligned16 ((UINT16 *)Buffer, SwapBytes16 (Parameters->parameters.symDetail.algorithm));
       Buffer += sizeof (UINT16);


### PR DESCRIPTION
Add missing break in Tpm2TestParms.

Reported in https://github.com/tianocore/edk2/issues/4073


Reviewed-by: Jiewen Yao <jiewen.yao@intel.com>