### PR TITLE
MdePkg/BaseLib: Add SpeculationBarrier implementation for RiscV64

### DIFF
--- a/MdePkg/Library/BaseLib/BaseLib.inf
+++ b/MdePkg/Library/BaseLib/BaseLib.inf
@@ -404,6 +404,7 @@
   RiscV64/CpuScratch.S              | GCC
   RiscV64/ReadTimer.S               | GCC
   RiscV64/RiscVMmu.S                | GCC
+  RiscV64/SpeculationBarrier.S      | GCC
 
 [Sources.LOONGARCH64]
   Math64.c

--- a/MdePkg/Library/BaseLib/RiscV64/SpeculationBarrier.S
+++ b/MdePkg/Library/BaseLib/RiscV64/SpeculationBarrier.S
@@ -1,0 +1,34 @@
+##------------------------------------------------------------------------------
+#
+# SpeculationBarrier() for RISCV64
+#
+# Copyright (c) 2023, Intel Corporation. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##------------------------------------------------------------------------------
+
+.text
+.p2align 2
+
+ASM_GLOBAL ASM_PFX(SpeculationBarrier)
+
+
+#/**
+#  Uses as a barrier to stop speculative execution.
+#
+#  Ensures that no later instruction will execute speculatively, until all prior
+#  instructions have completed.
+#
+#**/
+#VOID
+#EFIAPI
+#SpeculationBarrier (
+#  VOID
+#  );
+#
+ASM_PFX(SpeculationBarrier):
+    fence rw,rw
+    fence.i
+    fence r,r
+    ret


### PR DESCRIPTION
Implement the SpeculationBarrier with implementations consisting of fence instruction which provides finer-grain memory orderings. Perform Data Barrier in RiscV: fence rw,rw
Perform Instruction Barrier in RiscV: fence.i; fence r,r More detail is in Appendix A: RVWMO Explanatory Material in https://github.com/riscv/riscv-isa-manual

This API is first introduced in the below commits for IA32 and x64 https://github.com/tianocore/edk2/commit/d9f1cac51bd354507e880e614d11a1dc160d38a3 https://github.com/tianocore/edk2/commit/e83d841fdc2878959185c4c6cc38a7a1e88377a4 and below the commit for ARM and AArch64 implementation https://github.com/tianocore/edk2/commit/c0959b4426b2da45cdb8146a5116bb4fd9b86534

This commit is to add the RiscV64 implementation which will be used by variable service under Variable/RuntimeDxe

Cc: Andrei Warkentin <andrei.warkentin@intel.com>
Cc: Evan Chai <evan.chai@intel.com>
Cc: Sunil V L <sunilvl@ventanamicro.com>
Cc: Tuan Phan <tphan@ventanamicro.com>
Signed-off-by: Yong Li <yong.li@intel.com>
Reviewed-by: Sunil V L <sunilvl@ventanamicro.com>