### PR TITLE
CryptoPkg: Increase ScratchMemory buffer for openssl 3.0.15

### DIFF
--- a/CryptoPkg/Library/BaseCryptLib/SysCall/RuntimeMemAllocation.c
+++ b/CryptoPkg/Library/BaseCryptLib/SysCall/RuntimeMemAllocation.c
@@ -33,7 +33,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #define RT_PAGE_FREE  0x00000000
 #define RT_PAGE_USED  0x00000001
 
-#define MIN_REQUIRED_BLOCKS  600
+#define MIN_REQUIRED_BLOCKS  1100
 
 //
 // Memory Page Table


### PR DESCRIPTION
# Description
Openssl 3.0.15 has a larger memory footprint.

Updating from EDK 2022.2 (openssl 1.1.j) to 2024.2 (openssl 3.0.15) causes our EFI provisioning application[1] to fail due to an out of memory condition.

On inspection, at the time of that fault, 2022.2 had an additional 900 pages. This is why this patch proposes the increase of the ScratchMemory buffer by that same ammount.

[1] https://git.kernel.org/pub/scm/linux/kernel/git/jejb/efitools.git

- [x] Impacts security?
  - **Security**  Since this addresses OpenSSL errors that would be caused due to running out of memory, it has security implications.

## How This Was Tested

 https://git.kernel.org/pub/scm/linux/kernel/git/jejb/efitools.git
  0) Build efitools and generate LockDown.efi
  1) Using OVMF
       Execute LockDown.efi from a systemd-boot menu
  Without the fix, authenticating the proposed PK before attempting to set it will fail with a Security Violation error (-26)

## Integration Instructions
N/A
