### PR TITLE
EmulatorPkg: spurious failure in WriteBlocks on X64

### DIFF
--- a/EmulatorPkg/Win/Host/WinBlockIo.c
+++ b/EmulatorPkg/Win/Host/WinBlockIo.c
@@ -356,7 +356,7 @@ WinNtBlockIoWriteBlocks (
   )
 {
   WIN_NT_BLOCK_IO_PRIVATE  *Private;
-  UINTN                    BytesWritten;
+  DWORD                    BytesWritten;
   BOOL                     Success;
   EFI_STATUS               Status;
   UINT64                   DistanceToMove;
@@ -375,7 +375,7 @@ WinNtBlockIoWriteBlocks (
     return WinNtBlockIoError (Private->Media);
   }
 
-  Success = WriteFile (Private->NtHandle, Buffer, (DWORD)BufferSize, (LPDWORD)&BytesWritten, NULL);
+  Success = WriteFile (Private->NtHandle, Buffer, (DWORD)BufferSize, &BytesWritten, NULL);
   if (!Success || (BytesWritten != BufferSize)) {
     return WinNtBlockIoError (Private->Media);
   }


### PR DESCRIPTION
# Description

WinNtBlockIoWriteBlocks can spuriously fail on X64. This occurs because &BytesWritten is a `UINTN*` (i.e. `UINT64*`) but is cast to `LPDWORD` (i.e. `UINT32*`). Only the low 32 bits are initialized by WriteFile, so the high 32 bits are uninitialized. This means we will spuriously fail the `BytesWritten != BufferSize` test.

This doesn't occur on X86-32 since UINTN is the same as DWORD in that case.

Fix is to declare BytesWritten as DWORD to match the type expected by WriteFile. This also makes the cast unnecessary.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

- Observed spurious failures in WriteBlocks.
- Applied fix.
- WriteBlocks now works as expected.

## Integration Instructions

N/A
