### PR TITLE
UefiCpuPkg: RISC-V: Initialize FPU

### DIFF
--- a/MdePkg/Include/Register/RiscV64/RiscVEncoding.h
+++ b/MdePkg/Include/Register/RiscV64/RiscVEncoding.h
@@ -20,6 +20,7 @@
 #define MSTATUS_SPP         (1UL << MSTATUS_SPP_SHIFT)
 #define MSTATUS_MPP_SHIFT   11
 #define MSTATUS_MPP         (3UL << MSTATUS_MPP_SHIFT)
+#define MSTATUS_FS          0x00006000UL
 
 #define SSTATUS_SIE         MSTATUS_SIE
 #define SSTATUS_SPIE_SHIFT  MSTATUS_SPIE_SHIFT
@@ -75,6 +76,9 @@
 /* User Counters/Timers */
 #define CSR_CYCLE  0xc00
 #define CSR_TIME   0xc01
+
+/* Floating-Point */
+#define CSR_FCSR  0x003
 
 /* Supervisor Trap Setup */
 #define CSR_SSTATUS  0x100

--- a/OvmfPkg/RiscVVirt/RiscVVirt.dsc.inc
+++ b/OvmfPkg/RiscVVirt/RiscVVirt.dsc.inc
@@ -78,6 +78,7 @@
   # RISC-V Architectural Libraries
   CpuExceptionHandlerLib|UefiCpuPkg/Library/BaseRiscV64CpuExceptionHandlerLib/BaseRiscV64CpuExceptionHandlerLib.inf
   RiscVSbiLib|MdePkg/Library/BaseRiscVSbiLib/BaseRiscVSbiLib.inf
+  RiscVFpuLib|UefiCpuPkg/Library/BaseRiscVFpuLib/BaseRiscVFpuLib.inf
   RiscVMmuLib|UefiCpuPkg/Library/BaseRiscVMmuLib/BaseRiscVMmuLib.inf
   PlatformBootManagerLib|OvmfPkg/RiscVVirt/Library/PlatformBootManagerLib/PlatformBootManagerLib.inf
   ResetSystemLib|OvmfPkg/RiscVVirt/Library/ResetSystemLib/BaseResetSystemLib.inf

