### PR TITLE
BaseTools: fix spec keyword parsing

### DIFF
--- a/BaseTools/Source/Python/AutoGen/GenC.py
+++ b/BaseTools/Source/Python/AutoGen/GenC.py
@@ -1997,6 +1997,20 @@ def CreateHeaderCode(Info, AutoGenC, AutoGenH):
     AutoGenH.Append("#define EFI_CALLER_ID_GUID \\\n  %s\n" % GuidStringToGuidStructureString(Info.Guid))
     AutoGenH.Append("#define EDKII_DSC_PLATFORM_GUID \\\n  %s\n" % GuidStringToGuidStructureString(Info.PlatformInfo.Guid))
 
+    decimal_version_pattern = r'^[0-9]+(\.[0-9]+)?$'
+    # Handle SPEC keywords in [Defines] section
+    spec_key_regex = re.compile(r'^SPEC\s+([a-zA-Z_]\w*)$')
+    for k,v in Info.Module._Defs.items():
+        match = re.match(spec_key_regex, k)
+        if match:
+            # If value matches expected format, append a #define statement to AutoGen.h
+            if re.match(decimal_version_pattern, v):
+                AutoGenH.Append("\n#define %s %s\n" % (match.group(1), v))
+            else:
+                # If v does not match the <DecimalVersion> pattern log an error and exit gracefully
+                EdkLogger.error("build", FORMAT_NOT_SUPPORTED, "Refer to <DecimalVersion> pattern for SPEC keyword in Defines section", match.group(1))
+                return
+
     if Info.IsLibrary:
         return
     # C file header

--- a/BaseTools/Source/Python/AutoGen/GenMake.py
+++ b/BaseTools/Source/Python/AutoGen/GenMake.py
@@ -662,6 +662,8 @@ cleanlib:
                         break
             package_rel_dir = package_rel_dir[index + 1:]
 
+        spec_key_regex = re.compile(r'^SPEC\s+([a-zA-Z_]\w*)$')
+
         MakefileTemplateDict = {
             "makefile_header"           : self._FILE_HEADER_[self._FileType],
             "makefile_path"             : os.path.join("$(MODULE_BUILD_DIR)", MakefileName),
@@ -684,7 +686,7 @@ cleanlib:
             "module_relative_directory" : MyAgo.SourceDir,
             "module_dir"                : mws.join (self.Macros["WORKSPACE"], MyAgo.SourceDir),
             "package_relative_directory": package_rel_dir,
-            "module_extra_defines"      : ["%s = %s" % (k, v) for k, v in MyAgo.Module.Defines.items()],
+            "module_extra_defines"      : ["%s = %s" % (k, v) for k, v in MyAgo.Module.Defines.items() if not re.match(spec_key_regex, k)],
 
             "architecture"              : MyAgo.Arch,
             "toolchain_tag"             : MyAgo.ToolChain,


### PR DESCRIPTION
Fixes SPEC keyword parsing to match EDK2 specification

# Description
When SPEC keyword is used in the INF file, it does not create the equivalent #define in the autogen.h file of the module. Additionally it creates a line in autogenerated makefile. This generated line will cause builds to break of we follow the specification as defined in the example here, 
[https://github.com/tianocore-docs/edk2-InfSpecification/blob/master/3_edk_ii_inf_file_format/34_%5Bdefines%5D_section.md]
Ex : SPEC USB_SPECIFICATION_VERSION = 2.0
The changes fixes the autogen code to function as mentioned by the documentation. 

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - N/A
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - N/A
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - N/A

## How This Was Tested

Tested locally with builds.

## Integration Instructions

N/A
