### PR TITLE
Unit test framework pkg enable sanitize

### DIFF
--- a/BaseTools/Conf/Empty_C_File_Host_Application_Build.c
+++ b/BaseTools/Conf/Empty_C_File_Host_Application_Build.c
@@ -1,0 +1,7 @@
+/** @file
+  This is an empty C source file used in VS20xx HOST_APPLICATION
+  builds.
+
+  Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/

--- a/BaseTools/Conf/build_rule.template
+++ b/BaseTools/Conf/build_rule.template
@@ -322,7 +322,7 @@
         "$(OBJCOPY)" $(OBJCOPY_FLAGS) ${dst}
 
 
-[Static-Library-File.USER_DEFINED, Static-Library-File.HOST_APPLICATION]
+[Static-Library-File.USER_DEFINED]
     <InputFile>
         *.lib
 
@@ -334,6 +334,30 @@
 
     <Command.MSFT, Command.INTEL, Command.CLANGPDB>
         "$(DLINK)" $(DLINK_FLAGS) $(DLINK_SPATH) @$(STATIC_LIBRARY_FILES_LIST)
+
+    <Command.GCC>
+        "$(DLINK)" $(DLINK_FLAGS) -Wl,--start-group,@$(STATIC_LIBRARY_FILES_LIST),--end-group $(DLINK2_FLAGS)
+
+    <Command.XCODE>
+        "$(DLINK)" -o ${dst} $(DLINK_FLAGS)  $(DLINK_SPATH) -filelist $(STATIC_LIBRARY_FILES_LIST)  $(DLINK2_FLAGS)
+
+[Static-Library-File.HOST_APPLICATION]
+    <InputFile>
+        *.lib
+
+    <ExtraDependency>
+        $(MAKE_FILE)
+
+    <OutputFile>
+        $(DEBUG_DIR)(+)$(MODULE_NAME)
+
+    <Command.MSFT, Command.INTEL>
+        "$(CC)" /Fo$(OUTPUT_DIR)/Empty_C_File_Host_Application_Build.obj $(CC_FLAGS) $(INC) $(EDK_TOOLS_PATH)/Conf/Empty_C_File_Host_Application_Build.c
+        "$(DLINK)" $(DLINK_FLAGS) $(DLINK_SPATH) $(OUTPUT_DIR)/Empty_C_File_Host_Application_Build.obj @$(STATIC_LIBRARY_FILES_LIST)
+
+    <Command.CLANGPDB>
+        "$(CC)" -o $(OUTPUT_DIR)/Empty_C_File_Host_Application_Build.obj $(CC_FLAGS) $(INC) $(EDK_TOOLS_PATH)/Conf/Empty_C_File_Host_Application_Build.c
+        "$(DLINK)" $(DLINK_FLAGS) $(DLINK_SPATH) $(OUTPUT_DIR)/Empty_C_File_Host_Application_Build.obj @$(STATIC_LIBRARY_FILES_LIST)
 
     <Command.GCC>
         "$(DLINK)" $(DLINK_FLAGS) -Wl,--start-group,@$(STATIC_LIBRARY_FILES_LIST),--end-group $(DLINK2_FLAGS)

--- a/BaseTools/Plugin/HostBasedUnitTestRunner/HostBasedUnitTestRunner.py
+++ b/BaseTools/Plugin/HostBasedUnitTestRunner/HostBasedUnitTestRunner.py
@@ -52,6 +52,12 @@ class HostBasedUnitTestRunner(IUefiBuildPlugin):
 
         failure_count = 0
 
+        # Do not catch exceptions in gtest so they are handled by address sanitizer
+        shell_env.set_shell_var('GTEST_CATCH_EXCEPTIONS', '0')
+
+        # Disable address sanitizer memory leak detection
+        shell_env.set_shell_var('ASAN_OPTIONS', 'detect_leaks=0')
+
         # Set up the reporting type for Cmocka.
         shell_env.set_shell_var('CMOCKA_MESSAGE_OUTPUT', 'xml')
 

--- a/UnitTestFrameworkPkg/Include/Library/HostMemoryAllocationBelowAddressLib.h
+++ b/UnitTestFrameworkPkg/Include/Library/HostMemoryAllocationBelowAddressLib.h
@@ -1,0 +1,90 @@
+/** @file
+  HostMemoryAllocationBelowAddressLib class
+
+  Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef HOST_MEMORY_ALLOCATION_BELOW_ADDRESS_LIB_H_
+
+/**
+  Allocate memory below a specifies address.
+
+  @param[in] MaximumAddress  The address below which the memory allocation must
+                             be performed.
+  @param[in] Length          The size, in bytes, of the memory allocation.
+
+  @retval  !NULL  Pointer to the allocated memory.
+  @retval  NULL   The memory allocation failed.
+**/
+VOID *
+EFIAPI
+HostAllocatePoolBelowAddress (
+  IN UINT64  MaximumAddress,
+  IN UINT64  Length
+  );
+
+/**
+  Free memory allocated with AllocateMemoryHostAllocatePoolBelowAddress().
+
+  @param[in] Address  Pointer to buffer previously allocated with
+                      HostAllocatePoolBelowAddress().
+**/
+VOID
+EFIAPI
+HostFreePoolBelowAddress (
+  IN VOID  *Address
+  );
+
+/**
+  Allocates one or more 4KB pages below a specified address at a specified
+  alignment.
+
+  Allocates the number of 4KB pages specified by Pages below MaximumAddress with
+  an alignment specified by Alignment. The allocated buffer is returned.  If
+  Pages is 0, then NULL is returned.  If there is not enough memory below the
+  requested address at the specified alignment remaining to satisfy the request,
+  then NULL is returned.
+
+  If Alignment is not a power of two and Alignment is not zero, then ASSERT().
+  If Pages plus EFI_SIZE_TO_PAGES (Alignment) overflows, then ASSERT().
+
+  @param[in] MaximumAddress  The address below which the memory allocation must
+  @param[in] Pages           The number of 4 KB pages to allocate.
+  @param[in] Alignment       The requested alignment of the allocation. Must be
+                             a power of two. If Alignment is zero, then byte
+                             alignment is used.
+
+  @return  A pointer to the allocated buffer or NULL if allocation fails.
+**/
+VOID *
+EFIAPI
+HostAllocateAlignedPagesBelowAddress (
+  IN UINT64  MaximumAddress,
+  IN UINTN   Pages,
+  IN UINT64  Alignment
+  );
+
+/**
+  Frees one or more 4KB pages that were previously allocated with
+  HostAllocateAlignedPagesBelowAddress().
+
+  Frees the number of 4KB pages specified by Pages from the buffer specified by
+  Buffer. Buffer must have been allocated with HostAllocateAlignedPagesBelowAddress().
+  If it is not possible to free allocated pages, then this function will perform
+  no actions.
+
+  If Buffer was not allocated with HostAllocateAlignedPagesBelowAddress(), then
+  ASSERT(). If Pages is zero, then ASSERT().
+
+  @param[in] Buffer  The pointer to the buffer of pages to free.
+  @param[in] Pages   The number of 4 KB pages to free.
+**/
+VOID
+EFIAPI
+HostFreeAlignedPagesBelowAddress (
+  IN VOID   *Buffer,
+  IN UINTN  Pages
+  );
+
+#endif

--- a/UnitTestFrameworkPkg/Library/GoogleTestLib/GoogleTestLib.inf
+++ b/UnitTestFrameworkPkg/Library/GoogleTestLib/GoogleTestLib.inf
@@ -28,6 +28,6 @@
   UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
 
 [BuildOptions]
-  MSFT:*_*_*_CC_FLAGS   == /c /EHs /Zi /Od /MT
+  MSFT:*_*_*_CC_FLAGS   == /c /EHs /Zi /Od /MTd
   GCC:*_*_IA32_CC_FLAGS == -g -c -fshort-wchar -fexceptions -O0 -m32 -malign-double -fno-pie
   GCC:*_*_X64_CC_FLAGS  == -g -c -fshort-wchar -fexceptions -O0 -m64 -fno-pie "-DEFIAPI=__attribute__((ms_abi))"

