### PR TITLE
ArmPkg/CpuDxe: Use upper and lower attributes

### DIFF
--- a/ArmPkg/Drivers/CpuDxe/AArch64/Mmu.c
+++ b/ArmPkg/Drivers/CpuDxe/AArch64/Mmu.c
@@ -13,7 +13,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/MemoryAllocationLib.h>
 #include "CpuDxe.h"
 
-#define INVALID_ENTRY  ((UINT32)~0)
+#define INVALID_ENTRY  ((UINT64)~0)
 
 #define MIN_T0SZ        16
 #define BITS_PER_LEVEL  9
@@ -169,14 +169,14 @@ GetNextEntryAttribute (
   IN     UINTN   EntryCount,
   IN     UINTN   TableLevel,
   IN     UINT64  BaseAddress,
-  IN OUT UINT32  *PrevEntryAttribute,
+  IN OUT UINT64  *PrevEntryAttribute,
   IN OUT UINT64  *StartGcdRegion
   )
 {
   UINTN                            Index;
   UINT64                           Entry;
-  UINT32                           EntryAttribute;
-  UINT32                           EntryType;
+  UINT64                           EntryAttribute;
+  UINT64                           EntryType;
   EFI_STATUS                       Status;
   UINTN                            NumberOfDescriptors;
   EFI_GCD_MEMORY_SPACE_DESCRIPTOR  *MemorySpaceMap;
@@ -271,7 +271,7 @@ SyncCacheConfig (
   )
 {
   EFI_STATUS                       Status;
-  UINT32                           PageAttribute;
+  UINT64                           PageAttribute;
   UINT64                           *FirstLevelTableAddress;
   UINTN                            TableLevel;
   UINTN                            TableCount;


### PR DESCRIPTION
GetNextEntryAttribute() is currently applying a 64-bit mask
(TT_ATTRIBUTES_MASK) to a 32-bit descriptor value (EntryType).
The original descriptor was 64 bits containing the upper and
lower attributes which are included in TT_ATTRIBUTES_MASK.

The PrevEntryAttribute parameter is also a UINT32, but passed to
PageAttributeToGcdAttribute() for a UINT64 parameter where the
function checks masks in the upper 32 bits of the integer value:

```
  PageAttributeToGcdAttribute (*PrevEntryAttribute)
  ...
  STATIC
  UINT64
  PageAttributeToGcdAttribute (
    IN UINT64  PageAttributes
    )
  ...
  if ((PageAttributes & (TT_PXN_MASK | TT_UXN_MASK)) != 0) {
    GcdAttributes |= EFI_MEMORY_XP;
  }
  ...
  #define TT_PXN_MASK  BIT53
  #define TT_UXN_MASK  BIT54  // EL1&0
```

This change removes UINT32 intermediary values. For EntryType,
eliminating an unncessary cast. For EntryAttribute, preserving the
upper and lower attributes for evaluation in
PageAttributeToGcdAttribute().

This also resolves the following compiler warning previously present
on Visual Studio for the assignment to the previously 32-bit local
variables.

  '=': conversion from 'UINT64' to 'UINT32', possible loss of data

Cc: Ard Biesheuvel <ardb+tianocore@kernel.org>
Cc: Leif Lindholm <quic_llindhol@quicinc.com>
Cc: Sami Mujawar <sami.mujawar@arm.com>
Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>