### PR TITLE
MdePkg: Update the comments of ExtractConfig 

### DIFF
--- a/MdePkg/Include/Protocol/HiiConfigAccess.h
+++ b/MdePkg/Include/Protocol/HiiConfigAccess.h
@@ -102,8 +102,15 @@ typedef UINTN EFI_BROWSER_ACTION;
                                   string.
 
   @retval EFI_INVALID_PARAMETER   Unknown name. Progress points
-                                  to the & before the name in
+                                  to the "&" before the name in
                                   question.
+
+  @retval EFI_INVALID_PARAMETER   If Results or Progress is NULL.
+
+  @retval EFI_ACCESS_DENIED       The action violated a system policy.
+
+  @retval EFI_DEVICE_ERROR        Failed to extract the current configuration
+                                  for one or more named elements.
 
 **/
 typedef


### PR DESCRIPTION
Add status code EFI_DEVICE_ERROR for ExtractConfig to align with UEFI spec 2.10.

REF: UEFI spec 2.10 Table 35.5.2


Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Zhiguang Liu <zhiguang.liu@intel.com>
Cc: Yi Li <yi1.li@intel.com>