### PR TITLE
Bug xxx sbi serial port

### DIFF
--- a/MdePkg/Include/Library/BaseRiscVSbiLib.h
+++ b/MdePkg/Include/Library/BaseRiscVSbiLib.h
@@ -2,6 +2,7 @@
   Library to call the RISC-V SBI ecalls
 
   Copyright (c) 2021-2022, Hewlett Packard Development LP. All rights reserved.<BR>
+  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -18,10 +19,28 @@
 #include <Uefi.h>
 
 /* SBI Extension IDs */
-#define SBI_EXT_TIME  0x54494D45
-#define SBI_EXT_SRST  0x53525354
+#define SBI_EXT_0_1_CONSOLE_PUTCHAR  0x1
+#define SBI_EXT_0_1_CONSOLE_GETCHAR  0x2
+#define SBI_EXT_BASE                 0x10
+#define SBI_EXT_DBCN                 0x4442434E
+#define SBI_EXT_TIME                 0x54494D45
+#define SBI_EXT_SRST                 0x53525354
 
-/* SBI function IDs for TIME extension*/
+/* SBI function IDs for base extension */
+#define SBI_EXT_BASE_SPEC_VERSION   0x0
+#define SBI_EXT_BASE_IMPL_ID        0x1
+#define SBI_EXT_BASE_IMPL_VERSION   0x2
+#define SBI_EXT_BASE_PROBE_EXT      0x3
+#define SBI_EXT_BASE_GET_MVENDORID  0x4
+#define SBI_EXT_BASE_GET_MARCHID    0x5
+#define SBI_EXT_BASE_GET_MIMPID     0x6
+
+/* SBI function IDs for DBCN extension */
+#define SBI_EXT_DBCN_WRITE       0x0
+#define SBI_EXT_DBCN_READ        0x1
+#define SBI_EXT_DBCN_WRITE_BYTE  0x2
+
+/* SBI function IDs for TIME extension */
 #define SBI_EXT_TIME_SET_TIMER  0x0
 
 /* SBI function IDs for SRST extension */
@@ -61,6 +80,21 @@ typedef struct {
   UINTN    Error; ///< SBI status code
   UINTN    Value; ///< Value returned
 } SBI_RET;
+
+SBI_RET
+EFIAPI
+SbiCall (
+  IN  UINTN  ExtId,
+  IN  UINTN  FuncId,
+  IN  UINTN  NumArgs,
+  ...
+  );
+
+EFI_STATUS
+EFIAPI
+TranslateError (
+  IN  UINTN  SbiError
+  );
 
 VOID
 EFIAPI

--- a/MdePkg/Library/BaseRiscVSbiLib/BaseRiscVSbiLib.c
+++ b/MdePkg/Library/BaseRiscVSbiLib/BaseRiscVSbiLib.c
@@ -4,6 +4,7 @@
   It allows calling an SBI function via an ecall from S-Mode.
 
   Copyright (c) 2021-2022, Hewlett Packard Development LP. All rights reserved.<BR>
+  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -31,7 +32,6 @@
   @retval  Returns SBI_RET structure with value and error code.
 
 **/
