### PR TITLE
[CI Check]MdeModulePkg: Remove ArmPkg Dependency

### DIFF
--- a/MdeModulePkg/MdeModulePkg.ci.yaml
+++ b/MdeModulePkg/MdeModulePkg.ci.yaml
@@ -53,8 +53,7 @@
         "AcceptableDependencies": [
             "MdePkg/MdePkg.dec",
             "MdeModulePkg/MdeModulePkg.dec",
-            "StandaloneMmPkg/StandaloneMmPkg.dec",
-            "ArmPkg/ArmPkg.dec"  # this should be fixed by promoting an abstraction
+            "StandaloneMmPkg/StandaloneMmPkg.dec"
         ],
         # For host based unit tests
         "AcceptableDependencies-HOST_APPLICATION":[

--- a/MdeModulePkg/MdeModulePkg.dsc
+++ b/MdeModulePkg/MdeModulePkg.dsc
@@ -179,8 +179,6 @@
   MemLib|StandaloneMmPkg/Library/StandaloneMmMemLib/StandaloneMmMemLib.inf
 
 [LibraryClasses.ARM, LibraryClasses.AARCH64]
-  ArmLib|ArmPkg/Library/ArmLib/ArmBaseLib.inf
-  ArmMmuLib|ArmPkg/Library/ArmMmuLib/ArmMmuBaseLib.inf
   LockBoxLib|MdeModulePkg/Library/LockBoxNullLib/LockBoxNullLib.inf
 
   #


### PR DESCRIPTION
With https://github.com/tianocore/edk2/commit/a21a994f55e53325d3e060c435ca3a87fd7c2c79#diff-fa3db962f72224d05dbfc962b3721a700557fd20ad48f9478bff6da40eb1a06b MdeModulePkg no longer has a hard dependency on ArmMmuLib and therefore ArmLib. This is the final dependency on ArmPkg, so removed the unused libs and drop the allowed dependency on ArmPkg as MdeModulePkg should not depend on it.