### PR TITLE
MdeModulePkg/RuntimeResetSystemLib: Make global static

### DIFF
--- a/MdeModulePkg/Library/RuntimeResetSystemLib/RuntimeResetSystemLib.c
+++ b/MdeModulePkg/Library/RuntimeResetSystemLib/RuntimeResetSystemLib.c
@@ -12,8 +12,8 @@
 #include <Library/UefiBootServicesTableLib.h>
 #include <Library/DebugLib.h>
 
-EFI_EVENT             mRuntimeResetSystemLibVirtualAddressChangeEvent;
-EFI_RUNTIME_SERVICES  *mInternalRT;
+EFI_EVENT                    mRuntimeResetSystemLibVirtualAddressChangeEvent;
+static EFI_RUNTIME_SERVICES  *mInternalRT;
 
 /**
   This function causes a system-wide reset (cold reset), in which


### PR DESCRIPTION
# Description

Makes the `mInternalRT` global static in this library instance to avoid conflicting with other code such as a global variable with the same name in MdePkg/Library/UefiRuntimeLib.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

- CI

## Integration Instructions

- N/A