### PR TITLE
Pull: RISC-V: Support Svpbmt extension 

### DIFF
--- a/MdePkg/MdePkg.dec
+++ b/MdePkg/MdePkg.dec
@@ -2413,6 +2413,8 @@
   # previous stage has feature enabled and user wants to disable it.
   # BIT 1 = Supervisor Time Compare (Sstc). This bit is relevant only if
   # previous stage has feature enabled and user wants to disable it.
+  # BIT 2 = Page-Based Memory Types (Pbmt). This bit is relevant only if
+  # previous stage has feature enabled and user wants to disable it.
   #
   gEfiMdePkgTokenSpaceGuid.PcdRiscVFeatureOverride|0xFFFFFFFFFFFFFFFF|UINT64|0x69
 

--- a/OvmfPkg/RiscVVirt/RiscVVirt.dsc.inc
+++ b/OvmfPkg/RiscVVirt/RiscVVirt.dsc.inc
@@ -203,7 +203,7 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdInstallAcpiSdtProtocol|TRUE
 
 [PcdsFixedAtBuild.common]
-  gEfiMdePkgTokenSpaceGuid.PcdRiscVFeatureOverride|0xFFFFFFFFFFFFFFFC
+  gEfiMdePkgTokenSpaceGuid.PcdRiscVFeatureOverride|0xFFFFFFFFFFFFFFF8
   gEfiMdePkgTokenSpaceGuid.PcdMaximumUnicodeStringLength|1000000
   gEfiMdePkgTokenSpaceGuid.PcdMaximumAsciiStringLength|1000000
   gEfiMdePkgTokenSpaceGuid.PcdMaximumLinkedListLength|0

--- a/UefiCpuPkg/Library/BaseRiscVMmuLib/BaseRiscVMmuLib.inf
+++ b/UefiCpuPkg/Library/BaseRiscVMmuLib/BaseRiscVMmuLib.inf
@@ -28,3 +28,4 @@
 
 [Pcd]
   gUefiCpuPkgTokenSpaceGuid.PcdCpuRiscVMmuMaxSatpMode  ## CONSUMES
+  gEfiMdePkgTokenSpaceGuid.PcdRiscVFeatureOverride     ## CONSUMES


### PR DESCRIPTION
This series adds support for RISC-V Svpbmt extension.                                                                                                                                                       
                                                                                                                                                                                                            
The GCD EFI_MEMORY_UC and EFI_MEMORY_WC attributes will                                                                                                                                                     
be mapped to IO and NC mode defined in PBMT field.   