### PR TITLE
PrmPkg: Don't Set Access Attributes of Runtime MMIO Ranges

### DIFF
--- a/PrmPkg/PrmConfigDxe/PrmConfigDxe.c
+++ b/PrmPkg/PrmConfigDxe/PrmConfigDxe.c
@@ -152,10 +152,15 @@ SetRuntimeMemoryRangeAttributes (
       continue;
     }
 
+    // The memory space descriptor access attributes are not accurate. Don't pass
+    // in access attributes so SetMemorySpaceAttributes() doesn't update them.
+    // EFI_MEMORY_RUNTIME is not a CPU arch attribute, so calling
+    // SetMemorySpaceAttributes() with only it set will not clear existing page table
+    // attributes for this region, such as EFI_MEMORY_XP
     Status = gDS->SetMemorySpaceAttributes (
                     RuntimeMmioRanges->Range[Index].PhysicalBaseAddress,
                     (UINT64)RuntimeMmioRanges->Range[Index].Length,
-                    Descriptor.Attributes | EFI_MEMORY_RUNTIME
+                    EFI_MEMORY_RUNTIME
                     );
     ASSERT_EFI_ERROR (Status);
     if (EFI_ERROR (Status)) {


### PR DESCRIPTION
# Description

Passing in access attributes to SetMemorySpaceAttributes() will cause the existing attributes to be overwritten. The MMIO region should have the appropriate attributes applied during memory protection initialization and the attributes of the memory space descriptor are inaccurate. Don't pass in any CPU arch attributes so SetMemorySpaceAttributes() doesn't subsequently call gCpu->SetMemoryAttributes().

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [x] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Tested on a platform with PRM and saw that existing attributes were not removed.

## Integration Instructions

N/A.
