### PR TITLE
OvmfPkg/ResetVector: Fix SNP CPUID table processing results for ECX/EDX

### DIFF
--- a/OvmfPkg/ResetVector/Ia32/AmdSev.asm
+++ b/OvmfPkg/ResetVector/Ia32/AmdSev.asm
@@ -395,9 +395,9 @@ SnpCpuidEntryFound:
     mov     [esp + VC_CPUID_RESULT_EAX], eax
     mov     eax, [ecx + SNP_CPUID_ENTRY_EBX]
     mov     [esp + VC_CPUID_RESULT_EBX], eax
-    mov     eax, [ecx + SNP_CPUID_ENTRY_EDX]
-    mov     [esp + VC_CPUID_RESULT_ECX], eax
     mov     eax, [ecx + SNP_CPUID_ENTRY_ECX]
+    mov     [esp + VC_CPUID_RESULT_ECX], eax
+    mov     eax, [ecx + SNP_CPUID_ENTRY_EDX]
     mov     [esp + VC_CPUID_RESULT_EDX], eax
     jmp     VmmDoneSnpCpuid
 


### PR DESCRIPTION
The current support within the boot SNP CPUID table processing mistakenly swaps the ECX and EDX results. It does not have an effect at this time because current CPUID results checking does not check ECX or EDX. However, any future CPUID checks that need to check ECX or EDX may have erroneous behavior.

Fix the assembler code to save ECX and EDX to the proper locations.

Fixes: 34819f2caccb ("OvmfPkg/ResetVector: use SEV-SNP-validated CPUID values")

Reviewed-by: Michael Roth <michael.roth@amd.com>