### PR TITLE
Cryptopkg drop sm3 and openssl from arm

### DIFF
--- a/CryptoPkg/Library/BaseCryptLibMbedTls/BaseCryptLib.inf
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/BaseCryptLib.inf
@@ -22,7 +22,7 @@
 #
 # The following information is for reference only and not required by the build tools.
 #
-#  VALID_ARCHITECTURES           = IA32 X64 ARM AARCH64
+#  VALID_ARCHITECTURES           = IA32 X64 ARM AARCH64 RISCV64 LOONGARCH64
 #
 
 [Sources]
@@ -32,7 +32,6 @@
   Hash/CryptSha256.c
   Hash/CryptSha512.c
   Hash/CryptParallelHashNull.c
-  Hash/CryptSm3.c
   Hmac/CryptHmac.c
   Kdf/CryptHkdf.c
   Cipher/CryptAes.c
@@ -57,9 +56,15 @@
   Rand/CryptRand.c
 
   SysCall/CrtWrapper.c
+  SysCall/TimerWrapper.c
+
+[Sources.IA32, Sources.X64, Sources.AARCH64, Sources.RISCV64, Sources.LOONGARCH64]
+  Hash/CryptSm3.c
   SysCall/DummyOpensslSupport.c
   SysCall/BaseMemAllocation.c
-  SysCall/TimerWrapper.c
+
+[Sources.ARM]
+  Hash/CryptSm3Null.c
 
 [Packages]
   MdePkg/MdePkg.dec
@@ -72,11 +77,14 @@
   UefiRuntimeServicesTableLib
   DebugLib
   MbedTlsLib
-  OpensslLib
   PrintLib
   IntrinsicLib
   RngLib
   SynchronizationLib
+
+[LibraryClasses.IA32, LibraryClasses.X64, LibraryClasses.AARCH64, LibraryClasses.RISCV64, LibraryClasses.LOONGARCH64]
+  OpensslLib
+
 [Protocols]
   gEfiMpServiceProtocolGuid
 #

--- a/CryptoPkg/Library/BaseCryptLibMbedTls/PeiCryptLib.inf
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/PeiCryptLib.inf
@@ -99,8 +99,7 @@
   #
   MSFT:*_*_*_CC_FLAGS = /wd4090 /wd4718
 
-  GCC:*_CLANG35_*_CC_FLAGS = -std=c99
-  GCC:*_CLANG38_*_CC_FLAGS = -std=c99
+  GCC:*_CLANGDWARF_*_CC_FLAGS = -std=gnu99
   GCC:*_CLANGPDB_*_CC_FLAGS = -std=c99 -Wno-error=incompatible-pointer-types
 
   XCODE:*_*_*_CC_FLAGS = -std=c99

--- a/CryptoPkg/Library/BaseCryptLibMbedTls/PeiCryptLib.inf
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/PeiCryptLib.inf
@@ -30,7 +30,7 @@
 #
 # The following information is for reference only and not required by the build tools.
 #
-#  VALID_ARCHITECTURES           = IA32 X64
+#  VALID_ARCHITECTURES           = IA32 X64 ARM AARCH64 RISCV64 LOONGARCH64
 #
 
 [Sources]
@@ -40,7 +40,6 @@
   Hash/CryptSha256.c
   Hash/CryptSha512.c
   Hash/CryptParallelHashNull.c
-  Hash/CryptSm3.c
   Hmac/CryptHmac.c
   Kdf/CryptHkdf.c
   Cipher/CryptAes.c
@@ -65,9 +64,12 @@
   Bn/CryptBnNull.c
 
   SysCall/CrtWrapper.c
+  SysCall/ConstantTimeClock.c
+
+[Sources.IA32, Sources.X64, Sources.AARCH64, Sources.RISCV64, Sources.LOONGARCH64]
+  Hash/CryptSm3.c
   SysCall/DummyOpensslSupport.c
   SysCall/BaseMemAllocation.c
-  SysCall/ConstantTimeClock.c
 
 [Packages]
   MdePkg/MdePkg.dec
