### PR TITLE
UefiPayloadPkg: Make UPL build script arch agnostic

### DIFF
--- a/UefiPayloadPkg/Tools/MkFitImage.py
+++ b/UefiPayloadPkg/Tools/MkFitImage.py
@@ -59,16 +59,16 @@ def BuildConfNode(Fdt, ParentNode, MultiImage):
     libfdt.fdt_setprop(Fdt, ConfNode1, 'require-fit', b'', 0)
     libfdt.fdt_setprop(Fdt, ConfNode1, 'firmware', bytes('tianocore', 'utf-8'), len('tianocore') + 1)
 
-def BuildFvImageNode(Fdt, InfoHeader, ParentNode, DataOffset, DataSize, Description):
+def BuildFvImageNode(Fdt, InfoHeader, ParentNode, DataOffset, DataSize, Description, Arch):
     libfdt.fdt_setprop_u32(Fdt, ParentNode, 'data-size', DataSize)
     libfdt.fdt_setprop_u32(Fdt, ParentNode, 'data-offset', DataOffset)
     libfdt.fdt_setprop(Fdt, ParentNode, 'compression', bytes('none',                'utf-8'), len('none') + 1)
     libfdt.fdt_setprop(Fdt, ParentNode, 'project ',    bytes('tianocore',           'utf-8'), len('tianocore') + 1)
-    libfdt.fdt_setprop(Fdt, ParentNode, 'arch',        bytes('x86_64',              'utf-8'), len('x86_64') + 1)
+    libfdt.fdt_setprop(Fdt, ParentNode, 'arch',        bytes(Arch,                  'utf-8'), len(Arch) + 1)
     libfdt.fdt_setprop(Fdt, ParentNode, 'type',        bytes('flat-binary',         'utf-8'), len('flat-binary') + 1)
     libfdt.fdt_setprop(Fdt, ParentNode, 'description', bytes(Description,           'utf-8'), len(Description) + 1)
 
-def BuildTianoImageNode(Fdt, InfoHeader, ParentNode, DataOffset, DataSize, Description):
+def BuildTianoImageNode(Fdt, InfoHeader, ParentNode, DataOffset, DataSize, Description, Arch):
     #
     # Set 'load' and 'data-offset' to reserve the memory first.
     # They would be set again when Fdt completes or this function parses target binary file.
