### PR TITLE
NetworkPkg: Triger timely scan only if not connect to AP

### DIFF
--- a/NetworkPkg/WifiConnectionManagerDxe/WifiConnectionMgrImpl.c
+++ b/NetworkPkg/WifiConnectionManagerDxe/WifiConnectionMgrImpl.c
@@ -1506,8 +1506,8 @@ WifiMgrOnTimerTick (
   }
 
   Nic->ScanTickTime++;
-  if (((Nic->ScanTickTime > WIFI_SCAN_FREQUENCY) || Nic->OneTimeScanRequest) &&
-      (Nic->ScanState == WifiMgrScanFinished))
+  if ((((Nic->ScanTickTime > WIFI_SCAN_FREQUENCY) && (Nic->ConnectState != WifiMgrConnectedToAp)) ||
+       Nic->OneTimeScanRequest) && (Nic->ScanState == WifiMgrScanFinished))
   {
     Nic->OneTimeScanRequest = FALSE;
     Nic->ScanTickTime       = 0;


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4605

When UEFI Wi-Fi is in BSS connected state, the platform is considered as a static and Wi-Fi roaming support is not needed. Wifi connection manager should not initiate Scan requests in this state affect BSS client connectivity and must be avoided. Triger timely scan only if not connect to AP.


Cc: Saloni Kasbekar <saloni.kasbekar@intel.com>
Cc: Zachary Clark-williams <zachary.clark-williams@intel.com>