### PR TITLE
Base tools get maintainer reviewers only v3

### DIFF
--- a/BaseTools/Scripts/GetMaintainer.py
+++ b/BaseTools/Scripts/GetMaintainer.py
@@ -105,10 +105,8 @@ def get_maintainers(path, sections, level=0):
     lists = []
     for section in sections:
         tmp_maint, tmp_lists = get_section_maintainers(path, section)
-        if tmp_maint:
-            maintainers += tmp_maint
-        if tmp_lists:
-            lists += tmp_lists
+        maintainers += tmp_maint
+        lists += tmp_lists
 
     if not maintainers:
         # If no match found, look for match for (nonexistent) file

--- a/BaseTools/Scripts/GetMaintainer.py
+++ b/BaseTools/Scripts/GetMaintainer.py
@@ -88,7 +88,7 @@ def get_section_maintainers(path, section):
             if isinstance(address, list):
                 maintainers += address
             else:
-                lists += [address]
+                maintainers += [address]
         for address in section['list']:
             # Convert to list if necessary
             if isinstance(address, list):

--- a/BaseTools/Scripts/GetMaintainer.py
+++ b/BaseTools/Scripts/GetMaintainer.py
@@ -192,14 +192,16 @@ if __name__ == '__main__':
     else:
         FILES = get_modified_files(REPO, ARGS)
 
-    ADDRESSES = []
-
+    # Accumulate a sorted list of addresses
+    ADDRESSES = set([])
     for file in FILES:
         print(file)
         recipients = get_maintainers(file, SECTIONS)
-        ADDRESSES += recipients['maintainers'] + recipients['reviewers'] + recipients['lists']
+        ADDRESSES |= set(recipients['maintainers'] + recipients['reviewers'] + recipients['lists'])
+    ADDRESSES = list(ADDRESSES)
+    ADDRESSES.sort()
 
-    for address in list(OrderedDict.fromkeys(ADDRESSES)):
+    for address in ADDRESSES:
         if '<' in address and '>' in address:
             address = address.split('>', 1)[0] + '>'
         print('  %s' % address)

--- a/BaseTools/Scripts/GetMaintainer.py
+++ b/BaseTools/Scripts/GetMaintainer.py
@@ -96,7 +96,7 @@ def get_section_maintainers(path, section):
             else:
                 lists += [address]
 
