### PR TITLE
DynamicTablesPkg : Add RISC-V support

### DIFF
--- a/DynamicTablesPkg/Drivers/DynamicTableManagerDxe/DynamicTableManagerDxe.inf
+++ b/DynamicTablesPkg/Drivers/DynamicTableManagerDxe/DynamicTableManagerDxe.inf
@@ -31,6 +31,9 @@
 [Sources.IA32, Sources.X64]
   X64/X64DynamicTableManager.c
 
+[Sources.RISCV64]
+  RiscV/RiscVDynamicTableManagerDxe.c
+
 [Packages]
   MdePkg/MdePkg.dec
   MdeModulePkg/MdeModulePkg.dec

--- a/DynamicTablesPkg/Drivers/DynamicTableManagerDxe/RiscV/RiscVDynamicTableManagerDxe.c
+++ b/DynamicTablesPkg/Drivers/DynamicTableManagerDxe/RiscV/RiscVDynamicTableManagerDxe.c
@@ -1,0 +1,64 @@
+/** @file
+  RISC-V Dynamic Table Manager Dxe
+
+  Copyright (c) 2024, Ventana Micro Systems Inc. All rights reserved.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Library/DebugLib.h>
+#include <Library/PcdLib.h>
+#include <Library/UefiBootServicesTableLib.h>
+#include <Protocol/AcpiSystemDescriptionTable.h>
+#include <Protocol/AcpiTable.h>
+
+// Module specific include files.
+#include <AcpiTableGenerator.h>
+#include <ConfigurationManagerObject.h>
+#include <ConfigurationManagerHelper.h>
+#include <DeviceTreeTableGenerator.h>
+#include <Library/TableHelperLib.h>
+#include <Protocol/ConfigurationManagerProtocol.h>
+#include <Protocol/DynamicTableFactoryProtocol.h>
+#include "DynamicTableManagerDxe.h"
+#include "RiscVAcpi.h"
+
+///
+/// Array containing the ACPI tables to check.
+/// We require the FADT, MADT, RHCT and the DSDT tables to boot.
+/// This list also include optional ACPI tables: DBG2, SPCR.
+/// The FADT table must be placed at index 0.
+///
+STATIC ACPI_TABLE_PRESENCE_INFO  mAcpiVerifyTables[] = {
+  { EStdAcpiTableIdFadt, EFI_ACPI_6_2_FIXED_ACPI_DESCRIPTION_TABLE_SIGNATURE,            "FADT", TRUE,  0 },
+  { EStdAcpiTableIdMadt, EFI_ACPI_6_2_MULTIPLE_APIC_DESCRIPTION_TABLE_SIGNATURE,         "MADT", TRUE,  0 },
+  { EStdAcpiTableIdDsdt, EFI_ACPI_6_2_DIFFERENTIATED_SYSTEM_DESCRIPTION_TABLE_SIGNATURE, "DSDT", TRUE,  0 },
+  { EStdAcpiTableIdRhct, EFI_ACPI_6_6_RISCV_HART_CAPABILITIES_TABLE_SIGNATURE,           "RHCT", TRUE,  0 },
+  { EStdAcpiTableIdDbg2, EFI_ACPI_6_2_DEBUG_PORT_2_TABLE_SIGNATURE,                      "DBG2", FALSE, 0 },
+  { EStdAcpiTableIdSpcr, EFI_ACPI_6_2_SERIAL_PORT_CONSOLE_REDIRECTION_TABLE_SIGNATURE,   "SPCR", FALSE, 0 },
+};
+
+/** Get the arch specific ACPI table presence information.
+
+  @param [out] PresenceArray      Array containing the ACPI tables to check.
+  @param [out] PresenceArrayCount Count of elements in the PresenceArray.
+  @param [out] FadtIndex          Index of the FADT table in the PresenceArray.
+                                  -1 if absent.
+
+  @retval EFI_SUCCESS           Success.
+**/
+EFI_STATUS
+EFIAPI
+GetAcpiTablePresenceInfo (
+  OUT ACPI_TABLE_PRESENCE_INFO  **PresenceArray,
+  OUT UINT32                    *PresenceArrayCount,
+  OUT INT32                     *FadtIndex
+  )
+{
+  *PresenceArray      = mAcpiVerifyTables;
+  *PresenceArrayCount = ARRAY_SIZE (mAcpiVerifyTables);
+  *FadtIndex          = ACPI_TABLE_VERIFY_FADT;
+
+  return EFI_SUCCESS;
+}

--- a/DynamicTablesPkg/DynamicTables.dsc.inc
+++ b/DynamicTablesPkg/DynamicTables.dsc.inc
@@ -112,6 +112,7 @@
   #
   DynamicTablesPkg/Library/Acpi/RiscV/AcpiMadtLibRiscV/AcpiMadtLibRiscV.inf
   DynamicTablesPkg/Library/Acpi/RiscV/AcpiRhctLibRiscV/AcpiRhctLibRiscV.inf
+  DynamicTablesPkg/Library/Acpi/RiscV/AcpiSsdtPlicAplicLib/AcpiSsdtPlicAplicLib.inf
 
   #
   # Dynamic Table Factory Dxe
@@ -136,4 +137,5 @@
       # AML Codegen
       NULL|DynamicTablesPkg/Library/Acpi/Common/AcpiSsdtCpuTopologyLib/SsdtCpuTopologyLib.inf
       NULL|DynamicTablesPkg/Library/Acpi/Common/AcpiSsdtPcieLib/SsdtPcieLib.inf
+      NULL|DynamicTablesPkg/Library/Acpi/RiscV/AcpiSsdtPlicAplicLib/AcpiSsdtPlicAplicLib.inf
   }

--- a/DynamicTablesPkg/DynamicTables.dsc.inc
+++ b/DynamicTablesPkg/DynamicTables.dsc.inc
@@ -106,3 +106,34 @@
       NULL|DynamicTablesPkg/Library/Acpi/Common/AcpiSsdtPcieLib/SsdtPcieLib.inf
   }
 
+[Components.RISCV64]
+  #
+  # Generators (RISC-V specific)
+  #
+  DynamicTablesPkg/Library/Acpi/RiscV/AcpiMadtLibRiscV/AcpiMadtLibRiscV.inf
+  DynamicTablesPkg/Library/Acpi/RiscV/AcpiRhctLibRiscV/AcpiRhctLibRiscV.inf
+
+  #
+  # Dynamic Table Factory Dxe
+  #
+  DynamicTablesPkg/Drivers/DynamicTableFactoryDxe/DynamicTableFactoryDxe.inf {
+    <LibraryClasses>
+      NULL|DynamicTablesPkg/Library/Acpi/Common/AcpiDbg2Lib/AcpiDbg2Lib.inf
+      NULL|DynamicTablesPkg/Library/Acpi/Common/AcpiFadtLib/AcpiFadtLib.inf
+      NULL|DynamicTablesPkg/Library/Acpi/Common/AcpiMcfgLib/AcpiMcfgLib.inf
+      NULL|DynamicTablesPkg/Library/Acpi/Common/AcpiPcctLib/AcpiPcctLib.inf
+      NULL|DynamicTablesPkg/Library/Acpi/Common/AcpiPpttLib/AcpiPpttLib.inf
+      NULL|DynamicTablesPkg/Library/Acpi/Common/AcpiRawLib/AcpiRawLib.inf
+      NULL|DynamicTablesPkg/Library/Acpi/Common/AcpiSpcrLib/AcpiSpcrLib.inf
+      NULL|DynamicTablesPkg/Library/Acpi/Common/AcpiSratLib/AcpiSratLib.inf
+      #   RISC-V specific
+      NULL|DynamicTablesPkg/Library/Acpi/RiscV/AcpiMadtLibRiscV/AcpiMadtLibRiscV.inf
+      NULL|DynamicTablesPkg/Library/Acpi/RiscV/AcpiRhctLibRiscV/AcpiRhctLibRiscV.inf
+
+      # AML Fixup
+      NULL|DynamicTablesPkg/Library/Acpi/Common/AcpiSsdtSerialPortLib/SsdtSerialPortLib.inf
+
+      # AML Codegen
+      NULL|DynamicTablesPkg/Library/Acpi/Common/AcpiSsdtCpuTopologyLib/SsdtCpuTopologyLib.inf
+      NULL|DynamicTablesPkg/Library/Acpi/Common/AcpiSsdtPcieLib/SsdtPcieLib.inf
+  }

--- a/DynamicTablesPkg/DynamicTablesPkg.ci.yaml
+++ b/DynamicTablesPkg/DynamicTablesPkg.ci.yaml
@@ -129,7 +129,14 @@
            "TABLEEX",
            "TNSID",
            "Vatos",
-           "WBINVD"
+           "WBINVD",
+           "aplic",
+           "aplics",
+           "eriscv",
+           "gmode",
+           "imsic",
+           "imsics",
+           "rintc"
            ],           # words to extend to the dictionary for this package
         "IgnoreStandardPaths": [],   # Standard Plugin defined paths that
                                      # should be ignore

--- a/DynamicTablesPkg/Include/AcpiTableGenerator.h
+++ b/DynamicTablesPkg/Include/AcpiTableGenerator.h
@@ -99,6 +99,7 @@ typedef enum StdAcpiTableId {
   EStdAcpiTableIdSsdtCmn600,                    ///< SSDT Cmn-600 Generator
   EStdAcpiTableIdSsdtCpuTopology,               ///< SSDT Cpu Topology
   EStdAcpiTableIdSsdtPciExpress,                ///< SSDT Pci Express Generator
+  EStdAcpiTableIdSsdtPlicAplic,                 ///< SSDT Plic/Aplic Generator
   EStdAcpiTableIdPcct,                          ///< PCCT Generator
   EStdAcpiTableIdTpm2,                          ///< TPM2 Generator
   EStdAcpiTableIdRhct,                          ///< RHCT Generator

--- a/DynamicTablesPkg/Include/AcpiTableGenerator.h
+++ b/DynamicTablesPkg/Include/AcpiTableGenerator.h
@@ -101,6 +101,7 @@ typedef enum StdAcpiTableId {
   EStdAcpiTableIdSsdtPciExpress,                ///< SSDT Pci Express Generator
   EStdAcpiTableIdPcct,                          ///< PCCT Generator
   EStdAcpiTableIdTpm2,                          ///< TPM2 Generator
+  EStdAcpiTableIdRhct,                          ///< RHCT Generator
   EStdAcpiTableIdMax
 } ESTD_ACPI_TABLE_ID;
 
@@ -159,7 +160,8 @@ typedef enum StdAcpiTableId {
 /** The Creator ID for the ACPI tables generated using
   the standard ACPI table generators.
 */
-#define TABLE_GENERATOR_CREATOR_ID_ARM  SIGNATURE_32('A', 'R', 'M', 'H')
+#define TABLE_GENERATOR_CREATOR_ID_ARM    SIGNATURE_32('A', 'R', 'M', 'H')
+#define TABLE_GENERATOR_CREATOR_ID_RISCV  SIGNATURE_32('R', 'S', 'C', 'V')
 
 /** A macro to initialise the common header part of EFI ACPI tables as
     defined by the EFI_ACPI_DESCRIPTION_HEADER structure.

--- a/DynamicTablesPkg/Include/ArchCommonNameSpaceObjects.h
+++ b/DynamicTablesPkg/Include/ArchCommonNameSpaceObjects.h
@@ -203,6 +203,9 @@ typedef struct CmArchCommonGenericInterrupt {
   /// BIT1: 0: Interrupt is Active high
   ///       1: Interrupt is Active low
   UINT32    Flags;
+
+  // Phandle
+  INT32     Phandle;
 } CM_ARCH_COMMON_GENERIC_INTERRUPT;
 
 /** A structure that describes a PCI Interrupt Map.

--- a/DynamicTablesPkg/Include/ConfigurationManagerObject.h
+++ b/DynamicTablesPkg/Include/ConfigurationManagerObject.h
@@ -16,6 +16,7 @@
 
 #include <ArchCommonNameSpaceObjects.h>
 #include <ArmNameSpaceObjects.h>
+#include <RiscVNameSpaceObjects.h>
 #include <StandardNameSpaceObjects.h>
 #include <X64NameSpaceObjects.h>
 
@@ -36,6 +37,7 @@ Bits: [31:28] - Name Space ID
                 0001 - Arch Common
                 0010 - ARM
                 0011 - X64
+                0100 - RISC-V
                 1111 - Custom/OEM
                 All other values are reserved.
 
@@ -88,6 +90,7 @@ typedef enum ObjectNameSpaceID {
   EObjNameSpaceArchCommon,        ///< Arch Common Objects Namespace
   EObjNameSpaceArm,               ///< ARM Objects Namespace
   EObjNameSpaceX64,               ///< X64 Objects Namespace
+  EObjNameSpaceRiscV,             ///< RISC-V Objects Namespace
   EObjNameSpaceOem = 0xF,         ///< OEM Objects Namespace
   EObjNameSpaceMax,
 } EOBJECT_NAMESPACE_ID;
@@ -162,6 +165,16 @@ typedef struct CmObjDescriptor {
 **/
 #define CREATE_CM_ARM_OBJECT_ID(ObjectId) \
           (CREATE_CM_OBJECT_ID (EObjNameSpaceArm, ObjectId))
+
+/** This macro returns a Configuration Manager Object ID
+    in the RISC-V Object Namespace.
+
+  @param [in] ObjectId    The Object ID.
+
+  @retval Returns an RISC-V Configuration Manager Object ID.
+**/
+#define CREATE_CM_RISCV_OBJECT_ID(ObjectId) \
+          (CREATE_CM_OBJECT_ID (EObjNameSpaceRiscV, ObjectId))
 
 /** This macro returns a Configuration Manager Object ID
     in the Arch Common Object Namespace.

--- a/DynamicTablesPkg/Include/RiscVAcpi.h
+++ b/DynamicTablesPkg/Include/RiscVAcpi.h
@@ -1,0 +1,185 @@
+/** @file
+  ACPI table definition of RHCT table
+
+  Copyright (c) 2023-2024, Ventana Micro Systems Inc. All Rights Reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+  Temporary header till ACPI spec released and EDK2 header is updated.
+**/
+
+#ifndef RISCV_ACPI_H_
+#define RISCV_ACPI_H_
+
+#define EFI_ACPI_6_6_RINTC  0x18
+#define EFI_ACPI_6_6_IMSIC  0x19
+#define EFI_ACPI_6_6_APLIC  0x1A
+#define EFI_ACPI_6_6_PLIC   0x1B
+
+#define IMSIC_MMIO_PAGE_SHIFT  12
+#define IMSIC_MMIO_PAGE_SZ     (1 << IMSIC_MMIO_PAGE_SHIFT)
+
+#pragma pack (1)
+
+///
+/// RISC-V Hart Local Interrupt Controller
+///
+typedef struct {
+  UINT8     Type;
+  UINT8     Length;
+  UINT8     Version;
+  UINT8     Reserved1;
+  UINT32    Flags;
+  UINT64    HartId;
+  UINT32    AcpiProcessorUid;
+  UINT32    ExtIntCId;
+  UINT64    ImsicBaseAddress;
+  UINT32    ImsicSize;
+} EFI_ACPI_6_6_RINTC_STRUCTURE;
+
+#define EFI_ACPI_6_6_RISCV_RINTC_STRUCTURE_VERSION  1
+#define EFI_ACPI_6_6_RINTC_FLAG_ENABLE              1
+
+///
+/// RISC-V Incoming MSI Controller
+///
+typedef struct {
+  UINT8     Type;
+  UINT8     Length;
+  UINT8     Version;
+  UINT8     Reserved1;
+  UINT32    Flags;
+  UINT16    NumIds;
+  UINT16    NumGuestIds;
+  UINT8     GuestIndexBits;
+  UINT8     HartIndexBits;
+  UINT8     GroupIndexBits;
+  UINT8     GroupIndexShift;
+} EFI_ACPI_6_6_IMSIC_STRUCTURE;
+
+#define EFI_ACPI_6_6_RISCV_IMSIC_STRUCTURE_VERSION  1
+
+///
+/// RISC-V Advanced Platform Level Interrupt Controller (APLIC)
+///
+typedef struct {
+  UINT8     Type;
+  UINT8     Length;
+  UINT8     Version;
+  UINT8     AplicId;
+  UINT32    Flags;
+  UINT8     HwId[8];
+  UINT16    NumIdcs;
+  UINT16    NumSources;
+  UINT32    GsiBase;
+  UINT64    AplicAddress;
+  UINT32    AplicSize;
+} EFI_ACPI_6_6_APLIC_STRUCTURE;
+
+#define EFI_ACPI_6_6_RISCV_APLIC_STRUCTURE_VERSION  1
+///
+/// RISC-V Platform Level Interrupt Controller (PLIC)
+///
+typedef struct {
+  UINT8     Type;
+  UINT8     Length;
+  UINT8     Version;
+  UINT8     PlicId;
+  UINT8     HwId[8];
+  UINT16    NumSources;
+  UINT16    MaxPriority;
+  UINT32    Flags;
+  UINT32    PlicSize;
+  UINT64    PlicAddress;
+  UINT32    GsiBase;
+} EFI_ACPI_6_6_PLIC_STRUCTURE;
+
+#define EFI_ACPI_RHCT_TYPE_ISA_NODE                   0
+#define EFI_ACPI_RHCT_TYPE_CMO_NODE                   1
+#define EFI_ACPI_RHCT_TYPE_MMU_NODE                   2
+#define EFI_ACPI_RHCT_TYPE_HART_INFO_NODE             65535
+#define EFI_ACPI_6_6_RHCT_FLAG_TIMER_CANNOT_WAKE_CPU  0x1
+
+///
+/// RISC-V Hart RHCT Node Header Structure
+///
+typedef struct {
+  UINT16    Type;
+  UINT16    Length;
+  UINT16    Revision;
+} EFI_ACPI_6_6_RISCV_RHCT_NODE;
+
+///
+/// RISC-V Hart RHCT ISA Node Structure
+///
+typedef struct {
+  EFI_ACPI_6_6_RISCV_RHCT_NODE    Node;
+  UINT16                          IsaLength;
+  //  CHAR8     *IsaString;
+} EFI_ACPI_6_6_RISCV_RHCT_ISA_NODE;
+
+#define EFI_ACPI_6_6_RISCV_RHCT_ISA_NODE_STRUCTURE_VERSION  1
+
+///
+/// RISC-V Hart RHCT CMO Node Structure
+///
+typedef struct {
+  EFI_ACPI_6_6_RISCV_RHCT_NODE    Node;
+  UINT8                           Reserved;
+  UINT8                           CbomBlockSize;
+  UINT8                           CbopBlockSize;
+  UINT8                           CbozBlockSize;
+} EFI_ACPI_6_6_RISCV_RHCT_CMO_NODE;
+
+#define EFI_ACPI_6_6_RISCV_RHCT_CMO_NODE_STRUCTURE_VERSION  1
+
+///
+/// RISC-V Hart RHCT Hart Info Structure
+///
+typedef struct {
+  EFI_ACPI_6_6_RISCV_RHCT_NODE    Node;
+  UINT16                          NumOffsets;
+  UINT32                          ACPICpuUid;
+  UINT32                          Offsets[0];
+} EFI_ACPI_6_6_RISCV_RHCT_HART_INFO_NODE;
+
+#define EFI_ACPI_6_6_RISCV_RHCT_HART_INFO_NODE_STRUCTURE_VERSION  1
+
+///
+/// RISC-V Hart Capabilities Table (RHCT)
+///
+typedef struct {
+  EFI_ACPI_DESCRIPTION_HEADER    Header;
+  UINT32                         Flags;
+  UINT64                         TimerFreq;
+  UINT32                         NumNodes;
+  UINT32                         NodeOffset;
+} EFI_ACPI_6_6_RISCV_HART_CAPABILITIES_TABLE;
+
+#define EFI_ACPI_6_6_RISCV_RHCT_TABLE_REVISION  1
+
+///
+/// "RHCT" RISC-V Hart Capabilities Table
+///
+#define EFI_ACPI_6_6_RISCV_HART_CAPABILITIES_TABLE_SIGNATURE  SIGNATURE_32('R', 'H', 'C', 'T')
+
+/* 7: RINTC Affinity Structure(ACPI 6.6) */
+
+typedef struct {
+  UINT8     Type;
+  UINT8     Length;
+  UINT16    Reserved;
+  UINT32    ProximityDomain;
+  UINT32    AcpiProcessorUid;
+  UINT32    Flags;
+  UINT32    ClockDomain;
+} EFI_ACPI_6_6_RINTC_AFFINITY_STRUCTURE;
+
+#define EFI_ACPI_6_6_RINTC_AFFINITY  0x7
+/* Flags for ACPI_SRAT_RINTC_AFFINITY */
+
+#define ACPI_SRAT_RINTC_ENABLED  (1)            /* 00: Use affinity structure */
+
+#pragma pack ()
+
+#endif /* RISCV_ACPI_H_ */

--- a/DynamicTablesPkg/Include/RiscVNameSpaceObjects.h
+++ b/DynamicTablesPkg/Include/RiscVNameSpaceObjects.h
@@ -1,0 +1,258 @@
+/** @file
+
+  Copyright (c) 2024, Ventana Micro Systems Inc. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+  @par Glossary:
+    - Cm or CM   - Configuration Manager
+    - Obj or OBJ - Object
+    - Std or STD - Standard
+**/
+
+#ifndef RISCV_NAMESPACE_OBJECTS_H_
+#define RISCV_NAMESPACE_OBJECTS_H_
+
+#include <AcpiObjects.h>
+#include <StandardNameSpaceObjects.h>
+
+#pragma pack(1)
+
+/** The ERISCV_OBJECT_ID enum describes the Object IDs
+    in the RISCV Namespace
+
+  Note: Whenever an entry in this enum is updated,
+        the following data structures must also be
+        updated:
+        - CM_OBJECT_TOKEN_FIXER TokenFixer[] in
+          Library\Common\DynamicPlatRepoLib\CmObjectTokenFixer.c
+*/
+typedef enum RiscVObjectID {
+  ERiscVObjReserved,                                             ///< 0 - Reserved
+  ERiscVObjRintcInfo,                                            ///< 1 - RISC-V RINTC Info
+  ERiscVObjImsicInfo,                                            ///< 2 - RISC-V IMSIC Info
+  ERiscVObjAplicInfo,                                            ///< 3 - RISC-V APLIC Frame Info
+  ERiscVObjPlicInfo,                                             ///< 4 - RISC-V PLIC Info
+  ERiscVObjIsaStringInfo,                                        ///< 5 - RISC-V ISA String Info
+  ERiscVObjCmoInfo,                                              ///< 6 - RISC-V CMO Info
+  ERiscVObjMmuInfo,                                              ///< 7 - RISC-V MMU Type Info
+  ERiscVObjTimerInfo,                                            ///< 8 - RISC-V Timer Type Info
+  ERiscVObjMax
+} ERISCV_OBJECT_ID;
+
+/** A structure that describes the
+    RINTC for the Platform.
+
+    ID: ERiscVObjRintcInfo
+*/
+typedef struct CmRiscVRintcInfo {
+  /// Version
+  UINT8              Version;
+
+  /// Reserved1
+  UINT8              Reserved1;
+
+  /** The flags field as described by the RINTC structure
+      in the ACPI Specification.
+  */
+  UINT32             Flags;
+
+  // Hart ID
+  UINT64             HartId;
+
+  /** The ACPI Processor UID. This must match the
+      _UID of the CPU Device object information described
+      in the DSDT/SSDT for the CPU.
+  */
+  UINT32             AcpiProcessorUid;
+
+  // External Interrupt Controller ID
+  UINT32             ExtIntCId;
+
+  // IMSIC Base address
+  UINT64             ImsicBaseAddress;
+
+  // IMSIC Size
+  UINT32             ImsicSize;
+
+  // riscv,intc phandle
+  INT32              IntcPhandle;
+
+  /** The proximity domain to which the logical processor belongs.
+      This field is used to populate the RINTC affinity structure
+      in the SRAT table.
+  */
+  UINT32             ProximityDomain;
+
+  /** The clock domain to which the logical processor belongs.
+      This field is used to populate the RINTC affinity structure
+      in the SRAT table.
+  */
+  UINT32             ClockDomain;
+
+  /** The GICC Affinity flags field as described by the RINTC Affinity structure
+      in the SRAT table.
+  */
+  UINT32             AffinityFlags;
+
+  /** Optional field: Reference Token for the Cpc info of this processor.
+      i.e. a token referencing a CM_ARCH_COMMON_CPC_INFO object.
+  */
+  CM_OBJECT_TOKEN    CpcToken;
+} CM_RISCV_RINTC_INFO;
+
+/** A structure that describes the
+    IMSIC information for the Platform.
+
+    ID: ERiscVObjImsicInfo
+*/
+typedef struct CmRiscVImsicInfo {
+  /// Version
+  UINT8     Version;
+
+  /// Reserved1
+  UINT8     Reserved1;
+
+  /** The flags field as described by the IMSIC structure
+      in the ACPI Specification.
+  */
+  UINT32    Flags;
+
+  // Number of S-mode Interrupt Identities
+  UINT16    NumIds;
+
+  // Number of guest mode Interrupt Identities
+  UINT16    NumGuestIds;
+
+  // Guest Index Bits
+  UINT8     GuestIndexBits;
+
+  // Hart Index Bits
+  UINT8     HartIndexBits;
+
+  // Group Index Bits
+  UINT8     GroupIndexBits;
+
+  // Group Index Shift
+  UINT8     GroupIndexShift;
+} CM_RISCV_IMSIC_INFO;
+
+/** A structure that describes the
+    APLIC information for the Platform.
+
+    ID: ERiscVObjAplicInfo
+*/
+typedef struct CmRiscVAplicInfo {
+  /// Version
+  UINT8     Version;
+
+  /// APLIC ID
+  UINT8     AplicId;
+
+  /** The flags field as described by the APLIC structure
+      in the ACPI Specification.
+  */
+  UINT32    Flags;
+
+  /// Hardware ID
+  UINT8     HwId[8];
+
+  // Number of IDCs
+  UINT16    NumIdcs;
+
+  // Number of Interrupt Sources
+  UINT16    NumSources;
+
+  /// GSI Base
+  UINT32    GsiBase;
+
+  /// APLIC Address
+  UINT64    AplicAddress;
+
+  /// APLIC size
+  UINT32    AplicSize;
+
+  /// APLIC Phandle
+  INT32     Phandle;
+} CM_RISCV_APLIC_INFO;
+
+/** A structure that describes the
+    PLIC information for the Platform.
+
+    ID: ERiscVObjPlicInfo
+*/
+typedef struct CmRiscVPlicInfo {
+  /// Version
+  UINT8     Version;
+
+  /// PLIC ID
+  UINT8     PlicId;
+
+  /// Hardware ID
+  UINT8     HwId[8];
+
+  // Number of Interrupt Sources
+  UINT16    NumSources;
+
+  // Max Priority
+  UINT16    MaxPriority;
+
+  /** The flags field as described by the PLIC structure
+      in the ACPI Specification.
+  */
+  UINT32    Flags;
+
+  /// PLIC Size
+  UINT32    PlicSize;
+
+  /// PLIC Address
+  UINT64    PlicAddress;
+
+  /// GSI Base
+  UINT32    GsiBase;
+
+  /// PLIC Phandle
+  INT32     Phandle;
+} CM_RISCV_PLIC_INFO;
+
+/** A structure that describes the
+    ISA string for the Platform.
+
+    ID: ERiscVObjIsaStringInfo
+*/
+typedef struct CmRiscVIsaStringInfo {
+  UINT16    Length;
+
+  CHAR8     *IsaString;
+} CM_RISCV_ISA_STRING_NODE;
+
+/** A structure that describes the
+    CMO for the Platform.
+
+    ID: ERiscVObjCmoInfo
+*/
+typedef struct CmRiscVCmoInfo {
+  /// CbomBlockSize
+  UINT8    CbomBlockSize;
+
+  /// CbopBlockSize
+  UINT8    CbopBlockSize;
+
+  /// CbozBlockSize
+  UINT8    CbozBlockSize;
+} CM_RISCV_CMO_NODE;
+
+/** A structure that describes the
+    Timer for the Platform.
+
+    ID: ERiscVObjTimerInfo
+*/
+typedef struct CmRiscVTimerInfo {
+  UINT8     TimerCannotWakeCpu;
+
+  UINT64    TimeBaseFrequency;
+} CM_RISCV_TIMER_INFO;
+
+#pragma pack()
+
+#endif // RISCV_NAMESPACE_OBJECTS_H_

--- a/DynamicTablesPkg/Library/Acpi/Common/AcpiDbg2Lib/AcpiDbg2Lib.inf
+++ b/DynamicTablesPkg/Library/Acpi/Common/AcpiDbg2Lib/AcpiDbg2Lib.inf
@@ -23,6 +23,9 @@
 [Sources.ARM, Sources.AARCH64]
   Arm/ArmDbg2Generator.c
 
+[Sources.RISCV64]
+  RiscV/RiscVDbg2Generator.c
+
 [Sources.IA32, Sources.X86]
   Dbg2GeneratorNull.c
 

--- a/DynamicTablesPkg/Library/Acpi/Common/AcpiDbg2Lib/RiscV/RiscVDbg2Generator.c
+++ b/DynamicTablesPkg/Library/Acpi/Common/AcpiDbg2Lib/RiscV/RiscVDbg2Generator.c
@@ -1,0 +1,59 @@
+/** @file
+  RISC-V DBG2 Table Generator
+
+  Copyright (c) 2024, Ventana Micro Systems Inc. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+  @par Reference(s):
+  - Microsoft Debug Port Table 2 (DBG2) Specification
+**/
+
+#include <ConfigurationManagerObject.h>
+#include <Protocol/SerialIo.h>
+#include "Dbg2Generator.h"
+
+/**
+  Initialise the serial port to the specified settings.
+  The serial port is re-configured only if the specified settings
+  are different from the current settings.
+  All unspecified settings will be set to the default values.
+
+  @param  SerialPortInfo          CM_ARCH_COMMON_SERIAL_PORT_INFO object describing
+                                  the serial port.
+  @param  BaudRate                The baud rate of the serial device. If the
+                                  baud rate is not supported, the speed will be
+                                  reduced to the nearest supported one and the
+                                  variable's value will be updated accordingly.
+  @param  ReceiveFifoDepth        The number of characters the device will
+                                  buffer on input.  Value of 0 will use the
+                                  device's default FIFO depth.
+  @param  Parity                  If applicable, this is the EFI_PARITY_TYPE
+                                  that is computed or checked as each character
+                                  is transmitted or received. If the device
+                                  does not support parity, the value is the
+                                  default parity value.
+  @param  DataBits                The number of data bits in each character.
+  @param  StopBits                If applicable, the EFI_STOP_BITS_TYPE number
+                                  of stop bits per character.
+                                  If the device does not support stop bits, the
+                                  value is the default stop bit value.
+
+  @retval RETURN_SUCCESS            All attributes were set correctly on the
+                                    serial device.
+  @retval RETURN_INVALID_PARAMETER  One or more of the attributes has an
+                                    unsupported value.
+**/
+RETURN_STATUS
+EFIAPI
+Dbg2InitializePort (
+  IN  CONST CM_ARCH_COMMON_SERIAL_PORT_INFO  *SerialPortInfo,
+  IN OUT UINT64                              *BaudRate,
+  IN OUT UINT32                              *ReceiveFifoDepth,
+  IN OUT EFI_PARITY_TYPE                     *Parity,
+  IN OUT UINT8                               *DataBits,
+  IN OUT EFI_STOP_BITS_TYPE                  *StopBits
+  )
+{
+  // Nothing to do.
+  return EFI_SUCCESS;
+}

--- a/DynamicTablesPkg/Library/Acpi/Common/AcpiFadtLib/AcpiFadtLib.inf
+++ b/DynamicTablesPkg/Library/Acpi/Common/AcpiFadtLib/AcpiFadtLib.inf
@@ -26,6 +26,9 @@
 [Sources.IA32, Sources.X64]
   X64/X64FadtGenerator.c
 
+[Sources.RISCV64]
+  RiscV/RiscVFadtGenerator.c
+
 [Packages]
   MdePkg/MdePkg.dec
   MdeModulePkg/MdeModulePkg.dec

--- a/DynamicTablesPkg/Library/Acpi/Common/AcpiFadtLib/RiscV/RiscVFadtGenerator.c
+++ b/DynamicTablesPkg/Library/Acpi/Common/AcpiFadtLib/RiscV/RiscVFadtGenerator.c
@@ -1,0 +1,55 @@
+/** @file
+  RISC-V FADT Table Helpers
+
+  Copyright (c) 2024, Ventana Micro Systems Inc. All rights reserved.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+  @par Reference(s):
+  - ACPI 6.5 Specification, Aug 29, 2022
+
+**/
+
+#include <Library/AcpiLib.h>
+#include <Library/DebugLib.h>
+#include <Protocol/AcpiTable.h>
+
+// Module specific include files.
+#include <AcpiTableGenerator.h>
+#include <ConfigurationManagerObject.h>
+#include <ConfigurationManagerHelper.h>
+#include <Library/TableHelperLib.h>
+#include <Protocol/ConfigurationManagerProtocol.h>
+#include "FadtGenerator.h"
+
+/** This macro defines the FADT flag options for RISC-V Platforms.
+*/
+#define FADT_FLAGS  (EFI_ACPI_6_5_HW_REDUCED_ACPI |          \
+                     EFI_ACPI_6_5_LOW_POWER_S0_IDLE_CAPABLE)
+
+/** Updates the Architecture specific information in the FADT Table.
+
+  @param [in]  CfgMgrProtocol Pointer to the Configuration Manager
+                              Protocol Interface.
+  @param [in, out] Fadt       Pointer to the constructed ACPI Table.
+
+  @retval EFI_SUCCESS           Success.
+  @retval EFI_INVALID_PARAMETER A parameter is invalid.
+  @retval EFI_NOT_FOUND         The required object was not found.
+  @retval EFI_BAD_BUFFER_SIZE   The size returned by the Configuration
+                                Manager is less than the Object size for the
+                                requested object.
+**/
+EFI_STATUS
+EFIAPI
+FadtArchUpdate (
+  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST  CfgMgrProtocol,
+  IN   OUT EFI_ACPI_6_5_FIXED_ACPI_DESCRIPTION_TABLE      *Fadt
+  )
+{
+  ASSERT (CfgMgrProtocol != NULL);
+  ASSERT (Fadt != NULL);
+
+  Fadt->Flags = FADT_FLAGS;
+
+  return EFI_SUCCESS;
+}

--- a/DynamicTablesPkg/Library/Acpi/Common/AcpiSratLib/AcpiSratLib.inf
+++ b/DynamicTablesPkg/Library/Acpi/Common/AcpiSratLib/AcpiSratLib.inf
@@ -23,6 +23,9 @@
 [Sources.ARM, Sources.AARCH64]
   Arm/ArmSratGenerator.c
 
+[Sources.RISCV64]
+  RiscV/RiscVSratGenerator.c
+
 [Sources.IA32, Sources.X64]
   SratGeneratorNull.c
 

--- a/DynamicTablesPkg/Library/Acpi/Common/AcpiSratLib/RiscV/RiscVSratGenerator.c
+++ b/DynamicTablesPkg/Library/Acpi/Common/AcpiSratLib/RiscV/RiscVSratGenerator.c
@@ -1,0 +1,178 @@
+/** @file
+  RISC-V SRAT Table Generator
+
+  Copyright (c) 2024 Ventana Micro Systems Inc. All rights reserved.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+  @par Reference(s):
+  - ACPI 6.6 Specification
+
+  @par Glossary:
+  - Cm or CM   - Configuration Manager
+  - Obj or OBJ - Object
+**/
+
+#include <Library/AcpiLib.h>
+#include <Library/BaseLib.h>
+#include <Library/DebugLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Protocol/AcpiTable.h>
+
+// Module specific include files.
+#include <AcpiTableGenerator.h>
+#include <ConfigurationManagerObject.h>
+#include <ConfigurationManagerHelper.h>
+#include <Library/TableHelperLib.h>
+#include <Protocol/ConfigurationManagerProtocol.h>
+
+#include "RiscVAcpi.h"
+#include "SratGenerator.h"
+
+/**
+  RISC-V standard SRAT Generator
+
+  Requirements:
+    The following Configuration Manager Object(s) are used by this Generator:
+    - ERiscVObjRintcInfo (REQUIRED)
+*/
+
+/** This macro expands to a function that retrieves the RINTC
+    Information from the Configuration Manager.
+*/
+GET_OBJECT_LIST (
+  EObjNameSpaceRiscV,
+  ERiscVObjRintcInfo,
+  CM_RISCV_RINTC_INFO
+  );
+
+typedef struct SratSubTable {
+  /// Start offset of the arch specific sub-table.
+  UINT32    Offset;
+
+  /// Count
+  UINT32    Count;
+
+  /// Array of CmInfo objects of the relevant type.
+  VOID      *CmInfo;
+} SRAT_SUB_TABLE;
+
+STATIC SRAT_SUB_TABLE  mSratSubTable;
+
+/** Reserve arch sub-tables space.
+
+  @param [in] CfgMgrProtocol   Pointer to the Configuration Manager
+  @param [in, out] ArchOffset  On input, contains the offset where arch specific
+                               sub-tables can be written. It is expected that
+                               there enough space to write all the arch specific
+                               sub-tables from this offset onward.
+                               On ouput, contains the ending offset of the arch
+                               specific sub-tables.
+
+  @retval EFI_SUCCESS           Table generated successfully.
+  @retval EFI_INVALID_PARAMETER A parameter is invalid.
+  @retval EFI_NOT_FOUND         The required object information is not found.
+  @retval EFI_BAD_BUFFER_SIZE   The size returned by the Configuration
+                                Manager is less than the Object size for the
+                                requested object.
+**/
+EFI_STATUS
+EFIAPI
+ArchReserveOffsets (
+  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST  CfgMgrProtocol,
+  IN OUT UINT32                                           *ArchOffset
+  )
+{
+  EFI_STATUS  Status;
+
+  ASSERT (CfgMgrProtocol != NULL);
+  ASSERT (ArchOffset != NULL);
+
+  Status = GetERiscVObjRintcInfo (
+             CfgMgrProtocol,
+             CM_NULL_TOKEN,
+             (CM_RISCV_RINTC_INFO **)&mSratSubTable.CmInfo,
+             &mSratSubTable.Count
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "ERROR: SRAT: Failed to get RINTC Info. Status = %r\n",
+      Status
+      ));
+    return Status;
+  }
+
+  if (mSratSubTable.Count == 0) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "ERROR: SRAT: RINTC information not provided.\n"
+      ));
+    ASSERT (0);
+    return EFI_INVALID_PARAMETER;
+  }
+
+  mSratSubTable.Offset = *ArchOffset;
+  *ArchOffset         += (sizeof (EFI_ACPI_6_6_RINTC_AFFINITY_STRUCTURE) * mSratSubTable.Count);
+
+  return EFI_SUCCESS;
+}
+
+/** Add the RINTC Affinity Structures in the SRAT Table.
+
+  @param [in]  CfgMgrProtocol   Pointer to the Configuration Manager
+                                Protocol Interface.
+  @param [in]  Srat             Pointer to the SRAT Table.
+**/
+STATIC
+VOID
+EFIAPI
+AddRINTCAffinity (
+  IN CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL         *CONST  CfgMgrProtocol,
+  IN EFI_ACPI_6_3_SYSTEM_RESOURCE_AFFINITY_TABLE_HEADER *CONST  Srat
+  )
+{
+  EFI_ACPI_6_6_RINTC_AFFINITY_STRUCTURE  *RintcAff;
+  CM_RISCV_RINTC_INFO                    *RintcInfo;
+
+  RintcInfo = mSratSubTable.CmInfo;
+  RintcAff  = (EFI_ACPI_6_6_RINTC_AFFINITY_STRUCTURE *)((UINT8 *)Srat + mSratSubTable.Offset);
+
+  while (mSratSubTable.Count-- != 0) {
+    DEBUG ((DEBUG_INFO, "SRAT: RintcAff = 0x%p\n", RintcAff));
+
+    RintcAff->Type             = EFI_ACPI_6_6_RINTC_AFFINITY;
+    RintcAff->Length           = sizeof (EFI_ACPI_6_6_RINTC_AFFINITY_STRUCTURE);
+    RintcAff->ProximityDomain  = RintcInfo->ProximityDomain;
+    RintcAff->AcpiProcessorUid = RintcInfo->AcpiProcessorUid;
+    RintcAff->Flags            = RintcInfo->AffinityFlags;
+    RintcAff->ClockDomain      = RintcInfo->ClockDomain;
+
+    // Next
+    RintcAff++;
+    RintcInfo++;
+  }// while
+}
+
+/** Add the arch specific sub-tables to the SRAT table.
+
+  These sub-tables are written in the space reserved beforehand.
+
+  @param [in]  CfgMgrProtocol   Pointer to the Configuration Manager
+                                Protocol Interface.
+  @param [in]  Srat             Pointer to the SRAT Table.
+
+  @retval EFI_SUCCESS           Table generated successfully.
+**/
+EFI_STATUS
+EFIAPI
+AddArchObjects (
+  IN CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL         *CONST  CfgMgrProtocol,
+  IN EFI_ACPI_6_3_SYSTEM_RESOURCE_AFFINITY_TABLE_HEADER *CONST  Srat
+  )
+{
+  ASSERT (CfgMgrProtocol != NULL);
+  ASSERT (Srat != NULL);
+
+  AddRINTCAffinity (CfgMgrProtocol, Srat);
+  return EFI_SUCCESS;
+}

