### PR TITLE
Fix Python Minor Version

### DIFF
--- a/.azurepipelines/Ubuntu-PatchCheck.yml
+++ b/.azurepipelines/Ubuntu-PatchCheck.yml
@@ -27,7 +27,7 @@ steps:
 
 - task: UsePythonVersion@0
   inputs:
-    versionSpec: '>=3.10.6'
+    versionSpec: '3.11'
     architecture: 'x64'
 
 - script: |

--- a/.azurepipelines/templates/defaults.yml
+++ b/.azurepipelines/templates/defaults.yml
@@ -8,5 +8,5 @@
 ##
 
 variables:
-  default_python_version: ">=3.10.6"
+  default_python_version: "3.11"
   default_linux_image: "ghcr.io/tianocore/containers/fedora-37-test:a0dd931"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -85,7 +85,7 @@ jobs:
     - name: Install Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10.6'
+        python-version: '3.11'
         cache: 'pip'
         cache-dependency-path: 'pip-requirements.txt'
 


### PR DESCRIPTION
Python 3.12 released recently. The Python version is currently
specified to allow updates to newer minor versions. Time is
needed to adjust scripts for Python 3.12 so this series fixes
the Python version to 3.11.

Some places that were already fixed but need the version updated
to 3.11 for consistency are updated as well.