### PR TITLE
SignedCapsulePkg: Allow hex FirmwareType values in ini files

### DIFF
--- a/SignedCapsulePkg/Universal/SystemFirmwareUpdate/ParseConfigProfile.c
+++ b/SignedCapsulePkg/Universal/SystemFirmwareUpdate/ParseConfigProfile.c
@@ -114,6 +114,15 @@ ParseUpdateDataFile (
                &Num
                );
     if (EFI_ERROR (Status)) {
+      Status = GetHexUintnFromDataFile (
+                 Context,
+                 SectionName,
+                 "FirmwareType",
+                 &Num
+                 );
+    }
+
+    if (EFI_ERROR (Status)) {
       CloseIniFile (Context);
       DEBUG ((DEBUG_ERROR, "[%d] FirmwareType not found\n", Index));
       return EFI_NOT_FOUND;


### PR DESCRIPTION
# Description

Some platforms such as Ampere Altra have special values for the FirmwareType field: for example 2147483649 is for SCP updates.

To make such values easier to read/understand, allow them to be written in hex: in this case it would be 0x80000001. Implement this by attempting to get a hex integer from the ini data file if reading a decimal value fails.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Write a SystemFirmwareUpdateConfig.ini file with a FirmwareType value of 0x80000002 and verified it was correctly read and interpreted when applying a capsule update.

## Integration Instructions

N/A
