### PR TITLE
OvmfPkg/QemuFwCfgS3Lib: Disable S3 detection in TDVF

### DIFF
--- a/MdePkg/Include/Library/BaseLib.h
+++ b/MdePkg/Include/Library/BaseLib.h
@@ -5259,8 +5259,6 @@ SpeculationBarrier (
   VOID
   );
 
-#if defined (MDE_CPU_X64) || defined (MDE_CPU_IA32)
-
 /**
   The TDCALL instruction causes a VM exit to the Intel TDX module.  It is
   used to call guest-side Intel TDX functions, either local or a TD exit
@@ -5322,8 +5320,6 @@ EFIAPI
 TdIsEnabled (
   VOID
   );
-
-#endif
 
 #if defined (MDE_CPU_X64)
 //

--- a/MdePkg/Library/BaseLib/BaseLib.inf
+++ b/MdePkg/Library/BaseLib/BaseLib.inf
@@ -339,6 +339,7 @@
   Ebc/SpeculationBarrier.c
   Unaligned.c
   Math64.c
+  IntelTdxNull.c
 
 [Sources.ARM]
   Arm/InternalSwitchStack.c
@@ -364,6 +365,7 @@
   Arm/CpuBreakpoint.S           | GCC
   Arm/MemoryFence.S             | GCC
   Arm/SpeculationBarrier.S      | GCC
+  IntelTdxNull.c
 
 [Sources.AARCH64]
   Arm/InternalSwitchStack.c
@@ -391,6 +393,7 @@
   AArch64/SpeculationBarrier.asm    | MSFT
   AArch64/ArmReadCntPctReg.asm      | MSFT
   AArch64/ArmReadIdAA64Isar0Reg.asm     | MSFT
+  IntelTdxNull.c
 
 [Sources.RISCV64]
   Math64.c
@@ -412,6 +415,7 @@
   RiscV64/ReadTimer.S               | GCC
   RiscV64/RiscVMmu.S                | GCC
   RiscV64/SpeculationBarrier.S      | GCC
+  IntelTdxNull.c
 
 [Sources.LOONGARCH64]
   Math64.c
@@ -432,6 +436,7 @@
   LoongArch64/ExceptionBase.S       | GCC
   LoongArch64/Cpucfg.S              | GCC
   LoongArch64/ReadStableCounter.S   | GCC
+  IntelTdxNull.c
 
 [Packages]
   MdePkg/MdePkg.dec

--- a/OvmfPkg/Library/QemuFwCfgS3Lib/QemuFwCfgS3PeiDxe.c
+++ b/OvmfPkg/Library/QemuFwCfgS3Lib/QemuFwCfgS3PeiDxe.c
@@ -7,6 +7,7 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
+#include <Library/BaseLib.h>
 #include <Library/QemuFwCfgLib.h>
 #include <Library/QemuFwCfgS3Lib.h>
 
@@ -31,6 +32,10 @@ QemuFwCfgS3Enabled (
   FIRMWARE_CONFIG_ITEM  FwCfgItem;
   UINTN                 FwCfgSize;
   UINT8                 SystemStates[6];
+
+  if (TdIsEnabled ()) {
+    return FALSE;
+  }
 
   Status = QemuFwCfgFindFile ("etc/system-states", &FwCfgItem, &FwCfgSize);
   if ((Status != RETURN_SUCCESS) || (FwCfgSize != sizeof SystemStates)) {


### PR DESCRIPTION
Refer to the section 2.1 of tdx-virtual-firmware-design-guide spec, APCI S3 is not supported in TDVF.

Therefore, TDVF should not read the S3 status via fw_cfg and always set it as unsupported.

spec: https://cdrdv2.intel.com/v1/dl/getContent/733585

Cc: Erdem Aktas <erdemaktas@google.com>
Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Min Xu <min.m.xu@intel.com>
Cc: Gerd Hoffmann <kraxel@redhat.com>
Cc: Elena Reshetova <elena.reshetova@intel.com>
Signed-off-by: Ceping Sun <cepingx.sun@intel.com>
# Description

<_Include a description of the change and why this change was made._>

<_For each item, place an "x" in between `[` and `]` if true. Example: `[x]` (you can also check items in GitHub UI)_>

<_Create the PR as a Draft PR if it is only created to run CI checks._>

<_Delete lines in \<\> tags before creating the PR._>

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

<_Describe the test(s) that were run to verify the changes._>

## Integration Instructions

<_Describe how these changes should be integrated. Use N/A if nothing is required._>
