### PR TITLE
Add NOOPT Target to CompilerPlugin.py

### DIFF
--- a/.pytool/Plugin/CompilerPlugin/CompilerPlugin.py
+++ b/.pytool/Plugin/CompilerPlugin/CompilerPlugin.py
@@ -39,7 +39,7 @@ class CompilerPlugin(ICiBuildPlugin):
         return ("Compile " + packagename + " " + target, packagename + ".Compiler." + target)
 
     def RunsOnTargetList(self):
-        return ["DEBUG", "RELEASE"]
+        return ["DEBUG", "RELEASE", "NOOPT"]
 
     ##
     # External function of plugin.  This function is used to perform the task of the ICiBuildPlugin Plugin


### PR DESCRIPTION
Some UnitTest/HostTest supports this target only.

`CryptoPkg\Test\CryptoPkgHostUnitTest.dsc`
`FmpDevicePkg\Test\FmpDeviceHostPkgTest.dsc`
`MdeModulePkg\Test\MdeModulePkgHostTest.dsc`
`MdePkg\Test\MdePkgHostTest.dsc`
`NetworkPkg\Test\NetworkPkgHostTest.dsc`
`PrmPkg\Test\PrmPkgHostTest.dsc`
`PrmPkg\Test\PrmPkgHostTest.dsc`
`UefiCpuPkg\Test\UefiCpuPkgHostTest.dsc`
`UnitTestFrameworkPkg\Test\UnitTestFrameworkPkgHostTest.dsc` `UnitTestFrameworkPkg\Test\UnitTestFrameworkPkgHostTestExpectFail.dsc` . . .