### PR TITLE
[TEST] ArmPkg: Add Pcd to disable EFI_MEMORY_ATTRIBUTE_PROTOCOL

### DIFF
--- a/ArmPkg/ArmPkg.dec
+++ b/ArmPkg/ArmPkg.dec
@@ -172,6 +172,9 @@
   gArmTokenSpaceGuid.PcdCpuVectorBaseAddress|0xffff0000|UINT64|0x00000004
   gArmTokenSpaceGuid.PcdCpuResetAddress|0x00000000|UINT32|0x00000005
 
+  # Enable/Disable EFI_MEMORY_ATTRIBUTE_PROTOCOL
+  gArmTokenSpaceGuid.PcdEnableEfiMemoryAttributeProtocol|TRUE|BOOLEAN|0x000000EE
+
   #
   # ARM Secure Firmware PCDs
   #

--- a/ArmPkg/Drivers/CpuDxe/CpuDxe.c
+++ b/ArmPkg/Drivers/CpuDxe/CpuDxe.c
@@ -329,10 +329,19 @@ CpuDxeInitialize (
                   &mCpuHandle,
                   &gEfiCpuArchProtocolGuid,
                   &mCpu,
-                  &gEfiMemoryAttributeProtocolGuid,
-                  &mMemoryAttribute,
                   NULL
                   );
+  ASSERT_EFI_ERROR (Status);
+
+  if (PcdGetBool (PcdEnableEfiMemoryAttributeProtocol)) {
+    Status = gBS->InstallMultipleProtocolInterfaces (
+                    &mCpuHandle,
+                    &gEfiMemoryAttributeProtocolGuid,
+                    &mMemoryAttribute,
+                    NULL
+                    );
+    ASSERT_EFI_ERROR (Status);
+  }
 
   //
   // Make sure GCD and MMU settings match. This API calls gDS->SetMemorySpaceAttributes ()

--- a/ArmPkg/Drivers/CpuDxe/CpuDxe.inf
+++ b/ArmPkg/Drivers/CpuDxe/CpuDxe.inf
@@ -66,6 +66,7 @@
 [Pcd.common]
   gArmTokenSpaceGuid.PcdVFPEnabled
   gEfiMdeModulePkgTokenSpaceGuid.PcdDxeNxMemoryProtectionPolicy
+  gArmTokenSpaceGuid.PcdEnableEfiMemoryAttributeProtocol
 
 [FeaturePcd.common]
   gArmTokenSpaceGuid.PcdDebuggerExceptionSupport


### PR DESCRIPTION
Recent versions of shim (15.6 and 15.7) crash when the newly added EFI_MEMORY_ATTRIBUTE_PROTOCOL is provided by the firmware.  To allow existing installations to boot, provide a workaround in form of a Pcd that allows tuning it off at build time (defaults to 'enabled').

Additionally, check the return code of the protocol installation calls.