### PR TITLE
OvmfPkg/QemuBootOrderLib: Measure the etc/boot-menu-wait

### DIFF
--- a/OvmfPkg/Library/QemuBootOrderLib/QemuBootOrderLib.c
+++ b/OvmfPkg/Library/QemuBootOrderLib/QemuBootOrderLib.c
@@ -20,6 +20,8 @@
 #include <Library/BaseMemoryLib.h>
 #include <Guid/GlobalVariable.h>
 #include <Guid/VirtioMmioTransport.h>
+#include <IndustryStandard/UefiTcgPlatform.h>
+#include <Library/TpmMeasurementLib.h>
 
 #include "ExtraRootBusMap.h"
 
@@ -40,6 +42,9 @@
 #define REQUIRED_PCI_OFW_NODES   2
 #define REQUIRED_MMIO_OFW_NODES  1
 #define EXAMINED_OFW_NODES       6
+
+#define EV_POSTCODE_INFO_QEMU_BOOTMENU_WAIT_TIME_DATA  "QEMU BOOTMENU WAIT TIME"
+#define QEMU_BOOTMENU_WAIT_DATA_LEN                    (sizeof(EV_POSTCODE_INFO_QEMU_BOOTMENU_WAIT_TIME_DATA) - 1)
 
 /**
   Simple character classification routines, corresponding to POSIX class names
@@ -2418,5 +2423,19 @@ GetFrontPageTimeoutFromQemu (
   // seconds, round N up.
   //
   QemuFwCfgSelectItem (BootMenuWaitItem);
-  return (UINT16)((QemuFwCfgRead16 () + 999) / 1000);
+  Timeout = QemuFwCfgRead16 ();
+  //
+  // Measure the Timeout which is downloaded from QEMU.
+  // It has to be done before it is consumed.
+  //
+  TpmMeasureAndLogData (
+    1,
+    EV_PLATFORM_CONFIG_FLAGS,
+    EV_POSTCODE_INFO_QEMU_BOOTMENU_WAIT_TIME_DATA,
+    QEMU_BOOTMENU_WAIT_DATA_LEN,
+    (VOID *)(UINTN)&Timeout,
+    BootMenuWaitSize
+    );
+
+  return (UINT16)((Timeout + 999) / 1000);
 }

--- a/OvmfPkg/Library/QemuBootOrderLib/QemuBootOrderLib.inf
+++ b/OvmfPkg/Library/QemuBootOrderLib/QemuBootOrderLib.inf
@@ -45,6 +45,7 @@
   DevicePathLib
   BaseMemoryLib
   OrderedCollectionLib
+  TpmMeasurementLib
 
 [Guids]
   gEfiGlobalVariableGuid


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4415


Refer to the section 8.3.4 of tdx-virtual-firmware-design-guide spec,
OVMF would uses FW_CFG_IO_SELECTOR(0x510)  and FW_CFG_IO_DATA(0x511)
to get configuration from QEMU. From the security perspective, if TDVF
uses this method, configuration data must be measured into RTMR[0].

Currently, the etc/boot-menu-wait is using in TDVF, it required to be
measured into RTMR[0].

This is the first patch and will continue to be updated to measure 
additional configuration data.


Refernce:
spec: https://cdrdv2.intel.com/v1/dl/getContent/733585

Cc: Erdem Aktas <erdemaktas@google.com>
Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Min Xu <min.m.xu@intel.com>
Cc: Gerd Hoffmann <kraxel@redhat.com>
Cc: Elena Reshetova <elena.reshetova@intel.com>
Signed-off-by: Ceping Sun <cepingx.sun@intel.com>