### PR TITLE
ovmf resetvector 5-level paging

### DIFF
--- a/OvmfPkg/ResetVector/Ia32/AmdSev.asm
+++ b/OvmfPkg/ResetVector/Ia32/AmdSev.asm
@@ -146,6 +146,14 @@ BITS    32
     jmp     %%TerminateHlt
 %endmacro
 
+; Get the C-bit mask above 31.
+; Modified: EDX
+;
+; The value is returned in the EDX
+%macro GetSevCBitMaskAbove31 0
+    mov edx, dword[SEV_ES_WORK_AREA_ENC_MASK + 4]
+%endmacro
+
 ; Terminate the guest due to unexpected response code.
 SevEsUnexpectedRespTerminate:
     TerminateVmgExit    TERM_UNEXPECTED_RESP_CODE
@@ -190,14 +198,6 @@ pageTableEntries4kLoop:
 
 SevClearPageEncMaskForGhcbPageExit:
     OneTimeCallRet SevClearPageEncMaskForGhcbPage
-
-; Get the C-bit mask above 31.
-; Modified: EDX
-;
-; The value is returned in the EDX
-GetSevCBitMaskAbove31:
-    mov       edx, dword[SEV_ES_WORK_AREA_ENC_MASK + 4]
-    OneTimeCallRet GetSevCBitMaskAbove31
 
 %endif
 

--- a/OvmfPkg/ResetVector/Ia32/AmdSev.asm
+++ b/OvmfPkg/ResetVector/Ia32/AmdSev.asm
@@ -320,9 +320,9 @@ NoSevEsVcHlt:
 NoSevPass:
     xor       eax, eax
 
-SevExit:
     ;
-    ; Clear exception handlers and stack
+    ; When NOT running in SEV mode: clear exception handlers and stack here.
+    ; Otherwise: SevClearVcHandlerAndStack must be called later.
     ;
     push      eax
     mov       eax, ADDR_OF(IdtrClear)
@@ -330,7 +330,15 @@ SevExit:
     pop       eax
     mov       esp, 0
 
+SevExit:
     OneTimeCallRet CheckSevFeatures
+
+SevClearVcHandlerAndStack:
+    ; Clear exception handlers and stack
+    mov       eax, ADDR_OF(IdtrClear)
+    lidt      [cs:eax]
+    mov       esp, 0
+    OneTimeCallRet SevClearVcHandlerAndStack
 
 ; Start of #VC exception handling routines
 ;

--- a/OvmfPkg/ResetVector/Ia32/AmdSev.asm
+++ b/OvmfPkg/ResetVector/Ia32/AmdSev.asm
@@ -154,10 +154,6 @@ SevEsUnexpectedRespTerminate:
 
 ; If SEV-ES is enabled then initialize and make the GHCB page shared
 SevClearPageEncMaskForGhcbPage:
-    ; Check if SEV is enabled
-    cmp       byte[WORK_AREA_GUEST_TYPE], 1
-    jnz       SevClearPageEncMaskForGhcbPageExit
-
     ; Check if SEV-ES is enabled
     mov       ecx, 1
     bt        [SEV_ES_WORK_AREA_STATUS_MSR], ecx
@@ -195,20 +191,12 @@ pageTableEntries4kLoop:
 SevClearPageEncMaskForGhcbPageExit:
     OneTimeCallRet SevClearPageEncMaskForGhcbPage
 
-; Check if SEV is enabled, and get the C-bit mask above 31.
+; Get the C-bit mask above 31.
 ; Modified: EDX
 ;
 ; The value is returned in the EDX
 GetSevCBitMaskAbove31:
-    xor       edx, edx
-
-    ; Check if SEV is enabled
-    cmp       byte[WORK_AREA_GUEST_TYPE], 1
-    jnz       GetSevCBitMaskAbove31Exit
-
     mov       edx, dword[SEV_ES_WORK_AREA_ENC_MASK + 4]
-
-GetSevCBitMaskAbove31Exit:
     OneTimeCallRet GetSevCBitMaskAbove31
 
 %endif

--- a/OvmfPkg/ResetVector/Ia32/IntelTdx.asm
+++ b/OvmfPkg/ResetVector/Ia32/IntelTdx.asm
@@ -179,7 +179,7 @@ InitTdx:
 ;
 ; Modified:  EAX, EDX
 ;
-; 0-NonTdx, 1-TdxBsp, 2-TdxAps
+; 0-NonTdx, 1-TdxBsp, 2-TdxAps, 3-TdxAps5Level
 ;
 CheckTdxFeaturesBeforeBuildPagetables:
     xor     eax, eax
