### PR TITLE
MdePkg/Include: PciExpress60: Initial commit

### DIFF
--- a/MdePkg/Include/IndustryStandard/Pci.h
+++ b/MdePkg/Include/IndustryStandard/Pci.h
@@ -9,7 +9,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #ifndef _PCI_H_
 #define _PCI_H_
 
-#include <IndustryStandard/PciExpress50.h>
+#include <IndustryStandard/PciExpress60.h>
 #include <IndustryStandard/PciCodeId.h>
 
 #endif

--- a/MdePkg/Include/IndustryStandard/PciExpress60.h
+++ b/MdePkg/Include/IndustryStandard/PciExpress60.h
@@ -1,0 +1,17 @@
+/** @file
+Support for the PCI Express 6.0 standard.
+
+This header file may not define all structures.  Please extend as required.
+
+Copyright (C) 2024, Western Digital Corporation or its affiliates.
+SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef PCIEXPRESS60_H_
+#define PCIEXPRESS60_H_
+
+#include <IndustryStandard/PciExpress50.h>
+
+#define EFI_PCIE_CAPABILITY_ID_DOE  0x2E
+
+#endif


### PR DESCRIPTION
# Description

Initial commit of the PCIe 6.0 specification header file. This is used to define the EFI_PCIE_CAPABILITY_ID_DOE macro.

- [ ] Breaking change?
  - **Breaking change** - Will this cause a break in build or boot behavior?
  - Examples: Add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

As part of the DOE PR: https://github.com/tianocore/edk2/pull/5715

## Integration Instructions

N/A
