### PR TITLE
ShellPkg: Fix bug #3080, OOB, minor UefiShellLib fixes

### DIFF
--- a/ShellPkg/Library/UefiShellLib/UefiShellLib.c
+++ b/ShellPkg/Library/UefiShellLib/UefiShellLib.c
@@ -3894,6 +3894,10 @@ InternalShellIsHexOrDecimalNumber (
     Hex = FALSE;
   }
 
+  if ((*String == CHAR_NULL) && LeadingZero) {
+    return (TRUE);
+  }
+
   //
   // loop through the remaining characters and use the lib function
   //
@@ -4041,16 +4045,16 @@ InternalShellStrHexToUint64 (
     // Skip the 'X'
     //
     String++;
+
+    //
+    // there is a space where there should't be
+    //
+    if (*String == L' ') {
+      return (EFI_INVALID_PARAMETER);
+    }
   }
 
   Result = 0;
-
-  //
-  // there is a space where there should't be
-  //
-  if (*String == L' ') {
-    return (EFI_INVALID_PARAMETER);
-  }
 
   while (ShellIsHexaDecimalDigitCharacter (*String)) {
     //

--- a/ShellPkg/Library/UefiShellLib/UefiShellLib.c
+++ b/ShellPkg/Library/UefiShellLib/UefiShellLib.c
@@ -4012,7 +4012,7 @@ InternalShellStrHexToUint64 (
   UINT64   Result;
   BOOLEAN  LeadingZero;
 
-  if ((String == NULL) || (StrSize (String) == 0) || (Value == NULL)) {
+  if ((String == NULL) || (StrSize (String) == sizeof (*String)) || (Value == NULL)) {
     return (EFI_INVALID_PARAMETER);
   }
 
@@ -4116,7 +4116,7 @@ InternalShellStrDecimalToUint64 (
 {
   UINT64  Result;
 
-  if ((String == NULL) || (StrSize (String) == 0) || (Value == NULL)) {
+  if ((String == NULL) || (StrSize (String) == sizeof (*String)) || (Value == NULL)) {
     return (EFI_INVALID_PARAMETER);
   }
 

--- a/ShellPkg/Library/UefiShellLib/UefiShellLib.c
+++ b/ShellPkg/Library/UefiShellLib/UefiShellLib.c
@@ -4234,15 +4234,17 @@ ShellConvertStringToUint64 (
     Status = InternalShellStrDecimalToUint64 (Walker, &RetVal, StopAtSpace);
   }
 
-  if ((Value == NULL) && !EFI_ERROR (Status)) {
-    return (EFI_NOT_FOUND);
+  if (EFI_ERROR (Status)) {
+    return EFI_INVALID_PARAMETER;
   }
 
-  if (Value != NULL) {
-    *Value = RetVal;
+  if (Value == NULL) {
+    return EFI_NOT_FOUND;
   }
 
-  return (Status);
+  *Value = RetVal;
+
+  return EFI_SUCCESS;
 }
 
 /**

--- a/ShellPkg/Library/UefiShellLib/UefiShellLib.c
+++ b/ShellPkg/Library/UefiShellLib/UefiShellLib.c
@@ -4012,7 +4012,7 @@ InternalShellStrHexToUint64 (
   UINT64   Result;
   BOOLEAN  LeadingZero;
 
-  if ((String == NULL) || (StrSize (String) == sizeof (*String)) || (Value == NULL)) {
+  if ((String == NULL) || (*String == CHAR_NULL) || (Value == NULL)) {
     return (EFI_INVALID_PARAMETER);
   }
 
@@ -4116,7 +4116,7 @@ InternalShellStrDecimalToUint64 (
 {
   UINT64  Result;
 
-  if ((String == NULL) || (StrSize (String) == sizeof (*String)) || (Value == NULL)) {
+  if ((String == NULL) || (*String == CHAR_NULL) || (Value == NULL)) {
     return (EFI_INVALID_PARAMETER);
   }
 

--- a/ShellPkg/Library/UefiShellLib/UefiShellLib.c
+++ b/ShellPkg/Library/UefiShellLib/UefiShellLib.c
@@ -4009,7 +4009,8 @@ InternalShellStrHexToUint64 (
   IN CONST BOOLEAN  StopAtSpace
   )
 {
-  UINT64  Result;
+  UINT64   Result;
+  BOOLEAN  LeadingZero;
 
   if ((String == NULL) || (StrSize (String) == 0) || (Value == NULL)) {
     return (EFI_INVALID_PARAMETER);
@@ -4025,12 +4026,14 @@ InternalShellStrHexToUint64 (
   //
   // Ignore leading Zeros after the spaces
   //
+  LeadingZero = FALSE;
   while (*String == L'0') {
     String++;
+    LeadingZero = TRUE;
   }
 
   if (CharToUpper (*String) == L'X') {
-    if (*(String - 1) != L'0') {
+    if (!LeadingZero) {
       return 0;
     }
 


### PR DESCRIPTION
# Description

The commit _Prevent out-of-bounds access_ fixes a possible OOB in a way that is already used in another place in the file.

The commits _Correct check for empty string_ and _Simplify check for empty string_ can be squashed if the maintainers prefer, for the sake of review they are split up in a fix-up and an optimization.

The commit _Only write value if successful conversion_ is for correctness and conformance to documented behavior.

The commit _Accept "0 " as valid numeric string_ fixes a long-standing (since 2011?) bug that prevented the use of "0" as a numeric argument, e.g. to address the first boot option when using `bcfg`. A workaround, known to some, was to use "0x0" instead.

Note there was a similar fix for InternalShellStrDecimalToUint64() in commit 80f3e34f, however if ShellConvertStringToUint64() is called with ForceHex=TRUE, InternalShellStrHexToUint64() is called instead so it wouldn't help.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [x] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

The fix for bug 3080 was tested with builds from OvmfPkg in QEMU.
Before:
```
Shell> fs0:
FS0:\> bcfg boot -opt 0 FS0:\options.txt
bcfg: Invalid argument - 'Option Index'
FS0:\> 
```
After:
```
Shell> fs0:
FS0:\> bcfg boot -opt 0 FS0:\options.txt
FS0:\> 
```

## Integration Instructions

N/A