### PR TITLE
IntelFsp2Pkg/Library/BaseFspCommonLib: Fix OVERRUN Coverity issue

### DIFF
--- a/IntelFsp2Pkg/Library/BaseFspCommonLib/FspCommonLib.c
+++ b/IntelFsp2Pkg/Library/BaseFspCommonLib/FspCommonLib.c
@@ -377,7 +377,8 @@ GetFspSiliconInitUpdDataPointer (
 
   @param[in] Id       Measurement point ID.
 
-  @return performance timestamp.
+  @return performance timestamp if current PerfIdx is valid,
+          else return 0 as invalid performance timestamp
 **/
 UINT64
 EFIAPI
@@ -395,9 +396,10 @@ SetFspMeasurePoint (
   if (FspData->PerfIdx < sizeof (FspData->PerfData) / sizeof (FspData->PerfData[0])) {
     FspData->PerfData[FspData->PerfIdx]                  = AsmReadTsc ();
     ((UINT8 *)(&FspData->PerfData[FspData->PerfIdx]))[7] = Id;
+    return FspData->PerfData[(FspData->PerfIdx)++];
   }
 
-  return FspData->PerfData[(FspData->PerfIdx)++];
+  return 0;
 }
 
 /**


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4200

FspData->PerfIdx is getting increased for every call unconditionally in the function SetFspMeasurePoint and hence memory access can happen for out of bound FspData->PerfData[] array entries also.

Example -
   FspData->PerfData is an array of 32 UINT64 entries. Assume a call
   is made to SetFspMeasurePoint function when the FspData->PerfIdx
   last value is 31. It gets incremented to 32 at line 400.
   Any subsequent call to SetFspMeasurePoint functions leads to
   FspData->PerfData[32] getting accessed which is out of the PerfData
   array as well as the FSP_GLOBAL_DATA structure boundary.

Hence keep array access and index increment inside if block only and return invalid performance timestamp when PerfIdx is invalid.

Cc: Chasel Chiu <chasel.chiu@intel.com>
Cc: Nate DeSimone <nathaniel.l.desimone@intel.com>
Cc: Star Zeng <star.zeng@intel.com>

Acked-by: Pedro Falcato <pedro.falcato@gmail.com>
Reviewed-by: Chasel Chiu <chasel.chiu@intel.com>