### PR TITLE
.pytool/Plugin: UncrustifyCheck: use stat instead of os.stat

### DIFF
--- a/.pytool/Plugin/UncrustifyCheck/UncrustifyCheck.py
+++ b/.pytool/Plugin/UncrustifyCheck/UncrustifyCheck.py
@@ -12,6 +12,7 @@ import logging
 import os
 import pathlib
 import shutil
+import stat
 import timeit
 from edk2toolext.environment import version_aggregator
 from edk2toolext.environment.plugin_manager import PluginManager
@@ -628,7 +629,7 @@ class UncrustifyCheck(ICiBuildPlugin):
             """
             Private function to attempt to change permissions on file/folder being deleted.
             """
-            os.chmod(path, os.stat.S_IWRITE)
+            os.chmod(path, stat.S_IWRITE)
             func(path)
 
         for _ in range(3):  # retry up to 3 times


### PR DESCRIPTION
The UncrustifyCheck plugin passes os.stat.S_IWRITE to os.chmod, when attempting to change file permissions. os.stat.S_IWRITE does not exist as os.stat is a function. The correct value is stat.S_IWRITE.


Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Sean Brogan <sean.brogan@microsoft.com>
Reviewed-by: Michael D Kinney <michael.d.kinney@intel.com>