### PR TITLE
MdeModulePkg/Core/Pei: Add error handling for Section Length

### DIFF
--- a/MdeModulePkg/Core/Pei/FwVol/FwVol.c
+++ b/MdeModulePkg/Core/Pei/FwVol/FwVol.c
@@ -819,6 +819,10 @@ ProcessSection (
       if (!IsFfs3Fv) {
         DEBUG ((DEBUG_ERROR, "Found a FFS3 formatted section in a non-FFS3 formatted FV.\n"));
         SectionLength = SECTION2_SIZE (Section);
+        if (SectionLength == 0) {
+          break;
+        }
+
         //
         // SectionLength is adjusted it is 4 byte aligned.
         // Go to the next section
@@ -852,6 +856,10 @@ ProcessSection (
           SectionLength = SECTION2_SIZE (Section);
         } else {
           SectionLength = SECTION_SIZE (Section);
+        }
+
+        if (SectionLength == 0) {
+          break;
         }
 
         //
@@ -989,6 +997,10 @@ ProcessSection (
       SectionLength = SECTION2_SIZE (Section);
     } else {
       SectionLength = SECTION_SIZE (Section);
+    }
+
+    if (SectionLength == 0) {
+      break;
     }
 
     //


### PR DESCRIPTION
This patch breaks the section processing loop if an invalid section with zero SectionLength is encountered.


Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Dhanaraj V <vdhanaraj@ami.com>
Cc: Sachin Ganesh <sachinganesh@ami.com>

# Description

This patch breaks the section processing loop if an invalid section with zero SectionLength is encountered.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

## Integration Instructions

