### PR TITLE
StandaloneMmPkg: Fix section data length returned larger than actual size

### DIFF
--- a/StandaloneMmPkg/Include/Library/FvLib.h
+++ b/StandaloneMmPkg/Include/Library/FvLib.h
@@ -87,7 +87,7 @@ FindFfsSectionInSections (
   @param  FfsFileHeader   Pointer to the current file to search.
   @param  SectionData     Pointer to the Section matching SectionType in FfsFileHeader.
                           NULL if section not found
-  @param  SectionDataSize The size of SectionData
+  @param  SectionDataSize The size of SectionData, excluding the section header.
 
   @retval  EFI_NOT_FOUND  No files matching the search criteria were found
   @retval  EFI_SUCCESS

--- a/StandaloneMmPkg/Library/FvLib/FvLib.c
+++ b/StandaloneMmPkg/Library/FvLib/FvLib.c
@@ -338,11 +338,11 @@ FfsFindSection (
   Given the input file pointer, search for the next matching section in the
   FFS volume.
 
-  @param  SearchType      Filter to find only sections of this type.
-  @param  FfsFileHeader   Pointer to the current file to search.
-  @param  SectionData     Pointer to the Section matching SectionType in FfsFileHeader.
-                          NULL if section not found
-  @param  SectionDataSize The size of SectionData
+  @param[in]      SectionType     Filter to find only sections of this type.
+  @param[in]      FfsFileHeader   Pointer to the current file to search.
+  @param[in,out]  SectionData     Pointer to the Section matching SectionType in FfsFileHeader.
+                                  NULL if section not found
+  @param[in,out]  SectionDataSize The size of SectionData, excluding the section header.
 
   @retval  EFI_NOT_FOUND  No files matching the search criteria were found
   @retval  EFI_SUCCESS
@@ -380,10 +380,10 @@ FfsFindSectionData (
     if (Section->Type == SectionType) {
       if (IS_SECTION2 (Section)) {
         *SectionData     = (VOID *)((EFI_COMMON_SECTION_HEADER2 *)Section + 1);
-        *SectionDataSize = SECTION2_SIZE (Section);
+        *SectionDataSize = SECTION2_SIZE (Section) - sizeof (EFI_COMMON_SECTION_HEADER2);
       } else {
         *SectionData     = (VOID *)(Section + 1);
-        *SectionDataSize = SECTION_SIZE (Section);
+        *SectionDataSize = SECTION_SIZE (Section) - sizeof (EFI_COMMON_SECTION_HEADER);
       }
 
       return EFI_SUCCESS;


### PR DESCRIPTION
# Description

Fixes an issue where the returned section data length is always 4 bytes larger than the actual section length. This could cause an issue where the caller accesses the final 4 bytes which would be invalid.

- [x] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

> Marked as a breaking change due to modifying the behavior for the
library API.

## How This Was Tested

- CI
- Verified size returned now matches the `SectionData` length

## Integration Instructions

- Review code to determine if `FvLib` is being used
- If so, check if the `FfsFindSectionData()` API is being used
  - If so, check usage of the `SectionDataSize` parameter in code
    to determine if a change needs to be made for the header size
    being removed from the size returned.