### PR TITLE
MdePkg: Define the DevicePath argument from LoadImage as optional

### DIFF
--- a/MdePkg/Include/Uefi/UefiSpec.h
+++ b/MdePkg/Include/Uefi/UefiSpec.h
@@ -898,7 +898,7 @@ EFI_STATUS
 (EFIAPI *EFI_IMAGE_LOAD)(
   IN  BOOLEAN                      BootPolicy,
   IN  EFI_HANDLE                   ParentImageHandle,
-  IN  EFI_DEVICE_PATH_PROTOCOL     *DevicePath,
+  IN  EFI_DEVICE_PATH_PROTOCOL     *DevicePath   OPTIONAL,
   IN  VOID                         *SourceBuffer OPTIONAL,
   IN  UINTN                        SourceSize,
   OUT EFI_HANDLE                   *ImageHandle


### PR DESCRIPTION
Update the EFI LoadImage API in accordance with the UEFI v2.10 specification.

Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Zhiguang Liu <zhiguang.liu@intel.com>
Cc: T V Krishnamoorthy <krishnamoorthy.t.v@intel.com>

Reviewed-by: Zhiguang Liu <zhiguang.liu@intel.com>
Reviewed-by: Michael D Kinney <michael.d.kinney@intel.com>