### PR TITLE
MdePkg/DxeRngLib: Add missing GUID declaration in inf

### DIFF
--- a/MdePkg/Library/DxeRngLib/DxeRngLib.inf
+++ b/MdePkg/Library/DxeRngLib/DxeRngLib.inf
@@ -36,3 +36,4 @@
   gEfiRngAlgorithmSp80090Ctr256Guid
   gEfiRngAlgorithmSp80090Hash256Guid
   gEfiRngAlgorithmSp80090Hmac256Guid
+  gEfiRngAlgorithmRaw


### PR DESCRIPTION
Add missing GUID declaration in DxeRngLib.inf.

Fixes: bd1f0eecc1df ("MdePkg/DxeRngLib: Request raw algorithm instead of default")