### PR TITLE
MdeModulePkg/HiiDatabase: Return default value for BIT VarStore as UN…

### DIFF
--- a/MdeModulePkg/Universal/HiiDatabaseDxe/Database.c
+++ b/MdeModulePkg/Universal/HiiDatabaseDxe/Database.c
@@ -825,7 +825,7 @@ FindQuestionDefaultSetting (
       if (BitFieldQuestion) {
         CopyMem (&BufferValue, (UINT8 *)AuthVariableHeader + sizeof (AUTHENTICATED_VARIABLE_HEADER) + AuthVariableHeader->NameSize + ByteOffset, Width);
         BitFieldVal = BitFieldRead32 (BufferValue, StartBit, EndBit);
-        CopyMem (ValueBuffer, &BitFieldVal, Width);
+        CopyMem (ValueBuffer, &BitFieldVal, sizeof (UINT32));
       } else {
         CopyMem (ValueBuffer, (UINT8 *)AuthVariableHeader + sizeof (AUTHENTICATED_VARIABLE_HEADER) + AuthVariableHeader->NameSize + IfrQuestionHdr->VarStoreInfo.VarOffset, Width);
       }
@@ -862,7 +862,7 @@ FindQuestionDefaultSetting (
       if (BitFieldQuestion) {
         CopyMem (&BufferValue, (UINT8 *)VariableHeader + sizeof (VARIABLE_HEADER) + VariableHeader->NameSize + ByteOffset, Width);
         BitFieldVal = BitFieldRead32 (BufferValue, StartBit, EndBit);
-        CopyMem (ValueBuffer, &BitFieldVal, Width);
+        CopyMem (ValueBuffer, &BitFieldVal, sizeof (UINT32));
       } else {
         CopyMem (ValueBuffer, (UINT8 *)VariableHeader + sizeof (VARIABLE_HEADER) + VariableHeader->NameSize + IfrQuestionHdr->VarStoreInfo.VarOffset, Width);
       }


### PR DESCRIPTION
…IT32

REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4874

Question CheckBox, OneOf and Numeric can refer to Bit EFI VarStore CheckBox: data type is Boolean (1 byte)
Numeric/Oneof: data type is always UNIT32 for BIT VarStore When get default value for BIT VarStore, should return default value with sizeof (UINT32) rather than the byte the bit width occupied. Or incorrect default value will be used due to the size mismatch.

# Description

<_Include a description of the change and why this change was made._>

<_For each item, place an "x" in between `[` and `]` if true. Example: `[x]` (you can also check items in GitHub UI)_>

<_Create the PR as a Draft PR if it is only created to run CI checks._>

<_Delete lines in \<\> tags before creating the PR._>

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

<_Describe the test(s) that were run to verify the changes._>

## Integration Instructions

<_Describe how these changes should be integrated. Use N/A if nothing is required._>
