### PR TITLE
UefiPayloadPkg: CbParseLib: Fix integer overflow

### DIFF
--- a/UefiPayloadPkg/Library/CbParseLib/CbParseLib.c
+++ b/UefiPayloadPkg/Library/CbParseLib/CbParseLib.c
@@ -282,7 +282,7 @@ FindCbMemTable (
   for (Idx = 0; Idx < Root->num_entries; Idx++) {
     if (Entries[Idx].id == TableId) {
       if (IsImdEntry) {
-        *MemTable = (VOID *)((UINTN)Entries[Idx].start + (UINTN)Root);
+        *MemTable = (VOID *)((INTN)(INT32)Entries[Idx].start + (UINTN)Root);
       } else {
         *MemTable = (VOID *)(UINTN)Entries[Idx].start;
       }


### PR DESCRIPTION
The IMD entry uses the 32bit start field as relative offset to root. On Ia32X64 this works fine as UINTN is also 32 bit and negative relative offsets are properly calculated due to an integer overflow.

On X64 this doesn't work as UINTN is 64 bit and the offset is no longer subtracted, but it's added to the root. Fix that by sign extending the start field to 64 bit.

Test: Booting UefiPayloadPkg still works on Ia32X64 and now also
      works on X64.