### PR TITLE
MdePkg/Include/Guid: Fix EFI_CXL_COMPONENT_EVENT_LOG in Cper.h

### DIFF
--- a/MdePkg/Include/Guid/Cper.h
+++ b/MdePkg/Include/Guid/Cper.h
@@ -1300,10 +1300,10 @@ typedef struct {
 // CXL Component Events Section
 //
 typedef struct {
-  UINT32                   Length;
-  UINT64                   ValidFields;
-  CXL_ERROR_PCIE_DEV_ID    CxlDeviceId;
-  UINT64                   DeviceSerialNo;
+  UINT32                       Length;
+  UINT64                       ValidFields;
+  EFI_CXL_ERROR_PCIE_DEV_ID    CxlDeviceId;
+  UINT64                       DeviceSerialNo;
 } EFI_CXL_COMPONENT_EVENT_LOG;
 
 #pragma pack()


### PR DESCRIPTION
Fixes a19f50bb95f70c378488ed5459a1153730c0ef76 

[Issue Description]
CXL_ERROR_PCIE_DEV_ID in Cper.h was renamed to EFI_CXL_ERROR_PCIE_DEV_ID, but EFI_CXL_COMPONENT_EVENT_LOG still uses previous name.

[Resolution]
Modify EFI_CXL_COMPONENT_EVENT_LOG to use EFI_CXL_ERROR_PCIE_DEV_ID
