### PR TITLE
.github/workflows: Add Stale Check

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,44 @@
+# This workflow warns and then closes issues and PRs that have had no activity
+# for a specified amount of time.
+#
+# For more information, see:
+# https://github.com/actions/stale
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+
+name: Stale Check
+
+on:
+  schedule:
+    # At 23:35 on every day-of-week from Sunday through Saturday
+    # https://crontab.guru/#35_23_*_*_0-6
+    - cron: '35 23 * * 0-6'
+  workflow_dispatch:
+
+jobs:
+  stale:
+    name: Stale
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+    - name: Check for Stale Items
+      uses: actions/stale@v8
+      with:
+        days-before-issue-close: -1
+        days-before-issue-stale: -1
+        days-before-pr-stale: 60
+        days-before-pr-close: 7
+        stale-pr-message: >
+          This PR has been automatically marked as stale because it has not had
+          activity in 60 days. It will be closed if no further activity occurs within
+          7 days. Thank you for your contributions.
+        close-pr-message: >
+          This pull request has been automatically been closed because it did not have any
+          activity in 60 days and no follow up within 7 days after being marked stale.
+          Thank you for your contributions.
+        stale-pr-label: stale


### PR DESCRIPTION
Adds a GitHub workflow that uses the actions/stale GitHub action to automatically leave notifications on and close PRs that have had no activity for a long time.

Note: Modifications to a PR reset the staleness counter. This
      includes pushing to the PR, adding a label to the PR,
      commenting on the PR, etc.

If a PR has been marked "stale", simply leaving a comment will
reset the counter.

Configuration choices:

1. Do not attempt to close edk2 GitHub issues.
2. Mark edk2 PRs as stale if no activity in the last 60 days. Close PRs marked stale if no further activity in 7 days.
3. Do not exempt PRs with a "push" label.
4. Run the check once daily. Allow manual runs from those that have permission to run GitHub workflows.
5. Add the label "stale" to the PR when it enters the stale state.

Rationale:

1. We do not use issues often enough. The limited usage of GitHub issues in Tianocore org GitHub projects are in another repo not impacted by this workflow and expected to track long term tasks.
2. This is the default value. In non-edk2 projects, I've seen these times work fairly well to identify PRs that have fallen stale.
3. Adding a "push" label resets the stale timer. If a PR has had a "push" label for 60+ days and has not been fixed for submission, then it is has very likely been abandoned.
4. This is sufficient to update PRs on the day granularity the configuration settings are applied against.
5. The label makes it easy to filter stale PRs in the PR list and write automation around PRs that are stale. It's also an obvious visual identifier that a PR needs attention in the PR list.

Cc: Sean Brogan <sean.brogan@microsoft.com>
Cc: Michael Kubacki <mikuback@linux.microsoft.com>
Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Laszlo Ersek <lersek@redhat.com>
Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>

Notes:

I tested this workflow on my edk2 fork:

- https://github.com/makubacki/edk2/actions/runs/6700887619

Here's an example of a PR it did not mark stale there:

- https://github.com/makubacki/edk2/pull/136

Here's an example of a PR it did mark stale there:

- https://github.com/makubacki/edk2/pull/4
