### PR TITLE
RedfishPkg/RedfishDiscoverDxe: fix netmask check issue

### DIFF
--- a/RedfishPkg/Include/Library/RedfishDebugLib.h
+++ b/RedfishPkg/Include/Library/RedfishDebugLib.h
@@ -121,4 +121,21 @@ DumpHttpStatusCode (
   IN EFI_HTTP_STATUS_CODE  HttpStatusCode
   );
 
+/**
+
+  This function dump the IPv4 address in given error level.
+
+  @param[in]  ErrorLevel  DEBUG macro error level
+  @param[in]  Ipv4Address IPv4 address to dump
+
+  @retval     EFI_SUCCESS         IPv4 address string is printed.
+  @retval     Others              Errors occur.
+
+**/
+EFI_STATUS
+DumpIpv4Address (
+  IN UINTN             ErrorLevel,
+  IN EFI_IPv4_ADDRESS  *Ipv4Address
+  );
+
 #endif

--- a/RedfishPkg/Library/RedfishDebugLib/RedfishDebugLib.c
+++ b/RedfishPkg/Library/RedfishDebugLib/RedfishDebugLib.c
@@ -340,3 +340,29 @@ DumpRedfishResponse (
 
   return EFI_SUCCESS;
 }
+
+/**
+
+  This function dump the IPv4 address in given error level.
+
+  @param[in]  ErrorLevel  DEBUG macro error level
+  @param[in]  Ipv4Address IPv4 address to dump
+
+  @retval     EFI_SUCCESS         IPv4 address string is printed.
+  @retval     Others              Errors occur.
+
+**/
+EFI_STATUS
+DumpIpv4Address (
+  IN UINTN             ErrorLevel,
+  IN EFI_IPv4_ADDRESS  *Ipv4Address
+  )
+{
+  if (Ipv4Address == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  DEBUG ((ErrorLevel, "%d.%d.%d.%d\n", Ipv4Address->Addr[0], Ipv4Address->Addr[1], Ipv4Address->Addr[2], Ipv4Address->Addr[3]));
+
+  return EFI_SUCCESS;
+}

--- a/RedfishPkg/RedfishDiscoverDxe/RedfishDiscoverDxe.c
+++ b/RedfishPkg/RedfishDiscoverDxe/RedfishDiscoverDxe.c
@@ -531,15 +531,17 @@ DiscoverRedfishHostInterface (
       IP4_COPY_ADDRESS ((VOID *)&Instance->HostSubnetMask.v4, (VOID *)Data->HostIpMask);
 
       if (EFI_IP4_EQUAL (&Instance->HostIpAddress.v4, &mZeroIp4Addr)) {
-        DEBUG ((DEBUG_ERROR, "%a: invalid host IP address: zero address\n", __func__));
+        DEBUG ((DEBUG_ERROR, "%a: invalid host IP address: ", __func__));
+        DumpIpv4Address (DEBUG_ERROR, &Instance->HostIpAddress.v4);
         //
         // Invalid IP address detected. Change address format to Unknown and use system default address.
         //
         Instance->HostAddrFormat = REDFISH_HOST_INTERFACE_HOST_IP_ADDRESS_FORMAT_UNKNOWN;
       }
 
-      if (!IP4_IS_VALID_NETMASK (EFI_IP4 (Instance->HostSubnetMask.v4))) {
-        DEBUG ((DEBUG_ERROR, "%a: invalid subnet mask address\n", __func__));
+      if (!IP4_IS_VALID_NETMASK (NTOHL (EFI_IP4 (Instance->HostSubnetMask.v4)))) {
+        DEBUG ((DEBUG_ERROR, "%a: invalid subnet mask address: ", __func__));
+        DumpIpv4Address (DEBUG_ERROR, &Instance->HostSubnetMask.v4);
         //
         // Invalid subnet mast address detected. Change address format to Unknown and use system default address.
         //
@@ -553,7 +555,8 @@ DiscoverRedfishHostInterface (
       IP4_COPY_ADDRESS ((VOID *)&Instance->TargetIpAddress.v4, (VOID *)Data->RedfishServiceIpAddress);
 
       if (EFI_IP4_EQUAL (&Instance->TargetIpAddress.v4, &mZeroIp4Addr)) {
-        DEBUG ((DEBUG_ERROR, "%a: invalid service IP address: zero address\n", __func__));
+        DEBUG ((DEBUG_ERROR, "%a: invalid service IP address: ", __func__));
+        DumpIpv4Address (DEBUG_ERROR, &Instance->TargetIpAddress.v4);
       }
     } else {
       IP6_COPY_ADDRESS ((VOID *)&Instance->TargetIpAddress.v6, (VOID *)Data->RedfishServiceIpAddress);

--- a/RedfishPkg/RedfishDiscoverDxe/RedfishDiscoverDxe.inf
+++ b/RedfishPkg/RedfishDiscoverDxe/RedfishDiscoverDxe.inf
@@ -2,6 +2,7 @@
 #  Implementation of EFI_REDFISH_DISCOVER_PROTOCOL interfaces.
 #
 #  (C) Copyright 2021 Hewlett Packard Enterprise Development LP<BR>
+#  Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -34,6 +35,7 @@
   DebugLib
   MemoryAllocationLib
   PrintLib
+  RedfishDebugLib
   RestExLib
   UefiLib
   UefiBootServicesTableLib

--- a/RedfishPkg/RedfishDiscoverDxe/RedfishDiscoverInternal.h
+++ b/RedfishPkg/RedfishDiscoverDxe/RedfishDiscoverInternal.h
@@ -28,6 +28,7 @@
 #include <Library/MemoryAllocationLib.h>
 #include <Library/NetLib.h>
 #include <Library/PrintLib.h>
+#include <Library/RedfishDebugLib.h>
 #include <Library/RestExLib.h>
 #include <Library/UefiLib.h>
 #include <Library/UefiBootServicesTableLib.h>


### PR DESCRIPTION
Add NTOHL() for coverting IP address from EFI_IPv4_ADDRESS to IP4_ADDR so that IP4_IS_VALID_NETMASK() return correct value.


Cc: Abner Chang <abner.chang@amd.com>
Cc: Igor Kulchytskyy <igork@ami.com>
Cc: Nick Ramirez <nramirez@nvidia.com>