### PR TITLE
[PATCH] ArmVirtPkg/XenAcpiPlatformDxe: Install FACS table from DT -- push

### DIFF
--- a/ArmVirtPkg/XenAcpiPlatformDxe/XenAcpiPlatformDxe.c
+++ b/ArmVirtPkg/XenAcpiPlatformDxe/XenAcpiPlatformDxe.c
@@ -128,10 +128,12 @@ InstallXenArmTables (
   EFI_ACPI_DESCRIPTION_HEADER                   *Xsdt;
   EFI_ACPI_2_0_FIXED_ACPI_DESCRIPTION_TABLE     *FadtTable;
   EFI_ACPI_DESCRIPTION_HEADER                   *DsdtTable;
+  EFI_ACPI_3_0_FIRMWARE_ACPI_CONTROL_STRUCTURE  *FacsTable;
 
   XenAcpiRsdpStructurePtr = NULL;
   FadtTable               = NULL;
   DsdtTable               = NULL;
+  FacsTable               = NULL;
   TableHandle             = 0;
   NumberOfTableEntries    = 0;
 
@@ -191,6 +193,8 @@ InstallXenArmTables (
         FadtTable = (EFI_ACPI_2_0_FIXED_ACPI_DESCRIPTION_TABLE *)
                     (UINTN)CurrentTablePointer;
         DsdtTable = (EFI_ACPI_DESCRIPTION_HEADER *)(UINTN)FadtTable->Dsdt;
+        FacsTable = (EFI_ACPI_3_0_FIRMWARE_ACPI_CONTROL_STRUCTURE *)
+                    (UINTN)FadtTable->FirmwareCtrl;
       }
     }
   }
@@ -198,14 +202,31 @@ InstallXenArmTables (
   //
   // Install DSDT table.
   //
-  Status = AcpiProtocol->InstallAcpiTable (
-                           AcpiProtocol,
-                           DsdtTable,
-                           DsdtTable->Length,
-                           &TableHandle
-                           );
-  if (EFI_ERROR (Status)) {
-    return Status;
+  if (DsdtTable != NULL) {
+    Status = AcpiProtocol->InstallAcpiTable (
+                             AcpiProtocol,
+                             DsdtTable,
+                             DsdtTable->Length,
+                             &TableHandle
+                             );
+    if (EFI_ERROR (Status)) {
+      return Status;
+    }
+  }
+
+  //
+  // Install FACS table.
+  //
+  if (FacsTable != NULL) {
+    Status = AcpiProtocol->InstallAcpiTable (
+                             AcpiProtocol,
+                             FacsTable,
+                             FacsTable->Length,
+                             &TableHandle
+                             );
+    if (EFI_ERROR (Status)) {
+      return Status;
+    }
   }
 
   return EFI_SUCCESS;


### PR DESCRIPTION
https://edk2.groups.io/g/devel/message/115381
msgid `<881dd0a2558ecbdfa02c844722d8a1103ab97ab3.camel@infradead.org>`
~~~
From: David Woodhouse <dwmw@amazon.co.uk>

The FACS may still exist when the reduced hardware flag is set in FADT;
it is optional. Since it contains the hardware signature field which
indicates that a hibernated system should boot cleanly instead of
attempting to resume, a platform may choose to expose it. Propagate it
correctly.

Also avoid a NULL pointer dereference if the platform doesn't provide
a DSDT.

Signed-off-by: David Woodhouse <dwmw@amazon.co.uk>
---
 .../XenAcpiPlatformDxe/XenAcpiPlatformDxe.c   | 37 +++++++++++++++----
 1 file changed, 29 insertions(+), 8 deletions(-)
~~~