### PR TITLE
MdePkg/Library/BaseCpuLibNull: Add missing X86 specific services

### DIFF
--- a/MdePkg/Library/BaseCpuLibNull/BaseCpuLibNull.c
+++ b/MdePkg/Library/BaseCpuLibNull/BaseCpuLibNull.c
@@ -6,6 +6,8 @@
 
 **/
 
+#include <Library/CpuLib.h>
+
 /**
   Places the CPU in a sleep state until an interrupt is received.
 
@@ -34,19 +36,4 @@ CpuFlushTlb (
   VOID
   )
 {
-}
-
-/**
-  Determine if the standard CPU signature is "AuthenticAMD".
-
-  @retval TRUE  The CPU signature matches.
-  @retval FALSE The CPU signature does not match.
-**/
-BOOLEAN
-EFIAPI
-StandardSignatureIsAuthenticAMD (
-  VOID
-  )
-{
-  return FALSE;
 }

--- a/MdePkg/Library/BaseCpuLibNull/BaseCpuLibNull.inf
+++ b/MdePkg/Library/BaseCpuLibNull/BaseCpuLibNull.inf
@@ -22,5 +22,8 @@
 [Sources]
   BaseCpuLibNull.c
 
+[Sources.IA32, Sources.X64]
+  X86BaseCpuLibNull.c
+
 [Packages]
   MdePkg/MdePkg.dec

--- a/MdePkg/Library/BaseCpuLibNull/X86BaseCpuLibNull.c
+++ b/MdePkg/Library/BaseCpuLibNull/X86BaseCpuLibNull.c
@@ -1,0 +1,64 @@
+/** @file
+  Null instance of CPU Library for IA32/X64 specific services.
+
+  Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Library/CpuLib.h>
+
+/**
+  Initializes floating point units for requirement of UEFI specification.
+  This function initializes floating-point control word to 0x027F (all exceptions
+  masked,double-precision, round-to-nearest) and multimedia-extensions control word
+  (if supported) to 0x1F80 (all exceptions masked, round-to-nearest, flush to zero
+  for masked underflow).
+**/
+VOID
+EFIAPI
+InitializeFloatingPointUnits (
+  VOID
+  )
+{
+}
+
+/**
+  Determine if the standard CPU signature is "AuthenticAMD".
+  @retval TRUE  The CPU signature matches.
+  @retval FALSE The CPU signature does not match.
+**/
+BOOLEAN
+EFIAPI
+StandardSignatureIsAuthenticAMD (
+  VOID
+  )
+{
+  return FALSE;
+}
+
+/**
+  Return the 32bit CPU family and model value.
+  @return CPUID[01h].EAX with Processor Type and Stepping ID cleared.
+**/
+UINT32
+EFIAPI
+GetCpuFamilyModel (
+  VOID
+  )
+{
+  return 0;
+}
+
+/**
+  Return the CPU stepping ID.
+  @return CPU stepping ID value in CPUID[01h].EAX.
+**/
+UINT8
+EFIAPI
+GetCpuSteppingId (
+  VOID
+  )
+{
+  return 0;
+}


### PR DESCRIPTION
* Add InitializeFloatingPointUnits() to x86 specific file
* Add GetCpuFamilyModel() to x86 specific file
* Add GetCpuSteppingId() to x86 specific file
* Move StandardSignatureIsAuthenticAMD() to x86 specific file.
* Add CpuLib library class include to all C files.

Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Zhiguang Liu <zhiguang.liu@intel.com>
Cc: Laszlo Ersek <lersek@redhat.com>
Cc: Qing Huang <qing.huang@intel.com>