### PR TITLE
CryptoPkg: Updated the missing architectures.

### DIFF
--- a/CryptoPkg/Library/BaseCryptLib/PeiCryptLib.inf
+++ b/CryptoPkg/Library/BaseCryptLib/PeiCryptLib.inf
@@ -30,7 +30,7 @@
 #
 # The following information is for reference only and not required by the build tools.
 #
-#  VALID_ARCHITECTURES           = IA32 X64
+#  VALID_ARCHITECTURES           = IA32 X64 ARM AARCH64
 #
 
 [Sources]


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4838

Updated the missing architectures in PeiCryptLib.inf file.

Signed-off-by: Kanagavel S <kanagavels@ami.com>

# Description

PeiCryptLib from BaseCryptLib supports X86, IA32, ARM, AARCH64 architectures and missed to mention ARM, AARCH64 in PeiCryptLib.inf under valid architecture field.

Updated the missed architectures in PeiCryptLin.inf file.
