### PR TITLE
Added Mock TcgPpi for unit test

### DIFF
--- a/SecurityPkg/Test/Mock/Include/GoogleTest/Ppi/MockTcgPpi.h
+++ b/SecurityPkg/Test/Mock/Include/GoogleTest/Ppi/MockTcgPpi.h
@@ -1,0 +1,39 @@
+/** @file MockTcgPpiLib.h
+  Google Test mocks for TcgPpi
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef MOCK_TCG_PPI_H__
+
+#define MOCK_TCG_PPI_H__
+
+#include <Library/GoogleTestLib.h>
+#include <Library/FunctionMockLib.h>
+
+extern "C" {
+  #include <PiPei.h>
+  #include <Ppi/Tcg.h>
+}
+
+struct MockTcgPpiLib {
+  MOCK_INTERFACE_DECLARATION (MockTcgPpiLib);
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    HashLogExtendEvent,
+    (IN      EDKII_TCG_PPI             *This,
+     IN      UINT64                    Flags,
+     IN      UINT8                     *HashData,
+     IN      UINTN                     HashDataLen,
+     IN      TCG_PCR_EVENT_HDR         *NewEventHdr,
+     IN      UINT8                     *NewEventData)
+    );
+};
+
+MOCK_INTERFACE_DEFINITION (MockTcgPpiLib);
+
+MOCK_FUNCTION_DEFINITION (MockTcgPpiLib, HashLogExtendEvent, 6, EFIAPI);
+
+#endif


### PR DESCRIPTION
# Description

Added Mock TcgPpi for unit test to use.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [x] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Other repo consumes this mock and able to run the test.

## Integration Instructions

Consume `SecurityPkg\Test\Mock\Library\GoogleTest\Ppi\MockTcgPpiLib\MockTcgPpiLib.inf` if you need TcgPpi in the unit test.
