### PR TITLE
Fixes for `GenerateCapsule.py`

### DIFF
--- a/BaseTools/Source/Python/Capsule/GenerateCapsule.py
+++ b/BaseTools/Source/Python/Capsule/GenerateCapsule.py
@@ -513,11 +513,11 @@ if __name__ == '__main__':
                         raise argparse.ArgumentTypeError ('JSON field MonotonicCount must be an integer in range 0x0..0xffffffffffffffff')
                     else:
                         raise argparse.ArgumentTypeError ('--monotonic-count must be an integer in range 0x0..0xffffffffffffffff')
-                if self.UpdateImageIndex >0xFF:
+                if self.UpdateImageIndex < 0x1 or self.UpdateImageIndex > 0xFF:
                     if args.JsonFile:
-                        raise argparse.ArgumentTypeError ('JSON field UpdateImageIndex must be an integer in range 0x0..0xff')
+                        raise argparse.ArgumentTypeError ('JSON field UpdateImageIndex must be an integer in range 0x1..0xff')
                     else:
-                        raise argparse.ArgumentTypeError ('--update-image-index must be an integer in range 0x0..0xff')
+                        raise argparse.ArgumentTypeError ('--update-image-index must be an integer in range 0x1..0xff')
 
             if self.UseSignTool:
                 if self.SignToolPfxFile is not None:

--- a/BaseTools/Source/Python/Capsule/GenerateCapsule.py
+++ b/BaseTools/Source/Python/Capsule/GenerateCapsule.py
@@ -580,7 +580,7 @@ if __name__ == '__main__':
             try:
                 SinglePayloadDescriptor.Validate (args)
             except Exception as Msg:
-                print ('GenerateCapsule: error:' + str(Msg))
+                print ('GenerateCapsule: error: ' + str(Msg))
                 sys.exit (1)
         for SinglePayloadDescriptor in PayloadDescriptorList:
             ImageCapsuleSupport = 0x0000000000000000
@@ -708,7 +708,7 @@ if __name__ == '__main__':
             try:
                 SinglePayloadDescriptor.Validate (args)
             except Exception as Msg:
-                print ('GenerateCapsule: error:' + str(Msg))
+                print ('GenerateCapsule: error: ' + str(Msg))
                 sys.exit (1)
         try:
             Result = UefiCapsuleHeader.Decode (Buffer)

--- a/BaseTools/Source/Python/Capsule/GenerateCapsule.py
+++ b/BaseTools/Source/Python/Capsule/GenerateCapsule.py
@@ -519,6 +519,10 @@ if __name__ == '__main__':
                     else:
                         raise argparse.ArgumentTypeError ('--update-image-index must be an integer in range 0x1..0xff')
 
+            if args.Decode:
+                if args.OutputFile is None:
+                    raise argparse.ArgumentTypeError ('--decode requires --output')
+
             if self.UseSignTool:
                 if self.SignToolPfxFile is not None:
                     self.SignToolPfxFile.close()

--- a/BaseTools/Source/Python/Capsule/GenerateCapsule.py
+++ b/BaseTools/Source/Python/Capsule/GenerateCapsule.py
@@ -690,7 +690,7 @@ if __name__ == '__main__':
                                             args.HardwareInstance,
                                             args.UpdateImageIndex,
                                             args.SignToolPfxFile,
-                                            args.SignSubjectName,
+                                            args.SignToolSubjectName,
                                             args.OpenSslSignerPrivateCertFile,
                                             args.OpenSslOtherPublicCertFile,
                                             args.OpenSslTrustedPublicCertFile,

--- a/BaseTools/Source/Python/Capsule/GenerateCapsule.py
+++ b/BaseTools/Source/Python/Capsule/GenerateCapsule.py
@@ -831,7 +831,7 @@ if __name__ == '__main__':
                             print ('--------')
                             print ('No EFI_FIRMWARE_IMAGE_AUTHENTICATION')
 
