### PR TITLE
MdePkg: Update the comments of callback in EFI_FORM_BROWSER2_PROTOCOL

### DIFF
--- a/MdePkg/Include/Protocol/FormBrowser2.h
+++ b/MdePkg/Include/Protocol/FormBrowser2.h
@@ -138,9 +138,12 @@ EFI_STATUS
   @retval EFI_SUCCESS           The results have been distributed or are
                                 awaiting distribution.
 
-  @retval EFI_OUT_OF_RESOURCES  The ResultsDataSize specified
+  @retval EFI_BUFFER_TOO_SMALL  The ResultsDataSize specified
                                 was too small to contain the
                                 results data.
+
+  @retval EFI_UNSUPPORTED       Uncommitted browser state is not available
+                                at the current stage of execution.
 
 **/
 typedef


### PR DESCRIPTION
Add status code return for BROWSER callback in EFI_FORM_BROWSER2_PROTOCOL to align with UEFI spec 2.10.

REF: UEFI spec 2.10 Table 35.6.3


Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Zhiguang Liu <zhiguang.liu@intel.com>
Cc: Yi Li <yi1.li@intel.com>