### PR TITLE
fix mSecureHashAlgorithms name clash

### DIFF
--- a/MdePkg/Library/DxeRngLib/DxeRngLib.c
+++ b/MdePkg/Library/DxeRngLib/DxeRngLib.c
@@ -32,7 +32,7 @@ typedef struct {
 // These represent UEFI SPEC defined algorithms that should be supported by
 // the RNG protocol and are generally considered secure.
 //
-GLOBAL_REMOVE_IF_UNREFERENCED SECURE_RNG_ALGO_ARRAY  mSecureHashAlgorithms[] = {
+static GLOBAL_REMOVE_IF_UNREFERENCED SECURE_RNG_ALGO_ARRAY  mSecureHashAlgorithms[] = {
  #ifdef MDE_CPU_AARCH64
   {
     &gEfiRngAlgorithmArmRndr, // unspecified SP800-90A DRBG (through RNDR instr.)

--- a/NetworkPkg/Library/DxeNetLib/DxeNetLib.c
+++ b/NetworkPkg/Library/DxeNetLib/DxeNetLib.c
@@ -144,7 +144,7 @@ GLOBAL_REMOVE_IF_UNREFERENCED VLAN_DEVICE_PATH  mNetVlanDevicePathTemplate = {
 // If your platform needs to use a specific algorithm for the random number
 // generator, then you should modify this array.
 //
-GLOBAL_REMOVE_IF_UNREFERENCED EFI_GUID  *mSecureHashAlgorithms[] = {
+static GLOBAL_REMOVE_IF_UNREFERENCED EFI_GUID  *mSecureHashAlgorithms[] = {
   &gEfiRngAlgorithmSp80090Ctr256Guid,  // SP800-90A DRBG CTR using AES-256
   &gEfiRngAlgorithmSp80090Hmac256Guid, // SP800-90A DRBG HMAC using SHA-256
   &gEfiRngAlgorithmSp80090Hash256Guid, // SP800-90A DRBG Hash using SHA-256


### PR DESCRIPTION
Both DxeRngLib and DxeNetLib have a mSecureHashAlgorithms variable.
This breaks the ArmVirtPkg builds with iscsi support enabled.
Fix that by making the variables static in both libraries.

- **MdePkg/DxeRngLib: make mSecureHashAlgorithms static**
- **NetworkPkg/DxeNetLib: make mSecureHashAlgorithms static**
