### PR TITLE
OvmfPkg/IoMmuDxe: don't rely on TPLs to manage concurrency

### DIFF
--- a/OvmfPkg/IoMmuDxe/IoMmuDxe.inf
+++ b/OvmfPkg/IoMmuDxe/IoMmuDxe.inf
@@ -35,6 +35,7 @@
   MemEncryptSevLib
   MemEncryptTdxLib
   MemoryAllocationLib
+  SynchronizationLib
   UefiBootServicesTableLib
   UefiDriverEntryPoint
 


### PR DESCRIPTION
Instead of relying on raising the TPL to protect the critical sections that manipulate the global bitmask that keeps track of bounce buffer allocations, use compare-and-exchange to manage the global variable, and tweak the logic to line up with that.

Given that IoMmuDxe implements a singleton protocol that is shared between multiple drivers, and considering the elaborate and confusing requirements in the UEFP spec regarding TPL levels at which protocol methods may be invoked, not relying on TPL levels at all is a more robust approach in this case.

Link: https://bugzilla.redhat.com/show_bug.cgi?id=2211060

Acked-by: Pedro Falcato <pedro.falcato@gmail.com>