### PR TITLE
Use Consistent MM Communicate Header Width

### DIFF
--- a/MdeModulePkg/Application/MemoryProfileInfo/MemoryProfileInfo.c
+++ b/MdeModulePkg/Application/MemoryProfileInfo/MemoryProfileInfo.c
@@ -1240,7 +1240,7 @@ GetSmramProfileData (
   CommRecordingState->Header.ReturnStatus = (UINT64)-1;
   CommRecordingState->RecordingState      = MEMORY_PROFILE_RECORDING_DISABLE;
 
-  CommSize = sizeof (EFI_GUID) + sizeof (UINTN) + CommHeader->MessageLength;
+  CommSize = OFFSET_OF (EFI_SMM_COMMUNICATE_HEADER, Data) + (UINTN)CommHeader->MessageLength;
   Status   = SmmCommunication->Communicate (SmmCommunication, CommBuffer, &CommSize);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "SmramProfile: SmmCommunication - %r\n", Status));
@@ -1264,7 +1264,7 @@ GetSmramProfileData (
     CommRecordingState->Header.ReturnStatus = (UINT64)-1;
     CommRecordingState->RecordingState      = MEMORY_PROFILE_RECORDING_DISABLE;
 
-    CommSize = sizeof (EFI_GUID) + sizeof (UINTN) + CommHeader->MessageLength;
+    CommSize = OFFSET_OF (EFI_SMM_COMMUNICATE_HEADER, Data) + (UINTN)CommHeader->MessageLength;
     SmmCommunication->Communicate (SmmCommunication, CommBuffer, &CommSize);
   }
 
