### PR TITLE
SecurityPkg/Tcg2Config: Set TPM2.0 for default of Attempt TPM Device

### DIFF
--- a/SecurityPkg/Tcg/Tcg2Config/Tcg2Config.vfr
+++ b/SecurityPkg/Tcg/Tcg2Config/Tcg2Config.vfr
@@ -47,8 +47,8 @@ formset
           prompt = STRING_TOKEN(STR_TCG2_DEVICE_PROMPT),
           help   = STRING_TOKEN(STR_TCG2_DEVICE_HELP),
           flags  = INTERACTIVE,
-            option text = STRING_TOKEN(STR_TCG2_TPM_1_2),          value = TPM_DEVICE_1_2,          flags = DEFAULT | MANUFACTURING | RESET_REQUIRED;
-            option text = STRING_TOKEN(STR_TCG2_TPM_2_0_DTPM),     value = TPM_DEVICE_2_0_DTPM,     flags = RESET_REQUIRED;
+            option text = STRING_TOKEN(STR_TCG2_TPM_1_2),          value = TPM_DEVICE_1_2,          flags = RESET_REQUIRED;
+            option text = STRING_TOKEN(STR_TCG2_TPM_2_0_DTPM),     value = TPM_DEVICE_2_0_DTPM,     flags = DEFAULT | MANUFACTURING | RESET_REQUIRED;
     endoneof;
 
     suppressif ideqvallist TCG2_CONFIGURATION.TpmDevice == TPM_DEVICE_NULL TPM_DEVICE_1_2;


### PR DESCRIPTION
As TPM2.0 is popular, updating default value for the Setup menu supports a benefit for some systems that have another TPM Setup menu to select TPM2.0 devices (e.g. dTPM, fTPM) depending on platform bios. 

For example, when loading default configuration using F9 key in Setup (Brower Action: SystemLevel), it is possible for them to load an unsynchronized value. If user does not adjust the value before saving Setup, it could influence an unexpected TPM initialization at next boot. Setting TPM2.0 as default value supports the benefit related to the case.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

The update was verified on AMD platforms that support the 2 Setup menus (different page) usually. It fixed a QA issue that system can't detect dTPM when pressing F9 first and then setting to dTPM.

## Integration Instructions

N/A
