### PR TITLE
Enable foreign image loading on LoongArch64 and synchronize the changes about LoongArch64 in section 18.2.5 of UEFI 2.11

### DIFF
--- a/MdePkg/Include/Protocol/DebugSupport.h
+++ b/MdePkg/Include/Protocol/DebugSupport.h
@@ -680,23 +680,23 @@ typedef struct {
   UINT32    STVAL;
 } EFI_SYSTEM_CONTEXT_RISCV64;
 
-//
-// LoongArch processor exception types.
-//
-// The exception types is located in the CSR ESTAT
-// register offset 16 bits, width 6 bits.
-//
-// If you want to register an exception hook, you can
-// shfit the number left by 16 bits, and the exception
-// handler will know the types.
-//
-// For example:
-// mCpu->CpuRegisterInterruptHandler (
-//         mCpu,
-//         (EXCEPT_LOONGARCH_PPI << CSR_ESTAT_EXC_SHIFT),
-//         PpiExceptionHandler
-//         );
-//
+///
+/// LoongArch processor exception types.
+///
+/// The exception types is located in the CSR ESTAT
+/// register offset 16 bits, width 6 bits.
+///
+/// If you want to register an exception hook, you can
+/// shfit the number left by 16 bits, and the exception
+/// handler will know the types.
+///
+/// For example:
+/// mCpu->CpuRegisterInterruptHandler (
+///         mCpu,
+///         (EXCEPT_LOONGARCH_PPI << CSR_ESTAT_EXC_SHIFT),
+///         PpiExceptionHandler
+///         );
+///
 #define EXCEPT_LOONGARCH_INT   0
 #define EXCEPT_LOONGARCH_PIL   1
 #define EXCEPT_LOONGARCH_PIS   2
@@ -716,11 +716,22 @@ typedef struct {
 #define EXCEPT_LOONGARCH_SXD   16
 #define EXCEPT_LOONGARCH_ASXD  17
 #define EXCEPT_LOONGARCH_FPE   18
-#define EXCEPT_LOONGARCH_TBR   64 // For code only, there is no such type in the ISA spec, the TLB refill is defined for an independent exception.
+#define EXCEPT_LOONGARCH_WPE   19
+#define EXCEPT_LOONGARCH_BTD   20
+#define EXCEPT_LOONGARCH_BTE   21
+#define EXCEPT_LOONGARCH_GSPR  22
+#define EXCEPT_LOONGARCH_HVC   23
+#define EXCEPT_LOONGARCH_GCXC  24
 
-//
-// LoongArch processor Interrupt types.
-//
+///
+/// For coding convenience, define the maximum valid
+/// LoongArch exception.
+///
+#define MAX_LOONGARCH_EXCEPTION  64
+
+///
+/// LoongArch processor Interrupt types.
+///
 #define EXCEPT_LOONGARCH_INT_SIP0   0
 #define EXCEPT_LOONGARCH_INT_SIP1   1
 #define EXCEPT_LOONGARCH_INT_IP0    2
@@ -735,11 +746,11 @@ typedef struct {
 #define EXCEPT_LOONGARCH_INT_TIMER  11
 #define EXCEPT_LOONGARCH_INT_IPI    12
 
-//
-// For coding convenience, define the maximum valid
-// LoongArch interrupt.
-//
-#define MAX_LOONGARCH_INTERRUPT  14
+///
+/// For coding convenience, define the maximum valid
+/// LoongArch interrupt.
+///
+#define MAX_LOONGARCH_INTERRUPT  16
 
 typedef struct {
   UINT64    R0;

--- a/MdePkg/Library/BasePeCoffLib/LoongArch/PeCoffLoaderEx.c
+++ b/MdePkg/Library/BasePeCoffLib/LoongArch/PeCoffLoaderEx.c
@@ -104,7 +104,15 @@ PeCoffLoaderImageFormatSupported (
   IN  UINT16  Machine
   )
 {
-  if (Machine == IMAGE_FILE_MACHINE_LOONGARCH64) {
+  /*
+   * ARM64 and X64 may allow such foreign images to be used when
+   * a driver implementing EDKII_PECOFF_IMAGE_EMULATOR_PROTOCOL is
+   * present.
+   */
+  if ((Machine == IMAGE_FILE_MACHINE_LOONGARCH64) ||
+      (Machine == IMAGE_FILE_MACHINE_ARM64) ||
+      (Machine == IMAGE_FILE_MACHINE_X64))
+  {
     return TRUE;
   }
 

--- a/OvmfPkg/LoongArchVirt/Sec/LoongArch64/Start.S
+++ b/OvmfPkg/LoongArchVirt/Sec/LoongArch64/Start.S
@@ -19,12 +19,6 @@
 #include <Protocol/DebugSupport.h>
 
 #define BOOTCORE_ID  0
-//
-// For coding convenience, define the maximum valid
-// LoongArch exception.
-// Since UEFI V2.11, it will be present in DebugSupport.h.
-//
-#define MAX_LOONGARCH_EXCEPTION  64
 
 ASM_GLOBAL ASM_PFX(_ModuleEntryPoint)
 ASM_PFX(_ModuleEntryPoint):

--- a/UefiCpuPkg/CpuDxe/LoongArch64/CpuDxe.h
+++ b/UefiCpuPkg/CpuDxe/LoongArch64/CpuDxe.h
@@ -27,13 +27,6 @@
 #include <Protocol/DebugSupport.h>
 #include <Protocol/LoadedImage.h>
 
-//
-// For coding convenience, define the maximum valid
-// LoongArch exception.
-// Since UEFI V2.11, it will be present in DebugSupport.h.
-//
-#define MAX_LOONGARCH_EXCEPTION  64
-
 /*
   This function flushes the range of addresses from Start to Start+Length
   from the processor's data cache. If Start is not aligned to a cache line

--- a/UefiCpuPkg/Library/CpuExceptionHandlerLib/LoongArch/ExceptionCommon.h
+++ b/UefiCpuPkg/Library/CpuExceptionHandlerLib/LoongArch/ExceptionCommon.h
@@ -12,13 +12,6 @@
 
 #define MAX_DEBUG_MESSAGE_LENGTH  0x100
 
-//
-// For coding convenience, define the maximum valid
-// LoongArch exception.
-// Since UEFI V2.11, it will be present in DebugSupport.h.
-//
-#define MAX_LOONGARCH_EXCEPTION  64
-
 extern INTN  mExceptionKnownNameNum;
 
 /**

--- a/UefiCpuPkg/Library/CpuMmuLib/LoongArch64/Page.h
+++ b/UefiCpuPkg/Library/CpuMmuLib/LoongArch64/Page.h
@@ -23,11 +23,4 @@
 #define PTE_PPN_SHIFT             EFI_PAGE_SHIFT
 #define LOONGARCH_MMU_PAGE_SHIFT  EFI_PAGE_SHIFT
 
-//
-// For coding convenience, define the maximum valid
-// LoongArch exception.
-// Since UEFI V2.11, it will be present in DebugSupport.h.
-//
-#define MAX_LOONGARCH_EXCEPTION  64
-
 #endif // PAGE_H_


### PR DESCRIPTION
# Description
1. Added LoongArch64 loading foreign image support.
2. Synchronized UEFI 2.11 LoongArch64 changes.

## How This Was Tested

Build OvmfPkg/LoongArchVirt/LoongArchVirtQemu.dsc and run it.

## Integration Instructions

N/A
