### PR TITLE
MdeModulePkg HobPrintLib: Add Guid to Guids section.

### DIFF
--- a/MdeModulePkg/Library/HobPrintLib/HobPrintLib.inf
+++ b/MdeModulePkg/Library/HobPrintLib/HobPrintLib.inf
@@ -32,3 +32,4 @@
   gEfiHobMemoryAllocBspStoreGuid
   gEfiHobMemoryAllocStackGuid
   gEfiMemoryTypeInformationGuid
+  gEfiHobMemoryAllocModuleGuid


### PR DESCRIPTION

# Description
gEfiHobMemoryAllocModuleGuid is referenced in the HobPrintLib, but it is not defined in the INF file, causing an unresolved external error when the module is consumed by code.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested
Modified module to consume this library, experienced build error.
Corrected INF, module compiled correctly.


## Integration Instructions
N/A