### PR TITLE
BaseTools: change non-ASCII characters in LinuxGcc5ToolChain.py

### DIFF
--- a/BaseTools/Plugin/LinuxGcc5ToolChain/LinuxGcc5ToolChain.py
+++ b/BaseTools/Plugin/LinuxGcc5ToolChain/LinuxGcc5ToolChain.py
@@ -99,7 +99,7 @@ class LinuxGcc5ToolChain(IUefiBuildPlugin):
         return 0
 
     def _check_riscv64(self):
-        # now check for install dir.  If set then set the Prefix
+        # now check for install dir.  If set then set the Prefix
         install_path = shell_environment.GetEnvironment(
         ).get_shell_var("GCC5_RISCV64_INSTALL")
         if install_path is None:


### PR DESCRIPTION
Commit ea56fa3d4706 ("BaseTools: Enable RISC-V architecture for RISC-V EDK2 CI") introduced a UTF-8 NBSP (0xc2a0) inside a comment block otherwise copied identically from pre-existing architectures. This was clearly unintentional and confuses things when looking for which files contain UTF-8 encodings, so change it to good old 0x20.

This change is non-functional.