### PR TITLE
OvmfPkg: Move kernel hashes section to end

### DIFF
--- a/OvmfPkg/ResetVector/X64/OvmfSevMetadata.asm
+++ b/OvmfPkg/ResetVector/X64/OvmfSevMetadata.asm
@@ -76,6 +76,12 @@ SvsmCaa:
   DD  SVSM_CAA_SIZE
   DD  OVMF_SECTION_TYPE_SVSM_CAA
 
+; Region need to be pre-validated by the hypervisor
+PreValidate3:
+  DD  SNP_SEC_MEM_BASE_DESC_3
+  DD  SNP_SEC_MEM_SIZE_DESC_3
+  DD  OVMF_SECTION_TYPE_SNP_SEC_MEM
+
 %if (SEV_SNP_KERNEL_HASHES_BASE > 0)
 ; Kernel hashes for measured direct boot, or zero page if
 ; there are no kernel hashes / SEV secrets
@@ -85,10 +91,5 @@ SevSnpKernelHashes:
   DD  OVMF_SECTION_TYPE_KERNEL_HASHES
 %endif
 
-; Region need to be pre-validated by the hypervisor
-PreValidate3:
-  DD  SNP_SEC_MEM_BASE_DESC_3
-  DD  SNP_SEC_MEM_SIZE_DESC_3
-  DD  OVMF_SECTION_TYPE_SNP_SEC_MEM
 OvmfSevGuidedStructureEnd:
   ALIGN   16


### PR DESCRIPTION
When launching a SEV-SNP VM, the ROM is not all that must be measured. The OvmfSevMetadata sections describe ranges of memory that must be measured with different types than PAGE_TYPE_NORMAL, except one. The SevSnpKernelHashes page is also PAGE_TYPE_NORMAL, but is populated by the VMM from configuration data that is separate from the OVMF build itself. To more compactly provide reference values for the measurement of the firmware separately from the kernel hashes, it's advantageous to measure as much known information as possible first.

Whereas VMMs are permitted to measure these sections in any order they prefer, the normative order of how they appear in the .fd is easiest to follow. This change is semantics-preserving. Measurement calculation tools that do not follow the normative ordering would need updating to accommodate, but I don't know of any. The accounting for EC2 moving the CPUID page to the end of measurement would be unchanged.

This change is to improve performance of a proposed launch update event log to separate responsibility for initially measured data before VM launch, application/vnd.amd.sevsnp.launch-updates+cbor:

https://github.com/deeglaze/draft-deeglaze-amd-sev-snp-corim-profile

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

Built and launched a SEV-SNP VM with the changed firmware.

## Integration Instructions

N/A