@@ -79,12 +81,14 @@
   MemoryAllocationLib
   DebugLib
   MbedTlsLib
-  OpensslLib
   IntrinsicLib
   PrintLib
   PeiServicesTablePointerLib
   PeiServicesLib
   SynchronizationLib
+
+[LibraryClasses.IA32, LibraryClasses.X64, LibraryClasses.AARCH64, LibraryClasses.RISCV64, LibraryClasses.LOONGARCH64]
+  OpensslLib
 
 [Ppis]
   gEfiPeiMpServicesPpiGuid

--- a/CryptoPkg/Library/BaseCryptLibMbedTls/RuntimeCryptLib.inf
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/RuntimeCryptLib.inf
@@ -29,7 +29,7 @@
 #
 # The following information is for reference only and not required by the build tools.
 #
-#  VALID_ARCHITECTURES           = IA32 X64 ARM AARCH64
+#  VALID_ARCHITECTURES           = IA32 X64 ARM AARCH64 RISCV64 LOONGARCH64
 #
 
 [Sources]
@@ -39,7 +39,6 @@
   Hash/CryptSha256.c
   Hash/CryptSha512.c
   Hash/CryptParallelHashNull.c
-  Hash/CryptSm3.c
   Hmac/CryptHmac.c
   Kdf/CryptHkdf.c
   Cipher/CryptAes.c
@@ -65,8 +64,14 @@
 
   SysCall/CrtWrapper.c
   SysCall/TimerWrapper.c
-  SysCall/DummyOpensslSupport.c
   SysCall/RuntimeMemAllocation.c
+
+[Sources.IA32, Sources.X64, Sources.AARCH64, Sources.RISCV64, Sources.LOONGARCH64]
+  Hash/CryptSm3.c
+  SysCall/DummyOpensslSupport.c
+
+[Sources.ARM]
+  Hash/CryptSm3Null.c
 
 [Packages]
   MdePkg/MdePkg.dec
@@ -78,10 +83,12 @@
   UefiRuntimeServicesTableLib
   DebugLib
   MbedTlsLib
-  OpensslLib
   IntrinsicLib
   PrintLib
   RngLib
+
+[LibraryClasses.IA32, LibraryClasses.X64, LibraryClasses.AARCH64, LibraryClasses.RISCV64, LibraryClasses.LOONGARCH64]
+  OpensslLib
 
 #
 # Remove these [BuildOptions] after this library is cleaned up

--- a/CryptoPkg/Library/BaseCryptLibMbedTls/RuntimeCryptLib.inf
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/RuntimeCryptLib.inf
@@ -90,8 +90,7 @@
   #
   # suppress the following warnings so we do not break the build with warnings-as-errors:
   #
-  GCC:*_CLANG35_*_CC_FLAGS = -std=c99
-  GCC:*_CLANG38_*_CC_FLAGS = -std=c99
+  GCC:*_CLANGDWARF_*_CC_FLAGS = -std=gnu99
   GCC:*_CLANGPDB_*_CC_FLAGS = -std=c99 -Wno-error=incompatible-pointer-types
 
   XCODE:*_*_*_CC_FLAGS = -std=c99

--- a/CryptoPkg/Library/BaseCryptLibMbedTls/SecCryptLib.inf
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/SecCryptLib.inf
@@ -76,8 +76,7 @@
   #
   # suppress the following warnings so we do not break the build with warnings-as-errors:
   #
-  GCC:*_CLANG35_*_CC_FLAGS = -std=c99
-  GCC:*_CLANG38_*_CC_FLAGS = -std=c99
+  GCC:*_CLANGDWARF_*_CC_FLAGS = -std=gnu99
   GCC:*_CLANGPDB_*_CC_FLAGS = -std=c99 -Wno-error=incompatible-pointer-types
 
   XCODE:*_*_*_CC_FLAGS = -std=c99

--- a/CryptoPkg/Library/BaseCryptLibMbedTls/SmmCryptLib.inf
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/SmmCryptLib.inf
@@ -93,6 +93,5 @@
 
   XCODE:*_*_*_CC_FLAGS = -mmmx -msse -std=c99
 
