### PR TITLE
Arm virtio keyboard driver

### DIFF
--- a/OvmfPkg/Include/IndustryStandard/Virtio10.h
+++ b/OvmfPkg/Include/IndustryStandard/Virtio10.h
@@ -17,6 +17,7 @@
 // Subsystem Device IDs (to be) introduced in VirtIo 1.0
 //
 #define VIRTIO_SUBSYSTEM_GPU_DEVICE  16
+#define VIRTIO_SUBSYSTEM_INPUT 18
 //
 // Subsystem Device IDs from the VirtIo spec at git commit 87fa6b5d8155;
 // <https://github.com/oasis-tcs/virtio-spec/tree/87fa6b5d8155>.

--- a/OvmfPkg/Include/IndustryStandard/input-event-codes.h
+++ b/OvmfPkg/Include/IndustryStandard/input-event-codes.h
@@ -1,0 +1,977 @@
+/* SPDX-License-Identifier: GPL-2.0-only WITH Linux-syscall-note */
+/*
+ * Input event codes
+ *
+ *    *** IMPORTANT ***
+ * This file is not only included from C-code but also from devicetree source
+ * files. As such this file MUST only contain comments and defines.
+ *
+ * Copyright (c) 1999-2002 Vojtech Pavlik
+ * Copyright (c) 2015 Hans de Goede <hdegoede@redhat.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published by
+ * the Free Software Foundation.
+ */
+#ifndef _UAPI_INPUT_EVENT_CODES_H
+#define _UAPI_INPUT_EVENT_CODES_H
+
+/*
+ * Device properties and quirks
+ */
+
+#define INPUT_PROP_POINTER		0x00	/* needs a pointer */
+#define INPUT_PROP_DIRECT		0x01	/* direct input devices */
+#define INPUT_PROP_BUTTONPAD		0x02	/* has button(s) under pad */
+#define INPUT_PROP_SEMI_MT		0x03	/* touch rectangle only */
+#define INPUT_PROP_TOPBUTTONPAD		0x04	/* softbuttons at top of pad */
+#define INPUT_PROP_POINTING_STICK	0x05	/* is a pointing stick */
+#define INPUT_PROP_ACCELEROMETER	0x06	/* has accelerometer */
+
+#define INPUT_PROP_MAX			0x1f
+#define INPUT_PROP_CNT			(INPUT_PROP_MAX + 1)
+
+/*
+ * Event types
+ */
+
+#define EV_SYN			0x00
+#define EV_KEY			0x01
+#define EV_REL			0x02
+#define EV_ABS			0x03
+#define EV_MSC			0x04
+#define EV_SW			0x05
+#define EV_LED			0x11
+#define EV_SND			0x12
+#define EV_REP			0x14
+#define EV_FF			0x15
+#define EV_PWR			0x16
+#define EV_FF_STATUS		0x17
+#define EV_MAX			0x1f
+#define EV_CNT			(EV_MAX+1)
+
+/*
+ * Synchronization events.
+ */
+
+#define SYN_REPORT		0
+#define SYN_CONFIG		1
+#define SYN_MT_REPORT		2
+#define SYN_DROPPED		3
+#define SYN_MAX			0xf
+#define SYN_CNT			(SYN_MAX+1)
+
+/*
+ * Keys and buttons
+ *
+ * Most of the keys/buttons are modeled after USB HUT 1.12
+ * (see http://www.usb.org/developers/hidpage).
+ * Abbreviations in the comments:
+ * AC - Application Control
+ * AL - Application Launch Button
+ * SC - System Control
+ */
+
+#define KEY_RESERVED		0
+#define KEY_ESC			1
+#define KEY_1			2
+#define KEY_2			3
+#define KEY_3			4
+#define KEY_4			5
+#define KEY_5			6
+#define KEY_6			7
+#define KEY_7			8
+#define KEY_8			9
+#define KEY_9			10
+#define KEY_0			11
+#define KEY_MINUS		12
+#define KEY_EQUAL		13
+#define KEY_BACKSPACE		14
+#define KEY_TAB			15
+#define KEY_Q			16
+#define KEY_W			17
+#define KEY_E			18
+#define KEY_R			19
+#define KEY_T			20
+#define KEY_Y			21
+#define KEY_U			22
+#define KEY_I			23
+#define KEY_O			24
+#define KEY_P			25
+#define KEY_LEFTBRACE		26
+#define KEY_RIGHTBRACE		27
+#define KEY_ENTER		28
+#define KEY_LEFTCTRL		29
+#define KEY_A			30
+#define KEY_S			31
+#define KEY_D			32
+#define KEY_F			33
+#define KEY_G			34
+#define KEY_H			35
+#define KEY_J			36
+#define KEY_K			37
+#define KEY_L			38
+#define KEY_SEMICOLON		39
+#define KEY_APOSTROPHE		40
+#define KEY_GRAVE		41
+#define KEY_LEFTSHIFT		42
+#define KEY_BACKSLASH		43
+#define KEY_Z			44
+#define KEY_X			45
+#define KEY_C			46
+#define KEY_V			47
+#define KEY_B			48
+#define KEY_N			49
+#define KEY_M			50
+#define KEY_COMMA		51
+#define KEY_DOT			52
+#define KEY_SLASH		53
+#define KEY_RIGHTSHIFT		54
+#define KEY_KPASTERISK		55
+#define KEY_LEFTALT		56
+#define KEY_SPACE		57
+#define KEY_CAPSLOCK		58
+#define KEY_F1			59
+#define KEY_F2			60
+#define KEY_F3			61
+#define KEY_F4			62
+#define KEY_F5			63
+#define KEY_F6			64
+#define KEY_F7			65
+#define KEY_F8			66
+#define KEY_F9			67
+#define KEY_F10			68
+#define KEY_NUMLOCK		69
+#define KEY_SCROLLLOCK		70
+#define KEY_KP7			71
+#define KEY_KP8			72
+#define KEY_KP9			73
+#define KEY_KPMINUS		74
+#define KEY_KP4			75
+#define KEY_KP5			76
+#define KEY_KP6			77
+#define KEY_KPPLUS		78
+#define KEY_KP1			79
+#define KEY_KP2			80
+#define KEY_KP3			81
+#define KEY_KP0			82
+#define KEY_KPDOT		83
+
+#define KEY_ZENKAKUHANKAKU	85
+#define KEY_102ND		86
+#define KEY_F11			87
+#define KEY_F12			88
+#define KEY_RO			89
+#define KEY_KATAKANA		90
+#define KEY_HIRAGANA		91
+#define KEY_HENKAN		92
+#define KEY_KATAKANAHIRAGANA	93
+#define KEY_MUHENKAN		94
+#define KEY_KPJPCOMMA		95
+#define KEY_KPENTER		96
+#define KEY_RIGHTCTRL		97
+#define KEY_KPSLASH		98
+#define KEY_SYSRQ		99
+#define KEY_RIGHTALT		100
+#define KEY_LINEFEED		101
+#define KEY_HOME		102
+#define KEY_UP			103
+#define KEY_PAGEUP		104
+#define KEY_LEFT		105
+#define KEY_RIGHT		106
+#define KEY_END			107
+#define KEY_DOWN		108
+#define KEY_PAGEDOWN		109
+#define KEY_INSERT		110
+#define KEY_DELETE		111
+#define KEY_MACRO		112
+#define KEY_MUTE		113
+#define KEY_VOLUMEDOWN		114
+#define KEY_VOLUMEUP		115
+#define KEY_POWER		116	/* SC System Power Down */
+#define KEY_KPEQUAL		117
+#define KEY_KPPLUSMINUS		118
+#define KEY_PAUSE		119
+#define KEY_SCALE		120	/* AL Compiz Scale (Expose) */
+
+#define KEY_KPCOMMA		121
+#define KEY_HANGEUL		122
+#define KEY_HANGUEL		KEY_HANGEUL
+#define KEY_HANJA		123
+#define KEY_YEN			124
+#define KEY_LEFTMETA		125
+#define KEY_RIGHTMETA		126
+#define KEY_COMPOSE		127
+
+#define KEY_STOP		128	/* AC Stop */
+#define KEY_AGAIN		129
+#define KEY_PROPS		130	/* AC Properties */
+#define KEY_UNDO		131	/* AC Undo */
+#define KEY_FRONT		132
+#define KEY_COPY		133	/* AC Copy */
+#define KEY_OPEN		134	/* AC Open */
+#define KEY_PASTE		135	/* AC Paste */
+#define KEY_FIND		136	/* AC Search */
+#define KEY_CUT			137	/* AC Cut */
+#define KEY_HELP		138	/* AL Integrated Help Center */
+#define KEY_MENU		139	/* Menu (show menu) */
+#define KEY_CALC		140	/* AL Calculator */
+#define KEY_SETUP		141
+#define KEY_SLEEP		142	/* SC System Sleep */
+#define KEY_WAKEUP		143	/* System Wake Up */
+#define KEY_FILE		144	/* AL Local Machine Browser */
+#define KEY_SENDFILE		145
+#define KEY_DELETEFILE		146
+#define KEY_XFER		147
+#define KEY_PROG1		148
+#define KEY_PROG2		149
+#define KEY_WWW			150	/* AL Internet Browser */
+#define KEY_MSDOS		151
+#define KEY_COFFEE		152	/* AL Terminal Lock/Screensaver */
+#define KEY_SCREENLOCK		KEY_COFFEE
+#define KEY_ROTATE_DISPLAY	153	/* Display orientation for e.g. tablets */
+#define KEY_DIRECTION		KEY_ROTATE_DISPLAY
+#define KEY_CYCLEWINDOWS	154
+#define KEY_MAIL		155
+#define KEY_BOOKMARKS		156	/* AC Bookmarks */
+#define KEY_COMPUTER		157
+#define KEY_BACK		158	/* AC Back */
+#define KEY_FORWARD		159	/* AC Forward */
+#define KEY_CLOSECD		160
+#define KEY_EJECTCD		161
+#define KEY_EJECTCLOSECD	162
+#define KEY_NEXTSONG		163
+#define KEY_PLAYPAUSE		164
+#define KEY_PREVIOUSSONG	165
+#define KEY_STOPCD		166
+#define KEY_RECORD		167
+#define KEY_REWIND		168
+#define KEY_PHONE		169	/* Media Select Telephone */
+#define KEY_ISO			170
+#define KEY_CONFIG		171	/* AL Consumer Control Configuration */
+#define KEY_HOMEPAGE		172	/* AC Home */
+#define KEY_REFRESH		173	/* AC Refresh */
+#define KEY_EXIT		174	/* AC Exit */
+#define KEY_MOVE		175
+#define KEY_EDIT		176
+#define KEY_SCROLLUP		177
+#define KEY_SCROLLDOWN		178
+#define KEY_KPLEFTPAREN		179
+#define KEY_KPRIGHTPAREN	180
+#define KEY_NEW			181	/* AC New */
+#define KEY_REDO		182	/* AC Redo/Repeat */
+
+#define KEY_F13			183
+#define KEY_F14			184
+#define KEY_F15			185
+#define KEY_F16			186
+#define KEY_F17			187
+#define KEY_F18			188
+#define KEY_F19			189
+#define KEY_F20			190
+#define KEY_F21			191
+#define KEY_F22			192
+#define KEY_F23			193
+#define KEY_F24			194
+
+#define KEY_PLAYCD		200
+#define KEY_PAUSECD		201
+#define KEY_PROG3		202
+#define KEY_PROG4		203
+#define KEY_ALL_APPLICATIONS	204	/* AC Desktop Show All Applications */
+#define KEY_DASHBOARD		KEY_ALL_APPLICATIONS
+#define KEY_SUSPEND		205
+#define KEY_CLOSE		206	/* AC Close */
+#define KEY_PLAY		207
+#define KEY_FASTFORWARD		208
+#define KEY_BASSBOOST		209
+#define KEY_PRINT		210	/* AC Print */
+#define KEY_HP			211
+#define KEY_CAMERA		212
+#define KEY_SOUND		213
+#define KEY_QUESTION		214
+#define KEY_EMAIL		215
+#define KEY_CHAT		216
+#define KEY_SEARCH		217
+#define KEY_CONNECT		218
+#define KEY_FINANCE		219	/* AL Checkbook/Finance */
+#define KEY_SPORT		220
+#define KEY_SHOP		221
+#define KEY_ALTERASE		222
+#define KEY_CANCEL		223	/* AC Cancel */
+#define KEY_BRIGHTNESSDOWN	224
+#define KEY_BRIGHTNESSUP	225
+#define KEY_MEDIA		226
+
+#define KEY_SWITCHVIDEOMODE	227	/* Cycle between available video
+					   outputs (Monitor/LCD/TV-out/etc) */
+#define KEY_KBDILLUMTOGGLE	228
+#define KEY_KBDILLUMDOWN	229
+#define KEY_KBDILLUMUP		230
+
+#define KEY_SEND		231	/* AC Send */
+#define KEY_REPLY		232	/* AC Reply */
+#define KEY_FORWARDMAIL		233	/* AC Forward Msg */
+#define KEY_SAVE		234	/* AC Save */
+#define KEY_DOCUMENTS		235
+
+#define KEY_BATTERY		236
+
+#define KEY_BLUETOOTH		237
+#define KEY_WLAN		238
+#define KEY_UWB			239
+
+#define KEY_UNKNOWN		240
+
+#define KEY_VIDEO_NEXT		241	/* drive next video source */
+#define KEY_VIDEO_PREV		242	/* drive previous video source */
+#define KEY_BRIGHTNESS_CYCLE	243	/* brightness up, after max is min */
+#define KEY_BRIGHTNESS_AUTO	244	/* Set Auto Brightness: manual
+					  brightness control is off,
+					  rely on ambient */
+#define KEY_BRIGHTNESS_ZERO	KEY_BRIGHTNESS_AUTO
+#define KEY_DISPLAY_OFF		245	/* display device to off state */
+
+#define KEY_WWAN		246	/* Wireless WAN (LTE, UMTS, GSM, etc.) */
+#define KEY_WIMAX		KEY_WWAN
+#define KEY_RFKILL		247	/* Key that controls all radios */
+
+#define KEY_MICMUTE		248	/* Mute / unmute the microphone */
+
+/* Code 255 is reserved for special needs of AT keyboard driver */
+
+#define BTN_MISC		0x100
+#define BTN_0			0x100
+#define BTN_1			0x101
+#define BTN_2			0x102
+#define BTN_3			0x103
+#define BTN_4			0x104
+#define BTN_5			0x105
+#define BTN_6			0x106
+#define BTN_7			0x107
+#define BTN_8			0x108
+#define BTN_9			0x109
+
+#define BTN_MOUSE		0x110
+#define BTN_LEFT		0x110
+#define BTN_RIGHT		0x111
+#define BTN_MIDDLE		0x112
+#define BTN_SIDE		0x113
+#define BTN_EXTRA		0x114
+#define BTN_FORWARD		0x115
+#define BTN_BACK		0x116
+#define BTN_TASK		0x117
+
+#define BTN_JOYSTICK		0x120
+#define BTN_TRIGGER		0x120
+#define BTN_THUMB		0x121
+#define BTN_THUMB2		0x122
+#define BTN_TOP			0x123
+#define BTN_TOP2		0x124
+#define BTN_PINKIE		0x125
+#define BTN_BASE		0x126
+#define BTN_BASE2		0x127
+#define BTN_BASE3		0x128
+#define BTN_BASE4		0x129
+#define BTN_BASE5		0x12a
+#define BTN_BASE6		0x12b
+#define BTN_DEAD		0x12f
+
+#define BTN_GAMEPAD		0x130
+#define BTN_SOUTH		0x130
+#define BTN_A			BTN_SOUTH
+#define BTN_EAST		0x131
+#define BTN_B			BTN_EAST
+#define BTN_C			0x132
+#define BTN_NORTH		0x133
+#define BTN_X			BTN_NORTH
+#define BTN_WEST		0x134
+#define BTN_Y			BTN_WEST
+#define BTN_Z			0x135
+#define BTN_TL			0x136
+#define BTN_TR			0x137
+#define BTN_TL2			0x138
+#define BTN_TR2			0x139
+#define BTN_SELECT		0x13a
+#define BTN_START		0x13b
+#define BTN_MODE		0x13c
+#define BTN_THUMBL		0x13d
+#define BTN_THUMBR		0x13e
+
+#define BTN_DIGI		0x140
+#define BTN_TOOL_PEN		0x140
+#define BTN_TOOL_RUBBER		0x141
+#define BTN_TOOL_BRUSH		0x142
+#define BTN_TOOL_PENCIL		0x143
+#define BTN_TOOL_AIRBRUSH	0x144
+#define BTN_TOOL_FINGER		0x145
+#define BTN_TOOL_MOUSE		0x146
+#define BTN_TOOL_LENS		0x147
+#define BTN_TOOL_QUINTTAP	0x148	/* Five fingers on trackpad */
+#define BTN_STYLUS3		0x149
+#define BTN_TOUCH		0x14a
+#define BTN_STYLUS		0x14b
+#define BTN_STYLUS2		0x14c
+#define BTN_TOOL_DOUBLETAP	0x14d
+#define BTN_TOOL_TRIPLETAP	0x14e
+#define BTN_TOOL_QUADTAP	0x14f	/* Four fingers on trackpad */
+
+#define BTN_WHEEL		0x150
+#define BTN_GEAR_DOWN		0x150
+#define BTN_GEAR_UP		0x151
+
+#define KEY_OK			0x160
+#define KEY_SELECT		0x161
+#define KEY_GOTO		0x162
+#define KEY_CLEAR		0x163
+#define KEY_POWER2		0x164
+#define KEY_OPTION		0x165
+#define KEY_INFO		0x166	/* AL OEM Features/Tips/Tutorial */
+#define KEY_TIME		0x167
+#define KEY_VENDOR		0x168
+#define KEY_ARCHIVE		0x169
+#define KEY_PROGRAM		0x16a	/* Media Select Program Guide */
+#define KEY_CHANNEL		0x16b
+#define KEY_FAVORITES		0x16c
+#define KEY_EPG			0x16d
+#define KEY_PVR			0x16e	/* Media Select Home */
+#define KEY_MHP			0x16f
+#define KEY_LANGUAGE		0x170
+#define KEY_TITLE		0x171
+#define KEY_SUBTITLE		0x172
+#define KEY_ANGLE		0x173
+#define KEY_FULL_SCREEN		0x174	/* AC View Toggle */
+#define KEY_ZOOM		KEY_FULL_SCREEN
+#define KEY_MODE		0x175
+#define KEY_KEYBOARD		0x176
+#define KEY_ASPECT_RATIO	0x177	/* HUTRR37: Aspect */
+#define KEY_SCREEN		KEY_ASPECT_RATIO
+#define KEY_PC			0x178	/* Media Select Computer */
+#define KEY_TV			0x179	/* Media Select TV */
+#define KEY_TV2			0x17a	/* Media Select Cable */
+#define KEY_VCR			0x17b	/* Media Select VCR */
+#define KEY_VCR2		0x17c	/* VCR Plus */
+#define KEY_SAT			0x17d	/* Media Select Satellite */
+#define KEY_SAT2		0x17e
+#define KEY_CD			0x17f	/* Media Select CD */
+#define KEY_TAPE		0x180	/* Media Select Tape */
+#define KEY_RADIO		0x181
+#define KEY_TUNER		0x182	/* Media Select Tuner */
+#define KEY_PLAYER		0x183
+#define KEY_TEXT		0x184
+#define KEY_DVD			0x185	/* Media Select DVD */
+#define KEY_AUX			0x186
+#define KEY_MP3			0x187
+#define KEY_AUDIO		0x188	/* AL Audio Browser */
+#define KEY_VIDEO		0x189	/* AL Movie Browser */
+#define KEY_DIRECTORY		0x18a
+#define KEY_LIST		0x18b
+#define KEY_MEMO		0x18c	/* Media Select Messages */
+#define KEY_CALENDAR		0x18d
+#define KEY_RED			0x18e
+#define KEY_GREEN		0x18f
+#define KEY_YELLOW		0x190
+#define KEY_BLUE		0x191
+#define KEY_CHANNELUP		0x192	/* Channel Increment */
+#define KEY_CHANNELDOWN		0x193	/* Channel Decrement */
+#define KEY_FIRST		0x194
+#define KEY_LAST		0x195	/* Recall Last */
+#define KEY_AB			0x196
+#define KEY_NEXT		0x197
+#define KEY_RESTART		0x198
+#define KEY_SLOW		0x199
+#define KEY_SHUFFLE		0x19a
+#define KEY_BREAK		0x19b
+#define KEY_PREVIOUS		0x19c
+#define KEY_DIGITS		0x19d
+#define KEY_TEEN		0x19e
+#define KEY_TWEN		0x19f
+#define KEY_VIDEOPHONE		0x1a0	/* Media Select Video Phone */
+#define KEY_GAMES		0x1a1	/* Media Select Games */
+#define KEY_ZOOMIN		0x1a2	/* AC Zoom In */
+#define KEY_ZOOMOUT		0x1a3	/* AC Zoom Out */
+#define KEY_ZOOMRESET		0x1a4	/* AC Zoom */
+#define KEY_WORDPROCESSOR	0x1a5	/* AL Word Processor */
+#define KEY_EDITOR		0x1a6	/* AL Text Editor */
+#define KEY_SPREADSHEET		0x1a7	/* AL Spreadsheet */
+#define KEY_GRAPHICSEDITOR	0x1a8	/* AL Graphics Editor */
+#define KEY_PRESENTATION	0x1a9	/* AL Presentation App */
+#define KEY_DATABASE		0x1aa	/* AL Database App */
+#define KEY_NEWS		0x1ab	/* AL Newsreader */
+#define KEY_VOICEMAIL		0x1ac	/* AL Voicemail */
+#define KEY_ADDRESSBOOK		0x1ad	/* AL Contacts/Address Book */
+#define KEY_MESSENGER		0x1ae	/* AL Instant Messaging */
+#define KEY_DISPLAYTOGGLE	0x1af	/* Turn display (LCD) on and off */
+#define KEY_BRIGHTNESS_TOGGLE	KEY_DISPLAYTOGGLE
+#define KEY_SPELLCHECK		0x1b0   /* AL Spell Check */
+#define KEY_LOGOFF		0x1b1   /* AL Logoff */
+
+#define KEY_DOLLAR		0x1b2
+#define KEY_EURO		0x1b3
+
+#define KEY_FRAMEBACK		0x1b4	/* Consumer - transport controls */
+#define KEY_FRAMEFORWARD	0x1b5
+#define KEY_CONTEXT_MENU	0x1b6	/* GenDesc - system context menu */
+#define KEY_MEDIA_REPEAT	0x1b7	/* Consumer - transport control */
+#define KEY_10CHANNELSUP	0x1b8	/* 10 channels up (10+) */
+#define KEY_10CHANNELSDOWN	0x1b9	/* 10 channels down (10-) */
+#define KEY_IMAGES		0x1ba	/* AL Image Browser */
+#define KEY_NOTIFICATION_CENTER	0x1bc	/* Show/hide the notification center */
+#define KEY_PICKUP_PHONE	0x1bd	/* Answer incoming call */
+#define KEY_HANGUP_PHONE	0x1be	/* Decline incoming call */
+
+#define KEY_DEL_EOL		0x1c0
+#define KEY_DEL_EOS		0x1c1
+#define KEY_INS_LINE		0x1c2
+#define KEY_DEL_LINE		0x1c3
+
+#define KEY_FN			0x1d0
+#define KEY_FN_ESC		0x1d1
+#define KEY_FN_F1		0x1d2
+#define KEY_FN_F2		0x1d3
+#define KEY_FN_F3		0x1d4
+#define KEY_FN_F4		0x1d5
+#define KEY_FN_F5		0x1d6
+#define KEY_FN_F6		0x1d7
+#define KEY_FN_F7		0x1d8
+#define KEY_FN_F8		0x1d9
+#define KEY_FN_F9		0x1da
+#define KEY_FN_F10		0x1db
+#define KEY_FN_F11		0x1dc
+#define KEY_FN_F12		0x1dd
+#define KEY_FN_1		0x1de
+#define KEY_FN_2		0x1df
+#define KEY_FN_D		0x1e0
+#define KEY_FN_E		0x1e1
+#define KEY_FN_F		0x1e2
+#define KEY_FN_S		0x1e3
+#define KEY_FN_B		0x1e4
+#define KEY_FN_RIGHT_SHIFT	0x1e5
+
+#define KEY_BRL_DOT1		0x1f1
+#define KEY_BRL_DOT2		0x1f2
+#define KEY_BRL_DOT3		0x1f3
+#define KEY_BRL_DOT4		0x1f4
+#define KEY_BRL_DOT5		0x1f5
+#define KEY_BRL_DOT6		0x1f6
+#define KEY_BRL_DOT7		0x1f7
+#define KEY_BRL_DOT8		0x1f8
+#define KEY_BRL_DOT9		0x1f9
+#define KEY_BRL_DOT10		0x1fa
+
+#define KEY_NUMERIC_0		0x200	/* used by phones, remote controls, */
+#define KEY_NUMERIC_1		0x201	/* and other keypads */
+#define KEY_NUMERIC_2		0x202
+#define KEY_NUMERIC_3		0x203
+#define KEY_NUMERIC_4		0x204
+#define KEY_NUMERIC_5		0x205
+#define KEY_NUMERIC_6		0x206
+#define KEY_NUMERIC_7		0x207
+#define KEY_NUMERIC_8		0x208
+#define KEY_NUMERIC_9		0x209
+#define KEY_NUMERIC_STAR	0x20a
+#define KEY_NUMERIC_POUND	0x20b
+#define KEY_NUMERIC_A		0x20c	/* Phone key A - HUT Telephony 0xb9 */
+#define KEY_NUMERIC_B		0x20d
+#define KEY_NUMERIC_C		0x20e
+#define KEY_NUMERIC_D		0x20f
+
+#define KEY_CAMERA_FOCUS	0x210
+#define KEY_WPS_BUTTON		0x211	/* WiFi Protected Setup key */
+
+#define KEY_TOUCHPAD_TOGGLE	0x212	/* Request switch touchpad on or off */
+#define KEY_TOUCHPAD_ON		0x213
+#define KEY_TOUCHPAD_OFF	0x214
+
+#define KEY_CAMERA_ZOOMIN	0x215
+#define KEY_CAMERA_ZOOMOUT	0x216
+#define KEY_CAMERA_UP		0x217
+#define KEY_CAMERA_DOWN		0x218
+#define KEY_CAMERA_LEFT		0x219
+#define KEY_CAMERA_RIGHT	0x21a
+
+#define KEY_ATTENDANT_ON	0x21b
+#define KEY_ATTENDANT_OFF	0x21c
+#define KEY_ATTENDANT_TOGGLE	0x21d	/* Attendant call on or off */
+#define KEY_LIGHTS_TOGGLE	0x21e	/* Reading light on or off */
+
+#define BTN_DPAD_UP		0x220
+#define BTN_DPAD_DOWN		0x221
+#define BTN_DPAD_LEFT		0x222
+#define BTN_DPAD_RIGHT		0x223
+
+#define KEY_ALS_TOGGLE		0x230	/* Ambient light sensor */
+#define KEY_ROTATE_LOCK_TOGGLE	0x231	/* Display rotation lock */
+
+#define KEY_BUTTONCONFIG		0x240	/* AL Button Configuration */
+#define KEY_TASKMANAGER		0x241	/* AL Task/Project Manager */
+#define KEY_JOURNAL		0x242	/* AL Log/Journal/Timecard */
+#define KEY_CONTROLPANEL		0x243	/* AL Control Panel */
+#define KEY_APPSELECT		0x244	/* AL Select Task/Application */
+#define KEY_SCREENSAVER		0x245	/* AL Screen Saver */
+#define KEY_VOICECOMMAND		0x246	/* Listening Voice Command */
+#define KEY_ASSISTANT		0x247	/* AL Context-aware desktop assistant */
+#define KEY_KBD_LAYOUT_NEXT	0x248	/* AC Next Keyboard Layout Select */
+#define KEY_EMOJI_PICKER	0x249	/* Show/hide emoji picker (HUTRR101) */
+#define KEY_DICTATE		0x24a	/* Start or Stop Voice Dictation Session (HUTRR99) */
+#define KEY_CAMERA_ACCESS_ENABLE	0x24b	/* Enables programmatic access to camera devices. (HUTRR72) */
+#define KEY_CAMERA_ACCESS_DISABLE	0x24c	/* Disables programmatic access to camera devices. (HUTRR72) */
+#define KEY_CAMERA_ACCESS_TOGGLE	0x24d	/* Toggles the current state of the camera access control. (HUTRR72) */
+
+#define KEY_BRIGHTNESS_MIN		0x250	/* Set Brightness to Minimum */
+#define KEY_BRIGHTNESS_MAX		0x251	/* Set Brightness to Maximum */
+
+#define KEY_KBDINPUTASSIST_PREV		0x260
+#define KEY_KBDINPUTASSIST_NEXT		0x261
+#define KEY_KBDINPUTASSIST_PREVGROUP		0x262
+#define KEY_KBDINPUTASSIST_NEXTGROUP		0x263
+#define KEY_KBDINPUTASSIST_ACCEPT		0x264
+#define KEY_KBDINPUTASSIST_CANCEL		0x265
+
+/* Diagonal movement keys */
+#define KEY_RIGHT_UP			0x266
+#define KEY_RIGHT_DOWN			0x267
+#define KEY_LEFT_UP			0x268
+#define KEY_LEFT_DOWN			0x269
+
+#define KEY_ROOT_MENU			0x26a /* Show Device's Root Menu */
+/* Show Top Menu of the Media (e.g. DVD) */
+#define KEY_MEDIA_TOP_MENU		0x26b
+#define KEY_NUMERIC_11			0x26c
+#define KEY_NUMERIC_12			0x26d
+/*
+ * Toggle Audio Description: refers to an audio service that helps blind and
+ * visually impaired consumers understand the action in a program. Note: in
+ * some countries this is referred to as "Video Description".
+ */
+#define KEY_AUDIO_DESC			0x26e
+#define KEY_3D_MODE			0x26f
+#define KEY_NEXT_FAVORITE		0x270
+#define KEY_STOP_RECORD			0x271
+#define KEY_PAUSE_RECORD		0x272
+#define KEY_VOD				0x273 /* Video on Demand */
+#define KEY_UNMUTE			0x274
+#define KEY_FASTREVERSE			0x275
+#define KEY_SLOWREVERSE			0x276
+/*
+ * Control a data application associated with the currently viewed channel,
+ * e.g. teletext or data broadcast application (MHEG, MHP, HbbTV, etc.)
+ */
+#define KEY_DATA			0x277
+#define KEY_ONSCREEN_KEYBOARD		0x278
+/* Electronic privacy screen control */
+#define KEY_PRIVACY_SCREEN_TOGGLE	0x279
+
+/* Select an area of screen to be copied */
+#define KEY_SELECTIVE_SCREENSHOT	0x27a
+
+/* Move the focus to the next or previous user controllable element within a UI container */
+#define KEY_NEXT_ELEMENT               0x27b
+#define KEY_PREVIOUS_ELEMENT           0x27c
+
+/* Toggle Autopilot engagement */
+#define KEY_AUTOPILOT_ENGAGE_TOGGLE    0x27d
+
+/* Shortcut Keys */
+#define KEY_MARK_WAYPOINT              0x27e
+#define KEY_SOS                                0x27f
+#define KEY_NAV_CHART                  0x280
+#define KEY_FISHING_CHART              0x281
+#define KEY_SINGLE_RANGE_RADAR         0x282
+#define KEY_DUAL_RANGE_RADAR           0x283
+#define KEY_RADAR_OVERLAY              0x284
+#define KEY_TRADITIONAL_SONAR          0x285
+#define KEY_CLEARVU_SONAR              0x286
+#define KEY_SIDEVU_SONAR               0x287
+#define KEY_NAV_INFO                   0x288
+#define KEY_BRIGHTNESS_MENU            0x289
+
+/*
+ * Some keyboards have keys which do not have a defined meaning, these keys
+ * are intended to be programmed / bound to macros by the user. For most
+ * keyboards with these macro-keys the key-sequence to inject, or action to
+ * take, is all handled by software on the host side. So from the kernel's
+ * point of view these are just normal keys.
+ *
+ * The KEY_MACRO# codes below are intended for such keys, which may be labeled
+ * e.g. G1-G18, or S1 - S30. The KEY_MACRO# codes MUST NOT be used for keys
+ * where the marking on the key does indicate a defined meaning / purpose.
+ *
+ * The KEY_MACRO# codes MUST also NOT be used as fallback for when no existing
+ * KEY_FOO define matches the marking / purpose. In this case a new KEY_FOO
+ * define MUST be added.
+ */
+#define KEY_MACRO1			0x290
+#define KEY_MACRO2			0x291
+#define KEY_MACRO3			0x292
+#define KEY_MACRO4			0x293
+#define KEY_MACRO5			0x294
+#define KEY_MACRO6			0x295
+#define KEY_MACRO7			0x296
+#define KEY_MACRO8			0x297
+#define KEY_MACRO9			0x298
+#define KEY_MACRO10			0x299
+#define KEY_MACRO11			0x29a
+#define KEY_MACRO12			0x29b
+#define KEY_MACRO13			0x29c
+#define KEY_MACRO14			0x29d
+#define KEY_MACRO15			0x29e
+#define KEY_MACRO16			0x29f
+#define KEY_MACRO17			0x2a0
+#define KEY_MACRO18			0x2a1
+#define KEY_MACRO19			0x2a2
+#define KEY_MACRO20			0x2a3
+#define KEY_MACRO21			0x2a4
+#define KEY_MACRO22			0x2a5
+#define KEY_MACRO23			0x2a6
+#define KEY_MACRO24			0x2a7
+#define KEY_MACRO25			0x2a8
+#define KEY_MACRO26			0x2a9
+#define KEY_MACRO27			0x2aa
+#define KEY_MACRO28			0x2ab
+#define KEY_MACRO29			0x2ac
+#define KEY_MACRO30			0x2ad
+
+/*
+ * Some keyboards with the macro-keys described above have some extra keys
+ * for controlling the host-side software responsible for the macro handling:
+ * -A macro recording start/stop key. Note that not all keyboards which emit
+ *  KEY_MACRO_RECORD_START will also emit KEY_MACRO_RECORD_STOP if
+ *  KEY_MACRO_RECORD_STOP is not advertised, then KEY_MACRO_RECORD_START
+ *  should be interpreted as a recording start/stop toggle;
+ * -Keys for switching between different macro (pre)sets, either a key for
+ *  cycling through the configured presets or keys to directly select a preset.
+ */
+#define KEY_MACRO_RECORD_START		0x2b0
+#define KEY_MACRO_RECORD_STOP		0x2b1
+#define KEY_MACRO_PRESET_CYCLE		0x2b2
+#define KEY_MACRO_PRESET1		0x2b3
+#define KEY_MACRO_PRESET2		0x2b4
+#define KEY_MACRO_PRESET3		0x2b5
+
+/*
+ * Some keyboards have a buildin LCD panel where the contents are controlled
+ * by the host. Often these have a number of keys directly below the LCD
+ * intended for controlling a menu shown on the LCD. These keys often don't
+ * have any labeling so we just name them KEY_KBD_LCD_MENU#
+ */
+#define KEY_KBD_LCD_MENU1		0x2b8
+#define KEY_KBD_LCD_MENU2		0x2b9
+#define KEY_KBD_LCD_MENU3		0x2ba
+#define KEY_KBD_LCD_MENU4		0x2bb
+#define KEY_KBD_LCD_MENU5		0x2bc
+
+#define BTN_TRIGGER_HAPPY		0x2c0
+#define BTN_TRIGGER_HAPPY1		0x2c0
+#define BTN_TRIGGER_HAPPY2		0x2c1
+#define BTN_TRIGGER_HAPPY3		0x2c2
+#define BTN_TRIGGER_HAPPY4		0x2c3
+#define BTN_TRIGGER_HAPPY5		0x2c4
+#define BTN_TRIGGER_HAPPY6		0x2c5
+#define BTN_TRIGGER_HAPPY7		0x2c6
+#define BTN_TRIGGER_HAPPY8		0x2c7
+#define BTN_TRIGGER_HAPPY9		0x2c8
+#define BTN_TRIGGER_HAPPY10		0x2c9
+#define BTN_TRIGGER_HAPPY11		0x2ca
+#define BTN_TRIGGER_HAPPY12		0x2cb
+#define BTN_TRIGGER_HAPPY13		0x2cc
+#define BTN_TRIGGER_HAPPY14		0x2cd
+#define BTN_TRIGGER_HAPPY15		0x2ce
+#define BTN_TRIGGER_HAPPY16		0x2cf
+#define BTN_TRIGGER_HAPPY17		0x2d0
+#define BTN_TRIGGER_HAPPY18		0x2d1
+#define BTN_TRIGGER_HAPPY19		0x2d2
+#define BTN_TRIGGER_HAPPY20		0x2d3
+#define BTN_TRIGGER_HAPPY21		0x2d4
+#define BTN_TRIGGER_HAPPY22		0x2d5
+#define BTN_TRIGGER_HAPPY23		0x2d6
+#define BTN_TRIGGER_HAPPY24		0x2d7
+#define BTN_TRIGGER_HAPPY25		0x2d8
+#define BTN_TRIGGER_HAPPY26		0x2d9
+#define BTN_TRIGGER_HAPPY27		0x2da
+#define BTN_TRIGGER_HAPPY28		0x2db
+#define BTN_TRIGGER_HAPPY29		0x2dc
+#define BTN_TRIGGER_HAPPY30		0x2dd
+#define BTN_TRIGGER_HAPPY31		0x2de
+#define BTN_TRIGGER_HAPPY32		0x2df
+#define BTN_TRIGGER_HAPPY33		0x2e0
+#define BTN_TRIGGER_HAPPY34		0x2e1
+#define BTN_TRIGGER_HAPPY35		0x2e2
+#define BTN_TRIGGER_HAPPY36		0x2e3
+#define BTN_TRIGGER_HAPPY37		0x2e4
+#define BTN_TRIGGER_HAPPY38		0x2e5
+#define BTN_TRIGGER_HAPPY39		0x2e6
+#define BTN_TRIGGER_HAPPY40		0x2e7
+
+/* We avoid low common keys in module aliases so they don't get huge. */
+#define KEY_MIN_INTERESTING	KEY_MUTE
+#define KEY_MAX			0x2ff
+#define KEY_CNT			(KEY_MAX+1)
+
+/*
+ * Relative axes
+ */
+
+#define REL_X			0x00
+#define REL_Y			0x01
+#define REL_Z			0x02
+#define REL_RX			0x03
+#define REL_RY			0x04
+#define REL_RZ			0x05
+#define REL_HWHEEL		0x06
+#define REL_DIAL		0x07
+#define REL_WHEEL		0x08
+#define REL_MISC		0x09
+/*
+ * 0x0a is reserved and should not be used in input drivers.
+ * It was used by HID as REL_MISC+1 and userspace needs to detect if
+ * the next REL_* event is correct or is just REL_MISC + n.
+ * We define here REL_RESERVED so userspace can rely on it and detect
+ * the situation described above.
+ */
+#define REL_RESERVED		0x0a
+#define REL_WHEEL_HI_RES	0x0b
+#define REL_HWHEEL_HI_RES	0x0c
+#define REL_MAX			0x0f
+#define REL_CNT			(REL_MAX+1)
+
+/*
+ * Absolute axes
+ */
+
+#define ABS_X			0x00
+#define ABS_Y			0x01
+#define ABS_Z			0x02
+#define ABS_RX			0x03
+#define ABS_RY			0x04
+#define ABS_RZ			0x05
+#define ABS_THROTTLE		0x06
+#define ABS_RUDDER		0x07
+#define ABS_WHEEL		0x08
+#define ABS_GAS			0x09
+#define ABS_BRAKE		0x0a
+#define ABS_HAT0X		0x10
+#define ABS_HAT0Y		0x11
+#define ABS_HAT1X		0x12
+#define ABS_HAT1Y		0x13
+#define ABS_HAT2X		0x14
+#define ABS_HAT2Y		0x15
+#define ABS_HAT3X		0x16
+#define ABS_HAT3Y		0x17
+#define ABS_PRESSURE		0x18
+#define ABS_DISTANCE		0x19
+#define ABS_TILT_X		0x1a
+#define ABS_TILT_Y		0x1b
+#define ABS_TOOL_WIDTH		0x1c
+
+#define ABS_VOLUME		0x20
+#define ABS_PROFILE		0x21
+
+#define ABS_MISC		0x28
+
+/*
+ * 0x2e is reserved and should not be used in input drivers.
+ * It was used by HID as ABS_MISC+6 and userspace needs to detect if
+ * the next ABS_* event is correct or is just ABS_MISC + n.
+ * We define here ABS_RESERVED so userspace can rely on it and detect
+ * the situation described above.
+ */
+#define ABS_RESERVED		0x2e
+
+#define ABS_MT_SLOT		0x2f	/* MT slot being modified */
+#define ABS_MT_TOUCH_MAJOR	0x30	/* Major axis of touching ellipse */
+#define ABS_MT_TOUCH_MINOR	0x31	/* Minor axis (omit if circular) */
+#define ABS_MT_WIDTH_MAJOR	0x32	/* Major axis of approaching ellipse */
+#define ABS_MT_WIDTH_MINOR	0x33	/* Minor axis (omit if circular) */
+#define ABS_MT_ORIENTATION	0x34	/* Ellipse orientation */
+#define ABS_MT_POSITION_X	0x35	/* Center X touch position */
+#define ABS_MT_POSITION_Y	0x36	/* Center Y touch position */
+#define ABS_MT_TOOL_TYPE	0x37	/* Type of touching device */
+#define ABS_MT_BLOB_ID		0x38	/* Group a set of packets as a blob */
+#define ABS_MT_TRACKING_ID	0x39	/* Unique ID of initiated contact */
+#define ABS_MT_PRESSURE		0x3a	/* Pressure on contact area */
+#define ABS_MT_DISTANCE		0x3b	/* Contact hover distance */
+#define ABS_MT_TOOL_X		0x3c	/* Center X tool position */
+#define ABS_MT_TOOL_Y		0x3d	/* Center Y tool position */
+
+
+#define ABS_MAX			0x3f
+#define ABS_CNT			(ABS_MAX+1)
+
+/*
+ * Switch events
+ */
+
+#define SW_LID			0x00  /* set = lid shut */
+#define SW_TABLET_MODE		0x01  /* set = tablet mode */
+#define SW_HEADPHONE_INSERT	0x02  /* set = inserted */
+#define SW_RFKILL_ALL		0x03  /* rfkill master switch, type "any"
+					 set = radio enabled */
+#define SW_RADIO		SW_RFKILL_ALL	/* deprecated */
+#define SW_MICROPHONE_INSERT	0x04  /* set = inserted */
+#define SW_DOCK			0x05  /* set = plugged into dock */
+#define SW_LINEOUT_INSERT	0x06  /* set = inserted */
+#define SW_JACK_PHYSICAL_INSERT 0x07  /* set = mechanical switch set */
+#define SW_VIDEOOUT_INSERT	0x08  /* set = inserted */
+#define SW_CAMERA_LENS_COVER	0x09  /* set = lens covered */
+#define SW_KEYPAD_SLIDE		0x0a  /* set = keypad slide out */
+#define SW_FRONT_PROXIMITY	0x0b  /* set = front proximity sensor active */
+#define SW_ROTATE_LOCK		0x0c  /* set = rotate locked/disabled */
+#define SW_LINEIN_INSERT	0x0d  /* set = inserted */
+#define SW_MUTE_DEVICE		0x0e  /* set = device disabled */
+#define SW_PEN_INSERTED		0x0f  /* set = pen inserted */
+#define SW_MACHINE_COVER	0x10  /* set = cover closed */
+#define SW_MAX			0x10
+#define SW_CNT			(SW_MAX+1)
+
+/*
+ * Misc events
+ */
+
+#define MSC_SERIAL		0x00
+#define MSC_PULSELED		0x01
+#define MSC_GESTURE		0x02
+#define MSC_RAW			0x03
+#define MSC_SCAN		0x04
+#define MSC_TIMESTAMP		0x05
+#define MSC_MAX			0x07
+#define MSC_CNT			(MSC_MAX+1)
+
+/*
+ * LEDs
+ */
+
+#define LED_NUML		0x00
+#define LED_CAPSL		0x01
+#define LED_SCROLLL		0x02
+#define LED_COMPOSE		0x03
+#define LED_KANA		0x04
+#define LED_SLEEP		0x05
+#define LED_SUSPEND		0x06
+#define LED_MUTE		0x07
+#define LED_MISC		0x08
+#define LED_MAIL		0x09
+#define LED_CHARGING		0x0a
+#define LED_MAX			0x0f
+#define LED_CNT			(LED_MAX+1)
+
+/*
+ * Autorepeat values
+ */
+
+#define REP_DELAY		0x00
+#define REP_PERIOD		0x01
+#define REP_MAX			0x01
+#define REP_CNT			(REP_MAX+1)
+
+/*
+ * Sounds
+ */
+
+#define SND_CLICK		0x00
+#define SND_BELL		0x01
+#define SND_TONE		0x02
+#define SND_MAX			0x07
+#define SND_CNT			(SND_MAX+1)
+
+#endif

