### PR TITLE
MdePkg/SmmPciExpressLib: Ensure gBS variable for the constructor

### DIFF
--- a/MdePkg/Library/SmmPciExpressLib/SmmPciExpressLib.inf
+++ b/MdePkg/Library/SmmPciExpressLib/SmmPciExpressLib.inf
@@ -32,6 +32,7 @@
  PcdLib
  DebugLib
  IoLib
+ UefiBootServicesTableLib
 
 [Pcd]
  gEfiMdePkgTokenSpaceGuid.PcdPciExpressBaseAddress ## CONSUMES


### PR DESCRIPTION
The PCD token, PcdPciExpressBaseAddress is referred in the constructor. If the token is defined as PcdsDynamic type, the PCD function that gets the token value uses the gBS service to locate PCD protocol internally. In this case, it is possible for the function to be called before initializing gBS variable, then cause a system hang due to gBS variable. Need to ensure the availability of gBS variable.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

It was verified on an AMD WS platform that supports multiple PCI segments based on the PCD configuration.

This is an example for an AMD SMM driver, based on edk2-edk2-stable202408.

**CASE 1 (Issue) : AutoGen.c without the update :**
ProcessLibraryConstructorList 
{
  EFI_STATUS  Status;

  Status = BaseDebugLibSerialPortConstructor ();
  ASSERT_RETURN_ERROR (Status);

  Status = SmmPciExpressLibConstructor (ImageHandle, SystemTable);
  ASSERT_EFI_ERROR (Status);

  Status = UefiBootServicesTableLibConstructor (ImageHandle, SystemTable);
  ASSERT_EFI_ERROR (Status);

  Status = SmmServicesTableLibConstructor (ImageHandle, SystemTable);
  ASSERT_EFI_ERROR (Status);

  Status = SmmMemoryAllocationLibConstructor (ImageHandle, SystemTable);
  ASSERT_EFI_ERROR (Status);

  Status = UefiRuntimeServicesTableLibConstructor (ImageHandle, SystemTable);
  ASSERT_EFI_ERROR (Status);

  Status = UefiLibConstructor (ImageHandle, SystemTable);
  ASSERT_EFI_ERROR (Status);
  ...
}

**CASE 2 (Expected) : AutoGen.c with the update :**
ProcessLibraryConstructorList 
{
  EFI_STATUS  Status;

  Status = BaseDebugLibSerialPortConstructor ();
  ASSERT_RETURN_ERROR (Status);

  Status = UefiBootServicesTableLibConstructor (ImageHandle, SystemTable);
  ASSERT_EFI_ERROR (Status);
  
  Status = SmmPciExpressLibConstructor (ImageHandle, SystemTable);
  ASSERT_EFI_ERROR (Status);
  
  Status = SmmServicesTableLibConstructor (ImageHandle, SystemTable);
  ASSERT_EFI_ERROR (Status);

  Status = SmmMemoryAllocationLibConstructor (ImageHandle, SystemTable);
  ASSERT_EFI_ERROR (Status);

  Status = UefiRuntimeServicesTableLibConstructor (ImageHandle, SystemTable);
  ASSERT_EFI_ERROR (Status);

  Status = UefiLibConstructor (ImageHandle, SystemTable);
  ASSERT_EFI_ERROR (Status);
  ...
}

## Integration Instructions

N/A
