### PR TITLE
UefiCpuPkg/DxeMpInitLib: Add a PCD to allow the AP wakeup buffer to be reserved

### DIFF
--- a/UefiCpuPkg/Library/MpInitLib/DxeMpInitLib.inf
+++ b/UefiCpuPkg/Library/MpInitLib/DxeMpInitLib.inf
@@ -99,3 +99,4 @@
   gUefiCpuPkgTokenSpaceGuid.PcdGhcbHypervisorFeatures                  ## CONSUMES
   gUefiCpuPkgTokenSpaceGuid.PcdSevEsWorkAreaBase                       ## SOMETIMES_CONSUMES
   gUefiCpuPkgTokenSpaceGuid.PcdFirstTimeWakeUpAPsBySipi                ## CONSUMES
+  gUefiCpuPkgTokenSpaceGuid.PcdCpuApWakeupBufferReserved               ## CONSUMES

--- a/UefiCpuPkg/Library/MpInitLib/DxeMpLib.c
+++ b/UefiCpuPkg/Library/MpInitLib/DxeMpLib.c
@@ -91,8 +91,9 @@ GetWakeupBuffer (
   EFI_PHYSICAL_ADDRESS  StartAddress;
   EFI_MEMORY_TYPE       MemoryType;
 
-  if (ConfidentialComputingGuestHas (CCAttrAmdSevEs) &&
-      !ConfidentialComputingGuestHas (CCAttrAmdSevSnp))
+  if (PcdGetBool (PcdCpuApWakeupBufferReserved) ||
+      (ConfidentialComputingGuestHas (CCAttrAmdSevEs) &&
+       !ConfidentialComputingGuestHas (CCAttrAmdSevSnp)))
   {
     //
     // An SEV-ES-only guest requires the memory to be reserved. SEV-SNP, which

--- a/UefiCpuPkg/UefiCpuPkg.dec
+++ b/UefiCpuPkg/UefiCpuPkg.dec
@@ -428,6 +428,11 @@
   # @Prompt Enable performance collecting when processor trace is enabled.
   gUefiCpuPkgTokenSpaceGuid.PcdCpuProcTracePerformanceCollecting|FALSE|BOOLEAN|0x60000020
 
+  ## Specifies that the wake-up buffer for AP startup should be permanently
+  # allocated as reserved.
+  # @Prompt Allocates CPU wake-up buffer as reserved.
+  gUefiCpuPkgTokenSpaceGuid.PcdCpuApWakeupBufferReserved|FALSE|BOOLEAN|0x0000001F
+
 [PcdsFixedAtBuild.X64, PcdsPatchableInModule.X64, PcdsDynamic.X64, PcdsDynamicEx.X64]
   ## Indicate access to non-SMRAM memory is restricted to reserved, runtime and ACPI NVS type after SmmReadyToLock.
   #  MMIO access is always allowed regardless of the value of this PCD.


### PR DESCRIPTION
# Description

Creates a new PCD which when set will cause the AP wakeup buffer to be allocated as a reserved type.

<_For each item, place an "x" in between `[` and `]` if true. Example: `[x]` (you can also check items in GitHub UI)_>

<_Create the PR as a Draft PR if it is only created to run CI checks._>

<_Delete lines in \<\> tags before creating the PR._>

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Tested on custom Q35 image

## Integration Instructions

N/A
