### PR TITLE
Add support for a SVSM vTPM 

### DIFF
--- a/OvmfPkg/Library/AmdSvsmLib/AmdSvsmLib.c
+++ b/OvmfPkg/Library/AmdSvsmLib/AmdSvsmLib.c
@@ -498,3 +498,90 @@ AmdSvsmSnpVmsaRmpAdjust (
   return AmdSvsmIsSvsmPresent () ? SvsmVmsaRmpAdjust (Vmsa, ApicId, SetVmsa)
                                 : BaseVmsaRmpAdjust (Vmsa, SetVmsa);
 }
+
+/**
+  Perform a SVSM_VTPM_QUERY operation
+
+  Query the support provided by the SVSM vTPM.
+
+  @param[out] PlatformCommands    It will contain a bitmap indicating the
+                                  supported vTPM platform commands.
+  @param[out] Features            It will contain a bitmap indicating the
+                                  supported vTPM features.
+
+  @retval TRUE                    The query was processed.
+  @retval FALSE                   The query was not processed.
+
+**/
+BOOLEAN
+EFIAPI
+AmdSvsmVtpmQuery (
+  OUT UINT64 *PlatformCommands,
+  OUT UINT64 *Features
+  )
+{
+  SVSM_CALL_DATA  SvsmCallData;
+  SVSM_FUNCTION   Function;
+
+  if (!PlatformCommands && !Features)
+    return FALSE;
+
+  if (!AmdSvsmIsSvsmPresent ())
+    return FALSE;
+
+  Function.Id.Protocol = 2;
+  Function.Id.CallId = 0;
+
+  SvsmCallData.Caa = (SVSM_CAA *)AmdSvsmSnpGetCaa ();
+  SvsmCallData.RaxIn = Function.Uint64;
+
+  if (SvsmMsrProtocol (&SvsmCallData))
+    return FALSE;
+
+  if (PlatformCommands)
+    *PlatformCommands = SvsmCallData.RcxOut;
+
+  if (Features)
+    *Features = SvsmCallData.RdxOut;
+
+  return TRUE;
+}
+
+/**
+  Perform a SVSM_VTPM_CMD operation
+
+  Send the specified vTPM platform command to the SVSM vTPM.
+
+  @param[in, out] Buffer  It should contain the vTPM platform command
+                          request. The respective response will be returned
+                          in the same Buffer, but not all commands specify a
+                          response.
+
+  @retval TRUE            The command was processed.
+  @retval FALSE           The command was not processed.
+
+**/
+BOOLEAN
+EFIAPI
+AmdSvsmVtpmCmd (
+  IN OUT UINT8  *Buffer
+  )
+{
+  SVSM_CALL_DATA  SvsmCallData;
+  SVSM_FUNCTION   Function;
+  UINTN           Ret;
+
+  if (!AmdSvsmIsSvsmPresent ())
+    return FALSE;
+
+  Function.Id.Protocol = 2;
+  Function.Id.CallId = 1;
+
+  SvsmCallData.Caa = (SVSM_CAA *)AmdSvsmSnpGetCaa ();
+  SvsmCallData.RaxIn = Function.Uint64;
+  SvsmCallData.RcxIn = (UINT64)(UINTN)Buffer;
+
+  Ret = SvsmMsrProtocol (&SvsmCallData);
+
+  return (Ret == 0) ? TRUE : FALSE;
+}

--- a/SecurityPkg/Include/Library/Tpm2DeviceLib.h
+++ b/SecurityPkg/Include/Library/Tpm2DeviceLib.h
@@ -18,6 +18,7 @@ typedef enum {
   Tpm2PtpInterfaceTis,
   Tpm2PtpInterfaceFifo,
   Tpm2PtpInterfaceCrb,
+  Tpm2PtpInterfaceSvsm,
   Tpm2PtpInterfaceMax,
 } TPM2_PTP_INTERFACE_TYPE;
 

--- a/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2DeviceLibDTpm.h
+++ b/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2DeviceLibDTpm.h
@@ -64,4 +64,45 @@ InternalTpm2DeviceLibDTpmCommonConstructor (
   VOID
   );
 
