### PR TITLE
BaseTools: Fix multiple 'invalid escape sequence' warnings in tests

### DIFF
--- a/BaseTools/Source/Python/Ecc/Check.py
+++ b/BaseTools/Source/Python/Ecc/Check.py
@@ -1092,7 +1092,7 @@ class Check(object):
             RecordSet = EccGlobalData.gDb.TblInf.Exec(SqlCommand)
             for Record in RecordSet:
                 Path = Record[1]
-                Path = Path.upper().replace('\X64', '').replace('\IA32', '').replace('\EBC', '').replace('\IPF', '').replace('\ARM', '')
+                Path = Path.upper().replace(r'\X64', '').replace(r'\IA32', '').replace(r'\EBC', '').replace(r'\IPF', '').replace(r'\ARM', '')
                 if Path in InfPathList:
                     if not EccGlobalData.gException.IsException(ERROR_META_DATA_FILE_CHECK_MODULE_FILE_NO_USE, Record[2]):
                         EccGlobalData.gDb.TblReport.Insert(ERROR_META_DATA_FILE_CHECK_MODULE_FILE_NO_USE, OtherMsg="The source file [%s] is existing in module directory but it is not described in INF file." % (Record[2]), BelongsToTable='File', BelongsToItem=Record[0])

--- a/BaseTools/Source/Python/Ecc/Configuration.py
+++ b/BaseTools/Source/Python/Ecc/Configuration.py
@@ -432,7 +432,7 @@ class Configuration(object):
 # test that our dict and out class still match in contents.
 #
 if __name__ == '__main__':
-    myconfig = Configuration("BaseTools\Source\Python\Ecc\config.ini")
+    myconfig = Configuration(r"BaseTools\Source\Python\Ecc\config.ini")
     for each in myconfig.__dict__:
         if each == "Filename":
             continue

--- a/BaseTools/Source/Python/Ecc/MetaFileWorkspace/MetaFileParser.py
+++ b/BaseTools/Source/Python/Ecc/MetaFileWorkspace/MetaFileParser.py
@@ -1841,14 +1841,14 @@ class DecParser(MetaFileParser):
 
         if EccGlobalData.gConfig.UniCheckPCDInfo == '1' or EccGlobalData.gConfig.UniCheckAll == '1' or EccGlobalData.gConfig.CheckAll == '1':
             # check Description, Prompt information
-            PatternDesc = re.compile('##\s*([\x21-\x7E\s]*)', re.S)
-            PatternPrompt = re.compile('#\s+@Prompt\s+([\x21-\x7E\s]*)', re.S)
+            PatternDesc = re.compile(r'##\s*([\x21-\x7E\s]*)', re.S)
+            PatternPrompt = re.compile(r'#\s+@Prompt\s+([\x21-\x7E\s]*)', re.S)
             Description = None
             Prompt = None
             # check @ValidRange, @ValidList and @Expression format valid
             ErrorCodeValid = '0x0 <= %s <= 0xFFFFFFFF'
-            PatternValidRangeIn = '(NOT)?\s*(\d+\s*-\s*\d+|0[xX][a-fA-F0-9]+\s*-\s*0[xX][a-fA-F0-9]+|LT\s*\d+|LT\s*0[xX][a-fA-F0-9]+|GT\s*\d+|GT\s*0[xX][a-fA-F0-9]+|LE\s*\d+|LE\s*0[xX][a-fA-F0-9]+|GE\s*\d+|GE\s*0[xX][a-fA-F0-9]+|XOR\s*\d+|XOR\s*0[xX][a-fA-F0-9]+|EQ\s*\d+|EQ\s*0[xX][a-fA-F0-9]+)'
-            PatternValidRng = re.compile('^' + '(NOT)?\s*' + PatternValidRangeIn + '$')
+            PatternValidRangeIn = r'(NOT)?\s*(\d+\s*-\s*\d+|0[xX][a-fA-F0-9]+\s*-\s*0[xX][a-fA-F0-9]+|LT\s*\d+|LT\s*0[xX][a-fA-F0-9]+|GT\s*\d+|GT\s*0[xX][a-fA-F0-9]+|LE\s*\d+|LE\s*0[xX][a-fA-F0-9]+|GE\s*\d+|GE\s*0[xX][a-fA-F0-9]+|XOR\s*\d+|XOR\s*0[xX][a-fA-F0-9]+|EQ\s*\d+|EQ\s*0[xX][a-fA-F0-9]+)'
+            PatternValidRng = re.compile('^' + r'(NOT)?\s*' + PatternValidRangeIn + '$')
             for Comment in self._Comments:
                 Comm = Comment[0].strip()
                 if not Comm:
