### PR TITLE
ArmPlatformPkg: Update LcdHwNullLib to Prevent Init

### DIFF
--- a/ArmPlatformPkg/Library/LcdHwNullLib/LcdHwNullLib.c
+++ b/ArmPlatformPkg/Library/LcdHwNullLib/LcdHwNullLib.c
@@ -23,7 +23,7 @@ LcdIdentify (
   VOID
   )
 {
-  return EFI_SUCCESS;
+  return EFI_NOT_FOUND;
 }
 
 /**


### PR DESCRIPTION
# Description

Library previously returned EFI_SUCCESS which causes the platform to continue initializing LCD HW. Should return EFI_NOT_FOUND as this is a null library.

Resolves TCBZ3351: https://bugzilla.tianocore.org/show_bug.cgi?id=3351.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Tested using the null lib and seeing LCD HW init not continue.

## Integration Instructions

N/A.
