### PR TITLE
MdeModulePkg/VariableRuntimeDxe: Fix VariablePolicyProtocol PRODUCES

### DIFF
--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableRuntimeDxe.inf
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableRuntimeDxe.inf
@@ -84,7 +84,7 @@
   gEfiVariableWriteArchProtocolGuid             ## PRODUCES
   gEfiVariableArchProtocolGuid                  ## PRODUCES
   gEdkiiVariableLockProtocolGuid                ## PRODUCES
-  gEdkiiVariablePolicyProtocolGuid              ## CONSUMES
+  gEdkiiVariablePolicyProtocolGuid              ## PRODUCES
   gEdkiiVarCheckProtocolGuid                    ## PRODUCES
 
 [Guids]


### PR DESCRIPTION
# Description

This was spotted while trying to confirm whether `VariablePolicyDynamicCommand` makes sense to include in all Ovmf modules which can potentially use the `OvmfPkg/Include/*/Shell*.inc` files, for https://github.com/tianocore/edk2/pull/6092#issuecomment-2306961900. (I believe it does.)

If we search the codebase for `&gEdkiiVariablePolicyProtocolGuid` we can find two drivers which install this policy: [`VariableRuntimeDxe`](https://github.com/tianocore/edk2/blob/master/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableRuntimeDxe.inf) (installed in [`VariableDxe.c`](https://github.com/tianocore/edk2/blob/master/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableDxe.c)) and [`VariableSmmRuntimeDxe`](https://github.com/tianocore/edk2/blob/master/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxe.inf) (installed in [`VariablePolicySmmDxe.c`](https://github.com/tianocore/edk2/blob/master/MdeModulePkg/Universal/Variable/RuntimeDxe/VariablePolicySmmDxe.c)).

The `.inf` file for `VariableRuntimeDxe` incorrectly lists the protocol as `CONSUMES` in the comment, so change this to `PRODUCES`.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

N/A (comment fix)

## Integration Instructions

N/A
