### PR TITLE
Creates C-State, P-State and CPC objects under processor for X64 arch

### DIFF
--- a/DynamicTablesPkg/Include/AcpiObjects.h
+++ b/DynamicTablesPkg/Include/AcpiObjects.h
@@ -2,6 +2,7 @@
 
   Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.<BR>
   Copyright (c) 2022 - 2023, Arm Limited. All rights reserved.<BR>
+  Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
@@ -138,6 +139,113 @@ typedef struct AmlPsdInfo {
   /// Number of processors belonging to the Domain.
   UINT32    NumProc;
 } AML_PSD_INFO;
+
+/** A structure that describes a
+    processor power state control package Info.
+
+  Cf. ACPI 6.5, s8.4.1.1 _CST (Processor Power State Control).
+  Package {
+    Register  // Buffer (Resource Descriptor)
+    Type      // Integer (BYTE)
+    Latency   // Integer (WORD)
+    Power     // Integer (DWORD)
+  }
+*/
+typedef struct AmlCstInfo {
+  /// Information about the C-State register.
+  EFI_ACPI_6_5_GENERIC_ADDRESS_STRUCTURE    Register;
+
+  /// Type of C-State, such as c1, c2, c3, etc.
+  UINT8                                     Type;
+
+  /// Worst case latency for entering and exiting the C-State, in milliseconds.
+  UINT16                                    Latency;
+
+  /// C-State power consumption in mW.
+  UINT32                                    Power;
+} AML_CST_INFO;
+
+/** A structure that describes a
+    C-State Dependency (_CSD) Info.
+
+  Cf. ACPI 6.5, s8.4.1.2 _CSD (C-State Dependency).
+  Package {
+    NumEntries    // Integer, updated based on Revision
+    Revision      // Integer (BYTE)
+    Domain        // Integer (DWORD)
+    CoordType     // Integer (DWORD)
+    NumProcessors // Integer (DWORD)
+    Index         // Integer (DWORD)
+  }
+*/
+typedef struct AmlCsdInfo {
+  /// The revision of the C-State dependency table.
+  UINT8     Revision;
+
+  /// The domain ID.
+  UINT32    Domain;
+
+  /// The coordination type.
+  UINT32    CoordType;
+
+  /// The number of processors in the domain.
+  UINT32    NumProcessors;
+
+  /// The index of the C-State entry in _CST.
+  UINT32    Index;
+} AML_CSD_INFO;
+
+/** A structure that describes a
+    Processor Performance control (_PCT) Info.
+
+  Cf. ACPI 6.5, s8.4.5.1 _PCT (Processor Control).
+
+  Package
+  {
+    ControlRegister   // Buffer (Resource Descriptor (Register))
+    StatusRegister    // Buffer (Resource Descriptor (Register))
+  }
+*/
+typedef struct AmlPctInfo {
+  /// The performance control register for the processor.
+  EFI_ACPI_6_5_GENERIC_ADDRESS_STRUCTURE    ControlRegister;
+
+  /// The performance status register for the processor.
+  EFI_ACPI_6_5_GENERIC_ADDRESS_STRUCTURE    StatusRegister;
+} AML_PCT_INFO;
+
+/** A structure that describes a
+    Processor Supported Performance States (_PSS) Info.
+
+  Cf. ACPI 6.5, s8.4.5.2 _PSS (Processor Supported Performance States).
+  Package {
+    CoreFrequency     // Integer (DWORD)
+    Power             // Integer (DWORD)
+    Latency           // Integer (DWORD)
+    BusMasterLatency  // Integer (DWORD)
+    Control           // Integer (DWORD)
+    Status            // Integer (DWORD)
+  }
+*/
+typedef struct AmlPssInfo {
+  /// Processor core frequency in MHz.
+  UINT32    CoreFrequency;
+
+  /// Processor power consumption in mW.
+  UINT32    Power;
+
+  /// Processor latency in microseconds.
+  UINT32    Latency;
+
+  /// Processor bus master latency in microseconds.
+  UINT32    BusMasterLatency;
+
+  /// Value to write to the performance control register (_PCT).
+  UINT32    Control;
+
+  /// Value to compare with the read value performance status register (_PCT).
+  UINT32    Status;
+} AML_PSS_INFO;
 
 #pragma pack()
 

--- a/DynamicTablesPkg/Include/ArchCommonNameSpaceObjects.h
+++ b/DynamicTablesPkg/Include/ArchCommonNameSpaceObjects.h
@@ -2,7 +2,7 @@
 
   Copyright (c) 2024, Arm Limited. All rights reserved.<BR>
   Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.<BR>
-  Copyright (c) 2024 Advanced Micro Devices, Inc. All rights reserved.
+  Copyright (C) 2024 - 2025, Advanced Micro Devices, Inc. All rights reserved.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -53,6 +53,11 @@ typedef enum ArchCommonObjectID {
   EArchCommonObjTpm2InterfaceInfo,              ///< 26 - TPM Interface Info
   EArchCommonObjSpmiInterfaceInfo,              ///< 27 - SPMI Interface Info
   EArchCommonObjSpmiInterruptDeviceInfo,        ///< 28 - SPMI Interrupt and Device Info
+  EArchCommonObjCstInfo,                        ///< 29 - C-State Info
+  EArchCommonObjCsdInfo,                        ///< 30 - C-State Dependency (CSD) Info
+  EArchCommonObjPctInfo,                        ///< 31 - P-State control (PCT) Info
+  EArchCommonObjPssInfo,                        ///< 32 - P-State status (PSS) Info
+  EArchCommonObjPpcInfo,                        ///< 33 - P-State control (PPC) Info
   EArchCommonObjMax
 } EARCH_COMMON_OBJECT_ID;
 
@@ -728,6 +733,74 @@ typedef struct CmArchCommonObjSpmiInterruptDeviceInfo {
   /** Uid of the device */
   UINT32    DeviceId;
 } CM_ARCH_COMMON_SPMI_INTERRUPT_DEVICE_INFO;
+
+/** A structure that describes the Cst information.
+
+  Processor power state (C-state) is described in DSDT/SSDT and associated
+  to cpus/clusters in the cpu topology.
+
+  Unsupported Optional registers should be encoded with NULL resource
+  Register {(SystemMemory, 0, 0, 0, 0)}
+
+  For values that support Integer or Buffer, integer will be used
+  if buffer is NULL resource.
+  If resource is not NULL then Integer must be 0
+
+  Cf. ACPI 6.5, s8.4.1.1 _CST (C states)
+
+  ID: EArchCommonObjCstInfo
+*/
+typedef AML_CST_INFO CM_ARCH_COMMON_CST_INFO;
+
+/** A structure that describes the C-State Dependency (CSD) Info.
+
+    Cf. ACPI 6.5, s8.4.1.2 _CSD (C-State Dependency).
+
+    ID: EArchCommonObjCsdInfo
+*/
+typedef struct CmArchCommonObjCsdInfo {
+  /// The revision of the C-State dependency table.
+  UINT8              Revision;
+
+  /// The domain ID.
+  UINT32             Domain;
+
+  /// The coordination type.
+  UINT32             CoordType;
+
+  /// The number of processors in the domain.
+  UINT32             NumProcessors;
+
+  /// Token referencing the CST package of the CM object
+  CM_OBJECT_TOKEN    CstPkgRefToken;
+} CM_ARCH_COMMON_CSD_INFO;
+
+/** A structure that describes the P-State _PCT.
+
+    Cf. ACPI 6.5, s8.4.5.1 Processor Performance Control
+
+    ID: EArchCommonObjPctInfo
+*/
+typedef AML_PCT_INFO CM_ARCH_COMMON_PCT_INFO;
+
+/** A structure that describes the P-State _PSS.
+
+    Cf. ACPI 6.5, s8.4.5.2 Processor Performance Control
+
+    ID: EArchCommonObjPssInfo
+*/
+typedef AML_PSS_INFO CM_ARCH_COMMON_PSS_INFO;
+
+/** A structure that describes the P-State _PPC.
+
+    Cf. ACPI 6.5, s8.4.5.3 Processor Performance Control
+
+    ID: EArchCommonObjPpcInfo
+*/
+typedef struct CmArchCommonObjPpcInfo {
+  /// The number of performance states supported by the processor.
+  UINT32    PstateCount;
+} CM_ARCH_COMMON_PPC_INFO;
 #pragma pack()
 
 #endif // ARCH_COMMON_NAMESPACE_OBJECTS_H_

--- a/DynamicTablesPkg/Include/ArchCommonNameSpaceObjects.h
+++ b/DynamicTablesPkg/Include/ArchCommonNameSpaceObjects.h
@@ -58,6 +58,7 @@ typedef enum ArchCommonObjectID {
   EArchCommonObjPctInfo,                        ///< 31 - P-State control (PCT) Info
   EArchCommonObjPssInfo,                        ///< 32 - P-State status (PSS) Info
   EArchCommonObjPpcInfo,                        ///< 33 - P-State control (PPC) Info
+  EArchCommonObjStaInfo,                        ///< 34 - _STA (Device Status) Info
   EArchCommonObjMax
 } EARCH_COMMON_OBJECT_ID;
 
@@ -801,6 +802,16 @@ typedef struct CmArchCommonObjPpcInfo {
   /// The number of performance states supported by the processor.
   UINT32    PstateCount;
 } CM_ARCH_COMMON_PPC_INFO;