-    return maintainers, lists
+    return {'maintainers': maintainers, 'lists': lists}
 
 def get_maintainers(path, sections, level=0):
     """For 'path', iterates over all sections, returning maintainers
@@ -104,22 +104,24 @@ def get_maintainers(path, sections, level=0):
     maintainers = []
     lists = []
     for section in sections:
-        tmp_maint, tmp_lists = get_section_maintainers(path, section)
-        maintainers += tmp_maint
-        lists += tmp_lists
+        recipients = get_section_maintainers(path, section)
+        maintainers += recipients['maintainers']
+        lists += recipients['lists']
 
     if not maintainers:
         # If no match found, look for match for (nonexistent) file
         # REPO.working_dir/<default>
         print('"%s": no maintainers found, looking for default' % path)
         if level == 0:
-            maintainers = get_maintainers('<default>', sections, level=level + 1)
+            recipients = get_maintainers('<default>', sections, level=level + 1)
+            maintainers += recipients['maintainers']
+            lists += recipients['lists']
         else:
             print("No <default> maintainers set for project.")
         if not maintainers:
             return None
 
-    return maintainers + lists
+    return {'maintainers': maintainers, 'lists': lists}
 
 def parse_maintainers_line(line):
     """Parse one line of Maintainers.txt, returning any match group and its key."""
@@ -184,9 +186,8 @@ if __name__ == '__main__':
 
     for file in FILES:
         print(file)
-        addresslist = get_maintainers(file, SECTIONS)
-        if addresslist:
-            ADDRESSES += addresslist
+        recipients = get_maintainers(file, SECTIONS)
+        ADDRESSES += recipients['maintainers'] + recipients['lists']
 
     for address in list(OrderedDict.fromkeys(ADDRESSES)):
         if '<' in address and '>' in address:

--- a/BaseTools/Scripts/GetMaintainer.py
+++ b/BaseTools/Scripts/GetMaintainer.py
@@ -76,6 +76,7 @@ def get_section_maintainers(path, section):
     """Returns a list with email addresses to any M: and R: entries
        matching the provided path in the provided section."""
     maintainers = []
+    reviewers = []
     lists = []
     nowarn_status = ['Supported', 'Maintained']
 
@@ -83,12 +84,18 @@ def get_section_maintainers(path, section):
         for status in section['status']:
             if status not in nowarn_status:
                 print('WARNING: Maintained status for "%s" is \'%s\'!' % (path, status))
-        for address in section['maintainer'], section['reviewer']:
+        for address in section['maintainer']:
             # Convert to list if necessary
             if isinstance(address, list):
                 maintainers += address
             else:
                 maintainers += [address]
+        for address in section['reviewer']:
+            # Convert to list if necessary
+            if isinstance(address, list):
+                reviewers += address
+            else:
+                reviewers += [address]
         for address in section['list']:
             # Convert to list if necessary
             if isinstance(address, list):
@@ -96,16 +103,18 @@ def get_section_maintainers(path, section):
             else:
                 lists += [address]
 
-    return {'maintainers': maintainers, 'lists': lists}
+    return {'maintainers': maintainers, 'reviewers': reviewers, 'lists': lists}
 
 def get_maintainers(path, sections, level=0):
     """For 'path', iterates over all sections, returning maintainers
        for matching ones."""
     maintainers = []
+    reviewers = []
     lists = []
     for section in sections:
         recipients = get_section_maintainers(path, section)
         maintainers += recipients['maintainers']
+        reviewers += recipients['reviewers']
         lists += recipients['lists']
 
     if not maintainers:
@@ -115,13 +124,14 @@ def get_maintainers(path, sections, level=0):
         if level == 0:
             recipients = get_maintainers('<default>', sections, level=level + 1)
             maintainers += recipients['maintainers']
+            reviewers += recipients['reviewers']
             lists += recipients['lists']
         else:
             print("No <default> maintainers set for project.")
         if not maintainers:
             return None
 
-    return {'maintainers': maintainers, 'lists': lists}
+    return {'maintainers': maintainers, 'reviewers': reviewers, 'lists': lists}
 
 def parse_maintainers_line(line):
     """Parse one line of Maintainers.txt, returning any match group and its key."""
@@ -187,7 +197,7 @@ if __name__ == '__main__':
     for file in FILES:
         print(file)
         recipients = get_maintainers(file, SECTIONS)
-        ADDRESSES += recipients['maintainers'] + recipients['lists']
+        ADDRESSES += recipients['maintainers'] + recipients['reviewers'] + recipients['lists']
 
     for address in list(OrderedDict.fromkeys(ADDRESSES)):
         if '<' in address and '>' in address:


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4593

Fix logic bug where maintainers was incorrectly added to lists.

If a package only has reviewers and no maintainers, then also
return the <default> maintainers.

In order to detect this case, get_maintainers() is updated to
return maintainers, reviews, and lists separately instead of
a single merged list.  This also allows this module to be used
by other scripts that need to distinguish between maintainers,
reviewers, and lists.

Simplify logic that accumulates maintainers, reviewers, lists.

Sort the list of output addresses alphabetically and use set()
instead of OrderedDict() to accumulate unique addresses.

Changes since v2:
- Reworked internal return logic to use dictionaries.
- Reordered cleanup before new functionality.
Changes since v1:
- Split into patch series

Cc: Rebecca Cran <[rebecca@bsdio.com](mailto:rebecca@bsdio.com)>
Cc: Liming Gao <[gaoliming@byosoft.com.cn](mailto:gaoliming@byosoft.com.cn)>
Cc: Bob Feng <[bob.c.feng@intel.com](mailto:bob.c.feng@intel.com)>
Cc: Yuwei Chen <[yuwei.chen@intel.com](mailto:yuwei.chen@intel.com)>
Cc: Michael D Kinney <[michael.d.kinney@intel.com](mailto:michael.d.kinney@intel.com)>