@@ -2071,7 +2071,7 @@ class UniParser(object):
     def CheckKeyValid(self, Key, Contents=None):
         if not Contents:
             Contents = self.FileIn
-        KeyPattern = re.compile('#string\s+%s\s+.*?#language.*?".*?"' % Key, re.S)
+        KeyPattern = re.compile(r'#string\s+%s\s+.*?#language.*?".*?"' % Key, re.S)
         if KeyPattern.search(Contents):
             return True
         return False

--- a/BaseTools/Source/Python/Ecc/c.py
+++ b/BaseTools/Source/Python/Ecc/c.py
@@ -43,7 +43,7 @@ def GetArrayPattern():
     return p
 
 def GetTypedefFuncPointerPattern():
-    p = re.compile('[_\w\s]*\([\w\s]*\*+\s*[_\w]+\s*\)\s*\(.*\)', re.DOTALL)
+    p = re.compile(r'[_\w\s]*\([\w\s]*\*+\s*[_\w]+\s*\)\s*\(.*\)', re.DOTALL)
     return p
 
 def GetDB():

--- a/BaseTools/Source/Python/Eot/EotGlobalData.py
+++ b/BaseTools/Source/Python/Eot/EotGlobalData.py
@@ -11,7 +11,7 @@ from Common.LongFilePathSupport import OpenLongFilePath as open
 gEFI_SOURCE = ''
 gEDK_SOURCE = ''
 gWORKSPACE = ''
-gSHELL_INF = 'Application\Shell'
+gSHELL_INF = r'Application\Shell'
 gMAKE_FILE = ''
 gDSC_FILE = ''
 gFV_FILE = []

--- a/BaseTools/Source/Python/Eot/c.py
+++ b/BaseTools/Source/Python/Eot/c.py
@@ -54,7 +54,7 @@ def GetArrayPattern():
 #  @return p:    the pattern of function pointer
 #
 def GetTypedefFuncPointerPattern():
-    p = re.compile('[_\w\s]*\([\w\s]*\*+\s*[_\w]+\s*\)\s*\(.*\)', re.DOTALL)
+    p = re.compile(r'[_\w\s]*\([\w\s]*\*+\s*[_\w]+\s*\)\s*\(.*\)', re.DOTALL)
     return p
 
 ## GetDB() method

