### PR TITLE
DynamicTablesPkg: Fix BDF format for PCI initiators

### DIFF
--- a/DynamicTablesPkg/Library/Acpi/Common/AcpiSratLib/SratGenerator.c
+++ b/DynamicTablesPkg/Library/Acpi/Common/AcpiSratLib/SratGenerator.c
@@ -80,9 +80,9 @@ GET_OBJECT_LIST (
 
 /** Return the PCI Device information in BDF format
 
-    PCI Bus Number - Max 256 busses (Bits 15:8 of BDF)
-    PCI Device Number - Max 32 devices (Bits 7:3 of BDF)
-    PCI Function Number - Max 8 functions (Bits 2:0 of BDF)
+    PCI Bus Number - Max 256 busses (Bits 7:0 of byte 0 of BDF)
+    PCI Device Number - Max 32 devices (Bits 7:3 of byte 1 of BDF)
+    PCI Function Number - Max 8 functions (Bits 2:0 of byte 1 BDF)
 
     @param [in]  DeviceHandlePci   Pointer to the PCI Device Handle.
 
@@ -94,12 +94,12 @@ GetBdf (
   IN CONST CM_ARCH_COMMON_DEVICE_HANDLE_PCI  *DeviceHandlePci
   )
 {
-  UINT16  Bdf;
+  UINT8  Bdf[2];
 
-  Bdf  = (UINT16)DeviceHandlePci->BusNumber << 8;
-  Bdf |= (DeviceHandlePci->DeviceNumber & 0x1F) << 3;
-  Bdf |= DeviceHandlePci->FunctionNumber & 0x7;
-  return Bdf;
+  Bdf[0]  = DeviceHandlePci->BusNumber;
+  Bdf[1]  = (DeviceHandlePci->DeviceNumber & 0x1F) << 3;
+  Bdf[1] |= DeviceHandlePci->FunctionNumber & 0x7;
+  return *(UINT16 *)Bdf;
 }
 
 /** Add the Memory Affinity Structures in the SRAT Table.


### PR DESCRIPTION
# Description
The BDF format for PCI initiators in the SRAT table is incorrect. The format is not a UINT16 but specific bytes.

PCI Bus Number (Bits 7:0 of Byte 2)
PCI Device Number (Bits 7:3 of Byte 3)
PCI Function Number (Bits 2:0 of Byte 3)

REF: https://uefi.org/specs/ACPI/6.5/05_ACPI_Software_Programming_Model.html#device-handle-pci


- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Validated table output with the acpiview -s SRAT

## Integration Instructions

N/A