### PR TITLE
ArmPkg: Create DxeMmReadyToLockProtocol notification

### DIFF
--- a/ArmPkg/Drivers/MmCommunicationDxe/MmCommunication.inf
+++ b/ArmPkg/Drivers/MmCommunicationDxe/MmCommunication.inf
@@ -41,6 +41,7 @@
   UefiDriverEntryPoint
 
 [Protocols]
+  gEfiDxeMmReadyToLockProtocolGuid              ## UNDEFINED # SmiHandlerRegister
   gEfiMmCommunication2ProtocolGuid              ## PRODUCES
 
 [Guids]


### PR DESCRIPTION
Create DxeMmReadyToLockProtocol notification that Mm requires

# Description
The mmCommunication driver in ArmPkg needs to create a gEfiDxeMmReadyToLockProtocolGuid notification so that MmReadyToLockHandler can be called


## How This Was Tested
Tested in Arm platform
