### PR TITLE
BaseTools/GenFw: Add support for LOONGARCH64 relax relocation

### DIFF
--- a/BaseTools/Source/C/GenFw/Elf64Convert.c
+++ b/BaseTools/Source/C/GenFw/Elf64Convert.c
@@ -1778,7 +1778,17 @@ WriteSections64 (
           case R_LARCH_TLS_LD64_HI20:
           case R_LARCH_TLS_GD_PC_HI20:
           case R_LARCH_TLS_GD64_HI20:
+          case R_LARCH_32_PCREL:
           case R_LARCH_RELAX:
+          case R_LARCH_DELETE:
+          case R_LARCH_ALIGN:
+          case R_LARCH_PCREL20_S2:
+          case R_LARCH_CFA:
+          case R_LARCH_ADD6:
+          case R_LARCH_SUB6:
+          case R_LARCH_ADD_ULEB128:
+          case R_LARCH_SUB_ULEB128:
+          case R_LARCH_64_PCREL:
             //
             // These types are not used or do not require fixup.
             //
@@ -2185,7 +2195,17 @@ WriteRelocations64 (
               case R_LARCH_TLS_LD64_HI20:
               case R_LARCH_TLS_GD_PC_HI20:
               case R_LARCH_TLS_GD64_HI20:
+              case R_LARCH_32_PCREL:
               case R_LARCH_RELAX:
+              case R_LARCH_DELETE:
+              case R_LARCH_ALIGN:
+              case R_LARCH_PCREL20_S2:
+              case R_LARCH_CFA:
+              case R_LARCH_ADD6:
+              case R_LARCH_SUB6:
+              case R_LARCH_ADD_ULEB128:
+              case R_LARCH_SUB_ULEB128:
+              case R_LARCH_64_PCREL:
                 //
                 // These types are not used or do not require fixup in PE format files.
                 //

--- a/BaseTools/Source/C/GenFw/elf_common.h
+++ b/BaseTools/Source/C/GenFw/elf_common.h
@@ -1144,5 +1144,16 @@ typedef struct {
 #define R_LARCH_TLS_LD64_HI20              96
 #define R_LARCH_TLS_GD_PC_HI20             97
 #define R_LARCH_TLS_GD64_HI20              98
-#define R_LARCH_RELAX                      99
+#define R_LARCH_32_PCREL                   99
+#define R_LARCH_RELAX                      100
+#define R_LARCH_DELETE                     101
+#define R_LARCH_ALIGN                      102
+#define R_LARCH_PCREL20_S2                 103
+#define R_LARCH_CFA                        104
+#define R_LARCH_ADD6                       105
+#define R_LARCH_SUB6                       106
+#define R_LARCH_ADD_ULEB128                107
+#define R_LARCH_SUB_ULEB128                108
+#define R_LARCH_64_PCREL                   109
+
 #endif /* !_SYS_ELF_COMMON_H_ */


### PR DESCRIPTION
Correct relax id from 99 to 100 and added relocation support up to 109

fix gcc14 adds new relocation, and the generated relocation causes the build and compilation to fail.
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4559

Cc: Rebecca Cran <rebecca@bsdio.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Bob Feng <bob.c.feng@intel.com>
Cc: Yuwei Chen <yuwei.chen@intel.com>
Cc: Chao Li <lichao@loongson.cn>
Signed-off-by: Dongyan Qian <qiandongyan@loongson.cn>
Reviewed-by: Chao Li <lichao@loongson.cn>