### PR TITLE
[MdePkg] Add definition for EFI_NVDIMM_LABEL_FLAGS_LOCAL

### DIFF
--- a/MdePkg/Include/Protocol/NvdimmLabel.h
+++ b/MdePkg/Include/Protocol/NvdimmLabel.h
@@ -108,6 +108,9 @@ typedef struct {
 ///
 /// When set, the complete label set is local to a single NVDIMM Label Storage Area.
 /// When clear, the complete label set is contained on multiple NVDIMM Label Storage Areas.
+/// If NLabel is 1 then setting this flag is optional and it is implied that the
+/// EFI_NVDIMM_LABEL_FLAGS_LOCAL flag is set as the complete label set is local to a single NVDIMM
+/// Label Storage Area.
 ///
 #define EFI_NVDIMM_LABEL_FLAGS_LOCAL  0x00000002
 


### PR DESCRIPTION
Mantis: https://mantis.uefi.org/mantis/view.php?id=1830

According to UEFI spec 2.10 Table 13.9.We need a clearer explanation for
EFI_NVDIMM_LABEL_FLAGS_LOCAL flag.So we add a situation in comments if
NLabel is 1 then setting this flag is optional and set this flag as the
complete label set and it is local to a single NVDIMM.

REF: UEFI spec 2.10 Table 13.9

Signed-off-by: SuqiangX Ren <suqiangx.ren@intel.com>
Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Zhiguang Liu <zhiguang.liu@intel.com>
Cc: Yi Li <yi1.li@intel.com>