### PR TITLE
UefiPayloadPkg:Modify the PCD PcieResizableBar to dynamic PCD

### DIFF
--- a/UefiPayloadPkg/UefiPayloadPkg.dsc
+++ b/UefiPayloadPkg/UefiPayloadPkg.dsc
@@ -575,6 +575,7 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdAriSupport|TRUE
   gEfiMdeModulePkgTokenSpaceGuid.PcdMrIovSupport|FALSE
   gEfiMdeModulePkgTokenSpaceGuid.PcdSrIovSupport|TRUE
+  gEfiMdeModulePkgTokenSpaceGuid.PcdPcieResizableBarSupport|FALSE
   gEfiMdeModulePkgTokenSpaceGuid.PcdSrIovSystemPageSize|0x1
   gUefiCpuPkgTokenSpaceGuid.PcdCpuApInitTimeOutInMicroSeconds|50000
   gUefiCpuPkgTokenSpaceGuid.PcdCpuApLoopMode|1


### PR DESCRIPTION
# Description
 The platforms  and UefiPayload  use the difference PCD attribute to define the PCD PcieResizableBarSupport , So that cause the UefiPayload  got the wrong value of this PCD.

Therefore synchronize PCD attribute settings to solve this problem.

- [ ] Breaking change?
   NO
- [ ] Impacts security?
   NO
- [ ] Includes tests?
   NO

## How This Was Tested

N/A

## Integration Instructions

N/A
