### PR TITLE
Update Support for LoongArch

### DIFF
--- a/MdeModulePkg/Core/Dxe/Image/Image.c
+++ b/MdeModulePkg/Core/Dxe/Image/Image.c
@@ -77,12 +77,13 @@ typedef struct {
 } MACHINE_TYPE_INFO;
 
 GLOBAL_REMOVE_IF_UNREFERENCED MACHINE_TYPE_INFO  mMachineTypeInfo[] = {
-  { EFI_IMAGE_MACHINE_IA32,           L"IA32"    },
-  { EFI_IMAGE_MACHINE_IA64,           L"IA64"    },
-  { EFI_IMAGE_MACHINE_X64,            L"X64"     },
-  { EFI_IMAGE_MACHINE_ARMTHUMB_MIXED, L"ARM"     },
-  { EFI_IMAGE_MACHINE_AARCH64,        L"AARCH64" },
-  { EFI_IMAGE_MACHINE_RISCV64,        L"RISCV64" },
+  { EFI_IMAGE_MACHINE_IA32,           L"IA32"        },
+  { EFI_IMAGE_MACHINE_IA64,           L"IA64"        },
+  { EFI_IMAGE_MACHINE_X64,            L"X64"         },
+  { EFI_IMAGE_MACHINE_ARMTHUMB_MIXED, L"ARM"         },
+  { EFI_IMAGE_MACHINE_AARCH64,        L"AARCH64"     },
+  { EFI_IMAGE_MACHINE_RISCV64,        L"RISCV64"     },
+  { EFI_IMAGE_MACHINE_LOONGARCH64,    L"LOONGARCH64" },
 };
 
 UINT16  mDxeCoreImageMachineType = 0;

--- a/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/PrintInfo.c
+++ b/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/PrintInfo.c
@@ -2610,6 +2610,74 @@ DisplayProcessorFamily2 (
       Print (L"RISC-V RV128\n");
       break;
 
+    case 0x258:
+      Print (L"LoongArch\n");
+      break;
+
+    case 0x259:
+      Print (L"Loongson1\n");
+      break;
+
+    case 0x25A:
+      Print (L"Loongson2\n");
+      break;
+
+    case 0x25B:
+      Print (L"Loongson3\n");
+      break;
+
+    case 0x25C:
+      Print (L"Loongson2K\n");
+      break;
+
+    case 0x25D:
+      Print (L"Loongson3A\n");
+      break;
+
+    case 0x25E:
+      Print (L"Loongson3B\n");
+      break;
+
+    case 0x25F:
+      Print (L"Loongson3C\n");
+      break;
+
+    case 0x260:
+      Print (L"Loongson3D\n");
+      break;
+
+    case 0x261:
+      Print (L"Loongson3E\n");
+      break;
+
+    case 0x262:
+      Print (L"DualCoreLoongson2K\n");
+      break;
+
+    case 0x26C:
+      Print (L"QuadCoreLoongson3A\n");
+      break;
+
+    case 0x26D:
+      Print (L"MultiCoreLoongson3A\n");
+      break;
+
+    case 0x26E:
+      Print (L"QuadCoreLoongson3B\n");
+      break;
+
+    case 0x26F:
+      Print (L"MultiCoreLoongson3B\n");
+      break;
+
+    case 0x270:
+      Print (L"MultiCoreLoongson3C\n");
+      break;
+
+    case 0x271:
+      Print (L"MultiCoreLoongson3D\n");
+      break;
+
     default:
       ShellPrintHiiEx (-1, -1, NULL, STRING_TOKEN (STR_SMBIOSVIEW_PRINTINFO_UNDEFINED_PROC_FAMILY), gShellDebug1HiiHandle);
   }

--- a/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/QueryTable.c
+++ b/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/QueryTable.c
@@ -3652,6 +3652,14 @@ TABLE_ITEM  ProcessorArchitectureTypesTable[] = {
   {
     8,
     L" 128-bit RISC-V (RV128) "
+  },
+  {
+    9,
+    L" 32-bit LoongArch (LoongArch32) "
+  },
+  {
+    10,
+    L" 64-bit LoongArch (LoongArch64) "
   }
 };
 


### PR DESCRIPTION
[PATCH 1/2] MdeModulePkg: Dxe: add LOONGARCH64 to mMachineTypeInfo
This fixes messages like:
"Image type X64 can't be loaded on <Unknown> UEFI system"
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Chao Li <lichao@loongson.cn>
Signed-off-by: Dongyan Qian <qiandongyan@loongson.cn>
Reviewed-by: Chao Li <lichao@loongson.cn>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>

[PATCH 2/2] ShellPkg: Update smbiosview for LoongArch
According to SMBIOS spec3.6, LoongArch information support has been added,
so this patch is submitted for display as information in smbiosview.
Cc: Zhichao Gao <zhichao.gao@intel.com>
Cc: Chao Li <lichao@loongson.cn>
Signed-off-by: Dongyan Qian <qiandongyan@loongson.cn>
Reviewed-by: Chao Li <lichao@loongson.cn>
Reviewed-by: Zhichao Gao <zhichao.gao@intel.com>
