### PR TITLE
MdeModulePkg/TerminalDxe: Added a PCD to set the timer interval.

### DIFF
--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -2253,6 +2253,11 @@
   # @Prompt The value is use for Usb Network rate limiting supported.
   gEfiMdeModulePkgTokenSpaceGuid.PcdUsbNetworkRateLimitingFactor|100|UINT32|0x10000028
 
+  ## This PCD determines the timer interval to be set when using serial console.<BR>
+  # 0 is considered disabled, and will use KEYBOARD_TIMER_INTERVAL.<BR>
+  # @Prompt Sets the serial console timer interval, in the unit of 100ns.
+  gEfiMdeModulePkgTokenSpaceGuid.PcdTerminalKeyboardTimerInterval|0x00000000|UINT32|0x00030025
+
 [PcdsPatchableInModule]
   ## Specify memory size with page number for PEI code when
   #  Loading Module at Fixed Address feature is enabled.

--- a/MdeModulePkg/Universal/Console/TerminalDxe/TerminalDxe.inf
+++ b/MdeModulePkg/Universal/Console/TerminalDxe/TerminalDxe.inf
@@ -88,6 +88,8 @@
   gEfiMdePkgTokenSpaceGuid.PcdDefaultTerminalType           ## SOMETIMES_CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdErrorCodeSetVariable    ## CONSUMES
 
+  gEfiMdeModulePkgTokenSpaceGuid.PcdTerminalKeyboardTimerInterval ## CONSUMES
+
 # [Event]
 # # Relative timer event set by UnicodeToEfiKey(), used to be one 2 seconds input timeout.
 # EVENT_TYPE_RELATIVE_TIMER                   ## CONSUMES


### PR DESCRIPTION
# Description

Create a PCD to allow setting the timer interval for terminal devices. Previous implementation would used a fixed define (KEYBOARD_TIMER_INTERVAL) to set the timer callback period. This change will allow for timer intervals for terminal devices to be changed, based on platform choices, and allow for higher/lower poll rates.
- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested
N/A

## Integration Instructions
N/A