### PR TITLE
IntelFsp2Pkg: Add get and set FspSmmInit upd data pointer functions

### DIFF
--- a/IntelFsp2Pkg/Include/Library/FspCommonLib.h
+++ b/IntelFsp2Pkg/Include/Library/FspCommonLib.h
@@ -193,6 +193,28 @@ GetFspSiliconInitUpdDataPointer (
   );
 
 /**
+  This function sets the smm init UPD data pointer.
+
+  @param[in] SmmInitUpdPtr   smm init UPD data pointer.
+**/
+VOID
+EFIAPI
+SetFspSmmInitUpdDataPointer (
+  IN VOID  *SmmInitUpdPtr
+  );
+
+/**
+  This function gets the smm init UPD data pointer.
+
+  @return smm init UPD data pointer.
+**/
+VOID *
+EFIAPI
+GetFspSmmInitUpdDataPointer (
+  VOID
+  );
+
+/**
   Set FSP measurement point timestamp.
 
   @param[in] Id       Measurement point ID.

--- a/IntelFsp2Pkg/Library/BaseFspCommonLib/FspCommonLib.c
+++ b/IntelFsp2Pkg/Library/BaseFspCommonLib/FspCommonLib.c
@@ -373,6 +373,47 @@ GetFspSiliconInitUpdDataPointer (
 }
 
 /**
+  This function sets the FspSmmInit UPD data pointer.
+
+  @param[in] SmmInitUpdPtr   FspSmmInit UPD data pointer.
+**/
+VOID
+EFIAPI
+SetFspSmmInitUpdDataPointer (
+  IN VOID  *SmmInitUpdPtr
+  )
+{
+  FSP_GLOBAL_DATA  *FspData;
+
+  //
+  // Get the FSP Global Data Pointer
+  //
+  FspData = GetFspGlobalDataPointer ();
+
+  //
+  // Set the FspSmmInit UPD data pointer.
+  //
+  FspData->SmmInitUpdPtr = SmmInitUpdPtr;
+}
+
+/**
+  This function gets the FspSmmInit UPD data pointer.
+
+  @return FspSmmInit UPD data pointer.
+**/
+VOID *
+EFIAPI
+GetFspSmmInitUpdDataPointer (
+  VOID
+  )
+{
+  FSP_GLOBAL_DATA  *FspData;
+
+  FspData = GetFspGlobalDataPointer ();
+  return FspData->SmmInitUpdPtr;
+}
+
+/**
   Set FSP measurement point timestamp.
 
   @param[in] Id       Measurement point ID.


### PR DESCRIPTION
FSP-SMM module need get and set FspSmmInit upd data pointer functions to get and set upd settings.


Cc: Chasel Chiu <chasel.chiu@intel.com>
Cc: Nate DeSimone <nathaniel.l.desimone@intel.com>
Cc: Duggapu Chinni B <chinni.b.duggapu@intel.com>
Cc: Ray Han Lim Ng <ray.han.lim.ng@intel.com>
Cc: Star Zeng <star.zeng@intel.com>
Cc: Ted Kuo <ted.kuo@intel.com>
Cc: Ashraf Ali S <ashraf.ali.s@intel.com>
Cc: Susovan Mohapatra <susovan.mohapatra@intel.com>
Reviewed-by: S Ashraf Ali <ashraf.ali.s@intel.com>
Reviewed-by: Chasel Chiu <chasel.chiu@intel.com>