### PR TITLE
ArmPkg: Disable AuditOnly mode for uncrustify

### DIFF
--- a/ArmPkg/ArmPkg.ci.yaml
+++ b/ArmPkg/ArmPkg.ci.yaml
@@ -239,10 +239,5 @@
         ],
         "AdditionalIncludePaths": [] # Additional paths to spell check
                                      # (wildcards supported)
-    },
-
-    # options defined in .pytool/Plugin/UncrustifyCheck
-    "UncrustifyCheck": {
-        "AuditOnly": True
     }
 }

--- a/ArmPkg/Library/ArmMonitorLib/ArmMonitorLib.c
+++ b/ArmPkg/Library/ArmMonitorLib/ArmMonitorLib.c
@@ -26,7 +26,7 @@ ArmMonitorCall (
   IN OUT ARM_MONITOR_ARGS  *Args
   )
 {
-  if (FeaturePcdGet  (PcdMonitorConduitHvc)) {
+  if (FeaturePcdGet (PcdMonitorConduitHvc)) {
     ArmCallHvc ((ARM_HVC_ARGS *)Args);
   } else {
     ArmCallSmc ((ARM_SMC_ARGS *)Args);

--- a/ArmPkg/Library/DebugPeCoffExtraActionLib/DebugPeCoffExtraActionLib.c
+++ b/ArmPkg/Library/DebugPeCoffExtraActionLib/DebugPeCoffExtraActionLib.c
@@ -32,7 +32,7 @@ PeCoffLoaderRelocateImageExtraAction (
   IN OUT PE_COFF_LOADER_IMAGE_CONTEXT  *ImageContext
   )
 {
-#ifdef __GNUC__
+ #ifdef __GNUC__
   if (ImageContext->PdbPointer) {
     DEBUG ((
       DEBUG_LOAD | DEBUG_INFO,
@@ -42,7 +42,8 @@ PeCoffLoaderRelocateImageExtraAction (
       ));
     return;
   }
-#endif
+
+ #endif
 
   DEBUG ((
     DEBUG_LOAD | DEBUG_INFO,
@@ -68,7 +69,7 @@ PeCoffLoaderUnloadImageExtraAction (
   IN OUT PE_COFF_LOADER_IMAGE_CONTEXT  *ImageContext
   )
 {
-#ifdef __GNUC__
+ #ifdef __GNUC__
   if (ImageContext->PdbPointer) {
     DEBUG ((
       DEBUG_LOAD | DEBUG_INFO,
@@ -78,7 +79,8 @@ PeCoffLoaderUnloadImageExtraAction (
       ));
     return;
   }
-#endif
+
+ #endif
 
   DEBUG ((
     DEBUG_LOAD | DEBUG_INFO,


### PR DESCRIPTION
Fix up a handful of uncrustify infractions and drop the AuditOnly override for uncrustify so we get the same uncrustify CI coverage as other packages.

