### PR TITLE
UefiCpuPkg MpInformation2.h: Include PiMultiPhase.h

### DIFF
--- a/UefiCpuPkg/Include/Guid/MpInformation2.h
+++ b/UefiCpuPkg/Include/Guid/MpInformation2.h
@@ -1,13 +1,13 @@
 /** @file
-  EFI MP information protocol provides a lightweight MP_SERVICES_PROTOCOL.
+  MP information HOB to be provided by MP service module.
 
-  MP information protocol only provides static information of MP processor.
+  MP information HOB only provides static information of MP processors.
 
   If SwitchBSP or Enable/DisableAP in MP service is called between the HOB
   production and HOB consumption, EFI_PROCESSOR_INFORMATION.StatusFlag field
   in this HOB may be invalidated.
 
-  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2023 - 2024, Intel Corporation. All rights reserved.<BR>
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -16,9 +16,8 @@
 #ifndef MP_INFORMATION2_H_
 #define MP_INFORMATION2_H_
 
+#include <Pi/PiMultiPhase.h>
 #include <Protocol/MpService.h>
-#include <PiPei.h>
-#include <Ppi/SecPlatformInformation.h>
 
 #define MP_INFORMATION2_HOB_REVISION  1
 


### PR DESCRIPTION
There will be build failure because of definition for EFI_AP_PROCEDURE is not found if MpInformation2.h is included by base type library.

MpInformation2.h depends on MpService.h because of EFI_PROCESSOR_INFORMATION definition, and then MpService.h depends on PiMultiPhase.h because of EFI_AP_PROCEDURE definition.

This patch updates MpInformation2.h to include PiMultiPhase.h instead of PiPei.h and also removes SecPlatformInformation.h including. It also does minor refinement to file header description.

# Description
- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested
CI test pass through Draft PR and internal build test pass.

## Integration Instructions
N/A
