### PR TITLE
MdeModulePkg: Avoid efi memory allocation for SP type

### DIFF
--- a/MdeModulePkg/Core/Dxe/Mem/Page.c
+++ b/MdeModulePkg/Core/Dxe/Mem/Page.c
@@ -1183,6 +1183,13 @@ CoreFindFreePagesI (
       continue;
     }
 
+    //
+    // Don't allocate out of Special-Purpose memory.
+    //
+    if ((Entry->Attribute & EFI_MEMORY_SP) != 0) {
+      continue;
+    }
+
     DescStart = Entry->Start;
     DescEnd   = Entry->End;
 


### PR DESCRIPTION
Most of the times it is desirable not to use special purpose memory for regular edk2 usages. That memory (HBm/CXL) are either meant for special purposes or are less reliable to be used. So avoid using them as long as possible. We could also introduce PCD for this control.

Cc: Liming Gao <gaoliming@byosoft.com.cn>

# Description

Most of the times it is desirable not to use special purpose memory for regular edk2 usages. That memory (HBm/CXL) are either meant for special purposes or are less reliable to be used. So avoid using them as long as possible. We could also introduce PCD for this control.

Test: Tested working on a RISCV system where edk2 excludes this range from allocation
