### PR TITLE
DynamicTablesPkg: AmlLib: Fix CodeQL Issue

### DIFF
--- a/DynamicTablesPkg/Library/Common/AmlLib/AmlEncoding/Aml.c
+++ b/DynamicTablesPkg/Library/Common/AmlLib/AmlEncoding/Aml.c
@@ -774,7 +774,7 @@ AmlSetPkgLength (
   // Write to the Buffer.
   *Buffer       = LeadByte;
   CurrentOffset = 1;
-  while (CurrentOffset < (Offset + 1)) {
+  while (CurrentOffset < (Offset + (UINT8)1)) {
     CurrentShift              = (UINT8)((CurrentOffset - 1) * 8);
     ComputedLength            = Length & (UINT32)(0x00000FF0 << CurrentShift);
     ComputedLength            = (ComputedLength) >> (4 + CurrentShift);


### PR DESCRIPTION
# Description

Without the addition of this cast, the compiler promotes 1 to a UINT32, which leads CodeQL to complain that different size types are being compared.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Running CodeQL, shipping in platforms.

## Integration Instructions

N/A.