### PR TITLE
MdeModulePkg/DxeCore: Call BeforeExitBootServices event group only once

### DIFF
--- a/MdeModulePkg/Core/Dxe/DxeMain/DxeMain.c
+++ b/MdeModulePkg/Core/Dxe/DxeMain/DxeMain.c
@@ -203,6 +203,8 @@ EFI_HANDLE            gDxeCoreImageHandle = NULL;
 
 BOOLEAN  gMemoryMapTerminated = FALSE;
 
+static BOOLEAN  mExitBootServicesCalled = FALSE;
+
 //
 // EFI Decompress Protocol
 //
@@ -778,7 +780,10 @@ CoreExitBootServices (
   // Notify other drivers of their last chance to use boot services
   // before the memory map is terminated.
   //
-  CoreNotifySignalList (&gEfiEventBeforeExitBootServicesGuid);
+  if (!mExitBootServicesCalled) {
+    CoreNotifySignalList (&gEfiEventBeforeExitBootServicesGuid);
+    mExitBootServicesCalled = TRUE;
+  }
 
   //
   // Disable Timer


### PR DESCRIPTION
According to UEFI spec 2.10 errata A section 7.4.6

  "All events from the EFI_EVENT_GROUP_BEFORE_EXIT_BOOT_SERVICES and
  EFI_EVENT_GROUP_EXIT_BOOT_SERVICES event notification groups as well
  as events of type EVT_SIGNAL_EXIT_BOOT_SERVICES must be signaled
  before ExitBootServices() returns EFI_SUCCESS. The events are only
  signaled once even if ExitBootServices() is called multiple times."

So keep track of whether ExitBootServices() has been called, and signal
the event group EFI_EVENT_GROUP_BEFORE_EXIT_BOOT_SERVICES only the first
time around.

EFI_EVENT_GROUP_EXIT_BOOT_SERVICES will only be signalled if
ExitBootServices() is going to run to [successful] completion, after
which calling it a second time is not possible anyway. So for this case,
no special handling is needed.