### PR TITLE
RedfishPkg/RedfishRestExDxe: return HTTP status code to caller.

### DIFF
--- a/MdePkg/Include/Protocol/RestEx.h
+++ b/MdePkg/Include/Protocol/RestEx.h
@@ -131,7 +131,8 @@ typedef struct {
   response when the data is retrieved from the service. RequestMessage contains the HTTP
   request to the REST resource identified by RequestMessage.Request.Url. The
   ResponseMessage is the returned HTTP response for that request, including any HTTP
-  status.
+  status. It's caller's responsibility to free this ResponseMessage using FreePool().
+  RestConfigFreeHttpMessage() in RedfishLib is an example to release ResponseMessage structure.
 
   @param[in]  This                Pointer to EFI_REST_EX_PROTOCOL instance for a particular
                                   REST service.


### PR DESCRIPTION
Return unsupported HTTP status code to caller so caller can handle HTTP error status code. Current implementation only return EFI error to caller. Without knowing the HTTP status code, caller has trouble to handle HTTP request failure.


Cc: Abner Chang <abner.chang@amd.com>
Cc: Igor Kulchytskyy <igork@ami.com>
Cc: Nick Ramirez <nramirez@nvidia.com>