### PR TITLE
MdeModulePkg DriverHealthManagerDxe: Display HealthStatus as TextTwo of TextOpCode

### DIFF
--- a/MdeModulePkg/Universal/DriverHealthManagerDxe/DriverHealthManagerDxe.c
+++ b/MdeModulePkg/Universal/DriverHealthManagerDxe/DriverHealthManagerDxe.c
@@ -694,6 +694,7 @@ DriverHealthManagerUpdateForm (
   UINTN               Index;
   EFI_STRING_ID       Prompt;
   EFI_STRING_ID       Help;
+  EFI_STRING_ID       TextTwo;
   CHAR16              String[512];
   UINTN               StringCount;
   EFI_STRING          TmpString;
@@ -848,11 +849,12 @@ DriverHealthManagerUpdateForm (
           mDriverHealthManagerHealthInfo[Index].HealthStatus == EfiDriverHealthStatusHealthy ||
           mDriverHealthManagerHealthInfo[Index].HealthStatus == EfiDriverHealthStatusFailed
           );
+        TextTwo = Help;
         HiiCreateTextOpCode (
           StartOpCodeHandle,
           Prompt,
-          Help,
-          0
+          0,
+          TextTwo
           );
         break;
     }


### PR DESCRIPTION
# Description

When PcdBrowserGrayOutTextStatement is TRUE, TextOpCode will be GrayOut.

HealthStatus cannot be displayed in help area, always use TextTwo to display it.

This change will keep the same behavior(of display info) for different `PcdBrowserGrayOutTextStatement` config.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

1. Set PcdBrowserGrayOutTextStatement to TRUE, check DriverHealthManager form.
   --> Only Driver/Controller name can be displayed on the form, no HealthStatus info.(Picture1)
2. Apply this patch, then check DriverHealthManager form
   --> HealthStatus is displayed as TextTwo.(Picture2)
3. And if set PcdBrowserGrayOutTextStatement to FALSE. HealthStatus is alse displayed as TextTwo.(Picture3)

Picture1:
![Picture1](https://github.com/user-attachments/assets/5ab936c7-937e-4a7b-89ac-aa54a236d6e1)

Picture2:
![Picture2](https://github.com/user-attachments/assets/a59f621e-b65f-49bc-b1aa-3ebbc3308fc2)

Picture3:
![image](https://github.com/user-attachments/assets/8b0d4aeb-fad1-478c-8305-9036508f79d1)


## Integration Instructions

N/A
