### PR TITLE
CryptoPkg: Added MM_STANDALONE support in CryptoPkg.

### DIFF
--- a/CryptoPkg/CryptoPkg.dsc
+++ b/CryptoPkg/CryptoPkg.dsc
@@ -6,6 +6,7 @@
 #  Copyright (c) 2020, Hewlett Packard Enterprise Development LP. All rights reserved.<BR>
 #  Copyright (c) 2022, Loongson Technology Corporation Limited. All rights reserved.<BR>
 #  Copyright (c) 2023, Arm Limited. All rights reserved.<BR>
+#  Copyright (c) 2024, American Megatrends International LLC. All rights reserved.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -83,6 +84,12 @@
   DEFINE  SMM_FULL_GUID       = 1930CE7E-6598-48ED-8AB1-EBE7E85EC254
   DEFINE  SMM_STD_ACCEL_GUID  = 828959D3-CEA6-4B79-B1FC-5AFA0D7F2144
   DEFINE  SMM_FULL_ACCEL_GUID = C1760694-AB3A-4532-8C6D-52D8F86EB1AA
+  DEFINE  MM_STANDALONE_CRYPTO_GUID     = 4E14BAAE-8AA0-4F28-B1F0-53215E4DEA81
+  DEFINE  MM_STANDALONE_STD_GUID        = FB88FFE8-C6E3-4752-8E85-0865DF7CDB1F
+  DEFINE  MM_STANDALONE_FULL_GUID       = 4A6F4C6E-6207-4801-9706-B9429936A38C
+  DEFINE  MM_STANDALONE_STD_ACCEL_GUID  = 9EF13BFA-912E-4589-8D6A-3ECCF1156B5E
+  DEFINE  MM_STANDALONE_FULL_ACCEL_GUID = 0A13116A-D6BF-4E4A-90DC-615C4C0A711D
+
 
 !if $(CRYPTO_SERVICES) == TARGET_UNIT_TESTS
 !include UnitTestFrameworkPkg/UnitTestFrameworkPkgTarget.dsc.inc
@@ -161,6 +168,15 @@
   PcdLib|MdePkg/Library/DxePcdLib/DxePcdLib.inf
   BaseCryptLib|CryptoPkg/Library/BaseCryptLib/SmmCryptLib.inf
   TlsLib|CryptoPkg/Library/TlsLibNull/TlsLibNull.inf
+
+[LibraryClasses.common.MM_STANDALONE]
+  BaseCryptLib|CryptoPkg/Library/BaseCryptLib/SmmCryptLib.inf
+  MmServicesTableLib|MdePkg/Library/StandaloneMmServicesTableLib/StandaloneMmServicesTableLib.inf
+  StandaloneMmDriverEntryPoint|MdePkg/Library/StandaloneMmDriverEntryPoint/StandaloneMmDriverEntryPoint.inf
+  TlsLib|CryptoPkg/Library/TlsLibNull/TlsLibNull.inf
+  PcdLib|MdePkg/Library/BasePcdLibNull/BasePcdLibNull.inf
+  ReportStatusCodeLib|MdePkg/Library/BaseReportStatusCodeLibNull/BaseReportStatusCodeLibNull.inf
+  MemoryAllocationLib|StandaloneMmPkg/Library/StandaloneMmMemoryAllocationLib/StandaloneMmMemoryAllocationLib.inf
 
 [LibraryClasses.common.UEFI_APPLICATION]
   UefiApplicationEntryPoint|MdePkg/Library/UefiApplicationEntryPoint/UefiApplicationEntryPoint.inf
@@ -377,6 +393,7 @@
   CryptoPkg/Library/BaseCryptLibOnProtocolPpi/PeiCryptLib.inf
   CryptoPkg/Library/BaseCryptLibOnProtocolPpi/DxeCryptLib.inf
   CryptoPkg/Library/BaseCryptLibOnProtocolPpi/SmmCryptLib.inf
