### PR TITLE
OvmfPkg/PlatformBootManagerLib: setup virtio-mmio devices.

### DIFF
--- a/OvmfPkg/Library/PlatformBootManagerLib/PlatformBootManagerLib.inf
+++ b/OvmfPkg/Library/PlatformBootManagerLib/PlatformBootManagerLib.inf
@@ -75,6 +75,7 @@
 [Protocols]
   gEfiDecompressProtocolGuid
   gEfiPciRootBridgeIoProtocolGuid
+  gVirtioDeviceProtocolGuid
   gEfiS3SaveStateProtocolGuid                   # PROTOCOL SOMETIMES_CONSUMED
   gEfiDxeSmmReadyToLockProtocolGuid             # PROTOCOL SOMETIMES_PRODUCED
   gEfiLoadedImageProtocolGuid                   # PROTOCOL SOMETIMES_PRODUCED


### PR DESCRIPTION
Add DetectAndPreparePlatformVirtioDevicePath() helper function
to setup virtio-mmio devices.  Start with virtio-serial support.

This makes virtio console usable with microvm.

Signed-off-by: Gerd Hoffmann <kraxel@redhat.com>
