### PR TITLE
Add CI for VS2022

### DIFF
--- a/.azurepipelines/Windows-VS2022.yml
+++ b/.azurepipelines/Windows-VS2022.yml
@@ -18,7 +18,7 @@ variables:
 jobs:
 - template: templates/pr-gate-build-job.yml
   parameters:
-    tool_chain_tag: 'VS2019'
+    tool_chain_tag: 'VS2022'
     vm_image: 'windows-2019'
     arch_list: "IA32,X64"
     usePythonVersion: ${{ variables.default_python_version }}


### PR DESCRIPTION
The latest release of edk2 support VS2022, so I add Azure Pipeline CI for VS2022.
  