### PR TITLE
Cache Disable should not be set by default in…

### DIFF
--- a/UefiCpuPkg/ResetVector/Vtf0/Ia16/Real16ToFlat32.asm
+++ b/UefiCpuPkg/ResetVector/Vtf0/Ia16/Real16ToFlat32.asm
@@ -7,7 +7,7 @@
 ;
 ;------------------------------------------------------------------------------
 
-%define SEC_DEFAULT_CR0  0x40000023
+%define SEC_DEFAULT_CR0  0x00000023
 %define SEC_DEFAULT_CR4  0x640
 
 BITS    16


### PR DESCRIPTION
… CR0

REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4511

With 64 bit build we are seeing the CD in control register CR 0 set. This causes the NEM to disabled for some specific bios profiles.

Cc: Eric Dong <eric.dong@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Cc: Rahul Kumar <rahul1.kumar@intel.com>
Cc: Gerd Hoffmann <kraxel@redhat.com>
Cc: Debkumar De <debkumar.de@intel.com>
Cc: Catharine West <catharine.west@intel.com>