--- a/OvmfPkg/Library/PlatformBootManagerLib/BdsPlatform.c
+++ b/OvmfPkg/Library/PlatformBootManagerLib/BdsPlatform.c
@@ -1059,6 +1059,28 @@ PrepareVirtioSerialDevicePath (
 }
 
 EFI_STATUS
+PrepareVirtioKeyboardDevicePath (
+  IN EFI_HANDLE  DeviceHandle
+  )
+{
+  EFI_STATUS                Status;
+  EFI_DEVICE_PATH_PROTOCOL  *DevicePath;
+
+  DevicePath = NULL;
+  Status     = gBS->HandleProtocol (
+                      DeviceHandle,
+                      &gEfiDevicePathProtocolGuid,
+                      (VOID *)&DevicePath
+                      );
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  EfiBootManagerUpdateConsoleVariable (ConIn, DevicePath, NULL);
+  return EFI_SUCCESS;
+}
+
+EFI_STATUS
 VisitAllInstancesOfProtocol (
   IN EFI_GUID                    *Id,
   IN PROTOCOL_INSTANCE_CALLBACK  CallBackFunction,
@@ -1231,6 +1253,13 @@ DetectAndPreparePlatformPciDevicePath (
   {
     DEBUG ((DEBUG_INFO, "Found virtio serial device\n"));
     PrepareVirtioSerialDevicePath (Handle);
+    return EFI_SUCCESS;
+  }
+
+  if ((Pci->Hdr.VendorId == 0x1af4) && (Pci->Hdr.DeviceId == 0x1052))
+  {
+    DEBUG ((DEBUG_INFO, "Found virtio keyboard device\n"));
+    PrepareVirtioKeyboardDevicePath (Handle);
     return EFI_SUCCESS;
   }
 

--- a/OvmfPkg/OvmfPkgIa32X64.dsc
+++ b/OvmfPkg/OvmfPkgIa32X64.dsc
@@ -800,6 +800,7 @@
   OvmfPkg/VirtioBlkDxe/VirtioBlk.inf
   OvmfPkg/VirtioScsiDxe/VirtioScsi.inf
   OvmfPkg/VirtioSerialDxe/VirtioSerial.inf
+  OvmfPkg/VirtioKeyboardDxe/VirtioKeyboard.inf
 !if $(PVSCSI_ENABLE) == TRUE
   OvmfPkg/PvScsiDxe/PvScsiDxe.inf
 !endif

--- a/OvmfPkg/OvmfPkgIa32X64.fdf
+++ b/OvmfPkg/OvmfPkgIa32X64.fdf
@@ -234,6 +234,7 @@ INF  OvmfPkg/Virtio10Dxe/Virtio10.inf
 INF  OvmfPkg/VirtioBlkDxe/VirtioBlk.inf
 INF  OvmfPkg/VirtioScsiDxe/VirtioScsi.inf
 INF  OvmfPkg/VirtioSerialDxe/VirtioSerial.inf
+INF  OvmfPkg/VirtioKeyboardDxe/VirtioKeyboard.inf
 !if $(PVSCSI_ENABLE) == TRUE
 INF  OvmfPkg/PvScsiDxe/PvScsiDxe.inf
 !endif

--- a/OvmfPkg/OvmfPkgX64.dsc
+++ b/OvmfPkg/OvmfPkgX64.dsc
@@ -868,6 +868,7 @@
   OvmfPkg/VirtioBlkDxe/VirtioBlk.inf
   OvmfPkg/VirtioScsiDxe/VirtioScsi.inf
   OvmfPkg/VirtioSerialDxe/VirtioSerial.inf
+  OvmfPkg/VirtioKeyboardDxe/VirtioKeyboard.inf
 !if $(PVSCSI_ENABLE) == TRUE
   OvmfPkg/PvScsiDxe/PvScsiDxe.inf
 !endif

--- a/OvmfPkg/OvmfPkgX64.fdf
+++ b/OvmfPkg/OvmfPkgX64.fdf
@@ -265,6 +265,7 @@ INF  OvmfPkg/Virtio10Dxe/Virtio10.inf
 INF  OvmfPkg/VirtioBlkDxe/VirtioBlk.inf
 INF  OvmfPkg/VirtioScsiDxe/VirtioScsi.inf
 INF  OvmfPkg/VirtioSerialDxe/VirtioSerial.inf
+INF  OvmfPkg/VirtioKeyboardDxe/VirtioKeyboard.inf
 !if $(PVSCSI_ENABLE) == TRUE
 INF  OvmfPkg/PvScsiDxe/PvScsiDxe.inf
 !endif

--- a/OvmfPkg/VirtioKeyboardDxe/VirtioKeyboard.c
+++ b/OvmfPkg/VirtioKeyboardDxe/VirtioKeyboard.c
@@ -1,0 +1,1560 @@
+/** @file
+
+  This driver produces EFI_SIMPLE_TEXT_INPUT_PROTOCOL for virtarm devices.
+
+  Copyright (C) 2023, Red Hat, Inc.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/UefiBootServicesTableLib.h>
+#include <Library/UefiLib.h>
+#include <Library/VirtioLib.h>
+#include <IndustryStandard/input-event-codes.h>
+
+#include <VirtioKeyboard.h>
+
+// -----------------------------------------------------------------------------
+// Return buffer pointer out of the ring buffer
+STATIC
+VOID *
+BufferPtr (
+  IN VIRTIO_KBD_RING  *Ring,
+  IN UINT32           BufferNr
+  )
+{
+  return Ring->Buffers + Ring->BufferSize * BufferNr;
+}
+
+// -----------------------------------------------------------------------------
+// Return buffer physical address out of the ring buffer
+STATIC
+EFI_PHYSICAL_ADDRESS
+BufferAddr (
+  IN VIRTIO_KBD_RING  *Ring,
+  IN UINT32           BufferNr
+  )
+{
+  return Ring->DeviceAddress + Ring->BufferSize * BufferNr;
+}
+
+// Return next buffer from ring
+STATIC
+UINT32
+BufferNext (
+  IN VIRTIO_KBD_RING  *Ring
+  )
+{
+  return Ring->Indices.NextDescIdx % Ring->Ring.QueueSize;
+}
+
+// -----------------------------------------------------------------------------
+// Push the buffer to the device
+EFI_STATUS
+EFIAPI
+VirtioKeyboardRingSendBuffer (
+  IN OUT VIRTIO_KBD_DEV  *Dev,
+  IN     UINT16          Index,
+  IN     VOID            *Data,
+  IN     UINT32          DataSize,
+  IN     BOOLEAN         Notify
+  )
+{
+  VIRTIO_KBD_RING  *Ring    = Dev->Rings + Index;
+  UINT32           BufferNr = BufferNext (Ring);
+  UINT16           Idx      = *Ring->Ring.Avail.Idx;
+  UINT16           Flags    = 0;
+
+  ASSERT (DataSize <= Ring->BufferSize);
+
+  if (Data) {
+    /* driver -> device */
+    CopyMem (BufferPtr (Ring, BufferNr), Data, DataSize);
+  } else {
+    /* device -> driver */
+    Flags |= VRING_DESC_F_WRITE;
+  }
+
+  VirtioAppendDesc (
+    &Ring->Ring,
+    BufferAddr (Ring, BufferNr),
+    DataSize,
+    Flags,
+    &Ring->Indices
+    );
+
+  Ring->Ring.Avail.Ring[Idx % Ring->Ring.QueueSize] =
+    Ring->Indices.HeadDescIdx % Ring->Ring.QueueSize;
+  Ring->Indices.HeadDescIdx = Ring->Indices.NextDescIdx;
+  Idx++;
+
+  // Force compiler to not optimize this code
+  MemoryFence ();
+  *Ring->Ring.Avail.Idx = Idx;
+  MemoryFence ();
+
+  if (Notify) {
+    Dev->VirtIo->SetQueueNotify (Dev->VirtIo, Index);
+  }
+
+  return EFI_SUCCESS;
+}
+
+// -----------------------------------------------------------------------------
+// Look for buffer ready to be processed
+BOOLEAN
+EFIAPI
+VirtioKeyboardRingHasBuffer (
+  IN OUT VIRTIO_KBD_DEV  *Dev,
+  IN     UINT16          Index
+  )
+{
+  VIRTIO_KBD_RING  *Ring   = Dev->Rings + Index;
+  UINT16           UsedIdx = *Ring->Ring.Used.Idx;
+
+  if (!Ring->Ready) {
+    return FALSE;
+  }
+
+  if (Ring->LastUsedIdx == UsedIdx) {
+    return FALSE;
+  }
+
+  return TRUE;
+}
+
+// -----------------------------------------------------------------------------
+// Get data from buffer which is marked as ready from device
+BOOLEAN
+EFIAPI
+VirtioKeyboardRingGetBuffer (
+  IN OUT VIRTIO_KBD_DEV  *Dev,
+  IN     UINT16          Index,
+  OUT    VOID            *Data,
+  OUT    UINT32          *DataSize
+  )
+{
+  VIRTIO_KBD_RING           *Ring   = Dev->Rings + Index;
+  UINT16                    UsedIdx = *Ring->Ring.Used.Idx;
+  volatile VRING_USED_ELEM  *UsedElem;
+
+  if (!Ring->Ready) {
+    return FALSE;
+  }
+
+  if (Ring->LastUsedIdx == UsedIdx) {
+    return FALSE;
+  }
+
+  UsedElem = Ring->Ring.Used.UsedElem + (Ring->LastUsedIdx % Ring->Ring.QueueSize);
+
+  if (UsedElem->Len > Ring->BufferSize) {
+    DEBUG ((DEBUG_ERROR, "%a:%d: %d: invalid length\n", __func__, __LINE__, Index));
+    UsedElem->Len = 0;
+  }
+
+  if (Data && DataSize) {
+    CopyMem (Data, BufferPtr (Ring, UsedElem->Id), UsedElem->Len);
+    *DataSize = UsedElem->Len;
+  }
+
+  if (Index % 2 == 0) {
+    /* RX - re-queue buffer */
+    VirtioKeyboardRingSendBuffer (Dev, Index, NULL, Ring->BufferSize, FALSE);
+  }
+
+  Ring->LastUsedIdx++;
+  return TRUE;
+}
+
+// -----------------------------------------------------------------------------
+// Initialize ring buffer
+EFI_STATUS
+EFIAPI
+VirtioKeyboardInitRing (
+  IN OUT VIRTIO_KBD_DEV  *Dev,
+  IN     UINT16          Index,
+  IN     UINT32          BufferSize
+  )
+{
+  VIRTIO_KBD_RING  *Ring = Dev->Rings + Index;
+  EFI_STATUS       Status;
+  UINT16           QueueSize;
+  UINT64           RingBaseShift;
+
+  //
+  // step 4b -- allocate request virtqueue
+  //
+  Status = Dev->VirtIo->SetQueueSel (Dev->VirtIo, Index);
+  if (EFI_ERROR (Status)) {
+    goto Failed;
+  }
+
+  Status = Dev->VirtIo->GetQueueNumMax (Dev->VirtIo, &QueueSize);
+  if (EFI_ERROR (Status)) {
+    goto Failed;
+  }
+
+  //
+  // VirtioSerial uses one descriptor
+  //
+  if (QueueSize < 1) {
+    Status = EFI_UNSUPPORTED;
+    goto Failed;
+  }
+
+  Status = VirtioRingInit (Dev->VirtIo, QueueSize, &Ring->Ring);
+  if (EFI_ERROR (Status)) {
+    goto Failed;
+  }
+
+  //
+  // If anything fails from here on, we must release the ring resources.
+  //
+  Status = VirtioRingMap (
+             Dev->VirtIo,
+             &Ring->Ring,
+             &RingBaseShift,
+             &Ring->RingMap
+             );
+  if (EFI_ERROR (Status)) {
+    goto ReleaseQueue;
+  }
+
+  //
+  // Additional steps for MMIO: align the queue appropriately, and set the
+  // size. If anything fails from here on, we must unmap the ring resources.
+  //
+  Status = Dev->VirtIo->SetQueueNum (Dev->VirtIo, QueueSize);
+  if (EFI_ERROR (Status)) {
+    goto UnmapQueue;
+  }
+
+  Status = Dev->VirtIo->SetQueueAlign (Dev->VirtIo, EFI_PAGE_SIZE);
+  if (EFI_ERROR (Status)) {
+    goto UnmapQueue;
+  }
+
+  //
+  // step 4c -- Report GPFN (guest-physical frame number) of queue.
+  //
+  Status = Dev->VirtIo->SetQueueAddress (
+                          Dev->VirtIo,
+                          &Ring->Ring,
+                          RingBaseShift
+                          );
+  if (EFI_ERROR (Status)) {
+    goto UnmapQueue;
+  }
+
+  Ring->BufferCount = QueueSize;
+  Ring->BufferSize  = BufferSize;
+  Ring->BufferPages = EFI_SIZE_TO_PAGES (Ring->BufferCount * Ring->BufferSize);
+
+  Status = Dev->VirtIo->AllocateSharedPages (Dev->VirtIo, Ring->BufferPages, (VOID **)&Ring->Buffers);
+  if (EFI_ERROR (Status)) {
+    goto UnmapQueue;
+  }
+
+  Status = VirtioMapAllBytesInSharedBuffer (
+             Dev->VirtIo,
+             VirtioOperationBusMasterCommonBuffer,
+             Ring->Buffers,
+             EFI_PAGES_TO_SIZE (Ring->BufferPages),
+             &Ring->DeviceAddress,
+             &Ring->BufferMap
+             );
+  if (EFI_ERROR (Status)) {
+    goto ReleasePages;
+  }
+
+  VirtioPrepare (&Ring->Ring, &Ring->Indices);
+  Ring->Ready = TRUE;
+
+  return EFI_SUCCESS;
+
+ReleasePages:
+  Dev->VirtIo->FreeSharedPages (
+                 Dev->VirtIo,
+                 Ring->BufferPages,
+                 Ring->Buffers
+                 );
+  Ring->Buffers = NULL;
+
+UnmapQueue:
+  Dev->VirtIo->UnmapSharedBuffer (Dev->VirtIo, Ring->RingMap);
+  Ring->RingMap = NULL;
+
+ReleaseQueue:
+  VirtioRingUninit (Dev->VirtIo, &Ring->Ring);
+
+Failed:
+  return Status;
+}
+
+// -----------------------------------------------------------------------------
+// Deinitialize ring buffer
+VOID
+EFIAPI
+VirtioKeyboardUninitRing (
+  IN OUT VIRTIO_KBD_DEV  *Dev,
+  IN     UINT16          Index
+  )
+{
+  VIRTIO_KBD_RING  *Ring = Dev->Rings + Index;
+
+  if (Ring->BufferMap) {
+    Dev->VirtIo->UnmapSharedBuffer (Dev->VirtIo, Ring->BufferMap);
+    Ring->BufferMap = NULL;
+  }
+
+  if (Ring->Buffers) {
+    Dev->VirtIo->FreeSharedPages (
+                   Dev->VirtIo,
+                   Ring->BufferPages,
+                   Ring->Buffers
+                   );
+    Ring->Buffers = NULL;
+  }
+
+  if (!Ring->RingMap) {
+    Dev->VirtIo->UnmapSharedBuffer (Dev->VirtIo, Ring->RingMap);
+    Ring->RingMap = NULL;
+  }
+
+  if (Ring->Ring.Base) {
+    VirtioRingUninit (Dev->VirtIo, &Ring->Ring);
+  }
+
+  ZeroMem (Ring, sizeof (*Ring));
+}
+
+// -----------------------------------------------------------------------------
+// Deinitialize all rings allocated in driver
+STATIC
+VOID
+EFIAPI
+VirtioKeyboardUninitAllRings (
+  IN OUT VIRTIO_KBD_DEV  *Dev
+  )
+{
+  UINT16  Index;
+
+  for (Index = 0; Index < KEYBOARD_MAX_RINGS; Index++) {
+    VirtioKeyboardUninitRing (Dev, Index);
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Mark all buffers as ready to write and push to device
+VOID
+EFIAPI
+VirtioKeyboardRingFillRx (
+  IN OUT VIRTIO_KBD_DEV  *Dev,
+  IN     UINT16          Index
+  )
+{
+  VIRTIO_KBD_RING  *Ring = Dev->Rings + Index;
+  UINT32           BufferNr;
+
+  for (BufferNr = 0; BufferNr < Ring->BufferCount; BufferNr++) {
+    VirtioKeyboardRingSendBuffer (Dev, Index, NULL, Ring->BufferSize, FALSE);
+  }
+
+  Dev->VirtIo->SetQueueNotify (Dev->VirtIo, Index);
+}
+
+// Forward declaration of module Uninit function
+STATIC
+VOID
+EFIAPI
+VirtioKeyboardUninit (
+  IN OUT VIRTIO_KBD_DEV  *Dev
+  );
+
+// Forward declaration of module Init function
+STATIC
+EFI_STATUS
+EFIAPI
+VirtioKeyboardInit (
+  IN OUT VIRTIO_KBD_DEV  *Dev
+  );
+
+// -----------------------------------------------------------------------------
+// EFI_SIMPLE_TEXT_INPUT_PROTOCOL API
+EFI_STATUS
+EFIAPI
+VirtioKeyboardSimpleTextInputReset (
+  IN EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL  *This,
+  IN BOOLEAN                            ExtendedVerification
+  )
+{
+  VIRTIO_KBD_DEV  *Dev;
+
+  Dev = VIRTIO_KEYBOARD_FROM_THIS (This);
+  VirtioKeyboardUninit (Dev);
+  VirtioKeyboardInit (Dev);
+
+  return EFI_SUCCESS;
+}
+
+// -----------------------------------------------------------------------------
+// EFI_SIMPLE_TEXT_INPUT_PROTOCOL API
+EFI_STATUS
+EFIAPI
+VirtioKeyboardSimpleTextInputReadKeyStroke (
+  IN  EFI_SIMPLE_TEXT_INPUT_PROTOCOL  *This,
+  OUT EFI_INPUT_KEY                   *Key
+  )
+{
+  VIRTIO_KBD_DEV  *Dev;
+  EFI_TPL         OldTpl;
+
+  if (Key == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Dev = VIRTIO_KEYBOARD_FROM_THIS (This);
+
+  OldTpl = gBS->RaiseTPL (TPL_NOTIFY);
+  if (Dev->KeyReady) {
+    // Get last key from the buffer
+    *Key = Dev->LastKey;
+
+    // Mark key as consumed
+    Dev->KeyReady = FALSE;
+
+    gBS->RestoreTPL (OldTpl);
+    return EFI_SUCCESS;
+  }
+
+  gBS->RestoreTPL (OldTpl);
+
+  return EFI_NOT_READY;
+}
+
+// -----------------------------------------------------------------------------
+// Function converting VirtIO key codes to UEFI key codes
+#define MAX_KEYBOARD_CODE  255
+
+STATIC
+VOID
+EFIAPI
+VirtioKeyboardConvertKeyCode (
+  IN OUT VIRTIO_KBD_DEV  *Dev,
+  IN UINT16              Code,
+  OUT EFI_INPUT_KEY      *Key
+  )
+{
+  // Key mapping in between Linux and UEFI
+  // https://github.com/torvalds/linux/blob/master/include/uapi/linux/input-event-codes.h
+  // https://dox.ipxe.org/SimpleTextIn_8h_source.html#l00048
+  // https://uefi.org/specs/UEFI/2.10/Apx_B_Console.html
+
+  static const UINT16  Map[] = {
+    [KEY_1]             = '1',  '2',  '3', '4', '5', '6', '7', '8', '9', '0',
+    [KEY_MINUS]         = '-',  '=',
+    [KEY_Q]             = 'q',  'w',  'e', 'r', 't', 'y', 'u', 'i', 'o', 'p',
+    [KEY_LEFTBRACE]     = '[',  ']',
+    [KEY_A]             = 'a',  's',  'd', 'f', 'g', 'h', 'j', 'k', 'l',
+    [KEY_SEMICOLON]     = ';',  '\'', '`',
+    [KEY_BACKSLASH]     = '\\',
+    [KEY_Z]             = 'z',  'x',  'c', 'v', 'b', 'n', 'm',
+    [KEY_COMMA]         = ',',  '.',  '/',
+    [KEY_SPACE]         = ' ',
+    [MAX_KEYBOARD_CODE] = 0x00
+  };
+
+  static const UINT16  MapShift[] = {
+    [KEY_1]             = '!', '@',  '#', '$', '%', '^', '&', '*', '(', ')',
+    [KEY_MINUS]         = '_', '+',
+    [KEY_Q]             = 'Q', 'W',  'E', 'R', 'T', 'Y', 'U', 'I', 'O', 'P',
+    [KEY_LEFTBRACE]     = '{', '}',
+    [KEY_A]             = 'A', 'S',  'D', 'F', 'G', 'H', 'J', 'K', 'L',
+    [KEY_SEMICOLON]     = ':', '\"', '~',
+    [KEY_BACKSLASH]     = '|',
+    [KEY_Z]             = 'Z', 'X',  'C', 'V', 'B', 'N', 'M',
+    [KEY_COMMA]         = '<', '>',  '?',
+    [KEY_SPACE]         = ' ',
+    [MAX_KEYBOARD_CODE] = 0x00
+  };
+
+  // Check if key code is not out of the keyboard mapping boundaries
+  if (Code >= MAX_KEYBOARD_CODE) {
+    DEBUG ((DEBUG_INFO, "%a: Key code out of range \n", __func__));
+    Key->ScanCode    = SCAN_NULL;
+    Key->UnicodeChar = CHAR_NULL;
+    return;
+  }
+
+  // Handle F1 - F10 keys
+  if ((Code >= KEY_F1) && (Code <= KEY_F10)) {
+    Key->ScanCode    = SCAN_F1 + (Code - KEY_F1);
+    Key->UnicodeChar = CHAR_NULL;
+    return;
+  }
+
+  switch (Code) {
+    case KEY_PAGEUP:
+      Key->ScanCode    = SCAN_PAGE_UP;
+      Key->UnicodeChar = CHAR_NULL;
+      break;
+
+    case KEY_PAGEDOWN:
+      Key->ScanCode    = SCAN_PAGE_DOWN;
+      Key->UnicodeChar = CHAR_NULL;
+      break;
+
+    case KEY_HOME:
+      Key->ScanCode    = SCAN_HOME;
+      Key->UnicodeChar = CHAR_NULL;
+      break;
+
+    case KEY_END:
+      Key->ScanCode    = SCAN_END;
+      Key->UnicodeChar = CHAR_NULL;
+      break;
+
+    case KEY_DELETE:
+      Key->ScanCode    = SCAN_DELETE;
+      Key->UnicodeChar = CHAR_NULL;
+      break;
+
+    case KEY_INSERT:
+      Key->ScanCode    = SCAN_INSERT;
+      Key->UnicodeChar = CHAR_NULL;
+      break;
+
+    case KEY_UP:
+      Key->ScanCode    = SCAN_UP;
+      Key->UnicodeChar = CHAR_NULL;
+      break;
+
+    case KEY_LEFT:
+      Key->ScanCode    = SCAN_LEFT;
+      Key->UnicodeChar = CHAR_NULL;
+      break;
+
+    case KEY_RIGHT:
+      Key->ScanCode    = SCAN_RIGHT;
+      Key->UnicodeChar = CHAR_NULL;
+      break;
+
+    case KEY_DOWN:
+      Key->ScanCode    = SCAN_DOWN;
+      Key->UnicodeChar = CHAR_NULL;
+      break;
+
+    case KEY_BACKSPACE:
+      Key->ScanCode    = SCAN_NULL;
+      Key->UnicodeChar = CHAR_BACKSPACE;
+      break;
+
+    case KEY_TAB:
+      Key->ScanCode    = SCAN_NULL;
+      Key->UnicodeChar = CHAR_TAB;
+      break;
+
+    case KEY_ENTER:
+      Key->ScanCode = SCAN_NULL;
+      // Key->UnicodeChar = CHAR_LINEFEED;
+      Key->UnicodeChar = CHAR_CARRIAGE_RETURN;
+      break;
+
+    case KEY_ESC:
+      Key->ScanCode    = SCAN_ESC;
+      Key->UnicodeChar = CHAR_NULL;
+      break;
+
+    default:
+      if (Dev->ShiftActive) {
+        Key->ScanCode    = MapShift[Code];
+        Key->UnicodeChar = MapShift[Code];
+      } else {
+        Key->ScanCode    = Map[Code];
+        Key->UnicodeChar = Map[Code];
+      }
+
+      if (Dev->CtrlActive) {
+        // Convert Ctrl+[a-z] and Ctrl+[A-Z] into [1-26] ASCII table entries
+        // Key->ScanCode    = SCAN_NULL;
+        if ((Key->UnicodeChar >= L'a') && (Key->UnicodeChar <= L'z')) {
+          Key->UnicodeChar = (CHAR16)(Key->UnicodeChar - L'a' + 1);
+        } else if ((Key->UnicodeChar >= L'A') && (Key->UnicodeChar <= L'Z')) {
+          Key->UnicodeChar = (CHAR16)(Key->UnicodeChar - L'A' + 1);
+        }
+      }
+
+      break;
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Main function processing virtio keyboard events
+STATIC
+VOID
+EFIAPI
+VirtioKeyboardGetDeviceData (
+  IN OUT VIRTIO_KBD_DEV  *Dev
+  )
+{
+  BOOLEAN           HasData;
+  UINT8             Data[KEYBOARD_RX_BUFSIZE + 1];
+  UINT32            DataSize;
+  VIRTIO_KBD_EVENT  Event;
+  EFI_TPL           OldTpl;
+
+  for ( ; ; ) {
+    HasData = VirtioKeyboardRingGetBuffer (Dev, 0, Data, &DataSize);
+
+    // Exit if no new data
+    if (!HasData) {
+      return;
+    }
+
+    if (DataSize < sizeof (Event)) {
+      continue;
+    }
+
+    // Clearing last character is not needed as it will be overwritten anyway
+    // Dev->LastKey.ScanCode = SCAN_NULL;
+    // Dev->LastKey.UnicodeChar = CHAR_NULL;
+
+    CopyMem (&Event, Data, sizeof (Event));
+
+    OldTpl = gBS->RaiseTPL (TPL_NOTIFY);
+    switch (Event.Type) {
+      case EV_SYN:
+        // Sync event received
+        break;
+
+      case EV_KEY:
+        // Key press event received
+        // DEBUG ((DEBUG_INFO, "%a: ---------------------- \nType: %x Code: %x Value: %x\n",
+        //              __func__, Event.Type, Event.Code, Event.Value));
+
+        if (Event.Value == KEY_PRESSED) {
+          // Check key modifiers first
+          if ((Event.Code == KEY_LEFTSHIFT) || (Event.Code == KEY_RIGHTSHIFT)) {
+            Dev->ShiftActive = TRUE;
+            // This is not visible character by itself
+            break;
+          }
+
+          if ((Event.Code == KEY_LEFTCTRL) || (Event.Code == KEY_RIGHTCTRL)) {
+            Dev->CtrlActive = TRUE;
+            // This is not visible character by itself
+            break;
+          }
+
+          if ((Event.Code == KEY_LEFTALT) || (Event.Code == KEY_RIGHTALT)) {
+            Dev->AltActive = TRUE;
+            // This is not visible character by itself
+            break;
+          }
+
+          // Evaluate key
+          VirtioKeyboardConvertKeyCode (Dev, Event.Code, &Dev->LastKey);
+
+          // Flag that printable character is ready to be send
+          Dev->KeyReady = TRUE;
+        } else {
+          // Check key modifiers first
+          if ((Event.Code == KEY_LEFTSHIFT) || (Event.Code == KEY_RIGHTSHIFT)) {
+            Dev->ShiftActive = FALSE;
+            // This is not visible character by itself
+            break;
+          }
+
+          if ((Event.Code == KEY_LEFTCTRL) || (Event.Code == KEY_RIGHTCTRL)) {
+            Dev->CtrlActive = FALSE;
+            // This is not visible character by itself
+            break;
+          }
+
+          if ((Event.Code == KEY_LEFTALT) || (Event.Code == KEY_RIGHTALT)) {
+            Dev->AltActive = FALSE;
+            // This is not visible character by itself
+            break;
+          }
+        }
+
+        break;
+
+      default:
+        DEBUG ((DEBUG_INFO, "%a: Unhandled VirtIo event\n", __func__));
+        break;
+    }
+
+    gBS->RestoreTPL (OldTpl);
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Callback hook for timer interrupt
+STATIC
+VOID
+EFIAPI
+VirtioKeyboardTimer (
+  IN EFI_EVENT  Event,
+  IN VOID       *Context
+  )
+{
+  VIRTIO_KBD_DEV  *Dev = Context;
+
+  VirtioKeyboardGetDeviceData (Dev);
+}
+
+// -----------------------------------------------------------------------------
+// EFI_SIMPLE_TEXT_INPUT_PROTOCOL API
+VOID
+EFIAPI
+VirtioKeyboardWaitForKey (
+  IN  EFI_EVENT  Event,
+  IN  VOID       *Context
+  )
+{
+  VIRTIO_KBD_DEV  *Dev = VIRTIO_KEYBOARD_FROM_THIS (Context);
+
+  //
+  // Stall 1ms to give a chance to let other driver interrupt this routine
+  // for their timer event.
+  // e.g. UI setup or Shell, other drivers which are driven by timer event
+  // will have a bad performance during this period,
+  // e.g. usb keyboard driver.
+  // Add a stall period can greatly increate other driver performance during
+  // the WaitForKey is recursivly invoked. 1ms delay will make little impact
+  // to the thunk keyboard driver, and user can not feel the delay at all when
+  // input.
+  gBS->Stall (1000);
+
+  // Use TimerEvent callback function to check whether there's any key pressed
+  VirtioKeyboardTimer (NULL, Dev);
+
+  // If there is a new key ready - send signal
+  if (Dev->KeyReady) {
+    gBS->SignalEvent (Event);
+  }
+}
+
+/// -----------------------------------------------------------------------------
+// EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL API
+EFI_STATUS
+EFIAPI
+VirtioKeyboardResetEx (
+  IN EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL  *This,
+  IN BOOLEAN                            ExtendedVerification
+  )
+{
+  VIRTIO_KBD_DEV  *Dev;
+  EFI_STATUS      Status;
+  EFI_TPL         OldTpl;
+
+  Dev = VIRTIO_KEYBOARD_EX_FROM_THIS (This);
+
+  // Call the reset function from SIMPLE_TEXT_INPUT protocol
+  Status = Dev->Txt.Reset (
+                      &Dev->Txt,
+                      ExtendedVerification
+                      );
+
+  if (EFI_ERROR (Status)) {
+    return EFI_DEVICE_ERROR;
+  }
+
+  OldTpl = gBS->RaiseTPL (TPL_NOTIFY);
+  gBS->RestoreTPL (OldTpl);
+
+  return EFI_SUCCESS;
+}
+
+// -----------------------------------------------------------------------------
+// EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL API
+EFI_STATUS
+EFIAPI
+VirtioKeyboardReadKeyStrokeEx (
+  IN  EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL  *This,
+  OUT EFI_KEY_DATA                       *KeyData
+  )
+{
+  VIRTIO_KBD_DEV  *Dev;
+  EFI_STATUS      Status;
+  EFI_INPUT_KEY   Key;
+  EFI_KEY_STATE   KeyState;
+
+  if (KeyData == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Dev = VIRTIO_KEYBOARD_EX_FROM_THIS (This);
+
+  // Get the last pressed key
+  Status = Dev->Txt.ReadKeyStroke (&Dev->Txt, &Key);
+  if (EFI_ERROR (Status)) {
+    return EFI_DEVICE_ERROR;
+  }
+
+  // Add key state informations
+  KeyState.KeyShiftState  = EFI_SHIFT_STATE_VALID;
+  KeyState.KeyToggleState = EFI_TOGGLE_STATE_VALID;
+
+  if (Dev->ShiftActive) {
+    KeyState.KeyShiftState |= EFI_LEFT_SHIFT_PRESSED;
+  }
+
+  if (Dev->CtrlActive) {
+    KeyState.KeyShiftState |= EFI_LEFT_CONTROL_PRESSED;
+  }
+
+  if (Dev->AltActive) {
+    KeyState.KeyShiftState |= EFI_LEFT_ALT_PRESSED;
+  }
+
+  // Return value only when there is no failure
+  KeyData->Key      = Key;
+  KeyData->KeyState = KeyState;
+
+  return EFI_SUCCESS;
+}
+
+// -----------------------------------------------------------------------------
+// EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL API
+VOID
+EFIAPI
+VirtioKeyboardWaitForKeyEx (
+  IN  EFI_EVENT  Event,
+  IN  VOID       *Context
+  )
+{
+  VIRTIO_KBD_DEV  *Dev;
+
+  Dev = VIRTIO_KEYBOARD_EX_FROM_THIS (Context);
+  VirtioKeyboardWaitForKey (Event, &Dev->Txt);
+}
+
+// -----------------------------------------------------------------------------
+// EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL API
+EFI_STATUS
+EFIAPI
+VirtioKeyboardSetState (
+  IN EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL  *This,
+  IN EFI_KEY_TOGGLE_STATE               *KeyToggleState
+  )
+{
+  if (KeyToggleState == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  return EFI_SUCCESS;
+}
+
+BOOLEAN
+IsKeyRegistered (
+  IN EFI_KEY_DATA  *RegsiteredData,
+  IN EFI_KEY_DATA  *InputData
+  )
+
+{
+  ASSERT (RegsiteredData != NULL && InputData != NULL);
+
+  if ((RegsiteredData->Key.ScanCode    != InputData->Key.ScanCode) ||
+      (RegsiteredData->Key.UnicodeChar != InputData->Key.UnicodeChar))
+  {
+    return FALSE;
+  }
+
+  //
+  // Assume KeyShiftState/KeyToggleState = 0 in Registered key data means
+  // these state could be ignored.
+  //
+  if ((RegsiteredData->KeyState.KeyShiftState != 0) &&
+      (RegsiteredData->KeyState.KeyShiftState != InputData->KeyState.KeyShiftState))
+  {
+    return FALSE;
+  }
+
+  if ((RegsiteredData->KeyState.KeyToggleState != 0) &&
+      (RegsiteredData->KeyState.KeyToggleState != InputData->KeyState.KeyToggleState))
+  {
+    return FALSE;
+  }
+
+  return TRUE;
+}
+
+// -----------------------------------------------------------------------------
+// EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL API
+EFI_STATUS
+EFIAPI
+VirtioKeyboardRegisterKeyNotify (
+  IN EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL  *This,
+  IN EFI_KEY_DATA                       *KeyData,
+  IN EFI_KEY_NOTIFY_FUNCTION            KeyNotificationFunction,
+  OUT VOID                              **NotifyHandle
+  )
+{
+  EFI_STATUS               Status;
+  VIRTIO_KBD_DEV           *Dev;
+  EFI_TPL                  OldTpl;
+  LIST_ENTRY               *Link;
+  VIRTIO_KBD_IN_EX_NOTIFY  *NewNotify;
+  VIRTIO_KBD_IN_EX_NOTIFY  *CurrentNotify;
+
+  if ((KeyData == NULL) ||
+      (NotifyHandle == NULL) ||
+      (KeyNotificationFunction == NULL))
+  {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Dev = VIRTIO_KEYBOARD_EX_FROM_THIS (This);
+
+  OldTpl = gBS->RaiseTPL (TPL_NOTIFY);
+
+  // Check if the (KeyData, NotificationFunction) pair is already registered.
+  for (Link = Dev->NotifyList.ForwardLink;
+       Link != &Dev->NotifyList;
+       Link = Link->ForwardLink)
+  {
+    CurrentNotify = CR (
+                      Link,
+                      VIRTIO_KBD_IN_EX_NOTIFY,
+                      NotifyEntry,
+                      VIRTIO_KBD_SIG
+                      );
+    if (IsKeyRegistered (&CurrentNotify->KeyData, KeyData)) {
+      if (CurrentNotify->KeyNotificationFn == KeyNotificationFunction) {
+        *NotifyHandle = CurrentNotify;
+        Status        = EFI_SUCCESS;
+        goto Exit;
+      }
+    }
+  }
+
+  NewNotify = (VIRTIO_KBD_IN_EX_NOTIFY *)AllocateZeroPool (sizeof (VIRTIO_KBD_IN_EX_NOTIFY));
+  if (NewNotify == NULL) {
+    Status = EFI_OUT_OF_RESOURCES;
+    goto Exit;
+  }
+
+  NewNotify->Signature         = VIRTIO_KBD_SIG;
+  NewNotify->KeyNotificationFn = KeyNotificationFunction;
+  CopyMem (&NewNotify->KeyData, KeyData, sizeof (EFI_KEY_DATA));
+  InsertTailList (&Dev->NotifyList, &NewNotify->NotifyEntry);
+
+  *NotifyHandle = NewNotify;
+  Status        = EFI_SUCCESS;
+
+Exit:
+  gBS->RestoreTPL (OldTpl);
+
+  return Status;
+}
+
+// -----------------------------------------------------------------------------
+// EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL API
+EFI_STATUS
+EFIAPI
+VirtioKeyboardUnregisterKeyNotify (
+  IN EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL  *This,
+  IN VOID                               *NotificationHandle
+  )
+{
+  EFI_STATUS               Status;
+  VIRTIO_KBD_DEV           *Dev;
+  EFI_TPL                  OldTpl;
+  LIST_ENTRY               *Link;
+  VIRTIO_KBD_IN_EX_NOTIFY  *CurrentNotify;
+
+  if (NotificationHandle == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (((VIRTIO_KBD_IN_EX_NOTIFY *)NotificationHandle)->Signature != VIRTIO_KBD_SIG) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Dev = VIRTIO_KEYBOARD_EX_FROM_THIS (This);
+
+  OldTpl = gBS->RaiseTPL (TPL_NOTIFY);
+
+  for (Link = Dev->NotifyList.ForwardLink;
+       Link != &Dev->NotifyList;
+       Link = Link->ForwardLink)
+  {
+    CurrentNotify = CR (
+                      Link,
+                      VIRTIO_KBD_IN_EX_NOTIFY,
+                      NotifyEntry,
+                      VIRTIO_KBD_SIG
+                      );
+    if (CurrentNotify == NotificationHandle) {
+      RemoveEntryList (&CurrentNotify->NotifyEntry);
+
+      Status = EFI_SUCCESS;
+      goto Exit;
+    }
+  }
+
+  // Notification has not been found
+  Status = EFI_INVALID_PARAMETER;
+
+Exit:
+  gBS->RestoreTPL (OldTpl);
+
+  return Status;
+}
+
+// -----------------------------------------------------------------------------
+// Driver init
+STATIC
+EFI_STATUS
+EFIAPI
+VirtioKeyboardInit (
+  IN OUT VIRTIO_KBD_DEV  *Dev
+  )
+{
+  UINT8       NextDevStat;
+  EFI_STATUS  Status;
+  UINT64      Features;
+
+  //
+  // Execute virtio-0.9.5, 2.2.1 Device Initialization Sequence.
+  //
+  NextDevStat = 0;             // step 1 -- reset device
+  Status      = Dev->VirtIo->SetDeviceStatus (Dev->VirtIo, NextDevStat);
+  if (EFI_ERROR (Status)) {
+    goto Failed;
+  }
+
+  NextDevStat |= VSTAT_ACK;    // step 2 -- acknowledge device presence
+  Status       = Dev->VirtIo->SetDeviceStatus (Dev->VirtIo, NextDevStat);
+  if (EFI_ERROR (Status)) {
+    goto Failed;
+  }
+
+  NextDevStat |= VSTAT_DRIVER; // step 3 -- we know how to drive it
+  Status       = Dev->VirtIo->SetDeviceStatus (Dev->VirtIo, NextDevStat);
+  if (EFI_ERROR (Status)) {
+    goto Failed;
+  }
+
+  //
+  // Set Page Size - MMIO VirtIo Specific
+  //
+  Status = Dev->VirtIo->SetPageSize (Dev->VirtIo, EFI_PAGE_SIZE);
+  if (EFI_ERROR (Status)) {
+    goto Failed;
+  }
+
+  //
+  // step 4a -- retrieve and validate features
+  //
+  Status = Dev->VirtIo->GetDeviceFeatures (Dev->VirtIo, &Features);
+  if (EFI_ERROR (Status)) {
+    goto Failed;
+  }
+
+  Features &= VIRTIO_F_VERSION_1 | VIRTIO_F_IOMMU_PLATFORM;
+
+  //
+  // In virtio-1.0, feature negotiation is expected to complete before queue
+  // discovery, and the device can also reject the selected set of features.
+  //
+  if (Dev->VirtIo->Revision >= VIRTIO_SPEC_REVISION (1, 0, 0)) {
+    Status = Virtio10WriteFeatures (Dev->VirtIo, Features, &NextDevStat);
+    if (EFI_ERROR (Status)) {
+      goto Failed;
+    }
+  }
+
+  Status = VirtioKeyboardInitRing (Dev, 0, KEYBOARD_RX_BUFSIZE);
+  if (EFI_ERROR (Status)) {
+    goto Failed;
+  }
+
+  //
+  // step 5 -- Report understood features and guest-tuneables.
+  //
+  if (Dev->VirtIo->Revision < VIRTIO_SPEC_REVISION (1, 0, 0)) {
+    Features &= ~(UINT64)(VIRTIO_F_VERSION_1 | VIRTIO_F_IOMMU_PLATFORM);
+    Status    = Dev->VirtIo->SetGuestFeatures (Dev->VirtIo, Features);
+    if (EFI_ERROR (Status)) {
+      goto Failed;
+    }
+  }
+
+  //
+  // step 6 -- initialization complete
+  //
+  NextDevStat |= VSTAT_DRIVER_OK;
+  Status       = Dev->VirtIo->SetDeviceStatus (Dev->VirtIo, NextDevStat);
+  if (EFI_ERROR (Status)) {
+    goto Failed;
+  }
+
+  //
+  // populate the exported interface's attributes
+  //
+
+  // struct _EFI_SIMPLE_TEXT_INPUT_PROTOCOL {
+  //    EFI_INPUT_RESET     Reset;
+  //    EFI_INPUT_READ_KEY  ReadKeyStroke;
+  //    EFI_EVENT           WaitForKey;
+  // };
+  Dev->Txt.Reset         = (EFI_INPUT_RESET)VirtioKeyboardSimpleTextInputReset;
+  Dev->Txt.ReadKeyStroke = VirtioKeyboardSimpleTextInputReadKeyStroke;
+  Dev->Txt.WaitForKey    = VirtioKeyboardWaitForKey;
+
+  // struct _EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL {
+  //    EFI_INPUT_RESET_EX              Reset;
+  //    EFI_INPUT_READ_KEY_EX           ReadKeyStrokeEx;
+  //    EFI_EVENT                       WaitForKeyEx;
+  //    EFI_SET_STATE                   SetState;
+  //    EFI_REGISTER_KEYSTROKE_NOTIFY   RegisterKeyNotify;
+  //    EFI_UNREGISTER_KEYSTROKE_NOTIFY UnregisterKeyNotify;
+  // }
+  Dev->TxtEx.Reset               = (EFI_INPUT_RESET_EX)VirtioKeyboardResetEx;
+  Dev->TxtEx.ReadKeyStrokeEx     = VirtioKeyboardReadKeyStrokeEx;
+  Dev->TxtEx.SetState            = VirtioKeyboardSetState;
+  Dev->TxtEx.RegisterKeyNotify   = VirtioKeyboardRegisterKeyNotify;
+  Dev->TxtEx.UnregisterKeyNotify = VirtioKeyboardUnregisterKeyNotify;
+  InitializeListHead (&Dev->NotifyList);
+
+  //
+  // Setup the WaitForKey event
+  //
+  Status = gBS->CreateEvent (
+                  EVT_NOTIFY_WAIT,
+                  TPL_NOTIFY,
+                  VirtioKeyboardWaitForKey,
+                  &(Dev->Txt),
+                  &((Dev->Txt).WaitForKey)
+                  );
+  if (EFI_ERROR (Status)) {
+    goto Failed;
+  }
+
+  //
+  // Setup the WaitForKeyEx event
+  //
+  Status = gBS->CreateEvent (
+                  EVT_NOTIFY_WAIT,
+                  TPL_NOTIFY,
+                  VirtioKeyboardWaitForKeyEx,
+                  &(Dev->TxtEx),
+                  &((Dev->TxtEx).WaitForKeyEx)
+                  );
+  if (EFI_ERROR (Status)) {
+    goto Failed;
+  }
+
+  VirtioKeyboardRingFillRx (Dev, 0);
+
+  //
+  // Event for reading key in time intervals
+  //
+  Status = gBS->CreateEvent (
+                  EVT_TIMER | EVT_NOTIFY_SIGNAL,
+                  TPL_NOTIFY,
+                  VirtioKeyboardTimer,
+                  Dev,
+                  &Dev->KeyReadTimer
+                  );
+  if (EFI_ERROR (Status)) {
+    goto Failed;
+  }
+
+  Status = gBS->SetTimer (
+                  Dev->KeyReadTimer,
+                  TimerPeriodic,
+                  EFI_TIMER_PERIOD_MILLISECONDS (KEYBOARD_PROBE_TIME_MS)
+                  );
+  if (EFI_ERROR (Status)) {
+    goto Failed;
+  }
+
+  return EFI_SUCCESS;
+
+Failed:
+  VirtioKeyboardUninitAllRings (Dev);
+  // VirtualKeyboardFreeNotifyList (&VirtualKeyboardPrivate->NotifyList);
+
+  //
+  // Notify the host about our failure to setup: virtio-0.9.5, 2.2.2.1 Device
+  // Status. VirtIo access failure here should not mask the original error.
+  //
+  NextDevStat |= VSTAT_FAILED;
+  Dev->VirtIo->SetDeviceStatus (Dev->VirtIo, NextDevStat);
+
+  return Status; // reached only via Failed above
+}
+
+// -----------------------------------------------------------------------------
+// Deinitialize driver
+STATIC
+VOID
+EFIAPI
+VirtioKeyboardUninit (
+  IN OUT VIRTIO_KBD_DEV  *Dev
+  )
+{
+  gBS->CloseEvent (Dev->KeyReadTimer);
+  //
+  // Reset the virtual device -- see virtio-0.9.5, 2.2.2.1 Device Status. When
+  // VIRTIO_CFG_WRITE() returns, the host will have learned to stay away from
+  // the old comms area.
+  //
+  Dev->VirtIo->SetDeviceStatus (Dev->VirtIo, 0);
+
+  VirtioKeyboardUninitAllRings (Dev);
+}
+
+// -----------------------------------------------------------------------------
+// Handle device exit before switch to boot
+STATIC
+VOID
+EFIAPI
+VirtioKeyboardExitBoot (
+  IN  EFI_EVENT  Event,
+  IN  VOID       *Context
+  )
+{
+  VIRTIO_KBD_DEV  *Dev;
+
+  DEBUG ((DEBUG_INFO, "%a: Context=0x%p\n", __func__, Context));
+  //
+  // Reset the device. This causes the hypervisor to forget about the virtio
+  // ring.
+  //
+  // We allocated said ring in EfiBootServicesData type memory, and code
+  // executing after ExitBootServices() is permitted to overwrite it.
+  //
+  Dev = Context;
+  Dev->VirtIo->SetDeviceStatus (Dev->VirtIo, 0);
+}
+
+// -----------------------------------------------------------------------------
+// Binding validation function
+STATIC
+EFI_STATUS
+EFIAPI
+VirtioKeyboardBindingSupported (
+  IN EFI_DRIVER_BINDING_PROTOCOL  *This,
+  IN EFI_HANDLE                   DeviceHandle,
+  IN EFI_DEVICE_PATH_PROTOCOL     *RemainingDevicePath
+  )
+{
+  EFI_STATUS              Status;
+  VIRTIO_DEVICE_PROTOCOL  *VirtIo;
+
+  //
+  // Attempt to open the device with the VirtIo set of interfaces. On success,
+  // the protocol is "instantiated" for the VirtIo device. Covers duplicate
+  // open attempts (EFI_ALREADY_STARTED).
+  //
+  Status = gBS->OpenProtocol (
+                  DeviceHandle,               // candidate device
+                  &gVirtioDeviceProtocolGuid, // for generic VirtIo access
+                  (VOID **)&VirtIo,           // handle to instantiate
+                  This->DriverBindingHandle,  // requestor driver identity
+                  DeviceHandle,               // ControllerHandle, according to
+                                              // the UEFI Driver Model
+                  EFI_OPEN_PROTOCOL_BY_DRIVER // get exclusive VirtIo access to
+                                              // the device; to be released
+                  );
+  if (EFI_ERROR (Status)) {
+    if (Status != EFI_UNSUPPORTED) {
+      DEBUG ((DEBUG_INFO, "%a:%d: %r\n", __func__, __LINE__, Status));
+    }
+
+    return Status;
+  }
+
+  DEBUG ((DEBUG_INFO, "%a:%d: 0x%x\n", __func__, __LINE__, VirtIo->SubSystemDeviceId));
+  if (VirtIo->SubSystemDeviceId != VIRTIO_SUBSYSTEM_INPUT) {
+    Status = EFI_UNSUPPORTED;
+  }
+
+  //
+  // We needed VirtIo access only transitorily, to see whether we support the
+  // device or not.
+  //
+  gBS->CloseProtocol (
+         DeviceHandle,
+         &gVirtioDeviceProtocolGuid,
+         This->DriverBindingHandle,
+         DeviceHandle
+         );
+  return Status;
+}
+
+// -----------------------------------------------------------------------------
+// Driver binding function API
+STATIC
+EFI_STATUS
+EFIAPI
+VirtioKeyboardBindingStart (
+  IN EFI_DRIVER_BINDING_PROTOCOL  *This,
+  IN EFI_HANDLE                   DeviceHandle,
+  IN EFI_DEVICE_PATH_PROTOCOL     *RemainingDevicePath
+  )
+{
+  VIRTIO_KBD_DEV  *Dev;
+  EFI_STATUS      Status;
+
+  Dev = (VIRTIO_KBD_DEV *)AllocateZeroPool (sizeof *Dev);
+  if (Dev == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  Status = gBS->OpenProtocol (
+                  DeviceHandle,
+                  &gVirtioDeviceProtocolGuid,
+                  (VOID **)&Dev->VirtIo,
+                  This->DriverBindingHandle,
+                  DeviceHandle,
+                  EFI_OPEN_PROTOCOL_BY_DRIVER
+                  );
+  if (EFI_ERROR (Status)) {
+    goto FreeVirtioKbd;
+  }
+
+  //
+  // VirtIo access granted, configure virtio keyboard device.
+  //
+  Status = VirtioKeyboardInit (Dev);
+  if (EFI_ERROR (Status)) {
+    goto CloseVirtIo;
+  }
+
+  Status = gBS->CreateEvent (
+                  EVT_SIGNAL_EXIT_BOOT_SERVICES,
+                  TPL_CALLBACK,
+                  &VirtioKeyboardExitBoot,
+                  Dev,
+                  &Dev->ExitBoot
+                  );
+  if (EFI_ERROR (Status)) {
+    goto UninitDev;
+  }
+
+  //
+  // Setup complete, attempt to export the driver instance's EFI_SIMPLE_TEXT_INPUT_PROTOCOL
+  // interface.
+  //
+  Dev->Signature = VIRTIO_KBD_SIG;
+  Status         = gBS->InstallMultipleProtocolInterfaces (
+                          &DeviceHandle,
+                          &gEfiSimpleTextInProtocolGuid,
+                          &Dev->Txt,
+                          &gEfiSimpleTextInputExProtocolGuid,
+                          &Dev->TxtEx,
+                          NULL
+                          );
+  if (EFI_ERROR (Status)) {
+    goto CloseExitBoot;
+  }
+
+  return EFI_SUCCESS;
+
+CloseExitBoot:
+  gBS->CloseEvent (Dev->ExitBoot);
+
+UninitDev:
+  VirtioKeyboardUninit (Dev);
+
+CloseVirtIo:
+  gBS->CloseProtocol (
+         DeviceHandle,
+         &gVirtioDeviceProtocolGuid,
+         This->DriverBindingHandle,
+         DeviceHandle
+         );
+
+FreeVirtioKbd:
+  FreePool (Dev);
+
+  return Status;
+}
+
+// -----------------------------------------------------------------------------
+// Driver unbinding function API
+STATIC
+EFI_STATUS
+EFIAPI
+VirtioKeyboardBindingStop (
+  IN EFI_DRIVER_BINDING_PROTOCOL  *This,
+  IN EFI_HANDLE                   DeviceHandle,
+  IN UINTN                        NumberOfChildren,
+  IN EFI_HANDLE                   *ChildHandleBuffer
+  )
+{
+  EFI_STATUS                      Status;
+  EFI_SIMPLE_TEXT_INPUT_PROTOCOL  *Txt;
+  VIRTIO_KBD_DEV                  *Dev;
+
+  Status = gBS->OpenProtocol (
+                  DeviceHandle,                     // candidate device
+                  &gEfiSimpleTextInProtocolGuid,    // retrieve the RNG iface
+                  (VOID **)&Txt,                    // target pointer
+                  This->DriverBindingHandle,        // requestor driver ident.
+                  DeviceHandle,                     // lookup req. for dev.
+                  EFI_OPEN_PROTOCOL_GET_PROTOCOL    // lookup only, no new ref.
+                  );
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Dev = VIRTIO_KEYBOARD_FROM_THIS (Txt);
+
+  //
+  // Handle Stop() requests for in-use driver instances gracefully.
+  //
+  Status = gBS->UninstallMultipleProtocolInterfaces (
+                  &DeviceHandle,
+                  &gEfiSimpleTextInProtocolGuid,
+                  &Dev->Txt,
+                  &gEfiSimpleTextInputExProtocolGuid,
+                  &Dev->TxtEx,
+                  NULL
+                  );
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  gBS->CloseEvent (Dev->ExitBoot);
+
+  VirtioKeyboardUninit (Dev);
+
+  gBS->CloseProtocol (
+         DeviceHandle,
+         &gVirtioDeviceProtocolGuid,
+         This->DriverBindingHandle,
+         DeviceHandle
+         );
+
+  FreePool (Dev);
+
+  return EFI_SUCCESS;
+}
+
+// -----------------------------------------------------------------------------
+// Forward declaration of global variable
+STATIC
+EFI_COMPONENT_NAME_PROTOCOL  gComponentName;
+
+// -----------------------------------------------------------------------------
+// Driver name to be displayed
+STATIC
+EFI_UNICODE_STRING_TABLE  mDriverNameTable[] = {
+  { "eng;en", L"Virtio Keyboard Driver" },
+  { NULL,     NULL                      }
+};
+
+// -----------------------------------------------------------------------------
+// Driver name lookup function
+STATIC
+EFI_STATUS
+EFIAPI
+VirtioKeyboardGetDriverName (
+  IN  EFI_COMPONENT_NAME_PROTOCOL  *This,
+  IN  CHAR8                        *Language,
+  OUT CHAR16                       **DriverName
+  )
+{
+  return LookupUnicodeString2 (
+           Language,
+           This->SupportedLanguages,
+           mDriverNameTable,
+           DriverName,
+           (BOOLEAN)(This == &gComponentName) // Iso639Language
+           );
+}
+
+// -----------------------------------------------------------------------------
+// Device name to be displayed
+STATIC
+EFI_UNICODE_STRING_TABLE  mDeviceNameTable[] = {
+  { "eng;en", L"RHEL virtio virtual keyboard BOB (Basic Operation Board)" },
+  { NULL,     NULL                                                        }
+};
+
+// -----------------------------------------------------------------------------
+STATIC
+EFI_COMPONENT_NAME_PROTOCOL  gDeviceName;
+
+// -----------------------------------------------------------------------------
+STATIC
+EFI_STATUS
+EFIAPI
+VirtioKeyboardGetDeviceName (
+  IN  EFI_COMPONENT_NAME_PROTOCOL  *This,
+  IN  EFI_HANDLE                   DeviceHandle,
+  IN  EFI_HANDLE                   ChildHandle,
+  IN  CHAR8                        *Language,
+  OUT CHAR16                       **ControllerName
+  )
+{
+  return LookupUnicodeString2 (
+           Language,
+           This->SupportedLanguages,
+           mDeviceNameTable,
+           ControllerName,
+           (BOOLEAN)(This == &gDeviceName) // Iso639Language
+           );
+}
+
+// -----------------------------------------------------------------------------
+// General driver UEFI interface for showing driver name
+STATIC
+EFI_COMPONENT_NAME_PROTOCOL  gComponentName = {
+  &VirtioKeyboardGetDriverName,
+  &VirtioKeyboardGetDeviceName,
+  "eng" // SupportedLanguages, ISO 639-2 language codes
+};
+
+// -----------------------------------------------------------------------------
+// General driver UEFI interface for showing driver name
+STATIC
+EFI_COMPONENT_NAME2_PROTOCOL  gComponentName2 = {
+  (EFI_COMPONENT_NAME2_GET_DRIVER_NAME)&VirtioKeyboardGetDriverName,
+  (EFI_COMPONENT_NAME2_GET_CONTROLLER_NAME)&VirtioKeyboardGetDeviceName,
+  "en" // SupportedLanguages, RFC 4646 language codes
+};
+
+// -----------------------------------------------------------------------------
+// General driver UEFI interface for loading / unloading driver
+STATIC EFI_DRIVER_BINDING_PROTOCOL  gDriverBinding = {
+  &VirtioKeyboardBindingSupported,
+  &VirtioKeyboardBindingStart,
+  &VirtioKeyboardBindingStop,
+  0x10, // Version, must be in [0x10 .. 0xFFFFFFEF] for IHV-developed drivers
+  NULL, // ImageHandle, to be overwritten by
+        // EfiLibInstallDriverBindingComponentName2() in VirtioKeyboardEntryPoint()
+  NULL  // DriverBindingHandle, ditto
+};
+
+// -----------------------------------------------------------------------------
+// Driver entry point set in INF file, registers all driver functions into UEFI
+EFI_STATUS
+EFIAPI
+VirtioKeyboardEntryPoint (
+  IN EFI_HANDLE        ImageHandle,
+  IN EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  DEBUG ((DEBUG_INFO, "Virtio keyboard has been loaded.......................\n"));
+  return EfiLibInstallDriverBindingComponentName2 (
+           ImageHandle,
+           SystemTable,
+           &gDriverBinding,
+           ImageHandle,
+           &gComponentName,
+           &gComponentName2
+           );
+}

--- a/OvmfPkg/VirtioKeyboardDxe/VirtioKeyboard.h
+++ b/OvmfPkg/VirtioKeyboardDxe/VirtioKeyboard.h
@@ -1,0 +1,208 @@
+/** @file
+
+  Private definitions of the VirtioKeyboard driver
+
+  Copyright (C) 2023, Red Hat
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef _VIRTIO_KEYBOARD_DXE_H_
+#define _VIRTIO_KEYBOARD_DXE_H_
+
+#include <Protocol/ComponentName.h>
+#include <Protocol/DriverBinding.h>
+#include <Protocol/SimpleTextIn.h>
+#include <Protocol/SimpleTextInEx.h>
+
+#include <IndustryStandard/Virtio.h>
+
+#define VIRTIO_KBD_SIG  SIGNATURE_32 ('V', 'K', 'B', 'D')
+
+#define KEYBOARD_MAX_RINGS   2
+#define KEYBOARD_RX_BUFSIZE  64
+
+// Fetch new key from VirtIO every 50ms
+#define KEYBOARD_PROBE_TIME_MS  50
+
+typedef struct {
+  UINTN                      Signature;
+  EFI_KEY_DATA               KeyData;
+  EFI_KEY_NOTIFY_FUNCTION    KeyNotificationFn;
+  LIST_ENTRY                 NotifyEntry;
+} VIRTIO_KBD_IN_EX_NOTIFY;
+
+// Data structure representing payload delivered from VirtIo
+typedef struct {
+  UINT16    Type;
+  UINT16    Code;
+  UINT32    Value;
+} VIRTIO_KBD_EVENT;
+
+// Data structure representing ring buffer
+typedef struct {
+  VRING                   Ring;
+  VOID                    *RingMap;
+  DESC_INDICES            Indices;        /* Avail Ring */
+  UINT16                  LastUsedIdx;    /* Used Ring */
+
+  UINT32                  BufferSize;
+  UINT32                  BufferCount;
+  UINT32                  BufferPages;
+  UINT8                   *Buffers;
+  VOID                    *BufferMap;
+  EFI_PHYSICAL_ADDRESS    DeviceAddress;
+
+  BOOLEAN                 Ready;
+} VIRTIO_KBD_RING;
+
+// Declaration of data structure representing driver context
+typedef struct {
+  // Device signature
+  UINT32                            Signature;
+
+  // Hook for the function which shall be caled when driver is closed
+  // before system state changes to boot
+  EFI_EVENT                         ExitBoot;
+
+  // Hooks for functions required by UEFI keyboard API
+  // struct _EFI_SIMPLE_TEXT_INPUT_PROTOCOL {
+  //    EFI_INPUT_RESET     Reset;
+  //    EFI_INPUT_READ_KEY  ReadKeyStroke;
+  //    EFI_EVENT           WaitForKey;
+  // };
+  EFI_SIMPLE_TEXT_INPUT_PROTOCOL    Txt;
+
+  // struct _EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL {
+  //    EFI_INPUT_RESET_EX              Reset;
+  //    EFI_INPUT_READ_KEY_EX           ReadKeyStrokeEx;
+  //    EFI_EVENT                       WaitForKeyEx;
+  //    EFI_SET_STATE                   SetState;
+  //    EFI_REGISTER_KEYSTROKE_NOTIFY   RegisterKeyNotify;
+  //    EFI_UNREGISTER_KEYSTROKE_NOTIFY UnregisterKeyNotify;
+  // }
+  EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL    TxtEx;
+
+  // Virtio device hook
+  VIRTIO_DEVICE_PROTOCOL               *VirtIo;
+
+  // Hook for ring buffer
+  VIRTIO_KBD_RING                      Rings[KEYBOARD_MAX_RINGS];
+
+  // Timer event for checking key presses from VirtIo
+  EFI_EVENT                            KeyReadTimer;
+
+  // List for notifications
+  LIST_ENTRY                           NotifyList;
+  EFI_EVENT                            KeyNotifyTimer;
+
+  // Last pressed key
+  // typedef struct {
+  //    UINT16  ScanCode;
+  //    CHAR16  UnicodeChar;
+  // } EFI_INPUT_KEY;
+  EFI_INPUT_KEY                        LastKey;
+
+  // Key modifiers
+  BOOLEAN                              ShiftActive;
+  BOOLEAN                              CtrlActive;
+  BOOLEAN                              AltActive;
+
+  // If key is ready
+  BOOLEAN                              KeyReady;
+} VIRTIO_KBD_DEV;
+
+// Helper functions to extract VIRTIO_KBD_DEV structure pointers
+#define VIRTIO_KEYBOARD_FROM_THIS(KbrPointer) \
+          CR (KbrPointer, VIRTIO_KBD_DEV, Txt, VIRTIO_KBD_SIG)
+#define VIRTIO_KEYBOARD_EX_FROM_THIS(KbrPointer) \
+          CR (KbrPointer, VIRTIO_KBD_DEV, TxtEx, VIRTIO_KBD_SIG)
+
+// Bellow candidates to be included as Linux header
+#define KEY_PRESSED  1
+
+// -----------------------------------------------------------------------------
+// EFI_SIMPLE_TEXT_INPUT_PROTOCOL API
+EFI_STATUS
+EFIAPI
+VirtioKeyboardSimpleTextInputReset (
+  IN EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL  *This,
+  IN BOOLEAN                            ExtendedVerification
+  );
+
+// -----------------------------------------------------------------------------
+// EFI_SIMPLE_TEXT_INPUT_PROTOCOL API
+EFI_STATUS
+EFIAPI
+VirtioKeyboardSimpleTextInputReadKeyStroke (
+  IN  EFI_SIMPLE_TEXT_INPUT_PROTOCOL  *This,
+  OUT EFI_INPUT_KEY                   *Key
+  );
+
+// -----------------------------------------------------------------------------
+// EFI_SIMPLE_TEXT_INPUT_PROTOCOL API
+VOID
+EFIAPI
+VirtioKeyboardWaitForKey (
+  IN  EFI_EVENT  Event,
+  IN  VOID       *Context
+  );
+
+// -----------------------------------------------------------------------------
+// EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL API
+EFI_STATUS
+EFIAPI
+VirtioKeyboardResetEx (
+  IN EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL  *This,
+  IN BOOLEAN                            ExtendedVerification
+  );
+
+// -----------------------------------------------------------------------------
+// EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL API
+EFI_STATUS
+EFIAPI
+VirtioKeyboardReadKeyStrokeEx (
+  IN  EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL  *This,
+  OUT EFI_KEY_DATA                       *KeyData
+  );
+
+// -----------------------------------------------------------------------------
+// EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL API
+VOID
+EFIAPI
+VirtioKeyboardWaitForKeyEx (
+  IN  EFI_EVENT  Event,
+  IN  VOID       *Context
+  );
+
+// -----------------------------------------------------------------------------
+// EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL API
+EFI_STATUS
+EFIAPI
+VirtioKeyboardSetState (
+  IN EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL  *This,
+  IN EFI_KEY_TOGGLE_STATE               *KeyToggleState
+  );
+
+// -----------------------------------------------------------------------------
+// EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL API
+EFI_STATUS
+EFIAPI
+VirtioKeyboardRegisterKeyNotify (
+  IN EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL  *This,
+  IN EFI_KEY_DATA                       *KeyData,
+  IN EFI_KEY_NOTIFY_FUNCTION            KeyNotificationFunction,
+  OUT VOID                              **NotifyHandle
+  );
+
+// -----------------------------------------------------------------------------
+// EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL API
+EFI_STATUS
+EFIAPI
+VirtioKeyboardUnregisterKeyNotify (
+  IN EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL  *This,
+  IN VOID                               *NotificationHandle
+  );
+
+#endif

--- a/OvmfPkg/VirtioKeyboardDxe/VirtioKeyboard.inf
+++ b/OvmfPkg/VirtioKeyboardDxe/VirtioKeyboard.inf
@@ -1,0 +1,40 @@
+## @file
+# This driver produces EFI_SIMPLE_TEXT_INPUT_PROTOCOL for virt ARM devices.
+#
+# Copyright (C) 2023, Red Hat
+#
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 1.29
+  BASE_NAME                      = VirtioKeyboardDxe
+  FILE_GUID                      = F141B1E5-9C7C-44CC-AFAA-E87D7689B113
+  MODULE_TYPE                    = UEFI_DRIVER
+  VERSION_STRING                 = 1.0
+  ENTRY_POINT                    = VirtioKeyboardEntryPoint
+
+[Sources]
+  VirtioKeyboard.c
+  VirtioKeyboard.h
+
+[Packages]
+  MdePkg/MdePkg.dec
+  OvmfPkg/OvmfPkg.dec
+
+[LibraryClasses]
+  BaseMemoryLib
+  DebugLib
+  MemoryAllocationLib
+  UefiBootServicesTableLib
+  UefiDriverEntryPoint
+  UefiLib
+  VirtioLib
+
+# Protocols used by this driver
+[Protocols]
+  #gEfiDriverBindingProtocolGuid
+  gEfiSimpleTextInProtocolGuid
+  gEfiSimpleTextInputExProtocolGuid
+  gVirtioDeviceProtocolGuid


### PR DESCRIPTION
# Description

This set of commits introduces virtio based keyboard driver. The main idea is to
have a keyboard driver which is more "light" than standard USB based driver.
This may be better for some small ARM based platforms with limited resources.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

I have tested this manually with RPi5 ARM platform and qemu. For test I have navigated
over efi shell, config and grub bootloader window running from Fedora ISO.

CODE=/home/koniu/RedHat/git/virt/edk2/Build/Ovmf3264/DEBUG_GCC5/FV/OVMF_CODE.fd
VARS=/home/koniu/RedHat/git/virt/edk2/Build/Ovmf3264/DEBUG_GCC5/FV/OVMF_VARS.fd

qemu-system-x86_64 \
    -blockdev node-name=code,driver=file,filename=${CODE},read-only=on \
    -drive if=none,id=vars,format=raw,file=${VARS},snapshot=on \
    -machine q35,kernel-irqchip=on,smm=on,pflash0=code,pflash1=vars \
    -accel kvm -m 4G -cpu host -smp cores=2,threads=1 \
    -chardev stdio,id=fwlog \
    -device isa-debugcon,iobase=0x402,chardev=fwlog \
    -net none \
    -device virtio-keyboard-pci \
    -boot d -cdrom ~/Pobrane/Fedora.iso


## Integration Instructions

N/A
