### PR TITLE
FmpDevicePkg: Assert on PcdFmpDeviceImageTypeIdGuid Size Mismatch

### DIFF
--- a/FmpDevicePkg/FmpDxe/FmpDxe.c
+++ b/FmpDevicePkg/FmpDxe/FmpDxe.c
@@ -181,7 +181,12 @@ GetImageTypeIdGuid (
     if (ImageTypeIdGuidSize == sizeof (EFI_GUID)) {
       FmpDeviceLibGuid = (EFI_GUID *)PcdGetPtr (PcdFmpDeviceImageTypeIdGuid);
     } else {
-      DEBUG ((DEBUG_WARN, "FmpDxe(%s): Fall back to ImageTypeIdGuid of gEfiCallerIdGuid\n", mImageIdName));
+      DEBUG ((
+        DEBUG_ERROR,
+        "FmpDxe(%s): Fall back to ImageTypeIdGuid of gEfiCallerIdGuid. FmpDxe error: misconfiguration\n",
+        mImageIdName
+        ));
+      ASSERT (FALSE);
       FmpDeviceLibGuid = &gEfiCallerIdGuid;
     }
   }


### PR DESCRIPTION
# Description

This patch adds an assert to FmpDxe.c to catch a platform misconfiguration of PcdFmpDeviceImageTypeIdGuid.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

N/A.

## Integration Instructions

N/A.
