### PR TITLE
MdeModulePkg/AcpiTableDxe: PCD switch to avoid using ACPI reclaim memory

### DIFF
--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -1533,6 +1533,13 @@
   # @Prompt Exposed ACPI table versions.
   gEfiMdeModulePkgTokenSpaceGuid.PcdAcpiExposedTableVersions|0x3E|UINT32|0x0001004c
 
+  ## Indicates whether ACPI Reclaim memory is not available
+  # Default is FALSE that means ACPI Reclaim memory is available
+  # If it is set to TRUE that means ACPI Reclaim memory is not available
+  # For example ACPI Table protocol will use ACPI NVS memory instead of ACPI Reclaim memory
+  # @Prompt ACPI Reclaim memory is not available.
+  gEfiMdeModulePkgTokenSpaceGuid.PcdNoACPIReclaimMemory|FALSE|BOOLEAN|0x0001008b
+
   ## This PCD defines the MAX repair count.
   #  The default value is 0 that means infinite.
   # @Prompt MAX repair count

--- a/MdeModulePkg/MdeModulePkg.uni
+++ b/MdeModulePkg/MdeModulePkg.uni
@@ -955,6 +955,14 @@
                                                                                              "BIT 4 - EFI_ACPI_TABLE_VERSION_4_0.<BR>\n"
                                                                                              "BIT 5 - EFI_ACPI_TABLE_VERSION_5_0.<BR>"
 
+#string STR_gEfiMdeModulePkgTokenSpaceGuid_PcdNoACPIReclaimMemory_PROMPT  #language en-US "ACPI Reclaim memory is not available."
+
+#string STR_gEfiMdeModulePkgTokenSpaceGuid_PcdNoACPIReclaimMemory_HELP  #language en-US "Indicates whether ACPI Reclaim memory is not available\n"
+                                                                                     "Default is FALSE that means ACPI Reclaim memory is available\n"
+                                                                                     "If it is set to TRUE that means ACPI Reclaim memory is not available\n"
+                                                                                     "For example ACPI Table protocol will use ACPI NVS memory instead of ACPI Reclaim memory"
+
+
 #string STR_gEfiMdeModulePkgTokenSpaceGuid_PcdHiiOsRuntimeSupport_PROMPT  #language en-US "Enable export HII data and configuration to be used in OS runtime."
 
 #string STR_gEfiMdeModulePkgTokenSpaceGuid_PcdHiiOsRuntimeSupport_HELP  #language en-US "Indicates if HII data and configuration has been exported.<BR><BR>\n"

--- a/MdeModulePkg/Universal/Acpi/AcpiTableDxe/AcpiTableDxe.inf
+++ b/MdeModulePkg/Universal/Acpi/AcpiTableDxe/AcpiTableDxe.inf
@@ -68,6 +68,7 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdAcpiDefaultCreatorId        ## CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdAcpiDefaultCreatorRevision  ## CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdAcpiExposedTableVersions    ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdNoACPIReclaimMemory         ## CONSUMES
 
 [Protocols]
   gEfiAcpiTableProtocolGuid                     ## PRODUCES


### PR DESCRIPTION
UEFI spec defined ACPI Tables at boot time can be contained in memory of type EfiACPIReclaimMemory or EfiAcpiMemoryNVS, although InstallAcpiTable with AcpiTableProtocol will only allocate memory with type EfiACPIReclaimMemory (Except FACS).

This patch provides an optional method controlled by PCD to avoid using EfiACPIReclaimMemory, by setting the PCD PcdNoACPIReclaimMemory to TRUE, all ACPI allocated memory will use EfiAcpiMemoryNVS instead.

Cc: Zhiguang Liu <zhiguang.liu@intel.com>
Cc: Dandan Bi <dandan.bi@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Liu Yun <yun.y.liu@intel.com>
Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Cc: Michael D Kinney <michael.d.kinney@intel.com>

Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>
Reviewed-by: Zhiguang Liu <zhiguang.liu@intel.com>