### PR TITLE
Maintainers.txt: add Sami as maintainer of arm-architectural subdirs

### DIFF
--- a/Maintainers.txt
+++ b/Maintainers.txt
@@ -88,6 +88,7 @@ F: */AArch64/
 F: */Arm/
 M: Leif Lindholm <quic_llindhol@quicinc.com> [leiflindholm]
 M: Ard Biesheuvel <ardb+tianocore@kernel.org> [ardbiesheuvel]
+M: Sami Mujawar <sami.mujawar@arm.com> [samimujawar]
 
 RISCV64
 F: */RiscV64/


### PR DESCRIPTION
We added Sami as a reviewer to ArmPkg early last year, and I think it was always our intention to have him as a reviewer of Arm architectural stuff in general, but we seem to have missed out the Arm/AArch64 subdir wildcards. So let's fix that.


Cc: Ard Biesheuvel <ardb+tianocore@kernel.org>
Cc: Sami Mujawar <sami.mujawar@arm.com>
Cc: Andrew Fish <afish@apple.com>
Cc: Michael D Kinney <michael.d.kinney@intel.com>
Reviewed-by: Michael D Kinney <michael.d.kinney@intel.com>
Reviewed-by: Sami Mujawar <sami.mujawar@arm.com>
Reviewed-by: Ard Biesheuvel <ardb@kernel.org>