### PR TITLE
MdeModulePkg: Gcd: Only Update gMemoryMap Attributes if Correct GCD Type

### DIFF
--- a/MdeModulePkg/Core/Dxe/Gcd/Gcd.c
+++ b/MdeModulePkg/Core/Dxe/Gcd/Gcd.c
@@ -989,6 +989,20 @@ CoreConvertSpace (
       //
       case GCD_SET_CAPABILITIES_MEMORY_OPERATION:
         Entry->Capabilities = Capabilities;
+
+        // Only SystemMemory and MoreReliable memory is in gMemoryMap
+        // so only attempt to update the attributes there if this is
+        // a relevant GCD type
+        if ((Entry->GcdMemoryType == EfiGcdMemoryTypeSystemMemory) ||
+            (Entry->GcdMemoryType == EfiGcdMemoryTypeMoreReliable))
+        {
+          CoreUpdateMemoryAttributes (
+            BaseAddress,
+            RShiftU64 (Length, EFI_PAGE_SHIFT),
+            Capabilities & (~EFI_MEMORY_RUNTIME)
+            );
+        }
+
         break;
     }
 
@@ -1700,17 +1714,10 @@ CoreSetMemorySpaceCapabilities (
   IN UINT64                Capabilities
   )
 {
-  EFI_STATUS  Status;
-
   DEBUG ((DEBUG_GCD, "GCD:CoreSetMemorySpaceCapabilities(Base=%016lx,Length=%016lx)\n", BaseAddress, Length));
   DEBUG ((DEBUG_GCD, "  Capabilities  = %016lx\n", Capabilities));
 
-  Status = CoreConvertSpace (GCD_SET_CAPABILITIES_MEMORY_OPERATION, (EFI_GCD_MEMORY_TYPE)0, (EFI_GCD_IO_TYPE)0, BaseAddress, Length, Capabilities, 0);
-  if (!EFI_ERROR (Status)) {
-    CoreUpdateMemoryAttributes (BaseAddress, RShiftU64 (Length, EFI_PAGE_SHIFT), Capabilities & (~EFI_MEMORY_RUNTIME));
-  }
-
-  return Status;
+  return CoreConvertSpace (GCD_SET_CAPABILITIES_MEMORY_OPERATION, (EFI_GCD_MEMORY_TYPE)0, (EFI_GCD_IO_TYPE)0, BaseAddress, Length, Capabilities, 0);
 }
 
 /**


### PR DESCRIPTION
# Description

Currently whenever gDS->SetMemorySpaceCapabilities() is called, it attempts to set the corresponding attributes in the gMemoryMap descriptor. However, gMemoryMap only contains entries from GCD types EfiGcdMemoryTypeSystemMemory and EfiGcdMemoryTypeMoreReliable, so for all other types a failure is reported in the code. This is a failure that is expected, so it does not provide value and can lead to real failures being ignored.

This patch updates the gDS->SetMemorySpaceCapabilities() code to only call into updating gMemoryMap if the GCD type is SystemMemory or MoreReliable, to avoid spurious errors being reported. This also avoids the expensive operation of searching through gMemoryMap for entries we know we will fail to find.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Booted on a virtual platform and confirmed former spurious prints are not seen and OS can be booted into.

## Integration Instructions

N/A.