### PR TITLE
Pytool: SpellCheck: Supporting dictionaries files

### DIFF
--- a/.pytool/Plugin/SpellCheck/Readme.md
+++ b/.pytool/Plugin/SpellCheck/Readme.md
@@ -19,6 +19,7 @@ The plugin has a few configuration options to support the UEFI codebase.
       "AuditOnly": False,          # If True, log all errors and then mark as skipped
       "IgnoreFiles": [],           # use gitignore syntax to ignore errors in matching files
       "ExtendWords": [],           # words to extend to the dictionary for this package
+      "ExtraDictionaries": []      # Extra dictionary files for lots of custom words
       "IgnoreStandardPaths": [],   # Standard Plugin defined paths that should be ignore
       "AdditionalIncludePaths": [] # Additional paths to spell check (wildcards supported)
   }
@@ -44,6 +45,17 @@ This supports .gitignore file and folder matching strings including wildcards
 
 This list allows words to be added to the dictionary for the spell checker when
 this package is tested.  These follow the rules of the cspell config words field.
+
+### ExtraDictionaries
+
+This list allows dictionary files to be added to the dictionary for the spell
+checker when this package is tested. Dictionary files contain one word per line.
+Dictionary paths interpreted from workspace root. All words in custom dictionary
+files are added to the cspell config words field for simplicity. Useful if you
+have a lot of custom words and allows integration with other cspell plugins
+(ex: vscode's Code Spell Checker plugin). Comments are not supported; if a word
+requires a comment it should be added to the `ExtendWords` config where comments
+can be added.
 
 ### IgnoreStandardPaths
 

--- a/.pytool/Plugin/SpellCheck/SpellCheck.py
+++ b/.pytool/Plugin/SpellCheck/SpellCheck.py
@@ -29,6 +29,7 @@ class SpellCheck(ICiBuildPlugin):
         "AuditOnly": False,          # Don't fail the build if there are errors.  Just log them
         "IgnoreFiles": [],           # use gitignore syntax to ignore errors in matching files
         "ExtendWords": [],           # words to extend to the dictionary for this package
+        "ExtraDictionaries": []      # Extra dictionary files for lots of custom words
         "IgnoreStandardPaths": [],   # Standard Plugin defined paths that should be ignore
         "AdditionalIncludePaths": [] # Additional paths to spell check (wildcards supported)
     }
@@ -148,6 +149,12 @@ class SpellCheck(ICiBuildPlugin):
 
         if("ExtendWords" in pkgconfig):
             config["words"].extend(pkgconfig["ExtendWords"])
+
+        if "ExtraDictionaries" in pkgconfig:
+            for path in pkgconfig["ExtraDictionaries"]:
+                with open(os.path.join(Edk2pathObj.WorkspacePath, path), 'r') as dictionary:
+                    config["words"].extend(dictionary.read().splitlines())
+
         with open(config_file_path, "w") as o:
             json.dump(config, o)  # output as json so compat with cspell
 


### PR DESCRIPTION
# Description

Added support for dictionary files to the `SpellCheck` plugin. This separates extra words from actual configuration, and allows for integration with other `cspell` plugins like vscode's Code Spell Checker plugin.


- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Ran `stuart_ci_build` on a platform with the words moved to a dictionary file. Compared the generated `cspell_actual_config.json` to a version generated before moving the words: contents matched.

## Integration Instructions

[Optional] In places where lots of words are in the `ExtendWords` config: move words to a dictionary file and add the workspace-relative path of the dictionary file to the `ExtraDictionaries` config.
