### PR TITLE
FmpDevicePkg/FmpDependencyLib: Fix potential overflow in loop

### DIFF
--- a/FmpDevicePkg/Library/FmpDependencyLib/FmpDependencyLib.c
+++ b/FmpDevicePkg/Library/FmpDependencyLib/FmpDependencyLib.c
@@ -228,7 +228,7 @@ EvaluateDependency (
 {
   EFI_STATUS     Status;
   UINT8          *Iterator;
-  UINT8          Index;
+  UINTN          Index;
   DEPEX_ELEMENT  Element1;
   DEPEX_ELEMENT  Element2;
   GUID           ImageTypeId;


### PR DESCRIPTION
# Description

FmpVersionsCount is a UINTN while the loop index variable compared against it is a UINT8. This can lead to an overflow of the loop index for FmpVersionsCount values larger than UINT8_MAX. This change makes Index a UINTN to match in width.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

- FmpDevicePkg build and CI
- CodeQL against FmpDevicePkg

## Integration Instructions

N/A