### PR TITLE
MdePkg/Library/BaseCpuLibNull: Add StandardSignatureIsAuthenticAMD()

### DIFF
--- a/MdePkg/Library/BaseCpuLibNull/BaseCpuLibNull.c
+++ b/MdePkg/Library/BaseCpuLibNull/BaseCpuLibNull.c
@@ -35,3 +35,18 @@ CpuFlushTlb (
   )
 {
 }
+
+/**
+  Determine if the standard CPU signature is "AuthenticAMD".
+
+  @retval TRUE  The CPU signature matches.
+  @retval FALSE The CPU signature does not match.
+**/
+BOOLEAN
+EFIAPI
+StandardSignatureIsAuthenticAMD (
+  VOID
+  )
+{
+  return FALSE;
+}


### PR DESCRIPTION
CpuLib.h exposes StandardSignatureIsAuthenticAMD() API and we require stub function in its BaseCpuLibNull library instance to avoid potential link issue.

Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Zhiguang Liu <zhiguang.liu@intel.com>

Reviewed-by: Michael D Kinney <michael.d.kinney@intel.com>