### PR TITLE
MdePkg/BaseLib: Optimize LOONGARCH64 csr usage

### DIFF
--- a/MdePkg/Library/BaseLib/LoongArch64/AsmCsr.S
+++ b/MdePkg/Library/BaseLib/LoongArch64/AsmCsr.S
@@ -100,8 +100,7 @@ DirMapCsrRd:
   jirl     $zero, $t0, 0
 
 ReadSelNumErr:
-  addi.d   $a0, $zero, -1
-  jirl     $zero, $ra, 0
+  break    0
 
 BasicCsrRead:
   CsrSel = LOONGARCH_CSR_CRMD
@@ -230,8 +229,7 @@ DirMapCsrWr:
   jirl     $zero, $t0, 0
 
 WriteSelNumErr:
-  addi.d   $a0, $zero, -1
-  jirl     $zero, $ra, 0
+  break    0
 
 BasicCsrWrite:
   CsrSel = LOONGARCH_CSR_CRMD
@@ -368,8 +366,7 @@ DirMapCsrXchg:
   jirl     $zero, $t0, 0
 
 XchgSelNumErr:
-  addi.d   $a0, $zero, -1
-  jirl     $zero, $ra, 0
+  break    0
 
 BasicCsrXchange:
   CsrSel = LOONGARCH_CSR_CRMD

--- a/MdePkg/Library/BaseLib/LoongArch64/Csr.c
+++ b/MdePkg/Library/BaseLib/LoongArch64/Csr.c
@@ -29,7 +29,8 @@ AsmCsrXChg (
 
   @param[in]  Select   CSR read instruction select values.
 
-  @return     The return value of csrrd instruction, return -1 means Select is out of support.
+  @return     The return value of csrrd instruction,
+              if a break exception is triggered, the Select is out of support.
 **/
 UINTN
 EFIAPI
@@ -47,7 +48,7 @@ CsrRead (
   @param[in, out]  Value   The csrwr will write the value.
 
   @return     The return value of csrwr instruction, that is, store the old value of
-              the register, return -1 means Select is out of support.
+              the register, if a break exception is triggered, the Select is out of support.
 **/
 UINTN
 EFIAPI
@@ -67,7 +68,7 @@ CsrWrite (
   @param[in]       Mask     The csrxchg mask value.
 
   @return     The return value of csrxchg instruction, that is, store the old value of
-              the register, return -1 means Select is out of support.
+              the register, if a break exception is triggered, the Select is out of support.
 **/
 UINTN
 EFIAPI


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4812

When the Select is out of support, use method break exception instead of method return -1, 
avoid unknown errors caused by untimely detection.

Cc: Chao Li <lichao@loongson.cn>
Signed-off-by: Dongyan Qian <qiandongyan@loongson.cn>
# Description

<_Include a description of the change and why this change was made._>

<_For each item, place an "x" in between `[` and `]` if true. Example: `[x]` (you can also check items in GitHub UI)_>

<_Create the PR as a Draft PR if it is only created to run CI checks._>

<_Delete lines in \<\> tags before creating the PR._>

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

<_Describe the test(s) that were run to verify the changes._>

## Integration Instructions

<_Describe how these changes should be integrated. Use N/A if nothing is required._>