+  CryptoPkg/Library/BaseCryptLibOnProtocolPpi/StandaloneMmCryptLib.inf
   #
   # Build verification of target-based unit tests
   #
@@ -574,6 +591,59 @@
   CryptoPkg/Driver/CryptoSmm.inf {
     <Defines>
       FILE_GUID = $(SMM_FULL_ACCEL_GUID)
+    <LibraryClasses>
+      OpensslLib|CryptoPkg/Library/OpensslLib/OpensslLibFullAccel.inf
+    <BuildOptions>
+      MSFT:*_*_IA32_DLINK_FLAGS = /ALIGN:4096
+      MSFT:*_*_X64_DLINK_FLAGS  = /ALIGN:4096
+  }
+  #
+  # CryptoStandaloneMm with OpensslLib instance with no SSL or EC services
+  #
+  CryptoPkg/Driver/CryptoStandaloneMm.inf {
+    <Defines>
+      FILE_GUID = $(MM_STANDALONE_CRYPTO_GUID)
+    <LibraryClasses>
+      OpensslLib|CryptoPkg/Library/OpensslLib/OpensslLibCrypto.inf
+  }
+  #
+  # CryptoStandaloneMm with OpensslLib instance with no SSL services
+  #
+  CryptoPkg/Driver/CryptoStandaloneMm.inf {
+    <Defines>
+      FILE_GUID = $(MM_STANDALONE_STD_GUID)
+    <LibraryClasses>
+      OpensslLib|CryptoPkg/Library/OpensslLib/OpensslLib.inf
+  }
+  #
+  # CryptoStandaloneMm with OpensslLib instance with no all services
+  #
+  CryptoPkg/Driver/CryptoStandaloneMm.inf {
+    <Defines>
+      FILE_GUID = $(MM_STANDALONE_FULL_GUID)
+    <LibraryClasses>
+      OpensslLib|CryptoPkg/Library/OpensslLib/OpensslLibFull.inf
+  }
+  #
+  # CryptoStandaloneMm with IA32/X64/AARCH64 performance optimized OpensslLib instance with no EC services
+  # IA32/X64 assembly optimizations required larger alignments
+  #
+  CryptoPkg/Driver/CryptoStandaloneMm.inf {
+    <Defines>
+      FILE_GUID = $(MM_STANDALONE_STD_ACCEL_GUID)
+    <LibraryClasses>
+      OpensslLib|CryptoPkg/Library/OpensslLib/OpensslLibAccel.inf
+    <BuildOptions>
+      MSFT:*_*_IA32_DLINK_FLAGS = /ALIGN:64
+      MSFT:*_*_X64_DLINK_FLAGS  = /ALIGN:256
+  }
+  #
+  # CryptoStandaloneMm with IA32/X64/AARCH64 performance optimized OpensslLib instance with all services
+  # IA32/X64 assembly optimizations required larger alignments
+  #
+  CryptoPkg/Driver/CryptoStandaloneMm.inf {
+    <Defines>
+      FILE_GUID = $(MM_STANDALONE_FULL_ACCEL_GUID)
     <LibraryClasses>
       OpensslLib|CryptoPkg/Library/OpensslLib/OpensslLibFullAccel.inf
     <BuildOptions>

--- a/CryptoPkg/Driver/CryptoStandaloneMm.c
+++ b/CryptoPkg/Driver/CryptoStandaloneMm.c
@@ -1,0 +1,41 @@
+/** @file
+  Installs the EDK II Crypto SMM Protocol in Standalone MM.
+
+  Copyright (c) 2024, American Megatrends International LLC. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <PiMm.h>
+#include <Library/MmServicesTableLib.h>
+#include <Protocol/SmmCrypto.h>
+
+extern CONST EDKII_CRYPTO_PROTOCOL  mEdkiiCrypto;
+
+/**
+  The module Entry Point of the Crypto Standalone MM Driver.
+
+  @param[in]  ImageHandle    The firmware allocated handle for the EFI image.
+  @param[in]  SystemTable    A pointer to the EFI System Table.
+
+  @retval EFI_SUCCESS    The entry point is executed successfully.
+  @retval Other          Some error occurs when executing this entry point.
+
+**/
+EFI_STATUS
+EFIAPI
+CryptoStandaloneMmEntry (
+  IN EFI_HANDLE           ImageHandle,
+  IN EFI_MM_SYSTEM_TABLE  *MmSystemTable
+  )
+{
+  EFI_HANDLE  Handle;
+
+  Handle = NULL;
+  return gMmst->MmInstallProtocolInterface (
+                  &Handle,
+                  &gEdkiiSmmCryptoProtocolGuid,
+                  EFI_NATIVE_INTERFACE,
+                  (EDKII_CRYPTO_PROTOCOL *)&mEdkiiCrypto
+                  );
+}

--- a/CryptoPkg/Driver/CryptoStandaloneMm.inf
+++ b/CryptoPkg/Driver/CryptoStandaloneMm.inf
@@ -1,0 +1,48 @@
+## @file
+#  Produces the EDK II SMM Crypto Protocol using the library services from
+#  BaseCryptLib and TlsLib for Standalone MM.
+#
+#  Copyright (c) 2024, American Megatrends International LLC. All rights reserved.<BR>
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x0001001B
+  PI_SPECIFICATION_VERSION       = 0x00010032
+  BASE_NAME                      = CryptoStandaloneMm
+  MODULE_UNI_FILE                = Crypto.uni
+  FILE_GUID                      = B7946FEA-15EF-43F4-9FF6-0F71E032ECF5
+  MODULE_TYPE                    = MM_STANDALONE
+  VERSION_STRING                 = 1.0
+  ENTRY_POINT                    = CryptoStandaloneMmEntry
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  Crypto.c
+  CryptoStandaloneMm.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  CryptoPkg/CryptoPkg.dec
+
+[LibraryClasses]
+  BaseCryptLib
+  DebugLib
+  MmServicesTableLib
+  StandaloneMmDriverEntryPoint
+  TlsLib
+
+[Protocols]
+  gEdkiiSmmCryptoProtocolGuid  ## PRODUCES
+
+[Pcd]
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceFamilyEnable  ## CONSUMES
+
+[Depex]
+  TRUE

--- a/CryptoPkg/Library/BaseCryptLibOnProtocolPpi/StandaloneMmCryptLib.c
+++ b/CryptoPkg/Library/BaseCryptLibOnProtocolPpi/StandaloneMmCryptLib.c
@@ -1,0 +1,79 @@
+/** @file
+  Implements the GetCryptoServices() API that retuns a pointer to the EDK II
+  SMM Crypto Protocol.
+
+  Copyright (c) 2024, American Megatrends International LLC. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <PiMm.h>
+#include <Library/BaseLib.h>
+#include <Library/DebugLib.h>
+#include <Library/MmServicesTableLib.h>
+#include <Protocol/SmmCrypto.h>
+
+EDKII_SMM_CRYPTO_PROTOCOL  *mSmmCryptoProtocol = NULL;
+
+/**
+  Internal worker function that returns the pointer to an EDK II Crypto
+  Protocol/PPI.  The layout of the PPI, DXE Protocol, and SMM Protocol are
+  identical which allows the implementation of the BaseCryptLib functions that
+  call through a Protocol/PPI to be shared for the PEI, DXE, and SMM
+  implementations.
+
+  This SMM implementation returns the pointer to the EDK II SMM Crypto Protocol
+  that was found in the library constructor SmmCryptLibConstructor().
+**/
+VOID *
+GetCryptoServices (
+  VOID
+  )
+{
+  return (VOID *)mSmmCryptoProtocol;
+}
+
+/**
+  Constructor looks up the EDK II SMM Crypto Protocol and verifies that it is
+  not NULL and has a high enough version value to support all the BaseCryptLib
+  functions.
+
+  @param  ImageHandle   The firmware allocated handle for the EFI image.
+  @param  MmSystemTable A pointer to the MM System Table.
+
+  @retval  EFI_SUCCESS    The EDK II SMM Crypto Protocol was found.
+  @retval  EFI_NOT_FOUND  The EDK II SMM Crypto Protocol was not found.
+**/
+EFI_STATUS
+EFIAPI
+StandaloneMmCryptLibConstructor (
+  IN EFI_HANDLE           ImageHandle,
+  IN EFI_MM_SYSTEM_TABLE  *MmSystemTable
+  )
+{
+  EFI_STATUS  Status;
+  UINTN       Version;
+
+  Status = gMmst->MmLocateProtocol (
+                    &gEdkiiSmmCryptoProtocolGuid,
+                    NULL,
+                    (VOID **)&mSmmCryptoProtocol
+                    );
+  if (EFI_ERROR (Status) || (mSmmCryptoProtocol == NULL)) {
+    DEBUG ((DEBUG_ERROR, "[StandaloneMmCryptLib] Failed to locate Crypto SMM Protocol. Status = %r\n", Status));
+    ASSERT_EFI_ERROR (Status);
+    ASSERT (mSmmCryptoProtocol != NULL);
+    mSmmCryptoProtocol = NULL;
+    return EFI_NOT_FOUND;
+  }
+
+  Version = mSmmCryptoProtocol->GetVersion ();
+  if (Version < EDKII_CRYPTO_VERSION) {
+    DEBUG ((DEBUG_ERROR, "[StandaloneMmCryptLib] Crypto SMM Protocol unsupported version %d\n", Version));
+    ASSERT (Version >= EDKII_CRYPTO_VERSION);
+    mSmmCryptoProtocol = NULL;
+    return EFI_NOT_FOUND;
+  }
+
+  return EFI_SUCCESS;
+}

--- a/CryptoPkg/Library/BaseCryptLibOnProtocolPpi/StandaloneMmCryptLib.inf
+++ b/CryptoPkg/Library/BaseCryptLibOnProtocolPpi/StandaloneMmCryptLib.inf
@@ -1,0 +1,45 @@
+## @file
+# Implements the BaseCryptLib and TlsLib using the services of the EDK II Crypto
+# SMM Protocol for Stdandalone MM.
+#
+# Copyright (c) 2024, American Megatrends International LLC. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x0001001B
+  BASE_NAME                      = StandaloneMmCryptLib
+  MODULE_UNI_FILE                = CryptLib.uni
+  FILE_GUID                      = FA7EB4FD-7B3B-4FE4-BA95-1CE47CD0BE3E
+  VERSION_STRING                 = 1.0
+  PI_SPECIFICATION_VERSION       = 0x00010032
+  MODULE_TYPE                    = MM_STANDALONE
+  LIBRARY_CLASS                  = BaseCryptLib | MM_STANDALONE
+  LIBRARY_CLASS                  = TlsLib       | MM_STANDALONE
+  CONSTRUCTOR                    = StandaloneMmCryptLibConstructor
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+# VALID_ARCHITECTURES = IA32 X64 ARM AARCH64
+#
+
+[Packages]
+  MdePkg/MdePkg.dec
+  CryptoPkg/CryptoPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  DebugLib
+  MmServicesTableLib
+
+[Sources]
+  StandaloneMmCryptLib.c
+  CryptLib.c
+
+[Protocols]
+  gEdkiiSmmCryptoProtocolGuid  ## CONSUMES
+
+[Depex]
+  gEdkiiSmmCryptoProtocolGuid


### PR DESCRIPTION
CryptoPkg: Added MM_STANDALONE support.

REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4867

Added MM_STANDALONE support in Driver and BaseCryptLibOnProtocolPpi.

Signed-off-by: Kanagavel S <kanagavels@ami.com>

# Description

Added MM_STANDALONE support in CryptoPkg Driver and BaseCryptLibOnProtocolPpi.



