### PR TITLE
Push ataatapipassthru coverity

### DIFF
--- a/MdeModulePkg/Bus/Ata/AtaAtapiPassThru/AtaAtapiPassThru.c
+++ b/MdeModulePkg/Bus/Ata/AtaAtapiPassThru/AtaAtapiPassThru.c
@@ -1345,7 +1345,7 @@ AtaPassThruPassThru (
     // Check logical block size
     //
     if ((IdentifyData->AtaData.phy_logic_sector_support & BIT12) != 0) {
-      BlockSize = (UINT32)(((IdentifyData->AtaData.logic_sector_size_hi << 16) | IdentifyData->AtaData.logic_sector_size_lo) * sizeof (UINT16));
+      BlockSize = (UINT32)(((UINT32)(IdentifyData->AtaData.logic_sector_size_hi << 16) | IdentifyData->AtaData.logic_sector_size_lo) * sizeof (UINT16));
     }
   }
 

--- a/MdeModulePkg/Bus/Ata/AtaAtapiPassThru/IdeMode.c
+++ b/MdeModulePkg/Bus/Ata/AtaAtapiPassThru/IdeMode.c
@@ -1992,6 +1992,10 @@ SetDriveParameters (
              NULL
              );
 
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_WARN, "Init Drive Parameters Fail, Status = %r\n", Status));
+  }
+
   //
   // Send Set Multiple parameters
   //
@@ -2007,6 +2011,10 @@ SetDriveParameters (
              ATA_ATAPI_TIMEOUT,
              NULL
              );
+
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_WARN, "Set Multiple Mode Parameters Fail, Status = %r\n", Status));
+  }
 
   return Status;
 }
@@ -2549,13 +2557,13 @@ DetectAndConfigIdeDevice (
     //
     if (DeviceType == EfiIdeHarddisk) {
       //
-      // Init driver parameters
+      // Init drive parameters
       //
       DriveParameters.Sector         = (UINT8)((ATA5_IDENTIFY_DATA *)(&Buffer.AtaData))->sectors_per_track;
       DriveParameters.Heads          = (UINT8)(((ATA5_IDENTIFY_DATA *)(&Buffer.AtaData))->heads - 1);
       DriveParameters.MultipleSector = (UINT8)((ATA5_IDENTIFY_DATA *)(&Buffer.AtaData))->multi_sector_cmd_max_sct_cnt;
 
-      Status = SetDriveParameters (Instance, IdeChannel, IdeDevice, &DriveParameters, NULL);
+      SetDriveParameters (Instance, IdeChannel, IdeDevice, &DriveParameters, NULL);
     }
 
     //


### PR DESCRIPTION
**Patch series sent at:**
https://edk2.groups.io/g/devel/message/106988
https://edk2.groups.io/g/devel/message/106989
https://edk2.groups.io/g/devel/message/106990

**Cover-letter:**
v3 -> v4:
  - [Patch 2] Further update as per review comments
      - Status storage removal at call point
      - Error checks moved inside SetDriveParameters function 

v2 -> v3:
  - [Patch 2] Update as per review comments

v1 -> v2:
  - Retain outer cast
  - Add error check instead of Status storage removal

Ranbir Singh (2):
  MdeModulePkg/Bus/Ata/AtaAtapiPassThru: Fix SIGN_EXTENSION Coverity
    issue
  MdeModulePkg/Bus/Ata/AtaAtapiPassThru: Fix UNUSED_VALUE Coverity issue

 MdeModulePkg/Bus/Ata/AtaAtapiPassThru/AtaAtapiPassThru.c |  2 +-
 MdeModulePkg/Bus/Ata/AtaAtapiPassThru/IdeMode.c          | 12 ++++++++++--
 2 files changed, 11 insertions(+), 3 deletions(-)
