### PR TITLE
MdeModulePkg/PciBusDxe: Remove assert when PCI enum is disabled

### DIFF
--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciDeviceSupport.c
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciDeviceSupport.c
@@ -772,7 +772,11 @@ StartPciDevices (
   LIST_ENTRY     *CurrentLink;
 
   RootBridge = GetRootBridgeByHandle (Controller);
-  ASSERT (RootBridge != NULL);
+  if (RootBridge == NULL) {
+    ASSERT (PcdGetBool (PcdPciDisableBusEnumeration));
+    return EFI_NOT_READY;
+  }
+
   ThisHostBridge = RootBridge->PciRootBridgeIo->ParentHandle;
 
   CurrentLink = mPciDevicePool.ForwardLink;


### PR DESCRIPTION
# Description

When setting PcdPciDisableBusEnumeration to TRUE, an assert is hit in StartPciDevices() due to the root bridge not existing. This is expected when skipping enumeration so change the assert to only trigger if enumeration is not disabled.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

- CI
- QEMU platform boot

## Integration Instructions

- N/A