### PR TITLE
Bug 4683 unit test unexpected exception may be seen as PASS condition

### DIFF
--- a/MdePkg/Include/Library/DebugLib.h
+++ b/MdePkg/Include/Library/DebugLib.h
@@ -375,9 +375,9 @@ UnitTestDebugAssert (
         DebugPrint (PrintLevel, ##__VA_ARGS__);      \
       }                                              \
     } while (FALSE)
-#define _DEBUG(Expression)  _DEBUG_PRINT Expression
+#define _DEBUGLIB_DEBUG(Expression)  _DEBUG_PRINT Expression
 #else
-#define _DEBUG(Expression)  DebugPrint Expression
+#define _DEBUGLIB_DEBUG(Expression)  DebugPrint Expression
 #endif
 
 /**
@@ -422,7 +422,7 @@ UnitTestDebugAssert (
 #define DEBUG(Expression)        \
     do {                           \
       if (DebugPrintEnabled ()) {  \
-        _DEBUG (Expression);       \
+        _DEBUGLIB_DEBUG (Expression);       \
       }                            \
     } while (FALSE)
 #else

--- a/UnitTestFrameworkPkg/Include/Library/GoogleTestLib.h
+++ b/UnitTestFrameworkPkg/Include/Library/GoogleTestLib.h
@@ -13,6 +13,26 @@
 #include <gmock/gmock.h>
 #include <cstring>
 
+using ::testing::Throws;
+using ::testing::ThrowsMessage;
+using ::testing::HasSubstr;
+
+//
+// Extended macros for testing exceptions with a specific description string
+// in the exception message.  Typically used to check that the expression
+// that generates an ASSERT() matches the expected expression.
+//
+#define EXPECT_THROW_MESSAGE(statement, description)            \
+  EXPECT_THAT (                                                 \
+    []() { statement; },                                        \
+    ThrowsMessage<std::runtime_error>(HasSubstr (description))  \
+    )
+#define ASSERT_THROW_MESSAGE(statement, description)            \
+  ASSERT_THAT (                                                 \
+    []() { statement; },                                        \
+    ThrowsMessage<std::runtime_error>(HasSubstr (description))  \
+    )
+
 extern "C" {
   #include <Uefi.h>
 }

--- a/UnitTestFrameworkPkg/Library/GoogleTestLib/GoogleTestLib.inf
+++ b/UnitTestFrameworkPkg/Library/GoogleTestLib/GoogleTestLib.inf
@@ -28,6 +28,6 @@
   UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
 
 [BuildOptions]
-  MSFT:*_*_*_CC_FLAGS   == /c /EHsc /Zi /Od
+  MSFT:*_*_*_CC_FLAGS   == /c /EHsc /Zi /Od /MT
   GCC:*_*_IA32_CC_FLAGS == -g -c -fshort-wchar -O0 -m32
   GCC:*_*_X64_CC_FLAGS  == -g -c -fshort-wchar -O0 -m64

--- a/UnitTestFrameworkPkg/Library/GoogleTestLib/GoogleTestLib.inf
+++ b/UnitTestFrameworkPkg/Library/GoogleTestLib/GoogleTestLib.inf
@@ -28,6 +28,6 @@
   UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
 
 [BuildOptions]
-  MSFT:*_*_*_CC_FLAGS   == /c /EHsc /Zi /Od /MT
-  GCC:*_*_IA32_CC_FLAGS == -g -c -fshort-wchar -O0 -m32
-  GCC:*_*_X64_CC_FLAGS  == -g -c -fshort-wchar -O0 -m64
+  MSFT:*_*_*_CC_FLAGS   == /c /EHs /Zi /Od /MT
+  GCC:*_*_IA32_CC_FLAGS == -g -c -fshort-wchar -fexceptions -O0 -m32 -malign-double -fno-pie
+  GCC:*_*_X64_CC_FLAGS  == -g -c -fshort-wchar -fexceptions -O0 -m64 -fno-pie "-DEFIAPI=__attribute__((ms_abi))"

--- a/UnitTestFrameworkPkg/Library/UnitTestDebugAssertLib/UnitTestDebugAssertLibHost.cpp
+++ b/UnitTestFrameworkPkg/Library/UnitTestDebugAssertLib/UnitTestDebugAssertLibHost.cpp
@@ -1,0 +1,63 @@
+/** @file
+  Unit Test Debug Assert Library for host-based environments
+
+  Copyright (c) 2020, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <stdexcept>
+
+#ifdef NULL
+  #undef NULL
+#endif
+
+extern "C" {
+  #include <Uefi.h>
+  #include <UnitTestFrameworkTypes.h>
+  #include <Library/BaseLib.h>
+  #include <Library/UnitTestLib.h>
+
+  ///
+  /// Point to jump buffer used with SetJump()/LongJump() to test if a function
+  /// under test generates an expected ASSERT() condition.
+  ///
+  BASE_LIBRARY_JUMP_BUFFER  *gUnitTestExpectAssertFailureJumpBuffer = NULL;
+
+  /**
+    Unit test library replacement for DebugAssert() in DebugLib.
+
+    If FileName is NULL, then a <FileName> string of "(NULL) Filename" is printed.
+    If Description is NULL, then a <Description> string of "(NULL) Description" is printed.
+
+    @param  FileName     The pointer to the name of the source file that generated the assert condition.
+    @param  LineNumber   The line number in the source file that generated the assert condition
+    @param  Description  The pointer to the description of the assert condition.
+
+  **/
+  VOID
+  EFIAPI
+  UnitTestDebugAssert (
+    IN CONST CHAR8  *FileName,
+    IN UINTN        LineNumber,
+    IN CONST CHAR8  *Description
+    )
+  {
+    CHAR8  Message[256];
+
+    if (gUnitTestExpectAssertFailureJumpBuffer != NULL) {
+      UT_LOG_INFO ("Detected expected ASSERT: %a(%d): %a\n", FileName, LineNumber, Description);
+      LongJump (gUnitTestExpectAssertFailureJumpBuffer, 1);
+    } else {
+      if (GetActiveFrameworkHandle () != NULL) {
+        AsciiStrCpyS (Message, sizeof (Message), "Detected unexpected ASSERT(");
+        AsciiStrCatS (Message, sizeof (Message), Description);
+        AsciiStrCatS (Message, sizeof (Message), ")");
+        UnitTestAssertTrue (FALSE, "", LineNumber, FileName, Message);
+      } else {
+        snprintf (Message, sizeof (Message), "Detected unexpected ASSERT: %s(%d): %s\n", FileName, (INT32)(UINT32)LineNumber, Description);
+        throw std::runtime_error (Message);
+      }
+    }
+  }
+}

--- a/UnitTestFrameworkPkg/Library/UnitTestDebugAssertLib/UnitTestDebugAssertLibHost.inf
+++ b/UnitTestFrameworkPkg/Library/UnitTestDebugAssertLib/UnitTestDebugAssertLibHost.inf
@@ -1,0 +1,36 @@
+## @file
+#  Unit Test Debug Assert Library for host-based environments
+#
+#  Copyright (c) 2020, Intel Corporation. All rights reserved.<BR>
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = UnitTestDebugAssertLibHost
+  MODULE_UNI_FILE                = UnitTestDebugAssertLibHost.uni
+  FILE_GUID                      = F097D67C-0340-49C8-AB30-ABC1B7D1C8D2
+  MODULE_TYPE                    = HOST_APPLICATION
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = NULL
+
+#
+#  VALID_ARCHITECTURES           = IA32 X64 ARM AARCH64
+#
+
+[Sources]
+  UnitTestDebugAssertLibHost.cpp
+
+[Packages]
+  MdePkg/MdePkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  UnitTestLib
+
+[BuildOptions]
+  MSFT:*_*_*_CC_FLAGS   == /c /EHs /Zi /Od /MT
+  GCC:*_*_IA32_CC_FLAGS == -g -c -fshort-wchar -fexceptions -O0 -m32 -malign-double -fno-pie
+  GCC:*_*_X64_CC_FLAGS  == -g -c -fshort-wchar -fexceptions -O0 -m64 -fno-pie "-DEFIAPI=__attribute__((ms_abi))"

--- a/UnitTestFrameworkPkg/Library/UnitTestDebugAssertLib/UnitTestDebugAssertLibHost.uni
+++ b/UnitTestFrameworkPkg/Library/UnitTestDebugAssertLib/UnitTestDebugAssertLibHost.uni
@@ -1,0 +1,11 @@
+// /** @file
+// Unit Test Debug Assert Library for host-based environments
+//
+// Copyright (c) 2020, Intel Corporation. All rights reserved.<BR>
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+// **/
+
+#string STR_MODULE_ABSTRACT             #language en-US "Unit Test Debug Assert Library for host-based environments"
+
+#string STR_MODULE_DESCRIPTION          #language en-US "Unit Test Debug Assert Library for host-based environments"

