### PR TITLE
Support for USB Interface Association.

### DIFF
--- a/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbBus.h
+++ b/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbBus.h
@@ -3,6 +3,7 @@
     Usb Bus Driver Binding and Bus IO Protocol.
 
 Copyright (c) 2004 - 2018, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2024, American Megatrends International LLC. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -15,6 +16,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Protocol/Usb2HostController.h>
 #include <Protocol/UsbHostController.h>
 #include <Protocol/UsbIo.h>
+#include <Protocol/UsbAssociationIo.h>
 #include <Protocol/DevicePath.h>
 
 #include <Library/BaseLib.h>
@@ -29,15 +31,17 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #include <IndustryStandard/Usb.h>
 
-typedef struct _USB_DEVICE     USB_DEVICE;
-typedef struct _USB_INTERFACE  USB_INTERFACE;
-typedef struct _USB_BUS        USB_BUS;
-typedef struct _USB_HUB_API    USB_HUB_API;
+typedef struct _USB_DEVICE       USB_DEVICE;
+typedef struct _USB_INTERFACE    USB_INTERFACE;
+typedef struct _USB_BUS          USB_BUS;
+typedef struct _USB_HUB_API      USB_HUB_API;
+typedef struct _USB_ASSOCIATION  USB_ASSOCIATION;
 
 #include "UsbUtility.h"
 #include "UsbDesc.h"
 #include "UsbHub.h"
 #include "UsbEnumer.h"
+#include "UsbIntfAssoc.h"
 
 //
 // USB bus timeout experience values
@@ -132,14 +136,18 @@ typedef struct _USB_HUB_API    USB_HUB_API;
 //
 #define  USB_BUS_TPL  TPL_NOTIFY
 
-#define  USB_INTERFACE_SIGNATURE  SIGNATURE_32 ('U', 'S', 'B', 'I')
-#define  USB_BUS_SIGNATURE        SIGNATURE_32 ('U', 'S', 'B', 'B')
+#define  USB_INTERFACE_SIGNATURE    SIGNATURE_32 ('U', 'S', 'B', 'I')
+#define  USB_BUS_SIGNATURE          SIGNATURE_32 ('U', 'S', 'B', 'B')
+#define  USB_ASSOCIATION_SIGNATURE  SIGNATURE_32 ('U', 'S', 'B', 'A')
 
 #define USB_BIT(a)                 ((UINTN)(1 << (a)))
 #define USB_BIT_IS_SET(Data, Bit)  ((BOOLEAN)(((Data) & (Bit)) == (Bit)))
 
 #define USB_INTERFACE_FROM_USBIO(a) \
           CR(a, USB_INTERFACE, UsbIo, USB_INTERFACE_SIGNATURE)
+
+#define USB_ASSOCIATION_FROM_USBIA(a) \
+          CR(a, USB_ASSOCIATION, UsbIa, USB_ASSOCIATION_SIGNATURE)
 
 #define USB_BUS_FROM_THIS(a) \
           CR(a, USB_BUS, BusId, USB_BUS_SIGNATURE)
@@ -175,6 +183,9 @@ struct _USB_DEVICE {
 
   UINT16                                LangId[USB_MAX_LANG_ID];
   UINT16                                TotalLangId;
+
+  UINT8                                 NumOfAssociation;
+  USB_ASSOCIATION                       *Associations[USB_MAX_ASSOCIATION];
 
   UINT8                                 NumOfInterface;
   USB_INTERFACE                         *Interfaces[USB_MAX_INTERFACE];
@@ -228,6 +239,23 @@ struct _USB_INTERFACE {
   // connected to EHCI.
   //
   UINT8                       MaxSpeed;
+};
+
+//
+// Stands for a function implemented using interface association
+//
+struct _USB_ASSOCIATION {
+  UINTN                             Signature;
+  USB_DEVICE                        *Device;
+  USB_INTERFACE_ASSOCIATION_DESC    *IaDesc;
+
+  //
+  // Handles and protocols
+  //
+  EFI_HANDLE                        Handle;
+  EFI_USB_IA_PROTOCOL               UsbIa;
+  EFI_DEVICE_PATH_PROTOCOL          *DevicePath;
+  BOOLEAN                           IsManaged;
 };
 
 //

--- a/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbBusDxe.inf
+++ b/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbBusDxe.inf
@@ -2,6 +2,7 @@
 #  The Usb Bus Dxe driver is used to enumerate and manage all attached usb devices.
 #
 #  Copyright (c) 2006 - 2018, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2024, American Megatrends International LLC. All rights reserved.<BR>
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -40,6 +41,8 @@
   UsbUtility.c
   UsbDesc.h
   UsbBus.h
+  UsbIntfAssoc.c
+  UsbIntfAssoc.h
 
 [Packages]
   MdePkg/MdePkg.dec
@@ -58,6 +61,7 @@
 
 [Protocols]
   gEfiUsbIoProtocolGuid                         ## BY_START
+  gEfiUsbIaProtocolGuid
   ## TO_START
   ## BY_START
   gEfiDevicePathProtocolGuid

--- a/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbDesc.c
+++ b/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbDesc.c
@@ -3,6 +3,7 @@
     Manage Usb Descriptor List
 
 Copyright (c) 2007 - 2018, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2024, American Megatrends International LLC. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -31,6 +32,10 @@ UsbFreeInterfaceDesc (
       Ep = Setting->Endpoints[Index];
 
       if (Ep != NULL) {
+        if (Ep->CsDesc != NULL) {
+          FreePool (Ep->CsDesc);
+        }
+
         FreePool (Ep);
       }
     }
@@ -43,7 +48,29 @@ UsbFreeInterfaceDesc (
     }
   }
 
+  for (Index = 0; Index < Setting->NumOfCsDesc; Index++) {
+    FreePool (Setting->CsDesc[Index]);
+  }
+
   FreePool (Setting);
