### PR TITLE
MdeModulePkg: Add extra RestoreTpl() call in DiskIo and StartImage() to maintain TPL raise/restore symmetry

### DIFF
--- a/MdeModulePkg/Core/Dxe/Image/Image.c
+++ b/MdeModulePkg/Core/Dxe/Image/Image.c
@@ -1725,7 +1725,9 @@ CoreStartImage (
   // Image has completed.  Verify the tpl is the same
   //
   ASSERT (Image->Tpl == gEfiCurrentTpl);
-  CoreRestoreTpl (Image->Tpl);
+  if (Image->Tpl != gEfiCurrentTpl) {
+    CoreRestoreTpl (Image->Tpl);
+  }
 
   CoreFreePool (Image->JumpBuffer);
 

--- a/MdeModulePkg/Universal/Disk/DiskIoDxe/DiskIo.c
+++ b/MdeModulePkg/Universal/Disk/DiskIoDxe/DiskIo.c
@@ -847,6 +847,7 @@ DiskIo2ReadWriteDisk (
   DISK_IO_SUBTASK         *Subtask;
   DISK_IO2_TASK           *Task;
   EFI_TPL                 OldTpl;
+  EFI_TPL                 OldTpl1;
   BOOLEAN                 Blocking;
   BOOLEAN                 SubtaskBlocking;
   LIST_ENTRY              *SubtasksPtr;
@@ -977,7 +978,7 @@ DiskIo2ReadWriteDisk (
     }
   }
 
-  gBS->RaiseTPL (TPL_NOTIFY);
+  OldTpl1 = gBS->RaiseTPL (TPL_NOTIFY);
 
   //
   // Remove all the remaining subtasks when failure.
@@ -1012,6 +1013,7 @@ DiskIo2ReadWriteDisk (
     FreePool (Task);
   }
 
+  gBS->RestoreTPL (OldTpl1);
   gBS->RestoreTPL (OldTpl);
 
   return Status;

--- a/MdeModulePkg/Universal/Disk/DiskIoDxe/DiskIo.c
+++ b/MdeModulePkg/Universal/Disk/DiskIoDxe/DiskIo.c
@@ -846,8 +846,8 @@ DiskIo2ReadWriteDisk (
   LIST_ENTRY              Subtasks;
   DISK_IO_SUBTASK         *Subtask;
   DISK_IO2_TASK           *Task;
-  EFI_TPL                 OldTpl;
-  EFI_TPL                 OldTpl1;
+  EFI_TPL                 SubtaskPerformTpl;
+  EFI_TPL                 SubtaskLockTpl;
   BOOLEAN                 Blocking;
   BOOLEAN                 SubtaskBlocking;
   LIST_ENTRY              *SubtasksPtr;
@@ -897,7 +897,7 @@ DiskIo2ReadWriteDisk (
 
   ASSERT (!IsListEmpty (SubtasksPtr));
 
-  OldTpl = gBS->RaiseTPL (TPL_CALLBACK);
+  SubtaskPerformTpl = gBS->RaiseTPL (TPL_CALLBACK);
   for ( Link = GetFirstNode (SubtasksPtr), NextLink = GetNextNode (SubtasksPtr, Link)
         ; !IsNull (SubtasksPtr, Link)
         ; Link = NextLink, NextLink = GetNextNode (SubtasksPtr, NextLink)
@@ -978,7 +978,7 @@ DiskIo2ReadWriteDisk (
     }
   }
 
-  OldTpl1 = gBS->RaiseTPL (TPL_NOTIFY);
+  SubtaskLockTpl = gBS->RaiseTPL (TPL_NOTIFY);
 
   //
   // Remove all the remaining subtasks when failure.
@@ -1013,8 +1013,8 @@ DiskIo2ReadWriteDisk (
     FreePool (Task);
   }
 
-  gBS->RestoreTPL (OldTpl1);
-  gBS->RestoreTPL (OldTpl);
+  gBS->RestoreTPL (SubtaskLockTpl);
+  gBS->RestoreTPL (SubtaskPerformTpl);
 
   return Status;
 }


### PR DESCRIPTION
# Description

Adds a call to RestoreTpl() in DiskIo2ReadWriteDisk(). While the current implementation does not technically violate spec on raise/restore TPL, this extra call ensures symmetry between RaiseTpl and RestoreTpl calls, which makes analysis of TPL correctness simpler and permits certain non-standard TPL usages that some platforms require.

Comments out a redundant call to RestoreTpl(). While this does not technically violate spec on raise/restore TPL, TPL should already be at the specified level. This extra call introduces an asymmetry between RaiseTpl and RestoreTpl calls, which makes analysis of TPL correctness more difficult and hampers certain non-standard TPL usages that some platforms require.

<_For each item, place an "x" in between `[` and `]` if true. Example: `[x]` (you can also check items in GitHub UI)_>

<_Create the PR as a Draft PR if it is only created to run CI checks._>

<_Delete lines in \<\> tags before creating the PR._>

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Booted and observed no un-intended side effects w.r.t. TPL with this modification. Added test instrumentation to verify that TPL is always already at the desired state prior to this call being executed.

## Integration Instructions

N/A
