### PR TITLE
UefiCpuPkg/MtrrLib: Fix unit test read overflow

### DIFF
--- a/UefiCpuPkg/Library/MtrrLib/UnitTest/Support.c
+++ b/UefiCpuPkg/Library/MtrrLib/UnitTest/Support.c
@@ -745,7 +745,7 @@ GetNextDifferentElementInSortedArray (
   UINT64  CurrentElement;
 
   CurrentElement = Array[Index];
-  while (CurrentElement == Array[Index] && Index < Count) {
+  while ((Index < Count) && (CurrentElement == Array[Index])) {
     Index++;
   }
 


### PR DESCRIPTION
# Description

Change conditional check to check the array index before reading the array member to prevent read past end of buffer.

Detected with use of address sanitizer in host based unit tests in draft PR https://github.com/tianocore/edk2/pull/6408

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [X] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Run host based unit tests with address sanitizer enabled and the issue is resolved with this change

## Integration Instructions
