### PR TITLE
IntelFsp2Pkg/PatchFv.py: FIX for GCC 32BIT build error

### DIFF
--- a/IntelFsp2Pkg/Tools/PatchFv.py
+++ b/IntelFsp2Pkg/Tools/PatchFv.py
@@ -432,7 +432,7 @@ class Symbols:
         if reportLine.strip().find("Archive member included") != -1:
             #GCC
             #                0x0000000000001d55                IoRead8
-            patchMapFileMatchString = r"\s+(0x[0-9a-fA-F]{16})\s+([^\s][^0x][_a-zA-Z0-9\-]+)\s"
+            patchMapFileMatchString = r"\s+(0x[0-9a-fA-F]{8,16})\s+([^\s][^0x][_a-zA-Z0-9\-]+)\s"
             matchKeyGroupIndex = 2
             matchSymbolGroupIndex  = 1
             prefix = '_'


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4762

Map file generating 8 byte address offset is not matched with the pattern defined in patchFv tool resulting build error.

Cc: Chasel Chiu <chasel.chiu@intel.com>
Reviewed-by: Nate DeSimone <nathaniel.l.desimone@intel.com>
Cc: Duggapu Chinni B <chinni.b.duggapu@intel.com>
Reviewed-by: Ashraf Ali S <ashraf.ali.s@intel.com>
Cc: Ted Kuo <ted.kuo@intel.com>