### PR TITLE
ShellPkg/Pci.c: Update supported link speed to PCIe Gen6

### DIFF
--- a/ShellPkg/Library/UefiShellDebug1CommandsLib/Pci.c
+++ b/ShellPkg/Library/UefiShellDebug1CommandsLib/Pci.c
@@ -4809,6 +4809,9 @@ ExplainPcieLinkCap (
     case 5:
       MaxLinkSpeed = L"32.0 GT/s";
       break;
+    case 6:
+      MaxLinkSpeed = L"64.0 GT/s";
+      break;
     default:
       MaxLinkSpeed = L"Reserved";
       break;
@@ -5014,6 +5017,9 @@ ExplainPcieLinkStatus (
       break;
     case 5:
       CurLinkSpeed = L"32.0 GT/s";
+      break;
+    case 6:
+      CurLinkSpeed = L"64.0 GT/s";
       break;
     default:
       CurLinkSpeed = L"Reserved";


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4779

Refer to PCI express base specification Reversion 6.2, table 7-23 Link Capabilities Register.
Supported Link Speeds Vector bit 5: speed 64 GT/s. Add the support to shell command 'pci'.

Signed-off-by: HoraceX Lien <horacex.lien@intel.com>
Cc: Zhichao Gao <zhichao.gao@intel.com>