+/**
+  Probe the SVSM vTPM for TPM_SEND_COMMAND support. The
+  TPM_SEND_COMMAND platform command can be used to execute a
+  TPM command and get the result.
+
+  @retval TRUE    TPM_SEND_COMMAND is supported.
+  @retval FALSE   TPM_SEND_COMMAND is not supported.
+
+**/
+BOOLEAN
+Tpm2SvsmQueryTpmSendCmd (
+  VOID
+  );
+
+/**
+  Send a TPM command to the SVSM vTPM and return the TPM response.
+
+  @param[in]      BufferIn      It should contain the marshaled
+                                TPM command.
+  @param[in]      SizeIn        Size of the TPM command.
+  @param[out]     BufferOut     It will contain the marshaled
+                                TPM response.
+  @param[in, out] SizeOut       Size of the BufferOut; it will also
+                                be used to return the size of the
+                                TPM response
+
+  @retval EFI_SUCCESS           Operation completed successfully.
+  @retval EFI_INVALID_PARAMETER Buffer not provided.
+  @retval EFI_BUFFER_TOO_SMALL  Response data buffer is too small.
+  @retval EFI_DEVICE_ERROR      Unexpected device behavior.
+  @retval EFI_UNSUPPORTED       Unsupported TPM version
+
+**/
+EFI_STATUS
+Tpm2SvsmTpmSendCommand (
+  IN     UINT8   *BufferIn,
+  IN     UINT32  SizeIn,
+     OUT UINT8   *BufferOut,
+  IN OUT UINT32  *SizeOut
+  );
+
 #endif // _TPM2_DEVICE_LIB_DTPM_H_

--- a/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2DeviceLibDTpm.inf
+++ b/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2DeviceLibDTpm.inf
@@ -33,6 +33,7 @@
 
 [Sources]
   Tpm2Tis.c
+  Tpm2Svsm.c
   Tpm2Ptp.c
   Tpm2DeviceLibDTpm.c
   Tpm2DeviceLibDTpmBase.c
@@ -41,6 +42,7 @@
 [Packages]
   MdePkg/MdePkg.dec
   SecurityPkg/SecurityPkg.dec
+  UefiCpuPkg/UefiCpuPkg.dec
 
 [LibraryClasses]
   BaseLib
@@ -49,6 +51,7 @@
   TimerLib
   DebugLib
   PcdLib
+  AmdSvsmLib
 
 [Pcd]
   gEfiSecurityPkgTokenSpaceGuid.PcdTpmBaseAddress            ## CONSUMES

--- a/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2DeviceLibDTpmStandaloneMm.inf
+++ b/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2DeviceLibDTpmStandaloneMm.inf
@@ -33,6 +33,7 @@
 
 [Sources]
   Tpm2Tis.c
+  Tpm2Svsm.c
   Tpm2Ptp.c
   Tpm2DeviceLibDTpm.c
   Tpm2DeviceLibDTpmStandaloneMm.c
@@ -41,6 +42,7 @@
 [Packages]
   MdePkg/MdePkg.dec
   SecurityPkg/SecurityPkg.dec
+  UefiCpuPkg/UefiCpuPkg.dec
 
 [LibraryClasses]
   BaseLib
@@ -49,6 +51,7 @@
   TimerLib
   DebugLib
   PcdLib
+  AmdSvsmLib
 
 [Pcd]
   gEfiSecurityPkgTokenSpaceGuid.PcdTpmBaseAddress            ## CONSUMES

--- a/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2InstanceLibDTpm.inf
+++ b/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2InstanceLibDTpm.inf
@@ -29,6 +29,7 @@
 
 [Sources]
   Tpm2Tis.c
+  Tpm2Svsm.c
   Tpm2Ptp.c
   Tpm2InstanceLibDTpm.c
   Tpm2DeviceLibDTpmBase.c
@@ -37,6 +38,7 @@
 [Packages]
   MdePkg/MdePkg.dec
   SecurityPkg/SecurityPkg.dec
