### PR TITLE
CI Check Test: MdeModulePkg/PciHostBridgeDxe: Add readback after final Cfg-Write

### DIFF
--- a/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciRootBridgeIo.c
+++ b/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciRootBridgeIo.c
@@ -1238,6 +1238,13 @@ RootBridgeIoPciAccess (
     }
   }
 
+  //
+  // Perform readback after write to confirm completion was received for the last write
+  //
+  if (!Read) {
+    PciSegmentRead8 (Address - InStride);
+  }
+
   return EFI_SUCCESS;
 }
 


### PR DESCRIPTION
CI Check test

REF: https://edk2.groups.io/g/devel/topic/102310377#110456

- Add a read after the final PCI Configuration space write in RootBridgeIoPciAccess.

- When configuration space is strongly ordered, this ensures that program execution cannot continue until the completion is received for the previous Cfg-Write, which may have side-effects.