### PR TITLE
CryptoPkg: Remove deprecated code related to SHA-1

### DIFF
--- a/CryptoPkg/Library/BaseCryptLib/Rand/CryptRand.c
+++ b/CryptoPkg/Library/BaseCryptLib/Rand/CryptRand.c
@@ -43,14 +43,6 @@ RandomSeed (
   }
 
   //
-  // The software PRNG implementation built in OpenSSL depends on message digest algorithm.
-  // Make sure SHA-1 digest algorithm is available here.
-  //
-  if (EVP_add_digest (EVP_sha1 ()) == 0) {
-    return FALSE;
-  }
-
-  //
   // Seed the pseudorandom number generator with user-supplied value.
   // NOTE: A cryptographic PRNG must be seeded with unpredictable data.
   //

--- a/CryptoPkg/Library/BaseCryptLib/Rand/CryptRandTsc.c
+++ b/CryptoPkg/Library/BaseCryptLib/Rand/CryptRandTsc.c
@@ -41,14 +41,6 @@ RandomSeed (
   }
 
   //
-  // The software PRNG implementation built in OpenSSL depends on message digest algorithm.
-  // Make sure SHA-1 digest algorithm is available here.
-  //
-  if (EVP_add_digest (EVP_sha1 ()) == 0) {
-    return FALSE;
-  }
-
-  //
   // Seed the pseudorandom number generator with user-supplied value.
   // NOTE: A cryptographic PRNG must be seeded with unpredictable data.
   //


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4698

The default drbg type of randlib has been switched to aes_256_ctr in openssl1.1.1, so sha1 is not really used in RandomSeed(). Remove related code which do SHA-1 support checking in CryptRand.c and CryptRandTsc.c to avoid potential compatibility errors.

Cc: Jiewen Yao <jiewen.yao@intel.com>
Reviewed-by: Yi Li <yi1.li@intel.com>

# Description

<_Include a description of the change and why this change was made._>

<_For each item, place an "x" in between `[` and `]` if true. Example: `[x]` (you can also check items in GitHub UI)_>

<_Create the PR as a Draft PR if it is only created to run CI checks._>

<_Delete lines in \<\> tags before creating the PR._>

- [ ] Breaking change?
  - **Breaking change** - Will this cause a break in build or boot behavior?
  - Examples: Add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

<_Describe the test(s) that were run to verify the changes._>

## Integration Instructions

<_Describe how these changes should be integrated. Use N/A if nothing is required._>
