### PR TITLE
RedfishPkg/RedfishDiscoverDxe: introduce PcdRedfishSendReceiveTimeout

### DIFF
--- a/RedfishPkg/RedfishDiscoverDxe/RedfishDiscoverDxe.c
+++ b/RedfishPkg/RedfishDiscoverDxe/RedfishDiscoverDxe.c
@@ -877,7 +877,7 @@ AddAndSignalNewRedfishService (
         goto EXIT_FREE_CONFIG_DATA;
       }
 
-      RestExHttpConfigData->SendReceiveTimeout                = 5000;
+      RestExHttpConfigData->SendReceiveTimeout                = PcdGet32 (PcdRedfishSendReceiveTimeout);
       RestExHttpConfigData->HttpConfigData.HttpVersion        = HttpVersion11;
       RestExHttpConfigData->HttpConfigData.LocalAddressIsIPv6 = CheckIsIpVersion6 (NetworkInterface);
       if (RestExHttpConfigData->HttpConfigData.LocalAddressIsIPv6) {

--- a/RedfishPkg/RedfishDiscoverDxe/RedfishDiscoverDxe.inf
+++ b/RedfishPkg/RedfishDiscoverDxe/RedfishDiscoverDxe.inf
@@ -54,4 +54,4 @@
 
 [Pcd]
   gEfiRedfishPkgTokenSpaceGuid.PcdRedfishDiscoverAccessModeInBand ## CONSUMES
-
+  gEfiRedfishPkgTokenSpaceGuid.PcdRedfishSendReceiveTimeout       ## CONSUEMS

--- a/RedfishPkg/RedfishPkg.dec
+++ b/RedfishPkg/RedfishPkg.dec
@@ -142,3 +142,8 @@
   # This PCD indicates that if BMC bootstrap credential service will be disabled by BIOS or not.
   #
   gEfiRedfishPkgTokenSpaceGuid.PcdRedfishDisableBootstrapCredentialService|FALSE|BOOLEAN|0x00001007
+  #
+  # The EFI_REST_EX_HTTP_CONFIG_DATA.SendReceiveTimeout value that RedfishDiscoverDxe driver
+  # set to EFI_REST_EX_PROTOCOL.
+  #
+  gEfiRedfishPkgTokenSpaceGuid.PcdRedfishSendReceiveTimeout|5000|UINT32|0x00001008


### PR DESCRIPTION
Introduce PCD PcdRedfishSendReceiveTimeout to RedfishDiscoverDxe driver. The SendReceiveTimeout is hard-code value in Redfish discover driver. With this PCD, platform owner can configure timeout value easily.


Cc: Abner Chang <abner.chang@amd.com>
Cc: Igor Kulchytskyy <igork@ami.com>