### PR TITLE
MdePkg/IpmiNetFnGroupExtension.h: Enforce structure alignment

### DIFF
--- a/MdePkg/Include/IndustryStandard/IpmiNetFnGroupExtension.h
+++ b/MdePkg/Include/IndustryStandard/IpmiNetFnGroupExtension.h
@@ -4,6 +4,12 @@
   Copyright (c) 1999 - 2015, Intel Corporation. All rights reserved.<BR>
   Copyright (c) 2024, Ampere Computing LLC. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
+
+  @par Revision Reference:
+    - Arm Server Base Manageability Requirements (SBMR) Specification
+      Revision 2.0d, Section F
+      https://developer.arm.com/documentation/den0069
+
 **/
 
 #ifndef _IPMI_NET_FN_GROUP_EXTENSION_H_
@@ -27,6 +33,7 @@
 /// https://developer.arm.com/documentation/den0069
 ///
 
+#pragma pack(1)
 //
 // Definitions for send progress code command
 //
@@ -85,5 +92,6 @@ typedef struct {
   UINT8                                             DefiningBody;
   IPMI_GROUP_EXTENSION_BOOT_PROGRESS_CODE_FORMAT    BootProgressCode;
 } IPMI_GROUP_EXTENSION_BOOT_PROGRESS_CODE_GET_RESPONSE;
+#pragma pack()
 
 #endif


### PR DESCRIPTION


# Description

The natural aligmenent seems to be failed on some cases. So, this patch intends to add the pack(1) to ensure the structure aligned with a one-byte boundary.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

## Integration Instructions

