### PR TITLE
BaseTools: Fix linker visibility issue in NOOPT CLANGDWARF X64 build

### DIFF
--- a/BaseTools/Conf/tools_def.template
+++ b/BaseTools/Conf/tools_def.template
@@ -2088,8 +2088,8 @@ RELEASE_CLANGDWARF_X64_CC_FLAGS       = DEF(CLANGDWARF_ALL_CC_FLAGS) -m64 "-DEFI
 RELEASE_CLANGDWARF_X64_DLINK_FLAGS    = DEF(CLANGDWARF_IA32_X64_DLINK_FLAGS) -flto -Wl,-O3 -Wl,-melf_x86_64 -Wl,--oformat,elf64-x86-64 -Wl,-pie -mcmodel=small -Wl,--apply-dynamic-relocs
 RELEASE_CLANGDWARF_X64_DLINK2_FLAGS   = DEF(CLANGDWARF_X64_DLINK2_FLAGS) -O3 -fuse-ld=lld
 
-NOOPT_CLANGDWARF_X64_CC_FLAGS         = DEF(CLANGDWARF_ALL_CC_FLAGS) -m64 "-DEFIAPI=__attribute__((ms_abi))" -mno-red-zone -mcmodel=small -fpie -fdirect-access-external-data -O0 DEF(CLANGDWARF_X64_TARGET) -g
-NOOPT_CLANGDWARF_X64_DLINK_FLAGS      = DEF(CLANGDWARF_IA32_X64_DLINK_FLAGS) -Wl,-O0 -Wl,-melf_x86_64 -Wl,--oformat,elf64-x86-64 -Wl,-pie -mcmodel=small -Wl,--apply-dynamic-relocs
+NOOPT_CLANGDWARF_X64_CC_FLAGS         = DEF(CLANGDWARF_ALL_CC_FLAGS) -m64 "-DEFIAPI=__attribute__((ms_abi))" -mno-red-zone -mcmodel=large -fno-pie -fdirect-access-external-data -O0 DEF(CLANGDWARF_X64_TARGET) -g
+NOOPT_CLANGDWARF_X64_DLINK_FLAGS      = DEF(CLANGDWARF_IA32_X64_DLINK_FLAGS) -Wl,-O0 -Wl,-melf_x86_64 -Wl,--oformat,elf64-x86-64 -Wl,--apply-dynamic-relocs
 NOOPT_CLANGDWARF_X64_DLINK2_FLAGS     = DEF(CLANGDWARF_X64_DLINK2_FLAGS) -O0 -fuse-ld=lld
 
 ##################


### PR DESCRIPTION
# Description

Fixes https://bugzilla.tianocore.org/show_bug.cgi?id=4617

Without this change the NOOPT CLANGDWARF X64 build of OvmfPkg hangs early, repeating the line `SecCoreStartupWithStack(0xFFFCC000, 0x820000)`.

The issue was introduced by 140e4422b16482f0bcafdc20d42141434d450450 which removes `#pragma GCC visibility push (hidden)` which had been applied for GCC family toolchains.

This commit works around the visibility issue in NOOPT CLANGDWARF X64 by not using GOT based references in the first place, in that toolchain.

This has a negative impact on code size, for example PEIFV of the build in question goes from 82% to 96% full, but code size should not in general be a concern for NOOPT builds.

*This patch was authored by @ardbiesheuvel in the bugzilla disucssion.* I raised the bug and would like to see it fixed, hence preparing and offering this PR. This obviously requires approval by @ardbiesheuvel. Of course I am happy to modify wording, commit authorship, etc., as required.

(I did mention in the bugzilla discussion another way of fixing the issue, which is enabling LTO in NOOPT CLANGDWARF X64 builds, as already done for DEBUG and RELEASE. In testing I did not find any effect on accurate single step debugging after this change, but I appreciate LTO may not be considered a reasonable feature to turn on in a NOOPT build, all the same.)

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

Local build.

## Integration Instructions

N/A
