### PR TITLE
PullRequests.github-issues: Add PR notebook

### DIFF
--- a/Maintainers.txt
+++ b/Maintainers.txt
@@ -133,6 +133,12 @@ M: Joey Vagedes <joey.vagedes@gmail.com> [javagedes]
 R: Michael D Kinney <michael.d.kinney@intel.com> [mdkinney]
 R: Liming Gao <gaoliming@byosoft.com.cn> [lgao4]
 
+EDK II Contributed Files:
+-------------------------
+VS Code PR Dashboard Notebook
+F: contrib/PullRequests.github-issues
+M: Michael Kubacki <mikuback@linux.microsoft.com> [makubacki]
+
 EDK II Packages:
 ----------------
 ArmPkg

--- a/contrib/PullRequests.github-issues
+++ b/contrib/PullRequests.github-issues
@@ -1,0 +1,72 @@
+[
+  {
+    "kind": 1,
+    "language": "markdown",
+    "value": "## Tianocore GitHub Pull Request Dashboard"
+  },
+  {
+    "kind": 2,
+    "language": "github-issues",
+    "value": "// List of tianocore repos to include in results\r\n$repos=repo:tianocore/edk2 repo:tianocore/edk2-platforms repo:tianocore/containers repo:tianocore/edk2-non-osi repo:tianocore/edk2-test repo:tianocore/edk2-basetools repo:tianocore/edk2-libc repo:tianocore/edk2-pytool-library repo:tianocore/edk2-pytool-extensions repo:tianocore/edk2-edkrepo repo:tianocore/edk2-edkrepo-manifest"
+  },
+  {
+    "kind": 1,
+    "language": "markdown",
+    "value": "#### All Open Pull Requests"
+  },
+  {
+    "kind": 2,
+    "language": "github-issues",
+    "value": "$repos is:open type:pr"
+  },
+  {
+    "kind": 1,
+    "language": "markdown",
+    "value": "#### My Open Pull Requests\r\n\r\nDescription: PRs that you have open right now."
+  },
+  {
+    "kind": 2,
+    "language": "github-issues",
+    "value": "$repos is:open type:pr author:@me"
+  },
+  {
+    "kind": 1,
+    "language": "markdown",
+    "value": "#### Pull Requests that Requested My Review\r\n\r\nDescription: PRs that are requesting your review.\r\n\r\n- **You**: Review these as soon as possible."
+  },
+  {
+    "kind": 2,
+    "language": "github-issues",
+    "value": "$repos is:open type:pr review-requested:@me"
+  },
+  {
+    "kind": 1,
+    "language": "markdown",
+    "value": "#### All Approved PRs\r\n\r\nDescription: These are the PRs that have been approved by at least one reviewer.\r\n\r\n- **Maintainers**: Check if they should have the ``push`` label added.\r\n"
+  },
+  {
+    "kind": 2,
+    "language": "github-issues",
+    "value": "$repos is:open type:pr review:approved"
+  },
+  {
+    "kind": 1,
+    "language": "markdown",
+    "value": "#### All Stale PRs\r\n\r\nDescription: PRs that have had no activity in the last 60 days. They will be closed 7 days after being marked stale if no activity occurs. Leaving a comment will mark them as active.\r\n\r\n- **All**: Review this list and determine whether removing the `stale` label is appropriate. If not, leave a comment to mark the PR as active."
+  },
+  {
+    "kind": 2,
+    "language": "github-issues",
+    "value": "$repos is:open is:pr archived:false label:stale"
+  },
+  {
+    "kind": 1,
+    "language": "markdown",
+    "value": "#### All Pull Requests with the Push Label\r\n\r\nDescriptions: PRs that have the `push` label. These PRs are ready to be merged.\r\n\r\n- **Maintainers**: Review these PRs to verify none are \"stuck\" and need further attention to be merged."
+  },
+  {
+    "kind": 2,
+    "language": "github-issues",
+    "value": "$repos is:open is:pr archived:false label:push"
+  }
+]


### PR DESCRIPTION
# Description

Adds a VS Code GitHub issue notebook that can be used with the VS Code GitHub Issue Notebook Extension to view PR queries on Tianocore repositories.

VS Code extension:
https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-github-issue-notebooks

This is intended to provide a single real-time dashboard that reflects PR status from all Tianocore repositories so users can track their PRs and quickly find PRs that need their attention.

To use this, install the VS Code extension and open the file. This can be done in a Web browser at vscode.dev or locally in VS Code.

---

> This was shown in the Tianocore Tools & CI meeting as a view to help bring visibility to PRs.

### Example of Notebook

<img width="562" alt="image" src="https://github.com/user-attachments/assets/61751527-febb-487a-81c3-5619cf95806e">

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

- Used the notebook in VS Code to view PRs on Tianocore repositories

## Integration Instructions

- N/A