### PR TITLE
BaseTools: Add ImageCapsuleSupport field to header

### DIFF
--- a/BaseTools/Source/Python/GenFds/CapsuleData.py
+++ b/BaseTools/Source/Python/GenFds/CapsuleData.py
@@ -200,7 +200,7 @@ class CapsulePayload(CapsuleData):
         # Fill structure
         #
         Guid = self.ImageTypeId.split('-')
-        Buffer = pack('=ILHHBBBBBBBBBBBBIIQ',
+        Buffer = pack('=ILHHBBBBBBBBBBBBIIQQ',
                        int(self.Version, 16),
                        int(Guid[0], 16),
                        int(Guid[1], 16),
@@ -219,7 +219,8 @@ class CapsulePayload(CapsuleData):
                        0,
                        ImageFileSize,
                        VendorFileSize,
-                       int(self.HardwareInstance, 16)
+                       int(self.HardwareInstance, 16),
+                       1
                        )
         if AuthData:
             Buffer += pack('QIHH', AuthData[0], AuthData[1], AuthData[2], AuthData[3])


### PR DESCRIPTION
# Description

I noticed when adding support for authenticated capsule updates that the code in GenFds was missing the last field from EFI_FIRMWARE_MANAGEMENT_CAPSULE_IMAGE_HEADER. I don't know if it makes any difference, but we should probably be including it.

**Note** Obviously this is a very basic implementation which isn't complete and probably shouldn't be merged.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Generated capsules and verified they installed correctly via FMP.

## Integration Instructions

N/A
