### PR TITLE
OvmfPkg/Bhyve: use a proper PCI IO range

### DIFF
--- a/OvmfPkg/Bhyve/PlatformPei/Platform.c
+++ b/OvmfPkg/Bhyve/PlatformPei/Platform.c
@@ -153,8 +153,8 @@ MemMapInitialization (
   UINT64         PciIoSize;
   RETURN_STATUS  PcdStatus;
 
-  PciIoBase = 0xC000;
-  PciIoSize = 0x4000;
+  PciIoBase = 0x2000;
+  PciIoSize = 0xE000;
 
   //
   // Create Memory Type Information HOB


### PR DESCRIPTION
Bhyve uses an io port range of [ 0x2000, 0x10000 ] [1]. At the moment, EDKII is using a subset of this range [ 0xC000, 0x10000 ] [2]. Even though the EDKII range doesn't exceed the bhyve range, it's causing issues on some guests like OpenBSD [3]. We don't know why it's causing issues yet. However, using the same IO port range in EDKII fixes the issue and is a good idea anyway.

[1] https://github.com/freebsd/freebsd-src/blob/82ea0132c8b17a7a6067c8a36c6434e587ede6de/usr.sbin/bhyve/pci_emul.c#L133-L134
[2] https://github.com/tianocore/edk2/blob/fb044b7fe893a4545995bfe2701fd38e593355d9/OvmfPkg/Bhyve/PlatformPei/Platform.c#L156-L157
[3] https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=274389


Reviewed-by: Laszlo Ersek <lersek@redhat.com>
Reviewed-by: Rebecca Cran <rebecca@bsdio.com>
Cc: Ard Biesheuvel <ardb+tianocore@kernel.org>
Cc: Gerd Hoffmann <kraxel@redhat.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Jiewen Yao <jiewen.yao@intel.com>