+  UefiCpuPkg/UefiCpuPkg.dec
 
 [LibraryClasses]
   BaseLib
@@ -45,6 +47,7 @@
   TimerLib
   DebugLib
   PcdLib
+  AmdSvsmLib
 
 [Pcd]
   gEfiSecurityPkgTokenSpaceGuid.PcdTpmBaseAddress          ## CONSUMES

--- a/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2Ptp.c
+++ b/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2Ptp.c
@@ -443,6 +443,11 @@ Tpm2GetPtpInterface (
     return Tpm2PtpInterfaceMax;
   }
 
+  if (Tpm2SvsmQueryTpmSendCmd ()) {
+    DEBUG((DEBUG_INFO, "Found SVSM vTPM\n"));
+    return Tpm2PtpInterfaceSvsm;
+  }
+
   //
   // Check interface id
   //
@@ -616,6 +621,13 @@ DTpm2SubmitCommand (
                OutputParameterBlock,
                OutputParameterBlockSize
                );
+    case Tpm2PtpInterfaceSvsm:
+      return Tpm2SvsmTpmSendCommand (
+               InputParameterBlock,
+               InputParameterBlockSize,
+               OutputParameterBlock,
+               OutputParameterBlockSize
+               );
     default:
       return EFI_NOT_FOUND;
   }
@@ -643,6 +655,8 @@ DTpm2RequestUseTpm (
     case Tpm2PtpInterfaceFifo:
     case Tpm2PtpInterfaceTis:
       return TisPcRequestUseTpm ((TIS_PC_REGISTERS_PTR)(UINTN)PcdGet64 (PcdTpmBaseAddress));
+    case Tpm2PtpInterfaceSvsm:
+      return EFI_SUCCESS;
     default:
       return EFI_NOT_FOUND;
   }

