### PR TITLE
OvmfPkg: Align the SEC module within OvmfPkgX64

### DIFF
--- a/OvmfPkg/OvmfPkgX64.fdf
+++ b/OvmfPkg/OvmfPkgX64.fdf
@@ -434,7 +434,7 @@ FILE FV_IMAGE = 9E21FD93-9C72-4c15-8C4B-E77F1DB2D792 {
 
 [Rule.Common.SEC]
   FILE SEC = $(NAMED_GUID) {
-    PE32     PE32           $(INF_OUTPUT)/$(MODULE_NAME).efi
+    PE32     PE32   Align=Auto    $(INF_OUTPUT)/$(MODULE_NAME).efi
     UI       STRING ="$(MODULE_NAME)" Optional
     VERSION  STRING ="$(INF_VERSION)" Optional BUILD_NUM=$(BUILD_NUMBER)
   }


### PR DESCRIPTION
Prior to this change the alignment of the SEC module would be 4 bytes. This is inconsistent with the expectations of the compiler and can lead to unexpected behavior.

For example a modern version of clang with size optimizations enabled (-Oz) can break the ALIGN_POINTER macro in the SEC module.

Here is a minimal example:

https://godbolt.org/z/fzW67ndTY

```
unsigned char mArray[112];

#define ALIGN_VALUE(Value, Alignment)  ((Value) + (((Alignment) - (Value)) & ((Alignment) - 1)))
#define ALIGN_POINTER(Pointer, Alignment)  ((void *) (ALIGN_VALUE ((uint64_t)(Pointer), (Alignment))))

int main() {
    printf("0x%llx\n", mArray);
    printf("0x%llx\n", ALIGN_POINTER(mArray, 64));
    return 0;
}
```

The above code compiles down to:

```
main:                                   # @main
        push    r14
        push    rbx
        push    rax
        lea     rbx, [rip + .L.str]
        lea     r14, [rip + mArray]
        mov     rdi, rbx
        mov     rsi, r14
        xor     eax, eax
        call    printf@PLT
        push    64
        pop     rsi
        sub     esi, r14d
        and     esi, 48
        add     rsi, r14
        mov     rdi, rbx
        xor     eax, eax
        call    printf@PLT
        xor     eax, eax
        add     rsp, 8
        pop     rbx
        pop     r14
        ret
mArray:
        .zero   112

.L.str:
        .asciz  "0x%llx\n"
```

Note that the `value & 63` in the ALIGN_VALUE implementation gets transformed into `and esi, 48` in the assembly. The compiler knows the array address is already aligned so it believes there is no need to clear the last 4 bits of the address.

However by mapping the data section that contains mArray onto a 4-byte-aligned base address we violate the compiler's expectations. The last 4 bits of the mArray address are no longer zeroes leading to an ALIGN_POINTER macro that doesn't work.