### PR TITLE
Snp fixes

### DIFF
--- a/OvmfPkg/EmuVariableFvbRuntimeDxe/Fvb.c
+++ b/OvmfPkg/EmuVariableFvbRuntimeDxe/Fvb.c
@@ -692,6 +692,8 @@ InitializeFvAndVariableStoreHeaders (
   //
   Fv           = (EFI_FIRMWARE_VOLUME_HEADER *)Ptr;
   Fv->Checksum = CalculateCheckSum16 (Ptr, Fv->HeaderLength);
+
+  DEBUG ((DEBUG_INFO, "EMU Variable FVB: Initialized FV using template structure\n"));
 }
 
 /**

--- a/OvmfPkg/Library/PlatformInitLib/Platform.c
+++ b/OvmfPkg/Library/PlatformInitLib/Platform.c
@@ -34,6 +34,7 @@
 #include <Guid/VariableFormat.h>
 #include <OvmfPlatforms.h>
 #include <Library/TdxLib.h>
+#include <Library/MemEncryptSevLib.h>
 
 #include <Library/PlatformInitLib.h>
 
@@ -774,6 +775,8 @@ PlatformValidateNvVarStore (
   EFI_FIRMWARE_VOLUME_HEADER     *NvVarStoreFvHeader;
   VARIABLE_STORE_HEADER          *NvVarStoreHeader;
   AUTHENTICATED_VARIABLE_HEADER  *VariableHeader;
+  BOOLEAN                        Retry;
+  EFI_STATUS                     Status;
 
   static EFI_GUID  FvHdrGUID       = EFI_SYSTEM_NV_DATA_FV_GUID;
   static EFI_GUID  VarStoreHdrGUID = EFI_AUTHENTICATED_VARIABLE_GUID;
@@ -792,6 +795,15 @@ PlatformValidateNvVarStore (
   //
   NvVarStoreFvHeader = (EFI_FIRMWARE_VOLUME_HEADER *)NvVarStoreBase;
 
+  //
+  // SEV and SEV-ES can use separate flash devices for OVMF code and
+  // OVMF variables. In this case, the OVMF variables will need to be
+  // mapped unencrypted. If the initial validation fails, remap the
+  // NV variable store as unencrypted and retry the validation.
+  //
+  Retry = MemEncryptSevIsEnabled ();
+
+RETRY:
   if ((!IsZeroBuffer (NvVarStoreFvHeader->ZeroVector, 16)) ||
       (!CompareGuid (&FvHdrGUID, &NvVarStoreFvHeader->FileSystemGuid)) ||
       (NvVarStoreFvHeader->Signature != EFI_FVH_SIGNATURE) ||
@@ -801,8 +813,24 @@ PlatformValidateNvVarStore (
       (NvVarStoreFvHeader->FvLength != NvVarStoreSize)
       )
   {
-    DEBUG ((DEBUG_ERROR, "NvVarStore FV headers were invalid.\n"));
-    return FALSE;
+    if (!Retry) {
+      DEBUG ((DEBUG_ERROR, "NvVarStore FV headers were invalid.\n"));
+      return FALSE;
+    }
+
+    DEBUG ((DEBUG_INFO, "Remapping NvVarStore as shared\n"));
+    Status = MemEncryptSevClearMmioPageEncMask (
+               0,
+               (UINTN)NvVarStoreBase,
+               EFI_SIZE_TO_PAGES (NvVarStoreSize)
+               );
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "Failed to map NvVarStore as shared\n"));
+      return FALSE;
+    }
+
+    Retry = FALSE;
+    goto RETRY;
   }
 
   //

--- a/OvmfPkg/Library/PlatformInitLib/PlatformInitLib.inf
+++ b/OvmfPkg/Library/PlatformInitLib/PlatformInitLib.inf
@@ -48,6 +48,7 @@
   HobLib
   QemuFwCfgLib
   QemuFwCfgSimpleParserLib
+  MemEncryptSevLib
   MemoryAllocationLib
   MtrrLib
   PcdLib

--- a/OvmfPkg/PlatformPei/Platform.c
+++ b/OvmfPkg/PlatformPei/Platform.c
@@ -353,10 +353,6 @@ InitializePlatform (
   InitializeRamRegions (PlatformInfoHob);
 
   if (PlatformInfoHob->BootMode != BOOT_ON_S3_RESUME) {
-    if (!PlatformInfoHob->SmmSmramRequire) {
-      ReserveEmuVariableNvStore ();
-    }
-
     PeiFvInitialization (PlatformInfoHob);
     MemTypeInfoInitialization (PlatformInfoHob);
     MemMapInitialization (PlatformInfoHob);
@@ -376,6 +372,16 @@ InitializePlatform (
   InstallFeatureControlCallback (PlatformInfoHob);
   if (PlatformInfoHob->SmmSmramRequire) {
     RelocateSmBase ();
+  }
+
+  //
+  // Performed after CoCo (SEV/TDX) initialization to allow the memory
+  // used to be validated before being used.
+  //
+  if (PlatformInfoHob->BootMode != BOOT_ON_S3_RESUME) {
+    if (!PlatformInfoHob->SmmSmramRequire) {
+      ReserveEmuVariableNvStore ();
+    }
   }
 
   return EFI_SUCCESS;

--- a/OvmfPkg/QemuFlashFvbServicesRuntimeDxe/QemuFlash.c
+++ b/OvmfPkg/QemuFlashFvbServicesRuntimeDxe/QemuFlash.c
@@ -259,6 +259,14 @@ QemuFlashInitialize (
   VOID
   )
 {
+  //
+  // The SNP model does not provide for QEMU flash device support, so exit
+  // early before attempting to initialize any QEMU flash device support.
+  //
+  if (MemEncryptSevSnpIsEnabled ()) {
+    return EFI_UNSUPPORTED;
+  }
+
   mFlashBase   = (UINT8 *)(UINTN)PcdGet32 (PcdOvmfFdBaseAddress);
   mFdBlockSize = PcdGet32 (PcdOvmfFirmwareBlockSize);
   ASSERT (PcdGet32 (PcdOvmfFirmwareFdSize) % mFdBlockSize == 0);


### PR DESCRIPTION
# Description

This pull request fixes problems related to SEV and the EFI variable store.

Patch 1:
Current SEV and SEV-ES guests run with flash devices, Qemu -drive if=pflash,... option, as the source for EFI code and variables. However, SEV-SNP does not use flash drives, instead running with the Qemu -bios option. As a result, the Qemu flash driver support should not be loaded under SEV-SNP. Fix this by not attempting to detect flash when running under SEV-SNP.

Patch 2:
When OVMF is built with SECURE_BOOT_ENABLE=TRUE, OVMF attempts to reserve and initialize memory for the EFI NV variable store during the PEI phase. However, this is done before SEV-SNP has had a chance to accept memory. Fix this by moving the call to ReserveEmuVariableNvStore() to after SEV-SNP initialization. Additionally, this is moved to after TDX initialization, too, but I am unable to test if that is an issue.

Patch 3:
When OVMF is build with SECURE_BOOT_ENABLE=TRUE, OVMF attempts to reserved and initialize memory for the EFI NV variable store during the PEI phase. For an SEV or SEV-ES, a flash device holds the EFI variable store. If this is the case, then accesses to the device need to be done unencrypted. PlatformValidateNvVarStore() validates the EFI variable store using an encrypted mapping. If this validation fails (because the flash device holds the variable store) then an ASSERT() is issued. Fix this issue by attempting a re-validation of the EFI variable store after changing the mapping to unencrypted. This fixes bugzilla 4379.

Patch 4:
Issue a message when the emulated variable store is initialized using the template structure.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Booted legacy, SEV, SEV-ES and SEV-SNP guests in multiple flash (or non-flash for SEV-SNP) configurations.

## Integration Instructions

N/A
