### PR TITLE
IntelFsp2WrapperPkg: Fix ASSERT when FSP-S/M use FFS3.

### DIFF
--- a/IntelFsp2WrapperPkg/FspmWrapperPeim/FspmWrapperPeim.c
+++ b/IntelFsp2WrapperPkg/FspmWrapperPeim/FspmWrapperPeim.c
@@ -217,7 +217,7 @@ FspmWrapperInit (
     ASSERT_EFI_ERROR (Status);
 
     PeiServicesInstallFvInfoPpi (
-      NULL,
+      &((EFI_FIRMWARE_VOLUME_HEADER *)(UINTN)PcdGet32 (PcdFspmBaseAddress))->FileSystemGuid,
       (VOID *)(UINTN)PcdGet32 (PcdFspmBaseAddress),
       (UINT32)((EFI_FIRMWARE_VOLUME_HEADER *)(UINTN)PcdGet32 (PcdFspmBaseAddress))->FvLength,
       NULL,

--- a/IntelFsp2WrapperPkg/FspsWrapperPeim/FspsWrapperPeim.c
+++ b/IntelFsp2WrapperPkg/FspsWrapperPeim/FspsWrapperPeim.c
@@ -438,7 +438,7 @@ FspsWrapperInitDispatchMode (
   // FSP-S Wrapper running in Dispatch mode and reports FSP-S FV to PEI dispatcher.
   //
   PeiServicesInstallFvInfoPpi (
-    NULL,
+    &((EFI_FIRMWARE_VOLUME_HEADER *)(UINTN)PcdGet32 (PcdFspsBaseAddress))->FileSystemGuid,
     (VOID *)(UINTN)PcdGet32 (PcdFspsBaseAddress),
     (UINT32)((EFI_FIRMWARE_VOLUME_HEADER *)(UINTN)PcdGet32 (PcdFspsBaseAddress))->FvLength,
     NULL,


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4458

Original code call PeiServicesInstallFvInfoPpi() with NULL for the FvFormat parameter, then PeiServicesInstallFvInfoPpi() will assume it use FFS2, then ASSERT if FSP-S/M use FFS3.
Now set the FvFormat to the info got from FvHeader.

Cc: Chasel Chiu <chasel.chiu@intel.com>
Cc: Duggapu Chinni B <chinni.b.duggapu@intel.com>

Reviewed-by: S Ashraf Ali <ashraf.ali.s@intel.com>
Reviewed-by: Chasel Chiu <chasel.chiu@intel.com>