### PR TITLE
MdePkg:Update Error Macro to reduce potential code size increasing

### DIFF
--- a/MdePkg/Include/Base.h
+++ b/MdePkg/Include/Base.h
@@ -1058,7 +1058,7 @@ typedef UINTN RETURN_STATUS;
   @retval FALSE         The high bit of StatusCode is clear.
 
 **/
-#define RETURN_ERROR(StatusCode)  (((RETURN_STATUS)(StatusCode)) >= MAX_BIT)
+#define RETURN_ERROR(StatusCode)  (((RETURN_STATUS)(StatusCode)) > 0)
 
 ///
 /// The operation completed successfully.


### PR DESCRIPTION
I found there may a potential bytes increasing phenomenon for the commit [MdePkg:Update Return Error Macro in Base.h · tianocore/edk2@1a89d98 (github.com)](https://github.com/tianocore/edk2/commit/1a89d9887ff41e804610c5687e646fe30af2d7b2) while using EFI_ERROR or RETURN_ERROR macro
Below is what I observed in .cod file of EDK2 driver (RamDiskDxe as example) with MS build option /FAcs

Left side is before applying the patch and right side is after applying the patch
![image](https://github.com/user-attachments/assets/003d2f56-6aa2-4524-9778-68e0815d8e0c)
 
The right side increase several bytes due to compiler might have treated “MAX_BIT” as a normal instant value
And the left side use “test” cmd due to compiler might have thought it’s better use “ZF” or “SF” to handle “< 0”

This result in module consuming EFI_ERROR or RETURN_ERROR will increases a considerable number of bytes after applying the patch as below (RamDiskDxe as example)
![image](https://github.com/user-attachments/assets/753edc0f-9f90-458c-a769-94451035d074)