### PR TITLE
NetworkPkg/HttpDxe: fix driver binding start issue.

### DIFF
--- a/NetworkPkg/HttpDxe/HttpDriver.c
+++ b/NetworkPkg/HttpDxe/HttpDriver.c
@@ -3,6 +3,7 @@
 
   Copyright (c) 2015 - 2018, Intel Corporation. All rights reserved.<BR>
   (C) Copyright 2016 Hewlett Packard Enterprise Development LP<BR>
+  Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -464,8 +465,16 @@ ON_ERROR:
 
   if (HttpService != NULL) {
     HttpCleanService (HttpService, UsingIpv6);
-    if ((HttpService->Tcp4ChildHandle == NULL) && (HttpService->Tcp6ChildHandle == NULL)) {
-      FreePool (HttpService);
+    Status = gBS->UninstallMultipleProtocolInterfaces (
+                    &ControllerHandle,
+                    &gEfiHttpServiceBindingProtocolGuid,
+                    &HttpService->ServiceBinding,
+                    NULL
+                    );
+    if (!EFI_ERROR (Status)) {
+      if ((HttpService->Tcp4ChildHandle == NULL) && (HttpService->Tcp6ChildHandle == NULL)) {
+        FreePool (HttpService);
+      }
     }
   }
 


### PR DESCRIPTION
When failure happens in HttpDxeStart, the error handling code release the memory buffer but it does not uninstall HTTP service binding protocol. As the result, application can still locate this protocol and invoke service binding functions in released memory pool.

Cc: Maciej Rabeda <maciej.rabeda@linux.intel.com>
Cc: Siyuan Fu <siyuan.fu@intel.com>
Cc: Abner Chang <abner.chang@amd.com>
Cc: Igor Kulchytskyy <igork@ami.com>
Cc: Nick Ramirez <nramirez@nvidia.com>

Reviewed-by: Saloni Kasbekar <saloni.kasbekar@intel.com>
Acked-by: Michael D Kinney <michael.d.kinney@intel.com>