### PR TITLE
MdePkg: Add error output for IoLib.c

### DIFF
--- a/MdePkg/Library/BaseIoLibIntrinsic/IoLib.c
+++ b/MdePkg/Library/BaseIoLibIntrinsic/IoLib.c
@@ -174,6 +174,12 @@ MmioRead16 (
   UINT16   Value;
   BOOLEAN  Flag;
 
+  DEBUG_CODE (
+    if ((Address & 1) != 0) {
+      DEBUG ((DEBUG_ERROR, "%a: invalid address: %lx\n", __func__, Address));
+    }
+    );
+
   ASSERT ((Address & 1) == 0);
   Flag = FilterBeforeMmIoRead (FilterWidth16, Address, &Value);
   if (Flag) {
@@ -220,6 +226,12 @@ MmioWrite16 (
 {
   BOOLEAN  Flag;
 
+  DEBUG_CODE (
+    if ((Address & 1) != 0) {
+      DEBUG ((DEBUG_ERROR, "%a: invalid address: %lx\n", __func__, Address));
+    }
+    );
+
   ASSERT ((Address & 1) == 0);
 
   Flag = FilterBeforeMmIoWrite (FilterWidth16, Address, &Value);
@@ -265,6 +277,12 @@ MmioRead32 (
 {
   UINT32   Value;
   BOOLEAN  Flag;
+
+  DEBUG_CODE (
+    if ((Address & 3) != 0) {
+      DEBUG ((DEBUG_ERROR, "%a: invalid address: %lx\n", __func__, Address));
+    }
+    );
 
   ASSERT ((Address & 3) == 0);
 
@@ -313,6 +331,12 @@ MmioWrite32 (
 {
   BOOLEAN  Flag;
 
+  DEBUG_CODE (
+    if ((Address & 3) != 0) {
+      DEBUG ((DEBUG_ERROR, "%a: invalid address: %lx\n", __func__, Address));
+    }
+    );
+
   ASSERT ((Address & 3) == 0);
 
   Flag = FilterBeforeMmIoWrite (FilterWidth32, Address, &Value);
@@ -359,6 +383,12 @@ MmioRead64 (
   UINT64   Value;
   BOOLEAN  Flag;
 
+  DEBUG_CODE (
+    if ((Address & 7) != 0) {
+      DEBUG ((DEBUG_ERROR, "%a: invalid address: %lx\n", __func__, Address));
+    }
+    );
+
   ASSERT ((Address & 7) == 0);
 
   Flag = FilterBeforeMmIoRead (FilterWidth64, Address, &Value);
@@ -403,6 +433,12 @@ MmioWrite64 (
   )
 {
   BOOLEAN  Flag;
+
+  DEBUG_CODE (
+    if ((Address & 7) != 0) {
+      DEBUG ((DEBUG_ERROR, "%a: invalid address: %lx\n", __func__, Address));
+    }
+    );
 
   ASSERT ((Address & 7) == 0);
 

--- a/MdePkg/Library/BaseIoLibIntrinsic/IoLibArmVirt.c
+++ b/MdePkg/Library/BaseIoLibIntrinsic/IoLibArmVirt.c
@@ -614,6 +614,12 @@ MmioRead16 (
   BOOLEAN  Flag;
   UINT16   Value;
 
+  DEBUG_CODE (
+    if ((Address & 1) != 0) {
+      DEBUG ((DEBUG_ERROR, "%a: invalid address: %lx\n", __func__, Address));
+    }
+    );
+
   ASSERT ((Address & 1) == 0);
 
   Flag = FilterBeforeMmIoRead (FilterWidth16, Address, &Value);
@@ -647,6 +653,12 @@ MmioWrite16 (
   )
 {
   BOOLEAN  Flag;
+
+  DEBUG_CODE (
+    if ((Address & 1) != 0) {
+      DEBUG ((DEBUG_ERROR, "%a: invalid address: %lx\n", __func__, Address));
+    }
+    );
 
   ASSERT ((Address & 1) == 0);
 
@@ -683,6 +695,12 @@ MmioRead32 (
   BOOLEAN  Flag;
   UINT32   Value;
 
+  DEBUG_CODE (
+    if ((Address & 3) != 0) {
+      DEBUG ((DEBUG_ERROR, "%a: invalid address: %lx\n", __func__, Address));
+    }
+    );
+
   ASSERT ((Address & 3) == 0);
 
   Flag = FilterBeforeMmIoRead (FilterWidth32, Address, &Value);
@@ -716,6 +734,12 @@ MmioWrite32 (
   )
 {
   BOOLEAN  Flag;
+
+  DEBUG_CODE (
+    if ((Address & 3) != 0) {
+      DEBUG ((DEBUG_ERROR, "%a: invalid address: %lx\n", __func__, Address));
+    }
+    );
 
   ASSERT ((Address & 3) == 0);
 
@@ -752,6 +776,12 @@ MmioRead64 (
   BOOLEAN  Flag;
   UINT64   Value;
 
+  DEBUG_CODE (
+    if ((Address & 7) != 0) {
+      DEBUG ((DEBUG_ERROR, "%a: invalid address: %lx\n", __func__, Address));
+    }
+    );
+
   ASSERT ((Address & 7) == 0);
 
   Flag = FilterBeforeMmIoRead (FilterWidth64, Address, &Value);
@@ -785,6 +815,12 @@ MmioWrite64 (
   )
 {
   BOOLEAN  Flag;
+
+  DEBUG_CODE (
+    if ((Address & 7) != 0) {
+      DEBUG ((DEBUG_ERROR, "%a: invalid address: %lx\n", __func__, Address));
+    }
+    );
 
   ASSERT ((Address & 7) == 0);
 

--- a/MdePkg/Library/BaseIoLibIntrinsic/IoLibGcc.c
+++ b/MdePkg/Library/BaseIoLibIntrinsic/IoLibGcc.c
@@ -123,6 +123,12 @@ IoRead16 (
   UINT16   Data;
   BOOLEAN  Flag;
 
+  DEBUG_CODE (
+    if ((Port & 1) != 0) {
+      DEBUG ((DEBUG_ERROR, "%a: invalid port: %lx\n", __func__, Port));
+    }
+    );
+
   ASSERT ((Port & 1) == 0);
 
   Flag = FilterBeforeIoRead (FilterWidth16, Port, &Data);
@@ -166,6 +172,12 @@ IoWrite16 (
 {
   BOOLEAN  Flag;
 
+  DEBUG_CODE (
+    if ((Port & 1) != 0) {
+      DEBUG ((DEBUG_ERROR, "%a: invalid port: %lx\n", __func__, Port));
+    }
+    );
+
   ASSERT ((Port & 1) == 0);
 
   Flag = FilterBeforeIoWrite (FilterWidth16, Port, &Value);
@@ -207,6 +219,12 @@ IoRead32 (
 {
   UINT32   Data;
   BOOLEAN  Flag;
+
+  DEBUG_CODE (
+    if ((Port & 3) != 0) {
+      DEBUG ((DEBUG_ERROR, "%a: invalid port: %lx\n", __func__, Port));
+    }
+    );
 
   ASSERT ((Port & 3) == 0);
 
@@ -250,6 +268,12 @@ IoWrite32 (
   )
 {
   BOOLEAN  Flag;
+
+  DEBUG_CODE (
+    if ((Port & 3) != 0) {
+      DEBUG ((DEBUG_ERROR, "%a: invalid port: %lx\n", __func__, Port));
+    }
+    );
 
   ASSERT ((Port & 3) == 0);
 

--- a/MdePkg/Library/BaseIoLibIntrinsic/IoLibInternalTdx.c
+++ b/MdePkg/Library/BaseIoLibIntrinsic/IoLibInternalTdx.c
@@ -85,6 +85,12 @@ TdIoRead16 (
   UINT64  Status;
   UINT64  Val;
 
+  DEBUG_CODE (
+    if ((Port & 1) != 0) {
+      DEBUG ((DEBUG_ERROR, "%a: invalid port: %lx\n", __func__, Port));
+    }
+    );
+
   ASSERT ((Port & 1) == 0);
 
   Status = TdVmCall (TDVMCALL_IO, TDVMCALL_ACCESS_SIZE_2, TDVMCALL_ACCESS_READ, Port, 0, &Val);
@@ -113,6 +119,12 @@ TdIoRead32 (
 {
   UINT64  Status;
   UINT64  Val;
+
+  DEBUG_CODE (
+    if ((Port & 3) != 0) {
+      DEBUG ((DEBUG_ERROR, "%a: invalid port: %lx\n", __func__, Port));
+    }
+    );
 
   ASSERT ((Port & 3) == 0);
 
@@ -175,6 +187,12 @@ TdIoWrite16 (
   UINT64  Status;
   UINT64  Val;
 
+  DEBUG_CODE (
+    if ((Port & 1) != 0) {
+      DEBUG ((DEBUG_ERROR, "%a: invalid port: %lx\n", __func__, Port));
+    }
+    );
+
   ASSERT ((Port & 1) == 0);
   Val    = Value;
   Status = TdVmCall (TDVMCALL_IO, TDVMCALL_ACCESS_SIZE_2, TDVMCALL_ACCESS_WRITE, Port, Val, 0);
@@ -205,6 +223,12 @@ TdIoWrite32 (
 {
   UINT64  Status;
   UINT64  Val;
+
+  DEBUG_CODE (
+    if ((Port & 3) != 0) {
+      DEBUG ((DEBUG_ERROR, "%a: invalid port: %lx\n", __func__, Port));
+    }
+    );
 
   ASSERT ((Port & 3) == 0);
   Val    = Value;
@@ -321,6 +345,12 @@ TdMmioWrite16 (
   UINT64  Val;
   UINT64  Status;
 
+  DEBUG_CODE (
+    if ((Address & 1) != 0) {
+      DEBUG ((DEBUG_ERROR, "%a: invalid address: %lx\n", __func__, Address));
+    }
+    );
+
   ASSERT ((Address & 1) == 0);
 
   Val    = Value;
@@ -380,6 +410,12 @@ TdMmioWrite32 (
   UINT64  Val;
   UINT64  Status;
 
+  DEBUG_CODE (
+    if ((Address & 3) != 0) {
+      DEBUG ((DEBUG_ERROR, "%a: invalid address: %lx\n", __func__, Address));
+    }
+    );
+
   ASSERT ((Address & 3) == 0);
 
   Val    = Value;
@@ -436,6 +472,12 @@ TdMmioWrite64 (
 {
   UINT64  Status;
   UINT64  Val;
+
+  DEBUG_CODE (
+    if ((Address & 7) != 0) {
+      DEBUG ((DEBUG_ERROR, "%a: invalid address: %lx\n", __func__, Address));
+    }
+    );
 
   ASSERT ((Address & 7) == 0);
 

--- a/MdePkg/Library/BaseIoLibIntrinsic/IoLibMmioBuffer.c
+++ b/MdePkg/Library/BaseIoLibIntrinsic/IoLibMmioBuffer.c
@@ -8,6 +8,41 @@
 
 #include "BaseIoLibIntrinsicInternal.h"
 
+STATIC
+VOID
+PrintErrorInfo (
+  IN       UINTN  Address,
+  IN       UINTN  Length,
+  IN CONST VOID   *Buffer,
+  IN       UINT16 AlignSize,
+  IN CONST CHAR8  *Prompt
+  )
+{
+  if ((Address & (AlignSize - 1)) != 0) {
+    DEBUG ((DEBUG_ERROR, "%a: invalid address: %lx\n", Prompt, Address));
+  }
+
+  if ((Length - 1) > (MAX_ADDRESS - Address)) {
+    DEBUG ((DEBUG_ERROR, "%a: invalid param, address: %lx len: %lx\n",
+      Prompt, Address, Length));
+  }
+
+  if ((Length - 1) > (MAX_ADDRESS - (UINTN)Buffer)) {
+    DEBUG ((DEBUG_ERROR, "%a: invalid param, buffer: %lx len: %lx\n",
+      Prompt, (UINTN)Buffer, Length));
+  }
+
+  if ((Length & (AlignSize - 1)) != 0) {
+    DEBUG ((DEBUG_ERROR, "%a: invalid len: %lx\n", Prompt, Length));
+  }
+
+  if (((UINTN)Buffer & (AlignSize - 1)) != 0) {
+    DEBUG ((DEBUG_ERROR, "%a: invalid buffer: %lx\n", Prompt, (UINTN)Buffer));
+  }
+
+  return;
+}
+
 /**
   Copy data from the MMIO region to system memory by using 8-bit access.
 
@@ -35,6 +70,18 @@ MmioReadBuffer8 (
   )
 {
   UINT8  *ReturnBuffer;
+
+  DEBUG_CODE (
+    if ((Length - 1) > (MAX_ADDRESS - StartAddress)) {
+      DEBUG ((DEBUG_ERROR, "%a: invalid param, address: %lx len: %lx\n",
+        __func__, StartAddress, Length));
+    }
+
+    if ((Length - 1) > (MAX_ADDRESS - (UINTN)Buffer)) {
+      DEBUG ((DEBUG_ERROR, "%a: invalid param, buffer: %lx len: %lx\n",
+        __func__, (UINTN)Buffer, Length));
+    }
+    );
 
   ASSERT ((Length - 1) <=  (MAX_ADDRESS - StartAddress));
   ASSERT ((Length - 1) <=  (MAX_ADDRESS - (UINTN)Buffer));
@@ -79,6 +126,10 @@ MmioReadBuffer16 (
   )
 {
   UINT16  *ReturnBuffer;
+
+  DEBUG_CODE (
+    PrintErrorInfo (StartAddress, Length, Buffer, sizeof (UINT16), __func__);
+    );
 
   ASSERT ((StartAddress & (sizeof (UINT16) - 1)) == 0);
 
@@ -131,6 +182,10 @@ MmioReadBuffer32 (
 {
   UINT32  *ReturnBuffer;
 
+  DEBUG_CODE (
+    PrintErrorInfo (StartAddress, Length, Buffer, sizeof (UINT32), __func__);
+    );
+
   ASSERT ((StartAddress & (sizeof (UINT32) - 1)) == 0);
 
   ASSERT ((Length - 1) <=  (MAX_ADDRESS - StartAddress));
@@ -182,6 +237,10 @@ MmioReadBuffer64 (
 {
   UINT64  *ReturnBuffer;
 
+  DEBUG_CODE (
+    PrintErrorInfo (StartAddress, Length, Buffer, sizeof (UINT64), __func__);
+    );
+
   ASSERT ((StartAddress & (sizeof (UINT64) - 1)) == 0);
 
   ASSERT ((Length - 1) <=  (MAX_ADDRESS - StartAddress));
@@ -229,6 +288,18 @@ MmioWriteBuffer8 (
 {
   VOID  *ReturnBuffer;
 
+  DEBUG_CODE (
+    if ((Length - 1) > (MAX_ADDRESS - StartAddress)) {
+      DEBUG ((DEBUG_ERROR, "%a: invalid param, address: %lx len: %lx\n",
+        __func__, StartAddress, Length));
+    }
+
+    if ((Length - 1) > (MAX_ADDRESS - (UINTN)Buffer)) {
+      DEBUG ((DEBUG_ERROR, "%a: invalid param, buffer: %lx len: %lx\n",
+        __func__, (UINTN)Buffer, Length));
+    }
+    );
+
   ASSERT ((Length - 1) <=  (MAX_ADDRESS - StartAddress));
   ASSERT ((Length - 1) <=  (MAX_ADDRESS - (UINTN)Buffer));
 
@@ -273,6 +344,10 @@ MmioWriteBuffer16 (
   )
 {
   UINT16  *ReturnBuffer;
+
+  DEBUG_CODE (
+    PrintErrorInfo (StartAddress, Length, Buffer, sizeof (UINT16), __func__);
+    );
 
   ASSERT ((StartAddress & (sizeof (UINT16) - 1)) == 0);
 
@@ -327,6 +402,10 @@ MmioWriteBuffer32 (
 {
   UINT32  *ReturnBuffer;
 
+  DEBUG_CODE (
+    PrintErrorInfo (StartAddress, Length, Buffer, sizeof (UINT32), __func__);
+    );
+
   ASSERT ((StartAddress & (sizeof (UINT32) - 1)) == 0);
 
   ASSERT ((Length - 1) <=  (MAX_ADDRESS - StartAddress));
@@ -379,6 +458,10 @@ MmioWriteBuffer64 (
   )
 {
   UINT64  *ReturnBuffer;
+
+  DEBUG_CODE (
+    PrintErrorInfo (StartAddress, Length, Buffer, sizeof (UINT64), __func__);
+    );
 
   ASSERT ((StartAddress & (sizeof (UINT64) - 1)) == 0);
 

--- a/MdePkg/Library/BaseIoLibIntrinsic/IoLibMsc.c
+++ b/MdePkg/Library/BaseIoLibIntrinsic/IoLibMsc.c
@@ -183,6 +183,12 @@ IoRead16 (
   UINT16   Value;
   BOOLEAN  Flag;
 
+  DEBUG_CODE (
+    if ((Port & 1) != 0) {
+      DEBUG ((DEBUG_ERROR, "%a: invalid port: %lx\n", __func__, Port));
+    }
+    );
+
   ASSERT ((Port & 1) == 0);
 
   Flag = FilterBeforeIoRead (FilterWidth16, Port, &Value);
@@ -228,6 +234,12 @@ IoWrite16 (
 {
   BOOLEAN  Flag;
 
+  DEBUG_CODE (
+    if ((Port & 1) != 0) {
+      DEBUG ((DEBUG_ERROR, "%a: invalid port: %lx\n", __func__, Port));
+    }
+    );
+
   ASSERT ((Port & 1) == 0);
 
   Flag = FilterBeforeIoWrite (FilterWidth16, Port, &Value);
@@ -271,6 +283,12 @@ IoRead32 (
 {
   UINT32   Value;
   BOOLEAN  Flag;
+
+  DEBUG_CODE (
+    if ((Port & 3) != 0) {
+      DEBUG ((DEBUG_ERROR, "%a: invalid port: %lx\n", __func__, Port));
+    }
+    );
 
   ASSERT ((Port & 3) == 0);
 
@@ -316,6 +334,12 @@ IoWrite32 (
   )
 {
   BOOLEAN  Flag;
+
+  DEBUG_CODE (
+    if ((Port & 3) != 0) {
+      DEBUG ((DEBUG_ERROR, "%a: invalid port: %lx\n", __func__, Port));
+    }
+    );
 
   ASSERT ((Port & 3) == 0);
 

--- a/MdePkg/Library/BaseIoLibIntrinsic/IoLibNoIo.c
+++ b/MdePkg/Library/BaseIoLibIntrinsic/IoLibNoIo.c
@@ -475,6 +475,12 @@ MmioRead16 (
   UINT16   Value;
   BOOLEAN  Flag;
 
+  DEBUG_CODE (
+    if ((Address & 1) != 0) {
+      DEBUG ((DEBUG_ERROR, "%a: invalid address: %lx\n", __func__, Address));
+    }
+    );
+
   ASSERT ((Address & 1) == 0);
 
   Flag = FilterBeforeMmIoRead (FilterWidth16, Address, &Value);
@@ -508,6 +514,12 @@ MmioWrite16 (
   )
 {
   BOOLEAN  Flag;
+
+  DEBUG_CODE (
+    if ((Address & 1) != 0) {
+      DEBUG ((DEBUG_ERROR, "%a: invalid address: %lx\n", __func__, Address));
+    }
+    );
 
   ASSERT ((Address & 1) == 0);
 
@@ -544,6 +556,12 @@ MmioRead32 (
   UINT32   Value;
   BOOLEAN  Flag;
 
+  DEBUG_CODE (
+    if ((Address & 3) != 0) {
+      DEBUG ((DEBUG_ERROR, "%a: invalid address: %lx\n", __func__, Address));
+    }
+    );
+
   ASSERT ((Address & 3) == 0);
 
   Flag = FilterBeforeMmIoRead (FilterWidth32, Address, &Value);
@@ -577,6 +595,12 @@ MmioWrite32 (
   )
 {
   BOOLEAN  Flag;
+
+  DEBUG_CODE (
+    if ((Address & 3) != 0) {
+      DEBUG ((DEBUG_ERROR, "%a: invalid address: %lx\n", __func__, Address));
+    }
+    );
 
   ASSERT ((Address & 3) == 0);
 
@@ -613,6 +637,12 @@ MmioRead64 (
   UINT64   Value;
   BOOLEAN  Flag;
 
+  DEBUG_CODE (
+    if ((Address & 7) != 0) {
+      DEBUG ((DEBUG_ERROR, "%a: invalid address: %lx\n", __func__, Address));
+    }
+    );
+
   ASSERT ((Address & 7) == 0);
 
   Flag = FilterBeforeMmIoRead (FilterWidth64, Address, &Value);
@@ -646,6 +676,12 @@ MmioWrite64 (
   )
 {
   BOOLEAN  Flag;
+
+  DEBUG_CODE (
+    if ((Address & 7) != 0) {
+      DEBUG ((DEBUG_ERROR, "%a: invalid address: %lx\n", __func__, Address));
+    }
+    );
 
   ASSERT ((Address & 7) == 0);
 


### PR DESCRIPTION
It is better to output error address information When Address is invalid before ASSERT.

Change since v1:
1 Modify other ASSERT() in IoLib;
2 Add DEBUG_CODE for print;