### PR TITLE
.mergify: Fix pull_request_rules deprecation

### DIFF
--- a/.mergify/config.yml
+++ b/.mergify/config.yml
@@ -26,9 +26,10 @@
 
 queue_rules:
   - name: default
-    conditions:
+    queue_conditions:
       - base~=(^main|^master|^stable/)
       - label=push
+    merge_method: rebase
 
 pull_request_rules:
   - name: Automatically merge a PR when all required checks pass and 'push' label is present
@@ -37,7 +38,6 @@ pull_request_rules:
       - label=push
     actions:
       queue:
-        method: rebase
         name: default
 
   - name: Post a comment on a PR that can not be merged due to a merge conflict


### PR DESCRIPTION
## Description

The following message is visible on mergify runs:

`"The configuration uses the deprecated merge_method attribute of the queue action in one or more pull_request_rules. It must now be used under the queue_rules configuration."`

With the following warning:

`"A brownout is planned on August 26th, 2024."`
`"This option will be removed on September 23rd, 2024."`

This change updates the configuration file to comply with the new format.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

- PR gates

## Integration Instructions

N/A - Only impacts edk2 repo usage of mergify