### PR TITLE
CryptoPkg: Apply gettimeofday() solution to BaseCryptLibMbedTls

### DIFF
--- a/CryptoPkg/Library/BaseCryptLibMbedTls/SysCall/ConstantTimeClock.c
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/SysCall/ConstantTimeClock.c
@@ -19,25 +19,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #include <Base.h>
 #include <Library/BaseMemoryLib.h>
-
-typedef int time_t;
-
-//
-// Structures Definitions
-//
-struct tm {
-  int     tm_sec;    /* seconds after the minute [0-60] */
-  int     tm_min;    /* minutes after the hour [0-59] */
-  int     tm_hour;   /* hours since midnight [0-23] */
-  int     tm_mday;   /* day of the month [1-31] */
-  int     tm_mon;    /* months since January [0-11] */
-  int     tm_year;   /* years since 1900 */
-  int     tm_wday;   /* days since Sunday [0-6] */
-  int     tm_yday;   /* days since January 1 [0-365] */
-  int     tm_isdst;  /* Daylight Savings Time flag */
-  long    tm_gmtoff; /* offset from CUT in seconds */
-  char    *tm_zone;  /* timezone abbreviation */
-};
+#include <CrtLibSupport.h>
 
 //
 // -- Time Management Routines --
@@ -72,4 +54,17 @@ _time64 (
   )
 {
   return time (t);
+}
+
+long  timezone;
+
+int
+gettimeofday (
+  struct timeval   *tv,
+  struct timezone  *tz
+  )
+{
+  tv->tv_sec  = 0;
+  tv->tv_usec = 0;
+  return 0;
 }

--- a/CryptoPkg/Library/BaseCryptLibMbedTls/SysCall/TimerWrapper.c
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/SysCall/TimerWrapper.c
@@ -11,25 +11,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/UefiRuntimeServicesTableLib.h>
 #include <Library/BaseMemoryLib.h>
 #include <Library/MemoryAllocationLib.h>
-
-typedef int time_t;
-
-//
-// Structures Definitions
-//
-struct tm {
-  int     tm_sec;    /* seconds after the minute [0-60] */
-  int     tm_min;    /* minutes after the hour [0-59] */
-  int     tm_hour;   /* hours since midnight [0-23] */
-  int     tm_mday;   /* day of the month [1-31] */
-  int     tm_mon;    /* months since January [0-11] */
-  int     tm_year;   /* years since 1900 */
-  int     tm_wday;   /* days since Sunday [0-6] */
-  int     tm_yday;   /* days since January 1 [0-365] */
-  int     tm_isdst;  /* Daylight Savings Time flag */
-  long    tm_gmtoff; /* offset from CUT in seconds */
-  char    *tm_zone;  /* timezone abbreviation */
-};
+#include <CrtLibSupport.h>
 
 //
 // -- Time Management Routines --
@@ -195,4 +177,17 @@ _time64 (
   )
 {
   return time (t);
+}
+
+long  timezone;
+
+int
+gettimeofday (
+  struct timeval   *tv,
+  struct timezone  *tz
+  )
+{
+  tv->tv_sec  = (long)time (NULL);
+  tv->tv_usec = 0;
+  return 0;
 }


### PR DESCRIPTION
BaseCryptLib turn gettimeofday() from a Macro into a function call, apply the same change to BaseCryptLibMbedTls

# Description

BaseCryptLib turn gettimeofday() from a Macro into a function call, apply the same change to BaseCryptLibMbedTls

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior? No

- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact? No

- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code? No

## How This Was Tested

Local build and boot from emulator passed 

## Integration Instructions

N/A
