### PR TITLE
NetworkPkg/Dhcp6Dxe: Fix sanitizer issues

### DIFF
--- a/NetworkPkg/Dhcp6Dxe/GoogleTest/Dhcp6IoGoogleTest.cpp
+++ b/NetworkPkg/Dhcp6Dxe/GoogleTest/Dhcp6IoGoogleTest.cpp
@@ -161,7 +161,7 @@ TEST_F (Dhcp6AppendOptionTest, ValidDataExpectSuccess) {
   Packet->Length = sizeof (EFI_DHCP6_HEADER);
   OriginalLength = Packet->Length;
 
-  UntrustedDuid = (EFI_DHCP6_DUID *)AllocateZeroPool (sizeof (EFI_DHCP6_DUID));
+  UntrustedDuid = (EFI_DHCP6_DUID *)AllocateZeroPool (OFFSET_OF (EFI_DHCP6_DUID, Duid) + sizeof (Duid));
   ASSERT_NE (UntrustedDuid, (EFI_DHCP6_DUID *)NULL);
 
   UntrustedDuid->Length = NTOHS (sizeof (Duid));
@@ -763,7 +763,7 @@ TEST_F (Dhcp6SeekStsOptionTest, SeekIATAOptionExpectFail) {
              Dhcp6SeekStsOptionTest::Packet,
              &Option,
              Dhcp6OptStatusCode,
-             SearchPatternLength,
+             HTONS (SearchPatternLength),
              (UINT8 *)&SearchPattern
              );
   ASSERT_EQ (Status, EFI_SUCCESS);
@@ -815,7 +815,7 @@ TEST_F (Dhcp6SeekStsOptionTest, SeekIANAOptionExpectSuccess) {
              Dhcp6SeekStsOptionTest::Packet,
              &Option,
              Dhcp6OptStatusCode,
-             SearchPatternLength,
+             HTONS (SearchPatternLength),
              (UINT8 *)&SearchPattern
              );
   ASSERT_EQ (Status, EFI_SUCCESS);


### PR DESCRIPTION
# Description

* EFI_DHCP6_DUID structure declares Duid[1], so the size of that structure is not large enough to hold an entire Duid. Instead, compute the correct size to allocate an EFI_DHCP6_DUID structure.
* Dhcp6AppendOption() takes a length parameter that in network order. Update test cases to make sure a network order length is passed in. A value of 0x0004 was being passed in and was then converted to 0x0400 length and buffer overflow was detected.

Detected with use of address sanitizer in host based unit tests in draft PR https://github.com/tianocore/edk2/pull/6408

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [X] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Run host based unit tests with address sanitizer enabled and the issue is resolved with this change

## Integration Instructions

