### PR TITLE
MdeModulePkg/HiiDatabase: Fix incorrect AllocateCopyPool size

### DIFF
--- a/MdeModulePkg/Universal/HiiDatabaseDxe/ConfigKeywordHandler.c
+++ b/MdeModulePkg/Universal/HiiDatabaseDxe/ConfigKeywordHandler.c
@@ -1987,7 +1987,7 @@ GetNameFromId (
                    NULL
                    );
   if (BestLanguage == NULL) {
-    BestLanguage = AllocateCopyPool (AsciiStrLen ("en-US"), "en-US");
+    BestLanguage = AllocateCopyPool (sizeof ("en-US"), "en-US");
     ASSERT (BestLanguage != NULL);
   }
 


### PR DESCRIPTION
The immediately preceding call, GetBestLanguage, plus the implementation of HiiGetString, which is called immediately afterwards, make it clear that BestLanguage is a null-terminated ASCII string, and not just a five byte, non-null terminated buffer.

Therefore AsciiStrLen is one byte too short, meaning that whether the space allocated is really sufficient and whether the resultant string is really null-terminated becomes implementation-dependent. Rather than switching to AsciiStrSize, we use an explicitly compile-time string length calculation (both compile-time and run-time approaches are currently used elsewhere in the codebase for copying static strings).


Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>
Reviewed-by: Dandan Bi <dandan.bi@intel.com>