### PR TITLE
[PATCH 0/9] ArmVirtPkg: support two PL011 UARTs -- push

### DIFF
--- a/ArmVirtPkg/ArmVirt.dsc.inc
+++ b/ArmVirtPkg/ArmVirt.dsc.inc
@@ -37,7 +37,7 @@
 !if $(TARGET) == RELEASE
   DebugLib|MdePkg/Library/BaseDebugLibNull/BaseDebugLibNull.inf
 !else
-  DebugLib|MdePkg/Library/BaseDebugLibSerialPort/BaseDebugLibSerialPort.inf
+  DebugLib|ArmVirtPkg/Library/DebugLibFdtPL011Uart/DebugLibFdtPL011UartRam.inf
 !endif
   DebugPrintErrorLevelLib|MdePkg/Library/BaseDebugPrintErrorLevelLib/BaseDebugPrintErrorLevelLib.inf
 
@@ -189,6 +189,9 @@
   PeiServicesLib|MdePkg/Library/PeiServicesLib/PeiServicesLib.inf
   PeiServicesTablePointerLib|ArmPkg/Library/PeiServicesTablePointerLib/PeiServicesTablePointerLib.inf
   MemoryAllocationLib|MdePkg/Library/PeiMemoryAllocationLib/PeiMemoryAllocationLib.inf
+!if $(TARGET) != RELEASE
+  DebugLib|ArmVirtPkg/Library/DebugLibFdtPL011Uart/DebugLibFdtPL011UartFlash.inf
+!endif
 
 [LibraryClasses.common.PEI_CORE]
   PcdLib|MdePkg/Library/PeiPcdLib/PeiPcdLib.inf
@@ -204,6 +207,9 @@
 
   PeiServicesTablePointerLib|ArmPkg/Library/PeiServicesTablePointerLib/PeiServicesTablePointerLib.inf
   SerialPortLib|ArmVirtPkg/Library/FdtPL011SerialPortLib/EarlyFdtPL011SerialPortLib.inf
+!if $(TARGET) != RELEASE
+  DebugLib|ArmVirtPkg/Library/DebugLibFdtPL011Uart/DebugLibFdtPL011UartFlash.inf
+!endif
 
 [LibraryClasses.common.PEIM]
   PcdLib|MdePkg/Library/PeiPcdLib/PeiPcdLib.inf
@@ -219,6 +225,9 @@
 
   PeiServicesTablePointerLib|ArmPkg/Library/PeiServicesTablePointerLib/PeiServicesTablePointerLib.inf
   SerialPortLib|ArmVirtPkg/Library/FdtPL011SerialPortLib/EarlyFdtPL011SerialPortLib.inf
+!if $(TARGET) != RELEASE
+  DebugLib|ArmVirtPkg/Library/DebugLibFdtPL011Uart/DebugLibFdtPL011UartFlash.inf
+!endif
 
 [LibraryClasses.common.DXE_CORE]
   HobLib|MdePkg/Library/DxeCoreHobLib/DxeCoreHobLib.inf
@@ -246,7 +255,7 @@
   MemoryAllocationLib|MdePkg/Library/UefiMemoryAllocationLib/UefiMemoryAllocationLib.inf
   CapsuleLib|MdeModulePkg/Library/DxeCapsuleLibNull/DxeCapsuleLibNull.inf
 !if $(TARGET) != RELEASE
-  DebugLib|MdePkg/Library/DxeRuntimeDebugLibSerialPort/DxeRuntimeDebugLibSerialPort.inf
+  DebugLib|ArmVirtPkg/Library/DebugLibFdtPL011Uart/DxeRuntimeDebugLibFdtPL011Uart.inf
 !endif
   VariablePolicyLib|MdeModulePkg/Library/VariablePolicyLib/VariablePolicyLibRuntimeDxe.inf
 

--- a/ArmVirtPkg/ArmVirt.dsc.inc
+++ b/ArmVirtPkg/ArmVirt.dsc.inc
@@ -121,6 +121,7 @@
   # ARM PL011 UART Driver
   PL011UartLib|ArmPlatformPkg/Library/PL011UartLib/PL011UartLib.inf
   SerialPortLib|ArmVirtPkg/Library/FdtPL011SerialPortLib/FdtPL011SerialPortLib.inf
+  FdtSerialPortAddressLib|ArmVirtPkg/Library/FdtSerialPortAddressLib/FdtSerialPortAddressLib.inf
 
   PeCoffExtraActionLib|ArmPkg/Library/DebugPeCoffExtraActionLib/DebugPeCoffExtraActionLib.inf
   #PeCoffExtraActionLib|MdePkg/Library/BasePeCoffExtraActionLibNull/BasePeCoffExtraActionLibNull.inf

--- a/ArmVirtPkg/ArmVirtKvmTool.dsc
+++ b/ArmVirtPkg/ArmVirtKvmTool.dsc
@@ -77,6 +77,9 @@
   PciExpressLib|MdePkg/Library/BasePciExpressLib/BasePciExpressLib.inf
   PlatformHookLib|ArmVirtPkg/Library/Fdt16550SerialPortHookLib/Fdt16550SerialPortHookLib.inf
   SerialPortLib|MdeModulePkg/Library/BaseSerialPortLib16550/BaseSerialPortLib16550.inf
+!if $(TARGET) != RELEASE
+  DebugLib|MdePkg/Library/BaseDebugLibSerialPort/BaseDebugLibSerialPort.inf
+!endif
 
   HwInfoParserLib|DynamicTablesPkg/Library/FdtHwInfoParserLib/FdtHwInfoParserLib.inf
   DynamicPlatRepoLib|DynamicTablesPkg/Library/Common/DynamicPlatRepoLib/DynamicPlatRepoLib.inf
@@ -88,6 +91,14 @@
   PciExpressLib|MdePkg/Library/BasePciExpressLib/BasePciExpressLib.inf
   PlatformHookLib|ArmVirtPkg/Library/Fdt16550SerialPortHookLib/EarlyFdt16550SerialPortHookLib.inf
   SerialPortLib|MdeModulePkg/Library/BaseSerialPortLib16550/BaseSerialPortLib16550.inf
+!if $(TARGET) != RELEASE
+  DebugLib|MdePkg/Library/BaseDebugLibSerialPort/BaseDebugLibSerialPort.inf
+!endif
+
+[LibraryClasses.common.DXE_RUNTIME_DRIVER]
+!if $(TARGET) != RELEASE
+  DebugLib|MdePkg/Library/DxeRuntimeDebugLibSerialPort/DxeRuntimeDebugLibSerialPort.inf
+!endif
 
 [LibraryClasses.common.UEFI_DRIVER]
   UefiScsiLib|MdePkg/Library/UefiScsiLib/UefiScsiLib.inf

--- a/ArmVirtPkg/ArmVirtPkg.dec
+++ b/ArmVirtPkg/ArmVirtPkg.dec
@@ -27,6 +27,7 @@
 
 [LibraryClasses]
   ArmVirtMemInfoLib|Include/Library/ArmVirtMemInfoLib.h
+  FdtSerialPortAddressLib|Include/Library/FdtSerialPortAddressLib.h
 
 [Guids.common]
   gArmVirtTokenSpaceGuid = { 0x0B6F5CA7, 0x4F53, 0x445A, { 0xB7, 0x6E, 0x2E, 0x36, 0x5B, 0x80, 0x63, 0x66 } }

--- a/ArmVirtPkg/ArmVirtXen.dsc
+++ b/ArmVirtPkg/ArmVirtXen.dsc
@@ -29,6 +29,9 @@
 
 [LibraryClasses]
   SerialPortLib|OvmfPkg/Library/XenConsoleSerialPortLib/XenConsoleSerialPortLib.inf
+!if $(TARGET) != RELEASE
+  DebugLib|MdePkg/Library/BaseDebugLibSerialPort/BaseDebugLibSerialPort.inf
+!endif
   RealTimeClockLib|OvmfPkg/Library/XenRealTimeClockLib/XenRealTimeClockLib.inf
   XenHypercallLib|OvmfPkg/Library/XenHypercallLib/XenHypercallLib.inf
 
@@ -51,6 +54,11 @@
   CustomizedDisplayLib|MdeModulePkg/Library/CustomizedDisplayLib/CustomizedDisplayLib.inf
   TpmMeasurementLib|MdeModulePkg/Library/TpmMeasurementLibNull/TpmMeasurementLibNull.inf
   TpmPlatformHierarchyLib|SecurityPkg/Library/PeiDxeTpmPlatformHierarchyLibNull/PeiDxeTpmPlatformHierarchyLib.inf
+
+[LibraryClasses.common.DXE_RUNTIME_DRIVER]
+!if $(TARGET) != RELEASE
+  DebugLib|MdePkg/Library/DxeRuntimeDebugLibSerialPort/DxeRuntimeDebugLibSerialPort.inf
+!endif
 
 [LibraryClasses.common.UEFI_DRIVER]
   UefiScsiLib|MdePkg/Library/UefiScsiLib/UefiScsiLib.inf
@@ -147,6 +155,9 @@
       PrePiHobListPointerLib|ArmPlatformPkg/Library/PrePiHobListPointerLib/PrePiHobListPointerLib.inf
       MemoryAllocationLib|EmbeddedPkg/Library/PrePiMemoryAllocationLib/PrePiMemoryAllocationLib.inf
       SerialPortLib|OvmfPkg/Library/XenConsoleSerialPortLib/XenConsoleSerialPortLib.inf
+!if $(TARGET) != RELEASE
+      DebugLib|MdePkg/Library/BaseDebugLibSerialPort/BaseDebugLibSerialPort.inf
+!endif
   }
 
   #

