### PR TITLE
RedfishPkg/RedfishDiscoverDxe: remove Redfish false alarm

### DIFF
--- a/RedfishPkg/RedfishDiscoverDxe/RedfishDiscoverDxe.c
+++ b/RedfishPkg/RedfishDiscoverDxe/RedfishDiscoverDxe.c
@@ -198,13 +198,17 @@ Tcp4GetSubnetInfo (
   Tcp4Option.EnableNagle       = TRUE;
   Status                       = Tcp4->Configure (Tcp4, &Tcp4CfgData);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: Can't get subnet information\n", __func__));
+    if (Status == EFI_NO_MAPPING) {
+      return EFI_SUCCESS;
+    }
+
+    DEBUG ((DEBUG_ERROR, "%a: Can't get subnet information: %r\n", __func__, Status));
     return Status;
   }
 
   Status = Tcp4->GetModeData (Tcp4, NULL, NULL, &IpModedata, NULL, NULL);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: Can't get IP mode data information\n", __func__));
+    DEBUG ((DEBUG_ERROR, "%a: Can't get IP mode data information: %r\n", __func__, Status));
     return Status;
   }
 
@@ -267,7 +271,7 @@ Tcp6GetSubnetInfo (
   ZeroMem ((VOID *)&IpModedata, sizeof (EFI_IP6_MODE_DATA));
   Status = Tcp6->GetModeData (Tcp6, NULL, NULL, &IpModedata, NULL, NULL);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: Can't get IP mode data information\n", __func__));
+    DEBUG ((DEBUG_ERROR, "%a: Can't get IP mode data information: %r\n", __func__, Status));
     return Status;
   }
 
@@ -1002,13 +1006,13 @@ NetworkInterfaceGetSubnetInfo (
                                                Instance
                                                );
     if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_ERROR, "%a:Failed to get Subnet infomation.\n", __func__));
+      DEBUG ((DEBUG_ERROR, "%a:Failed to get Subnet information.\n", __func__));
       return Status;
     } else {
       DEBUG ((DEBUG_MANAGEABILITY, "%a:MAC address: %s\n", __func__, Instance->StrMacAddr));
       if (CheckIsIpVersion6 (Instance)) {
         if (Instance->SubnetAddrInfoIPv6Number == 0) {
-          DEBUG ((DEBUG_ERROR, "%a: There is no Subnet infomation for IPv6 network interface.\n", __func__));
+          DEBUG ((DEBUG_WARN, "%a: There is no Subnet information for IPv6 network interface.\n", __func__));
           return EFI_NOT_FOUND;
         }
 
@@ -1554,7 +1558,7 @@ TestForRequiredProtocols (
                       );
       if (EFI_ERROR (Status)) {
         if (Index == ListCount - 1) {
-          DEBUG ((DEBUG_ERROR, "%a: all required protocols are found on this controller handle: %p.\n", __func__, ControllerHandle));
+          DEBUG ((DEBUG_INFO, "%a: all required protocols are found on this controller handle: %p.\n", __func__, ControllerHandle));
           return EFI_SUCCESS;
         }
       }


### PR DESCRIPTION
- It is expected that caller receives EFI_NO_MAPPING status when call issues Configure() to unconfigured network interface. Remove this false alarm in GetSubnetInfo() function.
- Fix typos


Cc: Abner Chang <abner.chang@amd.com>
Cc: Igor Kulchytskyy <igork@ami.com>
Cc: Nick Ramirez <nramirez@nvidia.com>