### PR TITLE
OvmfPkg/PlatformCI: Use Qemu 8 in CI and enable SMP in tests

### DIFF
--- a/.azurepipelines/templates/platform-build-run-steps.yml
+++ b/.azurepipelines/templates/platform-build-run-steps.yml
@@ -116,7 +116,7 @@ steps:
     filename: stuart_build
     arguments: -c ${{ parameters.build_file }} TOOL_CHAIN_TAG=${{ parameters.tool_chain_tag}} TARGET=${{ parameters.build_target}} -a ${{ parameters.build_arch}} ${{ parameters.build_flags}} ${{ parameters.run_flags }} --FlashOnly
   condition: and(and(gt(variables.pkg_count, 0), succeeded()), eq(variables['Run'], true))
-  timeoutInMinutes: 2
+  timeoutInMinutes: 4
 
 # Copy the build logs to the artifact staging directory
 - task: CopyFiles@2

--- a/OvmfPkg/PlatformCI/.azurepipelines/Windows-VS2019.yml
+++ b/OvmfPkg/PlatformCI/.azurepipelines/Windows-VS2019.yml
@@ -24,7 +24,7 @@ jobs:
       package: 'OvmfPkg'
       vm_image: 'windows-2019'
       should_run: true
-      run_flags: "MAKE_STARTUP_NSH=TRUE QEMU_HEADLESS=TRUE QEMU_CPUHP_QUIRK=TRUE"
+      run_flags: "MAKE_STARTUP_NSH=TRUE QEMU_HEADLESS=TRUE"
 
     #Use matrix to speed up the build process
     strategy:

--- a/OvmfPkg/PlatformCI/.azurepipelines/Windows-VS2019.yml
+++ b/OvmfPkg/PlatformCI/.azurepipelines/Windows-VS2019.yml
@@ -139,7 +139,7 @@ jobs:
         run_flags: $(Run.Flags)
         usePythonVersion: ${{ variables.default_python_version }}
         extra_install_step:
-        - powershell: choco install qemu --version=2021.5.5; Write-Host "##vso[task.prependpath]c:\Program Files\qemu"
+        - powershell: choco install qemu --version=2023.7.25; Write-Host "##vso[task.prependpath]c:\Program Files\qemu"
           displayName: Install QEMU and Set QEMU on path # friendly name displayed in the UI
           condition: and(gt(variables.pkg_count, 0), succeeded())
 

--- a/OvmfPkg/PlatformCI/PlatformBuildLib.py
+++ b/OvmfPkg/PlatformCI/PlatformBuildLib.py
@@ -195,6 +195,7 @@ class PlatformBuilder( UefiBuilder, BuildSettingsManager):
         args  = "-debugcon stdio"                                           # write messages to stdio
         args += " -global isa-debugcon.iobase=0x402"                        # debug messages out thru virtual io port
         args += " -net none"                                                # turn off network
+        args += " -smp 4"
         args += f" -drive file=fat:rw:{VirtualDrive},format=raw,media=disk" # Mount disk with startup.nsh
 
         if (self.env.GetValue("QEMU_HEADLESS").upper() == "TRUE"):

--- a/OvmfPkg/PlatformCI/PlatformBuildLib.py
+++ b/OvmfPkg/PlatformCI/PlatformBuildLib.py
@@ -170,7 +170,6 @@ class PlatformBuilder( UefiBuilder, BuildSettingsManager):
         self.env.SetValue("PRODUCT_NAME", "OVMF", "Platform Hardcoded")
         self.env.SetValue("MAKE_STARTUP_NSH", "FALSE", "Default to false")
         self.env.SetValue("QEMU_HEADLESS", "FALSE", "Default to false")
-        self.env.SetValue("QEMU_CPUHP_QUIRK", "FALSE", "Default to false")
         return 0
 
     def PlatformPreBuild(self):
@@ -210,17 +209,6 @@ class PlatformBuilder( UefiBuilder, BuildSettingsManager):
         else:
             args += " -pflash " + os.path.join(OutputPath_FV, "OVMF.fd")    # path to firmware
 
-
-        ###
-        ### NOTE This is a temporary workaround to allow platform CI to cope with
-        ###      a QEMU bug in the CPU hotplug code. Once the CI environment has
-        ###      been updated to carry a fixed version of QEMU, this can be
-        ###      removed again
-        ###
-        ### Bugzilla: https://bugzilla.tianocore.org/show_bug.cgi?id=4250
-        ###
-        if (self.env.GetValue("QEMU_CPUHP_QUIRK").upper() == "TRUE"):
-            args += "  -fw_cfg name=opt/org.tianocore/X-Cpuhp-Bugcheck-Override,string=yes"
 
         if (self.env.GetValue("MAKE_STARTUP_NSH").upper() == "TRUE"):
             f = open(os.path.join(VirtualDrive, "startup.nsh"), "w")


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4324

This series switches the OVMF CI jobs on Windows to a recent Qemu
version and re-enables SMP in the Qemu "Run to shell" CI jobs.
The Qemu tests run a little bit slower in SMP mode and sometimes
hit the time limit of 2 minutes, thus this limit is increased to 4
minutes.

Together with 81cb0371f9db ("CI: Use latest image for Linux jobs (Qemu
8, gcc 12)" this series is sufficient to close Bug 4324.
