### PR TITLE
OvmfPkg: Update VMM Hob list check to support new resource attributes

### DIFF
--- a/OvmfPkg/IntelTdx/TdxHelperLib/SecTdxHelper.c
+++ b/OvmfPkg/IntelTdx/TdxHelperLib/SecTdxHelper.c
@@ -643,6 +643,8 @@ ValidateHobList (
                                                             EFI_RESOURCE_ATTRIBUTE_PERSISTABLE |
                                                             EFI_RESOURCE_ATTRIBUTE_READ_ONLY_PROTECTED |
                                                             EFI_RESOURCE_ATTRIBUTE_READ_ONLY_PROTECTABLE |
+                                                            EFI_RESOURCE_ATTRIBUTE_ENCRYPTED|
+                                                            EFI_RESOURCE_ATTRIBUTE_SPECIAL_PURPOSE |
                                                             EFI_RESOURCE_ATTRIBUTE_MORE_RELIABLE))) != 0)
         {
           DEBUG ((DEBUG_ERROR, "HOB: Unknow ResourceDescriptor ResourceAttribute type. Type: 0x%08x\n", Hob.ResourceDescriptor->ResourceAttribute));


### PR DESCRIPTION
Encrypted and Special Purpose resource attributes are introduced in PI 1.8 Specification. This patch is to update VMM Hob list integrity check to recognize these resource attributes.

Cc: Ard Biesheuvel <ardb+tianocore@kernel.org>
Cc: Gerd Hoffmann <kraxel@redhat.com>
Cc: Jiewen Yao <jiewen.yao@intel.com>
Signed-off-by: Du Lin <du.lin@intel.com>
Acked-by: Gerd Hoffmann <kraxel@redhat.com>
Reviewed-by: Jiewen Yao <Jiewen.yao@intel.com>