### PR TITLE
MdeModulePkg: Remove PeiAllocatePool() Assert

### DIFF
--- a/MdeModulePkg/Core/Pei/Memory/MemoryServices.c
+++ b/MdeModulePkg/Core/Pei/Memory/MemoryServices.c
@@ -862,8 +862,6 @@ PeiAllocatePool (
              (UINT16)(sizeof (EFI_HOB_MEMORY_POOL) + Size),
              (VOID **)&Hob
              );
-  ASSERT_EFI_ERROR (Status);
-
   if (EFI_ERROR (Status)) {
     *Buffer = NULL;
   } else {


### PR DESCRIPTION
# Description

Removes an assert if PeiAllocatePool() fails to allocate memory to defer error handling to the caller so the error can be handled gracefully or asserted at that location which is more specific to the call that led to the allocation.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

- CI
- Platform boot with change that includes calls to `PeiAllocatePool()`

## Integration Instructions

- N/A