### PR TITLE
UefiCpuPkg: Fix unchecked returns and potential integer overflows V2

### DIFF
--- a/UefiCpuPkg/CpuMpPei/CpuMpPei.c
+++ b/UefiCpuPkg/CpuMpPei/CpuMpPei.c
@@ -437,8 +437,14 @@ InitializeExceptionStackSwitchHandlers (
 {
   EXCEPTION_STACK_SWITCH_CONTEXT  *SwitchStackData;
   UINTN                           Index;
+  EFI_STATUS                      Status;
 
-  MpInitLibWhoAmI (&Index);
+  Status = MpInitLibWhoAmI (&Index);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a - Failed to allocate Switch Stack pages.\n", __func__));
+    return;
+  }
+
   SwitchStackData = (EXCEPTION_STACK_SWITCH_CONTEXT *)Buffer;
 
   //
@@ -481,7 +487,12 @@ InitializeMpExceptionStackSwitchHandlers (
   }
 
   SwitchStackData = AllocatePages (EFI_SIZE_TO_PAGES (NumberOfProcessors * sizeof (EXCEPTION_STACK_SWITCH_CONTEXT)));
-  ASSERT (SwitchStackData != NULL);
+  if (SwitchStackData == NULL) {
+    ASSERT (SwitchStackData != NULL);
+    DEBUG ((DEBUG_ERROR, "%a - Failed to allocate Switch Stack pages.\n", __func__));
+    return;
+  }
+
   ZeroMem (SwitchStackData, NumberOfProcessors * sizeof (EXCEPTION_STACK_SWITCH_CONTEXT));
   for (Index = 0; Index < NumberOfProcessors; ++Index) {
     //
@@ -511,7 +522,12 @@ InitializeMpExceptionStackSwitchHandlers (
 
   if (BufferSize != 0) {
     Buffer = AllocatePages (EFI_SIZE_TO_PAGES (BufferSize));
-    ASSERT (Buffer != NULL);
+    if (Buffer == NULL) {
+      ASSERT (Buffer != NULL);
+      DEBUG ((DEBUG_ERROR, "%a - Failed to allocate Buffer pages.\n", __func__));
+      return;
+    }
+
     BufferSize = 0;
     for (Index = 0; Index < NumberOfProcessors; ++Index) {
       if (SwitchStackData[Index].Status == EFI_BUFFER_TOO_SMALL) {

--- a/UefiCpuPkg/Library/CpuCommonFeaturesLib/MachineCheck.c
+++ b/UefiCpuPkg/Library/CpuCommonFeaturesLib/MachineCheck.c
@@ -174,7 +174,7 @@ McaInitialize (
     }
 
     if (PcdGetBool (PcdIsPowerOnReset)) {
-      for (BankIndex = 0; BankIndex < (UINTN)McgCap.Bits.Count; BankIndex++) {
+      for (BankIndex = 0; BankIndex < (UINT32)McgCap.Bits.Count; BankIndex++) {
         CPU_REGISTER_TABLE_WRITE64 (
           ProcessorNumber,
           Msr,

--- a/UefiCpuPkg/Library/CpuExceptionHandlerLib/PeiCpuException.c
+++ b/UefiCpuPkg/Library/CpuExceptionHandlerLib/PeiCpuException.c
@@ -71,7 +71,11 @@ SetExceptionHandlerData (
   IdtTable = (IA32_IDT_GATE_DESCRIPTOR *)IdtDescriptor.Base;
 
   Exception0StubHeader = AllocatePool (sizeof (*Exception0StubHeader));
-  ASSERT (Exception0StubHeader != NULL);
+  if (Exception0StubHeader == NULL) {
+    ASSERT (Exception0StubHeader != NULL);
+    return;
+  }
+
   CopyMem (
     Exception0StubHeader->ExceptionStubHeader,
     (VOID *)ArchGetIdtHandler (&IdtTable[0]),
@@ -165,10 +169,18 @@ InitializeCpuExceptionHandlers (
   RESERVED_VECTORS_DATA   *ReservedVectors;
 
   ReservedVectors = AllocatePool (sizeof (RESERVED_VECTORS_DATA) * CPU_EXCEPTION_NUM);
-  ASSERT (ReservedVectors != NULL);
+  if (ReservedVectors == NULL) {
+    ASSERT (ReservedVectors != NULL);
+    return EFI_OUT_OF_RESOURCES;
+  }
 
   ExceptionHandlerData = AllocatePool (sizeof (EXCEPTION_HANDLER_DATA));
-  ASSERT (ExceptionHandlerData != NULL);
+  if (ExceptionHandlerData == NULL) {
+    ASSERT (ExceptionHandlerData != NULL);
+    FreePool (ReservedVectors);
+    return EFI_OUT_OF_RESOURCES;
+  }
+
   ExceptionHandlerData->IdtEntryCount            = CPU_EXCEPTION_NUM;
   ExceptionHandlerData->ReservedVectors          = ReservedVectors;
   ExceptionHandlerData->ExternalInterruptHandler = AllocateZeroPool (sizeof (EFI_CPU_INTERRUPT_HANDLER) * ExceptionHandlerData->IdtEntryCount);

--- a/UefiCpuPkg/Library/MpInitLib/AmdSev.c
+++ b/UefiCpuPkg/Library/MpInitLib/AmdSev.c
@@ -25,7 +25,9 @@ GetProtectedMode16CS (
   IA32_DESCRIPTOR          GdtrDesc;
   IA32_SEGMENT_DESCRIPTOR  *GdtEntry;
   UINTN                    GdtEntryCount;
-  UINT16                   Index;
+  UINTN                    Index;
+  UINT16                   CodeSegmentValue;
+  EFI_STATUS               Status;
 
   Index = (UINT16)-1;
   AsmReadGdtr (&GdtrDesc);
@@ -42,8 +44,19 @@ GetProtectedMode16CS (
     GdtEntry++;
   }
 
-  ASSERT (Index != GdtEntryCount);
-  return Index * 8;
+  Status = SafeUintnToUint16 (Index, &CodeSegmentValue);
+  if (EFI_ERROR (Status)) {
+    ASSERT_EFI_ERROR (Status);
+    return 0;
+  }
+
+  Status = SafeUint16Mult (CodeSegmentValue, 8, &CodeSegmentValue);
+  if (EFI_ERROR (Status)) {
+    ASSERT_EFI_ERROR (Status);
+    return 0;
+  }
+
+  return CodeSegmentValue;
 }
 
 /**
@@ -61,7 +74,9 @@ GetProtectedMode32CS (
   IA32_DESCRIPTOR          GdtrDesc;
   IA32_SEGMENT_DESCRIPTOR  *GdtEntry;
   UINTN                    GdtEntryCount;
-  UINT16                   Index;
+  UINTN                    Index;
+  UINT16                   CodeSegmentValue;
+  EFI_STATUS               Status;
 
   Index = (UINT16)-1;
   AsmReadGdtr (&GdtrDesc);
@@ -79,7 +94,19 @@ GetProtectedMode32CS (
   }
 
   ASSERT (Index != GdtEntryCount);
-  return Index * 8;
+  Status = SafeUintnToUint16 (Index, &CodeSegmentValue);
+  if (EFI_ERROR (Status)) {
+    ASSERT_EFI_ERROR (Status);
+    return 0;
+  }
+
+  Status = SafeUint16Mult (CodeSegmentValue, 8, &CodeSegmentValue);
+  if (EFI_ERROR (Status)) {
+    ASSERT_EFI_ERROR (Status);
+    return 0;
+  }
+
+  return CodeSegmentValue;
 }
 
 /**

--- a/UefiCpuPkg/Library/MpInitLib/DxeMpInitLib.inf
+++ b/UefiCpuPkg/Library/MpInitLib/DxeMpInitLib.inf
@@ -63,6 +63,7 @@
 
 [LibraryClasses.IA32, LibraryClasses.X64]
   AmdSvsmLib
+  SafeIntLib
   CcExitLib
   LocalApicLib
   MicrocodeLib

--- a/UefiCpuPkg/Library/MpInitLib/DxeMpLib.c
+++ b/UefiCpuPkg/Library/MpInitLib/DxeMpLib.c
@@ -313,7 +313,9 @@ GetProtectedMode16CS (
   IA32_DESCRIPTOR          GdtrDesc;
   IA32_SEGMENT_DESCRIPTOR  *GdtEntry;
   UINTN                    GdtEntryCount;
-  UINT16                   Index;
+  UINTN                    Index;
+  UINT16                   CodeSegmentValue;
+  EFI_STATUS               Status;
 
   Index = (UINT16)-1;
   AsmReadGdtr (&GdtrDesc);
@@ -329,8 +331,19 @@ GetProtectedMode16CS (
     GdtEntry++;
   }
 
-  ASSERT (Index != GdtEntryCount);
-  return Index * 8;
+  Status = SafeUintnToUint16 (Index, &CodeSegmentValue);
+  if (EFI_ERROR (Status)) {
+    ASSERT_EFI_ERROR (Status);
+    return 0;
+  }
+
+  Status = SafeUint16Mult (CodeSegmentValue, 8, &CodeSegmentValue);
+  if (EFI_ERROR (Status)) {
+    ASSERT_EFI_ERROR (Status);
+    return 0;
+  }
+
+  return CodeSegmentValue;
 }
 
 /**
@@ -346,7 +359,9 @@ GetProtectedModeCS (
   IA32_DESCRIPTOR          GdtrDesc;
   IA32_SEGMENT_DESCRIPTOR  *GdtEntry;
   UINTN                    GdtEntryCount;
-  UINT16                   Index;
+  UINTN                    Index;
+  UINT16                   CodeSegmentValue;
+  EFI_STATUS               Status;
 
   AsmReadGdtr (&GdtrDesc);
   GdtEntryCount = (GdtrDesc.Limit + 1) / sizeof (IA32_SEGMENT_DESCRIPTOR);
@@ -361,8 +376,19 @@ GetProtectedModeCS (
     GdtEntry++;
   }
 
-  ASSERT (Index != GdtEntryCount);
-  return Index * 8;
+  Status = SafeUintnToUint16 (Index, &CodeSegmentValue);
+  if (EFI_ERROR (Status)) {
+    ASSERT_EFI_ERROR (Status);
+    return 0;
+  }
+
+  Status = SafeUint16Mult (CodeSegmentValue, 8, &CodeSegmentValue);
+  if (EFI_ERROR (Status)) {
+    ASSERT_EFI_ERROR (Status);
+    return 0;
+  }
+
+  return CodeSegmentValue;
 }
 
 /**

--- a/UefiCpuPkg/Library/MpInitLib/MpLib.h
+++ b/UefiCpuPkg/Library/MpInitLib/MpLib.h
@@ -34,6 +34,7 @@
 #include <Library/PcdLib.h>
 #include <Library/MicrocodeLib.h>
 #include <Library/CpuPageTableLib.h>
+#include <Library/SafeIntLib.h>
 #include <ConfidentialComputingGuestAttr.h>
 
 #include <Register/Amd/SevSnpMsr.h>

--- a/UefiCpuPkg/Library/MpInitLib/PeiMpInitLib.inf
+++ b/UefiCpuPkg/Library/MpInitLib/PeiMpInitLib.inf
@@ -62,6 +62,7 @@
 
 [LibraryClasses.IA32, LibraryClasses.X64]
   AmdSvsmLib
+  SafeIntLib
   CcExitLib
   LocalApicLib
   MicrocodeLib

--- a/UefiCpuPkg/Library/MpInitLib/PeiMpLib.c
+++ b/UefiCpuPkg/Library/MpInitLib/PeiMpLib.c
@@ -230,7 +230,7 @@ GetWakeupBuffer (
           WakeupBufferEnd = BASE_1MB;
         }
 
-        while (WakeupBufferEnd > WakeupBufferSize) {
+        while (WakeupBufferEnd > (UINT64)WakeupBufferSize) {
           //
           // Wakeup buffer should be aligned on 4KB
           //

--- a/UefiCpuPkg/Library/MtrrLib/MtrrLib.c
+++ b/UefiCpuPkg/Library/MtrrLib/MtrrLib.c
@@ -1703,8 +1703,8 @@ MtrrLibCalculateMtrrs (
   }
 
   for (TypeCount = 2; TypeCount <= 3; TypeCount++) {
-    for (Start = 0; Start < VertexCount; Start++) {
-      for (Stop = Start + 2; Stop < VertexCount; Stop++) {
+    for (Start = 0; (UINT32)Start < VertexCount; Start++) {
+      for (Stop = Start + 2; (UINT32)Stop < VertexCount; Stop++) {
         ASSERT (Vertices[Stop].Address > Vertices[Start].Address);
         Length = Vertices[Stop].Address - Vertices[Start].Address;
         if (Length > Vertices[Start].Alignment) {
@@ -2139,13 +2139,13 @@ MtrrLibSetMemoryRanges (
   //
   BiggestScratchSize = 0;
 
-  for (Index = 0; Index < RangeCount;) {
+  for (Index = 0; (UINTN)Index < RangeCount;) {
     Base0 = Ranges[Index].BaseAddress;
 
     //
     // Full step is optimal
     //
-    while (Index < RangeCount) {
+    while ((UINTN)Index < RangeCount) {
       ASSERT (Ranges[Index].BaseAddress == Base0);
       Alignment = MtrrLibBiggestAlignment (Base0, A0);
       while (Base0 + Alignment <= Ranges[Index].BaseAddress + Ranges[Index].Length) {
@@ -2193,7 +2193,7 @@ MtrrLibSetMemoryRanges (
     CompatibleTypes = MtrrLibGetCompatibleTypes (&Ranges[Index], RangeCount - Index);
 
     End = Index; // End points to last one that matches the CompatibleTypes.
-    while (End + 1 < RangeCount) {
+    while ((UINTN)(End + 1) < RangeCount) {
       if (((1 << Ranges[End + 1].Type) & CompatibleTypes) == 0) {
         break;
       }
@@ -2209,7 +2209,7 @@ MtrrLibSetMemoryRanges (
     // Base1 may not in Ranges[End]. Update End to the range Base1 belongs to.
     //
     End = Index;
-    while (End + 1 < RangeCount) {
+    while ((UINTN)(End + 1) < RangeCount) {
       if (Base1 <= Ranges[End + 1].BaseAddress) {
         break;
       }

--- a/UefiCpuPkg/Library/RegisterCpuFeaturesLib/CpuFeaturesInitialize.c
+++ b/UefiCpuPkg/Library/RegisterCpuFeaturesLib/CpuFeaturesInitialize.c
@@ -95,6 +95,7 @@ CpuInitDataInitialize (
   EFI_STATUS                 Status;
   UINTN                      ProcessorNumber;
   EFI_PROCESSOR_INFORMATION  ProcessorInfoBuffer;
+  CPU_STATUS_INFORMATION     CpuStatusBackupBuffer;
   CPU_FEATURES_ENTRY         *CpuFeature;
   CPU_FEATURES_INIT_ORDER    *InitOrder;
   CPU_FEATURES_DATA          *CpuFeaturesData;
@@ -120,7 +121,19 @@ CpuInitDataInitialize (
   Package = 0;
   Thread  = 0;
 
+  CpuFeaturesData       = NULL;
+  CpuStatus             = NULL;
+  FirstCore             = NULL;
+  InitOrder             = NULL;
+  Location              = NULL;
+  ThreadCountPerCore    = NULL;
+  ThreadCountPerPackage = NULL;
+
   CpuFeaturesData = GetCpuFeaturesData ();
+  if (CpuFeaturesData == NULL) {
+    ASSERT (CpuFeaturesData != NULL);
+    return;
+  }
 
   //
   // Initialize CpuFeaturesData->MpService as early as possile, so later function can use it.
@@ -130,7 +143,11 @@ CpuInitDataInitialize (
   GetNumberOfProcessor (&NumberOfCpus, &NumberOfEnabledProcessors);
 
   CpuFeaturesData->InitOrder = AllocatePages (EFI_SIZE_TO_PAGES (sizeof (CPU_FEATURES_INIT_ORDER) * NumberOfCpus));
-  ASSERT (CpuFeaturesData->InitOrder != NULL);
+  if (CpuFeaturesData->InitOrder == NULL) {
+    ASSERT (CpuFeaturesData->InitOrder != NULL);
+    return;
+  }
+
   ZeroMem (CpuFeaturesData->InitOrder, sizeof (CPU_FEATURES_INIT_ORDER) * NumberOfCpus);
 
   //
@@ -150,19 +167,32 @@ CpuInitDataInitialize (
   CpuFeaturesData->NumberOfCpus = (UINT32)NumberOfCpus;
 
   AcpiCpuData = GetAcpiCpuData ();
-  ASSERT (AcpiCpuData != NULL);
+  if (AcpiCpuData == NULL) {
+    ASSERT (AcpiCpuData != NULL);
+    goto ExitOnError;
+  }
+
   CpuFeaturesData->AcpiCpuData = AcpiCpuData;
 
   CpuStatus = &AcpiCpuData->CpuFeatureInitData.CpuStatus;
-  Location  = AllocatePages (EFI_SIZE_TO_PAGES (sizeof (EFI_CPU_PHYSICAL_LOCATION) * NumberOfCpus));
-  ASSERT (Location != NULL);
+  CopyMem (&CpuStatusBackupBuffer, CpuStatus, sizeof (CpuStatusBackupBuffer));
+  Location = AllocatePages (EFI_SIZE_TO_PAGES (sizeof (EFI_CPU_PHYSICAL_LOCATION) * NumberOfCpus));
+  if (Location == NULL) {
+    ASSERT (Location != NULL);
+    goto ExitOnError;
+  }
+
   ZeroMem (Location, sizeof (EFI_CPU_PHYSICAL_LOCATION) * NumberOfCpus);
   AcpiCpuData->CpuFeatureInitData.ApLocation = (EFI_PHYSICAL_ADDRESS)(UINTN)Location;
 
   for (ProcessorNumber = 0; ProcessorNumber < NumberOfCpus; ProcessorNumber++) {
     InitOrder                        = &CpuFeaturesData->InitOrder[ProcessorNumber];
     InitOrder->FeaturesSupportedMask = AllocateZeroPool (CpuFeaturesData->BitMaskSize);
-    ASSERT (InitOrder->FeaturesSupportedMask != NULL);
+    if (InitOrder->FeaturesSupportedMask == NULL) {
+      ASSERT (InitOrder->FeaturesSupportedMask != NULL);
+      goto ExitOnError;
+    }
+
     InitializeListHead (&InitOrder->OrderList);
     Status = GetProcessorInformation (ProcessorNumber, &ProcessorInfoBuffer);
     ASSERT_EFI_ERROR (Status);
@@ -214,12 +244,20 @@ CpuInitDataInitialize (
   // Collect valid core count in each package because not all cores are valid.
   //
   ThreadCountPerPackage = AllocatePages (EFI_SIZE_TO_PAGES (sizeof (UINT32) * CpuStatus->PackageCount));
-  ASSERT (ThreadCountPerPackage != NULL);
+  if (ThreadCountPerPackage == NULL) {
+    ASSERT (ThreadCountPerPackage != NULL);
+    goto ExitOnError;
+  }
+
   ZeroMem (ThreadCountPerPackage, sizeof (UINT32) * CpuStatus->PackageCount);
   CpuStatus->ThreadCountPerPackage = (EFI_PHYSICAL_ADDRESS)(UINTN)ThreadCountPerPackage;
 
   ThreadCountPerCore = AllocatePages (EFI_SIZE_TO_PAGES (sizeof (UINT8) * CpuStatus->PackageCount * CpuStatus->MaxCoreCount));
-  ASSERT (ThreadCountPerCore != NULL);
+  if (ThreadCountPerCore == NULL) {
+    ASSERT (ThreadCountPerCore != NULL);
+    goto ExitOnError;
+  }
+
   ZeroMem (ThreadCountPerCore, sizeof (UINT8) * CpuStatus->PackageCount * CpuStatus->MaxCoreCount);
   CpuStatus->ThreadCountPerCore = (EFI_PHYSICAL_ADDRESS)(UINTN)ThreadCountPerCore;
 
@@ -247,9 +285,16 @@ CpuInitDataInitialize (
   }
 
   CpuFeaturesData->CpuFlags.CoreSemaphoreCount = AllocateZeroPool (sizeof (UINT32) * CpuStatus->PackageCount * CpuStatus->MaxCoreCount * CpuStatus->MaxThreadCount);
-  ASSERT (CpuFeaturesData->CpuFlags.CoreSemaphoreCount != NULL);
+  if (CpuFeaturesData->CpuFlags.CoreSemaphoreCount == NULL) {
+    ASSERT (CpuFeaturesData->CpuFlags.CoreSemaphoreCount != NULL);
+    goto ExitOnError;
+  }
+
   CpuFeaturesData->CpuFlags.PackageSemaphoreCount = AllocateZeroPool (sizeof (UINT32) * CpuStatus->PackageCount * CpuStatus->MaxCoreCount * CpuStatus->MaxThreadCount);
-  ASSERT (CpuFeaturesData->CpuFlags.PackageSemaphoreCount != NULL);
+  if (CpuFeaturesData->CpuFlags.PackageSemaphoreCount == NULL) {
+    ASSERT (CpuFeaturesData->CpuFlags.PackageSemaphoreCount != NULL);
+    goto ExitOnError;
+  }
 
   //
   // Initialize CpuFeaturesData->InitOrder[].CpuInfo.First
@@ -257,7 +302,11 @@ CpuInitDataInitialize (
   //
   Pages     = EFI_SIZE_TO_PAGES (CpuStatus->PackageCount * sizeof (UINT32) + CpuStatus->PackageCount * CpuStatus->MaxCoreCount * sizeof (UINT32));
   FirstCore = AllocatePages (Pages);
-  ASSERT (FirstCore != NULL);
+  if (FirstCore == NULL) {
+    ASSERT (FirstCore != NULL);
+    goto ExitOnError;
+  }
+
   FirstThread = FirstCore + CpuStatus->PackageCount;
 
   //
@@ -317,6 +366,60 @@ CpuInitDataInitialize (
   }
 
   FreePages (FirstCore, Pages);
+
+  return;
+
+ExitOnError:
+  if (FirstCore != NULL) {
+    FreePages (FirstCore, Pages);
+  }
+
+  if ((CpuFeaturesData != NULL) && (CpuFeaturesData->CpuFlags.PackageSemaphoreCount != NULL)) {
+    FreePool ((VOID *)CpuFeaturesData->CpuFlags.PackageSemaphoreCount);
+    CpuFeaturesData->CpuFlags.PackageSemaphoreCount = NULL;
+  }
+
+  if ((CpuFeaturesData != NULL) && (CpuFeaturesData->CpuFlags.CoreSemaphoreCount != NULL)) {
+    FreePool ((VOID *)CpuFeaturesData->CpuFlags.CoreSemaphoreCount);
+    CpuFeaturesData->CpuFlags.CoreSemaphoreCount = NULL;
+  }
+
+  if ((ThreadCountPerCore != NULL) && (CpuStatus != NULL)) {
+    FreePages (
+      ThreadCountPerCore,
+      EFI_SIZE_TO_PAGES (sizeof (UINT8) * CpuStatus->PackageCount * CpuStatus->MaxCoreCount)
+      );
+  }
+
+  if ((ThreadCountPerPackage != NULL) && (CpuStatus != NULL)) {
+    FreePages (
+      ThreadCountPerPackage,
+      EFI_SIZE_TO_PAGES (sizeof (UINT32) * CpuStatus->PackageCount)
+      );
+  }
+
+  if (InitOrder != NULL) {
+    for (ProcessorNumber = 0; ProcessorNumber < NumberOfCpus; ProcessorNumber++) {
+      InitOrder = &CpuFeaturesData->InitOrder[ProcessorNumber];
+      if (InitOrder->FeaturesSupportedMask != NULL) {
+        FreePool (InitOrder->FeaturesSupportedMask);
+        InitOrder->FeaturesSupportedMask = NULL;
+      }
+    }
+  }
+
+  if (Location != NULL) {
+    FreePages (Location, EFI_SIZE_TO_PAGES (sizeof (EFI_CPU_PHYSICAL_LOCATION) * NumberOfCpus));
+  }
+
+  if (CpuFeaturesData->InitOrder != NULL) {
+    FreePages (CpuFeaturesData->InitOrder, EFI_SIZE_TO_PAGES (sizeof (CPU_FEATURES_INIT_ORDER) * NumberOfCpus));
+    CpuFeaturesData->InitOrder = NULL;
+  }
+
+  if (CpuStatus != NULL) {
+    CopyMem (CpuStatus, &CpuStatusBackupBuffer, sizeof (*CpuStatus));
+  }
 }
 
 /**

--- a/UefiCpuPkg/PiSmmCpuDxeSmm/MpService.c
+++ b/UefiCpuPkg/PiSmmCpuDxeSmm/MpService.c
@@ -1006,10 +1006,17 @@ AllocateTokenBuffer (
   // Separate the Spin_lock and Proc_token because the alignment requires by Spin_Lock.
   //
   SpinLockBuffer = AllocatePool (SpinLockSize * TokenCountPerChunk);
-  ASSERT (SpinLockBuffer != NULL);
+  if (SpinLockBuffer == NULL) {
+    ASSERT (SpinLockBuffer != NULL);
+    return NULL;
+  }
 
   ProcTokens = AllocatePool (sizeof (PROCEDURE_TOKEN) * TokenCountPerChunk);
-  ASSERT (ProcTokens != NULL);
+  if (ProcTokens == NULL) {
+    ASSERT (ProcTokens != NULL);
+    FreePool (SpinLockBuffer);
+    return NULL;
+  }
 
   for (Index = 0; Index < TokenCountPerChunk; Index++) {
     SpinLock = (SPIN_LOCK *)(SpinLockBuffer + SpinLockSize * Index);
@@ -1820,7 +1827,11 @@ InitializeSmmCpuSemaphores (
   DEBUG ((DEBUG_INFO, "Total Semaphores Size = 0x%x\n", TotalSize));
   Pages          = EFI_SIZE_TO_PAGES (TotalSize);
   SemaphoreBlock = AllocatePages (Pages);
-  ASSERT (SemaphoreBlock != NULL);
+  if (SemaphoreBlock == NULL) {
+    ASSERT (SemaphoreBlock != NULL);
+    return;
+  }
+
   ZeroMem (SemaphoreBlock, TotalSize);
 
   SemaphoreAddr                                   = (UINTN)SemaphoreBlock;

--- a/UefiCpuPkg/PiSmmCpuDxeSmm/PiSmmCpuDxeSmm.c
+++ b/UefiCpuPkg/PiSmmCpuDxeSmm/PiSmmCpuDxeSmm.c
@@ -136,7 +136,11 @@ GetSmiCommandPort (
   Fadt = (EFI_ACPI_2_0_FIXED_ACPI_DESCRIPTION_TABLE *)EfiLocateFirstAcpiTable (
                                                         EFI_ACPI_2_0_FIXED_ACPI_DESCRIPTION_TABLE_SIGNATURE
                                                         );
-  ASSERT (Fadt != NULL);
+
+  if (Fadt == NULL) {
+    ASSERT (Fadt != NULL);
+    return;
+  }
 
   mSmiCommandPort = Fadt->SmiCmd;
   DEBUG ((DEBUG_INFO, "mSmiCommandPort = %x\n", mSmiCommandPort));

--- a/UefiCpuPkg/PiSmmCpuDxeSmm/X64/SmmFuncsArch.c
+++ b/UefiCpuPkg/PiSmmCpuDxeSmm/X64/SmmFuncsArch.c
@@ -118,7 +118,7 @@ GetProtectedModeCS (
   AsmReadGdtr (&GdtrDesc);
   GdtEntryCount = (GdtrDesc.Limit + 1) / sizeof (IA32_SEGMENT_DESCRIPTOR);
   GdtEntry      = (IA32_SEGMENT_DESCRIPTOR *)GdtrDesc.Base;
-  for (Index = 0; Index < GdtEntryCount; Index++) {
+  for (Index = 0; (UINTN)Index < GdtEntryCount; Index++) {
     if (GdtEntry->Bits.L == 0) {
       if ((GdtEntry->Bits.Type > 8) && (GdtEntry->Bits.DB == 1)) {
         break;

--- a/UefiCpuPkg/UefiCpuPkg.dsc
+++ b/UefiCpuPkg/UefiCpuPkg.dsc
@@ -27,6 +27,7 @@
 [LibraryClasses]
   BaseLib|MdePkg/Library/BaseLib/BaseLib.inf
   BaseMemoryLib|MdePkg/Library/BaseMemoryLib/BaseMemoryLib.inf
+  SafeIntLib|MdePkg/Library/BaseSafeIntLib/BaseSafeIntLib.inf
   CpuLib|MdePkg/Library/BaseCpuLib/BaseCpuLib.inf
   DebugLib|MdePkg/Library/BaseDebugLibNull/BaseDebugLibNull.inf
   SerialPortLib|MdePkg/Library/BaseSerialPortLibNull/BaseSerialPortLibNull.inf


### PR DESCRIPTION
# Description

Clone of PR #6397 to address issue with merging

Resolves several issues in UefiCpuPkg related to:

1. Unchecked returns leading to potential NULL or uninitialized access.
2. Potential unchecked integer overflows.
3. Incorrect comparison between integers of different sizes.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Shipped in platforms with Project Mu.

## Integration Instructions

N/A
