### PR TITLE
CI: Use Fedora 39 image for Linux jobs

### DIFF
--- a/.azurepipelines/templates/defaults.yml
+++ b/.azurepipelines/templates/defaults.yml
@@ -9,4 +9,4 @@
 
 variables:
   default_python_version: "3.12"
-  default_linux_image: "ghcr.io/tianocore/containers/fedora-37-test:a0dd931"
+  default_linux_image: "ghcr.io/tianocore/containers/fedora-39-test:232e8be"


### PR DESCRIPTION
Fedora 37 is EOL. Switch Linux CI jobs over to the new Fedora 39 image (gcc 13).