### PR TITLE
BaseTools: Ecc disable ascii scan

### DIFF
--- a/BaseTools/Source/Python/Ecc/Check.py
+++ b/BaseTools/Source/Python/Ecc/Check.py
@@ -181,7 +181,6 @@ class Check(object):
 
     # General Checking
     def GeneralCheck(self):
-        self.GeneralCheckNonAscii()
         self.UniCheck()
         self.GeneralCheckNoTab()
         self.GeneralCheckLineEnding()
@@ -237,25 +236,6 @@ class Check(object):
                         if Line.replace('\r', '').replace('\n', '').endswith(' '):
                             OtherMsg = "File %s has trailing white spaces at line %s" % (Record[1], IndexOfLine)
                             EccGlobalData.gDb.TblReport.Insert(ERROR_GENERAL_CHECK_TRAILING_WHITE_SPACE_LINE, OtherMsg=OtherMsg, BelongsToTable='File', BelongsToItem=Record[0])
-
-    # Check whether file has non ASCII char
-    def GeneralCheckNonAscii(self):
-        if EccGlobalData.gConfig.GeneralCheckNonAscii == '1' or EccGlobalData.gConfig.GeneralCheckAll == '1' or EccGlobalData.gConfig.CheckAll == '1':
-            EdkLogger.quiet("Checking Non-ASCII char in file ...")
-            SqlCommand = """select ID, FullPath, ExtName from File where ExtName in ('.dec', '.inf', '.dsc', 'c', 'h')"""
-            RecordSet = EccGlobalData.gDb.TblFile.Exec(SqlCommand)
-            for Record in RecordSet:
-                if Record[2].upper() not in EccGlobalData.gConfig.BinaryExtList:
-                    op = open(Record[1]).readlines()
-                    IndexOfLine = 0
-                    for Line in op:
-                        IndexOfLine += 1
-                        IndexOfChar = 0
-                        for Char in Line:
-                            IndexOfChar += 1
-                            if ord(Char) > 126:
-                                OtherMsg = "File %s has Non-ASCII char at line %s column %s" % (Record[1], IndexOfLine, IndexOfChar)
-                                EccGlobalData.gDb.TblReport.Insert(ERROR_GENERAL_CHECK_NON_ASCII, OtherMsg=OtherMsg, BelongsToTable='File', BelongsToItem=Record[0])
 
     # C Function Layout Checking
     def FunctionLayoutCheck(self):

--- a/BaseTools/Source/Python/Ecc/Check.py
+++ b/BaseTools/Source/Python/Ecc/Check.py
@@ -181,7 +181,7 @@ class Check(object):
 
     # General Checking
     def GeneralCheck(self):
-        self.GeneralCheckNonAcsii()
+        self.GeneralCheckNonAscii()
         self.UniCheck()
         self.GeneralCheckNoTab()
         self.GeneralCheckLineEnding()
@@ -238,10 +238,10 @@ class Check(object):
                             OtherMsg = "File %s has trailing white spaces at line %s" % (Record[1], IndexOfLine)
                             EccGlobalData.gDb.TblReport.Insert(ERROR_GENERAL_CHECK_TRAILING_WHITE_SPACE_LINE, OtherMsg=OtherMsg, BelongsToTable='File', BelongsToItem=Record[0])
 
-    # Check whether file has non ACSII char
-    def GeneralCheckNonAcsii(self):
-        if EccGlobalData.gConfig.GeneralCheckNonAcsii == '1' or EccGlobalData.gConfig.GeneralCheckAll == '1' or EccGlobalData.gConfig.CheckAll == '1':
-            EdkLogger.quiet("Checking Non-ACSII char in file ...")
+    # Check whether file has non ASCII char
+    def GeneralCheckNonAscii(self):
+        if EccGlobalData.gConfig.GeneralCheckNonAscii == '1' or EccGlobalData.gConfig.GeneralCheckAll == '1' or EccGlobalData.gConfig.CheckAll == '1':
+            EdkLogger.quiet("Checking Non-ASCII char in file ...")
             SqlCommand = """select ID, FullPath, ExtName from File where ExtName in ('.dec', '.inf', '.dsc', 'c', 'h')"""
             RecordSet = EccGlobalData.gDb.TblFile.Exec(SqlCommand)
             for Record in RecordSet:
