### PR TITLE
BaseTools/GetUtcDateTime.py: Python 3.12 support

### DIFF
--- a/BaseTools/Scripts/GetUtcDateTime.py
+++ b/BaseTools/Scripts/GetUtcDateTime.py
@@ -29,7 +29,7 @@ def Main():
         print ("ERROR: At least one argument is required!\n")
         PARSER.print_help()
 
-    today = datetime.datetime.utcnow()
+    today = datetime.datetime.now(datetime.timezone.utc)
     if ARGS.year:
         ReversedNumber = str(today.year)[::-1]
         print (''.join(hex(ord(HexString))[2:] for HexString in ReversedNumber))


### PR DESCRIPTION
Ref to https://docs.python.org/3/whatsnew/3.12.html utcnow() and utcfromtimestamp() are deprecated
Prevent use it cause build error.

Cc: Rebecca Cran <rebecca@bsdio.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn> (https://edk2.groups.io/g/devel/message/118145?p=%2C%2C%2C20%2C0%2C0%2C0%3A%3Arecentpostdate%2Fsticky%2C%2CBaseTools%2FGetUtcDateTime.py+3.12+support%2C20%2C2%2C0%2C105690657)
Cc: Bob Feng <bob.c.feng@intel.com>
Cc: Yuwei Chen <yuwei.chen@intel.com>