### PR TITLE
Wait for all net interfaces installed

### DIFF
--- a/RedfishPkg/RedfishDiscoverDxe/RedfishDiscoverDxe.c
+++ b/RedfishPkg/RedfishDiscoverDxe/RedfishDiscoverDxe.c
@@ -1547,25 +1547,26 @@ TestForRequiredProtocols (
                     ControllerHandle,
                     EFI_OPEN_PROTOCOL_TEST_PROTOCOL
                     );
+    if (EFI_ERROR (Status)) {
+      return EFI_UNSUPPORTED;
+    }
+
+    Status = gBS->OpenProtocol (
+                    ControllerHandle,
+                    gRequiredProtocol[Index].DiscoveredProtocolGuid,
+                    (VOID **)&Id,
+                    This->DriverBindingHandle,
+                    ControllerHandle,
+                    EFI_OPEN_PROTOCOL_GET_PROTOCOL
+                    );
     if (!EFI_ERROR (Status)) {
-      Status = gBS->OpenProtocol (
-                      ControllerHandle,
-                      gRequiredProtocol[Index].DiscoveredProtocolGuid,
-                      (VOID **)&Id,
-                      This->DriverBindingHandle,
-                      ControllerHandle,
-                      EFI_OPEN_PROTOCOL_GET_PROTOCOL
-                      );
-      if (EFI_ERROR (Status)) {
-        if (Index == ListCount - 1) {
-          DEBUG ((DEBUG_INFO, "%a: all required protocols are found on this controller handle: %p.\n", __func__, ControllerHandle));
-          return EFI_SUCCESS;
-        }
-      }
+      // Already installed
+      return EFI_UNSUPPORTED;
     }
   }
 
-  return EFI_UNSUPPORTED;
+  DEBUG ((DEBUG_MANAGEABILITY, "%a: all required protocols are found on this controller handle: %p.\n", __func__, ControllerHandle));
+  return EFI_SUCCESS;
 }
 
 /**

--- a/RedfishPkg/RedfishDiscoverDxe/RedfishDiscoverInternal.h
+++ b/RedfishPkg/RedfishDiscoverDxe/RedfishDiscoverInternal.h
@@ -39,6 +39,12 @@
 #define REDFISH_DISCOVER_VERSION                    0x00010000
 #define EFI_REDFISH_DISCOVER_NETWORK_INTERFACE_TPL  TPL_NOTIFY
 
+#define MAC_COMPARE(ThisNetworkInterface, TargetNetworkInterface)  (CompareMem ((VOID *)&ThisNetworkInterface->MacAddress, &TargetNetworkInterface->MacAddress, ThisNetworkInterface->HwAddressSize))
+#define VALID_TCP6(TargetNetworkInterface, ThisNetworkInterface)   (TargetNetworkInterface->IsIpv6 && (ThisNetworkInterface->NetworkProtocolType == ProtocolTypeTcp6))
+#define VALID_TCP4(TargetNetworkInterface, ThisNetworkInterface)   (!TargetNetworkInterface->IsIpv6 && (ThisNetworkInterface->NetworkProtocolType == ProtocolTypeTcp4))
+#define IS_TCP4_MATCH(IpType)                                      ((gRequiredProtocol[Index].ProtocolType == ProtocolTypeTcp4) && (IpType != REDFISH_HOST_INTERFACE_HOST_IP_ADDRESS_FORMAT_IP4))
+#define IS_TCP6_MATCH(IpType)                                      ((gRequiredProtocol[Index].ProtocolType == ProtocolTypeTcp6) && (IpType != REDFISH_HOST_INTERFACE_HOST_IP_ADDRESS_FORMAT_IP6))
+
 //
 // GUID definitions
 //


### PR DESCRIPTION
Supported function of the driver changed to wait for all network
interface to be installed.
Filter out the network interfaces which are not supported by
Redfish Host Interface.
