### PR TITLE
[PATCH v3 1/1] OvmfPkg/ResetVector: send post codes to qemu debug console -- push

### DIFF
--- a/OvmfPkg/ResetVector/QemuDebugCon.asm
+++ b/OvmfPkg/ResetVector/QemuDebugCon.asm
@@ -1,0 +1,36 @@
+;------------------------------------------------------------------------------
+; @file
+; qemu debug console support macros (based on serial port macros)
+;
+; Copyright (c) 2008 - 2018, Intel Corporation. All rights reserved.<BR>
+; Copyright (c) 2024, Red Hat, Inc.<BR>
+; SPDX-License-Identifier: BSD-2-Clause-Patent
+;
+;------------------------------------------------------------------------------
+
+%macro  debugShowCharacter 1
+    mov     dx, 0x402
+    mov     al, %1
+    out     dx, al
+%endmacro
+
+%macro  debugShowHexDigit 1
+  %if (%1 < 0xa)
+    debugShowCharacter BYTE ('0' + (%1))
+  %else
+    debugShowCharacter BYTE ('a' + ((%1) - 0xa))
+  %endif
+%endmacro
+
+%macro  debugShowPostCode 1
+    debugShowHexDigit (((%1) >> 4) & 0xf)
+    debugShowHexDigit ((%1) & 0xf)
+    debugShowCharacter `\r`
+    debugShowCharacter `\n`
+%endmacro
+
+BITS    16
+
+%macro  debugInitialize 0
+    ; not required
+%endmacro

--- a/OvmfPkg/ResetVector/ResetVector.nasmb
+++ b/OvmfPkg/ResetVector/ResetVector.nasmb
@@ -40,6 +40,10 @@
   %include "Port80Debug.asm"
 %elifdef DEBUG_SERIAL
   %include "SerialDebug.asm"
+%elif 0
+; Set ^ this to 1 to enable postcodes on the qemu debug console.
+; Disabled by default because it is incompatible with SEV-ES/SEV-SNP and TDX.
+  %include "QemuDebugCon.asm"
 %else
   %include "DebugDisabled.asm"
 %endif


### PR DESCRIPTION
~~~
Neat when doing ResetVector coding.
Incompatible with TDX and SEV, therefore not enabled by default.

Signed-off-by: Gerd Hoffmann <kraxel@redhat.com>
Acked-by: Tom Lendacky <thomas.lendacky@amd.com>
Acked-by: Erdem Aktas <erdemaktas@google.com>
Reviewed-by: Laszlo Ersek <lersek@redhat.com>
---
 OvmfPkg/ResetVector/QemuDebugCon.asm  | 36 +++++++++++++++++++++++++++
 OvmfPkg/ResetVector/ResetVector.nasmb |  4 +++
 2 files changed, 40 insertions(+)
 create mode 100644 OvmfPkg/ResetVector/QemuDebugCon.asm
~~~