### PR TITLE
BaseTools: Detect library class mismatch

### DIFF
--- a/BaseTools/Source/Python/AutoGen/AutoGenWorker.py
+++ b/BaseTools/Source/Python/AutoGen/AutoGenWorker.py
@@ -218,6 +218,7 @@ class AutoGenWorkerInProcess(mp.Process):
             GlobalData.gEnableGenfdsMultiThread = self.data_pipe.Get("EnableGenfdsMultiThread")
             GlobalData.gPlatformFinalPcds = self.data_pipe.Get("gPlatformFinalPcds")
             GlobalData.file_lock = self.file_lock
+            GlobalData.gLogLibraryMismatch = False
             CommandTarget = self.data_pipe.Get("CommandTarget")
             pcd_from_build_option = []
             for pcd_tuple in self.data_pipe.Get("BuildOptPcd"):

--- a/BaseTools/Source/Python/Common/GlobalData.py
+++ b/BaseTools/Source/Python/Common/GlobalData.py
@@ -124,3 +124,4 @@ gSikpAutoGenCache = set()
 file_lock = None
 gStackCookieValues32 = []
 gStackCookieValues64 = []
+gLogLibraryMismatch = True

--- a/BaseTools/Source/Python/Workspace/DscBuildData.py
+++ b/BaseTools/Source/Python/Workspace/DscBuildData.py
@@ -40,6 +40,8 @@ from collections import OrderedDict, defaultdict
 import json
 import shutil
 
+LoggedLibraryWarnings = set()
+
 def _IsFieldValueAnArray (Value):
     Value = Value.strip()
     if Value.startswith(TAB_GUID) and Value.endswith(')'):
@@ -763,6 +765,12 @@ class DscBuildData(PlatformBuildClassObject):
                 LibraryPath = PathClass(NormPath(Record[1], Macros), GlobalData.gWorkspace, Arch=self._Arch)
                 LineNo = Record[-1]
 
+                # Validate that the Library instance implements the Library Class
+                if self._ShouldLogLibrary(LineNo) and not self._ValidateLibraryClass(LibraryClass, LibraryPath, self._Arch):
+                    EdkLogger.warn("build",
+                                   f"{str(LibraryPath)} does not support LIBRARY_CLASS {LibraryClass}",
+                                   File=self.MetaFile)
+
                 # check the file validation
                 ErrorCode, ErrorInfo = LibraryPath.Validate('.inf')
                 if ErrorCode != 0:
@@ -866,6 +874,13 @@ class DscBuildData(PlatformBuildClassObject):
                     EdkLogger.verbose("Found forced library for arch=%s\n\t%s [%s]" % (Arch, LibraryInstance, LibraryClass))
                 LibraryClassSet.add(LibraryClass)
                 LibraryInstance = PathClass(NormPath(LibraryInstance, Macros), GlobalData.gWorkspace, Arch=self._Arch)
+
+                # Validate that the Library instance implements the Library Class
+                if self._ShouldLogLibrary(LineNo) and not self._ValidateLibraryClass(LibraryClass, LibraryInstance, Arch):
+                    EdkLogger.warn("build",
+                                   f"{str(LibraryInstance)} does not support LIBRARY_CLASS {LibraryClass}",
+                                   File=self.MetaFile)
+
                 # check the file validation
                 ErrorCode, ErrorInfo = LibraryInstance.Validate('.inf')
                 if ErrorCode != 0:
@@ -1130,6 +1145,27 @@ class DscBuildData(PlatformBuildClassObject):
                         field_assign[TokenSpaceGuid, Token] = []
             for item in delete_assign:
                 GlobalData.BuildOptionPcd.remove(item)
+
+    def _ValidateLibraryClass(self, LibraryClass: str, LibraryInstance: PathClass, Arch: str) -> bool:
+        if LibraryClass.upper().startswith('NULL'):
+            return True
+
+        ParsedLibraryInfo = self._Bdb[LibraryInstance, Arch, self._Target, self._Toolchain]
+
+        for LibraryClassObject in ParsedLibraryInfo.LibraryClass:
+            if LibraryClassObject.LibraryClass == LibraryClass:
+                return True
+        return False
+
+    def _ShouldLogLibrary(self, LineNo) -> bool:
+        if not GlobalData.gLogLibraryMismatch:
+            return False
+
+        if LineNo in LoggedLibraryWarnings:
+            return False
+
+        LoggedLibraryWarnings.add(LineNo)
+        return True
 
     @staticmethod
     def HandleFlexiblePcd(TokenSpaceGuidCName, TokenCName, PcdValue, PcdDatumType, GuidDict, FieldName=''):


### PR DESCRIPTION
# Description

Performs a check that will verify that the library instance implements the library specified in the dsc by ensuring a LIBRARY_CLASS definition exists in the INF [Defines] section and the value matches the library it says it is implementing.

That is to say, for the following example:
`TestLib|Path/To/BaseTestLib.inf`, that BaseTestLib.inf has `LIBRARY_CLASS = TestLib` defined in the [Defines] section.

- [ ] Breaking change?
  - **Breaking change** - Will this cause a break in build or boot behavior?
  - Examples: Add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

<_Describe the test(s) that were run to verify the changes._>

## Integration Instructions

While no Integration is required, a new build warning will be seen in the build log. The warning is in the following format:
`$(DSC_PATH): warning: $(INF) does not support LIBRARY_CLASS $(LIBRARY_CLASS)` where `$(DSC_PATH)` is the DSC being built, `$(INF)` is the INF described in the DSC, and `$(LIBRARY_CLASS)` is the name of the library class that the INF is attempting to represent. (i.e., `$(LIBRARY_CLASS)|$(INF)` or `TestLib|Path\to\BaseTestLib.inf`).

To resolve these errors, verify the library class is real (The Library class should have a header file associated with it in the DEC of the defining package). If it is real, then ensure the library instance truly implements the library class and add it to the DEFINE section of the library INF. If not, update the DSC to use the correct library class.

If this warning appears, it will appear at the beginning of the build command:
Processing meta-data .
Architecture(s)  = IA32 X64
Build target     = DEBUG
Toolchain        = VS2019
Active Platform          = c:\src\Path\Platform.dsc
build...
c:\src\Path\Platform.dsc(...): warning: c:\src\Path\BaseTestLib.inf does not support LIBRARY_CLASS TestLib
