### PR TITLE
SecurityPkg: Fix break missing at TPM_ALG_KEYEDHASH case

### DIFF
--- a/SecurityPkg/Library/Tpm2CommandLib/Tpm2Object.c
+++ b/SecurityPkg/Library/Tpm2CommandLib/Tpm2Object.c
@@ -178,6 +178,7 @@ Tpm2ReadPublic (
           return EFI_UNSUPPORTED;
       }
 
+      break;
     case TPM_ALG_SYMCIPHER:
       OutPublic->publicArea.parameters.symDetail.algorithm = SwapBytes16 (ReadUnaligned16 ((UINT16 *)Buffer));
       Buffer                                              += sizeof (UINT16);


### PR DESCRIPTION
According issue #5509, case TPM_ALG_KEYEDHASH is missing the break statement.

# Description
- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

N/A

## Integration Instructions

N/A