### PR TITLE
MdePkg: Update the definition of EFI_NVDIMM_LABEL_FLAGS_LOCAL 

### DIFF
--- a/MdePkg/Include/Protocol/NvdimmLabel.h
+++ b/MdePkg/Include/Protocol/NvdimmLabel.h
@@ -108,6 +108,8 @@ typedef struct {
 ///
 /// When set, the complete label set is local to a single NVDIMM Label Storage Area.
 /// When clear, the complete label set is contained on multiple NVDIMM Label Storage Areas.
+/// If NLabel is 1 then setting this flag is optional and it is implied that the
+/// EFI_NVDIMM_LABEL_FLAGS_LOCAL flag is set as the complete label set is local to a single NVDIMM Label Storage Area.
 ///
 #define EFI_NVDIMM_LABEL_FLAGS_LOCAL  0x00000002
 


### PR DESCRIPTION
Add the description of EFI_NVDIMM_LABEL_FLAGS_LOCAL to align with UEFI spec 2.10.

REF: UEFI spec 2.10 Table 13.19.4


Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Zhiguang Liu <zhiguang.liu@intel.com>
Cc: Yi Li <yi1.li@intel.com>