### PR TITLE
ci: update to py-3.13 and ubuntu-24.04

### DIFF
--- a/.azurepipelines/Ubuntu-GCC5.yml
+++ b/.azurepipelines/Ubuntu-GCC5.yml
@@ -20,7 +20,7 @@ jobs:
 - template: templates/pr-gate-build-job.yml
   parameters:
     tool_chain_tag: 'GCC5'
-    vm_image: 'ubuntu-22.04'
+    vm_image: 'ubuntu-24.04'
     container: ${{ variables.default_linux_image }}
     arch_list: "IA32,X64,ARM,AARCH64,RISCV64,LOONGARCH64"
     usePythonVersion: ''  # use Python from the container image

--- a/.azurepipelines/Ubuntu-PatchCheck.yml
+++ b/.azurepipelines/Ubuntu-PatchCheck.yml
@@ -27,7 +27,7 @@ steps:
 
 - task: UsePythonVersion@0
   inputs:
-    versionSpec: '3.12'
+    versionSpec: '3.13'
     architecture: 'x64'
 
 - script: |


### PR DESCRIPTION
Since python 3.13 and ubuntu-24.04 are available now, update to latest version.

Sign-off-by: Damien Chen <inkfan130924783@gmail.com>

## How This Was Tested

Test by original CI/CD

## Integration Instructions
N/A