### PR TITLE
MdeModulePkg: SataControllerSupported checks DevicePath Protocol

### DIFF
--- a/MdeModulePkg/Bus/Pci/SataControllerDxe/SataController.c
+++ b/MdeModulePkg/Bus/Pci/SataControllerDxe/SataController.c
@@ -287,9 +287,34 @@ SataControllerSupported (
   IN EFI_DEVICE_PATH_PROTOCOL     *RemainingDevicePath
   )
 {
-  EFI_STATUS           Status;
-  EFI_PCI_IO_PROTOCOL  *PciIo;
-  PCI_TYPE00           PciData;
+  EFI_STATUS                Status;
+  EFI_PCI_IO_PROTOCOL       *PciIo;
+  PCI_TYPE00                PciData;
+  EFI_DEVICE_PATH_PROTOCOL  *ParentDevicePath;
+
+  //
+  // Attempt to open DevicePath Protocol
+  //
+  Status = gBS->OpenProtocol (
+                  Controller,
+                  &gEfiDevicePathProtocolGuid,
+                  (VOID *)&ParentDevicePath,
+                  This->DriverBindingHandle,
+                  Controller,
+                  EFI_OPEN_PROTOCOL_BY_DRIVER
+                  );
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+  ///
+  /// Close the protocol because we don't use it here
+  ///
+  gBS->CloseProtocol (
+         Controller,
+         &gEfiDevicePathProtocolGuid,
+         This->DriverBindingHandle,
+         Controller
+         );
 
   //
   // Attempt to open PCI I/O Protocol

--- a/MdeModulePkg/Bus/Pci/SataControllerDxe/SataController.c
+++ b/MdeModulePkg/Bus/Pci/SataControllerDxe/SataController.c
@@ -306,6 +306,7 @@ SataControllerSupported (
   if (EFI_ERROR (Status)) {
     return Status;
   }
+
   ///
   /// Close the protocol because we don't use it here
   ///

--- a/MdeModulePkg/Bus/Pci/SataControllerDxe/SataController.h
+++ b/MdeModulePkg/Bus/Pci/SataControllerDxe/SataController.h
@@ -18,6 +18,7 @@
 #include <Protocol/DriverBinding.h>
 #include <Protocol/PciIo.h>
 #include <Protocol/IdeControllerInit.h>
+#include <Protocol/DevicePath.h>
 
 #include <Library/BaseLib.h>
 #include <Library/BaseMemoryLib.h>

--- a/MdeModulePkg/Bus/Pci/SataControllerDxe/SataControllerDxe.inf
+++ b/MdeModulePkg/Bus/Pci/SataControllerDxe/SataControllerDxe.inf
@@ -45,6 +45,7 @@
 [Protocols]
   gEfiPciIoProtocolGuid                     ## TO_START
   gEfiIdeControllerInitProtocolGuid         ## BY_START
+  gEfiDevicePathProtocolGuid
 
 [UserExtensions.TianoCore."ExtraFiles"]
   SataControllerDxeExtra.uni


### PR DESCRIPTION
# Description
REF:https://bugzilla.tianocore.org/show_bug.cgi?id=4858
Ph52a PCIE to SATA card inserted on Intel MTL/ARL causes system hanged.
Root cause of this issue is because Ph52a's driver only uses DevicePath 
protocol alone and EDK2 driver only uses PciIo protocol alone. Both drivers 
start and try to manage SATA controller.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested
Ph52a PCIE to SATA card inserted on Intel MTL/ARL did not causes system hanged. And SATA devices on Ph52a can be recognized and read.
Integration Instructions

## Integration Instructions
N/A
