### PR TITLE
BaseTools/Plugin/CodeQlQueries.qls: Pin to the 1.1.0 codeq/cpp-queries pack

### DIFF
--- a/BaseTools/Plugin/CodeQL/CodeQlQueries.qls
+++ b/BaseTools/Plugin/CodeQL/CodeQlQueries.qls
@@ -2,7 +2,7 @@
 - description: C++ queries
 
 - queries: '.'
-  from: codeql/cpp-queries
+  from: codeql/cpp-queries@1.1.0
 
 ##########################################################################################
 # Queries

--- a/BaseTools/Plugin/CodeQL/codeqlcli_ext_dep.yaml
+++ b/BaseTools/Plugin/CodeQL/codeqlcli_ext_dep.yaml
@@ -8,6 +8,13 @@
 # In an environment where a platform might build in different operating systems, it is recommended to set
 # the scope for the appropriate CodeQL external dependency based on the host operating system being used.
 #
+# ****VERSION UPDATE INSTRUCTIONS****
+#
+# When updating the CodeQL CLI used here, update the corresponding codeql/cpp-queries version in CodeQlQueries.qls.
+# Visit the `qlpack.yml` in the release branch for the CodeQL CLI to get the version to use there. For example, the
+# CodeQL CLI 2.18.1 file is https://github.com/github/codeql/blob/codeql-cli-2.18.1/cpp/ql/src/qlpack.yml and the
+# pack version there is 1.1.0.
+#
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 ##

--- a/BaseTools/Plugin/CodeQL/codeqlcli_linux_ext_dep.yaml
+++ b/BaseTools/Plugin/CodeQL/codeqlcli_linux_ext_dep.yaml
@@ -6,6 +6,13 @@
 # systems, it is recommended to set the scope for the appropriate CodeQL external dependency based on the
 # host operating system being used.
 #
+# ****VERSION UPDATE INSTRUCTIONS****
+#
+# When updating the CodeQL CLI used here, update the corresponding codeql/cpp-queries version in CodeQlQueries.qls.
+# Visit the `qlpack.yml` in the release branch for the CodeQL CLI to get the version to use there. For example, the
+# CodeQL CLI 2.18.1 file is https://github.com/github/codeql/blob/codeql-cli-2.18.1/cpp/ql/src/qlpack.yml and the
+# pack version there is 1.1.0.
+#
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 ##

--- a/BaseTools/Plugin/CodeQL/codeqlcli_windows_ext_dep.yaml
+++ b/BaseTools/Plugin/CodeQL/codeqlcli_windows_ext_dep.yaml
@@ -6,6 +6,13 @@
 # systems, it is recommended to set the scope for the appropriate CodeQL external dependency based on the
 # host operating system being used.
 #
+# ****VERSION UPDATE INSTRUCTIONS****
+#
+# When updating the CodeQL CLI used here, update the corresponding codeql/cpp-queries version in CodeQlQueries.qls.
+# Visit the `qlpack.yml` in the release branch for the CodeQL CLI to get the version to use there. For example, the
+# CodeQL CLI 2.18.1 file is https://github.com/github/codeql/blob/codeql-cli-2.18.1/cpp/ql/src/qlpack.yml and the
+# pack version there is 1.1.0.
+#
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 ##


### PR DESCRIPTION
# Description

The codeql/cpp-queries pack used in CodeQlQueries.qls was versioned 1.1.0 for the CodeQL CLI v2.18.1 release currently used.

https://github.com/github/codeql/blob/codeql-cli/v2.18.1/cpp/ql/src/qlpack.yml

This change pins that pack version to prevent the CodeQL CLI and pack from getting out of sync until explicitly updated.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

- CodeQL run with v2.18.1
- Confirm using the specified CodeQL language pack version is used

## Integration Instructions

- N/A