### PR TITLE
OvmfPkg/ResetVector: Move condition end outside of SearchBfv

### DIFF
--- a/OvmfPkg/ResetVector/Main.asm
+++ b/OvmfPkg/ResetVector/Main.asm
@@ -50,9 +50,10 @@ BITS    32
 Main32:
     OneTimeCall InitTdx
 
+%endif
+
 SearchBfv:
 
-%endif
 
     ;
     ; Search for the Boot Firmware Volume (BFV)


### PR DESCRIPTION
The %endif for %ifdef ARCH64 was originally inside SearchBvf, which makes the code harder to read and obscures the necessity of having it within SearchBvf. To improve code readability, move the condition end outside of SearchBvf.