### PR TITLE
AMD Debugswap

### DIFF
--- a/MdePkg/Include/ConfidentialComputingGuestAttr.h
+++ b/MdePkg/Include/ConfidentialComputingGuestAttr.h
@@ -29,9 +29,20 @@ typedef enum {
 
   /* The guest is running with Intel TDX memory encryption enabled. */
   CCAttrIntelTdx = 0x200,
+
+  CCAttrTypeMask = 0x000000000000ffff,
+
+  /* Features */
+
+  /* The AMD SEV-ES DebugSwap feature is enabled in SEV_STATUS */
+  CCAttrFeatureAmdSevDebugSwap = 0x0000000000010000,
+
+  CCAttrFeatureMask = 0xffffffffffff0000,
 } CONFIDENTIAL_COMPUTING_GUEST_ATTR;
 
-#define CC_GUEST_IS_TDX(x)  ((x) == CCAttrIntelTdx)
-#define CC_GUEST_IS_SEV(x)  ((x) == CCAttrAmdSev || (x) == CCAttrAmdSevEs || (x) == CCAttrAmdSevSnp)
+#define _CC_GUEST_IS_TDX(x)  ((x) == CCAttrIntelTdx)
+#define CC_GUEST_IS_TDX(x)   _CC_GUEST_IS_TDX((x) & CCAttrTypeMask)
+#define _CC_GUEST_IS_SEV(x)  ((x) == CCAttrAmdSev || (x) == CCAttrAmdSevEs || (x) == CCAttrAmdSevSnp)
+#define CC_GUEST_IS_SEV(x)   _CC_GUEST_IS_SEV((x) & CCAttrTypeMask)
 
 #endif

--- a/MdePkg/Include/Register/Amd/Fam17Msr.h
+++ b/MdePkg/Include/Register/Amd/Fam17Msr.h
@@ -126,19 +126,74 @@ typedef union {
     ///
     /// [Bit 0] Secure Encrypted Virtualization (Sev) is enabled
     ///
-    UINT32    SevBit    : 1;
+    UINT32    SevBit              : 1;
 
     ///
     /// [Bit 1] Secure Encrypted Virtualization Encrypted State (SevEs) is enabled
     ///
-    UINT32    SevEsBit  : 1;
+    UINT32    SevEsBit            : 1;
 
     ///
     /// [Bit 2] Secure Nested Paging (SevSnp) is enabled
     ///
-    UINT32    SevSnpBit : 1;
+    UINT32    SevSnpBit           : 1;
 
-    UINT32    Reserved2 : 29;
+    ///
+    /// [Bit 3] The guest was run with the Virtual TOM feature enabled in SEV_FEATURES[1]
+    ///
+    UINT32    vTOM_Enabled        : 1;
+
+    ///
+    /// [Bit 4] The guest was run with the ReflectVC feature enabled in SEV_FEATURES[2]
+    ///
+    UINT32    ReflectVC           : 1;
+
+    ///
+    /// [Bit 5] The guest was run with the Restricted Injection feature enabled in SEV_FEATURES[3]
+    ///
+    UINT32    RestrictedInjection : 1;
+
+    ///
+    /// [Bit 6] The guest was run with the Alternate Injection feature enabled in SEV_FEATURES[4]
+    ///
+    UINT32    AlternateInjection  : 1;
+
+    ///
+    /// [Bit 7] This guest was run with debug register swapping enabled in SEV_FEATURES[5]
+    ///
+    UINT32    DebugSwap           : 1;
+
+    ///
+    /// [Bit 8]  This guest was run with the PreventHostIBS feature enabled in SEV_FEATURES[6]
+    ///
+    UINT32    PreventHostIBS      : 1;
+
+    ///
+    /// [Bit 9] The guest was run with the BTB isolation feature enabled in SEV_FEATURES[7]
+    ///
+    UINT32    SNPBTBIsolation     : 1;
+
+    ///
+    /// [Bit 10]
+    ///
+    UINT32    Reserved0           : 1;
+
+    ///
+    /// [Bit 11] The guest was run with the Secure TSC feature enabled in SEV_FEATURES[9]
+    ///
+    UINT32    SecureTsc           : 1;
+
+    ///
+    /// [Bits 12 13 14 15]
+    ///
+    UINT32    Reserved1           : 4;
+
+    ///
+    /// [Bit 16] The guest was run with the VMSA Register Protection feature enabled in SEV_FEATURES[14]
+    ///
+    UINT32    VmsaRegProt_Enabled : 1;
+
+    UINT32    Reserved2           : 15;
   } Bits;
   ///
   /// All bit fields as a 32-bit value

