### PR TITLE
.github/GitHub.py: Update bot in redundant comment check

### DIFF
--- a/.github/scripts/GitHub.py
+++ b/.github/scripts/GitHub.py
@@ -243,7 +243,7 @@ def add_reviewers_to_pr(
             # If a comment has already been made for these non-collaborators,
             # do not make another comment.
             if (
-                comment.user.login == "github-actions[bot]"
+                comment.user.login == "tianocore-assign-reviewers[bot]"
                 and "WARNING: Cannot add some reviewers" in comment.body
                 and all(u in comment.body for u in non_collaborators)
             ):


### PR DESCRIPTION
# Description

The project moved from using the `github-actions[bot]` bot account to the `tianocore-assign-reviewers[bot]` account. A check is in place to prevent the "`WARNING: Cannot add some reviewers`" from appearing more than once if nothing has changed in the content it would post.

This change updates the bot account to the current one so the check can work again.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

- Verify JSON dump for comment posted by the bot to verify text and account info.
  - Example: [PR 6247 comments](https://api.github.com/repos/tianocore/edk2/issues/6247/comments)

![image](https://github.com/user-attachments/assets/f6198736-09c1-4714-aae9-c302df5f647a)

## Integration Instructions

N/A