--- a/UefiCpuPkg/CpuDxeRiscV64/CpuDxe.c
+++ b/UefiCpuPkg/CpuDxeRiscV64/CpuDxe.c
@@ -360,6 +360,12 @@ InitializeCpu (
   ASSERT_EFI_ERROR (Status);
 
   //
+  // Initialize FPU
+  //
+  Status = RiscVInitializeFpu ();
+  ASSERT_EFI_ERROR (Status);
+
+  //
   // Install Boot protocol
   //
   Status = gBS->InstallProtocolInterface (

--- a/UefiCpuPkg/CpuDxeRiscV64/CpuDxe.h
+++ b/UefiCpuPkg/CpuDxeRiscV64/CpuDxe.h
@@ -14,6 +14,7 @@
 
 #include <Protocol/Cpu.h>
 #include <Protocol/RiscVBootProtocol.h>
+#include <Library/BaseRiscVFpuLib.h>
 #include <Library/BaseRiscVSbiLib.h>
 #include <Library/BaseRiscVMmuLib.h>
 #include <Library/BaseLib.h>

--- a/UefiCpuPkg/CpuDxeRiscV64/CpuDxeRiscV64.inf
+++ b/UefiCpuPkg/CpuDxeRiscV64/CpuDxeRiscV64.inf
@@ -38,6 +38,7 @@
   PeCoffGetEntryPointLib
   RiscVSbiLib
   RiscVMmuLib
+  RiscVFpuLib
   CacheMaintenanceLib
 
 [Sources]

--- a/UefiCpuPkg/Include/Library/BaseRiscVFpuLib.h
+++ b/UefiCpuPkg/Include/Library/BaseRiscVFpuLib.h
@@ -1,0 +1,21 @@
+/** @file
+
+  Copyright (c) 2024, Canonical Services Ltd<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef BASE_RISCV_FPU_LIB_H_
+#define BASE_RISCV_FPU_LIB_H_
+
+/**
+  Initialize floating point unit
+
+**/
+EFI_STATUS
+EFIAPI
+RiscVInitializeFpu (
+  VOID
+  );
+
+#endif /* BASE_RISCV_FPU_LIB_H_ */

--- a/UefiCpuPkg/Library/BaseRiscVFpuLib/BaseRiscVFpuLib.inf
+++ b/UefiCpuPkg/Library/BaseRiscVFpuLib/BaseRiscVFpuLib.inf
@@ -1,0 +1,26 @@
+## @file
+#  RISC-V FPU library.
+#
+#  Copyright (c) 2024, Canonical Services Ltd
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION         = 0x0001001b
+  BASE_NAME           = BaseRiscVFpuLib
+  FILE_GUID           = e600fe4d-8595-40f3-90a0-5f043ce155c2
+  MODULE_TYPE         = BASE
+  VERSION_STRING      = 1.0
+  LIBRARY_CLASS       = RiscVFpuLib
+
+[Sources]
+  RiscVFpuCore.S
+
+[Packages]
+  MdePkg/MdePkg.dec
+  UefiCpuPkg/UefiCpuPkg.dec
+
+[LibraryClasses]
+  BaseLib

--- a/UefiCpuPkg/Library/BaseRiscVFpuLib/RiscVFpuCore.S
+++ b/UefiCpuPkg/Library/BaseRiscVFpuLib/RiscVFpuCore.S
@@ -1,0 +1,22 @@
+/** @file
+*
+*  Copyright (c) 2024, Canonical Services Ltd
+*
+*  SPDX-License-Identifier: BSD-2-Clause-Patent
+*
+**/
+
+#include <Library/BaseRiscVFpuLib.h>
+#include <Register/RiscV64/RiscVImpl.h>
+
+//
+// Initialize floating point unit
+//
+ASM_FUNC (RiscVInitializeFpu)
+  csrr  a0, CSR_SSTATUS
+  li    a1, MSTATUS_FS
+  or    a0, a0, a1
+  csrw  CSR_SSTATUS, a0
+  csrw  CSR_FCSR, x0
+  li    a0, 0
+  ret

--- a/UefiCpuPkg/UefiCpuPkg.dec
+++ b/UefiCpuPkg/UefiCpuPkg.dec
@@ -75,6 +75,8 @@
   SmmRelocationLib|Include/Library/SmmRelocationLib.h
 
 [LibraryClasses.RISCV64]
+  ##  @libraryclass  Provides function to initialize the FPU.
+  RiscVFpuLib|Include/Library/BaseRiscVFpuLib.h
   ##  @libraryclass  Provides functions to manage MMU features on RISCV64 CPUs.
   ##
   RiscVMmuLib|Include/Library/BaseRiscVMmuLib.h

--- a/UefiCpuPkg/UefiCpuPkg.dsc
+++ b/UefiCpuPkg/UefiCpuPkg.dsc
@@ -224,6 +224,7 @@
 [Components.RISCV64]
   UefiCpuPkg/Library/BaseRiscV64CpuExceptionHandlerLib/BaseRiscV64CpuExceptionHandlerLib.inf
   UefiCpuPkg/Library/BaseRiscV64CpuTimerLib/BaseRiscV64CpuTimerLib.inf
+  UefiCpuPkg/Library/BaseRiscVFpuLib/BaseRiscVFpuLib.inf
   UefiCpuPkg/Library/BaseRiscVMmuLib/BaseRiscVMmuLib.inf
   UefiCpuPkg/CpuTimerDxeRiscV64/CpuTimerDxeRiscV64.inf
   UefiCpuPkg/CpuDxeRiscV64/CpuDxeRiscV64.inf


### PR DESCRIPTION
# Description

EDK II build with TLS running on top of QEMU/KVM crashes when reaching the first floating point instruction in the OpenSSL library (https://bugs.launchpad.net/ubuntu/+source/qemu/+bug/2036604). This is due to the floating point unit being in an disabled state (FS bit-field in CSR mstatus).

With the series a library module BaseRiscVFpuLib is added. Here the relevant CSRs are initialized.
In future we can add here the initialization of the vector unit once any library uses it.

## How This Was Tested

Running with QEMU/KVM on SiFive HiFive Premier.

## Integration Instructions

N/A
