### PR TITLE
ArmPkg/DebugPeCoffExtraActionLib: Drop RVCT and Cygwin support

### DIFF
--- a/ArmPkg/Library/DebugPeCoffExtraActionLib/DebugPeCoffExtraActionLib.c
+++ b/ArmPkg/Library/DebugPeCoffExtraActionLib/DebugPeCoffExtraActionLib.c
@@ -18,45 +18,6 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/PrintLib.h>
 
 /**
-  If the build is done on cygwin the paths are cygpaths.
-  /cygdrive/c/tmp.txt vs c:\tmp.txt so we need to convert
-  them to work with RVD commands
-
-  @param  Name  Path to convert if needed
-
-**/
-CHAR8 *
-DeCygwinPathIfNeeded (
-  IN  CHAR8  *Name,
-  IN  CHAR8  *Temp,
-  IN  UINTN  Size
-  )
-{
-  CHAR8  *Ptr;
-  UINTN  Index;
-  UINTN  Index2;
-
-  Ptr = AsciiStrStr (Name, "/cygdrive/");
-  if (Ptr == NULL) {
-    return Name;
-  }
-
-  for (Index = 9, Index2 = 0; (Index < (Size + 9)) && (Ptr[Index] != '\0'); Index++, Index2++) {
-    Temp[Index2] = Ptr[Index];
-    if (Temp[Index2] == '/') {
-      Temp[Index2] = '\\';
-    }
-
-    if (Index2 == 1) {
-      Temp[Index2 - 1] = Ptr[Index];
-      Temp[Index2]     = ':';
-    }
-  }
-
-  return Temp;
-}
-
-/**
   Performs additional actions after a PE/COFF image has been loaded and relocated.
 
   If ImageContext is NULL, then ASSERT().
@@ -71,23 +32,24 @@ PeCoffLoaderRelocateImageExtraAction (
   IN OUT PE_COFF_LOADER_IMAGE_CONTEXT  *ImageContext
   )
 {
- #if !defined (MDEPKG_NDEBUG)
-  CHAR8  Temp[512];
- #endif
-
+#ifdef __GNUC__
   if (ImageContext->PdbPointer) {
- #ifdef __CC_ARM
-    // Print out the command for the DS-5 to load symbols for this image
-    DEBUG ((DEBUG_LOAD | DEBUG_INFO, "add-symbol-file %a 0x%p\n", DeCygwinPathIfNeeded (ImageContext->PdbPointer, Temp, sizeof (Temp)), (UINTN)(ImageContext->ImageAddress + ImageContext->SizeOfHeaders)));
- #elif __GNUC__
-    // This may not work correctly if you generate PE/COFF directly as then the Offset would not be required
-    DEBUG ((DEBUG_LOAD | DEBUG_INFO, "add-symbol-file %a 0x%p\n", DeCygwinPathIfNeeded (ImageContext->PdbPointer, Temp, sizeof (Temp)), (UINTN)(ImageContext->ImageAddress + ImageContext->SizeOfHeaders)));
- #else
-    DEBUG ((DEBUG_LOAD | DEBUG_INFO, "Loading driver at 0x%11p EntryPoint=0x%11p\n", (VOID *)(UINTN)ImageContext->ImageAddress, FUNCTION_ENTRY_POINT (ImageContext->EntryPoint)));
- #endif
-  } else {
-    DEBUG ((DEBUG_LOAD | DEBUG_INFO, "Loading driver at 0x%11p EntryPoint=0x%11p\n", (VOID *)(UINTN)ImageContext->ImageAddress, FUNCTION_ENTRY_POINT (ImageContext->EntryPoint)));
+    DEBUG ((
+      DEBUG_LOAD | DEBUG_INFO,
+      "add-symbol-file %a 0x%p\n",
+      ImageContext->PdbPointer,
+      (UINTN)(ImageContext->ImageAddress + ImageContext->SizeOfHeaders)
+      ));
+    return;
   }
+#endif
+
+  DEBUG ((
+    DEBUG_LOAD | DEBUG_INFO,
+    "Loading driver at 0x%11p EntryPoint=0x%11p\n",
+    (VOID *)(UINTN)ImageContext->ImageAddress,
+    FUNCTION_ENTRY_POINT (ImageContext->EntryPoint)
+    ));
 }
 
 /**
@@ -106,21 +68,21 @@ PeCoffLoaderUnloadImageExtraAction (
   IN OUT PE_COFF_LOADER_IMAGE_CONTEXT  *ImageContext
   )
 {
- #if !defined (MDEPKG_NDEBUG)
-  CHAR8  Temp[512];
- #endif
-
+#ifdef __GNUC__
   if (ImageContext->PdbPointer) {
- #ifdef __CC_ARM
-    // Print out the command for the RVD debugger to load symbols for this image
-    DEBUG ((DEBUG_LOAD | DEBUG_INFO, "unload symbols_only %a\n", DeCygwinPathIfNeeded (ImageContext->PdbPointer, Temp, sizeof (Temp))));
- #elif __GNUC__
-    // This may not work correctly if you generate PE/COFF directly as then the Offset would not be required
-    DEBUG ((DEBUG_LOAD | DEBUG_INFO, "remove-symbol-file %a 0x%08x\n", DeCygwinPathIfNeeded (ImageContext->PdbPointer, Temp, sizeof (Temp)), (UINTN)(ImageContext->ImageAddress + ImageContext->SizeOfHeaders)));
- #else
-    DEBUG ((DEBUG_LOAD | DEBUG_INFO, "Unloading %a\n", ImageContext->PdbPointer));
- #endif
-  } else {
-    DEBUG ((DEBUG_LOAD | DEBUG_INFO, "Unloading driver at 0x%11p\n", (VOID *)(UINTN)ImageContext->ImageAddress));
+    DEBUG ((
+      DEBUG_LOAD | DEBUG_INFO,
+      "remove-symbol-file %a 0x%08x\n",
+      ImageContext->PdbPointer,
+      (UINTN)(ImageContext->ImageAddress + ImageContext->SizeOfHeaders)
+      ));
+    return;
   }
+#endif
+
+  DEBUG ((
+    DEBUG_LOAD | DEBUG_INFO,
+    "Unloading driver at 0x%11p\n",
+    (VOID *)(UINTN)ImageContext->ImageAddress
+    ));
 }


### PR DESCRIPTION
The DebugPeCoffExtraActionLib implemention in ArmPkg contains some cruft that dates back to the original RVCT based ARM port, and support for RVCT was dropped a while ago.

Also drop the handling of Cygwin specific paths, which is highly unlikely to be still depended upon by anyone.

Tweak the logic so that only two versions of the DEBUG() invocations remain: one for __GNUC__ when PdbPointer is set, and the fallback that just prints the image address and the address of the entrypoint.


Reviewed-by: Leif Lindholm <quic_llindhol@quicinc.com>
Reviewed-by: Sami Mujawar <sami.mujawar@arm.com>