--- a/ArmVirtPkg/Include/Guid/EarlyPL011BaseAddress.h
+++ b/ArmVirtPkg/Include/Guid/EarlyPL011BaseAddress.h
@@ -1,6 +1,6 @@
 /** @file
-  GUID for the HOB that caches the base address of the PL011 serial port, for
-  when PCD access is not available.
+  GUID for the HOB that caches the base address(es) of the PL011 serial port(s),
+  for when PCD access is not available.
 
   Copyright (C) 2014, Red Hat, Inc.
 
@@ -17,5 +17,16 @@
         }
 
 extern EFI_GUID  gEarlyPL011BaseAddressGuid;
+
+typedef struct {
+  //
+  // for SerialPortLib and console IO
+  //
+  UINT64    ConsoleAddress;
+  //
+  // for DebugLib; may equal ConsoleAddress if there's only one PL011 UART
+  //
+  UINT64    DebugAddress;
+} EARLY_PL011_BASE_ADDRESS;
 
 #endif

--- a/ArmVirtPkg/Include/Library/FdtSerialPortAddressLib.h
+++ b/ArmVirtPkg/Include/Library/FdtSerialPortAddressLib.h
@@ -1,0 +1,83 @@
+/** @file
+  Determine the base addresses of serial ports from the Device Tree.
+
+  Copyright (C) Red Hat
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef FDT_SERIAL_PORT_ADDRESS_LIB_H_
+#define FDT_SERIAL_PORT_ADDRESS_LIB_H_
+
+#include <Base.h>
+
+typedef struct {
+  UINTN     NumberOfPorts;
+  UINT64    BaseAddress[2];
+} FDT_SERIAL_PORTS;
+
+/**
+  Collect the first ARRAY_SIZE (Ports->BaseAddress) serial ports into Ports from
+  DeviceTree.
+
+  @param[in] DeviceTree  The flat device tree (FDT) to scan.
+
+  @param[in] Compatible  Look for Compatible in the "compatible" property of the
+                         scanned nodes.
+
+  @param[out] Ports      On successful return, Ports->NumberOfPorts contains the
+                         number of serial ports found; it is (a) positive and
+                         (b) at most ARRAY_SIZE (Ports->BaseAddress). If the FDT
+                         had more serial ports, those are not reported. On
+                         error, the contents of Ports are indeterminate.
+
+  @retval RETURN_INVALID_PARAMETER  DeviceTree does not point to a valid FDT
+                                    header.
+
+  @retval RETURN_NOT_FOUND          No compatible and enabled serial port has
+                                    been found.
+
+  @retval RETURN_SUCCESS            At least one compatible and enabled serial
+                                    port has been found; Ports has been filled
+                                    in.
+**/
+RETURN_STATUS
+EFIAPI
+FdtSerialGetPorts (
+  IN  CONST VOID        *DeviceTree,
+  IN  CONST CHAR8       *Compatible,
+  OUT FDT_SERIAL_PORTS  *Ports
+  );
+
+/**
+  Fetch the base address of the serial port identified in the "stdout-path"
+  property of the "/chosen" node in DeviceTree.
+
+  @param[in] DeviceTree    The flat device tree (FDT) to scan.
+
+  @param[out] BaseAddress  On success, the base address of the preferred serial
+                           port (to be used as console). On error, BaseAddress
+                           is not modified.
+
+  @retval RETURN_INVALID_PARAMETER  DeviceTree does not point to a valid FDT
+                                    header.
+
+  @retval RETURN_NOT_FOUND          No enabled console port has been found.
+
+  @retval RETURN_PROTOCOL_ERROR     The first (or only) node path in the
+                                    "stdout-path" property is an empty string.
+
+  @retval RETURN_PROTOCOL_ERROR     The console port has been found in the FDT,
+                                    but its base address is not correctly
+                                    represented.
+
+  @retval RETURN_SUCCESS            BaseAddress has been populated.
+**/
+RETURN_STATUS
+EFIAPI
+FdtSerialGetConsolePort (
+  IN  CONST VOID  *DeviceTree,
+  OUT UINT64      *BaseAddress
+  );
+
+#endif