@@ -199,6 +199,17 @@ NotTdx:
 TdxPostBuildPageTables:
     mov     byte[TDX_WORK_AREA_PGTBL_READY], 1
     OneTimeCallRet TdxPostBuildPageTables
+
+%if PG_5_LEVEL
+
+;
+; Set byte[TDX_WORK_AREA_PGTBL_READY] to 2
+;
+TdxPostBuildPageTables5Level:
+    mov     byte[TDX_WORK_AREA_PGTBL_READY], 2
+    OneTimeCallRet TdxPostBuildPageTables5Level
+
+%endif
 
 ;
 ; Check if TDX is enabled

--- a/OvmfPkg/ResetVector/Ia32/IntelTdx.asm
+++ b/OvmfPkg/ResetVector/Ia32/IntelTdx.asm
@@ -197,11 +197,7 @@ NotTdx:
 ; Set byte[TDX_WORK_AREA_PGTBL_READY] to 1
 ;
 TdxPostBuildPageTables:
-    cmp     byte[WORK_AREA_GUEST_TYPE], VM_GUEST_TDX
-    jne     ExitTdxPostBuildPageTables
     mov     byte[TDX_WORK_AREA_PGTBL_READY], 1
-
-ExitTdxPostBuildPageTables:
     OneTimeCallRet TdxPostBuildPageTables
 
 ;

--- a/OvmfPkg/ResetVector/Ia32/PageTables64.asm
+++ b/OvmfPkg/ResetVector/Ia32/PageTables64.asm
@@ -10,6 +10,7 @@
 
 BITS    32
 
+; common for all levels
 %define PAGE_PRESENT            0x01
 %define PAGE_READ_WRITE         0x02
 %define PAGE_USER_SUPERVISOR    0x04
@@ -17,25 +18,29 @@ BITS    32
 %define PAGE_CACHE_DISABLE     0x010
 %define PAGE_ACCESSED          0x020
 %define PAGE_DIRTY             0x040
-%define PAGE_PAT               0x080
 %define PAGE_GLOBAL           0x0100
-%define PAGE_2M_MBO            0x080
-%define PAGE_2M_PAT          0x01000
+
+; page table entries (level 1)
+%define PAGE_PTE_PAT           0x080
+
+; page directory entries (level 2+)
+%define PAGE_PDE_LARGEPAGE     0x080
+%define PAGE_PDE_PAT         0x01000
 
 %define PAGE_4K_PDE_ATTR (PAGE_ACCESSED + \
                           PAGE_DIRTY + \
                           PAGE_READ_WRITE + \
                           PAGE_PRESENT)
 
-%define PAGE_2M_PDE_ATTR (PAGE_2M_MBO + \
-                          PAGE_ACCESSED + \
-                          PAGE_DIRTY + \
-                          PAGE_READ_WRITE + \
-                          PAGE_PRESENT)
+%define PAGE_PDE_LARGEPAGE_ATTR (PAGE_PDE_LARGEPAGE + \
+                                 PAGE_ACCESSED + \
+                                 PAGE_DIRTY + \
+                                 PAGE_READ_WRITE + \
+                                 PAGE_PRESENT)
 
-%define PAGE_PDP_ATTR (PAGE_ACCESSED + \
-                       PAGE_READ_WRITE + \
-                       PAGE_PRESENT)
+%define PAGE_PDE_DIRECTORY_ATTR (PAGE_ACCESSED + \
+                                 PAGE_READ_WRITE + \
+                                 PAGE_PRESENT)
 
 %define TDX_BSP         1
 %define TDX_AP          2
@@ -84,19 +89,19 @@ clearPageTablesMemoryLoop:
     ;
     ; Top level Page Directory Pointers (1 * 512GB entry)
     ;
-    mov     dword[PT_ADDR (0)], PT_ADDR (0x1000) + PAGE_PDP_ATTR
+    mov     dword[PT_ADDR (0)], PT_ADDR (0x1000) + PAGE_PDE_DIRECTORY_ATTR
     mov     dword[PT_ADDR (4)], edx
 
     ;
     ; Next level Page Directory Pointers (4 * 1GB entries => 4GB)
     ;
-    mov     dword[PT_ADDR (0x1000)], PT_ADDR (0x2000) + PAGE_PDP_ATTR
+    mov     dword[PT_ADDR (0x1000)], PT_ADDR (0x2000) + PAGE_PDE_DIRECTORY_ATTR
     mov     dword[PT_ADDR (0x1004)], edx
