### PR TITLE
Set Serial Clockrate based on data parsed from host firmware

### DIFF
--- a/UefiPayloadPkg/UefiPayloadEntry/UefiPayloadEntry.c
+++ b/UefiPayloadPkg/UefiPayloadEntry/UefiPayloadEntry.c
@@ -432,6 +432,14 @@ _ModuleEntryPoint (
     UniversalSerialPort->RegisterBase    = SerialPortInfo.BaseAddr;
     UniversalSerialPort->BaudRate        = SerialPortInfo.Baud;
     UniversalSerialPort->RegisterStride  = (UINT8)SerialPortInfo.RegWidth;
+    // Set PCD here (vs in PlatformHookLib.c) to avoid adding a new field to UniversalSerialPort struct
+    if (SerialPortInfo.InputHertz > 0) {
+      Status = PcdSet32S (PcdSerialClockRate, SerialPortInfo.InputHertz);
+      if (RETURN_ERROR (Status)) {
+        DEBUG ((DEBUG_ERROR, "Failed to set PcdSerialClockRate; Status = %r\n", Status));
+        return Status;
+      }
+    }
   }
 
   // The library constructors might depend on serial port, so call it after serial port hob

--- a/UefiPayloadPkg/UefiPayloadEntry/UefiPayloadEntry.inf
+++ b/UefiPayloadPkg/UefiPayloadEntry/UefiPayloadEntry.inf
@@ -96,3 +96,4 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdDxeNxMemoryProtectionPolicy ## SOMETIMES_CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdImageProtectionPolicy       ## SOMETIMES_CONSUMES
 
+  gEfiMdeModulePkgTokenSpaceGuid.PcdSerialClockRate             ## PRODUCES


### PR DESCRIPTION
# Description

Set PcdSerialClockRate from SerialPortInfo in UefiPayloadEntry. 

The initial approach was to add a ClockRate field to UNIVERSAL_PAYLOAD_SERIAL_PORT_INFO data struct, but simplified to setting the PCD directly based on feedback from reviewers.

These changes enable the serial clock rate value, which is already passed in from the host firmware, to be used when configuring the serial port for debug output. AMD Zen platform devices require this in order to have functional serial output.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

build/boot multiple AMD/Intel devices and verify serial output works for all.

## Integration Instructions

N/A
