### PR TITLE
BaseTools: Update RETURN_ERROR Macro in BaseTypes.h

### DIFF
--- a/BaseTools/Source/C/Include/Common/BaseTypes.h
+++ b/BaseTools/Source/C/Include/Common/BaseTypes.h
@@ -4,6 +4,8 @@
   This file is stand alone self consistent set of definitions.
 
   Copyright (c) 2006 - 2018, Intel Corporation. All rights reserved.<BR>
+  Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -202,7 +204,7 @@ typedef UINTN RETURN_STATUS;
 #define ENCODE_ERROR(a)              ((RETURN_STATUS)(MAX_BIT | (a)))
 
 #define ENCODE_WARNING(a)            ((RETURN_STATUS)(a))
-#define RETURN_ERROR(a)              (((INTN)(RETURN_STATUS)(a)) < 0)
+#define RETURN_ERROR(a)              (((RETURN_STATUS)(a)) >= MAX_BIT)
 
 #define RETURN_SUCCESS               0
 #define RETURN_LOAD_ERROR            ENCODE_ERROR (1)


### PR DESCRIPTION
This patch is to sync RETURN_ERROR macro with the
MdePkg/Include/Base.h

Ref: 1a89d9887f MdePkg:Update Return Error Macro in Base.h

Fixing RETURN_ERROR macro.
It is causing problem in Coverity Static analysis tool as we are directly converting the UINT value to INTN.

Changing value from UINT to INTN might cause problema Here we know that the values would not be in loss of data. To increase the code quality and increase the static tool analysis score we have to change it

Cc: Rebecca Cran <rebecca@bsdio.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Bob Feng <bob.c.feng@intel.com>
Cc: Yuwei Chen <yuwei.chen@intel.com>

# Description

This patch is to sync RETURN_ERROR macro with the
MdePkg/Include/Base.h

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Build and Boot to AMD systems.

## Integration Instructions
N/A
