### PR TITLE
OvmfPkg: Add network support for LoongArch QEMU platform

### DIFF
--- a/OvmfPkg/LoongArchVirt/LoongArchVirtQemu.dsc
+++ b/OvmfPkg/LoongArchVirt/LoongArchVirtQemu.dsc
@@ -552,12 +552,12 @@
   #
   # Network Support
   #
-#!include NetworkPkg/NetworkComponents.dsc.inc
+!include NetworkPkg/NetworkComponents.dsc.inc
 
-#  NetworkPkg/UefiPxeBcDxe/UefiPxeBcDxe.inf {
-#    <LibraryClasses>
-#      NULL|OvmfPkg/Library/PxeBcPcdProducerLib/PxeBcPcdProducerLib.inf
-#  }
+  NetworkPkg/UefiPxeBcDxe/UefiPxeBcDxe.inf {
+    <LibraryClasses>
+      NULL|OvmfPkg/Library/PxeBcPcdProducerLib/PxeBcPcdProducerLib.inf
+  }
 
 !if $(NETWORK_TLS_ENABLE) == TRUE
   NetworkPkg/TlsAuthConfigDxe/TlsAuthConfigDxe.inf {

--- a/OvmfPkg/LoongArchVirt/LoongArchVirtQemu.fdf
+++ b/OvmfPkg/LoongArchVirt/LoongArchVirtQemu.fdf
@@ -159,7 +159,7 @@ INF  OvmfPkg/AcpiPlatformDxe/AcpiPlatformDxe.inf
 
 #
 # Network modules
-#!include NetworkPkg/Network.fdf.inc
+!include NetworkPkg/Network.fdf.inc
 
 #
 # File system


### PR DESCRIPTION
# Description

Open the network option to enable networking on the LoongArch QEMU platform.

Cc: Ard Biesheuvel <ardb+tianocore@kernel.org>
Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Gerd Hoffmann <kraxel@redhat.com>

## How This Was Tested

* Build using OvmfPkg/LoongArchVirt/LoongArchQemuVirt.dsc
* Run the QEMU_EFI.fd with QEMU and add following operations:
`-netdev user,id=net0 -device virtio-rng-pci -device virtio-net-pci,netdev=net0`
* A PXE boot option will appear in the Boot Manager:
![image](https://github.com/user-attachments/assets/8c68b127-4380-4612-80d0-54c8a4c9ba17)


## Integration Instructions

N/A
