### PR TITLE
MdePkg/Include/Guid: Rename CXL definitions in Cper.h to include EFI_ prefix

### DIFF
--- a/MdePkg/Include/Guid/Cper.h
+++ b/MdePkg/Include/Guid/Cper.h
@@ -1211,34 +1211,34 @@ typedef struct {
 ///
 /// CXL Cachemem Event Log Valid bits
 ///@{
-#define CXL_CACHMEM_AGENT_TYPE      BIT0  // CXL Agent Type field is valid
-#define CXL_CACHMEM_AGENT_ADDRESS   BIT1  // CXL Agent Address field is valid
-#define CXL_CACHMEM_DEVICE_ID       BIT2  // Device ID field is valid
-#define CXL_CACHMEM_DEVICE_SER_NUM  BIT3  // Device Serial Number field is valid
-#define CXL_CACHMEM_CAP_STRUCT      BIT4  // Capability structure field is valid
-#define CXL_CACHMEM_DVSEC           BIT5  // CXL DVSET field is valid
-#define CXL_CACHMEM_ERROR_LOG       BIT6  // CXL Error Log field is valid
+#define EFI_CXL_CACHMEM_AGENT_TYPE      BIT0  // CXL Agent Type field is valid
+#define EFI_CXL_CACHMEM_AGENT_ADDRESS   BIT1  // CXL Agent Address field is valid
+#define EFI_CXL_CACHMEM_DEVICE_ID       BIT2  // Device ID field is valid
+#define EFI_CXL_CACHMEM_DEVICE_SER_NUM  BIT3  // Device Serial Number field is valid
+#define EFI_CXL_CACHMEM_CAP_STRUCT      BIT4  // Capability structure field is valid
+#define EFI_CXL_CACHMEM_DVSEC           BIT5  // CXL DVSET field is valid
+#define EFI_CXL_CACHMEM_ERROR_LOG       BIT6  // CXL Error Log field is valid
 ///@}
 
 //
 // CXL Agent Types
 ///@{
-#define CXL_AGENT_CXL11_DEV          0    // CXL 1.1 Device
-#define CXL_AGENT_CXL11_DSP          1    // CXL 1.1 Downstream Port
-#define CXL_AGENT_CXL20_DEV          2    // CXL 2.0 Device
-#define CXL_AGENT_CXL20_LOGICAL_DEV  3    // CXL 2.0 Logical Device
-#define CXL_AGENT_CXL20_FMLD         4    // CXL 2.0 Fabric Manager managed Logical device
-#define CXL_AGENT_CXL20_RP           5    // CXL 2.0 Root Port
-#define CXL_AGENT_CXL20_DSP          6    // CXL 2.0 Downstream Switch Port
-#define CXL_AGENT_CXL20_USP          7    // CXL 2.0 Upstream Switch Port
+#define EFI_CXL_AGENT_CXL11_DEV          0    // CXL 1.1 Device
+#define EFI_CXL_AGENT_CXL11_DSP          1    // CXL 1.1 Downstream Port
+#define EFI_CXL_AGENT_CXL20_DEV          2    // CXL 2.0 Device
+#define EFI_CXL_AGENT_CXL20_LOGICAL_DEV  3    // CXL 2.0 Logical Device
+#define EFI_CXL_AGENT_CXL20_FMLD         4    // CXL 2.0 Fabric Manager managed Logical device
+#define EFI_CXL_AGENT_CXL20_RP           5    // CXL 2.0 Root Port
+#define EFI_CXL_AGENT_CXL20_DSP          6    // CXL 2.0 Downstream Switch Port
+#define EFI_CXL_AGENT_CXL20_USP          7    // CXL 2.0 Upstream Switch Port
 ///@}
 
 //
 // CXL Mem Event Log Valid bits
 ///@{
-#define CXL_MEM_DEVICE_ID       BIT0  // Device ID field is valid
-#define CXL_MEM_DEVICE_SER_NUM  BIT1  // Device Serial Number field is valid
-#define CXL_MEM_COMP_ERROR_LOG  BIT2  // CXL Component Error Log field is valid
+#define EFI_CXL_MEM_DEVICE_ID       BIT0  // Device ID field is valid
+#define EFI_CXL_MEM_DEVICE_SER_NUM  BIT1  // Device Serial Number field is valid
+#define EFI_CXL_MEM_COMP_ERROR_LOG  BIT2  // CXL Component Error Log field is valid
 ///@}
 
 //
@@ -1256,12 +1256,12 @@ typedef union {
     UINT32    Low;
     UINT32    High;
   } RcrbBase;
-} CXL_AGENT_ADDRESS;
+} EFI_CXL_AGENT_ADDRESS;
 
 //
 // CXL Device ID
 //
-typedef struct _CXL_AGENT_DEVICE_ID {
+typedef struct {
   UINT16    VendorId;
   UINT16    DeviceId;
   UINT16    Svid;
@@ -1272,15 +1272,15 @@ typedef struct _CXL_AGENT_DEVICE_ID {
     UINT16    Num  : 13;
   } Slot;
   UINT32    Rsvd;
-} CXL_AGENT_DEVICE_ID;
+} EFI_CXL_AGENT_DEVICE_ID;
 
 //
 // CXL Device Serial Number
 //
-typedef struct _CXL_DEVICE_SERIAL_NUM {
+typedef struct {
   UINT32    Lower;
   UINT32    Upper;
-} CXL_DEVICE_SERIAL_NUM;
+} EFI_CXL_DEVICE_SERIAL_NUM;
 
 //
 // PCIe device identifiers of CXL Component
@@ -1294,17 +1294,17 @@ typedef struct {
   UINT16                        Segment;
   EFI_GENERIC_ERROR_PCI_SLOT    Slot;
   UINT8                         Resvd;
-} CXL_ERROR_PCIE_DEV_ID;
+} EFI_CXL_ERROR_PCIE_DEV_ID;
 
 //
 // CXL Component Events Section
 //
-typedef struct _CXL_COMPONENT_EVENT_LOG {
+typedef struct {
   UINT32                   Length;
   UINT64                   ValidFields;
   CXL_ERROR_PCIE_DEV_ID    CxlDeviceId;
   UINT64                   DeviceSerialNo;
-} CXL_COMPONENT_EVENT_LOG;
+} EFI_CXL_COMPONENT_EVENT_LOG;
 
 #pragma pack()
 


### PR DESCRIPTION
Previous [PR that introduced these definitions](https://github.com/tianocore/edk2/pull/6329) was merged without following naming convention of using EFI_ prefix in definitions in Cper.h. This PR fixes that.

[Issue Description]
In MdePkg/Include/Guid/Cper.h there are multiple definitions regarding CXL that can do use EFI_ prefix in their names

[Resolution]
Rename these definitions in MdePkg/Include/Guid/Cper.h

# Description

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - No
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - No
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - No

## How This Was Tested

Builds in CI pass

## Integration Instructions

N/A
