### PR TITLE
SecurityPkg-EnrollFromDefaultKeysApp: Fix mismatching logs

### DIFF
--- a/SecurityPkg/EnrollFromDefaultKeysApp/EnrollFromDefaultKeysApp.c
+++ b/SecurityPkg/EnrollFromDefaultKeysApp/EnrollFromDefaultKeysApp.c
@@ -66,12 +66,12 @@ UefiMain (
 
   Status = EnrollDbxFromDefault ();
   if (EFI_ERROR (Status)) {
-    AsciiPrint ("EnrollFromDefaultKeysApp: Cannot enroll dbt: %r\n", Status);
+    AsciiPrint ("EnrollFromDefaultKeysApp: Cannot enroll dbx: %r\n", Status);
   }
 
   Status = EnrollDbtFromDefault ();
   if (EFI_ERROR (Status)) {
-    AsciiPrint ("EnrollFromDefaultKeysApp: Cannot enroll dbx: %r\n", Status);
+    AsciiPrint ("EnrollFromDefaultKeysApp: Cannot enroll dbt: %r\n", Status);
   }
 
   Status = EnrollKEKFromDefault ();


### PR DESCRIPTION
The logs for enrolling default keys mismatched dbt and dbx. This commit fixes that mismatch.