### PR TITLE
MdePkg/BaseFdtLib: Rename standard functions

### DIFF
--- a/MdePkg/Library/BaseFdtLib/LibFdtSupport.h
+++ b/MdePkg/Library/BaseFdtLib/LibFdtSupport.h
@@ -63,13 +63,13 @@ strchr     (
   );
 
 char *
-strrchr    (
+fdt_strrchr    (
   const char *,
   int
   );
 
 unsigned long
-strtoul     (
+fdt_strtoul     (
   const char *,
   char **,
   int
@@ -93,7 +93,10 @@ strcpy (
 #define strnlen(str, count)                 (size_t)(AsciiStrnLenS(str, count))
 #define strncpy(strDest, strSource, count)  AsciiStrnCpyS(strDest, MAX_STRING_SIZE, strSource, (UINTN)count)
 #define strcat(strDest, strSource)          AsciiStrCatS(strDest, MAX_STRING_SIZE, strSource)
+#define strchr(str, ch)                     ScanMem8(str, AsciiStrSize (str), (UINT8)ch)
 #define strcmp(string1, string2, count)     (int)(AsciiStrCmp(string1, string2))
 #define strncmp(string1, string2, count)    (int)(AsciiStrnCmp(string1, string2, (UINTN)(count)))
+#define strrchr(str, ch)                    fdt_strrchr(str, ch)
+#define strtoul(ptr, end_ptr, base)         fdt_strtoul(ptr, end_ptr, base)
 
 #endif /* FDT_LIB_SUPPORT_H_ */

--- a/MdePkg/Library/BaseFdtLib/LibFdtWrapper.c
+++ b/MdePkg/Library/BaseFdtLib/LibFdtWrapper.c
@@ -18,28 +18,7 @@
 // so the code gets a bit clunky to handle that case specifically.
 
 char *
-strchr (
-  const char  *Str,
-  int         Char
-  )
-{
-  char  *S;
-
-  S = (char *)Str;
-
-  for ( ; ; S++) {
-    if (*S == Char) {
-      return S;
-    }
-
-    if (*S == '\0') {
-      return NULL;
-    }
-  }
-}
-
-char *
-strrchr (
+fdt_strrchr (
   const char  *Str,
   int         Char
   )
@@ -71,7 +50,7 @@ __isspace (
 }
 
 unsigned long
-strtoul (
+fdt_strtoul (
   const char  *Nptr,
   char        **EndPtr,
   int         Base


### PR DESCRIPTION
Rename the standard functions in the LibFdtSupport to remove conflicts with other libraries that define them.

Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Zhiguang Liu <zhiguang.liu@intel.com>

Reviewed-by: Michael D Kinney <michael.d.kinney@intel.com>