### PR TITLE
BaseTools/Scripts: Update PatchCheck.py Author checks

### DIFF
--- a/BaseTools/Scripts/PatchCheck.py
+++ b/BaseTools/Scripts/PatchCheck.py
@@ -85,7 +85,11 @@ class EmailAddressCheck:
             self.error("The email address cannot contain a space: " +
                        mo.group(3))
 
-        if ' via Groups.Io' in name and mo.group(3).endswith('@groups.io'):
+        if mo.group(3) == 'devel@edk2.groups.io':
+            self.error("Email rewritten by lists DMARC / DKIM / SPF: " +
+                       email)
+
+        if ' via groups.io' in name.lower() and mo.group(3).endswith('@groups.io'):
             self.error("Email rewritten by lists DMARC / DKIM / SPF: " +
                        email)
 


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4680

* Reject patches that match Author email "devel@edk2.groups.io"
* Update the current check for " via Groups.Io" to perform a case insensitive match. It appears that groups.io has changed the format of this string to use all lower case.

Cc: Rebecca Cran <rebecca@bsdio.com> [bcran]
Cc: Liming Gao <gaoliming@byosoft.com.cn> [lgao4]
Cc: Bob Feng <bob.c.feng@intel.com> [BobCF]
Cc: Yuwei Chen <yuwei.chen@intel.com> [YuweiChen1110]