### PR TITLE
MdeModulePkg: Warn if out of flash space when writing variables

### DIFF
--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/Variable.c
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/Variable.c
@@ -2364,6 +2364,8 @@ Done:
                   );
       ASSERT_EFI_ERROR (Status);
     }
+  } else if (Status == EFI_OUT_OF_RESOURCES) {
+    DEBUG ((DEBUG_WARN, "UpdateVariable failed: Out of flash space\n"));
   }
 
   return Status;


### PR DESCRIPTION
Emit a DEBUG_WARN message if there is not enough
flash space left to write/update a variable.
This condition is currently not logged appropriately
in all cases, given that full variable store can
easily render the system unbootable.
This new message helps identifying this condition quickly.