### PR TITLE
CI: Use Fedora 40 image for Linux jobs

### DIFF
--- a/.azurepipelines/templates/defaults.yml
+++ b/.azurepipelines/templates/defaults.yml
@@ -9,4 +9,4 @@
 
 variables:
   default_python_version: "3.12"
-  default_linux_image: "ghcr.io/tianocore/containers/fedora-37-test:a0dd931"
+  default_linux_image: "ghcr.io/tianocore/containers/fedora-40-test:61a5955"


### PR DESCRIPTION
# Description
Fedora 37 is EOL. Use the new Fedora 40 container image, featuring GCC 14, for Linux jobs in the CI.

- [ ] Breaking change?
  - **Breaking change** - Will this cause a break in build or boot behavior?
  - Examples: Add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

N/A

## Integration Instructions
N/A
