### PR TITLE
Add HMAC/HKDF/RSA/HASH/AES features based on Mbedtls

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -32,3 +32,6 @@
 [submodule "MdePkg/Library/MipiSysTLib/mipisyst"]
 	path = MdePkg/Library/MipiSysTLib/mipisyst
 	url = https://github.com/MIPI-Alliance/public-mipi-sys-t.git
+[submodule "CryptoPkg/Library/MbedTlsLib/mbedtls"]
+	path = CryptoPkg/Library/MbedTlsLib/mbedtls
+	url = https://github.com/ARMmbed/mbedtls

--- a/.pytool/CISettings.py
+++ b/.pytool/CISettings.py
@@ -199,6 +199,8 @@ class Settings(CiBuildSettingsManager, UpdateSettingsManager, SetupSettingsManag
             "MdePkg/Library/BaseFdtLib/libfdt", False))
         rs.append(RequiredSubmodule(
             "MdePkg/Library/MipiSysTLib/mipisyst", False))
+        rs.append(RequiredSubmodule(
+            "CryptoPkg/Library/MbedTlsLib/mbedtls", False))
         return rs
 
     def GetName(self):

--- a/CryptoPkg/CryptoPkg.ci.yaml
+++ b/CryptoPkg/CryptoPkg.ci.yaml
@@ -38,10 +38,20 @@
             # This has OpenSSL interfaces that aren't UEFI spec compliant
             "Library/BaseCryptLib/Hash/CryptParallelHash.h",
             "Library/Include/fcntl.h",
+            # This has Mbedtls interfaces that aren't UEFI spec compliant
+            "Library/Include/stdint.h",
+            "Library/Include/stubs-32.h",
             # These directories contain auto-generated OpenSSL content
             "Library/OpensslLib",
             "Library/IntrinsicLib",
-            "Library/BaseCryptLib/Pk/CryptPkcs7VerifyBase.c"
+            "Library/BaseCryptLib/Pk/CryptPkcs7VerifyBase.c",
+            # mbedtls
+            "Library/MbedTlsLib/mbedtls",
+            # This has mbedtls interfaces that aren't UEFI spec compliant
+            "Library/MbedTlsLib/EcSm2Null.c",
+            "Library/MbedTlsLib/CrtWrapper.c",
+            "Library/MbedTlsLib/Include/mbedtls/mbedtls_config.h",
+            "Library/BaseCryptLibMbedTls/SysCall"
         ]
     },
     "CompilerPlugin": {

--- a/CryptoPkg/CryptoPkg.dec
+++ b/CryptoPkg/CryptoPkg.dec
@@ -28,9 +28,9 @@
   Library/OpensslLib/OpensslGen/include
   Library/OpensslLib/OpensslGen/providers/common/include
   Library/MbedTlsLib/Include
-  Library/MbedTlsLib/mbedtls
   Library/MbedTlsLib/mbedtls/include
   Library/MbedTlsLib/mbedtls/include/mbedtls
+  Library/MbedTlsLib/mbedtls/library
 
 [LibraryClasses]
   ##  @libraryclass  Provides basic library functions for cryptographic primitives.
@@ -49,6 +49,7 @@
   ##  @libraryclass  Provides library functions from the openssl project.
   #
   OpensslLib|Private/Library/OpensslLib.h
+  MbedTlsLib|Private/Library/MbedTlsLib.h
 
   ##  @libraryclass  Provides compiler intrinsic functions required to link openssl project.
   #

--- a/CryptoPkg/CryptoPkg.dec
+++ b/CryptoPkg/CryptoPkg.dec
@@ -27,6 +27,10 @@
   Library/OpensslLib/openssl/providers/implementations/include
   Library/OpensslLib/OpensslGen/include
   Library/OpensslLib/OpensslGen/providers/common/include
+  Library/MbedTlsLib/Include
+  Library/MbedTlsLib/mbedtls
+  Library/MbedTlsLib/mbedtls/include
+  Library/MbedTlsLib/mbedtls/include/mbedtls
 
 [LibraryClasses]
   ##  @libraryclass  Provides basic library functions for cryptographic primitives.

--- a/CryptoPkg/CryptoPkg.dsc
+++ b/CryptoPkg/CryptoPkg.dsc
@@ -364,6 +364,14 @@
   CryptoPkg/Library/BaseCryptLib/PeiCryptLib.inf
   CryptoPkg/Library/BaseCryptLib/SmmCryptLib.inf
   CryptoPkg/Library/BaseCryptLib/RuntimeCryptLib.inf
+  CryptoPkg/Library/BaseCryptLibMbedTls/BaseCryptLib.inf
+  CryptoPkg/Library/BaseCryptLibMbedTls/SecCryptLib.inf
+  CryptoPkg/Library/BaseCryptLibMbedTls/PeiCryptLib.inf
+  CryptoPkg/Library/BaseCryptLibMbedTls/SmmCryptLib.inf
+  CryptoPkg/Library/BaseCryptLibMbedTls/RuntimeCryptLib.inf
+  CryptoPkg/Library/BaseCryptLibMbedTls/TestBaseCryptLib.inf
+  CryptoPkg/Library/MbedTlsLib/MbedTlsLib.inf
+  CryptoPkg/Library/MbedTlsLib/MbedTlsLibFull.inf
   CryptoPkg/Library/BaseCryptLibNull/BaseCryptLibNull.inf
   CryptoPkg/Library/IntrinsicLib/IntrinsicLib.inf
   CryptoPkg/Library/TlsLib/TlsLib.inf

--- a/CryptoPkg/CryptoPkgMbedTls.dsc
+++ b/CryptoPkg/CryptoPkgMbedTls.dsc
@@ -1,0 +1,280 @@
+## @file
+#  Cryptographic Library Package for UEFI Security Implementation.
+#  PEIM, DXE Driver, and SMM Driver with all crypto services enabled.
+#
+#  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+################################################################################
+#
+# Defines Section - statements that will be processed to create a Makefile.
+#
+################################################################################
+[Defines]
+  PLATFORM_NAME                  = CryptoPkg
+  PLATFORM_GUID                  = E1063286-6C8C-4c25-AEF0-67A9A5B6E6B6
+  PLATFORM_VERSION               = 0.98
+  DSC_SPECIFICATION              = 0x00010005
+  OUTPUT_DIRECTORY               = Build/CryptoPkgMbed
+  SUPPORTED_ARCHITECTURES        = IA32|X64|ARM|AARCH64|RISCV64
+  BUILD_TARGETS                  = DEBUG|RELEASE|NOOPT
+  SKUID_IDENTIFIER               = DEFAULT
+
+!ifndef CRYPTO_IMG_TYPE
+  DEFINE CRYPTO_IMG_TYPE         = DXE_SMM
+!endif
+
+!if $(CRYPTO_IMG_TYPE) IN "PEI_DEFAULT PEI_PREMEM DXE_SMM"
+!else
+  !error CRYPTO_IMG_TYPE must be set to one of PEI_DEFAULT PEI_PREMEM DXE_SMM.
+!endif
+
+################################################################################
+#
+# Library Class section - list of all Library Classes needed by this Platform.
+#
+################################################################################
+
+!include MdePkg/MdeLibs.dsc.inc
+[LibraryClasses]
+  BaseLib|MdePkg/Library/BaseLib/BaseLib.inf
+  BaseMemoryLib|MdePkg/Library/BaseMemoryLib/BaseMemoryLib.inf
+  PcdLib|MdePkg/Library/BasePcdLibNull/BasePcdLibNull.inf
+  DebugLib|MdePkg/Library/BaseDebugLibNull/BaseDebugLibNull.inf
+  UefiBootServicesTableLib|MdePkg/Library/UefiBootServicesTableLib/UefiBootServicesTableLib.inf
+  UefiDriverEntryPoint|MdePkg/Library/UefiDriverEntryPoint/UefiDriverEntryPoint.inf
+  BaseCryptLib|CryptoPkg/Library/BaseCryptLibNull/BaseCryptLibNull.inf
+  TlsLib|CryptoPkg/Library/TlsLibNull/TlsLibNull.inf
+  HashApiLib|CryptoPkg/Library/BaseHashApiLib/BaseHashApiLib.inf
+  RngLib|MdePkg/Library/BaseRngLib/BaseRngLib.inf
+  SynchronizationLib|MdePkg/Library/BaseSynchronizationLib/BaseSynchronizationLib.inf
+
+[LibraryClasses.ARM, LibraryClasses.AARCH64]
+  #
+  # It is not possible to prevent the ARM compiler for generic intrinsic functions.
+  # This library provides the instrinsic functions generate by a given compiler.
+  # [LibraryClasses.ARM, LibraryClasses.AARCH64] and NULL mean link this library
+  # into all ARM and AARCH64 images.
+  #
+  NULL|ArmPkg/Library/CompilerIntrinsicsLib/CompilerIntrinsicsLib.inf
+
+  # Add support for stack protector
+  NULL|MdePkg/Library/BaseStackCheckLib/BaseStackCheckLib.inf
+
+[LibraryClasses.common.PEIM]
+  PeimEntryPoint|MdePkg/Library/PeimEntryPoint/PeimEntryPoint.inf
+  MemoryAllocationLib|MdePkg/Library/PeiMemoryAllocationLib/PeiMemoryAllocationLib.inf
+  PeiServicesTablePointerLib|MdePkg/Library/PeiServicesTablePointerLib/PeiServicesTablePointerLib.inf
+  PeiServicesLib|MdePkg/Library/PeiServicesLib/PeiServicesLib.inf
+  HobLib|MdePkg/Library/PeiHobLib/PeiHobLib.inf
+
+[LibraryClasses.common.DXE_SMM_DRIVER]
+  SmmServicesTableLib|MdePkg/Library/SmmServicesTableLib/SmmServicesTableLib.inf
+  MemoryAllocationLib|MdePkg/Library/SmmMemoryAllocationLib/SmmMemoryAllocationLib.inf
+  MmServicesTableLib|MdePkg/Library/MmServicesTableLib/MmServicesTableLib.inf
+  SynchronizationLib|MdePkg/Library/BaseSynchronizationLib/BaseSynchronizationLib.inf
+
+[LibraryClasses]
+  MemoryAllocationLib|MdePkg/Library/UefiMemoryAllocationLib/UefiMemoryAllocationLib.inf
+  DebugLib|MdeModulePkg/Library/PeiDxeDebugLibReportStatusCode/PeiDxeDebugLibReportStatusCode.inf
+  DebugPrintErrorLevelLib|MdePkg/Library/BaseDebugPrintErrorLevelLib/BaseDebugPrintErrorLevelLib.inf
+  OemHookStatusCodeLib|MdeModulePkg/Library/OemHookStatusCodeLibNull/OemHookStatusCodeLibNull.inf
+  PrintLib|MdePkg/Library/BasePrintLib/BasePrintLib.inf
+  DevicePathLib|MdePkg/Library/UefiDevicePathLib/UefiDevicePathLib.inf
+  PcdLib|MdePkg/Library/DxePcdLib/DxePcdLib.inf
+  TimerLib|MdePkg/Library/BaseTimerLibNullTemplate/BaseTimerLibNullTemplate.inf
+  UefiRuntimeServicesTableLib|MdePkg/Library/UefiRuntimeServicesTableLib/UefiRuntimeServicesTableLib.inf
+  IoLib|MdePkg/Library/BaseIoLibIntrinsic/BaseIoLibIntrinsic.inf
+  MbedTlsLib|CryptoPkg/Library/MbedTlsLib/MbedTlsLib.inf
+  IntrinsicLib|CryptoPkg/Library/IntrinsicLib/IntrinsicLib.inf
+  SafeIntLib|MdePkg/Library/BaseSafeIntLib/BaseSafeIntLib.inf
+
+[LibraryClasses.ARM]
+  ArmSoftFloatLib|ArmPkg/Library/ArmSoftFloatLib/ArmSoftFloatLib.inf
+
+[LibraryClasses.common.PEIM]
+  PcdLib|MdePkg/Library/PeiPcdLib/PeiPcdLib.inf
+  ReportStatusCodeLib|MdeModulePkg/Library/PeiReportStatusCodeLib/PeiReportStatusCodeLib.inf
+  BaseCryptLib|CryptoPkg/Library/BaseCryptLibMbedTls/PeiCryptLib.inf
+  TlsLib|CryptoPkg/Library/TlsLibNull/TlsLibNull.inf
+
+[LibraryClasses.IA32.PEIM, LibraryClasses.X64.PEIM]
+  PeiServicesTablePointerLib|MdePkg/Library/PeiServicesTablePointerLibIdt/PeiServicesTablePointerLibIdt.inf
+
+[LibraryClasses.ARM.PEIM, LibraryClasses.AARCH64.PEIM]
+  PeiServicesTablePointerLib|ArmPkg/Library/PeiServicesTablePointerLib/PeiServicesTablePointerLib.inf
+
+[LibraryClasses.common.DXE_DRIVER]
+  ReportStatusCodeLib|MdeModulePkg/Library/DxeReportStatusCodeLib/DxeReportStatusCodeLib.inf
+  BaseCryptLib|CryptoPkg/Library/BaseCryptLibMbedTls/BaseCryptLib.inf
+  TlsLib|CryptoPkg/Library/TlsLibNull/TlsLibNull.inf
+
+[LibraryClasses.common.DXE_SMM_DRIVER]
+  ReportStatusCodeLib|MdeModulePkg/Library/SmmReportStatusCodeLib/SmmReportStatusCodeLib.inf
+  BaseCryptLib|CryptoPkg/Library/BaseCryptLibMbedTls/SmmCryptLib.inf
+  TlsLib|CryptoPkg/Library/TlsLibNull/TlsLibNull.inf
+
+################################################################################
+#
+# Pcd Section - list of all EDK II PCD Entries defined by this Platform
+#
+################################################################################
+[PcdsFixedAtBuild]
+  gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask|0x0f
+  gEfiMdePkgTokenSpaceGuid.PcdDebugPrintErrorLevel|0x80000000
+  gEfiMdePkgTokenSpaceGuid.PcdReportStatusCodePropertyMask|0x06
+
+!if $(CRYPTO_IMG_TYPE) IN "DXE_SMM"
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceFamilyEnable.HmacMd5.Family    | PCD_CRYPTO_SERVICE_ENABLE_FAMILY
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceFamilyEnable.HmacSha1.Family   | PCD_CRYPTO_SERVICE_ENABLE_FAMILY
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceFamilyEnable.HmacSha256.Family | PCD_CRYPTO_SERVICE_ENABLE_FAMILY
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceFamilyEnable.Md4.Family        | PCD_CRYPTO_SERVICE_ENABLE_FAMILY
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceFamilyEnable.Md5.Family        | PCD_CRYPTO_SERVICE_ENABLE_FAMILY
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceFamilyEnable.Pkcs.Family       | PCD_CRYPTO_SERVICE_ENABLE_FAMILY
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceFamilyEnable.Dh.Family         | PCD_CRYPTO_SERVICE_ENABLE_FAMILY
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceFamilyEnable.Random.Family     | PCD_CRYPTO_SERVICE_ENABLE_FAMILY
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceFamilyEnable.Rsa.Family        | PCD_CRYPTO_SERVICE_ENABLE_FAMILY
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceFamilyEnable.Sha1.Family       | PCD_CRYPTO_SERVICE_ENABLE_FAMILY
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceFamilyEnable.Sha256.Family     | PCD_CRYPTO_SERVICE_ENABLE_FAMILY
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceFamilyEnable.Sha384.Family     | PCD_CRYPTO_SERVICE_ENABLE_FAMILY
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceFamilyEnable.Sha512.Family     | PCD_CRYPTO_SERVICE_ENABLE_FAMILY
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceFamilyEnable.X509.Family       | PCD_CRYPTO_SERVICE_ENABLE_FAMILY
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceFamilyEnable.Tdes.Family       | PCD_CRYPTO_SERVICE_ENABLE_FAMILY
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceFamilyEnable.Aes.Family        | PCD_CRYPTO_SERVICE_ENABLE_FAMILY
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceFamilyEnable.Arc4.Family       | PCD_CRYPTO_SERVICE_ENABLE_FAMILY
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceFamilyEnable.Sm3.Family        | PCD_CRYPTO_SERVICE_ENABLE_FAMILY
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceFamilyEnable.Hkdf.Family       | PCD_CRYPTO_SERVICE_ENABLE_FAMILY
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceFamilyEnable.Tls.Family        | PCD_CRYPTO_SERVICE_ENABLE_FAMILY
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceFamilyEnable.TlsSet.Family     | PCD_CRYPTO_SERVICE_ENABLE_FAMILY
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceFamilyEnable.TlsGet.Family     | PCD_CRYPTO_SERVICE_ENABLE_FAMILY
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceFamilyEnable.ParallelHash.Family     | PCD_CRYPTO_SERVICE_ENABLE_FAMILY
+!endif
+
+!if $(CRYPTO_IMG_TYPE) IN "PEI_DEFAULT"
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceFamilyEnable.Aes.Family        | PCD_CRYPTO_SERVICE_ENABLE_FAMILY
+
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceFamilyEnable.Rsa.Services.Pkcs1Verify             | TRUE
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceFamilyEnable.Rsa.Services.New                     | TRUE
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceFamilyEnable.Rsa.Services.SetKey                  | TRUE
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceFamilyEnable.Rsa.Services.Free                    | TRUE
+
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceFamilyEnable.Sha1.Services.GetContextSize         | TRUE
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceFamilyEnable.Sha1.Services.Init                   | TRUE
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceFamilyEnable.Sha1.Services.Update                 | TRUE
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceFamilyEnable.Sha1.Services.Final                  | TRUE
+
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceFamilyEnable.Sha256.Services.GetContextSize       | TRUE
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceFamilyEnable.Sha256.Services.Init                 | TRUE
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceFamilyEnable.Sha256.Services.Update               | TRUE
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceFamilyEnable.Sha256.Services.Final                | TRUE
+
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceFamilyEnable.Sha384.Services.GetContextSize       | TRUE
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceFamilyEnable.Sha384.Services.Init                 | TRUE
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceFamilyEnable.Sha384.Services.Update               | TRUE
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceFamilyEnable.Sha384.Services.Final                | TRUE
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceFamilyEnable.Sha384.Services.HashAll              | TRUE
+
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceFamilyEnable.Sm3.Services.GetContextSize          | TRUE
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceFamilyEnable.Sm3.Services.Init                    | TRUE
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceFamilyEnable.Sm3.Services.Update                  | TRUE
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceFamilyEnable.Sm3.Services.Final                   | TRUE
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceFamilyEnable.Sm3.Services.HashAll                 | TRUE
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceFamilyEnable.Sm3.Services.Duplicate               | TRUE
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceFamilyEnable.HmacSha256.Services.New              | TRUE
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceFamilyEnable.HmacSha256.Services.Free             | TRUE
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceFamilyEnable.HmacSha256.Services.SetKey           | TRUE
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceFamilyEnable.HmacSha256.Services.Duplicate        | TRUE
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceFamilyEnable.HmacSha256.Services.Update           | TRUE
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceFamilyEnable.HmacSha256.Services.Final            | TRUE
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceFamilyEnable.Hkdf.Services.Sha256ExtractAndExpand | TRUE
+!endif
+
+!if $(CRYPTO_IMG_TYPE) IN "PEI_PREMEM"
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceFamilyEnable.Sha256.Services.GetContextSize       | TRUE
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceFamilyEnable.Sha256.Services.Init                 | TRUE
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceFamilyEnable.Sha256.Services.Update               | TRUE
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceFamilyEnable.Sha256.Services.Final                | TRUE
+
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceFamilyEnable.Sha384.Services.GetContextSize       | TRUE
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceFamilyEnable.Sha384.Services.Init                 | TRUE
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceFamilyEnable.Sha384.Services.Update               | TRUE
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceFamilyEnable.Sha384.Services.Final                | TRUE
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceFamilyEnable.Sha384.Services.HashAll              | TRUE
+
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceFamilyEnable.Sha512.Services.GetContextSize       | TRUE
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceFamilyEnable.Sha512.Services.Init                 | TRUE
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceFamilyEnable.Sha512.Services.Update               | TRUE
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceFamilyEnable.Sha512.Services.Final                | TRUE
+!endif
+
+###################################################################################################
+#
+# Components Section - list of the modules and components that will be processed by compilation
+#                      tools and the EDK II tools to generate PE32/PE32+/Coff image files.
+#
+# Note: The EDK II DSC file is not used to specify how compiled binary images get placed
+#       into firmware volume images. This section is just a list of modules to compile from
+#       source into UEFI-compliant binaries.
+#       It is the FDF file that contains information on combining binary files into firmware
+#       volume images, whose concept is beyond UEFI and is described in PI specification.
+#       Binary modules do not need to be listed in this section, as they should be
+#       specified in the FDF file. For example: Shell binary (Shell_Full.efi), FAT binary (Fat.efi),
+#       Logo (Logo.bmp), and etc.
+#       There may also be modules listed in this section that are not required in the FDF file,
+#       When a module listed here is excluded from FDF file, then UEFI-compliant binary will be
+#       generated for it, but the binary will not be put into any firmware volume.
+#
+###################################################################################################
+
+!if $(CRYPTO_IMG_TYPE) IN "PEI_DEFAULT PEI_PREMEM"
+[Components.IA32, Components.X64, Components.ARM, Components.AARCH64]
+  CryptoPkg/Driver/CryptoPei.inf {
+    <Defines>
+      !if "$(CRYPTO_SERVICES)" == "ALL"
+        FILE_GUID = 8DF53C2E-3380-495F-A8B7-370CFE28E1C6
+      !elseif "$(CRYPTO_SERVICES)" == "NONE"
+        FILE_GUID = E5A97EE3-71CC-407F-9DA9-6BE0C8A6C7DF
+      !elseif "$(CRYPTO_SERVICES)" == "MIN_PEI"
+        FILE_GUID = 0F5827A9-35FD-4F41-8D38-9BAFCE594D31
+      !endif
+  }
+!endif
+
+!if $(CRYPTO_IMG_TYPE) IN "DXE_SMM"
+[Components.IA32, Components.X64, Components.AARCH64]
+  CryptoPkg/Driver/CryptoDxe.inf {
+    <Defines>
+      !if "$(CRYPTO_SERVICES)" == "ALL"
+        FILE_GUID = D9444B06-060D-42C5-9344-F04707BE0169
+      !elseif "$(CRYPTO_SERVICES)" == "NONE"
+        FILE_GUID = C7A340F4-A6CC-4F95-A2DA-42BEA4C3944A
+      !elseif "$(CRYPTO_SERVICES)" == MIN_DXE_MIN_SMM
+        FILE_GUID = DDF5BE9E-159A-4B77-B6D7-82B84B5763A2
+      !endif
+  }
+
+[Components.IA32, Components.X64]
+  CryptoPkg/Driver/CryptoSmm.inf {
+    <Defines>
+      !if "$(CRYPTO_SERVICES)" == "ALL"
+        FILE_GUID = A3542CE8-77F7-49DC-A834-45D37D2EC1FA
+      !elseif "$(CRYPTO_SERVICES)" == "NONE"
+        FILE_GUID = 6DCB3127-01E7-4131-A487-DC77A965A541
+      !elseif "$(CRYPTO_SERVICES)" == MIN_DXE_MIN_SMM
+        FILE_GUID = 85F7EA15-3A2B-474A-8875-180542CD6BF3
+      !endif
+  }
+!endif
+
+[BuildOptions]
+  *_*_*_CC_FLAGS = -D DISABLE_NEW_DEPRECATED_INTERFACES
+  MSFT:*_*_*_CC_FLAGS = /D ENABLE_MD5_DEPRECATED_INTERFACES
+  INTEL:*_*_*_CC_FLAGS = /D ENABLE_MD5_DEPRECATED_INTERFACES
+  GCC:*_*_*_CC_FLAGS = -D ENABLE_MD5_DEPRECATED_INTERFACES
+  RVCT:*_*_*_CC_FLAGS = -DENABLE_MD5_DEPRECATED_INTERFACES
+!if $(CRYPTO_IMG_TYPE) IN "DXE_SMM"
+  MSFT:*_*_*_DLINK_FLAGS = /ALIGN:4096
+  GCC:*_GCC*_*_DLINK_FLAGS = -z common-page-size=0x1000
+!endif

--- a/CryptoPkg/Library/BaseCryptLibMbedTls/BaseCryptLib.inf
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/BaseCryptLib.inf
@@ -1,0 +1,81 @@
+## @file
+#  Cryptographic Library Instance for DXE_DRIVER.
+#
+#  Caution: This module requires additional review when modified.
+#  This library will have external input - signature.
+#  This external input must be validated carefully to avoid security issues such as
+#  buffer overflow or integer overflow.
+#
+#  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = BaseCryptLib
+  FILE_GUID                      = 693C5308-AF95-4CE5-ADE9-CA011C2FC642
+  MODULE_TYPE                    = DXE_DRIVER
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = BaseCryptLib|DXE_DRIVER DXE_CORE UEFI_APPLICATION UEFI_DRIVER
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64 ARM AARCH64
+#
+
+[Sources]
+  InternalCryptLib.h
+  Cipher/CryptAeadAesGcmNull.c
+  Cipher/CryptAes.c
+  Hash/CryptSha256.c
+  Hash/CryptSha512.c
+  Hash/CryptParallelHashNull.c
+  Hash/CryptSm3Null.c
+  Hash/CryptMd5.c
+  Hash/CryptSha1.c
+  Hmac/CryptHmac.c
+  Kdf/CryptHkdf.c
+  Pk/CryptRsaBasic.c
+  Pk/CryptRsaExtNull.c
+  Pk/CryptRsaPss.c
+  Pk/CryptRsaPssSignNull.c
+  Bn/CryptBnNull.c
+  Pem/CryptPemNull.c
+  Pk/CryptDhNull.c
+  Pk/CryptEcNull.c
+  Pk/CryptPkcs1OaepNull.c
+  Pk/CryptPkcs5Pbkdf2Null.c
+  Pk/CryptPkcs7SignNull.c
+  Pk/CryptPkcs7VerifyNull.c
+  Pk/CryptPkcs7VerifyEkuNull.c
+  Pk/CryptX509Null.c
+  Pk/CryptAuthenticodeNull.c
+  Pk/CryptTsNull.c
+  Rand/CryptRandNull.c
+  SysCall/CrtWrapper.c
+  SysCall/TimerWrapper.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  CryptoPkg/CryptoPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  BaseMemoryLib
+  MemoryAllocationLib
+  UefiRuntimeServicesTableLib
+  DebugLib
+  MbedTlsLib
+  PrintLib
+  IntrinsicLib
+  RngLib
+  SynchronizationLib
+[Protocols]
+  gEfiMpServiceProtocolGuid
+#
+# Remove these [BuildOptions] after this library is cleaned up
+#
+[BuildOptions]
+  MSFT:*_*_*_CC_FLAGS = /GL-

--- a/CryptoPkg/Library/BaseCryptLibMbedTls/Bn/CryptBnNull.c
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/Bn/CryptBnNull.c
@@ -1,0 +1,520 @@
+/** @file
+  Big number API implementation based on MbedTLS
+
+  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Library/BaseCryptLib.h>
+#include <Library/DebugLib.h>
+
+/**
+  Allocate new Big Number.
+
+  @retval New BigNum opaque structure or NULL on failure.
+**/
+VOID *
+EFIAPI
+BigNumInit (
+  VOID
+  )
+{
+  ASSERT (FALSE);
+  return NULL;
+}
+
+/**
+  Allocate new Big Number and assign the provided value to it.
+
+  @param[in]   Buf    Big endian encoded buffer.
+  @param[in]   Len    Buffer length.
+
+  @retval New BigNum opaque structure or NULL on failure.
+**/
+VOID *
+EFIAPI
+BigNumFromBin (
+  IN CONST UINT8  *Buf,
+  IN UINTN        Len
+  )
+{
+  ASSERT (FALSE);
+  return NULL;
+}
+
+/**
+  Convert the absolute value of Bn into big-endian form and store it at Buf.
+  The Buf array should have at least BigNumBytes() in it.
+
+  @param[in]   Bn     Big number to convert.
+  @param[out]  Buf    Output buffer.
+
+  @retval The length of the big-endian number placed at Buf or -1 on error.
+**/
+INTN
+EFIAPI
+BigNumToBin (
+  IN CONST VOID  *Bn,
+  OUT UINT8      *Buf
+  )
+{
+  ASSERT (FALSE);
+  return -1;
+}
+
+/**
+  Free the Big Number.
+
+  @param[in]   Bn      Big number to free.
+  @param[in]   Clear   TRUE if the buffer should be cleared.
+**/
+VOID
+EFIAPI
+BigNumFree (
+  IN VOID     *Bn,
+  IN BOOLEAN  Clear
+  )
+{
+  ASSERT (FALSE);
+}
+
+/**
+  Calculate the sum of two Big Numbers.
+  Please note, all "out" Big number arguments should be properly initialized
+  by calling to BigNumInit() or BigNumFromBin() functions.
+
+  @param[in]   BnA     Big number.
+  @param[in]   BnB     Big number.
+  @param[out]  BnRes   The result of BnA + BnB.
+
+  @retval TRUE          On success.
+  @retval FALSE         Otherwise.
+**/
+BOOLEAN
+EFIAPI
+BigNumAdd (
+  IN CONST VOID  *BnA,
+  IN CONST VOID  *BnB,
+  OUT VOID       *BnRes
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Subtract two Big Numbers.
+  Please note, all "out" Big number arguments should be properly initialized
+  by calling to BigNumInit() or BigNumFromBin() functions.
+
+  @param[in]   BnA     Big number.
+  @param[in]   BnB     Big number.
+  @param[out]  BnRes   The result of BnA - BnB.
+
+  @retval TRUE          On success.
+  @retval FALSE         Otherwise.
+**/
+BOOLEAN
+EFIAPI
+BigNumSub (
+  IN CONST VOID  *BnA,
+  IN CONST VOID  *BnB,
+  OUT VOID       *BnRes
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Calculate remainder: BnRes = BnA % BnB.
+  Please note, all "out" Big number arguments should be properly initialized
+  by calling to BigNumInit() or BigNumFromBin() functions.
+
+  @param[in]   BnA     Big number.
+  @param[in]   BnB     Big number.
+  @param[out]  BnRes   The result of BnA % BnB.
+
+  @retval TRUE          On success.
+  @retval FALSE         Otherwise.
+**/
+BOOLEAN
+EFIAPI
+BigNumMod (
+  IN CONST VOID  *BnA,
+  IN CONST VOID  *BnB,
+  OUT VOID       *BnRes
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Compute BnA to the BnP-th power modulo BnM.
+  Please note, all "out" Big number arguments should be properly initialized
+  by calling to BigNumInit() or BigNumFromBin() functions.
+
+  @param[in]   BnA     Big number.
+  @param[in]   BnP     Big number (power).
+  @param[in]   BnM     Big number (modulo).
+  @param[out]  BnRes   The result of (BnA ^ BnP) % BnM.
+
+  @retval TRUE          On success.
+  @retval FALSE         Otherwise.
+**/
+BOOLEAN
+EFIAPI
+BigNumExpMod (
+  IN CONST VOID  *BnA,
+  IN CONST VOID  *BnP,
+  IN CONST VOID  *BnM,
+  OUT VOID       *BnRes
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Compute BnA inverse modulo BnM.
+  Please note, all "out" Big number arguments should be properly initialized
+  by calling to BigNumInit() or BigNumFromBin() functions.
+
+  @param[in]   BnA     Big number.
+  @param[in]   BnM     Big number (modulo).
+  @param[out]  BnRes   The result, such that (BnA * BnRes) % BnM == 1.
+
+  @retval TRUE          On success.
+  @retval FALSE         Otherwise.
+**/
+BOOLEAN
+EFIAPI
+BigNumInverseMod (
+  IN CONST VOID  *BnA,
+  IN CONST VOID  *BnM,
+  OUT VOID       *BnRes
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Divide two Big Numbers.
+  Please note, all "out" Big number arguments should be properly initialized
+  by calling to BigNumInit() or BigNumFromBin() functions.
+
+  @param[in]   BnA     Big number.
+  @param[in]   BnB     Big number.
+  @param[out]  BnRes   The result, such that BnA / BnB.
+
+  @retval TRUE          On success.
+  @retval FALSE         Otherwise.
+**/
+BOOLEAN
+EFIAPI
+BigNumDiv (
+  IN CONST VOID  *BnA,
+  IN CONST VOID  *BnB,
+  OUT VOID       *BnRes
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Multiply two Big Numbers modulo BnM.
+  Please note, all "out" Big number arguments should be properly initialized
+  by calling to BigNumInit() or BigNumFromBin() functions.
+
+  @param[in]   BnA     Big number.
+  @param[in]   BnB     Big number.
+  @param[in]   BnM     Big number (modulo).
+  @param[out]  BnRes   The result, such that (BnA * BnB) % BnM.
+
+  @retval TRUE          On success.
+  @retval FALSE         Otherwise.
+**/
+BOOLEAN
+EFIAPI
+BigNumMulMod (
+  IN CONST VOID  *BnA,
+  IN CONST VOID  *BnB,
+  IN CONST VOID  *BnM,
+  OUT VOID       *BnRes
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Compare two Big Numbers.
+
+  @param[in]   BnA     Big number.
+  @param[in]   BnB     Big number.
+
+  @retval 0          BnA == BnB.
+  @retval 1          BnA > BnB.
+  @retval -1         BnA < BnB.
+**/
+INTN
+EFIAPI
+BigNumCmp (
+  IN CONST VOID  *BnA,
+  IN CONST VOID  *BnB
+  )
+{
+  ASSERT (FALSE);
+  return 0;
+}
+
+/**
+  Get number of bits in Bn.
+
+  @param[in]   Bn     Big number.
+
+  @retval Number of bits.
+**/
+UINTN
+EFIAPI
+BigNumBits (
+  IN CONST VOID  *Bn
+  )
+{
+  ASSERT (FALSE);
+  return 0;
+}
+
+/**
+  Get number of bytes in Bn.
+
+  @param[in]   Bn     Big number.
+
+  @retval Number of bytes.
+**/
+UINTN
+EFIAPI
+BigNumBytes (
+  IN CONST VOID  *Bn
+  )
+{
+  ASSERT (FALSE);
+  return 0;
+}
+
+/**
+  Checks if Big Number equals to the given Num.
+
+  @param[in]   Bn     Big number.
+  @param[in]   Num    Number.
+
+  @retval TRUE   iff Bn == Num.
+  @retval FALSE  otherwise.
+**/
+BOOLEAN
+EFIAPI
+BigNumIsWord (
+  IN CONST VOID  *Bn,
+  IN UINTN       Num
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Checks if Big Number is odd.
+
+  @param[in]   Bn     Big number.
+
+  @retval TRUE   Bn is odd (Bn % 2 == 1).
+  @retval FALSE  otherwise.
+**/
+BOOLEAN
+EFIAPI
+BigNumIsOdd (
+  IN CONST VOID  *Bn
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Copy Big number.
+
+  @param[out]  BnDst     Destination.
+  @param[in]   BnSrc     Source.
+
+  @retval BnDst on success.
+  @retval NULL otherwise.
+**/
+VOID *
+EFIAPI
+BigNumCopy (
+  OUT VOID       *BnDst,
+  IN CONST VOID  *BnSrc
+  )
+{
+  ASSERT (FALSE);
+  return NULL;
+}
+
+/**
+  Get constant Big number with value of "1".
+  This may be used to save expensive allocations.
+
+  @retval Big Number with value of 1.
+**/
+CONST VOID *
+EFIAPI
+BigNumValueOne (
+  VOID
+  )
+{
+  ASSERT (FALSE);
+  return NULL;
+}
+
+/**
+  Shift right Big Number.
+  Please note, all "out" Big number arguments should be properly initialized
+  by calling to BigNumInit() or BigNumFromBin() functions.
+
+  @param[in]   Bn      Big number.
+  @param[in]   N       Number of bits to shift.
+  @param[out]  BnRes   The result.
+
+  @retval TRUE          On success.
+  @retval FALSE         Otherwise.
+**/
+BOOLEAN
+EFIAPI
+BigNumRShift (
+  IN CONST VOID  *Bn,
+  IN UINTN       N,
+  OUT VOID       *BnRes
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Mark Big Number for constant time computations.
+  This function should be called before any constant time computations are
+  performed on the given Big number.
+
+  @param[in]   Bn     Big number
+**/
+VOID
+EFIAPI
+BigNumConstTime (
+  IN VOID  *Bn
+  )
+{
+  ASSERT (FALSE);
+}
+
+/**
+  Calculate square modulo.
+  Please note, all "out" Big number arguments should be properly initialized
+  by calling to BigNumInit() or BigNumFromBin() functions.
+
+  @param[in]   BnA     Big number.
+  @param[in]   BnM     Big number (modulo).
+  @param[out]  BnRes   The result, such that (BnA ^ 2) % BnM.
+
+  @retval TRUE          On success.
+  @retval FALSE         Otherwise.
+**/
+BOOLEAN
+EFIAPI
+BigNumSqrMod (
+  IN CONST VOID  *BnA,
+  IN CONST VOID  *BnM,
+  OUT VOID       *BnRes
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Create new Big Number computation context. This is an opaque structure
+  which should be passed to any function that requires it. The BN context is
+  needed to optimize calculations and expensive allocations.
+
+  @retval Big Number context struct or NULL on failure.
+**/
+VOID *
+EFIAPI
+BigNumNewContext (
+  VOID
+  )
+{
+  ASSERT (FALSE);
+  return NULL;
+}
+
+/**
+  Free Big Number context that was allocated with BigNumNewContext().
+
+  @param[in]   BnCtx     Big number context to free.
+**/
+VOID
+EFIAPI
+BigNumContextFree (
+  IN VOID  *BnCtx
+  )
+{
+  ASSERT (FALSE);
+}
+
+/**
+  Set Big Number to a given value.
+
+  @param[in]   Bn     Big number to set.
+  @param[in]   Val    Value to set.
+
+  @retval TRUE          On success.
+  @retval FALSE         Otherwise.
+**/
+BOOLEAN
+EFIAPI
+BigNumSetUint (
+  IN VOID   *Bn,
+  IN UINTN  Val
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Add two Big Numbers modulo BnM.
+
+  @param[in]   BnA       Big number.
+  @param[in]   BnB       Big number.
+  @param[in]   BnM       Big number (modulo).
+  @param[out]  BnRes     The result, such that (BnA + BnB) % BnM.
+
+  @retval TRUE          On success.
+  @retval FALSE         Otherwise.
+**/
+BOOLEAN
+EFIAPI
+BigNumAddMod (
+  IN CONST VOID  *BnA,
+  IN CONST VOID  *BnB,
+  IN CONST VOID  *BnM,
+  OUT VOID       *BnRes
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}

--- a/CryptoPkg/Library/BaseCryptLibMbedTls/Cipher/CryptAeadAesGcmNull.c
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/Cipher/CryptAeadAesGcmNull.c
@@ -1,0 +1,100 @@
+/** @file
+  AEAD Wrapper Implementation which does not provide real capabilities.
+
+Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "InternalCryptLib.h"
+
+/**
+  Performs AEAD AES-GCM authenticated encryption on a data buffer and additional authenticated data (AAD).
+
+  IvSize must be 12, otherwise FALSE is returned.
+  KeySize must be 16, 24 or 32, otherwise FALSE is returned.
+  TagSize must be 12, 13, 14, 15, 16, otherwise FALSE is returned.
+
+  @param[in]   Key         Pointer to the encryption key.
+  @param[in]   KeySize     Size of the encryption key in bytes.
+  @param[in]   Iv          Pointer to the IV value.
+  @param[in]   IvSize      Size of the IV value in bytes.
+  @param[in]   AData       Pointer to the additional authenticated data (AAD).
+  @param[in]   ADataSize   Size of the additional authenticated data (AAD) in bytes.
+  @param[in]   DataIn      Pointer to the input data buffer to be encrypted.
+  @param[in]   DataInSize  Size of the input data buffer in bytes.
+  @param[out]  TagOut      Pointer to a buffer that receives the authentication tag output.
+  @param[in]   TagSize     Size of the authentication tag in bytes.
+  @param[out]  DataOut     Pointer to a buffer that receives the encryption output.
+  @param[out]  DataOutSize Size of the output data buffer in bytes.
+
+  @retval TRUE   AEAD AES-GCM authenticated encryption succeeded.
+  @retval FALSE  AEAD AES-GCM authenticated encryption failed.
+
+**/
+BOOLEAN
+EFIAPI
+AeadAesGcmEncrypt (
+  IN   CONST UINT8  *Key,
+  IN   UINTN        KeySize,
+  IN   CONST UINT8  *Iv,
+  IN   UINTN        IvSize,
+  IN   CONST UINT8  *AData,
+  IN   UINTN        ADataSize,
+  IN   CONST UINT8  *DataIn,
+  IN   UINTN        DataInSize,
+  OUT  UINT8        *TagOut,
+  IN   UINTN        TagSize,
+  OUT  UINT8        *DataOut,
+  OUT  UINTN        *DataOutSize
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Performs AEAD AES-GCM authenticated decryption on a data buffer and additional authenticated data (AAD).
+
+  IvSize must be 12, otherwise FALSE is returned.
+  KeySize must be 16, 24 or 32, otherwise FALSE is returned.
+  TagSize must be 12, 13, 14, 15, 16, otherwise FALSE is returned.
+  If additional authenticated data verification fails, FALSE is returned.
+
+  @param[in]   Key         Pointer to the encryption key.
+  @param[in]   KeySize     Size of the encryption key in bytes.
+  @param[in]   Iv          Pointer to the IV value.
+  @param[in]   IvSize      Size of the IV value in bytes.
+  @param[in]   AData       Pointer to the additional authenticated data (AAD).
+  @param[in]   ADataSize   Size of the additional authenticated data (AAD) in bytes.
+  @param[in]   DataIn      Pointer to the input data buffer to be decrypted.
+  @param[in]   DataInSize  Size of the input data buffer in bytes.
+  @param[in]   Tag         Pointer to a buffer that contains the authentication tag.
+  @param[in]   TagSize     Size of the authentication tag in bytes.
+  @param[out]  DataOut     Pointer to a buffer that receives the decryption output.
+  @param[out]  DataOutSize Size of the output data buffer in bytes.
+
+  @retval TRUE   AEAD AES-GCM authenticated decryption succeeded.
+  @retval FALSE  AEAD AES-GCM authenticated decryption failed.
+
+**/
+BOOLEAN
+EFIAPI
+AeadAesGcmDecrypt (
+  IN   CONST UINT8  *Key,
+  IN   UINTN        KeySize,
+  IN   CONST UINT8  *Iv,
+  IN   UINTN        IvSize,
+  IN   CONST UINT8  *AData,
+  IN   UINTN        ADataSize,
+  IN   CONST UINT8  *DataIn,
+  IN   UINTN        DataInSize,
+  IN   CONST UINT8  *Tag,
+  IN   UINTN        TagSize,
+  OUT  UINT8        *DataOut,
+  OUT  UINTN        *DataOutSize
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}

--- a/CryptoPkg/Library/BaseCryptLibMbedTls/Cipher/CryptAes.c
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/Cipher/CryptAes.c
@@ -1,0 +1,225 @@
+/** @file
+  AES Wrapper Implementation over MbedTLS.
+
+Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "InternalCryptLib.h"
+#include <mbedtls/aes.h>
+
+/**
+  Retrieves the size, in bytes, of the context buffer required for AES operations.
+
+  @return  The size, in bytes, of the context buffer required for AES operations.
+
+**/
+UINTN
+EFIAPI
+AesGetContextSize (
+  VOID
+  )
+{
+  //
+  // AES uses different key contexts for encryption and decryption, so here memory
+  // for 2 copies of mbedtls_aes_context is allocated.
+  //
+  return (UINTN)(2 * sizeof (mbedtls_aes_context));
+}
+
+/**
+  Initializes user-supplied memory as AES context for subsequent use.
+
+  This function initializes user-supplied memory pointed by AesContext as AES context.
+  In addition, it sets up all AES key materials for subsequent encryption and decryption
+  operations.
+  There are 3 options for key length, 128 bits, 192 bits, and 256 bits.
+
+  If AesContext is NULL, then return FALSE.
+  If Key is NULL, then return FALSE.
+  If KeyLength is not valid, then return FALSE.
+
+  @param[out]  AesContext  Pointer to AES context being initialized.
+  @param[in]   Key         Pointer to the user-supplied AES key.
+  @param[in]   KeyLength   Length of AES key in bits.
+
+  @retval TRUE   AES context initialization succeeded.
+  @retval FALSE  AES context initialization failed.
+
+**/
+BOOLEAN
+EFIAPI
+AesInit (
+  OUT  VOID         *AesContext,
+  IN   CONST UINT8  *Key,
+  IN   UINTN        KeyLength
+  )
+{
+  mbedtls_aes_context  *AesCtx;
+
+  //
+  // Check input parameters.
+  //
+  if ((AesContext == NULL) || (Key == NULL) || ((KeyLength != 128) && (KeyLength != 192) && (KeyLength != 256))) {
+    return FALSE;
+  }
+
+  //
+  // Initialize AES encryption & decryption key schedule.
+  //
+  AesCtx = (mbedtls_aes_context *)AesContext;
+  if (mbedtls_aes_setkey_enc (AesCtx, Key, (UINT32)KeyLength) != 0) {
+    return FALSE;
+  }
+
+  if (mbedtls_aes_setkey_dec (AesCtx + 1, Key, (UINT32)KeyLength) != 0) {
+    return FALSE;
+  }
+
+  return TRUE;
+}
+
+/**
+  Performs AES encryption on a data buffer of the specified size in CBC mode.
+
+  This function performs AES encryption on data buffer pointed by Input, of specified
+  size of InputSize, in CBC mode.
+  InputSize must be multiple of block size (16 bytes). This function does not perform
+  padding. Caller must perform padding, if necessary, to ensure valid input data size.
+  Initialization vector should be one block size (16 bytes).
+  AesContext should be already correctly initialized by AesInit(). Behavior with
+  invalid AES context is undefined.
+
+  If AesContext is NULL, then return FALSE.
+  If Input is NULL, then return FALSE.
+  If InputSize is not multiple of block size (16 bytes), then return FALSE.
+  If Ivec is NULL, then return FALSE.
+  If Output is NULL, then return FALSE.
+
+  @param[in]   AesContext  Pointer to the AES context.
+  @param[in]   Input       Pointer to the buffer containing the data to be encrypted.
+  @param[in]   InputSize   Size of the Input buffer in bytes.
+  @param[in]   Ivec        Pointer to initialization vector.
+  @param[out]  Output      Pointer to a buffer that receives the AES encryption output.
+
+  @retval TRUE   AES encryption succeeded.
+  @retval FALSE  AES encryption failed.
+
+**/
+BOOLEAN
+EFIAPI
+AesCbcEncrypt (
+  IN   VOID         *AesContext,
+  IN   CONST UINT8  *Input,
+  IN   UINTN        InputSize,
+  IN   CONST UINT8  *Ivec,
+  OUT  UINT8        *Output
+  )
+{
+  mbedtls_aes_context  *AesCtx;
+  UINT8                IvecBuffer[AES_BLOCK_SIZE];
+
+  //
+  // Check input parameters.
+  //
+  if ((AesContext == NULL) || (Input == NULL) || ((InputSize % AES_BLOCK_SIZE) != 0)) {
+    return FALSE;
+  }
+
+  if ((Ivec == NULL) || (Output == NULL) || (InputSize > INT_MAX)) {
+    return FALSE;
+  }
+
+  AesCtx = (mbedtls_aes_context *)AesContext;
+  CopyMem (IvecBuffer, Ivec, AES_BLOCK_SIZE);
+
+  //
+  // Perform AES data encryption with CBC mode
+  //
+  if (mbedtls_aes_crypt_cbc (
+        AesCtx,
+        MBEDTLS_AES_ENCRYPT,
+        (UINT32)InputSize,
+        IvecBuffer,
+        Input,
+        Output
+        ) != 0)
+  {
+    return FALSE;
+  } else {
+    return TRUE;
+  }
+}
+
+/**
+  Performs AES decryption on a data buffer of the specified size in CBC mode.
+
+  This function performs AES decryption on data buffer pointed by Input, of specified
+  size of InputSize, in CBC mode.
+  InputSize must be multiple of block size (16 bytes). This function does not perform
+  padding. Caller must perform padding, if necessary, to ensure valid input data size.
+  Initialization vector should be one block size (16 bytes).
+  AesContext should be already correctly initialized by AesInit(). Behavior with
+  invalid AES context is undefined.
+
+  If AesContext is NULL, then return FALSE.
+  If Input is NULL, then return FALSE.
+  If InputSize is not multiple of block size (16 bytes), then return FALSE.
+  If Ivec is NULL, then return FALSE.
+  If Output is NULL, then return FALSE.
+
+  @param[in]   AesContext  Pointer to the AES context.
+  @param[in]   Input       Pointer to the buffer containing the data to be encrypted.
+  @param[in]   InputSize   Size of the Input buffer in bytes.
+  @param[in]   Ivec        Pointer to initialization vector.
+  @param[out]  Output      Pointer to a buffer that receives the AES encryption output.
+
+  @retval TRUE   AES decryption succeeded.
+  @retval FALSE  AES decryption failed.
+
+**/
+BOOLEAN
+EFIAPI
+AesCbcDecrypt (
+  IN   VOID         *AesContext,
+  IN   CONST UINT8  *Input,
+  IN   UINTN        InputSize,
+  IN   CONST UINT8  *Ivec,
+  OUT  UINT8        *Output
+  )
+{
+  mbedtls_aes_context  *AesCtx;
+  UINT8                IvecBuffer[AES_BLOCK_SIZE];
+
+  //
+  // Check input parameters.
+  //
+  if ((AesContext == NULL) || (Input == NULL) || ((InputSize % AES_BLOCK_SIZE) != 0)) {
+    return FALSE;
+  }
+
+  if ((Ivec == NULL) || (Output == NULL) || (InputSize > INT_MAX)) {
+    return FALSE;
+  }
+
+  AesCtx = (mbedtls_aes_context *)AesContext;
+  CopyMem (IvecBuffer, Ivec, AES_BLOCK_SIZE);
+
+  //
+  // Perform AES data encryption with CBC mode
+  //
+  if (mbedtls_aes_crypt_cbc (
+        AesCtx + 1,
+        MBEDTLS_AES_DECRYPT,
+        (UINT32)InputSize,
+        IvecBuffer,
+        Input,
+        Output
+        ) != 0)
+  {
+    return FALSE;
+  } else {
+    return TRUE;
+  }
+}

--- a/CryptoPkg/Library/BaseCryptLibMbedTls/Cipher/CryptAesNull.c
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/Cipher/CryptAesNull.c
@@ -1,0 +1,159 @@
+/** @file
+  AES Wrapper Implementation which does not provide real capabilities.
+
+Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "InternalCryptLib.h"
+
+/**
+  Retrieves the size, in bytes, of the context buffer required for AES operations.
+
+  Return zero to indicate this interface is not supported.
+
+  @retval  0   This interface is not supported.
+
+**/
+UINTN
+EFIAPI
+AesGetContextSize (
+  VOID
+  )
+{
+  ASSERT (FALSE);
+  return 0;
+}
+
+/**
+  Initializes user-supplied memory as AES context for subsequent use.
+
+  Return FALSE to indicate this interface is not supported.
+
+  @param[out]  AesContext  Pointer to AES context being initialized.
+  @param[in]   Key         Pointer to the user-supplied AES key.
+  @param[in]   KeyLength   Length of AES key in bits.
+
+  @retval FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+AesInit (
+  OUT  VOID         *AesContext,
+  IN   CONST UINT8  *Key,
+  IN   UINTN        KeyLength
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Performs AES encryption on a data buffer of the specified size in ECB mode.
+
+  Return FALSE to indicate this interface is not supported.
+
+  @param[in]   AesContext  Pointer to the AES context.
+  @param[in]   Input       Pointer to the buffer containing the data to be encrypted.
+  @param[in]   InputSize   Size of the Input buffer in bytes.
+  @param[out]  Output      Pointer to a buffer that receives the AES encryption output.
+
+  @retval FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+AesEcbEncrypt (
+  IN   VOID         *AesContext,
+  IN   CONST UINT8  *Input,
+  IN   UINTN        InputSize,
+  OUT  UINT8        *Output
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Performs AES decryption on a data buffer of the specified size in ECB mode.
+
+  Return FALSE to indicate this interface is not supported.
+
+  @param[in]   AesContext  Pointer to the AES context.
+  @param[in]   Input       Pointer to the buffer containing the data to be decrypted.
+  @param[in]   InputSize   Size of the Input buffer in bytes.
+  @param[out]  Output      Pointer to a buffer that receives the AES decryption output.
+
+  @retval FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+AesEcbDecrypt (
+  IN   VOID         *AesContext,
+  IN   CONST UINT8  *Input,
+  IN   UINTN        InputSize,
+  OUT  UINT8        *Output
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Performs AES encryption on a data buffer of the specified size in CBC mode.
+
+  Return FALSE to indicate this interface is not supported.
+
+  @param[in]   AesContext  Pointer to the AES context.
+  @param[in]   Input       Pointer to the buffer containing the data to be encrypted.
+  @param[in]   InputSize   Size of the Input buffer in bytes.
+  @param[in]   Ivec        Pointer to initialization vector.
+  @param[out]  Output      Pointer to a buffer that receives the AES encryption output.
+
+  @retval FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+AesCbcEncrypt (
+  IN   VOID         *AesContext,
+  IN   CONST UINT8  *Input,
+  IN   UINTN        InputSize,
+  IN   CONST UINT8  *Ivec,
+  OUT  UINT8        *Output
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Performs AES decryption on a data buffer of the specified size in CBC mode.
+
+  Return FALSE to indicate this interface is not supported.
+
+  @param[in]   AesContext  Pointer to the AES context.
+  @param[in]   Input       Pointer to the buffer containing the data to be encrypted.
+  @param[in]   InputSize   Size of the Input buffer in bytes.
+  @param[in]   Ivec        Pointer to initialization vector.
+  @param[out]  Output      Pointer to a buffer that receives the AES encryption output.
+
+  @retval FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+AesCbcDecrypt (
+  IN   VOID         *AesContext,
+  IN   CONST UINT8  *Input,
+  IN   UINTN        InputSize,
+  IN   CONST UINT8  *Ivec,
+  OUT  UINT8        *Output
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}

--- a/CryptoPkg/Library/BaseCryptLibMbedTls/Hash/CryptMd5.c
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/Hash/CryptMd5.c
@@ -1,0 +1,226 @@
+/** @file
+  MD5 Digest Wrapper Implementation over MbedTLS.
+
+Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "InternalCryptLib.h"
+#include <mbedtls/md5.h>
+#include <mbedtls/compat-2.x.h>
+
+#ifdef ENABLE_MD5_DEPRECATED_INTERFACES
+
+/**
+  Retrieves the size, in bytes, of the context buffer required for MD5 hash operations.
+
+  @return  The size, in bytes, of the context buffer required for MD5 hash operations.
+
+**/
+UINTN
+EFIAPI
+Md5GetContextSize (
+  VOID
+  )
+{
+  //
+  // Retrieves the MD5 Context Size
+  //
+  return (UINTN)(sizeof (mbedtls_md5_context));
+}
+
+/**
+  Initializes user-supplied memory pointed by Md5Context as MD5 hash context for
+  subsequent use.
+
+  If Md5Context is NULL, then return FALSE.
+
+  @param[out]  Md5Context  Pointer to MD5 context being initialized.
+
+  @retval TRUE   MD5 context initialization succeeded.
+  @retval FALSE  MD5 context initialization failed.
+
+**/
+BOOLEAN
+EFIAPI
+Md5Init (
+  OUT  VOID  *Md5Context
+  )
+{
+  INT32  Ret;
+
+  if (Md5Context == NULL) {
+    return FALSE;
+  }
+
+  mbedtls_md5_init (Md5Context);
+
+  Ret = mbedtls_md5_starts_ret (Md5Context);
+  if (Ret != 0) {
+    return FALSE;
+  }
+
+  return TRUE;
+}
+
+/**
+  Makes a copy of an existing MD5 context.
+
+  If Md5Context is NULL, then return FALSE.
+  If NewMd5Context is NULL, then return FALSE.
+
+  @param[in]  Md5Context     Pointer to MD5 context being copied.
+  @param[out] NewMd5Context  Pointer to new MD5 context.
+
+  @retval TRUE   MD5 context copy succeeded.
+  @retval FALSE  MD5 context copy failed.
+
+**/
+BOOLEAN
+EFIAPI
+Md5Duplicate (
+  IN   CONST VOID  *Md5Context,
+  OUT  VOID        *NewMd5Context
+  )
+{
+  if ((Md5Context == NULL) || (NewMd5Context == NULL)) {
+    return FALSE;
+  }
+
+  mbedtls_md5_clone (NewMd5Context, Md5Context);
+
+  return TRUE;
+}
+
+/**
+  Digests the input data and updates MD5 context.
+
+  This function performs MD5 digest on a data buffer of the specified size.
+  It can be called multiple times to compute the digest of long or discontinuous data streams.
+  MD5 context should be already correctly initialized by Md5Init(), and should not be finalized
+  by Md5Final(). Behavior with invalid context is undefined.
+
+  If Md5Context is NULL, then return FALSE.
+
+  @param[in, out]  Md5Context  Pointer to the MD5 context.
+  @param[in]       Data        Pointer to the buffer containing the data to be hashed.
+  @param[in]       DataSize    Size of Data buffer in bytes.
+
+  @retval TRUE   MD5 data digest succeeded.
+  @retval FALSE  MD5 data digest failed.
+
+**/
+BOOLEAN
+EFIAPI
+Md5Update (
+  IN OUT  VOID        *Md5Context,
+  IN      CONST VOID  *Data,
+  IN      UINTN       DataSize
+  )
+{
+  INT32  Ret;
+
+  if (Md5Context == NULL) {
+    return FALSE;
+  }
+
+  if ((Data == NULL) && (DataSize != 0)) {
+    return FALSE;
+  }
+
+  Ret = mbedtls_md5_update_ret (Md5Context, Data, DataSize);
+  if (Ret != 0) {
+    return FALSE;
+  }
+
+  return TRUE;
+}
+
+/**
+  Completes computation of the MD5 digest value.
+
+  This function completes MD5 hash computation and retrieves the digest value into
+  the specified memory. After this function has been called, the MD5 context cannot
+  be used again.
+  MD5 context should be already correctly initialized by Md5Init(), and should not be
+  finalized by Md5Final(). Behavior with invalid MD5 context is undefined.
+
+  If Md5Context is NULL, then return FALSE.
+  If HashValue is NULL, then return FALSE.
+
+  @param[in, out]  Md5Context  Pointer to the MD5 context.
+  @param[out]      HashValue   Pointer to a buffer that receives the MD5 digest
+                               value (16 bytes).
+
+  @retval TRUE   MD5 digest computation succeeded.
+  @retval FALSE  MD5 digest computation failed.
+
+**/
+BOOLEAN
+EFIAPI
+Md5Final (
+  IN OUT  VOID   *Md5Context,
+  OUT     UINT8  *HashValue
+  )
+{
+  INT32  Ret;
+
+  if ((Md5Context == NULL) || (HashValue == NULL)) {
+    return FALSE;
+  }
+
+  Ret = mbedtls_md5_finish_ret (Md5Context, HashValue);
+  mbedtls_md5_free (Md5Context);
+  if (Ret != 0) {
+    return FALSE;
+  }
+
+  return TRUE;
+}
+
+/**
+  Computes the MD5 message digest of a input data buffer.
+
+  This function performs the MD5 message digest of a given data buffer, and places
+  the digest value into the specified memory.
+
+  If this interface is not supported, then return FALSE.
+
+  @param[in]   Data        Pointer to the buffer containing the data to be hashed.
+  @param[in]   DataSize    Size of Data buffer in bytes.
+  @param[out]  HashValue   Pointer to a buffer that receives the MD5 digest
+                           value (16 bytes).
+
+  @retval TRUE   MD5 digest computation succeeded.
+  @retval FALSE  MD5 digest computation failed.
+  @retval FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+Md5HashAll (
+  IN   CONST VOID  *Data,
+  IN   UINTN       DataSize,
+  OUT  UINT8       *HashValue
+  )
+{
+  INT32  Ret;
+
+  if (HashValue == NULL) {
+    return FALSE;
+  }
+
+  if ((Data == NULL) && (DataSize != 0)) {
+    return FALSE;
+  }
+
+  Ret = mbedtls_md5_ret (Data, DataSize, HashValue);
+  if (Ret != 0) {
+    return FALSE;
+  }
+
+  return TRUE;
+}
+
+#endif

--- a/CryptoPkg/Library/BaseCryptLibMbedTls/Hash/CryptMd5Null.c
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/Hash/CryptMd5Null.c
@@ -1,0 +1,163 @@
+/** @file
+
+MD5 Digest Wrapper Null Implementation.
+
+Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "InternalCryptLib.h"
+
+/**
+  Retrieves the size, in bytes, of the context buffer required for MD5 hash operations.
+
+  @return  The size, in bytes, of the context buffer required for MD5 hash operations.
+
+**/
+UINTN
+EFIAPI
+Md5GetContextSize (
+  VOID
+  )
+{
+  ASSERT (FALSE);
+  return 0;
+}
+
+/**
+  Initializes user-supplied memory pointed by Md5Context as MD5 hash context for
+  subsequent use.
+
+  If Md5Context is NULL, then return FALSE.
+
+  @param[out]  Md5Context  Pointer to MD5 context being initialized.
+
+  @retval TRUE   MD5 context initialization succeeded.
+  @retval FALSE  MD5 context initialization failed.
+
+**/
+BOOLEAN
+EFIAPI
+Md5Init (
+  OUT  VOID  *Md5Context
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Makes a copy of an existing MD5 context.
+
+  If Md5Context is NULL, then return FALSE.
+  If NewMd5Context is NULL, then return FALSE.
+
+  @param[in]  Md5Context     Pointer to MD5 context being copied.
+  @param[out] NewMd5Context  Pointer to new MD5 context.
+
+  @retval TRUE   MD5 context copy succeeded.
+  @retval FALSE  MD5 context copy failed.
+
+**/
+BOOLEAN
+EFIAPI
+Md5Duplicate (
+  IN   CONST VOID  *Md5Context,
+  OUT  VOID        *NewMd5Context
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Digests the input data and updates MD5 context.
+
+  This function performs MD5 digest on a data buffer of the specified size.
+  It can be called multiple times to compute the digest of long or discontinuous data streams.
+  MD5 context should be already correctly intialized by Md5Init(), and should not be finalized
+  by Md5Final(). Behavior with invalid context is undefined.
+
+  If Md5Context is NULL, then return FALSE.
+
+  @param[in, out]  Md5Context  Pointer to the MD5 context.
+  @param[in]       Data        Pointer to the buffer containing the data to be hashed.
+  @param[in]       DataSize    Size of Data buffer in bytes.
+
+  @retval TRUE   MD5 data digest succeeded.
+  @retval FALSE  MD5 data digest failed.
+
+**/
+BOOLEAN
+EFIAPI
+Md5Update (
+  IN OUT  VOID        *Md5Context,
+  IN      CONST VOID  *Data,
+  IN      UINTN       DataSize
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Completes computation of the MD5 digest value.
+
+  This function completes MD5 hash computation and retrieves the digest value into
+  the specified memory. After this function has been called, the MD5 context cannot
+  be used again.
+  MD5 context should be already correctly intialized by Md5Init(), and should not be
+  finalized by Md5Final(). Behavior with invalid MD5 context is undefined.
+
+  If Md5Context is NULL, then return FALSE.
+  If HashValue is NULL, then return FALSE.
+
+  @param[in, out]  Md5Context  Pointer to the MD5 context.
+  @param[out]      HashValue   Pointer to a buffer that receives the MD5 digest
+                               value (16 bytes).
+
+  @retval TRUE   MD5 digest computation succeeded.
+  @retval FALSE  MD5 digest computation failed.
+
+**/
+BOOLEAN
+EFIAPI
+Md5Final (
+  IN OUT  VOID   *Md5Context,
+  OUT     UINT8  *HashValue
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+Computes the MD5 message digest of a input data buffer.
+
+This function performs the MD5 message digest of a given data buffer, and places
+the digest value into the specified memory.
+
+If this interface is not supported, then return FALSE.
+
+@param[in]   Data        Pointer to the buffer containing the data to be hashed.
+@param[in]   DataSize    Size of Data buffer in bytes.
+@param[out]  HashValue   Pointer to a buffer that receives the MD5 digest
+value (16 bytes).
+
+@retval TRUE   MD5 digest computation succeeded.
+@retval FALSE  MD5 digest computation failed.
+@retval FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+Md5HashAll (
+  IN   CONST VOID  *Data,
+  IN   UINTN       DataSize,
+  OUT  UINT8       *HashValue
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}

--- a/CryptoPkg/Library/BaseCryptLibMbedTls/Hash/CryptParallelHashNull.c
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/Hash/CryptParallelHashNull.c
@@ -1,0 +1,40 @@
+/** @file
+  ParallelHash Implementation which does not provide real capabilities.
+
+Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "InternalCryptLib.h"
+
+/**
+  Parallel hash function ParallelHash256, as defined in NIST's Special Publication 800-185,
+  published December 2016.
+
+  @param[in]   Input            Pointer to the input message (X).
+  @param[in]   InputByteLen     The number(>0) of input bytes provided for the input data.
+  @param[in]   BlockSize        The size of each block (B).
+  @param[out]  Output           Pointer to the output buffer.
+  @param[in]   OutputByteLen    The desired number of output bytes (L).
+  @param[in]   Customization    Pointer to the customization string (S).
+  @param[in]   CustomByteLen    The length of the customization string in bytes.
+
+  @retval FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+ParallelHash256HashAll (
+  IN CONST VOID   *Input,
+  IN       UINTN  InputByteLen,
+  IN       UINTN  BlockSize,
+  OUT      VOID   *Output,
+  IN       UINTN  OutputByteLen,
+  IN CONST VOID   *Customization,
+  IN       UINTN  CustomByteLen
+  )
+{
+  // ASSERT (FALSE);
+  return FALSE;
+}

--- a/CryptoPkg/Library/BaseCryptLibMbedTls/Hash/CryptSha1.c
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/Hash/CryptSha1.c
@@ -1,0 +1,226 @@
+/** @file
+  SHA-1 Digest Wrapper Implementation over MbedTLS.
+
+Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "InternalCryptLib.h"
+#include <mbedtls/sha1.h>
+#include <mbedtls/compat-2.x.h>
+
+#ifndef DISABLE_SHA1_DEPRECATED_INTERFACES
+
+/**
+  Retrieves the size, in bytes, of the context buffer required for SHA-1 hash operations.
+
+  @return  The size, in bytes, of the context buffer required for SHA-1 hash operations.
+
+**/
+UINTN
+EFIAPI
+Sha1GetContextSize (
+  VOID
+  )
+{
+  //
+  // Retrieves MbedTLS SHA Context Size
+  //
+  return (UINTN)(sizeof (mbedtls_sha1_context));
+}
+
+/**
+  Initializes user-supplied memory pointed by Sha1Context as SHA-1 hash context for
+  subsequent use.
+
+  If Sha1Context is NULL, then return FALSE.
+
+  @param[out]  Sha1Context  Pointer to SHA-1 context being initialized.
+
+  @retval TRUE   SHA-1 context initialization succeeded.
+  @retval FALSE  SHA-1 context initialization failed.
+
+**/
+BOOLEAN
+EFIAPI
+Sha1Init (
+  OUT  VOID  *Sha1Context
+  )
+{
+  INT32  Ret;
+
+  if (Sha1Context == NULL) {
+    return FALSE;
+  }
+
+  mbedtls_sha1_init (Sha1Context);
+
+  Ret = mbedtls_sha1_starts_ret (Sha1Context);
+  if (Ret != 0) {
+    return FALSE;
+  }
+
+  return TRUE;
+}
+
+/**
+  Makes a copy of an existing SHA-1 context.
+
+  If Sha1Context is NULL, then return FALSE.
+  If NewSha1Context is NULL, then return FALSE.
+
+  @param[in]  Sha1Context     Pointer to SHA-1 context being copied.
+  @param[out] NewSha1Context  Pointer to new SHA-1 context.
+
+  @retval TRUE   SHA-1 context copy succeeded.
+  @retval FALSE  SHA-1 context copy failed.
+
+**/
+BOOLEAN
+EFIAPI
+Sha1Duplicate (
+  IN   CONST VOID  *Sha1Context,
+  OUT  VOID        *NewSha1Context
+  )
+{
+  if ((Sha1Context == NULL) || (NewSha1Context == NULL)) {
+    return FALSE;
+  }
+
+  mbedtls_sha1_clone (NewSha1Context, Sha1Context);
+
+  return TRUE;
+}
+
+/**
+  Digests the input data and updates SHA-1 context.
+
+  This function performs SHA-1 digest on a data buffer of the specified size.
+  It can be called multiple times to compute the digest of long or discontinuous data streams.
+  SHA-1 context should be already correctly initialized by Sha1Init(), and should not be finalized
+  by Sha1Final(). Behavior with invalid context is undefined.
+
+  If Sha1Context is NULL, then return FALSE.
+
+  @param[in, out]  Sha1Context  Pointer to the SHA-1 context.
+  @param[in]       Data         Pointer to the buffer containing the data to be hashed.
+  @param[in]       DataSize     Size of Data buffer in bytes.
+
+  @retval TRUE   SHA-1 data digest succeeded.
+  @retval FALSE  SHA-1 data digest failed.
+
+**/
+BOOLEAN
+EFIAPI
+Sha1Update (
+  IN OUT  VOID        *Sha1Context,
+  IN      CONST VOID  *Data,
+  IN      UINTN       DataSize
+  )
+{
+  INT32  Ret;
+
+  if (Sha1Context == NULL) {
+    return FALSE;
+  }
+
+  if ((Data == NULL) && (DataSize != 0)) {
+    return FALSE;
+  }
+
+  Ret = mbedtls_sha1_update_ret (Sha1Context, Data, DataSize);
+  if (Ret != 0) {
+    return FALSE;
+  }
+
+  return TRUE;
+}
+
+/**
+  Completes computation of the SHA-1 digest value.
+
+  This function completes SHA-1 hash computation and retrieves the digest value into
+  the specified memory. After this function has been called, the SHA-1 context cannot
+  be used again.
+  SHA-1 context should be already correctly initialized by Sha1Init(), and should not be
+  finalized by Sha1Final(). Behavior with invalid SHA-1 context is undefined.
+
+  If Sha1Context is NULL, then return FALSE.
+  If HashValue is NULL, then return FALSE.
+
+  @param[in, out]  Sha1Context  Pointer to the SHA-1 context.
+  @param[out]      HashValue    Pointer to a buffer that receives the SHA-1 digest
+                                value (20 bytes).
+
+  @retval TRUE   SHA-1 digest computation succeeded.
+  @retval FALSE  SHA-1 digest computation failed.
+
+**/
+BOOLEAN
+EFIAPI
+Sha1Final (
+  IN OUT  VOID   *Sha1Context,
+  OUT     UINT8  *HashValue
+  )
+{
+  INT32  Ret;
+
+  if ((Sha1Context == NULL) || (HashValue == NULL)) {
+    return FALSE;
+  }
+
+  Ret = mbedtls_sha1_finish_ret (Sha1Context, HashValue);
+  mbedtls_sha1_free (Sha1Context);
+  if (Ret != 0) {
+    return FALSE;
+  }
+
+  return TRUE;
+}
+
+/**
+  Computes the SHA-1 message digest of a input data buffer.
+
+  This function performs the SHA-1 message digest of a given data buffer, and places
+  the digest value into the specified memory.
+
+  If this interface is not supported, then return FALSE.
+
+  @param[in]   Data        Pointer to the buffer containing the data to be hashed.
+  @param[in]   DataSize    Size of Data buffer in bytes.
+  @param[out]  HashValue   Pointer to a buffer that receives the SHA-1 digest
+                           value (20 bytes).
+
+  @retval TRUE   SHA-1 digest computation succeeded.
+  @retval FALSE  SHA-1 digest computation failed.
+  @retval FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+Sha1HashAll (
+  IN   CONST VOID  *Data,
+  IN   UINTN       DataSize,
+  OUT  UINT8       *HashValue
+  )
+{
+  INT32  Ret;
+
+  if (HashValue == NULL) {
+    return FALSE;
+  }
+
+  if ((Data == NULL) && (DataSize != 0)) {
+    return FALSE;
+  }
+
+  Ret = mbedtls_sha1_ret (Data, DataSize, HashValue);
+  if (Ret != 0) {
+    return FALSE;
+  }
+
+  return TRUE;
+}
+
+#endif

--- a/CryptoPkg/Library/BaseCryptLibMbedTls/Hash/CryptSha1Null.c
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/Hash/CryptSha1Null.c
@@ -1,0 +1,166 @@
+/** @file
+  SHA-1 Digest Wrapper Null Implementation.
+
+Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "InternalCryptLib.h"
+
+/**
+  Retrieves the size, in bytes, of the context buffer required for SHA-1 hash operations.
+
+  @return  The size, in bytes, of the context buffer required for SHA-1 hash operations.
+
+**/
+UINTN
+EFIAPI
+Sha1GetContextSize (
+  VOID
+  )
+{
+  //
+  // Retrieves SHA Context Size
+  //
+  ASSERT (FALSE);
+  return 0;
+}
+
+/**
+  Initializes user-supplied memory pointed by Sha1Context as SHA-1 hash context for
+  subsequent use.
+
+  If Sha1Context is NULL, then return FALSE.
+
+  @param[out]  Sha1Context  Pointer to SHA-1 context being initialized.
+
+  @retval TRUE   SHA-1 context initialization succeeded.
+  @retval FALSE  SHA-1 context initialization failed.
+
+**/
+BOOLEAN
+EFIAPI
+Sha1Init (
+  OUT  VOID  *Sha1Context
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Makes a copy of an existing SHA-1 context.
+
+  If Sha1Context is NULL, then return FALSE.
+  If NewSha1Context is NULL, then return FALSE.
+
+  @param[in]  Sha1Context     Pointer to SHA-1 context being copied.
+  @param[out] NewSha1Context  Pointer to new SHA-1 context.
+
+  @retval TRUE   SHA-1 context copy succeeded.
+  @retval FALSE  SHA-1 context copy failed.
+
+**/
+BOOLEAN
+EFIAPI
+Sha1Duplicate (
+  IN   CONST VOID  *Sha1Context,
+  OUT  VOID        *NewSha1Context
+  )
+{
+  ASSERT (FALSE);
+
+  return FALSE;
+}
+
+/**
+  Digests the input data and updates SHA-1 context.
+
+  This function performs SHA-1 digest on a data buffer of the specified size.
+  It can be called multiple times to compute the digest of long or discontinuous data streams.
+  SHA-1 context should be already correctly initialized by Sha1Init(), and should not be finalized
+  by Sha1Final(). Behavior with invalid context is undefined.
+
+  If Sha1Context is NULL, then return FALSE.
+
+  @param[in, out]  Sha1Context  Pointer to the SHA-1 context.
+  @param[in]       Data         Pointer to the buffer containing the data to be hashed.
+  @param[in]       DataSize     Size of Data buffer in bytes.
+
+  @retval TRUE   SHA-1 data digest succeeded.
+  @retval FALSE  SHA-1 data digest failed.
+
+**/
+BOOLEAN
+EFIAPI
+Sha1Update (
+  IN OUT  VOID        *Sha1Context,
+  IN      CONST VOID  *Data,
+  IN      UINTN       DataSize
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Completes computation of the SHA-1 digest value.
+
+  This function completes SHA-1 hash computation and retrieves the digest value into
+  the specified memory. After this function has been called, the SHA-1 context cannot
+  be used again.
+  SHA-1 context should be already correctly initialized by Sha1Init(), and should not be
+  finalized by Sha1Final(). Behavior with invalid SHA-1 context is undefined.
+
+  If Sha1Context is NULL, then return FALSE.
+  If HashValue is NULL, then return FALSE.
+
+  @param[in, out]  Sha1Context  Pointer to the SHA-1 context.
+  @param[out]      HashValue    Pointer to a buffer that receives the SHA-1 digest
+                                value (20 bytes).
+
+  @retval TRUE   SHA-1 digest computation succeeded.
+  @retval FALSE  SHA-1 digest computation failed.
+
+**/
+BOOLEAN
+EFIAPI
+Sha1Final (
+  IN OUT  VOID   *Sha1Context,
+  OUT     UINT8  *HashValue
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Computes the SHA-1 message digest of a input data buffer.
+
+  This function performs the SHA-1 message digest of a given data buffer, and places
+  the digest value into the specified memory.
+
+  If this interface is not supported, then return FALSE.
+
+  @param[in]   Data        Pointer to the buffer containing the data to be hashed.
+  @param[in]   DataSize    Size of Data buffer in bytes.
+  @param[out]  HashValue   Pointer to a buffer that receives the SHA-1 digest
+                           value (20 bytes).
+
+  @retval TRUE   SHA-1 digest computation succeeded.
+  @retval FALSE  SHA-1 digest computation failed.
+  @retval FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+Sha1HashAll (
+  IN   CONST VOID  *Data,
+  IN   UINTN       DataSize,
+  OUT  UINT8       *HashValue
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}

--- a/CryptoPkg/Library/BaseCryptLibMbedTls/Hash/CryptSha256.c
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/Hash/CryptSha256.c
@@ -1,0 +1,219 @@
+/** @file
+  SHA-256 Digest Wrapper Implementation over MbedTLS.
+
+Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "InternalCryptLib.h"
+#include <mbedtls/sha256.h>
+#include <mbedtls/compat-2.x.h>
+
+/**
+  Retrieves the size, in bytes, of the context buffer required for SHA-256 hash operations.
+
+  @return  The size, in bytes, of the context buffer required for SHA-256 hash operations.
+
+**/
+UINTN
+EFIAPI
+Sha256GetContextSize (
+  VOID
+  )
+{
+  return (UINTN)(sizeof (mbedtls_sha256_context));
+}
+
+/**
+  Initializes user-supplied memory pointed by Sha256Context as SHA-256 hash context for
+  subsequent use.
+
+  If Sha256Context is NULL, then return FALSE.
+
+  @param[out]  Sha256Context  Pointer to SHA-256 context being initialized.
+
+  @retval TRUE   SHA-256 context initialization succeeded.
+  @retval FALSE  SHA-256 context initialization failed.
+
+**/
+BOOLEAN
+EFIAPI
+Sha256Init (
+  OUT  VOID  *Sha256Context
+  )
+{
+  INT32  Ret;
+
+  if (Sha256Context == NULL) {
+    return FALSE;
+  }
+
+  mbedtls_sha256_init (Sha256Context);
+
+  Ret = mbedtls_sha256_starts_ret (Sha256Context, FALSE);
+  if (Ret != 0) {
+    return FALSE;
+  }
+
+  return TRUE;
+}
+
+/**
+  Makes a copy of an existing SHA-256 context.
+
+  If Sha256Context is NULL, then return FALSE.
+  If NewSha256Context is NULL, then return FALSE.
+
+  @param[in]  Sha256Context     Pointer to SHA-256 context being copied.
+  @param[out] NewSha256Context  Pointer to new SHA-256 context.
+
+  @retval TRUE   SHA-256 context copy succeeded.
+  @retval FALSE  SHA-256 context copy failed.
+
+**/
+BOOLEAN
+EFIAPI
+Sha256Duplicate (
+  IN   CONST VOID  *Sha256Context,
+  OUT  VOID        *NewSha256Context
+  )
+{
+  if ((Sha256Context == NULL) || (NewSha256Context == NULL)) {
+    return FALSE;
+  }
+
+  mbedtls_sha256_clone (NewSha256Context, Sha256Context);
+
+  return TRUE;
+}
+
+/**
+  Digests the input data and updates SHA-256 context.
+
+  This function performs SHA-256 digest on a data buffer of the specified size.
+  It can be called multiple times to compute the digest of long or discontinuous data streams.
+  SHA-256 context should be already correctly initialized by Sha256Init(), and should not be finalized
+  by Sha256Final(). Behavior with invalid context is undefined.
+
+  If Sha256Context is NULL, then return FALSE.
+
+  @param[in, out]  Sha256Context  Pointer to the SHA-256 context.
+  @param[in]       Data           Pointer to the buffer containing the data to be hashed.
+  @param[in]       DataSize       Size of Data buffer in bytes.
+
+  @retval TRUE   SHA-256 data digest succeeded.
+  @retval FALSE  SHA-256 data digest failed.
+
+**/
+BOOLEAN
+EFIAPI
+Sha256Update (
+  IN OUT  VOID        *Sha256Context,
+  IN      CONST VOID  *Data,
+  IN      UINTN       DataSize
+  )
+{
+  INT32  Ret;
+
+  if (Sha256Context == NULL) {
+    return FALSE;
+  }
+
+  if ((Data == NULL) && (DataSize != 0)) {
+    return FALSE;
+  }
+
+  Ret = mbedtls_sha256_update_ret (Sha256Context, Data, DataSize);
+  if (Ret != 0) {
+    return FALSE;
+  }
+
+  return TRUE;
+}
+
+/**
+  Completes computation of the SHA-256 digest value.
+
+  This function completes SHA-256 hash computation and retrieves the digest value into
+  the specified memory. After this function has been called, the SHA-256 context cannot
+  be used again.
+  SHA-256 context should be already correctly initialized by Sha256Init(), and should not be
+  finalized by Sha256Final(). Behavior with invalid SHA-256 context is undefined.
+
+  If Sha256Context is NULL, then return FALSE.
+  If HashValue is NULL, then return FALSE.
+
+  @param[in, out]  Sha256Context  Pointer to the SHA-256 context.
+  @param[out]      HashValue      Pointer to a buffer that receives the SHA-256 digest
+                                  value (32 bytes).
+
+  @retval TRUE   SHA-256 digest computation succeeded.
+  @retval FALSE  SHA-256 digest computation failed.
+
+**/
+BOOLEAN
+EFIAPI
+Sha256Final (
+  IN OUT  VOID   *Sha256Context,
+  OUT     UINT8  *HashValue
+  )
+{
+  INT32  Ret;
+
+  if ((Sha256Context == NULL) || (HashValue == NULL)) {
+    return FALSE;
+  }
+
+  Ret = mbedtls_sha256_finish_ret (Sha256Context, HashValue);
+  mbedtls_sha256_free (Sha256Context);
+  if (Ret != 0) {
+    return FALSE;
+  }
+
+  return TRUE;
+}
+
+/**
+  Computes the SHA-256 message digest of a input data buffer.
+
+  This function performs the SHA-256 message digest of a given data buffer, and places
+  the digest value into the specified memory.
+
+  If this interface is not supported, then return FALSE.
+
+  @param[in]   Data        Pointer to the buffer containing the data to be hashed.
+  @param[in]   DataSize    Size of Data buffer in bytes.
+  @param[out]  HashValue   Pointer to a buffer that receives the SHA-256 digest
+                           value (32 bytes).
+
+  @retval TRUE   SHA-256 digest computation succeeded.
+  @retval FALSE  SHA-256 digest computation failed.
+  @retval FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+Sha256HashAll (
+  IN   CONST VOID  *Data,
+  IN   UINTN       DataSize,
+  OUT  UINT8       *HashValue
+  )
+{
+  INT32  Ret;
+
+  if (HashValue == NULL) {
+    return FALSE;
+  }
+
+  if ((Data == NULL) && (DataSize != 0)) {
+    return FALSE;
+  }
+
+  Ret = mbedtls_sha256_ret (Data, DataSize, HashValue, FALSE);
+  if (Ret != 0) {
+    return FALSE;
+  }
+
+  return TRUE;
+}

--- a/CryptoPkg/Library/BaseCryptLibMbedTls/Hash/CryptSha256Null.c
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/Hash/CryptSha256Null.c
@@ -1,0 +1,162 @@
+/** @file
+  SHA-256 Digest Wrapper Null Implementation.
+
+Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "InternalCryptLib.h"
+
+/**
+  Retrieves the size, in bytes, of the context buffer required for SHA-256 hash operations.
+
+  @return  The size, in bytes, of the context buffer required for SHA-256 hash operations.
+
+**/
+UINTN
+EFIAPI
+Sha256GetContextSize (
+  VOID
+  )
+{
+  ASSERT (FALSE);
+  return 0;
+}
+
+/**
+  Initializes user-supplied memory pointed by Sha256Context as SHA-256 hash context for
+  subsequent use.
+
+  If Sha256Context is NULL, then return FALSE.
+
+  @param[out]  Sha256Context  Pointer to SHA-256 context being initialized.
+
+  @retval TRUE   SHA-256 context initialization succeeded.
+  @retval FALSE  SHA-256 context initialization failed.
+
+**/
+BOOLEAN
+EFIAPI
+Sha256Init (
+  OUT  VOID  *Sha256Context
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Makes a copy of an existing SHA-256 context.
+
+  If Sha256Context is NULL, then return FALSE.
+  If NewSha256Context is NULL, then return FALSE.
+
+  @param[in]  Sha256Context     Pointer to SHA-256 context being copied.
+  @param[out] NewSha256Context  Pointer to new SHA-256 context.
+
+  @retval TRUE   SHA-256 context copy succeeded.
+  @retval FALSE  SHA-256 context copy failed.
+
+**/
+BOOLEAN
+EFIAPI
+Sha256Duplicate (
+  IN   CONST VOID  *Sha256Context,
+  OUT  VOID        *NewSha256Context
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Digests the input data and updates SHA-256 context.
+
+  This function performs SHA-256 digest on a data buffer of the specified size.
+  It can be called multiple times to compute the digest of long or discontinuous data streams.
+  SHA-256 context should be already correctly initialized by Sha256Init(), and should not be finalized
+  by Sha256Final(). Behavior with invalid context is undefined.
+
+  If Sha256Context is NULL, then return FALSE.
+
+  @param[in, out]  Sha256Context  Pointer to the SHA-256 context.
+  @param[in]       Data           Pointer to the buffer containing the data to be hashed.
+  @param[in]       DataSize       Size of Data buffer in bytes.
+
+  @retval TRUE   SHA-256 data digest succeeded.
+  @retval FALSE  SHA-256 data digest failed.
+
+**/
+BOOLEAN
+EFIAPI
+Sha256Update (
+  IN OUT  VOID        *Sha256Context,
+  IN      CONST VOID  *Data,
+  IN      UINTN       DataSize
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Completes computation of the SHA-256 digest value.
+
+  This function completes SHA-256 hash computation and retrieves the digest value into
+  the specified memory. After this function has been called, the SHA-256 context cannot
+  be used again.
+  SHA-256 context should be already correctly initialized by Sha256Init(), and should not be
+  finalized by Sha256Final(). Behavior with invalid SHA-256 context is undefined.
+
+  If Sha256Context is NULL, then return FALSE.
+  If HashValue is NULL, then return FALSE.
+
+  @param[in, out]  Sha256Context  Pointer to the SHA-256 context.
+  @param[out]      HashValue      Pointer to a buffer that receives the SHA-256 digest
+                                  value (32 bytes).
+
+  @retval TRUE   SHA-256 digest computation succeeded.
+  @retval FALSE  SHA-256 digest computation failed.
+
+**/
+BOOLEAN
+EFIAPI
+Sha256Final (
+  IN OUT  VOID   *Sha256Context,
+  OUT     UINT8  *HashValue
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Computes the SHA-256 message digest of a input data buffer.
+
+  This function performs the SHA-256 message digest of a given data buffer, and places
+  the digest value into the specified memory.
+
+  If this interface is not supported, then return FALSE.
+
+  @param[in]   Data        Pointer to the buffer containing the data to be hashed.
+  @param[in]   DataSize    Size of Data buffer in bytes.
+  @param[out]  HashValue   Pointer to a buffer that receives the SHA-256 digest
+                           value (32 bytes).
+
+  @retval TRUE   SHA-256 digest computation succeeded.
+  @retval FALSE  SHA-256 digest computation failed.
+  @retval FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+Sha256HashAll (
+  IN   CONST VOID  *Data,
+  IN   UINTN       DataSize,
+  OUT  UINT8       *HashValue
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}

--- a/CryptoPkg/Library/BaseCryptLibMbedTls/Hash/CryptSha512.c
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/Hash/CryptSha512.c
@@ -1,0 +1,431 @@
+/** @file
+  SHA-384 and SHA-512 Digest Wrapper Implementations over MbedTLS.
+
+Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "InternalCryptLib.h"
+#include <mbedtls/sha512.h>
+#include <mbedtls/compat-2.x.h>
+
+/**
+  Retrieves the size, in bytes, of the context buffer required for SHA-384 hash operations.
+
+  @return  The size, in bytes, of the context buffer required for SHA-384 hash operations.
+
+**/
+UINTN
+EFIAPI
+Sha384GetContextSize (
+  VOID
+  )
+{
+  return (UINTN)(sizeof (mbedtls_sha512_context));
+}
+
+/**
+  Initializes user-supplied memory pointed by Sha384Context as SHA-384 hash context for
+  subsequent use.
+
+  If Sha384Context is NULL, then return FALSE.
+
+  @param[out]  Sha384Context  Pointer to SHA-384 context being initialized.
+
+  @retval TRUE   SHA-384 context initialization succeeded.
+  @retval FALSE  SHA-384 context initialization failed.
+
+**/
+BOOLEAN
+EFIAPI
+Sha384Init (
+  OUT  VOID  *Sha384Context
+  )
+{
+  INT32  Ret;
+
+  if (Sha384Context == NULL) {
+    return FALSE;
+  }
+
+  mbedtls_sha512_init (Sha384Context);
+
+  Ret = mbedtls_sha512_starts_ret (Sha384Context, TRUE);
+  if (Ret != 0) {
+    return FALSE;
+  }
+
+  return TRUE;
+}
+
+/**
+  Makes a copy of an existing SHA-384 context.
+
+  If Sha384Context is NULL, then return FALSE.
+  If NewSha384Context is NULL, then return FALSE.
+  If this interface is not supported, then return FALSE.
+
+  @param[in]  Sha384Context     Pointer to SHA-384 context being copied.
+  @param[out] NewSha384Context  Pointer to new SHA-384 context.
+
+  @retval TRUE   SHA-384 context copy succeeded.
+  @retval FALSE  SHA-384 context copy failed.
+  @retval FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+Sha384Duplicate (
+  IN   CONST VOID  *Sha384Context,
+  OUT  VOID        *NewSha384Context
+  )
+{
+  if ((Sha384Context == NULL) || (NewSha384Context == NULL)) {
+    return FALSE;
+  }
+
+  mbedtls_sha512_clone (NewSha384Context, Sha384Context);
+
+  return TRUE;
+}
+
+/**
+  Digests the input data and updates SHA-384 context.
+
+  This function performs SHA-384 digest on a data buffer of the specified size.
+  It can be called multiple times to compute the digest of long or discontinuous data streams.
+  SHA-384 context should be already correctly initialized by Sha384Init(), and should not be finalized
+  by Sha384Final(). Behavior with invalid context is undefined.
+
+  If Sha384Context is NULL, then return FALSE.
+
+  @param[in, out]  Sha384Context  Pointer to the SHA-384 context.
+  @param[in]       Data           Pointer to the buffer containing the data to be hashed.
+  @param[in]       DataSize       Size of Data buffer in bytes.
+
+  @retval TRUE   SHA-384 data digest succeeded.
+  @retval FALSE  SHA-384 data digest failed.
+
+**/
+BOOLEAN
+EFIAPI
+Sha384Update (
+  IN OUT  VOID        *Sha384Context,
+  IN      CONST VOID  *Data,
+  IN      UINTN       DataSize
+  )
+{
+  INT32  Ret;
+
+  if (Sha384Context == NULL) {
+    return FALSE;
+  }
+
+  if ((Data == NULL) && (DataSize != 0)) {
+    return FALSE;
+  }
+
+  Ret = mbedtls_sha512_update_ret (Sha384Context, Data, DataSize);
+  if (Ret != 0) {
+    return FALSE;
+  }
+
+  return TRUE;
+}
+
+/**
+  Completes computation of the SHA-384 digest value.
+
+  This function completes SHA-384 hash computation and retrieves the digest value into
+  the specified memory. After this function has been called, the SHA-384 context cannot
+  be used again.
+  SHA-384 context should be already correctly initialized by Sha384Init(), and should not be
+  finalized by Sha384Final(). Behavior with invalid SHA-384 context is undefined.
+
+  If Sha384Context is NULL, then return FALSE.
+  If HashValue is NULL, then return FALSE.
+
+  @param[in, out]  Sha384Context  Pointer to the SHA-384 context.
+  @param[out]      HashValue      Pointer to a buffer that receives the SHA-384 digest
+                                  value (48 bytes).
+
+  @retval TRUE   SHA-384 digest computation succeeded.
+  @retval FALSE  SHA-384 digest computation failed.
+
+**/
+BOOLEAN
+EFIAPI
+Sha384Final (
+  IN OUT  VOID   *Sha384Context,
+  OUT     UINT8  *HashValue
+  )
+{
+  INT32  Ret;
+
+  if ((Sha384Context == NULL) || (HashValue == NULL)) {
+    return FALSE;
+  }
+
+  Ret = mbedtls_sha512_finish_ret (Sha384Context, HashValue);
+  mbedtls_sha512_free (Sha384Context);
+  if (Ret != 0) {
+    return FALSE;
+  }
+
+  return TRUE;
+}
+
+/**
+  Computes the SHA-384 message digest of a input data buffer.
+
+  This function performs the SHA-384 message digest of a given data buffer, and places
+  the digest value into the specified memory.
+
+  If this interface is not supported, then return FALSE.
+
+  @param[in]   Data        Pointer to the buffer containing the data to be hashed.
+  @param[in]   DataSize    Size of Data buffer in bytes.
+  @param[out]  HashValue   Pointer to a buffer that receives the SHA-384 digest
+                           value (48 bytes).
+
+  @retval TRUE   SHA-384 digest computation succeeded.
+  @retval FALSE  SHA-384 digest computation failed.
+  @retval FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+Sha384HashAll (
+  IN   CONST VOID  *Data,
+  IN   UINTN       DataSize,
+  OUT  UINT8       *HashValue
+  )
+{
+  INT32  Ret;
+
+  if (HashValue == NULL) {
+    return FALSE;
+  }
+
+  if ((Data == NULL) && (DataSize != 0)) {
+    return FALSE;
+  }
+
+  Ret = mbedtls_sha512_ret (Data, DataSize, HashValue, TRUE);
+  if (Ret != 0) {
+    return FALSE;
+  }
+
+  return TRUE;
+}
+
+/**
+  Retrieves the size, in bytes, of the context buffer required for SHA-512 hash operations.
+
+  @return  The size, in bytes, of the context buffer required for SHA-512 hash operations.
+
+**/
+UINTN
+EFIAPI
+Sha512GetContextSize (
+  VOID
+  )
+{
+  return (UINTN)(sizeof (mbedtls_sha512_context));
+}
+
+/**
+  Initializes user-supplied memory pointed by Sha512Context as SHA-512 hash context for
+  subsequent use.
+
+  If Sha512Context is NULL, then return FALSE.
+
+  @param[out]  Sha512Context  Pointer to SHA-512 context being initialized.
+
+  @retval TRUE   SHA-512 context initialization succeeded.
+  @retval FALSE  SHA-512 context initialization failed.
+
+**/
+BOOLEAN
+EFIAPI
+Sha512Init (
+  OUT  VOID  *Sha512Context
+  )
+{
+  INT32  Ret;
+
+  if (Sha512Context == NULL) {
+    return FALSE;
+  }
+
+  mbedtls_sha512_init (Sha512Context);
+
+  Ret = mbedtls_sha512_starts_ret (Sha512Context, FALSE);
+  if (Ret != 0) {
+    return FALSE;
+  }
+
+  return TRUE;
+}
+
+/**
+  Makes a copy of an existing SHA-512 context.
+
+  If Sha512Context is NULL, then return FALSE.
+  If NewSha512Context is NULL, then return FALSE.
+  If this interface is not supported, then return FALSE.
+
+  @param[in]  Sha512Context     Pointer to SHA-512 context being copied.
+  @param[out] NewSha512Context  Pointer to new SHA-512 context.
+
+  @retval TRUE   SHA-512 context copy succeeded.
+  @retval FALSE  SHA-512 context copy failed.
+  @retval FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+Sha512Duplicate (
+  IN   CONST VOID  *Sha512Context,
+  OUT  VOID        *NewSha512Context
+  )
+{
+  if ((Sha512Context == NULL) || (NewSha512Context == NULL)) {
+    return FALSE;
+  }
+
+  mbedtls_sha512_clone (NewSha512Context, Sha512Context);
+
+  return TRUE;
+}
+
+/**
+  Digests the input data and updates SHA-512 context.
+
+  This function performs SHA-512 digest on a data buffer of the specified size.
+  It can be called multiple times to compute the digest of long or discontinuous data streams.
+  SHA-512 context should be already correctly initialized by Sha512Init(), and should not be finalized
+  by Sha512Final(). Behavior with invalid context is undefined.
+
+  If Sha512Context is NULL, then return FALSE.
+
+  @param[in, out]  Sha512Context  Pointer to the SHA-512 context.
+  @param[in]       Data           Pointer to the buffer containing the data to be hashed.
+  @param[in]       DataSize       Size of Data buffer in bytes.
+
+  @retval TRUE   SHA-512 data digest succeeded.
+  @retval FALSE  SHA-512 data digest failed.
+
+**/
+BOOLEAN
+EFIAPI
+Sha512Update (
+  IN OUT  VOID        *Sha512Context,
+  IN      CONST VOID  *Data,
+  IN      UINTN       DataSize
+  )
+{
+  INT32  Ret;
+
+  if (Sha512Context == NULL) {
+    return FALSE;
+  }
+
+  if ((Data == NULL) && (DataSize != 0)) {
+    return FALSE;
+  }
+
+  Ret = mbedtls_sha512_update_ret (Sha512Context, Data, DataSize);
+  if (Ret != 0) {
+    return FALSE;
+  }
+
+  return TRUE;
+}
+
+/**
+  Completes computation of the SHA-512 digest value.
+
+  This function completes SHA-512 hash computation and retrieves the digest value into
+  the specified memory. After this function has been called, the SHA-512 context cannot
+  be used again.
+  SHA-512 context should be already correctly initialized by Sha512Init(), and should not be
+  finalized by Sha512Final(). Behavior with invalid SHA-512 context is undefined.
+
+  If Sha512Context is NULL, then return FALSE.
+  If HashValue is NULL, then return FALSE.
+
+  @param[in, out]  Sha512Context  Pointer to the SHA-512 context.
+  @param[out]      HashValue      Pointer to a buffer that receives the SHA-512 digest
+                                  value (64 bytes).
+
+  @retval TRUE   SHA-512 digest computation succeeded.
+  @retval FALSE  SHA-512 digest computation failed.
+
+**/
+BOOLEAN
+EFIAPI
+Sha512Final (
+  IN OUT  VOID   *Sha512Context,
+  OUT     UINT8  *HashValue
+  )
+{
+  INT32  Ret;
+
+  if ((Sha512Context == NULL) || (HashValue == NULL)) {
+    return FALSE;
+  }
+
+  Ret = mbedtls_sha512_finish_ret (Sha512Context, HashValue);
+  mbedtls_sha512_free (Sha512Context);
+  if (Ret != 0) {
+    return FALSE;
+  }
+
+  return TRUE;
+}
+
+/**
+  Computes the SHA-512 message digest of a input data buffer.
+
+  This function performs the SHA-512 message digest of a given data buffer, and places
+  the digest value into the specified memory.
+
+  If this interface is not supported, then return FALSE.
+
+  @param[in]   Data        Pointer to the buffer containing the data to be hashed.
+  @param[in]   DataSize    Size of Data buffer in bytes.
+  @param[out]  HashValue   Pointer to a buffer that receives the SHA-512 digest
+                           value (64 bytes).
+
+  @retval TRUE   SHA-512 digest computation succeeded.
+  @retval FALSE  SHA-512 digest computation failed.
+  @retval FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+Sha512HashAll (
+  IN   CONST VOID  *Data,
+  IN   UINTN       DataSize,
+  OUT  UINT8       *HashValue
+  )
+{
+  INT32  Ret;
+
+  if (HashValue == NULL) {
+    return FALSE;
+  }
+
+  if ((Data == NULL) && (DataSize != 0)) {
+    return FALSE;
+  }
+
+  Ret = mbedtls_sha512_ret (Data, DataSize, HashValue, FALSE);
+  if (Ret != 0) {
+    return FALSE;
+  }
+
+  return TRUE;
+}

--- a/CryptoPkg/Library/BaseCryptLibMbedTls/Hash/CryptSha512Null.c
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/Hash/CryptSha512Null.c
@@ -1,0 +1,275 @@
+/** @file
+  SHA-384 and SHA-512 Digest Wrapper Implementations which does not provide real capabilities.
+
+Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "InternalCryptLib.h"
+
+/**
+  Retrieves the size, in bytes, of the context buffer required for SHA-384 hash operations.
+
+  Return zero to indicate this interface is not supported.
+
+  @retval  0   This interface is not supported.
+
+**/
+UINTN
+EFIAPI
+Sha384GetContextSize (
+  VOID
+  )
+{
+  ASSERT (FALSE);
+  return 0;
+}
+
+/**
+  Initializes user-supplied memory pointed by Sha384Context as SHA-384 hash context for
+  subsequent use.
+
+  Return FALSE to indicate this interface is not supported.
+
+  @param[out]  Sha384Context  Pointer to SHA-384 context being initialized.
+
+  @retval FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+Sha384Init (
+  OUT  VOID  *Sha384Context
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Makes a copy of an existing SHA-384 context.
+
+  Return FALSE to indicate this interface is not supported.
+
+  @param[in]  Sha384Context     Pointer to SHA-384 context being copied.
+  @param[out] NewSha384Context  Pointer to new SHA-384 context.
+
+  @retval FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+Sha384Duplicate (
+  IN   CONST VOID  *Sha384Context,
+  OUT  VOID        *NewSha384Context
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Digests the input data and updates SHA-384 context.
+
+  Return FALSE to indicate this interface is not supported.
+
+  @param[in, out]  Sha384Context  Pointer to the SHA-384 context.
+  @param[in]       Data           Pointer to the buffer containing the data to be hashed.
+  @param[in]       DataSize       Size of Data buffer in bytes.
+
+  @retval FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+Sha384Update (
+  IN OUT  VOID        *Sha384Context,
+  IN      CONST VOID  *Data,
+  IN      UINTN       DataSize
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Completes computation of the SHA-384 digest value.
+
+  Return FALSE to indicate this interface is not supported.
+
+  @param[in, out]  Sha384Context  Pointer to the SHA-384 context.
+  @param[out]      HashValue      Pointer to a buffer that receives the SHA-384 digest
+                                  value (48 bytes).
+
+  @retval FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+Sha384Final (
+  IN OUT  VOID   *Sha384Context,
+  OUT     UINT8  *HashValue
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Computes the SHA-384 message digest of a input data buffer.
+
+  Return FALSE to indicate this interface is not supported.
+
+  @param[in]   Data        Pointer to the buffer containing the data to be hashed.
+  @param[in]   DataSize    Size of Data buffer in bytes.
+  @param[out]  HashValue   Pointer to a buffer that receives the SHA-384 digest
+                           value (48 bytes).
+
+  @retval FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+Sha384HashAll (
+  IN   CONST VOID  *Data,
+  IN   UINTN       DataSize,
+  OUT  UINT8       *HashValue
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Retrieves the size, in bytes, of the context buffer required for SHA-512 hash operations.
+
+  Return zero to indicate this interface is not supported.
+
+  @retval  0   This interface is not supported.
+
+**/
+UINTN
+EFIAPI
+Sha512GetContextSize (
+  VOID
+  )
+{
+  ASSERT (FALSE);
+  return 0;
+}
+
+/**
+  Initializes user-supplied memory pointed by Sha512Context as SHA-512 hash context for
+  subsequent use.
+
+  Return FALSE to indicate this interface is not supported.
+
+  @param[out]  Sha512Context  Pointer to SHA-512 context being initialized.
+
+  @retval FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+Sha512Init (
+  OUT  VOID  *Sha512Context
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Makes a copy of an existing SHA-512 context.
+
+  Return FALSE to indicate this interface is not supported.
+
+  @param[in]  Sha512Context     Pointer to SHA-512 context being copied.
+  @param[out] NewSha512Context  Pointer to new SHA-512 context.
+
+  @retval FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+Sha512Duplicate (
+  IN   CONST VOID  *Sha512Context,
+  OUT  VOID        *NewSha512Context
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Digests the input data and updates SHA-512 context.
+
+  Return FALSE to indicate this interface is not supported.
+
+  @param[in, out]  Sha512Context  Pointer to the SHA-512 context.
+  @param[in]       Data           Pointer to the buffer containing the data to be hashed.
+  @param[in]       DataSize       Size of Data buffer in bytes.
+
+  @retval FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+Sha512Update (
+  IN OUT  VOID        *Sha512Context,
+  IN      CONST VOID  *Data,
+  IN      UINTN       DataSize
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Completes computation of the SHA-512 digest value.
+
+  Return FALSE to indicate this interface is not supported.
+
+  @param[in, out]  Sha512Context  Pointer to the SHA-512 context.
+  @param[out]      HashValue      Pointer to a buffer that receives the SHA-512 digest
+                                  value (64 bytes).
+
+  @retval FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+Sha512Final (
+  IN OUT  VOID   *Sha512Context,
+  OUT     UINT8  *HashValue
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Computes the SHA-512 message digest of a input data buffer.
+
+  Return FALSE to indicate this interface is not supported.
+
+  @param[in]   Data        Pointer to the buffer containing the data to be hashed.
+  @param[in]   DataSize    Size of Data buffer in bytes.
+  @param[out]  HashValue   Pointer to a buffer that receives the SHA-512 digest
+                           value (64 bytes).
+
+  @retval FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+Sha512HashAll (
+  IN   CONST VOID  *Data,
+  IN   UINTN       DataSize,
+  OUT  UINT8       *HashValue
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}

--- a/CryptoPkg/Library/BaseCryptLibMbedTls/Hash/CryptSm3Null.c
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/Hash/CryptSm3Null.c
@@ -1,0 +1,164 @@
+/** @file
+  SM3 Digest Wrapper Null Implementation.
+
+Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "InternalCryptLib.h"
+
+/**
+  Retrieves the size, in bytes, of the context buffer required for SM3 hash operations.
+
+  @return  The size, in bytes, of the context buffer required for SM3 hash operations.
+
+**/
+UINTN
+EFIAPI
+Sm3GetContextSize (
+  VOID
+  )
+{
+  ASSERT (FALSE);
+  return 0;
+}
+
+/**
+  Initializes user-supplied memory pointed by Sm3Context as SM3 hash context for
+  subsequent use.
+
+  If Sm3Context is NULL, then return FALSE.
+
+  @param[out]  Sm3Context  Pointer to SM3 context being initialized.
+
+  @retval TRUE   SM3 context initialization succeeded.
+  @retval FALSE  SM3 context initialization failed.
+
+**/
+BOOLEAN
+EFIAPI
+Sm3Init (
+  OUT  VOID  *Sm3Context
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Makes a copy of an existing SM3 context.
+
+  If Sm3Context is NULL, then return FALSE.
+  If NewSm3Context is NULL, then return FALSE.
+  If this interface is not supported, then return FALSE.
+
+  @param[in]  Sm3Context     Pointer to SM3 context being copied.
+  @param[out] NewSm3Context  Pointer to new SM3 context.
+
+  @retval TRUE   SM3 context copy succeeded.
+  @retval FALSE  SM3 context copy failed.
+  @retval FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+Sm3Duplicate (
+  IN   CONST VOID  *Sm3Context,
+  OUT  VOID        *NewSm3Context
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Digests the input data and updates SM3 context.
+
+  This function performs SM3 digest on a data buffer of the specified size.
+  It can be called multiple times to compute the digest of long or discontinuous data streams.
+  SM3 context should be already correctly initialized by Sm3Init(), and should not be finalized
+  by Sm3Final(). Behavior with invalid context is undefined.
+
+  If Sm3Context is NULL, then return FALSE.
+
+  @param[in, out]  Sm3Context     Pointer to the SM3 context.
+  @param[in]       Data           Pointer to the buffer containing the data to be hashed.
+  @param[in]       DataSize       Size of Data buffer in bytes.
+
+  @retval TRUE   SM3 data digest succeeded.
+  @retval FALSE  SM3 data digest failed.
+
+**/
+BOOLEAN
+EFIAPI
+Sm3Update (
+  IN OUT  VOID        *Sm3Context,
+  IN      CONST VOID  *Data,
+  IN      UINTN       DataSize
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Completes computation of the SM3 digest value.
+
+  This function completes SM3 hash computation and retrieves the digest value into
+  the specified memory. After this function has been called, the SM3 context cannot
+  be used again.
+  SM3 context should be already correctly initialized by Sm3Init(), and should not be
+  finalized by Sm3Final(). Behavior with invalid SM3 context is undefined.
+
+  If Sm3Context is NULL, then return FALSE.
+  If HashValue is NULL, then return FALSE.
+
+  @param[in, out]  Sm3Context     Pointer to the SM3 context.
+  @param[out]      HashValue      Pointer to a buffer that receives the SM3 digest
+                                  value (32 bytes).
+
+  @retval TRUE   SM3 digest computation succeeded.
+  @retval FALSE  SM3 digest computation failed.
+
+**/
+BOOLEAN
+EFIAPI
+Sm3Final (
+  IN OUT  VOID   *Sm3Context,
+  OUT     UINT8  *HashValue
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Computes the SM3 message digest of a input data buffer.
+
+  This function performs the SM3 message digest of a given data buffer, and places
+  the digest value into the specified memory.
+
+  If this interface is not supported, then return FALSE.
+
+  @param[in]   Data        Pointer to the buffer containing the data to be hashed.
+  @param[in]   DataSize    Size of Data buffer in bytes.
+  @param[out]  HashValue   Pointer to a buffer that receives the SM3 digest
+                           value (32 bytes).
+
+  @retval TRUE   SM3 digest computation succeeded.
+  @retval FALSE  SM3 digest computation failed.
+  @retval FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+Sm3HashAll (
+  IN   CONST VOID  *Data,
+  IN   UINTN       DataSize,
+  OUT  UINT8       *HashValue
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}

--- a/CryptoPkg/Library/BaseCryptLibMbedTls/Hmac/CryptHmac.c
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/Hmac/CryptHmac.c
@@ -1,0 +1,678 @@
+/** @file
+  HMAC-SHA256 Wrapper Implementation over MbedTLS.
+
+Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "InternalCryptLib.h"
+#include <mbedtls/md.h>
+
+/**
+  Allocates and initializes one HMAC_CTX context for subsequent HMAC-MD use.
+
+  @return  Pointer to the HMAC_CTX context that has been initialized.
+           If the allocations fails, HmacShaMdNew() returns NULL.
+
+**/
+STATIC
+VOID *
+HmacMdNew (
+  VOID
+  )
+{
+  VOID  *HmacMdCtx;
+
+  HmacMdCtx = AllocateZeroPool (sizeof (mbedtls_md_context_t));
+  if (HmacMdCtx == NULL) {
+    return NULL;
+  }
+
+  return HmacMdCtx;
+}
+
+/**
+  Release the specified HMAC_CTX context.
+
+  @param[in]  HmacMdCtx  Pointer to the HMAC_CTX context to be released.
+
+**/
+VOID
+HmacMdFree (
+  IN  VOID  *HmacMdCtx
+  )
+{
+  mbedtls_md_free (HmacMdCtx);
+  if (HmacMdCtx != NULL) {
+    FreePool (HmacMdCtx);
+  }
+}
+
+/**
+  Set user-supplied key for subsequent use. It must be done before any
+  calling to HmacMdUpdate().
+
+  If HmacMdContext is NULL, then return FALSE.
+
+  @param[in]   MdType             Message Digest Type.
+  @param[out]  HmacMdContext      Pointer to HMAC-MD context.
+  @param[in]   Key                Pointer to the user-supplied key.
+  @param[in]   KeySize            Key size in bytes.
+
+  @retval TRUE   The Key is set successfully.
+  @retval FALSE  The Key is set unsuccessfully.
+
+**/
+STATIC
+BOOLEAN
+HmacMdSetKey (
+  IN   mbedtls_md_type_t  MdType,
+  OUT  VOID               *HmacMdContext,
+  IN   CONST UINT8        *Key,
+  IN   UINTN              KeySize
+  )
+{
+  const mbedtls_md_info_t  *md_info;
+  INT32                    Ret;
+
+  if ((HmacMdContext == NULL) || (KeySize > INT_MAX)) {
+    return FALSE;
+  }
+
+  ZeroMem (HmacMdContext, sizeof (mbedtls_md_context_t));
+  mbedtls_md_init (HmacMdContext);
+
+  md_info = mbedtls_md_info_from_type (MdType);
+  ASSERT (md_info != NULL);
+
+  Ret = mbedtls_md_setup (HmacMdContext, md_info, 1);
+  if (Ret != 0) {
+    return FALSE;
+  }
+
+  Ret = mbedtls_md_hmac_starts (HmacMdContext, Key, KeySize);
+  if (Ret != 0) {
+    return FALSE;
+  }
+
+  return TRUE;
+}
+
+/**
+  Return block size in md_type.
+
+  @param[in]  MdType            message digest Type.
+
+  @retval blocksize in md_type.
+
+**/
+int
+HmacMdGetBlockSize (
+  mbedtls_md_type_t  MdType
+  )
+{
+  switch (MdType) {
+    case MBEDTLS_MD_SHA256:
+      return 64;
+    case MBEDTLS_MD_SHA384:
+      return 128;
+    default:
+      ASSERT (FALSE);
+      return 0;
+  }
+}
+
+/**
+  Makes a copy of an existing HMAC-MD context.
+
+  If HmacMdContext is NULL, then return FALSE.
+  If NewHmacMdContext is NULL, then return FALSE.
+
+  @param[in]  MdType            message digest Type.
+  @param[in]  HmacMdContext     Pointer to HMAC-MD context being copied.
+  @param[out] NewHmacMdContext  Pointer to new HMAC-MD context.
+
+  @retval TRUE   HMAC-MD context copy succeeded.
+  @retval FALSE  HMAC-MD context copy failed.
+
+**/
+STATIC
+BOOLEAN
+HmacMdDuplicate (
+  IN   CONST mbedtls_md_type_t  MdType,
+  IN   CONST VOID               *HmacMdContext,
+  OUT  VOID                     *NewHmacMdContext
+  )
+{
+  INT32                    Ret;
+  CONST mbedtls_md_info_t  *md_info;
+  mbedtls_md_context_t     *MdContext;
+
+  if ((HmacMdContext == NULL) || (NewHmacMdContext == NULL)) {
+    return FALSE;
+  }
+
+  ZeroMem (NewHmacMdContext, sizeof (mbedtls_md_context_t));
+  mbedtls_md_init (NewHmacMdContext);
+  md_info = mbedtls_md_info_from_type (MdType);
+  ASSERT (md_info != NULL);
+
+  Ret = mbedtls_md_setup (NewHmacMdContext, md_info, 1);
+  if (Ret != 0) {
+    return FALSE;
+  }
+
+  MdContext = (mbedtls_md_context_t *)NewHmacMdContext;
+
+  Ret = mbedtls_md_clone (NewHmacMdContext, HmacMdContext);
+  if (Ret != 0) {
+    if (MdContext->md_ctx != NULL) {
+      mbedtls_free (MdContext->md_ctx);
+    }
+
+    if (MdContext->hmac_ctx != NULL) {
+      mbedtls_free (MdContext->hmac_ctx);
+    }
+
+    return FALSE;
+  }
+
+  CopyMem (
+    ((mbedtls_md_context_t *)NewHmacMdContext)->hmac_ctx,
+    ((CONST mbedtls_md_context_t *)HmacMdContext)->hmac_ctx,
+    HmacMdGetBlockSize (MdType) * 2
+    );
+
+  return TRUE;
+}
+
+/**
+  Digests the input data and updates HMAC-MD context.
+
+  This function performs HMAC-MD digest on a data buffer of the specified size.
+  It can be called multiple times to compute the digest of long or discontinuous data streams.
+  HMAC-MD context should be initialized by HmacMdNew(), and should not be finalized
+  by HmacMdFinal(). Behavior with invalid context is undefined.
+
+  If HmacMdContext is NULL, then return FALSE.
+
+  @param[in, out]  HmacMdContext     Pointer to the HMAC-MD context.
+  @param[in]       Data              Pointer to the buffer containing the data to be digested.
+  @param[in]       DataSize          Size of Data buffer in bytes.
+
+  @retval TRUE   HMAC-MD data digest succeeded.
+  @retval FALSE  HMAC-MD data digest failed.
+
+**/
+STATIC
+BOOLEAN
+HmacMdUpdate (
+  IN OUT  VOID        *HmacMdContext,
+  IN      CONST VOID  *Data,
+  IN      UINTN       DataSize
+  )
+{
+  INT32  Ret;
+
+  if (HmacMdContext == NULL) {
+    return FALSE;
+  }
+
+  if ((Data == NULL) && (DataSize != 0)) {
+    return FALSE;
+  }
+
+  if (DataSize > INT_MAX) {
+    return FALSE;
+  }
+
+  Ret = mbedtls_md_hmac_update (HmacMdContext, Data, DataSize);
+  if (Ret != 0) {
+    return FALSE;
+  }
+
+  return TRUE;
+}
+
+/**
+  Completes computation of the HMAC-MD digest value.
+
+  This function completes HMAC-MD hash computation and retrieves the digest value into
+  the specified memory. After this function has been called, the HMAC-MD context cannot
+  be used again.
+  HMAC-MD context should be initialized by HmacMdNew(), and should not be finalized
+  by HmacMdFinal(). Behavior with invalid HMAC-MD context is undefined.
+
+  If HmacMdContext is NULL, then return FALSE.
+  If HmacValue is NULL, then return FALSE.
+
+  @param[in, out]  HmacMdContext      Pointer to the HMAC-MD context.
+  @param[out]      HmacValue          Pointer to a buffer that receives the HMAC-MD digest
+                                      value.
+
+  @retval TRUE   HMAC-MD digest computation succeeded.
+  @retval FALSE  HMAC-MD digest computation failed.
+
+**/
+STATIC
+BOOLEAN
+HmacMdFinal (
+  IN OUT  VOID   *HmacMdContext,
+  OUT     UINT8  *HmacValue
+  )
+{
+  INT32  Ret;
+
+  if ((HmacMdContext == NULL) || (HmacValue == NULL)) {
+    return FALSE;
+  }
+
+  Ret = mbedtls_md_hmac_finish (HmacMdContext, HmacValue);
+  if (Ret != 0) {
+    return FALSE;
+  }
+
+  Ret = mbedtls_md_hmac_reset (HmacMdContext);
+  if (Ret != 0) {
+    return FALSE;
+  }
+
+  return TRUE;
+}
+
+/**
+  Computes the HMAC-MD digest of a input data buffer.
+
+  This function performs the HMAC-MD digest of a given data buffer, and places
+  the digest value into the specified memory.
+
+  If this interface is not supported, then return FALSE.
+
+  @param[in]   MdType      Message Digest Type.
+  @param[in]   Data        Pointer to the buffer containing the data to be digested.
+  @param[in]   DataSize    Size of Data buffer in bytes.
+  @param[in]   Key         Pointer to the user-supplied key.
+  @param[in]   KeySize     Key size in bytes.
+  @param[out]  HmacValue   Pointer to a buffer that receives the HMAC-MD digest
+                           value.
+
+  @retval TRUE   HMAC-MD digest computation succeeded.
+  @retval FALSE  HMAC-MD digest computation failed.
+  @retval FALSE  This interface is not supported.
+
+**/
+STATIC
+BOOLEAN
+HmacMdAll (
+  IN   mbedtls_md_type_t  MdType,
+  IN   CONST VOID         *Data,
+  IN   UINTN              DataSize,
+  IN   CONST UINT8        *Key,
+  IN   UINTN              KeySize,
+  OUT  UINT8              *HmacValue
+  )
+{
+  const mbedtls_md_info_t  *md_info;
+  INT32                    Ret;
+
+  md_info = mbedtls_md_info_from_type (MdType);
+  ASSERT (md_info != NULL);
+
+  Ret = mbedtls_md_hmac (md_info, Key, KeySize, Data, DataSize, HmacValue);
+  if (Ret != 0) {
+    return FALSE;
+  }
+
+  return TRUE;
+}
+
+/**
+  Allocates and initializes one HMAC_CTX context for subsequent HMAC-SHA256 use.
+
+  @return  Pointer to the HMAC_CTX context that has been initialized.
+           If the allocations fails, HmacSha256New() returns NULL.
+
+**/
+VOID *
+EFIAPI
+HmacSha256New (
+  VOID
+  )
+{
+  return HmacMdNew ();
+}
+
+/**
+  Release the specified HMAC_CTX context.
+
+  @param[in]  HmacSha256Ctx  Pointer to the HMAC_CTX context to be released.
+
+**/
+VOID
+EFIAPI
+HmacSha256Free (
+  IN  VOID  *HmacSha256Ctx
+  )
+{
+  HmacMdFree (HmacSha256Ctx);
+}
+
+/**
+  Set user-supplied key for subsequent use. It must be done before any
+  calling to HmacSha256Update().
+
+  If HmacSha256Context is NULL, then return FALSE.
+
+  @param[out]  HmacSha256Context  Pointer to HMAC-SHA256 context.
+  @param[in]   Key                Pointer to the user-supplied key.
+  @param[in]   KeySize            Key size in bytes.
+
+  @retval TRUE   The Key is set successfully.
+  @retval FALSE  The Key is set unsuccessfully.
+
+**/
+BOOLEAN
+EFIAPI
+HmacSha256SetKey (
+  OUT  VOID         *HmacSha256Context,
+  IN   CONST UINT8  *Key,
+  IN   UINTN        KeySize
+  )
+{
+  return HmacMdSetKey (MBEDTLS_MD_SHA256, HmacSha256Context, Key, KeySize);
+}
+
+/**
+  Makes a copy of an existing HMAC-SHA256 context.
+
+  If HmacSha256Context is NULL, then return FALSE.
+  If NewHmacSha256Context is NULL, then return FALSE.
+
+  @param[in]  HmacSha256Context     Pointer to HMAC-SHA256 context being copied.
+  @param[out] NewHmacSha256Context  Pointer to new HMAC-SHA256 context.
+
+  @retval TRUE   HMAC-SHA256 context copy succeeded.
+  @retval FALSE  HMAC-SHA256 context copy failed.
+
+**/
+BOOLEAN
+EFIAPI
+HmacSha256Duplicate (
+  IN   CONST VOID  *HmacSha256Context,
+  OUT  VOID        *NewHmacSha256Context
+  )
+{
+  return HmacMdDuplicate (MBEDTLS_MD_SHA256, HmacSha256Context, NewHmacSha256Context);
+}
+
+/**
+  Digests the input data and updates HMAC-SHA256 context.
+
+  This function performs HMAC-SHA256 digest on a data buffer of the specified size.
+  It can be called multiple times to compute the digest of long or discontinuous data streams.
+  HMAC-SHA256 context should be initialized by HmacSha256New(), and should not be finalized
+  by HmacSha256Final(). Behavior with invalid context is undefined.
+
+  If HmacSha256Context is NULL, then return FALSE.
+
+  @param[in, out]  HmacSha256Context Pointer to the HMAC-SHA256 context.
+  @param[in]       Data              Pointer to the buffer containing the data to be digested.
+  @param[in]       DataSize          Size of Data buffer in bytes.
+
+  @retval TRUE   HMAC-SHA256 data digest succeeded.
+  @retval FALSE  HMAC-SHA256 data digest failed.
+
+**/
+BOOLEAN
+EFIAPI
+HmacSha256Update (
+  IN OUT  VOID        *HmacSha256Context,
+  IN      CONST VOID  *Data,
+  IN      UINTN       DataSize
+  )
+{
+  return HmacMdUpdate (HmacSha256Context, Data, DataSize);
+}
+
+/**
+  Completes computation of the HMAC-SHA256 digest value.
+
+  This function completes HMAC-SHA256 hash computation and retrieves the digest value into
+  the specified memory. After this function has been called, the HMAC-SHA256 context cannot
+  be used again.
+  HMAC-SHA256 context should be initialized by HmacSha256New(), and should not be finalized
+  by HmacSha256Final(). Behavior with invalid HMAC-SHA256 context is undefined.
+
+  If HmacSha256Context is NULL, then return FALSE.
+  If HmacValue is NULL, then return FALSE.
+
+  @param[in, out]  HmacSha256Context  Pointer to the HMAC-SHA256 context.
+  @param[out]      HmacValue          Pointer to a buffer that receives the HMAC-SHA256 digest
+                                      value (32 bytes).
+
+  @retval TRUE   HMAC-SHA256 digest computation succeeded.
+  @retval FALSE  HMAC-SHA256 digest computation failed.
+
+**/
+BOOLEAN
+EFIAPI
+HmacSha256Final (
+  IN OUT  VOID   *HmacSha256Context,
+  OUT     UINT8  *HmacValue
+  )
+{
+  return HmacMdFinal (HmacSha256Context, HmacValue);
+}
+
+/**
+  Computes the HMAC-SHA256 digest of a input data buffer.
+
+  This function performs the HMAC-SHA256 digest of a given data buffer, and places
+  the digest value into the specified memory.
+
+  If this interface is not supported, then return FALSE.
+
+  @param[in]   Data        Pointer to the buffer containing the data to be digested.
+  @param[in]   DataSize    Size of Data buffer in bytes.
+  @param[in]   Key         Pointer to the user-supplied key.
+  @param[in]   KeySize     Key size in bytes.
+  @param[out]  HmacValue   Pointer to a buffer that receives the HMAC-SHA256 digest
+                           value (32 bytes).
+
+  @retval TRUE   HMAC-SHA256 digest computation succeeded.
+  @retval FALSE  HMAC-SHA256 digest computation failed.
+  @retval FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+HmacSha256All (
+  IN   CONST VOID   *Data,
+  IN   UINTN        DataSize,
+  IN   CONST UINT8  *Key,
+  IN   UINTN        KeySize,
+  OUT  UINT8        *HmacValue
+  )
+{
+  return HmacMdAll (MBEDTLS_MD_SHA256, Data, DataSize, Key, KeySize, HmacValue);
+}
+
+/**
+  Allocates and initializes one HMAC_CTX context for subsequent HMAC-SHA384 use.
+
+  @return  Pointer to the HMAC_CTX context that has been initialized.
+           If the allocations fails, HmacSha384New() returns NULL.
+
+**/
+VOID *
+EFIAPI
+HmacSha384New (
+  VOID
+  )
+{
+  return HmacMdNew ();
+}
+
+/**
+  Release the specified HMAC_CTX context.
+
+  @param[in]  HmacSha384Ctx  Pointer to the HMAC_CTX context to be released.
+
+**/
+VOID
+EFIAPI
+HmacSha384Free (
+  IN  VOID  *HmacSha384Ctx
+  )
+{
+  HmacMdFree (HmacSha384Ctx);
+}
+
+/**
+  Set user-supplied key for subsequent use. It must be done before any
+  calling to HmacSha384Update().
+
+  If HmacSha384Context is NULL, then return FALSE.
+  If this interface is not supported, then return FALSE.
+
+  @param[out]  HmacSha384Context  Pointer to HMAC-SHA384 context.
+  @param[in]   Key                Pointer to the user-supplied key.
+  @param[in]   KeySize            Key size in bytes.
+
+  @retval TRUE   The Key is set successfully.
+  @retval FALSE  The Key is set unsuccessfully.
+  @retval FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+HmacSha384SetKey (
+  OUT  VOID         *HmacSha384Context,
+  IN   CONST UINT8  *Key,
+  IN   UINTN        KeySize
+  )
+{
+  return HmacMdSetKey (MBEDTLS_MD_SHA384, HmacSha384Context, Key, KeySize);
+}
+
+/**
+  Makes a copy of an existing HMAC-SHA384 context.
+
+  If HmacSha384Context is NULL, then return FALSE.
+  If NewHmacSha384Context is NULL, then return FALSE.
+  If this interface is not supported, then return FALSE.
+
+  @param[in]  HmacSha384Context     Pointer to HMAC-SHA384 context being copied.
+  @param[out] NewHmacSha384Context  Pointer to new HMAC-SHA384 context.
+
+  @retval TRUE   HMAC-SHA384 context copy succeeded.
+  @retval FALSE  HMAC-SHA384 context copy failed.
+  @retval FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+HmacSha384Duplicate (
+  IN   CONST VOID  *HmacSha384Context,
+  OUT  VOID        *NewHmacSha384Context
+  )
+{
+  return HmacMdDuplicate (MBEDTLS_MD_SHA384, HmacSha384Context, NewHmacSha384Context);
+}
+
+/**
+  Digests the input data and updates HMAC-SHA384 context.
+
+  This function performs HMAC-SHA384 digest on a data buffer of the specified size.
+  It can be called multiple times to compute the digest of long or discontinuous data streams.
+  HMAC-SHA384 context should be initialized by HmacSha384New(), and should not be finalized
+  by HmacSha384Final(). Behavior with invalid context is undefined.
+
+  If HmacSha384Context is NULL, then return FALSE.
+  If this interface is not supported, then return FALSE.
+
+  @param[in, out]  HmacSha384Context Pointer to the HMAC-SHA384 context.
+  @param[in]       Data              Pointer to the buffer containing the data to be digested.
+  @param[in]       DataSize          Size of Data buffer in bytes.
+
+  @retval TRUE   HMAC-SHA384 data digest succeeded.
+  @retval FALSE  HMAC-SHA384 data digest failed.
+  @retval FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+HmacSha384Update (
+  IN OUT  VOID        *HmacSha384Context,
+  IN      CONST VOID  *Data,
+  IN      UINTN       DataSize
+  )
+{
+  return HmacMdUpdate (HmacSha384Context, Data, DataSize);
+}
+
+/**
+  Completes computation of the HMAC-SHA384 digest value.
+
+  This function completes HMAC-SHA384 hash computation and retrieves the digest value into
+  the specified memory. After this function has been called, the HMAC-SHA384 context cannot
+  be used again.
+  HMAC-SHA384 context should be initialized by HmacSha384New(), and should not be finalized
+  by HmacSha384Final(). Behavior with invalid HMAC-SHA384 context is undefined.
+
+  If HmacSha384Context is NULL, then return FALSE.
+  If HmacValue is NULL, then return FALSE.
+  If this interface is not supported, then return FALSE.
+
+  @param[in, out]  HmacSha384Context  Pointer to the HMAC-SHA384 context.
+  @param[out]      HmacValue          Pointer to a buffer that receives the HMAC-SHA384 digest
+                                      value (48 bytes).
+
+  @retval TRUE   HMAC-SHA384 digest computation succeeded.
+  @retval FALSE  HMAC-SHA384 digest computation failed.
+  @retval FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+HmacSha384Final (
+  IN OUT  VOID   *HmacSha384Context,
+  OUT     UINT8  *HmacValue
+  )
+{
+  return HmacMdFinal (HmacSha384Context, HmacValue);
+}
+
+/**
+  Computes the HMAC-SHA384 digest of a input data buffer.
+
+  This function performs the HMAC-SHA384 digest of a given data buffer, and places
+  the digest value into the specified memory.
+
+  If this interface is not supported, then return FALSE.
+
+  @param[in]   Data        Pointer to the buffer containing the data to be digested.
+  @param[in]   DataSize    Size of Data buffer in bytes.
+  @param[in]   Key         Pointer to the user-supplied key.
+  @param[in]   KeySize     Key size in bytes.
+  @param[out]  HmacValue   Pointer to a buffer that receives the HMAC-SHA384 digest
+                           value (48 bytes).
+
+  @retval TRUE   HMAC-SHA384 digest computation succeeded.
+  @retval FALSE  HMAC-SHA384 digest computation failed.
+  @retval FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+HmacSha384All (
+  IN   CONST VOID   *Data,
+  IN   UINTN        DataSize,
+  IN   CONST UINT8  *Key,
+  IN   UINTN        KeySize,
+  OUT  UINT8        *HmacValue
+  )
+{
+  return HmacMdAll (MBEDTLS_MD_SHA384, Data, DataSize, Key, KeySize, HmacValue);
+}

--- a/CryptoPkg/Library/BaseCryptLibMbedTls/Hmac/CryptHmacNull.c
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/Hmac/CryptHmacNull.c
@@ -1,0 +1,359 @@
+/** @file
+  HMAC-SHA256/SHA384 Wrapper Implementation which does not provide real capabilities.
+
+Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "InternalCryptLib.h"
+
+/**
+  Allocates and initializes one HMAC_CTX context for subsequent HMAC-SHA256 use.
+
+  Return NULL to indicate this interface is not supported.
+
+  @return  NULL  This interface is not supported..
+
+**/
+VOID *
+EFIAPI
+HmacSha256New (
+  VOID
+  )
+{
+  ASSERT (FALSE);
+  return NULL;
+}
+
+/**
+  Release the specified HMAC_CTX context.
+
+  This function will do nothing.
+
+  @param[in]  HmacSha256Ctx  Pointer to the HMAC_CTX context to be released.
+
+**/
+VOID
+EFIAPI
+HmacSha256Free (
+  IN  VOID  *HmacSha256Ctx
+  )
+{
+  ASSERT (FALSE);
+  return;
+}
+
+/**
+  Set user-supplied key for subsequent use. It must be done before any
+  calling to HmacSha256Update().
+
+  Return FALSE to indicate this interface is not supported.
+
+  @param[out]  HmacSha256Context  Pointer to HMAC-SHA256 context.
+  @param[in]   Key                Pointer to the user-supplied key.
+  @param[in]   KeySize            Key size in bytes.
+
+  @retval FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+HmacSha256SetKey (
+  OUT  VOID         *HmacSha256Context,
+  IN   CONST UINT8  *Key,
+  IN   UINTN        KeySize
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Makes a copy of an existing HMAC-SHA256 context.
+
+  Return FALSE to indicate this interface is not supported.
+
+  @param[in]  HmacSha256Context     Pointer to HMAC-SHA256 context being copied.
+  @param[out] NewHmacSha256Context  Pointer to new HMAC-SHA256 context.
+
+  @retval FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+HmacSha256Duplicate (
+  IN   CONST VOID  *HmacSha256Context,
+  OUT  VOID        *NewHmacSha256Context
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Digests the input data and updates HMAC-SHA256 context.
+
+  Return FALSE to indicate this interface is not supported.
+
+  @param[in, out]  HmacSha256Context Pointer to the HMAC-SHA256 context.
+  @param[in]       Data              Pointer to the buffer containing the data to be digested.
+  @param[in]       DataSize          Size of Data buffer in bytes.
+
+  @retval FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+HmacSha256Update (
+  IN OUT  VOID        *HmacSha256Context,
+  IN      CONST VOID  *Data,
+  IN      UINTN       DataSize
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Completes computation of the HMAC-SHA256 digest value.
+
+  Return FALSE to indicate this interface is not supported.
+
+  @param[in, out]  HmacSha256Context  Pointer to the HMAC-SHA256 context.
+  @param[out]      HmacValue          Pointer to a buffer that receives the HMAC-SHA256 digest
+                                      value (32 bytes).
+
+  @retval FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+HmacSha256Final (
+  IN OUT  VOID   *HmacSha256Context,
+  OUT     UINT8  *HmacValue
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Computes the HMAC-SHA256 digest of a input data buffer.
+
+  This function performs the HMAC-SHA256 digest of a given data buffer, and places
+  the digest value into the specified memory.
+
+  If this interface is not supported, then return FALSE.
+
+  @param[in]   Data        Pointer to the buffer containing the data to be digested.
+  @param[in]   DataSize    Size of Data buffer in bytes.
+  @param[in]   Key         Pointer to the user-supplied key.
+  @param[in]   KeySize     Key size in bytes.
+  @param[out]  HmacValue   Pointer to a buffer that receives the HMAC-SHA256 digest
+                           value (32 bytes).
+
+  @retval TRUE   HMAC-SHA256 digest computation succeeded.
+  @retval FALSE  HMAC-SHA256 digest computation failed.
+  @retval FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+HmacSha256All (
+  IN   CONST VOID   *Data,
+  IN   UINTN        DataSize,
+  IN   CONST UINT8  *Key,
+  IN   UINTN        KeySize,
+  OUT  UINT8        *HmacValue
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Allocates and initializes one HMAC_CTX context for subsequent HMAC-SHA384 use.
+
+  @return  Pointer to the HMAC_CTX context that has been initialized.
+           If the allocations fails, HmacSha384New() returns NULL.
+
+**/
+VOID *
+EFIAPI
+HmacSha384New (
+  VOID
+  )
+{
+  ASSERT (FALSE);
+  return NULL;
+}
+
+/**
+  Release the specified HMAC_CTX context.
+
+  @param[in]  HmacSha384Ctx  Pointer to the HMAC_CTX context to be released.
+
+**/
+VOID
+EFIAPI
+HmacSha384Free (
+  IN  VOID  *HmacSha384Ctx
+  )
+{
+  ASSERT (FALSE);
+  return;
+}
+
+/**
+  Set user-supplied key for subsequent use. It must be done before any
+  calling to HmacSha384Update().
+
+  If HmacSha384Context is NULL, then return FALSE.
+  If this interface is not supported, then return FALSE.
+
+  @param[out]  HmacSha384Context  Pointer to HMAC-SHA384 context.
+  @param[in]   Key                Pointer to the user-supplied key.
+  @param[in]   KeySize            Key size in bytes.
+
+  @retval TRUE   The Key is set successfully.
+  @retval FALSE  The Key is set unsuccessfully.
+  @retval FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+HmacSha384SetKey (
+  OUT  VOID         *HmacSha384Context,
+  IN   CONST UINT8  *Key,
+  IN   UINTN        KeySize
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Makes a copy of an existing HMAC-SHA384 context.
+
+  If HmacSha384Context is NULL, then return FALSE.
+  If NewHmacSha384Context is NULL, then return FALSE.
+  If this interface is not supported, then return FALSE.
+
+  @param[in]  HmacSha384Context     Pointer to HMAC-SHA384 context being copied.
+  @param[out] NewHmacSha384Context  Pointer to new HMAC-SHA384 context.
+
+  @retval TRUE   HMAC-SHA384 context copy succeeded.
+  @retval FALSE  HMAC-SHA384 context copy failed.
+  @retval FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+HmacSha384Duplicate (
+  IN   CONST VOID  *HmacSha384Context,
+  OUT  VOID        *NewHmacSha384Context
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Digests the input data and updates HMAC-SHA384 context.
+
+  This function performs HMAC-SHA384 digest on a data buffer of the specified size.
+  It can be called multiple times to compute the digest of long or discontinuous data streams.
+  HMAC-SHA384 context should be initialized by HmacSha384New(), and should not be finalized
+  by HmacSha384Final(). Behavior with invalid context is undefined.
+
+  If HmacSha384Context is NULL, then return FALSE.
+  If this interface is not supported, then return FALSE.
+
+  @param[in, out]  HmacSha384Context Pointer to the HMAC-SHA384 context.
+  @param[in]       Data              Pointer to the buffer containing the data to be digested.
+  @param[in]       DataSize          Size of Data buffer in bytes.
+
+  @retval TRUE   HMAC-SHA384 data digest succeeded.
+  @retval FALSE  HMAC-SHA384 data digest failed.
+  @retval FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+HmacSha384Update (
+  IN OUT  VOID        *HmacSha384Context,
+  IN      CONST VOID  *Data,
+  IN      UINTN       DataSize
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Completes computation of the HMAC-SHA384 digest value.
+
+  This function completes HMAC-SHA384 hash computation and retrieves the digest value into
+  the specified memory. After this function has been called, the HMAC-SHA384 context cannot
+  be used again.
+  HMAC-SHA384 context should be initialized by HmacSha384New(), and should not be finalized
+  by HmacSha384Final(). Behavior with invalid HMAC-SHA384 context is undefined.
+
+  If HmacSha384Context is NULL, then return FALSE.
+  If HmacValue is NULL, then return FALSE.
+  If this interface is not supported, then return FALSE.
+
+  @param[in, out]  HmacSha384Context  Pointer to the HMAC-SHA384 context.
+  @param[out]      HmacValue          Pointer to a buffer that receives the HMAC-SHA384 digest
+                                      value (48 bytes).
+
+  @retval TRUE   HMAC-SHA384 digest computation succeeded.
+  @retval FALSE  HMAC-SHA384 digest computation failed.
+  @retval FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+HmacSha384Final (
+  IN OUT  VOID   *HmacSha384Context,
+  OUT     UINT8  *HmacValue
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Computes the HMAC-SHA384 digest of a input data buffer.
+
+  This function performs the HMAC-SHA384 digest of a given data buffer, and places
+  the digest value into the specified memory.
+
+  If this interface is not supported, then return FALSE.
+
+  @param[in]   Data        Pointer to the buffer containing the data to be digested.
+  @param[in]   DataSize    Size of Data buffer in bytes.
+  @param[in]   Key         Pointer to the user-supplied key.
+  @param[in]   KeySize     Key size in bytes.
+  @param[out]  HmacValue   Pointer to a buffer that receives the HMAC-SHA384 digest
+                           value (48 bytes).
+
+  @retval TRUE   HMAC-SHA384 digest computation succeeded.
+  @retval FALSE  HMAC-SHA384 digest computation failed.
+  @retval FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+HmacSha384All (
+  IN   CONST VOID   *Data,
+  IN   UINTN        DataSize,
+  IN   CONST UINT8  *Key,
+  IN   UINTN        KeySize,
+  OUT  UINT8        *HmacValue
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}

--- a/CryptoPkg/Library/BaseCryptLibMbedTls/InternalCryptLib.h
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/InternalCryptLib.h
@@ -1,0 +1,25 @@
+/** @file
+  Internal include file for BaseCryptLib.
+
+Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef INTERNAL_CRYPT_LIB_H_
+#define INTERNAL_CRYPT_LIB_H_
+
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/DebugLib.h>
+#include <Library/BaseCryptLib.h>
+#include <stdio.h>
+
+//
+// We should alwasy add mbedtls/config.h here
+// to ensure the config override takes effect.
+//
+#include <mbedtls/mbedtls_config.h>
+
+#endif

--- a/CryptoPkg/Library/BaseCryptLibMbedTls/Kdf/CryptHkdf.c
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/Kdf/CryptHkdf.c
@@ -1,0 +1,372 @@
+/** @file
+  HMAC-SHA256 KDF Wrapper Implementation over MbedTLS.
+
+  RFC 5869: HMAC-based Extract-and-Expand Key Derivation Function (HKDF)
+
+Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "InternalCryptLib.h"
+#include <mbedtls/hkdf.h>
+
+/**
+  Derive HMAC-based Extract-and-Expand Key Derivation Function (HKDF).
+
+  @param[in]   MdType           Message Digest Type.
+  @param[in]   Key              Pointer to the user-supplied key.
+  @param[in]   KeySize          Key size in bytes.
+  @param[in]   Salt             Pointer to the salt(non-secret) value.
+  @param[in]   SaltSize         Salt size in bytes.
+  @param[in]   Info             Pointer to the application specific info.
+  @param[in]   InfoSize         Info size in bytes.
+  @param[out]  Out              Pointer to buffer to receive hkdf value.
+  @param[in]   OutSize          Size of hkdf bytes to generate.
+
+  @retval TRUE   Hkdf generated successfully.
+  @retval FALSE  Hkdf generation failed.
+
+**/
+STATIC
+BOOLEAN
+HkdfMdExtractAndExpand (
+  IN   mbedtls_md_type_t  MdType,
+  IN   CONST UINT8        *Key,
+  IN   UINTN              KeySize,
+  IN   CONST UINT8        *Salt,
+  IN   UINTN              SaltSize,
+  IN   CONST UINT8        *Info,
+  IN   UINTN              InfoSize,
+  OUT  UINT8              *Out,
+  IN   UINTN              OutSize
+  )
+{
+  const mbedtls_md_info_t  *md;
+  INT32                    Ret;
+
+  if ((Key == NULL) || (Salt == NULL) || (Info == NULL) || (Out == NULL) ||
+      (KeySize > INT_MAX) || (SaltSize > INT_MAX) || (InfoSize > INT_MAX) || (OutSize > INT_MAX))
+  {
+    return FALSE;
+  }
+
+  md = mbedtls_md_info_from_type (MdType);
+  ASSERT (md != NULL);
+
+  Ret = mbedtls_hkdf (md, Salt, (UINT32)SaltSize, Key, (UINT32)KeySize, Info, (UINT32)InfoSize, Out, (UINT32)OutSize);
+  if (Ret != 0) {
+    return FALSE;
+  }
+
+  return TRUE;
+}
+
+/**
+  Derive HMAC-based Extract Key Derivation Function (HKDF).
+
+  @param[in]   MdType           Message Digest Type.
+  @param[in]   Key              Pointer to the user-supplied key.
+  @param[in]   KeySize          Key size in bytes.
+  @param[in]   Salt             Pointer to the salt(non-secret) value.
+  @param[in]   SaltSize         Salt size in bytes.
+  @param[out]  PrkOut           Pointer to buffer to receive hkdf value.
+  @param[in]   PrkOutSize       Size of hkdf bytes to generate.
+
+  @retval TRUE   Hkdf generated successfully.
+  @retval FALSE  Hkdf generation failed.
+
+**/
+STATIC
+BOOLEAN
+HkdfMdExtract (
+  IN   mbedtls_md_type_t  MdType,
+  IN   CONST UINT8        *Key,
+  IN   UINTN              KeySize,
+  IN   CONST UINT8        *Salt,
+  IN   UINTN              SaltSize,
+  OUT  UINT8              *PrkOut,
+  IN   UINTN              PrkOutSize
+  )
+{
+  const mbedtls_md_info_t  *md;
+  INT32                    Ret;
+  UINTN                    MdSize;
+
+  if ((Key == NULL) || (Salt == NULL) || (PrkOut == NULL) ||
+      (KeySize > INT_MAX) || (SaltSize > INT_MAX) || (PrkOutSize > INT_MAX))
+  {
+    return FALSE;
+  }
+
+  MdSize = 0;
+  switch (MdType) {
+    case MBEDTLS_MD_SHA256:
+      MdSize = SHA256_DIGEST_SIZE;
+      break;
+    case MBEDTLS_MD_SHA384:
+      MdSize = SHA384_DIGEST_SIZE;
+      break;
+    case MBEDTLS_MD_SHA512:
+      MdSize = SHA512_DIGEST_SIZE;
+      break;
+    default:
+      return FALSE;
+  }
+
+  if (PrkOutSize != MdSize) {
+    return FALSE;
+  }
+
+  md = mbedtls_md_info_from_type (MdType);
+  ASSERT (md != NULL);
+
+  Ret = mbedtls_hkdf_extract (md, Salt, (UINT32)SaltSize, Key, (UINT32)KeySize, PrkOut);
+  if (Ret != 0) {
+    return FALSE;
+  }
+
+  return TRUE;
+}
+
+/**
+  Derive HMAC-based Expand Key Derivation Function (HKDF).
+
+  @param[in]   MdType           Message Digest Type.
+  @param[in]   Prk              Pointer to the user-supplied key.
+  @param[in]   PrkSize          Key size in bytes.
+  @param[in]   Info             Pointer to the application specific info.
+  @param[in]   InfoSize         Info size in bytes.
+  @param[out]  Out              Pointer to buffer to receive hkdf value.
+  @param[in]   OutSize          Size of hkdf bytes to generate.
+
+  @retval TRUE   Hkdf generated successfully.
+  @retval FALSE  Hkdf generation failed.
+
+**/
+STATIC
+BOOLEAN
+HkdfMdExpand (
+  IN   mbedtls_md_type_t  MdType,
+  IN   CONST UINT8        *Prk,
+  IN   UINTN              PrkSize,
+  IN   CONST UINT8        *Info,
+  IN   UINTN              InfoSize,
+  OUT  UINT8              *Out,
+  IN   UINTN              OutSize
+  )
+{
+  const mbedtls_md_info_t  *md;
+  INT32                    Ret;
+  UINTN                    MdSize;
+
+  if ((Prk == NULL) || (Info == NULL) || (Out == NULL) ||
+      (PrkSize > INT_MAX) || (InfoSize > INT_MAX) || (OutSize > INT_MAX))
+  {
+    return FALSE;
+  }
+
+  switch (MdType) {
+    case MBEDTLS_MD_SHA256:
+      MdSize = SHA256_DIGEST_SIZE;
+      break;
+    case MBEDTLS_MD_SHA384:
+      MdSize = SHA384_DIGEST_SIZE;
+      break;
+    case MBEDTLS_MD_SHA512:
+      MdSize = SHA512_DIGEST_SIZE;
+      break;
+    default:
+      return FALSE;
+  }
+
+  if (PrkSize != MdSize) {
+    return FALSE;
+  }
+
+  md = mbedtls_md_info_from_type (MdType);
+  ASSERT (md != NULL);
+
+  Ret = mbedtls_hkdf_expand (md, Prk, (UINT32)PrkSize, Info, (UINT32)InfoSize, Out, (UINT32)OutSize);
+  if (Ret != 0) {
+    return FALSE;
+  }
+
+  return TRUE;
+}
+
+/**
+  Derive SHA256 HMAC-based Extract-and-Expand Key Derivation Function (HKDF).
+
+  @param[in]   Key              Pointer to the user-supplied key.
+  @param[in]   KeySize          Key size in bytes.
+  @param[in]   Salt             Pointer to the salt(non-secret) value.
+  @param[in]   SaltSize         Salt size in bytes.
+  @param[in]   Info             Pointer to the application specific info.
+  @param[in]   InfoSize         Info size in bytes.
+  @param[out]  Out              Pointer to buffer to receive hkdf value.
+  @param[in]   OutSize          Size of hkdf bytes to generate.
+
+  @retval TRUE   Hkdf generated successfully.
+  @retval FALSE  Hkdf generation failed.
+
+**/
+BOOLEAN
+EFIAPI
+HkdfSha256ExtractAndExpand (
+  IN   CONST UINT8  *Key,
+  IN   UINTN        KeySize,
+  IN   CONST UINT8  *Salt,
+  IN   UINTN        SaltSize,
+  IN   CONST UINT8  *Info,
+  IN   UINTN        InfoSize,
+  OUT  UINT8        *Out,
+  IN   UINTN        OutSize
+  )
+{
+  return HkdfMdExtractAndExpand (MBEDTLS_MD_SHA256, Key, KeySize, Salt, SaltSize, Info, InfoSize, Out, OutSize);
+}
+
+/**
+  Derive SHA256 HMAC-based Extract Key Derivation Function (HKDF).
+
+  @param[in]   Key              Pointer to the user-supplied key.
+  @param[in]   KeySize          Key size in bytes.
+  @param[in]   Salt             Pointer to the salt(non-secret) value.
+  @param[in]   SaltSize         Salt size in bytes.
+  @param[out]  PrkOut           Pointer to buffer to receive hkdf value.
+  @param[in]   PrkOutSize       Size of hkdf bytes to generate.
+
+  @retval TRUE   Hkdf generated successfully.
+  @retval FALSE  Hkdf generation failed.
+
+**/
+BOOLEAN
+EFIAPI
+HkdfSha256Extract (
+  IN   CONST UINT8  *Key,
+  IN   UINTN        KeySize,
+  IN   CONST UINT8  *Salt,
+  IN   UINTN        SaltSize,
+  OUT  UINT8        *PrkOut,
+  IN   UINTN        PrkOutSize
+  )
+{
+  return HkdfMdExtract (MBEDTLS_MD_SHA256, Key, KeySize, Salt, SaltSize, PrkOut, PrkOutSize);
+}
+
+/**
+  Derive SHA256 HMAC-based Expand Key Derivation Function (HKDF).
+
+  @param[in]   Prk              Pointer to the user-supplied key.
+  @param[in]   PrkSize          Key size in bytes.
+  @param[in]   Info             Pointer to the application specific info.
+  @param[in]   InfoSize         Info size in bytes.
+  @param[out]  Out              Pointer to buffer to receive hkdf value.
+  @param[in]   OutSize          Size of hkdf bytes to generate.
+
+  @retval TRUE   Hkdf generated successfully.
+  @retval FALSE  Hkdf generation failed.
+
+**/
+BOOLEAN
+EFIAPI
+HkdfSha256Expand (
+  IN   CONST UINT8  *Prk,
+  IN   UINTN        PrkSize,
+  IN   CONST UINT8  *Info,
+  IN   UINTN        InfoSize,
+  OUT  UINT8        *Out,
+  IN   UINTN        OutSize
+  )
+{
+  return HkdfMdExpand (MBEDTLS_MD_SHA256, Prk, PrkSize, Info, InfoSize, Out, OutSize);
+}
+
+/**
+  Derive SHA384 HMAC-based Extract-and-Expand Key Derivation Function (HKDF).
+
+  @param[in]   Key              Pointer to the user-supplied key.
+  @param[in]   KeySize          Key size in bytes.
+  @param[in]   Salt             Pointer to the salt(non-secret) value.
+  @param[in]   SaltSize         Salt size in bytes.
+  @param[in]   Info             Pointer to the application specific info.
+  @param[in]   InfoSize         Info size in bytes.
+  @param[out]  Out              Pointer to buffer to receive hkdf value.
+  @param[in]   OutSize          Size of hkdf bytes to generate.
+
+  @retval TRUE   Hkdf generated successfully.
+  @retval FALSE  Hkdf generation failed.
+
+**/
+BOOLEAN
+EFIAPI
+HkdfSha384ExtractAndExpand (
+  IN   CONST UINT8  *Key,
+  IN   UINTN        KeySize,
+  IN   CONST UINT8  *Salt,
+  IN   UINTN        SaltSize,
+  IN   CONST UINT8  *Info,
+  IN   UINTN        InfoSize,
+  OUT  UINT8        *Out,
+  IN   UINTN        OutSize
+  )
+{
+  return HkdfMdExtractAndExpand (MBEDTLS_MD_SHA384, Key, KeySize, Salt, SaltSize, Info, InfoSize, Out, OutSize);
+}
+
+/**
+  Derive SHA384 HMAC-based Extract Key Derivation Function (HKDF).
+
+  @param[in]   Key              Pointer to the user-supplied key.
+  @param[in]   KeySize          Key size in bytes.
+  @param[in]   Salt             Pointer to the salt(non-secret) value.
+  @param[in]   SaltSize         Salt size in bytes.
+  @param[out]  PrkOut           Pointer to buffer to receive hkdf value.
+  @param[in]   PrkOutSize       Size of hkdf bytes to generate.
+
+  @retval TRUE   Hkdf generated successfully.
+  @retval FALSE  Hkdf generation failed.
+
+**/
+BOOLEAN
+EFIAPI
+HkdfSha384Extract (
+  IN   CONST UINT8  *Key,
+  IN   UINTN        KeySize,
+  IN   CONST UINT8  *Salt,
+  IN   UINTN        SaltSize,
+  OUT  UINT8        *PrkOut,
+  IN   UINTN        PrkOutSize
+  )
+{
+  return HkdfMdExtract (MBEDTLS_MD_SHA384, Key, KeySize, Salt, SaltSize, PrkOut, PrkOutSize);
+}
+
+/**
+  Derive SHA384 HMAC-based Expand Key Derivation Function (HKDF).
+
+  @param[in]   Prk              Pointer to the user-supplied key.
+  @param[in]   PrkSize          Key size in bytes.
+  @param[in]   Info             Pointer to the application specific info.
+  @param[in]   InfoSize         Info size in bytes.
+  @param[out]  Out              Pointer to buffer to receive hkdf value.
+  @param[in]   OutSize          Size of hkdf bytes to generate.
+
+  @retval TRUE   Hkdf generated successfully.
+  @retval FALSE  Hkdf generation failed.
+
+**/
+BOOLEAN
+EFIAPI
+HkdfSha384Expand (
+  IN   CONST UINT8  *Prk,
+  IN   UINTN        PrkSize,
+  IN   CONST UINT8  *Info,
+  IN   UINTN        InfoSize,
+  OUT  UINT8        *Out,
+  IN   UINTN        OutSize
+  )
+{
+  return HkdfMdExpand (MBEDTLS_MD_SHA384, Prk, PrkSize, Info, InfoSize, Out, OutSize);
+}

--- a/CryptoPkg/Library/BaseCryptLibMbedTls/Kdf/CryptHkdfNull.c
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/Kdf/CryptHkdfNull.c
@@ -1,0 +1,192 @@
+/** @file
+  HMAC-SHA256 KDF Wrapper Implementation which does not provide real capabilities.
+
+Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Library/BaseCryptLib.h>
+#include <Library/DebugLib.h>
+
+/**
+  Derive key data using HMAC-SHA256 based KDF.
+
+  @param[in]   Key              Pointer to the user-supplied key.
+  @param[in]   KeySize          Key size in bytes.
+  @param[in]   Salt             Pointer to the salt(non-secret) value.
+  @param[in]   SaltSize         Salt size in bytes.
+  @param[in]   Info             Pointer to the application specific info.
+  @param[in]   InfoSize         Info size in bytes.
+  @param[out]  Out              Pointer to buffer to receive hkdf value.
+  @param[in]   OutSize          Size of hkdf bytes to generate.
+
+  @retval TRUE   Hkdf generated successfully.
+  @retval FALSE  Hkdf generation failed.
+
+**/
+BOOLEAN
+EFIAPI
+HkdfSha256ExtractAndExpand (
+  IN   CONST UINT8  *Key,
+  IN   UINTN        KeySize,
+  IN   CONST UINT8  *Salt,
+  IN   UINTN        SaltSize,
+  IN   CONST UINT8  *Info,
+  IN   UINTN        InfoSize,
+  OUT  UINT8        *Out,
+  IN   UINTN        OutSize
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Derive SHA256 HMAC-based Extract key Derivation Function (HKDF).
+
+  @param[in]   Key              Pointer to the user-supplied key.
+  @param[in]   KeySize          key size in bytes.
+  @param[in]   Salt             Pointer to the salt(non-secret) value.
+  @param[in]   SaltSize         salt size in bytes.
+  @param[out]  PrkOut           Pointer to buffer to receive hkdf value.
+  @param[in]   PrkOutSize       size of hkdf bytes to generate.
+
+  @retval true   Hkdf generated successfully.
+  @retval false  Hkdf generation failed.
+
+**/
+BOOLEAN
+EFIAPI
+HkdfSha256Extract (
+  IN CONST UINT8  *Key,
+  IN UINTN        KeySize,
+  IN CONST UINT8  *Salt,
+  IN UINTN        SaltSize,
+  OUT UINT8       *PrkOut,
+  UINTN           PrkOutSize
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Derive SHA256 HMAC-based Expand Key Derivation Function (HKDF).
+
+  @param[in]   Prk              Pointer to the user-supplied key.
+  @param[in]   PrkSize          Key size in bytes.
+  @param[in]   Info             Pointer to the application specific info.
+  @param[in]   InfoSize         Info size in bytes.
+  @param[out]  Out              Pointer to buffer to receive hkdf value.
+  @param[in]   OutSize          Size of hkdf bytes to generate.
+
+  @retval TRUE   Hkdf generated successfully.
+  @retval FALSE  Hkdf generation failed.
+
+**/
+BOOLEAN
+EFIAPI
+HkdfSha256Expand (
+  IN   CONST UINT8  *Prk,
+  IN   UINTN        PrkSize,
+  IN   CONST UINT8  *Info,
+  IN   UINTN        InfoSize,
+  OUT  UINT8        *Out,
+  IN   UINTN        OutSize
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Derive SHA384 HMAC-based Extract-and-Expand Key Derivation Function (HKDF).
+
+  @param[in]   Key              Pointer to the user-supplied key.
+  @param[in]   KeySize          Key size in bytes.
+  @param[in]   Salt             Pointer to the salt(non-secret) value.
+  @param[in]   SaltSize         Salt size in bytes.
+  @param[in]   Info             Pointer to the application specific info.
+  @param[in]   InfoSize         Info size in bytes.
+  @param[out]  Out              Pointer to buffer to receive hkdf value.
+  @param[in]   OutSize          Size of hkdf bytes to generate.
+
+  @retval TRUE   Hkdf generated successfully.
+  @retval FALSE  Hkdf generation failed.
+
+**/
+BOOLEAN
+EFIAPI
+HkdfSha384ExtractAndExpand (
+  IN   CONST UINT8  *Key,
+  IN   UINTN        KeySize,
+  IN   CONST UINT8  *Salt,
+  IN   UINTN        SaltSize,
+  IN   CONST UINT8  *Info,
+  IN   UINTN        InfoSize,
+  OUT  UINT8        *Out,
+  IN   UINTN        OutSize
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Derive SHA384 HMAC-based Extract key Derivation Function (HKDF).
+
+  @param[in]   Key              Pointer to the user-supplied key.
+  @param[in]   KeySize          key size in bytes.
+  @param[in]   Salt             Pointer to the salt(non-secret) value.
+  @param[in]   SaltSize         salt size in bytes.
+  @param[out]  PrkOut           Pointer to buffer to receive hkdf value.
+  @param[in]   PrkOutSize       size of hkdf bytes to generate.
+
+  @retval true   Hkdf generated successfully.
+  @retval false  Hkdf generation failed.
+
+**/
+BOOLEAN
+EFIAPI
+HkdfSha384Extract (
+  IN CONST UINT8  *Key,
+  IN UINTN        KeySize,
+  IN CONST UINT8  *Salt,
+  IN UINTN        SaltSize,
+  OUT UINT8       *PrkOut,
+  UINTN           PrkOutSize
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Derive SHA384 HMAC-based Expand Key Derivation Function (HKDF).
+
+  @param[in]   Prk              Pointer to the user-supplied key.
+  @param[in]   PrkSize          Key size in bytes.
+  @param[in]   Info             Pointer to the application specific info.
+  @param[in]   InfoSize         Info size in bytes.
+  @param[out]  Out              Pointer to buffer to receive hkdf value.
+  @param[in]   OutSize          Size of hkdf bytes to generate.
+
+  @retval TRUE   Hkdf generated successfully.
+  @retval FALSE  Hkdf generation failed.
+
+**/
+BOOLEAN
+EFIAPI
+HkdfSha384Expand (
+  IN   CONST UINT8  *Prk,
+  IN   UINTN        PrkSize,
+  IN   CONST UINT8  *Info,
+  IN   UINTN        InfoSize,
+  OUT  UINT8        *Out,
+  IN   UINTN        OutSize
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}

--- a/CryptoPkg/Library/BaseCryptLibMbedTls/PeiCryptLib.inf
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/PeiCryptLib.inf
@@ -1,0 +1,101 @@
+## @file
+#  Cryptographic Library Instance for PEIM.
+#
+#  Caution: This module requires additional review when modified.
+#  This library will have external input - signature.
+#  This external input must be validated carefully to avoid security issues such as
+#  buffer overflow or integer overflow.
+#
+#  Note:
+#  HMAC-SHA256 functions, AES functions, RSA external
+#  functions, PKCS#7 SignedData sign functions, Diffie-Hellman functions, X.509
+#  certificate handler functions, authenticode signature verification functions,
+#  PEM handler functions, and pseudorandom number generator functions are not
+#  supported in this instance.
+#
+#  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = PeiCryptLib
+  MODULE_UNI_FILE                = PeiCryptLib.uni
+  FILE_GUID                      = 91E0A3C3-37A7-4AEE-8689-C5B0AD2C8E63
+  MODULE_TYPE                    = PEIM
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = BaseCryptLib|PEIM PEI_CORE
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  InternalCryptLib.h
+  Hash/CryptMd5.c
+  Hash/CryptSha1.c
+  Hash/CryptSha256.c
+  Hash/CryptSm3Null.c
+  Hash/CryptSha512.c
+  Hash/CryptParallelHashNull.c
+  Hmac/CryptHmac.c
+  Kdf/CryptHkdf.c
+  Cipher/CryptAes.c
+  Cipher/CryptAeadAesGcmNull.c
+  Pk/CryptRsaBasic.c
+  Pk/CryptRsaExtNull.c
+  Pk/CryptRsaPss.c
+  Pk/CryptRsaPssSignNull.c
+  Bn/CryptBnNull.c
+  Pem/CryptPemNull.c
+  Pk/CryptDhNull.c
+  Pk/CryptEcNull.c
+  Pk/CryptPkcs1OaepNull.c
+  Pk/CryptPkcs5Pbkdf2Null.c
+  Pk/CryptPkcs7SignNull.c
+  Pk/CryptPkcs7VerifyNull.c
+  Pk/CryptPkcs7VerifyEkuNull.c
+  Pk/CryptX509Null.c
+  Pk/CryptAuthenticodeNull.c
+  Pk/CryptTsNull.c
+  Rand/CryptRandNull.c
+  SysCall/CrtWrapper.c
+  SysCall/ConstantTimeClock.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  CryptoPkg/CryptoPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  BaseMemoryLib
+  MemoryAllocationLib
+  DebugLib
+  MbedTlsLib
+  IntrinsicLib
+  PrintLib
+  PeiServicesTablePointerLib
+  PeiServicesLib
+  SynchronizationLib
+
+[Ppis]
+  gEfiPeiMpServicesPpiGuid
+#
+# Remove these [BuildOptions] after this library is cleaned up
+#
+[BuildOptions]
+  #
+  # suppress the following warnings so we do not break the build with warnings-as-errors:
+  # C4090: 'function' : different 'const' qualifiers
+  # C4718: 'function call' : recursive call has no side effects, deleting
+  #
+  MSFT:*_*_*_CC_FLAGS = /wd4090 /wd4718
+
+  GCC:*_CLANG35_*_CC_FLAGS = -std=c99
+  GCC:*_CLANG38_*_CC_FLAGS = -std=c99
+  GCC:*_CLANGPDB_*_CC_FLAGS = -std=c99 -Wno-error=incompatible-pointer-types
+
+  XCODE:*_*_*_CC_FLAGS = -std=c99

--- a/CryptoPkg/Library/BaseCryptLibMbedTls/PeiCryptLib.uni
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/PeiCryptLib.uni
@@ -1,0 +1,25 @@
+// /** @file
+// Cryptographic Library Instance for PEIM.
+//
+// Caution: This module requires additional review when modified.
+// This library will have external input - signature.
+// This external input must be validated carefully to avoid security issues such as
+// buffer overflow or integer overflow.
+//
+// Note: AES
+// functions, RSA external functions, PKCS#7 SignedData sign functions,
+// Diffie-Hellman functions, X.509 certificate handler functions, authenticode
+// signature verification functions, PEM handler functions, and pseudorandom number
+// generator functions are not supported in this instance.
+//
+// Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+// **/
+
+
+#string STR_MODULE_ABSTRACT             #language en-US "Cryptographic Library Instance for PEIM"
+
+#string STR_MODULE_DESCRIPTION          #language en-US "Caution: This module requires additional review when modified. This library will have external input - signature. This external input must be validated carefully to avoid security issues such as buffer overflow or integer overflow. Note: AES functions, RSA external functions, PKCS#7 SignedData sign functions, Diffie-Hellman functions, X.509 certificate handler functions, authenticode signature verification functions, PEM handler functions, and pseudorandom number generator functions are not supported in this instance."
+

--- a/CryptoPkg/Library/BaseCryptLibMbedTls/Pem/CryptPemNull.c
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/Pem/CryptPemNull.c
@@ -1,0 +1,69 @@
+/** @file
+  PEM (Privacy Enhanced Mail) Format Handler Wrapper Implementation which does
+  not provide real capabilities.
+
+Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "InternalCryptLib.h"
+
+/**
+  Retrieve the RSA Private Key from the password-protected PEM key data.
+
+  Return FALSE to indicate this interface is not supported.
+
+  @param[in]  PemData      Pointer to the PEM-encoded key data to be retrieved.
+  @param[in]  PemSize      Size of the PEM key data in bytes.
+  @param[in]  Password     NULL-terminated passphrase used for encrypted PEM key data.
+  @param[out] RsaContext   Pointer to new-generated RSA context which contain the retrieved
+                           RSA private key component. Use RsaFree() function to free the
+                           resource.
+
+  @retval FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+RsaGetPrivateKeyFromPem (
+  IN   CONST UINT8  *PemData,
+  IN   UINTN        PemSize,
+  IN   CONST CHAR8  *Password,
+  OUT  VOID         **RsaContext
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Retrieve the EC Private Key from the password-protected PEM key data.
+
+  Return FALSE to indicate this interface is not supported.
+
+  @param[in]  PemData      Pointer to the PEM-encoded key data to be retrieved.
+  @param[in]  PemSize      Size of the PEM key data in bytes.
+  @param[in]  Password     NULL-terminated passphrase used for encrypted PEM key data.
+  @param[out] EcContext    Pointer to new-generated EC context which contain the retrieved
+                           EC private key component. Use EcFree() function to free the
+                           resource.
+
+  If PemData is NULL, then return FALSE.
+  If EcContext is NULL, then return FALSE.
+
+  @retval FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+EcGetPrivateKeyFromPem (
+  IN   CONST UINT8  *PemData,
+  IN   UINTN        PemSize,
+  IN   CONST CHAR8  *Password,
+  OUT  VOID         **EcContext
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}

--- a/CryptoPkg/Library/BaseCryptLibMbedTls/Pk/CryptAuthenticodeNull.c
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/Pk/CryptAuthenticodeNull.c
@@ -1,0 +1,45 @@
+/** @file
+  Authenticode Portable Executable Signature Verification which does not provide
+  real capabilities.
+
+Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "InternalCryptLib.h"
+
+/**
+  Verifies the validity of a PE/COFF Authenticode Signature as described in "Windows
+  Authenticode Portable Executable Signature Format".
+
+  Return FALSE to indicate this interface is not supported.
+
+  @param[in]  AuthData     Pointer to the Authenticode Signature retrieved from signed
+                           PE/COFF image to be verified.
+  @param[in]  DataSize     Size of the Authenticode Signature in bytes.
+  @param[in]  TrustedCert  Pointer to a trusted/root certificate encoded in DER, which
+                           is used for certificate chain verification.
+  @param[in]  CertSize     Size of the trusted certificate in bytes.
+  @param[in]  ImageHash    Pointer to the original image file hash value. The procedure
+                           for calculating the image hash value is described in Authenticode
+                           specification.
+  @param[in]  HashSize     Size of Image hash value in bytes.
+
+  @retval FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+AuthenticodeVerify (
+  IN  CONST UINT8  *AuthData,
+  IN  UINTN        DataSize,
+  IN  CONST UINT8  *TrustedCert,
+  IN  UINTN        CertSize,
+  IN  CONST UINT8  *ImageHash,
+  IN  UINTN        HashSize
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}

--- a/CryptoPkg/Library/BaseCryptLibMbedTls/Pk/CryptDhNull.c
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/Pk/CryptDhNull.c
@@ -1,0 +1,150 @@
+/** @file
+  Diffie-Hellman Wrapper Implementation which does not provide
+  real capabilities.
+
+Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "InternalCryptLib.h"
+
+/**
+  Allocates and Initializes one Diffie-Hellman Context for subsequent use.
+
+  @return  Pointer to the Diffie-Hellman Context that has been initialized.
+           If the interface is not supported, DhNew() returns NULL.
+
+**/
+VOID *
+EFIAPI
+DhNew (
+  VOID
+  )
+{
+  ASSERT (FALSE);
+  return NULL;
+}
+
+/**
+  Release the specified DH context.
+
+  If the interface is not supported, then ASSERT().
+
+  @param[in]  DhContext  Pointer to the DH context to be released.
+
+**/
+VOID
+EFIAPI
+DhFree (
+  IN  VOID  *DhContext
+  )
+{
+  ASSERT (FALSE);
+}
+
+/**
+  Generates DH parameter.
+
+  Return FALSE to indicate this interface is not supported.
+
+  @param[in, out]  DhContext    Pointer to the DH context.
+  @param[in]       Generator    Value of generator.
+  @param[in]       PrimeLength  Length in bits of prime to be generated.
+  @param[out]      Prime        Pointer to the buffer to receive the generated prime number.
+
+  @retval FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+DhGenerateParameter (
+  IN OUT  VOID   *DhContext,
+  IN      UINTN  Generator,
+  IN      UINTN  PrimeLength,
+  OUT     UINT8  *Prime
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Sets generator and prime parameters for DH.
+
+  Return FALSE to indicate this interface is not supported.
+
+  @param[in, out]  DhContext    Pointer to the DH context.
+  @param[in]       Generator    Value of generator.
+  @param[in]       PrimeLength  Length in bits of prime to be generated.
+  @param[in]       Prime        Pointer to the prime number.
+
+  @retval FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+DhSetParameter (
+  IN OUT  VOID         *DhContext,
+  IN      UINTN        Generator,
+  IN      UINTN        PrimeLength,
+  IN      CONST UINT8  *Prime
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Generates DH public key.
+
+  Return FALSE to indicate this interface is not supported.
+
+  @param[in, out]  DhContext      Pointer to the DH context.
+  @param[out]      PublicKey      Pointer to the buffer to receive generated public key.
+  @param[in, out]  PublicKeySize  On input, the size of PublicKey buffer in bytes.
+                                  On output, the size of data returned in PublicKey buffer in bytes.
+
+  @retval FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+DhGenerateKey (
+  IN OUT  VOID   *DhContext,
+  OUT     UINT8  *PublicKey,
+  IN OUT  UINTN  *PublicKeySize
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Computes exchanged common key.
+
+  Return FALSE to indicate this interface is not supported.
+
+  @param[in, out]  DhContext          Pointer to the DH context.
+  @param[in]       PeerPublicKey      Pointer to the peer's public key.
+  @param[in]       PeerPublicKeySize  Size of peer's public key in bytes.
+  @param[out]      Key                Pointer to the buffer to receive generated key.
+  @param[in, out]  KeySize            On input, the size of Key buffer in bytes.
+                                      On output, the size of data returned in Key buffer in bytes.
+
+  @retval FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+DhComputeKey (
+  IN OUT  VOID         *DhContext,
+  IN      CONST UINT8  *PeerPublicKey,
+  IN      UINTN        PeerPublicKeySize,
+  OUT     UINT8        *Key,
+  IN OUT  UINTN        *KeySize
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}

--- a/CryptoPkg/Library/BaseCryptLibMbedTls/Pk/CryptEcNull.c
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/Pk/CryptEcNull.c
@@ -1,0 +1,578 @@
+/** @file
+  Elliptic Curve and ECDH API implementation based on MbedTLS
+
+  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Library/BaseCryptLib.h>
+#include <Library/DebugLib.h>
+
+/**
+  Initialize new opaque EcGroup object. This object represents an EC curve and
+  and is used for calculation within this group. This object should be freed
+  using EcGroupFree() function.
+
+  @param[in]  CryptoNid   Identifying number for the ECC curve (Defined in
+                          BaseCryptLib.h).
+
+  @retval EcGroup object  On success.
+  @retval NULL            On failure.
+**/
+VOID *
+EFIAPI
+EcGroupInit (
+  IN UINTN  CryptoNid
+  )
+{
+  ASSERT (FALSE);
+  return NULL;
+}
+
+/**
+  Get EC curve parameters. While elliptic curve equation is Y^2 mod P = (X^3 + AX + B) Mod P.
+  This function will set the provided Big Number objects  to the corresponding
+  values. The caller needs to make sure all the "out" BigNumber parameters
+  are properly initialized.
+
+  @param[in]  EcGroup    EC group object.
+  @param[out] BnPrime    Group prime number.
+  @param[out] BnA        A coefficient.
+  @param[out] BnB        B coefficient..
+  @param[in]  BnCtx      BN context.
+
+  @retval TRUE          On success.
+  @retval FALSE         Otherwise.
+**/
+BOOLEAN
+EFIAPI
+EcGroupGetCurve (
+  IN CONST VOID  *EcGroup,
+  OUT VOID       *BnPrime,
+  OUT VOID       *BnA,
+  OUT VOID       *BnB,
+  IN VOID        *BnCtx
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Get EC group order.
+  This function will set the provided Big Number object to the corresponding
+  value. The caller needs to make sure that the "out" BigNumber parameter
+  is properly initialized.
+
+  @param[in]  EcGroup   EC group object.
+  @param[out] BnOrder   Group prime number.
+
+  @retval TRUE          On success.
+  @retval FALSE         Otherwise.
+**/
+BOOLEAN
+EFIAPI
+EcGroupGetOrder (
+  IN VOID   *EcGroup,
+  OUT VOID  *BnOrder
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Free previously allocated EC group object using EcGroupInit().
+
+  @param[in]  EcGroup   EC group object to free.
+**/
+VOID
+EFIAPI
+EcGroupFree (
+  IN VOID  *EcGroup
+  )
+{
+  ASSERT (FALSE);
+}
+
+/**
+  Initialize new opaque EC Point object. This object represents an EC point
+  within the given EC group (curve).
+
+  @param[in]  EC Group, properly initialized using EcGroupInit().
+
+  @retval EC Point object  On success.
+  @retval NULL             On failure.
+**/
+VOID *
+EFIAPI
+EcPointInit (
+  IN CONST VOID  *EcGroup
+  )
+{
+  ASSERT (FALSE);
+  return NULL;
+}
+
+/**
+  Free previously allocated EC Point object using EcPointInit().
+
+  @param[in]  EcPoint   EC Point to free.
+  @param[in]  Clear     TRUE iff the memory should be cleared.
+**/
+VOID
+EFIAPI
+EcPointDeInit (
+  IN VOID     *EcPoint,
+  IN BOOLEAN  Clear
+  )
+{
+  ASSERT (FALSE);
+}
+
+/**
+  Get EC point affine (x,y) coordinates.
+  This function will set the provided Big Number objects to the corresponding
+  values. The caller needs to make sure all the "out" BigNumber parameters
+  are properly initialized.
+
+  @param[in]  EcGroup    EC group object.
+  @param[in]  EcPoint    EC point object.
+  @param[out] BnX        X coordinate.
+  @param[out] BnY        Y coordinate.
+  @param[in]  BnCtx      BN context, created with BigNumNewContext().
+
+  @retval TRUE          On success.
+  @retval FALSE         Otherwise.
+**/
+BOOLEAN
+EFIAPI
+EcPointGetAffineCoordinates (
+  IN CONST VOID  *EcGroup,
+  IN CONST VOID  *EcPoint,
+  OUT VOID       *BnX,
+  OUT VOID       *BnY,
+  IN VOID        *BnCtx
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Set EC point affine (x,y) coordinates.
+
+  @param[in]  EcGroup    EC group object.
+  @param[in]  EcPoint    EC point object.
+  @param[in]  BnX        X coordinate.
+  @param[in]  BnY        Y coordinate.
+  @param[in]  BnCtx      BN context, created with BigNumNewContext().
+
+  @retval TRUE          On success.
+  @retval FALSE         Otherwise.
+**/
+BOOLEAN
+EFIAPI
+EcPointSetAffineCoordinates (
+  IN CONST VOID  *EcGroup,
+  IN VOID        *EcPoint,
+  IN CONST VOID  *BnX,
+  IN CONST VOID  *BnY,
+  IN VOID        *BnCtx
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  EC Point addition. EcPointResult = EcPointA + EcPointB.
+
+  @param[in]  EcGroup          EC group object.
+  @param[out] EcPointResult    EC point to hold the result. The point should
+                               be properly initialized.
+  @param[in]  EcPointA         EC Point.
+  @param[in]  EcPointB         EC Point.
+  @param[in]  BnCtx            BN context, created with BigNumNewContext().
+
+  @retval TRUE          On success.
+  @retval FALSE         Otherwise.
+**/
+BOOLEAN
+EFIAPI
+EcPointAdd (
+  IN CONST VOID  *EcGroup,
+  OUT VOID       *EcPointResult,
+  IN CONST VOID  *EcPointA,
+  IN CONST VOID  *EcPointB,
+  IN VOID        *BnCtx
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Variable EC point multiplication. EcPointResult = EcPoint * BnPScalar.
+
+  @param[in]  EcGroup          EC group object.
+  @param[out] EcPointResult    EC point to hold the result. The point should
+                               be properly initialized.
+  @param[in]  EcPoint          EC Point.
+  @param[in]  BnPScalar        P Scalar.
+  @param[in]  BnCtx            BN context, created with BigNumNewContext().
+
+  @retval TRUE          On success.
+  @retval FALSE         Otherwise.
+**/
+BOOLEAN
+EFIAPI
+EcPointMul (
+  IN CONST VOID  *EcGroup,
+  OUT VOID       *EcPointResult,
+  IN CONST VOID  *EcPoint,
+  IN CONST VOID  *BnPScalar,
+  IN VOID        *BnCtx
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Calculate the inverse of the supplied EC point.
+
+  @param[in]     EcGroup   EC group object.
+  @param[in,out] EcPoint   EC point to invert.
+  @param[in]     BnCtx     BN context, created with BigNumNewContext().
+
+  @retval TRUE          On success.
+  @retval FALSE         Otherwise.
+**/
+BOOLEAN
+EFIAPI
+EcPointInvert (
+  IN CONST VOID  *EcGroup,
+  IN OUT VOID    *EcPoint,
+  IN VOID        *BnCtx
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Check if the supplied point is on EC curve.
+
+  @param[in]  EcGroup   EC group object.
+  @param[in]  EcPoint   EC point to check.
+  @param[in]  BnCtx     BN context, created with BigNumNewContext().
+
+  @retval TRUE          On curve.
+  @retval FALSE         Otherwise.
+**/
+BOOLEAN
+EFIAPI
+EcPointIsOnCurve (
+  IN CONST VOID  *EcGroup,
+  IN CONST VOID  *EcPoint,
+  IN VOID        *BnCtx
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Check if the supplied point is at infinity.
+
+  @param[in]  EcGroup   EC group object.
+  @param[in]  EcPoint   EC point to check.
+
+  @retval TRUE          At infinity.
+  @retval FALSE         Otherwise.
+**/
+BOOLEAN
+EFIAPI
+EcPointIsAtInfinity (
+  IN CONST VOID  *EcGroup,
+  IN CONST VOID  *EcPoint
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Check if EC points are equal.
+
+  @param[in]  EcGroup   EC group object.
+  @param[in]  EcPointA  EC point A.
+  @param[in]  EcPointB  EC point B.
+  @param[in]  BnCtx     BN context, created with BigNumNewContext().
+
+  @retval TRUE          A == B.
+  @retval FALSE         Otherwise.
+**/
+BOOLEAN
+EFIAPI
+EcPointEqual (
+  IN CONST VOID  *EcGroup,
+  IN CONST VOID  *EcPointA,
+  IN CONST VOID  *EcPointB,
+  IN VOID        *BnCtx
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Set EC point compressed coordinates. Points can be described in terms of
+  their compressed coordinates. For a point (x, y), for any given value for x
+  such that the point is on the curve there will only ever be two possible
+  values for y. Therefore, a point can be set using this function where BnX is
+  the x coordinate and YBit is a value 0 or 1 to identify which of the two
+  possible values for y should be used.
+
+  @param[in]  EcGroup    EC group object.
+  @param[in]  EcPoint    EC Point.
+  @param[in]  BnX        X coordinate.
+  @param[in]  YBit       0 or 1 to identify which Y value is used.
+  @param[in]  BnCtx      BN context, created with BigNumNewContext().
+
+  @retval TRUE          On success.
+  @retval FALSE         Otherwise.
+**/
+BOOLEAN
+EFIAPI
+EcPointSetCompressedCoordinates (
+  IN CONST VOID  *EcGroup,
+  IN VOID        *EcPoint,
+  IN CONST VOID  *BnX,
+  IN UINT8       YBit,
+  IN VOID        *BnCtx
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Allocates and Initializes one Elliptic Curve Context for subsequent use
+  with the NID.
+
+  @param[in]  Nid cipher NID
+  @return     Pointer to the Elliptic Curve Context that has been initialized.
+              If the allocations fails, EcNewByNid() returns NULL.
+**/
+VOID *
+EFIAPI
+EcNewByNid (
+  IN UINTN  Nid
+  )
+{
+  ASSERT (FALSE);
+  return NULL;
+}
+
+/**
+  Release the specified EC context.
+
+  @param[in]  EcContext  Pointer to the EC context to be released.
+**/
+VOID
+EFIAPI
+EcFree (
+  IN  VOID  *EcContext
+  )
+{
+  ASSERT (FALSE);
+}
+
+/**
+  Generates EC key and returns EC public key (X, Y), Please note, this function uses
+  pseudo random number generator. The caller must make sure RandomSeed()
+  function was properly called before.
+  The Ec context should be correctly initialized by EcNewByNid.
+  This function generates random secret, and computes the public key (X, Y), which is
+  returned via parameter Public, PublicSize.
+  X is the first half of Public with size being PublicSize / 2,
+  Y is the second half of Public with size being PublicSize / 2.
+  EC context is updated accordingly.
+  If the Public buffer is too small to hold the public X, Y, FALSE is returned and
+  PublicSize is set to the required buffer size to obtain the public X, Y.
+  For P-256, the PublicSize is 64. First 32-byte is X, Second 32-byte is Y.
+  For P-384, the PublicSize is 96. First 48-byte is X, Second 48-byte is Y.
+  For P-521, the PublicSize is 132. First 66-byte is X, Second 66-byte is Y.
+  If EcContext is NULL, then return FALSE.
+  If PublicSize is NULL, then return FALSE.
+  If PublicSize is large enough but Public is NULL, then return FALSE.
+  @param[in, out]  EcContext      Pointer to the EC context.
+  @param[out]      PublicKey      Pointer to t buffer to receive generated public X,Y.
+  @param[in, out]  PublicKeySize  On input, the size of Public buffer in bytes.
+                                  On output, the size of data returned in Public buffer in bytes.
+  @retval TRUE   EC public X,Y generation succeeded.
+  @retval FALSE  EC public X,Y generation failed.
+  @retval FALSE  PublicKeySize is not large enough.
+**/
+BOOLEAN
+EFIAPI
+EcGenerateKey (
+  IN OUT  VOID   *EcContext,
+  OUT     UINT8  *PublicKey,
+  IN OUT  UINTN  *PublicKeySize
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Gets the public key component from the established EC context.
+  The Ec context should be correctly initialized by EcNewByNid, and successfully
+  generate key pair from EcGenerateKey().
+  For P-256, the PublicSize is 64. First 32-byte is X, Second 32-byte is Y.
+  For P-384, the PublicSize is 96. First 48-byte is X, Second 48-byte is Y.
+  For P-521, the PublicSize is 132. First 66-byte is X, Second 66-byte is Y.
+  @param[in, out]  EcContext      Pointer to EC context being set.
+  @param[out]      PublicKey      Pointer to t buffer to receive generated public X,Y.
+  @param[in, out]  PublicKeySize  On input, the size of Public buffer in bytes.
+                                  On output, the size of data returned in Public buffer in bytes.
+  @retval  TRUE   EC key component was retrieved successfully.
+  @retval  FALSE  Invalid EC key component.
+**/
+BOOLEAN
+EFIAPI
+EcGetPubKey (
+  IN OUT  VOID   *EcContext,
+  OUT     UINT8  *PublicKey,
+  IN OUT  UINTN  *PublicKeySize
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Computes exchanged common key.
+  Given peer's public key (X, Y), this function computes the exchanged common key,
+  based on its own context including value of curve parameter and random secret.
+  X is the first half of PeerPublic with size being PeerPublicSize / 2,
+  Y is the second half of PeerPublic with size being PeerPublicSize / 2.
+  If EcContext is NULL, then return FALSE.
+  If PeerPublic is NULL, then return FALSE.
+  If PeerPublicSize is 0, then return FALSE.
+  If Key is NULL, then return FALSE.
+  If KeySize is not large enough, then return FALSE.
+  For P-256, the PeerPublicSize is 64. First 32-byte is X, Second 32-byte is Y.
+  For P-384, the PeerPublicSize is 96. First 48-byte is X, Second 48-byte is Y.
+  For P-521, the PeerPublicSize is 132. First 66-byte is X, Second 66-byte is Y.
+  @param[in, out]  EcContext          Pointer to the EC context.
+  @param[in]       PeerPublic         Pointer to the peer's public X,Y.
+  @param[in]       PeerPublicSize     Size of peer's public X,Y in bytes.
+  @param[in]       CompressFlag       Flag of PeerPublic is compressed or not.
+  @param[out]      Key                Pointer to the buffer to receive generated key.
+  @param[in, out]  KeySize            On input, the size of Key buffer in bytes.
+                                      On output, the size of data returned in Key buffer in bytes.
+  @retval TRUE   EC exchanged key generation succeeded.
+  @retval FALSE  EC exchanged key generation failed.
+  @retval FALSE  KeySize is not large enough.
+**/
+BOOLEAN
+EFIAPI
+EcDhComputeKey (
+  IN OUT  VOID         *EcContext,
+  IN      CONST UINT8  *PeerPublic,
+  IN      UINTN        PeerPublicSize,
+  IN      CONST INT32  *CompressFlag,
+  OUT     UINT8        *Key,
+  IN OUT  UINTN        *KeySize
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Carries out the EC-DSA signature.
+
+  This function carries out the EC-DSA signature.
+  If the Signature buffer is too small to hold the contents of signature, FALSE
+  is returned and SigSize is set to the required buffer size to obtain the signature.
+
+  If EcContext is NULL, then return FALSE.
+  If MessageHash is NULL, then return FALSE.
+  If HashSize need match the HashNid. HashNid could be SHA256, SHA384, SHA512, SHA3_256, SHA3_384, SHA3_512.
+  If SigSize is large enough but Signature is NULL, then return FALSE.
+
+  For P-256, the SigSize is 64. First 32-byte is R, Second 32-byte is S.
+  For P-384, the SigSize is 96. First 48-byte is R, Second 48-byte is S.
+  For P-521, the SigSize is 132. First 66-byte is R, Second 66-byte is S.
+
+  @param[in]       EcContext    Pointer to EC context for signature generation.
+  @param[in]       HashNid      hash NID
+  @param[in]       MessageHash  Pointer to octet message hash to be signed.
+  @param[in]       HashSize     Size of the message hash in bytes.
+  @param[out]      Signature    Pointer to buffer to receive EC-DSA signature.
+  @param[in, out]  SigSize      On input, the size of Signature buffer in bytes.
+                                On output, the size of data returned in Signature buffer in bytes.
+
+  @retval  TRUE   Signature successfully generated in EC-DSA.
+  @retval  FALSE  Signature generation failed.
+  @retval  FALSE  SigSize is too small.
+
+**/
+BOOLEAN
+EFIAPI
+EcDsaSign (
+  IN      VOID         *EcContext,
+  IN      UINTN        HashNid,
+  IN      CONST UINT8  *MessageHash,
+  IN      UINTN        HashSize,
+  OUT     UINT8        *Signature,
+  IN OUT  UINTN        *SigSize
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Verifies the EC-DSA signature.
+
+  If EcContext is NULL, then return FALSE.
+  If MessageHash is NULL, then return FALSE.
+  If Signature is NULL, then return FALSE.
+  If HashSize need match the HashNid. HashNid could be SHA256, SHA384, SHA512, SHA3_256, SHA3_384, SHA3_512.
+
+  For P-256, the SigSize is 64. First 32-byte is R, Second 32-byte is S.
+  For P-384, the SigSize is 96. First 48-byte is R, Second 48-byte is S.
+  For P-521, the SigSize is 132. First 66-byte is R, Second 66-byte is S.
+
+  @param[in]  EcContext    Pointer to EC context for signature verification.
+  @param[in]  HashNid      hash NID
+  @param[in]  MessageHash  Pointer to octet message hash to be checked.
+  @param[in]  HashSize     Size of the message hash in bytes.
+  @param[in]  Signature    Pointer to EC-DSA signature to be verified.
+  @param[in]  SigSize      Size of signature in bytes.
+
+  @retval  TRUE   Valid signature encoded in EC-DSA.
+  @retval  FALSE  Invalid signature or invalid EC context.
+
+**/
+BOOLEAN
+EFIAPI
+EcDsaVerify (
+  IN  VOID         *EcContext,
+  IN  UINTN        HashNid,
+  IN  CONST UINT8  *MessageHash,
+  IN  UINTN        HashSize,
+  IN  CONST UINT8  *Signature,
+  IN  UINTN        SigSize
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}

--- a/CryptoPkg/Library/BaseCryptLibMbedTls/Pk/CryptPkcs1OaepNull.c
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/Pk/CryptPkcs1OaepNull.c
@@ -1,0 +1,51 @@
+/** @file
+  This file contains UEFI wrapper functions for RSA PKCS1v2 OAEP encryption routines.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include "InternalCryptLib.h"
+
+/**
+  Encrypts a blob using PKCS1v2 (RSAES-OAEP) schema. On success, will return the
+  encrypted message in a newly allocated buffer.
+
+  Return FALSE to indicate this interface is not supported.
+
+  @param[in]  PublicKey           A pointer to the DER-encoded X509 certificate that
+                                  will be used to encrypt the data.
+  @param[in]  PublicKeySize       Size of the X509 cert buffer.
+  @param[in]  InData              Data to be encrypted.
+  @param[in]  InDataSize          Size of the data buffer.
+  @param[in]  PrngSeed            [Optional] If provided, a pointer to a random seed buffer
+                                  to be used when initializing the PRNG. NULL otherwise.
+  @param[in]  PrngSeedSize        [Optional] If provided, size of the random seed buffer.
+                                  0 otherwise.
+  @param[out] EncryptedData       Pointer to an allocated buffer containing the encrypted
+                                  message.
+  @param[out] EncryptedDataSize   Size of the encrypted message buffer.
+
+  @retval FALSE                   This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+Pkcs1v2Encrypt (
+  IN   CONST UINT8  *PublicKey,
+  IN   UINTN        PublicKeySize,
+  IN   UINT8        *InData,
+  IN   UINTN        InDataSize,
+  IN   CONST UINT8  *PrngSeed,
+  OPTIONAL
+  IN   UINTN        PrngSeedSize,
+  OPTIONAL
+  OUT  UINT8        **EncryptedData,
+  OUT  UINTN        *EncryptedDataSize
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}

--- a/CryptoPkg/Library/BaseCryptLibMbedTls/Pk/CryptPkcs5Pbkdf2Null.c
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/Pk/CryptPkcs5Pbkdf2Null.c
@@ -1,0 +1,48 @@
+/** @file
+  PBKDF2 Key Derivation Function Wrapper Implementation which does not provide real
+  capabilities.
+
+Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "InternalCryptLib.h"
+
+/**
+  Derives a key from a password using a salt and iteration count, based on PKCS#5 v2.0
+  password based encryption key derivation function PBKDF2, as specified in RFC 2898.
+
+  Return FALSE to indicate this interface is not supported.
+
+  @param[in]  PasswordLength  Length of input password in bytes.
+  @param[in]  Password        Pointer to the array for the password.
+  @param[in]  SaltLength      Size of the Salt in bytes.
+  @param[in]  Salt            Pointer to the Salt.
+  @param[in]  IterationCount  Number of iterations to perform. Its value should be
+                              greater than or equal to 1.
+  @param[in]  DigestSize      Size of the message digest to be used (eg. SHA256_DIGEST_SIZE).
+                              NOTE: DigestSize will be used to determine the hash algorithm.
+                                    Only SHA1_DIGEST_SIZE or SHA256_DIGEST_SIZE is supported.
+  @param[in]  KeyLength       Size of the derived key buffer in bytes.
+  @param[out] OutKey          Pointer to the output derived key buffer.
+
+  @retval  FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+Pkcs5HashPassword (
+  IN  UINTN        PasswordLength,
+  IN  CONST CHAR8  *Password,
+  IN  UINTN        SaltLength,
+  IN  CONST UINT8  *Salt,
+  IN  UINTN        IterationCount,
+  IN  UINTN        DigestSize,
+  IN  UINTN        KeyLength,
+  OUT UINT8        *OutKey
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}

--- a/CryptoPkg/Library/BaseCryptLibMbedTls/Pk/CryptPkcs7Internal.h
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/Pk/CryptPkcs7Internal.h
@@ -1,0 +1,83 @@
+/** @file
+  PKCS#7 SignedData Sign Wrapper and PKCS#7 SignedData Verification Wrapper
+  Implementation over mbedtls, Internal headers.
+
+  RFC 2315 - PKCS #7: Cryptographic Message Syntax Version 1.5
+
+Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef CRYPT_PKCS7_INTERNAL_H_
+#define CRYPT_PKCS7_INTERNAL_H_
+
+#include "InternalCryptLib.h"
+
+#include "mbedtls/oid.h"
+#include "mbedtls/asn1.h"
+#include "mbedtls/asn1write.h"
+#include "mbedtls/x509.h"
+#include "mbedtls/x509_crt.h"
+
+///
+/// PKCS7 OID
+///
+#define MBEDTLS_OID_PKCS7                            MBEDTLS_OID_PKCS "\x07"
+#define MBEDTLS_OID_PKCS7_DATA                       MBEDTLS_OID_PKCS7 "\x01"
+#define MBEDTLS_OID_PKCS7_SIGNED_DATA                MBEDTLS_OID_PKCS7 "\x02"
+#define MBEDTLS_OID_PKCS7_ENVELOPED_DATA             MBEDTLS_OID_PKCS7 "\x03"
+#define MBEDTLS_OID_PKCS7_SIGNED_AND_ENVELOPED_DATA  MBEDTLS_OID_PKCS7 "\x04"
+#define MBEDTLS_OID_PKCS7_DIGESTED_DATA              MBEDTLS_OID_PKCS7 "\x05"
+#define MBEDTLS_OID_PKCS7_ENCRYPTED_DATA             MBEDTLS_OID_PKCS7 "\x06"
+
+typedef mbedtls_asn1_buf         MBEDTLSPKCS7BUF;
+typedef mbedtls_asn1_named_data  MBEDTLSPKCS7NAME;
+typedef mbedtls_asn1_sequence    MBEDTLSPKCS7SEQUENCE;
+
+///
+/// PKCS7 SignerInfo type
+/// https://tools.ietf.org/html/rfc2315#section-9.2
+///
+typedef struct MbedtlsPkcs7SignerInfo {
+  INT32                            Version;
+  mbedtls_x509_buf                 Serial;
+  mbedtls_x509_name                Issuer;
+  mbedtls_x509_buf                 IssuerRaw;
+  mbedtls_x509_buf                 AlgIdentifier;
+  mbedtls_x509_buf                 SigAlgIdentifier;
+  mbedtls_x509_buf                 AuthAttr;
+  mbedtls_x509_buf                 Sig;
+  struct MBEDTLSPKCS7SIGNERINFO    *Next;
+} MBEDTLSPKCS7SIGNERINFO;
+
+///
+/// PKCS7 signed data attached data format
+///
+typedef struct MbedtlsPkcs7Data {
+  mbedtls_asn1_buf    Oid;
+  mbedtls_asn1_buf    Data;
+} MBEDTLSPKCS7DATA;
+
+///
+/// Signed Data
+/// https://tools.ietf.org/html/rfc2315#section-9.1
+///
+typedef struct MbedtlsPkcs7SignedData {
+  INT32                            Version;
+  mbedtls_asn1_buf                 DigestAlgorithms;
+  struct MBEDTLSPKCS7DATA          ContentInfo;
+  mbedtls_x509_crt                 Certificates;
+  mbedtls_x509_crl                 Crls;
+  struct MbedtlsPkcs7SignerInfo    SignerInfos;
+} MBEDTLSPKCS7SIGNEDDATA;
+
+///
+/// PKCS7 struct, only support SignedData
+///
+typedef struct MbedtlsPkcs7 {
+  mbedtls_asn1_buf                 ContentTypeOid;
+  struct MBEDTLSPKCS7SIGNEDDATA    SignedData;
+} MBEDTLSPKCS7;
+
+#endif

--- a/CryptoPkg/Library/BaseCryptLibMbedTls/Pk/CryptPkcs7SignNull.c
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/Pk/CryptPkcs7SignNull.c
@@ -1,0 +1,53 @@
+/** @file
+  PKCS#7 SignedData Sign Wrapper Implementation which does not provide real
+  capabilities.
+
+Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "InternalCryptLib.h"
+
+/**
+  Creates a PKCS#7 signedData as described in "PKCS #7: Cryptographic Message
+  Syntax Standard, version 1.5". This interface is only intended to be used for
+  application to perform PKCS#7 functionality validation.
+
+  Return FALSE to indicate this interface is not supported.
+
+  @param[in]  PrivateKey       Pointer to the PEM-formatted private key data for
+                               data signing.
+  @param[in]  PrivateKeySize   Size of the PEM private key data in bytes.
+  @param[in]  KeyPassword      NULL-terminated passphrase used for encrypted PEM
+                               key data.
+  @param[in]  InData           Pointer to the content to be signed.
+  @param[in]  InDataSize       Size of InData in bytes.
+  @param[in]  SignCert         Pointer to signer's DER-encoded certificate to sign with.
+  @param[in]  OtherCerts       Pointer to an optional additional set of certificates to
+                               include in the PKCS#7 signedData (e.g. any intermediate
+                               CAs in the chain).
+  @param[out] SignedData       Pointer to output PKCS#7 signedData. It's caller's
+                               responsibility to free the buffer with FreePool().
+  @param[out] SignedDataSize   Size of SignedData in bytes.
+
+  @retval FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+Pkcs7Sign (
+  IN   CONST UINT8  *PrivateKey,
+  IN   UINTN        PrivateKeySize,
+  IN   CONST UINT8  *KeyPassword,
+  IN   UINT8        *InData,
+  IN   UINTN        InDataSize,
+  IN   UINT8        *SignCert,
+  IN   UINT8        *OtherCerts      OPTIONAL,
+  OUT  UINT8        **SignedData,
+  OUT  UINTN        *SignedDataSize
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}

--- a/CryptoPkg/Library/BaseCryptLibMbedTls/Pk/CryptPkcs7VerifyEkuNull.c
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/Pk/CryptPkcs7VerifyEkuNull.c
@@ -1,0 +1,152 @@
+/** @file
+  PKCS7 Verify Null implementation.
+
+  Copyright (C) Microsoft Corporation. All Rights Reserved.
+  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "InternalCryptLib.h"
+
+/**
+  This function will return the leaf signer certificate in a chain.  This is
+  required because certificate chains are not guaranteed to have the
+  certificates in the order that they were issued.
+
+  A typical certificate chain looks like this:
+
+
+                 ----------------------------
+                |            Root            |
+                 ----------------------------
+                               ^
+                               |
+                 ----------------------------
+                |          Policy CA         | <-- Typical Trust Anchor.
+                 ----------------------------
+                               ^
+                               |
+                 ----------------------------
+                |         Issuing CA         |
+                 ----------------------------
+                               ^
+                               |
+                 -----------------------------
+                /  End-Entity (leaf) signer  / <-- Bottom certificate.
+                -----------------------------  EKU: "1.3.6.1.4.1.311.76.9.21.1"
+                                                    (Firmware Signing)
+
+
+  @param[in]   CertChain            Certificate chain.
+
+  @param[out]  SignerCert           Last certificate in the chain.  For PKCS7 signatures,
+                                    this will be the end-entity (leaf) signer cert.
+
+  @retval EFI_SUCCESS               The required EKUs were found in the signature.
+  @retval EFI_INVALID_PARAMETER     A parameter was invalid.
+  @retval EFI_NOT_FOUND             The number of signers found was not 1.
+
+**/
+EFI_STATUS
+GetSignerCertificate (
+  IN CONST VOID  *CertChain,
+  OUT VOID       **SignerCert
+  )
+{
+  ASSERT (FALSE);
+  return EFI_NOT_READY;
+}
+
+/**
+  Determines if the specified EKU represented in ASN1 form is present
+  in a given certificate.
+
+  @param[in]  Cert                  The certificate to check.
+
+  @param[in]  Asn1ToFind            The EKU to look for.
+
+  @retval EFI_SUCCESS               We successfully identified the signing type.
+  @retval EFI_INVALID_PARAMETER     A parameter was invalid.
+  @retval EFI_NOT_FOUND             One or more EKU's were not found in the signature.
+
+**/
+EFI_STATUS
+IsEkuInCertificate (
+  IN CONST VOID  *Cert,
+  IN VOID        *Asn1ToFind
+  )
+{
+  ASSERT (FALSE);
+  return EFI_NOT_READY;
+}
+
+/**
+  Determines if the specified EKUs are present in a signing certificate.
+
+  @param[in]  SignerCert            The certificate to check.
+  @param[in]  RequiredEKUs          The EKUs to look for.
+  @param[in]  RequiredEKUsSize      The number of EKUs
+  @param[in]  RequireAllPresent     If TRUE, then all the specified EKUs
+                                    must be present in the certificate.
+
+  @retval EFI_SUCCESS               We successfully identified the signing type.
+  @retval EFI_INVALID_PARAMETER     A parameter was invalid.
+  @retval EFI_NOT_FOUND             One or more EKU's were not found in the signature.
+**/
+EFI_STATUS
+CheckEKUs (
+  IN CONST VOID    *SignerCert,
+  IN CONST CHAR8   *RequiredEKUs[],
+  IN CONST UINT32  RequiredEKUsSize,
+  IN BOOLEAN       RequireAllPresent
+  )
+{
+  ASSERT (FALSE);
+  return EFI_NOT_READY;
+}
+
+/**
+  This function receives a PKCS#7 formatted signature blob,
+  looks for the EKU SEQUENCE blob, and if found then looks
+  for all the required EKUs. This function was created so that
+  the Surface team can cut down on the number of Certificate
+  Authorities (CA's) by checking EKU's on leaf signers for
+  a specific product. This prevents one product's certificate
+  from signing another product's firmware or unlock blobs.
+
+  Note that this function does not validate the certificate chain.
+  That needs to be done before using this function.
+
+  @param[in]  Pkcs7Signature       The PKCS#7 signed information content block. An array
+                                   containing the content block with both the signature,
+                                   the signer's certificate, and any necessary intermediate
+                                   certificates.
+  @param[in]  Pkcs7SignatureSize   Number of bytes in Pkcs7Signature.
+  @param[in]  RequiredEKUs         Array of null-terminated strings listing OIDs of
+                                   required EKUs that must be present in the signature.
+  @param[in]  RequiredEKUsSize     Number of elements in the RequiredEKUs string array.
+  @param[in]  RequireAllPresent    If this is TRUE, then all of the specified EKU's
+                                   must be present in the leaf signer.  If it is
+                                   FALSE, then we will succeed if we find any
+                                   of the specified EKU's.
+
+  @retval EFI_SUCCESS              The required EKUs were found in the signature.
+  @retval EFI_INVALID_PARAMETER    A parameter was invalid.
+  @retval EFI_NOT_FOUND            One or more EKU's were not found in the signature.
+
+**/
+EFI_STATUS
+EFIAPI
+VerifyEKUsInPkcs7Signature (
+  IN CONST UINT8   *Pkcs7Signature,
+  IN CONST UINT32  SignatureSize,
+  IN CONST CHAR8   *RequiredEKUs[],
+  IN CONST UINT32  RequiredEKUsSize,
+  IN BOOLEAN       RequireAllPresent
+  )
+{
+  ASSERT (FALSE);
+  return EFI_NOT_READY;
+}

--- a/CryptoPkg/Library/BaseCryptLibMbedTls/Pk/CryptPkcs7VerifyEkuRuntime.c
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/Pk/CryptPkcs7VerifyEkuRuntime.c
@@ -1,0 +1,56 @@
+/** @file
+  This module verifies that Enhanced Key Usages (EKU's) are present within
+  a PKCS7 signature blob using MbedTLS.
+
+  Copyright (C) Microsoft Corporation. All Rights Reserved.
+  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "InternalCryptLib.h"
+
+/**
+  This function receives a PKCS#7 formatted signature blob,
+  looks for the EKU SEQUENCE blob, and if found then looks
+  for all the required EKUs.  This function was created so that
+  the Surface team can cut down on the number of Certificate
+  Authorities (CA's) by checking EKU's on leaf signers for
+  a specific product.  This prevents one product's certificate
+  from signing another product's firmware or unlock blobs.
+
+  Return RETURN_UNSUPPORTED to indicate this interface is not supported.
+
+  @param[in]  Pkcs7Signature        The PKCS#7 signed information content block. An array
+                                    containing the content block with both the signature,
+                                    the signer's certificate, and any necessary intermediate
+                                    certificates.
+  @param[in]  Pkcs7SignatureSize    Number of bytes in pPkcs7Signature.
+  @param[in]  RequiredEKUs          Array of null-terminated strings listing OIDs of
+                                    required EKUs that must be present in the signature.
+                                    All specified EKU's must be present in order to
+                                    succeed.
+  @param[in]  RequiredEKUsSize      Number of elements in the rgRequiredEKUs string.
+                                    This parameter has a maximum of MAX_EKU_SEARCH.
+  @param[in]  RequireAllPresent     If this is TRUE, then all of the specified EKU's
+                                    must be present in the leaf signer.  If it is
+                                    FALSE, then we will succeed if we find any
+                                    of the specified EKU's.
+
+  @retval RETURN_UNSUPPORTED        The operation is not supported.
+
+**/
+EFI_STATUS
+EFIAPI
+VerifyEKUsInPkcs7Signature (
+  IN CONST UINT8   *Pkcs7Signature,
+  IN CONST UINT32  SignatureSize,
+  IN CONST CHAR8   *RequiredEKUs[],
+  IN CONST UINT32  RequiredEKUsSize,
+  IN BOOLEAN       RequireAllPresent
+  )
+{
+  ASSERT (FALSE);
+  return RETURN_UNSUPPORTED;
+}

--- a/CryptoPkg/Library/BaseCryptLibMbedTls/Pk/CryptPkcs7VerifyNull.c
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/Pk/CryptPkcs7VerifyNull.c
@@ -1,0 +1,163 @@
+/** @file
+  PKCS#7 SignedData Verification Wrapper Implementation which does not provide
+  real capabilities.
+
+Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "InternalCryptLib.h"
+
+/**
+  Get the signer's certificates from PKCS#7 signed data as described in "PKCS #7:
+  Cryptographic Message Syntax Standard". The input signed data could be wrapped
+  in a ContentInfo structure.
+
+  Return FALSE to indicate this interface is not supported.
+
+  @param[in]  P7Data       Pointer to the PKCS#7 message to verify.
+  @param[in]  P7Length     Length of the PKCS#7 message in bytes.
+  @param[out] CertStack    Pointer to Signer's certificates retrieved from P7Data.
+                           It's caller's responsibility to free the buffer with
+                           Pkcs7FreeSigners().
+                           This data structure is EFI_CERT_STACK type.
+  @param[out] StackLength  Length of signer's certificates in bytes.
+  @param[out] TrustedCert  Pointer to a trusted certificate from Signer's certificates.
+                           It's caller's responsibility to free the buffer with
+                           Pkcs7FreeSigners().
+  @param[out] CertLength   Length of the trusted certificate in bytes.
+
+  @retval FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+Pkcs7GetSigners (
+  IN  CONST UINT8  *P7Data,
+  IN  UINTN        P7Length,
+  OUT UINT8        **CertStack,
+  OUT UINTN        *StackLength,
+  OUT UINT8        **TrustedCert,
+  OUT UINTN        *CertLength
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Wrap function to use free() to free allocated memory for certificates.
+
+  If the interface is not supported, then ASSERT().
+
+  @param[in]  Certs        Pointer to the certificates to be freed.
+
+**/
+VOID
+EFIAPI
+Pkcs7FreeSigners (
+  IN  UINT8  *Certs
+  )
+{
+  ASSERT (FALSE);
+}
+
+/**
+  Retrieves all embedded certificates from PKCS#7 signed data as described in "PKCS #7:
+  Cryptographic Message Syntax Standard", and outputs two certificate lists chained and
+  unchained to the signer's certificates.
+  The input signed data could be wrapped in a ContentInfo structure.
+
+  @param[in]  P7Data            Pointer to the PKCS#7 message.
+  @param[in]  P7Length          Length of the PKCS#7 message in bytes.
+  @param[out] SignerChainCerts  Pointer to the certificates list chained to signer's
+                                certificate. It's caller's responsibility to free the buffer
+                                with Pkcs7FreeSigners().
+                                This data structure is EFI_CERT_STACK type.
+  @param[out] ChainLength       Length of the chained certificates list buffer in bytes.
+  @param[out] UnchainCerts      Pointer to the unchained certificates lists. It's caller's
+                                responsibility to free the buffer with Pkcs7FreeSigners().
+                                This data structure is EFI_CERT_STACK type.
+  @param[out] UnchainLength     Length of the unchained certificates list buffer in bytes.
+
+  @retval  TRUE         The operation is finished successfully.
+  @retval  FALSE        Error occurs during the operation.
+
+**/
+BOOLEAN
+EFIAPI
+Pkcs7GetCertificatesList (
+  IN  CONST UINT8  *P7Data,
+  IN  UINTN        P7Length,
+  OUT UINT8        **SignerChainCerts,
+  OUT UINTN        *ChainLength,
+  OUT UINT8        **UnchainCerts,
+  OUT UINTN        *UnchainLength
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Verifies the validity of a PKCS#7 signed data as described in "PKCS #7:
+  Cryptographic Message Syntax Standard". The input signed data could be wrapped
+  in a ContentInfo structure.
+
+  Return FALSE to indicate this interface is not supported.
+
+  @param[in]  P7Data       Pointer to the PKCS#7 message to verify.
+  @param[in]  P7Length     Length of the PKCS#7 message in bytes.
+  @param[in]  TrustedCert  Pointer to a trusted/root certificate encoded in DER, which
+                           is used for certificate chain verification.
+  @param[in]  CertLength   Length of the trusted certificate in bytes.
+  @param[in]  InData       Pointer to the content to be verified.
+  @param[in]  DataLength   Length of InData in bytes.
+
+  @retval FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+Pkcs7Verify (
+  IN  CONST UINT8  *P7Data,
+  IN  UINTN        P7Length,
+  IN  CONST UINT8  *TrustedCert,
+  IN  UINTN        CertLength,
+  IN  CONST UINT8  *InData,
+  IN  UINTN        DataLength
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Extracts the attached content from a PKCS#7 signed data if existed. The input signed
+  data could be wrapped in a ContentInfo structure.
+
+  Return FALSE to indicate this interface is not supported.
+
+  @param[in]   P7Data       Pointer to the PKCS#7 signed data to process.
+  @param[in]   P7Length     Length of the PKCS#7 signed data in bytes.
+  @param[out]  Content      Pointer to the extracted content from the PKCS#7 signedData.
+                            It's caller's responsibility to free the buffer with FreePool().
+  @param[out]  ContentSize  The size of the extracted content in bytes.
+
+  @retval     TRUE          The P7Data was correctly formatted for processing.
+  @retval     FALSE         The P7Data was not correctly formatted for processing.
+
+**/
+BOOLEAN
+EFIAPI
+Pkcs7GetAttachedContent (
+  IN  CONST UINT8  *P7Data,
+  IN  UINTN        P7Length,
+  OUT VOID         **Content,
+  OUT UINTN        *ContentSize
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}

--- a/CryptoPkg/Library/BaseCryptLibMbedTls/Pk/CryptPkcs7VerifyRuntime.c
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/Pk/CryptPkcs7VerifyRuntime.c
@@ -1,0 +1,38 @@
+/** @file
+  Runtime specific implementation of PKCS#7 SignedData Verification Wrapper.
+
+Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "InternalCryptLib.h"
+
+/**
+  Extracts the attached content from a PKCS#7 signed data if existed. The input signed
+  data could be wrapped in a ContentInfo structure.
+
+  Return FALSE to indicate this interface is not supported.
+
+  @param[in]   P7Data       Pointer to the PKCS#7 signed data to process.
+  @param[in]   P7Length     Length of the PKCS#7 signed data in bytes.
+  @param[out]  Content      Pointer to the extracted content from the PKCS#7 signedData.
+                            It's caller's responsibility to free the buffer with FreePool().
+  @param[out]  ContentSize  The size of the extracted content in bytes.
+
+  @retval     TRUE          The P7Data was correctly formatted for processing.
+  @retval     FALSE         The P7Data was not correctly formatted for processing.
+
+**/
+BOOLEAN
+EFIAPI
+Pkcs7GetAttachedContent (
+  IN  CONST UINT8  *P7Data,
+  IN  UINTN        P7Length,
+  OUT VOID         **Content,
+  OUT UINTN        *ContentSize
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}

--- a/CryptoPkg/Library/BaseCryptLibMbedTls/Pk/CryptRsaBasic.c
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/Pk/CryptRsaBasic.c
@@ -1,0 +1,278 @@
+/** @file
+  RSA Asymmetric Cipher Wrapper Implementation over MbedTLS.
+
+  This file implements following APIs which provide basic capabilities for RSA:
+  1) RsaNew
+  2) RsaFree
+  3) RsaSetKey
+  4) RsaPkcs1Verify
+
+  RFC 8017 - PKCS #1: RSA Cryptography Specifications Version 2.2
+
+Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "InternalCryptLib.h"
+
+#include <mbedtls/rsa.h>
+
+/**
+  Allocates and initializes one RSA context for subsequent use.
+
+  @return  Pointer to the RSA context that has been initialized.
+           If the allocations fails, RsaNew() returns NULL.
+
+**/
+VOID *
+EFIAPI
+RsaNew (
+  VOID
+  )
+{
+  VOID  *RsaContext;
+
+  RsaContext = AllocateZeroPool (sizeof (mbedtls_rsa_context));
+  if (RsaContext == NULL) {
+    return RsaContext;
+  }
+
+  mbedtls_rsa_init (RsaContext);
+  if (mbedtls_rsa_set_padding (RsaContext, MBEDTLS_RSA_PKCS_V15, MBEDTLS_MD_NONE) != 0) {
+    return NULL;
+  }
+
+  return RsaContext;
+}
+
+/**
+  Release the specified RSA context.
+
+  @param[in]  RsaContext  Pointer to the RSA context to be released.
+
+**/
+VOID
+EFIAPI
+RsaFree (
+  IN  VOID  *RsaContext
+  )
+{
+  mbedtls_rsa_free (RsaContext);
+  if (RsaContext != NULL) {
+    FreePool (RsaContext);
+  }
+}
+
+/**
+  Sets the tag-designated key component into the established RSA context.
+
+  This function sets the tag-designated RSA key component into the established
+  RSA context from the user-specified non-negative integer (octet string format
+  represented in RSA PKCS#1).
+  If BigNumber is NULL, then the specified key component in RSA context is cleared.
+
+  If RsaContext is NULL, then return FALSE.
+
+  @param[in, out]  RsaContext  Pointer to RSA context being set.
+  @param[in]       KeyTag      Tag of RSA key component being set.
+  @param[in]       BigNumber   Pointer to octet integer buffer.
+                               If NULL, then the specified key component in RSA
+                               context is cleared.
+  @param[in]       BnSize      Size of big number buffer in bytes.
+                               If BigNumber is NULL, then it is ignored.
+
+  @retval  TRUE   RSA key component was set successfully.
+  @retval  FALSE  Invalid RSA key component tag.
+
+**/
+BOOLEAN
+EFIAPI
+RsaSetKey (
+  IN OUT  VOID         *RsaContext,
+  IN      RSA_KEY_TAG  KeyTag,
+  IN      CONST UINT8  *BigNumber,
+  IN      UINTN        BnSize
+  )
+{
+  mbedtls_rsa_context  *RsaKey;
+  INT32                Ret;
+  mbedtls_mpi          Value;
+
+  //
+  // Check input parameters.
+  //
+  if ((RsaContext == NULL) || (BnSize > INT_MAX)) {
+    return FALSE;
+  }
+
+  mbedtls_mpi_init (&Value);
+
+  RsaKey = (mbedtls_rsa_context *)RsaContext;
+
+  // if BigNumber is Null clear
+  if (BigNumber != NULL) {
+    Ret = mbedtls_mpi_read_binary (&Value, BigNumber, BnSize);
+    if (Ret != 0) {
+      mbedtls_mpi_free (&Value);
+      return FALSE;
+    }
+  }
+
+  switch (KeyTag) {
+    case RsaKeyN:
+      Ret = mbedtls_rsa_import (
+              RsaKey,
+              &Value,
+              NULL,
+              NULL,
+              NULL,
+              NULL
+              );
+      break;
+    case RsaKeyE:
+      Ret = mbedtls_rsa_import (
+              RsaKey,
+              NULL,
+              NULL,
+              NULL,
+              NULL,
+              &Value
+              );
+      break;
+    case RsaKeyD:
+      Ret = mbedtls_rsa_import (
+              RsaKey,
+              NULL,
+              NULL,
+              NULL,
+              &Value,
+              NULL
+              );
+      break;
+    case RsaKeyQ:
+      Ret = mbedtls_rsa_import (
+              RsaKey,
+              NULL,
+              NULL,
+              &Value,
+              NULL,
+              NULL
+              );
+      break;
+    case RsaKeyP:
+      Ret = mbedtls_rsa_import (
+              RsaKey,
+              NULL,
+              &Value,
+              NULL,
+              NULL,
+              NULL
+              );
+      break;
+    case RsaKeyDp:
+    case RsaKeyDq:
+    case RsaKeyQInv:
+    default:
+      Ret = -1;
+      break;
+  }
+
+  mbedtls_mpi_free (&Value);
+  return Ret == 0;
+}
+
+/**
+  Verifies the RSA-SSA signature with EMSA-PKCS1-v1_5 encoding scheme defined in
+  RSA PKCS#1.
+
+  If RsaContext is NULL, then return FALSE.
+  If MessageHash is NULL, then return FALSE.
+  If Signature is NULL, then return FALSE.
+  If HashSize is not equal to the size of MD5, SHA-1, SHA-256, SHA-384 or SHA-512 digest, then return FALSE.
+
+  @param[in]  RsaContext   Pointer to RSA context for signature verification.
+  @param[in]  MessageHash  Pointer to octet message hash to be checked.
+  @param[in]  HashSize     Size of the message hash in bytes.
+  @param[in]  Signature    Pointer to RSA PKCS1-v1_5 signature to be verified.
+  @param[in]  SigSize      Size of signature in bytes.
+
+  @retval  TRUE   Valid signature encoded in PKCS1-v1_5.
+  @retval  FALSE  Invalid signature or invalid RSA context.
+
+**/
+BOOLEAN
+EFIAPI
+RsaPkcs1Verify (
+  IN  VOID         *RsaContext,
+  IN  CONST UINT8  *MessageHash,
+  IN  UINTN        HashSize,
+  IN  CONST UINT8  *Signature,
+  IN  UINTN        SigSize
+  )
+{
+  INT32                Ret;
+  mbedtls_md_type_t    md_alg;
+  mbedtls_rsa_context  *RsaKey;
+
+  if ((RsaContext == NULL) || (MessageHash == NULL) || (Signature == NULL)) {
+    return FALSE;
+  }
+
+  if ((SigSize > INT_MAX) || (SigSize == 0)) {
+    return FALSE;
+  }
+
+  RsaKey = (mbedtls_rsa_context *)RsaContext;
+  if (mbedtls_rsa_complete (RsaKey) != 0) {
+    return FALSE;
+  }
+
+  switch (HashSize) {
+ #ifdef ENABLE_MD5_DEPRECATED_INTERFACES
+    case MD5_DIGEST_SIZE:
+      md_alg = MBEDTLS_MD_MD5;
+      break;
+ #endif
+
+ #ifndef DISABLE_SHA1_DEPRECATED_INTERFACES
+    case SHA1_DIGEST_SIZE:
+      md_alg = MBEDTLS_MD_SHA1;
+      break;
+ #endif
+
+    case SHA256_DIGEST_SIZE:
+      md_alg = MBEDTLS_MD_SHA256;
+      break;
+
+    case SHA384_DIGEST_SIZE:
+      md_alg = MBEDTLS_MD_SHA384;
+      break;
+
+    case SHA512_DIGEST_SIZE:
+      md_alg = MBEDTLS_MD_SHA512;
+      break;
+
+    default:
+      return FALSE;
+  }
+
+  if (mbedtls_rsa_get_len (RsaContext) != SigSize) {
+    return FALSE;
+  }
+
+  mbedtls_rsa_set_padding (RsaContext, MBEDTLS_RSA_PKCS_V15, md_alg);
+
+  Ret = mbedtls_rsa_pkcs1_verify (
+          RsaContext,
+          md_alg,
+          (UINT32)HashSize,
+          MessageHash,
+          Signature
+          );
+  if (Ret != 0) {
+    return FALSE;
+  }
+
+  return TRUE;
+}

--- a/CryptoPkg/Library/BaseCryptLibMbedTls/Pk/CryptRsaBasicNull.c
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/Pk/CryptRsaBasicNull.c
@@ -1,0 +1,121 @@
+/** @file
+  RSA Asymmetric Cipher Wrapper Null Implementation.
+
+  This file implements following APIs which provide basic capabilities for RSA:
+  1) RsaNew
+  2) RsaFree
+  3) RsaSetKey
+  4) RsaPkcs1Verify
+
+Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "InternalCryptLib.h"
+
+/**
+  Allocates and initializes one RSA context for subsequent use.
+
+  @return  Pointer to the RSA context that has been initialized.
+           If the allocations fails, RsaNew() returns NULL.
+
+**/
+VOID *
+EFIAPI
+RsaNew (
+  VOID
+  )
+{
+  //
+  // Allocates & Initializes RSA Context
+  //
+  ASSERT (FALSE);
+  return NULL;
+}
+
+/**
+  Release the specified RSA context.
+
+  @param[in]  RsaContext  Pointer to the RSA context to be released.
+
+**/
+VOID
+EFIAPI
+RsaFree (
+  IN  VOID  *RsaContext
+  )
+{
+  //
+  // Free RSA Context
+  //
+  ASSERT (FALSE);
+}
+
+/**
+  Sets the tag-designated key component into the established RSA context.
+
+  This function sets the tag-designated RSA key component into the established
+  RSA context from the user-specified non-negative integer (octet string format
+  represented in RSA PKCS#1).
+  If BigNumber is NULL, then the specified key component in RSA context is cleared.
+
+  If RsaContext is NULL, then return FALSE.
+
+  @param[in, out]  RsaContext  Pointer to RSA context being set.
+  @param[in]       KeyTag      Tag of RSA key component being set.
+  @param[in]       BigNumber   Pointer to octet integer buffer.
+                               If NULL, then the specified key component in RSA
+                               context is cleared.
+  @param[in]       BnSize      Size of big number buffer in bytes.
+                               If BigNumber is NULL, then it is ignored.
+
+  @retval  TRUE   RSA key component was set successfully.
+  @retval  FALSE  Invalid RSA key component tag.
+
+**/
+BOOLEAN
+EFIAPI
+RsaSetKey (
+  IN OUT  VOID         *RsaContext,
+  IN      RSA_KEY_TAG  KeyTag,
+  IN      CONST UINT8  *BigNumber,
+  IN      UINTN        BnSize
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Verifies the RSA-SSA signature with EMSA-PKCS1-v1_5 encoding scheme defined in
+  RSA PKCS#1.
+
+  If RsaContext is NULL, then return FALSE.
+  If MessageHash is NULL, then return FALSE.
+  If Signature is NULL, then return FALSE.
+  If HashSize is not equal to the size of MD5, SHA-1 or SHA-256 digest, then return FALSE.
+
+  @param[in]  RsaContext   Pointer to RSA context for signature verification.
+  @param[in]  MessageHash  Pointer to octet message hash to be checked.
+  @param[in]  HashSize     Size of the message hash in bytes.
+  @param[in]  Signature    Pointer to RSA PKCS1-v1_5 signature to be verified.
+  @param[in]  SigSize      Size of signature in bytes.
+
+  @retval  TRUE   Valid signature encoded in PKCS1-v1_5.
+  @retval  FALSE  Invalid signature or invalid RSA context.
+
+**/
+BOOLEAN
+EFIAPI
+RsaPkcs1Verify (
+  IN  VOID         *RsaContext,
+  IN  CONST UINT8  *MessageHash,
+  IN  UINTN        HashSize,
+  IN  CONST UINT8  *Signature,
+  IN  UINTN        SigSize
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}

--- a/CryptoPkg/Library/BaseCryptLibMbedTls/Pk/CryptRsaExtNull.c
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/Pk/CryptRsaExtNull.c
@@ -1,0 +1,117 @@
+/** @file
+  RSA Asymmetric Cipher Wrapper Implementation over MbedTLS.
+
+  This file does not provide real capabilities for following APIs in RSA handling:
+  1) RsaGetKey
+  2) RsaGenerateKey
+  3) RsaCheckKey
+  4) RsaPkcs1Sign
+
+Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "InternalCryptLib.h"
+
+/**
+  Gets the tag-designated RSA key component from the established RSA context.
+
+  Return FALSE to indicate this interface is not supported.
+
+  @param[in, out]  RsaContext  Pointer to RSA context being set.
+  @param[in]       KeyTag      Tag of RSA key component being set.
+  @param[out]      BigNumber   Pointer to octet integer buffer.
+  @param[in, out]  BnSize      On input, the size of big number buffer in bytes.
+                               On output, the size of data returned in big number buffer in bytes.
+
+  @retval FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+RsaGetKey (
+  IN OUT  VOID         *RsaContext,
+  IN      RSA_KEY_TAG  KeyTag,
+  OUT     UINT8        *BigNumber,
+  IN OUT  UINTN        *BnSize
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Generates RSA key components.
+
+  Return FALSE to indicate this interface is not supported.
+
+  @param[in, out]  RsaContext           Pointer to RSA context being set.
+  @param[in]       ModulusLength        Length of RSA modulus N in bits.
+  @param[in]       PublicExponent       Pointer to RSA public exponent.
+  @param[in]       PublicExponentSize   Size of RSA public exponent buffer in bytes.
+
+  @retval FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+RsaGenerateKey (
+  IN OUT  VOID         *RsaContext,
+  IN      UINTN        ModulusLength,
+  IN      CONST UINT8  *PublicExponent,
+  IN      UINTN        PublicExponentSize
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Validates key components of RSA context.
+
+  Return FALSE to indicate this interface is not supported.
+
+  @param[in]  RsaContext  Pointer to RSA context to check.
+
+  @retval FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+RsaCheckKey (
+  IN  VOID  *RsaContext
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Carries out the RSA-SSA signature generation with EMSA-PKCS1-v1_5 encoding scheme.
+
+  Return FALSE to indicate this interface is not supported.
+
+  @param[in]       RsaContext   Pointer to RSA context for signature generation.
+  @param[in]       MessageHash  Pointer to octet message hash to be signed.
+  @param[in]       HashSize     Size of the message hash in bytes.
+  @param[out]      Signature    Pointer to buffer to receive RSA PKCS1-v1_5 signature.
+  @param[in, out]  SigSize      On input, the size of Signature buffer in bytes.
+                                On output, the size of data returned in Signature buffer in bytes.
+
+  @retval FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+RsaPkcs1Sign (
+  IN      VOID         *RsaContext,
+  IN      CONST UINT8  *MessageHash,
+  IN      UINTN        HashSize,
+  OUT     UINT8        *Signature,
+  IN OUT  UINTN        *SigSize
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}

--- a/CryptoPkg/Library/BaseCryptLibMbedTls/Pk/CryptRsaPss.c
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/Pk/CryptRsaPss.c
@@ -1,0 +1,174 @@
+/** @file
+  RSA Asymmetric Cipher Wrapper Implementation over MbedTLS.
+
+  This file implements following APIs which provide basic capabilities for RSA:
+  1) RsaPssVerify
+
+Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "InternalCryptLib.h"
+#include <mbedtls/rsa.h>
+
+/**
+  Verifies the RSA signature with RSASSA-PSS signature scheme defined in RFC 8017.
+  Implementation determines salt length automatically from the signature encoding.
+  Mask generation function is the same as the message digest algorithm.
+  Salt length should be equal to digest length.
+
+  @param[in]  RsaContext      Pointer to RSA context for signature verification.
+  @param[in]  Message         Pointer to octet message to be verified.
+  @param[in]  MsgSize         Size of the message in bytes.
+  @param[in]  Signature       Pointer to RSASSA-PSS signature to be verified.
+  @param[in]  SigSize         Size of signature in bytes.
+  @param[in]  DigestLen       Length of digest for RSA operation.
+  @param[in]  SaltLen         Salt length for PSS encoding.
+
+  @retval  TRUE   Valid signature encoded in RSASSA-PSS.
+  @retval  FALSE  Invalid signature or invalid RSA context.
+
+**/
+BOOLEAN
+EFIAPI
+RsaPssVerify (
+  IN  VOID         *RsaContext,
+  IN  CONST UINT8  *Message,
+  IN  UINTN        MsgSize,
+  IN  CONST UINT8  *Signature,
+  IN  UINTN        SigSize,
+  IN  UINT16       DigestLen,
+  IN  UINT16       SaltLen
+  )
+{
+  INT32                Ret;
+  mbedtls_md_type_t    md_alg;
+  UINT8                HashValue[SHA512_DIGEST_SIZE];
+  BOOLEAN              Status;
+  UINTN                ShaCtxSize;
+  VOID                 *ShaCtx;
+  mbedtls_rsa_context  *RsaKey;
+
+  if (RsaContext == NULL) {
+    return FALSE;
+  }
+
+  if ((Message == NULL) || (MsgSize == 0) || (MsgSize > INT_MAX)) {
+    return FALSE;
+  }
+
+  if (SaltLen != DigestLen) {
+    return FALSE;
+  }
+
+  if ((Signature == NULL) || (SigSize == 0) || (SigSize > INT_MAX)) {
+    return FALSE;
+  }
+
+  RsaKey = (mbedtls_rsa_context *)RsaContext;
+  if (mbedtls_rsa_complete (RsaKey) != 0) {
+    return FALSE;
+  }
+
+  ZeroMem (HashValue, DigestLen);
+
+  switch (DigestLen) {
+    case SHA256_DIGEST_SIZE:
+      md_alg     = MBEDTLS_MD_SHA256;
+      ShaCtxSize = Sha256GetContextSize ();
+      ShaCtx     = AllocateZeroPool (ShaCtxSize);
+
+      Status = Sha256Init (ShaCtx);
+      if (!Status) {
+        return FALSE;
+      }
+
+      Status = Sha256Update (ShaCtx, Message, MsgSize);
+      if (!Status) {
+        FreePool (ShaCtx);
+        return FALSE;
+      }
+
+      Status = Sha256Final (ShaCtx, HashValue);
+      if (!Status) {
+        FreePool (ShaCtx);
+        return FALSE;
+      }
+
+      FreePool (ShaCtx);
+      break;
+
+    case SHA384_DIGEST_SIZE:
+      md_alg     = MBEDTLS_MD_SHA384;
+      ShaCtxSize = Sha384GetContextSize ();
+      ShaCtx     = AllocateZeroPool (ShaCtxSize);
+
+      Status = Sha384Init (ShaCtx);
+      if (!Status) {
+        return FALSE;
+      }
+
+      Status = Sha384Update (ShaCtx, Message, MsgSize);
+      if (!Status) {
+        FreePool (ShaCtx);
+        return FALSE;
+      }
+
+      Status = Sha384Final (ShaCtx, HashValue);
+      if (!Status) {
+        FreePool (ShaCtx);
+        return FALSE;
+      }
+
+      FreePool (ShaCtx);
+      break;
+
+    case SHA512_DIGEST_SIZE:
+      md_alg     = MBEDTLS_MD_SHA512;
+      ShaCtxSize = Sha512GetContextSize ();
+      ShaCtx     = AllocateZeroPool (ShaCtxSize);
+
+      Status = Sha512Init (ShaCtx);
+      if (!Status) {
+        return FALSE;
+      }
+
+      Status = Sha512Update (ShaCtx, Message, MsgSize);
+      if (!Status) {
+        FreePool (ShaCtx);
+        return FALSE;
+      }
+
+      Status = Sha512Final (ShaCtx, HashValue);
+      if (!Status) {
+        FreePool (ShaCtx);
+        return FALSE;
+      }
+
+      FreePool (ShaCtx);
+      break;
+
+    default:
+      return FALSE;
+  }
+
+  if (mbedtls_rsa_get_len (RsaContext) != SigSize) {
+    return FALSE;
+  }
+
+  mbedtls_rsa_set_padding (RsaContext, MBEDTLS_RSA_PKCS_V21, md_alg);
+
+  Ret = mbedtls_rsa_rsassa_pss_verify (
+          RsaContext,
+          md_alg,
+          (UINT32)DigestLen,
+          HashValue,
+          Signature
+          );
+  if (Ret != 0) {
+    return FALSE;
+  }
+
+  return TRUE;
+}

--- a/CryptoPkg/Library/BaseCryptLibMbedTls/Pk/CryptRsaPssNull.c
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/Pk/CryptRsaPssNull.c
@@ -1,0 +1,46 @@
+/** @file
+  RSA-PSS Asymmetric Cipher Wrapper Implementation over MbedTLS.
+
+  This file does not provide real capabilities for following APIs in RSA handling:
+  1) RsaPssVerify
+
+Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "InternalCryptLib.h"
+
+/**
+  Verifies the RSA signature with RSASSA-PSS signature scheme defined in RFC 8017.
+  Implementation determines salt length automatically from the signature encoding.
+  Mask generation function is the same as the message digest algorithm.
+  Salt length should be equal to digest length.
+
+  @param[in]  RsaContext      Pointer to RSA context for signature verification.
+  @param[in]  Message         Pointer to octet message to be verified.
+  @param[in]  MsgSize         Size of the message in bytes.
+  @param[in]  Signature       Pointer to RSASSA-PSS signature to be verified.
+  @param[in]  SigSize         Size of signature in bytes.
+  @param[in]  DigestLen       Length of digest for RSA operation.
+  @param[in]  SaltLen         Salt length for PSS encoding.
+
+  @retval  TRUE   Valid signature encoded in RSASSA-PSS.
+  @retval  FALSE  Invalid signature or invalid RSA context.
+
+**/
+BOOLEAN
+EFIAPI
+RsaPssVerify (
+  IN  VOID         *RsaContext,
+  IN  CONST UINT8  *Message,
+  IN  UINTN        MsgSize,
+  IN  CONST UINT8  *Signature,
+  IN  UINTN        SigSize,
+  IN  UINT16       DigestLen,
+  IN  UINT16       SaltLen
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}

--- a/CryptoPkg/Library/BaseCryptLibMbedTls/Pk/CryptRsaPssSignNull.c
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/Pk/CryptRsaPssSignNull.c
@@ -1,0 +1,60 @@
+/** @file
+  RSA-PSS Asymmetric Cipher Wrapper Implementation over MbedTLS.
+
+  This file does not provide real capabilities for following APIs in RSA handling:
+  1) RsaPssSign
+
+Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "InternalCryptLib.h"
+
+/**
+  Carries out the RSA-SSA signature generation with EMSA-PSS encoding scheme.
+
+  This function carries out the RSA-SSA signature generation with EMSA-PSS encoding scheme defined in
+  RFC 8017.
+  Mask generation function is the same as the message digest algorithm.
+  If the Signature buffer is too small to hold the contents of signature, FALSE
+  is returned and SigSize is set to the required buffer size to obtain the signature.
+
+  If RsaContext is NULL, then return FALSE.
+  If Message is NULL, then return FALSE.
+  If MsgSize is zero or > INT_MAX, then return FALSE.
+  If DigestLen is NOT 32, 48 or 64, return FALSE.
+  If SaltLen is not equal to DigestLen, then return FALSE.
+  If SigSize is large enough but Signature is NULL, then return FALSE.
+  If this interface is not supported, then return FALSE.
+
+  @param[in]      RsaContext   Pointer to RSA context for signature generation.
+  @param[in]      Message      Pointer to octet message to be signed.
+  @param[in]      MsgSize      Size of the message in bytes.
+  @param[in]      DigestLen    Length of the digest in bytes to be used for RSA signature operation.
+  @param[in]      SaltLen      Length of the salt in bytes to be used for PSS encoding.
+  @param[out]     Signature    Pointer to buffer to receive RSA PSS signature.
+  @param[in, out] SigSize      On input, the size of Signature buffer in bytes.
+                               On output, the size of data returned in Signature buffer in bytes.
+
+  @retval  TRUE   Signature successfully generated in RSASSA-PSS.
+  @retval  FALSE  Signature generation failed.
+  @retval  FALSE  SigSize is too small.
+  @retval  FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+RsaPssSign (
+  IN      VOID         *RsaContext,
+  IN      CONST UINT8  *Message,
+  IN      UINTN        MsgSize,
+  IN      UINT16       DigestLen,
+  IN      UINT16       SaltLen,
+  OUT     UINT8        *Signature,
+  IN OUT  UINTN        *SigSize
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}

--- a/CryptoPkg/Library/BaseCryptLibMbedTls/Pk/CryptTsNull.c
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/Pk/CryptTsNull.c
@@ -1,0 +1,42 @@
+/** @file
+  RFC3161 Timestamp Countersignature Verification Wrapper Implementation which does
+  not provide real capabilities.
+
+Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "InternalCryptLib.h"
+
+/**
+  Verifies the validity of a RFC3161 Timestamp CounterSignature embedded in PE/COFF Authenticode
+  signature.
+
+  Return FALSE to indicate this interface is not supported.
+
+  @param[in]  AuthData     Pointer to the Authenticode Signature retrieved from signed
+                           PE/COFF image to be verified.
+  @param[in]  DataSize     Size of the Authenticode Signature in bytes.
+  @param[in]  TsaCert      Pointer to a trusted/root TSA certificate encoded in DER, which
+                           is used for TSA certificate chain verification.
+  @param[in]  CertSize     Size of the trusted certificate in bytes.
+  @param[out] SigningTime  Return the time of timestamp generation time if the timestamp
+                           signature is valid.
+
+  @retval  FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+ImageTimestampVerify (
+  IN  CONST UINT8  *AuthData,
+  IN  UINTN        DataSize,
+  IN  CONST UINT8  *TsaCert,
+  IN  UINTN        CertSize,
+  OUT EFI_TIME     *SigningTime
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}

--- a/CryptoPkg/Library/BaseCryptLibMbedTls/Pk/CryptX509Null.c
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/Pk/CryptX509Null.c
@@ -1,0 +1,753 @@
+/** @file
+  X.509 Certificate Handler Wrapper Implementation which does not provide
+  real capabilities.
+
+Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "InternalCryptLib.h"
+
+/**
+  Construct a X509 object from DER-encoded certificate data.
+
+  Return FALSE to indicate this interface is not supported.
+
+  @param[in]  Cert            Pointer to the DER-encoded certificate data.
+  @param[in]  CertSize        The size of certificate data in bytes.
+  @param[out] SingleX509Cert  The generated X509 object.
+
+  @retval FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+X509ConstructCertificate (
+  IN   CONST UINT8  *Cert,
+  IN   UINTN        CertSize,
+  OUT  UINT8        **SingleX509Cert
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Construct a X509 stack object from a list of DER-encoded certificate data.
+
+  If X509Stack is NULL, then return FALSE.
+  If this interface is not supported, then return FALSE.
+
+  @param[in, out]  X509Stack  On input, pointer to an existing or NULL X509 stack object.
+                              On output, pointer to the X509 stack object with new
+                              inserted X509 certificate.
+  @param[in]       Args       VA_LIST marker for the variable argument list.
+                              A list of DER-encoded single certificate data followed
+                              by certificate size. A NULL terminates the list. The
+                              pairs are the arguments to X509ConstructCertificate().
+
+  @retval     TRUE            The X509 stack construction succeeded.
+  @retval     FALSE           The construction operation failed.
+  @retval     FALSE           This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+X509ConstructCertificateStackV (
+  IN OUT  UINT8    **X509Stack,
+  IN      VA_LIST  Args
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Construct a X509 stack object from a list of DER-encoded certificate data.
+
+  Return FALSE to indicate this interface is not supported.
+
+  @param[in, out]  X509Stack  On input, pointer to an existing or NULL X509 stack object.
+                              On output, pointer to the X509 stack object with new
+                              inserted X509 certificate.
+  @param           ...        A list of DER-encoded single certificate data followed
+                              by certificate size. A NULL terminates the list. The
+                              pairs are the arguments to X509ConstructCertificate().
+
+  @retval FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+X509ConstructCertificateStack (
+  IN OUT  UINT8  **X509Stack,
+  ...
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Release the specified X509 object.
+
+  If the interface is not supported, then ASSERT().
+
+  @param[in]  X509Cert  Pointer to the X509 object to be released.
+
+**/
+VOID
+EFIAPI
+X509Free (
+  IN  VOID  *X509Cert
+  )
+{
+  ASSERT (FALSE);
+}
+
+/**
+  Release the specified X509 stack object.
+
+  If the interface is not supported, then ASSERT().
+
+  @param[in]  X509Stack  Pointer to the X509 stack object to be released.
+
+**/
+VOID
+EFIAPI
+X509StackFree (
+  IN  VOID  *X509Stack
+  )
+{
+  ASSERT (FALSE);
+}
+
+/**
+  Retrieve the subject bytes from one X.509 certificate.
+
+  Return FALSE to indicate this interface is not supported.
+
+  @param[in]      Cert         Pointer to the DER-encoded X509 certificate.
+  @param[in]      CertSize     Size of the X509 certificate in bytes.
+  @param[out]     CertSubject  Pointer to the retrieved certificate subject bytes.
+  @param[in, out] SubjectSize  The size in bytes of the CertSubject buffer on input,
+                               and the size of buffer returned CertSubject on output.
+
+
+  @retval FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+X509GetSubjectName (
+  IN      CONST UINT8  *Cert,
+  IN      UINTN        CertSize,
+  OUT     UINT8        *CertSubject,
+  IN OUT  UINTN        *SubjectSize
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Retrieve the common name (CN) string from one X.509 certificate.
+
+  Return RETURN_UNSUPPORTED to indicate this interface is not supported.
+
+  @param[in]      Cert             Pointer to the DER-encoded X509 certificate.
+  @param[in]      CertSize         Size of the X509 certificate in bytes.
+  @param[out]     CommonName       Buffer to contain the retrieved certificate common
+                                   name string (UTF8). At most CommonNameSize bytes will be
+                                   written and the string will be null terminated. May be
+                                   NULL in order to determine the size buffer needed.
+  @param[in,out]  CommonNameSize   The size in bytes of the CommonName buffer on input,
+                                   and the size of buffer returned CommonName on output.
+                                   If CommonName is NULL then the amount of space needed
+                                   in buffer (including the final null) is returned.
+
+  @retval RETURN_UNSUPPORTED       The operation is not supported.
+
+**/
+RETURN_STATUS
+EFIAPI
+X509GetCommonName (
+  IN      CONST UINT8  *Cert,
+  IN      UINTN        CertSize,
+  OUT     CHAR8        *CommonName   OPTIONAL,
+  IN OUT  UINTN        *CommonNameSize
+  )
+{
+  ASSERT (FALSE);
+  return RETURN_UNSUPPORTED;
+}
+
+/**
+  Retrieve the organization name (ON) string from one X.509 certificate.
+
+  Return RETURN_UNSUPPORTED to indicate this interface is not supported.
+
+  @param[in]      Cert             Pointer to the DER-encoded X509 certificate.
+  @param[in]      CertSize         Size of the X509 certificate in bytes.
+  @param[out]     NameBuffer       Buffer to contain the retrieved certificate organization
+                                   name string. At most NameBufferSize bytes will be
+                                   written and the string will be null terminated. May be
+                                   NULL in order to determine the size buffer needed.
+  @param[in,out]  NameBufferSize   The size in bytes of the Name buffer on input,
+                                   and the size of buffer returned Name on output.
+                                   If NameBuffer is NULL then the amount of space needed
+                                   in buffer (including the final null) is returned.
+
+  @retval RETURN_UNSUPPORTED       The operation is not supported.
+
+**/
+RETURN_STATUS
+EFIAPI
+X509GetOrganizationName (
+  IN      CONST UINT8  *Cert,
+  IN      UINTN        CertSize,
+  OUT     CHAR8        *NameBuffer   OPTIONAL,
+  IN OUT  UINTN        *NameBufferSize
+  )
+{
+  ASSERT (FALSE);
+  return RETURN_UNSUPPORTED;
+}
+
+/**
+  Retrieve the RSA Public Key from one DER-encoded X509 certificate.
+
+  Return FALSE to indicate this interface is not supported.
+
+  @param[in]  Cert         Pointer to the DER-encoded X509 certificate.
+  @param[in]  CertSize     Size of the X509 certificate in bytes.
+  @param[out] RsaContext   Pointer to new-generated RSA context which contain the retrieved
+                           RSA public key component. Use RsaFree() function to free the
+                           resource.
+
+  @retval FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+RsaGetPublicKeyFromX509 (
+  IN   CONST UINT8  *Cert,
+  IN   UINTN        CertSize,
+  OUT  VOID         **RsaContext
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Verify one X509 certificate was issued by the trusted CA.
+
+  Return FALSE to indicate this interface is not supported.
+
+  @param[in]      Cert         Pointer to the DER-encoded X509 certificate to be verified.
+  @param[in]      CertSize     Size of the X509 certificate in bytes.
+  @param[in]      CACert       Pointer to the DER-encoded trusted CA certificate.
+  @param[in]      CACertSize   Size of the CA Certificate in bytes.
+
+  @retval FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+X509VerifyCert (
+  IN  CONST UINT8  *Cert,
+  IN  UINTN        CertSize,
+  IN  CONST UINT8  *CACert,
+  IN  UINTN        CACertSize
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Retrieve the TBSCertificate from one given X.509 certificate.
+
+  Return FALSE to indicate this interface is not supported.
+
+  @param[in]      Cert         Pointer to the given DER-encoded X509 certificate.
+  @param[in]      CertSize     Size of the X509 certificate in bytes.
+  @param[out]     TBSCert      DER-Encoded To-Be-Signed certificate.
+  @param[out]     TBSCertSize  Size of the TBS certificate in bytes.
+
+  @retval  FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+X509GetTBSCert (
+  IN  CONST UINT8  *Cert,
+  IN  UINTN        CertSize,
+  OUT UINT8        **TBSCert,
+  OUT UINTN        *TBSCertSize
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Retrieve the EC Public Key from one DER-encoded X509 certificate.
+
+  @param[in]  Cert         Pointer to the DER-encoded X509 certificate.
+  @param[in]  CertSize     Size of the X509 certificate in bytes.
+  @param[out] EcContext    Pointer to new-generated EC DSA context which contain the retrieved
+                           EC public key component. Use EcFree() function to free the
+                           resource.
+
+  If Cert is NULL, then return FALSE.
+  If EcContext is NULL, then return FALSE.
+
+  @retval  TRUE   EC Public Key was retrieved successfully.
+  @retval  FALSE  Fail to retrieve EC public key from X509 certificate.
+
+**/
+BOOLEAN
+EFIAPI
+EcGetPublicKeyFromX509 (
+  IN   CONST UINT8  *Cert,
+  IN   UINTN        CertSize,
+  OUT  VOID         **EcContext
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Retrieve the version from one X.509 certificate.
+
+  If Cert is NULL, then return FALSE.
+  If CertSize is 0, then return FALSE.
+  If this interface is not supported, then return FALSE.
+
+  @param[in]      Cert         Pointer to the DER-encoded X509 certificate.
+  @param[in]      CertSize     Size of the X509 certificate in bytes.
+  @param[out]     Version      Pointer to the retrieved version integer.
+
+  @retval TRUE           The certificate version retrieved successfully.
+  @retval FALSE          If  Cert is NULL or CertSize is Zero.
+  @retval FALSE          The operation is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+X509GetVersion (
+  IN      CONST UINT8  *Cert,
+  IN      UINTN        CertSize,
+  OUT     UINTN        *Version
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Retrieve the serialNumber from one X.509 certificate.
+
+  If Cert is NULL, then return FALSE.
+  If CertSize is 0, then return FALSE.
+  If this interface is not supported, then return FALSE.
+
+  @param[in]      Cert         Pointer to the DER-encoded X509 certificate.
+  @param[in]      CertSize     Size of the X509 certificate in bytes.
+  @param[out]     SerialNumber  Pointer to the retrieved certificate SerialNumber bytes.
+  @param[in, out] SerialNumberSize  The size in bytes of the SerialNumber buffer on input,
+                               and the size of buffer returned SerialNumber on output.
+
+  @retval TRUE                     The certificate serialNumber retrieved successfully.
+  @retval FALSE                    If Cert is NULL or CertSize is Zero.
+                                   If SerialNumberSize is NULL.
+                                   If Certificate is invalid.
+  @retval FALSE                    If no SerialNumber exists.
+  @retval FALSE                    If the SerialNumber is NULL. The required buffer size
+                                   (including the final null) is returned in the
+                                   SerialNumberSize parameter.
+  @retval FALSE                    The operation is not supported.
+**/
+BOOLEAN
+EFIAPI
+X509GetSerialNumber (
+  IN      CONST UINT8  *Cert,
+  IN      UINTN        CertSize,
+  OUT     UINT8        *SerialNumber,
+  OPTIONAL
+  IN OUT  UINTN        *SerialNumberSize
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Retrieve the issuer bytes from one X.509 certificate.
+
+  If Cert is NULL, then return FALSE.
+  If CertIssuerSize is NULL, then return FALSE.
+  If this interface is not supported, then return FALSE.
+
+  @param[in]      Cert         Pointer to the DER-encoded X509 certificate.
+  @param[in]      CertSize     Size of the X509 certificate in bytes.
+  @param[out]     CertIssuer  Pointer to the retrieved certificate subject bytes.
+  @param[in, out] CertIssuerSize  The size in bytes of the CertIssuer buffer on input,
+                               and the size of buffer returned CertSubject on output.
+
+  @retval  TRUE   The certificate issuer retrieved successfully.
+  @retval  FALSE  Invalid certificate, or the CertIssuerSize is too small for the result.
+                  The CertIssuerSize will be updated with the required size.
+  @retval  FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+X509GetIssuerName (
+  IN      CONST UINT8  *Cert,
+  IN      UINTN        CertSize,
+  OUT     UINT8        *CertIssuer,
+  IN OUT  UINTN        *CertIssuerSize
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Retrieve the Signature Algorithm from one X.509 certificate.
+
+  @param[in]      Cert             Pointer to the DER-encoded X509 certificate.
+  @param[in]      CertSize         Size of the X509 certificate in bytes.
+  @param[out]     Oid              Signature Algorithm Object identifier buffer.
+  @param[in,out]  OidSize          Signature Algorithm Object identifier buffer size
+
+  @retval TRUE           The certificate Extension data retrieved successfully.
+  @retval FALSE                    If Cert is NULL.
+                                   If OidSize is NULL.
+                                   If Oid is not NULL and *OidSize is 0.
+                                   If Certificate is invalid.
+  @retval FALSE                    If no SignatureType.
+  @retval FALSE                    If the Oid is NULL. The required buffer size
+                                   is returned in the OidSize.
+  @retval FALSE                    The operation is not supported.
+**/
+BOOLEAN
+EFIAPI
+X509GetSignatureAlgorithm (
+  IN CONST UINT8  *Cert,
+  IN       UINTN  CertSize,
+  OUT   UINT8     *Oid,
+  OPTIONAL
+  IN OUT   UINTN  *OidSize
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Retrieve Extension data from one X.509 certificate.
+
+  @param[in]      Cert             Pointer to the DER-encoded X509 certificate.
+  @param[in]      CertSize         Size of the X509 certificate in bytes.
+  @param[in]      Oid              Object identifier buffer
+  @param[in]      OidSize          Object identifier buffer size
+  @param[out]     ExtensionData    Extension bytes.
+  @param[in, out] ExtensionDataSize Extension bytes size.
+
+  @retval TRUE                     The certificate Extension data retrieved successfully.
+  @retval FALSE                    If Cert is NULL.
+                                   If ExtensionDataSize is NULL.
+                                   If ExtensionData is not NULL and *ExtensionDataSize is 0.
+                                   If Certificate is invalid.
+  @retval FALSE                    If no Extension entry match Oid.
+  @retval FALSE                    If the ExtensionData is NULL. The required buffer size
+                                   is returned in the ExtensionDataSize parameter.
+  @retval FALSE                    The operation is not supported.
+**/
+BOOLEAN
+EFIAPI
+X509GetExtensionData (
+  IN     CONST UINT8  *Cert,
+  IN     UINTN        CertSize,
+  IN     CONST UINT8  *Oid,
+  IN     UINTN        OidSize,
+  OUT UINT8           *ExtensionData,
+  IN OUT UINTN        *ExtensionDataSize
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Retrieve the Extended Key Usage from one X.509 certificate.
+
+  @param[in]      Cert             Pointer to the DER-encoded X509 certificate.
+  @param[in]      CertSize         Size of the X509 certificate in bytes.
+  @param[out]     Usage            Key Usage bytes.
+  @param[in, out] UsageSize        Key Usage buffer sizs in bytes.
+
+  @retval TRUE                     The Usage bytes retrieve successfully.
+  @retval FALSE                    If Cert is NULL.
+                                   If CertSize is NULL.
+                                   If Usage is not NULL and *UsageSize is 0.
+                                   If Cert is invalid.
+  @retval FALSE                    If the Usage is NULL. The required buffer size
+                                   is returned in the UsageSize parameter.
+  @retval FALSE                    The operation is not supported.
+**/
+BOOLEAN
+EFIAPI
+X509GetExtendedKeyUsage (
+  IN     CONST UINT8  *Cert,
+  IN     UINTN        CertSize,
+  OUT UINT8           *Usage,
+  IN OUT UINTN        *UsageSize
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Retrieve the Validity from one X.509 certificate
+
+  If Cert is NULL, then return FALSE.
+  If CertIssuerSize is NULL, then return FALSE.
+  If this interface is not supported, then return FALSE.
+
+  @param[in]      Cert         Pointer to the DER-encoded X509 certificate.
+  @param[in]      CertSize     Size of the X509 certificate in bytes.
+  @param[in]      From         notBefore Pointer to DateTime object.
+  @param[in,out]  FromSize     notBefore DateTime object size.
+  @param[in]     To           notAfter Pointer to DateTime object.
+  @param[in,out]  ToSize       notAfter DateTime object size.
+
+  Note: X509CompareDateTime to compare DateTime oject
+        x509SetDateTime to get a DateTime object from a DateTimeStr
+
+  @retval  TRUE   The certificate Validity retrieved successfully.
+  @retval  FALSE  Invalid certificate, or Validity retrieve failed.
+  @retval  FALSE  This interface is not supported.
+**/
+BOOLEAN
+EFIAPI
+X509GetValidity  (
+  IN     CONST UINT8  *Cert,
+  IN     UINTN        CertSize,
+  IN     UINT8        *From,
+  IN OUT UINTN        *FromSize,
+  IN     UINT8        *To,
+  IN OUT UINTN        *ToSize
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Format a DateTimeStr to DataTime object in DataTime Buffer
+
+  If DateTimeStr is NULL, then return FALSE.
+  If DateTimeSize is NULL, then return FALSE.
+  If this interface is not supported, then return FALSE.
+
+  @param[in]      DateTimeStr      DateTime string like YYYYMMDDhhmmssZ
+                                   Ref: https://www.w3.org/TR/NOTE-datetime
+                                   Z stand for UTC time
+  @param[out]     DateTime         Pointer to a DateTime object.
+  @param[in,out]  DateTimeSize     DateTime object buffer size.
+
+  @retval TRUE                     The DateTime object create successfully.
+  @retval FALSE                    If DateTimeStr is NULL.
+                                   If DateTimeSize is NULL.
+                                   If DateTime is not NULL and *DateTimeSize is 0.
+                                   If Year Month Day Hour Minute Second combination is invalid datetime.
+  @retval FALSE                    If the DateTime is NULL. The required buffer size
+                                   (including the final null) is returned in the
+                                   DateTimeSize parameter.
+  @retval FALSE                    The operation is not supported.
+**/
+BOOLEAN
+EFIAPI
+X509FormatDateTime (
+  IN CONST CHAR8  *DateTimeStr,
+  OUT VOID        *DateTime,
+  IN OUT UINTN    *DateTimeSize
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Compare DateTime1 object and DateTime2 object.
+
+  If DateTime1 is NULL, then return -2.
+  If DateTime2 is NULL, then return -2.
+  If DateTime1 == DateTime2, then return 0
+  If DateTime1 > DateTime2, then return 1
+  If DateTime1 < DateTime2, then return -1
+
+  @param[in]      DateTime1         Pointer to a DateTime Ojbect
+  @param[in]      DateTime2         Pointer to a DateTime Object
+
+  @retval  0      If DateTime1 == DateTime2
+  @retval  1      If DateTime1 > DateTime2
+  @retval  -1     If DateTime1 < DateTime2
+**/
+INT32
+EFIAPI
+X509CompareDateTime (
+  IN  CONST  VOID  *DateTime1,
+  IN  CONST  VOID  *DateTime2
+  )
+{
+  ASSERT (FALSE);
+  return -3;
+}
+
+/**
+  Retrieve the Key Usage from one X.509 certificate.
+
+  @param[in]      Cert             Pointer to the DER-encoded X509 certificate.
+  @param[in]      CertSize         Size of the X509 certificate in bytes.
+  @param[out]     Usage            Key Usage (CRYPTO_X509_KU_*)
+
+  @retval  TRUE   The certificate Key Usage retrieved successfully.
+  @retval  FALSE  Invalid certificate, or Usage is NULL
+  @retval  FALSE  This interface is not supported.
+**/
+BOOLEAN
+EFIAPI
+X509GetKeyUsage (
+  IN    CONST UINT8  *Cert,
+  IN    UINTN        CertSize,
+  OUT   UINTN        *Usage
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Verify one X509 certificate was issued by the trusted CA.
+  @param[in]      RootCert          Trusted Root Certificate buffer
+
+  @param[in]      RootCertLength    Trusted Root Certificate buffer length
+  @param[in]      CertChain         One or more ASN.1 DER-encoded X.509 certificates
+                                    where the first certificate is signed by the Root
+                                    Certificate or is the Root Cerificate itself. and
+                                    subsequent cerificate is signed by the preceding
+                                    cerificate.
+  @param[in]      CertChainLength   Total length of the certificate chain, in bytes.
+
+  @retval  TRUE   All cerificates was issued by the first certificate in X509Certchain.
+  @retval  FALSE  Invalid certificate or the certificate was not issued by the given
+                  trusted CA.
+**/
+BOOLEAN
+EFIAPI
+X509VerifyCertChain (
+  IN CONST UINT8  *RootCert,
+  IN UINTN        RootCertLength,
+  IN CONST UINT8  *CertChain,
+  IN UINTN        CertChainLength
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Get one X509 certificate from CertChain.
+
+  @param[in]      CertChain         One or more ASN.1 DER-encoded X.509 certificates
+                                    where the first certificate is signed by the Root
+                                    Certificate or is the Root Cerificate itself. and
+                                    subsequent cerificate is signed by the preceding
+                                    cerificate.
+  @param[in]      CertChainLength   Total length of the certificate chain, in bytes.
+
+  @param[in]      CertIndex         Index of certificate.
+
+  @param[out]     Cert              The certificate at the index of CertChain.
+  @param[out]     CertLength        The length certificate at the index of CertChain.
+
+  @retval  TRUE   Success.
+  @retval  FALSE  Failed to get certificate from certificate chain.
+**/
+BOOLEAN
+EFIAPI
+X509GetCertFromCertChain (
+  IN CONST UINT8   *CertChain,
+  IN UINTN         CertChainLength,
+  IN CONST INT32   CertIndex,
+  OUT CONST UINT8  **Cert,
+  OUT UINTN        *CertLength
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Retrieve the tag and length of the tag.
+
+  @param Ptr      The position in the ASN.1 data
+  @param End      End of data
+  @param Length   The variable that will receive the length
+  @param Tag      The expected tag
+
+  @retval      TRUE   Get tag successful
+  @retval      FALSe  Failed to get tag or tag not match
+**/
+BOOLEAN
+EFIAPI
+Asn1GetTag (
+  IN OUT UINT8    **Ptr,
+  IN CONST UINT8  *End,
+  OUT UINTN       *Length,
+  IN     UINT32   Tag
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Retrieve the basic constraints from one X.509 certificate.
+
+  @param[in]      Cert                     Pointer to the DER-encoded X509 certificate.
+  @param[in]      CertSize                 size of the X509 certificate in bytes.
+  @param[out]     BasicConstraints         basic constraints bytes.
+  @param[in, out] BasicConstraintsSize     basic constraints buffer sizs in bytes.
+
+  @retval TRUE                     The basic constraints retrieve successfully.
+  @retval FALSE                    If cert is NULL.
+                                   If cert_size is NULL.
+                                   If basic_constraints is not NULL and *basic_constraints_size is 0.
+                                   If cert is invalid.
+  @retval FALSE                    The required buffer size is small.
+                                   The return buffer size is basic_constraints_size parameter.
+  @retval FALSE                    If no Extension entry match oid.
+  @retval FALSE                    The operation is not supported.
+ **/
+BOOLEAN
+EFIAPI
+X509GetExtendedBasicConstraints             (
+  CONST UINT8  *Cert,
+  UINTN        CertSize,
+  UINT8        *BasicConstraints,
+  UINTN        *BasicConstraintsSize
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}

--- a/CryptoPkg/Library/BaseCryptLibMbedTls/Rand/CryptRandNull.c
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/Rand/CryptRandNull.c
@@ -1,0 +1,56 @@
+/** @file
+  Pseudorandom Number Generator Wrapper Implementation which does not provide
+  real capabilities.
+
+Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "InternalCryptLib.h"
+
+/**
+  Sets up the seed value for the pseudorandom number generator.
+
+  Return FALSE to indicate this interface is not supported.
+
+  @param[in]  Seed      Pointer to seed value.
+                        If NULL, default seed is used.
+  @param[in]  SeedSize  Size of seed value.
+                        If Seed is NULL, this parameter is ignored.
+
+  @retval FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+RandomSeed (
+  IN  CONST  UINT8  *Seed  OPTIONAL,
+  IN  UINTN         SeedSize
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  Generates a pseudorandom byte stream of the specified size.
+
+  Return FALSE to indicate this interface is not supported.
+
+  @param[out]  Output  Pointer to buffer to receive random value.
+  @param[in]   Size    Size of random bytes to generate.
+
+  @retval FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+RandomBytes (
+  OUT  UINT8  *Output,
+  IN   UINTN  Size
+  )
+{
+  ASSERT (FALSE);
+  return FALSE;
+}

--- a/CryptoPkg/Library/BaseCryptLibMbedTls/RuntimeCryptLib.inf
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/RuntimeCryptLib.inf
@@ -1,0 +1,92 @@
+## @file
+#  Cryptographic Library Instance for DXE_RUNTIME_DRIVER.
+#
+#  Caution: This module requires additional review when modified.
+#  This library will have external input - signature.
+#  This external input must be validated carefully to avoid security issues such as
+#  buffer overflow or integer overflow.
+#
+#  Note: SHA-384 Digest functions, SHA-512 Digest functions,
+#  HMAC-SHA256 functions, AES functions, RSA external
+#  functions, PKCS#7 SignedData sign functions, Diffie-Hellman functions, and
+#  authenticode signature verification functions are not supported in this instance.
+#
+#  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = RuntimeCryptLib
+  MODULE_UNI_FILE                = RuntimeCryptLib.uni
+  FILE_GUID                      = D263B580-D9FC-4DC4-B445-578AAEFF530E
+  MODULE_TYPE                    = DXE_RUNTIME_DRIVER
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = BaseCryptLib|DXE_RUNTIME_DRIVER
+  CONSTRUCTOR                    = RuntimeCryptLibConstructor
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64 ARM AARCH64
+#
+
+[Sources]
+  InternalCryptLib.h
+  Hash/CryptMd5.c
+  Hash/CryptSha1.c
+  Hash/CryptSha256.c
+  Hash/CryptSm3Null.c
+  Hash/CryptSha512.c
+  Hash/CryptParallelHashNull.c
+  Hmac/CryptHmac.c
+  Kdf/CryptHkdf.c
+  Cipher/CryptAes.c
+  Cipher/CryptAeadAesGcmNull.c
+  Pk/CryptRsaBasic.c
+  Pk/CryptRsaExtNull.c
+  Pk/CryptRsaPssNull.c
+  Pk/CryptRsaPssSignNull.c
+  Bn/CryptBnNull.c
+  Pem/CryptPemNull.c
+  Pk/CryptDhNull.c
+  Pk/CryptEcNull.c
+  Pk/CryptPkcs1OaepNull.c
+  Pk/CryptPkcs5Pbkdf2Null.c
+  Pk/CryptPkcs7SignNull.c
+  Pk/CryptPkcs7VerifyNull.c
+  Pk/CryptPkcs7VerifyEkuNull.c
+  Pk/CryptX509Null.c
+  Pk/CryptAuthenticodeNull.c
+  Pk/CryptTsNull.c
+  Rand/CryptRandNull.c
+  SysCall/CrtWrapper.c
+  SysCall/TimerWrapper.c
+  SysCall/RuntimeMemAllocation.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  CryptoPkg/CryptoPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  BaseMemoryLib
+  UefiRuntimeServicesTableLib
+  DebugLib
+  MbedTlsLib
+  IntrinsicLib
+  PrintLib
+
+#
+# Remove these [BuildOptions] after this library is cleaned up
+#
+[BuildOptions]
+  #
+  # suppress the following warnings so we do not break the build with warnings-as-errors:
+  #
+  GCC:*_CLANG35_*_CC_FLAGS = -std=c99
+  GCC:*_CLANG38_*_CC_FLAGS = -std=c99
+  GCC:*_CLANGPDB_*_CC_FLAGS = -std=c99 -Wno-error=incompatible-pointer-types
+
+  XCODE:*_*_*_CC_FLAGS = -std=c99

--- a/CryptoPkg/Library/BaseCryptLibMbedTls/RuntimeCryptLib.uni
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/RuntimeCryptLib.uni
@@ -1,0 +1,22 @@
+// /** @file
+// Cryptographic Library Instance for DXE_RUNTIME_DRIVER.
+//
+// Caution: This module requires additional review when modified.
+// This library will have external input - signature.
+// This external input must be validated carefully to avoid security issues such as
+// buffer overflow or integer overflow.
+//
+// Note: AES
+// functions, RSA external functions, PKCS#7 SignedData sign functions,
+// Diffie-Hellman functions, and authenticode signature verification functions are
+// not supported in this instance.
+//
+// Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+// **/
+
+#string STR_MODULE_ABSTRACT             #language en-US "Cryptographic Library Instance for DXE_RUNTIME_DRIVER"
+
+#string STR_MODULE_DESCRIPTION          #language en-US "Caution: This module requires additional review when modified. This library will have external input - signature. This external input must be validated carefully to avoid security issues such as buffer overflow or integer overflow. Note: AES functions, RSA external functions, PKCS#7 SignedData sign functions, Diffie-Hellman functions, and authenticode signature verification functions are not supported in this instance."

--- a/CryptoPkg/Library/BaseCryptLibMbedTls/SecCryptLib.inf
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/SecCryptLib.inf
@@ -1,0 +1,84 @@
+## @file
+#  Cryptographic Library Instance for SEC.
+#
+#  Caution: This module requires additional review when modified.
+#  This library will have external input - signature.
+#  This external input must be validated carefully to avoid security issues such as
+#  buffer overflow or integer overflow.
+#
+#  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = SecCryptLib
+  MODULE_UNI_FILE                = SecCryptLib.uni
+  FILE_GUID                      = 894C367F-254A-4563-8624-798D46EAD796
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = BaseCryptLib|SEC
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  InternalCryptLib.h
+  Hash/CryptSha512.c
+
+  Hash/CryptMd5Null.c
+  Hash/CryptSha1Null.c
+  Hash/CryptSha256Null.c
+  Hash/CryptSm3Null.c
+  Hash/CryptParallelHashNull.c
+  Hmac/CryptHmacNull.c
+  Kdf/CryptHkdfNull.c
+  Cipher/CryptAesNull.c
+  Cipher/CryptAeadAesGcmNull.c
+  Pk/CryptRsaBasicNull.c
+  Pk/CryptRsaExtNull.c
+  Bn/CryptBnNull.c
+  Pem/CryptPemNull.c
+  Pk/CryptDhNull.c
+  Pk/CryptEcNull.c
+  Pk/CryptPkcs1OaepNull.c
+  Pk/CryptPkcs5Pbkdf2Null.c
+  Pk/CryptPkcs7SignNull.c
+  Pk/CryptPkcs7VerifyNull.c
+  Pk/CryptPkcs7VerifyEkuNull.c
+  Pk/CryptX509Null.c
+  Pk/CryptAuthenticodeNull.c
+  Pk/CryptTsNull.c
+  Rand/CryptRandNull.c
+  SysCall/CrtWrapper.c
+  SysCall/ConstantTimeClock.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  CryptoPkg/CryptoPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  BaseMemoryLib
+  MemoryAllocationLib
+  DebugLib
+  MbedTlsLib
+  IntrinsicLib
+  PrintLib
+
+#
+# Remove these [BuildOptions] after this library is cleaned up
+#
+[BuildOptions]
+  #
+  # suppress the following warnings so we do not break the build with warnings-as-errors:
+  #
+  GCC:*_CLANG35_*_CC_FLAGS = -std=c99
+  GCC:*_CLANG38_*_CC_FLAGS = -std=c99
+  GCC:*_CLANGPDB_*_CC_FLAGS = -std=c99 -Wno-error=incompatible-pointer-types
+
+  XCODE:*_*_*_CC_FLAGS = -std=c99

--- a/CryptoPkg/Library/BaseCryptLibMbedTls/SecCryptLib.uni
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/SecCryptLib.uni
@@ -1,0 +1,17 @@
+// /** @file
+// Cryptographic Library Instance for SEC driver.
+//
+// Caution: This module requires additional review when modified.
+// This library will have external input - signature.
+// This external input must be validated carefully to avoid security issues such as
+// buffer overflow or integer overflow.
+//
+// Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+// **/
+
+#string STR_MODULE_ABSTRACT             #language en-US "Cryptographic Library Instance for SEC driver"
+
+#string STR_MODULE_DESCRIPTION          #language en-US "Caution: This module requires additional review when modified. This library will have external input - signature. This external input must be validated carefully to avoid security issues such as buffer overflow or integer overflow. Note: AES functions, RSA external functions, PKCS#7 SignedData sign functions, Diffie-Hellman functions, and authenticode signature verification functions are not supported in this instance."

--- a/CryptoPkg/Library/BaseCryptLibMbedTls/SmmCryptLib.inf
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/SmmCryptLib.inf
@@ -1,0 +1,92 @@
+## @file
+#  Cryptographic Library Instance for SMM driver.
+#
+#  Caution: This module requires additional review when modified.
+#  This library will have external input - signature.
+#  This external input must be validated carefully to avoid security issues such as
+#  buffer overflow or integer overflow.
+#
+#  Note: SHA-384 Digest functions, SHA-512 Digest functions,
+#  RSA external functions, PKCS#7 SignedData sign functions, Diffie-Hellman functions, and
+#  authenticode signature verification functions are not supported in this instance.
+#
+#  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = SmmCryptLib
+  MODULE_UNI_FILE                = SmmCryptLib.uni
+  FILE_GUID                      = CF104633-9901-4504-AD7A-91690926A253
+  MODULE_TYPE                    = DXE_SMM_DRIVER
+  VERSION_STRING                 = 1.0
+  PI_SPECIFICATION_VERSION       = 0x0001000A
+  LIBRARY_CLASS                  = BaseCryptLib|DXE_SMM_DRIVER SMM_CORE MM_STANDALONE
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64 ARM AARCH64
+#
+
+[Sources]
+  InternalCryptLib.h
+  Hash/CryptMd5.c
+  Hash/CryptSha1.c
+  Hash/CryptSha256.c
+  Hash/CryptSm3Null.c
+  Hash/CryptSha512.c
+  Hash/CryptParallelHashNull.c
+  Hmac/CryptHmac.c
+  Kdf/CryptHkdf.c
+  Cipher/CryptAes.c
+  Cipher/CryptAeadAesGcmNull.c
+  Pk/CryptRsaBasic.c
+  Pk/CryptRsaExtNull.c
+  Pk/CryptRsaPss.c
+  Pk/CryptRsaPssSignNull.c
+  Bn/CryptBnNull.c
+  Pem/CryptPemNull.c
+  Pk/CryptDhNull.c
+  Pk/CryptEcNull.c
+  Pk/CryptPkcs1OaepNull.c
+  Pk/CryptPkcs5Pbkdf2Null.c
+  Pk/CryptPkcs7SignNull.c
+  Pk/CryptPkcs7VerifyNull.c
+  Pk/CryptPkcs7VerifyEkuNull.c
+  Pk/CryptX509Null.c
+  Pk/CryptAuthenticodeNull.c
+  Pk/CryptTsNull.c
+  Rand/CryptRandNull.c
+  SysCall/CrtWrapper.c
+  SysCall/ConstantTimeClock.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  CryptoPkg/CryptoPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  BaseMemoryLib
+  MemoryAllocationLib
+  MbedTlsLib
+  IntrinsicLib
+  PrintLib
+  MmServicesTableLib
+  SynchronizationLib
+
+#
+# Remove these [BuildOptions] after this library is cleaned up
+#
+[BuildOptions]
+  #
+  # suppress the following warnings so we do not break the build with warnings-as-errors:
+  #
+
+  XCODE:*_*_*_CC_FLAGS = -mmmx -msse -std=c99
+
+  GCC:*_CLANG35_*_CC_FLAGS = -std=c99
+  GCC:*_CLANG38_*_CC_FLAGS = -std=c99
+  GCC:*_CLANGPDB_*_CC_FLAGS = -std=c99 -Wno-error=incompatible-pointer-types

--- a/CryptoPkg/Library/BaseCryptLibMbedTls/SmmCryptLib.uni
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/SmmCryptLib.uni
@@ -1,0 +1,22 @@
+// /** @file
+// Cryptographic Library Instance for SMM driver.
+//
+// Caution: This module requires additional review when modified.
+// This library will have external input - signature.
+// This external input must be validated carefully to avoid security issues such as
+// buffer overflow or integer overflow.
+//
+// Note: AES
+// functions, RSA external functions, PKCS#7 SignedData sign functions,
+// Diffie-Hellman functions, and authenticode signature verification functions are
+// not supported in this instance.
+//
+// Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+// **/
+
+#string STR_MODULE_ABSTRACT             #language en-US "Cryptographic Library Instance for SMM driver"
+
+#string STR_MODULE_DESCRIPTION          #language en-US "Caution: This module requires additional review when modified. This library will have external input - signature. This external input must be validated carefully to avoid security issues such as buffer overflow or integer overflow. Note: AES functions, RSA external functions, PKCS#7 SignedData sign functions, Diffie-Hellman functions, and authenticode signature verification functions are not supported in this instance."

--- a/CryptoPkg/Library/BaseCryptLibMbedTls/SysCall/ConstantTimeClock.c
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/SysCall/ConstantTimeClock.c
@@ -1,0 +1,75 @@
+/** @file
+  C Run-Time Libraries (CRT) Time Management Routines Wrapper Implementation
+  for MbedTLS-based Cryptographic Library.
+
+  This C file implements constant time value for time() and NULL for gmtime()
+  thus should not be used in library instances which require functionality
+  of following APIs which need system time support:
+  1)  RsaGenerateKey
+  2)  RsaCheckKey
+  3)  RsaPkcs1Sign
+  4)  Pkcs7Sign
+  5)  DhGenerateParameter
+  6)  DhGenerateKey
+
+Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Base.h>
+#include <Library/BaseMemoryLib.h>
+
+typedef int time_t;
+
+//
+// Structures Definitions
+//
+struct tm {
+  int     tm_sec;    /* seconds after the minute [0-60] */
+  int     tm_min;    /* minutes after the hour [0-59] */
+  int     tm_hour;   /* hours since midnight [0-23] */
+  int     tm_mday;   /* day of the month [1-31] */
+  int     tm_mon;    /* months since January [0-11] */
+  int     tm_year;   /* years since 1900 */
+  int     tm_wday;   /* days since Sunday [0-6] */
+  int     tm_yday;   /* days since January 1 [0-365] */
+  int     tm_isdst;  /* Daylight Savings Time flag */
+  long    tm_gmtoff; /* offset from CUT in seconds */
+  char    *tm_zone;  /* timezone abbreviation */
+};
+
+//
+// -- Time Management Routines --
+//
+
+/**time function. **/
+time_t
+time (
+  time_t  *timer
+  )
+{
+  if (timer != NULL) {
+    *timer = 0;
+  }
+
+  return 0;
+}
+
+/**gmtime function. **/
+struct tm *
+gmtime (
+  const time_t  *timer
+  )
+{
+  return NULL;
+}
+
+/**_time64 function. **/
+time_t
+_time64 (
+  time_t  *t
+  )
+{
+  return time (t);
+}

--- a/CryptoPkg/Library/BaseCryptLibMbedTls/SysCall/CrtWrapper.c
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/SysCall/CrtWrapper.c
@@ -1,0 +1,58 @@
+/** @file
+  C Run-Time Libraries (CRT) Wrapper Implementation for MbedTLS-based
+  Cryptographic Library.
+
+Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Base.h>
+#include <Library/BaseLib.h>
+#include <Library/DebugLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <stdio.h>
+
+/**dummy mbedtls_printf function. **/
+int
+mbedtls_printf (
+  char const  *fmt,
+  ...
+  )
+{
+  ASSERT (FALSE);
+  return 0;
+}
+
+/**dummy mbedtls_vsnprintf function. **/
+int
+mbedtls_vsnprintf (
+  char        *str,
+  size_t      size,
+  const char  *format,
+  ...
+  )
+{
+  ASSERT (FALSE);
+  return 0;
+}
+
+/**strchr function. **/
+char *
+strchr (
+  const char  *str,
+  int         ch
+  )
+{
+  return ScanMem8 (str, AsciiStrSize (str), (char)ch);
+}
+
+/**strcmp function. **/
+int
+strcmp (
+  const char  *s1,
+  const char  *s2
+  )
+{
+  return (int)AsciiStrCmp (s1, s2);
+}

--- a/CryptoPkg/Library/BaseCryptLibMbedTls/SysCall/RuntimeMemAllocation.c
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/SysCall/RuntimeMemAllocation.c
@@ -1,0 +1,462 @@
+/** @file
+  Light-weight Memory Management Routines for MbedTLS-based Crypto
+  Library at Runtime Phase.
+
+Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <CrtLibSupport.h>
+#include <Library/UefiBootServicesTableLib.h>
+#include <Library/UefiRuntimeLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Guid/EventGroup.h>
+
+// ----------------------------------------------------------------
+// Initial version. Needs further optimizations.
+// ----------------------------------------------------------------
+
+//
+// Definitions for Runtime Memory Operations
+//
+#define RT_PAGE_SIZE   0x200
+#define RT_PAGE_MASK   0x1FF
+#define RT_PAGE_SHIFT  9
+
+#define RT_SIZE_TO_PAGES(a)  (((a) >> RT_PAGE_SHIFT) + (((a) & RT_PAGE_MASK) ? 1 : 0))
+#define RT_PAGES_TO_SIZE(a)  ((a) << RT_PAGE_SHIFT)
+
+//
+// Page Flag Definitions
+//
+#define RT_PAGE_FREE  0x00000000
+#define RT_PAGE_USED  0x00000001
+
+#define MIN_REQUIRED_BLOCKS  600
+
+//
+// Memory Page Table
+//
+typedef struct {
+  UINTN     StartPageOffset;    // Offset of the starting page allocated.
+                                // Only available for USED pages.
+  UINT32    PageFlag;           // Page Attributes.
+} RT_MEMORY_PAGE_ENTRY;
+
+typedef struct {
+  UINTN                   PageCount;
+  UINTN                   LastEmptyPageOffset;
+  UINT8                   *DataAreaBase;       // Pointer to data Area.
+  RT_MEMORY_PAGE_ENTRY    Pages[1];            // Page Table Entries.
+} RT_MEMORY_PAGE_TABLE;
+
+//
+// Global Page Table for Runtime Cryptographic Provider.
+//
+RT_MEMORY_PAGE_TABLE  *mRTPageTable = NULL;
+
+//
+// Event for Runtime Address Conversion.
+//
+STATIC EFI_EVENT  mVirtualAddressChangeEvent;
+
+/**
+  Initializes pre-allocated memory pointed by ScratchBuffer for subsequent
+  runtime use.
+
+  @param[in, out]  ScratchBuffer      Pointer to user-supplied memory buffer.
+  @param[in]       ScratchBufferSize  Size of supplied buffer in bytes.
+
+  @retval EFI_SUCCESS  Successful initialization.
+
+**/
+EFI_STATUS
+InitializeScratchMemory (
+  IN OUT  UINT8  *ScratchBuffer,
+  IN      UINTN  ScratchBufferSize
+  )
+{
+  UINTN  Index;
+  UINTN  MemorySize;
+
+  //
+  // Parameters Checking
+  //
+  if (ScratchBuffer == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (ScratchBufferSize < MIN_REQUIRED_BLOCKS * 1024) {
+    return EFI_BUFFER_TOO_SMALL;
+  }
+
+  mRTPageTable = (RT_MEMORY_PAGE_TABLE *)ScratchBuffer;
+
+  //
+  // Initialize Internal Page Table for Memory Management
+  //
+  SetMem (mRTPageTable, ScratchBufferSize, 0xFF);
+  MemorySize = ScratchBufferSize - sizeof (RT_MEMORY_PAGE_TABLE) + sizeof (RT_MEMORY_PAGE_ENTRY);
+
+  mRTPageTable->PageCount           = MemorySize / (RT_PAGE_SIZE + sizeof (RT_MEMORY_PAGE_ENTRY));
+  mRTPageTable->LastEmptyPageOffset = 0x0;
+
+  for (Index = 0; Index < mRTPageTable->PageCount; Index++) {
+    mRTPageTable->Pages[Index].PageFlag        = RT_PAGE_FREE;
+    mRTPageTable->Pages[Index].StartPageOffset = 0;
+  }
+
+  mRTPageTable->DataAreaBase = ScratchBuffer + sizeof (RT_MEMORY_PAGE_TABLE) +
+                               (mRTPageTable->PageCount - 1) * sizeof (RT_MEMORY_PAGE_ENTRY);
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Look-up Free memory Region for object allocation.
+
+  @param[in]  AllocationSize  Bytes to be allocated.
+
+  @return  Return available page offset for object allocation.
+
+**/
+UINTN
+LookupFreeMemRegion (
+  IN  UINTN  AllocationSize
+  )
+{
+  UINTN  StartPageIndex;
+  UINTN  Index;
+  UINTN  SubIndex;
+  UINTN  ReqPages;
+
+  StartPageIndex = RT_SIZE_TO_PAGES (mRTPageTable->LastEmptyPageOffset);
+  ReqPages       = RT_SIZE_TO_PAGES (AllocationSize);
+  if (ReqPages > mRTPageTable->PageCount) {
+    //
+    // No enough region for object allocation.
+    //
+    return (UINTN)(-1);
+  }
+
+  //
+  // Look up the free memory region with in current memory map table.
+  //
+  for (Index = StartPageIndex; Index <= (mRTPageTable->PageCount - ReqPages); ) {
+    //
+    // Check consecutive ReqPages pages.
+    //
+    for (SubIndex = 0; SubIndex < ReqPages; SubIndex++) {
+      if ((mRTPageTable->Pages[SubIndex + Index].PageFlag & RT_PAGE_USED) != 0) {
+        break;
+      }
+    }
+
+    if (SubIndex == ReqPages) {
+      //
+      // Succeed! Return the Starting Offset.
+      //
+      return RT_PAGES_TO_SIZE (Index);
+    }
+
+    //
+    // Failed! Skip current free memory pages and adjacent Used pages
+    //
+    while ((mRTPageTable->Pages[SubIndex + Index].PageFlag & RT_PAGE_USED) != 0) {
+      SubIndex++;
+    }
+
+    Index += SubIndex;
+  }
+
+  //
+  // Look up the free memory region from the beginning of the memory table
+  // until the StartCursorOffset
+  //
+  if (ReqPages > StartPageIndex) {
+    //
+    // No enough region for object allocation.
+    //
+    return (UINTN)(-1);
+  }
+
+  for (Index = 0; Index < (StartPageIndex - ReqPages); ) {
+    //
+    // Check Consecutive ReqPages Pages.
+    //
+    for (SubIndex = 0; SubIndex < ReqPages; SubIndex++) {
+      if ((mRTPageTable->Pages[SubIndex + Index].PageFlag & RT_PAGE_USED) != 0) {
+        break;
+      }
+    }
+
+    if (SubIndex == ReqPages) {
+      //
+      // Succeed! Return the Starting Offset.
+      //
+      return RT_PAGES_TO_SIZE (Index);
+    }
+
+    //
+    // Failed! Skip current adjacent Used pages
+    //
+    while ((SubIndex < (StartPageIndex - ReqPages)) &&
+           ((mRTPageTable->Pages[SubIndex + Index].PageFlag & RT_PAGE_USED) != 0))
+    {
+      SubIndex++;
+    }
+
+    Index += SubIndex;
+  }
+
+  //
+  // No available region for object allocation!
+  //
+  return (UINTN)(-1);
+}
+
+/**
+  Allocates a buffer at runtime phase.
+
+  @param[in]  AllocationSize    Bytes to be allocated.
+
+  @return  A pointer to the allocated buffer or NULL if allocation fails.
+
+**/
+VOID *
+RuntimeAllocateMem (
+  IN  UINTN  AllocationSize
+  )
+{
+  UINT8  *AllocPtr;
+  UINTN  ReqPages;
+  UINTN  Index;
+  UINTN  StartPage;
+  UINTN  AllocOffset;
+
+  AllocPtr = NULL;
+  ReqPages = 0;
+
+  //
+  // Look for available consecutive memory region starting from LastEmptyPageOffset.
+  // If no proper memory region found, look up from the beginning.
+  // If still not found, return NULL to indicate failed allocation.
+  //
+  AllocOffset = LookupFreeMemRegion (AllocationSize);
+  if (AllocOffset == (UINTN)(-1)) {
+    return NULL;
+  }
+
+  //
+  // Allocates consecutive memory pages with length of Size. Update the page
+  // table status. Returns the starting address.
+  //
+  ReqPages  = RT_SIZE_TO_PAGES (AllocationSize);
+  AllocPtr  = mRTPageTable->DataAreaBase + AllocOffset;
+  StartPage = RT_SIZE_TO_PAGES (AllocOffset);
+  Index     = 0;
+  while (Index < ReqPages) {
+    mRTPageTable->Pages[StartPage + Index].PageFlag       |= RT_PAGE_USED;
+    mRTPageTable->Pages[StartPage + Index].StartPageOffset = AllocOffset;
+
+    Index++;
+  }
+
+  mRTPageTable->LastEmptyPageOffset = AllocOffset + RT_PAGES_TO_SIZE (ReqPages);
+
+  ZeroMem (AllocPtr, AllocationSize);
+
+  //
+  // Returns a VOID pointer to the allocated space
+  //
+  return AllocPtr;
+}
+
+/**
+  Frees a buffer that was previously allocated at runtime phase.
+
+  @param[in]  Buffer  Pointer to the buffer to free.
+
+**/
+VOID
+RuntimeFreeMem (
+  IN  VOID  *Buffer
+  )
+{
+  UINTN  StartOffset;
+  UINTN  StartPageIndex;
+
+  StartOffset    = (UINTN)Buffer - (UINTN)mRTPageTable->DataAreaBase;
+  StartPageIndex = RT_SIZE_TO_PAGES (mRTPageTable->Pages[RT_SIZE_TO_PAGES (StartOffset)].StartPageOffset);
+
+  while (StartPageIndex < mRTPageTable->PageCount) {
+    if (((mRTPageTable->Pages[StartPageIndex].PageFlag & RT_PAGE_USED) != 0) &&
+        (mRTPageTable->Pages[StartPageIndex].StartPageOffset == StartOffset))
+    {
+      //
+      // Free this page
+      //
+      mRTPageTable->Pages[StartPageIndex].PageFlag       &= ~RT_PAGE_USED;
+      mRTPageTable->Pages[StartPageIndex].PageFlag       |= RT_PAGE_FREE;
+      mRTPageTable->Pages[StartPageIndex].StartPageOffset = 0;
+
+      StartPageIndex++;
+    } else {
+      break;
+    }
+  }
+
+  return;
+}
+
+/**
+  Notification function of EVT_SIGNAL_VIRTUAL_ADDRESS_CHANGE.
+
+  This is a notification function registered on EVT_SIGNAL_VIRTUAL_ADDRESS_CHANGE
+  event. It converts a pointer to a new virtual address.
+
+  @param[in]  Event      The event whose notification function is being invoked.
+  @param[in]  Context    The pointer to the notification function's context.
+
+**/
+VOID
+EFIAPI
+RuntimeCryptLibAddressChangeEvent (
+  IN  EFI_EVENT  Event,
+  IN  VOID       *Context
+  )
+{
+  //
+  // Converts a pointer for runtime memory management to a new virtual address.
+  //
+  EfiConvertPointer (0x0, (VOID **)&mRTPageTable->DataAreaBase);
+  EfiConvertPointer (0x0, (VOID **)&mRTPageTable);
+}
+
+/**
+  Constructor routine for runtime crypt library instance.
+
+  The constructor function pre-allocates space for runtime cryptographic operation.
+
+  @param  ImageHandle   The firmware allocated handle for the EFI image.
+  @param  SystemTable   A pointer to the EFI System Table.
+
+  @retval EFI_SUCCESS          The construction succeeded.
+  @retval EFI_OUT_OF_RESOURCE  Failed to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+RuntimeCryptLibConstructor (
+  IN EFI_HANDLE        ImageHandle,
+  IN EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  EFI_STATUS  Status;
+  VOID        *Buffer;
+
+  //
+  // Pre-allocates runtime space for possible cryptographic operations
+  //
+  Buffer = AllocateRuntimePool (MIN_REQUIRED_BLOCKS * 1024);
+  Status = InitializeScratchMemory (Buffer, MIN_REQUIRED_BLOCKS * 1024);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  //
+  // Create address change event
+  //
+  Status = gBS->CreateEventEx (
+                  EVT_NOTIFY_SIGNAL,
+                  TPL_NOTIFY,
+                  RuntimeCryptLibAddressChangeEvent,
+                  NULL,
+                  &gEfiEventVirtualAddressChangeGuid,
+                  &mVirtualAddressChangeEvent
+                  );
+  ASSERT_EFI_ERROR (Status);
+
+  return Status;
+}
+
+//
+// -- Memory-Allocation Routines Wrapper for UEFI-MbedTLS Library --
+//
+
+/** Allocates memory blocks. **/
+VOID *
+malloc (
+  size_t  size
+  )
+{
+  return RuntimeAllocateMem ((UINTN)size);
+}
+
+/** Reallocate memory blocks. **/
+VOID *
+realloc (
+  VOID    *ptr,
+  size_t  size
+  )
+{
+  VOID   *NewPtr;
+  UINTN  StartOffset;
+  UINTN  StartPageIndex;
+  UINTN  PageCount;
+
+  if (ptr == NULL) {
+    return malloc (size);
+  }
+
+  //
+  // Get Original Size of ptr
+  //
+  StartOffset    = (UINTN)ptr - (UINTN)mRTPageTable->DataAreaBase;
+  StartPageIndex = RT_SIZE_TO_PAGES (mRTPageTable->Pages[RT_SIZE_TO_PAGES (StartOffset)].StartPageOffset);
+  PageCount      = 0;
+  while (StartPageIndex < mRTPageTable->PageCount) {
+    if (((mRTPageTable->Pages[StartPageIndex].PageFlag & RT_PAGE_USED) != 0) &&
+        (mRTPageTable->Pages[StartPageIndex].StartPageOffset == StartOffset))
+    {
+      StartPageIndex++;
+      PageCount++;
+    } else {
+      break;
+    }
+  }
+
+  if (size <= RT_PAGES_TO_SIZE (PageCount)) {
+    //
+    // Return the original pointer, if Caller try to reduce region size;
+    //
+    return ptr;
+  }
+
+  NewPtr = RuntimeAllocateMem ((UINTN)size);
+  if (NewPtr == NULL) {
+    return NULL;
+  }
+
+  CopyMem (NewPtr, ptr, RT_PAGES_TO_SIZE (PageCount));
+
+  RuntimeFreeMem (ptr);
+
+  return NewPtr;
+}
+
+/** Deallocates or frees a memory block. **/
+VOID
+free (
+  VOID  *ptr
+  )
+{
+  //
+  // In Standard C, free() handles a null pointer argument transparently. This
+  // is not true of RuntimeFreeMem() below, so protect it.
+  //
+  if (ptr != NULL) {
+    RuntimeFreeMem (ptr);
+  }
+}

--- a/CryptoPkg/Library/BaseCryptLibMbedTls/SysCall/TimerWrapper.c
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/SysCall/TimerWrapper.c
@@ -1,0 +1,198 @@
+/** @file
+  C Run-Time Libraries (CRT) Time Management Routines Wrapper Implementation
+  for MbedTLS-based Cryptographic Library (used in DXE & RUNTIME).
+
+Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Uefi.h>
+#include <Library/UefiRuntimeServicesTableLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/MemoryAllocationLib.h>
+
+typedef int time_t;
+
+//
+// Structures Definitions
+//
+struct tm {
+  int     tm_sec;    /* seconds after the minute [0-60] */
+  int     tm_min;    /* minutes after the hour [0-59] */
+  int     tm_hour;   /* hours since midnight [0-23] */
+  int     tm_mday;   /* day of the month [1-31] */
+  int     tm_mon;    /* months since January [0-11] */
+  int     tm_year;   /* years since 1900 */
+  int     tm_wday;   /* days since Sunday [0-6] */
+  int     tm_yday;   /* days since January 1 [0-365] */
+  int     tm_isdst;  /* Daylight Savings Time flag */
+  long    tm_gmtoff; /* offset from CUT in seconds */
+  char    *tm_zone;  /* timezone abbreviation */
+};
+
+//
+// -- Time Management Routines --
+//
+
+#define IsLeap(y)  (((y) % 4) == 0 && (((y) % 100) != 0 || ((y) % 400) == 0))
+#define SECSPERMIN   (60)
+#define SECSPERHOUR  (60 * 60)
+#define SECSPERDAY   (24 * SECSPERHOUR)
+
+//
+//  The arrays give the cumulative number of days up to the first of the
+//  month number used as the index (1 -> 12) for regular and leap years.
+//  The value at index 13 is for the whole year.
+//
+UINTN  CumulativeDays[2][14] = {
+  {
+    0,
+    0,
+    31,
+    31 + 28,
+    31 + 28 + 31,
+    31 + 28 + 31 + 30,
+    31 + 28 + 31 + 30 + 31,
+    31 + 28 + 31 + 30 + 31 + 30,
+    31 + 28 + 31 + 30 + 31 + 30 + 31,
+    31 + 28 + 31 + 30 + 31 + 30 + 31 + 31,
+    31 + 28 + 31 + 30 + 31 + 30 + 31 + 31 + 30,
+    31 + 28 + 31 + 30 + 31 + 30 + 31 + 31 + 30 + 31,
+    31 + 28 + 31 + 30 + 31 + 30 + 31 + 31 + 30 + 31 + 30,
+    31 + 28 + 31 + 30 + 31 + 30 + 31 + 31 + 30 + 31 + 30 + 31
+  },
+  {
+    0,
+    0,
+    31,
+    31 + 29,
+    31 + 29 + 31,
+    31 + 29 + 31 + 30,
+    31 + 29 + 31 + 30 + 31,
+    31 + 29 + 31 + 30 + 31 + 30,
+    31 + 29 + 31 + 30 + 31 + 30 + 31,
+    31 + 29 + 31 + 30 + 31 + 30 + 31 + 31,
+    31 + 29 + 31 + 30 + 31 + 30 + 31 + 31 + 30,
+    31 + 29 + 31 + 30 + 31 + 30 + 31 + 31 + 30 + 31,
+    31 + 29 + 31 + 30 + 31 + 30 + 31 + 31 + 30 + 31 + 30,
+    31 + 29 + 31 + 30 + 31 + 30 + 31 + 31 + 30 + 31 + 30 + 31
+  }
+};
+
+/** Get the system time as seconds elapsed since midnight, January 1, 1970. **/
+time_t
+time (
+  time_t  *timer
+  )
+{
+  EFI_STATUS  Status;
+  EFI_TIME    Time;
+  time_t      CalTime;
+  UINTN       Year;
+
+  //
+  // Get the current time and date information
+  //
+  Status = gRT->GetTime (&Time, NULL);
+  if (EFI_ERROR (Status) || (Time.Year < 1970)) {
+    return 0;
+  }
+
+  //
+  // Years Handling
+  // UTime should now be set to 00:00:00 on Jan 1 of the current year.
+  //
+  for (Year = 1970, CalTime = 0; Year != Time.Year; Year++) {
+    CalTime = CalTime + (time_t)(CumulativeDays[IsLeap (Year)][13] * SECSPERDAY);
+  }
+
+  //
+  // Add in number of seconds for current Month, Day, Hour, Minute, Seconds, and TimeZone adjustment
+  //
+  CalTime = CalTime +
+            (time_t)((Time.TimeZone != EFI_UNSPECIFIED_TIMEZONE) ? (Time.TimeZone * 60) : 0) +
+            (time_t)(CumulativeDays[IsLeap (Time.Year)][Time.Month] * SECSPERDAY) +
+            (time_t)(((Time.Day > 0) ? Time.Day - 1 : 0) * SECSPERDAY) +
+            (time_t)(Time.Hour * SECSPERHOUR) +
+            (time_t)(Time.Minute * 60) +
+            (time_t)Time.Second;
+
+  if (timer != NULL) {
+    *timer = CalTime;
+  }
+
+  return CalTime;
+}
+
+/** Convert a time value from type time_t to struct tm. **/
+struct tm *
+gmtime (
+  const time_t  *timer
+  )
+{
+  struct tm  *GmTime;
+  UINT16     DayNo;
+  UINT16     DayRemainder;
+  time_t     Year;
+  time_t     YearNo;
+  UINT16     TotalDays;
+  UINT16     MonthNo;
+
+  if (timer == NULL) {
+    return NULL;
+  }
+
+  GmTime = AllocateZeroPool (sizeof (struct tm));
+  if (GmTime == NULL) {
+    return NULL;
+  }
+
+  ZeroMem ((VOID *)GmTime, (UINTN)sizeof (struct tm));
+
+  DayNo        = (UINT16)(*timer / SECSPERDAY);
+  DayRemainder = (UINT16)(*timer % SECSPERDAY);
+
+  GmTime->tm_sec  = (int)(DayRemainder % SECSPERMIN);
+  GmTime->tm_min  = (int)((DayRemainder % SECSPERHOUR) / SECSPERMIN);
+  GmTime->tm_hour = (int)(DayRemainder / SECSPERHOUR);
+  GmTime->tm_wday = (int)((DayNo + 4) % 7);
+
+  for (Year = 1970, YearNo = 0; DayNo > 0; Year++) {
+    TotalDays = (UINT16)(IsLeap (Year) ? 366 : 365);
+    if (DayNo >= TotalDays) {
+      DayNo = (UINT16)(DayNo - TotalDays);
+      YearNo++;
+    } else {
+      break;
+    }
+  }
+
+  GmTime->tm_year = (int)(YearNo + (1970 - 1900));
+  GmTime->tm_yday = (int)DayNo;
+
+  for (MonthNo = 12; MonthNo > 1; MonthNo--) {
+    if (DayNo >= CumulativeDays[IsLeap (Year)][MonthNo]) {
+      DayNo = (UINT16)(DayNo - (UINT16)(CumulativeDays[IsLeap (Year)][MonthNo]));
+      break;
+    }
+  }
+
+  GmTime->tm_mon  = (int)MonthNo - 1;
+  GmTime->tm_mday = (int)DayNo + 1;
+
+  GmTime->tm_isdst  = 0;
+  GmTime->tm_gmtoff = 0;
+  GmTime->tm_zone   = NULL;
+
+  return GmTime;
+}
+
+/**_time64 function. **/
+time_t
+_time64 (
+  time_t  *t
+  )
+{
+  return time (t);
+}

--- a/CryptoPkg/Library/BaseCryptLibMbedTls/TestBaseCryptLib.inf
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/TestBaseCryptLib.inf
@@ -1,0 +1,76 @@
+## @file
+#  Cryptographic Library Instance for DXE_DRIVER.
+#
+#  Caution: This module requires additional review when modified.
+#  This library will have external input - signature.
+#  This external input must be validated carefully to avoid security issues such as
+#  buffer overflow or integer overflow.
+#
+#  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = BaseCryptLib
+  FILE_GUID                      = 9DD60CFE-9D05-41E2-8B9E-958E2A4C1913
+  MODULE_TYPE                    = DXE_DRIVER
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = BaseCryptLib|DXE_DRIVER DXE_CORE UEFI_APPLICATION UEFI_DRIVER
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64 ARM AARCH64
+#
+
+[Sources]
+  InternalCryptLib.h
+  Cipher/CryptAeadAesGcmNull.c
+  Cipher/CryptAes.c
+  Hash/CryptSha256.c
+  Hash/CryptSha512.c
+  Hash/CryptSm3Null.c
+  Hash/CryptMd5.c
+  Hash/CryptSha1.c
+  Hmac/CryptHmac.c
+  Kdf/CryptHkdf.c
+  Pk/CryptRsaBasic.c
+  Pk/CryptRsaExtNull.c
+  Pk/CryptRsaPss.c
+  Pk/CryptRsaPssSignNull.c
+  Bn/CryptBnNull.c
+  Pem/CryptPemNull.c
+  Pk/CryptDhNull.c
+  Pk/CryptEcNull.c
+  Pk/CryptPkcs1OaepNull.c
+  Pk/CryptPkcs5Pbkdf2Null.c
+  Pk/CryptPkcs7SignNull.c
+  Pk/CryptPkcs7VerifyNull.c
+  Pk/CryptPkcs7VerifyEkuNull.c
+  Pk/CryptX509Null.c
+  Pk/CryptAuthenticodeNull.c
+  Pk/CryptTsNull.c
+  Rand/CryptRandNull.c
+  SysCall/CrtWrapper.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  CryptoPkg/CryptoPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  BaseMemoryLib
+  MemoryAllocationLib
+  UefiRuntimeServicesTableLib
+  DebugLib
+  MbedTlsLib
+  PrintLib
+  RngLib
+
+#
+# Remove these [BuildOptions] after this library is cleaned up
+#
+[BuildOptions]
+  MSFT:*_*_*_CC_FLAGS = /GL-

--- a/CryptoPkg/Library/Include/stdint.h
+++ b/CryptoPkg/Library/Include/stdint.h
@@ -1,0 +1,19 @@
+/** @file
+  Include file to support building the third-party cryptographic library.
+
+Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <CrtLibSupport.h>
+
+typedef INT8    int8_t;
+typedef UINT8   uint8_t;
+typedef INT16   int16_t;
+typedef UINT16  uint16_t;
+typedef INT32   int32_t;
+typedef UINT32  uint32_t;
+typedef INT64   int64_t;
+typedef UINT64  uint64_t;
+typedef UINTN   uintptr_t;

--- a/CryptoPkg/Library/Include/stubs-32.h
+++ b/CryptoPkg/Library/Include/stubs-32.h
@@ -1,0 +1,9 @@
+/** @file
+  Include file to support building the third-party cryptographic library.
+
+Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <CrtLibSupport.h>

--- a/CryptoPkg/Library/MbedTlsLib/CrtWrapper.c
+++ b/CryptoPkg/Library/MbedTlsLib/CrtWrapper.c
@@ -1,0 +1,96 @@
+/** @file
+  C Run-Time Libraries (CRT) Wrapper Implementation for MbedTLS-based
+  Cryptographic Library.
+
+Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Base.h>
+#include <Library/BaseLib.h>
+#include <Library/DebugLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <stdio.h>
+
+#include <Library/MemoryAllocationLib.h>
+
+int
+my_snprintf (
+  char        *str,
+  size_t      size,
+  const char  *format,
+  ...
+  )
+{
+  return 0;
+}
+
+//
+// Extra header to record the memory buffer size from malloc routine.
+//
+#define CRYPTMEM_HEAD_SIGNATURE  SIGNATURE_32('c','m','h','d')
+typedef struct {
+  UINT32    Signature;
+  UINT32    Reserved;
+  UINTN     Size;
+} CRYPTMEM_HEAD;
+
+#define CRYPTMEM_OVERHEAD  sizeof(CRYPTMEM_HEAD)
+
+//
+// -- Memory-Allocation Routines --
+//
+
+/* Allocates memory blocks */
+void *
+mbedtls_calloc (
+  size_t  num,
+  size_t  size
+  )
+{
+  CRYPTMEM_HEAD  *PoolHdr;
+  UINTN          NewSize;
+  VOID           *Data;
+
+  //
+  // Adjust the size by the buffer header overhead
+  //
+  NewSize = (UINTN)(size * num) + CRYPTMEM_OVERHEAD;
+
+  Data = AllocateZeroPool (NewSize);
+  if (Data != NULL) {
+    PoolHdr = (CRYPTMEM_HEAD *)Data;
+    //
+    // Record the memory brief information
+    //
+    PoolHdr->Signature = CRYPTMEM_HEAD_SIGNATURE;
+    PoolHdr->Size      = size;
+
+    return (VOID *)(PoolHdr + 1);
+  } else {
+    //
+    // The buffer allocation failed.
+    //
+    return NULL;
+  }
+}
+
+/* De-allocates or frees a memory block */
+void
+mbedtls_free (
+  void  *ptr
+  )
+{
+  CRYPTMEM_HEAD  *PoolHdr;
+
+  //
+  // In Standard C, free() handles a null pointer argument transparently. This
+  // is not true of FreePool() below, so protect it.
+  //
+  if (ptr != NULL) {
+    PoolHdr = (CRYPTMEM_HEAD *)ptr - 1;
+    ASSERT (PoolHdr->Signature == CRYPTMEM_HEAD_SIGNATURE);
+    FreePool (PoolHdr);
+  }
+}

--- a/CryptoPkg/Library/MbedTlsLib/EcSm2Null.c
+++ b/CryptoPkg/Library/MbedTlsLib/EcSm2Null.c
@@ -1,0 +1,495 @@
+/** @file
+  Null implementation of EC and SM2 functions called by BaseCryptLib.
+
+  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Library/DebugLib.h>
+
+#include <mbedtls/ecp.h>
+#include <mbedtls/ecdh.h>
+#include <mbedtls/ecdsa.h>
+#include <mbedtls/bignum.h>
+#include <library/bignum_core.h>
+
+/*
+ * Get the curve info for the internal identifier
+ */
+const mbedtls_ecp_curve_info *
+mbedtls_ecp_curve_info_from_grp_id (
+  mbedtls_ecp_group_id  grp_id
+  )
+{
+  ASSERT (FALSE);
+  return (NULL);
+}
+
+void
+mbedtls_ecdh_init (
+  mbedtls_ecdh_context  *ctx
+  )
+{
+  ASSERT (FALSE);
+}
+
+/*
+ * Free context
+ */
+void
+mbedtls_ecdh_free (
+  mbedtls_ecdh_context  *ctx
+  )
+{
+  ASSERT (FALSE);
+}
+
+int
+mbedtls_ecdh_calc_secret (
+  mbedtls_ecdh_context *ctx,
+  size_t *olen,
+  unsigned char *buf,
+  size_t blen,
+  int ( *f_rng )(void *, unsigned char *, size_t),
+  void *p_rng
+  )
+{
+  ASSERT (FALSE);
+  return -1;
+}
+
+void
+mbedtls_ecp_keypair_init (
+  mbedtls_ecp_keypair  *key
+  )
+{
+  ASSERT (FALSE);
+}
+
+void
+mbedtls_ecp_keypair_free (
+  mbedtls_ecp_keypair  *key
+  )
+{
+  ASSERT (FALSE);
+}
+
+int
+mbedtls_ecp_check_pub_priv (
+  const mbedtls_ecp_keypair *pub,
+  const mbedtls_ecp_keypair *prv,
+  int ( *f_rng )(void *, unsigned char *, size_t),
+  void *p_rng
+  )
+{
+  ASSERT (FALSE);
+  return -1;
+}
+
+int
+mbedtls_ecdsa_write_signature (
+  mbedtls_ecdsa_context *ctx,
+  mbedtls_md_type_t md_alg,
+  const unsigned char *hash,
+  size_t hlen,
+  unsigned char *sig,
+  size_t sig_size,
+  size_t *slen,
+  int ( *f_rng )(void *, unsigned char *, size_t),
+  void *p_rng
+  )
+{
+  ASSERT (FALSE);
+  return -1;
+}
+
+int
+mbedtls_ecdsa_write_signature_restartable (
+  mbedtls_ecdsa_context *ctx,
+  mbedtls_md_type_t md_alg,
+  const unsigned char *hash,
+  size_t hlen,
+  unsigned char *sig,
+  size_t sig_size,
+  size_t *slen,
+  int ( *f_rng )(void *, unsigned char *, size_t),
+  void *p_rng,
+  mbedtls_ecdsa_restart_ctx *rs_ctx
+  )
+{
+  ASSERT (FALSE);
+  return -1;
+}
+
+int
+mbedtls_ecdsa_read_signature (
+  mbedtls_ecdsa_context  *ctx,
+  const unsigned char    *hash,
+  size_t                 hlen,
+  const unsigned char    *sig,
+  size_t                 slen
+  )
+{
+  ASSERT (FALSE);
+  return -1;
+}
+
+int
+mbedtls_ecdsa_read_signature_restartable (
+  mbedtls_ecdsa_context      *ctx,
+  const unsigned char        *hash,
+  size_t                     hlen,
+  const unsigned char        *sig,
+  size_t                     slen,
+  mbedtls_ecdsa_restart_ctx  *rs_ctx
+  )
+{
+  ASSERT (FALSE);
+  return -1;
+}
+
+int
+mbedtls_ecdsa_from_keypair (
+  mbedtls_ecdsa_context      *ctx,
+  const mbedtls_ecp_keypair  *key
+  )
+{
+  ASSERT (FALSE);
+  return -1;
+}
+
+void
+mbedtls_ecdsa_init (
+  mbedtls_ecdsa_context  *ctx
+  )
+{
+  ASSERT (FALSE);
+}
+
+void
+mbedtls_ecdsa_free (
+  mbedtls_ecdsa_context  *ctx
+  )
+{
+  ASSERT (FALSE);
+}
+
+void
+mbedtls_ecdsa_restart_init (
+  mbedtls_ecdsa_restart_ctx  *ctx
+  )
+{
+  ASSERT (FALSE);
+}
+
+void
+mbedtls_ecdsa_restart_free (
+  mbedtls_ecdsa_restart_ctx  *ctx
+  )
+{
+  ASSERT (FALSE);
+}
+
+int
+mbedtls_ecp_point_write_binary (
+  const mbedtls_ecp_group  *grp,
+  const mbedtls_ecp_point  *P,
+  int                      format,
+  size_t                   *olen,
+  unsigned char            *buf,
+  size_t                   buflen
+  )
+{
+  ASSERT (FALSE);
+  return -1;
+}
+
+int
+mbedtls_ecp_point_read_binary (
+  const mbedtls_ecp_group  *grp,
+  mbedtls_ecp_point        *P,
+  const unsigned char      *buf,
+  size_t                   ilen
+  )
+{
+  ASSERT (FALSE);
+  return -1;
+}
+
+int
+mbedtls_ecp_write_key (
+  mbedtls_ecp_keypair  *key,
+  unsigned char        *buf,
+  size_t               buflen
+  )
+{
+  ASSERT (FALSE);
+  return -1;
+}
+
+int
+mbedtls_ecp_group_load (
+  mbedtls_ecp_group     *grp,
+  mbedtls_ecp_group_id  id
+  )
+{
+  ASSERT (FALSE);
+  return -1;
+}
+
+int
+mbedtls_ecp_mul (
+  mbedtls_ecp_group *grp,
+  mbedtls_ecp_point *R,
+  const mbedtls_mpi *m,
+  const mbedtls_ecp_point *P,
+  int ( *f_rng )(void *, unsigned char *, size_t),
+  void *p_rng
+  )
+{
+  ASSERT (FALSE);
+  return -1;
+}
+
+int
+mbedtls_ecp_check_pubkey (
+  const mbedtls_ecp_group  *grp,
+  const mbedtls_ecp_point  *pt
+  )
+{
+  ASSERT (FALSE);
+  return -1;
+}
+
+int
+mbedtls_ecp_check_privkey (
+  const mbedtls_ecp_group  *grp,
+  const mbedtls_mpi        *d
+  )
+{
+  ASSERT (FALSE);
+  return -1;
+}
+
+int
+mbedtls_ecp_restart_is_enabled (
+  void
+  )
+{
+  ASSERT (FALSE);
+  return -1;
+}
+
+const mbedtls_ecp_curve_info *
+mbedtls_ecp_curve_info_from_tls_id (
+  uint16_t  tls_id
+  )
+{
+  ASSERT (FALSE);
+  return (NULL);
+}
+
+int
+mbedtls_ecdh_setup (
+  mbedtls_ecdh_context  *ctx,
+  mbedtls_ecp_group_id  grp_id
+  )
+{
+  ASSERT (FALSE);
+  return -1;
+}
+
+int
+mbedtls_ecdh_make_params (
+  mbedtls_ecdh_context *ctx,
+  size_t *olen,
+  unsigned char *buf,
+  size_t blen,
+  int ( *f_rng )(void *, unsigned char *, size_t),
+  void *p_rng
+  )
+{
+  ASSERT (FALSE);
+  return -1;
+}
+
+int
+mbedtls_ecdh_get_params (
+  mbedtls_ecdh_context       *ctx,
+  const mbedtls_ecp_keypair  *key,
+  mbedtls_ecdh_side          side
+  )
+{
+  ASSERT (FALSE);
+  return -1;
+}
+
+int
+mbedtls_ecdh_read_public (
+  mbedtls_ecdh_context  *ctx,
+  const unsigned char   *buf,
+  size_t                blen
+  )
+{
+  ASSERT (FALSE);
+  return -1;
+}
+
+int
+mbedtls_ecdh_read_params (
+  mbedtls_ecdh_context  *ctx,
+  const unsigned char   **buf,
+  const unsigned char   *end
+  )
+{
+  ASSERT (FALSE);
+  return -1;
+}
+
+int
+mbedtls_ecdh_make_public (
+  mbedtls_ecdh_context *ctx,
+  size_t *olen,
+  unsigned char *buf,
+  size_t blen,
+  int ( *f_rng )(void *, unsigned char *, size_t),
+  void *p_rng
+  )
+{
+  ASSERT (FALSE);
+  return -1;
+}
+
+void
+mbedtls_ecdh_enable_restart (
+  mbedtls_ecdh_context  *ctx
+  )
+{
+  ASSERT (FALSE);
+}
+
+void
+mbedtls_ecp_point_init (
+  mbedtls_ecp_point  *pt
+  )
+{
+  ASSERT (FALSE);
+}
+
+void
+mbedtls_ecp_group_init (
+  mbedtls_ecp_group  *grp
+  )
+{
+  ASSERT (FALSE);
+}
+
+void
+mbedtls_ecp_point_free (
+  mbedtls_ecp_point  *pt
+  )
+{
+  ASSERT (FALSE);
+}
+
+void
+mbedtls_ecp_group_free (
+  mbedtls_ecp_group  *grp
+  )
+{
+  ASSERT (FALSE);
+}
+
+int
+mbedtls_ecp_is_zero (
+  mbedtls_ecp_point  *pt
+  )
+{
+  ASSERT (FALSE);
+  return -1;
+}
+
+int
+mbedtls_ecp_point_cmp (
+  const mbedtls_ecp_point  *P,
+  const mbedtls_ecp_point  *Q
+  )
+{
+  ASSERT (FALSE);
+  return -1;
+}
+
+int
+mbedtls_ecp_muladd (
+  mbedtls_ecp_group        *grp,
+  mbedtls_ecp_point        *R,
+  const mbedtls_mpi        *m,
+  const mbedtls_ecp_point  *P,
+  const mbedtls_mpi        *n,
+  const mbedtls_ecp_point  *Q
+  )
+{
+  ASSERT (FALSE);
+  return -1;
+}
+
+int
+mbedtls_ecdh_gen_public (
+  mbedtls_ecp_group *grp,
+  mbedtls_mpi *d,
+  mbedtls_ecp_point *Q,
+  int ( *f_rng )(void *, unsigned char *, size_t),
+  void *p_rng
+  )
+{
+  ASSERT (FALSE);
+  return -1;
+}
+
+int
+mbedtls_ecdh_compute_shared (
+  mbedtls_ecp_group *grp,
+  mbedtls_mpi *z,
+  const mbedtls_ecp_point *Q,
+  const mbedtls_mpi *d,
+  int ( *f_rng )(void *, unsigned char *, size_t),
+  void *p_rng
+  )
+{
+  ASSERT (FALSE);
+  return -1;
+}
+
+int
+mbedtls_ecdsa_verify (
+  mbedtls_ecp_group        *grp,
+  const unsigned char      *buf,
+  size_t                   blen,
+  const mbedtls_ecp_point  *Q,
+  const mbedtls_mpi        *r,
+  const mbedtls_mpi        *s
+  )
+{
+  ASSERT (FALSE);
+  return -1;
+}
+
+/*
+ * Compute ECDSA signature of a hashed message
+ */
+int
+mbedtls_ecdsa_sign (
+  mbedtls_ecp_group *grp,
+  mbedtls_mpi *r,
+  mbedtls_mpi *s,
+  const mbedtls_mpi *d,
+  const unsigned char *buf,
+  size_t blen,
+  int ( *f_rng )(void *, unsigned char *, size_t),
+  void *p_rng
+  )
+{
+  ASSERT (FALSE);
+  return -1;
+}

--- a/CryptoPkg/Library/MbedTlsLib/EcSm2Null.c
+++ b/CryptoPkg/Library/MbedTlsLib/EcSm2Null.c
@@ -12,7 +12,7 @@
 #include <mbedtls/ecdh.h>
 #include <mbedtls/ecdsa.h>
 #include <mbedtls/bignum.h>
-#include <library/bignum_core.h>
+#include <bignum_core.h>
 
 /*
  * Get the curve info for the internal identifier

--- a/CryptoPkg/Library/MbedTlsLib/Include/mbedtls/mbedtls_config.h
+++ b/CryptoPkg/Library/MbedTlsLib/Include/mbedtls/mbedtls_config.h
@@ -1,0 +1,3823 @@
+/** @file
+  mbedtls_config.h  Configuration options (set of defines).
+
+  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+/**
+ * This is an optional version symbol that enables compatibility handling of
+ * config files.
+ *
+ * It is equal to the #MBEDTLS_VERSION_NUMBER of the Mbed TLS version that
+ * introduced the config format we want to be compatible with.
+ */
+// #define MBEDTLS_CONFIG_VERSION 0x03000000
+
+/**
+ * \name SECTION: System support
+ *
+ * This section sets system specific settings.
+ * \{
+ */
+
+/**
+ * \def MBEDTLS_HAVE_ASM
+ *
+ * The compiler has support for asm().
+ *
+ * Requires support for asm() in compiler.
+ *
+ * Used in:
+ *      library/aria.c
+ *      library/bn_mul.h
+ *
+ * Required by:
+ *      MBEDTLS_AESNI_C
+ *      MBEDTLS_PADLOCK_C
+ *
+ * Comment to disable the use of assembly code.
+ */
+#define MBEDTLS_HAVE_ASM
+
+/**
+ * \def MBEDTLS_NO_UDBL_DIVISION
+ *
+ * The platform lacks support for double-width integer division (64-bit
+ * division on a 32-bit platform, 128-bit division on a 64-bit platform).
+ *
+ * Used in:
+ *      include/mbedtls/bignum.h
+ *      library/bignum.c
+ *
+ * The bignum code uses double-width division to speed up some operations.
+ * Double-width division is often implemented in software that needs to
+ * be linked with the program. The presence of a double-width integer
+ * type is usually detected automatically through preprocessor macros,
+ * but the automatic detection cannot know whether the code needs to
+ * and can be linked with an implementation of division for that type.
+ * By default division is assumed to be usable if the type is present.
+ * Uncomment this option to prevent the use of double-width division.
+ *
+ * Note that division for the native integer type is always required.
+ * Furthermore, a 64-bit type is always required even on a 32-bit
+ * platform, but it need not support multiplication or division. In some
+ * cases it is also desirable to disable some double-width operations. For
+ * example, if double-width division is implemented in software, disabling
+ * it can reduce code size in some embedded targets.
+ */
+// #define MBEDTLS_NO_UDBL_DIVISION
+
+/**
+ * \def MBEDTLS_NO_64BIT_MULTIPLICATION
+ *
+ * The platform lacks support for 32x32 -> 64-bit multiplication.
+ *
+ * Used in:
+ *      library/poly1305.c
+ *
+ * Some parts of the library may use multiplication of two unsigned 32-bit
+ * operands with a 64-bit result in order to speed up computations. On some
+ * platforms, this is not available in hardware and has to be implemented in
+ * software, usually in a library provided by the toolchain.
+ *
+ * Sometimes it is not desirable to have to link to that library. This option
+ * removes the dependency of that library on platforms that lack a hardware
+ * 64-bit multiplier by embedding a software implementation in Mbed TLS.
+ *
+ * Note that depending on the compiler, this may decrease performance compared
+ * to using the library function provided by the toolchain.
+ */
+// #define MBEDTLS_NO_64BIT_MULTIPLICATION
+
+/**
+ * \def MBEDTLS_HAVE_SSE2
+ *
+ * CPU supports SSE2 instruction set.
+ *
+ * Uncomment if the CPU supports SSE2 (IA-32 specific).
+ */
+// #define MBEDTLS_HAVE_SSE2
+
+/**
+ * \def MBEDTLS_HAVE_TIME
+ *
+ * System has time.h and time().
+ * The time does not need to be correct, only time differences are used,
+ * by contrast with MBEDTLS_HAVE_TIME_DATE
+ *
+ * Defining MBEDTLS_HAVE_TIME allows you to specify MBEDTLS_PLATFORM_TIME_ALT,
+ * MBEDTLS_PLATFORM_TIME_MACRO, MBEDTLS_PLATFORM_TIME_TYPE_MACRO and
+ * MBEDTLS_PLATFORM_STD_TIME.
+ *
+ * Comment if your system does not support time functions.
+ *
+ * \note If MBEDTLS_TIMING_C is set - to enable the semi-portable timing
+ *       interface - timing.c will include time.h on suitable platforms
+ *       regardless of the setting of MBEDTLS_HAVE_TIME, unless
+ *       MBEDTLS_TIMING_ALT is used. See timing.c for more information.
+ */
+#define MBEDTLS_HAVE_TIME
+
+/**
+ * \def MBEDTLS_HAVE_TIME_DATE
+ *
+ * System has time.h, time(), and an implementation for
+ * mbedtls_platform_gmtime_r() (see below).
+ * The time needs to be correct (not necessarily very accurate, but at least
+ * the date should be correct). This is used to verify the validity period of
+ * X.509 certificates.
+ *
+ * Comment if your system does not have a correct clock.
+ *
+ * \note mbedtls_platform_gmtime_r() is an abstraction in platform_util.h that
+ * behaves similarly to the gmtime_r() function from the C standard. Refer to
+ * the documentation for mbedtls_platform_gmtime_r() for more information.
+ *
+ * \note It is possible to configure an implementation for
+ * mbedtls_platform_gmtime_r() at compile-time by using the macro
+ * MBEDTLS_PLATFORM_GMTIME_R_ALT.
+ */
+// #define MBEDTLS_HAVE_TIME_DATE
+
+/**
+ * \def MBEDTLS_PLATFORM_MEMORY
+ *
+ * Enable the memory allocation layer.
+ *
+ * By default mbed TLS uses the system-provided calloc() and free().
+ * This allows different allocators (self-implemented or provided) to be
+ * provided to the platform abstraction layer.
+ *
+ * Enabling MBEDTLS_PLATFORM_MEMORY without the
+ * MBEDTLS_PLATFORM_{FREE,CALLOC}_MACROs will provide
+ * "mbedtls_platform_set_calloc_free()" allowing you to set an alternative calloc() and
+ * free() function pointer at runtime.
+ *
+ * Enabling MBEDTLS_PLATFORM_MEMORY and specifying
+ * MBEDTLS_PLATFORM_{CALLOC,FREE}_MACROs will allow you to specify the
+ * alternate function at compile time.
+ *
+ * Requires: MBEDTLS_PLATFORM_C
+ *
+ * Enable this layer to allow use of alternative memory allocators.
+ */
+#define MBEDTLS_PLATFORM_MEMORY
+
+/**
+ * \def MBEDTLS_PLATFORM_NO_STD_FUNCTIONS
+ *
+ * Do not assign standard functions in the platform layer (e.g. calloc() to
+ * MBEDTLS_PLATFORM_STD_CALLOC and printf() to MBEDTLS_PLATFORM_STD_PRINTF)
+ *
+ * This makes sure there are no linking errors on platforms that do not support
+ * these functions. You will HAVE to provide alternatives, either at runtime
+ * via the platform_set_xxx() functions or at compile time by setting
+ * the MBEDTLS_PLATFORM_STD_XXX defines, or enabling a
+ * MBEDTLS_PLATFORM_XXX_MACRO.
+ *
+ * Requires: MBEDTLS_PLATFORM_C
+ *
+ * Uncomment to prevent default assignment of standard functions in the
+ * platform layer.
+ */
+#define MBEDTLS_PLATFORM_NO_STD_FUNCTIONS
+
+/**
+ * \def MBEDTLS_PLATFORM_EXIT_ALT
+ *
+ * MBEDTLS_PLATFORM_XXX_ALT: Uncomment a macro to let mbed TLS support the
+ * function in the platform abstraction layer.
+ *
+ * Example: In case you uncomment MBEDTLS_PLATFORM_PRINTF_ALT, mbed TLS will
+ * provide a function "mbedtls_platform_set_printf()" that allows you to set an
+ * alternative printf function pointer.
+ *
+ * All these define require MBEDTLS_PLATFORM_C to be defined!
+ *
+ * \note MBEDTLS_PLATFORM_SNPRINTF_ALT is required on Windows;
+ * it will be enabled automatically by check_config.h
+ *
+ * \warning MBEDTLS_PLATFORM_XXX_ALT cannot be defined at the same time as
+ * MBEDTLS_PLATFORM_XXX_MACRO!
+ *
+ * Requires: MBEDTLS_PLATFORM_TIME_ALT requires MBEDTLS_HAVE_TIME
+ *
+ * Uncomment a macro to enable alternate implementation of specific base
+ * platform function
+ */
+// #define MBEDTLS_PLATFORM_SETBUF_ALT
+// #define MBEDTLS_PLATFORM_EXIT_ALT
+// #define MBEDTLS_PLATFORM_TIME_ALT
+#define MBEDTLS_PLATFORM_FPRINTF_ALT
+// #define MBEDTLS_PLATFORM_PRINTF_ALT
+// #define MBEDTLS_PLATFORM_SNPRINTF_ALT
+// #define MBEDTLS_PLATFORM_VSNPRINTF_ALT
+// #define MBEDTLS_PLATFORM_NV_SEED_ALT
+// #define MBEDTLS_PLATFORM_SETUP_TEARDOWN_ALT
+
+/**
+ * \def MBEDTLS_DEPRECATED_WARNING
+ *
+ * Mark deprecated functions and features so that they generate a warning if
+ * used. Functionality deprecated in one version will usually be removed in the
+ * next version. You can enable this to help you prepare the transition to a
+ * new major version by making sure your code is not using this functionality.
+ *
+ * This only works with GCC and Clang. With other compilers, you may want to
+ * use MBEDTLS_DEPRECATED_REMOVED
+ *
+ * Uncomment to get warnings on using deprecated functions and features.
+ */
+// #define MBEDTLS_DEPRECATED_WARNING
+
+/**
+ * \def MBEDTLS_DEPRECATED_REMOVED
+ *
+ * Remove deprecated functions and features so that they generate an error if
+ * used. Functionality deprecated in one version will usually be removed in the
+ * next version. You can enable this to help you prepare the transition to a
+ * new major version by making sure your code is not using this functionality.
+ *
+ * Uncomment to get errors on using deprecated functions and features.
+ */
+// #define MBEDTLS_DEPRECATED_REMOVED
+
+/** \} name SECTION: System support */
+
+/**
+ * \name SECTION: mbed TLS feature support
+ *
+ * This section sets support for features that are or are not needed
+ * within the modules that are enabled.
+ * \{
+ */
+
+/**
+ * \def MBEDTLS_TIMING_ALT
+ *
+ * Uncomment to provide your own alternate implementation for
+ * mbedtls_timing_get_timer(), mbedtls_set_alarm(), mbedtls_set/get_delay()
+ *
+ * Only works if you have MBEDTLS_TIMING_C enabled.
+ *
+ * You will need to provide a header "timing_alt.h" and an implementation at
+ * compile time.
+ */
+// #define MBEDTLS_TIMING_ALT
+
+/**
+ * \def MBEDTLS_AES_ALT
+ *
+ * MBEDTLS__MODULE_NAME__ALT: Uncomment a macro to let mbed TLS use your
+ * alternate core implementation of a symmetric crypto, an arithmetic or hash
+ * module (e.g. platform specific assembly optimized implementations). Keep
+ * in mind that the function prototypes should remain the same.
+ *
+ * This replaces the whole module. If you only want to replace one of the
+ * functions, use one of the MBEDTLS__FUNCTION_NAME__ALT flags.
+ *
+ * Example: In case you uncomment MBEDTLS_AES_ALT, mbed TLS will no longer
+ * provide the "struct mbedtls_aes_context" definition and omit the base
+ * function declarations and implementations. "aes_alt.h" will be included from
+ * "aes.h" to include the new function definitions.
+ *
+ * Uncomment a macro to enable alternate implementation of the corresponding
+ * module.
+ *
+ * \warning   MD5, DES and SHA-1 are considered weak and their
+ *            use constitutes a security risk. If possible, we recommend
+ *            avoiding dependencies on them, and considering stronger message
+ *            digests and ciphers instead.
+ *
+ */
+// #define MBEDTLS_AES_ALT
+// #define MBEDTLS_ARIA_ALT
+// #define MBEDTLS_CAMELLIA_ALT
+// #define MBEDTLS_CCM_ALT
+// #define MBEDTLS_CHACHA20_ALT
+// #define MBEDTLS_CHACHAPOLY_ALT
+// #define MBEDTLS_CMAC_ALT
+// #define MBEDTLS_DES_ALT
+// #define MBEDTLS_DHM_ALT
+// #define MBEDTLS_ECJPAKE_ALT
+// #define MBEDTLS_GCM_ALT
+// #define MBEDTLS_NIST_KW_ALT
+// #define MBEDTLS_MD5_ALT
+// #define MBEDTLS_POLY1305_ALT
+// #define MBEDTLS_RIPEMD160_ALT
+// #define MBEDTLS_RSA_ALT
+// #define MBEDTLS_SHA1_ALT
+// #define MBEDTLS_SHA256_ALT
+// #define MBEDTLS_SHA512_ALT
+
+/*
+ * When replacing the elliptic curve module, please consider, that it is
+ * implemented with two .c files:
+ *      - ecp.c
+ *      - ecp_curves.c
+ * You can replace them very much like all the other MBEDTLS__MODULE_NAME__ALT
+ * macros as described above. The only difference is that you have to make sure
+ * that you provide functionality for both .c files.
+ */
+// #define MBEDTLS_ECP_ALT
+
+/**
+ * \def MBEDTLS_SHA256_PROCESS_ALT
+ *
+ * MBEDTLS__FUNCTION_NAME__ALT: Uncomment a macro to let mbed TLS use you
+ * alternate core implementation of symmetric crypto or hash function. Keep in
+ * mind that function prototypes should remain the same.
+ *
+ * This replaces only one function. The header file from mbed TLS is still
+ * used, in contrast to the MBEDTLS__MODULE_NAME__ALT flags.
+ *
+ * Example: In case you uncomment MBEDTLS_SHA256_PROCESS_ALT, mbed TLS will
+ * no longer provide the mbedtls_sha1_process() function, but it will still provide
+ * the other function (using your mbedtls_sha1_process() function) and the definition
+ * of mbedtls_sha1_context, so your implementation of mbedtls_sha1_process must be compatible
+ * with this definition.
+ *
+ * \note If you use the AES_xxx_ALT macros, then it is recommended to also set
+ *       MBEDTLS_AES_ROM_TABLES in order to help the linker garbage-collect the AES
+ *       tables.
+ *
+ * Uncomment a macro to enable alternate implementation of the corresponding
+ * function.
+ *
+ * \warning   MD5, DES and SHA-1 are considered weak and their use
+ *            constitutes a security risk. If possible, we recommend avoiding
+ *            dependencies on them, and considering stronger message digests
+ *            and ciphers instead.
+ *
+ * \warning   If both MBEDTLS_ECDSA_SIGN_ALT and MBEDTLS_ECDSA_DETERMINISTIC are
+ *            enabled, then the deterministic ECDH signature functions pass the
+ *            the static HMAC-DRBG as RNG to mbedtls_ecdsa_sign(). Therefore
+ *            alternative implementations should use the RNG only for generating
+ *            the ephemeral key and nothing else. If this is not possible, then
+ *            MBEDTLS_ECDSA_DETERMINISTIC should be disabled and an alternative
+ *            implementation should be provided for mbedtls_ecdsa_sign_det_ext().
+ *
+ */
+// #define MBEDTLS_MD5_PROCESS_ALT
+// #define MBEDTLS_RIPEMD160_PROCESS_ALT
+// #define MBEDTLS_SHA1_PROCESS_ALT
+// #define MBEDTLS_SHA256_PROCESS_ALT
+// #define MBEDTLS_SHA512_PROCESS_ALT
+// #define MBEDTLS_DES_SETKEY_ALT
+// #define MBEDTLS_DES_CRYPT_ECB_ALT
+// #define MBEDTLS_DES3_CRYPT_ECB_ALT
+// #define MBEDTLS_AES_SETKEY_ENC_ALT
+// #define MBEDTLS_AES_SETKEY_DEC_ALT
+// #define MBEDTLS_AES_ENCRYPT_ALT
+// #define MBEDTLS_AES_DECRYPT_ALT
+// #define MBEDTLS_ECDH_GEN_PUBLIC_ALT
+// #define MBEDTLS_ECDH_COMPUTE_SHARED_ALT
+// #define MBEDTLS_ECDSA_VERIFY_ALT
+// #define MBEDTLS_ECDSA_SIGN_ALT
+// #define MBEDTLS_ECDSA_GENKEY_ALT
+
+/**
+ * \def MBEDTLS_ECP_INTERNAL_ALT
+ *
+ * Expose a part of the internal interface of the Elliptic Curve Point module.
+ *
+ * MBEDTLS_ECP__FUNCTION_NAME__ALT: Uncomment a macro to let mbed TLS use your
+ * alternative core implementation of elliptic curve arithmetic. Keep in mind
+ * that function prototypes should remain the same.
+ *
+ * This partially replaces one function. The header file from mbed TLS is still
+ * used, in contrast to the MBEDTLS_ECP_ALT flag. The original implementation
+ * is still present and it is used for group structures not supported by the
+ * alternative.
+ *
+ * The original implementation can in addition be removed by setting the
+ * MBEDTLS_ECP_NO_FALLBACK option, in which case any function for which the
+ * corresponding MBEDTLS_ECP__FUNCTION_NAME__ALT macro is defined will not be
+ * able to fallback to curves not supported by the alternative implementation.
+ *
+ * Any of these options become available by defining MBEDTLS_ECP_INTERNAL_ALT
+ * and implementing the following functions:
+ *      unsigned char mbedtls_internal_ecp_grp_capable(
+ *          const mbedtls_ecp_group *grp )
+ *      int  mbedtls_internal_ecp_init( const mbedtls_ecp_group *grp )
+ *      void mbedtls_internal_ecp_free( const mbedtls_ecp_group *grp )
+ * The mbedtls_internal_ecp_grp_capable function should return 1 if the
+ * replacement functions implement arithmetic for the given group and 0
+ * otherwise.
+ * The functions mbedtls_internal_ecp_init and mbedtls_internal_ecp_free are
+ * called before and after each point operation and provide an opportunity to
+ * implement optimized set up and tear down instructions.
+ *
+ * Example: In case you set MBEDTLS_ECP_INTERNAL_ALT and
+ * MBEDTLS_ECP_DOUBLE_JAC_ALT, mbed TLS will still provide the ecp_double_jac()
+ * function, but will use your mbedtls_internal_ecp_double_jac() if the group
+ * for the operation is supported by your implementation (i.e. your
+ * mbedtls_internal_ecp_grp_capable() function returns 1 for this group). If the
+ * group is not supported by your implementation, then the original mbed TLS
+ * implementation of ecp_double_jac() is used instead, unless this fallback
+ * behaviour is disabled by setting MBEDTLS_ECP_NO_FALLBACK (in which case
+ * ecp_double_jac() will return MBEDTLS_ERR_ECP_FEATURE_UNAVAILABLE).
+ *
+ * The function prototypes and the definition of mbedtls_ecp_group and
+ * mbedtls_ecp_point will not change based on MBEDTLS_ECP_INTERNAL_ALT, so your
+ * implementation of mbedtls_internal_ecp__function_name__ must be compatible
+ * with their definitions.
+ *
+ * Uncomment a macro to enable alternate implementation of the corresponding
+ * function.
+ */
+/* Required for all the functions in this section */
+// #define MBEDTLS_ECP_INTERNAL_ALT
+/* Turn off software fallback for curves not supported in hardware */
+// #define MBEDTLS_ECP_NO_FALLBACK
+/* Support for Weierstrass curves with Jacobi representation */
+// #define MBEDTLS_ECP_RANDOMIZE_JAC_ALT
+// #define MBEDTLS_ECP_ADD_MIXED_ALT
+// #define MBEDTLS_ECP_DOUBLE_JAC_ALT
+// #define MBEDTLS_ECP_NORMALIZE_JAC_MANY_ALT
+// #define MBEDTLS_ECP_NORMALIZE_JAC_ALT
+/* Support for curves with Montgomery arithmetic */
+// #define MBEDTLS_ECP_DOUBLE_ADD_MXZ_ALT
+// #define MBEDTLS_ECP_RANDOMIZE_MXZ_ALT
+// #define MBEDTLS_ECP_NORMALIZE_MXZ_ALT
+
+/**
+ * \def MBEDTLS_ENTROPY_HARDWARE_ALT
+ *
+ * Uncomment this macro to let mbed TLS use your own implementation of a
+ * hardware entropy collector.
+ *
+ * Your function must be called \c mbedtls_hardware_poll(), have the same
+ * prototype as declared in library/entropy_poll.h, and accept NULL as first
+ * argument.
+ *
+ * Uncomment to use your own hardware entropy collector.
+ */
+// #define MBEDTLS_ENTROPY_HARDWARE_ALT
+
+/**
+ * \def MBEDTLS_AES_ROM_TABLES
+ *
+ * Use precomputed AES tables stored in ROM.
+ *
+ * Uncomment this macro to use precomputed AES tables stored in ROM.
+ * Comment this macro to generate AES tables in RAM at runtime.
+ *
+ * Tradeoff: Using precomputed ROM tables reduces RAM usage by ~8kb
+ * (or ~2kb if \c MBEDTLS_AES_FEWER_TABLES is used) and reduces the
+ * initialization time before the first AES operation can be performed.
+ * It comes at the cost of additional ~8kb ROM use (resp. ~2kb if \c
+ * MBEDTLS_AES_FEWER_TABLES below is used), and potentially degraded
+ * performance if ROM access is slower than RAM access.
+ *
+ * This option is independent of \c MBEDTLS_AES_FEWER_TABLES.
+ *
+ */
+// #define MBEDTLS_AES_ROM_TABLES
+
+/**
+ * \def MBEDTLS_AES_FEWER_TABLES
+ *
+ * Use less ROM/RAM for AES tables.
+ *
+ * Uncommenting this macro omits 75% of the AES tables from
+ * ROM / RAM (depending on the value of \c MBEDTLS_AES_ROM_TABLES)
+ * by computing their values on the fly during operations
+ * (the tables are entry-wise rotations of one another).
+ *
+ * Tradeoff: Uncommenting this reduces the RAM / ROM footprint
+ * by ~6kb but at the cost of more arithmetic operations during
+ * runtime. Specifically, one has to compare 4 accesses within
+ * different tables to 4 accesses with additional arithmetic
+ * operations within the same table. The performance gain/loss
+ * depends on the system and memory details.
+ *
+ * This option is independent of \c MBEDTLS_AES_ROM_TABLES.
+ *
+ */
+// #define MBEDTLS_AES_FEWER_TABLES
+
+/**
+ * \def MBEDTLS_CAMELLIA_SMALL_MEMORY
+ *
+ * Use less ROM for the Camellia implementation (saves about 768 bytes).
+ *
+ * Uncomment this macro to use less memory for Camellia.
+ */
+// #define MBEDTLS_CAMELLIA_SMALL_MEMORY
+
+/**
+ * \def MBEDTLS_CHECK_RETURN_WARNING
+ *
+ * If this macro is defined, emit a compile-time warning if application code
+ * calls a function without checking its return value, but the return value
+ * should generally be checked in portable applications.
+ *
+ * This is only supported on platforms where #MBEDTLS_CHECK_RETURN is
+ * implemented. Otherwise this option has no effect.
+ *
+ * Uncomment to get warnings on using fallible functions without checking
+ * their return value.
+ *
+ * \note  This feature is a work in progress.
+ *        Warnings will be added to more functions in the future.
+ *
+ * \note  A few functions are considered critical, and ignoring the return
+ *        value of these functions will trigger a warning even if this
+ *        macro is not defined. To completely disable return value check
+ *        warnings, define #MBEDTLS_CHECK_RETURN with an empty expansion.
+ */
+// #define MBEDTLS_CHECK_RETURN_WARNING
+
+/**
+ * \def MBEDTLS_CIPHER_MODE_CBC
+ *
+ * Enable Cipher Block Chaining mode (CBC) for symmetric ciphers.
+ */
+#define MBEDTLS_CIPHER_MODE_CBC
+
+/**
+ * \def MBEDTLS_CIPHER_MODE_CFB
+ *
+ * Enable Cipher Feedback mode (CFB) for symmetric ciphers.
+ */
+// #define MBEDTLS_CIPHER_MODE_CFB
+
+/**
+ * \def MBEDTLS_CIPHER_MODE_CTR
+ *
+ * Enable Counter Block Cipher mode (CTR) for symmetric ciphers.
+ */
+// #define MBEDTLS_CIPHER_MODE_CTR
+
+/**
+ * \def MBEDTLS_CIPHER_MODE_OFB
+ *
+ * Enable Output Feedback mode (OFB) for symmetric ciphers.
+ */
+// #define MBEDTLS_CIPHER_MODE_OFB
+
+/**
+ * \def MBEDTLS_CIPHER_MODE_XTS
+ *
+ * Enable Xor-encrypt-xor with ciphertext stealing mode (XTS) for AES.
+ */
+// #define MBEDTLS_CIPHER_MODE_XTS
+
+/**
+ * \def MBEDTLS_CIPHER_NULL_CIPHER
+ *
+ * Enable NULL cipher.
+ * Warning: Only do so when you know what you are doing. This allows for
+ * encryption or channels without any security!
+ *
+ * To enable the following ciphersuites:
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_NULL_SHA
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_NULL_SHA
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_NULL_SHA
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_NULL_SHA
+ *      MBEDTLS_TLS_ECDHE_PSK_WITH_NULL_SHA384
+ *      MBEDTLS_TLS_ECDHE_PSK_WITH_NULL_SHA256
+ *      MBEDTLS_TLS_ECDHE_PSK_WITH_NULL_SHA
+ *      MBEDTLS_TLS_DHE_PSK_WITH_NULL_SHA384
+ *      MBEDTLS_TLS_DHE_PSK_WITH_NULL_SHA256
+ *      MBEDTLS_TLS_DHE_PSK_WITH_NULL_SHA
+ *      MBEDTLS_TLS_RSA_WITH_NULL_SHA256
+ *      MBEDTLS_TLS_RSA_WITH_NULL_SHA
+ *      MBEDTLS_TLS_RSA_WITH_NULL_MD5
+ *      MBEDTLS_TLS_RSA_PSK_WITH_NULL_SHA384
+ *      MBEDTLS_TLS_RSA_PSK_WITH_NULL_SHA256
+ *      MBEDTLS_TLS_RSA_PSK_WITH_NULL_SHA
+ *      MBEDTLS_TLS_PSK_WITH_NULL_SHA384
+ *      MBEDTLS_TLS_PSK_WITH_NULL_SHA256
+ *      MBEDTLS_TLS_PSK_WITH_NULL_SHA
+ *
+ * Uncomment this macro to enable the NULL cipher and ciphersuites
+ */
+// #define MBEDTLS_CIPHER_NULL_CIPHER
+
+/**
+ * \def MBEDTLS_CIPHER_PADDING_PKCS7
+ *
+ * MBEDTLS_CIPHER_PADDING_XXX: Uncomment or comment macros to add support for
+ * specific padding modes in the cipher layer with cipher modes that support
+ * padding (e.g. CBC)
+ *
+ * If you disable all padding modes, only full blocks can be used with CBC.
+ *
+ * Enable padding modes in the cipher layer.
+ */
+// #define MBEDTLS_CIPHER_PADDING_PKCS7
+// #define MBEDTLS_CIPHER_PADDING_ONE_AND_ZEROS
+// #define MBEDTLS_CIPHER_PADDING_ZEROS_AND_LEN
+// #define MBEDTLS_CIPHER_PADDING_ZEROS
+
+/** \def MBEDTLS_CTR_DRBG_USE_128_BIT_KEY
+ *
+ * Uncomment this macro to use a 128-bit key in the CTR_DRBG module.
+ * By default, CTR_DRBG uses a 256-bit key.
+ */
+// #define MBEDTLS_CTR_DRBG_USE_128_BIT_KEY
+
+/**
+ * \def MBEDTLS_ECP_DP_SECP192R1_ENABLED
+ *
+ * MBEDTLS_ECP_XXXX_ENABLED: Enables specific curves within the Elliptic Curve
+ * module.  By default all supported curves are enabled.
+ *
+ * Comment macros to disable the curve and functions for it
+ */
+/* Short Weierstrass curves (supporting ECP, ECDH, ECDSA) */
+// #define MBEDTLS_ECP_DP_SECP192R1_ENABLED
+// #define MBEDTLS_ECP_DP_SECP224R1_ENABLED
+#define MBEDTLS_ECP_DP_SECP256R1_ENABLED
+#define MBEDTLS_ECP_DP_SECP384R1_ENABLED
+#define MBEDTLS_ECP_DP_SECP521R1_ENABLED
+// #define MBEDTLS_ECP_DP_SECP192K1_ENABLED
+// #define MBEDTLS_ECP_DP_SECP224K1_ENABLED
+// #define MBEDTLS_ECP_DP_SECP256K1_ENABLED
+// #define MBEDTLS_ECP_DP_BP256R1_ENABLED
+// #define MBEDTLS_ECP_DP_BP384R1_ENABLED
+// #define MBEDTLS_ECP_DP_BP512R1_ENABLED
+/* Montgomery curves (supporting ECP) */
+#define MBEDTLS_ECP_DP_CURVE25519_ENABLED
+#define MBEDTLS_ECP_DP_CURVE448_ENABLED
+
+/**
+ * \def MBEDTLS_ECP_NIST_OPTIM
+ *
+ * Enable specific 'modulo p' routines for each NIST prime.
+ * Depending on the prime and architecture, makes operations 4 to 8 times
+ * faster on the corresponding curve.
+ *
+ * Comment this macro to disable NIST curves optimisation.
+ */
+#define MBEDTLS_ECP_NIST_OPTIM
+
+/**
+ * \def MBEDTLS_ECP_RESTARTABLE
+ *
+ * Enable "non-blocking" ECC operations that can return early and be resumed.
+ *
+ * This allows various functions to pause by returning
+ * #MBEDTLS_ERR_ECP_IN_PROGRESS (or, for functions in the SSL module,
+ * #MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS) and then be called later again in
+ * order to further progress and eventually complete their operation. This is
+ * controlled through mbedtls_ecp_set_max_ops() which limits the maximum
+ * number of ECC operations a function may perform before pausing; see
+ * mbedtls_ecp_set_max_ops() for more information.
+ *
+ * This is useful in non-threaded environments if you want to avoid blocking
+ * for too long on ECC (and, hence, X.509 or SSL/TLS) operations.
+ *
+ * Uncomment this macro to enable restartable ECC computations.
+ *
+ * \note  This option only works with the default software implementation of
+ *        elliptic curve functionality. It is incompatible with
+ *        MBEDTLS_ECP_ALT, MBEDTLS_ECDH_XXX_ALT, MBEDTLS_ECDSA_XXX_ALT.
+ */
+#define MBEDTLS_ECP_RESTARTABLE
+
+/**
+ * \def MBEDTLS_ECDSA_DETERMINISTIC
+ *
+ * Enable deterministic ECDSA (RFC 6979).
+ * Standard ECDSA is "fragile" in the sense that lack of entropy when signing
+ * may result in a compromise of the long-term signing key. This is avoided by
+ * the deterministic variant.
+ *
+ * Requires: MBEDTLS_HMAC_DRBG_C, MBEDTLS_ECDSA_C
+ *
+ * Comment this macro to disable deterministic ECDSA.
+ */
+// #define MBEDTLS_ECDSA_DETERMINISTIC
+
+/**
+ * \def MBEDTLS_KEY_EXCHANGE_PSK_ENABLED
+ *
+ * Enable the PSK based ciphersuite modes in SSL / TLS.
+ *
+ * This enables the following ciphersuites (if other requisites are
+ * enabled as well):
+ *      MBEDTLS_TLS_PSK_WITH_AES_256_GCM_SHA384
+ *      MBEDTLS_TLS_PSK_WITH_AES_256_CBC_SHA384
+ *      MBEDTLS_TLS_PSK_WITH_AES_256_CBC_SHA
+ *      MBEDTLS_TLS_PSK_WITH_CAMELLIA_256_GCM_SHA384
+ *      MBEDTLS_TLS_PSK_WITH_CAMELLIA_256_CBC_SHA384
+ *      MBEDTLS_TLS_PSK_WITH_AES_128_GCM_SHA256
+ *      MBEDTLS_TLS_PSK_WITH_AES_128_CBC_SHA256
+ *      MBEDTLS_TLS_PSK_WITH_AES_128_CBC_SHA
+ *      MBEDTLS_TLS_PSK_WITH_CAMELLIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_PSK_WITH_CAMELLIA_128_CBC_SHA256
+ */
+#define MBEDTLS_KEY_EXCHANGE_PSK_ENABLED
+
+/**
+ * \def MBEDTLS_KEY_EXCHANGE_DHE_PSK_ENABLED
+ *
+ * Enable the DHE-PSK based ciphersuite modes in SSL / TLS.
+ *
+ * Requires: MBEDTLS_DHM_C
+ *
+ * This enables the following ciphersuites (if other requisites are
+ * enabled as well):
+ *      MBEDTLS_TLS_DHE_PSK_WITH_AES_256_GCM_SHA384
+ *      MBEDTLS_TLS_DHE_PSK_WITH_AES_256_CBC_SHA384
+ *      MBEDTLS_TLS_DHE_PSK_WITH_AES_256_CBC_SHA
+ *      MBEDTLS_TLS_DHE_PSK_WITH_CAMELLIA_256_GCM_SHA384
+ *      MBEDTLS_TLS_DHE_PSK_WITH_CAMELLIA_256_CBC_SHA384
+ *      MBEDTLS_TLS_DHE_PSK_WITH_AES_128_GCM_SHA256
+ *      MBEDTLS_TLS_DHE_PSK_WITH_AES_128_CBC_SHA256
+ *      MBEDTLS_TLS_DHE_PSK_WITH_AES_128_CBC_SHA
+ *      MBEDTLS_TLS_DHE_PSK_WITH_CAMELLIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_DHE_PSK_WITH_CAMELLIA_128_CBC_SHA256
+ *
+ * \warning    Using DHE constitutes a security risk as it
+ *             is not possible to validate custom DH parameters.
+ *             If possible, it is recommended users should consider
+ *             preferring other methods of key exchange.
+ *             See dhm.h for more details.
+ *
+ */
+#define MBEDTLS_KEY_EXCHANGE_DHE_PSK_ENABLED
+
+/**
+ * \def MBEDTLS_KEY_EXCHANGE_ECDHE_PSK_ENABLED
+ *
+ * Enable the ECDHE-PSK based ciphersuite modes in SSL / TLS.
+ *
+ * Requires: MBEDTLS_ECDH_C
+ *
+ * This enables the following ciphersuites (if other requisites are
+ * enabled as well):
+ *      MBEDTLS_TLS_ECDHE_PSK_WITH_AES_256_CBC_SHA384
+ *      MBEDTLS_TLS_ECDHE_PSK_WITH_AES_256_CBC_SHA
+ *      MBEDTLS_TLS_ECDHE_PSK_WITH_CAMELLIA_256_CBC_SHA384
+ *      MBEDTLS_TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA256
+ *      MBEDTLS_TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA
+ *      MBEDTLS_TLS_ECDHE_PSK_WITH_CAMELLIA_128_CBC_SHA256
+ */
+#define MBEDTLS_KEY_EXCHANGE_ECDHE_PSK_ENABLED
+
+/**
+ * \def MBEDTLS_KEY_EXCHANGE_RSA_PSK_ENABLED
+ *
+ * Enable the RSA-PSK based ciphersuite modes in SSL / TLS.
+ *
+ * Requires: MBEDTLS_RSA_C, MBEDTLS_PKCS1_V15,
+ *           MBEDTLS_X509_CRT_PARSE_C
+ *
+ * This enables the following ciphersuites (if other requisites are
+ * enabled as well):
+ *      MBEDTLS_TLS_RSA_PSK_WITH_AES_256_GCM_SHA384
+ *      MBEDTLS_TLS_RSA_PSK_WITH_AES_256_CBC_SHA384
+ *      MBEDTLS_TLS_RSA_PSK_WITH_AES_256_CBC_SHA
+ *      MBEDTLS_TLS_RSA_PSK_WITH_CAMELLIA_256_GCM_SHA384
+ *      MBEDTLS_TLS_RSA_PSK_WITH_CAMELLIA_256_CBC_SHA384
+ *      MBEDTLS_TLS_RSA_PSK_WITH_AES_128_GCM_SHA256
+ *      MBEDTLS_TLS_RSA_PSK_WITH_AES_128_CBC_SHA256
+ *      MBEDTLS_TLS_RSA_PSK_WITH_AES_128_CBC_SHA
+ *      MBEDTLS_TLS_RSA_PSK_WITH_CAMELLIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_RSA_PSK_WITH_CAMELLIA_128_CBC_SHA256
+ */
+#define MBEDTLS_KEY_EXCHANGE_RSA_PSK_ENABLED
+
+/**
+ * \def MBEDTLS_KEY_EXCHANGE_RSA_ENABLED
+ *
+ * Enable the RSA-only based ciphersuite modes in SSL / TLS.
+ *
+ * Requires: MBEDTLS_RSA_C, MBEDTLS_PKCS1_V15,
+ *           MBEDTLS_X509_CRT_PARSE_C
+ *
+ * This enables the following ciphersuites (if other requisites are
+ * enabled as well):
+ *      MBEDTLS_TLS_RSA_WITH_AES_256_GCM_SHA384
+ *      MBEDTLS_TLS_RSA_WITH_AES_256_CBC_SHA256
+ *      MBEDTLS_TLS_RSA_WITH_AES_256_CBC_SHA
+ *      MBEDTLS_TLS_RSA_WITH_CAMELLIA_256_GCM_SHA384
+ *      MBEDTLS_TLS_RSA_WITH_CAMELLIA_256_CBC_SHA256
+ *      MBEDTLS_TLS_RSA_WITH_CAMELLIA_256_CBC_SHA
+ *      MBEDTLS_TLS_RSA_WITH_AES_128_GCM_SHA256
+ *      MBEDTLS_TLS_RSA_WITH_AES_128_CBC_SHA256
+ *      MBEDTLS_TLS_RSA_WITH_AES_128_CBC_SHA
+ *      MBEDTLS_TLS_RSA_WITH_CAMELLIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_RSA_WITH_CAMELLIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_RSA_WITH_CAMELLIA_128_CBC_SHA
+ */
+#define MBEDTLS_KEY_EXCHANGE_RSA_ENABLED
+
+/**
+ * \def MBEDTLS_KEY_EXCHANGE_DHE_RSA_ENABLED
+ *
+ * Enable the DHE-RSA based ciphersuite modes in SSL / TLS.
+ *
+ * Requires: MBEDTLS_DHM_C, MBEDTLS_RSA_C, MBEDTLS_PKCS1_V15,
+ *           MBEDTLS_X509_CRT_PARSE_C
+ *
+ * This enables the following ciphersuites (if other requisites are
+ * enabled as well):
+ *      MBEDTLS_TLS_DHE_RSA_WITH_AES_256_GCM_SHA384
+ *      MBEDTLS_TLS_DHE_RSA_WITH_AES_256_CBC_SHA256
+ *      MBEDTLS_TLS_DHE_RSA_WITH_AES_256_CBC_SHA
+ *      MBEDTLS_TLS_DHE_RSA_WITH_CAMELLIA_256_GCM_SHA384
+ *      MBEDTLS_TLS_DHE_RSA_WITH_CAMELLIA_256_CBC_SHA256
+ *      MBEDTLS_TLS_DHE_RSA_WITH_CAMELLIA_256_CBC_SHA
+ *      MBEDTLS_TLS_DHE_RSA_WITH_AES_128_GCM_SHA256
+ *      MBEDTLS_TLS_DHE_RSA_WITH_AES_128_CBC_SHA256
+ *      MBEDTLS_TLS_DHE_RSA_WITH_AES_128_CBC_SHA
+ *      MBEDTLS_TLS_DHE_RSA_WITH_CAMELLIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_DHE_RSA_WITH_CAMELLIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_DHE_RSA_WITH_CAMELLIA_128_CBC_SHA
+ *
+ * \warning    Using DHE constitutes a security risk as it
+ *             is not possible to validate custom DH parameters.
+ *             If possible, it is recommended users should consider
+ *             preferring other methods of key exchange.
+ *             See dhm.h for more details.
+ *
+ */
+#define MBEDTLS_KEY_EXCHANGE_DHE_RSA_ENABLED
+
+/**
+ * \def MBEDTLS_KEY_EXCHANGE_ECDHE_RSA_ENABLED
+ *
+ * Enable the ECDHE-RSA based ciphersuite modes in SSL / TLS.
+ *
+ * Requires: MBEDTLS_ECDH_C, MBEDTLS_RSA_C, MBEDTLS_PKCS1_V15,
+ *           MBEDTLS_X509_CRT_PARSE_C
+ *
+ * This enables the following ciphersuites (if other requisites are
+ * enabled as well):
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_CAMELLIA_256_GCM_SHA384
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_CAMELLIA_256_CBC_SHA384
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_CAMELLIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_CAMELLIA_128_CBC_SHA256
+ */
+#define MBEDTLS_KEY_EXCHANGE_ECDHE_RSA_ENABLED
+
+/**
+ * \def MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED
+ *
+ * Enable the ECDHE-ECDSA based ciphersuite modes in SSL / TLS.
+ *
+ * Requires: MBEDTLS_ECDH_C, MBEDTLS_ECDSA_C, MBEDTLS_X509_CRT_PARSE_C,
+ *
+ * This enables the following ciphersuites (if other requisites are
+ * enabled as well):
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_CAMELLIA_256_GCM_SHA384
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_CAMELLIA_256_CBC_SHA384
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_CAMELLIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_CAMELLIA_128_CBC_SHA256
+ */
+#define MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED
+
+/**
+ * \def MBEDTLS_KEY_EXCHANGE_ECDH_ECDSA_ENABLED
+ *
+ * Enable the ECDH-ECDSA based ciphersuite modes in SSL / TLS.
+ *
+ * Requires: MBEDTLS_ECDH_C, MBEDTLS_ECDSA_C, MBEDTLS_X509_CRT_PARSE_C
+ *
+ * This enables the following ciphersuites (if other requisites are
+ * enabled as well):
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA256
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA384
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_AES_256_GCM_SHA384
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_CAMELLIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_CAMELLIA_256_CBC_SHA384
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_CAMELLIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_CAMELLIA_256_GCM_SHA384
+ */
+#define MBEDTLS_KEY_EXCHANGE_ECDH_ECDSA_ENABLED
+
+/**
+ * \def MBEDTLS_KEY_EXCHANGE_ECDH_RSA_ENABLED
+ *
+ * Enable the ECDH-RSA based ciphersuite modes in SSL / TLS.
+ *
+ * Requires: MBEDTLS_ECDH_C, MBEDTLS_RSA_C, MBEDTLS_X509_CRT_PARSE_C
+ *
+ * This enables the following ciphersuites (if other requisites are
+ * enabled as well):
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_AES_128_CBC_SHA
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_AES_256_CBC_SHA
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_CAMELLIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_CAMELLIA_256_CBC_SHA384
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_CAMELLIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_CAMELLIA_256_GCM_SHA384
+ */
+#define MBEDTLS_KEY_EXCHANGE_ECDH_RSA_ENABLED
+
+/**
+ * \def MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED
+ *
+ * Enable the ECJPAKE based ciphersuite modes in SSL / TLS.
+ *
+ * \warning This is currently experimental. EC J-PAKE support is based on the
+ * Thread v1.0.0 specification; incompatible changes to the specification
+ * might still happen. For this reason, this is disabled by default.
+ *
+ * Requires: MBEDTLS_ECJPAKE_C
+ *           SHA-256 (via MD if present, or via PSA, see MBEDTLS_ECJPAKE_C)
+ *           MBEDTLS_ECP_DP_SECP256R1_ENABLED
+ *
+ * This enables the following ciphersuites (if other requisites are
+ * enabled as well):
+ *      MBEDTLS_TLS_ECJPAKE_WITH_AES_128_CCM_8
+ */
+// #define MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED
+
+/**
+ * \def MBEDTLS_PK_PARSE_EC_EXTENDED
+ *
+ * Enhance support for reading EC keys using variants of SEC1 not allowed by
+ * RFC 5915 and RFC 5480.
+ *
+ * Currently this means parsing the SpecifiedECDomain choice of EC
+ * parameters (only known groups are supported, not arbitrary domains, to
+ * avoid validation issues).
+ *
+ * Disable if you only need to support RFC 5915 + 5480 key formats.
+ */
+// #define MBEDTLS_PK_PARSE_EC_EXTENDED
+
+/**
+ * \def MBEDTLS_ERROR_STRERROR_DUMMY
+ *
+ * Enable a dummy error function to make use of mbedtls_strerror() in
+ * third party libraries easier when MBEDTLS_ERROR_C is disabled
+ * (no effect when MBEDTLS_ERROR_C is enabled).
+ *
+ * You can safely disable this if MBEDTLS_ERROR_C is enabled, or if you're
+ * not using mbedtls_strerror() or error_strerror() in your application.
+ *
+ * Disable if you run into name conflicts and want to really remove the
+ * mbedtls_strerror()
+ */
+#define MBEDTLS_ERROR_STRERROR_DUMMY
+
+/**
+ * \def MBEDTLS_GENPRIME
+ *
+ * Enable the prime-number generation code.
+ *
+ * Requires: MBEDTLS_BIGNUM_C
+ */
+#define MBEDTLS_GENPRIME
+
+/**
+ * \def MBEDTLS_FS_IO
+ *
+ * Enable functions that use the filesystem.
+ */
+// #define MBEDTLS_FS_IO
+
+/**
+ * \def MBEDTLS_NO_DEFAULT_ENTROPY_SOURCES
+ *
+ * Do not add default entropy sources in mbedtls_entropy_init().
+ *
+ * This is useful to have more control over the added entropy sources in an
+ * application.
+ *
+ * Uncomment this macro to prevent loading of default entropy functions.
+ */
+// #define MBEDTLS_NO_DEFAULT_ENTROPY_SOURCES
+
+/**
+ * \def MBEDTLS_NO_PLATFORM_ENTROPY
+ *
+ * Do not use built-in platform entropy functions.
+ * This is useful if your platform does not support
+ * standards like the /dev/urandom or Windows CryptoAPI.
+ *
+ * Uncomment this macro to disable the built-in platform entropy functions.
+ */
+// #define MBEDTLS_NO_PLATFORM_ENTROPY
+
+/**
+ * \def MBEDTLS_ENTROPY_FORCE_SHA256
+ *
+ * Force the entropy accumulator to use a SHA-256 accumulator instead of the
+ * default SHA-512 based one (if both are available).
+ *
+ * Requires: MBEDTLS_SHA256_C
+ *
+ * On 32-bit systems SHA-256 can be much faster than SHA-512. Use this option
+ * if you have performance concerns.
+ *
+ * This option is only useful if both MBEDTLS_SHA256_C and
+ * MBEDTLS_SHA512_C are defined. Otherwise the available hash module is used.
+ */
+// #define MBEDTLS_ENTROPY_FORCE_SHA256
+
+/**
+ * \def MBEDTLS_ENTROPY_NV_SEED
+ *
+ * Enable the non-volatile (NV) seed file-based entropy source.
+ * (Also enables the NV seed read/write functions in the platform layer)
+ *
+ * This is crucial (if not required) on systems that do not have a
+ * cryptographic entropy source (in hardware or kernel) available.
+ *
+ * Requires: MBEDTLS_ENTROPY_C, MBEDTLS_PLATFORM_C
+ *
+ * \note The read/write functions that are used by the entropy source are
+ *       determined in the platform layer, and can be modified at runtime and/or
+ *       compile-time depending on the flags (MBEDTLS_PLATFORM_NV_SEED_*) used.
+ *
+ * \note If you use the default implementation functions that read a seedfile
+ *       with regular fopen(), please make sure you make a seedfile with the
+ *       proper name (defined in MBEDTLS_PLATFORM_STD_NV_SEED_FILE) and at
+ *       least MBEDTLS_ENTROPY_BLOCK_SIZE bytes in size that can be read from
+ *       and written to or you will get an entropy source error! The default
+ *       implementation will only use the first MBEDTLS_ENTROPY_BLOCK_SIZE
+ *       bytes from the file.
+ *
+ * \note The entropy collector will write to the seed file before entropy is
+ *       given to an external source, to update it.
+ */
+// #define MBEDTLS_ENTROPY_NV_SEED
+
+/* MBEDTLS_PSA_CRYPTO_KEY_ID_ENCODES_OWNER
+ *
+ * Enable key identifiers that encode a key owner identifier.
+ *
+ * The owner of a key is identified by a value of type ::mbedtls_key_owner_id_t
+ * which is currently hard-coded to be int32_t.
+ *
+ * Note that this option is meant for internal use only and may be removed
+ * without notice.
+ */
+// #define MBEDTLS_PSA_CRYPTO_KEY_ID_ENCODES_OWNER
+
+/**
+ * \def MBEDTLS_MEMORY_DEBUG
+ *
+ * Enable debugging of buffer allocator memory issues. Automatically prints
+ * (to stderr) all (fatal) messages on memory allocation issues. Enables
+ * function for 'debug output' of allocated memory.
+ *
+ * Requires: MBEDTLS_MEMORY_BUFFER_ALLOC_C
+ *
+ * Uncomment this macro to let the buffer allocator print out error messages.
+ */
+// #define MBEDTLS_MEMORY_DEBUG
+
+/**
+ * \def MBEDTLS_MEMORY_BACKTRACE
+ *
+ * Include backtrace information with each allocated block.
+ *
+ * Requires: MBEDTLS_MEMORY_BUFFER_ALLOC_C
+ *           GLIBC-compatible backtrace() and backtrace_symbols() support
+ *
+ * Uncomment this macro to include backtrace information
+ */
+// #define MBEDTLS_MEMORY_BACKTRACE
+
+/**
+ * \def MBEDTLS_PK_RSA_ALT_SUPPORT
+ *
+ * Support external private RSA keys (eg from a HSM) in the PK layer.
+ *
+ * Comment this macro to disable support for external private RSA keys.
+ */
+// #define MBEDTLS_PK_RSA_ALT_SUPPORT
+
+/**
+ * \def MBEDTLS_PKCS1_V15
+ *
+ * Enable support for PKCS#1 v1.5 encoding.
+ *
+ * Requires: MBEDTLS_RSA_C
+ *
+ * This enables support for PKCS#1 v1.5 operations.
+ */
+#define MBEDTLS_PKCS1_V15
+
+/**
+ * \def MBEDTLS_PKCS1_V21
+ *
+ * Enable support for PKCS#1 v2.1 encoding.
+ *
+ * Requires: MBEDTLS_RSA_C and (MBEDTLS_MD_C or MBEDTLS_PSA_CRYPTO_C).
+ *
+ * \warning If building without MBEDTLS_MD_C, you must call psa_crypto_init()
+ * before doing any PKCS#1 v2.1 operation.
+ *
+ * \warning When building with MBEDTLS_MD_C, all hashes used with this
+ * need to be available as built-ins (that is, for SHA-256, MBEDTLS_SHA256_C,
+ * etc.) as opposed to just PSA drivers. So far, PSA drivers are only used by
+ * this module in builds where MBEDTLS_MD_C is disabled.
+ *
+ * This enables support for RSAES-OAEP and RSASSA-PSS operations.
+ */
+#define MBEDTLS_PKCS1_V21
+
+/** \def MBEDTLS_PSA_CRYPTO_BUILTIN_KEYS
+ *
+ * Enable support for platform built-in keys. If you enable this feature,
+ * you must implement the function mbedtls_psa_platform_get_builtin_key().
+ * See the documentation of that function for more information.
+ *
+ * Built-in keys are typically derived from a hardware unique key or
+ * stored in a secure element.
+ *
+ * Requires: MBEDTLS_PSA_CRYPTO_C.
+ *
+ * \warning This interface is experimental and may change or be removed
+ * without notice.
+ */
+// #define MBEDTLS_PSA_CRYPTO_BUILTIN_KEYS
+
+/** \def MBEDTLS_PSA_CRYPTO_CLIENT
+ *
+ * Enable support for PSA crypto client.
+ *
+ * \note This option allows to include the code necessary for a PSA
+ *       crypto client when the PSA crypto implementation is not included in
+ *       the library (MBEDTLS_PSA_CRYPTO_C disabled). The code included is the
+ *       code to set and get PSA key attributes.
+ *       The development of PSA drivers partially relying on the library to
+ *       fulfill the hardware gaps is another possible usage of this option.
+ *
+ * \warning This interface is experimental and may change or be removed
+ * without notice.
+ */
+// #define MBEDTLS_PSA_CRYPTO_CLIENT
+
+/** \def MBEDTLS_PSA_CRYPTO_DRIVERS
+ *
+ * Enable support for the experimental PSA crypto driver interface.
+ *
+ * Requires: MBEDTLS_PSA_CRYPTO_C
+ *
+ * \warning This interface is experimental. We intend to maintain backward
+ *          compatibility with application code that relies on drivers,
+ *          but the driver interfaces may change without notice.
+ */
+// #define MBEDTLS_PSA_CRYPTO_DRIVERS
+
+/** \def MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG
+ *
+ * Make the PSA Crypto module use an external random generator provided
+ * by a driver, instead of Mbed TLS's entropy and DRBG modules.
+ *
+ * \note This random generator must deliver random numbers with cryptographic
+ *       quality and high performance. It must supply unpredictable numbers
+ *       with a uniform distribution. The implementation of this function
+ *       is responsible for ensuring that the random generator is seeded
+ *       with sufficient entropy. If you have a hardware TRNG which is slow
+ *       or delivers non-uniform output, declare it as an entropy source
+ *       with mbedtls_entropy_add_source() instead of enabling this option.
+ *
+ * If you enable this option, you must configure the type
+ * ::mbedtls_psa_external_random_context_t in psa/crypto_platform.h
+ * and define a function called mbedtls_psa_external_get_random()
+ * with the following prototype:
+ * ```
+ * psa_status_t mbedtls_psa_external_get_random(
+ *     mbedtls_psa_external_random_context_t *context,
+ *     uint8_t *output, size_t output_size, size_t *output_length);
+ * );
+ * ```
+ * The \c context value is initialized to 0 before the first call.
+ * The function must fill the \c output buffer with \p output_size bytes
+ * of random data and set \c *output_length to \p output_size.
+ *
+ * Requires: MBEDTLS_PSA_CRYPTO_C
+ *
+ * \warning If you enable this option, code that uses the PSA cryptography
+ *          interface will not use any of the entropy sources set up for
+ *          the entropy module, nor the NV seed that MBEDTLS_ENTROPY_NV_SEED
+ *          enables.
+ *
+ * \note This option is experimental and may be removed without notice.
+ */
+// #define MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG
+
+/**
+ * \def MBEDTLS_PSA_CRYPTO_SPM
+ *
+ * When MBEDTLS_PSA_CRYPTO_SPM is defined, the code is built for SPM (Secure
+ * Partition Manager) integration which separates the code into two parts: a
+ * NSPE (Non-Secure Process Environment) and an SPE (Secure Process
+ * Environment).
+ *
+ * Module:  library/psa_crypto.c
+ * Requires: MBEDTLS_PSA_CRYPTO_C
+ *
+ */
+// #define MBEDTLS_PSA_CRYPTO_SPM
+
+/**
+ * \def MBEDTLS_PSA_INJECT_ENTROPY
+ *
+ * Enable support for entropy injection at first boot. This feature is
+ * required on systems that do not have a built-in entropy source (TRNG).
+ * This feature is currently not supported on systems that have a built-in
+ * entropy source.
+ *
+ * Requires: MBEDTLS_PSA_CRYPTO_STORAGE_C, MBEDTLS_ENTROPY_NV_SEED
+ *
+ */
+// #define MBEDTLS_PSA_INJECT_ENTROPY
+
+/**
+ * \def MBEDTLS_RSA_NO_CRT
+ *
+ * Do not use the Chinese Remainder Theorem
+ * for the RSA private operation.
+ *
+ * Uncomment this macro to disable the use of CRT in RSA.
+ *
+ */
+// #define MBEDTLS_RSA_NO_CRT
+
+/**
+ * \def MBEDTLS_SELF_TEST
+ *
+ * Enable the checkup functions (*_self_test).
+ */
+// #define MBEDTLS_SELF_TEST
+
+/**
+ * \def MBEDTLS_SHA256_SMALLER
+ *
+ * Enable an implementation of SHA-256 that has lower ROM footprint but also
+ * lower performance.
+ *
+ * The default implementation is meant to be a reasonable compromise between
+ * performance and size. This version optimizes more aggressively for size at
+ * the expense of performance. Eg on Cortex-M4 it reduces the size of
+ * mbedtls_sha256_process() from ~2KB to ~0.5KB for a performance hit of about
+ * 30%.
+ *
+ * Uncomment to enable the smaller implementation of SHA256.
+ */
+#define MBEDTLS_SHA256_SMALLER
+
+/**
+ * \def MBEDTLS_SHA512_SMALLER
+ *
+ * Enable an implementation of SHA-512 that has lower ROM footprint but also
+ * lower performance.
+ *
+ * Uncomment to enable the smaller implementation of SHA512.
+ */
+#define MBEDTLS_SHA512_SMALLER
+
+/**
+ * \def MBEDTLS_SSL_ALL_ALERT_MESSAGES
+ *
+ * Enable sending of alert messages in case of encountered errors as per RFC.
+ * If you choose not to send the alert messages, mbed TLS can still communicate
+ * with other servers, only debugging of failures is harder.
+ *
+ * The advantage of not sending alert messages, is that no information is given
+ * about reasons for failures thus preventing adversaries of gaining intel.
+ *
+ * Enable sending of all alert messages
+ */
+#define MBEDTLS_SSL_ALL_ALERT_MESSAGES
+
+/**
+ * \def MBEDTLS_SSL_DTLS_CONNECTION_ID
+ *
+ * Enable support for the DTLS Connection ID (CID) extension,
+ * which allows to identify DTLS connections across changes
+ * in the underlying transport. The CID functionality is described
+ * in RFC 9146.
+ *
+ * Setting this option enables the SSL APIs `mbedtls_ssl_set_cid()`,
+ * mbedtls_ssl_get_own_cid()`, `mbedtls_ssl_get_peer_cid()` and
+ * `mbedtls_ssl_conf_cid()`. See the corresponding documentation for
+ * more information.
+ *
+ * The maximum lengths of outgoing and incoming CIDs can be configured
+ * through the options
+ * - MBEDTLS_SSL_CID_OUT_LEN_MAX
+ * - MBEDTLS_SSL_CID_IN_LEN_MAX.
+ *
+ * Requires: MBEDTLS_SSL_PROTO_DTLS
+ *
+ * Uncomment to enable the Connection ID extension.
+ */
+#define MBEDTLS_SSL_DTLS_CONNECTION_ID
+
+/**
+ * \def MBEDTLS_SSL_DTLS_CONNECTION_ID_COMPAT
+ *
+ * Defines whether RFC 9146 (default) or the legacy version
+ * (version draft-ietf-tls-dtls-connection-id-05,
+ * https://tools.ietf.org/html/draft-ietf-tls-dtls-connection-id-05)
+ * is used.
+ *
+ * Set the value to 0 for the standard version, and
+ * 1 for the legacy draft version.
+ *
+ * \deprecated Support for the legacy version of the DTLS
+ *             Connection ID feature is deprecated. Please
+ *             switch to the standardized version defined
+ *             in RFC 9146 enabled by utilizing
+ *             MBEDTLS_SSL_DTLS_CONNECTION_ID without use
+ *             of MBEDTLS_SSL_DTLS_CONNECTION_ID_COMPAT.
+ *
+ * Requires: MBEDTLS_SSL_DTLS_CONNECTION_ID
+ */
+#define MBEDTLS_SSL_DTLS_CONNECTION_ID_COMPAT  0
+
+/**
+ * \def MBEDTLS_SSL_ASYNC_PRIVATE
+ *
+ * Enable asynchronous external private key operations in SSL. This allows
+ * you to configure an SSL connection to call an external cryptographic
+ * module to perform private key operations instead of performing the
+ * operation inside the library.
+ *
+ */
+// #define MBEDTLS_SSL_ASYNC_PRIVATE
+
+/**
+ * \def MBEDTLS_SSL_CONTEXT_SERIALIZATION
+ *
+ * Enable serialization of the TLS context structures, through use of the
+ * functions mbedtls_ssl_context_save() and mbedtls_ssl_context_load().
+ *
+ * This pair of functions allows one side of a connection to serialize the
+ * context associated with the connection, then free or re-use that context
+ * while the serialized state is persisted elsewhere, and finally deserialize
+ * that state to a live context for resuming read/write operations on the
+ * connection. From a protocol perspective, the state of the connection is
+ * unaffected, in particular this is entirely transparent to the peer.
+ *
+ * Note: this is distinct from TLS session resumption, which is part of the
+ * protocol and fully visible by the peer. TLS session resumption enables
+ * establishing new connections associated to a saved session with shorter,
+ * lighter handshakes, while context serialization is a local optimization in
+ * handling a single, potentially long-lived connection.
+ *
+ * Enabling these APIs makes some SSL structures larger, as 64 extra bytes are
+ * saved after the handshake to allow for more efficient serialization, so if
+ * you don't need this feature you'll save RAM by disabling it.
+ *
+ * Requires: MBEDTLS_GCM_C or MBEDTLS_CCM_C or MBEDTLS_CHACHAPOLY_C
+ *
+ * Comment to disable the context serialization APIs.
+ */
+#define MBEDTLS_SSL_CONTEXT_SERIALIZATION
+
+/**
+ * \def MBEDTLS_SSL_DEBUG_ALL
+ *
+ * Enable the debug messages in SSL module for all issues.
+ * Debug messages have been disabled in some places to prevent timing
+ * attacks due to (unbalanced) debugging function calls.
+ *
+ * If you need all error reporting you should enable this during debugging,
+ * but remove this for production servers that should log as well.
+ *
+ * Uncomment this macro to report all debug messages on errors introducing
+ * a timing side-channel.
+ *
+ */
+// #define MBEDTLS_SSL_DEBUG_ALL
+
+/** \def MBEDTLS_SSL_ENCRYPT_THEN_MAC
+ *
+ * Enable support for Encrypt-then-MAC, RFC 7366.
+ *
+ * This allows peers that both support it to use a more robust protection for
+ * ciphersuites using CBC, providing deep resistance against timing attacks
+ * on the padding or underlying cipher.
+ *
+ * This only affects CBC ciphersuites, and is useless if none is defined.
+ *
+ * Requires: MBEDTLS_SSL_PROTO_TLS1_2
+ *
+ * Comment this macro to disable support for Encrypt-then-MAC
+ */
+#define MBEDTLS_SSL_ENCRYPT_THEN_MAC
+
+/** \def MBEDTLS_SSL_EXTENDED_MASTER_SECRET
+ *
+ * Enable support for RFC 7627: Session Hash and Extended Master Secret
+ * Extension.
+ *
+ * This was introduced as "the proper fix" to the Triple Handshake family of
+ * attacks, but it is recommended to always use it (even if you disable
+ * renegotiation), since it actually fixes a more fundamental issue in the
+ * original SSL/TLS design, and has implications beyond Triple Handshake.
+ *
+ * Requires: MBEDTLS_SSL_PROTO_TLS1_2
+ *
+ * Comment this macro to disable support for Extended Master Secret.
+ */
+#define MBEDTLS_SSL_EXTENDED_MASTER_SECRET
+
+/**
+ * \def MBEDTLS_SSL_KEEP_PEER_CERTIFICATE
+ *
+ * This option controls the availability of the API mbedtls_ssl_get_peer_cert()
+ * giving access to the peer's certificate after completion of the handshake.
+ *
+ * Unless you need mbedtls_ssl_peer_cert() in your application, it is
+ * recommended to disable this option for reduced RAM usage.
+ *
+ * \note If this option is disabled, mbedtls_ssl_get_peer_cert() is still
+ *       defined, but always returns \c NULL.
+ *
+ * \note This option has no influence on the protection against the
+ *       triple handshake attack. Even if it is disabled, Mbed TLS will
+ *       still ensure that certificates do not change during renegotiation,
+ *       for example by keeping a hash of the peer's certificate.
+ *
+ * \note This option is required if MBEDTLS_SSL_PROTO_TLS1_3 is set.
+ *
+ * Comment this macro to disable storing the peer's certificate
+ * after the handshake.
+ */
+#define MBEDTLS_SSL_KEEP_PEER_CERTIFICATE
+
+/**
+ * \def MBEDTLS_SSL_RENEGOTIATION
+ *
+ * Enable support for TLS renegotiation.
+ *
+ * The two main uses of renegotiation are (1) refresh keys on long-lived
+ * connections and (2) client authentication after the initial handshake.
+ * If you don't need renegotiation, it's probably better to disable it, since
+ * it has been associated with security issues in the past and is easy to
+ * misuse/misunderstand.
+ *
+ * Comment this to disable support for renegotiation.
+ *
+ * \note   Even if this option is disabled, both client and server are aware
+ *         of the Renegotiation Indication Extension (RFC 5746) used to
+ *         prevent the SSL renegotiation attack (see RFC 5746 Sect. 1).
+ *         (See \c mbedtls_ssl_conf_legacy_renegotiation for the
+ *          configuration of this extension).
+ *
+ */
+#define MBEDTLS_SSL_RENEGOTIATION
+
+/**
+ * \def MBEDTLS_SSL_MAX_FRAGMENT_LENGTH
+ *
+ * Enable support for RFC 6066 max_fragment_length extension in SSL.
+ *
+ * Comment this macro to disable support for the max_fragment_length extension
+ */
+#define MBEDTLS_SSL_MAX_FRAGMENT_LENGTH
+
+/**
+ * \def MBEDTLS_SSL_PROTO_TLS1_2
+ *
+ * Enable support for TLS 1.2 (and DTLS 1.2 if DTLS is enabled).
+ *
+ * Requires: Without MBEDTLS_USE_PSA_CRYPTO: MBEDTLS_MD_C and
+ *              (MBEDTLS_SHA1_C or MBEDTLS_SHA256_C or MBEDTLS_SHA512_C)
+ *           With MBEDTLS_USE_PSA_CRYPTO:
+ *              PSA_WANT_ALG_SHA_1 or PSA_WANT_ALG_SHA_256 or
+ *              PSA_WANT_ALG_SHA_512
+ *
+ * \warning If building with MBEDTLS_USE_PSA_CRYPTO, you must call
+ * psa_crypto_init() before doing any TLS operations.
+ *
+ * Comment this macro to disable support for TLS 1.2 / DTLS 1.2
+ */
+#define MBEDTLS_SSL_PROTO_TLS1_2
+
+/**
+ * \def MBEDTLS_SSL_PROTO_TLS1_3
+ *
+ * Enable support for TLS 1.3.
+ *
+ * \note The support for TLS 1.3 is not comprehensive yet, in particular
+ *       pre-shared keys are not supported.
+ *       See docs/architecture/tls13-support.md for a description of the TLS
+ *       1.3 support that this option enables.
+ *
+ * Requires: MBEDTLS_SSL_KEEP_PEER_CERTIFICATE
+ * Requires: MBEDTLS_PSA_CRYPTO_C
+ *
+ * Note: even though TLS 1.3 depends on PSA Crypto, and uses it unconditionally
+ * for most operations, if you want it to only use PSA for all crypto
+ * operations, you need to also enable MBEDTLS_USE_PSA_CRYPTO; otherwise X.509
+ * operations, and functions that are common with TLS 1.2 (record protection,
+ * running handshake hash) will still use non-PSA crypto.
+ *
+ * Uncomment this macro to enable the support for TLS 1.3.
+ */
+// #define MBEDTLS_SSL_PROTO_TLS1_3
+
+/**
+ * \def MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
+ *
+ * Enable TLS 1.3 middlebox compatibility mode.
+ *
+ * As specified in Section D.4 of RFC 8446, TLS 1.3 offers a compatibility
+ * mode to make a TLS 1.3 connection more likely to pass through middle boxes
+ * expecting TLS 1.2 traffic.
+ *
+ * Turning on the compatibility mode comes at the cost of a few added bytes
+ * on the wire, but it doesn't affect compatibility with TLS 1.3 implementations
+ * that don't use it. Therefore, unless transmission bandwidth is critical and
+ * you know that middlebox compatibility issues won't occur, it is therefore
+ * recommended to set this option.
+ *
+ * Comment to disable compatibility mode for TLS 1.3. If
+ * MBEDTLS_SSL_PROTO_TLS1_3 is not enabled, this option does not have any
+ * effect on the build.
+ *
+ */
+// #define MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
+
+/**
+ * \def MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_ENABLED
+ *
+ * Enable TLS 1.3 PSK key exchange mode.
+ *
+ * Comment to disable support for the PSK key exchange mode in TLS 1.3. If
+ * MBEDTLS_SSL_PROTO_TLS1_3 is not enabled, this option does not have any
+ * effect on the build.
+ *
+ */
+#define MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_ENABLED
+
+/**
+ * \def MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
+ *
+ * Enable TLS 1.3 ephemeral key exchange mode.
+ *
+ * Requires: MBEDTLS_ECDH_C, MBEDTLS_X509_CRT_PARSE_C, MBEDTLS_ECDSA_C or
+ *           MBEDTLS_PKCS1_V21
+ *
+ * Comment to disable support for the ephemeral key exchange mode in TLS 1.3.
+ * If MBEDTLS_SSL_PROTO_TLS1_3 is not enabled, this option does not have any
+ * effect on the build.
+ *
+ */
+#define MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED
+
+/**
+ * \def MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_EPHEMERAL_ENABLED
+ *
+ * Enable TLS 1.3 PSK ephemeral key exchange mode.
+ *
+ * Requires: MBEDTLS_ECDH_C
+ *
+ * Comment to disable support for the PSK ephemeral key exchange mode in
+ * TLS 1.3. If MBEDTLS_SSL_PROTO_TLS1_3 is not enabled, this option does not
+ * have any effect on the build.
+ *
+ */
+#define MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_EPHEMERAL_ENABLED
+
+/**
+ * \def MBEDTLS_SSL_TLS1_3_TICKET_AGE_TOLERANCE
+ *
+ * Maximum time difference in milliseconds tolerated between the age of a
+ * ticket from the server and client point of view.
+ * From the client point of view, the age of a ticket is the time difference
+ * between the time when the client proposes to the server to use the ticket
+ * (time of writing of the Pre-Shared Key Extension including the ticket) and
+ * the time the client received the ticket from the server.
+ * From the server point of view, the age of a ticket is the time difference
+ * between the time when the server receives a proposition from the client
+ * to use the ticket and the time when the ticket was created by the server.
+ * The server age is expected to be always greater than the client one and
+ * MBEDTLS_SSL_TLS1_3_TICKET_AGE_TOLERANCE defines the
+ * maximum difference tolerated for the server to accept the ticket.
+ * This is not used in TLS 1.2.
+ *
+ */
+#define MBEDTLS_SSL_TLS1_3_TICKET_AGE_TOLERANCE  6000
+
+/**
+ * \def MBEDTLS_SSL_TLS1_3_TICKET_NONCE_LENGTH
+ *
+ * Size in bytes of a ticket nonce. This is not used in TLS 1.2.
+ *
+ * This must be less than 256.
+ */
+#define MBEDTLS_SSL_TLS1_3_TICKET_NONCE_LENGTH  32
+
+/**
+ * \def MBEDTLS_SSL_TLS1_3_DEFAULT_NEW_SESSION_TICKETS
+ *
+ * Default number of NewSessionTicket messages to be sent by a TLS 1.3 server
+ * after handshake completion. This is not used in TLS 1.2 and relevant only if
+ * the MBEDTLS_SSL_SESSION_TICKETS option is enabled.
+ *
+ */
+#define MBEDTLS_SSL_TLS1_3_DEFAULT_NEW_SESSION_TICKETS  1
+
+/**
+* \def MBEDTLS_SSL_EARLY_DATA
+*
+* Enable support for RFC 8446 TLS 1.3 early data.
+*
+* Requires: MBEDTLS_SSL_SESSION_TICKETS and either
+*           MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_ENABLED or
+*           MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_EPHEMERAL_ENABLED
+*
+* Comment this to disable support for early data. If MBEDTLS_SSL_PROTO_TLS1_3
+* is not enabled, this option does not have any effect on the build.
+*
+* This feature is experimental, not completed and thus not ready for
+* production.
+*
+*/
+// #define MBEDTLS_SSL_EARLY_DATA
+
+/**
+ * \def MBEDTLS_SSL_MAX_EARLY_DATA_SIZE
+ *
+ * The default maximum amount of 0-RTT data. See the documentation of
+ * \c mbedtls_ssl_tls13_conf_max_early_data_size() for more information.
+ *
+ * It must be positive and smaller than UINT32_MAX.
+ *
+ * If MBEDTLS_SSL_EARLY_DATA is not defined, this default value does not
+ * have any impact on the build.
+ *
+ * This feature is experimental, not completed and thus not ready for
+ * production.
+ *
+ */
+#define MBEDTLS_SSL_MAX_EARLY_DATA_SIZE  1024
+
+/**
+ * \def MBEDTLS_SSL_PROTO_DTLS
+ *
+ * Enable support for DTLS (all available versions).
+ *
+ * Enable this and MBEDTLS_SSL_PROTO_TLS1_2 to enable DTLS 1.2.
+ *
+ * Requires: MBEDTLS_SSL_PROTO_TLS1_2
+ *
+ * Comment this macro to disable support for DTLS
+ */
+#define MBEDTLS_SSL_PROTO_DTLS
+
+/**
+ * \def MBEDTLS_SSL_ALPN
+ *
+ * Enable support for RFC 7301 Application Layer Protocol Negotiation.
+ *
+ * Comment this macro to disable support for ALPN.
+ */
+#define MBEDTLS_SSL_ALPN
+
+/**
+ * \def MBEDTLS_SSL_DTLS_ANTI_REPLAY
+ *
+ * Enable support for the anti-replay mechanism in DTLS.
+ *
+ * Requires: MBEDTLS_SSL_TLS_C
+ *           MBEDTLS_SSL_PROTO_DTLS
+ *
+ * \warning Disabling this is often a security risk!
+ * See mbedtls_ssl_conf_dtls_anti_replay() for details.
+ *
+ * Comment this to disable anti-replay in DTLS.
+ */
+// #define MBEDTLS_SSL_DTLS_ANTI_REPLAY
+
+/**
+ * \def MBEDTLS_SSL_DTLS_HELLO_VERIFY
+ *
+ * Enable support for HelloVerifyRequest on DTLS servers.
+ *
+ * This feature is highly recommended to prevent DTLS servers being used as
+ * amplifiers in DoS attacks against other hosts. It should always be enabled
+ * unless you know for sure amplification cannot be a problem in the
+ * environment in which your server operates.
+ *
+ * \warning Disabling this can be a security risk! (see above)
+ *
+ * Requires: MBEDTLS_SSL_PROTO_DTLS
+ *
+ * Comment this to disable support for HelloVerifyRequest.
+ */
+// #define MBEDTLS_SSL_DTLS_HELLO_VERIFY
+
+/**
+ * \def MBEDTLS_SSL_DTLS_SRTP
+ *
+ * Enable support for negotiation of DTLS-SRTP (RFC 5764)
+ * through the use_srtp extension.
+ *
+ * \note This feature provides the minimum functionality required
+ * to negotiate the use of DTLS-SRTP and to allow the derivation of
+ * the associated SRTP packet protection key material.
+ * In particular, the SRTP packet protection itself, as well as the
+ * demultiplexing of RTP and DTLS packets at the datagram layer
+ * (see Section 5 of RFC 5764), are not handled by this feature.
+ * Instead, after successful completion of a handshake negotiating
+ * the use of DTLS-SRTP, the extended key exporter API
+ * mbedtls_ssl_conf_export_keys_cb() should be used to implement
+ * the key exporter described in Section 4.2 of RFC 5764 and RFC 5705
+ * (this is implemented in the SSL example programs).
+ * The resulting key should then be passed to an SRTP stack.
+ *
+ * Setting this option enables the runtime API
+ * mbedtls_ssl_conf_dtls_srtp_protection_profiles()
+ * through which the supported DTLS-SRTP protection
+ * profiles can be configured. You must call this API at
+ * runtime if you wish to negotiate the use of DTLS-SRTP.
+ *
+ * Requires: MBEDTLS_SSL_PROTO_DTLS
+ *
+ * Uncomment this to enable support for use_srtp extension.
+ */
+// #define MBEDTLS_SSL_DTLS_SRTP
+
+/**
+ * \def MBEDTLS_SSL_DTLS_CLIENT_PORT_REUSE
+ *
+ * Enable server-side support for clients that reconnect from the same port.
+ *
+ * Some clients unexpectedly close the connection and try to reconnect using the
+ * same source port. This needs special support from the server to handle the
+ * new connection securely, as described in section 4.2.8 of RFC 6347. This
+ * flag enables that support.
+ *
+ * Requires: MBEDTLS_SSL_DTLS_HELLO_VERIFY
+ *
+ * Comment this to disable support for clients reusing the source port.
+ */
+// #define MBEDTLS_SSL_DTLS_CLIENT_PORT_REUSE
+
+/**
+ * \def MBEDTLS_SSL_SESSION_TICKETS
+ *
+ * Enable support for RFC 5077 session tickets in SSL.
+ * Client-side, provides full support for session tickets (maintenance of a
+ * session store remains the responsibility of the application, though).
+ * Server-side, you also need to provide callbacks for writing and parsing
+ * tickets, including authenticated encryption and key management. Example
+ * callbacks are provided by MBEDTLS_SSL_TICKET_C.
+ *
+ * Comment this macro to disable support for SSL session tickets
+ */
+#define MBEDTLS_SSL_SESSION_TICKETS
+
+/**
+ * \def MBEDTLS_SSL_SERVER_NAME_INDICATION
+ *
+ * Enable support for RFC 6066 server name indication (SNI) in SSL.
+ *
+ * Requires: MBEDTLS_X509_CRT_PARSE_C
+ *
+ * Comment this macro to disable support for server name indication in SSL
+ */
+#define MBEDTLS_SSL_SERVER_NAME_INDICATION
+
+/**
+ * \def MBEDTLS_SSL_VARIABLE_BUFFER_LENGTH
+ *
+ * When this option is enabled, the SSL buffer will be resized automatically
+ * based on the negotiated maximum fragment length in each direction.
+ *
+ * Requires: MBEDTLS_SSL_MAX_FRAGMENT_LENGTH
+ */
+// #define MBEDTLS_SSL_VARIABLE_BUFFER_LENGTH
+
+/**
+ * \def MBEDTLS_TEST_CONSTANT_FLOW_MEMSAN
+ *
+ * Enable testing of the constant-flow nature of some sensitive functions with
+ * clang's MemorySanitizer. This causes some existing tests to also test
+ * this non-functional property of the code under test.
+ *
+ * This setting requires compiling with clang -fsanitize=memory. The test
+ * suites can then be run normally.
+ *
+ * \warning This macro is only used for extended testing; it is not considered
+ * part of the library's API, so it may change or disappear at any time.
+ *
+ * Uncomment to enable testing of the constant-flow nature of selected code.
+ */
+// #define MBEDTLS_TEST_CONSTANT_FLOW_MEMSAN
+
+/**
+ * \def MBEDTLS_TEST_CONSTANT_FLOW_VALGRIND
+ *
+ * Enable testing of the constant-flow nature of some sensitive functions with
+ * valgrind's memcheck tool. This causes some existing tests to also test
+ * this non-functional property of the code under test.
+ *
+ * This setting requires valgrind headers for building, and is only useful for
+ * testing if the tests suites are run with valgrind's memcheck. This can be
+ * done for an individual test suite with 'valgrind ./test_suite_xxx', or when
+ * using CMake, this can be done for all test suites with 'make memcheck'.
+ *
+ * \warning This macro is only used for extended testing; it is not considered
+ * part of the library's API, so it may change or disappear at any time.
+ *
+ * Uncomment to enable testing of the constant-flow nature of selected code.
+ */
+// #define MBEDTLS_TEST_CONSTANT_FLOW_VALGRIND
+
+/**
+ * \def MBEDTLS_TEST_HOOKS
+ *
+ * Enable features for invasive testing such as introspection functions and
+ * hooks for fault injection. This enables additional unit tests.
+ *
+ * Merely enabling this feature should not change the behavior of the product.
+ * It only adds new code, and new branching points where the default behavior
+ * is the same as when this feature is disabled.
+ * However, this feature increases the attack surface: there is an added
+ * risk of vulnerabilities, and more gadgets that can make exploits easier.
+ * Therefore this feature must never be enabled in production.
+ *
+ * See `docs/architecture/testing/mbed-crypto-invasive-testing.md` for more
+ * information.
+ *
+ * Uncomment to enable invasive tests.
+ */
+// #define MBEDTLS_TEST_HOOKS
+
+/**
+ * \def MBEDTLS_THREADING_ALT
+ *
+ * Provide your own alternate threading implementation.
+ *
+ * Requires: MBEDTLS_THREADING_C
+ *
+ * Uncomment this to allow your own alternate threading implementation.
+ */
+// #define MBEDTLS_THREADING_ALT
+
+/**
+ * \def MBEDTLS_THREADING_PTHREAD
+ *
+ * Enable the pthread wrapper layer for the threading layer.
+ *
+ * Requires: MBEDTLS_THREADING_C
+ *
+ * Uncomment this to enable pthread mutexes.
+ */
+// #define MBEDTLS_THREADING_PTHREAD
+
+/**
+ * \def MBEDTLS_USE_PSA_CRYPTO
+ *
+ * Make the X.509 and TLS library use PSA for cryptographic operations, and
+ * enable new APIs for using keys handled by PSA Crypto.
+ *
+ * \note Development of this option is currently in progress, and parts of Mbed
+ * TLS's X.509 and TLS modules are not ported to PSA yet. However, these parts
+ * will still continue to work as usual, so enabling this option should not
+ * break backwards compatibility.
+ *
+ * \note See docs/use-psa-crypto.md for a complete description of what this
+ * option currently does, and of parts that are not affected by it so far.
+ *
+ * \warning If you enable this option, you need to call `psa_crypto_init()`
+ * before calling any function from the SSL/TLS, X.509 or PK modules.
+ *
+ * Requires: MBEDTLS_PSA_CRYPTO_C.
+ * Conflicts with: MBEDTLS_ECP_RESTARTABLE
+ *
+ * Uncomment this to enable internal use of PSA Crypto and new associated APIs.
+ */
+// #define MBEDTLS_USE_PSA_CRYPTO
+
+/**
+ * \def MBEDTLS_PSA_CRYPTO_CONFIG
+ *
+ * This setting allows support for cryptographic mechanisms through the PSA
+ * API to be configured separately from support through the mbedtls API.
+ *
+ * When this option is disabled, the PSA API exposes the cryptographic
+ * mechanisms that can be implemented on top of the `mbedtls_xxx` API
+ * configured with `MBEDTLS_XXX` symbols.
+ *
+ * When this option is enabled, the PSA API exposes the cryptographic
+ * mechanisms requested by the `PSA_WANT_XXX` symbols defined in
+ * include/psa/crypto_config.h. The corresponding `MBEDTLS_XXX` settings are
+ * automatically enabled if required (i.e. if no PSA driver provides the
+ * mechanism). You may still freely enable additional `MBEDTLS_XXX` symbols
+ * in mbedtls_config.h.
+ *
+ * If the symbol #MBEDTLS_PSA_CRYPTO_CONFIG_FILE is defined, it specifies
+ * an alternative header to include instead of include/psa/crypto_config.h.
+ *
+ * This feature is still experimental and is not ready for production since
+ * it is not completed.
+ */
+// #define MBEDTLS_PSA_CRYPTO_CONFIG
+
+/**
+ * \def MBEDTLS_VERSION_FEATURES
+ *
+ * Allow run-time checking of compile-time enabled features. Thus allowing users
+ * to check at run-time if the library is for instance compiled with threading
+ * support via mbedtls_version_check_feature().
+ *
+ * Requires: MBEDTLS_VERSION_C
+ *
+ * Comment this to disable run-time checking and save ROM space
+ */
+// #define MBEDTLS_VERSION_FEATURES
+
+/**
+ * \def MBEDTLS_X509_TRUSTED_CERTIFICATE_CALLBACK
+ *
+ * If set, this enables the X.509 API `mbedtls_x509_crt_verify_with_ca_cb()`
+ * and the SSL API `mbedtls_ssl_conf_ca_cb()` which allow users to configure
+ * the set of trusted certificates through a callback instead of a linked
+ * list.
+ *
+ * This is useful for example in environments where a large number of trusted
+ * certificates is present and storing them in a linked list isn't efficient
+ * enough, or when the set of trusted certificates changes frequently.
+ *
+ * See the documentation of `mbedtls_x509_crt_verify_with_ca_cb()` and
+ * `mbedtls_ssl_conf_ca_cb()` for more information.
+ *
+ * Uncomment to enable trusted certificate callbacks.
+ */
+// #define MBEDTLS_X509_TRUSTED_CERTIFICATE_CALLBACK
+
+/**
+ * \def MBEDTLS_X509_REMOVE_INFO
+ *
+ * Disable mbedtls_x509_*_info() and related APIs.
+ *
+ * Uncomment to omit mbedtls_x509_*_info(), as well as mbedtls_debug_print_crt()
+ * and other functions/constants only used by these functions, thus reducing
+ * the code footprint by several KB.
+ */
+// #define MBEDTLS_X509_REMOVE_INFO
+
+/**
+ * \def MBEDTLS_X509_RSASSA_PSS_SUPPORT
+ *
+ * Enable parsing and verification of X.509 certificates, CRLs and CSRS
+ * signed with RSASSA-PSS (aka PKCS#1 v2.1).
+ *
+ * Comment this macro to disallow using RSASSA-PSS in certificates.
+ */
+#define MBEDTLS_X509_RSASSA_PSS_SUPPORT
+/** \} name SECTION: mbed TLS feature support */
+
+/**
+ * \name SECTION: mbed TLS modules
+ *
+ * This section enables or disables entire modules in mbed TLS
+ * \{
+ */
+
+/**
+ * \def MBEDTLS_AESNI_C
+ *
+ * Enable AES-NI support on x86-64.
+ *
+ * Module:  library/aesni.c
+ * Caller:  library/aes.c
+ *
+ * Requires: MBEDTLS_HAVE_ASM
+ *
+ * This modules adds support for the AES-NI instructions on x86-64
+ */
+// #define MBEDTLS_AESNI_C
+
+/**
+ * \def MBEDTLS_AES_C
+ *
+ * Enable the AES block cipher.
+ *
+ * Module:  library/aes.c
+ * Caller:  library/cipher.c
+ *          library/pem.c
+ *          library/ctr_drbg.c
+ *
+ * This module enables the following ciphersuites (if other requisites are
+ * enabled as well):
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_AES_128_CBC_SHA
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_AES_256_CBC_SHA
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA256
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA384
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_AES_256_GCM_SHA384
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+ *      MBEDTLS_TLS_DHE_RSA_WITH_AES_256_GCM_SHA384
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384
+ *      MBEDTLS_TLS_DHE_RSA_WITH_AES_256_CBC_SHA256
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA
+ *      MBEDTLS_TLS_DHE_RSA_WITH_AES_256_CBC_SHA
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+ *      MBEDTLS_TLS_DHE_RSA_WITH_AES_128_GCM_SHA256
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
+ *      MBEDTLS_TLS_DHE_RSA_WITH_AES_128_CBC_SHA256
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA
+ *      MBEDTLS_TLS_DHE_RSA_WITH_AES_128_CBC_SHA
+ *      MBEDTLS_TLS_DHE_PSK_WITH_AES_256_GCM_SHA384
+ *      MBEDTLS_TLS_ECDHE_PSK_WITH_AES_256_CBC_SHA384
+ *      MBEDTLS_TLS_DHE_PSK_WITH_AES_256_CBC_SHA384
+ *      MBEDTLS_TLS_ECDHE_PSK_WITH_AES_256_CBC_SHA
+ *      MBEDTLS_TLS_DHE_PSK_WITH_AES_256_CBC_SHA
+ *      MBEDTLS_TLS_DHE_PSK_WITH_AES_128_GCM_SHA256
+ *      MBEDTLS_TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA256
+ *      MBEDTLS_TLS_DHE_PSK_WITH_AES_128_CBC_SHA256
+ *      MBEDTLS_TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA
+ *      MBEDTLS_TLS_DHE_PSK_WITH_AES_128_CBC_SHA
+ *      MBEDTLS_TLS_RSA_WITH_AES_256_GCM_SHA384
+ *      MBEDTLS_TLS_RSA_WITH_AES_256_CBC_SHA256
+ *      MBEDTLS_TLS_RSA_WITH_AES_256_CBC_SHA
+ *      MBEDTLS_TLS_RSA_WITH_AES_128_GCM_SHA256
+ *      MBEDTLS_TLS_RSA_WITH_AES_128_CBC_SHA256
+ *      MBEDTLS_TLS_RSA_WITH_AES_128_CBC_SHA
+ *      MBEDTLS_TLS_RSA_PSK_WITH_AES_256_GCM_SHA384
+ *      MBEDTLS_TLS_RSA_PSK_WITH_AES_256_CBC_SHA384
+ *      MBEDTLS_TLS_RSA_PSK_WITH_AES_256_CBC_SHA
+ *      MBEDTLS_TLS_RSA_PSK_WITH_AES_128_GCM_SHA256
+ *      MBEDTLS_TLS_RSA_PSK_WITH_AES_128_CBC_SHA256
+ *      MBEDTLS_TLS_RSA_PSK_WITH_AES_128_CBC_SHA
+ *      MBEDTLS_TLS_PSK_WITH_AES_256_GCM_SHA384
+ *      MBEDTLS_TLS_PSK_WITH_AES_256_CBC_SHA384
+ *      MBEDTLS_TLS_PSK_WITH_AES_256_CBC_SHA
+ *      MBEDTLS_TLS_PSK_WITH_AES_128_GCM_SHA256
+ *      MBEDTLS_TLS_PSK_WITH_AES_128_CBC_SHA256
+ *      MBEDTLS_TLS_PSK_WITH_AES_128_CBC_SHA
+ *
+ * PEM_PARSE uses AES for decrypting encrypted keys.
+ */
+#define MBEDTLS_AES_C
+
+/**
+ * \def MBEDTLS_ASN1_PARSE_C
+ *
+ * Enable the generic ASN1 parser.
+ *
+ * Module:  library/asn1.c
+ * Caller:  library/x509.c
+ *          library/dhm.c
+ *          library/pkcs12.c
+ *          library/pkcs5.c
+ *          library/pkparse.c
+ */
+#define MBEDTLS_ASN1_PARSE_C
+
+/**
+ * \def MBEDTLS_ASN1_WRITE_C
+ *
+ * Enable the generic ASN1 writer.
+ *
+ * Module:  library/asn1write.c
+ * Caller:  library/ecdsa.c
+ *          library/pkwrite.c
+ *          library/x509_create.c
+ *          library/x509write_crt.c
+ *          library/x509write_csr.c
+ */
+#define MBEDTLS_ASN1_WRITE_C
+
+/**
+ * \def MBEDTLS_BASE64_C
+ *
+ * Enable the Base64 module.
+ *
+ * Module:  library/base64.c
+ * Caller:  library/pem.c
+ *
+ * This module is required for PEM support (required by X.509).
+ */
+#define MBEDTLS_BASE64_C
+
+/**
+ * \def MBEDTLS_BIGNUM_C
+ *
+ * Enable the multi-precision integer library.
+ *
+ * Module:  library/bignum.c
+ *          library/bignum_core.c
+ *          library/bignum_mod.c
+ *          library/bignum_mod_raw.c
+ * Caller:  library/dhm.c
+ *          library/ecp.c
+ *          library/ecdsa.c
+ *          library/rsa.c
+ *          library/rsa_alt_helpers.c
+ *          library/ssl_tls.c
+ *
+ * This module is required for RSA, DHM and ECC (ECDH, ECDSA) support.
+ */
+#define MBEDTLS_BIGNUM_C
+
+/**
+ * \def MBEDTLS_CAMELLIA_C
+ *
+ * Enable the Camellia block cipher.
+ *
+ * Module:  library/camellia.c
+ * Caller:  library/cipher.c
+ *
+ * This module enables the following ciphersuites (if other requisites are
+ * enabled as well):
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_CAMELLIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_CAMELLIA_256_CBC_SHA384
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_CAMELLIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_CAMELLIA_256_CBC_SHA384
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_CAMELLIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_CAMELLIA_256_GCM_SHA384
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_CAMELLIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_CAMELLIA_256_GCM_SHA384
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_CAMELLIA_256_GCM_SHA384
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_CAMELLIA_256_GCM_SHA384
+ *      MBEDTLS_TLS_DHE_RSA_WITH_CAMELLIA_256_GCM_SHA384
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_CAMELLIA_256_CBC_SHA384
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_CAMELLIA_256_CBC_SHA384
+ *      MBEDTLS_TLS_DHE_RSA_WITH_CAMELLIA_256_CBC_SHA256
+ *      MBEDTLS_TLS_DHE_RSA_WITH_CAMELLIA_256_CBC_SHA
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_CAMELLIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_CAMELLIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_DHE_RSA_WITH_CAMELLIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_CAMELLIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_CAMELLIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_DHE_RSA_WITH_CAMELLIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_DHE_RSA_WITH_CAMELLIA_128_CBC_SHA
+ *      MBEDTLS_TLS_DHE_PSK_WITH_CAMELLIA_256_GCM_SHA384
+ *      MBEDTLS_TLS_ECDHE_PSK_WITH_CAMELLIA_256_CBC_SHA384
+ *      MBEDTLS_TLS_DHE_PSK_WITH_CAMELLIA_256_CBC_SHA384
+ *      MBEDTLS_TLS_DHE_PSK_WITH_CAMELLIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_DHE_PSK_WITH_CAMELLIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_ECDHE_PSK_WITH_CAMELLIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_RSA_WITH_CAMELLIA_256_GCM_SHA384
+ *      MBEDTLS_TLS_RSA_WITH_CAMELLIA_256_CBC_SHA256
+ *      MBEDTLS_TLS_RSA_WITH_CAMELLIA_256_CBC_SHA
+ *      MBEDTLS_TLS_RSA_WITH_CAMELLIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_RSA_WITH_CAMELLIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_RSA_WITH_CAMELLIA_128_CBC_SHA
+ *      MBEDTLS_TLS_RSA_PSK_WITH_CAMELLIA_256_GCM_SHA384
+ *      MBEDTLS_TLS_RSA_PSK_WITH_CAMELLIA_256_CBC_SHA384
+ *      MBEDTLS_TLS_RSA_PSK_WITH_CAMELLIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_RSA_PSK_WITH_CAMELLIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_PSK_WITH_CAMELLIA_256_GCM_SHA384
+ *      MBEDTLS_TLS_PSK_WITH_CAMELLIA_256_CBC_SHA384
+ *      MBEDTLS_TLS_PSK_WITH_CAMELLIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_PSK_WITH_CAMELLIA_128_CBC_SHA256
+ */
+// #define MBEDTLS_CAMELLIA_C
+
+/**
+ * \def MBEDTLS_ARIA_C
+ *
+ * Enable the ARIA block cipher.
+ *
+ * Module:  library/aria.c
+ * Caller:  library/cipher.c
+ *
+ * This module enables the following ciphersuites (if other requisites are
+ * enabled as well):
+ *
+ *      MBEDTLS_TLS_RSA_WITH_ARIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_RSA_WITH_ARIA_256_CBC_SHA384
+ *      MBEDTLS_TLS_DHE_RSA_WITH_ARIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_DHE_RSA_WITH_ARIA_256_CBC_SHA384
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_ARIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_ARIA_256_CBC_SHA384
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_ARIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_ARIA_256_CBC_SHA384
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_ARIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_ARIA_256_CBC_SHA384
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_ARIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_ARIA_256_CBC_SHA384
+ *      MBEDTLS_TLS_RSA_WITH_ARIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_RSA_WITH_ARIA_256_GCM_SHA384
+ *      MBEDTLS_TLS_DHE_RSA_WITH_ARIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_DHE_RSA_WITH_ARIA_256_GCM_SHA384
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_ARIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_ARIA_256_GCM_SHA384
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_ARIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_ECDH_ECDSA_WITH_ARIA_256_GCM_SHA384
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_ARIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_ECDHE_RSA_WITH_ARIA_256_GCM_SHA384
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_ARIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_ECDH_RSA_WITH_ARIA_256_GCM_SHA384
+ *      MBEDTLS_TLS_PSK_WITH_ARIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_PSK_WITH_ARIA_256_CBC_SHA384
+ *      MBEDTLS_TLS_DHE_PSK_WITH_ARIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_DHE_PSK_WITH_ARIA_256_CBC_SHA384
+ *      MBEDTLS_TLS_RSA_PSK_WITH_ARIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_RSA_PSK_WITH_ARIA_256_CBC_SHA384
+ *      MBEDTLS_TLS_PSK_WITH_ARIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_PSK_WITH_ARIA_256_GCM_SHA384
+ *      MBEDTLS_TLS_DHE_PSK_WITH_ARIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_DHE_PSK_WITH_ARIA_256_GCM_SHA384
+ *      MBEDTLS_TLS_RSA_PSK_WITH_ARIA_128_GCM_SHA256
+ *      MBEDTLS_TLS_RSA_PSK_WITH_ARIA_256_GCM_SHA384
+ *      MBEDTLS_TLS_ECDHE_PSK_WITH_ARIA_128_CBC_SHA256
+ *      MBEDTLS_TLS_ECDHE_PSK_WITH_ARIA_256_CBC_SHA384
+ */
+// #define MBEDTLS_ARIA_C
+
+/**
+ * \def MBEDTLS_CCM_C
+ *
+ * Enable the Counter with CBC-MAC (CCM) mode for 128-bit block cipher.
+ *
+ * Module:  library/ccm.c
+ *
+ * Requires: MBEDTLS_CIPHER_C, MBEDTLS_AES_C or MBEDTLS_CAMELLIA_C or
+ *                             MBEDTLS_ARIA_C
+ *
+ * This module enables the AES-CCM ciphersuites, if other requisites are
+ * enabled as well.
+ */
+// #define MBEDTLS_CCM_C
+
+/**
+ * \def MBEDTLS_CHACHA20_C
+ *
+ * Enable the ChaCha20 stream cipher.
+ *
+ * Module:  library/chacha20.c
+ */
+#define MBEDTLS_CHACHA20_C
+
+/**
+ * \def MBEDTLS_CHACHAPOLY_C
+ *
+ * Enable the ChaCha20-Poly1305 AEAD algorithm.
+ *
+ * Module:  library/chachapoly.c
+ *
+ * This module requires: MBEDTLS_CHACHA20_C, MBEDTLS_POLY1305_C
+ */
+#define MBEDTLS_CHACHAPOLY_C
+
+/**
+ * \def MBEDTLS_CIPHER_C
+ *
+ * Enable the generic cipher layer.
+ *
+ * Module:  library/cipher.c
+ * Caller:  library/ccm.c
+ *          library/cmac.c
+ *          library/gcm.c
+ *          library/nist_kw.c
+ *          library/pkcs12.c
+ *          library/pkcs5.c
+ *          library/psa_crypto_aead.c
+ *          library/psa_crypto_mac.c
+ *          library/ssl_ciphersuites.c
+ *          library/ssl_msg.c
+ *          library/ssl_ticket.c (unless MBEDTLS_USE_PSA_CRYPTO is enabled)
+ *
+ * Uncomment to enable generic cipher wrappers.
+ */
+#define MBEDTLS_CIPHER_C
+
+/**
+ * \def MBEDTLS_CMAC_C
+ *
+ * Enable the CMAC (Cipher-based Message Authentication Code) mode for block
+ * ciphers.
+ *
+ * \note When #MBEDTLS_CMAC_ALT is active, meaning that the underlying
+ *       implementation of the CMAC algorithm is provided by an alternate
+ *       implementation, that alternate implementation may opt to not support
+ *       AES-192 or 3DES as underlying block ciphers for the CMAC operation.
+ *
+ * Module:  library/cmac.c
+ *
+ * Requires: MBEDTLS_CIPHER_C, MBEDTLS_AES_C or MBEDTLS_DES_C
+ *
+ */
+// #define MBEDTLS_CMAC_C
+
+/**
+ * \def MBEDTLS_CTR_DRBG_C
+ *
+ * Enable the CTR_DRBG AES-based random generator.
+ * The CTR_DRBG generator uses AES-256 by default.
+ * To use AES-128 instead, enable \c MBEDTLS_CTR_DRBG_USE_128_BIT_KEY above.
+ *
+ * \note To achieve a 256-bit security strength with CTR_DRBG,
+ *       you must use AES-256 *and* use sufficient entropy.
+ *       See ctr_drbg.h for more details.
+ *
+ * Module:  library/ctr_drbg.c
+ * Caller:
+ *
+ * Requires: MBEDTLS_AES_C
+ *
+ * This module provides the CTR_DRBG AES random number generator.
+ */
+#define MBEDTLS_CTR_DRBG_C
+
+/**
+ * \def MBEDTLS_DEBUG_C
+ *
+ * Enable the debug functions.
+ *
+ * Module:  library/debug.c
+ * Caller:  library/ssl_msg.c
+ *          library/ssl_tls.c
+ *          library/ssl_tls12_*.c
+ *          library/ssl_tls13_*.c
+ *
+ * This module provides debugging functions.
+ */
+// #define MBEDTLS_DEBUG_C
+
+/**
+ * \def MBEDTLS_DES_C
+ *
+ * Enable the DES block cipher.
+ *
+ * Module:  library/des.c
+ * Caller:  library/pem.c
+ *          library/cipher.c
+ *
+ * PEM_PARSE uses DES/3DES for decrypting encrypted keys.
+ *
+ * \warning   DES is considered a weak cipher and its use constitutes a
+ *            security risk. We recommend considering stronger ciphers instead.
+ */
+// #define MBEDTLS_DES_C
+
+/**
+ * \def MBEDTLS_DHM_C
+ *
+ * Enable the Diffie-Hellman-Merkle module.
+ *
+ * Module:  library/dhm.c
+ * Caller:  library/ssl_tls.c
+ *          library/ssl*_client.c
+ *          library/ssl*_server.c
+ *
+ * This module is used by the following key exchanges:
+ *      DHE-RSA, DHE-PSK
+ *
+ * \warning    Using DHE constitutes a security risk as it
+ *             is not possible to validate custom DH parameters.
+ *             If possible, it is recommended users should consider
+ *             preferring other methods of key exchange.
+ *             See dhm.h for more details.
+ *
+ */
+#define MBEDTLS_DHM_C
+
+/**
+ * \def MBEDTLS_ECDH_C
+ *
+ * Enable the elliptic curve Diffie-Hellman library.
+ *
+ * Module:  library/ecdh.c
+ * Caller:  library/psa_crypto.c
+ *          library/ssl_tls.c
+ *          library/ssl*_client.c
+ *          library/ssl*_server.c
+ *
+ * This module is used by the following key exchanges:
+ *      ECDHE-ECDSA, ECDHE-RSA, DHE-PSK
+ *
+ * Requires: MBEDTLS_ECP_C
+ */
+#define MBEDTLS_ECDH_C
+
+/**
+ * \def MBEDTLS_ECDSA_C
+ *
+ * Enable the elliptic curve DSA library.
+ *
+ * Module:  library/ecdsa.c
+ * Caller:
+ *
+ * This module is used by the following key exchanges:
+ *      ECDHE-ECDSA
+ *
+ * Requires: MBEDTLS_ECP_C, MBEDTLS_ASN1_WRITE_C, MBEDTLS_ASN1_PARSE_C,
+ *           and at least one MBEDTLS_ECP_DP_XXX_ENABLED for a
+ *           short Weierstrass curve.
+ */
+#define MBEDTLS_ECDSA_C
+
+/**
+ * \def MBEDTLS_ECJPAKE_C
+ *
+ * Enable the elliptic curve J-PAKE library.
+ *
+ * \note EC J-PAKE support is based on the Thread v1.0.0 specification.
+ *       It has not been reviewed for compliance with newer standards such as
+ *       Thread v1.1 or RFC 8236.
+ *
+ * Module:  library/ecjpake.c
+ * Caller:
+ *
+ * This module is used by the following key exchanges:
+ *      ECJPAKE
+ *
+ * Requires: MBEDTLS_ECP_C and either MBEDTLS_MD_C or MBEDTLS_PSA_CRYPTO_C
+ *
+ * \warning If building without MBEDTLS_MD_C, you must call psa_crypto_init()
+ * before doing any EC J-PAKE operations.
+ *
+ * \warning When building with MBEDTLS_MD_C, all hashes used with this
+ * need to be available as built-ins (that is, for SHA-256, MBEDTLS_SHA256_C,
+ * etc.) as opposed to just PSA drivers. So far, PSA drivers are only used by
+ * this module in builds where MBEDTLS_MD_C is disabled.
+ */
+// #define MBEDTLS_ECJPAKE_C
+
+/**
+ * \def MBEDTLS_ECP_C
+ *
+ * Enable the elliptic curve over GF(p) library.
+ *
+ * Module:  library/ecp.c
+ * Caller:  library/ecdh.c
+ *          library/ecdsa.c
+ *          library/ecjpake.c
+ *
+ * Requires: MBEDTLS_BIGNUM_C and at least one MBEDTLS_ECP_DP_XXX_ENABLED
+ */
+#define MBEDTLS_ECP_C
+
+/**
+ * \def MBEDTLS_ENTROPY_C
+ *
+ * Enable the platform-specific entropy code.
+ *
+ * Module:  library/entropy.c
+ * Caller:
+ *
+ * Requires: MBEDTLS_SHA512_C or MBEDTLS_SHA256_C
+ *
+ * This module provides a generic entropy pool
+ */
+#define MBEDTLS_ENTROPY_C
+
+/**
+ * \def MBEDTLS_ERROR_C
+ *
+ * Enable error code to error string conversion.
+ *
+ * Module:  library/error.c
+ * Caller:
+ *
+ * This module enables mbedtls_strerror().
+ */
+#define MBEDTLS_ERROR_C
+
+/**
+ * \def MBEDTLS_GCM_C
+ *
+ * Enable the Galois/Counter Mode (GCM).
+ *
+ * Module:  library/gcm.c
+ *
+ * Requires: MBEDTLS_CIPHER_C, MBEDTLS_AES_C or MBEDTLS_CAMELLIA_C or
+ *                             MBEDTLS_ARIA_C
+ *
+ * This module enables the AES-GCM and CAMELLIA-GCM ciphersuites, if other
+ * requisites are enabled as well.
+ */
+#define MBEDTLS_GCM_C
+
+/**
+ * \def MBEDTLS_HKDF_C
+ *
+ * Enable the HKDF algorithm (RFC 5869).
+ *
+ * Module:  library/hkdf.c
+ * Caller:
+ *
+ * Requires: MBEDTLS_MD_C
+ *
+ * This module adds support for the Hashed Message Authentication Code
+ * (HMAC)-based key derivation function (HKDF).
+ */
+#define MBEDTLS_HKDF_C
+
+/**
+ * \def MBEDTLS_HMAC_DRBG_C
+ *
+ * Enable the HMAC_DRBG random generator.
+ *
+ * Module:  library/hmac_drbg.c
+ * Caller:
+ *
+ * Requires: MBEDTLS_MD_C
+ *
+ * Uncomment to enable the HMAC_DRBG random number generator.
+ */
+#define MBEDTLS_HMAC_DRBG_C
+
+/**
+ * \def MBEDTLS_LMS_C
+ *
+ * Enable the LMS stateful-hash asymmetric signature algorithm.
+ *
+ * Module:  library/lms.c
+ * Caller:
+ *
+ * Requires: MBEDTLS_PSA_CRYPTO_C
+ *
+ * Uncomment to enable the LMS verification algorithm and public key operations.
+ */
+// #define MBEDTLS_LMS_C
+
+/**
+ * \def MBEDTLS_LMS_PRIVATE
+ *
+ * Enable LMS private-key operations and signing code. Functions enabled by this
+ * option are experimental, and should not be used in production.
+ *
+ * Requires: MBEDTLS_LMS_C
+ *
+ * Uncomment to enable the LMS signature algorithm and private key operations.
+ */
+// #define MBEDTLS_LMS_PRIVATE
+
+/**
+ * \def MBEDTLS_NIST_KW_C
+ *
+ * Enable the Key Wrapping mode for 128-bit block ciphers,
+ * as defined in NIST SP 800-38F. Only KW and KWP modes
+ * are supported. At the moment, only AES is approved by NIST.
+ *
+ * Module:  library/nist_kw.c
+ *
+ * Requires: MBEDTLS_AES_C and MBEDTLS_CIPHER_C
+ */
+// #define MBEDTLS_NIST_KW_C
+
+/**
+ * \def MBEDTLS_MD_C
+ *
+ * Enable the generic message digest layer.
+ *
+ * Requires: one of: MBEDTLS_MD5_C, MBEDTLS_RIPEMD160_C, MBEDTLS_SHA1_C,
+ *                   MBEDTLS_SHA224_C, MBEDTLS_SHA256_C, MBEDTLS_SHA384_C,
+ *                   MBEDTLS_SHA512_C.
+ * Module:  library/md.c
+ * Caller:  library/constant_time.c
+ *          library/ecdsa.c
+ *          library/ecjpake.c
+ *          library/hkdf.c
+ *          library/hmac_drbg.c
+ *          library/pk.c
+ *          library/pkcs5.c
+ *          library/pkcs12.c
+ *          library/psa_crypto_ecp.c
+ *          library/psa_crypto_rsa.c
+ *          library/rsa.c
+ *          library/ssl_cookie.c
+ *          library/ssl_msg.c
+ *          library/ssl_tls.c
+ *          library/x509.c
+ *          library/x509_crt.c
+ *          library/x509write_crt.c
+ *          library/x509write_csr.c
+ *
+ * Uncomment to enable generic message digest wrappers.
+ */
+#define MBEDTLS_MD_C
+
+/**
+ * \def MBEDTLS_MD5_C
+ *
+ * Enable the MD5 hash algorithm.
+ *
+ * Module:  library/md5.c
+ * Caller:  library/md.c
+ *          library/pem.c
+ *          library/ssl_tls.c
+ *
+ * This module is required for TLS 1.2 depending on the handshake parameters.
+ * Further, it is used for checking MD5-signed certificates, and for PBKDF1
+ * when decrypting PEM-encoded encrypted keys.
+ *
+ * \warning   MD5 is considered a weak message digest and its use constitutes a
+ *            security risk. If possible, we recommend avoiding dependencies on
+ *            it, and considering stronger message digests instead.
+ *
+ */
+#define MBEDTLS_MD5_C
+
+/**
+ * \def MBEDTLS_MEMORY_BUFFER_ALLOC_C
+ *
+ * Enable the buffer allocator implementation that makes use of a (stack)
+ * based buffer to 'allocate' dynamic memory. (replaces calloc() and free()
+ * calls)
+ *
+ * Module:  library/memory_buffer_alloc.c
+ *
+ * Requires: MBEDTLS_PLATFORM_C
+ *           MBEDTLS_PLATFORM_MEMORY (to use it within mbed TLS)
+ *
+ * Enable this module to enable the buffer memory allocator.
+ */
+// #define MBEDTLS_MEMORY_BUFFER_ALLOC_C
+
+/**
+ * \def MBEDTLS_NET_C
+ *
+ * Enable the TCP and UDP over IPv6/IPv4 networking routines.
+ *
+ * \note This module only works on POSIX/Unix (including Linux, BSD and OS X)
+ * and Windows. For other platforms, you'll want to disable it, and write your
+ * own networking callbacks to be passed to \c mbedtls_ssl_set_bio().
+ *
+ * \note See also our Knowledge Base article about porting to a new
+ * environment:
+ * https://mbed-tls.readthedocs.io/en/latest/kb/how-to/how-do-i-port-mbed-tls-to-a-new-environment-OS
+ *
+ * Module:  library/net_sockets.c
+ *
+ * This module provides networking routines.
+ */
+#define MBEDTLS_NET_C
+
+/**
+ * \def MBEDTLS_OID_C
+ *
+ * Enable the OID database.
+ *
+ * Module:  library/oid.c
+ * Caller:  library/asn1write.c
+ *          library/pkcs5.c
+ *          library/pkparse.c
+ *          library/pkwrite.c
+ *          library/rsa.c
+ *          library/x509.c
+ *          library/x509_create.c
+ *          library/x509_crl.c
+ *          library/x509_crt.c
+ *          library/x509_csr.c
+ *          library/x509write_crt.c
+ *          library/x509write_csr.c
+ *
+ * This modules translates between OIDs and internal values.
+ */
+#define MBEDTLS_OID_C
+
+/**
+ * \def MBEDTLS_PADLOCK_C
+ *
+ * Enable VIA Padlock support on x86.
+ *
+ * Module:  library/padlock.c
+ * Caller:  library/aes.c
+ *
+ * Requires: MBEDTLS_HAVE_ASM
+ *
+ * This modules adds support for the VIA PadLock on x86.
+ */
+// #define MBEDTLS_PADLOCK_C
+
+/**
+ * \def MBEDTLS_PEM_PARSE_C
+ *
+ * Enable PEM decoding / parsing.
+ *
+ * Module:  library/pem.c
+ * Caller:  library/dhm.c
+ *          library/pkparse.c
+ *          library/x509_crl.c
+ *          library/x509_crt.c
+ *          library/x509_csr.c
+ *
+ * Requires: MBEDTLS_BASE64_C
+ *
+ * This modules adds support for decoding / parsing PEM files.
+ */
+#define MBEDTLS_PEM_PARSE_C
+
+/**
+ * \def MBEDTLS_PEM_WRITE_C
+ *
+ * Enable PEM encoding / writing.
+ *
+ * Module:  library/pem.c
+ * Caller:  library/pkwrite.c
+ *          library/x509write_crt.c
+ *          library/x509write_csr.c
+ *
+ * Requires: MBEDTLS_BASE64_C
+ *
+ * This modules adds support for encoding / writing PEM files.
+ */
+#define MBEDTLS_PEM_WRITE_C
+
+/**
+ * \def MBEDTLS_PK_C
+ *
+ * Enable the generic public (asymmetric) key layer.
+ *
+ * Module:  library/pk.c
+ * Caller:  library/psa_crypto_rsa.c
+ *          library/ssl_tls.c
+ *          library/ssl*_client.c
+ *          library/ssl*_server.c
+ *          library/x509.c
+ *
+ * Requires: MBEDTLS_MD_C, MBEDTLS_RSA_C or MBEDTLS_ECP_C
+ *
+ * Uncomment to enable generic public key wrappers.
+ */
+#define MBEDTLS_PK_C
+
+/**
+ * \def MBEDTLS_PK_PARSE_C
+ *
+ * Enable the generic public (asymmetric) key parser.
+ *
+ * Module:  library/pkparse.c
+ * Caller:  library/x509_crt.c
+ *          library/x509_csr.c
+ *
+ * Requires: MBEDTLS_PK_C
+ *
+ * Uncomment to enable generic public key parse functions.
+ */
+#define MBEDTLS_PK_PARSE_C
+
+/**
+ * \def MBEDTLS_PK_WRITE_C
+ *
+ * Enable the generic public (asymmetric) key writer.
+ *
+ * Module:  library/pkwrite.c
+ * Caller:  library/x509write.c
+ *
+ * Requires: MBEDTLS_PK_C
+ *
+ * Uncomment to enable generic public key write functions.
+ */
+#define MBEDTLS_PK_WRITE_C
+
+/**
+ * \def MBEDTLS_PKCS5_C
+ *
+ * Enable PKCS#5 functions.
+ *
+ * Module:  library/pkcs5.c
+ *
+ * Requires: MBEDTLS_CIPHER_C and either MBEDTLS_MD_C or MBEDTLS_PSA_CRYPTO_C.
+ *
+ * \warning If building without MBEDTLS_MD_C, you must call psa_crypto_init()
+ * before doing any PKCS5 operation.
+ *
+ * \warning When building with MBEDTLS_MD_C, all hashes used with this
+ * need to be available as built-ins (that is, for SHA-256, MBEDTLS_SHA256_C,
+ * etc.) as opposed to just PSA drivers. So far, PSA drivers are only used by
+ * this module in builds where MBEDTLS_MD_C is disabled.
+ *
+ * This module adds support for the PKCS#5 functions.
+ */
+#define MBEDTLS_PKCS5_C
+
+/**
+ * \def MBEDTLS_PKCS7_C
+ *
+ * This feature is a work in progress and not ready for production. Testing and
+ * validation is incomplete, and handling of malformed inputs may not be robust.
+ * The API may change.
+ *
+ * Enable PKCS7 core for using PKCS7 formatted signatures.
+ * RFC Link - https://tools.ietf.org/html/rfc2315
+ *
+ * Module:  library/pkcs7.c
+ *
+ * Requires: MBEDTLS_ASN1_PARSE_C, MBEDTLS_OID_C, MBEDTLS_PK_PARSE_C,
+ *           MBEDTLS_X509_CRT_PARSE_C MBEDTLS_X509_CRL_PARSE_C,
+ *           MBEDTLS_BIGNUM_C, MBEDTLS_MD_C
+ *
+ * This module is required for the PKCS7 parsing modules.
+ */
+#define MBEDTLS_PKCS7_C
+
+/**
+ * \def MBEDTLS_PKCS12_C
+ *
+ * Enable PKCS#12 PBE functions.
+ * Adds algorithms for parsing PKCS#8 encrypted private keys
+ *
+ * Module:  library/pkcs12.c
+ * Caller:  library/pkparse.c
+ *
+ * Requires: MBEDTLS_ASN1_PARSE_C, MBEDTLS_CIPHER_C and either
+ * MBEDTLS_MD_C or MBEDTLS_PSA_CRYPTO_C.
+ *
+ * \warning If building without MBEDTLS_MD_C, you must call psa_crypto_init()
+ * before doing any PKCS12 operation.
+ *
+ * \warning When building with MBEDTLS_MD_C, all hashes used with this
+ * need to be available as built-ins (that is, for SHA-256, MBEDTLS_SHA256_C,
+ * etc.) as opposed to just PSA drivers. So far, PSA drivers are only used by
+ * this module in builds where MBEDTLS_MD_C is disabled.
+ *
+ * This module enables PKCS#12 functions.
+ */
+// #define MBEDTLS_PKCS12_C
+
+/**
+ * \def MBEDTLS_PLATFORM_C
+ *
+ * Enable the platform abstraction layer that allows you to re-assign
+ * functions like calloc(), free(), snprintf(), printf(), fprintf(), exit().
+ *
+ * Enabling MBEDTLS_PLATFORM_C enables to use of MBEDTLS_PLATFORM_XXX_ALT
+ * or MBEDTLS_PLATFORM_XXX_MACRO directives, allowing the functions mentioned
+ * above to be specified at runtime or compile time respectively.
+ *
+ * \note This abstraction layer must be enabled on Windows (including MSYS2)
+ * as other modules rely on it for a fixed snprintf implementation.
+ *
+ * Module:  library/platform.c
+ * Caller:  Most other .c files
+ *
+ * This module enables abstraction of common (libc) functions.
+ */
+#define MBEDTLS_PLATFORM_C
+
+/**
+ * \def MBEDTLS_POLY1305_C
+ *
+ * Enable the Poly1305 MAC algorithm.
+ *
+ * Module:  library/poly1305.c
+ * Caller:  library/chachapoly.c
+ */
+#define MBEDTLS_POLY1305_C
+
+/**
+ * \def MBEDTLS_PSA_CRYPTO_C
+ *
+ * Enable the Platform Security Architecture cryptography API.
+ *
+ * Module:  library/psa_crypto.c
+ *
+ * Requires: MBEDTLS_CIPHER_C,
+ *           either MBEDTLS_CTR_DRBG_C and MBEDTLS_ENTROPY_C,
+ *           or MBEDTLS_HMAC_DRBG_C and MBEDTLS_ENTROPY_C,
+ *           or MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG.
+ *
+ */
+// #define MBEDTLS_PSA_CRYPTO_C
+
+/**
+ * \def MBEDTLS_PSA_CRYPTO_SE_C
+ *
+ * Enable dynamic secure element support in the Platform Security Architecture
+ * cryptography API.
+ *
+ * \deprecated This feature is deprecated. Please switch to the driver
+ *             interface enabled by #MBEDTLS_PSA_CRYPTO_DRIVERS.
+ *
+ * Module:  library/psa_crypto_se.c
+ *
+ * Requires: MBEDTLS_PSA_CRYPTO_C, MBEDTLS_PSA_CRYPTO_STORAGE_C
+ *
+ */
+// #define MBEDTLS_PSA_CRYPTO_SE_C
+
+/**
+ * \def MBEDTLS_PSA_CRYPTO_STORAGE_C
+ *
+ * Enable the Platform Security Architecture persistent key storage.
+ *
+ * Module:  library/psa_crypto_storage.c
+ *
+ * Requires: MBEDTLS_PSA_CRYPTO_C,
+ *           either MBEDTLS_PSA_ITS_FILE_C or a native implementation of
+ *           the PSA ITS interface
+ */
+// #define MBEDTLS_PSA_CRYPTO_STORAGE_C
+
+/**
+ * \def MBEDTLS_PSA_ITS_FILE_C
+ *
+ * Enable the emulation of the Platform Security Architecture
+ * Internal Trusted Storage (PSA ITS) over files.
+ *
+ * Module:  library/psa_its_file.c
+ *
+ * Requires: MBEDTLS_FS_IO
+ */
+// #define MBEDTLS_PSA_ITS_FILE_C
+
+/**
+ * \def MBEDTLS_RIPEMD160_C
+ *
+ * Enable the RIPEMD-160 hash algorithm.
+ *
+ * Module:  library/ripemd160.c
+ * Caller:  library/md.c
+ *
+ */
+// #define MBEDTLS_RIPEMD160_C
+
+/**
+ * \def MBEDTLS_RSA_C
+ *
+ * Enable the RSA public-key cryptosystem.
+ *
+ * Module:  library/rsa.c
+ *          library/rsa_alt_helpers.c
+ * Caller:  library/pk.c
+ *          library/psa_crypto.c
+ *          library/ssl_tls.c
+ *          library/ssl*_client.c
+ *          library/ssl*_server.c
+ *
+ * This module is used by the following key exchanges:
+ *      RSA, DHE-RSA, ECDHE-RSA, RSA-PSK
+ *
+ * Requires: MBEDTLS_BIGNUM_C, MBEDTLS_OID_C
+ */
+#define MBEDTLS_RSA_C
+
+/**
+ * \def MBEDTLS_SHA1_C
+ *
+ * Enable the SHA1 cryptographic hash algorithm.
+ *
+ * Module:  library/sha1.c
+ * Caller:  library/md.c
+ *          library/psa_crypto_hash.c
+ *
+ * This module is required for TLS 1.2 depending on the handshake parameters,
+ * and for SHA1-signed certificates.
+ *
+ * \warning   SHA-1 is considered a weak message digest and its use constitutes
+ *            a security risk. If possible, we recommend avoiding dependencies
+ *            on it, and considering stronger message digests instead.
+ *
+ */
+#define MBEDTLS_SHA1_C
+
+/**
+ * \def MBEDTLS_SHA224_C
+ *
+ * Enable the SHA-224 cryptographic hash algorithm.
+ *
+ * Requires: MBEDTLS_SHA256_C. The library does not currently support enabling
+ *           SHA-224 without SHA-256.
+ *
+ * Module:  library/sha256.c
+ * Caller:  library/md.c
+ *          library/ssl_cookie.c
+ *
+ * This module adds support for SHA-224.
+ */
+#define MBEDTLS_SHA224_C
+
+/**
+ * \def MBEDTLS_SHA256_C
+ *
+ * Enable the SHA-256 cryptographic hash algorithm.
+ *
+ * Requires: MBEDTLS_SHA224_C. The library does not currently support enabling
+ *           SHA-256 without SHA-224.
+ *
+ * Module:  library/sha256.c
+ * Caller:  library/entropy.c
+ *          library/md.c
+ *          library/ssl_tls.c
+ *          library/ssl*_client.c
+ *          library/ssl*_server.c
+ *
+ * This module adds support for SHA-256.
+ * This module is required for the SSL/TLS 1.2 PRF function.
+ */
+#define MBEDTLS_SHA256_C
+
+/**
+ * \def MBEDTLS_SHA256_USE_A64_CRYPTO_IF_PRESENT
+ *
+ * Enable acceleration of the SHA-256 and SHA-224 cryptographic hash algorithms
+ * with the ARMv8 cryptographic extensions if they are available at runtime.
+ * If not, the library will fall back to the C implementation.
+ *
+ * \note If MBEDTLS_SHA256_USE_A64_CRYPTO_IF_PRESENT is defined when building
+ * for a non-Aarch64 build it will be silently ignored.
+ *
+ * \note The code uses Neon intrinsics, so \c CFLAGS must be set to a minimum
+ * of \c -march=armv8-a+crypto.
+ *
+ * \warning MBEDTLS_SHA256_USE_A64_CRYPTO_IF_PRESENT cannot be defined at the
+ * same time as MBEDTLS_SHA256_USE_A64_CRYPTO_ONLY.
+ *
+ * Requires: MBEDTLS_SHA256_C.
+ *
+ * Module:  library/sha256.c
+ *
+ * Uncomment to have the library check for the A64 SHA-256 crypto extensions
+ * and use them if available.
+ */
+// #define MBEDTLS_SHA256_USE_A64_CRYPTO_IF_PRESENT
+
+/**
+ * \def MBEDTLS_SHA256_USE_A64_CRYPTO_ONLY
+ *
+ * Enable acceleration of the SHA-256 and SHA-224 cryptographic hash algorithms
+ * with the ARMv8 cryptographic extensions, which must be available at runtime
+ * or else an illegal instruction fault will occur.
+ *
+ * \note This allows builds with a smaller code size than with
+ * MBEDTLS_SHA256_USE_A64_CRYPTO_IF_PRESENT
+ *
+ * \note The code uses Neon intrinsics, so \c CFLAGS must be set to a minimum
+ * of \c -march=armv8-a+crypto.
+ *
+ * \warning MBEDTLS_SHA256_USE_A64_CRYPTO_ONLY cannot be defined at the same
+ * time as MBEDTLS_SHA256_USE_A64_CRYPTO_IF_PRESENT.
+ *
+ * Requires: MBEDTLS_SHA256_C.
+ *
+ * Module:  library/sha256.c
+ *
+ * Uncomment to have the library use the A64 SHA-256 crypto extensions
+ * unconditionally.
+ */
+// #define MBEDTLS_SHA256_USE_A64_CRYPTO_ONLY
+
+/**
+ * \def MBEDTLS_SHA384_C
+ *
+ * Enable the SHA-384 cryptographic hash algorithm.
+ *
+ * Requires: MBEDTLS_SHA512_C
+ *
+ * Module:  library/sha512.c
+ * Caller:  library/md.c
+ *          library/psa_crypto_hash.c
+ *          library/ssl_tls.c
+ *          library/ssl*_client.c
+ *          library/ssl*_server.c
+ *
+ * Comment to disable SHA-384
+ */
+#define MBEDTLS_SHA384_C
+
+/**
+ * \def MBEDTLS_SHA512_C
+ *
+ * Enable SHA-512 cryptographic hash algorithms.
+ *
+ * Module:  library/sha512.c
+ * Caller:  library/entropy.c
+ *          library/md.c
+ *          library/ssl_tls.c
+ *          library/ssl_cookie.c
+ *
+ * This module adds support for SHA-512.
+ */
+#define MBEDTLS_SHA512_C
+
+/**
+ * \def MBEDTLS_SHA512_USE_A64_CRYPTO_IF_PRESENT
+ *
+ * Enable acceleration of the SHA-512 and SHA-384 cryptographic hash algorithms
+ * with the ARMv8 cryptographic extensions if they are available at runtime.
+ * If not, the library will fall back to the C implementation.
+ *
+ * \note If MBEDTLS_SHA512_USE_A64_CRYPTO_IF_PRESENT is defined when building
+ * for a non-Aarch64 build it will be silently ignored.
+ *
+ * \note The code uses the SHA-512 Neon intrinsics, so requires GCC >= 8 or
+ * Clang >= 7, and \c CFLAGS must be set to a minimum of
+ * \c -march=armv8.2-a+sha3. An optimisation level of \c -O3 generates the
+ * fastest code.
+ *
+ * \warning MBEDTLS_SHA512_USE_A64_CRYPTO_IF_PRESENT cannot be defined at the
+ * same time as MBEDTLS_SHA512_USE_A64_CRYPTO_ONLY.
+ *
+ * Requires: MBEDTLS_SHA512_C.
+ *
+ * Module:  library/sha512.c
+ *
+ * Uncomment to have the library check for the A64 SHA-512 crypto extensions
+ * and use them if available.
+ */
+// #define MBEDTLS_SHA512_USE_A64_CRYPTO_IF_PRESENT
+
+/**
+ * \def MBEDTLS_SHA512_USE_A64_CRYPTO_ONLY
+ *
+ * Enable acceleration of the SHA-512 and SHA-384 cryptographic hash algorithms
+ * with the ARMv8 cryptographic extensions, which must be available at runtime
+ * or else an illegal instruction fault will occur.
+ *
+ * \note This allows builds with a smaller code size than with
+ * MBEDTLS_SHA512_USE_A64_CRYPTO_IF_PRESENT
+ *
+ * \note The code uses the SHA-512 Neon intrinsics, so requires GCC >= 8 or
+ * Clang >= 7, and \c CFLAGS must be set to a minimum of
+ * \c -march=armv8.2-a+sha3. An optimisation level of \c -O3 generates the
+ * fastest code.
+ *
+ * \warning MBEDTLS_SHA512_USE_A64_CRYPTO_ONLY cannot be defined at the same
+ * time as MBEDTLS_SHA512_USE_A64_CRYPTO_IF_PRESENT.
+ *
+ * Requires: MBEDTLS_SHA512_C.
+ *
+ * Module:  library/sha512.c
+ *
+ * Uncomment to have the library use the A64 SHA-512 crypto extensions
+ * unconditionally.
+ */
+// #define MBEDTLS_SHA512_USE_A64_CRYPTO_ONLY
+
+/**
+ * \def MBEDTLS_SSL_CACHE_C
+ *
+ * Enable simple SSL cache implementation.
+ *
+ * Module:  library/ssl_cache.c
+ * Caller:
+ *
+ * Requires: MBEDTLS_SSL_CACHE_C
+ */
+#define MBEDTLS_SSL_CACHE_C
+
+/**
+ * \def MBEDTLS_SSL_COOKIE_C
+ *
+ * Enable basic implementation of DTLS cookies for hello verification.
+ *
+ * Module:  library/ssl_cookie.c
+ * Caller:
+ */
+#define MBEDTLS_SSL_COOKIE_C
+
+/**
+ * \def MBEDTLS_SSL_TICKET_C
+ *
+ * Enable an implementation of TLS server-side callbacks for session tickets.
+ *
+ * Module:  library/ssl_ticket.c
+ * Caller:
+ *
+ * Requires: (MBEDTLS_CIPHER_C || MBEDTLS_USE_PSA_CRYPTO) &&
+ *           (MBEDTLS_GCM_C || MBEDTLS_CCM_C || MBEDTLS_CHACHAPOLY_C)
+ */
+#define MBEDTLS_SSL_TICKET_C
+
+/**
+ * \def MBEDTLS_SSL_CLI_C
+ *
+ * Enable the SSL/TLS client code.
+ *
+ * Module:  library/ssl*_client.c
+ * Caller:
+ *
+ * Requires: MBEDTLS_SSL_TLS_C
+ *
+ * This module is required for SSL/TLS client support.
+ */
+#define MBEDTLS_SSL_CLI_C
+
+/**
+ * \def MBEDTLS_SSL_SRV_C
+ *
+ * Enable the SSL/TLS server code.
+ *
+ * Module:  library/ssl*_server.c
+ * Caller:
+ *
+ * Requires: MBEDTLS_SSL_TLS_C
+ *
+ * This module is required for SSL/TLS server support.
+ */
+#define MBEDTLS_SSL_SRV_C
+
+/**
+ * \def MBEDTLS_SSL_TLS_C
+ *
+ * Enable the generic SSL/TLS code.
+ *
+ * Module:  library/ssl_tls.c
+ * Caller:  library/ssl*_client.c
+ *          library/ssl*_server.c
+ *
+ * Requires: MBEDTLS_CIPHER_C, MBEDTLS_MD_C
+ *           and at least one of the MBEDTLS_SSL_PROTO_XXX defines
+ *
+ * This module is required for SSL/TLS.
+ */
+#define MBEDTLS_SSL_TLS_C
+
+/**
+ * \def MBEDTLS_THREADING_C
+ *
+ * Enable the threading abstraction layer.
+ * By default mbed TLS assumes it is used in a non-threaded environment or that
+ * contexts are not shared between threads. If you do intend to use contexts
+ * between threads, you will need to enable this layer to prevent race
+ * conditions. See also our Knowledge Base article about threading:
+ * https://mbed-tls.readthedocs.io/en/latest/kb/development/thread-safety-and-multi-threading
+ *
+ * Module:  library/threading.c
+ *
+ * This allows different threading implementations (self-implemented or
+ * provided).
+ *
+ * You will have to enable either MBEDTLS_THREADING_ALT or
+ * MBEDTLS_THREADING_PTHREAD.
+ *
+ * Enable this layer to allow use of mutexes within mbed TLS
+ */
+// #define MBEDTLS_THREADING_C
+
+/**
+ * \def MBEDTLS_TIMING_C
+ *
+ * Enable the semi-portable timing interface.
+ *
+ * \note The provided implementation only works on POSIX/Unix (including Linux,
+ * BSD and OS X) and Windows. On other platforms, you can either disable that
+ * module and provide your own implementations of the callbacks needed by
+ * \c mbedtls_ssl_set_timer_cb() for DTLS, or leave it enabled and provide
+ * your own implementation of the whole module by setting
+ * \c MBEDTLS_TIMING_ALT in the current file.
+ *
+ * \note The timing module will include time.h on suitable platforms
+ *       regardless of the setting of MBEDTLS_HAVE_TIME, unless
+ *       MBEDTLS_TIMING_ALT is used. See timing.c for more information.
+ *
+ * \note See also our Knowledge Base article about porting to a new
+ * environment:
+ * https://mbed-tls.readthedocs.io/en/latest/kb/how-to/how-do-i-port-mbed-tls-to-a-new-environment-OS
+ *
+ * Module:  library/timing.c
+ */
+// #define MBEDTLS_TIMING_C
+
+/**
+ * \def MBEDTLS_VERSION_C
+ *
+ * Enable run-time version information.
+ *
+ * Module:  library/version.c
+ *
+ * This module provides run-time version information.
+ */
+#define MBEDTLS_VERSION_C
+
+/**
+ * \def MBEDTLS_X509_USE_C
+ *
+ * Enable X.509 core for using certificates.
+ *
+ * Module:  library/x509.c
+ * Caller:  library/x509_crl.c
+ *          library/x509_crt.c
+ *          library/x509_csr.c
+ *
+ * Requires: MBEDTLS_ASN1_PARSE_C, MBEDTLS_BIGNUM_C, MBEDTLS_OID_C, MBEDTLS_PK_PARSE_C,
+ *           (MBEDTLS_MD_C or MBEDTLS_USE_PSA_CRYPTO)
+ *
+ * \warning If building with MBEDTLS_USE_PSA_CRYPTO, you must call
+ * psa_crypto_init() before doing any X.509 operation.
+ *
+ * This module is required for the X.509 parsing modules.
+ */
+#define MBEDTLS_X509_USE_C
+
+/**
+ * \def MBEDTLS_X509_CRT_PARSE_C
+ *
+ * Enable X.509 certificate parsing.
+ *
+ * Module:  library/x509_crt.c
+ * Caller:  library/ssl_tls.c
+ *          library/ssl*_client.c
+ *          library/ssl*_server.c
+ *
+ * Requires: MBEDTLS_X509_USE_C
+ *
+ * This module is required for X.509 certificate parsing.
+ */
+#define MBEDTLS_X509_CRT_PARSE_C
+
+/**
+ * \def MBEDTLS_X509_CRL_PARSE_C
+ *
+ * Enable X.509 CRL parsing.
+ *
+ * Module:  library/x509_crl.c
+ * Caller:  library/x509_crt.c
+ *
+ * Requires: MBEDTLS_X509_USE_C
+ *
+ * This module is required for X.509 CRL parsing.
+ */
+#define MBEDTLS_X509_CRL_PARSE_C
+
+/**
+ * \def MBEDTLS_X509_CSR_PARSE_C
+ *
+ * Enable X.509 Certificate Signing Request (CSR) parsing.
+ *
+ * Module:  library/x509_csr.c
+ * Caller:  library/x509_crt_write.c
+ *
+ * Requires: MBEDTLS_X509_USE_C
+ *
+ * This module is used for reading X.509 certificate request.
+ */
+#define MBEDTLS_X509_CSR_PARSE_C
+
+/**
+ * \def MBEDTLS_X509_CREATE_C
+ *
+ * Enable X.509 core for creating certificates.
+ *
+ * Module:  library/x509_create.c
+ *
+ * Requires: MBEDTLS_BIGNUM_C, MBEDTLS_OID_C, MBEDTLS_PK_PARSE_C,
+ *           (MBEDTLS_MD_C or MBEDTLS_USE_PSA_CRYPTO)
+ *
+ * \warning If building with MBEDTLS_USE_PSA_CRYPTO, you must call
+ * psa_crypto_init() before doing any X.509 create operation.
+ *
+ * This module is the basis for creating X.509 certificates and CSRs.
+ */
+#define MBEDTLS_X509_CREATE_C
+
+/**
+ * \def MBEDTLS_X509_CRT_WRITE_C
+ *
+ * Enable creating X.509 certificates.
+ *
+ * Module:  library/x509_crt_write.c
+ *
+ * Requires: MBEDTLS_X509_CREATE_C
+ *
+ * This module is required for X.509 certificate creation.
+ */
+#define MBEDTLS_X509_CRT_WRITE_C
+
+/**
+ * \def MBEDTLS_X509_CSR_WRITE_C
+ *
+ * Enable creating X.509 Certificate Signing Requests (CSR).
+ *
+ * Module:  library/x509_csr_write.c
+ *
+ * Requires: MBEDTLS_X509_CREATE_C
+ *
+ * This module is required for X.509 certificate request writing.
+ */
+#define MBEDTLS_X509_CSR_WRITE_C
+
+/** \} name SECTION: mbed TLS modules */
+
+/**
+ * \name SECTION: General configuration options
+ *
+ * This section contains Mbed TLS build settings that are not associated
+ * with a particular module.
+ *
+ * \{
+ */
+
+/**
+ * \def MBEDTLS_CONFIG_FILE
+ *
+ * If defined, this is a header which will be included instead of
+ * `"mbedtls/mbedtls_config.h"`.
+ * This header file specifies the compile-time configuration of Mbed TLS.
+ * Unlike other configuration options, this one must be defined on the
+ * compiler command line: a definition in `mbedtls_config.h` would have
+ * no effect.
+ *
+ * This macro is expanded after an <tt>\#include</tt> directive. This is a popular but
+ * non-standard feature of the C language, so this feature is only available
+ * with compilers that perform macro expansion on an <tt>\#include</tt> line.
+ *
+ * The value of this symbol is typically a path in double quotes, either
+ * absolute or relative to a directory on the include search path.
+ */
+// #define MBEDTLS_CONFIG_FILE "mbedtls/mbedtls_config.h"
+
+/**
+ * \def MBEDTLS_USER_CONFIG_FILE
+ *
+ * If defined, this is a header which will be included after
+ * `"mbedtls/mbedtls_config.h"` or #MBEDTLS_CONFIG_FILE.
+ * This allows you to modify the default configuration, including the ability
+ * to undefine options that are enabled by default.
+ *
+ * This macro is expanded after an <tt>\#include</tt> directive. This is a popular but
+ * non-standard feature of the C language, so this feature is only available
+ * with compilers that perform macro expansion on an <tt>\#include</tt> line.
+ *
+ * The value of this symbol is typically a path in double quotes, either
+ * absolute or relative to a directory on the include search path.
+ */
+// #define MBEDTLS_USER_CONFIG_FILE "/dev/null"
+
+/**
+ * \def MBEDTLS_PSA_CRYPTO_CONFIG_FILE
+ *
+ * If defined, this is a header which will be included instead of
+ * `"psa/crypto_config.h"`.
+ * This header file specifies which cryptographic mechanisms are available
+ * through the PSA API when #MBEDTLS_PSA_CRYPTO_CONFIG is enabled, and
+ * is not used when #MBEDTLS_PSA_CRYPTO_CONFIG is disabled.
+ *
+ * This macro is expanded after an <tt>\#include</tt> directive. This is a popular but
+ * non-standard feature of the C language, so this feature is only available
+ * with compilers that perform macro expansion on an <tt>\#include</tt> line.
+ *
+ * The value of this symbol is typically a path in double quotes, either
+ * absolute or relative to a directory on the include search path.
+ */
+// #define MBEDTLS_PSA_CRYPTO_CONFIG_FILE "psa/crypto_config.h"
+
+/**
+ * \def MBEDTLS_PSA_CRYPTO_USER_CONFIG_FILE
+ *
+ * If defined, this is a header which will be included after
+ * `"psa/crypto_config.h"` or #MBEDTLS_PSA_CRYPTO_CONFIG_FILE.
+ * This allows you to modify the default configuration, including the ability
+ * to undefine options that are enabled by default.
+ *
+ * This macro is expanded after an <tt>\#include</tt> directive. This is a popular but
+ * non-standard feature of the C language, so this feature is only available
+ * with compilers that perform macro expansion on an <tt>\#include</tt> line.
+ *
+ * The value of this symbol is typically a path in double quotes, either
+ * absolute or relative to a directory on the include search path.
+ */
+// #define MBEDTLS_PSA_CRYPTO_USER_CONFIG_FILE "/dev/null"
+
+/** \} name SECTION: General configuration options */
+
+/**
+ * \name SECTION: Module configuration options
+ *
+ * This section allows for the setting of module specific sizes and
+ * configuration options. The default values are already present in the
+ * relevant header files and should suffice for the regular use cases.
+ *
+ * Our advice is to enable options and change their values here
+ * only if you have a good reason and know the consequences.
+ * \{
+ */
+/* The Doxygen documentation here is used when a user comments out a
+ * setting and runs doxygen themselves. On the other hand, when we typeset
+ * the full documentation including disabled settings, the documentation
+ * in specific modules' header files is used if present. When editing this
+ * file, make sure that each option is documented in exactly one place,
+ * plus optionally a same-line Doxygen comment here if there is a Doxygen
+ * comment in the specific module. */
+
+/* MPI / BIGNUM options */
+// #define MBEDTLS_MPI_WINDOW_SIZE            6 /**< Maximum window size used. */
+// #define MBEDTLS_MPI_MAX_SIZE            1024 /**< Maximum number of bytes for usable MPIs. */
+
+/* CTR_DRBG options */
+// #define MBEDTLS_CTR_DRBG_ENTROPY_LEN               48 /**< Amount of entropy used per seed by default (48 with SHA-512, 32 with SHA-256) */
+// #define MBEDTLS_CTR_DRBG_RESEED_INTERVAL        10000 /**< Interval before reseed is performed by default */
+// #define MBEDTLS_CTR_DRBG_MAX_INPUT                256 /**< Maximum number of additional input bytes */
+// #define MBEDTLS_CTR_DRBG_MAX_REQUEST             1024 /**< Maximum number of requested bytes per call */
+// #define MBEDTLS_CTR_DRBG_MAX_SEED_INPUT           384 /**< Maximum size of (re)seed buffer */
+
+/* HMAC_DRBG options */
+// #define MBEDTLS_HMAC_DRBG_RESEED_INTERVAL   10000 /**< Interval before reseed is performed by default */
+// #define MBEDTLS_HMAC_DRBG_MAX_INPUT           256 /**< Maximum number of additional input bytes */
+// #define MBEDTLS_HMAC_DRBG_MAX_REQUEST        1024 /**< Maximum number of requested bytes per call */
+// #define MBEDTLS_HMAC_DRBG_MAX_SEED_INPUT      384 /**< Maximum size of (re)seed buffer */
+
+/* ECP options */
+// #define MBEDTLS_ECP_WINDOW_SIZE            4 /**< Maximum window size used */
+// #define MBEDTLS_ECP_FIXED_POINT_OPTIM      1 /**< Enable fixed-point speed-up */
+
+/* Entropy options */
+// #define MBEDTLS_ENTROPY_MAX_SOURCES                20 /**< Maximum number of sources supported */
+// #define MBEDTLS_ENTROPY_MAX_GATHER                128 /**< Maximum amount requested from entropy sources */
+// #define MBEDTLS_ENTROPY_MIN_HARDWARE               32 /**< Default minimum number of bytes required for the hardware entropy source mbedtls_hardware_poll() before entropy is released */
+
+/* Memory buffer allocator options */
+// #define MBEDTLS_MEMORY_ALIGN_MULTIPLE      4 /**< Align on multiples of this value */
+
+/* Platform options */
+// #define MBEDTLS_PLATFORM_STD_MEM_HDR   <stdlib.h> /**< Header to include if MBEDTLS_PLATFORM_NO_STD_FUNCTIONS is defined. Don't define if no header is needed. */
+// #define MBEDTLS_PLATFORM_STD_CALLOC        calloc /**< Default allocator to use, can be undefined */
+// #define MBEDTLS_PLATFORM_STD_FREE            free /**< Default free to use, can be undefined */
+// #define MBEDTLS_PLATFORM_STD_SETBUF      setbuf /**< Default setbuf to use, can be undefined */
+// #define MBEDTLS_PLATFORM_STD_EXIT            exit /**< Default exit to use, can be undefined */
+// #define MBEDTLS_PLATFORM_STD_TIME            time /**< Default time to use, can be undefined. MBEDTLS_HAVE_TIME must be enabled */
+// #define MBEDTLS_PLATFORM_STD_FPRINTF      fprintf /**< Default fprintf to use, can be undefined */
+// #define MBEDTLS_PLATFORM_STD_PRINTF        printf /**< Default printf to use, can be undefined */
+/* Note: your snprintf must correctly zero-terminate the buffer! */
+// #define MBEDTLS_PLATFORM_STD_SNPRINTF    snprintf /**< Default snprintf to use, can be undefined */
+// #define MBEDTLS_PLATFORM_STD_EXIT_SUCCESS       0 /**< Default exit value to use, can be undefined */
+// #define MBEDTLS_PLATFORM_STD_EXIT_FAILURE       1 /**< Default exit value to use, can be undefined */
+// #define MBEDTLS_PLATFORM_STD_NV_SEED_READ   mbedtls_platform_std_nv_seed_read /**< Default nv_seed_read function to use, can be undefined */
+// #define MBEDTLS_PLATFORM_STD_NV_SEED_WRITE  mbedtls_platform_std_nv_seed_write /**< Default nv_seed_write function to use, can be undefined */
+// #define MBEDTLS_PLATFORM_STD_NV_SEED_FILE  "seedfile" /**< Seed file to read/write with default implementation */
+
+/* To Use Function Macros MBEDTLS_PLATFORM_C must be enabled */
+/* MBEDTLS_PLATFORM_XXX_MACRO and MBEDTLS_PLATFORM_XXX_ALT cannot both be defined */
+// #define MBEDTLS_PLATFORM_CALLOC_MACRO        calloc /**< Default allocator macro to use, can be undefined */
+// #define MBEDTLS_PLATFORM_FREE_MACRO            free /**< Default free macro to use, can be undefined */
+// #define MBEDTLS_PLATFORM_EXIT_MACRO            exit /**< Default exit macro to use, can be undefined */
+// #define MBEDTLS_PLATFORM_SETBUF_MACRO      setbuf /**< Default setbuf macro to use, can be undefined */
+// #define MBEDTLS_PLATFORM_TIME_MACRO            time /**< Default time macro to use, can be undefined. MBEDTLS_HAVE_TIME must be enabled */
+// #define MBEDTLS_PLATFORM_TIME_TYPE_MACRO       time_t /**< Default time macro to use, can be undefined. MBEDTLS_HAVE_TIME must be enabled */
+// #define MBEDTLS_PLATFORM_FPRINTF_MACRO      fprintf /**< Default fprintf macro to use, can be undefined */
+// #define MBEDTLS_PLATFORM_PRINTF_MACRO        printf /**< Default printf macro to use, can be undefined */
+/* Note: your snprintf must correctly zero-terminate the buffer! */
+// #define MBEDTLS_PLATFORM_SNPRINTF_MACRO    snprintf /**< Default snprintf macro to use, can be undefined */
+// #define MBEDTLS_PLATFORM_VSNPRINTF_MACRO    vsnprintf /**< Default vsnprintf macro to use, can be undefined */
+// #define MBEDTLS_PLATFORM_NV_SEED_READ_MACRO   mbedtls_platform_std_nv_seed_read /**< Default nv_seed_read function to use, can be undefined */
+// #define MBEDTLS_PLATFORM_NV_SEED_WRITE_MACRO  mbedtls_platform_std_nv_seed_write /**< Default nv_seed_write function to use, can be undefined */
+
+extern int
+my_printf (
+  const char  *fmt,
+  ...
+  );
+
+#define MBEDTLS_PLATFORM_PRINTF_MACRO  my_printf
+
+extern int
+my_snprintf (
+  char        *str,
+  long long   size,
+  const char  *format,
+  ...
+  );
+
+#define MBEDTLS_PLATFORM_SNPRINTF_MACRO  my_snprintf
+
+#define MBEDTLS_PLATFORM_MEMORY
+#include <stddef.h>
+extern void *
+mbedtls_calloc (
+  size_t  n,
+  size_t  size
+  );
+
+extern void
+mbedtls_free (
+  void  *ptr
+  );
+
+#define MBEDTLS_PLATFORM_CALLOC_MACRO  mbedtls_calloc
+#define MBEDTLS_PLATFORM_FREE_MACRO    mbedtls_free
+
+/** \def MBEDTLS_CHECK_RETURN
+ *
+ * This macro is used at the beginning of the declaration of a function
+ * to indicate that its return value should be checked. It should
+ * instruct the compiler to emit a warning or an error if the function
+ * is called without checking its return value.
+ *
+ * There is a default implementation for popular compilers in platform_util.h.
+ * You can override the default implementation by defining your own here.
+ *
+ * If the implementation here is empty, this will effectively disable the
+ * checking of functions' return values.
+ */
+// #define MBEDTLS_CHECK_RETURN __attribute__((__warn_unused_result__))
+
+/** \def MBEDTLS_IGNORE_RETURN
+ *
+ * This macro requires one argument, which should be a C function call.
+ * If that function call would cause a #MBEDTLS_CHECK_RETURN warning, this
+ * warning is suppressed.
+ */
+// #define MBEDTLS_IGNORE_RETURN( result ) ((void) !(result))
+
+/* PSA options */
+
+/**
+ * Use HMAC_DRBG with the specified hash algorithm for HMAC_DRBG for the
+ * PSA crypto subsystem.
+ *
+ * If this option is unset:
+ * - If CTR_DRBG is available, the PSA subsystem uses it rather than HMAC_DRBG.
+ * - Otherwise, the PSA subsystem uses HMAC_DRBG with either
+ *   #MBEDTLS_MD_SHA512 or #MBEDTLS_MD_SHA256 based on availability and
+ *   on unspecified heuristics.
+ */
+// #define MBEDTLS_PSA_HMAC_DRBG_MD_TYPE MBEDTLS_MD_SHA256
+
+/** \def MBEDTLS_PSA_KEY_SLOT_COUNT
+ * Restrict the PSA library to supporting a maximum amount of simultaneously
+ * loaded keys. A loaded key is a key stored by the PSA Crypto core as a
+ * volatile key, or a persistent key which is loaded temporarily by the
+ * library as part of a crypto operation in flight.
+ *
+ * If this option is unset, the library will fall back to a default value of
+ * 32 keys.
+ */
+// #define MBEDTLS_PSA_KEY_SLOT_COUNT 32
+
+/* SSL Cache options */
+// #define MBEDTLS_SSL_CACHE_DEFAULT_TIMEOUT       86400 /**< 1 day  */
+// #define MBEDTLS_SSL_CACHE_DEFAULT_MAX_ENTRIES      50 /**< Maximum entries in cache */
+
+/* SSL options */
+
+/** \def MBEDTLS_SSL_IN_CONTENT_LEN
+ *
+ * Maximum length (in bytes) of incoming plaintext fragments.
+ *
+ * This determines the size of the incoming TLS I/O buffer in such a way
+ * that it is capable of holding the specified amount of plaintext data,
+ * regardless of the protection mechanism used.
+ *
+ * \note When using a value less than the default of 16KB on the client, it is
+ *       recommended to use the Maximum Fragment Length (MFL) extension to
+ *       inform the server about this limitation. On the server, there
+ *       is no supported, standardized way of informing the client about
+ *       restriction on the maximum size of incoming messages, and unless
+ *       the limitation has been communicated by other means, it is recommended
+ *       to only change the outgoing buffer size #MBEDTLS_SSL_OUT_CONTENT_LEN
+ *       while keeping the default value of 16KB for the incoming buffer.
+ *
+ * Uncomment to set the maximum plaintext size of the incoming I/O buffer.
+ */
+// #define MBEDTLS_SSL_IN_CONTENT_LEN              16384
+
+/** \def MBEDTLS_SSL_CID_IN_LEN_MAX
+ *
+ * The maximum length of CIDs used for incoming DTLS messages.
+ *
+ */
+// #define MBEDTLS_SSL_CID_IN_LEN_MAX 32
+
+/** \def MBEDTLS_SSL_CID_OUT_LEN_MAX
+ *
+ * The maximum length of CIDs used for outgoing DTLS messages.
+ *
+ */
+// #define MBEDTLS_SSL_CID_OUT_LEN_MAX 32
+
+/** \def MBEDTLS_SSL_CID_TLS1_3_PADDING_GRANULARITY
+ *
+ * This option controls the use of record plaintext padding
+ * in TLS 1.3 and when using the Connection ID extension in DTLS 1.2.
+ *
+ * The padding will always be chosen so that the length of the
+ * padded plaintext is a multiple of the value of this option.
+ *
+ * Note: A value of \c 1 means that no padding will be used
+ *       for outgoing records.
+ *
+ * Note: On systems lacking division instructions,
+ *       a power of two should be preferred.
+ */
+// #define MBEDTLS_SSL_CID_TLS1_3_PADDING_GRANULARITY 16
+
+/** \def MBEDTLS_SSL_OUT_CONTENT_LEN
+ *
+ * Maximum length (in bytes) of outgoing plaintext fragments.
+ *
+ * This determines the size of the outgoing TLS I/O buffer in such a way
+ * that it is capable of holding the specified amount of plaintext data,
+ * regardless of the protection mechanism used.
+ *
+ * It is possible to save RAM by setting a smaller outward buffer, while keeping
+ * the default inward 16384 byte buffer to conform to the TLS specification.
+ *
+ * The minimum required outward buffer size is determined by the handshake
+ * protocol's usage. Handshaking will fail if the outward buffer is too small.
+ * The specific size requirement depends on the configured ciphers and any
+ * certificate data which is sent during the handshake.
+ *
+ * Uncomment to set the maximum plaintext size of the outgoing I/O buffer.
+ */
+// #define MBEDTLS_SSL_OUT_CONTENT_LEN             16384
+
+/** \def MBEDTLS_SSL_DTLS_MAX_BUFFERING
+ *
+ * Maximum number of heap-allocated bytes for the purpose of
+ * DTLS handshake message reassembly and future message buffering.
+ *
+ * This should be at least 9/8 * MBEDTLS_SSL_IN_CONTENT_LEN
+ * to account for a reassembled handshake message of maximum size,
+ * together with its reassembly bitmap.
+ *
+ * A value of 2 * MBEDTLS_SSL_IN_CONTENT_LEN (32768 by default)
+ * should be sufficient for all practical situations as it allows
+ * to reassembly a large handshake message (such as a certificate)
+ * while buffering multiple smaller handshake messages.
+ *
+ */
+// #define MBEDTLS_SSL_DTLS_MAX_BUFFERING             32768
+
+// #define MBEDTLS_PSK_MAX_LEN               32 /**< Max size of TLS pre-shared keys, in bytes (default 256 bits) */
+// #define MBEDTLS_SSL_COOKIE_TIMEOUT        60 /**< Default expiration delay of DTLS cookies, in seconds if HAVE_TIME, or in number of cookies issued */
+
+/**
+ * Complete list of ciphersuites to use, in order of preference.
+ *
+ * \warning No dependency checking is done on that field! This option can only
+ * be used to restrict the set of available ciphersuites. It is your
+ * responsibility to make sure the needed modules are active.
+ *
+ * Use this to save a few hundred bytes of ROM (default ordering of all
+ * available ciphersuites) and a few to a few hundred bytes of RAM.
+ *
+ * The value below is only an example, not the default.
+ */
+// #define MBEDTLS_SSL_CIPHERSUITES MBEDTLS_TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,MBEDTLS_TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+
+/* X509 options */
+// #define MBEDTLS_X509_MAX_INTERMEDIATE_CA   8   /**< Maximum number of intermediate CAs in a verification chain. */
+// #define MBEDTLS_X509_MAX_FILE_PATH_LEN     512 /**< Maximum length of a path/filename string in bytes including the null terminator character ('\0'). */
+
+/**
+ * Uncomment the macro to let mbed TLS use your alternate implementation of
+ * mbedtls_platform_zeroize(). This replaces the default implementation in
+ * platform_util.c.
+ *
+ * mbedtls_platform_zeroize() is a widely used function across the library to
+ * zero a block of memory. The implementation is expected to be secure in the
+ * sense that it has been written to prevent the compiler from removing calls
+ * to mbedtls_platform_zeroize() as part of redundant code elimination
+ * optimizations. However, it is difficult to guarantee that calls to
+ * mbedtls_platform_zeroize() will not be optimized by the compiler as older
+ * versions of the C language standards do not provide a secure implementation
+ * of memset(). Therefore, MBEDTLS_PLATFORM_ZEROIZE_ALT enables users to
+ * configure their own implementation of mbedtls_platform_zeroize(), for
+ * example by using directives specific to their compiler, features from newer
+ * C standards (e.g using memset_s() in C11) or calling a secure memset() from
+ * their system (e.g explicit_bzero() in BSD).
+ */
+// #define MBEDTLS_PLATFORM_ZEROIZE_ALT
+
+/**
+ * Uncomment the macro to let Mbed TLS use your alternate implementation of
+ * mbedtls_platform_gmtime_r(). This replaces the default implementation in
+ * platform_util.c.
+ *
+ * gmtime() is not a thread-safe function as defined in the C standard. The
+ * library will try to use safer implementations of this function, such as
+ * gmtime_r() when available. However, if Mbed TLS cannot identify the target
+ * system, the implementation of mbedtls_platform_gmtime_r() will default to
+ * using the standard gmtime(). In this case, calls from the library to
+ * gmtime() will be guarded by the global mutex mbedtls_threading_gmtime_mutex
+ * if MBEDTLS_THREADING_C is enabled. We recommend that calls from outside the
+ * library are also guarded with this mutex to avoid race conditions. However,
+ * if the macro MBEDTLS_PLATFORM_GMTIME_R_ALT is defined, Mbed TLS will
+ * unconditionally use the implementation for mbedtls_platform_gmtime_r()
+ * supplied at compile time.
+ */
+// #define MBEDTLS_PLATFORM_GMTIME_R_ALT
+
+/**
+ * Enable the verified implementations of ECDH primitives from Project Everest
+ * (currently only Curve25519). This feature changes the layout of ECDH
+ * contexts and therefore is a compatibility break for applications that access
+ * fields of a mbedtls_ecdh_context structure directly. See also
+ * MBEDTLS_ECDH_LEGACY_CONTEXT in include/mbedtls/ecdh.h.
+ */
+// #define MBEDTLS_ECDH_VARIANT_EVEREST_ENABLED
+
+/** \} name SECTION: Module configuration options */
+
+#define MBEDTLS_ALLOW_PRIVATE_ACCESS

--- a/CryptoPkg/Library/MbedTlsLib/MbedTlsLib.inf
+++ b/CryptoPkg/Library/MbedTlsLib/MbedTlsLib.inf
@@ -1,0 +1,171 @@
+## @file
+#  library for the MbedTls.
+#
+#  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = MbedTlsLib
+  FILE_GUID                      = BB8E7D92-3E14-4907-A890-B28C7A0A1931
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = MbedTlsLib
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64 ARM AARCH64
+#
+
+[Sources]
+  Include/mbedtls/mbedtls_config.h
+  mbedtls/library/aes.c
+  mbedtls/library/asn1parse.c
+  mbedtls/library/asn1write.c
+  mbedtls/library/base64.c
+  mbedtls/library/bignum.c
+  mbedtls/library/ccm.c
+  mbedtls/library/chacha20.c
+  mbedtls/library/chachapoly.c
+  mbedtls/library/cipher.c
+  mbedtls/library/cipher_wrap.c
+  mbedtls/library/cmac.c
+  mbedtls/library/ctr_drbg.c
+  mbedtls/library/debug.c
+  mbedtls/library/des.c
+  mbedtls/library/dhm.c
+  EcSm2Null.c
+  mbedtls/library/error.c
+  mbedtls/library/gcm.c
+  mbedtls/library/hkdf.c
+  mbedtls/library/hmac_drbg.c
+  mbedtls/library/md.c
+  mbedtls/library/md5.c
+  mbedtls/library/ssl_msg.c
+  mbedtls/library/ssl_tls12_client.c
+  mbedtls/library/ssl_tls12_server.c
+  mbedtls/library/ssl_client.c
+  mbedtls/library/ssl_debug_helpers_generated.c
+  mbedtls/library/rsa_alt_helpers.c
+  mbedtls/library/hash_info.c
+  mbedtls/library/bignum_core.c
+  mbedtls/library/constant_time.c
+  mbedtls/library/memory_buffer_alloc.c
+  mbedtls/library/nist_kw.c
+  mbedtls/library/oid.c
+  mbedtls/library/padlock.c
+  mbedtls/library/pem.c
+  mbedtls/library/pk.c
+  mbedtls/library/pkcs12.c
+  mbedtls/library/pkcs5.c
+  mbedtls/library/pkparse.c
+  mbedtls/library/pkwrite.c
+  mbedtls/library/pk_wrap.c
+  mbedtls/library/poly1305.c
+  mbedtls/library/ripemd160.c
+  mbedtls/library/rsa.c
+  mbedtls/library/sha1.c
+  mbedtls/library/sha256.c
+  mbedtls/library/sha512.c
+  mbedtls/library/ssl_cache.c
+  mbedtls/library/ssl_ciphersuites.c
+  mbedtls/library/ssl_cookie.c
+  mbedtls/library/ssl_ticket.c
+  mbedtls/library/ssl_tls.c
+  mbedtls/library/threading.c
+  mbedtls/library/version.c
+  mbedtls/library/version_features.c
+  mbedtls/library/x509.c
+  mbedtls/library/x509write_crt.c
+  mbedtls/library/x509write_csr.c
+  mbedtls/library/x509_create.c
+  mbedtls/library/x509_crl.c
+  mbedtls/library/x509_crt.c
+  mbedtls/library/x509_csr.c
+  mbedtls/library/pkcs7.c
+  mbedtls/library/platform_util.c
+  CrtWrapper.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  CryptoPkg/CryptoPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  BaseMemoryLib
+  DebugLib
+  MemoryAllocationLib
+
+[BuildOptions]
+  #
+  # Disables the following Visual Studio compiler warnings brought by Mbedtls source,
+  # warning C4244: '=': conversion from 'int' to 'unsigned char', possible loss of data
+  # warning C4132: 'S': const object should be initialized
+  # warning C4245: '=': conversion from 'int' to 'mbedtls_mpi_uint', signed/unsigned mismatch
+  # warning C4310: cast truncates constant value
+  # warning C4204: nonstandard extension used
+  #
+  MSFT:*_*_IA32_CC_FLAGS   =  /DEFI32 /wd4244 /wd4132 /wd4245 /wd4310 /wd4204
+  MSFT:*_*_X64_CC_FLAGS   =  /DEFI32 /wd4244 /wd4132 /wd4245 /wd4310 /wd4204
+
+  #
+  # Disable following Visual Studio 2015 compiler warnings brought by mbedtls source,
+  # so we do not break the build with /WX option:
+  #   C4718: recursive call has no side effects, deleting
+  #
+  MSFT:*_VS2015x86_IA32_CC_FLAGS = /wd4718
+  MSFT:*_VS2015x86_X64_CC_FLAGS  = /wd4718
+
+  INTEL:*_*_IA32_CC_FLAGS  = -U_WIN32 -U_WIN64  /w
+  INTEL:*_*_X64_CC_FLAGS   = -U_WIN32 -U_WIN64  /w
+
+  #
+  # Suppress the following build warnings in mbedtls so we don't break the build with -Werror
+  #   -Werror=maybe-uninitialized: there exist some other paths for which the variable is not initialized.
+  #   -Werror=format: Check calls to printf and scanf, etc., to make sure that the arguments supplied have
+  #                   types appropriate to the format string specified.
+  #   -Werror=unused-but-set-variable: Warn whenever a local variable is assigned to, but otherwise unused (aside from its declaration).
+  #
+  GCC:*_*_IA32_CC_FLAGS    = -U_WIN32 -U_WIN64 -Wno-error=maybe-uninitialized -Wno-error=unused-but-set-variable
+  GCC:*_*_X64_CC_FLAGS     = -U_WIN32 -U_WIN64 -Wno-error=maybe-uninitialized -Wno-error=format -Wno-format -Wno-error=unused-but-set-variable -DNO_MSABI_VA_FUNCS
+  GCC:*_*_ARM_CC_FLAGS     =  -Wno-error=maybe-uninitialized -Wno-error=unused-but-set-variable
+  GCC:*_*_AARCH64_CC_FLAGS =  -Wno-error=maybe-uninitialized -Wno-format -Wno-error=unused-but-set-variable -Wno-error=format
+  GCC:*_*_RISCV64_CC_FLAGS =  -Wno-error=maybe-uninitialized -Wno-format -Wno-error=unused-but-set-variable
+  GCC:*_*_LOONGARCH64_CC_FLAGS =  -Wno-error=maybe-uninitialized -Wno-format -Wno-error=unused-but-set-variable
+  GCC:*_CLANG35_*_CC_FLAGS = -std=c99 -Wno-error=uninitialized
+  GCC:*_CLANG38_*_CC_FLAGS = -std=c99 -Wno-error=uninitialized
+  GCC:*_CLANGPDB_*_CC_FLAGS = -std=c99 -Wno-error=uninitialized -Wno-error=incompatible-pointer-types -Wno-error=pointer-sign -Wno-error=implicit-function-declaration -Wno-error=ignored-pragma-optimize
+
+  # suppress the following warnings in mbedtls so we don't break the build with warnings-as-errors:
+  # 1295: Deprecated declaration <entity> - give arg types
+  #  550: <entity> was set but never used
+  # 1293: assignment in condition
+  #  111: statement is unreachable (invariably "break;" after "return X;" in case statement)
+  #   68: integer conversion resulted in a change of sign ("if (Status == -1)")
+  #  177: <entity> was declared but never referenced
+  #  223: function <entity> declared implicitly
+  #  144: a value of type <type> cannot be used to initialize an entity of type <type>
+  #  513: a value of type <type> cannot be assigned to an entity of type <type>
+  #  188: enumerated type mixed with another type (i.e. passing an integer as an enum without a cast)
+  # 1296: Extended constant initialiser used
+  #  128: loop is not reachable - may be emitted inappropriately if code follows a conditional return
+  #       from the function that evaluates to true at compile time
+  #  546: transfer of control bypasses initialization - may be emitted inappropriately if the uninitialized
+  #       variable is never referenced after the jump
+  #    1: ignore "#1-D: last line of file ends without a newline"
+  XCODE:*_*_IA32_CC_FLAGS   = -mmmx -msse -U_WIN32 -U_WIN64   -w -std=c99 -Wno-error=uninitialized
+  XCODE:*_*_X64_CC_FLAGS    = -mmmx -msse -U_WIN32 -U_WIN64   -w -std=c99 -Wno-error=uninitialized
+
+  #
+  # AARCH64 uses strict alignment and avoids SIMD registers for code that may execute
+  # with the MMU off. This involves SEC, PEI_CORE and PEIM modules as well as BASE
+  # libraries, given that they may be included into such modules.
+  # This library, even though of the BASE type, is never used in such cases, and
+  # avoiding the SIMD register file (which is shared with the FPU) prevents the
+  # compiler from successfully building some of the mbedtls source files that
+  # use floating point types, so clear the flags here.
+  #
+  GCC:*_*_AARCH64_CC_XIPFLAGS ==

--- a/CryptoPkg/Library/MbedTlsLib/MbedTlsLibFull.inf
+++ b/CryptoPkg/Library/MbedTlsLib/MbedTlsLibFull.inf
@@ -1,0 +1,175 @@
+## @file
+#  library for the MbedTls.
+#
+#  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = MbedTlsLibFull
+  FILE_GUID                      = BE9B7BBC-F003-4D88-A7E3-EB73E951F5BF
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = MbedTlsLib
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64 ARM AARCH64
+#
+
+[Sources]
+  Include/mbedtls/mbedtls_config.h
+  mbedtls/library/aes.c
+  mbedtls/library/asn1parse.c
+  mbedtls/library/asn1write.c
+  mbedtls/library/base64.c
+  mbedtls/library/bignum.c
+  mbedtls/library/ccm.c
+  mbedtls/library/chacha20.c
+  mbedtls/library/chachapoly.c
+  mbedtls/library/cipher.c
+  mbedtls/library/cipher_wrap.c
+  mbedtls/library/cmac.c
+  mbedtls/library/ctr_drbg.c
+  mbedtls/library/debug.c
+  mbedtls/library/des.c
+  mbedtls/library/dhm.c
+  mbedtls/library/ecdh.c
+  mbedtls/library/ecdsa.c
+  mbedtls/library/ecjpake.c
+  mbedtls/library/ecp.c
+  mbedtls/library/ecp_curves.c
+  mbedtls/library/error.c
+  mbedtls/library/gcm.c
+  mbedtls/library/hkdf.c
+  mbedtls/library/hmac_drbg.c
+  mbedtls/library/md.c
+  mbedtls/library/md5.c
+  mbedtls/library/ssl_msg.c
+  mbedtls/library/ssl_tls12_client.c
+  mbedtls/library/ssl_tls12_server.c
+  mbedtls/library/ssl_client.c
+  mbedtls/library/ssl_debug_helpers_generated.c
+  mbedtls/library/rsa_alt_helpers.c
+  mbedtls/library/hash_info.c
+  mbedtls/library/bignum_core.c
+  mbedtls/library/constant_time.c
+  mbedtls/library/memory_buffer_alloc.c
+  mbedtls/library/nist_kw.c
+  mbedtls/library/oid.c
+  mbedtls/library/padlock.c
+  mbedtls/library/pem.c
+  mbedtls/library/pk.c
+  mbedtls/library/pkcs12.c
+  mbedtls/library/pkcs5.c
+  mbedtls/library/pkparse.c
+  mbedtls/library/pkwrite.c
+  mbedtls/library/pk_wrap.c
+  mbedtls/library/poly1305.c
+  mbedtls/library/ripemd160.c
+  mbedtls/library/rsa.c
+  mbedtls/library/sha1.c
+  mbedtls/library/sha256.c
+  mbedtls/library/sha512.c
+  mbedtls/library/ssl_cache.c
+  mbedtls/library/ssl_ciphersuites.c
+  mbedtls/library/ssl_cookie.c
+  mbedtls/library/ssl_ticket.c
+  mbedtls/library/ssl_tls.c
+  mbedtls/library/threading.c
+  mbedtls/library/version.c
+  mbedtls/library/version_features.c
+  mbedtls/library/x509.c
+  mbedtls/library/x509write_crt.c
+  mbedtls/library/x509write_csr.c
+  mbedtls/library/x509_create.c
+  mbedtls/library/x509_crl.c
+  mbedtls/library/x509_crt.c
+  mbedtls/library/x509_csr.c
+  mbedtls/library/pkcs7.c
+  mbedtls/library/platform_util.c
+  CrtWrapper.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  CryptoPkg/CryptoPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  BaseMemoryLib
+  DebugLib
+  MemoryAllocationLib
+
+[BuildOptions]
+  #
+  # Disables the following Visual Studio compiler warnings brought by Mbedtls source,
+  # warning C4244: '=': conversion from 'int' to 'unsigned char', possible loss of data
+  # warning C4132: 'S': const object should be initialized
+  # warning C4245: '=': conversion from 'int' to 'mbedtls_mpi_uint', signed/unsigned mismatch
+  # warning C4310: cast truncates constant value
+  # warning C4204: nonstandard extension used
+  #
+  MSFT:*_*_IA32_CC_FLAGS   =  /DEFI32 /wd4244 /wd4132 /wd4245 /wd4310 /wd4204
+  MSFT:*_*_X64_CC_FLAGS   =  /DEFI32 /wd4244 /wd4132 /wd4245 /wd4310 /wd4204
+
+  #
+  # Disable following Visual Studio 2015 compiler warnings brought by mbedtls source,
+  # so we do not break the build with /WX option:
+  #   C4718: recursive call has no side effects, deleting
+  #
+  MSFT:*_VS2015x86_IA32_CC_FLAGS = /wd4718
+  MSFT:*_VS2015x86_X64_CC_FLAGS  = /wd4718
+
+  INTEL:*_*_IA32_CC_FLAGS  = -U_WIN32 -U_WIN64  /w
+  INTEL:*_*_X64_CC_FLAGS   = -U_WIN32 -U_WIN64  /w
+
+  #
+  # Suppress the following build warnings in mbedtls so we don't break the build with -Werror
+  #   -Werror=maybe-uninitialized: there exist some other paths for which the variable is not initialized.
+  #   -Werror=format: Check calls to printf and scanf, etc., to make sure that the arguments supplied have
+  #                   types appropriate to the format string specified.
+  #   -Werror=unused-but-set-variable: Warn whenever a local variable is assigned to, but otherwise unused (aside from its declaration).
+  #
+  GCC:*_*_IA32_CC_FLAGS    = -U_WIN32 -U_WIN64 -Wno-error=maybe-uninitialized -Wno-error=unused-but-set-variable
+  GCC:*_*_X64_CC_FLAGS     = -U_WIN32 -U_WIN64 -Wno-error=maybe-uninitialized -Wno-error=format -Wno-format -Wno-error=unused-but-set-variable -DNO_MSABI_VA_FUNCS
+  GCC:*_*_ARM_CC_FLAGS     =  -Wno-error=maybe-uninitialized -Wno-error=unused-but-set-variable
+  GCC:*_*_AARCH64_CC_FLAGS =  -Wno-error=maybe-uninitialized -Wno-format -Wno-error=unused-but-set-variable -Wno-error=format
+  GCC:*_*_RISCV64_CC_FLAGS =  -Wno-error=maybe-uninitialized -Wno-format -Wno-error=unused-but-set-variable
+  GCC:*_*_LOONGARCH64_CC_FLAGS =  -Wno-error=maybe-uninitialized -Wno-format -Wno-error=unused-but-set-variable
+  GCC:*_CLANG35_*_CC_FLAGS = -std=c99 -Wno-error=uninitialized
+  GCC:*_CLANG38_*_CC_FLAGS = -std=c99 -Wno-error=uninitialized
+  GCC:*_CLANGPDB_*_CC_FLAGS = -std=c99 -Wno-error=uninitialized -Wno-error=incompatible-pointer-types -Wno-error=pointer-sign -Wno-error=implicit-function-declaration -Wno-error=ignored-pragma-optimize
+
+  # suppress the following warnings in mbedtls so we don't break the build with warnings-as-errors:
+  # 1295: Deprecated declaration <entity> - give arg types
+  #  550: <entity> was set but never used
+  # 1293: assignment in condition
+  #  111: statement is unreachable (invariably "break;" after "return X;" in case statement)
+  #   68: integer conversion resulted in a change of sign ("if (Status == -1)")
+  #  177: <entity> was declared but never referenced
+  #  223: function <entity> declared implicitly
+  #  144: a value of type <type> cannot be used to initialize an entity of type <type>
+  #  513: a value of type <type> cannot be assigned to an entity of type <type>
+  #  188: enumerated type mixed with another type (i.e. passing an integer as an enum without a cast)
+  # 1296: Extended constant initialiser used
+  #  128: loop is not reachable - may be emitted inappropriately if code follows a conditional return
+  #       from the function that evaluates to true at compile time
+  #  546: transfer of control bypasses initialization - may be emitted inappropriately if the uninitialized
+  #       variable is never referenced after the jump
+  #    1: ignore "#1-D: last line of file ends without a newline"
+  XCODE:*_*_IA32_CC_FLAGS   = -mmmx -msse -U_WIN32 -U_WIN64   -w -std=c99 -Wno-error=uninitialized
+  XCODE:*_*_X64_CC_FLAGS    = -mmmx -msse -U_WIN32 -U_WIN64   -w -std=c99 -Wno-error=uninitialized
+
+  #
+  # AARCH64 uses strict alignment and avoids SIMD registers for code that may execute
+  # with the MMU off. This involves SEC, PEI_CORE and PEIM modules as well as BASE
+  # libraries, given that they may be included into such modules.
+  # This library, even though of the BASE type, is never used in such cases, and
+  # avoiding the SIMD register file (which is shared with the FPU) prevents the
+  # compiler from successfully building some of the mbedtls source files that
+  # use floating point types, so clear the flags here.
+  #
+  GCC:*_*_AARCH64_CC_XIPFLAGS ==

--- a/CryptoPkg/Private/Library/MbedTlsLib.h
+++ b/CryptoPkg/Private/Library/MbedTlsLib.h
@@ -1,0 +1,12 @@
+/** @file
+  MbedTlsLib class with APIs from the mbedtls project
+
+  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef MBEDTLS_LIB_H_
+#define MBEDTLS_LIB_H_
+
+#endif

--- a/CryptoPkg/Readme.md
+++ b/CryptoPkg/Readme.md
@@ -3,7 +3,8 @@
 This package provides cryptographic services that are used to implement firmware
 features such as UEFI Secure Boot, Measured Boot, firmware image authentication,
 and network boot. The cryptographic service implementation in this package uses
-services from the [OpenSSL](https://www.openssl.org/) project.
+services from the [OpenSSL](https://www.openssl.org/) project and
+[MbedTLS](https://www.trustedfirmware.org/projects/mbed-tls/) project.
 
 EDK II firmware modules/libraries that requires the use of cryptographic
 services can either statically link all the required services, or the EDK II
@@ -18,14 +19,19 @@ provides the smallest overall firmware overhead.
 
 # Public Library Classes
 
-* **BaseCryptLib** - Provides library functions for cryptographic primitives.
-* **TlsLib**       - Provides TLS library functions for EFI TLS protocol.
-* **HashApiLib**   - Provides Unified API for different hash implementations.
+* **BaseCryptLib**        - Provides library functions based on OpenSSL for
+                            cryptographic primitives.
+* **BaseCryptLibMbedTls** - Provides library functions based on MbedTLS for
+                            cryptographic primitives.
+* **TlsLib**              - Provides TLS library functions for EFI TLS protocol.
+* **HashApiLib**          - Provides Unified API for different hash implementations.
 
 # Private Library Classes
 
 * **OpensslLib**   - Provides library functions from the openssl project.
-* **IntrinsicLib** - Provides C runtime library (CRT) required by openssl.
+* **MbedTlsLib**   - Provides library functions from the mbedtls project.
+* **IntrinsicLib** - Provides C runtime library (CRT) required by openssl
+                     and mbedtls.
 
 # Private Protocols and PPIs
 

--- a/CryptoPkg/Test/UnitTest/Library/BaseCryptLib/RsaTests.c
+++ b/CryptoPkg/Test/UnitTest/Library/BaseCryptLib/RsaTests.c
@@ -194,12 +194,22 @@ TestVerifyRsaGenerateKeyComponents (
   BOOLEAN  Status;
   UINTN    KeySize;
   UINT8    *KeyBuffer;
+  UINT8    TestPublicExponent1[] = { 0x03 };
+  UINT8    TestPublicExponent2[] = { 0x01, 0x01 };
+  UINT8    TestPublicExponent3[] = { 0x01, 0x00, 0x01 };
 
   //
   // Generate RSA Key Components
   //
 
   Status = RsaGenerateKey (mRsa, RSA_MODULUS_LENGTH, NULL, 0);
+  UT_ASSERT_TRUE (Status);
+
+  Status = RsaGenerateKey (mRsa, RSA_MODULUS_LENGTH, TestPublicExponent1, sizeof (TestPublicExponent1));
+  UT_ASSERT_TRUE (Status);
+  Status = RsaGenerateKey (mRsa, RSA_MODULUS_LENGTH, TestPublicExponent2, sizeof (TestPublicExponent2));
+  UT_ASSERT_TRUE (Status);
+  Status = RsaGenerateKey (mRsa, RSA_MODULUS_LENGTH, TestPublicExponent3, sizeof (TestPublicExponent3));
   UT_ASSERT_TRUE (Status);
 
   KeySize   = RSA_MODULUS_LENGTH / 8;


### PR DESCRIPTION
Purpose: This patch is needed to resolve the limitation from OpenSSL 3.0 that HMAC/HKDF/RSA cannot work in pre-memory phase.

There are five features based on mbedtls in the patch: HMAC/HKDF/RSA/HASH/AES.

Test: The patch has passed the unit_test and fuzz test. And the patch has passed testing on the Intel platform.

POC: https://github.com/tianocore/edk2-
staging/tree/OpenSSL11_EOL/CryptoPkg/Library/BaseCryptLibMbedTls

REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4177

Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Yi Li <yi1.li@intel.com>
Cc: Xiaoyu Lu <xiaoyu1.lu@intel.com>
Cc: Guomin Jiang <guomin.jiang@intel.com>
Signed-off-by: Wenxing Hou <wenxing.hou@intel.com>

Wenxing Hou (11):
  CryptoPkg: Add mbedtls submodule for EDKII
  CryptoPkg: Add mbedtls_config and MbedTlsLib.inf
  CryptoPkg: Add HMAC functions based on Mbedtls
  CryptoPkg: Add HKDF functions based on Mbedtls
  CryptoPkg: Add RSA functions based on Mbedtls
  CryptoPkg: Add all .inf files for BaseCryptLibMbedTls
  CryptoPkg: Add Null functions for building pass
  CryptoPkg: Add MD5/SHA1/SHA2 functions based on Mbedtls
  CryptoPkg: Add Mbedtls submodule in CI
  CryptoPkg: Add basic Readme for BaseCryptLibMbedTls
  CryptoPkg: Add CryptAes functions based on Mbedtls Add CryptAes APIS.