+
+/** A structure that describes the _STA (Device Status) Info.
+
+    ID: EArchCommonObjStaInfo
+*/
+typedef struct CmArchCommonStaInfo {
+  /// Device Status
+  UINT32    DeviceStatus;
+} CM_ARCH_COMMON_STA_INFO;
+
 #pragma pack()
 
 #endif // ARCH_COMMON_NAMESPACE_OBJECTS_H_

--- a/DynamicTablesPkg/Include/Library/AmlLib/AmlLib.h
+++ b/DynamicTablesPkg/Include/Library/AmlLib/AmlLib.h
@@ -2,7 +2,7 @@
   AML Lib.
 
   Copyright (c) 2019 - 2023, Arm Limited. All rights reserved.<BR>
-  Copyright (C) 2023 - 2024, Advanced Micro Devices, Inc. All rights reserved.<BR>
+  Copyright (C) 2023 - 2025, Advanced Micro Devices, Inc. All rights reserved.<BR>
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
@@ -1917,6 +1917,194 @@ AmlCreatePsdNode (
   IN  AML_PSD_INFO            *PsdInfo,
   IN  AML_NODE_HANDLE         ParentNode    OPTIONAL,
   OUT AML_OBJECT_NODE_HANDLE  *NewPsdNode   OPTIONAL
+  );
+
+/** Create a _CST node.
+
+  AmlCreateCstNode ("_CST", 0, 1, ParentNode, &CstNode) is
+  equivalent of the following ASL code:
+    Name (_CST, Package (
+                  0   // Count
+                  ))
+
+  This function doesn't define any CST state. As shown above, the count
+  of _CST state is set to 0.
+  The AmlAddCstState () function allows to add CST states.
+
+  Cf ACPI 6.5 specification, s8.4.1.1 _CST (C States)
+
+  @param [in]  CstNameString  The new CST 's object name.
+                              Must be a NULL-terminated ASL NameString
+                              e.g.: "_CST", "DEV0.CSTP", etc.
+                              The input string is copied.
+  @param [in]  ParentNode     If provided, set ParentNode as the parent
+                              of the node created.
+  @param [out] NewCstNode     If success, contains the created node.
+
+  @retval EFI_SUCCESS             The function completed successfully.
+  @retval EFI_INVALID_PARAMETER   Invalid parameter.
+  @retval EFI_OUT_OF_RESOURCES    Failed to allocate memory.
+**/
+EFI_STATUS
+EFIAPI
+AmlCreateCstNode (
+  IN  CONST CHAR8                   *CstNameString,
+  IN        AML_NODE_HANDLE         ParentNode   OPTIONAL,
+  OUT       AML_OBJECT_NODE_HANDLE  *NewCstNode   OPTIONAL
+  );
+
+/** Add an _CST state to a CST node created using AmlCreateCstNode.
+
+  AmlAddCstState increments the Count of CST states in the CST node by one,
+  and adds the following package:
+  Package {
+    Register  // Buffer (Resource Descriptor)
+    Type      // Integer (BYTE)
+    Latency   // Integer (WORD)
+    Power     // Integer (DWORD)
+  }
+
+  Cf ACPI 6.5 specification, s8.4.1.1 _CST (C States).
+
+  @param [in]  CstInfo                    CstInfo object
+  @param [in]  CstNode                    Cst node created with the function
+                                          AmlCreateCstNode to which the new CST
+                                          state is appended.
+
+  @retval EFI_SUCCESS             The function completed successfully.
+  @retval EFI_INVALID_PARAMETER   Invalid parameter.
+  @retval EFI_OUT_OF_RESOURCES    Failed to allocate memory.
+**/
+EFI_STATUS
+EFIAPI
+AmlAddCstState (
+  IN  AML_CST_INFO            *CstInfo,
+  IN  AML_OBJECT_NODE_HANDLE  CstNode
+  );
+
+/** Create a _CSD node.
+
+  Generates and optionally appends the following node:
+
+  Name (_CSD, Package()
+  {
+    Package () {
+      NumEntries,    // Integer
+      Revision,      // Integer (BYTE)
+      Domain,        // Integer (DWORD)
+      CoordType,     // Integer (DWORD)
+      NumProcessors, // Integer (DWORD)
+      Index          // Integer (DWORD)
+    }
+    Package () {
+      NumEntries,    // Integer
+      Revision,      // Integer (BYTE)
+      Domain,        // Integer (DWORD)
+      CoordType,     // Integer (DWORD)
+      NumProcessors, // Integer (DWORD)
+      Index          // Integer (DWORD)
+    }
+    ...
+  })
+  Cf. ACPI 6.5, s8.4.1.2 _CSD (C-State Dependency).
+
+  @ingroup CodeGenApis
+
+  @param [in]  CsdInfo      CsdInfo object
+  @param [in]  NumEntries   Number of packages to be created.
+  @param [in]  ParentNode   If provided, set ParentNode as the parent
+                            of the node created.
+  @param [out] NewCsdNode   If success and provided, contains the created node.
+
+  @retval EFI_SUCCESS             The function completed successfully.
+  @retval EFI_INVALID_PARAMETER   Invalid parameter.
+  @retval EFI_OUT_OF_RESOURCES    Failed to allocate memory.
+**/
+EFI_STATUS
+EFIAPI
+AmlCreateCsdNode (
+  IN  AML_CSD_INFO            *CsdInfo,
+  IN  UINT32                  NumEntries,
+  IN  AML_NODE_HANDLE         ParentNode    OPTIONAL,
+  OUT AML_OBJECT_NODE_HANDLE  *NewCsdNode   OPTIONAL
+  );
+
+/** Create _PCT node
+
+  Generates and optionally appends the following node:
+  Name (_PCT, Package()
+  {
+    ControlRegister   // Buffer (Resource Descriptor (Register))
+    StatusRegister    // Buffer (Resource Descriptor (Register))
+  })
+
+  Cf. ACPI 6.5, s8.4.5.1 _PCT (Processor Control).
+
+  @ingroup CodeGenApis
+
+  @param [in]  PctInfo      PctInfo object
+  @param [in]  ParentNode   If provided, set ParentNode as the parent
+                            of the node created.
+  @param [out] NewPctNode   If success and provided, contains the created node.
+
+  @retval EFI_SUCCESS             The function completed successfully.
+  @retval EFI_INVALID_PARAMETER   Invalid parameter.
+  @retval EFI_OUT_OF_RESOURCES    Failed to allocate memory.
+**/
+EFI_STATUS
+EFIAPI
+AmlCreatePctNode (
+  IN  AML_PCT_INFO            *PctInfo,
+  IN  AML_NODE_HANDLE         ParentNode    OPTIONAL,
+  OUT AML_OBJECT_NODE_HANDLE  *NewPctNode   OPTIONAL
+  );
+
+/** Create _PSS node
+
+  Generates and optionally appends the following node:
+  Name (_PSS, Package()
+  {
+    Package () {
+      CoreFrequency     // Integer (DWORD)
+      Power             // Integer (DWORD)
+      Latency           // Integer (DWORD)
+      BusMasterLatency  // Integer (DWORD)
+      Control           // Integer (DWORD)
+      Status            // Integer (DWORD)
+    }
+    Package () {
+      CoreFrequency     // Integer (DWORD)
+      Power             // Integer (DWORD)
+      Latency           // Integer (DWORD)
+      BusMasterLatency  // Integer (DWORD)
+      Control           // Integer (DWORD)
+      Status            // Integer (DWORD)
+    }
+    ...
+  })
+
+  Cf. ACPI 6.5, s8.4.5.2 _PSS (Processor Supported Performance States).
+
+  @ingroup CodeGenApis
+
+  @param [in]  PssInfo      Array of PssInfo object
+  @param [in]  NumPackages  Number of packages to be created.
+  @param [in]  ParentNode   If provided, set ParentNode as the parent
+                            of the node created.
+  @param [out] NewPssNode   If success and provided, contains the created node.
+
+  @retval EFI_SUCCESS             The function completed successfully.
+  @retval EFI_INVALID_PARAMETER   Invalid parameter.
+  @retval EFI_OUT_OF_RESOURCES    Failed to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+AmlCreatePssNode (
+  IN  AML_PSS_INFO            *PssInfo,
+  IN  UINT32                  NumPackages,
+  IN  AML_NODE_HANDLE         ParentNode    OPTIONAL,
+  OUT AML_OBJECT_NODE_HANDLE  *NewPssNode   OPTIONAL
   );
 
 #endif // AML_LIB_H_

--- a/DynamicTablesPkg/Include/X64NameSpaceObjects.h
+++ b/DynamicTablesPkg/Include/X64NameSpaceObjects.h
@@ -17,6 +17,7 @@
 
 #include <AcpiObjects.h>
 #include <StandardNameSpaceObjects.h>
+#include <ArchCommonNameSpaceObjects.h>
 
 #pragma pack(1)
 
@@ -228,9 +229,36 @@ typedef struct CmX64MadtInfo {
   ID: EX64ObjLocalApicX2ApicInfo
 */
 typedef struct CmX64LocalApicX2ApicInfo {
-  UINT32    ApicId;
-  UINT32    Flags;
-  UINT32    AcpiProcessorUid;
+  UINT32             ApicId;
+  UINT32             Flags;
+  UINT32             AcpiProcessorUid;
+
+  /** Optional field: Reference Token for the Cst info of this processor.
+      i.e. a token referencing a CM_ARCH_COMMON_OBJ_REF,
+      which in turn refers to an array of CM_ARCH_COMMON_OBJ_REF objects,
+      each pointing to individual CM_ARCH_COMMON_CST_INFO objects.
+  */
+  CM_OBJECT_TOKEN    CstToken;
+
+  /** Optional field: Reference Token for the Csd info of this processor.
+      i.e. a token referencing a CM_ARCH_COMMON_CSD_INFO object.
+  */
+  CM_OBJECT_TOKEN    CsdToken;
+
+  /** Optional field: Reference Token for the Pct info of this processor.
+      i.e. a token referencing a CM_ARCH_COMMON_Pct_INFO object.
+  */
+  CM_OBJECT_TOKEN    PctToken;
+
+  /** Optional field: Reference Token for the Pss info of this processor.
+      i.e. a token referencing a CM_ARCH_COMMON_PSS_INFO object.
+  */
+  CM_OBJECT_TOKEN    PssToken;
+
+  /** Optional field: Reference Token for the Ppc info of this processor.
+      i.e. a token referencing a CM_ARCH_COMMON_PPC_INFO object.
+  */
+  CM_OBJECT_TOKEN    PpcToken;
 } CM_X64_LOCAL_APIC_X2APIC_INFO;
 
 /**

--- a/DynamicTablesPkg/Include/X64NameSpaceObjects.h
+++ b/DynamicTablesPkg/Include/X64NameSpaceObjects.h
@@ -269,6 +269,11 @@ typedef struct CmX64LocalApicX2ApicInfo {
       i.e. a token referencing a CM_ARCH_COMMON_CPC_INFO object.
   */
   CM_OBJECT_TOKEN    CpcToken;