--- a/UnitTestFrameworkPkg/Library/UnitTestLib/Assert.c
+++ b/UnitTestFrameworkPkg/Library/UnitTestLib/Assert.c
@@ -57,6 +57,10 @@ UnitTestLogFailure (
   // Get active Framework handle
   //
   FrameworkHandle = GetActiveFrameworkHandle ();
+  if (FrameworkHandle == NULL) {
+    DEBUG ((DEBUG_ERROR, "%a - FrameworkHandle not initialized\n", __func__));
+    return;
+  }
 
   //
   // Convert the message to an ASCII String

--- a/UnitTestFrameworkPkg/Library/UnitTestLib/Log.c
+++ b/UnitTestFrameworkPkg/Library/UnitTestLib/Log.c
@@ -166,6 +166,10 @@ UnitTestLog (
   VA_LIST                     Marker;
 
   FrameworkHandle = GetActiveFrameworkHandle ();
+  if (FrameworkHandle == NULL) {
+    DEBUG ((DEBUG_ERROR, "%a - FrameworkHandle not initialized\n", __func__));
+    return;
+  }
 
   LogTypePrefix = NULL;
 

--- a/UnitTestFrameworkPkg/Library/UnitTestLib/RunTests.c
+++ b/UnitTestFrameworkPkg/Library/UnitTestLib/RunTests.c
@@ -21,7 +21,6 @@ GetActiveFrameworkHandle (
   VOID
   )
 {
-  ASSERT (mFrameworkHandle != NULL);
   return mFrameworkHandle;
 }
 

--- a/UnitTestFrameworkPkg/Library/UnitTestLib/RunTestsCmocka.c
+++ b/UnitTestFrameworkPkg/Library/UnitTestLib/RunTestsCmocka.c
@@ -27,7 +27,6 @@ GetActiveFrameworkHandle (
   VOID
   )
 {
-  ASSERT (mFrameworkHandle != NULL);
   return mFrameworkHandle;
 }
 

--- a/UnitTestFrameworkPkg/Library/UnitTestLib/UnitTestLib.c
+++ b/UnitTestFrameworkPkg/Library/UnitTestLib/UnitTestLib.c
@@ -826,6 +826,10 @@ SaveFrameworkState (
 
   Header          = NULL;
   FrameworkHandle = GetActiveFrameworkHandle ();
+  if (FrameworkHandle == NULL) {
+    DEBUG ((DEBUG_ERROR, "%a - Could not save state! FrameworkHandle not initialized\n", __func__));
+    return EFI_DEVICE_ERROR;
+  }
 
   //
   // Return a unique error code if the framework is not set.

--- a/UnitTestFrameworkPkg/ReadMe.md
+++ b/UnitTestFrameworkPkg/ReadMe.md
@@ -59,7 +59,7 @@ reviewed. The paths to the SecureBootVariableLib unit tests are:
 | Unit Test Source Language   |     C     |    C++     |
 | Register Test Suite         |    YES    |    Auto    |
 | Register Test Case          |    YES    |    Auto    |
-| Death/Expected Assert Tests |    YES    |    YES     |
+| Expected Assert Tests       |    YES    |    YES     |
 | Setup/Teardown Hooks        |    YES    |    YES     |
 | Value-Parameterized Tests   |    NO     |    YES     |
 | Typed Tests                 |    NO     |    YES     |

--- a/UnitTestFrameworkPkg/Test/GoogleTest/Sample/SampleGoogleTest/SampleGoogleTest.cpp
+++ b/UnitTestFrameworkPkg/Test/GoogleTest/Sample/SampleGoogleTest/SampleGoogleTest.cpp
@@ -7,7 +7,7 @@
 
 **/
 
-#include <gtest/gtest.h>
+#include <Library/GoogleTestLib.h>
 extern "C" {
   #include <Uefi.h>
   #include <Library/BaseLib.h>
@@ -229,7 +229,7 @@ TEST_P (MacroTestsAssertsEnabledDisabled, MacroExpectNoAssertFailure) {
 }
 
 /**
-  Sample unit test using the ASSERT_DEATH() macro to test expected ASSERT()s.
+  Sample unit test using the EXPECT_ANY_THROW() macro to test expected ASSERT()s.
 **/
 TEST_P (MacroTestsAssertsEnabledDisabled, MacroExpectAssertFailure) {
   //
@@ -242,14 +242,35 @@ TEST_P (MacroTestsAssertsEnabledDisabled, MacroExpectAssertFailure) {
   //
   // This test passes because it directly triggers an ASSERT().
   //
-  ASSERT_DEATH (ASSERT (FALSE), "");
+  EXPECT_ANY_THROW (ASSERT (FALSE));
 
   //
   // This test passes because DecimalToBcd() generates an ASSERT() if the
   // value passed in is >= 100.  The expected ASSERT() is caught by the unit
-  // test framework and ASSERT_DEATH() returns without an error.
+  // test framework and EXPECT_ANY_THROW() returns without an error.
   //
-  ASSERT_DEATH (DecimalToBcd8 (101), "");
+  EXPECT_ANY_THROW (DecimalToBcd8 (101));
+
+  //
+  // This test passes because DecimalToBcd() generates an ASSERT() if the
+  // value passed in is >= 100.  The expected ASSERT() is caught by the unit
+  // test framework and throws the C++ exception of type std::runtime_error.
+  // EXPECT_THROW() returns without an error.
+  //
+  EXPECT_THROW (DecimalToBcd8 (101), std::runtime_error);
+
+  //
+  // This test passes because DecimalToBcd() generates an ASSERT() if the
+  // value passed in is >= 100.  The expected ASSERT() is caught by the unit
+  // test framework and throws the C++ exception of type std::runtime_error with
+  // a message that includes the filename, linenumber, and the expression that
+  // triggered the ASSERT().
+  //
+  // EXPECT_THROW_MESSAGE() calls DecimalToBcd() expecting DecimalToBds() to
+  // throw a C++ exception of type std::runtime_error with a message that
+  // includes the expression of "Value < 100" that triggered the ASSERT().
+  //
+  EXPECT_THROW_MESSAGE (DecimalToBcd8 (101), "Value < 100");
 }
 
 INSTANTIATE_TEST_SUITE_P (
@@ -266,6 +287,11 @@ TEST (MacroTestsMessages, MacroTraceMessage) {
   // Example of logging.
   //
   SCOPED_TRACE ("SCOPED_TRACE message\n");
+
+  //
+  // Always pass
+  //
+  ASSERT_TRUE (TRUE);
 }
 
 int

--- a/UnitTestFrameworkPkg/Test/GoogleTest/Sample/SampleGoogleTestExpectFail/SampleGoogleTestExpectFail.cpp
+++ b/UnitTestFrameworkPkg/Test/GoogleTest/Sample/SampleGoogleTestExpectFail/SampleGoogleTestExpectFail.cpp
@@ -1,0 +1,334 @@
+/** @file
+  This is a sample to demonstrates the use of GoogleTest that supports host
+  execution environments for test case that are always expected to fail to
+  demonstrate the format of the log file and reports when failures occur.
+
+  Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Library/GoogleTestLib.h>
+extern "C" {
+  #include <Uefi.h>
+  #include <Library/BaseLib.h>
+  #include <Library/DebugLib.h>
+}
+
+/**
+  Sample unit test that verifies the expected result of an unsigned integer
+  addition operation.
+**/
+TEST (SimpleMathTests, OnePlusOneShouldEqualTwo) {
+  UINTN  A;
+  UINTN  B;
+  UINTN  C;
+
+  A = 1;
+  B = 1;
+  C = A + B;
+
+  ASSERT_NE (C, (UINTN)2);
+}
+
+/**
+  Sample unit test that verifies that a global BOOLEAN is updatable.
+**/
+class GlobalBooleanVarTests : public ::testing::Test {
+public:
+  BOOLEAN SampleGlobalTestBoolean = FALSE;
+};
+
+TEST_F (GlobalBooleanVarTests, GlobalBooleanShouldBeChangeable) {
+  SampleGlobalTestBoolean = TRUE;
+  EXPECT_FALSE (SampleGlobalTestBoolean);
+
+  SampleGlobalTestBoolean = FALSE;
+  EXPECT_TRUE (SampleGlobalTestBoolean);
+}
+
+/**
+  Sample unit test that logs a warning message and verifies that a global
+  pointer is updatable.
+**/
+class GlobalVarTests : public ::testing::Test {
+public:
+  VOID *SampleGlobalTestPointer = NULL;
+
+protected:
+  void
+  SetUp (
+    ) override
+  {
+    ASSERT_NE ((UINTN)SampleGlobalTestPointer, (UINTN)NULL);
+  }
+
+  void
+  TearDown (
+    )
+  {
+    SampleGlobalTestPointer = NULL;
+  }
+};
+
+TEST_F (GlobalVarTests, GlobalPointerShouldBeChangeable) {
+  SampleGlobalTestPointer = (VOID *)-1;
+  ASSERT_NE ((UINTN)SampleGlobalTestPointer, (UINTN)((VOID *)-1));
+}
+
+/**
+  Set PcdDebugPropertyMask for each MacroTestsAssertsEnabledDisabled test
+**/
+class MacroTestsAssertsEnabledDisabled : public testing::TestWithParam<UINT8> {
+  void
+  SetUp (
+    )
+  {
+    PatchPcdSet8 (PcdDebugPropertyMask, GetParam ());
+  }
+};
+
+/**
+  Sample unit test using the ASSERT_TRUE() macro.
+**/
+TEST_P (MacroTestsAssertsEnabledDisabled, MacroAssertTrue) {
+  UINT64  Result;
+
+  //
+  // This test passes because expression always evaluated to TRUE.
+  //
+  EXPECT_FALSE (TRUE);
+
+  //
+  // This test passes because expression always evaluates to TRUE.
+  //
+  Result = LShiftU64 (BIT0, 1);
+  EXPECT_FALSE (Result == BIT1);
+}
+
+/**
+  Sample unit test using the ASSERT_FALSE() macro.
+**/
+TEST_P (MacroTestsAssertsEnabledDisabled, MacroAssertFalse) {
+  UINT64  Result;
+
+  //
+  // This test passes because expression always evaluated to FALSE.
+  //
+  EXPECT_TRUE (FALSE);
+
+  //
+  // This test passes because expression always evaluates to FALSE.
+  //
+  Result = LShiftU64 (BIT0, 1);
+  EXPECT_TRUE (Result == BIT0);
+}
+
+/**
+  Sample unit test using the ASSERT_EQ() macro.
+**/
+TEST_P (MacroTestsAssertsEnabledDisabled, MacroAssertEqual) {
+  UINT64  Result;
+
+  //
+  // This test passes because both values are always equal.
+  //
+  EXPECT_NE (1, 1);
+
+  //
+  // This test passes because both values are always equal.
+  //
+  Result = LShiftU64 (BIT0, 1);
+  EXPECT_NE (Result, (UINT64)BIT1);
+}
+
+/**
+  Sample unit test using the ASSERT_STREQ() macro.
+**/
+TEST_P (MacroTestsAssertsEnabledDisabled, MacroAssertMemEqual) {
+  CHAR8  *String1;
+  CHAR8  *String2;
+
+  //
+  // This test passes because String1 and String2 are the same.
+  //
+  String1 = (CHAR8 *)"Hello";
+  String2 = (CHAR8 *)"Hello";
+  EXPECT_STRNE (String1, String2);
+}
+
+/**
+  Sample unit test using the ASSERT_NE() macro.
+**/
+TEST_P (MacroTestsAssertsEnabledDisabled, MacroAssertNotEqual) {
+  UINT64  Result;
+
+  //
+  // This test passes because both values are never equal.
+  //
+  EXPECT_EQ (0, 1);
+
+  //
+  // This test passes because both values are never equal.
+  //
+  Result = LShiftU64 (BIT0, 1);
+  EXPECT_EQ (Result, (UINT64)BIT0);
+}
+
+/**
+  Sample unit test using the ASSERT_TRUE() and ASSERT(FALSE)
+  and EFI_EFFOR() macros to check status
+**/
+TEST_P (MacroTestsAssertsEnabledDisabled, MacroAssertNotEfiError) {
+  //
+  // This test passes because the status is not an EFI error.
+  //
+  EXPECT_TRUE (EFI_ERROR (EFI_SUCCESS));
+
+  //
+  // This test passes because the status is not an EFI error.
+  //
+  EXPECT_TRUE (EFI_ERROR (EFI_WARN_BUFFER_TOO_SMALL));
+}
+
+/**
+  Sample unit test using the ASSERT_EQ() macro to compare EFI_STATUS values.
+**/
+TEST_P (MacroTestsAssertsEnabledDisabled, MacroAssertStatusEqual) {
+  //
+  // This test passes because the status value are always equal.
+  //
+  EXPECT_NE (EFI_SUCCESS, EFI_SUCCESS);
+}
+
+/**
+  Sample unit test using ASSERT_NE() macro to make sure a pointer is not NULL.
+**/
+TEST_P (MacroTestsAssertsEnabledDisabled, MacroAssertNotNull) {
+  UINT64  Result;
+
+  //
+  // This test passes because the pointer is never NULL.
+  //
+  EXPECT_EQ (&Result, (UINT64 *)NULL);
+}
+
+/**
+  Sample unit test using that generates an unexpected ASSERT
+**/
+TEST_P (MacroTestsAssertsEnabledDisabled, MacroDirectForceAssertExpectTestFail) {
+  //
+  // Skip tests that verify an ASSERT() is triggered if ASSERT()s are disabled.
+  //
+  if ((PcdGet8 (PcdDebugPropertyMask) & BIT0) == 0x00) {
+    EXPECT_TRUE (FALSE);
+    return;
+  }
+
+  //
+  // This test fails because it directly triggers an ASSERT().
+  //
+  ASSERT (FALSE);
+}
+
+/**
+  Sample unit test using that generates an unexpected ASSERT
+**/
+TEST_P (MacroTestsAssertsEnabledDisabled, MacroIndirectForceAssertExpectTestFail) {
+  //
+  // Skip tests that verify an ASSERT() is triggered if ASSERT()s are disabled.
+  //
+  if ((PcdGet8 (PcdDebugPropertyMask) & BIT0) == 0x00) {
+    EXPECT_TRUE (FALSE);
+    return;
+  }
+
+  //
+  // This test fails because DecimalToBcd() generates an ASSERT() if the
+  // value passed in is >= 100.  The unexpected ASSERT() is caught by the unit
+  // test framework and generates a failed test.
+  //
+  DecimalToBcd8 (101);
+}
+
+/**
+  Sample unit test using that do not generate an expected ASSERT()
+**/
+TEST_P (MacroTestsAssertsEnabledDisabled, MacroExpectedAssertNotTriggeredExpectTestFail) {
+  //
+  // When ASSERT()s are disabled, all tests for ASSERT()s will fail.
+  //
+  if ((PcdGet8 (PcdDebugPropertyMask) & BIT0) == 0x00) {
+    EXPECT_ANY_THROW (ASSERT (TRUE));
+    EXPECT_ANY_THROW (DecimalToBcd8 (99));
+    EXPECT_ANY_THROW (DecimalToBcd8 (101));
+    EXPECT_THROW (DecimalToBcd8 (99), std::runtime_error);
+    EXPECT_THROW (DecimalToBcd8 (101), std::runtime_error);
+    EXPECT_THROW (DecimalToBcd8 (99), std::overflow_error);
+    EXPECT_THROW (DecimalToBcd8 (101), std::overflow_error);
+    EXPECT_THROW_MESSAGE (DecimalToBcd8 (99), "Value < 999");
+    EXPECT_THROW_MESSAGE (DecimalToBcd8 (101), "Value < 999");
+    return;
+  }
+
+  //
+  // This test fails because ASSERT(TRUE) never triggers an ASSERT().
+  //
+  EXPECT_ANY_THROW (ASSERT (TRUE));
+
+  //
+  // This test fails because DecimalToBcd() does not generate an ASSERT() if the
+  // value passed in is < 100.
+  //
+  EXPECT_ANY_THROW (DecimalToBcd8 (99));
+
+  //
+  // This test fails because DecimalToBcd() does not generate an ASSERT() if the
+  // value passed in is < 100.
+  //
+  EXPECT_THROW (DecimalToBcd8 (99), std::runtime_error);
+
+  //
+  // This test fails because DecimalToBcd() does generate an ASSERT() if the
+  // value passed in is >= 100, but is generates a C++ exception of type
+  // std::runtime_error
+  //
+  EXPECT_THROW (DecimalToBcd8 (101), std::overflow_error);
+
+  //
+  // This test fails because DecimalToBcd() generates an ASSERT() if the
+  // value passed in is >= 100.  The expected ASSERT() is caught by the unit
+  // test framework and throws the C++ exception of type std::runtime_error with
+  // a message that includes the filename, linenumber, and the expression that
+  // triggered the ASSERT().  The message generated by BcdToDecimal() is
+  // "Value < 100", but the expression tested is not "Value < 100".
+  //
+  EXPECT_THROW_MESSAGE (DecimalToBcd8 (101), "Value < 999");
+}
+
+INSTANTIATE_TEST_SUITE_P (
+  ValidInput,
+  MacroTestsAssertsEnabledDisabled,
+  ::testing::Values (PcdGet8 (PcdDebugPropertyMask) | BIT0, PcdGet8 (PcdDebugPropertyMask) & (~BIT0))
+  );
+
+/**
+  Sample unit test using the SCOPED_TRACE() macro for trace messages.
+**/
+TEST (MacroTestsMessages, MacroTraceMessage) {
+  //
+  // Example of logging.
+  //
+  SCOPED_TRACE ("SCOPED_TRACE message\n");
+  EXPECT_TRUE (FALSE);
+}
+
+int
+main (
+  int   argc,
+  char  *argv[]
+  )
+{
+  testing::InitGoogleTest (&argc, argv);
+  return RUN_ALL_TESTS ();
+}

--- a/UnitTestFrameworkPkg/Test/GoogleTest/Sample/SampleGoogleTestExpectFail/SampleGoogleTestHostExpectFail.inf
+++ b/UnitTestFrameworkPkg/Test/GoogleTest/Sample/SampleGoogleTestExpectFail/SampleGoogleTestHostExpectFail.inf
@@ -1,0 +1,36 @@
+## @file
+# This is a sample to demonstrates the use of GoogleTest that supports host
+# execution environments for test case that are always expected to fail to
+# demonstrate the format of the log file and reports when failures occur.
+#
+# Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION    = 0x00010005
+  BASE_NAME      = SampleGoogleTestHostExpectFail
+  FILE_GUID      = 6042ADD2-E024-4FD5-8CD7-B2A146BF88D7
+  MODULE_TYPE    = HOST_APPLICATION
+  VERSION_STRING = 1.0
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  SampleGoogleTestExpectFail.cpp
+
+[Packages]
+  MdePkg/MdePkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+
+[LibraryClasses]
+  GoogleTestLib
+  BaseLib
+  DebugLib
+
+[Pcd]
+  gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask

--- a/UnitTestFrameworkPkg/Test/GoogleTest/Sample/SampleGoogleTestGenerateException/SampleGoogleTestGenerateException.cpp
+++ b/UnitTestFrameworkPkg/Test/GoogleTest/Sample/SampleGoogleTestGenerateException/SampleGoogleTestGenerateException.cpp
@@ -1,0 +1,54 @@
+/** @file
+  This is a sample to demonstrates the use of GoogleTest that supports host
+  execution environments for test case that generates an exception.  For some
+  host-based environments, this is a fatal condition that terminates the unit
+  tests and no additional test cases are executed. On other environments, this
+  condition may be report a unit test failure and continue with additional unit
+  tests.
+
+  Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <Library/GoogleTestLib.h>
+extern "C" {
+  #include <Uefi.h>
+  #include <Library/BaseLib.h>
+  #include <Library/DebugLib.h>
+}
+
+UINTN
+DivideWithNoParameterChecking (
+  UINTN  Dividend,
+  UINTN  Divisor
+  )
+{
+  //
+  // Perform integer division with no check for divide by zero
+  //
+  return (Dividend / Divisor);
+}
+
+/**
+  Sample unit test that generates an unexpected exception
+**/
+TEST (ExceptionTest, GenerateExceptionExpectTestFail) {
+  //
+  // Assertion that passes without generating an exception
+  //
+  EXPECT_EQ (DivideWithNoParameterChecking (20, 1), (UINTN)20);
+  //
+  // Assertion that generates divide by zero exception before result evaluated
+  //
+  EXPECT_EQ (DivideWithNoParameterChecking (20, 0), MAX_UINTN);
+}
+
+int
+main (
+  int   argc,
+  char  *argv[]
+  )
+{
+  testing::InitGoogleTest (&argc, argv);
+  return RUN_ALL_TESTS ();
+}

--- a/UnitTestFrameworkPkg/Test/GoogleTest/Sample/SampleGoogleTestGenerateException/SampleGoogleTestHostGenerateException.inf
+++ b/UnitTestFrameworkPkg/Test/GoogleTest/Sample/SampleGoogleTestGenerateException/SampleGoogleTestHostGenerateException.inf
@@ -1,0 +1,39 @@
+## @file
+# This is a sample to demonstrates the use of GoogleTest that supports host
+# execution environments for test case that generates an exception. For some
+# host-based environments, this is a fatal condition that terminates the unit
+# tests and no additional test cases are executed. On other environments, this
+# condition may be report a unit test failure and continue with additional unit
+# tests.
+#
+# Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION    = 0x00010005
+  BASE_NAME      = SampleGoogleTestHostGenerateException
+  FILE_GUID      = 037A3C56-44C5-4899-AC4D-911943E6FBA1
+  MODULE_TYPE    = HOST_APPLICATION
+  VERSION_STRING = 1.0
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  SampleGoogleTestGenerateException.cpp
+
+[Packages]
+  MdePkg/MdePkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+
+[LibraryClasses]
+  GoogleTestLib
+  BaseLib
+  DebugLib
+
+[Pcd]
+  gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask

--- a/UnitTestFrameworkPkg/Test/UnitTest/Sample/SampleUnitTestExpectFail/SampleUnitTestDxeExpectFail.inf
+++ b/UnitTestFrameworkPkg/Test/UnitTest/Sample/SampleUnitTestExpectFail/SampleUnitTestDxeExpectFail.inf
@@ -1,0 +1,41 @@
+## @file
+# Sample UnitTest built for execution in DXE.
+# All test case are always expected to fail to demonstrate the format of the log
+# file and reports when failures occur.
+#
+# Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION    = 0x00010006
+  BASE_NAME      = SampleUnitTestDxeExpectFail
+  FILE_GUID      = 7092E907-E817-4D39-877C-64BD0F54C1D4
+  MODULE_TYPE    = DXE_DRIVER
+  VERSION_STRING = 1.0
+  ENTRY_POINT    = DxeEntryPoint
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  SampleUnitTestExpectFail.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+
+[LibraryClasses]
+  UefiDriverEntryPoint
+  BaseLib
+  DebugLib
+  UnitTestLib
+  PrintLib
+
+[Pcd]
+  gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask
+
+[Depex]
+  TRUE

--- a/UnitTestFrameworkPkg/Test/UnitTest/Sample/SampleUnitTestExpectFail/SampleUnitTestExpectFail.c
+++ b/UnitTestFrameworkPkg/Test/UnitTest/Sample/SampleUnitTestExpectFail/SampleUnitTestExpectFail.c
@@ -1,0 +1,861 @@
+/** @file
+  This is a sample to demonstrate the usage of the Unit Test Library that
+  supports the PEI, DXE, SMM, UEFI Shell, and host execution environments.
+  All test case are always expected to fail to demonstrate the format of the log
+  file and reports when failures occur.
+
+  Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+#include <PiPei.h>
+#include <Uefi.h>
+#include <Library/UefiLib.h>
+#include <Library/DebugLib.h>
+#include <Library/UnitTestLib.h>
+#include <Library/PrintLib.h>
+
+#define UNIT_TEST_NAME     "Sample Unit Test Expect Fail"
+#define UNIT_TEST_VERSION  "0.1"
+
+///
+/// Global variables used in unit tests
+///
+BOOLEAN  mSampleGlobalTestBoolean  = FALSE;
+VOID     *mSampleGlobalTestPointer = NULL;
+
+/**
+  Sample Unit-Test Prerequisite Function that checks to make sure the global
+  pointer used in the test is already set to NULL.
+
+  Functions with this prototype are registered to be dispatched by the unit test
+  framework prior to a given test case. If this prereq function returns
+  UNIT_TEST_ERROR_PREREQUISITE_NOT_MET, the test case will be skipped.
+
+  @param[in]  Context    [Optional] An optional parameter that enables:
+                         1) test-case reuse with varied parameters and
+                         2) test-case re-entry for Target tests that need a
+                         reboot.  This parameter is a VOID* and it is the
+                         responsibility of the test author to ensure that the
+                         contents are well understood by all test cases that may
+                         consume it.
+
+  @retval  UNIT_TEST_PASSED                      Unit test case prerequisites
+                                                 are met.
+  @retval  UNIT_TEST_ERROR_PREREQUISITE_NOT_MET  Test case should be skipped.
+
+**/
+UNIT_TEST_STATUS
+EFIAPI
+MakeSureThatPointerIsNull (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  UT_ASSERT_NOT_EQUAL ((UINTN)mSampleGlobalTestPointer, (UINTN)NULL);
+  return UNIT_TEST_PASSED;
+}
+
+/**
+  Sample Unit-Test Cleanup (after) function that resets the global pointer to
+  NULL.
+
+  Functions with this prototype are registered to be dispatched by the
+  unit test framework after a given test case. This will be called even if the
+  test case returns an error, but not if the prerequisite fails and the test is
+  skipped.  The purpose of this function is to clean up any global state or
+  test data.
+
+  @param[in]  Context    [Optional] An optional parameter that enables:
+                         1) test-case reuse with varied parameters and
+                         2) test-case re-entry for Target tests that need a
+                         reboot.  This parameter is a VOID* and it is the
+                         responsibility of the test author to ensure that the
+                         contents are well understood by all test cases that may
+                         consume it.
+
+  @retval  UNIT_TEST_PASSED                Test case cleanup succeeded.
+  @retval  UNIT_TEST_ERROR_CLEANUP_FAILED  Test case cleanup failed.
+
+**/
+VOID
+EFIAPI
+ClearThePointer (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  mSampleGlobalTestPointer = NULL;
+}
+
+/**
+  Sample unit test that verifies the expected result of an unsigned integer
+  addition operation.
+
+  @param[in]  Context    [Optional] An optional parameter that enables:
+                         1) test-case reuse with varied parameters and
+                         2) test-case re-entry for Target tests that need a
+                         reboot.  This parameter is a VOID* and it is the
+                         responsibility of the test author to ensure that the
+                         contents are well understood by all test cases that may
+                         consume it.
+
+  @retval  UNIT_TEST_PASSED             The Unit test has completed and the test
+                                        case was successful.
+  @retval  UNIT_TEST_ERROR_TEST_FAILED  A test case assertion has failed.
+**/
+UNIT_TEST_STATUS
+EFIAPI
+OnePlusOneShouldEqualTwo (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  UINTN  A;
+  UINTN  B;
+  UINTN  C;
+
+  A = 1;
+  B = 1;
+  C = A + B;
+
+  UT_ASSERT_NOT_EQUAL (C, 2);
+
+  return UNIT_TEST_PASSED;
+}
+
+/**
+  Sample unit test that verifies that a global BOOLEAN is updatable.
+
+  @param[in]  Context    [Optional] An optional parameter that enables:
+                         1) test-case reuse with varied parameters and
+                         2) test-case re-entry for Target tests that need a
+                         reboot.  This parameter is a VOID* and it is the
+                         responsibility of the test author to ensure that the
+                         contents are well understood by all test cases that may
+                         consume it.
+
+  @retval  UNIT_TEST_PASSED             The Unit test has completed and the test
+                                        case was successful.
+  @retval  UNIT_TEST_ERROR_TEST_FAILED  A test case assertion has failed.
+**/
+UNIT_TEST_STATUS
+EFIAPI
+GlobalBooleanShouldBeChangeable (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  mSampleGlobalTestBoolean = TRUE;
+  UT_ASSERT_FALSE (mSampleGlobalTestBoolean);
+
+  mSampleGlobalTestBoolean = FALSE;
+  UT_ASSERT_TRUE (mSampleGlobalTestBoolean);
+
+  return UNIT_TEST_PASSED;
+}
+
+/**
+  Sample unit test that logs a warning message and verifies that a global
+  pointer is updatable.
+
+  @param[in]  Context    [Optional] An optional parameter that enables:
+                         1) test-case reuse with varied parameters and
+                         2) test-case re-entry for Target tests that need a
+                         reboot.  This parameter is a VOID* and it is the
+                         responsibility of the test author to ensure that the
+                         contents are well understood by all test cases that may
+                         consume it.
+
+  @retval  UNIT_TEST_PASSED             The Unit test has completed and the test
+                                        case was successful.
+  @retval  UNIT_TEST_ERROR_TEST_FAILED  A test case assertion has failed.
+**/
+UNIT_TEST_STATUS
+EFIAPI
+GlobalPointerShouldBeChangeable (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  //
+  // Example of logging.
+  //
+  UT_LOG_WARNING ("About to change a global pointer! Current value is 0x%X\n", mSampleGlobalTestPointer);
+
+  mSampleGlobalTestPointer = (VOID *)-1;
+  UT_ASSERT_NOT_EQUAL ((UINTN)mSampleGlobalTestPointer, (UINTN)((VOID *)-1));
+  return UNIT_TEST_PASSED;
+}
+
+/**
+  Unit-Test Test Suite Setup (before) function that enables ASSERT() macros.
+**/
+VOID
+EFIAPI
+TestSuiteEnableAsserts (
+  VOID
+  )
+{
+  //
+  // Set BIT0 (DEBUG_PROPERTY_DEBUG_ASSERT_ENABLED)
+  //
+  PatchPcdSet8 (PcdDebugPropertyMask, PcdGet8 (PcdDebugPropertyMask) | BIT0);
+}
+
+/**
+  Unit-Test Test Suite Setup (before) function that disables ASSERT() macros.
+**/
+VOID
+EFIAPI
+TestSuiteDisableAsserts (
+  VOID
+  )
+{
+  //
+  // Clear BIT0 (DEBUG_PROPERTY_DEBUG_ASSERT_ENABLED)
+  //
+  PatchPcdSet8 (PcdDebugPropertyMask, PcdGet8 (PcdDebugPropertyMask) & (~BIT0));
+}
+
+/**
+  Sample unit test using the UT_ASSERT_TRUE() macro.
+
+  @param[in]  Context    [Optional] An optional parameter that enables:
+                         1) test-case reuse with varied parameters and
+                         2) test-case re-entry for Target tests that need a
+                         reboot.  This parameter is a VOID* and it is the
+                         responsibility of the test author to ensure that the
+                         contents are well understood by all test cases that may
+                         consume it.
+
+  @retval  UNIT_TEST_PASSED             The Unit test has completed and the test
+                                        case was successful.
+  @retval  UNIT_TEST_ERROR_TEST_FAILED  A test case assertion has failed.
+**/
+UNIT_TEST_STATUS
+EFIAPI
+MacroUtAssertTrue (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  UINT64  Result;
+
+  //
+  // This test passes because expression always evaluated to TRUE.
+  //
+  UT_ASSERT_FALSE (TRUE);
+
+  //
+  // This test passes because expression always evaluates to TRUE.
+  //
+  Result = LShiftU64 (BIT0, 1);
+  UT_ASSERT_FALSE (Result == BIT1);
+
+  return UNIT_TEST_PASSED;
+}
+
+/**
+  Sample unit test using the UT_ASSERT_FALSE() macro.
+
+  @param[in]  Context    [Optional] An optional parameter that enables:
+                         1) test-case reuse with varied parameters and
+                         2) test-case re-entry for Target tests that need a
+                         reboot.  This parameter is a VOID* and it is the
+                         responsibility of the test author to ensure that the
+                         contents are well understood by all test cases that may
+                         consume it.
+
+  @retval  UNIT_TEST_PASSED             The Unit test has completed and the test
+                                        case was successful.
+  @retval  UNIT_TEST_ERROR_TEST_FAILED  A test case assertion has failed.
+**/
+UNIT_TEST_STATUS
+EFIAPI
+MacroUtAssertFalse (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  UINT64  Result;
+
+  //
+  // This test passes because expression always evaluated to FALSE.
+  //
+  UT_ASSERT_TRUE (FALSE);
+
+  //
+  // This test passes because expression always evaluates to FALSE.
+  //
+  Result = LShiftU64 (BIT0, 1);
+  UT_ASSERT_TRUE (Result == BIT0);
+
+  return UNIT_TEST_PASSED;
+}
+
+/**
+  Sample unit test using the UT_ASSERT_EQUAL() macro.
+
+  @param[in]  Context    [Optional] An optional parameter that enables:
+                         1) test-case reuse with varied parameters and
+                         2) test-case re-entry for Target tests that need a
+                         reboot.  This parameter is a VOID* and it is the
+                         responsibility of the test author to ensure that the
+                         contents are well understood by all test cases that may
+                         consume it.
+
+  @retval  UNIT_TEST_PASSED             The Unit test has completed and the test
+                                        case was successful.
+  @retval  UNIT_TEST_ERROR_TEST_FAILED  A test case assertion has failed.
+**/
+UNIT_TEST_STATUS
+EFIAPI
+MacroUtAssertEqual (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  UINT64  Result;
+
+  //
+  // This test passes because both values are always equal.
+  //
+  UT_ASSERT_NOT_EQUAL (1, 1);
+
+  //
+  // This test passes because both values are always equal.
+  //
+  Result = LShiftU64 (BIT0, 1);
+  UT_ASSERT_NOT_EQUAL (Result, BIT1);
+
+  return UNIT_TEST_PASSED;
+}
+
+/**
+  Sample unit test using the UT_ASSERT_MEM_EQUAL() macro.
+
+  @param[in]  Context    [Optional] An optional parameter that enables:
+                         1) test-case reuse with varied parameters and
+                         2) test-case re-entry for Target tests that need a
+                         reboot.  This parameter is a VOID* and it is the
+                         responsibility of the test author to ensure that the
+                         contents are well understood by all test cases that may
+                         consume it.
+
+  @retval  UNIT_TEST_PASSED             The Unit test has completed and the test
+                                        case was successful.
+  @retval  UNIT_TEST_ERROR_TEST_FAILED  A test case assertion has failed.
+**/
+UNIT_TEST_STATUS
+EFIAPI
+MacroUtAssertMemEqual (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  CHAR8  *String1;
+  CHAR8  *String2;
+  UINTN  Length;
+
+  //
+  // This test passes because String1 and String2 are the same.
+  //
+  String1 = "Hello1";
+  String2 = "Hello2";
+  Length  = sizeof ("Hello1");
+  UT_ASSERT_MEM_EQUAL (String1, String2, Length);
+
+  return UNIT_TEST_PASSED;
+}
+
+/**
+  Sample unit test using the UT_ASSERT_NOT_EQUAL() macro.
+
+  @param[in]  Context    [Optional] An optional parameter that enables:
+                         1) test-case reuse with varied parameters and
+                         2) test-case re-entry for Target tests that need a
+                         reboot.  This parameter is a VOID* and it is the
+                         responsibility of the test author to ensure that the
+                         contents are well understood by all test cases that may
+                         consume it.
+
+  @retval  UNIT_TEST_PASSED             The Unit test has completed and the test
+                                        case was successful.
+  @retval  UNIT_TEST_ERROR_TEST_FAILED  A test case assertion has failed.
+**/
+UNIT_TEST_STATUS
+EFIAPI
+MacroUtAssertNotEqual (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  UINT64  Result;
+
+  //
+  // This test passes because both values are never equal.
+  //
+  UT_ASSERT_EQUAL (0, 1);
+
+  //
+  // This test passes because both values are never equal.
+  //
+  Result = LShiftU64 (BIT0, 1);
+  UT_ASSERT_EQUAL (Result, BIT0);
+
+  return UNIT_TEST_PASSED;
+}
+
+/**
+  Sample unit test using the UT_ASSERT_NOT_EFI_ERROR() macro.
+
+  @param[in]  Context    [Optional] An optional parameter that enables:
+                         1) test-case reuse with varied parameters and
+                         2) test-case re-entry for Target tests that need a
+                         reboot.  This parameter is a VOID* and it is the
+                         responsibility of the test author to ensure that the
+                         contents are well understood by all test cases that may
+                         consume it.
+
+  @retval  UNIT_TEST_PASSED             The Unit test has completed and the test
+                                        case was successful.
+  @retval  UNIT_TEST_ERROR_TEST_FAILED  A test case assertion has failed.
+**/
+UNIT_TEST_STATUS
+EFIAPI
+MacroUtAssertNotEfiError (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  //
+  // This test passes because the status is not an EFI error.
+  //
+  UT_ASSERT_NOT_EFI_ERROR (EFI_INVALID_PARAMETER);
+
+  //
+  // This test passes because the status is not an EFI error.
+  //
+  UT_ASSERT_NOT_EFI_ERROR (EFI_BUFFER_TOO_SMALL);
+
+  return UNIT_TEST_PASSED;
+}
+
+/**
+  Sample unit test using the UT_ASSERT_STATUS_EQUAL() macro.
+
+  @param[in]  Context    [Optional] An optional parameter that enables:
+                         1) test-case reuse with varied parameters and
+                         2) test-case re-entry for Target tests that need a
+                         reboot.  This parameter is a VOID* and it is the
+                         responsibility of the test author to ensure that the
+                         contents are well understood by all test cases that may
+                         consume it.
+
+  @retval  UNIT_TEST_PASSED             The Unit test has completed and the test
+                                        case was successful.
+  @retval  UNIT_TEST_ERROR_TEST_FAILED  A test case assertion has failed.
+**/
+UNIT_TEST_STATUS
+EFIAPI
+MacroUtAssertStatusEqual (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  //
+  // This test passes because the status value are always equal.
+  //
+  UT_ASSERT_STATUS_EQUAL (EFI_SUCCESS, EFI_NOT_FOUND);
+
+  return UNIT_TEST_PASSED;
+}
+
+/**
+  Sample unit test using the UT_ASSERT_NOT_NULL() macro.
+
+  @param[in]  Context    [Optional] An optional parameter that enables:
+                         1) test-case reuse with varied parameters and
+                         2) test-case re-entry for Target tests that need a
+                         reboot.  This parameter is a VOID* and it is the
+                         responsibility of the test author to ensure that the
+                         contents are well understood by all test cases that may
+                         consume it.
+
+  @retval  UNIT_TEST_PASSED             The Unit test has completed and the test
+                                        case was successful.
+  @retval  UNIT_TEST_ERROR_TEST_FAILED  A test case assertion has failed.
+**/
+UNIT_TEST_STATUS
+EFIAPI
+MacroUtAssertNotNull (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  //
+  // This test passes because the pointer is never NULL.
+  //
+  UT_ASSERT_NOT_NULL (NULL);
+
+  return UNIT_TEST_PASSED;
+}
+
+/**
+  Sample unit test using the UT_EXPECT_ASSERT_FAILURE() macro.
+
+  @param[in]  Context    [Optional] An optional parameter that enables:
+                         1) test-case reuse with varied parameters and
+                         2) test-case re-entry for Target tests that need a
+                         reboot.  This parameter is a VOID* and it is the
+                         responsibility of the test author to ensure that the
+                         contents are well understood by all test cases that may
+                         consume it.
+
+  @retval  UNIT_TEST_PASSED             The Unit test has completed and the test
+                                        case was successful.
+  @retval  UNIT_TEST_ERROR_TEST_FAILED  A test case assertion has failed.
+**/
+UNIT_TEST_STATUS
+EFIAPI
+MacroUtExpectAssertFailure (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  //
+  // Skip tests that verify an ASSERT() is triggered if ASSERT()s are disabled.
+  //
+  if ((PcdGet8 (PcdDebugPropertyMask) & BIT0) == 0x00) {
+    UT_ASSERT_TRUE (FALSE);
+    return UNIT_TEST_PASSED;
+  }
+
+  //
+  // This test passes because it directly triggers an ASSERT().
+  //
+  UT_EXPECT_ASSERT_FAILURE (ASSERT (TRUE), NULL);
+
+  //
+  // This test passes because DecimalToBcd() generates an ASSERT() if the
+  // value passed in is >= 100.  The expected ASSERT() is caught by the unit
+  // test framework and UT_EXPECT_ASSERT_FAILURE() returns without an error.
+  //
+  UT_EXPECT_ASSERT_FAILURE (DecimalToBcd8 (99), NULL);
+
+  return UNIT_TEST_PASSED;
+}
+
+/**
+  Sample unit test the triggers an unexpected ASSERT()
+
+  @param[in]  Context    [Optional] An optional parameter that enables:
+                         1) test-case reuse with varied parameters and
+                         2) test-case re-entry for Target tests that need a
+                         reboot.  This parameter is a VOID* and it is the
+                         responsibility of the test author to ensure that the
+                         contents are well understood by all test cases that may
+                         consume it.
+
+  @retval  UNIT_TEST_PASSED             The Unit test has completed and the test
+                                        case was successful.
+  @retval  UNIT_TEST_ERROR_TEST_FAILED  A test case assertion has failed.
+**/
+UNIT_TEST_STATUS
+EFIAPI
+GenerateUnexpectedAssert (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  //
+  // Skip tests that verify an ASSERT() is triggered if ASSERT()s are disabled.
+  //
+  if ((PcdGet8 (PcdDebugPropertyMask) & BIT0) == 0x00) {
+    UT_ASSERT_TRUE (FALSE);
+    return UNIT_TEST_PASSED;
+  }
+
+  //
+  // This test fails because DecimalToBcd() generates an ASSERT() if the
+  // value passed in is >= 100.  The unexpected ASSERT() is caught by the unit
+  // test framework and generates a failed test.
+  //
+  DecimalToBcd8 (101);
+
+  return UNIT_TEST_PASSED;
+}
+
+/**
+  Sample unit test using the UT_LOG_ERROR() macro.
+
+  @param[in]  Context    [Optional] An optional parameter that enables:
+                         1) test-case reuse with varied parameters and
+                         2) test-case re-entry for Target tests that need a
+                         reboot.  This parameter is a VOID* and it is the
+                         responsibility of the test author to ensure that the
+                         contents are well understood by all test cases that may
+                         consume it.
+
+  @retval  UNIT_TEST_PASSED             The Unit test has completed and the test
+                                        case was successful.
+  @retval  UNIT_TEST_ERROR_TEST_FAILED  A test case assertion has failed.
+**/
+UNIT_TEST_STATUS
+EFIAPI
+MacroUtLogError (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  //
+  // Example of logging.
+  //
+  UT_LOG_ERROR ("UT_LOG_ERROR() message\n");
+
+  UT_ASSERT_TRUE (FALSE);
+
+  return UNIT_TEST_PASSED;
+}
+
+/**
+  Sample unit test using the UT_LOG_WARNING() macro.
+
+  @param[in]  Context    [Optional] An optional parameter that enables:
+                         1) test-case reuse with varied parameters and
+                         2) test-case re-entry for Target tests that need a
+                         reboot.  This parameter is a VOID* and it is the
+                         responsibility of the test author to ensure that the
+                         contents are well understood by all test cases that may
+                         consume it.
+
+  @retval  UNIT_TEST_PASSED             The Unit test has completed and the test
+                                        case was successful.
+  @retval  UNIT_TEST_ERROR_TEST_FAILED  A test case assertion has failed.
+**/
+UNIT_TEST_STATUS
+EFIAPI
+MacroUtLogWarning (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  //
+  // Example of logging.
+  //
+  UT_LOG_WARNING ("UT_LOG_WARNING() message\n");
+
+  UT_ASSERT_TRUE (FALSE);
+
+  return UNIT_TEST_PASSED;
+}
+
+/**
+  Sample unit test using the UT_LOG_INFO() macro.
+
+  @param[in]  Context    [Optional] An optional parameter that enables:
+                         1) test-case reuse with varied parameters and
+                         2) test-case re-entry for Target tests that need a
+                         reboot.  This parameter is a VOID* and it is the
+                         responsibility of the test author to ensure that the
+                         contents are well understood by all test cases that may
+                         consume it.
+
+  @retval  UNIT_TEST_PASSED             The Unit test has completed and the test
+                                        case was successful.
+  @retval  UNIT_TEST_ERROR_TEST_FAILED  A test case assertion has failed.
+**/
+UNIT_TEST_STATUS
+EFIAPI
+MacroUtLogInfo (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  //
+  // Example of logging.
+  //
+  UT_LOG_INFO ("UT_LOG_INFO() message\n");
+
+  UT_ASSERT_TRUE (FALSE);
+
+  return UNIT_TEST_PASSED;
+}
+
+/**
+  Sample unit test using the UT_LOG_VERBOSE() macro.
+
+  @param[in]  Context    [Optional] An optional parameter that enables:
+                         1) test-case reuse with varied parameters and
+                         2) test-case re-entry for Target tests that need a
+                         reboot.  This parameter is a VOID* and it is the
+                         responsibility of the test author to ensure that the
+                         contents are well understood by all test cases that may
+                         consume it.
+
+  @retval  UNIT_TEST_PASSED             The Unit test has completed and the test
+                                        case was successful.
+  @retval  UNIT_TEST_ERROR_TEST_FAILED  A test case assertion has failed.
+**/
+UNIT_TEST_STATUS
+EFIAPI
+MacroUtLogVerbose (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  //
+  // Example of logging.
+  //
+  UT_LOG_VERBOSE ("UT_LOG_VERBOSE() message\n");
+
+  UT_ASSERT_TRUE (FALSE);
+
+  return UNIT_TEST_PASSED;
+}
+
+/**
+  Initialize the unit test framework, suite, and unit tests for the
+  sample unit tests and run the unit tests.
+
+  @retval  EFI_SUCCESS           All test cases were dispatched.
+  @retval  EFI_OUT_OF_RESOURCES  There are not enough resources available to
+                                 initialize the unit tests.
+**/
+EFI_STATUS
+EFIAPI
+UefiTestMain (
+  VOID
+  )
+{
+  EFI_STATUS                  Status;
+  UNIT_TEST_FRAMEWORK_HANDLE  Framework;
+  UNIT_TEST_SUITE_HANDLE      SimpleMathTests;
+  UNIT_TEST_SUITE_HANDLE      GlobalVarTests;
+  UNIT_TEST_SUITE_HANDLE      MacroTestsAssertsEnabled;
+  UNIT_TEST_SUITE_HANDLE      MacroTestsAssertsDisabled;
+
+  Framework = NULL;
+
+  DEBUG ((DEBUG_INFO, "%a v%a\n", UNIT_TEST_NAME, UNIT_TEST_VERSION));
+
+  //
+  // Start setting up the test framework for running the tests.
+  //
+  Status = InitUnitTestFramework (&Framework, UNIT_TEST_NAME, gEfiCallerBaseName, UNIT_TEST_VERSION);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "Failed in InitUnitTestFramework. Status = %r\n", Status));
+    goto EXIT;
+  }
+
+  //
+  // Populate the SimpleMathTests Unit Test Suite.
+  //
+  Status = CreateUnitTestSuite (&SimpleMathTests, Framework, "Simple Math Tests", "Sample.Math", NULL, NULL);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "Failed in CreateUnitTestSuite for SimpleMathTests\n"));
+    Status = EFI_OUT_OF_RESOURCES;
+    goto EXIT;
+  }
+
+  AddTestCase (SimpleMathTests, "Adding 1 to 1 should produce 2", "Addition", OnePlusOneShouldEqualTwo, NULL, NULL, NULL);
+
+  //
+  // Populate the GlobalVarTests Unit Test Suite.
+  //
+  Status = CreateUnitTestSuite (&GlobalVarTests, Framework, "Global Variable Tests", "Sample.Globals", NULL, NULL);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "Failed in CreateUnitTestSuite for GlobalVarTests\n"));
+    Status = EFI_OUT_OF_RESOURCES;
+    goto EXIT;
+  }
+
+  AddTestCase (GlobalVarTests, "You should be able to change a global BOOLEAN", "Boolean", GlobalBooleanShouldBeChangeable, NULL, NULL, NULL);
+  AddTestCase (GlobalVarTests, "You should be able to change a global pointer", "Pointer", GlobalPointerShouldBeChangeable, MakeSureThatPointerIsNull, ClearThePointer, NULL);
+
+  //
+  // Populate the Macro Tests with ASSERT() enabled
+  //
+  Status = CreateUnitTestSuite (&MacroTestsAssertsEnabled, Framework, "Macro Tests with ASSERT() enabled", "Sample.MacroAssertsEnabled", TestSuiteEnableAsserts, NULL);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "Failed in CreateUnitTestSuite for MacroTestsAssertsEnabled\n"));
+    Status = EFI_OUT_OF_RESOURCES;
+    goto EXIT;
+  }
+
+  AddTestCase (MacroTestsAssertsEnabled, "Test UT_ASSERT_TRUE() macro", "MacroUtAssertTrue", MacroUtAssertTrue, NULL, NULL, NULL);
+  AddTestCase (MacroTestsAssertsEnabled, "Test UT_ASSERT_FALSE() macro", "MacroUtAssertFalse", MacroUtAssertFalse, NULL, NULL, NULL);
+  AddTestCase (MacroTestsAssertsEnabled, "Test UT_ASSERT_EQUAL() macro", "MacroUtAssertEqual", MacroUtAssertEqual, NULL, NULL, NULL);
+  AddTestCase (MacroTestsAssertsEnabled, "Test UT_ASSERT_MEM_EQUAL() macro", "MacroUtAssertMemEqual", MacroUtAssertMemEqual, NULL, NULL, NULL);
+  AddTestCase (MacroTestsAssertsEnabled, "Test UT_ASSERT_NOT_EQUAL() macro", "MacroUtAssertNotEqual", MacroUtAssertNotEqual, NULL, NULL, NULL);
+  AddTestCase (MacroTestsAssertsEnabled, "Test UT_ASSERT_NOT_EFI_ERROR() macro", "MacroUtAssertNotEfiError", MacroUtAssertNotEfiError, NULL, NULL, NULL);
+  AddTestCase (MacroTestsAssertsEnabled, "Test UT_ASSERT_STATUS_EQUAL() macro", "MacroUtAssertStatusEqual", MacroUtAssertStatusEqual, NULL, NULL, NULL);
+  AddTestCase (MacroTestsAssertsEnabled, "Test UT_ASSERT_NOT_NULL() macro", "MacroUtAssertNotNull", MacroUtAssertNotNull, NULL, NULL, NULL);
+  AddTestCase (MacroTestsAssertsEnabled, "Test UT_EXPECT_ASSERT_FAILURE() macro", "MacroUtExpectAssertFailure", MacroUtExpectAssertFailure, NULL, NULL, NULL);
+  AddTestCase (MacroTestsAssertsEnabled, "Test Unexpected ASSERT()", "GenerateUnexpectedAssert", GenerateUnexpectedAssert, NULL, NULL, NULL);
+
+  AddTestCase (MacroTestsAssertsEnabled, "Test UT_LOG_ERROR() macro", "MacroUtLogError", MacroUtLogError, NULL, NULL, NULL);
+  AddTestCase (MacroTestsAssertsEnabled, "Test UT_LOG_WARNING() macro", "MacroUtLogWarning", MacroUtLogWarning, NULL, NULL, NULL);
+  AddTestCase (MacroTestsAssertsEnabled, "Test UT_LOG_INFO() macro", "MacroUtLogInfo", MacroUtLogInfo, NULL, NULL, NULL);
+  AddTestCase (MacroTestsAssertsEnabled, "Test UT_LOG_VERBOSE() macro", "MacroUtLogVerbose", MacroUtLogVerbose, NULL, NULL, NULL);
+
+  //
+  // Populate the Macro Tests with ASSERT() disabled
+  //
+  Status = CreateUnitTestSuite (&MacroTestsAssertsDisabled, Framework, "Macro Tests with ASSERT() disabled", "Sample.MacroAssertsDisables", TestSuiteDisableAsserts, NULL);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "Failed in CreateUnitTestSuite for MacroTestsAssertsDisabled\n"));
+    Status = EFI_OUT_OF_RESOURCES;
+    goto EXIT;
+  }
+
+  AddTestCase (MacroTestsAssertsDisabled, "Test UT_ASSERT_TRUE() macro", "MacroUtAssertTrue", MacroUtAssertTrue, NULL, NULL, NULL);
+  AddTestCase (MacroTestsAssertsDisabled, "Test UT_ASSERT_FALSE() macro", "MacroUtAssertFalse", MacroUtAssertFalse, NULL, NULL, NULL);
+  AddTestCase (MacroTestsAssertsDisabled, "Test UT_ASSERT_EQUAL() macro", "MacroUtAssertEqual", MacroUtAssertEqual, NULL, NULL, NULL);
+  AddTestCase (MacroTestsAssertsDisabled, "Test UT_ASSERT_MEM_EQUAL() macro", "MacroUtAssertMemEqual", MacroUtAssertMemEqual, NULL, NULL, NULL);
+  AddTestCase (MacroTestsAssertsDisabled, "Test UT_ASSERT_NOT_EQUAL() macro", "MacroUtAssertNotEqual", MacroUtAssertNotEqual, NULL, NULL, NULL);
+  AddTestCase (MacroTestsAssertsDisabled, "Test UT_ASSERT_NOT_EFI_ERROR() macro", "MacroUtAssertNotEfiError", MacroUtAssertNotEfiError, NULL, NULL, NULL);
+  AddTestCase (MacroTestsAssertsDisabled, "Test UT_ASSERT_STATUS_EQUAL() macro", "MacroUtAssertStatusEqual", MacroUtAssertStatusEqual, NULL, NULL, NULL);
+  AddTestCase (MacroTestsAssertsDisabled, "Test UT_ASSERT_NOT_NULL() macro", "MacroUtAssertNotNull", MacroUtAssertNotNull, NULL, NULL, NULL);
+  AddTestCase (MacroTestsAssertsDisabled, "Test UT_EXPECT_ASSERT_FAILURE() macro", "MacroUtExpectAssertFailure", MacroUtExpectAssertFailure, NULL, NULL, NULL);
+
+  AddTestCase (MacroTestsAssertsDisabled, "Test Unexpected ASSERT()", "GenerateUnexpectedAssert", GenerateUnexpectedAssert, NULL, NULL, NULL);
+
+  AddTestCase (MacroTestsAssertsDisabled, "Test UT_LOG_ERROR() macro", "MacroUtLogError", MacroUtLogError, NULL, NULL, NULL);
+  AddTestCase (MacroTestsAssertsDisabled, "Test UT_LOG_WARNING() macro", "MacroUtLogWarning", MacroUtLogWarning, NULL, NULL, NULL);
+  AddTestCase (MacroTestsAssertsDisabled, "Test UT_LOG_INFO() macro", "MacroUtLogInfo", MacroUtLogInfo, NULL, NULL, NULL);
+  AddTestCase (MacroTestsAssertsDisabled, "Test UT_LOG_VERBOSE() macro", "MacroUtLogVerbose", MacroUtLogVerbose, NULL, NULL, NULL);
+
+  //
+  // Execute the tests.
+  //
+  Status = RunAllTestSuites (Framework);
+
+EXIT:
+  if (Framework) {
+    FreeUnitTestFramework (Framework);
+  }
+
+  return Status;
+}
+
+/**
+  Standard PEIM entry point for target based unit test execution from PEI.
+**/
+EFI_STATUS
+EFIAPI
+PeiEntryPoint (
+  IN EFI_PEI_FILE_HANDLE     FileHandle,
+  IN CONST EFI_PEI_SERVICES  **PeiServices
+  )
+{
+  return UefiTestMain ();
+}
+
+/**
+  Standard UEFI entry point for target based unit test execution from DXE, SMM,
+  UEFI Shell.
+**/
+EFI_STATUS
+EFIAPI
+DxeEntryPoint (
+  IN EFI_HANDLE        ImageHandle,
+  IN EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  return UefiTestMain ();
+}
+
+/**
+  Standard POSIX C entry point for host based unit test execution.
+**/
+int
+main (
+  int   argc,
+  char  *argv[]
+  )
+{
+  return UefiTestMain ();
+}

