### PR TITLE
BaseTools: trim warning to error

### DIFF
--- a/BaseTools/Source/Python/Trim/Trim.py
+++ b/BaseTools/Source/Python/Trim/Trim.py
@@ -281,10 +281,10 @@ def DoInclude(Source, Indent='', IncludePathList=[], LocalSearchPath=None, Inclu
                         F = File.readlines()
                 break
         else:
-            EdkLogger.warn("Trim", "Failed to find include file %s" % Source)
+            EdkLogger.error("Trim", "Failed to find include file %s" % Source)
             return []
     except:
-        EdkLogger.warn("Trim", FILE_OPEN_FAILURE, ExtraData=Source)
+        EdkLogger.error("Trim", FILE_OPEN_FAILURE, ExtraData=Source)
         return []
 
 


### PR DESCRIPTION
As the error is changed to warning, Trim.py will skip the build error when the source code have exactly issue.
This patch change warning to error to opens the checking.

Cc: Rebecca Cran <rebecca@bsdio.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Bob Feng <bob.c.feng@intel.com>