### PR TITLE
SecurityPkg: Fixes for variable validation

### DIFF
--- a/SecurityPkg/Library/AuthVariableLib/AuthService.c
+++ b/SecurityPkg/Library/AuthVariableLib/AuthService.c
@@ -552,7 +552,7 @@ CheckSignatureListFormat (
   // Walk through the input signature list and check the data format.
   // If any signature is incorrectly formed, the whole check will fail.
   //
-  while ((SigDataSize > 0) && (SigDataSize >= SigList->SignatureListSize)) {
+  while ((SigDataSize > 0) && (SigDataSize >= (UINTN)SigList->SignatureListSize)) {
     for (Index = 0; Index < (sizeof (mSupportSigItem) / sizeof (EFI_SIGNATURE_ITEM)); Index++ ) {
       if (CompareGuid (&SigList->SignatureType, &mSupportSigItem[Index].SigType)) {
         //
@@ -1092,7 +1092,7 @@ FilterSignatureList (
   Tail = TempData;
 
   NewCertList = (EFI_SIGNATURE_LIST *)NewData;
-  while ((*NewDataSize > 0) && (*NewDataSize >= NewCertList->SignatureListSize)) {
+  while ((*NewDataSize > 0) && (*NewDataSize >= (UINTN)NewCertList->SignatureListSize)) {
     NewCert      = (EFI_SIGNATURE_DATA *)((UINT8 *)NewCertList + sizeof (EFI_SIGNATURE_LIST) + NewCertList->SignatureHeaderSize);
     NewCertCount = (NewCertList->SignatureListSize - sizeof (EFI_SIGNATURE_LIST) - NewCertList->SignatureHeaderSize) / NewCertList->SignatureSize;
 
@@ -1102,7 +1102,7 @@ FilterSignatureList (
 
       Size     = DataSize;
       CertList = (EFI_SIGNATURE_LIST *)Data;
-      while ((Size > 0) && (Size >= CertList->SignatureListSize)) {
+      while ((Size > 0) && (Size >= (UINTN)CertList->SignatureListSize)) {
         if (CompareGuid (&CertList->SignatureType, &NewCertList->SignatureType) &&
             (CertList->SignatureSize == NewCertList->SignatureSize))
         {

--- a/SecurityPkg/Library/DxeImageVerificationLib/DxeImageVerificationLib.c
+++ b/SecurityPkg/Library/DxeImageVerificationLib/DxeImageVerificationLib.c
@@ -882,7 +882,7 @@ IsCertHashFoundInDbx (
     return Status;
   }
 
-  while ((DbxSize > 0) && (SignatureListSize >= DbxList->SignatureListSize)) {
+  while ((DbxSize > 0) && (SignatureListSize >= (UINTN)DbxList->SignatureListSize)) {
     //
     // Determine Hash Algorithm of Certificate in the forbidden database.
     //
@@ -1027,7 +1027,7 @@ IsSignatureFoundInDatabase (
   // Enumerate all signature data in SigDB to check if signature exists for executable.
   //
   CertList = (EFI_SIGNATURE_LIST *)Data;
-  while ((DataSize > 0) && (DataSize >= CertList->SignatureListSize)) {
+  while ((DataSize > 0) && (DataSize >= (UINTN)CertList->SignatureListSize)) {
     CertCount = (CertList->SignatureListSize - sizeof (EFI_SIGNATURE_LIST) - CertList->SignatureHeaderSize) / CertList->SignatureSize;
     Cert      = (EFI_SIGNATURE_DATA *)((UINT8 *)CertList + sizeof (EFI_SIGNATURE_LIST) + CertList->SignatureHeaderSize);
     if ((CertList->SignatureSize == sizeof (EFI_SIGNATURE_DATA) - 1 + SignatureSize) && (CompareGuid (&CertList->SignatureType, CertType))) {
@@ -1192,7 +1192,7 @@ PassTimestampCheck (
   }
 
   CertList = (EFI_SIGNATURE_LIST *)DbtData;
-  while ((DbtDataSize > 0) && (DbtDataSize >= CertList->SignatureListSize)) {
+  while ((DbtDataSize > 0) && (DbtDataSize >= (UINTN)CertList->SignatureListSize)) {
     if (CompareGuid (&CertList->SignatureType, &gEfiCertX509Guid)) {
       Cert      = (EFI_SIGNATURE_DATA *)((UINT8 *)CertList + sizeof (EFI_SIGNATURE_LIST) + CertList->SignatureHeaderSize);
       CertCount = (CertList->SignatureListSize - sizeof (EFI_SIGNATURE_LIST) - CertList->SignatureHeaderSize) / CertList->SignatureSize;
@@ -1318,7 +1318,7 @@ IsForbiddenByDbx (
   //
   CertList     = (EFI_SIGNATURE_LIST *)Data;
   CertListSize = DataSize;
-  while ((CertListSize > 0) && (CertListSize >= CertList->SignatureListSize)) {
+  while ((CertListSize > 0) && (CertListSize >= (UINTN)CertList->SignatureListSize)) {
     if (CompareGuid (&CertList->SignatureType, &gEfiCertX509Guid)) {
       CertData  = (EFI_SIGNATURE_DATA *)((UINT8 *)CertList + sizeof (EFI_SIGNATURE_LIST) + CertList->SignatureHeaderSize);
       CertCount = (CertList->SignatureListSize - sizeof (EFI_SIGNATURE_LIST) - CertList->SignatureHeaderSize) / CertList->SignatureSize;
@@ -1523,7 +1523,7 @@ IsAllowedByDb (
   // Find X509 certificate in Signature List to verify the signature in pkcs7 signed data.
   //
   CertList = (EFI_SIGNATURE_LIST *)Data;
-  while ((DataSize > 0) && (DataSize >= CertList->SignatureListSize)) {
+  while ((DataSize > 0) && (DataSize >= (UINTN)CertList->SignatureListSize)) {
     if (CompareGuid (&CertList->SignatureType, &gEfiCertX509Guid)) {
       CertData  = (EFI_SIGNATURE_DATA *)((UINT8 *)CertList + sizeof (EFI_SIGNATURE_LIST) + CertList->SignatureHeaderSize);
       CertCount = (CertList->SignatureListSize - sizeof (EFI_SIGNATURE_LIST) - CertList->SignatureHeaderSize) / CertList->SignatureSize;

--- a/SecurityPkg/Library/DxeImageVerificationLib/DxeImageVerificationLib.c
+++ b/SecurityPkg/Library/DxeImageVerificationLib/DxeImageVerificationLib.c
@@ -2049,8 +2049,9 @@ Failed:
   // executable information table in either case.
   //
   NameStr = ConvertDevicePathToText (File, FALSE, TRUE);
-  AddImageExeInfo (Action, NameStr, File, SignatureList, SignatureListSize);
+
   if (NameStr != NULL) {
+    AddImageExeInfo (Action, NameStr, File, SignatureList, SignatureListSize);
     DEBUG ((DEBUG_INFO, "The image doesn't pass verification: %s\n", NameStr));
     FreePool (NameStr);
   }

--- a/SecurityPkg/Library/DxeTcg2PhysicalPresenceLib/DxeTcg2PhysicalPresenceLib.c
+++ b/SecurityPkg/Library/DxeTcg2PhysicalPresenceLib/DxeTcg2PhysicalPresenceLib.c
@@ -387,7 +387,10 @@ Tcg2UserConfirm (
   NoPpiInfo   = FALSE;
   BufSize     = CONFIRM_BUFFER_SIZE;
   ConfirmText = AllocateZeroPool (BufSize);
-  ASSERT (ConfirmText != NULL);
+  if (ConfirmText == NULL) {
+    ASSERT (ConfirmText != NULL);
+    return FALSE;
+  }
 
   mTcg2PpStringPackHandle = HiiAddPackages (&gEfiTcg2PhysicalPresenceGuid, gImageHandle, DxeTcg2PhysicalPresenceLibStrings, NULL);
   ASSERT (mTcg2PpStringPackHandle != NULL);
@@ -401,10 +404,20 @@ Tcg2UserConfirm (
       TmpStr2    = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TPM_CLEAR));
 
       TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TPM_HEAD_STR));
+      if ((TmpStr1 == NULL) || (TmpStr2 == NULL)) {
+        FreePool (ConfirmText);
+        return FALSE;
+      }
+
       UnicodeSPrint (ConfirmText, BufSize, TmpStr1, TmpStr2);
       FreePool (TmpStr1);
 
       TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TPM_WARNING_CLEAR));
+      if (TmpStr1 == NULL) {
+        FreePool (ConfirmText);
+        return FALSE;
+      }
+
       StrnCatS (ConfirmText, BufSize / sizeof (CHAR16), TmpStr1, (BufSize / sizeof (CHAR16)) - StrLen (ConfirmText) - 1);
       StrnCatS (ConfirmText, BufSize / sizeof (CHAR16), L" \n\n", (BufSize / sizeof (CHAR16)) - StrLen (ConfirmText) - 1);
       FreePool (TmpStr1);
@@ -417,14 +430,29 @@ Tcg2UserConfirm (
       TmpStr2    = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TPM_CLEAR));
 
       TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TPM_PPI_HEAD_STR));
+      if ((TmpStr1 == NULL) || (TmpStr2 == NULL)) {
+        FreePool (ConfirmText);
+        return FALSE;
+      }
+
       UnicodeSPrint (ConfirmText, BufSize, TmpStr1, TmpStr2);
       FreePool (TmpStr1);
 
       TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TPM_NOTE_CLEAR));
+      if (TmpStr1 == NULL) {
+        FreePool (ConfirmText);
+        return FALSE;
+      }
+
       StrnCatS (ConfirmText, BufSize / sizeof (CHAR16), TmpStr1, (BufSize / sizeof (CHAR16)) - StrLen (ConfirmText) - 1);
       FreePool (TmpStr1);
 
       TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TPM_WARNING_CLEAR));
+      if (TmpStr1 == NULL) {
+        FreePool (ConfirmText);
+        return FALSE;
+      }
+
       StrnCatS (ConfirmText, BufSize / sizeof (CHAR16), TmpStr1, (BufSize / sizeof (CHAR16)) - StrLen (ConfirmText) - 1);
       StrnCatS (ConfirmText, BufSize / sizeof (CHAR16), L" \n\n", (BufSize / sizeof (CHAR16)) - StrLen (ConfirmText) - 1);
       FreePool (TmpStr1);
@@ -452,14 +480,29 @@ Tcg2UserConfirm (
       TmpStr2    = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TPM_SET_PCR_BANKS));
 
       TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TPM_HEAD_STR));
+      if ((TmpStr1 == NULL) || (TmpStr2 == NULL)) {
+        FreePool (ConfirmText);
+        return FALSE;
+      }
+
       UnicodeSPrint (ConfirmText, BufSize, TmpStr1, TmpStr2);
       FreePool (TmpStr1);
 
       TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TPM_WARNING_SET_PCR_BANKS_1));
+      if (TmpStr1 == NULL) {
+        FreePool (ConfirmText);
+        return FALSE;
+      }
+
       StrnCatS (ConfirmText, BufSize / sizeof (CHAR16), TmpStr1, (BufSize / sizeof (CHAR16)) - StrLen (ConfirmText) - 1);
       FreePool (TmpStr1);
 
       TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TPM_WARNING_SET_PCR_BANKS_2));
+      if (TmpStr1 == NULL) {
+        FreePool (ConfirmText);
+        return FALSE;
+      }
+
       StrnCatS (ConfirmText, BufSize / sizeof (CHAR16), TmpStr1, (BufSize / sizeof (CHAR16)) - StrLen (ConfirmText) - 1);
       FreePool (TmpStr1);
 
@@ -467,7 +510,11 @@ Tcg2UserConfirm (
       Tcg2FillBufferWithBootHashAlg (TempBuffer2, sizeof (TempBuffer2), CurrentPCRBanks);
 
       TmpStr1 = AllocateZeroPool (BufSize);
-      ASSERT (TmpStr1 != NULL);
+      if (TmpStr1 == NULL) {
+        ASSERT (TmpStr1 != NULL);
+        return FALSE;
+      }
+
       UnicodeSPrint (TmpStr1, BufSize, L"Current PCRBanks is 0x%x. (%s)\nNew PCRBanks is 0x%x. (%s)\n", CurrentPCRBanks, TempBuffer2, TpmPpCommandParameter, TempBuffer);
 
       StrnCatS (ConfirmText, BufSize / sizeof (CHAR16), TmpStr1, (BufSize / sizeof (CHAR16)) - StrLen (ConfirmText) - 1);
@@ -481,14 +528,29 @@ Tcg2UserConfirm (
       TmpStr2    = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TPM_CHANGE_EPS));
 
       TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TPM_HEAD_STR));
+      if ((TmpStr1 == NULL) || (TmpStr2 == NULL)) {
+        FreePool (ConfirmText);
+        return FALSE;
+      }
+
       UnicodeSPrint (ConfirmText, BufSize, TmpStr1, TmpStr2);
       FreePool (TmpStr1);
 
       TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TPM_WARNING_CHANGE_EPS_1));
+      if (TmpStr1 == NULL) {
+        FreePool (ConfirmText);
+        return FALSE;
+      }
+
       StrnCatS (ConfirmText, BufSize / sizeof (CHAR16), TmpStr1, (BufSize / sizeof (CHAR16)) - StrLen (ConfirmText) - 1);
       FreePool (TmpStr1);
 
       TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TPM_WARNING_CHANGE_EPS_2));
+      if (TmpStr1 == NULL) {
+        FreePool (ConfirmText);
+        return FALSE;
+      }
+
       StrnCatS (ConfirmText, BufSize / sizeof (CHAR16), TmpStr1, (BufSize / sizeof (CHAR16)) - StrLen (ConfirmText) - 1);
       FreePool (TmpStr1);
 
@@ -498,6 +560,11 @@ Tcg2UserConfirm (
       TmpStr2 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TCG_STORAGE_ENABLE_BLOCK_SID));
 
       TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TCG_STORAGE_HEAD_STR));
+      if ((TmpStr1 == NULL) || (TmpStr2 == NULL)) {
+        FreePool (ConfirmText);
+        return FALSE;
+      }
+
       UnicodeSPrint (ConfirmText, BufSize, TmpStr1, TmpStr2);
       FreePool (TmpStr1);
       break;
@@ -506,6 +573,11 @@ Tcg2UserConfirm (
       TmpStr2 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TCG_STORAGE_DISABLE_BLOCK_SID));
 
       TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TCG_STORAGE_HEAD_STR));