--- a/UnitTestFrameworkPkg/Test/UnitTest/Sample/SampleUnitTestExpectFail/SampleUnitTestHostExpectFail.inf
+++ b/UnitTestFrameworkPkg/Test/UnitTest/Sample/SampleUnitTestExpectFail/SampleUnitTestHostExpectFail.inf
@@ -1,0 +1,35 @@
+## @file
+# Sample UnitTest built for execution on a Host/Dev machine.
+# All test case are always expected to fail to demonstrate the format of the log
+# file and reports when failures occur.
+#
+# Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION    = 0x00010005
+  BASE_NAME      = SampleUnitTestHostExpectFail
+  FILE_GUID      = C419E68B-D5C6-4F35-AE99-470946328A1F
+  MODULE_TYPE    = HOST_APPLICATION
+  VERSION_STRING = 1.0
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  SampleUnitTestExpectFail.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+
+[LibraryClasses]
+  BaseLib
+  DebugLib
+  UnitTestLib
+
+[Pcd]
+  gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask

--- a/UnitTestFrameworkPkg/Test/UnitTest/Sample/SampleUnitTestExpectFail/SampleUnitTestPeiExpectFail.inf
+++ b/UnitTestFrameworkPkg/Test/UnitTest/Sample/SampleUnitTestExpectFail/SampleUnitTestPeiExpectFail.inf
@@ -1,0 +1,41 @@
+## @file
+# Sample UnitTest built for execution in PEI.
+# All test case are always expected to fail to demonstrate the format of the log
+# file and reports when failures occur.
+#
+# Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION    = 0x00010006
+  BASE_NAME      = SampleUnitTestPeiExpectFail
+  FILE_GUID      = A65EA745-A15E-480A-82E5-6AEED8AE8788
+  MODULE_TYPE    = PEIM
+  VERSION_STRING = 1.0
+  ENTRY_POINT    = PeiEntryPoint
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  SampleUnitTestExpectFail.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+
+[LibraryClasses]
+  PeimEntryPoint
+  BaseLib
+  DebugLib
+  UnitTestLib
+  PrintLib
+
+[Pcd]
+  gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask
+
+[Depex]
+  gEfiPeiMemoryDiscoveredPpiGuid

