### PR TITLE
StandaloneMmPkg: Fix the failure to find uncompressed inner FV.

### DIFF
--- a/StandaloneMmPkg/Core/FwVol.c
+++ b/StandaloneMmPkg/Core/FwVol.c
@@ -105,6 +105,17 @@ MmCoreFfsFindMmDriver (
     }
 
     Status = FfsFindSectionData (
+               EFI_SECTION_FIRMWARE_VOLUME_IMAGE,
+               FileHeader,
+               &SectionData,
+               &SectionDataSize
+               );
+    if (!EFI_ERROR (Status)) {
+      InnerFvHeader = (EFI_FIRMWARE_VOLUME_HEADER *)SectionData;
+      MmCoreFfsFindMmDriver (InnerFvHeader);
+    }
+
+    Status = FfsFindSectionData (
                EFI_SECTION_GUID_DEFINED,
                FileHeader,
                &SectionData,


### PR DESCRIPTION
The MmCoreFfsFindMmDriver only checks for encapsulated compressed FVs. When an inner FV is uncompressed, StandaloneMmCore will miss the FV and all the MM drivers in the FV will not be dispatched. Add checks for uncompressed inner FV to fix this issue.

Cc: Ard Biesheuvel <ardb+tianocore@kernel.org>
Cc: Sami Mujawar <sami.mujawar@arm.com>
Cc: Ray Ni <ray.ni@intel.com>