### PR TITLE
OvmfPkg/BaseMemEncryptTdxLib: Handle retry result of MapGPA 

### DIFF
--- a/OvmfPkg/Library/BaseMemEncryptTdxLib/BaseMemEncryptTdxLib.inf
+++ b/OvmfPkg/Library/BaseMemEncryptTdxLib/BaseMemEncryptTdxLib.inf
@@ -30,6 +30,7 @@
 [Sources]
   VirtualMemory.h
   MemoryEncryption.c
+  X64/TdVmCallMapGPA.nasm
 
 [LibraryClasses]
   BaseLib

--- a/OvmfPkg/Library/BaseMemEncryptTdxLib/MemoryEncryption.c
+++ b/OvmfPkg/Library/BaseMemEncryptTdxLib/MemoryEncryption.c
@@ -39,6 +39,25 @@ typedef enum {
 STATIC PAGE_TABLE_POOL  *mPageTablePool = NULL;
 
 /**
+  This function is used to help request the host VMM to map a GPA range as
+  private or shared-memory mappings.
+  @param[in]     Address     4K aligned start GPA of address range.
+  @param[in]     Length      Size of GPA region to be mapped.
+  @param[in,out] Results     Returned result of the GPA at which MapGPA failed
+
+  @return 0               A successful mapping
+  @return Other           Some errors occurred while mapping
+**/
+
+UINTN
+EFIAPI
+TdVmCallMapGPA (
+  IN UINT64    Address,
+  IN UINT64    Length,
+  IN OUT VOID  *Results
+  );
+
+/**
   Returns boolean to indicate whether to indicate which, if any, memory encryption is enabled
 
   @param[in]  Type          Bitmask of encryption technologies to check is enabled

--- a/OvmfPkg/Library/BaseMemEncryptTdxLib/X64/TdVmCallMapGPA.nasm
+++ b/OvmfPkg/Library/BaseMemEncryptTdxLib/X64/TdVmCallMapGPA.nasm
@@ -1,0 +1,130 @@
+;------------------------------------------------------------------------------
+;*
+;* Copyright (c) 2020 - 2021, Intel Corporation. All rights reserved.<BR>
+;* SPDX-License-Identifier: BSD-2-Clause-Patent
+;*
+;*
+;------------------------------------------------------------------------------
+
+DEFAULT REL
+SECTION .text
+
+%define TDVMCALL_EXPOSE_REGS_MASK       0xffec
+%define TDVMCALL                        0x0
+%define TDVMCALL_MAPGPA                 0x10001
+%define TDVMCALL_STATUS_RETRY           0x1
+
+%macro tdcall 0
+    db 0x66,0x0f,0x01,0xcc
+%endmacro
+
+%macro tdcall_push_regs 0
+    push rbp
+    mov  rbp, rsp
+    push r15
+    push r14
+    push r13
+    push r12
+    push rbx
+    push rsi
+    push rdi
+%endmacro
+
+%macro tdcall_pop_regs 0
+    pop rdi
+    pop rsi
+    pop rbx
+    pop r12
+    pop r13
+    pop r14
+    pop r15
+    pop rbp
+%endmacro
+
+%macro tdcall_regs_preamble 2
+    mov rax, %1
+
+    xor rcx, rcx
+    mov ecx, %2
+
+    ; R10 = 0 (standard TDVMCALL)
+
+    xor r10d, r10d
+
+    ; Zero out unused (for standard TDVMCALL) registers to avoid leaking
+    ; secrets to the VMM.
+
+    xor ebx, ebx
+    xor esi, esi
+    xor edi, edi
+
+    xor edx, edx
+    xor ebp, ebp
+    xor r8d, r8d
+    xor r9d, r9d
+%endmacro
+
+%macro tdcall_regs_postamble 0
+    xor ebx, ebx
+    xor esi, esi
+    xor edi, edi
+
+    xor ecx, ecx
+    xor edx, edx
+    xor r8d,  r8d
+    xor r9d,  r9d
+    xor r10d, r10d
+    xor r11d, r11d
+%endmacro
+
+;------------------------------------------------------------------------------
+; 0   => RAX = TDCALL leaf
+; M   => RCX = TDVMCALL register behavior
+; 1   => R10 = standard vs. vendor
+; 0xa => R11 = TDVMCALL function / MapGPA
+; RCX => R12 = p1
+; RDX => R13 = p2
+
+;  UINT64
+;  EFIAPI
+;  TdVmCallMapGPA (
+;    UINT64  Address,  // Rcx
+;    UINT64  Length,   // Rdx
+;    UINT64  *Results  // r8
+;    )
+global ASM_PFX(TdVmCallMapGPA)
+ASM_PFX(TdVmCallMapGPA):
+       tdcall_push_regs
+
+       mov r11, TDVMCALL_MAPGPA
+       mov r12, rcx
+       mov r13, rdx
+
+       push r8
+
+       tdcall_regs_preamble TDVMCALL, TDVMCALL_EXPOSE_REGS_MASK
+
+       tdcall
+
+       ; ignore return dataif TDCALL reports failure.
+       test rax, rax
+       jnz .no_return_data
+
+       ; Propagate TDVMCALL success/failure to return value.
+       mov rax, r10
+
+       ; Retrieve the Val pointer.
+       pop r8
+       test r8, r8
+       jz .no_return_data
+
+       ; On Retry, propagate TDVMCALL output value to output param
+       cmp  rax, TDVMCALL_STATUS_RETRY
+       jnz .no_return_data
+       mov [r8], r11
+.no_return_data:
+       tdcall_regs_postamble
+
+       tdcall_pop_regs
+
+       ret


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4572

According to section 3.2 of the [GHCI] documentation, if the result is "TDG.VP.VMCALL_RETRY" for TDG.VP.VMCALL<MapGPA>, TD must retry the mapping for the pages in the region starting at the GPA specified in r11. 

Currently, TDVF does not properly handle the retry results of MapGPA. For this, TDVF should add the API to return the value in R11 and must retry the mapping for the pages by the value.

How to verify the retry for MapGPA in TDVF:
Note: Since the range size of MapGPA in QEMU is limited to 64MB and TDVF always maps 1.5GB( 2GB~3.5GB) MMIO to shared-memory for TD guest, the retry action is triggered always.
Pre-Config:
QEMU: 
 https://github.com/intel/qemu-tdx/tree/tdx-qemu-upstream | tag: tdx-qemu-upstream-2023.10.20-v8.1.0
KERNEL:
https://github.com/intel/tdx/tree/kvm-upstream-2023.10.16-v6.6-rc2

Step:
 Boot with TD guest and check the log with TdVmcall(MAPGPA) . Would See the line as below:
TdxDxe:SetMemorySharedOrPrivate: Cr3Base=0x0 Physical=0x80000000 Length=0x60000000 Mode=Shared
SetOrClearSharedBit: TdVmcall(MAPGPA) Retry PhysicalAddress is 8000080000000, MapGpaRetryaddr is 8000084000000

Reference:
[GHCI]: TDX Guest-Host-Communication Interface v1.0
https://cdrdv2.intel.com/v1/dl/getContent/726790

Cc: Erdem Aktas <erdemaktas@google.com>
Cc: James Bottomley <jejb@linux.ibm.com>
Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Min Xu <min.m.xu@intel.com>
Cc: Tom Lendacky <thomas.lendacky@amd.com>
Cc: Michael Roth <michael.roth@amd.com>
Cc: Gerd Hoffmann <kraxel@redhat.com>
Signed-off-by: Ceping Sun <cepingx.sun@intel.com>
