### PR TITLE
IntelFsp2WrapperPkg/FspmWrapperPeim: Migrate Fsp binary to permanent RAM

### DIFF
--- a/IntelFsp2WrapperPkg/FspmWrapperPeim/FspmWrapperPeim.inf
+++ b/IntelFsp2WrapperPkg/FspmWrapperPeim/FspmWrapperPeim.inf
@@ -6,7 +6,7 @@
 # register TemporaryRamDonePpi to call TempRamExit API, and register MemoryDiscoveredPpi
 # notify to call FspSiliconInit API.
 #
-#  Copyright (c) 2014 - 2021, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2014 - 2024, Intel Corporation. All rights reserved.<BR>
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -69,10 +69,12 @@
 [Guids]
   gFspHobGuid                           ## PRODUCES ## HOB
   gFspApiPerformanceGuid                ## SOMETIMES_CONSUMES ## GUID
+  gEdkiiMigratedFvInfoGuid              ## SOMETIMES_CONSUMES ## HOB
 
 [Ppis]
   gEdkiiTcgPpiGuid                                       ## NOTIFY
   gEfiPeiFirmwareVolumeInfoMeasurementExcludedPpiGuid    ## PRODUCES
+  gEdkiiPeiMigrateTempRamPpiGuid                         ## NOTIFY
 
 [Depex]
   gEfiPeiMasterBootModePpiGuid

