### PR TITLE
CI: Use new Fedora-40 image for Linux jobs

### DIFF
--- a/.azurepipelines/templates/defaults.yml
+++ b/.azurepipelines/templates/defaults.yml
@@ -9,4 +9,4 @@
 
 variables:
   default_python_version: "3.12"
-  default_linux_image: "ghcr.io/tianocore/containers/fedora-37-test:a0dd931"
+  default_linux_image: "ghcr.io/tianocore/containers/fedora-40-test:c98ff99"

--- a/BaseTools/Plugin/HostBasedUnitTestRunner/HostBasedUnitTestRunner.py
+++ b/BaseTools/Plugin/HostBasedUnitTestRunner/HostBasedUnitTestRunner.py
@@ -156,7 +156,8 @@ class HostBasedUnitTestRunner(IUefiBuildPlugin):
             return 1
 
         # Coverage data for tested files only
-        ret = RunCmd("lcov", f"--capture --directory {buildOutputBase}/ --output-file {buildOutputBase}/coverage-test.info --rc lcov_branch_coverage=1")
+        # `--ignore-errors mismatch` needed to make lcov v2.0+/gcov work.
+        ret = RunCmd("lcov", f"--capture --directory {buildOutputBase}/ --output-file {buildOutputBase}/coverage-test.info --rc lcov_branch_coverage=1 --ignore-errors mismatch")
         if ret != 0:
             logging.error("UnitTest Coverage: Failed to build coverage data for tested files.")
             return 1


### PR DESCRIPTION
Switch the Linux CI jobs over to the latest Fedora 40 image.

