### PR TITLE
Improve Debugging and Logging

### DIFF
--- a/MdePkg/Include/Library/DebugLib.h
+++ b/MdePkg/Include/Library/DebugLib.h
@@ -629,4 +629,81 @@ UnitTestDebugAssert (
     BASE_CR (Record, TYPE, Field)
 #endif
 
+/**
+  Log a formatted hexdump as the debug message on the specified debug
+  error level.
+  The hexdump is split into lines of 16 dumped bytes. Each line is
+  prefixed with a caller-provided string and offset. The full hexdump
+  is bracketed, and its byte ascii char also print. If the byte value
+  is not the ascii code, it will print as '.'
+  @param[in] ErrorLevel        The error level of the debug message.
+  @param[in] Offset            Offset to be display after PrefixFormat.
+                               Offset will be increased for each print line.
+  @param[in] Data              The data to dump.
+  @param[in] DataSize          Number of bytes in Data.
+  @param[in] LinePrefixFormat  Format string describing the prefix that is
+                               printed at the beginning of each dump line,
+                               including the bracket lines.
+  @param[in] ...               Arguments for LinePrefixFormat.
+**/
+#if !defined (MDEPKG_NDEBUG)
+#define DUMP_HEX(ErrorLevel,                                                      \
+                 Offset,                                                          \
+                 Data,                                                            \
+                 DataSize,                                                        \
+                 LinePrefixFormat,                                                \
+                 ...)                                                             \
+    do {                                                                            \
+      if (DebugPrintEnabled () && DebugPrintLevelEnabled (ErrorLevel))  {           \
+        UINT8 *_DataToDump;                                                         \
+        UINT8 _Val[50];                                                             \
+        UINT8 _Str[20];                                                             \
+        UINT8 _TempByte;                                                            \
+        UINTN _Size;                                                                \
+        UINTN _DumpHexIndex;                                                        \
+        UINTN _LocalOffset;                                                         \
+        UINTN _LocalDataSize;                                                       \
+        CONST CHAR8 *_Hex = "0123456789ABCDEF";                                     \
+        _LocalOffset = (Offset);                                                    \
+        _LocalDataSize = (DataSize);                                                \
+        _DataToDump = (UINT8 *)(Data);                                              \
+                                                                                    \
+        ASSERT (_DataToDump != NULL);                                               \
+                                                                                    \
+        while (_LocalDataSize != 0) {                                               \
+          _Size = 16;                                                               \
+          if (_Size > _LocalDataSize) {                                             \
+            _Size = _LocalDataSize;                                                 \
+          }                                                                         \
+                                                                                    \
+          for (_DumpHexIndex = 0; _DumpHexIndex < _Size; _DumpHexIndex += 1) {      \
+            _TempByte            = (UINT8) _DataToDump[_DumpHexIndex];              \
+            _Val[_DumpHexIndex * 3 + 0]  = (UINT8) _Hex[_TempByte >> 4];            \
+            _Val[_DumpHexIndex * 3 + 1]  = (UINT8) _Hex[_TempByte & 0xF];           \
+            _Val[_DumpHexIndex * 3 + 2]  =                                          \
+              (CHAR8) ((_DumpHexIndex == 7) ? '-' : ' ');                           \
+            _Str[_DumpHexIndex]          =                                          \
+              (CHAR8) ((_TempByte < ' ' || _TempByte > '~') ? '.' : _TempByte);     \
+          }                                                                         \
+                                                                                    \
+          _Val[_DumpHexIndex * 3]  = 0;                                             \
+          _Str[_DumpHexIndex]      = 0;                                             \
+                                                                                    \
+          DebugPrint(ErrorLevel, LinePrefixFormat, ##__VA_ARGS__);                  \
+          DebugPrint(ErrorLevel, "%08X: %-48a *%a*\r\n", _LocalOffset, _Val, _Str); \
+          _DataToDump = (UINT8 *)(((UINTN)_DataToDump) + _Size);                    \
+          _LocalOffset += _Size;                                                    \
+          _LocalDataSize -= _Size;                                                  \
+        }                                                                           \
+      }                                                                             \
+    } while (FALSE)
+#else
+#define DUMP_HEX(ErrorLevel,       \
+                 Offset,           \
+                 Data,             \
+                 DataSize,         \
+                 LinePrefixFormat, \
+                 ...)
 #endif
