### PR TITLE
Remove TPM use of C++ Reserved Keywords

### DIFF
--- a/MdePkg/Include/IndustryStandard/Tpm12.h
+++ b/MdePkg/Include/IndustryStandard/Tpm12.h
@@ -10,6 +10,14 @@
 #define _TPM12_H_
 
 ///
+/// Temporary disable 4201 to support anonymous unions
+///
+#if defined (_MSC_EXTENSIONS)
+#pragma warning( push )
+#pragma warning ( disable : 4201 )
+#endif
+
+///
 /// The start of TPM return codes
 ///
 #define TPM_BASE  0
@@ -744,8 +752,11 @@ typedef struct tdTPM_PERMANENT_FLAGS {
   BOOLEAN              TPMpost;
   BOOLEAN              TPMpostLock;
   BOOLEAN              FIPS;
-  BOOLEAN                           operator;
-  BOOLEAN                           enableRevokeEK;
+  union {
+    BOOLEAN            operator;
+    BOOLEAN            operator_;
+  };
+  BOOLEAN              enableRevokeEK;
   BOOLEAN              nvLocked;
   BOOLEAN              readSRKPub;
   BOOLEAN              tpmEstablished;
@@ -2161,5 +2172,12 @@ typedef struct tdTPM_RSP_COMMAND_HDR {
 } TPM_RSP_COMMAND_HDR;
 
 #pragma pack ()
+
+///
+/// Temporary disable 4201 to support anonymous unions
+///
+#if defined (_MSC_EXTENSIONS)
+#pragma warning( pop )
+#endif
 
 #endif

--- a/MdePkg/Include/IndustryStandard/Tpm12.h
+++ b/MdePkg/Include/IndustryStandard/Tpm12.h
@@ -10,14 +10,6 @@
 #define _TPM12_H_
 
 ///
-/// Temporary disable 4201 to support anonymous unions
-///
-#if defined (_MSC_EXTENSIONS)
-#pragma warning( push )
-#pragma warning ( disable : 4201 )
-#endif
-
-///
 /// The start of TPM return codes
 ///
 #define TPM_BASE  0
@@ -752,10 +744,7 @@ typedef struct tdTPM_PERMANENT_FLAGS {
   BOOLEAN              TPMpost;
   BOOLEAN              TPMpostLock;
   BOOLEAN              FIPS;
-  union {
-    BOOLEAN            operator;
-    BOOLEAN            operator_;
-  };
+  BOOLEAN              operator_;
   BOOLEAN              enableRevokeEK;
   BOOLEAN              nvLocked;
   BOOLEAN              readSRKPub;
@@ -2172,12 +2161,5 @@ typedef struct tdTPM_RSP_COMMAND_HDR {
 } TPM_RSP_COMMAND_HDR;
 
 #pragma pack ()
-
-///
-/// Temporary disable 4201 to support anonymous unions
-///
-#if defined (_MSC_EXTENSIONS)
-#pragma warning( pop )
-#endif
 
 #endif

--- a/MdePkg/Include/IndustryStandard/Tpm20.h
+++ b/MdePkg/Include/IndustryStandard/Tpm20.h
@@ -15,6 +15,14 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #include <IndustryStandard/Tpm12.h>
 
+///
+/// Temporary disable 4201 to support anonymous unions
+///
+#if defined (_MSC_EXTENSIONS)
+#pragma warning( push )
+#pragma warning ( disable : 4201 )
+#endif
+
 #pragma pack (1)
 
 // Annex A Algorithm Constants
@@ -1248,7 +1256,10 @@ typedef union {
   TPMI_AES_KEY_BITS    aes;
   TPMI_SM4_KEY_BITS    SM4;
   TPM_KEY_BITS         sym;
-  TPMI_ALG_HASH     xor;
+  union {
+    TPMI_ALG_HASH      xor;
+    TPMI_ALG_HASH      xor_;
+  };
 } TPMU_SYM_KEY_BITS;
 
 // Table 123 - TPMU_SYM_MODE Union
@@ -1321,7 +1332,10 @@ typedef struct {
 // Table 136 - TPMU_SCHEME_KEYEDHASH Union
 typedef union {
   TPMS_SCHEME_HMAC    hmac;
-  TPMS_SCHEME_XOR  xor;
+  union {
+    TPMS_SCHEME_XOR   xor;
+    TPMS_SCHEME_XOR   xor_;
+  };
 } TPMU_SCHEME_KEYEDHASH;
 
 // Table 137 - TPMT_KEYEDHASH_SCHEME Structure
@@ -1809,5 +1823,12 @@ typedef struct {
 #define HASH_ALG_SHA384   0x00000004
 #define HASH_ALG_SHA512   0x00000008
 #define HASH_ALG_SM3_256  0x00000010
+
+///
+/// Temporary disable 4201 to support anonymous unions
+///
+#if defined (_MSC_EXTENSIONS)
+#pragma warning( pop )
+#endif
 
 #endif

--- a/MdePkg/Include/IndustryStandard/Tpm20.h
+++ b/MdePkg/Include/IndustryStandard/Tpm20.h
@@ -15,14 +15,6 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #include <IndustryStandard/Tpm12.h>
 
-///
-/// Temporary disable 4201 to support anonymous unions
-///
-#if defined (_MSC_EXTENSIONS)
-#pragma warning( push )
-#pragma warning ( disable : 4201 )
-#endif
-
 #pragma pack (1)
 
 // Annex A Algorithm Constants
@@ -1256,10 +1248,7 @@ typedef union {
   TPMI_AES_KEY_BITS    aes;
   TPMI_SM4_KEY_BITS    SM4;
   TPM_KEY_BITS         sym;
-  union {
-    TPMI_ALG_HASH      xor;
-    TPMI_ALG_HASH      xor_;
-  };
+  TPMI_ALG_HASH        xor_;
 } TPMU_SYM_KEY_BITS;
 
 // Table 123 - TPMU_SYM_MODE Union
@@ -1332,10 +1321,7 @@ typedef struct {
 // Table 136 - TPMU_SCHEME_KEYEDHASH Union
 typedef union {
   TPMS_SCHEME_HMAC    hmac;
-  union {
-    TPMS_SCHEME_XOR   xor;
-    TPMS_SCHEME_XOR   xor_;
-  };
+  TPMS_SCHEME_XOR     xor_;
 } TPMU_SCHEME_KEYEDHASH;
 
 // Table 137 - TPMT_KEYEDHASH_SCHEME Structure
@@ -1823,12 +1809,5 @@ typedef struct {
 #define HASH_ALG_SHA384   0x00000004
 #define HASH_ALG_SHA512   0x00000008
 #define HASH_ALG_SM3_256  0x00000010
-
-///
-/// Temporary disable 4201 to support anonymous unions
-///
-#if defined (_MSC_EXTENSIONS)
-#pragma warning( pop )
-#endif
 
 #endif

--- a/SecurityPkg/Library/Tpm2CommandLib/Tpm2Capability.c
+++ b/SecurityPkg/Library/Tpm2CommandLib/Tpm2Capability.c
@@ -734,9 +734,9 @@ Tpm2TestParms (
           Buffer += sizeof (UINT16);
           break;
         case TPM_ALG_XOR:
-          WriteUnaligned16 ((UINT16 *)Buffer, SwapBytes16 (Parameters->parameters.keyedHashDetail.scheme.details.xor.hashAlg));
+          WriteUnaligned16 ((UINT16 *)Buffer, SwapBytes16 (Parameters->parameters.keyedHashDetail.scheme.details.xor_.hashAlg));
           Buffer += sizeof (UINT16);
-          WriteUnaligned16 ((UINT16 *)Buffer, SwapBytes16 (Parameters->parameters.keyedHashDetail.scheme.details.xor.kdf));
+          WriteUnaligned16 ((UINT16 *)Buffer, SwapBytes16 (Parameters->parameters.keyedHashDetail.scheme.details.xor_.kdf));
           Buffer += sizeof (UINT16);
           break;
         default:
@@ -761,7 +761,7 @@ Tpm2TestParms (
           Buffer += sizeof (UINT16);
           break;
         case TPM_ALG_XOR:
-          WriteUnaligned16 ((UINT16 *)Buffer, SwapBytes16 (Parameters->parameters.symDetail.keyBits.xor));
+          WriteUnaligned16 ((UINT16 *)Buffer, SwapBytes16 (Parameters->parameters.symDetail.keyBits.xor_));
           Buffer += sizeof (UINT16);
           break;
         case TPM_ALG_NULL:

--- a/SecurityPkg/Library/Tpm2CommandLib/Tpm2Object.c
+++ b/SecurityPkg/Library/Tpm2CommandLib/Tpm2Object.c
@@ -169,10 +169,10 @@ Tpm2ReadPublic (
           Buffer                                                                      += sizeof (UINT16);
           break;
         case TPM_ALG_XOR:
-          OutPublic->publicArea.parameters.keyedHashDetail.scheme.details.xor.hashAlg = SwapBytes16 (ReadUnaligned16 ((UINT16 *)Buffer));
-          Buffer                                                                     += sizeof (UINT16);
-          OutPublic->publicArea.parameters.keyedHashDetail.scheme.details.xor.kdf     = SwapBytes16 (ReadUnaligned16 ((UINT16 *)Buffer));
-          Buffer                                                                     += sizeof (UINT16);
+          OutPublic->publicArea.parameters.keyedHashDetail.scheme.details.xor_.hashAlg = SwapBytes16 (ReadUnaligned16 ((UINT16 *)Buffer));
+          Buffer                                                                      += sizeof (UINT16);
+          OutPublic->publicArea.parameters.keyedHashDetail.scheme.details.xor_.kdf     = SwapBytes16 (ReadUnaligned16 ((UINT16 *)Buffer));
+          Buffer                                                                      += sizeof (UINT16);
           break;
         default:
           return EFI_UNSUPPORTED;
@@ -196,8 +196,8 @@ Tpm2ReadPublic (
           Buffer                                                += sizeof (UINT16);
           break;
         case TPM_ALG_XOR:
-          OutPublic->publicArea.parameters.symDetail.keyBits.xor = SwapBytes16 (ReadUnaligned16 ((UINT16 *)Buffer));
-          Buffer                                                += sizeof (UINT16);
+          OutPublic->publicArea.parameters.symDetail.keyBits.xor_ = SwapBytes16 (ReadUnaligned16 ((UINT16 *)Buffer));
+          Buffer                                                 += sizeof (UINT16);
           break;
         case TPM_ALG_NULL:
           break;

--- a/SecurityPkg/Library/Tpm2CommandLib/Tpm2Session.c
+++ b/SecurityPkg/Library/Tpm2CommandLib/Tpm2Session.c
@@ -119,7 +119,7 @@ Tpm2StartAuthSession (
       Buffer += sizeof (UINT16);
       break;
     case TPM_ALG_XOR:
-      WriteUnaligned16 ((UINT16 *)Buffer, SwapBytes16 (Symmetric->keyBits.xor));
+      WriteUnaligned16 ((UINT16 *)Buffer, SwapBytes16 (Symmetric->keyBits.xor_));
       Buffer += sizeof (UINT16);
       break;
     default:


### PR DESCRIPTION
# Description

Update `Tpm12.h` and `Tpm20.h` to not use C++ reserved keywords `operator` and `xor` in C structures to support use of these include files when building with a C++ compiler.  Change to `operator_` and `xor_` to match other projects name adjustments for C++ compatibility.

Update `SecurityPkg` TPM related sources to use `operator_` and `xor_`.

- [x] Breaking change?

This is a non-backwards compatible change to `Tpm12.h` and `Tmp20.h`. Any consumers of these include files that access the `operator` or `xor` fields must be updated.

- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

## Integration Instructions
