### PR TITLE
Drop pcd arm arch timer freq in hz

### DIFF
--- a/ArmPkg/ArmPkg.dec
+++ b/ArmPkg/ArmPkg.dec
@@ -314,11 +314,6 @@
   gArmTokenSpaceGuid.PcdEmbeddedControllerFirmwareRelease|0xFFFF|UINT16|0x30000059
 
 [PcdsFixedAtBuild.common, PcdsDynamic.common]
-  #
-  # ARM Architectural Timer
-  #
-  gArmTokenSpaceGuid.PcdArmArchTimerFreqInHz|0|UINT32|0x00000034
-
   # ARM Architectural Timer Interrupt(GIC PPI) numbers
   gArmTokenSpaceGuid.PcdArmArchTimerSecIntrNum|29|UINT32|0x00000035
   gArmTokenSpaceGuid.PcdArmArchTimerIntrNum|30|UINT32|0x00000036

--- a/ArmPkg/Library/ArmArchTimerLib/ArmArchTimerLib.c
+++ b/ArmPkg/Library/ArmArchTimerLib/ArmArchTimerLib.c
@@ -15,7 +15,7 @@
 #include <Library/PcdLib.h>
 #include <Library/ArmGenericTimerCounterLib.h>
 
-#define TICKS_PER_MICRO_SEC  (PcdGet32 (PcdArmArchTimerFreqInHz)/1000000U)
+#define TICKS_PER_MICRO_SEC  (ArmGenericTimerGetTimerFreq ()/1000000U)
 
 // Select appropriate multiply function for platform architecture.
 #ifdef MDE_CPU_ARM
@@ -34,19 +34,6 @@ TimerConstructor (
   // Check if the ARM Generic Timer Extension is implemented.
   //
   if (ArmIsArchTimerImplemented ()) {
-    //
-    // Check if Architectural Timer frequency is pre-determined by the platform
-    // (ie. nonzero).
-    //
-    if (PcdGet32 (PcdArmArchTimerFreqInHz) != 0) {
-      //
-      // Check if ticks/uS is not 0. The Architectural timer runs at constant
-      // frequency, irrespective of CPU frequency. According to Generic Timer
-      // Ref manual, lower bound of the frequency is in the range of 1-10MHz.
-      //
-      ASSERT (TICKS_PER_MICRO_SEC);
-    }
-
     //
     // Architectural Timer Frequency must be set in Secure privileged
     // mode (if secure extension is supported).
@@ -76,10 +63,7 @@ GetPlatformTimerFreq (
 {
   UINTN  TimerFreq;
 
-  TimerFreq = PcdGet32 (PcdArmArchTimerFreqInHz);
-  if (TimerFreq == 0) {
-    TimerFreq = ArmGenericTimerGetTimerFreq ();
-  }
+  TimerFreq = ArmGenericTimerGetTimerFreq ();
 
   return TimerFreq;
 }

--- a/ArmPkg/Library/ArmArchTimerLib/ArmArchTimerLib.c
+++ b/ArmPkg/Library/ArmArchTimerLib/ArmArchTimerLib.c
@@ -45,19 +45,6 @@ TimerConstructor (
       // Ref manual, lower bound of the frequency is in the range of 1-10MHz.
       //
       ASSERT (TICKS_PER_MICRO_SEC);
-
- #ifdef MDE_CPU_ARM
-      //
-      // Only set the frequency for ARMv7. We expect the secure firmware to
-      // have already done it.
-      // If the security extension is not implemented, set Timer Frequency
-      // here.
-      //
-      if (ArmHasSecurityExtensions ()) {
-        ArmGenericTimerSetTimerFreq (PcdGet32 (PcdArmArchTimerFreqInHz));
-      }
-
- #endif
     }
 
     //

--- a/ArmPkg/Library/ArmArchTimerLib/ArmArchTimerLib.inf
+++ b/ArmPkg/Library/ArmArchTimerLib/ArmArchTimerLib.inf
@@ -29,4 +29,3 @@
   ArmGenericTimerCounterLib
 
 [Pcd]
-  gArmTokenSpaceGuid.PcdArmArchTimerFreqInHz

--- a/ArmVirtPkg/ArmVirtKvmTool.dsc
+++ b/ArmVirtPkg/ArmVirtKvmTool.dsc
@@ -147,11 +147,6 @@
   # 0-PCANSI, 1-VT100, 2-VT00+, 3-UTF8, 4-TTYTERM
   gEfiMdePkgTokenSpaceGuid.PcdDefaultTerminalType|4
 
-  #
-  # ARM Virtual Architectural Timer -- fetch frequency from KVM
-  #
-  gArmTokenSpaceGuid.PcdArmArchTimerFreqInHz|0
-
   # Use MMIO for accessing Serial port registers.
   gEfiMdeModulePkgTokenSpaceGuid.PcdSerialUseMmio|TRUE
   gEfiMdeModulePkgTokenSpaceGuid.PcdSerialPciDeviceInfo|{0xFF}

--- a/ArmVirtPkg/ArmVirtQemu.dsc
+++ b/ArmVirtPkg/ArmVirtQemu.dsc
@@ -191,11 +191,6 @@
 !endif
 
   #
-  # ARM Virtual Architectural Timer -- fetch frequency from QEMU (TCG) or KVM
-  #
-  gArmTokenSpaceGuid.PcdArmArchTimerFreqInHz|0
-
-  #
   # Network Pcds
   #
 !include NetworkPkg/NetworkPcds.dsc.inc

--- a/ArmVirtPkg/ArmVirtQemuKernel.dsc
+++ b/ArmVirtPkg/ArmVirtQemuKernel.dsc
@@ -157,11 +157,6 @@
 !endif
 
   #
-  # ARM Virtual Architectural Timer -- fetch frequency from QEMU (TCG) or KVM
-  #
-  gArmTokenSpaceGuid.PcdArmArchTimerFreqInHz|0
-
-  #
   # Network Pcds
   #
 !include NetworkPkg/NetworkPcds.dsc.inc

--- a/ArmVirtPkg/ArmVirtXen.dsc
+++ b/ArmVirtPkg/ArmVirtXen.dsc
@@ -86,11 +86,6 @@
   # Size of the region used by UEFI in permanent memory (Reserved 64MB)
   gArmPlatformTokenSpaceGuid.PcdSystemMemoryUefiRegionSize|0x04000000
 
-  #
-  # ARM Virtual Architectural Timer
-  #
-  gArmTokenSpaceGuid.PcdArmArchTimerFreqInHz|0
-
   gEfiMdeModulePkgTokenSpaceGuid.PcdResetOnMemoryTypeInformationChange|FALSE
   gEfiMdeModulePkgTokenSpaceGuid.PcdBootManagerMenuFile|{ 0x21, 0xaa, 0x2c, 0x46, 0x14, 0x76, 0x03, 0x45, 0x83, 0x6e, 0x8a, 0xb6, 0xf4, 0x66, 0x23, 0x31 }
 


### PR DESCRIPTION
PcdArmArchTimerFreqInHz lets platforms override the architectural timer
frequency, but this really isn't supported in hardware by anything lower
than EL3. And we no longer support running edk2 at EL3.
Setting it to 0 skips the override - but that is also the default.

So rework ArmArchTimerLib not to use it anymore (never set it, and retrieve
it from the system registers using ArmGenericTimerGetTimerFreq () when
needed), update ArmVirtPkg platforms not to ecpliticly set it, then drop it
completely.

Note: merging this series will break a bunch of targets in edk2-platforms.