### PR TITLE
UefiPayloadPkg: Add LOCKBOX_SUPPORT in UPL and set it as FALSE in def…

### DIFF
--- a/UefiPayloadPkg/UefiPayloadPkg.dsc
+++ b/UefiPayloadPkg/UefiPayloadPkg.dsc
@@ -42,6 +42,7 @@
   DEFINE BOOTSPLASH_IMAGE             = FALSE
   DEFINE NVME_ENABLE                  = TRUE
   DEFINE CAPSULE_SUPPORT              = FALSE
+  DEFINE LOCKBOX_SUPPORT              = FALSE
 
   #
   # Crypto Support
@@ -298,7 +299,11 @@
 !endif
 
   DebugLib|MdeModulePkg/Library/PeiDxeDebugLibReportStatusCode/PeiDxeDebugLibReportStatusCode.inf
+!if $(LOCKBOX_SUPPORT) == TRUE
+  LockBoxLib|MdeModulePkg/Library/SmmLockBoxLib/SmmLockBoxDxeLib.inf
+!else
   LockBoxLib|MdeModulePkg/Library/LockBoxNullLib/LockBoxNullLib.inf
+!endif
   FileExplorerLib|MdeModulePkg/Library/FileExplorerLib/FileExplorerLib.inf
   AuthVariableLib|MdeModulePkg/Library/AuthVariableLibNull/AuthVariableLibNull.inf
 !if $(VARIABLE_SUPPORT) == "EMU"


### PR DESCRIPTION
…ault

S3 performance table is saved to LockBox. Without LockBox, S3 performance data will lost.

Add LOCKBOX_SUPPORT to optionally select LockBox libary instance, default value is FALSE.

# Description
function FpdtAllocateS3PerformanceTableMemory() invoke SaveLockBox() to save S3 performance data to LockBox.
As current LockBox is LockBoxNullLib,  data will not be saved.

## How This Was Tested
This change do not introduce change by default.
To test this change,  set LOCKBOX_SUPPORT=TRUE when building UPL,  save FPDT data after system resume from S3.

## Integration Instructions
N/A
