### PR TITLE
CryptoPkg: Fix strncpy for BaseCryptLibMbedTls

### DIFF
--- a/CryptoPkg/Library/BaseCryptLibMbedTls/SysCall/DummyOpensslSupport.c
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/SysCall/DummyOpensslSupport.c
@@ -258,9 +258,28 @@ strcpy (
   const char  *strSource
   )
 {
-  // AsciiStrCpyS (strDest, MAX_STRING_SIZE, strSource);
-  // return strDest;
-  return NULL;
+  AsciiStrCpyS (strDest, AsciiStrnSizeS (strSource, MAX_STRING_SIZE - 1), strSource);
+  return strDest;
+}
+
+char *
+strncpy (
+  char        *strDest,
+  const char  *strSource,
+  size_t      count
+  )
+{
+  UINTN  DestMax = MAX_STRING_SIZE;
+
+  if (count < MAX_STRING_SIZE) {
+    DestMax = count + 1;
+  } else {
+    count = MAX_STRING_SIZE-1;
+  }
+
+  AsciiStrnCpyS (strDest, DestMax, strSource, (UINTN)count);
+
+  return strDest;
 }
 
 //


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=2817

Because the change for strncpy, add the strncpy implementation for BaseCryptLibMbedTls.

# Description
- [ ] Breaking change?
  - **Breaking change** - Will this cause a break in build or boot behavior?
  - Examples: Add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested
From PR: https://github.com/tianocore/edk2/pull/5734
strcpy fix was tested after it was found with OVMF + GDB while testing HTTPS boot. In this test case the first HTTPS boot always failed, with the fix of strcpy the boot is successful on the first try.

## Integration Instructions

NA
