### PR TITLE
ArmPkg: Enable AuditMode for Uncrustify CI checks

### DIFF
--- a/ArmPkg/ArmPkg.ci.yaml
+++ b/ArmPkg/ArmPkg.ci.yaml
@@ -239,5 +239,10 @@
         ],
         "AdditionalIncludePaths": [] # Additional paths to spell check
                                      # (wildcards supported)
+    },
+
+    # options defined in .pytool/Plugin/UncrustifyCheck
+    "UncrustifyCheck": {
+        "AuditOnly": True
     }
 }


### PR DESCRIPTION
Uncrustify checks are too rigid, making them counter-productive:

- it leads to code that is arguably harder to parse visually (e.g., the changes to ArmPkg/Include/Chipset/AArch64Mmu.h in commit 429309e0c6b74792)
- it forces indentation-only changes to code in the vicinity of actual changes, making the code history more bloated than necessary (see commit 7f198321eec0f520373 for an example)
- finding out from the web UI what exactly Uncrustify objected to is not straight-forward.

So let's enable AuditMode for ArmPkg, so that interested parties can see the uncrustify recommendations if desired, but without preventing the changes from being merged. This leaves it at the discretion of the ArmPkg maintainers to decide which level of conformance is required.

Cc: Leif Lindholm <quic_llindhol@quicinc.com>
Cc: "Kinney, Michael D" <michael.d.kinney@intel.com>
Cc: Michael Kubacki <mikuback@linux.microsoft.com>

Reviewed-by: Leif Lindholm <quic_llindhol@quicinc.com>