### PR TITLE
CloudHv: Add CI for CloudHv on AArch64

### DIFF
--- a/ArmVirtPkg/PlatformCI/.azurepipelines/Ubuntu-GCC5.yml
+++ b/ArmVirtPkg/PlatformCI/.azurepipelines/Ubuntu-GCC5.yml
@@ -140,6 +140,19 @@ jobs:
             Build.Target: "RELEASE"
             Run: false
 
+          CLOUDHV_AARCH64_DEBUG:
+            Build.File: "$(package)/PlatformCI/CloudHvBuild.py"
+            Build.Arch: "AARCH64"
+            Build.Flags: ""
+            Build.Target: "DEBUG"
+            Run: false
+          CLOUDHV_AARCH64_RELEASE:
+            Build.File: "$(package)/PlatformCI/CloudHvBuild.py"
+            Build.Arch: "AARCH64"
+            Build.Flags: ""
+            Build.Target: "RELEASE"
+            Run: false
+
     workspace:
       clean: all
 

--- a/ArmVirtPkg/PlatformCI/CloudHvBuild.py
+++ b/ArmVirtPkg/PlatformCI/CloudHvBuild.py
@@ -1,0 +1,32 @@
+# @file
+# Script to Build ArmVirtPkg UEFI firmware
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+from PlatformBuildLib import SettingsManager
+from PlatformBuildLib import PlatformBuilder
+
+    # ####################################################################################### #
+    #                                Common Configuration                                     #
+    # ####################################################################################### #
+class CommonPlatform():
+    ''' Common settings for this platform.  Define static data here and use
+        for the different parts of stuart
+    '''
+    PackagesSupported = ("ArmVirtPkg",)
+    ArchSupported = ("AARCH64",)
+    TargetsSupported = ("DEBUG", "RELEASE")
+    Scopes = ('armvirt', 'edk2-build')
+    WorkspaceRoot = os.path.realpath(os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), "..", ".."))
+
+    DscName = os.path.join("ArmVirtPkg", "ArmVirtCloudHv.dsc")
+    FvQemuArg = "" # ignored
+
+import PlatformBuildLib
+PlatformBuildLib.CommonPlatform = CommonPlatform


### PR DESCRIPTION
Add the long lost CI for CloudHv on AArch64.
As CloudHv CI works nearly the same way with other VMMs like KvmTool, thus we can easily create its CI configuration based on KvmTool.

Reviewed-by: Laszlo Ersek <lersek@redhat.com>