### PR TITLE
MdeModulePkg/DxeCapsuleLibFmp: Fix crash if no ESRT is found

### DIFF
--- a/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleLib.c
+++ b/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleLib.c
@@ -11,6 +11,7 @@
   performs basic validation.
 
   Copyright (c) 2016 - 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2024, Ampere Computing LLC. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -47,6 +48,8 @@ BOOLEAN    mDxeCapsuleLibEndOfDxe      = FALSE;
 EFI_EVENT  mDxeCapsuleLibEndOfDxeEvent = NULL;
 
 EDKII_FIRMWARE_MANAGEMENT_PROGRESS_PROTOCOL  *mFmpProgress = NULL;
+
+extern BOOLEAN  mDxeCapsuleLibReadyToBootEvent;
 
 /**
   Initialize capsule related variables.
@@ -1402,6 +1405,16 @@ IsNestedFmpCapsule (
       }
     }
   } else {
+    if (mDxeCapsuleLibReadyToBootEvent) {
+      //
+      // The ESRT table (mEsrtTable) in the Configuration Table would be located
+      // at the ReadyToBoot event if it exists. Hence, it should return here to
+      // avoid a crash due to calling gBS->LocateProtocol () at runtime in case
+      // there is no ERST table installed.
+      //
+      return FALSE;
+    }
+
     //
     // Check ESRT protocol
     //

--- a/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleRuntime.c
+++ b/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleRuntime.c
@@ -2,6 +2,7 @@
   Capsule library runtime support.
 
   Copyright (c) 2016 - 2017, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2024, Ampere Computing LLC. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -23,6 +24,7 @@
 extern EFI_SYSTEM_RESOURCE_TABLE  *mEsrtTable;
 EFI_EVENT                         mDxeRuntimeCapsuleLibVirtualAddressChangeEvent = NULL;
 EFI_EVENT                         mDxeRuntimeCapsuleLibReadyToBootEvent          = NULL;
+BOOLEAN                           mDxeCapsuleLibReadyToBootEvent                 = FALSE;
 
 /**
   Convert EsrtTable physical address to virtual address.
@@ -93,6 +95,8 @@ DxeCapsuleLibReadyToBootEventNotify (
     //
     mEsrtTable->FwResourceCountMax = mEsrtTable->FwResourceCount;
   }
+
+  mDxeCapsuleLibReadyToBootEvent = TRUE;
 }
 
 /**


### PR DESCRIPTION
# Description

The ESRT table is not required in UEFI firmware. In such cases, the table may not be present in the UEFI Configuration Table. The mEsrtTable is to check if the IsNestedFmpCapsule() function is invoked at runtime to determine whether to use gEsrtManagementProtocolGuid or the ESRT table from the Configuration Table. Unfortunately, the check does not cover situations where the ESRT is not present, potentially resulting in a kernel crash. This patch is intended to fix this issue.

- [ ] Breaking change?
  - **Breaking change** - Will this cause a break in build or boot behavior?
  - Examples: Add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

<_Describe the test(s) that were run to verify the changes._>

## Integration Instructions

N/A
