### PR TITLE
BaseTools: FMMT GuidTool Auto Select Config file Enabling

### DIFF
--- a/BaseTools/Source/Python/FMMT/core/GuidTools.py
+++ b/BaseTools/Source/Python/FMMT/core/GuidTools.py
@@ -110,7 +110,7 @@ class GUIDTools:
         if os.environ['FmmtConfPath']:
             self.tooldef_file = os.path.join(os.environ['FmmtConfPath'], 'FmmtConf.ini')
         else:
-            PathList = os.environ['PATH']
+            PathList = os.environ['PATH'].split(os.pathsep)
             for CurrentPath in PathList:
                 if os.path.exists(os.path.join(CurrentPath, 'FmmtConf.ini')):
                     self.tooldef_file = os.path.join(CurrentPath, 'FmmtConf.ini')


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4624

Currently, Python FMMT tool does not support automatically select FMMTConf.ini file which saves GuidTool settings. This patch supports this features.

Cc: Rebecca Cran <rebecca@bsdio.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Bob Feng <bob.c.feng@intel.com>


Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>
Reviewed-by: Rebecca Cran <rebecca@bsdio.com>