### PR TITLE
RedfishPkg: Reduce DEBUG_ERROR to DEBUG_MANAGEABILITY in various places

### DIFF
--- a/RedfishPkg/RedfishConfigHandler/RedfishConfigHandlerDriver.c
+++ b/RedfishPkg/RedfishConfigHandler/RedfishConfigHandlerDriver.c
@@ -412,7 +412,7 @@ AcquireRedfishServiceOnNetworkInterfaceCallback (
         EFI_ERROR (ThisRedfishDiscoveredToken->DiscoverList.RedfishInstances->Status))
     {
       gBS->CloseEvent (ThisRedfishDiscoveredToken->Event);
-      DEBUG ((DEBUG_ERROR, "%a: Free Redfish discovered token - %x.\n", __func__, ThisRedfishDiscoveredToken));
+      DEBUG ((DEBUG_MANAGEABILITY, "%a: Free Redfish discovered token - %x.\n", __func__, ThisRedfishDiscoveredToken));
       FreePool (ThisRedfishDiscoveredToken);
     }
 

--- a/RedfishPkg/RedfishDiscoverDxe/RedfishDiscoverDxe.c
+++ b/RedfishPkg/RedfishDiscoverDxe/RedfishDiscoverDxe.c
@@ -570,9 +570,9 @@ DiscoverRedfishHostInterface (
     }
 
     if (MacCompareStatus != 0) {
-      DEBUG ((DEBUG_ERROR, "%a: MAC address is not matched.\n", __func__));
+      DEBUG ((DEBUG_MANAGEABILITY, "%a: MAC address is not matched.\n", __func__));
       DEBUG ((
-        DEBUG_ERROR,
+        DEBUG_MANAGEABILITY,
         "    NetworkInterface: %02x %02x %02x %02x %02x %02x.\n",
         Instance->NetworkInterface->MacAddress.Addr[0],
         Instance->NetworkInterface->MacAddress.Addr[1],
@@ -582,7 +582,7 @@ DiscoverRedfishHostInterface (
         Instance->NetworkInterface->MacAddress.Addr[5]
         ));
       DEBUG ((
-        DEBUG_ERROR,
+        DEBUG_MANAGEABILITY,
         "    Redfish Host interface: %02x %02x %02x %02x %02x %02x.\n",
         DeviceDescriptor->DeviceDescriptor.UsbDeviceV2.MacAddress[0],
         DeviceDescriptor->DeviceDescriptor.UsbDeviceV2.MacAddress[1],
@@ -1559,7 +1559,7 @@ RedfishServiceAcquireService (
           FreePool ((VOID *)Instance);
         }
 
-        DEBUG ((DEBUG_ERROR, "%a:Something wrong on Redfish service discovery Status1=%r.\n", __func__, Status1));
+        DEBUG ((DEBUG_MANAGEABILITY, "%a:Something wrong on Redfish service discovery Status1=%r.\n", __func__, Status1));
       } else {
         if (NewInstance) {
           InsertTailList (&mRedfishDiscoverList, &Instance->Entry);


### PR DESCRIPTION

# Description

The Redfish drivers log messages as errors in various places when they don't find an appropriate network interface - even when one has already been found. Reduce those log messages to DEBUG_MANAGEABILITY to avoid spamming the console in Release builds.