--- a/UnitTestFrameworkPkg/Library/Posix/MemoryAllocationLibPosix/AllocateBelowAddress.c
+++ b/UnitTestFrameworkPkg/Library/Posix/MemoryAllocationLibPosix/AllocateBelowAddress.c
@@ -1,0 +1,438 @@
+/** @file
+  Instance of Memory Below Address Allocation Library based on Windows APIs
+  and Linux APIs.
+
+  Uses Windows APIs VirtualAlloc() and VirtualFree() to allocate and free memory
+  below a specified virtual address.
+
+  Uses Linux APIs mmap() and munmap() to allocate and free memory below a
+  specified virtual address.
+
+  Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#if defined (_WIN32) || defined (_WIN64)
+  #include "WinInclude.h"
+#elif defined (__linux__)
+  #include <sys/mman.h>
+  #include <unistd.h>
+  #include <errno.h>
+  #include <string.h>
+#else
+  #error Unsupported target
+#endif
+
+#include <Library/HostMemoryAllocationBelowAddressLib.h>
+#include <Library/DebugLib.h>
+
+///
+/// Signature for PAGE_HEAD_BELOW_ADDRESS structure
+/// Used to verify that buffer being freed was allocated by this library.
+///
+#define PAGE_HEAD_BELOW_ADDRESS_PRIVATE_SIGNATURE  SIGNATURE_64 ('P', 'A', 'H', 'B', 'e', 'l', 'A', 'd')
+
+///
+/// Structure placed immediately before an aligned allocation to store the
+/// information required to free the entire allocated buffer.
+///
+typedef struct {
+  UINT64    Signature;
+  VOID      *AllocatedBuffer;
+  UINTN     TotalPages;
+  VOID      *AlignedBuffer;
+  UINTN     AlignedPages;
+} PAGE_HEAD_BELOW_ADDRESS;
+
+///
+/// Signature for POOL_HEAD_BELOW_ADDRESS structure
+/// Used to verify that buffer being freed was allocated by this library.
+///
+#define POOL_HEAD_BELOW_ADDRESS_PRIVATE_SIGNATURE  SIGNATURE_64 ('P', 'O', 'H', 'B', 'e', 'l', 'A', 'd')
+
+///
+/// Structure placed immediately before an pool allocation to store the
+/// information required to free the entire allocated buffer.
+///
+typedef struct {
+  UINT64    Signature;
+  UINT64    TotalSize;
+} POOL_HEAD_BELOW_ADDRESS;
+
+//
+// Lowest address that can be allocated by this library
+//
+#define MINIMUM_ALLOCATION_ADDRESS  BASE_64KB
+
+//
+// The page size of the host
+//
+static UINTN  mPageSize = 0;
+
+/**
+  Use system services to get the host page size.
+
+  @return  Host page size in bytes.
+**/
+static
+UINTN
+HostGetPageSize (
+  VOID
+  )
+{
+ #if defined (_WIN32) || defined (_WIN64)
+  SYSTEM_INFO  SystemInfo;
+
+  GetSystemInfo (&SystemInfo);
+  return (UINTN)SystemInfo.dwPageSize;
+ #elif defined (__linux__)
+  return sysconf (_SC_PAGESIZE);
+ #else
+  return 0;
+ #endif
+}
+
+/**
+  Use system services to allocate a buffer between a minimum and maximum
+  address aligned to the requested page size.
+
+  @param[in] MaximumAddress  The address below which the memory allocation must
+                             be performed.
+  @param[in] Length          The size, in bytes, of the memory allocation.
+
+  @retval  !NULL  Pointer to the allocated memory.
+  @retval  NULL   The memory allocation failed.
+**/
+static
+VOID *
+HostAllocateBufferInRange (
+  UINTN  MaximumAddress,
+  UINTN  Length
+  )
+{
+  UINTN  Address;
+  VOID   *AllocatedAddress;
+
+  if (mPageSize == 0) {
+    mPageSize = HostGetPageSize ();
+    if (mPageSize == 0) {
+      return NULL;
+    }
+  }
+
+  //
+  // Round maximum address down to the nearest page boundary
+  //
+  MaximumAddress &= ~(mPageSize - 1);
+
+  for (Address = MaximumAddress; Address >= MINIMUM_ALLOCATION_ADDRESS; Address -= mPageSize) {
+ #if defined (_WIN32) || defined (_WIN64)
+    AllocatedAddress = VirtualAlloc (
+                         (VOID *)Address,
+                         Length,
+                         MEM_RESERVE | MEM_COMMIT,
+                         PAGE_READWRITE
+                         );
+    if (AllocatedAddress != NULL) {
+      return AllocatedAddress;
+    }
+
+ #elif defined (__linux__)
+    AllocatedAddress = mmap (
+                         (VOID *)Address,
+                         Length,
+                         PROT_READ | PROT_WRITE,
+                         MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED_NOREPLACE,
+                         -1,
+                         0
+                         );
+    if (AllocatedAddress != MAP_FAILED) {
+      return AllocatedAddress;
+    }
+
+ #else
+    return NULL;
+ #endif
+  }
+
+  return NULL;
+}
+
+/**
+  Use system services to free memory allocated with HostAllocateBufferInRange().
+
+  @param[in] Buffer  Pointer to buffer previously allocated with
+                     HostAllocateBufferInRange().
+  @param[in] Length  Length, in bytes, of buffer previously allocated with
+                     HostAllocateBufferInRange().
+**/
+static
+VOID
+HostFreeBufferInRange (
+  IN VOID   *Buffer,
+  IN UINTN  Length
+  )
+{
+ #if defined (_WIN32) || defined (_WIN64)
+  if (!VirtualFree (Buffer, 0, MEM_RELEASE)) {
+    ASSERT (FALSE);
+  }
+
+ #elif defined (__linux__)
+  if (munmap (Buffer, Length) == -1) {
+    ASSERT (FALSE);
+  }
+
+ #endif
+}
+
+/**
+  Allocate memory below a specific address.
+
+  @param[in] MaximumAddress  The address below which the memory allocation must
+                             be performed.
+  @param[in] Length          The size, in bytes, of the memory allocation.
+
+  @retval  !NULL  Pointer to the allocated memory.
+  @retval  NULL   The memory allocation failed.
+**/
+VOID *
+EFIAPI
+HostAllocatePoolBelowAddress (
+  IN UINT64  MaximumAddress,
+  IN UINT64  Length
+  )
+{
+  VOID                     *AllocatedAddress;
+  POOL_HEAD_BELOW_ADDRESS  *PoolHead;
+
+  if (Length == 0) {
+    return NULL;
+  }
+
+  //
+  // Limit maximum address to the largest supported virtual address
+  //
+  MaximumAddress = MIN (MaximumAddress, MAX_UINTN);
+
+  //
+  // Increase requested allocation length by the size of the pool header
+  //
+  Length += sizeof (POOL_HEAD_BELOW_ADDRESS);
+
+  //
+  // Make sure allocation length is smaller than maximum address
+  //
+  if (Length > MaximumAddress) {
+    DEBUG ((DEBUG_ERROR, "HostAllocatePoolBelowAddress: Length > MaximumAddress\n"));
+    return NULL;
+  }
+
+  //
+  // Reduce maximum address by the requested allocation length
+  //
+  MaximumAddress -= Length;
+
+  AllocatedAddress = HostAllocateBufferInRange (
+                       (UINTN)MaximumAddress,
+                       (UINTN)Length
+                       );
+  if (AllocatedAddress == NULL) {
+    DEBUG ((DEBUG_ERROR, "HostAllocatePoolBelowAddress: HostAllocateBufferInRange failed\n"));
+    return NULL;
+  }
+
+  DEBUG_CLEAR_MEMORY (AllocatedAddress, (UINTN)Length);
+  PoolHead            = (POOL_HEAD_BELOW_ADDRESS *)AllocatedAddress;
+  PoolHead->Signature = POOL_HEAD_BELOW_ADDRESS_PRIVATE_SIGNATURE;
+  PoolHead->TotalSize = Length;
+  return (VOID *)(PoolHead + 1);
+}
+
+/**
+  Free memory allocated with HostAllocatePoolBelowAddress().
+
+  @param[in] Buffer  Pointer to buffer previously allocated with
+                     HostAllocatePoolBelowAddress().
+**/
+VOID
+EFIAPI
+HostFreePoolBelowAddress (
+  IN VOID  *Buffer
+  )
+{
+  POOL_HEAD_BELOW_ADDRESS  *PoolHead;
+  UINTN                    Length;
+
+  ASSERT (Buffer != NULL);
+
+  PoolHead = ((POOL_HEAD_BELOW_ADDRESS *)Buffer) - 1;
+
+  ASSERT (PoolHead != NULL);
+  ASSERT (PoolHead->Signature == POOL_HEAD_BELOW_ADDRESS_PRIVATE_SIGNATURE);
+  ASSERT (PoolHead->TotalSize >= sizeof (POOL_HEAD_BELOW_ADDRESS));
+  ASSERT (PoolHead->TotalSize <= MAX_UINTN);
+
+  Length = (UINTN)PoolHead->TotalSize;
+  DEBUG_CLEAR_MEMORY (PoolHead, Length);
+
+  HostFreeBufferInRange (PoolHead, Length);
+}
+
+/**
+  Allocates one or more 4KB pages below a specified address at a specified
+  alignment.
+
+  Allocates the number of 4KB pages specified by Pages below MaximumAddress with
+  an alignment specified by Alignment. The allocated buffer is returned.  If
+  Pages is 0, then NULL is returned.  If there is not enough memory below the
+  requested address at the specified alignment remaining to satisfy the request,
+  then NULL is returned.
+
+  If Alignment is not a power of two and Alignment is not zero, then ASSERT().
+  If Pages plus EFI_SIZE_TO_PAGES (Alignment) overflows, then ASSERT().
+
+  @param[in] MaximumAddress  The address below which the memory allocation must
+  @param[in] Pages           The number of 4 KB pages to allocate.
+  @param[in] Alignment       The requested alignment of the allocation. Must be
+                             a power of two. If Alignment is zero, then byte
+                             alignment is used.
+
+  @return  A pointer to the allocated buffer or NULL if allocation fails.
+**/
+VOID *
+EFIAPI
+HostAllocateAlignedPagesBelowAddress (
+  IN UINT64  MaximumAddress,
+  IN UINTN   Pages,
+  IN UINT64  Alignment
+  )
+{
+  PAGE_HEAD_BELOW_ADDRESS  PageHead;
+  PAGE_HEAD_BELOW_ADDRESS  *PageHeadPtr;
+  UINTN                    AlignmentMask;
+  UINTN                    Length;
+
+  if (Pages == 0) {
+    return NULL;
+  }
+
+  //
+  // Make sure alignment is a power of two
+  //
+  if ((Alignment & (Alignment - 1)) != 0) {
+    DEBUG ((DEBUG_ERROR, "HostAllocateAlignedPagesBelowAddress: Alignment is not a power of two\n"));
+    return NULL;
+  }
+
+  //
+  // Make sure alignment is smaller than the largest supported virtual address
+  //
+  if (Alignment > MAX_UINTN) {
+    DEBUG ((DEBUG_ERROR, "HostAllocateAlignedPagesBelowAddress: Alignment > MAX_UINTN\n"));
+    return NULL;
+  }
+
+  //
+  // Make sure alignment is at least 4KB
+  //
+  Alignment = MAX (Alignment, SIZE_4KB);
+
+  //
+  // Initialize local page head structure
+  //
+  PageHead.Signature    = PAGE_HEAD_BELOW_ADDRESS_PRIVATE_SIGNATURE;
+  PageHead.AlignedPages = Pages;
+  PageHead.TotalPages   = Pages + 2 * EFI_SIZE_TO_PAGES ((UINTN)Alignment);
+
+  //
+  // Limit maximum address to the largest supported virtual address
+  //
+  MaximumAddress = MIN (MaximumAddress, MAX_UINTN);
+
+  //
+  // Make sure total page allocation fits below maximum address
+  //
+  if (PageHead.TotalPages >= EFI_SIZE_TO_PAGES (MaximumAddress)) {
+    DEBUG ((DEBUG_ERROR, "HostAllocateAlignedPagesBelowAddress: TotalPages >= MaximumAddress\n"));
+    return NULL;
+  }
+
+  //
+  // Determine the length of the allocation in bytes
+  //
+  Length = EFI_PAGES_TO_SIZE (PageHead.TotalPages);
+
+  //
+  // Reduce maximum address by the total allocation length
+  //
+  MaximumAddress -= Length;
+
+  //
+  // Allocate buffer large enough to support aligned page request
+  //
+  PageHead.AllocatedBuffer = HostAllocateBufferInRange (
+                               (UINTN)MaximumAddress,
+                               Length
+                               );
+  if (PageHead.AllocatedBuffer == NULL) {
+    DEBUG ((DEBUG_ERROR, "HostAllocateAlignedPagesBelowAddress: HostAllocateBufferInRange failed\n"));
+    return NULL;
+  }
+
+  DEBUG_CLEAR_MEMORY (PageHead.AllocatedBuffer, Length);
+
+  AlignmentMask          = ((UINTN)Alignment - 1);
+  PageHead.AlignedBuffer = (VOID *)(((UINTN)PageHead.AllocatedBuffer + AlignmentMask) & ~AlignmentMask);
+  if ((UINTN)PageHead.AlignedBuffer - (UINTN)PageHead.AllocatedBuffer < sizeof (PAGE_HEAD_BELOW_ADDRESS)) {
+    PageHead.AlignedBuffer = (VOID *)((UINTN)PageHead.AlignedBuffer + (UINTN)Alignment);
+  }
+
+  PageHeadPtr = (PAGE_HEAD_BELOW_ADDRESS *)((UINTN)PageHead.AlignedBuffer) - 1;
+  memcpy (PageHeadPtr, &PageHead, sizeof (PageHead));
+
+  return PageHead.AlignedBuffer;
+}
+
+/**
+  Frees one or more 4KB pages that were previously allocated with
+  HostAllocateAlignedPagesBelowAddress().
+
+  Frees the number of 4KB pages specified by Pages from the buffer specified by
+  Buffer. Buffer must have been allocated with HostAllocateAlignedPagesBelowAddress().
+  If it is not possible to free allocated pages, then this function will perform
+  no actions.
+
+  If Buffer was not allocated with HostAllocateAlignedPagesBelowAddress(), then
+  ASSERT(). If Pages is zero, then ASSERT().
+
+  @param[in] Buffer  The pointer to the buffer of pages to free.
+  @param[in] Pages   The number of 4 KB pages to free.
+**/
+VOID
+EFIAPI
+HostFreeAlignedPagesBelowAddress (
+  IN VOID   *Buffer,
+  IN UINTN  Pages
+  )
+{
+  PAGE_HEAD_BELOW_ADDRESS  *PageHeadPtr;
+  VOID                     *AllocatedBuffer;
+  UINTN                    Length;
+
+  ASSERT (Buffer != NULL);
+
+  PageHeadPtr = ((PAGE_HEAD_BELOW_ADDRESS *)Buffer) - 1;
+
+  ASSERT (PageHeadPtr != NULL);
+  ASSERT (PageHeadPtr->Signature == PAGE_HEAD_BELOW_ADDRESS_PRIVATE_SIGNATURE);
+  ASSERT (PageHeadPtr->AlignedPages == Pages);
+  ASSERT (PageHeadPtr->AllocatedBuffer != NULL);
+
+  AllocatedBuffer = PageHeadPtr->AllocatedBuffer;
+  Length          = EFI_PAGES_TO_SIZE (PageHeadPtr->TotalPages);
+
+  DEBUG_CLEAR_MEMORY (AllocatedBuffer, Length);
+
+  HostFreeBufferInRange (AllocatedBuffer, Length);
+}

