### PR TITLE
UefiPayloadPkg: fix output dir name generation in .dsc

### DIFF
--- a/UefiPayloadPkg/UefiPayloadPkg.dsc
+++ b/UefiPayloadPkg/UefiPayloadPkg.dsc
@@ -22,7 +22,7 @@
   SUPPORTED_ARCHITECTURES             = IA32|X64
   BUILD_TARGETS                       = DEBUG|RELEASE|NOOPT
   SKUID_IDENTIFIER                    = DEFAULT
-  OUTPUT_DIRECTORY                    = Build/UefiPayloadPkg$(BUILD_ARCH)
+  OUTPUT_DIRECTORY                    = Build/UefiPayloadPkg$(ARCH)
   FLASH_DEFINITION                    = UefiPayloadPkg/UefiPayloadPkg.fdf
   PCD_DYNAMIC_AS_DYNAMICEX            = TRUE
 


### PR DESCRIPTION
I can only assume this has only been tested in environments where for some reason BUILD_ARCH is set for reasons unrelated to the EDK2 build system. When attempting to build directly, I ended up with a directory 'UefiPayloadPkg$(BUILD_ARCH)' created and the build immediately failing.

Change the .dsc to use ARCH instead, which *is* set by the build system.

- [?] Breaking change?
I don't know the situation in which the existing setup *could* work, so I'm unsure whether this change affects any build-time behaviours there.