### PR TITLE
ArmPkg/ArmMmuLib: Drop buggy secure memory type check

### DIFF
--- a/ArmPkg/Include/Library/ArmLib.h
+++ b/ArmPkg/Include/Library/ArmLib.h
@@ -45,8 +45,6 @@ typedef enum {
   ARM_MEMORY_REGION_ATTRIBUTE_DEVICE,
 } ARM_MEMORY_REGION_ATTRIBUTES;
 
-#define IS_ARM_MEMORY_REGION_ATTRIBUTES_SECURE(attr)  ((UINT32)(attr) & 1)
-
 typedef struct {
   EFI_PHYSICAL_ADDRESS            PhysicalBase;
   EFI_VIRTUAL_ADDRESS             VirtualBase;

--- a/ArmPkg/Library/ArmMmuLib/Arm/ArmMmuLibCore.c
+++ b/ArmPkg/Library/ArmMmuLib/Arm/ArmMmuLibCore.c
@@ -169,7 +169,6 @@ PopulateLevel2PageTable (
 
       // Overwrite the section entry to point to the new Level2 Translation Table
       *SectionEntry = (TranslationTable & TT_DESCRIPTOR_SECTION_PAGETABLE_ADDRESS_MASK) |
-                      (IS_ARM_MEMORY_REGION_ATTRIBUTES_SECURE (Attributes) ? (1 << 3) : 0) |
                       TT_DESCRIPTOR_SECTION_TYPE_PAGE_TABLE;
     } else {
       // We do not support the other section type (16MB Section)
@@ -192,7 +191,6 @@ PopulateLevel2PageTable (
     ZeroMem ((VOID *)TranslationTable, TRANSLATION_TABLE_PAGE_SIZE);
 
     *SectionEntry = (TranslationTable & TT_DESCRIPTOR_SECTION_PAGETABLE_ADDRESS_MASK) |
-                    (IS_ARM_MEMORY_REGION_ATTRIBUTES_SECURE (Attributes) ? (1 << 3) : 0) |
                     TT_DESCRIPTOR_SECTION_TYPE_PAGE_TABLE;
   }
 


### PR DESCRIPTION
Jake reports that the IS_ARM_MEMORY_REGION_ATTRIBUTES_SECURE() macro is no longer accurate since commit 852227a9d52e3cb9 ("ArmPkg/Mmu: Remove handling of NONSECURE memory regions").

Fortunately, it only affects the NS bit in level 1 short descriptors, which is ignored when executing in non-secure mode. And given that running UEFI in the secure world is not a use case we aim to support, let's just drop this logic altogether.

Reported-by: Jake Garver <jake@nvidia.com>

Reviewed-by: Leif Lindholm <quic_llindhol@quicinc.com>