### PR TITLE
Kexec

### DIFF
--- a/MdePkg/Include/IndustryStandard/Acpi64.h
+++ b/MdePkg/Include/IndustryStandard/Acpi64.h
@@ -609,6 +609,7 @@ typedef struct {
   UINT16    MailBoxVersion;
   UINT32    Reserved;
   UINT64    MailBoxAddress;
+  UINT64    ResetVector;
 } EFI_ACPI_6_4_MULTIPROCESSOR_WAKEUP_STRUCTURE;
 
 ///

--- a/OvmfPkg/Include/IndustryStandard/IntelTdx.h
+++ b/OvmfPkg/Include/IndustryStandard/IntelTdx.h
@@ -20,8 +20,9 @@
 typedef enum {
   MpProtectedModeWakeupCommandNoop        = 0,
   MpProtectedModeWakeupCommandWakeup      = 1,
-  MpProtectedModeWakeupCommandSleep       = 2,
-  MpProtectedModeWakeupCommandAcceptPages = 3,
+  MpProtectedModeWakeupCommandTest        = 2,
+  MpProtectedModeWakeupCommandSleep       = 3,
+  MpProtectedModeWakeupCommandAcceptPages = 4,
 } MP_CPU_PROTECTED_MODE_WAKEUP_CMD;
 
 #pragma pack(1)

