### PR TITLE
UefiPayloadPkg: Add AARCH64 FdtParseLib support and fix unaligned data access

### DIFF
--- a/UefiPayloadPkg/Library/CustomFdtNodeParserLib/CustomFdtNodeParserLib.c
+++ b/UefiPayloadPkg/Library/CustomFdtNodeParserLib/CustomFdtNodeParserLib.c
@@ -144,7 +144,7 @@ CustomFdtNodeParser (
       DEBUG ((DEBUG_INFO, "  Found upl-custom node (%08X)", CustomNode));
       PropertyPtr = FdtGetProperty (FdtBase, CustomNode, "hoblistptr", &TempLen);
       Data64      = (UINT64 *)(PropertyPtr->Data);
-      CHobList    = (UINTN)Fdt64ToCpu (*Data64);
+      CHobList    = (UINTN)Fdt64ToCpu (ReadUnaligned64 (Data64));
       DEBUG ((DEBUG_INFO, "  Found hob list node (%08X)", CustomNode));
       DEBUG ((DEBUG_INFO, " -pointer  %016lX\n", CHobList));
     }

--- a/UefiPayloadPkg/Library/FdtParserLib/FdtParseLib.inf
+++ b/UefiPayloadPkg/Library/FdtParserLib/FdtParseLib.inf
@@ -17,7 +17,7 @@
 #
 # The following information is for reference only and not required by the build tools.
 #
-#  VALID_ARCHITECTURES           = IA32 X64
+#  VALID_ARCHITECTURES           = IA32 X64 AARCH64
 #
 
 [Sources]
@@ -43,7 +43,7 @@
   gUniversalPayloadSerialPortInfoGuid
   gUplPciSegmentInfoHobGuid
 
-[Pcd.IA32,Pcd.X64,Pcd.RISCV64]
+[Pcd.IA32,Pcd.X64,Pcd.RISCV64,Pcd.AARCH64]
   gUefiPayloadPkgTokenSpaceGuid.PcdPayloadFdMemSize
   gUefiPayloadPkgTokenSpaceGuid.PcdSystemMemoryUefiRegionSize
   gUefiPayloadPkgTokenSpaceGuid.PcdHandOffFdtEnable