+      if ((TmpStr1 == NULL) || (TmpStr2 == NULL)) {
+        FreePool (ConfirmText);
+        return FALSE;
+      }
+
       UnicodeSPrint (ConfirmText, BufSize, TmpStr1, TmpStr2);
       FreePool (TmpStr1);
       break;
@@ -515,6 +587,11 @@ Tcg2UserConfirm (
       TmpStr2   = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TCG_STORAGE_PP_ENABLE_BLOCK_SID));
 
       TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TCG_STORAGE_PPI_HEAD_STR));
+      if ((TmpStr1 == NULL) || (TmpStr2 == NULL)) {
+        FreePool (ConfirmText);
+        return FALSE;
+      }
+
       UnicodeSPrint (ConfirmText, BufSize, TmpStr1, TmpStr2);
       FreePool (TmpStr1);
       break;
@@ -524,6 +601,11 @@ Tcg2UserConfirm (
       TmpStr2   = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TCG_STORAGE_PP_DISABLE_BLOCK_SID));
 
       TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TCG_STORAGE_PPI_HEAD_STR));
+      if ((TmpStr1 == NULL) || (TmpStr2 == NULL)) {
+        FreePool (ConfirmText);
+        return FALSE;
+      }
+
       UnicodeSPrint (ConfirmText, BufSize, TmpStr1, TmpStr2);
       FreePool (TmpStr1);
       break;
