### PR TITLE
ShellPkg/SmbiosView: type 45 and type 46 support.

### DIFF
--- a/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/PrintInfo.c
+++ b/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/PrintInfo.c
@@ -6,6 +6,7 @@
   (C) Copyright 2014 Hewlett-Packard Development Company, L.P.<BR>
   (C) Copyright 2015-2019 Hewlett Packard Enterprise Development LP<BR>
   Copyright (c) 2023 Apple Inc. All rights reserved.<BR>
+  Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -306,9 +307,10 @@ SmbiosPrintStructure (
   IN  UINT8                     Option
   )
 {
-  UINT8  Index;
-  UINT8  Index2;
-  UINT8  *Buffer;
+  UINT8       Index;
+  UINT8       Index2;
+  UINT8       *Buffer;
+  EFI_STRING  String;
 
   if (Struct == NULL) {
     return EFI_INVALID_PARAMETER;
@@ -1304,6 +1306,109 @@ SmbiosPrintStructure (
       DisplayProcessorArchitectureType (Struct->Type44->ProcessorSpecificBlock.ProcessorArchType, Option);
       break;
 
+    //
+    // Firmware Inventory (Type 45)
+    //
+    case 45:
+      PRINT_PENDING_STRING (Struct, Type45, FirmwareComponentName);
+      PRINT_PENDING_STRING (Struct, Type45, FirmwareVersion);
+      if (Struct->Type45->FirmwareVersionFormat == VersionFormatTypeFreeForm) {
+        String = L"Free-form string";
+      } else if (Struct->Type45->FirmwareVersionFormat == VersionFormatTypeMajorMinor) {
+        String = L"MAJOR.MINOR";
+      } else if (Struct->Type45->FirmwareVersionFormat == VersionFormatType32BitHex) {
+        String = L"32-bit hexadecimal string";
+      } else if (Struct->Type45->FirmwareVersionFormat == VersionFormatTypeMajorMinor) {
+        String = L"64-bit hexadecimal string";
+      } else if (Struct->Type45->FirmwareVersionFormat >= 0x80) {
+        String = L"BIOS Vendor/OEM-specific";
+      } else {
+        String = L"Reserved";
+      }
+
+      ShellPrintHiiEx (
+        -1,
+        -1,
+        NULL,
+        STRING_TOKEN (STR_SMBIOSVIEW_PRINTINFO_FIRMWARE_VERSION_FORMAT),
+        gShellDebug1HiiHandle,
+        String
+        );
+      PRINT_PENDING_STRING (Struct, Type45, FirmwareId);
+      if (Struct->Type45->FirmwareIdFormat == FirmwareIdFormatTypeFreeForm) {
+        String = L"Free-form string";
+      } else if (Struct->Type45->FirmwareIdFormat == FirmwareIdFormatTypeUuid) {
+        String = L"RFC4122 UUID string";
+      } else if (Struct->Type45->FirmwareIdFormat >= 0x80) {
+        String = L"BIOS Vendor/OEM-specific";
+      } else {
+        String = L"Reserved";
+      }
+
+      ShellPrintHiiEx (
+        -1,
+        -1,
+        NULL,
+        STRING_TOKEN (STR_SMBIOSVIEW_PRINTINFO_FIRMWARE_ID_FORMAT),
+        gShellDebug1HiiHandle,
+        String
+        );
+      PRINT_PENDING_STRING (Struct, Type45, ReleaseDate);
+      PRINT_PENDING_STRING (Struct, Type45, Manufacturer);
+      PRINT_PENDING_STRING (Struct, Type45, LowestSupportedVersion);
+      if (Struct->Type45->ImageSize != MAX_UINT64) {
+        PRINT_STRUCT_VALUE_H (Struct, Type45, ImageSize);
+      } else {
+        ShellPrintHiiEx (
+          -1,
+          -1,
+          NULL,
+          STRING_TOKEN (STR_SMBIOSVIEW_PRINTINFO_IMAGE_SIZE_UNKNOWN),
+          gShellDebug1HiiHandle
+          );
+      }
+
+      DisplayFirmwareCharacteristics (ReadUnaligned16 ((UINT16 *)(UINTN)&(Struct->Type45->Characteristics)), Option);
+      DisplayFirmwareState (*(UINT8 *)(UINTN)&(Struct->Type45->State), Option);
+
+      PRINT_STRUCT_VALUE_H (Struct, Type45, AssociatedComponentCount);
+      if (Struct->Hdr->Length > sizeof (*Struct->Type45)) {
+        for (Index = 0; Index < Struct->Type45->AssociatedComponentCount; Index++) {
+          ShellPrintHiiEx (-1, -1, NULL, STRING_TOKEN (STR_SMBIOSVIEW_PRINTINFO_FIRMWARE_INVENTORY_ASSOCIATED), gShellDebug1HiiHandle);
+          Print (L"    0x%04X ", Buffer[sizeof (*Struct->Type45) + (Index * sizeof (SMBIOS_HANDLE))]);
+          Print (L"\n");
+        }
+      }
+
+      break;
+
+    //
+    // String Property (Type 46)
+    //
+    case 46:
+      if (Struct->Type46->StringPropertyId == StringPropertyIdDevicePath) {
+        String = L"UEFI device path";
+      } else if ((Struct->Type46->StringPropertyId >= StringPropertyIdBiosVendor) &&
+                 (Struct->Type46->StringPropertyId < StringPropertyIdOem))
+      {
+        String = L"BIOS vendor defined";
+      } else if (Struct->Type46->StringPropertyId >= StringPropertyIdOem) {
+        String = L"OEM defined";
+      } else {
+        String = L"Reserved";
+      }
+
+      ShellPrintHiiEx (
+        -1,
+        -1,
+        NULL,
+        STRING_TOKEN (STR_SMBIOSVIEW_PRINTINFO_STRING_PROPERTY_ID),
+        gShellDebug1HiiHandle,
+        String
+        );
+      PRINT_PENDING_STRING (Struct, Type46, StringPropertyValue);
+      PRINT_STRUCT_VALUE_H (Struct, Type46, ParentHandle);
+      break;
     //
     // Inactive (Type 126)
     //

--- a/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/PrintInfo.h
+++ b/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/PrintInfo.h
@@ -3,6 +3,7 @@
 
   Copyright (c) 2005 - 2015, Intel Corporation. All rights reserved.<BR>
   (C) Copyright 2017 - 2019 Hewlett Packard Enterprise Development LP<BR>
+  Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -435,6 +436,30 @@ DisplayTpmDeviceCharacteristics (
 **/
 VOID
 DisplayProcessorArchitectureType (
+  IN UINT8  Key,
+  IN UINT8  Option
+  );
+
+/**
+  Display Firmware Characteristics (Type 45) details.
+
+  @param[in] Chara    The information bits.
+  @param[in] Option   The optional information.
+**/
+VOID
+DisplayFirmwareCharacteristics (
+  IN UINT16  Chara,
+  IN UINT8   Option
+  );
+
+/**
+  Display Firmware state (Type 45) details.
+
+  @param[in] Key            The key of the structure.
+  @param[in] Option         The optional information.
+**/
+VOID
+DisplayFirmwareState (
   IN UINT8  Key,
   IN UINT8  Option
   );

--- a/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/QueryTable.c
+++ b/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/QueryTable.c
@@ -4,6 +4,7 @@
 
   Copyright (c) 2005 - 2021, Intel Corporation. All rights reserved.<BR>
   (C) Copyright 2016-2019 Hewlett Packard Enterprise Development LP<BR>
+  Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -3622,6 +3623,52 @@ TABLE_ITEM  ProcessorArchitectureTypesTable[] = {
   }
 };
 
+TABLE_ITEM  FirmwareInventoryCharTable[] = {
+  {
+    0,
+    L"Updatable"
+  },
+  {
+    1,
+    L"Write-Protect"
+  }
+};
+
+TABLE_ITEM  FirmwareInventoryStateTable[] = {
+  {
+    1,
+    L"  Other"
+  },
+  {
+    2,
+    L"  Unknown "
+  },
+  {
+    3,
+    L"  Disabled: This firmware component is disabled. "
+  },
+  {
+    4,
+    L"  Enabled: This firmware component is enabled. "
+  },
+  {
+    5,
+    L"  Absent: This firmware component is either not present or not detected "
+  },
+  {
+    6,
+    L"  StandbyOffline: This firmware is enabled but awaits an external action to activate it. "
+  },
+  {
+    7,
+    L"  StandbySpare: This firmware is part of a redundancy set and awaits a failover or other external action to activate it. "
+  },
+  {
+    8,
+    L"  UnavailableOffline: This firmware component is present but cannot be used. "
+  },
+};
+
 TABLE_ITEM  StructureTypeInfoTable[] = {
   {
     0,
@@ -5124,6 +5171,40 @@ DisplayProcessorArchitectureType (
   ShellPrintHiiEx (-1, -1, NULL, STRING_TOKEN (STR_SMBIOSVIEW_QUERYTABLE_PROCESSOR_ARCH_TYPE), gShellDebug1HiiHandle);
   PRINT_INFO_OPTION (Key, Option);
   PRINT_TABLE_ITEM (ProcessorArchitectureTypesTable, Key);
+}
+
+/**
+  Display Firmware Characteristics (Type 45) details.
+
+  @param[in] Chara    The information bits.
+  @param[in] Option   The optional information.
+**/
+VOID
+DisplayFirmwareCharacteristics (
+  IN UINT16  Chara,
+  IN UINT8   Option
+  )
+{
+  ShellPrintHiiEx (-1, -1, NULL, STRING_TOKEN (STR_SMBIOSVIEW_QUERYTABLE_FIRMWARE_INVENTORY_CHAR), gShellDebug1HiiHandle);
+  PRINT_INFO_OPTION (Chara, Option);
+  PRINT_BITS_INFO (FirmwareInventoryCharTable, Chara);
+}
+
+/**
+  Display Firmware state (Type 45) details.
+
+  @param[in] Key            The key of the structure.
+  @param[in] Option         The optional information.
+**/
+VOID
+DisplayFirmwareState (
+  IN UINT8  Key,
+  IN UINT8  Option
+  )
+{
+  ShellPrintHiiEx (-1, -1, NULL, STRING_TOKEN (STR_SMBIOSVIEW_QUERYTABLE_FIRMWARE_INVENTORY_STATE), gShellDebug1HiiHandle);
+  PRINT_INFO_OPTION (Key, Option);
+  PRINT_TABLE_ITEM (FirmwareInventoryStateTable, Key);
 }
 
 /**

--- a/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/SmbiosViewStrings.uni
+++ b/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/SmbiosViewStrings.uni
@@ -4,6 +4,7 @@
 // Copyright (c) 1985 - 2022, American Megatrends International LLC.<BR>
 // (C) Copyright 2014-2015 Hewlett-Packard Development Company, L.P.<BR>
 // (C) Copyright 2015-2019 Hewlett Packard Enterprise Development LP<BR>
+// Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
 // Module Name:
@@ -511,4 +512,10 @@
 #string STR_SMBIOSVIEW_PRINTINFO_IPMI_SPECIFICATION_REVISION    #language en-US "IPMISpecificationRevision: %d.%d\n"
 #string STR_SMBIOSVIEW_PRINTINFO_NV_STORAGE_DEVICE_NOT_PRESENT  #language en-US "NVStorageDevice: Not Present\n"
 #string STR_SMBIOSVIEW_PRINTINFO_BASE_ADDRESS                   #language en-US "BaseAddress: 0x%x\n"
-
+#string STR_SMBIOSVIEW_PRINTINFO_FIRMWARE_VERSION_FORMAT        #language en-US "FirmwareVersionFormat: %s\r\n"
+#string STR_SMBIOSVIEW_PRINTINFO_FIRMWARE_ID_FORMAT             #language en-US "FirmwareIdFormat: %s\r\n"
+#string STR_SMBIOSVIEW_QUERYTABLE_FIRMWARE_INVENTORY_CHAR       #language en-US "Characteristics:\r\n"
+#string STR_SMBIOSVIEW_QUERYTABLE_FIRMWARE_INVENTORY_STATE      #language en-US "State:\r\n"
+#string STR_SMBIOSVIEW_PRINTINFO_FIRMWARE_INVENTORY_ASSOCIATED  #language en-US "  Associated handle:\r\n"
+#string STR_SMBIOSVIEW_PRINTINFO_IMAGE_SIZE_UNKNOWN             #language en-US "ImageSize: Unknown\r\n"
+#string STR_SMBIOSVIEW_PRINTINFO_STRING_PROPERTY_ID             #language en-US "String Property ID: %s\r\n"


### PR DESCRIPTION
The initial version of Smbios Specification 3.6.0
type 45 and type 46 support.


Cc: Ray Ni <ray.ni@intel.com>
Cc: Zhichao Gao <zhichao.gao@intel.com>
Reviewed-by: Zhichao Gao <zhichao.gao@intel.com>