### PR TITLE
MdeModulePkg/Xhci: Skip size round up for TRB during address translation

### DIFF
--- a/MdeModulePkg/Bus/Pci/XhciDxe/UsbHcMem.c
+++ b/MdeModulePkg/Bus/Pci/XhciDxe/UsbHcMem.c
@@ -226,6 +226,7 @@ UsbHcAllocMemFromBlock (
   @param  Pool           The memory pool of the host controller.
   @param  Mem            The pointer to host memory.
   @param  Size           The size of the memory region.
+  @param  Alignment      Alignment the size to USBHC_MEM_UNIT bytes.
 
   @return                The pci memory address
 
@@ -234,7 +235,8 @@ EFI_PHYSICAL_ADDRESS
 UsbHcGetPciAddrForHostAddr (
   IN USBHC_MEM_POOL  *Pool,
   IN VOID            *Mem,
-  IN UINTN           Size
+  IN UINTN           Size,
+  IN BOOLEAN         Alignment
   )
 {
   USBHC_MEM_BLOCK       *Head;
@@ -243,8 +245,12 @@ UsbHcGetPciAddrForHostAddr (
   EFI_PHYSICAL_ADDRESS  PhyAddr;
   UINTN                 Offset;
 
-  Head      = Pool->Head;
-  AllocSize = USBHC_MEM_ROUND (Size);
+  Head = Pool->Head;
+  if (Alignment) {
+    AllocSize = USBHC_MEM_ROUND (Size);
+  } else {
+    AllocSize = Size;
+  }
 
   if (Mem == NULL) {
     return 0;
@@ -275,6 +281,7 @@ UsbHcGetPciAddrForHostAddr (
   @param  Pool           The memory pool of the host controller.
   @param  Mem            The pointer to pci memory.
   @param  Size           The size of the memory region.
+  @param  Alignment      Alignment the size to USBHC_MEM_UNIT bytes.
 
   @return                The host memory address
 
@@ -283,7 +290,8 @@ EFI_PHYSICAL_ADDRESS
 UsbHcGetHostAddrForPciAddr (
   IN USBHC_MEM_POOL  *Pool,
   IN VOID            *Mem,
-  IN UINTN           Size
+  IN UINTN           Size,
+  IN BOOLEAN         Alignment
   )
 {
   USBHC_MEM_BLOCK       *Head;
@@ -292,8 +300,12 @@ UsbHcGetHostAddrForPciAddr (
   EFI_PHYSICAL_ADDRESS  HostAddr;
   UINTN                 Offset;
 
-  Head      = Pool->Head;
-  AllocSize = USBHC_MEM_ROUND (Size);
+  Head = Pool->Head;
+  if (Alignment) {
+    AllocSize = USBHC_MEM_ROUND (Size);
+  } else {
+    AllocSize = Size;
+  }
 
   if (Mem == NULL) {
     return 0;

--- a/MdeModulePkg/Bus/Pci/XhciDxe/UsbHcMem.h
+++ b/MdeModulePkg/Bus/Pci/XhciDxe/UsbHcMem.h
@@ -129,6 +129,7 @@ UsbHcFreeMem (
   @param  Pool           The memory pool of the host controller.
   @param  Mem            The pointer to host memory.
   @param  Size           The size of the memory region.
+  @param  Alignment      Alignment the size to USBHC_MEM_UNIT bytes.
 
   @return                The pci memory address
 
@@ -137,7 +138,8 @@ EFI_PHYSICAL_ADDRESS
 UsbHcGetPciAddrForHostAddr (
   IN USBHC_MEM_POOL  *Pool,
   IN VOID            *Mem,
-  IN UINTN           Size
+  IN UINTN           Size,
+  IN BOOLEAN         Alignment
   );
 
 /**
@@ -146,6 +148,7 @@ UsbHcGetPciAddrForHostAddr (
   @param  Pool           The memory pool of the host controller.
   @param  Mem            The pointer to pci memory.
   @param  Size           The size of the memory region.
+  @param  Alignment      Alignment the size to USBHC_MEM_UNIT bytes.
 
   @return                The host memory address
 
@@ -154,7 +157,8 @@ EFI_PHYSICAL_ADDRESS
 UsbHcGetHostAddrForPciAddr (
   IN USBHC_MEM_POOL  *Pool,
   IN VOID            *Mem,
-  IN UINTN           Size
+  IN UINTN           Size,
+  IN BOOLEAN         Alignment
   );
 
 /**

--- a/MdeModulePkg/Bus/Pci/XhciPei/UsbHcMem.c
+++ b/MdeModulePkg/Bus/Pci/XhciPei/UsbHcMem.c
@@ -190,6 +190,7 @@ UsbHcAllocMemFromBlock (
   @param  Pool          The memory pool of the host controller.
   @param  Mem           The pointer to host memory.
   @param  Size          The size of the memory region.
+  @param  Alignment     Alignment the size to USBHC_MEM_UNIT bytes.
 
   @return               The pci memory address
 
@@ -198,7 +199,8 @@ EFI_PHYSICAL_ADDRESS
 UsbHcGetPciAddrForHostAddr (
   IN USBHC_MEM_POOL  *Pool,
   IN VOID            *Mem,
-  IN UINTN           Size
+  IN UINTN           Size,
+  IN BOOLEAN         Alignment
   )
 {
   USBHC_MEM_BLOCK       *Head;
@@ -207,8 +209,12 @@ UsbHcGetPciAddrForHostAddr (
   EFI_PHYSICAL_ADDRESS  PhyAddr;
   UINTN                 Offset;
 
-  Head      = Pool->Head;
-  AllocSize = USBHC_MEM_ROUND (Size);
+  Head = Pool->Head;
+  if (Alignment) {
+    AllocSize = USBHC_MEM_ROUND (Size);
+  } else {
+    AllocSize = Size;
+  }
 
   if (Mem == NULL) {
     return 0;
@@ -239,6 +245,7 @@ UsbHcGetPciAddrForHostAddr (
   @param  Pool          The memory pool of the host controller.
   @param  Mem           The pointer to pci memory.
   @param  Size          The size of the memory region.
+  @param  Alignment     Alignment the size to USBHC_MEM_UNIT bytes.
 
   @return               The host memory address
 
@@ -247,7 +254,8 @@ EFI_PHYSICAL_ADDRESS
 UsbHcGetHostAddrForPciAddr (
   IN USBHC_MEM_POOL  *Pool,
   IN VOID            *Mem,
-  IN UINTN           Size
+  IN UINTN           Size,
+  IN BOOLEAN         Alignment
   )
 {
   USBHC_MEM_BLOCK       *Head;
@@ -256,8 +264,12 @@ UsbHcGetHostAddrForPciAddr (
   EFI_PHYSICAL_ADDRESS  HostAddr;
   UINTN                 Offset;
 
-  Head      = Pool->Head;
-  AllocSize = USBHC_MEM_ROUND (Size);
+  Head = Pool->Head;
+  if (Alignment) {
+    AllocSize = USBHC_MEM_ROUND (Size);
+  } else {
+    AllocSize = Size;
+  }
 
   if (Mem == NULL) {
     return 0;

--- a/MdeModulePkg/Bus/Pci/XhciPei/UsbHcMem.h
+++ b/MdeModulePkg/Bus/Pci/XhciPei/UsbHcMem.h
@@ -68,6 +68,7 @@ typedef struct _USBHC_MEM_POOL {
   @param  Pool          The memory pool of the host controller.
   @param  Mem           The pointer to host memory.
   @param  Size          The size of the memory region.
+  @param  Alignment     Alignment the size to USBHC_MEM_UNIT bytes.
 
   @return               The pci memory address
 
@@ -76,7 +77,8 @@ EFI_PHYSICAL_ADDRESS
 UsbHcGetPciAddrForHostAddr (
   IN USBHC_MEM_POOL  *Pool,
   IN VOID            *Mem,
-  IN UINTN           Size
+  IN UINTN           Size,
+  IN BOOLEAN         Alignment
   );
 
 /**
@@ -85,6 +87,7 @@ UsbHcGetPciAddrForHostAddr (
   @param  Pool          The memory pool of the host controller.
   @param  Mem           The pointer to pci memory.
   @param  Size          The size of the memory region.
+  @param  Alignment     Alignment the size to USBHC_MEM_UNIT bytes.
 
   @return               The host memory address
 
@@ -93,7 +96,8 @@ EFI_PHYSICAL_ADDRESS
 UsbHcGetHostAddrForPciAddr (
   IN USBHC_MEM_POOL  *Pool,
   IN VOID            *Mem,
-  IN UINTN           Size
+  IN UINTN           Size,
+  IN BOOLEAN         Alignment
   );
 
 /**

--- a/MdeModulePkg/Bus/Pci/XhciPei/XhciSched.c
+++ b/MdeModulePkg/Bus/Pci/XhciPei/XhciSched.c
@@ -675,7 +675,7 @@ XhcPeiCheckUrbResult (
     // Need convert pci device address to host address
     //
     PhyAddr = (EFI_PHYSICAL_ADDRESS)(EvtTrb->TRBPtrLo | LShiftU64 ((UINT64)EvtTrb->TRBPtrHi, 32));
-    TRBPtr  = (TRB_TEMPLATE *)(UINTN)UsbHcGetHostAddrForPciAddr (Xhc->MemPool, (VOID *)(UINTN)PhyAddr, sizeof (TRB_TEMPLATE));
+    TRBPtr  = (TRB_TEMPLATE *)(UINTN)UsbHcGetHostAddrForPciAddr (Xhc->MemPool, (VOID *)(UINTN)PhyAddr, sizeof (TRB_TEMPLATE), FALSE);
 
     //
     // Update the status of Urb according to the finished event regardless of whether
@@ -766,7 +766,7 @@ EXIT:
   High       = XhcPeiReadRuntimeReg (Xhc, XHC_ERDP_OFFSET + 4);
   XhcDequeue = (UINT64)(LShiftU64 ((UINT64)High, 32) | Low);
 
-  PhyAddr = UsbHcGetPciAddrForHostAddr (Xhc->MemPool, Xhc->EventRing.EventRingDequeue, sizeof (TRB_TEMPLATE));
+  PhyAddr = UsbHcGetPciAddrForHostAddr (Xhc->MemPool, Xhc->EventRing.EventRingDequeue, sizeof (TRB_TEMPLATE), FALSE);
 
   if ((XhcDequeue & (~0x0F)) != (PhyAddr & (~0x0F))) {
     //
@@ -1213,7 +1213,8 @@ XhcPeiInitializeDeviceSlot (
   PhyAddr = UsbHcGetPciAddrForHostAddr (
               Xhc->MemPool,
               ((TRANSFER_RING *)(UINTN)Xhc->UsbDevContext[SlotId].EndpointTransferRing[0])->RingSeg0,
-              sizeof (TRB_TEMPLATE) * TR_RING_TRB_NUMBER
+              sizeof (TRB_TEMPLATE) * TR_RING_TRB_NUMBER,
+              TRUE
               );
   InputContext->EP[0].PtrLo = XHC_LOW_32BIT (PhyAddr) | BIT0;
   InputContext->EP[0].PtrHi = XHC_HIGH_32BIT (PhyAddr);
@@ -1231,7 +1232,7 @@ XhcPeiInitializeDeviceSlot (
   // 7) Load the appropriate (Device Slot ID) entry in the Device Context Base Address Array (5.4.6) with
   //    a pointer to the Output Device Context data structure (6.2.1).
   //
-  PhyAddr = UsbHcGetPciAddrForHostAddr (Xhc->MemPool, OutputContext, sizeof (DEVICE_CONTEXT));
+  PhyAddr = UsbHcGetPciAddrForHostAddr (Xhc->MemPool, OutputContext, sizeof (DEVICE_CONTEXT), TRUE);
   //
   // Fill DCBAA with PCI device address
   //
@@ -1246,7 +1247,7 @@ XhcPeiInitializeDeviceSlot (
   //
   MicroSecondDelay (XHC_RESET_RECOVERY_DELAY);
   ZeroMem (&CmdTrbAddr, sizeof (CmdTrbAddr));
-  PhyAddr             = UsbHcGetPciAddrForHostAddr (Xhc->MemPool, Xhc->UsbDevContext[SlotId].InputContext, sizeof (INPUT_CONTEXT));
+  PhyAddr             = UsbHcGetPciAddrForHostAddr (Xhc->MemPool, Xhc->UsbDevContext[SlotId].InputContext, sizeof (INPUT_CONTEXT), TRUE);
   CmdTrbAddr.PtrLo    = XHC_LOW_32BIT (PhyAddr);
   CmdTrbAddr.PtrHi    = XHC_HIGH_32BIT (PhyAddr);
   CmdTrbAddr.CycleBit = 1;
@@ -1427,7 +1428,8 @@ XhcPeiInitializeDeviceSlot64 (
   PhyAddr = UsbHcGetPciAddrForHostAddr (
               Xhc->MemPool,
               ((TRANSFER_RING *)(UINTN)Xhc->UsbDevContext[SlotId].EndpointTransferRing[0])->RingSeg0,
-              sizeof (TRB_TEMPLATE) * TR_RING_TRB_NUMBER
+              sizeof (TRB_TEMPLATE) * TR_RING_TRB_NUMBER,
+              TRUE
               );
   InputContext->EP[0].PtrLo = XHC_LOW_32BIT (PhyAddr) | BIT0;
   InputContext->EP[0].PtrHi = XHC_HIGH_32BIT (PhyAddr);
@@ -1445,7 +1447,7 @@ XhcPeiInitializeDeviceSlot64 (
   // 7) Load the appropriate (Device Slot ID) entry in the Device Context Base Address Array (5.4.6) with
   //    a pointer to the Output Device Context data structure (6.2.1).
   //
-  PhyAddr = UsbHcGetPciAddrForHostAddr (Xhc->MemPool, OutputContext, sizeof (DEVICE_CONTEXT_64));
+  PhyAddr = UsbHcGetPciAddrForHostAddr (Xhc->MemPool, OutputContext, sizeof (DEVICE_CONTEXT_64), TRUE);
   //
   // Fill DCBAA with PCI device address
   //
@@ -1460,7 +1462,7 @@ XhcPeiInitializeDeviceSlot64 (
   //
   MicroSecondDelay (XHC_RESET_RECOVERY_DELAY);
   ZeroMem (&CmdTrbAddr, sizeof (CmdTrbAddr));
-  PhyAddr             = UsbHcGetPciAddrForHostAddr (Xhc->MemPool, Xhc->UsbDevContext[SlotId].InputContext, sizeof (INPUT_CONTEXT_64));
+  PhyAddr             = UsbHcGetPciAddrForHostAddr (Xhc->MemPool, Xhc->UsbDevContext[SlotId].InputContext, sizeof (INPUT_CONTEXT_64), TRUE);
   CmdTrbAddr.PtrLo    = XHC_LOW_32BIT (PhyAddr);
   CmdTrbAddr.PtrHi    = XHC_HIGH_32BIT (PhyAddr);
   CmdTrbAddr.CycleBit = 1;
@@ -1882,7 +1884,8 @@ XhcPeiSetConfigCmd (
       PhyAddr = UsbHcGetPciAddrForHostAddr (
                   Xhc->MemPool,
                   ((TRANSFER_RING *)(UINTN)Xhc->UsbDevContext[SlotId].EndpointTransferRing[Dci-1])->RingSeg0,
-                  sizeof (TRB_TEMPLATE) * TR_RING_TRB_NUMBER
+                  sizeof (TRB_TEMPLATE) * TR_RING_TRB_NUMBER,
+                  TRUE
                   );
       PhyAddr                      &= ~((EFI_PHYSICAL_ADDRESS)0x0F);
       PhyAddr                      |= (EFI_PHYSICAL_ADDRESS)((TRANSFER_RING *)(UINTN)Xhc->UsbDevContext[SlotId].EndpointTransferRing[Dci-1])->RingPCS;
@@ -1901,7 +1904,7 @@ XhcPeiSetConfigCmd (
   // configure endpoint
   //
   ZeroMem (&CmdTrbCfgEP, sizeof (CmdTrbCfgEP));
-  PhyAddr              = UsbHcGetPciAddrForHostAddr (Xhc->MemPool, InputContext, sizeof (INPUT_CONTEXT));
+  PhyAddr              = UsbHcGetPciAddrForHostAddr (Xhc->MemPool, InputContext, sizeof (INPUT_CONTEXT), TRUE);
   CmdTrbCfgEP.PtrLo    = XHC_LOW_32BIT (PhyAddr);
   CmdTrbCfgEP.PtrHi    = XHC_HIGH_32BIT (PhyAddr);
   CmdTrbCfgEP.CycleBit = 1;
@@ -2108,7 +2111,8 @@ XhcPeiSetConfigCmd64 (
       PhyAddr = UsbHcGetPciAddrForHostAddr (
                   Xhc->MemPool,
                   ((TRANSFER_RING *)(UINTN)Xhc->UsbDevContext[SlotId].EndpointTransferRing[Dci-1])->RingSeg0,
-                  sizeof (TRB_TEMPLATE) * TR_RING_TRB_NUMBER
+                  sizeof (TRB_TEMPLATE) * TR_RING_TRB_NUMBER,
+                  TRUE
                   );
 
       PhyAddr &= ~((EFI_PHYSICAL_ADDRESS)0x0F);
@@ -2129,7 +2133,7 @@ XhcPeiSetConfigCmd64 (
   // configure endpoint
   //
   ZeroMem (&CmdTrbCfgEP, sizeof (CmdTrbCfgEP));
-  PhyAddr              = UsbHcGetPciAddrForHostAddr (Xhc->MemPool, InputContext, sizeof (INPUT_CONTEXT_64));
+  PhyAddr              = UsbHcGetPciAddrForHostAddr (Xhc->MemPool, InputContext, sizeof (INPUT_CONTEXT_64), TRUE);
   CmdTrbCfgEP.PtrLo    = XHC_LOW_32BIT (PhyAddr);
   CmdTrbCfgEP.PtrHi    = XHC_HIGH_32BIT (PhyAddr);
   CmdTrbCfgEP.CycleBit = 1;
@@ -2184,7 +2188,7 @@ XhcPeiEvaluateContext (
   InputContext->EP[0].MaxPacketSize         = MaxPacketSize;
 
   ZeroMem (&CmdTrbEvalu, sizeof (CmdTrbEvalu));
-  PhyAddr              = UsbHcGetPciAddrForHostAddr (Xhc->MemPool, InputContext, sizeof (INPUT_CONTEXT));
+  PhyAddr              = UsbHcGetPciAddrForHostAddr (Xhc->MemPool, InputContext, sizeof (INPUT_CONTEXT), TRUE);
   CmdTrbEvalu.PtrLo    = XHC_LOW_32BIT (PhyAddr);
   CmdTrbEvalu.PtrHi    = XHC_HIGH_32BIT (PhyAddr);
   CmdTrbEvalu.CycleBit = 1;
@@ -2239,7 +2243,7 @@ XhcPeiEvaluateContext64 (
   InputContext->EP[0].MaxPacketSize         = MaxPacketSize;
 
   ZeroMem (&CmdTrbEvalu, sizeof (CmdTrbEvalu));
-  PhyAddr              = UsbHcGetPciAddrForHostAddr (Xhc->MemPool, InputContext, sizeof (INPUT_CONTEXT_64));
+  PhyAddr              = UsbHcGetPciAddrForHostAddr (Xhc->MemPool, InputContext, sizeof (INPUT_CONTEXT_64), TRUE);
   CmdTrbEvalu.PtrLo    = XHC_LOW_32BIT (PhyAddr);
   CmdTrbEvalu.PtrHi    = XHC_HIGH_32BIT (PhyAddr);
   CmdTrbEvalu.CycleBit = 1;
@@ -2308,7 +2312,7 @@ XhcPeiConfigHubContext (
   InputContext->Slot.MTT     = MTT;
 
   ZeroMem (&CmdTrbCfgEP, sizeof (CmdTrbCfgEP));
-  PhyAddr              = UsbHcGetPciAddrForHostAddr (Xhc->MemPool, InputContext, sizeof (INPUT_CONTEXT));
+  PhyAddr              = UsbHcGetPciAddrForHostAddr (Xhc->MemPool, InputContext, sizeof (INPUT_CONTEXT), TRUE);
   CmdTrbCfgEP.PtrLo    = XHC_LOW_32BIT (PhyAddr);
   CmdTrbCfgEP.PtrHi    = XHC_HIGH_32BIT (PhyAddr);
   CmdTrbCfgEP.CycleBit = 1;
@@ -2377,7 +2381,7 @@ XhcPeiConfigHubContext64 (
   InputContext->Slot.MTT     = MTT;
 
   ZeroMem (&CmdTrbCfgEP, sizeof (CmdTrbCfgEP));
-  PhyAddr              = UsbHcGetPciAddrForHostAddr (Xhc->MemPool, InputContext, sizeof (INPUT_CONTEXT_64));
+  PhyAddr              = UsbHcGetPciAddrForHostAddr (Xhc->MemPool, InputContext, sizeof (INPUT_CONTEXT_64), TRUE);
   CmdTrbCfgEP.PtrLo    = XHC_LOW_32BIT (PhyAddr);
   CmdTrbCfgEP.PtrHi    = XHC_HIGH_32BIT (PhyAddr);
   CmdTrbCfgEP.CycleBit = 1;
@@ -2522,7 +2526,7 @@ XhcPeiSetTrDequeuePointer (
   // Send stop endpoint command to transit Endpoint from running to stop state
   //
   ZeroMem (&CmdSetTRDeq, sizeof (CmdSetTRDeq));
-  PhyAddr              = UsbHcGetPciAddrForHostAddr (Xhc->MemPool, Urb->Ring->RingEnqueue, sizeof (CMD_SET_TR_DEQ_POINTER));
+  PhyAddr              = UsbHcGetPciAddrForHostAddr (Xhc->MemPool, Urb->Ring->RingEnqueue, sizeof (CMD_SET_TR_DEQ_POINTER), TRUE);
   CmdSetTRDeq.PtrLo    = XHC_LOW_32BIT (PhyAddr) | Urb->Ring->RingPCS;
   CmdSetTRDeq.PtrHi    = XHC_HIGH_32BIT (PhyAddr);
   CmdSetTRDeq.CycleBit = 1;
@@ -2682,7 +2686,7 @@ XhcPeiCreateEventRing (
   ASSERT (((UINTN)Buf & 0x3F) == 0);
   ZeroMem (Buf, Size);
 
-  DequeuePhy = UsbHcGetPciAddrForHostAddr (Xhc->MemPool, Buf, Size);
+  DequeuePhy = UsbHcGetPciAddrForHostAddr (Xhc->MemPool, Buf, Size, TRUE);
 
   EventRing->EventRingSeg0    = Buf;
   EventRing->TrbNumber        = EVENT_RING_TRB_NUMBER;
@@ -2707,7 +2711,7 @@ XhcPeiCreateEventRing (
   ERSTBase->PtrHi       = XHC_HIGH_32BIT (DequeuePhy);
   ERSTBase->RingTrbSize = EVENT_RING_TRB_NUMBER;
 
-  ERSTPhy = UsbHcGetPciAddrForHostAddr (Xhc->MemPool, Buf, Size);
+  ERSTPhy = UsbHcGetPciAddrForHostAddr (Xhc->MemPool, Buf, Size, TRUE);
 
   //
   // Program the Interrupter Event Ring Segment Table Size (ERSTSZ) register (5.5.2.3.1)
@@ -2855,7 +2859,7 @@ XhcPeiCreateTransferRing (
   //
   EndTrb        = (LINK_TRB *)((UINTN)Buf + sizeof (TRB_TEMPLATE) * (TrbNum - 1));
   EndTrb->Type  = TRB_TYPE_LINK;
-  PhyAddr       = UsbHcGetPciAddrForHostAddr (Xhc->MemPool, Buf, sizeof (TRB_TEMPLATE) * TrbNum);
+  PhyAddr       = UsbHcGetPciAddrForHostAddr (Xhc->MemPool, Buf, sizeof (TRB_TEMPLATE) * TrbNum, TRUE);
   EndTrb->PtrLo = XHC_LOW_32BIT (PhyAddr);
   EndTrb->PtrHi = XHC_HIGH_32BIT (PhyAddr);
   //
@@ -2988,7 +2992,7 @@ XhcPeiInitSched (
   // Some 3rd party XHCI external cards don't support single 64-bytes width register access,
   // So divide it to two 32-bytes width register access.
   //
-  DcbaaPhy = UsbHcGetPciAddrForHostAddr (Xhc->MemPool, Dcbaa, Size);
+  DcbaaPhy = UsbHcGetPciAddrForHostAddr (Xhc->MemPool, Dcbaa, Size, TRUE);
   XhcPeiWriteOpReg (Xhc, XHC_DCBAAP_OFFSET, XHC_LOW_32BIT (DcbaaPhy));
   XhcPeiWriteOpReg (Xhc, XHC_DCBAAP_OFFSET + 4, XHC_HIGH_32BIT (DcbaaPhy));
 
@@ -3006,7 +3010,7 @@ XhcPeiInitSched (
   // Transfer Ring it checks for a Cycle bit transition. If a transition detected, the ring is empty.
   // So we set RCS as inverted PCS init value to let Command Ring empty
   //
-  CmdRingPhy = UsbHcGetPciAddrForHostAddr (Xhc->MemPool, Xhc->CmdRing.RingSeg0, sizeof (TRB_TEMPLATE) * CMD_RING_TRB_NUMBER);
+  CmdRingPhy = UsbHcGetPciAddrForHostAddr (Xhc->MemPool, Xhc->CmdRing.RingSeg0, sizeof (TRB_TEMPLATE) * CMD_RING_TRB_NUMBER, TRUE);
   ASSERT ((CmdRingPhy & 0x3F) == 0);
   CmdRingPhy |= XHC_CRCR_RCS;
   //


### PR DESCRIPTION
REF:https://bugzilla.tianocore.org/show_bug.cgi?id=4560

TRB Template is 16 bytes. When boundary checking is 64 bytes for xHCI device/host memory address, it may exceed xHCI host memory pool and cause unwanted DXE_ASSERT. Introduce a new input parameter to indicate whether to enforce 64byte size alignment and round up. For TRB case, should set it to FALSE to skip the size round up.


Cc: Hao A Wu <hao.a.wu@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>