--- a/BaseTools/Source/Python/UPT/Library/CommentParsing.py
+++ b/BaseTools/Source/Python/UPT/Library/CommentParsing.py
@@ -238,7 +238,7 @@ def ParseDecPcdGenericComment (GenericComment, ContainerFile, TokenSpaceGuidCNam
         #
         # To replace Macro
         #
-        MACRO_PATTERN = '[\t\s]*\$\([A-Z][_A-Z0-9]*\)'
+        MACRO_PATTERN = r'[\t\s]*\$\([A-Z][_A-Z0-9]*\)'
         MatchedStrs =  re.findall(MACRO_PATTERN, Comment)
         for MatchedStr in MatchedStrs:
             if MatchedStr:

--- a/BaseTools/Source/Python/UPT/Library/ExpressionValidate.py
+++ b/BaseTools/Source/Python/UPT/Library/ExpressionValidate.py
@@ -66,13 +66,13 @@ class _ExprError(Exception):
 ## _ExprBase
 #
 class _ExprBase:
-    HEX_PATTERN = '[\t\s]*0[xX][a-fA-F0-9]+'
-    INT_PATTERN = '[\t\s]*[0-9]+'
-    MACRO_PATTERN = '[\t\s]*\$\(([A-Z][_A-Z0-9]*)\)'
+    HEX_PATTERN = r'[\t\s]*0[xX][a-fA-F0-9]+'
+    INT_PATTERN = r'[\t\s]*[0-9]+'
+    MACRO_PATTERN = r'[\t\s]*\$\(([A-Z][_A-Z0-9]*)\)'
     PCD_PATTERN = \
-    '[\t\s]*[_a-zA-Z][a-zA-Z0-9_]*[\t\s]*\.[\t\s]*[_a-zA-Z][a-zA-Z0-9_]*'
-    QUOTED_PATTERN = '[\t\s]*L?"[^"]*"'
-    BOOL_PATTERN = '[\t\s]*(true|True|TRUE|false|False|FALSE)'
+    r'[\t\s]*[_a-zA-Z][a-zA-Z0-9_]*[\t\s]*\.[\t\s]*[_a-zA-Z][a-zA-Z0-9_]*'
+    QUOTED_PATTERN = r'[\t\s]*L?"[^"]*"'
+    BOOL_PATTERN = r'[\t\s]*(true|True|TRUE|false|False|FALSE)'
     def __init__(self, Token):
         self.Token = Token
         self.Index = 0
@@ -303,9 +303,9 @@ class _LogicalExpressionParser(_ExprBase):
 ## _ValidRangeExpressionParser
 #
 class _ValidRangeExpressionParser(_ExprBase):
-    INT_RANGE_PATTERN = '[\t\s]*[0-9]+[\t\s]*-[\t\s]*[0-9]+'
+    INT_RANGE_PATTERN = r'[\t\s]*[0-9]+[\t\s]*-[\t\s]*[0-9]+'
     HEX_RANGE_PATTERN = \
-        '[\t\s]*0[xX][a-fA-F0-9]+[\t\s]*-[\t\s]*0[xX][a-fA-F0-9]+'
+        r'[\t\s]*0[xX][a-fA-F0-9]+[\t\s]*-[\t\s]*0[xX][a-fA-F0-9]+'
     def __init__(self, Token):
         _ExprBase.__init__(self, Token)
         self.Parens = 0
@@ -407,7 +407,7 @@ class _ValidRangeExpressionParser(_ExprBase):
 ## _ValidListExpressionParser
 #
 class _ValidListExpressionParser(_ExprBase):
-    VALID_LIST_PATTERN = '(0[xX][0-9a-fA-F]+|[0-9]+)([\t\s]*,[\t\s]*(0[xX][0-9a-fA-F]+|[0-9]+))*'
+    VALID_LIST_PATTERN = r'(0[xX][0-9a-fA-F]+|[0-9]+)([\t\s]*,[\t\s]*(0[xX][0-9a-fA-F]+|[0-9]+))*'
     def __init__(self, Token):
         _ExprBase.__init__(self, Token)
         self.NUM = 1

--- a/BaseTools/Source/Python/UPT/Library/Misc.py
+++ b/BaseTools/Source/Python/UPT/Library/Misc.py
@@ -69,11 +69,11 @@ def GuidStringToGuidStructureString(Guid):
 def CheckGuidRegFormat(GuidValue):
     ## Regular expression used to find out register format of GUID
     #
-    RegFormatGuidPattern = re.compile("^\s*([0-9a-fA-F]){8}-"
+    RegFormatGuidPattern = re.compile(r"^\s*([0-9a-fA-F]){8}-"
                                        "([0-9a-fA-F]){4}-"
                                        "([0-9a-fA-F]){4}-"
                                        "([0-9a-fA-F]){4}-"
-                                       "([0-9a-fA-F]){12}\s*$")
+                                       r"([0-9a-fA-F]){12}\s*$")
 
     if RegFormatGuidPattern.match(GuidValue):
         return True
@@ -837,8 +837,8 @@ def GetLibInstanceInfo(String, WorkSpace, LineNo):
                          ST.ERR_FILE_OPEN_FAILURE,
                          File=FullFileName)
 
-        ReFileGuidPattern = re.compile("^\s*FILE_GUID\s*=.*$")
-        ReVerStringPattern = re.compile("^\s*VERSION_STRING\s*=.*$")
+        ReFileGuidPattern = re.compile(r"^\s*FILE_GUID\s*=.*$")
+        ReVerStringPattern = re.compile(r"^\s*VERSION_STRING\s*=.*$")
 
         FileLinesList = ProcessLineExtender(FileLinesList)
 
@@ -978,7 +978,7 @@ def ValidateUNIFilePath(Path):
     #
     # Check if the file name is valid according to the DEC and INF specification
     #
-    Pattern = '[a-zA-Z0-9_][a-zA-Z0-9_\-\.]*'
+    Pattern = r'[a-zA-Z0-9_][a-zA-Z0-9_\-\.]*'
     FileName = Path.replace(Suffix, '')
     InvalidCh = re.sub(Pattern, '', FileName)
     if InvalidCh:

