### PR TITLE
MdeModulePkg/ImagePropertiesRecordLib: Reduce debug level

### DIFF
--- a/MdeModulePkg/Library/ImagePropertiesRecordLib/ImagePropertiesRecordLib.c
+++ b/MdeModulePkg/Library/ImagePropertiesRecordLib/ImagePropertiesRecordLib.c
@@ -1052,7 +1052,7 @@ CreateImagePropertiesRecord (
 
   PdbPointer = PeCoffLoaderGetPdbPointer ((VOID *)(UINTN)ImageBase);
   if (PdbPointer != NULL) {
-    DEBUG ((DEBUG_ERROR, " Image - %a\n", PdbPointer));
+    DEBUG ((DEBUG_VERBOSE, " Image - %a\n", PdbPointer));
   }
 
   // Check PE/COFF image


### PR DESCRIPTION
# Description

The presense of PdbPointer (PDB file name) is not an error. Hence, the debug message should be categorized as VERBOSE or INFO. However, the DEBUG_VERBOSE is more appropriate since the PDB file name is already output by the PeCoffLoaderRelocateImageExtraAction() function with the inline "add-symbol-file" when a platform uses the library instance DebugPeCoffExtraActionLib.

- [ ] Breaking change?
  - **Breaking change** - Will this cause a break in build or boot behavior?
  - Examples: Add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

## Integration Instructions
