### PR TITLE
UefiPayloadPkg: Add SMM variable related HOBs support for SBL

### DIFF
--- a/UefiPayloadPkg/Library/SblParseLib/SblParseLib.inf
+++ b/UefiPayloadPkg/Library/SblParseLib/SblParseLib.inf
@@ -41,6 +41,11 @@
   gEfiGraphicsInfoHobGuid
   gEfiGraphicsDeviceInfoHobGuid
   gUniversalPayloadPciRootBridgeInfoGuid
+  gSmmRegisterInfoGuid
+  gEfiSmmSmramMemoryGuid
+  gSpiFlashInfoGuid
+  gNvVariableInfoGuid
+  gS3CommunicationGuid
 
 [Pcd]
   gUefiPayloadPkgTokenSpaceGuid.PcdBootloaderParameter


### PR DESCRIPTION
When UefiPayloadPkg is compiled with SMM_SUPPORT enabled and VARIABLE_SUPPORT set to SPI, the following HOBs must be available:

* gSmmRegisterInfoGuid
* gEfiSmmSmramMemoryGuid
* gSpiFlashInfoGuid
* gNvVariableInfoGuid
* gS3CommunicationGuid

Migrate these HOBs information from the bootloader HOB space to the UEFI payload HOB space. Parse them in misc function, so it won't fail if there would be no HOBs.

This patch was tested on Slim Bootloader with latest UEFI payload, and it worked as expected.