### PR TITLE
AmdSev: enable kernel hashes without initrd

### DIFF
--- a/OvmfPkg/AmdSev/BlobVerifierLibSevHashes/BlobVerifierSevHashes.c
+++ b/OvmfPkg/AmdSev/BlobVerifierLibSevHashes/BlobVerifierSevHashes.c
@@ -156,16 +156,6 @@ VerifyBlob (
 
     DEBUG ((DEBUG_INFO, "%a: Found GUID %g in table\n", __func__, Guid));
 
-    if (BufSize == 0) {
-      DEBUG ((
-        DEBUG_ERROR,
-        "%a: Blob Specified in Hash Table was not Provided",
-        __func__
-        ));
-
-      CpuDeadLoop ();
-    }
-
     EntrySize = Entry->Len - sizeof Entry->Guid - sizeof Entry->Len;
     if (EntrySize != SHA256_DIGEST_SIZE) {
       DEBUG ((


### PR DESCRIPTION
#5769 does not allow for the situation where kernel hashes is used but an initrd is not provided. Thankfully it's easy to support this.

If kernel hashes are enabled but no initrd is provided, QEMU will still create an entry in the hash table, but it will be the hash of an empty buffer.

Remove the explicit check for the length of the blob. This logic will be handled by the later hash comparison, which will still fail when the blob is not present but is expected, but will pass when the blob is not present and the hash table contains a hash of an empty buffer.

cc: @bssrikanth @dubek @tlendacky @ardbiesheuvel @kraxel 