### PR TITLE
EmbeddedPkg: MDEPKG_NDEBUG fixes

### DIFF
--- a/EmbeddedPkg/EmbeddedPkg.dsc
+++ b/EmbeddedPkg/EmbeddedPkg.dsc
@@ -196,6 +196,7 @@
   gEmbeddedTokenSpaceGuid.PcdTimerPeriod|100000
 
 [BuildOptions]
+  RELEASE_*_*_CC_FLAGS  = -DMDEPKG_NDEBUG
   *_*_*_CC_FLAGS  = -DDISABLE_NEW_DEPRECATED_INTERFACES
 
 ################################################################################

--- a/EmbeddedPkg/Universal/MmcDxe/MmcDebug.c
+++ b/EmbeddedPkg/Universal/MmcDxe/MmcDebug.c
@@ -8,16 +8,14 @@
 
 #include "Mmc.h"
 
-#if !defined (MDEPKG_NDEBUG)
-CONST CHAR8  *mStrUnit[] = {
+STATIC CONST CHAR8  *mStrUnit[] = {
   "100kbit/s", "1Mbit/s", "10Mbit/s", "100MBit/s",
   "Unknown",   "Unknown", "Unknown",  "Unknown"
 };
-CONST CHAR8  *mStrValue[] = {
+STATIC CONST CHAR8  *mStrValue[] = {
   "1.0",     "1.2",     "1.3",     "1.5", "2.0", "2.5", "3.0", "3.5", "4.0", "4.5", "5.0",
   "Unknown", "Unknown", "Unknown", "Unknown"
 };
-#endif
 
 VOID
 PrintCID (


### PR DESCRIPTION
# Description

Add -DMDEPKG_NDEBUG to EmbeddedPkg CC_FLAGS for RELEASE build. Although EmbeddedPkg normally provides components to other packages, it is less surprising if its own build defines MDEPKG_NDEBUG when consuming packages normally would.

Additionally remove MDEPKG_NDEBUG dependent code which is no longer needed given update of 'null' debug macros in ae83c6b7fd83a5906e016a32027c1bcd792a624e to explicitly mark debug-only code as discarded; correctly mark as STATIC the two arrays within the updated code block.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

Local build.

## Integration Instructions

N/A
