### PR TITLE
StandaloneMmPkg/Core: Output status in MMI handler assertion

### DIFF
--- a/StandaloneMmPkg/Core/Mmi.c
+++ b/StandaloneMmPkg/Core/Mmi.c
@@ -208,7 +208,7 @@ MmiManage (
         //
         // Unexpected status code returned.
         //
-        ASSERT (FALSE);
+        ASSERT_EFI_ERROR (Status);
         break;
     }
   }


### PR DESCRIPTION
Currently, if a MMI handler returns an unexpected failure status code, ASSERT (FALSE) is used. It is more useful to use ASSERT_EFI_ERROR() which also outputs the status code value.


Reviewed-by: Laszlo Ersek <lersek@redhat.com>
Reviewed-by: Ray Ni <ray.ni@intel.com>