### PR TITLE
OvmfPkg/PlatformCI: Skip GCC5_OVMF_IA32X64_FULL_NOOPT build

### DIFF
--- a/OvmfPkg/PlatformCI/.azurepipelines/Ubuntu-GCC5.yml
+++ b/OvmfPkg/PlatformCI/.azurepipelines/Ubuntu-GCC5.yml
@@ -109,13 +109,16 @@ jobs:
             Build.Target: "RELEASE"
             Run.Flags: $(run_flags)
             Run: $(should_run)
-          OVMF_IA32X64_FULL_NOOPT:
-            Build.File: "$(package)/PlatformCI/PlatformBuild.py"
-            Build.Arch: "IA32,X64"
-            Build.Flags: "BLD_*_SECURE_BOOT_ENABLE=1 BLD_*_SMM_REQUIRE=1 BLD_*_TPM2_ENABLE=1 BLD_*_NETWORK_TLS_ENABLE=1 BLD_*_NETWORK_IP6_ENABLE=1 BLD_*_NETWORK_HTTP_BOOT_ENABLE=1"
-            Build.Target: "NOOPT"
-            Run.Flags: $(run_flags)
-            Run: $(should_run)
+          # This currently creates a very large image which is too big for the FDF declared range,
+          # skip this build for now.
+          #
+          # OVMF_IA32X64_FULL_NOOPT:
+          #   Build.File: "$(package)/PlatformCI/PlatformBuild.py"
+          #   Build.Arch: "IA32,X64"
+          #   Build.Flags: "BLD_*_SECURE_BOOT_ENABLE=1 BLD_*_SMM_REQUIRE=1 BLD_*_TPM2_ENABLE=1 BLD_*_NETWORK_TLS_ENABLE=1 BLD_*_NETWORK_IP6_ENABLE=1 BLD_*_NETWORK_HTTP_BOOT_ENABLE=1"
+          #   Build.Target: "NOOPT"
+          #   Run.Flags: $(run_flags)
+          #   Run: $(should_run)
 
           AMDSEV_X64_DEBUG:
             Build.File: "$(package)/PlatformCI/AmdSevBuild.py"


### PR DESCRIPTION
The effect of LTO is limited with optimization turned off, and blocked the upgrade of Openssl3.0. We already skipped this build with VS2019, skip the GCC NOOPT build also.


Cc: Ard Biesheuvel <ardb+tianocore@kernel.org>
Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Jordan Justen <jordan.l.justen@intel.com>
Cc: Gerd Hoffmann <kraxel@redhat.com>
Acked-by: Gerd Hoffmann <kraxel@redhat.com>
Reviewed-by: Jiewen Yao <jiewen.yao@intel.com>