### PR TITLE
MdeModulePkg ConPlatform: Support IAD-style USB input devices.

### DIFF
--- a/MdeModulePkg/Universal/Console/ConPlatformDxe/ConPlatform.c
+++ b/MdeModulePkg/Universal/Console/ConPlatformDxe/ConPlatform.c
@@ -27,6 +27,15 @@ EFI_DRIVER_BINDING_PROTOCOL  gConPlatformTextOutDriverBinding = {
   NULL
 };
 
+//
+// Values from Usb Inteface Association Descriptor Device
+//  Class Code and Usage Model specification (iadclasscode_r10.pdf)
+//  from Usb.org
+//
+#define USB_BASE_CLASS_MISCELLANEOUS       0xEF
+#define USB_MISCELLANEOUS_SUBCLASS_COMMON  0x02
+#define USB_MISCELLANEOUS_PROTOCOL_IAD     0x01
+
 /**
   Entrypoint of this module.
 
@@ -808,10 +817,16 @@ MatchUsbClass (
   DeviceClass    = DevDesc.DeviceClass;
   DeviceSubClass = DevDesc.DeviceSubClass;
   DeviceProtocol = DevDesc.DeviceProtocol;
-  if (DeviceClass == 0) {
+
+  if ((DeviceClass == 0) ||
+      ((DeviceClass == USB_BASE_CLASS_MISCELLANEOUS) &&
+       (DeviceSubClass == USB_MISCELLANEOUS_SUBCLASS_COMMON) &&
+       (DeviceProtocol == USB_MISCELLANEOUS_PROTOCOL_IAD)))
+  {
     //
-    // If Class in Device Descriptor is set to 0, use the Class, SubClass and
-    // Protocol in Interface Descriptor instead.
+    // If Class in Device Descriptor is set to 0 (Device), or
+    // Class/SubClass/Protocol is 0xEF/0x02/0x01 (IAD), use the Class, SubClass
+    // and Protocol in Interface Descriptor instead.
     //
     Status = UsbIo->UsbGetInterfaceDescriptor (UsbIo, &IfDesc);
     if (EFI_ERROR (Status)) {


### PR DESCRIPTION

# Description

Some multi-function input devices (e.g. combo keyboard and mouse) present as IAD-style devices (https://www.usb.org/defined-class-codes, https://learn.microsoft.com/en-us/windows-hardware/drivers/usbcon/usb-interface-association-descriptor). Historically, multi-function devices would report a DeviceClass of 0, indicating that interface matching should be done on the interface descriptor rather than the global device descriptor.

IAD-style devices use DeviceClass of 0xEF, so they don't match MatchUsbClass() for keyboard (DeviceClass=3, SubClass=1, Proto=1). If they are treated as if they had a DeviceClass of zero, which is more traditional for legacy multi-function devices, then the interface descriptors are used instead and these types of devices will "just work" without needing to add a custom USB device path to ConIn.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested
Verified this with an arduino-based test device that exposes an IAD-style descriptor with keyboard and mouse HID interfaces. Prior to this change, device keyboard input was not usable in shell because it didn't match the default ConIn USB input descriptor. After this change, the keyboard input worked as expected.

## Integration Instructions
N/A