### PR TITLE
UefiCpuPkg: Decouple the SEV-ES functionality.

### DIFF
--- a/UefiCpuPkg/Library/MpInitLib/MpLib.c
+++ b/UefiCpuPkg/Library/MpInitLib/MpLib.c
@@ -2160,7 +2160,10 @@ MpInitLibInitialize (
     // APs have been wakeup before, just get the CPU Information
     // from HOB
     //
-    AmdSevUpdateCpuMpData (CpuMpData);
+    if (CpuMpData->UseSevEsAPMethod) {
+      AmdSevUpdateCpuMpData (CpuMpData);
+    }
+
     CpuMpData->CpuCount  = MpHandOff->CpuCount;
     CpuMpData->BspNumber = GetBspNumber (MpHandOff);
     CpuInfoInHob         = (CPU_INFO_IN_HOB *)(UINTN)CpuMpData->CpuInfoInHob;


### PR DESCRIPTION
The purpose is to fix an issue where an exception occurs at the start of the DXE phase by applying the following patch series on INTEL-based systems.

UefiCpuPkg: Refactor the logic for placing APs in HltLoop.
UefiCpuPkg: Refactor the logic for placing APs in Mwait/Runloop.
UefiCpuPkg: Create MpHandOff.
UefiCpuPkg: ApWakeupFunction directly use CpuMpData.
UefiCpuPkg: Eliminate the second INIT-SIPI-SIPI sequence.

This series of patches makes changes to the way the APs are initialized and woken up. It removes the 2nd time INIT-SIPI-SIPI and introduces a special startup signal to wake up APs. These patches also create a new HOB identified by the mMpHandOffGuid, which stores only the
 minimum information required from the PEI phase to the DXE phase.
As a result, the original HOB (mCpuInitMpLibHobGuid) is now used only as a global variable in the PEI phase and is no longer necessary in the DXE phase for INTEL-based systems. The AMD SEV-ES related code still relies on the OldCpuMpData in the DXE phase.

This patch decouple the SEV-ES functionality of assigning CpuMpData to OldCpuMpData->NewCpuMpData from the Intel logic.

Cc: Eric Dong <eric.dong@intel.com>
Cc: Rahul Kumar <rahul1.kumar@intel.com>
Reviewed-by: Tom Lendacky <thomas.lendacky@amd.com>
Reviewed-by: Ray Ni <ray.ni@intel.com>