### PR TITLE
Add SHA3/SM3 functions with openssl for Mbedtls

### DIFF
--- a/CryptoPkg/Library/BaseCryptLibMbedTls/BaseCryptLib.inf
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/BaseCryptLib.inf
@@ -18,6 +18,7 @@
   MODULE_TYPE                    = DXE_DRIVER
   VERSION_STRING                 = 1.0
   LIBRARY_CLASS                  = BaseCryptLib|DXE_DRIVER DXE_CORE UEFI_APPLICATION UEFI_DRIVER
+  DEFINE BASE_CRYPT_PATH         = ../BaseCryptLib
 
 #
 # The following information is for reference only and not required by the build tools.
@@ -31,10 +32,14 @@
   Cipher/CryptAes.c
   Hash/CryptSha256.c
   Hash/CryptSha512.c
-  Hash/CryptParallelHashNull.c
-  Hash/CryptSm3Null.c
   Hash/CryptMd5.c
   Hash/CryptSha1.c
+  $(BASE_CRYPT_PATH)/Hash/CryptCShake256.c
+  $(BASE_CRYPT_PATH)/Hash/CryptDispatchApDxe.c
+  $(BASE_CRYPT_PATH)/Hash/CryptParallelHash.c
+  $(BASE_CRYPT_PATH)/Hash/CryptSha3.c
+  $(BASE_CRYPT_PATH)/Hash/CryptSm3.c
+  $(BASE_CRYPT_PATH)/Hash/CryptXkcp.c
   Hmac/CryptHmac.c
   Kdf/CryptHkdf.c
   Pk/CryptRsaBasic.c

--- a/CryptoPkg/Library/BaseCryptLibMbedTls/PeiCryptLib.inf
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/PeiCryptLib.inf
@@ -26,6 +26,7 @@
   MODULE_TYPE                    = PEIM
   VERSION_STRING                 = 1.0
   LIBRARY_CLASS                  = BaseCryptLib|PEIM PEI_CORE
+  DEFINE BASE_CRYPT_PATH         = ../BaseCryptLib
 
 #
 # The following information is for reference only and not required by the build tools.
@@ -38,9 +39,13 @@
   Hash/CryptMd5.c
   Hash/CryptSha1.c
   Hash/CryptSha256.c
-  Hash/CryptSm3Null.c
   Hash/CryptSha512.c
-  Hash/CryptParallelHashNull.c
+  $(BASE_CRYPT_PATH)/Hash/CryptCShake256.c
+  $(BASE_CRYPT_PATH)/Hash/CryptDispatchApPei.c
+  $(BASE_CRYPT_PATH)/Hash/CryptParallelHash.c
+  $(BASE_CRYPT_PATH)/Hash/CryptSha3.c
+  $(BASE_CRYPT_PATH)/Hash/CryptSm3.c
+  $(BASE_CRYPT_PATH)/Hash/CryptXkcp.c
   Hmac/CryptHmac.c
   Kdf/CryptHkdf.c
   Cipher/CryptAes.c

--- a/CryptoPkg/Library/BaseCryptLibMbedTls/RuntimeCryptLib.inf
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/RuntimeCryptLib.inf
@@ -25,6 +25,7 @@
   VERSION_STRING                 = 1.0
   LIBRARY_CLASS                  = BaseCryptLib|DXE_RUNTIME_DRIVER
   CONSTRUCTOR                    = RuntimeCryptLibConstructor
+  DEFINE BASE_CRYPT_PATH         = ../BaseCryptLib
 
 #
 # The following information is for reference only and not required by the build tools.
@@ -37,9 +38,9 @@
   Hash/CryptMd5.c
   Hash/CryptSha1.c
   Hash/CryptSha256.c
-  Hash/CryptSm3Null.c
   Hash/CryptSha512.c
   Hash/CryptParallelHashNull.c
+  $(BASE_CRYPT_PATH)/Hash/CryptSm3.c
   Hmac/CryptHmac.c
   Kdf/CryptHkdf.c
   Cipher/CryptAes.c

--- a/CryptoPkg/Library/BaseCryptLibMbedTls/SmmCryptLib.inf
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/SmmCryptLib.inf
@@ -24,6 +24,7 @@
   VERSION_STRING                 = 1.0
   PI_SPECIFICATION_VERSION       = 0x0001000A
   LIBRARY_CLASS                  = BaseCryptLib|DXE_SMM_DRIVER SMM_CORE MM_STANDALONE
