### PR TITLE
Fix bug in `UefiShellLib.c`

### DIFF
--- a/ShellPkg/Library/UefiShellLib/UefiShellLib.c
+++ b/ShellPkg/Library/UefiShellLib/UefiShellLib.c
@@ -2709,8 +2709,10 @@ ShellCommandLineGetCount (
         ; Node1 = GetNextNode (CheckPackage, Node1)
         )
   {
-    if (((SHELL_PARAM_PACKAGE *)Node1)->Name == NULL) {
+    if (((SHELL_PARAM_PACKAGE *)Node1)->Name != NULL) {
       Count++;
+    } else {
+      break;
     }
   }
 


### PR DESCRIPTION
Current `ShellCommandLineGetCount ()` will never return. 

Fix it.

Signed-off-by: Raymond Yang <yangrongwei@hotmail.com>