### PR TITLE
OvmfPkg/VirtHstiDxe: do not load driver in confidential guests

### DIFF
--- a/OvmfPkg/VirtHstiDxe/VirtHstiDxe.c
+++ b/OvmfPkg/VirtHstiDxe/VirtHstiDxe.c
@@ -17,6 +17,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/MemoryAllocationLib.h>
 #include <Library/UefiBootServicesTableLib.h>
 #include <Library/UefiLib.h>
+#include <Library/PcdLib.h>
 #include <Library/PlatformInitLib.h>
 
 #include <IndustryStandard/Hsti.h>
@@ -139,6 +140,11 @@ VirtHstiDxeEntrypoint (
   UINT16                               DevId;
   EFI_STATUS                           Status;
   EFI_EVENT                            Event;
+
+  if (PcdGet64 (PcdConfidentialComputingGuestAttr)) {
+    DEBUG ((DEBUG_INFO, "%a: confidential guest\n", __func__));
+    return EFI_UNSUPPORTED;
+  }
 
   DevId = VirtHstiGetHostBridgeDevId ();
   switch (DevId) {

--- a/OvmfPkg/VirtHstiDxe/VirtHstiDxe.inf
+++ b/OvmfPkg/VirtHstiDxe/VirtHstiDxe.inf
@@ -49,6 +49,7 @@
   gUefiOvmfPkgTokenSpaceGuid.PcdSmmSmramRequire
 
 [Pcd]
+  gEfiMdePkgTokenSpaceGuid.PcdConfidentialComputingGuestAttr
   gUefiOvmfPkgTokenSpaceGuid.PcdBfvBase
   gUefiOvmfPkgTokenSpaceGuid.PcdOvmfFlashNvStorageVariableBase
 


### PR DESCRIPTION
The VirtHstiDxe does not work in confidential guests.  There also isn't
anything we can reasonably test, neither flash storage nor SMM mode will
be used in that case.  So just skip driver load when running in a
confidential guest.

Cc: Ard Biesheuvel <ardb+tianocore@kernel.org>
Cc: Jiewen Yao <jiewen.yao@intel.com>
Fixes: 506740982bba ("OvmfPkg/VirtHstiDxe: add code flash check")
Signed-off-by: Gerd Hoffmann <kraxel@redhat.com>
Tested-by: Srikanth Aithal <sraithal@amd.com>
