### PR TITLE
MdePkg/BaseLib: Fix AARCH64 compilation error

### DIFF
--- a/MdePkg/Library/BaseLib/AArch64/SetJumpLongJump.asm
+++ b/MdePkg/Library/BaseLib/AArch64/SetJumpLongJump.asm
@@ -4,6 +4,7 @@
 ; SPDX-License-Identifier: BSD-2-Clause-Patent
 ;
 ;------------------------------------------------------------------------------
+  EXTERN InternalAssertJumpBuffer
 
   EXPORT SetJump
   EXPORT InternalLongJump


### PR DESCRIPTION
Declare InternalAssertJumpBuffer as EXTERN