### PR TITLE
RedfishPkg/RedfishCredentialDxe: Fix 'too many arguments' error

### DIFF
--- a/RedfishPkg/RedfishCredentialDxe/RedfishCredentialDxe.c
+++ b/RedfishPkg/RedfishCredentialDxe/RedfishCredentialDxe.c
@@ -567,6 +567,7 @@ RedfishGetAuthConfig (
 **/
 EFI_STATUS
 ClearRedfishServiceList (
+  VOID
   )
 {
   REDFISH_SERVICE_LIST  *Instance;
@@ -917,7 +918,7 @@ ReleaseCredentialPrivate (
       mCredentialPrivate->AccountName = NULL;
     }
 
-    ClearRedfishServiceList (mCredentialPrivate);
+    ClearRedfishServiceList ();
   }
 
   return EFI_SUCCESS;


### PR DESCRIPTION
# Description

This fixes the error 'too many arguments to ClearRedfishServiceList' when building with clang compiler.

```
RedfishPkg/RedfishCredentialDxe/RedfishCredentialDxe.c:920:48: error: too many arguments in call to 'ClearRedfishServiceList' [-Werror]
    ClearRedfishServiceList (mCredentialPrivate);
    ~~~~~~~~~~~~~~~~~~~~~~~                    ^
1 error generated.
```

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Compilation with the clang compiler.

## Integration Instructions
