### PR TITLE
DynamicTablesPkg: Fix X64 compilation errors

### DIFF
--- a/DynamicTablesPkg/DynamicTables.dsc.inc
+++ b/DynamicTablesPkg/DynamicTables.dsc.inc
@@ -2,6 +2,7 @@
 #  Dsc include file for Dynamic Tables Framework.
 #
 #  Copyright (c) 2017 - 2022, Arm Limited. All rights reserved.<BR>
+#  Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.<BR>
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -21,6 +22,17 @@
   SmbiosStringTableLib|DynamicTablesPkg/Library/Common/SmbiosStringTableLib/SmbiosStringTableLib.inf
 
 [Components.common]
+  #
+  # Dynamic Table Factory Dxe
+  #
+  DynamicTablesPkg/Drivers/DynamicTableFactoryDxe/DynamicTableFactoryDxe.inf
+
+  #
+  # Dynamic Tables Manager Dxe
+  #
+  DynamicTablesPkg/Drivers/DynamicTableManagerDxe/DynamicTableManagerDxe.inf
+
+[Components.ARM, Components.AARCH64]
   #
   # Generators
   #
@@ -69,9 +81,4 @@
       NULL|DynamicTablesPkg/Library/Acpi/Arm/AcpiSsdtCpuTopologyLibArm/SsdtCpuTopologyLibArm.inf
       NULL|DynamicTablesPkg/Library/Acpi/Arm/AcpiSsdtPcieLibArm/SsdtPcieLibArm.inf
   }
-
-  #
-  # Dynamic Tables Manager Dxe
-  #
-  DynamicTablesPkg/Drivers/DynamicTableManagerDxe/DynamicTableManagerDxe.inf
 

--- a/DynamicTablesPkg/DynamicTablesPkg.dsc
+++ b/DynamicTablesPkg/DynamicTablesPkg.dsc
@@ -3,6 +3,7 @@
 #
 #  Copyright (c) 2019, Linaro Limited. All rights reserved.<BR>
 #  Copyright (c) 2019 - 2022, Arm Limited. All rights reserved.<BR>
+#  Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.<BR>
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -14,7 +15,7 @@
   PLATFORM_VERSION               = 0.1
   DSC_SPECIFICATION              = 0x0001001a
   OUTPUT_DIRECTORY               = Build/DynamicTables
-  SUPPORTED_ARCHITECTURES        = ARM|AARCH64
+  SUPPORTED_ARCHITECTURES        = ARM|AARCH64|X64
   BUILD_TARGETS                  = DEBUG|RELEASE|NOOPT
   SKUID_IDENTIFIER               = DEFAULT
 
@@ -44,9 +45,11 @@
   DynamicTablesPkg/Library/Common/SsdtPcieSupportLib/SsdtPcieSupportLib.inf
   DynamicTablesPkg/Library/Common/SsdtSerialPortFixupLib/SsdtSerialPortFixupLib.inf
   DynamicTablesPkg/Library/Common/TableHelperLib/TableHelperLib.inf
-  DynamicTablesPkg/Library/FdtHwInfoParserLib/FdtHwInfoParserLib.inf
   DynamicTablesPkg/Library/Common/DynamicPlatRepoLib/DynamicPlatRepoLib.inf
   DynamicTablesPkg/Library/Common/SmbiosStringTableLib/SmbiosStringTableLib.inf
+
+[Components.ARM, Components.AARCH64]
+  DynamicTablesPkg/Library/FdtHwInfoParserLib/FdtHwInfoParserLib.inf
 
 [BuildOptions]
   *_*_*_CC_FLAGS = -D DISABLE_NEW_DEPRECATED_INTERFACES

--- a/DynamicTablesPkg/Library/Common/AmlLib/AmlLib.inf
+++ b/DynamicTablesPkg/Library/Common/AmlLib/AmlLib.inf
@@ -2,6 +2,7 @@
 #  AML Generation Library
 #
 #  Copyright (c) 2019 - 2021, Arm Limited. All rights reserved.<BR>
+#  Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.<BR>
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 ##
@@ -68,6 +69,7 @@
 [LibraryClasses]
   AcpiHelperLib
   BaseLib
