### PR TITLE
BaseTool/Ecc: Fix incorrect parsing of variable initialisation

### DIFF
--- a/BaseTools/Source/Python/Ecc/c.py
+++ b/BaseTools/Source/Python/Ecc/c.py
@@ -182,8 +182,27 @@ def GetIdentifierList():
             continue
 
         if var.Declarator.find('{') == -1:
-            for decl in var.Declarator.split(','):
-                DeclList = decl.split('=')
+            DeclText = var.Declarator
+            while (len(DeclText) > 0):
+                AllocatorPos = DeclText.find('=')
+                SplitPos = DeclText.find(',')
+
+                if (SplitPos == -1):
+                    SplitPos = len(DeclText)
+                elif (SplitPos > AllocatorPos):
+                    NextAllcatorPos = DeclText.find('=', AllocatorPos + 1)
+                    if (NextAllcatorPos == -1):
+                        NextAllcatorPos = len(DeclText)
+                    ParPos = DeclText.rfind(')', SplitPos, NextAllcatorPos)
+                    if (ParPos != -1):
+                        SplitPos = DeclText.find(',', ParPos)
+                        if (SplitPos == -1):
+                            SplitPos = ParPos + 1
+
+                SubDeclText = DeclText[:SplitPos]
+                DeclText = DeclText[SplitPos + 1:]
+
+                DeclList = SubDeclText.split('=')
                 Name = DeclList[0].strip()
                 if ArrayPattern.match(Name):
                     LSBPos = var.Declarator.find('[')


### PR DESCRIPTION
If a global variable is initialised using a macro with multiple arguments, ECC incorrectly parses the statement and reports the macro arguments as variable declarations.

Example: In the following statement:
  STATIC INT WrongVariable = MACRO_VERSION(1, 0), NextVariable;
The logic in the ECC function GetIdentifierList() interprets the above statement as declaration of three variables:
    1. 'WrongVariable = MACRO_VERSION(1,' 2. '0)' 3. 'NextVariable' Following which NamingConventionCheckVariableName() reports an error for "0)" stating an incorrect variable declaration as below:
"ERROR - *The variable name [0)] does not follow the rules"

This patch fixes the parsing logic so that scenarios with macro initialisations are handled correctly.