### PR TITLE
DynamicTablesPkg: TEST CI for X64/IA32 build failure

### DIFF
--- a/DynamicTablesPkg/Library/Common/TableHelperLib/ConfigurationManagerObjectParser.c
+++ b/DynamicTablesPkg/Library/Common/TableHelperLib/ConfigurationManagerObjectParser.c
@@ -1130,7 +1130,7 @@ ParseCmObjDesc (
         &RemainingSize,
         1
         );
-      if ((RemainingSize > (INTN)CmObjDesc->Size) ||
+      if ((RemainingSize > CmObjDesc->Size) ||
           (RemainingSize < 0))
       {
         ASSERT (0);


### PR DESCRIPTION
CI should fail only for VS2019.
for GCC it should pass

Cc: Pierre Gondois <pierre.gondois@arm.com>
Cc: Sami Mujawar <sami.mujawar@arm.com>