### PR TITLE
MdePkg: Add FltUsedLib

### DIFF
--- a/MdePkg/Library/FltUsedLib/FltUsedLib.c
+++ b/MdePkg/Library/FltUsedLib/FltUsedLib.c
@@ -1,0 +1,10 @@
+/** @file
+  Lib to include if using floats
+
+Copyright (C) Microsoft Corporation. All rights reserved..
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+// You need to include this to let the compiler know we are going to use floating point
+int  _fltused = 0x9875;

--- a/MdePkg/Library/FltUsedLib/FltUsedLib.inf
+++ b/MdePkg/Library/FltUsedLib/FltUsedLib.inf
@@ -1,0 +1,41 @@
+## @file
+#  Lib to include if using floats
+#
+# Copyright (C) Microsoft Corporation. All rights reserved..
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = FltUsedLib
+  FILE_GUID                      = C004F180-9FE2-4D2B-8318-BADC2A231774
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = FltUsedLib
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64 AARCH64
+#
+
+[Sources]
+  FltUsedLib.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+
+[LibraryClasses]
+
+[Guids]
+
+[Protocols]
+
+[BuildOptions]
+  # Disable GL due to linker error LNK1237
+  # https://docs.microsoft.com/en-us/cpp/error-messages/tool-errors/linker-tools-error-lnk1237?view=vs-2017
+  MSFT:*_*_*_CC_FLAGS = /GL-
+
+[Depex]
+  TRUE
+

--- a/MdePkg/Library/FltUsedLib/Readme.md
+++ b/MdePkg/Library/FltUsedLib/Readme.md
@@ -1,0 +1,15 @@
+# FltUsedLib
+
+This library provides a global (fltused) that needs to be defined anywhere floating point operations are used.
+The C compiler produces the _fltused symbol by default, this is just to satisfy the linker.
+
+## Using
+
+To use FltUsedLib, just include it in the INF of the module that uses floating point.
+
+```inf
+[LibraryClasses]
+  BaseLib
+  BaseMemoryLib
+  FltUsedLib
+```

--- a/MdePkg/MdePkg.ci.yaml
+++ b/MdePkg/MdePkg.ci.yaml
@@ -115,7 +115,9 @@
 
     ## options defined ci/Plugin/DscCompleteCheck
     "DscCompleteCheck": {
-        "IgnoreInf": [""],
+        "IgnoreInf": [
+            "MdePkg/Library/FltUsedLib/FltUsedLib.inf"
+        ],
         "DscPath": "MdePkg.dsc"
     },
 


### PR DESCRIPTION
# Description

This library provides a global (fltused) that needs to be defined anywhere floating point operations are used.
The C compiler produces the _fltused symbol by default, this is just to satisfy the linker.

<_For each item, place an "x" in between `[` and `]` if true. Example: `[x]` (you can also check items in GitHub UI)_>

<_Create the PR as a Draft PR if it is only created to run CI checks._>

<_Delete lines in \<\> tags before creating the PR._>

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Tested in Qemu.

## Integration Instructions

This information is included in the Readme.md file.
To use FltUsedLib, just include it in the INF of the module that uses floating point.

```inf
[LibraryClasses]
  BaseLib
  BaseMemoryLib
  FltUsedLib
```
