### PR TITLE
Devcontainer: Use latest Fedora 40 image

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "image": "ghcr.io/tianocore/containers/fedora-39-dev:latest",
+  "image": "ghcr.io/tianocore/containers/fedora-40-dev:latest",
   "postCreateCommand": "git config --global --add safe.directory '*' && pip install --upgrade -r pip-requirements.txt",
   "customizations": {
     "vscode": {


### PR DESCRIPTION

# Description

Since the CI is now running on Fedora 40, let's also switch over VSCode Devcontainer to use the same.


- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Untested - I have trouble getting the VSCode Devcontainer extension to work.
Can some regular VSCode user please try this?

## Integration Instructions

