### PR TITLE
Add const keyword for the input parameter Data of BuildGuidDataHob

### DIFF
--- a/ArmVirtPkg/Library/ArmVirtDxeHobLib/HobLib.c
+++ b/ArmVirtPkg/Library/ArmVirtDxeHobLib/HobLib.c
@@ -374,7 +374,7 @@ VOID *
 EFIAPI
 BuildGuidDataHob (
   IN CONST EFI_GUID  *Guid,
-  IN VOID            *Data,
+  IN CONST VOID      *Data,
   IN UINTN           DataLength
   )
 {

--- a/EmbeddedPkg/Include/Library/PrePiLib.h
+++ b/EmbeddedPkg/Include/Library/PrePiLib.h
@@ -487,7 +487,7 @@ VOID *
 EFIAPI
 BuildGuidDataHob (
   IN CONST EFI_GUID  *Guid,
-  IN VOID            *Data,
+  IN CONST VOID      *Data,
   IN UINTN           DataLength
   );
 

--- a/EmbeddedPkg/Library/PrePiHobLib/Hob.c
+++ b/EmbeddedPkg/Library/PrePiHobLib/Hob.c
@@ -496,7 +496,7 @@ VOID *
 EFIAPI
 BuildGuidDataHob (
   IN CONST EFI_GUID  *Guid,
-  IN VOID            *Data,
+  IN CONST VOID      *Data,
   IN UINTN           DataLength
   )
 {

--- a/MdeModulePkg/Library/BaseHobLibNull/BaseHobLibNull.c
+++ b/MdeModulePkg/Library/BaseHobLibNull/BaseHobLibNull.c
@@ -320,7 +320,7 @@ VOID *
 EFIAPI
 BuildGuidDataHob (
   IN CONST EFI_GUID  *Guid,
-  IN VOID            *Data,
+  IN CONST VOID      *Data,
   IN UINTN           DataLength
   )
 {

--- a/MdePkg/Include/Library/HobLib.h
+++ b/MdePkg/Include/Library/HobLib.h
@@ -286,7 +286,7 @@ VOID *
 EFIAPI
 BuildGuidDataHob (
   IN CONST EFI_GUID  *Guid,
-  IN VOID            *Data,
+  IN CONST VOID      *Data,
   IN UINTN           DataLength
   );
 

--- a/MdePkg/Library/DxeCoreHobLib/HobLib.c
+++ b/MdePkg/Library/DxeCoreHobLib/HobLib.c
@@ -364,7 +364,7 @@ VOID *
 EFIAPI
 BuildGuidDataHob (
   IN CONST EFI_GUID  *Guid,
-  IN VOID            *Data,
+  IN CONST VOID      *Data,
   IN UINTN           DataLength
   )
 {

--- a/MdePkg/Library/DxeHobLib/HobLib.c
+++ b/MdePkg/Library/DxeHobLib/HobLib.c
@@ -399,7 +399,7 @@ VOID *
 EFIAPI
 BuildGuidDataHob (
   IN CONST EFI_GUID  *Guid,
-  IN VOID            *Data,
+  IN CONST VOID      *Data,
   IN UINTN           DataLength
   )
 {

--- a/MdePkg/Library/PeiHobLib/HobLib.c
+++ b/MdePkg/Library/PeiHobLib/HobLib.c
@@ -459,7 +459,7 @@ VOID *
 EFIAPI
 BuildGuidDataHob (
   IN CONST EFI_GUID  *Guid,
-  IN VOID            *Data,
+  IN CONST VOID      *Data,
   IN UINTN           DataLength
   )
 {

--- a/MdePkg/Test/Mock/Include/GoogleTest/Library/MockHobLib.h
+++ b/MdePkg/Test/Mock/Include/GoogleTest/Library/MockHobLib.h
@@ -86,7 +86,7 @@ struct MockHobLib {
     VOID *,
     BuildGuidDataHob,
     (IN CONST EFI_GUID  *Guid,
-     IN VOID            *Data,
+     IN CONST VOID      *Data,
      IN UINTN           DataLength)
     );
   MOCK_FUNCTION_DECLARATION (

--- a/StandaloneMmPkg/Library/StandaloneMmCoreHobLib/Arm/StandaloneMmCoreHobLib.c
+++ b/StandaloneMmPkg/Library/StandaloneMmCoreHobLib/Arm/StandaloneMmCoreHobLib.c
@@ -212,7 +212,7 @@ VOID *
 EFIAPI
 BuildGuidDataHob (
   IN CONST EFI_GUID  *Guid,
-  IN VOID            *Data,
+  IN CONST VOID      *Data,
   IN UINTN           DataLength
   )
 {

--- a/StandaloneMmPkg/Library/StandaloneMmCoreHobLib/X64/StandaloneMmCoreHobLib.c
+++ b/StandaloneMmPkg/Library/StandaloneMmCoreHobLib/X64/StandaloneMmCoreHobLib.c
@@ -142,7 +142,7 @@ VOID *
 EFIAPI
 BuildGuidDataHob (
   IN CONST EFI_GUID  *Guid,
-  IN VOID            *Data,
+  IN CONST VOID      *Data,
   IN UINTN           DataLength
   )
 {

--- a/StandaloneMmPkg/Library/StandaloneMmHobLib/StandaloneMmHobLib.c
+++ b/StandaloneMmPkg/Library/StandaloneMmHobLib/StandaloneMmHobLib.c
@@ -369,7 +369,7 @@ VOID *
 EFIAPI
 BuildGuidDataHob (
   IN CONST EFI_GUID  *Guid,
-  IN VOID            *Data,
+  IN CONST VOID      *Data,
   IN UINTN           DataLength
   )
 {

--- a/UefiPayloadPkg/Library/DxeHobLib/HobLib.c
+++ b/UefiPayloadPkg/Library/DxeHobLib/HobLib.c
@@ -364,7 +364,7 @@ VOID *
 EFIAPI
 BuildGuidDataHob (
   IN CONST EFI_GUID  *Guid,
-  IN VOID            *Data,
+  IN CONST VOID      *Data,
   IN UINTN           DataLength
   )
 {

--- a/UefiPayloadPkg/Library/PayloadEntryHobLib/Hob.c
+++ b/UefiPayloadPkg/Library/PayloadEntryHobLib/Hob.c
@@ -425,7 +425,7 @@ VOID *
 EFIAPI
 BuildGuidDataHob (
   IN CONST EFI_GUID  *Guid,
-  IN VOID            *Data,
+  IN CONST VOID      *Data,
   IN UINTN           DataLength
   )
 {


### PR DESCRIPTION
# Description

Add const keyword for the input parameter Data of BuildGuidDataHob.
It's to specify the input buffer pointed by Data pointer cannot be modified.

## How This Was Tested

Tested by tianocore edk2 CI