### PR TITLE
ArmPkg/ArmVirtPkg: handle FEAT_VHE NS-EL2 virtual timer

### DIFF
--- a/ArmPkg/ArmPkg.dec
+++ b/ArmPkg/ArmPkg.dec
@@ -328,6 +328,7 @@
   gArmTokenSpaceGuid.PcdArmArchTimerIntrNum|30|UINT32|0x00000036
   gArmTokenSpaceGuid.PcdArmArchTimerHypIntrNum|26|UINT32|0x00000040
   gArmTokenSpaceGuid.PcdArmArchTimerVirtIntrNum|27|UINT32|0x00000041
+  gArmTokenSpaceGuid.PcdArmArchTimerHypVirtIntrNum|28|UINT32|0x0000004A
 
   #
   # ARM Generic Watchdog

--- a/ArmVirtPkg/ArmVirtCloudHv.dsc
+++ b/ArmVirtPkg/ArmVirtCloudHv.dsc
@@ -178,6 +178,7 @@
   gArmTokenSpaceGuid.PcdArmArchTimerIntrNum|0x0
   gArmTokenSpaceGuid.PcdArmArchTimerVirtIntrNum|0x0
   gArmTokenSpaceGuid.PcdArmArchTimerHypIntrNum|0x0
+  gArmTokenSpaceGuid.PcdArmArchTimerHypVirtIntrNum|0x0
 
   #
   # ARM General Interrupt Controller

--- a/ArmVirtPkg/ArmVirtKvmTool.dsc
+++ b/ArmVirtPkg/ArmVirtKvmTool.dsc
@@ -183,6 +183,7 @@
   gArmTokenSpaceGuid.PcdArmArchTimerIntrNum|0x0
   gArmTokenSpaceGuid.PcdArmArchTimerVirtIntrNum|0x0
   gArmTokenSpaceGuid.PcdArmArchTimerHypIntrNum|0x0
+  gArmTokenSpaceGuid.PcdArmArchTimerHypVirtIntrNum|0x0
 
   #
   # ARM General Interrupt Controller

--- a/ArmVirtPkg/ArmVirtQemu.dsc
+++ b/ArmVirtPkg/ArmVirtQemu.dsc
@@ -253,6 +253,7 @@
   gArmTokenSpaceGuid.PcdArmArchTimerIntrNum|0x0
   gArmTokenSpaceGuid.PcdArmArchTimerVirtIntrNum|0x0
   gArmTokenSpaceGuid.PcdArmArchTimerHypIntrNum|0x0
+  gArmTokenSpaceGuid.PcdArmArchTimerHypVirtIntrNum|0x0
 
   #
   # ARM General Interrupt Controller

--- a/ArmVirtPkg/ArmVirtQemuKernel.dsc
+++ b/ArmVirtPkg/ArmVirtQemuKernel.dsc
@@ -214,6 +214,7 @@
   gArmTokenSpaceGuid.PcdArmArchTimerIntrNum|0x0
   gArmTokenSpaceGuid.PcdArmArchTimerVirtIntrNum|0x0
   gArmTokenSpaceGuid.PcdArmArchTimerHypIntrNum|0x0
+  gArmTokenSpaceGuid.PcdArmArchTimerHypVirtIntrNum|0x0
 
   #
   # ARM General Interrupt Controller

--- a/ArmVirtPkg/ArmVirtXen.dsc
+++ b/ArmVirtPkg/ArmVirtXen.dsc
@@ -118,6 +118,7 @@
   gArmTokenSpaceGuid.PcdArmArchTimerIntrNum|0x0
   gArmTokenSpaceGuid.PcdArmArchTimerVirtIntrNum|0x0
   gArmTokenSpaceGuid.PcdArmArchTimerHypIntrNum|0x0
+  gArmTokenSpaceGuid.PcdArmArchTimerHypVirtIntrNum|0x0
 
   #
   # ARM General Interrupt Controller