--- a/OvmfPkg/Include/Library/MemEncryptSevLib.h
+++ b/OvmfPkg/Include/Library/MemEncryptSevLib.h
@@ -167,6 +167,18 @@ MemEncryptSevGetEncryptionMask (
   );
 
 /**
+  Returns a boolean to indicate whether DebugSwap is enabled.
+
+  @retval TRUE           DebugSwap is enabled
+  @retval FALSE          DebugSwap is not enabled
+**/
+BOOLEAN
+EFIAPI
+MemEncryptSevEsDebugSwapIsEnabled (
+  VOID
+  );
+
+/**
   Returns the encryption state of the specified virtual address range.
 
   @param[in]  Cr3BaseAddress          Cr3 Base Address (if zero then use

--- a/OvmfPkg/Library/BaseMemEncryptSevLib/DxeMemEncryptSevLibInternal.c
+++ b/OvmfPkg/Library/BaseMemEncryptSevLib/DxeMemEncryptSevLibInternal.c
@@ -40,19 +40,25 @@ AmdMemEncryptionAttrCheck (
   IN  CONFIDENTIAL_COMPUTING_GUEST_ATTR  Attr
   )
 {
+  UINT64  CurrentLevel;
+
+  CurrentLevel = CurrentAttr & CCAttrTypeMask;
+
   switch (Attr) {
     case CCAttrAmdSev:
       //
       // SEV is automatically enabled if SEV-ES or SEV-SNP is active.
       //
-      return CurrentAttr >= CCAttrAmdSev;
+      return CurrentLevel >= CCAttrAmdSev;
     case CCAttrAmdSevEs:
       //
       // SEV-ES is automatically enabled if SEV-SNP is active.
       //
-      return CurrentAttr >= CCAttrAmdSevEs;
+      return CurrentLevel >= CCAttrAmdSevEs;
     case CCAttrAmdSevSnp:
-      return CurrentAttr == CCAttrAmdSevSnp;
+      return CurrentLevel == CCAttrAmdSevSnp;
+    case CCAttrFeatureAmdSevDebugSwap:
+      return !!(CurrentAttr & CCAttrFeatureAmdSevDebugSwap);
     default:
       return FALSE;
   }
@@ -158,4 +164,19 @@ MemEncryptSevGetEncryptionMask (
   }
 
   return mSevEncryptionMask;
+}
+
+/**
+  Returns a boolean to indicate whether DebugSwap is enabled.
+
+  @retval TRUE           DebugSwap is enabled
+  @retval FALSE          DebugSwap is not enabled
+**/
+BOOLEAN
+EFIAPI
+MemEncryptSevEsDebugSwapIsEnabled (
+  VOID
+  )
+{
+  return ConfidentialComputingGuestHas (CCAttrFeatureAmdSevDebugSwap);
 }

--- a/OvmfPkg/Library/BaseMemEncryptSevLib/PeiMemEncryptSevLibInternal.c
+++ b/OvmfPkg/Library/BaseMemEncryptSevLib/PeiMemEncryptSevLibInternal.c
@@ -141,3 +141,22 @@ MemEncryptSevGetEncryptionMask (
 
   return SevEsWorkArea->EncryptionMask;
 }
+
+/**
+  Returns a boolean to indicate whether DebugSwap is enabled.
+
+  @retval TRUE           DebugSwap is enabled
+  @retval FALSE          DebugSwap is not enabled
+**/
+BOOLEAN
+EFIAPI
+MemEncryptSevEsDebugSwapIsEnabled (
+  VOID
+  )
+{
+  MSR_SEV_STATUS_REGISTER  Msr;
+
+  Msr.Uint32 = InternalMemEncryptSevStatus ();
+
+  return Msr.Bits.DebugSwap ? TRUE : FALSE;
+}

