### PR TITLE
MdeModulePkg/HiiDatabaseDxe: Avoid struct assignment

### DIFF
--- a/MdeModulePkg/Universal/HiiDatabaseDxe/Image.c
+++ b/MdeModulePkg/Universal/HiiDatabaseDxe/Image.c
@@ -1288,7 +1288,6 @@ HiiDrawImage (
   UINTN                          BufferLen;
   UINT16                         Width;
   UINT16                         Height;
-  UINTN                          Xpos;
   UINTN                          Ypos;
   UINTN                          OffsetY1;
   UINTN                          OffsetY2;
@@ -1390,9 +1389,11 @@ HiiDrawImage (
       for (Ypos = 0; Ypos < Height; Ypos++) {
         OffsetY1 = Image->Width * Ypos;
         OffsetY2 = Width * Ypos;
-        for (Xpos = 0; Xpos < Width; Xpos++) {
-          BltBuffer[OffsetY2 + Xpos] = Image->Bitmap[OffsetY1 + Xpos];
-        }
+        CopyMem (
+          &BltBuffer[OffsetY2],
+          &Image->Bitmap[OffsetY1],
+          Width * sizeof (*BltBuffer)
+          );
       }
     }
 


### PR DESCRIPTION
Struct assignments are not permitted in EDK2, as they may be converted by the compiler into calls to the 'memcpy' intrinsic, which is not guaranteed to be available in EDK2.

So replace the assignment with a call to CopyMem (), and -while at it- replace the loop with a single CopyMem () call, as the loop operates on items that are contiguous in memory.

## How This Was Tested

Build tested only