--- a/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2Svsm.c
+++ b/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2Svsm.c
@@ -1,0 +1,127 @@
+/** @file
+  SVSM TPM communication
+
+Copyright (C) 2024 James.Bottomley@HansenPartnership.com
+Copyright (C) 2024 IBM Corporation
+
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
+#include <Library/Tpm2DeviceLib.h>
+#include <Library/PcdLib.h>
+#include <Library/AmdSvsmLib.h>
+
+#include "Tpm2DeviceLibDTpm.h"
+
+/**
+  Platform commands (MSSIM commands) can be sent through the
+  SVSM_VTPM_CMD operation. Each command can have its own
+  request and response structures.
+**/
+#define TPM_SEND_COMMAND            8
+
+/* Max req/resp buffer size */
+#define TPM_PLATFORM_MAX_BUFFER     4096
+
+STATIC UINT8 Tpm2SvsmBuffer[TPM_PLATFORM_MAX_BUFFER];
+
+#pragma pack(1)
+typedef struct _TPM2_SEND_CMD_REQ {
+  UINT32  Cmd;
+  UINT8   Locality;
+  UINT32  BufSize;
+  UINT8   Buf[];
+} TPM2_SEND_CMD_REQ;
+
+typedef struct _TPM2_SEND_CMD_RESP {
+  INT32  Size;
+  UINT8  Buf[];
+} TPM2_SEND_CMD_RESP;
+#pragma pack()
+
+/**
+  Probe the SVSM vTPM for TPM_SEND_COMMAND support. The
+  TPM_SEND_COMMAND platform command can be used to execute a
+  TPM command and get the result.
+
+  @retval TRUE    TPM_SEND_COMMAND is supported.
+  @retval FALSE   TPM_SEND_COMMAND is not supported.
+
+**/
+BOOLEAN
+Tpm2SvsmQueryTpmSendCmd (
+  VOID
+  )
+{
+  UINT64 PlatformCmdBitmap;
+  UINT64 TpmSendMask;
+
+  PlatformCmdBitmap = 0;
+  TpmSendMask = 1 << TPM_SEND_COMMAND;
+
+  if (!AmdSvsmVtpmQuery (&PlatformCmdBitmap, NULL))
+    return FALSE;
+
+  return ((PlatformCmdBitmap & TpmSendMask) == TpmSendMask);
+}
+
+/**
+  Send a TPM command to the SVSM vTPM and return the TPM response.
+
+  @param[in]      BufferIn      It should contain the marshaled
+                                TPM command.
+  @param[in]      SizeIn        Size of the TPM command.
+  @param[out]     BufferOut     It will contain the marshaled
+                                TPM response.
+  @param[in, out] SizeOut       Size of the BufferOut; it will also
+                                be used to return the size of the
+                                TPM response
+
+  @retval EFI_SUCCESS           Operation completed successfully.
+  @retval EFI_INVALID_PARAMETER Buffer not provided.
+  @retval EFI_BUFFER_TOO_SMALL  Response data buffer is too small.
+  @retval EFI_DEVICE_ERROR      Unexpected device behavior.
+  @retval EFI_UNSUPPORTED       Unsupported TPM version
+
+**/
+EFI_STATUS
+Tpm2SvsmTpmSendCommand (
+  IN     UINT8   *BufferIn,
+  IN     UINT32  SizeIn,
+     OUT UINT8   *BufferOut,
+  IN OUT UINT32  *SizeOut
+  )
+{
+  TPM2_SEND_CMD_REQ  *req  = (TPM2_SEND_CMD_REQ *)Tpm2SvsmBuffer;
+  TPM2_SEND_CMD_RESP *resp = (TPM2_SEND_CMD_RESP *)Tpm2SvsmBuffer;
+
+  if (SizeIn == 0 || !BufferIn || !SizeOut || !BufferOut) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (SizeIn > sizeof (Tpm2SvsmBuffer) - sizeof (*req)) {
+    return EFI_BUFFER_TOO_SMALL;
+  }
+
+  req->Cmd = TPM_SEND_COMMAND;
+  req->Locality = 0;
+  req->BufSize = SizeIn;
+  CopyMem (req->Buf, BufferIn, SizeIn);
+
+  if (!AmdSvsmVtpmCmd (Tpm2SvsmBuffer)) {
+    return EFI_DEVICE_ERROR;
+  }
+
+  if (resp->Size > *SizeOut) {
+    return EFI_BUFFER_TOO_SMALL;
+  }
+
+  CopyMem (BufferOut, resp->Buf, resp->Size);
+  *SizeOut = resp->Size;
+
+  return EFI_SUCCESS;
+}

--- a/UefiCpuPkg/Include/Library/AmdSvsmLib.h
+++ b/UefiCpuPkg/Include/Library/AmdSvsmLib.h
@@ -98,4 +98,45 @@ AmdSvsmSnpVmsaRmpAdjust (
   IN BOOLEAN           SetVmsa
   );
 
+/**
+  Perform a SVSM_VTPM_QUERY operation
+
+  Query the support provided by the SVSM vTPM.
+
+  @param[out] PlatformCommands    It will contain a bitmap indicating the
+                                  supported vTPM platform commands.
+  @param[out] Features            It will contain a bitmap indicating the
+                                  supported vTPM features.
+
+  @retval TRUE                    The query was processed.
+  @retval FALSE                   The query was not processed.
+
+**/
+BOOLEAN
+EFIAPI
+AmdSvsmVtpmQuery (
+  OUT UINT64 *PlatformCommands,
+  OUT UINT64 *Features
+  );
+
+/**
+  Perform a SVSM_VTPM_CMD operation
+
+  Send the specified vTPM platform command to the SVSM vTPM.
+
+  @param[in, out] Buffer  It should contain the vTPM platform command
+                          request. The respective response will be returned
+                          in the same Buffer, but not all commands specify a
+                          response.
+
+  @retval TRUE            The command was processed.
+  @retval FALSE           The command was not processed.
+
+**/
+BOOLEAN
+EFIAPI
+AmdSvsmVtpmCmd (
+  IN OUT UINT8  *Buffer
+  );
+
 #endif

