### PR TITLE
Use C99 flexible arrays

### DIFF
--- a/EmbeddedPkg/Include/fdt.h
+++ b/EmbeddedPkg/Include/fdt.h
@@ -81,14 +81,14 @@ struct fdt_reserve_entry {
 
 struct fdt_node_header {
   fdt32_t    tag;
-  char       name[0];
+  char       name[];
 };
 
 struct fdt_property {
   fdt32_t    tag;
   fdt32_t    len;
   fdt32_t    nameoff;
-  char       data[0];
+  char       data[];
 };
 
 #endif /* !__ASSEMBLY */

--- a/MdeModulePkg/Library/FrameBufferBltLib/FrameBufferBltLib.c
+++ b/MdeModulePkg/Library/FrameBufferBltLib/FrameBufferBltLib.c
@@ -24,7 +24,7 @@ struct FRAME_BUFFER_CONFIGURE {
   EFI_PIXEL_BITMASK            PixelMasks;
   INT8                         PixelShl[4];    // R-G-B-Rsvd
   INT8                         PixelShr[4];    // R-G-B-Rsvd
-  UINT8                        LineBuffer[0];
+  UINT8                        LineBuffer[];
 };
 
 CONST EFI_PIXEL_BITMASK  mRgbPixelMasks = {

--- a/MdePkg/Include/IndustryStandard/IpmiNetFnApp.h
+++ b/MdePkg/Include/IndustryStandard/IpmiNetFnApp.h
@@ -433,7 +433,7 @@ typedef union {
 typedef struct {
   UINT8                              CompletionCode;
   IPMI_GET_MESSAGE_CHANNEL_NUMBER    ChannelNumber;
-  UINT8                              MessageData[0];
+  UINT8                              MessageData[];
 } IPMI_GET_MESSAGE_RESPONSE;
 
 //
@@ -457,12 +457,12 @@ typedef union {
 typedef struct {
   UINT8                               CompletionCode;
   IPMI_SEND_MESSAGE_CHANNEL_NUMBER    ChannelNumber;
-  UINT8                               MessageData[0];
+  UINT8                               MessageData[];
 } IPMI_SEND_MESSAGE_REQUEST;
 
 typedef struct {
   UINT8    CompletionCode;
-  UINT8    ResponseData[0];
+  UINT8    ResponseData[];
 } IPMI_SEND_MESSAGE_RESPONSE;
 
 //
@@ -906,7 +906,7 @@ typedef union {
 typedef struct {
   IPMI_SET_USER_PASSWORD_USER_ID      UserId;
   IPMI_SET_USER_PASSWORD_OPERATION    Operation;
-  UINT8                               PasswordData[0]; // 16 or 20 bytes, depending on the 'PasswordSize' field
+  UINT8                               PasswordData[]; // 16 or 20 bytes, depending on the 'PasswordSize' field
 } IPMI_SET_USER_PASSWORD_REQUEST;
 
 //

--- a/MdePkg/Include/IndustryStandard/IpmiNetFnChassis.h
+++ b/MdePkg/Include/IndustryStandard/IpmiNetFnChassis.h
@@ -183,7 +183,7 @@ typedef union {
 
 typedef struct {
   IPMI_SET_BOOT_OPTIONS_PARAMETER_VALID    ParameterValid;
-  UINT8                                    ParameterData[0];
+  UINT8                                    ParameterData[];
 } IPMI_SET_BOOT_OPTIONS_REQUEST;
 
 typedef struct {
@@ -415,7 +415,7 @@ typedef struct {
   UINT8                                      CompletionCode;
   IPMI_GET_BOOT_OPTIONS_PARAMETER_VERSION    ParameterVersion;
   IPMI_GET_BOOT_OPTIONS_PARAMETER_VALID      ParameterValid;
-  UINT8                                      ParameterData[0];
+  UINT8                                      ParameterData[];
 } IPMI_GET_BOOT_OPTIONS_RESPONSE;
 
 //

--- a/MdePkg/Include/IndustryStandard/IpmiNetFnStorage.h
+++ b/MdePkg/Include/IndustryStandard/IpmiNetFnStorage.h
@@ -76,7 +76,7 @@ typedef struct {
 typedef struct {
   UINT8    CompletionCode;
   UINT8    CountReturned;
-  UINT8    Data[0];
+  UINT8    Data[];
 } IPMI_READ_FRU_DATA_RESPONSE;
 
 //
@@ -95,7 +95,7 @@ typedef struct {
 typedef struct {
   UINT8     DeviceId;
   UINT16    InventoryOffset;
-  UINT8     Data[0];
+  UINT8     Data[];
 } IPMI_WRITE_FRU_DATA_REQUEST;
 
 typedef struct {
@@ -594,7 +594,7 @@ typedef struct {
   UINT16    RecordId;
   UINT8     OffsetIntoRecord;
   UINT8     InProgress;
-  UINT8     RecordData[0];
+  UINT8     RecordData[];
 } IPMI_PARTIAL_ADD_SEL_ENTRY_REQUEST;
 
 typedef struct {

--- a/MdePkg/Include/IndustryStandard/IpmiNetFnTransport.h
+++ b/MdePkg/Include/IndustryStandard/IpmiNetFnTransport.h
@@ -313,7 +313,7 @@ typedef union {
 typedef struct {
   IPMI_SET_LAN_CONFIG_CHANNEL_NUM    ChannelNumber;
   UINT8                              ParameterSelector;
-  UINT8                              ParameterData[0];
+  UINT8                              ParameterData[];
 } IPMI_SET_LAN_CONFIGURATION_PARAMETERS_COMMAND_REQUEST;
 
 //
@@ -343,7 +343,7 @@ typedef struct {
 typedef struct {
   UINT8    CompletionCode;
   UINT8    ParameterRevision;
-  UINT8    ParameterData[0];
+  UINT8    ParameterData[];
 } IPMI_GET_LAN_CONFIGURATION_PARAMETERS_RESPONSE;
 
 //
@@ -879,7 +879,7 @@ typedef union {
 typedef struct {
   IPMI_SET_SOL_CONFIG_PARAM_CHANNEL_NUM    ChannelNumber;
   UINT8                                    ParameterSelector;
-  UINT8                                    ParameterData[0];
+  UINT8                                    ParameterData[];
 } IPMI_SET_SOL_CONFIGURATION_PARAMETERS_REQUEST;
 
 //
@@ -909,7 +909,7 @@ typedef struct {
 typedef struct {
   UINT8    CompletionCode;
   UINT8    ParameterRevision;
-  UINT8    ParameterData[0];
+  UINT8    ParameterData[];
 } IPMI_GET_SOL_CONFIGURATION_PARAMETERS_RESPONSE;
 
 #pragma pack()

--- a/MdePkg/Include/IndustryStandard/PldmSmbiosTransfer.h
+++ b/MdePkg/Include/IndustryStandard/PldmSmbiosTransfer.h
@@ -92,7 +92,7 @@ typedef struct {
 typedef struct {
   UINT32    NextDataTransferHandle;
   UINT8     TransferFlag;
-  UINT8     Table[0];
+  UINT8     Table[];
 } PLDM_GET_SMBIOS_STRUCTURE_TABLE_RESPONSE;
 
 typedef struct {
@@ -106,7 +106,7 @@ typedef struct {
 typedef struct {
   UINT32    DataTransferHandle;
   UINT8     TransferFlag;
-  UINT8     Table[0];
+  UINT8     Table[];
 } PLDM_SET_SMBIOS_STRUCTURE_TABLE_REQUEST;
 
 typedef struct {
@@ -143,7 +143,7 @@ typedef struct {
 typedef struct {
   UINT32    NextDataTransferHandle;
   UINT8     TransferFlag;
-  UINT8     Table[0];
+  UINT8     Table[];
 } PLDM_GET_SMBIOS_STRUCTURE_BY_TYPE_RESPONSE;
 
 typedef struct {
@@ -171,7 +171,7 @@ typedef struct {
 typedef struct {
   UINT32    NextDataTransferHandle;
   UINT8     TransferFlag;
-  UINT8     Table[0];
+  UINT8     Table[];
 } PLDM_GET_SMBIOS_STRUCTURE_BY_HANDLE_RESPONSE;
 
 typedef struct {

--- a/MdePkg/Include/IndustryStandard/TcgStorageCore.h
+++ b/MdePkg/Include/IndustryStandard/TcgStorageCore.h
@@ -38,7 +38,7 @@ typedef struct {
   UINT32    OutstandingDataBE;
   UINT32    MinTransferBE;
   UINT32    LengthBE;
-  UINT8     Payload[0];
+  UINT8     Payload[];
 } TCG_COM_PACKET;
 
 typedef struct {
@@ -49,7 +49,7 @@ typedef struct {
   UINT16    AckTypeBE;
   UINT32    AcknowledgementBE;
   UINT32    LengthBE;
-  UINT8     Payload[0];
+  UINT8     Payload[];
 } TCG_PACKET;
 
 #define TCG_SUBPACKET_ALIGNMENT  4// 4-byte alignment per spec
@@ -58,7 +58,7 @@ typedef struct {
   UINT8     ReservedBE[6];
   UINT16    KindBE;
   UINT32    LengthBE;
-  UINT8     Payload[0];
+  UINT8     Payload[];
 } TCG_SUB_PACKET;
 
 #define SUBPACKET_KIND_DATA            0x0000

--- a/MdePkg/Include/Protocol/NetworkInterfaceIdentifier.h
+++ b/MdePkg/Include/Protocol/NetworkInterfaceIdentifier.h
@@ -101,7 +101,7 @@ struct undiconfig_table {
   struct {
     VOID    *NII_InterfacePointer;          ///< Pointer to the NII interface structure.
     VOID    *DevicePathPointer;             ///< Pointer to the device path for this NIC.
-  } NII_entry[1];
+  } NII_entry[];
 };
 
 extern EFI_GUID  gEfiNetworkInterfaceIdentifierProtocolGuid;

--- a/MdePkg/Include/Protocol/NvdimmLabel.h
+++ b/MdePkg/Include/Protocol/NvdimmLabel.h
@@ -244,7 +244,7 @@ typedef struct {
   ///
   /// Array size is 1 if EFI_NVDIMM_LABEL_FLAGS_LOCAL is set indicating a Local Namespaces.
   ///
-  EFI_NVDIMM_LABEL_SET_COOKIE_MAP    Mapping[0];
+  EFI_NVDIMM_LABEL_SET_COOKIE_MAP    Mapping[];
 } EFI_NVDIMM_LABEL_SET_COOKIE_INFO;
 
 /**

--- a/UefiPayloadPkg/Include/Coreboot.h
+++ b/UefiPayloadPkg/Include/Coreboot.h
@@ -59,7 +59,7 @@ struct cbmem_root {
   UINT32                num_entries;
   UINT32                locked;
   UINT32                size;
-  struct cbmem_entry    entries[0];
+  struct cbmem_entry    entries[];
 };
 
 struct imd_entry {
@@ -75,7 +75,7 @@ struct imd_root {
   UINT32              flags;
   UINT32              entry_align;
   UINT32              max_offset;
-  struct imd_entry    entries[0];
+  struct imd_entry    entries[];
 };
 
 struct cbuint64 {
@@ -119,7 +119,7 @@ struct cb_memory_range {
 struct cb_memory {
   UINT32                    tag;
   UINT32                    size;
-  struct cb_memory_range    map[0];
+  struct cb_memory_range    map[];
 };
 
 #define CB_TAG_MAINBOARD  0x0003
@@ -129,7 +129,7 @@ struct cb_mainboard {
   UINT32    size;
   UINT8     vendor_idx;
   UINT8     part_number_idx;
-  UINT8     strings[0];
+  UINT8     strings[];
 };
 
 #define CB_TAG_VERSION         0x0004
@@ -146,7 +146,7 @@ struct cb_mainboard {
 struct cb_string {
   UINT32    tag;
   UINT32    size;
-  UINT8     string[0];
+  UINT8     string[];
 };
 
 #define CB_TAG_SERIAL  0x000f


### PR DESCRIPTION
Use C99 flexible arrays instead of older style of one-element or zero-length arrays.
It allows the compiler to generate errors when the flexible array does not occur at the end in the structure.