### PR TITLE
UefiPayloadPkg: Add PCD for programming serial clockrate

### DIFF
--- a/MdeModulePkg/Include/UniversalPayload/SerialPortInfo.h
+++ b/MdeModulePkg/Include/UniversalPayload/SerialPortInfo.h
@@ -19,6 +19,7 @@ typedef struct {
   BOOLEAN                             UseMmio;
   UINT8                               RegisterStride;
   UINT32                              BaudRate;
+  UINT32                              ClockRate;
   EFI_PHYSICAL_ADDRESS                RegisterBase;
 } UNIVERSAL_PAYLOAD_SERIAL_PORT_INFO;
 #pragma pack()

--- a/UefiPayloadPkg/Library/PlatformHookLib/PlatformHookLib.c
+++ b/UefiPayloadPkg/Library/PlatformHookLib/PlatformHookLib.c
@@ -90,6 +90,11 @@ PlatformHookSerialPortInitialize (
       return Status;
     }
 
+    Status = PcdSet32S (PcdSerialClockRate, SerialPortInfo->ClockRate);
+    if (RETURN_ERROR (Status)) {
+      return Status;
+    }
+
     return RETURN_SUCCESS;
   }
 

--- a/UefiPayloadPkg/Library/PlatformHookLib/PlatformHookLib.inf
+++ b/UefiPayloadPkg/Library/PlatformHookLib/PlatformHookLib.inf
@@ -38,3 +38,4 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdSerialRegisterBase    ## PRODUCES
   gEfiMdeModulePkgTokenSpaceGuid.PcdSerialBaudRate        ## PRODUCES
   gEfiMdeModulePkgTokenSpaceGuid.PcdSerialRegisterStride  ## PRODUCES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdSerialClockRate       ## PRODUCES

--- a/UefiPayloadPkg/UefiPayloadEntry/UefiPayloadEntry.c
+++ b/UefiPayloadPkg/UefiPayloadEntry/UefiPayloadEntry.c
@@ -431,6 +431,7 @@ _ModuleEntryPoint (
     UniversalSerialPort->UseMmio         = (SerialPortInfo.Type == 1) ? FALSE : TRUE;
     UniversalSerialPort->RegisterBase    = SerialPortInfo.BaseAddr;
     UniversalSerialPort->BaudRate        = SerialPortInfo.Baud;
+    UniversalSerialPort->ClockRate       = SerialPortInfo.InputHertz;
     UniversalSerialPort->RegisterStride  = (UINT8)SerialPortInfo.RegWidth;
   }
 


### PR DESCRIPTION
Some platforms (Such as AMD Zen-based devices) use a non-standard serial clockrate, which if not programmed, will result in no serial output. Add support for setting a PCD based on the serial port data passed from coreboot, and using that to configure the serial port along with other params already programmed (such as base address, baud rate, etc).

TEST=build/boot UefiPayloadPkg on AMD Mendocino-based Chromebook with functional serial output

Signed-off-by: Matt DeVillier <matt.devillier@gmail.com>