### PR TITLE
DynamicTablesPkg: Update X64 FADT XPm1aEvtBlk

### DIFF
--- a/DynamicTablesPkg/Library/Acpi/Common/AcpiFadtLib/X64/X64FadtGenerator.c
+++ b/DynamicTablesPkg/Library/Acpi/Common/AcpiFadtLib/X64/X64FadtGenerator.c
@@ -244,8 +244,8 @@ FadtArchUpdate (
       ));
   } else {
     CopyMem (
-      &Fadt->XPm1aCntBlk,
-      &XpmBlockInfo->XPm1aCntBlk,
+      &Fadt->XPm1aEvtBlk,
+      &XpmBlockInfo->XPm1aEvtBlk,
       sizeof (EFI_ACPI_6_5_GENERIC_ADDRESS_STRUCTURE)
       );
     CopyMem (


### PR DESCRIPTION
Copy the provided configuration data for
PM1 event block.

Cc: Sami Mujawar <Sami.Mujawar@arm.com>
Cc: Pierre Gondois <pierre.gondois@arm.com>

# Description

Corrects the X64 FADT table by copying the PM1a event block
information from configuration data.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

tested on AMD X64 platform

## Integration Instructions

N/A
