### PR TITLE
Update TdVmCall to handle the retry for MapGPA

### DIFF
--- a/MdePkg/Library/BaseLib/X64/TdVmcall.nasm
+++ b/MdePkg/Library/BaseLib/X64/TdVmcall.nasm
@@ -133,9 +133,7 @@ ASM_PFX(TdVmCall):
        test r9, r9
        jz .no_return_data
 
-       ; On success, propagate TDVMCALL output value to output param
-       test rax, rax
-       jnz .no_return_data
+       ; Propagate TDVMCALL output value to output param
        mov [r9], r11
 .no_return_data:
        tdcall_regs_postamble

--- a/OvmfPkg/Library/BaseMemEncryptTdxLib/MemoryEncryption.c
+++ b/OvmfPkg/Library/BaseMemEncryptTdxLib/MemoryEncryption.c
@@ -38,6 +38,10 @@ typedef enum {
 
 STATIC PAGE_TABLE_POOL  *mPageTablePool = NULL;
 
+#define TDVMCALL_STATUS_RETRY  0x1
+
+#define MAX_RETRIES_PER_PAGE  3
+
 /**
   Returns boolean to indicate whether to indicate which, if any, memory encryption is enabled
 
@@ -527,6 +531,13 @@ SetOrClearSharedBit (
   EFI_STATUS                    Status;
   EDKII_MEMORY_ACCEPT_PROTOCOL  *MemoryAcceptProtocol;
 
+  UINT64  MapGpaRetryAddr;
+  UINT32  RetryCount;
+  UINT64  EndAddress;
+
+  MapGpaRetryAddr = 0;
+  RetryCount      = 0;
+
   AddressEncMask = GetMemEncryptionAddressMask ();
 
   //
@@ -540,7 +551,37 @@ SetOrClearSharedBit (
     PhysicalAddress   &= ~AddressEncMask;
   }
 
-  TdStatus = TdVmCall (TDVMCALL_MAPGPA, PhysicalAddress, Length, 0, 0, NULL);
+  EndAddress = PhysicalAddress + Length;
+  while (RetryCount < MAX_RETRIES_PER_PAGE) {
+    TdStatus = TdVmCall (TDVMCALL_MAPGPA, PhysicalAddress, Length, 0, 0, &MapGpaRetryAddr);
+    if (TdStatus != TDVMCALL_STATUS_RETRY) {
+      break;
+    }
+
+    DEBUG ((DEBUG_VERBOSE, "%a: TdVmcall(MAPGPA) Retry PhysicalAddress is %llx, MapGpaRetryAddr is %llx\n", __func__, PhysicalAddress, MapGpaRetryAddr));
+
+    if ((MapGpaRetryAddr < PhysicalAddress) || (MapGpaRetryAddr >= EndAddress)) {
+      DEBUG ((
+        DEBUG_ERROR,
+        "%a: TdVmcall(MAPGPA) failed with MapGpaRetryAddr(%llx) less than PhysicalAddress(%llx) or more than or equal to EndAddress(%llx) \n",
+        __func__,
+        MapGpaRetryAddr,
+        PhysicalAddress,
+        EndAddress
+        ));
+      break;
+    }
+
+    if (MapGpaRetryAddr == PhysicalAddress) {
+      RetryCount++;
+      continue;
+    }
+
+    PhysicalAddress = MapGpaRetryAddr;
+    Length          = EndAddress - PhysicalAddress;
+    RetryCount      = 0;
+  }
+
   if (TdStatus != 0) {
     DEBUG ((DEBUG_ERROR, "%a: TdVmcall(MAPGPA) failed with %llx\n", __func__, TdStatus));
     ASSERT (FALSE);


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4572

According to section 3.2 of the [GHCI] documentation, if the result is "TDG.VP.VMCALL_RETRY" for TDG.VP.VMCALL.MapGPA, TD must retry the mapping for the pages in the region starting at the GPA specified in r11.

Currently, TDVF does not properly handle the retry results of MapGPA. For this, TDVF should update the TdVmCall to return the value in R11 and must retry the mapping for the pages by the value.

How to verify the retry for MapGPA in TDVF:
Note: Since the range size of MapGPA in QEMU is limited to 64MB and TDVF always maps 1.5GB( 2GB~3.5GB) MMIO to shared-memory for TD guest, the retry action is triggered always.
Pre-Config:
QEMU:
https://github.com/intel/qemu-tdx/tree/tdx-qemu-upstream | tag: tdx-qemu-upstream-2023.10.20-v8.1.0
KERNEL:
https://github.com/intel/tdx/tree/kvm-upstream-2023.10.16-v6.6-rc2

Step:
Boot with TD guest and check the log with TdVmcall(MAPGPA) ,  as below:
TdxDxe:SetMemorySharedOrPrivate: Cr3Base=0x0 Physical=0x80000000 Length=0x60000000 Mode=Shared
SetOrClearSharedBit: TdVmcall(MAPGPA) Retry PhysicalAddress is 8000080000000, MapGpaRetryaddr is 8000084000000

Reference:
[GHCI]: TDX Guest-Host-Communication Interface v1.0
https://cdrdv2.intel.com/v1/dl/getContent/726790

v2 changes:

- Update the code based on the comments of v1 reviewer
- Update TdVmcall to instead of the extra API file

Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Erdem Aktas [erdemaktas@google.com](mailto:erdemaktas@google.com)
Cc: James Bottomley [jejb@linux.ibm.com](mailto:jejb@linux.ibm.com)
Cc: Jiewen Yao [jiewen.yao@intel.com](mailto:jiewen.yao@intel.com)
Cc: Min Xu [min.m.xu@intel.com](mailto:min.m.xu@intel.com)
Cc: Tom Lendacky [thomas.lendacky@amd.com](mailto:thomas.lendacky@amd.com)
Cc: Michael Roth [michael.roth@amd.com](mailto:michael.roth@amd.com)
Cc: Gerd Hoffmann [kraxel@redhat.com](mailto:kraxel@redhat.com)
Signed-off-by: Ceping Sun [cepingx.sun@intel.com](mailto:cepingx.sun@intel.com)