### PR TITLE
OvmfPkg/VirtIoSerialDxe: Update for 2015x86 compatibility

### DIFF
--- a/OvmfPkg/VirtioSerialDxe/VirtioSerial.c
+++ b/OvmfPkg/VirtioSerialDxe/VirtioSerial.c
@@ -66,11 +66,11 @@ VirtioSerialTxControl (
   IN     UINT16             Value
   )
 {
-  VIRTIO_SERIAL_CONTROL  Control = {
-    .Id    = Id,
-    .Event = Event,
-    .Value = Value,
-  };
+  VIRTIO_SERIAL_CONTROL  Control;
+
+  Control.Id    = Id;
+  Control.Event = Event;
+  Control.Value = Value;
 
   DEBUG ((
     DEBUG_INFO,


### PR DESCRIPTION
Move init of local variable structure fom declaration to statements to fix VS2015x86 build break.

Cc: Ard Biesheuvel <ardb+tianocore@kernel.org>
Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Jordan Justen <jordan.l.justen@intel.com>
Cc: Gerd Hoffmann <kraxel@redhat.com>