--- a/UnitTestFrameworkPkg/Library/Posix/MemoryAllocationLibPosix/MemoryAllocationLibPosix.c
+++ b/UnitTestFrameworkPkg/Library/Posix/MemoryAllocationLibPosix/MemoryAllocationLibPosix.c
@@ -27,11 +27,18 @@
 ///
 typedef struct {
   UINT32    Signature;
-  VOID      *AllocatedBufffer;
+  VOID      *AllocatedBuffer;
   UINTN     TotalPages;
   VOID      *AlignedBuffer;
   UINTN     AlignedPages;
 } PAGE_HEAD;
+
+#define POOL_HEAD_PRIVATE_SIGNATURE  SIGNATURE_32 ('P', 'O', 'H', 'D')
+
+typedef struct {
+  UINT32    Signature;
+  UINT32    TotalSize;
+} POOL_HEAD;
 
 /**
   Allocates one or more 4KB pages of type EfiBootServicesData.
@@ -165,16 +172,17 @@ AllocateAlignedPages (
   //
   // We need reserve Alignment pages for PAGE_HEAD, as meta data.
   //
-  PageHead.Signature        = PAGE_HEAD_PRIVATE_SIGNATURE;
-  PageHead.TotalPages       = Pages + EFI_SIZE_TO_PAGES (Alignment) * 2;
-  PageHead.AlignedPages     = Pages;
-  PageHead.AllocatedBufffer = malloc (EFI_PAGES_TO_SIZE (PageHead.TotalPages));
-  if (PageHead.AllocatedBufffer == NULL) {
-    return NULL;
-  }
+  PageHead.Signature       = PAGE_HEAD_PRIVATE_SIGNATURE;
+  PageHead.TotalPages      = Pages + EFI_SIZE_TO_PAGES (Alignment) * 2;
+  PageHead.AlignedPages    = Pages;
+  PageHead.AllocatedBuffer = malloc (EFI_PAGES_TO_SIZE (PageHead.TotalPages));
 
-  PageHead.AlignedBuffer = (VOID *)(((UINTN)PageHead.AllocatedBufffer + AlignmentMask) & ~AlignmentMask);
-  if ((UINTN)PageHead.AlignedBuffer - (UINTN)PageHead.AllocatedBufffer < sizeof (PAGE_HEAD)) {
+  ASSERT (PageHead.AllocatedBuffer != NULL);
+
+  DEBUG_CLEAR_MEMORY (PageHead.AllocatedBuffer, EFI_PAGES_TO_SIZE (PageHead.TotalPages));
+
+  PageHead.AlignedBuffer = (VOID *)(((UINTN)PageHead.AllocatedBuffer + AlignmentMask) & ~AlignmentMask);
+  if ((UINTN)PageHead.AlignedBuffer - (UINTN)PageHead.AllocatedBuffer < sizeof (PAGE_HEAD)) {
     PageHead.AlignedBuffer = (VOID *)((UINTN)PageHead.AlignedBuffer + Alignment);
   }
 
@@ -265,21 +273,24 @@ FreeAlignedPages (
   )
 {
   PAGE_HEAD  *PageHeadPtr;
+  VOID       *AllocatedBuffer;
+  UINTN      Length;
 
-  //
-  // NOTE: Partial free is not supported. Just keep it.
-  //
-  PageHeadPtr = (VOID *)((UINTN)Buffer - sizeof (PAGE_HEAD));
-  if (PageHeadPtr->Signature != PAGE_HEAD_PRIVATE_SIGNATURE) {
-    return;
-  }
+  ASSERT (Buffer != NULL);
 
-  if (PageHeadPtr->AlignedPages != Pages) {
-    return;
-  }
+  PageHeadPtr = ((PAGE_HEAD *)Buffer) - 1;
 
-  PageHeadPtr->Signature = 0;
-  free (PageHeadPtr->AllocatedBufffer);
+  ASSERT (PageHeadPtr != NULL);
+  ASSERT (PageHeadPtr->Signature == PAGE_HEAD_PRIVATE_SIGNATURE);
+  ASSERT (PageHeadPtr->AlignedPages == Pages);
+  ASSERT (PageHeadPtr->AllocatedBuffer != NULL);
+
+  AllocatedBuffer = PageHeadPtr->AllocatedBuffer;
+  Length          = EFI_PAGES_TO_SIZE (PageHeadPtr->TotalPages);
+
+  DEBUG_CLEAR_MEMORY (AllocatedBuffer, Length);
+
+  free (AllocatedBuffer);
 }
 
 /**
@@ -293,13 +304,27 @@ FreeAlignedPages (
 
   @return  A pointer to the allocated buffer or NULL if allocation fails.
 
-**/VOID *
+**/
+VOID *
 EFIAPI
 AllocatePool (
   IN UINTN  AllocationSize
   )
 {
-  return malloc (AllocationSize);
+  POOL_HEAD  *PoolHead;
+  UINTN      TotalSize;
+
+  TotalSize = sizeof (POOL_HEAD) + AllocationSize;
+  PoolHead  = malloc (TotalSize);
+  if (PoolHead == NULL) {
+    return NULL;
+  }
+
+  DEBUG_CLEAR_MEMORY (PoolHead, TotalSize);
+  PoolHead->Signature = POOL_HEAD_PRIVATE_SIGNATURE;
+  PoolHead->TotalSize = (UINT32)TotalSize;
+
+  return (VOID *)(PoolHead + 1);
 }
 
 /**
@@ -365,7 +390,7 @@ AllocateZeroPool (
 {
   VOID  *Buffer;
 
-  Buffer = malloc (AllocationSize);
+  Buffer = AllocatePool (AllocationSize);
   if (Buffer == NULL) {
     return NULL;
   }
@@ -444,7 +469,7 @@ AllocateCopyPool (
 {
   VOID  *Memory;
 
-  Memory = malloc (AllocationSize);
+  Memory = AllocatePool (AllocationSize);
   if (Memory == NULL) {
     return NULL;
   }
@@ -538,7 +563,7 @@ ReallocatePool (
 {
   VOID  *NewBuffer;
 
-  NewBuffer = malloc (NewSize);
+  NewBuffer = AllocatePool (NewSize);
   if ((NewBuffer != NULL) && (OldBuffer != NULL)) {
     memcpy (NewBuffer, OldBuffer, MIN (OldSize, NewSize));
   }
@@ -634,5 +659,16 @@ FreePool (
   IN VOID  *Buffer
   )
 {
-  free (Buffer);
+  POOL_HEAD  *PoolHead;
+
+  ASSERT (Buffer != NULL);
+
+  PoolHead = ((POOL_HEAD *)Buffer) - 1;
+
+  ASSERT (PoolHead != NULL);
+  ASSERT (PoolHead->Signature == POOL_HEAD_PRIVATE_SIGNATURE);
+  ASSERT (PoolHead->TotalSize >= sizeof (POOL_HEAD));
+
+  DEBUG_CLEAR_MEMORY (PoolHead, PoolHead->TotalSize);
+  free (PoolHead);
 }

--- a/UnitTestFrameworkPkg/Library/Posix/MemoryAllocationLibPosix/MemoryAllocationLibPosix.inf
+++ b/UnitTestFrameworkPkg/Library/Posix/MemoryAllocationLibPosix/MemoryAllocationLibPosix.inf
@@ -16,12 +16,16 @@
   MODULE_TYPE     = UEFI_DRIVER
   VERSION_STRING  = 1.0
   LIBRARY_CLASS   = MemoryAllocationLib|HOST_APPLICATION
+  LIBRARY_CLASS   = HostMemoryAllocationBelowAddressLib|HOST_APPLICATION
 
 [Sources]
   MemoryAllocationLibPosix.c
+  AllocateBelowAddress.c
+  WinInclude.h
 
 [Packages]
   MdePkg/MdePkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
 
 [LibraryClasses]
-  BaseLib
+  DebugLib

--- a/UnitTestFrameworkPkg/Library/Posix/MemoryAllocationLibPosix/WinInclude.h
+++ b/UnitTestFrameworkPkg/Library/Posix/MemoryAllocationLibPosix/WinInclude.h
@@ -1,0 +1,28 @@
+/** @file
+  Include windows.h addressing conflicts with forced include of Base.h
+
+  Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef WIN_INCLUDE_H_
+#define WIN_INCLUDE_H_
+
+#define GUID         _WINNT_DUP_GUID_____
+#define _LIST_ENTRY  _WINNT_DUP_LIST_ENTRY_FORWARD
+#define LIST_ENTRY   _WINNT_DUP_LIST_ENTRY
+#undef  VOID
+
+#pragma warning (push)
+#pragma warning (disable : 4668)
+
+#include <windows.h>
+
+#pragma warning (pop)
+
+#undef GUID
+#undef _LIST_ENTRY
+#undef LIST_ENTRY
+#define VOID  void
+
+#endif

--- a/UnitTestFrameworkPkg/Library/UnitTestDebugAssertLib/UnitTestDebugAssertLibHost.inf
+++ b/UnitTestFrameworkPkg/Library/UnitTestDebugAssertLib/UnitTestDebugAssertLibHost.inf
@@ -31,6 +31,6 @@
   UnitTestLib
 
 [BuildOptions]
-  MSFT:*_*_*_CC_FLAGS   == /c /EHs /Zi /Od /MT
+  MSFT:*_*_*_CC_FLAGS   == /c /EHs /Zi /Od /MTd
   GCC:*_*_IA32_CC_FLAGS == -g -c -fshort-wchar -fexceptions -O0 -m32 -malign-double -fno-pie
   GCC:*_*_X64_CC_FLAGS  == -g -c -fshort-wchar -fexceptions -O0 -m64 -fno-pie "-DEFIAPI=__attribute__((ms_abi))"

--- a/UnitTestFrameworkPkg/Library/UnitTestLib/AssertCmocka.c
+++ b/UnitTestFrameworkPkg/Library/UnitTestLib/AssertCmocka.c
@@ -381,21 +381,27 @@ UnitTestExpectAssertFailure (
   }
 
   if (UnitTestStatus == UNIT_TEST_PASSED) {
-    UT_LOG_INFO (
-      "[ASSERT PASS] %a:%d: UT_EXPECT_ASSERT_FAILURE(%a) detected expected assert\n",
+    snprintf (
+      TempStr,
+      sizeof (TempStr),
+      "[ASSERT PASS] %s:%d: UT_EXPECT_ASSERT_FAILURE(%s) detected expected assert\n",
       FileName,
-      LineNumber,
+      (int)LineNumber,
       FunctionCall
       );
+    UT_LOG_INFO (TempStr);
   }
 
   if (UnitTestStatus == UNIT_TEST_SKIPPED) {
-    UT_LOG_WARNING (
-      "[ASSERT WARN] %a:%d: UT_EXPECT_ASSERT_FAILURE(%a) disabled\n",
+    snprintf (
+      TempStr,
+      sizeof (TempStr),
+      "[ASSERT WARN] %s:%d: UT_EXPECT_ASSERT_FAILURE(%s) disabled\n",
       FileName,
-      LineNumber,
+      (int)LineNumber,
       FunctionCall
       );
+    UT_LOG_WARNING (TempStr);
   }
 
   if (UnitTestStatus == UNIT_TEST_ERROR_TEST_FAILED) {

--- a/UnitTestFrameworkPkg/Library/UnitTestLib/RunTestsCmocka.c
+++ b/UnitTestFrameworkPkg/Library/UnitTestLib/RunTestsCmocka.c
@@ -111,10 +111,14 @@ CmockaUnitTestTeardownFunctionRunner (
   // stdout and stderr in their xml format
   //
   if (UnitTest->Log != NULL) {
-    print_message ("UnitTest: %s - %s\n", UnitTest->Name, UnitTest->Description);
-    print_message ("Log Output Start\n");
-    print_message ("%s", UnitTest->Log);
-    print_message ("Log Output End\n");
+    //
+    // UnitTest->Log can be a large buffer that is larger than what DEBUG()
+    // can support. Use printf() directly.
+    //
+    printf ("UnitTest: %s - %s\n", UnitTest->Name, UnitTest->Description);
+    printf ("Log Output Start\n");
+    printf (UnitTest->Log);
+    printf ("Log Output End\n");
   }
 
   //

--- a/UnitTestFrameworkPkg/Library/UnitTestLib/UnitTestLib.c
+++ b/UnitTestFrameworkPkg/Library/UnitTestLib/UnitTestLib.c
@@ -131,6 +131,59 @@ CompareFingerprints (
   return (CompareMem (FingerprintA, FingerprintB, UNIT_TEST_FINGERPRINT_SIZE) == 0);
 }
 
+STATIC
+VOID
+FreeUnitTestTestEntry (
+  IN UNIT_TEST_LIST_ENTRY  *TestEntry
+  )
+{
+  if (TestEntry) {
+    if (TestEntry->UT.Description) {
+      FreePool (TestEntry->UT.Description);
+    }
+
+    if (TestEntry->UT.Name) {
+      FreePool (TestEntry->UT.Name);
+    }
+
+    FreePool (TestEntry);
+  }
+}
+
+STATIC
+EFI_STATUS
+FreeUnitTestSuiteEntry (
+  IN UNIT_TEST_SUITE_LIST_ENTRY  *SuiteEntry
+  )
+{
+  UNIT_TEST_LIST_ENTRY  *TestCase;
+  UNIT_TEST_LIST_ENTRY  *NextTestCase;
+  LIST_ENTRY            *TestCaseList;
+
+  if (SuiteEntry) {
+    TestCaseList = &(SuiteEntry->UTS.TestCaseList);
+    TestCase     = (UNIT_TEST_LIST_ENTRY *)GetFirstNode (TestCaseList);
+    while (&TestCase->Entry != TestCaseList) {
+      NextTestCase = (UNIT_TEST_LIST_ENTRY *)GetNextNode (TestCaseList, &TestCase->Entry);
+      RemoveEntryList (&TestCase->Entry);
+      FreeUnitTestTestEntry (TestCase);
+      TestCase = NextTestCase;
+    }
+
+    if (SuiteEntry->UTS.Title) {
+      FreePool (SuiteEntry->UTS.Title);
+    }
+
+    if (SuiteEntry->UTS.Name) {
+      FreePool (SuiteEntry->UTS.Name);
+    }
+
+    FreePool (SuiteEntry);
+  }
+
+  return EFI_SUCCESS;
+}
+
 /**
   Cleanup a test framework.
 
@@ -151,27 +204,35 @@ FreeUnitTestFramework (
   IN UNIT_TEST_FRAMEWORK_HANDLE  FrameworkHandle
   )
 {
-  // TODO: Finish this function.
-  return EFI_SUCCESS;
-}
+  UNIT_TEST_FRAMEWORK         *Framework;
+  UNIT_TEST_SUITE_LIST_ENTRY  *Suite;
+  UNIT_TEST_SUITE_LIST_ENTRY  *NextSuite;
 
-STATIC
-EFI_STATUS
-FreeUnitTestSuiteEntry (
-  IN UNIT_TEST_SUITE_LIST_ENTRY  *SuiteEntry
-  )
-{
-  // TODO: Finish this function.
-  return EFI_SUCCESS;
-}
+  Framework = (UNIT_TEST_FRAMEWORK *)FrameworkHandle;
+  if (Framework) {
+    Suite = (UNIT_TEST_SUITE_LIST_ENTRY *)GetFirstNode (&Framework->TestSuiteList);
+    while ((LIST_ENTRY *)Suite != &Framework->TestSuiteList) {
+      NextSuite = (UNIT_TEST_SUITE_LIST_ENTRY *)GetNextNode (&Framework->TestSuiteList, (LIST_ENTRY *)Suite);
+      RemoveEntryList ((LIST_ENTRY *)Suite);
+      FreeUnitTestSuiteEntry (Suite);
+      Suite = NextSuite;
+    }
 
-STATIC
-EFI_STATUS
-FreeUnitTestTestEntry (
-  IN UNIT_TEST_LIST_ENTRY  *TestEntry
-  )
-{
-  // TODO: Finish this function.
+    if (Framework->Title) {
+      FreePool (Framework->Title);
+    }
+
+    if (Framework->ShortTitle) {
+      FreePool (Framework->ShortTitle);
+    }
+
+    if (Framework->VersionString) {
+      FreePool (Framework->VersionString);
+    }
+
+    FreePool (Framework);
+  }
+
   return EFI_SUCCESS;
 }
 

--- a/UnitTestFrameworkPkg/Test/UnitTest/Sample/SampleUnitTestBufferOverflow/SampleUnitTestBufferOverflow.c
+++ b/UnitTestFrameworkPkg/Test/UnitTest/Sample/SampleUnitTestBufferOverflow/SampleUnitTestBufferOverflow.c
@@ -1,0 +1,117 @@
+/** @file
+  Sample UnitTest built for execution on a Host machine.
+  This test case generates a buffer overflow that is caught by a sanitizer.
+
+  Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+#include <PiPei.h>
+#include <Uefi.h>
+#include <Library/UefiLib.h>
+#include <Library/DebugLib.h>
+#include <Library/UnitTestLib.h>
+#include <Library/PrintLib.h>
+#include <Library/MemoryAllocationLib.h>
+
+#define UNIT_TEST_NAME     "Sample Unit Test Sanitize Buffer Overflow"
+#define UNIT_TEST_VERSION  "0.1"
+
+/**
+  Sample unit test the performs a buffer overflow
+
+  @param[in]  Context    [Optional] An optional parameter that enables:
+                         1) test-case reuse with varied parameters and
+                         2) test-case re-entry for Target tests that need a
+                         reboot.  This parameter is a VOID* and it is the
+                         responsibility of the test author to ensure that the
+                         contents are well understood by all test cases that may
+                         consume it.
+
+  @retval  UNIT_TEST_PASSED             The Unit test has completed and the test
+                                        case was successful.
+  @retval  UNIT_TEST_ERROR_TEST_FAILED  A test case assertion has failed.
+**/
+UNIT_TEST_STATUS
+EFIAPI
+SanitizeBufferOverflow (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  UINT8  *Pointer;
+
+  Pointer = (UINT8 *)AllocatePool (100);
+  UT_ASSERT_NOT_NULL (Pointer);
+  Pointer[110] = 0;
+  FreePool (Pointer);
+
+  return UNIT_TEST_PASSED;
+}
+
+/**
+  Initialize the unit test framework, suite, and unit tests for the
+  sample unit tests and run the unit tests.
+
+  @retval  EFI_SUCCESS           All test cases were dispatched.
+  @retval  EFI_OUT_OF_RESOURCES  There are not enough resources available to
+                                 initialize the unit tests.
+**/
+EFI_STATUS
+EFIAPI
+UefiTestMain (
+  VOID
+  )
+{
+  EFI_STATUS                  Status;
+  UNIT_TEST_FRAMEWORK_HANDLE  Framework;
+  UNIT_TEST_SUITE_HANDLE      SanitizeTests;
+
+  Framework = NULL;
+
+  DEBUG ((DEBUG_INFO, "%a v%a\n", UNIT_TEST_NAME, UNIT_TEST_VERSION));
+
+  //
+  // Start setting up the test framework for running the tests.
+  //
+  Status = InitUnitTestFramework (&Framework, UNIT_TEST_NAME, gEfiCallerBaseName, UNIT_TEST_VERSION);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "Failed in InitUnitTestFramework. Status = %r\n", Status));
+    goto EXIT;
+  }
+
+  //
+  // Populate the Macro Tests with ASSERT() enabled
+  //
+  Status = CreateUnitTestSuite (&SanitizeTests, Framework, "Sanitize tests", "Sanitize tests", NULL, NULL);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "Failed in CreateUnitTestSuite for SanitizeTests\n"));
+    Status = EFI_OUT_OF_RESOURCES;
+    goto EXIT;
+  }
+
+  AddTestCase (SanitizeTests, "Sanitize Buffer Overflow", "SanitizeBufferOverflow", SanitizeBufferOverflow, NULL, NULL, NULL);
+
+  //
+  // Execute the tests.
+  //
+  Status = RunAllTestSuites (Framework);
+
+EXIT:
+  if (Framework) {
+    FreeUnitTestFramework (Framework);
+  }
+
+  return Status;
+}
+
+/**
+  Standard POSIX C entry point for host based unit test execution.
+**/
+int
+main (
+  int   argc,
+  char  *argv[]
+  )
+{
+  return UefiTestMain ();
+}

