### PR TITLE
MdePkg/BaseCacheMaintenanceLib: RV64 replace asserts with logs

### DIFF
--- a/MdePkg/Library/BaseCacheMaintenanceLib/RiscVCache.c
+++ b/MdePkg/Library/BaseCacheMaintenanceLib/RiscVCache.c
@@ -183,9 +183,8 @@ WriteBackInvalidateDataCache (
   VOID
   )
 {
-  ASSERT (FALSE);
   DEBUG ((
-    DEBUG_ERROR,
+    DEBUG_VERBOSE,
     "WriteBackInvalidateDataCache: RISC-V unsupported function.\n"
     ));
 }
@@ -226,7 +225,9 @@ WriteBackInvalidateDataCacheRange (
   if (RiscVIsCMOEnabled ()) {
     CacheOpCacheRange (Address, Length, CacheOpFlush);
   } else {
-    ASSERT (FALSE);
+    DEBUG (
+      (DEBUG_VERBOSE,"WriteBackInvalidateDataCacheRange not supported \n")
+      );
   }
 
   return Address;
@@ -248,7 +249,7 @@ WriteBackDataCache (
   VOID
   )
 {
-  ASSERT (FALSE);
+  DEBUG ((DEBUG_VERBOSE,"WriteBackDataCache not supported \n"));
 }
 
 /**
@@ -283,7 +284,7 @@ WriteBackDataCacheRange (
   if (RiscVIsCMOEnabled ()) {
     CacheOpCacheRange (Address, Length, CacheOpClean);
   } else {
-    ASSERT (FALSE);
+    DEBUG ((DEBUG_VERBOSE,"WriteBackDataCacheRange not supported \n"));
   }
 
   return Address;


### PR DESCRIPTION
Some platforms do not implement cache management operations. Especially for DMA drivers have code to manage data cache. The code seem to depend on the underlying CPU/cache drivers to enact functionality and simply return if such functionality is not implemented. However this causes issue with CMO implementation which has an assert causing flow to hang within debug environment. While it is not an issue in production environment there is a recommendation to conver this assert in to a harmless logger message. Eventually platform/drivers need to have better guard for such functionality.


Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Zhiguang Liu <zhiguang.liu@intel.com>
Cc: Sunil V L <sunilvl@ventanamicro.com>
Cc: Andrei Warkentin <andrei.warkentin@intel.com>
Cc: Laszlo Ersek <lersek@redhat.com>
Cc: Pedro Falcato <pedro.falcato@gmail.com>
Cc: Yang Cheng <yangcheng.work@foxmail.com>