### PR TITLE
CryptoPkg: Fix wrong logic in X509GetTBSCert

### DIFF
--- a/CryptoPkg/Library/BaseCryptLib/Pk/CryptX509.c
+++ b/CryptoPkg/Library/BaseCryptLib/Pk/CryptX509.c
@@ -839,7 +839,7 @@ X509GetTBSCert (
   Length = 0;
   Inf    = ASN1_get_object (&Temp, (long *)&Length, (int *)&Asn1Tag, (int *)&ObjClass, (long)CertSize);
 
-  if (((Inf & 0x80) == 0x80) && (Asn1Tag != V_ASN1_SEQUENCE)) {
+  if (((Inf & 0x80) == 0x80) || (Asn1Tag != V_ASN1_SEQUENCE)) {
     return FALSE;
   }
 
@@ -849,7 +849,7 @@ X509GetTBSCert (
   //
   // Verify the parsed TBSCertificate is one correct SEQUENCE data.
   //
-  if (((Inf & 0x80) == 0x80) && (Asn1Tag != V_ASN1_SEQUENCE)) {
+  if (((Inf & 0x80) == 0x80) || (Asn1Tag != V_ASN1_SEQUENCE)) {
     return FALSE;
   }
 


### PR DESCRIPTION
# Description

REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4509

Both return 0x80 value and Asn1Tag != V_ASN1_SEQUENCE are wrong return.

- [ ] Breaking change?
  - **Breaking change** - Will this cause a break in build or boot behavior?
  - Examples: Add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

<_Describe the test(s) that were run to verify the changes._>

## Integration Instructions

N/A
