### PR TITLE
MdeModulePkg/Variable: TcgMorLockSmm Key Mismatch changes lock state

### DIFF
--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/TcgMorLockSmm.c
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/TcgMorLockSmm.c
@@ -312,6 +312,11 @@ SetVariableCheckHandlerMorLock (
       mMorLockState    = MorLockStateLocked;
       mMorLockKeyEmpty = TRUE;
       ZeroMem (mMorLockKey, sizeof (mMorLockKey));
+      //
+      // Update value to reflect locked without key
+      //
+      Status = SetMorLockVariable (MOR_LOCK_DATA_LOCKED_WITHOUT_KEY);
+      ASSERT_EFI_ERROR (Status);
       return EFI_ACCESS_DENIED;
     }
   }


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4410

Inside TcgMorLockSmm.c, the SetVariableCheckHandlerMorLock() function contains a scenario to prevent a possible dictionary attack on the MorLock Key in accordance with the TCG Platform Reset Mitigation Spec v1.10.

The mechanism to prevent this attack must also change the MorLock Variable Value to 0x01 to indicate Locked Without Key.

ASSERT_EFI_ERROR is added for error visibility since SetMorLockVariable returns a status code

Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Signed-off-by: Abhi Singh <Abhi.Singh@arm.com>

Acked-by: Michael Kubacki <michael.kubacki@microsoft.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>