### PR TITLE
ReadMe.rst: Add Apache License 2.0 and update submodule list

### DIFF
--- a/ReadMe.rst
+++ b/ReadMe.rst
@@ -134,11 +134,12 @@ To make a contribution to a TianoCore project, follow these steps.
     copyright license as the base project. When that is not possible,
     then contributions using the following licenses can be accepted:
 
--  BSD (2-clause): http://opensource.org/licenses/BSD-2-Clause
--  BSD (3-clause): http://opensource.org/licenses/BSD-3-Clause
--  MIT: http://opensource.org/licenses/MIT
--  Python-2.0: http://opensource.org/licenses/Python-2.0
--  Zlib: http://opensource.org/licenses/Zlib
+-  Apache License, Version 2.0: https://opensource.org/license/apache-2-0/
+-  BSD (2-clause): https://opensource.org/license/BSD-2-Clause
+-  BSD (3-clause): https://opensource.org/license/BSD-3-Clause
+-  MIT: https://opensource.org/license/MIT
+-  Python-2.0: https://opensource.org/license/Python-2.0
+-  Zlib: https://opensource.org/license/Zlib
 
 For documentation:
 
@@ -243,19 +244,7 @@ Definitions for sample patch email
 Submodules
 ----------
 
-Submodule in EDK II is allowed but submodule chain should be avoided
-as possible as we can. Currently EDK II contains the following submodules
-
--  CryptoPkg/Library/OpensslLib/openssl
--  ArmPkg/Library/ArmSoftFloatLib/berkeley-softfloat-3
--  MdeModulePkg/Universal/RegularExpressionDxe/oniguruma
--  MdeModulePkg/Library/BrotliCustomDecompressLib/brotli
--  BaseTools/Source/C/BrotliCompress/brotli
-
-ArmSoftFloatLib is actually required by OpensslLib. It's inevitable
-in openssl-1.1.1 (since stable201905) for floating point parameter
-conversion, but should be dropped once there's no such need in future
-release of openssl.
+The current submodules used in EDK II are in `.gitmodules <.gitmodules>`__.
 
 To get a full, buildable EDK II repository, use following steps of git
 command
@@ -282,6 +271,12 @@ submodules in above submodules. So using '--recursive' adds a
 dependency on being able to reach servers we do not actually want
 any code from, as well as needlessly downloading code we will not
 use.
+
+**Submodule Notes**
+
+ArmSoftFloatLib is required by OpensslLib. It's inevitable in openssl-1.1.1
+(since stable201905) for floating point parameter conversion, but should be
+dropped once there's no such need in future release of openssl.
 
 .. ===================================================================
 .. This is a bunch of directives to make the README file more readable


### PR DESCRIPTION
- Adds Apache License 2.0 as an acceptable source license per discussion in https://edk2.groups.io/g/devel/message/110226
- Updates the URL for existing licenses to match the current path used by opensource.org.
- The submodule list in this file is stale and is very prone to being forgotten. The list of submodules in the submodules setion is replaced with a link to .gitmodules which has an active list of submodules at any given time.

Cc: Andrew Fish <afish@apple.com>
Cc: Laszlo Ersek <lersek@redhat.com>
Cc: Leif Lindholm <quic_llindhol@quicinc.com>
Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Pedro Falcato <pedro.falcato@gmail.com>
Cc: Sean Brogan <sean.brogan@microsoft.com>
Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>