### PR TITLE
UnitTestFrameworkPkg: UnitTestLib: Support Failure Strings of 512 Chars

### DIFF
--- a/UnitTestFrameworkPkg/Library/UnitTestLib/Assert.c
+++ b/UnitTestFrameworkPkg/Library/UnitTestLib/Assert.c
@@ -33,7 +33,7 @@ AddUnitTestFailure (
   UnitTest->FailureType = FailureType;
   AsciiStrCpyS (
     &UnitTest->FailureMessage[0],
-    UNIT_TEST_TESTFAILUREMSG_LENGTH,
+    UNIT_TEST_MAX_STRING_LENGTH,
     FailureMessage
     );
 
@@ -50,7 +50,7 @@ UnitTestLogFailure (
   )
 {
   UNIT_TEST_FRAMEWORK_HANDLE  FrameworkHandle;
-  CHAR8                       LogString[UNIT_TEST_TESTFAILUREMSG_LENGTH];
+  CHAR8                       LogString[UNIT_TEST_MAX_STRING_LENGTH];
   VA_LIST                     Marker;
 
   //

--- a/UnitTestFrameworkPkg/Library/UnitTestLib/Log.c
+++ b/UnitTestFrameworkPkg/Library/UnitTestLib/Log.c
@@ -15,8 +15,7 @@
 #include <Library/PrintLib.h>
 #include <Library/PcdLib.h>
 
-#define UNIT_TEST_MAX_SINGLE_LOG_STRING_LENGTH  (512)
-#define UNIT_TEST_MAX_LOG_BUFFER                SIZE_16KB
+#define UNIT_TEST_MAX_LOG_BUFFER  SIZE_16KB
 
 struct _UNIT_TEST_LOG_PREFIX_STRING {
   UNIT_TEST_STATUS    LogLevel;
@@ -85,7 +84,7 @@ AddStringToUnitTestLog (
              UnitTest->Log,
              UNIT_TEST_MAX_LOG_BUFFER / sizeof (CHAR8),
              String,
-             UNIT_TEST_MAX_SINGLE_LOG_STRING_LENGTH
+             UNIT_TEST_MAX_STRING_LENGTH
              );
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "Failed to add unit test log string.  Status = %r\n", Status));
@@ -160,8 +159,8 @@ UnitTestLog (
   )
 {
   UNIT_TEST_FRAMEWORK_HANDLE  FrameworkHandle;
-  CHAR8                       NewFormatString[UNIT_TEST_MAX_SINGLE_LOG_STRING_LENGTH];
-  CHAR8                       LogString[UNIT_TEST_MAX_SINGLE_LOG_STRING_LENGTH];
+  CHAR8                       NewFormatString[UNIT_TEST_MAX_STRING_LENGTH];
+  CHAR8                       LogString[UNIT_TEST_MAX_STRING_LENGTH];
   CONST CHAR8                 *LogTypePrefix;
   VA_LIST                     Marker;
 

--- a/UnitTestFrameworkPkg/Library/UnitTestLib/UnitTestLib.c
+++ b/UnitTestFrameworkPkg/Library/UnitTestLib/UnitTestLib.c
@@ -571,9 +571,9 @@ UpdateTestFromSave (
     Test->FailureType = MatchingTest->FailureType;
     AsciiStrnCpyS (
       &Test->FailureMessage[0],
-      UNIT_TEST_TESTFAILUREMSG_LENGTH,
+      UNIT_TEST_MAX_STRING_LENGTH,
       &MatchingTest->FailureMessage[0],
-      UNIT_TEST_TESTFAILUREMSG_LENGTH
+      UNIT_TEST_MAX_STRING_LENGTH
       );
 
     //
@@ -748,7 +748,7 @@ SerializeState (
       //
       TestSaveData->Result      = UnitTest->Result;
       TestSaveData->FailureType = UnitTest->FailureType;
-      AsciiStrnCpyS (&TestSaveData->FailureMessage[0], UNIT_TEST_TESTFAILUREMSG_LENGTH, &UnitTest->FailureMessage[0], UNIT_TEST_TESTFAILUREMSG_LENGTH);
+      AsciiStrnCpyS (&TestSaveData->FailureMessage[0], UNIT_TEST_MAX_STRING_LENGTH, &UnitTest->FailureMessage[0], UNIT_TEST_MAX_STRING_LENGTH);
 
       //
       // If there is a log, save the log.

--- a/UnitTestFrameworkPkg/PrivateInclude/UnitTestFrameworkTypes.h
+++ b/UnitTestFrameworkPkg/PrivateInclude/UnitTestFrameworkTypes.h
@@ -15,7 +15,7 @@
 ///
 /// The maximum length of a string stored in the unit test framework
 ///
-#define UNIT_TEST_MAX_STRING_LENGTH  (120)
+#define UNIT_TEST_MAX_STRING_LENGTH  (512)
 
 ///
 /// The size of a firngerprint used to save/resume execution of a unit test
@@ -23,12 +23,6 @@
 ///
 ///
 #define UNIT_TEST_FINGERPRINT_SIZE  (sizeof (UINT32))
-
-///
-/// The maximum length of a test failure message stored in the unit test
-/// framework
-///
-#define UNIT_TEST_TESTFAILUREMSG_LENGTH  (120)
 
 ///
 /// FAILURE_TYPE used to record the type of assert that was triggered by a unit
@@ -54,7 +48,7 @@ typedef struct {
   CHAR8                     *Name; // can't have spaces and should be short
   CHAR8                     *Log;
   FAILURE_TYPE              FailureType;
-  CHAR8                     FailureMessage[UNIT_TEST_TESTFAILUREMSG_LENGTH];
+  CHAR8                     FailureMessage[UNIT_TEST_MAX_STRING_LENGTH];
   UINT8                     Fingerprint[UNIT_TEST_FINGERPRINT_SIZE];
   UNIT_TEST_STATUS          Result;
   UNIT_TEST_FUNCTION        RunTest;
@@ -117,7 +111,7 @@ typedef struct {
 typedef struct {
   UINT32              Size;                                       // Size of the UNIT_TEST_SAVE_TEST including Log[]
   UINT8               Fingerprint[UNIT_TEST_FINGERPRINT_SIZE];    // Fingerprint of the test itself.
-  CHAR8               FailureMessage[UNIT_TEST_TESTFAILUREMSG_LENGTH];
+  CHAR8               FailureMessage[UNIT_TEST_MAX_STRING_LENGTH];
   FAILURE_TYPE        FailureType;
   UNIT_TEST_STATUS    Result;
   CHAR8               Log[];


### PR DESCRIPTION
# Description

Currently, there is a mismatch of allowed string sizes in UnitTestLib. The UT_LOG_* macros allow a string size of 512, but failure messages are constrained to 120 characters and some other string lengths are similarly constrained. 120 characters is too few for some longer error messages, particularly the ones that print out the path to the failing line. This can result in the actual error not getting printed in the log.

This patch updates all UnitTestLib allowed string lengths to be 512 characters.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Tested by running successful and failing unit tests and confirming all output is given in the log. Previously truncated failure messages now print completely.

## Integration Instructions

N/A.
