### PR TITLE
MdePkg: Remove duplicate source from BaseMemoryLib INF files

### DIFF
--- a/MdePkg/Library/BaseMemoryLibMmx/BaseMemoryLibMmx.inf
+++ b/MdePkg/Library/BaseMemoryLibMmx/BaseMemoryLibMmx.inf
@@ -57,17 +57,6 @@
   Ia32/ZeroMem.nasm
   Ia32/SetMem.nasm
   Ia32/CopyMem.nasm
-  Ia32/ScanMem64.nasm
-  Ia32/ScanMem32.nasm
-  Ia32/ScanMem16.nasm
-  Ia32/ScanMem8.nasm
-  Ia32/CompareMem.nasm
-  Ia32/SetMem64.nasm
-  Ia32/SetMem32.nasm
-  Ia32/SetMem16.nasm
-  Ia32/ZeroMem.nasm
-  Ia32/SetMem.nasm
-  Ia32/CopyMem.nasm
   Ia32/IsZeroBuffer.nasm
 
 [Sources.X64]
@@ -82,19 +71,7 @@
   X64/SetMem16.nasm
   X64/SetMem.nasm
   X64/CopyMem.nasm
-  X64/ScanMem64.nasm
-  X64/ScanMem32.nasm
-  X64/ScanMem16.nasm
-  X64/ScanMem8.nasm
-  X64/CompareMem.nasm
-  X64/SetMem64.nasm
-  X64/SetMem32.nasm
-  X64/SetMem16.nasm
-  X64/ZeroMem.nasm
-  X64/SetMem.nasm
-  X64/CopyMem.nasm
   X64/IsZeroBuffer.nasm
-
 
 [LibraryClasses]
   DebugLib

--- a/MdePkg/Library/BaseMemoryLibOptDxe/BaseMemoryLibOptDxe.inf
+++ b/MdePkg/Library/BaseMemoryLibOptDxe/BaseMemoryLibOptDxe.inf
@@ -40,17 +40,6 @@
   Ia32/SetMem16.nasm
   Ia32/SetMem.nasm
   Ia32/CopyMem.nasm
-  Ia32/ScanMem64.nasm
-  Ia32/ScanMem32.nasm
-  Ia32/ScanMem16.nasm
-  Ia32/ScanMem8.nasm
-  Ia32/CompareMem.nasm
-  Ia32/ZeroMem.nasm
-  Ia32/SetMem64.nasm
-  Ia32/SetMem32.nasm
-  Ia32/SetMem16.nasm
-  Ia32/SetMem.nasm
-  Ia32/CopyMem.nasm
   Ia32/IsZeroBuffer.nasm
   MemLibGuid.c
 

--- a/MdePkg/Library/BaseMemoryLibOptPei/BaseMemoryLibOptPei.inf
+++ b/MdePkg/Library/BaseMemoryLibOptPei/BaseMemoryLibOptPei.inf
@@ -27,31 +27,6 @@
 
 [Sources]
   MemLibInternals.h
-
-[Sources.Ia32]
-  Ia32/ScanMem64.nasm
-  Ia32/ScanMem32.nasm
-  Ia32/ScanMem16.nasm
-  Ia32/ScanMem8.nasm
-  Ia32/CompareMem.nasm
-  Ia32/ZeroMem.nasm
-  Ia32/SetMem64.nasm
-  Ia32/SetMem32.nasm
-  Ia32/SetMem16.nasm
-  Ia32/SetMem.nasm
-  Ia32/CopyMem.nasm
-  Ia32/ScanMem64.nasm
-  Ia32/ScanMem32.nasm
-  Ia32/ScanMem16.nasm
-  Ia32/ScanMem8.nasm
-  Ia32/CompareMem.nasm
-  Ia32/ZeroMem.nasm
-  Ia32/SetMem64.nasm
-  Ia32/SetMem32.nasm
-  Ia32/SetMem16.nasm
-  Ia32/SetMem.nasm
-  Ia32/CopyMem.nasm
-  Ia32/IsZeroBuffer.nasm
   ScanMem64Wrapper.c
   ScanMem32Wrapper.c
   ScanMem16Wrapper.c
@@ -65,6 +40,20 @@
   CopyMemWrapper.c
   IsZeroBufferWrapper.c
   MemLibGuid.c
