### PR TITLE
MdePkg/SmBios.h: Add New ProcessorFamily definitions for SMBIOS Type4

### DIFF
--- a/MdePkg/Include/IndustryStandard/SmBios.h
+++ b/MdePkg/Include/IndustryStandard/SmBios.h
@@ -1,7 +1,7 @@
 /** @file
-  Industry Standard Definitions of SMBIOS Table Specification v3.7.0.
+  Industry Standard Definitions of SMBIOS Table Specification v3.8.0.
 
-Copyright (c) 2006 - 2023, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2006 - 2024, Intel Corporation. All rights reserved.<BR>
 (C) Copyright 2015-2017 Hewlett Packard Enterprise Development LP<BR>
 (C) Copyright 2015 - 2019 Hewlett Packard Enterprise Development LP<BR>
 Copyright (c) 2022, AMD Incorporated. All rights reserved.<BR>
@@ -774,7 +774,15 @@ typedef enum {
   ProcessorFamilyQuadCoreLoongson3B  = 0x026E,
   ProcessorFamilyMultiCoreLoongson3B = 0x026F,
   ProcessorFamilyMultiCoreLoongson3C = 0x0270,
-  ProcessorFamilyMultiCoreLoongson3D = 0x0271
+  ProcessorFamilyMultiCoreLoongson3D = 0x0271,
+  ProcessorFamilyIntelCore3          = 0x0300,
+  ProcessorFamilyIntelCore5          = 0x0301,
+  ProcessorFamilyIntelCore7          = 0x0302,
+  ProcessorFamilyIntelCore9          = 0x0303,
+  ProcessorFamilyIntelCoreUltra3     = 0x0304,
+  ProcessorFamilyIntelCoreUltra5     = 0x0305,
+  ProcessorFamilyIntelCoreUltra7     = 0x0306,
+  ProcessorFamilyIntelCoreUltra9     = 0x0307
 } PROCESSOR_FAMILY2_DATA;
 
 ///

--- a/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/PrintInfo.c
+++ b/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/PrintInfo.c
@@ -1,7 +1,7 @@
 /** @file
   Module for clarifying the content of the smbios structure element information.
 
-  Copyright (c) 2005 - 2018, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2005 - 2024, Intel Corporation. All rights reserved.<BR>
   Copyright (c) 1985 - 2022, American Megatrends International LLC.<BR>
   (C) Copyright 2014 Hewlett-Packard Development Company, L.P.<BR>
   (C) Copyright 2015-2019 Hewlett Packard Enterprise Development LP<BR>
@@ -2676,6 +2676,38 @@ DisplayProcessorFamily2 (
 
     case 0x271:
       Print (L"MultiCoreLoongson3D\n");
+      break;
+
+    case 0x300:
+      Print (L"IntelCore3\n");
+      break;
+
+    case 0x301:
+      Print (L"IntelCore5\n");
+      break;
+
+    case 0x302:
+      Print (L"IntelCore7\n");
+      break;
+
+    case 0x303:
+      Print (L"IntelCore9\n");
+      break;
+
+    case 0x304:
+      Print (L"IntelCoreUltra3\n");
+      break;
+
+    case 0x305:
+      Print (L"IntelCoreUltra5\n");
+      break;
+
+    case 0x306:
+      Print (L"IntelCoreUltra7\n");
+      break;
+
+    case 0x307:
+      Print (L"IntelCoreUltra9\n");
       break;
 
     default:


### PR DESCRIPTION
The patch adds new ProcessorFamily definitions for SMBIOS Type4 based on SMBIOS 3.8.0.


Cc: Zhiguang Liu <zhiguang.liu@intel.com>
Cc: Dandan Bi <dandan.bi@intel.com>
Cc: Star Zeng <star.zeng@intel.com>
Cc: Zhichao Gao <zhichao.gao@intel.com>
Cc: Benny Lin <benny.lin@intel.com>
Cc: Gua Guo <gua.guo@intel.com>
Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>