### PR TITLE
Smbios Spec V 3.8.0 ShellPkg and MdePkg changes

### DIFF
--- a/MdePkg/Include/IndustryStandard/SmBios.h
+++ b/MdePkg/Include/IndustryStandard/SmBios.h
@@ -706,6 +706,7 @@ typedef enum {
   ProcessorFamilyIntelCoreI5                     = 0xCD,
   ProcessorFamilyIntelCoreI3                     = 0xCE,
   ProcessorFamilyIntelCoreI9                     = 0xCF,
+  ProcessorFamilyIntelXeonD                      = 0xD0,  ///Smbios spec 3.8 updated this value
   ProcessorFamilyViaC7M                          = 0xD2,
   ProcessorFamilyViaC7D                          = 0xD3,
   ProcessorFamilyViaC7                           = 0xD4,

--- a/MdePkg/Include/IndustryStandard/SmBios.h
+++ b/MdePkg/Include/IndustryStandard/SmBios.h
@@ -706,7 +706,7 @@ typedef enum {
   ProcessorFamilyIntelCoreI5                     = 0xCD,
   ProcessorFamilyIntelCoreI3                     = 0xCE,
   ProcessorFamilyIntelCoreI9                     = 0xCF,
-  ProcessorFamilyIntelXeonD                      = 0xD0,  ///Smbios spec 3.8 updated this value
+  ProcessorFamilyIntelXeonD                      = 0xD0,  /// Smbios spec 3.8 updated this value
   ProcessorFamilyViaC7M                          = 0xD2,
   ProcessorFamilyViaC7D                          = 0xD3,
   ProcessorFamilyViaC7                           = 0xD4,

--- a/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/PrintInfo.c
+++ b/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/PrintInfo.c
@@ -2415,6 +2415,7 @@ DisplayProcessorFamily (
     case 0xD0:
       Print (L"Intel Xeon D Processor\n");
       break;
+
     case 0xD2:
       Print (L"ViaC7M\n");
       break;

--- a/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/PrintInfo.c
+++ b/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/PrintInfo.c
@@ -2412,10 +2412,6 @@ DisplayProcessorFamily (
       Print (L"Intel Core i9 processor\n");
       break;
 
-    case 0xD0:
-      Print (L"Intel Xeon D Processor\n");
-      break;
-
     case 0xD2:
       Print (L"ViaC7M\n");
       break;

--- a/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/PrintInfo.c
+++ b/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/PrintInfo.c
@@ -2412,6 +2412,9 @@ DisplayProcessorFamily (
       Print (L"Intel Core i9 processor\n");
       break;
 
+    case 0xD0:
+      Print (L"Intel Xeon D Processor\n");
+      break;
     case 0xD2:
       Print (L"ViaC7M\n");
       break;


### PR DESCRIPTION
MdePkg: Updated Type 4 Info as per Smbios 3.8.0

REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4861

Added PROCESSOR_FAMILY_NAME support in MdePkg and ShellPkg.

Signed-off-by: Revathy <revathyv@ami.com>