### PR TITLE
MdePkg:Added support for Smbios 3.7.0 Spec

### DIFF
--- a/MdePkg/Include/IndustryStandard/SmBios.h
+++ b/MdePkg/Include/IndustryStandard/SmBios.h
@@ -1524,7 +1524,7 @@ typedef struct {
   UINT8    AsyncSurpriseRemoval    : 1;
   UINT8    FlexbusSlotCxl10Capable : 1;
   UINT8    FlexbusSlotCxl20Capable : 1;
-  UINT8    Reserved                : 1; ///< Set to 0.
+  UINT8    FlexbusSlotCxl30Capable : 1; ///SMBIOS spec 3.7.0 updated CXL 3.0 support
 } MISC_SLOT_CHARACTERISTICS2;
 
 ///
@@ -2027,6 +2027,13 @@ typedef struct {
   //
   UINT32                                     ExtendedSpeed;
   UINT32                                     ExtendedConfiguredMemorySpeed;
+  //
+  // Add for smbios 3.7.0
+  //
+  UINT16                                     Pmic0ManufacturerID;
+  UINT16                                     Pmic0RevisionNumber;
+  UINT16                                     RcdManufacturerID;
+  UINT16                                     RcdRevisionNumber;
 } SMBIOS_TABLE_TYPE17;
 
 ///


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4563

As per Smbios 3.7.0 spec, add changes in Type9 and Type17 structures.

Signed-off-by: Shenbagadevi R <shenbagadevir@ami.com>

Cc: Gaoliming <gaoliming@byosoft.com.cn>
Cc: Sainadh N <sainadhn@ami.com>
Cc: Sundaresan S <sundaresans@ami.com>
Cc: Srinivasan M <srinivasanm@ami.com>
Cc: Ramesh R <rameshr@ami.com>

Reviewed-by: Gaoliming <gaoliming@byosoft.com.cn>