### PR TITLE
Tcg platform libaray

### DIFF
--- a/ArmVirtPkg/ArmVirtQemu.dsc
+++ b/ArmVirtPkg/ArmVirtQemu.dsc
@@ -593,6 +593,7 @@
       NULL|SecurityPkg/Library/HashInstanceLibSha384/HashInstanceLibSha384.inf
       NULL|SecurityPkg/Library/HashInstanceLibSha512/HashInstanceLibSha512.inf
       NULL|SecurityPkg/Library/HashInstanceLibSm3/HashInstanceLibSm3.inf
+      PlatformTcgEventLogLib|SecurityPkg/Library/DxePlatformTcgEventLogLibNull/DxePlatformTcgEventLogLibNull.inf
   }
 !if $(TPM2_CONFIG_ENABLE) == TRUE
   SecurityPkg/Tcg/Tcg2Config/Tcg2ConfigDxe.inf

--- a/OvmfPkg/Include/Dsc/OvmfTpmComponentsDxe.dsc.inc
+++ b/OvmfPkg/Include/Dsc/OvmfTpmComponentsDxe.dsc.inc
@@ -13,6 +13,7 @@
       NULL|SecurityPkg/Library/HashInstanceLibSha384/HashInstanceLibSha384.inf
       NULL|SecurityPkg/Library/HashInstanceLibSha512/HashInstanceLibSha512.inf
       NULL|SecurityPkg/Library/HashInstanceLibSm3/HashInstanceLibSm3.inf
+      PlatformTcgEventLogLib|SecurityPkg/Library/DxePlatformTcgEventLogLibNull/DxePlatformTcgEventLogLibNull.inf
   }
   SecurityPkg/Tcg/Tcg2Config/Tcg2ConfigDxe.inf
 !if $(TPM1_ENABLE) == TRUE

--- a/OvmfPkg/RiscVVirt/RiscVVirtQemu.dsc
+++ b/OvmfPkg/RiscVVirt/RiscVVirtQemu.dsc
@@ -477,6 +477,7 @@
       NULL|SecurityPkg/Library/HashInstanceLibSha384/HashInstanceLibSha384.inf
       NULL|SecurityPkg/Library/HashInstanceLibSha512/HashInstanceLibSha512.inf
       NULL|SecurityPkg/Library/HashInstanceLibSm3/HashInstanceLibSm3.inf
+      PlatformTcgEventLogLib|SecurityPkg/Library/DxePlatformTcgEventLogLibNull/DxePlatformTcgEventLogLibNull.inf
   }
 !if $(TPM2_CONFIG_ENABLE) == TRUE
   SecurityPkg/Tcg/Tcg2Config/Tcg2ConfigDxe.inf

--- a/SecurityPkg/Include/Library/PlatformTcgEventLogLib.h
+++ b/SecurityPkg/Include/Library/PlatformTcgEventLogLib.h
@@ -1,0 +1,38 @@
+/** @file
+  Definitions of TCG platform event log library.
+
+  Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef PLATFORM_TCG_EVENT_LOG_LIB_H_
+#define PLATFORM_TCG_EVENT_LOG_LIB_H_
+
+/**
+  This function returns the existence of platform specific TCG event
+  log.
+
+  @return TRUE  Platform specific TCG event log is exist.
+  @return FALSE Platform specific TCG event log is not exist.
+**/
+BOOLEAN
+PlatformTcgEventLogProvided (
+  VOID
+  );
+
+/**
+  Platform implementation of setting up TCG event log before combining
+  with PEI TCG event log from HOB.
+
+  @retval  EFI_SUCCESS      TCG event log is setup successfully.
+  @retval  EFI_UNSUPPORTED  No platform-specific implementation of
+                            seting up TCG event log.
+  @retval  Otherwise        Some other erros.
+**/
+EFI_STATUS
+PlatformTcgSetupEventLog (
+  VOID
+  );
+
+#endif

--- a/SecurityPkg/Library/DxePlatformTcgEventLogLibNull/DxePlatformTcgEventLogLibNull.inf
+++ b/SecurityPkg/Library/DxePlatformTcgEventLogLibNull/DxePlatformTcgEventLogLibNull.inf
@@ -1,0 +1,30 @@
+## @file
+#  NULL TCG platform event log library that provides the additional
+#  TCG event log.
+#
+#  Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = DxePlatformTcgEventLogLibNull
+  MODULE_UNI_FILE                = PlatformTcgEventLogLibNull.uni
+  FILE_GUID                      = B9B7C73C-D150-41AC-AD10-D9A8B8912C0C
+  MODULE_TYPE                    = DXE_DRIVER
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = PlatformTcgEventLogLib|DXE_DRIVER
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64 EBC
+#
+
+[Sources]
+  PlatformTcgEventLogLibNull.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  SecurityPkg/SecurityPkg.dec

--- a/SecurityPkg/Library/DxePlatformTcgEventLogLibNull/PlatformTcgEventLogLibNull.c
+++ b/SecurityPkg/Library/DxePlatformTcgEventLogLibNull/PlatformTcgEventLogLibNull.c
@@ -1,0 +1,39 @@
+/** @file
+  NULL TCG platform event log library that provides the additional TCG event log.
+
+  Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+/**
+  This function returns the existence of platform specific TCG event
+  log.
+
+  @return TRUE  Platform specific TCG event log is exist.
+  @return FALSE Platform specific TCG event log is not exist.
+**/
+BOOLEAN
+PlatformTcgEventLogProvided (
+  VOID
+  )
+{
+  return FALSE;
+}
+
+/**
+  Platform implementation of setting up TCG event log before combining
+  with PEI TCG event log from HOB.
+
+  @retval  EFI_SUCCESS      TCG event log is setup successfully.
+  @retval  EFI_UNSUPPORTED  No platform-specific implementation of
+                            seting up TCG event log.
+  @retval  Otherwise        Some other erros.
+**/
+EFI_STATUS
+PlatformTcgSetupEventLog (
+  VOID
+  )
+{
+  return EFI_UNSUPPORTED;
+}

