### PR TITLE
Pr armvirt avoid dynamic pcds for smcccc conduit

### DIFF
--- a/ArmPkg/ArmPkg.dec
+++ b/ArmPkg/ArmPkg.dec
@@ -139,6 +139,11 @@
   # Define if the GICv3 controller should use the GICv2 legacy
   gArmTokenSpaceGuid.PcdArmGicV3WithV2Legacy|FALSE|BOOLEAN|0x00000042
 
+  ## Define the conduit to use for monitor calls.
+  # Default PcdMonitorConduitHvc = FALSE, conduit = SMC
+  # If PcdMonitorConduitHvc = TRUE, conduit = HVC
+  gArmTokenSpaceGuid.PcdMonitorConduitHvc|FALSE|BOOLEAN|0x00000047
+
   # Whether to remap all unused memory NX before installing the CPU arch
   # protocol driver. This is needed on platforms that map all DRAM with RWX
   # attributes initially, and can be disabled otherwise.
@@ -311,11 +316,6 @@
 
   gArmTokenSpaceGuid.PcdSystemBiosRelease|0xFFFF|UINT16|0x30000058
   gArmTokenSpaceGuid.PcdEmbeddedControllerFirmwareRelease|0xFFFF|UINT16|0x30000059
-
-  ## Define the conduit to use for monitor calls.
-  # Default PcdMonitorConduitHvc = FALSE, conduit = SMC
-  # If PcdMonitorConduitHvc = TRUE, conduit = HVC
-  gArmTokenSpaceGuid.PcdMonitorConduitHvc|FALSE|BOOLEAN|0x00000047
 
 [PcdsFixedAtBuild.common, PcdsDynamic.common]
   #

