### PR TITLE
Update ArmCpuInfo

### DIFF
--- a/ArmPkg/Application/ArmCpuInfo/ArmCpuInfo.c
+++ b/ArmPkg/Application/ArmCpuInfo/ArmCpuInfo.c
@@ -659,7 +659,7 @@ HandleAa64Isar1 (
   Value = (Aa64Isar1 >>  4) & 0xf;
   switch (Value) {
     case b0000:
-      Description = "Address Authentication  (APA) not implemented.";
+      Description = "Address Authentication (APA) not implemented.";
       break;
     case b0001:
       Description = "FEAT_PAuth implemented.";
@@ -690,7 +690,7 @@ HandleAa64Isar1 (
   Value = (Aa64Isar1 >>  8) & 0xf;
   switch (Value) {
     case b0000:
-      Description = "Address Authentication  (API) not implemented.";
+      Description = "Address Authentication (API) not implemented.";
       break;
     case b0001:
       Description = "FEAT_PAuth implemented.";
@@ -1005,7 +1005,7 @@ HandleAa64Isar2 (
   Value = (Aa64Isar2 >> 12) & 0xf;
   switch (Value) {
     case b0000:
-      Description = "Address Authentication  (APA3) not implemented.";
+      Description = "Address Authentication (APA3) not implemented.";
       break;
     case b0001:
       Description = "FEAT_PAuth implemented.";
@@ -1099,25 +1099,25 @@ HandleAa64Mmfr0 (
   Value = Aa64Mmfr0 & 0xf;
   switch (Value) {
     case b0000:
-      Description = "32 Bits  (4GB) of physical address range supported.";
+      Description = "32 Bits (4GB) of physical address range supported.";
       break;
     case b0001:
-      Description = "36 Bits  (64GB) of physical address range supported.";
+      Description = "36 Bits (64GB) of physical address range supported.";
       break;
     case b0010:
-      Description = "40 Bits  (1TB) of physical address range supported.";
+      Description = "40 Bits (1TB) of physical address range supported.";
       break;
     case b0011:
-      Description = "42 Bits  (4TB) of physical address range supported.";
+      Description = "42 Bits (4TB) of physical address range supported.";
       break;
     case b0100:
-      Description = "44 Bits  (16TB) of physical address range supported.";
+      Description = "44 Bits (16TB) of physical address range supported.";
       break;
     case b0101:
-      Description = "48 Bits  (256TB) of physical address range supported.";
+      Description = "48 Bits (256TB) of physical address range supported.";
       break;
     case b0110:
-      Description = "52 Bits  (4PB) of physical address range supported.";
+      Description = "52 Bits (4PB) of physical address range supported.";
       break;
     default:
       Description = "unknown";
@@ -1982,7 +1982,7 @@ HandleAa64Pfr0 (
       Description = "Floating-point implemented.";
       break;
     case b0001:
-      Description = "Floating-point with half-precision support  (FEAT_FP16).";
+      Description = "Floating-point with half-precision support (FEAT_FP16).";
       break;
     case b1111:
       Description = "Floating-point not implemented.";
@@ -2001,7 +2001,7 @@ HandleAa64Pfr0 (
       Description = "Advanced SIMD implemented.";
       break;
     case b0001:
-      Description = "Advanced SIMD with half precision support  (FEAT_FP16).";
+      Description = "Advanced SIMD with half precision support (FEAT_FP16).";
       break;
     case b1111:
       Description = "Advanced SIMD not implemented.";

--- a/ArmPkg/Application/ArmCpuInfo/ArmCpuInfo.c
+++ b/ArmPkg/Application/ArmCpuInfo/ArmCpuInfo.c
@@ -107,7 +107,7 @@ HandleAa64Dfr0 (
   CONST CHAR8         *Bits;
 
   Bits  = "3:0 ";
-  Value = (Aa64Dfr0 >>  4) & 0xf;
+  Value = Aa64Dfr0 & 0xf;
   switch (Value) {
     case b0110:
       Description = "Armv8 debug architecture";
@@ -637,7 +637,7 @@ HandleAa64Isar1 (
   CONST CHAR8         *Bits;
 
   Bits  = "3:0 ";
-  Value = (Aa64Isar1 >>  4) & 0xf;
+  Value = Aa64Isar1 & 0xf;
   switch (Value) {
     case b0000:
       Description = "DC CVAP not implemented.";
@@ -954,7 +954,7 @@ HandleAa64Isar2 (
   CONST CHAR8         *Bits;
 
   Bits  = "3:0 ";
-  Value = (Aa64Isar2 >>  4) & 0xf;
+  Value = Aa64Isar2 & 0xf;
   switch (Value) {
     case b0000:
       Description = "FEAT_WFxT not implemented.";
@@ -1637,7 +1637,7 @@ HandleAa64Mmfr2 (
   CONST CHAR8         *Bits;
 
   Bits  = "3:0 ";
-  Value = (Aa64Mmfr2)       & 0xf;
+  Value = Aa64Mmfr2 & 0xf;
   switch (Value) {
     case b0000:
       Description = "FEAT_TTCNP not implemented.";
@@ -1906,7 +1906,7 @@ HandleAa64Pfr0 (
   CONST CHAR8         *Bits;
 
   Bits  = "3:0 ";
-  Value = (Aa64Pfr0)       & 0xf;
+  Value = Aa64Pfr0 & 0xf;
   switch (Value) {
     case b0001:
       Description = "EL0 in AArch64 only";

--- a/ArmPkg/Application/ArmCpuInfo/ArmCpuInfo.c
+++ b/ArmPkg/Application/ArmCpuInfo/ArmCpuInfo.c
@@ -53,7 +53,7 @@ PrintText (
   CONST CHAR8  *Description
   )
 {
-  AsciiPrint (" %-16a | %5a | %5a | %a\n", Field, Bits, Value, Description);
+  AsciiPrint ("%-5a | %5a | %5a | %a\n", Field, Bits, Value, Description);
 }
 
 /**
@@ -88,7 +88,7 @@ PrintSpacer (
   VOID
   )
 {
-  AsciiPrint ("------------------|-------|-------|----------------------------------------------\n");
+  AsciiPrint ("------|-------|-------|----------------------------------------------\n");
 }
 
 /**
@@ -102,7 +102,7 @@ HandleAa64Dfr0 (
   )
 {
   UINT64              Value;
-  STATIC CONST CHAR8  RegName[] = "ID_AA64DFR0";
+  STATIC CONST CHAR8  RegName[] = "DFR0";
   CONST CHAR8         *Description;
   CONST CHAR8         *Bits;
 
@@ -362,7 +362,7 @@ HandleAa64Isar0 (
   )
 {
   UINT64              Value;
-  STATIC CONST CHAR8  RegName[] = "ID_AA64ISAR0";
+  STATIC CONST CHAR8  RegName[] = "ISAR0";
   CONST CHAR8         *Description;
   CONST CHAR8         *Bits;
 
@@ -632,7 +632,7 @@ HandleAa64Isar1 (
   )
 {
   UINT64              Value;
-  STATIC CONST CHAR8  RegName[] = "ID_AA64ISAR1";
+  STATIC CONST CHAR8  RegName[] = "ISAR1";
   CONST CHAR8         *Description;
   CONST CHAR8         *Bits;
 
@@ -949,7 +949,7 @@ HandleAa64Isar2 (
   )
 {
   UINT64              Value;
-  STATIC CONST CHAR8  RegName[] = "ID_AA64ISAR2";
+  STATIC CONST CHAR8  RegName[] = "ISAR2";
   CONST CHAR8         *Description;
   CONST CHAR8         *Bits;
 
@@ -1091,7 +1091,7 @@ HandleAa64Mmfr0 (
   )
 {
   UINT64              Value;
-  STATIC CONST CHAR8  RegName[] = "ID_AA64MMFR0";
+  STATIC CONST CHAR8  RegName[] = "MMFR0";
   CONST CHAR8         *Description;
   CONST CHAR8         *Bits;
 
@@ -1164,11 +1164,11 @@ HandleAa64Mmfr0 (
   // If mixed-endian is present, check whether supported at EL0
   if (((Aa64Mmfr0 >>  8) & 0xf) != b0000 ) {
     if (((Aa64Mmfr0 >> 16) & 0xf) == b0000 ) {
-      PrintValues ("ID_AA64MMFR0", "19:16", b0000, "No mixed-endian support at EL0.");
+      PrintValues ("MMFR0", "19:16", b0000, "No mixed-endian support at EL0.");
     }
 
     if (((Aa64Mmfr0 >> 16) & 0xf) == b0001 ) {
-      PrintValues ("ID_AA64MMFR0", "19:16", b0001, "Mixed-endian support at EL0.");
+      PrintValues ("MMFR0", "19:16", b0001, "Mixed-endian support at EL0.");
     }
   }
 
@@ -1363,7 +1363,7 @@ HandleAa64Mmfr1 (
   )
 {
   UINT64              Value;
-  STATIC CONST CHAR8  RegName[] = "ID_AA64MMFR1";
+  STATIC CONST CHAR8  RegName[] = "MMFR1";
   CONST CHAR8         *Description;
   CONST CHAR8         *Bits;
 
@@ -1480,12 +1480,12 @@ HandleAa64Mmfr1 (
       (((Aa64Pfr0 >> 28) & 0xf) == b0010))
   {
     if (((Aa64Mmfr1 >> 24) & 0xf) == b0000 ) {
-      PrintValues ("ID_AA64MMFR1", "27:24", b0000, "The PE never generates an SError interrupt due to");
+      PrintValues ("MMFR1", "27:24", b0000, "The PE never generates an SError interrupt due to");
       PrintText ("", "", "", "an External abort on a speculative read.");
     }
 
     if (((Aa64Mmfr1 >> 24) & 0xf) == b0001 ) {
-      PrintValues ("ID_AA64MMFR1", "27:24", b0001, "The PE might generate an SError interrupt due to");
+      PrintValues ("MMFR1", "27:24", b0001, "The PE might generate an SError interrupt due to");
       PrintText ("", "", "", "an External abort on a speculative read.");
     }
   }
@@ -1632,7 +1632,7 @@ HandleAa64Mmfr2 (
   )
 {
   UINT64              Value;
-  STATIC CONST CHAR8  RegName[] = "ID_AA64MMFR2";
+  STATIC CONST CHAR8  RegName[] = "MMFR2";
   CONST CHAR8         *Description;
   CONST CHAR8         *Bits;
 
@@ -1901,7 +1901,7 @@ HandleAa64Pfr0 (
   )
 {
   UINT64              Value;
-  STATIC CONST CHAR8  RegName[] = "ID_AA64PFR0";
+  STATIC CONST CHAR8  RegName[] = "PFR0";
   CONST CHAR8         *Description;
   CONST CHAR8         *Bits;
 
@@ -2059,7 +2059,7 @@ HandleAa64Pfr0 (
   PrintValues (RegName, Bits, Value, Description);
   if (Value == b0001) {
     if (((Aa64Pfr1 >> 12) & 0xf) == b0001 ) {
-      PrintValues ("ID_AA64PRF1", "15:12", b0001, "FEAT_RASv1p1 implemented.");
+      PrintValues ("PRF1", "15:12", b0001, "FEAT_RASv1p1 implemented.");
     }
   }
 
@@ -2199,11 +2199,11 @@ HandleAa64Pfr0 (
   PrintValues (RegName, Bits, Value, Description);
   if (Value == b0001) {
     if (((Aa64Pfr1 >> 32) & 0xf) == b0001 ) {
-      PrintValues ("ID_AA64PRF1", "35:32", b0001, "FEAT_CSV2_1p1 implemented.");
+      PrintValues ("PRF1", "35:32", b0001, "FEAT_CSV2_1p1 implemented.");
     }
 
     if (((Aa64Pfr1 >> 32) & 0xf) == b0010 ) {
-      PrintValues ("ID_AA64PRF1", "35:32", b0010, "FEAT_CSV2_1p2 implemented.");
+      PrintValues ("PRF1", "35:32", b0010, "FEAT_CSV2_1p2 implemented.");
     }
   }
 
@@ -2235,7 +2235,7 @@ HandleAa64Pfr1 (
   )
 {
   UINT64              Value;
-  STATIC CONST CHAR8  RegName[] = "ID_AA64PFR1";
+  STATIC CONST CHAR8  RegName[] = "PFR1";
   CONST CHAR8         *Description;
   CONST CHAR8         *Bits;
 

--- a/ArmPkg/Application/ArmCpuInfo/ArmCpuInfo.c
+++ b/ArmPkg/Application/ArmCpuInfo/ArmCpuInfo.c
@@ -2354,6 +2354,333 @@ HandleAa64Pfr1 (
 }
 
 /**
+  Handle ID_AA64SMFR0_EL1 system register.
+
+  @param[in] Aa64Smfr0,  value of ID_AA64SMFR0_EL1 system register
+**/
+VOID
+HandleAa64Smfr0 (
+  CONST UINT64  Aa64Smfr0
+  )
+{
+  UINT64              Value;
+  STATIC CONST CHAR8  RegName[] = "SMFR0";
+  CONST CHAR8         *Description;
+  CONST CHAR8         *Bits;
+
+  // 31:0 reserved
+
+  Bits  = "   32";
+  Value = (Aa64Smfr0 >> 32) & 0x1;
+  switch (Value) {
+    case 0:
+      Description = "SME F32F32 not implemented.";
+      break;
+    case 1:
+      Description = "SME F32F32 implemented.";
+      break;
+    default:
+      Description = "unknown";
+      break;
+  }
+
+  PrintValues (RegName, Bits, Value, Description);
+
+  // 33 reserved
+
+  Bits  = "   34";
+  Value = (Aa64Smfr0 >> 34) & 0x1;
+  switch (Value) {
+    case 0:
+      Description = "SME B16F32 not implemented.";
+      break;
+    case 1:
+      Description = "SME B16F32 implemented.";
+      break;
+    default:
+      Description = "unknown";
+      break;
+  }
+
+  PrintValues (RegName, Bits, Value, Description);
+
+  Bits  = "   35";
+  Value = (Aa64Smfr0 >> 35) & 0x1;
+  switch (Value) {
+    case 0:
+      Description = "SME F16F32 not implemented.";
+      break;
+    case 1:
+      Description = "SME F16F32 implemented.";
+      break;
+    default:
+      Description = "unknown";
+      break;
+  }
+
+  PrintValues (RegName, Bits, Value, Description);
+
+  Bits  = "39:36";
+  Value = (Aa64Smfr0 >> 36) & 0xf;
+  switch (Value) {
+    case b0000:
+      Description = "SME I8I32 not implemented.";
+      break;
+    case b1111:
+      Description = "SME I8I32 implemented.";
+      break;
+    default:
+      Description = "unknown";
+      break;
+  }
+
+  PrintValues (RegName, Bits, Value, Description);
+
+  // 47:40 reserved
+
+  Bits  = "   48";
+  Value = (Aa64Smfr0 >> 48) & 0x1;
+  switch (Value) {
+    case 0:
+      Description = "SME F64F64 not implemented.";
+      break;
+    case 1:
+      Description = "SME F64F64 implemented.";
+      break;
+    default:
+      Description = "unknown";
+      break;
+  }
+
+  PrintValues (RegName, Bits, Value, Description);
+
+  // 51:49 reserved
+
+  Bits  = "55:52";
+  Value = (Aa64Smfr0 >> 52) & 0xf;
+  switch (Value) {
+    case b0000:
+      Description = "SME I16I64 not implemented";
+      break;
+    case b1111:
+      Description = "SME I16I64 implemented";
+      break;
+    default:
+      Description = "unknown";
+      break;
+  }
+
+  PrintValues (RegName, Bits, Value, Description);
+
+  Bits  = "59:56";
+  Value = (Aa64Smfr0 >> 56) & 0xf;
+  switch (Value) {
+    case b0000:
+      Description = "Mandatory SME instructions are implemented.";
+      break;
+    default:
+      Description = "unknown";
+      break;
+  }
+
+  PrintValues (RegName, Bits, Value, Description);
+
+  // 62:60 reserved
+
+  Bits  = "   63";
+  Value = (Aa64Smfr0 >> 63) & 0x1;
+  switch (Value) {
+    case 0:
+      Description = "SME_FA64 not implemented.";
+      break;
+    case 1:
+      Description = "SME_FA64 implemented.";
+      break;
+    default:
+      Description = "unknown";
+      break;
+  }
+
+  PrintValues (RegName, Bits, Value, Description);
+}
+
+/**
+  Handle ID_AA64ZFR0_EL1 system register.
+
+  @param[in] Aa64Zfr0,  value of ID_AA64ZFR0_EL1 system register
+**/
+VOID
+HandleAa64Zfr0 (
+  CONST UINT64  Aa64Zfr0
+  )
+{
+  UINT64              Value;
+  STATIC CONST CHAR8  RegName[] = "ZFR0";
+  CONST CHAR8         *Description;
+  CONST CHAR8         *Bits;
+
+  Bits  = "3:0 ";
+  Value = Aa64Zfr0 & 0xf;
+  switch (Value) {
+    case b0000:
+      Description = "FEAT_SVE implemented.";
+      break;
+    case b0001:
+      Description = "FEAT_SVE2 implemented.";
+      break;
+    default:
+      Description = "unknown";
+      break;
+  }
+
+  PrintValues (RegName, Bits, Value, Description);
+
+  Bits  = "7:4 ";
+  Value = (Aa64Zfr0 >>  4) & 0xf;
+  switch (Value) {
+    case b0000:
+      Description = "FEAT_SVE_AES not implemented.";
+      break;
+    case b0001:
+      Description = "FEAT_SVE_AES implemented.";
+      break;
+    case b0010:
+      Description = "FEAT_SVE_AES and FEAT_SVE_PMULL128 implemented.";
+      break;
+    default:
+      Description = "unknown";
+      break;
+  }
+
+  PrintValues (RegName, Bits, Value, Description);
+
+  // 15:8 reserved
+
+  Bits  = "19:16";
+  Value = (Aa64Zfr0 >> 16) & 0xf;
+  switch (Value) {
+    case b0000:
+      Description = "FEAT_SVE_BitPerm not implemented.";
+      break;
+    case b0001:
+      Description = "FEAT_SVE_BitPerm implemented.";
+      break;
+    default:
+      Description = "unknown";
+      break;
+  }
+
+  PrintValues (RegName, Bits, Value, Description);
+
+  Bits  = "23:20";
+  Value = (Aa64Zfr0 >> 20) & 0xf;
+  switch (Value) {
+    case b0000:
+      Description = "SVE BFloat16 not implemented.";
+      break;
+    case b0001:
+      Description = "FEAT_BF16 SVE implemented.";
+      break;
+    case b0010:
+      Description = "FEAT_EBF16 SVE implemented.";
+      break;
+    default:
+      Description = "unknown";
+      break;
+  }
+
+  PrintValues (RegName, Bits, Value, Description);
+
+  // 31:24 reserved
+
+  Bits  = "35:32";
+  Value = (Aa64Zfr0 >> 32) & 0xf;
+  switch (Value) {
+    case b0000:
+      Description = "FEAT_SVE_SHA3 not implemented.";
+      break;
+    case b0001:
+      Description = "FEAT_SVE_SHA3 implemented.";
+      break;
+    default:
+      Description = "unknown";
+      break;
+  }
+
+  PrintValues (RegName, Bits, Value, Description);
+
+  // 39:36 reserved
+
+  Bits  = "43:40";
+  Value = (Aa64Zfr0 >> 40) & 0xf;
+  switch (Value) {
+    case b0000:
+      Description = "FEAT_SVE_SM4 not implemented.";
+      break;
+    case b0001:
+      Description = "FEAT_SVE_SM4 implemented.";
+      break;
+    default:
+      Description = "unknown";
+      break;
+  }
+
+  PrintValues (RegName, Bits, Value, Description);
+
+  Bits  = "47:44";
+  Value = (Aa64Zfr0 >> 44) & 0xf;
+  switch (Value) {
+    case b0000:
+      Description = "FEAT_I8MM SVE not implemented.";
+      break;
+    case b0001:
+      Description = "FEAT_I8MM SVE implemented.";
+      break;
+    default:
+      Description = "unknown";
+      break;
+  }
+
+  PrintValues (RegName, Bits, Value, Description);
+
+  // 51:48 reserved
+
+  Bits  = "55:52";
+  Value = (Aa64Zfr0 >> 52) & 0xf;
+  switch (Value) {
+    case b0000:
+      Description = "FEAT_F32MM SVE not implemented";
+      break;
+    case b0001:
+      Description = "FEAT_F32MM SVE implemented";
+      break;
+    default:
+      Description = "unknown";
+      break;
+  }
+
+  PrintValues (RegName, Bits, Value, Description);
+
+  Bits  = "59:56";
+  Value = (Aa64Zfr0 >> 56) & 0xf;
+  switch (Value) {
+    case b0000:
+      Description = "FEAT_F64MM SVE not implemented";
+      break;
+    case b0001:
+      Description = "FEAT_F64MM SVE implemented";
+      break;
+    default:
+      Description = "unknown";
+      break;
+  }
+
+  PrintValues (RegName, Bits, Value, Description);
+
+  // 63:60 reserved
+}
+
+/**
   The user Entry Point for Application. The user code starts with this function
   as the real entry point for the application.
 
@@ -2380,6 +2707,8 @@ UefiMain (
   UINT64  Aa64Mmfr2;
   UINT64  Aa64Pfr0;
   UINT64  Aa64Pfr1;
+  UINT64  Aa64Smfr0;
+  UINT64  Aa64Zfr0;
 
   Aa64Dfr0  = ArmReadIdAA64Dfr0 ();
   Aa64Isar0 = ArmReadIdAA64Isar0 ();
@@ -2390,6 +2719,8 @@ UefiMain (
   Aa64Mmfr2 = ArmReadIdAA64Mmfr2 ();
   Aa64Pfr0  = ArmReadIdAA64Pfr0 ();
   Aa64Pfr1  = ArmReadIdAA64Pfr1 ();
+  Aa64Smfr0 = ArmReadIdAA64Smfr0 ();
+  Aa64Zfr0  = ArmReadIdAA64Zfr0 ();
 
   AsciiPrint ("ID_AA64MMFR0_EL1 = 0x%016lx\n", Aa64Mmfr0);
   AsciiPrint ("ID_AA64MMFR1_EL1 = 0x%016lx\n", Aa64Mmfr1);
@@ -2400,6 +2731,8 @@ UefiMain (
   AsciiPrint ("ID_AA64ISAR1_EL1 = 0x%016lx\n", Aa64Isar1);
   AsciiPrint ("ID_AA64ISAR2_EL1 = 0x%016lx\n", Aa64Isar2);
   AsciiPrint ("ID_AA64DFR0_EL1  = 0x%016lx\n", Aa64Dfr0);
+  AsciiPrint ("ID_AA64SMFR0_EL1 = 0x%016lx\n", Aa64Smfr0);
+  AsciiPrint ("ID_AA64ZFR0_EL1  = 0x%016lx\n", Aa64Zfr0);
   AsciiPrint ("\n");
 
   PrintText ("Register", "Bits", "Value", "Feature");
@@ -2440,6 +2773,17 @@ UefiMain (
   }
 
   HandleAa64Dfr0 (Aa64Dfr0);
+  PrintSpacer ();
+
+  if (Aa64Smfr0) {
+    HandleAa64Smfr0 (Aa64Smfr0);
+    PrintSpacer ();
+  }
+
+  if (Aa64Zfr0) {
+    HandleAa64Zfr0 (Aa64Zfr0);
+    PrintSpacer ();
+  }
 
   return EFI_SUCCESS;
 }

--- a/ArmPkg/Application/ArmCpuInfo/ArmCpuInfo.c
+++ b/ArmPkg/Application/ArmCpuInfo/ArmCpuInfo.c
@@ -77,7 +77,7 @@ PrintValues (
     "1000", "1001", "1010", "1011", "1100", "1101", "1110", "1111"
   };
 
-  AsciiPrint (" %-16a | %5a | %5a | %a\n", Field, Bits, Nibbles[Value & 0xf], Description);
+  PrintText (Field, Bits, Nibbles[Value & 0xf], Description);
 }
 
 /**

--- a/ArmPkg/Application/ArmCpuInfo/ArmCpuInfo.c
+++ b/ArmPkg/Application/ArmCpuInfo/ArmCpuInfo.c
@@ -2407,23 +2407,38 @@ UefiMain (
 
   HandleAa64Mmfr0 (Aa64Mmfr0);
   PrintSpacer ();
-  HandleAa64Mmfr1 (Aa64Mmfr1, Aa64Pfr0);
-  PrintSpacer ();
-  HandleAa64Mmfr2 (Aa64Mmfr2);
 
-  PrintSpacer ();
+  if (Aa64Mmfr1) {
+    HandleAa64Mmfr1 (Aa64Mmfr1, Aa64Pfr0);
+    PrintSpacer ();
+  }
+
+  if (Aa64Mmfr2) {
+    HandleAa64Mmfr2 (Aa64Mmfr2);
+    PrintSpacer ();
+  }
+
   HandleAa64Pfr0 (Aa64Pfr0, Aa64Pfr1);
   PrintSpacer ();
-  HandleAa64Pfr1 (Aa64Pfr1);
 
-  PrintSpacer ();
+  if (Aa64Pfr1) {
+    HandleAa64Pfr1 (Aa64Pfr1);
+    PrintSpacer ();
+  }
+
   HandleAa64Isar0 (Aa64Isar0);
   PrintSpacer ();
-  HandleAa64Isar1 (Aa64Isar1);
-  PrintSpacer ();
-  HandleAa64Isar2 (Aa64Isar2);
 
-  PrintSpacer ();
+  if (Aa64Isar1) {
+    HandleAa64Isar1 (Aa64Isar1);
+    PrintSpacer ();
+  }
+
+  if (Aa64Isar2) {
+    HandleAa64Isar2 (Aa64Isar2);
+    PrintSpacer ();
+  }
+
   HandleAa64Dfr0 (Aa64Dfr0);
 
   return EFI_SUCCESS;

--- a/ArmPkg/Library/ArmLib/AArch64/AArch64Lib.h
+++ b/ArmPkg/Library/ArmLib/AArch64/AArch64Lib.h
@@ -102,4 +102,16 @@ ArmReadIdAA64Pfr1 (
   VOID
   );
 
+UINTN
+EFIAPI
+ArmReadIdAA64Smfr0 (
+  VOID
+  );
+
+UINTN
+EFIAPI
+ArmReadIdAA64Zfr0 (
+  VOID
+  );
+
 #endif // AARCH64_LIB_H_

--- a/ArmPkg/Library/ArmLib/AArch64/AArch64Support.S
+++ b/ArmPkg/Library/ArmLib/AArch64/AArch64Support.S
@@ -524,4 +524,14 @@ ASM_FUNC(ArmReadIdAA64Pfr1)
   mrs   x0, ID_AA64PFR1_EL1
   ret
 
+
+ASM_FUNC(ArmReadIdAA64Smfr0)
+  mrs   x0, ID_AA64SMFR0_EL1
+  ret
+
+
+ASM_FUNC(ArmReadIdAA64Zfr0)
+  mrs   x0, ID_AA64ZFR0_EL1
+  ret
+
 ASM_FUNCTION_REMOVE_IF_UNREFERENCED

--- a/ArmPkg/Library/ArmLib/ArmBaseLib.inf
+++ b/ArmPkg/Library/ArmLib/ArmBaseLib.inf
@@ -48,3 +48,8 @@
 
 [FeaturePcd.ARM]
   gArmTokenSpaceGuid.PcdNormalMemoryNonshareableOverride
+
+# to access ID_AA64ZFR0_EL1 and ID_AA64SMFR0_EL1 system registers
+# we need to enable SME
+[BuildOptions]
+  GCC:*_*_AARCH64_ASM_FLAGS = -march=armv8-a+sme


### PR DESCRIPTION
With those changes ArmCpuInfo application is able to show SVE/SME information. Also if system register is not used on platform then it is not displayed.