--- a/ArmVirtPkg/Library/ArmVirtTimerFdtClientLib/ArmVirtTimerFdtClientLib.c
+++ b/ArmVirtPkg/Library/ArmVirtTimerFdtClientLib/ArmVirtTimerFdtClientLib.c
@@ -35,6 +35,7 @@ ArmVirtTimerFdtClientLibConstructor (
   CONST INTERRUPT_PROPERTY  *InterruptProp;
   UINT32                    PropSize;
   INT32                     SecIntrNum, IntrNum, VirtIntrNum, HypIntrNum;
+  INT32                     HypVirtIntrNum;
   RETURN_STATUS             PcdStatus;
 
   Status = gBS->LocateProtocol (
@@ -66,10 +67,10 @@ ArmVirtTimerFdtClientLibConstructor (
   }
 
   //
-  // - interrupts : Interrupt list for secure, non-secure, virtual and
-  //  hypervisor timers, in that order.
+  // - interrupts : Interrupt list for secure, non-secure, virtual,
+  //  hypervisor and hypervisor virtual timers, in that order.
   //
-  ASSERT (PropSize == 36 || PropSize == 48);
+  ASSERT (PropSize >= 36);
 
   SecIntrNum = SwapBytes32 (InterruptProp[0].Number)
                + (InterruptProp[0].Type ? 16 : 0);
@@ -79,6 +80,8 @@ ArmVirtTimerFdtClientLibConstructor (
                 + (InterruptProp[2].Type ? 16 : 0);
   HypIntrNum = PropSize < 48 ? 0 : SwapBytes32 (InterruptProp[3].Number)
                + (InterruptProp[3].Type ? 16 : 0);
+  HypVirtIntrNum = PropSize < 60 ? 0 : SwapBytes32 (InterruptProp[4].Number)
+                   + (InterruptProp[4].Type ? 16 : 0);
 
   DEBUG ((
     DEBUG_INFO,
@@ -96,6 +99,8 @@ ArmVirtTimerFdtClientLibConstructor (
   PcdStatus = PcdSet32S (PcdArmArchTimerVirtIntrNum, VirtIntrNum);
   ASSERT_RETURN_ERROR (PcdStatus);
   PcdStatus = PcdSet32S (PcdArmArchTimerHypIntrNum, HypIntrNum);
+  ASSERT_RETURN_ERROR (PcdStatus);
+  PcdStatus = PcdSet32S (PcdArmArchTimerHypVirtIntrNum, HypVirtIntrNum);
   ASSERT_RETURN_ERROR (PcdStatus);
 
   return EFI_SUCCESS;

--- a/ArmVirtPkg/Library/ArmVirtTimerFdtClientLib/ArmVirtTimerFdtClientLib.inf
+++ b/ArmVirtPkg/Library/ArmVirtTimerFdtClientLib/ArmVirtTimerFdtClientLib.inf
@@ -40,6 +40,7 @@
   gArmTokenSpaceGuid.PcdArmArchTimerIntrNum
   gArmTokenSpaceGuid.PcdArmArchTimerVirtIntrNum
   gArmTokenSpaceGuid.PcdArmArchTimerHypIntrNum
+  gArmTokenSpaceGuid.PcdArmArchTimerHypVirtIntrNum
 
 [Depex]
   gFdtClientProtocolGuid


### PR DESCRIPTION
An ASSERT trips when we try to add the NS-EL2 virtual timer to qemu
mach-virt.

Add a new Pcd for the new private peripheral interrupt id,
PcdArmArchTimerHypVirtIntrNum. 

Update ArmVirtTimerFdtClientLib to:
- Only assert on receiving less information that required through DT.
- Set PcdArmArchTimerHypVirtIntrNum if provided through DT.

Reported-by: Peter Maydell <peter.maydell@linaro.org>
Cc: Ard Biesheuvel <ardb+tianocore@kernel.org>
Cc: Sami Mujawar <sami.mujawar@arm.com>