--- a/DynamicTablesPkg/Library/Acpi/Common/AcpiSsdtCpuTopologyLib/RiscV/RiscVSsdtCpuTopologyGenerator.c
+++ b/DynamicTablesPkg/Library/Acpi/Common/AcpiSsdtCpuTopologyLib/RiscV/RiscVSsdtCpuTopologyGenerator.c
@@ -1,0 +1,202 @@
+/** @file
+  RISC-V SSDT Cpu Topology Table Generator Helpers.
+
+  Copyright (c) 2024, Ventana Micro Systems Inc. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+  @par Reference(s):
+    - TBD
+
+  @par Glossary:
+**/
+
+#include <Library/AcpiLib.h>
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Protocol/AcpiTable.h>
+
+// Module specific include files.
+#include <AcpiTableGenerator.h>
+#include <ConfigurationManagerObject.h>
+#include <ConfigurationManagerHelper.h>
+#include <Library/AcpiHelperLib.h>
+#include <Library/TableHelperLib.h>
+#include <Library/AmlLib/AmlLib.h>
+#include <Protocol/ConfigurationManagerProtocol.h>
+
+#include "SsdtCpuTopologyGenerator.h"
+
+/** This macro expands to a function that retrieves the RINTC
+    CPU interface Information from the Configuration Manager.
+*/
+GET_OBJECT_LIST (
+  EObjNameSpaceRiscV,
+  ERiscVObjRintcInfo,
+  CM_RISCV_RINTC_INFO
+  );
+
+/** Create the processor hierarchy AML tree from CM_RISCV_RINTC_INFO
+    CM objects.
+
+  A processor container is by extension any non-leave device in the cpu topology.
+
+  @param [in] Generator        The SSDT Cpu Topology generator.
+  @param [in] CfgMgrProtocol   Pointer to the Configuration Manager
+                               Protocol Interface.
+  @param [in] ScopeNode        Scope node handle ('\_SB' scope).
+
+  @retval EFI_SUCCESS             Success.
+  @retval EFI_INVALID_PARAMETER   Invalid parameter.
+  @retval EFI_OUT_OF_RESOURCES    Failed to allocate memory.
+**/
+EFI_STATUS
+EFIAPI
+CreateTopologyFromIntC (
+  IN        ACPI_CPU_TOPOLOGY_GENERATOR                   *Generator,
+  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST  CfgMgrProtocol,
+  IN        AML_OBJECT_NODE_HANDLE                        ScopeNode
+  )
+{
+  EFI_STATUS              Status;
+  CM_RISCV_RINTC_INFO     *RintcInfo;
+  UINT32                  RintcInfoCount;
+  UINT32                  Index;
+  AML_OBJECT_NODE_HANDLE  CpuNode;
+
+  ASSERT (Generator != NULL);
+  ASSERT (CfgMgrProtocol != NULL);
+  ASSERT (ScopeNode != NULL);
+
+  Status = GetERiscVObjRintcInfo (
+             CfgMgrProtocol,
+             CM_NULL_TOKEN,
+             &RintcInfo,
+             &RintcInfoCount
+             );
+  if (EFI_ERROR (Status)) {
+    ASSERT (0);
+    return Status;
+  }
+
+  // For each CM_RISCV_RINTC_INFO object, create an AML node.
+  for (Index = 0; Index < RintcInfoCount; Index++) {
+    Status = CreateAmlCpu (
+               Generator,
+               ScopeNode,
+               RintcInfo[Index].AcpiProcessorUid,
+               Index,
+               &CpuNode
+               );
+    if (EFI_ERROR (Status)) {
+      ASSERT (0);
+      break;
+    }
+
+    // If a CPC info is associated with the
+    // GicCinfo, create an _CPC method returning them.
+    if (RintcInfo[Index].CpcToken != CM_NULL_TOKEN) {
+      Status = CreateAmlCpcNode (Generator, CfgMgrProtocol, RintcInfo[Index].CpcToken, CpuNode);
+      if (EFI_ERROR (Status)) {
+        ASSERT_EFI_ERROR (Status);
+        break;
+      }
+    }
+  } // for
+
+  return Status;
+}
+
+/** Get UID, CpcToken and EtToken from local interrupt controller structure.
+
+  @param [in]  CfgMgrProtocol    Pointer to the Configuration Manager
+                                 Protocol Interface.
+  @param [in]  IntCToken         Unique Local INTC token to find the correct
+                                 INTC info structure.
+  @param [out] AcpiProcessorUid  UID of the CPU.
+  @param [out] CpcToken          CpcToken of the CPU / local INTC.
+  @param [out] EtToken           EtToken of the CPU / local INTC.
+
+  @retval EFI_SUCCESS             Success.
+  @retval EFI_NOT_FOUND           INTC structure not found.
+**/
+EFI_STATUS
+EFIAPI
+GetIntCInfo (
+  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST  CfgMgrProtocol,
+  IN  CM_OBJECT_TOKEN                                     IntCToken,
+  OUT UINT32                                              *AcpiProcessorUid,
+  OUT CM_OBJECT_TOKEN                                     *CpcToken,
+  OUT CM_OBJECT_TOKEN                                     *EtToken
+  )
+{
+  EFI_STATUS           Status;
+  CM_RISCV_RINTC_INFO  *RintcInfo;
+
+  Status = GetERiscVObjRintcInfo (
+             CfgMgrProtocol,
+             IntCToken,
+             &RintcInfo,
+             NULL
+             );
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  if (AcpiProcessorUid != NULL) {
+    *AcpiProcessorUid = RintcInfo->AcpiProcessorUid;
+  }
+
+  if (CpcToken != NULL) {
+    *CpcToken = RintcInfo->CpcToken;
+  }
+
+  *EtToken = CM_NULL_TOKEN; // RISC-V doesn't have EtToken
+
+  return Status;
+}
+
+/** Add arch specific information to a CPU node in the asl description.
+
+  @param [in]  Generator          The SSDT Cpu Topology generator.
+  @param [in]  CfgMgrProtocol     Pointer to the Configuration Manager
+                                  Protocol Interface.
+  @param [in]  AcpiIdObjectToken  AcpiIdObjectToken identifying the CPU to fetch the
+                                  other fields from.
+  @param [in]  CpuName            Value used to generate the CPU node name.
+  @param [out] CpuNode            CPU Node to which the ET device node is
+                                  attached.
+
+  @retval EFI_SUCCESS             Success.
+  @retval EFI_INVALID_PARAMETER   Invalid parameter.
+  @retval EFI_NOT_FOUND           Not found.
+  @retval EFI_UNSUPPORTED         Feature Unsupported.
+  @retval EFI_OUT_OF_RESOURCES    Failed to allocate memory.
+**/
+EFI_STATUS
+EFIAPI
+AddArchAmlCpuInfo (
+  IN  ACPI_CPU_TOPOLOGY_GENERATOR                         *Generator,
+  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST  CfgMgrProtocol,
+  IN  CM_OBJECT_TOKEN                                     AcpiIdObjectToken,
+  IN  UINT32                                              CpuName,
+  OUT  AML_OBJECT_NODE_HANDLE                             *CpuNode
+  )
+{
+  EFI_STATUS           Status;
+  CM_RISCV_RINTC_INFO  *RintcInfo;
+
+  Status = GetERiscVObjRintcInfo (
+             CfgMgrProtocol,
+             AcpiIdObjectToken,
+             &RintcInfo,
+             NULL
+             );
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  return EFI_SUCCESS;
+}

--- a/DynamicTablesPkg/Library/Acpi/Common/AcpiSsdtCpuTopologyLib/SsdtCpuTopologyLib.inf
+++ b/DynamicTablesPkg/Library/Acpi/Common/AcpiSsdtCpuTopologyLib/SsdtCpuTopologyLib.inf
@@ -23,6 +23,9 @@
 [Sources.ARM, Sources.AARCH64]
   Arm/ArmSsdtCpuTopologyGenerator.c
 
+[Sources.RISCV64]
+  RiscV/RiscVSsdtCpuTopologyGenerator.c
+
 [Packages.ARM, Packages.AARCH64]
   ArmPlatformPkg/ArmPlatformPkg.dec
 

--- a/DynamicTablesPkg/Library/Acpi/Common/AcpiSsdtPcieLib/RiscV/RiscVSsdtPcieGenerator.c
+++ b/DynamicTablesPkg/Library/Acpi/Common/AcpiSsdtPcieLib/RiscV/RiscVSsdtPcieGenerator.c
@@ -1,0 +1,112 @@
+/** @file
+  RISC-V PLIC/APLIC Map.
+
+  Copyright (c) 2024, Ventana Micro Systems Inc. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+  @par Reference(s):
+  - TBD
+**/
+
+#include <Library/AcpiLib.h>
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <ConfigurationManagerObject.h>
+#include <ConfigurationManagerHelper.h>
+#include <Protocol/ConfigurationManagerProtocol.h>
+
+/** RISC-V SSDT PLIC/APLIC namespace device Generator.
+
+Requirements:
+  The following Configuration Manager Object(s) are used by
+  this Generator:
+  - ERiscVObjAplicInfo
+  - ERiscVObjPlicInfo
+*/
+
+/** This macro expands to a function that retrieves the APLIC
+    Information from the Configuration Manager.
+*/
+GET_OBJECT_LIST (
+  EObjNameSpaceRiscV,
+  ERiscVObjAplicInfo,
+  CM_RISCV_APLIC_INFO
+  );
+
+/** This macro expands to a function that retrieves the PLIC
+    Information from the Configuration Manager.
+*/
+
+GET_OBJECT_LIST (
+  EObjNameSpaceRiscV,
+  ERiscVObjPlicInfo,
+  CM_RISCV_PLIC_INFO
+  );
+
+/**
+  Get GSI number for the interrupt number.
+
+  On RISC-V, GSIs are divided across PLICs or APLICs. So, the interrupt
+  number from interrupt map in DT should be converted to appropriate GSI
+  number using the interrupt controller phandle and GSI base of each PLIC
+  or APLIC.
+
+  @param  CfgMgrProtocol     Pointer to the Configuration Manager
+                             Protocol interface.
+  @param  IrqId              The IRQ number to convert to GSI.
+  @param  IntcPhandle        Reference to the interrupt controller.
+
+**/
+UINT32
+ArchGetGsiIrqId (
+  IN      CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST  CfgMgrProtocol,
+  IN UINT32                                                   IrqId,
+  IN INT32                                                    IntcPhandle
+  )
+{
+  CM_RISCV_APLIC_INFO  *AplicInfo;
+  CM_RISCV_PLIC_INFO   *PlicInfo;
+  EFI_STATUS           Status;
+  UINT32               Index, Count;
+
+  Status = GetERiscVObjAplicInfo (
+             CfgMgrProtocol,
+             CM_NULL_TOKEN,
+             &AplicInfo,
+             &Count
+             );
+  if (!EFI_ERROR (Status)) {
+    for (Index = 0; Index < Count; Index++) {
+      if (AplicInfo[Index].Phandle == IntcPhandle) {
+        return IrqId + AplicInfo[Index].GsiBase;
+      }
+    }
+
+    ASSERT (0);
+    return IrqId;
+  } else if (Status == EFI_NOT_FOUND) {
+    Status = GetERiscVObjPlicInfo (
+               CfgMgrProtocol,
+               CM_NULL_TOKEN,
+               &PlicInfo,
+               &Count
+               );
+    if (!EFI_ERROR (Status)) {
+      for (Index = 0; Index < Count; Index++) {
+        if (PlicInfo[Index].Phandle == IntcPhandle) {
+          return IrqId + PlicInfo[Index].GsiBase;
+        }
+      }
+
+      ASSERT (0);
+      return IrqId;
+    }
+  } else {
+    ASSERT (0);
+  }
+
+  return IrqId;
+}

--- a/DynamicTablesPkg/Library/Acpi/Common/AcpiSsdtPcieLib/SsdtPcieGenerator.c
+++ b/DynamicTablesPkg/Library/Acpi/Common/AcpiSsdtPcieLib/SsdtPcieGenerator.c
@@ -364,6 +364,7 @@ GeneratePrt (
       goto exit_handler;
     }
 
