### PR TITLE
MdePkg: Add CUSTOM_STACK_CHECK_LIB Macro

### DIFF
--- a/MdePkg/MdeLibs.dsc.inc
+++ b/MdePkg/MdeLibs.dsc.inc
@@ -31,8 +31,15 @@
   #
   NULL|MdePkg/Library/CompilerIntrinsicsLib/CompilerIntrinsicsLib.inf
 
+#
 # Stack Cookies cannot be generically applied to SEC modules because they may not define _ModuleEntryPoint and when we
 # link a library in, we have to be able to define the entry point. SEC modules that do define _ModuleEntryPoint can
-# apply a library class override to get StackCheckLibNull.inf
+# apply a library class override to get StackCheckLibNull.inf.
+#
+# If CUSTOM_STACK_CHECK_LIB is set, MdeLibs.dsc.inc will not link StackCheckLibNull and it is expected that the
+# DSC being built is providing it's own implementation of StackCheckLib.
+#
 [LibraryClasses.common.PEI_CORE, LibraryClasses.common.PEIM, LibraryClasses.common.DXE_CORE, LibraryClasses.common.SMM_CORE, LibraryClasses.common.MM_CORE_STANDALONE, LibraryClasses.common.DXE_DRIVER, LibraryClasses.common.DXE_RUNTIME_DRIVER, LibraryClasses.common.DXE_SMM_DRIVER, LibraryClasses.common.MM_STANDALONE, LibraryClasses.common.UEFI_DRIVER, LibraryClasses.common.UEFI_APPLICATION]
+!ifndef CUSTOM_STACK_CHECK_LIB
   NULL|MdePkg/Library/StackCheckLibNull/StackCheckLibNull.inf
+!endif


### PR DESCRIPTION
# Description

Commit https://github.com/tianocore/edk2/commit/ac43bbacdef18a6fea6d978e096326ec0805885d
added StackCheckLibNull to MdeLibs.dsc.inc per review requests on the PR:
https://github.com/tianocore/edk2/pull/5957#issuecomment-2246925255
https://github.com/tianocore/edk2/pull/5957#discussion_r1694761065

The PR was adapted to move specifying StackCheckLibNull in every DSC
to MdeLibs.dsc.inc. However, while this works, it does not allow for
a platform to use one of the other StackCheckLibs (such as
StackCheckLibStaticInit) because we get a linker error by having the
compiler defined stack cookie variables defined more than once (once
from StackCheckLibNull in MdeLibs.dsc.inc and the other in the actual
StackCheckLib implementation). Every platform must include MdeLibs.dsc.inc
and there is no way to override a NULL library class.

In order to support a platform overriding StackCheckLibNull
provided by MdeLibs.dsc.inc, the CUSTOM_STACK_CHECK_LIB macro
is introduced. If this macro is defined, MdeLibs.dsc.inc will
not link StackCheckLibNull and it is expected that the platform
will link the version(s) of StackCheckLib that it requires.

The StackCheckLib README is also updated in this patch to
document the new macro and provide additional information.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

This has been tested that StackCheckLibStaticInit can be used in a package's CI instead of the null version now.

## Integration Instructions

If a platform would like to include a real version of the StackCheckLib, it should include:

```inf
[Defines]
  DEFINE CUSTOM_STACK_CHECK_LIB = TRUE

[LibraryClasses]
  NULL|MdePkg/Library/StackCheckLib/StackCheckLibStaticInit.inf # e.g., could be different instance
  StackCheckFailureHookLib|MdePkg/Library/StackCheckFailureHookLibNull/StackCheckFailureHookLibNull.inf
```

For the current details, see https://github.com/tianocore/edk2/blob/HEAD/MdePkg/Library/StackCheckLib/Readme.md.
