### PR TITLE
RedfishPkg/HostInterfaceBmcUsbNic: Set default Redfish service port

### DIFF
--- a/RedfishPkg/Library/PlatformHostInterfaceBmcUsbNicLib/PlatformHostInterfaceBmcUsbNicLib.c
+++ b/RedfishPkg/Library/PlatformHostInterfaceBmcUsbNicLib/PlatformHostInterfaceBmcUsbNicLib.c
@@ -244,7 +244,7 @@ RedfishPlatformHostInterfaceProtocolData (
         );
 
       // RedfishServiceIpPort
-      RedfishOverIpData->RedfishServiceIpPort = 0;
+      RedfishOverIpData->RedfishServiceIpPort = PcdGet16 (PcdRedfishServicePort);
 
       // RedfishServiceVlanId
       RedfishOverIpData->RedfishServiceVlanId = ThisInstance->VLanId;

--- a/RedfishPkg/Library/PlatformHostInterfaceBmcUsbNicLib/PlatformHostInterfaceBmcUsbNicLib.inf
+++ b/RedfishPkg/Library/PlatformHostInterfaceBmcUsbNicLib/PlatformHostInterfaceBmcUsbNicLib.inf
@@ -43,6 +43,7 @@
 [Pcd]
   gEfiRedfishPkgTokenSpaceGuid.PcdRedfishHostName     ## CONSUMED
   gEfiRedfishPkgTokenSpaceGuid.PcdRedfishServiceUuid  ## CONSUMED
+  gEfiRedfishPkgTokenSpaceGuid.PcdRedfishServicePort  ## CONSUMED
 
 [Depex]
   gIpmiProtocolGuid

--- a/RedfishPkg/RedfishPkg.dec
+++ b/RedfishPkg/RedfishPkg.dec
@@ -138,12 +138,16 @@
   # specification for that.
   #
   gEfiRedfishPkgTokenSpaceGuid.PcdRedfishServiceUuid|L"00000000-0000-0000-0000-000000000000"|VOID*|0x00001006
+  # Use PCD to declare the Redfish service port, default set to port 443.
+  # Platform can overide this value in platform DSC file.
+  #
+  gEfiRedfishPkgTokenSpaceGuid.PcdRedfishServicePort|443|UINT16|0x00001007
   #
   # This PCD indicates that if BMC bootstrap credential service will be disabled by BIOS or not.
   #
-  gEfiRedfishPkgTokenSpaceGuid.PcdRedfishDisableBootstrapCredentialService|FALSE|BOOLEAN|0x00001007
+  gEfiRedfishPkgTokenSpaceGuid.PcdRedfishDisableBootstrapCredentialService|FALSE|BOOLEAN|0x00001008
   #
   # The EFI_REST_EX_HTTP_CONFIG_DATA.SendReceiveTimeout value that RedfishDiscoverDxe driver
   # set to EFI_REST_EX_PROTOCOL.
   #
-  gEfiRedfishPkgTokenSpaceGuid.PcdRedfishSendReceiveTimeout|5000|UINT32|0x00001008
+  gEfiRedfishPkgTokenSpaceGuid.PcdRedfishSendReceiveTimeout|5000|UINT32|0x00001009


### PR DESCRIPTION
BZ #4607
Create a PCD for the default Redfish service port.


Cc: Nickle Wang <nicklew@nvidia.com>
Cc: Igor Kulchytskyy <igork@ami.com>
Cc: Mike Maslenkin <mike.maslenkin@gmail.com>
Reviewed-by: Nickle Wang <nicklew@nvidia.com>