### PR TITLE
UefiCpuPkg/MpInitLib: Use AsmCpuidEx() for CPUID_EXTENDED_TOPOLOGY leaf

### DIFF
--- a/UefiCpuPkg/Library/MpInitLib/AmdSev.c
+++ b/UefiCpuPkg/Library/MpInitLib/AmdSev.c
@@ -256,7 +256,14 @@ FillExchangeInfoDataSevEs (
   if (StdRangeMax >= CPUID_EXTENDED_TOPOLOGY) {
     CPUID_EXTENDED_TOPOLOGY_EBX  ExtTopoEbx;
 
-    AsmCpuid (CPUID_EXTENDED_TOPOLOGY, NULL, &ExtTopoEbx.Uint32, NULL, NULL);
+    AsmCpuidEx (
+      CPUID_EXTENDED_TOPOLOGY,
+      0,
+      NULL,
+      &ExtTopoEbx.Uint32,
+      NULL,
+      NULL
+      );
     ExchangeInfo->ExtTopoAvail = !!ExtTopoEbx.Bits.LogicalProcessors;
   }
 }


### PR DESCRIPTION
The CPUID_EXTENDED_TOPOLOGY CPUID leaf takes a subleaf as input when returning CPUID information. However, the AsmCpuid() function does not zero out ECX before the CPUID instruction, so the input leaf is used as the sub-leaf for the CPUID request and returns erroneous/invalid CPUID data, since the intent of the request was to get data related to sub-leaf 0. Instead, use AsmCpuidEx() for the CPUID_EXTENDED_TOPOLOGY leaf.

Fixes: d4d7c9ad5fe5 ("UefiCpuPkg/MpInitLib: use BSP to do extended ...")