### PR TITLE
Introduce and use PCD for Memory Attributes Table

### DIFF
--- a/MdeModulePkg/Core/Dxe/DxeMain.inf
+++ b/MdeModulePkg/Core/Dxe/DxeMain.inf
@@ -178,6 +178,7 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdLoadFixAddressRuntimeCodePageNumber     ## SOMETIMES_CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdLoadModuleAtFixAddressEnable            ## CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdMaxEfiSystemTablePointerAddress         ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdMemoryAttributesTableVersion            ## CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdMemoryProfileMemoryType                 ## CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdMemoryProfilePropertyMask               ## CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdMemoryProfileDriverPath                 ## CONSUMES

--- a/MdeModulePkg/Core/Dxe/Misc/MemoryAttributesTable.c
+++ b/MdeModulePkg/Core/Dxe/Misc/MemoryAttributesTable.c
@@ -181,10 +181,10 @@ InstallMemoryAttributesTable (
   //
   MemoryAttributesTable = AllocatePool (sizeof (EFI_MEMORY_ATTRIBUTES_TABLE) + DescriptorSize * RuntimeEntryCount);
   ASSERT (MemoryAttributesTable != NULL);
-  MemoryAttributesTable->Version         = EFI_MEMORY_ATTRIBUTES_TABLE_VERSION;
+  MemoryAttributesTable->Version         = PcdGet32 (PcdMemoryAttributesTableVersion);
   MemoryAttributesTable->NumberOfEntries = RuntimeEntryCount;
   MemoryAttributesTable->DescriptorSize  = (UINT32)DescriptorSize;
-  if (gMemoryAttributesTableForwardCfi) {
+  if ((MemoryAttributesTable->Version > 0x01) && gMemoryAttributesTableForwardCfi) {
     MemoryAttributesTable->Flags = EFI_MEMORY_ATTRIBUTES_FLAGS_RT_FORWARD_CONTROL_FLOW_GUARD;
   } else {
     MemoryAttributesTable->Flags = 0;

--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -1604,6 +1604,10 @@
   # @Prompt ACPI Reclaim memory is not available.
   gEfiMdeModulePkgTokenSpaceGuid.PcdNoACPIReclaimMemory|FALSE|BOOLEAN|0x0001008b
 
+  ## Indicates which Memory Attributes Table version exposed to the OS.
+  # @Prompt Exposed Memory Attributes Table version.
+  gEfiMdeModulePkgTokenSpaceGuid.PcdMemoryAttributesTableVersion|0x00000002|UINT32|0x12f85350
+
   ## This PCD defines the MAX repair count.
   #  The default value is 0 that means infinite.
   # @Prompt MAX repair count

--- a/MdeModulePkg/MdeModulePkg.uni
+++ b/MdeModulePkg/MdeModulePkg.uni
@@ -962,6 +962,9 @@
                                                                                      "If it is set to TRUE that means ACPI Reclaim memory is not available\n"
                                                                                      "For example ACPI Table protocol will use ACPI NVS memory instead of ACPI Reclaim memory"
 
+#string STR_gEfiMdeModulePkgTokenSpaceGuid_PcdMemoryAttributesTableVersion_PROMPT  #language en-US "Exposed Memory Attributes Table version."
+
+#string STR_gEfiMdeModulePkgTokenSpaceGuid_PcdMemoryAttributesTableVersion_HELP  #language en-US "Indicates which Memory Attributes Table version exposed to the OS."
 
 #string STR_gEfiMdeModulePkgTokenSpaceGuid_PcdHiiOsRuntimeSupport_PROMPT  #language en-US "Enable export HII data and configuration to be used in OS runtime."
 

--- a/MdePkg/Include/Guid/MemoryAttributesTable.h
+++ b/MdePkg/Include/Guid/MemoryAttributesTable.h
@@ -21,8 +21,6 @@ typedef struct {
   // EFI_MEMORY_DESCRIPTOR Entry[1];
 } EFI_MEMORY_ATTRIBUTES_TABLE;
 
-#define EFI_MEMORY_ATTRIBUTES_TABLE_VERSION  0x00000002
-
 #define EFI_MEMORY_ATTRIBUTES_FLAGS_RT_FORWARD_CONTROL_FLOW_GUARD  0x1
 // BIT0 implies that Runtime code includes the forward control flow guard
 // instruction, such as X86 CET-IBT or ARM BTI.


### PR DESCRIPTION
This patch-set allows UEFI to choose which version of the memory attributes table to produce.