### PR TITLE
UefiCpuPkg: RISC-V: Fix timer calculation

### DIFF
--- a/MdePkg/Include/Register/RiscV64/RiscVImpl.h
+++ b/MdePkg/Include/Register/RiscV64/RiscVImpl.h
@@ -20,6 +20,5 @@
   Name:
 
 #define ASM_FUNC(Name)  _ASM_FUNC(ASM_PFX(Name), .text. ## Name)
-#define RISCV_TIMER_COMPARE_BITS  32
 
 #endif

--- a/UefiCpuPkg/CpuTimerDxeRiscV64/CpuTimerDxeRiscV64.inf
+++ b/UefiCpuPkg/CpuTimerDxeRiscV64/CpuTimerDxeRiscV64.inf
@@ -40,6 +40,9 @@
   Timer.h
   Timer.c
 
+[Pcd]
+  gUefiCpuPkgTokenSpaceGuid.PcdCpuCoreCrystalClockFrequency  ## CONSUMES
+
 [Protocols]
   gEfiCpuArchProtocolGuid       ## CONSUMES
   gEfiTimerArchProtocolGuid     ## PRODUCES

--- a/UefiCpuPkg/CpuTimerDxeRiscV64/Timer.c
+++ b/UefiCpuPkg/CpuTimerDxeRiscV64/Timer.c
@@ -80,8 +80,15 @@ TimerInterruptHandler (
     return;
   }
 
-  mLastPeriodStart          = PeriodStart;
-  SbiSetTimer (PeriodStart += mTimerPeriod);
+  mLastPeriodStart = PeriodStart;
+  PeriodStart     += DivU64x32 (
+                       MultU64x32 (
+                         mTimerPeriod,
+                         PcdGet64 (PcdCpuCoreCrystalClockFrequency)
+                         ),
+                       1000000u
+                       );  // convert to tick
+  SbiSetTimer (PeriodStart);
   RiscVEnableTimerInterrupt (); // enable SMode timer int
   gBS->RestoreTPL (OriginalTPL);
 }
@@ -163,6 +170,8 @@ TimerDriverSetTimerPeriod (
   IN UINT64                   TimerPeriod
   )
 {
+  UINT64  PeriodStart;
+
   DEBUG ((DEBUG_INFO, "TimerDriverSetTimerPeriod(0x%lx)\n", TimerPeriod));
 
   if (TimerPeriod == 0) {
@@ -171,9 +180,18 @@ TimerDriverSetTimerPeriod (
     return EFI_SUCCESS;
   }
 
-  mTimerPeriod     = TimerPeriod / 10; // convert unit from 100ns to 1us
+  mTimerPeriod = TimerPeriod / 10;     // convert unit from 100ns to 1us
+
   mLastPeriodStart = RiscVReadTimer ();
-  SbiSetTimer (mLastPeriodStart + mTimerPeriod);
+  PeriodStart      = mLastPeriodStart;
+  PeriodStart     += DivU64x32 (
+                       MultU64x32 (
+                         mTimerPeriod,
+                         PcdGet64 (PcdCpuCoreCrystalClockFrequency)
+                         ),
+                       1000000u
+                       ); // convert to tick
+  SbiSetTimer (PeriodStart);
 
   mCpu->EnableInterrupt (mCpu);
   RiscVEnableTimerInterrupt (); // enable SMode timer int

--- a/UefiCpuPkg/CpuTimerDxeRiscV64/Timer.h
+++ b/UefiCpuPkg/CpuTimerDxeRiscV64/Timer.h
@@ -21,7 +21,7 @@
 #include <Library/IoLib.h>
 
 //
-// RISC-V use 100us timer.
+// RISC-V use 100ns timer.
 // The default timer tick duration is set to 10 ms = 10 * 1000 * 10 100 ns units
 //
 #define DEFAULT_TIMER_TICK_DURATION  100000

--- a/UefiCpuPkg/Library/BaseRiscV64CpuTimerLib/CpuTimerLib.c
+++ b/UefiCpuPkg/Library/BaseRiscV64CpuTimerLib/CpuTimerLib.c
@@ -22,26 +22,19 @@
   @param  Delay     A period of time to delay in ticks.
 
 **/
+STATIC
 VOID
 InternalRiscVTimerDelay (
-  IN UINT32  Delay
+  IN UINT64  Delay
   )
 {
-  UINT32  Ticks;
-  UINT32  Times;
+  UINT64  Ticks;
 
-  Times  = Delay >> (RISCV_TIMER_COMPARE_BITS - 2);
-  Delay &= ((1 << (RISCV_TIMER_COMPARE_BITS - 2)) - 1);
-  do {
-    //
-    // The target timer count is calculated here
-    //
-    Ticks = RiscVReadTimer () + Delay;
-    Delay = 1 << (RISCV_TIMER_COMPARE_BITS - 2);
-    while (((Ticks - RiscVReadTimer ()) & (1 << (RISCV_TIMER_COMPARE_BITS - 1))) == 0) {
-      CpuPause ();
-    }
-  } while (Times-- > 0);
+  Ticks = RiscVReadTimer () + Delay;
+
+  while (RiscVReadTimer () <= Ticks) {
+    CpuPause ();
+  }
 }
 
 /**
@@ -61,13 +54,13 @@ MicroSecondDelay (
   )
 {
   InternalRiscVTimerDelay (
-    (UINT32)DivU64x32 (
-              MultU64x32 (
-                MicroSeconds,
-                PcdGet64 (PcdCpuCoreCrystalClockFrequency)
-                ),
-              1000000u
-              )
+    DivU64x32 (
+      MultU64x32 (
+        MicroSeconds,
+        PcdGet64 (PcdCpuCoreCrystalClockFrequency)
+        ),
+      1000000u
+      )
     );
   return MicroSeconds;
 }
@@ -89,13 +82,13 @@ NanoSecondDelay (
   )
 {
   InternalRiscVTimerDelay (
-    (UINT32)DivU64x32 (
-              MultU64x32 (
-                NanoSeconds,
-                PcdGet64 (PcdCpuCoreCrystalClockFrequency)
-                ),
-              1000000000u
-              )
+    DivU64x32 (
+      MultU64x32 (
+        NanoSeconds,
+        PcdGet64 (PcdCpuCoreCrystalClockFrequency)
+        ),
+      1000000000u
+      )
     );
   return NanoSeconds;
 }


### PR DESCRIPTION
This series fixes the issue that timer value has not been calculated correctly.