### PR TITLE
EmulatorPkg: BlockIo2 APIs do not signal event

### DIFF
--- a/EmulatorPkg/EmuBlockIoDxe/EmuBlockIo.c
+++ b/EmulatorPkg/EmuBlockIoDxe/EmuBlockIo.c
@@ -96,6 +96,11 @@ EmuBlockIo2ReadBlocksEx (
   Status = Private->Io->ReadBlocks (Private->Io, MediaId, LBA, Token, BufferSize, Buffer);
 
   gBS->RestoreTPL (OldTpl);
+
+  if (Token && Token->Event && !EFI_ERROR (Status)) {
+    gBS->SignalEvent (Token->Event);
+  }
+
   return Status;
 }
 
@@ -152,6 +157,11 @@ EmuBlockIo2WriteBlocksEx (
   Status = Private->Io->WriteBlocks (Private->Io, MediaId, LBA, Token, BufferSize, Buffer);
 
   gBS->RestoreTPL (OldTpl);
+
+  if (Token && Token->Event && !EFI_ERROR (Status)) {
+    gBS->SignalEvent (Token->Event);
+  }
+
   return Status;
 }
 
@@ -195,6 +205,11 @@ EmuBlockIo2Flush (
   Status = Private->Io->FlushBlocks (Private->Io, Token);
 
   gBS->RestoreTPL (OldTpl);
+
+  if (Token && Token->Event && !EFI_ERROR (Status)) {
+    gBS->SignalEvent (Token->Event);
+  }
+
   return Status;
 }
 


### PR DESCRIPTION
# Description

BlockIo2 Read/Write/Flush APIs should signal the token's event when the I/O operation completes, but the Emulator APIs do not. As a result, any code that tries to implement async I/O will hang on emulator.

Both Windows and Unix emulator hosts work the same way:

- All I/O is completed synchronously.
- All I/O implementations contain the comment: `// Caller is responsible for signaling EFI Event`

However, the protocol implementations do not signal the event, so the event is never signalled.

Fix is to signal the event in the appropriate protocol implementations.

- If the host API returns success then the I/O is complete since it's always synchronous.
- If there is a Token and Token->Event is not null and the I/O is successful then the event should be signalled.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

- Using application that uses async I/O and works correctly on real hardware.
- Application hanging in emulator because events are never signalled.
- Applied fix.
- Application now works correctly in emulator.

## Integration Instructions

N/A
