### PR TITLE
FatPkg/FatPei: Check array offset before use

### DIFF
--- a/FatPkg/FatPei/FatLiteApi.c
+++ b/FatPkg/FatPei/FatLiteApi.c
@@ -459,7 +459,7 @@ GetRecoveryCapsuleInfo (
       // Find corresponding physical block device
       //
       BlockDeviceNo = PrivateData->Volume[Index].BlockDeviceNo;
-      while (PrivateData->BlockDevice[BlockDeviceNo].Logical && BlockDeviceNo < PrivateData->BlockDeviceCount) {
+      while (BlockDeviceNo < PrivateData->BlockDeviceCount && PrivateData->BlockDevice[BlockDeviceNo].Logical) {
         BlockDeviceNo = PrivateData->BlockDevice[BlockDeviceNo].ParentDevNo;
       }
 


### PR DESCRIPTION
Move the range check before array access to enforce the bounds as expected.

Cc: Ray Ni <ray.ni@intel.com>
Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>
Reviewed-by: Michael D Kinney [<michael.d.kinney@intel.com>](mailto:michael.d.kinney@intel.com)