### PR TITLE
MdePkg: Add UefiBootServicesTableLib gmock support

### DIFF
--- a/MdePkg/Test/MdePkgHostTest.dsc
+++ b/MdePkg/Test/MdePkgHostTest.dsc
@@ -38,3 +38,4 @@
   MdePkg/Test/Mock/Library/GoogleTest/MockUefiRuntimeServicesTableLib/MockUefiRuntimeServicesTableLib.inf
   MdePkg/Test/Mock/Library/GoogleTest/MockPeiServicesLib/MockPeiServicesLib.inf
   MdePkg/Test/Mock/Library/GoogleTest/MockHobLib/MockHobLib.inf
+  MdePkg/Test/Mock/Library/GoogleTest/MockUefiBootServicesTableLib/MockUefiBootServicesTableLib.inf

--- a/MdePkg/Test/Mock/Include/GoogleTest/Library/MockUefiBootServicesTableLib.h
+++ b/MdePkg/Test/Mock/Include/GoogleTest/Library/MockUefiBootServicesTableLib.h
@@ -1,0 +1,85 @@
+/** @file
+  Google Test mocks for UefiBootServicesTableLib
+
+  Copyright (c) 2023, Intel Corporation. All rights reserved.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef MOCK_UEFI_BOOT_SERVICES_TABLE_LIB_H_
+#define MOCK_UEFI_BOOT_SERVICES_TABLE_LIB_H_
+
+#include <Library/GoogleTestLib.h>
+#include <Library/FunctionMockLib.h>
+extern "C" {
+#include <Uefi.h>
+#include <Library/UefiBootServicesTableLib.h>
+}
+
+struct MockUefiBootServicesTableLib {
+  MOCK_INTERFACE_DECLARATION (MockUefiBootServicesTableLib);
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    gBS_LocateProtocol,
+    (IN   EFI_GUID  *Protocol,
+     IN   VOID      *Registration  OPTIONAL,
+     OUT  VOID      **Interface)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    gBS_LocateHandleBuffer,
+    (IN   EFI_LOCATE_SEARCH_TYPE    SearchType,
+     IN   EFI_GUID                  *Protocol       OPTIONAL,
+     IN   VOID                      *SearchKey      OPTIONAL,
+     OUT  UINTN                     *NoHandles,
+     OUT  EFI_HANDLE                **Buffer)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    gBS_DisconnectController,
+    (IN  EFI_HANDLE   ControllerHandle,
+     IN  EFI_HANDLE   DriverImageHandle  OPTIONAL,
+     IN  EFI_HANDLE   ChildHandle        OPTIONAL)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    gBS_FreePool,
+    (IN  VOID  *Buffer)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    gBS_ConnectController,
+    (IN  EFI_HANDLE                 ControllerHandle,
+     IN  EFI_HANDLE                 *DriverImageHandle    OPTIONAL,
+     IN  EFI_DEVICE_PATH_PROTOCOL   *RemainingDevicePath  OPTIONAL,
+     IN  BOOLEAN                    Recursive)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    gBS_HandleProtocol,
+    (IN  EFI_HANDLE    Handle,
+     IN  EFI_GUID      *Protocol,
+     OUT VOID          **Interface)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    gBS_CopyMem,
+    (IN VOID     *Destination,
+     IN VOID     *Source,
+     IN UINTN    Length)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    gBS_Stall,
+    (IN  UINTN  Microseconds)
+    );
+};
+
+#endif

--- a/MdePkg/Test/Mock/Library/GoogleTest/MockUefiBootServicesTableLib/MockUefiBootServicesTableLib.cpp
+++ b/MdePkg/Test/Mock/Library/GoogleTest/MockUefiBootServicesTableLib/MockUefiBootServicesTableLib.cpp
@@ -1,0 +1,76 @@
+/** @file
+  Google Test mocks for UefiBootServicesTableLib
+
+  Copyright (c) 2023, Intel Corporation. All rights reserved.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+#include <GoogleTest/Library/MockUefiBootServicesTableLib.h>
+
+MOCK_INTERFACE_DEFINITION(MockUefiBootServicesTableLib);
+
+MOCK_FUNCTION_DEFINITION(MockUefiBootServicesTableLib, gBS_LocateProtocol, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION(MockUefiBootServicesTableLib, gBS_LocateHandleBuffer, 5, EFIAPI);
+MOCK_FUNCTION_DEFINITION(MockUefiBootServicesTableLib, gBS_DisconnectController, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION(MockUefiBootServicesTableLib, gBS_FreePool, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION(MockUefiBootServicesTableLib, gBS_ConnectController, 4, EFIAPI);
+MOCK_FUNCTION_DEFINITION(MockUefiBootServicesTableLib, gBS_HandleProtocol, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION(MockUefiBootServicesTableLib, gBS_Stall, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION(MockUefiBootServicesTableLib, gBS_CopyMem, 3, EFIAPI);
+
+static EFI_BOOT_SERVICES localBs = {
+  {
+    (UINT64)NULL,                                         // Signature
+    0,                                                    // Revision
+    0,                                                    // HeaderSize
+    0,                                                    // CRC32
+    0                                                     // Reserved
+  },
+  NULL,                                                   // RaiseTPL
+  NULL,                                                   // RestoreTPL
+  NULL,                                                   // AllocatePages
+  NULL,                                                   // FreePages
+  NULL,                                                   // GetMemoryMap
+  NULL,                                                   // AllocatePool
+  (EFI_FREE_POOL)gBS_FreePool,                            // FreePool
+  NULL,                                                   // CreateEvent
+  NULL,                                                   // SetTimer
+  NULL,                                                   // WaitForEvent
+  NULL,                                                   // SignalEvent
+  NULL,                                                   // CloseEvent
+  NULL,                                                   // CheckEvent
+  NULL,                                                   // InstallProtocolInterface
+  NULL,                                                   // ReinstallProtocolInterface
+  NULL,                                                   // UninstallProtocolInterface
+  (EFI_HANDLE_PROTOCOL)gBS_HandleProtocol,                // HandleProtocol
+  (VOID *)NULL,                                           // Reserved
+  NULL,                                                   // RegisterProtocolNotify
+  NULL,                                                   // LocateHandle
+  NULL,                                                   // LocateDevicePath
+  NULL,                                                   // InstallConfigurationTable
+  NULL,                                                   // LoadImage
+  NULL,                                                   // StartImage
+  NULL,                                                   // Exit
+  NULL,                                                   // UnloadImage
+  NULL,                                                   // ExitBootServices
+  NULL,                                                   // GetNextMonotonicCount
+  (EFI_STALL)gBS_Stall,                                   // Stall
+  NULL,                                                   // SetWatchdogTimer
+  (EFI_CONNECT_CONTROLLER)gBS_ConnectController,          // ConnectController
+  (EFI_DISCONNECT_CONTROLLER)gBS_DisconnectController,    // DisconnectController
+  NULL,                                                   // OpenProtocol
+  NULL,                                                   // CloseProtocol
+  NULL,                                                   // OpenProtocolInformation
+  NULL,                                                   // ProtocolsPerHandle
+  (EFI_LOCATE_HANDLE_BUFFER)gBS_LocateHandleBuffer,       // LocateHandleBuffer
+  (EFI_LOCATE_PROTOCOL)gBS_LocateProtocol,                // LocateProtocol
+  NULL,                                                   // InstallMultipleProtocolInterfaces
+  NULL,                                                   // UninstallMultipleProtocolInterfaces
+  NULL,                                                   // CalculateCrc32
+  (EFI_COPY_MEM)gBS_CopyMem,                              // CopyMem
+  NULL,                                                   // SetMem
+  NULL                                                    // CreateEventEx
+};
+
+extern "C" {
+  EFI_BOOT_SERVICES* gBS = &localBs;
+}

--- a/MdePkg/Test/Mock/Library/GoogleTest/MockUefiBootServicesTableLib/MockUefiBootServicesTableLib.inf
+++ b/MdePkg/Test/Mock/Library/GoogleTest/MockUefiBootServicesTableLib/MockUefiBootServicesTableLib.inf
@@ -1,0 +1,33 @@
+## @file
+# Google Test mocks for UefiBootServicesTableLib
+#
+# Copyright (c) 2023, Intel Corporation. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = MockUefiBootServicesTableLib
+  FILE_GUID                      = 9C6D2161-61B2-4094-BC8D-92F70C5E3C06
+  MODULE_TYPE                    = HOST_APPLICATION
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = MockUefiBootServicesTableLib
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  MockUefiBootServicesTableLib.cpp
+
+[Packages]
+  MdePkg/MdePkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+
+[LibraryClasses]
+  GoogleTestLib
+
+[BuildOptions]
+  MSFT:*_*_*_CC_FLAGS = /EHsc


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4485

Add Google Mock Library for UefiBootServicesTableLib

Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Zhiguang Liu <zhiguang.liu@intel.com>