### PR TITLE
MdePkg/Test/DevicePathLib: Remove FreePool(NULL)

### DIFF
--- a/MdePkg/Test/UnitTest/Library/DevicePathLib/TestDevicePathLib.c
+++ b/MdePkg/Test/UnitTest/Library/DevicePathLib/TestDevicePathLib.c
@@ -473,11 +473,9 @@ TestAppendDevicePathInstance (
 
   Appended = AppendDevicePathInstance (NULL, NULL);
   UT_ASSERT_EQUAL ((uintptr_t)Appended, (uintptr_t)NULL);
-  FreePool (Appended);
 
   Appended = AppendDevicePathInstance ((EFI_DEVICE_PATH_PROTOCOL *)&mSimpleDevicePath, (EFI_DEVICE_PATH_PROTOCOL *)&mInvalidSimpleDevicePath);
   UT_ASSERT_EQUAL ((uintptr_t)Appended, (uintptr_t)NULL);
-  FreePool (Appended);
 
   return UNIT_TEST_PASSED;
 }


### PR DESCRIPTION
# Description

Unit test checks if AppendDevicePathInstance() returns NULL. In those cases, AppendDevicePathInstance() does not allocate a device path, so the call to FreePool() must not be performed.

Detected with use of address sanitizer in host based unit tests in draft PR https://github.com/tianocore/edk2/pull/6408

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [X] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Run host based unit tests with address sanitizer enabled and the issue is resolved with this change

## Integration Instructions