-  GCC:*_CLANG35_*_CC_FLAGS = -std=c99
-  GCC:*_CLANG38_*_CC_FLAGS = -std=c99
+  GCC:*_CLANGDWARF_*_CC_FLAGS = -std=gnu99
   GCC:*_CLANGPDB_*_CC_FLAGS = -std=c99 -Wno-error=incompatible-pointer-types

--- a/CryptoPkg/Library/BaseCryptLibMbedTls/SmmCryptLib.inf
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/SmmCryptLib.inf
@@ -28,7 +28,7 @@
 #
 # The following information is for reference only and not required by the build tools.
 #
-#  VALID_ARCHITECTURES           = IA32 X64 ARM AARCH64
+#  VALID_ARCHITECTURES           = IA32 X64 ARM AARCH64 RISCV64 LOONGARCH64
 #
 
 [Sources]
@@ -38,7 +38,6 @@
   Hash/CryptSha256.c
   Hash/CryptSha512.c
   Hash/CryptParallelHashNull.c
-  Hash/CryptSm3.c
   Hmac/CryptHmac.c
   Kdf/CryptHkdf.c
   Cipher/CryptAes.c
@@ -63,9 +62,15 @@
   Rand/CryptRand.c
 
   SysCall/CrtWrapper.c
+  SysCall/ConstantTimeClock.c
+
+[Sources.IA32, Sources.X64, Sources.AARCH64, Sources.RISCV64, Sources.LOONGARCH64]
+  Hash/CryptSm3.c
   SysCall/DummyOpensslSupport.c
   SysCall/BaseMemAllocation.c
-  SysCall/ConstantTimeClock.c
+
+[Sources.ARM]
+  Hash/CryptSm3Null.c
 
 [Packages]
   MdePkg/MdePkg.dec
@@ -76,12 +81,14 @@
   BaseMemoryLib
   MemoryAllocationLib
   MbedTlsLib
-  OpensslLib
   IntrinsicLib
   PrintLib
   MmServicesTableLib
   RngLib
   SynchronizationLib
+
+[LibraryClasses.IA32, LibraryClasses.X64, LibraryClasses.AARCH64, LibraryClasses.RISCV64, LibraryClasses.LOONGARCH64]
+  OpensslLib
 
 #
 # Remove these [BuildOptions] after this library is cleaned up

--- a/CryptoPkg/Library/MbedTlsLib/MbedTlsLib.inf
+++ b/CryptoPkg/Library/MbedTlsLib/MbedTlsLib.inf
@@ -135,8 +135,7 @@
   GCC:*_*_AARCH64_CC_FLAGS =  -Wno-error=maybe-uninitialized -Wno-format -Wno-error=unused-but-set-variable -Wno-error=format
   GCC:*_*_RISCV64_CC_FLAGS =  -Wno-error=maybe-uninitialized -Wno-format -Wno-error=unused-but-set-variable
   GCC:*_*_LOONGARCH64_CC_FLAGS =  -Wno-error=maybe-uninitialized -Wno-format -Wno-error=unused-but-set-variable
-  GCC:*_CLANG35_*_CC_FLAGS = -std=c99 -Wno-error=uninitialized
-  GCC:*_CLANG38_*_CC_FLAGS = -std=c99 -Wno-error=uninitialized
+  GCC:*_CLANGDWARF_*_CC_FLAGS = -std=gnu99 -Wno-error=uninitialized
   GCC:*_CLANGPDB_*_CC_FLAGS = -std=c99 -Wno-error=uninitialized -Wno-error=incompatible-pointer-types -Wno-error=pointer-sign -Wno-error=implicit-function-declaration -Wno-error=ignored-pragma-optimize
 
   # suppress the following warnings in mbedtls so we don't break the build with warnings-as-errors:

