### PR TITLE
 Add a new FdtNorFalshQemuLib and enable it in ArmVirtPkg

### DIFF
--- a/ArmVirtPkg/ArmVirtQemu.dsc
+++ b/ArmVirtPkg/ArmVirtQemu.dsc
@@ -66,7 +66,7 @@
   QemuLoadImageLib|OvmfPkg/Library/GenericQemuLoadImageLib/GenericQemuLoadImageLib.inf
 
   TimerLib|ArmPkg/Library/ArmArchTimerLib/ArmArchTimerLib.inf
-  VirtNorFlashPlatformLib|ArmVirtPkg/Library/NorFlashQemuLib/NorFlashQemuLib.inf
+  VirtNorFlashPlatformLib|OvmfPkg/Library/FdtNorFlashQemuLib/FdtNorFlashQemuLib.inf
 
   CapsuleLib|MdeModulePkg/Library/DxeCapsuleLibNull/DxeCapsuleLibNull.inf
   BootLogoLib|MdeModulePkg/Library/BootLogoLib/BootLogoLib.inf
@@ -152,6 +152,9 @@
   gArmTokenSpaceGuid.PcdVFPEnabled|1
 !endif
 
+  gUefiOvmfPkgTokenSpaceGuid.PcdOvmfFdBaseAddress|0x00000000
+  gUefiOvmfPkgTokenSpaceGuid.PcdOvmfFirmwareFdSize|$(FD_SIZE)
+
   gArmPlatformTokenSpaceGuid.PcdCPUCoresStackBase|0x4007c000
   gArmPlatformTokenSpaceGuid.PcdCPUCorePrimaryStackSize|0x4000
   gEfiMdeModulePkgTokenSpaceGuid.PcdMaxVariableSize|0x2000
@@ -231,6 +234,10 @@
   # System Memory Size -- 128 MB initially, actual size will be fetched from DT
   gArmTokenSpaceGuid.PcdSystemMemorySize|0x8000000
 
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageVariableSize   | 0x40000
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwSpareSize   | 0x40000
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwWorkingSize | 0x40000
+
 [PcdsFixedAtBuild.AARCH64]
   # Clearing BIT0 in this PCD prevents installing a 32-bit SMBIOS entry point,
   # if the entry point version is >= 3.0. AARCH64 OSes cannot assume the
@@ -242,6 +249,13 @@
 
 [PcdsDynamicDefault.common]
   gEfiMdePkgTokenSpaceGuid.PcdPlatformBootTimeOut|3
+
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwSpareBase     | 0
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwSpareBase64   | 0
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageVariableBase64   | 0
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageVariableBase     | 0
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwWorkingBase   | 0
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwWorkingBase64 | 0
 
   ## If TRUE, OvmfPkg/AcpiPlatformDxe will not wait for PCI
   #  enumeration to complete before installing ACPI tables.
@@ -404,7 +418,10 @@
   MdeModulePkg/Universal/SecurityStubDxe/SecurityStubDxe.inf
 !endif
   MdeModulePkg/Universal/CapsuleRuntimeDxe/CapsuleRuntimeDxe.inf