@@ -544,11 +626,21 @@ Tcg2UserConfirm (
       TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TPM_ACCEPT_KEY));
     }
 
+    if (TmpStr1 == NULL) {
+      FreePool (ConfirmText);
+      return FALSE;
+    }
+
     StrnCatS (ConfirmText, BufSize / sizeof (CHAR16), TmpStr1, (BufSize / sizeof (CHAR16)) - StrLen (ConfirmText) - 1);
     FreePool (TmpStr1);
 
     if (NoPpiInfo) {
       TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TPM_NO_PPI_INFO));
+      if (TmpStr1 == NULL) {
+        FreePool (ConfirmText);
+        return FALSE;
+      }
+
       StrnCatS (ConfirmText, BufSize / sizeof (CHAR16), TmpStr1, (BufSize / sizeof (CHAR16)) - StrLen (ConfirmText) - 1);
       FreePool (TmpStr1);
     }
@@ -561,16 +653,31 @@ Tcg2UserConfirm (
       TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TCG_STORAGE_ACCEPT_KEY));
     }
 
+    if (TmpStr1 == NULL) {
+      FreePool (ConfirmText);
+      return FALSE;
+    }
+
     StrnCatS (ConfirmText, BufSize / sizeof (CHAR16), TmpStr1, (BufSize / sizeof (CHAR16)) - StrLen (ConfirmText) - 1);
     FreePool (TmpStr1);
 
     if (NoPpiInfo) {
       TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TCG_STORAGE_NO_PPI_INFO));
+      if (TmpStr1 == NULL) {
+        FreePool (ConfirmText);
+        return FALSE;
+      }
+
       StrnCatS (ConfirmText, BufSize / sizeof (CHAR16), TmpStr1, (BufSize / sizeof (CHAR16)) - StrLen (ConfirmText) - 1);
       FreePool (TmpStr1);
     }
 
     TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TCG_STORAGE_REJECT_KEY));
+  }
+
+  if (TmpStr1 == NULL) {
+    FreePool (ConfirmText);
+    return FALSE;
   }
 
   BufSize -= StrSize (ConfirmText);

