### PR TITLE
MdePkg ACPI65: Update MADT Revision pre ACPI Spec 6.5

### DIFF
--- a/MdePkg/Include/IndustryStandard/Acpi65.h
+++ b/MdePkg/Include/IndustryStandard/Acpi65.h
@@ -293,7 +293,7 @@ typedef struct {
 ///
 /// MADT Revision (as defined in ACPI 6.5 spec.)
 ///
-#define EFI_ACPI_6_5_MULTIPLE_APIC_DESCRIPTION_TABLE_REVISION  0x05
+#define EFI_ACPI_6_5_MULTIPLE_APIC_DESCRIPTION_TABLE_REVISION  0x06
 
 ///
 /// Multiple APIC Flags


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4474

ACPI_Spec_6_5_Aug29 Table 5.19 page #128 that MADT Revision field is 6.

Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Zhiguang Liu <zhiguang.liu@intel.com>
Cc: Jiewen Yao <jiewen.yao@intel.com>

Reviewed-by: Michael D Kinney <michael.d.kinney@intel.com>