### PR TITLE
Variable: Add variable store exceed maximum debug info

### DIFF
--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/Variable.c
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/Variable.c
@@ -1943,6 +1943,7 @@ UpdateVariable (
           // Existing data size + new data size exceed maximum variable size limitation.
           //
           Status = EFI_INVALID_PARAMETER;
+          DEBUG ((DEBUG_ERROR, "ERROR: The variable store exceed maximum variable size limitation.\n"));
           goto Done;
         }
 


### PR DESCRIPTION
When the variable store is full, edk2 will directly assert. 
Add debug information to help users understand what caused 
the assertion.

 Actual results:
 RecordVarErrorFlag (0xEF) 9A144FE2A47E:937FE521-95AE-4D1A-8929-48BCD90AD31A - 0x00000003 - 0x7E
 CommonVariableSpace = 0x3FF9C - CommonVariableTotalSize = 0x3FF98
 RecordVarErrorFlag (0xEF) 9A144FE2A47E:937FE521-95AE-4D1A-8929-48BCD90AD31A - 0x00000003 - 0x92
 CommonVariableSpace = 0x3FF9C - CommonVariableTotalSize = 0x3FF98

 Synchronous Exception at 0x000000023CA60374
 ......
 ASSERT [ArmCpuDxe] /builddir/build/BUILD/edk2-f80f052277c8/ArmPkg/Library/DefaultExceptionHandlerLib/AArch64/DefaultExceptionHandler.c(333): ((BOOLEAN) (0==1))

Signed-off-by: Zhenyu Zhang <zhenyzha@redhat.com>
Cc: Oliver Steffen <osteffen@redhat.com>
Cc: Gerd Hoffmann <ghoffman@redhat.com>
Cc: Gavin Shan <gshan@redhat.com>
Cc: Shaoqin Huang <shahuang@redhat.com>