### PR TITLE
BaseTools: Allow ascii exceptions for ECC

### DIFF
--- a/BaseTools/Source/Python/Ecc/Check.py
+++ b/BaseTools/Source/Python/Ecc/Check.py
@@ -181,7 +181,7 @@ class Check(object):
 
     # General Checking
     def GeneralCheck(self):
-        self.GeneralCheckNonAcsii()
+        self.GeneralCheckNonAscii()
         self.UniCheck()
         self.GeneralCheckNoTab()
         self.GeneralCheckLineEnding()
@@ -238,10 +238,10 @@ class Check(object):
                             OtherMsg = "File %s has trailing white spaces at line %s" % (Record[1], IndexOfLine)
                             EccGlobalData.gDb.TblReport.Insert(ERROR_GENERAL_CHECK_TRAILING_WHITE_SPACE_LINE, OtherMsg=OtherMsg, BelongsToTable='File', BelongsToItem=Record[0])
 
-    # Check whether file has non ACSII char
-    def GeneralCheckNonAcsii(self):
-        if EccGlobalData.gConfig.GeneralCheckNonAcsii == '1' or EccGlobalData.gConfig.GeneralCheckAll == '1' or EccGlobalData.gConfig.CheckAll == '1':
-            EdkLogger.quiet("Checking Non-ACSII char in file ...")
+    # Check whether file has non ASCII char
+    def GeneralCheckNonAscii(self):
+        if EccGlobalData.gConfig.GeneralCheckNonAscii == '1' or EccGlobalData.gConfig.GeneralCheckAll == '1' or EccGlobalData.gConfig.CheckAll == '1':
+            EdkLogger.quiet("Checking Non-ASCII char in file ...")
             SqlCommand = """select ID, FullPath, ExtName from File where ExtName in ('.dec', '.inf', '.dsc', 'c', 'h')"""
             RecordSet = EccGlobalData.gDb.TblFile.Exec(SqlCommand)
             for Record in RecordSet:
@@ -255,7 +255,7 @@ class Check(object):
                             IndexOfChar += 1
                             if ord(Char) > 126:
                                 OtherMsg = "File %s has Non-ASCII char at line %s column %s" % (Record[1], IndexOfLine, IndexOfChar)
-                                EccGlobalData.gDb.TblReport.Insert(ERROR_GENERAL_CHECK_NON_ACSII, OtherMsg=OtherMsg, BelongsToTable='File', BelongsToItem=Record[0])
+                                EccGlobalData.gDb.TblReport.Insert(ERROR_GENERAL_CHECK_NON_ASCII, OtherMsg=OtherMsg, BelongsToTable='File', BelongsToItem=Record[0])
 
     # C Function Layout Checking
     def FunctionLayoutCheck(self):

--- a/BaseTools/Source/Python/Ecc/Configuration.py
+++ b/BaseTools/Source/Python/Ecc/Configuration.py
@@ -59,7 +59,7 @@ _ConfigFileToInternalTranslation = {
     "GeneralCheckNoProgma":"GeneralCheckNoProgma",
     "GeneralCheckNoTab":"GeneralCheckNoTab",
     "GeneralCheckNo_Asm":"GeneralCheckNo_Asm",
-    "GeneralCheckNonAcsii":"GeneralCheckNonAcsii",
+    "GeneralCheckNonAscii":"GeneralCheckNonAscii",
     "GeneralCheckTabWidth":"GeneralCheckTabWidth",
     "GeneralCheckTrailingWhiteSpaceLine":"GeneralCheckTrailingWhiteSpaceLine",
     "GeneralCheckUni":"GeneralCheckUni",
@@ -179,8 +179,8 @@ class Configuration(object):
         self.GeneralCheckCarriageReturn = 1
         # Check whether the file exists
         self.GeneralCheckFileExistence = 1
-        # Check whether file has non ACSII char
-        self.GeneralCheckNonAcsii = 1
+        # Check whether file has non ASCII char
+        self.GeneralCheckNonAscii = 1
         # Check whether UNI file is valid
         self.GeneralCheckUni = 1
         # Check Only use CRLF (Carriage Return Line Feed) line endings.

--- a/BaseTools/Source/Python/Ecc/EccToolError.py
+++ b/BaseTools/Source/Python/Ecc/EccToolError.py
@@ -14,7 +14,7 @@ ERROR_GENERAL_CHECK_NO_ASM = 1004
 ERROR_GENERAL_CHECK_NO_PROGMA = 1005
 ERROR_GENERAL_CHECK_CARRIAGE_RETURN = 1006
 ERROR_GENERAL_CHECK_FILE_EXISTENCE = 1007
-ERROR_GENERAL_CHECK_NON_ACSII = 1008
+ERROR_GENERAL_CHECK_NON_ASCII = 1008
 ERROR_GENERAL_CHECK_UNI = 1009
 ERROR_GENERAL_CHECK_UNI_HELP_INFO = 1010
 ERROR_GENERAL_CHECK_INVALID_LINE_ENDING = 1011
@@ -113,7 +113,7 @@ gEccErrorMessage = {
     ERROR_GENERAL_CHECK_NO_PROGMA : """There should be no use of "#progma" in source file except "#pragma pack(#)\"""",
     ERROR_GENERAL_CHECK_CARRIAGE_RETURN : "There should be a carriage return at the end of the file",
     ERROR_GENERAL_CHECK_FILE_EXISTENCE : "File not found",
-    ERROR_GENERAL_CHECK_NON_ACSII : "File has invalid Non-ACSII char",
+    ERROR_GENERAL_CHECK_NON_ASCII : "File has invalid Non-ASCII char",
     ERROR_GENERAL_CHECK_UNI : "File is not a valid UTF-16 UNI file",
     ERROR_GENERAL_CHECK_UNI_HELP_INFO : "UNI file that is associated by INF or DEC file need define the prompt and help information.",
     ERROR_GENERAL_CHECK_INVALID_LINE_ENDING : "Only CRLF (Carriage Return Line Feed) is allowed to line ending.",

--- a/BaseTools/Source/Python/Ecc/config.ini
+++ b/BaseTools/Source/Python/Ecc/config.ini
@@ -62,8 +62,8 @@ GeneralCheckNoProgma = 1
 GeneralCheckCarriageReturn = 1
 # Check whether the file exists
 GeneralCheckFileExistence = 1
-# Check whether file has non ACSII char
-GeneralCheckNonAcsii = 1
+# Check whether file has non ASCII char
+GeneralCheckNonAscii = 1
 # Check whether UNI file is valid
 GeneralCheckUni = 1
 # Check Only use CRLF (Carriage Return Line Feed) line endings.


### PR DESCRIPTION
As part of trying to merge https://github.com/tianocore/edk2/pull/5840,
I realised ECC was not respecting the new exception I added to EmbeddedPkg
in order to pass CI.

So I did some digging in ECC, and first of all found "ascii" was consistently
misspelt throughout, so first a patch to fix that.

But then I also found it bails if it finds any non-7-bit characters without
even looking at the exceptions. So I added support for checking the exception
list. As part of that, the error reporting drops to one report per line.

I don't tend to write much python, and I'm sure someone who does could do it
more cleanly. Feedback very welcome.

@mariobalanica @mdkinney @makubacki 