--- a/UefiCpuPkg/Library/AmdSvsmLibNull/AmdSvsmLibNull.c
+++ b/UefiCpuPkg/Library/AmdSvsmLibNull/AmdSvsmLibNull.c
@@ -106,3 +106,50 @@ AmdSvsmSnpVmsaRmpAdjust (
 {
   return EFI_UNSUPPORTED;
 }
+
+/**
+  Perform a SVSM_VTPM_QUERY operation
+
+  Query the support provided by the SVSM vTPM.
+
+  @param[out] PlatformCommands    It will contain a bitmap indicating the
+                                  supported vTPM platform commands.
+  @param[out] Features            It will contain a bitmap indicating the
+                                  supported vTPM features.
+
+  @retval TRUE                    The query was processed.
+  @retval FALSE                   The query was not processed.
+
+**/
+BOOLEAN
+EFIAPI
+AmdSvsmVtpmQuery (
+  OUT UINT64 *PlatformCommands,
+  OUT UINT64 *Features
+  )
+{
+  return FALSE;
+}
+
+/**
+  Perform a SVSM_VTPM_CMD operation
+
+  Send the specified vTPM platform command to the SVSM vTPM.
+
+  @param[in, out] Buffer  It should contain the vTPM platform command
+                          request. The respective response will be returned
+                          in the same Buffer, but not all commands specify a
+                          response.
+
+  @retval TRUE            The command was processed.
+  @retval FALSE           The command was not processed.
+
+**/
+BOOLEAN
+EFIAPI
+AmdSvsmVtpmCmd (
+  IN OUT UINT8  *Buffer
+  )
+{
+  return FALSE;
+}


### PR DESCRIPTION
# Description

This series adds a DTpm driver to communicate with a virtual TPM running in the Secure VM Service Module (SVSM), enabling OVMF to do measured boot in SEV-SNP confidential VMs.

SEV-SNP provides a feature known as VM Privilege Level (VMPL), which allows for services to be run in the guest at different privilege levels. By running at VMPL0 (most priviledged VM level), the SVSM can be used to provide privileged services, e.g. virtual TPM, for the guest rather than trust such services from the hypervisor.

As described in the [SVSM specification](https://www.amd.com/content/dam/amd/en/documents/epyc-technical-docs/specifications/58019.pdf), guest components can call to the SVSM vTPM through the vTPM protocol (protocol-id 2).

The vTPM protocol follows the [Microsoft TPM Simulator interface (MSSIM)](https://github.com/microsoft/ms-tpm-20-ref/blob/main/TPMCmd/Simulator/include/prototypes/Simulator_fp.h) and it supports two services:

- SVSM_VTPM_QUERY (call-id 0): query MSSIM commands and vTPM features supported
- SVSM_VTPM_CMD (call-id 1): send a MSSIM command to be run by the vTPM and get the result 

The SVSM vTPM protocol is also added in this series.


- [ ] Breaking change?
  - **Breaking change** - Will this cause a break in build or boot behavior?
  - Examples: Add a new library class or move a module to a different repo.
- [ x ] Impacts security?
  - **Security** - Does the change have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

This was tested with the latest COCONUT-SVSM upstream code (commit 75b83b3e1a5c860a84ccfe0e4b503e7efee5834f), which provides vTPM service.  The instructions to build and run a guest under a SVSM can be found in the [INSTALL.md](https://github.com/coconut-svsm/svsm/blob/main/Documentation/docs/installation/INSTALL.md). 

The OVMF boot message log below shows that it was able to find the SVSM vTPM and also use it for measured boot.
````
[snip]

Creating MpInformation2 HOB...
Loading PEIM F12F698A-E506-4A1B-B32E-6920E55DA1C4
Loading PEIM at 0x0007FB89000 EntryPoint=0x0007FB8A5E4 TpmMmioSevDecryptPei.efi
TpmMmioSevDecryptPeimEntryPoint
TpmMmioSevDecryptPeimEntryPoint: mapping TPM MMIO address range unencrypted
Install PPI: 35C84FF2-7BFE-453D-845F-683A492CF7B7
Loading PEIM 8AD3148F-945F-46B4-8ACD-71469EA73945
Loading PEIM at 0x0007F7FC000 EntryPoint=0x0007F7FD916 Tcg2ConfigPei.efi
Found SVSM vTPM
Tcg2ConfigPeimEntryPoint
Tcg2ConfigPeimEntryPoint: TPM2 detected
Install PPI: 7F4158D3-074D-456D-8CB2-01F9C8F79DAA
Loading PEIM 2BE1E4A6-6505-43B3-9FFC-A3C8330E0432
Loading PEIM at 0x0007F7F7000 EntryPoint=0x0007F7F9E2F TcgPei.efi
No TPM12 instance required!
Loading PEIM A0C98B77-CBA5-4BB8-993B-4AF6CE33ECE4
Loading PEIM at 0x0007F7E9000 EntryPoint=0x0007F7F1FCC Tcg2Pei.efi

[snip]

EFI stub: Loaded initrd from LINUX_EFI_INITRD_MEDIA_GUID device path
ReadPcr - 09
Supported PCRs - Count = 00000003
GetSupportedAndActivePcrs - Count = 00000003
ReadPcr - HashAlg = 0x0004, Pcr[09], digest = 68 36 46 79 6E 8A 5E 5E 37 34 DB 36 A9 84 85 36 6F C9 BD 07 
ReadPcr - HashAlg = 0x000B, Pcr[09], digest = 12 10 49 80 43 DB 86 46 AD 0F CE 32 76 7B EE 87 5B 20 3B D9 14 93 EA F4 D8 8F E9 39 10 8B CA 3E 
ReadPcr - HashAlg = 0x000C, Pcr[09], digest = E2 54 A7 DD CA BF EA C8 B1 CD A2 12 D7 2A A7 A8 04 BE A9 9D 1F 88 7A D9 40 28 4C 79 C9 DB F8 0C A6 BE AD C0 E9 44 FE AD F7 7F 32 D1 65 80 A3 14 
SupportedEventLogs - 0x00000003
  LogFormat - 0x00000001
  LogFormat - 0x00000002
EFI stub: Measured initrd data into PCR 9
Tcg2GetEventLog ... (0x2)
Tcg2GetEventLog (EventLogLocation - 7E577000)
Tcg2GetEventLog (EventLogLastEntry - 7E577E14)
Tcg2GetEventLog (EventLogTruncated - 0)
Tcg2GetEventLog - Success
EventLogFormat: (0x2)
  Event:
    PCRIndex  - 0
    EventType - 0x00000003
    Digest    - 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
    EventSize - 0x00000029
0000: 53706563204944204576656E7430330000000000000200020300000004001400
0020: 0B0020000C00300000
  TCG_EfiSpecIDEventStruct:
    signature          - 'Spec ID Event03 '
    platformClass      - 0x00000000
    specVersion        - 2.00
    uintnSize          - 0x02
    NumberOfAlgorithms - 0x00000003
    digest(0)
      algorithmId      - 0x0004
      digestSize       - 0x0014
    digest(1)
      algorithmId      - 0x000B
      digestSize       - 0x0020
    digest(2)
      algorithmId      - 0x000C
      digestSize       - 0x0030
    VendorInfoSize     - 0x00
    VendorInfo         - 
  Event:
    PCRIndex  - 0
    EventType - 0x00000008
    DigestCount: 0x00000003
      HashAlgo : 0x0004
      Digest(0): 14 89 F9 23 C4 DC A7 29 17 8B 3E 32 33 45 85 50 D8 DD DF 29 
      HashAlgo : 0x000B
      Digest(1): 96 A2 96 D2 24 F2 85 C6 7B EE 93 C3 0F 8A 30 91 57 F0 DA A3 5D C5 B8 7E 41 0B 78 63 0A 09 CF C7 
      HashAlgo : 0x000C
      Digest(2): 1D D6 F7 B4 57 AD 88 0D 84 0D 41 C9 61 28 3B AB 68 8E 94 E4 B5 93 59 EA 45 68 65 81 E9 0F EC CE A3 C6 24 B1 22 61 13 F8 24 F3 15 EB 60 AE 0A 7C 

    EventSize - 0x00000002
0000: 0000

[snip]
````

## Integration Instructions

N/A