+}
+
+/**
+  Free the interface association descriptor
+
+  @param  Iad               The interface association descriptor to free.
+
+**/
+VOID
+UsbFreeInterfaceAssociationDesc (
+  IN USB_INTERFACE_ASSOCIATION_DESC  *Iad
+  )
+{
+  if (Iad->Interfaces != NULL) {
+    FreePool (Iad->Interfaces);
+  }
+
+  FreePool (Iad);
 }
 
 /**
@@ -167,6 +194,11 @@ UsbCreateDesc (
       CtrlLen = sizeof (USB_ENDPOINT_DESC);
       break;
 
+    case USB_DESC_TYPE_INTERFACE_ASSOCIATION:
+      DescLen = sizeof (EFI_USB_INTERFACE_ASSOCIATION_DESCRIPTOR);
+      CtrlLen = sizeof (USB_INTERFACE_ASSOCIATION_DESC);
+      break;
+
     default:
       ASSERT (FALSE);
       return NULL;
@@ -231,6 +263,7 @@ UsbCreateDesc (
     return NULL;
   }
 
+  ASSERT (CtrlLen >= DescLen);
   CopyMem (Desc, Head, (UINTN)DescLen);
 
   *Consumed = Offset;
@@ -273,6 +306,36 @@ UsbParseInterfaceDesc (
   Offset = Used;
 
   //
+  // Check for CS descriptor(s)
+  // Assumptions:
+  //   1. CS descriptor(s) immediately follow interface descriptor
+  //   2. There are no more than USB_MAX_CS_INTERFACE descriptors per interface
+  //
+  for (Index = 0; Index < USB_MAX_CS_INTERFACE; Index++) {
+    if (*(DescBuf + Offset + 1) != USB_DESC_TYPE_CS_INTERFACE) {
+      break;
+    }
+
+    //
+    // Found CS inderface descriptor, save it
+    //
+    Setting->CsDesc[Index] = AllocateZeroPool (*(DescBuf + Offset));
+    CopyMem (Setting->CsDesc[Index], DescBuf + Offset, *(DescBuf + Offset));
+    Offset += *(DescBuf + Offset);
+  }
+
+  ASSERT (Index < USB_MAX_CS_INTERFACE);
+  Setting->NumOfCsDesc = Index;
+
+  DEBUG ((
+    DEBUG_INFO,
+    "UsbParseInterfaceDesc: interface %d (setting %d) has %d CS interfaces\n",
+    Setting->Desc.InterfaceNumber,
+    Setting->Desc.AlternateSetting,
+    Index
+    ));
+
+  //
   // Create an array to hold the interface's endpoints
   //
   NumEp = Setting->Desc.NumEndpoints;
@@ -308,6 +371,19 @@ UsbParseInterfaceDesc (
 
     Setting->Endpoints[Index] = Ep;
     Offset                   += Used;
+    //
+    // Check for EP CS descriptor
+    //
+    if (*(DescBuf+Offset+1) == USB_DESC_TYPE_CS_ENDPOINT) {
+      Setting->Endpoints[Index]->CsDesc = AllocateZeroPool (*(DescBuf + Offset));
+      CopyMem (Setting->Endpoints[Index]->CsDesc, DescBuf + Offset, *(DescBuf + Offset));
+      DEBUG ((
+        DEBUG_INFO,
+        "UsbParseInterfaceDesc: interface %d (setting %d) has CS endpoint\n",
+        Setting->Desc.InterfaceNumber,
+        Setting->Desc.AlternateSetting
+        ));
+    }
   }
 
 ON_EXIT:
@@ -316,6 +392,87 @@ ON_EXIT:
 
 ON_ERROR:
   UsbFreeInterfaceDesc (Setting);
+  return NULL;
+}
+
+/**
+  Parse an interface association and its interfaces.
+
+  @param  DescBuf               The buffer of raw interface association descriptor.
+  @param  Len                   The length of the raw descriptor buffer.
+  @param  Config                The device configuration buffer.
+  @param  Consumed              The number of raw descriptor consumed.
+
+  @return The created interface association descriptor or NULL if failed.
+
+**/
+USB_INTERFACE_ASSOCIATION_DESC *
+UsbParseInterfaceAssociationDesc (
+  IN UINT8            *DescBuf,
+  IN UINTN            Len,
+  IN USB_CONFIG_DESC  *Config,
+  OUT UINTN           *Consumed
+  )
+{
+  USB_INTERFACE_ASSOCIATION_DESC  *Iad;
+  UINT8                           Index;
+  UINT8                           IfIndex;
+  UINT8                           i;
+  UINTN                           NumIf;
+  UINTN                           Used;
+
+  *Consumed = 0;
+  Iad       = UsbCreateDesc (DescBuf, Len, USB_DESC_TYPE_INTERFACE_ASSOCIATION, &Used);
+
+  if (Iad == NULL) {
+    return NULL;
+  }
+
+  //
+  // Create an array to hold the association's interfaces
+  //
+  NumIf = Iad->Desc.InterfaceCount;
+
+  DEBUG ((
+    DEBUG_INFO,
+    "UsbParseInterfaceAssociationDesc: interface association has %d interfaces\n",
+    (UINT32)NumIf
+    ));
+
+  ASSERT (NumIf > 0);
+  if (NumIf == 0) {
+    DEBUG ((DEBUG_ERROR, "UsbParseInterfaceAssociationDesc: no interfaces are reported for this association.\n"));
+    goto ON_ERROR;
+  }
+
+  Iad->Interfaces = AllocateZeroPool (sizeof (USB_INTERFACE_DESC *) * NumIf);
+
+  //
+  // Populate interfaces for this association
+  //
+  IfIndex = 0;
+  for (Index = Iad->Desc.FirstInterface;
+       Index < (UINT8)(Iad->Desc.FirstInterface + Iad->Desc.InterfaceCount); Index++)
+  {
+    for (i = 0; i < Config->Desc.NumInterfaces; i++) {
+      if (Index == Config->Interfaces[i]->Settings[0]->Desc.InterfaceNumber) {
+        break;
+      }
+    }
+
+    if (i == Config->Desc.NumInterfaces) {
+      DEBUG ((DEBUG_ERROR, "UsbParseInterfaceAssociationDesc: interface %d not found.\n", Index));
+      goto ON_ERROR;
+    }
+
+    Iad->Interfaces[IfIndex++] = Config->Interfaces[i];
+  }
+
+  *Consumed = Used;
+  return Iad;
+
+ON_ERROR:
+  UsbFreeInterfaceAssociationDesc (Iad);
   return NULL;
 }
 
