### PR TITLE
ArmPkg/ArmLib: Add ArmHasVhe () helper function

### DIFF
--- a/ArmPkg/Include/Chipset/AArch64.h
+++ b/ArmPkg/Include/Chipset/AArch64.h
@@ -24,6 +24,9 @@
 // Coprocessor Trap Register (CPTR)
 #define AARCH64_CPTR_TFP  (1 << 10)
 
+// ID_AA64MMFR1 - AArch64 Memory Model Feature Register 0 definitions
+#define AARCH64_MMFR1_VH  (0xF << 8)
+
 // ID_AA64PFR0 - AArch64 Processor Feature Register 0 definitions
 #define AARCH64_PFR0_FP   (0xF << 16)
 #define AARCH64_PFR0_GIC  (0xF << 24)

--- a/ArmPkg/Include/Library/ArmLib.h
+++ b/ArmPkg/Include/Library/ArmLib.h
@@ -764,6 +764,24 @@ ArmHasCcidx (
   VOID
   );
 
+#ifdef MDE_CPU_AARCH64
+///
+/// AArch64-only ID Register Helper functions
+///
+
+/**
+  Checks whether the CPU implements the Virtualization Host Extensions.
+
+  @retval TRUE  FEAT_VHE is implemented.
+  @retval FALSE FEAT_VHE is not mplemented.
+**/
+BOOLEAN
+EFIAPI
+ArmHasVhe (
+  VOID
+  );
+#endif // MDE_CPU_AARCH64
+
 #ifdef MDE_CPU_ARM
 ///
 /// AArch32-only ID Register Helper functions

--- a/ArmPkg/Library/ArmLib/AArch64/AArch64Lib.c
+++ b/ArmPkg/Library/ArmLib/AArch64/AArch64Lib.c
@@ -104,3 +104,18 @@ ArmHasCcidx (
   Mmfr2 = ArmReadIdAA64Mmfr2 ();
   return (((Mmfr2 >> 20) & 0xF) == 1) ? TRUE : FALSE;
 }
+
+/**
+  Checks whether the CPU implements the Virtualization Host Extensions.
+
+  @retval TRUE  FEAT_VHE is implemented.
+  @retval FALSE FEAT_VHE is not mplemented.
+**/
+BOOLEAN
+EFIAPI
+ArmHasVhe (
+  VOID
+  )
+{
+  return ((ArmReadIdAA64Mmfr1 () & AARCH64_MMFR1_VH) != 0);
+}


### PR DESCRIPTION
Create a helper function to query whether ID_AA64MFR1_EL1 indicates presence of the Virtualization Host Extensions. This feature is only visible in AARCH64 state.


Cc: Ard Biesheuvel <ardb+tianocore@kernel.org>
Cc: Sami Mujawar <sami.mujawar@arm.com>
Cc: Marcin Juszkiewicz <marcin.juszkiewicz@linaro.org>
Reviewed-by: Sami Mujawar <sami.mujawar@arm.com>
Tested-by: Marcin Juszkiewicz <marcin.juszkiewicz@linaro.org>