### PR TITLE
.github: Add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,27 @@
+# Description
+
+<_Include a description of the change and why this change was made._>
+
+<_For each item, place an "x" in between `[` and `]` if true. Example: `[x]` (you can also check items in GitHub UI)_>
+
+<_Create the PR as a Draft PR if it is only created to run CI checks._>
+
+<_Delete lines in \<\> tags before creating the PR._>
+
+- [ ] Breaking change?
+  - **Breaking change** - Will this cause a break in build or boot behavior?
+  - Examples: Add a new library class or move a module to a different repo.
+- [ ] Impacts security?
+  - **Security** - Does the change have a direct security impact?
+  - Examples: Crypto algorithm change or buffer overflow fix.
+- [ ] Includes tests?
+  - **Tests** - Does the change include any explicit test code?
+  - Examples: Unit tests or integration tests.
+
+## How This Was Tested
+
+<_Describe the test(s) that were run to verify the changes._>
+
+## Integration Instructions
+
+<_Describe how these changes should be integrated. Use N/A if nothing is required._>

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,36 @@
+# This workflow automatically applies labels to pull requests based on regular expression matches against the content
+# in the pull request.
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+# For more information, see:
+# https://github.com/github/issue-labeler
+
+name: Apply Labels Based on Message Content
+
+on:
+  pull_request_target:
+    types:
+      - edited
+      - opened
+      - reopened
+      - synchronize
+  workflow_dispatch:
+
+jobs:
+  sync:
+    name: Label PR from Description
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Apply Labels Based on PR Description
+        uses: github/issue-labeler@v3.1
+        with:
+          configuration-path: .github/workflows/pr-labeler/regex.yml
+          enable-versioned-regex: 0
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-labeler/regex.yml
+++ b/.github/workflows/pr-labeler/regex.yml
@@ -1,0 +1,16 @@
+# Specifies labels to apply to pull requests based on regular expressions.
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+# For more information, see:
+# https://github.com/github/issue-labeler
+
+impact:breaking-change:
+  - '\s*-\s*\[\s*[x|X]\s*\] Breaking change\?'
+
+impact:security:
+  - '\s*-\s*\[\s*[x|X]\s*\] Impacts security\?'
+
+impact:testing:
+  - '\s*-\s*\[\s*[x|X]\s*\] Includes tests\?'


### PR DESCRIPTION
Adds a pull request template with important information to note in
the PR description and guidance on how to classify the PR.

A simple GitHub action is present that applies three labels based
on the boxes checked in the PR template:

- `impact:breaking-change`
- `impact:security`
- `impact:testing`

These provide several benefits.

1. Bring attention to the impact of the PR both for reviewers and
   consumers that reference the PR in the future during debug or integration.
3. Allow automated tools like those that create release notes to
   be able to highlight important changes.
5. Similarly, to allow PR searches to conditionalize the search on
   PRs with these tags present.