### PR TITLE
SecurityPkg: Fix exponent unmarshaled as 16 bits

### DIFF
--- a/SecurityPkg/Library/Tpm2CommandLib/Tpm2Object.c
+++ b/SecurityPkg/Library/Tpm2CommandLib/Tpm2Object.c
@@ -252,7 +252,7 @@ Tpm2ReadPublic (
 
       OutPublic->publicArea.parameters.rsaDetail.keyBits  = SwapBytes16 (ReadUnaligned16 ((UINT16 *)Buffer));
       Buffer                                             += sizeof (UINT16);
-      OutPublic->publicArea.parameters.rsaDetail.exponent = SwapBytes16 (ReadUnaligned16 ((UINT16 *)Buffer));
+      OutPublic->publicArea.parameters.rsaDetail.exponent = SwapBytes32 (ReadUnaligned32 ((UINT32 *)Buffer));
       Buffer                                             += sizeof (UINT32);
       break;
     case TPM_ALG_ECC:


### PR DESCRIPTION
# Description
According issue #5536, exponent is 32 bits but is unmarshaled as 16 bits.
- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

N/A

## Integration Instructions

N/A
