### PR TITLE
RedfishPkg: Switch bmc usb nic lib to credential protocol

### DIFF
--- a/RedfishPkg/Library/PlatformHostInterfaceBmcUsbNicLib/PlatformHostInterfaceBmcUsbNicLib.c
+++ b/RedfishPkg/Library/PlatformHostInterfaceBmcUsbNicLib/PlatformHostInterfaceBmcUsbNicLib.c
@@ -1202,6 +1202,7 @@ CheckBmcUsbNic (
   DEBUG ((DEBUG_MANAGEABILITY, "%a: Entry, the registration key - 0x%08x.\n", __func__, Registration));
 
   Handle = NULL;
+  HandleBuffer = NULL;
   Status = EFI_SUCCESS;
 
   do {

--- a/RedfishPkg/Library/PlatformHostInterfaceBmcUsbNicLib/PlatformHostInterfaceBmcUsbNicLib.c
+++ b/RedfishPkg/Library/PlatformHostInterfaceBmcUsbNicLib/PlatformHostInterfaceBmcUsbNicLib.c
@@ -23,7 +23,7 @@ static LIST_ENTRY  mBmcIpmiLan;
   Bootstrapping.
 
   @retval TRUE   Yes, it is supported.
-          TRUE   No, it is not supported.
+          FALSE  No, it is not supported.
 
 **/
 BOOLEAN
@@ -31,47 +31,53 @@ ProbeRedfishCredentialBootstrap (
   VOID
   )
 {
-  EFI_STATUS                                  Status;
-  IPMI_BOOTSTRAP_CREDENTIALS_COMMAND_DATA     CommandData;
-  IPMI_BOOTSTRAP_CREDENTIALS_RESULT_RESPONSE  ResponseData;
-  UINT32                                      ResponseSize;
-  BOOLEAN                                     ReturnBool;
+  EDKII_REDFISH_AUTH_METHOD           AuthMethod;
+  EDKII_REDFISH_CREDENTIAL2_PROTOCOL  *CredentialProtocol;
+  CHAR8                               *UserName;
+  CHAR8                               *Password;
+  BOOLEAN                             ReturnBool;
+  EFI_STATUS                          Status;
 
   DEBUG ((DEBUG_MANAGEABILITY, "%a: Entry\n", __func__));
 
+  ReturnBool = FALSE;
   //
-  // IPMI callout to NetFn 2C, command 02
-  //    Request data:
-  //      Byte 1: REDFISH_IPMI_GROUP_EXTENSION
-  //      Byte 2: DisableBootstrapControl
+  // Locate HII credential protocol.
   //
-  CommandData.GroupExtensionId        = REDFISH_IPMI_GROUP_EXTENSION;
-  CommandData.DisableBootstrapControl = REDFISH_IPMI_BOOTSTRAP_CREDENTIAL_ENABLE;
-  ResponseData.CompletionCode         = IPMI_COMP_CODE_UNSPECIFIED;
-  ResponseSize                        = sizeof (ResponseData);
-  //
-  //  Response data: Ignored.
-  //
-  Status = IpmiSubmitCommand (
-             IPMI_NETFN_GROUP_EXT,
-             REDFISH_IPMI_GET_BOOTSTRAP_CREDENTIALS_CMD,
-             (UINT8 *)&CommandData,
-             sizeof (CommandData),
-             (UINT8 *)&ResponseData,
-             &ResponseSize
-             );
-  if (!EFI_ERROR (Status) &&
-      ((ResponseData.CompletionCode == IPMI_COMP_CODE_NORMAL) ||
-       (ResponseData.CompletionCode == REDFISH_IPMI_COMP_CODE_BOOTSTRAP_CREDENTIAL_DISABLED)
-      ))
-  {
-    DEBUG ((DEBUG_REDFISH_HOST_INTERFACE, "    Redfish Credential Bootstrapping is supported\n"));
-    ReturnBool = TRUE;
-  } else {
-    DEBUG ((DEBUG_REDFISH_HOST_INTERFACE, "    Redfish Credential Bootstrapping is not supported\n"));
-    ReturnBool = FALSE;
+  Status = gBS->LocateProtocol (
+                  &gEdkIIRedfishCredential2ProtocolGuid,
+                  NULL,
+                  (VOID **)&CredentialProtocol
+                  );
+  if (EFI_ERROR (Status)) {
+    ASSERT_EFI_ERROR (Status);
+    return FALSE;
   }
 
+  Status = CredentialProtocol->GetAuthInfo (
+                                 CredentialProtocol,
+                                 &AuthMethod,
+                                 &UserName,
+                                 &Password
+                                 );
+  if (!EFI_ERROR (Status)) {
+    ZeroMem (Password, AsciiStrSize (Password));
+    FreePool (Password);
+    ZeroMem (UserName, AsciiStrSize (UserName));
+    FreePool (UserName);
+    ReturnBool = TRUE;
+  } else {
+    if (Status == EFI_ACCESS_DENIED) {
+      // bootstrap credential support was disabled
+      ReturnBool = TRUE;
+    }
+  }
+
+  DEBUG ((
+    DEBUG_REDFISH_HOST_INTERFACE,
+    "    Redfish Credential Bootstrapping is %a\n",
+    ReturnBool ? "supported" : "not supported"
+    ));
   return ReturnBool;
 }
 
@@ -1201,9 +1207,9 @@ CheckBmcUsbNic (
 
   DEBUG ((DEBUG_MANAGEABILITY, "%a: Entry, the registration key - 0x%08x.\n", __func__, Registration));
 
-  Handle = NULL;
+  Handle       = NULL;
   HandleBuffer = NULL;
-  Status = EFI_SUCCESS;
+  Status       = EFI_SUCCESS;
 
   do {
     BufferSize = 0;

--- a/RedfishPkg/Library/PlatformHostInterfaceBmcUsbNicLib/PlatformHostInterfaceBmcUsbNicLib.h
+++ b/RedfishPkg/Library/PlatformHostInterfaceBmcUsbNicLib/PlatformHostInterfaceBmcUsbNicLib.h
@@ -21,7 +21,6 @@
 #include <Library/BaseMemoryLib.h>
 #include <Library/DebugLib.h>
 #include <Library/DevicePathLib.h>
-#include <Library/IpmiLib.h>
 #include <Library/IpmiCommandLib.h>
 #include <Library/RedfishHostInterfaceLib.h>
 #include <Library/MemoryAllocationLib.h>
@@ -29,6 +28,7 @@
 #include <Library/DevicePathLib.h>
 #include <Library/RedfishDebugLib.h>
 
+#include <Protocol/EdkIIRedfishCredential2.h>
 #include <Protocol/SimpleNetwork.h>
 #include <Protocol/UsbIo.h>
 

--- a/RedfishPkg/Library/PlatformHostInterfaceBmcUsbNicLib/PlatformHostInterfaceBmcUsbNicLib.inf
+++ b/RedfishPkg/Library/PlatformHostInterfaceBmcUsbNicLib/PlatformHostInterfaceBmcUsbNicLib.inf
@@ -29,7 +29,6 @@
 [LibraryClasses]
   BaseMemoryLib
   DebugLib
-  IpmiLib
   IpmiCommandLib
   MemoryAllocationLib
   UefiLib
@@ -39,6 +38,7 @@
   gEfiSimpleNetworkProtocolGuid                 ## CONSUMED
   gEfiUsbIoProtocolGuid                         ## CONSUMED
   gEfiDevicePathProtocolGuid                    ## CONSUMED
+  gEdkIIRedfishCredential2ProtocolGuid          ## CONSUMED
 
 [Pcd]
   gEfiRedfishPkgTokenSpaceGuid.PcdRedfishHostName     ## CONSUMED
@@ -47,3 +47,4 @@
 
 [Depex]
   gIpmiProtocolGuid
+  AND gEdkIIRedfishCredential2ProtocolGuid

--- a/RedfishPkg/RedfishDiscoverDxe/RedfishDiscoverDxe.c
+++ b/RedfishPkg/RedfishDiscoverDxe/RedfishDiscoverDxe.c
@@ -1855,6 +1855,7 @@ BuildupNetworkInterface (
   ListCount                    = (sizeof (mRequiredProtocol) / sizeof (REDFISH_DISCOVER_REQUIRED_PROTOCOL));
   NewNetworkInterfaceInstalled = FALSE;
   Index                        = 0;
+  RestExInstance               = NULL;
 
   for (Index = 0; Index < ListCount; Index++) {
     Status = gBS->OpenProtocol (


### PR DESCRIPTION
# Description

This patch replaces call of IpmiSubmitCommand() issued
    REDFISH_IPMI_BOOTSTRAP_CREDENTIAL_ENABLE IPMI command to check
    whether bootstrap credential support enabled or not.
    The problem is that in accordance with IPMI spec while handling
    such command BMC creates bootstrap account. The credentials of this account
    is returned as a response. Obviously in this code the response is not used.
    From the other side there is an implementation
    of EDKII_REDFISH_CREDENTIAL_PROTOCOL exists and used by
    RedfishPlatformCredentialIpmiLib.

By design RedfishPlatformCredentialIpmiLib keeps returned bootstrap
    credentials and uses it later. So all services using
    EDKII_REDFISH_CREDENTIAL_PROTOCOL instance operates with a same
    credentials.
    Current design of PlatformHostInterfaceBmcUsbNicLib leads to creation
    of two bootstrap accounts on BMC side. This is on nesseccary and one
    account is not used at all.
    
Using EDKII_REDFISH_CREDENTIAL_PROTOCOL in PlatformHostInterfaceBmcUsbNicLib
    prevents from creating useless bootstrap account on BMC side.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

A simple smoke test was performed. The number of bootstrap accounts was reduced.

## Integration Instructions

N/A
