### PR TITLE
MdeModulePkg: Change in the type of the Variable header structure

### DIFF
--- a/ArmPkg/ArmPkg.ci.yaml
+++ b/ArmPkg/ArmPkg.ci.yaml
@@ -24,7 +24,6 @@
         "IgnoreFiles": [
             "Library/ArmSoftFloatLib/berkeley-softfloat-3",
             "Library/ArmSoftFloatLib/ArmSoftFloatLib.c",
-            "Library/CompilerIntrinsicsLib",
             "Universal/Smbios/SmbiosMiscDxe"
         ]
     },

--- a/ArmPkg/Library/DefaultExceptionHandlerLib/AArch64/DefaultExceptionHandler.c
+++ b/ArmPkg/Library/DefaultExceptionHandlerLib/AArch64/DefaultExceptionHandler.c
@@ -157,7 +157,6 @@ DescribeExceptionSyndrome (
   DEBUG ((DEBUG_ERROR, "\n %a \n", Message));
 }
 
-#ifndef MDEPKG_NDEBUG
 STATIC
 CONST CHAR8 *
 BaseName (
@@ -176,8 +175,6 @@ BaseName (
 
   return Str;
 }
-
-#endif
 
 /**
   This is the default action to take on an unexpected exception

--- a/BaseTools/Conf/tools_def.template
+++ b/BaseTools/Conf/tools_def.template
@@ -2017,7 +2017,7 @@ DEFINE CLANGDWARF_X64_DLINK2_FLAGS        = -Wl,--defsym=PECOFF_HEADER_SIZE=0x22
 DEFINE CLANGDWARF_IA32_TARGET             = -target i686-pc-linux-gnu
 DEFINE CLANGDWARF_X64_TARGET              = -target x86_64-pc-linux-gnu
 
-DEFINE CLANGDWARF_WARNING_OVERRIDES    = -Wno-parentheses-equality -Wno-empty-body -Wno-unused-const-variable -Wno-varargs -Wno-unknown-warning-option -Wno-unused-but-set-variable -Wno-unused-const-variable -Wno-unaligned-access -Wno-unneeded-internal-declaration
+DEFINE CLANGDWARF_WARNING_OVERRIDES    = -Wno-parentheses-equality -Wno-empty-body -Wno-unused-const-variable -Wno-varargs -Wno-unknown-warning-option -Wno-unused-but-set-variable -Wno-unused-const-variable -Wno-unaligned-access
 DEFINE CLANGDWARF_ALL_CC_FLAGS         = DEF(GCC48_ALL_CC_FLAGS) DEF(CLANGDWARF_WARNING_OVERRIDES) -fno-stack-protector -mms-bitfields -Wno-address -Wno-shift-negative-value -Wno-unknown-pragmas -Wno-incompatible-library-redeclaration -fno-asynchronous-unwind-tables -mno-sse -mno-mmx -msoft-float -mno-implicit-float  -ftrap-function=undefined_behavior_has_been_optimized_away_by_clang -funsigned-char -fno-ms-extensions -Wno-null-dereference
 
 ###########################

--- a/BaseTools/Source/C/GenFw/Elf64Convert.c
+++ b/BaseTools/Source/C/GenFw/Elf64Convert.c
@@ -1482,9 +1482,18 @@ WriteSections64 (
               - (SecOffset - SecShdr->sh_addr));
             VerboseMsg ("Relocation:  0x%08X", *(UINT32 *)Targ);
             break;
+          case R_X86_64_REX_GOTPCRELX:
+            //
+            // This is a relaxable GOTPCREL relocation, and the linker may have
+            // applied this relaxation without updating the relocation type.
+            // In the position independent code model, only transformations
+            // from MOV to LEA are possible for REX-prefixed instructions.
+            //
+            if (Targ[-2] == 0x8d) { // LEA
+              break;
+            }
           case R_X86_64_GOTPCREL:
           case R_X86_64_GOTPCRELX:
-          case R_X86_64_REX_GOTPCRELX:
             VerboseMsg ("R_X86_64_GOTPCREL family");
             VerboseMsg ("Offset: 0x%08X, Addend: 0x%08X",
               (UINT32)(SecOffset + (Rel->r_offset - SecShdr->sh_addr)),

--- a/DynamicTablesPkg/Library/Acpi/Common/AcpiFadtLib/X64/X64FadtGenerator.c
+++ b/DynamicTablesPkg/Library/Acpi/Common/AcpiFadtLib/X64/X64FadtGenerator.c
@@ -244,8 +244,8 @@ FadtArchUpdate (
       ));
   } else {
     CopyMem (
-      &Fadt->XPm1aCntBlk,
-      &XpmBlockInfo->XPm1aCntBlk,
+      &Fadt->XPm1aEvtBlk,
+      &XpmBlockInfo->XPm1aEvtBlk,
       sizeof (EFI_ACPI_6_5_GENERIC_ADDRESS_STRUCTURE)
       );
     CopyMem (

--- a/DynamicTablesPkg/Library/Acpi/X64/AcpiWsmtLib/WsmtGenerator.c
+++ b/DynamicTablesPkg/Library/Acpi/X64/AcpiWsmtLib/WsmtGenerator.c
@@ -223,7 +223,7 @@ ACPI_TABLE_GENERATOR  WsmtGenerator = {
   // Minimum supported ACPI Table Revision
   EFI_WSMT_TABLE_REVISION,
   // Creator ID
-  TABLE_GENERATOR_CREATOR_ID_ARM,
+  TABLE_GENERATOR_CREATOR_ID,
   // Creator Revision
   WSMT_GENERATOR_REVISION,
   // Build Table function

--- a/EmbeddedPkg/EmbeddedPkg.dsc
+++ b/EmbeddedPkg/EmbeddedPkg.dsc
@@ -196,6 +196,7 @@
   gEmbeddedTokenSpaceGuid.PcdTimerPeriod|100000
 
 [BuildOptions]
+  RELEASE_*_*_CC_FLAGS  = -DMDEPKG_NDEBUG
   *_*_*_CC_FLAGS  = -DDISABLE_NEW_DEPRECATED_INTERFACES
 
 ################################################################################

--- a/EmbeddedPkg/Universal/MmcDxe/MmcDebug.c
+++ b/EmbeddedPkg/Universal/MmcDxe/MmcDebug.c
@@ -8,16 +8,14 @@
 
 #include "Mmc.h"
 
-#if !defined (MDEPKG_NDEBUG)
-CONST CHAR8  *mStrUnit[] = {
+STATIC CONST CHAR8  *mStrUnit[] = {
   "100kbit/s", "1Mbit/s", "10Mbit/s", "100MBit/s",
   "Unknown",   "Unknown", "Unknown",  "Unknown"
 };
-CONST CHAR8  *mStrValue[] = {
+STATIC CONST CHAR8  *mStrValue[] = {
   "1.0",     "1.2",     "1.3",     "1.5", "2.0", "2.5", "3.0", "3.5", "4.0", "4.5", "5.0",
   "Unknown", "Unknown", "Unknown", "Unknown"
 };
-#endif
 
 VOID
 PrintCID (

--- a/MdeModulePkg/Bus/Usb/UsbNetwork/UsbCdcEcm/UsbEcmFunction.c
+++ b/MdeModulePkg/Bus/Usb/UsbNetwork/UsbCdcEcm/UsbEcmFunction.c
@@ -111,7 +111,7 @@ GetFunctionalDescriptor (
 
   for (Offset = 0; NextDescriptor (Config, &Offset);) {
     Interface = (EFI_USB_INTERFACE_DESCRIPTOR *)((UINT8 *)Config + Offset);
-    if (Interface->DescriptorType == CS_INTERFACE) {
+    if (Interface->DescriptorType == USB_DESC_TYPE_CS_INTERFACE) {
       if (((USB_HEADER_FUN_DESCRIPTOR *)Interface)->DescriptorSubtype == FunDescriptorType) {
         switch (FunDescriptorType) {
           case HEADER_FUN_DESCRIPTOR:

--- a/MdeModulePkg/Bus/Usb/UsbNetwork/UsbCdcNcm/UsbNcmFunction.c
+++ b/MdeModulePkg/Bus/Usb/UsbNetwork/UsbCdcNcm/UsbNcmFunction.c
@@ -111,7 +111,7 @@ GetFunctionalDescriptor (
 
   for (Offset = 0; NextDescriptor (Config, &Offset);) {
     Interface = (EFI_USB_INTERFACE_DESCRIPTOR *)((UINT8 *)Config + Offset);
-    if (Interface->DescriptorType == CS_INTERFACE) {
+    if (Interface->DescriptorType == USB_DESC_TYPE_CS_INTERFACE) {
       if (((USB_HEADER_FUN_DESCRIPTOR *)Interface)->DescriptorSubtype == FunDescriptorType) {
         switch (FunDescriptorType) {
           case HEADER_FUN_DESCRIPTOR:

--- a/MdeModulePkg/Bus/Usb/UsbNetwork/UsbRndis/UsbRndisFunction.c
+++ b/MdeModulePkg/Bus/Usb/UsbNetwork/UsbRndis/UsbRndisFunction.c
@@ -123,7 +123,7 @@ GetFunctionalDescriptor (
 
   for (Offset = 0; NextDescriptor (Config, &Offset);) {
     Interface = (EFI_USB_INTERFACE_DESCRIPTOR *)((UINT8 *)Config + Offset);
-    if (Interface->DescriptorType == CS_INTERFACE) {
+    if (Interface->DescriptorType == USB_DESC_TYPE_CS_INTERFACE) {
       if (((USB_HEADER_FUN_DESCRIPTOR *)Interface)->DescriptorSubtype == FunDescriptorType) {
         switch (FunDescriptorType) {
           case HEADER_FUN_DESCRIPTOR:

--- a/MdeModulePkg/Include/Protocol/UsbEthernetProtocol.h
+++ b/MdeModulePkg/Include/Protocol/UsbEthernetProtocol.h
@@ -28,10 +28,6 @@ typedef struct _EDKII_USB_ETHERNET_PROTOCOL EDKII_USB_ETHERNET_PROTOCOL;
 #define USB_RNDIS_SUBCLASS           0x04
 #define USB_RNDIS_ETHERNET_PROTOCOL  0x01
 
-// Type Values for the DescriptorType Field
-#define CS_INTERFACE  0x24
-#define CS_ENDPOINT   0x25
-
 // Descriptor SubType in Functional Descriptors
 #define HEADER_FUN_DESCRIPTOR    0x00
 #define UNION_FUN_DESCRIPTOR     0x06

--- a/MdeModulePkg/Universal/HiiDatabaseDxe/Database.c
+++ b/MdeModulePkg/Universal/HiiDatabaseDxe/Database.c
@@ -574,6 +574,45 @@ IsEfiVarStoreQuestion (
 
   @return Pointer to the matched variable header or NULL if not found.
 **/
+AUTHENTICATED_VARIABLE_HEADER *
+AuthFindVariableData (
+  IN  VARIABLE_STORE_HEADER  *VariableStorage,
+  IN  EFI_GUID               *VarGuid,
+  IN  UINT32                 VarAttribute,
+  IN  CHAR16                 *VarName
+  )
+{
+  AUTHENTICATED_VARIABLE_HEADER  *VariableHeader;
+  AUTHENTICATED_VARIABLE_HEADER  *VariableEnd;
+
+  VariableEnd    = (AUTHENTICATED_VARIABLE_HEADER *)((UINT8 *)VariableStorage + VariableStorage->Size);
+  VariableHeader = (AUTHENTICATED_VARIABLE_HEADER *)(VariableStorage + 1);
+  VariableHeader = (AUTHENTICATED_VARIABLE_HEADER *)HEADER_ALIGN (VariableHeader);
+  while (VariableHeader < VariableEnd) {
+    if (CompareGuid (&VariableHeader->VendorGuid, VarGuid) &&
+        (VariableHeader->Attributes == VarAttribute) &&
+        (StrCmp (VarName, (CHAR16 *)(VariableHeader + 1)) == 0))
+    {
+      return VariableHeader;
+    }
+
+    VariableHeader = (AUTHENTICATED_VARIABLE_HEADER *)((UINT8 *)VariableHeader + sizeof (AUTHENTICATED_VARIABLE_HEADER) + VariableHeader->NameSize + VariableHeader->DataSize);
+    VariableHeader = (AUTHENTICATED_VARIABLE_HEADER *)HEADER_ALIGN (VariableHeader);
+  }
+
+  return NULL;
+}
+
+/**
+  Find the matched variable from the input variable storage.
+
+  @param[in] VariableStorage Point to the variable storage header.
+  @param[in] VarGuid         A unique identifier for the variable.
+  @param[in] VarAttribute    The attributes bitmask for the variable.
+  @param[in] VarName         A Null-terminated ascii string that is the name of the variable.
+
+  @return Pointer to the matched variable header or NULL if not found.
+**/
 VARIABLE_HEADER *
 FindVariableData (
   IN  VARIABLE_STORE_HEADER  *VariableStorage,
@@ -626,25 +665,27 @@ FindQuestionDefaultSetting (
   IN  BOOLEAN                  BitFieldQuestion
   )
 {
-  VARIABLE_HEADER          *VariableHeader;
-  VARIABLE_STORE_HEADER    *VariableStorage;
-  LIST_ENTRY               *Link;
-  VARSTORAGE_DEFAULT_DATA  *Entry;
-  VARIABLE_STORE_HEADER    *NvStoreBuffer;
-  UINT8                    *DataBuffer;
-  UINT8                    *BufferEnd;
-  BOOLEAN                  IsFound;
-  UINTN                    Index;
-  UINT32                   BufferValue;
-  UINT32                   BitFieldVal;
-  UINTN                    BitOffset;
-  UINTN                    ByteOffset;
-  UINTN                    BitWidth;
-  UINTN                    StartBit;
-  UINTN                    EndBit;
-  PCD_DEFAULT_DATA         *DataHeader;
-  PCD_DEFAULT_INFO         *DefaultInfo;
-  PCD_DATA_DELTA           *DeltaData;
+  AUTHENTICATED_VARIABLE_HEADER  *AuthVariableHeader;
+  VARIABLE_HEADER                *VariableHeader;
+  VARIABLE_STORE_HEADER          *VariableStorage;
+  LIST_ENTRY                     *Link;
+  VARSTORAGE_DEFAULT_DATA        *Entry;
+  VARIABLE_STORE_HEADER          *NvStoreBuffer;
+  UINT8                          *DataBuffer;
+  UINT8                          *BufferEnd;
+  BOOLEAN                        IsFound;
+  UINTN                          Index;
+  UINT32                         BufferValue;
+  UINT32                         BitFieldVal;
+  UINTN                          BitOffset;
+  UINTN                          ByteOffset;
+  UINTN                          BitWidth;
+  UINTN                          StartBit;
+  UINTN                          EndBit;
+  PCD_DEFAULT_DATA               *DataHeader;
+  PCD_DEFAULT_INFO               *DefaultInfo;
+  PCD_DATA_DELTA                 *DeltaData;
+  BOOLEAN                        VarCheck;
 
   if (gSkuId == 0xFFFFFFFFFFFFFFFF) {
     gSkuId = LibPcdGetSku ();
@@ -750,40 +791,81 @@ FindQuestionDefaultSetting (
     return EFI_NOT_FOUND;
   }
 
-  //
-  // Find the question default value from the variable storage
-  //
-  VariableHeader = FindVariableData (VariableStorage, &EfiVarStore->Guid, EfiVarStore->Attributes, (CHAR16 *)EfiVarStore->Name);
-  if (VariableHeader == NULL) {
-    return EFI_NOT_FOUND;
-  }
+  VarCheck = (BOOLEAN)(CompareGuid (&VariableStorage->Signature, &gEfiAuthenticatedVariableGuid));
 
-  StartBit   = 0;
-  EndBit     = 0;
-  ByteOffset = IfrQuestionHdr->VarStoreInfo.VarOffset;
-  if (BitFieldQuestion) {
-    BitOffset  = IfrQuestionHdr->VarStoreInfo.VarOffset;
-    ByteOffset = BitOffset / 8;
-    BitWidth   = Width;
-    StartBit   = BitOffset % 8;
-    EndBit     = StartBit + BitWidth - 1;
-    Width      = EndBit / 8 + 1;
-  }
+  if (VarCheck == 1) {
+    //
+    // Find the question default value from the variable storage
+    //
+    AuthVariableHeader = AuthFindVariableData (VariableStorage, &EfiVarStore->Guid, EfiVarStore->Attributes, (CHAR16 *)EfiVarStore->Name);
+    if (AuthVariableHeader == NULL) {
+      return EFI_NOT_FOUND;
+    }
 
-  if (VariableHeader->DataSize < ByteOffset + Width) {
-    return EFI_INVALID_PARAMETER;
-  }
-
-  //
-  // Copy the question value
-  //
-  if (ValueBuffer != NULL) {
+    StartBit   = 0;
+    EndBit     = 0;
+    ByteOffset = IfrQuestionHdr->VarStoreInfo.VarOffset;
     if (BitFieldQuestion) {
-      CopyMem (&BufferValue, (UINT8 *)VariableHeader + sizeof (VARIABLE_HEADER) + VariableHeader->NameSize + ByteOffset, Width);
-      BitFieldVal = BitFieldRead32 (BufferValue, StartBit, EndBit);
-      CopyMem (ValueBuffer, &BitFieldVal, Width);
-    } else {
-      CopyMem (ValueBuffer, (UINT8 *)VariableHeader + sizeof (VARIABLE_HEADER) + VariableHeader->NameSize + IfrQuestionHdr->VarStoreInfo.VarOffset, Width);
+      BitOffset  = IfrQuestionHdr->VarStoreInfo.VarOffset;
+      ByteOffset = BitOffset / 8;
+      BitWidth   = Width;
+      StartBit   = BitOffset % 8;
+      EndBit     = StartBit + BitWidth - 1;
+      Width      = EndBit / 8 + 1;
+    }
+
+    if (AuthVariableHeader->DataSize < ByteOffset + Width) {
+      return EFI_INVALID_PARAMETER;
+    }
+
+    //
+    // Copy the question value
+    //
+    if (ValueBuffer != NULL) {
+      if (BitFieldQuestion) {
+        CopyMem (&BufferValue, (UINT8 *)AuthVariableHeader + sizeof (AUTHENTICATED_VARIABLE_HEADER) + AuthVariableHeader->NameSize + ByteOffset, Width);
+        BitFieldVal = BitFieldRead32 (BufferValue, StartBit, EndBit);
+        CopyMem (ValueBuffer, &BitFieldVal, Width);
+      } else {
+        CopyMem (ValueBuffer, (UINT8 *)AuthVariableHeader + sizeof (AUTHENTICATED_VARIABLE_HEADER) + AuthVariableHeader->NameSize + IfrQuestionHdr->VarStoreInfo.VarOffset, Width);
+      }
+    }
+  } else {
+    //
+    // Find the question default value from the variable storage
+    //
+    VariableHeader = FindVariableData (VariableStorage, &EfiVarStore->Guid, EfiVarStore->Attributes, (CHAR16 *)EfiVarStore->Name);
+    if (VariableHeader == NULL) {
+      return EFI_NOT_FOUND;
+    }
+
+    StartBit   = 0;
+    EndBit     = 0;
+    ByteOffset = IfrQuestionHdr->VarStoreInfo.VarOffset;
+    if (BitFieldQuestion) {
+      BitOffset  = IfrQuestionHdr->VarStoreInfo.VarOffset;
+      ByteOffset = BitOffset / 8;
+      BitWidth   = Width;
+      StartBit   = BitOffset % 8;
+      EndBit     = StartBit + BitWidth - 1;
+      Width      = EndBit / 8 + 1;
+    }
+
+    if (VariableHeader->DataSize < ByteOffset + Width) {
+      return EFI_INVALID_PARAMETER;
+    }
+
+    //
+    // Copy the question value
+    //
+    if (ValueBuffer != NULL) {
+      if (BitFieldQuestion) {
+        CopyMem (&BufferValue, (UINT8 *)VariableHeader + sizeof (VARIABLE_HEADER) + VariableHeader->NameSize + ByteOffset, Width);
+        BitFieldVal = BitFieldRead32 (BufferValue, StartBit, EndBit);
+        CopyMem (ValueBuffer, &BitFieldVal, Width);
+      } else {
+        CopyMem (ValueBuffer, (UINT8 *)VariableHeader + sizeof (VARIABLE_HEADER) + VariableHeader->NameSize + IfrQuestionHdr->VarStoreInfo.VarOffset, Width);
+      }
     }
   }
 

--- a/MdeModulePkg/Universal/HiiDatabaseDxe/HiiDatabaseDxe.inf
+++ b/MdeModulePkg/Universal/HiiDatabaseDxe/HiiDatabaseDxe.inf
@@ -86,6 +86,7 @@
   gEfiHiiImageDecoderNameJpegGuid |gEfiMdeModulePkgTokenSpaceGuid.PcdSupportHiiImageProtocol  ## SOMETIMES_CONSUMES ## GUID
   gEfiHiiImageDecoderNamePngGuid  |gEfiMdeModulePkgTokenSpaceGuid.PcdSupportHiiImageProtocol  ## SOMETIMES_CONSUMES ## GUID
   gEdkiiIfrBitVarstoreGuid                                                                    ## SOMETIMES_CONSUMES ## GUID
+  gEfiAuthenticatedVariableGuid                                                               ## CONSUMES ## GUID
 
 [Depex]
   TRUE

--- a/MdePkg/Include/Guid/Cper.h
+++ b/MdePkg/Include/Guid/Cper.h
@@ -1211,34 +1211,34 @@ typedef struct {
 ///
 /// CXL Cachemem Event Log Valid bits
 ///@{
-#define CXL_CACHMEM_AGENT_TYPE      BIT0  // CXL Agent Type field is valid
-#define CXL_CACHMEM_AGENT_ADDRESS   BIT1  // CXL Agent Address field is valid
-#define CXL_CACHMEM_DEVICE_ID       BIT2  // Device ID field is valid
-#define CXL_CACHMEM_DEVICE_SER_NUM  BIT3  // Device Serial Number field is valid
-#define CXL_CACHMEM_CAP_STRUCT      BIT4  // Capability structure field is valid
-#define CXL_CACHMEM_DVSEC           BIT5  // CXL DVSET field is valid
-#define CXL_CACHMEM_ERROR_LOG       BIT6  // CXL Error Log field is valid
+#define EFI_CXL_CACHMEM_AGENT_TYPE      BIT0  // CXL Agent Type field is valid
+#define EFI_CXL_CACHMEM_AGENT_ADDRESS   BIT1  // CXL Agent Address field is valid
+#define EFI_CXL_CACHMEM_DEVICE_ID       BIT2  // Device ID field is valid
+#define EFI_CXL_CACHMEM_DEVICE_SER_NUM  BIT3  // Device Serial Number field is valid
+#define EFI_CXL_CACHMEM_CAP_STRUCT      BIT4  // Capability structure field is valid
+#define EFI_CXL_CACHMEM_DVSEC           BIT5  // CXL DVSET field is valid
+#define EFI_CXL_CACHMEM_ERROR_LOG       BIT6  // CXL Error Log field is valid
 ///@}
 
 //
 // CXL Agent Types
 ///@{
-#define CXL_AGENT_CXL11_DEV          0    // CXL 1.1 Device
-#define CXL_AGENT_CXL11_DSP          1    // CXL 1.1 Downstream Port
-#define CXL_AGENT_CXL20_DEV          2    // CXL 2.0 Device
-#define CXL_AGENT_CXL20_LOGICAL_DEV  3    // CXL 2.0 Logical Device
-#define CXL_AGENT_CXL20_FMLD         4    // CXL 2.0 Fabric Manager managed Logical device
-#define CXL_AGENT_CXL20_RP           5    // CXL 2.0 Root Port
-#define CXL_AGENT_CXL20_DSP          6    // CXL 2.0 Downstream Switch Port
-#define CXL_AGENT_CXL20_USP          7    // CXL 2.0 Upstream Switch Port
+#define EFI_CXL_AGENT_CXL11_DEV          0    // CXL 1.1 Device
+#define EFI_CXL_AGENT_CXL11_DSP          1    // CXL 1.1 Downstream Port
+#define EFI_CXL_AGENT_CXL20_DEV          2    // CXL 2.0 Device
+#define EFI_CXL_AGENT_CXL20_LOGICAL_DEV  3    // CXL 2.0 Logical Device
+#define EFI_CXL_AGENT_CXL20_FMLD         4    // CXL 2.0 Fabric Manager managed Logical device
+#define EFI_CXL_AGENT_CXL20_RP           5    // CXL 2.0 Root Port
+#define EFI_CXL_AGENT_CXL20_DSP          6    // CXL 2.0 Downstream Switch Port
+#define EFI_CXL_AGENT_CXL20_USP          7    // CXL 2.0 Upstream Switch Port
 ///@}
 
 //
 // CXL Mem Event Log Valid bits
 ///@{
-#define CXL_MEM_DEVICE_ID       BIT0  // Device ID field is valid
-#define CXL_MEM_DEVICE_SER_NUM  BIT1  // Device Serial Number field is valid
-#define CXL_MEM_COMP_ERROR_LOG  BIT2  // CXL Component Error Log field is valid
+#define EFI_CXL_MEM_DEVICE_ID       BIT0  // Device ID field is valid
+#define EFI_CXL_MEM_DEVICE_SER_NUM  BIT1  // Device Serial Number field is valid
+#define EFI_CXL_MEM_COMP_ERROR_LOG  BIT2  // CXL Component Error Log field is valid
 ///@}
 
 //
@@ -1256,12 +1256,12 @@ typedef union {
     UINT32    Low;
     UINT32    High;
   } RcrbBase;
-} CXL_AGENT_ADDRESS;
+} EFI_CXL_AGENT_ADDRESS;
 
 //
 // CXL Device ID
 //
-typedef struct _CXL_AGENT_DEVICE_ID {
+typedef struct {
   UINT16    VendorId;
   UINT16    DeviceId;
   UINT16    Svid;
@@ -1272,15 +1272,15 @@ typedef struct _CXL_AGENT_DEVICE_ID {
     UINT16    Num  : 13;
   } Slot;
   UINT32    Rsvd;
-} CXL_AGENT_DEVICE_ID;
+} EFI_CXL_AGENT_DEVICE_ID;
 
 //
 // CXL Device Serial Number
 //
-typedef struct _CXL_DEVICE_SERIAL_NUM {
+typedef struct {
   UINT32    Lower;
   UINT32    Upper;
-} CXL_DEVICE_SERIAL_NUM;
+} EFI_CXL_DEVICE_SERIAL_NUM;
 
 //
 // PCIe device identifiers of CXL Component
@@ -1294,17 +1294,17 @@ typedef struct {
   UINT16                        Segment;
   EFI_GENERIC_ERROR_PCI_SLOT    Slot;
   UINT8                         Resvd;
-} CXL_ERROR_PCIE_DEV_ID;
+} EFI_CXL_ERROR_PCIE_DEV_ID;
 
 //
 // CXL Component Events Section
 //
-typedef struct _CXL_COMPONENT_EVENT_LOG {
+typedef struct {
   UINT32                   Length;
   UINT64                   ValidFields;
   CXL_ERROR_PCIE_DEV_ID    CxlDeviceId;
   UINT64                   DeviceSerialNo;
-} CXL_COMPONENT_EVENT_LOG;
+} EFI_CXL_COMPONENT_EVENT_LOG;
 
 #pragma pack()
 

--- a/MdePkg/Include/Guid/Cper.h
+++ b/MdePkg/Include/Guid/Cper.h
@@ -1300,10 +1300,10 @@ typedef struct {
 // CXL Component Events Section
 //
 typedef struct {
-  UINT32                   Length;
-  UINT64                   ValidFields;
-  CXL_ERROR_PCIE_DEV_ID    CxlDeviceId;
-  UINT64                   DeviceSerialNo;
+  UINT32                       Length;
+  UINT64                       ValidFields;
+  EFI_CXL_ERROR_PCIE_DEV_ID    CxlDeviceId;
+  UINT64                       DeviceSerialNo;
 } EFI_CXL_COMPONENT_EVENT_LOG;
 
 #pragma pack()

--- a/MdePkg/Include/IndustryStandard/SmBios.h
+++ b/MdePkg/Include/IndustryStandard/SmBios.h
@@ -706,6 +706,7 @@ typedef enum {
   ProcessorFamilyIntelCoreI5                     = 0xCD,
   ProcessorFamilyIntelCoreI3                     = 0xCE,
   ProcessorFamilyIntelCoreI9                     = 0xCF,
+  ProcessorFamilyIntelXeonD                      = 0xD0,  /// Smbios spec 3.8 updated this value
   ProcessorFamilyViaC7M                          = 0xD2,
   ProcessorFamilyViaC7D                          = 0xD3,
   ProcessorFamilyViaC7                           = 0xD4,

--- a/MdePkg/Include/Library/DebugLib.h
+++ b/MdePkg/Include/Library/DebugLib.h
@@ -8,6 +8,13 @@
   of size reduction when compiler optimization is disabled. If MDEPKG_NDEBUG is
   defined, then debug and assert related macros wrapped by it are the NULL implementations.
 
+  The implementations of the macros used when MDEPKG_NDEBUG is defined rely on the fact that
+  directly unreachable code is pruned, even with compiler optimization disabled (which has
+  been confirmed by generated code size tests on supported compilers). The advantage of
+  implementations which consume their arguments within directly unreachable code is that
+  compilers understand this, and stop warning about variables which would become unused when
+  MDEPKG_NDEBUG is defined if the macros had completely empty definitions.
+
 Copyright (c) 2006 - 2020, Intel Corporation. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -403,7 +410,12 @@ UnitTestDebugAssert (
       }                             \
     } while (FALSE)
 #else
-#define ASSERT(Expression)
+#define ASSERT(Expression)       \
+    do {                           \
+      if (FALSE) {                 \
+        (VOID) (Expression);       \
+      }                            \
+    } while (FALSE)
 #endif
 
 /**
@@ -426,7 +438,12 @@ UnitTestDebugAssert (
       }                            \
     } while (FALSE)
 #else
-#define DEBUG(Expression)
+#define DEBUG(Expression)        \
+    do {                           \
+      if (FALSE) {                 \
+        _DEBUGLIB_DEBUG (Expression);       \
+      }                            \
+    } while (FALSE)
 #endif
 
 /**
@@ -452,7 +469,12 @@ UnitTestDebugAssert (
       }                                                                                  \
     } while (FALSE)
 #else
-#define ASSERT_EFI_ERROR(StatusParameter)
+#define ASSERT_EFI_ERROR(StatusParameter)                                             \
+    do {                                                                                \
+      if (FALSE) {                                                                      \
+        (VOID) (StatusParameter);                                                       \
+      }                                                                                 \
+    } while (FALSE)
 #endif
 
 /**
@@ -479,7 +501,12 @@ UnitTestDebugAssert (
       }                                                                 \
     } while (FALSE)
 #else
-#define ASSERT_RETURN_ERROR(StatusParameter)
+#define ASSERT_RETURN_ERROR(StatusParameter)                          \
+    do {                                                                \
+      if (FALSE) {                                                      \
+        (VOID) (StatusParameter);                                       \
+      }                                                                 \
+    } while (FALSE)
 #endif
 
 /**

--- a/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/PrintInfo.c
+++ b/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/PrintInfo.c
@@ -2423,6 +2423,10 @@ DisplayProcessorFamily (
       Print (L"Intel Core i9 processor\n");
       break;
 
+    case 0xD0:
+      Print (L"Intel Xeon D Processor\n");
+      break;
+
     case 0xD2:
       Print (L"ViaC7M\n");
       break;

--- a/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/PrintInfo.c
+++ b/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/PrintInfo.c
@@ -520,11 +520,11 @@ SmbiosPrintStructure (
         ShellPrintEx (-1, -1, L"Thread Count 2: %u\n", Struct->Type4->ThreadCount2);
       }
 
-      if (AE_SMBIOS_VERSION (0x3, 0x6) && (Struct->Hdr->Length > 0x2E)) {
+      if (AE_SMBIOS_VERSION (0x3, 0x6) && (Struct->Hdr->Length > 0x30)) {
         ShellPrintEx (-1, -1, L"Thread Enabled: %u\n", Struct->Type4->ThreadEnabled);
       }
 
-      if (AE_SMBIOS_VERSION (0x3, 0x8) && (Struct->Hdr->Length > 0x30)) {
+      if (AE_SMBIOS_VERSION (0x3, 0x8) && (Struct->Hdr->Length > 0x32)) {
         ShellPrintEx (-1, -1, L"Socket Type: %a\n", LibGetSmbiosString (Struct, Struct->Type4->SocketType));
       }
 


### PR DESCRIPTION
REF:https://bugzilla.tianocore.org/show_bug.cgi?id=4857

The change involves replacing the VARIABLE_HEADER structure with the AUTHENTICATED_VARIABLE_HEADER structure.

# Description
Bios Setup knobs not able to retain the Sku specific default configuration values after pressing the Load Defaults hot key from the Bios Setup page.
The Header format of the NVvariables generated from the HiiPcd are all in AUTHENTICATED_HEADER format.
So FindVariableData function from HiiDatabaseDxe driver which searches for those  variables was still using the old un-authenticted header format to search for the data. Hence was not able to find the correct data.


## How This Was Tested

Local Build and Boot test

## Integration Instructions

N/A
