### PR TITLE
MdePkg: Fix overflow issue in BasePeCoffLib: PeCoffLoaderRelocateImage

### DIFF
--- a/MdePkg/Library/BasePeCoffLib/BasePeCoff.c
+++ b/MdePkg/Library/BasePeCoffLib/BasePeCoff.c
@@ -1054,7 +1054,7 @@ PeCoffLoaderRelocateImage (
     RelocDir = &Hdr.Te->DataDirectory[0];
   }
 
-  if ((RelocDir != NULL) && (RelocDir->Size > 0)) {
+  if ((RelocDir != NULL) && (RelocDir->Size > 0) && (RelocDir->Size - 1 < MAX_UINT32 - RelocDir->VirtualAddress)) {
     RelocBase    = (EFI_IMAGE_BASE_RELOCATION *)PeCoffLoaderImageAddress (ImageContext, RelocDir->VirtualAddress, TeStrippedOffset);
     RelocBaseEnd = (EFI_IMAGE_BASE_RELOCATION *)PeCoffLoaderImageAddress (
                                                   ImageContext,


### PR DESCRIPTION
# Description

The RelocDir->Size is a UINT32 value, and RelocDir->VirtualAddress is also a UINT32 value. The current code does not check for overflow when adding RelocDir->Size to RelocDir->VirtualAddress. This patch adds a check to ensure that the addition does not overflow.

- [ ] Breaking change?
- [X] Impacts security?
- [ ] Includes tests?

## How This Was Tested

In BasePeCoff.c, the PeCoffLoaderRelocateImage() does RelocDir→VirtualAddress + ReloDir→Size- 1
inside the function was overflowing and causing memory corruption.
so added the below check for avoiding the memory corruption before calculating the RelocBase and RelocBaseEnd.
if ((RelocDir != NULL) && (RelocDir->Size > 0) && (RelocDir->Size -1 < MAX_UINT32 - RelocDir->VirtualAddress))

With this condition added the max value while adding size and address is always less than MAX_UINT32.
Hence there won’t be integer overflow with possible values for RelocDir->VirtualAddress and RelocDir->Size.

Have tested the fix in real platform and confirmed the image is booting fine.

## Integration Instructions

N/A
