### PR TITLE
Restore XCODE5 build - further changes

### DIFF
--- a/ArmPkg/Library/DefaultExceptionHandlerLib/AArch64/DefaultExceptionHandler.c
+++ b/ArmPkg/Library/DefaultExceptionHandlerLib/AArch64/DefaultExceptionHandler.c
@@ -157,7 +157,6 @@ DescribeExceptionSyndrome (
   DEBUG ((DEBUG_ERROR, "\n %a \n", Message));
 }
 
-#ifndef MDEPKG_NDEBUG
 STATIC
 CONST CHAR8 *
 BaseName (
@@ -176,8 +175,6 @@ BaseName (
 
   return Str;
 }
-
-#endif
 
 /**
   This is the default action to take on an unexpected exception

--- a/MdePkg/Include/Library/DebugLib.h
+++ b/MdePkg/Include/Library/DebugLib.h
@@ -403,7 +403,12 @@ UnitTestDebugAssert (
       }                             \
     } while (FALSE)
 #else
-#define ASSERT(Expression)
+#define ASSERT(Expression)       \
+    do {                           \
+      if (FALSE) {                 \
+        (VOID) (Expression);       \
+      }                            \
+    } while (FALSE)
 #endif
 
 /**
@@ -426,7 +431,12 @@ UnitTestDebugAssert (
       }                            \
     } while (FALSE)
 #else
-#define DEBUG(Expression)
+#define DEBUG(Expression)        \
+    do {                           \
+      if (FALSE) {                 \
+        _DEBUGLIB_DEBUG (Expression);       \
+      }                            \
+    } while (FALSE)
 #endif
 
 /**
@@ -452,7 +462,12 @@ UnitTestDebugAssert (
       }                                                                                  \
     } while (FALSE)
 #else
-#define ASSERT_EFI_ERROR(StatusParameter)
+#define ASSERT_EFI_ERROR(StatusParameter)                                             \
+    do {                                                                                \
+      if (FALSE) {                                                                      \
+        (VOID) (StatusParameter);                                                       \
+      }                                                                                 \
+    } while (FALSE)
 #endif
 
 /**
@@ -479,7 +494,12 @@ UnitTestDebugAssert (
       }                                                                 \
     } while (FALSE)
 #else
-#define ASSERT_RETURN_ERROR(StatusParameter)
+#define ASSERT_RETURN_ERROR(StatusParameter)                          \
+    do {                                                                \
+      if (FALSE) {                                                      \
+        (VOID) (StatusParameter);                                       \
+      }                                                                 \
+    } while (FALSE)
 #endif
 
 /**

--- a/UefiCpuPkg/PiSmmCpuDxeSmm/NonMmramMapDxeSmm.c
+++ b/UefiCpuPkg/PiSmmCpuDxeSmm/NonMmramMapDxeSmm.c
@@ -634,7 +634,7 @@ CreateExtendedProtectionRange (
          &MemorySpaceMap
          );
   for (Index = 0; Index < NumberOfSpaceDescriptors; Index++) {
-    if ((MemorySpaceMap[Index].GcdMemoryType == EfiGcdMemoryTypeMemoryMappedIo)) {
+    if (MemorySpaceMap[Index].GcdMemoryType == EfiGcdMemoryTypeMemoryMappedIo) {
       if (ADDRESS_IS_ALIGNED (MemorySpaceMap[Index].BaseAddress, SIZE_4KB) &&
           (MemorySpaceMap[Index].Length % SIZE_4KB == 0))
       {


### PR DESCRIPTION
# Description

These changes are also required for successful XCODE5 RELEASE builds.

Apologies for not offering these together with https://github.com/tianocore/edk2/pull/6226 - I had intended those to be the complete set of XCODE5 fixes, at least for OvmfPkg, but manage to overlook some additional commits required for some builds.

I think the null macro changes here are somewhat 'better' in their own right (in addition to fixing XCODE5 build), in that they avoid occasional additional work-around code that is otherwise needed, as in the ArmPkg commit here.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

Builds and runs locally and in test CI on macOS; still builds and runs correctly on all platforms in existing CI.

## Integration Instructions

N/A
