### PR TITLE
MdeModulePkg/Console:Modify check of text output attribute

### DIFF
--- a/MdeModulePkg/Universal/Console/ConSplitterDxe/ConSplitter.c
+++ b/MdeModulePkg/Universal/Console/ConSplitterDxe/ConSplitter.c
@@ -4933,7 +4933,7 @@ ConSplitterTextOutSetAttribute (
   //
   // Check whether param Attribute is valid.
   //
-  if ((Attribute | 0x7F) != 0x7F) {
+  if ((Attribute | 0xFF) != 0xFF) {
     return EFI_UNSUPPORTED;
   }
 

--- a/MdeModulePkg/Universal/Console/GraphicsConsoleDxe/GraphicsConsole.c
+++ b/MdeModulePkg/Universal/Console/GraphicsConsoleDxe/GraphicsConsole.c
@@ -1514,7 +1514,7 @@ GraphicsConsoleConOutSetAttribute (
 {
   EFI_TPL  OldTpl;
 
-  if ((Attribute | 0x7F) != 0x7F) {
+  if ((Attribute | 0xFF) != 0xFF) {
     return EFI_UNSUPPORTED;
   }
 

--- a/MdeModulePkg/Universal/Console/TerminalDxe/TerminalConOut.c
+++ b/MdeModulePkg/Universal/Console/TerminalDxe/TerminalConOut.c
@@ -546,7 +546,7 @@ TerminalConOutSetAttribute (
   //
   //  only the bit0..6 of the Attribute is valid
   //
-  if ((Attribute | 0x7f) != 0x7f) {
+  if ((Attribute | 0xff) != 0xff) {
     return EFI_UNSUPPORTED;
   }
 


### PR DESCRIPTION
When using EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL to output text, if the character is wide, the bit7 of attribute should be set to
1. But SetAttribute failed and return EFI_UNSUPPORTED. Out->Mode->Attribute = Out->Mode->Attribute | 0x80; Out->SetAttribute (Out, Out->Mode->Attribute);

So changing the check of attribute from 0x7F to 0xFF to cover the bit 7 for wide character.

Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Zhichao Gao <zhichao.gao@intel.com>
Cc: Ray Ni <ray.ni@intel.com>