### PR TITLE
UniversalPayload: Add serial and graphic parse in pci-rb node which is non-compatible to 'pci-rb' property

### DIFF
--- a/UefiPayloadPkg/Library/FdtParserLib/FdtParserLib.c
+++ b/UefiPayloadPkg/Library/FdtParserLib/FdtParserLib.c
@@ -658,7 +658,26 @@ ParsePciRootBridge (
   UINTN               HobDataSize;
   UINT8               Base;
 
+  // Parse serial port and graphic device nodes if "pci-rb" node is not
+  // compatbile to "pci-rb" property type.
+  //
+  // With serial port and graphic device nodes parsed,  debug trace log
+  // can be enabled and graphic device can be worked as expected before
+  // UPL scan Host PCI Root Bridge.
   if (RootBridgeCount == 0) {
+    for (SubNode = FdtFirstSubnode (Fdt, Node); SubNode >= 0; SubNode = FdtNextSubnode (Fdt, SubNode)) {
+      NodePtr = (FDT_NODE_HEADER *)((CONST CHAR8 *)Fdt + SubNode + Fdt32ToCpu (((FDT_HEADER *)Fdt)->OffsetDtStruct));
+      DEBUG ((DEBUG_INFO, "\n      SubNode(%08X)  %a", SubNode, NodePtr->Name));
+
+      if (AsciiStrnCmp (NodePtr->Name, "serial@", AsciiStrLen ("serial@")) == 0) {
+        ParseSerialPort (Fdt, SubNode);
+      }
+
+      if (AsciiStrnCmp (NodePtr->Name, GmaStr, AsciiStrLen (GmaStr)) == 0) {
+        DEBUG ((DEBUG_INFO, "  Found gma@ node \n"));
+        ParsegraphicNode (Fdt, SubNode);
+      }
+    }
     return;
   }
 

--- a/UefiPayloadPkg/Library/FdtParserLib/FdtParserLib.c
+++ b/UefiPayloadPkg/Library/FdtParserLib/FdtParserLib.c
@@ -360,6 +360,21 @@ ParseFrameBuffer (
     } else if (AsciiStrCmp (TempStr, "height") == 0) {
       Data32                                        = (UINT32 *)(PropertyPtr->Data);
       GraphicsInfo->GraphicsMode.VerticalResolution = Fdt32ToCpu (*Data32);
+    } else if (AsciiStrCmp (TempStr, "redmask") == 0) {
+      Data32                                              = (UINT32 *)(PropertyPtr->Data);
+      GraphicsInfo->GraphicsMode.PixelInformation.RedMask = Fdt32ToCpu (*Data32);
+    } else if (AsciiStrCmp (TempStr, "greenmask") == 0) {
+      Data32                                                = (UINT32 *)(PropertyPtr->Data);
+      GraphicsInfo->GraphicsMode.PixelInformation.GreenMask = Fdt32ToCpu (*Data32);
+    } else if (AsciiStrCmp (TempStr, "bluemask") == 0) {
+      Data32                                               = (UINT32 *)(PropertyPtr->Data);
+      GraphicsInfo->GraphicsMode.PixelInformation.BlueMask = Fdt32ToCpu (*Data32);
+    } else if (AsciiStrCmp (TempStr, "reservedmask") == 0) {
+      Data32                                                   = (UINT32 *)(PropertyPtr->Data);
+      GraphicsInfo->GraphicsMode.PixelInformation.ReservedMask = Fdt32ToCpu (*Data32);
+    } else if (AsciiStrCmp (TempStr, "pixelsperscanline") == 0) {
+      Data32                                       = (UINT32 *)(PropertyPtr->Data);
+      GraphicsInfo->GraphicsMode.PixelsPerScanLine = Fdt32ToCpu (*Data32);
     } else if (AsciiStrCmp (TempStr, "format") == 0) {
       TempStr = (CHAR8 *)(PropertyPtr->Data);
       if (AsciiStrCmp (TempStr, "a8r8g8b8") == 0) {


### PR DESCRIPTION
# Description

Serial port and Graphic device nodes are sub nodes of PCI Root Bridge node, they will be parsed only when 'pci-rb'
node is compatible to 'pci-rb' type in current logic. Add support to parse both Serial device and Graphic device node
and utilize Host PCI Root Bridge scanning feature in pci-rb node which does not compatible to 'pci-rb' property type.

Also we need to parse more options for GOP to ensure framebuffer can be flashed to Graphic device correctly

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

Validated with x86 kernel with FB_EFI/DRM_BOCHS configurations enabled on top QEMU environment.

## Integration Instructions

N/A