### PR TITLE
Fix boot failure when use secure boot supported (-D SECURE_BOOT_ENABLE=TRUE) OVMF packages

### DIFF
--- a/OvmfPkg/Library/PlatformInitLib/PlatformInitLib.inf
+++ b/OvmfPkg/Library/PlatformInitLib/PlatformInitLib.inf
@@ -104,6 +104,7 @@
   gUefiOvmfPkgTokenSpaceGuid.PcdTdxAcceptPageSize
   gUefiOvmfPkgTokenSpaceGuid.PcdOvmfFlashNvStorageVariableBase
   gUefiOvmfPkgTokenSpaceGuid.PcdCfvRawDataSize
+  gUefiOvmfPkgTokenSpaceGuid.PcdOvmfFirmwareBlockSize
 
 [FeaturePcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdDxeIplSwitchToLongMode

--- a/OvmfPkg/PlatformPei/Platform.c
+++ b/OvmfPkg/PlatformPei/Platform.c
@@ -224,6 +224,12 @@ ReserveEmuVariableNvStore (
   PcdStatus     = PcdSet64S (PcdEmuVariableNvStoreReserved, VariableStore);
 
   if (FeaturePcdGet (PcdSecureBootSupported)) {
+    // update mapping of FlashNvVarStore address range
+    SevFlashNvVarStoreUpdateMapping (
+                                     PcdGet32 (PcdOvmfFlashNvStorageVariableBase),
+                                     2 * PcdGet32 (PcdFlashNvStorageFtwSpareSize)
+                                     );
+
     // restore emulated VarStore from pristine ROM copy
     PlatformInitEmuVariableNvStore ((VOID *)(UINTN)VariableStore);
   }

--- a/OvmfPkg/PlatformPei/Platform.h
+++ b/OvmfPkg/PlatformPei/Platform.h
@@ -111,4 +111,10 @@ SevInitializeRam (
   VOID
   );
 
+VOID
+SevFlashNvVarStoreUpdateMapping (
+  IN UINTN  NvVarStoreBase,
+  IN UINTN  NvVarStoreSize
+  );
+
 #endif // _PLATFORM_PEI_H_INCLUDED_

--- a/OvmfPkg/PlatformPei/PlatformPei.inf
+++ b/OvmfPkg/PlatformPei/PlatformPei.inf
@@ -139,6 +139,7 @@
   gUefiOvmfPkgTokenSpaceGuid.PcdOvmfWorkAreaSize
   gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSnpSecretsBase
   gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSnpSecretsSize
+  gUefiOvmfPkgTokenSpaceGuid.PcdOvmfFlashNvStorageVariableBase
 
 [FeaturePcd]
   gUefiOvmfPkgTokenSpaceGuid.PcdSmmSmramRequire


### PR DESCRIPTION
https://bugzilla.tianocore.org/show_bug.cgi?id=4807

This patch series provides fixes for using secure boot enabled OVMF packages when launch a VM.

The fixes include:

- Detect FlashNvVarStore before validate it in PlatformInitLib
- Init the whole EmuVariableNvStore before copy the content from FlashNvVarStore
- Mapping the address range of FlashNvVarStore correctly before access these region