--- a/ArmVirtPkg/Library/DebugLibFdtPL011Uart/DebugLib.c
+++ b/ArmVirtPkg/Library/DebugLibFdtPL011Uart/DebugLib.c
@@ -1,0 +1,355 @@
+/** @file
+  Originally copied from "MdePkg/Library/BaseDebugLibSerialPort/DebugLib.c" at
+  commit f36e1ec1f0a5, and customized for:
+
+  - RAM vs. flash dependent PL011 UART initialization,
+
+  - direct PL011 UART access, with the base address taken from the device tree
+    such that the debug output be separate from the SerialPortLib / UEFI console
+    traffic.
+
+  Both of these customizations are hidden behind DebugLibFdtPL011UartWrite(),
+  which replaces SerialPortWrite().
+
+  Copyright (C) Red Hat
+  Copyright (c) 2006 - 2019, Intel Corporation. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <Base.h>
+#include <Library/DebugLib.h>
+#include <Library/BaseLib.h>
+#include <Library/PrintLib.h>
+#include <Library/PcdLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/DebugPrintErrorLevelLib.h>
+
+#include "Write.h"
+
+//
+// Define the maximum debug and assert message length that this library supports
+//
+#define MAX_DEBUG_MESSAGE_LENGTH  0x100
+
+//
+// VA_LIST can not initialize to NULL for all compiler, so we use this to
+// indicate a null VA_LIST
+//
+VA_LIST  mVaListNull;
+
+/**
+  Prints a debug message to the debug output device if the specified error level is enabled.
+
+  If any bit in ErrorLevel is also set in DebugPrintErrorLevelLib function
+  GetDebugPrintErrorLevel (), then print the message specified by Format and the
+  associated variable argument list to the debug output device.
+
+  If Format is NULL, then ASSERT().
+
+  @param  ErrorLevel  The error level of the debug message.
+  @param  Format      Format string for the debug message to print.
+  @param  ...         Variable argument list whose contents are accessed
+                      based on the format string specified by Format.
+
+**/
+VOID
+EFIAPI
+DebugPrint (
+  IN  UINTN        ErrorLevel,
+  IN  CONST CHAR8  *Format,
+  ...
+  )
+{
+  VA_LIST  Marker;
+
+  VA_START (Marker, Format);
+  DebugVPrint (ErrorLevel, Format, Marker);
+  VA_END (Marker);
+}
+
+/**
+  Prints a debug message to the debug output device if the specified
+  error level is enabled base on Null-terminated format string and a
+  VA_LIST argument list or a BASE_LIST argument list.
+
+  If any bit in ErrorLevel is also set in DebugPrintErrorLevelLib function
+  GetDebugPrintErrorLevel (), then print the message specified by Format and
+  the associated variable argument list to the debug output device.
+
+  If Format is NULL, then ASSERT().
+
+  @param  ErrorLevel      The error level of the debug message.
+  @param  Format          Format string for the debug message to print.
+  @param  VaListMarker    VA_LIST marker for the variable argument list.
+  @param  BaseListMarker  BASE_LIST marker for the variable argument list.
+
+**/
+VOID
+DebugPrintMarker (
+  IN  UINTN        ErrorLevel,
+  IN  CONST CHAR8  *Format,
+  IN  VA_LIST      VaListMarker,
+  IN  BASE_LIST    BaseListMarker
+  )
+{
+  CHAR8  Buffer[MAX_DEBUG_MESSAGE_LENGTH];
+
+  //
+  // If Format is NULL, then ASSERT().
+  //
+  ASSERT (Format != NULL);
+
+  //
+  // Check driver debug mask value and global mask
+  //
+  if ((ErrorLevel & GetDebugPrintErrorLevel ()) == 0) {
+    return;
+  }
+
+  //
+  // Convert the DEBUG() message to an ASCII String
+  //
+  if (BaseListMarker == NULL) {
+    AsciiVSPrint (Buffer, sizeof (Buffer), Format, VaListMarker);
+  } else {
+    AsciiBSPrint (Buffer, sizeof (Buffer), Format, BaseListMarker);
+  }
+
+  //
+  // Send the print string to a Serial Port
+  //
+  DebugLibFdtPL011UartWrite ((UINT8 *)Buffer, AsciiStrLen (Buffer));
+}
+
+/**
+  Prints a debug message to the debug output device if the specified
+  error level is enabled.
+
+  If any bit in ErrorLevel is also set in DebugPrintErrorLevelLib function
+  GetDebugPrintErrorLevel (), then print the message specified by Format and
+  the associated variable argument list to the debug output device.
+
+  If Format is NULL, then ASSERT().
+
+  @param  ErrorLevel    The error level of the debug message.
+  @param  Format        Format string for the debug message to print.
+  @param  VaListMarker  VA_LIST marker for the variable argument list.
+
+**/
+VOID
+EFIAPI
+DebugVPrint (
+  IN  UINTN        ErrorLevel,
+  IN  CONST CHAR8  *Format,
+  IN  VA_LIST      VaListMarker
+  )
+{
+  DebugPrintMarker (ErrorLevel, Format, VaListMarker, NULL);
+}
+
+/**
+  Prints a debug message to the debug output device if the specified
+  error level is enabled.
+  This function use BASE_LIST which would provide a more compatible
+  service than VA_LIST.
+
+  If any bit in ErrorLevel is also set in DebugPrintErrorLevelLib function
+  GetDebugPrintErrorLevel (), then print the message specified by Format and
+  the associated variable argument list to the debug output device.
+
+  If Format is NULL, then ASSERT().
+
+  @param  ErrorLevel      The error level of the debug message.
+  @param  Format          Format string for the debug message to print.
+  @param  BaseListMarker  BASE_LIST marker for the variable argument list.
+
+**/
+VOID
+EFIAPI
+DebugBPrint (
+  IN  UINTN        ErrorLevel,
+  IN  CONST CHAR8  *Format,
+  IN  BASE_LIST    BaseListMarker
+  )
+{
+  DebugPrintMarker (ErrorLevel, Format, mVaListNull, BaseListMarker);
+}
+
+/**
+  Prints an assert message containing a filename, line number, and description.
+  This may be followed by a breakpoint or a dead loop.
+
+  Print a message of the form "ASSERT <FileName>(<LineNumber>): <Description>\n"
+  to the debug output device.  If DEBUG_PROPERTY_ASSERT_BREAKPOINT_ENABLED bit of
+  PcdDebugProperyMask is set then CpuBreakpoint() is called. Otherwise, if
+  DEBUG_PROPERTY_ASSERT_DEADLOOP_ENABLED bit of PcdDebugProperyMask is set then
+  CpuDeadLoop() is called.  If neither of these bits are set, then this function
+  returns immediately after the message is printed to the debug output device.
+  DebugAssert() must actively prevent recursion.  If DebugAssert() is called while
+  processing another DebugAssert(), then DebugAssert() must return immediately.
+
+  If FileName is NULL, then a <FileName> string of "(NULL) Filename" is printed.
+  If Description is NULL, then a <Description> string of "(NULL) Description" is printed.
+
+  @param  FileName     The pointer to the name of the source file that generated the assert condition.
+  @param  LineNumber   The line number in the source file that generated the assert condition
+  @param  Description  The pointer to the description of the assert condition.
+
+**/
+VOID
+EFIAPI
+DebugAssert (
+  IN CONST CHAR8  *FileName,
+  IN UINTN        LineNumber,
+  IN CONST CHAR8  *Description
+  )
+{
+  CHAR8  Buffer[MAX_DEBUG_MESSAGE_LENGTH];
+
+  //
+  // Generate the ASSERT() message in Ascii format
+  //
+  AsciiSPrint (Buffer, sizeof (Buffer), "ASSERT [%a] %a(%d): %a\n", gEfiCallerBaseName, FileName, LineNumber, Description);
+
+  //
+  // Send the print string to the Console Output device
+  //
+  DebugLibFdtPL011UartWrite ((UINT8 *)Buffer, AsciiStrLen (Buffer));
+
+  //
+  // Generate a Breakpoint, DeadLoop, or NOP based on PCD settings
+  //
+  if ((PcdGet8 (PcdDebugPropertyMask) & DEBUG_PROPERTY_ASSERT_BREAKPOINT_ENABLED) != 0) {
+    CpuBreakpoint ();
+  } else if ((PcdGet8 (PcdDebugPropertyMask) & DEBUG_PROPERTY_ASSERT_DEADLOOP_ENABLED) != 0) {
+    CpuDeadLoop ();
+  }
+}
+
+/**
+  Fills a target buffer with PcdDebugClearMemoryValue, and returns the target buffer.
+
+  This function fills Length bytes of Buffer with the value specified by
+  PcdDebugClearMemoryValue, and returns Buffer.
+
+  If Buffer is NULL, then ASSERT().
+  If Length is greater than (MAX_ADDRESS - Buffer + 1), then ASSERT().
+
+  @param   Buffer  The pointer to the target buffer to be filled with PcdDebugClearMemoryValue.
+  @param   Length  The number of bytes in Buffer to fill with zeros PcdDebugClearMemoryValue.
+
+  @return  Buffer  The pointer to the target buffer filled with PcdDebugClearMemoryValue.
+
+**/
+VOID *
+EFIAPI
+DebugClearMemory (
+  OUT VOID  *Buffer,
+  IN UINTN  Length
+  )
+{
+  //
+  // If Buffer is NULL, then ASSERT().
+  //
+  ASSERT (Buffer != NULL);
+
+  //
+  // SetMem() checks for the the ASSERT() condition on Length and returns Buffer
+  //
+  return SetMem (Buffer, Length, PcdGet8 (PcdDebugClearMemoryValue));
+}
+
+/**
+  Returns TRUE if ASSERT() macros are enabled.
+
+  This function returns TRUE if the DEBUG_PROPERTY_DEBUG_ASSERT_ENABLED bit of
+  PcdDebugProperyMask is set.  Otherwise FALSE is returned.
+
+  @retval  TRUE    The DEBUG_PROPERTY_DEBUG_ASSERT_ENABLED bit of PcdDebugProperyMask is set.
+  @retval  FALSE   The DEBUG_PROPERTY_DEBUG_ASSERT_ENABLED bit of PcdDebugProperyMask is clear.
+
+**/
+BOOLEAN
+EFIAPI
+DebugAssertEnabled (
+  VOID
+  )
+{
+  return (BOOLEAN)((PcdGet8 (PcdDebugPropertyMask) & DEBUG_PROPERTY_DEBUG_ASSERT_ENABLED) != 0);
+}
+
+/**
+  Returns TRUE if DEBUG() macros are enabled.
+
+  This function returns TRUE if the DEBUG_PROPERTY_DEBUG_PRINT_ENABLED bit of
+  PcdDebugProperyMask is set.  Otherwise FALSE is returned.
+
+  @retval  TRUE    The DEBUG_PROPERTY_DEBUG_PRINT_ENABLED bit of PcdDebugProperyMask is set.
+  @retval  FALSE   The DEBUG_PROPERTY_DEBUG_PRINT_ENABLED bit of PcdDebugProperyMask is clear.
+
+**/
+BOOLEAN
+EFIAPI
+DebugPrintEnabled (
+  VOID
+  )
+{
+  return (BOOLEAN)((PcdGet8 (PcdDebugPropertyMask) & DEBUG_PROPERTY_DEBUG_PRINT_ENABLED) != 0);
+}
+
+/**
+  Returns TRUE if DEBUG_CODE() macros are enabled.
+
+  This function returns TRUE if the DEBUG_PROPERTY_DEBUG_CODE_ENABLED bit of
+  PcdDebugProperyMask is set.  Otherwise FALSE is returned.
+
+  @retval  TRUE    The DEBUG_PROPERTY_DEBUG_CODE_ENABLED bit of PcdDebugProperyMask is set.
+  @retval  FALSE   The DEBUG_PROPERTY_DEBUG_CODE_ENABLED bit of PcdDebugProperyMask is clear.
+
+**/
+BOOLEAN
+EFIAPI
+DebugCodeEnabled (
+  VOID
+  )
+{
+  return (BOOLEAN)((PcdGet8 (PcdDebugPropertyMask) & DEBUG_PROPERTY_DEBUG_CODE_ENABLED) != 0);
+}
+
+/**
+  Returns TRUE if DEBUG_CLEAR_MEMORY() macro is enabled.
+
+  This function returns TRUE if the DEBUG_PROPERTY_CLEAR_MEMORY_ENABLED bit of
+  PcdDebugProperyMask is set.  Otherwise FALSE is returned.
+
+  @retval  TRUE    The DEBUG_PROPERTY_CLEAR_MEMORY_ENABLED bit of PcdDebugProperyMask is set.
+  @retval  FALSE   The DEBUG_PROPERTY_CLEAR_MEMORY_ENABLED bit of PcdDebugProperyMask is clear.
+
+**/
+BOOLEAN
+EFIAPI
+DebugClearMemoryEnabled (
+  VOID
+  )
+{
+  return (BOOLEAN)((PcdGet8 (PcdDebugPropertyMask) & DEBUG_PROPERTY_CLEAR_MEMORY_ENABLED) != 0);
+}
+
+/**
+  Returns TRUE if any one of the bit is set both in ErrorLevel and PcdFixedDebugPrintErrorLevel.
+
+  This function compares the bit mask of ErrorLevel and PcdFixedDebugPrintErrorLevel.
+
+  @retval  TRUE    Current ErrorLevel is supported.
+  @retval  FALSE   Current ErrorLevel is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+DebugPrintLevelEnabled (
+  IN  CONST UINTN  ErrorLevel
+  )
+{
+  return (BOOLEAN)((ErrorLevel & PcdGet32 (PcdFixedDebugPrintErrorLevel)) != 0);
+}

--- a/ArmVirtPkg/Library/DebugLibFdtPL011Uart/DebugLibFdtPL011UartFlash.inf
+++ b/ArmVirtPkg/Library/DebugLibFdtPL011Uart/DebugLibFdtPL011UartFlash.inf
@@ -1,0 +1,54 @@
+## @file
+# DebugLib instance that produces debug output directly via PL011UartLib.
+#
+# If there are at least two PL011 UARTs in the device tree, and the /chosen
+# node's "stdout-path" property references one PL011 UART, then both raw
+# SerialPortLib IO, and -- via SerialDxe -- UEFI console IO, will occur on that
+# UART; and this DebugLib instance will produce output on a *different* UART.
+#
+# This instance is suitable for modules that may run from flash or RAM.
+#
+# Copyright (C) Red Hat
+#
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION    = 1.27
+  BASE_NAME      = DebugLibFdtPL011UartFlash
+  FILE_GUID      = 43A4C56B-D071-4CE0-A157-9D59E6161DEC
+  MODULE_TYPE    = BASE
+  VERSION_STRING = 1.0
+  LIBRARY_CLASS  = DebugLib|SEC PEI_CORE PEIM
+
+[Sources]
+  DebugLib.c
+  Flash.c
+  Write.h
+
+[Packages]
+  ArmPlatformPkg/ArmPlatformPkg.dec
+  ArmVirtPkg/ArmVirtPkg.dec
+  MdePkg/MdePkg.dec
+
+[LibraryClasses]
+  BaseLib
+  BaseMemoryLib
+  DebugPrintErrorLevelLib
+  FdtSerialPortAddressLib # Flash.c
+  PL011UartLib
+  PcdLib
+  PrintLib
+
+[Pcd]
+  gArmVirtTokenSpaceGuid.PcdDeviceTreeInitialBaseAddress # Flash.c
+  gEfiMdePkgTokenSpaceGuid.PcdDebugClearMemoryValue
+  gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask
+  gEfiMdePkgTokenSpaceGuid.PcdFixedDebugPrintErrorLevel
+
+[FixedPcd]
+  gArmPlatformTokenSpaceGuid.PL011UartClkInHz
+  gEfiMdePkgTokenSpaceGuid.PcdUartDefaultBaudRate
+  gEfiMdePkgTokenSpaceGuid.PcdUartDefaultDataBits
+  gEfiMdePkgTokenSpaceGuid.PcdUartDefaultParity
+  gEfiMdePkgTokenSpaceGuid.PcdUartDefaultStopBits

--- a/ArmVirtPkg/Library/DebugLibFdtPL011Uart/DebugLibFdtPL011UartRam.inf
+++ b/ArmVirtPkg/Library/DebugLibFdtPL011Uart/DebugLibFdtPL011UartRam.inf
@@ -1,0 +1,60 @@
+## @file
+# DebugLib instance that produces debug output directly via PL011UartLib.
+#
+# If there are at least two PL011 UARTs in the device tree, and the /chosen
+# node's "stdout-path" property references one PL011 UART, then both raw
+# SerialPortLib IO, and -- via SerialDxe -- UEFI console IO, will occur on that
+# UART; and this DebugLib instance will produce output on a *different* UART.
+#
+# This instance is suitable for modules that can only run from RAM (except
+# DXE_RUNTIME_DRIVER).
+#
+# Copyright (C) Red Hat
+#
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION    = 1.27
+  BASE_NAME      = DebugLibFdtPL011UartRam
+  FILE_GUID      = 0584DE55-9C4C-49C1-ADA0-F62C9C1F3600
+  MODULE_TYPE    = BASE
+  VERSION_STRING = 1.0
+  LIBRARY_CLASS  = DebugLib|DXE_CORE SMM_CORE MM_CORE_STANDALONE DXE_DRIVER DXE_SMM_DRIVER SMM_DRIVER MM_STANDALONE UEFI_DRIVER UEFI_APPLICATION
+  CONSTRUCTOR    = DebugLibFdtPL011UartRamConstructor
+
+[Sources]
+  DebugLib.c
+  Ram.c
+  Ram.h
+  RamNonRuntime.c
+  Write.h
+
+[Packages]
+  ArmPlatformPkg/ArmPlatformPkg.dec
+  ArmVirtPkg/ArmVirtPkg.dec
+  MdePkg/MdePkg.dec
+
+[LibraryClasses]
+  BaseLib
+  BaseMemoryLib
+  DebugPrintErrorLevelLib
+  HobLib                  # Ram.c
+  PL011UartLib
+  PcdLib
+  PrintLib
+
+[Pcd]
+  gEfiMdePkgTokenSpaceGuid.PcdDebugClearMemoryValue
+  gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask
+  gEfiMdePkgTokenSpaceGuid.PcdFixedDebugPrintErrorLevel
+
+[FixedPcd]
+  gArmPlatformTokenSpaceGuid.PL011UartClkInHz
+  gEfiMdePkgTokenSpaceGuid.PcdUartDefaultBaudRate
+  gEfiMdePkgTokenSpaceGuid.PcdUartDefaultDataBits
+  gEfiMdePkgTokenSpaceGuid.PcdUartDefaultParity
+  gEfiMdePkgTokenSpaceGuid.PcdUartDefaultStopBits
+
+[Guids]
+  gEarlyPL011BaseAddressGuid # Ram.c

--- a/ArmVirtPkg/Library/DebugLibFdtPL011Uart/DxeRuntimeDebugLibFdtPL011Uart.inf
+++ b/ArmVirtPkg/Library/DebugLibFdtPL011Uart/DxeRuntimeDebugLibFdtPL011Uart.inf
@@ -1,0 +1,61 @@
+## @file
+# DebugLib instance that produces debug output directly via PL011UartLib.
+#
+# If there are at least two PL011 UARTs in the device tree, and the /chosen
+# node's "stdout-path" property references one PL011 UART, then both raw
+# SerialPortLib IO, and -- via SerialDxe -- UEFI console IO, will occur on that
+# UART; and this DebugLib instance will produce output on a *different* UART.
+#
+# This instance is suitable for DXE_RUNTIME_DRIVER modules. When exiting boot
+# services, UART access is stopped.
+#
+# Copyright (C) Red Hat
+#
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION    = 1.27
+  BASE_NAME      = DxeRuntimeDebugLibFdtPL011Uart
+  FILE_GUID      = 8A6E0972-81B5-4FF4-BB24-A07748415947
+  MODULE_TYPE    = DXE_RUNTIME_DRIVER
+  VERSION_STRING = 1.0
+  LIBRARY_CLASS  = DebugLib|DXE_RUNTIME_DRIVER
+  CONSTRUCTOR    = DxeRuntimeDebugLibFdtPL011UartConstructor
+  DESTRUCTOR     = DxeRuntimeDebugLibFdtPL011UartDestructor
+
+[Sources]
+  DebugLib.c
+  Ram.c
+  Ram.h
+  Runtime.c
+  Write.h
+
+[Packages]
+  ArmPlatformPkg/ArmPlatformPkg.dec
+  ArmVirtPkg/ArmVirtPkg.dec
+  MdePkg/MdePkg.dec
+
+[LibraryClasses]
+  BaseLib
+  BaseMemoryLib
+  DebugPrintErrorLevelLib
+  HobLib                  # Ram.c
+  PL011UartLib
+  PcdLib
+  PrintLib
+
+[Pcd]
+  gEfiMdePkgTokenSpaceGuid.PcdDebugClearMemoryValue
+  gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask
+  gEfiMdePkgTokenSpaceGuid.PcdFixedDebugPrintErrorLevel
+
+[FixedPcd]
+  gArmPlatformTokenSpaceGuid.PL011UartClkInHz
+  gEfiMdePkgTokenSpaceGuid.PcdUartDefaultBaudRate
+  gEfiMdePkgTokenSpaceGuid.PcdUartDefaultDataBits
+  gEfiMdePkgTokenSpaceGuid.PcdUartDefaultParity
+  gEfiMdePkgTokenSpaceGuid.PcdUartDefaultStopBits
+
+[Guids]
+  gEarlyPL011BaseAddressGuid # Ram.c

--- a/ArmVirtPkg/Library/DebugLibFdtPL011Uart/Flash.c
+++ b/ArmVirtPkg/Library/DebugLibFdtPL011Uart/Flash.c
@@ -1,0 +1,107 @@
+/** @file
+  Define DebugLibFdtPL011UartWrite() for modules that may run from flash or RAM.
+
+  Copyright (C) Red Hat
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <Library/FdtSerialPortAddressLib.h>
+#include <Library/PL011UartLib.h>
+#include <Library/PcdLib.h>
+
+#include "Write.h"
+
+/**
+  (Copied from SerialPortWrite() in "MdePkg/Include/Library/SerialPortLib.h" at
+  commit c4547aefb3d0, with the Buffer non-nullity assertion removed:)
+
+  Write data from buffer to serial device.
+
+  Writes NumberOfBytes data bytes from Buffer to the serial device.
+  The number of bytes actually written to the serial device is returned.
+  If the return value is less than NumberOfBytes, then the write operation failed.
+  If NumberOfBytes is zero, then return 0.
+
+  @param  Buffer           Pointer to the data buffer to be written.
+  @param  NumberOfBytes    Number of bytes to written to the serial device.
+
+  @retval 0                NumberOfBytes is 0.
+  @retval >0               The number of bytes written to the serial device.
+                           If this value is less than NumberOfBytes, then the write operation failed.
+**/
+UINTN
+DebugLibFdtPL011UartWrite (
+  IN UINT8  *Buffer,
+  IN UINTN  NumberOfBytes
+  )
+{
+  CONST VOID          *DeviceTree;
+  RETURN_STATUS       Status;
+  FDT_SERIAL_PORTS    Ports;
+  UINT64              DebugAddress;
+  UINT64              BaudRate;
+  UINT32              ReceiveFifoDepth;
+  EFI_PARITY_TYPE     Parity;
+  UINT8               DataBits;
+  EFI_STOP_BITS_TYPE  StopBits;
+
+  DeviceTree = (VOID *)(UINTN)PcdGet64 (PcdDeviceTreeInitialBaseAddress);
+  if (DeviceTree == NULL) {
+    return 0;
+  }
+
+  Status = FdtSerialGetPorts (DeviceTree, "arm,pl011", &Ports);
+  if (RETURN_ERROR (Status)) {
+    return 0;
+  }
+
+  if (Ports.NumberOfPorts == 1) {
+    //
+    // Just one UART; direct DebugLib to it.
+    //
+    DebugAddress = Ports.BaseAddress[0];
+  } else {
+    UINT64  ConsoleAddress;
+
+    Status = FdtSerialGetConsolePort (DeviceTree, &ConsoleAddress);
+    if (EFI_ERROR (Status)) {
+      //
+      // At least two UARTs; but failed to get the console preference. Use the
+      // second UART for DebugLib.
+      //
+      DebugAddress = Ports.BaseAddress[1];
+    } else {
+      //
+      // At least two UARTs; and console preference available. Use the first
+      // such UART for DebugLib that *differs* from ConsoleAddress.
+      //
+      if (ConsoleAddress == Ports.BaseAddress[0]) {
+        DebugAddress = Ports.BaseAddress[1];
+      } else {
+        DebugAddress = Ports.BaseAddress[0];
+      }
+    }
+  }
+
+  BaudRate         = (UINTN)FixedPcdGet64 (PcdUartDefaultBaudRate);
+  ReceiveFifoDepth = 0; // Use the default value for Fifo depth
+  Parity           = (EFI_PARITY_TYPE)FixedPcdGet8 (PcdUartDefaultParity);
+  DataBits         = FixedPcdGet8 (PcdUartDefaultDataBits);
+  StopBits         = (EFI_STOP_BITS_TYPE)FixedPcdGet8 (PcdUartDefaultStopBits);
+
+  Status = PL011UartInitializePort (
+             (UINTN)DebugAddress,
+             FixedPcdGet32 (PL011UartClkInHz),
+             &BaudRate,
+             &ReceiveFifoDepth,
+             &Parity,
+             &DataBits,
+             &StopBits
+             );
+  if (RETURN_ERROR (Status)) {
+    return 0;
+  }
+
+  return PL011UartWrite ((UINTN)DebugAddress, Buffer, NumberOfBytes);
+}

