### PR TITLE
OvmfPkg/OvmfPkgX64: Support embedding default secure boot certs

### DIFF
--- a/OvmfPkg/OvmfPkgX64.dsc
+++ b/OvmfPkg/OvmfPkgX64.dsc
@@ -1027,6 +1027,8 @@
 !if $(SECURE_BOOT_ENABLE) == TRUE
   SecurityPkg/VariableAuthenticated/SecureBootConfigDxe/SecureBootConfigDxe.inf
   OvmfPkg/EnrollDefaultKeys/EnrollDefaultKeys.inf
+  SecurityPkg/EnrollFromDefaultKeysApp/EnrollFromDefaultKeysApp.inf
+  SecurityPkg/VariableAuthenticated/SecureBootDefaultKeysDxe/SecureBootDefaultKeysDxe.inf
 !endif
 
   OvmfPkg/PlatformDxe/Platform.inf

--- a/OvmfPkg/OvmfPkgX64.fdf
+++ b/OvmfPkg/OvmfPkgX64.fdf
@@ -276,7 +276,9 @@ INF  OvmfPkg/LsiScsiDxe/LsiScsiDxe.inf
 !endif
 
 !if $(SECURE_BOOT_ENABLE) == TRUE
+!include OvmfPkg/SecureBootDefaultKeys.fdf.inc
   INF  SecurityPkg/VariableAuthenticated/SecureBootConfigDxe/SecureBootConfigDxe.inf
+  INF  SecurityPkg/VariableAuthenticated/SecureBootDefaultKeysDxe/SecureBootDefaultKeysDxe.inf
 !endif
 
 INF  MdeModulePkg/Universal/WatchdogTimerDxe/WatchdogTimer.inf

--- a/OvmfPkg/SecureBootDefaultKeys.fdf.inc
+++ b/OvmfPkg/SecureBootDefaultKeys.fdf.inc
@@ -1,0 +1,70 @@
+## @file
+# FDF include file which allows to embed Secure Boot keys
+#
+#  Copyright (c) 2021, ARM Limited. All rights reserved.
+#  Copyright (c) 2021, Semihalf. All rights reserved.
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+
+!if $(DEFAULT_KEYS) == TRUE
+  FILE FREEFORM = 85254ea7-4759-4fc4-82d4-5eed5fb0a4a0 {
+  !ifdef $(PK_DEFAULT_FILE)
+    SECTION RAW = $(PK_DEFAULT_FILE)
+  !endif
+    SECTION UI = "PK Default"
+  }
+
+  FILE FREEFORM = 6f64916e-9f7a-4c35-b952-cd041efb05a3 {
+  !ifdef $(KEK_DEFAULT_FILE1)
+    SECTION RAW = $(KEK_DEFAULT_FILE1)
+  !endif
+  !ifdef $(KEK_DEFAULT_FILE2)
+    SECTION RAW = $(KEK_DEFAULT_FILE2)
+  !endif
+  !ifdef $(KEK_DEFAULT_FILE3)
+    SECTION RAW = $(KEK_DEFAULT_FILE3)
+  !endif
+    SECTION UI = "KEK Default"
+  }
+
+  FILE FREEFORM = c491d352-7623-4843-accc-2791a7574421 {
+  !ifdef $(DB_DEFAULT_FILE1)
+    SECTION RAW = $(DB_DEFAULT_FILE1)
+  !endif
+  !ifdef $(DB_DEFAULT_FILE2)
+    SECTION RAW = $(DB_DEFAULT_FILE2)
+  !endif
+  !ifdef $(DB_DEFAULT_FILE3)
+    SECTION RAW = $(DB_DEFAULT_FILE3)
+  !endif
+    SECTION UI = "DB Default"
+  }
+
+  FILE FREEFORM = 36c513ee-a338-4976-a0fb-6ddba3dafe87 {
+  !ifdef $(DBT_DEFAULT_FILE1)
+    SECTION RAW = $(DBT_DEFAULT_FILE1)
+  !endif
+  !ifdef $(DBT_DEFAULT_FILE2)
+    SECTION RAW = $(DBT_DEFAULT_FILE2)
+  !endif
+  !ifdef $(DBT_DEFAULT_FILE3)
+    SECTION RAW = $(DBT_DEFAULT_FILE3)
+  !endif
+    SECTION UI = "DBT Default"
+  }
+
+  FILE FREEFORM = 5740766a-718e-4dc0-9935-c36f7d3f884f {
+  !ifdef $(DBX_DEFAULT_FILE1)
+    SECTION RAW = $(DBX_DEFAULT_FILE1)
+  !endif
+  !ifdef $(DBX_DEFAULT_FILE2)
+    SECTION RAW = $(DBX_DEFAULT_FILE2)
+  !endif
+  !ifdef $(DBX_DEFAULT_FILE3)
+    SECTION RAW = $(DBX_DEFAULT_FILE3)
+  !endif
+    SECTION UI = "DBX Default"
+  }
+
+!endif


### PR DESCRIPTION
I don't remember whether I previously submitted this, but it doesn't show up in the PR history so I guess not.

This feature was already implemented for the RPi4 in ArmPlatformPkg.  It allows one to embed secure boot keys into OVMF firmware like this:

```
make -C BaseTools/Source/C -j9

./OvmfPkg/build.sh -a X64 -b RELEASE -D SECURE_BOOT_ENABLE=TRUE -D TPM1_ENABLE=TRUE -D TPM2_ENABLE=TRUE \
  -D NETWORK_IP6_ENABLE=TRUE -D NETWORK_HTTP_BOOT_ENABLE=TRUE -D DEFAULT_KEYS=TRUE \
  -D PK_DEFAULT_FILE=${UEFI_KEYS}/PrivateCorp/PrivateCorp-PK.cer \
  -D KEK_DEFAULT_FILE1=${UEFI_KEYS}/PrivateCorp/PrivateCorp-KEK.cer \
  -D KEK_DEFAULT_FILE2=${UEFI_KEYS}/MicrosoftUEFI/MicCorKEKCA2011_2011-06-24.crt \
  -D DB_DEFAULT_FILE1=${UEFI_KEYS}/PrivateCorp/PrivateCorp-DB.cer \
  -D DB_DEFAULT_FILE2=${UEFI_KEYS}/MicrosoftUEFI/MicWinProPCA2011_2011-10-19.crt \
  -D DB_DEFAULT_FILE3=${UEFI_KEYS}/MicrosoftUEFI/MicCorUEFCA2011_2011-06-27.crt \
  ...
```

where PrivateCorp keys are generated generated using e.g. ```openssl req``` and in DER format.