### PR TITLE
OvmfPkg/PlatformInitLib: enable x2apic mode if needed

### DIFF
--- a/OvmfPkg/Library/PlatformInitLib/Platform.c
+++ b/OvmfPkg/Library/PlatformInitLib/Platform.c
@@ -30,6 +30,7 @@
 #include <Library/QemuFwCfgS3Lib.h>
 #include <Library/QemuFwCfgSimpleParserLib.h>
 #include <Library/PciLib.h>
+#include <Library/LocalApicLib.h>
 #include <Guid/SystemNvDataGuid.h>
 #include <Guid/VariableFormat.h>
 #include <OvmfPlatforms.h>
@@ -719,6 +720,11 @@ PlatformMaxCpuCountInitialization (
     MaxCpuCount
     ));
   ASSERT (BootCpuCount <= MaxCpuCount);
+
+  if (MaxCpuCount > 255) {
+    DEBUG ((DEBUG_INFO, "%a: enable x2apic mode\n", __func__));
+    SetApicMode (LOCAL_APIC_MODE_X2APIC);
+  }
 
   PlatformInfoHob->PcdCpuMaxLogicalProcessorNumber  = MaxCpuCount;
   PlatformInfoHob->PcdCpuBootLogicalProcessorNumber = BootCpuCount;

--- a/OvmfPkg/Library/PlatformInitLib/PlatformInitLib.inf
+++ b/OvmfPkg/Library/PlatformInitLib/PlatformInitLib.inf
@@ -48,6 +48,7 @@
   HobLib
   QemuFwCfgLib
   QemuFwCfgSimpleParserLib
+  LocalApicLib
   MemEncryptSevLib
   MemoryAllocationLib
   MtrrLib


### PR DESCRIPTION
Enable x2apic mode in case the number of possible CPUs (including
hotplug-able CPus which are not (yet) online) is larger than 255.

Signed-off-by: Gerd Hoffmann <kraxel@redhat.com>
