### PR TITLE
MdeModulePkg/XhciDxe: Reset endpoint while USB Transaction error

### DIFF
--- a/MdeModulePkg/Bus/Pci/XhciDxe/Xhci.c
+++ b/MdeModulePkg/Bus/Pci/XhciDxe/Xhci.c
@@ -825,7 +825,10 @@ XhcTransfer (
   *TransferResult = Urb->Result;
   *DataLength     = Urb->Completed;
 
-  if ((*TransferResult == EFI_USB_ERR_STALL) || (*TransferResult == EFI_USB_ERR_BABBLE)) {
+  //
+  // Based on XHCI spec 4.8.3, software should do the reset endpoint while USB Transaction occur.
+  //
+  if ((*TransferResult == EFI_USB_ERR_STALL) || (*TransferResult == EFI_USB_ERR_BABBLE) || (*TransferResult == EDKII_USB_ERR_TRANSACTION)) {
     ASSERT (Status == EFI_DEVICE_ERROR);
     RecoveryStatus = XhcRecoverHaltedEndpoint (Xhc, Urb);
     if (EFI_ERROR (RecoveryStatus)) {

--- a/MdeModulePkg/Bus/Pci/XhciDxe/XhciSched.c
+++ b/MdeModulePkg/Bus/Pci/XhciDxe/XhciSched.c
@@ -1192,8 +1192,11 @@ XhcCheckUrbResult (
         DEBUG ((DEBUG_ERROR, "XhcCheckUrbResult: ERR_BUFFER! Completecode = %x\n", EvtTrb->Completecode));
         goto EXIT;
 
+      //
+      // Based on XHCI spec 4.8.3, software should do the reset endpoint while USB Transaction occur.
+      //
       case TRB_COMPLETION_USB_TRANSACTION_ERROR:
-        CheckedUrb->Result  |= EFI_USB_ERR_TIMEOUT;
+        CheckedUrb->Result  |= EDKII_USB_ERR_TRANSACTION;
         CheckedUrb->Finished = TRUE;
         DEBUG ((DEBUG_ERROR, "XhcCheckUrbResult: TRANSACTION_ERROR! Completecode = %x\n", EvtTrb->Completecode));
         goto EXIT;

--- a/MdeModulePkg/Bus/Pci/XhciDxe/XhciSched.h
+++ b/MdeModulePkg/Bus/Pci/XhciDxe/XhciSched.h
@@ -79,6 +79,13 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #define TRB_COMPLETION_STOPPED_LENGTH_INVALID  27
 
 //
+// USB Transfer Results Internal Definition
+// Based on XHCI spec 4.8.3, software should do the reset endpoint while USB Transaction occur.
+// Add the error code for USB Transaction error since UEFI spec don't have the related definition.
+//
+#define EDKII_USB_ERR_TRANSACTION  0x200
+
+//
 // The topology string used to present usb device location
 //
 typedef struct _USB_DEV_TOPOLOGY {


### PR DESCRIPTION
https://bugzilla.tianocore.org/show_bug.cgi?id=4556

Based on XHCI spec 4.8.3, software should do the
reset endpoint while USB Transaction occur.
Add the error code for USB Transaction error
since UEFI spec don't have the related definition.

Cc: Ray Ni                  <ray.ni@intel.com>
Cc: Liming Gao              <gaoliming@byosoft.com.cn>
Cc: Krzysztof Lewandowski   <krzysztof.lewandowski@intel.com>
Cc: Jenny Huang             <jenny.huang@intel.com>
Cc: More Shih               <more.shih@intel.com>

Reviewed-by: Krzysztof Lewandowski <krzysztof.lewandowski@intel.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>