### PR TITLE
MdeModulePkg/DisplayEngineDxe: Support "^" and "V" key on pop-up form

### DIFF
--- a/MdeModulePkg/Universal/DisplayEngineDxe/InputHandler.c
+++ b/MdeModulePkg/Universal/DisplayEngineDxe/InputHandler.c
@@ -2,6 +2,7 @@
 Implementation for handling user input from the User Interfaces.
 
 Copyright (c) 2004 - 2018, Intel Corporation. All rights reserved.<BR>
+Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -1564,6 +1565,47 @@ TheKey:
             ASSERT (CurrentOption != NULL);
             SwapListEntries (&CurrentOption->Link, CurrentOption->Link.ForwardLink);
           }
+        }
+
+        break;
+
+      case '^':
+        if ((TopOptionIndex > 0) && (TopOptionIndex == HighlightOptionIndex)) {
+          //
+          // Highlight reaches the top of the popup window, scroll one menu item.
+          //
+          TopOptionIndex--;
+          ShowDownArrow = TRUE;
+        }
+
+        if (TopOptionIndex == 0) {
+          ShowUpArrow = FALSE;
+        }
+
+        if (HighlightOptionIndex > 0) {
+          HighlightOptionIndex--;
+        }
+
+        break;
+
+      case 'V':
+      case 'v':
+        if (((TopOptionIndex + MenuLinesInView) < PopUpMenuLines) &&
+            (HighlightOptionIndex == (TopOptionIndex + MenuLinesInView - 1)))
+        {
+          //
+          // Highlight reaches the bottom of the popup window, scroll one menu item.
+          //
+          TopOptionIndex++;
+          ShowUpArrow = TRUE;
+        }
+
+        if ((TopOptionIndex + MenuLinesInView) == PopUpMenuLines) {
+          ShowDownArrow = FALSE;
+        }
+
+        if (HighlightOptionIndex < (PopUpMenuLines - 1)) {
+          HighlightOptionIndex++;
         }
 
         break;


### PR DESCRIPTION
# Description
BZ #4790
Support "^" and "V" key stokes on the pop-up form. Align the implementation with key support on the regular HII form.

- [ ] Breaking change?
  - **Breaking change** - Will this cause a break in build or boot behavior?
  - Examples: Add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests or integration tests.


