### PR TITLE
MdeModulePkg: Ensure DTR and RTS are set on Terminal ConIn Reset

### DIFF
--- a/MdeModulePkg/Universal/Console/TerminalDxe/TerminalConIn.c
+++ b/MdeModulePkg/Universal/Console/TerminalDxe/TerminalConIn.c
@@ -95,6 +95,14 @@ TerminalConInReset (
       );
   }
 
+  //
+  // After resetting the console, ensure device is ready to recieve data
+  // by setting data terminal ready and request to send
+  //
+  if (!EFI_ERROR (Status)) {
+    Status = TerminalDevice->SerialIo->SetControl (TerminalDevice->SerialIo, EFI_SERIAL_DATA_TERMINAL_READY|EFI_SERIAL_REQUEST_TO_SEND);
+  }
+
   return Status;
 }
 


### PR DESCRIPTION

# Description

When Terminal starts to manage a serial deivce, it needs to ensure the underlying serial port is configured to recieve data. The serial device being managed requires Data Terminal Ready and Request to Send to be configured so attached devices can start to send data.

Adding a call to SetControl to configure these signals.

- [ ] Breaking change?
  - **Breaking change** - Will this cause a break in build or boot behavior?
  - Examples: Add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested
On a platform where DTR/RTS were not configured by hardware, verified without change the terminal would not receive keystrokes, and with change, keystrokes were read correctly.

## Integration Instructions
N/A