### PR TITLE
MdePkg Updated the comments of EFI_SYSTEM_TABLE and ReadKeyStroke

### DIFF
--- a/MdePkg/Include/Protocol/SimpleTextIn.h
+++ b/MdePkg/Include/Protocol/SimpleTextIn.h
@@ -100,6 +100,7 @@ EFI_STATUS
   @retval EFI_NOT_READY    There was no keystroke data available.
   @retval EFI_DEVICE_ERROR The keystroke information was not returned due to
                            hardware errors.
+  @retval EFI_UNSUPPORTED  The device does not support the ability to read keystroke data.
 
 **/
 typedef

--- a/MdePkg/Include/Protocol/SimpleTextInEx.h
+++ b/MdePkg/Include/Protocol/SimpleTextInEx.h
@@ -186,6 +186,7 @@ typedef struct {
   @retval EFI_NOT_READY    There was no keystroke data available.
   @retval EFI_DEVICE_ERROR The keystroke information was not returned due to
                            hardware errors.
+  @retval EFI_UNSUPPORTED  The device does not support the ability to read keystroke data.
 
 
 **/

--- a/MdePkg/Include/Uefi/UefiSpec.h
+++ b/MdePkg/Include/Uefi/UefiSpec.h
@@ -2042,7 +2042,8 @@ typedef struct {
   UINT32                             FirmwareRevision;
   ///
   /// The handle for the active console input device. This handle must support
-  /// EFI_SIMPLE_TEXT_INPUT_PROTOCOL and EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL.
+  /// EFI_SIMPLE_TEXT_INPUT_PROTOCOL and EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL. If
+  /// there is no active console, these protocols must still be present.
   ///
   EFI_HANDLE                         ConsoleInHandle;
   ///
@@ -2051,7 +2052,9 @@ typedef struct {
   ///
   EFI_SIMPLE_TEXT_INPUT_PROTOCOL     *ConIn;
   ///
-  /// The handle for the active console output device.
+  /// The handle for the active console output device. This handle must support the
+  /// EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL. If there is no active console, these protocols
+  /// must still be present.
   ///
   EFI_HANDLE                         ConsoleOutHandle;
   ///
@@ -2061,7 +2064,8 @@ typedef struct {
   EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL    *ConOut;
   ///
   /// The handle for the active standard error console device.
-  /// This handle must support the EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL.
+  /// This handle must support the EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL. If there
+  /// is no active console, this protocol must still be present.
   ///
   EFI_HANDLE                         StandardErrorHandle;
   ///


### PR DESCRIPTION
1. Refer to Uefi spec 2.10 section 4.3.1, Updated the comments of EFI_SYSTEM_TABLE to satisfy ConIn/ConOut/StdErr requirements.
2. Refer to Uefi spec 2.10 section 13.3.3, Add a new retval EFI_UNSUPPORTED to EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL.ReadKeyStrokeEx and EFI_SIMPLE_TEXT_INPUT_PROTOCOL.ReadKeyStroke().


Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Zhiguang Liu <zhiguang.liu@intel.com>
Cc: Yi Li <yi1.li@intel.com>