### PR TITLE
MdeModulePkg: UefiBootManagerLib: Update assert condition

### DIFF
--- a/MdeModulePkg/Library/UefiBootManagerLib/BmBoot.c
+++ b/MdeModulePkg/Library/UefiBootManagerLib/BmBoot.c
@@ -147,6 +147,12 @@ BmFindBootOptionInVariable (
   if (OptionNumber == LoadOptionNumberUnassigned) {
     BootOptions = EfiBootManagerGetLoadOptions (&BootOptionCount, LoadOptionTypeBoot);
 
+    // Only assert if the BootOption is non-zero
+    if ((BootOptions == NULL) && (BootOptionCount > 0)) {
+      ASSERT (BootOptions != NULL);
+      return LoadOptionNumberUnassigned;
+    }
+
     Index = EfiBootManagerFindLoadOption (OptionToFind, BootOptions, BootOptionCount);
     if (Index != -1) {
       OptionNumber = BootOptions[Index].OptionNumber;


### PR DESCRIPTION

Currently the following assertion is made in
`BmFindBootOptionInVariable()`:

```c
  if (OptionNumber == LoadOptionNumberUnassigned) {
    BootOptions = EfiBootManagerGetLoadOptions (&BootOptionCount, LoadOptionTypeBoot);

    if (BootOptions == NULL) {
      ASSERT (BootOptions != NULL);
      return LoadOptionNumberUnassigned;
    }

    Index = EfiBootManagerFindLoadOption (OptionToFind, BootOptions, BootOptionCount);
```

The reason behind this is to prevent passing a null pointer to `EfiBootManagerFindLoadOption()`.

However, `EfiBootManagerFindLoadOption()` accepts a null pointer argument to be passed as the second argument ('Array') as long as the `Count` argument is `0`.

In that case `LoadOptionNumberUnassigned` will still be returned from the function but an assert is not necessary.

This change updates the condition to only assert if the pointer is null and the boot option count is non-zero.

<_For each item, place an "x" in between `[` and `]` if true. Example: `[x]` (you can also check items in GitHub UI)_>

<_Create the PR as a Draft PR if it is only created to run CI checks._>

<_Delete lines in \<\> tags before creating the PR._>

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Verified build and boot on Qemu35Pkg.

## Integration Instructions

N/A
