### PR TITLE
IntelFsp2Pkg/PatchFv: Fix syntax issue in markdown manual

### DIFF
--- a/IntelFsp2Pkg/Tools/UserManuals/PatchFvUserManual.md
+++ b/IntelFsp2Pkg/Tools/UserManuals/PatchFvUserManual.md
@@ -1,9 +1,9 @@
-#Name
+# Name
 **_PatchFv.py_** - The python script that patches the firmware volumes (**FV**)
 with in the flash device (**FD**) file post FSP build.
 From version 0.60, script is capable of patching flash device (**FD**) directly.
 
-#Synopsis
+# Synopsis
 
 ```
 PatchFv FvBuildDir [FvFileBaseNames:]FdFileBaseNameToPatch ["Offset, Value"]+
@@ -18,32 +18,32 @@ PatchFv FdFileDir FdFileName ["Offset, Value"]+
   | ["Offset, Value, $Command, @Comment"]+
 ```
 
-#Description
+# Description
 The **_PatchFv.py_** tool allows the developer to fix up FD images to follow the
 Intel FSP Architecture specification.  It also makes the FD image relocatable.
 The tool is written in Python and uses Python 2.7 or later to run.
 Consider using the tool in a build script.
 
-#FvBuildDir (Argument 1)
+# FvBuildDir (Argument 1)
 This is the first argument that **_PatchFv.py_** requires.  It is the build
 directory for all firmware volumes created during the FSP build. The path must
 be either an absolute path or a relevant path, relevant to the top level of the
 FSP tree.
 
-####Example usage:
+#### Example usage:
 ```
  Build\YouPlatformFspPkg\%BD_TARGET%_%VS_VERSION%%VS_X86%\FV
 ```
 
 The example used contains Windows batch script %VARIABLES%.
 
-#FvFileBaseNames (Argument 2: Optional Part 1)
+# FvFileBaseNames (Argument 2: Optional Part 1)
 The firmware volume file base names (**_FvFileBaseNames_**) are the independent
-Fv?s that are to be patched within the FD. (0 or more in the form
-**FVFILEBASENAME:**) The colon **:** is used for delimiting the single
+FVs that are to be patched within the FD. (0 or more in the form
+**FvFileBaseNames:**) The colon **:** is used for delimiting the single
 argument and must be appended to the end of each (**_FvFileBaseNames_**).
 
-####Example usage:
+#### Example usage:
 ```
 STAGE1:STAGE2:MANIFEST:YOURPLATFORM
 ```
@@ -55,14 +55,14 @@ In the example **STAGE1** is **STAGE1.Fv** in **YOURPLATFORM.fd**.
 Firmware device file name to patch (**_FdFileNameToPatch_**) is the base name of
 the FD file that is to be patched. (1 only, in the form **YOURPLATFORM**)
 
-####Example usage:
+#### Example usage:
 ```
 STAGE1:STAGE2:MANIFEST:YOURPLATFORM
 ```
 
 In the example **YOURPLATFORM** is from **_YOURPLATFORM.fd_**
 
-#"Offset, Value[, Command][, Comment]" (Argument 3)
+# "Offset, Value[, Command][, Comment]" (Argument 3)
 The **_Offset_** can be a positive or negative number and represents where the
 **_Value_** to be patched is located within the FD. The **_Value_** is what
 will be written at the given **_Offset_** in the FD. Constants may be used for
@@ -79,10 +79,10 @@ The entire argument includes the quote marks like in the example argument below:
 0xFFFFFFC0, SomeCore:__EntryPoint - [0x000000F0],@SomeCore Entry
 ```
 
-###Constants:
+### Constants:
  Hexadecimal (use **0x** as prefix) | Decimal
 
-####Examples:
+#### Examples:
 
 | **Positive Hex** | **Negative Hex** | **Positive Decimal** | **Negative Decimal** |
 | ---------------: | ---------------: | -------------------: | -------------------: |
@@ -93,7 +93,7 @@ ModuleName:FunctionName | ModuleName:GlobalVariableName
 ModuleGuid:Offset
 ```
 
-###Operators:
+### Operators:
 
 ```
 
@@ -113,7 +113,7 @@ From version 0.60 tool allows to pass flash device file path as Argument 1 and
 flash device name as Argument 2 and rules for passing offset & value are same
 as explained in the previous sections.
 
-####Example usage:
+#### Example usage:
 Argument 1
 ```
  YouPlatformFspBinPkg\
@@ -123,21 +123,21 @@ Argument 2
  Fsp_Rebased_T
 ```
 
-###Special Commands:
+### Special Commands:
 Special commands must use the **$** symbol as a prefix to the command itself.
 There is only one command available at this time.
 
 ```
-$COPY ? Copy a binary block from source to destination.
+$COPY   Copy a binary block from source to destination.
 ```
 
-####Example:
+#### Example:
 
 ```
 0x94, [PlatformInit:__gPcd_BinPatch_FvRecOffset] + 0x94, [0x98], $COPY, @Sync up 2nd FSP Header
 ```
 
-###Comments:
+### Comments:
 Comments are allowed in the **Offset, Value [, Comment]** argument. Comments
 must use the **@** symbol as a prefix. The comment will output to the build
 window upon successful completion of patching along with the offset and value data.


### PR DESCRIPTION
According to the markdown language syntax, headings should be after number signs (#). The number of number signs correspond to the heading level.
But current PatchFvUserManual.md doesn't insert a space between the number signs and the heading title, resulting the markdown file is not rendered well in markdown viewers.

The patch doesn't change any content but only adds spaces to ensure the headings are correctly recognized.


Cc: Chasel Chiu <chasel.chiu@intel.com>
Reviewed-by: Nate DeSimone <nathaniel.l.desimone@intel.com>
Cc: Duggapu Chinni B <chinni.b.duggapu@intel.com>
Cc: Ray Han Lim Ng <ray.han.lim.ng@intel.com>
Cc: Star Zeng <star.zeng@intel.com>
Cc: Ted Kuo <ted.kuo@intel.com>
Reviewed-by: Ashraf Ali S <ashraf.ali.s@intel.com>
Cc: Susovan Mohapatra <susovan.mohapatra@intel.com>