### PR TITLE
UefiCpuPkg/MpInitLib: Reduce compiler dependencies for LoongArch

### DIFF
--- a/UefiCpuPkg/Library/MpInitLib/LoongArch64/MpLib.c
+++ b/UefiCpuPkg/Library/MpInitLib/LoongArch64/MpLib.c
@@ -130,8 +130,8 @@ SortApicId (
         } else {
           for ( ; Index2 <= ApCount; Index2++) {
             if (CpuInfoInHob[Index2].ApicId == INVALID_APIC_ID) {
-              CopyMem (&CpuInfoInHob[Index2], &CpuInfoInHob[Index1], sizeof (CPU_INFO_IN_HOB));
-              CpuMpData->CpuData[Index2]  = CpuMpData->CpuData[Index1];
+              CopyMem (CpuInfoInHob + Index2, CpuInfoInHob + Index1, sizeof (CPU_INFO_IN_HOB));
+              CopyMem (CpuMpData->CpuData + Index2, CpuMpData->CpuData + Index1, sizeof (CPU_AP_DATA));
               CpuInfoInHob[Index1].ApicId = INVALID_APIC_ID;
               break;
             }


### PR DESCRIPTION
Structure assignment may depend on the compiler to expand to memcpy. 
For this, we may need to add -mno-memcpy to the compilation flag. 
Here, we reduce dependencies and use CopyMem for data conversion without
memcpy.

Cc: Ray Ni <ray.ni@intel.com>
Cc: Rahul Kumar <rahul1.kumar@intel.com>
Cc: Gerd Hoffmann <kraxel@redhat.com>
Cc: Jiaxin Wu <jiaxin.wu@intel.com>
Cc: Chao Li <lichao@loongson.cn>
Signed-off-by: Dongyan Qian <qiandongyan@loongson.cn>
Co-authored-by: Chao Li <lichao@loongson.cn>

# Description

<_Include a description of the change and why this change was made._>

<_For each item, place an "x" in between `[` and `]` if true. Example: `[x]` (you can also check items in GitHub UI)_>

<_Create the PR as a Draft PR if it is only created to run CI checks._>

<_Delete lines in \<\> tags before creating the PR._>

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

<_Describe the test(s) that were run to verify the changes._>

## Integration Instructions

<_Describe how these changes should be integrated. Use N/A if nothing is required._>
