### PR TITLE
EmbeddedPkg/Scripts/LauterbachT32: Fix EfiLoadDxe.cmm

### DIFF
--- a/EmbeddedPkg/Scripts/LauterbachT32/EfiLoadDxe.cmm
+++ b/EmbeddedPkg/Scripts/LauterbachT32/EfiLoadDxe.cmm
@@ -1,79 +1,22 @@
 ;
+; Copyright (c) 2024, Ampere Computing LLC. All rights reserved.<BR>
 ; Copyright (c) 2011, Hewlett-Packard Company. All rights reserved.<BR>
 ; 
 ; SPDX-License-Identifier: BSD-2-Clause-Patent
 ; 
 
-  LOCAL &maxmem &systbl &memsize
-  
-  &memsize=0x20000000   ; default to 512MB
-  
-  gosub FindSystemTable &memsize
-  ENTRY &systbl
-  
-  if &systbl!=0
-  (
-    print "found system table at &systbl"
-    gosub FindDebugInfo &systbl
-  )
-  else
-  (
-    print "ERROR: system table not found, check memory size"
-  )
+  PARAMETERS &systbl
+
+  gosub FindDebugInfo &systbl
   enddo
-
-FindSystemTable:
-  LOCAL   &TopOfRam &offset
-  ENTRY   &TopOfRam
-  
-  print "FindSystemTable"
-  print "top of mem is &TopOfRam$"
-  
-  &offset=&TopOfRam
-  
-  ; align to highest 4MB boundary
-  &offset=&offset&0xFFC00000
-  
-  ; start at top and look on 4MB boundaries for system table ptr structure
-  while &offset>0
-  (
-    ; low signature match
-    if Data.Long(a:&offset)==0x20494249
-    (
-      ; high signature match
-      if Data.Long(a:&offset+4)==0x54535953
-      (
-        ; less than 4GB?
-        if Data.Long(a:&offset+0x0c)==0
-        (
-          ; less than top of ram?
-          if Data.Long(a:&offset+8)<&TopOfRam
-          (
-            return Data.Long(a:&offset+8)
-          )
-        )
-      )
-    )
-   
-    if &offset<0x400000
-    (
-      return 0
-    )
-    &offset=&offset-0x400000
-  )
-  
-  return 0
-
 
 FindDebugInfo:
   LOCAL   &SystemTable &CfgTableEntries &ConfigTable &i &offset &dbghdr &dbgentries &dbgptr &dbginfo &loadedimg
   ENTRY   &SystemTable
   
-  print "FindDebugInfo"
-  
   &dbgentries=0
-  &CfgTableEntries=Data.Long(a:&SystemTable+0x40)
-  &ConfigTable=Data.Long(a:&SystemTable+0x44)
+  &CfgTableEntries=Data.Long(a:&SystemTable+0x68)
+  &ConfigTable=Data.Long(a:&SystemTable+0x70)
   
   print "config table is at &ConfigTable (&CfgTableEntries entries)"
   
@@ -82,7 +25,7 @@ FindDebugInfo:
   &i=0
   while &i<&CfgTableEntries
   (
-    &offset=&ConfigTable+(&i*0x14)
+    &offset=&ConfigTable+(&i*0x18)
     if Data.Long(a:&offset)==0x49152E77
     (
       if Data.Long(a:&offset+4)==0x47641ADA
@@ -120,8 +63,10 @@ FindDebugInfo:
     (
       if Data.Long(a:&dbginfo)==1 ; normal debug info type
       (
-        &loadedimg=Data.Long(a:&dbginfo+4)
-        do EfiProcessPeImage Data.Long(a:&loadedimg+0x20)
+        &loadedimg=Data.Long(a:&dbginfo+8)
+        &imagebaseptr=&loadedimg+0x40
+        &imagebase=Data.Long(a:&imagebaseptr)
+        do ~~~~/EfiProcessPeImage.cmm "&imagebase"
       )
     )
     &i=&i+1

--- a/EmbeddedPkg/Scripts/LauterbachT32/EfiProcessPeImage.cmm
+++ b/EmbeddedPkg/Scripts/LauterbachT32/EfiProcessPeImage.cmm
@@ -1,4 +1,5 @@
 ;
+; Copyright (c) 2024, Ampere Computing LLC. All rights reserved.<BR>
 ; Copyright (c) 2011, Hewlett-Packard Company. All rights reserved.<BR>
 ; 
 ; SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -10,11 +11,11 @@
   &imgstart=&imgstart
   print "PE32 image found at &imgstart"
 
-  ; offset from dos hdr to PE file hdr
+  ; offset from dos hdr to PE file hdr (i.e. 'PE\0\0' signature)
   &filehdrstart=&imgstart+Data.Long(c:&imgstart+0x3C)
 
   ; offset to debug dir in PE hdrs
-  &debugdirentryrva=Data.Long(c:&filehdrstart+0xA8)
+  &debugdirentryrva=Data.Long(c:&imgstart+0xf10)
   if &debugdirentryrva==0
   (
     print "no debug dir for image at &imgstart"
@@ -62,7 +63,7 @@
     &elfbase=&baseofdata;
   )
 
-  print "found path &elfpath"
+  print "found path &elfpath with address &elfbase"
         ON ERROR GOSUB
               return
   data.load.elf &elfpath &elfbase /NOCODE /NOCLEAR

--- a/EmbeddedPkg/Scripts/LauterbachT32/Readme.md
+++ b/EmbeddedPkg/Scripts/LauterbachT32/Readme.md
@@ -1,10 +1,10 @@
 # DXE Phase Debug
-Update the memsize variable in EfiLoadDxe.cmm for the actual amount of memory
-available in your system.  Allow your system to boot to the point that the DXE
+Allow your system to boot to the point that the DXE
 core is initialized (so that the System Table and Debug Information table is
 present in memory) and execute this script (using the toolbar button or
-'do EfiLoadDxe' from the command area).  It will scan memory for the debug info
-table and load modules in it.
+'do EfiLoadDxe "0xGST_ADDRESS"' from the command area). 'GST_ADDRESS' is the
+address of the EFI_SYSTEM_TABLE, and can be found by the global `gST`.
+The script will scan memory for the debug info table and load modules in it.
 
 # SEC/PEI Phase Debug
 There is no way to autodetect where these images reside so you must pass an


### PR DESCRIPTION
There have been many changes since EfiLoadDxe.cmm was last updated in
2011. The EFI_SYSTEM_TABLE can no longer be found by scanning memory on 4KB boundaries, so require users pass in its address instead. Update various offsets so that the debug information can be found and loaded with a recent version of TRACE32.