--- a/SecurityPkg/Library/DxePlatformTcgEventLogLibNull/PlatformTcgEventLogLibNull.uni
+++ b/SecurityPkg/Library/DxePlatformTcgEventLogLibNull/PlatformTcgEventLogLibNull.uni
@@ -1,0 +1,13 @@
+// /** @file
+// NULL TCG platform event log library that provides the additional TCG event log
+//
+// Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+// **/
+
+#string STR_MODULE_ABSTRACT             #language en-US "NULL TCG platform event log library that provides the additional TCG event log"
+
+#string STR_MODULE_DESCRIPTION          #language en-US "NULL TCG platform event log library that provides the additional TCG event log."
+

--- a/SecurityPkg/SecurityPkg.dec
+++ b/SecurityPkg/SecurityPkg.dec
@@ -8,6 +8,7 @@
 # Copyright (c) 2009 - 2024, Intel Corporation. All rights reserved.<BR>
 # (C) Copyright 2015 Hewlett Packard Enterprise Development LP <BR>
 # Copyright (c) Microsoft Corporation.<BR>
+# Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -104,6 +105,10 @@
   ##  @libraryclass Perform SPDM (following SPDM spec) and measure data to TPM (following TCG PFP spec).
   ##
   SpdmSecurityLib|Include/Library/SpdmSecurityLib.h
+
+  ##  @libraryclass Provides platform-specific TCG event log
+  ##
+  DxePlatformTcgEventLogLib|Include/Library/DxePlatformTcgEventLogLib.h
 
 [Guids]
   ## Security package token space guid.

--- a/SecurityPkg/SecurityPkg.dsc
+++ b/SecurityPkg/SecurityPkg.dsc
@@ -5,6 +5,7 @@
 # (C) Copyright 2015-2020 Hewlett Packard Enterprise Development LP<BR>
 # Copyright (c) 2022, Loongson Technology Corporation Limited. All rights reserved.<BR>
 # Copyright (c) 2021 - 2022, Arm Limited. All rights reserved.<BR>
+# Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -145,6 +146,7 @@
   Tpm12DeviceLib|SecurityPkg/Library/Tpm12DeviceLibTcg/Tpm12DeviceLibTcg.inf
   Tpm2DeviceLib|SecurityPkg/Library/Tpm2DeviceLibTcg2/Tpm2DeviceLibTcg2.inf
   FileExplorerLib|MdeModulePkg/Library/FileExplorerLib/FileExplorerLib.inf
+  PlatformTcgEventLogLib|SecurityPkg/Library/DxePlatformTcgEventLogLibNull/DxePlatformTcgEventLogLibNull.inf
 
 [LibraryClasses.common.UEFI_DRIVER, LibraryClasses.common.DXE_RUNTIME_DRIVER, LibraryClasses.common.DXE_SAL_DRIVER,]
   HobLib|MdePkg/Library/DxeHobLib/DxeHobLib.inf
@@ -286,6 +288,7 @@
   SecurityPkg/Library/Tcg2PpVendorLibNull/Tcg2PpVendorLibNull.inf
   SecurityPkg/Library/TcgPpVendorLibNull/TcgPpVendorLibNull.inf
   SecurityPkg/Library/TcgEventLogRecordLib/TcgEventLogRecordLib.inf
+  SecurityPkg/Library/DxePlatformTcgEventLogLibNull/DxePlatformTcgEventLogLibNull.inf
 
 [Components.IA32, Components.X64, Components.ARM, Components.AARCH64]
   SecurityPkg/Library/AuthVariableLib/AuthVariableLib.inf

--- a/SecurityPkg/Tcg/Tcg2Dxe/Tcg2Dxe.inf
+++ b/SecurityPkg/Tcg/Tcg2Dxe/Tcg2Dxe.inf
@@ -17,6 +17,7 @@
 #  buffer overflow, integer overflow.
 #
 # Copyright (c) 2015 - 2024, Intel Corporation. All rights reserved.<BR>
+# Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -64,6 +65,7 @@
   ReportStatusCodeLib
   Tcg2PhysicalPresenceLib
   PeCoffLib
+  PlatformTcgEventLogLib
 
 [Guids]
   ## SOMETIMES_CONSUMES     ## Variable:L"SecureBoot"


### PR DESCRIPTION
# Description
Introduce a platform-level library that facilitates the platform-specific implementation to provide and initiate TCG event log area with the event logs created before PEI phase.  In AMD use case, we have the TCG event log before the X86 phase.

- [X ] Breaking change?
  - **Breaking change** - Will this cause a break in build or boot behavior?
    The platform may be built failed as TcgDxe has a dependency with DxePlatformTcgEventLogLib.
Currently, only Intel Quark and Vlv2TbltDevice have the reference of TcgDxe under edk2-platforms. However, these two 
platforms can not be built successfully even without the changes provided in this PR. I think these two platforms are not in maintenance. We can merge this PR with the approval and go back to update the DSC files of Intel platforms on edk2-platforms. 

- [ ] Impacts security?
   No
- [ ] Includes tests?
  Tested on AMD server platform

## How This Was Tested
Tested on AMD server platform

## Integration Instructions
A NULL instance is provided for the platform if they don't have the platform-specific implementation on TCG event log. Platform-level implementation is provided if the platform has its own TCG event log before PEI phase.
