### PR TITLE
OvmfPkg/XenPvBlkDxe: Update disk size calculation

### DIFF
--- a/OvmfPkg/XenPvBlkDxe/BlockFront.c
+++ b/OvmfPkg/XenPvBlkDxe/BlockFront.c
@@ -356,7 +356,7 @@ Again:
 
   DEBUG ((
     DEBUG_INFO,
-    "XenPvBlk: New disk with %ld sectors of %d bytes\n",
+    "XenPvBlk: New disk with %ld 512B-sectors and logical sector size of %d bytes\n",
     Dev->MediaInfo.Sectors,
     Dev->MediaInfo.SectorSize
     ));

--- a/OvmfPkg/XenPvBlkDxe/XenPvBlkDxe.c
+++ b/OvmfPkg/XenPvBlkDxe/XenPvBlkDxe.c
@@ -295,14 +295,18 @@ XenPvBlkDxeDriverBindingStart (
     //    MdeModulePkg/Universal/Disk/PartitionDxe/ElTorito.c
     //
     Media->BlockSize = 2048;
-    Media->LastBlock = DivU64x32 (
-                         Dev->MediaInfo.Sectors,
-                         Media->BlockSize / Dev->MediaInfo.SectorSize
-                         ) - 1;
   } else {
     Media->BlockSize = Dev->MediaInfo.SectorSize;
-    Media->LastBlock = Dev->MediaInfo.Sectors - 1;
   }
+
+  //
+  // Sectors is express as 512B unit, size of disk is "Sectors * 512",
+  // independently from SectorSize.
+  //
+  Media->LastBlock = DivU64x32 (
+                       Dev->MediaInfo.Sectors,
+                       Media->BlockSize / 512
+                       ) - 1;
 
   ASSERT (Media->BlockSize % 512 == 0);
   Dev->BlockIo.Media = Media;


### PR DESCRIPTION
# Description

This is a follow-up on a clarification of the Xen blkif PV disk protocol, which has been committed as https://github.com/xen-project/xen/commit/221f2748e8dabe8361b8cdfcffbeab9102c4c899. The calculation of the disk size happen to be wrong when the backend is Linux.


- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Just a quick run in `osstest` (one of Xen's CI) to check for regression.

## Integration Instructions

N/A
