### PR TITLE
MdePkg/Nvme.h: Add missing NVMe capability descriptions

### DIFF
--- a/MdePkg/Include/IndustryStandard/Nvme.h
+++ b/MdePkg/Include/IndustryStandard/Nvme.h
@@ -54,16 +54,16 @@ typedef struct {
   UINT8     Cqr    : 1; // Contiguous Queues Required
   UINT8     Ams    : 2; // Arbitration Mechanism Supported
   UINT8     Rsvd1  : 5;
-  UINT8     To;     // Timeout
-  UINT16    Dstrd  : 4;
+  UINT8     To;         // Timeout
+  UINT16    Dstrd  : 4; // Doorbell Stride
   UINT16    Nssrs  : 1; // NVM Subsystem Reset Supported NSSRS
   UINT16    Css    : 8; // Command Sets Supported - Bit 37
   UINT16    Bps    : 1; // Boot Partition Support - Bit 45 in NVMe1.4
   UINT16    Rsvd3  : 2;
-  UINT8     Mpsmin : 4;
-  UINT8     Mpsmax : 4;
-  UINT8     Pmrs   : 1;
-  UINT8     Cmbs   : 1;
+  UINT8     Mpsmin : 4; // Memory Page Size Minimum
+  UINT8     Mpsmax : 4; // Memory Page Size Maximum
+  UINT8     Pmrs   : 1; // Persistent Memory Region Supported
+  UINT8     Cmbs   : 1; // Controller Memory Buffer Supported
   UINT8     Rsvd4  : 6;
 } NVME_CAP;
 


### PR DESCRIPTION
# Description

Most of the definitions in this file are currently well documented.

This adds documentation for a few missing fields in the NVMe Controller Capabilities structure.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

- CI

## Integration Instructions

N/A

---

> Note: This is a trivial change made while debugging a NVMe issue that has no functional impact.