### PR TITLE
IntelFsp2Pkg/FspSecCore: Update for x64 build

### DIFF
--- a/IntelFsp2Pkg/FspSecCore/SecFsp.c
+++ b/IntelFsp2Pkg/FspSecCore/SecFsp.c
@@ -88,8 +88,9 @@ SecGetPlatformData (
       if (*(StackPtr - 1) == FSP_MCUD_SIGNATURE) {
         //
         // This following data was pushed onto stack after TempRamInit API
+        // 64-bit FSP-T pushes these values as QWORDs
         //
-        DwordSize = 4;
+        DwordSize = (4*sizeof (UINTN))/sizeof (UINT32);
         StackPtr  = StackPtr - 1 - DwordSize;
         CopyMem (&(FspPlatformData->MicrocodeRegionBase), StackPtr, (DwordSize << 2));
         StackPtr--;


### PR DESCRIPTION
SecGetPlatformData() fills in MicrocodeRegion and CodeRegion info from fields populated in the top of CAR stack by EstablishStackFsp. These stack fields are populated using native word size, but SecGetPlatformData() assumes ia32 build. This causes incorrect values in FspPlatformData. The fix is to adjust the offset/size copied from stack based on the size of UINTN.

Signed-off-by: Bejean Mosher <bejean.mosher@intel.com>
Reviewed-by: Guo Dong <guo.dong@intel.com>