### PR TITLE
RedfishPkg/RedfishCrtLib: multiple definitions of strncpy.

### DIFF
--- a/RedfishPkg/Include/Library/RedfishCrtLib.h
+++ b/RedfishPkg/Include/Library/RedfishCrtLib.h
@@ -3,6 +3,7 @@
 
   Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
   (C) Copyright 2021 Hewlett Packard Enterprise Development LP<BR>
+  Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
     SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -304,8 +305,7 @@ char           *
 strncpy    (
   char *,
   size_t,
-  const char *,
-  size_t
+  const char *
   );
 
 int


### PR DESCRIPTION
There are two definitions for strncpy() function in RedfishCrtLib.h

Cc: Abner Chang <abner.chang@amd.com>
Cc: Igor Kulchytskyy <igork@ami.com>
Cc: Nick Ramirez <nramirez@nvidia.com>