### PR TITLE
Add RISC-V Specific CPU HOB

### DIFF
--- a/MdePkg/Include/Pi/PiHob.h
+++ b/MdePkg/Include/Pi/PiHob.h
@@ -26,8 +26,11 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #define EFI_HOB_TYPE_LOAD_PEIM_UNUSED     0x000A
 #define EFI_HOB_TYPE_UEFI_CAPSULE         0x000B
 #define EFI_HOB_TYPE_FV3                  0x000C
-#define EFI_HOB_TYPE_UNUSED               0xFFFE
-#define EFI_HOB_TYPE_END_OF_HOB_LIST      0xFFFF
+// For now using this higher count to ensure it does not conflict with PI
+// defined HOBs. Once RV CPU HOB is ratified it should come from PiHob.h.
+#define EFI_HOB_TYPE_RISCV_CPU        0x000D
+#define EFI_HOB_TYPE_UNUSED           0xFFFE
+#define EFI_HOB_TYPE_END_OF_HOB_LIST  0xFFFF
 
 ///
 /// Describes the format and size of the data inside the HOB.
@@ -455,6 +458,14 @@ typedef struct {
   UINT8                     Reserved[6];
 } EFI_HOB_CPU;
 
+typedef struct {
+  ///
+  /// The HOB generic header. Header.HobType = EFI_HOB_RISCV_CPU.
+  ///
+  EFI_HOB_GENERIC_HEADER    Header;
+  UINT8                     CpuId;
+  UINT8                     Reserved[7];
+} EFI_HOB_RISCV_CPU;
 ///
 /// Describes pool memory allocations.
 ///

--- a/UefiCpuPkg/CpuDxeRiscV64/CpuDxe.c
+++ b/UefiCpuPkg/CpuDxeRiscV64/CpuDxe.c
@@ -7,7 +7,7 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
-
+#include <Library/HobLib.h>
 #include "CpuDxe.h"
 
 //
@@ -331,19 +331,16 @@ InitializeCpu (
   IN EFI_SYSTEM_TABLE  *SystemTable
   )
 {
-  EFI_STATUS                  Status;
-  EFI_RISCV_FIRMWARE_CONTEXT  *FirmwareContext;
+  EFI_STATUS         Status;
+  EFI_HOB_RISCV_CPU  *CpuHob;
 
-  GetFirmwareContextPointer (&FirmwareContext);
-  ASSERT (FirmwareContext != NULL);
-  if (FirmwareContext == NULL) {
-    DEBUG ((DEBUG_ERROR, "Failed to get the pointer of EFI_RISCV_FIRMWARE_CONTEXT\n"));
-    return EFI_NOT_FOUND;
-  }
+  //
+  // Get the number of address lines in the I/O and Memory space for the CPU
+  //
+  CpuHob = GetFirstHob (EFI_HOB_TYPE_RISCV_CPU);
+  ASSERT (CpuHob != NULL);
+  mBootHartId = CpuHob->CpuId;
 
-  DEBUG ((DEBUG_INFO, " %a: Firmware Context is at 0x%x.\n", __func__, FirmwareContext));
-
-  mBootHartId = FirmwareContext->BootHartId;
   DEBUG ((DEBUG_INFO, " %a: mBootHartId = 0x%x.\n", __func__, mBootHartId));
 
   InitializeCpuExceptionHandlers (NULL);


### PR DESCRIPTION
# Description
RISCV requires to access certain information like hartid etc from one FW stage to another. Based on few discussions it was found that it is better to have a RISCV specific HOB for this purpose. It would also contain information like certain 
RISCV specific feature in future as required.


- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested
It was tested on an internal simulation platform.

Hartid information is properly stored in the HOB which is then referred to by CPU driver to populate and share it with the OS to provide with correct hartid information.
## Integration Instructions


