### PR TITLE
MdeModulePkg/UefiBootManagerLib: Build proper SD/MMC boot descriptions

### DIFF
--- a/MdeModulePkg/Library/UefiBootManagerLib/InternalBm.h
+++ b/MdeModulePkg/Library/UefiBootManagerLib/InternalBm.h
@@ -18,6 +18,8 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <IndustryStandard/Atapi.h>
 #include <IndustryStandard/Scsi.h>
 #include <IndustryStandard/Nvme.h>
+#include <IndustryStandard/Sd.h>
+#include <IndustryStandard/Emmc.h>
 
 #include <Protocol/PciRootBridgeIo.h>
 #include <Protocol/BlockIo.h>


### PR DESCRIPTION
# Description

This generates boot descriptions for SD/MMC devices in the form of:
  - "UEFI SanDisk SC128 2A2B1E4F SD Device"
  - "UEFI Samsung BJTD4R 7AB3A8DE eMMC User Data"

The manufacturer ID tables are a best-effort, collected from various places and personal testing. They're not complete and may be inaccurate for rebranded cards.

- [ ] Breaking change?
  - **Breaking change** - Will this cause a break in build or boot behavior?
  - Examples: Add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests or integration tests.