--- a/ArmPkg/Library/ArmMonitorLib/ArmMonitorLib.c
+++ b/ArmPkg/Library/ArmMonitorLib/ArmMonitorLib.c
@@ -26,7 +26,7 @@ ArmMonitorCall (
   IN OUT ARM_MONITOR_ARGS  *Args
   )
 {
-  if (PcdGetBool (PcdMonitorConduitHvc)) {
+  if (FeaturePcdGet  (PcdMonitorConduitHvc)) {
     ArmCallHvc ((ARM_HVC_ARGS *)Args);
   } else {
     ArmCallSmc ((ARM_SMC_ARGS *)Args);

--- a/ArmVirtPkg/ArmVirt.dsc.inc
+++ b/ArmVirtPkg/ArmVirt.dsc.inc
@@ -289,6 +289,8 @@
 
   gEmbeddedTokenSpaceGuid.PcdPrePiProduceMemoryTypeInformationHob|TRUE
 
+  gArmTokenSpaceGuid.PcdMonitorConduitHvc|TRUE
+
 [PcdsFeatureFlag.AARCH64]
   #
   # Activate AcpiSdtProtocol

--- a/ArmVirtPkg/ArmVirtCloudHv.dsc
+++ b/ArmVirtPkg/ArmVirtCloudHv.dsc
@@ -201,9 +201,6 @@
 [PcdsDynamicHii]
   gUefiOvmfPkgTokenSpaceGuid.PcdForceNoAcpi|L"ForceNoAcpi"|gOvmfVariableGuid|0x0|FALSE|NV,BS
 
-[PcdsPatchableInModule.common]
-  gArmTokenSpaceGuid.PcdMonitorConduitHvc|TRUE
-
 ################################################################################
 #
 # Components Section - list of all EDK II Modules needed by this Platform

--- a/ArmVirtPkg/ArmVirtKvmTool.dsc
+++ b/ArmVirtPkg/ArmVirtKvmTool.dsc
@@ -165,8 +165,6 @@
   #
   gEmbeddedTokenSpaceGuid.PcdPrePiCpuIoSize|16
 
-  gArmTokenSpaceGuid.PcdMonitorConduitHvc|TRUE
-
 [PcdsPatchableInModule.common]
   #
   # This will be overridden in the code

--- a/ArmVirtPkg/ArmVirtQemu.dsc
+++ b/ArmVirtPkg/ArmVirtQemu.dsc
@@ -309,10 +309,6 @@
   gEfiNetworkPkgTokenSpaceGuid.PcdIPv4PXESupport|0x01
   gEfiNetworkPkgTokenSpaceGuid.PcdIPv6PXESupport|0x01
 
-  # whether to use HVC or SMC to issue monitor calls - this typically depends
-  # on the exception level at which the UEFI system firmware executes
-  gArmTokenSpaceGuid.PcdMonitorConduitHvc|TRUE
-
   #
   # TPM2 support
   #

--- a/ArmVirtPkg/ArmVirtQemu.dsc
+++ b/ArmVirtPkg/ArmVirtQemu.dsc
@@ -92,6 +92,8 @@
   TpmPlatformHierarchyLib|SecurityPkg/Library/PeiDxeTpmPlatformHierarchyLibNull/PeiDxeTpmPlatformHierarchyLib.inf
 !endif
 
+  ArmMonitorLib|ArmVirtPkg/Library/ArmVirtQemuMonitorLib/ArmVirtQemuMonitorLib.inf
+
 [LibraryClasses.AARCH64]
   ArmPlatformLib|ArmVirtPkg/Library/ArmPlatformLibQemu/ArmPlatformLibQemu.inf
 

--- a/ArmVirtPkg/ArmVirtQemu.dsc
+++ b/ArmVirtPkg/ArmVirtQemu.dsc
@@ -334,7 +334,11 @@
   gEfiMdePkgTokenSpaceGuid.PcdPlatformBootTimeOut|L"Timeout"|gEfiGlobalVariableGuid|0x0|5
 
 [LibraryClasses.common.PEI_CORE, LibraryClasses.common.PEIM]
+!if $(TPM2_ENABLE) == TRUE
   PcdLib|MdePkg/Library/PeiPcdLib/PeiPcdLib.inf
+!else
+  PcdLib|MdePkg/Library/BasePcdLibNull/BasePcdLibNull.inf
+!endif
 
 ################################################################################
 #
@@ -351,11 +355,11 @@
   ArmVirtPkg/MemoryInitPei/MemoryInitPeim.inf
   ArmPkg/Drivers/CpuPei/CpuPei.inf
 
+!if $(TPM2_ENABLE) == TRUE
   MdeModulePkg/Universal/PCD/Pei/Pcd.inf {
     <LibraryClasses>
       PcdLib|MdePkg/Library/BasePcdLibNull/BasePcdLibNull.inf
   }
-!if $(TPM2_ENABLE) == TRUE
   MdeModulePkg/Universal/ResetSystemPei/ResetSystemPei.inf {
     <LibraryClasses>
       ResetSystemLib|ArmVirtPkg/Library/ArmVirtPsciResetSystemPeiLib/ArmVirtPsciResetSystemPeiLib.inf

--- a/ArmVirtPkg/ArmVirtQemu.fdf
+++ b/ArmVirtPkg/ArmVirtQemu.fdf
@@ -111,8 +111,8 @@ READ_LOCK_STATUS   = TRUE
   INF ArmPkg/Drivers/CpuPei/CpuPei.inf
   INF MdeModulePkg/Core/DxeIplPeim/DxeIpl.inf
 
-  INF MdeModulePkg/Universal/PCD/Pei/Pcd.inf
 !if $(TPM2_ENABLE) == TRUE
+  INF MdeModulePkg/Universal/PCD/Pei/Pcd.inf
   INF MdeModulePkg/Universal/ResetSystemPei/ResetSystemPei.inf
   INF OvmfPkg/Tcg/Tcg2Config/Tcg2ConfigPei.inf
   INF SecurityPkg/Tcg/Tcg2Pei/Tcg2Pei.inf

--- a/ArmVirtPkg/ArmVirtQemuKernel.dsc
+++ b/ArmVirtPkg/ArmVirtQemuKernel.dsc
@@ -211,8 +211,6 @@
   gArmTokenSpaceGuid.PcdFdBaseAddress|0x0
   gArmTokenSpaceGuid.PcdFvBaseAddress|0x0
 
-  gArmTokenSpaceGuid.PcdMonitorConduitHvc|TRUE
-
 [PcdsDynamicDefault.common]
   gEfiMdePkgTokenSpaceGuid.PcdPlatformBootTimeOut|3
 

--- a/ArmVirtPkg/ArmVirtQemuKernel.dsc
+++ b/ArmVirtPkg/ArmVirtQemuKernel.dsc
@@ -82,6 +82,8 @@
   TpmMeasurementLib|MdeModulePkg/Library/TpmMeasurementLibNull/TpmMeasurementLibNull.inf
   TpmPlatformHierarchyLib|SecurityPkg/Library/PeiDxeTpmPlatformHierarchyLibNull/PeiDxeTpmPlatformHierarchyLib.inf
 
+  ArmMonitorLib|ArmVirtPkg/Library/ArmVirtQemuMonitorLib/ArmVirtQemuMonitorLib.inf
+
 [LibraryClasses.common.DXE_DRIVER]
   AcpiPlatformLib|OvmfPkg/Library/AcpiPlatformLib/DxeAcpiPlatformLib.inf
   ReportStatusCodeLib|MdeModulePkg/Library/DxeReportStatusCodeLib/DxeReportStatusCodeLib.inf

--- a/ArmVirtPkg/ArmVirtXen.dsc
+++ b/ArmVirtPkg/ArmVirtXen.dsc
@@ -120,8 +120,6 @@
   gArmTokenSpaceGuid.PcdFdBaseAddress|0x0
   gArmTokenSpaceGuid.PcdFvBaseAddress|0x0
 
-  gArmTokenSpaceGuid.PcdMonitorConduitHvc|TRUE
-
 [PcdsDynamicDefault.common]
 
   gArmTokenSpaceGuid.PcdArmArchTimerSecIntrNum|0x0

--- a/ArmVirtPkg/Library/ArmVirtQemuMonitorLib/ArmVirtQemuMonitorLib.c
+++ b/ArmVirtPkg/Library/ArmVirtQemuMonitorLib/ArmVirtQemuMonitorLib.c
@@ -1,0 +1,95 @@
+/** @file
+  Arm Monitor Library that chooses the conduit based on the PSCI node in the
+  device tree provided by QEMU
+
+  Copyright (c) 2022, Arm Limited. All rights reserved.<BR>
+  Copyright (c) 2024, Google LLC. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <PiDxe.h>
+
+#include <Library/BaseLib.h>
+#include <Library/DebugLib.h>
+#include <Library/ArmHvcLib.h>
+#include <Library/ArmMonitorLib.h>
+#include <Library/ArmSmcLib.h>
+#include <Library/UefiBootServicesTableLib.h>
+
+#include <Protocol/FdtClient.h>
+
+STATIC UINT32  mArmSmcccMethod;
+
+/** Library constructor.
+
+  Assign the global variable mArmSmcccMethod based on the PSCI node in the
+  device tree.
+**/
+RETURN_STATUS
+EFIAPI
+ArmVirtQemuMonitorLibConstructor (
+  VOID
+  )
+{
+  EFI_STATUS           Status;
+  FDT_CLIENT_PROTOCOL  *FdtClient;
+  CONST VOID           *Prop;
+
+  Status = gBS->LocateProtocol (
+                  &gFdtClientProtocolGuid,
+                  NULL,
+                  (VOID **)&FdtClient
+                  );
+  ASSERT_EFI_ERROR (Status);
+
+  Status = FdtClient->FindCompatibleNodeProperty (
+                        FdtClient,
+                        "arm,psci-0.2",
+                        "method",
+                        &Prop,
+                        NULL
+                        );
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  if (AsciiStrnCmp (Prop, "hvc", 3) == 0) {
+    mArmSmcccMethod = 1;
+  } else if (AsciiStrnCmp (Prop, "smc", 3) == 0) {
+    mArmSmcccMethod = 2;
+  } else {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: Unknown SMCCC method \"%a\"\n",
+      __func__,
+      Prop
+      ));
+    return EFI_NOT_FOUND;
+  }
+
+  return EFI_SUCCESS;
+}
+
+/** Monitor call.
+
+  An HyperVisor Call (HVC) or System Monitor Call (SMC) will be issued
+  depending on the default conduit.
+
+  @param [in,out]  Args    Arguments for the HVC/SMC.
+**/
+VOID
+EFIAPI
+ArmMonitorCall (
+  IN OUT ARM_MONITOR_ARGS  *Args
+  )
+{
+  if (mArmSmcccMethod == 1) {
+    ArmCallHvc ((ARM_HVC_ARGS *)Args);
+  } else if (mArmSmcccMethod == 2) {
+    ArmCallSmc ((ARM_SMC_ARGS *)Args);
+  } else {
+    ASSERT ((mArmSmcccMethod == 1) || (mArmSmcccMethod == 2));
+  }
+}

--- a/ArmVirtPkg/Library/ArmVirtQemuMonitorLib/ArmVirtQemuMonitorLib.inf
+++ b/ArmVirtPkg/Library/ArmVirtQemuMonitorLib/ArmVirtQemuMonitorLib.inf
@@ -1,0 +1,39 @@
+## @file
+#  Arm Monitor Library that chooses the conduit based on the PSCI node in the
+#  device tree provided by QEMU
+#
+#  Copyright (c) 2022, Arm Limited. All rights reserved.<BR>
+#  Copyright (c) 2024, Google LLC. All rights reserved.<BR>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION                    = 1.29
+  BASE_NAME                      = ArmVirtQemuMonitorLib
+  FILE_GUID                      = 09f50ee5-2aa2-42b9-a2a0-090faeefed2b
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = ArmMonitorLib|DXE_DRIVER DXE_RUNTIME_DRIVER
+  CONSTRUCTOR                    = ArmVirtQemuMonitorLibConstructor
+
+[Sources]
+  ArmVirtQemuMonitorLib.c
+
+[Packages]
+  ArmPkg/ArmPkg.dec
+  EmbeddedPkg/EmbeddedPkg.dec
+  MdePkg/MdePkg.dec
+
+[LibraryClasses]
+  ArmHvcLib
+  ArmSmcLib
+  BaseLib
+  DebugLib
+  UefiBootServicesTableLib
+
+[Protocols]
+  gFdtClientProtocolGuid                                ## CONSUMES
+
+[Depex]
+  gFdtClientProtocolGuid

--- a/ArmVirtPkg/Library/PlatformPeiLib/PlatformPeiLib.c
+++ b/ArmVirtPkg/Library/PlatformPeiLib/PlatformPeiLib.c
@@ -18,8 +18,6 @@
 #include <Library/FdtSerialPortAddressLib.h>
 #include <libfdt.h>
 
-#include <Chipset/AArch64.h>
-
 #include <Guid/EarlyPL011BaseAddress.h>
 #include <Guid/FdtHob.h>
 

--- a/ArmVirtPkg/Library/PlatformPeiLib/PlatformPeiLib.c
+++ b/ArmVirtPkg/Library/PlatformPeiLib/PlatformPeiLib.c
@@ -226,17 +226,5 @@ PlatformPeim (
 
   BuildFvHob (PcdGet64 (PcdFvBaseAddress), PcdGet32 (PcdFvSize));
 
- #ifdef MDE_CPU_AARCH64
-  //
-  // Set the SMCCC conduit to SMC if executing at EL2, which is typically the
-  // exception level that services HVCs rather than the one that invokes them.
-  //
-  if (ArmReadCurrentEL () == AARCH64_EL2) {
-    Status = PcdSetBoolS (PcdMonitorConduitHvc, FALSE);
-    ASSERT_EFI_ERROR (Status);
-  }
-
- #endif
-
   return EFI_SUCCESS;
 }

--- a/ArmVirtPkg/Library/PlatformPeiLib/PlatformPeiLib.inf
+++ b/ArmVirtPkg/Library/PlatformPeiLib/PlatformPeiLib.inf
@@ -45,7 +45,6 @@
 
 [Pcd]
   gArmTokenSpaceGuid.PcdFvBaseAddress
-  gArmTokenSpaceGuid.PcdMonitorConduitHvc
   gEfiSecurityPkgTokenSpaceGuid.PcdTpmBaseAddress             ## SOMETIMES_PRODUCES
   gUefiOvmfPkgTokenSpaceGuid.PcdDeviceTreeInitialBaseAddress
 

--- a/ArmVirtPkg/PrePi/AArch64/ArchPrePi.c
+++ b/ArmVirtPkg/PrePi/AArch64/ArchPrePi.c
@@ -15,11 +15,6 @@ ArchInitialize (
   VOID
   )
 {
-  // Enable Floating Point
-  if (FixedPcdGet32 (PcdVFPEnabled)) {
-    ArmEnableVFP ();
-  }
-
   if (ArmReadCurrentEL () == AARCH64_EL2) {
     // Trap General Exceptions. All exceptions that would be routed to EL1 are routed to EL2
     ArmWriteHcr (ARM_HCR_TGE);

--- a/ArmVirtPkg/PrePi/AArch64/ModuleEntryPoint.S
+++ b/ArmVirtPkg/PrePi/AArch64/ModuleEntryPoint.S
@@ -9,6 +9,23 @@
 #include <AsmMacroIoLibV8.h>
 
 ASM_FUNC(_ModuleEntryPoint)
+  //
+  // If we are booting from RAM using the Linux kernel boot protocol, x0 will
+  // point to the DTB image in memory. Otherwise, use the default value defined
+  // by the platform.
+  //
+  cbnz  x0, 0f
+  ldr   x0, PcdGet64 (PcdDeviceTreeInitialBaseAddress)
+
+0:mov   x28, x0             // preserve DTB pointer
+  mov   x27, x1             // preserve base of image pointer
+
+#if (FixedPcdGet32 (PcdVFPEnabled))
+  // Enable Floating Point. This needs to be done before entering C code, which
+  // may use FP/SIMD registers.
+  bl    ArmEnableVFP
+#endif
+
   bl    ASM_PFX(DiscoverDramFromDt)
 
   // Get ID of this CPU in Multicore system
@@ -95,28 +112,18 @@ _NeverReturn:
 
 // VOID
 // DiscoverDramFromDt (
-//   VOID   *DeviceTreeBaseAddress,   // passed by loader in x0
-//   VOID   *ImageBase                // passed by FDF trampoline in x1
+//   VOID   *DeviceTreeBaseAddress,   // passed by loader in x0, preserved in x28
+//   VOID   *ImageBase                // passed by FDF trampoline in x1, preserved in x27
 //   );
 ASM_PFX(DiscoverDramFromDt):
-  //
-  // If we are booting from RAM using the Linux kernel boot protocol, x0 will
-  // point to the DTB image in memory. Otherwise, use the default value defined
-  // by the platform.
-  //
-  cbnz  x0, 0f
-  ldr   x0, PcdGet64 (PcdDeviceTreeInitialBaseAddress)
-
-0:mov   x29, x30            // preserve LR
-  mov   x28, x0             // preserve DTB pointer
-  mov   x27, x1             // preserve base of image pointer
+  mov   x29, x30            // preserve LR
 
   //
-  // The base of the runtime image has been preserved in x1. Check whether
+  // The base of the runtime image has been preserved in x27. Check whether
   // the expected magic number can be found in the header.
   //
   ldr   w8, .LArm64LinuxMagic
-  ldr   w9, [x1, #0x38]
+  ldr   w9, [x27, #0x38]
   cmp   w8, w9
   bne   .Lout
 
@@ -132,8 +139,8 @@ ASM_PFX(DiscoverDramFromDt):
   ldr   x6, [x8]
   ldr   x7, [x9]
   sub   x7, x7, x6
-  add   x7, x7, x1
-  str   x1, [x8]
+  add   x7, x7, x27
+  str   x27, [x8]
   str   x7, [x9]
 
   //


### PR DESCRIPTION
The recent last-minute changes to the ArmMonitorLib to accommodate the NetworkPkg CVE fixes resulted in some breakage for PrePi based virtual ARM platforms, as they cannot support dynamic PCDs yet at the point where the SMCCC conduit is discovered.

Since discovering the SMCCC conduit is rarely necessary in practice, let's rip this out again, and instead, provide a special version of ArmMonitorLib for ArmVirtQemu that discovers the SMCCC conduit from the PSCI device tree node.

The first patch is an unrelated fix but required to test and run this code with the CLANGDWARF toolchain