-  MdeModulePkg/Universal/FaultTolerantWriteDxe/FaultTolerantWriteDxe.inf
+  MdeModulePkg/Universal/FaultTolerantWriteDxe/FaultTolerantWriteDxe.inf {
+    <LibraryClasses>
+      NULL|EmbeddedPkg/Library/NvVarStoreFormattedLib/NvVarStoreFormattedLib.inf
+  }
   MdeModulePkg/Universal/MonotonicCounterRuntimeDxe/MonotonicCounterRuntimeDxe.inf
   MdeModulePkg/Universal/ResetSystemRuntimeDxe/ResetSystemRuntimeDxe.inf
   EmbeddedPkg/RealTimeClockRuntimeDxe/RealTimeClockRuntimeDxe.inf {

--- a/ArmVirtPkg/ArmVirtQemuKernel.dsc
+++ b/ArmVirtPkg/ArmVirtQemuKernel.dsc
@@ -65,7 +65,7 @@
   ArmVirtMemInfoLib|ArmVirtPkg/Library/QemuVirtMemInfoLib/QemuVirtMemInfoLib.inf
 
   TimerLib|ArmPkg/Library/ArmArchTimerLib/ArmArchTimerLib.inf
-  VirtNorFlashPlatformLib|ArmVirtPkg/Library/NorFlashQemuLib/NorFlashQemuLib.inf
+  VirtNorFlashPlatformLib|OvmfPkg/Library/FdtNorFlashQemuLib/FdtNorFlashQemuLib.inf
 
   CapsuleLib|MdeModulePkg/Library/DxeCapsuleLibNull/DxeCapsuleLibNull.inf
   BootLogoLib|MdeModulePkg/Library/BootLogoLib/BootLogoLib.inf
@@ -120,6 +120,8 @@
   gArmTokenSpaceGuid.PcdVFPEnabled|1
 !endif
 
+  gUefiOvmfPkgTokenSpaceGuid.PcdOvmfFdBaseAddress|0x00000000
+  gUefiOvmfPkgTokenSpaceGuid.PcdOvmfFirmwareFdSize|$(FD_SIZE)
   gArmPlatformTokenSpaceGuid.PcdCPUCorePrimaryStackSize|0x4000
   gEfiMdeModulePkgTokenSpaceGuid.PcdMaxVariableSize|0x2000
   gEfiMdeModulePkgTokenSpaceGuid.PcdMaxAuthVariableSize|0x2800
@@ -181,6 +183,10 @@
   gEfiMdePkgTokenSpaceGuid.PcdReportStatusCodePropertyMask|3
   gEfiShellPkgTokenSpaceGuid.PcdShellFileOperationSize|0x20000
 
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageVariableSize   | 0x40000
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwSpareSize   | 0x40000
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwWorkingSize | 0x40000
+
 [PcdsPatchableInModule.common]
   # we need to provide a resolution for this PCD that supports PcdSet64()
   # being called from ArmVirtPkg/Library/PlatformPeiLib/PlatformPeiLib.c,
@@ -207,6 +213,13 @@
 
 [PcdsDynamicDefault.common]
   gEfiMdePkgTokenSpaceGuid.PcdPlatformBootTimeOut|3
+
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwSpareBase     | 0
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwSpareBase64   | 0
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageVariableBase64   | 0
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageVariableBase     | 0
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwWorkingBase   | 0
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwWorkingBase64 | 0
 
   ## If TRUE, OvmfPkg/AcpiPlatformDxe will not wait for PCI
   #  enumeration to complete before installing ACPI tables.
@@ -313,7 +326,10 @@
   MdeModulePkg/Universal/SecurityStubDxe/SecurityStubDxe.inf
 !endif
   MdeModulePkg/Universal/CapsuleRuntimeDxe/CapsuleRuntimeDxe.inf
-  MdeModulePkg/Universal/FaultTolerantWriteDxe/FaultTolerantWriteDxe.inf
+  MdeModulePkg/Universal/FaultTolerantWriteDxe/FaultTolerantWriteDxe.inf {
+    <LibraryClasses>
+      NULL|EmbeddedPkg/Library/NvVarStoreFormattedLib/NvVarStoreFormattedLib.inf
+  }
   MdeModulePkg/Universal/MonotonicCounterRuntimeDxe/MonotonicCounterRuntimeDxe.inf
   MdeModulePkg/Universal/ResetSystemRuntimeDxe/ResetSystemRuntimeDxe.inf
   EmbeddedPkg/RealTimeClockRuntimeDxe/RealTimeClockRuntimeDxe.inf {

--- a/ArmVirtPkg/VarStore.fdf.inc
+++ b/ArmVirtPkg/VarStore.fdf.inc
@@ -10,7 +10,7 @@
 ##
 
 [FD.QEMU_VARS]
-BaseAddress   = 0x04000000
+BaseAddress   = 0x00000000
 Size          = 0xc0000
 ErasePolarity = 1
 BlockSize     = 0x40000
@@ -18,7 +18,6 @@ NumBlocks     = 3
 
 
 0x00000000|0x00040000
-gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageVariableBase|gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageVariableSize
 #NV_VARIABLE_STORE
 DATA = {
   ## This is the EFI_FIRMWARE_VOLUME_HEADER
@@ -57,7 +56,6 @@ DATA = {
 
 
 0x00040000|0x00040000
-gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwWorkingBase|gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwWorkingSize
 #NV_FTW_WORKING
 DATA = {
   # EFI_FAULT_TOLERANT_WORKING_BLOCK_HEADER->Signature = gEdkiiWorkingBlockSignatureGuid         =
@@ -71,5 +69,4 @@ DATA = {
 }
 
 0x00080000|0x00040000
-gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwSpareBase|gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwSpareSize
 #NV_FTW_SPARE

--- a/OvmfPkg/Library/FdtNorFlashQemuLib/FdtNorFlashQemuLib.c
+++ b/OvmfPkg/Library/FdtNorFlashQemuLib/FdtNorFlashQemuLib.c
@@ -1,0 +1,165 @@
+/** @file
+
+  Copyright (c) 2014-2018, Linaro Ltd. All rights reserved.<BR>
+  Copyright (c) 2024 Loongson Technology Corporation Limited. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Library/BaseLib.h>
+#include <Library/DebugLib.h>
+#include <Library/UefiBootServicesTableLib.h>
+#include <Library/VirtNorFlashPlatformLib.h>
+
+#include <Protocol/FdtClient.h>
+#include <stdbool.h>
+
+#define QEMU_NOR_BLOCK_SIZE  SIZE_256KB
+#define MAX_FLASH_BANKS      4
+
+STATIC VIRT_NOR_FLASH_DESCRIPTION  mNorFlashDevices[MAX_FLASH_BANKS];
+
+EFI_STATUS
+VirtNorFlashPlatformInitialization (
+  VOID
+  )
+{
+  return EFI_SUCCESS;
+}
+
+EFI_STATUS
+VirtNorFlashPlatformGetDevices (
+  OUT VIRT_NOR_FLASH_DESCRIPTION  **NorFlashDescriptions,
+  OUT UINT32                      *Count
+  )
+{
+  FDT_CLIENT_PROTOCOL  *FdtClient;
+  INT32                Node;
+  EFI_STATUS           Status;
+  EFI_STATUS           FindNodeStatus;
+  CONST UINT32         *Reg;
+  UINT32               PropSize;
+  UINT32               Num;
+  UINT64               Base;
+  UINT64               Size;
+  BOOLEAN              Found;
+
+  Status = gBS->LocateProtocol (
+                  &gFdtClientProtocolGuid,
+                  NULL,
+                  (VOID **)&FdtClient
+                  );
+  ASSERT_EFI_ERROR (Status);
+
+  Num   = 0;
+  Found = FALSE;
+  for (FindNodeStatus = FdtClient->FindCompatibleNode (
+                                     FdtClient,
+                                     "cfi-flash",
+                                     &Node
+                                     );
+       !EFI_ERROR (FindNodeStatus) && Num < MAX_FLASH_BANKS;
+       FindNodeStatus = FdtClient->FindNextCompatibleNode (
+                                     FdtClient,
+                                     "cfi-flash",
+                                     Node,
+                                     &Node
+                                     ))
+  {
+    Status = FdtClient->GetNodeProperty (
+                          FdtClient,
+                          Node,
+                          "reg",
+                          (CONST VOID **)&Reg,
+                          &PropSize
+                          );
+    if (EFI_ERROR (Status)) {
+      DEBUG ((
+        DEBUG_ERROR,
+        "%a: GetNodeProperty () failed (Status == %r)\n",
+        __func__,
+        Status
+        ));
+      continue;
+    }
+
+    ASSERT ((PropSize % (4 * sizeof (UINT32))) == 0);
+
+    while (PropSize >= (4 * sizeof (UINT32)) && Num < MAX_FLASH_BANKS) {
+      Base = SwapBytes64 (ReadUnaligned64 ((VOID *)&Reg[0]));
+      Size = SwapBytes64 (ReadUnaligned64 ((VOID *)&Reg[2]));
+      Reg += 4;
+
+      PropSize -= 4 * sizeof (UINT32);
+
+      //
+      // Disregard any flash devices that overlap with the primary FV.
+      // The firmware is not updatable from inside the guest anyway.
+      //
+      if ((PcdGet32 (PcdOvmfFdBaseAddress) + PcdGet32 (PcdOvmfFirmwareFdSize) > Base) &&
+          ((Base + Size) > PcdGet32 (PcdOvmfFdBaseAddress)))
+      {
+        continue;
+      }
+
+      mNorFlashDevices[Num].DeviceBaseAddress = (UINTN)Base;
+      mNorFlashDevices[Num].RegionBaseAddress = (UINTN)Base;
+      mNorFlashDevices[Num].Size              = (UINTN)Size;
+      mNorFlashDevices[Num].BlockSize         = QEMU_NOR_BLOCK_SIZE;
+      Num++;
+      if (!Found) {
+        //
+        // By default, the second available flash is stored as a non-volatile variable.
+        //
+        Status = PcdSet32S (PcdFlashNvStorageVariableBase, Base);
+        ASSERT_EFI_ERROR (Status);
+
+        //
+        // The Base is the value of PcdFlashNvStorageVariableBase,
+        // PcdFlashNvStorageFtwWorkingBase can be got by
+        // PcdFlashNvStorageVariableBase + PcdFlashNvStorageVariableSize
+        //
+        Base  += PcdGet32 (PcdFlashNvStorageVariableSize);
+        Status = PcdSet32S (PcdFlashNvStorageFtwWorkingBase, Base);
+        ASSERT_EFI_ERROR (Status);
+
+        //
+        // Now, the Base is the value of PcdFlashNvStorageFtwWorkingBase,
+        // PcdFlashNvStorageFtwSpareBase can be got by
+        // PcdFlashNvStorageFtwWorkingBase + PcdFlashNvStorageFtwWorkingSize.
+        //
+        Base  += PcdGet32 (PcdFlashNvStorageFtwWorkingSize);
+        Status = PcdSet32S (PcdFlashNvStorageFtwSpareBase, Base);
+        ASSERT_EFI_ERROR (Status);
+        Found = TRUE;
+      }
+    }
+
+    //
+    // UEFI takes ownership of the NOR flash, and exposes its functionality
+    // through the UEFI Runtime Services GetVariable, SetVariable, etc. This
+    // means we need to disable it in the device tree to prevent the OS from
+    // attaching its device driver as well.
+    // Note that this also hides other flash banks, but the only other flash
+    // bank we expect to encounter is the one that carries the UEFI executable
+    // code, which is not intended to be guest updatable, and is usually backed
+    // in a readonly manner by QEMU anyway.
+    //
+    Status = FdtClient->SetNodeProperty (
+                          FdtClient,
+                          Node,
+                          "status",
+                          "disabled",
+                          sizeof ("disabled")
+                          );
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_WARN, "Failed to set NOR flash status to 'disabled'\n"));
+    }
+  }
+
+  *NorFlashDescriptions = mNorFlashDevices;
+  *Count                = Num;
+
+  return EFI_SUCCESS;
+}

--- a/OvmfPkg/Library/FdtNorFlashQemuLib/FdtNorFlashQemuLib.inf
+++ b/OvmfPkg/Library/FdtNorFlashQemuLib/FdtNorFlashQemuLib.inf
@@ -1,0 +1,46 @@
+## @file
+#
+#  Copyright (c) 2014-2018, Linaro Ltd. All rights reserved.<BR>
+#  Copyright (c) 2024 Loongson Technology Corporation Limited. All rights reserved.<BR>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 1.29
+  BASE_NAME                      = NorFlashQemuLib
+  FILE_GUID                      = E225C90F-6CB9-8AF3-095B-2668FC633A57
+  MODULE_TYPE                    = DXE_DRIVER
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = NorFlashQemuLib|DXE_DRIVER DXE_RUNTIME_DRIVER UEFI_DRIVER UEFI_APPLICATION
+
+[Sources]
+  FdtNorFlashQemuLib.c
+
+[Packages]
+  EmbeddedPkg/EmbeddedPkg.dec
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  OvmfPkg/OvmfPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  DebugLib
+  UefiBootServicesTableLib
+
+[Protocols]
+  gFdtClientProtocolGuid          ## CONSUMES
+
+[Depex]
+  gFdtClientProtocolGuid
+
+[Pcd]
+gUefiOvmfPkgTokenSpaceGuid.PcdOvmfFdBaseAddress
+gUefiOvmfPkgTokenSpaceGuid.PcdOvmfFirmwareFdSize
+gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageVariableSize
+gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwSpareSize
+gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwWorkingSize
+gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageVariableBase
+gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwWorkingBase
+gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwSpareBase


### PR DESCRIPTION
# Description

Add a new FdtNorFalshQemuLib and enable it in ArmVirt platforms

* Patch1: Added a new library called FdtNorFlashQemuLib in OvmfPkg/Library which is non-hardcode dependency.
* Patch2: Enable the new library in ArmVirtQemu.dsc and ArmVirtQemuKernel.dsc.

BZ: https://bugzilla.tianocore.org/show_bug.cgi?id=4770

## How This Was Tested

### Step 1
Build the two platforms firmware using ArmVirtQemu.dsc and ArmVirtQemuKernel.dsc, and then create the pflash files using following command:
```
cat QEMU_EFI.fd  /dev/zero | head -c 64m > ./QEMU_EFI-pflash.raw
cat QEMU_VARS.fd  /dev/zero | head -c 64m > ./vars-template-pflash.raw
qemu-img convert -f raw -O qcow2 -o cluster_size=4096 -S 4096 QEMU_EFI-pflash.raw  QEMU_EFI-pflash.qcow2
qemu-img convert -f raw -O qcow2 -o cluster_size=4096 -S 4096 vars-template-pflash.raw vars-template-pflash.qcow2
```
### Step 2
Verification the pflash working:
#### ArmVirtQemu:
Run the QEMU ARM virt machine using the following command:
```
qemu-system-aarch64 \
    -blockdev '{"driver":"file","filename":"/usr/share/edk2/aarch64/QEMU_EFI-pflash.qcow2","node-name":"libvirt-pflash0-storage","auto-read-only":true,"discard":"unmap"}' \
    -blockdev '{"node-name":"libvirt-pflash0-format","read-only":true,"driver":"qcow2","file":"libvirt-pflash0-storage"}' \
    -blockdev '{"driver":"file","filename":"/usr/share/edk2/aarch64/vars-template-pflash.qcow2","node-name":"libvirt-pflash1-storage","auto-read-only":true,"discard":"unmap"}' \
    -blockdev '{"node-name":"libvirt-pflash1-format","read-only":false,"driver":"qcow2","file":"libvirt-pflash1-storage"}' \
    -machine virt,pflash0=libvirt-pflash0-format,pflash1=libvirt-pflash1-format,acpi=on \
    -cpu cortex-a57 \
    -m size=2097152k \
    -serial stdio \
    -net none \
    -device ramfb \
    -device nec-usb-xhci \
    -device usb-mouse \
    -device usb-kbd
```

#### ArmVirtQemuKernel:
Run the QEMU kernel ARM virt machine using the following command:
```
qemu-system-aarch64 \
    -blockdev '{"driver":"file","filename":"/usr/share/edk2/aarch64/vars-template-pflash.raw","node-name":"libvirt-pflash1-storage","auto-read-only":true,"discard":"unmap"}' \
    -blockdev '{"node-name":"libvirt-pflash1-format","read-only":false,"driver":"raw","file":"libvirt-pflash1-storage"}' \
    -machine virt,usb=off,dump-guest-core=off,gic-version=3,pflash1=libvirt-pflash1-format \
    -cpu cortex-a57 \
    -m 4096 \
    -smp 1,sockets=1,cores=1,threads=1 \
    -no-user-config \
    -nodefaults \
    -device virtio-gpu-pci \
    -kernel /usr/share/edk2/aarch64/QEMU_EFI-pflash.raw \
    -serial stdio \
    -device nec-usb-xhci \
    -device usb-mouse \
    -device usb-kbd  \
    -hda /usr/share/edk2/aarch64/openEuler-22.03-LTS-SP3-aarch64.qcow2 \
    -monitor tcp::3333,server,nowait
```

### Step 3
* After the virt-machines starts, enter "F2" to enter the setup UI, try to change the boot order or some ther variables stored in the flash, then enter "F10" to save the changes and reboot it.
* After restarting, enter "F2" to enter the setup UI and check whether the changes before the restart operation have been saved.

Using the above three steps, both platforms will works fine


## Integration Instructions

N/A
