### PR TITLE
ArmPkg/SmbiosMiscDxe: use UINT64 for BiosPhysicalSize

### DIFF
--- a/ArmPkg/Universal/Smbios/SmbiosMiscDxe/Type00/MiscBiosVendorFunction.c
+++ b/ArmPkg/Universal/Smbios/SmbiosMiscDxe/Type00/MiscBiosVendorFunction.c
@@ -185,7 +185,7 @@ SMBIOS_MISC_TABLE_FUNCTION (MiscBiosVendor) {
   UINTN               VendorStrLen;
   UINTN               VerStrLen;
   UINTN               DateStrLen;
-  UINTN               BiosPhysicalSize;
+  UINT64              BiosPhysicalSize;
   CHAR16              *Vendor;
   CHAR16              *Version;
   CHAR16              *ReleaseDate;


### PR DESCRIPTION
The top two bits of the Extended BIOS ROM Size field indicates the unit used for the remaining 14 bits. If the size is greater than 16GB, the unit is gigabytes.
The test for this uses the local BiosPhysicalSize variable, which is a UINTN, meaning that when building for ARM/CLANGDWARF we have a tautological constant comparison, which the toolchain flags now we've stopped disabling that warning.
So switch the BiosPhysicalSize variable to UINT64.


Cc: Ard Biesheuvel <ardb+tianocore@kernel.org>
Cc: Rebecca Cran <rebecca@bsdio.com>
Reviewed-by: Ard Biesheuvel <ardb@kernel.org>