### PR TITLE
Add EFI_UNSUPPORTED return for some Runtime Service functions

### DIFF
--- a/ArmPlatformPkg/Library/PL031RealTimeClockLib/PL031RealTimeClockLib.c
+++ b/ArmPlatformPkg/Library/PL031RealTimeClockLib/PL031RealTimeClockLib.c
@@ -111,7 +111,9 @@ EXIT:
   @retval EFI_SUCCESS            The operation completed successfully.
   @retval EFI_INVALID_PARAMETER  Time is NULL.
   @retval EFI_DEVICE_ERROR       The time could not be retrieved due to hardware error.
-  @retval EFI_SECURITY_VIOLATION The time could not be retrieved due to an authentication failure.
+  @retval EFI_UNSUPPORTED        This call is not supported by this platform at the time the call is made.
+                                 The platform should describe this runtime service as unsupported at runtime
+                                 via an EFI_RT_PROPERTIES_TABLE configuration table.
 
 **/
 EFI_STATUS
@@ -172,6 +174,9 @@ LibGetTime (
   @retval EFI_SUCCESS           The operation completed successfully.
   @retval EFI_INVALID_PARAMETER A time field is out of range.
   @retval EFI_DEVICE_ERROR      The time could not be set due to hardware error.
+  @retval EFI_UNSUPPORTED       This call is not supported by this platform at the time the call is made.
+                                The platform should describe this runtime service as unsupported at runtime
+                                via an EFI_RT_PROPERTIES_TABLE configuration table.
 
 **/
 EFI_STATUS
@@ -224,8 +229,13 @@ LibSetTime (
   @param  Time                  The current alarm setting.
 
   @retval EFI_SUCCESS           The alarm settings were returned.
-  @retval EFI_INVALID_PARAMETER Any parameter is NULL.
+  @retval EFI_INVALID_PARAMETER Enabled is NULL.
+  @retval EFI_INVALID_PARAMETER Pending is NULL.
+  @retval EFI_INVALID_PARAMETER Time is NULL.
   @retval EFI_DEVICE_ERROR      The wakeup time could not be retrieved due to a hardware error.
+  @retval EFI_UNSUPPORTED       This call is not supported by this platform at the time the call is made.
+                                The platform should describe this runtime service as unsupported at runtime
+                                via an EFI_RT_PROPERTIES_TABLE configuration table.
 
 **/
 EFI_STATUS
@@ -248,9 +258,13 @@ LibGetWakeupTime (
 
   @retval EFI_SUCCESS           If Enable is TRUE, then the wakeup alarm was enabled. If
                                 Enable is FALSE, then the wakeup alarm was disabled.
-  @retval EFI_INVALID_PARAMETER A time field is out of range.
+  @retval EFI_INVALID_PARAMETER Enabled is NULL.
+  @retval EFI_INVALID_PARAMETER Pending is NULL.
+  @retval EFI_INVALID_PARAMETER Time is NULL.
   @retval EFI_DEVICE_ERROR      The wakeup time could not be set due to a hardware error.
-  @retval EFI_UNSUPPORTED       A wakeup timer is not supported on this platform.
+  @retval EFI_UNSUPPORTED       This call is not supported by this platform at the time the call is made.
+                                The platform should describe this runtime service as unsupported at runtime
+                                via an EFI_RT_PROPERTIES_TABLE configuration table.
 
 **/
 EFI_STATUS

--- a/EmbeddedPkg/Include/Library/RealTimeClockLib.h
+++ b/EmbeddedPkg/Include/Library/RealTimeClockLib.h
@@ -23,6 +23,9 @@
   @retval EFI_SUCCESS           The operation completed successfully.
   @retval EFI_INVALID_PARAMETER Time is NULL.
   @retval EFI_DEVICE_ERROR      The time could not be retrieved due to hardware error.
+  @retval EFI_UNSUPPORTED       This call is not supported by this platform at the time the call is made.
+                                The platform should describe this runtime service as unsupported at runtime
+                                via an EFI_RT_PROPERTIES_TABLE configuration table.
 
 **/
 EFI_STATUS
@@ -40,6 +43,9 @@ LibGetTime (
   @retval EFI_SUCCESS           The operation completed successfully.
   @retval EFI_INVALID_PARAMETER A time field is out of range.
   @retval EFI_DEVICE_ERROR      The time could not be set due to hardware error.
+  @retval EFI_UNSUPPORTED       This call is not supported by this platform at the time the call is made.
+                                The platform should describe this runtime service as unsupported at runtime
+                                via an EFI_RT_PROPERTIES_TABLE configuration table.
 
 **/
 EFI_STATUS
@@ -56,8 +62,13 @@ LibSetTime (
   @param  Time                  The current alarm setting.
 
   @retval EFI_SUCCESS           The alarm settings were returned.
-  @retval EFI_INVALID_PARAMETER Any parameter is NULL.
+  @retval EFI_INVALID_PARAMETER Enabled is NULL.
+  @retval EFI_INVALID_PARAMETER Pending is NULL.
+  @retval EFI_INVALID_PARAMETER Time is NULL.
   @retval EFI_DEVICE_ERROR      The wakeup time could not be retrieved due to a hardware error.
+  @retval EFI_UNSUPPORTED       This call is not supported by this platform at the time the call is made.
+                                The platform should describe this runtime service as unsupported at runtime
+                                via an EFI_RT_PROPERTIES_TABLE configuration table.
 
 **/
 EFI_STATUS
@@ -76,9 +87,13 @@ LibGetWakeupTime (
 
   @retval EFI_SUCCESS           If Enable is TRUE, then the wakeup alarm was enabled. If
                                 Enable is FALSE, then the wakeup alarm was disabled.
-  @retval EFI_INVALID_PARAMETER A time field is out of range.
+  @retval EFI_INVALID_PARAMETER Enabled is NULL.
+  @retval EFI_INVALID_PARAMETER Pending is NULL.
+  @retval EFI_INVALID_PARAMETER Time is NULL.
   @retval EFI_DEVICE_ERROR      The wakeup time could not be set due to a hardware error.
-  @retval EFI_UNSUPPORTED       A wakeup timer is not supported on this platform.
+  @retval EFI_UNSUPPORTED       This call is not supported by this platform at the time the call is made.
+                                The platform should describe this runtime service as unsupported at runtime
+                                via an EFI_RT_PROPERTIES_TABLE configuration table.
 
 **/
 EFI_STATUS

--- a/EmbeddedPkg/RealTimeClockRuntimeDxe/RealTimeClock.c
+++ b/EmbeddedPkg/RealTimeClockRuntimeDxe/RealTimeClock.c
@@ -44,6 +44,9 @@ STATIC NON_VOLATILE_TIME_SETTINGS  mTimeSettings;
   @retval EFI_SUCCESS           The operation completed successfully.
   @retval EFI_INVALID_PARAMETER Time is NULL.
   @retval EFI_DEVICE_ERROR      The time could not be retrieved due to hardware error.
+  @retval EFI_UNSUPPORTED       This call is not supported by this platform at the time the call is made.
+                                The platform should describe this runtime service as unsupported at runtime
+                                via an EFI_RT_PROPERTIES_TABLE configuration table.
 
 **/
 EFI_STATUS
@@ -75,6 +78,9 @@ GetTime (
   @retval EFI_SUCCESS           The operation completed successfully.
   @retval EFI_INVALID_PARAMETER A time field is out of range.
   @retval EFI_DEVICE_ERROR      The time could not be set due to hardware error.
+  @retval EFI_UNSUPPORTED       This call is not supported by this platform at the time the call is made.
+                                The platform should describe this runtime service as unsupported at runtime
+                                via an EFI_RT_PROPERTIES_TABLE configuration table.
 
 **/
 EFI_STATUS
@@ -132,6 +138,9 @@ SetTime (
   @retval EFI_SUCCESS           The alarm settings were returned.
   @retval EFI_INVALID_PARAMETER Any parameter is NULL.
   @retval EFI_DEVICE_ERROR      The wakeup time could not be retrieved due to a hardware error.
+  @retval EFI_UNSUPPORTED       This call is not supported by this platform at the time the call is made.
+                                The platform should describe this runtime service as unsupported at runtime
+                                via an EFI_RT_PROPERTIES_TABLE configuration table.
 
 **/
 EFI_STATUS
@@ -166,7 +175,9 @@ GetWakeupTime (
                                 Enable is FALSE, then the wakeup alarm was disabled.
   @retval EFI_INVALID_PARAMETER A time field is out of range.
   @retval EFI_DEVICE_ERROR      The wakeup time could not be set due to a hardware error.
-  @retval EFI_UNSUPPORTED       A wakeup timer is not supported on this platform.
+  @retval EFI_UNSUPPORTED       This call is not supported by this platform at the time the call is made.
+                                The platform should describe this runtime service as unsupported at runtime
+                                via an EFI_RT_PROPERTIES_TABLE configuration table.
 
 **/
 EFI_STATUS

--- a/MdeModulePkg/Core/RuntimeDxe/Runtime.c
+++ b/MdeModulePkg/Core/RuntimeDxe/Runtime.c
@@ -117,7 +117,12 @@ RuntimeDriverCalculateEfiHdrCrc (
   @retval  EFI_SUCCESS              The pointer pointed to by Address was modified.
   @retval  EFI_NOT_FOUND            The pointer pointed to by Address was not found to be part
                                     of the current memory map. This is normally fatal.
-  @retval  EFI_INVALID_PARAMETER    One of the parameters has an invalid value.
+  @retval  EFI_INVALID_PARAMETER    1) Address is NULL.
+                                    2) *Address is NULL and DebugDisposition does
+                                    not have the EFI_OPTIONAL_PTR bit set.
+  @retval  EFI_UNSUPPORTED          This call is not supported by this platform at the time the call is made.
+                                    The platform should describe this runtime service as unsupported at runtime
+                                    via an EFI_RT_PROPERTIES_TABLE configuration table.
 
 **/
 EFI_STATUS
@@ -227,6 +232,9 @@ RuntimeDriverConvertInternalPointer (
                                   map that requires a mapping.
   @retval  EFI_NOT_FOUND          A virtual address was supplied for an address that is not found
                                   in the memory map.
+  @retval  EFI_UNSUPPORTED        This call is not supported by this platform at the time the call is made.
+                                  The platform should describe this runtime service as unsupported at runtime
+                                  via an EFI_RT_PROPERTIES_TABLE configuration table.
 
 **/
 EFI_STATUS

--- a/MdeModulePkg/Core/RuntimeDxe/Runtime.h
+++ b/MdeModulePkg/Core/RuntimeDxe/Runtime.h
@@ -59,7 +59,12 @@ RuntimeDriverCalculateCrc32 (
   @retval  EFI_SUCCESS              The pointer pointed to by Address was modified.
   @retval  EFI_NOT_FOUND            The pointer pointed to by Address was not found to be part
                                     of the current memory map. This is normally fatal.
-  @retval  EFI_INVALID_PARAMETER    One of the parameters has an invalid value.
+  @retval  EFI_INVALID_PARAMETER    1) Address is NULL.
+                                    2) *Address is NULL and DebugDisposition does
+                                    not have the EFI_OPTIONAL_PTR bit set.
+  @retval  EFI_UNSUPPORTED          This call is not supported by this platform at the time the call is made.
+                                    The platform should describe this runtime service as unsupported at runtime
+                                    via an EFI_RT_PROPERTIES_TABLE configuration table.
 
 **/
 EFI_STATUS
@@ -86,6 +91,9 @@ RuntimeDriverConvertPointer (
                                   map that requires a mapping.
   @retval  EFI_NOT_FOUND          A virtual address was supplied for an address that is not found
                                   in the memory map.
+  @retval  EFI_UNSUPPORTED        This call is not supported by this platform at the time the call is made.
+                                  The platform should describe this runtime service as unsupported at runtime
+                                  via an EFI_RT_PROPERTIES_TABLE configuration table.
 
 **/
 EFI_STATUS

--- a/MdeModulePkg/Universal/CapsuleRuntimeDxe/CapsuleService.c
+++ b/MdeModulePkg/Universal/CapsuleRuntimeDxe/CapsuleService.c
@@ -53,6 +53,9 @@ UINT32  mMaxSizeNonPopulateCapsule = 0;
                                 in runtime. The caller may resubmit the capsule prior to ExitBootServices().
   @retval EFI_OUT_OF_RESOURCES  When ExitBootServices() has not been previously called then this error indicates
                                 the capsule is compatible with this platform but there are insufficient resources to process.
+  @retval EFI_UNSUPPORTED       This call is not supported by this platform at the time the call is made.
+                                The platform should describe this runtime service as unsupported at runtime
+                                via an EFI_RT_PROPERTIES_TABLE configuration table.
 
 **/
 EFI_STATUS
@@ -247,6 +250,16 @@ UpdateCapsule (
                                 MaximumCapsuleSize and ResetType are undefined.
   @retval EFI_INVALID_PARAMETER MaximumCapsuleSize is NULL, or ResetTyep is NULL,
                                 Or CapsuleCount is Zero, or CapsuleImage is not valid.
+  @retval EFI_OUT_OF_RESOURCES  When ExitBootServices() has been previously called this error indicates
+                                the capsule is compatible with this platform but is not capable of
+                                being submitted or processed in runtime.
+                                The caller may resubmit the capsule prior to ExitBootServices().
+  @retval EFI_OUT_OF_RESOURCES  When ExitBootServices() has not been previously called then this error
+                                indicates the capsule is compatible with this platform but there are
+                                insufficient resources to process.
+  @retval EFI_UNSUPPORTED       This call is not supported by this platform at the time the call is made.
+                                The platform should describe this runtime service as unsupported at runtime
+                                via an EFI_RT_PROPERTIES_TABLE configuration table.
 
 **/
 EFI_STATUS

--- a/MdeModulePkg/Universal/MonotonicCounterRuntimeDxe/MonotonicCounter.c
+++ b/MdeModulePkg/Universal/MonotonicCounterRuntimeDxe/MonotonicCounter.c
@@ -125,6 +125,9 @@ MonotonicCounterDriverGetNextMonotonicCount (
   @retval EFI_DEVICE_ERROR      The variable could not be saved due to a hardware failure.
   @retval EFI_OUT_OF_RESOURCES  If variable service reports that not enough storage
                                 is available to hold the variable and its data.
+  @retval EFI_UNSUPPORTED       This call is not supported by this platform at the time the call is made.
+                                The platform should describe this runtime service as unsupported at runtime
+                                via an EFI_RT_PROPERTIES_TABLE configuration table.
 
 **/
 EFI_STATUS

--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/Variable.c
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/Variable.c
@@ -2385,10 +2385,19 @@ Done:
   @param Data                       The buffer to return the contents of the variable. May be NULL
                                     with a zero DataSize in order to determine the size buffer needed.
 
-  @return EFI_INVALID_PARAMETER     Invalid parameter.
-  @return EFI_SUCCESS               Find the specified variable.
-  @return EFI_NOT_FOUND             Not found.
-  @return EFI_BUFFER_TO_SMALL       DataSize is too small for the result.
+  @retval EFI_SUCCESS               The function completed successfully.
+  @retval EFI_NOT_FOUND             The variable was not found.
+  @retval EFI_BUFFER_TOO_SMALL      The DataSize is too small for the result.
+  @retval EFI_INVALID_PARAMETER     VariableName is NULL.
+  @retval EFI_INVALID_PARAMETER     VendorGuid is NULL.
+  @retval EFI_INVALID_PARAMETER     DataSize is NULL.
+  @retval EFI_INVALID_PARAMETER     The DataSize is not too small and Data is NULL.
+  @retval EFI_DEVICE_ERROR          The variable could not be retrieved due to a hardware error.
+  @retval EFI_SECURITY_VIOLATION    The variable could not be retrieved due to an authentication failure.
+  @retval EFI_UNSUPPORTED           After ExitBootServices() has been called, this return code may be returned
+                                    if no variable storage is supported. The platform should describe this
+                                    runtime service as unsupported at runtime via an EFI_RT_PROPERTIES_TABLE
+                                    configuration table.
 
 **/
 EFI_STATUS
@@ -2479,6 +2488,11 @@ Done:
                                     GUID of an existing variable.
   @retval EFI_INVALID_PARAMETER     Null-terminator is not found in the first VariableNameSize bytes of
                                     the input VariableName buffer.
+  @retval EFI_DEVICE_ERROR          The variable could not be retrieved due to a hardware error.
+  @retval EFI_UNSUPPORTED           After ExitBootServices() has been called, this return code may be returned
+                                    if no variable storage is supported. The platform should describe this
+                                    runtime service as unsupported at runtime via an EFI_RT_PROPERTIES_TABLE
+                                    configuration table.
 
 **/
 EFI_STATUS
@@ -2576,11 +2590,19 @@ VariableServiceGetNextVariableName (
                                           data, this value contains the required size.
   @param Data                             Data pointer.
 
-  @return EFI_INVALID_PARAMETER           Invalid parameter.
-  @return EFI_SUCCESS                     Set successfully.
-  @return EFI_OUT_OF_RESOURCES            Resource not enough to set variable.
-  @return EFI_NOT_FOUND                   Not found.
-  @return EFI_WRITE_PROTECTED             Variable is read-only.
+  @retval EFI_SUCCESS                     The function completed successfully.
+  @retval EFI_NOT_FOUND                   The variable was not found.
+  @retval EFI_BUFFER_TOO_SMALL            The DataSize is too small for the result.
+  @retval EFI_INVALID_PARAMETER           VariableName is NULL.
+  @retval EFI_INVALID_PARAMETER           VendorGuid is NULL.
+  @retval EFI_INVALID_PARAMETER           DataSize is NULL.
+  @retval EFI_INVALID_PARAMETER           The DataSize is not too small and Data is NULL.
+  @retval EFI_DEVICE_ERROR                The variable could not be retrieved due to a hardware error.
+  @retval EFI_SECURITY_VIOLATION          The variable could not be retrieved due to an authentication failure.
+  @retval EFI_UNSUPPORTED                 After ExitBootServices() has been called, this return code may be returned
+                                          if no variable storage is supported. The platform should describe this
+                                          runtime service as unsupported at runtime via an EFI_RT_PROPERTIES_TABLE
+                                          configuration table.
 
 **/
 EFI_STATUS

--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/Variable.h
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/Variable.h
@@ -446,10 +446,19 @@ GetFvbInfoByAddress (
   @param Data                       The buffer to return the contents of the variable. May be NULL
                                     with a zero DataSize in order to determine the size buffer needed.
 
-  @return EFI_INVALID_PARAMETER     Invalid parameter.
-  @return EFI_SUCCESS               Find the specified variable.
-  @return EFI_NOT_FOUND             Not found.
-  @return EFI_BUFFER_TO_SMALL       DataSize is too small for the result.
+  @retval EFI_SUCCESS            The function completed successfully.
+  @retval EFI_NOT_FOUND          The variable was not found.
+  @retval EFI_BUFFER_TOO_SMALL   The DataSize is too small for the result.
+  @retval EFI_INVALID_PARAMETER  VariableName is NULL.
+  @retval EFI_INVALID_PARAMETER  VendorGuid is NULL.
+  @retval EFI_INVALID_PARAMETER  DataSize is NULL.
+  @retval EFI_INVALID_PARAMETER  The DataSize is not too small and Data is NULL.
+  @retval EFI_DEVICE_ERROR       The variable could not be retrieved due to a hardware error.
+  @retval EFI_SECURITY_VIOLATION The variable could not be retrieved due to an authentication failure.
+  @retval EFI_UNSUPPORTED        After ExitBootServices() has been called, this return code may be returned
+                                 if no variable storage is supported. The platform should describe this
+                                 runtime service as unsupported at runtime via an EFI_RT_PROPERTIES_TABLE
+                                 configuration table.
 
 **/
 EFI_STATUS
@@ -485,6 +494,11 @@ VariableServiceGetVariable (
                                     GUID of an existing variable.
   @retval EFI_INVALID_PARAMETER     Null-terminator is not found in the first VariableNameSize bytes of
                                     the input VariableName buffer.
+  @retval EFI_DEVICE_ERROR          The variable could not be retrieved due to a hardware error.
+  @retval EFI_UNSUPPORTED           After ExitBootServices() has been called, this return code may be returned
+                                    if no variable storage is supported. The platform should describe this
+                                    runtime service as unsupported at runtime via an EFI_RT_PROPERTIES_TABLE
+                                    configuration table.
 
 **/
 EFI_STATUS
@@ -513,11 +527,19 @@ VariableServiceGetNextVariableName (
                                           data, this value contains the required size.
   @param Data                             Data pointer.
 
-  @return EFI_INVALID_PARAMETER           Invalid parameter.
-  @return EFI_SUCCESS                     Set successfully.
-  @return EFI_OUT_OF_RESOURCES            Resource not enough to set variable.
-  @return EFI_NOT_FOUND                   Not found.
-  @return EFI_WRITE_PROTECTED             Variable is read-only.
+  @retval EFI_SUCCESS                     The function completed successfully.
+  @retval EFI_NOT_FOUND                   The variable was not found.
+  @retval EFI_BUFFER_TOO_SMALL            The DataSize is too small for the result.
+  @retval EFI_INVALID_PARAMETER           VariableName is NULL.
+  @retval EFI_INVALID_PARAMETER           VendorGuid is NULL.
+  @retval EFI_INVALID_PARAMETER           DataSize is NULL.
+  @retval EFI_INVALID_PARAMETER           The DataSize is not too small and Data is NULL.
+  @retval EFI_DEVICE_ERROR                The variable could not be retrieved due to a hardware error.
+  @retval EFI_SECURITY_VIOLATION          The variable could not be retrieved due to an authentication failure.
+  @retval EFI_UNSUPPORTED                 After ExitBootServices() has been called, this return code may be returned
+                                          if no variable storage is supported. The platform should describe this
+                                          runtime service as unsupported at runtime via an EFI_RT_PROPERTIES_TABLE
+                                          configuration table.
 
 **/
 EFI_STATUS

--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxe.c
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxe.c
@@ -831,10 +831,19 @@ Done:
                                      data, this value contains the required size.
   @param[out]     Data               Data pointer.
 
-  @retval EFI_INVALID_PARAMETER      Invalid parameter.
-  @retval EFI_SUCCESS                Find the specified variable.
-  @retval EFI_NOT_FOUND              Not found.
-  @retval EFI_BUFFER_TO_SMALL        DataSize is too small for the result.
+  @retval EFI_SUCCESS                The function completed successfully.
+  @retval EFI_NOT_FOUND              The variable was not found.
+  @retval EFI_BUFFER_TOO_SMALL       The DataSize is too small for the result.
+  @retval EFI_INVALID_PARAMETER      VariableName is NULL.
+  @retval EFI_INVALID_PARAMETER      VendorGuid is NULL.
+  @retval EFI_INVALID_PARAMETER      DataSize is NULL.
+  @retval EFI_INVALID_PARAMETER      The DataSize is not too small and Data is NULL.
+  @retval EFI_DEVICE_ERROR           The variable could not be retrieved due to a hardware error.
+  @retval EFI_SECURITY_VIOLATION     The variable could not be retrieved due to an authentication failure.
+  @retval EFI_UNSUPPORTED            After ExitBootServices() has been called, this return code may be returned
+                                     if no variable storage is supported. The platform should describe this
+                                     runtime service as unsupported at runtime via an EFI_RT_PROPERTIES_TABLE
+                                     configuration table.
 
 **/
 EFI_STATUS
@@ -876,10 +885,22 @@ RuntimeServiceGetVariable (
   @param[in, out] VariableName       Pointer to variable name.
   @param[in, out] VendorGuid         Variable Vendor Guid.
 
-  @retval EFI_INVALID_PARAMETER      Invalid parameter.
-  @retval EFI_SUCCESS                Find the specified variable.
-  @retval EFI_NOT_FOUND              Not found.
-  @retval EFI_BUFFER_TO_SMALL        DataSize is too small for the result.
+  @retval EFI_SUCCESS                The function completed successfully.
+  @retval EFI_NOT_FOUND              The next variable was not found.
+  @retval EFI_BUFFER_TOO_SMALL       The VariableNameSize is too small for the result.
+                                     VariableNameSize has been updated with the size needed to complete the request.
+  @retval EFI_INVALID_PARAMETER      VariableNameSize is NULL.
+  @retval EFI_INVALID_PARAMETER      VariableName is NULL.
+  @retval EFI_INVALID_PARAMETER      VendorGuid is NULL.
+  @retval EFI_INVALID_PARAMETER      The input values of VariableName and VendorGuid are not a name and
+                                     GUID of an existing variable.
+  @retval EFI_INVALID_PARAMETER      Null-terminator is not found in the first VariableNameSize bytes of
+                                     the input VariableName buffer.
+  @retval EFI_DEVICE_ERROR           The variable could not be retrieved due to a hardware error.
+  @retval EFI_UNSUPPORTED            After ExitBootServices() has been called, this return code may be returned
+                                     if no variable storage is supported. The platform should describe this
+                                     runtime service as unsupported at runtime via an EFI_RT_PROPERTIES_TABLE
+                                     configuration table.
 
 **/
 EFI_STATUS
@@ -951,10 +972,22 @@ GetNextVariableNameInRuntimeCache (
   @param[in, out] VariableName       Pointer to variable name.
   @param[in, out] VendorGuid         Variable Vendor Guid.
 
-  @retval EFI_INVALID_PARAMETER      Invalid parameter.
-  @retval EFI_SUCCESS                Find the specified variable.
-  @retval EFI_NOT_FOUND              Not found.
-  @retval EFI_BUFFER_TO_SMALL        DataSize is too small for the result.
+  @retval EFI_SUCCESS                The function completed successfully.
+  @retval EFI_NOT_FOUND              The next variable was not found.
+  @retval EFI_BUFFER_TOO_SMALL       The VariableNameSize is too small for the result.
+                                     VariableNameSize has been updated with the size needed to complete the request.
+  @retval EFI_INVALID_PARAMETER      VariableNameSize is NULL.
+  @retval EFI_INVALID_PARAMETER      VariableName is NULL.
+  @retval EFI_INVALID_PARAMETER      VendorGuid is NULL.
+  @retval EFI_INVALID_PARAMETER      The input values of VariableName and VendorGuid are not a name and
+                                     GUID of an existing variable.
+  @retval EFI_INVALID_PARAMETER      Null-terminator is not found in the first VariableNameSize bytes of
+                                     the input VariableName buffer.
+  @retval EFI_DEVICE_ERROR           The variable could not be retrieved due to a hardware error.
+  @retval EFI_UNSUPPORTED            After ExitBootServices() has been called, this return code may be returned
+                                     if no variable storage is supported. The platform should describe this
+                                     runtime service as unsupported at runtime via an EFI_RT_PROPERTIES_TABLE
+                                     configuration table.
 
 **/
 EFI_STATUS
@@ -1052,10 +1085,22 @@ Done:
   @param[in, out] VariableName       Pointer to variable name.
   @param[in, out] VendorGuid         Variable Vendor Guid.
 
-  @retval EFI_INVALID_PARAMETER      Invalid parameter.
-  @retval EFI_SUCCESS                Find the specified variable.
-  @retval EFI_NOT_FOUND              Not found.
-  @retval EFI_BUFFER_TO_SMALL        DataSize is too small for the result.
+  @retval EFI_SUCCESS                The function completed successfully.
+  @retval EFI_NOT_FOUND              The next variable was not found.
+  @retval EFI_BUFFER_TOO_SMALL       The VariableNameSize is too small for the result.
+                                     VariableNameSize has been updated with the size needed to complete the request.
+  @retval EFI_INVALID_PARAMETER      VariableNameSize is NULL.
+  @retval EFI_INVALID_PARAMETER      VariableName is NULL.
+  @retval EFI_INVALID_PARAMETER      VendorGuid is NULL.
+  @retval EFI_INVALID_PARAMETER      The input values of VariableName and VendorGuid are not a name and
+                                     GUID of an existing variable.
+  @retval EFI_INVALID_PARAMETER      Null-terminator is not found in the first VariableNameSize bytes of
+                                     the input VariableName buffer.
+  @retval EFI_DEVICE_ERROR           The variable could not be retrieved due to a hardware error.
+  @retval EFI_UNSUPPORTED            After ExitBootServices() has been called, this return code may be returned
+                                     if no variable storage is supported. The platform should describe this
+                                     runtime service as unsupported at runtime via an EFI_RT_PROPERTIES_TABLE
+                                     configuration table.
 
 **/
 EFI_STATUS
@@ -1112,11 +1157,23 @@ RuntimeServiceGetNextVariableName (
                                           data, this value contains the required size.
   @param[in] Data                         Data pointer.
 
-  @retval EFI_INVALID_PARAMETER           Invalid parameter.
-  @retval EFI_SUCCESS                     Set successfully.
-  @retval EFI_OUT_OF_RESOURCES            Resource not enough to set variable.
-  @retval EFI_NOT_FOUND                   Not found.
-  @retval EFI_WRITE_PROTECTED             Variable is read-only.
+  @retval EFI_SUCCESS                     The firmware has successfully stored the variable and its data as
+                                          defined by the Attributes.
+  @retval EFI_INVALID_PARAMETER           An invalid combination of attribute bits, name, and GUID was supplied, or the
+                                          DataSize exceeds the maximum allowed.
+  @retval EFI_INVALID_PARAMETER           VariableName is an empty string.
+  @retval EFI_OUT_OF_RESOURCES            Not enough storage is available to hold the variable and its data.
+  @retval EFI_DEVICE_ERROR                The variable could not be retrieved due to a hardware error.
+  @retval EFI_WRITE_PROTECTED             The variable in question is read-only.
+  @retval EFI_WRITE_PROTECTED             The variable in question cannot be deleted.
+  @retval EFI_SECURITY_VIOLATION          The variable could not be written due to
+                                          EFI_VARIABLE_TIME_BASED_AUTHENTICATED_WRITE_ACESS being set,
+                                          but the AuthInfo does NOT pass the validation check carried out by the firmware.
+
+  @retval EFI_NOT_FOUND                   The variable trying to be updated or deleted was not found.
+  @retval EFI_UNSUPPORTED                 This call is not supported by this platform at the time the call is made.
+                                          The platform should describe this runtime service as unsupported at runtime
+                                          via an EFI_RT_PROPERTIES_TABLE configuration table.
 
 **/
 EFI_STATUS

--- a/MdePkg/Include/Library/UefiRuntimeLib.h
+++ b/MdePkg/Include/Library/UefiRuntimeLib.h
@@ -64,6 +64,9 @@ EfiGoneVirtual (
   @retval  EFI_SUCCESS            The operation completed successfully.
   @retval  EFI_INVALID_PARAMETER  Time is NULL.
   @retval  EFI_DEVICE_ERROR       The time could not be retrieved due to a hardware error.
+  @retval  EFI_UNSUPPORTED        This call is not supported by this platform at the time the call is made.
+                                  The platform should describe this runtime service as unsupported at runtime
+                                  via an EFI_RT_PROPERTIES_TABLE configuration table.
 
 **/
 EFI_STATUS
@@ -93,6 +96,9 @@ EfiGetTime (
   @retval  EFI_SUCCESS            The operation completed successfully.
   @retval  EFI_INVALID_PARAMETER  A time field is out of range.
   @retval  EFI_DEVICE_ERROR       The time could not be set due to a hardware error.
+  @retval  EFI_UNSUPPORTED        This call is not supported by this platform at the time the call is made.
+                                  The platform should describe this runtime service as unsupported at runtime
+                                  via an EFI_RT_PROPERTIES_TABLE configuration table.
 
 **/
 EFI_STATUS
@@ -119,7 +125,9 @@ EfiSetTime (
   @retval  EFI_INVALID_PARAMETER  Pending is NULL.
   @retval  EFI_INVALID_PARAMETER  Time is NULL.
   @retval  EFI_DEVICE_ERROR       The wakeup time could not be retrieved due to a hardware error.
-  @retval  EFI_UNSUPPORTED        A wakeup timer is not supported on this platform.
+  @retval  EFI_UNSUPPORTED        This call is not supported by this platform at the time the call is made.
+                                  The platform should describe this runtime service as unsupported at runtime
+                                  via an EFI_RT_PROPERTIES_TABLE configuration table.
 
 **/
 EFI_STATUS
@@ -149,7 +157,9 @@ EfiGetWakeupTime (
                                   If Enable is FALSE, then the wakeup alarm was disabled.
   @retval  EFI_INVALID_PARAMETER  A time field is out of range.
   @retval  EFI_DEVICE_ERROR       The wakeup time could not be set due to a hardware error.
-  @retval  EFI_UNSUPPORTED        A wakeup timer is not supported on this platform.
+  @retval  EFI_UNSUPPORTED        This call is not supported by this platform at the time the call is made.
+                                  The platform should describe this runtime service as unsupported at runtime
+                                  via an EFI_RT_PROPERTIES_TABLE configuration table.
 
 **/
 EFI_STATUS
@@ -188,6 +198,10 @@ EfiSetWakeupTime (
   @retval  EFI_INVALID_PARAMETER  The DataSize is not too small and Data is NULL.
   @retval  EFI_DEVICE_ERROR       The variable could not be retrieved due to a hardware error.
   @retval  EFI_SECURITY_VIOLATION The variable could not be retrieved due to an authentication failure.
+  @retval  EFI_UNSUPPORTED        After ExitBootServices() has been called, this return code may be returned
+                                  if no variable storage is supported. The platform should describe this
+                                  runtime service as unsupported at runtime via an EFI_RT_PROPERTIES_TABLE
+                                  configuration table.
 **/
 EFI_STATUS
 EFIAPI
@@ -227,6 +241,10 @@ EfiGetVariable (
   @retval  EFI_INVALID_PARAMETER VariableName is NULL.
   @retval  EFI_INVALID_PARAMETER VendorGuid is NULL.
   @retval  EFI_DEVICE_ERROR      The variable name could not be retrieved due to a hardware error.
+  @retval  EFI_UNSUPPORTED       After ExitBootServices() has been called, this return code may be returned
+                                 if no variable storage is supported. The platform should describe this
+                                 runtime service as unsupported at runtime via an EFI_RT_PROPERTIES_TABLE
+                                 configuration table.
 
 **/
 EFI_STATUS
@@ -264,6 +282,9 @@ EfiGetNextVariableName (
                                   set but the AuthInfo does NOT pass the validation check carried
                                   out by the firmware.
   @retval  EFI_NOT_FOUND          The variable trying to be updated or deleted was not found.
+  @retval  EFI_UNSUPPORTED        This call is not supported by this platform at the time the call is made.
+                                  The platform should describe this runtime service as unsupported at runtime
+                                  via an EFI_RT_PROPERTIES_TABLE configuration table.
 
 **/
 EFI_STATUS
@@ -290,6 +311,10 @@ EfiSetVariable (
   @retval  EFI_SUCCESS           The next high monotonic count was returned.
   @retval  EFI_DEVICE_ERROR      The device is not functioning properly.
   @retval  EFI_INVALID_PARAMETER HighCount is NULL.
+  @retval  EFI_UNSUPPORTED       This call is not supported by this platform at the time the call is made.
+                                 The platform should describe this runtime service as unsupported at runtime
+                                 via an EFI_RT_PROPERTIES_TABLE configuration table.
+
 
 **/
 EFI_STATUS
@@ -350,7 +375,11 @@ EfiResetSystem (
   @retval  EFI_NOT_FOUND          The pointer pointed to by Address was not found to be part of
                                   the current memory map. This is normally fatal.
   @retval  EFI_INVALID_PARAMETER  Address is NULL.
-  @retval  EFI_INVALID_PARAMETER  *Address is NULL and DebugDispositio
+  @retval  EFI_INVALID_PARAMETER  *Address is NULL and DebugDisposition does
+                                  not have the EFI_OPTIONAL_PTR bit set.
+  @retval  EFI_UNSUPPORTED        This call is not supported by this platform at the time the call is made.
+                                  The platform should describe this runtime service as unsupported at runtime
+                                  via an EFI_RT_PROPERTIES_TABLE configuration table.
 
 **/
 EFI_STATUS
@@ -414,6 +443,9 @@ EfiConvertFunctionPointer (
                                 map that requires a mapping.
   @retval EFI_NOT_FOUND         A virtual address was supplied for an address that is not found
                                 in the memory map.
+  @retval EFI_UNSUPPORTED       This call is not supported by this platform at the time the call is made.
+                                The platform should describe this runtime service as unsupported at runtime
+                                via an EFI_RT_PROPERTIES_TABLE configuration table.
 **/
 EFI_STATUS
 EFIAPI
@@ -478,6 +510,9 @@ EfiConvertList (
   @retval EFI_DEVICE_ERROR      The capsule update was started, but failed due to a device error.
   @retval EFI_UNSUPPORTED       The capsule type is not supported on this platform.
   @retval EFI_OUT_OF_RESOURCES  There were insufficient resources to process the capsule.
+  @retval EFI_UNSUPPORTED       This call is not supported by this platform at the time the call is made.
+                                The platform should describe this runtime service as unsupported at runtime
+                                via an EFI_RT_PROPERTIES_TABLE configuration table.
 
 **/
 EFI_STATUS
@@ -520,6 +555,9 @@ EfiUpdateCapsule (
   @retval EFI_UNSUPPORTED       The capsule type is not supported on this platform, and
                                 MaximumCapsuleSize and ResetType are undefined.
   @retval EFI_OUT_OF_RESOURCES  There were insufficient resources to process the query request.
+  @retval EFI_UNSUPPORTED       This call is not supported by this platform at the time the call is made.
+                                The platform should describe this runtime service as unsupported at runtime
+                                via an EFI_RT_PROPERTIES_TABLE configuration table.
 
 **/
 EFI_STATUS

--- a/MdePkg/Include/Uefi/UefiSpec.h
+++ b/MdePkg/Include/Uefi/UefiSpec.h
@@ -320,6 +320,9 @@ EFI_STATUS
                                 map that requires a mapping.
   @retval EFI_NOT_FOUND         A virtual address was supplied for an address that is not found
                                 in the memory map.
+  @retval EFI_UNSUPPORTED       This call is not supported by this platform at the time the call is made.
+                                The platform should describe this runtime service as unsupported at runtime
+                                via an EFI_RT_PROPERTIES_TABLE configuration table.
 
 **/
 typedef
@@ -410,11 +413,14 @@ EFI_STATUS
                                      for the new virtual address mappings being applied.
 
   @retval EFI_SUCCESS           The pointer pointed to by Address was modified.
-  @retval EFI_INVALID_PARAMETER 1) Address is NULL.
-                                2) *Address is NULL and DebugDisposition does
-                                not have the EFI_OPTIONAL_PTR bit set.
   @retval EFI_NOT_FOUND         The pointer pointed to by Address was not found to be part
                                 of the current memory map. This is normally fatal.
+  @retval EFI_INVALID_PARAMETER Address is NULL.
+  @retval EFI_INVALID_PARAMETER *Address is NULL and DebugDisposition does
+                                not have the EFI_OPTIONAL_PTR bit set.
+  @retval EFI_UNSUPPORTED       This call is not supported by this platform at the time the call is made.
+                                The platform should describe this runtime service as unsupported at runtime
+                                via an EFI_RT_PROPERTIES_TABLE configuration table.
 
 **/
 typedef
@@ -679,6 +685,10 @@ VOID
   @retval EFI_INVALID_PARAMETER  The DataSize is not too small and Data is NULL.
   @retval EFI_DEVICE_ERROR       The variable could not be retrieved due to a hardware error.
   @retval EFI_SECURITY_VIOLATION The variable could not be retrieved due to an authentication failure.
+  @retval EFI_UNSUPPORTED        After ExitBootServices() has been called, this return code may be returned
+                                 if no variable storage is supported. The platform should describe this
+                                 runtime service as unsupported at runtime via an EFI_RT_PROPERTIES_TABLE
+                                 configuration table.
 
 **/
 typedef
@@ -715,6 +725,10 @@ EFI_STATUS
   @retval EFI_INVALID_PARAMETER Null-terminator is not found in the first VariableNameSize bytes of
                                 the input VariableName buffer.
   @retval EFI_DEVICE_ERROR      The variable could not be retrieved due to a hardware error.
+  @retval EFI_UNSUPPORTED       After ExitBootServices() has been called, this return code may be returned
+                                if no variable storage is supported. The platform should describe this
+                                runtime service as unsupported at runtime via an EFI_RT_PROPERTIES_TABLE
+                                configuration table.
 
 **/
 typedef
@@ -757,6 +771,9 @@ EFI_STATUS
                                  but the AuthInfo does NOT pass the validation check carried out by the firmware.
 
   @retval EFI_NOT_FOUND          The variable trying to be updated or deleted was not found.
+  @retval EFI_UNSUPPORTED        This call is not supported by this platform at the time the call is made.
+                                 The platform should describe this runtime service as unsupported at runtime
+                                 via an EFI_RT_PROPERTIES_TABLE configuration table.
 
 **/
 typedef
@@ -809,6 +826,9 @@ typedef struct {
   @retval EFI_SUCCESS           The operation completed successfully.
   @retval EFI_INVALID_PARAMETER Time is NULL.
   @retval EFI_DEVICE_ERROR      The time could not be retrieved due to hardware error.
+  @retval EFI_UNSUPPORTED       This call is not supported by this platform at the time the call is made.
+                                The platform should describe this runtime service as unsupported at runtime
+                                via an EFI_RT_PROPERTIES_TABLE configuration table.
 
 **/
 typedef
@@ -826,6 +846,9 @@ EFI_STATUS
   @retval EFI_SUCCESS           The operation completed successfully.
   @retval EFI_INVALID_PARAMETER A time field is out of range.
   @retval EFI_DEVICE_ERROR      The time could not be set due due to hardware error.
+  @retval EFI_UNSUPPORTED       This call is not supported by this platform at the time the call is made.
+                                The platform should describe this runtime service as unsupported at runtime
+                                via an EFI_RT_PROPERTIES_TABLE configuration table.
 
 **/
 typedef
@@ -846,7 +869,9 @@ EFI_STATUS
   @retval EFI_INVALID_PARAMETER Pending is NULL.
   @retval EFI_INVALID_PARAMETER Time is NULL.
   @retval EFI_DEVICE_ERROR      The wakeup time could not be retrieved due to a hardware error.
-  @retval EFI_UNSUPPORTED       A wakeup timer is not supported on this platform.
+  @retval EFI_UNSUPPORTED       This call is not supported by this platform at the time the call is made.
+                                The platform should describe this runtime service as unsupported at runtime
+                                via an EFI_RT_PROPERTIES_TABLE configuration table.
 
 **/
 typedef
@@ -868,7 +893,9 @@ EFI_STATUS
                                 Enable is FALSE, then the wakeup alarm was disabled.
   @retval EFI_INVALID_PARAMETER A time field is out of range.
   @retval EFI_DEVICE_ERROR      The wakeup time could not be set due to a hardware error.
-  @retval EFI_UNSUPPORTED       A wakeup timer is not supported on this platform.
+  @retval EFI_UNSUPPORTED       This call is not supported by this platform at the time the call is made.
+                                The platform should describe this runtime service as unsupported at runtime
+                                via an EFI_RT_PROPERTIES_TABLE configuration table.
 
 **/
 typedef
@@ -1090,6 +1117,9 @@ EFI_STATUS
   @retval EFI_SUCCESS           The next high monotonic count was returned.
   @retval EFI_INVALID_PARAMETER HighCount is NULL.
   @retval EFI_DEVICE_ERROR      The device is not functioning properly.
+  @retval EFI_UNSUPPORTED       This call is not supported by this platform at the time the call is made.
+                                The platform should describe this runtime service as unsupported at runtime
+                                via an EFI_RT_PROPERTIES_TABLE configuration table.
 
 **/
 typedef
@@ -1716,6 +1746,9 @@ typedef struct {
                                 in runtime. The caller may resubmit the capsule prior to ExitBootServices().
   @retval EFI_OUT_OF_RESOURCES  When ExitBootServices() has not been previously called then this error indicates
                                 the capsule is compatible with this platform but there are insufficient resources to process.
+  @retval EFI_UNSUPPORTED       This call is not supported by this platform at the time the call is made.
+                                The platform should describe this runtime service as unsupported at runtime
+                                via an EFI_RT_PROPERTIES_TABLE configuration table.
 
 **/
 typedef
@@ -1747,6 +1780,9 @@ EFI_STATUS
                                 in runtime. The caller may resubmit the capsule prior to ExitBootServices().
   @retval EFI_OUT_OF_RESOURCES  When ExitBootServices() has not been previously called then this error indicates
                                 the capsule is compatible with this platform but there are insufficient resources to process.
+  @retval EFI_UNSUPPORTED       This call is not supported by this platform at the time the call is made.
+                                The platform should describe this runtime service as unsupported at runtime
+                                via an EFI_RT_PROPERTIES_TABLE configuration table.
 
 **/
 typedef

--- a/MdePkg/Library/UefiRuntimeLib/RuntimeLib.c
+++ b/MdePkg/Library/UefiRuntimeLib/RuntimeLib.c
@@ -252,6 +252,9 @@ EfiResetSystem (
   @retval  EFI_SUCCESS            The operation completed successfully.
   @retval  EFI_INVALID_PARAMETER  Time is NULL.
   @retval  EFI_DEVICE_ERROR       The time could not be retrieved due to a hardware error.
+  @retval  EFI_UNSUPPORTED        This call is not supported by this platform at the time the call is made.
+                                  The platform should describe this runtime service as unsupported at runtime
+                                  via an EFI_RT_PROPERTIES_TABLE configuration table.
 
 **/
 EFI_STATUS
@@ -284,6 +287,9 @@ EfiGetTime (
   @retval  EFI_SUCCESS            The operation completed successfully.
   @retval  EFI_INVALID_PARAMETER  A time field is out of range.
   @retval  EFI_DEVICE_ERROR       The time could not be set due to a hardware error.
+  @retval  EFI_UNSUPPORTED        This call is not supported by this platform at the time the call is made.
+                                  The platform should describe this runtime service as unsupported at runtime
+                                  via an EFI_RT_PROPERTIES_TABLE configuration table.
 
 **/
 EFI_STATUS
@@ -313,7 +319,9 @@ EfiSetTime (
   @retval  EFI_INVALID_PARAMETER  Pending is NULL.
   @retval  EFI_INVALID_PARAMETER  Time is NULL.
   @retval  EFI_DEVICE_ERROR       The wakeup time could not be retrieved due to a hardware error.
-  @retval  EFI_UNSUPPORTED        A wakeup timer is not supported on this platform.
+  @retval  EFI_UNSUPPORTED        This call is not supported by this platform at the time the call is made.
+                                  The platform should describe this runtime service as unsupported at runtime
+                                  via an EFI_RT_PROPERTIES_TABLE configuration table.
 
 **/
 EFI_STATUS
@@ -346,7 +354,9 @@ EfiGetWakeupTime (
                                   If Enable is FALSE, then the wakeup alarm was disabled.
   @retval  EFI_INVALID_PARAMETER  A time field is out of range.
   @retval  EFI_DEVICE_ERROR       The wakeup time could not be set due to a hardware error.
-  @retval  EFI_UNSUPPORTED        A wakeup timer is not supported on this platform.
+  @retval  EFI_UNSUPPORTED        This call is not supported by this platform at the time the call is made.
+                                  The platform should describe this runtime service as unsupported at runtime
+                                  via an EFI_RT_PROPERTIES_TABLE configuration table.
 
 **/
 EFI_STATUS
@@ -388,6 +398,10 @@ EfiSetWakeupTime (
   @retval  EFI_INVALID_PARAMETER  The DataSize is not too small and Data is NULL.
   @retval  EFI_DEVICE_ERROR       The variable could not be retrieved due to a hardware error.
   @retval  EFI_SECURITY_VIOLATION The variable could not be retrieved due to an authentication failure.
+  @retval  EFI_UNSUPPORTED        After ExitBootServices() has been called, this return code may be returned
+                                  if no variable storage is supported. The platform should describe this
+                                  runtime service as unsupported at runtime via an EFI_RT_PROPERTIES_TABLE
+                                  configuration table.
 **/
 EFI_STATUS
 EFIAPI
@@ -430,6 +444,10 @@ EfiGetVariable (
   @retval  EFI_INVALID_PARAMETER VariableName is NULL.
   @retval  EFI_INVALID_PARAMETER VendorGuid is NULL.
   @retval  EFI_DEVICE_ERROR      The variable name could not be retrieved due to a hardware error.
+  @retval  EFI_UNSUPPORTED       After ExitBootServices() has been called, this return code may be returned
+                                 if no variable storage is supported. The platform should describe this
+                                 runtime service as unsupported at runtime via an EFI_RT_PROPERTIES_TABLE
+                                 configuration table.
 
 **/
 EFI_STATUS
@@ -470,6 +488,9 @@ EfiGetNextVariableName (
                                   set but the AuthInfo does NOT pass the validation check carried
                                   out by the firmware.
   @retval  EFI_NOT_FOUND          The variable trying to be updated or deleted was not found.
+  @retval  EFI_UNSUPPORTED        This call is not supported by this platform at the time the call is made.
+                                  The platform should describe this runtime service as unsupported at runtime
+                                  via an EFI_RT_PROPERTIES_TABLE configuration table.
 
 **/
 EFI_STATUS
@@ -499,6 +520,9 @@ EfiSetVariable (
   @retval  EFI_SUCCESS           The next high monotonic count was returned.
   @retval  EFI_DEVICE_ERROR      The device is not functioning properly.
   @retval  EFI_INVALID_PARAMETER HighCount is NULL.
+  @retval  EFI_UNSUPPORTED       This call is not supported by this platform at the time the call is made.
+                                 The platform should describe this runtime service as unsupported at runtime
+                                 via an EFI_RT_PROPERTIES_TABLE configuration table.
 
 **/
 EFI_STATUS
@@ -525,7 +549,11 @@ EfiGetNextHighMonotonicCount (
   @retval  EFI_NOT_FOUND          The pointer pointed to by Address was not found to be part of
                                   the current memory map. This is normally fatal.
   @retval  EFI_INVALID_PARAMETER  Address is NULL.
-  @retval  EFI_INVALID_PARAMETER  *Address is NULL and DebugDispositio
+  @retval  EFI_INVALID_PARAMETER  *Address is NULL and DebugDisposition does
+                                  not have the EFI_OPTIONAL_PTR bit set.
+  @retval  EFI_UNSUPPORTED        This call is not supported by this platform at the time the call is made.
+                                  The platform should describe this runtime service as unsupported at runtime
+                                  via an EFI_RT_PROPERTIES_TABLE configuration table.
 
 **/
 EFI_STATUS
@@ -649,6 +677,9 @@ EfiConvertList (
                                 map that requires a mapping.
   @retval EFI_NOT_FOUND         A virtual address was supplied for an address that is not found
                                 in the memory map.
+  @retval EFI_UNSUPPORTED       This call is not supported by this platform at the time the call is made.
+                                The platform should describe this runtime service as unsupported at runtime
+                                via an EFI_RT_PROPERTIES_TABLE configuration table.
 **/
 EFI_STATUS
 EFIAPI
@@ -699,6 +730,9 @@ EfiSetVirtualAddressMap (
   @retval EFI_DEVICE_ERROR      The capsule update was started, but failed due to a device error.
   @retval EFI_UNSUPPORTED       The capsule type is not supported on this platform.
   @retval EFI_OUT_OF_RESOURCES  There were insufficient resources to process the capsule.
+  @retval EFI_UNSUPPORTED       This call is not supported by this platform at the time the call is made.
+                                The platform should describe this runtime service as unsupported at runtime
+                                via an EFI_RT_PROPERTIES_TABLE configuration table.
 
 **/
 EFI_STATUS
@@ -748,6 +782,9 @@ EfiUpdateCapsule (
   @retval EFI_UNSUPPORTED       The capsule type is not supported on this platform, and
                                 MaximumCapsuleSize and ResetType are undefined.
   @retval EFI_OUT_OF_RESOURCES  There were insufficient resources to process the query request.
+  @retval EFI_UNSUPPORTED       This call is not supported by this platform at the time the call is made.
+                                The platform should describe this runtime service as unsupported at runtime
+                                via an EFI_RT_PROPERTIES_TABLE configuration table.
 
 **/
 EFI_STATUS

--- a/OvmfPkg/Library/XenRealTimeClockLib/XenRealTimeClockLib.c
+++ b/OvmfPkg/Library/XenRealTimeClockLib/XenRealTimeClockLib.c
@@ -80,6 +80,9 @@ EpochToEfiTime (
   @retval EFI_SUCCESS           The operation completed successfully.
   @retval EFI_INVALID_PARAMETER Time is NULL.
   @retval EFI_DEVICE_ERROR      The time could not be retrieved due to hardware error.
+  @retval EFI_UNSUPPORTED       This call is not supported by this platform at the time the call is made.
+                                The platform should describe this runtime service as unsupported at runtime
+                                via an EFI_RT_PROPERTIES_TABLE configuration table.
 
 **/
 EFI_STATUS
@@ -109,6 +112,9 @@ LibGetTime (
   @retval EFI_SUCCESS           The operation completed successfully.
   @retval EFI_INVALID_PARAMETER A time field is out of range.
   @retval EFI_DEVICE_ERROR      The time could not be set due to hardware error.
+  @retval EFI_UNSUPPORTED       This call is not supported by this platform at the time the call is made.
+                                The platform should describe this runtime service as unsupported at runtime
+                                via an EFI_RT_PROPERTIES_TABLE configuration table.
 
 **/
 EFI_STATUS
@@ -128,9 +134,13 @@ LibSetTime (
   @param  Time                  The current alarm setting.
 
   @retval EFI_SUCCESS           The alarm settings were returned.
-  @retval EFI_INVALID_PARAMETER Any parameter is NULL.
+  @retval EFI_INVALID_PARAMETER Enabled is NULL.
+  @retval EFI_INVALID_PARAMETER Pending is NULL.
+  @retval EFI_INVALID_PARAMETER Time is NULL.
   @retval EFI_DEVICE_ERROR      The wakeup time could not be retrieved due to a hardware error.
-  @retval EFI_UNSUPPORTED       A wakeup timer is not supported on this platform.
+  @retval EFI_UNSUPPORTED       This call is not supported by this platform at the time the call is made.
+                                The platform should describe this runtime service as unsupported at runtime
+                                via an EFI_RT_PROPERTIES_TABLE configuration table.
 
 **/
 EFI_STATUS
@@ -152,9 +162,13 @@ LibGetWakeupTime (
 
   @retval EFI_SUCCESS           If Enable is TRUE, then the wakeup alarm was enabled. If
                                 Enable is FALSE, then the wakeup alarm was disabled.
-  @retval EFI_INVALID_PARAMETER A time field is out of range.
+  @retval EFI_INVALID_PARAMETER Enabled is NULL.
+  @retval EFI_INVALID_PARAMETER Pending is NULL.
+  @retval EFI_INVALID_PARAMETER Time is NULL.
   @retval EFI_DEVICE_ERROR      The wakeup time could not be set due to a hardware error.
-  @retval EFI_UNSUPPORTED       A wakeup timer is not supported on this platform.
+  @retval EFI_UNSUPPORTED       This call is not supported by this platform at the time the call is made.
+                                The platform should describe this runtime service as unsupported at runtime
+                                via an EFI_RT_PROPERTIES_TABLE configuration table.
 
 **/
 EFI_STATUS


### PR DESCRIPTION
According to UEFI Spec 2.10 page 206, if any EFI_RUNTIME_SERVICES* calls
are not supported for use by the OS at runtime, an EFI_RT_PROPERTIES_TABLE
configuration table should be published describing which runtime services
are supported at runtime. So need to add EFI_UNSUPPORTED return for some
Runtime Service functions.

REF: UEFI spec 2.10 section 8 Services — Runtime Services

V2:
Update some Runtime Service functions header return
on both C and H header files.

V1:
Add EFI_UNSUPPORTED return for some Runtime Service
functions on UefiSpec.h file.

Signed-off-by: Suqiang Ren <[suqiangx.ren@intel.com](mailto:suqiangx.ren@intel.com)>
Cc: Michael D Kinney <[michael.d.kinney@intel.com](mailto:michael.d.kinney@intel.com)>
Cc: Liming Gao <[gaoliming@byosoft.com.cn](mailto:gaoliming@byosoft.com.cn)>
Cc: Zhiguang Liu <[zhiguang.liu@intel.com](mailto:zhiguang.liu@intel.com)>
Cc: Leif Lindholm <[quic_llindhol@quicinc.com](mailto:quic_llindhol@quicinc.com)>
Cc: Ard Biesheuvel <[ardb+tianocore@kernel.org](mailto:ardb+tianocore@kernel.org)>
Cc: Abner Chang <[abner.chang@amd.com](mailto:abner.chang@amd.com)>
Cc: Jiewen Yao <[jiewen.yao@intel.com](mailto:jiewen.yao@intel.com)>
Cc: Laszlo Ersek <[lersek@redhat.com](mailto:lersek@redhat.com)>