### PR TITLE
CryptoPkg/BaseCryptoLib: Remove unnecessary key generation.

### DIFF
--- a/CryptoPkg/Library/BaseCryptLib/Pk/CryptEc.c
+++ b/CryptoPkg/Library/BaseCryptLib/Pk/CryptEc.c
@@ -497,17 +497,22 @@ EcGenerateKey (
   Group    = EC_KEY_get0_group (EcKey);
   HalfSize = (EC_GROUP_get_degree (Group) + 7) / 8;
 
+  if ((PublicKey != NULL) && (*PublicKeySize < HalfSize * 2)) {
+    *PublicKeySize = HalfSize * 2;
+    return FALSE;
+  }
+
   // Assume RAND_seed was called
   if (EC_KEY_generate_key (EcKey) != 1) {
     return FALSE;
   }
 
-  if (*PublicKeySize < HalfSize * 2) {
-    *PublicKeySize = HalfSize * 2;
-    return FALSE;
-  }
-
   *PublicKeySize = HalfSize * 2;
+
+  // If PublicKey is NULL and PublicKeySize is 0, return True and fill PublickKeySize with correct Key Size.
+  if (PublicKey == NULL) {
+    return TRUE;
+  }
 
   EcPoint = EC_KEY_get0_public_key (EcKey);
   if (EcPoint == NULL) {


### PR DESCRIPTION
When EcGenerateKey() is called with PublicKeySize set to zero or less than the required size,
it returns the size of the required buffer with failure. However, EcGenerateKey() generates a key and then checks if the buffer size is insufficient.
This can be optimised by moving the public key size check before generating the key.
Therefore, optimise to avoid unnecessary key generation.