### PR TITLE
MdeModulePkg: Cache device path during LoadImage calls

### DIFF
--- a/MdeModulePkg/Core/Dxe/Hand/Locate.c
+++ b/MdeModulePkg/Core/Dxe/Hand/Locate.c
@@ -14,6 +14,10 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 //
 UINTN  mEfiLocateHandleRequest = 0;
 
+extern EFI_DEVICE_PATH_PROTOCOL *gFilePathCache;
+extern EFI_HANDLE                gDeviceHandleCache;
+extern EFI_DEVICE_PATH_PROTOCOL *gOutgoingDevicePathCache;
+
 //
 // Internal prototypes
 //
@@ -467,8 +471,19 @@ CoreLocateDevicePath (
     return EFI_INVALID_PARAMETER;
   }
 
-  if ((DevicePath == NULL) || (*DevicePath == NULL)) {
+  if ((DevicePath == NULL) || (*DevicePath == NULL) || (Device == NULL)) {
     return EFI_INVALID_PARAMETER;
+  }
+
+  if (gFilePathCache != NULL) {
+    Size = GetDevicePathSize (gFilePathCache) - sizeof (EFI_DEVICE_PATH_PROTOCOL);
+    SourceSize = GetDevicePathSize (*DevicePath) - sizeof (EFI_DEVICE_PATH_PROTOCOL);
+
+    if (Size == SourceSize && CompareMem (gFilePathCache, *DevicePath, (UINTN)Size) == 0) {
+      *Device = gDeviceHandleCache;
+      *DevicePath = gOutgoingDevicePathCache;
+      return EFI_SUCCESS;
+    }
   }
 
   Handles       = NULL;
@@ -539,10 +554,6 @@ CoreLocateDevicePath (
   //
   if (BestMatch == -1) {
     return EFI_NOT_FOUND;
-  }
-
-  if (Device == NULL) {
-    return EFI_INVALID_PARAMETER;
   }
 
   *Device = BestDevice;

--- a/MdeModulePkg/Core/Dxe/Image/Image.c
+++ b/MdeModulePkg/Core/Dxe/Image/Image.c
@@ -13,6 +13,9 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 // Module Globals
 //
 LOADED_IMAGE_PRIVATE_DATA  *mCurrentImage = NULL;
+EFI_DEVICE_PATH_PROTOCOL *gFilePathCache = NULL;
+EFI_DEVICE_PATH_PROTOCOL *gOutgoingDevicePathCache = NULL;
+EFI_HANDLE                gDeviceHandleCache = NULL;
 
 typedef struct {
   LIST_ENTRY                              Link;
@@ -1220,6 +1223,9 @@ CoreLoadImageCommon (
     Status = CoreLocateDevicePath (&gEfiFirmwareVolume2ProtocolGuid, &HandleFilePath, &DeviceHandle);
     if (!EFI_ERROR (Status)) {
       ImageIsFromFv = TRUE;
+      gFilePathCache = FilePath;
+      gOutgoingDevicePathCache = HandleFilePath;
+      gDeviceHandleCache = DeviceHandle;
     } else {
       HandleFilePath = FilePath;
       Status         = CoreLocateDevicePath (&gEfiSimpleFileSystemProtocolGuid, &HandleFilePath, &DeviceHandle);
@@ -1496,6 +1502,11 @@ Done:
   if (Image != NULL) {
     Image->LoadImageStatus = Status;
   }
+
+  // Clear cache
+  gFilePathCache = NULL;
+  gOutgoingDevicePathCache = NULL;
+  gDeviceHandleCache = NULL;
 
   return Status;
 }


### PR DESCRIPTION
During LoadImage, there 6-7 of the same call to CoreLocateDevicePath and can be cached during a particular call to LoadImage. For implementations with significant numbers of calls to LoadImage (>250), this change will improve the boot time by >10ms.