### PR TITLE
Smmcpu platform hook Before MMI Handler 

### DIFF
--- a/OvmfPkg/Library/SmmCpuPlatformHookLibQemu/SmmCpuPlatformHookLibQemu.c
+++ b/OvmfPkg/Library/SmmCpuPlatformHookLibQemu/SmmCpuPlatformHookLibQemu.c
@@ -2,7 +2,7 @@
 SMM CPU Platform Hook library instance for QEMU.
 
 Copyright (c) 2020, Red Hat, Inc.
-Copyright (c) 2006 - 2015, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2006 - 2024, Intel Corporation. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -109,6 +109,24 @@ GetPlatformPageTableAttribute (
   IN OUT SMM_PAGE_SIZE_TYPE  *PageSize,
   IN OUT UINTN               *NumOfPages,
   IN OUT UINTN               *PageAttribute
+  )
+{
+  return EFI_UNSUPPORTED;
+}
+
+/**
+  SMM CPU Platform Hook before executing MMI Handler.
+
+  This function can be used to perform the platform specific items before executing MMI Handler.
+
+  @retval EFI_SUCCESS      The smm cpu platform hook before executing MMI Handler is executed successfully.
+  @retval EFI_UNSUPPORTED  The smm cpu platform hook before executing MMI Handler is unsupported.
+
+**/
+EFI_STATUS
+EFIAPI
+SmmCpuPlatformHookBeforeMmiHandler (
+  VOID
   )
 {
   return EFI_UNSUPPORTED;

--- a/UefiCpuPkg/Include/Library/SmmCpuPlatformHookLib.h
+++ b/UefiCpuPkg/Include/Library/SmmCpuPlatformHookLib.h
@@ -1,7 +1,7 @@
 /** @file
   Public include file for the SMM CPU Platform Hook Library.
 
-  Copyright (c) 2010 - 2015, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2010 - 2024, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -98,6 +98,21 @@ GetPlatformPageTableAttribute (
   OUT SMM_PAGE_SIZE_TYPE  *PageSize,
   OUT UINTN               *NumOfPages,
   OUT UINTN               *PageAttribute
+  );
+
+/**
+  SMM CPU Platform Hook before executing MMI Handler.
+
+  This function can be used to perform the platform specific items before executing MMI Handler.
+
+  @retval EFI_SUCCESS      The smm cpu platform hook before executing MMI Handler is executed successfully.
+  @retval EFI_UNSUPPORTED  The smm cpu platform hook before executing MMI Handler is unsupported.
+
+**/
+EFI_STATUS
+EFIAPI
+SmmCpuPlatformHookBeforeMmiHandler (
+  VOID
   );
 
 #endif

--- a/UefiCpuPkg/Library/SmmCpuPlatformHookLibNull/SmmCpuPlatformHookLibNull.c
+++ b/UefiCpuPkg/Library/SmmCpuPlatformHookLibNull/SmmCpuPlatformHookLibNull.c
@@ -1,7 +1,7 @@
 /** @file
 SMM CPU Platform Hook NULL library instance.
 
-Copyright (c) 2006 - 2015, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2006 - 2024, Intel Corporation. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -96,6 +96,24 @@ GetPlatformPageTableAttribute (
   IN OUT SMM_PAGE_SIZE_TYPE  *PageSize,
   IN OUT UINTN               *NumOfPages,
   IN OUT UINTN               *PageAttribute
+  )
+{
+  return EFI_UNSUPPORTED;
+}
+
+/**
+  SMM CPU Platform Hook before executing MMI Handler.
+
+  This function can be used to perform the platform specific items before executing MMI Handler.
+
+  @retval EFI_SUCCESS      The smm cpu platform hook before executing MMI Handler is executed successfully.
+  @retval EFI_UNSUPPORTED  The smm cpu platform hook before executing MMI Handler is unsupported.
+
+**/
+EFI_STATUS
+EFIAPI
+SmmCpuPlatformHookBeforeMmiHandler (
+  VOID
   )
 {
   return EFI_UNSUPPORTED;

--- a/UefiCpuPkg/PiSmmCpuDxeSmm/MpService.c
+++ b/UefiCpuPkg/PiSmmCpuDxeSmm/MpService.c
@@ -522,13 +522,13 @@ BSPHandler (
     //
     // Wait for all APs to get ready for programming MTRRs
     //
-    SmmCpuSyncWaitForAPs (mSmmMpSyncData->SyncContext, ApCount, CpuIndex);
+    SmmCpuSyncWaitForAPs (mSmmMpSyncData->SyncContext, ApCount, CpuIndex); /// #1: Wait APs
 
     if (SmmCpuFeaturesNeedConfigureMtrrs ()) {
       //
       // Signal all APs it's time for backup MTRRs
       //
-      ReleaseAllAPs ();
+      ReleaseAllAPs (); /// #2: Signal APs
 
       //
       // SmmCpuSyncWaitForAPs() may wait for ever if an AP happens to enter SMM at
@@ -543,12 +543,12 @@ BSPHandler (
       //
       // Wait for all APs to complete their MTRR saving
       //
-      SmmCpuSyncWaitForAPs (mSmmMpSyncData->SyncContext, ApCount, CpuIndex);
+      SmmCpuSyncWaitForAPs (mSmmMpSyncData->SyncContext, ApCount, CpuIndex); /// #3: Wait APs
 
       //
       // Let all processors program SMM MTRRs together
       //
-      ReleaseAllAPs ();
+      ReleaseAllAPs (); /// #4: Signal APs
 
       //
       // SmmCpuSyncWaitForAPs() may wait for ever if an AP happens to enter SMM at
@@ -560,7 +560,7 @@ BSPHandler (
       //
       // Wait for all APs to complete their MTRR programming
       //
-      SmmCpuSyncWaitForAPs (mSmmMpSyncData->SyncContext, ApCount, CpuIndex);
+      SmmCpuSyncWaitForAPs (mSmmMpSyncData->SyncContext, ApCount, CpuIndex); /// #5: Wait APs
     }
   }
 
@@ -625,18 +625,18 @@ BSPHandler (
   // Notify all APs to exit
   //
   *mSmmMpSyncData->InsideSmm = FALSE;
-  ReleaseAllAPs ();
+  ReleaseAllAPs (); /// #6: Signal APs
 
   if (SmmCpuFeaturesNeedConfigureMtrrs ()) {
     //
     // Wait for all APs the readiness to program MTRRs
     //
-    SmmCpuSyncWaitForAPs (mSmmMpSyncData->SyncContext, ApCount, CpuIndex);
+    SmmCpuSyncWaitForAPs (mSmmMpSyncData->SyncContext, ApCount, CpuIndex); /// #7: Wait APs
 
     //
     // Signal APs to restore MTRRs
     //
-    ReleaseAllAPs ();
+    ReleaseAllAPs (); /// #8: Signal APs
 
     //
     // Restore OS MTRRs
@@ -649,12 +649,12 @@ BSPHandler (
     //
     // Wait for all APs to complete their pending tasks including MTRR programming if needed.
     //
-    SmmCpuSyncWaitForAPs (mSmmMpSyncData->SyncContext, ApCount, CpuIndex);
+    SmmCpuSyncWaitForAPs (mSmmMpSyncData->SyncContext, ApCount, CpuIndex); /// #9: Wait APs
 
     //
     // Signal APs to Reset states/semaphore for this processor
     //
-    ReleaseAllAPs ();
+    ReleaseAllAPs (); /// #10: Signal APs
   }
 
   if (mSmmDebugAgentSupport) {
@@ -679,7 +679,7 @@ BSPHandler (
   // Gather APs to exit SMM synchronously. Note the Present flag is cleared by now but
   // WaitForAllAps does not depend on the Present flag.
   //
-  SmmCpuSyncWaitForAPs (mSmmMpSyncData->SyncContext, ApCount, CpuIndex);
+  SmmCpuSyncWaitForAPs (mSmmMpSyncData->SyncContext, ApCount, CpuIndex); /// #11: Wait APs
 
   //
   // At this point, all APs should have exited from APHandler().
@@ -805,14 +805,14 @@ APHandler (
     //
     // Notify BSP of arrival at this point
     //
-    SmmCpuSyncReleaseBsp (mSmmMpSyncData->SyncContext, CpuIndex, BspIndex);
+    SmmCpuSyncReleaseBsp (mSmmMpSyncData->SyncContext, CpuIndex, BspIndex); /// #1: Signal BSP
   }
 
   if (SmmCpuFeaturesNeedConfigureMtrrs ()) {
     //
     // Wait for the signal from BSP to backup MTRRs
     //
-    SmmCpuSyncWaitForBsp (mSmmMpSyncData->SyncContext, CpuIndex, BspIndex);
+    SmmCpuSyncWaitForBsp (mSmmMpSyncData->SyncContext, CpuIndex, BspIndex); /// #2: Wait BSP
 
     //
     // Backup OS MTRRs
@@ -822,12 +822,12 @@ APHandler (
     //
     // Signal BSP the completion of this AP
     //
-    SmmCpuSyncReleaseBsp (mSmmMpSyncData->SyncContext, CpuIndex, BspIndex);
+    SmmCpuSyncReleaseBsp (mSmmMpSyncData->SyncContext, CpuIndex, BspIndex); /// #3: Signal BSP
 
     //
     // Wait for BSP's signal to program MTRRs
     //
-    SmmCpuSyncWaitForBsp (mSmmMpSyncData->SyncContext, CpuIndex, BspIndex);
+    SmmCpuSyncWaitForBsp (mSmmMpSyncData->SyncContext, CpuIndex, BspIndex); /// #4: Wait BSP
 
     //
     // Replace OS MTRRs with SMI MTRRs
@@ -837,14 +837,14 @@ APHandler (
     //
     // Signal BSP the completion of this AP
     //
-    SmmCpuSyncReleaseBsp (mSmmMpSyncData->SyncContext, CpuIndex, BspIndex);
+    SmmCpuSyncReleaseBsp (mSmmMpSyncData->SyncContext, CpuIndex, BspIndex); /// #5: Signal BSP
   }
 
   while (TRUE) {
     //
     // Wait for something to happen
     //
-    SmmCpuSyncWaitForBsp (mSmmMpSyncData->SyncContext, CpuIndex, BspIndex);
+    SmmCpuSyncWaitForBsp (mSmmMpSyncData->SyncContext, CpuIndex, BspIndex); /// #6: Wait BSP
 
     //
     // Check if BSP wants to exit SMM
@@ -884,12 +884,12 @@ APHandler (
     //
     // Notify BSP the readiness of this AP to program MTRRs
     //
-    SmmCpuSyncReleaseBsp (mSmmMpSyncData->SyncContext, CpuIndex, BspIndex);
+    SmmCpuSyncReleaseBsp (mSmmMpSyncData->SyncContext, CpuIndex, BspIndex); /// #7: Signal BSP
 
     //
     // Wait for the signal from BSP to program MTRRs
     //
-    SmmCpuSyncWaitForBsp (mSmmMpSyncData->SyncContext, CpuIndex, BspIndex);
+    SmmCpuSyncWaitForBsp (mSmmMpSyncData->SyncContext, CpuIndex, BspIndex); /// #8: Wait BSP
 
     //
     // Restore OS MTRRs
@@ -902,12 +902,12 @@ APHandler (
     //
     // Notify BSP the readiness of this AP to Reset states/semaphore for this processor
     //
-    SmmCpuSyncReleaseBsp (mSmmMpSyncData->SyncContext, CpuIndex, BspIndex);
+    SmmCpuSyncReleaseBsp (mSmmMpSyncData->SyncContext, CpuIndex, BspIndex); /// #9: Signal BSP
 
     //
     // Wait for the signal from BSP to Reset states/semaphore for this processor
     //
-    SmmCpuSyncWaitForBsp (mSmmMpSyncData->SyncContext, CpuIndex, BspIndex);
+    SmmCpuSyncWaitForBsp (mSmmMpSyncData->SyncContext, CpuIndex, BspIndex); /// #10: Wait BSP
   }
 
   //
@@ -918,7 +918,7 @@ APHandler (
   //
   // Notify BSP the readiness of this AP to exit SMM
   //
-  SmmCpuSyncReleaseBsp (mSmmMpSyncData->SyncContext, CpuIndex, BspIndex);
+  SmmCpuSyncReleaseBsp (mSmmMpSyncData->SyncContext, CpuIndex, BspIndex); /// #11: Signal BSP
 }
 
 /**


### PR DESCRIPTION
# Description

This patch is to add SmmCpuPlatformHookBeforeMmiHandler interface in SmmCpuPlatformHookLib.

The new API can be used to perform the platform specific items before MMI Handler. For example, Intel can leverage this API to clear the pending SMI bit after all CPUs finish the sync and before the MMI handlers. If so, the the redundant SMI can be avoided after CPU exit from current SMI.

## How This Was Tested

No function impact for open source.
