### PR TITLE
NetworkPkg/DxeNetLib: Update misleading comment

### DIFF
--- a/NetworkPkg/Library/DxeNetLib/DxeNetLib.c
+++ b/NetworkPkg/Library/DxeNetLib/DxeNetLib.c
@@ -133,10 +133,16 @@ GLOBAL_REMOVE_IF_UNREFERENCED VLAN_DEVICE_PATH  mNetVlanDevicePathTemplate = {
 // These represent UEFI SPEC defined algorithms that should be supported by
 // the RNG protocol and are generally considered secure.
 //
-// The order of the algorithms in this array is important. This order is the order
-// in which the algorithms will be tried by the RNG protocol.
-// If your platform needs to use a specific algorithm for the random number generator,
-// then you should place that algorithm first in the array.
+// Assuming that PcdEnforceSecureRngAlgorithms is TRUE (the default) then
+// only the algorithms defined here will be used by the network stack, and
+// none of these being available will result in an error condition (even if
+// some other RNG implementation is available).
+//
+// If PcdEnforceSecureRngAlgorithms is FALSE this list is not consulted,
+// and the first available RNG algorithm is used.
+//
+// If your platform needs to use a specific algorithm for the random number
+// generator, then you should modify this array.
 //
 GLOBAL_REMOVE_IF_UNREFERENCED EFI_GUID  *mSecureHashAlgorithms[] = {
   &gEfiRngAlgorithmSp80090Ctr256Guid,  // SP800-90A DRBG CTR using AES-256


### PR DESCRIPTION
# Description

Commit 6862b9d538d96363635677198899e1669e591259 makes more explicit the previous logic of [the code](https://github.com/tianocore/edk2/commit/4c4ceb2ceb80c42fd5545b2a4bd80321f07f4345) which uses `mSecureHashAlgorithms`, which is that it is (and was) only a fatal error if all secure algorithms fail.

However the comment updated by this commit seems somewhat incompatible with that recent change, and even with the previous code (which operated as now, just logging different error messages).

This updates the comment to be more compatible with how the code operates.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

cc @kraxel @Flickdm 

## How This Was Tested

N/A (comment change only)

## Integration Instructions

N/A