### PR TITLE
MdePkg: Update the definition of FileName on EFI_FILE_INFO structure

### DIFF
--- a/MdePkg/Include/Guid/FileInfo.h
+++ b/MdePkg/Include/Guid/FileInfo.h
@@ -47,6 +47,7 @@ typedef struct {
   UINT64      Attribute;
   ///
   /// The Null-terminated name of the file.
+  /// For a root directory, the name is an empty string.
   ///
   CHAR16      FileName[1];
 } EFI_FILE_INFO;


### PR DESCRIPTION
Add the description of FileName to align with UEFI spec 2.10.

REF: UEFI spec 2.10 Table 13.5.16


Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Zhiguang Liu <zhiguang.liu@intel.com>
Cc: Yi Li <yi1.li@intel.com>