### PR TITLE
OvmfPkg/ResetVector: Fix assembler bit test flag check

### DIFF
--- a/OvmfPkg/ResetVector/Ia32/Flat32ToFlat64.asm
+++ b/OvmfPkg/ResetVector/Ia32/Flat32ToFlat64.asm
@@ -44,7 +44,7 @@ Transition32FlatTo64Flat:
 
     mov     ecx, 1
     bt      [SEV_ES_WORK_AREA_STATUS_MSR], ecx
-    jz      EnablePaging
+    jnc     EnablePaging
 
     ;
     ; SEV-ES is active, perform a quick sanity check against the reported


### PR DESCRIPTION
Commit 63c50d3ff2854a76432b752af4f2a76f33ff1974 changed the check that is used to determine if SEV-ES is active. Originally, a CMP instruction with a supporting JZ instruction was used for the check. It was changed to use the BT instruction but not JZ instruction. The result of a BT instruction changes the the carry flag (CF) and not the zero flag (ZF). As a result, the wrong condition is being checked. Update the JZ to a JNC to properly detect if SEV-ES is active.

Fixes: 63c50d3ff285 ("OvmfPkg/ResetVector: cache the SEV status MSR...")