### PR TITLE
UefiCpuPkg/CpuMmuLib: Adjust default memory attributes on LoongArch

### DIFF
--- a/UefiCpuPkg/Library/CpuMmuLib/LoongArch64/CpuMmu.c
+++ b/UefiCpuPkg/Library/CpuMmuLib/LoongArch64/CpuMmu.c
@@ -595,6 +595,7 @@ EfiAttributeConverse (
       LoongArchAttributes &= ~PAGE_DIRTY;
       break;
     default:
+      LoongArchAttributes |= CACHE_CC;
       break;
   }
 


### PR DESCRIPTION
When updating memory attributes, if only access attributes are changed, the default memory cache attribute is NULL and a CACHE_CC is added by default.

## How This Was Tested

By calling CpuSetMemoryAttributes and giving only EFI_MEMORY_XP, the default memory cache will have a CACHE_CC attribute.

## Integration Instructions

N/A
