### PR TITLE
ArmPkg: Add new function OemGetPhysicalBiosSize to OemMiscLib

### DIFF
--- a/ArmPkg/Include/Library/OemMiscLib.h
+++ b/ArmPkg/Include/Library/OemMiscLib.h
@@ -64,6 +64,12 @@ typedef enum {
   SmbiosHiiStringFieldMax
 } OEM_MISC_SMBIOS_HII_STRING_FIELD;
 
+UINT64
+EFIAPI
+OemGetPhysicalBiosSize (
+  VOID
+  );
+
 /*
  * The following are functions that the each platform needs to
  * implement in its OemMiscLib library.

--- a/ArmPkg/Universal/Smbios/SmbiosMiscDxe/SmbiosMiscDxe.inf
+++ b/ArmPkg/Universal/Smbios/SmbiosMiscDxe/SmbiosMiscDxe.inf
@@ -68,7 +68,6 @@
   gEfiSmbiosProtocolGuid                       # PROTOCOL ALWAYS_CONSUMED
 
 [Pcd]
-  gArmTokenSpaceGuid.PcdFdSize
   gEfiMdeModulePkgTokenSpaceGuid.PcdFirmwareVendor
   gEfiMdeModulePkgTokenSpaceGuid.PcdFirmwareVersionString
   gArmTokenSpaceGuid.PcdSystemBiosRelease

--- a/ArmPkg/Universal/Smbios/SmbiosMiscDxe/Type00/MiscBiosVendorFunction.c
+++ b/ArmPkg/Universal/Smbios/SmbiosMiscDxe/Type00/MiscBiosVendorFunction.c
@@ -235,7 +235,7 @@ SMBIOS_MISC_TABLE_FUNCTION (MiscBiosVendor) {
   //
   // Now update the BiosPhysicalSize
   //
-  BiosPhysicalSize = FixedPcdGet32 (PcdFdSize);
+  BiosPhysicalSize = OemGetPhysicalBiosSize ();
 
   //
   // Two zeros following the last string.


### PR DESCRIPTION
# Description

The FD size often isn't the same as the physical size of the SPI-NOR EEPROM it gets written to, but is instead combined with other files and data to create the final image. Add a function `OemGetPhysicalBiosSize` which allows platforms to provide the actual size of the EEPROM for SMBIOS.

- [x] Breaking change?
  - **Breaking change** - Will this cause a break in build or boot behavior?
  - Examples: Add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

## Integration Instructions

An implementation of OemGetPhysicalBiosSize should be added to AArch64 platforms.
