### PR TITLE
NetworkPkg/DxeNetLib: adjust PseudoRandom error logging

### DIFF
--- a/NetworkPkg/Library/DxeNetLib/DxeNetLib.c
+++ b/NetworkPkg/Library/DxeNetLib/DxeNetLib.c
@@ -951,7 +951,7 @@ PseudoRandom (
         //
         // Secure Algorithm was not supported on this platform
         //
-        DEBUG ((DEBUG_ERROR, "Failed to generate random data using secure algorithm %d: %r\n", AlgorithmIndex, Status));
+        DEBUG ((DEBUG_VERBOSE, "Failed to generate random data using secure algorithm %d: %r\n", AlgorithmIndex, Status));
 
         //
         // Try the next secure algorithm
@@ -971,6 +971,7 @@ PseudoRandom (
     // If we get here, we failed to generate random data using any secure algorithm
     // Platform owner should ensure that at least one secure algorithm is supported
     //
+    DEBUG ((DEBUG_ERROR, "Failed to generate random data, no supported secure algorithm found\n"));
     ASSERT_EFI_ERROR (Status);
     return Status;
   }


### PR DESCRIPTION
There is a list of allowed rng algorithms, if /one/ of them is not
supported this is not a problem, only /all/ of them failing is an
error condition.

Downgrade the message for a single unsupported algorithm from ERROR to
VERBOSE.  Add an error message in case we finish the loop without
finding a supported algorithm.