+
+#endif // __DEBUG_LIB_H__

--- a/MdePkg/Include/Library/UnitTestLib.h
+++ b/MdePkg/Include/Library/UnitTestLib.h
@@ -442,6 +442,58 @@ SaveFrameworkState (
   }
 
 /**
+  The following macros are almost identical to the UT_ASSERT_* macros, but rather than returning
+  immediately, they jump to a `Cleanup` label for late memory cleanup before exiting.
+**/
+#define UT_CLEANUP_ASSERT_TRUE(Expression)                                                         \
+  if(!UnitTestAssertTrue ((Expression), __FUNC__, DEBUG_LINE_NUMBER, __FILE__, #Expression)) { \
+    TestResult = UNIT_TEST_ERROR_TEST_FAILED;                                                      \
+    goto Cleanup;                                                                                  \
+  }
+
+#define UT_CLEANUP_ASSERT_FALSE(Expression)                                                         \
+  if(!UnitTestAssertFalse ((Expression), __FUNC__, DEBUG_LINE_NUMBER, __FILE__, #Expression)) { \
+    TestResult = UNIT_TEST_ERROR_TEST_FAILED;                                                       \
+    goto Cleanup;                                                                                   \
+  }
+
+#define UT_CLEANUP_ASSERT_EQUAL(ValueA, ValueB)                                                                                \
+  if(!UnitTestAssertEqual ((UINT64)(ValueA), (UINT64)(ValueB), __FUNC__, DEBUG_LINE_NUMBER, __FILE__, #ValueA, #ValueB)) { \
+    TestResult = UNIT_TEST_ERROR_TEST_FAILED;                                                                                  \
+    goto Cleanup;                                                                                                              \
+  }
+
+#define UT_CLEANUP_ASSERT_MEM_EQUAL(BufferA, BufferB, Length)                                                                                                      \
+  if(!UnitTestAssertMemEqual ((VOID *)(UINTN)(BufferA), (VOID *)(UINTN)(BufferB), (UINTN)Length, __FUNC__, DEBUG_LINE_NUMBER, __FILE__, #BufferA, #BufferB)) { \
+    TestResult = UNIT_TEST_ERROR_TEST_FAILED;                                                                                                                      \
+    goto Cleanup;                                                                                                                                                  \
+  }
+
+#define UT_CLEANUP_ASSERT_NOT_EQUAL(ValueA, ValueB)                                                                               \
+  if(!UnitTestAssertNotEqual ((UINT64)(ValueA), (UINT64)(ValueB), __FUNC__, DEBUG_LINE_NUMBER, __FILE__, #ValueA, #ValueB)) { \
+    TestResult = UNIT_TEST_ERROR_TEST_FAILED;                                                                                     \
+    goto Cleanup;                                                                                                                 \
+  }
+
+#define UT_CLEANUP_ASSERT_NOT_EFI_ERROR(Status)                                                   \
+  if(!UnitTestAssertNotEfiError ((Status), __FUNC__, DEBUG_LINE_NUMBER, __FILE__, #Status)) { \
+    TestResult = UNIT_TEST_ERROR_TEST_FAILED;                                                     \
+    goto Cleanup;                                                                                 \
+  }
+
+#define UT_CLEANUP_ASSERT_STATUS_EQUAL(Status, Expected)                                                      \
+  if(!UnitTestAssertStatusEqual ((Status), (Expected), __FUNC__, DEBUG_LINE_NUMBER, __FILE__, #Status)) { \
+    TestResult = UNIT_TEST_ERROR_TEST_FAILED;                                                                 \
+    goto Cleanup;                                                                                             \
+  }
+
+#define UT_CLEANUP_ASSERT_NOT_NULL(Pointer)                                                     \
+  if(!UnitTestAssertNotNull ((Pointer), __FUNC__, DEBUG_LINE_NUMBER, __FILE__, #Pointer)) { \
+    TestResult = UNIT_TEST_ERROR_TEST_FAILED;                                                   \
+    goto Cleanup;                                                                               \
+  }
+
+/**
   This macro uses the framework assertion logic to check whether a function call
   triggers an ASSERT() condition.  The BaseLib SetJump()/LongJump() services
   are used to establish a safe return point when an ASSERT() is triggered.

--- a/UnitTestFrameworkPkg/Library/CmockaLib/CmockaLib.inf
+++ b/UnitTestFrameworkPkg/Library/CmockaLib/CmockaLib.inf
@@ -29,7 +29,7 @@
   MSFT:*_*_*_CC_FLAGS     == /c -DHAVE_VSNPRINTF -DHAVE_SNPRINTF /Zi
   MSFT:NOOPT_*_*_CC_FLAGS =  /Od
 
-  GCC:*_*_*_CC_FLAGS     == -g -DHAVE_SIGNAL_H
+  GCC:*_*_*_CC_FLAGS     == -g -DHAVE_SIGNAL_H -DHAVE_STRSIGNAL
   GCC:NOOPT_*_*_CC_FLAGS =  -O0
   GCC:*_*_IA32_CC_FLAGS  =  -m32
   GCC:*_*_X64_CC_FLAGS   =  -m64

--- a/UnitTestFrameworkPkg/Library/UnitTestLib/AssertCmocka.c
+++ b/UnitTestFrameworkPkg/Library/UnitTestLib/AssertCmocka.c
@@ -49,6 +49,7 @@ UnitTestAssertTrue (
   CHAR8  TempStr[MAX_STRING_SIZE];
 
   snprintf (TempStr, sizeof (TempStr), "UT_ASSERT_TRUE(%s:%x)", Description, Expression);
+  printf ("%s:%d %s\n", FileName, (INT32)LineNumber, TempStr);     // Report source of ASSERTs
   _assert_true (Expression, TempStr, FileName, (INT32)LineNumber);
 
   return Expression;

--- a/UnitTestFrameworkPkg/ReadMe.md
+++ b/UnitTestFrameworkPkg/ReadMe.md
@@ -1634,8 +1634,8 @@ We don't know if these types will exist or be applicable yet, but if you write a
 
 Code/Test                                   | Location
 ---------                                   | --------
-Host-Based Library Implementations                 | Host-Based Implementations of common libraries (eg. MemoryAllocationLibHost) should live in the same package that declares the library interface in its .DEC file in the `*Pkg/HostLibrary` directory. Should have 'Host' in the name.
-Host-Based Mocks and Stubs  | Mock and Stub libraries should live in the `UefiTestFrameworkPkg/StubLibrary` with either 'Mock' or 'Stub' in the library name.
+Host-Based Library Implementations                 | Host-Based Implementations of common libraries (eg. MemoryAllocationLibHost) should live in the same package that declares the library interface in its .DEC file in the `*Pkg/Test/Library` directory. Should have 'Host' in the name.
+Host-Based Mocks and Stubs  | Mock and Stub libraries that require test infrastructure should live in the `UefiTestFrameworkPkg/Library` with either 'Mock' or 'Stub' in the library name.
 
 ### If still in doubt...
 


### PR DESCRIPTION
# Description

Add macro to dump hex.

Add Assert macro.

Improve logging for Linux exceptions in unit tests.

---

Cherry-picked from the following commits:

https://github.com/microsoft/mu_basecore/commit/fedcaf9176481467b89820b31ad898f4465ad25f
https://github.com/microsoft/mu_basecore/commit/0a17e75b380b5e4ef50aebf9dbcd616e80d971aa
https://github.com/microsoft/mu_basecore/commit/a40a022ba081256575ce67146413868c93aa161b

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?
 
## How This Was Tested

Tested in Project MU

## Integration Instructions

N/A
