### PR TITLE
MdePkg: Updated the definition of CapsuleImageSize on EFI_CAPSULE_HEADER

### DIFF
--- a/MdePkg/Include/Uefi/UefiSpec.h
+++ b/MdePkg/Include/Uefi/UefiSpec.h
@@ -1663,7 +1663,7 @@ typedef struct {
   ///
   UINT32      Flags;
   ///
-  /// Size in bytes of the capsule.
+  /// Size in bytes of the capsule (including capsule header).
   ///
   UINT32      CapsuleImageSize;
 } EFI_CAPSULE_HEADER;


### PR DESCRIPTION
Add the description of CapsuleImageSize to align with UEFI spec 2.10.

REF: UEFI spec 2.10 section 8.5.3.1


Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Zhiguang Liu <zhiguang.liu@intel.com>
Cc: Yi Li <yi1.li@intel.com>