### PR TITLE
Measure the FW_CFG data from QEMU

### DIFF
--- a/MdePkg/Include/Protocol/CcMeasurement.h
+++ b/MdePkg/Include/Protocol/CcMeasurement.h
@@ -73,6 +73,13 @@ typedef UINT32 EFI_CC_MR_INDEX;
 #define EFI_CC_EVENT_HEADER_VERSION  1
 
 typedef struct {
+  UINT32    LogIndex;
+  UINT32    LogSize;
+} EFI_CC_EVENT_VARIABLE_HEADER;
+
+#define OVMF_CC_MEASUREMENT_EVENT_VARIABLE_NAME  L"CcEventVar"
+
+typedef struct {
   //
   // Size of the event header itself (sizeof(EFI_CC_EVENT_HEADER)).
   //

--- a/OvmfPkg/AmdSev/AmdSevX64.dsc
+++ b/OvmfPkg/AmdSev/AmdSevX64.dsc
@@ -578,6 +578,7 @@
   OvmfPkg/PlatformPei/PlatformPei.inf {
     <LibraryClasses>
       NULL|OvmfPkg/IntelTdx/TdxHelperLib/TdxHelperLibNull.inf
+      BaseCryptLib|CryptoPkg/Library/BaseCryptLibNull/BaseCryptLibNull.inf
   }
   UefiCpuPkg/Universal/Acpi/S3Resume2Pei/S3Resume2Pei.inf
   UefiCpuPkg/CpuMpPei/CpuMpPei.inf

--- a/OvmfPkg/CloudHv/CloudHvX64.dsc
+++ b/OvmfPkg/CloudHv/CloudHvX64.dsc
@@ -676,6 +676,7 @@
   OvmfPkg/PlatformPei/PlatformPei.inf {
     <LibraryClasses>
       NULL|OvmfPkg/IntelTdx/TdxHelperLib/TdxHelperLibNull.inf
+      BaseCryptLib|CryptoPkg/Library/BaseCryptLibNull/BaseCryptLibNull.inf
   }
   UefiCpuPkg/Universal/Acpi/S3Resume2Pei/S3Resume2Pei.inf {
     <LibraryClasses>

--- a/OvmfPkg/Include/Library/TdxHelperLib.h
+++ b/OvmfPkg/Include/Library/TdxHelperLib.h
@@ -67,4 +67,21 @@ TdxHelperBuildGuidHobForTdxMeasurement (
   VOID
   );
 
+/**
+ * In Tdx guest, OVMF uses FW_CFG_SELECTOR(0x510) and FW_CFG_IO_DATA(0x511)
+ * to get configuration infomation from QEMU. From the security perspective,
+ * that should be measured before it is consumed.
+
+  @retval EFI_SUCCESS  The measurement is successfully
+  @retval Others       Other errors as indicated
+**/
+EFI_STATUS
+EFIAPI
+TdxHelperMeasureFwCfgData (
+  IN VOID    *EventLog,
+  IN UINT32  LogLen,
+  IN VOID    *HashData,
+  IN UINT64  HashDataLen
+  );
+
 #endif

--- a/OvmfPkg/IntelTdx/IntelTdxX64.dsc
+++ b/OvmfPkg/IntelTdx/IntelTdxX64.dsc
@@ -606,6 +606,7 @@
       PciHostBridgeLib|OvmfPkg/Library/PciHostBridgeLib/PciHostBridgeLib.inf
       PciHostBridgeUtilityLib|OvmfPkg/Library/PciHostBridgeUtilityLib/PciHostBridgeUtilityLib.inf
       NULL|OvmfPkg/Library/PlatformHasIoMmuLib/PlatformHasIoMmuLib.inf
+      NULL|OvmfPkg/IntelTdx/TdxHelperLib/DxeTdxHelperLib.inf
   }
   MdeModulePkg/Bus/Pci/PciBusDxe/PciBusDxe.inf {
     <LibraryClasses>

--- a/OvmfPkg/IntelTdx/TdxHelperLib/DxeTdxHelper.c
+++ b/OvmfPkg/IntelTdx/TdxHelperLib/DxeTdxHelper.c
@@ -1,0 +1,216 @@
+/** @file
+  TdxHelper Functions which are used in SEC phase
+
+  Copyright (c) 2022 - 2023, Intel Corporation. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+#include <Library/BaseLib.h>
+#include <Library/DebugLib.h>
+#include <Library/BaseCryptLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <IndustryStandard/Tdx.h>
+#include <IndustryStandard/IntelTdx.h>
+#include <Library/TdxLib.h>
+#include <Library/TdxHelperLib.h>
+#include <IndustryStandard/UefiTcgPlatform.h>
+#include <Library/UefiRuntimeServicesTableLib.h>
+#include <Protocol/CcMeasurement.h>
+
+UINT32  mCcEventLogCount;
+
+/**
+ * Calculate the sha384 of input Data and extend it to RTMR register.
+ *
+ * @param RtmrIndex       Index of the RTMR register
+ * @param DataToHash      Data to be hashed
+ * @param DataToHashLen   Length of the data
+ * @param Digest          Hash value of the input data
+ * @param DigestLen       Length of the hash value
+ *
+ * @retval EFI_SUCCESS    Successfully hash and extend to RTMR
+ * @retval Others         Other errors as indicated
+ */
+EFI_STATUS
+HashAndExtendToRtmr (
+  IN UINT32  RtmrIndex,
+  IN VOID    *DataToHash,
+  IN UINTN   DataToHashLen,
+  OUT UINT8  *Digest,
+  IN  UINTN  DigestLen
+  )
+{
+  EFI_STATUS  Status;
+
+  if ((DataToHash == NULL) || (DataToHashLen == 0)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if ((Digest == NULL) || (DigestLen != SHA384_DIGEST_SIZE)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  //
+  // Calculate the sha384 of the data
+  //
+  if (!Sha384HashAll (DataToHash, DataToHashLen, Digest)) {
+    return EFI_ABORTED;
+  }
+
+  //
+  // Extend to RTMR
+  //
+  Status = TdExtendRtmr (
+             (UINT32 *)Digest,
+             SHA384_DIGEST_SIZE,
+             (UINT8)RtmrIndex
+             );
+
+  ASSERT (!EFI_ERROR (Status));
+  return Status;
+}
+
+EFI_STATUS
+BuildCcEventVariable (
+  UINT32  RtmrIndex,
+  UINT32  EventType,
+  UINT8   *EventData,
+  UINT32  EventSize,
+  UINT8   *HashValue,
+  UINT32  HashSize
+  )
+{
+  EFI_STATUS          Status;
+  UINT8               *Ptr;
+  UINT8               *VariableData;
+  UINTN               VariableDataSize;
+  TPML_DIGEST_VALUES  *TdxDigest;
+
+  EFI_CC_EVENT_VARIABLE_HEADER  CcEventVariableHeader;
+
+  CcEventVariableHeader.LogIndex = mCcEventLogCount;
+  VariableData                   = NULL;
+  if (HashSize != SHA384_DIGEST_SIZE) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  #define TDX_DIGEST_VALUE_LEN  (sizeof (UINT32) + sizeof (TPMI_ALG_HASH) + SHA384_DIGEST_SIZE)
+
+  CcEventVariableHeader.LogSize = sizeof (TCG_PCRINDEX) + sizeof (TCG_EVENTTYPE) + TDX_DIGEST_VALUE_LEN + sizeof (UINT32) + EventSize;
+  VariableDataSize              = sizeof (CcEventVariableHeader) + CcEventVariableHeader.LogSize;
+  VariableData                  = AllocatePool (VariableDataSize);
+  if (VariableData == NULL ) {
+    ASSERT (FALSE);
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  Ptr = VariableData;
+
+  CopyMem (Ptr, &CcEventVariableHeader, sizeof (CcEventVariableHeader));
+  Ptr += sizeof (CcEventVariableHeader);
+  //
+  // There are 2 types of measurement registers in TDX: MRTD and RTMR[0-3].
+  // According to UEFI Spec 2.10 Section 38.4.1, RTMR[0-3] is mapped to MrIndex[1-4].
+  // So RtmrIndex must be increased by 1 before the event log is created.
+  //
+  RtmrIndex++;
+  CopyMem (Ptr, &RtmrIndex, sizeof (UINT32));
+  Ptr += sizeof (UINT32);
+
+  CopyMem (Ptr, &EventType, sizeof (TCG_EVENTTYPE));
+  Ptr += sizeof (TCG_EVENTTYPE);
+
+  TdxDigest                     = (TPML_DIGEST_VALUES *)Ptr;
+  TdxDigest->count              = 1;
+  TdxDigest->digests[0].hashAlg = TPM_ALG_SHA384;
+  CopyMem (
+    TdxDigest->digests[0].digest.sha384,
+    HashValue,
+    SHA384_DIGEST_SIZE
+    );
+  Ptr += TDX_DIGEST_VALUE_LEN;
+
+  CopyMem (Ptr, &EventSize, sizeof (UINT32));
+  Ptr += sizeof (UINT32);
+
+  CopyMem (Ptr, (VOID *)EventData, EventSize);
+  Ptr += EventSize;
+
+  Status = gRT->SetVariable (
+                  OVMF_CC_MEASUREMENT_EVENT_VARIABLE_NAME,
+                  &gCcEventVariableGuid,
+                  EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_RUNTIME_ACCESS | EFI_VARIABLE_APPEND_WRITE,
+                  VariableDataSize,
+                  VariableData
+                  );
+
+  if (EFI_ERROR (Status)) {
+    ASSERT (FALSE);
+  }
+
+  if (VariableData) {
+    FreePool (VariableData);
+  }
+
+  mCcEventLogCount++;
+  return Status;
+}
+
+/**
+ * In Tdx guest, OVMF uses FW_CFG_SELECTOR(0x510) and FW_CFG_IO_DATA(0x511)
+ * to get configuration infomation from QEMU. From the security perspective,
+ * that should be measured before it is consumed.
+
+  @retval EFI_SUCCESS  The measurement is successfully
+  @retval Others       Other errors as indicated
+**/
+EFI_STATUS
+EFIAPI
+TdxHelperMeasureFwCfgData (
+  IN VOID    *EventLog,
+  IN UINT32  LogLen,
+  IN VOID    *HashData,
+  IN UINT64  HashDataLen
+  )
+{
+  EFI_STATUS  Status;
+  UINT8       Digest[SHA384_DIGEST_SIZE];
+
+  if ((EventLog == NULL) || (HashData == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (!TdIsEnabled ()) {
+    return EFI_UNSUPPORTED;
+  }
+
+  Status = HashAndExtendToRtmr (
+             0,
+             (UINT8 *)HashData,
+             (UINTN)HashDataLen,
+             Digest,
+             SHA384_DIGEST_SIZE
+             );
+
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: HashAndExtendToRtmr failed with %r\n", __func__, Status));
+    return Status;
+  }
+
+  Status = BuildCcEventVariable (
+             0,
+             EV_PLATFORM_CONFIG_FLAGS,
+             EventLog,
+             LogLen,
+             Digest,
+             SHA384_DIGEST_SIZE
+             );
+
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: BuildTdxMeasurementGuidHob failed with %r\n", __func__, Status));
+  }
+
+  return Status;
+}

--- a/OvmfPkg/IntelTdx/TdxHelperLib/DxeTdxHelperLib.inf
+++ b/OvmfPkg/IntelTdx/TdxHelperLib/DxeTdxHelperLib.inf
@@ -1,0 +1,42 @@
+## @file
+#  TdxHelperLib PEI instance
+#
+#  This module provides Tdx helper functions in PEI phase.
+#  Copyright (c) 2021 - 2023, Intel Corporation. All rights reserved.<BR>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = DxeTdxHelperLib
+  FILE_GUID                      = d219c014-dcb3-11ee-b82f-cb5ad8b69742
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = TdxHelperLib|DXE_CORE DXE_DRIVER
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = X64
+#
+
+[Sources]
+  DxeTdxHelper.c
+
+[Packages]
+  CryptoPkg/CryptoPkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  MdePkg/MdePkg.dec
+  OvmfPkg/OvmfPkg.dec
+  SecurityPkg/SecurityPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  DebugLib
+  TdxLib
+  BaseCryptLib
+
+[Guids]
+  gCcEventVariableGuid

--- a/OvmfPkg/IntelTdx/TdxHelperLib/PeiTdxHelperLib.inf
+++ b/OvmfPkg/IntelTdx/TdxHelperLib/PeiTdxHelperLib.inf
@@ -27,6 +27,7 @@
   TdxMeasurementHob.c
 
 [Packages]
+  CryptoPkg/CryptoPkg.dec
   MdeModulePkg/MdeModulePkg.dec
   MdePkg/MdePkg.dec
   OvmfPkg/OvmfPkg.dec
@@ -37,6 +38,8 @@
   DebugLib
   HobLib
   PcdLib
+  TdxLib
+  BaseCryptLib
 
 [FixedPcd]
   gUefiOvmfPkgTokenSpaceGuid.PcdOvmfWorkAreaBase

--- a/OvmfPkg/IntelTdx/TdxHelperLib/TdxHelperNull.c
+++ b/OvmfPkg/IntelTdx/TdxHelperLib/TdxHelperNull.c
@@ -77,3 +77,23 @@ TdxHelperBuildGuidHobForTdxMeasurement (
 {
   return EFI_UNSUPPORTED;
 }
+
+/**
+ * In Tdx guest, OVMF uses FW_CFG_SELECTOR(0x510) and FW_CFG_IO_DATA(0x511)
+ * to get configuration infomation from QEMU. From the security perspective,
+ * that should be measured before it is consumed.
+
+  @retval EFI_SUCCESS  The GuidHob is built successfully
+  @retval Others       Other errors as indicated
+**/
+EFI_STATUS
+EFIAPI
+TdxHelperMeasureFwCfgData (
+  IN VOID    *EventLog,
+  IN UINT32  LogLen,
+  IN VOID    *HashData,
+  IN UINT64  HashDataLen
+  )
+{
+  return EFI_UNSUPPORTED;
+}

--- a/OvmfPkg/Library/PlatformInitLib/MemDetect.c
+++ b/OvmfPkg/Library/PlatformInitLib/MemDetect.c
@@ -40,10 +40,17 @@ Module Name:
 #include <Library/QemuFwCfgLib.h>
 #include <Library/QemuFwCfgSimpleParserLib.h>
 #include <Library/TdxLib.h>
+#include <Library/TdxHelperLib.h>
 
 #include <Library/PlatformInitLib.h>
 
 #define MEGABYTE_SHIFT  20
+
+#define EV_POSTCODE_INFO_QEMU_RESERVED_MEMORY_END_DATA  "QEMU RESERVED MEMORY END"
+#define QEMU_RESERVED_MEMORY_END_DATA_LEN               (sizeof(EV_POSTCODE_INFO_QEMU_RESERVED_MEMORY_END_DATA) - 1)
+
+#define EV_POSTCODE_INFO_QEMU_X_PCIMMIO64MB_DATA  "QEMU X-PCIMMIO64MB"
+#define QEMU_X_PCIMMIO64MB_DATA_LEN               (sizeof(EV_POSTCODE_INFO_QEMU_X_PCIMMIO64MB_DATA) - 1)
 
 VOID
 EFIAPI
@@ -518,6 +525,20 @@ PlatformGetFirstNonAddress (
     case EFI_NOT_FOUND:
       break;
     case EFI_SUCCESS:
+
+ #ifdef MDE_CPU_X64
+      //
+      // Measure the "opt/ovmf/X-PciMmio64Mb" which is downloaded from QEMU.
+      // It has to be done before it is consumed.
+      //
+      TdxHelperMeasureFwCfgData (
+        EV_POSTCODE_INFO_QEMU_X_PCIMMIO64MB_DATA,
+        QEMU_X_PCIMMIO64MB_DATA_LEN,
+        (VOID *)(UINTN)&FwCfgPciMmio64Mb,
+        sizeof (FwCfgPciMmio64Mb)
+        );
+ #endif
+
       if (FwCfgPciMmio64Mb <= 0x1000000) {
         PlatformInfoHob->PcdPciMmio64Size = LShiftU64 (FwCfgPciMmio64Mb, 20);
         break;
@@ -566,6 +587,20 @@ PlatformGetFirstNonAddress (
   if (!EFI_ERROR (Status) && (FwCfgSize == sizeof HotPlugMemoryEnd)) {
     QemuFwCfgSelectItem (FwCfgItem);
     QemuFwCfgReadBytes (FwCfgSize, &HotPlugMemoryEnd);
+
+ #ifdef MDE_CPU_X64
+    //
+    // Measure the "etc/reserved-memory-end" which is downloaded from QEMU.
+    // It has to be done before it is consumed.
+    //
+    TdxHelperMeasureFwCfgData (
+      EV_POSTCODE_INFO_QEMU_RESERVED_MEMORY_END_DATA,
+      QEMU_RESERVED_MEMORY_END_DATA_LEN,
+      (VOID *)(UINTN)&HotPlugMemoryEnd,
+      FwCfgSize
+      );
+ #endif
+
     DEBUG ((
       DEBUG_VERBOSE,
       "%a: HotPlugMemoryEnd=0x%Lx\n",

--- a/OvmfPkg/Library/QemuBootOrderLib/QemuBootOrderLib.inf
+++ b/OvmfPkg/Library/QemuBootOrderLib/QemuBootOrderLib.inf
@@ -45,6 +45,7 @@
   DevicePathLib
   BaseMemoryLib
   OrderedCollectionLib
+  TpmMeasurementLib
 
 [Guids]
   gEfiGlobalVariableGuid

--- a/OvmfPkg/Library/QemuFwCfgS3Lib/DxeQemuFwCfgS3LibFwCfg.inf
+++ b/OvmfPkg/Library/QemuFwCfgS3Lib/DxeQemuFwCfgS3LibFwCfg.inf
@@ -29,6 +29,7 @@
 [Packages]
   MdePkg/MdePkg.dec
   OvmfPkg/OvmfPkg.dec
+  MdeModulePkg/MdeModulePkg.dec
 
 [LibraryClasses]
   BaseLib
@@ -36,6 +37,7 @@
   MemoryAllocationLib
   QemuFwCfgLib
   UefiBootServicesTableLib
+  TpmMeasurementLib
 
 [Protocols]
   gEfiS3SaveStateProtocolGuid ## SOMETIMES_CONSUMES

--- a/OvmfPkg/Library/QemuFwCfgS3Lib/QemuFwCfgS3Dxe.c
+++ b/OvmfPkg/Library/QemuFwCfgS3Lib/QemuFwCfgS3Dxe.c
@@ -13,6 +13,8 @@
 #include <Library/QemuFwCfgS3Lib.h>
 #include <Library/UefiBootServicesTableLib.h>
 #include <Protocol/S3SaveState.h>
+#include <IndustryStandard/UefiTcgPlatform.h>
+#include <Library/TpmMeasurementLib.h>
 
 //
 // Event to signal when the S3SaveState protocol interface is installed.
@@ -884,4 +886,30 @@ QemuFwCfgS3ScriptCheckValue (
   }
 
   return RETURN_SUCCESS;
+}
+
+VOID
+TdxMeasureQemuSystemStates (
+  IN VOID    *EventLog,
+  IN UINT32  LogLen,
+  IN VOID    *HashData,
+  IN UINT64  HashDataLen
+  )
+{
+  if ((EventLog == NULL) || (HashData == NULL)) {
+    return;
+  }
+
+  //
+  // Measure the "etc/system-states" which is downloaded from QEMU.
+  // It has to be done before it is consumed.
+  //
+  TpmMeasureAndLogData (
+    1,
+    EV_PLATFORM_CONFIG_FLAGS,
+    EventLog,
+    LogLen,
+    HashData,
+    HashDataLen
+    );
 }

--- a/OvmfPkg/Library/QemuFwCfgS3Lib/QemuFwCfgS3Pei.c
+++ b/OvmfPkg/Library/QemuFwCfgS3Lib/QemuFwCfgS3Pei.c
@@ -10,6 +10,7 @@
 **/
 
 #include <Library/QemuFwCfgS3Lib.h>
+#include <Library/TdxHelperLib.h>
 
 /**
   Install the client module's FW_CFG_BOOT_SCRIPT_CALLBACK_FUNCTION callback for
@@ -77,4 +78,26 @@ QemuFwCfgS3CallWhenBootScriptReady (
   )
 {
   return RETURN_UNSUPPORTED;
+}
+
+VOID
+TdxMeasureQemuSystemStates (
+  IN VOID    *EventLog,
+  IN UINT32  LogLen,
+  IN VOID    *HashData,
+  IN UINT64  HashDataLen
+  )
+{
+  if ((EventLog == NULL) || (HashData == NULL)) {
+    return;
+  }
+
+ #if defined (TDX_GUEST_SUPPORTED)
+  TdxHelperMeasureFwCfgData (
+    EventLog,
+    LogLen,
+    HashData,
+    HashDataLen
+    );
+ #endif
 }

--- a/OvmfPkg/Library/QemuFwCfgS3Lib/QemuFwCfgS3PeiDxe.c
+++ b/OvmfPkg/Library/QemuFwCfgS3Lib/QemuFwCfgS3PeiDxe.c
@@ -9,6 +9,18 @@
 
 #include <Library/QemuFwCfgLib.h>
 #include <Library/QemuFwCfgS3Lib.h>
+#include <Library/BaseLib.h>
+
+#define EV_POSTCODE_INFO_QEMU_SYSTEM_STATES_DATA  "QEMU SYSTEM STATES DATA"
+#define QEMU_QEMU_SYSTEM_STATES_DATA_LEN          (sizeof(EV_POSTCODE_INFO_QEMU_SYSTEM_STATES_DATA) - 1)
+
+VOID
+TdxMeasureQemuSystemStates (
+  IN VOID    *EventLog,
+  IN UINT32  LogLen,
+  IN VOID    *HashData,
+  IN UINT64  HashDataLen
+  );
 
 /**
   Determine if S3 support is explicitly enabled.
@@ -39,5 +51,18 @@ QemuFwCfgS3Enabled (
 
   QemuFwCfgSelectItem (FwCfgItem);
   QemuFwCfgReadBytes (sizeof SystemStates, SystemStates);
+  if (TdIsEnabled ()) {
+    //
+    // Measure the "etc/system-states" which is downloaded from QEMU.
+    // It has to be done before it is consumed.
+    //
+    TdxMeasureQemuSystemStates (
+      EV_POSTCODE_INFO_QEMU_SYSTEM_STATES_DATA,
+      QEMU_QEMU_SYSTEM_STATES_DATA_LEN,
+      (VOID *)(UINTN)&SystemStates,
+      sizeof (SystemStates)
+      );
+  }
+
   return (BOOLEAN)(SystemStates[3] & BIT7);
 }

--- a/OvmfPkg/Microvm/MicrovmX64.dsc
+++ b/OvmfPkg/Microvm/MicrovmX64.dsc
@@ -689,6 +689,7 @@
   OvmfPkg/PlatformPei/PlatformPei.inf {
     <LibraryClasses>
       NULL|OvmfPkg/IntelTdx/TdxHelperLib/TdxHelperLibNull.inf
+      BaseCryptLib|CryptoPkg/Library/BaseCryptLibNull/BaseCryptLibNull.inf
   }
   UefiCpuPkg/Universal/Acpi/S3Resume2Pei/S3Resume2Pei.inf
   UefiCpuPkg/CpuMpPei/CpuMpPei.inf

--- a/OvmfPkg/OvmfPkgX64.dsc
+++ b/OvmfPkg/OvmfPkgX64.dsc
@@ -738,6 +738,7 @@
   OvmfPkg/PlatformPei/PlatformPei.inf {
     <LibraryClasses>
       NULL|OvmfPkg/IntelTdx/TdxHelperLib/PeiTdxHelperLib.inf
+      BaseCryptLib|CryptoPkg/Library/BaseCryptLib/PeiCryptLib.inf
   }
   UefiCpuPkg/Universal/Acpi/S3Resume2Pei/S3Resume2Pei.inf {
     <LibraryClasses>

--- a/OvmfPkg/OvmfPkgX64.dsc
+++ b/OvmfPkg/OvmfPkgX64.dsc
@@ -837,6 +837,7 @@
       PciHostBridgeLib|OvmfPkg/Library/PciHostBridgeLib/PciHostBridgeLib.inf
       PciHostBridgeUtilityLib|OvmfPkg/Library/PciHostBridgeUtilityLib/PciHostBridgeUtilityLib.inf
       NULL|OvmfPkg/Library/PlatformHasIoMmuLib/PlatformHasIoMmuLib.inf
+      NULL|OvmfPkg/IntelTdx/TdxHelperLib/DxeTdxHelperLib.inf
   }
   MdeModulePkg/Bus/Pci/PciBusDxe/PciBusDxe.inf {
     <LibraryClasses>

--- a/OvmfPkg/PlatformPei/IntelTdx.c
+++ b/OvmfPkg/PlatformPei/IntelTdx.c
@@ -40,8 +40,6 @@ IntelTdxInitialize (
     return;
   }
 
-  TdxHelperBuildGuidHobForTdxMeasurement ();
-
   PcdStatus = PcdSet64S (PcdConfidentialComputingGuestAttr, CCAttrIntelTdx);
   ASSERT_RETURN_ERROR (PcdStatus);
 

--- a/OvmfPkg/PlatformPei/Platform.c
+++ b/OvmfPkg/PlatformPei/Platform.c
@@ -38,6 +38,7 @@
 #include <IndustryStandard/QemuCpuHotplug.h>
 #include <Library/MemEncryptSevLib.h>
 #include <OvmfPlatforms.h>
+#include <Library/TdxHelperLib.h>
 
 #include "Platform.h"
 
@@ -309,6 +310,13 @@ InitializePlatform (
 
   DEBUG ((DEBUG_INFO, "Platform PEIM Loaded\n"));
   PlatformInfoHob = BuildPlatformInfoHob ();
+
+ #ifdef MDE_CPU_X64
+  if (TdIsEnabled ()) {
+    TdxHelperBuildGuidHobForTdxMeasurement ();
+  }
+
+ #endif
 
   PlatformInfoHob->SmmSmramRequire     = FeaturePcdGet (PcdSmmSmramRequire);
   PlatformInfoHob->SevEsIsEnabled      = MemEncryptSevEsIsEnabled ();

--- a/SecurityPkg/SecurityPkg.dec
+++ b/SecurityPkg/SecurityPkg.dec
@@ -219,6 +219,9 @@
   ## GUID used to specify section with default dbt content
   gDefaultdbtFileGuid                = { 0x36c513ee, 0xa338, 0x4976, { 0xa0, 0xfb, 0x6d, 0xdb, 0xa3, 0xda, 0xfe, 0x87 } }
 
+  ## GUID used to specify section with Cc Event Variable content
+  gCcEventVariableGuid               = { 0xa291ce0e, 0xdc09, 0x11ee, { 0x9e, 0xdb, 0x73, 0x49, 0xd7, 0x92, 0xaf, 0x51 } }
+
 [Ppis]
   ## The PPI GUID for that TPM physical presence should be locked.
   # Include/Ppi/LockPhysicalPresence.h

--- a/SecurityPkg/Tcg/TdTcg2Dxe/TdTcg2Dxe.inf
+++ b/SecurityPkg/Tcg/TdTcg2Dxe/TdTcg2Dxe.inf
@@ -69,6 +69,7 @@
   gTcg800155PlatformIdEventHobGuid                   ## SOMETIMES_CONSUMES  ## HOB
   gEfiCcFinalEventsTableGuid                         ## PRODUCES
 
+  gCcEventVariableGuid
 [Protocols]
   gEfiCcMeasurementProtocolGuid                      ## PRODUCES
   gEfiMpServiceProtocolGuid                          ## SOMETIMES_CONSUMES


### PR DESCRIPTION
In this patch, implement the measurement for below FW_CFG values :
etc/system-states
opt/ovmf/X-PciMmio64Mb
etc/reserved-memory-end
etc/boot-menu-wait
etc./extra-pci-roots