### PR TITLE
CI: Use latest image for Linux jobs

### DIFF
--- a/.azurepipelines/templates/defaults.yml
+++ b/.azurepipelines/templates/defaults.yml
@@ -9,4 +9,4 @@
 
 variables:
   default_python_version: ">=3.10.6"
-  default_linux_image: "ghcr.io/tianocore/containers/fedora-37-test:3b3eb8f"
+  default_linux_image: "ghcr.io/tianocore/containers/fedora-37-test:a0dd931"


### PR DESCRIPTION
Use the latest Linux container image (from 2023-05-30). It uses Qemu 8.0.0 and GCC12.

REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4324