### PR TITLE
RedfishPkg/libredfish: check createServiceEnumerator*Auth return pointer before use

### DIFF
--- a/RedfishPkg/PrivateLibrary/RedfishLib/edk2libredfish/src/service.c
+++ b/RedfishPkg/PrivateLibrary/RedfishLib/edk2libredfish/src/service.c
@@ -389,7 +389,8 @@ createServiceEnumerator (
     goto ON_EXIT;
   }
 
-  ret->RestEx = RestEx;
+  if(ret)
+    ret->RestEx = RestEx;
 ON_EXIT:
   if (HttpUrl != NULL) {
     FreePool (HttpUrl);


### PR DESCRIPTION
Add pointer check in createServiceEnumerator

# Description

createServiceEnumerator() should check return value of createServiceEnumeratorAuth() before use, since createServiceEnumeratorAuth() return NULL when fail.

