### PR TITLE
EmbeddedPkg/VirtualRealTimeClockLib: Support SOURCE_DATE_EPOCH

### DIFF
--- a/EmbeddedPkg/Library/VirtualRealTimeClockLib/VirtualRealTimeClockLib.inf
+++ b/EmbeddedPkg/Library/VirtualRealTimeClockLib/VirtualRealTimeClockLib.inf
@@ -34,4 +34,4 @@
 
 # Current usage of this library expects GCC in a UNIX-like shell environment with the date command
 [BuildOptions]
-  GCC:*_*_*_CC_FLAGS = -DBUILD_EPOCH=`date +%s`
+  GCC:*_*_*_CC_FLAGS = -DBUILD_EPOCH=`printenv SOURCE_DATE_EPOCH || date +%s`


### PR DESCRIPTION
RISC-V ovmf used VirtualRealTimeClockLib but the default epoch is a compilation time. It causes that the RISC-V ovmf binary image is NOT reproducible.

This patch added the support of SOURCE_DATE_EPOCH by printenv command. If SOURCE_DATE_EPOCH be found then we use it as BUILD_EPOCH. Otherwise we run date command for setting BUILD_EPOCH.

For distributions want a reproducible RISC-V ovmf image, they should export SOURCE_DATE_EPOCH environment variable before building ovmf.

References: https://reproducible-builds.org/docs/source-date-epoch/
Cc: Pete Batard <pete@akeo.ie>
Cc: Ard Biesheuvel <ard.biesheuvel@linaro.org>