### PR TITLE
MdeModulePkg: Add Segment info promt for PCIe enumeration.

### DIFF
--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciEnumeratorSupport.c
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciEnumeratorSupport.c
@@ -222,16 +222,21 @@ PciSearchDevice (
 {
   PCI_IO_DEVICE  *PciIoDevice;
   BOOLEAN        IgnoreOptionRom;
+  UINT32         Seg = 0;
+  EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL              *PciRootBridgeIo;
 
   PciIoDevice     = NULL;
   IgnoreOptionRom = FALSE;
+  PciRootBridgeIo = Bridge->PciRootBridgeIo;
+  Seg = PciRootBridgeIo->SegmentNumber;
 
   DEBUG ((
     DEBUG_INFO,
-    "PciBus: Discovered %s @ [%02x|%02x|%02x]  [VID = 0x%x, DID = 0x%0x]\n",
+    "PciBus: Discovered %s @ [%04x|%02x|%02x|%02x]  [VID = 0x%x, DID = 0x%0x]\n",
     IS_PCI_BRIDGE (Pci) ?     L"PPB" :
     IS_CARDBUS_BRIDGE (Pci) ? L"P2C" :
     L"PCI",
+    Seg,
     Bus,
     Device,
     Func,


### PR DESCRIPTION
Ref:https://bugzilla.tianocore.org/show_bug.cgi?id=4000

For platforms supporting multi-segments, the edk2 would only print 
Bus,Dev,Func info but ignore the segments info which would cause duplicate
device scanning info.

Signed-off-by: Darren Dong <darren.dong@intel.com>

# Description

<_Include a description of the change and why this change was made._>

<_For each item, place an "x" in between `[` and `]` if true. Example: `[x]` (you can also check items in GitHub UI)_>

<_Create the PR as a Draft PR if it is only created to run CI checks._>

<_Delete lines in \<\> tags before creating the PR._>

- [ ] Breaking change?
  - **Breaking change** - Will this cause a break in build or boot behavior?
  - Examples: Add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

<_Describe the test(s) that were run to verify the changes._>

## Integration Instructions

<_Describe how these changes should be integrated. Use N/A if nothing is required._>
