### PR TITLE
Add EFI_STATUS return to EMU_THUNK_PROTOCOL.SetTime()

### DIFF
--- a/EmulatorPkg/Include/Protocol/EmuThunk.h
+++ b/EmulatorPkg/Include/Protocol/EmuThunk.h
@@ -2,6 +2,7 @@
   Emulator Thunk to abstract OS services from pure EFI code
 
   Copyright (c) 2008 - 2011, Apple Inc. All rights reserved.<BR>
+  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -148,12 +149,12 @@ VOID
 typedef
 VOID
 (EFIAPI *EMU_GET_TIME)(
-  OUT  EFI_TIME               *Time,
+  OUT EFI_TIME                *Time,
   OUT EFI_TIME_CAPABILITIES   *Capabilities OPTIONAL
   );
 
 typedef
-VOID
+EFI_STATUS
 (EFIAPI *EMU_SET_TIME)(
   IN   EFI_TIME               *Time
   );

--- a/EmulatorPkg/Unix/Host/EmuThunk.c
+++ b/EmulatorPkg/Unix/Host/EmuThunk.c
@@ -387,14 +387,14 @@ SecGetTime (
   }
 }
 
-VOID
+EFI_STATUS
 SecSetTime (
   IN  EFI_TIME  *Time
   )
 {
   // Don't change the time on the system
   // We could save delta to localtime() and have SecGetTime adjust return values?
-  return;
+  return EFI_UNSUPPORTED;
 }
 
 EFI_STATUS

--- a/EmulatorPkg/Win/Host/WinThunk.c
+++ b/EmulatorPkg/Win/Host/WinThunk.c
@@ -10,21 +10,14 @@ Module Name:
 Abstract:
 
   Since the SEC is the only windows program in our emulation we
-  must use a Tiano mechanism to export Win32 APIs to other modules.
-  This is the role of the EFI_WIN_NT_THUNK_PROTOCOL.
+  must use a Tiano mechanism to export operating system services
+  to other modules. This is the role of the EMU_THUNK_PROTOCOL.
 
-  The mWinNtThunkTable exists so that a change to EFI_WIN_NT_THUNK_PROTOCOL
+  The gEmuThunkProtocol exists so that a change to EMU_THUNK_PROTOCOL
   will cause an error in initializing the array if all the member functions
   are not added. It looks like adding a element to end and not initializing
-  it may cause the table to be initaliized with the members at the end being
-  set to zero. This is bad as jumping to zero will case the NT32 to crash.
-
-  All the member functions in mWinNtThunkTable are Win32
-  API calls, so please reference Microsoft documentation.
-
-
-  gWinNt is a a public exported global that contains the initialized
-  data.
+  it may cause the table to be initalized with the members at the end being
+  set to zero. This is bad as jumping to zero will case EmulatorPkg to crash.
 
 **/
 

--- a/EmulatorPkg/Win/Host/WinThunk.c
+++ b/EmulatorPkg/Win/Host/WinThunk.c
@@ -264,11 +264,11 @@ volatile BOOLEAN  mInterruptEnabled = FALSE;
 VOID
 CALLBACK
 MMTimerThread (
-  UINT   wTimerID,
-  UINT   msg,
-  DWORD  dwUser,
-  DWORD  dw1,
-  DWORD  dw2
+  UINT       wTimerID,
+  UINT       msg,
+  DWORD_PTR  dwUser,
+  DWORD_PTR  dw1,
+  DWORD_PTR  dw2
   )
 {
   UINT32  CurrentTick;


### PR DESCRIPTION
There is an inconsistency between the UNIX and Windows
implementations of EMU_THUNK_PROTOCOL.SetTime(). The Windows
version returns an EFI_STATUS value whereas the the UNIX
implementation is VOID. However, the UNIX implementation is an
unimplemented stub whereas the Windows version is implementated.

The current EMU_THUNK_PROTOCOL function pointer definition
specifies a VOID return type. However, EMU_THUNK_PROTOCOL.SetTime()
is close to the spec defined gRT->SetTime() except for missing the
EFI_STATUS return type.

Therefore, I conclude that the most sensible reconciliation is to
add the EFI_STATUS return type to the protocol definition.

Cc: Andrew Fish <afish@apple.com>
Reviewed-by: Ray Ni <ray.ni@intel.com>
Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Chasel Chiu <chasel.chiu@intel.com>
Signed-off-by: Nate DeSimone <nathaniel.l.desimone@intel.com>