### PR TITLE
[CI Check]CharEncodingCheckPlugin: Remove Noisy Print

### DIFF
--- a/.pytool/Plugin/CharEncodingCheck/CharEncodingCheck.py
+++ b/.pytool/Plugin/CharEncodingCheck/CharEncodingCheck.py
@@ -93,9 +93,7 @@ class CharEncodingCheck(ICiBuildPlugin):
             files = [Edk2pathObj.GetAbsolutePathOnThisSystemFromEdk2RelativePath(x) for x in files]
             for a in files:
                 files_tested += 1
-                if(self.TestEncodingOk(a, enc)):
-                    logging.debug("File {0} Passed Encoding Check {1}".format(a, enc))
-                else:
+                if not self.TestEncodingOk(a, enc):
                     tc.LogStdError("Encoding Failure in {0}.  Not {1}".format(a, enc))
                     overall_status += 1
 


### PR DESCRIPTION
Currently, CharEncodingCheckPlugin prints a message for every file that passes the test, which for some platforms can cause most of the CI build log to be filled with this print. It does not add any value, so this patch removes the noisy print and only prints if the encoding check fails.

Cc: Sean Brogan <sean.brogan@microsoft.com>
Cc: Michael Kubacki <mikuback@linux.microsoft.com>
Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>