### PR TITLE
MdeModulePkg/Bus: Fix port multiplier port in AhciPei PEIM

### DIFF
--- a/MdeModulePkg/Bus/Ata/AhciPei/AhciPeiPassThru.c
+++ b/MdeModulePkg/Bus/Ata/AhciPei/AhciPeiPassThru.c
@@ -3,6 +3,7 @@
   mode at PEI phase.
 
   Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.<BR>
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -91,6 +92,15 @@ AhciPassThruExecute (
   )
 {
   EFI_STATUS  Status;
+
+  if (PortMultiplierPort == 0xFFFF) {
+    //
+    // If there is no port multiplier, PortMultiplierPort will be 0xFFFF
+    // according to UEFI spec. Here, we convert its value to 0 to follow
+    // AHCI spec.
+    //
+    PortMultiplierPort = 0;
+  }
 
   switch (Packet->Protocol) {
     case EFI_ATA_PASS_THRU_PROTOCOL_ATA_NON_DATA:


### PR DESCRIPTION
Patch sent at: https://edk2.groups.io/g/devel/message/105204

If there is no port multiplier, PortMultiplierPort should be converted to 0 to follow AHCI spec.
The same logic already applied in AtaAtapiPassThruDxe driver.


Acked-by: Abner Chang <abner.chang@amd.com>
Reviewed-by: Hao A Wu <hao.a.wu@intel.com>