### PR TITLE
Acpiview update 6 5 ras2

### DIFF
--- a/MdePkg/Include/IndustryStandard/Acpi65.h
+++ b/MdePkg/Include/IndustryStandard/Acpi65.h
@@ -1057,6 +1057,26 @@ typedef struct {
 #define EFI_ACPI_6_5_RASF_PATROL_SCRUB_COMMAND_STOP_PATROL_SCRUBBER   0x03
 
 ///
+/// ACPI RAS2 PCC Descriptor
+///
+typedef struct {
+  UINT8     PccId;
+  UINT8     Reserved[2];
+  UINT8     RasFeatureType;
+  UINT32    Instance;
+} EFI_ACPI_RAS2_PCC_DESCRIPTOR;
+
+///
+/// ACPI RAS2 Feature Table definition.
+///
+typedef struct {
+  EFI_ACPI_DESCRIPTION_HEADER    Header;
+  UINT16                         Reserved;
+  UINT16                         PccCount;
+  // EFI_ACPI_RAS2_PCC_DESCRIPTOR Descriptors[PccCount];
+} EFI_ACPI_6_5_RAS2_FEATURE_TABLE;
+
+///
 /// Memory Power State Table definition.
 ///
 typedef struct {
@@ -3120,6 +3140,11 @@ typedef struct {
 /// "PSDT" Persistent System Description Table
 ///
 #define EFI_ACPI_6_5_PERSISTENT_SYSTEM_DESCRIPTION_TABLE_SIGNATURE  SIGNATURE_32('P', 'S', 'D', 'T')
+
+///
+/// "RAS2" ACPI RAS2 Feature Table
+///
+#define EFI_ACPI_6_5_ACPI_RAS2_FEATURE_TABLE_SIGNATURE  SIGNATURE_32('R', 'A', 'S', '2')
 
 ///
 /// "RASF" ACPI RAS Feature Table

--- a/ShellPkg/Library/UefiShellAcpiViewCommandLib/AcpiParser.h
+++ b/ShellPkg/Library/UefiShellAcpiViewCommandLib/AcpiParser.h
@@ -1007,6 +1007,29 @@ ParseAcpiPptt (
   );
 
 /**
+  This function parses the ACPI RAS2 table.
+  When trace is enabled this function parses the RAS2 table and
+  traces the ACPI table fields.
+
+  This function parses the RAS2 ACPI table along with PCC Entries
+
+  This function also performs validation of the ACPI table fields.
+
+  @param [in] Trace              If TRUE, trace the ACPI fields.
+  @param [in] Ptr                Pointer to the start of the buffer.
+  @param [in] AcpiTableLength    Length of the ACPI table.
+  @param [in] AcpiTableRevision  Revision of the ACPI table.
+**/
+VOID
+EFIAPI
+ParseAcpiRas2 (
+  IN BOOLEAN  Trace,
+  IN UINT8    *Ptr,
+  IN UINT32   AcpiTableLength,
+  IN UINT8    AcpiTableRevision
+  );
+
+/**
   This function parses the ACPI RSDP table.
 
   This function invokes the parser for the XSDT table.

--- a/ShellPkg/Library/UefiShellAcpiViewCommandLib/Parsers/Ras2/Ras2Parser.c
+++ b/ShellPkg/Library/UefiShellAcpiViewCommandLib/Parsers/Ras2/Ras2Parser.c
@@ -1,0 +1,118 @@
+/** @file
+  RAS2 table parser
+
+  Copyright (c) 2024, Arm Limited. All rights reserved.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+  @par Reference(s):
+    - ACPI 6.5 Specification - August 2022
+**/
+
+#include <Library/PrintLib.h>
+#include <Library/BaseLib.h>
+#include <Library/UefiLib.h>
+#include "AcpiParser.h"
+#include "AcpiView.h"
+
+// Maximum Memory Domain matrix print size.
+#define MAX_MEMORY_DOMAIN_TARGET_PRINT_MATRIX  10
+
+// Local variables
+STATIC CONST UINT16  *Ras2PccDescriptors;
+
+STATIC ACPI_DESCRIPTION_HEADER_INFO  AcpiHdrInfo;
+
+/**
+  An ACPI_PARSER array describing the ACPI RAS2 Table.
+*/
+STATIC CONST ACPI_PARSER  Ras2Parser[] = {
+  PARSE_ACPI_HEADER (&AcpiHdrInfo),
+  { L"Reserved",                   2,  36, L"0x%x", NULL, NULL,                         NULL, NULL },
+  { L"PCC Descriptors",            2,  38, L"%d",   NULL, (VOID **)&Ras2PccDescriptors, NULL, NULL }
+};
+
+/**
+  An ACPI_PARSER array describing the RAS2 PCC ID Entry
+*/
+STATIC CONST ACPI_PARSER  Ras2StructurePccDescriptor[] = {
+  { L"PCC ID",       1, 0, L"0x%x", NULL, NULL, NULL, NULL },
+  { L"Reserved",     1, 1, L"0x%x", NULL, NULL, NULL, NULL },
+  { L"Reserved",     1, 2, L"0x%x", NULL, NULL, NULL, NULL },
+  { L"Feature Type", 1, 3, L"0x%x", NULL, NULL, NULL, NULL },
+  { L"Instance",     4, 4, L"0x%x", NULL, NULL, NULL, NULL }
+};
+
+STATIC
+VOID
+DumpPccEntry (
+  IN UINT8   *Ptr,
+  IN UINT32  Length
+  )
+{
+  ParseAcpi (
+    TRUE,
+    2,
+    "PCC Descriptor Entry",
+    Ptr,
+    Length,
+    PARSER_PARAMS (Ras2StructurePccDescriptor)
+    );
+}
+
+/**
+  This function parses the ACPI RAS2 table.
+  When trace is enabled this function parses the RAS2 table and
+  traces the ACPI table fields.
+
+  This function parses the following RAS2 structures:
+    - Pcc Instries
+    - Entry Pcc ID
+    - Entry Feature Type
+    - Entry Pcc Instance
+
+  This function also performs validation of the ACPI table fields.
+
+  @param [in] Trace              If TRUE, trace the ACPI fields.
+  @param [in] Ptr                Pointer to the start of the buffer.
+  @param [in] AcpiTableLength    Length of the ACPI table.
+  @param [in] AcpiTableRevision  Revision of the ACPI table.
+**/
+VOID
+EFIAPI
+ParseAcpiRas2 (
+  IN BOOLEAN  Trace,
+  IN UINT8    *Ptr,
+  IN UINT32   AcpiTableLength,
+  IN UINT8    AcpiTableRevision
+  )
+{
+  UINT32  Offset;
+
+  if (!Trace) {
+    return;
+  }
+
+  // Parse ACPI Header + RAS2 "fixed" fields
+  Offset = ParseAcpi (
+             Trace,
+             0,
+             "RAS2",
+             Ptr,
+             AcpiTableLength,
+             PARSER_PARAMS (Ras2Parser)
+             );
+
+  // Table is too small to contain data
+  if (Offset >= AcpiTableLength) {
+    return;
+  }
+
+  // Loop over rest of table for PCC Entries and dump them
+  while (Offset <= (AcpiTableLength - sizeof (EFI_ACPI_RAS2_PCC_DESCRIPTOR))) {
+    DumpPccEntry (
+      Ptr + Offset,
+      sizeof (EFI_ACPI_RAS2_PCC_DESCRIPTOR)
+      );
+    Offset += sizeof (EFI_ACPI_RAS2_PCC_DESCRIPTOR);
+  } // while
+}

--- a/ShellPkg/Library/UefiShellAcpiViewCommandLib/UefiShellAcpiViewCommandLib.c
+++ b/ShellPkg/Library/UefiShellAcpiViewCommandLib/UefiShellAcpiViewCommandLib.c
@@ -71,6 +71,7 @@ ACPI_TABLE_PARSER  ParserList[] = {
     ParseAcpiPcct },
   { EFI_ACPI_6_4_PROCESSOR_PROPERTIES_TOPOLOGY_TABLE_STRUCTURE_SIGNATURE,
     ParseAcpiPptt },
+  { EFI_ACPI_6_5_ACPI_RAS2_FEATURE_TABLE_SIGNATURE,                                                      ParseAcpiRas2 },
   { RSDP_TABLE_INFO,                                                                                     ParseAcpiRsdp },
   { EFI_ACPI_6_2_SYSTEM_LOCALITY_INFORMATION_TABLE_SIGNATURE,                                            ParseAcpiSlit },
   { EFI_ACPI_6_2_SERIAL_PORT_CONSOLE_REDIRECTION_TABLE_SIGNATURE,                                        ParseAcpiSpcr },

--- a/ShellPkg/Library/UefiShellAcpiViewCommandLib/UefiShellAcpiViewCommandLib.inf
+++ b/ShellPkg/Library/UefiShellAcpiViewCommandLib/UefiShellAcpiViewCommandLib.inf
@@ -50,6 +50,7 @@
   Parsers/Pcct/PcctParser.h
   Parsers/Pptt/PpttParser.c
   Parsers/Pptt/PpttParser.h
+  Parsers/Ras2/Ras2Parser.c
   Parsers/Rsdp/RsdpParser.c
   Parsers/Slit/SlitParser.c
   Parsers/Spcr/SpcrParser.c


### PR DESCRIPTION
# Description

Adding RAS2 support in ACPI 6.5 and appropriate acpiview parsing

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

Sample platform was created with RAS2 ACPI Table with various ranges of PCC Entries and acpiview was used to verify it parses (based on ACPI 6.5 specifications).

## Integration Instructions

N/A