### PR TITLE
[PATCH 0/5] EmbeddedPkg/RealTimeClockLib: drop LibRtcVirtualNotifyEvent from lib class -- push

### DIFF
--- a/ArmPlatformPkg/Library/PL031RealTimeClockLib/PL031RealTimeClockLib.c
+++ b/ArmPlatformPkg/Library/PL031RealTimeClockLib/PL031RealTimeClockLib.c
@@ -274,9 +274,10 @@ LibSetWakeupTime (
   @param[in]    Event   The Event that is being processed
   @param[in]    Context Event Context
 **/
+STATIC
 VOID
 EFIAPI
-LibRtcVirtualNotifyEvent (
+VirtualNotifyEvent (
   IN EFI_EVENT  Event,
   IN VOID       *Context
   )
@@ -346,7 +347,7 @@ LibRtcInitialize (
   Status = gBS->CreateEventEx (
                   EVT_NOTIFY_SIGNAL,
                   TPL_NOTIFY,
-                  LibRtcVirtualNotifyEvent,
+                  VirtualNotifyEvent,
                   NULL,
                   &gEfiEventVirtualAddressChangeGuid,
                   &mRtcVirtualAddrChangeEvent

--- a/EmbeddedPkg/Include/Library/RealTimeClockLib.h
+++ b/EmbeddedPkg/Include/Library/RealTimeClockLib.h
@@ -105,19 +105,4 @@ LibRtcInitialize (
   IN EFI_SYSTEM_TABLE  *SystemTable
   );
 
-/**
-  Fixup internal data so that EFI can be call in virtual mode.
-  Call the passed in Child Notify event and convert any pointers in
-  lib to virtual mode.
-
-  @param[in]    Event   The Event that is being processed
-  @param[in]    Context Event Context
-**/
-VOID
-EFIAPI
-LibRtcVirtualNotifyEvent (
-  IN EFI_EVENT  Event,
-  IN VOID       *Context
-  );
-
 #endif

--- a/EmbeddedPkg/Library/TemplateRealTimeClockLib/RealTimeClockLib.c
+++ b/EmbeddedPkg/Library/TemplateRealTimeClockLib/RealTimeClockLib.c
@@ -133,27 +133,3 @@ LibRtcInitialize (
   //
   return EFI_SUCCESS;
 }
-
-/**
-  Fixup internal data so that EFI can be call in virtual mode.
-  Call the passed in Child Notify event and convert any pointers in
-  lib to virtual mode.
-
-  @param[in]    Event   The Event that is being processed
-  @param[in]    Context Event Context
-**/
-VOID
-EFIAPI
-LibRtcVirtualNotifyEvent (
-  IN EFI_EVENT  Event,
-  IN VOID       *Context
-  )
-{
-  //
-  // Only needed if you are going to support the OS calling RTC functions in virtual mode.
-  // You will need to call EfiConvertPointer (). To convert any stored physical addresses
-  // to virtual address. After the OS transitions to calling in virtual mode, all future
-  // runtime calls will be made in virtual mode.
-  //
-  return;
-}

--- a/EmbeddedPkg/Library/VirtualRealTimeClockLib/VirtualRealTimeClockLib.c
+++ b/EmbeddedPkg/Library/VirtualRealTimeClockLib/VirtualRealTimeClockLib.c
@@ -402,21 +402,3 @@ LibRtcInitialize (
 {
   return EFI_SUCCESS;
 }
-
-/**
-   Fixup internal data so that EFI can be call in virtual mode.
-   Call the passed in Child Notify event and convert any pointers in
-   lib to virtual mode.
-
-   @param[in]    Event   The Event that is being processed
-   @param[in]    Context Event Context
-**/
-VOID
-EFIAPI
-LibRtcVirtualNotifyEvent (
-  IN EFI_EVENT  Event,
-  IN VOID       *Context
-  )
-{
-  return;
-}

--- a/PcAtChipsetPkg/PcatRealTimeClockRuntimeDxe/PcRtcEntry.c
+++ b/PcAtChipsetPkg/PcatRealTimeClockRuntimeDxe/PcRtcEntry.c
@@ -122,9 +122,10 @@ PcRtcEfiSetWakeupTime (
   @param[in]    Event   The Event that is being processed
   @param[in]    Context Event Context
 **/
+STATIC
 VOID
 EFIAPI
-LibRtcVirtualNotifyEvent (
+VirtualNotifyEvent (
   IN EFI_EVENT  Event,
   IN VOID       *Context
   )
@@ -220,7 +221,7 @@ InitializePcRtc (
     Status = gBS->CreateEventEx (
                     EVT_NOTIFY_SIGNAL,
                     TPL_NOTIFY,
-                    LibRtcVirtualNotifyEvent,
+                    VirtualNotifyEvent,
                     NULL,
                     &gEfiEventVirtualAddressChangeGuid,
                     &mVirtualAddrChangeEvent


### PR DESCRIPTION
https://bugzilla.tianocore.org/show_bug.cgi?id=4564
https://edk2.groups.io/g/devel/message/109563
https://listman.redhat.com/archives/edk2-devel-archive/2023-October/068862.html
http://mid.mail-archive.com/20231012091057.108728-1-lersek@redhat.com
~~~
https://bugzilla.tianocore.org/show_bug.cgi?id=4564

The RealTimeClockLib class header in edk2's EmbeddedPkg mistakenly
declares a function called LibRtcVirtualNotifyEvent(). No component ever
calls this function across module boundaries; all RealTimeClockLib
instances in edk2 and edk2-platforms are supposed to register -- and do
register -- their SetVirtualAddressMap() notification functions.

After the edk2-platforms and edk2-non-osi changes, we can repeat the
procedure form the edk2-platforms series in edk2. In those
RealTimeClockLib instances that define LibRtcVirtualNotifyEvent(),
demonstrate that either (a) the usage is module-internal, or (b) there
is no usage. In case (a), rename LibRtcVirtualNotifyEvent() to
VirtualNotifyEvent(), and make it static. In case (b), remove the
function definition.

There is a superficial name match in
PcAtChipsetPkg/PcatRealTimeClockRuntimeDxe. Note that that module is a
*driver*, not a library instance; what's more,
PcatRealTimeClockRuntimeDxe does not depend on "EmbeddedPkg.dec" at all.
Treat that module too as case (a), right at the front of the series.

Finally, drop the LibRtcVirtualNotifyEvent() API declaration.

Cc: Abner Chang [<abner.chang@amd.com>](mailto:abner.chang@amd.com)
Cc: Ard Biesheuvel [<ardb+tianocore@kernel.org>](mailto:ardb+tianocore@kernel.org)
Cc: Daniel Schaefer [<git@danielschaefer.me>](mailto:git@danielschaefer.me)
Cc: Leif Lindholm [<quic_llindhol@quicinc.com>](mailto:quic_llindhol@quicinc.com)
Cc: Ray Ni [<ray.ni@intel.com>](mailto:ray.ni@intel.com)

Thanks
Laszlo

Laszlo Ersek (5):
  PcAtChipsetPkg/PcatRealTimeClockRuntimeDxe: rename
    LibRtcVirtualNotifyEvent
  ArmPlatformPkg/PL031RealTimeClockLib: hide LibRtcVirtualNotifyEvent
  EmbeddedPkg/TemplateRealTimeClockLib: drop LibRtcVirtualNotifyEvent
  EmbeddedPkg/VirtualRealTimeClockLib: drop LibRtcVirtualNotifyEvent
  EmbeddedPkg/RealTimeClockLib: drop LibRtcVirtualNotifyEvent from lib
    class

 ArmPlatformPkg/Library/PL031RealTimeClockLib/PL031RealTimeClockLib.c  |  5 ++--
 EmbeddedPkg/Include/Library/RealTimeClockLib.h                        | 15 ------------
 EmbeddedPkg/Library/TemplateRealTimeClockLib/RealTimeClockLib.c       | 24 --------------------
 EmbeddedPkg/Library/VirtualRealTimeClockLib/VirtualRealTimeClockLib.c | 18 ---------------
 PcAtChipsetPkg/PcatRealTimeClockRuntimeDxe/PcRtcEntry.c               |  5 ++--
 5 files changed, 6 insertions(+), 61 deletions(-)


base-commit: 95c9f470ca6eab23bfd016bd438f932d7263d395
~~~