### PR TITLE
BaseTools: Resolve invalid escape sequence

### DIFF
--- a/BaseTools/Scripts/BinToPcd.py
+++ b/BaseTools/Scripts/BinToPcd.py
@@ -10,13 +10,12 @@ BinToPcd
 '''
 from __future__ import print_function
 
-import sys
 import argparse
-import re
-import xdrlib
 import io
-import struct
 import math
+import re
+import struct
+import sys
 
 #
 # Globals for help information
@@ -38,13 +37,13 @@ if __name__ == '__main__':
         return Value
 
     def ValidatePcdName (Argument):
-        if re.split ('[a-zA-Z\_][a-zA-Z0-9\_]*\.[a-zA-Z\_][a-zA-Z0-9\_]*', Argument) != ['', '']:
+        if re.split (r'[a-zA-Z\_][a-zA-Z0-9\_]*\.[a-zA-Z\_][a-zA-Z0-9\_]*', Argument) != ['', '']:
             Message = '{Argument} is not in the form <PcdTokenSpaceGuidCName>.<PcdCName>'.format (Argument = Argument)
             raise argparse.ArgumentTypeError (Message)
         return Argument
 
     def ValidateGuidName (Argument):
-        if re.split ('[a-zA-Z\_][a-zA-Z0-9\_]*', Argument) != ['', '']:
+        if re.split (r'[a-zA-Z\_][a-zA-Z0-9\_]*', Argument) != ['', '']:
             Message = '{Argument} is not a valid GUID C name'.format (Argument = Argument)
             raise argparse.ArgumentTypeError (Message)
         return Argument


### PR DESCRIPTION
Resolves an invalid escape sequence in a regex string that occurs because the string was not marked as a raw string, so backslash characters create unexpected escape sequences.

This was brought to light due to Python 3.12 now detecting invalid escape sequences and generates a warning. It is best practice to always use raw strings for regex strings.

Cc: Rebecca Cran <rebecca@bsdio.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Bob Feng <bob.c.feng@intel.com>
Cc: Yuwei Chen <yuwei.chen@intel.com>