### PR TITLE
crypto agile feature

### DIFF
--- a/CryptoPkg/Library/BaseCryptLib/Pk/CryptTs.c
+++ b/CryptoPkg/Library/BaseCryptLib/Pk/CryptTs.c
@@ -591,7 +591,8 @@ ImageTimestampVerify (
   // Register & Initialize necessary digest algorithms for PKCS#7 Handling.
   //
   if ((EVP_add_digest (EVP_md5 ()) == 0) || (EVP_add_digest (EVP_sha1 ()) == 0) ||
-      (EVP_add_digest (EVP_sha256 ()) == 0) || ((EVP_add_digest_alias (SN_sha1WithRSAEncryption, SN_sha1WithRSA)) == 0))
+      (EVP_add_digest (EVP_sha256 ()) == 0) || (EVP_add_digest (EVP_sha384 ()) == 0) ||
+      (EVP_add_digest (EVP_sha512 ()) == 0) || ((EVP_add_digest_alias (SN_sha1WithRSAEncryption, SN_sha1WithRSA)) == 0))
   {
     return FALSE;
   }

--- a/SecurityPkg/Library/AuthVariableLib/AuthServiceInternal.h
+++ b/SecurityPkg/Library/AuthVariableLib/AuthServiceInternal.h
@@ -92,7 +92,9 @@ extern UINT32  mMaxCertDbSize;
 extern UINT32  mPlatformMode;
 extern UINT8   mVendorKeyState;
 
-extern VOID  *mHashCtx;
+extern VOID  *mHashSha256Ctx;
+extern VOID  *mHashSha384Ctx;
+extern VOID  *mHashSha512Ctx;
 
 extern AUTH_VAR_LIB_CONTEXT_IN  *mAuthVarLibContextIn;
 

--- a/SecurityPkg/VariableAuthenticated/SecureBootConfigDxe/SecureBootConfigDxe.inf
+++ b/SecurityPkg/VariableAuthenticated/SecureBootConfigDxe/SecureBootConfigDxe.inf
@@ -82,6 +82,14 @@
   ## SOMETIMES_PRODUCES      ## GUID            # Unique ID for the type of the signature.
   gEfiCertSha256Guid
 
+  ## SOMETIMES_CONSUMES      ## GUID            # Unique ID for the type of the signature.
+  ## SOMETIMES_PRODUCES      ## GUID            # Unique ID for the type of the signature.
+  gEfiCertSha384Guid
+
+  ## SOMETIMES_CONSUMES      ## GUID            # Unique ID for the type of the signature.
+  ## SOMETIMES_PRODUCES      ## GUID            # Unique ID for the type of the signature.
+  gEfiCertSha512Guid
+
   ## SOMETIMES_CONSUMES      ## Variable:L"db"
   ## SOMETIMES_PRODUCES      ## Variable:L"db"
   ## SOMETIMES_CONSUMES      ## Variable:L"dbx"

--- a/SecurityPkg/VariableAuthenticated/SecureBootConfigDxe/SecureBootConfigImpl.h
+++ b/SecurityPkg/VariableAuthenticated/SecureBootConfigDxe/SecureBootConfigImpl.h
@@ -82,6 +82,8 @@ extern  EFI_IFR_GUID_LABEL  *mEndLabel;
 #define MAX_DIGEST_SIZE  SHA512_DIGEST_SIZE
 
 #define WIN_CERT_UEFI_RSA2048_SIZE  256
+#define WIN_CERT_UEFI_RSA3072_SIZE  384
+#define WIN_CERT_UEFI_RSA4096_SIZE  512
 
 //
 // Support hash types
@@ -97,6 +99,11 @@ extern  EFI_IFR_GUID_LABEL  *mEndLabel;
 // Certificate public key minimum size (bytes)
 //
 #define CER_PUBKEY_MIN_SIZE  256
+
+//
+// Define KeyType for public key storing file
+//
+#define KEY_TYPE_RSASSA  0
 
 //
 // Types of errors may occur during certificate enrollment.

--- a/SecurityPkg/VariableAuthenticated/SecureBootConfigDxe/SecureBootConfigStrings.uni
+++ b/SecurityPkg/VariableAuthenticated/SecureBootConfigDxe/SecureBootConfigStrings.uni
@@ -124,6 +124,8 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #string STR_LIST_TYPE_X509                        #language en-US "X509"
 #string STR_LIST_TYPE_SHA1                        #language en-US "SHA1"
 #string STR_LIST_TYPE_SHA256                      #language en-US "SHA256"
+#string STR_LIST_TYPE_SHA384                      #language en-US "SHA384"
+#string STR_LIST_TYPE_SHA512                      #language en-US "SHA512"
 #string STR_LIST_TYPE_X509_SHA256                 #language en-US "X509_SHA256"
 #string STR_LIST_TYPE_X509_SHA384                 #language en-US "X509_SHA384"
 #string STR_LIST_TYPE_X509_SHA512                 #language en-US "X509_SHA512"


### PR DESCRIPTION
Patch V9:
Refine coding format for file AuthService.c

Patch V8:
Update the patch comments for CryptoPkg.
Comment should be <76 characters in each line.
Refine coding format.

Patch V7:
Drop raw RSA3072 and RSA4096. Only use gEfiCertX509Guid for RSA3072 and RSA4096
Do the positive tests and the negative tests below. And got all the expected results.

Patch V6:
Remove the changes in MdePkg.
The changes of patch v6 are in CryptoPkg and SecurityPkg.
Set signature type to gEfiCertX509Guid when enroll RSA3072/RSA4096 KEK.
This signature type is used to check the supported signature and show the strings.

Patch V5:
Using define KEY_TYPE_RSASSA to replace the magic number.

Patch V4:
Determine the RSA algorithm by a supported algorithm list.

Patch V3:
Select SHA algorithm automaticly for a unsigned efi image.

Patch V2:
Determine the SHA algorithm by a supported algorithm list.
Create SHA context for each algorithm.

Test Case:
1. Enroll a RSA4096 Cert, and execute an RSA4096 signed efi image under UEFI shell. 
2. Enroll a RSA3072 Cert, and execute an RSA3072 signed efi image under UEFI shell. 
3. Enroll a RSA2048 Cert, and execute an RSA2048 signed efi image under UEFI shell. 
4. Enroll an unsigned efi image, execute the unsigned efi image under UEFI shell

Test Result:
Pass

Negative Test Case:
1) Enroll a RSA2048 Cert, execute an unsigned efi image.
2) Enroll a RSA2048 Cert, execute a RSA4096 signed efi image.
3) Enroll a RSA4096 Cert, execute a RSA3072 signed efi image.
4) Enroll a RSA4096 Cert to both DB and DBX, execute the RSA4096 signed efi image.

Test Result:
Get "Access Denied" when try to execute the efi image.