--- a/UnitTestFrameworkPkg/Test/UnitTest/Sample/SampleUnitTestBufferOverflow/SampleUnitTestBufferOverflow.inf
+++ b/UnitTestFrameworkPkg/Test/UnitTest/Sample/SampleUnitTestBufferOverflow/SampleUnitTestBufferOverflow.inf
@@ -1,0 +1,32 @@
+## @file
+# Sample UnitTest built for execution on a Host machine.
+# This test case generates a buffer overflow that is caught by a sanitizer.
+#
+# Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION    = 0x00010005
+  BASE_NAME      = SampleUnitTestBufferOverflow
+  FILE_GUID      = 3772390C-CF33-4826-BB2F-A279C1AC12E0
+  MODULE_TYPE    = HOST_APPLICATION
+  VERSION_STRING = 1.0
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  SampleUnitTestBufferOverflow.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+
+[LibraryClasses]
+  BaseLib
+  DebugLib
+  UnitTestLib
+  MemoryAllocationLib

--- a/UnitTestFrameworkPkg/Test/UnitTest/Sample/SampleUnitTestBufferUnderflow/SampleUnitTestBufferUnderflow.c
+++ b/UnitTestFrameworkPkg/Test/UnitTest/Sample/SampleUnitTestBufferUnderflow/SampleUnitTestBufferUnderflow.c
@@ -1,0 +1,117 @@
+/** @file
+  Sample UnitTest built for execution on a Host machine.
+  This test case generates a buffer underflow that is caught by a sanitizer.
+
+  Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+#include <PiPei.h>
+#include <Uefi.h>
+#include <Library/UefiLib.h>
+#include <Library/DebugLib.h>
+#include <Library/UnitTestLib.h>
+#include <Library/PrintLib.h>
+#include <Library/MemoryAllocationLib.h>
+
+#define UNIT_TEST_NAME     "Sample Unit Test Sanitize Buffer Underflow"
+#define UNIT_TEST_VERSION  "0.1"
+
+/**
+  Sample unit test the performs a buffer underflow
+
+  @param[in]  Context    [Optional] An optional parameter that enables:
+                         1) test-case reuse with varied parameters and
+                         2) test-case re-entry for Target tests that need a
+                         reboot.  This parameter is a VOID* and it is the
+                         responsibility of the test author to ensure that the
+                         contents are well understood by all test cases that may
+                         consume it.
+
+  @retval  UNIT_TEST_PASSED             The Unit test has completed and the test
+                                        case was successful.
+  @retval  UNIT_TEST_ERROR_TEST_FAILED  A test case assertion has failed.
+**/
+UNIT_TEST_STATUS
+EFIAPI
+SanitizeBufferUnderflow (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  UINT8  *Pointer;
+
+  Pointer = (UINT8 *)AllocatePool (100);
+  UT_ASSERT_NOT_NULL (Pointer);
+  Pointer[-10] = 0;
+  FreePool (Pointer);
+
+  return UNIT_TEST_PASSED;
+}
+
+/**
+  Initialize the unit test framework, suite, and unit tests for the
+  sample unit tests and run the unit tests.
+
+  @retval  EFI_SUCCESS           All test cases were dispatched.
+  @retval  EFI_OUT_OF_RESOURCES  There are not enough resources available to
+                                 initialize the unit tests.
+**/
+EFI_STATUS
+EFIAPI
+UefiTestMain (
+  VOID
+  )
+{
+  EFI_STATUS                  Status;
+  UNIT_TEST_FRAMEWORK_HANDLE  Framework;
+  UNIT_TEST_SUITE_HANDLE      SanitizeTests;
+
+  Framework = NULL;
+
+  DEBUG ((DEBUG_INFO, "%a v%a\n", UNIT_TEST_NAME, UNIT_TEST_VERSION));
+
+  //
+  // Start setting up the test framework for running the tests.
+  //
+  Status = InitUnitTestFramework (&Framework, UNIT_TEST_NAME, gEfiCallerBaseName, UNIT_TEST_VERSION);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "Failed in InitUnitTestFramework. Status = %r\n", Status));
+    goto EXIT;
+  }
+
+  //
+  // Populate the Macro Tests with ASSERT() enabled
+  //
+  Status = CreateUnitTestSuite (&SanitizeTests, Framework, "Sanitize tests", "Sanitize tests", NULL, NULL);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "Failed in CreateUnitTestSuite for SanitizeTests\n"));
+    Status = EFI_OUT_OF_RESOURCES;
+    goto EXIT;
+  }
+
+  AddTestCase (SanitizeTests, "Sanitize Buffer Underflow", "SanitizeBufferUnderflow", SanitizeBufferUnderflow, NULL, NULL, NULL);
+
+  //
+  // Execute the tests.
+  //
+  Status = RunAllTestSuites (Framework);
+
+EXIT:
+  if (Framework) {
+    FreeUnitTestFramework (Framework);
+  }
+
+  return Status;
+}
+
+/**
+  Standard POSIX C entry point for host based unit test execution.
+**/
+int
+main (
+  int   argc,
+  char  *argv[]
+  )
+{
+  return UefiTestMain ();
+}

