### PR TITLE
Bug 4673 network pkg dhcp6 dxe advertise message parsing

### DIFF
--- a/NetworkPkg/Dhcp6Dxe/Dhcp6Io.c
+++ b/NetworkPkg/Dhcp6Dxe/Dhcp6Io.c
@@ -528,13 +528,23 @@ Dhcp6UpdateIaInfo (
 {
   EFI_STATUS  Status;
   UINT8       *Option;
+  UINT32      OptionLen;
   UINT8       *IaInnerOpt;
   UINT16      IaInnerLen;
   UINT16      StsCode;
   UINT32      T1;
   UINT32      T2;
 
+  T1 = 0;
+  T2 = 0;
+
   ASSERT (Instance->Config != NULL);
+
+  // OptionLen is the length of the Options excluding the DHCP header.
+  // Length of the EFI_DHCP6_PACKET from the first byte of the Header field to the last
+  // byte of the Option[] field.
+  OptionLen = Packet->Length - sizeof (Packet->Dhcp6.Header);
+
   //
   // If the reply was received in response to a solicit with rapid commit option,
   // request, renew or rebind message, the client updates the information it has
@@ -549,12 +559,28 @@ Dhcp6UpdateIaInfo (
   //
   Option = Dhcp6SeekIaOption (
              Packet->Dhcp6.Option,
-             Packet->Length - sizeof (EFI_DHCP6_HEADER),
+             OptionLen,
              &Instance->Config->IaDescriptor
              );
   if (Option == NULL) {
     return EFI_DEVICE_ERROR;
   }
+
+  //
+  // Calculate the distance from Packet->Dhcp6.Option to the IA option.
+  //
+  // Packet->Size and Packet->Length are both UINT32 type, and Packet->Size is
+  // the size of the whole packet, including the DHCP header, and Packet->Length
+  // is the length of the DHCP message body, excluding the DHCP header.
+  //
+  // (*Option - Packet->Dhcp6.Option) is the number of bytes from the start of
+  // DHCP6 option area to the start of the IA option.
+  //
+  // Dhcp6SeekInnerOptionSafe() is searching starting from the start of the
+  // IA option to the end of the DHCP6 option area, thus subtract the space
+  // up until this option
+  //
+  OptionLen = OptionLen - (UINT32)(Option - Packet->Dhcp6.Option);
 
   //
   // The format of the IA_NA option is:
@@ -591,32 +617,32 @@ Dhcp6UpdateIaInfo (
   //
 
   //
-  // sizeof (option-code + option-len + IaId)           = 8
-  // sizeof (option-code + option-len + IaId + T1)      = 12
-  // sizeof (option-code + option-len + IaId + T1 + T2) = 16
+  // Seek the inner option
   //
-  // The inner options still start with 2 bytes option-code and 2 bytes option-len.
-  //
+  if (EFI_ERROR (
+        Dhcp6SeekInnerOptionSafe (
+          Instance->Config->IaDescriptor.Type,
+          Option,
+          OptionLen,
+          &IaInnerOpt,
+          &IaInnerLen
+          )
+        ))
+  {
+    return EFI_DEVICE_ERROR;
+  }
+
   if (Instance->Config->IaDescriptor.Type == Dhcp6OptIana) {
     T1 = NTOHL (ReadUnaligned32 ((UINT32 *)(DHCP6_OFFSET_OF_IA_NA_T1 (Option))));
     T2 = NTOHL (ReadUnaligned32 ((UINT32 *)(DHCP6_OFFSET_OF_IA_NA_T2 (Option))));
     //
     // Refer to RFC3155 Chapter 22.4. If a client receives an IA_NA with T1 greater than T2,
     // and both T1 and T2 are greater than 0, the client discards the IA_NA option and processes
-    // the remainder of the message as though the server had not  included the invalid IA_NA option.
+    // the remainder of the message as though the server had not included the invalid IA_NA option.
     //
     if ((T1 > T2) && (T2 > 0)) {
       return EFI_DEVICE_ERROR;
     }
-
-    IaInnerOpt = DHCP6_OFFSET_OF_IA_NA_INNER_OPT (Option);
-    IaInnerLen = (UINT16)(NTOHS (ReadUnaligned16 ((UINT16 *)(DHCP6_OFFSET_OF_OPT_LEN (Option)))) - DHCP6_SIZE_OF_COMBINED_IAID_T1_T2);
-  } else {
-    T1 = 0;
-    T2 = 0;
-
-    IaInnerOpt = DHCP6_OFFSET_OF_IA_TA_INNER_OPT (Option);
-    IaInnerLen = (UINT16)(NTOHS (ReadUnaligned16 ((UINT16 *)(DHCP6_OFFSET_OF_OPT_LEN (Option)))) - DHCP6_SIZE_OF_IAID);
   }
 
   //
@@ -642,7 +668,7 @@ Dhcp6UpdateIaInfo (
   Option  = Dhcp6SeekOption (IaInnerOpt, IaInnerLen, Dhcp6OptStatusCode);
 
   if (Option != NULL) {
-    StsCode = NTOHS (ReadUnaligned16 ((UINT16 *)(DHCP6_OFFSET_OF_OPT_LEN (Option))));
+    StsCode = NTOHS (ReadUnaligned16 ((UINT16 *)(DHCP6_OFFSET_OF_STATUS_CODE (Option))));
     if (StsCode != Dhcp6StsSuccess) {
       return EFI_DEVICE_ERROR;
     }
@@ -703,15 +729,21 @@ Dhcp6SeekInnerOptionSafe (
   }
 
   if (IaType == Dhcp6OptIana) {
+    //
     // Verify we have a fully formed IA_NA
+    //
     if (OptionLen < DHCP6_MIN_SIZE_OF_IA_NA) {
       return EFI_DEVICE_ERROR;
     }
 
     //
+    // Get the IA Inner Option and Length
+    //
     IaInnerOptTmp = DHCP6_OFFSET_OF_IA_NA_INNER_OPT (Option);
 
+    //
     // Verify the IaInnerLen is valid.
+    //
     IaInnerLenTmp = (UINT16)NTOHS (ReadUnaligned16 ((UINT16 *)DHCP6_OFFSET_OF_OPT_LEN (Option)));
     if (IaInnerLenTmp < DHCP6_SIZE_OF_COMBINED_IAID_T1_T2) {
       return EFI_DEVICE_ERROR;
@@ -719,14 +751,18 @@ Dhcp6SeekInnerOptionSafe (
 
     IaInnerLenTmp -= DHCP6_SIZE_OF_COMBINED_IAID_T1_T2;
   } else if (IaType == Dhcp6OptIata) {
+    //
     // Verify the OptionLen is valid.
+    //
     if (OptionLen < DHCP6_MIN_SIZE_OF_IA_TA) {
       return EFI_DEVICE_ERROR;
     }
 
     IaInnerOptTmp = DHCP6_OFFSET_OF_IA_TA_INNER_OPT (Option);
 
+    //
     // Verify the IaInnerLen is valid.
+    //
     IaInnerLenTmp = (UINT16)NTOHS (ReadUnaligned16 ((UINT16 *)(DHCP6_OFFSET_OF_OPT_LEN (Option))));
     if (IaInnerLenTmp < DHCP6_SIZE_OF_IAID) {
       return EFI_DEVICE_ERROR;

--- a/NetworkPkg/Dhcp6Dxe/Dhcp6Io.h
+++ b/NetworkPkg/Dhcp6Dxe/Dhcp6Io.h
@@ -217,4 +217,26 @@ Dhcp6OnTimerTick (
   IN VOID       *Context
   );
 
+/**
+  Seeks the Inner Options from a DHCP6 Option
+
+  @param[in]  IaType          The type of the IA option.
+  @param[in]  Option          The pointer to the DHCP6 Option.
+  @param[in]  OptionLen       The length of the DHCP6 Option.
+  @param[out] IaInnerOpt      The pointer to the IA inner option.
+  @param[out] IaInnerLen      The length of the IA inner option.
+
+  @retval EFI_SUCCESS         Seek the inner option successfully.
+  @retval EFI_DEVICE_ERROR    The OptionLen is invalid. On Error,
+                              the pointers are not modified
+**/
+EFI_STATUS
+Dhcp6SeekInnerOptionSafe (
+  IN  UINT16  IaType,
+  IN  UINT8   *Option,
+  IN  UINT32  OptionLen,
+  OUT UINT8   **IaInnerOpt,
+  OUT UINT16  *IaInnerLen
+  );
+
 #endif

--- a/NetworkPkg/Dhcp6Dxe/Dhcp6Utility.c
+++ b/NetworkPkg/Dhcp6Dxe/Dhcp6Utility.c
@@ -10,6 +10,16 @@
 
 #include "Dhcp6Impl.h"
 
+//
+// Verifies the packet cursor is within the packet
+// otherwise it is invalid
+//
+#define IS_INVALID_PACKET_CURSOR(PacketCursor, Packet) \
+  (((*PacketCursor) < (Packet)->Dhcp6.Option) || \
+   ((*PacketCursor) >= (Packet)->Dhcp6.Option + ((Packet)->Size - sizeof(EFI_DHCP6_HEADER))) \
+  )                                                                            \
+
+
 /**
   Generate client Duid in the format of Duid-llt.
 
@@ -638,9 +648,7 @@ Dhcp6AppendOption (
   //
   // Verify the PacketCursor is within the packet
   //
-  if (  (*PacketCursor < Packet->Dhcp6.Option)
-     || (*PacketCursor >= Packet->Dhcp6.Option + (Packet->Size - sizeof (EFI_DHCP6_HEADER))))
-  {
+  if (IS_INVALID_PACKET_CURSOR (PacketCursor, Packet)) {
     return EFI_INVALID_PARAMETER;
   }
 
@@ -655,15 +663,6 @@ Dhcp6AppendOption (
   Length = Packet->Size - Packet->Length;
   if (Length < BytesNeeded) {
     return EFI_BUFFER_TOO_SMALL;
-  }
-
-  //
-  // Verify the PacketCursor is within the packet
-  //
-  if (  (*PacketCursor < Packet->Dhcp6.Option)
-     || (*PacketCursor >= Packet->Dhcp6.Option + (Packet->Size - sizeof (EFI_DHCP6_HEADER))))
-  {
-    return EFI_INVALID_PARAMETER;
   }
 
   WriteUnaligned16 ((UINT16 *)*PacketCursor, OptType);
@@ -744,9 +743,7 @@ Dhcp6AppendIaAddrOption (
   //
   // Verify the PacketCursor is within the packet
   //
-  if (  (*PacketCursor < Packet->Dhcp6.Option)
-     || (*PacketCursor >= Packet->Dhcp6.Option + (Packet->Size - sizeof (EFI_DHCP6_HEADER))))
-  {
+  if (IS_INVALID_PACKET_CURSOR (PacketCursor, Packet)) {
     return EFI_INVALID_PARAMETER;
   }
 
@@ -877,9 +874,7 @@ Dhcp6AppendIaOption (
   //
   // Verify the PacketCursor is within the packet
   //
-  if (  (*PacketCursor < Packet->Dhcp6.Option)
-     || (*PacketCursor >= Packet->Dhcp6.Option + (Packet->Size - sizeof (EFI_DHCP6_HEADER))))
-  {
+  if (IS_INVALID_PACKET_CURSOR (PacketCursor, Packet)) {
     return EFI_INVALID_PARAMETER;
   }
 
@@ -941,14 +936,14 @@ Dhcp6AppendIaOption (
   }
 
   //
-  // Fill the value of Ia option length
-  //
-  *Len = HTONS ((UINT16)(*PacketCursor - (UINT8 *)Len - 2));
-
-  //
   // Update the packet length
   //
   Packet->Length += BytesNeeded;
+
+  //
+  // Fill the value of Ia option length
+  //
+  *Len = HTONS ((UINT16)(*PacketCursor - (UINT8 *)Len - 2));
 
   return EFI_SUCCESS;
 }
@@ -957,6 +952,7 @@ Dhcp6AppendIaOption (
   Append the appointed Elapsed time option to Buf, and move Buf to the end.
 
   @param[in, out] Packet        A pointer to the packet, on success Packet->Length
+                                will be updated.
   @param[in, out] PacketCursor  The pointer in the packet, on success PacketCursor
                                 will be moved to the end of the option.
   @param[in]      Instance      The pointer to the Dhcp6 instance.
@@ -1012,9 +1008,7 @@ Dhcp6AppendETOption (
   //
   // Verify the PacketCursor is within the packet
   //
-  if (  (*PacketCursor < Packet->Dhcp6.Option)
-     || (*PacketCursor >= Packet->Dhcp6.Option + (Packet->Size - sizeof (EFI_DHCP6_HEADER))))
-  {
+  if (IS_INVALID_PACKET_CURSOR (PacketCursor, Packet)) {
     return EFI_INVALID_PARAMETER;
   }
 

--- a/NetworkPkg/Dhcp6Dxe/Dhcp6Utility.c
+++ b/NetworkPkg/Dhcp6Dxe/Dhcp6Utility.c
@@ -925,6 +925,11 @@ Dhcp6AppendIaOption (
   }
 
   //
+  // Update the packet length
+  //
+  Packet->Length += BytesNeeded;
+
+  //
   // Fill all the addresses belong to the Ia
   //
   for (Index = 0; Index < Ia->IaAddressCount; Index++) {
@@ -934,11 +939,6 @@ Dhcp6AppendIaOption (
       return Status;
     }
   }
-
-  //
-  // Update the packet length
-  //
-  Packet->Length += BytesNeeded;
 
   //
   // Fill the value of Ia option length

--- a/NetworkPkg/SecurityFixes.yaml
+++ b/NetworkPkg/SecurityFixes.yaml
@@ -8,6 +8,7 @@ CVE_2023_45229:
   commit_titles:
     - "NetworkPkg: Dhcp6Dxe: SECURITY PATCH CVE-2023-45229 Patch"
     - "NetworkPkg: Dhcp6Dxe: SECURITY PATCH CVE-2023-45229 Unit Tests"
+    - "NetworkPkg: Dhcp6Dxe: SECURITY PATCH CVE-2023-45229 Related Patch"
   cve: CVE-2023-45229
   date_reported: 2023-08-28 13:56 UTC
   description: "Bug 01 - edk2/NetworkPkg: Out-of-bounds read when processing IA_NA/IA_TA options in a DHCPv6 Advertise message"


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4673

This patch series corrects an additional security concern
found in Dhc6Dxe related to CVE-2023-45229. 

Additionally this fixes some issues on the mailing list
that were not pulled in before merging into Edk2.

Cc: Saloni Kasbekar <[saloni.kasbekar@intel.com](mailto:saloni.kasbekar@intel.com)>
Cc: Zachary Clark-williams <[zachary.clark-williams@intel.com](mailto:zachary.clark-williams@intel.com)>
Cc: Andrew Fish <[afish@apple.com](mailto:afish@apple.com)>
Cc: Leif Lindholm <[quic_llindhol@quicinc.com](mailto:quic_llindhol@quicinc.com)>
Cc: Michael D Kinney <[michael.d.kinney@intel.com](mailto:michael.d.kinney@intel.com)>
Signed-off-by: Doug Flick [MSFT] <[doug.edk2@gmail.com](mailto:doug.edk2@gmail.com)>