### PR TITLE
BaseTools: Support XCODE5 in Edk2ToolsBuild.py

### DIFF
--- a/BaseTools/Edk2ToolsBuild.py
+++ b/BaseTools/Edk2ToolsBuild.py
@@ -1,7 +1,7 @@
 # @file Edk2ToolsBuild.py
 # Invocable class that builds the basetool c files.
 #
-# Supports VS2017, VS2019, and GCC5
+# Supports VS2017, VS2019, GCC5 and XCODE5
 ##
 # Copyright (c) Microsoft Corporation
 #
@@ -146,7 +146,7 @@ class Edk2ToolsBuild(BaseAbstractInvocable):
             self.WritePathEnvFile(self.OutputDir)
             return ret
 
-        elif self.tool_chain_tag.lower().startswith("gcc"):
+        elif self.tool_chain_tag.lower().startswith("gcc") or self.tool_chain_tag.lower().startswith("xcode"):
             cpu_count = self.GetCpuThreads()
 
             output_stream = edk2_logging.create_output_stream()


### PR DESCRIPTION
# Description

macOS (and in particular, pre-existing macOS build support in EDK 2) is similar enough to Linux that this simple change is enough to allow the command `python3 BaseTools/Edk2ToolsBuild.py -t XCODE5` to work correctly.

Further changes are needed for full macOS `stuart` build support, but this change is compatible with the other changes needed, and stands alone to get this step working.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

Running locally, and in test CI.

## Integration Instructions

N/A
