### PR TITLE
MdePkg/Include/Guid: Update the definition of FileName in EFI_FILE_INFO

### DIFF
--- a/MdePkg/Include/Guid/FileInfo.h
+++ b/MdePkg/Include/Guid/FileInfo.h
@@ -47,6 +47,7 @@ typedef struct {
   UINT64      Attribute;
   ///
   /// The Null-terminated name of the file.
+  /// For a root directory, the name is an empty string.
   ///
   CHAR16      FileName[1];
 } EFI_FILE_INFO;


### PR DESCRIPTION
Add the description of EFI_FILE_INFO FileName[1] field to align with UEFI spec 2.10 Section 13.5.16.

Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Zhiguang Liu <zhiguang.liu@intel.com>

Reviewed-by: Michael D Kinney <michael.d.kinney@intel.com>