### PR TITLE
CryptoPkg: BaseCryptLib: ASN1_get_object() function return value is n…

### DIFF
--- a/CryptoPkg/Library/BaseCryptLib/Pk/CryptX509.c
+++ b/CryptoPkg/Library/BaseCryptLib/Pk/CryptX509.c
@@ -839,17 +839,17 @@ X509GetTBSCert (
   Length = 0;
   Inf    = ASN1_get_object (&Temp, (long *)&Length, (int *)&Asn1Tag, (int *)&ObjClass, (long)CertSize);
 
-  if (((Inf & 0x80) == 0x00) && (Asn1Tag != V_ASN1_SEQUENCE)) {
+  if (((Inf & 0x80) == 0x80) || (Asn1Tag != V_ASN1_SEQUENCE)) {
     return FALSE;
   }
 
   *TBSCert = (UINT8 *)Temp;
 
-  ASN1_get_object (&Temp, (long *)&Length, (int *)&Asn1Tag, (int *)&ObjClass, (long)Length);
+  Inf = ASN1_get_object (&Temp, (long *)&Length, (int *)&Asn1Tag, (int *)&ObjClass, (long)Length);
   //
   // Verify the parsed TBSCertificate is one correct SEQUENCE data.
   //
-  if (((Inf & 0x80) == 0x00) && (Asn1Tag != V_ASN1_SEQUENCE)) {
+  if (((Inf & 0x80) == 0x80) || (Asn1Tag != V_ASN1_SEQUENCE)) {
     return FALSE;
   }
 


### PR DESCRIPTION
CryptoPkg: BaseCryptLib: ASN1_get_object() function return value is not checked properly in CryptX509.c.

REF:https://bugzilla.tianocore.org/show_bug.cgi?id=4509

Added Inf variable, and the return value was checked properly.

Signed-off-by: Sountharya N <sountharyan@ami.com>

CC: Prarthana Sagar <prarthanasv@ami.com>
CC: Gayathri Thunuguntla <gayathrit@ami.com>
CC: Srinivasan Mani <srinivasanm@ami.com>