### PR TITLE
DynamicTablesPkg: Support for generic DBG2 devices

### DIFF
--- a/DynamicTablesPkg/Include/ArmNameSpaceObjects.h
+++ b/DynamicTablesPkg/Include/ArmNameSpaceObjects.h
@@ -1,6 +1,7 @@
 /** @file
 
   Copyright (c) 2017 - 2024, Arm Limited. All rights reserved.<BR>
+  Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved. <BR>
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -13,6 +14,8 @@
 #ifndef ARM_NAMESPACE_OBJECTS_H_
 #define ARM_NAMESPACE_OBJECTS_H_
 
+#include <IndustryStandard/AcpiAml.h>
+#include <IndustryStandard/Pci.h>
 #include <AcpiObjects.h>
 #include <StandardNameSpaceObjects.h>
 
@@ -73,6 +76,7 @@ typedef enum ArmObjectID {
   EArmObjPccSubspaceType5Info,                                 ///< 48 - Pcc Subspace Type 5 Info
   EArmObjEtInfo,                                               ///< 49 - Embedded Trace Extension/Module Info
   EArmObjPsdInfo,                                              ///< 50 - P-State Dependency (PSD) Info
+  EArmObjDbg2DeviceInfo,                                       ///< 51 - Generic DBG2 devices
   EArmObjMax
 } EARM_OBJECT_ID;
 
@@ -1344,6 +1348,34 @@ typedef struct CmArmEtInfo {
     ID: EArmObjPsdInfo
 */
 typedef AML_PSD_INFO CM_ARM_PSD_INFO;
+
+/** A structure that describes a generic device to add a DBG2 device node from.
+
+  ID: EArmObjDbg2DeviceInfo,
+*/
+typedef struct CmArmDbg2DeviceInfo {
+  /// The number of addresses in the device
+  UINT8     NumberOfAddresses;
+
+  /// The physical base address array for the device
+  UINT64    BaseAddress[PCI_MAX_BAR];
+
+  /// The Base address length array
+  UINT64    BaseAddressLength[PCI_MAX_BAR];
+
+  /// The DBG2 port type
+  UINT16    PortType;
+
+  /// The DBG2 port subtype
+  UINT16    PortSubtype;
+
+  /// Access Size
+  UINT8     AccessSize;
+
+  /** ASCII Null terminated string that will be appended to \_SB_. for the full path.
+  */
+  CHAR8     ObjectName[AML_NAME_SEG_SIZE + 1];
+} CM_ARM_DBG2_DEVICE_INFO;
 
 #pragma pack()
 

--- a/DynamicTablesPkg/Library/Acpi/Arm/AcpiDbg2LibArm/AcpiDbg2LibArm.inf
+++ b/DynamicTablesPkg/Library/Acpi/Arm/AcpiDbg2LibArm/AcpiDbg2LibArm.inf
@@ -29,6 +29,7 @@
 [LibraryClasses]
   BaseLib
   PL011UartLib
+  PrintLib
   SsdtSerialPortFixupLib
 
 [FixedPcd]


### PR DESCRIPTION
# Description

Add support for creating DBG2 nodes for non-serial port devices.
This allows for either COM based or devices that point to other nodes.

- [ ] Breaking change?
  - **Breaking change** - Will this cause a break in build or boot behavior?
  - Examples: Add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Generated DBG2 entries for PCIe network devices with and without a serial debug device.

## Integration Instructions

N/A
