### PR TITLE
MdeModulePkg: Cache device path during LoadImage calls

### DIFF
--- a/MdeModulePkg/Core/Dxe/Image/Image.c
+++ b/MdeModulePkg/Core/Dxe/Image/Image.c
@@ -12,7 +12,10 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 //
 // Module Globals
 //
-LOADED_IMAGE_PRIVATE_DATA  *mCurrentImage = NULL;
+LOADED_IMAGE_PRIVATE_DATA  *mCurrentImage            = NULL;
+EFI_DEVICE_PATH_PROTOCOL   *gFilePathCache           = NULL;
+EFI_DEVICE_PATH_PROTOCOL   *gOutgoingDevicePathCache = NULL;
+EFI_HANDLE                 gDeviceHandleCache        = NULL;
 
 typedef struct {
   LIST_ENTRY                              Link;
@@ -1219,7 +1222,10 @@ CoreLoadImageCommon (
     Node   = NULL;
     Status = CoreLocateDevicePath (&gEfiFirmwareVolume2ProtocolGuid, &HandleFilePath, &DeviceHandle);
     if (!EFI_ERROR (Status)) {
-      ImageIsFromFv = TRUE;
+      ImageIsFromFv            = TRUE;
+      gFilePathCache           = FilePath;
+      gOutgoingDevicePathCache = HandleFilePath;
+      gDeviceHandleCache       = DeviceHandle;
     } else {
       HandleFilePath = FilePath;
       Status         = CoreLocateDevicePath (&gEfiSimpleFileSystemProtocolGuid, &HandleFilePath, &DeviceHandle);
@@ -1496,6 +1502,11 @@ Done:
   if (Image != NULL) {
     Image->LoadImageStatus = Status;
   }
+
+  // Clear cache
+  gFilePathCache           = NULL;
+  gOutgoingDevicePathCache = NULL;
+  gDeviceHandleCache       = NULL;
 
   return Status;
 }


### PR DESCRIPTION
During LoadImage, there 6-7 of the same call to CoreLocateDevicePath and can be cached during a particular call to LoadImage. For implementations with significant numbers of calls to LoadImage (>250), this change will improve the boot time by >10ms.