### PR TITLE
ArmPkg: ArmMmuLib: Pre-Allocate Page Table Memory

### DIFF
--- a/ArmPkg/ArmPkg.dec
+++ b/ArmPkg/ArmPkg.dec
@@ -116,6 +116,10 @@
   ## ArmPkg/Include/Protocol/ArmScmiPerformanceProtocol.h
   gArmScmiPerformanceProtocolGuid = { 0x9b8ba84, 0x3dd3, 0x49a6, { 0xa0, 0x5a, 0x31, 0x34, 0xa5, 0xf0, 0x7b, 0xad } }
 
+  ## Arm Page Table Memory Allocation Protocol
+  ## ArmPkg/Include/Protocol/ArmPageTableMemoryAllocation.h
+  gArmPageTableMemoryAllocationProtocolGuid = { 0x623be44e, 0x506d, 0x487f, {0xa3, 0xa6, 0x92, 0xda, 0xef, 0x30, 0x2c, 0x70 } }
+
 [Ppis]
   ## Include/Ppi/ArmMpCoreInfo.h
   gArmMpCoreInfoPpiGuid = { 0x6847cc74, 0xe9ec, 0x4f8f, {0xa2, 0x9d, 0xab, 0x44, 0xe7, 0x54, 0xa8, 0xfc} }
@@ -134,11 +138,6 @@
 
   # Define if the GICv3 controller should use the GICv2 legacy
   gArmTokenSpaceGuid.PcdArmGicV3WithV2Legacy|FALSE|BOOLEAN|0x00000042
-
-  # Whether to remap all unused memory NX before installing the CPU arch
-  # protocol driver. This is needed on platforms that map all DRAM with RWX
-  # attributes initially, and can be disabled otherwise.
-  gArmTokenSpaceGuid.PcdRemapUnusedMemoryNx|TRUE|BOOLEAN|0x00000048
 
 [PcdsFeatureFlag.ARM]
   # Whether to map normal memory as non-shareable. FALSE is the safe choice, but

--- a/ArmPkg/ArmPkg.dsc
+++ b/ArmPkg/ArmPkg.dsc
@@ -94,6 +94,7 @@
 [LibraryClasses.common.SEC]
   # ARM platforms have SEC modules with standard entry points, so we can generically link StackCheckLib
   NULL|MdePkg/Library/StackCheckLibNull/StackCheckLibNull.inf
+  ArmMmuLib|ArmPkg/Library/ArmMmuLib/ArmMmuSecLib.inf
 
 [LibraryClasses.common.PEIM]
   HobLib|MdePkg/Library/PeiHobLib/PeiHobLib.inf
@@ -101,6 +102,7 @@
   MemoryAllocationLib|MdePkg/Library/PeiMemoryAllocationLib/PeiMemoryAllocationLib.inf
   PeiServicesLib|MdePkg/Library/PeiServicesLib/PeiServicesLib.inf
   PeiServicesTablePointerLib|MdePkg/Library/PeiServicesTablePointerLib/PeiServicesTablePointerLib.inf
+  ArmMmuLib|ArmPkg/Library/ArmMmuLib/ArmMmuPeiLib.inf
 
 [Components.common]
   ArmPkg/Library/ArmCacheMaintenanceLib/ArmCacheMaintenanceLib.inf
@@ -162,6 +164,7 @@
   ArmPkg/Drivers/ArmPsciMpServicesDxe/ArmPsciMpServicesDxe.inf
   ArmPkg/Drivers/MmCommunicationDxe/MmCommunication.inf
   ArmPkg/Library/ArmMmuLib/ArmMmuPeiLib.inf
+  ArmPkg/Library/ArmMmuLib/ArmMmuSecLib.inf
 
 [Components.AARCH64, Components.ARM]
   ArmPkg/Library/StandaloneMmMmuLib/ArmMmuStandaloneMmLib.inf

--- a/ArmPkg/Drivers/CpuDxe/CpuDxe.c
+++ b/ArmPkg/Drivers/CpuDxe/CpuDxe.c
@@ -229,77 +229,6 @@ InitializeDma (
   CpuArchProtocol->DmaBufferAlignment = ArmCacheWritebackGranule ();
 }
 
