### PR TITLE
MdePkg: Update the definition of EFI_TCP6_OPTION

### DIFF
--- a/MdePkg/Include/Protocol/Tcp6.h
+++ b/MdePkg/Include/Protocol/Tcp6.h
@@ -192,12 +192,12 @@ typedef struct {
   BOOLEAN    EnableNagle;
   ///
   /// Set it to TRUE to enable TCP timestamps option as defined in
-  /// RFC1323. Set to FALSE to disable it.
+  /// RFC7323. Set to FALSE to disable it.
   ///
   BOOLEAN    EnableTimeStamp;
   ///
   /// Set it to TRUE to enable TCP window scale option as defined in
-  /// RFC1323. Set it to FALSE to disable it.
+  /// RFC7323. Set it to FALSE to disable it.
   ///
   BOOLEAN    EnableWindowScaling;
   ///

--- a/NetworkPkg/TcpDxe/TcpInput.c
+++ b/NetworkPkg/TcpDxe/TcpInput.c
@@ -1177,7 +1177,7 @@ TcpInput (
   //
   if (TCP_FLG_ON (Option.Flag, TCP_OPTION_RCVD_TS)) {
     //
-    // update TsRecent as specified in page 16 RFC1323.
+    // update TsRecent as specified in page 17 RFC7323.
     // RcvWl2 equals to the variable "LastAckSent"
     // defined there.
     //

--- a/NetworkPkg/TcpDxe/TcpProto.h
+++ b/NetworkPkg/TcpDxe/TcpProto.h
@@ -277,7 +277,7 @@ struct _TCP_CONTROL_BLOCK {
   BOOLEAN             ProbeTimerOn;            ///< If TRUE, the probe time is on.
 
   //
-  // RFC1323 defined variables, about window scale,
+  // RFC7323 defined variables, about window scale,
   // timestamp and PAWS
   //
   UINT8               SndWndScale; ///< Wndscale received from the peer.


### PR DESCRIPTION
REF: UEFI spec 2.10 section 28.2.5
 
Change the description of RFC1323 to align with UEFI spec 2.10.

Signed-off-by: Suqiang Ren <suqiangx.ren@intel.com>
Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Zhiguang Liu <zhiguang.liu@intel.com>
Cc: Saloni Kasbekar <saloni.kasbekar@intel.com>
Cc: Zachary Clark-williams <zachary.clark-williams@intel.com>