-    mov     dword[PT_ADDR (0x1008)], PT_ADDR (0x3000) + PAGE_PDP_ATTR
+    mov     dword[PT_ADDR (0x1008)], PT_ADDR (0x3000) + PAGE_PDE_DIRECTORY_ATTR
     mov     dword[PT_ADDR (0x100C)], edx
-    mov     dword[PT_ADDR (0x1010)], PT_ADDR (0x4000) + PAGE_PDP_ATTR
+    mov     dword[PT_ADDR (0x1010)], PT_ADDR (0x4000) + PAGE_PDE_DIRECTORY_ATTR
     mov     dword[PT_ADDR (0x1014)], edx
-    mov     dword[PT_ADDR (0x1018)], PT_ADDR (0x5000) + PAGE_PDP_ATTR
+    mov     dword[PT_ADDR (0x1018)], PT_ADDR (0x5000) + PAGE_PDE_DIRECTORY_ATTR
     mov     dword[PT_ADDR (0x101C)], edx
 
     ;
@@ -107,7 +112,7 @@ pageTableEntriesLoop:
     mov     eax, ecx
     dec     eax
     shl     eax, 21
-    add     eax, PAGE_2M_PDE_ATTR
+    add     eax, PAGE_PDE_LARGEPAGE_ATTR
     mov     [ecx * 8 + PT_ADDR (0x2000 - 8)], eax
     mov     [(ecx * 8 + PT_ADDR (0x2000 - 8)) + 4], edx
     loop    pageTableEntriesLoop

--- a/OvmfPkg/ResetVector/Ia32/PageTables64.asm
+++ b/OvmfPkg/ResetVector/Ia32/PageTables64.asm
@@ -69,6 +69,10 @@ BITS    32
 ; Argument: upper 32 bits of the page table entries
 ;
 %macro CreatePageTables4Level 1
+
+    ; indicate 4-level paging
+    debugShowPostCode 0x41
+
     ;
     ; Top level Page Directory Pointers (1 * 512GB entry)
     ;
@@ -153,6 +157,10 @@ BITS    32
 ; level 3 directory.
 ;
 %macro CreatePageTables5Level 1
+
+    ; indicate 5-level paging
+    debugShowPostCode 0x51
+
     ; level 5
     mov     dword[PT_ADDR (0)], PT_ADDR (0x1000) + PAGE_PDE_DIRECTORY_ATTR
     mov     dword[PT_ADDR (4)], %1

--- a/OvmfPkg/ResetVector/Ia32/PageTables64.asm
+++ b/OvmfPkg/ResetVector/Ia32/PageTables64.asm
@@ -44,6 +44,7 @@ BITS    32
 
 %define TDX_BSP         1
 %define TDX_AP          2
+%define TDX_AP_5_LEVEL  3
 
 ;
 ; For OVMF, build some initial page tables at
@@ -214,7 +215,14 @@ SetCr3ForPageTables64:
     je        TdxBspInit
     cmp       eax, TDX_AP
     je        SetCr3
+%if PG_5_LEVEL
+    cmp       eax, TDX_AP_5_LEVEL
+    jne       CheckForSev
+    Enable5LevelPaging
+    jmp       SetCr3
+%endif
 
+CheckForSev:
     ; Check whether the SEV is active and populate the SevEsWorkArea
     OneTimeCall   CheckSevFeatures
     cmp       byte[WORK_AREA_GUEST_TYPE], 1
@@ -253,6 +261,14 @@ TdxBspInit:
     ; TDX BSP workflow
     ;
     ClearOvmfPageTables
+%if PG_5_LEVEL
+    Check5LevelPaging Tdx4Level
+    CreatePageTables5Level 0
+    OneTimeCall TdxPostBuildPageTables5Level
+    Enable5LevelPaging
+    jmp SetCr3
+Tdx4Level:
+%endif
     CreatePageTables4Level 0
     OneTimeCall TdxPostBuildPageTables
     jmp SetCr3

--- a/OvmfPkg/ResetVector/Ia32/PageTables64.asm
+++ b/OvmfPkg/ResetVector/Ia32/PageTables64.asm
@@ -46,6 +46,24 @@ BITS    32
 %define TDX_AP          2
 
 ;
+; For OVMF, build some initial page tables at
+; PcdOvmfSecPageTablesBase - (PcdOvmfSecPageTablesBase + 0x6000).
+;
+; This range should match with PcdOvmfSecPageTablesSize which is
+; declared in the FDF files.
+;
+; At the end of PEI, the pages tables will be rebuilt into a
+; more permanent location by DxeIpl.
+;
+%macro ClearOvmfPageTables 0
+    mov     ecx, 6 * 0x1000 / 4
+    xor     eax, eax
+.clearPageTablesMemoryLoop:
+    mov     dword[ecx * 4 + PT_ADDR (0) - 4], eax
+    loop    .clearPageTablesMemoryLoop
+%endmacro
+
+;
 ; Modified:  EAX, EBX, ECX, EDX
 ;
 SetCr3ForPageTables64:
