### PR TITLE
Basetools: Include PCD declarations from Library Instance

### DIFF
--- a/BaseTools/Source/Python/AutoGen/WorkspaceAutoGen.py
+++ b/BaseTools/Source/Python/AutoGen/WorkspaceAutoGen.py
@@ -439,6 +439,10 @@ class WorkspaceAutoGen(AutoGen):
             PkgSet = set()
             for mb in [self.BuildDatabase[m, Arch, self.BuildTarget, self.ToolChain] for m in Platform.Modules]:
                 PkgSet.update(mb.Packages)
+
+            for lb in [self.BuildDatabase[l, Arch, self.BuildTarget, self.ToolChain] for l in Platform.LibraryInstances]:
+                PkgSet.update(lb.Packages)
+
             for Inf in ModuleList:
                 ModuleFile = PathClass(NormPath(Inf), GlobalData.gWorkspace, Arch)
                 if ModuleFile in Platform.Modules:
@@ -968,4 +972,3 @@ class WorkspaceAutoGen(AutoGen):
     #
     def CreateAsBuiltInf(self):
         return
-


### PR DESCRIPTION
The patch "[PATCH v3 1/2] StandaloneMmPkg: Make StandaloneMmCpu driver architecture independent" (https://edk2.groups.io/g/devel/message/109178) removed ArmPkg/ArmPkg.dec from the Packages section in the INF file: StandaloneMmPkg/Drivers/StandaloneMmCpu/StandaloneMmCpu.inf

This change was done as part of making the StandaloneMmCpu driver architecture independent.

Although this change is correct, it results in a side effect here some platforms that utilise PCDs declared in ArmPkg.dec are no longer declared.

An example of this issue can be seen when building edk2-platforms/Platform/ARM/SgiPkg/PlatformStandaloneMm.dsc

$ build -a AARCH64 -t GCC -p Platform/ARM/SgiPkg/PlatformStandaloneMm.dsc build.py...
/mnt/source/edk2-platforms/Platform/ARM/SgiPkg/PlatformStandaloneMm.fdf(23):
  error F001: PCD (gArmTokenSpaceGuid.PcdFdBaseAddress) used in
  FDF is not declared in DEC files.

As seen above, removing ArmPkg.dec from the Packages section in the StandAloneMmCpu Driver Inf file triggers build failure. Although, ArmPkg.dec is included in other Library Instances, the build system does not include the declarations from .dec files defined in Library instances.

The build system only includes the PCD declarations from DEC files that are specified in INF files for Modules (components).

Therefore, extend the build system to include the Packages from Library Instances so that the PCD declarations from the respective package DEC files are included.

This patch can be seen on
    https://github.com/LeviYeoReum/edk2/tree/levi/2848_dec_check_on_library


Tested-by: Pierre Gondois <pierre.gondois@arm.com>
Reviewed-by: Rebecca Cran <rebecca@bsdio.com>
Reviewed-by: Sami Mujawar <sami.mujawar@arm.com>