### PR TITLE
UefiCpuPkg: Add cache operations support for Arch proto

### DIFF
--- a/UefiCpuPkg/CpuDxeRiscV64/CpuDxe.c
+++ b/UefiCpuPkg/CpuDxeRiscV64/CpuDxe.c
@@ -90,6 +90,20 @@ CpuFlushCpuDataCache (
   IN EFI_CPU_FLUSH_TYPE     FlushType
   )
 {
+  switch (FlushType) {
+    case EfiCpuFlushTypeWriteBack:
+      WriteBackDataCacheRange ((VOID *)(UINTN)Start, (UINTN)Length);
+      break;
+    case EfiCpuFlushTypeInvalidate:
+      InvalidateDataCacheRange ((VOID *)(UINTN)Start, (UINTN)Length);
+      break;
+    case EfiCpuFlushTypeWriteBackInvalidate:
+      WriteBackInvalidateDataCacheRange ((VOID *)(UINTN)Start, (UINTN)Length);
+      break;
+    default:
+      return EFI_INVALID_PARAMETER;
+  }
+
   return EFI_SUCCESS;
 }
 

--- a/UefiCpuPkg/CpuDxeRiscV64/CpuDxe.h
+++ b/UefiCpuPkg/CpuDxeRiscV64/CpuDxe.h
@@ -17,6 +17,7 @@
 #include <Library/BaseRiscVSbiLib.h>
 #include <Library/BaseRiscVMmuLib.h>
 #include <Library/BaseLib.h>
+#include <Library/CacheMaintenanceLib.h>
 #include <Library/CpuExceptionHandlerLib.h>
 #include <Library/DebugLib.h>
 #include <Library/UefiBootServicesTableLib.h>


### PR DESCRIPTION
With CMO operations available for RISC-V, utilize them in CPU Architecture protocol.

Signed-off-by: Dhaval Sharma <dhaval@rivosinc.com>
Gerd Hoffmann <kraxel@redhat.com>
Laszlo Ersek <lersek@redhat.com>
Rahul Kumar <rahul1.kumar@intel.com>
Ray Ni <ray.ni@intel.com>
Sunil VL <sunilvl@ventanamicro.com>
Andrei Warkentin <andrei.warkentin@intel.com>
devel@edk2.groups.io