--- a/MdeModulePkg/Core/Pei/PeiMain.h
+++ b/MdeModulePkg/Core/Pei/PeiMain.h
@@ -1,7 +1,7 @@
 /** @file
   Definition of Pei Core Structures and Services
 
-Copyright (c) 2006 - 2019, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2006 - 2024, Intel Corporation. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -26,6 +26,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Ppi/TemporaryRamDone.h>
 #include <Ppi/SecHobData.h>
 #include <Ppi/PeiCoreFvLocation.h>
+#include <Ppi/MigrateTempRam.h>
 #include <Library/DebugLib.h>
 #include <Library/PeiCoreEntryPoint.h>
 #include <Library/BaseLib.h>

--- a/MdeModulePkg/Core/Pei/PeiMain.inf
+++ b/MdeModulePkg/Core/Pei/PeiMain.inf
@@ -6,7 +6,7 @@
 # 2) Dispatch PEIM from discovered FV.
 # 3) Handoff control to DxeIpl to load DXE core and enter DXE phase.
 #
-# Copyright (c) 2006 - 2019, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2006 - 2024, Intel Corporation. All rights reserved.<BR>
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -101,6 +101,7 @@
   gEfiPeiReset2PpiGuid                          ## SOMETIMES_CONSUMES
   gEfiSecHobDataPpiGuid                         ## SOMETIMES_CONSUMES
   gEfiPeiCoreFvLocationPpiGuid                  ## SOMETIMES_CONSUMES
+  gEdkiiPeiMigrateTempRamPpiGuid                ## PRODUCES
 
 [Pcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdPeiCoreMaxPeiStackSize                  ## CONSUMES

--- a/MdeModulePkg/Core/Pei/PeiMain/PeiMain.c
+++ b/MdeModulePkg/Core/Pei/PeiMain/PeiMain.c
@@ -1,7 +1,7 @@
 /** @file
   Pei Core Main Entry Point
 
-Copyright (c) 2006 - 2019, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2006 - 2024, Intel Corporation. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -11,6 +11,11 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 EFI_PEI_PPI_DESCRIPTOR  mMemoryDiscoveredPpi = {
   (EFI_PEI_PPI_DESCRIPTOR_PPI | EFI_PEI_PPI_DESCRIPTOR_TERMINATE_LIST),
   &gEfiPeiMemoryDiscoveredPpiGuid,
+  NULL
+};
+EFI_PEI_PPI_DESCRIPTOR  mMigrateTempRamPpi = {
+  (EFI_PEI_PPI_DESCRIPTOR_PPI | EFI_PEI_PPI_DESCRIPTOR_TERMINATE_LIST),
+  &gEdkiiPeiMigrateTempRamPpiGuid,
   NULL
 };
 
@@ -448,6 +453,9 @@ PeiCore (
       // Migrate installed content from Temporary RAM to Permanent RAM
       //
       EvacuateTempRam (&PrivateData, SecCoreData);
+
+      Status = PeiServicesInstallPpi (&mMigrateTempRamPpi);
+      ASSERT_EFI_ERROR (Status);
 
       DEBUG ((DEBUG_VERBOSE, "PPI lists after temporary RAM evacuation:\n"));
       DumpPpiList (&PrivateData);

--- a/MdeModulePkg/Include/Guid/MigratedFvInfo.h
+++ b/MdeModulePkg/Include/Guid/MigratedFvInfo.h
@@ -1,7 +1,7 @@
 /** @file
   Migrated FV information
 
-Copyright (c) 2020, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2020 - 2024, Intel Corporation. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -50,7 +50,7 @@ typedef struct {
 
 typedef struct {
   UINT32    FvOrgBase;         // original FV address
-  UINT32    FvNewBase;         // new FV address
+  UINT32    FvNewBase;         // new FV address, 0 means rebased data is not copied
   UINT32    FvDataBase;        // original FV data, 0 means raw data is not copied
   UINT32    FvLength;          // Fv Length
 } EDKII_MIGRATED_FV_INFO;

--- a/MdeModulePkg/Include/Ppi/MigrateTempRam.h
+++ b/MdeModulePkg/Include/Ppi/MigrateTempRam.h
@@ -1,0 +1,23 @@
+/** @file
+  This file declares Migrate Temporary Memory PPI.
+
+  This PPI is published by the PEI Foundation when temporary RAM needs to evacuate.
+  Its purpose is to be used as a signal for other PEIMs who can register for a
+  notification on its installation.
+
+  Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef PEI_MIGRATE_TEMP_RAM_PPI_H_
+#define PEI_MIGRATE_TEMP_RAM_PPI_H_
+
+#define EFI_PEI_MIGRATE_TEMP_RAM_PPI_GUID \
+  { \
+    0xc79dc53b, 0xafcd, 0x4a6a, {0xad, 0x94, 0xa7, 0x6a, 0x3f, 0xa9, 0xe9, 0xc2 } \
+  }
+
+extern EFI_GUID  gEdkiiPeiMigrateTempRamPpiGuid;
+
+#endif

--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -4,7 +4,7 @@
 # and libraries instances, which are used for those modules.
 #
 # Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
-# Copyright (c) 2007 - 2021, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2007 - 2024, Intel Corporation. All rights reserved.<BR>
 # Copyright (c) 2016, Linaro Ltd. All rights reserved.<BR>
 # (C) Copyright 2016 - 2019 Hewlett Packard Enterprise Development LP<BR>
 # Copyright (c) 2017, AMD Incorporated. All rights reserved.<BR>
@@ -545,6 +545,9 @@
 
   ## Include/Ppi/MemoryAttribute.h
   gEdkiiMemoryAttributePpiGuid              = { 0x1be840de, 0x2d92, 0x41ec, { 0xb6, 0xd3, 0x19, 0x64, 0x13, 0x50, 0x51, 0xfb } }
+
+  ## Include/Ppi/MigrateTempRam.h
+  gEdkiiPeiMigrateTempRamPpiGuid            = { 0xc79dc53b, 0xafcd, 0x4a6a, { 0xad, 0x94, 0xa7, 0x6a, 0x3f, 0xa9, 0xe9, 0xc2 } }
 
 [Protocols]
   ## Load File protocol provides capability to load and unload EFI image into memory and execute it.


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4716

Migrate FSP-T/M binary from temporary RAM to permanent RAM before NEM tear down. Tcg module will use permanent address of FSP-T/M for measurement.
1. PeiCore installs mMigrateTempRamPpi if PcdMigrateTemporaryRamFirmwareVolumes is True
2. FspmWrapperPeim migrate FspT/M binary to permanent memory and build MigatedFvInfoHob
3. TCG notification checks MigatedFvInfoHob and transmits DRAM address for measurement

Cc: Chasel Chiu <chasel.chiu@intel.com>
Cc: Nate DeSimone <nathaniel.l.desimone@intel.com>
Cc: Duggapu Chinni B <chinni.b.duggapu@intel.com>
Cc: Chen Gang C <gang.c.chen@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>

Change-Id: I06f4c0386cc7d0af7e0bb391ac83d8e832f18be0