### PR TITLE
ovmf scalability fixes

### DIFF
--- a/OvmfPkg/PlatformPei/MemDetect.c
+++ b/OvmfPkg/PlatformPei/MemDetect.c
@@ -263,6 +263,30 @@ GetPeiMemoryCap (
   //
   MemoryCap = EFI_PAGES_TO_SIZE ((UINTN)TotalPages) + ApStacks + SIZE_64MB;
 
+  DEBUG ((
+    DEBUG_INFO,
+    "%a: page tables: %6lu KB (%u/%u/%u/%u pages for levels 5/4/3/2)\n",
+    __func__,
+    RShiftU64 (EFI_PAGES_TO_SIZE ((UINTN)TotalPages), 10),
+    Level5Pages,
+    Level4Pages,
+    Level3Pages,
+    Level2Pages
+    ));
+  DEBUG ((
+    DEBUG_INFO,
+    "%a: ap stacks:   %6lu KB (%u cpus)\n",
+    __func__,
+    RShiftU64 (ApStacks, 10),
+    PlatformInfoHob->PcdCpuMaxLogicalProcessorNumber
+    ));
+  DEBUG ((
+    DEBUG_INFO,
+    "%a: memory cap:  %6lu KB\n",
+    __func__,
+    RShiftU64 (MemoryCap, 10)
+    ));
+
   ASSERT (MemoryCap <= MAX_UINT32);
   return (UINT32)MemoryCap;
 }

--- a/OvmfPkg/PlatformPei/MemDetect.c
+++ b/OvmfPkg/PlatformPei/MemDetect.c
@@ -319,6 +319,14 @@ PublishPeiMemory (
     if (MemorySize > PeiMemoryCap) {
       MemoryBase = LowerMemorySize - PeiMemoryCap;
       MemorySize = PeiMemoryCap;
+    } else {
+      DEBUG ((
+        DEBUG_WARN,
+        "%a: Not enough memory for PEI (have %lu KB, estimated need %u KB)\n",
+        __func__,
+        RShiftU64 (MemorySize, 10),
+        PeiMemoryCap >> 10
+        ));
     }
   }
 


### PR DESCRIPTION
- OvmfPkg/PlatformPei: consider AP stacks for pei memory cap
- OvmfPkg/PlatformPei: rewrite page table calculation
- OvmfPkg/PlatformPei: log pei memory cap details
