### PR TITLE
BaseTools: toolsetup.bat always execute PYTHON_HOME

### DIFF
--- a/BaseTools/toolsetup.bat
+++ b/BaseTools/toolsetup.bat
@@ -313,14 +313,16 @@ if not defined PYTHON_COMMAND (
   )
 )
 
-if defined PYTHON_HOME (
-  if EXIST "%PYTHON_HOME%" (
-    set PYTHON_COMMAND=%PYTHON_HOME%\python.exe
-  ) else (
-    echo .
-    echo !!! ERROR !!!  PYTHON_HOME="%PYTHON_HOME%" does not exist.
-    echo .
-    goto end
+if not defined PYTHON_COMMAND (
+  if defined PYTHON_HOME (
+    if EXIST "%PYTHON_HOME%" (
+      set PYTHON_COMMAND=%PYTHON_HOME%\python.exe
+    ) else (
+      echo .
+      echo !!! ERROR !!!  PYTHON_HOME="%PYTHON_HOME%" does not exist.
+      echo .
+      goto end
+    )
   )
 )
 
@@ -447,5 +449,4 @@ set VS2015=
 set VSTool=
 set PYTHON_VER_MAJOR=
 set PYTHON_VER_MINOR=
-set SCRIPT_ERROR=
 popd


### PR DESCRIPTION
Ideally behavior is like below order that can support one local build machine, clone multiple Edk2, some of edk2 repo use old tag and some of edk2 repo use new tag, they can both support on one machine.

1. if defined PYTHON_COMMAND only
   - use PYTHON_COMMAND = user assigned
2. if not defined PYTHON_COMMAND, auto detect py -3
   - use PYTHON_COMMAND = py -3
3. if defined PYTHON_COMMAND and PYTHON_HOME, use PYTHON_COMMAND
   - use PYTHON_COMMAND = user assigned
4. if defined PYTHON_HOME only,
   - use PYTHON_COMMAND = %PYTHON_HOME%/python.exe

SCRIPT_ERROR should return for paraent batch file to consume for error handle.

Cc: Rebecca Cran <rebecca@bsdio.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Bob Feng <bob.c.feng@intel.com>
Cc: Yuwei Chen <yuwei.chen@intel.com>