### PR TITLE
OvmfPkg/Library/HardwareInfoLib: Fix memory allocation at PciHostBridgeUtilityGetRootBridgesHostProvided

### DIFF
--- a/OvmfPkg/Library/PciHostBridgeUtilityLib/PciHostBridgeUtilityLib.c
+++ b/OvmfPkg/Library/PciHostBridgeUtilityLib/PciHostBridgeUtilityLib.c
@@ -444,6 +444,12 @@ PciHostBridgeUtilityGetRootBridgesHostProvided (
   PCI_ROOT_BRIDGE_APERTURE  PMem;
   PCI_ROOT_BRIDGE_APERTURE  PMemAbove4G;
 
+  ZeroMem (&Io, sizeof (Io));
+  ZeroMem (&Mem, sizeof (Mem));
+  ZeroMem (&MemAbove4G, sizeof (MemAbove4G));
+  ZeroMem (&PMem, sizeof (PMem));
+  ZeroMem (&PMemAbove4G, sizeof (PMemAbove4G));
+
   //
   // Initialize the Hardware Info list head to start with an empty but valid
   // list head.


### PR DESCRIPTION
# Description

Currently, PciHostBridgeUtilityGetRootBridgesHostProvided allocates memory
for aperture structures without clearing memory. This causes garbage in
the Translation field, but the Base and Limit fields have the correct
values because they are copied from the HOST_BRIDGE_INFO fields in the
HardwareInfoPciHostBridgeHostBridgeHostBridgeGetApertures function.

```
RootBridge: PciRoot(0x0)
  Support/Attr: 70069 / 70069
    DmaAbove4G: No
NoExtConfSpace: No
     AllocAttr: 3 (CombineMemPMem Mem64Decode)
           Bus: 0 - 80 Translation=0
            Io: 6000 - FFFF Translation=5E9EB018
           Mem: 80000000 - DFFFFFFF Translation=0
    MemAbove4G: 600000000000 - 7FFFFFFFFFFF Translation=0
          PMem: FFFFFFFFFFFFFFFF - 0 Translation=0
   PMemAbove4G: FFFFFFFFFFFFFFFF - 0 Translation=0
```

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Manual execution returns:

```
RootBridge: PciRoot(0x0)
  Support/Attr: 70069 / 70069
    DmaAbove4G: No
NoExtConfSpace: No
     AllocAttr: 3 (CombineMemPMem Mem64Decode)
           Bus: 0 - 80 Translation=0
            Io: 6000 - FFFF Translation=0
           Mem: 80000000 - DFFFFFFF Translation=0
    MemAbove4G: 600000000000 - 7FFFFFFFFFFF Translation=0
          PMem: FFFFFFFFFFFFFFFF - 0 Translation=0
   PMemAbove4G: FFFFFFFFFFFFFFFF - 0 Translation=0
```

## Integration Instructions

N/A
