### PR TITLE
ArmVirtPkg: PXE boot option build flag

### DIFF
--- a/ArmVirtPkg/ArmVirtQemu.dsc
+++ b/ArmVirtPkg/ArmVirtQemu.dsc
@@ -42,6 +42,7 @@
   DEFINE NETWORK_TLS_ENABLE              = FALSE
   DEFINE NETWORK_ALLOW_HTTP_CONNECTIONS  = TRUE
   DEFINE NETWORK_ISCSI_ENABLE            = FALSE
+  DEFINE NETWORK_PXE_BOOT_ENABLE         = TRUE
 
 !if $(NETWORK_SNP_ENABLE) == TRUE
   !error "NETWORK_SNP_ENABLE is IA32/X64/EBC only"
@@ -496,10 +497,12 @@
   #
 !include NetworkPkg/NetworkComponents.dsc.inc
 
+!if $(NETWORK_PXE_BOOT_ENABLE) == TRUE
   NetworkPkg/UefiPxeBcDxe/UefiPxeBcDxe.inf {
     <LibraryClasses>
       NULL|OvmfPkg/Library/PxeBcPcdProducerLib/PxeBcPcdProducerLib.inf
   }
+!endif
 
 !if $(NETWORK_TLS_ENABLE) == TRUE
   NetworkPkg/TlsAuthConfigDxe/TlsAuthConfigDxe.inf {

--- a/ArmVirtPkg/ArmVirtQemuKernel.dsc
+++ b/ArmVirtPkg/ArmVirtQemuKernel.dsc
@@ -39,6 +39,7 @@
   DEFINE NETWORK_TLS_ENABLE              = FALSE
   DEFINE NETWORK_ALLOW_HTTP_CONNECTIONS  = TRUE
   DEFINE NETWORK_ISCSI_ENABLE            = FALSE
+  DEFINE NETWORK_PXE_BOOT_ENABLE         = TRUE
 
 !if $(NETWORK_SNP_ENABLE) == TRUE
   !error "NETWORK_SNP_ENABLE is IA32/X64/EBC only"
@@ -406,10 +407,12 @@
   #
 !include NetworkPkg/NetworkComponents.dsc.inc
 
+!if $(NETWORK_PXE_BOOT_ENABLE) == TRUE
   NetworkPkg/UefiPxeBcDxe/UefiPxeBcDxe.inf {
     <LibraryClasses>
       NULL|OvmfPkg/Library/PxeBcPcdProducerLib/PxeBcPcdProducerLib.inf
   }
+!endif
 
 !if $(NETWORK_TLS_ENABLE) == TRUE
   NetworkPkg/TlsAuthConfigDxe/TlsAuthConfigDxe.inf {


### PR DESCRIPTION
# Description

The first step is to add an option to disable PXE loading. The patch is divided into 3 parts. This part adds the NETWORK_PXE_BOOT_ENABLE flag to the ArmVirtPkg module. At the current stage the flag is not functional.

- [x] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

```
build -a IA32 -a X64 -t GCC5 -p OvmfPkg/OvmfPkgIa32X64.dsc -DNETWORK_HTTP_BOOT_ENABLE=TRUE -DNETWORK_IP6_ENABLE=TRUE -DNETWORK_TLS_ENABLE -DSECURE_BOOT_ENABLE=TRUE -DBUILD_SHELL=FALSE -DTPM2_ENABLE=TRUE -DFD_SIZE_4MB -DSMM_REQUIRE=TRUE -b RELEASE -DNETWORK_PXE_BOOT_ENABLE=FALSE
find ./Build -name "*Pxe*"

stuart_build -c OvmfPkg/PlatformCI/PlatformBuild.py -a IA32,X64 TOOL_CHAIN_TAG=GCC5
stuart_ci_build -c .pytool/CISettings.py -a IA32,X64 TOOL_CHAIN_TAG=GCC5

GCC5_AARCH64_PREFIX=/usr/bin/aarch64-linux-gnu- stuart_build -c ArmVirtPkg/PlatformCI/QemuBuild.py -a AARCH64 TOOL_CHAIN_TAG=GCC5 TARGET=DEBUG
grep 'Pxe' /opt/edk2/Build/BUILDLOG_ArmVirtPkg.txt

GCC5_LOONGARCH64_PREFIX=/opt/loongson/cross-tools/bin/loongarch64-unknown-linux-gnu- stuart_build -c ./OvmfPkg/PlatformCI/QemuBuild.py -a LOONGARCH64 TOOL_CHAIN_TAG=GCC5 TARGET=DEBUG
grep 'Pxe' /opt/edk2/Build/BUILDLOG_OvmfPkg.txt
```

## Integration Instructions

N/A
