### PR TITLE
CryptoPkg: Add HMAC algorithms for signature/keymgmt

### DIFF
--- a/CryptoPkg/Library/OpensslLib/OpensslStub/uefiprov.c
+++ b/CryptoPkg/Library/OpensslLib/OpensslStub/uefiprov.c
@@ -193,6 +193,7 @@ static const OSSL_ALGORITHM deflt_signature[] = {
 #ifndef OPENSSL_NO_EC
     { PROV_NAMES_ECDSA, "provider=default", ossl_ecdsa_signature_functions },
 #endif
+    { PROV_NAMES_HMAC, "provider=default", ossl_mac_legacy_hmac_signature_functions },
 
     { NULL, NULL, NULL }
 };
@@ -222,6 +223,8 @@ static const OSSL_ALGORITHM deflt_keymgmt[] = {
       PROV_DESCS_TLS1_PRF_SIGN },
     { PROV_NAMES_HKDF, "provider=default", ossl_kdf_keymgmt_functions,
       PROV_DESCS_HKDF_SIGN },
+    { PROV_NAMES_HMAC, "provider=default", ossl_mac_legacy_keymgmt_functions,
+      PROV_DESCS_HMAC_SIGN },
 
     { NULL, NULL, NULL }
 };


### PR DESCRIPTION
# Description

Some parts and versions of TLS require HMAC. This adds the missing HMAC algorithms to the UEFI provider. One entry in the default signature algorithms and one in the key management algorithms.

Source of these entries is the default OpenSSL provider, defltprov.c, included in the OpenSSL library.

This change was required to connect to some TLS servers depending on the used ciphers.

The following ciphers were tested:

IANA Name - OpenSSL name
**TLS_RSA_WITH_AES_128_CBC_SHA256 - AES128-SHA256 -> Fails**
**TLS_RSA_WITH_AES_256_CBC_SHA256 - AES256-SHA256 -> Fails**
TLS_RSA_WITH_AES_128_GCM_SHA256 - AES128-GCM-SHA256 -> OK
**TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256 - ECDHE-RSA-AES128-SHA256 -> Fails**
**TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384 - ECDHE-RSA-AES256-SHA384 -> Fails**
TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 - ECDHE-RSA-AES128-GCM-SHA256 -> OK

When the connection fails, the following error message can be found in the debug output:
`
TlsDoHandshake SSL_HANDSHAKE_ERROR State=0x10 SSL_ERROR_SSL
TlsDoHandshake ERROR 0x308010C=L6:R8010C inner_evp_generic_fetch(): Global default library context, Algorithm (HMAC : 66), Properties (<null>)
TlsDoHandshake ERROR 0xA0C0103=L14:RC0103 tls1_change_cipher_state(): 
`

With this patch, HMAC will be supported and with this the ciphers using CBC are working.

- [ ] Breaking change
- [ ] Impacts security
- [ ] Includes tests

## How This Was Tested

This can be tested by creating a server certificate/key pair, installing the server certificate in the UEFI TLS store and creating a HTTPS boot entry to a _openssl s_server_. For example:
`
openssl s_server -accept 8080 -cert cert/httpsboot.crt -key cert/httpsbootkey.pem -tls1_2 -cipher AES256-SHA256 -www
`

This won't be enough for a successful boot but the TLS connection will fail before it can try to fetch any file via HTTP request.
The error message can then be found in the debug output.

## Integration Instructions

N/A