-STATIC
 SBI_RET
 EFIAPI
 SbiCall (
@@ -88,7 +88,6 @@ SbiCall (
   @param[in] SbiError   SBI error code
   @retval EFI_STATUS
 **/
-STATIC
 EFI_STATUS
 EFIAPI
 TranslateError (

--- a/MdePkg/Library/BaseSerialPortLibRiscVSbiLib/BaseSerialPortLibRiscVSbiLib.c
+++ b/MdePkg/Library/BaseSerialPortLibRiscVSbiLib/BaseSerialPortLibRiscVSbiLib.c
@@ -1,0 +1,208 @@
+/** @file
+  Serial Port Library backed by SBI console.
+
+  Meant for SEC and PEI (XIP) environments.
+
+  Due to limitations of SBI console interface and XIP environments
+  (on use of globals), this library instance does not implement reading
+  and polling the serial port. See BaseSerialPortLibRiscVSbiLibRam.c for
+  the full-featured variant meant for PrePi and DXE environments.
+
+  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "Common.h"
+
+/**
+  Initialize the serial device hardware.
+
+  If no initialization is required, then return RETURN_SUCCESS.
+  If the serial device was successfully initialized, then return RETURN_SUCCESS.
+  If the serial device could not be initialized, then return RETURN_DEVICE_ERROR.
+
+  @retval RETURN_SUCCESS        The serial device was initialized.
+  @retval RETURN_DEVICE_ERROR   The serial device could not be initialized.
+
+**/
+RETURN_STATUS
+EFIAPI
+SerialPortInitialize (
+  VOID
+  )
+{
+  return RETURN_SUCCESS;
+}
+
+/**
+  Write data from buffer to serial device.
+
+  Writes NumberOfBytes data bytes from Buffer to the serial device.
+  The number of bytes actually written to the serial device is returned.
+  If the return value is less than NumberOfBytes, then the write operation failed.
+  If NumberOfBytes is zero, then return 0.
+
+  @param  Buffer           The pointer to the data buffer to be written.
+  @param  NumberOfBytes    The number of bytes to written to the serial device.
+
+  @retval 0                NumberOfBytes is 0.
+  @retval >0               The number of bytes written to the serial device.
+                           If this value is less than NumberOfBytes, then the write operation failed.
+
+**/
+UINTN
+EFIAPI
+SerialPortWrite (
+  IN UINT8  *Buffer,
+  IN UINTN  NumberOfBytes
+  )
+{
+  if (NumberOfBytes == 0) {
+    return 0;
+  }
+
+  if (SbiImplementsDbcn ()) {
+    return SbiDbcnWrite (Buffer, NumberOfBytes);
+  }
+
+  if (SbiImplementsLegacyPutchar ()) {
+    return SbiLegacyPutchar (Buffer, NumberOfBytes);
+  }
+
+  /*
+   * Neither DBCN or legacy extension were present.
+   */
+  return 0;
+}
+
+/**
+  Read data from serial device and save the datas in buffer.
+
+  Reads NumberOfBytes data bytes from a serial device into the buffer
+  specified by Buffer. The number of bytes actually read is returned.
+  If the return value is less than NumberOfBytes, then the rest operation failed.
+  If NumberOfBytes is zero, then return 0.
+
+  @param  Buffer           The pointer to the data buffer to store the data read from the serial device.
+  @param  NumberOfBytes    The number of bytes which will be read.
+
+  @retval 0                Read data failed; No data is to be read.
+  @retval >0               The actual number of bytes read from serial device.
+
+**/
+UINTN
+EFIAPI
+SerialPortRead (
+  OUT UINT8  *Buffer,
+  IN  UINTN  NumberOfBytes
+  )
+{
+  return 0;
+}
+
+/**
+  Polls a serial device to see if there is any data waiting to be read.
+
+  Polls a serial device to see if there is any data waiting to be read.
+  If there is data waiting to be read from the serial device, then TRUE is returned.
+  If there is no data waiting to be read from the serial device, then FALSE is returned.
+
+  @retval TRUE             Data is waiting to be read from the serial device.
+  @retval FALSE            There is no data waiting to be read from the serial device.
+
+**/
+BOOLEAN
+EFIAPI
+SerialPortPoll (
+  VOID
+  )
+{
+  return FALSE;
+}
+
+/**
+  Sets the control bits on a serial device.
+
+  @param Control                Sets the bits of Control that are settable.
+
+  @retval RETURN_SUCCESS        The new control bits were set on the serial device.
+  @retval RETURN_UNSUPPORTED    The serial device does not support this operation.
+  @retval RETURN_DEVICE_ERROR   The serial device is not functioning correctly.
+
+**/
+RETURN_STATUS
+EFIAPI
+SerialPortSetControl (
+  IN UINT32  Control
+  )
+{
+  return RETURN_SUCCESS;
+}
+
+/**
+  Retrieve the status of the control bits on a serial device.
+
+  @param Control                A pointer to return the current control signals from the serial device.
+
+  @retval RETURN_SUCCESS        The control bits were read from the serial device.
+  @retval RETURN_UNSUPPORTED    The serial device does not support this operation.
+  @retval RETURN_DEVICE_ERROR   The serial device is not functioning correctly.
+
+**/
+RETURN_STATUS
+EFIAPI
+SerialPortGetControl (
+  OUT UINT32  *Control
+  )
+{
+  *Control = 0;
+  return RETURN_SUCCESS;
+}
+
+/**
+  Sets the baud rate, receive FIFO depth, transmit/receice time out, parity,
+  data bits, and stop bits on a serial device.
+
+  @param BaudRate           The requested baud rate. A BaudRate value of 0 will use the
+                            device's default interface speed.
+                            On output, the value actually set.
+  @param ReveiveFifoDepth   The requested depth of the FIFO on the receive side of the
+                            serial interface. A ReceiveFifoDepth value of 0 will use
+                            the device's default FIFO depth.
+                            On output, the value actually set.
+  @param Timeout            The requested time out for a single character in microseconds.
+                            This timeout applies to both the transmit and receive side of the
+                            interface. A Timeout value of 0 will use the device's default time
+                            out value.
+                            On output, the value actually set.
+  @param Parity             The type of parity to use on this serial device. A Parity value of
+                            DefaultParity will use the device's default parity value.
+                            On output, the value actually set.
+  @param DataBits           The number of data bits to use on the serial device. A DataBits
+                            vaule of 0 will use the device's default data bit setting.
+                            On output, the value actually set.
+  @param StopBits           The number of stop bits to use on this serial device. A StopBits
+                            value of DefaultStopBits will use the device's default number of
+                            stop bits.
+                            On output, the value actually set.
+
+  @retval RETURN_SUCCESS            The new attributes were set on the serial device.
+  @retval RETURN_UNSUPPORTED        The serial device does not support this operation.
+  @retval RETURN_INVALID_PARAMETER  One or more of the attributes has an unsupported value.
+  @retval RETURN_DEVICE_ERROR       The serial device is not functioning correctly.
+
+**/
+RETURN_STATUS
+EFIAPI
+SerialPortSetAttributes (
+  IN OUT UINT64              *BaudRate,
+  IN OUT UINT32              *ReceiveFifoDepth,
+  IN OUT UINT32              *Timeout,
+  IN OUT EFI_PARITY_TYPE     *Parity,
+  IN OUT UINT8               *DataBits,
+  IN OUT EFI_STOP_BITS_TYPE  *StopBits
+  )
+{
+  return RETURN_SUCCESS;
+}

--- a/MdePkg/Library/BaseSerialPortLibRiscVSbiLib/BaseSerialPortLibRiscVSbiLib.inf
+++ b/MdePkg/Library/BaseSerialPortLibRiscVSbiLib/BaseSerialPortLibRiscVSbiLib.inf
@@ -1,0 +1,41 @@
+## @file
+#  Serial Port Library backed by SBI console.
+#
+#  Meant for SEC and PEI (XIP) environments.
+#
+#  Due to limitations of SBI console interface and XIP environments
+#  (on use of globals), this library instance does not implement reading
+#  and polling the serial port. See PrePiDxeSerialPortLibRiscVSbiRam.inf
+#  for the full-featured variant meant for PrePi and DXE environments.
+#
+#  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x0001001B
+  BASE_NAME                      = BaseSerialPortLibRiscVSbiLib
+  MODULE_UNI_FILE                = BaseSerialPortLibRiscVSbiLib.uni
+  FILE_GUID                      = 639fad38-4bfd-4eb9-9f09-e97c7947d480
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = SerialPortLib | SEC PEI_CORE PEIM
+
+
+#
+#  VALID_ARCHITECTURES           = RISCV64
+#
+
+[Sources]
+  BaseSerialPortLibRiscVSbiLib.c
+  Common.c
+  Common.h
+
+[Packages]
+  MdePkg/MdePkg.dec
+
+[LibraryClasses]
+  RiscVSbiLib

--- a/MdePkg/Library/BaseSerialPortLibRiscVSbiLib/BaseSerialPortLibRiscVSbiLib.uni
+++ b/MdePkg/Library/BaseSerialPortLibRiscVSbiLib/BaseSerialPortLibRiscVSbiLib.uni
@@ -1,0 +1,16 @@
+// /** @file
+// Serial Port Library backed by SBI console.
+//
+// Serial Port Library backed by SBI console.
+//
+// Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+// **/
+
+
+#string STR_MODULE_ABSTRACT             #language en-US "Serial Port Library backed by SBI console"
+
+#string STR_MODULE_DESCRIPTION          #language en-US "Serial Port Library backed by SBI console."
+

--- a/MdePkg/Library/BaseSerialPortLibRiscVSbiLib/BaseSerialPortLibRiscVSbiLibRam.c
+++ b/MdePkg/Library/BaseSerialPortLibRiscVSbiLib/BaseSerialPortLibRiscVSbiLibRam.c
@@ -1,0 +1,289 @@
+/** @file
+  Serial Port Library backed by SBI console.
+
+  Meant for PrePi and DXE environments (where globals are allowed). See
+  BaseSerialPortLibRiscVSbiLib.c for a reduced variant appropriate for
+  SEC and PEI (XIP) environments.
+
+  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Base.h>
+#include <Library/SerialPortLib.h>
+#include <Library/BaseRiscVSbiLib.h>
+#include "Common.h"
+
+STATIC BOOLEAN  mHaveDbcn          = FALSE;
+STATIC BOOLEAN  mHaveLegacyPutchar = FALSE;
+STATIC BOOLEAN  mHaveLegacyGetchar = FALSE;
+STATIC INT64    mLastGetChar       = -1;
+
+/**
+  Return whether the legacy console getchar extension is implemented.
+
+  @retval TRUE                  Extension is implemented.
+  @retval FALSE                 Extension is not implemented.
+
+**/
+STATIC
+BOOLEAN
+SbiImplementsLegacyGetchar (
+  VOID
+  )
+{
+  SBI_RET  Ret;
+
+  Ret = SbiCall (SBI_EXT_BASE, SBI_EXT_BASE_PROBE_EXT, 1, SBI_EXT_0_1_CONSOLE_GETCHAR);
+  if ((TranslateError (Ret.Error) == EFI_SUCCESS) &&
+      (Ret.Value != 0))
+  {
+    return TRUE;
+  }
+
+  return FALSE;
+}
+
+/**
+  Initialize the serial device hardware.
+
+  If no initialization is required, then return RETURN_SUCCESS.
+  If the serial device was successfully initialized, then return RETURN_SUCCESS.
+  If the serial device could not be initialized, then return RETURN_DEVICE_ERROR.
+
+  @retval RETURN_SUCCESS        The serial device was initialized.
+  @retval RETURN_DEVICE_ERROR   The serial device could not be initialized.
+
+**/
+RETURN_STATUS
+EFIAPI
+SerialPortInitialize (
+  VOID
+  )
+{
+  if (SbiImplementsDbcn ()) {
+    mHaveDbcn = TRUE;
+    return RETURN_SUCCESS;
+  }
+
+  if (SbiImplementsLegacyPutchar ()) {
+    mHaveLegacyPutchar = TRUE;
+  }
+
+  if (SbiImplementsLegacyGetchar ()) {
+    mHaveLegacyGetchar = TRUE;
+  }
+
+  return (mHaveLegacyGetchar && mHaveLegacyPutchar) ?
+         RETURN_SUCCESS :
+         RETURN_DEVICE_ERROR;
+}
+
+/**
+  Write data from buffer to serial device.
+
+  Writes NumberOfBytes data bytes from Buffer to the serial device.
+  The number of bytes actually written to the serial device is returned.
+  If the return value is less than NumberOfBytes, then the write operation failed.
+  If NumberOfBytes is zero, then return 0.
+
+  @param  Buffer           The pointer to the data buffer to be written.
+  @param  NumberOfBytes    The number of bytes to written to the serial device.
+
+  @retval 0                NumberOfBytes is 0.
+  @retval >0               The number of bytes written to the serial device.
+                           If this value is less than NumberOfBytes, then the write operation failed.
+
+**/
+UINTN
+EFIAPI
+SerialPortWrite (
+  IN UINT8  *Buffer,
+  IN UINTN  NumberOfBytes
+  )
+{
+  if (NumberOfBytes == 0) {
+    return 0;
+  }
+
+  if (mHaveDbcn) {
+    return SbiDbcnWrite (Buffer, NumberOfBytes);
+  } else if (mHaveLegacyPutchar) {
+    return SbiLegacyPutchar (Buffer, NumberOfBytes);
+  }
+
+  /*
+   * Neither DBCN or legacy extension were present.
+   */
+  return 0;
+}
+
+/**
+  Read data from serial device and save the datas in buffer.
+
+  Reads NumberOfBytes data bytes from a serial device into the buffer
+  specified by Buffer. The number of bytes actually read is returned.
+  If the return value is less than NumberOfBytes, then the rest operation failed.
+  If NumberOfBytes is zero, then return 0.
+
+  @param  Buffer           The pointer to the data buffer to store the data read from the serial device.
+  @param  NumberOfBytes    The number of bytes which will be read.
+
+  @retval 0                Read data failed; No data is to be read.
+  @retval >0               The actual number of bytes read from serial device.
+
+**/
+UINTN
+EFIAPI
+SerialPortRead (
+  OUT UINT8  *Buffer,
+  IN  UINTN  NumberOfBytes
+  )
+{
+  UINTN  Index;
+
+  Index = 0;
+  while ((Index < NumberOfBytes) && SerialPortPoll ()) {
+    Buffer[Index++] = (UINT8)mLastGetChar;
+    mLastGetChar    = -1;
+  }
+
+  return Index;
+}
+
+/**
+  Polls a serial device to see if there is any data waiting to be read.
+
+  Polls a serial device to see if there is any data waiting to be read.
+  If there is data waiting to be read from the serial device, then TRUE is returned.
+  If there is no data waiting to be read from the serial device, then FALSE is returned.
+
+  @retval TRUE             Data is waiting to be read from the serial device.
+  @retval FALSE            There is no data waiting to be read from the serial device.
+
+**/
+BOOLEAN
+EFIAPI
+SerialPortPoll (
+  VOID
+  )
+{
+  /*
+   * Careful. OpenSBI with HTIF console will return -1 followed by -2
+   * if there is no character received. So just check for values >= 0.
+   */
+
+  if (mLastGetChar >= 0) {
+    return TRUE;
+  }
+
+  if (mHaveDbcn) {
+    UINT8    Buffer;
+    SBI_RET  Ret;
+
+    Ret = SbiCall (
+            SBI_EXT_DBCN,
+            SBI_EXT_DBCN_READ,
+            3,
+            1,
+            ((UINTN)&Buffer),
+            0
+            );
+    if ((TranslateError (Ret.Error) == EFI_SUCCESS) &&
+        (Ret.Value == 1))
+    {
+      mLastGetChar = Buffer;
+    }
+  } else if (mHaveLegacyGetchar) {
+    mLastGetChar = (INT64)SbiCall (SBI_EXT_0_1_CONSOLE_GETCHAR, 0, 0).Error;
+  }
+
+  return mLastGetChar >= 0;
+}
+
+/**
+  Sets the control bits on a serial device.
+
+  @param Control                Sets the bits of Control that are settable.
+
+  @retval RETURN_SUCCESS        The new control bits were set on the serial device.
+  @retval RETURN_UNSUPPORTED    The serial device does not support this operation.
+  @retval RETURN_DEVICE_ERROR   The serial device is not functioning correctly.
+
+**/
+RETURN_STATUS
+EFIAPI
+SerialPortSetControl (
+  IN UINT32  Control
+  )
+{
+  return RETURN_SUCCESS;
+}
+
+/**
+  Retrieve the status of the control bits on a serial device.
+
+  @param Control                A pointer to return the current control signals from the serial device.
+
+  @retval RETURN_SUCCESS        The control bits were read from the serial device.
+  @retval RETURN_UNSUPPORTED    The serial device does not support this operation.
+  @retval RETURN_DEVICE_ERROR   The serial device is not functioning correctly.
+
+**/
+RETURN_STATUS
+EFIAPI
+SerialPortGetControl (
+  OUT UINT32  *Control
+  )
+{
+  *Control = 0;
+  return RETURN_SUCCESS;
+}
+
+/**
+  Sets the baud rate, receive FIFO depth, transmit/receice time out, parity,
+  data bits, and stop bits on a serial device.
+
+  @param BaudRate           The requested baud rate. A BaudRate value of 0 will use the
+                            device's default interface speed.
+                            On output, the value actually set.
+  @param ReveiveFifoDepth   The requested depth of the FIFO on the receive side of the
+                            serial interface. A ReceiveFifoDepth value of 0 will use
+                            the device's default FIFO depth.
+                            On output, the value actually set.
+  @param Timeout            The requested time out for a single character in microseconds.
+                            This timeout applies to both the transmit and receive side of the
+                            interface. A Timeout value of 0 will use the device's default time
+                            out value.
+                            On output, the value actually set.
+  @param Parity             The type of parity to use on this serial device. A Parity value of
+                            DefaultParity will use the device's default parity value.
+                            On output, the value actually set.
+  @param DataBits           The number of data bits to use on the serial device. A DataBits
+                            vaule of 0 will use the device's default data bit setting.
+                            On output, the value actually set.
+  @param StopBits           The number of stop bits to use on this serial device. A StopBits
+                            value of DefaultStopBits will use the device's default number of
+                            stop bits.
+                            On output, the value actually set.
+
+  @retval RETURN_SUCCESS            The new attributes were set on the serial device.
+  @retval RETURN_UNSUPPORTED        The serial device does not support this operation.
+  @retval RETURN_INVALID_PARAMETER  One or more of the attributes has an unsupported value.
+  @retval RETURN_DEVICE_ERROR       The serial device is not functioning correctly.
+
+**/
+RETURN_STATUS
+EFIAPI
+SerialPortSetAttributes (
+  IN OUT UINT64              *BaudRate,
+  IN OUT UINT32              *ReceiveFifoDepth,
+  IN OUT UINT32              *Timeout,
+  IN OUT EFI_PARITY_TYPE     *Parity,
+  IN OUT UINT8               *DataBits,
+  IN OUT EFI_STOP_BITS_TYPE  *StopBits
+  )
+{
+  return RETURN_SUCCESS;
+}

--- a/MdePkg/Library/BaseSerialPortLibRiscVSbiLib/BaseSerialPortLibRiscVSbiLibRam.inf
+++ b/MdePkg/Library/BaseSerialPortLibRiscVSbiLib/BaseSerialPortLibRiscVSbiLibRam.inf
@@ -1,0 +1,38 @@
+## @file
+#  Serial Port Library backed by SBI console.
+#
+#  Meant for PrePi and DXE environments (where globals are allowed). See
+#  BaseSerialPortLibRiscVSbiLib.inf for a reduced variant appropriate
+#  for SEC and PEI (XIP) environments.
+#
+#  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x0001001B
+  BASE_NAME                      = BaseSerialPortLibRiscVSbiLibRam
+  MODULE_UNI_FILE                = BaseSerialPortLibRiscVSbiLib.uni
+  FILE_GUID                      = 872af743-ab56-45b4-a065-602567f4820c
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = SerialPortLib | SEC DXE_CORE DXE_DRIVER DXE_RUNTIME_DRIVER UEFI_DRIVER UEFI_APPLICATION
+
+
+#
+#  VALID_ARCHITECTURES           = RISCV64
+#
+
+[Sources]
+  BaseSerialPortLibRiscVSbiLibRam.c
+  Common.c
+  Common.h
+
+[Packages]
+  MdePkg/MdePkg.dec
+
+[LibraryClasses]
+  RiscVSbiLib

--- a/MdePkg/Library/BaseSerialPortLibRiscVSbiLib/Common.c
+++ b/MdePkg/Library/BaseSerialPortLibRiscVSbiLib/Common.c
@@ -1,0 +1,132 @@
+/** @file
+  Serial Port Library backed by SBI console.
+
+  Common functionality shared by PrePiDxeSerialPortLibRiscVSbi and
+  PrePiDxeSerialPortLibRiscVSbiRam implementations.
+
+  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "Common.h"
+
+/**
+  Return whether the DBCN extension is implemented.
+
+  @retval TRUE                  Extension is implemented.
+  @retval FALSE                 Extension is not implemented.
+
+**/
+BOOLEAN
+SbiImplementsDbcn (
+  VOID
+  )
+{
+  SBI_RET  Ret;
+
+  Ret = SbiCall (SBI_EXT_BASE, SBI_EXT_BASE_PROBE_EXT, 1, SBI_EXT_DBCN);
+  if ((TranslateError (Ret.Error) == EFI_SUCCESS) &&
+      (Ret.Value != 0))
+  {
+    return TRUE;
+  }
+
+  return FALSE;
+}
+
+/**
+  Return whether the legacy console putchar extension is implemented.
+
+  @retval TRUE                  Extension is implemented.
+  @retval FALSE                 Extension is not implemented.
+
+**/
+BOOLEAN
+SbiImplementsLegacyPutchar (
+  VOID
+  )
+{
+  SBI_RET  Ret;
+
+  Ret = SbiCall (SBI_EXT_BASE, SBI_EXT_BASE_PROBE_EXT, 1, SBI_EXT_0_1_CONSOLE_PUTCHAR);
+  if ((TranslateError (Ret.Error) == EFI_SUCCESS) &&
+      (Ret.Value != 0))
+  {
+    return TRUE;
+  }
+
+  return FALSE;
+}
+
+/**
+  Write data from buffer to console via SBI legacy putchar extension.
+
+  The number of bytes actually written to the SBI console is returned.
+  If the return value is less than NumberOfBytes, then the write operation failed.
+
+  @param  Buffer           The pointer to the data buffer to be written.
+  @param  NumberOfBytes    The number of bytes to written to the serial device.
+
+  @retval >=0              The number of bytes written to the serial device.
+                           If this value is less than NumberOfBytes, then the
+                           write operation failed.
+
+**/
+UINTN
+SbiLegacyPutchar (
+  IN  UINT8  *Buffer,
+  IN  UINTN  NumberOfBytes
+  )
+{
+  SBI_RET  Ret;
+  UINTN    Index;
+
+  for (Index = 0; Index < NumberOfBytes; Index++) {
+    Ret =  SbiCall (SBI_EXT_0_1_CONSOLE_PUTCHAR, 0, 1, Buffer[Index]);
+    if ((INT64)Ret.Error < 0) {
+      break;
+    }
+  }
+
+  return Index;
+}
+
+/**
+  Write data from buffer to console via SBI DBCN.
+
+  The number of bytes actually written to the SBI console is returned.
+  If the return value is less than NumberOfBytes, then the write operation failed.
+
+  @param  Buffer           The pointer to the data buffer to be written.
+  @param  NumberOfBytes    The number of bytes to written to the serial device.
+
+  @retval >=0              The number of bytes written to the serial device.
+                           If this value is less than NumberOfBytes, then the
+                           write operation failed.
+
+**/
+UINTN
+SbiDbcnWrite (
+  IN  UINT8  *Buffer,
+  IN  UINTN  NumberOfBytes
+  )
+{
+  SBI_RET  Ret;
+
+  Ret = SbiCall (
+          SBI_EXT_DBCN,
+          SBI_EXT_DBCN_WRITE,
+          3,
+          NumberOfBytes,
+          ((UINTN)Buffer),
+          0
+          );
+
+  /*
+   * May do partial writes. Don't bother decoding
+   * Ret.Error as we're only interested in number of
+   * bytes written to console.
+   */
+  return Ret.Value;
+}

--- a/MdePkg/Library/BaseSerialPortLibRiscVSbiLib/Common.h
+++ b/MdePkg/Library/BaseSerialPortLibRiscVSbiLib/Common.h
@@ -1,0 +1,41 @@
+/** @file
+  Serial Port Library backed by SBI console.
+
+  Common functionality shared by PrePiDxeSerialPortLibRiscVSbi and
+  PrePiDxeSerialPortLibRiscVSbiRam implementations.
+
+  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef SERIAL_PORT_SBI_COMMON_H_
+#define SERIAL_PORT_SBI_COMMON_H_
+
+#include <Base.h>
+#include <Library/SerialPortLib.h>
+#include <Library/BaseRiscVSbiLib.h>
+
+BOOLEAN
+SbiImplementsDbcn (
+  VOID
+  );
+
+BOOLEAN
+SbiImplementsLegacyPutchar (
+  VOID
+  );
+
+UINTN
+SbiLegacyPutchar (
+  IN  UINT8  *Buffer,
+  IN  UINTN  NumberOfBytes
+  );
+
+UINTN
+SbiDbcnWrite (
+  IN  UINT8  *Buffer,
+  IN  UINTN  NumberOfBytes
+  );
+
+#endif /* SERIAL_PORT_SBI_COMMON_H_ */

--- a/MdePkg/MdePkg.dsc
+++ b/MdePkg/MdePkg.dsc
@@ -197,5 +197,7 @@
 
 [Components.RISCV64]
   MdePkg/Library/BaseRiscVSbiLib/BaseRiscVSbiLib.inf
+  MdePkg/Library/BaseSerialPortLibRiscVSbiLib/BaseSerialPortLibRiscVSbiLib.inf
+  MdePkg/Library/BaseSerialPortLibRiscVSbiLib/BaseSerialPortLibRiscVSbiLibRam.inf
 
 [BuildOptions]

--- a/OvmfPkg/RiscVVirt/Sec/SecMain.c
+++ b/OvmfPkg/RiscVVirt/Sec/SecMain.c
@@ -1,7 +1,7 @@
 /** @file
   RISC-V SEC phase module for Qemu Virt.
 
-  Copyright (c) 2008 - 2015, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2008 - 2023, Intel Corporation. All rights reserved.<BR>
   Copyright (c) 2022, Ventana Micro Systems Inc. All rights reserved.<BR>
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -56,6 +56,8 @@ SecStartup (
   UINT64                      UefiMemoryBase;
   UINT64                      StackBase;
   UINT32                      StackSize;
+
+  SerialPortInitialize ();
 
   //
   // Report Status Code to indicate entering SEC core

--- a/OvmfPkg/RiscVVirt/Sec/SecMain.h
+++ b/OvmfPkg/RiscVVirt/Sec/SecMain.h
@@ -29,6 +29,7 @@
 #include <Library/PrePiLib.h>
 #include <Library/PlatformInitLib.h>
 #include <Library/PrePiHobListPointerLib.h>
+#include <Library/SerialPortLib.h>
 #include <Register/RiscV64/RiscVImpl.h>
 
 /**

--- a/OvmfPkg/RiscVVirt/Sec/SecMain.inf
+++ b/OvmfPkg/RiscVVirt/Sec/SecMain.inf
@@ -48,6 +48,7 @@
   FdtLib
   MemoryAllocationLib
   HobLib
+  SerialPortLib
 
 [Ppis]
   gEfiTemporaryRamSupportPpiGuid                # PPI ALWAYS_PRODUCED


### PR DESCRIPTION
Here are three patches that provide a SerialLib backed by SBI console. 
Both legacy and DBCN mechanisms are supported in various execution environments and have been tested with UART and HTIF consoles.

MdePkg reviewers: please review MdePkg.dsc changes.

This is also available at
https://github.com/andreiw/edk2-rv-wip/tree/patchset-2

A CI run is at https://github.com/tianocore/edk2/pull/4252

Compared to v6:

- Unify the two SerialLib implementations under one directory and
  factor out the code somewhat.
- Sunil's feedback on correctness.

Compared to v5:

Rename components as per Michael Kinney's suggestions.

Compared to v4:

(not sent out). CC MdePkg maintainers, fix copyright date in SecMain.c.

Compared to v3

EccCheck fixes. Add MdePkg infs to DSC.

Compared to v2:
- Probes legacy extension as well.
- Encode supported module types in the INF file. This is done using LIBRARY_CLASS,
  as MODULE_TYPE cannot encode multiple types, so MODULE_TYPE is retained as BASE.
- Update INF version and generate brand new GUIDs instead of editing them.
- Checked that all patches retain ^M endings.
