### PR TITLE
OvmfPkg/PeilessStartupLib: Updated with PcdSecureBootSupported

### DIFF
--- a/OvmfPkg/Library/PeilessStartupLib/PeilessStartup.c
+++ b/OvmfPkg/Library/PeilessStartupLib/PeilessStartup.c
@@ -82,9 +82,9 @@ InitializePlatform (
 
   VariableStore                                  = PlatformReserveEmuVariableNvStore ();
   PlatformInfoHob->PcdEmuVariableNvStoreReserved = (UINT64)(UINTN)VariableStore;
- #ifdef SECURE_BOOT_FEATURE_ENABLED
-  PlatformInitEmuVariableNvStore (VariableStore);
- #endif
+  if (FeaturePcdGet (PcdSecureBootSupported)) {
+    PlatformInitEmuVariableNvStore (VariableStore);
+  }
 
   if (TdIsEnabled ()) {
     PlatformTdxPublishRamRegions ();

--- a/OvmfPkg/Library/PeilessStartupLib/PeilessStartupLib.inf
+++ b/OvmfPkg/Library/PeilessStartupLib/PeilessStartupLib.inf
@@ -83,3 +83,4 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdNullPointerDetectionPropertyMask    ## CONSUMES
   gUefiOvmfPkgTokenSpaceGuid.PcdOvmfDxeMemFvBase
   gUefiOvmfPkgTokenSpaceGuid.PcdOvmfDxeMemFvSize
+  gUefiOvmfPkgTokenSpaceGuid.PcdSecureBootSupported


### PR DESCRIPTION
SECURE_BOOT_FEATURE_ENABLED was dropped by the commit(92da8a154f), but the PeilessStartupLib was not updated with PcdSecureBootSupported, that made SecureBoot no longer work in IntelTdxX64.

Fix this by replacing SECURE_BOOT_FEATURE_ENABLED with PcdSecureBootSupported in PeilessStartupLib.

Cc: Erdem Aktas <erdemaktas@google.com>
Cc: James Bottomley <jejb@linux.ibm.com>
Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Gerd Hoffmann <kraxel@redhat.com>
Cc: Min Xu <min.m.xu@intel.com>
Cc: Tom Lendacky <thomas.lendacky@amd.com>
Cc: Michael Roth <michael.roth@amd.com>

Acked-by: Gerd Hoffmann <kraxel@redhat.com>
Reviewed-by: Jiewen Yao <jiewen.yao@intel.com>