### PR TITLE
[TEST] OvmfPkg: Use recent Qemu in CI on Windows

### DIFF
--- a/OvmfPkg/PlatformCI/.azurepipelines/Windows-VS2019.yml
+++ b/OvmfPkg/PlatformCI/.azurepipelines/Windows-VS2019.yml
@@ -139,7 +139,7 @@ jobs:
         run_flags: $(Run.Flags)
         usePythonVersion: ${{ variables.default_python_version }}
         extra_install_step:
-        - powershell: choco install qemu --version=2021.5.5; Write-Host "##vso[task.prependpath]c:\Program Files\qemu"
+        - powershell: choco install qemu --version=2023.7.25; Write-Host "##vso[task.prependpath]c:\Program Files\qemu"
           displayName: Install QEMU and Set QEMU on path # friendly name displayed in the UI
           condition: and(gt(variables.pkg_count, 0), succeeded())
 


### PR DESCRIPTION
OvmfPkg: Use recent Qemu in CI on Windows

Bump the version of the Qemu chocolatey package up to 2023.7.25.
The Linux CI is already using Qemu 8.

REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4324