+
+  /** Optional field: Reference Token for _STA info of this processor.
+      i.e. a token referencing a CM_ARCH_COMMON_STA_INFO object.
+   */
+  CM_OBJECT_TOKEN    StaToken;
 } CM_X64_LOCAL_APIC_X2APIC_INFO;
 
 /**

--- a/DynamicTablesPkg/Include/X64NameSpaceObjects.h
+++ b/DynamicTablesPkg/Include/X64NameSpaceObjects.h
@@ -259,6 +259,16 @@ typedef struct CmX64LocalApicX2ApicInfo {
       i.e. a token referencing a CM_ARCH_COMMON_PPC_INFO object.
   */
   CM_OBJECT_TOKEN    PpcToken;
+
+  /** Optional field: Reference Token for the Psd info of this processor.
+      i.e. a token referencing a CM_ARCH_COMMON_PSD_INFO object.
+  */
+  CM_OBJECT_TOKEN    PsdToken;
+
+  /** Optional field: Reference Token for the Cpc info of this processor.
+      i.e. a token referencing a CM_ARCH_COMMON_CPC_INFO object.
+  */
+  CM_OBJECT_TOKEN    CpcToken;
 } CM_X64_LOCAL_APIC_X2APIC_INFO;
 
 /**

--- a/DynamicTablesPkg/Library/Acpi/Common/AcpiSsdtCpuTopologyLib/SsdtCpuTopologyGenerator.c
+++ b/DynamicTablesPkg/Library/Acpi/Common/AcpiSsdtCpuTopologyLib/SsdtCpuTopologyGenerator.c
@@ -2,6 +2,7 @@
   SSDT Cpu Topology Table Generator.
 
   Copyright (c) 2021 - 2023, Arm Limited. All rights reserved.<BR>
+  Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
   @par Reference(s):
@@ -280,7 +281,6 @@ WriteAslName (
   @retval EFI_INVALID_PARAMETER   Invalid parameter.
   @retval EFI_OUT_OF_RESOURCES    Failed to allocate memory.
 **/
