### PR TITLE
OvmfPkg/VirtioRngDxe: check if device is ready

### DIFF
--- a/OvmfPkg/VirtioRngDxe/VirtioRng.h
+++ b/OvmfPkg/VirtioRngDxe/VirtioRng.h
@@ -33,6 +33,7 @@ typedef struct {
   VRING                     Ring;           // VirtioRingInit       2
   EFI_RNG_PROTOCOL          Rng;            // VirtioRngInit        1
   VOID                      *RingMap;       // VirtioRingMap        2
+  BOOLEAN                   Ready;
 } VIRTIO_RNG_DEV;
 
 #define VIRTIO_ENTROPY_SOURCE_FROM_RNG(RngPointer) \


### PR DESCRIPTION
Add a 'Ready' boolean to the driver state struct, use it to track
whenever the device is ready to be used.  In case it is not ready
throw an EFI_DEVICE_ERROR instead of sending a request which will
never receive an answer.
