### PR TITLE
MdeModulePkg: Add Boot#### structure check

### DIFF
--- a/MdeModulePkg/Include/Library/UefiBootManagerLib.h
+++ b/MdeModulePkg/Include/Library/UefiBootManagerLib.h
@@ -813,4 +813,21 @@ EfiBootManagerDispatchDeferredImages (
   VOID
   );
 
+/**
+  Validate the Boot####, Driver####, SysPrep#### and PlatformRecovery####
+  variable (VendorGuid/Name)
+
+  @param  Variable              The variable data.
+  @param  VariableSize          The variable size.
+
+  @retval TRUE                  The variable data is correct.
+  @retval FALSE                 The variable data is corrupted.
+
+**/
+BOOLEAN
+BmValidateOption (
+  UINT8  *Variable,
+  UINTN  VariableSize
+  );
+
 #endif

--- a/MdeModulePkg/Library/BootMaintenanceManagerUiLib/BootOption.c
+++ b/MdeModulePkg/Library/BootMaintenanceManagerUiLib/BootOption.c
@@ -356,6 +356,11 @@ BOpt_GetBootOptions (
       continue;
     }
 
+    if (!BmValidateOption (LoadOptionFromVar, BootOptionSize)) {
+      FreePool (LoadOptionFromVar);
+      continue;
+    }
+
     if (BootNext != NULL) {
       BootNextFlag = (BOOLEAN)(*BootNext == BootOrderList[Index]);
     } else {


### PR DESCRIPTION
Add Boot#### structure check to prevent Boot%04x variable error.

# Description
- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [x] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

OVMF build

## Integration Instructions

According bugzilla issue [4792](https://bugzilla.tianocore.org/show_bug.cgi?id=4792), it should check Boot%04x variable in BOpt_GetBootOptions to prevent error sturcture.
