### PR TITLE
StandaloneMmPkg/Core: Restart dispatcher once MmEntryPoint is registered

### DIFF
--- a/StandaloneMmPkg/Core/StandaloneMmCore.c
+++ b/StandaloneMmPkg/Core/StandaloneMmCore.c
@@ -84,6 +84,7 @@ EFI_MM_SYSTEM_TABLE  gMmCoreMmst = {
 // Table of MMI Handlers that are registered by the MM Core when it is initialized
 //
 MM_CORE_MMI_HANDLERS  mMmCoreMmiHandlers[] = {
+  { MmDriverDispatchHandler,  &gEfiEventDxeDispatchGuid,         NULL, TRUE  },
   { MmReadyToLockHandler,     &gEfiDxeMmReadyToLockProtocolGuid, NULL, TRUE  },
   { MmEndOfDxeHandler,        &gEfiEndOfDxeEventGroupGuid,       NULL, FALSE },
   { MmExitBootServiceHandler, &gEfiEventExitBootServicesGuid,    NULL, FALSE },

--- a/StandaloneMmPkg/Core/StandaloneMmCore.inf
+++ b/StandaloneMmPkg/Core/StandaloneMmCore.inf
@@ -76,6 +76,9 @@
   gEfiEventExitBootServicesGuid
   gEfiEventReadyToBootGuid
 
+[Pcd]
+  gStandaloneMmPkgTokenSpaceGuid.PcdRestartMmDispatcherOnceMmEntryRegistered
+
 #
 # This configuration fails for CLANGPDB, which does not support PIE in the GCC
 # sense. Such however is required for ARM family StandaloneMmCore

--- a/StandaloneMmPkg/StandaloneMmPkg.dec
+++ b/StandaloneMmPkg/StandaloneMmPkg.dec
@@ -48,3 +48,9 @@
   gEfiStandaloneMmNonSecureBufferGuid      = { 0xf00497e3, 0xbfa2, 0x41a1, { 0x9d, 0x29, 0x54, 0xc2, 0xe9, 0x37, 0x21, 0xc5 }}
   gEfiArmTfCpuDriverEpDescriptorGuid       = { 0x6ecbd5a1, 0xc0f8, 0x4702, { 0x83, 0x01, 0x4f, 0xc2, 0xc5, 0x47, 0x0a, 0x51 }}
 
+[PcdsFeatureFlag]
+  ## Indicates if restart MM Dispatcher once MM Entry Point is registered.<BR><BR>
+  #   TRUE  - Restart MM Dispatcher once MM Entry Point is registered.<BR>
+  #   FALSE - Do not restart MM Dispatcher once MM Entry Point is registered.<BR>
+  # @Prompt Restart MM Dispatcher once MM Entry Point is registered.
+  gStandaloneMmPkgTokenSpaceGuid.PcdRestartMmDispatcherOnceMmEntryRegistered|FALSE|BOOLEAN|0x00000001


### PR DESCRIPTION
Defer the dispatch of the remaining MM drivers once the CPU driver has been dispatched.

REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4599

In MmDispatcher, return immediately if the MM Entry Point was registered. Then the MM IPL will reinvoke the MM Core Dispatcher. This is required so MM Mode may be enabled as soon as all the dependent MM Drivers for MM Mode have been dispatched.

Introduce a FeatureFlag PCD to control if MmDispatcher returns or not when MmEntryPointPoint is registered. Default value is FALSE.

Cc: Ard Biesheuvel <ardb+tianocore@kernel.org>
Cc: Sami Mujawar <sami.mujawar@arm.com>
Cc: Ray Ni <ray.ni@intel.com>