-STATIC
 EFI_STATUS
 EFIAPI
 CreateAmlPsdNode (

--- a/DynamicTablesPkg/Library/Acpi/Common/AcpiSsdtCpuTopologyLib/SsdtCpuTopologyGenerator.h
+++ b/DynamicTablesPkg/Library/Acpi/Common/AcpiSsdtCpuTopologyLib/SsdtCpuTopologyGenerator.h
@@ -2,6 +2,7 @@
   SSDT Cpu Topology Table Generator.
 
   Copyright (c) 2021 - 2023, Arm Limited. All rights reserved.<BR>
+  Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
   @par Reference(s):
@@ -51,6 +52,17 @@
 #define SB_SCOPE_PREFIX  SB_SCOPE "."
 /// Size of the SB_SCOPE_PREFIX string.
 #define SB_SCOPE_PREFIX_SIZE  sizeof (SB_SCOPE_PREFIX)
+
+/** C-state are stored in the ASL namspace at '\_SB_.CSTS.Cxxx',
+    where xxx represents the C-state index:
+    CSTx  - for C-state indices less than 0xF.
+    CSxx  - for C-state indices between 0xF and 0xFF.
+    Cxxx  - for C-state indices greater than 0xFF.
+*/
+#define CSTS_SCOPE         "CSTS"
+#define CSTS_SCOPE_PREFIX  SB_SCOPE_PREFIX CSTS_SCOPE "."
+/// Size of the CSTS_SCOPE_PREFIX string.
+#define CSTS_SCOPE_PREFIX_SIZE  sizeof (CSTS_SCOPE_PREFIX)
 
 /// HID for a processor device.
 #define ACPI_HID_PROCESSOR_DEVICE  "ACPI0007"

--- a/DynamicTablesPkg/Library/Acpi/Common/AcpiSsdtCpuTopologyLib/SsdtCpuTopologyGenerator.h
+++ b/DynamicTablesPkg/Library/Acpi/Common/AcpiSsdtCpuTopologyLib/SsdtCpuTopologyGenerator.h
@@ -352,4 +352,48 @@ AddArchAmlCpuInfo (
   OUT  AML_OBJECT_NODE_HANDLE                             *CpuNode
   );
 
+/** Create and add an _PSD Node to Cpu Node.
+
+  For instance, transform an AML node from:
+  Device (C002)
+  {
+      Name (_UID, 2)
+      Name (_HID, "ACPI0007")
+  }
+
+  To:
+  Device (C002)
+  {
+      Name (_UID, 2)
+      Name (_HID, "ACPI0007")
+      Name (_PSD, Package()
+      {
+        NumEntries,      // Integer
+        Revision,        // Integer
+        Domain,          // Integer
+        CoordType,       // Integer
+        NumProcessors,   // Integer
+      })
+  }
+
+  @param [in]  Generator              The SSDT Cpu Topology generator.
+  @param [in]  CfgMgrProtocol         Pointer to the Configuration Manager
+                                      Protocol Interface.
+  @param [in]  PsdToken               Token to identify the Psd information.
+  @param [in]  Node                   CPU Node to which the _CPC node is
+                                      attached.
+
+  @retval EFI_SUCCESS             The function completed successfully.
+  @retval EFI_INVALID_PARAMETER   Invalid parameter.
+  @retval EFI_OUT_OF_RESOURCES    Failed to allocate memory.
+**/
+EFI_STATUS
+EFIAPI
+CreateAmlPsdNode (
+  IN  ACPI_CPU_TOPOLOGY_GENERATOR                         *Generator,
+  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST  CfgMgrProtocol,
+  IN  CM_OBJECT_TOKEN                                     PsdToken,
+  IN  AML_OBJECT_NODE_HANDLE                              *Node
+  );
+
 #endif // SSDT_CPU_TOPOLOGY_GENERATOR_H_

--- a/DynamicTablesPkg/Library/Acpi/Common/AcpiSsdtCpuTopologyLib/X64/X64SsdtCpuTopologyGenerator.c
+++ b/DynamicTablesPkg/Library/Acpi/Common/AcpiSsdtCpuTopologyLib/X64/X64SsdtCpuTopologyGenerator.c
@@ -1,7 +1,7 @@
 /** @file
   X64 SSDT Cpu Topology Table Generator Helpers.
 
-  Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+  Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -18,6 +18,9 @@
 #include <ConfigurationManagerHelper.h>
 #include <Library/TableHelperLib.h>
 #include <Library/AmlLib/AmlLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/AcpiHelperLib.h>
 #include <Protocol/ConfigurationManagerProtocol.h>
 
 #include "SsdtCpuTopologyGenerator.h"
@@ -31,15 +34,437 @@ GET_OBJECT_LIST (
   CM_X64_LOCAL_APIC_X2APIC_INFO
   );
 
+/** This macro expands to a function that retrieves the
+    C-State information from the Configuration Manager.
+*/
+GET_OBJECT_LIST (
+  EObjNameSpaceArchCommon,
+  EArchCommonObjCstInfo,
+  CM_ARCH_COMMON_CST_INFO
+  );
+
+/** This macro expands to a function that retrieves the
+    C-State dependency information from the Configuration Manager.
+*/
+GET_OBJECT_LIST (
+  EObjNameSpaceArchCommon,
+  EArchCommonObjCsdInfo,
+  CM_ARCH_COMMON_CSD_INFO
+  );
+
+/** This macro expands to a function that retrieves the
+    P-State PCT information from the Configuration Manager.
+*/
+GET_OBJECT_LIST (
+  EObjNameSpaceArchCommon,
+  EArchCommonObjPctInfo,
+  CM_ARCH_COMMON_PCT_INFO
+  );
+
+/** This macro expands to a function that retrieves the
+    P-State PSS information from the Configuration Manager.
+*/
+GET_OBJECT_LIST (
+  EObjNameSpaceArchCommon,
+  EArchCommonObjPssInfo,
+  CM_ARCH_COMMON_PSS_INFO
+  );
+
+/** This macro expands to a function that retrieves the
+    P-State PPC information from the Configuration Manager.
+*/
+GET_OBJECT_LIST (
+  EObjNameSpaceArchCommon,
+  EArchCommonObjPpcInfo,
+  CM_ARCH_COMMON_PPC_INFO
+  );
+
 /**
-  Create the processor hierarchy AML tree from arch specific CM objects.
+  This macro expands to a function that retrieves the cross-CM-object-
+  reference information from the Configuration Manager.
+*/
+GET_OBJECT_LIST (
+  EObjNameSpaceArchCommon,
+  EArchCommonObjCmRef,
+  CM_ARCH_COMMON_OBJ_REF
+  );
 
-  @param [in] Generator        The SSDT Cpu Topology generator.
-  @param [in] CfgMgrProtocol   Pointer to the Configuration Manager
-                               Protocol Interface.
-  @param [in] ScopeNode        Scope node handle ('\_SB' scope).
+/** Add a new entry to the TokenTable and return its index.
 
-  @retval EFI_UNSUPPORTED      Not supported
+  If an entry with Token is already available in the table,
+  return its index without adding a new entry.
+
+  @param [in]  TokenTable Pointer to the TokenTable to update.
+  @param [in]  Token      New Token entry to add.
+
+  @retval The index of the token entry in the TokenTable.
+**/
+STATIC
+UINT32
+EFIAPI
+TokenTableAdd (
+  IN  TOKEN_TABLE      *TokenTable,
+  IN  CM_OBJECT_TOKEN  Token
+  )
+{
+  UINT32  Index;
+
+  if ((TokenTable == NULL) || (TokenTable->Table == NULL)) {
+    ASSERT_EFI_ERROR (EFI_INVALID_PARAMETER);
+    return 0;
+  }
+
+  // Search if there is already an entry with this Token.
+  for (Index = 0; Index < TokenTable->LastIndex; Index++) {
+    if (TokenTable->Table[Index] == Token) {
+      return Index;
+    }
+  }
+
+  // If no, create a new entry.
+  TokenTable->Table[TokenTable->LastIndex] = Token;
+  return TokenTable->LastIndex++;
+}
+
+/** Free the memory allocated for the TokenTable.
+
+  @param [in]  TokenTable  Pointer to the TokenTable to free.
+**/
+STATIC
+VOID
+EFIAPI
+TokenTableFree (
+  IN  TOKEN_TABLE  *TokenTable
+  )
+{
+  if (TokenTable == NULL) {
+    return;
+  }
+
+  if (TokenTable->Table != NULL) {
+    FreePool (TokenTable->Table);
+  }
+
+  TokenTable->Table     = NULL;
+  TokenTable->LastIndex = 0;
+}
+
+/** Update the TokenTable.
+  Allocate memory for the TokenTable and add the CstToken entries.
+
+  @param [in]  TokenTable Pointer to the TokenTable to initialize.
+  @param [in]  LocalApic  Pointer to the Local APIC or X2APIC information.
+  @param [in]  Count      Number of entries to allocate in the TokenTable.
+
+  @retval EFI_SUCCESS            Success.
+  @retval EFI_INVALID_PARAMETER  Invalid parameter.
+  @retval EFI_OUT_OF_RESOURCES   Failed to allocate memory.
+**/
+STATIC
+EFI_STATUS
+EFIAPI
+TokenTableUpdate (
+  IN  TOKEN_TABLE                    *TokenTable,
+  IN  CM_X64_LOCAL_APIC_X2APIC_INFO  *LocalApic,
+  IN  UINT32                         Count
+  )
+{
+  UINT32  Index;
+
+  if ((TokenTable == NULL) ||
+      (LocalApic == NULL)   ||
+      (Count == 0)        ||
+      (Count >= MAX_NODE_COUNT))
+  {
+    ASSERT_EFI_ERROR (EFI_INVALID_PARAMETER);
+    return EFI_INVALID_PARAMETER;
+  }
+
+  TokenTable->Table = AllocateZeroPool (sizeof (CM_OBJECT_TOKEN) * Count);
+  if (TokenTable->Table == NULL) {
+    ASSERT_EFI_ERROR (EFI_OUT_OF_RESOURCES);
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  TokenTable->LastIndex = 0;
+
+  for (Index = 0; Index < Count; Index++) {
+    if (LocalApic[Index].CstToken != CM_NULL_TOKEN) {
+      TokenTableAdd (TokenTable, LocalApic[Index].CstToken);
+    }
+  }
+
+  return EFI_SUCCESS;
+}
+
+/** Generate the name for a C-State node in the format Cxxx,
+  where xxx represents the C-state Index:
+  CSTx  - for C-state indices less than 0xF.
+  CSxx  - for C-state indices between 0xF and 0xFF.
+  Cxxx  - for C-state indices greater than 0xFF.
+
+  @param [in, out] AslName     Buffer to store the generated name.
+  @param [in]      AslNameSize Size of the buffer.
+  @param [in]      Index       Index of the C-State in the TokenTable.
+
+  @retval EFI_SUCCESS            Success.
+  @retval EFI_INVALID_PARAMETER  Invalid parameter.
+**/
+STATIC
+EFI_STATUS
+EFIAPI
+GenerateCstAslName (
+  IN OUT CHAR8  *AslName,
+  IN UINTN      AslNameSize,
+  IN UINT32     Index
+  )
+{
+  if ((AslName == NULL) || (AslNameSize < sizeof (CSTS_SCOPE))) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  CopyMem (AslName, CSTS_SCOPE, AslNameSize);
+
+  AslName[3] = AsciiFromHex (Index & 0xF);
+
+  if (Index > 0xF) {
+    AslName[2] = AsciiFromHex ((Index >> 4) & 0xF);
+  }
+
+  if (Index > 0xFF) {
+    AslName[1] = AsciiFromHex ((Index >> 8) & 0xF);
+  }
+
+  return EFI_SUCCESS;
+}
+
+/** Generate all the C-States under the '_SB_.CSTS' scope.
+
+  This function generates the following ASL code:
+  Scope (\_SB) {
+    Scope(CSTS) {
+      Name (CST0, Package() {
+        X, // Count
+        Package() {
+          [An CST state]
+        },
+        Package() {
+          [Another CST state]
+        },
+      } // Name CST0
+
+      Name (CST1, Package() {
+        ...
+      } // Name CST1
+    } // Scope CSTS
+    ...
+  } // Scope /_SB
+
+  The c-states are fetched from the Configuration Manager.
+  The names of the c-states are generated from the TokenTable.
+
+  @param [in]  CstTokenTable    Pointer to the TokenTable containing
+                                the C-State tokens.
+  @param [in]  CfgMgrProtocol   Pointer to the Configuration Manager
+                                Protocol Interface.
+  @param [in] ScopeNode         Scope node handle ('CSTS' scope).
+
+  @retval EFI_SUCCESS             Success.
+  @retval EFI_INVALID_PARAMETER   Invalid parameter.
+  @retval EFI_OUT_OF_RESOURCES    Failed to allocate memory.
+**/
+STATIC
+EFI_STATUS
+EFIAPI
+GenerateCstStates (
+  IN  TOKEN_TABLE                                         *CstTokenTable,
+  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST  CfgMgrProtocol,
+  IN        AML_OBJECT_NODE_HANDLE                        ScopeNode
+  )
+{
+  AML_OBJECT_NODE_HANDLE   CstNode;
+  CHAR8                    AslName[AML_NAME_SEG_SIZE + 1];
+  CM_ARCH_COMMON_CST_INFO  *CstInfo;
+  CM_ARCH_COMMON_OBJ_REF   *CstPkgRefInfo;
+  CM_ARCH_COMMON_OBJ_REF   *CstRefInfo;
+  EFI_STATUS               Status;
+  UINT32                   CstPkgRefIndex;
+  UINT32                   CstPkgRefInfoCount;
+  UINT32                   CstRefIndex;
+  UINT32                   CstRefInfoCount;
+  UINT32                   Index;
+
+  if ((CstTokenTable == NULL) || (CfgMgrProtocol == NULL) || (ScopeNode == NULL)) {
+    ASSERT_EFI_ERROR (EFI_INVALID_PARAMETER);
+    return EFI_INVALID_PARAMETER;
+  }
+
+  for (Index = 0; Index < CstTokenTable->LastIndex; Index++) {
+    Status = GenerateCstAslName (AslName, AML_NAME_SEG_SIZE + 1, Index);
+    if (EFI_ERROR (Status)) {
+      ASSERT_EFI_ERROR (Status);
+      return Status;
+    }
+
+    Status = AmlCreateCstNode (AslName, ScopeNode, &CstNode);
+    if (EFI_ERROR (Status)) {
+      ASSERT_EFI_ERROR (Status);
+      return Status;
+    }
+
+    Status = GetEArchCommonObjCmRef (
+               CfgMgrProtocol,
+               CstTokenTable->Table[Index],
+               &CstRefInfo,
+               &CstRefInfoCount
+               );
+    if (EFI_ERROR (Status)) {
+      ASSERT_EFI_ERROR (Status);
+      return Status;
+    }
+
+    for (CstRefIndex = 0; CstRefIndex < CstRefInfoCount; CstRefIndex++) {
+      /// Each CST object contains the references to the CST packages object
+      Status = GetEArchCommonObjCmRef (
+                 CfgMgrProtocol,
+                 CstRefInfo[CstRefIndex].ReferenceToken,
+                 &CstPkgRefInfo,
+                 &CstPkgRefInfoCount
+                 );
+      if (EFI_ERROR (Status)) {
+        ASSERT_EFI_ERROR (Status);
+        return Status;
+      }
+
+      for (CstPkgRefIndex = 0; CstPkgRefIndex < CstPkgRefInfoCount; CstPkgRefIndex++) {
+        Status = GetEArchCommonObjCstInfo (
+                   CfgMgrProtocol,
+                   CstPkgRefInfo[CstPkgRefIndex].ReferenceToken,
+                   &CstInfo,
+                   NULL
+                   );
+        if (EFI_ERROR (Status)) {
+          ASSERT_EFI_ERROR (Status);
+          return Status;
+        }
+
+        Status = AmlAddCstState (
+                   CstInfo,
+                   CstNode
+                   );
+        if (EFI_ERROR (Status)) {
+          ASSERT_EFI_ERROR (Status);
+          return Status;
+        }
+      }
+    } // for CstRefIndex
+  } // for Index
+
+  return EFI_SUCCESS;
+}
+
+/** Create and add an _CST method to cpu node.
+
+  For instance, transform an AML node from:
+  Device (C002)
+  {
+      Name (_UID, 2)
+      Name (_HID, "ACPI0007")
+  }
+
+  To:
+  Device (C002)
+  {
+      Name (_UID, 2)
+      Name (_HID, "ACPI0007")
+      Method (_CST, 0, NotSerialized)
+      {
+          Return (\_SB.CSTS.CST1)
+      }
+  }
+
+  @param [in]  CstTokenTable    Pointer to the TokenTable containing the C-State tokens.
+  @param [in]  CstToken         C-State token to add to the CPU node.
+  @param [in]  CfgMgrProtocol   Pointer to the Configuration Manager
+                                Protocol Interface.
+  @param [in]  Node             CPU node handle.
+
+  @retval EFI_SUCCESS             Success.
+  @retval EFI_INVALID_PARAMETER   Invalid parameter.
+  @retval EFI_OUT_OF_RESOURCES    Failed to allocate memory.
+**/
+STATIC
+EFI_STATUS
+EFIAPI
+CreateAmlCstMethod (
+  IN  TOKEN_TABLE                                         *CstTokenTable,
+  IN  CM_OBJECT_TOKEN                                     CstToken,
+  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST  CfgMgrProtocol,
+  IN  AML_OBJECT_NODE_HANDLE                              *Node
+  )
+{
+  CHAR8       AslName[AML_NAME_SEG_SIZE + 1];
+  CHAR8       AslNameFull[CSTS_SCOPE_PREFIX_SIZE + AML_NAME_SEG_SIZE + 1];
+  EFI_STATUS  Status;
+  UINT32      Index;
+
+  if ((CstTokenTable == NULL) || (CfgMgrProtocol == NULL) || (Node == NULL)) {
+    ASSERT_EFI_ERROR (EFI_INVALID_PARAMETER);
+    return EFI_INVALID_PARAMETER;
+  }
+
+  for (Index = 0; Index < CstTokenTable->LastIndex; Index++) {
+    if (CstTokenTable->Table[Index] == CstToken) {
+      break;
+    }
+  }
+
+  if (Index == CstTokenTable->LastIndex) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Status = GenerateCstAslName (AslName, AML_NAME_SEG_SIZE + 1, Index);
+  if (EFI_ERROR (Status)) {
+    ASSERT_EFI_ERROR (Status);
+    return Status;
+  }
+
+  CopyMem (AslNameFull, CSTS_SCOPE_PREFIX, CSTS_SCOPE_PREFIX_SIZE);
+  CopyMem (&AslNameFull[CSTS_SCOPE_PREFIX_SIZE - 1], AslName, AML_NAME_SEG_SIZE);
+  AslNameFull[CSTS_SCOPE_PREFIX_SIZE + AML_NAME_SEG_SIZE - 1] = '\0';
+  // ASL:
+  // Method (_CST, 0) {
+  //   Return ([AslName])
+  // }
+  Status = AmlCodeGenMethodRetNameString (
+             "_CST",
+             AslNameFull,
+             0,
+             FALSE,
+             0,
+             Node,
+             NULL
+             );
+  if (EFI_ERROR (Status)) {
+    ASSERT_EFI_ERROR (Status);
+  }
+
+  return Status;
+}
+
+/**
+  Create a standard ACPI CPU node.
+  Collect the information from the Configuration Manager.
+  Optionally creates a C-State, P-State and _STA method.
+
+  @param [in]  Generator          The SSDT Cpu Topology generator.
+  @param [in]  CfgMgrProtocol     Pointer to the Configuration Manager
+                                  Protocol Interface.
+  @param [in]  ScopeNode          Scope node handle.
+
+  @retval EFI_SUCCESS             Success.
+  @retval EFI_INVALID_PARAMETER   Invalid parameter.
+  @retval EFI_OUT_OF_RESOURCES    Failed to allocate memory.
 **/
 EFI_STATUS
 EFIAPI
@@ -49,16 +474,35 @@ CreateTopologyFromIntC (
   IN        AML_OBJECT_NODE_HANDLE                        ScopeNode
   )
 {
-  EFI_STATUS                     Status;
-  CM_X64_LOCAL_APIC_X2APIC_INFO  *LocalApicX2ApicInfo;
-  UINT32                         LocalApicX2ApicCount;
-  UINT32                         Index;
+  AML_CSD_INFO                   *CsdInfo;
   AML_OBJECT_NODE_HANDLE         CpuNode;
+  AML_OBJECT_NODE_HANDLE         CstsScopeNode;
+  CM_ARCH_COMMON_CSD_INFO        *CmCsdInfo;
+  CM_ARCH_COMMON_OBJ_REF         *CstPkgRefInfo;
+  CM_ARCH_COMMON_OBJ_REF         *CstRefInfo;
+  CM_ARCH_COMMON_PCT_INFO        *PctInfo;
+  CM_ARCH_COMMON_PPC_INFO        *PpcInfo;
+  CM_ARCH_COMMON_PSS_INFO        *PssInfo;
+  CM_X64_LOCAL_APIC_X2APIC_INFO  *LocalApicX2ApicInfo;
+  EFI_STATUS                     Status;
+  TOKEN_TABLE                    CstTokenTable;
+  UINT32                         CsdIndex;
+  UINT32                         CsdNumEntries;
+  UINT32                         CstIndex;
+  UINT32                         CstPkgIndex;
+  UINT32                         CstPkgRefIndex;
+  UINT32                         CstPkgRefInfoCount;
+  UINT32                         CstRefInfoCount;
+  UINT32                         Index;
+  UINT32                         LocalApicX2ApicCount;
+  UINT32                         PssNumEntries;
 
-  ASSERT (Generator != NULL);
-  ASSERT (CfgMgrProtocol != NULL);
-  ASSERT (ScopeNode != NULL);
+  if ((Generator == NULL) || (CfgMgrProtocol == NULL) || (ScopeNode == NULL)) {
+    ASSERT_EFI_ERROR (EFI_INVALID_PARAMETER);
+    return EFI_INVALID_PARAMETER;
+  }
 
+  CsdInfo              = NULL;
   LocalApicX2ApicCount = 0;
   Status               = GetEX64ObjLocalApicX2ApicInfo (
                            CfgMgrProtocol,
@@ -69,6 +513,31 @@ CreateTopologyFromIntC (
   if (EFI_ERROR (Status)) {
     ASSERT_EFI_ERROR (Status);
     return Status;
+  }
+
+  Status = TokenTableUpdate (
+             &CstTokenTable,
+             LocalApicX2ApicInfo,
+             LocalApicX2ApicCount
+             );
+  if (EFI_ERROR (Status)) {
+    ASSERT_EFI_ERROR (Status);
+    return Status;
+  }
+
+  /// if C-State are provided, create the CSTS scope and C-states
+  if (CstTokenTable.LastIndex > 0) {
+    Status = AmlCodeGenScope (CSTS_SCOPE, ScopeNode, &CstsScopeNode);
+    if (EFI_ERROR (Status)) {
+      ASSERT_EFI_ERROR (Status);
+      goto return_handler;
+    }
+
+    Status = GenerateCstStates (&CstTokenTable, CfgMgrProtocol, CstsScopeNode);
+    if (EFI_ERROR (Status)) {
+      ASSERT_EFI_ERROR (Status);
+      goto return_handler;
+    }
   }
 
   /// for each processor object, create an AML node.
@@ -82,8 +551,190 @@ CreateTopologyFromIntC (
                );
     if (EFI_ERROR (Status)) {
       ASSERT_EFI_ERROR (Status);
-      break;
+      goto return_handler;
     }
+
+    ///
+    /// Check for optional tokens and add them to the CPU node.
+    ///
+    if (LocalApicX2ApicInfo[Index].CstToken != CM_NULL_TOKEN) {
+      Status = CreateAmlCstMethod (
+                 &CstTokenTable,
+                 LocalApicX2ApicInfo[Index].CstToken,
+                 CfgMgrProtocol,
+                 CpuNode
+                 );
+      if (EFI_ERROR (Status)) {
+        ASSERT_EFI_ERROR (Status);
+        goto return_handler;
+      }
+
+      if (LocalApicX2ApicInfo[Index].CsdToken != CM_NULL_TOKEN) {
+        Status = GetEArchCommonObjCsdInfo (
+                   CfgMgrProtocol,
+                   LocalApicX2ApicInfo[Index].CsdToken,
+                   &CmCsdInfo,
+                   &CsdNumEntries
+                   );
+        if (EFI_ERROR (Status)) {
+          ASSERT_EFI_ERROR (Status);
+          goto return_handler;
+        }
+
+        CsdInfo = AllocateZeroPool (sizeof (AML_CSD_INFO) * CsdNumEntries);
+        if (CsdInfo == NULL) {
+          ASSERT_EFI_ERROR (EFI_OUT_OF_RESOURCES);
+          Status = EFI_OUT_OF_RESOURCES;
+          goto return_handler;
+        }
+
+        for (CsdIndex = 0; CsdIndex < CsdNumEntries; CsdIndex++) {
+          CsdInfo[CsdIndex].Revision      = CmCsdInfo[CsdIndex].Revision;
+          CsdInfo[CsdIndex].Domain        = CmCsdInfo[CsdIndex].Domain;
+          CsdInfo[CsdIndex].CoordType     = CmCsdInfo[CsdIndex].CoordType;
+          CsdInfo[CsdIndex].NumProcessors = CmCsdInfo[CsdIndex].NumProcessors;
+          if (CmCsdInfo[CsdIndex].CstPkgRefToken == CM_NULL_TOKEN) {
+            ASSERT_EFI_ERROR (EFI_INVALID_PARAMETER);
+            Status = EFI_INVALID_PARAMETER;
+            goto return_handler;
+          }
+
+          /// Initialize to maximum value until the CST package reference token is found
+          CsdInfo[CsdIndex].Index = MAX_UINT32;
+          for (CstIndex = 0; ((CstIndex < CstTokenTable.LastIndex) && (CsdInfo[CsdIndex].Index == MAX_UINT32)); CstIndex++) {
+            Status = GetEArchCommonObjCmRef (
+                       CfgMgrProtocol,
+                       CstTokenTable.Table[CstIndex],
+                       &CstRefInfo,
+                       &CstRefInfoCount
+                       );
+            if (EFI_ERROR (Status)) {
+              ASSERT_EFI_ERROR (Status);
+              goto return_handler;
+            }
+
+            for (CstPkgIndex = 0; ((CstPkgIndex < CstRefInfoCount) && (CsdInfo[CsdIndex].Index == MAX_UINT32)); CstPkgIndex++) {
+              Status = GetEArchCommonObjCmRef (
+                         CfgMgrProtocol,
+                         CstRefInfo[CstPkgIndex].ReferenceToken,
+                         &CstPkgRefInfo,
+                         &CstPkgRefInfoCount
+                         );
+              if (EFI_ERROR (Status)) {
+                ASSERT_EFI_ERROR (Status);
+                goto return_handler;
+              }
+
+              for (CstPkgRefIndex = 0; ((CstPkgRefIndex < CstPkgRefInfoCount) && (CsdInfo[CsdIndex].Index == MAX_UINT32)); CstPkgRefIndex++) {
+                if (CstPkgRefInfo[CstPkgRefIndex].ReferenceToken == CmCsdInfo[CsdIndex].CstPkgRefToken) {
+                  CsdInfo[CsdIndex].Index = CstPkgIndex;
+                  break;
+                }
+              }
+            }
+          }
+
+          if (CsdInfo[CsdIndex].Index == MAX_UINT32) {
+            ASSERT_EFI_ERROR (EFI_INVALID_PARAMETER);
+            Status = EFI_INVALID_PARAMETER;
+            goto return_handler;
+          }
+        }
+
+        Status = AmlCreateCsdNode (
+                   CsdInfo,
+                   CsdNumEntries,
+                   CpuNode,
+                   NULL
+                   );
+        if (EFI_ERROR (Status)) {
+          ASSERT_EFI_ERROR (Status);
+          goto return_handler;
+        }
+      }
+    }
+
+    ///
+    /// Check for optional tokens and add them to the CPU node.
+    ///
+    if ((LocalApicX2ApicInfo[Index].PctToken != CM_NULL_TOKEN) &&
+        (LocalApicX2ApicInfo[Index].PssToken != CM_NULL_TOKEN) &&
+        (LocalApicX2ApicInfo[Index].PpcToken != CM_NULL_TOKEN))
+    {
+      Status = GetEArchCommonObjPctInfo (
+                 CfgMgrProtocol,
+                 LocalApicX2ApicInfo[Index].PctToken,
+                 &PctInfo,
+                 NULL
+                 );
+      if (EFI_ERROR (Status)) {
+        ASSERT_EFI_ERROR (Status);
+        goto return_handler;
+      }
+
+      Status = GetEArchCommonObjPssInfo (
+                 CfgMgrProtocol,
+                 LocalApicX2ApicInfo[Index].PssToken,
+                 &PssInfo,
+                 &PssNumEntries
+                 );
+      if (EFI_ERROR (Status)) {
+        ASSERT_EFI_ERROR (Status);
+        goto return_handler;
+      }
+
+      Status = GetEArchCommonObjPpcInfo (
+                 CfgMgrProtocol,
+                 LocalApicX2ApicInfo[Index].PpcToken,
+                 &PpcInfo,
+                 NULL
+                 );
+      if (EFI_ERROR (Status)) {
+        ASSERT_EFI_ERROR (Status);
+        goto return_handler;
+      }
+
+      Status = AmlCreatePctNode (
+                 PctInfo,
+                 CpuNode,
+                 NULL
+                 );
+      if (EFI_ERROR (Status)) {
+        ASSERT_EFI_ERROR (Status);
+        goto return_handler;
+      }
+
+      Status = AmlCreatePssNode (
+                 PssInfo,
+                 PssNumEntries,
+                 CpuNode,
+                 NULL
+                 );
+      if (EFI_ERROR (Status)) {
+        ASSERT_EFI_ERROR (Status);
+        goto return_handler;
+      }
+
+      Status = AmlCodeGenMethodRetInteger (
+                 "_PPC",
+                 PpcInfo->PstateCount,
+                 0,
+                 FALSE,
+                 0,
+                 CpuNode,
+                 NULL
+                 );
+      if (EFI_ERROR (Status)) {
+        ASSERT_EFI_ERROR (Status);
+        goto return_handler;
+      }
+    }
+  }
+
+return_handler:
+  TokenTableFree (&CstTokenTable);
+  if (CsdInfo != NULL) {
+    FreePool (CsdInfo);
   }
 
   return Status;

--- a/DynamicTablesPkg/Library/Common/TableHelperLib/ConfigurationManagerObjectParser.c
+++ b/DynamicTablesPkg/Library/Common/TableHelperLib/ConfigurationManagerObjectParser.c
@@ -751,6 +751,12 @@ STATIC CONST CM_OBJ_PARSER  CmArchCommonPpcInfoParser[] = {
   { "PstateCount", 4, "0x%x", NULL }
 };
 
+/** A parser for EArchCommonObjStaInfo.
+*/
+STATIC CONST CM_OBJ_PARSER  CmArchCommonStaInfoParser[] = {
+  { "DeviceStatus", 4, "0x%x", NULL }
+};
+
 /** A parser for Arch Common namespace objects.
 */
 STATIC CONST CM_OBJ_PARSER_ARRAY  ArchCommonNamespaceObjectParser[] = {
@@ -788,6 +794,7 @@ STATIC CONST CM_OBJ_PARSER_ARRAY  ArchCommonNamespaceObjectParser[] = {
   CM_PARSER_ADD_OBJECT (EArchCommonObjPctInfo,                     CmArchCommonPctInfoParser),
   CM_PARSER_ADD_OBJECT (EArchCommonObjPssInfo,                     CmArchCommonPssInfoParser),
   CM_PARSER_ADD_OBJECT (EArchCommonObjPpcInfo,                     CmArchCommonPpcInfoParser),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjStaInfo,                     CmArchCommonStaInfoParser),
   CM_PARSER_ADD_OBJECT_RESERVED (EArchCommonObjMax)
 };
 
@@ -965,7 +972,8 @@ STATIC CONST CM_OBJ_PARSER  CmX64ObjLocalApicX2ApicInfoParser[] = {
   { "PssToken",         sizeof (CM_OBJECT_TOKEN), "0x%p", NULL },
   { "PpcToken",         sizeof (CM_OBJECT_TOKEN), "0x%p", NULL },
   { "PsdToken",         sizeof (CM_OBJECT_TOKEN), "0x%p", NULL },
-  { "CpcToken",         sizeof (CM_OBJECT_TOKEN), "0x%p", NULL }
+  { "CpcToken",         sizeof (CM_OBJECT_TOKEN), "0x%p", NULL },
+  { "StaToken",         sizeof (CM_OBJECT_TOKEN), "0x%p", NULL }
 };
 
 /** A parser for CmX64IoApicInfoParser.

--- a/DynamicTablesPkg/Library/Common/TableHelperLib/ConfigurationManagerObjectParser.c
+++ b/DynamicTablesPkg/Library/Common/TableHelperLib/ConfigurationManagerObjectParser.c
@@ -963,7 +963,9 @@ STATIC CONST CM_OBJ_PARSER  CmX64ObjLocalApicX2ApicInfoParser[] = {
   { "CsdToken",         sizeof (CM_OBJECT_TOKEN), "0x%p", NULL },
   { "PctToken",         sizeof (CM_OBJECT_TOKEN), "0x%p", NULL },
   { "PssToken",         sizeof (CM_OBJECT_TOKEN), "0x%p", NULL },
-  { "PpcToken",         sizeof (CM_OBJECT_TOKEN), "0x%p", NULL }
+  { "PpcToken",         sizeof (CM_OBJECT_TOKEN), "0x%p", NULL },
+  { "PsdToken",         sizeof (CM_OBJECT_TOKEN), "0x%p", NULL },
+  { "CpcToken",         sizeof (CM_OBJECT_TOKEN), "0x%p", NULL }
 };
 
 /** A parser for CmX64IoApicInfoParser.

--- a/DynamicTablesPkg/Library/Common/TableHelperLib/ConfigurationManagerObjectParser.c
+++ b/DynamicTablesPkg/Library/Common/TableHelperLib/ConfigurationManagerObjectParser.c
@@ -956,9 +956,14 @@ STATIC CONST CM_OBJ_PARSER  CmX64ObjMadtInfoParser[] = {
 /** A parser for CmArchCommonLocalApicX2ApicInfoParser.
 */
 STATIC CONST CM_OBJ_PARSER  CmX64ObjLocalApicX2ApicInfoParser[] = {
-  { "ApicId",           4, "0x%x", NULL },
-  { "Flags",            4, "0x%x", NULL },
-  { "AcpiProcessorUid", 4, "0x%x", NULL }
+  { "ApicId",           4,                        "0x%x", NULL },
+  { "Flags",            4,                        "0x%x", NULL },
+  { "AcpiProcessorUid", 4,                        "0x%x", NULL },
+  { "CstToken",         sizeof (CM_OBJECT_TOKEN), "0x%p", NULL },
+  { "CsdToken",         sizeof (CM_OBJECT_TOKEN), "0x%p", NULL },
+  { "PctToken",         sizeof (CM_OBJECT_TOKEN), "0x%p", NULL },
+  { "PssToken",         sizeof (CM_OBJECT_TOKEN), "0x%p", NULL },
+  { "PpcToken",         sizeof (CM_OBJECT_TOKEN), "0x%p", NULL }
 };
 
 /** A parser for CmX64IoApicInfoParser.

--- a/DynamicTablesPkg/Library/Common/TableHelperLib/ConfigurationManagerObjectParser.c
+++ b/DynamicTablesPkg/Library/Common/TableHelperLib/ConfigurationManagerObjectParser.c
@@ -695,6 +695,62 @@ STATIC CONST CM_OBJ_PARSER  CmArchCommonSpmiInterruptDeviceInfoParser[] = {
   { "DeviceId",              sizeof (UINT32), "0x%x", NULL }
 };
 
+STATIC CONST CM_OBJ_PARSER  CmArchCommonCstInfoParser[] = {
+  { "Register",
+    sizeof (EFI_ACPI_6_5_GENERIC_ADDRESS_STRUCTURE),
+    NULL,
+    NULL,
+    AcpiGenericAddressParser,
+    ARRAY_SIZE (AcpiGenericAddressParser) },
+  { "Type",    1,  "0x%x", NULL },
+  { "Latency", 2,  "0x%x", NULL },
+  { "Power",   4,  "0x%x", NULL }
+};
+
+/** A parser for EArchCommonObjCsdInfo.
+*/
+STATIC CONST CM_OBJ_PARSER  CmArchCommonCsdInfoParser[] = {
+  { "Revision",       1,                        "0x%x", NULL },
+  { "Domain",         4,                        "0x%x", NULL },
+  { "CoordType",      4,                        "0x%x", NULL },
+  { "NumProcessors",  4,                        "0x%x", NULL },
+  { "CstPkgRefToken", sizeof (CM_OBJECT_TOKEN), "0x%p", NULL }
+};
+
+/** A parser for EArchCommonObjPctInfo.
+*/
+STATIC CONST CM_OBJ_PARSER  CmArchCommonPctInfoParser[] = {
+  { "ControlRegister",
+    sizeof (EFI_ACPI_6_5_GENERIC_ADDRESS_STRUCTURE),
+    NULL,
+    NULL,
+    AcpiGenericAddressParser,
+    ARRAY_SIZE (AcpiGenericAddressParser) },
+  { "StatusRegister",
+    sizeof (EFI_ACPI_6_5_GENERIC_ADDRESS_STRUCTURE),
+    NULL,
+    NULL,
+    AcpiGenericAddressParser,
+    ARRAY_SIZE (AcpiGenericAddressParser) }
+};
+
+/** A parser for EArchCommonObjPssInfo.
+*/
+STATIC CONST CM_OBJ_PARSER  CmArchCommonPssInfoParser[] = {
+  { "CoreFrequency",    4, "0x%x", NULL },
+  { "Power",            4, "0x%x", NULL },
+  { "Latency",          4, "0x%x", NULL },
+  { "BusMasterLatency", 4, "0x%x", NULL },
+  { "Control",          4, "0x%x", NULL },
+  { "Status",           4, "0x%x", NULL }
+};
+
+/** A parser for EArchCommonObjPpcInfo.
+*/
+STATIC CONST CM_OBJ_PARSER  CmArchCommonPpcInfoParser[] = {
+  { "PstateCount", 4, "0x%x", NULL }
+};
+
 /** A parser for Arch Common namespace objects.
 */
 STATIC CONST CM_OBJ_PARSER_ARRAY  ArchCommonNamespaceObjectParser[] = {
@@ -727,6 +783,11 @@ STATIC CONST CM_OBJ_PARSER_ARRAY  ArchCommonNamespaceObjectParser[] = {
   CM_PARSER_ADD_OBJECT (EArchCommonObjTpm2InterfaceInfo,           CmArchCommonTpm2InterfaceInfo),
   CM_PARSER_ADD_OBJECT (EArchCommonObjSpmiInterfaceInfo,           CmArchCommonSpmiInterfaceInfoParser),
   CM_PARSER_ADD_OBJECT (EArchCommonObjSpmiInterruptDeviceInfo,     CmArchCommonSpmiInterruptDeviceInfoParser),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjCstInfo,                     CmArchCommonCstInfoParser),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjCsdInfo,                     CmArchCommonCsdInfoParser),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjPctInfo,                     CmArchCommonPctInfoParser),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjPssInfo,                     CmArchCommonPssInfoParser),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjPpcInfo,                     CmArchCommonPpcInfoParser),
   CM_PARSER_ADD_OBJECT_RESERVED (EArchCommonObjMax)
 };
 