--- a/ArmVirtPkg/Library/DebugLibFdtPL011Uart/Ram.c
+++ b/ArmVirtPkg/Library/DebugLibFdtPL011Uart/Ram.c
@@ -1,0 +1,124 @@
+/** @file
+  Define DebugLibFdtPL011UartWrite() for modules that can only run from RAM.
+
+  Copyright (C) Red Hat
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <Uefi/UefiBaseType.h>
+#include <Uefi/UefiMultiPhase.h>
+#include <Pi/PiBootMode.h>
+#include <Pi/PiHob.h>
+#include <Library/HobLib.h>
+#include <Library/PL011UartLib.h>
+#include <Library/PcdLib.h>
+#include <Guid/EarlyPL011BaseAddress.h>
+
+#include "Ram.h"
+#include "Write.h"
+
+UINTN          mDebugLibFdtPL011UartAddress;
+RETURN_STATUS  mDebugLibFdtPL011UartPermanentStatus = RETURN_SUCCESS;
+
+/**
+  Statefully initialize both the library instance and the debug PL011 UART.
+**/
+STATIC
+RETURN_STATUS
+Initialize (
+  VOID
+  )
+{
+  CONST VOID                      *Hob;
+  CONST EARLY_PL011_BASE_ADDRESS  *UartBase;
+  RETURN_STATUS                   Status;
+  UINTN                           DebugAddress;
+  UINT64                          BaudRate;
+  UINT32                          ReceiveFifoDepth;
+  EFI_PARITY_TYPE                 Parity;
+  UINT8                           DataBits;
+  EFI_STOP_BITS_TYPE              StopBits;
+
+  if (mDebugLibFdtPL011UartAddress != 0) {
+    return RETURN_SUCCESS;
+  }
+
+  if (RETURN_ERROR (mDebugLibFdtPL011UartPermanentStatus)) {
+    return mDebugLibFdtPL011UartPermanentStatus;
+  }
+
+  Hob = GetFirstGuidHob (&gEarlyPL011BaseAddressGuid);
+  if ((Hob == NULL) || (GET_GUID_HOB_DATA_SIZE (Hob) != sizeof *UartBase)) {
+    Status = RETURN_NOT_FOUND;
+    goto Failed;
+  }
+
+  UartBase = GET_GUID_HOB_DATA (Hob);
+
+  DebugAddress = (UINTN)UartBase->DebugAddress;
+  if (DebugAddress == 0) {
+    Status = RETURN_NOT_FOUND;
+    goto Failed;
+  }
+
+  BaudRate         = (UINTN)PcdGet64 (PcdUartDefaultBaudRate);
+  ReceiveFifoDepth = 0; // Use the default value for Fifo depth
+  Parity           = (EFI_PARITY_TYPE)PcdGet8 (PcdUartDefaultParity);
+  DataBits         = PcdGet8 (PcdUartDefaultDataBits);
+  StopBits         = (EFI_STOP_BITS_TYPE)PcdGet8 (PcdUartDefaultStopBits);
+
+  Status = PL011UartInitializePort (
+             DebugAddress,
+             FixedPcdGet32 (PL011UartClkInHz),
+             &BaudRate,
+             &ReceiveFifoDepth,
+             &Parity,
+             &DataBits,
+             &StopBits
+             );
+  if (RETURN_ERROR (Status)) {
+    goto Failed;
+  }
+
+  mDebugLibFdtPL011UartAddress = DebugAddress;
+  return RETURN_SUCCESS;
+
+Failed:
+  mDebugLibFdtPL011UartPermanentStatus = Status;
+  return Status;
+}
+
+/**
+  (Copied from SerialPortWrite() in "MdePkg/Include/Library/SerialPortLib.h" at
+  commit c4547aefb3d0, with the Buffer non-nullity assertion removed:)
+
+  Write data from buffer to serial device.
+
+  Writes NumberOfBytes data bytes from Buffer to the serial device.
+  The number of bytes actually written to the serial device is returned.
+  If the return value is less than NumberOfBytes, then the write operation failed.
+  If NumberOfBytes is zero, then return 0.
+
+  @param  Buffer           Pointer to the data buffer to be written.
+  @param  NumberOfBytes    Number of bytes to written to the serial device.
+
+  @retval 0                NumberOfBytes is 0.
+  @retval >0               The number of bytes written to the serial device.
+                           If this value is less than NumberOfBytes, then the write operation failed.
+**/
+UINTN
+DebugLibFdtPL011UartWrite (
+  IN UINT8  *Buffer,
+  IN UINTN  NumberOfBytes
+  )
+{
+  RETURN_STATUS  Status;
+
+  Status = Initialize ();
+  if (RETURN_ERROR (Status)) {
+    return 0;
+  }
+
+  return PL011UartWrite (mDebugLibFdtPL011UartAddress, Buffer, NumberOfBytes);
+}

