### PR TITLE
BaseTools/WinRcPath: Improve Performance.

### DIFF
--- a/BaseTools/Plugin/WindowsResourceCompiler/WinRcPath.py
+++ b/BaseTools/Plugin/WindowsResourceCompiler/WinRcPath.py
@@ -6,24 +6,40 @@
 # Copyright (c) Microsoft Corporation
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 ##
-import os
+import logging
 from edk2toolext.environment.plugintypes.uefi_build_plugin import IUefiBuildPlugin
 import edk2toollib.windows.locate_tools as locate_tools
 from edk2toolext.environment import shell_environment
 from edk2toolext.environment import version_aggregator
+from pathlib import Path
+
 
 class WinRcPath(IUefiBuildPlugin):
 
-    def do_post_build(self, thebuilder):
-        return 0
-
     def do_pre_build(self, thebuilder):
-        #get the locate tools module
+        # Check if the rc.exe path is already cached and still exists
+        cache_path = Path(thebuilder.ws, "Conf", ".rc_path")
+        if cache_path.exists():
+            with open(cache_path, "r") as f:
+                rc_path = Path(f.readline().strip()).absolute()
+                if (rc_path / "rc.exe").exists():
+                    logging.debug(f"Found rc.exe folder in cache: {rc_path}")
+                    self._set_path(rc_path)
+                    return 0
+
+        # If it does not exist, try to find it with FindToolInWinSdk
         path = locate_tools.FindToolInWinSdk("rc.exe")
         if path is None:
-            thebuilder.logging.warning("Failed to find rc.exe")
-        else:
-            p = os.path.abspath(os.path.dirname(path))
-            shell_environment.GetEnvironment().set_shell_var("WINSDK_PATH_FOR_RC_EXE", p)
-            version_aggregator.GetVersionAggregator().ReportVersion("WINSDK_PATH_FOR_RC_EXE", p, version_aggregator.VersionTypes.INFO)
+            logging.critical("Failed to find rc.exe")
+            return 1
+
+        path = Path(path).absolute().parent
+        self._set_path(path)
+        cache_path.unlink(missing_ok=True)
+        with cache_path.open("w") as f:
+            f.write(str(path))
         return 0
+
+    def _set_path(self, path: Path):
+        shell_environment.GetEnvironment().set_shell_var("WINSDK_PATH_FOR_RC_EXE", str(path))
+        version_aggregator.GetVersionAggregator().ReportVersion("WINSDK_PATH_FOR_RC_EXE", str(path), version_aggregator.VersionTypes.INFO)


### PR DESCRIPTION
# Description

WinRcPath generally takes about 2 seconds to run, due to calling multiple .bat files behind the scenes. This change reduces this time to ~0 seconds due to the following changes:

1. It will attempt to load the path from the cache, which is located a $(WORKSPACE)/Conf/.rc_path. If the loading is a success and the rc_path still exists, it will use it.

2. If the cache did not exist, or the path provided by the cache does not exist, it will find the rc path via the .bat files. If that succeeds, it will write the path to the cache.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested
Ran WinRcPath plugin before and after change to measure performance.

## Integration Instructions
N/A