### PR TITLE
SecurityPkg: Improve formatting of msg when GetVariable fails

### DIFF
--- a/SecurityPkg/Library/SecureBootVariableProvisionLib/SecureBootVariableProvisionLib.c
+++ b/SecurityPkg/Library/SecureBootVariableProvisionLib/SecureBootVariableProvisionLib.c
@@ -162,7 +162,7 @@ EnrollFromDefault (
   DataSize = 0;
   Status   = GetVariable2 (DefaultName, &gEfiGlobalVariableGuid, &Data, &DataSize);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "error: GetVariable (\"%s): %r\n", DefaultName, Status));
+    DEBUG ((DEBUG_ERROR, "Error: GetVariable (\"%s\"): %r\n", DefaultName, Status));
     return Status;
   }
 


### PR DESCRIPTION
# Description

Improve the formatting of the error message when GetVariable fails: start the message with an upper-case character, and close the quotes around the variable name.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Verified the error message was formatted better after the change.

## Integration Instructions

N/A
