### PR TITLE
OvmfPkg: Update TdVmCall to handle the retry for MapGPA 

### DIFF
--- a/MdePkg/Include/IndustryStandard/Tdx.h
+++ b/MdePkg/Include/IndustryStandard/Tdx.h
@@ -103,6 +103,8 @@
 #define TDVMCALL_REPORT_FATAL_ERR    0x10003
 #define TDVMCALL_SETUP_EVENT_NOTIFY  0x10004
 
+#define TDVMCALL_STATUS_RETRY  0x1
+
 #pragma pack(1)
 typedef struct {
   UINT64    Data[6];

--- a/MdePkg/Library/BaseLib/X64/TdVmcall.nasm
+++ b/MdePkg/Library/BaseLib/X64/TdVmcall.nasm
@@ -133,9 +133,7 @@ ASM_PFX(TdVmCall):
        test r9, r9
        jz .no_return_data
 
-       ; On success, propagate TDVMCALL output value to output param
-       test rax, rax
-       jnz .no_return_data
+       ; Propagate TDVMCALL output value to output param
        mov [r9], r11
 .no_return_data:
        tdcall_regs_postamble


### PR DESCRIPTION

REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4572

According to section 3.2 of the [GHCI] spec, if the result is 
"TDG.VP.VMCALL_RETRY" for TDG.VP.VMCALL.MapGPA, TD must retry the
mapping for the pages in the region starting at the GPA specified in r11.

Currently, TDVF does not properly handle the retry results of MapGPA.
For this, TDVF should update the TdVmCall to return the value in R11
and must retry the mapping for the pages by the value.

How to verify the retry for MapGPA in TDVF:
Note: Since the range size of MapGPA in QEMU is limited to 64MB and
TDVF always maps 1.5GB( 2GB~3.5GB) MMIO to shared-memory for TD guest, 
the retry action is triggered always.
Pre-Config:
QEMU:
https://github.com/intel/qemu-tdx/tree/tdx-qemu-upstream | tag: tdx-qemu-upstream-2023.10.20-v8.1.0
KERNEL:
https://github.com/intel/tdx/tree/kvm-upstream-2023.10.16-v6.6-rc2

Step:
Boot with TD guest and check the log with TdVmcall(MAPGPA), as below:
TdxDxe:SetMemorySharedOrPrivate: Cr3Base=0x0 Physical=0x80000000 Length=0x60000000 Mode=Shared
SetOrClearSharedBit: TdVmcall(MAPGPA) Retry PhysicalAddress is 8000080000000, MapGpaRetryaddr is 8000084000000

Reference:
[GHCI]: TDX Guest-Host-Communication Interface v1.0
https://cdrdv2.intel.com/v1/dl/getContent/726790

v2 changes:
  - Update the code based on the comments of v1 reviewer
  - Update TdVmcall to instead of the extra API file

v3 changes:
  - Move the definition of TDVMCALL_STATUS_RETRY to Tdx.h

v4 changes:
  - Split the patch to MdePkg update and OvmfPkg update.

code: https://github.com/sunceping/edk2/tree/handleRetryMapGPA.v4

Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Erdem Aktas <erdemaktas@google.com>
Cc: James Bottomley <jejb@linux.ibm.com>
Cc: Min Xu <min.m.xu@intel.com>
Cc: Tom Lendacky <thomas.lendacky@amd.com>
Cc: Michael Roth <michael.roth@amd.com>
Cc: Jiewen Yao <jiewen.yao@intel.com>
Acked-by: Gerd Hoffmann <kraxel@redhat.com>
Signed-off-by: Ceping Sun <cepingx.sun@intel.com>

Ceping Sun (3):
  MdePkg/BaseLib: Update TdVmcall to always output the value in R11
  MdePkg/Tdx.h: Add TDVMCALL_STATUS_RETRY
  OvmfPkg/BaseMemEncryptTdxLib: Handle retry result of MapGPA

 MdePkg/Include/IndustryStandard/Tdx.h         |  2 +
 MdePkg/Library/BaseLib/X64/TdVmcall.nasm      |  4 +-
 .../BaseMemEncryptTdxLib/MemoryEncryption.c   | 41 ++++++++++++++++++-
 3 files changed, 43 insertions(+), 4 deletions(-)
