### PR TITLE
ArmPkg: CpuDxe: Remove MemoryAttributeProtocol SystemMemory Check

### DIFF
--- a/ArmPkg/Drivers/CpuDxe/MemoryAttribute.c
+++ b/ArmPkg/Drivers/CpuDxe/MemoryAttribute.c
@@ -9,42 +9,6 @@
 #include "CpuDxe.h"
 
 /**
-  Check whether the provided memory range is covered by a single entry of type
-  EfiGcdSystemMemory in the GCD memory map.
-
-  @param  BaseAddress       The physical address that is the start address of
-                            a memory region.
-  @param  Length            The size in bytes of the memory region.
-
-  @return Whether the region is system memory or not.
-**/
-STATIC
-BOOLEAN
-RegionIsSystemMemory (
-  IN  EFI_PHYSICAL_ADDRESS  BaseAddress,
-  IN  UINT64                Length
-  )
-{
-  EFI_GCD_MEMORY_SPACE_DESCRIPTOR  GcdDescriptor;
-  EFI_PHYSICAL_ADDRESS             GcdEndAddress;
-  EFI_STATUS                       Status;
-
-  Status = gDS->GetMemorySpaceDescriptor (BaseAddress, &GcdDescriptor);
-  if (EFI_ERROR (Status) ||
-      (GcdDescriptor.GcdMemoryType != EfiGcdMemoryTypeSystemMemory))
-  {
-    return FALSE;
-  }
-
-  GcdEndAddress = GcdDescriptor.BaseAddress + GcdDescriptor.Length;
-
-  //
-  // Return TRUE if the GCD descriptor covers the range entirely
-  //
-  return GcdEndAddress >= (BaseAddress + Length);
-}
-
-/**
   This function retrieves the attributes of the memory region specified by
   BaseAddress and Length. If different attributes are obtained from different
   parts of the memory region, EFI_NO_MAPPING will be returned.
@@ -90,10 +54,6 @@ GetMemoryAttributes (
       Length
       ));
     return EFI_INVALID_PARAMETER;
-  }
-
-  if (!RegionIsSystemMemory (BaseAddress, Length)) {
-    return EFI_UNSUPPORTED;
   }
 
   DEBUG ((
@@ -212,10 +172,6 @@ SetMemoryAttributes (
     return EFI_INVALID_PARAMETER;
   }
 
-  if (!RegionIsSystemMemory (BaseAddress, Length)) {
-    return EFI_UNSUPPORTED;
-  }
-
   return ArmSetMemoryAttributes (BaseAddress, Length, Attributes, Attributes);
 }
 
@@ -278,10 +234,6 @@ ClearMemoryAttributes (
       Attributes
       ));
     return EFI_INVALID_PARAMETER;
-  }
-
-  if (!RegionIsSystemMemory (BaseAddress, Length)) {
-    return EFI_UNSUPPORTED;
   }
 
   return ArmSetMemoryAttributes (BaseAddress, Length, 0, Attributes);


### PR DESCRIPTION
# Description

The UEFI spec does not restrict the Memory Attribute Protocol to only operating on GCD SystemMemory, however Arm's CpuDxe was enforcing this. There are valid Get/Set operations on other types of memory, such as MMIO.

In addition, this check can cause a lock issue after the CPU architecture protocol is installed due to the GCD lock being held during GCD synchronization and a call being made to get memory attributes using the memory attribute protocol, when the memory attribute protocol is attempted to be used more widely.

This patch removes the RegionIsSystemMemory check from Arm's CpuDxe's memory attribute protocol, which puts it in line with the UEFI spec and the proposed x86 memory attribute protocol implementation.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [x] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Running on Project Mu platforms.

## Integration Instructions

N/A.
