### PR TITLE
MdeModulePkg: Add alternative queue sizes in NVME driver

### DIFF
--- a/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpress.c
+++ b/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpress.c
@@ -582,6 +582,8 @@ ProcessAsyncTaskList (
   EFI_BLOCK_IO2_TOKEN           *Token;
   BOOLEAN                       HasNewItem;
   EFI_STATUS                    Status;
+  UINT16  QueueSize = PcdGetBool (PcdSupportAlternativeQueueSize) ?
+                      NVME_ALTERNATIVE_MAX_QUEUE_SIZE : NVME_ASYNC_CCQ_SIZE;
 
   Private    = (NVME_CONTROLLER_PRIVATE_DATA *)Context;
   QueueId    = 2;
@@ -724,7 +726,7 @@ ProcessAsyncTaskList (
     }
 
     Private->CqHdbl[QueueId].Cqh++;
-    if (Private->CqHdbl[QueueId].Cqh > MIN (NVME_ASYNC_CCQ_SIZE, Private->Cap.Mqes)) {
+    if (Private->CqHdbl[QueueId].Cqh > MIN (QueueSize, Private->Cap.Mqes)) {
       Private->CqHdbl[QueueId].Cqh = 0;
       Private->Pt[QueueId]        ^= 1;
     }
@@ -957,6 +959,8 @@ NvmExpressDriverBindingStart (
   EFI_PHYSICAL_ADDRESS                MappedAddr;
   UINTN                               Bytes;
   EFI_NVM_EXPRESS_PASS_THRU_PROTOCOL  *Passthru;
+  UINTN  QueuePageCount = PcdGetBool (PcdSupportAlternativeQueueSize) ?
+                          NVME_ALTERNATIVE_TOTAL_QUEUE_BUFFER_IN_PAGES : 6;
 
   DEBUG ((DEBUG_INFO, "NvmExpressDriverBindingStart: start\n"));
 
@@ -1029,6 +1033,10 @@ NvmExpressDriverBindingStart (
     }
 
     //
+    // Depending on PCD disablement, either support the default or alternative
+    // queue sizes.
+    //
+    // Default:
     // 6 x 4kB aligned buffers will be carved out of this buffer.
     // 1st 4kB boundary is the start of the admin submission queue.
     // 2nd 4kB boundary is the start of the admin completion queue.
@@ -1039,11 +1047,22 @@ NvmExpressDriverBindingStart (
     //
     // Allocate 6 pages of memory, then map it for bus master read and write.
     //
+    // Alternative:
+    // 15 x 4kB aligned buffers will be carved out of this buffer.
+    // 1st 4kB boundary is the start of the admin submission queue.
+    // 5th 4kB boundary is the start of the admin completion queue.
+    // 6th 4kB boundary is the start of I/O submission queue #1.
+    // 10th 4kB boundary is the start of I/O completion queue #1.
+    // 11th 4kB boundary is the start of I/O submission queue #2.
+    // 15th 4kB boundary is the start of I/O completion queue #2.
+    //
+    // Allocate 15 pages of memory, then map it for bus master read and write.
+    //
     Status = PciIo->AllocateBuffer (
                       PciIo,
                       AllocateAnyPages,
                       EfiBootServicesData,
-                      6,
+                      QueuePageCount,
                       (VOID **)&Private->Buffer,
                       0
                       );
@@ -1051,7 +1070,7 @@ NvmExpressDriverBindingStart (
       goto Exit;
     }
 
-    Bytes  = EFI_PAGES_TO_SIZE (6);
+    Bytes  = EFI_PAGES_TO_SIZE (QueuePageCount);
     Status = PciIo->Map (
                       PciIo,
                       EfiPciIoOperationBusMasterCommonBuffer,
@@ -1061,7 +1080,7 @@ NvmExpressDriverBindingStart (
                       &Private->Mapping
                       );
 
-    if (EFI_ERROR (Status) || (Bytes != EFI_PAGES_TO_SIZE (6))) {
+    if (EFI_ERROR (Status) || (Bytes != EFI_PAGES_TO_SIZE (QueuePageCount))) {
       goto Exit;
     }
 
@@ -1171,7 +1190,7 @@ Exit:
   }
 
   if ((Private != NULL) && (Private->Buffer != NULL)) {
-    PciIo->FreeBuffer (PciIo, 6, Private->Buffer);
+    PciIo->FreeBuffer (PciIo, QueuePageCount, Private->Buffer);
   }
 
   if ((Private != NULL) && (Private->ControllerData != NULL)) {
@@ -1247,6 +1266,8 @@ NvmExpressDriverBindingStop (
   EFI_NVM_EXPRESS_PASS_THRU_PROTOCOL  *PassThru;
   BOOLEAN                             IsEmpty;
   EFI_TPL                             OldTpl;
+  UINT16  QueuePageCount = PcdGetBool (PcdSupportAlternativeQueueSize) ?
+                           NVME_ALTERNATIVE_TOTAL_QUEUE_BUFFER_IN_PAGES : 6;
 
   if (NumberOfChildren == 0) {
     Status = gBS->OpenProtocol (
@@ -1293,7 +1314,7 @@ NvmExpressDriverBindingStop (
       }
 
       if (Private->Buffer != NULL) {
-        Private->PciIo->FreeBuffer (Private->PciIo, 6, Private->Buffer);
+        Private->PciIo->FreeBuffer (Private->PciIo, QueuePageCount, Private->Buffer);
       }
 
       FreePool (Private->ControllerData);

--- a/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpress.h
+++ b/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpress.h
@@ -81,6 +81,17 @@ extern EFI_DRIVER_SUPPORTED_EFI_VERSION_PROTOCOL  gNvmExpressDriverSupportedEfiV
 #define NVME_MAX_QUEUES  3                              // Number of queues supported by the driver
 
 //
+// NVMe DXE to accommodate hardware which requires queue size 255.
+// Driver supports queue size up to 255 (4 page SQ buffer).
+// DXE driver creates queue size MIN(Cap.Mqes, NVME_MAX_QUEUE_SIZE) for all queues.
+// Driver allocates queue buffer to support 255 max queue size.
+// Each submission queue buffer is allocated as 64B * 256 = 4 * 4kB = 4 pages.
+// Each completion queue buffer is allocated as 16B * 256 = 4kB = 1 page.
+//
+#define NVME_ALTERNATIVE_MAX_QUEUE_SIZE               255
+#define NVME_ALTERNATIVE_TOTAL_QUEUE_BUFFER_IN_PAGES  NVME_MAX_QUEUES * 5
+
+//
 // FormatNVM Admin Command LBA Format (LBAF) Mask
 //
 #define NVME_LBA_FORMATNVM_LBAF_MASK  0xF

--- a/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressDxe.inf
+++ b/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressDxe.inf
@@ -77,6 +77,9 @@
   gMediaSanitizeProtocolGuid                  ## PRODUCES
   gEfiResetNotificationProtocolGuid           ## CONSUMES
 
+[Pcd]
+  gEfiMdeModulePkgTokenSpaceGuid.PcdSupportAlternativeQueueSize ## CONSUMES
+
 # [Event]
 # EVENT_TYPE_RELATIVE_TIMER ## SOMETIMES_CONSUMES
 #

--- a/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressHci.c
+++ b/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressHci.c
@@ -30,8 +30,8 @@ UINTN  mNvmeControllerNumber = 0;
 **/
 EFI_STATUS
 ReadNvmeControllerCapabilities (
-  IN NVME_CONTROLLER_PRIVATE_DATA  *Private,
-  IN NVME_CAP                      *Cap
+  IN  NVME_CONTROLLER_PRIVATE_DATA  *Private,
+  OUT NVME_CAP                      *Cap
   )
 {
   EFI_PCI_IO_PROTOCOL  *PciIo;

--- a/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressHci.c
+++ b/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressHci.c
@@ -730,13 +730,34 @@ NvmeControllerInit (
   NVME_AQA             Aqa;
   NVME_ASQ             Asq;
   NVME_ACQ             Acq;
+  UINT16               VidDid[2];
   UINT8                Sn[21];
   UINT8                Mn[41];
+
+  PciIo = Private->PciIo;
+
+  //
+  // Verify the controller is still accessible
+  //
+  Status = PciIo->Pci.Read (
+                        PciIo,
+                        EfiPciIoWidthUint16,
+                        PCI_VENDOR_ID_OFFSET,
+                        ARRAY_SIZE (VidDid),
+                        VidDid
+                        );
+  if (EFI_ERROR (Status)) {
+    ASSERT_EFI_ERROR (Status);
+    return EFI_DEVICE_ERROR;
+  }
+
+  if ((VidDid[0] == 0xFFFF) || (VidDid[1] == 0xFFFF)) {
+    return EFI_DEVICE_ERROR;
+  }
 
   //
   // Enable this controller.
   //
-  PciIo  = Private->PciIo;
   Status = PciIo->Attributes (
                     PciIo,
                     EfiPciIoAttributeOperationSupported,
@@ -774,8 +795,13 @@ NvmeControllerInit (
 
   //
   // Currently the driver only supports 4k page size.
+  // Currently, this means Cap.Mpsmin must be zero for an EFI_PAGE_SHIFT size of 12.
   //
   ASSERT ((Private->Cap.Mpsmin + 12) <= EFI_PAGE_SHIFT);
+  if ((Private->Cap.Mpsmin + 12) > EFI_PAGE_SHIFT) {
+    DEBUG ((DEBUG_ERROR, "NvmeControllerInit: Mpsmin is larger than expected (0x%02x).\n", Private->Cap.Mpsmin));
+    return EFI_DEVICE_ERROR;
+  }
 
   Private->Cid[0]        = 0;
   Private->Cid[1]        = 0;

--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -1198,6 +1198,10 @@
   # @Prompt Defines the page allocation for the MM communication buffer; default is 128 pages (512KB).
   gEfiMdeModulePkgTokenSpaceGuid.PcdMmCommBufferPages|128|UINT32|0x30001061
 
+  ## Support for the alternative queue size.
+  # @Prompt TRUE to enable support for alternative queue size in NVME driver.
+  gEfiMdeModulePkgTokenSpaceGuid.PcdSupportAlternativeQueueSize|FALSE|BOOLEAN|0x40000151
+
 [PcdsFixedAtBuild, PcdsPatchableInModule]
   ## Dynamic type PCD can be registered callback function for Pcd setting action.
   #  PcdMaxPeiPcdCallBackNumberPerPcdEntry indicates the maximum number of callback function


### PR DESCRIPTION
# Description

Add a new PCD that toggles between the old driver behavior and new behavior that uses a different hardcoded queue size to support specific devices.  Default behavior should not change.

MdeModulePkg/NvmExpressDxe: Improve NVMe controller init robustness

It has been observed that some faulty NVMe devices may return invalid values. The code in NvmExpressDxe recognizes the controller is not responding correctly and issues an ASSERT() often in DEBUG builds or a reset in RELEASE builds.

The following changes are made to NvmeControllerInit() to prevent a faulty NVMe device from halting the overall boot:

1. Check the Vendor ID and Device ID to verify they are read properly and if not, return EFI_DEVICE_ERROR
2. After the ASSERT() when Memory Page Size Minimum (Cap.Mpsmin),
   produce an error message and return EFI_DEVICE_ERROR

MdeModulePkg/NvmExpressDxe: Correct function parameter modifer

Updates the `Cap` parameter for `ReadNvmeControllerCapabilities()` to be `OUT` since the buffer pointed to is written within the function.

---
Cherry-picked the following commits:
https://github.com/microsoft/mu_basecore/commit/9837db39da115a1fa4a322d13adafbba862212d8
https://github.com/microsoft/mu_basecore/commit/0a5a1d950449f1133a6a648efe849e4be5cbb287
https://github.com/microsoft/mu_basecore/commit/e397168aec57fa86c3683d97022111d76daf9fd6

---

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

Tested in Project MU

## Integration Instructions

N/A

