### PR TITLE
NetworkPkg/HttpBootDxe: Correctly uninstall HttpBootCallbackProtocol

### DIFF
--- a/NetworkPkg/HttpBootDxe/HttpBootImpl.c
+++ b/NetworkPkg/HttpBootDxe/HttpBootImpl.c
@@ -77,12 +77,23 @@ HttpBootUninstallCallback (
   IN HTTP_BOOT_PRIVATE_DATA  *Private
   )
 {
+  EFI_STATUS  Status;
+  EFI_HANDLE  ControllerHandle;
+
   if (Private->HttpBootCallback == &Private->LoadFileCallback) {
-    gBS->UninstallProtocolInterface (
-           Private->Controller,
-           &gEfiHttpBootCallbackProtocolGuid,
-           &Private->HttpBootCallback
-           );
+    if (!Private->UsingIpv6) {
+      ControllerHandle = Private->Ip4Nic->Controller;
+    } else {
+      ControllerHandle = Private->Ip6Nic->Controller;
+    }
+
+    Status = gBS->UninstallProtocolInterface (
+                    ControllerHandle,
+                    &gEfiHttpBootCallbackProtocolGuid,
+                    Private->HttpBootCallback
+                    );
+    ASSERT_EFI_ERROR (Status);
+
     Private->HttpBootCallback = NULL;
   }
 }


### PR DESCRIPTION
The existing uninstall call was passing the wrong handle (parent object, not the correct child object) and additionally passing the address of a pointer to the interface to be removed rather than the pointer itself, so always failed with EFI_NOT_FOUND. After altering these, we add an ASSERT which confirms that the modified uninstall is succeeding.