### PR TITLE
.github: Request PR reviewers enhancements

### DIFF
--- a/.github/scripts/GitHub.py
+++ b/.github/scripts/GitHub.py
@@ -221,30 +221,40 @@ def add_reviewers_to_pr(
             f"::error title=User is not a Collaborator!::{', '.join(non_collaborators)}"
             )
 
-        repo_admins = [
-            a.login for a in repo_gh.get_collaborators(permission="admin")
-        ]
+        for comment in pr.get_issue_comments():
+            # If a comment has already been made for these non-collaborators,
+            # do not make another comment.
+            if (
+                comment.user.login == "github-actions[bot]"
+                and "WARNING: Cannot add some reviewers" in comment.body
+                and all(u in comment.body for u in non_collaborators)
+            ):
+                break
+        else:
+            repo_admins = [
+                a.login for a in repo_gh.get_collaborators(permission="admin")
+            ]
 
-        leave_pr_comment(
-            token,
-            owner,
-            repo,
-            pr_number,
-            f"&#9888; **WARNING: Cannot add some reviewers**: A user  "
-            f"specified as a reviewer for this PR is not a collaborator "
-            f"of the repository. Please add them as a collaborator to "
-            f"the repository so they can be requested in the future.\n\n"
-            f"Non-collaborators requested:\n"
-            f"{'\n'.join([f'- @{c}' for c in non_collaborators])}"
-            f"\n\nAttn Admins:\n"
-            f"{'\n'.join([f'- @{a}' for a in repo_admins])}\n---\n"
-            f"**Admin Instructions:**\n"
-            f"- Add the non-collaborators as collaborators to the "
-            f"appropriate team(s) listed in "
-            f"[teams](https://github.com/orgs/tianocore/teams)\n"
-            f"- If they are no longer needed as reviewers, remove them "
-            f"from [`Maintainers.txt`](https://github.com/tianocore/edk2/blob/HEAD/Maintainers.txt)",
-        )
+            leave_pr_comment(
+                token,
+                owner,
+                repo,
+                pr_number,
+                f"&#9888; **WARNING: Cannot add some reviewers**: A user  "
+                f"specified as a reviewer for this PR is not a collaborator "
+                f"of the repository. Please add them as a collaborator to "
+                f"the repository so they can be requested in the future.\n\n"
+                f"Non-collaborators requested:\n"
+                f"{'\n'.join([f'- @{c}' for c in non_collaborators])}"
+                f"\n\nAttn Admins:\n"
+                f"{'\n'.join([f'- @{a}' for a in repo_admins])}\n---\n"
+                f"**Admin Instructions:**\n"
+                f"- Add the non-collaborators as collaborators to the "
+                f"appropriate team(s) listed in "
+                f"[teams](https://github.com/orgs/tianocore/teams)\n"
+                f"- If they are no longer needed as reviewers, remove them "
+                f"from [`Maintainers.txt`](https://github.com/tianocore/edk2/blob/HEAD/Maintainers.txt)",
+            )
 
     # Add any new reviewers to the PR if needed.
     if new_pr_reviewers:

--- a/.github/scripts/GitHub.py
+++ b/.github/scripts/GitHub.py
@@ -221,16 +221,29 @@ def add_reviewers_to_pr(
             f"::error title=User is not a Collaborator!::{', '.join(non_collaborators)}"
             )
 
+        repo_admins = [
+            a.login for a in repo_gh.get_collaborators(permission="admin")
+        ]
+
         leave_pr_comment(
             token,
             owner,
             repo,
             pr_number,
-            f"&#9888; **WARNING: Cannot add reviewers**: A user specified as a "
-            f"reviewer for this PR is not a collaborator "
-            f"of the edk2 repository. Please add them as a collaborator to the "
-            f"repository and re-request the review.\n\n"
-            f"Users requested:\n{', '.join(user_names)}",
+            f"&#9888; **WARNING: Cannot add some reviewers**: A user  "
+            f"specified as a reviewer for this PR is not a collaborator "
+            f"of the repository. Please add them as a collaborator to "
+            f"the repository so they can be requested in the future.\n\n"
+            f"Non-collaborators requested:\n"
+            f"{'\n'.join([f'- @{c}' for c in non_collaborators])}"
+            f"\n\nAttn Admins:\n"
+            f"{'\n'.join([f'- @{a}' for a in repo_admins])}\n---\n"
+            f"**Admin Instructions:**\n"
+            f"- Add the non-collaborators as collaborators to the "
+            f"appropriate team(s) listed in "
+            f"[teams](https://github.com/orgs/tianocore/teams)\n"
+            f"- If they are no longer needed as reviewers, remove them "
+            f"from [`Maintainers.txt`](https://github.com/tianocore/edk2/blob/HEAD/Maintainers.txt)",
         )
 
     # Add any new reviewers to the PR if needed.

