### PR TITLE
[test CI] MdePkg: fix the types of casting for TD MMIO read

### DIFF
--- a/MdePkg/Library/BaseIoLibIntrinsic/IoLibInternalTdx.c
+++ b/MdePkg/Library/BaseIoLibIntrinsic/IoLibInternalTdx.c
@@ -237,7 +237,7 @@ TdMmioRead8 (
 
   Status = TdVmCall (TDVMCALL_MMIO, TDVMCALL_ACCESS_SIZE_1, TDVMCALL_ACCESS_READ, Address | TdSharedPageMask (), 0, &Value);
   if (Status != 0) {
-    Value = *(volatile UINT64 *)Address;
+    Value = *(volatile UINT8 *)Address;
   }
 
   return (UINT8)Value;
@@ -294,7 +294,7 @@ TdMmioRead16 (
 
   Status = TdVmCall (TDVMCALL_MMIO, TDVMCALL_ACCESS_SIZE_2, TDVMCALL_ACCESS_READ, Address | TdSharedPageMask (), 0, &Value);
   if (Status != 0) {
-    Value = *(volatile UINT64 *)Address;
+    Value = *(volatile UINT16 *)Address;
   }
 
   return (UINT16)Value;
@@ -353,7 +353,7 @@ TdMmioRead32 (
 
   Status = TdVmCall (TDVMCALL_MMIO, TDVMCALL_ACCESS_SIZE_4, TDVMCALL_ACCESS_READ, Address | TdSharedPageMask (), 0, &Value);
   if (Status != 0) {
-    Value = *(volatile UINT64 *)Address;
+    Value = *(volatile UINT32 *)Address;
   }
 
   return (UINT32)Value;


### PR DESCRIPTION
Currently the types of casting mismatch with TD MMIO read 1, 2 and 4
bytes, that might introduce potential issues. So fix the types as
conventional MmioRead[8|16|32] does.

Signed-off-by: Zhiquan Li <zhiquan1.li@intel.com>