### PR TITLE
ShellPkg: Do not strip quotation marks for internal shell commands

### DIFF
--- a/ShellPkg/Application/Shell/ShellParametersProtocol.c
+++ b/ShellPkg/Application/Shell/ShellParametersProtocol.c
@@ -1441,7 +1441,7 @@ UpdateArgcArgv (
   BOOLEAN  StripParamQuotation;
 
   ASSERT (ShellParameters != NULL);
-  StripParamQuotation = TRUE;
+  StripParamQuotation = FALSE;
 
   if (OldArgc != NULL) {
     *OldArgc = ShellParameters->Argc;
@@ -1451,8 +1451,8 @@ UpdateArgcArgv (
     *OldArgv = ShellParameters->Argv;
   }
 
-  if (Type == Script_File_Name) {
-    StripParamQuotation = FALSE;
+  if (Type == Efi_Application) {
+    StripParamQuotation = TRUE;
   }
 
   return ParseCommandLineToArgs (

--- a/ShellPkg/Library/UefiShellBcfgCommandLib/UefiShellBcfgCommandLib.c
+++ b/ShellPkg/Library/UefiShellBcfgCommandLib/UefiShellBcfgCommandLib.c
@@ -568,6 +568,7 @@ BcfgAdd (
   EFI_SHELL_FILE_INFO       *Arg;
   EFI_SHELL_FILE_INFO       *FileList;
   CHAR16                    OptionStr[40];
+  CHAR16                    *ClosingQuote;
   UINTN                     DescSize, FilePathSize;
   BOOLEAN                   Found;
   UINTN                     TargetLocation;
@@ -774,6 +775,19 @@ BcfgAdd (
       ShellPrintHiiEx (-1, -1, NULL, STRING_TOKEN (STR_BCFG_TARGET_NF), gShellBcfgHiiHandle, L"bcfg");
     } else {
       ShellPrintHiiEx (-1, -1, NULL, STRING_TOKEN (STR_BCFG_TARGET), gShellBcfgHiiHandle, TargetLocation);
+    }
+  }
+
+  if (ShellStatus == SHELL_SUCCESS) {
+    //
+    // Remove quotes from description string
+    //
+    if (*Desc == L'\"') {
+      Desc         = &Desc[1];
+      ClosingQuote = StrStr (Desc, L"\"");
+      if (ClosingQuote) {
+        *ClosingQuote = CHAR_NULL;
+      }
     }
   }
 

--- a/ShellPkg/Library/UefiShellLevel2CommandsLib/Set.c
+++ b/ShellPkg/Library/UefiShellLevel2CommandsLib/Set.c
@@ -62,11 +62,13 @@ ShellCommandRunSet (
   LIST_ENTRY    *Package;
   CONST CHAR16  *KeyName;
   CONST CHAR16  *Value;
+  CHAR16        *CleanValue;
   CHAR16        *ProblemParam;
   SHELL_STATUS  ShellStatus;
 
   ProblemParam = NULL;
   ShellStatus  = SHELL_SUCCESS;
+  CleanValue   = NULL;
 
   //
   // initialize the shell lib (we must be in non-auto-init...)
@@ -134,10 +136,19 @@ ShellCommandRunSet (
         //
         // assigning one
         //
-        Status = ShellSetEnvironmentVariable (KeyName, Value, ShellCommandLineGetFlag (Package, L"-v"));
+
+        Status = ShellLevel2StripQuotes (Value, &CleanValue);
         if (EFI_ERROR (Status)) {
           ShellPrintHiiEx (-1, -1, NULL, STRING_TOKEN (STR_SET_ERROR_SET), gShellLevel2HiiHandle, L"set", KeyName);
           ShellStatus = (SHELL_STATUS)(Status & (~MAX_BIT));
+        } else {
+          Status = ShellSetEnvironmentVariable (KeyName, CleanValue, ShellCommandLineGetFlag (Package, L"-v"));
+          if (EFI_ERROR (Status)) {
+            ShellPrintHiiEx (-1, -1, NULL, STRING_TOKEN (STR_SET_ERROR_SET), gShellLevel2HiiHandle, L"set", KeyName);
+            ShellStatus = (SHELL_STATUS)(Status & (~MAX_BIT));
+          }
+
+          FreePool (CleanValue);
         }
       } else {
         if (KeyName != NULL) {


### PR DESCRIPTION
# Description

Some shell commands relies on being able to detect if an argument is enclosed in double quotes or not. See for example the `bcfg -opt` option description on page 97 of the UEFI Shell 2.2 specification. We must therefore preserve double quotes while passing the arguments around.

The UEFI Shell 2.2 specification page 68 indicates that only shell applications should have the double quotes removed.

In the above mentioned case of bcfg, the current code actually checks for quotes, but will not see any since they are already stripped.


- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Before:

```
Shell> bcfg boot -opt 2 "abc"
bcfg: File not found - 'abc'
Shell>
```
(bcfg boot dump -b -v confirms nothing was changed)
```
Shell> bcfg boot dump -v -b
  ...
  Optional- Y
  00000000: 78 00 79 00 7A 00 00 00-                         *x.y.z...*
```

After:

```
Shell> bcfg boot -opt 2 "abc"
Shell>
Shell> bcfg boot dump -v -b
  ...
  Optional- Y
  00000000: 61 00 62 00 63 00 00 00-                         *a.b.c...*
```

The exisiting workaround of escaping the quotes, i.e. `bcfg boot -opt 2 ^"abc^"` still works with this PR applied.

Note that PR #5971 was also applied in above test to avoid corrupted data in the optional data. The PRs are independent but the other PR makes it easier to verify this PR.

## Possible regressions

These commands are the only ones where quoting is mentioned in the specification:

- [x] `bcfg boot add` requires a "description" argument that should be quoted. bcfg has been fixed to strip these quotes in the first commit.

- [x] `for` takes a space-separated set of items, and quotes can be used for items that includes a space. Both `%i in "1" "2"` and `for %i in "1 2"`  works as expected with this PR applied.

- [ ] `setvar`: String values for `=S` should be quoted. However, I am currently not able to create new variables for testing this, and resetting existing ones also fail.

Other commands:

- [x] `set`: The specification doesn't mention quoting. `set abc "a b c"` will include the quotes in the value. `set abc a b c` will fail with "Too many arguments". I have fixed `set` to remove the quotes in the second commit.

- [x] Various commands taking file names as arguments: File names that includes spaces need quotes. E.g. `type "split name.txt"` works as expected.

## Integration Instructions

N/A