### PR TITLE
MdePkg: Added definition of AMD specific public MSRs

### DIFF
--- a/MdePkg/Include/Register/Amd/ArchitecturalMsr.h
+++ b/MdePkg/Include/Register/Amd/ArchitecturalMsr.h
@@ -1,0 +1,55 @@
+/** @file ArchitecturalMsr.h
+  AMD Architectural MSR Definitions.
+
+  Provides defines for Machine Specific Registers(MSR) indexes.
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+  @par Specification Reference:
+  AMD64 Architecture Programmer’s Manual, Volumes 2
+  Rev. 3.37, Volume 2: System Programming
+
+**/
+
+#ifndef AMD_ARCHITECTURAL_MSR_H_
+#define AMD_ARCHITECTURAL_MSR_H_
+
+/*
+  See Appendix A.8, "System Management Mode MSR Cross-Reference".
+
+  SMBASE MSR that contains the SMRAM base address.
+  Reset value: 0000_0000_0003_0000h
+
+*/
+#define AMD_64_SMM_BASE  0xC0010111
+
+/*
+  See Appendix A.8, "System Management Mode MSR Cross-Reference".
+
+  SMM_ADDR Contains the base address of protected
+  memory for the SMM Handler.
+
+  Specific usage, see AMD64 Architecture Programmer’s Manual,
+  Volumes 2 (Rev. 3.37), Section 10.2.5
+
+  Reset value: 0000_0000_0000_0000h
+
+*/
+#define AMD_64_SMM_ADDR  0xC0010112
+
+/*
+  See Appendix A.8, "System Management Mode MSR Cross-Reference".
+
+  SMM_MASK Contains a mask which determines the size of
+  the protected area for the SMM handler.
+
+  Specific usage, see AMD64 Architecture Programmer’s Manual,
+  Volumes 2 (Rev. 3.37), Section 10.2.5
+
+  Reset value: 0000_0000_0000_0000h
+
+*/
+#define AMD_64_SMM_MASK  0xC0010113
+
+#endif // AMD_ARCHITECTURAL_MSR_H_

--- a/MdePkg/Include/Register/Amd/Msr.h
+++ b/MdePkg/Include/Register/Amd/Msr.h
@@ -18,6 +18,7 @@
 #define AMD_MSR_H_
 
 #include <Register/Intel/ArchitecturalMsr.h>
+#include <Register/Amd/ArchitecturalMsr.h>
 #include <Register/Amd/SevSnpMsr.h>
 #include <Register/Amd/SvsmMsr.h>
 

--- a/UefiCpuPkg/Library/MmSaveStateLib/AmdMmSaveState.c
+++ b/UefiCpuPkg/Library/MmSaveStateLib/AmdMmSaveState.c
@@ -10,10 +10,8 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include "MmSaveState.h"
 #include <Register/Amd/SmramSaveStateMap.h>
 #include <Library/BaseLib.h>
+#include <Register/Amd/Msr.h>
 
-// EFER register LMA bit
-#define LMA                                        BIT10
-#define EFER_ADDRESS                               0xC0000080ul
 #define AMD_MM_SAVE_STATE_REGISTER_SMMREVID_INDEX  1
 #define AMD_MM_SAVE_STATE_REGISTER_MAX_INDEX       2
 
