### PR TITLE
BdsDxe: Add pcd Boot0000

### DIFF
--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -2167,6 +2167,10 @@
   # @Prompt The value is use for Usb Network rate limiting supported.
   gEfiMdeModulePkgTokenSpaceGuid.PcdUsbNetworkRateLimitingFactor|100|UINT32|0x10000028
 
+  ## Indicate the first boot entry, does not set bootorder
+  # @Prompt First boot entry.
+  gEfiMdeModulePkgTokenSpaceGuid.PcdPlatformBootBoot0000|L""|VOID*|0x0000012e
+
 [PcdsPatchableInModule]
   ## Specify memory size with page number for PEI code when
   #  Loading Module at Fixed Address feature is enabled.

--- a/MdeModulePkg/Universal/BdsDxe/BdsDxe.inf
+++ b/MdeModulePkg/Universal/BdsDxe/BdsDxe.inf
@@ -98,6 +98,7 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdTestKeyUsed                       ## CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdCapsuleOnDiskSupport              ## CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdPlatformRecoverySupport           ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdPlatformBootBoot0000              ## CONSUMES
 
 [Depex]
   TRUE


### PR DESCRIPTION
When building existing platforms descriptions, it is hard for a user to choose a default boot option at build time.
This patch adds a Pcd that set Boot0000 in the early boot. This does not change BootOrder, so the BootOrder can still be overriden with NVData.

Example:
'--pcd=gEfiMdeModulePkgTokenSpaceGuid.PcdPlatformBootBoot0000=Lshell.efi' will boot a newly flashed device to the shell.