### PR TITLE
BaseTools/GenFds: Resolve absolute workspace INF paths

### DIFF
--- a/BaseTools/Source/Python/GenFds/FfsInfStatement.py
+++ b/BaseTools/Source/Python/GenFds/FfsInfStatement.py
@@ -19,6 +19,7 @@ from .GenFdsGlobalVariable import GenFdsGlobalVariable
 from .Ffs import SectionSuffix,FdfFvFileTypeToFileType
 import subprocess
 import sys
+from pathlib import Path
 from . import Section
 from . import RuleSimpleFile
 from . import RuleComplexFile
@@ -156,7 +157,12 @@ class FfsInfStatement(FfsInfStatementClassObject):
         if len(self.InfFileName) > 1 and self.InfFileName[0] == '\\' and self.InfFileName[1] == '\\':
             pass
         elif self.InfFileName[0] == '\\' or self.InfFileName[0] == '/' :
-            self.InfFileName = self.InfFileName[1:]
+            ws_path = Path(GenFdsGlobalVariable.WorkSpaceDir)
+            inf_path = Path(self.InfFileName)
+            if ws_path in inf_path.parents:
+                self.InfFileName = str(inf_path.relative_to(ws_path))
+            else:
+                self.InfFileName = self.InfFileName[1:]
 
         if self.InfFileName.find('$') == -1:
             InfPath = NormPath(self.InfFileName)


### PR DESCRIPTION
Currently, if an INF path is an absolute path on Linux (begins with
"/"), the "/" character will be removed. If the path is an absolute
system path, this creates an invalid path.

An example of when this may be an issue is in external dependencies
where an INF is within the external dependency, the `set_build_var`
flag is set, and DSC files refer to files by its build variable
(e.g. `$(SHARED_BINARIES)/Module.inf`). INFs in a binary distribution
like this example may contain a [Binaries] section and refer to
different section files that can be used by a platform to compose an
FFS file. For example, the PE32 (.efi) and DEPEX (.depex) files.

In this case, `$(SHARED_BINARIES)` will be an absolute path to the
ext dep directory and `FfsInfStatement.__InfParse__` will remove the
leading "/" character so the path is invalid.

This change first checks if the absolute path will resolve into the
current workspace. If it does (as will happen in the shared crypto
ext dep example above), it modifies the path to be relative to the
workspace so later logic dependent on relative paths can operate on
it. If the absolute path is not within the current workspace, it
follows previous behavior for backward compatibility to that
scenario.

Cc: Rebecca Cran <rebecca@bsdio.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Bob Feng <bob.c.feng@intel.com>
Cc: Yuwei Chen <yuwei.chen@intel.com>
Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>
Reviewed-by: Rebecca Cran <rebecca@bsdio.com>