### PR TITLE
MdeModulePkg/PciHostBridgeDxe: Ignore TypeIo for non X86/X64 architectures

### DIFF
--- a/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostBridge.c
+++ b/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostBridge.c
@@ -675,7 +675,7 @@ ResourceConflict (
        )
   {
     RootBridge = ROOT_BRIDGE_FROM_LINK (Link);
-    for (Index = TypeIo; Index < TypeMax; Index++) {
+    for (Index = PCI_RESOURCE_TYPE_ENUM_START; Index < TypeMax; Index++) {
       ResAllocNode = &RootBridge->ResAllocNode[Index];
 
       Descriptor->Desc         = ACPI_ADDRESS_SPACE_DESCRIPTOR;
@@ -918,7 +918,7 @@ NotifyPhase (
         RootBridge = ROOT_BRIDGE_FROM_LINK (Link);
         DEBUG ((DEBUG_INFO, " RootBridge: %s\n", RootBridge->DevicePathStr));
 
-        for (Index1 = TypeIo; Index1 < TypeBus; Index1++) {
+        for (Index1 = PCI_RESOURCE_TYPE_ENUM_START; Index1 < TypeBus; Index1++) {
           if (RootBridge->ResAllocNode[Index1].Status == ResNone) {
             ResNodeHandled[Index1] = TRUE;
           } else {
@@ -927,7 +927,7 @@ NotifyPhase (
             //
             MaxAlignment = 0;
             Index        = TypeMax;
-            for (Index2 = TypeIo; Index2 < TypeBus; Index2++) {
+            for (Index2 = PCI_RESOURCE_TYPE_ENUM_START; Index2 < TypeBus; Index2++) {
               if (ResNodeHandled[Index2]) {
                 continue;
               }
@@ -1132,7 +1132,7 @@ NotifyPhase (
            )
       {
         RootBridge = ROOT_BRIDGE_FROM_LINK (Link);
-        for (Index = TypeIo; Index < TypeBus; Index++) {
+        for (Index = PCI_RESOURCE_TYPE_ENUM_START; Index < TypeBus; Index++) {
           if (RootBridge->ResAllocNode[Index].Status == ResAllocated) {
             switch (Index) {
               case TypeIo:
@@ -1632,7 +1632,7 @@ GetProposedResources (
       }
 
       Descriptor = (EFI_ACPI_ADDRESS_SPACE_DESCRIPTOR *)Buffer;
-      for (Index = 0; Index < TypeBus; Index++) {
+      for (Index = PCI_RESOURCE_TYPE_ENUM_START; Index < TypeBus; Index++) {
         ResStatus = RootBridge->ResAllocNode[Index].Status;
         if (ResStatus != ResNone) {
           Descriptor->Desc    = ACPI_ADDRESS_SPACE_DESCRIPTOR;

--- a/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostResource.h
+++ b/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostResource.h
@@ -24,6 +24,12 @@ typedef enum {
   TypeMax
 } PCI_RESOURCE_TYPE;
 
+#if defined (MDE_CPU_IA32) || defined (MDE_CPU_X64)
+#define PCI_RESOURCE_TYPE_ENUM_START  TypeIo
+#else
+#define PCI_RESOURCE_TYPE_ENUM_START  TypeMem32
+#endif
+
 typedef enum {
   ResNone,
   ResSubmitted,

--- a/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciRootBridgeIo.c
+++ b/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciRootBridgeIo.c
@@ -219,7 +219,7 @@ CreateRootBridge (
   CopyMem (&RootBridge->PMem, &Bridge->PMem, sizeof (PCI_ROOT_BRIDGE_APERTURE));
   CopyMem (&RootBridge->PMemAbove4G, &Bridge->PMemAbove4G, sizeof (PCI_ROOT_BRIDGE_APERTURE));
 
-  for (Index = TypeIo; Index < TypeMax; Index++) {
+  for (Index = PCI_RESOURCE_TYPE_ENUM_START; Index < TypeMax; Index++) {
     switch (Index) {
       case TypeBus:
         Aperture = &RootBridge->Bus;
@@ -1889,7 +1889,7 @@ RootBridgeIoConfiguration (
     TypeMax * sizeof (EFI_ACPI_ADDRESS_SPACE_DESCRIPTOR) + sizeof (EFI_ACPI_END_TAG_DESCRIPTOR)
     );
   Descriptor = RootBridge->ConfigBuffer;
-  for (Index = TypeIo; Index < TypeMax; Index++) {
+  for (Index = PCI_RESOURCE_TYPE_ENUM_START; Index < TypeMax; Index++) {
     ResAllocNode = &RootBridge->ResAllocNode[Index];
 
     if (ResAllocNode->Status != ResAllocated) {


### PR DESCRIPTION
# Description

Throughout PciHostBridgeDxe, functions iterate through all entries in the `PCI_RESOURCE_TYPE` enum. However `TypeIo` only applies for x86_64 platforms and on platforms such as Arm, the driver may exit early if resources are not available.

This changes the starting point of the `PCI_RESOURCE_TYPE` enum iteration from `0` to `PCI_RESOURCE_TYPE_ENUM_START` and conditionally sets that value to `TypeIo` or `TypeMem32` based on whether the platform is x86_64 or not.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

- CI
- X64/AARCH64 platform boot

## Integration Instructions

N/A