--- a/SecurityPkg/Library/DxeTcgPhysicalPresenceLib/DxeTcgPhysicalPresenceLib.c
+++ b/SecurityPkg/Library/DxeTcgPhysicalPresenceLib/DxeTcgPhysicalPresenceLib.c
@@ -540,7 +540,7 @@ UserConfirm (
   CHAR16   *TmpStr2;
   UINTN    BufSize;
   BOOLEAN  CautionKey;
-  UINT16   Index;
+  UINTN    Index;
   CHAR16   DstStr[81];
 
   TmpStr2     = NULL;

--- a/SecurityPkg/Library/DxeTpm2MeasureBootLib/DxeTpm2MeasureBootLib.c
+++ b/SecurityPkg/Library/DxeTpm2MeasureBootLib/DxeTpm2MeasureBootLib.c
@@ -621,6 +621,9 @@ GetMeasureBootProtocols (
   @retval EFI_SUCCESS             The file specified by DevicePath and non-NULL
                                   FileBuffer did authenticate, and the platform policy dictates
                                   that the DXE Foundation may use the file.
+
+  @retval EFI_OUT_OF_RESOURCES    A necessary memory buffer could not be allocated.
+
   @retval other error value
 **/
 EFI_STATUS
@@ -723,9 +726,16 @@ DxeTpm2MeasureBootHandler (
             }
           }
 
-          FreePool (OrigDevicePathNode);
+          if (OrigDevicePathNode != NULL) {
+            FreePool (OrigDevicePathNode);
+          }
+
           OrigDevicePathNode = DuplicateDevicePath (File);
-          ASSERT (OrigDevicePathNode != NULL);
+          if (OrigDevicePathNode == NULL) {
+            ASSERT (OrigDevicePathNode != NULL);
+            return EFI_OUT_OF_RESOURCES;
+          }
+
           break;
         }
       }

