### PR TITLE
CryptoPkg/BaseCryptLibMbedTls: Fix uninitialized variable errors

### DIFF
--- a/CryptoPkg/Library/BaseCryptLibMbedTls/Pk/CryptPkcs7Sign.c
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/Pk/CryptPkcs7Sign.c
@@ -486,6 +486,7 @@ Pkcs7Sign (
     return FALSE;
   }
 
+  Buffer     = NULL;
   BufferSize = 4096;
 
   SignatureLen = MAX_SIGNATURE_SIZE;

--- a/CryptoPkg/Library/BaseCryptLibMbedTls/Pk/CryptTs.c
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/Pk/CryptTs.c
@@ -118,12 +118,11 @@ ImageTimestampVerify (
   OUT EFI_TIME     *SigningTime
   )
 {
-  BOOLEAN  Status;
-  UINT8    *Ptr;
-  UINT8    *End;
-  INT32    Len;
-  UINTN    ObjLen;
-  UINT8    *TempPtr;
+  UINT8  *Ptr;
+  UINT8  *End;
+  INT32  Len;
+  UINTN  ObjLen;
+  UINT8  *TempPtr;
 
   //
   // Initializations
@@ -374,8 +373,8 @@ ImageTimestampVerify (
   //
   if (SigningTime != NULL) {
     SetMem (SigningTime, sizeof (EFI_TIME), 0);
-    Status = ConvertAsn1TimeToEfiTime (Ptr, SigningTime);
+    return ConvertAsn1TimeToEfiTime (Ptr, SigningTime);
   }
 
-  return Status;
+  return TRUE;
 }


### PR DESCRIPTION
Clang complains about a couple of variables potentially being uninitialized, and those complaints seem to be valid.