@@ -1281,7 +1281,7 @@ GetSmramProfileData (
   CommGetProfileInfo->Header.ReturnStatus = (UINT64)-1;
   CommGetProfileInfo->ProfileSize         = 0;
 
-  CommSize = sizeof (EFI_GUID) + sizeof (UINTN) + CommHeader->MessageLength;
+  CommSize = OFFSET_OF (EFI_SMM_COMMUNICATE_HEADER, Data) + (UINTN)CommHeader->MessageLength;
   Status   = SmmCommunication->Communicate (SmmCommunication, CommBuffer, &CommSize);
   ASSERT_EFI_ERROR (Status);
 
@@ -1312,7 +1312,7 @@ GetSmramProfileData (
   CommGetProfileData->Header.DataLength   = sizeof (*CommGetProfileData);
   CommGetProfileData->Header.ReturnStatus = (UINT64)-1;
 
-  CommSize = sizeof (EFI_GUID) + sizeof (UINTN) + CommHeader->MessageLength;
+  CommSize = OFFSET_OF (EFI_SMM_COMMUNICATE_HEADER, Data) + (UINTN)CommHeader->MessageLength;
   Buffer   = (UINT8 *)CommHeader + CommSize;
   Size    -= CommSize;
 
@@ -1372,7 +1372,7 @@ Done:
     CommRecordingState->Header.ReturnStatus = (UINT64)-1;
     CommRecordingState->RecordingState      = MEMORY_PROFILE_RECORDING_ENABLE;
 
-    CommSize = sizeof (EFI_GUID) + sizeof (UINTN) + CommHeader->MessageLength;
+    CommSize = OFFSET_OF (EFI_SMM_COMMUNICATE_HEADER, Data) + (UINTN)CommHeader->MessageLength;
     SmmCommunication->Communicate (SmmCommunication, CommBuffer, &CommSize);
   }
 

--- a/MdeModulePkg/Application/SmiHandlerProfileInfo/SmiHandlerProfileInfo.c
+++ b/MdeModulePkg/Application/SmiHandlerProfileInfo/SmiHandlerProfileInfo.c
@@ -120,7 +120,7 @@ GetSmiHandlerProfileDatabase (
   CommGetInfo->Header.ReturnStatus = (UINT64)-1;
   CommGetInfo->DataSize            = 0;
 
-  CommSize = sizeof (EFI_GUID) + sizeof (UINTN) + CommHeader->MessageLength;
+  CommSize = OFFSET_OF (EFI_SMM_COMMUNICATE_HEADER, Data) + (UINTN)CommHeader->MessageLength;
   Status   = SmmCommunication->Communicate (SmmCommunication, CommBuffer, &CommSize);
   if (EFI_ERROR (Status)) {
     Print (L"SmiHandlerProfile: SmmCommunication - %r\n", Status);
@@ -153,7 +153,7 @@ GetSmiHandlerProfileDatabase (
   CommGetData->Header.DataLength   = sizeof (*CommGetData);
   CommGetData->Header.ReturnStatus = (UINT64)-1;
 
-  CommSize = sizeof (EFI_GUID) + sizeof (UINTN) + CommHeader->MessageLength;
+  CommSize = OFFSET_OF (EFI_SMM_COMMUNICATE_HEADER, Data) + (UINTN)CommHeader->MessageLength;
   Buffer   = (UINT8 *)CommHeader + CommSize;
   Size    -= CommSize;
 

--- a/MdeModulePkg/Core/PiSmmCore/PiSmmIpl.c
+++ b/MdeModulePkg/Core/PiSmmCore/PiSmmIpl.c
@@ -514,6 +514,7 @@ SmmCommunicationCommunicate (
   EFI_STATUS                  Status;
   EFI_SMM_COMMUNICATE_HEADER  *CommunicateHeader;
   BOOLEAN                     OldInSmm;
+  UINT64                      LongCommSize;
   UINTN                       TempCommSize;
 
   //
@@ -526,7 +527,15 @@ SmmCommunicationCommunicate (
   CommunicateHeader = (EFI_SMM_COMMUNICATE_HEADER *)CommBuffer;
 
   if (CommSize == NULL) {
-    TempCommSize = OFFSET_OF (EFI_SMM_COMMUNICATE_HEADER, Data) + CommunicateHeader->MessageLength;
+    Status = SafeUint64Add (OFFSET_OF (EFI_SMM_COMMUNICATE_HEADER, Data), CommunicateHeader->MessageLength, &LongCommSize);
+    if (EFI_ERROR (Status)) {
+      return EFI_INVALID_PARAMETER;
+    }
+
+    Status = SafeUint64ToUintn (LongCommSize, &TempCommSize);
+    if (EFI_ERROR (Status)) {
+      return EFI_INVALID_PARAMETER;
+    }
   } else {
     TempCommSize = *CommSize;
     //

--- a/MdePkg/Include/Protocol/MmCommunication.h
+++ b/MdePkg/Include/Protocol/MmCommunication.h
@@ -26,7 +26,7 @@ typedef struct {
   ///
   /// Describes the size of Data (in bytes) and does not include the size of the header.
   ///
-  UINTN       MessageLength;
+  UINT64      MessageLength;
   ///
   /// Designates an array of bytes that is MessageLength in size.
   ///

--- a/StandaloneMmPkg/Drivers/StandaloneMmCpu/EventHandle.c
+++ b/StandaloneMmPkg/Drivers/StandaloneMmCpu/EventHandle.c
@@ -268,7 +268,7 @@ PiMmCpuTpFwRootMmiHandler (
                     &PerCpuGuidedEventContext[CpuNumber]->HeaderGuid,
                     NULL,
                     PerCpuGuidedEventContext[CpuNumber]->Data,
-                    &PerCpuGuidedEventContext[CpuNumber]->MessageLength
+                    (UINTN)&PerCpuGuidedEventContext[CpuNumber]->MessageLength
                     );
 
   if (Status != EFI_SUCCESS) {


### PR DESCRIPTION
# Description

REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3398
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3430

These changes update references to the `MessageLength` field of
`EFI_MM_COMMUNICATE_HEADER` to use consistent integer width.

This structure can be used for both PEI and DXE MM communication.

Thus, for a system that supports PEI MM launch with a 32-bit PEI
environment and a 64-bit MM environment,  the current
`EFI_MM_COMMUNICATE_HEADER` definition will cause structure parse
error due to the use of `UINTN`.

- [x] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

> Marked as breaking due to a change in the definition of `EFI_MM_COMMUNICATE_HEADER`.

## How This Was Tested

- CI
- Verify MM communication with 32-bit PEI and 64-bit MM

## Integration Instructions

- Review any potential usage of `EFI_MM_COMMUNICATE_HEADER` to compensate
  for the `MessageLength` field being a `UINT64` instead of `UINTN`.