### PR TITLE
MdePkg/UefiDebugLibDebugPortProtocol: Make ExitBootServicesCallback() static

### DIFF
--- a/MdePkg/Library/UefiDebugLibDebugPortProtocol/DebugLibConstructor.c
+++ b/MdePkg/Library/UefiDebugLibDebugPortProtocol/DebugLibConstructor.c
@@ -34,9 +34,10 @@ EFI_BOOT_SERVICES  *mDebugBS;
   @param  Context      Pointer to the notification function's context.
 
 **/
+static
 VOID
 EFIAPI
-ExitBootServicesCallback (
+UefiDebugLibDebugPortProtocolExitBootServicesCallback (
   EFI_EVENT  Event,
   VOID       *Context
   )
@@ -67,7 +68,7 @@ DxeDebugLibConstructor (
   mDebugBS->CreateEvent (
               EVT_SIGNAL_EXIT_BOOT_SERVICES,
               TPL_NOTIFY,
-              ExitBootServicesCallback,
+              UefiDebugLibDebugPortProtocolExitBootServicesCallback,
               NULL,
               &mExitBootServicesEvent
               );


### PR DESCRIPTION
# Description

REF:https://bugzilla.tianocore.org/show_bug.cgi?id=3083

Since this is a library, make the function ExitBootServicesCallback() STATIC to prevent the likelihood that it collides with other symbols.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

- CI

## Integration Instructions

N/A