### PR TITLE
OvmfPkg: Fix Hii form name mismatch with EFI variable

### DIFF
--- a/OvmfPkg/PlatformDxe/Platform.c
+++ b/OvmfPkg/PlatformDxe/Platform.c
@@ -279,7 +279,7 @@ ExtractConfig (
     //
     ConfigRequestHdr = HiiConstructConfigHdr (
                          &gOvmfPlatformConfigGuid,
-                         mVariableName,
+                         mHiiFormName,
                          mImageHandle
                          );
     if (ConfigRequestHdr == NULL) {


### PR DESCRIPTION
The Hii form is named "MainFormState" while the EFI variable is named "PlatformConfig".  This discrepancy in names causes the following SCT cases to fail on RiscVVirtQemu:

  ExtractConfigConformance
  ExtractConfigFunction
  ExtractConfig_Func

Previous commit 16acacf addressed two of these issues, and this patch fixes the remaining one.


Reviewed-by: Dandan Bi <dandan.bi@intel.com>