### PR TITLE
Queue 2024-Mar-01

### DIFF
--- a/MdeModulePkg/Core/Pei/Dispatcher/Dispatcher.c
+++ b/MdeModulePkg/Core/Pei/Dispatcher/Dispatcher.c
@@ -1,7 +1,7 @@
 /** @file
   EFI PEI Core dispatch services
 
-Copyright (c) 2006 - 2019, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2006 - 2024, Intel Corporation. All rights reserved.<BR>
 (C) Copyright 2016 Hewlett Packard Enterprise Development LP<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -1305,7 +1305,7 @@ EvacuateTempRam (
                     );
         ASSERT_EFI_ERROR (Status);
         RawDataFvHeader = (EFI_FIRMWARE_VOLUME_HEADER *)(UINTN)FvHeaderAddress;
-        CopyMem (RawDataFvHeader, MigratedFvHeader, (UINTN)FvHeader->FvLength);
+        CopyMem (RawDataFvHeader, FvHeader, (UINTN)FvHeader->FvLength);
         MigratedFvInfo.FvDataBase = (UINT32)(UINTN)RawDataFvHeader;
       }
 

--- a/MdeModulePkg/Core/PiSmmCore/Smi.c
+++ b/MdeModulePkg/Core/PiSmmCore/Smi.c
@@ -134,8 +134,14 @@ SmiManage (
 
   Head = &SmiEntry->SmiHandlers;
 
-  for (Link = Head->ForwardLink; Link != Head; Link = Link->ForwardLink) {
+  for (Link = Head->ForwardLink; Link != Head;) {
     SmiHandler = CR (Link, SMI_HANDLER, Link, SMI_HANDLER_SIGNATURE);
+    //
+    // To support unregister SMI handler inside SMI handler itself,
+    // get next node before handler is executed, since LIST_ENTRY that
+    // Link points to may be freed if unregister SMI handler.
+    //
+    Link = Link->ForwardLink;
 
     Status = SmiHandler->Handler (
                            (EFI_HANDLE)SmiHandler,

--- a/OvmfPkg/ResetVector/Ia32/AmdSev.asm
+++ b/OvmfPkg/ResetVector/Ia32/AmdSev.asm
@@ -154,10 +154,6 @@ SevEsUnexpectedRespTerminate:
 
 ; If SEV-ES is enabled then initialize and make the GHCB page shared
 SevClearPageEncMaskForGhcbPage:
-    ; Check if SEV is enabled
-    cmp       byte[WORK_AREA_GUEST_TYPE], 1
-    jnz       SevClearPageEncMaskForGhcbPageExit
-
     ; Check if SEV-ES is enabled
     mov       ecx, 1
     bt        [SEV_ES_WORK_AREA_STATUS_MSR], ecx
@@ -195,20 +191,12 @@ pageTableEntries4kLoop:
 SevClearPageEncMaskForGhcbPageExit:
     OneTimeCallRet SevClearPageEncMaskForGhcbPage
 
-; Check if SEV is enabled, and get the C-bit mask above 31.
+; Get the C-bit mask above 31.
 ; Modified: EDX
 ;
 ; The value is returned in the EDX
 GetSevCBitMaskAbove31:
-    xor       edx, edx
-
-    ; Check if SEV is enabled
-    cmp       byte[WORK_AREA_GUEST_TYPE], 1
-    jnz       GetSevCBitMaskAbove31Exit
-
     mov       edx, dword[SEV_ES_WORK_AREA_ENC_MASK + 4]
-
-GetSevCBitMaskAbove31Exit:
     OneTimeCallRet GetSevCBitMaskAbove31
 
 %endif

--- a/OvmfPkg/ResetVector/Ia32/IntelTdx.asm
+++ b/OvmfPkg/ResetVector/Ia32/IntelTdx.asm
@@ -179,7 +179,7 @@ InitTdx:
 ;
 ; Modified:  EAX, EDX
 ;
-; 0-NonTdx, 1-TdxBsp, 2-TdxAps
+; 0-NonTdx, 1-TdxBsp, 2-TdxAps, 3-TdxAps5Level
 ;
 CheckTdxFeaturesBeforeBuildPagetables:
     xor     eax, eax
@@ -199,6 +199,17 @@ NotTdx:
 TdxPostBuildPageTables:
     mov     byte[TDX_WORK_AREA_PGTBL_READY], 1
     OneTimeCallRet TdxPostBuildPageTables
+
+%if PG_5_LEVEL
+
+;
+; Set byte[TDX_WORK_AREA_PGTBL_READY] to 2
+;
+TdxPostBuildPageTables5Level:
+    mov     byte[TDX_WORK_AREA_PGTBL_READY], 2
+    OneTimeCallRet TdxPostBuildPageTables5Level
+
+%endif
 
 ;
 ; Check if TDX is enabled

--- a/OvmfPkg/ResetVector/Ia32/IntelTdx.asm
+++ b/OvmfPkg/ResetVector/Ia32/IntelTdx.asm
@@ -197,11 +197,7 @@ NotTdx:
 ; Set byte[TDX_WORK_AREA_PGTBL_READY] to 1
 ;
 TdxPostBuildPageTables:
-    cmp     byte[WORK_AREA_GUEST_TYPE], VM_GUEST_TDX
-    jne     ExitTdxPostBuildPageTables
     mov     byte[TDX_WORK_AREA_PGTBL_READY], 1
-
-ExitTdxPostBuildPageTables:
     OneTimeCallRet TdxPostBuildPageTables
 
 ;

--- a/OvmfPkg/ResetVector/Ia32/PageTables64.asm
+++ b/OvmfPkg/ResetVector/Ia32/PageTables64.asm
@@ -10,6 +10,7 @@
 
 BITS    32
 
+; common for all levels
 %define PAGE_PRESENT            0x01
 %define PAGE_READ_WRITE         0x02
 %define PAGE_USER_SUPERVISOR    0x04
@@ -17,25 +18,29 @@ BITS    32
 %define PAGE_CACHE_DISABLE     0x010
 %define PAGE_ACCESSED          0x020
 %define PAGE_DIRTY             0x040
-%define PAGE_PAT               0x080
 %define PAGE_GLOBAL           0x0100
-%define PAGE_2M_MBO            0x080
-%define PAGE_2M_PAT          0x01000
+
+; page table entries (level 1)
+%define PAGE_PTE_PAT           0x080
+
+; page directory entries (level 2+)
+%define PAGE_PDE_LARGEPAGE     0x080
+%define PAGE_PDE_PAT         0x01000
 
 %define PAGE_4K_PDE_ATTR (PAGE_ACCESSED + \
                           PAGE_DIRTY + \
                           PAGE_READ_WRITE + \
                           PAGE_PRESENT)
 
-%define PAGE_2M_PDE_ATTR (PAGE_2M_MBO + \
-                          PAGE_ACCESSED + \
-                          PAGE_DIRTY + \
-                          PAGE_READ_WRITE + \
-                          PAGE_PRESENT)
+%define PAGE_PDE_LARGEPAGE_ATTR (PAGE_PDE_LARGEPAGE + \
+                                 PAGE_ACCESSED + \
+                                 PAGE_DIRTY + \
+                                 PAGE_READ_WRITE + \
+                                 PAGE_PRESENT)
 
-%define PAGE_PDP_ATTR (PAGE_ACCESSED + \
-                       PAGE_READ_WRITE + \
-                       PAGE_PRESENT)
+%define PAGE_PDE_DIRECTORY_ATTR (PAGE_ACCESSED + \
+                                 PAGE_READ_WRITE + \
+                                 PAGE_PRESENT)
 
 %define TDX_BSP         1
 %define TDX_AP          2
@@ -84,19 +89,19 @@ clearPageTablesMemoryLoop:
     ;
     ; Top level Page Directory Pointers (1 * 512GB entry)
     ;
-    mov     dword[PT_ADDR (0)], PT_ADDR (0x1000) + PAGE_PDP_ATTR
+    mov     dword[PT_ADDR (0)], PT_ADDR (0x1000) + PAGE_PDE_DIRECTORY_ATTR
     mov     dword[PT_ADDR (4)], edx
 
     ;
     ; Next level Page Directory Pointers (4 * 1GB entries => 4GB)
     ;
-    mov     dword[PT_ADDR (0x1000)], PT_ADDR (0x2000) + PAGE_PDP_ATTR
+    mov     dword[PT_ADDR (0x1000)], PT_ADDR (0x2000) + PAGE_PDE_DIRECTORY_ATTR
     mov     dword[PT_ADDR (0x1004)], edx
-    mov     dword[PT_ADDR (0x1008)], PT_ADDR (0x3000) + PAGE_PDP_ATTR
+    mov     dword[PT_ADDR (0x1008)], PT_ADDR (0x3000) + PAGE_PDE_DIRECTORY_ATTR
     mov     dword[PT_ADDR (0x100C)], edx
-    mov     dword[PT_ADDR (0x1010)], PT_ADDR (0x4000) + PAGE_PDP_ATTR
+    mov     dword[PT_ADDR (0x1010)], PT_ADDR (0x4000) + PAGE_PDE_DIRECTORY_ATTR
     mov     dword[PT_ADDR (0x1014)], edx
-    mov     dword[PT_ADDR (0x1018)], PT_ADDR (0x5000) + PAGE_PDP_ATTR
+    mov     dword[PT_ADDR (0x1018)], PT_ADDR (0x5000) + PAGE_PDE_DIRECTORY_ATTR
     mov     dword[PT_ADDR (0x101C)], edx
 
     ;
@@ -107,7 +112,7 @@ pageTableEntriesLoop:
     mov     eax, ecx
     dec     eax
     shl     eax, 21
-    add     eax, PAGE_2M_PDE_ATTR
+    add     eax, PAGE_PDE_LARGEPAGE_ATTR
     mov     [ecx * 8 + PT_ADDR (0x2000 - 8)], eax
     mov     [(ecx * 8 + PT_ADDR (0x2000 - 8)) + 4], edx
     loop    pageTableEntriesLoop

--- a/OvmfPkg/ResetVector/Ia32/PageTables64.asm
+++ b/OvmfPkg/ResetVector/Ia32/PageTables64.asm
@@ -69,6 +69,10 @@ BITS    32
 ; Argument: upper 32 bits of the page table entries
 ;
 %macro CreatePageTables4Level 1
+
+    ; indicate 4-level paging
+    debugShowPostCode 0x41
+
     ;
     ; Top level Page Directory Pointers (1 * 512GB entry)
     ;
@@ -153,6 +157,10 @@ BITS    32
 ; level 3 directory.
 ;
 %macro CreatePageTables5Level 1
+
+    ; indicate 5-level paging
+    debugShowPostCode 0x51
+
     ; level 5
     mov     dword[PT_ADDR (0)], PT_ADDR (0x1000) + PAGE_PDE_DIRECTORY_ATTR
     mov     dword[PT_ADDR (4)], %1

--- a/OvmfPkg/ResetVector/Ia32/PageTables64.asm
+++ b/OvmfPkg/ResetVector/Ia32/PageTables64.asm
@@ -46,6 +46,24 @@ BITS    32
 %define TDX_AP          2
 
 ;
+; For OVMF, build some initial page tables at
+; PcdOvmfSecPageTablesBase - (PcdOvmfSecPageTablesBase + 0x6000).
+;
+; This range should match with PcdOvmfSecPageTablesSize which is
+; declared in the FDF files.
+;
+; At the end of PEI, the pages tables will be rebuilt into a
+; more permanent location by DxeIpl.
+;
+%macro ClearOvmfPageTables 0
+    mov     ecx, 6 * 0x1000 / 4
+    xor     eax, eax
+.clearPageTablesMemoryLoop:
+    mov     dword[ecx * 4 + PT_ADDR (0) - 4], eax
+    loop    .clearPageTablesMemoryLoop
+%endmacro
+
+;
 ; Modified:  EAX, EBX, ECX, EDX
 ;
 SetCr3ForPageTables64:
@@ -69,22 +87,7 @@ SetCr3ForPageTables64:
     OneTimeCall   GetSevCBitMaskAbove31
 
 ClearOvmfPageTables:
-    ;
-    ; For OVMF, build some initial page tables at
-    ; PcdOvmfSecPageTablesBase - (PcdOvmfSecPageTablesBase + 0x6000).
-    ;
-    ; This range should match with PcdOvmfSecPageTablesSize which is
-    ; declared in the FDF files.
-    ;
-    ; At the end of PEI, the pages tables will be rebuilt into a
-    ; more permanent location by DxeIpl.
-    ;
-
-    mov     ecx, 6 * 0x1000 / 4
-    xor     eax, eax
-clearPageTablesMemoryLoop:
-    mov     dword[ecx * 4 + PT_ADDR (0) - 4], eax
-    loop    clearPageTablesMemoryLoop
+    ClearOvmfPageTables
 
     ;
     ; Top level Page Directory Pointers (1 * 512GB entry)

--- a/OvmfPkg/ResetVector/Ia32/PageTables64.asm
+++ b/OvmfPkg/ResetVector/Ia32/PageTables64.asm
@@ -118,15 +118,26 @@ SetCr3ForPageTables64:
 
     ; Check whether the SEV is active and populate the SevEsWorkArea
     OneTimeCall   CheckSevFeatures
+    cmp       byte[WORK_AREA_GUEST_TYPE], 1
+    jz        SevInit
 
+    ;
+    ; normal (non-CoCo) workflow
+    ;
+    ClearOvmfPageTables
+    CreatePageTables4Level 0
+    jmp SetCr3
+
+SevInit:
+    ;
+    ; SEV workflow
+    ;
+    ClearOvmfPageTables
     ; If SEV is enabled, the C-bit position is always above 31.
     ; The mask will be saved in the EDX and applied during the
     ; the page table build below.
     OneTimeCall   GetSevCBitMaskAbove31
-
-    ClearOvmfPageTables
     CreatePageTables4Level edx
-
     ; Clear the C-bit from the GHCB page if the SEV-ES is enabled.
     OneTimeCall   SevClearPageEncMaskForGhcbPage
     jmp SetCr3

--- a/OvmfPkg/ResetVector/Ia32/PageTables64.asm
+++ b/OvmfPkg/ResetVector/Ia32/PageTables64.asm
@@ -112,7 +112,7 @@ SetCr3ForPageTables64:
     ; is set.
     OneTimeCall   CheckTdxFeaturesBeforeBuildPagetables
     cmp       eax, TDX_BSP
-    je        ClearOvmfPageTables
+    je        TdxBspInit
     cmp       eax, TDX_AP
     je        SetCr3
 
@@ -124,16 +124,21 @@ SetCr3ForPageTables64:
     ; the page table build below.
     OneTimeCall   GetSevCBitMaskAbove31
 
-ClearOvmfPageTables:
     ClearOvmfPageTables
     CreatePageTables4Level edx
 
     ; Clear the C-bit from the GHCB page if the SEV-ES is enabled.
     OneTimeCall   SevClearPageEncMaskForGhcbPage
+    jmp SetCr3
 
-    ; TDX will do some PostBuildPages task, such as setting
-    ; byte[TDX_WORK_AREA_PGTBL_READY].
-    OneTimeCall   TdxPostBuildPageTables
+TdxBspInit:
+    ;
+    ; TDX BSP workflow
+    ;
+    ClearOvmfPageTables
+    CreatePageTables4Level 0
+    OneTimeCall TdxPostBuildPageTables
+    jmp SetCr3
 
 SetCr3:
     ;

--- a/OvmfPkg/ResetVector/ResetVector.inf
+++ b/OvmfPkg/ResetVector/ResetVector.inf
@@ -64,3 +64,4 @@
   gUefiOvmfPkgTokenSpaceGuid.PcdQemuHashTableSize
   gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSnpSecretsBase
   gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSnpSecretsSize
+  gEfiMdeModulePkgTokenSpaceGuid.PcdUse5LevelPageTable

--- a/OvmfPkg/ResetVector/ResetVector.nasmb
+++ b/OvmfPkg/ResetVector/ResetVector.nasmb
@@ -53,6 +53,7 @@
 
 %define WORK_AREA_GUEST_TYPE          (FixedPcdGet32 (PcdOvmfWorkAreaBase))
 %define PT_ADDR(Offset)               (FixedPcdGet32 (PcdOvmfSecPageTablesBase) + (Offset))
+%define PG_5_LEVEL                    (FixedPcdGetBool (PcdUse5LevelPageTable))
 
 %define GHCB_PT_ADDR                  (FixedPcdGet32 (PcdOvmfSecGhcbPageTableBase))
 %define GHCB_BASE                     (FixedPcdGet32 (PcdOvmfSecGhcbBase))

--- a/StandaloneMmPkg/Core/Mmi.c
+++ b/StandaloneMmPkg/Core/Mmi.c
@@ -154,9 +154,14 @@ MmiManage (
     Head = &MmiEntry->MmiHandlers;
   }
 
-  for (Link = Head->ForwardLink; Link != Head; Link = Link->ForwardLink) {
+  for (Link = Head->ForwardLink; Link != Head;) {
     MmiHandler = CR (Link, MMI_HANDLER, Link, MMI_HANDLER_SIGNATURE);
-
+    //
+    // To support unregister MMI handler inside MMI handler itself,
+    // get next node before handler is executed, since LIST_ENTRY that
+    // Link points to may be freed if unregister MMI handler.
+    //
+    Link   = Link->ForwardLink;
     Status = MmiHandler->Handler (
                            (EFI_HANDLE)MmiHandler,
                            Context,

--- a/UefiCpuPkg/Library/CpuPageTableLib/CpuPageTableMap.c
+++ b/UefiCpuPkg/Library/CpuPageTableLib/CpuPageTableMap.c
@@ -20,10 +20,10 @@
 **/
 VOID
 PageTableLibSetPte4K (
-  IN IA32_PTE_4K         *Pte4K,
-  IN UINT64              Offset,
-  IN IA32_MAP_ATTRIBUTE  *Attribute,
-  IN IA32_MAP_ATTRIBUTE  *Mask
+  IN OUT IA32_PTE_4K         *Pte4K,
+  IN UINT64                  Offset,
+  IN IA32_MAP_ATTRIBUTE      *Attribute,
+  IN IA32_MAP_ATTRIBUTE      *Mask
   )
 {
   IA32_PTE_4K  LocalPte4K;
@@ -94,10 +94,10 @@ PageTableLibSetPte4K (
 **/
 VOID
 PageTableLibSetPleB (
-  IN IA32_PAGE_LEAF_ENTRY_BIG_PAGESIZE  *PleB,
-  IN UINT64                             Offset,
-  IN IA32_MAP_ATTRIBUTE                 *Attribute,
-  IN IA32_MAP_ATTRIBUTE                 *Mask
+  IN OUT IA32_PAGE_LEAF_ENTRY_BIG_PAGESIZE  *PleB,
+  IN UINT64                                 Offset,
+  IN IA32_MAP_ATTRIBUTE                     *Attribute,
+  IN IA32_MAP_ATTRIBUTE                     *Mask
   )
 {
   IA32_PAGE_LEAF_ENTRY_BIG_PAGESIZE  LocalPleB;
@@ -171,11 +171,11 @@ PageTableLibSetPleB (
 **/
 VOID
 PageTableLibSetPle (
-  IN UINTN               Level,
-  IN IA32_PAGING_ENTRY   *Ple,
-  IN UINT64              Offset,
-  IN IA32_MAP_ATTRIBUTE  *Attribute,
-  IN IA32_MAP_ATTRIBUTE  *Mask
+  IN UINTN                   Level,
+  IN OUT IA32_PAGING_ENTRY   *Ple,
+  IN UINT64                  Offset,
+  IN IA32_MAP_ATTRIBUTE      *Attribute,
+  IN IA32_MAP_ATTRIBUTE      *Mask
   )
 {
   if (Level == 1) {
@@ -195,9 +195,9 @@ PageTableLibSetPle (
 **/
 VOID
 PageTableLibSetPnle (
-  IN IA32_PAGE_NON_LEAF_ENTRY  *Pnle,
-  IN IA32_MAP_ATTRIBUTE        *Attribute,
-  IN IA32_MAP_ATTRIBUTE        *Mask
+  IN OUT IA32_PAGE_NON_LEAF_ENTRY  *Pnle,
+  IN IA32_MAP_ATTRIBUTE            *Attribute,
+  IN IA32_MAP_ATTRIBUTE            *Mask
   )
 {
   IA32_PAGE_NON_LEAF_ENTRY  LocalPnle;

--- a/UefiCpuPkg/Library/CpuPageTableLib/CpuPageTableMap.c
+++ b/UefiCpuPkg/Library/CpuPageTableLib/CpuPageTableMap.c
@@ -20,17 +20,17 @@
 **/
 VOID
 PageTableLibSetPte4K (
-  IN OUT IA32_PTE_4K         *Pte4K,
-  IN UINT64                  Offset,
-  IN IA32_MAP_ATTRIBUTE      *Attribute,
-  IN IA32_MAP_ATTRIBUTE      *Mask
+  IN OUT volatile IA32_PTE_4K  *Pte4K,
+  IN UINT64                    Offset,
+  IN IA32_MAP_ATTRIBUTE        *Attribute,
+  IN IA32_MAP_ATTRIBUTE        *Mask
   )
 {
   IA32_PTE_4K  LocalPte4K;
 
   LocalPte4K.Uint64 = Pte4K->Uint64;
   if (Mask->Bits.PageTableBaseAddressLow || Mask->Bits.PageTableBaseAddressHigh) {
-    LocalPte4K.Uint64 = (IA32_MAP_ATTRIBUTE_PAGE_TABLE_BASE_ADDRESS (Attribute) + Offset) | (Pte4K->Uint64 & ~IA32_PE_BASE_ADDRESS_MASK_40);
+    LocalPte4K.Uint64 = (IA32_MAP_ATTRIBUTE_PAGE_TABLE_BASE_ADDRESS (Attribute) + Offset) | (LocalPte4K.Uint64 & ~IA32_PE_BASE_ADDRESS_MASK_40);
   }
 
   if (Mask->Bits.Present) {
@@ -94,17 +94,17 @@ PageTableLibSetPte4K (
 **/
 VOID
 PageTableLibSetPleB (
-  IN OUT IA32_PAGE_LEAF_ENTRY_BIG_PAGESIZE  *PleB,
-  IN UINT64                                 Offset,
-  IN IA32_MAP_ATTRIBUTE                     *Attribute,
-  IN IA32_MAP_ATTRIBUTE                     *Mask
+  IN OUT volatile IA32_PAGE_LEAF_ENTRY_BIG_PAGESIZE  *PleB,
+  IN UINT64                                          Offset,
+  IN IA32_MAP_ATTRIBUTE                              *Attribute,
+  IN IA32_MAP_ATTRIBUTE                              *Mask
   )
 {
   IA32_PAGE_LEAF_ENTRY_BIG_PAGESIZE  LocalPleB;
 
   LocalPleB.Uint64 = PleB->Uint64;
   if (Mask->Bits.PageTableBaseAddressLow || Mask->Bits.PageTableBaseAddressHigh) {
-    LocalPleB.Uint64 = (IA32_MAP_ATTRIBUTE_PAGE_TABLE_BASE_ADDRESS (Attribute) + Offset) | (PleB->Uint64 & ~IA32_PE_BASE_ADDRESS_MASK_39);
+    LocalPleB.Uint64 = (IA32_MAP_ATTRIBUTE_PAGE_TABLE_BASE_ADDRESS (Attribute) + Offset) | (LocalPleB.Uint64 & ~IA32_PE_BASE_ADDRESS_MASK_39);
   }
 
   LocalPleB.Bits.MustBeOne = 1;
@@ -171,11 +171,11 @@ PageTableLibSetPleB (
 **/
 VOID
 PageTableLibSetPle (
-  IN UINTN                   Level,
-  IN OUT IA32_PAGING_ENTRY   *Ple,
-  IN UINT64                  Offset,
-  IN IA32_MAP_ATTRIBUTE      *Attribute,
-  IN IA32_MAP_ATTRIBUTE      *Mask
+  IN UINTN                           Level,
+  IN OUT volatile IA32_PAGING_ENTRY  *Ple,
+  IN UINT64                          Offset,
+  IN IA32_MAP_ATTRIBUTE              *Attribute,
+  IN IA32_MAP_ATTRIBUTE              *Mask
   )
 {
   if (Level == 1) {
@@ -195,9 +195,9 @@ PageTableLibSetPle (
 **/
 VOID
 PageTableLibSetPnle (
-  IN OUT IA32_PAGE_NON_LEAF_ENTRY  *Pnle,
-  IN IA32_MAP_ATTRIBUTE            *Attribute,
-  IN IA32_MAP_ATTRIBUTE            *Mask
+  IN OUT volatile IA32_PAGE_NON_LEAF_ENTRY  *Pnle,
+  IN IA32_MAP_ATTRIBUTE                     *Attribute,
+  IN IA32_MAP_ATTRIBUTE                     *Mask
   )
 {
   IA32_PAGE_NON_LEAF_ENTRY  LocalPnle;


### PR DESCRIPTION
* [PATCH v2] UefiCpuPkg/CpuPageTableLib: Fix IN OUT parameters marked as IN
  msgid `<20240222023922.29275-1-jianfeng.zhou@intel.com>`
  https://edk2.groups.io/g/devel/message/115871
* [PATCH] UefiCpuPkg/CpuPageTableLib: qualify page table accesses as volatile
  msgid `<20240301025447.41170-1-jianfeng.zhou@intel.com>`
  https://edk2.groups.io/g/devel/message/116230
* [PATCH v3 0/4] Support to unregister SMI handler inside SMI handler
  msgid `<20240301030133.628-1-zhiguang.liu@intel.com>`
  https://edk2.groups.io/g/devel/message/116202
* [PATCH v1] MdeModulePkg/Core/Pei: Improve the copy performance
  msgid `<20240301071147.519-1-zhihao.li@intel.com>`
  https://edk2.groups.io/g/devel/message/116212
  https://bugzilla.tianocore.org/show_bug.cgi?id=4697
* [PATCH v2 00/10] OvmfPkg/ResetVector: cleanup and add 5-level paging support.
  msgid `<20240301074402.98625-1-kraxel@redhat.com>`
  https://edk2.groups.io/g/devel/message/116215
  (first 8 patches out of 10)