### PR TITLE
StandaloneMmPkg: Add MmServicesTableLib for MM_CORE_STANDALONE

### DIFF
--- a/StandaloneMmPkg/Library/StandaloneMmCoreMemoryAllocationLib/StandaloneMmCoreMemoryAllocationLib.c
+++ b/StandaloneMmPkg/Library/StandaloneMmCoreMemoryAllocationLib/StandaloneMmCoreMemoryAllocationLib.c
@@ -15,9 +15,8 @@
 #include <Library/BaseMemoryLib.h>
 #include <Library/DebugLib.h>
 #include <Library/HobLib.h>
+#include <Library/MmServicesTableLib.h>
 #include "StandaloneMmCoreMemoryAllocationServices.h"
-
-EFI_MM_SYSTEM_TABLE  *gMmst = NULL;
 
 /**
   Allocates one or more 4KB pages of a certain memory type.

--- a/StandaloneMmPkg/Library/StandaloneMmCoreMemoryAllocationLib/StandaloneMmCoreMemoryAllocationLib.inf
+++ b/StandaloneMmPkg/Library/StandaloneMmCoreMemoryAllocationLib/StandaloneMmCoreMemoryAllocationLib.inf
@@ -39,6 +39,7 @@
   BaseMemoryLib
   DebugLib
   HobLib
+  MmServicesTableLib
 
 [Guids]
   gEfiMmPeiMmramMemoryReserveGuid

--- a/StandaloneMmPkg/Library/StandaloneMmServicesTableLib/StandaloneMmServicesTableLibCore.c
+++ b/StandaloneMmPkg/Library/StandaloneMmServicesTableLib/StandaloneMmServicesTableLibCore.c
@@ -1,0 +1,13 @@
+/** @file
+  MM Services Table Library.
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <PiMm.h>
+#include <Library/MmServicesTableLib.h>
+#include <Library/DebugLib.h>
+
+EFI_MM_SYSTEM_TABLE  *gMmst = NULL;

--- a/StandaloneMmPkg/Library/StandaloneMmServicesTableLib/StandaloneMmServicesTableLibCore.inf
+++ b/StandaloneMmPkg/Library/StandaloneMmServicesTableLib/StandaloneMmServicesTableLibCore.inf
@@ -1,0 +1,25 @@
+## @file
+# Standalone MM Services Table Library.
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION                    = 0x0001001B
+  BASE_NAME                      = StandaloneMmServicesTableLibCore
+  FILE_GUID                      = A9E61A64-FDD4-4162-9321-C6769FB96E3B
+  MODULE_TYPE                    = MM_CORE_STANDALONE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = MmServicesTableLib|MM_CORE_STANDALONE
+  PI_SPECIFICATION_VERSION       = 0x00010032
+
+#
+#  VALID_ARCHITECTURES           = IA32 X64 ARM AARCH64
+#
+
+[Sources]
+  StandaloneMmServicesTableLibCore.c
+
+[Packages]
+  MdePkg/MdePkg.dec

--- a/StandaloneMmPkg/StandaloneMmPkg.dsc
+++ b/StandaloneMmPkg/StandaloneMmPkg.dsc
@@ -72,6 +72,7 @@
 
 [LibraryClasses.common.MM_CORE_STANDALONE]
   HobLib|StandaloneMmPkg/Library/StandaloneMmCoreHobLib/StandaloneMmCoreHobLib.inf
+  MmServicesTableLib|StandaloneMmPkg/Library/StandaloneMmServicesTableLib/StandaloneMmServicesTableLibCore.inf
 
 [LibraryClasses.common.MM_STANDALONE]
   MemoryAllocationLib|StandaloneMmPkg/Library/StandaloneMmMemoryAllocationLib/StandaloneMmMemoryAllocationLib.inf
@@ -117,6 +118,7 @@
   StandaloneMmPkg/Library/StandaloneMmMemLib/StandaloneMmMemLib.inf
   StandaloneMmPkg/Library/StandaloneMmMemoryAllocationLib/StandaloneMmMemoryAllocationLib.inf
   StandaloneMmPkg/Library/VariableMmDependency/VariableMmDependency.inf
+  StandaloneMmPkg/Library/StandaloneMmServicesTableLib/StandaloneMmServicesTableLibCore.inf
 
 [Components.AARCH64, Components.ARM]
   StandaloneMmPkg/Drivers/StandaloneMmCpu/StandaloneMmCpu.inf


### PR DESCRIPTION
# Description

Adds a `MmServicesTableLib` instance for the Standalone MM core that
uses an extern to link the `gMmst` to the global MM table, so
Standalone MM core libraries can use `gMmst` more generically.

This is used to remove the declaration of `gMmst` from the
Standalone MM Core `MemoryAllocationLib` instance in favor of using
the new Core MM Services Table library instance.

- [x] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

- CI
- Use `StandaloneMmServiceTableLibCore` on a X64 platform

## Integration Instructions

- If using Standalone MM, add an instance of `MmServicesTableLib` for `MM_CORE_STANDALONE`. The instance provided here is `StandaloneMmPkg/Library/StandaloneMmServicesTableLib/StandaloneMmServicesTableLibCore.inf`.