### PR TITLE
SecurityPkg: remove unused `EfiSig` variable in SecureBootFetchData

### DIFF
--- a/SecurityPkg/Library/SecureBootVariableProvisionLib/SecureBootVariableProvisionLib.c
+++ b/SecurityPkg/Library/SecureBootVariableProvisionLib/SecureBootVariableProvisionLib.c
@@ -46,7 +46,6 @@ SecureBootFetchData (
   OUT EFI_SIGNATURE_LIST  **SigListOut
   )
 {
-  EFI_SIGNATURE_LIST            *EfiSig;
   EFI_STATUS                    Status;
   VOID                          *Buffer;
   VOID                          *RsaPubKey;
@@ -57,7 +56,6 @@ SecureBootFetchData (
   SECURE_BOOT_CERTIFICATE_INFO  *NewCertInfo;
 
   KeyIndex      = 0;
-  EfiSig        = NULL;
   *SigListOut   = NULL;
   *SigListsSize = 0;
   CertInfo      = AllocatePool (sizeof (SECURE_BOOT_CERTIFICATE_INFO));
@@ -82,10 +80,6 @@ SecureBootFetchData (
       RsaPubKey = NULL;
       if (RsaGetPublicKeyFromX509 (Buffer, Size, &RsaPubKey) == FALSE) {
         DEBUG ((DEBUG_ERROR, "%a: Invalid key format: %d\n", __func__, KeyIndex));
-        if (EfiSig != NULL) {
-          FreePool (EfiSig);
-        }
-
         FreePool (Buffer);
         Status = EFI_INVALID_PARAMETER;
         break;


### PR DESCRIPTION
# Description

While looking through SecureBootFetchData I noticed the `EfiSig` variable is unused. So this PR removes it.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Built and ran with Secure Boot enabled on my Ampere Altra Dev Kit and verified functionality was unchanged.

## Integration Instructions

N/A