@@ -280,6 +278,16 @@ MmSaveStateGetRegisterLma (
   VOID
   )
 {
+  UINT32  LMAValue;
+
+  MSR_IA32_EFER_REGISTER  Msr;
+
+  Msr.Uint64 = AsmReadMsr64 (MSR_IA32_EFER);
+  LMAValue   = Msr.Bits.LMA;
+  if (LMAValue) {
+    return EFI_MM_SAVE_STATE_REGISTER_LMA_64BIT;
+  }
+
   //
   // AMD64 processors support EFI_SMM_SAVE_STATE_REGISTER_LMA_64BIT only
   //

--- a/UefiCpuPkg/Library/SmmCpuFeaturesLib/AmdSmmCpuFeaturesLib.c
+++ b/UefiCpuPkg/Library/SmmCpuFeaturesLib/AmdSmmCpuFeaturesLib.c
@@ -17,14 +17,10 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/DebugLib.h>
 #include <Library/MmSaveStateLib.h>
 #include <Library/HobLib.h>
+#include <Register/Amd/Msr.h>
 
 // EFER register LMA bit
 #define LMA  BIT10
-
-// Machine Specific Registers (MSRs)
-#define SMMADDR_ADDRESS  0xC0010112ul
-#define SMMMASK_ADDRESS  0xC0010113ul
-#define EFER_ADDRESS     0XC0000080ul
 
 // The mode of the CPU at the time an SMI occurs
 STATIC UINT8  mSmmSaveStateRegisterLma;
@@ -105,6 +101,10 @@ SmmCpuFeaturesInitializeProcessor (
     CpuState->x64.SMBASE = (UINT32)CpuHotPlugData->SmBase[CpuIndex];
   }
 
+  // Re-initialize the value of mSmmSaveStateRegisterLma flag which might have been changed in PiCpuSmmDxeSmm Driver
+  // Entry point, to make sure correct value on AMD platform is assigned to be used by SmmCpuFeaturesLib.
+  mSmmSaveStateRegisterLma = EFI_SMM_SAVE_STATE_REGISTER_LMA_64BIT;
+
   //
   // If SMRR is supported, then program SMRR base/mask MSRs.
   // The EFI_MSR_SMRR_PHYS_MASK_VALID bit is not set until the first normal SMI.
@@ -130,8 +130,8 @@ SmmCpuFeaturesInitializeProcessor (
         CpuDeadLoop ();
       }
     } else {
-      AsmWriteMsr64 (SMMADDR_ADDRESS, CpuHotPlugData->SmrrBase);
-      AsmWriteMsr64 (SMMMASK_ADDRESS, ((~(UINT64)(CpuHotPlugData->SmrrSize - 1)) | 0x6600));
+      AsmWriteMsr64 (AMD_64_SMM_ADDR, CpuHotPlugData->SmrrBase);
+      AsmWriteMsr64 (AMD_64_SMM_MASK, ((~(UINT64)(CpuHotPlugData->SmrrSize - 1)) | 0x6600));
     }
   }
 }

--- a/UefiCpuPkg/Library/SmmRelocationLib/AmdSmramSaveStateConfig.c
+++ b/UefiCpuPkg/Library/SmmRelocationLib/AmdSmramSaveStateConfig.c
@@ -9,8 +9,6 @@
 #include "InternalSmmRelocationLib.h"
 #include <Register/Amd/SmramSaveStateMap.h>
 
