### PR TITLE
Bug 4688 - GetInfo() of Adapter Information Protocol should have a provision for IHV to return no data for UEFI Spec compliance 2.9

### DIFF
--- a/MdePkg/Include/Protocol/AdapterInformation.h
+++ b/MdePkg/Include/Protocol/AdapterInformation.h
@@ -150,6 +150,7 @@ typedef struct {
 
   @retval EFI_SUCCESS                The InformationType information was retrieved.
   @retval EFI_UNSUPPORTED            The InformationType is not known.
+  @retval EFI_NOT_FOUND              Information is not available for the requested information type.
   @retval EFI_DEVICE_ERROR           The device reported an error.
   @retval EFI_OUT_OF_RESOURCES       The request could not be completed due to a lack of resources.
   @retval EFI_INVALID_PARAMETER      This is NULL.


### PR DESCRIPTION
mantis #1866
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4688

Signed-off-by: Gahan Saraiya <gahan.saraiya@intel.com>