### PR TITLE
BaseTools/Fmmt.py: Python 3.12 support

### DIFF
--- a/BaseTools/Source/Python/FMMT/FMMT.py
+++ b/BaseTools/Source/Python/FMMT/FMMT.py
@@ -37,7 +37,7 @@ parser.add_argument("-l", "--LayoutFileName", dest="LayoutFileName", nargs='+',
                         the file will be generated with default name (Layout_'InputFileName'.txt). \
                         Currently supports two formats: json, txt. More formats will be added in the future")
 parser.add_argument("-c", "--ConfigFilePath", dest="ConfigFilePath", nargs='+',
-                    help="Provide the target FmmtConf.ini file path: '-c C:\Code\FmmtConf.ini' \
+                    help="Provide the target FmmtConf.ini file path: '-c C:\\Code\\FmmtConf.ini' \
                         FmmtConf file saves the target guidtool used in compress/uncompress process.\
                         If do not provide, FMMT tool will search the inputfile folder for FmmtConf.ini firstly, if not found,\
                         the FmmtConf.ini saved in FMMT tool's folder will be used as default.")


### PR DESCRIPTION
Ref to https://docs.python.org/3/whatsnew/3.12.html A backslash-character pair that is not a valid
escape sequence now generates

Cc: Rebecca Cran <rebecca@bsdio.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Bob Feng <bob.c.feng@intel.com>
Cc: Yuwei Chen <yuwei.chen@intel.com>