### PR TITLE
BaseTools: build: Always log respfilelist.txt

### DIFF
--- a/BaseTools/Source/Python/build/build.py
+++ b/BaseTools/Source/Python/build/build.py
@@ -257,19 +257,24 @@ def LaunchCommand(Command, WorkingDir,ModuleAuto = None):
     if Proc.stdout:
         StdOutThread.join()
 
-    # check the return code of the program
-    if Proc.returncode != 0:
-        if not isinstance(Command, type("")):
-            Command = " ".join(Command)
-        # print out the Response file and its content when make failure
-        RespFile = os.path.join(WorkingDir, 'OUTPUT', 'respfilelist.txt')
-        if os.path.isfile(RespFile):
-            f = open(RespFile)
-            RespContent = f.read()
-            f.close()
-            EdkLogger.info(RespContent)
+    RespFile = os.path.join(WorkingDir, 'OUTPUT', 'respfilelist.txt')
+    if os.path.isfile(RespFile):
+        f = open(RespFile)
+        RespContent = f.read().splitlines()
+        f.close()
 
+        EdkLogger.info("Built with Respfile ... %s", WorkingDir)
+
+        for i in range(0, len(RespContent), 2):
+            cmd = RespContent[i]
+            cmd = cmd[cmd.find("OUTPUT")+7 : cmd.find("_resp.txt")]
+            flags = RespContent[i+1]
+            EdkLogger.info("  \"%s_FLAGS\" : %s" % (cmd.upper(), flags))
+
+    if Proc.returncode != 0:
+        Command = " ".join(Command)
         EdkLogger.error("build", COMMAND_FAILURE, ExtraData="%s [%s]" % (Command, WorkingDir))
+
     if ModuleAuto:
         iau = IncludesAutoGen(WorkingDir,ModuleAuto)
         if ModuleAuto.ToolChainFamily == TAB_COMPILER_MSFT:


### PR DESCRIPTION
# Description

Currently, the build flags located in the respfilelist.txt file (if it exists) are only logged if the command fails,. Thus, The typical log message for a build command that exceeds 4096 characters is the command itself, followed by the flag pointing at the respfilelist.txt. This makes a review of the build log harder than it needs to be. This commit changes the logic such that the build flags are always logged, making it easier to review the build logs, rather than needing to navigate to the respfilelist.txt file.

- [ ] Breaking change?
  - **Breaking change** - Will this cause a break in build or boot behavior?
  - Examples: Add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

This change has been used in a downstream consumer with no issues.

## Integration Instructions

N/A
