### PR TITLE
[PATCH v2 0/3] updates for "OvmfPkg/RiscVVirt/README.md" -- push

### DIFF
--- a/OvmfPkg/RiscVVirt/README.md
+++ b/OvmfPkg/RiscVVirt/README.md
@@ -70,6 +70,11 @@ Below example shows how to boot openSUSE Tumbleweed E20.
         -device virtio-blk-device,drive=hd0 \
         -drive file=openSUSE-Tumbleweed-RISC-V-E20-efi.riscv64.raw,format=raw,id=hd0
 
+    Note: the `acpi=off` machine property is specified because Linux guest
+    support for ACPI (that is, the ACPI consumer side) is a work in progress.
+    Currently, `acpi=off` is recommended unless you are developing ACPI support
+    yourself.
+
 ## Test with your own OpenSBI binary
 Using the above QEMU command line, **RISCV_VIRT_CODE.fd** is launched by the
 OpenSBI binary that is bundled with QEMU. You can build your own OpenSBI binary

--- a/OvmfPkg/RiscVVirt/README.md
+++ b/OvmfPkg/RiscVVirt/README.md
@@ -86,3 +86,8 @@ then specify that binary for QEMU, with the following additional command line
 option:
 
     -bios $OPENSBI_DIR/build/platform/generic/firmware/fw_dynamic.bin
+
+Note that the above only makes a difference with software emulation (which you
+can force with `-M accel=tcg`). With hardware virtualization (`-M accel=kvm`),
+KVM services the SBI (Supervisor Binary Interface) calls internally, therefore
+any OpenSBI binary specified with `-bios` is rejected.

--- a/OvmfPkg/RiscVVirt/README.md
+++ b/OvmfPkg/RiscVVirt/README.md
@@ -75,8 +75,39 @@ Below example shows how to boot openSUSE Tumbleweed E20.
     Currently, `acpi=off` is recommended unless you are developing ACPI support
     yourself.
 
+3) Running QEMU with direct kernel boot
+
+    The following example boots the same guest, but loads the kernel image and
+    the initial RAM disk (which were extracted from
+    `openSUSE-Tumbleweed-RISC-V-E20-efi.riscv64.raw`) from the host filesystem.
+    It also sets the guest kernel command line on the QEMU command line.
+
+        CMDLINE=(root=UUID=76d9b92d-09e9-4df0-8262-c1a7a466f2bc
+                 systemd.show_status=1
+                 ignore_loglevel
+                 console=ttyS0
+                 earlycon=uart8250,mmio,0x10000000)
+
+        qemu-system-riscv64 \
+        -M virt,pflash0=pflash0,pflash1=pflash1,acpi=off \
+        -m 4096 -smp 2 \
+        -serial mon:stdio \
+        -device virtio-gpu-pci -full-screen \
+        -device qemu-xhci \
+        -device usb-kbd \
+        -device virtio-rng-pci \
+        -blockdev node-name=pflash0,driver=file,read-only=on,filename=RISCV_VIRT_CODE.fd \
+        -blockdev node-name=pflash1,driver=file,filename=RISCV_VIRT_VARS.fd \
+        -netdev user,id=net0 \
+        -device virtio-net-pci,netdev=net0 \
+        -device virtio-blk-device,drive=hd0 \
+        -drive file=openSUSE-Tumbleweed-RISC-V-E20-efi.riscv64.raw,format=raw,id=hd0 \
+        -kernel Image-6.5.2-1-default \
+        -initrd initrd-6.5.2-1-default \
+        -append "${CMDLINE[*]}"
+
 ## Test with your own OpenSBI binary
-Using the above QEMU command line, **RISCV_VIRT_CODE.fd** is launched by the
+Using the above QEMU command lines, **RISCV_VIRT_CODE.fd** is launched by the
 OpenSBI binary that is bundled with QEMU. You can build your own OpenSBI binary
 as well:
 


### PR DESCRIPTION
Original posting: `[PATCH 0/3] updates for "OvmfPkg/RiscVVirt/README.md"`
http://mid.mail-archive.com/20230913105551.12680-1-lersek@redhat.com
https://edk2.groups.io/g/devel/message/108575
https://listman.redhat.com/archives/edk2-devel-archive/2023-September/067875.html

This v2 has never been posted to the list, but it only incorporates a small fix, addressing Drew's comment under patch#1. The change is noted in the commit message of patch#1. The interdiff is:

~~~
1:  f99c0f999a47 ! 1:  4c8053b787ca OvmfPkg/RiscVVirt/README: explain that "-bios" is only useful with TCG
    @@ Commit message
         Cc: Jordan Justen <jordan.l.justen@intel.com>
         Cc: Sunil V L <sunilvl@ventanamicro.com>
         Signed-off-by: Laszlo Ersek <lersek@redhat.com>
    +    [lersek@redhat.com: '-bios' is rejected with KVM accel (Drew)]
    +    Reviewed-by: Andrew Jones <ajones@ventanamicro.com>
    +    Reviewed-by: Sunil V L <sunilvl@ventanamicro.com>
     
      ## OvmfPkg/RiscVVirt/README.md ##
     @@ OvmfPkg/RiscVVirt/README.md: then specify that binary for QEMU, with the following additional command line
    @@ OvmfPkg/RiscVVirt/README.md: then specify that binary for QEMU, with the followi
     +Note that the above only makes a difference with software emulation (which you
     +can force with `-M accel=tcg`). With hardware virtualization (`-M accel=kvm`),
     +KVM services the SBI (Supervisor Binary Interface) calls internally, therefore
    -+any externally loaded OpenSBI binary is ignored.
    ++any OpenSBI binary specified with `-bios` is rejected.
~~~