### PR TITLE
Add UEFI 2.10 DeviceAuthentication and GUID

### DIFF
--- a/MdePkg/Include/Guid/DeviceAuthentication.h
+++ b/MdePkg/Include/Guid/DeviceAuthentication.h
@@ -1,0 +1,61 @@
+/** @file
+  Guid & data structure used for Device Security.
+
+  Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef EFI_DEVICE_AUTHENTICATION_GUID_H_
+#define EFI_DEVICE_AUTHENTICATION_GUID_H_
+
+/**
+  This is a signature database for device authentication, instead of image authentication.
+
+  The content of the signature database is same as the one in db/dbx. (a list of EFI_SIGNATURE_LIST)
+**/
+#define EFI_DEVICE_SIGNATURE_DATABASE_GUID \
+  {0xb9c2b4f4, 0xbf5f, 0x462d, 0x8a, 0xdf, 0xc5, 0xc7, 0xa, 0xc3, 0x5d, 0xad}
+#define EFI_DEVICE_SECURITY_DATABASE  L"devdb"
+
+extern EFI_GUID  gEfiDeviceSignatureDatabaseGuid;
+
+/**
+  Signature Database:
+
+  +---------------------------------------+ <-----------------
+  | SignatureType (GUID)                  |                  |
+  +---------------------------------------+                  |
+  | SignatureListSize (UINT32)            |                  |
+  +---------------------------------------+                  |
+  | SignatureHeaderSize (UINT32)          |                  |
+  +---------------------------------------+                  |
+  | SignatureSize (UINT32)                |                  |-EFI_SIGNATURE_LIST (1)
+  +---------------------------------------+                  |
+  | SignatureHeader (SignatureHeaderSize) |                  |
+  +---------------------------------------+ <--              |
+  | SignatureOwner (GUID)                 |   |              |
+  +---------------------------------------+   |-EFI_SIGNATURE_DATA (1)
+  | SignatureData (SignatureSize - 16)    |   |              |
+  +---------------------------------------+ <--              |
+  | SignatureOwner (GUID)                 |   |              |
+  +---------------------------------------+   |-EFI_SIGNATURE_DATA (n)
+  | SignatureData (SignatureSize - 16)    |   |              |
+  +---------------------------------------+ <-----------------
+  | SignatureType (GUID)                  |                  |
+  +---------------------------------------+                  |
+  | SignatureListSize (UINT32)            |                  |-EFI_SIGNATURE_LIST (n)
+  +---------------------------------------+                  |
+  | ...                                   |                  |
+  +---------------------------------------+ <-----------------
+
+  SignatureType := EFI_CERT_SHAxxx_GUID |
+                   EFI_CERT_RSA2048_GUID |
+                   EFI_CERT_RSA2048_SHAxxx_GUID |
+                   EFI_CERT_X509_GUID |
+                   EFI_CERT_X509_SHAxxx_GUID
+  (xxx = 256, 384, 512)
+
+**/
+
+#endif

--- a/MdePkg/MdePkg.dec
+++ b/MdePkg/MdePkg.dec
@@ -4,7 +4,7 @@
 # It also provides the definitions(including PPIs/PROTOCOLs/GUIDs) of
 # EFI1.10/UEFI2.7/PI1.7 and some Industry Standards.
 #
-# Copyright (c) 2007 - 2022, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2007 - 2024, Intel Corporation. All rights reserved.<BR>
 # Portions copyright (c) 2008 - 2009, Apple Inc. All rights reserved.<BR>
 # (C) Copyright 2016 - 2021 Hewlett Packard Enterprise Development LP<BR>
 # Copyright (c) 2022, Loongson Technology Corporation Limited. All rights reserved.<BR>
@@ -739,6 +739,12 @@
 
   ## Include/Protocol/SerilaIo.h
   gEfiSerialTerminalDeviceTypeGuid = { 0x6AD9A60F, 0x5815, 0x4C7C, { 0x8A, 0x10, 0x50, 0x53, 0xD2, 0xBF, 0x7A, 0x1B }}
+
+  # GUIDs defined in UEFI2.10
+  #
+  ## GUID used to specify section with devdb content
+  ## Include/Guid/DeviceAuthentication.h
+  gEfiDeviceSignatureDatabaseGuid  = { 0xb9c2b4f4, 0xbf5f, 0x462d, {0x8a, 0xdf, 0xc5, 0xc7, 0xa, 0xc3, 0x5d, 0xad }}
 
   #
   # GUID defined in PI1.0


### PR DESCRIPTION

Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Zhiguang Liu <zhiguang.liu@intel.com>
Cc: Jiewen Yao <jiewen.yao@intel.com>
Signed-off-by: Wenxing Hou <wenxing.hou@intel.com>

Wenxing Hou (2):
  MdePkg: Add UEFI 2.10 DeviceAuthentication
  MdePkg: Add gEfiDeviceSignatureDatabaseGuid to dec

 MdePkg/Include/Guid/DeviceAuthentication.h | 61 ++++++++++++++++++++++
 MdePkg/MdePkg.dec                          |  8 ++-
 2 files changed, 68 insertions(+), 1 deletion(-)
 create mode 100644 MdePkg/Include/Guid/DeviceAuthentication.h
