### PR TITLE
MdeModulePkg/Variable: Merge variable header + data update into one step

### DIFF
--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/Variable.c
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/Variable.c
@@ -2168,11 +2168,9 @@ UpdateVariable (
 
     if (!mVariableModuleGlobal->VariableGlobal.EmuNvMode) {
       //
-      // Four steps
-      // 1. Write variable header
-      // 2. Set variable state to header valid
-      // 3. Write variable data
-      // 4. Set variable state to valid
+      // Two steps
+      // 1. Write variable header and data
+      // 2. Set variable state to valid
       //
       //
       // Step 1:
@@ -2183,7 +2181,7 @@ UpdateVariable (
                  TRUE,
                  Fvb,
                  mVariableModuleGlobal->NonVolatileLastVariableOffset,
-                 (UINT32)GetVariableHeaderSize (AuthFormat),
+                 (UINT32)VarSize,
                  (UINT8 *)NextVariable
                  );
 
@@ -2193,41 +2191,6 @@ UpdateVariable (
 
       //
       // Step 2:
-      //
-      NextVariable->State = VAR_HEADER_VALID_ONLY;
-      Status              = UpdateVariableStore (
-                              &mVariableModuleGlobal->VariableGlobal,
-                              FALSE,
-                              TRUE,
-                              Fvb,
-                              mVariableModuleGlobal->NonVolatileLastVariableOffset + OFFSET_OF (VARIABLE_HEADER, State),
-                              sizeof (UINT8),
-                              &NextVariable->State
-                              );
-
-      if (EFI_ERROR (Status)) {
-        goto Done;
-      }
-
-      //
-      // Step 3:
-      //
-      Status = UpdateVariableStore (
-                 &mVariableModuleGlobal->VariableGlobal,
-                 FALSE,
-                 TRUE,
-                 Fvb,
-                 mVariableModuleGlobal->NonVolatileLastVariableOffset + GetVariableHeaderSize (AuthFormat),
-                 (UINT32)(VarSize - GetVariableHeaderSize (AuthFormat)),
-                 (UINT8 *)NextVariable + GetVariableHeaderSize (AuthFormat)
-                 );
-
-      if (EFI_ERROR (Status)) {
-        goto Done;
-      }
-
-      //
-      // Step 4:
       //
       NextVariable->State = VAR_ADDED;
       Status              = UpdateVariableStore (


### PR DESCRIPTION
REF:https://bugzilla.tianocore.org/show_bug.cgi?id=4597

When creating a new variable, skip marking VAR_HEADER_VALID_ONLY so that variable header + data update can be merged into one flash write. This will greatly reduce the time taken for updating a variable and thus increase performance. Removing VAR_HEADER_VALID_ONLY marking doesn't have any function impact since it's not used by current code to detect variable header + data corruption.

Cc: Liming Gao <gaoliming@byosoft.com.cn>