### PR TITLE
PcAtChipsetPkg/HpetTimerDxe: Fix nested interrupt time accuracy

### DIFF
--- a/PcAtChipsetPkg/HpetTimerDxe/HpetTimer.c
+++ b/PcAtChipsetPkg/HpetTimerDxe/HpetTimer.c
@@ -388,10 +388,17 @@ TimerInterruptHandler (
                     );
 
     //
+    // Save main counter value before calling notification function
+    // that may enable interrupts and allow interrupt nesting.
+    //
+    mPreviousMainCounter = MainCounter;
+
+    //
     // Call registered notification function passing in the time since the last
     // interrupt in 100 ns units.
     //
     mTimerNotifyFunction (TimerPeriod);
+    return;
   }
 
   //


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4659

When HPET timer is used as the timer interrupt and nested interrupts into the HPET timer interrupt handler occur, the elapsed time passed into the DXE Core is sometime too large and this causes the DXE Core internal system time to run too fast. Fix the logic so the previous main counter value stored in the module global variable mPreviousMainCounter is always captured before the timer notification function is called.

Without this change, mPreviousMainCounter is updated after the timer notification function is called and when nesting occurs, it updates with the value from the first level of nesting which is further back in time than the interrupt from the deepest level of nesting.  This causes the next two timer interrupts to compute a TimerPeriod that is twice the actual time period since the last interrupt and this causes the DXE Core internal time to run faster than expected.

Cc: Ray Ni <ray.ni@intel.com>