### PR TITLE
Set ARM RTC MMIO as NX

### DIFF
--- a/ArmPlatformPkg/Library/PL031RealTimeClockLib/PL031RealTimeClockLib.c
+++ b/ArmPlatformPkg/Library/PL031RealTimeClockLib/PL031RealTimeClockLib.c
@@ -331,13 +331,13 @@ LibRtcInitialize (
                   EfiGcdMemoryTypeMemoryMappedIo,
                   mPL031RtcBase,
                   SIZE_4KB,
-                  EFI_MEMORY_UC | EFI_MEMORY_RUNTIME
+                  EFI_MEMORY_UC | EFI_MEMORY_RUNTIME | EFI_MEMORY_XP
                   );
   if (EFI_ERROR (Status)) {
     return Status;
   }
 
-  Status = gDS->SetMemorySpaceAttributes (mPL031RtcBase, SIZE_4KB, EFI_MEMORY_UC | EFI_MEMORY_RUNTIME);
+  Status = gDS->SetMemorySpaceAttributes (mPL031RtcBase, SIZE_4KB, EFI_MEMORY_UC | EFI_MEMORY_RUNTIME | EFI_MEMORY_XP);
   if (EFI_ERROR (Status)) {
     return Status;
   }

--- a/ArmVirtPkg/Library/KvmtoolRtcFdtClientLib/KvmtoolRtcFdtClientLib.c
+++ b/ArmVirtPkg/Library/KvmtoolRtcFdtClientLib/KvmtoolRtcFdtClientLib.c
@@ -44,7 +44,7 @@ KvmtoolRtcMapMemory (
                   EfiGcdMemoryTypeMemoryMappedIo,
                   RtcPageBase,
                   EFI_PAGE_SIZE,
-                  EFI_MEMORY_UC | EFI_MEMORY_RUNTIME
+                  EFI_MEMORY_UC | EFI_MEMORY_RUNTIME | EFI_MEMORY_XP
                   );
   if (EFI_ERROR (Status)) {
     DEBUG ((
@@ -80,7 +80,7 @@ KvmtoolRtcMapMemory (
   Status = gDS->SetMemorySpaceAttributes (
                   RtcPageBase,
                   EFI_PAGE_SIZE,
-                  EFI_MEMORY_UC | EFI_MEMORY_RUNTIME
+                  EFI_MEMORY_UC | EFI_MEMORY_RUNTIME | EFI_MEMORY_XP
                   );
   if (EFI_ERROR (Status)) {
     DEBUG ((


### PR DESCRIPTION
# Description

Two ARM RTC libs will clear EFI_MEMORY_XP from MMIO memory if a platform has set it, because they explicitly set memory attributes that do not include EFI_MEMORY_XP. These regions are not intended to be executed from, so this patch set updates the libs to explicitly set the regions to EFI_MEMORY_XP.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [x] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Tested on ARM64 virtual platforms.

## Integration Instructions

N/A.