--- a/ArmVirtPkg/Library/DebugLibFdtPL011Uart/Ram.h
+++ b/ArmVirtPkg/Library/DebugLibFdtPL011Uart/Ram.h
@@ -1,0 +1,18 @@
+/** @file
+  Declare the variables that modules that can only run from RAM use for
+  remembering initialization status.
+
+  Copyright (C) Red Hat
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef DEBUG_LIB_FDT_PL011_UART_RAM_H_
+#define DEBUG_LIB_FDT_PL011_UART_RAM_H_
+
+#include <Base.h>
+
+extern UINTN          mDebugLibFdtPL011UartAddress;
+extern RETURN_STATUS  mDebugLibFdtPL011UartPermanentStatus;
+
+#endif

--- a/ArmVirtPkg/Library/DebugLibFdtPL011Uart/RamNonRuntime.c
+++ b/ArmVirtPkg/Library/DebugLibFdtPL011Uart/RamNonRuntime.c
@@ -1,0 +1,27 @@
+/** @file
+  Provide an empty lib instance constructor for modules that can only run from
+  RAM but are not DXE_RUNTIME_DRIVER modules.
+
+  This ensures that e.g. any HobLib constructor is ordered correctly. (The
+  DXE_CORE calls constructors late, but the DXE_CORE HobLib instance needs no
+  construction anyway.)
+
+  Copyright (C) Red Hat
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <Base.h>
+
+/**
+  Empty library instance constructor, only for ensuring the connectivity of the
+  constructor dependency graph.
+**/
+RETURN_STATUS
+EFIAPI
+DebugLibFdtPL011UartRamConstructor (
+  VOID
+  )
+{
+  return RETURN_SUCCESS;
+}

--- a/ArmVirtPkg/Library/DebugLibFdtPL011Uart/Runtime.c
+++ b/ArmVirtPkg/Library/DebugLibFdtPL011Uart/Runtime.c
@@ -1,0 +1,88 @@
+/** @file
+  Permanently disable the library instance in DXE_RUNTIME_DRIVER modules when
+  exiting boot services.
+
+  Copyright (C) Red Hat
+  Copyright (c) 2006 - 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2018, Linaro, Ltd. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <Uefi/UefiSpec.h>
+
+#include "Ram.h"
+
+STATIC EFI_EVENT  mExitBootServicesEvent;
+
+/**
+  Notification function that is triggered when the boot service
+  ExitBootServices() is called.
+
+  @param[in] Event    Event whose notification function is being invoked. Here,
+                      unused.
+
+  @param[in] Context  The pointer to the notification function's context, which
+                      is implementation-dependent. Here, unused.
+**/
+STATIC
+VOID
+EFIAPI
+ExitBootServicesNotify (
+  IN EFI_EVENT  Event,
+  IN VOID       *Context
+  )
+{
+  mDebugLibFdtPL011UartAddress         = 0;
+  mDebugLibFdtPL011UartPermanentStatus = RETURN_ABORTED;
+}
+
+/**
+  Library instance constructor, registering ExitBootServicesNotify().
+
+  @param[in] ImageHandle  The firmware-allocated handle for the EFI image.
+
+  @param[in] SystemTable  A pointer to the EFI System Table.
+
+  @retval EFI_SUCCESS  The operation completed successfully.
+
+  @return              Error codes propagated from CreateEvent(); the
+                       registration of ExitBootServicesNotify() failed.
+**/
+EFI_STATUS
+EFIAPI
+DxeRuntimeDebugLibFdtPL011UartConstructor (
+  IN EFI_HANDLE        ImageHandle,
+  IN EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  return SystemTable->BootServices->CreateEvent (
+                                      EVT_SIGNAL_EXIT_BOOT_SERVICES,
+                                      TPL_CALLBACK,
+                                      ExitBootServicesNotify,
+                                      NULL /* NotifyContext */,
+                                      &mExitBootServicesEvent
+                                      );
+}
+
+/**
+  Library instance destructor, deregistering ExitBootServicesNotify().
+
+  @param[in] ImageHandle  The firmware-allocated handle for the EFI image.
+
+  @param[in] SystemTable  A pointer to the EFI System Table.
+
+  @retval EFI_SUCCESS  Library instance tear-down complete.
+
+  @return              Error codes propagated from CloseEvent(); the
+                       deregistration of ExitBootServicesNotify() failed.
+**/
+EFI_STATUS
+EFIAPI
+DxeRuntimeDebugLibFdtPL011UartDestructor (
+  IN EFI_HANDLE        ImageHandle,
+  IN EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  return SystemTable->BootServices->CloseEvent (mExitBootServicesEvent);
+}

--- a/ArmVirtPkg/Library/DebugLibFdtPL011Uart/Write.h
+++ b/ArmVirtPkg/Library/DebugLibFdtPL011Uart/Write.h
@@ -1,0 +1,39 @@
+/** @file
+  Declare DebugLibFdtPL011UartWrite(), for abstracting PL011 UART initialization
+  differences between flash- vs. RAM-based modules.
+
+  Copyright (C) Red Hat
+  Copyright (c) 2006 - 2018, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2012 - 2014, ARM Ltd. All rights reserved.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef DEBUG_LIB_FDT_PL011_UART_WRITE_H_
+#define DEBUG_LIB_FDT_PL011_UART_WRITE_H_
+
+/**
+  (Copied from SerialPortWrite() in "MdePkg/Include/Library/SerialPortLib.h" at
+  commit c4547aefb3d0, with the Buffer non-nullity assertion removed:)
+
+  Write data from buffer to serial device.
+
+  Writes NumberOfBytes data bytes from Buffer to the serial device.
+  The number of bytes actually written to the serial device is returned.
+  If the return value is less than NumberOfBytes, then the write operation failed.
+  If NumberOfBytes is zero, then return 0.
+
+  @param  Buffer           Pointer to the data buffer to be written.
+  @param  NumberOfBytes    Number of bytes to written to the serial device.
+
+  @retval 0                NumberOfBytes is 0.
+  @retval >0               The number of bytes written to the serial device.
+                           If this value is less than NumberOfBytes, then the write operation failed.
+**/
+UINTN
+DebugLibFdtPL011UartWrite (
+  IN UINT8  *Buffer,
+  IN UINTN  NumberOfBytes
+  );
+
+#endif

--- a/ArmVirtPkg/Library/Fdt16550SerialPortHookLib/EarlyFdt16550SerialPortHookLib.c
+++ b/ArmVirtPkg/Library/Fdt16550SerialPortHookLib/EarlyFdt16550SerialPortHookLib.c
@@ -17,90 +17,7 @@
 #include <Library/HobLib.h>
 #include <Library/PcdLib.h>
 #include <Library/PlatformHookLib.h>
-#include <libfdt.h>
-
-/** Get the UART base address of the console serial-port from the DT.
-
-  This function fetches the node referenced in the "stdout-path"
-  property of the "chosen" node and returns the base address of
-  the console UART.
-
-  @param [in]   Fdt                   Pointer to a Flattened Device Tree (Fdt).
-  @param [out]  SerialConsoleAddress  If success, contains the base address
-                                      of the console serial-port.
-
-  @retval EFI_SUCCESS             The function completed successfully.
-  @retval EFI_NOT_FOUND           Console serial-port info not found in DT.
-  @retval EFI_INVALID_PARAMETER   Invalid parameter.
-**/
-STATIC
-EFI_STATUS
-EFIAPI
-GetSerialConsolePortAddress (
-  IN  CONST VOID    *Fdt,
-  OUT       UINT64  *SerialConsoleAddress
-  )
-{
-  CONST CHAR8   *Prop;
-  INT32         PropSize;
-  CONST CHAR8   *Path;
-  INT32         PathLen;
-  INT32         ChosenNode;
-  INT32         SerialConsoleNode;
-  INT32         Len;
-  CONST CHAR8   *NodeStatus;
-  CONST UINT64  *RegProperty;
-
-  if ((Fdt == NULL) || (fdt_check_header (Fdt) != 0)) {
-    return EFI_INVALID_PARAMETER;
-  }
-
-  // The "chosen" node resides at the root of the DT. Fetch it.
-  ChosenNode = fdt_path_offset (Fdt, "/chosen");
-  if (ChosenNode < 0) {
-    return EFI_NOT_FOUND;
-  }
-
-  Prop = fdt_getprop (Fdt, ChosenNode, "stdout-path", &PropSize);
-  if (PropSize < 0) {
-    return EFI_NOT_FOUND;
-  }
-
-  // Determine the actual path length, as a colon terminates the path.
-  Path = ScanMem8 (Prop, PropSize, ':');
-  if (Path == NULL) {
-    PathLen = AsciiStrLen (Prop);
-  } else {
-    PathLen = Path - Prop;
-  }
-
-  // Aliases cannot start with a '/', so it must be the actual path.
-  if (Prop[0] == '/') {
-    SerialConsoleNode = fdt_path_offset_namelen (Fdt, Prop, PathLen);
-  } else {
-    // Lookup the alias, as this contains the actual path.
-    Path = fdt_get_alias_namelen (Fdt, Prop, PathLen);
-    if (Path == NULL) {
-      return EFI_NOT_FOUND;
-    }
-
-    SerialConsoleNode = fdt_path_offset (Fdt, Path);
-  }
-
-  NodeStatus = fdt_getprop (Fdt, SerialConsoleNode, "status", &Len);
-  if ((NodeStatus != NULL) && (AsciiStrCmp (NodeStatus, "okay") != 0)) {
-    return EFI_NOT_FOUND;
-  }
-
-  RegProperty = fdt_getprop (Fdt, SerialConsoleNode, "reg", &Len);
-  if (Len != 16) {
-    return EFI_INVALID_PARAMETER;
-  }
-
-  *SerialConsoleAddress = fdt64_to_cpu (ReadUnaligned64 (RegProperty));
-
-  return EFI_SUCCESS;
-}
+#include <Library/FdtSerialPortAddressLib.h>
 
 /** Platform hook to retrieve the 16550 UART base address from the platform
     Device tree and store it in PcdSerialRegisterBase.
@@ -108,6 +25,7 @@ GetSerialConsolePortAddress (
   @retval RETURN_SUCCESS            Success.
   @retval RETURN_INVALID_PARAMETER  A parameter was invalid.
   @retval RETURN_NOT_FOUND          Serial port information not found.
+  @retval RETURN_PROTOCOL_ERROR     Invalid information in the Device Tree.
 
 **/
 RETURN_STATUS
