### PR TITLE
MdeModulePkg/DxeCapsuleLibFmp: Fix crash with VirtualAddressMap omitted

### DIFF
--- a/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleLib.c
+++ b/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleLib.c
@@ -41,8 +41,7 @@
 #include <Protocol/FirmwareManagementProgress.h>
 #include <Protocol/DevicePath.h>
 
-EFI_SYSTEM_RESOURCE_TABLE  *mEsrtTable             = NULL;
-BOOLEAN                    mIsVirtualAddrConverted = FALSE;
+EFI_SYSTEM_RESOURCE_TABLE  *mEsrtTable = NULL;
 
 BOOLEAN    mDxeCapsuleLibEndOfDxe      = FALSE;
 EFI_EVENT  mDxeCapsuleLibEndOfDxeEvent = NULL;
@@ -1394,14 +1393,12 @@ IsNestedFmpCapsule (
   EFI_SYSTEM_RESOURCE_ENTRY  Entry;
 
   EsrtGuidFound = FALSE;
-  if (mIsVirtualAddrConverted) {
-    if (mEsrtTable != NULL) {
-      EsrtEntry = (EFI_SYSTEM_RESOURCE_ENTRY *)(mEsrtTable + 1);
-      for (Index = 0; Index < mEsrtTable->FwResourceCount; Index++, EsrtEntry++) {
-        if (CompareGuid (&EsrtEntry->FwClass, &CapsuleHeader->CapsuleGuid)) {
-          EsrtGuidFound = TRUE;
-          break;
-        }
+  if (mEsrtTable != NULL) {
+    EsrtEntry = (EFI_SYSTEM_RESOURCE_ENTRY *)(mEsrtTable + 1);
+    for (Index = 0; Index < mEsrtTable->FwResourceCount; Index++, EsrtEntry++) {
+      if (CompareGuid (&EsrtEntry->FwClass, &CapsuleHeader->CapsuleGuid)) {
+        EsrtGuidFound = TRUE;
+        break;
       }
     }
   } else {

--- a/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleRuntime.c
+++ b/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleRuntime.c
@@ -21,7 +21,6 @@
 #include <Library/MemoryAllocationLib.h>
 
 extern EFI_SYSTEM_RESOURCE_TABLE  *mEsrtTable;
-extern BOOLEAN                    mIsVirtualAddrConverted;
 EFI_EVENT                         mDxeRuntimeCapsuleLibVirtualAddressChangeEvent = NULL;
 EFI_EVENT                         mDxeRuntimeCapsuleLibReadyToBootEvent          = NULL;
 
@@ -40,7 +39,6 @@ DxeCapsuleLibVirtualAddressChangeEvent (
   )
 {
   gRT->ConvertPointer (EFI_OPTIONAL_PTR, (VOID **)&mEsrtTable);
-  mIsVirtualAddrConverted = TRUE;
 }
 
 /**


### PR DESCRIPTION
If the SetVirtualAddressMap() is not called, mIsVirtualAddrConverted is FALSE and the kernel crash occurs in IsNestedFmpCapsule() when executing gBS->LocateProtocol () in the else case.

To serve the omitted SetVirtualAddressMap() call, we could just check mEsrtTable presence instead of relying on mIsVirtualAddrConverted.

Signed-off-by: Nhi Pham <nhi@os.amperecomputing.com>
Reviewed-by: Ard Biesheuvel <ardb@kernel.org>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>