### PR TITLE
UefiCpuPkg/Library: Cleanup debug message in LmceSupport

### DIFF
--- a/UefiCpuPkg/Library/CpuCommonFeaturesLib/MachineCheck.c
+++ b/UefiCpuPkg/Library/CpuCommonFeaturesLib/MachineCheck.c
@@ -1,7 +1,7 @@
 /** @file
   Machine Check features.
 
-  Copyright (c) 2017 - 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017 - 2024, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -289,9 +289,6 @@ LmceSupport (
   }
 
   McgCap.Uint64 = AsmReadMsr64 (MSR_IA32_MCG_CAP);
-  if (ProcessorNumber == 0) {
-    DEBUG ((DEBUG_INFO, "LMCE enable = %x\n", (BOOLEAN)(McgCap.Bits.MCG_LMCE_P != 0)));
-  }
 
   return (BOOLEAN)(McgCap.Bits.MCG_LMCE_P != 0);
 }


### PR DESCRIPTION
ProcessorNumber 0 is not always BSP. Debug message based on 0 of ProcessorNumber is incorrect.

This patch is to clean the debug message in LmceSupport directly.

Cc: Ray Ni <ray.ni@intel.com>
Cc: Zeng Star <star.zeng@intel.com>
Cc: Gerd Hoffmann <kraxel@redhat.com>
Cc: Rahul Kumar <rahul1.kumar@intel.com>

Reviewed-by: Zeng Star <star.zeng@intel.com>
Reviewed-by: Ray Ni <ray.ni@intel.com>