### PR TITLE
ShellPkg/AcpiView: RAS2 Parser - check validity of PCC Count

### DIFF
--- a/ShellPkg/Library/UefiShellAcpiViewCommandLib/Parsers/Ras2/Ras2Parser.c
+++ b/ShellPkg/Library/UefiShellAcpiViewCommandLib/Parsers/Ras2/Ras2Parser.c
@@ -83,7 +83,9 @@ ParseAcpiRas2 (
   IN UINT8    AcpiTableRevision
   )
 {
-  UINT32  Offset;
+  UINT32        Offset;
+  UINT16        Count = 0;
+  CONST CHAR16  *Message;
 
   if (!Trace) {
     return;
@@ -111,5 +113,18 @@ ParseAcpiRas2 (
       sizeof (EFI_ACPI_RAS2_PCC_DESCRIPTOR)
       );
     Offset += sizeof (EFI_ACPI_RAS2_PCC_DESCRIPTOR);
+    Count++;
   } // while
+
+  // Check counts match and print error if not
+  if (Count != *Ras2PccDescriptors) {
+    Message = Count > *Ras2PccDescriptors ? L"many" : L"few";
+    IncrementWarningCount ();
+    Print (
+      L"\nWARNING: Too %s descriptors provided (advertised %d, provided %d)",
+      Message,
+      *Ras2PccDescriptors,
+      Count
+      );
+  }
 }


### PR DESCRIPTION
This checks the number of PCC descriptor entries provided match the count set in the table, and if they don't indicate and error and what it is.

# Description

As per review and reply comment https://github.com/tianocore/edk2/pull/6269#issuecomment-2387969394 - This now checks and reports errors when PCC Count does not match the number of Descriptor entries.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

Compile and run an edk2 and a modified edk2-platforms firmware build against an FVP emulation. Modify edk2-platforms to add a RAS2 entry into a test platform. Use this result and once booted to an UEFI shell, run acpivew to see that it correctly displays the RAS2 and reports errors manually introduced into the platform code to test with.

## Integration Instructions

N/A