### PR TITLE
MdeModulePkg SdMmcPciHcDxe: SD/MMC capability debug print is incorrect

### DIFF
--- a/MdeModulePkg/Bus/Pci/SdMmcPciHcDxe/SdMmcPciHci.c
+++ b/MdeModulePkg/Bus/Pci/SdMmcPciHcDxe/SdMmcPciHci.c
@@ -30,7 +30,7 @@ DumpCapabilityReg (
   //
   // Dump Capability Data
   //
-  DEBUG ((DEBUG_INFO, " == Slot [%d] Capability is 0x%x ==\n", Slot, Capability));
+  DEBUG ((DEBUG_INFO, " == Slot [%d] Capability is 0x%llx ==\n", Slot, *(UINT64 *)Capability));
   DEBUG ((DEBUG_INFO, "   Timeout Clk Freq  %d%a\n", Capability->TimeoutFreq, (Capability->TimeoutUnit) ? "MHz" : "KHz"));
   DEBUG ((DEBUG_INFO, "   Base Clk Freq     %dMHz\n", Capability->BaseClkFreq));
   DEBUG ((DEBUG_INFO, "   Max Blk Len       %dbytes\n", 512 * (1 << Capability->MaxBlkLen)));


### PR DESCRIPTION
Patch sent at: https://edk2.groups.io/g/devel/message/104785

REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4394

Fix DumpCapabilityReg() debug log to print 64 bit capability instead of 32 bit pointer

Cc: Hao A Wu <hao.a.wu@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Andrew Fish <afish@apple.com>

Reviewed-by: Ard Biesheuvel <ardb@kernel.org>
Reviewed-by: Hao A Wu <hao.a.wu@intel.com>