### PR TITLE
Adding definitions for Ipmi Net Sensor Get/Set Thresholds commands 

### DIFF
--- a/MdePkg/Include/IndustryStandard/IpmiNetFnSensorEvent.h
+++ b/MdePkg/Include/IndustryStandard/IpmiNetFnSensorEvent.h
@@ -10,6 +10,7 @@
   and Appendix H, Sub-function Assignments.
 
   Copyright (c) 1999 - 2015, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) Microsoft Corporation.
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
@@ -41,6 +42,51 @@ typedef struct {
   UINT8    OEMEvData2;
   UINT8    OEMEvData3;
 } IPMI_PLATFORM_EVENT_MESSAGE_DATA_REQUEST;
+
+//
+// Definitions for Set Sensor Thresholds command
+//
+#define IPMI_SENSOR_SET_SENSOR_THRESHOLDS  0x26
+
+typedef union {
+  struct _SENSOR_BITS {
+    UINT8    LowerNonCriticalThreshold    : 1;
+    UINT8    LowerCriticalThreshold       : 1;
+    UINT8    LowerNonRecoverableThreshold : 1;
+    UINT8    UpperNonCriticalThreshold    : 1;
+    UINT8    UpperCriticalThreshold       : 1;
+    UINT8    UpperNonRecoverableThreshold : 1;
+    UINT8    Reserved                     : 2;
+  } Bits;
+  UINT8    Uint8;
+} SENSOR_BITS;
+
+typedef struct _IPMI_SENSOR_SET_SENSOR_THRESHOLD_REQUEST_DATA {
+  UINT8          SensorNumber;
+  SENSOR_BITS    SetBitEnable;
+  UINT8          LowerNonCriticalThreshold;
+  UINT8          LowerCriticalThreshold;
+  UINT8          LowerNonRecoverableThreshold;
+  UINT8          UpperNonCriticalThreshold;
+  UINT8          UpperCriticalThreshold;
+  UINT8          UpperNonRecoverableThreshold;
+} IPMI_SENSOR_SET_SENSOR_THRESHOLD_REQUEST_DATA;
+
+//
+// Definitions for Get Sensor Thresholds command
+//
+#define IPMI_SENSOR_GET_SENSOR_THRESHOLDS  0x27
+
+typedef struct _IPMI_SENSOR_GET_SENSOR_THRESHOLD_RESPONSE_DATA {
+  UINT8          CompletionCode;
+  SENSOR_BITS    GetBitEnable;
+  UINT8          LowerNonCriticalThreshold;
+  UINT8          LowerCriticalThreshold;
+  UINT8          LowerNonRecoverableThreshold;
+  UINT8          UpperNonCriticalThreshold;
+  UINT8          UpperCriticalThreshold;
+  UINT8          UpperNonRecoverableThreshold;
+} IPMI_SENSOR_GET_SENSOR_THRESHOLD_RESPONSE_DATA;
 
 #pragma pack()
 #endif


### PR DESCRIPTION
# Description

Adding Ipmi command and structure definitions for optional `Get Sensor Threshold` and `Set Sensor Threshold` commands. 

- [ ] Breaking change?
  - **Breaking change** - Will this cause a break in build or boot behavior?
  - Examples: Add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Local CI Run.
Verified on platform that defines allowed communication with BMC.

## Integration Instructions

N/A
