### PR TITLE
OvmfPkg/AmdSev: Disable PcdFirstTimeWakeUpAPsBySipti

### DIFF
--- a/OvmfPkg/AmdSev/AmdSevX64.dsc
+++ b/OvmfPkg/AmdSev/AmdSevX64.dsc
@@ -468,6 +468,14 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdConInConnectOnDemand|TRUE
   gUefiOvmfPkgTokenSpaceGuid.PcdBootRestrictToFirmware|TRUE
 
+  #
+  # INIT is now triggered before BIOS by ucode/hardware. In the OVMF
+  # environment, QEMU lacks a simulation for the INIT process.
+  # To address this, PcdFirstTimeWakeUpAPsBySipi set to FALSE to
+  # broadcast INIT-SIPI-SIPI for the first time.
+  #
+  gUefiCpuPkgTokenSpaceGuid.PcdFirstTimeWakeUpAPsBySipi|FALSE
+
 ################################################################################
 #
 # Pcd Dynamic Section - list of all EDK II PCD Entries defined by this Platform


### PR DESCRIPTION
PcdFirstTimeWakeUpAPsBySipi was recently introduced to indicate when the full INIT-SIPI-SIPI sequence can be skipped for AP bringup. It is true by default, but needs to be disabled for QEMU/OVMF where early INIT is not simulated. Commit 1d76560146 ("OvmfPkg: Disable PcdFirstTimeWakeUpAPsBySipi.") added changes to disable it by default for OvmfPkg, but a similar change was not made for the AmdSev package. This breaks booting of SEV and SNP guests.

Fix this defaulting PcdFirstTimeWakeUpAPsBySipi to false for AmdSev package, as was previously done for OvmfPkg variants.

Fixes: eaffa1d7ff ("UefiCpuPkg:Wake up APs after power-up or RESET through SIPI.")

Acked-by: Gerd Hoffmann <kraxel@redhat.com>