### PR TITLE
OvmfPkg/TdxDxe: Change MadtMpWk->MailBoxVersion from 1 to 0

### DIFF
--- a/OvmfPkg/TdxDxe/TdxAcpiTable.c
+++ b/OvmfPkg/TdxDxe/TdxAcpiTable.c
@@ -186,7 +186,7 @@ AlterAcpiTable (
       MadtMpWk                 = (EFI_ACPI_6_4_MULTIPROCESSOR_WAKEUP_STRUCTURE *)(NewMadtTable + Table->Length);
       MadtMpWk->Type           = EFI_ACPI_6_4_MULTIPROCESSOR_WAKEUP;
       MadtMpWk->Length         = sizeof (EFI_ACPI_6_4_MULTIPROCESSOR_WAKEUP_STRUCTURE);
-      MadtMpWk->MailBoxVersion = 1;
+      MadtMpWk->MailBoxVersion = 0;
       MadtMpWk->Reserved       = 0;
       MadtMpWk->MailBoxAddress = RelocateMailboxAddress;
 


### PR DESCRIPTION
BZ: https://bugzilla.tianocore.org/show_bug.cgi?id=4527

According to ACPI 6.5 (https://uefi.org/specs/ACPI/6.5/05_ACPI_Software _Programming_Model.html?highlight=mailboxversion#multiprocessor-wakeup- structure) the MailBoxVersion is 0.

This patch changed MadtMpWk->MailBoxVersion from 1 to 0 to fix the error.

Cc: Erdem Aktas <erdemaktas@google.com>
Cc: James Bottomley <jejb@linux.ibm.com>
Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Gerd Hoffmann <kraxel@redhat.com>
Cc: Tom Lendacky <thomas.lendacky@amd.com>
Cc: Michael Roth <michael.roth@amd.com>

Reviewed-by: Jiewen Yao <jiewen.yao@intel.com>