### PR TITLE
IntelFsp2Pkg/SwitchStack: Reserve 32B when calling C function in 64bit

### DIFF
--- a/IntelFsp2Pkg/Library/BaseFspSwitchStackLib/X64/Stack.nasm
+++ b/IntelFsp2Pkg/Library/BaseFspSwitchStackLib/X64/Stack.nasm
@@ -1,6 +1,6 @@
 ;------------------------------------------------------------------------------
 ;
-; Copyright (c) 2022, Intel Corporation. All rights reserved.<BR>
+; Copyright (c) 2022 - 2023, Intel Corporation. All rights reserved.<BR>
 ; SPDX-License-Identifier: BSD-2-Clause-Patent
 ;
 ; Abstract:
@@ -60,7 +60,9 @@ ASM_PFX(FspSwitchStack):
 
     ; Load new stack
     mov     rcx, rsp
+    sub     rsp, 0x20
     call    ASM_PFX(SwapStack)
+    add     rsp, 0x20
     mov     rsp, rax
 
     ; Restore previous contexts


### PR DESCRIPTION
When FSP runs in API mode, it saves the IDTR in its own stack then switches to bootloader's stack before it returns from FspMemoryInit. Next time when the bootloader calls TempRamExit, FSP switches to its own stack and restores IDTR from its stack saved earlier.

However, due to a bug in BaseFspSwitchStackLib, the IDTR saved on FSP's stack might be corrupted that results the following TempRamExit call fails inside FSP due to PeiServices pointer cannot be retrieved from IDT.base - 8.

The bug is the assembly code doesn't reserve 32 bytes before calling the C routine in 64bit. According to the x86-64 calling convention, caller is responsible for allocating 32 bytes of "shadow space" on the stack right before calling the function (regardless of the actual number of parameters used).

When FSP is built in optimization-off mode, the C routine makes use of the 32-byte "shadow space" which is not reserved by the assembly caller. That causes the IDTR saved on the stack is corrupted by the C routine.
The patch fixes so by reserving the 32 bytes before calling C routine.


Cc: Chasel Chiu <chasel.chiu@intel.com>
Reviewed-by: Nate DeSimone <nathaniel.l.desimone@intel.com>
Cc: Duggapu Chinni B <chinni.b.duggapu@intel.com>
Cc: Ray Han Lim Ng <ray.han.lim.ng@intel.com>
Cc: Star Zeng <star.zeng@intel.com>
Reviewed-by: Ted Kuo <ted.kuo@intel.com>
Reviewed-by: Ashraf Ali S <ashraf.ali.s@intel.com>
Cc: Susovan Mohapatra <susovan.mohapatra@intel.com>