### PR TITLE
MdeModulePkg/Core/DxeIplPeim: Enhance Code in DxeIplFindDxeCore Function

### DIFF
--- a/MdeModulePkg/Core/DxeIplPeim/DxeLoad.c
+++ b/MdeModulePkg/Core/DxeIplPeim/DxeLoad.c
@@ -487,9 +487,9 @@ DxeIplFindDxeCore (
     //
     if (EFI_ERROR (Status)) {
       REPORT_STATUS_CODE (EFI_PROGRESS_CODE, (EFI_SOFTWARE_PEI_MODULE | EFI_SW_PEI_CORE_EC_DXE_CORRUPT));
+      ASSERT_EFI_ERROR (Status);
+      break;
     }
-
-    ASSERT_EFI_ERROR (Status);
 
     //
     // Find the DxeCore file type from the beginning in this firmware volume.
@@ -509,6 +509,14 @@ DxeIplFindDxeCore (
     //
     Instance++;
   }
+
+  //
+  // DxeCore cannot find in any firmware volume.
+  //
+  ASSERT (FALSE);
+  CpuDeadLoop ();
+
+  return NULL;
 }
 
 /**


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4653

In DxeIplFindDxeCore function, there exists different behavior between Debug and Release built BIOS. This change is used to unify both of the code flow and fix the potential overflow of "Instance" variable.

In this change,
1. Move the ASSERT_EFI_ERROR (Status) in failure to find DxeCore in any firmware volume.
2. Break the while-loop when not found necessary DxeCore. This would make the Instance variable not overflow in while-loop.
3. Add the ASSERT (FALSE) and CpuDeadLoop () in the end of the function and do not return since DxeCore is mandatory for the following booting to hand-off the PEI phase to DXE phase.