### PR TITLE
CryptoPkg: Add support for aes128-sha256 and aes256-sha256 cipher

### DIFF
--- a/CryptoPkg/Library/OpensslLib/OpensslStub/uefiprov.c
+++ b/CryptoPkg/Library/OpensslLib/OpensslStub/uefiprov.c
@@ -141,6 +141,17 @@ static const OSSL_ALGORITHM_CAPABLE deflt_ciphers[] = {
     ALG(PROV_NAMES_AES_192_GCM, ossl_aes192gcm_functions),
     ALG(PROV_NAMES_AES_128_GCM, ossl_aes128gcm_functions),
 
+    ALGC (
+        PROV_NAMES_AES_128_CBC_HMAC_SHA256,
+        ossl_aes128cbc_hmac_sha256_functions,
+        ossl_cipher_capable_aes_cbc_hmac_sha256
+        ),
+    ALGC (
+        PROV_NAMES_AES_256_CBC_HMAC_SHA256,
+        ossl_aes256cbc_hmac_sha256_functions,
+        ossl_cipher_capable_aes_cbc_hmac_sha256
+        ),
+
     { { NULL, NULL, NULL }, NULL }
 };
 static OSSL_ALGORITHM exported_ciphers[OSSL_NELEM(deflt_ciphers)];


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4739

AES256-SHA256 is a Tls1.2 suite we need to support, add it to deflt_ciphers in OpensslStub.


Cc: Jiewen Yao <jiewen.yao@intel.com>
Reviewed-by: Yi Li <yi1.li@intel.com>

# Description

<_Include a description of the change and why this change was made._>

<_For each item, place an "x" in between `[` and `]` if true. Example: `[x]` (you can also check items in GitHub UI)_>

<_Create the PR as a Draft PR if it is only created to run CI checks._>

<_Delete lines in \<\> tags before creating the PR._>

- [ ] Breaking change?
  - **Breaking change** - Will this cause a break in build or boot behavior?
  - Examples: Add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

<_Describe the test(s) that were run to verify the changes._>

## Integration Instructions

<_Describe how these changes should be integrated. Use N/A if nothing is required._>
