### PR TITLE
MdeModulePkg/DxeCapsuleLibFmp: Fix compilation error

### DIFF
--- a/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleLib.c
+++ b/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleLib.c
@@ -49,7 +49,7 @@ EFI_EVENT  mDxeCapsuleLibEndOfDxeEvent = NULL;
 
 EDKII_FIRMWARE_MANAGEMENT_PROGRESS_PROTOCOL  *mFmpProgress = NULL;
 
-extern BOOLEAN  mDxeCapsuleLibReadyToBootEvent;
+BOOLEAN  mDxeCapsuleLibReadyToBootEvent = FALSE;
 
 /**
   Initialize capsule related variables.

--- a/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleRuntime.c
+++ b/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleRuntime.c
@@ -24,7 +24,7 @@
 extern EFI_SYSTEM_RESOURCE_TABLE  *mEsrtTable;
 EFI_EVENT                         mDxeRuntimeCapsuleLibVirtualAddressChangeEvent = NULL;
 EFI_EVENT                         mDxeRuntimeCapsuleLibReadyToBootEvent          = NULL;
-BOOLEAN                           mDxeCapsuleLibReadyToBootEvent                 = FALSE;
+extern BOOLEAN                    mDxeCapsuleLibReadyToBootEvent;
 
 /**
   Convert EsrtTable physical address to virtual address.


### PR DESCRIPTION
# Description

The commit "MdeModulePkg/DxeCapsuleLibFmp: Fix crash if no ESRT is found" leads to a compilation error in
MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleLib.inf. The issue occurs because the variable mDxeCapsuleLibReadyToBootEvent which is declared as extern does not exist, while it is defined in DxeCapsuleRuntime.c, a file not included in DxeCapsuleLib.inf. This patch is to fix this by moving the variable defintion to DxeCapsuleLib.c and declare it as extern in DxeCapsuleRuntime.c.

Reported-by: Gua Guo <gua.guo@intel.com>

- [ ] Breaking change?
  - **Breaking change** - Will this cause a break in build or boot behavior?
  - Examples: Add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

## Integration Instructions
