### PR TITLE
MdeModulePkg/TraceHubDebugSysTLib: Use wider type for loop comparisons

### DIFF
--- a/MdeModulePkg/Library/TraceHubDebugSysTLib/BaseTraceHubDebugSysTLib.c
+++ b/MdeModulePkg/Library/TraceHubDebugSysTLib/BaseTraceHubDebugSysTLib.c
@@ -41,7 +41,7 @@ TraceHubSysTDebugWrite (
   MIPI_SYST_HEADER  MipiSystHeader;
   RETURN_STATUS     Status;
   UINT32            DbgInstCount;
-  UINT16            Index;
+  UINT32            Index;
 
   if (NumberOfBytes == 0) {
     //
@@ -109,7 +109,7 @@ TraceHubSysTWriteCataLog64StatusCode (
   MIPI_SYST_HEADER  MipiSystHeader;
   RETURN_STATUS     Status;
   UINT32            DbgInstCount;
-  UINT16            Index;
+  UINT32            Index;
 
   if (Guid == NULL) {
     return RETURN_INVALID_PARAMETER;

--- a/MdeModulePkg/Library/TraceHubDebugSysTLib/DxeSmmTraceHubDebugSysTLib.c
+++ b/MdeModulePkg/Library/TraceHubDebugSysTLib/DxeSmmTraceHubDebugSysTLib.c
@@ -45,7 +45,7 @@ TraceHubSysTDebugWrite (
   MIPI_SYST_HANDLE  MipiSystHandle;
   MIPI_SYST_HEADER  MipiSystHeader;
   RETURN_STATUS     Status;
-  UINT16            Index;
+  UINT32            Index;
 
   if ((mDbgInstCount == 0) || (mThDebugInstArray == NULL)) {
     return RETURN_ABORTED;

--- a/MdeModulePkg/Library/TraceHubDebugSysTLib/InternalTraceHubApi.c
+++ b/MdeModulePkg/Library/TraceHubDebugSysTLib/InternalTraceHubApi.c
@@ -56,7 +56,7 @@ PackThDebugInstance (
   )
 {
   UINT8   *DbgContext;
-  UINT16  Index;
+  UINT32  Index;
 
   DbgContext = GetFirstGuidHob (&gTraceHubDebugInfoHobGuid);
   if (DbgContext != NULL) {


### PR DESCRIPTION
Resolves a new CodeQL error due to the value being incremented in the
loop being a narrower type than the variable it is being compared
against.

The variable is changed to a UINT32 type so it has the same width as
the type it is being compared against.

Issue explanation: In a loop condition, comparison of a value of a
narrow type with a value of a wide type may result in unexpected
behavior if the wider value is sufficiently large (or small). This
is because the narrower value may overflow. This can lead to an
infinite loop.

Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Gua Guo <gua.guo@intel.com>
Cc: Prakashan Krishnadas Veliyathuparambil <krishnadas.veliyathuparambil.prakashan@intel.com>
Cc: K N Karthik <karthik.k.n@intel.com>
Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>
Reviewed-by: Gua Guo <gua.guo@intel.com>