### PR TITLE
BaseTools/HostBasedUnitTestRunner: Promote Unittest error to CI fail.

### DIFF
--- a/BaseTools/Plugin/HostBasedUnitTestRunner/HostBasedUnitTestRunner.py
+++ b/BaseTools/Plugin/HostBasedUnitTestRunner/HostBasedUnitTestRunner.py
@@ -110,6 +110,7 @@ class HostBasedUnitTestRunner(IUefiBuildPlugin):
                 if ret != 0:
                     logging.error("UnitTest Execution Error: " +
                                   os.path.basename(test))
+                    failure_count += 1
                 else:
                     logging.info("UnitTest Completed: " +
                                  os.path.basename(test))


### PR DESCRIPTION
# Description

Some unit tests would fail to execute or execute and not produce any output logs. In these cases, the only output would be in the CI Log as `UnitTest Execution Error`.

A UnitTest Execution Error should be considered the same as a unit tests test failing.

- [X] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested
When running a unit test on a repo where the unit test was not implemented correctly, CI would still pass.
After making this change, the unit test execution error was reported as CI failure. 

## Integration Instructions
Impact to unit tests that are silently failing. On a case by case basis, those unit tests will need to be modified to be able to execute.