### PR TITLE
Move RUNTIME_FUNCTION redefinition fix to EmulatorPkg

### DIFF
--- a/EmulatorPkg/Win/Host/WinInclude.h
+++ b/EmulatorPkg/Win/Host/WinInclude.h
@@ -10,7 +10,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 //
 // Win32 include files do not compile clean with /W4, so we use the warning
-// pragma to suppress the warnings for Win32 only. This way our code can stil
+// pragma to suppress the warnings for Win32 only. This way our code can still
 // compile at /W4 (highest warning level) with /WX (warnings cause build
 // errors).
 //
@@ -19,9 +19,10 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #pragma warning(disable : 4028)
 #pragma warning(disable : 4133)
 
-#define GUID         _WINNT_DUP_GUID_____
-#define _LIST_ENTRY  _WINNT_DUP_LIST_ENTRY_FORWARD
-#define LIST_ENTRY   _WINNT_DUP_LIST_ENTRY
+#define GUID              _WINNT_DUP_GUID_____
+#define _LIST_ENTRY       _WINNT_DUP_LIST_ENTRY_FORWARD
+#define LIST_ENTRY        _WINNT_DUP_LIST_ENTRY
+#define RUNTIME_FUNCTION  _WINNT_DUP_RUNTIME_FUNCTION
 #if defined (MDE_CPU_IA32) && (_MSC_VER < 1800)
 #define InterlockedIncrement          _WINNT_DUP_InterlockedIncrement
 #define InterlockedDecrement          _WINNT_DUP_InterlockedDecrement
@@ -45,6 +46,7 @@ typedef UINT32 size_t;
 #undef GUID
 #undef _LIST_ENTRY
 #undef LIST_ENTRY
+#undef RUNTIME_FUNCTION
 #undef InterlockedIncrement
 #undef InterlockedDecrement
 #undef InterlockedCompareExchange64

--- a/MdePkg/Include/IndustryStandard/PeImage.h
+++ b/MdePkg/Include/IndustryStandard/PeImage.h
@@ -678,9 +678,6 @@ typedef struct {
   //
 } EFI_IMAGE_DEBUG_CODEVIEW_MTOC_ENTRY;
 
-// avoid conflict with windows header files
-#ifndef RUNTIME_FUNCTION_INDIRECT
-
 //
 // .pdata entries for X64
 //
@@ -689,8 +686,6 @@ typedef struct {
   UINT32    FunctionEndAddress;
   UINT32    UnwindInfoAddress;
 } RUNTIME_FUNCTION;
-
-#endif
 
 typedef struct {
   UINT8    Version             : 3;


### PR DESCRIPTION
Remove RUNTIME_FUNCTION redefinition error workaround from
the following commit to the MdePkg that only impacts EmulatorPkg
builds that uses windows include files:

https://github.com/tianocore/edk2/commit/ff52068d9261b9391d75b83a2a4e40e040f3b6eb

The correct location for this fix is in the EmulatorPkg
in the WinInclude.h file that addresses all the name
collisions between edk2 types and windows types.

Cc: Gerd Hoffmann <[kraxel@redhat.com](mailto:kraxel@redhat.com)>
Cc: Rebecca Cran <[rebecca@bsdio.com](mailto:rebecca@bsdio.com)>
Cc: Liming Gao <[gaoliming@byosoft.com.cn](mailto:gaoliming@byosoft.com.cn)>
Cc: Zhiguang Liu <[zhiguang.liu@intel.com](mailto:zhiguang.liu@intel.com)>
Cc: Andrew Fish <[afish@apple.com](mailto:afish@apple.com)>
Cc: Ray Ni <[ray.ni@intel.com](mailto:ray.ni@intel.com)>
Signed-off-by: Michael D Kinney [michael.d.kinney@intel.com](mailto:michael.d.kinney@intel.com)