### PR TITLE
.gitmodules: Fix Path to berkeley-softfloat-3.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "CryptoPkg/Library/OpensslLib/openssl"]
 	path = CryptoPkg/Library/OpensslLib/openssl
 	url = https://github.com/openssl/openssl
-[submodule "SoftFloat"]
+[submodule "ArmPkg/Library/ArmSoftFloatLib/SoftFloat"]
 	path = ArmPkg/Library/ArmSoftFloatLib/berkeley-softfloat-3
 	url = https://github.com/ucb-bar/berkeley-softfloat-3.git
 [submodule "UnitTestFrameworkPkg/Library/CmockaLib/cmocka"]


### PR DESCRIPTION
# Description

While attempting to initialize arm package, the
berkeley-softfloat-3 submodule would not be initialized
under ArmPkg\Library.

The .gitmodules definition for softfloat was different, in that
it did not have the path to where the submodule needed to be
downloaded.

After correcting, the submodule was initialized correctly.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested
stuart_ci_setup -c .pytool/CISettings.py

Before the change, berkeley-softfloat-3 could not initialize.
After the change, the submodule was available.

## Integration Instructions
N/A