### PR TITLE
MdePkg: Add SynchronizationLib to MdeLibs.dsc.inc

### DIFF
--- a/MdePkg/MdeLibs.dsc.inc
+++ b/MdePkg/MdeLibs.dsc.inc
@@ -17,3 +17,4 @@
   CpuLib|MdePkg/Library/BaseCpuLib/BaseCpuLib.inf
   SmmCpuRendezvousLib|MdePkg/Library/SmmCpuRendezvousLibNull/SmmCpuRendezvousLibNull.inf
   SafeIntLib|MdePkg/Library/BaseSafeIntLib/BaseSafeIntLib.inf
+  SynchronizationLib|MdePkg/Library/BaseSynchronizationLib/BaseSynchronizationLib.inf


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4675

Add library mapping for the SynchrnizationLib to MdeLibs.dsc.inc to resolve build failures in the FmpDevicePkg and NetworkPkg for missing library mapping.

The following email details why this was missed by EDK II CI

* https://edk2.groups.io/g/devel/message/115185

Local builds of all packages that use -D CONTINUOUS_INTEGRATION were performed to verify that this change resolves the missing library mapping.

Cc: Andrew Fish <afish@apple.com>
Cc: Leif Lindholm <quic_llindhol@quicinc.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Zhiguang Liu <zhiguang.liu@intel.com>
Cc: Wei6 Xu <wei6.xu@intel.com>
Cc: Saloni Kasbekar <saloni.kasbekar@intel.com>
Cc: Zachary Clark-williams <zachary.clark-williams@intel.com>