### PR TITLE
SecurityPkg/Tcg2Acpi: Revise debug print

### DIFF
--- a/SecurityPkg/Tcg/Tcg2Acpi/Tcg2Acpi.c
+++ b/SecurityPkg/Tcg/Tcg2Acpi/Tcg2Acpi.c
@@ -641,7 +641,7 @@ UpdateHID (
         CopyMem (DataPtr, Hid, TPM_HID_ACPI_SIZE);
       }
 
-      DEBUG ((DEBUG_INFO, "TPM2 ACPI _HID is patched to %a\n", DataPtr));
+      DEBUG ((DEBUG_INFO, "TPM2 ACPI _HID is patched to %a\n", Hid));
 
       return Status;
     }


### PR DESCRIPTION
# Description

This debug print may attempt to print a string without a null terminator that can lead to a machine check.

The value printed is substituted with a source buffer to still allow debug.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

- Verified boot with code after the change

## Integration Instructions

- N/A