### PR TITLE
MdePkg: Added support for Smbios 3.7.0

### DIFF
--- a/MdePkg/Include/IndustryStandard/SmBios.h
+++ b/MdePkg/Include/IndustryStandard/SmBios.h
@@ -1524,7 +1524,7 @@ typedef struct {
   UINT8    AsyncSurpriseRemoval    : 1;
   UINT8    FlexbusSlotCxl10Capable : 1;
   UINT8    FlexbusSlotCxl20Capable : 1;
-  UINT8    Reserved                : 1; ///< Set to 0.
+  UINT8    FlexbusSlotCxl30Capable : 1; ///SMBIOS spec 3.7.0 updated CXL 3.0 support
 } MISC_SLOT_CHARACTERISTICS2;
 
 ///
@@ -2027,6 +2027,13 @@ typedef struct {
   //
   UINT32                                     ExtendedSpeed;
   UINT32                                     ExtendedConfiguredMemorySpeed;
+  //
+  // Add for smbios 3.7.0
+  //
+  UINT16                                     Pmic0ManufacturerID;
+  UINT16                                     Pmic0RevisionNumber;
+  UINT16                                     RcdManufacturerID;
+  UINT16                                     RcdRevisionNumber;
 } SMBIOS_TABLE_TYPE17;
 
 ///

--- a/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/PrintInfo.c
+++ b/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/PrintInfo.c
@@ -903,6 +903,13 @@ SmbiosPrintStructure (
         ShellPrintEx (-1, -1, L"Extended Configured Memory Speed: 0x%x\n", Struct->Type17->ExtendedConfiguredMemorySpeed);
       }
 
+      if (AE_SMBIOS_VERSION (0x3, 0x7) && (Struct->Hdr->Length > 0x5C)) {
+        ShellPrintEx (-1, -1, L"PMIC0 Manufacturer ID: 0x%x\n", Struct->Type17->Pmic0ManufacturerID);
+        ShellPrintEx (-1, -1, L"PMIC0 Revision Number: 0x%x\n", Struct->Type17->Pmic0RevisionNumber);
+        ShellPrintEx (-1, -1, L"RCD Manufacturer ID: 0x%x\n", Struct->Type17->RcdManufacturerID);
+        ShellPrintEx (-1, -1, L"RCD Revision Number: 0x%x\n", Struct->Type17->RcdRevisionNumber);
+      }
+
       break;
 
     //


### PR DESCRIPTION
REF:https://bugzilla.tianocore.org/show_bug.cgi?id=4563

As per Smbios 3.7.0 spec, added CXL 3.0 support in Type 9, also added PMIC & RCD manufacturer ID and Revision information in Type17.Add changes to print PMIC and RCD details of Smbios Type17 in Shell Smbiosview command in ShellPkg.


Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>
Reviewed-by: Giri Mudusuru <girimudusuru@microsoft.com>