### PR TITLE
ArmPkg: Avoid building ArmCrashDumpDxe on ARM

### DIFF
--- a/ArmPkg/ArmPkg.dsc
+++ b/ArmPkg/ArmPkg.dsc
@@ -151,7 +151,6 @@
   ArmPkg/Library/PlatformBootManagerLib/PlatformBootManagerLib.inf
   ArmPkg/Library/LinuxBootBootManagerLib/LinuxBootBootManagerLib.inf
 
-  ArmPkg/Drivers/ArmCrashDumpDxe/ArmCrashDumpDxe.inf
   ArmPkg/Drivers/ArmScmiDxe/ArmScmiDxe.inf
 
   ArmPkg/Universal/Smbios/ProcessorSubClassDxe/ProcessorSubClassDxe.inf
@@ -161,6 +160,7 @@
   ArmPkg/Drivers/MmCommunicationPei/MmCommunicationPei.inf
 
 [Components.AARCH64]
+  ArmPkg/Drivers/ArmCrashDumpDxe/ArmCrashDumpDxe.inf
   ArmPkg/Drivers/ArmPsciMpServicesDxe/ArmPsciMpServicesDxe.inf
   ArmPkg/Drivers/MmCommunicationDxe/MmCommunication.inf
   ArmPkg/Library/ArmMmuLib/ArmMmuPeiLib.inf


### PR DESCRIPTION
For reasons that are unclear, the Linaro EDK2 CI is throwing errors when building ArmCrashDumpDxe with CLANGDWARF, as the resulting build contains non-adjacet MOVW/MOVT pairs, which cannot be relocated correctly in PE/COFF.

Let's build it only for AARCH64 - its utility on ARM is doubtful anyway.
