### PR TITLE
MdePkg/Library/BaseRngLib: Fix include guard

### DIFF
--- a/MdePkg/Library/BaseRngLib/BaseRngLibInternals.h
+++ b/MdePkg/Library/BaseRngLib/BaseRngLibInternals.h
@@ -9,6 +9,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
 #ifndef BASE_RNGLIB_INTERNALS_H_
+#define BASE_RNGLIB_INTERNALS_H_
 
 /**
   Generates a 16-bit random number.


### PR DESCRIPTION
The include guard is incomplete and does not define the macro.

Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Zhiguang Liu <zhiguang.liu@intel.com>
Cc: Rebecca Cran <rebecca@bsdio.com>
Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>
Reviewed-by: Rebecca Cran <rebecca@os.amperecomputing.com>
Reviewed-by: Michael D Kinney <michael.d.kinney@intel.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>