### PR TITLE
.pytool/UncrustifyCheck: Add a in-place option

### DIFF
--- a/.pytool/Plugin/UncrustifyCheck/Readme.md
+++ b/.pytool/Plugin/UncrustifyCheck/Readme.md
@@ -104,6 +104,23 @@ plugin execution.
 By default, files in paths matched in a .gitignore file or a recognized git submodule are excluded. If this option
 is `True`, the plugin will not attempt to recognize these files and exclude them.
 
+### `UNCRUSTIFY_IN_PLACE=TRUE`
+
+This command supports any uncrustify changes to be made in-place to the files in the workspace. This is useful for
+formatting any failing code before submitting a PR. Since this is an option for a local developer to use that would
+modify their files, it must be explicitly specified as a CLI argument or set as an environment variable.
+
+_NOTE:_ This is _not_ an option in the config `yaml`. It is an option passed directly into the tool based on local
+        developer need.
+
+#### Example Usage
+
+In this example, Uncrustify would format files in `UefiCpuPkg` without running any other plugins or building any code.
+
+```bash
+stuart_ci_build -c .pytool/CISettings.py -p UefiCpuPkg -t NO-TARGET UNCRUSTIFY_IN_PLACE=TRUE --disable-all UncrustifyCheck=run
+```
+
 ## High-Level Plugin Operation
 
 This plugin generates two main sets of temporary files:

--- a/.pytool/Plugin/UncrustifyCheck/UncrustifyCheck.py
+++ b/.pytool/Plugin/UncrustifyCheck/UncrustifyCheck.py
@@ -153,6 +153,7 @@ class UncrustifyCheck(ICiBuildPlugin):
         """
         try:
             # Initialize plugin and check pre-requisites.
+            self._env = environment_config
             self._initialize_environment_info(
                 package_rel_path, edk2_path, package_config, tc)
             self._initialize_configuration()
@@ -270,9 +271,17 @@ class UncrustifyCheck(ICiBuildPlugin):
         Executes Uncrustify with the initialized configuration.
         """
         output = StringIO()
+        params = ['-c', self._app_config_file]
+        params += ['-F', self._app_input_file_path]
+        params += ['--if-changed']
+        if self._env.GetValue("UNCRUSTIFY_IN_PLACE", "FALSE") == "TRUE":
+            params += ['--replace', '--no-backup']
+        else:
+            params += ['--suffix', UncrustifyCheck.FORMATTED_FILE_EXTENSION]
         self._app_exit_code = RunCmd(
             self._app_path,
-            f"-c {self._app_config_file} -F {self._app_input_file_path} --if-changed --suffix {UncrustifyCheck.FORMATTED_FILE_EXTENSION}", outstream=output)
+            " ".join(params),
+            outstream=output)
         self._app_output = output.getvalue().strip().splitlines()
 
     def _get_files_ignored_in_config(self):


### PR DESCRIPTION
# Description

To simplify automatic formatting of new code, this feature lets a local developer specify the `UNCRUSTIFY_IN_PLACE=TRUE` parameter on the command line to automatically format files.

This is particularly useful when a large amount of new code needs to be formatted in batch.

See the readme for more details.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

- Uncrustify execution with and without the new option enabled

## Integration Instructions

- Use the new option if useful for a local development scenario