### PR TITLE
UefiPayloadPkg: Match BAR if framebuffer is at an offset

### DIFF
--- a/UefiPayloadPkg/GraphicsOutputDxe/GraphicsOutput.c
+++ b/UefiPayloadPkg/GraphicsOutputDxe/GraphicsOutput.c
@@ -435,9 +435,12 @@ GraphicsOutputDriverBindingStart (
             }
 
             if (DeviceInfo->BarIndex == MAX_UINT8) {
-              if (Resources->AddrRangeMin == GraphicsInfo->FrameBufferBase) {
-                FrameBufferBase = Resources->AddrRangeMin;
-                break;
+              if (GraphicsInfo->FrameBufferBase >= Resources->AddrRangeMin) {
+                if ((GraphicsInfo->FrameBufferBase + GraphicsInfo->FrameBufferSize) <= (Resources->AddrRangeMin + Resources->AddrLen))
+                {
+                  FrameBufferBase = GraphicsInfo->FrameBufferBase;
+                  break;
+                }
               }
             } else {
               break;


### PR DESCRIPTION
**Note**: this pull request is a copy of my email to the `devel` mailing list:
https://edk2.groups.io/g/devel/message/106743
https://edk2.groups.io/g/devel/message/106744

I had already brought up the issue on #coreboot in IRC and was suggested to send my patch here, not to the downstream versions by MrChromebox or StarLabsLtd (which are used by coreboot), since it applies here all the same and doesn't seem to be coreboot-specific.

When the framebuffer region (starting address and address range) from the GraphicsInfo HOB is fully enclosed within a BAR region, but does not start on the same address as the BAR, it does not get matched to that BAR. The driver fails to bind to the graphics device and no graphics output is possible until the OS initializes its own driver.

This was encountered on a PC with an Intel DQ67SW mainboard and a discrete GPU (Nvidia GTX 670) that is running coreboot with UefiPayload from the 'mrchromebox' or 'starlabsltd' fork of EDK II.

coreboot runs the VGA BIOS which reports an address range for the framebuffer to coreboot. It is within one of its BAR regions, but not at the starting address (BAR2 at 0xE8000000 vs framebuffer at 0xE9000000).

EDK II finds the framebuffer information provided by coreboot and later fails to find the correspondig BAR due to the behavior described above. With this patch, graphics output is working.