### PR TITLE
Fix uninitialized variable error

### DIFF
--- a/BaseTools/Conf/tools_def.template
+++ b/BaseTools/Conf/tools_def.template
@@ -853,7 +853,7 @@ DEFINE GCC5_RISCV_ALL_DLINK_COMMON                = -nostdlib -Wl,-n,-q,--gc-sec
 DEFINE GCC5_RISCV_ALL_DLINK_FLAGS                 = DEF(GCC5_RISCV_ALL_DLINK_COMMON) -Wl,--entry,$(IMAGE_ENTRY_POINT) -u $(IMAGE_ENTRY_POINT) -Wl,-Map,$(DEST_DIR_DEBUG)/$(BASE_NAME).map
 DEFINE GCC5_RISCV_ALL_DLINK2_FLAGS                = -Wl,--defsym=PECOFF_HEADER_SIZE=0x220,--script=$(EDK_TOOLS_PATH)/Scripts/GccBase.lds
 DEFINE GCC5_RISCV_ALL_ASM_FLAGS                   = -c -x assembler -imacros $(DEST_DIR_DEBUG)/AutoGen.h
-DEFINE GCC5_RISCV_ALL_CC_FLAGS_WARNING_DISABLE    = -Wno-tautological-compare -Wno-pointer-compare
+DEFINE GCC5_RISCV_ALL_CC_FLAGS_WARNING_DISABLE    = -Wno-tautological-compare -Wno-pointer-compare -Wno-maybe-uninitialized
 
 DEFINE GCC5_RISCV_OPENSBI_TYPES                   = -DOPENSBI_EXTERNAL_SBI_TYPES=OpensbiTypes.h
 


### PR DESCRIPTION
Compiling for riscv64 target emits "maybe-uninitialized" error.
Compilation command: build -t GCC5 -n $NCPUS -b RELEASE -a RISCV64 -p OvmfPkg/RiscVVirt/RiscVVirtQemu.dsc -D SECURE_BOOT_ENABLE=TRUE -D TPM_ENABLE=TRUE -D TPM_CONFIG_ENABLE=TRUE

There are two error logs:
[GenericQemuLoadImageLib.c error log](https://build.tarsier-infra.com/package/live_build_log/home:ouuleilei:branches:home:ouuleilei:branches:openEuler:Mainline/edk2-test/openEuler_Mainline_standard_riscv64_gcc/riscv64)
[Handle.c  error log](https://build.tarsier-infra.com/build/home:ouuleilei:branches:home:ouuleilei:branches:openEuler:Mainline/openEuler_Mainline_standard_riscv64_gcc/riscv64/edk2-test/_log)