### PR TITLE
Add a .editorconfig file to tell editors basic formatting details

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,31 @@
+# EditorConfig file: https://EditorConfig.org
+
+root = true
+
+[*]
+charset = latin1
+end_of_line = crlf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.py]
+charset = utf-8
+indent_style = space
+indent_size = 4
+
+[*.sh]
+end_of_line = lf
+
+[.gitattributes]
+end_of_line = lf
+
+[.mailmap]
+charset = utf-8
+
+[Maintainers.txt]
+charset = utf-8
+
+[Makefile,GNUmakefile]
+indent_style = tab


### PR DESCRIPTION
Add a .editorconfig file which editors can use for basic formatting details of files, such as tabs/spaces, line endings etc.


Reviewed-by: Ard Biesheuvel <ardb@kernel.org>
Acked-by: Michael D Kinney <michael.d.kinney@intel.com>