### PR TITLE
MdeModulePkg/Bus/Pci/NvmExpressPei: Fix DEADCODE Coverity issue

### DIFF
--- a/MdeModulePkg/Bus/Pci/NvmExpressPei/NvmExpressPeiS3.c
+++ b/MdeModulePkg/Bus/Pci/NvmExpressPei/NvmExpressPeiS3.c
@@ -62,10 +62,6 @@ NvmeS3SkipThisController (
     }
   }
 
-  if (S3InitDevices == NULL) {
-    return Skip;
-  }
-
   //
   // Only need to initialize the controllers that exist in the device list.
   //


### PR DESCRIPTION
The code can reach line 65 only through the else path above at line 53. The else path already has the same NULL check at line 55 and hence the duplicate code lines are totally redundant which can be deleted.

REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4220

Cc: Hao A Wu <hao.a.wu@intel.com>
Cc: Ray Ni <ray.ni@intel.com>



Reviewed-by: Hao A Wu <hao.a.wu@intel.com>