### PR TITLE
UefiCpuPkg: Uses gMmst in MmSaveStateLib

### DIFF
--- a/UefiCpuPkg/Library/MmSaveStateLib/AmdMmSaveState.c
+++ b/UefiCpuPkg/Library/MmSaveStateLib/AmdMmSaveState.c
@@ -108,7 +108,7 @@ MmSaveStateReadRegister (
   UINT8                      DataWidth;
 
   // Read CPU State
-  CpuSaveState = (AMD_SMRAM_SAVE_STATE_MAP *)gSmst->CpuSaveState[CpuIndex];
+  CpuSaveState = (AMD_SMRAM_SAVE_STATE_MAP *)gMmst->CpuSaveState[CpuIndex];
 
   // Check for special EFI_MM_SAVE_STATE_REGISTER_LMA
   if (Register == EFI_MM_SAVE_STATE_REGISTER_LMA) {
@@ -226,7 +226,7 @@ MmSaveStateWriteRegister (
     return EFI_NOT_FOUND;
   }
 
-  CpuSaveState = gSmst->CpuSaveState[CpuIndex];
+  CpuSaveState = gMmst->CpuSaveState[CpuIndex];
 
   //
   // Do not write non-writable SaveState, because it will cause exception.

--- a/UefiCpuPkg/Library/MmSaveStateLib/AmdMmSaveStateLib.inf
+++ b/UefiCpuPkg/Library/MmSaveStateLib/AmdMmSaveStateLib.inf
@@ -31,4 +31,4 @@
   BaseLib
   BaseMemoryLib
   DebugLib
-  SmmServicesTableLib
+  MmServicesTableLib

--- a/UefiCpuPkg/Library/MmSaveStateLib/IntelMmSaveState.c
+++ b/UefiCpuPkg/Library/MmSaveStateLib/IntelMmSaveState.c
@@ -296,7 +296,7 @@ MmSaveStateWriteRegister (
     return EFI_NOT_FOUND;
   }
 
-  CpuSaveState = gSmst->CpuSaveState[CpuIndex];
+  CpuSaveState = gMmst->CpuSaveState[CpuIndex];
 
   //
   // Do not write non-writable SaveState, because it will cause exception.

--- a/UefiCpuPkg/Library/MmSaveStateLib/IntelMmSaveStateLib.inf
+++ b/UefiCpuPkg/Library/MmSaveStateLib/IntelMmSaveStateLib.inf
@@ -31,4 +31,4 @@
   BaseLib
   BaseMemoryLib
   DebugLib
-  SmmServicesTableLib
+  MmServicesTableLib

--- a/UefiCpuPkg/Library/MmSaveStateLib/MmSaveState.h
+++ b/UefiCpuPkg/Library/MmSaveStateLib/MmSaveState.h
@@ -14,7 +14,7 @@
 #include <Protocol/MmCpu.h>
 #include <Library/DebugLib.h>
 #include <Library/MmSaveStateLib.h>
-#include <Library/SmmServicesTableLib.h>
+#include <Library/MmServicesTableLib.h>
 #include <Library/BaseMemoryLib.h>
 
 // Macro used to simplify the lookup table entries of type CPU_MM_SAVE_STATE_REGISTER_RANGE

--- a/UefiCpuPkg/Library/MmSaveStateLib/MmSaveStateCommon.c
+++ b/UefiCpuPkg/Library/MmSaveStateLib/MmSaveStateCommon.c
@@ -99,8 +99,8 @@ MmSaveStateReadRegisterByIndex (
     //
     // Write return buffer
     //
-    ASSERT (gSmst->CpuSaveState[CpuIndex] != NULL);
-    CopyMem (Buffer, (UINT8 *)gSmst->CpuSaveState[CpuIndex] + mCpuWidthOffset[RegisterIndex].Offset32, Width);
+    ASSERT (gMmst->CpuSaveState[CpuIndex] != NULL);
+    CopyMem (Buffer, (UINT8 *)gMmst->CpuSaveState[CpuIndex] + mCpuWidthOffset[RegisterIndex].Offset32, Width);
   } else {
     //
     // If 64-bit mode width is zero, then the specified register can not be accessed
@@ -119,12 +119,12 @@ MmSaveStateReadRegisterByIndex (
     //
     // Write lower 32-bits of return buffer
     //
-    CopyMem (Buffer, (UINT8 *)gSmst->CpuSaveState[CpuIndex] + mCpuWidthOffset[RegisterIndex].Offset64Lo, MIN (4, Width));
+    CopyMem (Buffer, (UINT8 *)gMmst->CpuSaveState[CpuIndex] + mCpuWidthOffset[RegisterIndex].Offset64Lo, MIN (4, Width));
     if (Width > 4) {
       //
       // Write upper 32-bits of return buffer
       //
-      CopyMem ((UINT8 *)Buffer + 4, (UINT8 *)gSmst->CpuSaveState[CpuIndex] + mCpuWidthOffset[RegisterIndex].Offset64Hi, Width - 4);
+      CopyMem ((UINT8 *)Buffer + 4, (UINT8 *)gMmst->CpuSaveState[CpuIndex] + mCpuWidthOffset[RegisterIndex].Offset64Hi, Width - 4);
     }
   }
 


### PR DESCRIPTION
BZ: https://bugzilla.tianocore.org/show_bug.cgi?id=4182

Use gMmst instead of gSmst.
Replace SmmServicesTableLib with MmServicesTableLib.

Cc: Eric Dong <eric.dong@intel.com>
Reviewed-by: Ray Ni <ray.ni@intel.com>
Cc: Rahul Kumar <rahul1.kumar@intel.com>
Cc: Gerd Hoffmann <kraxel@redhat.com>
Acked-by: Abner Chang <abner.chang@amd.com>