### PR TITLE
NetworkPkg: PXE boot option build flag

### DIFF
--- a/NetworkPkg/Network.fdf.inc
+++ b/NetworkPkg/Network.fdf.inc
@@ -39,7 +39,10 @@
   !endif
 
   INF  NetworkPkg/TcpDxe/TcpDxe.inf
-  INF  NetworkPkg/UefiPxeBcDxe/UefiPxeBcDxe.inf
+
+  !if $(NETWORK_PXE_BOOT_ENABLE) == TRUE
+    INF  NetworkPkg/UefiPxeBcDxe/UefiPxeBcDxe.inf
+  !endif
 
   !if $(NETWORK_TLS_ENABLE) == TRUE
     INF  NetworkPkg/TlsDxe/TlsDxe.inf

--- a/NetworkPkg/NetworkComponents.dsc.inc
+++ b/NetworkPkg/NetworkComponents.dsc.inc
@@ -41,7 +41,10 @@
   !endif
 
   NetworkPkg/TcpDxe/TcpDxe.inf
-  NetworkPkg/UefiPxeBcDxe/UefiPxeBcDxe.inf
+
+  !if $(NETWORK_PXE_BOOT_ENABLE) == TRUE
+    NetworkPkg/UefiPxeBcDxe/UefiPxeBcDxe.inf
+  !endif
 
   !if $(NETWORK_TLS_ENABLE) == TRUE
     NetworkPkg/TlsDxe/TlsDxe.inf

--- a/NetworkPkg/NetworkDefines.dsc.inc
+++ b/NetworkPkg/NetworkDefines.dsc.inc
@@ -21,6 +21,7 @@
 #   DEFINE NETWORK_ISCSI_ENABLE           = FALSE
 #   DEFINE NETWORK_ISCSI_MD5_ENABLE       = TRUE
 #   DEFINE NETWORK_VLAN_ENABLE            = TRUE
+#   DEFINE NETWORK_PXE_BOOT_ENABLE        = TRUE
 #
 # Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
 # (C) Copyright 2020 Hewlett Packard Enterprise Development LP<BR>
@@ -135,6 +136,13 @@
   #       several vendors' iSCSI targets only support MD5, for CHAP.
   #
   DEFINE NETWORK_ISCSI_MD5_ENABLE = TRUE
+!endif
+
+!ifndef NETWORK_PXE_BOOT_ENABLE
+  #
+  # This flag is to enable or disable PXE boot feature.
+  #
+  DEFINE NETWORK_PXE_BOOT_ENABLE = TRUE
 !endif
 
 !if $(NETWORK_ENABLE) == TRUE

--- a/NetworkPkg/NetworkDynamicPcds.dsc.inc
+++ b/NetworkPkg/NetworkDynamicPcds.dsc.inc
@@ -14,7 +14,7 @@
 #
 # IPv4 and IPv6 PXE Boot support.
 #
-!if $(NETWORK_ENABLE) == TRUE
+!if ($(NETWORK_ENABLE) == TRUE) AND ($(NETWORK_PXE_BOOT_ENABLE) == TRUE)
   gEfiNetworkPkgTokenSpaceGuid.PcdIPv4PXESupport|0x01
   gEfiNetworkPkgTokenSpaceGuid.PcdIPv6PXESupport|0x01
 !endif

--- a/NetworkPkg/NetworkPkg.ci.yaml
+++ b/NetworkPkg/NetworkPkg.ci.yaml
@@ -83,5 +83,6 @@
         "BLD_*_NETWORK_HTTP_ENABLE": "FALSE",
         "BLD_*_NETWORK_HTTP_BOOT_ENABLE": "TRUE",
         "BLD_*_NETWORK_ISCSI_ENABLE": "TRUE",
+        "BLD_*_NETWORK_PXE_BOOT_ENABLE": "TRUE",
     }
 }


### PR DESCRIPTION
# Description

Currently, the only way to disable PXE boot options is to change the PCD variables PcdIPv4PXESupport and PcdIPv6PXESupport in the source code or use the "--pcd" option in the build script. Other boot options such as HTTP or iSCSI can be disabled using the -D<option> flag. NETWORK_PXE_BOOT_ENABLE will add a consistent way to disable PXE booting.

- [x] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

```
build -a IA32 -a X64 -t GCC5 -p OvmfPkg/OvmfPkgIa32X64.dsc -DNETWORK_HTTP_BOOT_ENABLE=TRUE -DNETWORK_IP6_ENABLE=TRUE -DNETWORK_TLS_ENABLE -DSECURE_BOOT_ENABLE=TRUE -DBUILD_SHELL=FALSE -DTPM2_ENABLE=TRUE -DFD_SIZE_4MB -DSMM_REQUIRE=TRUE -b RELEASE -DNETWORK_PXE_BOOT_ENABLE=FALSE
find ./Build -name "*Pxe*"

stuart_build -c OvmfPkg/PlatformCI/PlatformBuild.py -a IA32,X64 TOOL_CHAIN_TAG=GCC5
stuart_ci_build -c .pytool/CISettings.py -a IA32,X64 TOOL_CHAIN_TAG=GCC5

GCC5_AARCH64_PREFIX=/usr/bin/aarch64-linux-gnu- stuart_build -c ArmVirtPkg/PlatformCI/QemuBuild.py -a AARCH64 TOOL_CHAIN_TAG=GCC5 TARGET=DEBUG
grep 'Pxe' /opt/edk2/Build/BUILDLOG_ArmVirtPkg.txt

GCC5_LOONGARCH64_PREFIX=/opt/loongson/cross-tools/bin/loongarch64-unknown-linux-gnu- stuart_build -c ./OvmfPkg/PlatformCI/QemuBuild.py -a LOONGARCH64 TOOL_CHAIN_TAG=GCC5 TARGET=DEBUG
grep 'Pxe' /opt/edk2/Build/BUILDLOG_OvmfPkg.txt
```

## Integration Instructions

N/A
