### PR TITLE
[BZ-4821] Support to Use Different Hash Algorithm for Capsule Payload Content

### DIFF
--- a/BaseTools/Source/Python/Capsule/GenerateCapsule.py
+++ b/BaseTools/Source/Python/Capsule/GenerateCapsule.py
@@ -252,7 +252,7 @@ if __name__ == '__main__':
             HardwareInstance             = ConvertJsonValue (Config, 'HardwareInstance', ValidateUnsignedInteger, Required = False, Default = 0)
             MonotonicCount               = ConvertJsonValue (Config, 'MonotonicCount', ValidateUnsignedInteger, Required = False, Default = 0)
             SignToolPfxFile              = ConvertJsonValue (Config, 'SignToolPfxFile', os.path.expandvars, Required = False, Default = None, Open = True)
-            SignToolSubjectName          = ConvertJsonValue (Config, 'SignToolSubjectName', os.path.expandvars, Required = False, Default = None, Open = True)
+            SignToolSubjectName          = ConvertJsonValue (Config, 'SignToolSubjectName', str, Required = False, Default = None, Open = False)
             OpenSslSignerPrivateCertFile = ConvertJsonValue (Config, 'OpenSslSignerPrivateCertFile', os.path.expandvars, Required = False, Default = None, Open = True)
             OpenSslOtherPublicCertFile   = ConvertJsonValue (Config, 'OpenSslOtherPublicCertFile', os.path.expandvars, Required = False, Default = None, Open = True)
             OpenSslTrustedPublicCertFile = ConvertJsonValue (Config, 'OpenSslTrustedPublicCertFile', os.path.expandvars, Required = False, Default = None, Open = True)
@@ -308,7 +308,7 @@ if __name__ == '__main__':
             UpdateImageIndex             = ConvertJsonValue (Config, 'UpdateImageIndex', ValidateUnsignedInteger, Required = False, Default = 1)
             MonotonicCount               = ConvertJsonValue (Config, 'MonotonicCount', ValidateUnsignedInteger, Required = False, Default = 0)
             SignToolPfxFile              = ConvertJsonValue (Config, 'SignToolPfxFile', os.path.expandvars, Required = False, Default = None, Open = True)
-            SignToolSubjectName          = ConvertJsonValue (Config, 'SignToolSubjectName', os.path.expandvars, Required = False, Default = None, Open = True)
+            SignToolSubjectName          = ConvertJsonValue (Config, 'SignToolSubjectName', str, Required = False, Default = None, Open = False)
             OpenSslSignerPrivateCertFile = ConvertJsonValue (Config, 'OpenSslSignerPrivateCertFile', os.path.expandvars, Required = False, Default = None, Open = True)
             OpenSslOtherPublicCertFile   = ConvertJsonValue (Config, 'OpenSslOtherPublicCertFile', os.path.expandvars, Required = False, Default = None, Open = True)
             OpenSslTrustedPublicCertFile = ConvertJsonValue (Config, 'OpenSslTrustedPublicCertFile', os.path.expandvars, Required = False, Default = None, Open = True)
@@ -413,7 +413,7 @@ if __name__ == '__main__':
             print ('GenerateCapsule: error: Argument --pfx-file conflicts with Argument -j')
             sys.exit (1)
         if args.SignToolSubjectName:
-            print ('GenerateCapsule: error: Argument --SubjectName conflicts with Argument -j')
+            print ('GenerateCapsule: error: Argument --subject-name conflicts with Argument -j')
             sys.exit (1)
         if args.OpenSslSignerPrivateCertFile:
             print ('GenerateCapsule: error: Argument --signer-private-cert conflicts with Argument -j')

--- a/BaseTools/Source/Python/Capsule/GenerateCapsule.py
+++ b/BaseTools/Source/Python/Capsule/GenerateCapsule.py
@@ -75,7 +75,7 @@ def SignPayloadSignTool (Payload, ToolPath, PfxFile, SubjectName, Verbose = Fals
     if PfxFile is not None:
         Command = Command + '/f {PfxFile} '.format (PfxFile = PfxFile)
     if SubjectName is not None:
-        Command = Command + '/n {SubjectName} '.format (SubjectName = SubjectName)
+        Command = Command + '/n "{SubjectName}" '.format (SubjectName = SubjectName)
     Command = Command + TempFileName
     if Verbose:
         print (Command)

--- a/BaseTools/Source/Python/Capsule/GenerateCapsule.py
+++ b/BaseTools/Source/Python/Capsule/GenerateCapsule.py
@@ -751,7 +751,9 @@ if __name__ == '__main__':
                     for Index in range (0, FmpCapsuleHeader.PayloadItemCount):
                         if Index > 0:
                             PayloadDecodeFile = FmpCapsuleHeader.GetFmpCapsuleImageHeader (Index).Payload
-                            PayloadDescriptorList.append (PayloadDescriptor (PayloadDecodeFile,
+                            PayloadDescriptorList.append (PayloadDescriptor (
+                                                            PayloadDecodeFile,
+                                                            None,
                                                             None,
                                                             None,
                                                             None,


### PR DESCRIPTION
# Description

- [Bugzilla#4821](https://bugzilla.tianocore.org/show_bug.cgi?id=4821)

- Changes
  - Deliver some of the script bug-fixes and correct the some of debug message.
  - Add the ```HashAlgorithm``` key in JSON file and ```--hash-algorithm``` in command arguments.
  - Allow caller to assign the expected hash algorithm for capsule payload digest.

- Backward Compatibility
  - Default hash algorithm would be kept as ```SHA256```.
  - Without giving the new key in JSON file or input the new flag in command line, default ```SHA256``` would be used.

- Notice
  - It would be the caller and the tool responsibility to check the hash algorithm is supported and valid.
  - Platform needs to enable the correspond code flow to make sure the PKCS#7 signature could be decoded and verified successfully.

- [X] Breaking change?
  - Yes, JSON file would add the new key ```HashAlgorithm``` in payloads list.
  - Script defined functions and class would add new argument and use the new class property across different function.
  - Backward compatibility had been done to handle the argument or JSON file without this.
- [ ] Impacts security?
  - No, this change do not include any security-related change.
- [X] Includes tests?
  - Tested the capsule file ```encode```, ```decode```, and ```dumpinfo``` are fine without any issue.

## How This Was Tested

- ```Encode```:
  - ```signtool``` Tested to encode the capsule via command arguments within and without ```HashAlgorithm``` key.
  - ```signtool``` Tested to encode the capsule via JSON file within and without ```HashAlgorithm``` key.
  - ```OpenSSL``` Tested to encode the capsule via command arguments within and without ```HashAlgorithm``` key.
  - ```OpenSSL``` Tested to encode the capsule via JSON file within and without ```HashAlgorithm``` key.

- ```Decode```:
  - ```signtool``` Tested to decode the capsule via command arguments within and without ```HashAlgorithm``` key. (signtool verify is not supported.)
  - ```signtool``` Tested to decode the capsule via JSON file within and without ```HashAlgorithm``` key. (signtool verify is not supported.)
  - ```OpenSSL``` Tested to decode the capsule via command arguments within and without ```HashAlgorithm``` key.
  - ```OpenSSL``` Tested to decode the capsule via JSON file within and without ```HashAlgorithm``` key.

- ```DumpInfo```:
  - Tested the ```--dump-info``` command is working fine.

## Integration Instructions

- Argument: Add the argument flag ```--hash-algorithm``` to assign the algorithm expected to use.
- JSON file: Add the key ```HashAlgorithm``` in payloads list.