### PR TITLE
DynamicTablesPkg: Fix assert in CmObject parser

### DIFF
--- a/DynamicTablesPkg/Library/Common/TableHelperLib/ConfigurationManagerObjectParser.c
+++ b/DynamicTablesPkg/Library/Common/TableHelperLib/ConfigurationManagerObjectParser.c
@@ -84,7 +84,8 @@ STATIC CONST CM_OBJ_PARSER  CmArmGicCInfoParser[] = {
   { "ClockDomain",                   4,                        "0x%x",   NULL },
   { "AffinityFlags",                 4,                        "0x%x",   NULL },
   { "CpcToken",                      sizeof (CM_OBJECT_TOKEN), "0x%p",   NULL },
-  { "TRBEInterrupt",                 2,                        "0x%x",   NULL }
+  { "TRBEInterrupt",                 2,                        "0x%x",   NULL },
+  { "EtToken",                       sizeof (CM_OBJECT_TOKEN), "0x%p",   NULL }
 };
 
 /** A parser for EArmObjGicDInfo.


### PR DESCRIPTION
The patch "f81ee47513e5 DynamicTablesPkg: Add an ET info object parser" updates the Configuration Manager object parser to add support for parsing CM_ARM_ET_INFO object.

However, the GicC info structure also has an ET Reference token that points to the CM_ARM_ET_INFO object. Therefore, update the GICC info object parser to add an entry to parse the ET reference token. Without this change an assert stating that the RemainingSize != 0 will be triggered.


Reviewed-by: levi.yun <yeoreum.yun@arm.com>