### PR TITLE
[BZ-4653] MdeModulePkg/Core/DxeIplPeim: Enhance Code in DxeIplFindDxeCore Function

### DIFF
--- a/MdeModulePkg/Core/DxeIplPeim/DxeLoad.c
+++ b/MdeModulePkg/Core/DxeIplPeim/DxeLoad.c
@@ -3,7 +3,7 @@
   Responsibility of this module is to load the DXE Core from a Firmware Volume.
 
 Copyright (c) 2016 HP Development Company, L.P.
-Copyright (c) 2006 - 2019, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2006 - 2024, Intel Corporation. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -487,9 +487,9 @@ DxeIplFindDxeCore (
     //
     if (EFI_ERROR (Status)) {
       REPORT_STATUS_CODE (EFI_PROGRESS_CODE, (EFI_SOFTWARE_PEI_MODULE | EFI_SW_PEI_CORE_EC_DXE_CORRUPT));
+      ASSERT_EFI_ERROR (Status);
+      break;
     }
-
-    ASSERT_EFI_ERROR (Status);
 
     //
     // Find the DxeCore file type from the beginning in this firmware volume.
@@ -509,6 +509,13 @@ DxeIplFindDxeCore (
     //
     Instance++;
   }
+
+  //
+  // DxeCore cannot find in any firmware volume.
+  //
+  CpuDeadLoop ();
+
+  return NULL;
 }
 
 /**


### PR DESCRIPTION
# Description

- [Bugzilla#4653](https://bugzilla.tianocore.org/show_bug.cgi?id=4653)

- In DxeIplFindDxeCore function, there exists different behavior between Debug and Release built BIOS.
- This change is used to unify both of the code flow and fix the potential overflow of "Instance" variable.

- In this change,
  1. Move the ASSERT_EFI_ERROR (Status) in failure to find DxeCore in any firmware volume condition.
  2. Break the while-loop when not found required DxeCore. This would make the Instance variable not overflow in while-loop.
  3. Add the CpuDeadLoop () in the end of the function and do not return since DxeCore is mandatory for the following booting to hand-off the PEI phase to DXE phase.
  4. In case of the CpuDeadLoop () is de-assert by debugger, return the NULL pointer.

- [ ] Breaking change?
  - No, it is changed the internal function code flow within module only

- [X] Impacts security?
  - Yes, this change would make the "Instance" variable would not happen overflow when DxeCore not found

- [X] Includes tests?
  - Tested on QEMU platform, it is booting fine after the code change

## How This Was Tested

- Tested on QEMU platform without wrapping the DxeCore module.
- It is asserted in expected location and would reach break to escape from while-loop.

## Integration Instructions

- N/A
