### PR TITLE
CryptoPkg: Fix redefinition error of int defines

### DIFF
--- a/CryptoPkg/Library/Include/CrtLibSupport.h
+++ b/CryptoPkg/Library/Include/CrtLibSupport.h
@@ -424,19 +424,4 @@ strcpy (
 #define atoi(nptr)              AsciiStrDecimalToUintn(nptr)
 #define gettimeofday(tvp, tz)   do { (tvp)->tv_sec = time(NULL); (tvp)->tv_usec = 0; } while (0)
 
-//
-// only use in Mbedlts. The Openssl has defined them internally.
-//
-#ifndef OPENSSL_SYS_UEFI
-typedef INT8   int8_t;
-typedef UINT8  uint8_t;
-typedef INT16  int16_t;
-typedef UINT16 uint16_t;
-typedef INT32  int32_t;
-typedef UINT32 uint32_t;
-typedef INT64  int64_t;
-typedef UINT64 uint64_t;
-typedef UINTN  uintptr_t;
-#endif
-
 #endif

--- a/CryptoPkg/Library/Include/stdint.h
+++ b/CryptoPkg/Library/Include/stdint.h
@@ -6,4 +6,23 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
 
+#ifndef CRYPTO_CRT_STDIO_H_
+#define CRYPTO_CRT_STDIO_H_
 #include <CrtLibSupport.h>
+
+//
+// only use in Mbedlts. The Openssl has defined them internally.
+//
+#ifndef OPENSSL_SYS_UEFI
+typedef INT8    int8_t;
+typedef UINT8   uint8_t;
+typedef INT16   int16_t;
+typedef UINT16  uint16_t;
+typedef INT32   int32_t;
+typedef UINT32  uint32_t;
+typedef INT64   int64_t;
+typedef UINT64  uint64_t;
+typedef UINTN   uintptr_t;
+#endif
+
+#endif


### PR DESCRIPTION
REF:https://bugzilla.tianocore.org/show_bug.cgi?id=4632

Move the define to stdint and add MACRO to prevent duplicate inclusion.

Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Yi Li <yi1.li@intel.com>
Cc: Guomin Jiang <guomin.jiang@intel.com>

Reviewed-by: Yi Li <yi1.li@intel.com>