@@ -334,16 +491,22 @@ UsbParseConfigDesc (
   IN UINTN  Len
   )
 {
-  USB_CONFIG_DESC        *Config;
-  USB_INTERFACE_SETTING  *Setting;
-  USB_INTERFACE_DESC     *Interface;
-  UINTN                  Index;
-  UINTN                  NumIf;
-  UINTN                  Consumed;
+  USB_CONFIG_DESC                 *Config;
+  USB_INTERFACE_SETTING           *Setting;
+  USB_INTERFACE_DESC              *Interface;
+  UINTN                           Index;
+  UINTN                           NumIf;
+  UINTN                           Consumed;
+  UINT8                           *Buffer;
+  UINTN                           Length;
+  USB_INTERFACE_ASSOCIATION_DESC  *Iad;
 
   ASSERT (DescBuf != NULL);
 
-  Config = UsbCreateDesc (DescBuf, Len, USB_DESC_TYPE_CONFIG, &Consumed);
+  Buffer = DescBuf;
+  Length = Len;
+
+  Config = UsbCreateDesc (Buffer, Length, USB_DESC_TYPE_CONFIG, &Consumed);
 
   if (Config == NULL) {
     return NULL;
@@ -384,15 +547,15 @@ UsbParseConfigDesc (
   // setting 1|interface 1, setting 0|interface 2, setting 0|. Check
   // USB2.0 spec, page 267.
   //
-  DescBuf += Consumed;
-  Len     -= Consumed;
+  Buffer += Consumed;
+  Length -= Consumed;
 
   //
   // Make allowances for devices that return extra data at the
   // end of their config descriptors
   //
-  while (Len >= sizeof (EFI_USB_INTERFACE_DESCRIPTOR)) {
-    Setting = UsbParseInterfaceDesc (DescBuf, Len, &Consumed);
+  while (Length >= sizeof (EFI_USB_INTERFACE_DESCRIPTOR)) {
+    Setting = UsbParseInterfaceDesc (Buffer, Length, &Consumed);
 
     if (Setting == NULL) {
       DEBUG ((DEBUG_ERROR, "UsbParseConfigDesc: warning: failed to get interface setting, stop parsing now.\n"));
@@ -416,8 +579,36 @@ UsbParseConfigDesc (
     Interface->Settings[Interface->NumOfSetting] = Setting;
     Interface->NumOfSetting++;
 
-    DescBuf += Consumed;
-    Len     -= Consumed;
+    Buffer += Consumed;
+    Length -= Consumed;
+  }
+
+  //
+  // Process interface association descriptors.
+  //
+  Buffer = DescBuf;
+  Length = Len;
+
+  while (Length >= sizeof (EFI_USB_INTERFACE_ASSOCIATION_DESCRIPTOR)) {
+    Iad = UsbParseInterfaceAssociationDesc (Buffer, Length, Config, &Consumed);
+
+    if (Iad == NULL) {
+      break;
+    }
+
+    //
+    // Insert the association descriptor to the corresponding set.
+    //
+    if (Config->NumOfIads >= USB_MAX_ASSOCIATION) {
+      DEBUG ((DEBUG_ERROR, "UsbParseConfigDesc: too many interface association descriptors in this configuration.\n"));
+      goto ON_ERROR;
+    }
+
+    Config->Iads[Config->NumOfIads] = Iad;
+    Config->NumOfIads++;
+
+    Buffer += Consumed;
+    Length -= Consumed;
   }
 
   return Config;

--- a/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbDesc.h
+++ b/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbDesc.h
@@ -3,6 +3,7 @@
     Manage Usb Descriptor List
 
 Copyright (c) 2007 - 2014, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2024, American Megatrends International LLC. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -11,6 +12,8 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #define _USB_DESCRIPTOR_H_
 
 #define USB_MAX_INTERFACE_SETTING  256
+#define USB_MAX_CS_INTERFACE       256
+#define USB_MAX_ASSOCIATION        16
 
 //
 // The RequestType in EFI_USB_DEVICE_REQUEST is composed of
@@ -35,7 +38,9 @@ typedef struct {
 // Each USB device has a device descriptor. Each device may
 // have several configures. Each configure contains several
 // interfaces. Each interface may have several settings. Each
-// setting has several endpoints.
+// setting has several endpoints. Interfaces and endpoints may
+// be accompanied by class specific interface and endpoint
+// descriptors.
 //
 // EFI_USB_..._DESCRIPTOR must be the first member of the
 // structure.
@@ -43,10 +48,13 @@ typedef struct {
 typedef struct {
   EFI_USB_ENDPOINT_DESCRIPTOR    Desc;
   UINT8                          Toggle;
+  UINT8                          *CsDesc;
 } USB_ENDPOINT_DESC;
 
 typedef struct {
   EFI_USB_INTERFACE_DESCRIPTOR    Desc;
+  UINTN                           NumOfCsDesc;
+  UINT8                           *CsDesc[USB_MAX_CS_INTERFACE];
   USB_ENDPOINT_DESC               **Endpoints;
 } USB_INTERFACE_SETTING;
 
@@ -62,8 +70,15 @@ typedef struct {
 } USB_INTERFACE_DESC;
 
 typedef struct {
-  EFI_USB_CONFIG_DESCRIPTOR    Desc;
-  USB_INTERFACE_DESC           **Interfaces;
+  EFI_USB_INTERFACE_ASSOCIATION_DESCRIPTOR    Desc;
+  USB_INTERFACE_DESC                          **Interfaces;
+} USB_INTERFACE_ASSOCIATION_DESC;
+
+typedef struct {
+  EFI_USB_CONFIG_DESCRIPTOR         Desc;
+  USB_INTERFACE_ASSOCIATION_DESC    *Iads[USB_MAX_ASSOCIATION];
+  UINT8                             NumOfIads;
+  USB_INTERFACE_DESC                **Interfaces;
 } USB_CONFIG_DESC;
 
 typedef struct {

--- a/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbIntfAssoc.c
+++ b/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbIntfAssoc.c
@@ -1,0 +1,435 @@
+/** @file
+
+  Usb Interface Association Protocol implementation.
+
+Copyright (c) 2024, American Megatrends International LLC. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "UsbIntfAssoc.h"
+
+EFI_USB_IA_PROTOCOL  mUsbIaProtocol = {
+  UsbIaGetAssociationDescriptor,
+  UsbIaGetAssociateAltSettings,
+  UsbIaGetInterfaceDescriptor,
+  UsbIaGetEndpointDescriptor,
+  UsbIaGetCsInterfaceDescriptor,
+  UsbIaGetCsEndpointDescriptor
+};
+
+/**
+  Get the interface from interface association.
+
+  @param[in]  UsbIa   A pointer to the interface association data.
+  @param[in]  InterfaceNumber Interface to look for inside the association.
+
+  @retval A pointer to the interface data
+  @retval NULL  Interface is not found in the association.
+
+**/
+USB_INTERFACE_DESC *
+UsbAssocFindInterface (
+  IN USB_ASSOCIATION  *UsbIa,
+  IN UINT8            InterfaceNumber
+  )
+{
+  UINT8  Index;
+  UINT8  Intrf;
+
+  Intrf = UsbIa->IaDesc->Desc.FirstInterface;
+  for (Index = 0; Index < UsbIa->IaDesc->Desc.InterfaceCount; Index++) {
+    if (InterfaceNumber == Intrf) {
+      return UsbIa->IaDesc->Interfaces[Index];
+    }
+
+    Intrf++;
+  }
+
+  DEBUG ((DEBUG_ERROR, "UsbAssocFindInterface: interface 0x%x does not belong to this association\n", InterfaceNumber));
+  return NULL;
+}
+
+/**
+  Get the USB Interface Association Descriptor from the current USB configuration.
+
+  @param[in] This              A pointer to the EFI_USB_IA_PROTOCOL instance.
+  @param[out] Descriptor       A pointer to the caller allocated USB Interface Association Descriptor.
+
+  @retval EFI_SUCCESS           The descriptor was retrieved successfully.
+  @retval EFI_INVALID_PARAMETER Descriptor is NULL.
+
+**/
+EFI_STATUS
+EFIAPI
+UsbIaGetAssociationDescriptor (
+  IN  EFI_USB_IA_PROTOCOL                       *This,
+  OUT EFI_USB_INTERFACE_ASSOCIATION_DESCRIPTOR  *Descriptor
+  )
+{
+  USB_ASSOCIATION  *UsbIa;
+  EFI_TPL          OldTpl;
+  EFI_STATUS       Status;
+
+  OldTpl = gBS->RaiseTPL (USB_BUS_TPL);
+
+  Status = EFI_SUCCESS;
+
+  ASSERT (Descriptor != NULL);
+  if (Descriptor == NULL) {
+    Status = EFI_INVALID_PARAMETER;
+    goto ON_EXIT;
+  }
+
+  UsbIa = USB_ASSOCIATION_FROM_USBIA (This);
+  CopyMem (Descriptor, &(UsbIa->IaDesc->Desc), sizeof (EFI_USB_INTERFACE_ASSOCIATION_DESCRIPTOR));
+
+ON_EXIT:
+  gBS->RestoreTPL (OldTpl);
+
+  return Status;
+}
+
+/**
+  Retrieve the details of the requested interface that belongs to USB association.
+
+  @param[in]  This              A pointer to the EFI_USB_IA_PROTOCOL instance.
+  @param[in]  InterfaceNumber   Interface that belongs to this association.
+  @param[out]  UsbIo            A pointer to the caller allocated UsbIo protocol.
+  @param[out]  AltSettingsNum   Number of alternate settings of this interface.
+
+  @retval EFI_SUCCESS           Output parameters were updated successfully.
+  @retval EFI_INVALID_PARAMETER UsbIo or AltSettingsNum is NULL.
+  @retval EFI_NOT_FOUND         InterfaceNumber does not belong to this interface association.
+
+**/
+EFI_STATUS
+EFIAPI
+UsbIaGetAssociateAltSettings (
+  IN  EFI_USB_IA_PROTOCOL  *This,
+  IN  UINT8                InterfaceNumber,
+  OUT EFI_USB_IO_PROTOCOL  **UsbIo,
+  OUT UINTN                *AltSettingsNumber
+  )
+{
+  USB_ASSOCIATION     *UsbIa;
+  EFI_TPL             OldTpl;
+  UINT8               Index;
+  EFI_STATUS          Status;
+  USB_DEVICE          *Device;
+  USB_INTERFACE_DESC  *IfDesc;
+
+  OldTpl = gBS->RaiseTPL (USB_BUS_TPL);
+
+  ASSERT ((UsbIo != NULL) && (AltSettingsNumber != NULL));
+  if ((UsbIo == NULL) || (AltSettingsNumber == NULL)) {
+    Status =  EFI_INVALID_PARAMETER;
+    goto  ON_EXIT;
+  }
+
+  UsbIa = USB_ASSOCIATION_FROM_USBIA (This);
+
+  IfDesc = UsbAssocFindInterface (UsbIa, InterfaceNumber);
+  if (IfDesc == NULL) {
+    Status = EFI_NOT_FOUND;
+    goto ON_EXIT;
+  }
+
+  *AltSettingsNumber = IfDesc->NumOfSetting - 1;
+
+  //
+  // Find UsbIo protocol for this interface
+  //
+  Device = UsbIa->Device;
+  Status = EFI_NOT_FOUND;
+
+  for (Index = 0; Index < Device->NumOfInterface; Index++) {
+    if (Device->Interfaces[Index]->IfSetting->Desc.InterfaceNumber == InterfaceNumber) {
+      *UsbIo = &Device->Interfaces[Index]->UsbIo;
+      Status = EFI_SUCCESS;
+      break;
+    }
+  }
+
+ON_EXIT:
+  gBS->RestoreTPL (OldTpl);
+  return Status;
+}
+
+/**
+  Retrieve the interface descriptor details from the interface setting.
+
+  This is an extended version of UsbIo->GetInterfaceDescriptor. It can get the interface descriptor for any alternate
+  setting of the interface. It also returns the number of class specific interfaces.
+
+  @param[in]  This              A pointer to the EFI_USB_IA_PROTOCOL instance.
+  @param[in]  InterfaceNumber   Interface that belongs to this association.
+  @param[in]  AltSetting        Interface alternate setting.
+  @param[out]  Descriptor       The caller allocated buffer to return the contents of the Interface descriptor.
+  @param[out]  CsInterfaceNumber  Number of class specific interfaces for this interface setting.
+
+  @retval EFI_SUCCESS           Output parameters were updated successfully.
+  @retval EFI_INVALID_PARAMETER Descriptor or CsInterfaceNumber is NULL.
+  @retval EFI_NOT_FOUND         Interface does not belong to this association.
+                                AltSetting is greater than the number of alternate settings in this interface.
+**/
+EFI_STATUS
+EFIAPI
+UsbIaGetInterfaceDescriptor (
+  IN  EFI_USB_IA_PROTOCOL           *This,
+  IN  UINT8                         InterfaceNumber,
+  IN  UINTN                         AltSetting,
+  OUT EFI_USB_INTERFACE_DESCRIPTOR  *Descriptor,
+  OUT UINTN                         *CsInterfacesNumber
+  )
+{
+  EFI_TPL             OldTpl;
+  EFI_STATUS          Status;
+  USB_ASSOCIATION     *UsbIa;
+  USB_INTERFACE_DESC  *IfDesc;
+
+  OldTpl = gBS->RaiseTPL (USB_BUS_TPL);
+
+  Status = EFI_SUCCESS;
+
+  ASSERT ((Descriptor != NULL) && (CsInterfacesNumber != NULL));
+  if ((Descriptor == NULL) || (CsInterfacesNumber == NULL)) {
+    Status =  EFI_INVALID_PARAMETER;
+    goto  ON_EXIT;
+  }
+
+  UsbIa  = USB_ASSOCIATION_FROM_USBIA (This);
+  IfDesc = UsbAssocFindInterface (UsbIa, InterfaceNumber);
+
+  if ((IfDesc == NULL) || (AltSetting > (IfDesc->NumOfSetting - 1))) {
+    Status = EFI_NOT_FOUND;
+    goto ON_EXIT;
+  }
+
+  CopyMem (Descriptor, &(IfDesc->Settings[AltSetting]->Desc), sizeof (EFI_USB_INTERFACE_DESCRIPTOR));
+  *CsInterfacesNumber = IfDesc->Settings[AltSetting]->NumOfCsDesc;
+
+ON_EXIT:
+  gBS->RestoreTPL (OldTpl);
+
+  return Status;
+}
+
+/**
+  Retrieve the endpoint descriptor from the interface setting.
+
+  This is an extended version of UsbIo->GetEndpointDescriptor. It can get the endpoint descriptor for any alternate
+  setting of a given interface. Total number of endpoints for this setting can be retrieved from the interface
+  descriptor returned by EFI_USB_IA_GET_INTERFACE_DESCRIPTOR function.
+
+  @param[in]  This              A pointer to the EFI_USB_IA_PROTOCOL instance.
+  @param[in]  InterfaceNumber   Interface that belongs to this association.
+  @param[in]  AltSetting        Interface alternate setting.
+  @param[in]  Index             Index of the endpoint to retrieve. The valid range is 0..15.
+  @param[out]  Descriptor       A pointer to the caller allocated USB Interface Descriptor.
+
+  @retval EFI_SUCCESS           Output parameters were updated successfully.
+  @retval EFI_INVALID_PARAMETER Descriptor is NULL.
+  @retval EFI_NOT_FOUND         Interface does not belong to this association.
+                                AltSetting is greater than the number of alternate settings in this interface.
+                                Index is greater than the number of endpoints in this interface.
+**/
+EFI_STATUS
+EFIAPI
+UsbIaGetEndpointDescriptor (
+  IN  EFI_USB_IA_PROTOCOL          *This,
+  IN  UINT8                        InterfaceNumber,
+  IN  UINTN                        AltSetting,
+  IN  UINTN                        Index,
+  OUT EFI_USB_ENDPOINT_DESCRIPTOR  *Descriptor
+  )
+{
+  EFI_TPL             OldTpl;
+  EFI_STATUS          Status;
+  USB_ASSOCIATION     *UsbIa;
+  USB_INTERFACE_DESC  *IfDesc;
+
+  OldTpl = gBS->RaiseTPL (USB_BUS_TPL);
+
+  Status = EFI_SUCCESS;
+
+  if (Descriptor == NULL) {
+    Status = EFI_INVALID_PARAMETER;
+    goto ON_EXIT;
+  }
+
+  UsbIa  = USB_ASSOCIATION_FROM_USBIA (This);
+  IfDesc = UsbAssocFindInterface (UsbIa, InterfaceNumber);
+
+  if ((IfDesc == NULL) || (AltSetting > (IfDesc->NumOfSetting - 1))) {
+    Status = EFI_NOT_FOUND;
+    goto ON_EXIT;
+  }
+
+  CopyMem (Descriptor, &(IfDesc->Settings[AltSetting]->Endpoints[Index]->Desc), sizeof (EFI_USB_ENDPOINT_DESCRIPTOR));
+
+ON_EXIT:
+  gBS->RestoreTPL (OldTpl);
+
+  return Status;
+}
+
+/**
+  Retrieve class specific interface descriptor.
+
+  @param[in]  This              A pointer to the EFI_USB_IA_PROTOCOL instance.
+  @param[in]  InterfaceNumber   Interface that belongs to this association.
+  @param[in]  AltSetting        Interface alternate setting.
+  @param[in]  Index             Zero-based index of the class specific interface.
+  @param[in][out]  BufferSize   On input, the size in bytes of the return Descriptor buffer.
+                                On output the size of data returned in Descriptor.
+  @param[out]  Descriptor       The buffer to return the contents of the class specific interface descriptor. May
+                                be NULL with a zero BufferSize in order to determine the size buffer needed.
+
+  @retval EFI_SUCCESS           Output parameters were updated successfully.
+  @retval EFI_INVALID_PARAMETER BufferSize is NULL.
+                                Buffer is NULL and *BufferSize is not zero.
+  @retval EFI_NOT_FOUND         Interface does not belong to this association.
+                                AltSetting is greater than the number of alternate settings in this interface.
+                                Index is greater than the number of class specific interfaces.
+  @retval EFI_BUFFER_TOO_SMALL  The BufferSize is too small for the result. BufferSize has been updated with the size
+                                needed to complete the request.
+**/
+EFI_STATUS
+EFIAPI
+UsbIaGetCsInterfaceDescriptor (
+  IN  EFI_USB_IA_PROTOCOL  *This,
+  IN  UINT8                InterfaceNumber,
+  IN  UINTN                AltSetting,
+  IN  UINTN                Index,
+  IN OUT UINTN             *BufferSize,
+  OUT VOID                 *Buffer
+  )
+{
+  EFI_TPL             OldTpl;
+  EFI_STATUS          Status;
+  USB_ASSOCIATION     *UsbIa;
+  USB_INTERFACE_DESC  *IfDesc;
+  UINT8               *Desc;
+  UINT8               DescLength;
+
+  OldTpl = gBS->RaiseTPL (USB_BUS_TPL);
+  Status = EFI_SUCCESS;
+
+  if (  (BufferSize == NULL)
+     || ((Buffer == NULL) && (*BufferSize != 0)))
+  {
+    Status = EFI_INVALID_PARAMETER;
+    goto ON_EXIT;
+  }
+
+  UsbIa  = USB_ASSOCIATION_FROM_USBIA (This);
+  IfDesc = UsbAssocFindInterface (UsbIa, InterfaceNumber);
+
+  if (  (IfDesc == NULL)
+     || (AltSetting > (IfDesc->NumOfSetting - 1))
+     || ((Index + 1) > IfDesc->Settings[AltSetting]->NumOfCsDesc))
+  {
+    Status = EFI_NOT_FOUND;
+    goto ON_EXIT;
+  }
+
+  Desc       = IfDesc->Settings[AltSetting]->CsDesc[Index];
+  DescLength = Desc[0];
+
+  *BufferSize = DescLength;
+  if (  (Buffer == NULL)
+     || (DescLength > *BufferSize))
+  {
+    Status = EFI_BUFFER_TOO_SMALL;
+    goto ON_EXIT;
+  }
+
+  CopyMem (Buffer, Desc, DescLength);
+
+ON_EXIT:
+  gBS->RestoreTPL (OldTpl);
+
+  return Status;
+}
+
+/**
+  Retrieve class specific endpoint descriptor.
+
+  @param[in]  This              A pointer to the EFI_USB_IA_PROTOCOL instance.
+  @param[in]  InterfaceNumber   Interface that belongs to this association.
+  @param[in]  AltSetting        Interface alternate setting.
+  @param[in]  Index             Index of the non-zero endpoint.
+  @param[in][out]  BufferSize   On input, the size in bytes of the return Descriptor buffer.
+                                On output the size of data returned in Descriptor.
+  @param[out]  Descriptor       The buffer to return the contents of the class specific endpoint descriptor. May
+                                be NULL with a zero BufferSize in order to determine the size buffer needed.
+
+  @retval EFI_SUCCESS           Output parameters were updated successfully.
+  @retval EFI_INVALID_PARAMETER BufferSize is NULL.
+                                Buffer is NULL and *BufferSize is not zero.
+  @retval EFI_NOT_FOUND         Interface does not belong to this association.
+                                AltSetting is greater than the number of alternate settings in this interface.
+                                Index is greater than the number of endpoints in this interface.
+                                Endpoint does not have class specific endpoint descriptor.
+  @retval EFI_BUFFER_TOO_SMALL  The BufferSize is too small for the result. BufferSize has been updated with the size
+                                needed to complete the request.
+**/
+EFI_STATUS
+EFIAPI
+UsbIaGetCsEndpointDescriptor (
+  IN  EFI_USB_IA_PROTOCOL  *This,
+  IN  UINT8                InterfaceNumber,
+  IN  UINTN                AltSetting,
+  IN  UINTN                Index,
+  IN OUT UINTN             *BufferSize,
+  OUT VOID                 *Buffer
+  )
+{
+  EFI_TPL             OldTpl;
+  EFI_STATUS          Status;
+  USB_ASSOCIATION     *UsbIa;
+  USB_INTERFACE_DESC  *IfDesc;
+  UINT8               *Desc;
+  UINT8               DescLength;
+
+  OldTpl = gBS->RaiseTPL (USB_BUS_TPL);
+  Status = EFI_SUCCESS;
+
+  if (  (BufferSize == NULL)
+     || ((Buffer == NULL) && (*BufferSize != 0)))
+  {
+    Status = EFI_INVALID_PARAMETER;
+    goto ON_EXIT;
+  }
+
+  UsbIa  = USB_ASSOCIATION_FROM_USBIA (This);
+  IfDesc = UsbAssocFindInterface (UsbIa, InterfaceNumber);
+
+  if (  (IfDesc == NULL)
+     || (AltSetting > (IfDesc->NumOfSetting - 1))
+     || ((Index + 1) > IfDesc->Settings[AltSetting]->Desc.NumEndpoints)
+     || (IfDesc->Settings[AltSetting]->Endpoints[Index]->CsDesc == NULL))
+  {
+    Status = EFI_NOT_FOUND;
+    goto ON_EXIT;
+  }
+
+  Desc       = IfDesc->Settings[AltSetting]->Endpoints[Index]->CsDesc;
+  DescLength = Desc[0];
+
+  *BufferSize = DescLength;
+  if (  (Buffer == NULL)
+     || (DescLength > *BufferSize))
+  {
+    Status = EFI_BUFFER_TOO_SMALL;
+    goto ON_EXIT;
+  }
+
+  CopyMem (Buffer, Desc, DescLength);
+
+ON_EXIT:
+  gBS->RestoreTPL (OldTpl);
+
+  return Status;
+}

--- a/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbIntfAssoc.h
+++ b/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbIntfAssoc.h
@@ -1,0 +1,177 @@
+/** @file
+
+  Usb Interface Association Protocol header.
+
+Copyright (c) 2024, American Megatrends International LLC. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef __USB_INTF_ASSOC_IO_H__
+#define __USB_INTF_ASSOC_IO_H__
+
+#include "UsbBus.h"
+
+/**
+  Get the USB Interface Association Descriptor from the current USB configuration.
+
+  @param[in] This              A pointer to the EFI_USB_IA_PROTOCOL instance.
+  @param[out] Descriptor       A pointer to the caller allocated USB Interface Association Descriptor.
+
+  @retval EFI_SUCCESS           The descriptor was retrieved successfully.
+  @retval EFI_INVALID_PARAMETER Descriptor is NULL.
+
+**/
+EFI_STATUS
+EFIAPI
+UsbIaGetAssociationDescriptor (
+  IN  EFI_USB_IA_PROTOCOL                       *This,
+  OUT EFI_USB_INTERFACE_ASSOCIATION_DESCRIPTOR  *Descriptor
+  );
+
+/**
+  Retrieve the details of the requested interface that belongs to USB association.
+
+  @param[in] This              A pointer to the EFI_USB_IA_PROTOCOL instance.
+  @param[in] InterfaceNumber   Interface that belongs to this association.
+  @param[out] UsbIo            A pointer to the caller allocated UsbIo protocol.
+  @param[out] AltSettingsNum   Number of alternate settings of this interface.
+
+  @retval EFI_SUCCESS           Output parameters were updated successfully.
+  @retval EFI_INVALID_PARAMETER UsbIo or AltSettingsNum is NULL.
+  @retval EFI_NOT_FOUND         InterfaceNumber does not belong to this interface association.
+
+**/
+EFI_STATUS
+EFIAPI
+UsbIaGetAssociateAltSettings (
+  IN  EFI_USB_IA_PROTOCOL  *This,
+  IN  UINT8                InterfaceNumber,
+  OUT EFI_USB_IO_PROTOCOL  **UsbIo,
+  OUT UINTN                *AltSettingsNumber
+  );
+
+/**
+  Retrieve the interface descriptor details from the interface setting.
+
+  This is an extended version of UsbIo->GetInterfaceDescriptor. It can get the interface descriptor for any alternate
+  setting of the interface. It also returns the number of class specific interfaces.
+
+  @param[in]  This              A pointer to the EFI_USB_IA_PROTOCOL instance.
+  @param[in]  InterfaceNumber   Interface that belongs to this association.
+  @param[in]  AltSetting        Interface alternate setting.
+  @param[out]  Descriptor       The caller allocated buffer to return the contents of the Interface descriptor.
+  @param[out]  CsInterfaceNumber  Number of class specific interfaces for this interface setting.
+
+  @retval EFI_SUCCESS           Output parameters were updated successfully.
+  @retval EFI_INVALID_PARAMETER Descriptor or CsInterfaceNumber is NULL.
+  @retval EFI_NOT_FOUND         Interface does not belong to this association.
+                                AltSetting is greater than the number of alternate settings in this interface.
+**/
+EFI_STATUS
+EFIAPI
+UsbIaGetInterfaceDescriptor (
+  IN  EFI_USB_IA_PROTOCOL           *This,
+  IN  UINT8                         InterfaceNumber,
+  IN  UINTN                         AltSetting,
+  OUT EFI_USB_INTERFACE_DESCRIPTOR  *Descriptor,
+  OUT UINTN                         *CsInterfacesNumber
+  );
+
+/**
+  Retrieve the endpoint descriptor from the interface setting.
+
+  This is an extended version of UsbIo->GetEndpointDescriptor. It can get the endpoint descriptor for any alternate
+  setting of a given interface. Total number of endpoints for this setting can be retrieved from the interface
+  descriptor returned by EFI_USB_IA_GET_INTERFACE_DESCRIPTOR function.
+
+  @param[in]  This              A pointer to the EFI_USB_IA_PROTOCOL instance.
+  @param[in]  InterfaceNumber   Interface that belongs to this association.
+  @param[in]  AltSetting        Interface alternate setting.
+  @param[in]  Index             Index of the endpoint to retrieve. The valid range is 0..15.
+  @param[out]  Descriptor       A pointer to the caller allocated USB Interface Descriptor.
+
+  @retval EFI_SUCCESS           Output parameters were updated successfully.
+  @retval EFI_INVALID_PARAMETER Descriptor is NULL.
+  @retval EFI_NOT_FOUND         Interface does not belong to this association.
+                                AltSetting is greater than the number of alternate settings in this interface.
+                                Index is greater than the number of endpoints in this interface.
+**/
+EFI_STATUS
+EFIAPI
+UsbIaGetEndpointDescriptor (
+  IN  EFI_USB_IA_PROTOCOL          *This,
+  IN  UINT8                        InterfaceNumber,
+  IN  UINTN                        AltSetting,
+  IN  UINTN                        Index,
+  OUT EFI_USB_ENDPOINT_DESCRIPTOR  *Descriptor
+  );
+
+/**
+  Retrieve class specific interface descriptor.
+
+  @param[in]  This              A pointer to the EFI_USB_IA_PROTOCOL instance.
+  @param[in]  InterfaceNumber   Interface that belongs to this association.
+  @param[in]  AltSetting        Interface alternate setting.
+  @param[in]  Index             Zero-based index of the class specific interface.
+  @param[in]  [out]BufferSize   On input, the size in bytes of the return Descriptor buffer.
+                                On output the size of data returned in Descriptor.
+  @param[out]  Descriptor       The buffer to return the contents of the class specific interface descriptor. May
+                                be NULL with a zero BufferSize in order to determine the size buffer needed.
+
+  @retval EFI_SUCCESS           Output parameters were updated successfully.
+  @retval EFI_INVALID_PARAMETER BufferSize is NULL.
+                                Buffer is NULL and *BufferSize is not zero.
+  @retval EFI_NOT_FOUND         Interface does not belong to this association.
+                                AltSetting is greater than the number of alternate settings in this interface.
+                                Index is greater than the number of class specific interfaces.
+  @retval EFI_BUFFER_TOO_SMALL  The BufferSize is too small for the result. BufferSize has been updated with the size
+                                needed to complete the request.
+**/
+EFI_STATUS
+EFIAPI
+UsbIaGetCsInterfaceDescriptor (
+  IN  EFI_USB_IA_PROTOCOL  *This,
+  IN  UINT8                InterfaceNumber,
+  IN  UINTN                AltSetting,
+  IN  UINTN                Index,
+  IN OUT UINTN             *BufferSize,
+  OUT VOID                 *Buffer
+  );
+
+/**
+  Retrieve class specific endpoint descriptor.
+
+  @param[in]  This              A pointer to the EFI_USB_IA_PROTOCOL instance.
+  @param[in]  InterfaceNumber   Interface that belongs to this association.
+  @param[in]  AltSetting        Interface alternate setting.
+  @param[in]  Index             Index of the non-zero endpoint.
+  @param[in]  [out]BufferSize   On input, the size in bytes of the return Descriptor buffer.
+                                On output the size of data returned in Descriptor.
+  @param[out]  Descriptor       The buffer to return the contents of the class specific endpoint descriptor. May
+                                be NULL with a zero BufferSize in order to determine the size buffer needed.
+
+  @retval EFI_SUCCESS           Output parameters were updated successfully.
+  @retval EFI_INVALID_PARAMETER BufferSize is NULL.
+                                Buffer is NULL and *BufferSize is not zero.
+  @retval EFI_NOT_FOUND         Interface does not belong to this association.
+                                AltSetting is greater than the number of alternate settings in this interface.
+                                Index is greater than the number of endpoints in this interface.
+                                Endpoint does not have class specific endpoint descriptor.
+  @retval EFI_BUFFER_TOO_SMALL  The BufferSize is too small for the result. BufferSize has been updated with the size
+                                needed to complete the request.
+**/
+EFI_STATUS
+EFIAPI
+UsbIaGetCsEndpointDescriptor (
+  IN  EFI_USB_IA_PROTOCOL  *This,
+  IN  UINT8                InterfaceNumber,
+  IN  UINTN                AltSettingsNumber,
+  IN  UINTN                Index,
+  IN OUT UINTN             *BufferSize,
+  OUT VOID                 *Buffer
+  );
+
+extern EFI_USB_IA_PROTOCOL  mUsbIaProtocol;
+
+#endif

--- a/MdeModulePkg/Bus/Usb/UsbNetwork/UsbCdcEcm/UsbEcmFunction.c
+++ b/MdeModulePkg/Bus/Usb/UsbNetwork/UsbCdcEcm/UsbEcmFunction.c
@@ -111,7 +111,7 @@ GetFunctionalDescriptor (
 
   for (Offset = 0; NextDescriptor (Config, &Offset);) {
     Interface = (EFI_USB_INTERFACE_DESCRIPTOR *)((UINT8 *)Config + Offset);
-    if (Interface->DescriptorType == CS_INTERFACE) {
+    if (Interface->DescriptorType == USB_DESC_TYPE_CS_INTERFACE) {
       if (((USB_HEADER_FUN_DESCRIPTOR *)Interface)->DescriptorSubtype == FunDescriptorType) {
         switch (FunDescriptorType) {
           case HEADER_FUN_DESCRIPTOR:

--- a/MdeModulePkg/Bus/Usb/UsbNetwork/UsbCdcNcm/UsbNcmFunction.c
+++ b/MdeModulePkg/Bus/Usb/UsbNetwork/UsbCdcNcm/UsbNcmFunction.c
@@ -111,7 +111,7 @@ GetFunctionalDescriptor (
 
   for (Offset = 0; NextDescriptor (Config, &Offset);) {
     Interface = (EFI_USB_INTERFACE_DESCRIPTOR *)((UINT8 *)Config + Offset);
-    if (Interface->DescriptorType == CS_INTERFACE) {
+    if (Interface->DescriptorType == USB_DESC_TYPE_CS_INTERFACE) {
       if (((USB_HEADER_FUN_DESCRIPTOR *)Interface)->DescriptorSubtype == FunDescriptorType) {
         switch (FunDescriptorType) {
           case HEADER_FUN_DESCRIPTOR:

--- a/MdeModulePkg/Bus/Usb/UsbNetwork/UsbRndis/UsbRndisFunction.c
+++ b/MdeModulePkg/Bus/Usb/UsbNetwork/UsbRndis/UsbRndisFunction.c
@@ -123,7 +123,7 @@ GetFunctionalDescriptor (
 
   for (Offset = 0; NextDescriptor (Config, &Offset);) {
     Interface = (EFI_USB_INTERFACE_DESCRIPTOR *)((UINT8 *)Config + Offset);
-    if (Interface->DescriptorType == CS_INTERFACE) {
+    if (Interface->DescriptorType == USB_DESC_TYPE_CS_INTERFACE) {
       if (((USB_HEADER_FUN_DESCRIPTOR *)Interface)->DescriptorSubtype == FunDescriptorType) {
         switch (FunDescriptorType) {
           case HEADER_FUN_DESCRIPTOR:

--- a/MdeModulePkg/Include/Protocol/UsbEthernetProtocol.h
+++ b/MdeModulePkg/Include/Protocol/UsbEthernetProtocol.h
@@ -2,7 +2,7 @@
   Header file contains code for USB Ethernet Protocol
   definitions
 
-  Copyright (c) 2023, American Megatrends International LLC. All rights reserved.<BR>
+  Copyright (c) 2023 - 2024, American Megatrends International LLC. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
@@ -27,10 +27,6 @@ typedef struct _EDKII_USB_ETHERNET_PROTOCOL EDKII_USB_ETHERNET_PROTOCOL;
 #define USB_MISC_CLASS               0xEF
 #define USB_RNDIS_SUBCLASS           0x04
 #define USB_RNDIS_ETHERNET_PROTOCOL  0x01
-
-// Type Values for the DescriptorType Field
-#define CS_INTERFACE  0x24
-#define CS_ENDPOINT   0x25
 
 // Descriptor SubType in Functional Descriptors
 #define HEADER_FUN_DESCRIPTOR    0x00

--- a/MdePkg/Include/IndustryStandard/Usb.h
+++ b/MdePkg/Include/IndustryStandard/Usb.h
@@ -2,6 +2,8 @@
   Support for USB 2.0 standard.
 
   Copyright (c) 2006 - 2014, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2024, American Megatrends International LLC. All rights reserved.<BR>
+
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -132,6 +134,21 @@ typedef struct {
 } USB_CONFIG_DESCRIPTOR;
 
 ///
+/// Standard Interface Association Descriptor
+/// USB Engineering Change Note "Interface Association Descriptors" Revision 2.0, Page 4
+///
+typedef struct {
+  UINT8    Length;
+  UINT8    DescriptorType;
+  UINT8    FirstInterface;
+  UINT8    InterfaceCount;
+  UINT8    FunctionClass;
+  UINT8    FunctionSubclass;
+  UINT8    FunctionProtocol;
+  UINT8    FunctionDescriptionStringIndex;
+} USB_INTERFACE_ASSOCIATION_DESCRIPTOR;
+
+///
 /// Standard Interface Descriptor
 /// USB 2.0 spec, Section 9.6.5
 ///
@@ -207,13 +224,16 @@ typedef enum {
   //
   // USB Descriptor types
   //
-  USB_DESC_TYPE_DEVICE    = 0x01,
-  USB_DESC_TYPE_CONFIG    = 0x02,
-  USB_DESC_TYPE_STRING    = 0x03,
-  USB_DESC_TYPE_INTERFACE = 0x04,
-  USB_DESC_TYPE_ENDPOINT  = 0x05,
-  USB_DESC_TYPE_HID       = 0x21,
-  USB_DESC_TYPE_REPORT    = 0x22,
+  USB_DESC_TYPE_DEVICE                = 0x01,
+  USB_DESC_TYPE_CONFIG                = 0x02,
+  USB_DESC_TYPE_STRING                = 0x03,
+  USB_DESC_TYPE_INTERFACE             = 0x04,
+  USB_DESC_TYPE_ENDPOINT              = 0x05,
+  USB_DESC_TYPE_INTERFACE_ASSOCIATION = 0x0b,
+  USB_DESC_TYPE_HID                   = 0x21,
+  USB_DESC_TYPE_REPORT                = 0x22,
+  USB_DESC_TYPE_CS_INTERFACE          = 0x24,
+  USB_DESC_TYPE_CS_ENDPOINT           = 0x25,
 
   //
   // Features to be cleared by CLEAR_FEATURE requests

--- a/MdePkg/Include/Protocol/UsbAssociationIo.h
+++ b/MdePkg/Include/Protocol/UsbAssociationIo.h
@@ -1,0 +1,202 @@
+/** @file
+  EFI Usb Interface Association protocol.
+
+  This protocol is used by USB drivers, running in the EFI boot services
+  environment to access USB devices that implement their configurations
+  using interface association: USB cameras, USB audio devices, USB modems, etc.
+
+  Copyright (c) 2024, American Megatrends International LLC. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef __USB_ASSOCIATION_IO_H__
+#define __USB_ASSOCIATION_IO_H__
+
+#include <IndustryStandard/Usb.h>
+#include <Protocol/UsbIo.h>
+
+typedef USB_INTERFACE_ASSOCIATION_DESCRIPTOR EFI_USB_INTERFACE_ASSOCIATION_DESCRIPTOR;
+
+//
+// Global ID for the USB IAD Protocol
+//
+#define EFI_USB_IA_PROTOCOL_GUID \
+  { \
+    0xf4279fb1, 0xef1e, 0x4346, { 0xab, 0x32, 0x3f, 0xe3, 0x86, 0xee, 0xb4, 0x52 } \
+  }
+
+typedef struct _EFI_USB_IA_PROTOCOL EFI_USB_IA_PROTOCOL;
+
+/**
+  Get the USB Interface Association Descriptor from the current USB configuration.
+
+  @param[in]  This              A pointer to the EFI_USB_IA_PROTOCOL instance.
+  @param[out]  Descriptor       A pointer to the caller allocated USB Interface Association Descriptor.
+
+  @retval EFI_SUCCESS           The descriptor was retrieved successfully.
+  @retval EFI_INVALID_PARAMETER Descriptor is NULL.
+
+**/
+typedef
+EFI_STATUS
+(EFIAPI *EFI_USB_IA_GET_ASSOCIATION_DESCRIPTOR)(
+  IN  EFI_USB_IA_PROTOCOL                       *This,
+  OUT EFI_USB_INTERFACE_ASSOCIATION_DESCRIPTOR  *Descriptor
+  );
+
+/**
+  Retrieve the details of the requested interface that belongs to USB association.
+
+  @param[in] This              A pointer to the EFI_USB_IA_PROTOCOL instance.
+  @param[in] InterfaceNumber   Interface that belongs to this association.
+  @param[out] UsbIo            A pointer to the caller allocated UsbIo protocol.
+  @param[out] AltSettingsNum   Number of alternate settings of this interface.
+
+  @retval EFI_SUCCESS           Output parameters were updated successfully.
+  @retval EFI_INVALID_PARAMETER UsbIo or AltSettingsNum is NULL.
+  @retval EFI_NOT_FOUND         InterfaceNumber does not belong to this interface association.
+
+**/
+typedef
+EFI_STATUS
+(EFIAPI *EFI_USB_IA_GET_ASSOCIATE_ALTSETTINGS)(
+  IN  EFI_USB_IA_PROTOCOL   *This,
+  IN  UINT8                 InterfaceNumber,
+  OUT EFI_USB_IO_PROTOCOL   **UsbIo,
+  OUT UINTN                 *AltSettingsNumber
+  );
+
+/**
+  Retrieve the interface descriptor details from the interface setting.
+
+  This is an extended version of UsbIo->GetInterfaceDescriptor. It can get the interface descriptor for any alternate
+  setting of the interface. It also returns the number of class specific interfaces.
+
+  @param[in]  This              A pointer to the EFI_USB_IA_PROTOCOL instance.
+  @param[in]  InterfaceNumber   Interface that belongs to this association.
+  @param[in]  AltSetting        Interface alternate setting.
+  @param[out]  Descriptor       The caller allocated buffer to return the contents of the Interface descriptor.
+  @param[out]  CsInterfaceNumber  Number of class specific interfaces for this interface setting.
+
+  @retval EFI_SUCCESS           Output parameters were updated successfully.
+  @retval EFI_INVALID_PARAMETER Descriptor or CsInterfaceNumber is NULL.
+  @retval EFI_NOT_FOUND         Interface does not belong to this association.
+                                AltSetting is greater than the number of alternate settings in this interface.
+**/
+typedef
+EFI_STATUS
+(EFIAPI *EFI_USB_IA_GET_INTERFACE_DESCRIPTOR)(
+  IN  EFI_USB_IA_PROTOCOL           *This,
+  IN  UINT8                         InterfaceNumber,
+  IN  UINTN                         AltSetting,
+  OUT EFI_USB_INTERFACE_DESCRIPTOR  *Descriptor,
+  OUT UINTN                         *CsInterfacesNumber
+  );
+
+/**
+  Retrieve the endpoint descriptor from the interface setting.
+
+  This is an extended version of UsbIo->GetEndpointDescriptor. It can get the endpoint descriptor for any alternate
+  setting of a given interface. Total number of endpoints for this setting can be retrieved from the interface
+  descriptor returned by EFI_USB_IA_GET_INTERFACE_DESCRIPTOR function.
+
+  @param[in]  This              A pointer to the EFI_USB_IA_PROTOCOL instance.
+  @param[in]  InterfaceNumber   Interface that belongs to this association.
+  @param[in]  AltSetting        Interface alternate setting.
+  @param[in]  Index             Index of the endpoint to retrieve. The valid range is 0..15.
+  @param[out]  Descriptor       A pointer to the caller allocated USB Interface Descriptor.
+
+  @retval EFI_SUCCESS           Output parameters were updated successfully.
+  @retval EFI_INVALID_PARAMETER Descriptor is NULL.
+  @retval EFI_NOT_FOUND         Interface does not belong to this association.
+                                AltSetting is greater than the number of alternate settings in this interface.
+                                Index is greater than the number of endpoints in this interface.
+**/
+typedef
+EFI_STATUS
+(EFIAPI *EFI_USB_IA_GET_ENDPOINT_DESCRIPTOR)(
+  IN  EFI_USB_IA_PROTOCOL           *This,
+  IN  UINT8                         InterfaceNumber,
+  IN  UINTN                         AltSetting,
+  IN  UINTN                         Index,
+  OUT EFI_USB_ENDPOINT_DESCRIPTOR   *Descriptor
+  );
+
+/**
+  Retrieve class specific interface descriptor.
+
+  @param[in]  This              A pointer to the EFI_USB_IA_PROTOCOL instance.
+  @param[in]  InterfaceNumber   Interface that belongs to this association.
+  @param[in]  AltSetting        Interface alternate setting.
+  @param[in]  Index             Zero-based index of the class specific interface.
+  @param[in][out]  BufferSize   On input, the size in bytes of the return Descriptor buffer.
+                                On output the size of data returned in Descriptor.
+  @param[out]  Descriptor       The buffer to return the contents of the class specific interface descriptor. May
+                                be NULL with a zero BufferSize in order to determine the size buffer needed.
+
+  @retval EFI_SUCCESS           Output parameters were updated successfully.
+  @retval EFI_INVALID_PARAMETER BufferSize is NULL.
+                                Buffer is NULL and *BufferSize is not zero.
+  @retval EFI_NOT_FOUND         Interface does not belong to this association.
+                                AltSetting is greater than the number of alternate settings in this interface.
+                                Index is greater than the number of class specific interfaces.
+  @retval EFI_BUFFER_TOO_SMALL  The BufferSize is too small for the result. BufferSize has been updated with the size
+                                needed to complete the request.
+**/
+typedef
+EFI_STATUS
+(EFIAPI *EFI_USB_IA_GET_CS_INTERFACE_DESCRIPTOR)(
+  IN  EFI_USB_IA_PROTOCOL   *This,
+  IN  UINT8                 InterfaceNumber,
+  IN  UINTN                 AltSetting,
+  IN  UINTN                 Index,
+  IN OUT UINTN              *BufferSize,
+  OUT VOID                  *Buffer
+  );
+
+/**
+  Retrieve class specific endpoint descriptor.
+
+  @param[in]  This              A pointer to the EFI_USB_IA_PROTOCOL instance.
+  @param[in]  InterfaceNumber   Interface that belongs to this association.
+  @param[in]  AltSetting        Interface alternate setting.
+  @param[in]  Index             Index of the non-zero endpoint.
+  @param[in][out]  BufferSize   On input, the size in bytes of the return Descriptor buffer.
+                                On output the size of data returned in Descriptor.
+  @param[out]  Descriptor       The buffer to return the contents of the class specific endpoint descriptor. May
+                                be NULL with a zero BufferSize in order to determine the size buffer needed.
+
+  @retval EFI_SUCCESS           Output parameters were updated successfully.
+  @retval EFI_INVALID_PARAMETER BufferSize is NULL.
+                                Buffer is NULL and *BufferSize is not zero.
+  @retval EFI_NOT_FOUND         Interface does not belong to this association.
+                                AltSetting is greater than the number of alternate settings in this interface.
+                                Index is greater than the number of endpoints in this interface.
+                                Endpoint does not have class specific endpoint descriptor.
+  @retval EFI_BUFFER_TOO_SMALL  The BufferSize is too small for the result. BufferSize has been updated with the size
+                                needed to complete the request.
+**/
+typedef
+EFI_STATUS
+(EFIAPI *EFI_USB_IA_GET_CS_ENDPOINT_DESCRIPTOR)(
+  IN  EFI_USB_IA_PROTOCOL   *This,
+  IN  UINT8                 InterfaceNumber,
+  IN  UINTN                 AltSettingsNumber,
+  IN  UINTN                 Index,
+  IN OUT UINTN              *BufferSize,
+  OUT VOID                  *Buffer
+  );
+
+struct _EFI_USB_IA_PROTOCOL {
+  EFI_USB_IA_GET_ASSOCIATION_DESCRIPTOR     UsbIaGetAssociationDescriptor;
+  EFI_USB_IA_GET_ASSOCIATE_ALTSETTINGS      UsbIaGetAssociateSettings;
+  EFI_USB_IA_GET_INTERFACE_DESCRIPTOR       UsbIaGetInterfaceDescriptor;
+  EFI_USB_IA_GET_ENDPOINT_DESCRIPTOR        UsbIaGetEndpointDescriptor;
+  EFI_USB_IA_GET_CS_INTERFACE_DESCRIPTOR    UsbIaGetCsInterfaceDescriptor;
+  EFI_USB_IA_GET_CS_ENDPOINT_DESCRIPTOR     UsbIaGetCsEndpointDescriptor;
+};
+
+extern EFI_GUID  gEfiUsbIaProtocolGuid;
+
+#endif

--- a/MdePkg/MdePkg.dec
+++ b/MdePkg/MdePkg.dec
@@ -11,6 +11,7 @@
 # Copyright (c) 2021 - 2022, Arm Limited. All rights reserved.<BR>
 # Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.<BR>
 # Copyright (c) 2023, Ampere Computing LLC. All rights reserved.<BR>
+# Copyright (c) 2024, American Megatrends International LLC. All rights reserved.<BR>
 #
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -1590,6 +1591,9 @@
 
   ## Include/Protocol/UsbIo.h
   gEfiUsbIoProtocolGuid          = { 0x2B2F68D6, 0x0CD2, 0x44CF, { 0x8E, 0x8B, 0xBB, 0xA2, 0x0B, 0x1B, 0x5B, 0x75 }}
+
+  ## Include/Protocol/UsbIad.h
+  gEfiUsbIaProtocolGuid          = { 0xf4279fb1, 0xef1e, 0x4346, { 0xab, 0x32, 0x3f, 0xe3, 0x86, 0xee, 0xb4, 0x52 }}
 
   ## Include/Protocol/AcpiTable.h
   gEfiAcpiTableProtocolGuid      = { 0xFFE06BDD, 0x6107, 0x46A6, { 0x7B, 0xB2, 0x5A, 0x9C, 0x7E, 0xC5, 0x27, 0x5C }}


### PR DESCRIPTION
Some USB devices - cameras, modems, network, etc. - may implement their configurations using Interface Association. For these devices UsbBus installs UsbIo for every interface. The installed UsbIo's are not grouped into associations. Also, these devices typically carry Class Specific interface descriptors that are not currently parsed and reported by UsbBus. Adding interface association protocol is essential for device drivers implementation.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested
Usb Ia protocol test shell application is executed while the device with USB association descriptor was connected (USB camera).

## Integration Instructions
N/A

