### PR TITLE
ArmVirtPkg: KvmTool: Fix clang linker error

### DIFF
--- a/ArmVirtPkg/ArmVirtKvmTool.dsc
+++ b/ArmVirtPkg/ArmVirtKvmTool.dsc
@@ -368,17 +368,17 @@
   UefiCpuPkg/CpuMmio2Dxe/CpuMmio2Dxe.inf {
     <LibraryClasses>
       NULL|OvmfPkg/Fdt/FdtPciPcdProducerLib/FdtPciPcdProducerLib.inf
-      NULL|OvmfPkg/Library/BaseCachingPciExpressLib/BaseCachingPciExpressLib.inf
+      PciExpressLib|OvmfPkg/Library/BaseCachingPciExpressLib/BaseCachingPciExpressLib.inf
   }
   MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostBridgeDxe.inf {
     <LibraryClasses>
       NULL|OvmfPkg/Fdt/FdtPciPcdProducerLib/FdtPciPcdProducerLib.inf
-      NULL|OvmfPkg/Library/BaseCachingPciExpressLib/BaseCachingPciExpressLib.inf
+      PciExpressLib|OvmfPkg/Library/BaseCachingPciExpressLib/BaseCachingPciExpressLib.inf
   }
   MdeModulePkg/Bus/Pci/PciBusDxe/PciBusDxe.inf {
     <LibraryClasses>
       NULL|OvmfPkg/Fdt/FdtPciPcdProducerLib/FdtPciPcdProducerLib.inf
-      NULL|OvmfPkg/Library/BaseCachingPciExpressLib/BaseCachingPciExpressLib.inf
+      PciExpressLib|OvmfPkg/Library/BaseCachingPciExpressLib/BaseCachingPciExpressLib.inf
   }
   OvmfPkg/VirtioPciDeviceDxe/VirtioPciDeviceDxe.inf
   OvmfPkg/Virtio10Dxe/Virtio10.inf


### PR DESCRIPTION
Clang build for ArmVirtPkg/ArmVirtKvmTool.dsc fails with the below warning:

  |  ld.lld: error: duplicate symbol: PciExpressRegisterForRuntimeAccess
  |  ld.lld: error: duplicate symbol: GetPciExpressBaseAddress
  |  ld.lld: error: duplicate symbol: PciExpressRead8
  |  ld.lld: error: duplicate symbol: PciExpressWrite8
  |  ld.lld: error: duplicate symbol: PciExpressOr8
  |  ld.lld: error: duplicate symbol: PciExpressAnd8
  |  ld.lld: error: duplicate symbol: PciExpressAndThenOr8
  |  ld.lld: error: duplicate symbol: PciExpressBitFieldRead8
  |  ld.lld: error: duplicate symbol: PciExpressBitFieldWrite8
  |  ld.lld: error: duplicate symbol: PciExpressBitFieldOr8
  |  ld.lld: error: duplicate symbol: PciExpressBitFieldAnd8
  |  ld.lld: error: duplicate symbol: PciExpressBitFieldAndThenOr8
  |  ld.lld: error: duplicate symbol: PciExpressRead16
  |  ld.lld: error: duplicate symbol: PciExpressWrite16
  |  ld.lld: error: duplicate symbol: PciExpressOr16
  |  ld.lld: error: duplicate symbol: PciExpressAnd16
  |  ld.lld: error: duplicate symbol: PciExpressAndThenOr16
  |  ld.lld: error: duplicate symbol: PciExpressBitFieldRead16
  |  ld.lld: error: duplicate symbol: PciExpressBitFieldWrite16
  |  ld.lld: error: duplicate symbol: PciExpressBitFieldOr16
  |  >>> defined in MdePkg/Library/BasePciExpressLib/BasePciExpressLib/OUTPUT/BasePciExpressLib.lib(PciExpressLib.obj)
  |  >>> defined in OvmfPkg/Library/BaseCachingPciExpressLib/BaseCachingPciExpressLib/OUTPUT/BaseCachingPciExpressLib.lib(PciExpressLib.obj)
  |
  |  ld.lld: error: too many errors emitted, stopping now (use --error-limit=0 to see all errors)
  |  clang: error: linker command failed with exit code 1 (use -v to see invocation)

OvmfPkg/Library/BaseCachingPciExpressLib/BaseCachingPciExpressLib.inf is getting linked as NULL library in these pacakges:
1. UefiCpuPkg/CpuMmio2Dxe/CpuMmio2Dxe.inf
2. MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostBridgeDxe.inf
3. MdeModulePkg/Bus/Pci/PciBusDxe/PciBusDxe.inf which results in duplicate symbols shown in the warning above as MdePkg/Library/BasePciExpressLib/BasePciExpressLib.inf is not properly replaced by OvmfPkg/Library/BaseCachingPciExpressLib/BaseCachingPciExpressLib.inf as PciExpressLib library.

Test on Arm FVP using kvmtool to boot KVMTOOL_EFI.fd

