### PR TITLE
Bug 4682 uefi cpu pkg pi smm cpu dxe smm fix null deref

### DIFF
--- a/UefiCpuPkg/PiSmmCpuDxeSmm/PiSmmCpuDxeSmm.c
+++ b/UefiCpuPkg/PiSmmCpuDxeSmm/PiSmmCpuDxeSmm.c
@@ -1146,6 +1146,13 @@ PiCpuSmmEntry (
     // When the HOB doesn't exist, allocate new SMBASE itself.
     //
     DEBUG ((DEBUG_INFO, "PiCpuSmmEntry: gSmmBaseHobGuid not found!\n"));
+
+    mCpuHotPlugData.SmBase = (UINTN *)AllocatePool (sizeof (UINTN) * mMaxNumberOfCpus);
+    if (mCpuHotPlugData.SmBase == NULL) {
+      ASSERT (mCpuHotPlugData.SmBase != NULL);
+      CpuDeadLoop ();
+    }
+
     //
     // very old processors (i486 + pentium) need 32k not 4k alignment, exclude them.
     //


### PR DESCRIPTION
Ref: https://bugzilla.tianocore.org/show_bug.cgi?id=4682

Commit 725acd0b9cc0 ("UefiCpuPkg: Avoid assuming only one smmbasehob",
2023-12-12) introduced a NULL pointer dereference to PiSmmCpuDxeSmm on
such platforms that do not produce the "gSmmBaseHobGuid" GUID HOB at
all.

Please see the multi-step analysis in the following thread:

  [edk2-devel] [PATCH 1/1] OvmfPkg/QemuVideoDxe: purge VbeShim
  https://edk2.groups.io/g/devel/message/115377
  message-id: <[20240213085925.687848-1-kraxel@redhat.com](mailto:20240213085925.687848-1-kraxel@redhat.com)>

This issue needs to be fixed for edk2-stable202402.

Cc: Dun Tan <[dun.tan@intel.com](mailto:dun.tan@intel.com)>
Cc: Gerd Hoffmann <[kraxel@redhat.com](mailto:kraxel@redhat.com)>
Cc: Liming Gao <[gaoliming@byosoft.com.cn](mailto:gaoliming@byosoft.com.cn)>
Cc: Michael D Kinney <[michael.d.kinney@intel.com](mailto:michael.d.kinney@intel.com)>
Cc: Rahul Kumar <[rahul1.kumar@intel.com](mailto:rahul1.kumar@intel.com)>
Cc: Ray Ni <[ray.ni@intel.com](mailto:ray.ni@intel.com)>