### PR TITLE
OvmfPkg/PciHotPlugInitDxe: fix io window size

### DIFF
--- a/OvmfPkg/PciHotPlugInitDxe/PciHotPlugInit.c
+++ b/OvmfPkg/PciHotPlugInitDxe/PciHotPlugInit.c
@@ -741,7 +741,7 @@ GetResourcePadding (
     //
     // Request defaults.
     //
-    SetIoPadding (--FirstResource, (UINTN)HighBitSetRoundUp64 (512));
+    SetIoPadding (--FirstResource, (UINTN)HighBitSetRoundUp64 (0x1000));
   }
 
   if (DefaultMmio) {


### PR DESCRIPTION
Smallest IO window size for PCI bridges is 0x1000.  Fix default size accordingly.  Avoids broken resource assignments like this:

    [ ... ]
    PciBus: Resource Map for Root Bridge PciRoot(0x0)
    Type =   Io16; Base = 0x6000;   Length = 0x7000;        Alignment = 0xFFF
    [ ... ]
       Base = 0xC000;       Length = 0x200; Alignment = 0xFFF;      Owner = PPB [00|02|00:**]
       Base = 0xC200;       Length = 0x40;  Alignment = 0x3F;       Owner = PCI [00|1F|03:20]
       Base = 0xC240;       Length = 0x20;  Alignment = 0x1F;       Owner = PCI [00|1F|02:20]
    [ ... ]

... which the linux kernel fixes up later:

    [    0.644657] pci 0000:00:1f.3: BAR 4: assigned [io  0x1000-0x103f]
    [    0.646833] pci 0000:00:1f.2: BAR 4: assigned [io  0x1040-0x105f]

With the patch applied:

    { ... ]
    PciBus: Resource Map for Root Bridge PciRoot(0x0)
    Type =   Io16; Base = 0x6000;   Length = 0x8000;        Alignment = 0xFFF
    [ ... ]
       Base = 0xC000;       Length = 0x1000;        Alignment = 0xFFF;      Owner = PPB [00|02|00:**]
       Base = 0xD000;       Length = 0x40;  Alignment = 0x3F;       Owner = PCI [00|1F|03:20]
       Base = 0xD040;       Length = 0x20;  Alignment = 0x1F;       Owner = PCI [00|1F|02:20]
    [ ... ]