### PR TITLE
Revert "Add RngDxe to OVMF, with runtime check for rdrand, alternative approach"

### DIFF
--- a/MdePkg/Library/BaseRngLib/Rand/RdRand.c
+++ b/MdePkg/Library/BaseRngLib/Rand/RdRand.c
@@ -3,7 +3,6 @@
   to provide high-quality random numbers.
 
 Copyright (c) 2023, Arm Limited. All rights reserved.<BR>
-Copyright (c) 2022, Pedro Falcato. All rights reserved.<BR>
 Copyright (c) 2021, NUVIA Inc. All rights reserved.<BR>
 Copyright (c) 2015, Intel Corporation. All rights reserved.<BR>
 
@@ -24,88 +23,6 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #define RDRAND_MASK  BIT30
 
 STATIC BOOLEAN  mRdRandSupported;
-
-//
-// Intel SDM says 10 tries is good enough for reliable RDRAND usage.
-//
-#define RDRAND_RETRIES  10
-
-#define RDRAND_TEST_SAMPLES  8
-
-#define RDRAND_MIN_CHANGE  5
-
-//
-// Add a define for native-word RDRAND, just for the test.
-//
-#ifdef MDE_CPU_X64
-#define ASM_RDRAND  AsmRdRand64
-#else
-#define ASM_RDRAND  AsmRdRand32
-#endif
-
-/**
-  Tests RDRAND for broken implementations.
-
-  @retval TRUE         RDRAND is reliable (and hopefully safe).
-  @retval FALSE        RDRAND is unreliable and should be disabled, despite CPUID.
-
-**/
-STATIC
-BOOLEAN
-TestRdRand (
-  VOID
-  )
-{
-  //
-  // Test for notoriously broken rdrand implementations that always return the same
-  // value, like the Zen 3 uarch (all-1s) or other several AMD families on suspend/resume (also all-1s).
-  // Note that this should be expanded to extensively test for other sorts of possible errata.
-  //
-
-  //
-  // Our algorithm samples rdrand $RDRAND_TEST_SAMPLES times and expects
-  // a different result $RDRAND_MIN_CHANGE times for reliable RDRAND usage.
-  //
-  UINTN   Prev;
-  UINT8   Idx;
-  UINT8   TestIteration;
-  UINT32  Changed;
-
-  Changed = 0;
-
-  for (TestIteration = 0; TestIteration < RDRAND_TEST_SAMPLES; TestIteration++) {
-    UINTN  Sample;
-    //
-    // Note: We use a retry loop for rdrand. Normal users get this in BaseRng.c
-    // Any failure to get a random number will assume RDRAND does not work.
-    //
-    for (Idx = 0; Idx < RDRAND_RETRIES; Idx++) {
-      if (ASM_RDRAND (&Sample)) {
-        break;
-      }
-    }
-
-    if (Idx == RDRAND_RETRIES) {
-      DEBUG ((DEBUG_ERROR, "BaseRngLib/x86: CPU BUG: Failed to get an RDRAND random number - disabling\n"));
-      return FALSE;
-    }
-
-    if (TestIteration != 0) {
-      Changed += Sample != Prev;
-    }
-
-    Prev = Sample;
-  }
-
-  if (Changed < RDRAND_MIN_CHANGE) {
-    DEBUG ((DEBUG_ERROR, "BaseRngLib/x86: CPU BUG: RDRAND not reliable - disabling\n"));
-    return FALSE;
-  }
-
-  return TRUE;
-}
-
-#undef ASM_RDRAND
 
 /**
   The constructor function checks whether or not RDRAND instruction is supported
@@ -131,12 +48,9 @@ BaseRngLibConstructor (
   // CPUID. A value of 1 indicates that processor support RDRAND instruction.
   //
   AsmCpuid (1, 0, 0, &RegEcx, 0);
+  ASSERT ((RegEcx & RDRAND_MASK) == RDRAND_MASK);
 
   mRdRandSupported = ((RegEcx & RDRAND_MASK) == RDRAND_MASK);
-
-  if (mRdRandSupported) {
-    mRdRandSupported = TestRdRand ();
-  }
 
   return EFI_SUCCESS;
 }
@@ -156,7 +70,6 @@ ArchGetRandomNumber16 (
   OUT     UINT16  *Rand
   )
 {
-  ASSERT (mRdRandSupported);
   return AsmRdRand16 (Rand);
 }
 
@@ -175,7 +88,6 @@ ArchGetRandomNumber32 (
   OUT     UINT32  *Rand
   )
 {
-  ASSERT (mRdRandSupported);
   return AsmRdRand32 (Rand);
 }
 
@@ -194,7 +106,6 @@ ArchGetRandomNumber64 (
   OUT     UINT64  *Rand
   )
 {
-  ASSERT (mRdRandSupported);
   return AsmRdRand64 (Rand);
 }
 
@@ -211,7 +122,13 @@ ArchIsRngSupported (
   VOID
   )
 {
-  return mRdRandSupported;
+  /*
+     Existing software depends on this always returning TRUE, so for
+     now hard-code it.
+
+     return mRdRandSupported;
+  */
+  return TRUE;
 }
 
 /**

--- a/OvmfPkg/AmdSev/AmdSevX64.dsc
+++ b/OvmfPkg/AmdSev/AmdSevX64.dsc
@@ -649,6 +649,7 @@
   OvmfPkg/Virtio10Dxe/Virtio10.inf
   OvmfPkg/VirtioBlkDxe/VirtioBlk.inf
   OvmfPkg/VirtioScsiDxe/VirtioScsi.inf
+  OvmfPkg/VirtioRngDxe/VirtioRng.inf
 !if $(PVSCSI_ENABLE) == TRUE
   OvmfPkg/PvScsiDxe/PvScsiDxe.inf
 !endif
@@ -732,7 +733,6 @@
   OvmfPkg/AmdSev/Grub/Grub.inf
 
 !include OvmfPkg/Include/Dsc/ShellComponents.dsc.inc
-!include OvmfPkg/Include/Dsc/OvmfRngComponents.dsc.inc
 
   OvmfPkg/PlatformDxe/Platform.inf
   OvmfPkg/AmdSevDxe/AmdSevDxe.inf {

--- a/OvmfPkg/AmdSev/AmdSevX64.fdf
+++ b/OvmfPkg/AmdSev/AmdSevX64.fdf
@@ -228,6 +228,7 @@ INF  OvmfPkg/VirtioPciDeviceDxe/VirtioPciDeviceDxe.inf
 INF  OvmfPkg/Virtio10Dxe/Virtio10.inf
 INF  OvmfPkg/VirtioBlkDxe/VirtioBlk.inf
 INF  OvmfPkg/VirtioScsiDxe/VirtioScsi.inf
+INF  OvmfPkg/VirtioRngDxe/VirtioRng.inf
 !if $(PVSCSI_ENABLE) == TRUE
 INF  OvmfPkg/PvScsiDxe/PvScsiDxe.inf
 !endif
@@ -320,7 +321,6 @@ INF  MdeModulePkg/Universal/Variable/RuntimeDxe/VariableRuntimeDxe.inf
 !include OvmfPkg/Include/Fdf/OvmfTpmDxe.fdf.inc
 
 !include OvmfPkg/Include/Fdf/ShellDxe.fdf.inc
-!include OvmfPkg/Include/Fdf/OvmfRngDxe.fdf.inc
 
 ################################################################################
 

--- a/OvmfPkg/Include/Dsc/OvmfRngComponents.dsc.inc
+++ b/OvmfPkg/Include/Dsc/OvmfRngComponents.dsc.inc
@@ -1,9 +1,0 @@
-##
-#    SPDX-License-Identifier: BSD-2-Clause-Patent
-##
-
-  SecurityPkg/RandomNumberGenerator/RngDxe/RngDxe.inf {
-    <LibraryClasses>
-      RngLib|MdePkg/Library/BaseRngLib/BaseRngLib.inf
-  }
-  OvmfPkg/VirtioRngDxe/VirtioRng.inf

--- a/OvmfPkg/Include/Fdf/OvmfRngDxe.fdf.inc
+++ b/OvmfPkg/Include/Fdf/OvmfRngDxe.fdf.inc
@@ -1,6 +1,0 @@
-##
-#    SPDX-License-Identifier: BSD-2-Clause-Patent
-##
-
-INF  SecurityPkg/RandomNumberGenerator/RngDxe/RngDxe.inf
-INF  OvmfPkg/VirtioRngDxe/VirtioRng.inf

--- a/OvmfPkg/IntelTdx/IntelTdxX64.dsc
+++ b/OvmfPkg/IntelTdx/IntelTdxX64.dsc
@@ -635,6 +635,7 @@
   OvmfPkg/Virtio10Dxe/Virtio10.inf
   OvmfPkg/VirtioBlkDxe/VirtioBlk.inf
   OvmfPkg/VirtioScsiDxe/VirtioScsi.inf
+  OvmfPkg/VirtioRngDxe/VirtioRng.inf
 !if $(PVSCSI_ENABLE) == TRUE
   OvmfPkg/PvScsiDxe/PvScsiDxe.inf
 !endif
@@ -717,7 +718,6 @@
   MdeModulePkg/Bus/Usb/UsbMassStorageDxe/UsbMassStorageDxe.inf
 
 !include OvmfPkg/Include/Dsc/ShellComponents.dsc.inc
-!include OvmfPkg/Include/Dsc/OvmfRngComponents.dsc.inc
 
 !if $(SECURE_BOOT_ENABLE) == TRUE
   SecurityPkg/VariableAuthenticated/SecureBootConfigDxe/SecureBootConfigDxe.inf

--- a/OvmfPkg/IntelTdx/IntelTdxX64.fdf
+++ b/OvmfPkg/IntelTdx/IntelTdxX64.fdf
@@ -285,6 +285,7 @@ READ_LOCK_STATUS   = TRUE
 #
 INF  MdeModulePkg/Universal/EbcDxe/EbcDxe.inf
 INF  OvmfPkg/VirtioScsiDxe/VirtioScsi.inf
+INF  OvmfPkg/VirtioRngDxe/VirtioRng.inf
 !if $(PVSCSI_ENABLE) == TRUE
 INF  OvmfPkg/PvScsiDxe/PvScsiDxe.inf
 !endif
@@ -325,7 +326,6 @@ INF  OvmfPkg/VirtioGpuDxe/VirtioGpu.inf
 INF  OvmfPkg/PlatformDxe/Platform.inf
 
 !include OvmfPkg/Include/Fdf/ShellDxe.fdf.inc
-!include OvmfPkg/Include/Fdf/OvmfRngDxe.fdf.inc
 
 ################################################################################
 

--- a/OvmfPkg/Microvm/MicrovmX64.dsc
+++ b/OvmfPkg/Microvm/MicrovmX64.dsc
@@ -760,6 +760,7 @@
   OvmfPkg/Virtio10Dxe/Virtio10.inf
   OvmfPkg/VirtioBlkDxe/VirtioBlk.inf
   OvmfPkg/VirtioScsiDxe/VirtioScsi.inf
+  OvmfPkg/VirtioRngDxe/VirtioRng.inf
   OvmfPkg/VirtioSerialDxe/VirtioSerial.inf
   MdeModulePkg/Universal/WatchdogTimerDxe/WatchdogTimer.inf
   MdeModulePkg/Universal/MonotonicCounterRuntimeDxe/MonotonicCounterRuntimeDxe.inf
@@ -845,7 +846,6 @@
   MdeModulePkg/Bus/Usb/UsbMassStorageDxe/UsbMassStorageDxe.inf
 
 !include OvmfPkg/Include/Dsc/ShellComponents.dsc.inc
-!include OvmfPkg/Include/Dsc/OvmfRngComponents.dsc.inc
 
 !if $(SECURE_BOOT_ENABLE) == TRUE
   SecurityPkg/VariableAuthenticated/SecureBootConfigDxe/SecureBootConfigDxe.inf

--- a/OvmfPkg/Microvm/MicrovmX64.fdf
+++ b/OvmfPkg/Microvm/MicrovmX64.fdf
@@ -207,6 +207,7 @@ INF  OvmfPkg/VirtioPciDeviceDxe/VirtioPciDeviceDxe.inf
 INF  OvmfPkg/Virtio10Dxe/Virtio10.inf
 INF  OvmfPkg/VirtioBlkDxe/VirtioBlk.inf
 INF  OvmfPkg/VirtioScsiDxe/VirtioScsi.inf
+INF  OvmfPkg/VirtioRngDxe/VirtioRng.inf
 INF  OvmfPkg/VirtioSerialDxe/VirtioSerial.inf
 
 !if $(SECURE_BOOT_ENABLE) == TRUE
@@ -298,7 +299,6 @@ INF  MdeModulePkg/Universal/FaultTolerantWriteDxe/FaultTolerantWriteDxe.inf
 INF  MdeModulePkg/Universal/Variable/RuntimeDxe/VariableRuntimeDxe.inf
 
 !include OvmfPkg/Include/Fdf/ShellDxe.fdf.inc
-!include OvmfPkg/Include/Fdf/OvmfRngDxe.fdf.inc
 
 ################################################################################
 

--- a/OvmfPkg/OvmfPkgIa32.dsc
+++ b/OvmfPkg/OvmfPkgIa32.dsc
@@ -784,6 +784,7 @@
   OvmfPkg/Virtio10Dxe/Virtio10.inf
   OvmfPkg/VirtioBlkDxe/VirtioBlk.inf
   OvmfPkg/VirtioScsiDxe/VirtioScsi.inf
+  OvmfPkg/VirtioRngDxe/VirtioRng.inf
   OvmfPkg/VirtioSerialDxe/VirtioSerial.inf
 !if $(PVSCSI_ENABLE) == TRUE
   OvmfPkg/PvScsiDxe/PvScsiDxe.inf
@@ -881,7 +882,6 @@
 
 !include OvmfPkg/Include/Dsc/ShellComponents.dsc.inc
 !include OvmfPkg/Include/Dsc/MorLock.dsc.inc
-!include OvmfPkg/Include/Dsc/OvmfRngComponents.dsc.inc
 
 !if $(SECURE_BOOT_ENABLE) == TRUE
   SecurityPkg/VariableAuthenticated/SecureBootConfigDxe/SecureBootConfigDxe.inf

--- a/OvmfPkg/OvmfPkgIa32.fdf
+++ b/OvmfPkg/OvmfPkgIa32.fdf
@@ -232,6 +232,7 @@ INF  OvmfPkg/VirtioPciDeviceDxe/VirtioPciDeviceDxe.inf
 INF  OvmfPkg/Virtio10Dxe/Virtio10.inf
 INF  OvmfPkg/VirtioBlkDxe/VirtioBlk.inf
 INF  OvmfPkg/VirtioScsiDxe/VirtioScsi.inf
+INF  OvmfPkg/VirtioRngDxe/VirtioRng.inf
 INF  OvmfPkg/VirtioSerialDxe/VirtioSerial.inf
 !if $(PVSCSI_ENABLE) == TRUE
 INF  OvmfPkg/PvScsiDxe/PvScsiDxe.inf
@@ -359,7 +360,6 @@ INF  MdeModulePkg/Universal/Variable/RuntimeDxe/VariableRuntimeDxe.inf
 
 !include OvmfPkg/Include/Fdf/ShellDxe.fdf.inc
 !include OvmfPkg/Include/Fdf/MorLock.fdf.inc
-!include OvmfPkg/Include/Fdf/OvmfRngDxe.fdf.inc
 
 !if $(LOAD_X64_ON_IA32_ENABLE) == TRUE
 INF  OvmfPkg/CompatImageLoaderDxe/CompatImageLoaderDxe.inf

--- a/OvmfPkg/OvmfPkgIa32X64.dsc
+++ b/OvmfPkg/OvmfPkgIa32X64.dsc
@@ -798,6 +798,7 @@
   OvmfPkg/Virtio10Dxe/Virtio10.inf
   OvmfPkg/VirtioBlkDxe/VirtioBlk.inf
   OvmfPkg/VirtioScsiDxe/VirtioScsi.inf
+  OvmfPkg/VirtioRngDxe/VirtioRng.inf
   OvmfPkg/VirtioSerialDxe/VirtioSerial.inf
 !if $(PVSCSI_ENABLE) == TRUE
   OvmfPkg/PvScsiDxe/PvScsiDxe.inf
@@ -895,7 +896,6 @@
 
 !include OvmfPkg/Include/Dsc/ShellComponents.dsc.inc
 !include OvmfPkg/Include/Dsc/MorLock.dsc.inc
-!include OvmfPkg/Include/Dsc/OvmfRngComponents.dsc.inc
 
 !if $(SECURE_BOOT_ENABLE) == TRUE
   SecurityPkg/VariableAuthenticated/SecureBootConfigDxe/SecureBootConfigDxe.inf

--- a/OvmfPkg/OvmfPkgIa32X64.fdf
+++ b/OvmfPkg/OvmfPkgIa32X64.fdf
@@ -233,6 +233,7 @@ INF  OvmfPkg/VirtioPciDeviceDxe/VirtioPciDeviceDxe.inf
 INF  OvmfPkg/Virtio10Dxe/Virtio10.inf
 INF  OvmfPkg/VirtioBlkDxe/VirtioBlk.inf
 INF  OvmfPkg/VirtioScsiDxe/VirtioScsi.inf
+INF  OvmfPkg/VirtioRngDxe/VirtioRng.inf
 INF  OvmfPkg/VirtioSerialDxe/VirtioSerial.inf
 !if $(PVSCSI_ENABLE) == TRUE
 INF  OvmfPkg/PvScsiDxe/PvScsiDxe.inf
@@ -366,7 +367,6 @@ INF  MdeModulePkg/Universal/Variable/RuntimeDxe/VariableRuntimeDxe.inf
 
 !include OvmfPkg/Include/Fdf/ShellDxe.fdf.inc
 !include OvmfPkg/Include/Fdf/MorLock.fdf.inc
-!include OvmfPkg/Include/Fdf/OvmfRngDxe.fdf.inc
 
 ################################################################################
 

--- a/OvmfPkg/OvmfPkgX64.dsc
+++ b/OvmfPkg/OvmfPkgX64.dsc
@@ -866,6 +866,7 @@
   OvmfPkg/Virtio10Dxe/Virtio10.inf
   OvmfPkg/VirtioBlkDxe/VirtioBlk.inf
   OvmfPkg/VirtioScsiDxe/VirtioScsi.inf
+  OvmfPkg/VirtioRngDxe/VirtioRng.inf
   OvmfPkg/VirtioSerialDxe/VirtioSerial.inf
 !if $(PVSCSI_ENABLE) == TRUE
   OvmfPkg/PvScsiDxe/PvScsiDxe.inf
@@ -963,7 +964,6 @@
 
 !include OvmfPkg/Include/Dsc/ShellComponents.dsc.inc
 !include OvmfPkg/Include/Dsc/MorLock.dsc.inc
-!include OvmfPkg/Include/Dsc/OvmfRngComponents.dsc.inc
 
 !if $(SECURE_BOOT_ENABLE) == TRUE
   SecurityPkg/VariableAuthenticated/SecureBootConfigDxe/SecureBootConfigDxe.inf

--- a/OvmfPkg/OvmfPkgX64.fdf
+++ b/OvmfPkg/OvmfPkgX64.fdf
@@ -264,6 +264,7 @@ INF  OvmfPkg/VirtioPciDeviceDxe/VirtioPciDeviceDxe.inf
 INF  OvmfPkg/Virtio10Dxe/Virtio10.inf
 INF  OvmfPkg/VirtioBlkDxe/VirtioBlk.inf
 INF  OvmfPkg/VirtioScsiDxe/VirtioScsi.inf
+INF  OvmfPkg/VirtioRngDxe/VirtioRng.inf
 INF  OvmfPkg/VirtioSerialDxe/VirtioSerial.inf
 !if $(PVSCSI_ENABLE) == TRUE
 INF  OvmfPkg/PvScsiDxe/PvScsiDxe.inf
@@ -406,7 +407,6 @@ INF OvmfPkg/Tcg/TdTcg2Dxe/TdTcg2Dxe.inf
 
 !include OvmfPkg/Include/Fdf/ShellDxe.fdf.inc
 !include OvmfPkg/Include/Fdf/MorLock.fdf.inc
-!include OvmfPkg/Include/Fdf/OvmfRngDxe.fdf.inc
 
 ################################################################################
 

--- a/SecurityPkg/RandomNumberGenerator/RngDxe/Rand/RngDxe.c
+++ b/SecurityPkg/RandomNumberGenerator/RngDxe/Rand/RngDxe.c
@@ -23,7 +23,6 @@
 
 #include <Library/BaseLib.h>
 #include <Library/BaseMemoryLib.h>
-#include <Library/RngLib.h>
 
 #include "RngDxeInternals.h"
 
@@ -44,12 +43,7 @@ GetAvailableAlgorithms (
   VOID
   )
 {
-  UINT64  RngTest;
-
-  if (GetRandomNumber64 (&RngTest)) {
-    mAvailableAlgoArrayCount = RNG_ALGORITHM_COUNT;
-  }
-
+  mAvailableAlgoArrayCount = RNG_ALGORITHM_COUNT;
   return EFI_SUCCESS;
 }
 


### PR DESCRIPTION
Reverts tianocore/edk2#5714

Crypto unit tests are failing, possibly due to RDRAND issues on the CI infra servers.

@kraxel 