--- a/OvmfPkg/Include/IndustryStandard/IntelTdx.h
+++ b/OvmfPkg/Include/IndustryStandard/IntelTdx.h
@@ -61,6 +61,7 @@ typedef struct {
 typedef struct {
   UINT8    *RelocateApLoopFuncAddress;
   UINTN    RelocateApLoopFuncSize;
+  UINT8    *RelocateApResetVector;
 } MP_RELOCATION_MAP;
 
 #pragma pack()

--- a/OvmfPkg/Include/TdxCommondefs.inc
+++ b/OvmfPkg/Include/TdxCommondefs.inc
@@ -41,8 +41,9 @@ ERROR_INVALID_FALLBACK_PAGE_LEVEL         equ       3
 
 MpProtectedModeWakeupCommandNoop          equ       0
 MpProtectedModeWakeupCommandWakeup        equ       1
-MpProtectedModeWakeupCommandSleep         equ       2
-MpProtectedModeWakeupCommandAcceptPages   equ       3
+MpProtectedModeWakeupCommandTest          equ       2
+MpProtectedModeWakeupCommandSleep         equ       3
+MpProtectedModeWakeupCommandAcceptPages   equ       4
 
 MailboxApicIdInvalid                      equ       0xffffffff
 MailboxApicidBroadcast                    equ       0xfffffffe

--- a/OvmfPkg/Include/WorkArea.h
+++ b/OvmfPkg/Include/WorkArea.h
@@ -12,7 +12,7 @@
 
 #include <ConfidentialComputingGuestAttr.h>
 #include <IndustryStandard/Tpm20.h>
-
+#include <Library/BaseLib.h>
 //
 // Confidential computing work area header definition. Any change
 // to the structure need to be kept in sync with the
@@ -78,6 +78,38 @@ typedef struct _TDX_MEASUREMENTS_DATA {
   UINT8     CfvImgHashValue[SHA384_DIGEST_SIZE];
 } TDX_MEASUREMENTS_DATA;
 
+#pragma pack (1)
+typedef struct {
+  UINT16    Limit;
+  UINTN     Base;
+} IA32_GDTR;
+
+typedef union {
+  struct {
+    UINT32    LimitLow    : 16;
+    UINT32    BaseLow     : 16;
+    UINT32    BaseMid     : 8;
+    UINT32    Type        : 4;
+    UINT32    System      : 1;
+    UINT32    Dpl         : 2;
+    UINT32    Present     : 1;
+    UINT32    LimitHigh   : 4;
+    UINT32    Software    : 1;
+    UINT32    Reserved    : 1;
+    UINT32    DefaultSize : 1;
+    UINT32    Granularity : 1;
+    UINT32    BaseHigh    : 8;
+  } Bits;
+  UINT64    Uint64;
+} IA32_GDT;
+#pragma pack()
+
+#define MAILBOX_GDT_SIZE  (sizeof(IA32_GDT) * 5)
+
+typedef struct _MAILBOX_GDT {
+  IA32_GDTR    Gdtr;
+  UINT8        Data[MAILBOX_GDT_SIZE];
+} MAILBOX_GDT;
 //
 // The TDX work area definition
 //
@@ -91,6 +123,7 @@ typedef struct _SEC_TDX_WORK_AREA {
 typedef struct _TDX_WORK_AREA {
   CONFIDENTIAL_COMPUTING_WORK_AREA_HEADER    Header;
   SEC_TDX_WORK_AREA                          SecTdxWorkArea;
+  MAILBOX_GDT                                MailboxGdt;
 } TDX_WORK_AREA;
 
 //

--- a/OvmfPkg/TdxDxe/TdxAcpiTable.c
+++ b/OvmfPkg/TdxDxe/TdxAcpiTable.c
@@ -74,12 +74,14 @@ SetMailboxResetVectorGDT (
   memory block which is allocated in the ACPI Nvs memory. APs are waken up and
   spin around the relocated mailbox for further command.
 
+  @param[in, out]  ResetVector      Pointer to the ResetVector
+
   @return   EFI_PHYSICAL_ADDRESS    Address of the relocated mailbox
 **/
 EFI_PHYSICAL_ADDRESS
 EFIAPI
 RelocateMailbox (
-  VOID
+  EFI_PHYSICAL_ADDRESS  *ResetVector
   )
 {
   EFI_PHYSICAL_ADDRESS  Address;
@@ -153,6 +155,12 @@ RelocateMailbox (
     0
     );
 
+  *ResetVector = (UINT64)ApLoopFunc + (RelocationMap.RelocateApResetVector - RelocationMap.RelocateApLoopFuncAddress);
+  DEBUG ((
+    DEBUG_INFO,
+    "Ap Relocation: reset_vector %llx\n",
+    *ResetVector
+    ));
   return Address;
 }
 
@@ -180,6 +188,7 @@ AlterAcpiTable (
   UINT8                                                *NewMadtTable;
   UINTN                                                NewMadtTableLength;
   EFI_PHYSICAL_ADDRESS                                 RelocateMailboxAddress;
+  EFI_PHYSICAL_ADDRESS                                 RelocateResetVector;
   EFI_ACPI_6_4_MULTIPROCESSOR_WAKEUP_STRUCTURE         *MadtMpWk;
   EFI_ACPI_1_0_MULTIPLE_APIC_DESCRIPTION_TABLE_HEADER  *MadtHeader;
 
@@ -193,7 +202,7 @@ AlterAcpiTable (
     return;
   }
 
-  RelocateMailboxAddress = RelocateMailbox ();
+  RelocateMailboxAddress = RelocateMailbox (&RelocateResetVector);
   if (RelocateMailboxAddress == 0) {
     ASSERT (FALSE);
     DEBUG ((DEBUG_ERROR, "Failed to relocate Td mailbox\n"));
@@ -224,9 +233,10 @@ AlterAcpiTable (
       MadtMpWk                 = (EFI_ACPI_6_4_MULTIPROCESSOR_WAKEUP_STRUCTURE *)(NewMadtTable + Table->Length);
       MadtMpWk->Type           = EFI_ACPI_6_4_MULTIPROCESSOR_WAKEUP;
       MadtMpWk->Length         = sizeof (EFI_ACPI_6_4_MULTIPROCESSOR_WAKEUP_STRUCTURE);
-      MadtMpWk->MailBoxVersion = 0;
+      MadtMpWk->MailBoxVersion = 1;
       MadtMpWk->Reserved       = 0;
       MadtMpWk->MailBoxAddress = RelocateMailboxAddress;
+      MadtMpWk->ResetVector    = RelocateResetVector;
 
       Status = AcpiTableProtocol->InstallAcpiTable (AcpiTableProtocol, NewMadtTable, NewMadtTableLength, &NewTableKey);
       if (EFI_ERROR (Status)) {

--- a/OvmfPkg/TdxDxe/TdxAcpiTable.h
+++ b/OvmfPkg/TdxDxe/TdxAcpiTable.h
@@ -37,12 +37,14 @@ AsmGetRelocationMap (
   memory block which is allocated in the ACPI Nvs memory. APs are waken up and
   spin around the relocated mailbox for further command.
 
+  @param[in, out]  ResetVector      Pointer to the ResetVector
+
   @return   EFI_PHYSICAL_ADDRESS    Address of the relocated mailbox
 **/
 EFI_PHYSICAL_ADDRESS
 EFIAPI
 RelocateMailbox (
-  VOID
+  EFI_PHYSICAL_ADDRESS  *ResetVector
   );
 
 /**

--- a/OvmfPkg/TdxDxe/TdxAcpiTable.h
+++ b/OvmfPkg/TdxDxe/TdxAcpiTable.h
@@ -20,6 +20,7 @@
 #include <Library/PcdLib.h>
 #include <IndustryStandard/IntelTdx.h>
 #include <IndustryStandard/Acpi.h>
+#include <WorkArea.h>
 
 VOID
 EFIAPI

--- a/OvmfPkg/TdxDxe/TdxDxe.inf
+++ b/OvmfPkg/TdxDxe/TdxDxe.inf
@@ -71,3 +71,7 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdSetNxForStack
   gEfiMdeModulePkgTokenSpaceGuid.PcdEmuVariableNvStoreReserved
   gUefiOvmfPkgTokenSpaceGuid.PcdTdxAcceptPageSize
+  gUefiOvmfPkgTokenSpaceGuid.PcdOvmfWorkAreaBase
+  gUefiOvmfPkgTokenSpaceGuid.PcdOvmfWorkAreaSize
+  gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSecPageTablesBase
+  gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSecPageTablesSize

--- a/OvmfPkg/TdxDxe/X64/ApRunLoop.nasm
+++ b/OvmfPkg/TdxDxe/X64/ApRunLoop.nasm
@@ -62,6 +62,8 @@ MailBoxLoop:
 MailBoxProcessCommand:
     cmp        dword [rbx + CommandOffset], MpProtectedModeWakeupCommandWakeup
     je         MailBoxWakeUp
+    cmp        dword [rbx + CommandOffset], MpProtectedModeWakeupCommandTest
+    je         MailBoxTest
     cmp        dword [rbx + CommandOffset], MpProtectedModeWakeupCommandSleep
     je         MailBoxSleep
     ; Don't support this command, so ignore
@@ -72,6 +74,9 @@ MailBoxWakeUp:
     ; the command field back to zero as acknowledgement.
     mov        qword [rbx + CommandOffset], 0
     jmp        rax
+MailBoxTest:
+    mov        qword [rbx + CommandOffset], 0
+    jmp        MailBoxLoop
 MailBoxSleep:
     jmp       $
 Panic:

--- a/OvmfPkg/TdxDxe/X64/ApRunLoop.nasm
+++ b/OvmfPkg/TdxDxe/X64/ApRunLoop.nasm
@@ -16,7 +16,16 @@
 
 DEFAULT REL
 
+SECTION .bss
+global STACK_BASE
+STACK_BASE:
+ resb 1024
+STACK_TOP:
+
 SECTION .text
+
+%define TDX_WORK_AREA_MAILBOX_GDTR   (FixedPcdGet32 (PcdOvmfWorkAreaBase) + 128)
+%define PT_ADDR(Offset)              (FixedPcdGet32 (PcdOvmfSecPageTablesBase) + (Offset))
 
 BITS 64
 
@@ -49,6 +58,7 @@ AsmRelocateApMailBoxLoopStart:
     test        r10, r10
     jnz         Panic
     mov         r8, r15
+    mov         qword[rel mailbox_address], rbx
 
 MailBoxLoop:
     ; Spin until command set
@@ -81,6 +91,91 @@ MailBoxSleep:
     jmp       $
 Panic:
     ud2
+
+AsmRelocateApResetVector:
+
+.prepareStack:
+    ; The stack can then be used to switch from long mode to compatibility mode
+    mov rsp, STACK_TOP
+
+.loadGDT:
+    cli
+    mov      rax, TDX_WORK_AREA_MAILBOX_GDTR
+    lgdt     [rax]
+
+.loadSwicthModeCode:
+    mov     rcx, dword 0x10    ; load long mode selector
+    shl     rcx, 32
+    lea     rdx, [LongMode]    ; assume address < 4G
+    or      rcx, rdx
+    push    rcx
+
+    mov     rcx, dword 0x08     ; load compatible mode selector
+    shl     rcx, 32
+    lea     rdx, [Compatible]  ; assume address < 4G
+    or      rcx, rdx
+    push    rcx
+    retf
+
+BITS 32
+Compatible:
+    mov     eax, dword 0x18
+;     ; reload DS/ES/SS to make sure they are correct referred to current GDT
+    mov     ds, ax
+    mov     es, ax
+    mov     ss, ax
+    ; reload the fs and gs
+    mov     fs, ax
+    mov     gs, ax
+
+    ; Must clear the CR4.PCIDE before clearing paging
+    mov     ecx, cr4
+    btc     ecx, 17
+    mov     cr4, ecx
+    ;
+    ; Disable paging
+    ;
+    mov     ecx, cr0
+    btc     ecx, 31
+    mov     cr0, ecx
+    ;
+RestoreCr0:
+    ; Only enable  PE(bit 0), NE(bit 5), ET(bit 4) 0x31
+    mov    eax, dword 0x31
+    mov    cr0, eax
+
+
+    ; Only Enable MCE(bit 6), VMXE(bit 13) 0x2040
+    ; TDX enforeced the VMXE = 1 and mask it in VMM, so not set it.
+RestoreCr4:
+    mov     eax, 0x40
+    mov     cr4, eax
+SetCr3:
+    ;
+    ; Can use the boot page tables since it's reserved
+
+    mov     eax, PT_ADDR (0)
+    mov     cr3, eax
+
+EnablePAE:
+    mov     eax, cr4
+    bts     eax, 5
+    mov     cr4, eax
+
+EnablePaging:
+    mov     eax, cr0
+    bts     eax, 31                     ; set PG
+    mov     cr0, eax                    ; enable paging
+    ; return to LongMode
+    retf
+
+BITS  64
+LongMode:
+    mov      rbx, qword[rel mailbox_address]
+    jmp      AsmRelocateApMailBoxLoopStart
+align 16
+mailbox_address:
+    dq 0
 BITS 64
 AsmRelocateApMailBoxLoopEnd:
 
@@ -92,5 +187,6 @@ ASM_PFX(AsmGetRelocationMap):
     lea        rax, [AsmRelocateApMailBoxLoopStart]
     mov        qword [rcx], rax
     mov        qword [rcx +  8h], AsmRelocateApMailBoxLoopEnd - AsmRelocateApMailBoxLoopStart
+    lea        rax, [AsmRelocateApResetVector]
+    mov        qword [rcx + 10h], rax
     ret
-


### PR DESCRIPTION
As currently defined, ACPI MADT doesn't allow to offline a CPU 
after it was woken up. which is problematic in some use cases, like kexec.

For this reason, ACPI 6.6 add a ResetVector field to Multiprocessor 
Wakeup Structure in order to provide the OS with a physical address
of a Multiprocessor Wakeup Mailbox entry point for application
processors that need to use the mailbox again after having used
it once already.

Since TDVF does not support CPU hardware restart, it can not direct reset
the AP and make it to enable the mailbox again. TDVF needs to use 
CPU instructions to changed the CPU states refer to the SDM spec about 
X86_64 CPU,  it requires TDVF changes the control register and paging mode. 

According to the SDM Volume 3 for X86_64, changing the paging mode must
be preceded by switching the CPU mode, which requires the provision
of a GDT to control the CPU mode and should always be present at runtime. 

Therefore, TDVF should create a GDT to switching the paging mode and 
set control register to the value that can be reload the Mailbox for a given AP.

ACPI LINK: https://lore.kernel.org/all/13356251.uLZWGnKmhe@kreacher/

Tested-by: Kirill A. Shutemov <kirill.shutemov@linux.intel.com>
Signed-off-by: Ceping Sun <cepingx.sun@intel.com>
Signed-off-by: Kirill A. Shutemov <kirill.shutemov@linux.intel.com>