### PR TITLE
EmulatorPkg: Fix Terminal Issues

### DIFF
--- a/EmulatorPkg/Unix/Host/EmuThunk.c
+++ b/EmulatorPkg/Unix/Host/EmuThunk.c
@@ -9,7 +9,7 @@
   it may cause the table to be initialized with the members at the end being
   set to zero. This is bad as jumping to zero will crash.
 
-Copyright (c) 2004 - 2019, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2004 - 2023, Intel Corporation. All rights reserved.<BR>
 Portions copyright (c) 2008 - 2011, Apple Inc. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -33,6 +33,9 @@ struct timeval  settimer_timeval;
 UINTN           settimer_callback = 0;
 
 BOOLEAN  gEmulatorInterruptEnabled = FALSE;
+
+STATIC BOOLEAN         mEmulatorStdInConfigured = FALSE;
+STATIC struct termios  mOldTty;
 
 UINTN
 SecWriteStdErr (
@@ -58,8 +61,16 @@ SecConfigStdIn (
   // Need to turn off line buffering, ECHO, and make it unbuffered.
   //
   tcgetattr (STDIN_FILENO, &tty);
+  if (!mEmulatorStdInConfigured) {
+    //
+    // Save the original state of the TTY so it can be restored on exit
+    //
+    CopyMem (&mOldTty, &tty, sizeof (struct termios));
+  }
+
   tty.c_lflag &= ~(ICANON | ECHO);
   tcsetattr (STDIN_FILENO, TCSANOW, &tty);
+  mEmulatorStdInConfigured = TRUE;
 
   //  setvbuf (STDIN_FILENO, NULL, _IONBF, 0);
 
@@ -338,6 +349,11 @@ SecExit (
   UINTN  Status
   )
 {
+  // Reset the TTY back to its original state
+  if (mEmulatorStdInConfigured) {
+    tcsetattr (STDIN_FILENO, TCSANOW, &mOldTty);
+  }
+
   exit (Status);
 }
 

--- a/EmulatorPkg/Win/Host/WinThunk.c
+++ b/EmulatorPkg/Win/Host/WinThunk.c
@@ -1,6 +1,6 @@
 /**@file
 
-Copyright (c) 2006 - 2018, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2006 - 2023, Intel Corporation. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 Module Name:
@@ -29,6 +29,12 @@ Abstract:
 **/
 
 #include "WinHost.h"
+
+STATIC BOOLEAN  mEmulatorStdInConfigured = FALSE;
+STATIC DWORD    mOldStdInMode;
+#if defined (NTDDI_VERSION) && defined (NTDDI_WIN10_TH2) && (NTDDI_VERSION > NTDDI_WIN10_TH2)
+STATIC DWORD  mOldStdOutMode;
+#endif
 
 UINTN
 SecWriteStdErr (
@@ -61,6 +67,13 @@ SecConfigStdIn (
 
   Success = GetConsoleMode (GetStdHandle (STD_INPUT_HANDLE), &Mode);
   if (Success) {
+    if (!mEmulatorStdInConfigured) {
+      //
+      // Save the original state of the console so it can be restored on exit
+      //
+      mOldStdInMode = Mode;
+    }
+
     //
     // Disable buffer (line input), echo, mouse, window
     //
@@ -82,6 +95,13 @@ SecConfigStdIn (
   //
   if (Success) {
     Success = GetConsoleMode (GetStdHandle (STD_OUTPUT_HANDLE), &Mode);
+    if (!mEmulatorStdInConfigured) {
+      //
+      // Save the original state of the console so it can be restored on exit
+      //
+      mOldStdOutMode = Mode;
+    }
+
     if (Success) {
       Success = SetConsoleMode (
                   GetStdHandle (STD_OUTPUT_HANDLE),
@@ -91,6 +111,9 @@ SecConfigStdIn (
   }
 
  #endif
+  if (Success) {
+    mEmulatorStdInConfigured = TRUE;
+  }
   return Success ? EFI_SUCCESS : EFI_DEVICE_ERROR;
 }
 
@@ -467,6 +490,21 @@ SecExit (
   UINTN  Status
   )
 {
+  if (mEmulatorStdInConfigured) {
+    //
+    // Reset the console back to its original state
+    //
+ #if defined (NTDDI_VERSION) && defined (NTDDI_WIN10_TH2) && (NTDDI_VERSION > NTDDI_WIN10_TH2)
+    BOOL  Success = SetConsoleMode (GetStdHandle (STD_INPUT_HANDLE), mOldStdInMode);
+    if (Success) {
+      SetConsoleMode (GetStdHandle (STD_OUTPUT_HANDLE), mOldStdOutMode);
+    }
+
+ #else
+    SetConsoleMode (GetStdHandle (STD_INPUT_HANDLE), mOldStdInMode);
+ #endif
+  }
+
   exit ((int)Status);
 }
 


### PR DESCRIPTION
After running EmulatorPkg, one will notice that their terminal acts strangely. This is caused by the EmulatorPkg Host changing the terminal mode and not restoring the original mode, which is now fixed.

Reviewed-by: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Andrew Fish <afish@apple.com>
Cc: Ray Ni <ray.ni@intel.com>
Cc: Chasel Chiu <chasel.chiu@intel.com>