### PR TITLE
MdePkg: Add PanicLib Library

### DIFF
--- a/MdeModulePkg/MdeModulePkg.dsc
+++ b/MdeModulePkg/MdeModulePkg.dsc
@@ -108,6 +108,7 @@
   VariableFlashInfoLib|MdeModulePkg/Library/BaseVariableFlashInfoLib/BaseVariableFlashInfoLib.inf
   IpmiCommandLib|MdeModulePkg/Library/BaseIpmiCommandLibNull/BaseIpmiCommandLibNull.inf
   SpiHcPlatformLib|MdeModulePkg/Library/BaseSpiHcPlatformLibNull/BaseSpiHcPlatformLibNull.inf
+  PanicLib|MdePkg/Library/BasePanicLibNull/BasePanicLibNull.inf
 
 [LibraryClasses.EBC.PEIM]
   IoLib|MdePkg/Library/PeiIoLibCpuIo/PeiIoLibCpuIo.inf

--- a/MdeModulePkg/Universal/ResetSystemPei/ResetSystem.c
+++ b/MdeModulePkg/Universal/ResetSystemPei/ResetSystem.c
@@ -300,6 +300,13 @@ ResetSystem2 (
     RecursionDepthPointer = (UINT8 *)GET_GUID_HOB_DATA (Hob);
   }
 
+  if (RecursionDepthPointer == NULL) {
+    // Critical build failure so Panicking
+    PANIC ("Failed to build or get the RecursionDepthPointer Hob");
+    // Reset anyway if we can't get the RecursionDepthPointer
+    goto Done;
+  }
+
   //
   // Only do REPORT_STATUS_CODE() on first call to ResetSystem()
   //
@@ -338,6 +345,7 @@ ResetSystem2 (
     DEBUG ((DEBUG_ERROR, "PEI ResetSystem2: Maximum reset call depth is met. Use the current reset type: %s!\n", mResetTypeStr[ResetType]));
   }
 