@@ -100,7 +100,7 @@ def BuildTianoImageNode(Fdt, InfoHeader, ParentNode, DataOffset, DataSize, Descr
 #
 # The subnode would be inserted from bottom to top of structure block.
 #
-def BuildFitImage(Fdt, InfoHeader):
+def BuildFitImage(Fdt, InfoHeader, Arch):
     MultiImage = [
         ["tianocore",   InfoHeader.Binary,        BuildTianoImageNode , InfoHeader.Description,     None, 0 ],
         ["uefi-fv",     InfoHeader.UefifvPath,    BuildFvImageNode,     "UEFI Firmware Volume",     None, 0 ],
@@ -143,7 +143,7 @@ def BuildFitImage(Fdt, InfoHeader):
         if os.path.exists (Item[1]) == False:
             continue
         FvNode = libfdt.fdt_add_subnode(Fdt, ImageNode, Name)
-        BuildFvNode (Fdt, InfoHeader, FvNode, DataOffset, len(BinaryData), Description)
+        BuildFvNode (Fdt, InfoHeader, FvNode, DataOffset, len(BinaryData), Description, Arch)
 
     #
     # Create new image file and combine all binary.
@@ -160,7 +160,7 @@ def BuildFitImage(Fdt, InfoHeader):
 
     return True
 
-def MakeFitImage(InfoHeader):
+def MakeFitImage(InfoHeader, Arch):
     #
     # Allocate fdt byte array.
     #
@@ -175,9 +175,9 @@ def MakeFitImage(InfoHeader):
     #
     # Parse args to build fit image.
     #
-    return BuildFitImage(Fdt, InfoHeader)
+    return BuildFitImage(Fdt, InfoHeader, Arch)
 
-def ReplaceFv (UplBinary, SectionFvFile, SectionName):
+def ReplaceFv (UplBinary, SectionFvFile, SectionName, Arch):
     try:
         #
         # Get Original Multi Fv
@@ -231,7 +231,7 @@ def ReplaceFv (UplBinary, SectionFvFile, SectionName):
                 SectionFvFileBinary = File.read ()
             MultiFvList.append ([SectionName, SectionFvFileBinary])
             FvNode = libfdt.fdt_add_subnode(NewFitHeader, ImagesNode, SectionName)
-            BuildFvImageNode (NewFitHeader, None, FvNode, FitSize, len(SectionFvFileBinary), SectionName + " Firmware Volume")
+            BuildFvImageNode (NewFitHeader, None, FvNode, FitSize, len(SectionFvFileBinary), SectionName + " Firmware Volume", Arch)
             FitSize += len(SectionFvFileBinary)
         else:
             for Index in range (0, len (MultiFvList)):

--- a/UefiPayloadPkg/UefiPayloadPkg.dsc
+++ b/UefiPayloadPkg/UefiPayloadPkg.dsc
@@ -22,7 +22,7 @@
   SUPPORTED_ARCHITECTURES             = IA32|X64
   BUILD_TARGETS                       = DEBUG|RELEASE|NOOPT
   SKUID_IDENTIFIER                    = DEFAULT
-  OUTPUT_DIRECTORY                    = Build/UefiPayloadPkgX64
+  OUTPUT_DIRECTORY                    = Build/UefiPayloadPkg$(ARCH)
   FLASH_DEFINITION                    = UefiPayloadPkg/UefiPayloadPkg.fdf
   PCD_DYNAMIC_AS_DYNAMICEX            = TRUE
 

--- a/UefiPayloadPkg/UniversalPayloadBuild.py
+++ b/UefiPayloadPkg/UniversalPayloadBuild.py
@@ -125,17 +125,26 @@ def BuildUniversalPayload(Args):
         Args.Macro.append("UNIVERSAL_PAYLOAD_FORMAT=ELF")
         UpldEntryFile = "UniversalPayloadEntry"
 
-    BuildDir     = os.path.join(os.environ['WORKSPACE'], os.path.normpath("Build/UefiPayloadPkgX64"))
+    BuildDir     = os.path.join(os.environ['WORKSPACE'], os.path.normpath("Build/UefiPayloadPkg"))
+    BuildDirWithArch = BuildDir + Args.Arch
+    print(BuildDir)
     if Args.Arch == 'X64':
         BuildArch      = "X64"
         FitArch        = "x86_64"
         ObjCopyFlag    = "elf64-x86-64"
-        EntryOutputDir = os.path.join(BuildDir, "{}_{}".format (BuildTarget, PayloadEntryToolChain), os.path.normpath("X64/UefiPayloadPkg/UefiPayloadEntry/{}/DEBUG/{}.dll".format (UpldEntryFile, UpldEntryFile)))
-    else:
+        EntryOutputDir = os.path.join(BuildDirWithArch, "{}_{}".format (BuildTarget, PayloadEntryToolChain), os.path.normpath("X64/UefiPayloadPkg/UefiPayloadEntry/{}/DEBUG/{}.dll".format (UpldEntryFile, UpldEntryFile)))
+    elif Args.Arch == 'IA32':
         BuildArch      = "IA32 -a X64"
         FitArch        = "x86"
         ObjCopyFlag    = "elf32-i386"
-        EntryOutputDir = os.path.join(BuildDir, "{}_{}".format (BuildTarget, PayloadEntryToolChain), os.path.normpath("IA32/UefiPayloadPkg/UefiPayloadEntry/{}/DEBUG/{}.dll".format (UpldEntryFile, UpldEntryFile)))
+        EntryOutputDir = os.path.join(BuildDirWithArch, "{}_{}".format (BuildTarget, PayloadEntryToolChain), os.path.normpath("IA32/UefiPayloadPkg/UefiPayloadEntry/{}/DEBUG/{}.dll".format (UpldEntryFile, UpldEntryFile)))
+    elif Args.Arch == 'RISCV64':
+        BuildArch      = "RISCV64"
+        FitArch        = "RISCV64"
+        ObjCopyFlag    = "rv64"
+        EntryOutputDir = os.path.join(BuildDirWithArch, "{}_{}".format (BuildTarget, PayloadEntryToolChain), os.path.normpath("RISCV64/UefiPayloadPkg/UefiPayloadEntry/{}/DEBUG/{}.dll".format (UpldEntryFile, UpldEntryFile)))
+    else:
+        print("Incorrect arch option provided")
 
     EntryModuleInf = os.path.normpath("UefiPayloadPkg/UefiPayloadEntry/{}.inf".format (UpldEntryFile))
     DscPath = os.path.normpath("UefiPayloadPkg/UefiPayloadPkg.dsc")
@@ -160,7 +169,7 @@ def BuildUniversalPayload(Args):
     # Building DXE core and DXE drivers as DXEFV.
     #
     if Args.BuildEntryOnly == False:
-        BuildPayload = "build -p {} -b {} -a X64 -t {} -y {} {}".format (DscPath, BuildTarget, ToolChain, PayloadReportPath, Quiet)
+        BuildPayload = "build -p {} -b {} -a {} -t {} -y {} {}".format (DscPath, BuildTarget, BuildArch, ToolChain, PayloadReportPath, Quiet)
         BuildPayload += Pcds
         BuildPayload += Defines
         RunCommand(BuildPayload)
@@ -292,7 +301,7 @@ def BuildUniversalPayload(Args):
         fit_image_info_header.DataSize   = TianoEntryBinarySize
         fit_image_info_header.Binary     = TargetRebaseEntryFile
 
-        if MkFitImage.MakeFitImage(fit_image_info_header) is True:
+        if MkFitImage.MakeFitImage(fit_image_info_header, Args.Arch) is True:
             print('\nSuccessfully build Fit Image')
         else:
             sys.exit(1)
@@ -304,7 +313,7 @@ def main():
     parser = argparse.ArgumentParser(description='For building Universal Payload')
     parser.add_argument('-t', '--ToolChain')
     parser.add_argument('-b', '--Target', default='DEBUG')
-    parser.add_argument('-a', '--Arch', choices=['IA32', 'X64'], help='Specify the ARCH for payload entry module. Default build X64 image.', default ='X64')
+    parser.add_argument('-a', '--Arch', choices=['IA32', 'X64', 'RISCV64'], help='Specify the ARCH for payload entry module. Default build X64 image.', default ='X64')
     parser.add_argument("-D", "--Macro", action="append", default=["UNIVERSAL_PAYLOAD=TRUE"])
     parser.add_argument('-i', '--ImageId', type=str, help='Specify payload ID (16 bytes maximal).', default ='UEFI')
     parser.add_argument('-q', '--Quiet', action='store_true', help='Disable all build messages except FATAL ERRORS.')
@@ -331,14 +340,14 @@ def main():
         for (SectionName, SectionFvFile) in args.AddFv:
             MultiFvList.append ([SectionName, SectionFvFile])
 
-    def ReplaceFv (UplBinary, SectionFvFile, SectionName):
+    def ReplaceFv (UplBinary, SectionFvFile, SectionName, Arch):
         print (bcolors.OKGREEN + "Patch {}={} into {}".format (SectionName, SectionFvFile, UplBinary) + bcolors.ENDC)
         if (args.Fit == False):
             import Tools.ElfFv as ElfFv
             return ElfFv.ReplaceFv (UplBinary, SectionFvFile, '.upld.{}'.format (SectionName))
         else:
             import Tools.MkFitImage as MkFitImage
-            return MkFitImage.ReplaceFv (UplBinary, SectionFvFile, SectionName)
+            return MkFitImage.ReplaceFv (UplBinary, SectionFvFile, SectionName, Arch)
 
     if (UniversalPayloadBinary != None):
         for (SectionName, SectionFvFile) in MultiFvList:
@@ -347,7 +356,7 @@ def main():
             if (args.Fit == False):
                 status = ReplaceFv (UniversalPayloadBinary, SectionFvFile, SectionName)
             else:
-                status = ReplaceFv (UniversalPayloadBinary, SectionFvFile, SectionName.replace ("_", "-"))
+                status = ReplaceFv (UniversalPayloadBinary, SectionFvFile, SectionName.replace ("_", "-"), args.Arch)
             if status != 0:
                 print (bcolors.FAIL + "[Fail] Patch {}={}".format (SectionName, SectionFvFile) + bcolors.ENDC)
                 return status


### PR DESCRIPTION
Current implementation makes assumptions about arch it will be built for. Need to make it more generic to add follow up support for RISCV. Right now it does not build for RV until relevant dsc file is available.

Cc: Guo Dong <guo.dong@intel.com>
Cc: Sean Rhodes <sean@starlabs.systems>
Cc: James Lu <james.lu@intel.com>
Cc: Gua Guo <gua.guo@intel.com>