@@ -129,7 +47,7 @@ PlatformHookSerialPortInitialize (
     return RETURN_NOT_FOUND;
   }
 
-  Status = GetSerialConsolePortAddress (DeviceTreeBase, &SerialConsoleAddress);
+  Status = FdtSerialGetConsolePort (DeviceTreeBase, &SerialConsoleAddress);
   if (RETURN_ERROR (Status)) {
     return Status;
   }

--- a/ArmVirtPkg/Library/Fdt16550SerialPortHookLib/EarlyFdt16550SerialPortHookLib.inf
+++ b/ArmVirtPkg/Library/Fdt16550SerialPortHookLib/EarlyFdt16550SerialPortHookLib.inf
@@ -22,12 +22,11 @@
 [LibraryClasses]
   BaseLib
   PcdLib
-  FdtLib
+  FdtSerialPortAddressLib
   HobLib
 
 [Packages]
   ArmVirtPkg/ArmVirtPkg.dec
-  EmbeddedPkg/EmbeddedPkg.dec
   MdeModulePkg/MdeModulePkg.dec
   MdePkg/MdePkg.dec
 

--- a/ArmVirtPkg/Library/FdtPL011SerialPortLib/EarlyFdtPL011SerialPortLib.c
+++ b/ArmVirtPkg/Library/FdtPL011SerialPortLib/EarlyFdtPL011SerialPortLib.c
@@ -15,7 +15,7 @@
 #include <Library/PcdLib.h>
 #include <Library/PL011UartLib.h>
 #include <Library/SerialPortLib.h>
-#include <libfdt.h>
+#include <Library/FdtSerialPortAddressLib.h>
 
 RETURN_STATUS
 EFIAPI
