### PR TITLE
MdeModulePkg: Solve boot hang xhci driver when use USB DVD with empty…

### DIFF
--- a/MdeModulePkg/Bus/Pci/XhciDxe/XhciSched.c
+++ b/MdeModulePkg/Bus/Pci/XhciDxe/XhciSched.c
@@ -171,7 +171,6 @@ XhcCreateUrb (
   Urb->Context  = Context;
 
   Status = XhcCreateTransferTrb (Xhc, Urb);
-  ASSERT_EFI_ERROR (Status);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "XhcCreateUrb: XhcCreateTransferTrb Failed, Status = %r\n", Status));
     FreePool (Urb);
@@ -248,6 +247,9 @@ XhcCreateTransferTrb (
   Dci = XhcEndpointToDci (Urb->Ep.EpAddr, (UINT8)(Urb->Ep.Direction));
   ASSERT (Dci < 32);
   EPRing        = (TRANSFER_RING *)(UINTN)Xhc->UsbDevContext[SlotId].EndpointTransferRing[Dci-1];
+  if (EPRing == NULL) {
+    return EFI_OUT_OF_RESOURCES; 
+  }
   Urb->Ring     = EPRing;
   OutputContext = Xhc->UsbDevContext[SlotId].OutputContext;
   if (Xhc->HcCParams.Data.Csz == 0) {


### PR DESCRIPTION
use USB DVD with empty disk boot hang Xhci drvier, delete ASSERT to aviod hang with  any side effect.

error print : MdeModulePkg/Bus/Pci/XhciDxe/XhciSched.c(1847): TrsRing != ((void *) 0)