### PR TITLE
MdeModulePkg/PciBusDxe: Fix boot hang with faulty PCI Option ROM

### DIFF
--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciOptionRomSupport.c
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciOptionRomSupport.c
@@ -506,13 +506,13 @@ LoadOpRomImage (
     Indicator    = RomPcir->Indicator;
     RomImageSize = RomImageSize + RomPcir->ImageLength * 512;
     RomBarOffset = RomBarOffset + RomPcir->ImageLength * 512;
-  } while (((Indicator & 0x80) == 0x00) && ((RomBarOffset - RomBar) < RomSize));
+  } while (((Indicator & 0x80) == 0x00) && ((RomBarOffset - RomBar) < RomSize) && (RomImageSize > 0));
 
   //
   // Some Legacy Cards do not report the correct ImageLength so used the maximum
   // of the legacy length and the PCIR Image Length
   //
-  if (CodeType == PCI_CODE_TYPE_PCAT_IMAGE) {
+  if ((RomImageSize > 0) && (CodeType == PCI_CODE_TYPE_PCAT_IMAGE)) {
     RomImageSize = MAX (RomImageSize, LegacyImageLength);
   }
 


### PR DESCRIPTION
A faulty PCI device has the Option ROM image size set to 0. UEFI reads two headers PCI_EXPANSION_ROM_HEADER and PCI_DATA_STRUCTURE to get the Option ROM information. Because the image size is 0, the Option ROM header address never changes. As a result, UEFI keeps reading the same two headers definitely. This patch is intended to fix it.

Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Hao A Wu <hao.a.wu@intel.com>
Cc: Ray Ni <ray.ni@intel.com>

Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>