### PR TITLE
MdePkg/BaseLib: Fix InternalSwitchStack bug for RISCV64.

### DIFF
--- a/MdePkg/Library/BaseLib/BaseLib.inf
+++ b/MdePkg/Library/BaseLib/BaseLib.inf
@@ -405,6 +405,7 @@
   RiscV64/ReadTimer.S               | GCC
   RiscV64/RiscVMmu.S                | GCC
   RiscV64/SpeculationBarrier.S      | GCC
+  RiscV64/RiscVSwitchStack.S        | GCC
 
 [Sources.LOONGARCH64]
   Math64.c

--- a/MdePkg/Library/BaseLib/RiscV64/InternalSwitchStack.c
+++ b/MdePkg/Library/BaseLib/RiscV64/InternalSwitchStack.c
@@ -11,6 +11,30 @@
 /**
   Transfers control to a function starting with a new stack.
 
+  This internal worker function transfers control to the function
+  specified by EntryPoint using the new stack specified by NewStack,
+  and passes in the parameters specified by Context1 and Context2.
+  Context1 and Context2 are optional and may be NULL.
+  The function EntryPoint must never return.
+
+  @param EntryPoint   The pointer to the function to enter.
+  @param Context1     The first parameter to pass in.
+  @param Context2     The second Parameter to pass in
+  @param NewStack     The new Location of the stack
+
+**/
+VOID
+EFIAPI
+InternalSwitchStackAsm (
+  IN      SWITCH_STACK_ENTRY_POINT  EntryPoint,
+  IN      VOID                      *Context1    OPTIONAL,
+  IN      VOID                      *Context2    OPTIONAL,
+  IN      VOID                      *NewStack
+  );
+
+/**
+  Transfers control to a function starting with a new stack.
+
   Transfers control to the function specified by EntryPoint using the
   new stack specified by NewStack and passing in the parameters specified
   by Context1 and Context2.  Context1 and Context2 are optional and may
@@ -42,12 +66,7 @@ InternalSwitchStack (
   IN      VA_LIST                   Marker
   )
 {
-  BASE_LIBRARY_JUMP_BUFFER  JumpBuffer;
+  InternalSwitchStackAsm(EntryPoint, Context1, Context2, (void *)(UINTN)NewStack - sizeof (VOID *));
 
-  JumpBuffer.RA = (UINTN)EntryPoint;
-  JumpBuffer.SP = (UINTN)NewStack - sizeof (VOID *);
-  JumpBuffer.S0 = (UINT64)(UINTN)Context1;
-  JumpBuffer.S1 = (UINT64)(UINTN)Context2;
-  LongJump (&JumpBuffer, (UINTN)-1);
   ASSERT (FALSE);
 }

--- a/MdePkg/Library/BaseLib/RiscV64/RiscVSwitchStack.S
+++ b/MdePkg/Library/BaseLib/RiscV64/RiscVSwitchStack.S
@@ -1,0 +1,38 @@
+//------------------------------------------------------------------------------
+//
+// Switch Stack for RISC-V
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+//------------------------------------------------------------------------------
+
+/**
+//
+//  This allows the caller to switch the stack and goes to the new entry point
+//
+// @param      EntryPoint   The pointer to the location to enter
+// @param      Context      Parameter to pass in
+// @param      Context2     Parameter2 to pass in
+// @param      NewStack     New Location of the stack
+//
+// @return     Nothing. Goes to the Entry Point passing in the new parameters
+//
+VOID
+EFIAPI
+InternalSwitchStackAsm (
+  SWITCH_STACK_ENTRY_POINT EntryPoint,
+  VOID  *Context,
+  VOID  *Context2,
+  VOID  *NewStack
+  );
+**/
+
+.align 3
+    .globl  InternalSwitchStackAsm
+InternalSwitchStackAsm:
+  mv  ra, a0
+  mv  a0, a1
+  mv  a1, a2
+  mv  sp, a3
+
+  ret


### PR DESCRIPTION
REF:https://bugzilla.tianocore.org/show_bug.cgi?id=4611

Fixed the InternalSwitchStack error of RISCV64. LongJump is no longer used for stack switch. Refer to Arm and AArch64 and use InternalSwitchStackAsm instead.