### PR TITLE
DynamicTablesPkg: Add HexDump for CM Object parser

### DIFF
--- a/DynamicTablesPkg/Library/Common/TableHelperLib/ConfigurationManagerObjectParser.c
+++ b/DynamicTablesPkg/Library/Common/TableHelperLib/ConfigurationManagerObjectParser.c
@@ -16,7 +16,8 @@ VOID
 EFIAPI
 PrintString (
   CONST CHAR8  *Format,
-  UINT8        *Ptr
+  UINT8        *Ptr,
+  UINT32       Length
   );
 
 STATIC
@@ -24,31 +25,26 @@ VOID
 EFIAPI
 PrintStringPtr (
   CONST CHAR8  *Format,
-  UINT8        *Ptr
+  UINT8        *Ptr,
+  UINT32       Length
   );
 
 STATIC
 VOID
 EFIAPI
-PrintChar4 (
+PrintChars (
   CONST CHAR8  *Format,
-  UINT8        *Ptr
+  UINT8        *Ptr,
+  UINT32       Length
   );
 
 STATIC
 VOID
 EFIAPI
-PrintChar6 (
+HexDump (
   CONST CHAR8  *Format,
-  UINT8        *Ptr
-  );
-
-STATIC
-VOID
-EFIAPI
-PrintChar8 (
-  CONST CHAR8  *Format,
-  UINT8        *Ptr
+  UINT8        *Ptr,
+  UINT32       Length
   );
 
 /** A parser for EArmObjBootArchInfo.
@@ -785,20 +781,20 @@ STATIC CONST CM_OBJ_PARSER_ARRAY  ArmNamespaceObjectParser[] = {
 /** A parser for EStdObjCfgMgrInfo.
 */
 STATIC CONST CM_OBJ_PARSER  StdObjCfgMgrInfoParser[] = {
-  { "Revision", 4, "0x%x",         NULL       },
-  { "OemId[6]", 6, "%c%c%c%c%c%c", PrintChar6 }
+  { "Revision", 4, "0x%x", NULL       },
+  { "OemId[6]", 6, NULL,   PrintChars }
 };
 
 /** A parser for EStdObjAcpiTableList.
 */
 STATIC CONST CM_OBJ_PARSER  StdObjAcpiTableInfoParser[] = {
-  { "AcpiTableSignature", 4,                                      "%c%c%c%c",         PrintChar4 },
-  { "AcpiTableRevision",  1,                                      "%d",               NULL       },
-  { "TableGeneratorId",   sizeof (ACPI_TABLE_GENERATOR_ID),       "0x%x",             NULL       },
-  { "AcpiTableData",      sizeof (EFI_ACPI_DESCRIPTION_HEADER *), "0x%p",             NULL       },
-  { "OemTableId",         8,                                      "%c%c%c%c%c%c%c%c", PrintChar8 },
-  { "OemRevision",        4,                                      "0x%x",             NULL       },
-  { "MinorRevision",      1,                                      "0x%x",             NULL       },
+  { "AcpiTableSignature", 4,                                      NULL,   PrintChars },
+  { "AcpiTableRevision",  1,                                      "%d",   NULL       },
+  { "TableGeneratorId",   sizeof (ACPI_TABLE_GENERATOR_ID),       "0x%x", NULL       },
+  { "AcpiTableData",      sizeof (EFI_ACPI_DESCRIPTION_HEADER *), "0x%p", NULL       },
+  { "OemTableId",         8,                                      NULL,   PrintChars },
+  { "OemRevision",        4,                                      "0x%x", NULL       },
+  { "MinorRevision",      1,                                      "0x%x", NULL       },
 };
 
 /** A parser for EStdObjSmbiosTableList.
@@ -826,13 +822,15 @@ STATIC CONST CM_OBJ_PARSER_ARRAY  StdNamespaceObjectParser[] = {
 
   @param [in]  Format  Format to print the Ptr.
   @param [in]  Ptr     Pointer to the string.
+  @param [in]  Length  Length of the field
 **/
 STATIC
 VOID
 EFIAPI
 PrintString (
   IN CONST CHAR8  *Format,
-  IN UINT8        *Ptr
+  IN UINT8        *Ptr,
+  IN UINT32       Length
   )
 {
   if (Ptr == NULL) {
@@ -840,7 +838,7 @@ PrintString (
     return;
   }
 
-  DEBUG ((DEBUG_ERROR, "%a", Ptr));
+  DEBUG ((DEBUG_INFO, "%a", Ptr));
 }
 
 /** Print string from pointer.
@@ -849,13 +847,15 @@ PrintString (
 
   @param [in]  Format      Format to print the string.
   @param [in]  Ptr         Pointer to the string pointer.
+  @param [in]  Length      Length of the field
 **/
 STATIC
 VOID
 EFIAPI
 PrintStringPtr (
   IN CONST CHAR8  *Format,
-  IN UINT8        *Ptr
+  IN UINT8        *Ptr,
+  IN UINT32       Length
   )
 {
   UINT8  *String;
@@ -871,82 +871,51 @@ PrintStringPtr (
     String = (UINT8 *)"(NULLPTR)";
   }
 
-  PrintString (Format, String);
+  PrintString (Format, String, Length);
 }
 
-/** Print 4 characters.
+/** Print characters.
 
   @param [in]  Format  Format to print the Ptr.
   @param [in]  Ptr     Pointer to the characters.
+  @param [in]  Length  Length of the field
 **/
 STATIC
 VOID
 EFIAPI
-PrintChar4 (
+PrintChars (
   IN  CONST CHAR8  *Format,
-  IN  UINT8        *Ptr
+  IN  UINT8        *Ptr,
+  IN  UINT32       Length
   )
 {
-  DEBUG ((
-    DEBUG_ERROR,
-    (Format != NULL) ? Format : "%c%c%c%c",
-    Ptr[0],
-    Ptr[1],
-    Ptr[2],
-    Ptr[3]
-    ));
+  UINT32  Index;
+
+  for (Index = 0; Index < Length; Index++) {
+    DEBUG ((DEBUG_INFO, "%c", Ptr[Index]));
+  }
 }
 
-/** Print 6 characters.
+/** Dump data in Hex format
 
   @param [in]  Format  Format to print the Ptr.
-  @param [in]  Ptr     Pointer to the characters.
+  @param [in]  Ptr     Pointer to the string.
+  @param [in]  Length  Length of the field
 **/
 STATIC
 VOID
 EFIAPI
-PrintChar6 (
-  IN  CONST CHAR8  *Format,
-  IN  UINT8        *Ptr
+HexDump (
+  IN CONST CHAR8  *Format,
+  IN UINT8        *Ptr,
+  IN UINT32       Length
   )
 {
-  DEBUG ((
-    DEBUG_ERROR,
-    (Format != NULL) ? Format : "%c%c%c%c%c%c",
-    Ptr[0],
-    Ptr[1],
-    Ptr[2],
-    Ptr[3],
-    Ptr[4],
-    Ptr[5]
-    ));
-}
+  UINT32  Index;
 
-/** Print 8 characters.
-
-  @param [in]  Format  Format to print the Ptr.
-  @param [in]  Ptr     Pointer to the characters.
-**/
-STATIC
-VOID
-EFIAPI
-PrintChar8 (
-  IN  CONST CHAR8  *Format,
-  IN  UINT8        *Ptr
-  )
-{
-  DEBUG ((
-    DEBUG_ERROR,
-    (Format != NULL) ? Format : "%c%c%c%c%c%c%c%c",
-    Ptr[0],
-    Ptr[1],
-    Ptr[2],
-    Ptr[3],
-    Ptr[4],
-    Ptr[5],
-    Ptr[6],
-    Ptr[7]
-    ));
+  for (Index = 0; Index < Length; Index++) {
+    DEBUG ((DEBUG_INFO, "0x%02x ", *Ptr++));
+  }
 }
 
 /** Print fields of the objects.
@@ -1008,7 +977,7 @@ PrintCmObjDesc (
       Parser[Index].NameStr
       ));
     if (Parser[Index].PrintFormatter != NULL) {
-      Parser[Index].PrintFormatter (Parser[Index].Format, Data);
+      Parser[Index].PrintFormatter (Parser[Index].Format, Data, Parser[Index].Length);
     } else if (Parser[Index].Format != NULL) {
       switch (Parser[Index].Length) {
         case 1:

--- a/DynamicTablesPkg/Library/Common/TableHelperLib/ConfigurationManagerObjectParser.h
+++ b/DynamicTablesPkg/Library/Common/TableHelperLib/ConfigurationManagerObjectParser.h
@@ -16,8 +16,9 @@
   @param [in] Format  Format string for tracing the data as specified by
                       the 'Format' member of ACPI_PARSER.
   @param [in] Ptr     Pointer to the start of the buffer.
+  @param [in] Length  Length of the field
 **/
-typedef VOID (EFIAPI *FNPTR_PRINT_FORMATTER)(CONST CHAR8 *Format, UINT8 *Ptr);
+typedef VOID (EFIAPI *FNPTR_PRINT_FORMATTER)(CONST CHAR8 *Format, UINT8 *Ptr, UINT32 Length);
 
 /**
   The CM_OBJ_PARSER structure describes the fields of an CmObject and


### PR DESCRIPTION
# Description

Add helper function HexDump for printing hex dump of CM Object fields.

Also merge multiple flavors of PrintCharX into one function PrintChars by using the field length.

- [ ] Breaking change?
  - **Breaking change** - Will this cause a break in build or boot behavior?
  - Examples: Add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Called ParseCmObjDesc() and ensured that "AcpiTableSignature", "OemTableId", "OemId[6]" fields were printed correctly. And HexDump was tested by dumping the 12 bytes of TPM2 "StartMethodParameters".

## Integration Instructions

N/A