-/**
-  Map all EfiConventionalMemory regions in the memory map with NX
-  attributes so that allocating or freeing EfiBootServicesData regions
-  does not result in changes to memory permission attributes.
-
-**/
-STATIC
-VOID
-RemapUnusedMemoryNx (
-  VOID
-  )
-{
-  UINT64                 TestBit;
-  UINTN                  MemoryMapSize;
-  UINTN                  MapKey;
-  UINTN                  DescriptorSize;
-  UINT32                 DescriptorVersion;
-  EFI_MEMORY_DESCRIPTOR  *MemoryMap;
-  EFI_MEMORY_DESCRIPTOR  *MemoryMapEntry;
-  EFI_MEMORY_DESCRIPTOR  *MemoryMapEnd;
-  EFI_STATUS             Status;
-
-  TestBit = LShiftU64 (1, EfiBootServicesData);
-  if ((PcdGet64 (PcdDxeNxMemoryProtectionPolicy) & TestBit) == 0) {
-    return;
-  }
-
-  MemoryMapSize = 0;
-  MemoryMap     = NULL;
-
-  Status = gBS->GetMemoryMap (
-                  &MemoryMapSize,
-                  MemoryMap,
-                  &MapKey,
-                  &DescriptorSize,
-                  &DescriptorVersion
-                  );
-  ASSERT (Status == EFI_BUFFER_TOO_SMALL);
-  do {
-    MemoryMap = (EFI_MEMORY_DESCRIPTOR *)AllocatePool (MemoryMapSize);
-    ASSERT (MemoryMap != NULL);
-    Status = gBS->GetMemoryMap (
-                    &MemoryMapSize,
-                    MemoryMap,
-                    &MapKey,
-                    &DescriptorSize,
-                    &DescriptorVersion
-                    );
-    if (EFI_ERROR (Status)) {
-      FreePool (MemoryMap);
-    }
-  } while (Status == EFI_BUFFER_TOO_SMALL);
-
-  ASSERT_EFI_ERROR (Status);
-
-  MemoryMapEntry = MemoryMap;
-  MemoryMapEnd   = (EFI_MEMORY_DESCRIPTOR *)((UINT8 *)MemoryMap + MemoryMapSize);
-  while ((UINTN)MemoryMapEntry < (UINTN)MemoryMapEnd) {
-    if (MemoryMapEntry->Type == EfiConventionalMemory) {
-      ArmSetMemoryAttributes (
-        MemoryMapEntry->PhysicalStart,
-        EFI_PAGES_TO_SIZE (MemoryMapEntry->NumberOfPages),
-        EFI_MEMORY_XP,
-        EFI_MEMORY_XP
-        );
-    }
-
-    MemoryMapEntry = NEXT_MEMORY_DESCRIPTOR (MemoryMapEntry, DescriptorSize);
-  }
-}
-
 EFI_STATUS
 CpuDxeInitialize (
   IN EFI_HANDLE        ImageHandle,
@@ -313,18 +242,10 @@ CpuDxeInitialize (
 
   InitializeDma (&mCpu);
 
-  //
-  // Once we install the CPU arch protocol, the DXE core's memory
-  // protection routines will invoke them to manage the permissions of page
-  // allocations as they are created. Given that this includes pages
-  // allocated for page tables by this driver, we must ensure that unused
-  // memory is mapped with the same permissions as boot services data
-  // regions. Otherwise, we may end up with unbounded recursion, due to the
-  // fact that updating permissions on a newly allocated page table may trigger
-  // a block entry split, which triggers a page table allocation, etc etc
-  //
-  if (FeaturePcdGet (PcdRemapUnusedMemoryNx)) {
-    RemapUnusedMemoryNx ();
+  Status = InitializePageTableMemory (ImageHandle);
+  if (EFI_ERROR (Status)) {
+    ASSERT (FALSE);
+    return Status;
   }
 
   Status = gBS->InstallMultipleProtocolInterfaces (
@@ -335,6 +256,11 @@ CpuDxeInitialize (
                   &mMemoryAttribute,
                   NULL
                   );
+
+  if (EFI_ERROR (Status)) {
+    ASSERT (FALSE);
+    return Status;
+  }
 
   //
   // Make sure GCD and MMU settings match. This API calls gDS->SetMemorySpaceAttributes ()

--- a/ArmPkg/Drivers/CpuDxe/CpuDxe.h
+++ b/ArmPkg/Drivers/CpuDxe/CpuDxe.h
@@ -31,6 +31,7 @@
 #include <Protocol/DebugSupport.h>
 #include <Protocol/LoadedImage.h>
 #include <Protocol/MemoryAttribute.h>
+#include <Protocol/ArmPageTableMemoryAllocation.h>
 
 extern BOOLEAN  mIsFlushingGCD;
 
@@ -141,6 +142,21 @@ SetGcdMemorySpaceAttributes (
 UINT64
 RegionAttributeToGcdAttribute (
   IN UINTN  PageAttributes
+  );
+
+/**
+  Initialize the page table memory pool and produce the page table memory allocation
+  protocol.
+
+  @param[in] ImageHandle  Handle on which to install the protocol.
+
+  @retval EFI_SUCCESS           The page table pool was initialized and protocol produced.
+  @retval Others                The driver returned an error while initializing.
+**/
+EFI_STATUS
+EFIAPI
+InitializePageTableMemory (
+  IN EFI_HANDLE  ImageHandle
   );
 
 #endif // CPU_DXE_H_

--- a/ArmPkg/Drivers/CpuDxe/CpuDxe.inf
+++ b/ArmPkg/Drivers/CpuDxe/CpuDxe.inf
@@ -24,6 +24,7 @@
   CpuMmuCommon.c
   Exception.c
   MemoryAttribute.c
+  PageTableMemoryAllocation.c
 
 [Sources.ARM]
   Arm/Mmu.c
@@ -40,6 +41,7 @@
 [LibraryClasses]
   ArmLib
   ArmMmuLib
+  BaseLib
   BaseMemoryLib
   CacheMaintenanceLib
   CpuLib
@@ -56,6 +58,7 @@
 [Protocols]
   gEfiCpuArchProtocolGuid
   gEfiMemoryAttributeProtocolGuid
+  gArmPageTableMemoryAllocationProtocolGuid
 
 [Guids]
   gEfiDebugImageInfoTableGuid
@@ -69,7 +72,6 @@
 
 [FeaturePcd.common]
   gArmTokenSpaceGuid.PcdDebuggerExceptionSupport
-  gArmTokenSpaceGuid.PcdRemapUnusedMemoryNx
 
 [Depex]
   gHardwareInterruptProtocolGuid OR gHardwareInterrupt2ProtocolGuid

--- a/ArmPkg/Drivers/CpuDxe/PageTableMemoryAllocation.c
+++ b/ArmPkg/Drivers/CpuDxe/PageTableMemoryAllocation.c
@@ -1,0 +1,211 @@
+/** @file PageTableAlloc.c
+
+Logic facilitating the pre-allocation of page table memory.
+
+Copyright (c) Microsoft Corporation.
+SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <Uefi.h>
+#include <Library/BaseLib.h>
+#include <Library/DebugLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/UefiBootServicesTableLib.h>
+#include <Protocol/ArmPageTableMemoryAllocation.h>
+
+#pragma pack(1)
+
+typedef struct {
+  UINT32        Signature;
+  UINTN         Offset;
+  UINTN         FreePages;
+  LIST_ENTRY    NextPool;
+} PAGE_TABLE_POOL;
+
+#pragma pack()
+
+// the minimum number of pages we want to have available is 5, because If we're going to go below the minimum number
+// of pages reserved by serving the current request, the logic will hold a semaphore and call to allocate more page
+// table memory. That request will require at most 4 more pages if every level needs a table entry and may cause
+// reentry into AllocatePageTableMemory(). Because the semaphore is held, that request will be serviced by the pages
+// still in reserve to prevent infinite recursion. Once the top level request for more translation table memory resumes
+// execution, it will relinquish the lock and have at least another 512 pages for translation table entries.
+#define MIN_PAGES_AVAILABLE        5
+#define PAGE_TABLE_POOL_SIGNATURE  SIGNATURE_32 ('P','T','P','L')
+
+STATIC UINTN       mTotalFreePages    = 0;
+STATIC BOOLEAN     mPageTablePoolLock = FALSE;
+STATIC LIST_ENTRY  mPageTablePoolList = INITIALIZE_LIST_HEAD_VARIABLE (mPageTablePoolList);
+
+/**
+  Allocates pages for page table memory and adds them to the pool list.
+
+  @param[in] PoolPages The number of pages to allocate. The actual number of pages
+                       reserved will be at least 512 - the number of pages required to describe a
+                       fully split 2MB region.
+
+  @retval EFI_SUCCESS             More pages successfully added to the pool list
+  @retval EFI_INVALID_PARAMETER   PoolPages is zero
+  @retval EFI_ABORTED             Software lock is held by another call to this function
+  @retval EFI_OUT_OF_RESOURCES    Unable to allocate pages
+**/
+EFI_STATUS
+GetMorePages (
+  IN  UINTN  PoolPages
+  )
+{
+  PAGE_TABLE_POOL  *Buffer;
+
+  if (PoolPages == 0) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  // Add one page for the header
+  PoolPages++;
+  PoolPages = ALIGN_VALUE (PoolPages, EFI_SIZE_TO_PAGES (SIZE_2MB));
+  Buffer    = (PAGE_TABLE_POOL *)AllocateAlignedPages (PoolPages, SIZE_2MB);
+  if (Buffer == NULL) {
+    DEBUG ((DEBUG_ERROR, "ERROR: Out of aligned pages\n"));
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  // Reserve one page for pool header.
+  Buffer->FreePages = PoolPages - 1;
+  Buffer->Offset    = EFI_PAGE_SIZE;
+  Buffer->Signature = PAGE_TABLE_POOL_SIGNATURE;
+  mTotalFreePages  += Buffer->FreePages;
+  InsertHeadList (&mPageTablePoolList, &Buffer->NextPool);
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Walks the list to find a pool with enough free pages to allocate from.
+
+  @param[in] Pages The number of pages to allocate
+
+  @retval A pointer to the pool with enough free pages to allocate
+          from or NULL if no pool has enough free pages.
+**/
+PAGE_TABLE_POOL *
+FindPoolToAllocateFrom (
+  IN UINTN  Pages
+  )
+{
+  PAGE_TABLE_POOL  *PoolToAllocateFrom = NULL;
+  LIST_ENTRY       *CurrentEntry       = GetFirstNode (&mPageTablePoolList);
+
+  while (CurrentEntry != &mPageTablePoolList) {
+    PoolToAllocateFrom = CR (CurrentEntry, PAGE_TABLE_POOL, NextPool, PAGE_TABLE_POOL_SIGNATURE);
+    if (Pages <= PoolToAllocateFrom->FreePages) {
+      break;
+    }
+
+    CurrentEntry       = GetNextNode (&mPageTablePoolList, CurrentEntry);
+    PoolToAllocateFrom = NULL;
+  }
+
+  return PoolToAllocateFrom;
+}
+
+/**
+  Allocate memory for the page table.
+
+  @param[in]  NumPages          Number of pages to allocate.
+
+  @retval A pointer to the allocated page table memory or NULL if the
+          allocation failed.
+**/
+VOID *
+AllocatePageTableMemory (
+  IN UINTN  Pages
+  )
+{
+  VOID             *Buffer;
+  PAGE_TABLE_POOL  *PoolToAllocateFrom = NULL;
+  EFI_STATUS       Status;
+
+  if (Pages == 0) {
+    return NULL;
+  }
+
+  PoolToAllocateFrom = FindPoolToAllocateFrom (Pages);
+
+  // If we are running low on free pages, allocate more while we
+  // still have enough pages to accommodate a potential split. Hold
+  // a lock during this because the AllocatePages() call in GetMorePages()
+  // may call this function recursively. In that recursive call, it should
+  // pull from the existing pool rather than allocating more pages.
+  if (((PoolToAllocateFrom == NULL) ||
+       (mTotalFreePages < Pages) ||
+       ((mTotalFreePages - Pages) <= MIN_PAGES_AVAILABLE)) &&
+      !mPageTablePoolLock)
+  {
+    DEBUG ((DEBUG_INFO, "%a - The reserve of translation table memory is being refilled!\n", __func__));
+    mPageTablePoolLock = TRUE;
+    Status             = GetMorePages (1);
+    mPageTablePoolLock = FALSE;
+    if (EFI_ERROR (Status)) {
+      return NULL;
+    }
+
+    PoolToAllocateFrom = FindPoolToAllocateFrom (Pages);
+  }
+
+  if (PoolToAllocateFrom == NULL) {
+    return NULL;
+  }
+
+  Buffer                         = (UINT8 *)PoolToAllocateFrom + PoolToAllocateFrom->Offset;
+  PoolToAllocateFrom->Offset    += EFI_PAGES_TO_SIZE (Pages);
+  PoolToAllocateFrom->FreePages -= Pages;
+  mTotalFreePages               -= Pages;
+
+  return Buffer;
+}
+
+PAGE_TABLE_MEM_ALLOC_PROTOCOL  mPageTableMemAllocProtocol = {
+  AllocatePageTableMemory
+};
+
+/**
+  Initialize the page table memory pool and produce the page table memory allocation
+  protocol.
+
+  @param[in] ImageHandle  Handle on which to install the protocol.
+
+  @retval EFI_SUCCESS           The page table pool was initialized and protocol produced.
+  @retval Others                The driver returned an error while initializing.
+**/
+EFI_STATUS
+EFIAPI
+InitializePageTableMemory (
+  IN EFI_HANDLE  ImageHandle
+  )
+{
+  EFI_STATUS       Status;
+  PAGE_TABLE_POOL  *Pages;
+
+  Status = GetMorePages (1);
+
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "ERROR: Failed to allocate initial page table pool\n"));
+    return Status;
+  }
+
+  Status = gBS->InstallMultipleProtocolInterfaces (
+                  &ImageHandle,
+                  &gArmPageTableMemoryAllocationProtocolGuid,
+                  &mPageTableMemAllocProtocol,
+                  NULL
+                  );
+
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "ERROR: Failed to install ARM page table memory allocation protocol!\n"));
+    Pages = CR (mPageTablePoolList.ForwardLink, PAGE_TABLE_POOL, NextPool, PAGE_TABLE_POOL_SIGNATURE);
+    // Free the pages allocated for the pool, one was substracted from Pages->FreePages for the header
+    FreePages (Pages, Pages->FreePages + 1);
+  }
+
+  return Status;
+}

--- a/ArmPkg/Include/Protocol/ArmPageTableMemoryAllocation.h
+++ b/ArmPkg/Include/Protocol/ArmPageTableMemoryAllocation.h
@@ -1,0 +1,40 @@
+/** @file ArmPageTableMemoryAllocation.h
+
+Logic facilitating the allocation of page table memory.
+
+Copyright (c) Microsoft Corporation.
+SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef ARM_PAGE_TABLE_MEM_ALLOC_H_
+#define ARM_PAGE_TABLE_MEM_ALLOC_H_
+
+#define ARM_PAGE_TABLE_MEM_ALLOC_PROTOCOL  { \
+    0x623be44e, 0x506d, 0x487f, {0xa3, 0xa6, 0x92, 0xda, 0xef, 0x30, 0x2c, 0x70 } \
+    }
+
+extern EFI_GUID  gArmPageTableMemoryAllocationProtocolGuid;
+
+typedef struct _PAGE_TABLE_MEM_ALLOC_PROTOCOL PAGE_TABLE_MEM_ALLOC_PROTOCOL;
+
+// Protocol Interface functions.
+
+/**
+  Allocate memory for the page table.
+
+  @param[in]  NumPages          Number of pages to allocate.
+
+  @retval A pointer to the allocated page table memory or NULL if the
+          allocation failed.
+**/
+typedef
+VOID *
+(EFIAPI *ALLOCATE_PAGE_TABLE_MEMORY)(
+  IN UINTN NumPages
+  );
+
+typedef struct _PAGE_TABLE_MEM_ALLOC_PROTOCOL {
+  ALLOCATE_PAGE_TABLE_MEMORY    AllocatePageTableMemory;
+} PAGE_TABLE_MEM_ALLOC_PROTOCOL;
+
+#endif

--- a/ArmPkg/Library/ArmMmuLib/AArch64/ArmMmuLibCore.c
+++ b/ArmPkg/Library/ArmMmuLib/AArch64/ArmMmuLibCore.c
@@ -24,6 +24,18 @@
 
 STATIC  ARM_REPLACE_LIVE_TRANSLATION_ENTRY  mReplaceLiveEntryFunc = ArmReplaceLiveTranslationEntry;
 
+/**
+  Allocates pages for the page table from a reserved pool.
+
+  @param[in]  Pages  The number of pages to allocate
+
+  @return A pointer to the allocated buffer or NULL if allocation fails
+**/
+VOID *
+AllocatePageTableMemory (
+  IN UINTN  Pages
+  );
+
 STATIC
 UINT64
 ArmMemoryAttributeToPageAttribute (
@@ -272,7 +284,7 @@ UpdateRegionMappingRecursive (
         // No table entry exists yet, so we need to allocate a page table
         // for the next level.
         //
-        TranslationTable = AllocatePages (1);
+        TranslationTable = AllocatePageTableMemory (1);
         if (TranslationTable == NULL) {
           return EFI_OUT_OF_RESOURCES;
         }
@@ -665,7 +677,7 @@ ArmConfigureMmu (
   ArmSetTCR (TCR);
 
   // Allocate pages for translation table
-  TranslationTable = AllocatePages (1);
+  TranslationTable = AllocatePageTableMemory (1);
   if (TranslationTable == NULL) {
     return EFI_OUT_OF_RESOURCES;
   }

--- a/ArmPkg/Library/ArmMmuLib/AArch64/ArmMmuLibPageTableAlloc.c
+++ b/ArmPkg/Library/ArmMmuLib/AArch64/ArmMmuLibPageTableAlloc.c
@@ -1,0 +1,43 @@
+/** @file ArmMmuLibPageTableAlloc.c
+
+  Logic facilitating the allocation of page table memory from a reserved pool.
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <Uefi.h>
+#include <Library/DebugLib.h>
+#include <Library/UefiBootServicesTableLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Protocol/ArmPageTableMemoryAllocation.h>
+
+PAGE_TABLE_MEM_ALLOC_PROTOCOL  *mPageTableMemAllocProtocol = NULL;
+
+/**
+  Allocates pages for the page table from a reserved pool.
+
+  @param[in]  Pages  The number of pages to allocate
+
+  @return A pointer to the allocated buffer or NULL if allocation fails
+**/
+VOID *
+AllocatePageTableMemory (
+  IN UINTN  Pages
+  )
+{
+  if (mPageTableMemAllocProtocol == NULL) {
+    gBS->LocateProtocol (
+           &gArmPageTableMemoryAllocationProtocolGuid,
+           NULL,
+           (VOID **)&mPageTableMemAllocProtocol
+           );
+  }
+
+  if (mPageTableMemAllocProtocol != NULL) {
+    return mPageTableMemAllocProtocol->AllocatePageTableMemory (Pages);
+  }
+
+  ASSERT (mPageTableMemAllocProtocol != NULL);
+  return NULL;
+}

--- a/ArmPkg/Library/ArmMmuLib/AArch64/ArmMmuLibPageTableAllocPei.c
+++ b/ArmPkg/Library/ArmMmuLib/AArch64/ArmMmuLibPageTableAllocPei.c
@@ -1,0 +1,25 @@
+/** @file ArmMmuLibPageTableAllocPei.c
+
+  Logic facilitating the allocation of page table memory from a reserved pool.
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <Uefi.h>
+#include <Library/MemoryAllocationLib.h>
+
+/**
+  Allocates pages for the page table from a reserved pool.
+
+  @param[in]  Pages  The number of pages to allocate
+
+  @return A pointer to the allocated buffer or NULL if allocation fails
+**/
+VOID *
+AllocatePageTableMemory (
+  IN UINTN  Pages
+  )
+{
+  return AllocatePages (Pages);
+}

--- a/ArmPkg/Library/ArmMmuLib/AArch64/ArmMmuPeiLibConstructor.c
+++ b/ArmPkg/Library/ArmMmuLib/AArch64/ArmMmuPeiLibConstructor.c
@@ -7,6 +7,7 @@
 */
 
 #include <Base.h>
+#include <PiPei.h>
 
 #include <Library/ArmLib.h>
 #include <Library/ArmMmuLib.h>

--- a/ArmPkg/Library/ArmMmuLib/ArmMmuPeiLib.inf
+++ b/ArmPkg/Library/ArmMmuLib/ArmMmuPeiLib.inf
@@ -4,6 +4,7 @@
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
+#  Non-XIP PEI modules should use this version of ArmMmuLib.
 #
 #**/
 
@@ -13,7 +14,9 @@
   FILE_GUID                      = b50d8d53-1ad1-44ea-9e69-8c89d4a6d08b
   MODULE_TYPE                    = PEIM
   VERSION_STRING                 = 1.0
-  LIBRARY_CLASS                  = ArmMmuLib|PEIM
+  LIBRARY_CLASS                  = ArmMmuLib | PEIM PEI_CORE
+
+[Defines.AARCH64]
   CONSTRUCTOR                    = ArmMmuPeiLibConstructor
 
 [Sources.AARCH64]
@@ -21,6 +24,14 @@
   AArch64/ArmMmuLibCore.c
   AArch64/ArmMmuPeiLibConstructor.c
   AArch64/ArmMmuLibReplaceEntry.S
+  AArch64/ArmMmuLibPageTableAllocPei.c
+
+[Sources.ARM]
+  ArmMmuLibInternal.h
+  Arm/ArmMmuLibConvert.c
+  Arm/ArmMmuLibCore.c
+  Arm/ArmMmuLibUpdate.c
+  Arm/ArmMmuLibV7Support.S   | GCC
 
 [Packages]
   ArmPkg/ArmPkg.dec
@@ -35,3 +46,6 @@
 
 [Guids]
   gArmMmuReplaceLiveTranslationEntryFuncGuid
+
+[Pcd.ARM]
+  gArmTokenSpaceGuid.PcdNormalMemoryNonshareableOverride

--- a/ArmPkg/Library/ArmMmuLib/ArmMmuSecLib.inf
+++ b/ArmPkg/Library/ArmMmuLib/ArmMmuSecLib.inf
@@ -4,17 +4,17 @@
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
+#  XIP SEC/PEI modules should use this instance of ArmMmuLib.
 #
 #**/
 
 [Defines]
   INF_VERSION                    = 0x00010005
-  BASE_NAME                      = ArmMmuBaseLib
-  FILE_GUID                      = da8f0232-fb14-42f0-922c-63104d2c70bd
+  BASE_NAME                      = ArmMmuSecLib
+  FILE_GUID                      = EA59A139-086A-4B8E-9297-FE161EFEB251
   MODULE_TYPE                    = BASE
   VERSION_STRING                 = 1.0
-  # Can't be fully BASE, because it doesn't work in MM_STANDALONE.
-  LIBRARY_CLASS                  = ArmMmuLib | DXE_DRIVER DXE_CORE DXE_RUNTIME_DRIVER
+  LIBRARY_CLASS                  = ArmMmuLib | SEC PEI_CORE PEIM
 
 [Defines.AARCH64]
   CONSTRUCTOR                    = ArmMmuBaseLibConstructor
@@ -22,15 +22,16 @@
 [Sources.AARCH64]
   ArmMmuLibInternal.h
   AArch64/ArmMmuLibCore.c
+  AArch64/ArmMmuPeiLibConstructor.c
   AArch64/ArmMmuLibReplaceEntry.S
-  AArch64/ArmMmuLibPageTableAlloc.c
+  AArch64/ArmMmuLibPageTableAllocPei.c
 
 [Sources.ARM]
   ArmMmuLibInternal.h
   Arm/ArmMmuLibConvert.c
   Arm/ArmMmuLibCore.c
   Arm/ArmMmuLibUpdate.c
-  Arm/ArmMmuLibV7Support.S   |GCC
+  Arm/ArmMmuLibV7Support.S   | GCC
 
 [Packages]
   ArmPkg/ArmPkg.dec
@@ -42,13 +43,9 @@
   CacheMaintenanceLib
   HobLib
   MemoryAllocationLib
-  UefiBootServicesTableLib
 
 [Guids]
   gArmMmuReplaceLiveTranslationEntryFuncGuid
 
 [Pcd.ARM]
   gArmTokenSpaceGuid.PcdNormalMemoryNonshareableOverride
-
-[Protocols]
-  gArmPageTableMemoryAllocationProtocolGuid ## PRODUCES

--- a/ArmPlatformPkg/ArmPlatformPkg.dsc
+++ b/ArmPlatformPkg/ArmPlatformPkg.dsc
@@ -74,6 +74,7 @@
   UefiRuntimeServicesTableLib|MdePkg/Library/UefiRuntimeServicesTableLib/UefiRuntimeServicesTableLib.inf
 
 [LibraryClasses.common.PEIM]
+  ArmMmuLib|ArmPkg/Library/ArmMmuLib/ArmMmuPeiLib.inf
   HobLib|MdePkg/Library/PeiHobLib/PeiHobLib.inf
   MemoryAllocationLib|MdePkg/Library/PeiMemoryAllocationLib/PeiMemoryAllocationLib.inf
   PeimEntryPoint|MdePkg/Library/PeimEntryPoint/PeimEntryPoint.inf
@@ -81,6 +82,7 @@
   PeiServicesTablePointerLib|MdePkg/Library/PeiServicesTablePointerLib/PeiServicesTablePointerLib.inf
 
 [LibraryClasses.common.SEC]
+  ArmMmuLib|ArmPkg/Library/ArmMmuLib/ArmMmuSecLib.inf
   ExtractGuidedSectionLib|EmbeddedPkg/Library/PrePiExtractGuidedSectionLib/PrePiExtractGuidedSectionLib.inf
   HobLib|EmbeddedPkg/Library/PrePiHobLib/PrePiHobLib.inf
   MemoryAllocationLib|EmbeddedPkg/Library/PrePiMemoryAllocationLib/PrePiMemoryAllocationLib.inf

--- a/ArmVirtPkg/ArmVirt.dsc.inc
+++ b/ArmVirtPkg/ArmVirt.dsc.inc
@@ -168,6 +168,11 @@
 
   ReportStatusCodeLib|MdePkg/Library/BaseReportStatusCodeLibNull/BaseReportStatusCodeLibNull.inf
 
+  ArmMmuLib|ArmPkg/Library/ArmMmuLib/ArmMmuBaseLib.inf
+
+[LibraryClasses.common.SEC, LibraryClasses.common.PEI_CORE, LibraryClasses.common.PEIM]
+  ArmMmuLib|ArmPkg/Library/ArmMmuLib/ArmMmuSecLib.inf
+
 [LibraryClasses.common.SEC]
   PcdLib|MdePkg/Library/BasePcdLibNull/BasePcdLibNull.inf
   BaseMemoryLib|MdePkg/Library/BaseMemoryLib/BaseMemoryLib.inf

--- a/ArmVirtPkg/ArmVirtCloudHv.dsc
+++ b/ArmVirtPkg/ArmVirtCloudHv.dsc
@@ -32,7 +32,6 @@
 
 [LibraryClasses.common]
   ArmLib|ArmPkg/Library/ArmLib/ArmBaseLib.inf
-  ArmMmuLib|ArmPkg/Library/ArmMmuLib/ArmMmuBaseLib.inf
 
   # Virtio Support
   VirtioLib|OvmfPkg/Library/VirtioLib/VirtioLib.inf

--- a/ArmVirtPkg/ArmVirtKvmTool.dsc
+++ b/ArmVirtPkg/ArmVirtKvmTool.dsc
@@ -40,7 +40,6 @@
 
 [LibraryClasses.common]
   ArmLib|ArmPkg/Library/ArmLib/ArmBaseLib.inf
-  ArmMmuLib|ArmPkg/Library/ArmMmuLib/ArmMmuBaseLib.inf
 
   # Virtio Support
   VirtioLib|OvmfPkg/Library/VirtioLib/VirtioLib.inf

--- a/ArmVirtPkg/ArmVirtQemu.dsc
+++ b/ArmVirtPkg/ArmVirtQemu.dsc
@@ -55,7 +55,6 @@
 
 [LibraryClasses.common]
   ArmLib|ArmPkg/Library/ArmLib/ArmBaseLib.inf
-  ArmMmuLib|ArmPkg/Library/ArmMmuLib/ArmMmuBaseLib.inf
 
   # Virtio Support
   VirtioLib|OvmfPkg/Library/VirtioLib/VirtioLib.inf
@@ -107,7 +106,6 @@
   Tpm2DeviceLib|SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2DeviceLibDTpm.inf
 
 [LibraryClasses.AARCH64.PEIM]
-  ArmMmuLib|ArmPkg/Library/ArmMmuLib/ArmMmuPeiLib.inf
   BaseCryptLib|CryptoPkg/Library/BaseCryptLib/PeiCryptLib.inf
 
 [LibraryClasses.ARM.PEIM]
@@ -335,6 +333,8 @@
 !else
   PcdLib|MdePkg/Library/BasePcdLibNull/BasePcdLibNull.inf
 !endif
+
+  ArmMmuLib|ArmPkg/Library/ArmMmuLib/ArmMmuPeiLib.inf
 
 ################################################################################
 #

--- a/ArmVirtPkg/ArmVirtQemuKernel.dsc
+++ b/ArmVirtPkg/ArmVirtQemuKernel.dsc
@@ -52,7 +52,6 @@
 
 [LibraryClasses.common]
   ArmLib|ArmPkg/Library/ArmLib/ArmBaseLib.inf
-  ArmMmuLib|ArmPkg/Library/ArmMmuLib/ArmMmuBaseLib.inf
 
   # Virtio Support
   VirtioLib|OvmfPkg/Library/VirtioLib/VirtioLib.inf

--- a/ArmVirtPkg/ArmVirtXen.dsc
+++ b/ArmVirtPkg/ArmVirtXen.dsc
@@ -37,7 +37,6 @@
 
   ArmGenericTimerCounterLib|ArmVirtPkg/Library/XenArmGenericTimerVirtCounterLib/XenArmGenericTimerVirtCounterLib.inf
   ArmLib|ArmPkg/Library/ArmLib/ArmBaseLib.inf
-  ArmMmuLib|ArmPkg/Library/ArmMmuLib/ArmMmuBaseLib.inf
 
   # Virtio Support
   VirtioLib|OvmfPkg/Library/VirtioLib/VirtioLib.inf


### PR DESCRIPTION
# Description

Allocating memory when memory protection is active can cause the below infinite loop:

1. gCpu->SetMemoryAttributes(EFI_MEMORY_RO)
2. ArmSetMemoryAttributes ()
3. SetMemoryRegionAttribute()
4. UpdateRegionMapping()
5. UpdateRegionMappingRecursive()
6. AllocatePages() -> Need memory for a translation table entry
7. CoreAllocatePages()
8. ApplyMemoryProtectionPolicy() -> Policy says new page should be XN
9. gCpu->SetMemoryAttributes()
10. Back to 3

To fix this previously, CpuDxe would update conventional memory to be XN prior to installing the CpuArch protocol. However, when we transition to setting EFI_MEMORY_RP on free memory, this will no longer work. This a prerequisite to bring in the EFI_MEMORY_RP on free memory feature that has been discussed on the mailing list.

This PR updates ArmMmuLib to reserve page table memory for allocation during table spits to prevent the infinite loop. This follows the same pattern that the x86 CpuDxe does to preallocate page table memory: https://github.com/tianocore/edk2/blob/f962adc8a089949ecc730ba17f08234b52e3952d/UefiCpuPkg/CpuDxe/CpuPageTable.c#L1117.

It also updates the consumers of ArmMmuLib to consume the PEI version of the lib in the same commit so as to not break them.

Continuous-integration-options: PatchCheck.ignore-multi-package

- [x] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Tested on ArmVirtQemu by creating the scenario where the infinite loop (without the XN remap routine in place) and booting successfully. This was also tested using the EFI_MEMORY_RP on free memory feature that is pending upstreaming. This has been shipping in platforms.

## Integration Instructions

Platforms which are using ArmMmuBaseLib for PEIM, PEI_CORE, and SEC
modules will need to switch those module types to use ArmMmuPeiLib.

```inf
[LibraryClasses.common.SEC]
  ArmMmuLib|ArmPkg/Library/ArmMmuLib/ArmMmuSecLib.inf

[LibraryClasses.common.PEIM, LibraryClasses.common.PEI_CORE]
  ArmMmuLib|ArmPkg/Library/ArmMmuLib/ArmMmuPeiLib.inf
```

Platforms will also need to remove `gArmTokenSpaceGuid.PcdRemapUnusedMemoryNx` as it has been removed.