### PR TITLE
MdeModulePkg: Fix PeiAllocatePages() corner case

### DIFF
--- a/MdeModulePkg/Core/Pei/Memory/MemoryServices.c
+++ b/MdeModulePkg/Core/Pei/Memory/MemoryServices.c
@@ -555,6 +555,7 @@ PeiAllocatePages (
   EFI_PHYSICAL_ADDRESS  *FreeMemoryTop;
   EFI_PHYSICAL_ADDRESS  *FreeMemoryBottom;
   UINTN                 RemainingPages;
+  UINTN                 RemainingMemory;
   UINTN                 Granularity;
   UINTN                 Padding;
 
@@ -636,24 +637,18 @@ PeiAllocatePages (
   //
   // Verify that there is sufficient memory to satisfy the allocation.
   //
-  RemainingPages = (UINTN)(*FreeMemoryTop - *FreeMemoryBottom) >> EFI_PAGE_SHIFT;
+  RemainingMemory = (UINTN)(*FreeMemoryTop - *FreeMemoryBottom);
+  RemainingPages  = RemainingMemory >> EFI_PAGE_SHIFT;
   //
-  // The number of remaining pages needs to be greater than or equal to that of the request pages.
+  // The number of remaining pages needs to be greater than or equal to that of
+  // the request pages. In addition, there should be enough space left to hold a
+  // Memory Allocation HOB.
   //
   Pages = ALIGN_VALUE (Pages, EFI_SIZE_TO_PAGES (Granularity));
-  if (RemainingPages < Pages) {
-    //
-    // Try to find free memory by searching memory allocation HOBs.
-    //
-    Status = FindFreeMemoryFromMemoryAllocationHob (MemoryType, Pages, Granularity, Memory);
-    if (!EFI_ERROR (Status)) {
-      return Status;
-    }
-
-    DEBUG ((DEBUG_ERROR, "AllocatePages failed: No 0x%lx Pages is available.\n", (UINT64)Pages));
-    DEBUG ((DEBUG_ERROR, "There is only left 0x%lx pages memory resource to be allocated.\n", (UINT64)RemainingPages));
-    return EFI_OUT_OF_RESOURCES;
-  } else {
+  if ((RemainingPages > Pages) ||
+      ((RemainingPages == Pages) &&
+       ((RemainingMemory & EFI_PAGE_MASK) >= sizeof (EFI_HOB_MEMORY_ALLOCATION))))
+  {
     //
     // Update the PHIT to reflect the memory usage
     //
@@ -674,6 +669,18 @@ PeiAllocatePages (
       );
 
     return EFI_SUCCESS;
+  } else {
+    //
+    // Try to find free memory by searching memory allocation HOBs.
+    //
+    Status = FindFreeMemoryFromMemoryAllocationHob (MemoryType, Pages, Granularity, Memory);
+    if (!EFI_ERROR (Status)) {
+      return Status;
+    }
+
+    DEBUG ((DEBUG_ERROR, "AllocatePages failed: No 0x%lx Pages is available.\n", (UINT64)Pages));
+    DEBUG ((DEBUG_ERROR, "There is only left 0x%lx pages memory resource to be allocated.\n", (UINT64)RemainingPages));
+    return EFI_OUT_OF_RESOURCES;
   }
 }
 

--- a/MdeModulePkg/Core/Pei/Memory/MemoryServices.c
+++ b/MdeModulePkg/Core/Pei/Memory/MemoryServices.c
@@ -638,7 +638,7 @@ PeiAllocatePages (
   // Verify that there is sufficient memory to satisfy the allocation.
   //
   RemainingMemory = (UINTN)(*FreeMemoryTop - *FreeMemoryBottom);
-  RemainingPages  = RemainingMemory >> EFI_PAGE_SHIFT;
+  RemainingPages  = (UINTN)(RShiftU64 (RemainingMemory, EFI_PAGE_SHIFT));
   //
   // The number of remaining pages needs to be greater than or equal to that of
   // the request pages. In addition, there should be enough space left to hold a


### PR DESCRIPTION
I recently ran into an AllocatePages() hang. It turns out that AllocatePages() does not account for the Memory Allocation HOB when it makes the decision of allocating out of free memory.

Here is the scenario:

  FreeMemoryTop    - 0x71C03000
  FreeMemoryBottom - 0x71BDBFD8
  => We have 159,784 bytes left => ~39.0098 pages left.

We attempt to allocate 39 pages. There are enough pages left but allocating those pages requires to allocate a Memory Allocation HOB which needs an extra 48 bytes. But once the pages are allocated, there are only 40 bytes left.

In addition to taking into account the Memory Allocation HOB size, this commit reverses the condition to keep it simple.

# Description

<_Include a description of the change and why this change was made._>

<_For each item, place an "x" in between `[` and `]` if true. Example: `[x]` (you can also check items in GitHub UI)_>

<_Create the PR as a Draft PR if it is only created to run CI checks._>

<_Delete lines in \<\> tags before creating the PR._>

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

<_Describe the test(s) that were run to verify the changes._>

## Integration Instructions

<_Describe how these changes should be integrated. Use N/A if nothing is required._>
