### PR TITLE
ArmPkg/ProcessorSubClassDxe: Limit values to 0xFF

### DIFF
--- a/ArmPkg/Universal/Smbios/ProcessorSubClassDxe/ProcessorSubClass.c
+++ b/ArmPkg/Universal/Smbios/ProcessorSubClassDxe/ProcessorSubClass.c
@@ -709,11 +709,11 @@ AddSmbiosProcessorTypeTable (
   Type4Record->L1CacheHandle     = L1CacheHandle;
   Type4Record->L2CacheHandle     = L2CacheHandle;
   Type4Record->L3CacheHandle     = L3CacheHandle;
-  Type4Record->CoreCount         = MiscProcessorData.CoreCount;
+  Type4Record->CoreCount         = MIN (MiscProcessorData.CoreCount, MAX_UINT8);
   Type4Record->CoreCount2        = MiscProcessorData.CoreCount;
-  Type4Record->EnabledCoreCount  = MiscProcessorData.CoresEnabled;
+  Type4Record->EnabledCoreCount  = MIN (MiscProcessorData.CoresEnabled, MAX_UINT8);
   Type4Record->EnabledCoreCount2 = MiscProcessorData.CoresEnabled;
-  Type4Record->ThreadCount       = MiscProcessorData.ThreadCount;
+  Type4Record->ThreadCount       = MIN (MiscProcessorData.ThreadCount, MAX_UINT8);
   Type4Record->ThreadCount2      = MiscProcessorData.ThreadCount;
 
   Type4Record->CurrentSpeed  = GetCpuFrequency (ProcessorIndex);


### PR DESCRIPTION
# Description

 The CoreCount, EnabledCore and ThreadCount counts should be set to 0xFF if value is greater than 255 per the SMBIOS specification.

- [ ] Breaking change?
  - **Breaking change** - Will this cause a break in build or boot behavior?
  - Examples: Add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Validated SMBIOS table was correct with CoreCounts > 255

## Integration Instructions

N/A
