### PR TITLE
OvmfPkg/QemuVideoDxe: add feature PCD to remap framebuffer W/C

### DIFF
--- a/OvmfPkg/OvmfPkg.dec
+++ b/OvmfPkg/OvmfPkg.dec
@@ -449,3 +449,8 @@
 
   ## This feature flag indicates the firmware build supports secure boot.
   gUefiOvmfPkgTokenSpaceGuid.PcdSecureBootSupported|FALSE|BOOLEAN|0x6d
+
+  ## Whether QemuVideoDxe should perform a EFI_MEMORY_WC remap of the PCI
+  #  framebuffer. This might be required on platforms that do not tolerate
+  #  misaligned accesses otherwise.
+  gUefiOvmfPkgTokenSpaceGuid.PcdRemapFrameBufferWriteCombine|FALSE|BOOLEAN|0x75

--- a/OvmfPkg/QemuVideoDxe/Gop.c
+++ b/OvmfPkg/QemuVideoDxe/Gop.c
@@ -9,6 +9,8 @@
 
 #include "Qemu.h"
 
+#include <Library/DxeServicesTableLib.h>
+
 STATIC
 VOID
 QemuVideoCompleteModeInfo (
@@ -54,6 +56,7 @@ QemuVideoCompleteModeData (
   EFI_GRAPHICS_OUTPUT_MODE_INFORMATION  *Info;
   EFI_ACPI_ADDRESS_SPACE_DESCRIPTOR     *FrameBufDesc;
   QEMU_VIDEO_MODE_DATA                  *ModeData;
+  EFI_STATUS                            Status;
 
   ModeData = &Private->ModeData[Mode->Mode];
   Info     = Mode->Info;
@@ -78,6 +81,22 @@ QemuVideoCompleteModeData (
     Mode->FrameBufferBase,
     (UINT64)Mode->FrameBufferSize
     ));
+
+  if (FeaturePcdGet (PcdRemapFrameBufferWriteCombine)) {
+    Status = gDS->SetMemorySpaceCapabilities (
+                    FrameBufDesc->AddrRangeMin,
+                    FrameBufDesc->AddrLen,
+                    EFI_MEMORY_UC | EFI_MEMORY_WC | EFI_MEMORY_XP
+                    );
+    ASSERT_EFI_ERROR (Status);
+
+    Status = gDS->SetMemorySpaceAttributes (
+                    FrameBufDesc->AddrRangeMin,
+                    FrameBufDesc->AddrLen,
+                    EFI_MEMORY_WC | EFI_MEMORY_XP
+                    );
+    ASSERT_EFI_ERROR (Status);
+  }
 
   FreePool (FrameBufDesc);
   return EFI_SUCCESS;

--- a/OvmfPkg/QemuVideoDxe/Qemu.h
+++ b/OvmfPkg/QemuVideoDxe/Qemu.h
@@ -13,7 +13,7 @@
 #ifndef _QEMU_H_
 #define _QEMU_H_
 
-#include <Uefi.h>
+#include <PiDxe.h>
 #include <Protocol/GraphicsOutput.h>
 #include <Protocol/PciIo.h>
 #include <Protocol/DriverSupportedEfiVersion.h>

--- a/OvmfPkg/QemuVideoDxe/QemuVideoDxe.inf
+++ b/OvmfPkg/QemuVideoDxe/QemuVideoDxe.inf
@@ -40,6 +40,7 @@
 
 [LibraryClasses]
   BaseMemoryLib
+  DxeServicesTableLib
   FrameBufferBltLib
   DebugLib
   DevicePathLib
@@ -56,6 +57,9 @@
   gEfiGraphicsOutputProtocolGuid                # PROTOCOL BY_START
   gEfiDevicePathProtocolGuid                    # PROTOCOL BY_START
   gEfiPciIoProtocolGuid                         # PROTOCOL TO_START
+
+[FeaturePcd]
+  gUefiOvmfPkgTokenSpaceGuid.PcdRemapFrameBufferWriteCombine
 
 [Pcd]
   gUefiOvmfPkgTokenSpaceGuid.PcdOvmfHostBridgePciDevId


### PR DESCRIPTION
============ RFC =============
QEMU no longer permits misaligned access to device memory, which breaks QemuVideoDxe on SbsaQemu.

This is one potential work-around - it is quick and dirty hack, and I'm open to alternative approaches.