### PR TITLE
UefiCpuPkg/Library: Support to get processor extended info

### DIFF
--- a/UefiCpuPkg/Library/RegisterCpuFeaturesLib/DxeRegisterCpuFeaturesLib.c
+++ b/UefiCpuPkg/Library/RegisterCpuFeaturesLib/DxeRegisterCpuFeaturesLib.c
@@ -1,7 +1,7 @@
 /** @file
   CPU Register Table Library functions.
 
-  Copyright (c) 2017 - 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017 - 2024, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -101,7 +101,7 @@ GetProcessorInformation (
 
   Status = MpServices->GetProcessorInfo (
                          MpServices,
-                         ProcessorNumber,
+                         ProcessorNumber | CPU_V2_EXTENDED_TOPOLOGY,
                          ProcessorInfoBuffer
                          );
   return Status;

--- a/UefiCpuPkg/Library/RegisterCpuFeaturesLib/PeiRegisterCpuFeaturesLib.c
+++ b/UefiCpuPkg/Library/RegisterCpuFeaturesLib/PeiRegisterCpuFeaturesLib.c
@@ -1,7 +1,7 @@
 /** @file
   CPU Register Table Library functions.
 
-  Copyright (c) 2016 - 2020, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2016 - 2024, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -139,7 +139,7 @@ GetProcessorInformation (
 
   Status = CpuMp2Ppi->GetProcessorInfo (
                         CpuMp2Ppi,
-                        ProcessorNumber,
+                        ProcessorNumber | CPU_V2_EXTENDED_TOPOLOGY,
                         ProcessorInfoBuffer
                         );
   return Status;


### PR DESCRIPTION
Intel has some features need to use processor extended information under CPU feature InitializeFunc(), so add code to support it: This patch is to add CPU_V2_EXTENDED_TOPOLOGY to get processor extended info.

Cc: Ray Ni <ray.ni@intel.com>
Cc: Zeng Star <star.zeng@intel.com>
Cc: Gerd Hoffmann <kraxel@redhat.com>
Cc: Rahul Kumar <rahul1.kumar@intel.com>