### PR TITLE
MdeModulePkg/BrotliCustomDecompressLib: Make the library buildable

### DIFF
--- a/MdeModulePkg/Library/BrotliCustomDecompressLib/BrotliCustomDecompressLib.inf
+++ b/MdeModulePkg/Library/BrotliCustomDecompressLib/BrotliCustomDecompressLib.inf
@@ -1,9 +1,10 @@
 ## @file
 #  BrotliCustomDecompressLib produces BROTLI custom decompression algorithm.
 #
-#  It is based on the Brotli v0.5.2.
+#  It is based on the Brotli v1.0.9.
 #  Brotli was released on the website https://github.com/google/brotli.
 #
+#  Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.<BR>
 #  Copyright (c) 2017 - 2020, Intel Corporation. All rights reserved.<BR>
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -41,6 +42,10 @@
   # Wrapper header files end #
   brotli/c/common/dictionary.c
   brotli/c/common/transform.c
+  brotli/c/common/context.c
+  brotli/c/common/platform.c
+  brotli/c/common/constants.c
+  brotli/c/common/shared_dictionary.c
   brotli/c/dec/bit_reader.c
   brotli/c/dec/decode.c
   brotli/c/dec/huffman.c

--- a/MdeModulePkg/Library/BrotliCustomDecompressLib/intrin.h
+++ b/MdeModulePkg/Library/BrotliCustomDecompressLib/intrin.h
@@ -1,0 +1,9 @@
+/** @file
+  Include file to support building the third-party brotli.
+
+  Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <BrotliDecUefiSupport.h>

--- a/MdeModulePkg/Library/BrotliCustomDecompressLib/memory.h
+++ b/MdeModulePkg/Library/BrotliCustomDecompressLib/memory.h
@@ -1,0 +1,9 @@
+/** @file
+  Include file to support building the third-party brotli.
+
+  Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <BrotliDecUefiSupport.h>

--- a/MdeModulePkg/Library/BrotliCustomDecompressLib/stdio.h
+++ b/MdeModulePkg/Library/BrotliCustomDecompressLib/stdio.h
@@ -1,0 +1,9 @@
+/** @file
+  Include file to support building the third-party brotli.
+
+  Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <BrotliDecUefiSupport.h>


### PR DESCRIPTION
Brotli decompression library is supported in EDK2 core. Currently it is not buildable when linking it to DxeIpl driver. The result is also checked on edk2 master branch. It could be related to updating Brotli submodule (v1.0.9) on the previous commit (1193aa2). The update makes the library buildable. It was verified for the functional status.

REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4877

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

It has been tested and verified on some recent AMD platforms that support the decompression algorithm.

## Integration Instructions

N/A