### PR TITLE
EmbeddedPkg: compiler error due to arithmetic operation on void pointer

### DIFF
--- a/EmbeddedPkg/Library/PrePiMemoryAllocationLib/MemoryAllocationLib.c
+++ b/EmbeddedPkg/Library/PrePiMemoryAllocationLib/MemoryAllocationLib.c
@@ -308,7 +308,7 @@ ReallocatePool (
   if (OldBuffer != NULL) {
     HandOffHob = GetHobList ();
     ASSERT (((EFI_PHYSICAL_ADDRESS)(UINTN)OldBuffer >= HandOffHob->EfiMemoryBottom));
-    ASSERT (((EFI_PHYSICAL_ADDRESS)(UINTN)(OldBuffer + OldSize) <= HandOffHob->EfiFreeMemoryBottom));
+    ASSERT (((EFI_PHYSICAL_ADDRESS)((UINTN)OldBuffer + OldSize) <= HandOffHob->EfiFreeMemoryBottom));
   }
 
   DEBUG_CODE_END ();


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4668

This commit fixes the issue reported in the BZ4668. The EmbeddedPkg fails to compile with a compiler error generated due to invalid/illegal arithmetic operation on void pointers. It has been fixed by using explicit type conversion of the void pointer to UINTN.

Cc: Rebecca Cran <rebecca@bsdio.com>
Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Laszlo Ersek <lersek@redhat.com>
Cc: Leif Lindholm <quic_llindhol@quicinc.com>
Cc: Ard Biesheuvel <ardb+tianocore@kernel.org>
Cc: Abner Chang <abner.chang@amd.com>
Cc: Jayaprakash N <n.jayaprakash@intel.com>

Reviewed-by: Laszlo Ersek <lersek@redhat.com>
Reviewed-by: Ard Biesheuvel <ardb+tianocore@kernel.org>
Acked-by: Michael D Kinney <michael.d.kinney@intel.com>