### PR TITLE
.pytool/Readme.md: Update matrix for DynamicTablesPkg

### DIFF
--- a/.pytool/Readme.md
+++ b/.pytool/Readme.md
@@ -15,7 +15,7 @@ on the TianoCore wiki.
 | ArmPlatformPkg       |                    | :heavy_check_mark: |
 | ArmVirtPkg           | SEE PACKAGE README | SEE PACKAGE README |
 | CryptoPkg            | :heavy_check_mark: | :heavy_check_mark: | Spell checking in audit mode
-| DynamicTablesPkg     |                    | :heavy_check_mark: |
+| DynamicTablesPkg     | :heavy_check_mark: | :heavy_check_mark: |
 | EmbeddedPkg          |
 | EmulatorPkg          | SEE PACKAGE README | SEE PACKAGE README | Spell checking in audit mode
 | FatPkg               | :heavy_check_mark: | :heavy_check_mark: |


### PR DESCRIPTION
Update the "Basic Status" matrix for DynamicTablesPkg by adding a check mark for Windows VS2019 IA32/X64 support.

Cc: Sean Brogan <sean.brogan@microsoft.com>
Cc: Joey Vagedes <joey.vagedes@gmail.com>
Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Pierre Gondois <pierre.gondois@arm.com>
Cc: Sami Mujawar <sami.mujawar@arm.com>

Reviewed-by: Sami Mujawar <sami.mujawar@arm.com>
Reviewed-by: Joey Vagedes <joey.vagedes@gmail.com>