@@ -255,7 +255,7 @@ class Check(object):
                             IndexOfChar += 1
                             if ord(Char) > 126:
                                 OtherMsg = "File %s has Non-ASCII char at line %s column %s" % (Record[1], IndexOfLine, IndexOfChar)
-                                EccGlobalData.gDb.TblReport.Insert(ERROR_GENERAL_CHECK_NON_ACSII, OtherMsg=OtherMsg, BelongsToTable='File', BelongsToItem=Record[0])
+                                EccGlobalData.gDb.TblReport.Insert(ERROR_GENERAL_CHECK_NON_ASCII, OtherMsg=OtherMsg, BelongsToTable='File', BelongsToItem=Record[0])
 
     # C Function Layout Checking
     def FunctionLayoutCheck(self):

--- a/BaseTools/Source/Python/Ecc/Configuration.py
+++ b/BaseTools/Source/Python/Ecc/Configuration.py
@@ -59,7 +59,7 @@ _ConfigFileToInternalTranslation = {
     "GeneralCheckNoProgma":"GeneralCheckNoProgma",
     "GeneralCheckNoTab":"GeneralCheckNoTab",
     "GeneralCheckNo_Asm":"GeneralCheckNo_Asm",
-    "GeneralCheckNonAcsii":"GeneralCheckNonAcsii",
+    "GeneralCheckNonAscii":"GeneralCheckNonAscii",
     "GeneralCheckTabWidth":"GeneralCheckTabWidth",
     "GeneralCheckTrailingWhiteSpaceLine":"GeneralCheckTrailingWhiteSpaceLine",
     "GeneralCheckUni":"GeneralCheckUni",
@@ -179,8 +179,8 @@ class Configuration(object):
         self.GeneralCheckCarriageReturn = 1
         # Check whether the file exists
         self.GeneralCheckFileExistence = 1
-        # Check whether file has non ACSII char
-        self.GeneralCheckNonAcsii = 1
+        # Check whether file has non ASCII char
+        self.GeneralCheckNonAscii = 1
         # Check whether UNI file is valid
         self.GeneralCheckUni = 1
         # Check Only use CRLF (Carriage Return Line Feed) line endings.

--- a/BaseTools/Source/Python/Ecc/Configuration.py
+++ b/BaseTools/Source/Python/Ecc/Configuration.py
@@ -59,7 +59,6 @@ _ConfigFileToInternalTranslation = {
     "GeneralCheckNoProgma":"GeneralCheckNoProgma",
     "GeneralCheckNoTab":"GeneralCheckNoTab",
     "GeneralCheckNo_Asm":"GeneralCheckNo_Asm",
-    "GeneralCheckNonAscii":"GeneralCheckNonAscii",
     "GeneralCheckTabWidth":"GeneralCheckTabWidth",
     "GeneralCheckTrailingWhiteSpaceLine":"GeneralCheckTrailingWhiteSpaceLine",
     "GeneralCheckUni":"GeneralCheckUni",
@@ -179,8 +178,6 @@ class Configuration(object):
         self.GeneralCheckCarriageReturn = 1
         # Check whether the file exists
         self.GeneralCheckFileExistence = 1
-        # Check whether file has non ASCII char
-        self.GeneralCheckNonAscii = 1
         # Check whether UNI file is valid
         self.GeneralCheckUni = 1
         # Check Only use CRLF (Carriage Return Line Feed) line endings.

--- a/BaseTools/Source/Python/Ecc/EccToolError.py
+++ b/BaseTools/Source/Python/Ecc/EccToolError.py
@@ -14,7 +14,6 @@ ERROR_GENERAL_CHECK_NO_ASM = 1004
 ERROR_GENERAL_CHECK_NO_PROGMA = 1005
 ERROR_GENERAL_CHECK_CARRIAGE_RETURN = 1006
 ERROR_GENERAL_CHECK_FILE_EXISTENCE = 1007
-ERROR_GENERAL_CHECK_NON_ASCII = 1008
 ERROR_GENERAL_CHECK_UNI = 1009
 ERROR_GENERAL_CHECK_UNI_HELP_INFO = 1010
 ERROR_GENERAL_CHECK_INVALID_LINE_ENDING = 1011
@@ -113,7 +112,6 @@ gEccErrorMessage = {
     ERROR_GENERAL_CHECK_NO_PROGMA : """There should be no use of "#progma" in source file except "#pragma pack(#)\"""",
     ERROR_GENERAL_CHECK_CARRIAGE_RETURN : "There should be a carriage return at the end of the file",
     ERROR_GENERAL_CHECK_FILE_EXISTENCE : "File not found",
-    ERROR_GENERAL_CHECK_NON_ASCII : "File has invalid Non-ASCII char",
     ERROR_GENERAL_CHECK_UNI : "File is not a valid UTF-16 UNI file",
     ERROR_GENERAL_CHECK_UNI_HELP_INFO : "UNI file that is associated by INF or DEC file need define the prompt and help information.",
     ERROR_GENERAL_CHECK_INVALID_LINE_ENDING : "Only CRLF (Carriage Return Line Feed) is allowed to line ending.",

--- a/BaseTools/Source/Python/Ecc/EccToolError.py
+++ b/BaseTools/Source/Python/Ecc/EccToolError.py
@@ -14,7 +14,7 @@ ERROR_GENERAL_CHECK_NO_ASM = 1004
 ERROR_GENERAL_CHECK_NO_PROGMA = 1005
 ERROR_GENERAL_CHECK_CARRIAGE_RETURN = 1006
 ERROR_GENERAL_CHECK_FILE_EXISTENCE = 1007
-ERROR_GENERAL_CHECK_NON_ACSII = 1008
+ERROR_GENERAL_CHECK_NON_ASCII = 1008
 ERROR_GENERAL_CHECK_UNI = 1009
 ERROR_GENERAL_CHECK_UNI_HELP_INFO = 1010
 ERROR_GENERAL_CHECK_INVALID_LINE_ENDING = 1011
@@ -113,7 +113,7 @@ gEccErrorMessage = {
     ERROR_GENERAL_CHECK_NO_PROGMA : """There should be no use of "#progma" in source file except "#pragma pack(#)\"""",
     ERROR_GENERAL_CHECK_CARRIAGE_RETURN : "There should be a carriage return at the end of the file",
     ERROR_GENERAL_CHECK_FILE_EXISTENCE : "File not found",
-    ERROR_GENERAL_CHECK_NON_ACSII : "File has invalid Non-ACSII char",
+    ERROR_GENERAL_CHECK_NON_ASCII : "File has invalid Non-ASCII char",
     ERROR_GENERAL_CHECK_UNI : "File is not a valid UTF-16 UNI file",
     ERROR_GENERAL_CHECK_UNI_HELP_INFO : "UNI file that is associated by INF or DEC file need define the prompt and help information.",
     ERROR_GENERAL_CHECK_INVALID_LINE_ENDING : "Only CRLF (Carriage Return Line Feed) is allowed to line ending.",

--- a/BaseTools/Source/Python/Ecc/config.ini
+++ b/BaseTools/Source/Python/Ecc/config.ini
@@ -62,8 +62,8 @@ GeneralCheckNoProgma = 1
 GeneralCheckCarriageReturn = 1
 # Check whether the file exists
 GeneralCheckFileExistence = 1
-# Check whether file has non ACSII char
-GeneralCheckNonAcsii = 1
+# Check whether file has non ASCII char
+GeneralCheckNonAscii = 1
 # Check whether UNI file is valid
 GeneralCheckUni = 1
 # Check Only use CRLF (Carriage Return Line Feed) line endings.

--- a/BaseTools/Source/Python/Ecc/config.ini
+++ b/BaseTools/Source/Python/Ecc/config.ini
@@ -62,8 +62,6 @@ GeneralCheckNoProgma = 1
 GeneralCheckCarriageReturn = 1
 # Check whether the file exists
 GeneralCheckFileExistence = 1
-# Check whether file has non ASCII char
-GeneralCheckNonAscii = 1
 # Check whether UNI file is valid
 GeneralCheckUni = 1
 # Check Only use CRLF (Carriage Return Line Feed) line endings.


### PR DESCRIPTION
Related to the discussion in #5893, replacing #5867 based on conversation with @mdkinney and @ajfish.

The conversation on what to do with regards to the style rules will be a longer one. This change lets us merge #5840 while that conversation is ongoing.

Patch 1/2 still fixes a consistent misspelling of ASCII in ECC.

Patch 2/2 now completely deletes the GeneralCheckNoAscii() test from ECC. However, there are some other tests that still verify (via regex) various identifiers against naming standards from the coding style, enforcing a subset of ASCII there.
 
My intent is to follow this PR with one adding ASCII-checks for remaining identifier types, as an RFC.