### PR TITLE
ShellPkg: Fix copy-pasto in NULL check to prevent segfault

### DIFF
--- a/ShellPkg/Application/Shell/ShellParametersProtocol.c
+++ b/ShellPkg/Application/Shell/ShellParametersProtocol.c
@@ -1470,7 +1470,7 @@ UpdateArgcArgv (
     *OldArgc = ShellParameters->Argc;
   }
 
-  if (OldArgc != NULL) {
+  if (OldArgv != NULL) {
     *OldArgv = ShellParameters->Argv;
   }
 


### PR DESCRIPTION
# Description

The UpdateArgcArgv() function documentation says "If OldArgv or OldArgc is NULL then that value is not returned."

However, only OldArgc was checked for NULL. In case OldArgc was non-NULL, but OldArgv was NULL, it could cause a segmentation fault.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Not tested. Not sure if any of the current code calls UpdateArgcArgv() with OldArgc non-NULL and OldArgv NULL.

## Integration Instructions

N/A