+
+[Sources.Ia32]
+  Ia32/ScanMem64.nasm
+  Ia32/ScanMem32.nasm
+  Ia32/ScanMem16.nasm
+  Ia32/ScanMem8.nasm
+  Ia32/CompareMem.nasm
+  Ia32/ZeroMem.nasm
+  Ia32/SetMem64.nasm
+  Ia32/SetMem32.nasm
+  Ia32/SetMem16.nasm
+  Ia32/SetMem.nasm
+  Ia32/CopyMem.nasm
+  Ia32/IsZeroBuffer.nasm
 
 [Sources.X64]
   X64/ScanMem64.nasm
@@ -79,20 +68,6 @@
   X64/SetMem.nasm
   X64/CopyMem.nasm
   X64/IsZeroBuffer.nasm
-  ScanMem64Wrapper.c
-  ScanMem32Wrapper.c
-  ScanMem16Wrapper.c
-  ScanMem8Wrapper.c
-  ZeroMemWrapper.c
-  CompareMemWrapper.c
-  SetMem64Wrapper.c
-  SetMem32Wrapper.c
-  SetMem16Wrapper.c
-  SetMemWrapper.c
-  CopyMemWrapper.c
-  IsZeroBufferWrapper.c
-  MemLibGuid.c
-
 
 [Packages]
   MdePkg/MdePkg.dec

--- a/MdePkg/Library/BaseMemoryLibRepStr/BaseMemoryLibRepStr.inf
+++ b/MdePkg/Library/BaseMemoryLibRepStr/BaseMemoryLibRepStr.inf
@@ -53,31 +53,9 @@
   Ia32/SetMem16.nasm
   Ia32/SetMem.nasm
   Ia32/CopyMem.nasm
-  Ia32/ScanMem64.nasm
-  Ia32/ScanMem32.nasm
-  Ia32/ScanMem16.nasm
-  Ia32/ScanMem8.nasm
-  Ia32/CompareMem.nasm
-  Ia32/ZeroMem.nasm
-  Ia32/SetMem64.nasm
-  Ia32/SetMem32.nasm
-  Ia32/SetMem16.nasm
-  Ia32/SetMem.nasm
-  Ia32/CopyMem.nasm
   Ia32/IsZeroBuffer.nasm
 
 [Sources.X64]
-  X64/ScanMem64.nasm
-  X64/ScanMem32.nasm
-  X64/ScanMem16.nasm
-  X64/ScanMem8.nasm
-  X64/CompareMem.nasm
-  X64/ZeroMem.nasm
-  X64/SetMem64.nasm
-  X64/SetMem32.nasm
-  X64/SetMem16.nasm
-  X64/SetMem.nasm
-  X64/CopyMem.nasm
   X64/ScanMem64.nasm
   X64/ScanMem32.nasm
   X64/ScanMem16.nasm

--- a/MdePkg/Library/BaseMemoryLibSse2/BaseMemoryLibSse2.inf
+++ b/MdePkg/Library/BaseMemoryLibSse2/BaseMemoryLibSse2.inf
@@ -52,31 +52,9 @@
   Ia32/SetMem16.nasm
   Ia32/SetMem.nasm
   Ia32/CopyMem.nasm
-  Ia32/ScanMem64.nasm
-  Ia32/ScanMem32.nasm
-  Ia32/ScanMem16.nasm
-  Ia32/ScanMem8.nasm
-  Ia32/CompareMem.nasm
-  Ia32/ZeroMem.nasm
-  Ia32/SetMem64.nasm
-  Ia32/SetMem32.nasm
-  Ia32/SetMem16.nasm
-  Ia32/SetMem.nasm
-  Ia32/CopyMem.nasm
   Ia32/IsZeroBuffer.nasm
 
 [Sources.X64]
-  X64/ScanMem64.nasm
-  X64/ScanMem32.nasm
-  X64/ScanMem16.nasm
-  X64/ScanMem8.nasm
-  X64/CompareMem.nasm
-  X64/ZeroMem.nasm
-  X64/SetMem64.nasm
-  X64/SetMem32.nasm
-  X64/SetMem16.nasm
-  X64/SetMem.nasm
-  X64/CopyMem.nasm
   X64/ScanMem64.nasm
   X64/ScanMem32.nasm
   X64/ScanMem16.nasm


### PR DESCRIPTION
# Description

There are some duplicate source files exits in the INF file, this patch is to remove those duplicate sources.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Basic Build

## Integration Instructions

N/A
