### PR TITLE
RedfishPkg: Fix SortLib library class name typo.

### DIFF
--- a/RedfishPkg/PrivateLibrary/RedfishCrtLib/RedfishCrtLib.inf
+++ b/RedfishPkg/PrivateLibrary/RedfishCrtLib/RedfishCrtLib.inf
@@ -25,7 +25,7 @@
 
 [LibraryClasses]
   BaseLib
-  BaseSortLib
+  SortLib
   DebugLib
   MemoryAllocationLib
   UefiRuntimeServicesTableLib

--- a/RedfishPkg/RedfishLibs.dsc.inc
+++ b/RedfishPkg/RedfishLibs.dsc.inc
@@ -14,7 +14,7 @@
 !if $(REDFISH_ENABLE) == TRUE
   RestExLib|RedfishPkg/Library/DxeRestExLib/DxeRestExLib.inf
   Ucs2Utf8Lib|RedfishPkg/Library/BaseUcs2Utf8Lib/BaseUcs2Utf8Lib.inf
-  BaseSortLib|MdeModulePkg/Library/BaseSortLib/BaseSortLib.inf
+  SortLib|MdeModulePkg/Library/BaseSortLib/BaseSortLib.inf
   RedfishCrtLib|RedfishPkg/PrivateLibrary/RedfishCrtLib/RedfishCrtLib.inf
   JsonLib|RedfishPkg/Library/JsonLib/JsonLib.inf
   RedfishLib|RedfishPkg/PrivateLibrary/RedfishLib/RedfishLib.inf


### PR DESCRIPTION
BaseSortLib is the library instance name not the class name.

Signed-off-by: Mike Maslenkin <mike.maslenkin@gmail.com>
Cc: Abner Chang <abner.chang@amd.com>
Cc: Nickle Wang <nicklew@nvidia.com>
Cc: Igor Kulchytskyy <igork@ami.com>