### PR TITLE
UefiPayloadPkg: UPL arch backward support ELF

### DIFF
--- a/UefiPayloadPkg/UniversalPayloadBuild.py
+++ b/UefiPayloadPkg/UniversalPayloadBuild.py
@@ -348,7 +348,7 @@ def main():
             if os.path.exists (SectionFvFile) == False:
                 continue
             if (args.Fit == False):
-                status = ReplaceFv (UniversalPayloadBinary, SectionFvFile, SectionName)
+                status = ReplaceFv (UniversalPayloadBinary, SectionFvFile, SectionName, args.Arch)
             else:
                 status = ReplaceFv (UniversalPayloadBinary, SectionFvFile, SectionName.replace ("_", "-"), args.Arch)
             if status != 0:


### PR DESCRIPTION
After 11ad164bcea6b0ed3628d merge,
ELF format API won't meet backward requirement.

Cc: Guo Dong <guo.dong@intel.com>
Cc: Sean Rhodes <sean@starlabs.systems>
Reviewed-by: James Lu <james.lu@intel.com>
Cc: Gua Guo <gua.guo@intel.com>