--- a/UnitTestFrameworkPkg/Test/UnitTest/Sample/SampleUnitTestExpectFail/SampleUnitTestSmmExpectFail.inf
+++ b/UnitTestFrameworkPkg/Test/UnitTest/Sample/SampleUnitTestExpectFail/SampleUnitTestSmmExpectFail.inf
@@ -1,0 +1,42 @@
+## @file
+# Sample UnitTest built for execution in SMM.
+# All test case are always expected to fail to demonstrate the format of the log
+# file and reports when failures occur.
+#
+# Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION              = 0x00010006
+  BASE_NAME                = SampleUnitTestSmmExpectFail
+  FILE_GUID                = 031B1FE7-582E-4F43-B50D-5A7E42BCC11C
+  MODULE_TYPE              = DXE_SMM_DRIVER
+  VERSION_STRING           = 1.0
+  PI_SPECIFICATION_VERSION = 0x0001000A
+  ENTRY_POINT              = DxeEntryPoint
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  SampleUnitTestExpectFail.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+
+[LibraryClasses]
+  UefiDriverEntryPoint
+  BaseLib
+  DebugLib
+  UnitTestLib
+  PrintLib
+
+[Pcd]
+  gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask
+
+[Depex]
+  gEfiSmmCpuProtocolGuid

