### PR TITLE
IntelFsp2Pkg: Correcting Data Region Length of MCUD section

### DIFF
--- a/IntelFsp2Pkg/FspSecCore/SecFsp.c
+++ b/IntelFsp2Pkg/FspSecCore/SecFsp.c
@@ -53,7 +53,7 @@ SecGetPlatformData (
   FSP_PLAT_DATA  *FspPlatformData;
   UINT32         TopOfCar;
   UINT32         *StackPtr;
-  UINT32         DwordSize;
+  UINT32         DataSize;
   UINT32         TemporaryRamSize;
 
   FspPlatformData = &FspData->PlatformData;
@@ -89,22 +89,21 @@ SecGetPlatformData (
         //
         // This following data was pushed onto stack after TempRamInit API
         //
-        DwordSize = 4;
-        StackPtr  = StackPtr - 1 - DwordSize;
-        CopyMem (&(FspPlatformData->MicrocodeRegionBase), StackPtr, (DwordSize << 2));
-        StackPtr--;
+        DataSize  = *(StackPtr);
+        DataSize  = DataSize / sizeof (DataSize);
+        StackPtr -= DataSize;
+        CopyMem (&(FspPlatformData->MicrocodeRegionBase), StackPtr + 1, 4 * sizeof (UINTN));
       } else if (*(StackPtr - 1) == FSP_PER0_SIGNATURE) {
         //
         // This is the performance data for InitTempMemory API entry/exit
         //
-        DwordSize = 4;
-        StackPtr  = StackPtr - 1 - DwordSize;
-        CopyMem (FspData->PerfData, StackPtr, (DwordSize << 2));
+        DataSize  = *(StackPtr);
+        DataSize  = DataSize / sizeof (DataSize);
+        StackPtr -= DataSize;
+        CopyMem (FspData->PerfData, StackPtr + 1, 2 * sizeof (UINT64)); // Copy from the end of the PER0 data
 
         ((UINT8 *)(&FspData->PerfData[0]))[7] = FSP_PERF_ID_API_TEMP_RAM_INIT_ENTRY;
         ((UINT8 *)(&FspData->PerfData[1]))[7] = FSP_PERF_ID_API_TEMP_RAM_INIT_EXIT;
-
-        StackPtr--;
       } else {
         StackPtr -= (*StackPtr);
       }

--- a/IntelFsp2Pkg/FspSecCore/X64/FspApiEntryT.nasm
+++ b/IntelFsp2Pkg/FspSecCore/X64/FspApiEntryT.nasm
@@ -30,7 +30,7 @@ extern ASM_PFX(SecCarInit)
 ; Define the data length that we saved on the stack top
 ;
 DATA_LEN_OF_PER0         EQU   18h
-DATA_LEN_OF_MCUD         EQU   18h
+DATA_LEN_OF_MCUD         EQU   28h
 DATA_LEN_AT_STACK_TOP    EQU   (DATA_LEN_OF_PER0 + DATA_LEN_OF_MCUD + 4)
 
 ;


### PR DESCRIPTION
# Description

MCUD Data Region Length(DATA_LEN_OF_MCUD) pushed to stack is incorrect for 64-bit. This commit inputs the correct Data Region Length for the MCUD Section.

REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4793

- [ ] Breaking change?
  - **Breaking change** - Will this cause a break in build or boot behavior?
  - Examples: Add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

N/A

## Integration Instructions

N/A