@@ -69,22 +87,7 @@ SetCr3ForPageTables64:
     OneTimeCall   GetSevCBitMaskAbove31
 
 ClearOvmfPageTables:
-    ;
-    ; For OVMF, build some initial page tables at
-    ; PcdOvmfSecPageTablesBase - (PcdOvmfSecPageTablesBase + 0x6000).
-    ;
-    ; This range should match with PcdOvmfSecPageTablesSize which is
-    ; declared in the FDF files.
-    ;
-    ; At the end of PEI, the pages tables will be rebuilt into a
-    ; more permanent location by DxeIpl.
-    ;
-
-    mov     ecx, 6 * 0x1000 / 4
-    xor     eax, eax
-clearPageTablesMemoryLoop:
-    mov     dword[ecx * 4 + PT_ADDR (0) - 4], eax
-    loop    clearPageTablesMemoryLoop
+    ClearOvmfPageTables
 
     ;
     ; Top level Page Directory Pointers (1 * 512GB entry)

--- a/OvmfPkg/ResetVector/Ia32/PageTables64.asm
+++ b/OvmfPkg/ResetVector/Ia32/PageTables64.asm
@@ -254,6 +254,7 @@ SevInit:
     CreatePageTables4Level edx
     ; Clear the C-bit from the GHCB page if the SEV-ES is enabled.
     OneTimeCall   SevClearPageEncMaskForGhcbPage
+    OneTimeCall   SevClearVcHandlerAndStack
     jmp SetCr3
 
 TdxBspInit:

--- a/OvmfPkg/ResetVector/Ia32/PageTables64.asm
+++ b/OvmfPkg/ResetVector/Ia32/PageTables64.asm
@@ -247,11 +247,23 @@ SevInit:
     ; SEV workflow
     ;
     ClearOvmfPageTables
+%if PG_5_LEVEL
+    Check5LevelPaging Sev4Level
     ; If SEV is enabled, the C-bit position is always above 31.
     ; The mask will be saved in the EDX and applied during the
     ; the page table build below.
-    OneTimeCall   GetSevCBitMaskAbove31
+    GetSevCBitMaskAbove31
+    CreatePageTables5Level edx
+    Enable5LevelPaging
+    jmp SevCommon
+Sev4Level:
+%endif
+    ; If SEV is enabled, the C-bit position is always above 31.
+    ; The mask will be saved in the EDX and applied during the
+    ; the page table build below.
+    GetSevCBitMaskAbove31
     CreatePageTables4Level edx
+SevCommon:
     ; Clear the C-bit from the GHCB page if the SEV-ES is enabled.
     OneTimeCall   SevClearPageEncMaskForGhcbPage
     OneTimeCall   SevClearVcHandlerAndStack

--- a/OvmfPkg/ResetVector/Ia32/PageTables64.asm
+++ b/OvmfPkg/ResetVector/Ia32/PageTables64.asm
@@ -118,15 +118,26 @@ SetCr3ForPageTables64:
 
     ; Check whether the SEV is active and populate the SevEsWorkArea
     OneTimeCall   CheckSevFeatures
+    cmp       byte[WORK_AREA_GUEST_TYPE], 1
+    jz        SevInit
 
+    ;
+    ; normal (non-CoCo) workflow
+    ;
+    ClearOvmfPageTables
+    CreatePageTables4Level 0
+    jmp SetCr3
+
+SevInit:
+    ;
+    ; SEV workflow
+    ;
+    ClearOvmfPageTables
     ; If SEV is enabled, the C-bit position is always above 31.
     ; The mask will be saved in the EDX and applied during the
     ; the page table build below.
     OneTimeCall   GetSevCBitMaskAbove31
-
-    ClearOvmfPageTables
     CreatePageTables4Level edx
-
     ; Clear the C-bit from the GHCB page if the SEV-ES is enabled.
     OneTimeCall   SevClearPageEncMaskForGhcbPage
     jmp SetCr3

--- a/OvmfPkg/ResetVector/Ia32/PageTables64.asm
+++ b/OvmfPkg/ResetVector/Ia32/PageTables64.asm
@@ -112,7 +112,7 @@ SetCr3ForPageTables64:
     ; is set.
     OneTimeCall   CheckTdxFeaturesBeforeBuildPagetables
     cmp       eax, TDX_BSP
