### PR TITLE
MdeModulePkg/Bus/Ata/AtaBusDxe: Fix SIGN_EXTENSION Coverity issue

### DIFF
--- a/MdeModulePkg/Bus/Ata/AtaBusDxe/AtaPassThruExecute.c
+++ b/MdeModulePkg/Bus/Ata/AtaBusDxe/AtaPassThruExecute.c
@@ -362,7 +362,7 @@ IdentifyAtaDevice (
     // Check logical block size
     //
     if ((PhyLogicSectorSupport & BIT12) != 0) {
-      BlockMedia->BlockSize = (UINT32)(((IdentifyData->logic_sector_size_hi << 16) | IdentifyData->logic_sector_size_lo) * sizeof (UINT16));
+      BlockMedia->BlockSize = (UINT32)(((UINT32)(IdentifyData->logic_sector_size_hi << 16) | IdentifyData->logic_sector_size_lo) * sizeof (UINT16));
     }
 
     AtaDevice->BlockIo.Revision = EFI_BLOCK_IO_PROTOCOL_REVISION2;


### PR DESCRIPTION
Line number 365 does contain a typecast with UINT32, but it is after all the operations (16-bit left shift followed by OR'ing) are over. To avoid any SIGN_EXTENSION, typecast the intermediate result after 16-bit left shift operation immediately with UINT32.

REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4209

Cc: Hao A Wu <hao.a.wu@intel.com>
Cc: Ray Ni <ray.ni@intel.com>


Reviewed-by: Hao A Wu <hao.a.wu@intel.com>