-#define EFER_ADDRESS  0XC0000080ul
-
 /**
   Get the mode of the CPU at the time an SMI occurs
 
@@ -23,13 +21,14 @@ GetMmSaveStateRegisterLma (
   VOID
   )
 {
-  UINT8   SmmSaveStateRegisterLma;
-  UINT32  LMAValue;
+  UINT8                   SmmSaveStateRegisterLma;
+  MSR_IA32_EFER_REGISTER  Msr;
+
+  Msr.Uint64 = AsmReadMsr64 (MSR_IA32_EFER);
 
   SmmSaveStateRegisterLma = (UINT8)EFI_MM_SAVE_STATE_REGISTER_LMA_32BIT;
 
-  LMAValue = (UINT32)AsmReadMsr64 (EFER_ADDRESS) & LMA;
-  if (LMAValue) {
+  if (Msr.Bits.LMA) {
     SmmSaveStateRegisterLma = (UINT8)EFI_MM_SAVE_STATE_REGISTER_LMA_64BIT;
   }
 
@@ -91,12 +90,14 @@ HookReturnFromSmm (
 {
   UINT64                    OriginalInstructionPointer;
   AMD_SMRAM_SAVE_STATE_MAP  *AmdCpuState;
+  MSR_IA32_EFER_REGISTER    Msr;
 
   AmdCpuState = (AMD_SMRAM_SAVE_STATE_MAP *)CpuState;
 
   OriginalInstructionPointer = AmdCpuState->x64._RIP;
+  Msr.Uint64                 = AmdCpuState->x64.EFER;
 
-  if ((AmdCpuState->x64.EFER & LMA) == 0) {
+  if (!Msr.Bits.LMA) {
     AmdCpuState->x64._RIP = NewInstructionPointer32;
   } else {
     AmdCpuState->x64._RIP = NewInstructionPointer;

--- a/UefiCpuPkg/Library/SmmRelocationLib/InternalSmmRelocationLib.h
+++ b/UefiCpuPkg/Library/SmmRelocationLib/InternalSmmRelocationLib.h
@@ -29,6 +29,7 @@
 #include <Guid/SmramMemoryReserve.h>
 #include <Guid/SmmBaseHob.h>
 #include <Register/Intel/Cpuid.h>
+#include <Register/Intel/Msr.h>
 #include <Register/Intel/SmramSaveStateMap.h>
 #include <Protocol/MmCpu.h>
 
@@ -50,11 +51,6 @@ X86_ASSEMBLY_PATCH_LABEL  gPatchSmmInitStack;
 #define BACK_BUF_SIZE  0x20
 
 #define CR4_CET_ENABLE  BIT23
-
-//
-// EFER register LMA bit
-//
-#define LMA  BIT10
 
 /**
   This function configures the SmBase on the currently executing CPU.

--- a/UefiCpuPkg/Library/SmmRelocationLib/SmramSaveStateConfig.c
+++ b/UefiCpuPkg/Library/SmmRelocationLib/SmramSaveStateConfig.c
@@ -102,7 +102,8 @@ HookReturnFromSmm (
   IN     UINT64                NewInstructionPointer
   )
 {
-  UINT64  OriginalInstructionPointer;
+  UINT64                  OriginalInstructionPointer;
+  MSR_IA32_EFER_REGISTER  Msr;
 
   if (GetMmSaveStateRegisterLma () == EFI_MM_SAVE_STATE_REGISTER_LMA_32BIT) {
     OriginalInstructionPointer = (UINT64)CpuState->x86._EIP;
@@ -117,7 +118,8 @@ HookReturnFromSmm (
     }
   } else {
     OriginalInstructionPointer = CpuState->x64._RIP;
-    if ((CpuState->x64.IA32_EFER & LMA) == 0) {
+    Msr.Uint64                 = CpuState->x64.IA32_EFER;
+    if (!Msr.Bits.LMA) {
       CpuState->x64._RIP = (UINT32)NewInstructionPointer32;
     } else {
       CpuState->x64._RIP = (UINT32)NewInstructionPointer;

--- a/UefiCpuPkg/PiSmmCpuDxeSmm/SmmProfile.c
+++ b/UefiCpuPkg/PiSmmCpuDxeSmm/SmmProfile.c
@@ -131,7 +131,13 @@ DisableBTS (
   VOID
   )
 {
-  AsmMsrAnd64 (MSR_DEBUG_CTL, ~((UINT64)(MSR_DEBUG_CTL_BTS | MSR_DEBUG_CTL_TR)));
+  MSR_IA32_DEBUGCTL_REGISTER  DebugCtl;
+
+  DebugCtl.Uint64   = AsmReadMsr64 (MSR_IA32_DEBUGCTL);
+  DebugCtl.Bits.BTS = 0;
+  DebugCtl.Bits.TR  = 0;
+
+  AsmWriteMsr64 (MSR_IA32_DEBUGCTL, DebugCtl.Uint64);
 }
 
 /**
@@ -143,7 +149,13 @@ EnableBTS (
   VOID
   )
 {
-  AsmMsrOr64 (MSR_DEBUG_CTL, (MSR_DEBUG_CTL_BTS | MSR_DEBUG_CTL_TR));
+  MSR_IA32_DEBUGCTL_REGISTER  DebugCtl;
+
+  DebugCtl.Uint64   = AsmReadMsr64 (MSR_IA32_DEBUGCTL);
+  DebugCtl.Bits.BTS = 1;
+  DebugCtl.Bits.TR  = 1;
+
+  AsmWriteMsr64 (MSR_IA32_DEBUGCTL, DebugCtl.Uint64);
 }
 
 /**
@@ -930,15 +942,15 @@ ActivateLBR (
   VOID
   )
 {
-  UINT64  DebugCtl;
+  MSR_IA32_DEBUGCTL_REGISTER  DebugCtl;
 
-  DebugCtl = AsmReadMsr64 (MSR_DEBUG_CTL);
-  if ((DebugCtl & MSR_DEBUG_CTL_LBR) != 0) {
+  DebugCtl.Uint64 = AsmReadMsr64 (MSR_IA32_DEBUGCTL);
+  if (DebugCtl.Bits.LBR) {
     return;
   }
 
-  DebugCtl |= MSR_DEBUG_CTL_LBR;
-  AsmWriteMsr64 (MSR_DEBUG_CTL, DebugCtl);
+  DebugCtl.Bits.LBR = 1;
+  AsmWriteMsr64 (MSR_IA32_DEBUGCTL, DebugCtl.Uint64);
 }
 
 /**
@@ -952,17 +964,23 @@ ActivateBTS (
   IN      UINTN  CpuIndex
   )
 {
-  UINT64  DebugCtl;
+  MSR_IA32_DEBUGCTL_REGISTER  DebugCtl;
 
-  DebugCtl = AsmReadMsr64 (MSR_DEBUG_CTL);
-  if ((DebugCtl & MSR_DEBUG_CTL_BTS) != 0) {
+  DebugCtl.Uint64 = AsmReadMsr64 (MSR_IA32_DEBUGCTL);
+  if ((DebugCtl.Bits.BTS)) {
     return;
   }
 
   AsmWriteMsr64 (MSR_DS_AREA, (UINT64)(UINTN)mMsrDsArea[CpuIndex]);
-  DebugCtl |= (UINT64)(MSR_DEBUG_CTL_BTS | MSR_DEBUG_CTL_TR);
-  DebugCtl &= ~((UINT64)MSR_DEBUG_CTL_BTINT);
-  AsmWriteMsr64 (MSR_DEBUG_CTL, DebugCtl);
+
+  //
+  // Enable BTS
+  //
+  DebugCtl.Bits.BTS = 1;
+  DebugCtl.Bits.TR  = 1;
+
+  DebugCtl.Bits.BTINT = 0;
+  AsmWriteMsr64 (MSR_IA32_DEBUGCTL, DebugCtl.Uint64);
 }
 
 /**

--- a/UefiCpuPkg/PiSmmCpuDxeSmm/SmmProfileInternal.h
+++ b/UefiCpuPkg/PiSmmCpuDxeSmm/SmmProfileInternal.h
@@ -39,20 +39,13 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 //
 // CPU generic definition
 //
-#define   MSR_EFER     0xc0000080
-#define   MSR_EFER_XD  0x800
+#define MSR_EFER_XD  0x800
 
-#define   CPUID1_EDX_BTS_AVAILABLE  0x200000
+#define CPUID1_EDX_BTS_AVAILABLE  0x200000
 
-#define   DR6_SINGLE_STEP  0x4000
-#define   RFLAG_TF         0x100
+#define DR6_SINGLE_STEP  0x4000
 
-#define MSR_DEBUG_CTL          0x1D9
-#define   MSR_DEBUG_CTL_LBR    0x1
-#define   MSR_DEBUG_CTL_TR     0x40
-#define   MSR_DEBUG_CTL_BTS    0x80
-#define   MSR_DEBUG_CTL_BTINT  0x100
-#define MSR_DS_AREA            0x600
+#define MSR_DS_AREA  0x600
 
 #define HEAP_GUARD_NONSTOP_MODE      \
         ((PcdGet8 (PcdHeapGuardPropertyMask) & (BIT6|BIT3|BIT2)) > BIT6)


### PR DESCRIPTION
# Description

Added definition of AMD specific public MSRs:
1. SMBASE
2. SMM_ADDR
3. SMM_MASK

Replaced local Msr defines where applicable by including `Register/Amd/Msr.h`

---
Cherry-picked first commit from:
https://github.com/microsoft/mu_basecore/commit/2e2958c6d448fe8a31c71528ff954279c2bfeaf1

---

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

Tested in Project MU

## Integration Instructions

N/A

