### PR TITLE
OvmfPkg: secure boot support for direct kernel boot (via shim)

### DIFF
--- a/OvmfPkg/Library/X86QemuLoadImageLib/X86QemuLoadImageLib.c
+++ b/OvmfPkg/Library/X86QemuLoadImageLib/X86QemuLoadImageLib.c
@@ -57,6 +57,25 @@ STATIC CONST KERNEL_VENMEDIA_FILE_DEVPATH  mKernelDevicePath = {
   }
 };
 
+STATIC CONST KERNEL_VENMEDIA_FILE_DEVPATH  mShimDevicePath = {
+  {
+    {
+      MEDIA_DEVICE_PATH, MEDIA_VENDOR_DP,
+      { sizeof (VENDOR_DEVICE_PATH)       }
+    },
+    QEMU_KERNEL_LOADER_FS_MEDIA_GUID
+  },  {
+    {
+      MEDIA_DEVICE_PATH, MEDIA_FILEPATH_DP,
+      { sizeof (KERNEL_FILE_DEVPATH)      }
+    },
+    L"shim",
+  },  {
+    END_DEVICE_PATH_TYPE, END_ENTIRE_DEVICE_PATH_SUBTYPE,
+    { sizeof (EFI_DEVICE_PATH_PROTOCOL) }
+  }
+};
+
 STATIC
 VOID
 FreeLegacyImage (
@@ -339,6 +358,7 @@ QemuLoadKernelImage (
   UINTN                      CommandLineSize;
   CHAR8                      *CommandLine;
   UINTN                      InitrdSize;
+  BOOLEAN                    Shim;
 
   //
   // Redundant assignment to work around GCC48/GCC49 limitations.
@@ -351,11 +371,30 @@ QemuLoadKernelImage (
   Status = gBS->LoadImage (
                   FALSE,                    // BootPolicy: exact match required
                   gImageHandle,             // ParentImageHandle
-                  (EFI_DEVICE_PATH_PROTOCOL *)&mKernelDevicePath,
+                  (EFI_DEVICE_PATH_PROTOCOL *)&mShimDevicePath,
                   NULL,                     // SourceBuffer
                   0,                        // SourceSize
                   &KernelImageHandle
                   );
+  if (Status == EFI_SUCCESS) {
+    Shim = TRUE;
+    DEBUG ((DEBUG_INFO, "%a: booting via shim\n", __func__));
+  } else {
+    Shim = FALSE;
+    if (Status == EFI_SECURITY_VIOLATION) {
+      gBS->UnloadImage (KernelImageHandle);
+    }
+
+    Status = gBS->LoadImage (
+                    FALSE,                  // BootPolicy: exact match required
+                    gImageHandle,           // ParentImageHandle
+                    (EFI_DEVICE_PATH_PROTOCOL *)&mKernelDevicePath,
+                    NULL,                   // SourceBuffer
+                    0,                      // SourceSize
+                    &KernelImageHandle
+                    );
+  }
+
   switch (Status) {
     case EFI_SUCCESS:
       break;
@@ -465,6 +504,13 @@ QemuLoadKernelImage (
     KernelLoadedImage->LoadOptionsSize += sizeof (L" initrd=initrd") - 2;
   }
 
+  if (Shim) {
+    //
+    // Prefix 'kernel ' in UTF-16.
+    //
+    KernelLoadedImage->LoadOptionsSize += sizeof (L"kernel ") - 2;
+  }
+
   if (KernelLoadedImage->LoadOptionsSize == 0) {
     KernelLoadedImage->LoadOptions = NULL;
   } else {
@@ -485,7 +531,8 @@ QemuLoadKernelImage (
     UnicodeSPrintAsciiFormat (
       KernelLoadedImage->LoadOptions,
       KernelLoadedImage->LoadOptionsSize,
-      "%a%a",
+      "%a%a%a",
+      (Shim == FALSE)        ?  "" : "kernel ",
       (CommandLineSize == 0) ?  "" : CommandLine,
       (InitrdSize == 0)      ?  "" : " initrd=initrd"
       );

--- a/OvmfPkg/Library/X86QemuLoadImageLib/X86QemuLoadImageLib.inf
+++ b/OvmfPkg/Library/X86QemuLoadImageLib/X86QemuLoadImageLib.inf
@@ -33,6 +33,7 @@
   LoadLinuxLib
   PrintLib
   QemuFwCfgLib
+  QemuFwCfgSimpleParserLib
   ReportStatusCodeLib
   UefiBootServicesTableLib
 

--- a/OvmfPkg/QemuKernelLoaderFsDxe/QemuKernelLoaderFsDxe.c
+++ b/OvmfPkg/QemuKernelLoaderFsDxe/QemuKernelLoaderFsDxe.c
@@ -35,6 +35,7 @@ typedef enum {
   KernelBlobTypeKernel,
   KernelBlobTypeInitrd,
   KernelBlobTypeCommandLine,
+  KernelBlobTypeShim,
   KernelBlobTypeMax
 } KERNEL_BLOB_TYPE;
 
@@ -68,6 +69,12 @@ STATIC KERNEL_BLOB  mKernelBlob[KernelBlobTypeMax] = {
     {
       { QemuFwCfgItemCommandLineSize, QemuFwCfgItemCommandLineData, },
     }
+  },  {
+    L"shim",
+    {
+      { 0,                            },
+    },
+    "etc/boot/shim"
   }
 };
 
@@ -790,6 +797,11 @@ StubFileOpen (
   }
 
   if (BlobType == KernelBlobTypeMax) {
+    return EFI_NOT_FOUND;
+  }
+
+  if ((BlobType == KernelBlobTypeShim) && (mKernelBlob[BlobType].Size == 0)) {
+    DEBUG ((DEBUG_INFO, "%a: ERROR: not found (shim zero length)\n", __func__));
     return EFI_NOT_FOUND;
   }
 


### PR DESCRIPTION
- **OvmfPkg/QemuKernelLoaderFsDxe: fetch kernel from etc/boot/kernel if present**
- **OvmfPkg/QemuKernelLoaderFsDxe: fetch shim.efi from etc/boot/shim if present**
- **OvmfPkg/X86QemuLoadImageLib: support booting via shim**
- **OvmfPkg/GenericQemuLoadImageLib: support booting via shim**
- **OvmfPkg/X86QemuLoadImageLib: make legacy loader configurable.**

## Description

qemu support for making shim.efi support available via FwCfg just landed in master branch and will be available in qemu release 10.0 (ETA ~ March 2025).  This PR is the edk2 side of things, adding support for loading shim and booting the kernel via shim, so shim can handle the secure boot verification of the linux kernel when using direct kernel boot.

This PR also adds a config option to enable/disable the insecure legacy linux kernel loader.  For now this option is enabled by default, but most likely the default will be flipped to to disabled at some point in the future (once the new qemu version has found its way into linux distributions).

A warning will be printed to the screen in case the legacy loader is used due to secure boot verification failing.