### PR TITLE
RedfishPkg/RedfishPlatformConfigDxe: fix value type issue.

### DIFF
--- a/RedfishPkg/RedfishPlatformConfigDxe/RedfishPlatformConfigDxe.c
+++ b/RedfishPkg/RedfishPlatformConfigDxe/RedfishPlatformConfigDxe.c
@@ -1221,6 +1221,16 @@ HiiValueToRedfishValue (
       RedfishValue->Type = RedfishValueTypeString;
       break;
     case EFI_IFR_CHECKBOX_OP:
+      //
+      // There is case where HII driver defines UINT8 for checked-box opcode storage.
+      // IFR compiler will assign EFI_IFR_TYPE_NUM_SIZE_8 to its value type instead of
+      // EFI_IFR_TYPE_BOOLEAN. We do a patch here and use boolean value type for this
+      // case.
+      //
+      if (Value->Type != EFI_IFR_TYPE_BOOLEAN) {
+        Value->Type = EFI_IFR_TYPE_BOOLEAN;
+      }
+
     case EFI_IFR_NUMERIC_OP:
       Status = HiiValueToRedfishNumeric (Value, RedfishValue);
       if (EFI_ERROR (Status)) {


### PR DESCRIPTION
Fix incorrect value type issue for checked-box op-code. When the variable for checked-box is defined as UINT8 in varstore structure, IFR compiler assign its value type to EFI_IFR_TYPE_NUM_SIZE_8 instead of EFI_IFR_TYPE_BOOLEAN. However, the value type for checked-box is boolean value. Redfish service may return error because of incorrect value type passed to BIOS attribute registry.


Cc: Abner Chang <abner.chang@amd.com>
Cc: Igor Kulchytskyy <igork@ami.com>