--- a/BaseTools/Source/Python/UPT/Library/StringUtils.py
+++ b/BaseTools/Source/Python/UPT/Library/StringUtils.py
@@ -23,7 +23,7 @@ from Logger import StringTable as ST
 #
 # Regular expression for matching macro used in DSC/DEC/INF file inclusion
 #
-gMACRO_PATTERN = re.compile("\$\(([_A-Z][_A-Z0-9]*)\)", re.UNICODE)
+gMACRO_PATTERN = re.compile(r"\$\(([_A-Z][_A-Z0-9]*)\)", re.UNICODE)
 
 ## GetSplitValueList
 #

--- a/BaseTools/Source/Python/UPT/Parser/DecParserMisc.py
+++ b/BaseTools/Source/Python/UPT/Parser/DecParserMisc.py
@@ -25,7 +25,7 @@ from Library.ExpressionValidate import IsValidStringTest
 from Library.Misc import CheckGuidRegFormat
 
 TOOL_NAME = 'DecParser'
-VERSION_PATTERN = '[0-9]+(\.[0-9]+)?'
+VERSION_PATTERN = r'[0-9]+(\.[0-9]+)?'
 CVAR_PATTERN = '[_a-zA-Z][a-zA-Z0-9_]*'
 PCD_TOKEN_PATTERN = '(0[xX]0*[a-fA-F0-9]{1,8})|([0-9]+)'
 MACRO_PATTERN = '[A-Z][_A-Z0-9]*'

--- a/BaseTools/Source/Python/UPT/Parser/InfAsBuiltProcess.py
+++ b/BaseTools/Source/Python/UPT/Parser/InfAsBuiltProcess.py
@@ -53,12 +53,12 @@ def GetLibInstanceInfo(String, WorkSpace, LineNo, CurrentInfFileName):
     #
     # To deal with library instance specified by GUID and version
     #
-    RegFormatGuidPattern = re.compile("\s*([0-9a-fA-F]){8}-"
+    RegFormatGuidPattern = re.compile(r"\s*([0-9a-fA-F]){8}-"
                                        "([0-9a-fA-F]){4}-"
                                        "([0-9a-fA-F]){4}-"
                                        "([0-9a-fA-F]){4}-"
-                                       "([0-9a-fA-F]){12}\s*")
-    VersionPattern = re.compile('[\t\s]*\d+(\.\d+)?[\t\s]*')
+                                       r"([0-9a-fA-F]){12}\s*")
+    VersionPattern = re.compile(r'[\t\s]*\d+(\.\d+)?[\t\s]*')
     GuidMatchedObj = RegFormatGuidPattern.search(String)
 
     if String.upper().startswith('GUID') and GuidMatchedObj and 'Version' in String:
@@ -75,8 +75,8 @@ def GetLibInstanceInfo(String, WorkSpace, LineNo, CurrentInfFileName):
     FileLinesList = GetFileLineContent(String, WorkSpace, LineNo, OriginalString)
 
 
-    ReFindFileGuidPattern = re.compile("^\s*FILE_GUID\s*=.*$")
-    ReFindVerStringPattern = re.compile("^\s*VERSION_STRING\s*=.*$")
+    ReFindFileGuidPattern = re.compile(r"^\s*FILE_GUID\s*=.*$")
+    ReFindVerStringPattern = re.compile(r"^\s*VERSION_STRING\s*=.*$")
 
     for Line in FileLinesList:
         if ReFindFileGuidPattern.match(Line):
@@ -106,8 +106,8 @@ def GetPackageListInfo(FileNameString, WorkSpace, LineNo):
 
     FileLinesList = GetFileLineContent(FileNameString, WorkSpace, LineNo, '')
 
-    RePackageHeader = re.compile('^\s*\[Packages.*\].*$')
-    ReDefineHeader = re.compile('^\s*\[Defines].*$')
+    RePackageHeader = re.compile(r'^\s*\[Packages.*\].*$')
+    ReDefineHeader = re.compile(r'^\s*\[Defines].*$')
 
     PackageHederFlag = False
     DefineHeaderFlag = False
@@ -255,8 +255,8 @@ def GetGuidVerFormLibInstance(Guid, Version, WorkSpace, CurrentInfFileName):
             FileLinesList = InfFileObj.readlines()
             FileLinesList = ProcessLineExtender(FileLinesList)
 
