### PR TITLE
MdeModulePkg: Warn if out of flash space when writing variables

### DIFF
--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/Variable.c
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/Variable.c
@@ -2364,6 +2364,8 @@ Done:
                   );
       ASSERT_EFI_ERROR (Status);
     }
+  } else if (Status == EFI_OUT_OF_RESOURCES) {
+    DEBUG ((DEBUG_WARN, "UpdateVariable failed: Out of flash space\n"));
   }
 
   return Status;


### PR DESCRIPTION
# Description

Emit a DEBUG_WARN message if there is not enough flash space left to write/update a variable. This condition is currently not logged appropriately in all cases, given that full variable store can easily render the system unbootable.
This new message helps identifying this condition.

Reviewed-by: Laszlo Ersek <lersek@redhat.com>
Reviewed-by: Gerd Hoffmann <kraxel@redhat.com>


- [ ] Breaking change?
  - **Breaking change** - Will this cause a break in build or boot behavior?
  - Examples: Add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Built OvmfX64 and ran in Qemu with a full varstore.

## Integration Instructions

N/A