--- a/CryptoPkg/Library/MbedTlsLib/MbedTlsLibFull.inf
+++ b/CryptoPkg/Library/MbedTlsLib/MbedTlsLibFull.inf
@@ -139,8 +139,7 @@
   GCC:*_*_AARCH64_CC_FLAGS =  -Wno-error=maybe-uninitialized -Wno-format -Wno-error=unused-but-set-variable -Wno-error=format
   GCC:*_*_RISCV64_CC_FLAGS =  -Wno-error=maybe-uninitialized -Wno-format -Wno-error=unused-but-set-variable
   GCC:*_*_LOONGARCH64_CC_FLAGS =  -Wno-error=maybe-uninitialized -Wno-format -Wno-error=unused-but-set-variable
-  GCC:*_CLANG35_*_CC_FLAGS = -std=c99 -Wno-error=uninitialized
-  GCC:*_CLANG38_*_CC_FLAGS = -std=c99 -Wno-error=uninitialized
+  GCC:*_CLANGDWARF_*_CC_FLAGS = -std=gnu99 -Wno-error=uninitialized
   GCC:*_CLANGPDB_*_CC_FLAGS = -std=c99 -Wno-error=uninitialized -Wno-error=incompatible-pointer-types -Wno-error=pointer-sign -Wno-error=implicit-function-declaration -Wno-error=ignored-pragma-optimize
 
   # suppress the following warnings in mbedtls so we don't break the build with warnings-as-errors:

--- a/CryptoPkg/Library/OpensslLib/OpensslLib.inf
+++ b/CryptoPkg/Library/OpensslLib/OpensslLib.inf
@@ -24,7 +24,7 @@
   DEFINE OPENSSL_FLAGS_NOASM     =
 
 #
-#  VALID_ARCHITECTURES           = IA32 X64 ARM AARCH64
+#  VALID_ARCHITECTURES           = IA32 X64 AARCH64
 #
 
 [Sources]
@@ -665,9 +665,6 @@
   BaseLib
   DebugLib
   RngLib
-
-[LibraryClasses.ARM]
-  ArmSoftFloatLib
 
 [BuildOptions]
   #

--- a/CryptoPkg/Library/OpensslLib/OpensslLibCrypto.inf
+++ b/CryptoPkg/Library/OpensslLib/OpensslLibCrypto.inf
@@ -25,7 +25,7 @@
   DEFINE OPENSSL_FLAGS_NOASM     =
 
 #
-#  VALID_ARCHITECTURES           = IA32 X64 ARM AARCH64
+#  VALID_ARCHITECTURES           = IA32 X64 AARCH64
 #
 
 [Sources]
@@ -621,9 +621,6 @@
   BaseLib
   DebugLib
   RngLib
-
-[LibraryClasses.ARM]
-  ArmSoftFloatLib
 
 [BuildOptions]
   #

--- a/CryptoPkg/Library/OpensslLib/OpensslLibFull.inf
+++ b/CryptoPkg/Library/OpensslLib/OpensslLibFull.inf
@@ -29,7 +29,7 @@
   DEFINE OPENSSL_FLAGS_NOASM     =
 
 #
-#  VALID_ARCHITECTURES           = IA32 X64 ARM AARCH64
+#  VALID_ARCHITECTURES           = IA32 X64 AARCH64
 #
 
 [Sources]
@@ -719,9 +719,6 @@
   BaseLib
   DebugLib
   RngLib
-
-[LibraryClasses.ARM]
-  ArmSoftFloatLib
 
 [BuildOptions]
   #


### PR DESCRIPTION
- Remove SM3 support from the 32-bit ARM build of MbedTlsLib, so it no longer depends on OpensslLib
- Remove 32-bit ARM support from OpensslLib so we no longer need ArmSoftFloatLib

Other explored solutions (#6165)
- Add SM3 implementation directly (rejected by @liyi)
- Pull in SM3 code from OpenSSL without relying on the entire OpensslLlib (rejected by @mdkinney)
- Contribute SM3 support to MbedTLS - existing effort stalled for 2 years, and outdated now; MbedTLS API itself has evolved and top-of-tree can no longer be used with EDK2's existing glue code.
