### PR TITLE
OvmfPkg:  Fix the coverity errors

### DIFF
--- a/OvmfPkg/AcpiPlatformDxe/CloudHvAcpi.c
+++ b/OvmfPkg/AcpiPlatformDxe/CloudHvAcpi.c
@@ -71,6 +71,7 @@ InstallCloudHvTablesTdx (
   if (DsdtTable == NULL) {
     DEBUG ((DEBUG_INFO, "%a: no DSDT found\n", __func__));
     ASSERT (FALSE);
+    CpuDeadLoop ();
   }
 
   Status = AcpiProtocol->InstallAcpiTable (

--- a/OvmfPkg/AcpiPlatformDxe/CloudHvAcpi.c
+++ b/OvmfPkg/AcpiPlatformDxe/CloudHvAcpi.c
@@ -53,6 +53,11 @@ InstallCloudHvTablesTdx (
                                CurrentTable->Length,
                                &TableHandle
                                );
+      if (EFI_ERROR (Status)) {
+        ASSERT_EFI_ERROR (Status);
+        return Status;
+      }
+
       for (UINTN i = 0; i < CurrentTable->Length; i++) {
         DEBUG ((DEBUG_INFO, " %x", *((UINT8 *)CurrentTable + i)));
       }


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4568

Coverity report 2 issues in OvmfPkg/AcpiPlatformDxe/CloudHvAcpi.c.

In the function InstallCloudHvTablesTdx, already had check the pointer 
  if (DsdtTable == NULL) {
    DEBUG ((DEBUG_INFO, "%a: no DSDT found\n", __func__));
    ASSERT (FALSE);
  }
but only assert in DEBUG mode, in Release mode, that would be an error with 
dereferencing null pointer. Fix this by adding CpuDeadLoop() after assert. 

In addition, the status of "AcpiProtocol->InstallAcpiTable" is overwritten before
it can be used in the function, it is better to check it before overwriting.

Cc: Gerd Hoffmann <kraxel@redhat.com>
Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Min Xu <min.m.xu@intel.com>
Signed-off-by: Ceping Sun <cepingx.sun@intel.com>