### PR TITLE
ArmPkg/ArmPsciMpServices: Add EFI_NOT_READY return

### DIFF
--- a/ArmPkg/Drivers/ArmPsciMpServicesDxe/ArmPsciMpServicesDxe.c
+++ b/ArmPkg/Drivers/ArmPsciMpServicesDxe/ArmPsciMpServicesDxe.c
@@ -103,7 +103,9 @@ DispatchCpu (
 
   ArmCallSmc (&Args);
 
-  if (Args.Arg0 != ARM_SMC_PSCI_RET_SUCCESS) {
+  if (Args.Arg0 == ARM_SMC_PSCI_RET_ALREADY_ON) {
+    Status = EFI_NOT_READY;
+  } else if (Args.Arg0 != ARM_SMC_PSCI_RET_SUCCESS) {
     DEBUG ((DEBUG_ERROR, "PSCI_CPU_ON call failed: %d\n", Args.Arg0));
     Status = EFI_DEVICE_ERROR;
   }


### PR DESCRIPTION
Add EFI_NOT_READY return if the CPU can not be enabled because the processor is already on.

This can occur in normal use if the CPU is still being turned off from a previous call when this is called again.


Reviewed-by: Rebecca Cran <rebecca@bsdio.com>