### PR TITLE
ShellPkg/SmbiosView: type 45 and type 46 support.

### DIFF
--- a/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/PrintInfo.h
+++ b/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/PrintInfo.h
@@ -3,6 +3,7 @@
 
   Copyright (c) 2005 - 2015, Intel Corporation. All rights reserved.<BR>
   (C) Copyright 2017 - 2019 Hewlett Packard Enterprise Development LP<BR>
+  Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -435,6 +436,30 @@ DisplayTpmDeviceCharacteristics (
 **/
 VOID
 DisplayProcessorArchitectureType (
+  IN UINT8  Key,
+  IN UINT8  Option
+  );
+
+/**
+  Display Firmware Characteristics (Type 45) details.
+
+  @param[in] Chara    The information bits.
+  @param[in] Option   The optional information.
+**/
+VOID
+DisplayFirmwareCharacteristics (
+  IN UINT16  Chara,
+  IN UINT8   Option
+  );
+
+/**
+  Display Firmware state (Type 45) details.
+
+  @param[in] Key            The key of the structure.
+  @param[in] Option         The optional information.
+**/
+VOID
+DisplayFirmwareState (
   IN UINT8  Key,
   IN UINT8  Option
   );

--- a/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/QueryTable.c
+++ b/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/QueryTable.c
@@ -4,6 +4,7 @@
 
   Copyright (c) 2005 - 2021, Intel Corporation. All rights reserved.<BR>
   (C) Copyright 2016-2019 Hewlett Packard Enterprise Development LP<BR>
+  Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -3622,6 +3623,52 @@ TABLE_ITEM  ProcessorArchitectureTypesTable[] = {
   }
 };
 
+TABLE_ITEM  FirmwareInventoryCharTable[] = {
+  {
+    0,
+    L"Updatable"
+  },
+  {
+    1,
+    L"Write-Protect"
+  }
+};
+
+TABLE_ITEM  FirmwareInventoryStateTable[] = {
+  {
+    1,
+    L"  Other"
+  },
+  {
+    2,
+    L"  Unknown "
+  },
+  {
+    3,
+    L"  Disabled: This firmware component is disabled. "
+  },
+  {
+    4,
+    L"  Enabled: This firmware component is enabled. "
+  },
+  {
+    5,
+    L"  Absent: This firmware component is either not present or not detected "
+  },
+  {
+    6,
+    L"  StandbyOffline: This firmware is enabled but awaits an external action to activate it. "
+  },
+  {
+    7,
+    L"  StandbySpare: This firmware is part of a redundancy set and awaits a failover or other external action to activate it. "
+  },
+  {
+    8,
+    L"  UnavailableOffline: This firmware component is present but cannot be used. "
+  },
+};
+
 TABLE_ITEM  StructureTypeInfoTable[] = {
   {
     0,
@@ -5124,6 +5171,40 @@ DisplayProcessorArchitectureType (
   ShellPrintHiiEx (-1, -1, NULL, STRING_TOKEN (STR_SMBIOSVIEW_QUERYTABLE_PROCESSOR_ARCH_TYPE), gShellDebug1HiiHandle);
   PRINT_INFO_OPTION (Key, Option);
   PRINT_TABLE_ITEM (ProcessorArchitectureTypesTable, Key);
+}
+
+/**
+  Display Firmware Characteristics (Type 45) details.
+
+  @param[in] Chara    The information bits.
+  @param[in] Option   The optional information.
+**/
+VOID
+DisplayFirmwareCharacteristics (
+  IN UINT16  Chara,
+  IN UINT8   Option
+  )
+{
+  ShellPrintHiiEx (-1, -1, NULL, STRING_TOKEN (STR_SMBIOSVIEW_QUERYTABLE_FIRMWARE_INVENTORY_CHAR), gShellDebug1HiiHandle);
+  PRINT_INFO_OPTION (Chara, Option);
+  PRINT_BITS_INFO (FirmwareInventoryCharTable, Chara);
+}
+
+/**
+  Display Firmware state (Type 45) details.
+
+  @param[in] Key            The key of the structure.
+  @param[in] Option         The optional information.
+**/
+VOID
+DisplayFirmwareState (
+  IN UINT8  Key,
+  IN UINT8  Option
+  )
+{
+  ShellPrintHiiEx (-1, -1, NULL, STRING_TOKEN (STR_SMBIOSVIEW_QUERYTABLE_FIRMWARE_INVENTORY_STATE), gShellDebug1HiiHandle);
+  PRINT_INFO_OPTION (Key, Option);
+  PRINT_TABLE_ITEM (FirmwareInventoryStateTable, Key);
 }
 
 /**

--- a/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/SmbiosViewStrings.uni
+++ b/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/SmbiosViewStrings.uni
@@ -4,6 +4,7 @@
 // Copyright (c) 1985 - 2022, American Megatrends International LLC.<BR>
 // (C) Copyright 2014-2015 Hewlett-Packard Development Company, L.P.<BR>
 // (C) Copyright 2015-2019 Hewlett Packard Enterprise Development LP<BR>
+// Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
 // Module Name:
@@ -511,4 +512,10 @@
 #string STR_SMBIOSVIEW_PRINTINFO_IPMI_SPECIFICATION_REVISION    #language en-US "IPMISpecificationRevision: %d.%d\n"
 #string STR_SMBIOSVIEW_PRINTINFO_NV_STORAGE_DEVICE_NOT_PRESENT  #language en-US "NVStorageDevice: Not Present\n"
 #string STR_SMBIOSVIEW_PRINTINFO_BASE_ADDRESS                   #language en-US "BaseAddress: 0x%x\n"
-
+#string STR_SMBIOSVIEW_PRINTINFO_FIRMWARE_VERSION_FORMAT        #language en-US "FirmwareVersionFormat: %s\r\n"
+#string STR_SMBIOSVIEW_PRINTINFO_FIRMWARE_ID_FORMAT             #language en-US "FirmwareIdFormat: %s\r\n"
+#string STR_SMBIOSVIEW_QUERYTABLE_FIRMWARE_INVENTORY_CHAR       #language en-US "Characteristics:\r\n"
+#string STR_SMBIOSVIEW_QUERYTABLE_FIRMWARE_INVENTORY_STATE      #language en-US "State:\r\n"
+#string STR_SMBIOSVIEW_PRINTINFO_FIRMWARE_INVENTORY_ASSOCIATED  #language en-US "  Associated handle:\r\n"
+#string STR_SMBIOSVIEW_PRINTINFO_IMAGE_SIZE_UNKNOWN             #language en-US "ImageSize: Unknown\r\n"
+#string STR_SMBIOSVIEW_PRINTINFO_STRING_PROPERTY_ID             #language en-US "String Property ID: %s\r\n"


### PR DESCRIPTION
The initial version of Smbios Specification 3.6.0
type 45 and type 46 support.

Cc: Ray Ni <ray.ni@intel.com>
Cc: Zhichao Gao <zhichao.gao@intel.com>
Signed-off-by: Simon Wang <simowang@nvidia.com>
Reviewed-by: Zhichao Gao <zhichao.gao@intel.com>