### PR TITLE
BaseTools: Declare $(DEBUG_DIR)/<module>.efi output

### DIFF
--- a/BaseTools/Conf/build_rule.template
+++ b/BaseTools/Conf/build_rule.template
@@ -376,6 +376,7 @@
     <OutputFile>
         $(OUTPUT_DIR)(+)$(MODULE_NAME).efi
         $(OUTPUT_DIR)(+)$(MODULE_NAME).map
+        $(DEBUG_DIR)(+)$(MODULE_NAME).efi
 
     <Command.MSFT, Command.INTEL, Command.CLANGPDB>
         "$(GENFW)" -e $(MODULE_TYPE) -o ${dst} ${src} $(GENFW_FLAGS)


### PR DESCRIPTION
`$(DEBUG_DIR)/<M>.efi` is generated by the recipe of `$(OUTPUT_DIR)/<M>.efi`: the .efi file is generated and then copied into `$(DEBUG_DIR)`. At the moment the generate GNUmakefile does not declare the dependency between these two files, which can be a problem because `$(FFS_OUTPUT_DIR)/<M>.offset` depends on `$(DEBUG_DIR)/<M>.efi`.

Normally `$(DEBUG_DIR)/<M>.efi` is generated first and there is no problem, but when an external tool builds edk2 from a Makefile, like OP-TEE build does for instance, the parallel '-j' flag passed to Make is inherited by the edk2 GNUmakefile from the environment. As a result Make might try to build the `$(FFS_OUTPUT_DIR)/<M>.offset` target in parallel and fail to find the .efi file:

make[1]: *** No rule to make target 'Build/ArmVirtQemu-AARCH64/DEBUG_GCC5/AARCH64/NetworkPkg/VlanConfigDxe/VlanConfigDxe/DEBUG/VlanConfigDxe.efi', needed by 'Build/ArmVirtQemu-AARCH64/DEBUG_GCC5/FV/Ffs/E4F61863-FE2C-4b56-A8F4-08519BC439DFVlanConfigDxe/VlanConfigDxe.offset'.  Stop.

If we declare the `$(DEBUG_DIR)` file as output of this rule, then the generated GNUmakefile will contain the right dependency declaration:

	$(DEBUG_DIR)/VlanConfigDxe.efi: $(OUTPUT_DIR)/VlanConfigDxe.efi

and the parallel build will succeed.

## How This Was Tested

Create a Makefile containing the following:
```
.ONESHELL:
SHELL = /bin/bash

all:
        source edksetup.sh --reconfig
        export GCC5_AARCH64_PREFIX=aarch64-linux-gnu-
        build -b DEBUG -a AARCH64 -t GCC5 -p ArmVirtPkg/ArmVirtQemu.dsc cleanall
        build -b DEBUG -a AARCH64 -t GCC5 -p ArmVirtPkg/ArmVirtQemu.dsc
```

and run `make -j`