### PR TITLE
MdePkg/BaseFdtLib: Add FdtNodeOffsetByCompatible()

### DIFF
--- a/MdePkg/Include/Library/FdtLib.h
+++ b/MdePkg/Include/Library/FdtLib.h
@@ -432,4 +432,21 @@ FdtNodeDepth (
   IN INT32       NodeOffset
   );
 
+/**
+  Find nodes with a given 'compatible' value.
+
+  @param[in] Fdt            The pointer to FDT blob.
+  @param[in] StartOffset    Only find nodes after this offset.
+  @param[in] Compatible     The string to match against.
+
+  @retval The offset of the first node after StartOffset.
+**/
+INT32
+EFIAPI
+FdtNodeOffsetByCompatible (
+  IN CONST VOID   *Fdt,
+  IN INT32        StartOffset,
+  IN CONST CHAR8  *Compatible
+  );
+
 #endif /* FDT_LIB_H_ */

--- a/MdePkg/Library/BaseFdtLib/FdtLib.c
+++ b/MdePkg/Library/BaseFdtLib/FdtLib.c
@@ -442,3 +442,23 @@ FdtNodeDepth (
 {
   return fdt_node_depth (Fdt, NodeOffset);
 }
+
+/**
+  Find nodes with a given 'compatible' value.
+
+  @param[in] Fdt            The pointer to FDT blob.
+  @param[in] StartOffset    Only find nodes after this offset.
+  @param[in] Compatible     The string to match against.
+
+  @retval The offset of the first node after StartOffset.
+**/
+INT32
+EFIAPI
+FdtNodeOffsetByCompatible (
+  IN CONST VOID   *Fdt,
+  IN INT32        StartOffset,
+  IN CONST CHAR8  *Compatible
+  )
+{
+  return fdt_node_offset_by_compatible (Fdt, StartOffset, Compatible);
+}


### PR DESCRIPTION
# Description

This adds FdtNodeOffsetByCompatible() to support finding the offset of the first node with a given 'compatible' value after an offset.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

## Integration Instructions
