### PR TITLE
ShellPkg/SmbiosView: Update display of PCIe system slot ID

### DIFF
--- a/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/PrintInfo.c
+++ b/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/PrintInfo.c
@@ -3105,7 +3105,7 @@ DisplaySystemSlotId (
       break;
 
     default:
-      if (((SlotType >= 0x0E) && (SlotType <= 0x12)) || ((SlotType >= 0xA6) && (SlotType <= 0xB6))) {
+      if (((SlotType >= 0x0E) && (SlotType <= 0x12)) || ((SlotType >= 0xA6) && (SlotType <= 0xC4))) {
         ShellPrintHiiEx (-1, -1, NULL, STRING_TOKEN (STR_SMBIOSVIEW_PRINTINFO_VALUE_PRESENT), gShellDebug1HiiHandle, SlotId);
       } else {
         ShellPrintHiiEx (-1, -1, NULL, STRING_TOKEN (STR_SMBIOSVIEW_PRINTINFO_UNDEFINED_SLOT_ID), gShellDebug1HiiHandle);


### PR DESCRIPTION
This updates the system slot ID up to SlotTypePCIExpressGen6andBeyond (0xC4) added by updating type 9 with SMBIOS version 3.5 to cover modern PCIe Gens.


Reviewed-by: Zhichao Gao <zhichao.gao@intel.com>