--- a/DynamicTablesPkg/Readme.md
+++ b/DynamicTablesPkg/Readme.md
@@ -501,6 +501,11 @@ The CM_OBJECT_ID type is used to identify the Configuration Manager
 |  26   | TPM Interface Info                        | |
 |  27   | SPMI Interface Info                       | |
 |  28   | SPMI Interrupt and Device/Uid Info        | |
+|  29   | Processor C-State Control Info            | |
+|  30   | Processor C-State Dependency Info         | |
+|  31   | Processor P-State Control Info            | |
+|  32   | Processor P-State Status Info             | |
+|  33   | Processor P-State Capability Info         | |
 |  `*`  | All other values are reserved.            | |
 
 #### Object ID's in the X64 Namespace:

--- a/DynamicTablesPkg/Readme.md
+++ b/DynamicTablesPkg/Readme.md
@@ -506,6 +506,7 @@ The CM_OBJECT_ID type is used to identify the Configuration Manager
 |  31   | Processor P-State Control Info            | |
 |  32   | Processor P-State Status Info             | |
 |  33   | Processor P-State Capability Info         | |
+|  34   | _STA Device Status Info                   | |
 |  `*`  | All other values are reserved.            | |
 
 #### Object ID's in the X64 Namespace:

--- a/MdePkg/Include/IndustryStandard/Acpi30.h
+++ b/MdePkg/Include/IndustryStandard/Acpi30.h
@@ -2,6 +2,7 @@
   ACPI 3.0 definitions from the ACPI Specification Revision 3.0b October 10, 2006
 
   Copyright (c) 2006 - 2018, Intel Corporation. All rights reserved.<BR>
