### PR TITLE
EmulatorPkg/Win/Host: Source level debug on already been loaded DLL

### DIFF
--- a/EmulatorPkg/Win/Host/WinHost.c
+++ b/EmulatorPkg/Win/Host/WinHost.c
@@ -1131,13 +1131,7 @@ PeCoffLoaderRelocateImageExtraAction (
 
     if ((Library != NULL) && (DllEntryPoint != NULL)) {
       Status = AddModHandle (ImageContext, Library);
-      if (Status == EFI_ALREADY_STARTED) {
-        //
-        // If the DLL has already been loaded before, then this instance of the DLL can not be debugged.
-        //
-        ImageContext->PdbPointer = NULL;
-        SecPrint ("WARNING: DLL already loaded.  No source level debug %S.\n\r", DllFileName);
-      } else {
+      if (Status == EFI_SUCCESS) {
         //
         // This DLL is not already loaded, so source level debugging is supported.
         //


### PR DESCRIPTION
Source level debugging is not happening for already loaded DLL file after temporary memory migration,
especially on PeiCore, PcdPeim and DxeCore.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

 - Pick any PEI module loaded after temporary memory migration.
 - Before retuning from Entry Point add the breakpoint in Visual Studio.
 - Step in instruction, it will go AutoGen _ModuleEntryPoint, again step in so that it will go to PeiCore
 - there Symbols will not be loaded from PeiCore (Error Message from Visual Studio as "The current stack frame was not found in a loaded module. Source cannot be shown for this location.")
 - After adding this patch, we can able to see C code in the Visual Studio Debugger from PeiCore.

## Integration Instructions

N/A
