### PR TITLE
MdeModulePkg: Optimize PEI Core Migration Algorithm

### DIFF
--- a/MdeModulePkg/Core/Pei/PeiMain/PeiMain.c
+++ b/MdeModulePkg/Core/Pei/PeiMain/PeiMain.c
@@ -323,6 +323,21 @@ PeiCore (
       //
       OldCoreData->PeiMemoryInstalled = TRUE;
 
+      if (PcdGetBool (PcdMigrateTemporaryRamFirmwareVolumes)) {
+        DEBUG ((DEBUG_VERBOSE, "Early Migration - PPI lists before temporary RAM evacuation:\n"));
+        DumpPpiList (OldCoreData);
+
+        //
+        // Migrate installed content from Temporary RAM to Permanent RAM at this
+        // stage when PEI core still runs from a cached location.
+        // FVs that doesn't contain PEI_CORE should be migrated here.
+        //
+        EvacuateTempRam (OldCoreData, SecCoreData);
+
+        DEBUG ((DEBUG_VERBOSE, "Early Migration - PPI lists after temporary RAM evacuation:\n"));
+        DumpPpiList (OldCoreData);
+      }
+
       //
       // Indicate that PeiCore reenter
       //
@@ -451,6 +466,7 @@ PeiCore (
 
       //
       // Migrate installed content from Temporary RAM to Permanent RAM
+      // FVs containing PEI_CORE should be migrated here.
       //
       EvacuateTempRam (&PrivateData, SecCoreData);
 

--- a/MdeModulePkg/Include/Guid/MigratedFvInfo.h
+++ b/MdeModulePkg/Include/Guid/MigratedFvInfo.h
@@ -18,7 +18,8 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 // 1: FV raw data will be copied to permanent memory for later phase use (such as
 //    FV measurement).
 //
-#define FLAGS_FV_RAW_DATA_COPY  BIT0
+#define FLAGS_FV_RAW_DATA_COPY                    BIT0
+#define FLAGS_FV_MIGRATE_BEFORE_PEI_CORE_REENTRY  BIT1
 
 ///
 /// In real use cases, not all FVs need migrate to permanent memory before TempRam tears


### PR DESCRIPTION
REF : https://bugzilla.tianocore.org/show_bug.cgi?id=4750

Migrate the FV that doesn't contain the currently executing PEI Core when permanent memory is initialized but PEI Core is still potentially running from faster memory (Tepmorary RAM). This may reduce the time required to migrate FVs to permanent memory. The FV containing PEI Core is migrated after the PEI Core reentry when it is executed from permanent memory.

This may or may not improve performance depending on the behavior of temporary RAM and the actual performance changes must be measured with the feature enabled and disabled.

This migration algorithm is only used for FVs specified in the gEdkiiMigrationInfoGuid HOB and built with flag
FLAGS_FV_MIGRATE_BEFORE_PEI_CORE_REENTRY.

# Description

<_Include a description of the change and why this change was made._>

<_For each item, place an "x" in between `[` and `]` if true. Example: `[x]` (you can also check items in GitHub UI)_>

<_Create the PR as a Draft PR if it is only created to run CI checks._>

<_Delete lines in \<\> tags before creating the PR._>

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

<_Describe the test(s) that were run to verify the changes._>

## Integration Instructions

<_Describe how these changes should be integrated. Use N/A if nothing is required._>
