### PR TITLE
CryptoPkg/BaseCryptLib: Fix serial number read overrun

### DIFF
--- a/CryptoPkg/Library/BaseCryptLib/Pk/CryptX509.c
+++ b/CryptoPkg/Library/BaseCryptLib/Pk/CryptX509.c
@@ -1056,7 +1056,7 @@ X509GetSerialNumber (
   }
 
   if (SerialNumber != NULL) {
-    CopyMem (SerialNumber, Asn1Integer->data, *SerialNumberSize);
+    CopyMem (SerialNumber, Asn1Integer->data, (UINTN)Asn1Integer->length);
     Status = TRUE;
   }
 


### PR DESCRIPTION
# Description

Fix serial number read overrun detected with use of address sanitizer in host based unit tests in draft PR https://github.com/tianocore/edk2/pull/6408

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [X] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Run host based unit tests with address sanitizer enabled and the issue is resolved with this change

## Integration Instructions
