### PR TITLE
BaseTools/Scripts: Fix PatchCheck commit range

### DIFF
--- a/BaseTools/Scripts/PatchCheck.py
+++ b/BaseTools/Scripts/PatchCheck.py
@@ -684,8 +684,6 @@ class CheckGitCommits:
     def __init__(self, rev_spec, max_count):
         dec_files = self.read_dec_files_from_git()
         commits = self.read_commit_list_from_git(rev_spec, max_count)
-        if len(commits) == 1 and Verbose.level > Verbose.ONELINE:
-            commits = [ rev_spec ]
         self.ok = True
         blank_line = False
         for commit in commits:


### PR DESCRIPTION
# Description

There are a few PRs that are failing PatchCheck with an error condition of more than one package
modified by a commit, but there are no commits that have files modified in more than one package.

The root cause is a logic error that incorrectly changes the range of commits based on a verbosity level
and discards the list of commit shas collected from the range specified on the command line.

- [ ] Breaking change?
  - **Breaking change** - Will this cause a break in build or boot behavior?
  - Examples: Add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

* Tested branch from failing PR locally and reproduced the incorrect error condition.
* The logic bug was fixed and verified that local runs do not generate the error condition.
* Submitted Draft PR and verified that patch check passed.

## Integration Instructions

N/A
