### PR TITLE
RedfishPkg/RedfishPlatformConfigDxe: remove false alarm

### DIFF
--- a/RedfishPkg/RedfishPlatformConfigDxe/RedfishPlatformConfigDxe.c
+++ b/RedfishPkg/RedfishPlatformConfigDxe/RedfishPlatformConfigDxe.c
@@ -2483,7 +2483,7 @@ HiiStringProtocolInstalled (
                   (VOID **)&mRedfishPlatformConfigPrivate->HiiString
                   );
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: locate EFI_HII_STRING_PROTOCOL failure: %r\n", __func__, Status));
+    DEBUG ((DEBUG_INFO, "%a: locate EFI_HII_STRING_PROTOCOL failure: %r\n", __func__, Status));
     return;
   }
 
@@ -2518,7 +2518,7 @@ HiiDatabaseProtocolInstalled (
                   (VOID **)&mRedfishPlatformConfigPrivate->HiiDatabase
                   );
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: locate EFI_HII_DATABASE_PROTOCOL failure: %r\n", __func__, Status));
+    DEBUG ((DEBUG_INFO, "%a: locate EFI_HII_DATABASE_PROTOCOL failure: %r\n", __func__, Status));
     return;
   }
 
@@ -2581,7 +2581,7 @@ RegexProtocolInstalled (
                   (VOID **)&mRedfishPlatformConfigPrivate->RegularExpressionProtocol
                   );
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: locate EFI_REGULAR_EXPRESSION_PROTOCOL failure: %r\n", __func__, Status));
+    DEBUG ((DEBUG_INFO, "%a: locate EFI_REGULAR_EXPRESSION_PROTOCOL failure: %r\n", __func__, Status));
     return;
   }
 


### PR DESCRIPTION
# Description
Change the debug message level to DEBUG_INFO for protocol notification functions. The protocol notification function is invoked at least one time. The failure of locating protocol is expected because protocol may not be installed when Redfish platform config driver is launched.

Signed-off-by: Nickle Wang <nicklew@nvidia.com>

- [ ] Breaking change?
  - **Breaking change** - Will this cause a break in build or boot behavior?
  - Examples: Add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

N/A

## Integration Instructions

N/A
