### PR TITLE
MdeModulePkg/VariablePolicyLib: Use wildcard character constant

### DIFF
--- a/MdeModulePkg/Library/VariablePolicyLib/VariablePolicyLib.c
+++ b/MdeModulePkg/Library/VariablePolicyLib/VariablePolicyLib.c
@@ -178,7 +178,7 @@ IsValidVariablePolicyStructure (
     WildcardCount = 0;
     while (*CheckChar != CHAR_NULL) {
       // Make sure there aren't excessive wildcards.
-      if (*CheckChar == '#') {
+      if (*CheckChar == L'#') {
         WildcardCount++;
         if (WildcardCount > MATCH_PRIORITY_MIN) {
           return FALSE;
@@ -263,7 +263,7 @@ EvaluatePolicyMatch (
   // Keep going until the end of both strings.
   while (PolicyName[Index] != CHAR_NULL || VariableName[Index] != CHAR_NULL) {
     // If we don't have a match...
-    if ((PolicyName[Index] != VariableName[Index]) || (PolicyName[Index] == '#')) {
+    if ((PolicyName[Index] != VariableName[Index]) || (PolicyName[Index] == L'#')) {
       // If this is a numerical wildcard, we can consider
       // it a match if we alter the priority.
       if ((PolicyName[Index] == L'#') &&


### PR DESCRIPTION
# Description

Makes the `#` character used for comparison against wildcard characters in `CHAR16` strings to be prefixed with `L` so the character is treated as a wide character constant.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

- CI

## Integration Instructions

- N/A