### PR TITLE
EmbeddedPkg: Improve error handling in LocateAndInstallAcpiFromFvConditional

### DIFF
--- a/EmbeddedPkg/Library/AcpiLib/AcpiLib.c
+++ b/EmbeddedPkg/Library/AcpiLib/AcpiLib.c
@@ -52,6 +52,9 @@ LocateAndInstallAcpiFromFvConditional (
   UINTN                          AcpiTableSize;
   UINTN                          AcpiTableKey;
   BOOLEAN                        Valid;
+  BOOLEAN                        FoundAcpiFile;
+
+  FoundAcpiFile = FALSE;
 
   // Ensure the ACPI Table is present
   Status = gBS->LocateProtocol (
@@ -107,47 +110,48 @@ LocateAndInstallAcpiFromFvConditional (
                              &SectionSize,
                              &FvStatus
                              );
-      if (!EFI_ERROR (Status)) {
-        AcpiTableKey  = 0;
-        AcpiTableSize = ((EFI_ACPI_DESCRIPTION_HEADER *)AcpiTable)->Length;
-        ASSERT (SectionSize >= AcpiTableSize);
 
-        DEBUG ((
-          DEBUG_ERROR,
-          "- Found '%c%c%c%c' ACPI Table\n",
-          (((EFI_ACPI_DESCRIPTION_HEADER *)AcpiTable)->Signature & 0xFF),
-          ((((EFI_ACPI_DESCRIPTION_HEADER *)AcpiTable)->Signature >> 8) & 0xFF),
-          ((((EFI_ACPI_DESCRIPTION_HEADER *)AcpiTable)->Signature >> 16) & 0xFF),
-          ((((EFI_ACPI_DESCRIPTION_HEADER *)AcpiTable)->Signature >> 24) & 0xFF)
-          ));
-
-        // Is the ACPI table valid?
-        if (CheckAcpiTableFunction) {
-          Valid = CheckAcpiTableFunction ((EFI_ACPI_DESCRIPTION_HEADER *)AcpiTable);
-        } else {
-          Valid = TRUE;
-        }
-
-        // Install the ACPI Table
-        if (Valid) {
-          Status = AcpiProtocol->InstallAcpiTable (
-                                   AcpiProtocol,
-                                   AcpiTable,
-                                   AcpiTableSize,
-                                   &AcpiTableKey
-                                   );
-        }
-
-        // Free memory allocated by ReadSection
-        gBS->FreePool (AcpiTable);
-
-        if (EFI_ERROR (Status)) {
-          break;
-        }
-
-        // Increment the section instance
-        SectionInstance++;
+      if (EFI_ERROR (Status)) {
+        break;
       }
+
+      FoundAcpiFile = TRUE;
+
+      AcpiTableKey  = 0;
+      AcpiTableSize = ((EFI_ACPI_DESCRIPTION_HEADER *)AcpiTable)->Length;
+      ASSERT (SectionSize >= AcpiTableSize);
+
+      DEBUG ((
+        DEBUG_ERROR,
+        "- Found '%c%c%c%c' ACPI Table\n",
+        (((EFI_ACPI_DESCRIPTION_HEADER *)AcpiTable)->Signature & 0xFF),
+        ((((EFI_ACPI_DESCRIPTION_HEADER *)AcpiTable)->Signature >> 8) & 0xFF),
+        ((((EFI_ACPI_DESCRIPTION_HEADER *)AcpiTable)->Signature >> 16) & 0xFF),
+        ((((EFI_ACPI_DESCRIPTION_HEADER *)AcpiTable)->Signature >> 24) & 0xFF)
+        ));
+
+      // Is the ACPI table valid?
+      if (CheckAcpiTableFunction) {
+        Valid = CheckAcpiTableFunction ((EFI_ACPI_DESCRIPTION_HEADER *)AcpiTable);
+      } else {
+        Valid = TRUE;
+      }
+
+      // Install the ACPI Table
+      if (Valid) {
+        Status = AcpiProtocol->InstallAcpiTable (
+                                 AcpiProtocol,
+                                 AcpiTable,
+                                 AcpiTableSize,
+                                 &AcpiTableKey
+                                 );
+      }
+
+      // Free memory allocated by ReadSection
+      gBS->FreePool (AcpiTable);
+
+      // Increment the section instance
+      SectionInstance++;
     }
   }
 
@@ -157,7 +161,7 @@ FREE_HANDLE_BUFFER:
   //
   gBS->FreePool (HandleBuffer);
 
-  return EFI_SUCCESS;
+  return (FoundAcpiFile? EFI_SUCCESS : EFI_NOT_FOUND);
 }
 
 /**


### PR DESCRIPTION
# Description

LocateAndInstallAcpiFromFvConditional was always returning EFI_SUCCESS even when it failed to find `AcpiFile`. Fix that, and improve the layout by checking if an error occurred and breaking earlier.

- [ ] Breaking change?
  - **Breaking change** - Will this cause a break in build or boot behavior?
  - Examples: Add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

## Integration Instructions

N/A