--- a/UnitTestFrameworkPkg/Test/UnitTest/Sample/SampleUnitTestBufferUnderflow/SampleUnitTestBufferUnderflow.inf
+++ b/UnitTestFrameworkPkg/Test/UnitTest/Sample/SampleUnitTestBufferUnderflow/SampleUnitTestBufferUnderflow.inf
@@ -1,0 +1,32 @@
+## @file
+# Sample UnitTest built for execution on a Host machine.
+# This test case generates a buffer underflow that is caught by a sanitizer.
+#
+# Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION    = 0x00010005
+  BASE_NAME      = SampleUnitTestBufferUnderflow
+  FILE_GUID      = ECA331D2-D794-4798-B145-770A570F3309
+  MODULE_TYPE    = HOST_APPLICATION
+  VERSION_STRING = 1.0
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  SampleUnitTestBufferUnderflow.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+
+[LibraryClasses]
+  BaseLib
+  DebugLib
+  UnitTestLib
+  MemoryAllocationLib

--- a/UnitTestFrameworkPkg/Test/UnitTest/Sample/SampleUnitTestDoubleFree/SampleUnitTestDoubleFree.c
+++ b/UnitTestFrameworkPkg/Test/UnitTest/Sample/SampleUnitTestDoubleFree/SampleUnitTestDoubleFree.c
@@ -1,0 +1,117 @@
+/** @file
+  Sample UnitTest built for execution on a Host machine.
+  This test case generates a double free that is caught by a sanitizer.
+
+  Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+#include <PiPei.h>
+#include <Uefi.h>
+#include <Library/UefiLib.h>
+#include <Library/DebugLib.h>
+#include <Library/UnitTestLib.h>
+#include <Library/PrintLib.h>
+#include <Library/MemoryAllocationLib.h>
+
+#define UNIT_TEST_NAME     "Sample Unit Test Sanitize Double Free"
+#define UNIT_TEST_VERSION  "0.1"
+
+/**
+  Sample unit test the performs a double free
+
+  @param[in]  Context    [Optional] An optional parameter that enables:
+                         1) test-case reuse with varied parameters and
+                         2) test-case re-entry for Target tests that need a
+                         reboot.  This parameter is a VOID* and it is the
+                         responsibility of the test author to ensure that the
+                         contents are well understood by all test cases that may
+                         consume it.
+
+  @retval  UNIT_TEST_PASSED             The Unit test has completed and the test
+                                        case was successful.
+  @retval  UNIT_TEST_ERROR_TEST_FAILED  A test case assertion has failed.
+**/
+UNIT_TEST_STATUS
+EFIAPI
+SanitizeDoubleFree (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  UINT8  *Pointer;
+
+  Pointer = (UINT8 *)AllocatePool (100);
+  UT_ASSERT_NOT_NULL (Pointer);
+  FreePool (Pointer);
+  FreePool (Pointer);
+
+  return UNIT_TEST_PASSED;
+}
+
+/**
+  Initialize the unit test framework, suite, and unit tests for the
+  sample unit tests and run the unit tests.
+
+  @retval  EFI_SUCCESS           All test cases were dispatched.
+  @retval  EFI_OUT_OF_RESOURCES  There are not enough resources available to
+                                 initialize the unit tests.
+**/
+EFI_STATUS
+EFIAPI
+UefiTestMain (
+  VOID
+  )
+{
+  EFI_STATUS                  Status;
+  UNIT_TEST_FRAMEWORK_HANDLE  Framework;
+  UNIT_TEST_SUITE_HANDLE      SanitizeTests;
+
+  Framework = NULL;
+
+  DEBUG ((DEBUG_INFO, "%a v%a\n", UNIT_TEST_NAME, UNIT_TEST_VERSION));
+
+  //
+  // Start setting up the test framework for running the tests.
+  //
+  Status = InitUnitTestFramework (&Framework, UNIT_TEST_NAME, gEfiCallerBaseName, UNIT_TEST_VERSION);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "Failed in InitUnitTestFramework. Status = %r\n", Status));
+    goto EXIT;
+  }
+
+  //
+  // Populate the Macro Tests with ASSERT() enabled
+  //
+  Status = CreateUnitTestSuite (&SanitizeTests, Framework, "Sanitize tests", "Sanitize tests", NULL, NULL);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "Failed in CreateUnitTestSuite for SanitizeTests\n"));
+    Status = EFI_OUT_OF_RESOURCES;
+    goto EXIT;
+  }
+
+  AddTestCase (SanitizeTests, "Sanitize Double Free", "SanitizeDoubleFree", SanitizeDoubleFree, NULL, NULL, NULL);
+
+  //
+  // Execute the tests.
+  //
+  Status = RunAllTestSuites (Framework);
+
+EXIT:
+  if (Framework) {
+    FreeUnitTestFramework (Framework);
+  }
+
+  return Status;
+}
+
+/**
+  Standard POSIX C entry point for host based unit test execution.
+**/
+int
+main (
+  int   argc,
+  char  *argv[]
+  )
+{
+  return UefiTestMain ();
+}

