### PR TITLE
[CI Check]ArmVirtPkg: ArmVirtQemu: Add Graphics and Input

### DIFF
--- a/ArmVirtPkg/PlatformCI/PlatformBuildLib.py
+++ b/ArmVirtPkg/PlatformCI/PlatformBuildLib.py
@@ -244,6 +244,11 @@ class PlatformBuilder(UefiBuilder, BuildSettingsManager):
         # Conditional Args
         if (self.env.GetValue("QEMU_HEADLESS").upper() == "TRUE"):
             args += " -display none"  # no graphics
+        else:
+            args += " -device virtio-gpu-pci"
+            args += " -device qemu-xhci,id=usb"
+            args += " -device usb-tablet,id=input0,bus=usb.0,port=1"  # add a usb mouse
+            args += " -device usb-kbd,id=input1,bus=usb.0,port=2"     # add a usb keyboard
 
         if (self.env.GetValue("MAKE_STARTUP_NSH").upper() == "TRUE"):
             f = open(os.path.join(VirtualDrive, "startup.nsh"), "w")


### PR DESCRIPTION
Currently, unlike OVMF, ArmVirtQemu does not display any graphics, only the QEMU monitor. Graphics are helpful to confirm booting into an OS is successful, interacting with the EFI shell while getting separate logging messages, etc.

This patch adds the QEMU parameters to launch a graphical window and add a USB keyboard and mouse, which is modeled as a tablet as it tracks better in QEMU than a generic mouse. virtio-gpu-pci is chosen as the graphics device as it is recommended by QEMU for the ARM virtual platform.

The graphics and USB input devices will only be added to QEMU when QEMU_HEADLESS == FALSE, so CI builds will not attempt to use the graphics and if a user does not want graphics, they can add QEMU_HEADLESS=TRUE to the build cmdline.

Cc: Leif Lindholm <quic_llindhol@quicinc.com>
Cc: Ard Biesheuvel <ardb+tianocore@kernel.org>
Cc: Sami Mujawar <sami.mujawar@arm.com>
Cc: Gerd Hoffmann <kraxel@redhat.com>