### PR TITLE
MdeModulePkg/Core/Pei: set AprioriCount=0 before walking through next FV

### DIFF
--- a/MdeModulePkg/Core/Pei/Dispatcher/Dispatcher.c
+++ b/MdeModulePkg/Core/Pei/Dispatcher/Dispatcher.c
@@ -1630,6 +1630,7 @@ PeiDispatcher (
       Private->CurrentFileHandle    = NULL;
       Private->CurrentPeimCount     = 0;
       Private->CurrentFvFileHandles = NULL;
+      Private->AprioriCount         = 0;
     }
 
     //


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4438

The main dispatch loop in PeiDispatcher() goes through each FV and calls DiscoverPeimsAndOrderWithApriori() to search Apriori file to reorder all PEIMs then do the PEIM dispatched.

DiscoverPeimsAndOrderWithApriori() calculates Apriori file count for every FV once and set Private->AprioriCount, but Private->AprioriCount doesn't be set to 0 before dispatch loop walking through the next FV.

It causes the peim which sort on less than Private->AprioriCount and depex is not satisfied would be dispatched when dispatch loop go through to a scaned FV, even the peim is not set in APRIORI file.

Cc: Leon Chen <leon.chen@insyde.com>
Cc: Tim Lewis <tim.lewis@insyde.com>
Reported-by: Esther Lee <esther.lee@insyde.com>

Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>