### PR TITLE
PcAtChipsetPkg: Fix AcpiTimerLib incompatibility with XhciDxe

### DIFF
--- a/PcAtChipsetPkg/Library/AcpiTimerLib/DxeStandaloneMmAcpiTimerLib.c
+++ b/PcAtChipsetPkg/Library/AcpiTimerLib/DxeStandaloneMmAcpiTimerLib.c
@@ -1,7 +1,7 @@
 /** @file
   ACPI Timer implements one instance of Timer Library.
 
-  Copyright (c) 2013 - 2018, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2013 - 2023, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -10,6 +10,11 @@
 #include <Library/TimerLib.h>
 #include <Library/BaseLib.h>
 #include <Library/HobLib.h>
+
+//
+// Cached performance counter frequency
+//
+static UINT64  mAcpiTimerLibTscFrequency = 0;
 
 extern GUID  mFrequencyHobGuid;
 
@@ -48,11 +53,6 @@ InternalCalculateTscFrequency (
   VOID
   );
 
-//
-// Cached performance counter frequency
-//
-UINT64  mPerformanceCounterFrequency = 0;
-
 /**
   Internal function to retrieves the 64-bit frequency in Hz.
 
@@ -66,7 +66,7 @@ InternalGetPerformanceCounterFrequency (
   VOID
   )
 {
-  return mPerformanceCounterFrequency;
+  return mAcpiTimerLibTscFrequency;
 }
 
 /**
@@ -92,9 +92,9 @@ CommonAcpiTimerLibConstructor (
   //
   GuidHob = GetFirstGuidHob (&mFrequencyHobGuid);
   if (GuidHob != NULL) {
-    mPerformanceCounterFrequency = *(UINT64 *)GET_GUID_HOB_DATA (GuidHob);
+    mAcpiTimerLibTscFrequency = *(UINT64 *)GET_GUID_HOB_DATA (GuidHob);
   } else {
-    mPerformanceCounterFrequency = InternalCalculateTscFrequency ();
+    mAcpiTimerLibTscFrequency = InternalCalculateTscFrequency ();
   }
 
   return EFI_SUCCESS;


### PR DESCRIPTION
The DXE & MM standalone variant of AcpiTimerLib defines a global named mPerformanceCounterFrequency. A global with an identical name is also present in MdeModulePkg/Bus/Pci/XhciDxe/Xhci.c

Since XhciDxe has a dependency on TimerLib, this can cause link errors due to the same symbol being defined twice if the platform DSC chooses to use AcpiTimerLib as the TimerLib implementation for any given platform.

To resolve this, I have changed made the definition of mPerformanceCounterFrequency to static and renamed it to mAcpiTimerLibTscFrequency. Since this variable is not used outside of the DxeStandaloneMmAcpiTimerLib.c compilation unit, there is no reason to have it exported as a global.

Reviewed-by: Ray Ni <ray.ni@intel.com>
Cc: Michael D Kinney <michael.d.kinney@intel.com>