### PR TITLE
CloudHv: support guests w/ >1TiB of high memory.

### DIFF
--- a/OvmfPkg/CloudHv/CloudHvX64.dsc
+++ b/OvmfPkg/CloudHv/CloudHvX64.dsc
@@ -565,6 +565,8 @@
   # Point to the MdeModulePkg/Application/UiApp/UiApp.inf
   gEfiMdeModulePkgTokenSpaceGuid.PcdBootManagerMenuFile|{ 0x21, 0xaa, 0x2c, 0x46, 0x14, 0x76, 0x03, 0x45, 0x83, 0x6e, 0x8a, 0xb6, 0xf4, 0x66, 0x23, 0x31 }
 
+  gEfiMdeModulePkgTokenSpaceGuid.PcdUse1GPageTable|TRUE
+
 ################################################################################
 #
 # Pcd Dynamic Section - list of all EDK II PCD Entries defined by this Platform

--- a/OvmfPkg/Library/PlatformInitLib/MemDetect.c
+++ b/OvmfPkg/Library/PlatformInitLib/MemDetect.c
@@ -249,6 +249,67 @@ PlatformReservationConflictCB (
 }
 
 /**
+  Returns PVH memmap
+  @param Entries      Pointer to PVH memmap
+  @param Count        Number of entries
+  @return EFI_STATUS
+**/
+EFI_STATUS
+GetPvhMemmapEntries (
+  struct hvm_memmap_table_entry  **Entries,
+  UINT32                         *Count
+  )
+{
+  UINT32                 *PVHResetVectorData;
+  struct hvm_start_info  *pvh_start_info;
+
+  PVHResetVectorData = (VOID *)(UINTN)PcdGet32 (PcdXenPvhStartOfDayStructPtr);
+  if (PVHResetVectorData == 0) {
+    return EFI_NOT_FOUND;
+  }
+
+  pvh_start_info = (struct hvm_start_info *)(UINTN)PVHResetVectorData[0];
+
+  *Entries = (struct hvm_memmap_table_entry *)(UINTN)pvh_start_info->memmap_paddr;
+  *Count   = pvh_start_info->memmap_entries;
+
+  return EFI_SUCCESS;
+}
+
+STATIC
+EFI_STATUS
+PlatformScanE820Pvh (
+  IN      E820_SCAN_CALLBACK     Callback,
+  IN OUT  EFI_HOB_PLATFORM_INFO  *PlatformInfoHob
+  )
+{
+  struct hvm_memmap_table_entry  *Memmap;
+  UINT32                         MemmapEntriesCount;
+  struct hvm_memmap_table_entry  *Entry;
+  EFI_E820_ENTRY64               E820Entry;
+  EFI_STATUS                     Status;
+  UINT32                         Loop;
+
+  Status = GetPvhMemmapEntries (&Memmap, &MemmapEntriesCount);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  for (Loop = 0; Loop < MemmapEntriesCount; Loop++) {
+    Entry = Memmap + Loop;
+
+    if (Entry->type == XEN_HVM_MEMMAP_TYPE_RAM) {
+      E820Entry.BaseAddr = Entry->addr;
+      E820Entry.Length = Entry->size;
+      E820Entry.Type = Entry->type;
+      Callback (&E820Entry, PlatformInfoHob);
+    }
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
   Iterate over the entries in QEMU's fw_cfg E820 RAM map, call the
   passed callback for each entry.
 
@@ -279,6 +340,10 @@ PlatformScanE820 (
   EFI_E820_ENTRY64      E820Entry;
   UINTN                 Processed;
 
+  if (PlatformInfoHob->HostBridgeDevId == CLOUDHV_DEVICE_ID) {
+    return PlatformScanE820Pvh (Callback, PlatformInfoHob);
+  }
+
   Status = QemuFwCfgFindFile ("etc/e820", &FwCfgItem, &FwCfgSize);
   if (EFI_ERROR (Status)) {
     return Status;
@@ -293,36 +358,6 @@ PlatformScanE820 (
     QemuFwCfgReadBytes (sizeof E820Entry, &E820Entry);
     Callback (&E820Entry, PlatformInfoHob);
   }
-
-  return EFI_SUCCESS;
-}
-
-/**
-  Returns PVH memmap
-
-  @param Entries      Pointer to PVH memmap
-  @param Count        Number of entries
-
-  @return EFI_STATUS
-**/
-EFI_STATUS
-GetPvhMemmapEntries (
-  struct hvm_memmap_table_entry  **Entries,
-  UINT32                         *Count
-  )
-{
-  UINT32                 *PVHResetVectorData;
-  struct hvm_start_info  *pvh_start_info;
-
-  PVHResetVectorData = (VOID *)(UINTN)PcdGet32 (PcdXenPvhStartOfDayStructPtr);
-  if (PVHResetVectorData == 0) {
-    return EFI_NOT_FOUND;
-  }
-
-  pvh_start_info = (struct hvm_start_info *)(UINTN)PVHResetVectorData[0];
-
-  *Entries = (struct hvm_memmap_table_entry *)(UINTN)pvh_start_info->memmap_paddr;
-  *Count   = pvh_start_info->memmap_entries;
 
   return EFI_SUCCESS;
 }


### PR DESCRIPTION
When booting cloud-hypervisor guests with greater than 1TiB of high memory, the PlatformAddressWidthInitialization function incorrect calculates the address width using the overflowed 24-bit CMOS register rather than the E820 entries.
See [this](https://github.com/tianocore/edk2/commit/1fceaddb12b59e5711b26f26859e324e7a8e212a) PR for context.

This PR adds support for the commonly used PlatformScanE820 helper function to correctly read PVH E820 entries on CloudHv guests.