--- a/UnitTestFrameworkPkg/Test/UnitTest/Sample/SampleUnitTestDoubleFree/SampleUnitTestDoubleFree.inf
+++ b/UnitTestFrameworkPkg/Test/UnitTest/Sample/SampleUnitTestDoubleFree/SampleUnitTestDoubleFree.inf
@@ -1,0 +1,32 @@
+## @file
+# Sample UnitTest built for execution on a Host machine.
+# This test case generates a double free that is caught by a sanitizer.
+#
+# Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION    = 0x00010005
+  BASE_NAME      = SampleUnitTestDoubleFree
+  FILE_GUID      = B40BBE1C-90AB-4DE9-9B49-E734666FF9A7
+  MODULE_TYPE    = HOST_APPLICATION
+  VERSION_STRING = 1.0
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  SampleUnitTestDoubleFree.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+
+[LibraryClasses]
+  BaseLib
+  DebugLib
+  UnitTestLib
+  MemoryAllocationLib

--- a/UnitTestFrameworkPkg/Test/UnitTest/Sample/SampleUnitTestInvalidAddress/SampleUnitTestInvalidAddress.c
+++ b/UnitTestFrameworkPkg/Test/UnitTest/Sample/SampleUnitTestInvalidAddress/SampleUnitTestInvalidAddress.c
@@ -1,0 +1,110 @@
+/** @file
+  Sample UnitTest built for execution on a Host machine.
+  This test case accesses an invalid address that is caught by a sanitizer.
+
+  Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+#include <PiPei.h>
+#include <Uefi.h>
+#include <Library/UefiLib.h>
+#include <Library/DebugLib.h>
+#include <Library/UnitTestLib.h>
+#include <Library/PrintLib.h>
+
+#define UNIT_TEST_NAME     "Sample Unit Test Sanitize Invalid Address"
+#define UNIT_TEST_VERSION  "0.1"
+
+/**
+  Sample unit test that accesses an invalid address
+
+  @param[in]  Context    [Optional] An optional parameter that enables:
+                         1) test-case reuse with varied parameters and
+                         2) test-case re-entry for Target tests that need a
+                         reboot.  This parameter is a VOID* and it is the
+                         responsibility of the test author to ensure that the
+                         contents are well understood by all test cases that may
+                         consume it.
+
+  @retval  UNIT_TEST_PASSED             The Unit test has completed and the test
+                                        case was successful.
+  @retval  UNIT_TEST_ERROR_TEST_FAILED  A test case assertion has failed.
+**/
+UNIT_TEST_STATUS
+EFIAPI
+SanitizeInvalidAddress (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  *(volatile UINT8 *)(-1) = 0;
+  return UNIT_TEST_PASSED;
+}
+
+/**
+  Initialize the unit test framework, suite, and unit tests for the
+  sample unit tests and run the unit tests.
+
+  @retval  EFI_SUCCESS           All test cases were dispatched.
+  @retval  EFI_OUT_OF_RESOURCES  There are not enough resources available to
+                                 initialize the unit tests.
+**/
+EFI_STATUS
+EFIAPI
+UefiTestMain (
+  VOID
+  )
+{
+  EFI_STATUS                  Status;
+  UNIT_TEST_FRAMEWORK_HANDLE  Framework;
+  UNIT_TEST_SUITE_HANDLE      SanitizeTests;
+
+  Framework = NULL;
+
+  DEBUG ((DEBUG_INFO, "%a v%a\n", UNIT_TEST_NAME, UNIT_TEST_VERSION));
+
+  //
+  // Start setting up the test framework for running the tests.
+  //
+  Status = InitUnitTestFramework (&Framework, UNIT_TEST_NAME, gEfiCallerBaseName, UNIT_TEST_VERSION);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "Failed in InitUnitTestFramework. Status = %r\n", Status));
+    goto EXIT;
+  }
+
+  //
+  // Populate the Macro Tests with ASSERT() enabled
+  //
+  Status = CreateUnitTestSuite (&SanitizeTests, Framework, "Sanitize tests", "Sanitize tests", NULL, NULL);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "Failed in CreateUnitTestSuite for SanitizeTests\n"));
+    Status = EFI_OUT_OF_RESOURCES;
+    goto EXIT;
+  }
+
+  AddTestCase (SanitizeTests, "Sanitize Invalid Address", "SanitizeInvalidAddress", SanitizeInvalidAddress, NULL, NULL, NULL);
+
+  //
+  // Execute the tests.
+  //
+  Status = RunAllTestSuites (Framework);
+
+EXIT:
+  if (Framework) {
+    FreeUnitTestFramework (Framework);
+  }
+
+  return Status;
+}
+
+/**
+  Standard POSIX C entry point for host based unit test execution.
+**/
+int
+main (
+  int   argc,
+  char  *argv[]
+  )
+{
+  return UefiTestMain ();
+}

--- a/UnitTestFrameworkPkg/Test/UnitTest/Sample/SampleUnitTestInvalidAddress/SampleUnitTestInvalidAddress.inf
+++ b/UnitTestFrameworkPkg/Test/UnitTest/Sample/SampleUnitTestInvalidAddress/SampleUnitTestInvalidAddress.inf
@@ -1,0 +1,31 @@
+## @file
+# Sample UnitTest built for execution on a Host machine.
+# This test case accesses an invalid address that is caught by a sanitizer.
+#
+# Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION    = 0x00010005
+  BASE_NAME      = SampleUnitTestInvalidAddress
+  FILE_GUID      = 60CED393-1342-45E9-9D8B-589F02255674
+  MODULE_TYPE    = HOST_APPLICATION
+  VERSION_STRING = 1.0
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  SampleUnitTestInvalidAddress.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+
+[LibraryClasses]
+  BaseLib
+  DebugLib
+  UnitTestLib

