### PR TITLE
.github/request-reviews.yml: Use GitHub App authentication

### DIFF
--- a/.github/workflows/request-reviews.yml
+++ b/.github/workflows/request-reviews.yml
@@ -32,6 +32,13 @@ jobs:
       pull-requests: write
 
     steps:
+      - name: Generate Token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.TIANOCORE_ASSIGN_REVIEWERS_APPLICATION_ID }}
+          private-key: ${{ secrets.TIANOCORE_ASSIGN_REVIEWERS_APPLICATION_PRIVATE_KEY }}
+
       # Reduce checkout time with sparse-checkout
       #   - .github: Contains the scripts to interact with Github and add reviewers
       #   - BaseTools/Scripts: Contains the GetMaintainer.py script
@@ -57,7 +64,7 @@ jobs:
 
       - name: Add Reviewers to Pull Request
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
           ORG_NAME: ${{ github.repository_owner }}
           PR_NUMBER: ${{ github.event.number}}
           REPO_NAME: ${{ github.event.pull_request.base.repo.name }}


### PR DESCRIPTION
# Description

Since the edk2 repository is owned by an organization, the default GitHub token will not be able to access the collaborator list.

Therefore, a GitHub App with `metadata:read` permission will be used to grant access to that REST API. This is used in GitHub.py when it makes the `repo_gh.get_collaborators()` call that resolves to the `/repos/{owner}/{repo}/collaborators` GitHub REST API.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

- Testing in `master` branch4

## Integration Instructions

- N/A