### PR TITLE
MdePkg: Updated SpcrTable structure for Revision_4

### DIFF
--- a/MdePkg/Include/IndustryStandard/SerialPortConsoleRedirectionTable.h
+++ b/MdePkg/Include/IndustryStandard/SerialPortConsoleRedirectionTable.h
@@ -23,6 +23,7 @@
 ///
 #define EFI_ACPI_SERIAL_PORT_CONSOLE_REDIRECTION_TABLE_REVISION  0x02
 
+#define EFI_ACPI_4_0_SERIAL_PORT_CONSOLE_REDIRECTION_TABLE_REVISION  0x04
 ///
 /// Serial Port Console Redirection Table Format
 ///
@@ -49,6 +50,37 @@ typedef struct {
   UINT8                                     PciSegment;
   UINT32                                    Reserved3;
 } EFI_ACPI_SERIAL_PORT_CONSOLE_REDIRECTION_TABLE;
+
+///
+/// Serial Port Console Redirection Table Format Revision 4
+///
+typedef struct {
+  EFI_ACPI_DESCRIPTION_HEADER               Header;
+  UINT8                                     InterfaceType;
+  UINT8                                     Reserved1[3];
+  EFI_ACPI_5_0_GENERIC_ADDRESS_STRUCTURE    BaseAddress;
+  UINT8                                     InterruptType;
+  UINT8                                     Irq;
+  UINT32                                    GlobalSystemInterrupt;
+  UINT8                                     BaudRate;
+  UINT8                                     Parity;
+  UINT8                                     StopBits;
+  UINT8                                     FlowControl;
+  UINT8                                     TerminalType;
+  UINT8                                     Reserved2;
+  UINT16                                    PciDeviceId;
+  UINT16                                    PciVendorId;
+  UINT8                                     PciBusNumber;
+  UINT8                                     PciDeviceNumber;
+  UINT8                                     PciFunctionNumber;
+  UINT32                                    PciFlags;
+  UINT8                                     PciSegment;
+  UINT32                                    UartClockFrequency;
+  UINT32                                    PreciseBaudRate;
+  UINT16                                    NameSpaceStrLength;
+  UINT16                                    NameSpaceStrOffset;
+  CHAR8                                     NameSpaceString[0];
+} EFI_ACPI_4_0_SERIAL_PORT_CONSOLE_REDIRECTION_TABLE;
 
 #pragma pack()
 


### PR DESCRIPTION
REF:https://bugzilla.tianocore.org/show_bug.cgi?id=4656

In SPCR table, 4 structure members have been added newly as per SPCR table Revision 4, which has to be added in
MdePkg/Include/IndustryStandard/SerialPortConsoleRedirectionTable.h.

Signed-off-by: Praveen Sankar N <praveensankarn@ami.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>

Cc: Felix Polyudov <Felixp@ami.com>
Cc: Srinivasan Mani <srinivasanm@ami.com>
Cc: Sundaresan S <sundaresans@ami.com>
Cc: Rabisha R <rabishar@ami.com>