### PR TITLE
.pytool/EccCheck: Trim leading path to modified directory

### DIFF
--- a/.pytool/Plugin/EccCheck/EccCheck.py
+++ b/.pytool/Plugin/EccCheck/EccCheck.py
@@ -182,6 +182,11 @@ class EccCheck(ICiBuildPlugin):
             #
             file_dir = os.path.dirname(file_path[-1])
             #
+            # strip the prefix path till the package name
+            #
+            if pkg in file_dir:
+                file_dir = file_dir[file_dir.find(pkg):]
+            #
             # Skip directory names that do not start with the package being scanned.
             #
             if file_dir.split('/')[0] != pkg:


### PR DESCRIPTION
The code changes in the patch is for trimming the leading path to the modified directory in the .pytool/EccCheck script. This is necessary when running Ecc on other repositories, such as edk2-platforms, where the platform package is located in a subfolder, like Platform/AMD/AmdPlatformPkg.

The EccCheck script checks for modified directories and expects them to start with the package name.
        #
        # Skip directory names that do not start with the package being scanned.
        #
        if file_dir.split('/')[0] != pkg:
                continue

However, if the package name is in a subfolder,
the "git diff" command gives a relative path,
like Platform/AMD, which causes the condition to be false.
"M       Platform/AMD/AmdPlatformPkg/Universal/LogoDxe/Logo.c"
As a result, EccCheck does not happen on modified files.

To fix this issue, the leading path needs to be trimmed so that it starts from the directory name.
This change will not affect the existing check for the edk2 repository, where all package names are at the first level directory.

Cc: Sean Brogan <sean.brogan@microsoft.com>
Cc: Joey Vagedes <joey.vagedes@gmail.com>
Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>

# Description

Trim the leading path of the modified directory list from "git diff" output.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested
Tested with the stuart build from edk2 and edk2-platform repo.

## Integration Instructions

N/A
