### PR TITLE
NetworkPkg: UefiPxeBcDxe: Fix error packet detection

### DIFF
--- a/NetworkPkg/UefiPxeBcDxe/PxeBcMtftp.c
+++ b/NetworkPkg/UefiPxeBcDxe/PxeBcMtftp.c
@@ -52,12 +52,12 @@ PxeBcMtftp6CheckPacket (
   Callback = Private->PxeBcCallback;
   Status   = EFI_SUCCESS;
 
-  if (Packet->OpCode == EFI_MTFTP6_OPCODE_ERROR) {
+  if (NTOHS (Packet->OpCode) == EFI_MTFTP6_OPCODE_ERROR) {
     //
     // Store the tftp error message into mode data and set the received flag.
     //
     Private->Mode.TftpErrorReceived   = TRUE;
-    Private->Mode.TftpError.ErrorCode = (UINT8)Packet->Error.ErrorCode;
+    Private->Mode.TftpError.ErrorCode = (UINT8)NTOHS (Packet->Error.ErrorCode);
     AsciiStrnCpyS (
       Private->Mode.TftpError.ErrorString,
       PXE_MTFTP_ERROR_STRING_LENGTH,
@@ -184,7 +184,7 @@ PxeBcMtftp6GetFileSize (
       // Store the tftp error message into mode data and set the received flag.
       //
       Private->Mode.TftpErrorReceived   = TRUE;
-      Private->Mode.TftpError.ErrorCode = (UINT8)Packet->Error.ErrorCode;
+      Private->Mode.TftpError.ErrorCode = (UINT8)NTOHS (Packet->Error.ErrorCode);
       AsciiStrnCpyS (
         Private->Mode.TftpError.ErrorString,
         PXE_MTFTP_ERROR_STRING_LENGTH,
@@ -530,12 +530,12 @@ PxeBcMtftp4CheckPacket (
   Callback = Private->PxeBcCallback;
   Status   = EFI_SUCCESS;
 
-  if (Packet->OpCode == EFI_MTFTP4_OPCODE_ERROR) {
+  if (NTOHS (Packet->OpCode) == EFI_MTFTP4_OPCODE_ERROR) {
     //
     // Store the tftp error message into mode data and set the received flag.
     //
     Private->Mode.TftpErrorReceived   = TRUE;
-    Private->Mode.TftpError.ErrorCode = (UINT8)Packet->Error.ErrorCode;
+    Private->Mode.TftpError.ErrorCode = (UINT8)NTOHS (Packet->Error.ErrorCode);
     AsciiStrnCpyS (
       Private->Mode.TftpError.ErrorString,
       PXE_MTFTP_ERROR_STRING_LENGTH,
@@ -662,7 +662,7 @@ PxeBcMtftp4GetFileSize (
       // Store the tftp error message into mode data and set the received flag.
       //
       Private->Mode.TftpErrorReceived   = TRUE;
-      Private->Mode.TftpError.ErrorCode = (UINT8)Packet->Error.ErrorCode;
+      Private->Mode.TftpError.ErrorCode = (UINT8)NTOHS (Packet->Error.ErrorCode);
       AsciiStrnCpyS (
         Private->Mode.TftpError.ErrorString,
         PXE_MTFTP_ERROR_STRING_LENGTH,


### PR DESCRIPTION
# Description

Per RFC 1350, TFTP error packets include 2 byte OpCode and ErrorCode fields in network byte order. Those need to be swapped to host order to be interpreted correctly. Without this change, the TftpErrorReceived and TftpError Mode fields are never set and EFI applications can't inspect the error received from the TFTP server.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

I was testing shim to see how it handles TFTP file not found errors in https://github.com/rhboot/shim/pull/695. The OVMF firmware was used to boot a VM using QEMU's TFTP server support. Without this change shim would not report the specific error since `TftpErrorReceived` is `FALSE`. With this change it was able to see `TftpErrorReceived` is `TRUE` and `TftpError.ErrorCode` set to `1`, which is file not found as expected.

## Integration Instructions

N/A, will be included in the UefiPxeBcDxe package.