### PR TITLE
SecurityPkg/OpalPasswordDxe: Update UI according to UEFI spec

### DIFF
--- a/SecurityPkg/Tcg/Opal/OpalPassword/OpalHii.c
+++ b/SecurityPkg/Tcg/Opal/OpalPassword/OpalHii.c
@@ -494,7 +494,6 @@ HiiPopulateMainMenuForm (
     }
   }
 
-  OpalHiiSetBrowserData ();
   return EFI_SUCCESS;
 }
 
@@ -632,17 +631,7 @@ DriverCallback (
   HiiKey.Raw = QuestionId;
   HiiKeyId   = (UINT8)HiiKey.KeyBits.Id;
 
-  if (Action == EFI_BROWSER_ACTION_FORM_OPEN) {
-    switch (HiiKeyId) {
-      case HII_KEY_ID_VAR_SUPPORTED_DISKS:
-        DEBUG ((DEBUG_INFO, "HII_KEY_ID_VAR_SUPPORTED_DISKS\n"));
-        return HiiPopulateMainMenuForm ();
-
-      case HII_KEY_ID_VAR_SELECTED_DISK_AVAILABLE_ACTIONS:
-        DEBUG ((DEBUG_INFO, "HII_KEY_ID_VAR_SELECTED_DISK_AVAILABLE_ACTIONS\n"));
-        return HiiPopulateDiskInfoForm ();
-    }
-  } else if (Action == EFI_BROWSER_ACTION_CHANGING) {
+  if (Action == EFI_BROWSER_ACTION_CHANGING) {
     switch (HiiKeyId) {
       case HII_KEY_ID_GOTO_DISK_INFO:
         return HiiSelectDisk ((UINT8)HiiKey.KeyBits.Index);
@@ -819,6 +808,7 @@ HiiSelectDisk (
 {
   OpalHiiGetBrowserData ();
   gHiiConfiguration.SelectedDiskIndex = Index;
+  HiiPopulateDiskInfoForm ();
   OpalHiiSetBrowserData ();
 
   return EFI_SUCCESS;
@@ -839,8 +829,6 @@ HiiPopulateDiskInfoForm (
   OPAL_DISK_ACTIONS  AvailActions;
   TCG_RESULT         Ret;
   CHAR8              *DiskName;
-
-  OpalHiiGetBrowserData ();
 
   DiskName = HiiDiskGetNameCB (gHiiConfiguration.SelectedDiskIndex);
   if (DiskName == NULL) {
@@ -902,11 +890,6 @@ HiiPopulateDiskInfoForm (
 
     GetSavedOpalRequest (OpalDisk, &gHiiConfiguration.OpalRequest);
   }
-
-  //
-  // Pass the current configuration to the BIOS
-  //
-  OpalHiiSetBrowserData ();
 
   return EFI_SUCCESS;
 }
@@ -1060,6 +1043,8 @@ ExtractConfig (
     UnicodeSPrint (ConfigRequest, Size, L"%s&OFFSET=0&WIDTH=%016LX", ConfigRequestHdr, (UINT64)BufferSize);
     FreePool (ConfigRequestHdr);
   }
+
+  HiiPopulateMainMenuForm ();
 
   //
   // Convert Buffer Data to <ConfigResp> by helper function BlockToConfig( )


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4735

Should not call HiiGetBrowserData() and HiiSetBrowserData() in FORM_OPEN call back function.
Those APIs are called within OpalHiiSetBrowserData/OpalHiiGetBrowserData which have been used by OpalHii.c.

1. Move HiiPopulateMainMenuForm() into ExtracConfig() for the Opal main formset initialize.
2. Move HiiPopulateDiskInfoForm() to HiiSelectDisk().
3. Remove HiiGetBrowserData() and HiiSetBrowserData() redundant usage.

Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Rahul Kumar <rahul1.kumar@intel.com>
Cc: Dandan Bi<dandan.bi@intel.com>
Cc: Ming Tan <ming.tan@intel.com>
Cc: Arthur Chen <arthur.g.chen@intel.com>
Cc: Xiao X Chen <xiao.x.chen@intel.com>
Cc: CindyX Kuo <cindyx.kuo@intel.com>