### PR TITLE
MdePkg: Update HEST Revision As 2

### DIFF
--- a/MdePkg/Include/IndustryStandard/Acpi65.h
+++ b/MdePkg/Include/IndustryStandard/Acpi65.h
@@ -1949,7 +1949,7 @@ typedef struct {
 ///
 /// HEST Version (as defined in ACPI 6.5 spec.)
 ///
-#define EFI_ACPI_6_5_HARDWARE_ERROR_SOURCE_TABLE_REVISION  0x01
+#define EFI_ACPI_6_5_HARDWARE_ERROR_SOURCE_TABLE_REVISION  0x02
 
 //
 // Error Source structure types.


### PR DESCRIPTION
# Description
This modification come from ACPI 6.5 spec.
Besides, Starting with revision 2 of HEST, the Error Source Structures must be sorted in Type ascending order for Error Source Structure Types of less than 12.