--- a/UnitTestFrameworkPkg/Test/UnitTest/Sample/SampleUnitTestExpectFail/SampleUnitTestUefiShellExpectFail.inf
+++ b/UnitTestFrameworkPkg/Test/UnitTest/Sample/SampleUnitTestExpectFail/SampleUnitTestUefiShellExpectFail.inf
@@ -1,0 +1,38 @@
+## @file
+# Sample UnitTest built for execution in UEFI Shell.
+# All test case are always expected to fail to demonstrate the format of the log
+# file and reports when failures occur.
+#
+# Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION    = 0x00010006
+  BASE_NAME      = SampleUnitTestUefiShellExpectFail
+  FILE_GUID      = 8AF3A9A7-228B-462A-B91A-0591493F8D1F
+  MODULE_TYPE    = UEFI_APPLICATION
+  VERSION_STRING = 1.0
+  ENTRY_POINT    = DxeEntryPoint
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  SampleUnitTestExpectFail.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+
+[LibraryClasses]
+  UefiApplicationEntryPoint
+  BaseLib
+  DebugLib
+  UnitTestLib
+  PrintLib
+
+[Pcd]
+  gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask

--- a/UnitTestFrameworkPkg/Test/UnitTest/Sample/SampleUnitTestGenerateException/SampleUnitTestDxeGenerateException.inf
+++ b/UnitTestFrameworkPkg/Test/UnitTest/Sample/SampleUnitTestGenerateException/SampleUnitTestDxeGenerateException.inf
@@ -1,0 +1,43 @@
+## @file
+# Sample UnitTest built for execution in DXE.
+# This test case generates an exception. For some host-based environments, this
+# is a fatal condition that terminates the unit tests and no additional test
+# cases are executed. On other environments, this condition may be report a unit
+# test failure and continue with additional unit tests.
+#
+# Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION    = 0x00010006
+  BASE_NAME      = SampleUnitTestDxeGenerateException
+  FILE_GUID      = 2E8C07AF-FAC7-44F3-9108-7F548D347EE1
+  MODULE_TYPE    = DXE_DRIVER
+  VERSION_STRING = 1.0
+  ENTRY_POINT    = DxeEntryPoint
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  SampleUnitTestGenerateException.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+
+[LibraryClasses]
+  UefiDriverEntryPoint
+  BaseLib
+  DebugLib
+  UnitTestLib
+  PrintLib
+
+[Pcd]
+  gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask
+
+[Depex]
+  TRUE

