### PR TITLE
.pytool: CompilerPlugin: Pass through build vars

### DIFF
--- a/.pytool/Plugin/CompilerPlugin/CompilerPlugin.py
+++ b/.pytool/Plugin/CompilerPlugin/CompilerPlugin.py
@@ -74,9 +74,10 @@ class CompilerPlugin(ICiBuildPlugin):
         self._env.SetValue("ACTIVE_PLATFORM", AP_Path, "Set in Compiler Plugin")
 
         # Parse DSC to check for SUPPORTED_ARCHITECTURES
+        build_target = self._env.GetValue("TARGET")
+        input_vars = self._env.GetAllBuildKeyValues(build_target)
         dp = DscParser()
-        dp.SetBaseAbsPath(Edk2pathObj.WorkspacePath)
-        dp.SetPackagePaths(Edk2pathObj.PackagePathList)
+        dp.SetEdk2Path(Edk2pathObj).SetInputVars(input_vars)
         dp.ParseFile(AP_Path)
         if "SUPPORTED_ARCHITECTURES" in dp.LocalVars:
             SUPPORTED_ARCHITECTURES = dp.LocalVars["SUPPORTED_ARCHITECTURES"].split('|')
@@ -85,7 +86,7 @@ class CompilerPlugin(ICiBuildPlugin):
             # Skip if there is no intersection between SUPPORTED_ARCHITECTURES and TARGET_ARCHITECTURES
             if len(set(SUPPORTED_ARCHITECTURES) & set(TARGET_ARCHITECTURES)) == 0:
                 tc.SetSkipped()
-                tc.LogStdError("No supported architecutres to build")
+                tc.LogStdError("No supported architectures to build")
                 return -1
 
         uefiBuilder = UefiBuilder()


### PR DESCRIPTION
# Description

Pass build variables (those passed to build.py through -D) to the DSC parser to provide a more accurate parsing of the DSC file.

- [ ] Breaking change?
  - **Breaking change** - Will this cause a break in build or boot behavior?
  - Examples: Add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Compiler plugin continues to successfully compile all packages.

## Integration Instructions

N/A
