### PR TITLE
DynamicTablesPkg: Fix the comparision by using correct max value of U…

### DIFF
--- a/DynamicTablesPkg/Library/Common/AmlLib/CodeGen/AmlResourceDataCodeGen.c
+++ b/DynamicTablesPkg/Library/Common/AmlLib/CodeGen/AmlResourceDataCodeGen.c
@@ -1437,9 +1437,7 @@ AmlCodeGenRdRegister (
 
   // Cf. ACPI 6.4, s14.7 Referencing the PCC address space
   // The AccessSize represents the Subspace Id for the PCC address space.
-  if (((AddressSpace == EFI_ACPI_6_4_PLATFORM_COMMUNICATION_CHANNEL) &&
-       (AccessSize > 256)) ||
-      ((AddressSpace != EFI_ACPI_6_4_PLATFORM_COMMUNICATION_CHANNEL) &&
+  if (((AddressSpace != EFI_ACPI_6_4_PLATFORM_COMMUNICATION_CHANNEL) &&
        (AccessSize > EFI_ACPI_6_4_QWORD)) ||
       ((NameOpNode == NULL) && (NewRdNode == NULL)))
   {


### PR DESCRIPTION
DynamicTablesPkg: Fix the comparision by using correct max value of UINT8

Clang build breaks with the following error:
    
      | DynamicTablesPkg/Library/Common/AmlLib/CodeGen/AmlResourceDataCodeGen.c:1441:20:
      |      error: result of comparison of constant 256 with expression of type 'UINT8'
      |      (aka 'unsigned char') is always false [-Werror,-Wtautological-constant-out-of-range-compare]
      |      1441 |        (AccessSize > 256)) ||
      |           |         ~~~~~~~~~~ ^ ~~~
      |    1 error generated.
    
    AccessSize is UINT8 and the maximum value for UINT8 is 255, use the same
    in the comparison to fix the build.

- [ ] Breaking change?
   No
- [ ] Impacts security?
  No
- [ ] Includes tests?
 No

Build and boot tested on arm64 Vexpress FVP.