### PR TITLE
IntelFsp2WrapperPkg: Add variable initialization

### DIFF
--- a/IntelFsp2WrapperPkg/Library/FspWrapperMultiPhaseProcessLib/PeiFspWrapperMultiPhaseProcessLib.c
+++ b/IntelFsp2WrapperPkg/Library/FspWrapperMultiPhaseProcessLib/PeiFspWrapperMultiPhaseProcessLib.c
@@ -80,6 +80,7 @@ CallFspMultiPhaseEntry (
   BOOLEAN                 IsVariableServiceRequest;
   FSP_MULTI_PHASE_PARAMS  *FspMultiPhaseParamsPtr;
 
+  FspMultiPhaseApiOffset   = 0;
   FspMultiPhaseParamsPtr   = (FSP_MULTI_PHASE_PARAMS *)FspMultiPhaseParams;
   IsVariableServiceRequest = FALSE;
   if ((FspMultiPhaseParamsPtr->MultiPhaseAction == EnumMultiPhaseGetVariableRequestInfo) ||


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4595

Fix build error when remove "-Wno-sometimes-uninitialized" option, Add variable "FspMultiPhaseApiOffset" initialization.

Cc: Nate DeSimone <nathaniel.l.desimone@intel.com>
Cc: Star Zeng <star.zeng@intel.com>
Cc: James Lu <james.lu@intel.com>
Cc: Gua Guo <gua.guo@intel.com>