### PR TITLE
USB Class specific definitions

### DIFF
--- a/MdeModulePkg/Bus/Usb/UsbNetwork/UsbCdcEcm/UsbEcmFunction.c
+++ b/MdeModulePkg/Bus/Usb/UsbNetwork/UsbCdcEcm/UsbEcmFunction.c
@@ -111,7 +111,7 @@ GetFunctionalDescriptor (
 
   for (Offset = 0; NextDescriptor (Config, &Offset);) {
     Interface = (EFI_USB_INTERFACE_DESCRIPTOR *)((UINT8 *)Config + Offset);
-    if (Interface->DescriptorType == CS_INTERFACE) {
+    if (Interface->DescriptorType == USB_DESC_TYPE_CS_INTERFACE) {
       if (((USB_HEADER_FUN_DESCRIPTOR *)Interface)->DescriptorSubtype == FunDescriptorType) {
         switch (FunDescriptorType) {
           case HEADER_FUN_DESCRIPTOR:

--- a/MdeModulePkg/Bus/Usb/UsbNetwork/UsbCdcNcm/UsbNcmFunction.c
+++ b/MdeModulePkg/Bus/Usb/UsbNetwork/UsbCdcNcm/UsbNcmFunction.c
@@ -111,7 +111,7 @@ GetFunctionalDescriptor (
 
   for (Offset = 0; NextDescriptor (Config, &Offset);) {
     Interface = (EFI_USB_INTERFACE_DESCRIPTOR *)((UINT8 *)Config + Offset);
-    if (Interface->DescriptorType == CS_INTERFACE) {
+    if (Interface->DescriptorType == USB_DESC_TYPE_CS_INTERFACE) {
       if (((USB_HEADER_FUN_DESCRIPTOR *)Interface)->DescriptorSubtype == FunDescriptorType) {
         switch (FunDescriptorType) {
           case HEADER_FUN_DESCRIPTOR:

--- a/MdeModulePkg/Bus/Usb/UsbNetwork/UsbRndis/UsbRndisFunction.c
+++ b/MdeModulePkg/Bus/Usb/UsbNetwork/UsbRndis/UsbRndisFunction.c
@@ -123,7 +123,7 @@ GetFunctionalDescriptor (
 
   for (Offset = 0; NextDescriptor (Config, &Offset);) {
     Interface = (EFI_USB_INTERFACE_DESCRIPTOR *)((UINT8 *)Config + Offset);
-    if (Interface->DescriptorType == CS_INTERFACE) {
+    if (Interface->DescriptorType == USB_DESC_TYPE_CS_INTERFACE) {
       if (((USB_HEADER_FUN_DESCRIPTOR *)Interface)->DescriptorSubtype == FunDescriptorType) {
         switch (FunDescriptorType) {
           case HEADER_FUN_DESCRIPTOR:

--- a/MdeModulePkg/Include/Protocol/UsbEthernetProtocol.h
+++ b/MdeModulePkg/Include/Protocol/UsbEthernetProtocol.h
@@ -28,10 +28,6 @@ typedef struct _EDKII_USB_ETHERNET_PROTOCOL EDKII_USB_ETHERNET_PROTOCOL;
 #define USB_RNDIS_SUBCLASS           0x04
 #define USB_RNDIS_ETHERNET_PROTOCOL  0x01
 
-// Type Values for the DescriptorType Field
-#define CS_INTERFACE  0x24
-#define CS_ENDPOINT   0x25
-
 // Descriptor SubType in Functional Descriptors
 #define HEADER_FUN_DESCRIPTOR    0x00
 #define UNION_FUN_DESCRIPTOR     0x06


### PR DESCRIPTION
- Class specific types for interface and endpoint are generic
- Definitions are in IndustryStandard/Usb.h
- Remove type redefinition
- Update references to the descriptor types

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## Integration Instructions
N/A
