### PR TITLE
ArmPkg/Smbios: Change uni values to "Not Set"

### DIFF
--- a/ArmPkg/Universal/Smbios/ProcessorSubClassDxe/ProcessorSubClassStrings.uni
+++ b/ArmPkg/Universal/Smbios/ProcessorSubClassDxe/ProcessorSubClassStrings.uni
@@ -15,10 +15,10 @@
 //
 // Processor Information
 //
-#string STR_PROCESSOR_SOCKET_DESIGNATION    #language en-US  "Not Specified"
-#string STR_PROCESSOR_MANUFACTURE           #language en-US  "Not Specified"
-#string STR_PROCESSOR_VERSION               #language en-US  "Not Specified"
-#string STR_PROCESSOR_SERIAL_NUMBER         #language en-US  "Not Specified"
-#string STR_PROCESSOR_ASSET_TAG             #language en-US  "Not Specified"
-#string STR_PROCESSOR_PART_NUMBER           #language en-US  "Not Specified"
+#string STR_PROCESSOR_SOCKET_DESIGNATION    #language en-US  "Not Set"
+#string STR_PROCESSOR_MANUFACTURE           #language en-US  "Not Set"
+#string STR_PROCESSOR_VERSION               #language en-US  "Not Set"
+#string STR_PROCESSOR_SERIAL_NUMBER         #language en-US  "Not Set"
+#string STR_PROCESSOR_ASSET_TAG             #language en-US  "Not Set"
+#string STR_PROCESSOR_PART_NUMBER           #language en-US  "Not Set"
 #string STR_PROCESSOR_UNKNOWN               #language en-US  "Unknown"

--- a/ArmPkg/Universal/Smbios/SmbiosMiscDxe/Type00/MiscBiosVendor.uni
+++ b/ArmPkg/Universal/Smbios/SmbiosMiscDxe/Type00/MiscBiosVendor.uni
@@ -11,8 +11,8 @@
 
 /=#
 
-#string STR_MISC_BIOS_VENDOR           #language en-US  "Not Specified"
-#string STR_MISC_BIOS_VERSION          #language en-US  "Not Specified"
-#string STR_MISC_BIOS_RELEASE_DATE     #language en-US  "Not Specified"
-#string STR_MISC_BIOS_VENDOR           #language en-US  "Not Specified"
+#string STR_MISC_BIOS_VENDOR           #language en-US  "Not Set"
+#string STR_MISC_BIOS_VERSION          #language en-US  "Not Set"
+#string STR_MISC_BIOS_RELEASE_DATE     #language en-US  "Not Set"
+#string STR_MISC_BIOS_VENDOR           #language en-US  "Not Set"
 #string STR_MISC_BIOS_RELEASE_DATE     #language en-US  "12/02/2020"

--- a/ArmPkg/Universal/Smbios/SmbiosMiscDxe/Type01/MiscSystemManufacturer.uni
+++ b/ArmPkg/Universal/Smbios/SmbiosMiscDxe/Type01/MiscSystemManufacturer.uni
@@ -11,9 +11,9 @@
 
 /=#
 
-#string STR_MISC_SYSTEM_MANUFACTURER   #language en-US  "Not Specified"
-#string STR_MISC_SYSTEM_PRODUCT_NAME   #language en-US  "Not Specified"
-#string STR_MISC_SYSTEM_VERSION        #language en-US  "Not Specified"
-#string STR_MISC_SYSTEM_SERIAL_NUMBER  #language en-US  "Not Specified"
-#string STR_MISC_SYSTEM_SKU_NUMBER     #language en-US  "Not Specified"
-#string STR_MISC_SYSTEM_FAMILY         #language en-US  "Not Specified"
+#string STR_MISC_SYSTEM_MANUFACTURER   #language en-US  "Not Set"
+#string STR_MISC_SYSTEM_PRODUCT_NAME   #language en-US  "Not Set"
+#string STR_MISC_SYSTEM_VERSION        #language en-US  "Not Set"
+#string STR_MISC_SYSTEM_SERIAL_NUMBER  #language en-US  "Not Set"
+#string STR_MISC_SYSTEM_SKU_NUMBER     #language en-US  "Not Set"
+#string STR_MISC_SYSTEM_FAMILY         #language en-US  "Not Set"