+  Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
@@ -9,6 +10,16 @@
 #define _ACPI_3_0_H_
 
 #include <IndustryStandard/Acpi20.h>
+
+///
+/// _CSD Revision for ACPI 3.0
+///
+#define EFI_ACPI_3_0_AML_CSD_REVISION  0
+
+///
+/// _CSD NumEntries for ACPI 3.0
+///
+#define EFI_ACPI_3_0_AML_CSD_NUM_ENTRIES  6
 
 //
 // Define for Descriptor

--- a/MdePkg/Include/IndustryStandard/Acpi40.h
+++ b/MdePkg/Include/IndustryStandard/Acpi40.h
@@ -2,6 +2,7 @@
   ACPI 4.0 definitions from the ACPI Specification Revision 4.0a April 5, 2010
 
   Copyright (c) 2010 - 2022, Intel Corporation. All rights reserved.<BR>
+  Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
@@ -9,6 +10,16 @@
 #define _ACPI_4_0_H_
 
 #include <IndustryStandard/Acpi30.h>
+
+///
+/// _CSD Revision for ACPI 4.0
+///
+#define EFI_ACPI_4_0_AML_CSD_REVISION  0
+
+///
+/// _CSD NumEntries for ACPI 4.0
+///
+#define EFI_ACPI_4_0_AML_CSD_NUM_ENTRIES  6
 
 ///
 /// _PSD Revision for ACPI 4.0

