### PR TITLE
NetworkPkg: Correct the length of EAP Identity when in ASCII format

### DIFF
--- a/NetworkPkg/WifiConnectionManagerDxe/WifiConnectionMgrImpl.c
+++ b/NetworkPkg/WifiConnectionManagerDxe/WifiConnectionMgrImpl.c
@@ -572,15 +572,24 @@ WifiMgrConfigEap (
   // Set Identity to Eap peer, Mandatory field for PEAP and TTLS
   //
   if (StrLen (Profile->EapIdentity) > 0) {
-    IdentitySize = sizeof (CHAR8) * (StrLen (Profile->EapIdentity) + 1);
-    Identity     = AllocateZeroPool (IdentitySize);
+    Status = gBS->LocateProtocol (&gEdkiiWiFiProfileSyncProtocolGuid, NULL, (VOID **)&WiFiProfileSyncProtocol);
+    if (!EFI_ERROR (Status)) {
+      /* Max size of EapIdentity ::= sizeof (CHAR16) * sizeof (Profile->EapIdentity) ::= 2 * EAP_IDENTITY_SIZE */
+      IdentitySize = sizeof (CHAR8) * (AsciiStrnLenS ((CHAR8 *)Profile->EapIdentity, sizeof (CHAR16) * sizeof (Profile->EapIdentity)) + 1);
+    } else {
+      IdentitySize = sizeof (CHAR8) * (StrLen (Profile->EapIdentity) + 1);
+    }
+
+    Identity = AllocateZeroPool (IdentitySize);
     if (Identity == NULL) {
       return EFI_OUT_OF_RESOURCES;
     }
 
-    Status = gBS->LocateProtocol (&gEdkiiWiFiProfileSyncProtocolGuid, NULL, (VOID **)&WiFiProfileSyncProtocol);
     if (!EFI_ERROR (Status)) {
-      CopyMem (Identity, &Profile->EapIdentity, IdentitySize);
+      /* The size of Identity from Username may equal
+         to the max size of EapIdentity(EAP_IDENTITY_SIZE*2=128 bytes),
+         so here only valid characters except NULL characters are copied. */
+      CopyMem (Identity, &Profile->EapIdentity, IdentitySize - 1);
     } else {
       UnicodeStrToAsciiStrS (Profile->EapIdentity, Identity, IdentitySize);
     }


### PR DESCRIPTION
FIX: https://bugzilla.tianocore.org/show_bug.cgi?id=4477

Tls connection fail over WiFi in AMT OCR flow due to invalid identity.

This was due to missing conversion between unicode and ascii string which resulted in invalid strlen.

Cc: Maciej Rabeda <maciej.rabeda@linux.intel.com>
Cc: Siyuan Fu <siyuan.fu@intel.com>