-                    PayloadSignature = struct.unpack ('<I', SinglePayloadDescriptor.Payload[0:4])
+                    (PayloadSignature,) = struct.unpack ('<I', SinglePayloadDescriptor.Payload[0:4])
                     if PayloadSignature != FmpPayloadHeader.Signature:
                         SinglePayloadDescriptor.UseDependency = True
                         try:
@@ -918,7 +918,7 @@ if __name__ == '__main__':
                         print ('--------')
                         print ('No EFI_FIRMWARE_IMAGE_AUTHENTICATION')
 
-                    PayloadSignature = struct.unpack ('<I', Result[0:4])
+                    (PayloadSignature,) = struct.unpack ('<I', Result[0:4])
                     if PayloadSignature != FmpPayloadHeader.Signature:
                         try:
                             Result = CapsuleDependency.Decode (Result)

--- a/BaseTools/Source/Python/Capsule/GenerateCapsule.py
+++ b/BaseTools/Source/Python/Capsule/GenerateCapsule.py
@@ -873,8 +873,8 @@ if __name__ == '__main__':
                         print ('GenerateCapsule: error: can not write embedded driver file {File}'.format (File = EmbeddedDriverPath))
                         sys.exit (1)
 
-        except:
-            print ('GenerateCapsule: error: can not decode capsule')
+        except Exception as Msg:
+            print ('GenerateCapsule: error: can not decode capsule: ' + str(Msg))
             sys.exit (1)
         GenerateOutputJson(PayloadJsonDescriptorList)
         PayloadIndex = 0

--- a/BaseTools/Source/Python/Common/Uefi/Capsule/FmpCapsuleHeader.py
+++ b/BaseTools/Source/Python/Common/Uefi/Capsule/FmpCapsuleHeader.py
@@ -92,7 +92,7 @@ class FmpCapsuleImageHeaderClass (object):
 
     def Decode (self, Buffer):
         if len (Buffer) < self._StructSize:
-            raise ValueError
+            raise ValueError ('Buffer is too small for decoding')
         (Version, UpdateImageTypeId, UpdateImageIndex, r0, r1, r2, UpdateImageSize, UpdateVendorCodeSize, UpdateHardwareInstance, ImageCapsuleSupport) = \
             struct.unpack (
                      self._StructFormat,
@@ -100,11 +100,11 @@ class FmpCapsuleImageHeaderClass (object):
                      )
 
         if Version < self.EFI_FIRMWARE_MANAGEMENT_CAPSULE_IMAGE_HEADER_INIT_VERSION:
-            raise ValueError
+            raise ValueError ('Incorrect capsule image header version')
         if UpdateImageIndex < 1:
-            raise ValueError
+            raise ValueError ('Update image index is less than 1')
         if UpdateImageSize + UpdateVendorCodeSize != len (Buffer[self._StructSize:]):
-            raise ValueError
+            raise ValueError ('Non-vendor and vendor parts do not add up')
 
         self.Version                = Version
         self.UpdateImageTypeId      = uuid.UUID (bytes_le = UpdateImageTypeId)
@@ -120,7 +120,7 @@ class FmpCapsuleImageHeaderClass (object):
 
     def DumpInfo (self):
         if not self._Valid:
-            raise ValueError
+            raise ValueError ('Can not dump an invalid header')
         print ('EFI_FIRMWARE_MANAGEMENT_CAPSULE_IMAGE_HEADER.Version                = {Version:08X}'.format (Version = self.Version))
         print ('EFI_FIRMWARE_MANAGEMENT_CAPSULE_IMAGE_HEADER.UpdateImageTypeId      = {UpdateImageTypeId}'.format (UpdateImageTypeId = str(self.UpdateImageTypeId).upper()))
         print ('EFI_FIRMWARE_MANAGEMENT_CAPSULE_IMAGE_HEADER.UpdateImageIndex       = {UpdateImageIndex:08X}'.format (UpdateImageIndex = self.UpdateImageIndex))
