### PR TITLE
Add Memory Attribute Protocol Logging

### DIFF
--- a/ArmPkg/Drivers/CpuDxe/MemoryAttribute.c
+++ b/ArmPkg/Drivers/CpuDxe/MemoryAttribute.c
@@ -82,6 +82,13 @@ GetMemoryAttributes (
   EFI_STATUS  Status;
 
   if ((Length == 0) || (Attributes == NULL)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: BaseAddress 0x%llx Length 0x%llx is zero or Attributes is NULL\n",
+      __func__,
+      BaseAddress,
+      Length
+      ));
     return EFI_INVALID_PARAMETER;
   }
 
@@ -195,6 +202,13 @@ SetMemoryAttributes (
   if ((Length == 0) ||
       ((Attributes & ~(EFI_MEMORY_RO | EFI_MEMORY_RP | EFI_MEMORY_XP)) != 0))
   {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: BaseAddress 0x%llx Length is zero or Attributes (0x%llx) is invalid\n",
+      __func__,
+      BaseAddress,
+      Attributes
+      ));
     return EFI_INVALID_PARAMETER;
   }
 
@@ -256,6 +270,13 @@ ClearMemoryAttributes (
   if ((Length == 0) ||
       ((Attributes & ~(EFI_MEMORY_RO | EFI_MEMORY_RP | EFI_MEMORY_XP)) != 0))
   {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: BaseAddress 0x%llx Length is zero or Attributes (0x%llx) is invalid\n",
+      __func__,
+      BaseAddress,
+      Attributes
+      ));
     return EFI_INVALID_PARAMETER;
   }
 

--- a/ArmPkg/Library/ArmMmuLib/AArch64/ArmMmuLibCore.c
+++ b/ArmPkg/Library/ArmMmuLib/AArch64/ArmMmuLibCore.c
@@ -382,6 +382,13 @@ UpdateRegionMapping (
   UINTN  T0SZ;
 
   if (((RegionStart | RegionLength) & EFI_PAGE_MASK) != 0) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a RegionStart: 0x%llx or RegionLength: 0x%llx are not page aligned!\n",
+      __func__,
+      RegionStart,
+      RegionLength
+      ));
     return EFI_INVALID_PARAMETER;
   }
 

--- a/ArmPkg/Library/ArmMmuLib/Arm/ArmMmuLibUpdate.c
+++ b/ArmPkg/Library/ArmMmuLib/Arm/ArmMmuLibUpdate.c
@@ -377,6 +377,13 @@ SetMemoryAttributes (
   BOOLEAN     FlushTlbs;
 
   if (BaseAddress > (UINT64)MAX_ADDRESS) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a BaseAddress: 0x%llx is greater than MAX_ADDRESS: 0x%llx, fail to apply attributes!\n",
+      __func__,
+      BaseAddress,
+      (UINT64)MAX_ADDRESS
+      ));
     return EFI_UNSUPPORTED;
   }
 
@@ -437,6 +444,14 @@ SetMemoryAttributes (
     }
 
     if (EFI_ERROR (Status)) {
+      DEBUG ((
+        DEBUG_ERROR,
+        "%a failed to update attributes with status %r for BaseAddress 0x%llx of length 0x%llx\n",
+        __func__,
+        Status,
+        BaseAddress,
+        ChunkLength
+        ));
       break;
     }
 


### PR DESCRIPTION
# Description

The memory attribute protocol is primarily used by bootloaders and there are many released bootloaders who use the protocol incorrectly. It is challenging to debug these situations because the bootloaders are generally black boxes and we silently fail on the FW side. This patch series adds logging for ARM32 and AARCH64 to log during failures of the memory attribute protocol (and in ArmMmuLib) for commonly seen bootloader failures using the memory attribute protocol.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Tested on virtual platforms with a failing bootloader and saw the messages printed.

## Integration Instructions

N/A.
