### PR TITLE
Nvme u64 format fix

### DIFF
--- a/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpress.c
+++ b/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpress.c
@@ -300,7 +300,7 @@ EnumerateNvmeDevNamespace (
     Sn[20] = 0;
     CopyMem (Mn, Private->ControllerData->Mn, sizeof (Private->ControllerData->Mn));
     Mn[40] = 0;
-    UnicodeSPrintAsciiFormat (Device->ModelName, sizeof (Device->ModelName), "%a-%a-%x", Sn, Mn, NamespaceData->Eui64);
+    UnicodeSPrintAsciiFormat (Device->ModelName, sizeof (Device->ModelName), "%a-%a-%lx", Sn, Mn, NamespaceData->Eui64);
 
     AddUnicodeString2 (
       "eng",

--- a/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpress.c
+++ b/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpress.c
@@ -288,9 +288,9 @@ EnumerateNvmeDevNamespace (
     // Dump NvmExpress Identify Namespace Data
     //
     DEBUG ((DEBUG_INFO, " == NVME IDENTIFY NAMESPACE [%d] DATA ==\n", NamespaceId));
-    DEBUG ((DEBUG_INFO, "    NSZE        : 0x%x\n", NamespaceData->Nsze));
-    DEBUG ((DEBUG_INFO, "    NCAP        : 0x%x\n", NamespaceData->Ncap));
-    DEBUG ((DEBUG_INFO, "    NUSE        : 0x%x\n", NamespaceData->Nuse));
+    DEBUG ((DEBUG_INFO, "    NSZE        : 0x%lx\n", NamespaceData->Nsze));
+    DEBUG ((DEBUG_INFO, "    NCAP        : 0x%lx\n", NamespaceData->Ncap));
+    DEBUG ((DEBUG_INFO, "    NUSE        : 0x%lx\n", NamespaceData->Nuse));
     DEBUG ((DEBUG_INFO, "    LBAF0.LBADS : 0x%x\n", (NamespaceData->LbaFormat[0].Lbads)));
 
     //


### PR DESCRIPTION
# Description

This PR fixes format specifiers used for UINT64 values.

This set was sent to the list in Feb 2024 and reviewed by Laszlo Ersek
https://edk2.groups.io/g/devel/message/115601 ,
and I didn't get any reply from MdeModulePkg/NvmExpressDxe maintainers.

  - **Breaking change** - this patch can change the NVM device model name set as Controller Name which consumed by SecurityPkg/Tcg/Opal/OpalPassword driver and used in HII.
  
## How This Was Tested

None. The change is trivial.

## Integration Instructions

N/A