### PR TITLE
MdeModulePkg/PciHostBridgeDxe: Ignore TypeIo for non X86/X64 architec…

### DIFF
--- a/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostBridge.c
+++ b/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostBridge.c
@@ -675,7 +675,7 @@ ResourceConflict (
        )
   {
     RootBridge = ROOT_BRIDGE_FROM_LINK (Link);
-    for (Index = TypeIo; Index < TypeMax; Index++) {
+    for (Index = PCI_RESOURCE_TYPE_ENUM_START; Index < TypeMax; Index++) {
       ResAllocNode = &RootBridge->ResAllocNode[Index];
 
       Descriptor->Desc         = ACPI_ADDRESS_SPACE_DESCRIPTOR;
@@ -918,7 +918,7 @@ NotifyPhase (
         RootBridge = ROOT_BRIDGE_FROM_LINK (Link);
         DEBUG ((DEBUG_INFO, " RootBridge: %s\n", RootBridge->DevicePathStr));
 
-        for (Index1 = TypeIo; Index1 < TypeBus; Index1++) {
+        for (Index1 = PCI_RESOURCE_TYPE_ENUM_START; Index1 < TypeBus; Index1++) {
           if (RootBridge->ResAllocNode[Index1].Status == ResNone) {
             ResNodeHandled[Index1] = TRUE;
           } else {
@@ -927,7 +927,7 @@ NotifyPhase (
             //
             MaxAlignment = 0;
             Index        = TypeMax;
-            for (Index2 = TypeIo; Index2 < TypeBus; Index2++) {
+            for (Index2 = PCI_RESOURCE_TYPE_ENUM_START; Index2 < TypeBus; Index2++) {
               if (ResNodeHandled[Index2]) {
                 continue;
               }
@@ -1132,7 +1132,7 @@ NotifyPhase (
            )
       {
         RootBridge = ROOT_BRIDGE_FROM_LINK (Link);
-        for (Index = TypeIo; Index < TypeBus; Index++) {
+        for (Index = PCI_RESOURCE_TYPE_ENUM_START; Index < TypeBus; Index++) {
           if (RootBridge->ResAllocNode[Index].Status == ResAllocated) {
             switch (Index) {
               case TypeIo:
@@ -1632,7 +1632,7 @@ GetProposedResources (
       }
 
       Descriptor = (EFI_ACPI_ADDRESS_SPACE_DESCRIPTOR *)Buffer;
-      for (Index = 0; Index < TypeBus; Index++) {
+      for (Index = PCI_RESOURCE_TYPE_ENUM_START; Index < TypeBus; Index++) {
         ResStatus = RootBridge->ResAllocNode[Index].Status;
         if (ResStatus != ResNone) {
           Descriptor->Desc    = ACPI_ADDRESS_SPACE_DESCRIPTOR;

--- a/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostBridgeDxe.inf
+++ b/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostBridgeDxe.inf
@@ -21,7 +21,12 @@
   PciRootBridge.h
   PciHostBridge.c
   PciRootBridgeIo.c
+
+[Sources.EBC, Sources.ARM, Sources.AARCH64, Sources.RISCV64, Sources.LOONGARCH64]
   PciHostResource.h
+
+[Sources.IA32, Sources.X64]
+  X86PciHostResource.h
 
 [Packages]
   MdePkg/MdePkg.dec

--- a/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciRootBridgeIo.c
+++ b/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciRootBridgeIo.c
@@ -219,7 +219,7 @@ CreateRootBridge (
   CopyMem (&RootBridge->PMem, &Bridge->PMem, sizeof (PCI_ROOT_BRIDGE_APERTURE));
   CopyMem (&RootBridge->PMemAbove4G, &Bridge->PMemAbove4G, sizeof (PCI_ROOT_BRIDGE_APERTURE));
 
-  for (Index = TypeIo; Index < TypeMax; Index++) {
+  for (Index = PCI_RESOURCE_TYPE_ENUM_START; Index < TypeMax; Index++) {
     switch (Index) {
       case TypeBus:
         Aperture = &RootBridge->Bus;
@@ -1889,7 +1889,7 @@ RootBridgeIoConfiguration (
     TypeMax * sizeof (EFI_ACPI_ADDRESS_SPACE_DESCRIPTOR) + sizeof (EFI_ACPI_END_TAG_DESCRIPTOR)
     );
   Descriptor = RootBridge->ConfigBuffer;
-  for (Index = TypeIo; Index < TypeMax; Index++) {
+  for (Index = PCI_RESOURCE_TYPE_ENUM_START; Index < TypeMax; Index++) {
     ResAllocNode = &RootBridge->ResAllocNode[Index];
 
     if (ResAllocNode->Status != ResAllocated) {

--- a/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/X86PciHostResource.h
+++ b/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/X86PciHostResource.h
@@ -25,7 +25,7 @@ typedef enum {
   TypeMax
 } PCI_RESOURCE_TYPE;
 
-#define PCI_RESOURCE_TYPE_ENUM_START  TypeIo
+#define PCI_RESOURCE_TYPE_ENUM_START  TypeMem32
 
 typedef enum {
   ResNone,


### PR DESCRIPTION
…tures.

Throughout PciHostBridgeDxe, functions iterate through all entries in the `PCI_RESOURCE_TYPE` enum. However `TypeIo` only applies for x86_64 platforms and on platforms such as Arm, the driver may exit early if resources are not available.

This changes the starting point of the `PCI_RESOURCE_TYPE` enum iteration from `0` to `PCI_RESOURCE_TYPE_ENUM_START` and conditionally sets that value to `TypeIo` or `TypeMem32` based on whether the platform is x86_64 or not.

# Description

<_Include a description of the change and why this change was made._>

<_For each item, place an "x" in between `[` and `]` if true. Example: `[x]` (you can also check items in GitHub UI)_>

<_Create the PR as a Draft PR if it is only created to run CI checks._>

<_Delete lines in \<\> tags before creating the PR._>

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

<_Describe the test(s) that were run to verify the changes._>

## Integration Instructions

<_Describe how these changes should be integrated. Use N/A if nothing is required._>
