### PR TITLE
BaseTools/CodeQl: Give preference to Plugin settings

### DIFF
--- a/BaseTools/Plugin/CodeQL/CodeQlAnalyzePlugin.py
+++ b/BaseTools/Plugin/CodeQL/CodeQlAnalyzePlugin.py
@@ -3,6 +3,7 @@
 # A build plugin that analyzes a CodeQL database.
 #
 # Copyright (c) Microsoft Corporation. All rights reserved.
+# Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 ##
 
@@ -78,6 +79,11 @@ class CodeQlAnalyzePlugin(IUefiBuildPlugin):
         # Packages are allowed to specify package-specific query specifiers
         # in the package CI YAML file that override the global query specifier.
         audit_only = False
+        global_audit_only = builder.env.GetValue("STUART_CODEQL_AUDIT_ONLY")
+        if global_audit_only:
+            if global_audit_only.strip().lower() == "true":
+                audit_only = True
+
         query_specifiers = None
         package_config_file = Path(os.path.join(
                                 self.package_path, self.package + ".ci.yaml"))
@@ -93,11 +99,6 @@ class CodeQlAnalyzePlugin(IUefiBuildPlugin):
                         logging.debug(f"Loading CodeQL query specifiers in "
                                       f"{str(package_config_file)}")
                         query_specifiers = plugin_data["QuerySpecifiers"]
-
-        global_audit_only = builder.env.GetValue("STUART_CODEQL_AUDIT_ONLY")
-        if global_audit_only:
-            if global_audit_only.strip().lower() == "true":
-                audit_only = True
 
         if audit_only:
             logging.info(f"CodeQL Analyze plugin is in audit only mode for "


### PR DESCRIPTION
For the CodeQl `AuditOnly` flag,
prioritize Plugin settings over global settings.

This patch adjusts the logic for the global `AuditOnly` setting, placing it before the Plugin setting code.
This ensures that Plugin settings take precedence over global settings.

Cc: Sean Brogan <sean.brogan@microsoft.com>
Cc: Joey Vagedes <joey.vagedes@gmail.com>
Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>

# Description
This patch adjusts the logic for the global `AuditOnly` setting, placing it before the Plugin setting code.
This ensures that Plugin settings take precedence over global settings.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Tested with stuart_ci_build locally on AMD platforms.

## Integration Instructions
N/A
