### PR TITLE
MdePkg: various fixes to ARM/AArch64 SetJump/LongJump 

### DIFF
--- a/MdePkg/Library/BaseLib/AArch64/SetJumpLongJump.S
+++ b/MdePkg/Library/BaseLib/AArch64/SetJumpLongJump.S
@@ -46,6 +46,14 @@ GCC_ASM_EXPORT(InternalLongJump)
 #
 ASM_PFX(SetJump):
         AARCH64_BTI(c)
+#ifndef MDEPKG_NDEBUG
+        stp     x29, x30, [sp, #-32]!
+        mov     x29, sp
+        str     x0, [sp, #16]
+        bl      InternalAssertJumpBuffer
+        ldr     x0, [sp, #16]
+        ldp     x29, x30, [sp], #32
+#endif
         mov     x16, sp // use IP0 so save SP
 #define REG_PAIR(REG1, REG2, OFFS)      stp REG1, REG2, [x0, OFFS]
 #define REG_ONE(REG1, OFFS)             str REG1, [x0, OFFS]

--- a/MdePkg/Library/BaseLib/AArch64/SetJumpLongJump.S
+++ b/MdePkg/Library/BaseLib/AArch64/SetJumpLongJump.S
@@ -33,7 +33,6 @@ GCC_ASM_EXPORT(InternalLongJump)
 #  value to be returned by SetJump().
 #
 #  If JumpBuffer is NULL, then ASSERT().
-#  For IPF CPUs, if JumpBuffer is not aligned on a 16-byte boundary, then ASSERT().
 #
 #  @param  JumpBuffer    A pointer to CPU context buffer.
 #
@@ -62,7 +61,7 @@ ASM_PFX(SetJump):
 #
 #  Restores the CPU context from the buffer specified by JumpBuffer.
 #  This function never returns to the caller.
-#  Instead is resumes execution based on the state of JumpBuffer.
+#  Instead it resumes execution based on the state of JumpBuffer.
 #
 #  @param  JumpBuffer    A pointer to CPU context buffer.
 #  @param  Value         The value to return when the SetJump() context is restored.

--- a/MdePkg/Library/BaseLib/AArch64/SetJumpLongJump.S
+++ b/MdePkg/Library/BaseLib/AArch64/SetJumpLongJump.S
@@ -61,7 +61,7 @@ ASM_PFX(SetJump):
         FPR_LAYOUT
 #undef REG_PAIR
 #undef REG_ONE
-        mov     w0, #0
+        mov     x0, #0
         ret
 
 #/**
@@ -91,9 +91,9 @@ ASM_PFX(InternalLongJump):
 #undef REG_PAIR
 #undef REG_ONE
         mov     sp, x16
-        cmp     w1, #0
-        mov     w0, #1
-        csel    w0, w1, w0, ne
+        cmp     x1, #0
+        mov     x0, #1
+        csel    x0, x1, x0, ne
         ret
 
 ASM_FUNCTION_REMOVE_IF_UNREFERENCED

--- a/MdePkg/Library/BaseLib/AArch64/SetJumpLongJump.asm
+++ b/MdePkg/Library/BaseLib/AArch64/SetJumpLongJump.asm
@@ -59,7 +59,7 @@ SetJump
         FPR_LAYOUT
 #undef REG_PAIR
 #undef REG_ONE
-        mov     w0, #0
+        mov     x0, #0
         ret
 
 ;/**
@@ -88,10 +88,10 @@ InternalLongJump
 #undef REG_PAIR
 #undef REG_ONE
         mov     sp, x16
-        cmp     w1, #0
-        mov     w0, #1
+        cmp     x1, #0
+        mov     x0, #1
         beq     exit
-        mov     w0, w1
+        mov     x0, x1
 exit
         // use br not ret, as ret is guaranteed to mispredict
         br      x30

--- a/MdePkg/Library/BaseLib/AArch64/SetJumpLongJump.asm
+++ b/MdePkg/Library/BaseLib/AArch64/SetJumpLongJump.asm
@@ -44,6 +44,14 @@
 ;  );
 ;
 SetJump
+#ifndef MDEPKG_NDEBUG
+        stp     x29, x30, [sp, #-32]!
+        mov     x29, sp
+        str     x0, [sp, #16]
+        bl      InternalAssertJumpBuffer
+        ldr     x0, [sp, #16]
+        ldp     x29, x30, [sp], #32
+#endif
         mov     x16, sp // use IP0 so save SP
 #define REG_PAIR(REG1, REG2, OFFS)      stp REG1, REG2, [x0, OFFS]
 #define REG_ONE(REG1, OFFS)             str REG1, [x0, OFFS]

--- a/MdePkg/Library/BaseLib/AArch64/SetJumpLongJump.asm
+++ b/MdePkg/Library/BaseLib/AArch64/SetJumpLongJump.asm
@@ -32,7 +32,6 @@
 ;  value to be returned by SetJump().
 ;
 ;  If JumpBuffer is NULL, then ASSERT().
-;  For IPF CPUs, if JumpBuffer is not aligned on a 16-byte boundary, then ASSERT().
 ;
 ;  @param  JumpBuffer    A pointer to CPU context buffer.
 ;
@@ -60,7 +59,7 @@ SetJump
 ;
 ;  Restores the CPU context from the buffer specified by JumpBuffer.
 ;  This function never returns to the caller.
-;  Instead is resumes execution based on the state of JumpBuffer.
+;  Instead it resumes execution based on the state of JumpBuffer.
 ;
 ;  @param  JumpBuffer    A pointer to CPU context buffer.
 ;  @param  Value         The value to return when the SetJump() context is restored.

--- a/MdePkg/Library/BaseLib/Arm/SetJumpLongJump.S
+++ b/MdePkg/Library/BaseLib/Arm/SetJumpLongJump.S
@@ -57,6 +57,8 @@ ASM_PFX(SetJump):
 ASM_PFX(InternalLongJump):
   ldmia  r0, {r3-r12,r14}
   mov    r13, r3
+  cmp    r1, #0
+  moveq  r1, #1
   mov    r0, r1
   bx     lr
 

--- a/MdePkg/Library/BaseLib/Arm/SetJumpLongJump.S
+++ b/MdePkg/Library/BaseLib/Arm/SetJumpLongJump.S
@@ -33,7 +33,7 @@ GCC_ASM_EXPORT(InternalLongJump)
 ASM_PFX(SetJump):
   mov   r3, r13
   stmia r0, {r3-r12,r14}
-  eor   r0, r0, r0
+  mov   r0, #0
   bx    lr
 
 #/**

--- a/MdePkg/Library/BaseLib/Arm/SetJumpLongJump.S
+++ b/MdePkg/Library/BaseLib/Arm/SetJumpLongJump.S
@@ -19,7 +19,6 @@ GCC_ASM_EXPORT(InternalLongJump)
 #  value to be returned by SetJump().
 #
 #  If JumpBuffer is NULL, then ASSERT().
-#  For IPF CPUs, if JumpBuffer is not aligned on a 16-byte boundary, then ASSERT().
 #
 #  @param  JumpBuffer    A pointer to CPU context buffer.
 #
@@ -42,7 +41,7 @@ ASM_PFX(SetJump):
 #
 #  Restores the CPU context from the buffer specified by JumpBuffer.
 #  This function never returns to the caller.
-#  Instead is resumes execution based on the state of JumpBuffer.
+#  Instead it resumes execution based on the state of JumpBuffer.
 #
 #  @param  JumpBuffer    A pointer to CPU context buffer.
 #  @param  Value         The value to return when the SetJump() context is restored.

--- a/MdePkg/Library/BaseLib/Arm/SetJumpLongJump.asm
+++ b/MdePkg/Library/BaseLib/Arm/SetJumpLongJump.asm
@@ -57,6 +57,8 @@ SetJump
 InternalLongJump
   LDM   R0, {R3-R12,R14}
   MOV   R13, R3
+  CMP   R1, #0
+  MOVEQ R1, #1
   MOV   R0, R1
   BX    LR
 

--- a/MdePkg/Library/BaseLib/Arm/SetJumpLongJump.asm
+++ b/MdePkg/Library/BaseLib/Arm/SetJumpLongJump.asm
@@ -19,7 +19,6 @@
 ;  value to be returned by SetJump().
 ;
 ;  If JumpBuffer is NULL, then ASSERT().
-;  For IPF CPUs, if JumpBuffer is not aligned on a 16-byte boundary, then ASSERT().
 ;
 ;  @param  JumpBuffer    A pointer to CPU context buffer.
 ;
@@ -42,7 +41,7 @@ SetJump
 ;
 ;  Restores the CPU context from the buffer specified by JumpBuffer.
 ;  This function never returns to the caller.
-;  Instead is resumes execution based on the state of JumpBuffer.
+;  Instead it resumes execution based on the state of JumpBuffer.
 ;
 ;  @param  JumpBuffer    A pointer to CPU context buffer.
 ;  @param  Value         The value to return when the SetJump() context is restored.

--- a/MdePkg/Library/BaseLib/Arm/SetJumpLongJump.asm
+++ b/MdePkg/Library/BaseLib/Arm/SetJumpLongJump.asm
@@ -33,7 +33,7 @@
 SetJump
   MOV  R3, R13
   STM  R0, {R3-R12,R14}
-  EOR  R0, R0
+  MOV  RO, #0
   BX   LR
 
 ;/**


### PR DESCRIPTION
Back in the mists of time (January 2020) I submitted a set to clean up                                                                           
and fix a few bugs in ARM/AArch64 BaseLib SetJump/LongJump implementations:                                                                      
https://edk2.groups.io/g/devel/message/65812                                                                                                     
                                                                                                                                                 
Then hubris struck and I meant to refactor the code for all architectures,                                                                       
and since this was in my first week in a new job, that meant everything                                                                          
got completely dropped on the floor.                                                                                                             
                                                                                                                                                 
Then Andrei's fix of similar issues for RiscV64 made me remember this set.                                                                       
And I figured, let's dial back the ambition and get the actual fixes                                                                             
merged.                                                                                                                                          
                                                                                                                                                 
The overall scope remains:                                                                                                                       
- Fix comments (drop Itanium mention, correct spelling)                                                                                          
- Make code match existing comments                                                                                                              
- Don't try to optimise ARM for executing on the 8088                                                                                            
- Use the correct register sizes on AArch64                                                                                                      
- Actually follow the API on ARM                                                                                                                 
                                                                                                                                                 
And like the original submission, the changes to .asm files have been                                                                            
neither build nor runtime tested.                                                                                                                
                                                                                                                                                 
Any acks/reviewed-bys have been dropped, it having been over 3.5 years.                                                                          
                                                                                                                                                 
Changes since v1:                                                                                                                                
- Rebased to current edk2 main.                                                                                                                  
- Incorporate Ard's feedback on maintaining a clean call stack for                                                                               
  InternalAssertJumpBuffer, *and* conditionalising it on !MDEPKG_NDEBUG.                                                                         
- Changed authorship to my current identity (the company I worked at                                                                             
  during v1 having been acquired by my current employer, this feels                                                                              
  like a reasonable course of action).

Cc: Ard Biesheuvel <ardb+tianocore@kernel.org>                                                                                                   
Cc: Sami Mujawar <sami.mujawar@arm.com>                                                                                                          
Cc: Andrei Warkentin <andrei.warkentin@intel.com> 