### PR TITLE
ArmPlatformPkg: Initialize Serial Port Before Writing

### DIFF
--- a/ArmPlatformPkg/PrePeiCore/PrePeiCore.c
+++ b/ArmPlatformPkg/PrePeiCore/PrePeiCore.c
@@ -76,6 +76,10 @@ PrintFirmwareVersion (
                 __TIME__,
                 __DATE__
                 );
+
+  // Because we are directly bit banging the serial port instead of going through the DebugLib, we need to make sure
+  // the serial port is initialized before we write to it
+  SerialPortInitialize ();
   SerialPortWrite ((UINT8 *)Buffer, CharCount);
 }
 

--- a/ArmPlatformPkg/Sec/Sec.c
+++ b/ArmPlatformPkg/Sec/Sec.c
@@ -139,6 +139,10 @@ PrintFirmwareVersion (
                 __TIME__,
                 __DATE__
                 );
+
+  // Because we are directly bit banging the serial port instead of going through the DebugLib, we need to make sure
+  // the serial port is initialized before we write to it
+  SerialPortInitialize ();
   SerialPortWrite ((UINT8 *)Buffer, CharCount);
 }
 


### PR DESCRIPTION
# Description

PrePeiCore and Sec directly write the firmware version to the serial port.
They relies on another component to initialize the serial port, however
in certain configurations (such as release builds that don't use a
DebugLib that initializes the serial port), the serial port can be
uninitialized at this point, causing a crash when SerialPortWrite
is called here.

This patch updates PrePeiCore and Sec to call SerialPortInitialize before
calling SerialPortWrite directly, which follows the pattern of
other serial port writes. It is accepted to call the initialization
routine multiple times, it is supposed to dump out if the serial
port is already initialized.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Tested on a release build for a platform that did not use a serial port DebugLib and crashed without this change.

## Integration Instructions

N/A.
