### PR TITLE
Allocate EfiACPIMemoryNVS buffer for TCG2 related usage in Tcg2ConfigPeim

### DIFF
--- a/SecurityPkg/Tcg/Tcg2Config/Tcg2ConfigPeim.c
+++ b/SecurityPkg/Tcg/Tcg2Config/Tcg2ConfigPeim.c
@@ -75,21 +75,25 @@ BuildTcg2AcpiCommunicateBufferHob (
 {
   TCG2_ACPI_COMMUNICATE_BUFFER  *Tcg2AcpiCommunicateBufferHob;
   EFI_STATUS                    Status;
-  VOID                          *Buffer;
+  EFI_PHYSICAL_ADDRESS          Buffer;
   UINTN                         Pages;
 
   Pages  = EFI_SIZE_TO_PAGES (sizeof (TCG_NVS));
-  Buffer = AllocateRuntimePages (Pages);
-  ASSERT (Buffer != NULL);
+  Status = PeiServicesAllocatePages (
+             EfiACPIMemoryNVS,
+             Pages,
+             &Buffer
+             );
+  ASSERT_EFI_ERROR (Status);
 
-  Status = MmUnblockMemoryRequest ((UINTN)Buffer, Pages);
+  Status = MmUnblockMemoryRequest (Buffer, Pages);
   if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
     return Status;
   }
 
   Tcg2AcpiCommunicateBufferHob = BuildGuidHob (&gEdkiiTcg2AcpiCommunicateBufferHobGuid, sizeof (TCG2_ACPI_COMMUNICATE_BUFFER));
   ASSERT (Tcg2AcpiCommunicateBufferHob != NULL);
-  Tcg2AcpiCommunicateBufferHob->Tcg2AcpiCommunicateBuffer = (UINTN)Buffer;
+  Tcg2AcpiCommunicateBufferHob->Tcg2AcpiCommunicateBuffer = Buffer;
   Tcg2AcpiCommunicateBufferHob->Pages                     = Pages;
 
   return EFI_SUCCESS;

--- a/SecurityPkg/Tcg/Tcg2Config/Tcg2ConfigPeim.c
+++ b/SecurityPkg/Tcg/Tcg2Config/Tcg2ConfigPeim.c
@@ -78,7 +78,7 @@ BuildTcg2AcpiCommunicateBufferHob (
   VOID                          *Buffer;
   UINTN                         Pages;
 
-  Pages  = sizeof (TCG_NVS);
+  Pages  = EFI_SIZE_TO_PAGES (sizeof (TCG_NVS));
   Buffer = AllocateRuntimePages (Pages);
   ASSERT (Buffer != NULL);
 


### PR DESCRIPTION
# Description

Allocate EfiACPIMemoryNVS buffer for TCG2 related usage in Tcg2ConfigPeim. The buffer will be used in Tcg2Acpi driver
to retrive information from SMM environment.

Previously, the buffer used in Tcg2Acpi driver is AcpiNvs type. But I mistakenly thought the Runtime Data type buffer should also work. So I used API AllocateRuntimePages() to allocate buffer in https://github.com/tianocore/edk2/commit/9a76c7945b762ed8abed3b917aa6217846ae1918 and consume the buffer in https://github.com/tianocore/edk2/commit/e939ecf6c19f932535d073e383d016e8bf2e8ee7. Recently we found that if the buffer type is Runtime Data instead of AcpiNvs, BSOD issue happened after boot into OS.

So this commit is to Allocate EfiACPIMemoryNVS buffer for TCG2 usage in SMM to align with the initial code logic.

## How This Was Tested
Boot on Intel internal platform into OS with TPM enabled
