### PR TITLE
[Patch V3] UefiCpuPkg/MpInitLib: Wait for all APs to finish initialization -- push

### DIFF
--- a/UefiCpuPkg/Library/MpInitLib/MpLib.c
+++ b/UefiCpuPkg/Library/MpInitLib/MpLib.c
@@ -913,8 +913,8 @@ DxeApEntryPoint (
   UINTN  ProcessorNumber;
 
   GetProcessorNumber (CpuMpData, &ProcessorNumber);
-  InterlockedIncrement ((UINT32 *)&CpuMpData->FinishedCount);
   RestoreVolatileRegisters (&CpuMpData->CpuData[0].VolatileRegisters, FALSE);
+  InterlockedIncrement ((UINT32 *)&CpuMpData->FinishedCount);
   PlaceAPInMwaitLoopOrRunLoop (
     CpuMpData->ApLoopMode,
     CpuMpData->CpuData[ProcessorNumber].StartupApSignal,
@@ -2201,7 +2201,12 @@ MpInitLibInitialize (
       // looping process there.
       //
       SwitchApContext (MpHandOff);
-      ASSERT (CpuMpData->FinishedCount == (CpuMpData->CpuCount - 1));
+      //
+      // Wait for all APs finished initialization
+      //
+      while (CpuMpData->FinishedCount < (CpuMpData->CpuCount - 1)) {
+        CpuPause ();
+      }
 
       //
       // Set Apstate as Idle, otherwise Aps cannot be waken-up again.


### PR DESCRIPTION
https://edk2.groups.io/g/devel/message/110052
https://listman.redhat.com/archives/edk2-devel-archive/2023-October/069353.html
http://mid.mail-archive.com/20231025114216.2824-1-yuanhao.xie@intel.com
~~~
Aim:
- To solve the assertion that checks if CpuMpData->FinishedCount
equals (CpuMpData->CpuCount - 1). The assertion arises from a timing
discrepancy between the BSP's completion of startup signal checks and
the APs' incrementation of the FinishedCount.
- This patch also ensures that "finished" reporting from the APs is as
later as possible.

More specifially:

In the SwitchApContext() function, the BSP trigers
the startup signal and check whether the APs have received it. After
completing this check, the BSP then verifies if the FinishedCount is
equal to CpuCount-1.

On the AP side, upon receiving the startup signal, they invoke
SwitchContextPerAp() and increase the FinishedCount to indicate their
activation. However, even when all APs have received the startup signal,
they might not have finished incrementing the FinishedCount. This timing
gap results in the triggering of the assertion.

Solution:
Instead of assertion, use while loop to waits until all the APs have
incremented the FinishedCount.

Fixes: 964a4f032dcd

Signed-off-by: Yuanhao Xie [<yuanhao.xie@intel.com>](mailto:yuanhao.xie@intel.com)
Cc: Ray Ni [<ray.ni@intel.com>](mailto:ray.ni@intel.com)
Cc: Eric Dong [<eric.dong@intel.com>](mailto:eric.dong@intel.com)
Cc: Rahul Kumar [<rahul1.kumar@intel.com>](mailto:rahul1.kumar@intel.com)
Cc: Tom Lendacky [<thomas.lendacky@amd.com>](mailto:thomas.lendacky@amd.com)
---
 UefiCpuPkg/Library/MpInitLib/MpLib.c | 9 +++++++--
 1 file changed, 7 insertions(+), 2 deletions(-)
~~~