### PR TITLE
ArmVirtPkg: Kvmtool: Fix ACPI/DT boot selection

### DIFF
--- a/ArmVirtPkg/ArmVirtKvmTool.dsc
+++ b/ArmVirtPkg/ArmVirtKvmTool.dsc
@@ -189,6 +189,20 @@
 [PcdsDynamicHii]
   gEfiMdePkgTokenSpaceGuid.PcdPlatformBootTimeOut|L"Timeout"|gEfiGlobalVariableGuid|0x0|5
 
+  #
+  #  Dynamic Hii PCD to select ACPI/DT boot.
+  #
+  #   1. Check the status of the 'ForceNoAcpi' variable
+  #      setvar ForceNoAcpi -guid "50BEA1E5-A2C5-46E9-9B3A-59596516B00A" -nv -bs
+  #        Value 00 indicates ACPI boot
+  #        Value 01 indicates DT boot
+  #   2. Set the boot mode to ACPI
+  #      setvar ForceNoAcpi -guid "50BEA1E5-A2C5-46E9-9B3A-59596516B00A" -nv -bs =0x00
+  #   3. Set the boot mode to DT
+  #      setvar ForceNoAcpi -guid "50BEA1E5-A2C5-46E9-9B3A-59596516B00A" -nv -bs =0x01
+  #
+  gUefiOvmfPkgTokenSpaceGuid.PcdForceNoAcpi|L"ForceNoAcpi"|gOvmfVariableGuid|0x0|FALSE|NV,BS
+
 [PcdsDynamicDefault.common]
   gArmTokenSpaceGuid.PcdArmArchTimerSecIntrNum|0x0
   gArmTokenSpaceGuid.PcdArmArchTimerIntrNum|0x0

--- a/ArmVirtPkg/KvmtoolPlatformDxe/KvmtoolPlatformDxe.inf
+++ b/ArmVirtPkg/KvmtoolPlatformDxe/KvmtoolPlatformDxe.inf
@@ -42,4 +42,4 @@
   gUefiOvmfPkgTokenSpaceGuid.PcdForceNoAcpi
 
 [Depex]
-  TRUE
+  gEfiVariableArchProtocolGuid


### PR DESCRIPTION
The Kvmtool guest firmware uses the dynamic HII
PCD PcdForceNoAcpi to determine if ACPI tables
or the DT must be used for booting an OS.

This PcdForceNoAcpi is a BOOLEAN value that can
be configured using the variable "ForceNoAcpi"
specifing the gOvmfVariableGuid GUID which is
"50BEA1E5-A2C5-46E9-9B3A-59596516B00A".

However, this feature was not working as the
PCD was not defined in the platform DSC file
and the DEPEX section in KvmtoolPlatfomDxe.inf
was not set correctly.

Therefore, fix this issue so that the ACPI/DT
boot selection can be done from the UEFI shell
as shown below.

1. Check the status of the 'ForceNoAcpi' variable setvar ForceNoAcpi -guid "50BEA1E5-A2C5-46E9-9B3A-59596516B00A" -nv -bs

    Value 00 indicates ACPI boot
    Value 01 indicates DT boot

2. Set the boot mode to ACPI setvar ForceNoAcpi -guid "50BEA1E5-A2C5-46E9-9B3A-59596516B00A" -nv -bs =0x00

3. Set the boot mode to DT setvar ForceNoAcpi -guid "50BEA1E5-A2C5-46E9-9B3A-59596516B00A" -nv -bs =0x01

Cc: Ard Biesheuvel <ardb+tianocore@kernel.org>
Cc: Leif Lindholm <quic_llindhol@quicinc.com>
Cc: Gerd Hoffmann <kraxel@redhat.com>