### PR TITLE
Bug 4679 4680 4693 4694 patch check updates

### DIFF
--- a/BaseTools/Scripts/PatchCheck.py
+++ b/BaseTools/Scripts/PatchCheck.py
@@ -85,7 +85,11 @@ class EmailAddressCheck:
             self.error("The email address cannot contain a space: " +
                        mo.group(3))
 
-        if ' via Groups.Io' in name and mo.group(3).endswith('@groups.io'):
+        if mo.group(3) == 'devel@edk2.groups.io':
+            self.error("Email rewritten by lists DMARC / DKIM / SPF: " +
+                       email)
+
+        if ' via groups.io' in name.lower() and mo.group(3).endswith('@groups.io'):
             self.error("Email rewritten by lists DMARC / DKIM / SPF: " +
                        email)
 

--- a/BaseTools/Scripts/PatchCheck.py
+++ b/BaseTools/Scripts/PatchCheck.py
@@ -202,7 +202,7 @@ class CommitMessageCheck:
             if s[2] != ' ':
                 self.error("There should be a space after '" + sig + ":'")
 
-            EmailAddressCheck(s[3], sig)
+            self.ok &= EmailAddressCheck(s[3], sig).ok
 
         return sigs
 

--- a/BaseTools/Scripts/PatchCheck.py
+++ b/BaseTools/Scripts/PatchCheck.py
@@ -229,8 +229,10 @@ class CommitMessageCheck:
         )
 
     def check_misc_signatures(self):
-        for sig in self.sig_types:
-            self.find_signatures(sig)
+        for sigtype in self.sig_types:
+            sigs = self.find_signatures(sigtype)
+            if sigtype == 'Cc' and len(sigs) == 0:
+                self.error('No Cc: tags for maintainers/reviewers found!')
 
     cve_re = re.compile('CVE-[0-9]{4}-[0-9]{5}[^0-9]')
 


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4679
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4680
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4693
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4694

Fix a collection of PatchCheck issues and add a new PatchCheck
featue to check for a commit that modifies files in multiple
packages with option to disable the multiple package check as
a command line option or a commit message tag.

* Reject patches that match Author email "[devel@edk2.groups.io](mailto:devel@edk2.groups.io)"
* Update the current check for " via Groups.Io" to perform a
  case insensitive match. It appears that groups.io has changed the
  format of this string to use all lower case.
* Update logic in CommitMessageCheck class to return errors
  detected in commit message signatures instead of silently 
  passing the check.
* Genenerate an error if no Cc tags are present to make sure
  all patches Cc the required maintainers/reviewers.

Cc: Rebecca Cran <[rebecca@bsdio.com](mailto:rebecca@bsdio.com)>
Cc: Liming Gao <[gaoliming@byosoft.com.cn](mailto:gaoliming@byosoft.com.cn)>
Cc: Bob Feng <[bob.c.feng@intel.com](mailto:bob.c.feng@intel.com)>
Cc: Yuwei Chen <[yuwei.chen@intel.com](mailto:yuwei.chen@intel.com)>
Cc: Michael Kubacki <[mikuback@linux.microsoft.com](mailto:mikuback@linux.microsoft.com)>
Cc: Ard Biesheuvel <[ardb+tianocore@kernel.org](mailto:ardb+tianocore@kernel.org)>
Cc: Leif Lindholm <[quic_llindhol@quicinc.com](mailto:quic_llindhol@quicinc.com)>
Signed-off-by: Michael D Kinney <[michael.d.kinney@intel.com](mailto:michael.d.kinney@intel.com)>