### PR TITLE
SecurityPkg/Tcg2Config: Hide BIOS unsupported hash algorithm from UI

### DIFF
--- a/SecurityPkg/Tcg/Tcg2Config/Tcg2ConfigImpl.c
+++ b/SecurityPkg/Tcg/Tcg2Config/Tcg2ConfigImpl.c
@@ -722,33 +722,50 @@ FillBufferWithBootHashAlg (
 }
 
 /**
-  Set ConfigInfo according to TpmAlgHash.
+  Set ConfigInfo according to TpmAlgHash and BiosHashAlgBitmap.
 
   @param[in,out] Tcg2ConfigInfo       TCG2 config info.
   @param[in]     TpmAlgHash           TpmAlgHash.
+  @param[in]     BiosHashAlgBitmap    Bios Hash Algorithm Bitmap.
 
 **/
 VOID
 SetConfigInfo (
   IN OUT TCG2_CONFIGURATION_INFO  *Tcg2ConfigInfo,
-  IN UINT32                       TpmAlgHash
+  IN UINT32                       TpmAlgHash,
+  IN UINT32                       BiosHashAlgBitmap
   )
 {
   switch (TpmAlgHash) {
     case TPM_ALG_SHA1:
-      Tcg2ConfigInfo->Sha1Supported = TRUE;
+      if ((BiosHashAlgBitmap & HASH_ALG_SHA1) != 0) {
+        Tcg2ConfigInfo->Sha1Supported = TRUE;
+      }
+
       break;
     case TPM_ALG_SHA256:
-      Tcg2ConfigInfo->Sha256Supported = TRUE;
+      if ((BiosHashAlgBitmap & HASH_ALG_SHA256) != 0) {
+        Tcg2ConfigInfo->Sha256Supported = TRUE;
+      }
+
       break;
     case TPM_ALG_SHA384:
-      Tcg2ConfigInfo->Sha384Supported = TRUE;
+      if ((BiosHashAlgBitmap & HASH_ALG_SHA384) != 0) {
+        Tcg2ConfigInfo->Sha384Supported = TRUE;
+      }
+
       break;
     case TPM_ALG_SHA512:
-      Tcg2ConfigInfo->Sha512Supported = TRUE;
+      if ((BiosHashAlgBitmap & HASH_ALG_SHA512) != 0) {
+        Tcg2ConfigInfo->Sha512Supported = TRUE;
+      }
+
       break;
     case TPM_ALG_SM3_256:
-      Tcg2ConfigInfo->Sm3Supported = TRUE;
+      if ((BiosHashAlgBitmap & HASH_ALG_SM3_256) != 0) {
+        Tcg2ConfigInfo->Sm3Supported = TRUE;
+      }
+
       break;
   }
 }
@@ -809,16 +826,17 @@ InstallTcg2ConfigForm (
   IN OUT TCG2_CONFIG_PRIVATE_DATA  *PrivateData
   )
 {
-  EFI_STATUS                      Status;
-  EFI_HII_HANDLE                  HiiHandle;
-  EFI_HANDLE                      DriverHandle;
-  EFI_HII_CONFIG_ACCESS_PROTOCOL  *ConfigAccess;
-  UINTN                           Index;
-  TPML_PCR_SELECTION              Pcrs;
-  CHAR16                          TempBuffer[1024];
-  TCG2_CONFIGURATION_INFO         Tcg2ConfigInfo;
-  TPM2_PTP_INTERFACE_TYPE         TpmDeviceInterfaceDetected;
-  BOOLEAN                         IsCmdImp = FALSE;
+  EFI_STATUS                       Status;
+  EFI_HII_HANDLE                   HiiHandle;
+  EFI_HANDLE                       DriverHandle;
+  EFI_HII_CONFIG_ACCESS_PROTOCOL   *ConfigAccess;
+  UINTN                            Index;
+  TPML_PCR_SELECTION               Pcrs;
+  CHAR16                           TempBuffer[1024];
+  TCG2_CONFIGURATION_INFO          Tcg2ConfigInfo;
+  TPM2_PTP_INTERFACE_TYPE          TpmDeviceInterfaceDetected;
+  BOOLEAN                          IsCmdImp;
+  EFI_TCG2_EVENT_ALGORITHM_BITMAP  BiosHashAlgorithmBitmap;
 
   DriverHandle = NULL;
   ConfigAccess = &PrivateData->ConfigAccess;
@@ -879,6 +897,8 @@ InstallTcg2ConfigForm (
       break;
   }
 
+  BiosHashAlgorithmBitmap = PcdGet32 (PcdTcg2HashAlgorithmBitmap);
+
   ZeroMem (&Tcg2ConfigInfo, sizeof (Tcg2ConfigInfo));
   Status = Tpm2GetCapabilityPcrs (&Pcrs);
   if (EFI_ERROR (Status)) {
@@ -897,20 +917,21 @@ InstallTcg2ConfigForm (
     TempBuffer[0] = 0;
     for (Index = 0; Index < Pcrs.count; Index++) {
       AppendBufferWithTpmAlgHash (TempBuffer, sizeof (TempBuffer), Pcrs.pcrSelections[Index].hash);
-      SetConfigInfo (&Tcg2ConfigInfo, Pcrs.pcrSelections[Index].hash);
+      SetConfigInfo (&Tcg2ConfigInfo, Pcrs.pcrSelections[Index].hash, BiosHashAlgorithmBitmap);
     }
 
     HiiSetString (PrivateData->HiiHandle, STRING_TOKEN (STR_TPM2_SUPPORTED_HASH_ALGO_CONTENT), TempBuffer, NULL);
   }
 
-  Status = Tpm2GetCapabilityIsCommandImplemented (TPM_CC_ChangeEPS, &IsCmdImp);
+  IsCmdImp = FALSE;
+  Status   = Tpm2GetCapabilityIsCommandImplemented (TPM_CC_ChangeEPS, &IsCmdImp);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "Tpm2GetCapabilityIsCmdImpl fails %r\n", Status));
   }
 
   Tcg2ConfigInfo.ChangeEPSSupported = IsCmdImp;
 
-  FillBufferWithBootHashAlg (TempBuffer, sizeof (TempBuffer), PcdGet32 (PcdTcg2HashAlgorithmBitmap));
+  FillBufferWithBootHashAlg (TempBuffer, sizeof (TempBuffer), BiosHashAlgorithmBitmap);
   HiiSetString (PrivateData->HiiHandle, STRING_TOKEN (STR_BIOS_HASH_ALGO_CONTENT), TempBuffer, NULL);
 
   //


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4731

TCG2 configuration UI shows all the hash algorithms that TPM hardware supports in the checkbox. If user only selects one algorithm that is supported by TPM hardware but not supported by BIOS and uncheck the others, the SyncPcrAllocationsAndPcrMask in Tcg2Pei will not be able to decide a viable PCR to activate, then an assert occurs.

Add check against PcdTcg2HashAlgorithmBitmap when deciding whether to suppress the hash algorithm checkbox to avoid user to select the hash algorithm which may cause an assert.

Cc: Rahul Kumar <rahul1.kumar@intel.com>
Cc: Jiewen Yao <jiewen.yao@intel.com>

Reviewed-by: Rahul Kumar <rahul1.kumar@intel.com>