### PR TITLE
BaseTools/Scripts: Remove Cc: tag check from PatchCheck.py

### DIFF
--- a/BaseTools/Scripts/PatchCheck.py
+++ b/BaseTools/Scripts/PatchCheck.py
@@ -234,8 +234,6 @@ class CommitMessageCheck:
     def check_misc_signatures(self):
         for sigtype in self.sig_types:
             sigs = self.find_signatures(sigtype)
-            if sigtype == 'Cc' and len(sigs) == 0:
-                self.error('No Cc: tags for maintainers/reviewers found!')
 
     cve_re = re.compile('CVE-[0-9]{4}-[0-9]{5}[^0-9]')
 


### PR DESCRIPTION
The commit message format requirements have been updated for GitHub PR based code reviews and no longer required Cc: tags for the maintainers and reviewers.  Remove the Cc: tag check from PatchCheck.py.