### PR TITLE
MdePkg,ShellPkg: Add New Socket Type for SMBIOS Type4

### DIFF
--- a/MdePkg/Include/IndustryStandard/SmBios.h
+++ b/MdePkg/Include/IndustryStandard/SmBios.h
@@ -887,7 +887,8 @@ typedef enum {
   ProcessorUpgradeSocketBGA2551   = 0x54,
   ProcessorUpgradeSocketLGA1851   = 0x55,
   ProcessorUpgradeSocketBGA2114   = 0x56,
-  ProcessorUpgradeSocketBGA2833   = 0x57
+  ProcessorUpgradeSocketBGA2833   = 0x57,
+  ProcessorUpgradeInvalid         = 0xFF
 } PROCESSOR_UPGRADE;
 
 ///

--- a/MdePkg/Include/IndustryStandard/SmBios.h
+++ b/MdePkg/Include/IndustryStandard/SmBios.h
@@ -1020,6 +1020,10 @@ typedef struct {
   // Add for smbios 3.6
   //
   UINT16                 ThreadEnabled;
+  //
+  // Add for smbios 3.8
+  //
+  SMBIOS_TABLE_STRING    SocketType;
 } SMBIOS_TABLE_TYPE4;
 
 ///

--- a/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/PrintInfo.c
+++ b/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/PrintInfo.c
@@ -524,6 +524,10 @@ SmbiosPrintStructure (
         ShellPrintEx (-1, -1, L"Thread Enabled: %u\n", Struct->Type4->ThreadEnabled);
       }
 
+      if (AE_SMBIOS_VERSION (0x3, 0x8) && (Struct->Hdr->Length > 0x30)) {
+        ShellPrintEx (-1, -1, L"Socket Type: %a\n", LibGetSmbiosString (Struct, Struct->Type4->SocketType));
+      }
+
       break;
 
     //


### PR DESCRIPTION
The patch adds new socket type (Type 4, Offset 32h) for SMBIOS Type4 and also update SmbiosView PrintInfo.c to use the new field name based on SMBIOS v3.8.0.

