### PR TITLE
BaseTools: BinToPcd: Remove xdrlib dependency

### DIFF
--- a/BaseTools/Scripts/BinToPcd.py
+++ b/BaseTools/Scripts/BinToPcd.py
@@ -10,13 +10,12 @@ BinToPcd
 '''
 from __future__ import print_function
 
-import sys
 import argparse
-import re
-import xdrlib
 import io
-import struct
 import math
+import re
+import struct
+import sys
 
 #
 # Globals for help information


### PR DESCRIPTION
# Description

The xdrlib dependency was removed in commit 5cadb8ce2148979b6c464f6da5a8cd97425c5165 but the actual import of the module was not removed. This commit removes the import of xdrlib and sorts the imports. This will prevent a runtime error when xdrlib is eventually removed from python.

- [ ] Breaking change?
  - **Breaking change** - Will this cause a break in build or boot behavior?
  - Examples: Add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

No functional change.

## Integration Instructions

N/A