-    je        ClearOvmfPageTables
+    je        TdxBspInit
     cmp       eax, TDX_AP
     je        SetCr3
 
@@ -124,16 +124,21 @@ SetCr3ForPageTables64:
     ; the page table build below.
     OneTimeCall   GetSevCBitMaskAbove31
 
-ClearOvmfPageTables:
     ClearOvmfPageTables
     CreatePageTables4Level edx
 
     ; Clear the C-bit from the GHCB page if the SEV-ES is enabled.
     OneTimeCall   SevClearPageEncMaskForGhcbPage
+    jmp SetCr3
 
-    ; TDX will do some PostBuildPages task, such as setting
-    ; byte[TDX_WORK_AREA_PGTBL_READY].
-    OneTimeCall   TdxPostBuildPageTables
+TdxBspInit:
+    ;
+    ; TDX BSP workflow
+    ;
+    ClearOvmfPageTables
+    CreatePageTables4Level 0
+    OneTimeCall TdxPostBuildPageTables
+    jmp SetCr3
 
 SetCr3:
     ;

--- a/OvmfPkg/ResetVector/Main.asm
+++ b/OvmfPkg/ResetVector/Main.asm
@@ -80,7 +80,9 @@ SearchBfv:
     ; Set the OVMF/SEV work area as appropriate.
     ;
     OneTimeCall CheckSevFeatures
+    OneTimeCall SevClearVcHandlerAndStack
 
+NoSevIa32:
     ;
     ; Restore initial EAX value into the EAX register
     ;

--- a/OvmfPkg/ResetVector/ResetVector.inf
+++ b/OvmfPkg/ResetVector/ResetVector.inf
@@ -64,3 +64,4 @@
   gUefiOvmfPkgTokenSpaceGuid.PcdQemuHashTableSize
   gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSnpSecretsBase
   gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSnpSecretsSize
+  gEfiMdeModulePkgTokenSpaceGuid.PcdUse5LevelPageTable

--- a/OvmfPkg/ResetVector/ResetVector.nasmb
+++ b/OvmfPkg/ResetVector/ResetVector.nasmb
@@ -53,6 +53,7 @@
 
 %define WORK_AREA_GUEST_TYPE          (FixedPcdGet32 (PcdOvmfWorkAreaBase))
 %define PT_ADDR(Offset)               (FixedPcdGet32 (PcdOvmfSecPageTablesBase) + (Offset))
+%define PG_5_LEVEL                    (FixedPcdGetBool (PcdUse5LevelPageTable))
 
 %define GHCB_PT_ADDR                  (FixedPcdGet32 (PcdOvmfSecGhcbPageTableBase))
 %define GHCB_BASE                     (FixedPcdGet32 (PcdOvmfSecGhcbBase))

--- a/OvmfPkg/ResetVector/ResetVector.nasmb
+++ b/OvmfPkg/ResetVector/ResetVector.nasmb
@@ -92,6 +92,8 @@
 %define SNP_SEC_MEM_BASE_DESC_3       (CPUID_BASE + CPUID_SIZE + SEV_SNP_KERNEL_HASHES_SIZE)
 %define SNP_SEC_MEM_SIZE_DESC_3       (FixedPcdGet32 (PcdOvmfPeiMemFvBase) - SNP_SEC_MEM_BASE_DESC_3)
 
+%include "Ia32/AmdSev.asm"
+
 %ifdef ARCH_X64
   #include <AutoGen.h>
 
@@ -143,8 +145,6 @@
   %include "Ia32/IntelTdx.asm"
   %include "X64/OvmfSevMetadata.asm"
 %endif
-
-%include "Ia32/AmdSev.asm"
 
 %include "Ia16/Real16ToFlat32.asm"
 %include "Ia16/Init16.asm"


### PR DESCRIPTION
- **OvmfPkg/ResetVector: improve page table flag names**
- **OvmfPkg/ResetVector: add ClearOvmfPageTables macro**
- **OvmfPkg/ResetVector: add CreatePageTables4Level macro**
- **OvmfPkg/ResetVector: split TDX BSP workflow**
- **OvmfPkg/ResetVector: split SEV and non-CoCo workflows**
- **OvmfPkg/ResetVector: add 5-level paging support**
- **OvmfPkg/ResetVector: print post codes for 4/5 level paging**
- **OvmfPkg/ResetVector: wire up 5-level paging for TDX**
- **OvmfPkg/ResetVector: leave SEV VC handler installed longer**
- **OvmfPkg/ResetVector: wire up 5-level paging for SEV**
