### PR TITLE
FatPkg: Fix potentially uninitialized variable

### DIFF
--- a/FatPkg/EnhancedFatDxe/Info.c
+++ b/FatPkg/EnhancedFatDxe/Info.c
@@ -303,6 +303,8 @@ FatSetFileInfo (
   UINT8          NewAttribute;
   BOOLEAN        ReadOnly;
 
+  TempDirEnt = NULL;
+
   ZeroMem (&ZeroTime, sizeof (EFI_TIME));
   Parent = OFile->Parent;
   DirEnt = OFile->DirEnt;

--- a/FatPkg/FatPei/FatLiteApi.c
+++ b/FatPkg/FatPei/FatLiteApi.c
@@ -426,6 +426,8 @@ GetRecoveryCapsuleInfo (
   PEI_FILE_HANDLE       Handle;
   UINTN                 NumberRecoveryCapsules;
 
+  Handle = NULL;
+
   Status = GetNumberRecoveryCapsules (PeiServices, This, &NumberRecoveryCapsules);
 
   if (EFI_ERROR (Status)) {
@@ -550,6 +552,8 @@ LoadRecoveryCapsule (
   UINTN                 RecoveryCapsuleCount;
   PEI_FILE_HANDLE       Handle;
   UINTN                 NumberRecoveryCapsules;
+
+  Handle = NULL;
 
   Status = GetNumberRecoveryCapsules (PeiServices, This, &NumberRecoveryCapsules);
 


### PR DESCRIPTION
# Description

REF:https://bugzilla.tianocore.org/show_bug.cgi?id=1559

Initializes the variable to prevent an uninitialized variable
warning in Visual Studio with C4701 enabled.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

- FatPkg build with VS2017, VS2019, VS2022, GCC

## Integration Instructions

N/A