--- a/UnitTestFrameworkPkg/Test/UnitTest/Sample/SampleUnitTestGenerateException/SampleUnitTestGenerateException.c
+++ b/UnitTestFrameworkPkg/Test/UnitTest/Sample/SampleUnitTestGenerateException/SampleUnitTestGenerateException.c
@@ -1,0 +1,204 @@
+/** @file
+  This is a sample to demonstrate the usage of the Unit Test Library that
+  supports the PEI, DXE, SMM, UEFI Shell, and host execution environments.
+  This test case generates an exception. For some host-based environments, this
+  is a fatal condition that terminates the unit tests and no additional test
+  cases are executed. On other environments, this condition may be report a unit
+  test failure and continue with additional unit tests.
+
+  Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+#include <PiPei.h>
+#include <Uefi.h>
+#include <Library/UefiLib.h>
+#include <Library/DebugLib.h>
+#include <Library/UnitTestLib.h>
+#include <Library/PrintLib.h>
+
+#define UNIT_TEST_NAME     "Sample Unit Test Generate Exception"
+#define UNIT_TEST_VERSION  "0.1"
+
+/**
+  Unit-Test Test Suite Setup (before) function that enables ASSERT() macros.
+**/
+VOID
+EFIAPI
+TestSuiteEnableAsserts (
+  VOID
+  )
+{
+  //
+  // Set BIT0 (DEBUG_PROPERTY_DEBUG_ASSERT_ENABLED)
+  //
+  PatchPcdSet8 (PcdDebugPropertyMask, PcdGet8 (PcdDebugPropertyMask) | BIT0);
+}
+
+/**
+  Unit-Test Test Suite Setup (before) function that disables ASSERT() macros.
+**/
+VOID
+EFIAPI
+TestSuiteDisableAsserts (
+  VOID
+  )
+{
+  //
+  // Clear BIT0 (DEBUG_PROPERTY_DEBUG_ASSERT_ENABLED)
+  //
+  PatchPcdSet8 (PcdDebugPropertyMask, PcdGet8 (PcdDebugPropertyMask) & (~BIT0));
+}
+
+UINTN
+DivideWithNoParameterChecking (
+  UINTN  Dividend,
+  UINTN  Divisor
+  )
+{
+  //
+  // Perform integer division with no check for divide by zero
+  //
+  return (Dividend / Divisor);
+}
+
+/**
+  Sample unit test the triggers an unexpected exception
+
+  @param[in]  Context    [Optional] An optional parameter that enables:
+                         1) test-case reuse with varied parameters and
+                         2) test-case re-entry for Target tests that need a
+                         reboot.  This parameter is a VOID* and it is the
+                         responsibility of the test author to ensure that the
+                         contents are well understood by all test cases that may
+                         consume it.
+
+  @retval  UNIT_TEST_PASSED             The Unit test has completed and the test
+                                        case was successful.
+  @retval  UNIT_TEST_ERROR_TEST_FAILED  A test case assertion has failed.
+**/
+UNIT_TEST_STATUS
+EFIAPI
+GenerateUnexpectedException (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  //
+  // Assertion that passes without generating an exception
+  //
+  UT_ASSERT_EQUAL (DivideWithNoParameterChecking (20, 1), (UINTN)20);
+  //
+  // Assertion that generates divide by zero exception before result evaluated
+  //
+  UT_ASSERT_EQUAL (DivideWithNoParameterChecking (20, 0), MAX_UINTN);
+
+  return UNIT_TEST_PASSED;
+}
+
+/**
+  Initialize the unit test framework, suite, and unit tests for the
+  sample unit tests and run the unit tests.
+
+  @retval  EFI_SUCCESS           All test cases were dispatched.
+  @retval  EFI_OUT_OF_RESOURCES  There are not enough resources available to
+                                 initialize the unit tests.
+**/
+EFI_STATUS
+EFIAPI
+UefiTestMain (
+  VOID
+  )
+{
+  EFI_STATUS                  Status;
+  UNIT_TEST_FRAMEWORK_HANDLE  Framework;
+  UNIT_TEST_SUITE_HANDLE      MacroTestsAssertsEnabled;
+  UNIT_TEST_SUITE_HANDLE      MacroTestsAssertsDisabled;
+
+  Framework = NULL;
+
+  DEBUG ((DEBUG_INFO, "%a v%a\n", UNIT_TEST_NAME, UNIT_TEST_VERSION));
+
+  //
+  // Start setting up the test framework for running the tests.
+  //
+  Status = InitUnitTestFramework (&Framework, UNIT_TEST_NAME, gEfiCallerBaseName, UNIT_TEST_VERSION);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "Failed in InitUnitTestFramework. Status = %r\n", Status));
+    goto EXIT;
+  }
+
+  //
+  // Populate the Macro Tests with ASSERT() enabled
+  //
+  Status = CreateUnitTestSuite (&MacroTestsAssertsEnabled, Framework, "Macro Tests with ASSERT() enabled", "Sample.MacroAssertsEnabled", TestSuiteEnableAsserts, NULL);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "Failed in CreateUnitTestSuite for MacroTestsAssertsEnabled\n"));
+    Status = EFI_OUT_OF_RESOURCES;
+    goto EXIT;
+  }
+
+  AddTestCase (MacroTestsAssertsEnabled, "Test Unexpected Exception", "GenerateUnexpectedException", GenerateUnexpectedException, NULL, NULL, NULL);
+
+  //
+  // Populate the Macro Tests with ASSERT() disabled
+  //
+  Status = CreateUnitTestSuite (&MacroTestsAssertsDisabled, Framework, "Macro Tests with ASSERT() disabled", "Sample.MacroAssertsDisables", TestSuiteDisableAsserts, NULL);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "Failed in CreateUnitTestSuite for MacroTestsAssertsDisabled\n"));
+    Status = EFI_OUT_OF_RESOURCES;
+    goto EXIT;
+  }
+
+  AddTestCase (MacroTestsAssertsDisabled, "Test Unexpected Exception", "GenerateUnexpectedException", GenerateUnexpectedException, NULL, NULL, NULL);
+
+  //
+  // Execute the tests.
+  //
+  Status = RunAllTestSuites (Framework);
+
+EXIT:
+  if (Framework) {
+    FreeUnitTestFramework (Framework);
+  }
+
+  return Status;
+}
+
+/**
+  Standard PEIM entry point for target based unit test execution from PEI.
+**/
+EFI_STATUS
+EFIAPI
+PeiEntryPoint (
+  IN EFI_PEI_FILE_HANDLE     FileHandle,
+  IN CONST EFI_PEI_SERVICES  **PeiServices
+  )
+{
+  return UefiTestMain ();
+}
+
+/**
+  Standard UEFI entry point for target based unit test execution from DXE, SMM,
+  UEFI Shell.
+**/
+EFI_STATUS
+EFIAPI
+DxeEntryPoint (
+  IN EFI_HANDLE        ImageHandle,
+  IN EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  return UefiTestMain ();
+}
+
+/**
+  Standard POSIX C entry point for host based unit test execution.
+**/
+int
+main (
+  int   argc,
+  char  *argv[]
+  )
+{
+  return UefiTestMain ();
+}