--- a/.github/scripts/GitHub.py
+++ b/.github/scripts/GitHub.py
@@ -8,7 +8,6 @@
 import git
 import logging
 import re
-import requests
 
 from collections import OrderedDict
 from edk2toollib.utility_functions import RunPythonScript
@@ -171,32 +170,6 @@ def get_pr_sha(token: str, owner: str, repo: str, pr_number: int) -> str:
         return merge_commit_sha
 
     return ""
-
-
-def download_gh_file(github_url: str, local_path: str, token=None):
-    """Downloads a file from GitHub.
-
-    Args:
-        github_url (str): The GitHub raw file URL.
-        local_path (str): A local path to write the file contents to.
-        token (_type_, optional): A GitHub authentication token.
-            Only needed for a private repo. Defaults to None.
-    """
-    headers = {}
-    if token:
-        headers["Authorization"] = f"Bearer {token}"
-
-    try:
-        response = requests.get(github_url, headers=headers)
-        response.raise_for_status()
-    except requests.exceptions.HTTPError:
-        print(
-            f"::error title=HTTP Error!::Error downloading {github_url}: {response.reason}"
-        )
-        return
-
-    with open(local_path, "w", encoding="utf-8") as file:
-        file.write(response.text)
 
 
 def add_reviewers_to_pr(

--- a/.github/scripts/GitHub.py
+++ b/.github/scripts/GitHub.py
@@ -126,7 +126,9 @@ def get_reviewers_for_range(
         )
         if cmd_ret != 0:
             print(
-                f"::error title=Reviewer Lookup Error!::Error calling GetMaintainer.py: [{cmd_ret}]: {reviewer_stream_buffer.getvalue()}"
+                f"::error title=Reviewer Lookup Error!::Error calling "
+                f"GetMaintainer.py: [{cmd_ret}]: "
+                f"{reviewer_stream_buffer.getvalue()}"
             )
             return []
 
@@ -138,7 +140,8 @@ def get_reviewers_for_range(
             return []
 
         print(
-            f"::debug title=Commit {commit_sha[:7]} Reviewer(s)::{', '.join(matches)}"
+            f"::debug title=Commit {commit_sha[:7]} "
+            f"Reviewer(s)::{', '.join(matches)}"
         )
 
         raw_reviewers.extend(matches)
@@ -232,8 +235,9 @@ def add_reviewers_to_pr(
     # Notify the admins of the repository if non-collaborators are requested.
     if non_collaborators:
         print(
-            f"::warning title=Non-Collaborator Reviewers Found!::{', '.join(non_collaborators)}"
-            )
+            f"::warning title=Non-Collaborator Reviewers Found!::"
+            f"{', '.join(non_collaborators)}"
+        )
 
         for comment in pr.get_issue_comments():
             # If a comment has already been made for these non-collaborators,

--- a/.github/scripts/RequestPrReviewers.py
+++ b/.github/scripts/RequestPrReviewers.py
@@ -1,0 +1,98 @@
+## @file
+#  Used in a CI workflow to request reviewers for a pull request.
+#
+#  Refer to the following link for a list of pre-defined GitHub workflow
+#  environment variables:
+#    https://docs.github.com/actions/reference/environment-variables
+#
+#  Copyright (c) Microsoft Corporation.
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+
+import git
+import GitHub
+import os
+import sys
+
+
+"""Request Pull Request Reviewers Helpers"""
+
+
+def request_pr_reviewers():
+    """Request pull request reviewers for a GitHub PR.
+
+    This function is intended to be used in a GitHub Actions workflow to
+    request reviewers for a pull request triggered by a GitHub event. The
+    function makes assumptions about GitHub workflow environment variables and
+    the pull request context in which it is run.
+
+    The function will exit with a non-zero status indicating an error if a
+    critical error occurs during execution so the workflow fails.
+
+    The following environment variables are expected to be set before calling
+    this function. The recommend GitHub context values are show for reference:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ORG_NAME: ${{ github.repository_owner }}
+          PR_NUMBER: ${{ github.event.number}}
+          REPO_NAME: ${{ github.event.pull_request.base.repo.name }}
+          TARGET_BRANCH: ${{ github.event.pull_request.base.ref }}
+          WORKSPACE_PATH: ${{ github.workspace }}
+    """
+    WORKSPACE_PATH = os.environ["WORKSPACE_PATH"]
+    GET_MAINTAINER_LOCAL_PATH = os.path.join(
+        WORKSPACE_PATH, os.environ["GET_MAINTAINER_REL_PATH"]
+    )
+
+    # Step 1: Get the GitHub created PR commit SHA (contains all changes in a single commit)
+    pr_commit_sha = GitHub.get_pr_sha(
+        os.environ["GH_TOKEN"],
+        os.environ["ORG_NAME"],
+        os.environ["REPO_NAME"],
+        int(os.environ["PR_NUMBER"]),
+    )
+    if not pr_commit_sha:
+        sys.exit(1)
+
+    print(
+        f"::notice title=PR Commit SHA::Looking at files in consolidated PR commit: {pr_commit_sha}"
+    )
+
+    # Step 2: Fetch only the PR commit to get the files changed in the PR
+    git.Repo(WORKSPACE_PATH).remotes.origin.fetch(pr_commit_sha, depth=1)
+
+    # Step 3: Get the list of reviewers for the PR
+    reviewers = GitHub.get_reviewers_for_range(
+        WORKSPACE_PATH, GET_MAINTAINER_LOCAL_PATH, pr_commit_sha, pr_commit_sha
+    )
+    if not reviewers:
+        print("::notice title=No New Reviewers Found!::No reviewers found for this PR.")
+        sys.exit(0)
+
+    print(
+        f"::notice title=Preliminary Reviewer List::Total reviewer candidates for "
+        f"PR {os.environ['PR_NUMBER']}: {', '.join(reviewers)}"
+    )
+
+    # Step 4: Add the reviewers to the PR
+    #         Note the final requested reviewer list in the workflow run for reference
+    new_reviewers = GitHub.add_reviewers_to_pr(
+        os.environ["GH_TOKEN"],
+        os.environ["ORG_NAME"],
+        os.environ["REPO_NAME"],
+        int(os.environ["PR_NUMBER"]),
+        reviewers,
+    )
+    if new_reviewers:
+        print(
+            f"::notice title=New Reviewers Added::New reviewers requested for PR "
+            f"{os.environ['PR_NUMBER']}: {', '.join(new_reviewers)}"
+        )
+    else:
+        print(
+            "::notice title=No New Reviewers Added::No reviewers were found that "
+            "should be newly requested."
+        )
+
+
+if __name__ == '__main__':
+    request_pr_reviewers()

--- a/.github/scripts/requirements.txt
+++ b/.github/scripts/requirements.txt
@@ -1,0 +1,12 @@
+## @file
+# GitHub Helpers Python PIP requirements file
+#
+# This file provides the list of python components used in GitHub scripts in this repository.
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+edk2-pytool-library==0.*
+requests==2.*

--- a/.github/scripts/requirements.txt
+++ b/.github/scripts/requirements.txt
@@ -11,4 +11,3 @@
 edk2-pytool-library==0.*
 GitPython==3.*
 PyGithub==2.*
-requests==2.*

--- a/.github/scripts/requirements.txt
+++ b/.github/scripts/requirements.txt
@@ -10,4 +10,5 @@
 
 edk2-pytool-library==0.*
 GitPython==3.*
+PyGithub==2.*
 requests==2.*

--- a/.github/scripts/requirements.txt
+++ b/.github/scripts/requirements.txt
@@ -9,4 +9,5 @@
 ##
 
 edk2-pytool-library==0.*
+GitPython==3.*
 requests==2.*

--- a/.github/workflows/request-reviews.yml
+++ b/.github/workflows/request-reviews.yml
@@ -45,13 +45,15 @@ jobs:
             BaseTools/Scripts
             Maintainers.txt
 
-      - name: Set up Python
+      - name: Setup Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.x'
+          cache: 'pip'
+          cache-dependency-path: '.github/scripts/requirements.txt'
 
       - name: Install PIP Modules
-        run: pip install edk2-pytool-library edk2-pytool-extensions requests
+        run: pip install -r .github/scripts/requirements.txt --upgrade
 
       - name: Add Reviewers to Pull Request
         shell: python

--- a/.github/workflows/request-reviews.yml
+++ b/.github/workflows/request-reviews.yml
@@ -32,10 +32,18 @@ jobs:
       pull-requests: write
 
     steps:
+      # Reduce checkout time with sparse-checkout
+      #   - .github: Contains the scripts to interact with Github and add reviewers
+      #   - BaseTools/Scripts: Contains the GetMaintainer.py script
+      #   - Maintainers.txt: Contains the list of maintainers for the repository
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 1
+          sparse-checkout: |
+            .github
+            BaseTools/Scripts
+            Maintainers.txt
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/request-reviews.yml
+++ b/.github/workflows/request-reviews.yml
@@ -65,12 +65,10 @@ jobs:
           TARGET_BRANCH: ${{ github.event.pull_request.base.ref }}
           WORKSPACE_PATH: ${{ github.workspace }}
         run: |
-            import logging
+            import git
             import os
             import sys
             sys.path.append(os.path.join(os.environ['WORKSPACE_PATH'], ".github"))
-            from edk2toollib.utility_functions import RunCmd
-            from io import StringIO
             from scripts import GitHub
 
             WORKSPACE_PATH = os.environ['WORKSPACE_PATH']
@@ -82,19 +80,7 @@ jobs:
 
             print(f"::notice title=PR Commit SHA::Looking at files in consolidated PR commit: {pr_commit_sha}")
 
-            out_stream_buffer = StringIO()
-            cmd_ret = RunCmd(
-                "git",
-                f"fetch origin {pr_commit_sha}",
-                workingdir=WORKSPACE_PATH,
-                outstream=out_stream_buffer,
-                logging_level=logging.INFO,
-            )
-            if cmd_ret != 0:
-                print(
-                    f"::error title=Commit Fetch Error!::Error fetching PR commit: [{cmd_ret}]: {out_stream_buffer.getvalue()}"
-                )
-                sys.exit(1)
+            git.Repo(WORKSPACE_PATH).remotes.origin.fetch(pr_commit_sha, depth=1)
 
             reviewers = GitHub.get_reviewers_for_range(WORKSPACE_PATH, GET_MAINTAINER_LOCAL_PATH, pr_commit_sha, pr_commit_sha)
             if not reviewers:

--- a/.github/workflows/request-reviews.yml
+++ b/.github/workflows/request-reviews.yml
@@ -74,14 +74,17 @@ jobs:
             WORKSPACE_PATH = os.environ['WORKSPACE_PATH']
             GET_MAINTAINER_LOCAL_PATH = os.path.join(WORKSPACE_PATH, os.environ['GET_MAINTAINER_REL_PATH'])
 
+            # Step 1: Get the GitHub created PR commit SHA (contains all changes in a single commit)
             pr_commit_sha = GitHub.get_pr_sha(os.environ['GH_TOKEN'], os.environ['ORG_NAME'], os.environ['REPO_NAME'], int(os.environ['PR_NUMBER']))
             if not pr_commit_sha:
                 sys.exit(1)
 
             print(f"::notice title=PR Commit SHA::Looking at files in consolidated PR commit: {pr_commit_sha}")
 
+            # Step 2: Fetch only the PR commit to get the files changed in the PR
             git.Repo(WORKSPACE_PATH).remotes.origin.fetch(pr_commit_sha, depth=1)
 
+            # Step 3: Get the list of reviewers for the PR
             reviewers = GitHub.get_reviewers_for_range(WORKSPACE_PATH, GET_MAINTAINER_LOCAL_PATH, pr_commit_sha, pr_commit_sha)
             if not reviewers:
                 print("::notice title=No New Reviewers Found!::No reviewers found for this PR.")
@@ -92,6 +95,8 @@ jobs:
                 f"PR {os.environ['PR_NUMBER']}: {', '.join(reviewers)}"
             )
 
+            # Step 4: Add the reviewers to the PR
+            #         Note the final requested reviewer list in the workflow run for reference
             new_reviewers = GitHub.add_reviewers_to_pr(
                 os.environ["GH_TOKEN"],
                 os.environ["ORG_NAME"],

--- a/.github/workflows/request-reviews.yml
+++ b/.github/workflows/request-reviews.yml
@@ -68,24 +68,36 @@ jobs:
             import git
             import os
             import sys
-            sys.path.append(os.path.join(os.environ['WORKSPACE_PATH'], ".github"))
+
+            sys.path.append(os.path.join(os.environ["WORKSPACE_PATH"], ".github"))
             from scripts import GitHub
 
-            WORKSPACE_PATH = os.environ['WORKSPACE_PATH']
-            GET_MAINTAINER_LOCAL_PATH = os.path.join(WORKSPACE_PATH, os.environ['GET_MAINTAINER_REL_PATH'])
+            WORKSPACE_PATH = os.environ["WORKSPACE_PATH"]
+            GET_MAINTAINER_LOCAL_PATH = os.path.join(
+                WORKSPACE_PATH, os.environ["GET_MAINTAINER_REL_PATH"]
+            )
 
             # Step 1: Get the GitHub created PR commit SHA (contains all changes in a single commit)
-            pr_commit_sha = GitHub.get_pr_sha(os.environ['GH_TOKEN'], os.environ['ORG_NAME'], os.environ['REPO_NAME'], int(os.environ['PR_NUMBER']))
+            pr_commit_sha = GitHub.get_pr_sha(
+                os.environ["GH_TOKEN"],
+                os.environ["ORG_NAME"],
+                os.environ["REPO_NAME"],
+                int(os.environ["PR_NUMBER"]),
+            )
             if not pr_commit_sha:
                 sys.exit(1)
 
-            print(f"::notice title=PR Commit SHA::Looking at files in consolidated PR commit: {pr_commit_sha}")
+            print(
+                f"::notice title=PR Commit SHA::Looking at files in consolidated PR commit: {pr_commit_sha}"
+            )
 
             # Step 2: Fetch only the PR commit to get the files changed in the PR
             git.Repo(WORKSPACE_PATH).remotes.origin.fetch(pr_commit_sha, depth=1)
 
             # Step 3: Get the list of reviewers for the PR
-            reviewers = GitHub.get_reviewers_for_range(WORKSPACE_PATH, GET_MAINTAINER_LOCAL_PATH, pr_commit_sha, pr_commit_sha)
+            reviewers = GitHub.get_reviewers_for_range(
+                WORKSPACE_PATH, GET_MAINTAINER_LOCAL_PATH, pr_commit_sha, pr_commit_sha
+            )
             if not reviewers:
                 print("::notice title=No New Reviewers Found!::No reviewers found for this PR.")
                 sys.exit(0)

--- a/.github/workflows/request-reviews.yml
+++ b/.github/workflows/request-reviews.yml
@@ -56,7 +56,6 @@ jobs:
         run: pip install -r .github/scripts/requirements.txt --upgrade
 
       - name: Add Reviewers to Pull Request
-        shell: python
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ORG_NAME: ${{ github.repository_owner }}
@@ -64,65 +63,4 @@ jobs:
           REPO_NAME: ${{ github.event.pull_request.base.repo.name }}
           TARGET_BRANCH: ${{ github.event.pull_request.base.ref }}
           WORKSPACE_PATH: ${{ github.workspace }}
-        run: |
-            import git
-            import os
-            import sys
-
-            sys.path.append(os.path.join(os.environ["WORKSPACE_PATH"], ".github"))
-            from scripts import GitHub
-
-            WORKSPACE_PATH = os.environ["WORKSPACE_PATH"]
-            GET_MAINTAINER_LOCAL_PATH = os.path.join(
-                WORKSPACE_PATH, os.environ["GET_MAINTAINER_REL_PATH"]
-            )
-
-            # Step 1: Get the GitHub created PR commit SHA (contains all changes in a single commit)
-            pr_commit_sha = GitHub.get_pr_sha(
-                os.environ["GH_TOKEN"],
-                os.environ["ORG_NAME"],
-                os.environ["REPO_NAME"],
-                int(os.environ["PR_NUMBER"]),
-            )
-            if not pr_commit_sha:
-                sys.exit(1)
-
-            print(
-                f"::notice title=PR Commit SHA::Looking at files in consolidated PR commit: {pr_commit_sha}"
-            )
-
-            # Step 2: Fetch only the PR commit to get the files changed in the PR
-            git.Repo(WORKSPACE_PATH).remotes.origin.fetch(pr_commit_sha, depth=1)
-
-            # Step 3: Get the list of reviewers for the PR
-            reviewers = GitHub.get_reviewers_for_range(
-                WORKSPACE_PATH, GET_MAINTAINER_LOCAL_PATH, pr_commit_sha, pr_commit_sha
-            )
-            if not reviewers:
-                print("::notice title=No New Reviewers Found!::No reviewers found for this PR.")
-                sys.exit(0)
-
-            print(
-                f"::notice title=Preliminary Reviewer List::Total reviewer candidates for "
-                f"PR {os.environ['PR_NUMBER']}: {', '.join(reviewers)}"
-            )
-
-            # Step 4: Add the reviewers to the PR
-            #         Note the final requested reviewer list in the workflow run for reference
-            new_reviewers = GitHub.add_reviewers_to_pr(
-                os.environ["GH_TOKEN"],
-                os.environ["ORG_NAME"],
-                os.environ["REPO_NAME"],
-                int(os.environ["PR_NUMBER"]),
-                reviewers,
-            )
-            if new_reviewers:
-                print(
-                    f"::notice title=New Reviewers Added::New reviewers requested for PR "
-                    f"{os.environ['PR_NUMBER']}: {', '.join(new_reviewers)}"
-                )
-            else:
-                print(
-                    "::notice title=No New Reviewers Added::No reviewers were found that "
-                    "should be newly requested."
-                )
+        run: python .github/scripts/RequestPrReviewers.py

--- a/.github/workflows/request-reviews.yml
+++ b/.github/workflows/request-reviews.yml
@@ -74,7 +74,7 @@ jobs:
             WORKSPACE_PATH = os.environ['WORKSPACE_PATH']
             GET_MAINTAINER_LOCAL_PATH = os.path.join(WORKSPACE_PATH, os.environ['GET_MAINTAINER_REL_PATH'])
 
-            pr_commit_sha = GitHub.get_pr_sha(os.environ['GH_TOKEN'], os.environ['ORG_NAME'], os.environ['REPO_NAME'], os.environ['PR_NUMBER'])
+            pr_commit_sha = GitHub.get_pr_sha(os.environ['GH_TOKEN'], os.environ['ORG_NAME'], os.environ['REPO_NAME'], int(os.environ['PR_NUMBER']))
             if not pr_commit_sha:
                 sys.exit(1)
 
@@ -89,4 +89,4 @@ jobs:
 
             print(f"::notice title=Reviewer List::Reviewers found for PR {os.environ['PR_NUMBER']}:\n{', '.join(reviewers)}")
 
-            GitHub.add_reviewers_to_pr(os.environ['GH_TOKEN'], os.environ['ORG_NAME'], os.environ['REPO_NAME'], os.environ['PR_NUMBER'], reviewers)
+            GitHub.add_reviewers_to_pr(os.environ['GH_TOKEN'], os.environ['ORG_NAME'], os.environ['REPO_NAME'], int(os.environ['PR_NUMBER']), reviewers)

--- a/.github/workflows/request-reviews.yml
+++ b/.github/workflows/request-reviews.yml
@@ -84,9 +84,28 @@ jobs:
 
             reviewers = GitHub.get_reviewers_for_range(WORKSPACE_PATH, GET_MAINTAINER_LOCAL_PATH, pr_commit_sha, pr_commit_sha)
             if not reviewers:
-                print("::notice title=No Reviewers Found!::No reviewers found for this PR.")
-                sys.exit(1)
+                print("::notice title=No New Reviewers Found!::No reviewers found for this PR.")
+                sys.exit(0)
 
-            print(f"::notice title=Reviewer List::Reviewers found for PR {os.environ['PR_NUMBER']}:\n{', '.join(reviewers)}")
+            print(
+                f"::notice title=Preliminary Reviewer List::Total reviewer candidates for "
+                f"PR {os.environ['PR_NUMBER']}: {', '.join(reviewers)}"
+            )
 
-            GitHub.add_reviewers_to_pr(os.environ['GH_TOKEN'], os.environ['ORG_NAME'], os.environ['REPO_NAME'], int(os.environ['PR_NUMBER']), reviewers)
+            new_reviewers = GitHub.add_reviewers_to_pr(
+                os.environ["GH_TOKEN"],
+                os.environ["ORG_NAME"],
+                os.environ["REPO_NAME"],
+                int(os.environ["PR_NUMBER"]),
+                reviewers,
+            )
+            if new_reviewers:
+                print(
+                    f"::notice title=New Reviewers Added::New reviewers requested for PR "
+                    f"{os.environ['PR_NUMBER']}: {', '.join(new_reviewers)}"
+                )
+            else:
+                print(
+                    "::notice title=No New Reviewers Added::No reviewers were found that "
+                    "should be newly requested."
+                )


### PR DESCRIPTION
# Description

Makes a number of optimizations and enhancements for the request reviewer workflow.  This is considered a large rewrite of the workflow. The following items represent the main changes.

1. Uses `PyGithub` for GitHub interactions instead of the GitHub REST API directly.
2. Uses `GitPython` instead of invoking the git executable directly.
3. Optimizes the repository checkout step from an average time of 21 seconds to 1 second by performing a sparse checkout of only the file paths needed for the workflow run at a fetch depth of 1.
4. Optimizes and makes the PIP module installation process for the workflow more robust by caching the pip modules used so the only time the workflow needs to reach to PyPi is when new PIP modules are published.
5. Improves long term stability by locking the major versions for PIP modules in the workflow. This is to reduce overall maintenance over time to automatically pick up new versions while also not being broken in the process.
6. Cleans up workflow messages so it is easy to see the code evaluated by the workflow (the GitHub created PR merge commit), the list of reviewers relevant to the PR changes (those returned from GetMaintainer.py for the change), and the final list of reviewers being added to the PR (if any).
7. Today, if a reviewer found is not a collaborator of the repo, the workflow will post a comment in the PR with the list of GitHub usernames requested for reviewer and state that one or more reviewers are not collaborators. This change enhances this flow by:

   1. Adding reviewers that are collaborators to the PR (instead of only commenting and not adding any reviewers).
   2. Adding a notification in the comment for the current admins of the repo so they are directly notified and no action is needed from PR participants.
   3. Only posting the comment once in the PR by checking if a comment was already previously posted for the given set of non-collaborator reviewers found.
   4. Enhancing the workflow messages by always showing the list of non-collaborator reviewers found.
8. Reduces the overall number GitHub REST API calls made per run by leveraging information available in larger PR context structures.
9. Removes unnecessary code and adds additional code documentation in some places.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

Pull requests made from public forks onto an edk2 fork.

Verified:

- The GitHub workflow token has sufficient privilege.
- The GitHub workflow triggers as expected.
- Incoming GitHub context is accurate for its usage.
- The GitHub PR merge commit used for processing is valid per run with expected content.
- Draft pull requests are successfully excluded.
- Expected reviewers are added to the PR.
  - New reviewers are requested in the PR successfully.
  - Reviewers are not requested for a PR if they are already listed as a PR reviewer.
  - The requested reviewers list acquired from GitHub is accurate (requested and no review).
  - The reviewers list acquired from GitHub is accurate (requested and reviewed).
- The flow for the case a reviewer is found that is not a collaborator is successful.
  - The repo collaborators list acquired from GitHub is accurate.
  - The repo administrators list acquired from GitHub is accurate.
  - A GitHub comment is posted and formatted properly.
  - The list of non-collaborator users referenced in the comment is accurate.
  - The admins are notified as expected in the comment.
  - The comment is only posted in a PR once unless a new non-collaborator is added.
- Workflow debug messages are as expected in presence and content.
- Git command line calls replaced with `GitPython` return the same content.
- PIP module caching works as expected.
- Workflow error exit path behaves as expected.
- Workflow run time is consistent (~30s total).

## Integration Instructions

N/A - Local to edk2 repo