### PR TITLE
EmbeddedPkg/.ci.yaml: add temporary workaround ECC exception

### DIFF
--- a/EmbeddedPkg/EmbeddedPkg.ci.yaml
+++ b/EmbeddedPkg/EmbeddedPkg.ci.yaml
@@ -20,6 +20,7 @@
         ##     "<ErrorID>", "<KeyWord>"
         ## ]
         "ExceptionList": [
+            "1008", "Bălănică"
         ],
         ## Both file path and directory path are accepted.
         "IgnoreFiles": []


### PR DESCRIPTION
A new contributor has a name not describable by the character set developed for 1960s US teleprinters, causing the CI to object and blocking their code from being merged due to the copyright statement.

While we do want to keep the code clean from characters other contributors cannot trivially reproduce, this should not extend to requiring intentionally misstating legal claims.

Until we figure out the long-term fix, add an exception for the surname triggering the failure.