### PR TITLE
.azurepipelines: Fix Python version (to 3.12)

### DIFF
--- a/.azurepipelines/Ubuntu-PatchCheck.yml
+++ b/.azurepipelines/Ubuntu-PatchCheck.yml
@@ -27,7 +27,7 @@ steps:
 
 - task: UsePythonVersion@0
   inputs:
-    versionSpec: '3.11'
+    versionSpec: '3.12'
     architecture: 'x64'
 
 - script: |

--- a/.azurepipelines/templates/defaults.yml
+++ b/.azurepipelines/templates/defaults.yml
@@ -8,5 +8,5 @@
 ##
 
 variables:
-  default_python_version: "3.11"
+  default_python_version: "3.12"
   default_linux_image: "ghcr.io/tianocore/containers/fedora-37-test:a0dd931"


### PR DESCRIPTION
Upgrades python to 3.12 for build as it has been released and all supporting tools have been updated to also support 3.12.

Cc: Sean Brogan <sean.brogan@microsoft.com>
Cc: Michael Kubacki <mikuback@linux.microsoft.com>
Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Reviewed-by: Michael D Kinney <michael.d.kinney@intel.com>
Reviewed-by: Michael Kubacki <michael.kubacki@microsoft.com>