### PR TITLE
EmbeddedPkg/NonCoherentIoMmuDxe: Make SetAttributes always succeed

### DIFF
--- a/EmbeddedPkg/Drivers/NonCoherentIoMmuDxe/NonCoherentIoMmuDxe.c
+++ b/EmbeddedPkg/Drivers/NonCoherentIoMmuDxe/NonCoherentIoMmuDxe.c
@@ -70,7 +70,7 @@ NonCoherentIoMmuSetAttribute (
   IN UINT64                IoMmuAccess
   )
 {
-  return EFI_UNSUPPORTED;
+  return EFI_SUCCESS;
 }
 
 /**


### PR DESCRIPTION
NonCoherentIoMmuSetAttribute() does nothing except return EFI_UNSUPPORTED. This was fine when it was introduced, but now, the PCI bus driver will fail a PCI I/O Map() operation if the call to SetAttributes() fails.

So return EFI_SUCCESS instead.

Cc: Leif Lindholm <quic_llindhol@quicinc.com>
Cc: Abner Chang <abner.chang@amd.com>

Reviewed-by: Leif Lindholm <quic_llindhol@quicinc.com>