### PR TITLE
OvmfPkg/PlatformPei: drop S3Verification()

### DIFF
--- a/OvmfPkg/PlatformPei/Platform.c
+++ b/OvmfPkg/PlatformPei/Platform.c
@@ -232,36 +232,6 @@ ReserveEmuVariableNvStore (
 
 STATIC
 VOID
-S3Verification (
-  IN EFI_HOB_PLATFORM_INFO  *PlatformInfoHob
-  )
-{
- #if defined (MDE_CPU_X64)
-  if (PlatformInfoHob->SmmSmramRequire && PlatformInfoHob->S3Supported) {
-    DEBUG ((
-      DEBUG_ERROR,
-      "%a: S3Resume2Pei doesn't support X64 PEI + SMM yet.\n",
-      __func__
-      ));
-    DEBUG ((
-      DEBUG_ERROR,
-      "%a: Please disable S3 on the QEMU command line (see the README),\n",
-      __func__
-      ));
-    DEBUG ((
-      DEBUG_ERROR,
-      "%a: or build OVMF with \"OvmfPkgIa32X64.dsc\".\n",
-      __func__
-      ));
-    ASSERT (FALSE);
-    CpuDeadLoop ();
-  }
-
- #endif
-}
-
-STATIC
-VOID
 Q35BoardVerification (
   IN EFI_HOB_PLATFORM_INFO  *PlatformInfoHob
   )
@@ -354,7 +324,6 @@ InitializePlatform (
     ASSERT_EFI_ERROR (Status);
   }
 
-  S3Verification (PlatformInfoHob);
   BootModeInitialization (PlatformInfoHob);
 
   //


### PR DESCRIPTION
Not needed any more, SMM + 64-bit PEI + S3 suspend works now.

Fixed by commits:
 - 8bd2028f9ac3 ("MdeModulePkg: Supporting S3 in 64bit PEI")
 - 6acf72901a2e ("UefiCpuPkg: Supporting S3 in 64bit PEI")
See also https://bugzilla.tianocore.org/show_bug.cgi?id=4195

Signed-off-by: Gerd Hoffmann <kraxel@redhat.com>
