### PR TITLE
ArmPkg: Allow platforms to avoid installing the bite watchdog handler

### DIFF
--- a/ArmPkg/ArmPkg.dec
+++ b/ArmPkg/ArmPkg.dec
@@ -328,6 +328,7 @@
   gArmTokenSpaceGuid.PcdGenericWatchdogControlBase|0x2A440000|UINT64|0x00000007
   gArmTokenSpaceGuid.PcdGenericWatchdogRefreshBase|0x2A450000|UINT64|0x00000008
   gArmTokenSpaceGuid.PcdGenericWatchdogEl2IntrNum|93|UINT32|0x00000009
+  gArmTokenSpaceGuid.PcdGenericWatchdogInstallInterruptHandler|TRUE|BOOLEAN|0x0000000A
 
   #
   # ARM Generic Interrupt Controller

--- a/ArmPkg/Drivers/GenericWatchdogDxe/GenericWatchdogDxe.inf
+++ b/ArmPkg/Drivers/GenericWatchdogDxe/GenericWatchdogDxe.inf
@@ -38,6 +38,7 @@
   gArmTokenSpaceGuid.PcdGenericWatchdogControlBase
   gArmTokenSpaceGuid.PcdGenericWatchdogRefreshBase
   gArmTokenSpaceGuid.PcdGenericWatchdogEl2IntrNum
+  gArmTokenSpaceGuid.PcdGenericWatchdogInstallInterruptHandler
 
 [Protocols]
   gEfiWatchdogTimerArchProtocolGuid       ## ALWAYS_PRODUCES


### PR DESCRIPTION
# Description

Update GenericWatchdogDxe to allow platforms to avoid installing the interrupt handler for the watchdog bite. Some platforms may have a system control processor which handles the bite and does extra processing before resetting the system.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?
