### PR TITLE
IntelFsp2WrapperPkg: Get HobListPtr before calling the Multiphase FSPS

### DIFF
--- a/IntelFsp2WrapperPkg/FspsWrapperPeim/FspsWrapperPeim.c
+++ b/IntelFsp2WrapperPkg/FspsWrapperPeim/FspsWrapperPeim.c
@@ -336,6 +336,14 @@ PeiMemoryDiscoveredNotify (
 
   DEBUG ((DEBUG_INFO, "FspSiliconInit status: %r\n", Status));
 
+  //
+  // Get FspHobList
+  //
+  GuidHob = GetFirstGuidHob (&gFspHobGuid);
+  ASSERT (GuidHob != NULL);
+  FspHobListPtr = *(VOID **)GET_GUID_HOB_DATA (GuidHob);
+  DEBUG ((DEBUG_INFO, "FspHobListPtr - 0x%x\n", FspHobListPtr));
+
   if (Status == FSP_STATUS_VARIABLE_REQUEST) {
     //
     // call to Variable request handler
@@ -356,13 +364,6 @@ PeiMemoryDiscoveredNotify (
     DEBUG ((DEBUG_ERROR, "ERROR - TestFspSiliconInitApiOutput () fail, Status = %r\n", Status));
   }
 
-  //
-  // Now FspHobList complete, process it
-  //
-  GuidHob = GetFirstGuidHob (&gFspHobGuid);
-  ASSERT (GuidHob != NULL);
-  FspHobListPtr = *(VOID **)GET_GUID_HOB_DATA (GuidHob);
-  DEBUG ((DEBUG_INFO, "FspHobListPtr - 0x%x\n", FspHobListPtr));
   PostFspsHobProcess (FspHobListPtr);
 
   //


### PR DESCRIPTION
REF : https://bugzilla.tianocore.org/show_bug.cgi?id=4480

In the FspsWrapperPeim, before calling FspWrapperVariableRequestHandler and FspWrapperMultiPhaseHandler ,FspHobListPtr should be available so that BL will be able to get the correct FspHobListPtr value


Cc: Chasel Chiu <chasel.chiu@intel.com>
Cc: Nate DeSimone <nathaniel.l.desimone@intel.com>
Cc: Duggapu Chinni B <chinni.b.duggapu@intel.com>
Cc: Chen Gang C <gang.c.chen@intel.com>
Cc: Star Zeng <star.zeng@intel.com>
Cc: Ted Kuo <ted.kuo@intel.com>
Cc: Ashraf Ali S <ashraf.ali.s@intel.com>
Cc: Susovan Mohapatra <susovan.mohapatra@intel.com>
Reviewed-by: Ashraf Ali S <ashraf.ali.s@intel.com>
Reviewed-by: Chasel Chiu <chasel.chiu@intel.com>