### PR TITLE
ArmPkg: CompilerIntrinsicLib enhancements

### DIFF
--- a/ArmPkg/Library/CompilerIntrinsicsLib/CompilerIntrinsicsLib.inf
+++ b/ArmPkg/Library/CompilerIntrinsicsLib/CompilerIntrinsicsLib.inf
@@ -16,6 +16,7 @@
   MODULE_TYPE                    = BASE
   VERSION_STRING                 = 1.0
   LIBRARY_CLASS                  = CompilerIntrinsicsLib
+  LIBRARY_CLASS                  = IntrinsicLib
 
 [Sources]
   memcpy.c             | GCC

--- a/ArmPkg/Library/CompilerIntrinsicsLib/CompilerIntrinsicsLib.inf
+++ b/ArmPkg/Library/CompilerIntrinsicsLib/CompilerIntrinsicsLib.inf
@@ -19,6 +19,7 @@
   LIBRARY_CLASS                  = IntrinsicLib
 
 [Sources]
+  strcmp.c
   memcpy.c             | GCC
   memset.c             | GCC
 

--- a/ArmPkg/Library/CompilerIntrinsicsLib/strcmp.c
+++ b/ArmPkg/Library/CompilerIntrinsicsLib/strcmp.c
@@ -1,0 +1,32 @@
+// ------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+// ------------------------------------------------------------------------------
+
+int
+strcmp (
+  const char  *,
+  const char  *
+  );
+
+#if defined (_MSC_VER)
+  #pragma intrinsic(strcmp)
+  #pragma function(strcmp)
+#endif
+
+int
+strcmp (
+  const char  *s1,
+  const char  *s2
+  )
+{
+  while ((*s1 != '\0') && (*s1 == *s2)) {
+    s1++;
+    s2++;
+  }
+
+  return *s1 - *s2;
+}


### PR DESCRIPTION
# Description

Two commits to update `CompilerIntrinsicsLib` to be useful in additional scenarios.

---

**ArmPkg/CompilerIntrinsicsLib: Support the IntrinsicLib library class**

There are currently two common intrinsic libraries used in edk2:

1. CryptoPkg/Library/IntrinsicLib/IntrinsicLib.inf
   - Contains a memcpy intrinsic for IA32 and X64
   - Contains shifting, multiplication, and 64-bit math intrinsics for IA32
   - Contains a memset, memcmp, and strcmp intrinsic for all architectures
   - `LIBRARY_CLASS = IntrinsicLib`

2. ArmPkg/Library/CompilerIntrinsicsLib/CompilerIntrinsicsLib.inf
   - Contains many intrinsics for GCC ARM
   - Contains a few math related intrinsics for MSFT ARM
   - Only provides a few atomic intrinsics for GCC AARCH64
   - Provides memcpy and memset for GCC and MSFT (all archs)
   - Additionally provides memcmp and memmove for MSFT (all archs)
   - `LIBRARY_CLASS = CompilerIntrinsicsLib`

Neither of these library classes have a defined interface but can be
linked against a module which declares the class as a dependency.

In situations where the `CompilerIntrinsicsLib` library instance
provides the intrinsics suitable for a given module, this change adds
the `IntrinsicLib` library class to the INF to allow the library
instance to be specified for that intrinsic dependency.

---

**ArmPkg/CompilerIntrinsicsLib: Add strcmp**

Adds a `strcmp` implementation to the library. THe library instance
provides most of the basic intrinsics needed except string
comparison.

---

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

- Linked `CompilerIntrinsicsLib` to modules with an `IntrinsicLib` dependency
- Verified the `strcmp` function on MSVC and GCC builds

## Integration Instructions

- Evaluate if the new functionality is useful for your platform