### PR TITLE
MdeModulePkg/Core/Pei: Improve the copy performance

### DIFF
--- a/MdeModulePkg/Core/Pei/Dispatcher/Dispatcher.c
+++ b/MdeModulePkg/Core/Pei/Dispatcher/Dispatcher.c
@@ -1,7 +1,7 @@
 /** @file
   EFI PEI Core dispatch services
 
-Copyright (c) 2006 - 2019, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2006 - 2024, Intel Corporation. All rights reserved.<BR>
 (C) Copyright 2016 Hewlett Packard Enterprise Development LP<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -1305,7 +1305,7 @@ EvacuateTempRam (
                     );
         ASSERT_EFI_ERROR (Status);
         RawDataFvHeader = (EFI_FIRMWARE_VOLUME_HEADER *)(UINTN)FvHeaderAddress;
-        CopyMem (RawDataFvHeader, MigratedFvHeader, (UINTN)FvHeader->FvLength);
+        CopyMem (RawDataFvHeader, FvHeader, (UINTN)FvHeader->FvLength);
         MigratedFvInfo.FvDataBase = (UINT32)(UINTN)RawDataFvHeader;
       }
 


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4697

EvacuateTempRam function will copy the temporary memory context to the rebased pages and the raw pages. Migrations of rebased PEIMs is from cache to memory, while raw PEIMs is from memory to memory. So the migrations of raw PEIMs is slower than rebased PEIMs. Experimental data indicates that changing the source address of raw PEIMs migration will improve performance by 35%.

Cc: Liming Gao <gaoliming@byosoft.com.cn>