### PR TITLE
MdePkg: Add UEFI v2.10 ISA memory type definition

### DIFF
--- a/MdePkg/Include/Uefi/UefiSpec.h
+++ b/MdePkg/Include/Uefi/UefiSpec.h
@@ -111,6 +111,21 @@ typedef enum {
 #define EFI_MEMORY_RUNTIME  0x8000000000000000ULL
 
 //
+// If this flag is set, the memory region is
+// described with additional ISA-specific memory attributes
+// as specified in EFI_MEMORY_ISA_MASK.
+//
+#define EFI_MEMORY_ISA_VALID  0x4000000000000000ULL
+
+//
+// Defines the bits reserved for describing optional ISA-specific cacheability
+// attributes that are not covered by the standard UEFI Memory Attributes cacheability
+// bits (EFI_MEMORY_UC, EFI_MEMORY_WC, EFI_MEMORY_WT, EFI_MEMORY_WB and EFI_MEMORY_UCE).
+// See Calling Conventions for further ISA-specific enumeration of these bits.
+//
+#define EFI_MEMORY_ISA_MASK  0x0FFFF00000000000ULL
+
+//
 // Attributes bitmasks, grouped by type
 //
 #define EFI_CACHE_ATTRIBUTE_MASK   (EFI_MEMORY_UC | EFI_MEMORY_WC | EFI_MEMORY_WT | EFI_MEMORY_WB | EFI_MEMORY_UCE | EFI_MEMORY_WP)


### PR DESCRIPTION
New memory type as defined in UEFI standard v2.10

Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Zhiguang Liu <zhiguang.liu@intel.com>
Cc: T V Krishnamoorthy <krishnamoorthy.t.v@intel.com>

Reviewed-by: Zhiguang Liu <zhiguang.liu@intel.com>
Reviewed-by: Michael D Kinney <michael.d.kinney@intel.com>