### PR TITLE
MdeModulePkg/PciBusDxe: Fix assert

### DIFF
--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciLib.c
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciLib.c
@@ -411,6 +411,7 @@ AdjustPciDeviceBarSize (
   BOOLEAN        Adjusted;
   UINTN          Offset;
   UINTN          BarIndex;
+  EFI_STATUS     Status;
 
   Adjusted    = FALSE;
   CurrentLink = RootBridgeDev->ChildList.ForwardLink;
@@ -423,6 +424,16 @@ AdjustPciDeviceBarSize (
         Adjusted = TRUE;
       }
     } else {
+      Status = LocatePciExpressCapabilityRegBlock (
+                 PciIoDevice,
+                 PCI_EXPRESS_EXTENDED_CAPABILITY_RESIZABLE_BAR_ID,
+                 &PciIoDevice->ResizableBarOffset,
+                 NULL
+                 );
+      if (EFI_ERROR (Status)) {
+        continue;
+      }
+
       if (PciIoDevice->ResizableBarOffset != 0) {
         DEBUG ((
           DEBUG_ERROR,


### PR DESCRIPTION
Fix assert if multi graphics card connect, but
one graphics card support "resizable bar" and
another one doesn't support, in this case, system
shouldn't assert.

# Description

if system connect multiple graphics card, and this graphics card support resizable bar feature, system will have assert happen when booting to OS.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Make sure iGFX + NVDIA Graphics + DG2 Graphics shouldn't have assert happening when booting to OS.

## Integration Instructions

N/A