### PR TITLE
MdeModulePkg SmbiosMeasurementDxe: Release TableAddress after use

### DIFF
--- a/MdeModulePkg/Universal/SmbiosMeasurementDxe/SmbiosMeasurementDxe.c
+++ b/MdeModulePkg/Universal/SmbiosMeasurementDxe/SmbiosMeasurementDxe.c
@@ -637,6 +637,10 @@ MeasureSmbiosTable (
     if (!EFI_ERROR (Status)) {
       gBS->CloseEvent (Event);
     }
+
+    if (TableAddress != NULL) {
+      FreePool (TableAddress);
+    }
   }
 
   return;


### PR DESCRIPTION
# Description

BZ: https://bugzilla.tianocore.org/show_bug.cgi?id=4575

- [ ] Breaking change?
  - N/A
- [ ] Impacts security?
  - N/A
- [ ] Includes tests?
  - N/A

## How This Was Tested

Just include this module and boot into OS.

## Integration Instructions

N/A
