### PR TITLE
Fix issue in Pei/Variable.c

### DIFF
--- a/MdeModulePkg/Universal/Variable/Pei/Variable.c
+++ b/MdeModulePkg/Universal/Variable/Pei/Variable.c
@@ -1336,6 +1336,7 @@ CalculateHobVariableCacheSize (
   VARIABLE_STORE_HEADER  *VariableStoreHeader;
 
   VariableStoreHeader = NULL;
+  ZeroMem (&StoreInfo, sizeof (VARIABLE_STORE_INFO));
   GetHobVariableStore (&StoreInfo, &VariableStoreHeader);
 
   if (VariableStoreHeader == NULL) {


### PR DESCRIPTION
# Description

This patch is to fix issue caused by uninitialized local variable in Pei/Variable.c.

In the fucntion CalculateHobVariableCacheSize(), the local variable VARIABLE_STORE_INFO StoreInfo is used without
initialization. When the uninitialized variable is passed to CalculateAuthVarStorageSize() and GetNextVariablePtr(), the field StoreInfo->FtwLastWriteData might be a uninitialized non-zero value. Then the code execution will access the invalid address StoreInfo->FtwLastWriteData->TargetAddress. This might cause issue.

So in this commit, the local variable VARIABLE_STORE_INFO StoreInfo is initialized by a ZeroMem() before use.

## How This Was Tested
Tested in Intel internal platform