@@ -180,7 +180,7 @@ class FmpCapsuleHeaderClass (object):
 
     def GetEmbeddedDriver (self, Index):
         if Index > len (self._EmbeddedDriverList):
-            raise ValueError
+            raise ValueError ('Invalid embedded driver index')
         return self._EmbeddedDriverList[Index]
 
     def AddPayload (self, UpdateImageTypeId, Payload = b'', VendorCodeBytes = b'', HardwareInstance = 0, UpdateImageIndex = 1, CapsuleSupport = 0):
@@ -188,7 +188,7 @@ class FmpCapsuleHeaderClass (object):
 
     def GetFmpCapsuleImageHeader (self, Index):
         if Index >= len (self._FmpCapsuleImageHeaderList):
-            raise ValueError
+            raise ValueError ('Invalid capsule image index')
         return self._FmpCapsuleImageHeaderList[Index]
 
     def Encode (self):
@@ -234,14 +234,14 @@ class FmpCapsuleHeaderClass (object):
 
     def Decode (self, Buffer):
         if len (Buffer) < self._StructSize:
-            raise ValueError
+            raise ValueError ('Buffer is too small for decoding')
         (Version, EmbeddedDriverCount, PayloadItemCount) = \
             struct.unpack (
                      self._StructFormat,
                      Buffer[0:self._StructSize]
                      )
         if Version < self.EFI_FIRMWARE_MANAGEMENT_CAPSULE_HEADER_INIT_VERSION:
-            raise ValueError
+            raise ValueError ('Incorrect capsule header version')
 
         self.Version                    = Version
         self.EmbeddedDriverCount        = EmbeddedDriverCount
@@ -258,7 +258,7 @@ class FmpCapsuleHeaderClass (object):
         for Index in range (0, EmbeddedDriverCount + PayloadItemCount):
             ItemOffset = struct.unpack (self._ItemOffsetFormat, Buffer[Offset:Offset + self._ItemOffsetSize])[0]
             if ItemOffset >= len (Buffer):
-                raise ValueError
+                raise ValueError ('Item offset is outside of buffer')
             self._ItemOffsetList.append (ItemOffset)
             Offset = Offset + self._ItemOffsetSize
         Result = Buffer[Offset:]
@@ -297,7 +297,7 @@ class FmpCapsuleHeaderClass (object):
 
     def DumpInfo (self):
         if not self._Valid:
-            raise ValueError
+            raise ValueError ('Can not dump an invalid header')
         print ('EFI_FIRMWARE_MANAGEMENT_CAPSULE_HEADER.Version             = {Version:08X}'.format (Version = self.Version))
         print ('EFI_FIRMWARE_MANAGEMENT_CAPSULE_HEADER.EmbeddedDriverCount = {EmbeddedDriverCount:08X}'.format (EmbeddedDriverCount = self.EmbeddedDriverCount))
         for EmbeddedDriver in self._EmbeddedDriverList:


### PR DESCRIPTION
# Description

I was trying out `GenerateCapsule.py` for a [project](https://docs.dasharo.com/projects/capsule-updates/) to support coreboot firmware updates via UEFI capsules and hit a sequence of issues with running the script and interpreting its output.  Thought it's my bad but looking at the code proved that it needs to be improved in multiple places.

See individual commits for explanation of what they are fixing.

- [ ] Breaking change?
  - No, unless somebody used incorrect `UpdateImageIndex` equal to zero which can't be used anymore.
  - These are just fixes, like making `GenerateCapsule.py --decode` not fail due to querying an invalid parameter.
- [ ] Impacts security?
  - No, I don't think so.
- [ ] Includes tests?
  - No.

## How This Was Tested

Manually run `BaseTools/BinWrappers/PosixLike/GenerateCapsule` with `--encode`, `--decode` and `--dump-info`.

## Integration Instructions

N/A