--- a/MdePkg/Include/IndustryStandard/Acpi50.h
+++ b/MdePkg/Include/IndustryStandard/Acpi50.h
@@ -4,6 +4,7 @@
   Copyright (c) 2014 Hewlett-Packard Development Company, L.P.<BR>
   Copyright (c) 2011 - 2022, Intel Corporation. All rights reserved.<BR>
   Copyright (c) 2020, ARM Ltd. All rights reserved.<BR>
+  Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
@@ -11,6 +12,16 @@
 #define _ACPI_5_0_H_
 
 #include <IndustryStandard/Acpi40.h>
+
+///
+/// _CSD Revision for ACPI 5.0
+///
+#define EFI_ACPI_5_0_AML_CSD_REVISION  0
+
+///
+/// _CSD NumEntries for ACPI 5.0
+///
+#define EFI_ACPI_5_0_AML_CSD_NUM_ENTRIES  6
 
 //
 // Define for Descriptor

--- a/MdePkg/Include/IndustryStandard/Acpi51.h
+++ b/MdePkg/Include/IndustryStandard/Acpi51.h
@@ -5,6 +5,7 @@
   Copyright (c) 2014 - 2022, Intel Corporation. All rights reserved.<BR>
   (C) Copyright 2015 Hewlett Packard Enterprise Development LP<BR>
   Copyright (c) 2020, ARM Ltd. All rights reserved.<BR>
