### PR TITLE
MdeModulePkg/UefiBootManagerLib: Signal ReadyToBoot on platform recovery

### DIFF
--- a/MdeModulePkg/Library/UefiBootManagerLib/BmLoadOption.c
+++ b/MdeModulePkg/Library/UefiBootManagerLib/BmLoadOption.c
@@ -1416,6 +1416,17 @@ EfiBootManagerProcessLoadOption (
     return EFI_SUCCESS;
   }
 
+  if (LoadOption->OptionType == LoadOptionTypePlatformRecovery) {
+    //
+    // Signal the EVT_SIGNAL_READY_TO_BOOT event when we are about to load and execute the boot option.
+    //
+    EfiSignalEventReadyToBoot ();
+    //
+    // Report Status Code to indicate ReadyToBoot was signaled
+    //
+    REPORT_STATUS_CODE (EFI_PROGRESS_CODE, (EFI_SOFTWARE_DXE_BS_DRIVER | EFI_SW_DXE_BS_PC_READY_TO_BOOT_EVENT));
+  }
+
   //
   // Load and start the load option.
   //


### PR DESCRIPTION
Currently, the ReadyToBoot event is only signaled when a formal Boot Manager option is executed (in BmBoot.c -> EfiBootManagerBoot ()).

However, the introduction of Platform Recovery in UEFI 2.5 makes it necessary to signal ReadyToBoot when a Platform Recovery boot loader runs because otherwise it may lead to the execution of a boot loader that has similar requirements to a regular one that is not launched as a Boot Manager option.

This is especially critical to ensuring that the graphical console is actually usable during platform recovery, as some platforms do rely on the ConsolePrefDxe driver, which only performs console initialization after ReadyToBoot is triggered.

This patch fixes that behavior by calling EfiSignalEventReadyToBoot () in EfiBootManagerProcessLoadOption () when invoking platform recovery, which is the function that sets up the platform recovery boot process.

The expected behavior has been clarified in the UEFI 2.10 specification to explicitly indicate this behavior is required for correct operation.

This is a rebased version of the patch originally written by Pete Batard.

Ref: https://bugzilla.tianocore.org/show_bug.cgi?id=2831



Reviewed-by: Jeremy Linton <jeremy.linton@arm.com>
Reviewed-by: Laszlo Ersek <lersek@redhat.com>
Reviewed-by: Leif Lindholm <quic_llindhol@quicinc.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>