### PR TITLE
IntelFsp2WrapperPkg: Error handling of TpmMeasureAndLogDataWithFlags()

### DIFF
--- a/IntelFsp2WrapperPkg/Library/BaseFspMeasurementLib/FspMeasurementLib.c
+++ b/IntelFsp2WrapperPkg/Library/BaseFspMeasurementLib/FspMeasurementLib.c
@@ -197,6 +197,10 @@ MeasureFspFirmwareBlobWithCfg (
              (UINTN)sizeof (DigestList),
              EDKII_TCG_PRE_HASH_LOG_ONLY
              );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "TpmMeasureAndLogDataWithFlags failed - %r\n", Status));
+    return Status;
+  }
 
   Status = TpmMeasureAndLogData (
              1,


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4700

TpmMeasureAndLogDataWithFlags() computes the measure the code and
log it into PCR 0. TpmMeasureAndLogData() computes the hash for the
configuration. The same "Status" variable is used to store the return
values for both of the functions. There is no error handling if
TpmMeasureAndLogDataWithFlags() returns an error Status.
Fix the issue by adding error handling for TpmMeasureAndLogDataWithFlags().