### PR TITLE
MdePkg/Include/IndustryStandard: Add missing RAS related structures to Industry Standard CXL headers

### DIFF
--- a/MdePkg/Include/IndustryStandard/Cxl20.h
+++ b/MdePkg/Include/IndustryStandard/Cxl20.h
@@ -458,6 +458,17 @@ typedef union {
   UINT64    Uint64;
 } CXL_MEMORY_DEVICE_STATUS_REGISTER;
 
+//
+// Get Event Interrupt Policy payload
+// Compute Express Link Specification Revision 2.0  - Chapter 8.2.9.1.4
+//
+typedef struct {
+  UINT8    InformationalEventLogInterruptSettings;
+  UINT8    WarningEventLogInterruptSettings;
+  UINT8    FailureEventLogInterruptSettings;
+  UINT8    FatalEventLogInterruptSettings;
+} CXL_2_0_EVENT_INTERRUPT_POLICY_PAYLOAD;
+
 #pragma pack()
 
 #endif


### PR DESCRIPTION
[Issue Description]
In MdePkg/Include/IndustryStandard CXL files there are missing multiple definitions regarding RAS related structures like Event Records, Media and Poison Management structures, Scan Media payload structures, Event Interrupt Policy

[Resolution]
Add these definitions to MdePkg/Include/IndustryStandard/Cxl30.h and Cxl20.h

# Description
- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - No
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - No
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - No

## How This Was Tested

CI builds pass

## Integration Instructions

N/A
