### PR TITLE
UefiPayloadPkg/Build: align python execute

### DIFF
--- a/UefiPayloadPkg/UniversalPayloadBuild.py
+++ b/UefiPayloadPkg/UniversalPayloadBuild.py
@@ -160,12 +160,12 @@ def BuildUniversalPayload(Args):
     if (Args.Macro != None):
         for MacroItem in Args.Macro:
             Defines += " -D {}".format (MacroItem)
-
+    BuildScript = os.path.join (os.environ['EDK_TOOLS_PATH'], 'Source', 'Python', 'build', 'build.py')
     #
     # Building DXE core and DXE drivers as DXEFV.
     #
     if Args.BuildEntryOnly == False:
-        BuildPayload = "build -p {} -b {} -a {} -t {} -y {} {}".format (DscPath, BuildTarget, BuildArch, ToolChain, PayloadReportPath, Quiet)
+        BuildPayload = "\"{}\" {} -p {} -b {} -a {} -t {} -y {} {}".format (sys.executable, BuildScript, DscPath, BuildTarget, BuildArch, ToolChain, PayloadReportPath, Quiet)
         BuildPayload += Pcds
         BuildPayload += Defines
         RunCommand(BuildPayload)
@@ -173,7 +173,7 @@ def BuildUniversalPayload(Args):
     # Building Universal Payload entry.
     #
     if Args.PreBuildUplBinary is None:
-        BuildModule = "build -p {} -b {} -a {} -m {} -t {} -y {} {}".format (DscPath, BuildTarget, BuildArch, EntryModuleInf, PayloadEntryToolChain, ModuleReportPath, Quiet)
+        BuildModule = "\"{}\" {} -p {} -b {} -a {} -m {} -t {} -y {} {}".format (sys.executable, BuildScript, DscPath, BuildTarget, BuildArch, EntryModuleInf, PayloadEntryToolChain, ModuleReportPath, Quiet)
         BuildModule += Pcds
         BuildModule += Defines
         RunCommand(BuildModule)


### PR DESCRIPTION
In Edk2 behavior, build.py call flow will be like it.
| BaseTools/BinWrappers/PosixLike/build
| $(PYTHON_COMMAND) build.py
V

In UPL behavior, will one more python to call build, it will cause PYTHON_COMMAND miss
| UniversalPayloadBuild.py
| BaseTools/BinWrappers/PosixLike/build
| $(PYTHON_COMMAND) build.py
V

# Description

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - No, just make sure caller and callee has aligned python process.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact? No Impact
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested
Make sure all code in UPL use aligned python version

## Integration Instructions

N/A