### PR TITLE
SecurityPkg/Tpm2DeviceLibTcg2: Make mTcg2Protocol static

### DIFF
--- a/SecurityPkg/Library/Tpm2DeviceLibTcg2/Tpm2DeviceLibTcg2.c
+++ b/SecurityPkg/Library/Tpm2DeviceLibTcg2/Tpm2DeviceLibTcg2.c
@@ -14,7 +14,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Protocol/Tcg2Protocol.h>
 #include <IndustryStandard/Tpm20.h>
 
-EFI_TCG2_PROTOCOL  *mTcg2Protocol = NULL;
+STATIC  EFI_TCG2_PROTOCOL  *mTcg2Protocol = NULL;
 
 /**
   This service enables the sending of commands to the TPM2.


### PR DESCRIPTION
The global variable has a common name that can conflict with other TCG modules. For example, Tcg2Dxe has a similarly named global that is of type EFI_TCG2_PROTOCOL instead of EFI_TCG2_PROTOCOL*.

Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Jian J Wang <jian.j.wang@intel.com>

Reviewed-by: Jiewen Yao <jiewen.yao@intel.com>