### PR TITLE
OvmfPkg: Revert "Update build.sh to allow building OVMF then running …

### DIFF
--- a/OvmfPkg/build.sh
+++ b/OvmfPkg/build.sh
@@ -246,11 +246,11 @@ else
 fi
 
 #
-# Build the edk2 OvmfPkg
+# Run previously built OVMF image for current build options, in place.
+# Do not rebuild first, rather allow multiple runs of a previously built
+# image to start quickly (without rebuild), and with preserved NVRAM contents
+# between runs (until the next rebuild).
 #
-echo Running edk2 build for OvmfPkg$Processor
-build -p $PLATFORMFILE $BUILD_OPTIONS -b $BUILDTARGET -t $TARGET_TOOLS -n $THREADNUMBER -DDEBUG_ON_SERIAL_PORT=TRUE
-
 if [[ "$RUN_QEMU" == "yes" ]]; then
   if [[ ! -d $QEMU_FIRMWARE_DIR ]]; then
     mkdir $QEMU_FIRMWARE_DIR
@@ -265,3 +265,10 @@ if [[ "$RUN_QEMU" == "yes" ]]; then
   $QEMU_COMMAND "$@"
   exit $?
 fi
+
+#
+# Build the edk2 OvmfPkg
+#
+echo Running edk2 build for OvmfPkg$Processor
+build -p $PLATFORMFILE $BUILD_OPTIONS -b $BUILDTARGET -t $TARGET_TOOLS -n $THREADNUMBER
+exit $?


### PR DESCRIPTION
…QEMU"

This reverts commit 173a7a7daaad560cd69e1000faca1d2b91774c46

Fixes https://bugzilla.tianocore.org/show_bug.cgi?id=4528

The build.sh qemu option starts the correct qemu executable for the selected architecture (build.sh -a option, or implicit) and uses the correct previously built OVMF image for the selected architecture and build target (build.sh -b option, or implicit).

With this revert, the above step will fail if there is no matching previously built OVMF image. This is advantageous over rebuilding each time the build.sh qemu option is used (as in the reverted commit), because it provides a quick way to run a just-built OVMF image in place, while:
 a) Starting immediately (saving the time required for a rebuild on each
    usage, if the VM is started multiple times)
 b) Preserving the NVRAM contents between multiple runs (i.e. until the
    image is next rebuilt)