### PR TITLE
[CI Check]ArmVirtPkg: Enable Early Serial For DxeCore

### DIFF
--- a/ArmVirtPkg/ArmVirt.dsc.inc
+++ b/ArmVirtPkg/ArmVirt.dsc.inc
@@ -225,6 +225,7 @@
   DxeCoreEntryPoint|MdePkg/Library/DxeCoreEntryPoint/DxeCoreEntryPoint.inf
   ExtractGuidedSectionLib|MdePkg/Library/DxeExtractGuidedSectionLib/DxeExtractGuidedSectionLib.inf
   PerformanceLib|MdeModulePkg/Library/DxeCorePerformanceLib/DxeCorePerformanceLib.inf
+  SerialPortLib|ArmVirtPkg/Library/FdtPL011SerialPortLib/EarlyFdtPL011SerialPortLib.inf
 
 [LibraryClasses.common.DXE_DRIVER]
   SecurityManagementLib|MdeModulePkg/Library/DxeSecurityManagementLib/DxeSecurityManagementLib.inf

--- a/ArmVirtPkg/Library/FdtPL011SerialPortLib/EarlyFdtPL011SerialPortLib.inf
+++ b/ArmVirtPkg/Library/FdtPL011SerialPortLib/EarlyFdtPL011SerialPortLib.inf
@@ -14,7 +14,7 @@
   FILE_GUID                      = 0983616A-49BC-4732-B531-4AF98D2056F0
   MODULE_TYPE                    = BASE
   VERSION_STRING                 = 1.0
-  LIBRARY_CLASS                  = SerialPortLib|SEC PEI_CORE PEIM
+  LIBRARY_CLASS                  = SerialPortLib|SEC PEI_CORE PEIM DXE_CORE
 
 [Sources.common]
   EarlyFdtPL011SerialPortLib.c


### PR DESCRIPTION
Currently, ArmVirtPkg does not provide a serial library for DxeCore, so any early prints are missed. These prints are extremely valuable for debugging.

The early serial port lib used by PeiCore and PEIMs is also applicable to DxeCore and in testing works to print debug prints from DxeCore throughout its lifecycle.

This patchset adds the indicated support for DXE_CORE to EarlyFdtPL011SerialPortLib and adds this as the serial port instance for DxeCore in ArmVirtPkg.

Github PR: https://github.com/tianocore/edk2/pull/4793

Cc: Leif Lindholm <quic_llindhol@quicinc.com>
Cc: Ard Biesheuvel <ardb+tianocore@kernel.org>
Cc: Sami Mujawar <sami.mujawar@arm.com>
Cc: Gerd Hoffmann <kraxel@redhat.com>