### PR TITLE
ArmPkg/GenericWatchdogDxe: Removed fixed PCDs

### DIFF
--- a/ArmPkg/Drivers/GenericWatchdogDxe/GenericWatchdogDxe.c
+++ b/ArmPkg/Drivers/GenericWatchdogDxe/GenericWatchdogDxe.c
@@ -375,7 +375,7 @@ GenericWatchdogEntry (
   // Install interrupt handler
   Status = mInterruptProtocol->RegisterInterruptSource (
                                  mInterruptProtocol,
-                                 FixedPcdGet32 (PcdGenericWatchdogEl2IntrNum),
+                                 PcdGet32 (PcdGenericWatchdogEl2IntrNum),
                                  WatchdogInterruptHandler
                                  );
   if (EFI_ERROR (Status)) {
@@ -384,7 +384,7 @@ GenericWatchdogEntry (
 
   Status = mInterruptProtocol->SetTriggerType (
                                  mInterruptProtocol,
-                                 FixedPcdGet32 (PcdGenericWatchdogEl2IntrNum),
+                                 PcdGet32 (PcdGenericWatchdogEl2IntrNum),
                                  EFI_HARDWARE_INTERRUPT2_TRIGGER_EDGE_RISING
                                  );
   if (EFI_ERROR (Status)) {
@@ -421,7 +421,7 @@ UnregisterHandler:
   // Unregister the handler
   mInterruptProtocol->RegisterInterruptSource (
                         mInterruptProtocol,
-                        FixedPcdGet32 (PcdGenericWatchdogEl2IntrNum),
+                        PcdGet32 (PcdGenericWatchdogEl2IntrNum),
                         NULL
                         );
   return Status;


### PR DESCRIPTION
 Removed the "fixed" attribute for the PCD PcdGenericWatchdogEl2IntrNum.
 This enables platforms to modify it dynamically.

# Description

This change is made to enable the platform code to modify the PcdGenericWatchdogEl2IntrNum dynamically.

<_For each item, place an "x" in between `[` and `]` if true. Example: `[x]` (you can also check items in GitHub UI)_>

<_Create the PR as a Draft PR if it is only created to run CI checks._>

<_Delete lines in \<\> tags before creating the PR._>

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Verified the build with this change

## Integration Instructions

N/A