--- a/UnitTestFrameworkPkg/Test/UnitTest/Sample/SampleUnitTestNullAddress/SampleUnitTestNullAddress.c
+++ b/UnitTestFrameworkPkg/Test/UnitTest/Sample/SampleUnitTestNullAddress/SampleUnitTestNullAddress.c
@@ -1,0 +1,110 @@
+/** @file
+  Sample UnitTest built for execution on a Host machine.
+  This test case dereferences a NULL pointer that is caught by a sanitizer.
+
+  Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+#include <PiPei.h>
+#include <Uefi.h>
+#include <Library/UefiLib.h>
+#include <Library/DebugLib.h>
+#include <Library/UnitTestLib.h>
+#include <Library/PrintLib.h>
+
+#define UNIT_TEST_NAME     "Sample Unit Test Sanitize NULL Pointer"
+#define UNIT_TEST_VERSION  "0.1"
+
+/**
+  Sample unit test that dereferences a NULL pointer.
+
+  @param[in]  Context    [Optional] An optional parameter that enables:
+                         1) test-case reuse with varied parameters and
+                         2) test-case re-entry for Target tests that need a
+                         reboot.  This parameter is a VOID* and it is the
+                         responsibility of the test author to ensure that the
+                         contents are well understood by all test cases that may
+                         consume it.
+
+  @retval  UNIT_TEST_PASSED             The Unit test has completed and the test
+                                        case was successful.
+  @retval  UNIT_TEST_ERROR_TEST_FAILED  A test case assertion has failed.
+**/
+UNIT_TEST_STATUS
+EFIAPI
+SanitizeNullAddress (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  *(volatile UINT8 *)(NULL) = 0;
+  return UNIT_TEST_PASSED;
+}
+
+/**
+  Initialize the unit test framework, suite, and unit tests for the
+  sample unit tests and run the unit tests.
+
+  @retval  EFI_SUCCESS           All test cases were dispatched.
+  @retval  EFI_OUT_OF_RESOURCES  There are not enough resources available to
+                                 initialize the unit tests.
+**/
+EFI_STATUS
+EFIAPI
+UefiTestMain (
+  VOID
+  )
+{
+  EFI_STATUS                  Status;
+  UNIT_TEST_FRAMEWORK_HANDLE  Framework;
+  UNIT_TEST_SUITE_HANDLE      SanitizeTests;
+
+  Framework = NULL;
+
+  DEBUG ((DEBUG_INFO, "%a v%a\n", UNIT_TEST_NAME, UNIT_TEST_VERSION));
+
+  //
+  // Start setting up the test framework for running the tests.
+  //
+  Status = InitUnitTestFramework (&Framework, UNIT_TEST_NAME, gEfiCallerBaseName, UNIT_TEST_VERSION);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "Failed in InitUnitTestFramework. Status = %r\n", Status));
+    goto EXIT;
+  }
+
+  //
+  // Populate the Macro Tests with ASSERT() enabled
+  //
+  Status = CreateUnitTestSuite (&SanitizeTests, Framework, "Sanitize tests", "Sanitize tests", NULL, NULL);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "Failed in CreateUnitTestSuite for SanitizeTests\n"));
+    Status = EFI_OUT_OF_RESOURCES;
+    goto EXIT;
+  }
+
+  AddTestCase (SanitizeTests, "Sanitize NULL Address", "SanitizeNullAddress", SanitizeNullAddress, NULL, NULL, NULL);
+
+  //
+  // Execute the tests.
+  //
+  Status = RunAllTestSuites (Framework);
+
+EXIT:
+  if (Framework) {
+    FreeUnitTestFramework (Framework);
+  }
+
+  return Status;
+}
+
+/**
+  Standard POSIX C entry point for host based unit test execution.
+**/
+int
+main (
+  int   argc,
+  char  *argv[]
+  )
+{
+  return UefiTestMain ();
+}

--- a/UnitTestFrameworkPkg/Test/UnitTest/Sample/SampleUnitTestNullAddress/SampleUnitTestNullAddress.inf
+++ b/UnitTestFrameworkPkg/Test/UnitTest/Sample/SampleUnitTestNullAddress/SampleUnitTestNullAddress.inf
@@ -1,0 +1,31 @@
+## @file
+# Sample UnitTest built for execution on a Host machine.
+# This test case dereferences a NULL pointer that is caught by a sanitizer.
+#
+# Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION    = 0x00010005
+  BASE_NAME      = SampleUnitTestNullAddress
+  FILE_GUID      = FDD2EFA0-74BE-4628-A860-A60EF81B9023
+  MODULE_TYPE    = HOST_APPLICATION
+  VERSION_STRING = 1.0
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  SampleUnitTestNullAddress.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+
+[LibraryClasses]
+  BaseLib
+  DebugLib
+  UnitTestLib

--- a/UnitTestFrameworkPkg/Test/UnitTestFrameworkPkgHostTest.dsc
+++ b/UnitTestFrameworkPkg/Test/UnitTestFrameworkPkgHostTest.dsc
@@ -19,7 +19,7 @@
 !include UnitTestFrameworkPkg/UnitTestFrameworkPkgHost.dsc.inc
 
 [PcdsPatchableInModule]
-  gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask|0x17
+  gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask|0x1F
 
 [Components]
   #

--- a/UnitTestFrameworkPkg/Test/UnitTestFrameworkPkgHostTestExpectFail.dsc
+++ b/UnitTestFrameworkPkg/Test/UnitTestFrameworkPkgHostTestExpectFail.dsc
@@ -21,7 +21,7 @@
 !include UnitTestFrameworkPkg/UnitTestFrameworkPkgHost.dsc.inc
 
 [PcdsPatchableInModule]
-  gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask|0x17
+  gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask|0x1F
 
 [Components]
   #

--- a/UnitTestFrameworkPkg/Test/UnitTestFrameworkPkgHostTestExpectFail.dsc
+++ b/UnitTestFrameworkPkg/Test/UnitTestFrameworkPkgHostTestExpectFail.dsc
@@ -1,7 +1,12 @@
 ## @file
-# UnitTestFrameworkPkg DSC file used to build host-based unit tests that archive
+# UnitTestFrameworkPkg DSC file used to build host-based unit tests that are
 # always expected to fail to demonstrate the format of the log file and reports
 # when failures occur.
+#
+# For Google Test based unit tests, in order to see full log of errors from the
+# sanitizer, the Google Test handling of exceptions must be disabled by either
+# setting the environment variable GTEST_CATCH_EXCEPTIONS=0 or passing
+# --gtest-catch-exceptions=0 on the command line when executing unit tests.
 #
 # Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -42,3 +47,12 @@
     <BuildOptions>
       MSFT:*_*_*_CC_FLAGS = /wd4723
   }
+
+  #
+  # Unit tests that perform illegal actions that are caught by a sanitizer
+  #
+  UnitTestFrameworkPkg/Test/UnitTest/Sample/SampleUnitTestDoubleFree/SampleUnitTestDoubleFree.inf
+  UnitTestFrameworkPkg/Test/UnitTest/Sample/SampleUnitTestBufferOverflow/SampleUnitTestBufferOverflow.inf
+  UnitTestFrameworkPkg/Test/UnitTest/Sample/SampleUnitTestBufferUnderflow/SampleUnitTestBufferUnderflow.inf
+  UnitTestFrameworkPkg/Test/UnitTest/Sample/SampleUnitTestNullAddress/SampleUnitTestNullAddress.inf
+  UnitTestFrameworkPkg/Test/UnitTest/Sample/SampleUnitTestInvalidAddress/SampleUnitTestInvalidAddress.inf

--- a/UnitTestFrameworkPkg/UnitTestFrameworkPkg.ci.yaml
+++ b/UnitTestFrameworkPkg/UnitTestFrameworkPkg.ci.yaml
@@ -66,7 +66,12 @@
             "UnitTestFrameworkPkg/Test/GoogleTest/Sample/SampleGoogleTestExpectFail/SampleGoogleTestHostExpectFail.inf",
             "UnitTestFrameworkPkg/Test/GoogleTest/Sample/SampleGoogleTestGenerateException/SampleGoogleTestHostGenerateException.inf",
             "UnitTestFrameworkPkg/Test/UnitTest/Sample/SampleUnitTestExpectFail/SampleUnitTestHostExpectFail.inf",
-            "UnitTestFrameworkPkg/Test/UnitTest/Sample/SampleUnitTestGenerateException/SampleUnitTestHostGenerateException.inf"
+            "UnitTestFrameworkPkg/Test/UnitTest/Sample/SampleUnitTestGenerateException/SampleUnitTestHostGenerateException.inf",
+            "UnitTestFrameworkPkg/Test/UnitTest/Sample/SampleUnitTestDoubleFree/SampleUnitTestDoubleFree.inf",
+            "UnitTestFrameworkPkg/Test/UnitTest/Sample/SampleUnitTestBufferOverflow/SampleUnitTestBufferOverflow.inf",
+            "UnitTestFrameworkPkg/Test/UnitTest/Sample/SampleUnitTestBufferUnderflow/SampleUnitTestBufferUnderflow.inf",
+            "UnitTestFrameworkPkg/Test/UnitTest/Sample/SampleUnitTestNullAddress/SampleUnitTestNullAddress.inf",
+            "UnitTestFrameworkPkg/Test/UnitTest/Sample/SampleUnitTestInvalidAddress/SampleUnitTestInvalidAddress.inf"
         ],
         "DscPath": "Test/UnitTestFrameworkPkgHostTest.dsc"
     },

