### PR TITLE
TCG_Sp800_155_PlatformId_Event3 support

### DIFF
--- a/MdePkg/Include/IndustryStandard/UefiTcgPlatform.h
+++ b/MdePkg/Include/IndustryStandard/UefiTcgPlatform.h
@@ -451,6 +451,7 @@ typedef struct tdTCG_PCClientTaggedEvent {
 
 #define TCG_Sp800_155_PlatformId_Event_SIGNATURE   "SP800-155 Event"
 #define TCG_Sp800_155_PlatformId_Event2_SIGNATURE  "SP800-155 Event2"
+#define TCG_Sp800_155_PlatformId_Event3_SIGNATURE  "SP800-155 Event3"
 
 typedef struct tdTCG_Sp800_155_PlatformId_Event2 {
   UINT8       Signature[16];
@@ -478,8 +479,43 @@ typedef struct tdTCG_Sp800_155_PlatformId_Event2 {
   // UINT8               FirmwareManufacturerStr[FirmwareManufacturerStrSize];
   // UINT32              FirmwareManufacturerId;
   // UINT8               FirmwareVersion;
-  // UINT8               FirmwareVersion[FirmwareVersionSize]];
+  // UINT8               FirmwareVersion[FirmwareVersionSize];
 } TCG_Sp800_155_PlatformId_Event2;
+
+typedef struct tdTCG_Sp800_155_PlatformId_Event3 {
+  UINT8       Signature[16];
+  //
+  // Where Vendor ID is an integer defined
+  // at http://www.iana.org/assignments/enterprisenumbers
+  //
+  UINT32      VendorId;
+  //
+  // 16-byte identifier of a given platform's static configuration of code
+  //
+  EFI_GUID    ReferenceManifestGuid;
+  // UINT8               PlatformManufacturerStrSize;
+  // UINT8               PlatformManufacturerStr[PlatformManufacturerStrSize];
+  // UINT8               PlatformModelSize;
+  // UINT8               PlatformModel[PlatformModelSize];
+  // UINT8               PlatformVersionSize;
+  // UINT8               PlatformVersion[PlatformVersionSize];
+  // UINT8               PlatformModelSize;
+  // UINT8               PlatformModel[PlatformModelSize];
+  // UINT8               FirmwareManufacturerStrSize;
+  // UINT8               FirmwareManufacturerStr[FirmwareManufacturerStrSize];
+  // UINT32              FirmwareManufacturerId;
+  // UINT8               FirmwareVersion;
+  // UINT8               FirmwareVersion[FirmwareVersionSize];
+  //
+  // Below structure is newly added in TCG_Sp800_155_PlatformId_Event3
+  //
+  // UINT32              RimLocatorType;
+  // UINT32              RimLocatorLength;
+  // UINT8               RimLocator[RimLocatorLength];
+  // UINT32              PlatformCertLocatorType;
+  // UINT32              PlatformCertLocatorLength;
+  // UINT8               PlatformCertLocator[PlatformCertLocatorLength];
+} TCG_Sp800_155_PlatformId_Event3;
 
 #define TCG_EfiStartupLocalityEvent_SIGNATURE  "StartupLocality"
 

--- a/OvmfPkg/Tcg/TdTcg2Dxe/TdTcg2Dxe.c
+++ b/OvmfPkg/Tcg/TdTcg2Dxe/TdTcg2Dxe.c
@@ -821,11 +821,16 @@ Is800155Event (
 {
   if ((((TCG_PCR_EVENT2_HDR *)NewEventHdr)->EventType == EV_NO_ACTION) &&
       (NewEventSize >= sizeof (TCG_Sp800_155_PlatformId_Event2)) &&
-      (CompareMem (
-         NewEventData,
-         TCG_Sp800_155_PlatformId_Event2_SIGNATURE,
-         sizeof (TCG_Sp800_155_PlatformId_Event2_SIGNATURE) - 1
-         ) == 0))
+      ((CompareMem (
+          NewEventData,
+          TCG_Sp800_155_PlatformId_Event2_SIGNATURE,
+          sizeof (TCG_Sp800_155_PlatformId_Event2_SIGNATURE) - 1
+          ) == 0) ||
+       (CompareMem (
+          NewEventData,
+          TCG_Sp800_155_PlatformId_Event3_SIGNATURE,
+          sizeof (TCG_Sp800_155_PlatformId_Event3_SIGNATURE) - 1
+          ) == 0)))
   {
     return TRUE;
   }

--- a/SecurityPkg/Tcg/Tcg2Dxe/Tcg2Dxe.c
+++ b/SecurityPkg/Tcg/Tcg2Dxe/Tcg2Dxe.c
@@ -812,11 +812,16 @@ Is800155Event (
 {
   if ((((TCG_PCR_EVENT2_HDR *)NewEventHdr)->EventType == EV_NO_ACTION) &&
       (NewEventSize >= sizeof (TCG_Sp800_155_PlatformId_Event2)) &&
-      (CompareMem (
-         NewEventData,
-         TCG_Sp800_155_PlatformId_Event2_SIGNATURE,
-         sizeof (TCG_Sp800_155_PlatformId_Event2_SIGNATURE) - 1
-         ) == 0))
+      ((CompareMem (
+          NewEventData,
+          TCG_Sp800_155_PlatformId_Event2_SIGNATURE,
+          sizeof (TCG_Sp800_155_PlatformId_Event2_SIGNATURE) - 1
+          ) == 0) ||
+       (CompareMem (
+          NewEventData,
+          TCG_Sp800_155_PlatformId_Event3_SIGNATURE,
+          sizeof (TCG_Sp800_155_PlatformId_Event3_SIGNATURE) - 1
+          ) == 0)))
   {
     return TRUE;
   }


### PR DESCRIPTION

In December 2023, the TCG published the PC Client Platform Firmware
Profile version 1.06 revision 52. This revision includes a new event
type for NIST SP 800-155 recommended signed BIOS reference measurements.
The new type allows for the event log auditor to find local or remote
copies of the signed reference measurements.

Supporting this new event type eases the process of distributing signed
reference measurements since the machine can now simply report where
they can be found in a standard way.

Changes since v3:
  - Fixed build error from 1 too many ')'s.
  - Fixed formatting for uncrustify.
Changes since v2:
  - Removed errant spacing.
Changes since v1:
  - MdePkg defines TCG_Sp800_155_PlatformId_Event3 instead of adding a
    comment about Event3 to Event2.

Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Zhiguang Liu <zhiguang.liu@intel.com>
Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Rahul Kumar <rahul1.kumar@intel.com>
Cc: Ard Biesheuvel <ardb+tianocore@kernel.org>
Cc: Gerd Hoffmann <kraxel@redhat.com>
Reviewed-by: Jiewen Yao <jiewen.yao@intel.com>

Dionna Glaze (3):
  MdePkg: Add TcgSp800155Event3 type info
  SecurityPkg: Recognize sp800155Event3 event
  OvmfPkg: Add sp800155Event3 support

 .../IndustryStandard/UefiTcgPlatform.h        | 38 ++++++++++++++++++-
 OvmfPkg/Tcg/TdTcg2Dxe/TdTcg2Dxe.c             | 15 +++++---
 SecurityPkg/Tcg/Tcg2Dxe/Tcg2Dxe.c             | 15 +++++---
 3 files changed, 57 insertions(+), 11 deletions(-)
