### PR TITLE
[PATCH] ArmPlatformPkg/PL031RealTimeClockLib: remove superfluous instance init steps -- push

### DIFF
--- a/ArmPlatformPkg/Library/PL031RealTimeClockLib/PL031RealTimeClockLib.c
+++ b/ArmPlatformPkg/Library/PL031RealTimeClockLib/PL031RealTimeClockLib.c
@@ -27,8 +27,6 @@
 #include <Library/UefiRuntimeServicesTableLib.h>
 #include <Library/UefiRuntimeLib.h>
 
-#include <Protocol/RealTimeClock.h>
-
 #include "PL031RealTimeClock.h"
 
 STATIC BOOLEAN    mPL031Initialized = FALSE;
@@ -310,7 +308,6 @@ LibRtcInitialize (
   )
 {
   EFI_STATUS  Status;
-  EFI_HANDLE  Handle;
 
   // Initialize RTC Base Address
   mPL031RtcBase = PcdGet32 (PcdPL031RtcBase);
@@ -330,16 +327,6 @@ LibRtcInitialize (
   if (EFI_ERROR (Status)) {
     return Status;
   }
-
-  // Install the protocol
-  Handle = NULL;
-  Status = gBS->InstallMultipleProtocolInterfaces (
-                  &Handle,
-                  &gEfiRealTimeClockArchProtocolGuid,
-                  NULL,
-                  NULL
-                  );
-  ASSERT_EFI_ERROR (Status);
 
   //
   // Register for the virtual address change event


### PR DESCRIPTION
https://bugzilla.tianocore.org/show_bug.cgi?id=4565
http://mid.mail-archive.com/20231020121748.44862-1-lersek@redhat.com
https://listman.redhat.com/archives/edk2-devel-archive/2023-October/069136.html
https://edk2.groups.io/g/devel/message/109835
~~~
RealTimeClockLib instances are consumed by edk2's
EmbeddedPkg/RealTimeClockRuntimeDxe driver. In its entry point function
InitializeRealTimeClock(), the driver:

(1) calls LibRtcInitialize(),

(2) sets the GetTime(), SetTime(), GetWakeupTime() and SetWakeupTime()
    runtime services to its own similarly-named functions -- where those
    functions wrap the corresponding RealTimeClockLib APIs,

(3) installs EFI_REAL_TIME_CLOCK_ARCH_PROTOCOL with a NULL protocol
    interface.

Steps (2) and (3) conform to PI v1.8 sections II-9.7.2.4 through
II-9.7.2.7.

However, this means that LibRtcInitialize() (of any RealTimeClockLib
instance) should not itself (a) set the GetTime(), SetTime(),
GetWakeupTime() and SetWakeupTime() runtime services, nor (b) install
EFI_REAL_TIME_CLOCK_ARCH_PROTOCOL. The runtime service pointers will be
overwritten in step (2) anyway, and step (3) will uselessly install a
second (NULL-interface) EFI_REAL_TIME_CLOCK_ARCH_PROTOCOL instance in the
protocol database. (The protocol only serves to notify the DXE Foundation
about said runtime services being available.)

Clean up ArmPlatformPkg/PL031RealTimeClockLib accordingly (it only has
code that's redundant for step (3); it does not try to set "gRT" fields).

(Note that the lib instance INF file already does not list
gEfiRealTimeClockArchProtocolGuid.)

Tested with ArmVirtQemu.

Cc: Ard Biesheuvel [<ardb+tianocore@kernel.org>](mailto:ardb+tianocore@kernel.org)
Cc: Leif Lindholm [<quic_llindhol@quicinc.com>](mailto:quic_llindhol@quicinc.com)
Ref: https://bugzilla.tianocore.org/show_bug.cgi?id=4565
Signed-off-by: Laszlo Ersek [<lersek@redhat.com>](mailto:lersek@redhat.com)
---

Notes:
    context:-W

 ArmPlatformPkg/Library/PL031RealTimeClockLib/PL031RealTimeClockLib.c | 13 -------------
 1 file changed, 13 deletions(-)
~~~