### PR TITLE
CryptoPkg: Add dummy inttypes header to fix clang build

### DIFF
--- a/CryptoPkg/CryptoPkg.ci.yaml
+++ b/CryptoPkg/CryptoPkg.ci.yaml
@@ -44,6 +44,7 @@
             # This has Mbedtls interfaces that aren't UEFI spec compliant
             "Library/Include/stdint.h",
             "Library/Include/stubs-32.h",
+            "Library/Include/inttypes.h",
             # These directories contain auto-generated OpenSSL content
             "Library/OpensslLib",
             "Library/IntrinsicLib",

--- a/CryptoPkg/Library/Include/inttypes.h
+++ b/CryptoPkg/Library/Include/inttypes.h
@@ -1,0 +1,9 @@
+/** @file
+  Include file to support building the third-party cryptographic library.
+
+Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <CrtLibSupport.h>


### PR DESCRIPTION
REF:https://bugzilla.tianocore.org/show_bug.cgi?id=4642

When use Mbedtls, there is a clang build error.
Add dummy inttypes header to fix clang build.

Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Yi Li <yi1.li@intel.com>
Cc: Guomin Jiang <guomin.jiang@intel.com>
Signed-off-by: Wenxing Hou <wenxing.hou@intel.com>

Reviewed-by: Yi Li <yi1.li@intel.com>