### PR TITLE
TESTING-ONLY: OvmfPkg/MemEncryptSevLib: Fix address overflow during PVALIDATE (v2)

### DIFF
--- a/OvmfPkg/Library/BaseMemEncryptSevLib/X64/SnpPageStateChangeInternal.c
+++ b/OvmfPkg/Library/BaseMemEncryptSevLib/X64/SnpPageStateChangeInternal.c
@@ -78,13 +78,14 @@ PvalidateRange (
   IN  BOOLEAN                     Validate
   )
 {
-  UINTN  Address, RmpPageSize, Ret, i;
+  UINTN                 RmpPageSize, Ret, i;
+  EFI_PHYSICAL_ADDRESS  Address;
 
   for ( ; StartIndex <= EndIndex; StartIndex++) {
     //
     // Get the address and the page size from the Info.
     //
-    Address     = Info->Entry[StartIndex].GuestFrameNumber << EFI_PAGE_SHIFT;
+    Address     = ((EFI_PHYSICAL_ADDRESS)Info->Entry[StartIndex].GuestFrameNumber) << EFI_PAGE_SHIFT;
     RmpPageSize = Info->Entry[StartIndex].PageSize;
 
     Ret = AsmPvalidate (RmpPageSize, Validate, Address);


### PR DESCRIPTION
The struct used for GHCB-based page-state change requests uses a 40-bit bit-field for the GFN, which is shifted by PAGE_SHIFT to generate a 64-bit address. However, anything beyond 40-bits simply gets shifted off when doing this, which will cause issues when dealing with 1TB+ addresses. Fix this by casting the 40-bit GFN values to 64-bit ones prior to shifting it by PAGE_SHIFT.

Fixes: ade62c18f474 ("OvmfPkg/MemEncryptSevLib: add support to validate system RAM")