### PR TITLE
MdeModulePkg DxeMain: Add late initialization for Debug Agent.

### DIFF
--- a/MdeModulePkg/Core/Dxe/DxeMain/DxeMain.c
+++ b/MdeModulePkg/Core/Dxe/DxeMain/DxeMain.c
@@ -463,6 +463,11 @@ DxeMain (
   Status = CoreInitializeEventServices ();
   ASSERT_EFI_ERROR (Status);
 
+  //
+  // Give the debug agent a chance to initialize with events.
+  //
+  InitializeDebugAgent (DEBUG_AGENT_INIT_DXE_CORE_LATE, HobStart, NULL);
+
   MemoryProfileInstallProtocol ();
 
   CoreInitializeMemoryAttributesTable ();

--- a/MdeModulePkg/Include/Library/DebugAgentLib.h
+++ b/MdeModulePkg/Include/Library/DebugAgentLib.h
@@ -21,6 +21,8 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #define DEBUG_AGENT_INIT_DXE_LOAD             10
 #define DEBUG_AGENT_INIT_DXE_UNLOAD           11
 #define DEBUG_AGENT_INIT_THUNK_PEI_IA32TOX64  12
+#define DEBUG_AGENT_INIT_REINITIALIZE         13
+#define DEBUG_AGENT_INIT_DXE_CORE_LATE        14
 
 //
 // Context for DEBUG_AGENT_INIT_POSTMEM_SEC

--- a/SourceLevelDebugPkg/Library/DebugAgent/DxeDebugAgent/DxeDebugAgentLib.c
+++ b/SourceLevelDebugPkg/Library/DebugAgent/DxeDebugAgent/DxeDebugAgentLib.c
@@ -2,6 +2,7 @@
   Debug Agent library implementation for Dxe Core and Dxr modules.
 
   Copyright (c) 2010 - 2018, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) Microsoft Corporation.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -534,6 +535,11 @@ InitializeDebugAgent (
         //
         CpuBreakpoint ();
       }
+
+      break;
+
+    case DEBUG_AGENT_INIT_REINITIALIZE:
+    case DEBUG_AGENT_INIT_DXE_CORE_LATE:
 
       break;
 


### PR DESCRIPTION
# Description

Add a late initialize in DxeMain for the debug agent. This is required for the debug agent to be able to setup events to handle image loads, exit boot services, and other important callbacks.

Define a reinitialize debug agent.

These are being used in https://github.com/microsoft/mu_feature_debugger

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested
N/A

## Integration Instructions
N/A