### PR TITLE
MdeModulePkg: Require IOMMU protocol before DMA access

### DIFF
--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciIo.c
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciIo.c
@@ -1007,6 +1007,15 @@ PciIoMap (
       );
   }
 
+  // Attempt to find the IOMMU protocol in case it was installed late.
+  if (mIoMmuProtocol == NULL) {
+    gBS->LocateProtocol (
+           &gEdkiiIoMmuProtocolGuid,
+           NULL,
+           (VOID **)&mIoMmuProtocol
+           );
+  }
+
   if (mIoMmuProtocol != NULL) {
     if (!EFI_ERROR (Status)) {
       switch (Operation) {
@@ -1057,6 +1066,15 @@ PciIoUnmap (
   PCI_IO_DEVICE  *PciIoDevice;
 
   PciIoDevice = PCI_IO_DEVICE_FROM_PCI_IO_THIS (This);
+
+  // Attempt to find the IOMMU protocol in case it was installed late.
+  if (mIoMmuProtocol == NULL) {
+    gBS->LocateProtocol (
+           &gEdkiiIoMmuProtocolGuid,
+           NULL,
+           (VOID **)&mIoMmuProtocol
+           );
+  }
 
   if (mIoMmuProtocol != NULL) {
     mIoMmuProtocol->SetAttribute (

--- a/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostBridgeDxe.inf
+++ b/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostBridgeDxe.inf
@@ -39,6 +39,11 @@
   UefiLib
   PciHostBridgeLib
   TimerLib
+  PcdLib
+  ReportStatusCodeLib
+
+[FeaturePcd]
+  gEfiMdeModulePkgTokenSpaceGuid.PcdRequireIommu
 
 [Protocols]
   gEfiCpuIo2ProtocolGuid                          ## CONSUMES

--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -964,6 +964,13 @@
   # @Prompt Enable process non-reset capsule image at runtime.
   gEfiMdeModulePkgTokenSpaceGuid.PcdSupportProcessCapsuleAtRuntime|FALSE|BOOLEAN|0x00010079
 
+  ## Indicates if DMA can be accessed before thee IOMMU protocol is installed.<BR><BR>
+  #  If enabled, an assert and EFI_DEVICE_ERROR will be returned on DMA access prior to IOMMU protocol install.<BR><BR>
+  #   TRUE  - IOMMU protocol is required for DMA access.<BR>
+  #   FALSE - DMA access can occur before IOMMU protocol installation.<BR>
+  # @Prompt Enable DMA before IOMMU protocol.
+  gEfiMdeModulePkgTokenSpaceGuid.PcdRequireIommu|FALSE|BOOLEAN|0x0001007a
+
 [PcdsFeatureFlag.IA32, PcdsFeatureFlag.ARM, PcdsFeatureFlag.AARCH64, PcdsFeatureFlag.LOONGARCH64]
   gEfiMdeModulePkgTokenSpaceGuid.PcdPciDegradeResourceForOptionRom|FALSE|BOOLEAN|0x0001003a
 


### PR DESCRIPTION
# Description

Adds a PCD (`gEfiMdeModulePkgTokenSpaceGuid.PcdRequireIommu`) and support code to allow a platform to require that the IOMMU protocol be present before allowing PCI DMA operations to prevent DMA access prior to IOMMU initialization.

The default is `FALSE` for compatibility. It is recommended platforms set to `TRUE` and use the IOMMU protocol.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

- CI
- Platform that maps DMA with the IOMMU protocol installed

## Integration Instructions

If using DMA, ensure the IOMMU protocol is installed before mapping buffers and set the `PcdRequireIommu` PCD introduced to `TRUE`.

---

Please let me know if there's feedback on the default PCD value (whether it should be `TRUE` which is potentially a breaking change or `FALSE` for compatibility).