--- a/OvmfPkg/Library/BaseMemEncryptSevLib/SecMemEncryptSevLibInternal.c
+++ b/OvmfPkg/Library/BaseMemEncryptSevLib/SecMemEncryptSevLibInternal.c
@@ -143,6 +143,25 @@ MemEncryptSevGetEncryptionMask (
 }
 
 /**
+  Returns a boolean to indicate whether DebugSwap is enabled.
+
+  @retval TRUE           DebugSwap is enabled
+  @retval FALSE          DebugSwap is not enabled
+**/
+BOOLEAN
+EFIAPI
+MemEncryptSevEsDebugSwapIsEnabled (
+  VOID
+  )
+{
+  MSR_SEV_STATUS_REGISTER  Msr;
+
+  Msr.Uint32 = InternalMemEncryptSevStatus ();
+
+  return Msr.Bits.DebugSwap ? TRUE : FALSE;
+}
+
+/**
   Locate the page range that covers the initial (pre-SMBASE-relocation) SMRAM
   Save State Map.
 

--- a/OvmfPkg/Library/CcExitLib/CcExitVcHandler.c
+++ b/OvmfPkg/Library/CcExitLib/CcExitVcHandler.c
@@ -1619,6 +1619,10 @@ Dr7WriteExit (
   UINT64                     *Register;
   UINT64                     Status;
 
+  if (MemEncryptSevEsDebugSwapIsEnabled ()) {
+    return UnsupportedExit (Ghcb, Regs, InstructionData);
+  }
+
   Ext       = &InstructionData->Ext;
   SevEsData = (SEV_ES_PER_CPU_DATA *)(Ghcb + 1);
 
@@ -1668,6 +1672,10 @@ Dr7ReadExit (
   CC_INSTRUCTION_OPCODE_EXT  *Ext;
   SEV_ES_PER_CPU_DATA        *SevEsData;
   UINT64                     *Register;
+
+  if (MemEncryptSevEsDebugSwapIsEnabled ()) {
+    return UnsupportedExit (Ghcb, Regs, InstructionData);
+  }
 
   Ext       = &InstructionData->Ext;
   SevEsData = (SEV_ES_PER_CPU_DATA *)(Ghcb + 1);

--- a/OvmfPkg/PlatformPei/AmdSev.c
+++ b/OvmfPkg/PlatformPei/AmdSev.c
@@ -434,6 +434,7 @@ AmdSevInitialize (
   )
 {
   UINT64         EncryptionMask;
+  UINT64         CCGuestAttr;
   RETURN_STATUS  PcdStatus;
 
   //
@@ -517,12 +518,18 @@ AmdSevInitialize (
   // technology is active.
   //
   if (MemEncryptSevSnpIsEnabled ()) {
-    PcdStatus = PcdSet64S (PcdConfidentialComputingGuestAttr, CCAttrAmdSevSnp);
+    CCGuestAttr = CCAttrAmdSevSnp;
   } else if (MemEncryptSevEsIsEnabled ()) {
-    PcdStatus = PcdSet64S (PcdConfidentialComputingGuestAttr, CCAttrAmdSevEs);
+    CCGuestAttr = CCAttrAmdSevEs;
   } else {
-    PcdStatus = PcdSet64S (PcdConfidentialComputingGuestAttr, CCAttrAmdSev);
+    CCGuestAttr = CCAttrAmdSev;
   }
+
+  if (MemEncryptSevEsDebugSwapIsEnabled ()) {
+    CCGuestAttr |= CCAttrFeatureAmdSevDebugSwap;
+  }
+
+  PcdStatus = PcdSet64S (PcdConfidentialComputingGuestAttr, CCGuestAttr);
 
   ASSERT_RETURN_ERROR (PcdStatus);
 }

--- a/UefiCpuPkg/Library/MpInitLib/MpLib.c
+++ b/UefiCpuPkg/Library/MpInitLib/MpLib.c
@@ -3178,19 +3178,25 @@ AmdMemEncryptionAttrCheck (
   IN  CONFIDENTIAL_COMPUTING_GUEST_ATTR  Attr
   )
 {
+  UINT64  CurrentLevel;
+
+  CurrentLevel = CurrentAttr & CCAttrTypeMask;
+
   switch (Attr) {
     case CCAttrAmdSev:
       //
       // SEV is automatically enabled if SEV-ES or SEV-SNP is active.
       //
-      return CurrentAttr >= CCAttrAmdSev;
+      return CurrentLevel >= CCAttrAmdSev;
     case CCAttrAmdSevEs:
       //
       // SEV-ES is automatically enabled if SEV-SNP is active.
       //
-      return CurrentAttr >= CCAttrAmdSevEs;
+      return CurrentLevel >= CCAttrAmdSevEs;
     case CCAttrAmdSevSnp:
-      return CurrentAttr == CCAttrAmdSevSnp;
+      return CurrentLevel == CCAttrAmdSevSnp;
+    case CCAttrFeatureAmdSevDebugSwap:
+      return !!(CurrentAttr & CCAttrFeatureAmdSevDebugSwap);
     default:
       return FALSE;
   }


### PR DESCRIPTION
This is to prevent #DB interception on AMD SEV-ES VM with enabled DebugSwap feature, more details in 3/5.

The goal of this pull request is CI check.