### PR TITLE
MdePkg/StmApi.h: Add SMM_REV_ID definition for STM header

### DIFF
--- a/MdePkg/Include/Register/Intel/StmApi.h
+++ b/MdePkg/Include/Register/Intel/StmApi.h
@@ -18,6 +18,8 @@
 
 #pragma pack (1)
 
+#define STM_SMM_REV_ID  0x80010100
+
 /**
   STM Header Structures
 **/


### PR DESCRIPTION
# Description

The `SMM_REV_ID` is defined in the STM specification: https://www.intel.com/content/www/us/en/content-details/671521/smi-transfer-monitor-stm-developer-or-user-guide.html?wapkw=stm, section 10.1.1.

This adds it into the `StmApi.h` for potential STM usage.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

- CI

## Integration Instructions

- N/A