### PR TITLE
[CI Check]MdeModulePkg: DxeCore: Align Memory Requests When Allocating With Guard

### DIFF
--- a/MdeModulePkg/Core/Dxe/Mem/HeapGuard.h
+++ b/MdeModulePkg/Core/Dxe/Mem/HeapGuard.h
@@ -270,24 +270,41 @@ AdjustMemoryF (
   );
 
 /**
-  Adjust address of free memory according to existing and/or required Guard.
+  Adjust the start address of a proposed allocation to ensure that guard
+  pages fit within free space around the allocation.
 
-  This function will check if there're existing Guard pages of adjacent
+  This function will check if there are existing Guard pages of adjacent
   memory blocks, and try to use it as the Guard page of the memory to be
-  allocated.
+  allocated. It will respect the alignment guarantees of the allocation in
+  question and attempt to shift the allocation within the provided memory
+  descriptor if there is no tail guard to share.
 
-  @param[in]  Start           Start address of free memory block.
-  @param[in]  Size            Size of free memory block.
-  @param[in]  SizeRequested   Size of memory to allocate.
+  This function assumes that the free memory descriptors are merged to create
+  the largest possible contiguous free memory range. This is a behavior of the
+  page management code. This function also assumes that the page management code
+  has attempted an AllocationStart as close to the end of the memory descriptor
+  as possible, so that if a new tail guard is allocated we can shift the
+  allocation towards the start of the memory descriptor. However, if the
+  AllocationStart is at the beginning of the memory descriptor and we need to
+  allocate a new head guard, we will fail because we know there is not enough space
+  at the end of the descriptor.
 
-  @return The end address of memory block found.
-  @return 0 if no enough space for the required size of memory and its Guard.
+  @param[in]  AllocationStart           Start address of allocation to check if guards fit
+  @param[in]  AllocationSize            Size of memory requested in this allocation
+  @param[in]  DescriptorStart           Start address of the free memory descriptor
+  @param[in]  DescriptorSize            Size from DescriptorStart to end of the descriptor
+  @param[in]  Alignment                 Required alignment of the start of this allocation
+
+  @return The start address of this new allocation that will satisify alignment and guard requirements
+  @return 0 if there is not enough space for the required size of memory and the guards
 **/
 UINT64
 AdjustMemoryS (
-  IN UINT64  Start,
-  IN UINT64  Size,
-  IN UINT64  SizeRequested
+  IN UINT64  AllocationStart,
+  IN UINT64  AllocationSize,
+  IN UINT64  DescriptorStart,
+  IN UINT64  DescriptorSize,
+  IN UINT64  Alignment
   );
 
 /**


### PR DESCRIPTION
There are certain architectures, that have runtime memory alignment requirements that are not equal to EFI_PAGE_SIZE (which is what x86 requires). For example, AARCH64 requires a 64k runtime page granularity.

The FindFreePages and PageGuard functionality was not written with different alignments in mind. This code would seek to align the end of a free memory descriptor with the alignment guaranteed and it assumed that the number of pages allocated would cause the start of that descriptor to also match the alignment. This works when we only require page alignment, but not when we have different alignment requirements.

The page guard code manipulates the start of a free memory range to include new guard pages, if shared pages cannot be used. This also completely ignored alignment requirements, which again was fine when the alignment was the page size. However, on AARCH64, it would create a runtime memory allocation that was a page size off from 64k alignment. This would break on a system that actually had the requirement for 64k alignment (not all AARCH64 systems do, but we use that alignment at runtime to enable support for the systems that require it). It also breaks in the case where runtime memory was allocated with a guard and then freed during bootservices time (for example when a runtime buffer was reallocated to be larger) because the freeing code checks the alignment requirement and saw that the alignment was incorrect and would assert.

This patch fixes the assumption in CoreFindFreePagesI and AdjustMemoryS to take any alignment requirements into account. Importantly, this makes sure the start of the memory region to be allocated is aligned, not the end.

This was tested on Ovmf and ArmVirtQemu with combinations of Page and Pool guard enabled/disabled and on ArmVirtQemu allocating and freeing a runtime memory buffer with page guard enabled (which without this change asserts).

Cc: Leif Lindholm <quic_llindhol@quicinc.com>
Cc: Ard Biesheuvel <ardb+tianocore@kernel.org>
Cc: Sami Mujawar <sami.mujawar@arm.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>