### PR TITLE
UsbBusDxe: Add quirk for Realtek RTL8156

### DIFF
--- a/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbEnumer.c
+++ b/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbEnumer.c
@@ -827,7 +827,12 @@ UsbEnumerateNewDev (
   // Select a default configuration: UEFI must set the configuration
   // before the driver can connect to the device.
   //
-  Config = Child->DevDesc->Configs[0]->Desc.ConfigurationValue;
+  // Quirk for Realtek Ethernet adapter, must select second configuration for CDC NCM
+  if (Child->DevDesc->Desc.IdVendor == 0x0bda && Child->DevDesc->Desc.IdProduct == 0x8156) {
+    Config = Child->DevDesc->Configs[1]->Desc.ConfigurationValue;
+  } else {
+    Config = Child->DevDesc->Configs[0]->Desc.ConfigurationValue;
+  }
   Status = UsbSetConfig (Child, Config);
 
   if (EFI_ERROR (Status)) {


### PR DESCRIPTION
# Description

The Framework Ethernet Expansion card uses an Realtek 8156 chip. It has a device descriptor with three configurations:

- Vendor Specific
- CDC NCM
- CDC ECM

The default configuration cannot be used by drivers available in EDK2, so we must change it.
FreeBSD used to have the same quirk before they implemented a custom driver for Realtek adapters:
https://github.com/freebsd/freebsd-src/commit/6ea4d95f6c76aa64d2db5c04c87e68dc299544df

Realtek provides a proprietary UEFI driver, but with this change, the open source EDK2 driver also works.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Selecting configuration 1 results in
> drivers
8A 00000001 D - -  1  - USB NCM Driver                      UsbCdcNcm
Selecting configuration 2 results in
> drivers
89 00000001 D - -  1  - USB ECM Driver                      UsbCdcEcm

Both of them can work with iPXE/netboot.xyz

Tested in QEMU/OVMF by passing the USB device through.

> sudo qemu-system-x86_64 -bios Build/OvmfX64/DEBUG_GCC5/FV/OVMF.fd -m 4G \
  -device qemu-xhci,id=xhci -device usb-host,bus=xhci.0,vendorid=0x0bda,productid=0x8156 \
  -nic none \
  -cdrom netboot.xyz.iso