### PR TITLE
NetworkPkg/NetLib: Replace __FILE__ with __FILE_NAME__ in NetLib

### DIFF
--- a/NetworkPkg/Include/Library/NetLib.h
+++ b/NetworkPkg/Include/Library/NetLib.h
@@ -274,7 +274,7 @@ typedef struct {
   NetDebugOutput ( \
     NETDEBUG_LEVEL_TRACE, \
     Module, \
-    __FILE__, \
+    __FILE_NAME__, \
     DEBUG_LINE_NUMBER, \
     NetDebugASPrint PrintArg \
     )
@@ -283,7 +283,7 @@ typedef struct {
   NetDebugOutput ( \
     NETDEBUG_LEVEL_WARNING, \
     Module, \
-    __FILE__, \
+    __FILE_NAME__, \
     DEBUG_LINE_NUMBER, \
     NetDebugASPrint PrintArg \
     )
@@ -292,7 +292,7 @@ typedef struct {
   NetDebugOutput ( \
     NETDEBUG_LEVEL_ERROR, \
     Module, \
-    __FILE__, \
+    __FILE_NAME__, \
     DEBUG_LINE_NUMBER, \
     NetDebugASPrint PrintArg \
     )
@@ -308,7 +308,7 @@ typedef struct {
          NetDebugOutput (
            NETDEBUG_LEVEL_TRACE,
            "Tcp",
-           __FILE__,
+           __FILE_NAME__,
            DEBUG_LINE_NUMBER,
            NetDebugASPrint ("State transit to %a\n", Name)
          )


### PR DESCRIPTION
This change helps to:
- Shorten the file name displayed in debug logs, reducing the overall file size.
- Avoid exposing full directory structures in build output, enhancing portability between different build environments.


- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

