### PR TITLE
UefiCpuPkg/PiSmmCpuDxeSmm: Clear CR4.CET before restoring MSR IA32_S_CET

### DIFF
--- a/UefiCpuPkg/PiSmmCpuDxeSmm/X64/SmmFuncsArch.c
+++ b/UefiCpuPkg/PiSmmCpuDxeSmm/X64/SmmFuncsArch.c
@@ -20,7 +20,7 @@ UINT32                    mCetPl0Ssp;
 UINT32                    mCetInterruptSsp;
 UINT32                    mCetInterruptSspTable;
 
-UINTN  mSmmInterruptSspTables;
+UINTN  mSmmInterruptSspTables = 0;
 
 /**
   Initialize IDT IST Field.


### PR DESCRIPTION
Clear CR4.CET bit before restoring MSR IA32_S_CET. Backup/restore MSR IA32_U_CET in SMI.
Use current CR4 value when changing CR4.CET.
Initial mSmmInterruptSspTables to 0.

Change-Id: I6b4468350adc674423378305cf3dc7bca82f8f6f

Cc: Eric Dong <eric.dong@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Cc: Laszlo Ersek <lersek@redhat.com>
Cc: Wu Jiaxin <jiaxin.wu@intel.com>
Cc: Tan Dun <dun.tan@intel.com>