### PR TITLE
MdeModulePkg/TerminalDxe: Return success if device not support SetControl

### DIFF
--- a/MdeModulePkg/Universal/Console/TerminalDxe/TerminalConIn.c
+++ b/MdeModulePkg/Universal/Console/TerminalDxe/TerminalConIn.c
@@ -97,6 +97,9 @@ TerminalConInReset (
 
   if (!EFI_ERROR (Status)) {
     Status = TerminalDevice->SerialIo->SetControl (TerminalDevice->SerialIo, EFI_SERIAL_DATA_TERMINAL_READY|EFI_SERIAL_REQUEST_TO_SEND);
+    if (Status == EFI_UNSUPPORTED) {
+      Status = EFI_SUCCESS;
+    }
   }
 
   return Status;


### PR DESCRIPTION
MdeModulePkg/TerminalDxe: Return success if device not support SetControl

# Description

Some serial device may not support SetControl.
Ignore the error from SetControl if EFI_UNSUPPORTED is return.

We see some compatible issue related to PR: https://github.com/tianocore/edk2/pull/6106/files
this patch can help on the compatible issue with some serial drivers which do not support SetControl.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

<_Describe the test(s) that were run to verify the changes._>

## Integration Instructions

<_Describe how these changes should be integrated. Use N/A if nothing is required._>
