### PR TITLE
Pull: RISCV: Fix InternalLongJump to return correct value

### DIFF
--- a/MdePkg/Library/BaseLib/RiscV64/RiscVSetJumpLongJump.S
+++ b/MdePkg/Library/BaseLib/RiscV64/RiscVSetJumpLongJump.S
@@ -3,6 +3,7 @@
 // Set/Long jump for RISC-V
 //
 // Copyright (c) 2020, Hewlett Packard Enterprise Development LP. All rights reserved.<BR>
+// Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -47,9 +48,5 @@ InternalLongJump:
     REG_L s10, 11*SZREG(a0)
     REG_L s11, 12*SZREG(a0)
     REG_L sp,  13*SZREG(a0)
-
-    add   a0, s0, 0
-    add   a1, s1, 0
-    add   a2, s2, 0
-    add   a3, s3, 0
+    mv    a0, a1
     ret


### PR DESCRIPTION
InternalLongJump was not returning the 2nd parameter passed to LongJmp (Value) as the return value from SetJmp.

Seen with code compiled with -Os, where an LongJmp (Buffer, -1) somehow translated to SetJmp returning 0...

Cc: Yong Li <yong.li@intel.com>
Cc: Sunil V L <sunilvl@ventanamicro.com>
Cc: Tuan Phan <tphan@ventanamicro.com>
Cc: Daniel Schaefer <git@danielschaefer.me>

Reviewed-by: Sunil V L <sunilvl@ventanamicro.com>