### PR TITLE
MdeModulePkg/Bus/Pci/EhciDxe: Fix FORWARD_NULL Coverity issues

### DIFF
--- a/MdeModulePkg/Bus/Pci/EhciDxe/UsbHcMem.c
+++ b/MdeModulePkg/Bus/Pci/EhciDxe/UsbHcMem.c
@@ -250,6 +250,11 @@ UsbHcGetPciAddressForHostMem (
   }
 
   ASSERT ((Block != NULL));
+
+  if (Block == NULL) {
+    return 0;
+  }
+
   //
   // calculate the pci memory address for host memory address.
   //
@@ -535,6 +540,10 @@ UsbHcFreeMem (
   // the caller has passed in a wrong memory point
   //
   ASSERT (Block != NULL);
+
+  if (Block == NULL) {
+    return;
+  }
 
   //
   // Release the current memory block if it is empty and not the head


### PR DESCRIPTION
The function UsbHcGetPciAddressForHostMem has

    ASSERT ((Block != NULL));

and the UsbHcFreeMem has

    ASSERT (Block != NULL);

statement after for loop, but these are applicable only in DEBUG mode. In RELEASE mode, if for whatever reasons there is no match inside the for loop and the loop exits because of Block != NULL; condition, then there is no "Block" NULL pointer check afterwards and the code proceeds to do dereferencing "Block" which will lead to CRASH.

Hence, for safety add NULL pointer checks always.

Cc: Hao A Wu <hao.a.wu@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4210


Reviewed-by: Hao A Wu <hao.a.wu@intel.com>