### PR TITLE
MdePkg/Library/TdxLib: Remove unnecessary comparison

### DIFF
--- a/MdePkg/Library/TdxLib/Rtmr.c
+++ b/MdePkg/Library/TdxLib/Rtmr.c
@@ -51,7 +51,7 @@ TdExtendRtmr (
 
   ASSERT (Data != NULL);
   ASSERT (DataLen == SHA384_DIGEST_SIZE);
-  ASSERT (Index >= 0 && Index < RTMR_COUNT);
+  ASSERT (Index < RTMR_COUNT);
 
   if ((Data == NULL) || (DataLen != SHA384_DIGEST_SIZE) || (Index >= RTMR_COUNT)) {
     return EFI_INVALID_PARAMETER;


### PR DESCRIPTION
Removes the comparison since unsigned values are always greater than or equal to 0.

See the following CodeQL query for more info:
/cpp/cpp-unsigned-comparison-zero/

Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Zhiguang Liu <zhiguang.liu@intel.com>
Cc: Rebecca Cran <rebecca@bsdio.com>
Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>
Reviewed-by: Michael D Kinney <michael.d.kinney@intel.com>
Reviewed-by: Jiewen Yao <Jiewen.yao@intel.com>