--- a/UnitTestFrameworkPkg/Test/UnitTest/Sample/SampleUnitTestGenerateException/SampleUnitTestHostGenerateException.inf
+++ b/UnitTestFrameworkPkg/Test/UnitTest/Sample/SampleUnitTestGenerateException/SampleUnitTestHostGenerateException.inf
@@ -1,0 +1,37 @@
+## @file
+# Sample UnitTest built for execution on a Host/Dev machine.
+# This test case generates an exception. For some host-based environments, this
+# is a fatal condition that terminates the unit tests and no additional test
+# cases are executed. On other environments, this condition may be report a unit
+# test failure and continue with additional unit tests.
+#
+# Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION    = 0x00010005
+  BASE_NAME      = SampleUnitTestHostGenerateException
+  FILE_GUID      = 842C65F7-E31A-4E67-85B2-72F2958636DF
+  MODULE_TYPE    = HOST_APPLICATION
+  VERSION_STRING = 1.0
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  SampleUnitTestGenerateException.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+
+[LibraryClasses]
+  BaseLib
+  DebugLib
+  UnitTestLib
+
+[Pcd]
+  gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask

--- a/UnitTestFrameworkPkg/Test/UnitTest/Sample/SampleUnitTestGenerateException/SampleUnitTestPeiGenerateException.inf
+++ b/UnitTestFrameworkPkg/Test/UnitTest/Sample/SampleUnitTestGenerateException/SampleUnitTestPeiGenerateException.inf
@@ -1,0 +1,43 @@
+## @file
+# Sample UnitTest built for execution in PEI.
+# This test case generates an exception. For some host-based environments, this
+# is a fatal condition that terminates the unit tests and no additional test
+# cases are executed. On other environments, this condition may be report a unit
+# test failure and continue with additional unit tests.
+#
+# Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION    = 0x00010006
+  BASE_NAME      = SampleUnitTestPeiGenerateException
+  FILE_GUID      = F66B54D6-0EB0-410E-A5A5-C76A739C5F5D
+  MODULE_TYPE    = PEIM
+  VERSION_STRING = 1.0
+  ENTRY_POINT    = PeiEntryPoint
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  SampleUnitTestGenerateException.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+
+[LibraryClasses]
+  PeimEntryPoint
+  BaseLib
+  DebugLib
+  UnitTestLib
+  PrintLib
+
+[Pcd]
+  gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask
+
+[Depex]
+  gEfiPeiMemoryDiscoveredPpiGuid

--- a/UnitTestFrameworkPkg/Test/UnitTest/Sample/SampleUnitTestGenerateException/SampleUnitTestSmmGenerateException.inf
+++ b/UnitTestFrameworkPkg/Test/UnitTest/Sample/SampleUnitTestGenerateException/SampleUnitTestSmmGenerateException.inf
@@ -1,0 +1,44 @@
+## @file
+# Sample UnitTest built for execution in SMM.
+# This test case generates an exception. For some host-based environments, this
+# is a fatal condition that terminates the unit tests and no additional test
+# cases are executed. On other environments, this condition may be report a unit
+# test failure and continue with additional unit tests.
+#
+# Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION              = 0x00010006
+  BASE_NAME                = SampleUnitTestSmmGenerateException
+  FILE_GUID                = C28BCCD6-3B42-4896-9931-62CCC5DF91B8
+  MODULE_TYPE              = DXE_SMM_DRIVER
+  VERSION_STRING           = 1.0
+  PI_SPECIFICATION_VERSION = 0x0001000A
+  ENTRY_POINT              = DxeEntryPoint
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  SampleUnitTestGenerateException.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+
+[LibraryClasses]
+  UefiDriverEntryPoint
+  BaseLib
+  DebugLib
+  UnitTestLib
+  PrintLib
+
+[Pcd]
+  gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask
+
+[Depex]
+  gEfiSmmCpuProtocolGuid

--- a/UnitTestFrameworkPkg/Test/UnitTest/Sample/SampleUnitTestGenerateException/SampleUnitTestUefiShellGenerateException.inf
+++ b/UnitTestFrameworkPkg/Test/UnitTest/Sample/SampleUnitTestGenerateException/SampleUnitTestUefiShellGenerateException.inf
@@ -1,0 +1,40 @@
+## @file
+# Sample UnitTest built for execution in UEFI Shell.
+# This test case generates an exception. For some host-based environments, this
+# is a fatal condition that terminates the unit tests and no additional test
+# cases are executed. On other environments, this condition may be report a unit
+# test failure and continue with additional unit tests.
+#
+# Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION    = 0x00010006
+  BASE_NAME      = SampleUnitTestUefiShellGenerateException
+  FILE_GUID      = E854F900-6B7A-448D-8689-736EB96875BF
+  MODULE_TYPE    = UEFI_APPLICATION
+  VERSION_STRING = 1.0
+  ENTRY_POINT    = DxeEntryPoint
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  SampleUnitTestGenerateException.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+
+[LibraryClasses]
+  UefiApplicationEntryPoint
+  BaseLib
+  DebugLib
+  UnitTestLib
+  PrintLib
+
+[Pcd]
+  gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask

--- a/UnitTestFrameworkPkg/Test/UnitTestFrameworkPkgHostTest.dsc
+++ b/UnitTestFrameworkPkg/Test/UnitTestFrameworkPkgHostTest.dsc
@@ -38,3 +38,4 @@
   UnitTestFrameworkPkg/Library/Posix/MemoryAllocationLibPosix/MemoryAllocationLibPosix.inf
   UnitTestFrameworkPkg/Library/SubhookLib/SubhookLib.inf
   UnitTestFrameworkPkg/Library/UnitTestLib/UnitTestLibCmocka.inf
+  UnitTestFrameworkPkg/Library/UnitTestDebugAssertLib/UnitTestDebugAssertLibHost.inf

--- a/UnitTestFrameworkPkg/Test/UnitTestFrameworkPkgHostTestExpectFail.dsc
+++ b/UnitTestFrameworkPkg/Test/UnitTestFrameworkPkgHostTestExpectFail.dsc
@@ -1,0 +1,44 @@
+## @file
+# UnitTestFrameworkPkg DSC file used to build host-based unit tests that archive
+# always expected to fail to demonstrate the format of the log file and reports
+# when failures occur.
+#
+# Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  PLATFORM_NAME           = UnitTestFrameworkPkgHostTest
+  PLATFORM_GUID           = C7F97D6D-54AC-45A9-8197-CC99B20CC7EC
+  PLATFORM_VERSION        = 0.1
+  DSC_SPECIFICATION       = 0x00010005
+  OUTPUT_DIRECTORY        = Build/UnitTestFrameworkPkg/HostTestExpectFail
+  SUPPORTED_ARCHITECTURES = IA32|X64
+  BUILD_TARGETS           = NOOPT
+  SKUID_IDENTIFIER        = DEFAULT
+
+!include UnitTestFrameworkPkg/UnitTestFrameworkPkgHost.dsc.inc
+
+[PcdsPatchableInModule]
+  gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask|0x17
+
+[Components]
+  #
+  # Build HOST_APPLICATIONs that test the SampleUnitTest
+  #
+  UnitTestFrameworkPkg/Test/GoogleTest/Sample/SampleGoogleTestExpectFail/SampleGoogleTestHostExpectFail.inf
+  UnitTestFrameworkPkg/Test/UnitTest/Sample/SampleUnitTestExpectFail/SampleUnitTestHostExpectFail.inf
+
+  #
+  # Disable warning for divide by zero to pass build of unit tests
+  # that generate a divide by zero exception.
+  #
+  UnitTestFrameworkPkg/Test/GoogleTest/Sample/SampleGoogleTestGenerateException/SampleGoogleTestHostGenerateException.inf {
+    <BuildOptions>
+      MSFT:*_*_*_CC_FLAGS = /wd4723
+  }
+  UnitTestFrameworkPkg/Test/UnitTest/Sample/SampleUnitTestGenerateException/SampleUnitTestHostGenerateException.inf {
+    <BuildOptions>
+      MSFT:*_*_*_CC_FLAGS = /wd4723
+  }

--- a/UnitTestFrameworkPkg/UnitTestFrameworkPkg.ci.yaml
+++ b/UnitTestFrameworkPkg/UnitTestFrameworkPkg.ci.yaml
@@ -62,7 +62,12 @@
     },
     ## options defined .pytool/Plugin/HostUnitTestDscCompleteCheck
     "HostUnitTestDscCompleteCheck": {
-        "IgnoreInf": [],
+        "IgnoreInf": [
+            "UnitTestFrameworkPkg/Test/GoogleTest/Sample/SampleGoogleTestExpectFail/SampleGoogleTestHostExpectFail.inf",
+            "UnitTestFrameworkPkg/Test/GoogleTest/Sample/SampleGoogleTestGenerateException/SampleGoogleTestHostGenerateException.inf",
+            "UnitTestFrameworkPkg/Test/UnitTest/Sample/SampleUnitTestExpectFail/SampleUnitTestHostExpectFail.inf",
+            "UnitTestFrameworkPkg/Test/UnitTest/Sample/SampleUnitTestGenerateException/SampleUnitTestHostGenerateException.inf"
+        ],
         "DscPath": "Test/UnitTestFrameworkPkgHostTest.dsc"
     },
     ## options defined .pytool/Plugin/GuidCheck
@@ -110,5 +115,14 @@
         ],
         "IgnoreStandardPaths": [],   # Standard Plugin defined paths that should be ignore
         "AdditionalIncludePaths": [] # Additional paths to spell check (wildcards supported)
