### PR TITLE
UefiCpuPkg:  check cpu sync mode in  SmmCpuRendezvous()

### DIFF
--- a/UefiCpuPkg/PiSmmCpuDxeSmm/CpuService.c
+++ b/UefiCpuPkg/PiSmmCpuDxeSmm/CpuService.c
@@ -1,7 +1,7 @@
 /** @file
 Implementation of SMM CPU Services Protocol.
 
-Copyright (c) 2011 - 2022, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2011 - 2023, Intel Corporation. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -421,11 +421,18 @@ SmmCpuRendezvous (
     goto ON_EXIT;
   }
 
-  //
-  // There are some APs outside SMM, Wait for all avaiable APs to arrive.
-  //
-  SmmWaitForApArrival ();
-  Status = mSmmMpSyncData->AllApArrivedWithException ? EFI_SUCCESS : EFI_TIMEOUT;
+  if ((mSmmMpSyncData->EffectiveSyncMode != SmmCpuSyncModeTradition) && !SmmCpuFeaturesNeedConfigureMtrrs ()) {
+    //
+    // There are some APs outside SMM, Wait for all avaiable APs to arrive.
+    //
+    SmmWaitForApArrival ();
+    Status = mSmmMpSyncData->AllApArrivedWithException ? EFI_SUCCESS : EFI_TIMEOUT;
+  } else {
+    //
+    // BSP has already waitted for APs to arrive SMM if SmmCpuSyncMode selected or need config MTRR.
+    //
+    Status = EFI_TIMEOUT;
+  }
 
 ON_EXIT:
   if (!mSmmMpSyncData->AllApArrivedWithException) {

--- a/UefiCpuPkg/PiSmmCpuDxeSmm/PiSmmCpuDxeSmm.c
+++ b/UefiCpuPkg/PiSmmCpuDxeSmm/PiSmmCpuDxeSmm.c
@@ -1541,6 +1541,19 @@ PerformRemainingTasks (
 {
   if (mSmmReadyToLock) {
     //
+    // Check if all Aps enter SMM. In Relaxed-AP Sync Mode, BSP will not wait for
+    // all Aps arrive. However,PerformRemainingTasks() needs to wait all Aps arrive before calling
+    // SetMemMapAttributes() and ConfigSmmCodeAccessCheck() when mSmmReadyToLock
+    // is true. In SetMemMapAttributes(), SmmSetMemoryAttributesEx() will call
+    // FlushTlbForAll() that need to start up the aps. So it need to let all
+    // aps arrive. Same as SetMemMapAttributes(), ConfigSmmCodeAccessCheck()
+    // also will start up the aps.
+    //
+    if (EFI_ERROR (SmmCpuRendezvous (NULL, TRUE))) {
+      DEBUG ((DEBUG_ERROR, "PerformRemainingTasks: fail to wait for all AP check in SMM!\n"));
+    }
+
+    //
     // Start SMM Profile feature
     //
     if (FeaturePcdGet (PcdCpuSmmProfileEnable)) {


### PR DESCRIPTION
add Ap Rendezvous check in PerformRemainingTasks and check cpu sync mode in  SmmCpuRendezvous().

REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4424
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4431

In Ap relaxed mode, some SMI handlers should call SmmWaitForApArrival() to 
let all ap arrive in SmmCpuRendezvous(). But in traditional mode, these SMI 
handlers don't need to call SmmWaitForApArrival() again. So it need to be 
check cpu sync mode before calling SmmWaitForApArrival().

In Relaxed-AP Sync Mode, BSP will not wait for all Aps arrive. However,
PerformRemainingTasks() needs to wait all Aps arrive before calling
SetMemMapAttributes and ConfigSmmCodeAccessCheck() when mSmmReadyToLock
is true. In SetMemMapAttributes(), SmmSetMemoryAttributesEx() will call
FlushTlbForAll() that need to start up the aps. So it need to let all
aps arrive. Same as SetMemMapAttributes(), ConfigSmmCodeAccessCheck()
also will start up the aps.

Cc: Eric Dong <eric.dong@intel.com>
Cc: Ray Ni <ray.ni@intel.com>

Signed-off-by: Zhihao Li <zhihao.li@intel.com>
Reviewed-by: Ray Ni <ray.ni@intel.com>
