### PR TITLE
MdePkg/IndustryStandard: add definitions for CXL CEDT

### DIFF
--- a/MdePkg/Include/IndustryStandard/Cxl20.h
+++ b/MdePkg/Include/IndustryStandard/Cxl20.h
@@ -14,6 +14,7 @@
 #define CXL20_H_
 
 #include <IndustryStandard/Cxl11.h>
+#include <IndustryStandard/Acpi.h>
 
 //
 // CXL DVSEC IDs
@@ -101,6 +102,15 @@
 #define CXL_MEM_DEVICE_MEDIA_STATUS_READY      0x1
 #define CXL_MEM_DEVICE_MEDIA_STATUS_ERROR      0x2
 #define CXL_MEM_DEVICE_MEDIA_STATUS_DISABLED   0x3
+
+///
+/// "CEDT" CXL Early Discovery Table
+///
+#define CXL_EARLY_DISCOVERY_TABLE_SIGNATURE  SIGNATURE_32 ('C', 'E', 'D', 'T')
+
+#define CXL_EARLY_DISCOVERY_TABLE_REVISION_01  0x1
+
+#define CEDT_TYPE_CHBS     0x0
 
 //
 // Ensure proper structure formats
@@ -457,6 +467,34 @@ typedef union {
   } Bits;
   UINT64    Uint64;
 } CXL_MEMORY_DEVICE_STATUS_REGISTER;
+
+///
+/// CEDT header
+///
+typedef struct {
+  EFI_ACPI_DESCRIPTION_HEADER    Header;
+} CXL_EARLY_DISCOVERY_TABLE;
+
+///
+/// Node header definition shared by all CEDT structure types
+///
+typedef struct {
+  UINT8     Type;
+  UINT8     Reserved;
+  UINT16    Length;
+} CEDT_STRUCTURE;
+
+///
+/// Definition for CXL Host Bridge Structure (CHBS)
+///
+typedef struct {
+  CEDT_STRUCTURE                   Header;
+  UINT32                           UID;
+  UINT32                           CXLVersion;
+  UINT32                           Reserved;
+  UINT64                           Base;
+  UINT64                           Length;
+} CXL_HOST_BRIDGE_STRUCTURE;
 
 #pragma pack()
 

--- a/MdePkg/Include/IndustryStandard/Cxl30.h
+++ b/MdePkg/Include/IndustryStandard/Cxl30.h
@@ -45,6 +45,13 @@
 #define CXL_HDM_6_WAY_INTERLEAVING   0x9
 #define CXL_HDM_12_WAY_INTERLEAVING  0xA
 
+///
+/// "CEDT" CXL Early Discovery Table
+///
+#define CEDT_TYPE_CFMWS    0x1
+#define CEDT_TYPE_CXIMS    0x2
+#define CEDT_TYPE_RDPAS    0x3
+
 //
 // Ensure proper structure formats
 //
@@ -310,6 +317,45 @@ typedef struct {
   CXL_3_0_CXL_TIMEOUT_AND_ISOLATION_CONTROL       TimeoutAndIsolationControl;
   CXL_3_0_CXL_TIMEOUT_AND_ISOLATION_STATUS        TimeoutAndIsolationStatus;
 } CXL_3_0_CXL_TIMEOUT_AND_ISOLATION_CAPABILITY_STRUCTURE;
+
+///
+/// Definition for CXL Fixed Memory Window Structure (CFMWS)
+///
+typedef struct {
+  CEDT_STRUCTURE                       Header;
+  UINT32                               Reserved;
+  UINT64                               BaseHPA;
+  UINT64                               WindowSize;
+  UINT8                                InterleaveMembers;
+  UINT8                                InterleaveArithmetic;
+  UINT16                               Reserved1;
+  UINT32                               Granularity;
+  UINT16                               Restrictions;
+  UINT16                               QtgId;
+  UINT32                               TargetList[16];
+} CXL_FIXED_MEMORY_WINDOW_STRUCTURE;
+
+///
+/// Definition for CXL XOR Interleave Math Structure (CXIMS)
+///
+typedef struct {
+  CEDT_STRUCTURE                       Header;
+  UINT16                               Reserved;
+  UINT8                                HBIG;
+  UINT8                                NIB;
+  UINT64                               XORMAPLIST[4];
+} CXL_XOR_INTERLEAVE_MATH_STRUCTURE;
+
+///
+/// Definition for RCEC Downstream Port Association Structure (RDPAS)
+///
+typedef struct {
+  CEDT_STRUCTURE                       Header;
+  UINT16                               SegmentNumber;
+  UINT16                               BDF;
+  UINT8                                ProtocolType;
+  UINT64                               BaseAddress;
+} RCEC_DOWNSTREAM_PORT_ASSOCIATION_STRUCTURE;
 
 #pragma pack()
 

--- a/MdePkg/Include/IndustryStandard/Cxl31.h
+++ b/MdePkg/Include/IndustryStandard/Cxl31.h
@@ -1,0 +1,45 @@
+/** @file
+  CXL 3.1 definitions
+
+  This file contains the register definitions and firmware interface based
+  on the Compute Express Link (CXL) Specification Revision 3.1.
+
+  Copyright (c) 2024, Phytium Technology Co Ltd. All rights reserved.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+  @par Reference(s):
+  - Compute Express Link (CXL) Specification Revision 3.1.
+    (https://computeexpresslink.org/cxl-specification/)
+
+**/
+
+#ifndef CXL31_H_
+#define CXL31_H_
+
+#include <IndustryStandard/Cxl30.h>
+
+///
+/// "CEDT" CXL Early Discovery Table
+///
+#define CXL_EARLY_DISCOVERY_TABLE_REVISION_02  0x2
+
+#define CEDT_TYPE_CSDS     0x4
+
+//
+// Ensure proper structure formats
+//
+#pragma pack(1)
+
+///
+/// Definition for CXL System Description Structure (CSDS)
+///
+typedef struct {
+  CEDT_STRUCTURE                       Header;
+  UINT16                               Capabilities;
+  UINT16                               Reserved;
+} CXL_DOWNSTREAM_PORT_ASSOCIATION_STRUCTURE;
+
+#pragma pack()
+
+#endif


### PR DESCRIPTION
# Description

This adds #defines and struct typedefs for the various structure types in the CXL3.1 CXL Early Discovery Table (CEDT).

## How This Was Tested

Include this header file for platform CEDT creation.