+ #if defined (MDE_CPU_ARM) || defined (MDE_CPU_AARCH64)
     // Check that the interrupts flags are SPIs, level high.
     // Cf. Arm BSA v1.0, sE.6 "Legacy interrupts"
     if ((Index > 0)   &&
@@ -375,6 +376,8 @@ GeneratePrt (
       ASSERT_EFI_ERROR (Status);
       goto exit_handler;
     }
+
+ #endif
 
     // Add the device to the DeviceTable.
     MappingTableAdd (&Generator->DeviceTable, IrqMapInfo->PciDevice);

--- a/DynamicTablesPkg/Library/Acpi/Common/AcpiSsdtPcieLib/SsdtPcieGenerator.c
+++ b/DynamicTablesPkg/Library/Acpi/Common/AcpiSsdtPcieLib/SsdtPcieGenerator.c
@@ -379,6 +379,14 @@ GeneratePrt (
 
  #endif
 
+ #if defined (MDE_CPU_RISCV64)
+    IrqMapInfo->IntcInterrupt.Interrupt = ArchGetGsiIrqId (
+                                            CfgMgrProtocol,
+                                            IrqMapInfo->IntcInterrupt.Interrupt,
+                                            IrqMapInfo->IntcInterrupt.Phandle
+                                            );
+ #endif
+
     // Add the device to the DeviceTable.
     MappingTableAdd (&Generator->DeviceTable, IrqMapInfo->PciDevice);
 

--- a/DynamicTablesPkg/Library/Acpi/Common/AcpiSsdtPcieLib/SsdtPcieGenerator.h
+++ b/DynamicTablesPkg/Library/Acpi/Common/AcpiSsdtPcieLib/SsdtPcieGenerator.h
@@ -16,6 +16,13 @@
 #ifndef SSDT_PCIE_GENERATOR_H_
 #define SSDT_PCIE_GENERATOR_H_
 
+UINT32
+ArchGetGsiIrqId (
+  IN      CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST  CfgMgrProtocol,
+  IN UINT32                                                   IrqId,
+  IN INT32                                                    IntcPhandle
+  );
+
 /** Pci address attributes.
 
   This can also be denoted as space code, address space or ss.

--- a/DynamicTablesPkg/Library/Acpi/Common/AcpiSsdtPcieLib/SsdtPcieLib.inf
+++ b/DynamicTablesPkg/Library/Acpi/Common/AcpiSsdtPcieLib/SsdtPcieLib.inf
@@ -20,6 +20,9 @@
   SsdtPcieGenerator.c
   SsdtPcieGenerator.h
 
+[Sources.RISCV64]
+  RiscV/RiscVSsdtPcieGenerator.c
+
 [Packages]
   DynamicTablesPkg/DynamicTablesPkg.dec
   EmbeddedPkg/EmbeddedPkg.dec

--- a/DynamicTablesPkg/Library/Acpi/RiscV/AcpiMadtLibRiscV/AcpiMadtLibRiscV.inf
+++ b/DynamicTablesPkg/Library/Acpi/RiscV/AcpiMadtLibRiscV/AcpiMadtLibRiscV.inf
@@ -1,0 +1,29 @@
+## @file
+#  MADT Table Generator
+#
+#  Copyright (c) 2024, Ventana Micro Systems Inc. All rights reserved.
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION    = 0x00010019
+  BASE_NAME      = AcpiMadtLibRiscV
+  FILE_GUID      = 4696C865-9751-4811-832E-3DA8287F168A
+  VERSION_STRING = 1.0
+  MODULE_TYPE    = DXE_DRIVER
+  LIBRARY_CLASS  = NULL|DXE_DRIVER
+  CONSTRUCTOR    = AcpiMadtLibConstructor
+  DESTRUCTOR     = AcpiMadtLibDestructor
+
+[Sources]
+  MadtGenerator.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  EmbeddedPkg/EmbeddedPkg.dec
+  DynamicTablesPkg/DynamicTablesPkg.dec
+
+[LibraryClasses]
+  BaseLib

--- a/DynamicTablesPkg/Library/Acpi/RiscV/AcpiMadtLibRiscV/MadtGenerator.c
+++ b/DynamicTablesPkg/Library/Acpi/RiscV/AcpiMadtLibRiscV/MadtGenerator.c
@@ -1,0 +1,757 @@
+/** @file
+  MADT Table Generator for RISC-V
+
+  Copyright (c) 2024, Ventana Micro Systems Inc. All rights reserved.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+  @par Reference(s):
+  - TBD - ACPI 6.6 Specification
+
+**/
+
+#include <Library/AcpiLib.h>
+#include <Library/DebugLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Protocol/AcpiTable.h>
+
+// Module specific include files.
+#include <AcpiTableGenerator.h>
+#include <ConfigurationManagerObject.h>
+#include <ConfigurationManagerHelper.h>
+#include <RiscVAcpi.h>
+#include <Library/TableHelperLib.h>
+#include <Protocol/ConfigurationManagerProtocol.h>
+
+/** RISC-V standard MADT Generator
+
+Requirements:
+  The following Configuration Manager Object(s) are required by
+  this Generator:
+  - ERiscVObjRintcInfo
+  - ERiscVObjImsicInfo (OPTIONAL)
+  - ERiscVObjAplicInfo (OPTIONAL)
+  - ERiscVObjPlicInfo  (OPTIONAL)
+*/
+
+/** This macro expands to a function that retrieves the RINTC
+    Information from the Configuration Manager.
+*/
+GET_OBJECT_LIST (
+  EObjNameSpaceRiscV,
+  ERiscVObjRintcInfo,
+  CM_RISCV_RINTC_INFO
+  );
+
+/** This macro expands to a function that retrieves the IMSIC
+    Information from the Configuration Manager.
+*/
+
+GET_OBJECT_LIST (
+  EObjNameSpaceRiscV,
+  ERiscVObjImsicInfo,
+  CM_RISCV_IMSIC_INFO
+  );
+
+/** This macro expands to a function that retrieves the APLIC
+    Information from the Configuration Manager.
+*/
+GET_OBJECT_LIST (
+  EObjNameSpaceRiscV,
+  ERiscVObjAplicInfo,
+  CM_RISCV_APLIC_INFO
+  );
+
+/** This macro expands to a function that retrieves the PLIC
+    Information from the Configuration Manager.
+*/
+
+GET_OBJECT_LIST (
+  EObjNameSpaceRiscV,
+  ERiscVObjPlicInfo,
+  CM_RISCV_PLIC_INFO
+  );
+
+/** This function updates the RINTC Information in the
+    EFI_ACPI_6_6_RINTC_STRUCTURE structure.
+
+  @param [in]  Rintc       Pointer to RINTC structure.
+  @param [in]  RintcInfo   Pointer to the RINTC Information.
+  @param [in]  MadtRev    MADT table revision.
+**/
+STATIC
+VOID
+AddRINTC (
+  IN  EFI_ACPI_6_6_RINTC_STRUCTURE  *CONST  Rintc,
+  IN  CONST CM_RISCV_RINTC_INFO     *CONST  RintcInfo,
+  IN  CONST UINT8                           MadtRev
+  )
+{
+  ASSERT (Rintc != NULL);
+  ASSERT (RintcInfo != NULL);
+
+  // UINT8 Type
+  Rintc->Type = EFI_ACPI_6_6_RINTC;
+  // UINT8 Length
+  Rintc->Length = sizeof (EFI_ACPI_6_6_RINTC_STRUCTURE);
+  // UINT8 Version
+  Rintc->Version = 1;
+  // UINT8 Reserved
+  Rintc->Reserved1 = EFI_ACPI_RESERVED_BYTE;
+
+  // UINT32 Flags
+  Rintc->Flags = RintcInfo->Flags;
+  // UINT64 HartID
+  Rintc->HartId = RintcInfo->HartId;
+  // UINT32 AcpiProcessorUid
+  Rintc->AcpiProcessorUid = RintcInfo->AcpiProcessorUid;
+  // UINT32 ExtIntCId
+  Rintc->ExtIntCId = RintcInfo->ExtIntCId;
+  // UINT64 ImsicBaseAddress
+  Rintc->ImsicBaseAddress = RintcInfo->ImsicBaseAddress;
+  // UINT32 ImsicSize
+  Rintc->ImsicSize = RintcInfo->ImsicSize;
+}
+
+/**
+  Function to test if two GIC CPU Interface information structures have the
+  same ACPI Processor UID.
+
+  @param [in]  RintcInfo1          Pointer to the first RINTC info structure.
+  @param [in]  RintcInfo2          Pointer to the second RINTC info structure.
+  @param [in]  Index1             Index of RintcInfo1 in the shared list of GIC
+                                  CPU Interface Info structures.
+  @param [in]  Index2             Index of RintcInfo2 in the shared list of GIC
+                                  CPU Interface Info structures.
+
+  @retval TRUE                    RintcInfo1 and GicCInfo2 have the same UID.
+  @retval FALSE                   RintcInfo1 and GicCInfo2 have different UIDs.
+**/
+BOOLEAN
+EFIAPI
+IsAcpiUidEqual (
+  IN  CONST VOID   *RintcInfo1,
+  IN  CONST VOID   *RintcInfo2,
+  IN        UINTN  Index1,
+  IN        UINTN  Index2
+  )
+{
+  UINT32  Uid1;
+  UINT32  Uid2;
+
+  ASSERT ((RintcInfo1 != NULL) && (RintcInfo2 != NULL));
+
+  Uid1 = ((CM_RISCV_RINTC_INFO *)RintcInfo1)->AcpiProcessorUid;
+  Uid2 = ((CM_RISCV_RINTC_INFO *)RintcInfo2)->AcpiProcessorUid;
+
+  if (Uid1 == Uid2) {
+    DEBUG (
+      (
+       DEBUG_ERROR,
+       "ERROR: MADT: RINTC Info Structures %d and %d have the same ACPI " \
+       "Processor UID: 0x%x.\n",
+       Index1,
+       Index2,
+       Uid1
+      )
+      );
+    return TRUE;
+  }
+
+  return FALSE;
+}
+
+/** Add the RINTC Information to the MADT Table.
+
+  This function also checks for duplicate ACPI Processor UIDs.
+
+  @param [in]  Rintc                 Pointer to RINTC structure list.
+  @param [in]  RintcInfo             Pointer to the RINTC Information list.
+  @param [in]  RintcCount            Count of RINTC.
+  @param [in]  MadtRev               MADT table revision.
+
+  @retval EFI_SUCCESS               RINTC Information was added successfully.
+  @retval EFI_INVALID_PARAMETER     One or more invalid RINTC Info values were
+                                    provided and the generator failed to add the
+                                    information to the table.
+**/
+STATIC
+EFI_STATUS
+AddRINTCList (
+  IN  EFI_ACPI_6_6_RINTC_STRUCTURE  *Rintc,
+  IN  CONST CM_RISCV_RINTC_INFO     *RintcInfo,
+  IN  UINT32                        RintcCount,
+  IN  CONST UINT8                   MadtRev
+  )
+{
+  BOOLEAN  IsAcpiProcUidDuplicated;
+
+  ASSERT (Rintc != NULL);
+  ASSERT (RintcInfo != NULL);
+
+  IsAcpiProcUidDuplicated = FindDuplicateValue (
+                              RintcInfo,
+                              RintcCount,
+                              sizeof (CM_RISCV_RINTC_INFO),
+                              IsAcpiUidEqual
+                              );
+  // Duplicate ACPI Processor UID was found so the RINTC info provided
+  // is invalid
+  if (IsAcpiProcUidDuplicated) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  while (RintcCount-- != 0) {
+    AddRINTC (Rintc++, RintcInfo++, MadtRev);
+  }
+
+  return EFI_SUCCESS;
+}
+
+/** Update the IMSIC Information in the MADT Table.
+
+  @param [in]  Imsic      Pointer to IMSIC structure.
+  @param [in]  ImsicInfo  Pointer to the IMSIC Information.
+**/
+STATIC
+VOID
+AddIMSIC (
+  EFI_ACPI_6_6_IMSIC_STRUCTURE  *CONST  Imsic,
+  CONST CM_RISCV_IMSIC_INFO     *CONST  ImsicInfo
+  )
+{
+  ASSERT (Imsic != NULL);
+  ASSERT (ImsicInfo != NULL);
+
+  // UINT8 Type
+  Imsic->Type = EFI_ACPI_6_6_IMSIC;
+  // UINT8 Length
+  Imsic->Length = sizeof (EFI_ACPI_6_6_IMSIC_STRUCTURE);
+  // UINT8 Version
+  Imsic->Version = 1;
+  // UINT8 Reserved
+  Imsic->Reserved1 = EFI_ACPI_RESERVED_BYTE;
+
+  // UINT32 Flags
+  Imsic->Flags = ImsicInfo->Flags;
+  // UINT16 NumIds
+  Imsic->NumIds = ImsicInfo->NumIds;
+  // UINT16 NumGuestIds
+  Imsic->NumGuestIds = ImsicInfo->NumGuestIds;
+  // UINT8 GuestIndexBits
+  Imsic->GuestIndexBits = ImsicInfo->GuestIndexBits;
+  // UINT8 GuestIndexBits
+  Imsic->HartIndexBits = ImsicInfo->HartIndexBits;
+  // UINT8 GroupIndexBits
+  Imsic->GroupIndexBits = ImsicInfo->GroupIndexBits;
+  // UINT8 GroupIndexShift
+  Imsic->GroupIndexShift = ImsicInfo->GroupIndexShift;
+}
+
+/** Update the APLIC Information.
+
+  @param [in]  Aplic                 Pointer to APLIC structure.
+  @param [in]  AplicInfo             Pointer to the APLIC Info.
+**/
+STATIC
+VOID
+AddAPLIC (
+  IN  EFI_ACPI_6_6_APLIC_STRUCTURE   *CONST  Aplic,
+  IN  CONST CM_RISCV_APLIC_INFO  *CONST      AplicInfo
+  )
+{
+  UINTN  Idx;
+
+  ASSERT (Aplic != NULL);
+  ASSERT (AplicInfo != NULL);
+
+  Aplic->Type    = EFI_ACPI_6_6_APLIC;
+  Aplic->Length  = sizeof (EFI_ACPI_6_6_APLIC_STRUCTURE);
+  Aplic->Version = 1;
+  Aplic->AplicId = AplicInfo->AplicId;
+  Aplic->Flags   = AplicInfo->Flags;
+  for (Idx = 0; Idx < 8; Idx++) {
+    Aplic->HwId[Idx] = AplicInfo->HwId[Idx];
+  }
+
+  Aplic->NumIdcs      = AplicInfo->NumIdcs;
+  Aplic->NumSources   = AplicInfo->NumSources;
+  Aplic->GsiBase      = AplicInfo->GsiBase;
+  Aplic->AplicAddress = AplicInfo->AplicAddress;
+  Aplic->AplicSize    = AplicInfo->AplicSize;
+}
+
+/** Add the APLIC Information to the MADT Table.
+
+  @param [in]  Aplic      Pointer to APLIC structure list.
+  @param [in]  AplicInfo  Pointer to the APLIC info list.
+  @param [in]  AplicCount Count of APLICs.
+**/
+STATIC
+VOID
+AddAPLICList (
+  IN  EFI_ACPI_6_6_APLIC_STRUCTURE  *Aplic,
+  IN  CONST CM_RISCV_APLIC_INFO     *AplicInfo,
+  IN  UINT32                        AplicCount
+  )
+{
+  ASSERT (Aplic != NULL);
+  ASSERT (AplicInfo != NULL);
+
+  while (AplicCount-- != 0) {
+    AddAPLIC (Aplic++, AplicInfo++);
+  }
+}
+
+/** Update the PLIC Information.
+
+  @param [in]  Plic                 Pointer to PLIC structure.
+  @param [in]  PlicInfo             Pointer to the PLIC Info.
+**/
+STATIC
+VOID
+AddPLIC (
+  IN  EFI_ACPI_6_6_PLIC_STRUCTURE   *CONST  Plic,
+  IN  CONST CM_RISCV_PLIC_INFO  *CONST      PlicInfo
+  )
+{
+  UINTN  Idx;
+
+  ASSERT (Plic != NULL);
+  ASSERT (PlicInfo != NULL);
+
+  Plic->Type    = EFI_ACPI_6_6_PLIC;
+  Plic->Length  = sizeof (EFI_ACPI_6_6_PLIC_STRUCTURE);
+  Plic->Version = 1;
+  Plic->PlicId  = PlicInfo->PlicId;
+  for (Idx = 0; Idx < 8; Idx++) {
+    Plic->HwId[Idx] = PlicInfo->HwId[Idx];
+  }
+
+  Plic->NumSources  = PlicInfo->NumSources;
+  Plic->MaxPriority = PlicInfo->MaxPriority;
+  Plic->Flags       = PlicInfo->Flags;
+  Plic->PlicSize    = PlicInfo->PlicSize;
+  Plic->PlicAddress = PlicInfo->PlicAddress;
+  Plic->GsiBase     = PlicInfo->GsiBase;
+}
+
+/** Add the PLIC Information to the MADT Table.
+
+  @param [in]  Plic      Pointer to PLIC structure list.
+  @param [in]  PlicInfo  Pointer to the PLIC info list.
+  @param [in]  PlicCount Count of PLICs.
+**/
+STATIC
+VOID
+AddPLICList (
+  IN  EFI_ACPI_6_6_PLIC_STRUCTURE  *Plic,
+  IN  CONST CM_RISCV_PLIC_INFO     *PlicInfo,
+  IN  UINT32                       PlicCount
+  )
+{
+  ASSERT (Plic != NULL);
+  ASSERT (PlicInfo != NULL);
+
+  while (PlicCount-- != 0) {
+    AddPLIC (Plic++, PlicInfo++);
+  }
+}
+
+/** Construct the MADT ACPI table.
+
+  This function invokes the Configuration Manager protocol interface
+  to get the required hardware information for generating the ACPI
+  table.
+
+  If this function allocates any resources then they must be freed
+  in the FreeXXXXTableResources function.
+
+  @param [in]  This           Pointer to the table generator.
+  @param [in]  AcpiTableInfo  Pointer to the ACPI Table Info.
+  @param [in]  CfgMgrProtocol Pointer to the Configuration Manager
+                              Protocol Interface.
+  @param [out] Table          Pointer to the constructed ACPI Table.
+
+  @retval EFI_SUCCESS           Table generated successfully.
+  @retval EFI_INVALID_PARAMETER A parameter is invalid.
+  @retval EFI_NOT_FOUND         The required object was not found.
+  @retval EFI_BAD_BUFFER_SIZE   The size returned by the Configuration
+                                Manager is less than the Object size for the
+                                requested object.
+**/
+STATIC
+EFI_STATUS
+EFIAPI
+BuildMadtTable (
+  IN  CONST ACPI_TABLE_GENERATOR                  *CONST  This,
+  IN  CONST CM_STD_OBJ_ACPI_TABLE_INFO            *CONST  AcpiTableInfo,
+  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST  CfgMgrProtocol,
+  OUT       EFI_ACPI_DESCRIPTION_HEADER          **CONST  Table
+  )
+{
+  CM_RISCV_RINTC_INFO  *RintcInfo;
+  CM_RISCV_IMSIC_INFO  *ImsicInfo;
+  CM_RISCV_APLIC_INFO  *AplicInfo;
+  CM_RISCV_PLIC_INFO   *PlicInfo;
+  EFI_STATUS           Status;
+  UINT32               TableSize;
+  UINT32               RintcCount;
+  UINT32               ImsicCount;
+  UINT32               AplicCount;
+  UINT32               PlicCount;
+  UINT32               RintcOffset;
+  UINT32               ImsicOffset;
+  UINT32               AplicOffset;
+  UINT32               PlicOffset;
+
+  EFI_ACPI_6_5_MULTIPLE_APIC_DESCRIPTION_TABLE_HEADER  *Madt;
+
+  ASSERT (This != NULL);
+  ASSERT (AcpiTableInfo != NULL);
+  ASSERT (CfgMgrProtocol != NULL);
+  ASSERT (Table != NULL);
+  ASSERT (AcpiTableInfo->TableGeneratorId == This->GeneratorID);
+  ASSERT (AcpiTableInfo->AcpiTableSignature == This->AcpiTableSignature);
+
+  if ((AcpiTableInfo->AcpiTableRevision < This->MinAcpiTableRevision) ||
+      (AcpiTableInfo->AcpiTableRevision > This->AcpiTableRevision))
+  {
+    DEBUG (
+      (
+       DEBUG_ERROR,
+       "ERROR: MADT: Requested table revision = %d, is not supported."
+       "Supported table revision: Minimum = %d, Maximum = %d\n",
+       AcpiTableInfo->AcpiTableRevision,
+       This->MinAcpiTableRevision,
+       This->AcpiTableRevision
+      )
+      );
+    return EFI_INVALID_PARAMETER;
+  }
+
+  *Table = NULL;
+
+  Status = GetERiscVObjRintcInfo (
+             CfgMgrProtocol,
+             CM_NULL_TOKEN,
+             &RintcInfo,
+             &RintcCount
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG (
+      (
+       DEBUG_ERROR,
+       "ERROR: MADT: Failed to get RINTC Info. Status = %r\n",
+       Status
+      )
+      );
+    goto error_handler;
+  }
+
+  if (RintcCount == 0) {
+    DEBUG (
+      (
+       DEBUG_ERROR,
+       "ERROR: MADT: RINTC information not provided.\n"
+      )
+      );
+    ASSERT (RintcCount != 0);
+    Status = EFI_INVALID_PARAMETER;
+    goto error_handler;
+  }
+
+  Status = GetERiscVObjImsicInfo (
+             CfgMgrProtocol,
+             CM_NULL_TOKEN,
+             &ImsicInfo,
+             &ImsicCount
+             );
+  if (EFI_ERROR (Status) && (Status != EFI_NOT_FOUND)) {
+    DEBUG (
+      (
+       DEBUG_ERROR,
+       "ERROR: MADT: Failed to get IMSIC Info. Status = %r\n",
+       Status
+      )
+      );
+    goto error_handler;
+  }
+
+  if (ImsicCount > 1) {
+    DEBUG (
+      (
+       DEBUG_ERROR,
+       "ERROR: MADT: One, and only one, IMSIC must be present."
+       "GicDCount = %d\n",
+       ImsicCount
+      )
+      );
+    ASSERT (ImsicCount <= 1);
+    Status = EFI_INVALID_PARAMETER;
+    goto error_handler;
+  }
+
+  Status = GetERiscVObjAplicInfo (
+             CfgMgrProtocol,
+             CM_NULL_TOKEN,
+             &AplicInfo,
+             &AplicCount
+             );
+  if (EFI_ERROR (Status) && (Status != EFI_NOT_FOUND)) {
+    DEBUG (
+      (
+       DEBUG_ERROR,
+       "ERROR: MADT: Failed to get APLIC Info. Status = %r\n",
+       Status
+      )
+      );
+    goto error_handler;
+  }
+
+  Status = GetERiscVObjPlicInfo (
+             CfgMgrProtocol,
+             CM_NULL_TOKEN,
+             &PlicInfo,
+             &PlicCount
+             );
+  if (EFI_ERROR (Status) && (Status != EFI_NOT_FOUND)) {
+    DEBUG (
+      (
+       DEBUG_ERROR,
+       "ERROR: MADT: Failed to get PLIC Info. Status = %r\n",
+       Status
+      )
+      );
+    goto error_handler;
+  }
+
+  TableSize = sizeof (EFI_ACPI_6_5_MULTIPLE_APIC_DESCRIPTION_TABLE_HEADER);
+
+  RintcOffset = TableSize;
+  TableSize  += (sizeof (EFI_ACPI_6_6_RINTC_STRUCTURE) * RintcCount);
+
+  ImsicOffset = TableSize;
+  TableSize  += (sizeof (EFI_ACPI_6_6_IMSIC_STRUCTURE) * ImsicCount);
+
+  AplicOffset = TableSize;
+  TableSize  += (sizeof (EFI_ACPI_6_6_APLIC_STRUCTURE) * AplicCount);
+
+  PlicOffset = TableSize;
+  TableSize += (sizeof (EFI_ACPI_6_6_PLIC_STRUCTURE) * PlicCount);
+
+  // Allocate the Buffer for MADT table
+  *Table = (EFI_ACPI_DESCRIPTION_HEADER *)AllocateZeroPool (TableSize);
+  if (*Table == NULL) {
+    Status = EFI_OUT_OF_RESOURCES;
+    DEBUG (
+      (
+       DEBUG_ERROR,
+       "ERROR: MADT: Failed to allocate memory for MADT Table, Size = %d," \
+       " Status = %r\n",
+       TableSize,
+       Status
+      )
+      );
+    goto error_handler;
+  }
+
+  Madt = (EFI_ACPI_6_5_MULTIPLE_APIC_DESCRIPTION_TABLE_HEADER *)*Table;
+
+  DEBUG (
+    (
+     DEBUG_INFO,
+     "MADT: Madt = 0x%p TableSize = 0x%x\n",
+     Madt,
+     TableSize
+    )
+    );
+
+  Status = AddAcpiHeader (
+             CfgMgrProtocol,
+             This,
+             &Madt->Header,
+             AcpiTableInfo,
+             TableSize
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG (
+      (
+       DEBUG_ERROR,
+       "ERROR: MADT: Failed to add ACPI header. Status = %r\n",
+       Status
+      )
+      );
+    goto error_handler;
+  }
+
+  Status = AddRINTCList (
+             (EFI_ACPI_6_6_RINTC_STRUCTURE *)((UINT8 *)Madt + RintcOffset),
+             RintcInfo,
+             RintcCount,
+             Madt->Header.Revision
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG (
+      (
+       DEBUG_ERROR,
+       "ERROR: MADT: Failed to add RINTC structures. Status = %r\n",
+       Status
+      )
+      );
+    goto error_handler;
+  }
+
+  if (ImsicCount != 0) {
+    AddIMSIC (
+      (EFI_ACPI_6_6_IMSIC_STRUCTURE *)((UINT8 *)Madt + ImsicOffset),
+      ImsicInfo
+      );
+  }
+
+  if (AplicCount != 0) {
+    AddAPLICList (
+      (EFI_ACPI_6_6_APLIC_STRUCTURE *)((UINT8 *)Madt + AplicOffset),
+      AplicInfo,
+      AplicCount
+      );
+  }
+
+  if (PlicCount != 0) {
+    AddPLICList (
+      (EFI_ACPI_6_6_PLIC_STRUCTURE *)((UINT8 *)Madt + PlicOffset),
+      PlicInfo,
+      PlicCount
+      );
+  }
+
+  return EFI_SUCCESS;
+
+error_handler:
+  if (*Table != NULL) {
+    FreePool (*Table);
+    *Table = NULL;
+  }
+
+  return Status;
+}
+
+/** Free any resources allocated for constructing the MADT
+
+  @param [in]      This           Pointer to the table generator.
+  @param [in]      AcpiTableInfo  Pointer to the ACPI Table Info.
+  @param [in]      CfgMgrProtocol Pointer to the Configuration Manager
+                                  Protocol Interface.
+  @param [in, out] Table          Pointer to the ACPI Table.
+
+  @retval EFI_SUCCESS           The resources were freed successfully.
+  @retval EFI_INVALID_PARAMETER The table pointer is NULL or invalid.
+**/
+STATIC
+EFI_STATUS
+FreeMadtTableResources (
+  IN      CONST ACPI_TABLE_GENERATOR                  *CONST  This,
+  IN      CONST CM_STD_OBJ_ACPI_TABLE_INFO            *CONST  AcpiTableInfo,
+  IN      CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST  CfgMgrProtocol,
+  IN OUT        EFI_ACPI_DESCRIPTION_HEADER          **CONST  Table
+  )
+{
+  ASSERT (This != NULL);
+  ASSERT (AcpiTableInfo != NULL);
+  ASSERT (CfgMgrProtocol != NULL);
+  ASSERT (AcpiTableInfo->TableGeneratorId == This->GeneratorID);
+  ASSERT (AcpiTableInfo->AcpiTableSignature == This->AcpiTableSignature);
+
+  if ((Table == NULL) || (*Table == NULL)) {
+    DEBUG ((DEBUG_ERROR, "ERROR: MADT: Invalid Table Pointer\n"));
+    ASSERT ((Table != NULL) && (*Table != NULL));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  FreePool (*Table);
+  *Table = NULL;
+  return EFI_SUCCESS;
+}
+
+/** The MADT Table Generator revision.
+*/
+#define MADT_GENERATOR_REVISION  CREATE_REVISION (1, 0)
+
+/** The interface for the MADT Table Generator.
+*/
+STATIC
+CONST
+ACPI_TABLE_GENERATOR  MadtGenerator = {
+  // Generator ID
+  CREATE_STD_ACPI_TABLE_GEN_ID (EStdAcpiTableIdMadt),
+  // Generator Description
+  L"ACPI.STD.MADT.GENERATOR",
+  // ACPI Table Signature
+  EFI_ACPI_6_5_MULTIPLE_APIC_DESCRIPTION_TABLE_SIGNATURE,
+  // ACPI Table Revision supported by this Generator
+  EFI_ACPI_6_5_MULTIPLE_APIC_DESCRIPTION_TABLE_REVISION,
+  // Minimum supported ACPI Table Revision
+  EFI_ACPI_6_2_MULTIPLE_APIC_DESCRIPTION_TABLE_REVISION,
+  // Creator ID
+  TABLE_GENERATOR_CREATOR_ID_RISCV,
+  // Creator Revision
+  MADT_GENERATOR_REVISION,
+  // Build Table function
+  BuildMadtTable,
+  // Free Resource function
+  FreeMadtTableResources,
+  // Extended build function not needed
+  NULL,
+  // Extended build function not implemented by the generator.
+  // Hence extended free resource function is not required.
+  NULL
+};
+
+/** Register the Generator with the ACPI Table Factory.
+
+  @param [in]  ImageHandle  The handle to the image.
+  @param [in]  SystemTable  Pointer to the System Table.
+
+  @retval EFI_SUCCESS           The Generator is registered.
+  @retval EFI_INVALID_PARAMETER A parameter is invalid.
+  @retval EFI_ALREADY_STARTED   The Generator for the Table ID
+                                is already registered.
+**/
+EFI_STATUS
+EFIAPI
+AcpiMadtLibConstructor (
+  IN  EFI_HANDLE        ImageHandle,
+  IN  EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  EFI_STATUS  Status;
+
+  Status = RegisterAcpiTableGenerator (&MadtGenerator);
+  DEBUG ((DEBUG_INFO, "MADT: Register Generator. Status = %r\n", Status));
+  ASSERT_EFI_ERROR (Status);
+  return Status;
+}
+
+/** Deregister the Generator from the ACPI Table Factory.
+
+  @param [in]  ImageHandle  The handle to the image.
+  @param [in]  SystemTable  Pointer to the System Table.
+
+  @retval EFI_SUCCESS           The Generator is deregistered.
+  @retval EFI_INVALID_PARAMETER A parameter is invalid.
+  @retval EFI_NOT_FOUND         The Generator is not registered.
+**/
+EFI_STATUS
+EFIAPI
+AcpiMadtLibDestructor (
+  IN  EFI_HANDLE        ImageHandle,
+  IN  EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  EFI_STATUS  Status;
+
+  Status = DeregisterAcpiTableGenerator (&MadtGenerator);
+  DEBUG ((DEBUG_INFO, "MADT: Deregister Generator. Status = %r\n", Status));
+  ASSERT_EFI_ERROR (Status);
+  return Status;
+}

--- a/DynamicTablesPkg/Library/Acpi/RiscV/AcpiRhctLibRiscV/AcpiRhctLibRiscV.inf
+++ b/DynamicTablesPkg/Library/Acpi/RiscV/AcpiRhctLibRiscV/AcpiRhctLibRiscV.inf
@@ -1,0 +1,31 @@
+## @file
+#  RHCT Table Generator
+#
+#  Copyright (c) 2024, Ventana Micro Systems Inc. All rights reserved.
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION    = 0x00010019
+  BASE_NAME      = AcpiRhctLibRiscV
+  FILE_GUID      = A3C3A90D-7F06-47EA-B78E-ED41B47D7153
+  VERSION_STRING = 1.0
+  MODULE_TYPE    = DXE_DRIVER
+  LIBRARY_CLASS  = NULL|DXE_DRIVER
+  CONSTRUCTOR    = AcpiRhctLibConstructor
+  DESTRUCTOR     = AcpiRhctLibDestructor
+
+[Sources]
+  RhctGenerator.c
+  RhctGenerator.h
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  EmbeddedPkg/EmbeddedPkg.dec
+  DynamicTablesPkg/DynamicTablesPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  BaseMemoryLib

--- a/DynamicTablesPkg/Library/Acpi/RiscV/AcpiRhctLibRiscV/RhctGenerator.c
+++ b/DynamicTablesPkg/Library/Acpi/RiscV/AcpiRhctLibRiscV/RhctGenerator.c
@@ -1,0 +1,1039 @@
+/** @file
+  RHCT Table Generator
+
+  Copyright (c) 2024, Ventana Micro Systems Inc. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+  @par Reference(s):
+    - TBD
+
+**/
+
+#include <IndustryStandard/IoRemappingTable.h>
+#include <Library/AcpiLib.h>
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Protocol/AcpiTable.h>
+
+// Module specific include files.
+#include <AcpiTableGenerator.h>
+#include <ConfigurationManagerObject.h>
+#include <ConfigurationManagerHelper.h>
+#include <Library/TableHelperLib.h>
+#include <Protocol/ConfigurationManagerProtocol.h>
+#include <RiscVAcpi.h>
+
+#include "RhctGenerator.h"
+
+/** RISC-V standard RHCT Generator
+
+Requirements:
+  The following Configuration Manager Object(s) are required by
+  this Generator:
+  - ERiscVObjCmoInfo,
+  - ERiscVObjTimerInfo,
+  - ERiscVObjRintcInfo,
+  - ERiscVObjIsaStringInfo
+*/
+
+GET_OBJECT_LIST (
+  EObjNameSpaceRiscV,
+  ERiscVObjCmoInfo,
+  CM_RISCV_CMO_NODE
+  );
+
+GET_OBJECT_LIST (
+  EObjNameSpaceRiscV,
+  ERiscVObjTimerInfo,
+  CM_RISCV_TIMER_INFO
+  );
+
+GET_OBJECT_LIST (
+  EObjNameSpaceRiscV,
+  ERiscVObjRintcInfo,
+  CM_RISCV_RINTC_INFO
+  );
+
+/** This macro expands to a function that retrieves the
+    Named Component node information from the Configuration Manager.
+*/
+GET_OBJECT_LIST (
+  EObjNameSpaceRiscV,
+  ERiscVObjIsaStringInfo,
+  CM_RISCV_ISA_STRING_NODE
+  );
+
+/** This macro expands to a function that retrieves the
+     Root Complex node information from the Configuration Manager.
+GET_OBJECT_LIST (
+  EObjNameSpaceArch,
+  EArchObjHartInfo,
+  CM_RISCV_HART_INFO_NODE
+  );
+
+*/
+/** Returns the size of the CMO node.
+
+    @param [in]  Node    Pointer to CMO node.
+
+    @retval Size of the ITS Group Node.
+**/
+STATIC
+UINT32
+GetCmoNodeSize (
+  IN  CONST CM_RISCV_CMO_NODE  *Node
+  )
+{
+  ASSERT (Node != NULL);
+
+  return (UINT32)(sizeof (EFI_ACPI_6_6_RISCV_RHCT_CMO_NODE));
+}
+
+/** Returns the total size required for the CMO nodes and
+    updates the Node Indexer.
+
+    This function calculates the size required for the node group
+    and also populates the Node Indexer array with offsets for the
+    individual nodes.
+
+    @param [in]       NodeStartOffset Offset from the start of the
+                                      RHCT where this node group starts.
+    @param [in]       NodeList        Pointer to CMO node list.
+    @param [in]       NodeCount       Count of the CMO nodes.
+    @param [in, out]  NodeIndexer     Pointer to the next Node Indexer.
+
+    @retval Total size of the ITS Group Nodes.
+**/
+STATIC
+UINT64
+GetSizeofCmoNodes (
+  IN      CONST UINT32                         NodeStartOffset,
+  IN      CONST CM_RISCV_CMO_NODE              *NodeList,
+  IN            UINT32                         NodeCount,
+  IN OUT        RHCT_NODE_INDEXER     **CONST  NodeIndexer
+  )
+{
+  UINT64  Size;
+
+  ASSERT (NodeList != NULL);
+
+  Size = 0;
+  while (NodeCount-- != 0) {
+    (*NodeIndexer)->Object = (VOID *)NodeList;
+    (*NodeIndexer)->Offset = (UINT32)(Size + NodeStartOffset);
+    DEBUG (
+      (
+       DEBUG_INFO,
+       "RHCT: Node Indexer = %p, Object = %p,"
+       " Offset = 0x%x\n",
+       *NodeIndexer,
+       (*NodeIndexer)->Object,
+       (*NodeIndexer)->Offset
+      )
+      );
+
+    Size += sizeof (EFI_ACPI_6_6_RISCV_RHCT_CMO_NODE);
+    (*NodeIndexer)++;
+    NodeList++;
+  }
+
+  return Size;
+}
+
+/** Returns the size of the Named Component node.
+
+    @param [in]  IsaString    NULL terminated ASCII string.
+
+    @retval Size of the Named Component node.
+**/
+STATIC
+UINT32
+GetIsaStringNodeSize (
+  IN  CONST CHAR8  *IsaString
+  )
+{
+  ASSERT (IsaString != NULL);
+
+  return (UINT32)(sizeof (EFI_ACPI_6_6_RISCV_RHCT_ISA_NODE) +
+                  ALIGN_VALUE (AsciiStrSize ((CHAR8 *)IsaString), 2));
+}
+
+/** Returns the size of the Named Component node.
+
+    @param [in]  NumOffsets    Number of offsets in Hart Info node.
+
+    @retval Size of the Named Component node.
+**/
+STATIC
+UINT32
+GetHartInfoSize (
+  IN  UINT32  NumOffsets
+  )
+{
+  return sizeof (EFI_ACPI_6_6_RISCV_RHCT_HART_INFO_NODE) +
+         (sizeof (UINT32) * NumOffsets);
+}
+
+/** Returns the total size required for the Root Complex nodes and
+    updates the Node Indexer.
+
+    This function calculates the size required for the node group
+    and also populates the Node Indexer array with offsets for the
+    individual nodes.
+
+    @param [in]       NodeStartOffset Offset from the start of the
+                                      RHCT where this node group starts.
+    @param [in]       NodeList        Pointer to Root Complex node list.
+    @param [in]       NodeCount       Count of the Root Complex nodes.
+    @param [in]       NumOffsets      Number of offsets in Hart Info node.
+    @param [in, out]  NodeIndexer     Pointer to the next Node Indexer.
+
+    @retval Total size of the Root Complex nodes.
+**/
+STATIC
+UINT64
+GetSizeofHartInfoNodes (
+  IN      CONST UINT32                              NodeStartOffset,
+  IN      CONST CM_RISCV_RINTC_INFO                 *NodeList,
+  IN            UINT32                              NodeCount,
+  IN            UINT32                              NumOffsets,
+  IN OUT        RHCT_NODE_INDEXER          **CONST  NodeIndexer
+  )
+{
+  UINT64  Size;
+
+  ASSERT (NodeList != NULL);
+
+  Size = 0;
+  while (NodeCount-- != 0) {
+    (*NodeIndexer)->Object = (VOID *)NodeList;
+    (*NodeIndexer)->Offset = (UINT32)(Size + NodeStartOffset);
+    DEBUG (
+      (
+       DEBUG_INFO,
+       "RHCT: Node Indexer = %p, Object = %p,"
+       " Offset = 0x%x\n",
+       *NodeIndexer,
+       (*NodeIndexer)->Object,
+       (*NodeIndexer)->Offset
+      )
+      );
+
+    Size += GetHartInfoSize (NumOffsets);
+    (*NodeIndexer)++;
+    NodeList++;
+  }
+
+  return Size;
+}
+
+/** Update the CMO Node Information.
+
+    @param [in]     This             Pointer to the table Generator.
+    @param [in]     CfgMgrProtocol   Pointer to the Configuration Manager
+                                     Protocol Interface.
+    @param [in]     AcpiTableInfo    Pointer to the ACPI table info structure.
+    @param [in]     Rhct             Pointer to RHCT table structure.
+    @param [in]     NodesStartOffset Offset for the start of the ITS Group
+                                     Nodes.
+    @param [in]     NodeList         Pointer to an array of ITS Group Node
+                                     Objects.
+    @param [in]     NodeCount        Number of ITS Group Node Objects.
+
+    @retval EFI_SUCCESS           Table generated successfully.
+    @retval EFI_INVALID_PARAMETER A parameter is invalid.
+    @retval EFI_NOT_FOUND         The required object was not found.
+**/
+STATIC
+EFI_STATUS
+AddCmoNodes (
+  IN  CONST ACPI_TABLE_GENERATOR                  *CONST  This,
+  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST  CfgMgrProtocol,
+  IN  CONST CM_STD_OBJ_ACPI_TABLE_INFO            *CONST  AcpiTableInfo,
+  IN  CONST EFI_ACPI_6_6_RISCV_HART_CAPABILITIES_TABLE    *Rhct,
+  IN  CONST UINT32                                        NodesStartOffset,
+  IN  CONST CM_RISCV_CMO_NODE                             *NodeList,
+  IN        UINT32                                        NodeCount
+  )
+{
+  EFI_ACPI_6_6_RISCV_RHCT_CMO_NODE  *CmoNode;
+  EFI_STATUS                        Status;
+  UINT64                            NodeLength;
+
+  ASSERT (Rhct != NULL);
+
+  CmoNode = (EFI_ACPI_6_6_RISCV_RHCT_CMO_NODE *)((UINT8 *)Rhct + NodesStartOffset);
+
+  while (NodeCount-- != 0) {
+    NodeLength = GetCmoNodeSize (NodeList);
+    if (NodeLength > MAX_UINT16) {
+      Status = EFI_INVALID_PARAMETER;
+      DEBUG (
+        (
+         DEBUG_ERROR,
+         "ERROR: RHCT: ITS Id Array Node length 0x%lx > MAX_UINT16."
+         " Status = %r\n",
+         NodeLength,
+         Status
+        )
+        );
+      return Status;
+    }
+
+    // Populate the node header
+    CmoNode->Node.Type     = EFI_ACPI_RHCT_TYPE_CMO_NODE;
+    CmoNode->Node.Length   = (UINT16)NodeLength;
+    CmoNode->Node.Revision = 1;
+
+    // RHCT specific data
+    CmoNode->CbomBlockSize = NodeList->CbomBlockSize;
+    CmoNode->CbopBlockSize = NodeList->CbopBlockSize;
+    CmoNode->CbozBlockSize = NodeList->CbozBlockSize;
+    NodeList++;
+  } // RHCT Group Node
+
+  return EFI_SUCCESS;
+}
+
+/** Update the ISA Node Information.
+
+    @param [in]     This              Pointer to the table Generator.
+    @param [in]     CfgMgrProtocol    Pointer to the Configuration Manager
+                                      Protocol Interface.
+    @param [in]     AcpiTableInfo     Pointer to the ACPI table info structure.
+    @param [in]     Rhct              Pointer to RHCT table structure.
+    @param [in]     NodesStartOffset  Node start offset.
+    @param [in]     IsaString         RISC-V ISA string.
+
+    @retval EFI_SUCCESS           Table generated successfully.
+    @retval EFI_INVALID_PARAMETER A parameter is invalid.
+    @retval EFI_NOT_FOUND         The required object was not found.
+**/
+STATIC
+EFI_STATUS
+AddIsaStringNode (
+  IN  CONST ACPI_TABLE_GENERATOR                  *CONST  This,
+  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST  CfgMgrProtocol,
+  IN  CONST CM_STD_OBJ_ACPI_TABLE_INFO            *CONST  AcpiTableInfo,
+  IN  CONST EFI_ACPI_6_6_RISCV_HART_CAPABILITIES_TABLE    *Rhct,
+  IN  CONST UINT32                                        NodesStartOffset,
+  IN  CONST CHAR8                                         *IsaString
+  )
+{
+  EFI_ACPI_6_6_RISCV_RHCT_ISA_NODE  *IsaStringNode;
+  EFI_STATUS                        Status;
+  UINT64                            NodeLength;
+  UINT16                            IsaLength;
+  UINT16                            *TgtIsaLength;
+  CHAR8                             *TgtIsaString;
+
+  ASSERT (Rhct != NULL);
+
+  IsaStringNode = (EFI_ACPI_6_6_RISCV_RHCT_ISA_NODE *)((UINT8 *)Rhct + NodesStartOffset);
+
+  NodeLength = GetIsaStringNodeSize (IsaString);
+  if (NodeLength > MAX_UINT16) {
+    Status = EFI_INVALID_PARAMETER;
+    DEBUG (
+      (
+       DEBUG_ERROR,
+       "ERROR: RHCT: ISA Node length 0x%lx > MAX_UINT16."
+       " Status = %r\n",
+       NodeLength,
+       Status
+      )
+      );
+    return Status;
+  }
+
+  // Populate the node header
+  IsaStringNode->Node.Type     = EFI_ACPI_RHCT_TYPE_ISA_NODE;
+  IsaStringNode->Node.Length   = (UINT16)NodeLength;
+  IsaStringNode->Node.Revision = 1;
+
+  TgtIsaString  = (CHAR8 *)IsaStringNode + sizeof (EFI_ACPI_6_6_RISCV_RHCT_ISA_NODE);
+  TgtIsaLength  = (UINT16 *)((CHAR8 *)IsaStringNode + sizeof (EFI_ACPI_6_6_RISCV_RHCT_NODE));
+  IsaLength     = AsciiStrSize (IsaString) + 1;
+  *TgtIsaLength = IsaLength;
+  Status        = AsciiStrCpyS (
+                    TgtIsaString,
+                    IsaLength,
+                    IsaString
+                    );
+  DEBUG ((DEBUG_INFO, "%a: TgtIsaString = %a, IsaLength = %d\n", __func__, TgtIsaString, IsaLength));
+  return EFI_SUCCESS;
+}
+
+/** Update the Hart Info Node Information.
+
+    @param [in]     This             Pointer to the table Generator.
+    @param [in]     CfgMgrProtocol   Pointer to the Configuration Manager
+                                     Protocol Interface.
+    @param [in]     AcpiTableInfo    Pointer to the ACPI table info structure.
+    @param [in]     Rhct             Pointer to RHCT table structure.
+    @param [in]     NodesStartOffset Offset for the start of the ITS Group
+                                     Nodes.
+    @param [in]     NumOffsets       Number of offsets.
+    @param [in]     Offsets          Array of offsets in Hart Info node.
+    @param [in]     NodeList         Pointer to an array of ITS Group Node
+                                     Objects.
+    @param [in]     NodeCount        Number of ITS Group Node Objects.
+
+    @retval EFI_SUCCESS           Added Hart Info node successfully.
+    @retval EFI_INVALID_PARAMETER A parameter is invalid.
+**/
+STATIC
+EFI_STATUS
+AddHartInfoNodes (
+  IN  CONST ACPI_TABLE_GENERATOR                  *CONST  This,
+  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST  CfgMgrProtocol,
+  IN  CONST CM_STD_OBJ_ACPI_TABLE_INFO            *CONST  AcpiTableInfo,
+  IN  CONST EFI_ACPI_6_6_RISCV_HART_CAPABILITIES_TABLE    *Rhct,
+  IN  CONST UINT32                                        NodesStartOffset,
+  IN        UINT32                                        NumOffsets,
+  IN        UINT32                                        *Offsets,
+  IN  CONST CM_RISCV_RINTC_INFO                           *NodeList,
+  IN        UINT32                                        NodeCount
+  )
+{
+  EFI_ACPI_6_6_RISCV_RHCT_HART_INFO_NODE  *HartInfoNode;
+  EFI_STATUS                              Status;
+  UINT64                                  NodeLength;
+  UINTN                                   Idx;
+
+  ASSERT (Rhct != NULL);
+
+  HartInfoNode = (EFI_ACPI_6_6_RISCV_RHCT_HART_INFO_NODE *)((UINT8 *)Rhct + NodesStartOffset);
+
+  while (NodeCount-- != 0) {
+    NodeLength = GetHartInfoSize (NumOffsets);
+    if (NodeLength > MAX_UINT16) {
+      Status = EFI_INVALID_PARAMETER;
+      DEBUG (
+        (
+         DEBUG_ERROR,
+         "ERROR: RHCT: HartInfo Node length 0x%lx > MAX_UINT16."
+         " Status = %r\n",
+         NodeLength,
+         Status
+        )
+        );
+      return Status;
+    }
+
+    DEBUG ((DEBUG_INFO, "%a: HartInfoNode = 0x%llx, NodeList->AcpiProcessorUid=0x%x, NodeLength=%d\n", __func__, HartInfoNode, NodeList->AcpiProcessorUid, NodeLength));
+    // Populate the node header
+    HartInfoNode->Node.Type     = EFI_ACPI_RHCT_TYPE_HART_INFO_NODE;
+    HartInfoNode->Node.Length   = (UINT16)NodeLength;
+    HartInfoNode->Node.Revision = 1;
+
+    // RHCT specific data
+    HartInfoNode->NumOffsets = NumOffsets;
+    HartInfoNode->ACPICpuUid = NodeList->AcpiProcessorUid;
+    for (Idx = 0; Idx < NumOffsets; Idx++) {
+      HartInfoNode->Offsets[Idx] = Offsets[Idx];
+    }
+
+    HartInfoNode = (EFI_ACPI_6_6_RISCV_RHCT_HART_INFO_NODE *)((CHAR8 *)HartInfoNode + NodeLength);
+    NodeList++;
+  } // RHCT Group Node
+
+  return EFI_SUCCESS;
+}
+
+/** Construct the RHCT ACPI table.
+
+    This function invokes the Configuration Manager protocol interface
+    to get the required hardware information for generating the ACPI
+    table.
+
+    If this function allocates any resources then they must be freed
+    in the FreeXXXXTableResources function.
+
+    @param [in]  This           Pointer to the table generator.
+    @param [in]  AcpiTableInfo  Pointer to the ACPI Table Info.
+    @param [in]  CfgMgrProtocol Pointer to the Configuration Manager
+                                Protocol Interface.
+    @param [out] Table          Pointer to the constructed ACPI Table.
+
+    @retval EFI_SUCCESS           Table generated successfully.
+    @retval EFI_INVALID_PARAMETER A parameter is invalid.
+    @retval EFI_NOT_FOUND         The required object was not found.
+    @retval EFI_BAD_BUFFER_SIZE   The size returned by the Configuration
+                                  Manager is less than the Object size for the
+                                  requested object.
+**/
+STATIC
+EFI_STATUS
+EFIAPI
+BuildRhctTable (
+  IN  CONST ACPI_TABLE_GENERATOR                  *CONST  This,
+  IN  CONST CM_STD_OBJ_ACPI_TABLE_INFO            *CONST  AcpiTableInfo,
+  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST  CfgMgrProtocol,
+  OUT       EFI_ACPI_DESCRIPTION_HEADER          **CONST  Table
+  )
+{
+  EFI_ACPI_6_6_RISCV_HART_CAPABILITIES_TABLE  *Rhct;
+  CM_RISCV_ISA_STRING_NODE                    *IsaStringNode;
+  CM_RISCV_TIMER_INFO                         *TimerInfo;
+  CM_RISCV_RINTC_INFO                         *RintcInfoNodeList;
+  ACPI_RHCT_GENERATOR                         *Generator;
+  RHCT_NODE_INDEXER                           *NodeIndexer;
+  CM_RISCV_CMO_NODE                           *CmoNodeList;
+  EFI_STATUS                                  Status;
+  UINT64                                      TableSize, NodeSize;
+  UINT32                                      RhctNodeCount;
+  UINT32                                      IsaStringNodeCount;
+  UINT32                                      IsaStringOffset;
+  UINT32                                      CmoNodeCount, CmoOffset;
+  UINT32                                      HartInfoNodeCount, HartInfoOffset;
+  UINT32                                      TimerInfoCount;
+  UINT32                                      *Offsets;
+  UINTN                                       Idx;
+
+  // CHAR8  *IsaString;
+
+  ASSERT (This != NULL);
+  ASSERT (AcpiTableInfo != NULL);
+  ASSERT (CfgMgrProtocol != NULL);
+  ASSERT (Table != NULL);
+  ASSERT (AcpiTableInfo->TableGeneratorId == This->GeneratorID);
+  ASSERT (AcpiTableInfo->AcpiTableSignature == This->AcpiTableSignature);
+
+  if ((AcpiTableInfo->AcpiTableRevision < This->MinAcpiTableRevision) ||
+      (AcpiTableInfo->AcpiTableRevision > This->AcpiTableRevision))
+  {
+    DEBUG (
+      (
+       DEBUG_ERROR,
+       "ERROR: RHCT: Requested table revision = %d, is not supported."
+       "Supported table revision: Minimum = %d, Maximum = %d\n",
+       AcpiTableInfo->AcpiTableRevision,
+       This->MinAcpiTableRevision,
+       This->AcpiTableRevision
+      )
+      );
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Generator = (ACPI_RHCT_GENERATOR *)This;
+  *Table    = NULL;
+
+  Status = GetERiscVObjTimerInfo (
+             CfgMgrProtocol,
+             CM_NULL_TOKEN,
+             &TimerInfo,
+             &TimerInfoCount
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG (
+      (
+       DEBUG_ERROR,
+       "ERROR: RHCT: Failed to get Timer Info. Status = %r\n",
+       Status
+      )
+      );
+    goto error_handler;
+  }
+
+  // Get the Isa String node info
+  Status = GetERiscVObjIsaStringInfo (
+             CfgMgrProtocol,
+             CM_NULL_TOKEN,
+             &IsaStringNode,
+             &IsaStringNodeCount
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG (
+      (
+       DEBUG_ERROR,
+       "ERROR: RHCT: Failed to get ISA string Node Info. Status = %r\n",
+       Status
+      )
+      );
+    goto error_handler;
+  }
+
+  // Add the ISA string node count
+  RhctNodeCount = IsaStringNodeCount;
+
+  // Get the CMO node info
+  Status = GetERiscVObjCmoInfo (
+             CfgMgrProtocol,
+             CM_NULL_TOKEN,
+             &CmoNodeList,
+             &CmoNodeCount
+             );
+  if (EFI_ERROR (Status) && (Status != EFI_NOT_FOUND)) {
+    DEBUG (
+      (
+       DEBUG_ERROR,
+       "ERROR: RHCT: Failed to get CMO Node Info. Status = %r\n",
+       Status
+      )
+      );
+    goto error_handler;
+  }
+
+  // Add the CMO node count
+  RhctNodeCount += CmoNodeCount;
+
+  // Get the hart info node info
+  Status = GetERiscVObjRintcInfo (
+             CfgMgrProtocol,
+             CM_NULL_TOKEN,
+             &RintcInfoNodeList,
+             &HartInfoNodeCount
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG (
+      (
+       DEBUG_ERROR,
+       "ERROR: RHCT: Failed to get Hart Info Node Info. Status = %r\n",
+       Status
+      )
+      );
+    goto error_handler;
+  }
+
+  // Add the Root Complex node count
+  RhctNodeCount += HartInfoNodeCount;
+
+  // Allocate Node Indexer array
+  NodeIndexer = (RHCT_NODE_INDEXER *)AllocateZeroPool (
+                                       (sizeof (RHCT_NODE_INDEXER) *
+                                        RhctNodeCount)
+                                       );
+  if (NodeIndexer == NULL) {
+    Status = EFI_OUT_OF_RESOURCES;
+    DEBUG (
+      (
+       DEBUG_ERROR,
+       "ERROR: RHCT: Failed to allocate memory for Node Indexer" \
+       " Status = %r\n",
+       Status
+      )
+      );
+    goto error_handler;
+  }
+
+  DEBUG ((DEBUG_INFO, "INFO: NodeIndexer = %p\n", NodeIndexer));
+  Generator->RhctNodeCount = RhctNodeCount;
+  Generator->NodeIndexer   = NodeIndexer;
+
+  // Calculate the size of the RHCT table
+  TableSize = sizeof (EFI_ACPI_6_6_RISCV_HART_CAPABILITIES_TABLE);
+
+  if (IsaStringNodeCount > 0) {
+    IsaStringOffset = (UINT32)TableSize;
+    NodeSize        = GetIsaStringNodeSize (
+                        IsaStringNode->IsaString
+                        );
+    if (NodeSize > MAX_UINT32) {
+      Status = EFI_INVALID_PARAMETER;
+      DEBUG (
+        (
+         DEBUG_ERROR,
+         "ERROR: RHCT: Invalid Size of ISA string. Status = %r\n",
+         Status
+        )
+        );
+      goto error_handler;
+    }
+
+    TableSize += NodeSize;
+
+    DEBUG (
+      (
+       DEBUG_INFO,
+       " IsaStringNodeCount = %d\n" \
+       " IsaStringNodeSize = %d\n" \
+       " IsaStringOffset = %d\n",
+       IsaStringNodeCount,
+       NodeSize,
+       IsaStringOffset
+      )
+      );
+  }
+
+  // Named Component Nodes
+  if (CmoNodeCount > 0) {
+    CmoOffset = (UINT32)TableSize;
+    // Size of Named Component node list.
+    NodeSize = GetSizeofCmoNodes (
+                 CmoOffset,
+                 CmoNodeList,
+                 CmoNodeCount,
+                 &NodeIndexer
+                 );
+    if (NodeSize > MAX_UINT32) {
+      Status = EFI_INVALID_PARAMETER;
+      DEBUG (
+        (
+         DEBUG_ERROR,
+         "ERROR: RHCT: Invalid Size of CMO Nodes. Status = %r\n",
+         Status
+        )
+        );
+      goto error_handler;
+    }
+
+    TableSize += NodeSize;
+
+    DEBUG (
+      (
+       DEBUG_INFO,
+       " CmoNodeCount = %d\n" \
+       " CmoOffset = %d\n",
+       CmoNodeCount,
+       CmoOffset
+      )
+      );
+  }
+
+  // Hart Info Nodes
+  if (HartInfoNodeCount > 0) {
+    HartInfoOffset = (UINT32)TableSize;
+    // Size of Root Complex node list.
+    NodeSize = GetSizeofHartInfoNodes (
+                 HartInfoOffset,
+                 RintcInfoNodeList,
+                 HartInfoNodeCount,
+                 RhctNodeCount - HartInfoNodeCount,
+                 &NodeIndexer
+                 );
+    if (NodeSize > MAX_UINT32) {
+      Status = EFI_INVALID_PARAMETER;
+      DEBUG (
+        (
+         DEBUG_ERROR,
+         "ERROR: RHCT: Invalid Size of Hart Info Nodes. Status = %r\n",
+         Status
+        )
+        );
+      goto error_handler;
+    }
+
+    TableSize += NodeSize;
+
+    DEBUG (
+      (
+       DEBUG_INFO,
+       " HartInfoNodeCount = %d\n" \
+       " HartInfoOffset = %d\n",
+       HartInfoNodeCount,
+       HartInfoOffset
+      )
+      );
+  }
+
+  DEBUG (
+    (
+     DEBUG_INFO,
+     "INFO: RHCT:\n" \
+     " RhctNodeCount = %d\n" \
+     " TableSize = 0x%lx\n",
+     RhctNodeCount,
+     TableSize
+    )
+    );
+
+  if (TableSize > MAX_UINT32) {
+    Status = EFI_INVALID_PARAMETER;
+    DEBUG (
+      (
+       DEBUG_ERROR,
+       "ERROR: RHCT: RHCT Table Size 0x%lx > MAX_UINT32," \
+       " Status = %r\n",
+       TableSize,
+       Status
+      )
+      );
+    goto error_handler;
+  }
+
+  // Allocate the Buffer for RHCT table
+  *Table = (EFI_ACPI_DESCRIPTION_HEADER *)AllocateZeroPool (TableSize);
+  if (*Table == NULL) {
+    Status = EFI_OUT_OF_RESOURCES;
+    DEBUG (
+      (
+       DEBUG_ERROR,
+       "ERROR: RHCT: Failed to allocate memory for RHCT Table, Size = %d," \
+       " Status = %r\n",
+       TableSize,
+       Status
+      )
+      );
+    goto error_handler;
+  }
+
+  Rhct = (EFI_ACPI_6_6_RISCV_HART_CAPABILITIES_TABLE *)*Table;
+
+  DEBUG (
+    (
+     DEBUG_INFO,
+     "RHCT: Rhct = 0x%p TableSize = 0x%lx\n",
+     Rhct,
+     TableSize
+    )
+    );
+
+  Status = AddAcpiHeader (
+             CfgMgrProtocol,
+             This,
+             &Rhct->Header,
+             AcpiTableInfo,
+             (UINT32)TableSize
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG (
+      (
+       DEBUG_ERROR,
+       "ERROR: RHCT: Failed to add ACPI header. Status = %r\n",
+       Status
+      )
+      );
+    goto error_handler;
+  }
+
+  // Update RHCT table
+  Rhct->NumNodes   = RhctNodeCount;
+  Rhct->NodeOffset = sizeof (EFI_ACPI_6_6_RISCV_HART_CAPABILITIES_TABLE);
+  Rhct->TimerFreq  = TimerInfo->TimeBaseFrequency;
+  Rhct->Flags      = TimerInfo->TimerCannotWakeCpu ? EFI_ACPI_6_6_RHCT_FLAG_TIMER_CANNOT_WAKE_CPU : 0;
+
+  if (IsaStringNodeCount > 0) {
+    Status = AddIsaStringNode (
+               This,
+               CfgMgrProtocol,
+               AcpiTableInfo,
+               Rhct,
+               IsaStringOffset,
+               IsaStringNode->IsaString
+               );
+    if (EFI_ERROR (Status)) {
+      DEBUG (
+        (
+         DEBUG_ERROR,
+         "ERROR: RHCT: Failed to add ISA string Node. Status = %r\n",
+         Status
+        )
+        );
+      goto error_handler;
+    }
+  }
+
+  if (CmoNodeCount > 0) {
+    Status = AddCmoNodes (
+               This,
+               CfgMgrProtocol,
+               AcpiTableInfo,
+               Rhct,
+               CmoOffset,
+               CmoNodeList,
+               CmoNodeCount
+               );
+    if (EFI_ERROR (Status)) {
+      DEBUG (
+        (
+         DEBUG_ERROR,
+         "ERROR: RHCT: Failed to add Named Component Node. Status = %r\n",
+         Status
+        )
+        );
+      goto error_handler;
+    }
+  }
+
+  Offsets = AllocateZeroPool (sizeof (UINT32) * (RhctNodeCount - HartInfoNodeCount));
+  Idx     = 0;
+  if (IsaStringNodeCount > 0) {
+    Offsets[Idx++] = IsaStringOffset;
+  }
+
+  if (CmoNodeCount > 0) {
+    Offsets[Idx++] = CmoOffset;
+  }
+
+  if (HartInfoNodeCount > 0) {
+    Status = AddHartInfoNodes (
+               This,
+               CfgMgrProtocol,
+               AcpiTableInfo,
+               Rhct,
+               HartInfoOffset,
+               RhctNodeCount - HartInfoNodeCount,
+               Offsets,
+               RintcInfoNodeList,
+               HartInfoNodeCount
+               );
+    if (EFI_ERROR (Status)) {
+      DEBUG (
+        (
+         DEBUG_ERROR,
+         "ERROR: RHCT: Failed to add Hart Info Node. Status = %r\n",
+         Status
+        )
+        );
+      goto error_handler;
+    }
+  }
+
+  return EFI_SUCCESS;
+
+error_handler:
+  if (Generator->NodeIndexer != NULL) {
+    FreePool (Generator->NodeIndexer);
+    Generator->NodeIndexer = NULL;
+  }
+
+  if (*Table != NULL) {
+    FreePool (*Table);
+    *Table = NULL;
+  }
+
+  return Status;
+}
+
+/** Free any resources allocated for constructing the RHCT
+
+  @param [in]      This           Pointer to the table generator.
+  @param [in]      AcpiTableInfo  Pointer to the ACPI Table Info.
+  @param [in]      CfgMgrProtocol Pointer to the Configuration Manager
+                                  Protocol Interface.
+  @param [in, out] Table          Pointer to the ACPI Table.
+
+  @retval EFI_SUCCESS           The resources were freed successfully.
+  @retval EFI_INVALID_PARAMETER The table pointer is NULL or invalid.
+**/
+STATIC
+EFI_STATUS
+FreeRhctTableResources (
+  IN      CONST ACPI_TABLE_GENERATOR                  *CONST  This,
+  IN      CONST CM_STD_OBJ_ACPI_TABLE_INFO            *CONST  AcpiTableInfo,
+  IN      CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST  CfgMgrProtocol,
+  IN OUT        EFI_ACPI_DESCRIPTION_HEADER          **CONST  Table
+  )
+{
+  ACPI_RHCT_GENERATOR  *Generator;
+
+  ASSERT (This != NULL);
+  ASSERT (AcpiTableInfo != NULL);
+  ASSERT (CfgMgrProtocol != NULL);
+  ASSERT (AcpiTableInfo->TableGeneratorId == This->GeneratorID);
+  ASSERT (AcpiTableInfo->AcpiTableSignature == This->AcpiTableSignature);
+
+  Generator = (ACPI_RHCT_GENERATOR *)This;
+
+  // Free any memory allocated by the generator
+  if (Generator->NodeIndexer != NULL) {
+    FreePool (Generator->NodeIndexer);
+    Generator->NodeIndexer = NULL;
+  }
+
+  if ((Table == NULL) || (*Table == NULL)) {
+    DEBUG ((DEBUG_ERROR, "ERROR: RHCT: Invalid Table Pointer\n"));
+    ASSERT ((Table != NULL) && (*Table != NULL));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  FreePool (*Table);
+  *Table = NULL;
+  return EFI_SUCCESS;
+}
+
+/** The RHCT Table Generator revision.
+*/
+#define RHCT_GENERATOR_REVISION  CREATE_REVISION (1, 0)
+
+/** The interface for the MADT Table Generator.
+*/
+STATIC
+ACPI_RHCT_GENERATOR  RhctGenerator = {
+  // ACPI table generator header
+  {
+    // Generator ID
+    CREATE_STD_ACPI_TABLE_GEN_ID (EStdAcpiTableIdRhct),
+    // Generator Description
+    L"ACPI.STD.RHCT.GENERATOR",
+    // ACPI Table Signature
+    EFI_ACPI_6_6_RISCV_HART_CAPABILITIES_TABLE_SIGNATURE,
+    // ACPI Table Revision supported by this Generator
+    1,
+    // Minimum supported ACPI Table Revision
+    1,
+    // Creator ID
+    TABLE_GENERATOR_CREATOR_ID_RISCV,
+    // Creator Revision
+    RHCT_GENERATOR_REVISION,
+    // Build Table function
+    BuildRhctTable,
+    // Free Resource function
+    FreeRhctTableResources,
+    // Extended build function not needed
+    NULL,
+    // Extended build function not implemented by the generator.
+    // Hence extended free resource function is not required.
+    NULL
+  },
+
+  // RHCT Generator private data
+
+  // Rhct Node count
+  0,
+  // Pointer to Rhct node indexer
+  NULL
+};
+
+/** Register the Generator with the ACPI Table Factory.
+
+    @param [in]  ImageHandle  The handle to the image.
+    @param [in]  SystemTable  Pointer to the System Table.
+
+    @retval EFI_SUCCESS           The Generator is registered.
+    @retval EFI_INVALID_PARAMETER A parameter is invalid.
+    @retval EFI_ALREADY_STARTED   The Generator for the Table ID
+                                  is already registered.
+**/
+EFI_STATUS
+EFIAPI
+AcpiRhctLibConstructor (
+  IN  EFI_HANDLE        ImageHandle,
+  IN  EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  EFI_STATUS  Status;
+
+  Status = RegisterAcpiTableGenerator (&RhctGenerator.Header);
+  DEBUG ((DEBUG_INFO, "RHCT: Register Generator. Status = %r\n", Status));
+  ASSERT_EFI_ERROR (Status);
+  return Status;
+}
+
+/** Deregister the Generator from the ACPI Table Factory.
+
+    @param [in]  ImageHandle  The handle to the image.
+    @param [in]  SystemTable  Pointer to the System Table.
+
+    @retval EFI_SUCCESS           The Generator is deregistered.
+    @retval EFI_INVALID_PARAMETER A parameter is invalid.
+    @retval EFI_NOT_FOUND         The Generator is not registered.
+**/
+EFI_STATUS
+EFIAPI
+AcpiRhctLibDestructor (
+  IN  EFI_HANDLE        ImageHandle,
+  IN  EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  EFI_STATUS  Status;
+
+  Status = DeregisterAcpiTableGenerator (&RhctGenerator.Header);
+  DEBUG ((DEBUG_INFO, "Rhct: Deregister Generator. Status = %r\n", Status));
+  ASSERT_EFI_ERROR (Status);
+  return Status;
+}

--- a/DynamicTablesPkg/Library/Acpi/RiscV/AcpiRhctLibRiscV/RhctGenerator.h
+++ b/DynamicTablesPkg/Library/Acpi/RiscV/AcpiRhctLibRiscV/RhctGenerator.h
@@ -1,0 +1,44 @@
+/** @file
+
+  Copyright (c) 2024, Ventana Micro Systems Inc. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+  @par Glossary:
+    - Cm or CM   - Configuration Manager
+    - Obj or OBJ - Object
+    - Std or STD - Standard
+**/
+
+#ifndef RHCT_GENERATOR_H_
+#define RHCT_GENERATOR_H_
+
+#pragma pack(1)
+
+/** A structure that describes the Node indexer
+    used for indexing the RHCT nodes.
+*/
+typedef struct RhctNodeIndexer {
+  /// Index token for the Node
+  CM_OBJECT_TOKEN    Token;
+  /// Pointer to the node
+  VOID               *Object;
+  /// Node offset from the start of the RHCT table
+  UINT32             Offset;
+} RHCT_NODE_INDEXER;
+
+typedef struct AcpiRhctGenerator {
+  /// ACPI Table generator header
+  ACPI_TABLE_GENERATOR    Header;
+
+  // RHCT Generator private data
+
+  /// RHCT node count
+  UINT32                  RhctNodeCount;
+  /// Pointer to the node indexer array
+  RHCT_NODE_INDEXER       *NodeIndexer;
+} ACPI_RHCT_GENERATOR;
+
+#pragma pack()
+
+#endif // RHCT_GENERATOR_H_

--- a/DynamicTablesPkg/Library/Acpi/RiscV/AcpiSsdtPlicAplicLib/AcpiSsdtPlicAplicLib.inf
+++ b/DynamicTablesPkg/Library/Acpi/RiscV/AcpiSsdtPlicAplicLib/AcpiSsdtPlicAplicLib.inf
@@ -1,0 +1,30 @@
+## @file
+# Ssdt PLIC/APLIC Generator
+#
+#  Copyright (c) 2024, Ventana Micro Systems Inc. All rights reserved.<BR>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION    = 0x0001001B
+  BASE_NAME      = SsdtPlicAplicLib
+  FILE_GUID      = 5f9983fc-7dd3-552c-8580-d6d5b4a9a40e
+  VERSION_STRING = 1.0
+  MODULE_TYPE    = DXE_DRIVER
+  LIBRARY_CLASS  = NULL|DXE_DRIVER
+  CONSTRUCTOR    = AcpiSsdtPlicAplicLibConstructor
+  DESTRUCTOR     = AcpiSsdtPlicAplicLibDestructor
+
+[Sources]
+  SsdtPlicAplicGenerator.c
+
+[Packages]
+  DynamicTablesPkg/DynamicTablesPkg.dec
+  EmbeddedPkg/EmbeddedPkg.dec
+  MdePkg/MdePkg.dec
+
+[LibraryClasses]
+  AcpiHelperLib
+  AmlLib
+  BaseLib

--- a/DynamicTablesPkg/Library/Acpi/RiscV/AcpiSsdtPlicAplicLib/SsdtPlicAplicGenerator.c
+++ b/DynamicTablesPkg/Library/Acpi/RiscV/AcpiSsdtPlicAplicLib/SsdtPlicAplicGenerator.c
@@ -1,0 +1,578 @@
+/** @file
+  RISC-V SSDT PLIC/APLIC namespace Generator.
+
+  Copyright (c) 2024, Ventana Micro Systems Inc. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Library/AcpiLib.h>
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Protocol/AcpiTable.h>
+
+// Module specific include files.
+#include <AcpiTableGenerator.h>
+#include <ConfigurationManagerObject.h>
+#include <ConfigurationManagerHelper.h>
+#include <Library/AcpiHelperLib.h>
+#include <Library/TableHelperLib.h>
+#include <Library/AmlLib/AmlLib.h>
+#include <Protocol/ConfigurationManagerProtocol.h>
+
+// _SB scope of the AML namespace.
+#define SB_SCOPE  "\\_SB_"
+
+/** RISC-V SSDT PLIC/APLIC namespace device Generator.
+
+Requirements:
+  The following Configuration Manager Object(s) are used by
+  this Generator:
+  - ERiscVObjAplicInfo
+  - ERiscVObjPlicInfo
+*/
+
+/** This macro expands to a function that retrieves the APLIC
+    Information from the Configuration Manager.
+*/
+GET_OBJECT_LIST (
+  EObjNameSpaceRiscV,
+  ERiscVObjAplicInfo,
+  CM_RISCV_APLIC_INFO
+  );
+
+/** This macro expands to a function that retrieves the PLIC
+    Information from the Configuration Manager.
+*/
+
+GET_OBJECT_LIST (
+  EObjNameSpaceRiscV,
+  ERiscVObjPlicInfo,
+  CM_RISCV_PLIC_INFO
+  );
+
+/** Generate a PLIC/APLIC device.
+
+  @param [in]       Generator       The SSDT PlicAplic generator.
+  @param [in]       CfgMgrProtocol  Pointer to the Configuration Manager
+                                    Protocol interface.
+  @param [in]  BaseAddress      MMIO base of the PLIC/APLIC device.
+  @param [in]  Size             MMIO size of the PLIC/APLIC device.
+  @param [in]  GsiBase          GSI Base of the PLIC/APLIC device.
+  @param [in]  Uid              Unique Id of the PlicAplic device.
+  @param [in]  Hid              HID/CID of the interrupt controller device.
+  @param [in, out]  RootNode        RootNode of the AML tree to populate.
+
+  @retval EFI_SUCCESS             The function completed successfully.
+  @retval EFI_INVALID_PARAMETER   Invalid parameter.
+  @retval EFI_OUT_OF_RESOURCES    Could not allocate memory.
+**/
+STATIC
+EFI_STATUS
+EFIAPI
+GeneratePlicAplicDevice (
+  IN      CONST ACPI_TABLE_GENERATOR                          *Generator,
+  IN      CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST  CfgMgrProtocol,
+  IN            UINT32                                        BaseAddress,
+  IN            UINT32                                        Size,
+  IN            UINT32                                        GsiBase,
+  IN            UINT32                                        Uid,
+  IN            CHAR8                                         *Hid,
+  IN  OUT       AML_ROOT_NODE_HANDLE                          *RootNode
+  )
+{
+  AML_OBJECT_NODE_HANDLE  ScopeNode;
+  AML_OBJECT_NODE_HANDLE  IcNode;
+  AML_OBJECT_NODE_HANDLE  CrsNode;
+  EFI_STATUS              Status;
+  CHAR8                   AslName[AML_NAME_SEG_SIZE + 1];
+
+  ASSERT (Generator != NULL);
+  ASSERT (CfgMgrProtocol != NULL);
+  ASSERT (RootNode != NULL);
+
+  IcNode = NULL;
+
+  // ASL: Scope (\_SB) {}
+  Status = AmlCodeGenScope (SB_SCOPE, RootNode, &ScopeNode);
+  if (EFI_ERROR (Status)) {
+    ASSERT (0);
+    return Status;
+  }
+
+  // Write the name of the PCI device.
+  CopyMem (AslName, "ICxx", AML_NAME_SEG_SIZE + 1);
+  AslName[AML_NAME_SEG_SIZE - 2] = AsciiFromHex (Uid & 0xFF);
+
+  // ASL: Device (ICxx) {}
+  Status = AmlCodeGenDevice (AslName, ScopeNode, &IcNode);
+  if (EFI_ERROR (Status)) {
+    ASSERT (0);
+    return Status;
+  }
+
+  // ASL: Name (_UID, <Uid>)
+  Status = AmlCodeGenNameInteger ("_UID", Uid, IcNode, NULL);
+  if (EFI_ERROR (Status)) {
+    ASSERT (0);
+    return Status;
+  }
+
+  Status = AmlCodeGenNameString (
+             "_HID",
+             Hid,
+             IcNode,
+             NULL
+             );
+  if (EFI_ERROR (Status)) {
+    ASSERT (0);
+    return Status;
+  }
+
+  // ASL: Name (_CRS, ResourceTemplate () {})
+  Status = AmlCodeGenNameResourceTemplate ("_CRS", IcNode, &CrsNode);
+  if (EFI_ERROR (Status)) {
+    ASSERT (0);
+    return Status;
+  }
+
+  Status = AmlCodeGenRdMemory32Fixed (TRUE, BaseAddress, Size, CrsNode, NULL);
+  if (EFI_ERROR (Status)) {
+    ASSERT (0);
+    return Status;
+  }
+
+  Status = AmlCodeGenNameInteger ("_GSB", GsiBase, IcNode, NULL);
+  if (EFI_ERROR (Status)) {
+    ASSERT (0);
+    return Status;
+  }
+
+  return Status;
+}
+
+/** Build an Ssdt table describing a PlicAplic device.
+
+  @param [in]  Generator        The SSDT PlicAplic generator.
+  @param [in]  CfgMgrProtocol   Pointer to the Configuration Manager
+                                Protocol interface.
+  @param [in]  AcpiTableInfo    Pointer to the ACPI table information.
+  @param [in]  BaseAddress      MMIO base of the PLIC/APLIC device.
+  @param [in]  Size             MMIO size of the PLIC/APLIC device.
+  @param [in]  GsiBase          GSI Base of the PLIC/APLIC device.
+  @param [in]  Hid              HID/CID of the interrupt controller device.
+  @param [in]  Uid              Unique Id of the PlicAplic device.
+  @param [out] Table            If success, contains the created SSDT table.
+
+  @retval EFI_SUCCESS             The function completed successfully.
+  @retval EFI_INVALID_PARAMETER   Invalid parameter.
+  @retval EFI_OUT_OF_RESOURCES    Could not allocate memory.
+**/
+STATIC
+EFI_STATUS
+EFIAPI
+BuildSsdtPlicAplicTable (
+  IN        ACPI_TABLE_GENERATOR                          *Generator,
+  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST  CfgMgrProtocol,
+  IN  CONST CM_STD_OBJ_ACPI_TABLE_INFO            *CONST  AcpiTableInfo,
+  IN        UINT32                                        BaseAddress,
+  IN        UINT32                                        Size,
+  IN        UINT32                                        GsiBase,
+  IN        CHAR8                                         *Hid,
+  IN        UINT32                                        Uid,
+  OUT       EFI_ACPI_DESCRIPTION_HEADER                   **Table
+  )
+{
+  AML_ROOT_NODE_HANDLE  RootNode;
+  EFI_STATUS            Status;
+  EFI_STATUS            Status1;
+
+  ASSERT (Generator != NULL);
+  ASSERT (CfgMgrProtocol != NULL);
+  ASSERT (Table != NULL);
+
+  // Create a new Ssdt table.
+  Status = AddSsdtAcpiHeader (
+             CfgMgrProtocol,
+             Generator,
+             AcpiTableInfo,
+             &RootNode
+             );
+  if (EFI_ERROR (Status)) {
+    ASSERT (0);
+    return Status;
+  }
+
+  Status = GeneratePlicAplicDevice (
+             Generator,
+             CfgMgrProtocol,
+             BaseAddress,
+             Size,
+             GsiBase,
+             Uid,
+             Hid,
+             RootNode
+             );
+  if (EFI_ERROR (Status)) {
+    ASSERT (0);
+    goto exit_handler;
+  }
+
+  // Serialize the tree.
+  Status = AmlSerializeDefinitionBlock (
+             RootNode,
+             Table
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "ERROR: SSDT-PLIC: Failed to Serialize SSDT Table Data."
+      " Status = %r\n",
+      Status
+      ));
+  }
+
+exit_handler:
+  // Cleanup
+  Status1 = AmlDeleteTree (RootNode);
+  if (EFI_ERROR (Status1)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "ERROR: SSDT-PLIC: Failed to cleanup AML tree."
+      " Status = %r\n",
+      Status1
+      ));
+    // If Status was success but we failed to delete the AML Tree
+    // return Status1 else return the original error code, i.e. Status.
+    if (!EFI_ERROR (Status)) {
+      return Status1;
+    }
+  }
+
+  return Status;
+}
+
+/** Construct SSDT tables describing PLIC/APLIC devices
+
+  This function invokes the Configuration Manager protocol interface
+  to get the required hardware information for generating the ACPI
+  table.
+
+  If this function allocates any resources then they must be freed
+  in the FreeXXXXTableResourcesEx function.
+
+  @param [in]  This            Pointer to the ACPI table generator.
+  @param [in]  AcpiTableInfo   Pointer to the ACPI table information.
+  @param [in]  CfgMgrProtocol  Pointer to the Configuration Manager
+                               Protocol interface.
+  @param [out] Table           Pointer to a list of generated ACPI table(s).
+  @param [out] TableCount      Number of generated ACPI table(s).
+
+  @retval EFI_SUCCESS            Table generated successfully.
+  @retval EFI_BAD_BUFFER_SIZE    The size returned by the Configuration
+                                 Manager is less than the Object size for
+                                 the requested object.
+  @retval EFI_INVALID_PARAMETER  A parameter is invalid.
+  @retval EFI_NOT_FOUND          Could not find information.
+  @retval EFI_OUT_OF_RESOURCES   Could not allocate memory.
+  @retval EFI_UNSUPPORTED        Unsupported configuration.
+**/
+STATIC
+EFI_STATUS
+EFIAPI
+BuildSsdtPlicAplicTableEx (
+  IN  CONST ACPI_TABLE_GENERATOR                           *This,
+  IN  CONST CM_STD_OBJ_ACPI_TABLE_INFO             *CONST  AcpiTableInfo,
+  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL   *CONST  CfgMgrProtocol,
+  OUT       EFI_ACPI_DESCRIPTION_HEADER                    ***Table,
+  OUT       UINTN                                  *CONST  TableCount
+  )
+{
+  EFI_ACPI_DESCRIPTION_HEADER  **TableList;
+  ACPI_TABLE_GENERATOR         *Generator;
+  CM_RISCV_APLIC_INFO          *AplicInfo;
+  CM_RISCV_PLIC_INFO           *PlicInfo;
+  EFI_STATUS                   Status;
+  UINT32                       Index;
+  UINT32                       PlicCount, AplicCount, Count;
+  UINT32                       Uid;
+
+  ASSERT (This != NULL);
+  ASSERT (AcpiTableInfo != NULL);
+  ASSERT (CfgMgrProtocol != NULL);
+  ASSERT (Table != NULL);
+  ASSERT (TableCount != NULL);
+  ASSERT (AcpiTableInfo->TableGeneratorId == This->GeneratorID);
+  ASSERT (AcpiTableInfo->AcpiTableSignature == This->AcpiTableSignature);
+
+  *TableCount = 0;
+  Generator   = (ACPI_TABLE_GENERATOR *)This;
+
+  Status = GetERiscVObjAplicInfo (
+             CfgMgrProtocol,
+             CM_NULL_TOKEN,
+             &AplicInfo,
+             &AplicCount
+             );
+  if (EFI_ERROR (Status) && (Status != EFI_NOT_FOUND)) {
+    ASSERT (0);
+    return Status;
+  } else if (Status == EFI_NOT_FOUND) {
+    Status = GetERiscVObjPlicInfo (
+               CfgMgrProtocol,
+               CM_NULL_TOKEN,
+               &PlicInfo,
+               &PlicCount
+               );
+    if (EFI_ERROR (Status) && (Status != EFI_NOT_FOUND)) {
+      ASSERT (0);
+      return Status;
+    }
+  }
+
+  Count = (AplicCount != 0) ? AplicCount : PlicCount;
+
+  ASSERT (Count != 0);
+
+  // Allocate a table to store pointers to the SSDT tables.
+  TableList = (EFI_ACPI_DESCRIPTION_HEADER **)
+              AllocateZeroPool (
+                (sizeof (EFI_ACPI_DESCRIPTION_HEADER *) * Count)
+                );
+  if (TableList == NULL) {
+    Status = EFI_OUT_OF_RESOURCES;
+    DEBUG ((
+      DEBUG_ERROR,
+      "ERROR: SSDT-PLIC-APLIC: Failed to allocate memory for Table List."
+      " Status = %r\n",
+      Status
+      ));
+    return Status;
+  }
+
+  // Setup the table list early so that appropriate cleanup
+  // can be done in case of failure.
+  *Table = TableList;
+
+  for (Index = 0; Index < Count; Index++) {
+    Uid = Index;
+    if (AplicCount != 0) {
+      // Build a SSDT table describing the APLIC devices.
+      Status = BuildSsdtPlicAplicTable (
+                 Generator,
+                 CfgMgrProtocol,
+                 AcpiTableInfo,
+                 AplicInfo[Index].AplicAddress,
+                 AplicInfo[Index].AplicSize,
+                 AplicInfo[Index].GsiBase,
+                 "RSCV0002",
+                 Uid,
+                 &TableList[Index]
+                 );
+      if (EFI_ERROR (Status)) {
+        DEBUG ((
+          DEBUG_ERROR,
+          "ERROR: SSDT-PLIC-APLIC: Failed to build associated SSDT table."
+          " Status = %r\n",
+          Status
+          ));
+        goto error_handler;
+      }
+    } else if (PlicCount != 0) {
+      // Build a SSDT table describing the APLIC devices.
+      Status = BuildSsdtPlicAplicTable (
+                 Generator,
+                 CfgMgrProtocol,
+                 AcpiTableInfo,
+                 PlicInfo[Index].PlicAddress,
+                 PlicInfo[Index].PlicSize,
+                 PlicInfo[Index].GsiBase,
+                 "RSCV0001",
+                 Uid,
+                 &TableList[Index]
+                 );
+      if (EFI_ERROR (Status)) {
+        DEBUG ((
+          DEBUG_ERROR,
+          "ERROR: SSDT-PLIC-APLIC: Failed to build associated SSDT table."
+          " Status = %r\n",
+          Status
+          ));
+        goto error_handler;
+      }
+    } else {
+      DEBUG ((
+        DEBUG_ERROR,
+        "ERROR: SSDT-PLIC-APLIC: Neither PLIC not APLIC found, Failed to"
+        " build associated SSDT table. Status = %r\n",
+        Status
+        ));
+      goto error_handler;
+    }
+
+    *TableCount += 1;
+  } // for
+
+error_handler:
+  // Note: Table list and Table count have been setup. The
+  // error handler does nothing here as the framework will invoke
+  // FreeSsdtPlicAplicTableEx () even on failure.
+  return Status;
+}
+
+/** Free any resources allocated for constructing the tables.
+
+  @param [in]      This           Pointer to the ACPI table generator.
+  @param [in]      AcpiTableInfo  Pointer to the ACPI Table Info.
+  @param [in]      CfgMgrProtocol Pointer to the Configuration Manager
+                                  Protocol Interface.
+  @param [in, out] Table          Pointer to an array of pointers
+                                  to ACPI Table(s).
+  @param [in]      TableCount     Number of ACPI table(s).
+
+  @retval EFI_SUCCESS           The resources were freed successfully.
+  @retval EFI_INVALID_PARAMETER The table pointer is NULL or invalid.
+**/
+STATIC
+EFI_STATUS
+EFIAPI
+FreeSsdtPlicAplicTableEx (
+  IN      CONST ACPI_TABLE_GENERATOR                   *CONST  This,
+  IN      CONST CM_STD_OBJ_ACPI_TABLE_INFO             *CONST  AcpiTableInfo,
+  IN      CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL   *CONST  CfgMgrProtocol,
+  IN OUT        EFI_ACPI_DESCRIPTION_HEADER          ***CONST  Table,
+  IN      CONST UINTN                                          TableCount
+  )
+{
+  EFI_ACPI_DESCRIPTION_HEADER  **TableList;
+  UINTN                        Index;
+
+  ASSERT (This != NULL);
+  ASSERT (AcpiTableInfo != NULL);
+  ASSERT (CfgMgrProtocol != NULL);
+  ASSERT (AcpiTableInfo->TableGeneratorId == This->GeneratorID);
+  ASSERT (AcpiTableInfo->AcpiTableSignature == This->AcpiTableSignature);
+
+  if ((Table == NULL)   ||
+      (*Table == NULL)  ||
+      (TableCount == 0))
+  {
+    DEBUG ((DEBUG_ERROR, "ERROR: SSDT-PCI: Invalid Table Pointer\n"));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  TableList = *Table;
+  for (Index = 0; Index < TableCount; Index++) {
+    if ((TableList[Index] != NULL) &&
+        (TableList[Index]->Signature ==
+         EFI_ACPI_6_3_SECONDARY_SYSTEM_DESCRIPTION_TABLE_SIGNATURE))
+    {
+      FreePool (TableList[Index]);
+    } else {
+      DEBUG ((
+        DEBUG_ERROR,
+        "ERROR: SSDT-PCI: Could not free SSDT table at index %d.",
+        Index
+        ));
+      return EFI_INVALID_PARAMETER;
+    }
+  } // for
+
+  // Free the table list.
+  FreePool (*Table);
+
+  return EFI_SUCCESS;
+}
+
+/** This macro defines the SSDT PlicAplic Table Generator revision.
+*/
+#define SSDT_PLIC_APLIC_GENERATOR_REVISION  CREATE_REVISION (1, 0)
+
+/** The interface for the RISC-V SSDT PLIC/APLIC Table Generator.
+*/
+STATIC
+CONST
+ACPI_TABLE_GENERATOR  SsdtPlicAplicGenerator = {
+  // Generator ID
+  CREATE_STD_ACPI_TABLE_GEN_ID (EStdAcpiTableIdSsdtPlicAplic),
+  // Generator Description
+  L"ACPI.STD.SSDT.PLIC.APLIC.GENERATOR",
+  // ACPI Table Signature
+  EFI_ACPI_6_3_SECONDARY_SYSTEM_DESCRIPTION_TABLE_SIGNATURE,
+  // ACPI Table Revision - Unused
+  0,
+  // Minimum ACPI Table Revision - Unused
+  0,
+  // Creator ID
+  TABLE_GENERATOR_CREATOR_ID_RISCV,
+  // Creator Revision
+  SSDT_PLIC_APLIC_GENERATOR_REVISION,
+  // Build table function. Use the extended version instead.
+  NULL,
+  // Free table function. Use the extended version instead.
+  NULL,
+  // Extended Build table function.
+  BuildSsdtPlicAplicTableEx,
+  // Extended free function.
+  FreeSsdtPlicAplicTableEx
+};
+
+/** Register the Generator with the ACPI Table Factory.
+
+  @param [in]  ImageHandle  The handle to the image.
+  @param [in]  SystemTable  Pointer to the System Table.
+
+  @retval EFI_SUCCESS           The Generator is registered.
+  @retval EFI_INVALID_PARAMETER A parameter is invalid.
+  @retval EFI_ALREADY_STARTED   The Generator for the Table ID
+                                is already registered.
+**/
+EFI_STATUS
+EFIAPI
+AcpiSsdtPlicAplicLibConstructor (
+  IN  EFI_HANDLE        ImageHandle,
+  IN  EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  EFI_STATUS  Status;
+
+  Status = RegisterAcpiTableGenerator (&SsdtPlicAplicGenerator);
+  DEBUG ((
+    DEBUG_INFO,
+    "SSDT-PLIC-APLIC: Register Generator. Status = %r\n",
+    Status
+    ));
+  ASSERT_EFI_ERROR (Status);
+  return Status;
+}
+
+/** Deregister the Generator from the ACPI Table Factory.
+
+  @param [in]  ImageHandle  The handle to the image.
+  @param [in]  SystemTable  Pointer to the System Table.
+
+  @retval EFI_SUCCESS           The Generator is deregistered.
+  @retval EFI_INVALID_PARAMETER A parameter is invalid.
+  @retval EFI_NOT_FOUND         The Generator is not registered.
+**/
+EFI_STATUS
+EFIAPI
+AcpiSsdtPlicAplicLibDestructor (
+  IN  EFI_HANDLE        ImageHandle,
+  IN  EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  EFI_STATUS  Status;
+
+  Status = DeregisterAcpiTableGenerator (&SsdtPlicAplicGenerator);
+  DEBUG ((
+    DEBUG_INFO,
+    "SSDT-PLIC-APLIC: Deregister Generator. Status = %r\n",
+    Status
+    ));
+  ASSERT_EFI_ERROR (Status);
+  return Status;
+}

--- a/DynamicTablesPkg/Library/Common/DynamicPlatRepoLib/DynamicPlatRepo.c
+++ b/DynamicTablesPkg/Library/Common/DynamicPlatRepoLib/DynamicPlatRepo.c
@@ -161,6 +161,13 @@ DynPlatRepoAddObject (
     }
 
     ObjList = &This->ArmCmObjList[ObjId];
+  } else if (EObjNameSpaceRiscV == NamespaceId) {
+    if (ObjId >= ERiscVObjMax) {
+      ASSERT (0);
+      return EFI_INVALID_PARAMETER;
+    }
+
+    ObjList = &This->RiscVCmObjList[ObjId];
   } else if (EObjNameSpaceArchCommon == NamespaceId) {
     if ((ObjId >= EArchCommonObjMax) ||
         ((CmObjDesc->Count > 1)  && (ObjId != EArchCommonObjCmRef)))
@@ -253,6 +260,14 @@ GroupCmObjNodes (
 
     ListHead = &This->ArmCmObjList[ObjIndex];
     ObjArray = &This->ArmCmObjArray[ObjIndex];
+  } else if (NamespaceId == EObjNameSpaceRiscV) {
+    if (ObjIndex >= ERiscVObjMax) {
+      ASSERT (0);
+      return EFI_INVALID_PARAMETER;
+    }
+
+    ListHead = &This->RiscVCmObjList[ObjIndex];
+    ObjArray = &This->RiscVCmObjArray[ObjIndex];
   } else if (NamespaceId == EObjNameSpaceArchCommon) {
     if (ObjIndex >= EArchCommonObjMax) {
       ASSERT (0);
@@ -396,6 +411,14 @@ DynamicPlatRepoFinalise (
     }
   } // for
 
+  for (ObjIndex = 0; ObjIndex < ERiscVObjMax; ObjIndex++) {
+    Status = GroupCmObjNodes (This, EObjNameSpaceRiscV, (UINT32)ObjIndex);
+    if (EFI_ERROR (Status)) {
+      ASSERT (0);
+      goto error_handler;
+    }
+  } // for
+
   for (ObjIndex = 0; ObjIndex < EArchCommonObjMax; ObjIndex++) {
     Status = GroupCmObjNodes (This, EObjNameSpaceArchCommon, (UINT32)ObjIndex);
     if (EFI_ERROR (Status)) {
@@ -458,6 +481,13 @@ DynamicPlatRepoGetObject (
     }
 
     Desc = &This->ArmCmObjArray[ObjId];
+  } else if (NamespaceId == EObjNameSpaceRiscV) {
+    if (ObjId >= ERiscVObjMax) {
+      ASSERT (0);
+      return EFI_INVALID_PARAMETER;
+    }
+
+    Desc = &This->RiscVCmObjArray[ObjId];
   } else if (NamespaceId == EObjNameSpaceArchCommon) {
     if ((ObjId >= EArchCommonObjMax) ||
         ((ObjId == EArchCommonObjCmRef) &&
@@ -534,6 +564,10 @@ DynamicPlatRepoInit (
     InitializeListHead (&Repo->ArmCmObjList[Index]);
   }
 
+  for (Index = 0; Index < ERiscVObjMax; Index++) {
+    InitializeListHead (&Repo->RiscVCmObjList[Index]);
+  }
+
   for (Index = 0; Index < EArchCommonObjMax; Index++) {
     InitializeListHead (&Repo->ArchCommonCmObjList[Index]);
   }
@@ -580,6 +614,47 @@ DynamicPlatRepoFreeArmObjects (
   // Free the arrays.
   CmObjDesc = DynPlatRepo->ArmCmObjArray;
   for (Index = 0; Index < EArmObjMax; Index++) {
+    Data = CmObjDesc[Index].Data;
+    if (Data != NULL) {
+      FreePool (Data);
+    }
+  } // for
+}
+
+/** Free RISC-V Namespace objects.
+
+  Free all the memory allocated for the Arm namespace objects in the
+  dynamic platform repository.
+
+  @param [in]  DynPlatRepo    The dynamic platform repository.
+
+**/
+STATIC
+VOID
+EFIAPI
+DynamicPlatRepoFreeRiscVObjects (
+  IN  DYNAMIC_PLATFORM_REPOSITORY_INFO  *DynPlatRepo
+  )
+{
+  UINT32             Index;
+  LIST_ENTRY         *ListHead;
+  CM_OBJ_DESCRIPTOR  *CmObjDesc;
+  VOID               *Data;
+
+  ASSERT (DynPlatRepo != NULL);
+
+  // Free the list of objects.
+  for (Index = 0; Index < ERiscVObjMax; Index++) {
+    // Free all the nodes with this object Id.
+    ListHead = &DynPlatRepo->RiscVCmObjList[Index];
+    while (!IsListEmpty (ListHead)) {
+      FreeCmObjNode ((CM_OBJ_NODE *)GetFirstNode (ListHead));
+    } // while
+  } // for
+
+  // Free the arrays.
+  CmObjDesc = DynPlatRepo->RiscVCmObjArray;
+  for (Index = 0; Index < ERiscVObjMax; Index++) {
     Data = CmObjDesc[Index].Data;
     if (Data != NULL) {
       FreePool (Data);
@@ -651,6 +726,7 @@ DynamicPlatRepoShutdown (
   }
 
   DynamicPlatRepoFreeArmObjects (DynPlatRepo);
+  DynamicPlatRepoFreeRiscVObjects (DynPlatRepo);
   DynamicPlatRepoFreeArchCommonObjects (DynPlatRepo);
 
   // Free the TokenMapper

--- a/DynamicTablesPkg/Library/Common/DynamicPlatRepoLib/DynamicPlatRepoInternal.h
+++ b/DynamicTablesPkg/Library/Common/DynamicPlatRepoLib/DynamicPlatRepoInternal.h
@@ -67,6 +67,15 @@ typedef struct DynamicPlatformRepositoryInfo {
   /// This array is populated when the Repo is finalized.
   CM_OBJ_DESCRIPTOR      ArmCmObjArray[EArmObjMax];
 
+  /// Link lists of CmObj from the RiscVNameSpace
+  /// that are added in the Transient state.
+  LIST_ENTRY             RiscVCmObjList[ERiscVObjMax];
+
+  /// Structure Members used in Finalized state.
+  /// An array of CmObj Descriptors from the RiscVNameSpace
+  /// This array is populated when the Repo is finalized.
+  CM_OBJ_DESCRIPTOR      RiscVCmObjArray[ERiscVObjMax];
+
   /// Link lists of CmObj from the ArchCommon Namespace
   /// that are added in the Transient state.
   LIST_ENTRY             ArchCommonCmObjList[EArchCommonObjMax];

--- a/DynamicTablesPkg/Library/Common/TableHelperLib/ConfigurationManagerObjectParser.c
+++ b/DynamicTablesPkg/Library/Common/TableHelperLib/ConfigurationManagerObjectParser.c
@@ -317,7 +317,8 @@ STATIC CONST CM_OBJ_PARSER  CmArmIdMappingParser[] = {
 */
 STATIC CONST CM_OBJ_PARSER  CmArchCommonGenericInterruptParser[] = {
   { "Interrupt", 4, "0x%x", NULL },
-  { "Flags",     4, "0x%x", NULL }
+  { "Flags",     4, "0x%x", NULL },
+  { "Phandle",   4, "0x%x", NULL }
 };
 
 /** A parser for EArchCommonObjProcHierarchyInfo.

--- a/DynamicTablesPkg/Library/Common/TableHelperLib/ConfigurationManagerObjectParser.c
+++ b/DynamicTablesPkg/Library/Common/TableHelperLib/ConfigurationManagerObjectParser.c
@@ -677,6 +677,93 @@ STATIC CONST CM_OBJ_PARSER  CmArchCommonTpm2InterfaceInfo[] = {
   { "Lasa",                      sizeof (UINT64),                                               "0x%llx", NULL    },
 };
 
+//////////// RISC-V///////////////////////////
+
+/** A parser for ERiscVObjRintcInfo.
+*/
+STATIC CONST CM_OBJ_PARSER  CmRiscVRintcInfoParser[] = {
+  { "Version",          1,                        "0x%x",   NULL },
+  { "Reserved",         1,                        "0x%x",   NULL },
+  { "Flags",            4,                        "0x%x",   NULL },
+  { "HartId",           8,                        "0x%llx", NULL },
+  { "AcpiProcessorUid", 4,                        "0x%x",   NULL },
+  { "ExtIntCId",        4,                        "0x%x",   NULL },
+  { "ImsicBaseAddress", 8,                        "0x%llx", NULL },
+  { "ImsicSize",        4,                        "0x%llx", NULL },
+  { "IntcPhandle",      4,                        "0x%llx", NULL },
+  { "ProximityDomain",  4,                        "0x%llx", NULL },
+  { "ClockDomain",      4,                        "0x%llx", NULL },
+  { "AffinityFlags",    4,                        "0x%llx", NULL },
+  { "CpcToken",         sizeof (CM_OBJECT_TOKEN), "0x%p",   NULL },
+};
+
+/** A parser for ERiscVObjImsicInfo.
+*/
+STATIC CONST CM_OBJ_PARSER  CmRiscVImsicInfoParser[] = {
+  { "Version",         1, "0x%x", NULL },
+  { "Reserved",        1, "0x%x", NULL },
+  { "Flags",           4, "0x%x", NULL },
+  { "NumSmodeIds",     2, "0x%x", NULL },
+  { "NumGmodeIds",     2, "0x%x", NULL },
+  { "GuestIndexBits",  1, "0x%x", NULL },
+  { "HartIndexBits",   1, "0x%x", NULL },
+  { "GroupIndexBits",  1, "0x%x", NULL },
+  { "GroupIndexShift", 1, "0x%x", NULL },
+};
+
+/** A parser for ERiscVObjAplicInfo.
+*/
+STATIC CONST CM_OBJ_PARSER  CmRiscVAplicInfoParser[] = {
+  { "Version",      1, "0x%x",  NULL },
+  { "AplicId",      1, "0x%x",  NULL },
+  { "Flags",        4, "0x%x",  NULL },
+  { "HardwareId",   8, "0x%lx", NULL },
+  { "NumIdcs",      2, "0x%x",  NULL },
+  { "NumSources",   2, "0x%x",  NULL },
+  { "GsiBase",      4, "0x%x",  NULL },
+  { "AplicAddress", 8, "0x%lx", NULL },
+  { "AplicSize",    4, "0x%x",  NULL },
+  { "Phandle",      4, "0x%x",  NULL },
+};
+
+/** A parser for ERiscVVObjPlicInfo.
+*/
+STATIC CONST CM_OBJ_PARSER  CmRiscVPlicInfoParser[] = {
+  { "Version",     1, "0x%x",  NULL },
+  { "PlicId",      1, "0x%x",  NULL },
+  { "HardwareId",  8, "0x%lx", NULL },
+  { "NumIrqs",     2, "0x%x",  NULL },
+  { "MaxPriority", 2, "0x%x",  NULL },
+  { "Flags",       4, "0x%x",  NULL },
+  { "PlicSize",    4, "0x%x",  NULL },
+  { "PlicAddress", 8, "0x%lx", NULL },
+  { "GsiBase",     4, "0x%x",  NULL },
+  { "Phandle",     4, "0x%x",  NULL },
+};
+
+/** A parser for ERiscVVObjCmoInfo.
+*/
+STATIC CONST CM_OBJ_PARSER  CmRiscVCmoInfoParser[] = {
+  { "CBOM Block Size", 1, "0x%x", NULL },
+  { "CBOP Block Size", 1, "0x%x", NULL },
+  { "CBOZ Block Size", 1, "0x%x", NULL },
+};
+
+/** A parser for ERiscVVObjMmuInfo.
+*/
+STATIC CONST CM_OBJ_PARSER  CmRiscVMmuInfoParser[] = {
+  { "MMU Type", 1, "0x%x", NULL },
+};
+
+/** A parser for ERiscVVObjTimerInfo.
+*/
+STATIC CONST CM_OBJ_PARSER  CmRiscVTimerInfoParser[] = {
+  { "Timer Can Not Wakeup CPU", 1, "0x%x",  NULL },
+  { "Timer Base Frequency",     8, "0x%lx", NULL },
+};
+
+//////////// RISC-V///////////////////////////
+
 /** A parser for Arch Common namespace objects.
 */
 STATIC CONST CM_OBJ_PARSER_ARRAY  ArchCommonNamespaceObjectParser[] = {
@@ -864,6 +951,21 @@ STATIC CONST CM_OBJ_PARSER_ARRAY  X64NamespaceObjectParser[] = {
   CM_PARSER_ADD_OBJECT (EX64ObjFadtResetBlockInfo,CmX64ObjFadtResetBlockInfoParser),
   CM_PARSER_ADD_OBJECT (EX64ObjFadtMiscInfo,      CmX64ObjFadtMiscInfoParser),
   CM_PARSER_ADD_OBJECT_RESERVED (EX64ObjMax)
+};
+
+/** A parser for RISC-V namespace objects.
+*/
+STATIC CONST CM_OBJ_PARSER_ARRAY  RiscVNamespaceObjectParser[] = {
+  CM_PARSER_ADD_OBJECT_RESERVED (ERiscVObjReserved),
+  CM_PARSER_ADD_OBJECT (ERiscVObjRintcInfo,              CmRiscVRintcInfoParser),
+  CM_PARSER_ADD_OBJECT (ERiscVObjImsicInfo,              CmRiscVImsicInfoParser),
+  CM_PARSER_ADD_OBJECT (ERiscVObjAplicInfo,              CmRiscVAplicInfoParser),
+  CM_PARSER_ADD_OBJECT (ERiscVObjPlicInfo,               CmRiscVPlicInfoParser),
+  CM_PARSER_ADD_OBJECT_RESERVED (ERiscVObjIsaStringInfo),
+  CM_PARSER_ADD_OBJECT (ERiscVObjCmoInfo,                CmRiscVCmoInfoParser),
+  CM_PARSER_ADD_OBJECT (ERiscVObjMmuInfo,                CmRiscVMmuInfoParser),
+  CM_PARSER_ADD_OBJECT (ERiscVObjTimerInfo,              CmRiscVTimerInfoParser),
+  CM_PARSER_ADD_OBJECT_RESERVED (ERiscVObjMax)
 };
 
 /** A parser for EStdObjCfgMgrInfo.
@@ -1164,6 +1266,21 @@ ParseCmObjDesc (
       }
 
       ParserArray = &ArmNamespaceObjectParser[ObjId];
+      break;
+
+    case EObjNameSpaceRiscV:
+      if (ObjId >= ERiscVObjMax) {
+        ASSERT (0);
+        return;
+      }
+
+      if (ObjId >= ARRAY_SIZE (RiscVNamespaceObjectParser)) {
+        DEBUG ((DEBUG_ERROR, "ObjId 0x%x is missing from the RiscVNamespaceObjectParser array\n", ObjId));
+        ASSERT (0);
+        return;
+      }
+
+      ParserArray = &RiscVNamespaceObjectParser[ObjId];
       break;
 
     case EObjNameSpaceArchCommon:

--- a/DynamicTablesPkg/Library/FdtHwInfoParserLib/FdtHwInfoParserLib.inf
+++ b/DynamicTablesPkg/Library/FdtHwInfoParserLib/FdtHwInfoParserLib.inf
@@ -47,6 +47,15 @@
   Arm/Gic/ArmGicRParser.c
   Arm/Gic/ArmGicRParser.h
 
+[Sources.RISCV64]
+  RiscV/RiscVFdtInterrupt.c
+  RiscV/RiscVFdtHwInfoParser.c
+  RiscV/Intc/RiscVIntcDispatcher.c
+  RiscV/Intc/RiscVIntcDispatcher.h
+  RiscV/Intc/RiscVIntcParser.c
+  RiscV/Intc/RiscVIntcParser.h
+  RiscV/HartInfo/RiscVHartInfoDispatcher.c
+
 [Packages.ARM, Packages.AARCH64]
   ArmPkg/ArmPkg.dec
 

--- a/DynamicTablesPkg/Library/FdtHwInfoParserLib/FdtUtility.h
+++ b/DynamicTablesPkg/Library/FdtHwInfoParserLib/FdtUtility.h
@@ -62,9 +62,11 @@
 #define DT_SPI_IRQ  (0U)
 #define DT_IRQ_IS_EDGE_TRIGGERED(x)  ((((x) & (BIT0 | BIT1)) != 0))
 #define DT_IRQ_IS_ACTIVE_LOW(x)      ((((x) & (BIT1 | BIT3)) != 0))
-#define IRQ_TYPE_OFFSET    (0U)
-#define IRQ_NUMBER_OFFSET  (1U)
-#define IRQ_FLAGS_OFFSET   (2U)
+#define IRQ_TYPE_OFFSET          (0U)
+#define IRQ_NUMBER_OFFSET        (1U)
+#define IRQ_FLAGS_OFFSET         (2U)
+#define RISCV_IRQ_NUMBER_OFFSET  (0U)
+#define RISCV_IRQ_FLAGS_OFFSET   (1U)
 
 /** Get the interrupt Id of an interrupt described in a fdt.
 

--- a/DynamicTablesPkg/Library/FdtHwInfoParserLib/Pci/PciConfigSpaceParser.c
+++ b/DynamicTablesPkg/Library/FdtHwInfoParserLib/Pci/PciConfigSpaceParser.c
@@ -432,6 +432,7 @@ ParseIrqMap (
     PciInterruptMapInfo[Index].PciInterrupt -= 1;
     Offset                                  += PCI_INTERRUPTS_CELLS * sizeof (UINT32);
 
+    PciInterruptMapInfo[Index].IntcInterrupt.Phandle = fdt32_to_cpu (*(UINT32 *)&Data[Offset]);
     // PHandle (skip it)
     Offset += sizeof (UINT32);
 

--- a/DynamicTablesPkg/Library/FdtHwInfoParserLib/Pci/PciConfigSpaceParser.c
+++ b/DynamicTablesPkg/Library/FdtHwInfoParserLib/Pci/PciConfigSpaceParser.c
@@ -441,8 +441,12 @@ ParseIrqMap (
     // Interrupt controller interrupt and flags
     PciInterruptMapInfo[Index].IntcInterrupt.Interrupt =
       FdtGetInterruptId ((UINT32 *)&Data[Offset]);
-    PciInterruptMapInfo[Index].IntcInterrupt.Flags =
-      FdtGetInterruptFlags ((UINT32 *)&Data[Offset]);
+    if (IntcCells > 1) {
+      PciInterruptMapInfo[Index].IntcInterrupt.Flags =
+        FdtGetInterruptFlags ((UINT32 *)&Data[Offset]);
+    } else {
+      PciInterruptMapInfo[Index].IntcInterrupt.Flags = 0x0;
+    }
   } // for
 
   PciInfo->Mapping[PciMappingTableInterrupt].ObjectId =

--- a/DynamicTablesPkg/Library/FdtHwInfoParserLib/RiscV/HartInfo/RiscVHartInfoDispatcher.c
+++ b/DynamicTablesPkg/Library/FdtHwInfoParserLib/RiscV/HartInfo/RiscVHartInfoDispatcher.c
@@ -1,0 +1,415 @@
+/** @file
+  RISC-V Hart Information dispatcher.
+
+  Copyright (c) 2024, Ventana Micro Systems Inc. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+  @par Reference(s):
+**/
+
+#include "FdtHwInfoParser.h"
+#include "CmObjectDescUtility.h"
+
+/** List of "compatible" property values for CPU nodes.
+
+  Any other "compatible" value is not supported by this module.
+*/
+STATIC CONST COMPATIBILITY_STR  CpuCompatibleStr[] = {
+  { "riscv" }
+};
+
+/** COMPATIBILITY_INFO structure for CPU nodes.
+*/
+STATIC CONST COMPATIBILITY_INFO  CpuCompatibleInfo = {
+  ARRAY_SIZE (CpuCompatibleStr),
+  CpuCompatibleStr
+};
+
+/** List of "compatible" property values for timer node.
+
+  Any other "compatible" value is not supported by this module.
+*/
+STATIC CONST COMPATIBILITY_STR  TimerCompatibleStr[] = {
+  { "riscv,timer" }
+};
+
+/** COMPATIBILITY_INFO structure for timer node.
+*/
+STATIC CONST COMPATIBILITY_INFO  TimerCompatibleInfo = {
+  ARRAY_SIZE (TimerCompatibleStr),
+  TimerCompatibleStr
+};
+
+/** Get compatible node in FDT
+
+  @param [in]  FdtParserHandle Pointer to device tree.
+  @param [in]  CompatInfo      Pointer to compatibility info.
+  @param [out] TargetNode      Pointer to target Node.
+
+  @retval TRUE                 The AplicNode is S-mode APLIC
+  @retval FALSE                The AplicNode is not S-mode APLIC
+**/
+STATIC
+EFI_STATUS
+FdtGetCompatNode (
+  IN  CONST FDT_HW_INFO_PARSER_HANDLE  FdtParserHandle,
+  IN  CONST VOID                       *CompatInfo,
+  OUT INT32                            *TargetNode
+  )
+{
+  INT32  Prev, Node;
+  VOID   *Fdt;
+
+  Fdt = FdtParserHandle->Fdt;
+
+  for (Prev = 0; ; Prev = Node) {
+    Node = fdt_next_node (Fdt, Prev, NULL);
+    if (Node < 0) {
+      return EFI_NOT_FOUND;
+    }
+
+    if (FdtNodeIsCompatible (Fdt, Node, CompatInfo)) {
+      *TargetNode = Node;
+      return EFI_SUCCESS;
+    }
+  }
+
+  return EFI_NOT_FOUND;
+}
+
+/** Get CMO block size
+
+  CMO block size in ACPI table is power of 2 value.
+
+  @param [in]  Val       CBO size.
+
+  @retval Ret            Exponent value when Val is represented in power of 2.
+**/
+STATIC
+UINT32
+CmoGetBlockSize (
+  UINT32  Val
+  )
+{
+  UINT32  Ret;
+
+  while (Val > 1) {
+    Ret++;
+    Val >>= 1;
+  }
+
+  return Ret;
+}
+
+/** Create CMO info structure if CMO extension present
+
+  Create CMO structure with CBOM, CBOP and CBOZ sizes.
+
+  @param [in]  FdtParserHandle    A handle to the parser instance.
+  @param [in]  CpusNode            cpus node.
+
+**/
+STATIC
+EFI_STATUS
+EFIAPI
+RiscVCmoInfoParser (
+  IN  CONST FDT_HW_INFO_PARSER_HANDLE  FdtParserHandle,
+  IN        INT32                      CpusNode
+  )
+{
+  CM_RISCV_CMO_NODE  CmoInfo;
+  CONST UINT32       *Prop;
+  EFI_STATUS         Status;
+  INT32              CpuNode, Len;
+  VOID               *Fdt;
+
+  Fdt     = FdtParserHandle->Fdt;
+  CpuNode = CpusNode;
+  Status  = FdtGetNextNamedNodeInBranch (Fdt, CpusNode, "cpu", &CpuNode);
+  if (EFI_ERROR (Status)) {
+    ASSERT (0);
+    if (Status == EFI_NOT_FOUND) {
+      // Should have found the node.
+      Status = EFI_ABORTED;
+    }
+
+    return Status;
+  }
+
+  // Parse the "cpu" node.
+  if (!FdtNodeIsCompatible (Fdt, CpuNode, &CpuCompatibleInfo)) {
+    ASSERT (0);
+    Status = EFI_ABORTED;
+    return Status;
+  }
+
+  ZeroMem (&CmoInfo, sizeof (CM_RISCV_CMO_NODE));
+  Prop = fdt_getprop (Fdt, CpuNode, "riscv,cbom-block-size", &Len);
+  if (Prop) {
+    CmoInfo.CbomBlockSize = CmoGetBlockSize (fdt32_to_cpu (ReadUnaligned32 ((const UINT32 *)Prop)));
+  } else {
+    DEBUG (
+      (
+       DEBUG_VERBOSE,
+       "%a: Failed to parse cpu node: riscv,cbom-block-size\n",
+       __func__
+      )
+      );
+    return EFI_NOT_FOUND;
+  }
+
+  Prop = fdt_getprop (Fdt, CpuNode, "riscv,cboz-block-size", &Len);
+  if (Prop) {
+    CmoInfo.CbozBlockSize = CmoGetBlockSize (fdt32_to_cpu (ReadUnaligned32 ((const UINT32 *)Prop)));
+  } else {
+    DEBUG (
+      (
+       DEBUG_VERBOSE,
+       "%a: Failed to parse cpu node: riscv,cboz-block-size\n",
+       __func__
+      )
+      );
+  }
+
+  Prop = fdt_getprop (Fdt, CpuNode, "riscv,cbop-block-size", &Len);
+  if (Prop) {
+    CmoInfo.CbopBlockSize = CmoGetBlockSize (fdt32_to_cpu (ReadUnaligned32 ((const UINT32 *)Prop)));
+  } else {
+    DEBUG (
+      (
+       DEBUG_VERBOSE,
+       "%a: Failed to parse cpu node: riscv,cbop-block-size\n",
+       __func__
+      )
+      );
+  }
+
+  // Add the CmObj to the Configuration Manager.
+  Status = AddSingleCmObj (
+             FdtParserHandle,
+             CREATE_CM_RISCV_OBJECT_ID (ERiscVObjCmoInfo),
+             &CmoInfo,
+             sizeof (CM_RISCV_CMO_NODE),
+             NULL
+             );
+  if (EFI_ERROR (Status)) {
+    ASSERT (0);
+  }
+
+  return Status;
+}
+
+/** Create ISA string Info structure
+
+  @param [in]  FdtParserHandle    A handle to the parser instance.
+  @param [in]  CpusNode           cpus node.
+**/
+STATIC
+EFI_STATUS
+EFIAPI
+RiscVIsaStringInfoParser (
+  IN  CONST FDT_HW_INFO_PARSER_HANDLE  FdtParserHandle,
+  IN        INT32                      CpusNode
+  )
+{
+  CM_RISCV_ISA_STRING_NODE  IsaStringInfo;
+  CONST UINT32              *Prop;
+  EFI_STATUS                Status;
+  INT32                     Len, CpuNode;
+  INT32                     AlignedLen;
+  VOID                      *Fdt;
+
+  Fdt     = FdtParserHandle->Fdt;
+  CpuNode = CpusNode;
+  Status  = FdtGetNextNamedNodeInBranch (Fdt, CpusNode, "cpu", &CpuNode);
+  if (EFI_ERROR (Status)) {
+    ASSERT (0);
+    if (Status == EFI_NOT_FOUND) {
+      // Should have found the node.
+      Status = EFI_ABORTED;
+    }
+
+    return Status;
+  }
+
+  // Parse the "cpu" node.
+  if (!FdtNodeIsCompatible (Fdt, CpuNode, &CpuCompatibleInfo)) {
+    ASSERT (0);
+    Status = EFI_ABORTED;
+    return Status;
+  }
+
+  ZeroMem (&IsaStringInfo, sizeof (CM_RISCV_ISA_STRING_NODE));
+  Prop = fdt_getprop (Fdt, CpuNode, "riscv,isa", &Len);
+  if (!Prop) {
+    DEBUG (
+      (
+       DEBUG_ERROR,
+       "%a: Failed to parse cpu node: riscv,isa\n",
+       __func__
+      )
+      );
+    ASSERT (0);
+    return EFI_ABORTED;
+  }
+
+  AlignedLen              = ALIGN_VALUE (Len, 2);
+  IsaStringInfo.IsaString = AllocateZeroPool (AlignedLen);
+  if (IsaStringInfo.IsaString == NULL) {
+    ASSERT (0);
+    return EFI_ABORTED;
+  }
+
+  Status = AsciiStrCpyS (
+             IsaStringInfo.IsaString,
+             Len,
+             (CHAR8 *)Prop
+             );
+  IsaStringInfo.Length = Len;
+  // Add the CmObj to the Configuration Manager.
+  Status = AddSingleCmObj (
+             FdtParserHandle,
+             CREATE_CM_RISCV_OBJECT_ID (ERiscVObjIsaStringInfo),
+             &IsaStringInfo,
+             AlignedLen,
+             NULL
+             );
+  if (EFI_ERROR (Status)) {
+    ASSERT (0);
+  }
+
+  //  FreePool(IsaStringInfo.IsaString);
+  return Status;
+}
+
+/** Create Timer Info structure.
+
+  Create Timer info structure with time base frequency and flag.
+
+  @param [in]  FdtParserHandle     A handle to the parser instance.
+  @param [in]  CpusNode            cpus node.
+**/
+STATIC
+EFI_STATUS
+EFIAPI
+RiscVTimerInfoParser (
+  IN  CONST FDT_HW_INFO_PARSER_HANDLE  FdtParserHandle,
+  IN        INT32                      CpusNode
+  )
+{
+  CM_RISCV_TIMER_INFO  TimerInfo;
+  CONST UINT64         *Prop;
+  EFI_STATUS           Status;
+  INT32                Len, TimerNode;
+  VOID                 *Fdt;
+
+  Fdt = FdtParserHandle->Fdt;
+
+  ZeroMem (&TimerInfo, sizeof (CM_RISCV_TIMER_INFO));
+  if (CpusNode < 0) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Prop = fdt_getprop (Fdt, CpusNode, "timebase-frequency", &Len);
+  if (Prop) {
+    TimerInfo.TimeBaseFrequency = fdt32_to_cpu (ReadUnaligned32 ((const UINT32 *)Prop));
+  } else {
+    DEBUG (
+      (
+       DEBUG_ERROR,
+       "%a: Failed to parse cpu node:timebase-frequency \n",
+       __func__
+      )
+      );
+    return EFI_NOT_FOUND;
+  }
+
+  Status = FdtGetCompatNode (FdtParserHandle, &TimerCompatibleInfo, &TimerNode);
+  if (!EFI_ERROR (Status)) {
+    Prop = fdt_getprop (Fdt, TimerNode, "riscv,timer-cannot-wake-cpu", &Len);
+    if (Prop) {
+      TimerInfo.TimerCannotWakeCpu = 1;
+    }
+  }
+
+  Status = AddSingleCmObj (
+             FdtParserHandle,
+             CREATE_CM_RISCV_OBJECT_ID (ERiscVObjTimerInfo),
+             &TimerInfo,
+             sizeof (CM_RISCV_TIMER_INFO),
+             NULL
+             );
+  if (EFI_ERROR (Status)) {
+    ASSERT (0);
+  }
+
+  return Status;
+}
+
+/** Hart Info dispatcher.
+
+  A parser parses a Device Tree to populate a specific CmObj type. None,
+  one or many CmObj can be created by the parser.
+  The created CmObj are then handed to the parser's caller through the
+  HW_INFO_ADD_OBJECT interface.
+  This can also be a dispatcher. I.e. a function that not parsing a
+  Device Tree but calling other parsers.
+
+  @param [in]  FdtParserHandle A handle to the parser instance.
+  @param [in]  FdtBranch       When searching for DT node name, restrict
+                               the search to this Device Tree branch.
+
+  @retval EFI_SUCCESS             The function completed successfully.
+  @retval EFI_ABORTED             An error occurred.
+  @retval EFI_INVALID_PARAMETER   Invalid parameter.
+  @retval EFI_NOT_FOUND           Not found.
+  @retval EFI_UNSUPPORTED         Unsupported.
+**/
+EFI_STATUS
+EFIAPI
+RiscVHartInfoDispatcher (
+  IN  CONST FDT_HW_INFO_PARSER_HANDLE  FdtParserHandle,
+  IN        INT32                      FdtBranch
+  )
+{
+  EFI_STATUS  Status;
+  INT32       CpusNode;
+  VOID        *Fdt;
+
+  if (FdtParserHandle == NULL) {
+    ASSERT (0);
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Fdt = FdtParserHandle->Fdt;
+
+  // The "cpus" node resides at the root of the DT. Fetch it.
+  CpusNode = fdt_path_offset (Fdt, "/cpus");
+  if (CpusNode < 0) {
+    return EFI_NOT_FOUND;
+  }
+
+  Status = RiscVCmoInfoParser (FdtParserHandle, CpusNode);
+  if (EFI_ERROR (Status)) {
+    // EFI_NOT_FOUND is not tolerated at this point.
+    ASSERT (0);
+    return Status;
+  }
+
+  Status = RiscVIsaStringInfoParser (FdtParserHandle, CpusNode);
+  if (EFI_ERROR (Status)) {
+    // EFI_NOT_FOUND is not tolerated at this point.
+    ASSERT (0);
+    return Status;
+  }
+
+  Status = RiscVTimerInfoParser (FdtParserHandle, CpusNode);
+  if (EFI_ERROR (Status)) {
+    // EFI_NOT_FOUND is not tolerated at this point.
+    ASSERT (0);
+    return Status;
+  }
+
+  return EFI_SUCCESS;
+}

--- a/DynamicTablesPkg/Library/FdtHwInfoParserLib/RiscV/HartInfo/RiscVHartInfoDispatcher.h
+++ b/DynamicTablesPkg/Library/FdtHwInfoParserLib/RiscV/HartInfo/RiscVHartInfoDispatcher.h
@@ -1,0 +1,42 @@
+/** @file
+  RISC-V Hart Info dispatcher.
+
+  Copyright (c) 2024, Ventana Micro Systems Inc. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef RISCV_HART_INFO_DISPATCHER_H_
+#define RISCV_HART_INFO_DISPATCHER_H_
+
+#include <FdtHwInfoParserInclude.h>
+#include "FdtUtility.h"
+
+/** RISC-V Hart Info dispatcher.
+
+  A parser parses a Device Tree to populate a specific CmObj type. None,
+  one or many CmObj can be created by the parser.
+  The created CmObj are then handed to the parser's caller through the
+  HW_INFO_ADD_OBJECT interface.
+  This can also be a dispatcher. I.e. a function that not parsing a
+  Device Tree but calling other parsers.
+
+  @param [in]  FdtParserHandle A handle to the parser instance.
+  @param [in]  FdtBranch       When searching for DT node name, restrict
+                               the search to this Device Tree branch.
+
+  @retval EFI_SUCCESS             The function completed successfully.
+  @retval EFI_ABORTED             An error occurred.
+  @retval EFI_INVALID_PARAMETER   Invalid parameter.
+  @retval EFI_NOT_FOUND           Not found.
+  @retval EFI_UNSUPPORTED         Unsupported.
+**/
+EFI_STATUS
+EFIAPI
+RiscVHartInfoDispatcher (
+  IN  CONST FDT_HW_INFO_PARSER_HANDLE  FdtParserHandle,
+  IN        INT32                      FdtBranch
+  );
+
+#endif // RISCV_HART_INFO_DISPATCHER_H_

--- a/DynamicTablesPkg/Library/FdtHwInfoParserLib/RiscV/Intc/RiscVIntcDispatcher.c
+++ b/DynamicTablesPkg/Library/FdtHwInfoParserLib/RiscV/Intc/RiscVIntcDispatcher.c
@@ -1,0 +1,66 @@
+/** @file
+  RISC-V Interrupt Controller dispatcher.
+
+  Copyright (c) 2024, Ventana Micro Systems Inc. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+  @par Reference(s):
+**/
+
+#include "FdtHwInfoParser.h"
+#include "RiscV/Intc/RiscVIntcParser.h"
+#include "RiscV/Intc/RiscVIntcDispatcher.h"
+
+/** MADT dispatcher.
+
+  A parser parses a Device Tree to populate a specific CmObj type. None,
+  one or many CmObj can be created by the parser.
+  The created CmObj are then handed to the parser's caller through the
+  HW_INFO_ADD_OBJECT interface.
+  This can also be a dispatcher. I.e. a function that not parsing a
+  Device Tree but calling other parsers.
+
+  @param [in]  FdtParserHandle A handle to the parser instance.
+  @param [in]  FdtBranch       When searching for DT node name, restrict
+                               the search to this Device Tree branch.
+
+  @retval EFI_SUCCESS             The function completed successfully.
+  @retval EFI_ABORTED             An error occurred.
+  @retval EFI_INVALID_PARAMETER   Invalid parameter.
+  @retval EFI_NOT_FOUND           Not found.
+  @retval EFI_UNSUPPORTED         Unsupported.
+**/
+EFI_STATUS
+EFIAPI
+RiscVIntcDispatcher (
+  IN  CONST FDT_HW_INFO_PARSER_HANDLE  FdtParserHandle,
+  IN        INT32                      FdtBranch
+  )
+{
+  EFI_STATUS  Status;
+  INT32       CpusNode;
+  VOID        *Fdt;
+
+  if (FdtParserHandle == NULL) {
+    ASSERT (0);
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Fdt = FdtParserHandle->Fdt;
+
+  // The "cpus" node resides at the root of the DT. Fetch it.
+  CpusNode = fdt_path_offset (Fdt, "/cpus");
+  if (CpusNode < 0) {
+    return EFI_NOT_FOUND;
+  }
+
+  Status = RiscVIntcInfoParser (FdtParserHandle, CpusNode);
+  if (EFI_ERROR (Status)) {
+    // EFI_NOT_FOUND is not tolerated at this point.
+    ASSERT (0);
+    return Status;
+  }
+
+  return EFI_SUCCESS;
+}

--- a/DynamicTablesPkg/Library/FdtHwInfoParserLib/RiscV/Intc/RiscVIntcDispatcher.h
+++ b/DynamicTablesPkg/Library/FdtHwInfoParserLib/RiscV/Intc/RiscVIntcDispatcher.h
@@ -1,0 +1,45 @@
+/** @file
+  RISC-V MADT dispatcher.
+
+  Copyright (c) 2024, Ventana Micro Systems Inc. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef RISCV_INTC_DISPATCHER_H_
+#define RISCV_INTC_DISPATCHER_H_
+
+#include <FdtHwInfoParserInclude.h>
+#include "FdtUtility.h"
+
+#define IRQ_S_EXT  9
+
+/** RISC-V MADT dispatcher.
+
+
+  A parser parses a Device Tree to populate a specific CmObj type. None,
+  one or many CmObj can be created by the parser.
+  The created CmObj are then handed to the parser's caller through the
+  HW_INFO_ADD_OBJECT interface.
+  This can also be a dispatcher. I.e. a function that not parsing a
+  Device Tree but calling other parsers.
+
+  @param [in]  FdtParserHandle A handle to the parser instance.
+  @param [in]  FdtBranch       When searching for DT node name, restrict
+                               the search to this Device Tree branch.
+
+  @retval EFI_SUCCESS             The function completed successfully.
+  @retval EFI_ABORTED             An error occurred.
+  @retval EFI_INVALID_PARAMETER   Invalid parameter.
+  @retval EFI_NOT_FOUND           Not found.
+  @retval EFI_UNSUPPORTED         Unsupported.
+**/
+EFI_STATUS
+EFIAPI
+RiscVIntcDispatcher (
+  IN  CONST FDT_HW_INFO_PARSER_HANDLE  FdtParserHandle,
+  IN        INT32                      FdtBranch
+  );
+
+#endif // RISCV_INTC_DISPATCHER_H_

--- a/DynamicTablesPkg/Library/FdtHwInfoParserLib/RiscV/Intc/RiscVIntcParser.c
+++ b/DynamicTablesPkg/Library/FdtHwInfoParserLib/RiscV/Intc/RiscVIntcParser.c
@@ -1,0 +1,824 @@
+/** @file
+  RISC-V Interrupt Controllers parser.
+
+  Copyright (c) 2024, Ventana Micro Systems Inc. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+  @par Reference(s):
+  - linux/Documentation/devicetree/bindings/riscv/cpus.yaml
+**/
+
+#include "FdtHwInfoParser.h"
+#include "CmObjectDescUtility.h"
+#include "RiscVAcpi.h"
+#include "RiscV/Intc/RiscVIntcParser.h"
+#include "RiscV/Intc/RiscVIntcDispatcher.h"
+
+#define ACPI_BUILD_EXT_INTC_ID(PlicAplicId, CtxIdcId) \
+                    ((PlicAplicId << 24) | (CtxIdcId))
+
+/** List of "compatible" property values for CPU nodes.
+
+  Any other "compatible" value is not supported by this module.
+*/
+STATIC CONST COMPATIBILITY_STR  CpuCompatibleStr[] = {
+  { "riscv" }
+};
+
+/** COMPATIBILITY_INFO structure for CPU nodes.
+*/
+STATIC CONST COMPATIBILITY_INFO  CpuCompatibleInfo = {
+  ARRAY_SIZE (CpuCompatibleStr),
+  CpuCompatibleStr
+};
+
+/** List of "compatible" property values for IMSIC node.
+
+  Any other "compatible" value is not supported by this module.
+*/
+STATIC CONST COMPATIBILITY_STR  ImsicCompatibleStr[] = {
+  { "riscv,imsics" }
+};
+
+/** COMPATIBILITY_INFO structure for IMSIC node.
+*/
+STATIC CONST COMPATIBILITY_INFO  ImsicCompatibleInfo = {
+  ARRAY_SIZE (ImsicCompatibleStr),
+  ImsicCompatibleStr
+};
+
+/** List of "compatible" property values for APLIC node.
+
+  Any other "compatible" value is not supported by this module.
+*/
+STATIC CONST COMPATIBILITY_STR  AplicCompatibleStr[] = {
+  { "riscv,aplic" }
+};
+
+/** COMPATIBILITY_INFO structure for APLIC node.
+*/
+STATIC CONST COMPATIBILITY_INFO  AplicCompatibleInfo = {
+  ARRAY_SIZE (AplicCompatibleStr),
+  AplicCompatibleStr
+};
+
+/** List of "compatible" property values for PLIC node.
+
+  Any other "compatible" value is not supported by this module.
+*/
+STATIC CONST COMPATIBILITY_STR  PlicCompatibleStr[] = {
+  { "riscv,plic0" }
+};
+
+/** COMPATIBILITY_INFO structure for IMSIC node.
+*/
+STATIC CONST COMPATIBILITY_INFO  PlicCompatibleInfo = {
+  ARRAY_SIZE (PlicCompatibleStr),
+  PlicCompatibleStr
+};
+
+/** Parse a "cpu" node.
+
+  CPU node parser.
+
+  @param [in]  FdtParserHandle    A handle to the parser instance.
+  @param [in]  CpuNode            cpu node.
+  @param [in]  AddressCells       AddressCells info.
+  @param [out] RintcInfo          Pointer to RINTC Info structure.
+
+  @retval EFI_SUCCESS             The function completed successfully.
+  @retval EFI_ABORTED             An error occurred.
+  @retval EFI_INVALID_PARAMETER   Invalid parameter.
+  @retval EFI_NOT_FOUND           Not found.
+  @retval EFI_UNSUPPORTED         Unsupported.
+**/
+STATIC
+EFI_STATUS
+EFIAPI
+CpuNodeParser (
+  IN  CONST FDT_HW_INFO_PARSER_HANDLE  FdtParserHandle,
+  IN        INT32                      CpuNode,
+  IN        UINT32                     AddressCells,
+  OUT       CM_RISCV_RINTC_INFO        *RintcInfo
+  )
+{
+  STATIC UINT32  ProcUid;
+  CONST UINT32   *Prop;
+  CONST UINT8    *Data;
+  EFI_STATUS     Status;
+  UINT64         HartId;
+  INT32          DataSize, Len;
+  INT32          IntcNode;
+  VOID           *Fdt;
+
+  if (RintcInfo == NULL) {
+    ASSERT (0);
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Fdt  = FdtParserHandle->Fdt;
+  Data = fdt_getprop (Fdt, CpuNode, "reg", &DataSize);
+  if ((Data == NULL)                  ||
+      ((DataSize != sizeof (UINT32))  &&
+       (DataSize != sizeof (UINT64))))
+  {
+    ASSERT (0);
+    return EFI_ABORTED;
+  }
+
+  IntcNode = CpuNode;
+  Status   = FdtGetNextNamedNodeInBranch (Fdt, CpuNode, "interrupt-controller", &IntcNode);
+  if (EFI_ERROR (Status)) {
+    ASSERT (0);
+    if (Status == EFI_NOT_FOUND) {
+      // Should have found the node.
+      Status = EFI_ABORTED;
+    }
+  }
+
+  Prop = fdt_getprop (Fdt, IntcNode, "phandle", &Len);
+  if (Prop || (Len > 0)) {
+    RintcInfo->IntcPhandle = fdt32_to_cpu (*((UINT32 *)Prop));
+  }
+
+  if (AddressCells == 2) {
+    HartId = fdt64_to_cpu (*((UINT64 *)Data));
+  } else {
+    HartId = fdt32_to_cpu (*((UINT32 *)Data));
+  }
+
+  RintcInfo->Flags            = EFI_ACPI_6_6_RINTC_FLAG_ENABLE; // REVISIT - check status
+  RintcInfo->HartId           = HartId;
+  RintcInfo->Version          = 1;
+  RintcInfo->AcpiProcessorUid = ProcUid++;
+  RintcInfo->ExtIntCId        = 0;
+  return EFI_SUCCESS;
+}
+
+/** CPU node parser
+
+  CPU node parser.
+
+  @param [in]  FdtParserHandle    A handle to the parser instance.
+  @param [in]  CpusNode           cpus node.
+  @param [out] NewRintcCmObjDesc   Pointer to array of RINTC CM objects.
+
+  @retval EFI_SUCCESS             The function completed successfully.
+  @retval EFI_ABORTED             An error occurred.
+  @retval EFI_INVALID_PARAMETER   Invalid parameter.
+  @retval EFI_NOT_FOUND           Not found.
+  @retval EFI_UNSUPPORTED         Unsupported.
+**/
+STATIC
+EFI_STATUS
+EFIAPI
+CpusNodeParser (
+  IN  CONST FDT_HW_INFO_PARSER_HANDLE  FdtParserHandle,
+  IN        INT32                      CpusNode,
+  OUT       CM_OBJ_DESCRIPTOR          **NewRintcCmObjDesc
+  )
+{
+  EFI_STATUS  Status;
+  UINT32      CpuNodeCount;
+  INT32       CpuNode;
+  INT32       AddressCells;
+
+  UINT32               Index;
+  CM_RISCV_RINTC_INFO  *RintcInfoBuffer;
+  UINT32               RintcInfoBufferSize;
+  VOID                 *Fdt;
+
+  if (NewRintcCmObjDesc == NULL) {
+    ASSERT (0);
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Fdt          = FdtParserHandle->Fdt;
+  AddressCells = fdt_address_cells (Fdt, CpusNode);
+  if (AddressCells < 0) {
+    ASSERT (0);
+    return EFI_ABORTED;
+  }
+
+  // Count the number of "cpu" nodes under the "cpus" node.
+  Status = FdtCountNamedNodeInBranch (Fdt, CpusNode, "cpu", &CpuNodeCount);
+  if (EFI_ERROR (Status)) {
+    ASSERT (0);
+    return Status;
+  }
+
+  if (CpuNodeCount == 0) {
+    ASSERT (0);
+    return EFI_NOT_FOUND;
+  }
+
+  RintcInfoBufferSize = CpuNodeCount * sizeof (CM_RISCV_RINTC_INFO);
+  RintcInfoBuffer     = AllocateZeroPool (RintcInfoBufferSize);
+  if (RintcInfoBuffer == NULL) {
+    ASSERT (0);
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  CpuNode = CpusNode;
+  for (Index = 0; Index < CpuNodeCount; Index++) {
+    Status = FdtGetNextNamedNodeInBranch (Fdt, CpusNode, "cpu", &CpuNode);
+    if (EFI_ERROR (Status)) {
+      ASSERT (0);
+      if (Status == EFI_NOT_FOUND) {
+        // Should have found the node.
+        Status = EFI_ABORTED;
+      }
+
+      goto exit_handler;
+    }
+
+    // Parse the "cpu" node.
+    if (!FdtNodeIsCompatible (Fdt, CpuNode, &CpuCompatibleInfo)) {
+      ASSERT (0);
+      Status = EFI_UNSUPPORTED;
+      goto exit_handler;
+    }
+
+    Status = CpuNodeParser (
+               FdtParserHandle,
+               CpuNode,
+               AddressCells,
+               &RintcInfoBuffer[Index]
+               );
+    if (EFI_ERROR (Status)) {
+      ASSERT (0);
+      goto exit_handler;
+    }
+  } // for
+
+  Status = CreateCmObjDesc (
+             CREATE_CM_RISCV_OBJECT_ID (ERiscVObjRintcInfo),
+             CpuNodeCount,
+             RintcInfoBuffer,
+             RintcInfoBufferSize,
+             NewRintcCmObjDesc
+             );
+  ASSERT_EFI_ERROR (Status);
+
+exit_handler:
+  FreePool (RintcInfoBuffer);
+  return Status;
+}
+
+/** Find the RINTC structure for a phandle
+
+  @param [in] NewRintcCmObjDesc  Pointer to array of RINTC CM objects.
+  @param [in] Phandle            Phandle to search
+
+**/
+STATIC
+CM_RISCV_RINTC_INFO *
+RiscVFindRintc (
+  IN CM_OBJ_DESCRIPTOR  *NewRintcCmObjDesc,
+  INT32                 Phandle
+  )
+{
+  CM_RISCV_RINTC_INFO  *RintcInfo;
+  INT32                Idx;
+
+  RintcInfo = (CM_RISCV_RINTC_INFO *)NewRintcCmObjDesc->Data;
+
+  for (Idx = 0; Idx < NewRintcCmObjDesc->Count; Idx++) {
+    if (RintcInfo[Idx].IntcPhandle == Phandle) {
+      return &RintcInfo[Idx];
+    }
+  }
+
+  return NULL;
+}
+
+/**
+  PLIC parser and update RINTC
+
+  @param [in]      FdtParserHandle    A handle to the parser instance.
+  @param [in, out] NewRintcCmObjDesc  Pointer to array of RINTC CM objects.
+
+  @retval EFI_SUCCESS             The function completed successfully.
+  @retval EFI_ABORTED             An error occurred.
+  @retval EFI_INVALID_PARAMETER   Invalid parameter.
+  @retval EFI_NOT_FOUND           Not found.
+  @retval EFI_UNSUPPORTED         Unsupported.
+**/
+STATIC
+EFI_STATUS
+EFIAPI
+PlicRintcInfoParser (
+  IN  CONST FDT_HW_INFO_PARSER_HANDLE  FdtParserHandle,
+  IN  OUT   CM_OBJ_DESCRIPTOR          *NewRintcCmObjDesc
+  )
+{
+  CM_RISCV_RINTC_INFO  *RintcInfo;
+  CM_RISCV_PLIC_INFO   PlicInfo;
+  CONST UINT32         *Prop;
+  CONST UINT32         *IntExtProp;
+  CONST UINT32         *PhandleProp;
+  EFI_STATUS           Status;
+  UINT32               PlicGsiBase;
+  INT32                Len, LocalCpuId;
+  INT32                PlicId, Idx1, Idx2, Phandle;
+  INT32                Prev, PlicNode;
+  VOID                 *Fdt;
+
+  if (FdtParserHandle == NULL) {
+    ASSERT (0);
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Fdt         = FdtParserHandle->Fdt;
+  PlicGsiBase = 0;
+  PlicId      = 0;
+
+  for (Prev = 0; ; Prev = PlicNode) {
+    PlicNode = fdt_next_node (Fdt, Prev, NULL);
+    if (PlicNode < 0) {
+      return EFI_SUCCESS;
+    }
+
+    if (FdtNodeIsCompatible (Fdt, PlicNode, &PlicCompatibleInfo)) {
+      IntExtProp = fdt_getprop (Fdt, PlicNode, "interrupts-extended", &Len);
+      if ((IntExtProp == NULL) || (Len < 4)) {
+        ASSERT (0);
+        return EFI_INVALID_PARAMETER;
+      } else {
+        Len = Len / 4;
+        for (Idx1 = 0, Idx2 = 0; Idx1 < Len; Idx1 += 2, Idx2++) {
+          if (fdt32_to_cpu (IntExtProp[Idx1 + 1]) == IRQ_S_EXT) {
+            Phandle   = fdt32_to_cpu (ReadUnaligned32 ((const UINT32 *)IntExtProp + Idx1));
+            RintcInfo = RiscVFindRintc (NewRintcCmObjDesc, Phandle);
+            if (RintcInfo == NULL) {
+              ASSERT (0);
+              return EFI_INVALID_PARAMETER;
+            }
+
+            LocalCpuId = Idx2 / 2;
+            /* Update RINTC EXT INTC ID */
+            RintcInfo->ExtIntCId = ACPI_BUILD_EXT_INTC_ID (PlicId, 2 * LocalCpuId + 1);
+          }
+        }
+
+        ZeroMem (&PlicInfo, sizeof (CM_RISCV_PLIC_INFO));
+        Prop = fdt_getprop (Fdt, PlicNode, "reg", &Len);
+        if ((Prop == NULL) || (Len % 4 > 0)) {
+          ASSERT (0);
+          return EFI_INVALID_PARAMETER;
+        }
+
+        PlicInfo.PlicAddress = fdt64_to_cpu (ReadUnaligned64 ((const UINT64 *)Prop));
+        PlicInfo.PlicSize    = fdt64_to_cpu (ReadUnaligned64 ((const UINT64 *)Prop + 1));
+        Prop                 = fdt_getprop (Fdt, PlicNode, "riscv,ndev", &Len);
+        if (Prop == NULL) {
+          ASSERT (0);
+          return EFI_INVALID_PARAMETER;
+        }
+
+        PlicInfo.NumSources = fdt32_to_cpu (ReadUnaligned32 ((const UINT32 *)Prop));
+        PhandleProp         = fdt_getprop (Fdt, PlicNode, "phandle", &Len);
+        if (PhandleProp == NULL) {
+          ASSERT (0);
+          return EFI_INVALID_PARAMETER;
+        }
+
+        PlicInfo.Phandle = fdt32_to_cpu (ReadUnaligned32 ((const UINT32 *)PhandleProp));
+        PlicInfo.GsiBase = PlicGsiBase;
+        PlicInfo.Version = 1;
+        PlicInfo.PlicId  = PlicId++;
+        PlicGsiBase     += PlicInfo.NumSources;
+
+        // Add the CmObj to the Configuration Manager.
+        Status = AddSingleCmObj (
+                   FdtParserHandle,
+                   CREATE_CM_RISCV_OBJECT_ID (ERiscVObjPlicInfo),
+                   &PlicInfo,
+                   sizeof (CM_RISCV_PLIC_INFO),
+                   NULL
+                   );
+        if (EFI_ERROR (Status)) {
+          ASSERT (0);
+          return Status;
+        }
+      }
+    }
+  }
+
+  return EFI_SUCCESS;
+}
+
+/** Check if it is S-mode APLIC
+
+  FDT will have entries for both M-mode and S-mode APLIC. We
+  need only S-mode APLIC.
+
+  @param [in]  Fdt             Pointer to device tree.
+  @param [in]  AplicNode       Node with APLIC compatible property.
+
+  @retval TRUE                 The AplicNode is S-mode APLIC
+  @retval FALSE                The AplicNode is not S-mode APLIC
+**/
+STATIC
+BOOLEAN
+IsSmodeAplic (
+  IN VOID   *Fdt,
+  IN INT32  AplicNode
+  )
+{
+  fdt32_t  *IrqProp;
+  fdt32_t  *MsiProp;
+  INT32    Len, ImsicNode;
+
+  IrqProp = (fdt32_t *)fdt_getprop (Fdt, AplicNode, "interrupts-extended", &Len);
+  if ((IrqProp > 0) && (Len >= 4) &&
+      (fdt32_to_cpu (IrqProp[1]) == IRQ_S_EXT))
+  {
+    return TRUE;
+  }
+
+  MsiProp = (fdt32_t *)fdt_getprop (Fdt, AplicNode, "msi-parent", &Len);
+  if (MsiProp && (Len >= sizeof (fdt32_t))) {
+    ImsicNode = fdt_node_offset_by_phandle (Fdt, fdt32_to_cpu (*MsiProp));
+    if (ImsicNode < 0) {
+      return FALSE;
+    }
+
+    IrqProp = (fdt32_t *)fdt_getprop (Fdt, ImsicNode, "interrupts-extended", &Len);
+    if ((IrqProp > 0) && (Len >= 4) &&
+        (fdt32_to_cpu (IrqProp[1]) == IRQ_S_EXT))
+    {
+      return TRUE;
+    }
+  }
+
+  return FALSE;
+}
+
+/**
+  APLIC parser and update RINTC
+
+  @param [in]      FdtParserHandle    A handle to the parser instance.
+  @param [in, out] NewRintcCmObjDesc  Pointer to array of RINTC CM objects.
+
+  @retval EFI_SUCCESS             The function completed successfully.
+  @retval EFI_ABORTED             An error occurred.
+  @retval EFI_INVALID_PARAMETER   Invalid parameter.
+  @retval EFI_NOT_FOUND           Not found.
+  @retval EFI_UNSUPPORTED         Unsupported.
+**/
+STATIC
+EFI_STATUS
+EFIAPI
+AplicRintcInfoParser (
+  IN  CONST FDT_HW_INFO_PARSER_HANDLE  FdtParserHandle,
+  IN  OUT   CM_OBJ_DESCRIPTOR          *NewRintcCmObjDesc
+  )
+{
+  CM_RISCV_RINTC_INFO  *RintcInfo;
+  CM_RISCV_APLIC_INFO  AplicInfo;
+  CONST UINT32         *IntExtProp;
+  CONST UINT32         *PhandleProp;
+  CONST UINT64         *Prop;
+  EFI_STATUS           Status;
+  UINT32               AplicGsiBase;
+  INT32                Len;
+  INT32                AplicId, Idx, Phandle;
+  INT32                Prev, AplicNode;
+  VOID                 *Fdt;
+
+  if (FdtParserHandle == NULL) {
+    ASSERT (0);
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Fdt          = FdtParserHandle->Fdt;
+  AplicGsiBase = 0;
+  AplicId      = 0;
+
+  for (Prev = 0; ; Prev = AplicNode) {
+    AplicNode = fdt_next_node (Fdt, Prev, NULL);
+    if (AplicNode < 0) {
+      return EFI_SUCCESS;
+    }
+
+    if (FdtNodeIsCompatible (Fdt, AplicNode, &AplicCompatibleInfo) &&
+        IsSmodeAplic (Fdt, AplicNode))
+    {
+      ZeroMem (&AplicInfo, sizeof (CM_RISCV_APLIC_INFO));
+      IntExtProp = fdt_getprop (Fdt, AplicNode, "interrupts-extended", &Len);
+      if ((IntExtProp != 0) && ((Len / sizeof (UINT32)) % 2 == 0)) {
+        Len               = Len / 4;
+        AplicInfo.NumIdcs = Len / 2;
+        for (Idx = 0; Idx < Len; Idx += 2) {
+          Phandle   = fdt32_to_cpu (ReadUnaligned32 ((const UINT32 *)IntExtProp + Idx));
+          RintcInfo = RiscVFindRintc (NewRintcCmObjDesc, Phandle);
+          if (RintcInfo == NULL) {
+            ASSERT (0);
+            return EFI_NOT_FOUND;
+          }
+
+          /* Update RINTC EXT INTC ID */
+          RintcInfo->ExtIntCId = ACPI_BUILD_EXT_INTC_ID (AplicId, Idx / 2);
+        }
+      }
+
+      Prop = fdt_getprop (Fdt, AplicNode, "reg", &Len);
+      if ((Prop == NULL) || (Len % 4 > 0)) {
+        ASSERT (0);
+        return EFI_INVALID_PARAMETER;
+      }
+
+      AplicInfo.AplicAddress = fdt64_to_cpu (ReadUnaligned64 ((const UINT64 *)Prop));
+      AplicInfo.AplicSize    = fdt64_to_cpu (ReadUnaligned64 ((const UINT64 *)Prop + 1));
+      Prop                   = fdt_getprop (Fdt, AplicNode, "riscv,num-sources", &Len);
+      if (!Prop) {
+        ASSERT (0);
+        return EFI_INVALID_PARAMETER;
+      }
+
+      AplicInfo.NumSources = fdt32_to_cpu (ReadUnaligned32 ((const UINT32 *)Prop));
+      PhandleProp          = fdt_getprop (Fdt, AplicNode, "phandle", &Len);
+      if (!PhandleProp) {
+        ASSERT (0);
+        return EFI_INVALID_PARAMETER;
+      }
+
+      AplicInfo.Phandle = fdt32_to_cpu (ReadUnaligned32 ((const UINT32 *)PhandleProp));
+      AplicInfo.GsiBase = AplicGsiBase;
+      AplicInfo.Version = 1;
+      AplicInfo.AplicId = AplicId++;
+      AplicGsiBase     += AplicInfo.NumSources;
+
+      // Add the CmObj to the Configuration Manager.
+      Status = AddSingleCmObj (
+                 FdtParserHandle,
+                 CREATE_CM_RISCV_OBJECT_ID (ERiscVObjAplicInfo),
+                 &AplicInfo,
+                 sizeof (CM_RISCV_APLIC_INFO),
+                 NULL
+                 );
+      if (EFI_ERROR (Status)) {
+        ASSERT (0);
+        return Status;
+      }
+    }
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  RINTC parser using IMSIC node
+
+  Parse RINTC information using IMSIC.
+
+  @param [in]      FdtParserHandle     A handle to the parser instance.
+  @param [in, out] NewRintcCmObjDesc   Pointer to array of RINTC CM objects.
+
+  @retval EFI_SUCCESS             The function completed successfully.
+  @retval EFI_ABORTED             An error occurred.
+  @retval EFI_INVALID_PARAMETER   Invalid parameter.
+  @retval EFI_NOT_FOUND           Not found.
+  @retval EFI_UNSUPPORTED         Unsupported.
+**/
+STATIC
+EFI_STATUS
+EFIAPI
+ImsicRintcInfoParser (
+  IN  CONST FDT_HW_INFO_PARSER_HANDLE  FdtParserHandle,
+  IN  OUT   CM_OBJ_DESCRIPTOR          *NewRintcCmObjDesc
+  )
+{
+  CM_RISCV_RINTC_INFO  *RintcInfoBuffer;
+  CM_RISCV_IMSIC_INFO  ImsicInfo;
+  CONST UINT64         *Prop;
+  CONST UINT32         *IntExtProp;
+  CONST UINT64         *ImsicRegProp;
+  EFI_STATUS           Status;
+  UINT64               ImsicBaseAddr, ImsicBaseLen;
+  UINT64               ImsicCpuBaseAddr, ImsicCpuBaseLen;
+  UINTN                NumImsicBase;
+  INT32                Len, NumPhandle, Phandle;
+  INT32                Prev, ImsicNode;
+  INTN                 Idx, Idx1, Idx2, Limit;
+  VOID                 *Fdt;
+
+  if (NewRintcCmObjDesc == NULL) {
+    ASSERT (0);
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Fdt = FdtParserHandle->Fdt;
+  ZeroMem (&ImsicInfo, sizeof (CM_RISCV_IMSIC_INFO));
+
+  for (Prev = 0; ; Prev = ImsicNode) {
+    ImsicNode = fdt_next_node (Fdt, Prev, NULL);
+    if (ImsicNode < 0) {
+      return EFI_NOT_FOUND;
+    }
+
+    if (FdtNodeIsCompatible (Fdt, ImsicNode, &ImsicCompatibleInfo)) {
+      IntExtProp = fdt_getprop (Fdt, ImsicNode, "interrupts-extended", &Len);
+      if ((IntExtProp == 0) || ((Len / sizeof (UINT32)) % 2 != 0)) {
+        /* interrupts-extended: <phandle>, <flag> */
+        ASSERT (0);
+        return EFI_INVALID_PARAMETER;
+      }
+
+      /* There can be M-mode IMSIC in DT. Consider only S-mode */
+      if (fdt32_to_cpu (IntExtProp[1]) == IRQ_S_EXT) {
+        NumPhandle = (Len / sizeof (UINT32)) / 2;
+        if (NumPhandle == 0) {
+          ASSERT (0);
+          return EFI_NOT_FOUND;
+        }
+
+        Prop = fdt_getprop (Fdt, ImsicNode, "riscv,num-ids", &Len);
+        if (Prop == 0) {
+          ASSERT (0);
+          return EFI_INVALID_PARAMETER;
+        }
+
+        ImsicInfo.NumIds = fdt32_to_cpu (ReadUnaligned32 ((const UINT32 *)Prop));
+        Prop             = fdt_getprop (Fdt, ImsicNode, "riscv,num-guest-ids", &Len);
+        if (Prop == 0) {
+          ImsicInfo.NumGuestIds = ImsicInfo.NumIds;
+        } else {
+          ImsicInfo.NumGuestIds = fdt32_to_cpu (ReadUnaligned32 ((const UINT32 *)Prop));
+        }
+
+        Prop = fdt_getprop (Fdt, ImsicNode, "riscv,guest-index-bits", &Len);
+        if (Prop == 0) {
+          ImsicInfo.GuestIndexBits = 0;
+        } else {
+          ImsicInfo.GuestIndexBits = fdt32_to_cpu (ReadUnaligned32 ((const UINT32 *)Prop));
+        }
+
+        Prop = fdt_getprop (Fdt, ImsicNode, "riscv,hart-index-bits", &Len);
+        if (Prop == 0) {
+          ImsicInfo.HartIndexBits = 0; // update default value later
+        } else {
+          ImsicInfo.HartIndexBits = fdt32_to_cpu (ReadUnaligned32 ((const UINT32 *)Prop));
+        }
+
+        Prop = fdt_getprop (Fdt, ImsicNode, "riscv,group-index-bits", &Len);
+        if (Prop == 0) {
+          ImsicInfo.GroupIndexBits = 0;
+        } else {
+          ImsicInfo.GroupIndexBits = fdt32_to_cpu (ReadUnaligned32 ((const UINT32 *)Prop));
+        }
+
+        Prop = fdt_getprop (Fdt, ImsicNode, "riscv,group-index-shift", &Len);
+        if (Prop == 0) {
+          ImsicInfo.GroupIndexShift = IMSIC_MMIO_PAGE_SHIFT * 2;
+        } else {
+          ImsicInfo.GroupIndexShift = fdt32_to_cpu (ReadUnaligned32 ((const UINT32 *)Prop));
+        }
+
+        ImsicInfo.Version   = 1;
+        ImsicInfo.Reserved1 = 0;
+        ImsicInfo.Flags     = 0;
+        Prop                = fdt_getprop (Fdt, ImsicNode, "reg", &Len);
+        if ((Prop == 0) || (((Len / sizeof (UINT32)) % 4) != 0)) {
+          // address-cells and size-cells are always 2
+          DEBUG (
+            (
+             DEBUG_ERROR,
+             "%a: Failed to parse imsic node: reg\n",
+             __func__
+            )
+            );
+          return EFI_INVALID_PARAMETER;
+        }
+
+        ImsicRegProp = Prop;
+        NumImsicBase = (Len / sizeof (UINT32)) / 4;
+        if (ImsicInfo.HartIndexBits == 0) {
+          Len = NumPhandle;
+          while (Len > 0) {
+            ImsicInfo.HartIndexBits++;
+            Len = Len >> 1;
+          }
+        }
+
+        Idx2 = 0;
+        for (Idx = 0; Idx < NumImsicBase; Idx++) {
+          ImsicBaseAddr = fdt64_to_cpu (ReadUnaligned64 ((const UINT64 *)ImsicRegProp + Idx * 2));
+          ImsicBaseLen  = fdt64_to_cpu (ReadUnaligned64 ((const UINT64 *)ImsicRegProp + Idx * 2 + 1));
+          // Calculate the limit of number of cpu nodes this imsic can handle
+          Limit = ImsicBaseLen /  IMSIC_MMIO_PAGE_SZ;
+          for (Idx1 = 0; Idx1 < Limit && Idx2 < NumPhandle; Idx1++, Idx2++) {
+            Phandle         = fdt32_to_cpu (ReadUnaligned32 ((const UINT32 *)IntExtProp + Idx2 * 2));
+            RintcInfoBuffer = RiscVFindRintc (NewRintcCmObjDesc, Phandle);
+            if (RintcInfoBuffer == NULL) {
+              DEBUG ((DEBUG_ERROR, "%a: Failed to find RINTC node\n", __func__));
+              return EFI_NOT_FOUND;
+            }
+
+            ImsicCpuBaseAddr                  = ImsicBaseAddr + Idx1 * IMSIC_MMIO_PAGE_SZ;
+            ImsicCpuBaseLen                   = IMSIC_MMIO_PAGE_SZ;
+            RintcInfoBuffer->ImsicBaseAddress = ImsicCpuBaseAddr;
+            RintcInfoBuffer->ImsicSize        = ImsicCpuBaseLen;
+          }
+        }
+
+        // Add the CmObj to the Configuration Manager.
+        Status = AddSingleCmObj (
+                   FdtParserHandle,
+                   CREATE_CM_RISCV_OBJECT_ID (ERiscVObjImsicInfo),
+                   &ImsicInfo,
+                   sizeof (CM_RISCV_IMSIC_INFO),
+                   NULL
+                   );
+        if (EFI_ERROR (Status)) {
+          ASSERT (0);
+        }
+
+        return Status;
+      }
+    }
+  }
+
+  return Status;
+}
+
+/** CM_RISCV_RINTC_INFO and CM_ARCH_IMSIC_INFO parser function.
+
+  A parser parses a Device Tree to populate a specific CmObj type. None,
+  one or many CmObj can be created by the parser.
+  The created CmObj are then handed to the parser's caller through the
+  HW_INFO_ADD_OBJECT interface.
+  This can also be a dispatcher. I.e. a function that not parsing a
+  Device Tree but calling other parsers.
+
+  @param [in]  FdtParserHandle A handle to the parser instance.
+  @param [in]  FdtBranch       When searching for DT node name, restrict
+                               the search to this Device Tree branch.
+
+  @retval EFI_SUCCESS             The function completed successfully.
+  @retval EFI_ABORTED             An error occurred.
+  @retval EFI_INVALID_PARAMETER   Invalid parameter.
+  @retval EFI_NOT_FOUND           Not found.
+  @retval EFI_UNSUPPORTED         Unsupported.
+**/
+EFI_STATUS
+EFIAPI
+RiscVIntcInfoParser (
+  IN  CONST FDT_HW_INFO_PARSER_HANDLE  FdtParserHandle,
+  IN        INT32                      FdtBranch
+  )
+{
+  CM_OBJ_DESCRIPTOR  *NewCmObjDesc;
+  EFI_STATUS         Status;
+  VOID               *Fdt;
+
+  if (FdtParserHandle == NULL) {
+    ASSERT (0);
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Fdt          = FdtParserHandle->Fdt;
+  NewCmObjDesc = NULL;
+
+  // Parse the "cpus" nodes and its children "cpu" nodes,
+  // and create a CM_OBJ_DESCRIPTOR.
+  Status = CpusNodeParser (FdtParserHandle, FdtBranch, &NewCmObjDesc);
+  if (EFI_ERROR (Status)) {
+    ASSERT (0);
+    return Status;
+  }
+
+  /* Search for IMSIC presence and update RINTC structures if so */
+  Status = ImsicRintcInfoParser (FdtParserHandle, NewCmObjDesc);
+  if (EFI_ERROR (Status) && (Status != EFI_NOT_FOUND)) {
+    ASSERT_EFI_ERROR (Status);
+    goto exit_handler;
+  }
+
+  /* Search for APLIC presence and update RINTC structures if so */
+  Status = AplicRintcInfoParser (FdtParserHandle, NewCmObjDesc);
+  if (EFI_ERROR (Status) && (Status != EFI_NOT_FOUND)) {
+    ASSERT_EFI_ERROR (Status);
+    goto exit_handler;
+  }
+
+  /* Search for PLIC presence and update RINTC structures if so */
+  Status = PlicRintcInfoParser (FdtParserHandle, NewCmObjDesc);
+  if (EFI_ERROR (Status) && (Status != EFI_NOT_FOUND)) {
+    ASSERT_EFI_ERROR (Status);
+    goto exit_handler;
+  }
+
+  // Finally, add all the RINTC CmObjs to the Configuration Manager.
+  Status = AddMultipleCmObj (FdtParserHandle, NewCmObjDesc, 0, NULL);
+  if (EFI_ERROR (Status)) {
+    ASSERT (0);
+    goto exit_handler;
+  }
+
+exit_handler:
+  FreeCmObjDesc (NewCmObjDesc);
+  return Status;
+}

--- a/DynamicTablesPkg/Library/FdtHwInfoParserLib/RiscV/Intc/RiscVIntcParser.h
+++ b/DynamicTablesPkg/Library/FdtHwInfoParserLib/RiscV/Intc/RiscVIntcParser.h
@@ -1,0 +1,40 @@
+/** @file
+  RISC-V RINTC and IMSIC parser.
+
+  Copyright (c) 2024, Ventana Micro Systems Inc. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+  @par Reference(s):
+**/
+
+#ifndef RISCV_RINTC_PARSER_H_
+#define RISCV_RINTC_PARSER_H_
+
+/** CM_RISCV_RINTC_INFO parser function.
+
+  A parser parses a Device Tree to populate a specific CmObj type. None,
+  one or many CmObj can be created by the parser.
+  The created CmObj are then handed to the parser's caller through the
+  HW_INFO_ADD_OBJECT interface.
+  This can also be a dispatcher. I.e. a function that not parsing a
+  Device Tree but calling other parsers.
+
+  @param [in]  FdtParserHandle A handle to the parser instance.
+  @param [in]  FdtBranch       When searching for DT node name, restrict
+                               the search to this Device Tree branch.
+
+  @retval EFI_SUCCESS             The function completed successfully.
+  @retval EFI_ABORTED             An error occurred.
+  @retval EFI_INVALID_PARAMETER   Invalid parameter.
+  @retval EFI_NOT_FOUND           Not found.
+  @retval EFI_UNSUPPORTED         Unsupported.
+**/
+EFI_STATUS
+EFIAPI
+RiscVIntcInfoParser (
+  IN  CONST FDT_HW_INFO_PARSER_HANDLE  FdtParserHandle,
+  IN        INT32                      FdtBranch
+  );
+
+#endif // RISCV_RINTC_PARSER_H_

--- a/DynamicTablesPkg/Library/FdtHwInfoParserLib/RiscV/RiscVFdtHwInfoParser.c
+++ b/DynamicTablesPkg/Library/FdtHwInfoParserLib/RiscV/RiscVFdtHwInfoParser.c
@@ -1,0 +1,82 @@
+/** @file
+  Flattened Device Tree parser library for RISC-V.
+
+  Copyright (c) 2024, Ventana Micro Systems Inc. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include "FdtHwInfoParser.h"
+#include "Pci/PciConfigSpaceParser.h"
+#include "Serial/SerialPortParser.h"
+#include "Intc/RiscVIntcDispatcher.h"
+#include "HartInfo/RiscVHartInfoDispatcher.h"
+
+/** Ordered table of parsers/dispatchers.
+
+  A parser parses a Device Tree to populate a specific CmObj type. None,
+  one or many CmObj can be created by the parser.
+  The created CmObj are then handed to the parser's caller through the
+  HW_INFO_ADD_OBJECT interface.
+  This can also be a dispatcher. I.e. a function that not parsing a
+  Device Tree but calling other parsers.
+*/
+STATIC CONST FDT_HW_INFO_PARSER_FUNC  HwInfoParserTable[] = {
+  RiscVIntcDispatcher,
+  RiscVHartInfoDispatcher,
+  PciConfigInfoParser,
+  SerialPortDispatcher
+};
+
+/** Main dispatcher: sequentially call the parsers/dispatchers
+    of the HwInfoParserTable.
+
+  A parser parses a Device Tree to populate a specific CmObj type. None,
+  one or many CmObj can be created by the parser.
+  The created CmObj are then handed to the parser's caller through the
+  HW_INFO_ADD_OBJECT interface.
+  This can also be a dispatcher. I.e. a function that not parsing a
+  Device Tree but calling other parsers.
+
+  @param [in]  FdtParserHandle A handle to the parser instance.
+  @param [in]  FdtBranch       When searching for DT node name, restrict
+                               the search to this Device Tree branch.
+
+  @retval EFI_SUCCESS             The function completed successfully.
+  @retval EFI_ABORTED             An error occurred.
+  @retval EFI_INVALID_PARAMETER   Invalid parameter.
+  @retval EFI_NOT_FOUND           Not found.
+  @retval EFI_UNSUPPORTED         Unsupported.
+**/
+EFI_STATUS
+EFIAPI
+ArchFdtHwInfoMainDispatcher (
+  IN  CONST FDT_HW_INFO_PARSER_HANDLE  FdtParserHandle,
+  IN        INT32                      FdtBranch
+  )
+{
+  EFI_STATUS  Status;
+  UINT32      Index;
+
+  if (fdt_check_header (FdtParserHandle->Fdt) < 0) {
+    ASSERT (0);
+    return EFI_INVALID_PARAMETER;
+  }
+
+  for (Index = 0; Index < ARRAY_SIZE (HwInfoParserTable); Index++) {
+    Status = HwInfoParserTable[Index](
+                                      FdtParserHandle,
+                                      FdtBranch
+                                      );
+    if (EFI_ERROR (Status)  &&
+        (Status != EFI_NOT_FOUND))
+    {
+      // If EFI_NOT_FOUND, the parser didn't find information in the DT.
+      // Don't trigger an error.
+      ASSERT (0);
+      return Status;
+    }
+  } // for
+
+  return EFI_SUCCESS;
+}

--- a/DynamicTablesPkg/Library/FdtHwInfoParserLib/RiscV/RiscVFdtInterrupt.c
+++ b/DynamicTablesPkg/Library/FdtHwInfoParserLib/RiscV/RiscVFdtInterrupt.c
@@ -1,0 +1,91 @@
+/** @file
+  RISC-V Flattened device tree utility for Interrupts.
+
+  Copyright (c) 2024, Ventana Micro Systems Inc. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+  @par Reference(s):
+  - Device tree Specification - Release v0.3
+**/
+
+#include <FdtHwInfoParserInclude.h>
+#include "FdtUtility.h"
+
+/** Get the interrupt Id of an interrupt described in a fdt.
+
+  @param [in]  Data   Pointer to the first cell of an "interrupts" property.
+
+  @retval  The interrupt id.
+**/
+UINT32
+EFIAPI
+FdtGetInterruptId (
+  UINT32 CONST  *Data
+  )
+{
+  ASSERT (Data != NULL);
+
+  return fdt32_to_cpu (Data[RISCV_IRQ_NUMBER_OFFSET]);
+}
+
+/** Get the ACPI interrupt flags of an interrupt described in a fdt.
+
+  @param [in]  Data   Pointer to the first cell of an "interrupts" property.
+
+  @retval  The interrupt flags (for ACPI).
+**/
+UINT32
+EFIAPI
+FdtGetInterruptFlags (
+  UINT32 CONST  *Data
+  )
+{
+  UINT32  IrqFlags;
+  UINT32  AcpiIrqFlags;
+
+  ASSERT (Data != NULL);
+
+  IrqFlags = fdt32_to_cpu (Data[RISCV_IRQ_FLAGS_OFFSET]);
+
+  AcpiIrqFlags  = DT_IRQ_IS_EDGE_TRIGGERED (IrqFlags) ? BIT0 : 0;
+  AcpiIrqFlags |= DT_IRQ_IS_ACTIVE_LOW (IrqFlags) ? BIT1 : 0;
+
+  return AcpiIrqFlags;
+}
+
+/** Get the Address cell info of the INTC node
+
+  @param [in]  Fdt              Pointer to a Flattened Device Tree.
+
+  @param [in]  Node             Offset of the node having to get the
+                                "#address-cells" and "#size-cells"
+                                properties from.
+
+  @param [out] AddressCells     If success, number of address-cells.
+                                If the property is not available,
+                                default value is 2.
+
+  @param [out] SizeCells        If success, number of size-cells.
+                                If the property is not available,
+                                default value is 1.
+
+  @retval EFI_SUCCESS           The function always returns SUCCESS
+
+**/
+EFI_STATUS
+
+EFIAPI
+
+FdtGetIntcAddressCells (
+  IN  CONST VOID *Fdt,
+  IN        INT32 Node,
+  OUT       INT32 *AddressCells, OPTIONAL
+  OUT       INT32  *SizeCells      OPTIONAL
+  )
+{
+  /* Address Cells is zero for RISC-V */
+  *AddressCells = 0;
+
+  return EFI_SUCCESS;
+}

--- a/OvmfPkg/OvmfPkg.ci.yaml
+++ b/OvmfPkg/OvmfPkg.ci.yaml
@@ -44,6 +44,7 @@
     "DependencyCheck": {
         "AcceptableDependencies": [
             "CryptoPkg/CryptoPkg.dec",
+            "DynamicTablesPkg/DynamicTablesPkg.dec",
             "MdePkg/MdePkg.dec",
             "MdeModulePkg/MdeModulePkg.dec",
             "OvmfPkg/OvmfPkg.dec",

--- a/OvmfPkg/RiscVVirt/RiscVVirtCfgMgrDxe/AslTables/Dsdt.asl
+++ b/OvmfPkg/RiscVVirt/RiscVVirtCfgMgrDxe/AslTables/Dsdt.asl
@@ -1,0 +1,21 @@
+/** @file
+  Differentiated System Description Table Fields (DSDT)
+
+  Copyright (c) 2024, Ventana Micro Systems Inc. All rights reserved.<BR>
+    SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+DefinitionBlock ("DsdtTable.aml", "DSDT", 2, "RSCVIN", "RSCVVIRT", 1) {
+  Scope (_SB) {
+    //
+    // Most ACPI tables for Kvmtool firmware are
+    // dynamically generated. The AML code is also
+    // generated at runtime for most components in
+    // appropriate SSDTs.
+    // Although there may not be much to describe
+    // in the DSDT, the DSDT table is mandatory.
+    // Therefore, add an empty stub for DSDT.
+    //
+  } // Scope (_SB)
+}

--- a/OvmfPkg/RiscVVirt/RiscVVirtCfgMgrDxe/ConfigurationManager.c
+++ b/OvmfPkg/RiscVVirt/RiscVVirtCfgMgrDxe/ConfigurationManager.c
@@ -1,0 +1,885 @@
+/** @file
+  Configuration Manager Dxe
+
+  Copyright (c) 2024, Ventana Micro Systems Inc. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+  @par Glossary:
+    - Cm or CM   - Configuration Manager
+    - Obj or OBJ - Object
+**/
+
+#include <IndustryStandard/DebugPort2Table.h>
+#include <IndustryStandard/MemoryMappedConfigurationSpaceAccessTable.h>
+#include <IndustryStandard/SerialPortConsoleRedirectionTable.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
+#include <Library/DynamicPlatRepoLib.h>
+#include <Library/HobLib.h>
+#include <Library/HwInfoParserLib.h>
+#include <Library/IoLib.h>
+#include <Library/PcdLib.h>
+#include <Library/TableHelperLib.h>
+#include <Library/UefiBootServicesTableLib.h>
+#include <Protocol/AcpiTable.h>
+#include <Protocol/ConfigurationManagerProtocol.h>
+
+#include "ConfigurationManager.h"
+
+#define EFI_ACPI_6_6_RISCV_HART_CAPABILITIES_TABLE_SIGNATURE  SIGNATURE_32('R', 'H', 'C', 'T')
+
+//
+// The platform configuration repository information.
+//
+STATIC
+EDKII_PLATFORM_REPOSITORY_INFO  mRiscVVirtPlatRepositoryInfo = {
+  //
+  // Configuration Manager information
+  //
+  { CONFIGURATION_MANAGER_REVISION, CFG_MGR_OEM_ID },
+
+  //
+  // ACPI Table List
+  //
+  {
+    //
+    // FADT Table
+    //
+    {
+      EFI_ACPI_6_3_FIXED_ACPI_DESCRIPTION_TABLE_SIGNATURE,
+      EFI_ACPI_6_3_FIXED_ACPI_DESCRIPTION_TABLE_REVISION,
+      CREATE_STD_ACPI_TABLE_GEN_ID (EStdAcpiTableIdFadt),
+      NULL
+    },
+    //
+    // MADT Table
+    //
+    {
+      EFI_ACPI_6_3_MULTIPLE_APIC_DESCRIPTION_TABLE_SIGNATURE,
+      EFI_ACPI_6_3_MULTIPLE_APIC_DESCRIPTION_TABLE_REVISION,
+      CREATE_STD_ACPI_TABLE_GEN_ID (EStdAcpiTableIdMadt),
+      NULL
+    },
+    //
+    // RHCT Table
+    //
+    {
+      EFI_ACPI_6_6_RISCV_HART_CAPABILITIES_TABLE_SIGNATURE,
+      1,
+      CREATE_STD_ACPI_TABLE_GEN_ID (EStdAcpiTableIdRhct),
+      NULL
+    },
+    //
+    // SPCR Table
+    //
+    {
+      EFI_ACPI_6_3_SERIAL_PORT_CONSOLE_REDIRECTION_TABLE_SIGNATURE,
+      EFI_ACPI_SERIAL_PORT_CONSOLE_REDIRECTION_TABLE_REVISION,
+      CREATE_STD_ACPI_TABLE_GEN_ID (EStdAcpiTableIdSpcr),
+      NULL
+    },
+    //
+    // DSDT Table
+    //
+    {
+      EFI_ACPI_6_3_DIFFERENTIATED_SYSTEM_DESCRIPTION_TABLE_SIGNATURE,
+      0, // Unused
+      CREATE_STD_ACPI_TABLE_GEN_ID (EStdAcpiTableIdDsdt),
+      (EFI_ACPI_DESCRIPTION_HEADER *)dsdt_aml_code
+    },
+    //
+    // SSDT Cpu Hierarchy Table
+    //
+    {
+      EFI_ACPI_6_3_SECONDARY_SYSTEM_DESCRIPTION_TABLE_SIGNATURE,
+      0, // Unused
+      CREATE_STD_ACPI_TABLE_GEN_ID (EStdAcpiTableIdSsdtCpuTopology),
+      NULL
+    },
+    //
+    // PCI MCFG Table
+    //
+    {
+      EFI_ACPI_6_3_PCI_EXPRESS_MEMORY_MAPPED_CONFIGURATION_SPACE_BASE_ADDRESS_DESCRIPTION_TABLE_SIGNATURE,
+      EFI_ACPI_MEMORY_MAPPED_CONFIGURATION_SPACE_ACCESS_TABLE_REVISION,
+      CREATE_STD_ACPI_TABLE_GEN_ID (EStdAcpiTableIdMcfg),
+      NULL
+    },
+    //
+    // SSDT table describing the PCI root complex
+    //
+    {
+      EFI_ACPI_6_3_SECONDARY_SYSTEM_DESCRIPTION_TABLE_SIGNATURE,
+      0, // Unused
+      CREATE_STD_ACPI_TABLE_GEN_ID (EStdAcpiTableIdSsdtPciExpress),
+      NULL
+    },
+    //
+    // SSDT PLIC/APLIC
+    //
+    {
+      EFI_ACPI_6_3_SECONDARY_SYSTEM_DESCRIPTION_TABLE_SIGNATURE,
+      0, // Unused
+      CREATE_STD_ACPI_TABLE_GEN_ID (EStdAcpiTableIdSsdtPlicAplic),
+      NULL
+    },
+  },
+
+  //
+  // Power management profile information
+  //
+  { EFI_ACPI_6_3_PM_PROFILE_ENTERPRISE_SERVER },    // PowerManagement Profile
+};
+
+/**
+  A helper function for returning the Configuration Manager Objects.
+
+  @param [in]       CmObjectId     The Configuration Manager Object ID.
+  @param [in]       Object         Pointer to the Object(s).
+  @param [in]       ObjectSize     Total size of the Object(s).
+  @param [in]       ObjectCount    Number of Objects.
+  @param [in, out]  CmObjectDesc   Pointer to the Configuration Manager Object
+                                   descriptor describing the requested Object.
+
+  @retval EFI_SUCCESS           Success.
+**/
+STATIC
+EFI_STATUS
+EFIAPI
+HandleCmObject (
+  IN  CONST CM_OBJECT_ID                CmObjectId,
+  IN        VOID                        *Object,
+  IN  CONST UINTN                       ObjectSize,
+  IN  CONST UINTN                       ObjectCount,
+  IN  OUT   CM_OBJ_DESCRIPTOR   *CONST  CmObjectDesc
+  )
+{
+  CmObjectDesc->ObjectId = CmObjectId;
+  CmObjectDesc->Size     = ObjectSize;
+  CmObjectDesc->Data     = Object;
+  CmObjectDesc->Count    = ObjectCount;
+  DEBUG (
+    (
+     DEBUG_INFO,
+     "INFO: CmObjectId = " FMT_CM_OBJECT_ID ", "
+                                            "Ptr = 0x%p, Size = %lu, Count = %lu\n",
+     CmObjectId,
+     CmObjectDesc->Data,
+     CmObjectDesc->Size,
+     CmObjectDesc->Count
+    )
+    );
+  return EFI_SUCCESS;
+}
+
+/**
+  A helper function for returning the Configuration Manager Objects that
+  match the token.
+
+  @param [in]  This               Pointer to the Configuration Manager Protocol.
+  @param [in]  CmObjectId         The Configuration Manager Object ID.
+  @param [in]  Object             Pointer to the Object(s).
+  @param [in]  ObjectSize         Total size of the Object(s).
+  @param [in]  ObjectCount        Number of Objects.
+  @param [in]  Token              A token identifying the object.
+  @param [in]  HandlerProc        A handler function to search the object
+                                  referenced by the token.
+  @param [in, out]  CmObjectDesc  Pointer to the Configuration Manager Object
+                                  descriptor describing the requested Object.
+
+  @retval EFI_SUCCESS           Success.
+  @retval EFI_INVALID_PARAMETER A parameter is invalid.
+  @retval EFI_NOT_FOUND         The required object information is not found.
+STATIC
+EFI_STATUS
+EFIAPI
+HandleCmObjectRefByToken (
+  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST  This,
+  IN  CONST CM_OBJECT_ID                                  CmObjectId,
+  IN        VOID                                          *Object,
+  IN  CONST UINTN                                         ObjectSize,
+  IN  CONST UINTN                                         ObjectCount,
+  IN  CONST CM_OBJECT_TOKEN                               Token,
+  IN  CONST CM_OBJECT_HANDLER_PROC                        HandlerProc,
+  IN  OUT   CM_OBJ_DESCRIPTOR                     *CONST  CmObjectDesc
+  )
+{
+  EFI_STATUS  Status;
+
+  CmObjectDesc->ObjectId = CmObjectId;
+  if (Token == CM_NULL_TOKEN) {
+    CmObjectDesc->Size  = ObjectSize;
+    CmObjectDesc->Data  = Object;
+    CmObjectDesc->Count = ObjectCount;
+    Status              = EFI_SUCCESS;
+  } else {
+    Status = HandlerProc (This, CmObjectId, Token, CmObjectDesc);
+  }
+
+  DEBUG ((
+    DEBUG_INFO,
+    "INFO: Token = 0x%p, CmObjectId = " FMT_CM_OBJECT_ID ", "
+                                                         "Ptr = 0x%p, Size = %lu, Count = %lu\n",
+    (VOID *)Token,
+    CmObjectId,
+    CmObjectDesc->Data,
+    CmObjectDesc->Size,
+    CmObjectDesc->Count
+    ));
+  return Status;
+}
+**/
+
+/**
+  Function pointer called by the parser to add information.
+
+  Callback function that the parser can use to add new
+  CmObj. This function must copy the CmObj data and not rely on
+  the parser preserving the CmObj memory.
+  This function is responsible of the Token allocation.
+
+  @param  [in]  ParserHandle  A handle to the parser instance.
+  @param  [in]  Context       A pointer to the caller's context provided in
+                              HwInfoParserInit ().
+  @param  [in]  CmObjDesc     CM_OBJ_DESCRIPTOR containing the CmObj(s) to add.
+  @param  [out] Token         If provided and success, contain the token
+                              generated for the CmObj.
+
+  @retval EFI_SUCCESS             The function completed successfully.
+  @retval EFI_INVALID_PARAMETER   Invalid parameter.
+**/
+STATIC
+EFI_STATUS
+EFIAPI
+HwInfoAdd (
+  IN        HW_INFO_PARSER_HANDLE  ParserHandle,
+  IN        VOID                   *Context,
+  IN  CONST CM_OBJ_DESCRIPTOR      *CmObjDesc,
+  OUT       CM_OBJECT_TOKEN        *Token OPTIONAL
+  )
+{
+  EFI_STATUS                      Status;
+  EDKII_PLATFORM_REPOSITORY_INFO  *PlatformRepo;
+
+  if ((ParserHandle == NULL)  ||
+      (Context == NULL)       ||
+      (CmObjDesc == NULL))
+  {
+    ASSERT (ParserHandle != NULL);
+    ASSERT (Context != NULL);
+    ASSERT (CmObjDesc != NULL);
+    return EFI_INVALID_PARAMETER;
+  }
+
+  PlatformRepo = (EDKII_PLATFORM_REPOSITORY_INFO *)Context;
+
+  DEBUG_CODE_BEGIN ();
+  //
+  // Print the received objects.
+  //
+  ParseCmObjDesc (CmObjDesc);
+  DEBUG_CODE_END ();
+
+  Status = DynPlatRepoAddObject (
+             PlatformRepo->DynamicPlatformRepo,
+             CmObjDesc,
+             Token
+             );
+  if (EFI_ERROR (Status)) {
+    ASSERT_EFI_ERROR (Status);
+  }
+
+  return Status;
+}
+
+/**
+  Cleanup the platform configuration repository.
+
+  @param [in]  This        Pointer to the Configuration Manager Protocol.
+
+  @retval EFI_SUCCESS             Success
+  @retval EFI_INVALID_PARAMETER   A parameter is invalid.
+**/
+STATIC
+EFI_STATUS
+EFIAPI
+CleanupPlatformRepository (
+  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST  This
+  )
+{
+  EFI_STATUS                      Status;
+  EDKII_PLATFORM_REPOSITORY_INFO  *PlatformRepo;
+
+  if (This == NULL) {
+    ASSERT (This != NULL);
+    return EFI_INVALID_PARAMETER;
+  }
+
+  PlatformRepo = This->PlatRepoInfo;
+
+  //
+  // Shutdown the dynamic repo and free all objects.
+  //
+  Status = DynamicPlatRepoShutdown (PlatformRepo->DynamicPlatformRepo);
+  if (EFI_ERROR (Status)) {
+    ASSERT_EFI_ERROR (Status);
+    return Status;
+  }
+
+  //
+  // Shutdown parser.
+  //
+  Status = HwInfoParserShutdown (PlatformRepo->FdtParserHandle);
+  if (EFI_ERROR (Status)) {
+    ASSERT_EFI_ERROR (Status);
+  }
+
+  return Status;
+}
+
+/**
+  Initialize the platform configuration repository.
+
+  @param [in]  This        Pointer to the Configuration Manager Protocol.
+
+  @retval EFI_SUCCESS             Success
+  @retval EFI_INVALID_PARAMETER   A parameter is invalid.
+  @retval EFI_OUT_OF_RESOURCES    An allocation has failed.
+**/
+STATIC
+EFI_STATUS
+EFIAPI
+InitializePlatformRepository (
+  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST  This
+  )
+{
+  EFI_STATUS                      Status;
+  EDKII_PLATFORM_REPOSITORY_INFO  *PlatformRepo;
+  VOID                            *Hob;
+
+  if (This == NULL) {
+    ASSERT (This != NULL);
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Hob = GetFirstGuidHob (&gFdtHobGuid);
+  if ((Hob == NULL) || (GET_GUID_HOB_DATA_SIZE (Hob) != sizeof (UINT64))) {
+    ASSERT (FALSE);
+    ASSERT (GET_GUID_HOB_DATA_SIZE (Hob) != sizeof (UINT64));
+    return EFI_NOT_FOUND;
+  }
+
+  PlatformRepo          = This->PlatRepoInfo;
+  PlatformRepo->FdtBase = (VOID *)*(UINTN *)GET_GUID_HOB_DATA (Hob);
+
+  //
+  // Initialise the dynamic platform repository.
+  //
+  Status = DynamicPlatRepoInit (&PlatformRepo->DynamicPlatformRepo);
+  if (EFI_ERROR (Status)) {
+    ASSERT_EFI_ERROR (Status);
+    return Status;
+  }
+
+  //
+  // Initialise the FDT parser
+  //
+  Status = HwInfoParserInit (
+             PlatformRepo->FdtBase,
+             PlatformRepo,
+             HwInfoAdd,
+             &PlatformRepo->FdtParserHandle
+             );
+  if (EFI_ERROR (Status)) {
+    ASSERT_EFI_ERROR (Status);
+    goto ErrorHandler;
+  }
+
+  Status = HwInfoParse (PlatformRepo->FdtParserHandle);
+  if (EFI_ERROR (Status)) {
+    ASSERT_EFI_ERROR (Status);
+    goto ErrorHandler;
+  }
+
+  Status = DynamicPlatRepoFinalise (PlatformRepo->DynamicPlatformRepo);
+  if (EFI_ERROR (Status)) {
+    ASSERT_EFI_ERROR (Status);
+    goto ErrorHandler;
+  }
+
+  return EFI_SUCCESS;
+
+ErrorHandler:
+  CleanupPlatformRepository (This);
+  return Status;
+}
+
+/**
+  Return a standard namespace object.
+
+  @param [in]      This        Pointer to the Configuration Manager Protocol.
+  @param [in]      CmObjectId  The Configuration Manager Object ID.
+  @param [in]      Token       An optional token identifying the object. If
+                               unused this must be CM_NULL_TOKEN.
+  @param [in, out] CmObject    Pointer to the Configuration Manager Object
+                               descriptor describing the requested Object.
+
+  @retval EFI_SUCCESS           Success.
+  @retval EFI_INVALID_PARAMETER A parameter is invalid.
+  @retval EFI_NOT_FOUND         The required object information is not found.
+**/
+EFI_STATUS
+EFIAPI
+GetStandardNameSpaceObject (
+  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST  This,
+  IN  CONST CM_OBJECT_ID                                  CmObjectId,
+  IN  CONST CM_OBJECT_TOKEN                               Token OPTIONAL,
+  IN  OUT   CM_OBJ_DESCRIPTOR                     *CONST  CmObject
+  )
+{
+  EFI_STATUS                      Status;
+  EDKII_PLATFORM_REPOSITORY_INFO  *PlatformRepo;
+  UINTN                           AcpiTableCount;
+  CM_OBJ_DESCRIPTOR               CmObjDesc;
+
+  if ((This == NULL) || (CmObject == NULL)) {
+    ASSERT (This != NULL);
+    ASSERT (CmObject != NULL);
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Status       = EFI_NOT_FOUND;
+  PlatformRepo = This->PlatRepoInfo;
+
+  switch (GET_CM_OBJECT_ID (CmObjectId)) {
+    case EStdObjCfgMgrInfo:
+      Status = HandleCmObject (
+                 CmObjectId,
+                 &PlatformRepo->CmInfo,
+                 sizeof (PlatformRepo->CmInfo),
+                 1,
+                 CmObject
+                 );
+      break;
+
+    case EStdObjAcpiTableList:
+      AcpiTableCount = ARRAY_SIZE (PlatformRepo->CmAcpiTableList);
+
+      //
+      // Get Pci config space information.
+      //
+      Status = DynamicPlatRepoGetObject (
+                 PlatformRepo->DynamicPlatformRepo,
+                 CREATE_CM_ARCH_COMMON_OBJECT_ID (
+                   EArchCommonObjPciConfigSpaceInfo
+                   ),
+                 CM_NULL_TOKEN,
+                 &CmObjDesc
+                 );
+      if (Status == EFI_NOT_FOUND) {
+        //
+        // The last 3 tables are for PCIe. If PCIe information is not
+        // present, RiscVVirt was launched without the PCIe option.
+        // Therefore, reduce the table count by 3.
+        //
+        AcpiTableCount -= 3;
+      } else if (EFI_ERROR (Status)) {
+        ASSERT_EFI_ERROR (Status);
+        return Status;
+      }
+
+      Status = HandleCmObject (
+                 CmObjectId,
+                 PlatformRepo->CmAcpiTableList,
+                 (sizeof (PlatformRepo->CmAcpiTableList[0]) * AcpiTableCount),
+                 AcpiTableCount,
+                 CmObject
+                 );
+      break;
+
+    default:
+      Status = EFI_NOT_FOUND;
+      DEBUG (
+        (
+         DEBUG_ERROR,
+         "ERROR: CmObjectId " FMT_CM_OBJECT_ID ". Status = %r\n",
+         CmObjectId,
+         Status
+        )
+        );
+      break;
+  }
+
+  return Status;
+}
+
+/**
+  Return an ArchCommon namespace object.
+
+  @param [in]      This        Pointer to the Configuration Manager Protocol.
+  @param [in]      CmObjectId  The Configuration Manager Object ID.
+  @param [in]      Token       An optional token identifying the object. If
+                               unused this must be CM_NULL_TOKEN.
+  @param [in, out] CmObject    Pointer to the Configuration Manager Object
+                               descriptor describing the requested Object.
+
+  @retval EFI_SUCCESS           Success.
+  @retval EFI_INVALID_PARAMETER A parameter is invalid.
+  @retval EFI_NOT_FOUND         The required object information is not found.
+**/
+EFI_STATUS
+EFIAPI
+GetArchCommonNameSpaceObject (
+  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST  This,
+  IN  CONST CM_OBJECT_ID                                  CmObjectId,
+  IN  CONST CM_OBJECT_TOKEN                               Token OPTIONAL,
+  IN  OUT   CM_OBJ_DESCRIPTOR                     *CONST  CmObject
+  )
+{
+  EFI_STATUS                      Status;
+  EDKII_PLATFORM_REPOSITORY_INFO  *PlatformRepo;
+
+  if ((This == NULL) || (CmObject == NULL)) {
+    ASSERT (This != NULL);
+    ASSERT (CmObject != NULL);
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Status       = EFI_NOT_FOUND;
+  PlatformRepo = This->PlatRepoInfo;
+
+  //
+  // First check among the static objects.
+  //
+  switch (GET_CM_OBJECT_ID (CmObjectId)) {
+    case EArchCommonObjPowerManagementProfileInfo:
+      Status = HandleCmObject (
+                 CmObjectId,
+                 &PlatformRepo->PmProfileInfo,
+                 sizeof (PlatformRepo->PmProfileInfo),
+                 1,
+                 CmObject
+                 );
+      break;
+
+    default:
+      //
+      // No match found among the static objects.
+      // Check the dynamic objects.
+      //
+      Status = DynamicPlatRepoGetObject (
+                 PlatformRepo->DynamicPlatformRepo,
+                 CmObjectId,
+                 Token,
+                 CmObject
+                 );
+      break;
+  } // switch
+
+  if (Status == EFI_NOT_FOUND) {
+    DEBUG (
+      (
+       DEBUG_INFO,
+       "INFO: CmObjectId " FMT_CM_OBJECT_ID ". Status = %r\n",
+       CmObjectId,
+       Status
+      )
+      );
+  } else {
+    ASSERT_EFI_ERROR (Status);
+  }
+
+  return Status;
+}
+
+/**
+  Return RISC-V namespace object.
+
+  @param [in]      This        Pointer to the Configuration Manager Protocol.
+  @param [in]      CmObjectId  The Configuration Manager Object ID.
+  @param [in]      Token       An optional token identifying the object. If
+                               unused this must be CM_NULL_TOKEN.
+  @param [in, out] CmObject    Pointer to the Configuration Manager Object
+                               descriptor describing the requested Object.
+
+  @retval EFI_SUCCESS           Success.
+  @retval EFI_INVALID_PARAMETER A parameter is invalid.
+  @retval EFI_NOT_FOUND         The required object information is not found.
+**/
+EFI_STATUS
+EFIAPI
+GetRiscVNameSpaceObject (
+  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST  This,
+  IN  CONST CM_OBJECT_ID                                  CmObjectId,
+  IN  CONST CM_OBJECT_TOKEN                               Token OPTIONAL,
+  IN  OUT   CM_OBJ_DESCRIPTOR                     *CONST  CmObject
+  )
+{
+  EFI_STATUS                      Status;
+  EDKII_PLATFORM_REPOSITORY_INFO  *PlatformRepo;
+
+  if ((This == NULL) || (CmObject == NULL)) {
+    ASSERT (This != NULL);
+    ASSERT (CmObject != NULL);
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Status       = EFI_NOT_FOUND;
+  PlatformRepo = This->PlatRepoInfo;
+
+  //
+  // First check among the static objects.
+  //
+  Status = DynamicPlatRepoGetObject (
+             PlatformRepo->DynamicPlatformRepo,
+             CmObjectId,
+             Token,
+             CmObject
+             );
+
+  if (Status == EFI_NOT_FOUND) {
+    DEBUG (
+      (
+       DEBUG_INFO,
+       "INFO: CmObjectId " FMT_CM_OBJECT_ID ". Status = %r\n",
+       CmObjectId,
+       Status
+      )
+      );
+  } else {
+    ASSERT_EFI_ERROR (Status);
+  }
+
+  return Status;
+}
+
+/**
+  Return an OEM namespace object.
+
+  @param [in]      This        Pointer to the Configuration Manager Protocol.
+  @param [in]      CmObjectId  The Configuration Manager Object ID.
+  @param [in]      Token       An optional token identifying the object. If
+                               unused this must be CM_NULL_TOKEN.
+  @param [in, out] CmObject    Pointer to the Configuration Manager Object
+                               descriptor describing the requested Object.
+
+  @retval EFI_SUCCESS           Success.
+  @retval EFI_INVALID_PARAMETER A parameter is invalid.
+  @retval EFI_NOT_FOUND         The required object information is not found.
+**/
+EFI_STATUS
+EFIAPI
+GetOemNameSpaceObject (
+  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST  This,
+  IN  CONST CM_OBJECT_ID                                  CmObjectId,
+  IN  CONST CM_OBJECT_TOKEN                               Token OPTIONAL,
+  IN  OUT   CM_OBJ_DESCRIPTOR                     *CONST  CmObject
+  )
+{
+  EFI_STATUS  Status;
+
+  Status = EFI_SUCCESS;
+  if ((This == NULL) || (CmObject == NULL)) {
+    ASSERT (This != NULL);
+    ASSERT (CmObject != NULL);
+    return EFI_INVALID_PARAMETER;
+  }
+
+  switch (GET_CM_OBJECT_ID (CmObjectId)) {
+    default:
+      Status = EFI_NOT_FOUND;
+      DEBUG (
+        (
+         DEBUG_ERROR,
+         "ERROR: CmObjectId " FMT_CM_OBJECT_ID ". Status = %r\n",
+         CmObjectId,
+         Status
+        )
+        );
+      break;
+  }
+
+  return Status;
+}
+
+/**
+  The GetObject function defines the interface implemented by the
+  Configuration Manager Protocol for returning the Configuration
+  Manager Objects.
+
+  @param [in]      This        Pointer to the Configuration Manager Protocol.
+  @param [in]      CmObjectId  The Configuration Manager Object ID.
+  @param [in]      Token       An optional token identifying the object. If
+                               unused this must be CM_NULL_TOKEN.
+  @param [in, out] CmObject    Pointer to the Configuration Manager Object
+                               descriptor describing the requested Object.
+
+  @retval EFI_SUCCESS           Success.
+  @retval EFI_INVALID_PARAMETER A parameter is invalid.
+  @retval EFI_NOT_FOUND         The required object information is not found.
+**/
+EFI_STATUS
+EFIAPI
+RiscVVirtPlatformGetObject (
+  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST  This,
+  IN  CONST CM_OBJECT_ID                                  CmObjectId,
+  IN  CONST CM_OBJECT_TOKEN                               Token OPTIONAL,
+  IN  OUT   CM_OBJ_DESCRIPTOR                     *CONST  CmObject
+  )
+{
+  EFI_STATUS  Status;
+
+  if ((This == NULL) || (CmObject == NULL)) {
+    ASSERT (This != NULL);
+    ASSERT (CmObject != NULL);
+    return EFI_INVALID_PARAMETER;
+  }
+
+  switch (GET_CM_NAMESPACE_ID (CmObjectId)) {
+    case EObjNameSpaceStandard:
+      Status = GetStandardNameSpaceObject (This, CmObjectId, Token, CmObject);
+      break;
+    case EObjNameSpaceArchCommon:
+      Status = GetArchCommonNameSpaceObject (This, CmObjectId, Token, CmObject);
+      break;
+    case EObjNameSpaceRiscV:
+      Status = GetRiscVNameSpaceObject (This, CmObjectId, Token, CmObject);
+      break;
+    case EObjNameSpaceOem:
+      Status = GetOemNameSpaceObject (This, CmObjectId, Token, CmObject);
+      break;
+    default:
+      Status = EFI_INVALID_PARAMETER;
+      DEBUG (
+        (
+         DEBUG_ERROR,
+         "ERROR: Unknown Namespace CmObjectId " FMT_CM_OBJECT_ID ". "
+                                                                 "Status = %r\n",
+         CmObjectId,
+         Status
+        )
+        );
+      break;
+  }
+
+  return Status;
+}
+
+/**
+  The SetObject function defines the interface implemented by the
+  Configuration Manager Protocol for updating the Configuration
+  Manager Objects.
+
+  @param [in]      This        Pointer to the Configuration Manager Protocol.
+  @param [in]      CmObjectId  The Configuration Manager Object ID.
+  @param [in]      Token       An optional token identifying the object. If
+                               unused this must be CM_NULL_TOKEN.
+  @param [in]      CmObject    Pointer to the Configuration Manager Object
+                               descriptor describing the Object.
+
+  @retval EFI_UNSUPPORTED  This operation is not supported.
+**/
+EFI_STATUS
+EFIAPI
+RiscVVirtPlatformSetObject (
+  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST  This,
+  IN  CONST CM_OBJECT_ID                                  CmObjectId,
+  IN  CONST CM_OBJECT_TOKEN                               Token OPTIONAL,
+  IN        CM_OBJ_DESCRIPTOR                     *CONST  CmObject
+  )
+{
+  return EFI_UNSUPPORTED;
+}
+
+//
+// A structure describing the configuration manager protocol interface.
+//
+STATIC
+CONST
+EDKII_CONFIGURATION_MANAGER_PROTOCOL  mRiscVVirtPlatformConfigManagerProtocol = {
+  CREATE_REVISION (1,         0),
+  RiscVVirtPlatformGetObject,
+  RiscVVirtPlatformSetObject,
+  &mRiscVVirtPlatRepositoryInfo
+};
+
+/**
+  Entrypoint of Configuration Manager Dxe.
+
+  @param  ImageHandle
+  @param  SystemTable
+
+  @retval EFI_SUCCESS
+  @retval EFI_LOAD_ERROR
+  @retval EFI_OUT_OF_RESOURCES
+**/
+EFI_STATUS
+EFIAPI
+ConfigurationManagerDxeInitialize (
+  IN EFI_HANDLE        ImageHandle,
+  IN EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  EFI_STATUS  Status;
+
+  Status = gBS->InstallProtocolInterface (
+                  &ImageHandle,
+                  &gEdkiiConfigurationManagerProtocolGuid,
+                  EFI_NATIVE_INTERFACE,
+                  (VOID *)&mRiscVVirtPlatformConfigManagerProtocol
+                  );
+  if (EFI_ERROR (Status)) {
+    DEBUG (
+      (
+       DEBUG_ERROR,
+       "ERROR: Failed to get Install Configuration Manager Protocol." \
+       " Status = %r\n",
+       Status
+      )
+      );
+    return Status;
+  }
+
+  Status = InitializePlatformRepository (
+             &mRiscVVirtPlatformConfigManagerProtocol
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG (
+      (
+       DEBUG_ERROR,
+       "ERROR: Failed to initialize the Platform Configuration Repository." \
+       " Status = %r\n",
+       Status
+      )
+      );
+    goto ErrorHandler;
+  }
+
+  return Status;
+
+ErrorHandler:
+  gBS->UninstallProtocolInterface (
+         &ImageHandle,
+         &gEdkiiConfigurationManagerProtocolGuid,
+         (VOID *)&mRiscVVirtPlatformConfigManagerProtocol
+         );
+  return Status;
+}
+
+/**
+  Unload function for this image.
+
+  @param ImageHandle   Handle for the image of this driver.
+
+  @retval EFI_SUCCESS  Driver unloaded successfully.
+  @retval other        Driver can not unloaded.
+**/
+EFI_STATUS
+EFIAPI
+ConfigurationManagerDxeUnloadImage (
+  IN EFI_HANDLE  ImageHandle
+  )
+{
+  return CleanupPlatformRepository (&mRiscVVirtPlatformConfigManagerProtocol);
+}

--- a/OvmfPkg/RiscVVirt/RiscVVirtCfgMgrDxe/ConfigurationManager.h
+++ b/OvmfPkg/RiscVVirt/RiscVVirtCfgMgrDxe/ConfigurationManager.h
@@ -1,0 +1,106 @@
+/** @file
+
+  Copyright (c) 2024, Ventana Micro Systems Inc. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+  @par Glossary:
+    - Cm or CM   - Configuration Manager
+    - Obj or OBJ - Object
+**/
+
+#ifndef CONFIGURATION_MANAGER_H_
+#define CONFIGURATION_MANAGER_H_
+
+///
+/// C array containing the compiled AML template.
+/// This symbol is defined in the auto generated C file
+/// containing the AML bytecode array.
+///
+extern CHAR8  dsdt_aml_code[];
+
+///
+/// The configuration manager version.
+///
+#define CONFIGURATION_MANAGER_REVISION  CREATE_REVISION (1, 0)
+
+///
+/// The OEM ID
+///
+#define CFG_MGR_OEM_ID      { 'R', 'S', 'C', 'V', 'I', 'N' }
+#define CFG_MGR_CREATOR_ID  { 'R', 'S', 'C', 'V' }
+
+///
+/// Memory address size limit. Assume the whole address space.
+///
+#define MEMORY_ADDRESS_SIZE_LIMIT  64
+
+/** A function that prepares Configuration Manager Objects for returning.
+
+  @param [in]  This        Pointer to the Configuration Manager Protocol.
+  @param [in]  CmObjectId  The Configuration Manager Object ID.
+  @param [in]  Token       A token for identifying the object.
+  @param [out] CmObject    Pointer to the Configuration Manager Object
+                           descriptor describing the requested Object.
+
+  @retval EFI_SUCCESS           Success.
+  @retval EFI_INVALID_PARAMETER A parameter is invalid.
+  @retval EFI_NOT_FOUND         The required object information is not found.
+**/
+typedef EFI_STATUS (*CM_OBJECT_HANDLER_PROC) (
+  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST  This,
+  IN  CONST CM_OBJECT_ID                                  CmObjectId,
+  IN  CONST CM_OBJECT_TOKEN                               Token,
+  IN  OUT   CM_OBJ_DESCRIPTOR                     *CONST  CmObject
+  );
+
+///
+/// A helper macro for mapping a reference token.
+///
+#define REFERENCE_TOKEN(Field)                                     \
+          (CM_OBJECT_TOKEN)((UINT8*)&mRiscVVirtPlatRepositoryInfo +  \
+           OFFSET_OF (EDKII_PLATFORM_REPOSITORY_INFO, Field))
+
+///
+/// The number of ACPI tables to install
+///
+#define PLAT_ACPI_TABLE_COUNT  9
+
+///
+/// A structure describing the platform configuration
+/// manager repository information
+///
+typedef struct PlatformRepositoryInfo {
+  ///
+  /// Configuration Manager Information.
+  ///
+  CM_STD_OBJ_CONFIGURATION_MANAGER_INFO           CmInfo;
+
+  ///
+  /// List of ACPI tables
+  ///
+  CM_STD_OBJ_ACPI_TABLE_INFO                      CmAcpiTableList[PLAT_ACPI_TABLE_COUNT];
+
+  ///
+  /// Power management profile information
+  ///
+  CM_ARCH_COMMON_POWER_MANAGEMENT_PROFILE_INFO    PmProfileInfo;
+
+  ///
+  /// Dynamic platform repository.
+  /// CmObj created by parsing the Kvmtool device tree are stored here.
+  ///
+  DYNAMIC_PLATFORM_REPOSITORY_INFO                *DynamicPlatformRepo;
+
+  ///
+  /// Base address of the FDT.
+  ///
+  VOID                                            *FdtBase;
+
+  ///
+  /// A handle to the FDT HwInfoParser.
+  ///
+  HW_INFO_PARSER_HANDLE                           FdtParserHandle;
+} EDKII_PLATFORM_REPOSITORY_INFO;
+
+#endif // CONFIGURATION_MANAGER_H_

--- a/OvmfPkg/RiscVVirt/RiscVVirtCfgMgrDxe/ConfigurationManagerDxe.inf
+++ b/OvmfPkg/RiscVVirt/RiscVVirtCfgMgrDxe/ConfigurationManagerDxe.inf
@@ -1,0 +1,53 @@
+## @file
+#  Configuration Manager Dxe
+#
+#  Copyright (c) 2024, Ventana Micro Systems Inc. All rights reserved.<BR>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION                    = 0x0001001B
+  BASE_NAME                      = ConfigurationManagerDxe
+  FILE_GUID                      = 848763bf-21ad-565d-a77d-2a204594011a
+  MODULE_TYPE                    = DXE_DRIVER
+  VERSION_STRING                 = 1.0
+  ENTRY_POINT                    = ConfigurationManagerDxeInitialize
+  UNLOAD_IMAGE                   = ConfigurationManagerDxeUnloadImage
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = RISCV64
+#
+
+[Sources]
+  AslTables/Dsdt.asl
+  ConfigurationManager.c
+  ConfigurationManager.h
+
+[Packages]
+  DynamicTablesPkg/DynamicTablesPkg.dec
+  EmbeddedPkg/EmbeddedPkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  MdePkg/MdePkg.dec
+  OvmfPkg/OvmfPkg.dec
+
+[LibraryClasses]
+  DynamicPlatRepoLib
+  HobLib
+  HwInfoParserLib
+  PrintLib
+  TableHelperLib
+  UefiBootServicesTableLib
+  UefiDriverEntryPoint
+  UefiRuntimeServicesTableLib
+
+[Protocols]
+  gEdkiiConfigurationManagerProtocolGuid
+
+[Guids]
+  gFdtHobGuid
+
+[Depex]
+  TRUE

--- a/OvmfPkg/RiscVVirt/RiscVVirtQemu.dsc
+++ b/OvmfPkg/RiscVVirt/RiscVVirtQemu.dsc
@@ -45,6 +45,7 @@
   DEFINE NETWORK_TLS_ENABLE             = FALSE
   DEFINE NETWORK_ALLOW_HTTP_CONNECTIONS = TRUE
   DEFINE NETWORK_ISCSI_ENABLE           = FALSE
+  DEFINE ACPIVIEW_ENABLE                = TRUE
 
 !if $(NETWORK_SNP_ENABLE) == TRUE
   !error "NETWORK_SNP_ENABLE is IA32/X64/EBC only"
@@ -64,6 +65,10 @@
   GCC:  *_*_*_DLINK_FLAGS = -z common-page-size=0x1000
   MSFT: *_*_*_DLINK_FLAGS = /ALIGN:4096
 
+!ifdef DYNAMIC_TABLES_FRAMEWORK
+  *_*_*_PLATFORM_FLAGS = -DDYNAMIC_TABLES_FRAMEWORK
+!endif
+
 ################################################################################
 #
 # Library Class section - list of all Library Classes needed by this Platform.
@@ -73,6 +78,10 @@
 !include OvmfPkg/RiscVVirt/RiscVVirt.dsc.inc
 
 !include MdePkg/MdeLibs.dsc.inc
+
+!ifdef DYNAMIC_TABLES_FRAMEWORK
+!include DynamicTablesPkg/DynamicTables.dsc.inc
+!endif
 
 [LibraryClasses.common]
   # Virtio Support
@@ -101,6 +110,11 @@
   PeiHardwareInfoLib|OvmfPkg/Library/HardwareInfoLib/PeiHardwareInfoLib.inf
   PlatformHookLib|MdeModulePkg/Library/BasePlatformHookLibNull/BasePlatformHookLibNull.inf
   ImagePropertiesRecordLib|MdeModulePkg/Library/ImagePropertiesRecordLib/ImagePropertiesRecordLib.inf
+
+!ifdef DYNAMIC_TABLES_FRAMEWORK
+  HwInfoParserLib|DynamicTablesPkg/Library/FdtHwInfoParserLib/FdtHwInfoParserLib.inf
+  DynamicPlatRepoLib|DynamicTablesPkg/Library/Common/DynamicPlatRepoLib/DynamicPlatRepoLib.inf
+!endif
 
 !if $(TPM2_ENABLE) == TRUE
   Tpm2CommandLib|SecurityPkg/Library/Tpm2CommandLib/Tpm2CommandLib.inf
@@ -180,6 +194,10 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdStatusCodeMemorySize|1
 
   gEfiMdeModulePkgTokenSpaceGuid.PcdSmbiosEntryPointProvideMethod|0x2
+!ifdef DYNAMIC_TABLES_FRAMEWORK
+  gEdkiiDynamicTablesPkgTokenSpaceGuid.PcdNonBsaCompliant16550SerialHid|"RSCV0003"
+!endif
+
 
 [PcdsDynamicDefault.common]
   gEfiMdePkgTokenSpaceGuid.PcdPlatformBootTimeOut|3
@@ -487,8 +505,12 @@
   # ACPI Support
   #
   OvmfPkg/PlatformHasAcpiDtDxe/PlatformHasAcpiDtDxe.inf
+!ifndef DYNAMIC_TABLES_FRAMEWORK
   MdeModulePkg/Universal/Acpi/BootGraphicsResourceTableDxe/BootGraphicsResourceTableDxe.inf
   OvmfPkg/AcpiPlatformDxe/AcpiPlatformDxe.inf {
     <LibraryClasses>
       NULL|OvmfPkg/Fdt/FdtPciPcdProducerLib/FdtPciPcdProducerLib.inf
   }
+!else
+  OvmfPkg/RiscVVirt/RiscVVirtCfgMgrDxe/ConfigurationManagerDxe.inf
+!endif

--- a/OvmfPkg/RiscVVirt/RiscVVirtQemu.fdf
+++ b/OvmfPkg/RiscVVirt/RiscVVirtQemu.fdf
@@ -178,8 +178,14 @@ INF  OvmfPkg/SmbiosPlatformDxe/SmbiosPlatformDxe.inf
 #
 INF  OvmfPkg/PlatformHasAcpiDtDxe/PlatformHasAcpiDtDxe.inf
 INF  MdeModulePkg/Universal/Acpi/AcpiTableDxe/AcpiTableDxe.inf
-INF  MdeModulePkg/Universal/Acpi/BootGraphicsResourceTableDxe/BootGraphicsResourceTableDxe.inf
-INF  OvmfPkg/AcpiPlatformDxe/AcpiPlatformDxe.inf
+
+!ifdef DYNAMIC_TABLES_FRAMEWORK
+  !include DynamicTablesPkg/DynamicTables.fdf.inc
+  INF  OvmfPkg/RiscVVirt/RiscVVirtCfgMgrDxe/ConfigurationManagerDxe.inf
+!else
+  INF  OvmfPkg/AcpiPlatformDxe/AcpiPlatformDxe.inf
+  INF  MdeModulePkg/Universal/Acpi/BootGraphicsResourceTableDxe/BootGraphicsResourceTableDxe.inf
+!endif
 
 #
 # PCI support


### PR DESCRIPTION
# Description

This series adds support for RISC-V in DynamicTablesPkg. This helps in creating ACPI tables using device tree.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

RiscVVirtQemu platform is updated to use DynamicTablesPkg based on the build time option. With DynamicTablesPkg enabled, EDK2 for RiscVVirtQemu ignores the ACPI tables passed by qemu and creates new ACPI tables using the information from the DT passed from M-mode firmware (opensbi). Linux with ACPI support is booted with different interrupt controllers and with different number of cpus and verified things are created as expected.

## Integration Instructions

<NA>