+  MemoryAllocationLib
 
 [BuildOptions]
   *_*_*_CC_FLAGS = -DAML_HANDLE

--- a/DynamicTablesPkg/Library/Common/AmlLib/CodeGen/AmlCodeGen.c
+++ b/DynamicTablesPkg/Library/Common/AmlLib/CodeGen/AmlCodeGen.c
@@ -2,7 +2,7 @@
   AML Code Generation.
 
   Copyright (c) 2020 - 2022, Arm Limited. All rights reserved.<BR>
-  Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.<BR>
+  Copyright (C) 2023 - 2024, Advanced Micro Devices, Inc. All rights reserved.<BR>
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
@@ -922,7 +922,7 @@ AmlCodeGenNameUnicodeString (
   Status = AmlCreateDataNode (
              EAmlNodeDataTypeRaw,
              (CONST UINT8 *)String,
-             StrSize (String),
+             (UINT32)StrSize (String),
              &DataNode
              );
   if (EFI_ERROR (Status)) {

--- a/DynamicTablesPkg/Library/Common/DynamicPlatRepoLib/DynamicPlatRepo.c
+++ b/DynamicTablesPkg/Library/Common/DynamicPlatRepoLib/DynamicPlatRepo.c
@@ -2,6 +2,7 @@
   Dynamic Platform Info Repository
 
   Copyright (c) 2021, Arm Limited. All rights reserved.<BR>
+  Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.<BR>
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -287,8 +288,8 @@ GroupCmObjNodes (
 
   CmObjDesc           = &This->ArmCmObjArray[ArmObjIndex];
   CmObjDesc->ObjectId = CmObjId;
-  CmObjDesc->Size     = Size;
-  CmObjDesc->Count    = Count;
+  CmObjDesc->Size     = (UINT32)Size;
+  CmObjDesc->Count    = (UINT32)Count;
   CmObjDesc->Data     = GroupedData;
 
   return Status;
@@ -340,7 +341,7 @@ DynamicPlatRepoFinalise (
   //    (the array is wrapped in a CmObjDesc).
   //  - Add the Token/CmObj binding to the token mapper.
   for (ArmObjIndex = 0; ArmObjIndex < EArmObjMax; ArmObjIndex++) {
-    Status = GroupCmObjNodes (This, ArmObjIndex);
+    Status = GroupCmObjNodes (This, (UINT32)ArmObjIndex);
     if (EFI_ERROR (Status)) {
       ASSERT (0);
       // Free the TokenMapper.

--- a/DynamicTablesPkg/Library/Common/TableHelperLib/TableHelper.c
+++ b/DynamicTablesPkg/Library/Common/TableHelperLib/TableHelper.c
@@ -2,6 +2,7 @@
   Table Helper
 
   Copyright (c) 2017 - 2021, Arm Limited. All rights reserved.<BR>
+  Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.<BR>
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
@@ -16,6 +17,7 @@
 #include <ConfigurationManagerObject.h>
 #include <Library/TableHelperLib.h>
 #include <Protocol/ConfigurationManagerProtocol.h>
+#include <Library/AmlLib/AmlLib.h>
 
 /** The GetCgfMgrInfo function gets the CM_STD_OBJ_CONFIGURATION_MANAGER_INFO
     object from the Configuration Manager.

--- a/DynamicTablesPkg/Library/Common/TableHelperLib/TableHelperLib.inf
+++ b/DynamicTablesPkg/Library/Common/TableHelperLib/TableHelperLib.inf
@@ -2,6 +2,7 @@
 #  Table Helper
 #
 #  Copyright (c) 2017 - 2021, ARM Limited. All rights reserved.
+#  Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.<BR>
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 ##
@@ -25,3 +26,4 @@
 
 [LibraryClasses]
   BaseLib
+  AmlLib


### PR DESCRIPTION
Add the support for X64 compilation to the CI.
Fix the compilation errors.

Cc: Pierre Gondois <pierre.gondois@arm.com>
Cc: Sami Mujawar <sami.mujawar@arm.com>