### PR TITLE
StandaloneMmPkg: Initialise serial port early in

### DIFF
--- a/StandaloneMmPkg/Library/StandaloneMmCoreEntryPoint/Arm/StandaloneMmCoreEntryPoint.c
+++ b/StandaloneMmPkg/Library/StandaloneMmCoreEntryPoint/Arm/StandaloneMmCoreEntryPoint.c
@@ -335,6 +335,9 @@ _ModuleEntryPoint (
   UINTN                           TeDataSize;
   EFI_PHYSICAL_ADDRESS            ImageBase;
 
+  // Initialize the Serial Port early to print debug log before StandaloneMmMain.
+  SerialPortInitialize ();
+
   // Get Secure Partition Manager Version Information
   Status = GetSpmVersion ();
   if (EFI_ERROR (Status)) {


### PR DESCRIPTION
Serial port used by the DEBUG macro is initialised in StandaloneMmMain by the DebugLib constructor.

When we use a serial port initialised by TF-A it is not a problem. However, if we use a serial port that is not initialised by TF-A, the debug log prints hangs.

Therefore, initialise the serial port early on in the entry point.