+Done:
   switch (ResetType) {
     case EfiResetWarm:
       ResetWarm ();

--- a/MdeModulePkg/Universal/ResetSystemPei/ResetSystem.h
+++ b/MdeModulePkg/Universal/ResetSystemPei/ResetSystem.h
@@ -24,6 +24,7 @@
 #include <Library/HobLib.h>
 #include <Library/ResetSystemLib.h>
 #include <Library/ReportStatusCodeLib.h>
+#include <Library/PanicLib.h>
 
 //
 // The maximum recursion depth to ResetSystem() by reset notification handlers

--- a/MdeModulePkg/Universal/ResetSystemPei/ResetSystemPei.inf
+++ b/MdeModulePkg/Universal/ResetSystemPei/ResetSystemPei.inf
@@ -37,6 +37,7 @@
   DebugLib
   PeiServicesLib
   HobLib
+  PanicLib
   PeimEntryPoint
   ResetSystemLib
   ReportStatusCodeLib

--- a/MdePkg/Include/Library/PanicLib.h
+++ b/MdePkg/Include/Library/PanicLib.h
@@ -1,0 +1,64 @@
+/** @file
+  Provides an API that can be used to halt boot during a critical error and
+  leave a message describing what went wrong.  This should be used for unrecoverable
+  errors in boot that usually occur in early in boot.
+Copyright (c) Microsoft Corporation.
+SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef PANIC_LIB_H_
+#define PANIC_LIB_H_
+
+/**
+  Prints a panic message containing a filename, line number, and description.
+  This is always followed by a dead loop.
+  Print a message of the form "PANIC <FileName>(<LineNumber>): <Description>\n"
+  to the debug output device.  Immediately after that CpuDeadLoop() is called.
+  If FileName is NULL, then a <FileName> string of "(NULL) Filename" is printed.
+  If Description is NULL, then a <Description> string of "(NULL) Description" is printed.
+  @param[in]  FileName     The pointer to the name of the source file that generated the panic condition.
+  @param[in]  LineNumber   The line number in the source file that generated the panic condition
+  @param[in]  Description  The pointer to the description of the panic condition.
+**/
+VOID
+EFIAPI
+PanicReport (
+  IN CONST CHAR8  *FileName,
+  IN UINTN        LineNumber,
+  IN CONST CHAR8  *Description
+  );
+
+//
+// Source file line number.
+// Default is use the to compiler provided __LINE__ macro value. The __LINE__
+// mapping can be overriden by predefining PANIC_LINE_NUMBER
+
+//
+// Defining PANIC_LINE_NUMBER to a fixed value is useful when comparing builds
+// across source code formatting changes that may add/remove lines in a source
+// file.
+//
+#ifndef PANIC_LINE_NUMBER
+#define PANIC_LINE_NUMBER  __LINE__
+#endif
+
+// File name being printed out.
+// Default is the compiler provided __FILE__ macro value. You can overwrite this
+// by defining __FILE_NAME__
+#if defined (__clang__) && defined (__FILE_NAME__)
+#define _PANIC(Message)  PanicReport (__FILE_NAME__, PANIC_LINE_NUMBER, Message)
+#else
+#define _PANIC(Message)  PanicReport (__FILE__, PANIC_LINE_NUMBER, Message)
+#endif
+
+/**
+  Macro that calls PanicReport().
+  @param  Message  A format string
+**/
+#define PANIC(Message)        \
+    do {                            \
+      _PANIC (Message);     \
+      ANALYZER_UNREACHABLE ();  \
+    } while (FALSE)
+
+#endif // PANIC_LIB_H_

--- a/MdePkg/Library/BasePanicLibNull/BasePanicLibNull.c
+++ b/MdePkg/Library/BasePanicLibNull/BasePanicLibNull.c
@@ -1,0 +1,29 @@
+/** @file
+  Base Panic Library with empty functions.
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Base.h>
+#include <Library/PanicLib.h>
+
+/**
+  This would usually print a panic message containing a filename, line number,
+  and description.  For the NULL implementation nothing is done when panicking.
+
+  @param  FileName     The pointer to the name of the source file that generated the panic condition.
+  @param  LineNumber   The line number in the source file that generated the panic condition
+  @param  Description  The pointer to the description of the panic condition.
+
+**/
+VOID
+EFIAPI
+PanicReport (
+  IN CONST CHAR8  *FileName,
+  IN UINTN        LineNumber,
+  IN CONST CHAR8  *Description
+  )
+{
+}

--- a/MdePkg/Library/BasePanicLibNull/BasePanicLibNull.inf
+++ b/MdePkg/Library/BasePanicLibNull/BasePanicLibNull.inf
@@ -1,0 +1,26 @@
+## @file
+#  Panic Library with empty functions.
+#
+#  Copyright (c) Microsoft Corporation.
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = BasePanicLibNull
+  FILE_GUID                      = 0A097ABB-3869-4CF8-B5C0-AE798F135C46
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = PanicLib
+
+
+#
+#  VALID_ARCHITECTURES           = ANY
+#
+
+[Sources]
+  BasePanicLibNull.c
+
+[Packages]
+  MdePkg/MdePkg.dec

--- a/MdePkg/Library/BasePanicLibSerialPort/BasePanicLibSerialPort.c
+++ b/MdePkg/Library/BasePanicLibSerialPort/BasePanicLibSerialPort.c
@@ -1,0 +1,68 @@
+/** @file
+  Base Serial Port Panic Library.
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Base.h>
+#include <Library/BaseLib.h>
+#include <Library/PrintLib.h>
+#include <Library/SerialPortLib.h>
+#include <Library/PanicLib.h>
+
+//
+// Define the maximum panic message length that this library supports
+//
+#define MAX_PANIC_MESSAGE_LENGTH  0x100
+
+/**
+  Prints a panic message containing a filename, line number, and description.
+  This is always followed by a dead loop.
+
+  Print a message of the form "PANIC <FileName>(<LineNumber>): <Description>\n"
+  to the debug output device.  Immediately after that CpuDeadLoop() is called.
+
+  If FileName is NULL, then a <FileName> string of "(NULL) Filename" is printed.
+  If Description is NULL, then a <Description> string of "(NULL) Description" is printed.
+
+  @param  FileName     The pointer to the name of the source file that generated the panic condition.
+  @param  LineNumber   The line number in the source file that generated the panic condition
+  @param  Description  The pointer to the description of the panic condition.
+
+**/
+VOID
+EFIAPI
+PanicReport (
+  IN CONST CHAR8  *FileName,
+  IN UINTN        LineNumber,
+  IN CONST CHAR8  *Description
+  )
+{
+  CHAR8  Buffer[MAX_PANIC_MESSAGE_LENGTH];
+
+  if (FileName == NULL) {
+    FileName = "(NULL) Filename";
+  }
+
+  if (Description == NULL) {
+    Description = "(NULL) Description";
+  }
+
+  //
+  // Generate the PANIC message in ASCII format
+  //
+  AsciiSPrint (Buffer, sizeof (Buffer), "PANIC [%a] %a(%d): %a\n", gEfiCallerBaseName, FileName, LineNumber, Description);
+
+  // Initialize Serial Port to write the panic message
+  SerialPortInitialize ();
+
+  //
+  // Send the print string to the Logging device device
+  //
+  SerialPortWrite ((UINT8 *)Buffer, AsciiStrLen (Buffer));
+
+  // Deadlooping because system is in an unrecoverable state.
+  CpuDeadLoop ();
+}

--- a/MdePkg/Library/BasePanicLibSerialPort/BasePanicLibSerialPort.inf
+++ b/MdePkg/Library/BasePanicLibSerialPort/BasePanicLibSerialPort.inf
@@ -1,0 +1,31 @@
+## @file
+#  Panic Library.
+#
+#  Copyright (c) Microsoft Corporation.
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = BasePanicLibSerialPort
+  FILE_GUID                      = DF456972-AF4A-4F3A-B33C-DD31368BF490
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = PanicLib
+
+
+#
+#  VALID_ARCHITECTURES           = ANY
+#
+
+[Sources]
+  BasePanicLibSerialPort.c
+
+[LibraryClasses]
+  PrintLib
+  SerialPortLib
+  BaseLib
+
+[Packages]
+  MdePkg/MdePkg.dec

--- a/MdePkg/MdePkg.dec
+++ b/MdePkg/MdePkg.dec
@@ -303,6 +303,10 @@
   #
   TraceHubDebugSysTLib|Include/Library/TraceHubDebugSysTLib.h
 
+  ##  @libraryclass  Provides panic functionality.
+  #
+  PanicLib|Include/Library/PanicLib.h
+
 [LibraryClasses.IA32, LibraryClasses.X64, LibraryClasses.AARCH64]
   ##  @libraryclass  Provides services to generate random number.
   #

--- a/MdePkg/MdePkg.dsc
+++ b/MdePkg/MdePkg.dsc
@@ -58,6 +58,8 @@
   MdePkg/Library/PciSegmentLibSegmentInfo/DxeRuntimePciSegmentLibSegmentInfo.inf
   MdePkg/Library/BaseS3PciSegmentLib/BaseS3PciSegmentLib.inf
   MdePkg/Library/BaseArmTrngLibNull/BaseArmTrngLibNull.inf
+  MdePkg/Library/BasePanicLibSerialPort/BasePanicLibSerialPort.inf
+  MdePkg/Library/BasePanicLibNull/BasePanicLibNull.inf
   MdePkg/Library/BasePeCoffGetEntryPointLib/BasePeCoffGetEntryPointLib.inf
   MdePkg/Library/BasePeCoffLib/BasePeCoffLib.inf
   MdePkg/Library/BasePeCoffExtraActionLibNull/BasePeCoffExtraActionLibNull.inf

--- a/UefiCpuPkg/CpuDxe/CpuDxe.inf
+++ b/UefiCpuPkg/CpuDxe/CpuDxe.inf
@@ -33,6 +33,7 @@
   HobLib
   MemoryAllocationLib
   MpInitLib
+  PanicLib
   PeCoffGetEntryPointLib
   ReportStatusCodeLib
   TimerLib

--- a/UefiCpuPkg/CpuMpPei/CpuMpPei.c
+++ b/UefiCpuPkg/CpuMpPei/CpuMpPei.c
@@ -437,8 +437,15 @@ InitializeExceptionStackSwitchHandlers (
 {
   EXCEPTION_STACK_SWITCH_CONTEXT  *SwitchStackData;
   UINTN                           Index;
+  EFI_STATUS                      Status;
 
-  MpInitLibWhoAmI (&Index);
+  Status = MpInitLibWhoAmI (&Index);
+
+  if (EFI_ERROR (Status)) {
+    PANIC ("Failed to get processor number when initializing the stack switch exception handlers.");
+    return;
+  }
+
   SwitchStackData = (EXCEPTION_STACK_SWITCH_CONTEXT *)Buffer;
 
   //

--- a/UefiCpuPkg/CpuMpPei/CpuMpPei.h
+++ b/UefiCpuPkg/CpuMpPei/CpuMpPei.h
@@ -29,6 +29,7 @@
 #include <Library/BaseMemoryLib.h>
 #include <Library/MemoryAllocationLib.h>
 #include <Library/CpuPageTableLib.h>
+#include <Library/PanicLib.h>
 
 #include <Guid/MpInformation2.h>
 

--- a/UefiCpuPkg/CpuMpPei/CpuMpPei.inf
+++ b/UefiCpuPkg/CpuMpPei/CpuMpPei.inf
@@ -47,6 +47,7 @@
   CpuLib
   MemoryAllocationLib
   CpuPageTableLib
+  PanicLib
 
 [Guids]
   gEdkiiMigratedFvInfoGuid                                             ## SOMETIMES_CONSUMES     ## HOB

--- a/UefiCpuPkg/UefiCpuPkg.dsc
+++ b/UefiCpuPkg/UefiCpuPkg.dsc
@@ -69,6 +69,7 @@
   UnitTestPersistenceLib|UnitTestFrameworkPkg/Library/UnitTestPersistenceLibNull/UnitTestPersistenceLibNull.inf
   UnitTestResultReportLib|UnitTestFrameworkPkg/Library/UnitTestResultReportLib/UnitTestResultReportLibDebugLib.inf
   LockBoxLib|MdeModulePkg/Library/SmmLockBoxLib/SmmLockBoxDxeLib.inf
+  PanicLib|MdePkg/Library/BasePanicLibNull/BasePanicLibNull.inf
 
 [LibraryClasses.common.SEC]
   PlatformSecLib|UefiCpuPkg/Library/PlatformSecLibNull/PlatformSecLibNull.inf


### PR DESCRIPTION
# Description

Added a panic library to MdePkg. This provides an API to use for when an unrecoverable error is hit during boot. It will print a message to the debug console and have the system deadloop indefinitely.

It can be used by including the BasePanicLib implementation in your module or library and calling `PANIC`. You can input your own custom message to indicate what's triggering the `PANIC`.



- [x] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Tested on QemuQ35 and intel based physical platforms.  When a `PANIC` is forcefully hit we halt boot as expected and print out the correct `PANIC` message.

## Integration Instructions

Platforms will need to include the `BasePanicLibNull` library in their platform DSCs.
