### PR TITLE
Fix bugs in LoongArch64

### DIFF
--- a/MdePkg/Library/BaseLib/LoongArch64/Cpucfg.S
+++ b/MdePkg/Library/BaseLib/LoongArch64/Cpucfg.S
@@ -20,7 +20,7 @@ ASM_GLOBAL ASM_PFX(AsmCpucfg)
 
 ASM_PFX(AsmCpucfg):
   cpucfg  $t0, $a0
-  stptr.d $t0, $a1, 0
+  stptr.w $t0, $a1, 0
 
   jirl    $zero, $ra, 0
   .end

--- a/UefiCpuPkg/Library/CpuExceptionHandlerLib/LoongArch/LoongArch64/ExceptionHandlerAsm.S
+++ b/UefiCpuPkg/Library/CpuExceptionHandlerLib/LoongArch/LoongArch64/ExceptionHandlerAsm.S
@@ -34,6 +34,7 @@ PopContext:
   //
   bl      DisableInterrupts
 
+  move    $a0, $s0                // Restore a0 parameter through s0(EFI_SYSTEM_CONTEXT)
   bl      GetExceptionType        // Get current exception type, and stored in register a0
 
   // Check whether the FPE is changed during interrupt handler, if ture restore it.


### PR DESCRIPTION
UefiCpuPkg/ExceptionHandler: Fix a context error in LoongArch64
On the LoongArch platform:
 the a0 register can be used as both a function parameter and a return value.

Due to parameter EFI_SYSTEM_CONTEXT being overwritten by an invalid context address,
when calling GetExceptionType, incorrect parameter address causes memory access exception.

BZ: https://bugzilla.tianocore.org/show_bug.cgi?id=4796

Cc: Chao Li <lichao@loongson.cn>
Signed-off-by: Dongyan Qian <qiandongyan@loongson.cn>
...
MdePkg/BaseLib: Fix an instruction write width error in LoongArch64
Cpucfg fetch is a 32-bit register, and AsmCpucfg's function
 declaration is a 32-bit address storage operation in BaseLib.h,
So, fix it by replacing stptr.d with stptr.w instrcution.

BZ: https://bugzilla.tianocore.org/show_bug.cgi?id=4797

Cc: Chao Li <lichao@loongson.cn>
Signed-off-by: Dongyan Qian <qiandongyan@loongson.cn>
Co-authored-by: Chao Li <lichao@loongson.cn>
...

# Description

<_Include a description of the change and why this change was made._>

<_For each item, place an "x" in between `[` and `]` if true. Example: `[x]` (you can also check items in GitHub UI)_>

<_Create the PR as a Draft PR if it is only created to run CI checks._>

<_Delete lines in \<\> tags before creating the PR._>

- [ ] Breaking change?
  - **Breaking change** - Will this cause a break in build or boot behavior?
  - Examples: Add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

<_Describe the test(s) that were run to verify the changes._>

## Integration Instructions

<_Describe how these changes should be integrated. Use N/A if nothing is required._>