+  Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved.
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
@@ -12,6 +13,16 @@
 #define _ACPI_5_1_H_
 
 #include <IndustryStandard/Acpi50.h>
+
+///
+/// _CSD Revision for ACPI 5.1
+///
+#define EFI_ACPI_5_1_AML_CSD_REVISION  0
+
+///
+/// _CSD NumEntries for ACPI 5.1
+///
+#define EFI_ACPI_5_1_AML_CSD_NUM_ENTRIES  6
 
 ///
 /// _PSD Revision for ACPI 5.1

--- a/MdePkg/Include/IndustryStandard/Acpi60.h
+++ b/MdePkg/Include/IndustryStandard/Acpi60.h
@@ -4,6 +4,7 @@
   Copyright (c) 2015 - 2022, Intel Corporation. All rights reserved.<BR>
   (C) Copyright 2015-2016 Hewlett Packard Enterprise Development LP<BR>
   Copyright (c) 2020, ARM Ltd. All rights reserved.<BR>
+  Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
@@ -11,6 +12,16 @@
 #define _ACPI_6_0_H_
 
 #include <IndustryStandard/Acpi51.h>
+
+///
+/// _CSD Revision for ACPI 6.0
+///
+#define EFI_ACPI_6_0_AML_CSD_REVISION  0
+
+///
+/// _CSD NumEntries for ACPI 6.0
+///
+#define EFI_ACPI_6_0_AML_CSD_NUM_ENTRIES  6
 
 ///
 /// _PSD Revision for ACPI 6.0

--- a/MdePkg/Include/IndustryStandard/Acpi61.h
+++ b/MdePkg/Include/IndustryStandard/Acpi61.h
@@ -4,6 +4,7 @@
   Copyright (c) 2016 - 2022, Intel Corporation. All rights reserved.<BR>
  (C) Copyright 2016 Hewlett Packard Enterprise Development LP<BR>
   Copyright (c) 2020, ARM Ltd. All rights reserved.<BR>
+  Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
@@ -11,6 +12,16 @@
 #define _ACPI_6_1_H_
 
 #include <IndustryStandard/Acpi60.h>
+
+///
+/// _CSD Revision for ACPI 6.1
+///
+#define EFI_ACPI_6_1_AML_CSD_REVISION  0
+
+///
+/// _CSD NumEntries for ACPI 6.1
+///
+#define EFI_ACPI_6_1_AML_CSD_NUM_ENTRIES  6
 
 ///
 /// _PSD Revision for ACPI 6.1

--- a/MdePkg/Include/IndustryStandard/Acpi62.h
+++ b/MdePkg/Include/IndustryStandard/Acpi62.h
@@ -3,6 +3,7 @@
 
   Copyright (c) 2017 - 2022, Intel Corporation. All rights reserved.<BR>
   Copyright (c) 2020, ARM Ltd. All rights reserved.<BR>
+  Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
@@ -10,6 +11,16 @@
 #define _ACPI_6_2_H_
 
 #include <IndustryStandard/Acpi61.h>
+
+///
+/// _CSD Revision for ACPI 6.2
+///
+#define EFI_ACPI_6_2_AML_CSD_REVISION  0
+
+///
+/// _CSD NumEntries for ACPI 6.2
+///
+#define EFI_ACPI_6_2_AML_CSD_NUM_ENTRIES  6
 
 //
 // Large Item Descriptor Name

--- a/MdePkg/Include/IndustryStandard/Acpi63.h
+++ b/MdePkg/Include/IndustryStandard/Acpi63.h
@@ -3,6 +3,7 @@
 
   Copyright (c) 2017 - 2022, Intel Corporation. All rights reserved.<BR>
   Copyright (c) 2019 - 2020, ARM Ltd. All rights reserved.<BR>
+  Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
@@ -11,6 +12,16 @@
 #define _ACPI_6_3_H_
 
 #include <IndustryStandard/Acpi62.h>
+
+///
+/// _CSD Revision for ACPI 6.3
+///
+#define EFI_ACPI_6_3_AML_CSD_REVISION  0
+
+///
+/// _CSD NumEntries for ACPI 6.3
+///
+#define EFI_ACPI_6_3_AML_CSD_NUM_ENTRIES  6
 
 ///
 /// _PSD Revision for ACPI 6.3

--- a/MdePkg/Include/IndustryStandard/Acpi64.h
+++ b/MdePkg/Include/IndustryStandard/Acpi64.h
@@ -3,6 +3,7 @@
 
   Copyright (c) 2017 - 2022, Intel Corporation. All rights reserved.<BR>
   Copyright (c) 2019 - 2021, ARM Ltd. All rights reserved.<BR>
+  Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
@@ -11,6 +12,16 @@
 #define ACPI_6_4_H_
 
 #include <IndustryStandard/Acpi63.h>
+
+///
+/// _CSD Revision for ACPI 6.4
+///
+#define EFI_ACPI_6_4_AML_CSD_REVISION  0
+
+///
+/// _CSD NumEntries for ACPI 6.4
+///
+#define EFI_ACPI_6_4_AML_CSD_NUM_ENTRIES  6
 
 ///
 /// _PSD Revision for ACPI 6.4

--- a/MdePkg/Include/IndustryStandard/Acpi65.h
+++ b/MdePkg/Include/IndustryStandard/Acpi65.h
@@ -4,6 +4,7 @@
   Copyright (c) 2017 - 2022, Intel Corporation. All rights reserved.<BR>
   Copyright (c) 2019 - 2024, ARM Ltd. All rights reserved.<BR>
   Copyright (c) 2023, Loongson Technology Corporation Limited. All rights reserved.<BR>
+  Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
@@ -17,6 +18,16 @@
 // Ensure proper structure formats
 //
 #pragma pack(1)
+
+///
+/// _CSD Revision for ACPI 6.5
+///
+#define EFI_ACPI_6_5_AML_CSD_REVISION  0
+
+///
+/// _CSD NumEntries for ACPI 6.5
+///
+#define EFI_ACPI_6_5_AML_CSD_NUM_ENTRIES  6
 
 ///
 /// _PSD Revision for ACPI 6.5

--- a/MdePkg/Include/IndustryStandard/Acpi65.h
+++ b/MdePkg/Include/IndustryStandard/Acpi65.h
@@ -20,6 +20,15 @@
 #pragma pack(1)
 
 ///
+/// _STA bit definitions ACPI 6.5 s6.3.7
+///
+#define ACPI_AML_STA_DEVICE_STATUS_PRESET       0x1
+#define ACPI_AML_STA_DEVICE_STATUS_ENABLED      0x2
+#define ACPI_AML_STA_DEVICE_STATUS_UI           0x4
+#define ACPI_AML_STA_DEVICE_STATUS_FUNCTIONING  0x8
+#define ACPI_AML_STA_DEVICE_STATUS_BATTERY      0x10
+
+///
 /// _CSD Revision for ACPI 6.5
 ///
 #define EFI_ACPI_6_5_AML_CSD_REVISION  0


### PR DESCRIPTION
# Description
This PR creates below ACPI objects for processor device for X64 arch
  C-State: Creates _CST and _CSD objects.
  P-State: Create _PCT, _PSS objects plus _PPC method
  _PSD object for domain dependency
  _CPC continue performance control object
 Update AML library to generate _CST, _CSD, _PCT and _PSS node.
 Generates _STA method based on configuration data.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Tested on AMD Platform

## Integration Instructions

N/A