--- a/ArmPkg/Universal/Smbios/SmbiosMiscDxe/Type02/MiscBaseBoardManufacturer.uni
+++ b/ArmPkg/Universal/Smbios/SmbiosMiscDxe/Type02/MiscBaseBoardManufacturer.uni
@@ -11,10 +11,10 @@
 
 /=#
 
-#string STR_MISC_BASE_BOARD_MANUFACTURER     #language en-US  "Not Specified"
-#string STR_MISC_BASE_BOARD_PRODUCT_NAME     #language en-US  "Not Specified"
-#string STR_MISC_BASE_BOARD_VERSION          #language en-US  "Not Specified"
-#string STR_MISC_BASE_BOARD_SERIAL_NUMBER    #language en-US  "Not Specified"
-#string STR_MISC_BASE_BOARD_ASSET_TAG        #language en-US  "Not Specified"
-#string STR_MISC_BASE_BOARD_CHASSIS_LOCATION #language en-US  "Not Specified"
-#string STR_MISC_BASE_BOARD_SKU_NUMBER       #language en-US  "Not Specified"
+#string STR_MISC_BASE_BOARD_MANUFACTURER     #language en-US  "Not Set"
+#string STR_MISC_BASE_BOARD_PRODUCT_NAME     #language en-US  "Not Set"
+#string STR_MISC_BASE_BOARD_VERSION          #language en-US  "Not Set"
+#string STR_MISC_BASE_BOARD_SERIAL_NUMBER    #language en-US  "Not Set"
+#string STR_MISC_BASE_BOARD_ASSET_TAG        #language en-US  "Not Set"
+#string STR_MISC_BASE_BOARD_CHASSIS_LOCATION #language en-US  "Not Set"
+#string STR_MISC_BASE_BOARD_SKU_NUMBER       #language en-US  "Not Set"

--- a/ArmPkg/Universal/Smbios/SmbiosMiscDxe/Type03/MiscChassisManufacturer.uni
+++ b/ArmPkg/Universal/Smbios/SmbiosMiscDxe/Type03/MiscChassisManufacturer.uni
@@ -11,8 +11,8 @@
 
 /=#
 
-#string STR_MISC_CHASSIS_MANUFACTURER  #language en-US  "Not Specified"
-#string STR_MISC_CHASSIS_VERSION       #language en-US  "Not Specified"
-#string STR_MISC_CHASSIS_SERIAL_NUMBER #language en-US  "Not Specified"
-#string STR_MISC_CHASSIS_ASSET_TAG     #language en-US  "Not Specified"
-#string STR_MISC_CHASSIS_SKU_NUMBER    #language en-US  "Not Specified"
+#string STR_MISC_CHASSIS_MANUFACTURER  #language en-US  "Not Set"
+#string STR_MISC_CHASSIS_VERSION       #language en-US  "Not Set"
+#string STR_MISC_CHASSIS_SERIAL_NUMBER #language en-US  "Not Set"
+#string STR_MISC_CHASSIS_ASSET_TAG     #language en-US  "Not Set"
+#string STR_MISC_CHASSIS_SKU_NUMBER    #language en-US  "Not Set"


### PR DESCRIPTION
# Description

Current default value for DMI tables in uni files is "Not Specified". This causes an error when running FWTS tests. To avoid these errors, and align more accurately with the SMBIOS spec, this value should be changed to "Not Set".

This patch is originally posted at https://edk2.groups.io/g/devel/message/96133 (`ArmPkg/Smbios: Changing default uni values to ""`). I recall implementing a similar fix for Ampere platforms. This pull request incorporates the patch from @skaynor and alters the default uni values to "Not Set"

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested


## Integration Instructions

