### PR TITLE
SecurityPkg: RngDxe: Fixing mAvailableAlgoArray allocator

### DIFF
--- a/SecurityPkg/RandomNumberGenerator/RngDxe/AArch64/AArch64Algo.c
+++ b/SecurityPkg/RandomNumberGenerator/RngDxe/AArch64/AArch64Algo.c
@@ -39,7 +39,7 @@ GetAvailableAlgorithms (
   UnSafeAlgo = FALSE;
 
   // Rng algorithms 2 times, one for the allocation, one to populate.
-  mAvailableAlgoArray = AllocateZeroPool (RNG_AVAILABLE_ALGO_MAX);
+  mAvailableAlgoArray = AllocateZeroPool (RNG_AVAILABLE_ALGO_MAX * sizeof (EFI_RNG_ALGORITHM));
   if (mAvailableAlgoArray == NULL) {
     return EFI_OUT_OF_RESOURCES;
   }

--- a/SecurityPkg/RandomNumberGenerator/RngDxe/Arm/ArmAlgo.c
+++ b/SecurityPkg/RandomNumberGenerator/RngDxe/Arm/ArmAlgo.c
@@ -32,7 +32,7 @@ GetAvailableAlgorithms (
   UINT16  MinorRevision;
 
   // Rng algorithms 2 times, one for the allocation, one to populate.
-  mAvailableAlgoArray = AllocateZeroPool (RNG_AVAILABLE_ALGO_MAX);
+  mAvailableAlgoArray = AllocateZeroPool (RNG_AVAILABLE_ALGO_MAX * sizeof (EFI_RNG_ALGORITHM));
   if (mAvailableAlgoArray == NULL) {
     return EFI_OUT_OF_RESOURCES;
   }


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?idD91

mAvailableAlgoArray is currently allocated for "RNG_AVAILABLE_ALGO_MAX" number of bytes, whereas it was dereferenced as "EFI_RNG_ALGORITHM".

This change fixed the buffer allocation logic by allocating a proper size of buffer before referencing.

Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Sami Mujawar <Sami.Mujawar@arm.com>
Cc: Pierre Gondois <pierre.gondois@arm.com>


Reviewed-by: Sami Mujawar <sami.mujawar@arm.com>