### PR TITLE
MdePkg/Tdx.h: Fix the order of NumVcpus and MaxVcpus

### DIFF
--- a/MdePkg/Include/IndustryStandard/Tdx.h
+++ b/MdePkg/Include/IndustryStandard/Tdx.h
@@ -113,8 +113,8 @@ typedef struct {
 typedef struct {
   UINT64    Gpaw;
   UINT64    Attributes;
-  UINT32    MaxVcpus;
   UINT32    NumVcpus;
+  UINT32    MaxVcpus;
   UINT64    Resv[3];
 } TDCALL_INFO_RETURN_DATA;
 


### PR DESCRIPTION
# Description

Currently, TDX QEMU always configure TD_PARAMS.MAX_VCPUS as the number of actual vcpus it has created for the TD. 
So in the TDG.VP.INFO, the returned value of NUM_VCPUS and MAX_VCPUS in R8 are always same. 

However, TDX QEMU + KVM are going to set a big value for TD_PARAMS.MAX_VCPUS than actual created TD vcpus, which triggers the issue and find the bug.