### PR TITLE
MdeModulePkg/Bus: Fix XhciDxe Linker Issues

### DIFF
--- a/MdeModulePkg/Bus/Pci/XhciDxe/Xhci.c
+++ b/MdeModulePkg/Bus/Pci/XhciDxe/Xhci.c
@@ -2,7 +2,7 @@
   The XHCI controller driver.
 
 (C) Copyright 2023 Hewlett Packard Enterprise Development LP<BR>
-Copyright (c) 2011 - 2022, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2011 - 2023, Intel Corporation. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -86,10 +86,10 @@ EFI_USB2_HC_PROTOCOL  gXhciUsb2HcTemplate = {
   0x0
 };
 
-UINT64   mPerformanceCounterStartValue;
-UINT64   mPerformanceCounterEndValue;
-UINT64   mPerformanceCounterFrequency;
-BOOLEAN  mPerformanceCounterValuesCached = FALSE;
+static UINT64   mXhciPerformanceCounterStartValue;
+static UINT64   mXhciPerformanceCounterEndValue;
+static UINT64   mXhciPerformanceCounterFrequency;
+static BOOLEAN  mXhciPerformanceCounterValuesCached = FALSE;
 
 /**
   Retrieves the capability of root hub ports.
@@ -2318,17 +2318,17 @@ XhcConvertTimeToTicks (
   UINTN   Shift;
 
   // Cache the return values to avoid repeated calls to GetPerformanceCounterProperties ()
-  if (!mPerformanceCounterValuesCached) {
-    mPerformanceCounterFrequency = GetPerformanceCounterProperties (
-                                     &mPerformanceCounterStartValue,
-                                     &mPerformanceCounterEndValue
-                                     );
+  if (!mXhciPerformanceCounterValuesCached) {
+    mXhciPerformanceCounterFrequency = GetPerformanceCounterProperties (
+                                         &mXhciPerformanceCounterStartValue,
+                                         &mXhciPerformanceCounterEndValue
+                                         );
 
-    mPerformanceCounterValuesCached = TRUE;
+    mXhciPerformanceCounterValuesCached = TRUE;
   }
 
   // Prevent returning a tick value of 0, unless Time is already 0
-  if (0 == mPerformanceCounterFrequency) {
+  if (0 == mXhciPerformanceCounterFrequency) {
     return Time;
   }
 
@@ -2342,7 +2342,7 @@ XhcConvertTimeToTicks (
   //
   Ticks = MultU64x64 (
             DivU64x64Remainder (
-              mPerformanceCounterFrequency,
+              mXhciPerformanceCounterFrequency,
               Divisor,
               &Remainder
               ),
@@ -2384,12 +2384,12 @@ XhcGetElapsedTicks (
   //
   // Determine if the counter is counting up or down
   //
-  if (mPerformanceCounterStartValue < mPerformanceCounterEndValue) {
+  if (mXhciPerformanceCounterStartValue < mXhciPerformanceCounterEndValue) {
     //
     // Counter counts upwards, check for an overflow condition
     //
     if (*PreviousTick > CurrentTick) {
-      Delta = (mPerformanceCounterEndValue - *PreviousTick) + CurrentTick;
+      Delta = (mXhciPerformanceCounterEndValue - *PreviousTick) + CurrentTick;
     } else {
       Delta = CurrentTick - *PreviousTick;
     }
@@ -2398,7 +2398,7 @@ XhcGetElapsedTicks (
     // Counter counts downwards, check for an underflow condition
     //
     if (*PreviousTick < CurrentTick) {
-      Delta = (mPerformanceCounterStartValue - CurrentTick) + *PreviousTick;
+      Delta = (mXhciPerformanceCounterStartValue - CurrentTick) + *PreviousTick;
     } else {
       Delta = *PreviousTick - CurrentTick;
     }


### PR DESCRIPTION
The DXE & MM standalone variant of AcpiTimerLib defines a global named mPerformanceCounterFrequency. A global with an identical name is also present in MdeModulePkg/Bus/Pci/XhciDxe/Xhci.c

Since XhciDxe has a dependency on TimerLib, this can cause link errors due to the same symbol being defined twice if the platform DSC chooses to use AcpiTimerLib as the TimerLib implementation for any given platform.

To resolve this, I noted that some of the globals in Xhci.c are not used outside of the Xhci.c compilation unit:

- mPerformanceCounterStartValue
- mPerformanceCounterEndValue
- mPerformanceCounterFrequency
- mPerformanceCounterValuesCached

I have changed the definition for all of these to static and added an Xhci prefix. Since they are not used outside of the Xhci.c compilation unit, there is no reason to have them exported as globals.

Reviewed-by: Ray Ni <ray.ni@intel.com>
Cc: Michael D Kinney <michael.d.kinney@intel.com>