### PR TITLE
OvmfPkg/Bhyve: don't exit early if RSDP is not found in memory

### DIFF
--- a/OvmfPkg/Bhyve/AcpiPlatformDxe/AcpiPlatform.c
+++ b/OvmfPkg/Bhyve/AcpiPlatformDxe/AcpiPlatform.c
@@ -259,19 +259,17 @@ InstallAcpiTables (
              BHYVE_BIOS_PHYSICAL_END,
              &Rsdp
              );
-  if (EFI_ERROR (Status)) {
-    return Status;
-  }
-
-  Status = InstallAcpiTablesFromRsdp (
-             AcpiTable,
-             Rsdp
-             );
   if (!EFI_ERROR (Status)) {
-    return EFI_SUCCESS;
+    Status = InstallAcpiTablesFromRsdp (
+               AcpiTable,
+               Rsdp
+               );
+    if (!EFI_ERROR (Status)) {
+      return EFI_SUCCESS;
+    }
   }
 
-  if (Status != EFI_NOT_FOUND) {
+  if (EFI_ERROR (Status)) {
     DEBUG (
       (
        DEBUG_WARN,
@@ -280,7 +278,6 @@ InstallAcpiTables (
        Status
       )
       );
-    return Status;
   }
 
   Status = InstallOvmfFvTables (AcpiTable);


### PR DESCRIPTION
If OVMF fails to find the RSDP in memory, it should fall back installing the statically provided ACPI tables.


Cc: Ard Biesheuvel <ardb+tianocore@kernel.org>
Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Jordan Justen <jordan.l.justen@intel.com>
Cc: Gerd Hoffmann <kraxel@redhat.com>
Cc: Rebecca Cran <rebecca@bsdio.com>
Cc: Peter Grehan <grehan@freebsd.org>