### PR TITLE
BaseTools/SetupGit.py: Fix invalid choice 'edk2-test'

### DIFF
--- a/BaseTools/Scripts/SetupGit.py
+++ b/BaseTools/Scripts/SetupGit.py
@@ -150,7 +150,7 @@ if __name__ == '__main__':
                         action='store_true',
                         required=False)
     PARSER.add_argument('-n', '--name', type=str, metavar='repo',
-                        choices=['edk2', 'edk2-platforms', 'edk2-non-osi'],
+                        choices=['edk2', 'edk2-platforms', 'edk2-non-osi', 'edk2-test'],
                         help='set the repo name to configure for, if not '
                              'detected automatically',
                         required=False)


### PR DESCRIPTION

# Description

This fixes missing 'edk2-test' in the choices of the repo name option.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Tested with running BaseTools/Scripts/SetupGit.py with the repo name edk2-test.

## Integration Instructions
