### PR TITLE
MdePkg/BaseLib: Let CpuDeadLoop() be breakable in debugger

### DIFF
--- a/MdePkg/Library/BaseLib/CpuDeadLoop.c
+++ b/MdePkg/Library/BaseLib/CpuDeadLoop.c
@@ -1,13 +1,15 @@
 /** @file
   Base Library CPU Functions for all architectures.
 
-  Copyright (c) 2006 - 2008, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2006 - 2024, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
 
 #include <Base.h>
 #include <Library/BaseLib.h>
+
+static volatile UINTN  mDeadLoopComparator = 0;
 
 /**
   Executes an infinite loop.
@@ -26,7 +28,7 @@ CpuDeadLoop (
 {
   volatile UINTN  Index;
 
-  for (Index = 0; Index == 0;) {
+  for (Index = mDeadLoopComparator; Index == mDeadLoopComparator;) {
     CpuPause ();
   }
 }


### PR DESCRIPTION
Starting from certain version of Visual Studio  C compiler (I don’t have the exact version. I am using VS2019), CpuDeadLoop is optimized quite well by compiler.
The compiler does not generate instructions that jump out of the loop when the "Index" is non-zero.
It becomes harder/impossible for developers to break out of the dead-loop in debugger.

The new version of CpuDeadLoop() compares a volatile global to a volatile local. This forces 2 reads and a comparison on every loop iteration. The local variable can be set to 1 to exit the loop without modifying the global variable.
Using VS2019 with max opt enabled, The dead-loop can be exit by setting Index to 1 in a debugger.