### PR TITLE
UefiPayloadPkg: Remove ProcessLibraryConstructorList()

### DIFF
--- a/UefiPayloadPkg/UefiPayloadEntry/FitUniversalPayloadEntry.c
+++ b/UefiPayloadPkg/UefiPayloadEntry/FitUniversalPayloadEntry.c
@@ -616,8 +616,6 @@ _ModuleEntryPoint (
 
   mHobList = (VOID *)BootloaderParameter;
   DxeFv    = NULL;
-  // Call constructor for all libraries
-  ProcessLibraryConstructorList ();
 
   DEBUG ((DEBUG_INFO, "Entering Universal Payload...\n"));
   DEBUG ((DEBUG_INFO, "sizeof(UINTN) = 0x%x\n", sizeof (UINTN)));

--- a/UefiPayloadPkg/UefiPayloadEntry/UefiPayloadEntry.c
+++ b/UefiPayloadPkg/UefiPayloadEntry/UefiPayloadEntry.c
@@ -434,8 +434,6 @@ _ModuleEntryPoint (
     UniversalSerialPort->RegisterStride  = (UINT8)SerialPortInfo.RegWidth;
   }
 
-  // The library constructors might depend on serial port, so call it after serial port hob
-  ProcessLibraryConstructorList ();
   DEBUG ((DEBUG_INFO, "sizeof(UINTN) = 0x%x\n", sizeof (UINTN)));
 
   // Build HOB based on information from Bootloader

--- a/UefiPayloadPkg/UefiPayloadEntry/UniversalPayloadEntry.c
+++ b/UefiPayloadPkg/UefiPayloadEntry/UniversalPayloadEntry.c
@@ -462,8 +462,6 @@ _ModuleEntryPoint (
 
   mHobList = (VOID *)BootloaderParameter;
   DxeFv    = NULL;
-  // Call constructor for all libraries
-  ProcessLibraryConstructorList ();
 
   DEBUG ((DEBUG_INFO, "Entering Universal Payload...\n"));
   DEBUG ((DEBUG_INFO, "sizeof(UINTN) = 0x%x\n", sizeof (UINTN)));


### PR DESCRIPTION
ProcessLibraryConstructorList() no needs to be called manually after INF version greater or equal to 1.30.

Cc: Guo Dong <guo.dong@intel.com>
Cc: Sean Rhodes <sean@starlabs.systems>
Cc: James Lu <james.lu@intel.com>
Cc: Gua Guo <gua.guo@intel.com>