### PR TITLE
MdeModulePkg: In RemoveTableFromRsdt don't read from unallocated memory

### DIFF
--- a/MdeModulePkg/Universal/Acpi/AcpiTableDxe/AcpiTableProtocol.c
+++ b/MdeModulePkg/Universal/Acpi/AcpiTableDxe/AcpiTableProtocol.c
@@ -1279,16 +1279,16 @@ RemoveTableFromRsdt (
     {
       //
       // Found entry, so copy all following entries and shrink table
-      // We actually copy all + 1 to copy the initialized value of memory over
-      // the last entry.
       //
       if (Rsdt != NULL) {
-        CopyMem (CurrentRsdtEntry, CurrentRsdtEntry + 1, (*NumberOfTableEntries - Index) * sizeof (UINT32));
+        CopyMem (CurrentRsdtEntry, CurrentRsdtEntry + 1, (*NumberOfTableEntries - Index - 1) * sizeof (UINT32));
+        ZeroMem ((UINT8 *)Rsdt + sizeof (EFI_ACPI_DESCRIPTION_HEADER) + ((*NumberOfTableEntries - 1) * sizeof (UINT32)), sizeof (UINT32));
         Rsdt->Length = Rsdt->Length - sizeof (UINT32);
       }
 
       if (Xsdt != NULL) {
-        CopyMem (CurrentXsdtEntry, ((UINT64 *)CurrentXsdtEntry) + 1, (*NumberOfTableEntries - Index) * sizeof (UINT64));
+        CopyMem (CurrentXsdtEntry, ((UINT64 *)CurrentXsdtEntry) + 1, (*NumberOfTableEntries - Index - 1) * sizeof (UINT64));
+        ZeroMem ((UINT8 *)Xsdt + sizeof (EFI_ACPI_DESCRIPTION_HEADER) + ((*NumberOfTableEntries - 1) * sizeof (UINT64)), sizeof (UINT64));
         Xsdt->Length = Xsdt->Length - sizeof (UINT64);
       }
 


### PR DESCRIPTION


# Description

Instead of copying from unallocated memory in RemoveTableFromRsdt, do a CopyMem followed by ZeroMem.

- [ ] Breaking change?
  - **Breaking change** - Will this cause a break in build or boot behavior?
  - Examples: Add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Enabled the following PCDs and booted my ADLINK AADK system. The crash following the read from unallocated memory was no longer seen.

```
  gEfiMdeModulePkgTokenSpaceGuid.PcdHeapGuardPageType|0xC000000000007B9E
  gEfiMdeModulePkgTokenSpaceGuid.PcdHeapGuardPoolType|0xC000000000007B9E
  gEfiMdeModulePkgTokenSpaceGuid.PcdHeapGuardPropertyMask|0x0F
```

## Integration Instructions

N/A
