### PR TITLE
RedfishPkg: Use base version SortLib for the specific modules

### DIFF
--- a/RedfishPkg/RedfishComponents.dsc.inc
+++ b/RedfishPkg/RedfishComponents.dsc.inc
@@ -16,9 +16,15 @@
 !if $(REDFISH_ENABLE) == TRUE
   RedfishPkg/RestJsonStructureDxe/RestJsonStructureDxe.inf
   RedfishPkg/RedfishHostInterfaceDxe/RedfishHostInterfaceDxe.inf
-  RedfishPkg/RedfishRestExDxe/RedfishRestExDxe.inf
+  RedfishPkg/RedfishRestExDxe/RedfishRestExDxe.inf  {
+    <LibraryClasses>
+      SortLib|MdeModulePkg/Library/BaseSortLib/BaseSortLib.inf
+  }
   RedfishPkg/RedfishCredentialDxe/RedfishCredentialDxe.inf
-  RedfishPkg/RedfishDiscoverDxe/RedfishDiscoverDxe.inf
+  RedfishPkg/RedfishDiscoverDxe/RedfishDiscoverDxe.inf  {
+    <LibraryClasses>
+      SortLib|MdeModulePkg/Library/BaseSortLib/BaseSortLib.inf
+  }
   RedfishPkg/RedfishConfigHandler/RedfishConfigHandlerDriver.inf
   RedfishPkg/RedfishPlatformConfigDxe/RedfishPlatformConfigDxe.inf
   MdeModulePkg/Universal/RegularExpressionDxe/RegularExpressionDxe.inf

--- a/RedfishPkg/RedfishLibs.dsc.inc
+++ b/RedfishPkg/RedfishLibs.dsc.inc
@@ -14,7 +14,6 @@
 !if $(REDFISH_ENABLE) == TRUE
   RestExLib|RedfishPkg/Library/DxeRestExLib/DxeRestExLib.inf
   Ucs2Utf8Lib|RedfishPkg/Library/BaseUcs2Utf8Lib/BaseUcs2Utf8Lib.inf
-  SortLib|MdeModulePkg/Library/BaseSortLib/BaseSortLib.inf
   RedfishCrtLib|RedfishPkg/PrivateLibrary/RedfishCrtLib/RedfishCrtLib.inf
   JsonLib|RedfishPkg/Library/JsonLib/JsonLib.inf
   RedfishLib|RedfishPkg/PrivateLibrary/RedfishLib/RedfishLib.inf


### PR DESCRIPTION
BZ #: 4566

Update Redfish modules to use the small footprint
version of base SortLib by the means of module scoped subelement <LibraryClass>. With this the platform
level SortLib (full version) is not impacted if
Redfish.dsc.inc is included in platform DSC.


Cc: Nickle Wang <nicklew@nvidia.com>
Cc: Igor Kulchytskyy <igork@ami.com>
Cc: Nhi Pham <nhi@os.amperecomputing.com>