### PR TITLE
OvmfPkg: Introduce UEFI shell support for fw_cfg 

### DIFF
--- a/OvmfPkg/Library/PlatformBootManagerLib/BdsPlatform.c
+++ b/OvmfPkg/Library/PlatformBootManagerLib/BdsPlatform.c
@@ -15,6 +15,8 @@
 #include <Library/Tcg2PhysicalPresenceLib.h>
 #include <Library/XenPlatformLib.h>
 
+#include <Library/QemuFwCfgSimpleParserLib.h>
+
 //
 // Global data
 //
@@ -1843,6 +1845,18 @@ PlatformBootManagerAfterConsole (
     EfiBootManagerRefreshAllBootOption ();
   }
 
+  BOOLEAN        ShellEnabled;
+  RETURN_STATUS  RetStatus;
+
+  RetStatus = QemuFwCfgParseBool (
+                "opt/org.tianocore/EFIShellSupport",
+                &ShellEnabled
+                );
+
+  if (RETURN_ERROR (RetStatus)) {
+    ShellEnabled = TRUE;
+  }
+
   //
   // Register UEFI Shell
   //
@@ -1850,7 +1864,7 @@ PlatformBootManagerAfterConsole (
     &gUefiShellFileGuid,
     L"EFI Internal Shell",
     LOAD_OPTION_ACTIVE,
-    TRUE
+    ShellEnabled
     );
 
   //

--- a/OvmfPkg/Library/PlatformBootManagerLib/BdsPlatform.c
+++ b/OvmfPkg/Library/PlatformBootManagerLib/BdsPlatform.c
@@ -86,7 +86,8 @@ VOID
 PlatformRegisterFvBootOption (
   EFI_GUID  *FileGuid,
   CHAR16    *Description,
-  UINT32    Attributes
+  UINT32    Attributes,
+  BOOLEAN   Enabled
   )
 {
   EFI_STATUS                         Status;
@@ -138,8 +139,14 @@ PlatformRegisterFvBootOption (
                   BootOptionCount
                   );
 
-  if (OptionIndex == -1) {
+  if ((OptionIndex == -1) && Enabled) {
     Status = EfiBootManagerAddLoadOptionVariable (&NewOption, MAX_UINTN);
+    ASSERT_EFI_ERROR (Status);
+  } else if ((OptionIndex != -1) && !Enabled) {
+    Status = EfiBootManagerDeleteLoadOptionVariable (
+               BootOptions[OptionIndex].OptionNumber,
+               LoadOptionTypeBoot
+               );
     ASSERT_EFI_ERROR (Status);
   }
 
@@ -1842,7 +1849,8 @@ PlatformBootManagerAfterConsole (
   PlatformRegisterFvBootOption (
     &gUefiShellFileGuid,
     L"EFI Internal Shell",
-    LOAD_OPTION_ACTIVE
+    LOAD_OPTION_ACTIVE,
+    TRUE
     );
 
   //
@@ -1851,7 +1859,8 @@ PlatformBootManagerAfterConsole (
   PlatformRegisterFvBootOption (
     &gGrubFileGuid,
     L"Grub Bootloader",
-    LOAD_OPTION_ACTIVE
+    LOAD_OPTION_ACTIVE,
+    TRUE
     );
 
   RemoveStaleFvFileOptions ();

--- a/OvmfPkg/Library/PlatformBootManagerLib/BdsPlatform.c
+++ b/OvmfPkg/Library/PlatformBootManagerLib/BdsPlatform.c
@@ -199,6 +199,15 @@ PlatformRegisterFvBootOption (
                  );
   ASSERT (DevicePath != NULL);
 
+  //
+  // File is not in firmware, so it is going to be deleted anyway by
+  // RemoveStaleFvFileOptions, let's not add it.
+  //
+  if (!FileIsInFv (DevicePath)) {
+    FreePool (DevicePath);
+    return;
+  }
+
   Status = EfiBootManagerInitializeLoadOption (
              &NewOption,
              LoadOptionNumberUnassigned,

--- a/OvmfPkg/Library/PlatformBootManagerLib/PlatformBootManagerLib.inf
+++ b/OvmfPkg/Library/PlatformBootManagerLib/PlatformBootManagerLib.inf
@@ -56,6 +56,7 @@
   PlatformBmPrintScLib
   Tcg2PhysicalPresenceLib
   XenPlatformLib
+  QemuFwCfgSimpleParserLib
 
 [Pcd]
   gUefiOvmfPkgTokenSpaceGuid.PcdEmuVariableEvent

--- a/OvmfPkg/OvmfXen.dsc
+++ b/OvmfPkg/OvmfXen.dsc
@@ -168,6 +168,7 @@
   UefiUsbLib|MdePkg/Library/UefiUsbLib/UefiUsbLib.inf
   SerializeVariablesLib|OvmfPkg/Library/SerializeVariablesLib/SerializeVariablesLib.inf
   QemuFwCfgLib|OvmfPkg/Library/QemuFwCfgLib/QemuFwCfgDxeLib.inf
+  QemuFwCfgSimpleParserLib|OvmfPkg/Library/QemuFwCfgSimpleParserLib/QemuFwCfgSimpleParserLib.inf
   QemuLoadImageLib|OvmfPkg/Library/GenericQemuLoadImageLib/GenericQemuLoadImageLib.inf
   MemEncryptSevLib|OvmfPkg/Library/BaseMemEncryptSevLib/DxeMemEncryptSevLib.inf
   LockBoxLib|OvmfPkg/Library/LockBoxLib/LockBoxBaseLib.inf

--- a/OvmfPkg/RUNTIME_CONFIG.md
+++ b/OvmfPkg/RUNTIME_CONFIG.md
@@ -2,7 +2,7 @@
 
 Some aspects of OVMF can be configured from the host, mostly by adding
 firmware config files using the qemu command line option `-fw_cfg`.
-The official namespace prefix for edk2 is `opt/org.tianocode/` which
+The official namespace prefix for edk2 is `opt/org.tianocore/` which
 is used by most options.  Some options are elsewhere for historical
 reasons.
 
@@ -113,6 +113,16 @@ a workaround for a bug in shim version 15.6.  Usage:
 
 ```
 qemu-system-x86_64 -fw_cfg name=opt/org.tianocore/UninstallMemAttrProtocol,string=yes
+```
+
+
+## Shell: opt/org.tianocore/EFIShellSupport
+
+This enables/disables the EFI shell.
+Default: enabled.  Usage:
+
+```
+qemu-system-x86_64 -fw_cfg name=opt/org.tianocore/EFIShellSupport,string=no
 ```
 
 


### PR DESCRIPTION
# Description
This PR introduces the possibility to disable the UEFI shell from the QEMU CLI using the fw_cfg variable.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Run QEMU on X86-64 with and without the fw_cfg flag set.
For reference `qemu -fw_cfg name=opt/org.tianocore/EFIShellSupport=no`
UEFI Shell fails to boot when the value is set to no.

## Integration Instructions

N/A
