### PR TITLE
Fix potential UINT32 overflow and the subsequent attempt to divide by 0

### DIFF
--- a/MdeModulePkg/Universal/Acpi/FirmwarePerformanceDataTablePei/FirmwarePerformancePei.c
+++ b/MdeModulePkg/Universal/Acpi/FirmwarePerformanceDataTablePei/FirmwarePerformancePei.c
@@ -111,6 +111,12 @@ FpdtStatusCodeListenerPei (
   // Calculate average S3 resume time.
   //
   S3ResumeTotal = MultU64x32 (AcpiS3ResumeRecord->AverageResume, AcpiS3ResumeRecord->ResumeCount);
+
+  if (AcpiS3ResumeRecord->ResumeCount == MAX_UINT32) {
+    DEBUG ((DEBUG_ERROR, "ResumeCount cannot be equal to MAX_UINT32 because of subsequent incrementing\n"));
+    return EFI_ABORTED;
+  }
+
   AcpiS3ResumeRecord->ResumeCount++;
   AcpiS3ResumeRecord->AverageResume = DivU64x32 (S3ResumeTotal + AcpiS3ResumeRecord->FullResume, AcpiS3ResumeRecord->ResumeCount);
 


### PR DESCRIPTION
Hello. This PR is fixing `UINT32` overflow vulnerability that will lead to division by `0` in `FpdtStatusCodeListenerPei` function.

An attacker with the ability to modify physical memory can control the value of `AcpiS3ResumeRecord->ResumeCount`. If the attacker sets the value of `ResumeCount` to `MAX_UINT32` (`0xFFFFFFFF`), and `ResumeCount` is subsequently incremented, its new value will be `0` (due to `UINT32` overflow). Since there is no check for overflow, when `ResumeCount` is `0` and passed as the second argument to `DivU64x32()`, it will trigger a division by `0`, and cause a system crash, leading to a DoS.

This issue was identified by the **BINARLY efiXplorer team** and initially reported to Intel in July 26, 2022 along with another vulnerability in an Intel server board firmware ([BRLY-2022-009](https://github.com/binarly-io/Vulnerability-REsearch/blob/main/AMI/BRLY-2022-009.md)).

We have published a separate advisory for this issue: [BRLY-2023-021](https://github.com/binarly-io/Vulnerability-REsearch/blob/main/EDK2/BRLY-2023-021.md).
It contains details of the vulnerability and PoC for the Intel NUC M15.

Also, we suggest that you consider using the following function instead of `DivU64x32()`:

```c
EFI_STATUS
EFIAPI
CheckedDivU64x32 (
  IN      UINT64  Dividend,
  IN      UINT32  Divisor,
  OUT     UINT64  *Result
  )
```

CC: @matrosov, @flothrone, @xorpse.