+    },
+
+    # options defined in .pytool/Plugin/UncrustifyCheck
+    "UncrustifyCheck": {
+        "IgnoreFiles": [
+            "Library/CmockaLib/cmocka/**",
+            "Library/GoogleTestLib/googletest/**",
+            "Library/SubhookLib/subhook/**"
+        ]
     }
 }

--- a/UnitTestFrameworkPkg/UnitTestFrameworkPkg.ci.yaml
+++ b/UnitTestFrameworkPkg/UnitTestFrameworkPkg.ci.yaml
@@ -102,6 +102,8 @@
             "cobertura",
             "DHAVE", # build flag for cmocka in the INF
             "gtest", # file name in GoogleTestLib.inf
+            "defiapi",      # build flag for gtest
+            "fexceptions",  # build flag for gtest
             "corthon",      # Contact GitHub account in Readme
             "mdkinney",     # Contact GitHub account in Readme
             "spbrogan"      # Contact GitHub account in Readme

--- a/UnitTestFrameworkPkg/UnitTestFrameworkPkg.dsc
+++ b/UnitTestFrameworkPkg/UnitTestFrameworkPkg.dsc
@@ -41,3 +41,29 @@
   UnitTestFrameworkPkg/Test/UnitTest/Sample/SampleUnitTest/SampleUnitTestPei.inf
   UnitTestFrameworkPkg/Test/UnitTest/Sample/SampleUnitTest/SampleUnitTestSmm.inf
   UnitTestFrameworkPkg/Test/UnitTest/Sample/SampleUnitTest/SampleUnitTestUefiShell.inf
+
+  UnitTestFrameworkPkg/Test/UnitTest/Sample/SampleUnitTestExpectFail/SampleUnitTestDxeExpectFail.inf
+  UnitTestFrameworkPkg/Test/UnitTest/Sample/SampleUnitTestExpectFail/SampleUnitTestPeiExpectFail.inf
+  UnitTestFrameworkPkg/Test/UnitTest/Sample/SampleUnitTestExpectFail/SampleUnitTestSmmExpectFail.inf
+  UnitTestFrameworkPkg/Test/UnitTest/Sample/SampleUnitTestExpectFail/SampleUnitTestUefiShellExpectFail.inf
+
+  #
+  # Disable warning for divide by zero to pass build of unit tests
+  # that generate a divide by zero exception.
+  #
+  UnitTestFrameworkPkg/Test/UnitTest/Sample/SampleUnitTestGenerateException/SampleUnitTestDxeGenerateException.inf {
+    <BuildOptions>
+      MSFT:*_*_*_CC_FLAGS = /wd4723
+  }
+  UnitTestFrameworkPkg/Test/UnitTest/Sample/SampleUnitTestGenerateException/SampleUnitTestPeiGenerateException.inf {
+    <BuildOptions>
+      MSFT:*_*_*_CC_FLAGS = /wd4723
+  }
+  UnitTestFrameworkPkg/Test/UnitTest/Sample/SampleUnitTestGenerateException/SampleUnitTestSmmGenerateException.inf {
+    <BuildOptions>
+      MSFT:*_*_*_CC_FLAGS = /wd4723
+  }
+  UnitTestFrameworkPkg/Test/UnitTest/Sample/SampleUnitTestGenerateException/SampleUnitTestUefiShellGenerateException.inf {
+    <BuildOptions>
+      MSFT:*_*_*_CC_FLAGS = /wd4723
+  }

--- a/UnitTestFrameworkPkg/UnitTestFrameworkPkgHost.dsc.inc
+++ b/UnitTestFrameworkPkg/UnitTestFrameworkPkgHost.dsc.inc
@@ -31,13 +31,14 @@
   GCC:*_*_*_CC_FLAGS   = -D UNIT_TESTING_DEBUG=1
   XCODE:*_*_*_CC_FLAGS = -D UNIT_TESTING_DEBUG=1
 !endif
-  GCC:*_GCC5_*_CC_FLAGS = --coverage
-  GCC:*_GCC5_*_DLINK_FLAGS = --coverage
+  GCC:*_*_*_CC_FLAGS = -fexceptions
+  GCC:*_*_*_CC_FLAGS = --coverage
+  GCC:*_*_*_DLINK_FLAGS = --coverage
 [BuildOptions.common.EDKII.HOST_APPLICATION]
   #
   # MSFT
   #
-  MSFT:*_*_*_CC_FLAGS               = /EHsc
+  MSFT:*_*_*_CC_FLAGS               = /EHs
   MSFT:*_*_*_DLINK_FLAGS            == /out:"$(BIN_DIR)\$(MODULE_NAME_GUID).exe" /pdb:"$(BIN_DIR)\$(MODULE_NAME_GUID).pdb" /IGNORE:4001 /NOLOGO /SUBSYSTEM:CONSOLE /DEBUG /STACK:0x40000,0x40000 /WHOLEARCHIVE
   MSFT:*_*_IA32_DLINK_FLAGS         = /MACHINE:I386
   MSFT:*_*_X64_DLINK_FLAGS          = /MACHINE:AMD64

--- a/UnitTestFrameworkPkg/UnitTestFrameworkPkgHost.dsc.inc
+++ b/UnitTestFrameworkPkg/UnitTestFrameworkPkgHost.dsc.inc
@@ -22,6 +22,7 @@
   MemoryAllocationLib|UnitTestFrameworkPkg/Library/Posix/MemoryAllocationLibPosix/MemoryAllocationLibPosix.inf
   UefiBootServicesTableLib|UnitTestFrameworkPkg/Library/UnitTestUefiBootServicesTableLib/UnitTestUefiBootServicesTableLib.inf
   PeiServicesTablePointerLib|UnitTestFrameworkPkg/Library/UnitTestPeiServicesTablePointerLib/UnitTestPeiServicesTablePointerLib.inf
+  NULL|UnitTestFrameworkPkg/Library/UnitTestDebugAssertLib/UnitTestDebugAssertLibHost.inf
 
 [BuildOptions]
   MSFT:*_*_*_CC_FLAGS = /MT

--- a/UnitTestFrameworkPkg/UnitTestFrameworkPkgHost.dsc.inc
+++ b/UnitTestFrameworkPkg/UnitTestFrameworkPkgHost.dsc.inc
@@ -24,9 +24,10 @@
   PeiServicesTablePointerLib|UnitTestFrameworkPkg/Library/UnitTestPeiServicesTablePointerLib/UnitTestPeiServicesTablePointerLib.inf
 
 [BuildOptions]
+  MSFT:*_*_*_CC_FLAGS = /MT
   GCC:*_*_*_CC_FLAGS = -fno-pie
 !ifdef $(UNIT_TESTING_DEBUG)
-  MSFT:*_*_*_CC_FLAGS  = -D UNIT_TESTING_DEBUG=1
+  MSFT:*_*_*_CC_FLAGS  = /MTd -D UNIT_TESTING_DEBUG=1
   GCC:*_*_*_CC_FLAGS   = -D UNIT_TESTING_DEBUG=1
   XCODE:*_*_*_CC_FLAGS = -D UNIT_TESTING_DEBUG=1
 !endif

--- a/UnitTestFrameworkPkg/UnitTestFrameworkPkgTarget.dsc.inc
+++ b/UnitTestFrameworkPkg/UnitTestFrameworkPkgTarget.dsc.inc
@@ -29,6 +29,20 @@
   UnitTestLib|UnitTestFrameworkPkg/Library/UnitTestLib/UnitTestLib.inf
   UnitTestPersistenceLib|UnitTestFrameworkPkg/Library/UnitTestPersistenceLibNull/UnitTestPersistenceLibNull.inf
   UnitTestResultReportLib|UnitTestFrameworkPkg/Library/UnitTestResultReportLib/UnitTestResultReportLibDebugLib.inf
+
+[LibraryClasses.common.SEC, LibraryClasses.common.PEI_CORE, LibraryClasses.common.PEIM]
+  NULL|UnitTestFrameworkPkg/Library/UnitTestDebugAssertLib/UnitTestDebugAssertLib.inf
+
+[LibraryClasses.common.DXE_CORE, LibraryClasses.common.DXE_DRIVER, LibraryClasses.common.DXE_RUNTIME_DRIVER]
+  NULL|UnitTestFrameworkPkg/Library/UnitTestDebugAssertLib/UnitTestDebugAssertLib.inf
+
+[LibraryClasses.common.SMM_CORE, LibraryClasses.common.DXE_SMM_DRIVER]
+  NULL|UnitTestFrameworkPkg/Library/UnitTestDebugAssertLib/UnitTestDebugAssertLib.inf
+
+[LibraryClasses.common.MM_STANDALONE]
+  NULL|UnitTestFrameworkPkg/Library/UnitTestDebugAssertLib/UnitTestDebugAssertLib.inf
+
+[LibraryClasses.common.UEFI_DRIVER, LibraryClasses.common.UEFI_APPLICATION]
   NULL|UnitTestFrameworkPkg/Library/UnitTestDebugAssertLib/UnitTestDebugAssertLib.inf
 
 [LibraryClasses.ARM, LibraryClasses.AARCH64]


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4683

The main bug is that EDK II CI can miss a unit test failure when
a unit test generates an exception. Addressing this one issue 
required the following chain of changes to the UnitTestFrameworkPkg
that are included in this patch series.

New in v4
==========
* Moved GoogleTestLib.inf /EHsc --> EHs from Patch 2 ->Patch 3
  so the /EHsc change is not mixed with /MT changes in Patch 2.
* Fixed typo in Patch 1 commit message

New in V3
=========
* Add EXPECT_THROW_MESSAGE() and ASSERT_THROW_MESSAGE() to 
  GoogleTestLib.h to simplify unit test case statements testing for 
  an ASSERT() for a specific trigger expressiom. Uncrustify format
  of EXPECT_THAT() with [](){stmt} make code harder to read. Adding
  macros makes the source content in unit test cases match the 
  source style of EXPECT_THROW() statements.
* Update GoogTest samples to use EXPECT_THROW_MESSAGE() instead of 
  EXPECT_THAT().

New in V2
=========
* Include Throws() APIs in GoogleTestLib.h
* Update GoogleTest samples to demonstrate use of EXPECT_THROW()
  and EXPECT_THAT() to test for more specific ASSERT() conditions
  including the ability to verify the specific ASSERT() expression
  that was triggered.

V1
=========
* For host-base VX20xx builds, use release builds by default to
  make sure unexpected exceptions are caught as a test failure.
  Using debug libraries may generate a popup window to prompt 
  running a debugger, which is value for debug, but that mode
  does not generate an error in CI.
* Update UNIT_TEST_DEBUG to enable use of VS20xx debug libraries
  to enable popup windows to run debugger. 
* Remove DebugLib.h internal macro name collision with windows.h
  that was introduced when release libraries are used by default.
* Update MSFT and GCC flags to consistently enable structured 
  exception handling so Google Test host-based unit tests that
  check for expected ASSERT() conditions can be properly detected.
  The additional benefit of this bug fix is that catching thrown
  exceptions is much faster than EXPECT_DEATH() tests. The gtest
  sample unit tests are updated to use ASSERT_ANY_THROW() instead
  of EXPECT_DEATH().
* In order to catch C++ exceptions for google test, the 
  UnitTestDebugAssertLib has to be split into a target version
  and a host version and had to be able to detect the difference
  between cmock host-based tests and gtest host-based tests. This
  required minor changes to the UnitTestLib to be able to use the
  UnitTestLib GetFrameworkHandle() API to make that determination.
  It is NULL for gtest and non-NULL for cmocka.
* In order to test the unit test failing conditions, unit tests
  the fail on purpose and unit tests that generate exceptions are
  added.  These are not added to CI because that would cause CI to
  always fail. Instead, they can be run to make sure that reports
  generated provide the right level of detail for a developer to
  quickly identify the source of the unit test failure or the 
  source of the exception.

Cc: Michael Kubacki [mikuback@linux.microsoft.com](mailto:mikuback@linux.microsoft.com)
Cc: Sean Brogan [sean.brogan@microsoft.com](mailto:sean.brogan@microsoft.com)
Cc: Liming Gao [gaoliming@byosoft.com.cn](mailto:gaoliming@byosoft.com.cn)
Cc: Zhiguang Liu [zhiguang.liu@intel.com](mailto:zhiguang.liu@intel.com)
Cc: Andrew Fish [afish@apple.com](mailto:afish@apple.com)
Cc: Leif Lindholm [quic_llindhol@quicinc.com](mailto:quic_llindhol@quicinc.com)
Signed-off-by: Michael D Kinney [michael.d.kinney@intel.com](mailto:michael.d.kinney@intel.com)