+  DEFINE BASE_CRYPT_PATH         = ../BaseCryptLib
 
 #
 # The following information is for reference only and not required by the build tools.
@@ -36,9 +37,13 @@
   Hash/CryptMd5.c
   Hash/CryptSha1.c
   Hash/CryptSha256.c
-  Hash/CryptSm3Null.c
   Hash/CryptSha512.c
-  Hash/CryptParallelHashNull.c
+  $(BASE_CRYPT_PATH)/Hash/CryptCShake256.c
+  $(BASE_CRYPT_PATH)/Hash/CryptDispatchApMm.c
+  $(BASE_CRYPT_PATH)/Hash/CryptParallelHash.c
+  $(BASE_CRYPT_PATH)/Hash/CryptSha3.c
+  $(BASE_CRYPT_PATH)/Hash/CryptSm3.c
+  $(BASE_CRYPT_PATH)/Hash/CryptXkcp.c
   Hmac/CryptHmac.c
   Kdf/CryptHkdf.c
   Cipher/CryptAes.c

--- a/CryptoPkg/Library/BaseCryptLibMbedTls/TestBaseCryptLib.inf
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/TestBaseCryptLib.inf
@@ -18,6 +18,7 @@
   MODULE_TYPE                    = DXE_DRIVER
   VERSION_STRING                 = 1.0
   LIBRARY_CLASS                  = BaseCryptLib|DXE_DRIVER DXE_CORE UEFI_APPLICATION UEFI_DRIVER
+  DEFINE BASE_CRYPT_PATH         = ../BaseCryptLib
 
 #
 # The following information is for reference only and not required by the build tools.
@@ -31,9 +32,10 @@
   Cipher/CryptAes.c
   Hash/CryptSha256.c
   Hash/CryptSha512.c
-  Hash/CryptSm3Null.c
   Hash/CryptMd5.c
   Hash/CryptSha1.c
+  $(BASE_CRYPT_PATH)/Hash/CryptSm3.c
+  Hash/CryptParallelHashNull.c
   Hmac/CryptHmac.c
   Kdf/CryptHkdf.c
   Pk/CryptRsaBasic.c

--- a/CryptoPkg/Library/MbedTlsLib/MbedTlsLib.inf
+++ b/CryptoPkg/Library/MbedTlsLib/MbedTlsLib.inf
@@ -13,6 +13,7 @@
   MODULE_TYPE                    = BASE
   VERSION_STRING                 = 1.0
   LIBRARY_CLASS                  = MbedTlsLib
+  DEFINE OPENSSL_PATH            = ../OpensslLib/openssl
 
 #
 # The following information is for reference only and not required by the build tools.
@@ -21,6 +22,11 @@
 #
 
 [Sources]
+# Openssl files list starts here
+  $(OPENSSL_PATH)/crypto/mem_clr.c
+  $(OPENSSL_PATH)/crypto/sha/keccak1600.c
+  $(OPENSSL_PATH)/crypto/sm3/sm3.c
+# Openssl files list ends here
   Include/mbedtls/mbedtls_config.h
   mbedtls/library/aes.c
   mbedtls/library/asn1parse.c

--- a/CryptoPkg/Library/MbedTlsLib/MbedTlsLibFull.inf
+++ b/CryptoPkg/Library/MbedTlsLib/MbedTlsLibFull.inf
@@ -13,6 +13,7 @@
   MODULE_TYPE                    = BASE
   VERSION_STRING                 = 1.0
   LIBRARY_CLASS                  = MbedTlsLib
+  DEFINE OPENSSL_PATH            = ../OpensslLib/openssl
 
 #
 # The following information is for reference only and not required by the build tools.
@@ -21,6 +22,11 @@
 #
 
 [Sources]
+# Openssl files list starts here
+  $(OPENSSL_PATH)/crypto/mem_clr.c
+  $(OPENSSL_PATH)/crypto/sha/keccak1600.c
+  $(OPENSSL_PATH)/crypto/sm3/sm3.c
+# Openssl files list ends here
   Include/mbedtls/mbedtls_config.h
   mbedtls/library/aes.c
   mbedtls/library/asn1parse.c


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4177

Because the Mbedlts 3.3.0 doesn't have SHA3 and Sm3, the SHA3 and Sm3 implementaion based on Openssl.

Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Yi Li <yi1.li@intel.com>