### PR TITLE
NetworkPkg/WifiConnectionManagerDxe: Keep Setup page on no Wi-Fi module

### DIFF
--- a/NetworkPkg/WifiConnectionManagerDxe/WifiConnectionMgrHiiConfigAccess.c
+++ b/NetworkPkg/WifiConnectionManagerDxe/WifiConnectionMgrHiiConfigAccess.c
@@ -1351,7 +1351,6 @@ WifiMgrDxeHiiConfigAccessRouteConfig (
   @retval EFI_SUCCESS            The callback successfully handled the action.
   @retval EFI_OUT_OF_RESOURCES   Not enough storage is available to hold the
                                  variable and its data.
-  @retval EFI_DEVICE_ERROR       The variable could not be saved.
   @retval EFI_UNSUPPORTED        The specified Action is not supported by the
                                  callback.
 
@@ -1400,7 +1399,7 @@ WifiMgrDxeHiiConfigAccessCallback (
   Status  = EFI_SUCCESS;
   Private = WIFI_MGR_PRIVATE_DATA_FROM_CONFIG_ACCESS (This);
   if (Private->CurrentNic == NULL) {
-    return EFI_DEVICE_ERROR;
+    return EFI_UNSUPPORTED;
   }
 
   //


### PR DESCRIPTION
With the driver, "Wi-Fi Configuration" Setup page is available regardless of Wi-Fi module existence. When there is no Wi-Fi module, it is found that entering the page causes exiting Setup browser. User would think the result as an error. For better user experience, the update enables the page to report the module status like a blank page. It prevents exiting Setup.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

We had an issue that system exits setup unexpectedly when entering the Wifi Configuration page without connecting a Wifi module. It has been tested and verified on AMD platforms that include the update.

## Integration Instructions

N/A