### PR TITLE
MdeModulePkg: Update USB descriptor information

### DIFF
--- a/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbBus.c
+++ b/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbBus.c
@@ -4,6 +4,7 @@
 
 Copyright (c) 2004 - 2018, Intel Corporation. All rights reserved.<BR>
 Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+Copyright (c) Microsoft Corporation.
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -878,6 +879,11 @@ UsbIoPortReset (
   }
 
   DEBUG ((DEBUG_INFO, "UsbIoPortReset: device is now ADDRESSED at %d\n", Dev->Address));
+
+  //
+  // Endpoint descriptor state needs to be updated following a reset.
+  //
+  UsbUpdateDescriptors (Dev);
 
   //
   // Reset the current active configure, after this device

--- a/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbDesc.c
+++ b/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbDesc.c
@@ -3,6 +3,7 @@
     Manage Usb Descriptor List
 
 Copyright (c) 2007 - 2018, Intel Corporation. All rights reserved.<BR>
+Copyright (c) Microsoft Corporation.
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -1008,4 +1009,26 @@ UsbIoClearFeature (
                     );
 
   return Status;
+}
+
+/**
+  Update the device's descriptor information.
+  @param  UsbDev                The Usb device.
+**/
+VOID
+UsbUpdateDescriptors (
+  IN USB_DEVICE  *UsbDev
+  )
+{
+  EFI_USB_CONFIG_DESCRIPTOR  *ConfDesc;
+  EFI_USB_DEVICE_DESCRIPTOR  DevDesc;
+  UINT8                      Index;
+
+  UsbCtrlGetDesc (UsbDev, USB_DESC_TYPE_DEVICE, 0, 0, &DevDesc, sizeof (EFI_USB_DEVICE_DESCRIPTOR));
+  for (Index = 0; Index < DevDesc.NumConfigurations; Index++) {
+    ConfDesc = UsbGetOneConfig (UsbDev, Index);
+    FreePool (ConfDesc);
+  }
+
+  return;
 }

--- a/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbDesc.h
+++ b/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbDesc.h
@@ -3,6 +3,7 @@
     Manage Usb Descriptor List
 
 Copyright (c) 2007 - 2014, Intel Corporation. All rights reserved.<BR>
+Copyright (c) Microsoft Corporation.
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -222,6 +223,15 @@ UsbIoClearFeature (
   IN  UINTN                Target,
   IN  UINT16               Feature,
   IN  UINT16               Index
+  );
+
+/**
+  Usb UsbIo interface to update descriptor information.
+  @param  UsbDev                The Usb device.
+**/
+VOID
+UsbUpdateDescriptors (
+  IN USB_DEVICE  *UsbDev
   );
 
 #endif


### PR DESCRIPTION
# Description

Add new function UsbUpdateDescriptors () which reads the current USB device configuration, and invoke that as part of UsbIoPortReset ()

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

Shipping in Microsoft firmware for last several years.

## Integration Instructions

N/A