### PR TITLE
 OvmfPkg: Update TDVMCALL to avoid leaking secrets to the VMM

### DIFF
--- a/MdePkg/Library/BaseLib/X64/TdVmcall.nasm
+++ b/MdePkg/Library/BaseLib/X64/TdVmcall.nasm
@@ -9,7 +9,7 @@
 DEFAULT REL
 SECTION .text
 
-%define TDVMCALL_EXPOSE_REGS_MASK       0xffec
+%define TDVMCALL_EXPOSE_REGS_MASK       0xffcc
 %define TDVMCALL                        0x0
 
 %macro tdcall 0

--- a/OvmfPkg/Library/CcExitLib/X64/TdVmcallCpuid.nasm
+++ b/OvmfPkg/Library/CcExitLib/X64/TdVmcallCpuid.nasm
@@ -9,7 +9,7 @@
 DEFAULT REL
 SECTION .text
 
-%define TDVMCALL_EXPOSE_REGS_MASK       0xffec
+%define TDVMCALL_EXPOSE_REGS_MASK       0xffcc
 %define TDVMCALL                        0x0
 %define EXIT_REASON_CPUID               0xa
 

--- a/OvmfPkg/TdxDxe/X64/ApRunLoop.nasm
+++ b/OvmfPkg/TdxDxe/X64/ApRunLoop.nasm
@@ -20,12 +20,36 @@ SECTION .text
 
 BITS 64
 
-%define TDVMCALL_EXPOSE_REGS_MASK       0xffec
+%define TDVMCALL_EXPOSE_REGS_MASK       0xffcc
 %define TDVMCALL                        0x0
 %define EXIT_REASON_CPUID               0xa
 
 %macro  tdcall  0
   db  0x66, 0x0f, 0x01, 0xcc
+%endmacro
+
+%macro tdcall_regs_preamble 2
+    mov rax, %1
+
+    xor rcx, rcx
+    mov ecx, %2
+
+    ; R10 = 0 (standard TDVMCALL)
+
+    xor r10d, r10d
+
+    ; Zero out unused (for standard TDVMCALL) registers to avoid leaking
+    ; secrets to the VMM.
+
+    xor esi, esi
+    xor edi, edi
+
+    xor edx, edx
+    xor ebp, ebp
+    xor r8d, r8d
+    xor r9d, r9d
+    xor r14, r14
+    xor r15, r15
 %endmacro
 
 ;
@@ -40,11 +64,9 @@ global ASM_PFX(AsmRelocateApMailBoxLoop)
 ASM_PFX(AsmRelocateApMailBoxLoop):
 AsmRelocateApMailBoxLoopStart:
 
-    mov         rax, TDVMCALL
-    mov         rcx, TDVMCALL_EXPOSE_REGS_MASK
-    xor         r10, r10
     mov         r11, EXIT_REASON_CPUID
     mov         r12, 0xb
+    tdcall_regs_preamble TDVMCALL, TDVMCALL_EXPOSE_REGS_MASK
     tdcall
     test        r10, r10
     jnz         Panic


### PR DESCRIPTION

REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4696

According to section 2.4.1 of [GHCI] spec,
RBP register is usually used as a frame pointer according to the C language calling convention. 
The software should not use RBP as an input/output parameter and should clear BIT5 (RBP) in
the GPR mask in RCX.

Reference:
[GHCI]: TDX Guest-Host-Communication Interface v1.5
https://cdrdv2.intel.com/v1/dl/getContent/726792


Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Erdem Aktas <erdemaktas@google.com>
Cc: James Bottomley <jejb@linux.ibm.com>
Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Min Xu <min.m.xu@intel.com>
Cc: Tom Lendacky <thomas.lendacky@amd.com>
Cc: Michael Roth <michael.roth@amd.com>
Cc: Gerd Hoffmann <kraxel@redhat.com>
Cc: Isaku Yamahata <isaku.yamahata@intel.com>
Signed-off-by: Ceping Sun <cepingx.sun@intel.com>

Ceping Sun (3):
  MdePkg/BaseLib: Update TDVMCALL_EXPOSE_REGS_MASK
  OvmfPkg/CcExitLib: Update TDVMCALL_EXPOSE_REGS_MASK
  OvmfPkg/TdxDxe: Clear the registers before tdcall

 MdePkg/Library/BaseLib/X64/TdVmcall.nasm      |  2 +-
 .../Library/CcExitLib/X64/TdVmcallCpuid.nasm  |  2 +-
 OvmfPkg/TdxDxe/X64/ApRunLoop.nasm             | 30 ++++++++++++++++---
 3 files changed, 28 insertions(+), 6 deletions(-)