--- a/UnitTestFrameworkPkg/UnitTestFrameworkPkg.ci.yaml
+++ b/UnitTestFrameworkPkg/UnitTestFrameworkPkg.ci.yaml
@@ -96,6 +96,7 @@
             "Library/SubhookLib/subhook/**/*.*"  # not going to spell check a submodule
         ],
         "ExtendWords": [             # words to extend to the dictionary for this package
+            "noreplace",
             "Pointee",
             "gmock",
             "GMOCK",

--- a/UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+++ b/UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
@@ -39,6 +39,11 @@
   SubhookLib|Include/Library/SubhookLib.h
   FunctionMockLib|Include/Library/FunctionMockLib.h
 
+  ## @libraryclass Host only memory allocation library that supports allocating
+  #  buffers below a specified address.
+  #
+  HostMemoryAllocationBelowAddressLib|Include/Library/HostMemoryAllocationBelowAddressLib.h
+
 [LibraryClasses.Common.Private]
   ## @libraryclass Provides a unit test result report
   #

--- a/UnitTestFrameworkPkg/UnitTestFrameworkPkg.dsc
+++ b/UnitTestFrameworkPkg/UnitTestFrameworkPkg.dsc
@@ -23,7 +23,7 @@
 !include MdePkg/MdeLibs.dsc.inc
 
 [PcdsPatchableInModule]
-  gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask|0x17
+  gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask|0x1F
 
 [Components]
   UnitTestFrameworkPkg/Library/UnitTestLib/UnitTestLib.inf

--- a/UnitTestFrameworkPkg/UnitTestFrameworkPkgCommon.dsc.inc
+++ b/UnitTestFrameworkPkg/UnitTestFrameworkPkgCommon.dsc.inc
@@ -14,7 +14,7 @@
   PrintLib|MdePkg/Library/BasePrintLib/BasePrintLib.inf
 
 [PcdsFixedAtBuild]
-  gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask|0x17
+  gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask|0x1F
 
 [BuildOptions]
   MSFT:*_*_*_CC_FLAGS  = -D DISABLE_NEW_DEPRECATED_INTERFACES -D EDKII_UNIT_TEST_FRAMEWORK_ENABLED

--- a/UnitTestFrameworkPkg/UnitTestFrameworkPkgHost.dsc.inc
+++ b/UnitTestFrameworkPkg/UnitTestFrameworkPkgHost.dsc.inc
@@ -8,6 +8,9 @@
 
 !include UnitTestFrameworkPkg/UnitTestFrameworkPkgCommon.dsc.inc
 
+[Defines]
+  UNIT_TESTING_ADDRESS_SANITIZER_ENABLE = TRUE
+
 [LibraryClasses.common.HOST_APPLICATION]
   BaseLib|MdePkg/Library/BaseLib/UnitTestHostBaseLib.inf
   UnitTestHostBaseLib|MdePkg/Library/BaseLib/UnitTestHostBaseLib.inf
@@ -26,10 +29,18 @@
   NULL|MdePkg/Library/StackCheckLibNull/StackCheckLibNullHostApplication.inf
 
 [BuildOptions]
-  MSFT:*_*_*_CC_FLAGS = /MT
+  MSFT:*_*_*_CC_FLAGS = /MTd
   GCC:*_*_*_CC_FLAGS = -fno-pie
+!if $(UNIT_TESTING_ADDRESS_SANITIZER_ENABLE)
+  #
+  # Enable Address Sanitizer for VS2019, VS2022, and GCC
+  #
+  MSFT:*_VS2019_*_CC_FLAGS = /fsanitize=address
+  MSFT:*_VS2022_*_CC_FLAGS = /fsanitize=address
+  GCC:*_*_*_CC_FLAGS = -fsanitize=address
+!endif
 !ifdef $(UNIT_TESTING_DEBUG)
-  MSFT:*_*_*_CC_FLAGS  = /MTd -D UNIT_TESTING_DEBUG=1
+  MSFT:*_*_*_CC_FLAGS  = -D UNIT_TESTING_DEBUG=1
   GCC:*_*_*_CC_FLAGS   = -D UNIT_TESTING_DEBUG=1
   XCODE:*_*_*_CC_FLAGS = -D UNIT_TESTING_DEBUG=1
 !endif
@@ -41,9 +52,7 @@
   # MSFT
   #
   MSFT:*_*_*_CC_FLAGS               = /EHs
-  MSFT:*_*_*_DLINK_FLAGS            == /out:"$(BIN_DIR)\$(MODULE_NAME_GUID).exe" /pdb:"$(BIN_DIR)\$(MODULE_NAME_GUID).pdb" /IGNORE:4001 /NOLOGO /SUBSYSTEM:CONSOLE /DEBUG /STACK:0x40000,0x40000 /WHOLEARCHIVE
-  MSFT:*_*_IA32_DLINK_FLAGS         = /MACHINE:I386
-  MSFT:*_*_X64_DLINK_FLAGS          = /MACHINE:AMD64
+  MSFT:*_*_*_DLINK_FLAGS            == /nologo /SUBSYSTEM:CONSOLE /DEBUG /out:"$(BIN_DIR)\$(MODULE_NAME_GUID).exe" /pdb:"$(BIN_DIR)\$(MODULE_NAME_GUID).pdb"
 
   MSFT:*_VS2015_IA32_DLINK_FLAGS    = /LIBPATH:"%VS2015_PREFIX%Lib" /LIBPATH:"%VS2015_PREFIX%VC\Lib" /LIBPATH:"%UniversalCRTSdkDir%lib\%UCRTVersion%\ucrt\x86" /LIBPATH:"%WindowsSdkDir%lib\%WindowsSDKLibVersion%\um\x86"
   MSFT:*_VS2015x86_IA32_DLINK_FLAGS = /LIBPATH:"%VS2015_PREFIX%Lib" /LIBPATH:"%VS2015_PREFIX%VC\Lib" /LIBPATH:"%UniversalCRTSdkDir%lib\%UCRTVersion%\ucrt\x86" /LIBPATH:"%WindowsSdkDir%lib\%WindowsSDKLibVersion%\um\x86"
@@ -68,6 +77,12 @@
   #
   GCC:*_*_*_DLINK_FLAGS    = -Wl,--whole-archive
   GCC:*_*_*_DLINK2_FLAGS   == -Wl,--no-whole-archive -lgcov -lpthread -lstdc++ -lm
+!if $(UNIT_TESTING_ADDRESS_SANITIZER_ENABLE)
+  #
+  # Enable Address Sanitizer for GCC for HOST_APPLICATION
+  #
+  GCC:*_*_*_DLINK_FLAGS    = -fsanitize=address
+!endif
 
   #
   # Need to do this link via gcc and not ld as the pathing to libraries changes from OS version to OS version

--- a/UnitTestFrameworkPkg/UnitTestFrameworkPkgHost.dsc.inc
+++ b/UnitTestFrameworkPkg/UnitTestFrameworkPkgHost.dsc.inc
@@ -23,6 +23,7 @@
   UnitTestLib|UnitTestFrameworkPkg/Library/UnitTestLib/UnitTestLibCmocka.inf
   DebugLib|UnitTestFrameworkPkg/Library/Posix/DebugLibPosix/DebugLibPosix.inf
   MemoryAllocationLib|UnitTestFrameworkPkg/Library/Posix/MemoryAllocationLibPosix/MemoryAllocationLibPosix.inf
+  HostMemoryAllocationBelowAddressLib|UnitTestFrameworkPkg/Library/Posix/MemoryAllocationLibPosix/MemoryAllocationLibPosix.inf
   UefiBootServicesTableLib|UnitTestFrameworkPkg/Library/UnitTestUefiBootServicesTableLib/UnitTestUefiBootServicesTableLib.inf
   PeiServicesTablePointerLib|UnitTestFrameworkPkg/Library/UnitTestPeiServicesTablePointerLib/UnitTestPeiServicesTablePointerLib.inf
   NULL|UnitTestFrameworkPkg/Library/UnitTestDebugAssertLib/UnitTestDebugAssertLibHost.inf


### PR DESCRIPTION
# Description

UnitTestFrameworkPkg: Use /MTd and enable Address Sanitizers

* Update host based unit test VS20xx builds to use /MTd instead of
  /MT to enable use of debug libraries for host based unit tests.
* Enable /fsanitize=address for host based unit test VS2019 builds
* Enable /fsanitize=address for host based unit test VS2022 builds
* Enable -fsanitize=address for host based unit test GCC builds
* Add UNIT_TESTING_ADDRESS_SANITIZER_ENABLE define that is set to
  TRUE by default so it is always enabled, but can be set to FALSE
  to temporarily disable during development/debug of unit tests.
* Add HostMemoryAllocationBelowAddressLib to support allocating 
  buffers below a specified address in unit test code and mocks to
  support code under test that requires a buffer below a specific 
  address (e.g. 4GB). The services included are:
```
VOID * EFIAPI HostAllocatePoolBelowAddress (IN VOID   *MaximumAddress, IN UINTN  Length);
VOID EFIAPI HostFreePoolBelowAddress (IN VOID  *Address);
VOID * EFIAPI HostAllocateAlignedPagesBelowAddress (IN VOID   *MaximumAddress, IN UINTN  Pages, IN UINTN  Alignment );
VOID EFIAPI HostFreeAlignedPagesBelowAddress (IN VOID   *Buffer, IN UINTN  Pages);
```
Enabling the Address Sanitizer can detect double frees, buffer
overflow, buffer underflow, access to invalid addresses, and
various exceptions. These can be detected in both the unit test
case sources as well as the code under test.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

## Integration Instructions

The environment variable `GTEST_CATCH_EXCEPTION` must be set to `0` for so all exceptions are handled by the address sanitizer and not GoogleTest. This allows stack back trace and other details to be logged by the address sanitizer so the source of the issue identified address sanitizer can be determined.

The environment variable `ASAN_OPTIONS` must be set to `detect_leaks=0` to disable memory leak detection. The unit test frameworks may have memory leaks and some firmware code under test use cases may perform a memory allocation without a matching memory free as their expected behavior.

### Windows

```
set GTEST_CATCH_EXCEPTIONS=0
set ASAN_OPTIONS=detect_leaks=0
```

### Linux

```
export GTEST_CATCH_EXCEPTIONS=0
export ASAN_OPTIONS=detect_leaks=0
```