### PR TITLE
MdeModulePkg/SmiHandlerProfileInfo: Declare correct XML encoding

### DIFF
--- a/MdeModulePkg/Application/SmiHandlerProfileInfo/SmiHandlerProfileInfo.c
+++ b/MdeModulePkg/Application/SmiHandlerProfileInfo/SmiHandlerProfileInfo.c
@@ -667,7 +667,7 @@ SmiHandlerProfileInfoEntrypoint (
   //
   // Dump all image
   //
-  Print (L"<?xml version=\"1.0\" encoding=\"utf-8\"?>\n");
+  Print (L"<?xml version=\"1.0\" encoding=\"utf-16\"?>\n");
   Print (L"<SmiHandlerProfile>\n");
   Print (L"<ImageDatabase>\n");
   Print (L"  <!-- SMM image loaded -->\n");


### PR DESCRIPTION
# Description

The code prints wide strings, so the content should be "utf-16" rather than "utf-8".

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

- Check encoding declared vs actual

## Integration Instructions

N/A