### PR TITLE
RedfishPkg/JsonLib: fix JsonObjectGetValue issue

### DIFF
--- a/RedfishPkg/Library/JsonLib/JsonLib.c
+++ b/RedfishPkg/Library/JsonLib/JsonLib.c
@@ -19,6 +19,8 @@
 
 #include "jansson.h"
 
+extern volatile UINT32  hashtable_seed;
+
 /**
   The function is used to initialize a JSON value which contains a new JSON array,
   or NULL on error. Initially, the array is empty.
@@ -1137,4 +1139,37 @@ JsonGetType (
   )
 {
   return (EDKII_JSON_TYPE)(((json_t *)JsonValue)->type);
+}
+
+/**
+  JSON Library constructor.
+
+  @param ImageHandle     The image handle.
+  @param SystemTable     The system table.
+
+  @retval  EFI_SUCCESS  Protocol listener is registered successfully.
+
+**/
+EFI_STATUS
+EFIAPI
+JsonLibConstructor (
+  IN EFI_HANDLE        ImageHandle,
+  IN EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  //
+  // hashtable_seed is initalized by current time while JsonLib is loaded.
+  // Due to above mechanism, hashtable_seed will be different in each individual
+  // UEFI driver. As the result, the hash of same key in different UEFI driver
+  // would be different. This breaks JsonObjectGetValue() because
+  // JsonObjectGetValue() won't be able to find corresponding JSON value if
+  // this EDKII_JSON_VALUE is created by another UEFI driver.
+  //
+  // Initial the seed to a fixed magic value for JsonLib to be working in all
+  // UEFI drivers. This fixed number will be removed after the protocol version
+  // of JsonLib is implemented in the future.
+  //
+  hashtable_seed = 0xFDAE2143;
+
+  return EFI_SUCCESS;
 }

--- a/RedfishPkg/Library/JsonLib/JsonLib.inf
+++ b/RedfishPkg/Library/JsonLib/JsonLib.inf
@@ -15,6 +15,7 @@
   MODULE_TYPE                    = DXE_DRIVER
   VERSION_STRING                 = 1.0
   LIBRARY_CLASS                  = JsonLib|DXE_DRIVER UEFI_APPLICATION UEFI_DRIVER
+  CONSTRUCTOR                    = JsonLibConstructor
 
 #
 #  VALID_ARCHITECTURES           = IA32 X64 ARM AARCH64 RISCV64


### PR DESCRIPTION
JsonObjectGetValue() cannot find corresponding JSON value when the EDKII_JSON_VALUE object is created by another UEFI driver. This is because "hashtable_seed" is initialized by current time while JsonLib is loaded. So, "hashtable_seed" will be different in each individual UEFI driver.