-            ReFindFileGuidPattern = re.compile("^\s*FILE_GUID\s*=.*$")
-            ReFindVerStringPattern = re.compile("^\s*VERSION_STRING\s*=.*$")
+            ReFindFileGuidPattern = re.compile(r"^\s*FILE_GUID\s*=.*$")
+            ReFindVerStringPattern = re.compile(r"^\s*VERSION_STRING\s*=.*$")
 
             for Line in FileLinesList:
                 if ReFindFileGuidPattern.match(Line):

--- a/BaseTools/Source/Python/UPT/Parser/InfDefineSectionParser.py
+++ b/BaseTools/Source/Python/UPT/Parser/InfDefineSectionParser.py
@@ -40,7 +40,7 @@ def GetValidateArchList(LineContent):
 
         TempArch = GetSplitValueList(TempArch, '(', 1)[0]
 
-        ArchList = re.split('\s+', TempArch)
+        ArchList = re.split(r'\s+', TempArch)
         NewArchList = []
         for Arch in ArchList:
             if IsValidArch(Arch):

--- a/BaseTools/Source/Python/UPT/Parser/InfParserMisc.py
+++ b/BaseTools/Source/Python/UPT/Parser/InfParserMisc.py
@@ -109,7 +109,7 @@ def InfExpandMacro(Content, LineInfo, GlobalMacros=None, SectionMacros=None, Fla
         return Content
     else:
         for Macro in MacroUsed:
-            gQuotedMacro = re.compile(".*\".*\$\(%s\).*\".*"%(Macro))
+            gQuotedMacro = re.compile(r".*\".*\$\(%s\).*\".*"%(Macro))
             if not gQuotedMacro.match(Content):
                 #
                 # Still have MACROs can't be expanded.
@@ -130,8 +130,8 @@ def IsBinaryInf(FileLineList):
     if not FileLineList:
         return False
 
-    ReIsSourcesSection = re.compile("^\s*\[Sources.*\]\s.*$", re.IGNORECASE)
-    ReIsBinarySection = re.compile("^\s*\[Binaries.*\]\s.*$", re.IGNORECASE)
+    ReIsSourcesSection = re.compile(r"^\s*\[Sources.*\]\s.*$", re.IGNORECASE)
+    ReIsBinarySection = re.compile(r"^\s*\[Binaries.*\]\s.*$", re.IGNORECASE)
     BinarySectionFoundFlag = False
 
     for Line in FileLineList:
@@ -155,7 +155,7 @@ def IsBinaryInf(FileLineList):
 # @return Flag
 #
 def IsLibInstanceInfo(String):
-    ReIsLibInstance = re.compile("^\s*##\s*@LIB_INSTANCES\s*$")
+    ReIsLibInstance = re.compile(r"^\s*##\s*@LIB_INSTANCES\s*$")
     if ReIsLibInstance.match(String):
         return True
     else:
@@ -171,7 +171,7 @@ def IsLibInstanceInfo(String):
 # @return Flag
 #
 def IsAsBuildOptionInfo(String):
-    ReIsAsBuildInstance = re.compile("^\s*##\s*@AsBuilt\s*$")
+    ReIsAsBuildInstance = re.compile(r"^\s*##\s*@AsBuilt\s*$")
     if ReIsAsBuildInstance.match(String):
         return True
     else:

--- a/BaseTools/Source/Python/UPT/PomAdapter/DecPomAlignment.py
+++ b/BaseTools/Source/Python/UPT/PomAdapter/DecPomAlignment.py
@@ -747,12 +747,12 @@ class DecPomAlignment(PackageObject):
         #
         # deal with "NOT EQ", "NOT LT", "NOT GT", "NOT LE", "NOT GE", "NOT NOT"
         #
-        NOTNOT_Pattern = '[\t\s]*NOT[\t\s]+NOT[\t\s]*'
-        NOTGE_Pattern = '[\t\s]*NOT[\t\s]+GE[\t\s]*'
-        NOTLE_Pattern = '[\t\s]*NOT[\t\s]+LE[\t\s]*'
-        NOTGT_Pattern = '[\t\s]*NOT[\t\s]+GT[\t\s]*'
-        NOTLT_Pattern = '[\t\s]*NOT[\t\s]+LT[\t\s]*'
-        NOTEQ_Pattern = '[\t\s]*NOT[\t\s]+EQ[\t\s]*'
+        NOTNOT_Pattern = r'[\t\s]*NOT[\t\s]+NOT[\t\s]*'
+        NOTGE_Pattern = r'[\t\s]*NOT[\t\s]+GE[\t\s]*'
+        NOTLE_Pattern = r'[\t\s]*NOT[\t\s]+LE[\t\s]*'
+        NOTGT_Pattern = r'[\t\s]*NOT[\t\s]+GT[\t\s]*'
+        NOTLT_Pattern = r'[\t\s]*NOT[\t\s]+LT[\t\s]*'
+        NOTEQ_Pattern = r'[\t\s]*NOT[\t\s]+EQ[\t\s]*'
         ReplaceValue = re.compile(NOTNOT_Pattern).sub('', ReplaceValue)
         ReplaceValue = re.compile(NOTLT_Pattern).sub('x >= ', ReplaceValue)
         ReplaceValue = re.compile(NOTGT_Pattern).sub('x <= ', ReplaceValue)
@@ -785,7 +785,7 @@ class DecPomAlignment(PackageObject):
         if ReplaceValue.find('!') >= 0 and ReplaceValue[ReplaceValue.index('!') + 1] != '=':
             ReplaceValue = ReplaceValue.replace('!', ' not ')
         if '.' in ReplaceValue:
-            Pattern = '[a-zA-Z0-9]{1,}\.[a-zA-Z0-9]{1,}'
+            Pattern = r'[a-zA-Z0-9]{1,}\.[a-zA-Z0-9]{1,}'
             MatchedList = re.findall(Pattern, ReplaceValue)
             for MatchedItem in MatchedList:
                 if MatchedItem not in self.PcdDefaultValueDict:
@@ -814,7 +814,7 @@ class DecPomAlignment(PackageObject):
                     #
                     # Delete the 'L' prefix of a quoted string, this operation is for eval()
                     #
-                    QUOTED_PATTERN = '[\t\s]*L?"[^"]*"'
+                    QUOTED_PATTERN = r'[\t\s]*L?"[^"]*"'
                     QuotedMatchedObj = re.search(QUOTED_PATTERN, Expression)
                     if QuotedMatchedObj:
                         MatchedStr = QuotedMatchedObj.group().strip()
@@ -847,7 +847,7 @@ class DecPomAlignment(PackageObject):
             #
             # Delete the 'L' prefix of a quoted string, this operation is for eval()
             #
-            QUOTED_PATTERN = '[\t\s]*L?"[^"]*"'
+            QUOTED_PATTERN = r'[\t\s]*L?"[^"]*"'
             QuotedMatchedObj = re.search(QUOTED_PATTERN, DefaultValue)
             if QuotedMatchedObj:
                 MatchedStr = QuotedMatchedObj.group().strip()

--- a/BaseTools/Source/Python/UPT/Xml/IniToXml.py
+++ b/BaseTools/Source/Python/UPT/Xml/IniToXml.py
@@ -200,9 +200,9 @@ def ValidateRegValues(Key, Value):
             ('[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}'
             '-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}',
             ST.ERR_GUID_VALUE % Value),
-        'Version'   :   ('[0-9]+(\.[0-9]+)?', ST.ERR_VERSION_VALUE % \
+        'Version'   :   (r'[0-9]+(\.[0-9]+)?', ST.ERR_VERSION_VALUE % \
                          (Key, Value)),
-        'XmlSpecification' : ('1\.1', ST.ERR_VERSION_XMLSPEC % Value)
+        'XmlSpecification' : (r'1\.1', ST.ERR_VERSION_XMLSPEC % Value)
     }
     if Key not in ValidateMap:
         return True, ''

--- a/BaseTools/Source/Python/UPT/Xml/PcdXml.py
+++ b/BaseTools/Source/Python/UPT/Xml/PcdXml.py
@@ -100,11 +100,11 @@ class PcdErrorXml(object):
     def TransferValidRange2Expr(self, TokenSpaceGuidCName, CName, ValidRange):
         if self.Expression:
             pass
-        INT_RANGE_PATTERN1 = '[\t\s]*[0-9]+[\t\s]*-[\t\s]*[0-9]+'
-        INT_RANGE_PATTERN2 = '[\t\s]*(LT|GT|LE|GE|XOR|EQ)[\t\s]+\d+[\t\s]*'
+        INT_RANGE_PATTERN1 = r'[\t\s]*[0-9]+[\t\s]*-[\t\s]*[0-9]+'
+        INT_RANGE_PATTERN2 = r'[\t\s]*(LT|GT|LE|GE|XOR|EQ)[\t\s]+\d+[\t\s]*'
         HEX_RANGE_PATTERN1 = \
-            '[\t\s]*0[xX][a-fA-F0-9]+[\t\s]*-[\t\s]*0[xX][a-fA-F0-9]+'
-        HEX_RANGE_PATTERN2 = '[\t\s]*(LT|GT|LE|GE|XOR|EQ)[\t\s]+0[xX][a-fA-F0-9]+[\t\s]*'
+            r'[\t\s]*0[xX][a-fA-F0-9]+[\t\s]*-[\t\s]*0[xX][a-fA-F0-9]+'
+        HEX_RANGE_PATTERN2 = r'[\t\s]*(LT|GT|LE|GE|XOR|EQ)[\t\s]+0[xX][a-fA-F0-9]+[\t\s]*'
         IntMatch1 = re.compile(INT_RANGE_PATTERN1)
         IntMatch2 = re.compile(INT_RANGE_PATTERN2)
         HexMatch1 = re.compile(HEX_RANGE_PATTERN1)
@@ -158,18 +158,18 @@ class PcdErrorXml(object):
             pass
 
         PCD_PATTERN = \
-        '[\t\s]*[_a-zA-Z][a-zA-Z0-9_]*[\t\s]*\.[\t\s]*[_a-zA-Z][a-zA-Z0-9_]*[\t\s]*'
+        r'[\t\s]*[_a-zA-Z][a-zA-Z0-9_]*[\t\s]*\.[\t\s]*[_a-zA-Z][a-zA-Z0-9_]*[\t\s]*'
         IntPattern1 = \
-        '[\t\s]*\([\t\s]*'+PCD_PATTERN+'[\t\s]+GE[\t\s]+\d+[\t\s]*\)[\t\s]+AND[\t\s]+\([\t\s]*'+\
-        PCD_PATTERN+'[\t\s]+LE[\t\s]+\d+[\t\s]*\)'
+        r'[\t\s]*\([\t\s]*'+PCD_PATTERN+r'[\t\s]+GE[\t\s]+\d+[\t\s]*\)[\t\s]+AND[\t\s]+\([\t\s]*'+\
+        PCD_PATTERN+r'[\t\s]+LE[\t\s]+\d+[\t\s]*\)'
         IntPattern1 = IntPattern1.replace(' ', '')
-        IntPattern2 = '[\t\s]*'+PCD_PATTERN+'[\t\s]+(LT|GT|LE|GE|XOR|EQ)[\t\s]+\d+[\t\s]*'
+        IntPattern2 = r'[\t\s]*'+PCD_PATTERN+r'[\t\s]+(LT|GT|LE|GE|XOR|EQ)[\t\s]+\d+[\t\s]*'
 
         HexPattern1 = \
-        '[\t\s]*\([\t\s]*'+PCD_PATTERN+'[\t\s]+GE[\t\s]+0[xX][0-9a-fA-F]+[\t\s]*\)[\t\s]+AND[\t\s]+\([\t\s]*'+\
-        PCD_PATTERN+'[\t\s]+LE[\t\s]+0[xX][0-9a-fA-F]+[\t\s]*\)'
+        r'[\t\s]*\([\t\s]*'+PCD_PATTERN+r'[\t\s]+GE[\t\s]+0[xX][0-9a-fA-F]+[\t\s]*\)[\t\s]+AND[\t\s]+\([\t\s]*'+\
+        PCD_PATTERN+r'[\t\s]+LE[\t\s]+0[xX][0-9a-fA-F]+[\t\s]*\)'
         HexPattern1 = HexPattern1.replace(' ', '')
-        HexPattern2 = '[\t\s]*'+PCD_PATTERN+'[\t\s]+(LT|GT|LE|GE|XOR|EQ)[\t\s]+0[xX][0-9a-zA-Z]+[\t\s]*'
+        HexPattern2 = r'[\t\s]*'+PCD_PATTERN+r'[\t\s]+(LT|GT|LE|GE|XOR|EQ)[\t\s]+0[xX][0-9a-zA-Z]+[\t\s]*'
 
         #
         # Do the Hex1 conversion
@@ -180,7 +180,7 @@ class PcdErrorXml(object):
             #
             # To match items on both sides of '-'
             #
-            RangeItemList = re.compile('[\t\s]*0[xX][0-9a-fA-F]+[\t\s]*').findall(HexMatchedItem)
+            RangeItemList = re.compile(r'[\t\s]*0[xX][0-9a-fA-F]+[\t\s]*').findall(HexMatchedItem)
             if RangeItemList and len(RangeItemList) == 2:
                 HexRangeDict[HexMatchedItem] = RangeItemList
 
@@ -204,7 +204,7 @@ class PcdErrorXml(object):
             #
             # To match items on both sides of '-'
             #
-            RangeItemList = re.compile('[\t\s]*\d+[\t\s]*').findall(MatchedItem)
+            RangeItemList = re.compile(r'[\t\s]*\d+[\t\s]*').findall(MatchedItem)
             if RangeItemList and len(RangeItemList) == 2:
                 IntRangeDict[MatchedItem] = RangeItemList
 

--- a/BaseTools/Source/Python/UPT/Xml/XmlParser.py
+++ b/BaseTools/Source/Python/UPT/Xml/XmlParser.py
@@ -281,33 +281,33 @@ class DistributionPackageXml(object):
             #
             XmlContent = \
             re.sub(r'[\s\r\n]*SupArchList[\s\r\n]*=[\s\r\n]*"[\s\r\n]*COMMON'
-            '[\s\r\n]*"', '', XmlContent)
+            r'[\s\r\n]*"', '', XmlContent)
             XmlContent = \
             re.sub(r'[\s\r\n]*SupArchList[\s\r\n]*=[\s\r\n]*"[\s\r\n]*common'
-            '[\s\r\n]*"', '', XmlContent)
+            r'[\s\r\n]*"', '', XmlContent)
             #
             # Remove <SupArchList> COMMON </SupArchList>
             #
             XmlContent = \
             re.sub(r'[\s\r\n]*<SupArchList>[\s\r\n]*COMMON[\s\r\n]*'
-            '</SupArchList>[\s\r\n]*', '', XmlContent)
+            r'</SupArchList>[\s\r\n]*', '', XmlContent)
 
             #
             # Remove <SupArchList> common </SupArchList>
             #
             XmlContent = \
             re.sub(r'[\s\r\n]*<SupArchList>[\s\r\n]*'
-            'common[\s\r\n]*</SupArchList>[\s\r\n]*', '', XmlContent)
+            r'common[\s\r\n]*</SupArchList>[\s\r\n]*', '', XmlContent)
 
             #
             # Remove SupModList="COMMON" or "common"
             #
             XmlContent = \
             re.sub(r'[\s\r\n]*SupModList[\s\r\n]*=[\s\r\n]*"[\s\r\n]*COMMON'
-            '[\s\r\n]*"', '', XmlContent)
+            r'[\s\r\n]*"', '', XmlContent)
             XmlContent = \
             re.sub(r'[\s\r\n]*SupModList[\s\r\n]*=[\s\r\n]*"[\s\r\n]*common'
-            '[\s\r\n]*"', '', XmlContent)
+            r'[\s\r\n]*"', '', XmlContent)
 
             return XmlContent
 


### PR DESCRIPTION
# Description

In Python 3.12 invalid escape sequences in strings moved from DeprecationWarning to SyntaxWarning (ref https://docs.python.org/3/whatsnew/changelog.html#python-3-12-0-final and search for gh-98401). In a future Python version this will become SyntaxError.

Multiple instances of these SyntaxWarnings are currently printed when running the BaseTools tests using Python 3.12 (though without actually failing the affected tests).

This commit updates all lines which were causing this type of warning.

Typical examples which needed fixing are:

- "BaseTools\Source\Python" representing a path: "\S" and "\P" are invalid escape sequences, therefore left unchanged, therefore the test works (with a warning in Python 3.12). r"BaseTools\Source\Python" represents the same string, but with escapes turned off completely thus no warning.

- Where '\t\s' is used as a regex pattern, then chr(9) + '\\\\s' is sent to the regex parser (with a warning in Python 3.12) since '\s' is not a valid Python escape sequence. This works correctly, though arguably for the wrong reasons. r'\t\s' sends the same as '\\\\t\\\\s', as originally intended and with no warning.

(Note that ' and " are not fundamentally different in Python.)

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

Confirm all tests passing and no warnings printed after change, using either Python 3.11 or 3.12.

## Integration Instructions

N/A
