### PR TITLE
MdeModulePkg/Variable: TcgMorLockSmm Key Mismatch changes lock state

### DIFF
--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/TcgMorLockSmm.c
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/TcgMorLockSmm.c
@@ -312,6 +312,10 @@ SetVariableCheckHandlerMorLock (
       mMorLockState    = MorLockStateLocked;
       mMorLockKeyEmpty = TRUE;
       ZeroMem (mMorLockKey, sizeof (mMorLockKey));
+      //
+      // Update value to reflect locked without key
+      //
+      SetMorLockVariable (MOR_LOCK_DATA_LOCKED_WITHOUT_KEY);
       return EFI_ACCESS_DENIED;
     }
   }


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4410

Inside TcgMorLockSmm.c, the SetVariableCheckHandlerMorLock() function contains a scenario to prevent a possible dictionary attack on the MorLock Key in accordance with the TCG Platform Reset Mitigation Spec v1.10.

The mechanism to prevent this attack must also change the MorLock Variable Value to 0x01 to indicate Locked Without Key.

Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>