### PR TITLE
BaseTools/CodeQL: Removed unused static function query

### DIFF
--- a/BaseTools/Plugin/CodeQL/CodeQlQueries.qls
+++ b/BaseTools/Plugin/CodeQL/CodeQlQueries.qls
@@ -70,8 +70,6 @@
 - include:
     id: cpp/unused-local-variable
 - include:
-    id: cpp/unused-static-function
-- include:
     id: cpp/unused-static-variable
 
 # Note: Some queries above are not active by default with the below filter.


### PR DESCRIPTION
# Description

This query produces a high rate of false positives with some common patterns in edk2 like passing function pointers for callback.

Previously, due to the usage of `STATIC` instead of `static`, particularly for functions, this query was rarely used in the past. It is removed here to prevent future false positives.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

- Run the CodeQL plugin before and after the change with a `static` function present.

## Integration Instructions

- N/A