### PR TITLE
ArmPkg/ArmMmuLib: Use function pointer type

### DIFF
--- a/ArmPkg/Library/ArmMmuLib/AArch64/ArmMmuLibCore.c
+++ b/ArmPkg/Library/ArmMmuLib/AArch64/ArmMmuLibCore.c
@@ -20,16 +20,9 @@
 #include <Library/BaseLib.h>
 #include <Library/DebugLib.h>
 #include <Library/HobLib.h>
+#include "ArmMmuLibInternal.h"
 
-STATIC
-VOID (
-  EFIAPI  *mReplaceLiveEntryFunc
-  )(
-    IN  UINT64  *Entry,
-    IN  UINT64  Value,
-    IN  UINT64  RegionStart,
-    IN  BOOLEAN DisableMmu
-    ) = ArmReplaceLiveTranslationEntry;
+STATIC  ARM_REPLACE_LIVE_TRANSLATION_ENTRY  mReplaceLiveEntryFunc = ArmReplaceLiveTranslationEntry;
 
 STATIC
 UINT64
@@ -742,7 +735,7 @@ ArmMmuBaseLibConstructor (
 
   Hob = GetFirstGuidHob (&gArmMmuReplaceLiveTranslationEntryFuncGuid);
   if (Hob != NULL) {
-    mReplaceLiveEntryFunc = *(VOID **)GET_GUID_HOB_DATA (Hob);
+    mReplaceLiveEntryFunc = *(ARM_REPLACE_LIVE_TRANSLATION_ENTRY *)GET_GUID_HOB_DATA (Hob);
   } else {
     //
     // The ArmReplaceLiveTranslationEntry () helper function may be invoked

--- a/ArmPkg/Library/ArmMmuLib/AArch64/ArmMmuPeiLibConstructor.c
+++ b/ArmPkg/Library/ArmMmuLib/AArch64/ArmMmuPeiLibConstructor.c
@@ -13,6 +13,7 @@
 #include <Library/CacheMaintenanceLib.h>
 #include <Library/DebugLib.h>
 #include <Library/HobLib.h>
+#include "ArmMmuLibInternal.h"
 
 EFI_STATUS
 EFIAPI
@@ -21,9 +22,9 @@ ArmMmuPeiLibConstructor (
   IN CONST EFI_PEI_SERVICES     **PeiServices
   )
 {
-  extern UINT32  ArmReplaceLiveTranslationEntrySize;
-  VOID           *ArmReplaceLiveTranslationEntryFunc;
-  VOID           *Hob;
+  extern UINT32                       ArmReplaceLiveTranslationEntrySize;
+  ARM_REPLACE_LIVE_TRANSLATION_ENTRY  ArmReplaceLiveTranslationEntryFunc;
+  VOID                                *Hob;
 
   EFI_FV_FILE_INFO  FileInfo;
   EFI_STATUS        Status;

--- a/ArmPkg/Library/ArmMmuLib/ArmMmuBaseLib.inf
+++ b/ArmPkg/Library/ArmMmuLib/ArmMmuBaseLib.inf
@@ -19,10 +19,12 @@
   CONSTRUCTOR                    = ArmMmuBaseLibConstructor
 
 [Sources.AARCH64]
+  ArmMmuLibInternal.h
   AArch64/ArmMmuLibCore.c
   AArch64/ArmMmuLibReplaceEntry.S
 
 [Sources.ARM]
+  ArmMmuLibInternal.h
   Arm/ArmMmuLibConvert.c
   Arm/ArmMmuLibCore.c
   Arm/ArmMmuLibUpdate.c

--- a/ArmPkg/Library/ArmMmuLib/ArmMmuLibInternal.h
+++ b/ArmPkg/Library/ArmMmuLib/ArmMmuLibInternal.h
@@ -1,0 +1,23 @@
+/** @file
+  Arm MMU library instance internal header file.
+
+  Copyright (C) Microsoft Corporation. All rights reserved.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef ARM_MMU_LIB_INTERNAL_H_
+#define ARM_MMU_LIB_INTERNAL_H_
+
+typedef
+VOID(
+ EFIAPI  *ARM_REPLACE_LIVE_TRANSLATION_ENTRY
+ )(
+  IN  UINT64  *Entry,
+  IN  UINT64  Value,
+  IN  UINT64  RegionStart,
+  IN  BOOLEAN DisableMmu
+  );
+
+#endif

--- a/ArmPkg/Library/ArmMmuLib/ArmMmuPeiLib.inf
+++ b/ArmPkg/Library/ArmMmuLib/ArmMmuPeiLib.inf
@@ -17,6 +17,7 @@
   CONSTRUCTOR                    = ArmMmuPeiLibConstructor
 
 [Sources.AARCH64]
+  ArmMmuLibInternal.h
   AArch64/ArmMmuLibCore.c
   AArch64/ArmMmuPeiLibConstructor.c
   AArch64/ArmMmuLibReplaceEntry.S


### PR DESCRIPTION
mReplaceLiveEntryFunc is a function pointer but assigned as a VOID* pointer:

  mReplaceLiveEntryFunc = *(VOID **)GET_GUID_HOB_DATA (Hob);

This leads to the Visual Studio warning:

  nonstandard extension, function/data pointer conversion in
  expression

This change updates the assignment to avoid using a data pointer and defines a type for the function pointer to succinctly and accurately refer to the type when it is used in the library code.


Reviewed-by: Ard Biesheuvel <ardb@kernel.org>