### PR TITLE
MdeModulePkg: Optimize PEI Core Migration Algorithm

### DIFF
--- a/MdeModulePkg/Core/Pei/PeiMain/PeiMain.c
+++ b/MdeModulePkg/Core/Pei/PeiMain/PeiMain.c
@@ -323,6 +323,21 @@ PeiCore (
       //
       OldCoreData->PeiMemoryInstalled = TRUE;
 
+      if (PcdGetBool (PcdMigrateTemporaryRamFirmwareVolumes)) {
+        DEBUG ((DEBUG_VERBOSE, "Early Migration - PPI lists before temporary RAM evacuation:\n"));
+        DumpPpiList (OldCoreData);
+
+        //
+        // Migrate installed content from Temporary RAM to Permanent RAM at this
+        // stage when PEI core still runs from a cached location.
+        // FVs that doesn't contain PEI_CORE should be migrated here.
+        //
+        EvacuateTempRam (OldCoreData, SecCoreData);
+
+        DEBUG ((DEBUG_VERBOSE, "Early Migration - PPI lists after temporary RAM evacuation:\n"));
+        DumpPpiList (OldCoreData);
+      }
+
       //
       // Indicate that PeiCore reenter
       //
@@ -451,6 +466,7 @@ PeiCore (
 
       //
       // Migrate installed content from Temporary RAM to Permanent RAM
+      // FVs containing PEI_CORE should be migrated here.
       //
       EvacuateTempRam (&PrivateData, SecCoreData);
 


### PR DESCRIPTION
REF : https://bugzilla.tianocore.org/show_bug.cgi?id=4750

Migrate the FV that doesn't contain the currently executing PEI Core when memory is initialized but PEI Core is still potentially running from faster memory. This may reduce the time required to migrate FVs to permanent memory. The FV containing PEI Core is migrated after the PEI Core reentry when it is executed from permanent memory.

This migration algorithm is only used for FVs specified in the gEdkiiMigrationInfoGuid HOB.

Signed-off-by: Awiral Shrivastava <awiral.shrivastava@intel.com>