### PR TITLE
SecurityPkg/Tcg2Config: Cast pointer type to VOID* to avoid potential build error.

### DIFF
--- a/SecurityPkg/Tcg/Tcg2Config/Tcg2ConfigPeim.c
+++ b/SecurityPkg/Tcg/Tcg2Config/Tcg2ConfigPeim.c
@@ -190,7 +190,7 @@ Tcg2ConfigPeimEntryPoint (
   //
   Hob = BuildGuidDataHob (
           &gEdkiiTpmInstanceHobGuid,
-          PcdGetPtr (PcdTpmInstanceGuid),
+          (VOID *)PcdGetPtr (PcdTpmInstanceGuid),
           sizeof (EFI_GUID)
           );
   ASSERT (Hob != NULL);
@@ -200,7 +200,7 @@ Tcg2ConfigPeimEntryPoint (
   //
   Hob = BuildGuidDataHob (
           &gEdkiiTcgPhysicalPresenceInterfaceVerHobGuid,
-          PcdGetPtr (PcdTcgPhysicalPresenceInterfaceVer),
+          (VOID *)PcdGetPtr (PcdTcgPhysicalPresenceInterfaceVer),
           AsciiStrSize ((CHAR8 *)PcdGetPtr (PcdTcgPhysicalPresenceInterfaceVer))
           );
   ASSERT (Hob != NULL);


### PR DESCRIPTION
# Description

Cast pointer type to VOID* to avoid potential build error. If the two PCD are FixAtBuild, PcdGetPtr will return a const type pointer. Since the second parameter of BuildGuidDataHob is VOID*, build error may happen with following log: 
warning C4090: 'function': different 'const' qualifiers

## How This Was Tested

Tested by tianocore edk2 CI

