### PR TITLE
MdeModulePkg/XhciDxe: Add PCD for the delay of HCRST

### DIFF
--- a/MdeModulePkg/Bus/Pci/XhciDxe/Xhci.h
+++ b/MdeModulePkg/Bus/Pci/XhciDxe/Xhci.h
@@ -28,6 +28,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/DebugLib.h>
 #include <Library/ReportStatusCodeLib.h>
 #include <Library/TimerLib.h>
+#include <Library/PcdLib.h>
 
 #include <IndustryStandard/Pci.h>
 

--- a/MdeModulePkg/Bus/Pci/XhciDxe/XhciDxe.inf
+++ b/MdeModulePkg/Bus/Pci/XhciDxe/XhciDxe.inf
@@ -45,6 +45,7 @@
 
 [Packages]
   MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
 
 [LibraryClasses]
   MemoryAllocationLib
@@ -56,6 +57,7 @@
   DebugLib
   ReportStatusCodeLib
   TimerLib
+  PcdLib
 
 [Guids]
   gEfiEventExitBootServicesGuid                 ## SOMETIMES_CONSUMES ## Event
@@ -63,6 +65,9 @@
 [Protocols]
   gEfiPciIoProtocolGuid                         ## TO_START
   gEfiUsb2HcProtocolGuid                        ## BY_START
+
+[Pcd]
+  gEfiMdeModulePkgTokenSpaceGuid.PcdDelayXhciHCReset  ## CONSUMES
 
 # [Event]
 # EVENT_TYPE_PERIODIC_TIMER       ## CONSUMES

--- a/MdeModulePkg/Bus/Pci/XhciDxe/XhciReg.c
+++ b/MdeModulePkg/Bus/Pci/XhciDxe/XhciReg.c
@@ -864,7 +864,7 @@ XhcResetHC (
     // Otherwise there may have the timeout case happened.
     // The below is a workaround to solve such problem.
     //
-    gBS->Stall (XHC_1_MILLISECOND);
+    gBS->Stall (PcdGet16 (PcdDelayXhciHCReset));
     Status = XhcWaitOpRegBit (Xhc, XHC_USBCMD_OFFSET, XHC_USBCMD_RESET, FALSE, Timeout);
 
     if (!EFI_ERROR (Status)) {

--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -1154,6 +1154,11 @@
   # @Prompt Enable large address image loading.
   gEfiMdeModulePkgTokenSpaceGuid.PcdImageLargeAddressLoad|TRUE|BOOLEAN|0x30001059
 
+  ## Indicates time delay for XHCI registers access after it issues HCRST.
+  # Default is 2000, it represent delay is 2 ms.
+  # @Prompt Delay access XHCI register after it issues HCRST (us)
+  gEfiMdeModulePkgTokenSpaceGuid.PcdDelayXhciHCReset|2000|UINT16|0x30001060
+
 [PcdsFixedAtBuild, PcdsPatchableInModule]
   ## Dynamic type PCD can be registered callback function for Pcd setting action.
   #  PcdMaxPeiPcdCallBackNumberPerPcdEntry indicates the maximum number of callback function


### PR DESCRIPTION
https://bugzilla.tianocore.org/show_bug.cgi?id=4727

Recently some of XHCI host controllers require to have extra 1ms delay before accessing any MMIO register during reset. PHY transition from P3 to P0 can take around 1.3ms and the xHCI reset can take around 1.5ms. Add PCD to control the delay, the default is 2 ms.

Cc: Ray Ni                   <ray.ni@intel.com>
Cc: Liming Gao               <gaoliming@byosoft.com.cn>
Cc: Krzysztof Lewandowski    <krzysztof.lewandowski@intel.com>
Cc: Jenny Huang              <jenny.huang@intel.com>
Cc: More Shih                <more.shih@intel.com>
Cc: Ian Chiu                 <ian.chiu@intel.com>

Reviewed-by: Krzysztof Lewandowski <krzysztof.lewandowski@intel.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>