--- a/UefiPayloadPkg/Library/FdtParserLib/FdtParserLib.c
+++ b/UefiPayloadPkg/Library/FdtParserLib/FdtParserLib.c
@@ -190,8 +190,8 @@ ParseMemory (
     TempStr     = FdtGetString (Fdt, Fdt32ToCpu (PropertyPtr->NameOffset), NULL);
     if (AsciiStrCmp (TempStr, "reg") == 0) {
       Data64        = (UINT64 *)(PropertyPtr->Data);
-      StartAddress  = Fdt64ToCpu (*Data64);
-      NumberOfBytes = Fdt64ToCpu (*(Data64 + 1));
+      StartAddress  = Fdt64ToCpu (ReadUnaligned64 (Data64));
+      NumberOfBytes = Fdt64ToCpu (ReadUnaligned64 (Data64 + 1));
     } else if (AsciiStrCmp (TempStr, "ecc-detection-bits") == 0) {
       Data32  = (UINT32 *)(PropertyPtr->Data);
       ECCData = Fdt32ToCpu (*Data32);
@@ -250,8 +250,8 @@ ParseReservedMemory (
     TempStr = (CHAR8 *)(PropertyPtr->Data);
     if (TempLen > 0) {
       Data64        = (UINT64 *)(PropertyPtr->Data);
-      StartAddress  = Fdt64ToCpu (*Data64);
-      NumberOfBytes = Fdt64ToCpu (*(Data64 + 1));
+      StartAddress  = Fdt64ToCpu (ReadUnaligned64 (Data64));
+      NumberOfBytes = Fdt64ToCpu (ReadUnaligned64 (Data64 + 1));
       DEBUG ((DEBUG_INFO, "\n         Property  %a", TempStr));
       DEBUG ((DEBUG_INFO, "  %016lX  %016lX\n", StartAddress, NumberOfBytes));
     }
@@ -430,7 +430,7 @@ ParseOptions (
       ASSERT (TempLen > 0);
       if (TempLen > 0) {
         Data64       = (UINT64 *)(PropertyPtr->Data);
-        StartAddress = Fdt64ToCpu (*Data64);
+        StartAddress = Fdt64ToCpu (ReadUnaligned64 (Data64));
         DEBUG ((DEBUG_INFO, "\n         Property(00000000)  entry"));
         DEBUG ((DEBUG_INFO, "  %016lX\n", StartAddress));
 
@@ -758,7 +758,7 @@ ParsePciRootBridge (
 
     if (AsciiStrCmp (TempStr, "reg") == 0) {
       UINT64  *Data64 = (UINT64 *)(PropertyPtr->Data);
-      mUplPciSegmentInfoHob->SegmentInfo[RbIndex].BaseAddress = Fdt64ToCpu (*Data64);
+      mUplPciSegmentInfoHob->SegmentInfo[RbIndex].BaseAddress = Fdt64ToCpu (ReadUnaligned64 (Data64));
       DEBUG ((DEBUG_INFO, "PciRootBridge->Ecam.Base %llx, \n", mUplPciSegmentInfoHob->SegmentInfo[RbIndex].BaseAddress));
     }
 
@@ -845,7 +845,7 @@ ParseDtb (
 
   for (Node = FdtNextNode (Fdt, 0, &Depth); Node >= 0; Node = FdtNextNode (Fdt, Node, &Depth)) {
     NodePtr = (FDT_NODE_HEADER *)((CONST CHAR8 *)Fdt + Node + Fdt32ToCpu (((FDT_HEADER *)Fdt)->OffsetDtStruct));
-    DEBUG ((DEBUG_INFO, "\n   Node(%08x)  %a   Depth %x", Node, NodePtr->Name, Depth));
+    DEBUG ((DEBUG_INFO, "\n   Node(%08x)  %a   Depth %x\n", Node, NodePtr->Name, Depth));
     // memory node
     if (AsciiStrnCmp (NodePtr->Name, "memory@", AsciiStrLen ("memory@")) == 0) {
       for (Property = FdtFirstPropertyOffset (Fdt, Node); Property >= 0; Property = FdtNextPropertyOffset (Fdt, Property)) {
@@ -853,8 +853,8 @@ ParseDtb (
         TempStr     = FdtGetString (Fdt, Fdt32ToCpu (PropertyPtr->NameOffset), NULL);
         if (AsciiStrCmp (TempStr, "reg") == 0) {
           Data64        = (UINT64 *)(PropertyPtr->Data);
-          StartAddress  = Fdt64ToCpu (*Data64);
-          NumberOfBytes = Fdt64ToCpu (*(Data64 + 1));
+          StartAddress  = Fdt64ToCpu (ReadUnaligned64 (Data64));
+          NumberOfBytes = Fdt64ToCpu (ReadUnaligned64 (Data64 + 1));
           DEBUG ((DEBUG_INFO, "\n         Property(%08X)  %a", Property, TempStr));
           DEBUG ((DEBUG_INFO, "  %016lX  %016lX", StartAddress, NumberOfBytes));
           if (!IsHobConstructed) {

--- a/UefiPayloadPkg/UefiPayloadEntry/AcpiTable.c
+++ b/UefiPayloadPkg/UefiPayloadEntry/AcpiTable.c
@@ -77,7 +77,7 @@ ParseAcpiInfo (
     Entry64    = (UINT64 *)(Xsdt + 1);
     Entry64Num = (Xsdt->Length - sizeof (EFI_ACPI_DESCRIPTION_HEADER)) >> 3;
     for (Idx = 0; Idx < Entry64Num; Idx++) {
-      Signature = (UINT32 *)(UINTN)Entry64[Idx];
+      Signature = (UINT32 *)(UINTN)ReadUnaligned64 (&Entry64[Idx]);
       if (*Signature == EFI_ACPI_3_0_FIXED_ACPI_DESCRIPTION_TABLE_SIGNATURE) {
         Fadt = (EFI_ACPI_3_0_FIXED_ACPI_DESCRIPTION_TABLE *)Signature;
         DEBUG ((DEBUG_INFO, "Found Fadt in Xsdt\n"));


### PR DESCRIPTION
# Description

1) Add AARCH64 support in UefiPayloadPkg/FdtParseLib
2) Add fix in Fdt Parse Lib for unaligned data access
3) Add fix in ACPI parsing

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - No
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - No
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - No
## How This Was Tested

These commits have been validated on top of QEMU and Bare Metal AARCH64 platforms.

## Integration Instructions

<N/A>
