### PR TITLE
Pcd create shell boot option

### DIFF
--- a/ArmPkg/Library/PlatformBootManagerLib/PlatformBm.c
+++ b/ArmPkg/Library/PlatformBootManagerLib/PlatformBm.c
@@ -1059,9 +1059,11 @@ PlatformBootManagerAfterConsole (
   //
   // Register UEFI Shell
   //
-  Key.ScanCode    = SCAN_NULL;
-  Key.UnicodeChar = L's';
-  PlatformRegisterFvBootOption (&gUefiShellFileGuid, L"UEFI Shell", 0, &Key);
+  if (FixedPcdGetBool (PcdUefiShellCreateBootOption)) {
+    Key.ScanCode    = SCAN_NULL;
+    Key.UnicodeChar = L's';
+    PlatformRegisterFvBootOption (&gUefiShellFileGuid, L"UEFI Shell", 0, &Key);
+  }
 }
 
 /**

--- a/ArmPkg/Library/PlatformBootManagerLib/PlatformBootManagerLib.inf
+++ b/ArmPkg/Library/PlatformBootManagerLib/PlatformBootManagerLib.inf
@@ -58,6 +58,7 @@
 [FixedPcd]
   gArmTokenSpaceGuid.PcdUefiShellDefaultBootEnable
   gEfiMdeModulePkgTokenSpaceGuid.PcdFirmwareVersionString
+  gEfiMdeModulePkgTokenSpaceGuid.PcdUefiShellCreateBootOption
   gEfiMdePkgTokenSpaceGuid.PcdUartDefaultBaudRate
   gEfiMdePkgTokenSpaceGuid.PcdUartDefaultDataBits
   gEfiMdePkgTokenSpaceGuid.PcdUartDefaultParity

--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -1212,6 +1212,11 @@
   # @Prompt Defines the page allocation for the MM communication buffer; default is 128 pages (512KB).
   gEfiMdeModulePkgTokenSpaceGuid.PcdMmCommBufferPages|128|UINT32|0x30001061
 
+  ## Indicates if the Platform Boot Manager should add an entry for the UEFI Shell.
+  #  TRUE  - Boot Manager will add a Shell entry.<BR>
+  #  FALSE - Boot Manager will not add a Shell entry.<BR>
+  gEfiMdeModulePkgTokenSpaceGuid.PcdUefiShellCreateBootOption|TRUE|BOOLEAN|0x30001062
+
 [PcdsFixedAtBuild, PcdsPatchableInModule]
   ## Dynamic type PCD can be registered callback function for Pcd setting action.
   #  PcdMaxPeiPcdCallBackNumberPerPcdEntry indicates the maximum number of callback function
@@ -1684,7 +1689,7 @@
   #   TRUE  - Capsule On Disk is supported.<BR>
   #   FALSE - Capsule On Disk is not supported.<BR>
   #  If platform does not use this feature, this PCD should be set to FALSE.<BR><BR>
-  #  Two sulotions to deliver Capsule On Disk:<BR>
+  #  Two solutions to deliver Capsule On Disk:<BR>
   #    a) If PcdCapsuleInRamSupport = TRUE, Load Capsule On Disk image out of TCB, and reuse
   #       Capsule In Ram to deliver capsule.<BR>
   #    b) If PcdCapsuleInRamSupport = FALSE, Relocate Capsule On Disk image to RootDir out

--- a/OvmfPkg/Library/PlatformBootManagerLib/BdsPlatform.c
+++ b/OvmfPkg/Library/PlatformBootManagerLib/BdsPlatform.c
@@ -1837,11 +1837,13 @@ PlatformBootManagerAfterConsole (
   //
   // Register UEFI Shell
   //
-  PlatformRegisterFvBootOption (
-    &gUefiShellFileGuid,
-    L"EFI Internal Shell",
-    LOAD_OPTION_ACTIVE
-    );
+  if (FixedPcdGetBool (PcdUefiShellCreateBootOption)) {
+    PlatformRegisterFvBootOption (
+      &gUefiShellFileGuid,
+      L"EFI Internal Shell",
+      LOAD_OPTION_ACTIVE
+      );
+  }
 
   //
   // Register Grub

--- a/OvmfPkg/Library/PlatformBootManagerLib/PlatformBootManagerLib.inf
+++ b/OvmfPkg/Library/PlatformBootManagerLib/PlatformBootManagerLib.inf
@@ -63,6 +63,7 @@
   gUefiOvmfPkgTokenSpaceGuid.PcdOvmfHostBridgePciDevId
   gUefiOvmfPkgTokenSpaceGuid.PcdBootRestrictToFirmware
   gEfiMdeModulePkgTokenSpaceGuid.PcdAcpiS3Enable
+  gEfiMdeModulePkgTokenSpaceGuid.PcdUefiShellCreateBootOption
   gEfiMdePkgTokenSpaceGuid.PcdPlatformBootTimeOut
   gEfiMdePkgTokenSpaceGuid.PcdUartDefaultBaudRate         ## CONSUMES
   gEfiMdePkgTokenSpaceGuid.PcdUartDefaultDataBits         ## CONSUMES

--- a/OvmfPkg/Library/PlatformBootManagerLibLight/PlatformBm.c
+++ b/OvmfPkg/Library/PlatformBootManagerLibLight/PlatformBm.c
@@ -1227,11 +1227,13 @@ PlatformBootManagerAfterConsole (
   //
   // Register UEFI Shell
   //
-  PlatformRegisterFvBootOption (
-    &gUefiShellFileGuid,
-    L"EFI Internal Shell",
-    LOAD_OPTION_ACTIVE
-    );
+  if (FixedPcdGetBool (PcdUefiShellCreateBootOption)) {
+    PlatformRegisterFvBootOption (
+      &gUefiShellFileGuid,
+      L"EFI Internal Shell",
+      LOAD_OPTION_ACTIVE
+      );
+  }
 
   RemoveStaleFvFileOptions ();
   SetBootOrderFromQemu ();

--- a/OvmfPkg/Library/PlatformBootManagerLibLight/PlatformBootManagerLib.inf
+++ b/OvmfPkg/Library/PlatformBootManagerLibLight/PlatformBootManagerLib.inf
@@ -55,6 +55,7 @@
   UefiRuntimeServicesTableLib
 
 [FixedPcd]
+  gEfiMdeModulePkgTokenSpaceGuid.PcdUefiShellCreateBootOption
   gEfiMdePkgTokenSpaceGuid.PcdUartDefaultBaudRate
   gEfiMdePkgTokenSpaceGuid.PcdUartDefaultDataBits
   gEfiMdePkgTokenSpaceGuid.PcdUartDefaultParity

--- a/OvmfPkg/RiscVVirt/Library/PlatformBootManagerLib/PlatformBm.c
+++ b/OvmfPkg/RiscVVirt/Library/PlatformBootManagerLib/PlatformBm.c
@@ -965,11 +965,13 @@ PlatformBootManagerAfterConsole (
   //
   // Register UEFI Shell
   //
-  PlatformRegisterFvBootOption (
-    &gUefiShellFileGuid,
-    L"EFI Internal Shell",
-    LOAD_OPTION_ACTIVE
-    );
+  if (FixedPcdGetBool (PcdUefiShellCreateBootOption)) {
+    PlatformRegisterFvBootOption (
+      &gUefiShellFileGuid,
+      L"EFI Internal Shell",
+      LOAD_OPTION_ACTIVE
+      );
+  }
 
   RemoveStaleFvFileOptions ();
   SetBootOrderFromQemu ();

--- a/OvmfPkg/RiscVVirt/Library/PlatformBootManagerLib/PlatformBootManagerLib.inf
+++ b/OvmfPkg/RiscVVirt/Library/PlatformBootManagerLib/PlatformBootManagerLib.inf
@@ -52,6 +52,7 @@
   UefiRuntimeServicesTableLib
 
 [FixedPcd]
+  gEfiMdeModulePkgTokenSpaceGuid.PcdUefiShellCreateBootOption
   gEfiMdePkgTokenSpaceGuid.PcdUartDefaultBaudRate
   gEfiMdePkgTokenSpaceGuid.PcdUartDefaultDataBits
   gEfiMdePkgTokenSpaceGuid.PcdUartDefaultParity

--- a/UefiPayloadPkg/Library/PlatformBootManagerLib/PlatformBootManager.c
+++ b/UefiPayloadPkg/Library/PlatformBootManagerLib/PlatformBootManager.c
@@ -314,7 +314,9 @@ PlatformBootManagerAfterConsole (
   //
   // Register UEFI Shell
   //
-  PlatformRegisterFvBootOption (&gUefiShellFileGuid, L"UEFI Shell", LOAD_OPTION_ACTIVE);
+  if (FixedPcdGetBool (PcdUefiShellCreateBootOption)) {
+    PlatformRegisterFvBootOption (&gUefiShellFileGuid, L"UEFI Shell", LOAD_OPTION_ACTIVE);
+  }
 
   if (FixedPcdGetBool (PcdBootManagerEscape)) {
     Print (

--- a/UefiPayloadPkg/Library/PlatformBootManagerLib/PlatformBootManagerLib.inf
+++ b/UefiPayloadPkg/Library/PlatformBootManagerLib/PlatformBootManagerLib.inf
@@ -62,6 +62,9 @@
   gEfiSerialIoProtocolGuid
   gEfiPciRootBridgeIoProtocolGuid
 
+[FixedPcd]
+  gEfiMdeModulePkgTokenSpaceGuid.PcdUefiShellCreateBootOption
+
 [Pcd]
   gEfiMdePkgTokenSpaceGuid.PcdPlatformBootTimeOut
   gEfiMdePkgTokenSpaceGuid.PcdUgaConsumeSupport


### PR DESCRIPTION
# Description

Best practise for secure firmware is to omit the UEFI Shell from
builds, since it can be used to perform attacks. From
https://lvfs.readthedocs.io/en/latest/claims.html :
    
"Including the Shell.efi in a firmware update can create additional
supply chain security risks. From the UEFI shell it is very easy to
downgrade processor microcode or to abuse the existing update process.
It also makes attacking SMI handlers much easier, e.g. ThinkPwn.
    
The EFI shell allows direct RW access to memory using mm command, which
by itself defeats SecureBoot and everything else that’s security is
based on memory not being being attacker-controlled."
    
To allow platforms to more easily omit the shell, add a new PCD which
boot managers can use to skip creation of a boot entry for it. Without
this, the "UEFI Shell" entry is present but non-functional.

Also, update boot manager libraries in ArmPkg, OvmfPkg and UefiPayloadPkg to skip creation of the shell boot option if the PCD is set to FALSE.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Reflashed the entire SPI-NOR of my ADLINK Ampere Altra Dev Kit and verified the UEFI Shell boot option wasn't present when the PCD was set to FALSE.

## Integration Instructions

N/A
