### PR TITLE
UefiCpuPkg: Use NonSmm BSP as BSP if BSP election is not enabled.

### DIFF
--- a/UefiCpuPkg/PiSmmCpuDxeSmm/MpService.c
+++ b/UefiCpuPkg/PiSmmCpuDxeSmm/MpService.c
@@ -1953,6 +1953,16 @@ InitializeMpSyncData (
       // Enable BSP election by setting BspIndex to -1
       //
       mSmmMpSyncData->BspIndex = (UINT32)-1;
+    } else {
+      //
+      // Use NonSMM BSP as SMM BSP
+      //
+      for (CpuIndex = 0; CpuIndex < gSmmCpuPrivate->SmmCoreEntryContext.NumberOfCpus; CpuIndex++) {
+        if (GetApicId () == gSmmCpuPrivate->ProcessorInfo[CpuIndex].ProcessorId) {
+          mSmmMpSyncData->BspIndex = (UINT32)CpuIndex;
+          break;
+        }
+      }
     }
 
     mSmmMpSyncData->EffectiveSyncMode = mCpuSmmSyncMode;


### PR DESCRIPTION
Currently, if BSP election is not enabled, will use Core0 as SMM BSP, however, Core0 does not always have the highest performance core. So, we can used NonSmm BSP as default BSP.

Cc: Ray Ni <ray.ni@intel.com>
Cc: Rahul Kumar <rahul1.kumar@intel.com>
Cc: Gerd Hoffmann <kraxel@redhat.com>