### PR TITLE
.github: Handle deleted GitHub accounts

### DIFF
--- a/.github/scripts/GitHub.py
+++ b/.github/scripts/GitHub.py
@@ -218,15 +218,17 @@ def add_reviewers_to_pr(
 
     # The current PR reviewers do not need to be requested again.
     current_pr_requested_reviewers = [
-        r.login.strip() for r in pr.get_review_requests()[0]
+        r.login.strip() for r in pr.get_review_requests()[0] if r
     ]
-    current_pr_reviewed_reviewers = [r.user.login.strip() for r in pr.get_reviews()]
+    current_pr_reviewed_reviewers = [
+        r.user.login.strip() for r in pr.get_reviews() if r and r.user
+    ]
     current_pr_reviewers = list(
         set(current_pr_requested_reviewers + current_pr_reviewed_reviewers)
     )
 
     # A user can only be added if they are a collaborator of the repository.
-    repo_collaborators = [c.login.strip() for c in repo_gh.get_collaborators()]
+    repo_collaborators = [c.login.strip() for c in repo_gh.get_collaborators() if c]
     non_collaborators = [u for u in user_names if u not in repo_collaborators]
 
     excluded_pr_reviewers = [pr_author] + current_pr_reviewers + non_collaborators
@@ -243,14 +245,15 @@ def add_reviewers_to_pr(
             # If a comment has already been made for these non-collaborators,
             # do not make another comment.
             if (
-                comment.user.login == "tianocore-assign-reviewers[bot]"
+                comment.user
+                and comment.user.login == "tianocore-assign-reviewers[bot]"
                 and "WARNING: Cannot add some reviewers" in comment.body
                 and all(u in comment.body for u in non_collaborators)
             ):
                 break
         else:
             repo_admins = [
-                a.login for a in repo_gh.get_collaborators(permission="admin")
+                a.login for a in repo_gh.get_collaborators(permission="admin") if a
             ]
 
             leave_pr_comment(


### PR DESCRIPTION
# Description

If a GitHub account has been deleted entirely, a `None` user will be returrned from the GitHub API. This change accounts for a `None` user when querying GitHub APIs for user information.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

- Verified flow locally against a PR with no reviewers. The `None` user is ignored as expected.

## Integration Instructions

- N/A