### PR TITLE
MdePkg: Improving readability of CVE patch for PeCoffLoaderRelocateImage

### DIFF
--- a/MdePkg/Library/BasePeCoffLib/BasePeCoff.c
+++ b/MdePkg/Library/BasePeCoffLib/BasePeCoff.c
@@ -1054,7 +1054,7 @@ PeCoffLoaderRelocateImage (
     RelocDir = &Hdr.Te->DataDirectory[0];
   }
 
-  if ((RelocDir != NULL) && (RelocDir->Size > 0) && (RelocDir->Size - 1 < MAX_UINT32 - RelocDir->VirtualAddress)) {
+  if ((RelocDir != NULL) && (RelocDir->Size > 0) && ((RelocDir->Size - 1) < (MAX_UINT32 - RelocDir->VirtualAddress))) {
     RelocBase    = (EFI_IMAGE_BASE_RELOCATION *)PeCoffLoaderImageAddress (ImageContext, RelocDir->VirtualAddress, TeStrippedOffset);
     RelocBaseEnd = (EFI_IMAGE_BASE_RELOCATION *)PeCoffLoaderImageAddress (
                                                   ImageContext,


### PR DESCRIPTION
This change adds parantheses to the if condition detecting overflow in the PeCoffLoaderRelocateImage function to improve readability.

Follow on change for:
    REF!: https://github.com/tianocore/edk2/pull/6249

- [ ] Breaking change?
  
- [ ] Impacts security?

- [ ] Includes tests?

## How This Was Tested

Booted Locally