@@ -56,74 +56,48 @@ SerialPortGetBaseAddress (
   UINT8               DataBits;
   EFI_STOP_BITS_TYPE  StopBits;
   VOID                *DeviceTreeBase;
-  INT32               Node, Prev;
-  INT32               Len;
-  CONST CHAR8         *Compatible;
-  CONST CHAR8         *NodeStatus;
-  CONST CHAR8         *CompatibleItem;
-  CONST UINT64        *RegProperty;
-  UINTN               UartBase;
+  FDT_SERIAL_PORTS    Ports;
+  UINT64              UartBase;
   RETURN_STATUS       Status;
 
   DeviceTreeBase = (VOID *)(UINTN)PcdGet64 (PcdDeviceTreeInitialBaseAddress);
 
-  if ((DeviceTreeBase == NULL) || (fdt_check_header (DeviceTreeBase) != 0)) {
+  if (DeviceTreeBase == NULL) {
+    return 0;
+  }
+
+  Status = FdtSerialGetPorts (DeviceTreeBase, "arm,pl011", &Ports);
+  if (RETURN_ERROR (Status)) {
     return 0;
   }
 
   //
-  // Enumerate all FDT nodes looking for a PL011 and capture its base address
+  // Default to the first port found, but (if there are multiple ports) allow
+  // the "/chosen" node to override it. Note that if FdtSerialGetConsolePort()
+  // fails, it does not modify UartBase.
   //
-  for (Prev = 0; ; Prev = Node) {
-    Node = fdt_next_node (DeviceTreeBase, Prev, NULL);
-    if (Node < 0) {
-      break;
-    }
+  UartBase = Ports.BaseAddress[0];
+  if (Ports.NumberOfPorts > 1) {
+    FdtSerialGetConsolePort (DeviceTreeBase, &UartBase);
+  }
 
-    Compatible = fdt_getprop (DeviceTreeBase, Node, "compatible", &Len);
-    if (Compatible == NULL) {
-      continue;
-    }
+  BaudRate         = (UINTN)FixedPcdGet64 (PcdUartDefaultBaudRate);
+  ReceiveFifoDepth = 0; // Use the default value for Fifo depth
+  Parity           = (EFI_PARITY_TYPE)FixedPcdGet8 (PcdUartDefaultParity);
+  DataBits         = FixedPcdGet8 (PcdUartDefaultDataBits);
+  StopBits         = (EFI_STOP_BITS_TYPE)FixedPcdGet8 (PcdUartDefaultStopBits);
 
-    //
-    // Iterate over the NULL-separated items in the compatible string
-    //
-    for (CompatibleItem = Compatible; CompatibleItem < Compatible + Len;
-         CompatibleItem += 1 + AsciiStrLen (CompatibleItem))
-    {
-      if (AsciiStrCmp (CompatibleItem, "arm,pl011") == 0) {
-        NodeStatus = fdt_getprop (DeviceTreeBase, Node, "status", &Len);
-        if ((NodeStatus != NULL) && (AsciiStrCmp (NodeStatus, "okay") != 0)) {
-          continue;
-        }
-
-        RegProperty = fdt_getprop (DeviceTreeBase, Node, "reg", &Len);
-        if (Len != 16) {
-          return 0;
-        }
-
-        UartBase = (UINTN)fdt64_to_cpu (ReadUnaligned64 (RegProperty));
-
-        BaudRate         = (UINTN)FixedPcdGet64 (PcdUartDefaultBaudRate);
-        ReceiveFifoDepth = 0; // Use the default value for Fifo depth
-        Parity           = (EFI_PARITY_TYPE)FixedPcdGet8 (PcdUartDefaultParity);
-        DataBits         = FixedPcdGet8 (PcdUartDefaultDataBits);
-        StopBits         = (EFI_STOP_BITS_TYPE)FixedPcdGet8 (PcdUartDefaultStopBits);
-
-        Status = PL011UartInitializePort (
-                   UartBase,
-                   FixedPcdGet32 (PL011UartClkInHz),
-                   &BaudRate,
-                   &ReceiveFifoDepth,
-                   &Parity,
-                   &DataBits,
-                   &StopBits
-                   );
-        if (!EFI_ERROR (Status)) {
-          return UartBase;
-        }
-      }
-    }
+  Status = PL011UartInitializePort (
+             UartBase,
+             FixedPcdGet32 (PL011UartClkInHz),
+             &BaudRate,
+             &ReceiveFifoDepth,
+             &Parity,
+             &DataBits,
+             &StopBits
+             );
+  if (!RETURN_ERROR (Status)) {
+    return UartBase;
   }
 
   return 0;

--- a/ArmVirtPkg/Library/FdtPL011SerialPortLib/EarlyFdtPL011SerialPortLib.inf
+++ b/ArmVirtPkg/Library/FdtPL011SerialPortLib/EarlyFdtPL011SerialPortLib.inf
@@ -22,11 +22,10 @@
 [LibraryClasses]
   PL011UartLib
   PcdLib
-  FdtLib
+  FdtSerialPortAddressLib
 
 [Packages]
   MdePkg/MdePkg.dec
-  EmbeddedPkg/EmbeddedPkg.dec
   ArmPlatformPkg/ArmPlatformPkg.dec
   ArmVirtPkg/ArmVirtPkg.dec
 

--- a/ArmVirtPkg/Library/FdtPL011SerialPortLib/FdtPL011SerialPortLib.c
+++ b/ArmVirtPkg/Library/FdtPL011SerialPortLib/FdtPL011SerialPortLib.c
@@ -46,7 +46,7 @@ SerialPortInitialize (
 {
   VOID                            *Hob;
   RETURN_STATUS                   Status;
-  CONST UINT64                    *UartBase;
+  CONST EARLY_PL011_BASE_ADDRESS  *UartBase;
   UINTN                           SerialBaseAddress;
   UINT64                          BaudRate;
   UINT32                          ReceiveFifoDepth;
@@ -70,7 +70,7 @@ SerialPortInitialize (
 
   UartBase = GET_GUID_HOB_DATA (Hob);
 
-  SerialBaseAddress = (UINTN)*UartBase;
+  SerialBaseAddress = (UINTN)UartBase->ConsoleAddress;
   if (SerialBaseAddress == 0) {
     Status = RETURN_NOT_FOUND;
     goto Failed;

--- a/ArmVirtPkg/Library/FdtPL011SerialPortLib/FdtPL011SerialPortLib.c
+++ b/ArmVirtPkg/Library/FdtPL011SerialPortLib/FdtPL011SerialPortLib.c
@@ -44,15 +44,15 @@ SerialPortInitialize (
   VOID
   )
 {
-  VOID                *Hob;
-  RETURN_STATUS       Status;
-  CONST UINT64        *UartBase;
-  UINTN               SerialBaseAddress;
-  UINT64              BaudRate;
-  UINT32              ReceiveFifoDepth;
-  EFI_PARITY_TYPE     Parity;
-  UINT8               DataBits;
-  EFI_STOP_BITS_TYPE  StopBits;
+  VOID                            *Hob;
+  RETURN_STATUS                   Status;
+  CONST UINT64                    *UartBase;
+  UINTN                           SerialBaseAddress;
+  UINT64                          BaudRate;
+  UINT32                          ReceiveFifoDepth;
+  EFI_PARITY_TYPE                 Parity;
+  UINT8                           DataBits;
+  EFI_STOP_BITS_TYPE              StopBits;
 
   if (mSerialBaseAddress != 0) {
     return RETURN_SUCCESS;

--- a/ArmVirtPkg/Library/FdtSerialPortAddressLib/FdtSerialPortAddressLib.c
+++ b/ArmVirtPkg/Library/FdtSerialPortAddressLib/FdtSerialPortAddressLib.c
@@ -1,0 +1,256 @@
+/** @file
+  Determine the base addresses of serial ports from the Device Tree.
+
+  Copyright (C) Red Hat
+  Copyright (c) 2011 - 2023, Arm Ltd. All rights reserved.<BR>
+  Copyright (c) 2008 - 2010, Apple Inc. All rights reserved.<BR>
+  Copyright (c) 2014 - 2020, Linaro Ltd. All rights reserved.<BR>
+  Copyright (c) 2015, Intel Corporation. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <Library/BaseLib.h>
+#include <Library/FdtSerialPortAddressLib.h>
+#include <libfdt.h>
+
+/**
+  Read the "reg" property of Node in DeviceTree as a UINT64 base address.
+
+  @param[in] DeviceTree    The flat device tree (FDT) to scan.
+
+  @param[in] Node          The node to read the "reg" property of.
+
+  @param[out] BaseAddress  On success, the base address read out of Node's "reg"
+                           property. On error, not modified.
+
+  @retval RETURN_DEVICE_ERROR     Node has a "status" property with value
+                                  different from "okay".
+
+  @retval RETURN_NOT_FOUND        Node does not have a "reg" property.
+
+  @retval RETURN_BAD_BUFFER_SIZE  The size of Node's "reg" property is not 16
+                                  bytes.
+
+  @retval RETURN_SUCCESS          BaseAddress has been populated.
+**/
+STATIC
+RETURN_STATUS
+GetBaseAddress (
+  IN  CONST VOID  *DeviceTree,
+  IN  INT32       Node,
+  OUT UINT64      *BaseAddress
+  )
+{
+  CONST CHAR8  *NodeStatus;
+  CONST VOID   *RegProp;
+  INT32        PropSize;
+
+  NodeStatus = fdt_getprop (DeviceTree, Node, "status", NULL);
+  if ((NodeStatus != NULL) && (AsciiStrCmp (NodeStatus, "okay") != 0)) {
+    return RETURN_DEVICE_ERROR;
+  }
+
+  RegProp = fdt_getprop (DeviceTree, Node, "reg", &PropSize);
+  if (RegProp == NULL) {
+    return RETURN_NOT_FOUND;
+  }
+
+  if (PropSize != 16) {
+    return RETURN_BAD_BUFFER_SIZE;
+  }
+
+  *BaseAddress = fdt64_to_cpu (ReadUnaligned64 (RegProp));
+  return RETURN_SUCCESS;
+}
+
+/**
+  Collect the first ARRAY_SIZE (Ports->BaseAddress) serial ports into Ports from
+  DeviceTree.
+
+  @param[in] DeviceTree  The flat device tree (FDT) to scan.
+
+  @param[in] Compatible  Look for Compatible in the "compatible" property of the
+                         scanned nodes.
+
+  @param[out] Ports      On successful return, Ports->NumberOfPorts contains the
+                         number of serial ports found; it is (a) positive and
+                         (b) at most ARRAY_SIZE (Ports->BaseAddress). If the FDT
+                         had more serial ports, those are not reported. On
+                         error, the contents of Ports are indeterminate.
+
+  @retval RETURN_INVALID_PARAMETER  DeviceTree does not point to a valid FDT
+                                    header.
+
+  @retval RETURN_NOT_FOUND          No compatible and enabled serial port has
+                                    been found.
+
+  @retval RETURN_SUCCESS            At least one compatible and enabled serial
+                                    port has been found; Ports has been filled
+                                    in.
+**/
+RETURN_STATUS
+EFIAPI
+FdtSerialGetPorts (
+  IN  CONST VOID        *DeviceTree,
+  IN  CONST CHAR8       *Compatible,
+  OUT FDT_SERIAL_PORTS  *Ports
+  )
+{
+  INT32  Node;
+
+  if (fdt_check_header (DeviceTree) != 0) {
+    return RETURN_INVALID_PARAMETER;
+  }
+
+  Ports->NumberOfPorts = 0;
+  Node                 = fdt_next_node (DeviceTree, 0, NULL);
+  while ((Node > 0) &&
+         (Ports->NumberOfPorts < ARRAY_SIZE (Ports->BaseAddress)))
+  {
+    CONST CHAR8  *CompatProp;
+    INT32        PropSize;
+
+    CompatProp = fdt_getprop (DeviceTree, Node, "compatible", &PropSize);
+    if (CompatProp != NULL) {
+      CONST CHAR8  *CompatItem;
+
+      CompatItem = CompatProp;
+      while ((CompatItem < CompatProp + PropSize) &&
+             (AsciiStrCmp (CompatItem, Compatible) != 0))
+      {
+        CompatItem += AsciiStrLen (CompatItem) + 1;
+      }
+
+      if (CompatItem < CompatProp + PropSize) {
+        RETURN_STATUS  Status;
+        UINT64         BaseAddress;
+
+        Status = GetBaseAddress (DeviceTree, Node, &BaseAddress);
+        if (!RETURN_ERROR (Status)) {
+          Ports->BaseAddress[Ports->NumberOfPorts++] = BaseAddress;
+        }
+      }
+    }
+
+    Node = fdt_next_node (DeviceTree, Node, NULL);
+  }
+
+  return Ports->NumberOfPorts > 0 ? RETURN_SUCCESS : RETURN_NOT_FOUND;
+}
+
+/**
+  Fetch the base address of the serial port identified in the "stdout-path"
+  property of the "/chosen" node in DeviceTree.
+
+  @param[in] DeviceTree    The flat device tree (FDT) to scan.
+
+  @param[out] BaseAddress  On success, the base address of the preferred serial
+                           port (to be used as console). On error, BaseAddress
+                           is not modified.
+
+  @retval RETURN_INVALID_PARAMETER  DeviceTree does not point to a valid FDT
+                                    header.
+
+  @retval RETURN_NOT_FOUND          No enabled console port has been found.
+
+  @retval RETURN_PROTOCOL_ERROR     The first (or only) node path in the
+                                    "stdout-path" property is an empty string.
+
+  @retval RETURN_PROTOCOL_ERROR     The console port has been found in the FDT,
+                                    but its base address is not correctly
+                                    represented.
+
+  @retval RETURN_SUCCESS            BaseAddress has been populated.
+**/
+RETURN_STATUS
+EFIAPI
+FdtSerialGetConsolePort (
+  IN  CONST VOID  *DeviceTree,
+  OUT UINT64      *BaseAddress
+  )
+{
+  INT32          ChosenNode;
+  CONST CHAR8    *StdoutPathProp;
+  INT32          PropSize;
+  CONST CHAR8    *StdoutPathEnd;
+  UINTN          StdoutPathLength;
+  INT32          ConsoleNode;
+  RETURN_STATUS  Status;
+
+  if (fdt_check_header (DeviceTree) != 0) {
+    return RETURN_INVALID_PARAMETER;
+  }
+
+  ChosenNode = fdt_path_offset (DeviceTree, "/chosen");
+  if (ChosenNode < 0) {
+    return RETURN_NOT_FOUND;
+  }
+
+  StdoutPathProp = fdt_getprop (
+                     DeviceTree,
+                     ChosenNode,
+                     "stdout-path",
+                     &PropSize
+                     );
+  if (StdoutPathProp == NULL) {
+    return RETURN_NOT_FOUND;
+  }
+
+  //
+  // If StdoutPathProp contains a colon (":"), then the colon terminates the
+  // path we're interested in.
+  //
+  StdoutPathEnd = AsciiStrStr (StdoutPathProp, ":");
+  if (StdoutPathEnd == NULL) {
+    StdoutPathLength = PropSize - 1;
+  } else {
+    StdoutPathLength = StdoutPathEnd - StdoutPathProp;
+  }
+
+  if (StdoutPathLength == 0) {
+    return RETURN_PROTOCOL_ERROR;
+  }
+
+  if (StdoutPathProp[0] == '/') {
+    //
+    // StdoutPathProp starts with an absolute node path.
+    //
+    ConsoleNode = fdt_path_offset_namelen (
+                    DeviceTree,
+                    StdoutPathProp,
+                    (INT32)StdoutPathLength
+                    );
+  } else {
+    //
+    // StdoutPathProp starts with an alias.
+    //
+    CONST CHAR8  *ResolvedStdoutPath;
+
+    ResolvedStdoutPath = fdt_get_alias_namelen (
+                           DeviceTree,
+                           StdoutPathProp,
+                           (INT32)StdoutPathLength
+                           );
+    if (ResolvedStdoutPath == NULL) {
+      return RETURN_NOT_FOUND;
+    }
+
+    ConsoleNode = fdt_path_offset (DeviceTree, ResolvedStdoutPath);
+  }
+
+  if (ConsoleNode < 0) {
+    return RETURN_NOT_FOUND;
+  }
+
+  Status = GetBaseAddress (DeviceTree, ConsoleNode, BaseAddress);
+  switch (Status) {
+    case RETURN_NOT_FOUND:
+    case RETURN_BAD_BUFFER_SIZE:
+      return RETURN_PROTOCOL_ERROR;
+    case RETURN_SUCCESS:
+      return RETURN_SUCCESS;
+    default:
+      return RETURN_NOT_FOUND;
+  }
+}

--- a/ArmVirtPkg/Library/FdtSerialPortAddressLib/FdtSerialPortAddressLib.inf
+++ b/ArmVirtPkg/Library/FdtSerialPortAddressLib/FdtSerialPortAddressLib.inf
@@ -1,0 +1,27 @@
+## @file
+# Determine the base addresses of serial ports from the Device Tree.
+#
+# Copyright (C) Red Hat
+#
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION    = 1.27
+  BASE_NAME      = FdtSerialPortAddressLib
+  FILE_GUID      = AEBE813B-25EA-40E5-95C4-2B864FE1E951
+  MODULE_TYPE    = BASE
+  VERSION_STRING = 1.0
+  LIBRARY_CLASS  = FdtSerialPortAddressLib
+
+[Sources]
+  FdtSerialPortAddressLib.c
+
+[Packages]
+  ArmVirtPkg/ArmVirtPkg.dec
+  EmbeddedPkg/EmbeddedPkg.dec
+  MdePkg/MdePkg.dec
+
+[LibraryClasses]
+  BaseLib
+  FdtLib

--- a/ArmVirtPkg/Library/PlatformPeiLib/PlatformPeiLib.c
+++ b/ArmVirtPkg/Library/PlatformPeiLib/PlatformPeiLib.c
@@ -37,25 +37,25 @@ PlatformPeim (
   VOID
   )
 {
-  VOID          *Base;
-  VOID          *NewBase;
-  UINTN         FdtSize;
-  UINTN         FdtPages;
-  UINT64        *FdtHobData;
-  UINT64        *UartHobData;
-  INT32         Node, Prev;
-  INT32         Parent, Depth;
-  CONST CHAR8   *Compatible;
-  CONST CHAR8   *CompItem;
-  CONST CHAR8   *NodeStatus;
-  INT32         Len;
-  INT32         RangesLen;
-  INT32         StatusLen;
-  CONST UINT64  *RegProp;
-  CONST UINT32  *RangesProp;
-  UINT64        UartBase;
-  UINT64        TpmBase;
-  EFI_STATUS    Status;
+  VOID                      *Base;
+  VOID                      *NewBase;
+  UINTN                     FdtSize;
+  UINTN                     FdtPages;
+  UINT64                    *FdtHobData;
+  UINT64                    *UartHobData;
+  INT32                     Node, Prev;
+  INT32                     Parent, Depth;
+  CONST CHAR8               *Compatible;
+  CONST CHAR8               *CompItem;
+  CONST CHAR8               *NodeStatus;
+  INT32                     Len;
+  INT32                     RangesLen;
+  INT32                     StatusLen;
+  CONST UINT64              *RegProp;
+  CONST UINT32              *RangesProp;
+  UINT64                    UartBase;
+  UINT64                    TpmBase;
+  EFI_STATUS                Status;
 
   Base = (VOID *)(UINTN)PcdGet64 (PcdDeviceTreeInitialBaseAddress);
   ASSERT (Base != NULL);

--- a/ArmVirtPkg/Library/PlatformPeiLib/PlatformPeiLib.inf
+++ b/ArmVirtPkg/Library/PlatformPeiLib/PlatformPeiLib.inf
@@ -31,6 +31,7 @@
   gArmVirtTokenSpaceGuid.PcdTpm2SupportEnabled
 
 [LibraryClasses]
+  BaseMemoryLib
   DebugLib
   HobLib
   FdtLib

--- a/ArmVirtPkg/Library/PlatformPeiLib/PlatformPeiLib.inf
+++ b/ArmVirtPkg/Library/PlatformPeiLib/PlatformPeiLib.inf
@@ -34,6 +34,7 @@
   DebugLib
   HobLib
   FdtLib
+  FdtSerialPortAddressLib
   PcdLib
   PeiServicesLib
 


### PR DESCRIPTION
https://bugzilla.tianocore.org/show_bug.cgi?id=4577
https://edk2.groups.io/g/devel/message/109394
http://mid.mail-archive.com/20231008153912.175941-1-lersek@redhat.com
https://listman.redhat.com/archives/edk2-devel-archive/2023-October/068694.html
~~~
This ArmVirtPkg series can be fetched from:

  repo:   https://pagure.io/lersek/edk2.git
  branch: armvirt-dual-serial @ 65ee08413595

The series does the following:

- It centralizes (and cleans up) two FDT parsing actions, namely looking
  up all serial ports, and looking up the /chosen "stdout-path" serial
  port, in a new library class and instance.

- It rebases Fdt16550SerialPortHookLib, EarlyFdtPL011SerialPortLib and
  PlatformPeiLib to the new library.

- If QEMU specifies just one PL011 UART, then this patch set is
  unobservable from the outside.

- If QEMU specifies (at least) two PL011 UARTs, then we distinguish a
  "chosen" one, and a (first) "non-chosen" one:

  - Both EarlyFdtPL011SerialPortLib, and (PlatformPeiLib +
    FdtPL011SerialPortLib), target the "chosen" PL011. The consequence
    of this is that (a) direct SerialPortLib traffic, (b) the dependent
    SerialIo (SerialDxe) protocol traffic, and (c) the dependent UEFI
    console traffic, all occcur on the same PL011, and do so regardless
    of the firmware phase. Furthermore, (d) the Linux serial console
    traffic is directed to the same PL011 as well. In total, the
    "chosen" PL011 UART becomes "the console", covering both firmware
    and Linux.

  - Three new DebugLib instances -- namely Flash, RAM, and DXE Runtime
    instances of "DebugLibFdtPL011Uart" -- target the (first)
    "non-chosen" PL011. The consequence is that DebugLib output is
    hermetically separated from the above-mentioned console, mirroring
    the isa-debugcon situation with x86 OVMF.

Peter's QEMU patch set that this series interoperates with is at:

  repo:   https://git.linaro.org/people/pmaydell/qemu-arm.git
  branch: uart-edk-investigation @ 66bff4241bf8

See the larger background, and my detailed test results -- using
"ArmVirtQemu.dsc" -- in the following thread:

  EDK2 ArmVirtQemu behaviour with multiple UARTs
  http://mid.mail-archive.com/CAFEAcA_P5aOTQnM2ARYgR5WvKouvndMbX95XNmDsS0KTxMkMMw@mail.gmail.com
  https://listman.redhat.com/archives/edk2-devel-archive/2023-September/068241.html
  https://edk2.groups.io/g/devel/message/108941

For my testing, I rebased Peter's set on more recent QEMU commit
36e9aab3c569. Also, importantly, Peter's last patch 66bff4241bf8 ("virt:
Reverse order of UART dtb nodes", 2023-09-21) is *indifferent* regarding
my test results (which shows that the ordering of the two PL011 UARTs in
the DTB does not matter, with this edk2 series applied). See more on
that in the above-noted thread.

"ArmVirtKvmTool.dsc" and "ArmVirtXen.dsc" are not supposed to be visibly
affected by this series; I test-built them, and checked the library
resolutions before/after in their build report files (no change).
Runtime regression testing with these platforms would be welcome.

I also test-built "ArmVirtCloudHv.dsc" and "ArmVirtQemuKernel.dsc".
Those *are* supposed to receive the same feature, but I couldn't /
didn't boot them, respectively.

I've formatted the patches with "--find-copies-harder", because (a) that
makes for an easier reading, and (b) leaves the patches applicable from
the list. The base commit is noted at the end of this message.

Cc: Ard Biesheuvel [<ardb+tianocore@kernel.org>](mailto:ardb+tianocore@kernel.org)
Cc: Gerd Hoffmann [<kraxel@redhat.com>](mailto:kraxel@redhat.com)
Cc: Julien Grall [<julien@xen.org>](mailto:julien@xen.org)
Cc: Leif Lindholm [<quic_llindhol@quicinc.com>](mailto:quic_llindhol@quicinc.com)
Cc: Peter Maydell [<peter.maydell@linaro.org>](mailto:peter.maydell@linaro.org)
Cc: Sami Mujawar [<sami.mujawar@arm.com>](mailto:sami.mujawar@arm.com)

(I've not Cc'd Peter on the patches themselves, but I'm Cc'ing him on
the cover letter.)

Thanks,
Laszlo

Laszlo Ersek (9):
  ArmVirtPkg: introduce FdtSerialPortAddressLib
  ArmVirtPkg/Fdt16550SerialPortHookLib: rebase to
    FdtSerialPortAddressLib
  ArmVirtPkg: adjust whitespace in block scope declarations
  ArmVirtPkg: adhere to the serial port selected by /chosen
    "stdout-path"
  ArmVirtPkg: store separate console and debug PL011 addresses in GUID
    HOB
  ArmVirtPkg: introduce DebugLibFdtPL011Uart Flash instance
  ArmVirtPkg: introduce DebugLibFdtPL011Uart RAM instance
  ArmVirtPkg: introduce DebugLibFdtPL011Uart DXE Runtime instance
  ArmVirtPkg: steer DebugLib output away from SerialPortLib+console
    traffic

 ArmVirtPkg/ArmVirt.dsc.inc                                                                    |  14 +-
 ArmVirtPkg/ArmVirtKvmTool.dsc                                                                 |  11 +
 ArmVirtPkg/ArmVirtPkg.dec                                                                     |   1 +
 ArmVirtPkg/ArmVirtXen.dsc                                                                     |  11 +
 ArmVirtPkg/Include/Guid/EarlyPL011BaseAddress.h                                               |  15 +-
 ArmVirtPkg/Include/Library/FdtSerialPortAddressLib.h                                          |  83 +++++++
 ArmVirtPkg/Library/DebugLibFdtPL011Uart/DebugLibFdtPL011UartFlash.inf                         |  54 +++++
 ArmVirtPkg/Library/DebugLibFdtPL011Uart/DebugLibFdtPL011UartRam.inf                           |  60 +++++
 ArmVirtPkg/Library/DebugLibFdtPL011Uart/DxeRuntimeDebugLibFdtPL011Uart.inf                    |  61 +++++
 ArmVirtPkg/Library/DebugLibFdtPL011Uart/Flash.c                                               | 107 ++++++++
 ArmVirtPkg/Library/DebugLibFdtPL011Uart/Ram.c                                                 | 124 ++++++++++
 ArmVirtPkg/Library/DebugLibFdtPL011Uart/Ram.h                                                 |  18 ++
 ArmVirtPkg/Library/DebugLibFdtPL011Uart/RamNonRuntime.c                                       |  27 +++
 ArmVirtPkg/Library/DebugLibFdtPL011Uart/Runtime.c                                             |  88 +++++++
 ArmVirtPkg/Library/DebugLibFdtPL011Uart/Write.h                                               |  39 +++
 ArmVirtPkg/Library/Fdt16550SerialPortHookLib/EarlyFdt16550SerialPortHookLib.c                 |  88 +------
 ArmVirtPkg/Library/Fdt16550SerialPortHookLib/EarlyFdt16550SerialPortHookLib.inf               |   3 +-
 ArmVirtPkg/Library/FdtPL011SerialPortLib/EarlyFdtPL011SerialPortLib.c                         |  90 +++----
 ArmVirtPkg/Library/FdtPL011SerialPortLib/EarlyFdtPL011SerialPortLib.inf                       |   3 +-
 ArmVirtPkg/Library/FdtPL011SerialPortLib/FdtPL011SerialPortLib.c                              |  20 +-
 ArmVirtPkg/Library/FdtSerialPortAddressLib/FdtSerialPortAddressLib.c                          | 256 ++++++++++++++++++++
 ArmVirtPkg/Library/FdtSerialPortAddressLib/FdtSerialPortAddressLib.inf                        |  27 +++
 ArmVirtPkg/Library/PlatformPeiLib/PlatformPeiLib.c                                            | 108 ++++++---
 ArmVirtPkg/Library/PlatformPeiLib/PlatformPeiLib.inf                                          |   2 +
 {MdePkg/Library/BaseDebugLibSerialPort => ArmVirtPkg/Library/DebugLibFdtPL011Uart}/DebugLib.c |  41 ++--
 25 files changed, 1128 insertions(+), 223 deletions(-)
 copy {MdePkg/Library/BaseDebugLibSerialPort => ArmVirtPkg/Library/DebugLibFdtPL011Uart}/DebugLib.c (89%)
 create mode 100644 ArmVirtPkg/Include/Library/FdtSerialPortAddressLib.h
 create mode 100644 ArmVirtPkg/Library/DebugLibFdtPL011Uart/DebugLibFdtPL011UartFlash.inf
 create mode 100644 ArmVirtPkg/Library/DebugLibFdtPL011Uart/DebugLibFdtPL011UartRam.inf
 create mode 100644 ArmVirtPkg/Library/DebugLibFdtPL011Uart/DxeRuntimeDebugLibFdtPL011Uart.inf
 create mode 100644 ArmVirtPkg/Library/DebugLibFdtPL011Uart/Flash.c
 create mode 100644 ArmVirtPkg/Library/DebugLibFdtPL011Uart/Ram.c
 create mode 100644 ArmVirtPkg/Library/DebugLibFdtPL011Uart/Ram.h
 create mode 100644 ArmVirtPkg/Library/DebugLibFdtPL011Uart/RamNonRuntime.c
 create mode 100644 ArmVirtPkg/Library/DebugLibFdtPL011Uart/Runtime.c
 create mode 100644 ArmVirtPkg/Library/DebugLibFdtPL011Uart/Write.h
 create mode 100644 ArmVirtPkg/Library/FdtSerialPortAddressLib/FdtSerialPortAddressLib.c
 create mode 100644 ArmVirtPkg/Library/FdtSerialPortAddressLib/FdtSerialPortAddressLib.inf


base-commit: 4ddd8ac3a29d9c5974a19f36c1dc5896d813dc6e
~~~