### PR TITLE
NetworkPkg: Restore TPL Before Return

### DIFF
--- a/NetworkPkg/Ip6Dxe/Ip6Impl.c
+++ b/NetworkPkg/Ip6Dxe/Ip6Impl.c
@@ -61,7 +61,6 @@ EfiIp6GetModeData (
     return EFI_INVALID_PARAMETER;
   }
 
-  OldTpl     = gBS->RaiseTPL (TPL_CALLBACK);
   IpInstance = IP6_INSTANCE_FROM_PROTOCOL (This);
   IpSb       = IpInstance->Service;
   IpIf       = IpInstance->Interface;
@@ -69,6 +68,8 @@ EfiIp6GetModeData (
   if (IpSb->LinkLocalDadFail) {
     return EFI_INVALID_PARAMETER;
   }
+
+  OldTpl = gBS->RaiseTPL (TPL_CALLBACK);
 
   if (Ip6ModeData != NULL) {
     //

--- a/NetworkPkg/SnpDxe/Get_status.c
+++ b/NetworkPkg/SnpDxe/Get_status.c
@@ -216,11 +216,11 @@ SnpUndi32GetStatus (
 
   Snp = EFI_SIMPLE_NETWORK_DEV_FROM_THIS (This);
 
-  OldTpl = gBS->RaiseTPL (TPL_CALLBACK);
-
   if (Snp == NULL) {
     return EFI_DEVICE_ERROR;
   }
+
+  OldTpl = gBS->RaiseTPL (TPL_CALLBACK);
 
   switch (Snp->Mode.State) {
     case EfiSimpleNetworkInitialized:

--- a/NetworkPkg/SnpDxe/Transmit.c
+++ b/NetworkPkg/SnpDxe/Transmit.c
@@ -287,11 +287,11 @@ SnpUndi32Transmit (
 
   Snp = EFI_SIMPLE_NETWORK_DEV_FROM_THIS (This);
 
-  OldTpl = gBS->RaiseTPL (TPL_CALLBACK);
-
   if (Snp == NULL) {
     return EFI_DEVICE_ERROR;
   }
+
+  OldTpl = gBS->RaiseTPL (TPL_CALLBACK);
 
   switch (Snp->Mode.State) {
     case EfiSimpleNetworkInitialized:


### PR DESCRIPTION
# Description

This patch fixes a few instances of error cases in NetworkPkg returning after a RaiseTpl call without restoring the TPL first.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Code review.

## Integration Instructions

N/A.
