### PR TITLE
OvmfPkg/BhyvePkg: honor FwCfg when setting the bootorder

### DIFF
--- a/OvmfPkg/Bhyve/BhyveX64.dsc
+++ b/OvmfPkg/Bhyve/BhyveX64.dsc
@@ -358,6 +358,7 @@
 !endif
   PlatformBootManagerLib|OvmfPkg/Library/PlatformBootManagerLibBhyve/PlatformBootManagerLibBhyve.inf
   PlatformBmPrintScLib|OvmfPkg/Library/PlatformBmPrintScLib/PlatformBmPrintScLib.inf
+  QemuBootOrderLib|OvmfPkg/Library/QemuBootOrderLib/QemuBootOrderLib.inf
   CpuExceptionHandlerLib|UefiCpuPkg/Library/CpuExceptionHandlerLib/DxeCpuExceptionHandlerLib.inf
   LockBoxLib|OvmfPkg/Library/LockBoxLib/LockBoxDxeLib.inf
 !if $(SOURCE_DEBUG_ENABLE) == TRUE

--- a/OvmfPkg/Library/PlatformBootManagerLibBhyve/BdsPlatform.c
+++ b/OvmfPkg/Library/PlatformBootManagerLibBhyve/BdsPlatform.c
@@ -1433,7 +1433,8 @@ PlatformBdsConnectSequence (
   VOID
   )
 {
-  UINTN  Index;
+  UINTN          Index;
+  RETURN_STATUS  Status;
 
   DEBUG ((DEBUG_INFO, "PlatformBdsConnectSequence\n"));
 
@@ -1452,11 +1453,14 @@ PlatformBdsConnectSequence (
     Index++;
   }
 
-  //
-  // Just use the simple policy to connect all devices
-  //
-  DEBUG ((DEBUG_INFO, "EfiBootManagerConnectAll\n"));
-  EfiBootManagerConnectAll ();
+  Status = ConnectDevicesFromQemu ();
+  if (RETURN_ERROR (Status)) {
+    //
+    // Just use the simple policy to connect all devices
+    //
+    DEBUG ((DEBUG_INFO, "EfiBootManagerConnectAll\n"));
+    EfiBootManagerConnectAll ();
+  }
 }
 
 /**
@@ -1581,6 +1585,7 @@ PlatformBootManagerAfterConsole (
     );
 
   RemoveStaleFvFileOptions ();
+  SetBootOrderFromQemu ();
 
   PlatformBmPrintScRegisterHandler ();
 }

--- a/OvmfPkg/Library/PlatformBootManagerLibBhyve/PlatformBootManagerLibBhyve.inf
+++ b/OvmfPkg/Library/PlatformBootManagerLibBhyve/PlatformBootManagerLibBhyve.inf
@@ -46,6 +46,7 @@
   BootLogoLib
   DevicePathLib
   PciLib
+  QemuBootOrderLib
   NvVarsFileLib
   ReportStatusCodeLib
   UefiLib


### PR DESCRIPTION
Bhyve has added support for the bootorder FwCfg file some time ago [1][2]. This FwCfg file is currently ignored by the OVMF and has no effect. Copy the relevant code from Qemu to Bhyve to make it usable.

[1] https://github.com/freebsd/freebsd-src/commit/6632a0a4e3ab68b0e31b612e8aeca14de3fc8159
[2] https://github.com/freebsd/freebsd-src/commit/480bef9481f0c44b19ac4b2adb09f6c3191acd41