### PR TITLE
EmulatorPkg: fix build error.

### DIFF
--- a/EmulatorPkg/Unix/Host/Gasket.h
+++ b/EmulatorPkg/Unix/Host/Gasket.h
@@ -140,7 +140,7 @@ GasketSecGetTime (
   OUT EFI_TIME_CAPABILITIES  *Capabilities OPTIONAL
   );
 
-VOID
+EFI_STATUS
 EFIAPI
 GasketSecSetTime (
   IN  EFI_TIME  *Time


### PR DESCRIPTION
GasketSecSetTime is EMU_SET_TIME and returns EFI_STATUS.  Fix the
declaration accordingly.  Fixes build error with gcc 14.

    /home/kraxel/projects/edk2/EmulatorPkg/Unix/Host/EmuThunk.c:429:3: error: initialization of ‘EFI_STATUS (__attribute__((ms_abi)) *)(EFI_TIME *)’ {aka ‘long long unsigned int (__attribute__((ms_abi)) *)(EFI_TIME *)’} from incompatible pointer type ‘void (__attribute__((ms_abi)) *)(EFI_TIME *)’ [-Wincompatible-pointer-types]
      429 |   GasketSecSetTime,
          |   ^~~~~~~~~~~~~~~~

Signed-off-by: Gerd Hoffmann <kraxel@redhat.com>
