### PR TITLE
OvmfPkg/LoongArchVirt: Clear the PGD series registers

### DIFF
--- a/OvmfPkg/LoongArchVirt/Library/CpuMmuInitLib/CpuMmuInit.c
+++ b/OvmfPkg/LoongArchVirt/Library/CpuMmuInitLib/CpuMmuInit.c
@@ -141,6 +141,12 @@ ConfigureMemoryManagementUnit (
     return EFI_UNSUPPORTED;
   }
 
+  //
+  // Clear PGD series registers.
+  //
+  CsrWrite (LOONGARCH_CSR_PGDL, 0x0);
+  CsrWrite (LOONGARCH_CSR_PGDH, 0x0);
+
   PageTable = 0;
   while (MemoryTable->NumberOfPages != 0) {
     DEBUG ((


### PR DESCRIPTION
# Description

Since the PGD series registers are in an unknown state when reset, some simulators will hang when restarting if these registers are not cleared, so they are cleared in this patch.

## How This Was Tested

Start the VM with an OS and reboot in the OS and it will hang. Apply this patch and it will work fine.

## Integration Instructions

N/A