--- a/SecurityPkg/Library/HashInstanceLibSha1/HashInstanceLibSha1.c
+++ b/SecurityPkg/Library/HashInstanceLibSha1/HashInstanceLibSha1.c
@@ -56,7 +56,10 @@ Sha1HashInit (
 
   CtxSize = Sha1GetContextSize ();
   Sha1Ctx = AllocatePool (CtxSize);
-  ASSERT (Sha1Ctx != NULL);
+  if (Sha1Ctx == NULL) {
+    ASSERT (Sha1Ctx != NULL);
+    return EFI_OUT_OF_RESOURCES;
+  }
 
   Sha1Init (Sha1Ctx);
 

--- a/SecurityPkg/Library/HashInstanceLibSha256/HashInstanceLibSha256.c
+++ b/SecurityPkg/Library/HashInstanceLibSha256/HashInstanceLibSha256.c
@@ -56,7 +56,10 @@ Sha256HashInit (
 
   CtxSize   = Sha256GetContextSize ();
   Sha256Ctx = AllocatePool (CtxSize);
-  ASSERT (Sha256Ctx != NULL);
+  if (Sha256Ctx == NULL) {
+    ASSERT (Sha256Ctx != NULL);
+    return EFI_OUT_OF_RESOURCES;
+  }
 
   Sha256Init (Sha256Ctx);
 

--- a/SecurityPkg/Library/HashLibBaseCryptoRouter/HashLibBaseCryptoRouterDxe.c
+++ b/SecurityPkg/Library/HashLibBaseCryptoRouter/HashLibBaseCryptoRouterDxe.c
@@ -80,6 +80,11 @@ HashStart (
 
   for (Index = 0; Index < mHashInterfaceCount; Index++) {
     HashMask = Tpm2GetHashMaskFromAlgo (&mHashInterface[Index].HashGuid);
+    if (HashCtx == NULL) {
+      // If we fail to get the hash mask we don't have resources.
+      return EFI_OUT_OF_RESOURCES;
+    }
+
     if ((HashMask & PcdGet32 (PcdTpm2HashMask)) != 0) {
       mHashInterface[Index].HashInit (&HashCtx[Index]);
     }

--- a/SecurityPkg/Library/HashLibBaseCryptoRouter/HashLibBaseCryptoRouterDxe.c
+++ b/SecurityPkg/Library/HashLibBaseCryptoRouter/HashLibBaseCryptoRouterDxe.c
@@ -283,8 +283,16 @@ HashAndExtend (
 
   CheckSupportedHashMaskMismatch ();
 
-  HashStart (&HashHandle);
-  HashUpdate (HashHandle, DataToHash, DataToHashLen);
+  Status = HashStart (&HashHandle);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Status = HashUpdate (HashHandle, DataToHash, DataToHashLen);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
   Status = HashCompleteAndExtend (HashHandle, PcrIndex, NULL, 0, DigestList);
 
   return Status;

--- a/SecurityPkg/Library/HashLibBaseCryptoRouter/HashLibBaseCryptoRouterPei.c
+++ b/SecurityPkg/Library/HashLibBaseCryptoRouter/HashLibBaseCryptoRouterPei.c
@@ -106,7 +106,10 @@ CheckSupportedHashMaskMismatch (
   HASH_INTERFACE_HOB  *HashInterfaceHobLast;
 
   HashInterfaceHobLast = InternalGetHashInterfaceHob (&gZeroGuid);
-  ASSERT (HashInterfaceHobLast != NULL);
+  if (HashInterfaceHobLast == NULL) {
+    ASSERT (HashInterfaceHobLast != NULL);
+    return;
+  }
 
   if ((HashInterfaceHobLast->SupportedHashMask != 0) &&
       (HashInterfaceHobCurrent->SupportedHashMask != HashInterfaceHobLast->SupportedHashMask))
@@ -152,7 +155,10 @@ HashStart (
   CheckSupportedHashMaskMismatch (HashInterfaceHob);
 
   HashCtx = AllocatePool (sizeof (*HashCtx) * HashInterfaceHob->HashInterfaceCount);
-  ASSERT (HashCtx != NULL);
+  if (HashCtx == NULL) {
+    ASSERT (HashCtx != NULL);
+    return EFI_OUT_OF_RESOURCES;
+  }
 
   for (Index = 0; Index < HashInterfaceHob->HashInterfaceCount; Index++) {
     HashMask = Tpm2GetHashMaskFromAlgo (&HashInterfaceHob->HashInterface[Index].HashGuid);
@@ -304,7 +310,6 @@ HashAndExtend (
   }
 
   CheckSupportedHashMaskMismatch (HashInterfaceHob);
-
   HashStart (&HashHandle);
   HashUpdate (HashHandle, DataToHash, DataToHashLen);
   Status = HashCompleteAndExtend (HashHandle, PcrIndex, NULL, 0, DigestList);

--- a/SecurityPkg/Library/HashLibBaseCryptoRouter/HashLibBaseCryptoRouterPei.c
+++ b/SecurityPkg/Library/HashLibBaseCryptoRouter/HashLibBaseCryptoRouterPei.c
@@ -310,8 +310,17 @@ HashAndExtend (
   }
 
   CheckSupportedHashMaskMismatch (HashInterfaceHob);
-  HashStart (&HashHandle);
-  HashUpdate (HashHandle, DataToHash, DataToHashLen);
+
+  Status = HashStart (&HashHandle);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Status = HashUpdate (HashHandle, DataToHash, DataToHashLen);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
   Status = HashCompleteAndExtend (HashHandle, PcrIndex, NULL, 0, DigestList);
 
   return Status;

--- a/SecurityPkg/Library/SecureBootVariableProvisionLib/SecureBootVariableProvisionLib.c
+++ b/SecurityPkg/Library/SecureBootVariableProvisionLib/SecureBootVariableProvisionLib.c
@@ -61,7 +61,11 @@ SecureBootFetchData (
   *SigListOut   = NULL;
   *SigListsSize = 0;
   CertInfo      = AllocatePool (sizeof (SECURE_BOOT_CERTIFICATE_INFO));
-  NewCertInfo   = CertInfo;
+  if (CertInfo == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  NewCertInfo = CertInfo;
   while (1) {
     if (NewCertInfo == NULL) {
       Status = EFI_OUT_OF_RESOURCES;
@@ -99,6 +103,9 @@ SecureBootFetchData (
                       sizeof (SECURE_BOOT_CERTIFICATE_INFO) * (KeyIndex + 1),
                       CertInfo
                       );
+      if (NewCertInfo == NULL) {
+        goto Cleanup;
+      }
     }
 
     if (Status == EFI_NOT_FOUND) {

--- a/SecurityPkg/Library/TcgEventLogRecordLib/TcgEventLogRecordLib.c
+++ b/SecurityPkg/Library/TcgEventLogRecordLib/TcgEventLogRecordLib.c
@@ -106,7 +106,7 @@ MeasureFirmwareBlob (
   {
     if (Description != NULL) {
       AsciiSPrint ((CHAR8 *)FvBlob2.BlobDescription, sizeof (FvBlob2.BlobDescription), "%a", Description);
-    } else {
+    } else if (FvName != NULL) {
       AsciiSPrint ((CHAR8 *)FvBlob2.BlobDescription, sizeof (FvBlob2.BlobDescription), "Fv(%g)", FvName);
     }
 

--- a/SecurityPkg/Library/Tpm12DeviceLibDTpm/Tpm12Tis.c
+++ b/SecurityPkg/Library/Tpm12DeviceLibDTpm/Tpm12Tis.c
@@ -270,7 +270,7 @@ Tpm12TisTpmCommand (
 {
   EFI_STATUS  Status;
   UINT16      BurstCount;
-  UINT32      Index;
+  UINTN       Index;
   UINT32      TpmOutSize;
   UINT16      Data16;
   UINT32      Data32;

--- a/SecurityPkg/RandomNumberGenerator/RngDxe/Rand/AesCore.c
+++ b/SecurityPkg/RandomNumberGenerator/RngDxe/Rand/AesCore.c
@@ -230,6 +230,8 @@ AesEncrypt (
   UINTN    NbIndex;
   UINTN    Round;
 
+  EFI_STATUS  Status;
+
   if ((Key == NULL) || (InData == NULL) || (OutData == NULL)) {
     return EFI_INVALID_PARAMETER;
   }
@@ -237,7 +239,10 @@ AesEncrypt (
   //
   // Expands AES Key for encryption.
   //
-  AesExpandKey (Key, 128, &AesKey);
+  Status = AesExpandKey (Key, 128, &AesKey);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
 
   Nr = AesKey.Nk + 6;
   Ek = AesKey.EncKey;

--- a/SecurityPkg/Tcg/Opal/OpalPassword/OpalDriver.c
+++ b/SecurityPkg/Tcg/Opal/OpalPassword/OpalDriver.c
@@ -2223,7 +2223,7 @@ ProcessOpalRequest (
   //
   TempVariable = Variable;
   while ((VariableSize > sizeof (OPAL_REQUEST_VARIABLE)) &&
-         (VariableSize >= TempVariable->Length) &&
+         (VariableSize >= (UINTN)TempVariable->Length) &&
          (TempVariable->Length > sizeof (OPAL_REQUEST_VARIABLE)))
   {
     DevicePathInVariable     = (EFI_DEVICE_PATH_PROTOCOL *)((UINTN)TempVariable + sizeof (OPAL_REQUEST_VARIABLE));

--- a/SecurityPkg/Tcg/Opal/OpalPassword/OpalHii.c
+++ b/SecurityPkg/Tcg/Opal/OpalPassword/OpalHii.c
@@ -226,7 +226,11 @@ SaveOpalRequest (
       DevicePathSize  = GetDevicePathSize (DevicePath);
       NewVariableSize = VariableSize + sizeof (OPAL_REQUEST_VARIABLE) + DevicePathSize;
       NewVariable     = AllocatePool (NewVariableSize);
-      ASSERT (NewVariable != NULL);
+      if (NewVariable == NULL) {
+        ASSERT (NewVariable != NULL);
+        return;
+      }
+
       CopyMem (NewVariable, Variable, VariableSize);
       TempVariable         = (OPAL_REQUEST_VARIABLE *)((UINTN)NewVariable + VariableSize);
       TempVariable->Length = (UINT32)(sizeof (OPAL_REQUEST_VARIABLE) + DevicePathSize);
@@ -239,7 +243,11 @@ SaveOpalRequest (
     DevicePathSize  = GetDevicePathSize (DevicePath);
     NewVariableSize = sizeof (OPAL_REQUEST_VARIABLE) + DevicePathSize;
     NewVariable     = AllocatePool (NewVariableSize);
-    ASSERT (NewVariable != NULL);
+    if (NewVariable == NULL) {
+      ASSERT (NewVariable != NULL);
+      return;
+    }
+
     NewVariable->Length = (UINT32)(sizeof (OPAL_REQUEST_VARIABLE) + DevicePathSize);
     CopyMem (&NewVariable->OpalRequest, &OpalRequest, sizeof (OPAL_REQUEST));
     DevicePathInVariable = (EFI_DEVICE_PATH_PROTOCOL *)((UINTN)NewVariable + sizeof (OPAL_REQUEST_VARIABLE));
@@ -1110,8 +1118,13 @@ ExtractConfig (
     //
     DriverHandle     = HiiGetDriverImageHandleCB ();
     ConfigRequestHdr = HiiConstructConfigHdr (&gHiiSetupVariableGuid, OpalPasswordStorageName, DriverHandle);
-    Size             = (StrLen (ConfigRequestHdr) + 32 + 1) * sizeof (CHAR16);
-    ConfigRequest    = AllocateZeroPool (Size);
+    if (ConfigRequestHdr == NULL) {
+      ASSERT (ConfigRequestHdr != NULL);
+      return EFI_OUT_OF_RESOURCES;
+    }
+
+    Size          = (StrLen (ConfigRequestHdr) + 32 + 1) * sizeof (CHAR16);
+    ConfigRequest = AllocateZeroPool (Size);
     if (ConfigRequest == NULL) {
       return EFI_OUT_OF_RESOURCES;
     }

--- a/SecurityPkg/Tcg/Opal/OpalPassword/OpalHii.c
+++ b/SecurityPkg/Tcg/Opal/OpalPassword/OpalHii.c
@@ -113,7 +113,7 @@ GetSavedOpalRequest (
 
   TempVariable = Variable;
   while ((VariableSize > sizeof (OPAL_REQUEST_VARIABLE)) &&
-         (VariableSize >= TempVariable->Length) &&
+         (VariableSize >= (UINTN)TempVariable->Length) &&
          (TempVariable->Length > sizeof (OPAL_REQUEST_VARIABLE)))
   {
     DevicePathInVariable     = (EFI_DEVICE_PATH_PROTOCOL *)((UINTN)TempVariable + sizeof (OPAL_REQUEST_VARIABLE));
@@ -193,7 +193,7 @@ SaveOpalRequest (
     TempVariable     = Variable;
     TempVariableSize = VariableSize;
     while ((TempVariableSize > sizeof (OPAL_REQUEST_VARIABLE)) &&
-           (TempVariableSize >= TempVariable->Length) &&
+           (TempVariableSize >= (UINTN)TempVariable->Length) &&
            (TempVariable->Length > sizeof (OPAL_REQUEST_VARIABLE)))
     {
       DevicePathInVariable     = (EFI_DEVICE_PATH_PROTOCOL *)((UINTN)TempVariable + sizeof (OPAL_REQUEST_VARIABLE));

--- a/SecurityPkg/Tcg/Tcg2Config/Tcg2ConfigDriver.c
+++ b/SecurityPkg/Tcg/Tcg2Config/Tcg2ConfigDriver.c
@@ -103,7 +103,11 @@ InitializeTcg2VersionInfo (
                        TCG2_VERSION_NAME,
                        PrivateData->DriverHandle
                        );
-  ASSERT (ConfigRequestHdr != NULL);
+  if (ConfigRequestHdr == NULL) {
+    ASSERT (ConfigRequestHdr != NULL);
+    return;
+  }
+
   DataSize = sizeof (Tcg2Version);
   Status   = gRT->GetVariable (
                     TCG2_VERSION_NAME,

--- a/SecurityPkg/Tcg/Tcg2Dxe/Tcg2Dxe.c
+++ b/SecurityPkg/Tcg/Tcg2Dxe/Tcg2Dxe.c
@@ -626,14 +626,14 @@ DumpEventLog (
   TCG_PCR_EVENT_HDR         *EventHdr;
   TCG_PCR_EVENT2            *TcgPcrEvent2;
   TCG_EfiSpecIDEventStruct  *TcgEfiSpecIdEventStruct;
-  UINTN                     NumberOfEvents;
+  UINT64                    NumberOfEvents;
 
   DEBUG ((DEBUG_INFO, "EventLogFormat: (0x%x)\n", EventLogFormat));
 
   switch (EventLogFormat) {
     case EFI_TCG2_EVENT_LOG_FORMAT_TCG_1_2:
       EventHdr = (TCG_PCR_EVENT_HDR *)(UINTN)EventLogLocation;
-      while ((UINTN)EventHdr <= EventLogLastEntry) {
+      while ((EFI_PHYSICAL_ADDRESS)(UINTN)EventHdr <= EventLogLastEntry) {
         DumpEvent (EventHdr);
         EventHdr = (TCG_PCR_EVENT_HDR *)((UINTN)EventHdr + sizeof (TCG_PCR_EVENT_HDR) + EventHdr->EventSize);
       }
@@ -664,7 +664,7 @@ DumpEventLog (
       DumpTcgEfiSpecIdEventStruct (TcgEfiSpecIdEventStruct);
 
       TcgPcrEvent2 = (TCG_PCR_EVENT2 *)((UINTN)TcgEfiSpecIdEventStruct + GetTcgEfiSpecIdEventStructSize (TcgEfiSpecIdEventStruct));
-      while ((UINTN)TcgPcrEvent2 <= EventLogLastEntry) {
+      while ((EFI_PHYSICAL_ADDRESS)(UINTN)TcgPcrEvent2 <= EventLogLastEntry) {
         DumpEvent2 (TcgPcrEvent2);
         TcgPcrEvent2 = (TCG_PCR_EVENT2 *)((UINTN)TcgPcrEvent2 + GetPcrEvent2Size (TcgPcrEvent2));
       }

--- a/SecurityPkg/Tcg/TcgConfigDxe/TcgConfigImpl.c
+++ b/SecurityPkg/Tcg/TcgConfigDxe/TcgConfigImpl.c
@@ -193,9 +193,19 @@ TcgExtractConfig (
     // followed by "&OFFSET=0&WIDTH=WWWWWWWWWWWWWWWW" followed by a Null-terminator
     //
     ConfigRequestHdr = HiiConstructConfigHdr (&gTcgConfigFormSetGuid, mTcgStorageName, PrivateData->DriverHandle);
-    Size             = (StrLen (ConfigRequestHdr) + 32 + 1) * sizeof (CHAR16);
-    ConfigRequest    = AllocateZeroPool (Size);
-    ASSERT (ConfigRequest != NULL);
+    if (ConfigRequestHdr == NULL) {
+      ASSERT (ConfigRequestHdr != NULL);
+      return EFI_OUT_OF_RESOURCES;
+    }
+
+    Size          = (StrLen (ConfigRequestHdr) + 32 + 1) * sizeof (CHAR16);
+    ConfigRequest = AllocateZeroPool (Size);
+    if (ConfigRequest == NULL) {
+      ASSERT (ConfigRequest != NULL);
+      FreePool (ConfigRequestHdr);
+      return EFI_OUT_OF_RESOURCES;
+    }
+
     AllocatedRequest = TRUE;
     UnicodeSPrint (ConfigRequest, Size, L"%s&OFFSET=0&WIDTH=%016LX", ConfigRequestHdr, sizeof (TCG_CONFIGURATION));
     FreePool (ConfigRequestHdr);

--- a/SecurityPkg/Tcg/TcgDxe/TcgDxe.c
+++ b/SecurityPkg/Tcg/TcgDxe/TcgDxe.c
@@ -286,7 +286,10 @@ TpmCommHashAll (
 
   CtxSize = Sha1GetContextSize ();
   Sha1Ctx = AllocatePool (CtxSize);
-  ASSERT (Sha1Ctx != NULL);
+  if (Sha1Ctx == NULL) {
+    ASSERT (Sha1Ctx != NULL);
+    return EFI_OUT_OF_RESOURCES;
+  }
 
   Sha1Init (Sha1Ctx);
   Sha1Update (Sha1Ctx, Data, DataLen);

--- a/SecurityPkg/VariableAuthenticated/SecureBootConfigDxe/SecureBootConfigFileExplorer.c
+++ b/SecurityPkg/VariableAuthenticated/SecureBootConfigDxe/SecureBootConfigFileExplorer.c
@@ -98,7 +98,11 @@ ExtractFileNameFromDevicePath (
 
   ASSERT (DevicePath != NULL);
 
-  String      = DevicePathToStr (DevicePath);
+  String = DevicePathToStr (DevicePath);
+  if (String == NULL) {
+    return NULL;
+  }
+
   MatchString = String;
   LastMatch   = String;
   FileName    = NULL;

--- a/SecurityPkg/VariableAuthenticated/SecureBootConfigDxe/SecureBootConfigImpl.c
+++ b/SecurityPkg/VariableAuthenticated/SecureBootConfigDxe/SecureBootConfigImpl.c
@@ -1164,7 +1164,10 @@ CalculateCertHash (
   //
   CtxSize = mHash[HashAlg].GetContextSize ();
   HashCtx = AllocatePool (CtxSize);
-  ASSERT (HashCtx != NULL);
+  if (HashCtx == NULL) {
+    ASSERT (HashCtx != NULL);
+    return FALSE;
+  }
 
   //
   // 2. Initialize a hash context.
@@ -1879,7 +1882,10 @@ HashPeImage (
   CtxSize = mHash[HashAlg].GetContextSize ();
 
   HashCtx = AllocatePool (CtxSize);
-  ASSERT (HashCtx != NULL);
+  if (HashCtx == NULL) {
+    ASSERT (HashCtx != NULL);
+    goto Done;
+  }
 
   // 1.  Load the image header into memory.
 
@@ -3508,9 +3514,19 @@ SecureBootExtractConfig (
     // followed by "&OFFSET=0&WIDTH=WWWWWWWWWWWWWWWW" followed by a Null-terminator
     //
     ConfigRequestHdr = HiiConstructConfigHdr (&gSecureBootConfigFormSetGuid, mSecureBootStorageName, PrivateData->DriverHandle);
-    Size             = (StrLen (ConfigRequestHdr) + 32 + 1) * sizeof (CHAR16);
-    ConfigRequest    = AllocateZeroPool (Size);
-    ASSERT (ConfigRequest != NULL);
+    if (ConfigRequestHdr == NULL) {
+      ASSERT (ConfigRequestHdr != NULL);
+      return EFI_OUT_OF_RESOURCES;
+    }
+
+    Size          = (StrLen (ConfigRequestHdr) + 32 + 1) * sizeof (CHAR16);
+    ConfigRequest = AllocateZeroPool (Size);
+    if (ConfigRequest == NULL) {
+      ASSERT (ConfigRequest != NULL);
+      FreePool (ConfigRequestHdr);
+      return EFI_OUT_OF_RESOURCES;
+    }
+
     AllocatedRequest = TRUE;
     UnicodeSPrint (ConfigRequest, Size, L"%s&OFFSET=0&WIDTH=%016LX", ConfigRequestHdr, (UINT64)BufferSize);
     FreePool (ConfigRequestHdr);

--- a/SecurityPkg/VariableAuthenticated/SecureBootConfigDxe/SecureBootConfigImpl.c
+++ b/SecurityPkg/VariableAuthenticated/SecureBootConfigDxe/SecureBootConfigImpl.c
@@ -1086,7 +1086,7 @@ IsSignatureFoundInDatabase (
   // Enumerate all signature data in SigDB to check if signature exists for executable.
   //
   CertList = (EFI_SIGNATURE_LIST *)Data;
-  while ((DataSize > 0) && (DataSize >= CertList->SignatureListSize)) {
+  while ((DataSize > 0) && (DataSize >= (UINTN)CertList->SignatureListSize)) {
     CertCount = (CertList->SignatureListSize - sizeof (EFI_SIGNATURE_LIST) - CertList->SignatureHeaderSize) / CertList->SignatureSize;
     Cert      = (EFI_SIGNATURE_DATA *)((UINT8 *)CertList + sizeof (EFI_SIGNATURE_LIST) + CertList->SignatureHeaderSize);
     if ((CertList->SignatureSize == sizeof (EFI_SIGNATURE_DATA) - 1 + SignatureSize) && (CompareGuid (&CertList->SignatureType, &gEfiCertX509Guid))) {
@@ -1255,7 +1255,7 @@ IsCertHashFoundInDbx (
   // Check whether the certificate hash exists in the forbidden database.
   //
   DbxList = (EFI_SIGNATURE_LIST *)Data;
-  while ((DataSize > 0) && (DataSize >= DbxList->SignatureListSize)) {
+  while ((DataSize > 0) && (DataSize >= (UINTN)DbxList->SignatureListSize)) {
     //
     // Determine Hash Algorithm of Certificate in the forbidden database.
     //
@@ -1342,7 +1342,7 @@ GetSignaturelistOffset (
 
   SigList     = Database;
   SiglistSize = DatabaseSize;
-  while ((SiglistSize > 0) && (SiglistSize >= SigList->SignatureListSize)) {
+  while ((SiglistSize > 0) && (SiglistSize >= (UINTN)SigList->SignatureListSize)) {
     if (CompareGuid (&SigList->SignatureType, SignatureType)) {
       *Offset = DatabaseSize - SiglistSize;
       return TRUE;
@@ -2532,7 +2532,7 @@ UpdateDeletePage (
   )
 {
   EFI_STATUS          Status;
-  UINT32              Index;
+  UINTN               Index;
   UINTN               CertCount;
   UINTN               GuidIndex;
   VOID                *StartOpCodeHandle;
@@ -2725,7 +2725,7 @@ DeleteKeyExchangeKey (
   UINT8               *Data;
   UINT8               *OldData;
   UINT32              Attr;
-  UINT32              Index;
+  UINTN               Index;
   EFI_SIGNATURE_LIST  *CertList;
   EFI_SIGNATURE_LIST  *NewCertList;
   EFI_SIGNATURE_DATA  *Cert;
@@ -2929,7 +2929,7 @@ DeleteSignature (
   UINT8               *Data;
   UINT8               *OldData;
   UINT32              Attr;
-  UINT32              Index;
+  UINTN               Index;
   EFI_SIGNATURE_LIST  *CertList;
   EFI_SIGNATURE_LIST  *NewCertList;
   EFI_SIGNATURE_DATA  *Cert;
@@ -3207,7 +3207,7 @@ DeleteSignatureEx (
     //
     //  Traverse to target EFI_SIGNATURE_LIST but others will be skipped.
     //
-    while ((RemainingSize > 0) && (RemainingSize >= ListWalker->SignatureListSize) && ListIndex < PrivateData->ListIndex) {
+    while ((RemainingSize > 0) && (RemainingSize >= (UINTN)ListWalker->SignatureListSize) && ListIndex < PrivateData->ListIndex) {
       CopyMem ((UINT8 *)NewVariableData + Offset, ListWalker, ListWalker->SignatureListSize);
       Offset += ListWalker->SignatureListSize;
 
@@ -3805,7 +3805,7 @@ LoadSignatureList (
 
   RemainingSize = DataSize;
   ListWalker    = (EFI_SIGNATURE_LIST *)VariableData;
-  while ((RemainingSize > 0) && (RemainingSize >= ListWalker->SignatureListSize)) {
+  while ((RemainingSize > 0) && (RemainingSize >= (UINTN)ListWalker->SignatureListSize)) {
     if (CompareGuid (&ListWalker->SignatureType, &gEfiCertRsa2048Guid)) {
       ListType = STRING_TOKEN (STR_LIST_TYPE_RSA2048_SHA256);
     } else if (CompareGuid (&ListWalker->SignatureType, &gEfiCertX509Guid)) {
@@ -4221,7 +4221,7 @@ LoadSignatureData (
   VOID                *EndOpCodeHandle;
   UINTN               DataSize;
   UINTN               RemainingSize;
-  UINT16              Index;
+  UINT64              Index;
   UINT8               *VariableData;
   CHAR16              VariableName[BUFFER_MAX_SIZE];
   CHAR16              NameBuffer[BUFFER_MAX_SIZE];
@@ -4305,7 +4305,7 @@ LoadSignatureData (
   //
   // Skip signature list.
   //
-  while ((RemainingSize > 0) && (RemainingSize >= ListWalker->SignatureListSize) && ListIndex-- > 0) {
+  while ((RemainingSize > 0) && (RemainingSize >= (UINTN)ListWalker->SignatureListSize) && ListIndex-- > 0) {
     RemainingSize -= ListWalker->SignatureListSize;
     ListWalker     = (EFI_SIGNATURE_LIST *)((UINT8 *)ListWalker + ListWalker->SignatureListSize);
   }


### PR DESCRIPTION
# Description

Throughout SecurityPkg there are issues where variables aren't correctly validated before the code uses them.  This PR fixes three main forms of this issue throughout the package:

1.  _NULL pointers:_   Typically in edk2 we assert if a pointer is NULL.  The issue with this approach is that asserts can be suppressed and ignored by a platform.  These have been changed to now include returning a failure status code if applicable and to free memory that was allocated.
2.  _Fixing Types:_   For some comparisons the two variables are types of different width which can cause an error.  They have been updated to be the same.
3.  _Checking return statuses:_    Some variables are assigned values by a function call but the return status for these functions are never checked.  Now we check the return status to make sure the variable has a valid value.

<_For each item, place an "x" in between `[` and `]` if true. Example: `[x]` (you can also check items in GitHub UI)_>

<_Create the PR as a Draft PR if it is only created to run CI checks._>

<_Delete lines in \<\> tags before creating the PR._>

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Tested on Intel hardware and with CI.

## Integration Instructions

N/A
