### PR TITLE
[CI CHECK]ArmPkg: CpuDxe: Report AARCH64 Memory Protections Attributes To GCD

### DIFF
--- a/ArmPkg/Drivers/CpuDxe/AArch64/Mmu.c
+++ b/ArmPkg/Drivers/CpuDxe/AArch64/Mmu.c
@@ -120,7 +120,7 @@ GetFirstPageAttribute (
   } else if (((FirstEntry & TT_TYPE_MASK) == TT_TYPE_BLOCK_ENTRY) ||
              ((TableLevel == 3) && ((FirstEntry & TT_TYPE_MASK) == TT_TYPE_BLOCK_ENTRY_LEVEL3)))
   {
-    return FirstEntry & TT_ATTR_INDX_MASK;
+    return FirstEntry & TT_ATTRIBUTES_MASK;
   } else {
     return INVALID_ENTRY;
   }
@@ -158,7 +158,7 @@ GetNextEntryAttribute (
   for (Index = 0; Index < EntryCount; Index++) {
     Entry          = TableAddress[Index];
     EntryType      = Entry & TT_TYPE_MASK;
-    EntryAttribute = Entry  & TT_ATTR_INDX_MASK;
+    EntryAttribute = Entry & TT_ATTRIBUTES_MASK;
 
     // If Entry is a Table Descriptor type entry then go through the sub-level table
     if ((EntryType == TT_TYPE_BLOCK_ENTRY) ||


### PR DESCRIPTION
When the AARCH64 CpuDxe attempts to SyncCacheConfig() with the GCD, it collects the page attributes as:

EntryAttribute = Entry & TT_ATTR_INDX_MASK

However, TT_ATTR_INDX_MASK only masks the cacheability attributes and drops the memory protections attributes. Importantly, it also drops the TT_AF (access flag) which is now wired up in EDK2 to represent EFI_MEMORY_RP, so by default all SystemMem pages will report as EFI_MEMORY_RP to the GCD. The GCD currently drops that silently, because the Capabilities field in the GCD does not support EFI_MEMORY_RP by default.

However, some ranges may support EFI_MEMORY_RP and incorrectly mark those ranges as read protected. In conjunction with another change on the mailing list (see:
https://edk2.groups.io/g/devel/topic/98505340#:~:text=This%20patch%20follows%20the%20UefiCpuPkg%20pattern%20and%20adds%3D0D,between%20the%20GCD%20and%20the%20page%20table.%3D0D%20%3D0D), this causes an access flag fault incorrectly. See the linked BZ below for full details.

BZ: https://bugzilla.tianocore.org/show_bug.cgi?id=4463 Personal GitHub PR:
Github branch:

Cc: Leif Lindholm <quic_llindhol@quicinc.com>
Cc: Ard Biesheuvel <ardb+tianocore@kernel.org>
Cc: Sami Mujawar <sami.mujawar@arm.com>
Cc: Michael Kubacki <mikuback@linux.microsoft.com>
Cc: Sean Brogan <sean.brogan@microsoft.com>