### PR TITLE
MdeModulePkg/SdMmcPciHcDxe: Support override for SD 1.8v signaling switch

### DIFF
--- a/MdeModulePkg/Bus/Pci/SdMmcPciHcDxe/SdMmcPciHci.h
+++ b/MdeModulePkg/Bus/Pci/SdMmcPciHcDxe/SdMmcPciHci.h
@@ -60,6 +60,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 //
 // SD Host Controller bits to HOST_CTRL2 register
 //
+#define SD_MMC_HC_CTRL_1V8_SIGNAL  0x0008
 #define SD_MMC_HC_CTRL_UHS_MASK    0x0007
 #define SD_MMC_HC_CTRL_UHS_SDR12   0x0000
 #define SD_MMC_HC_CTRL_UHS_SDR25   0x0001
@@ -551,6 +552,26 @@ SdMmcHcInitPowerVoltage (
   IN EFI_PCI_IO_PROTOCOL  *PciIo,
   IN UINT8                Slot,
   IN SD_MMC_HC_SLOT_CAP   Capability
+  );
+
+/**
+  Set the voltage regulator for I/O signaling.
+
+  @param[in] ControllerHandle   The handle of the controller.
+  @param[in] PciIo              The PCI IO protocol instance.
+  @param[in] Slot               The slot number of the SD card to send the command to.
+  @param[in] Voltage            The signaling voltage.
+
+  @retval EFI_SUCCESS           The voltage is set successfully.
+  @retval Others                The voltage isn't set successfully.
+
+**/
+EFI_STATUS
+SdMmcHcSetSignalingVoltage (
+  IN EFI_HANDLE                ControllerHandle,
+  IN EFI_PCI_IO_PROTOCOL       *PciIo,
+  IN UINT8                     Slot,
+  IN SD_MMC_SIGNALING_VOLTAGE  Voltage
   );
 
 /**

--- a/MdeModulePkg/Include/Protocol/SdMmcOverride.h
+++ b/MdeModulePkg/Include/Protocol/SdMmcOverride.h
@@ -16,7 +16,7 @@
 #define EDKII_SD_MMC_OVERRIDE_PROTOCOL_GUID \
   { 0xeaf9e3c1, 0xc9cd, 0x46db, { 0xa5, 0xe5, 0x5a, 0x12, 0x4c, 0x83, 0x23, 0x23 } }
 
-#define EDKII_SD_MMC_OVERRIDE_PROTOCOL_VERSION  0x3
+#define EDKII_SD_MMC_OVERRIDE_PROTOCOL_VERSION  0x4
 
 typedef struct _EDKII_SD_MMC_OVERRIDE EDKII_SD_MMC_OVERRIDE;
 
@@ -84,13 +84,19 @@ typedef enum {
 } SD_MMC_BUS_MODE;
 
 typedef enum {
+  SdMmcSignalingVoltage33,
+  SdMmcSignalingVoltage18
+} SD_MMC_SIGNALING_VOLTAGE;
+
+typedef enum {
   EdkiiSdMmcResetPre,
   EdkiiSdMmcResetPost,
   EdkiiSdMmcInitHostPre,
   EdkiiSdMmcInitHostPost,
   EdkiiSdMmcUhsSignaling,
   EdkiiSdMmcSwitchClockFreqPost,
-  EdkiiSdMmcGetOperatingParam
+  EdkiiSdMmcGetOperatingParam,
+  EdkiiSdMmcSetSignalingVoltage
 } EDKII_SD_MMC_PHASE_TYPE;
 
 /**


### PR DESCRIPTION
# Description

Some platforms (e.g. Raspberry Pi) have SDHCI implementations where the internal signaling voltage control isn't wired up and therefore needs to be set externally, in a non-standard way.

Power cycling the card to get it out of 1.8V is also kind of necessary, but for now it can be done in the Reset/InitHost phase override.

- [ ] Breaking change?
  - **Breaking change** - Will this cause a break in build or boot behavior?
  - Examples: Add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests or integration tests.
