### PR TITLE
[v2] Add support for a SVSM vTPM

### DIFF
--- a/Maintainers.txt
+++ b/Maintainers.txt
@@ -599,6 +599,11 @@ SecurityPkg: Tcg related modules
 F: SecurityPkg/Tcg/
 R: Rahul Kumar <rahul1.kumar@intel.com> [rahul1-kumar]
 
+SecurityPkg: SVSM related modules
+F: SecurityPkg/Library/Tpm2DeviceLibDTpm/*Svsm*
+R: Oliver Steffen <osteffen@redhat.com> [osteffenrh]
+R: Tom Lendacky <thomas.lendacky@amd.com> [tlendacky]
+
 ShellPkg
 F: ShellPkg/
 W: https://github.com/tianocore/tianocore.github.io/wiki/ShellPkg

--- a/MdePkg/Include/Register/Amd/Svsm.h
+++ b/MdePkg/Include/Register/Amd/Svsm.h
@@ -98,4 +98,23 @@ typedef union {
   UINT64    Uint64;
 } SVSM_FUNCTION;
 
+/// SVSM Guest Protocols
+/// @{
+#define SVSM_PROTOCOL_CORE         0
+#define SVSM_PROTOCOL_ATTESTATION  1
+#define SVSM_PROTOCOL_VTPM         2
+/// @}
+
+/// SVSM Core Protocol calls
+/// @{
+#define SVSM_CORE_REMAP_CA        0
+#define SVSM_CORE_PVALIDATE       1
+#define SVSM_CORE_CREATE_VCPU     2
+#define SVSM_CORE_DELETE_VCPU     3
+#define SVSM_CORE_DEPOSIT_MEM     4
+#define SVSM_CORE_WITHDRAW_MEM    5
+#define SVSM_CORE_QUERY_PROTOCOL  6
+#define SVSM_CORE_CONFIGURE_VTOM  7
+/// @}
+
 #endif

--- a/MdePkg/Include/Register/Amd/Svsm.h
+++ b/MdePkg/Include/Register/Amd/Svsm.h
@@ -117,4 +117,10 @@ typedef union {
 #define SVSM_CORE_CONFIGURE_VTOM  7
 /// @}
 
+/// SVSM vTPM Protocol calls
+/// @{
+#define SVSM_VTPM_QUERY  0
+#define SVSM_VTPM_CMD    1
+/// @}
+
 #endif

--- a/OvmfPkg/Include/Dsc/OvmfTpmComponentsDxe.dsc.inc
+++ b/OvmfPkg/Include/Dsc/OvmfTpmComponentsDxe.dsc.inc
@@ -6,7 +6,7 @@
   SecurityPkg/Tcg/Tcg2Dxe/Tcg2Dxe.inf {
     <LibraryClasses>
       Tpm2DeviceLib|SecurityPkg/Library/Tpm2DeviceLibRouter/Tpm2DeviceLibRouterDxe.inf
-      NULL|SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2InstanceLibDTpm.inf
+      NULL|SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2InstanceLibDTpmSvsm.inf
       HashLib|SecurityPkg/Library/HashLibBaseCryptoRouter/HashLibBaseCryptoRouterDxe.inf
       NULL|SecurityPkg/Library/HashInstanceLibSha1/HashInstanceLibSha1.inf
       NULL|SecurityPkg/Library/HashInstanceLibSha256/HashInstanceLibSha256.inf

--- a/OvmfPkg/Include/Dsc/OvmfTpmLibs.dsc.inc
+++ b/OvmfPkg/Include/Dsc/OvmfTpmLibs.dsc.inc
@@ -30,7 +30,7 @@
 !if $(TPM1_ENABLE) == TRUE
   Tpm12DeviceLib|SecurityPkg/Library/Tpm12DeviceLibDTpm/Tpm12DeviceLibDTpm.inf
 !endif
-  Tpm2DeviceLib|SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2DeviceLibDTpm.inf
+  Tpm2DeviceLib|SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2DeviceLibDTpmSvsm.inf
 !endif
 
 !if $(TPM2_ENABLE) == TRUE || $(CC_MEASUREMENT_ENABLE) == TRUE

--- a/OvmfPkg/Library/AmdSvsmLib/AmdSvsmLib.c
+++ b/OvmfPkg/Library/AmdSvsmLib/AmdSvsmLib.c
@@ -498,3 +498,98 @@ AmdSvsmSnpVmsaRmpAdjust (
   return AmdSvsmIsSvsmPresent () ? SvsmVmsaRmpAdjust (Vmsa, ApicId, SetVmsa)
                                 : BaseVmsaRmpAdjust (Vmsa, SetVmsa);
 }
+
+/**
+  Perform a SVSM_VTPM_QUERY operation
+
+  Query the support provided by the SVSM vTPM.
+
+  @param[out] PlatformCommands    It will contain a bitmap indicating the
+                                  supported vTPM platform commands.
+  @param[out] Features            It will contain a bitmap indicating the
+                                  supported vTPM features.
+
+  @retval TRUE                    The query was processed.
+  @retval FALSE                   The query was not processed.
+
+**/
+BOOLEAN
+EFIAPI
+AmdSvsmVtpmQuery (
+  OUT UINT64  *PlatformCommands,
+  OUT UINT64  *Features
+  )
+{
+  SVSM_CALL_DATA  SvsmCallData;
+  SVSM_FUNCTION   Function;
+  UINTN           Ret;
+
+  if (!PlatformCommands && !Features) {
+    return FALSE;
+  }
+
+  if (!AmdSvsmIsSvsmPresent ()) {
+    return FALSE;
+  }
+
+  Function.Id.Protocol = SVSM_PROTOCOL_VTPM;
+  Function.Id.CallId   = SVSM_VTPM_QUERY;
+
+  SvsmCallData.Caa   = (SVSM_CAA *)AmdSvsmSnpGetCaa ();
+  SvsmCallData.RaxIn = Function.Uint64;
+
+  Ret = SvsmMsrProtocol (&SvsmCallData);
+  if (Ret != 0) {
+    return FALSE;
+  }
+
+  if (PlatformCommands) {
+    *PlatformCommands = SvsmCallData.RcxOut;
+  }
+
+  if (Features) {
+    *Features = SvsmCallData.RdxOut;
+  }
+
+  return TRUE;
+}
+
+/**
+  Perform a SVSM_VTPM_CMD operation
+
+  Send the specified vTPM platform command to the SVSM vTPM.
+
+  @param[in, out] Buffer  It should contain the vTPM platform command
+                          request. The respective response will be returned
+                          in the same Buffer, but not all commands specify a
+                          response.
+
+  @retval TRUE            The command was processed.
+  @retval FALSE           The command was not processed.
+
+**/
+BOOLEAN
+EFIAPI
+AmdSvsmVtpmCmd (
+  IN OUT UINT8  *Buffer
+  )
+{
+  SVSM_CALL_DATA  SvsmCallData;
+  SVSM_FUNCTION   Function;
+  UINTN           Ret;
+
+  if (!AmdSvsmIsSvsmPresent ()) {
+    return FALSE;
+  }
+
+  Function.Id.Protocol = SVSM_PROTOCOL_VTPM;
+  Function.Id.CallId   = SVSM_VTPM_CMD;
+
+  SvsmCallData.Caa   = (SVSM_CAA *)AmdSvsmSnpGetCaa ();
+  SvsmCallData.RaxIn = Function.Uint64;
+  SvsmCallData.RcxIn = (UINT64)(UINTN)Buffer;
+
+  Ret = SvsmMsrProtocol (&SvsmCallData);
+
+  return (Ret == 0) ? TRUE : FALSE;
+}

--- a/OvmfPkg/Library/AmdSvsmLib/AmdSvsmLib.c
+++ b/OvmfPkg/Library/AmdSvsmLib/AmdSvsmLib.c
@@ -213,8 +213,8 @@ SvsmPvalidate (
   Caa = (SVSM_CAA *)AmdSvsmSnpGetCaa ();
   ZeroMem (Caa->SvsmBuffer, sizeof (Caa->SvsmBuffer));
 
-  Function.Id.Protocol = 0;
-  Function.Id.CallId   = 1;
+  Function.Id.Protocol = SVSM_PROTOCOL_CORE;
+  Function.Id.CallId   = SVSM_CORE_PVALIDATE;
 
   Request    = (SVSM_PVALIDATE_REQUEST *)Caa->SvsmBuffer;
   EntryLimit = ((sizeof (Caa->SvsmBuffer) - sizeof (*Request)) /
@@ -407,17 +407,17 @@ SvsmVmsaRmpAdjust (
 
   SvsmCallData.Caa = (SVSM_CAA *)AmdSvsmSnpGetCaa ();
 
-  Function.Id.Protocol = 0;
+  Function.Id.Protocol = SVSM_PROTOCOL_CORE;
 
   if (SetVmsa) {
-    Function.Id.CallId = 2;
+    Function.Id.CallId = SVSM_CORE_CREATE_VCPU;
 
     SvsmCallData.RaxIn = Function.Uint64;
     SvsmCallData.RcxIn = (UINT64)(UINTN)Vmsa;
     SvsmCallData.RdxIn = (UINT64)(UINTN)Vmsa + SIZE_4KB;
     SvsmCallData.R8In  = ApicId;
   } else {
-    Function.Id.CallId = 3;
+    Function.Id.CallId = SVSM_CORE_DELETE_VCPU;
 
     SvsmCallData.RaxIn = Function.Uint64;
     SvsmCallData.RcxIn = (UINT64)(UINTN)Vmsa;

--- a/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2DeviceLibDTpm.c
+++ b/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2DeviceLibDTpm.c
@@ -79,9 +79,9 @@ Tpm2SubmitCommand (
 }
 
 /**
-  This service requests use TPM2.
+  This service requests to use TPM2.
 
-  @retval EFI_SUCCESS      Get the control of TPM2 chip.
+  @retval EFI_SUCCESS      Get the control of the TPM2 chip.
   @retval EFI_NOT_FOUND    TPM2 not found.
   @retval EFI_DEVICE_ERROR Unexpected device behavior.
 **/
@@ -95,13 +95,13 @@ Tpm2RequestUseTpm (
 }
 
 /**
-  This service register TPM2 device.
+  This service registers a TPM2 device.
 
   @param Tpm2Device  TPM2 device
 
-  @retval EFI_SUCCESS          This TPM2 device is registered successfully.
-  @retval EFI_UNSUPPORTED      System does not support register this TPM2 device.
-  @retval EFI_ALREADY_STARTED  System already register this TPM2 device.
+  @retval EFI_SUCCESS          TPM2 device was registered successfully.
+  @retval EFI_UNSUPPORTED      System does not support registering this TPM2 device.
+  @retval EFI_ALREADY_STARTED  This TPM2 device is already registered.
 **/
 EFI_STATUS
 EFIAPI
@@ -115,7 +115,7 @@ Tpm2RegisterTpm2DeviceLib (
 /**
   The function caches current active TPM interface type.
 
-  @retval EFI_SUCCESS   DTPM2.0 instance is registered, or system does not support register DTPM2.0 instance
+  @retval EFI_SUCCESS   DTPM2.0 instance is registered, or system does not support registering a DTPM2.0 instance
 **/
 EFI_STATUS
 EFIAPI

--- a/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2DeviceLibDTpm.c
+++ b/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2DeviceLibDTpm.c
@@ -13,41 +13,8 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/Tpm2DeviceLib.h>
 #include <Library/PcdLib.h>
 
+#include "Tpm2Ptp.h"
 #include "Tpm2DeviceLibDTpm.h"
-
-/**
-  This service enables the sending of commands to the TPM2.
-
-  @param[in]      InputParameterBlockSize  Size of the TPM2 input parameter block.
-  @param[in]      InputParameterBlock      Pointer to the TPM2 input parameter block.
-  @param[in,out]  OutputParameterBlockSize Size of the TPM2 output parameter block.
-  @param[in]      OutputParameterBlock     Pointer to the TPM2 output parameter block.
-
-  @retval EFI_SUCCESS            The command byte stream was successfully sent to the device and a response was successfully received.
-  @retval EFI_DEVICE_ERROR       The command was not successfully sent to the device or a response was not successfully received from the device.
-  @retval EFI_BUFFER_TOO_SMALL   The output parameter block is too small.
-**/
-EFI_STATUS
-EFIAPI
-DTpm2SubmitCommand (
-  IN UINT32      InputParameterBlockSize,
-  IN UINT8       *InputParameterBlock,
-  IN OUT UINT32  *OutputParameterBlockSize,
-  IN UINT8       *OutputParameterBlock
-  );
-
-/**
-  This service requests use TPM2.
-
-  @retval EFI_SUCCESS      Get the control of TPM2 chip.
-  @retval EFI_NOT_FOUND    TPM2 not found.
-  @retval EFI_DEVICE_ERROR Unexpected device behavior.
-**/
-EFI_STATUS
-EFIAPI
-DTpm2RequestUseTpm (
-  VOID
-  );
 
 /**
   This service enables the sending of commands to the TPM2.

--- a/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2DeviceLibDTpmSvsm.c
+++ b/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2DeviceLibDTpmSvsm.c
@@ -1,0 +1,96 @@
+/** @file
+  This library is a TPM2 DTPM instance, supporting SVSM based vTPMs and regular
+  TPM2s at the same time.
+  Choosing this library means platform uses and only uses DTPM device as TPM2 engine.
+
+Copyright (c) 2024 Red Hat
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Library/BaseLib.h>
+#include <Library/Tpm2DeviceLib.h>
+
+#include "Tpm2DeviceLibDTpm.h"
+#include "Tpm2PtpSvsmShim.h"
+
+/**
+  This service enables the sending of commands to the TPM2.
+
+  @param[in]      InputParameterBlockSize  Size of the TPM2 input parameter block.
+  @param[in]      InputParameterBlock      Pointer to the TPM2 input parameter block.
+  @param[in,out]  OutputParameterBlockSize Size of the TPM2 output parameter block.
+  @param[in]      OutputParameterBlock     Pointer to the TPM2 output parameter block.
+
+  @retval EFI_SUCCESS            The command byte stream was successfully sent to the device and a response was successfully received.
+  @retval EFI_DEVICE_ERROR       The command was not successfully sent to the device or a response was not successfully received from the device.
+  @retval EFI_BUFFER_TOO_SMALL   The output parameter block is too small.
+**/
+EFI_STATUS
+EFIAPI
+Tpm2SubmitCommand (
+  IN UINT32      InputParameterBlockSize,
+  IN UINT8       *InputParameterBlock,
+  IN OUT UINT32  *OutputParameterBlockSize,
+  IN UINT8       *OutputParameterBlock
+  )
+{
+  return SvsmDTpm2SubmitCommand (
+           InputParameterBlockSize,
+           InputParameterBlock,
+           OutputParameterBlockSize,
+           OutputParameterBlock
+           );
+}
+
+/**
+  This service requests to use TPM2.
+
+  @retval EFI_SUCCESS      Get the control of the TPM2 chip.
+  @retval EFI_NOT_FOUND    TPM2 not found.
+  @retval EFI_DEVICE_ERROR Unexpected device behavior.
+**/
+EFI_STATUS
+EFIAPI
+Tpm2RequestUseTpm (
+  VOID
+  )
+{
+  return SvsmDTpm2RequestUseTpm ();
+}
+
+/**
+  This service registers a TPM2 device.
+
+  @param Tpm2Device  TPM2 device
+
+  @retval EFI_SUCCESS          TPM2 device was registered successfully.
+  @retval EFI_UNSUPPORTED      System does not support registering this TPM2 device.
+  @retval EFI_ALREADY_STARTED  This TPM2 device is already registered.
+**/
+EFI_STATUS
+EFIAPI
+Tpm2RegisterTpm2DeviceLib (
+  IN TPM2_DEVICE_INTERFACE  *Tpm2Device
+  )
+{
+  return EFI_UNSUPPORTED;
+}
+
+/**
+  Initialize the library and cache SVSM vTPM presence state and TPM interface type, if applicable.
+
+  @retval EFI_SUCCESS   DTPM2.0 instance is registered, or system does not support registering a DTPM2.0 instance
+**/
+EFI_STATUS
+EFIAPI
+Tpm2DeviceLibConstructorSvsm (
+  VOID
+  )
+{
+  if (TryUseSvsmVTpm ()) {
+    return EFI_SUCCESS;
+  } else {
+    return InternalTpm2DeviceLibDTpmCommonConstructor ();
+  }
+}

--- a/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2DeviceLibDTpmSvsm.inf
+++ b/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2DeviceLibDTpmSvsm.inf
@@ -1,0 +1,66 @@
+## @file
+#  Provides SVSM based vTPM and regular TPM 2.0 TIS/PTP functions for DTPM
+#
+#  Spec Compliance Info:
+#    "TCG PC Client Platform TPM Profile(PTP) Specification Family 2.0 Level 00 Revision 00.43"
+#    "TCG PC Client Specific TPM Interface Specification(TIS) Version 1.3"
+#
+#  This library implements TIS (TPM Interface Specification) and
+#  PTP (Platform TPM Profile) functions which is
+#  used for every TPM 2.0 command. Choosing this library means platform uses and
+#  only uses TPM 2.0 DTPM device.
+#
+#  This version of the library additionally supports SVSM based vTPMs for confidential
+#  virtual machines under AMD-SEV SNP.
+#
+# Copyright (c) 2013 - 2018, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) Microsoft Corporation.
+# Copyright (c) 2024 Red Hat
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 1.30
+  BASE_NAME                      = Tpm2DeviceLibDTpmSvsm
+  MODULE_UNI_FILE                = Tpm2DeviceLibDTpm.uni
+  FILE_GUID                      = EE79D4E4-8538-4FE6-A7EF-4095CB6B38E7
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = Tpm2DeviceLib|PEIM DXE_DRIVER DXE_RUNTIME_DRIVER DXE_SMM_DRIVER UEFI_APPLICATION UEFI_DRIVER
+  CONSTRUCTOR                    = Tpm2DeviceLibConstructorSvsm
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = X64
+#
+
+[Sources]
+  Tpm2Tis.c
+  Tpm2Svsm.c
+  Tpm2PtpSvsmShim.c
+  Tpm2Ptp.c
+  Tpm2DeviceLibDTpmSvsm.c
+  Tpm2DeviceLibDTpmBase.c
+  Tpm2DeviceLibDTpm.h
+
+[Packages]
+  MdePkg/MdePkg.dec
+  SecurityPkg/SecurityPkg.dec
+  UefiCpuPkg/UefiCpuPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  BaseMemoryLib
+  IoLib
+  TimerLib
+  DebugLib
+  PcdLib
+  AmdSvsmLib
+
+[Pcd]
+  gEfiSecurityPkgTokenSpaceGuid.PcdTpmBaseAddress            ## CONSUMES
+  gEfiSecurityPkgTokenSpaceGuid.PcdActiveTpmInterfaceType    ## PRODUCES
+  gEfiSecurityPkgTokenSpaceGuid.PcdCRBIdleByPass             ## PRODUCES
+  gEfiSecurityPkgTokenSpaceGuid.PcdSvsmVTpmPresence          ## PRODUCES
+  gEfiSecurityPkgTokenSpaceGuid.PcdSvsmVTpmBufferPtr         ## PRODUCES

--- a/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2InstanceLibDTpm.c
+++ b/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2InstanceLibDTpm.c
@@ -69,9 +69,9 @@ TPM2_DEVICE_INTERFACE  mDTpm2InternalTpm2Device = {
 };
 
 /**
-  The function register DTPM2.0 instance and caches current active TPM interface type.
+  Registers DTPM2.0 instance and caches current active TPM interface type.
 
-  @retval EFI_SUCCESS   DTPM2.0 instance is registered, or system does not support register DTPM2.0 instance
+  @retval EFI_SUCCESS   DTPM2.0 instance is registered, or system does not support registering a DTPM2.0 instance
 **/
 EFI_STATUS
 EFIAPI

--- a/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2InstanceLibDTpm.c
+++ b/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2InstanceLibDTpm.c
@@ -16,51 +16,8 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #include <Guid/TpmInstance.h>
 
+#include "Tpm2Ptp.h"
 #include "Tpm2DeviceLibDTpm.h"
-
-/**
-  Dump PTP register information.
-
-  @param[in] Register                Pointer to PTP register.
-**/
-VOID
-DumpPtpInfo (
-  IN VOID  *Register
-  );
-
-/**
-  This service enables the sending of commands to the TPM2.
-
-  @param[in]      InputParameterBlockSize  Size of the TPM2 input parameter block.
-  @param[in]      InputParameterBlock      Pointer to the TPM2 input parameter block.
-  @param[in,out]  OutputParameterBlockSize Size of the TPM2 output parameter block.
-  @param[in]      OutputParameterBlock     Pointer to the TPM2 output parameter block.
-
-  @retval EFI_SUCCESS            The command byte stream was successfully sent to the device and a response was successfully received.
-  @retval EFI_DEVICE_ERROR       The command was not successfully sent to the device or a response was not successfully received from the device.
-  @retval EFI_BUFFER_TOO_SMALL   The output parameter block is too small.
-**/
-EFI_STATUS
-EFIAPI
-DTpm2SubmitCommand (
-  IN UINT32      InputParameterBlockSize,
-  IN UINT8       *InputParameterBlock,
-  IN OUT UINT32  *OutputParameterBlockSize,
-  IN UINT8       *OutputParameterBlock
-  );
-
-/**
-  This service requests use TPM2.
-
-  @retval EFI_SUCCESS      Get the control of TPM2 chip.
-  @retval EFI_NOT_FOUND    TPM2 not found.
-  @retval EFI_DEVICE_ERROR Unexpected device behavior.
-**/
-EFI_STATUS
-EFIAPI
-DTpm2RequestUseTpm (
-  VOID
-  );
 
 TPM2_DEVICE_INTERFACE  mDTpm2InternalTpm2Device = {
   TPM_DEVICE_INTERFACE_TPM20_DTPM,

--- a/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2InstanceLibDTpmSvsm.c
+++ b/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2InstanceLibDTpmSvsm.c
@@ -1,0 +1,64 @@
+/** @file
+  This library is a TPM2 DTPM instance, supporting SVSM based vTPMs and regular
+  TPM2s at the same time.
+
+  It can be registered to Tpm2 Device router, to be active TPM2 engine,
+  based on platform setting.
+
+Copyright (c) 2024 Red Hat
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Library/BaseLib.h>
+#include <Library/Tpm2DeviceLib.h>
+
+#include <Guid/TpmInstance.h>
+
+#include "Tpm2Ptp.h"
+#include "Tpm2DeviceLibDTpm.h"
+#include "Tpm2PtpSvsmShim.h"
+
+TPM2_DEVICE_INTERFACE  mDTpm2InternalTpm2Device = {
+  TPM_DEVICE_INTERFACE_TPM20_DTPM,
+  SvsmDTpm2SubmitCommand,
+  SvsmDTpm2RequestUseTpm,
+};
+
+/**
+  Registers DTPM2.0 instance and caches current active TPM interface type.
+
+  @retval EFI_SUCCESS   DTPM2.0 instance is registered, or system does not support registering a DTPM2.0 instance
+**/
+EFI_STATUS
+EFIAPI
+Tpm2InstanceLibDTpmConstructorSvsm (
+  VOID
+  )
+{
+  EFI_STATUS  Status;
+
+  Status = Tpm2RegisterTpm2DeviceLib (&mDTpm2InternalTpm2Device);
+
+  if (Status == EFI_UNSUPPORTED) {
+    //
+    // Unsupported means platform policy does not need this instance enabled.
+    //
+    return EFI_SUCCESS;
+  }
+
+  if (Status != EFI_SUCCESS) {
+    return Status;
+  }
+
+  if (TryUseSvsmVTpm ()) {
+    // SVSM vTPM found.
+    return EFI_SUCCESS;
+  }
+
+  // No SVSM vTPM found; set up regular DTPM Ptp implementation
+  Status = InternalTpm2DeviceLibDTpmCommonConstructor ();
+  DumpPtpInfo ((VOID *)(UINTN)PcdGet64 (PcdTpmBaseAddress));
+
+  return Status;
+}

--- a/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2InstanceLibDTpmSvsm.inf
+++ b/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2InstanceLibDTpmSvsm.inf
@@ -1,0 +1,60 @@
+## @file
+#  Provides a DTPM instance for SVSM based vTPMs and TPM 2.0 TIS/PTP.
+#
+#  This library can be registered to Tpm 2.0 device router, to be active TPM 2.0
+#  engine, based on platform setting. It supports both TIS (TPM Interface Specification)
+#  and PTP (Platform TPM Profile) functions.
+#
+#  This version of the library additionally supports SVSM based vTPMs for confidential
+#  virtual machines under AMD SEV-SNP.
+#
+# Copyright (c) 2024 Red Hat
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 1.30
+  BASE_NAME                      = Tpm2InstanceLibDTpmSvsm
+  MODULE_UNI_FILE                = Tpm2InstanceLibDTpm.uni
+  FILE_GUID                      = C7777207-A8DF-47E4-AA3C-E8BF74E7F233
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = NULL
+  CONSTRUCTOR                    = Tpm2InstanceLibDTpmConstructorSvsm
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = X64
+#
+
+[Sources]
+  Tpm2Tis.c
+  Tpm2Svsm.c
+  Tpm2Ptp.c
+  Tpm2PtpSvsmShim.c
+  Tpm2InstanceLibDTpmSvsm.c
+  Tpm2DeviceLibDTpmBase.c
+  Tpm2DeviceLibDTpm.h
+
+[Packages]
+  MdePkg/MdePkg.dec
+  SecurityPkg/SecurityPkg.dec
+  UefiCpuPkg/UefiCpuPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  BaseMemoryLib
+  IoLib
+  TimerLib
+  DebugLib
+  PcdLib
+  AmdSvsmLib
+
+[Pcd]
+  gEfiSecurityPkgTokenSpaceGuid.PcdTpmBaseAddress          ## CONSUMES
+  gEfiSecurityPkgTokenSpaceGuid.PcdActiveTpmInterfaceType  ## PRODUCES
+  gEfiSecurityPkgTokenSpaceGuid.PcdCRBIdleByPass           ## PRODUCES
+  gEfiSecurityPkgTokenSpaceGuid.PcdSvsmVTpmPresence        ## PRODUCES
+  gEfiSecurityPkgTokenSpaceGuid.PcdSvsmVTpmBufferPtr       ## PRODUCES

--- a/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2Ptp.c
+++ b/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2Ptp.c
@@ -22,6 +22,8 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #include "Tpm2DeviceLibDTpm.h"
 
+#include "Tpm2Ptp.h"
+
 //
 // Execution of the command may take from several seconds to minutes for certain
 // commands, such as key generation.

--- a/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2Ptp.c
+++ b/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2Ptp.c
@@ -1,5 +1,5 @@
 /** @file
-  PTP (Platform TPM Profile) CRB (Command Response Buffer) interface used by dTPM2.0 library.
+  PTP (Platform TPM Profile) CRB (Command Response Buffer) interface used by DTPM2.0 library.
 
 Copyright (c) 2015 - 2021, Intel Corporation. All rights reserved.<BR>
 Copyright (c), Microsoft Corporation.

--- a/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2Ptp.h
+++ b/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2Ptp.h
@@ -1,0 +1,53 @@
+/** @file
+  PTP (Platform TPM Profile) CRB (Command Response Buffer) interface used by dTPM2.0 library.
+
+Copyright (c) 2024 Red Hat
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Uefi.h>
+
+/**
+  Dump PTP register information.
+
+  @param[in] Register                Pointer to PTP register.
+**/
+VOID
+DumpPtpInfo (
+  IN VOID  *Register
+  );
+
+/**
+  This service enables the sending of commands to the TPM2.
+
+  @param[in]      InputParameterBlockSize  Size of the TPM2 input parameter block.
+  @param[in]      InputParameterBlock      Pointer to the TPM2 input parameter block.
+  @param[in,out]  OutputParameterBlockSize Size of the TPM2 output parameter block.
+  @param[in]      OutputParameterBlock     Pointer to the TPM2 output parameter block.
+
+  @retval EFI_SUCCESS            The command byte stream was successfully sent to the device and a response was successfully received.
+  @retval EFI_DEVICE_ERROR       The command was not successfully sent to the device or a response was not successfully received from the device.
+  @retval EFI_BUFFER_TOO_SMALL   The output parameter block is too small.
+**/
+EFI_STATUS
+EFIAPI
+DTpm2SubmitCommand (
+  IN UINT32      InputParameterBlockSize,
+  IN UINT8       *InputParameterBlock,
+  IN OUT UINT32  *OutputParameterBlockSize,
+  IN UINT8       *OutputParameterBlock
+  );
+
+/**
+  This service requests use TPM2.
+
+  @retval EFI_SUCCESS      Get the control of TPM2 chip.
+  @retval EFI_NOT_FOUND    TPM2 not found.
+  @retval EFI_DEVICE_ERROR Unexpected device behavior.
+**/
+EFI_STATUS
+EFIAPI
+DTpm2RequestUseTpm (
+  VOID
+  );

--- a/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2Ptp.h
+++ b/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2Ptp.h
@@ -1,5 +1,5 @@
 /** @file
-  PTP (Platform TPM Profile) CRB (Command Response Buffer) interface used by dTPM2.0 library.
+  PTP (Platform TPM Profile) CRB (Command Response Buffer) interface used by DTPM2.0 library.
 
 Copyright (c) 2024 Red Hat
 SPDX-License-Identifier: BSD-2-Clause-Patent

--- a/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2PtpSvsmShim.c
+++ b/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2PtpSvsmShim.c
@@ -1,0 +1,123 @@
+/** @file
+  PTP (Platform TPM Profile) CRB (Command Response Buffer) interface shim that switches between
+  SVSM vTPM Ptp and regular Ptp implementations.
+
+  Use TryUseSvsmVTpm () do check for SVSM vTPM presnece and initialzie the shim.
+
+  The SVSM vTPM presence state is cached across library instances.
+
+Copyright (c) 2024 Red Hat
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Uefi.h>
+#include <Library/Tpm2DeviceLib.h>
+#include <Library/PcdLib.h>
+#include <Library/DebugLib.h>
+#include "Tpm2Ptp.h"
+#include "Tpm2Svsm.h"
+
+/// SVSM vTPM presence state as stored in PcdSvsmVTpmPresence
+/// @{
+#define SVSM_VTPM_PRESENCE_UNKNOWN  0xFF
+#define SVSM_VTPM_PRESENT           0x01
+#define SVSM_VTPM_ABSENT            0x00
+/// @}
+
+static BOOLEAN  mUseSvsmVTpm = FALSE;
+
+/**
+ Initializes SVSM vTPM if present, or otherwise uses TCG PTP method.
+
+ If an SVSM based vTPM is found, use it from now on.
+ If none is found, call the regular Ptp TPM implementation instead.
+
+ This function is meant to be called from the DTpm library constructor.
+ If it has not been called, the regular Ptp implementation is used.
+
+ @retval TRUE   SVSM vTPM is present.
+ @retval FALSE  SVSM vTPM was not discovered.
+ */
+BOOLEAN
+EFIAPI
+TryUseSvsmVTpm (
+  )
+{
+  UINT8  SvsmVTpmPresence = (UINT8)PcdGet8 (PcdSvsmVTpmPresence);
+
+  if (SvsmVTpmPresence == SVSM_VTPM_PRESENCE_UNKNOWN) {
+    SvsmVTpmPresence = Tpm2SvsmQueryTpmSendCmd () ? SVSM_VTPM_PRESENT : SVSM_VTPM_ABSENT;
+    PcdSet8S (PcdSvsmVTpmPresence, SvsmVTpmPresence);
+    if (SvsmVTpmPresence == SVSM_VTPM_PRESENT) {
+      DEBUG ((DEBUG_INFO, " Found SVSM vTPM\n"));
+    }
+  }
+
+  mUseSvsmVTpm = SvsmVTpmPresence == SVSM_VTPM_PRESENT;
+  return mUseSvsmVTpm;
+}
+
+/**
+  This service enables the sending of commands to the selected TPM2.
+
+  Commands are send to either the SVSM vTPM or the regular Ptp based TPM, depending
+  on what was discovered by TryUseSvsmVTpm ().
+
+  @param[in]      InputParameterBlockSize  Size of the TPM2 input parameter block.
+  @param[in]      InputParameterBlock      Pointer to the TPM2 input parameter block.
+  @param[in,out]  OutputParameterBlockSize Size of the TPM2 output parameter block.
+  @param[in]      OutputParameterBlock     Pointer to the TPM2 output parameter block.
+
+  @retval EFI_SUCCESS            The command byte stream was successfully sent to the device and a response was successfully received.
+  @retval EFI_DEVICE_ERROR       The command was not successfully sent to the device or a response was not successfully received from the device.
+  @retval EFI_BUFFER_TOO_SMALL   The output parameter block is too small.
+**/
+EFI_STATUS
+EFIAPI
+SvsmDTpm2SubmitCommand (
+  IN UINT32      InputParameterBlockSize,
+  IN UINT8       *InputParameterBlock,
+  IN OUT UINT32  *OutputParameterBlockSize,
+  IN UINT8       *OutputParameterBlock
+  )
+{
+  if (mUseSvsmVTpm) {
+    return Tpm2SvsmTpmSendCommand (
+             InputParameterBlock,
+             InputParameterBlockSize,
+             OutputParameterBlock,
+             OutputParameterBlockSize
+             );
+  } else {
+    return DTpm2SubmitCommand (
+             InputParameterBlockSize,
+             InputParameterBlock,
+             OutputParameterBlockSize,
+             OutputParameterBlock
+             );
+  }
+}
+
+/**
+  This service requests to use TPM2.
+
+  Depending on what was discovered by TryUseSvsmVTpm (), this function either
+  returns EFI_SUCCESS, for SVSM vTPM, or calls the regular Ptp implementation.
+
+  @retval EFI_SUCCESS      Get the control of the TPM2 chip.
+  @retval EFI_NOT_FOUND    TPM2 not found.
+  @retval EFI_DEVICE_ERROR Unexpected device behavior.
+**/
+EFI_STATUS
+EFIAPI
+SvsmDTpm2RequestUseTpm (
+  VOID
+  )
+{
+  if (mUseSvsmVTpm) {
+    return EFI_SUCCESS;
+  } else {
+    return DTpm2RequestUseTpm ();
+  }
+}

--- a/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2PtpSvsmShim.h
+++ b/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2PtpSvsmShim.h
@@ -1,0 +1,30 @@
+/** @file
+  PTP (Platform TPM Profile) CRB (Command Response Buffer) interface shim that switches between
+  SVSM vTPM Ptp and regular Ptp implementations.
+
+  Use TryUseSvsmVTpm () do check for SVSM vTPM presnece and initialzie the shim.
+
+Copyright (c) 2024 Red Hat
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+BOOLEAN
+EFIAPI
+TryUseSvsmVTpm (
+  );
+
+EFI_STATUS
+EFIAPI
+SvsmDTpm2SubmitCommand (
+  IN UINT32      InputParameterBlockSize,
+  IN UINT8       *InputParameterBlock,
+  IN OUT UINT32  *OutputParameterBlockSize,
+  IN UINT8       *OutputParameterBlock
+  );
+
+EFI_STATUS
+EFIAPI
+SvsmDTpm2RequestUseTpm (
+  VOID
+  );

--- a/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2Svsm.c
+++ b/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2Svsm.c
@@ -1,0 +1,152 @@
+/** @file
+  SVSM TPM communication
+
+Copyright (C) 2024 James.Bottomley@HansenPartnership.com
+Copyright (C) 2024 IBM Corporation
+Copyright (C) 2024 Red Hat
+
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Uefi.h>
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/AmdSvsmLib.h>
+#include <Library/PcdLib.h>
+
+#include "Tpm2Svsm.h"
+
+/**
+  Platform commands (MSSIM commands) can be sent through the
+  SVSM_VTPM_CMD operation. Each command can have its own
+  request and response structures.
+**/
+#define TPM_SEND_COMMAND  8
+
+#pragma pack(1)
+typedef struct _TPM2_SEND_CMD_REQ {
+  UINT32    Cmd;
+  UINT8     Locality;
+  UINT32    BufSize;
+  UINT8     Buf[];
+} TPM2_SEND_CMD_REQ;
+
+typedef struct _TPM2_SEND_CMD_RESP {
+  UINT32    Size;
+  UINT8     Buf[];
+} TPM2_SEND_CMD_RESP;
+#pragma pack()
+
+/* Max req/resp buffer size */
+#define TPM_PLATFORM_MAX_BUFFER  4096
+
+typedef union {
+  TPM2_SEND_CMD_REQ     req;
+  TPM2_SEND_CMD_RESP    resp;
+} SVSM_TPM_CMD_BUFFER;
+
+STATIC_ASSERT (sizeof (SVSM_TPM_CMD_BUFFER) <= TPM_PLATFORM_MAX_BUFFER, "SVSM_TPM_CMD_BUFFER too large");
+
+/**
+  Probe the SVSM vTPM for TPM_SEND_COMMAND support. The
+  TPM_SEND_COMMAND platform command can be used to execute a
+  TPM command and get the result.
+
+  @retval TRUE    TPM_SEND_COMMAND is supported.
+  @retval FALSE   TPM_SEND_COMMAND is not supported.
+
+**/
+BOOLEAN
+Tpm2SvsmQueryTpmSendCmd (
+  VOID
+  )
+{
+  UINT64  PlatformCmdBitmap;
+  UINT64  TpmSendMask;
+
+  PlatformCmdBitmap = 0;
+  TpmSendMask       = 1 << TPM_SEND_COMMAND;
+
+  if (!AmdSvsmVtpmQuery (&PlatformCmdBitmap, NULL)) {
+    return FALSE;
+  }
+
+  return ((PlatformCmdBitmap & TpmSendMask) == TpmSendMask) ? TRUE : FALSE;
+}
+
+/**
+  Send a TPM command to the SVSM vTPM and return the TPM response.
+
+  @param[in]      BufferIn      It should contain the marshaled
+                                TPM command.
+  @param[in]      SizeIn        Size of the TPM command.
+  @param[out]     BufferOut     It will contain the marshaled
+                                TPM response.
+  @param[in, out] SizeOut       Size of the BufferOut; it will also
+                                be used to return the size of the
+                                TPM response
+
+  @retval EFI_SUCCESS           Operation completed successfully.
+  @retval EFI_INVALID_PARAMETER Buffer not provided.
+  @retval EFI_BUFFER_TOO_SMALL  Response data buffer is too small.
+  @retval EFI_DEVICE_ERROR      Unexpected device behavior.
+  @retval EFI_OUT_OF_RESOURCES  Out of memory when allocating internal buffer.
+  @retval EFI_UNSUPPORTED       Unsupported TPM version
+
+**/
+EFI_STATUS
+Tpm2SvsmTpmSendCommand (
+  IN     UINT8   *BufferIn,
+  IN     UINT32  SizeIn,
+  OUT UINT8      *BufferOut,
+  IN OUT UINT32  *SizeOut
+  )
+{
+  STATIC SVSM_TPM_CMD_BUFFER  *Buffer = NULL;
+
+  if ((SizeIn == 0) || !BufferIn || !SizeOut || !BufferOut) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (SizeIn > TPM_PLATFORM_MAX_BUFFER - sizeof (TPM2_SEND_CMD_REQ)) {
+    return EFI_BUFFER_TOO_SMALL;
+  }
+
+  if (Buffer == NULL) {
+    STATIC_ASSERT (sizeof (UINT64) >= sizeof (UINTN), "Pointer size larger than 64bit");
+    Buffer = (SVSM_TPM_CMD_BUFFER *)(UINTN)PcdGet64 (PcdSvsmVTpmBufferPtr);
+
+    if (Buffer == NULL) {
+      Buffer = (SVSM_TPM_CMD_BUFFER *)AllocatePages (EFI_SIZE_TO_PAGES (TPM_PLATFORM_MAX_BUFFER));
+      if (Buffer == NULL) {
+        DEBUG ((DEBUG_ERROR, "Unable to allocate SVSM vTPM buffer: %r", EFI_OUT_OF_RESOURCES));
+        return EFI_OUT_OF_RESOURCES;
+      }
+
+      PcdSet64S (PcdSvsmVTpmBufferPtr, (UINTN)(VOID *)Buffer);
+    }
+  }
+
+  Buffer->req.Cmd      = TPM_SEND_COMMAND;
+  Buffer->req.Locality = 0;
+  Buffer->req.BufSize  = SizeIn;
+  CopyMem (Buffer->req.Buf, BufferIn, SizeIn);
+
+  if (!AmdSvsmVtpmCmd ((UINT8 *)Buffer)) {
+    return EFI_DEVICE_ERROR;
+  }
+
+  if (Buffer->resp.Size > TPM_PLATFORM_MAX_BUFFER - sizeof (TPM2_SEND_CMD_RESP)) {
+    return EFI_DEVICE_ERROR;
+  }
+
+  if (Buffer->resp.Size > *SizeOut) {
+    return EFI_BUFFER_TOO_SMALL;
+  }
+
+  CopyMem (BufferOut, Buffer->resp.Buf, Buffer->resp.Size);
+  *SizeOut = Buffer->resp.Size;
+  return EFI_SUCCESS;
+}

--- a/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2Svsm.h
+++ b/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2Svsm.h
@@ -1,0 +1,25 @@
+/** @file
+  SVSM TPM communication
+
+Copyright (C) 2024 James.Bottomley@HansenPartnership.com
+Copyright (C) 2024 IBM Corporation
+Copyright (C) 2024 Red Hat
+
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Library/BaseLib.h>
+
+BOOLEAN
+Tpm2SvsmQueryTpmSendCmd (
+  VOID
+  );
+
+EFI_STATUS
+Tpm2SvsmTpmSendCommand (
+  IN     UINT8   *BufferIn,
+  IN     UINT32  SizeIn,
+  OUT UINT8      *BufferOut,
+  IN OUT UINT32  *SizeOut
+  );

--- a/SecurityPkg/SecurityPkg.ci.yaml
+++ b/SecurityPkg/SecurityPkg.ci.yaml
@@ -48,6 +48,7 @@
         "AcceptableDependencies": [
             "MdePkg/MdePkg.dec",
             "MdeModulePkg/MdeModulePkg.dec",
+            "UefiCpuPkg/UefiCpuPkg.dec",
             "UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec",
             "SecurityPkg/SecurityPkg.dec",
             "StandaloneMmPkg/StandaloneMmPkg.dec",

--- a/SecurityPkg/SecurityPkg.dec
+++ b/SecurityPkg/SecurityPkg.dec
@@ -604,6 +604,16 @@
   ## This PCD records LASA field in CC EVENTLOG ACPI table.
   gEfiSecurityPkgTokenSpaceGuid.PcdCcEventlogAcpiTableLasa|0|UINT64|0x00010026
 
+  ## This PCD caches the presence state of a AMD SEV-SNP SVSM-provided vTPM.
+  # 0xFF - Unknown - Probing needed
+  # 0x00 - No - Use regular TPM
+  # 0x01 - Yes - SVSM vTPM present
+  gEfiSecurityPkgTokenSpaceGuid.PcdSvsmVTpmPresence|0xFF|UINT8|0x00020030
+
+  ## This PCD stores the pointer to the communication buffer for a
+  #   AMD SEV-SNP SVSM-provided vTPM.
+  gEfiSecurityPkgTokenSpaceGuid.PcdSvsmVTpmBufferPtr|0|UINT64|0x00020031
+
 [PcdsFeatureFlag]
   ## Indicates if the platform requires PK to be self-signed when setting the PK in setup mode.
   #   TRUE  - Require PK to be self-signed.

--- a/SecurityPkg/SecurityPkg.dsc
+++ b/SecurityPkg/SecurityPkg.dsc
@@ -370,6 +370,18 @@
   }
 
   #
+  # AMD SEV-SNP SVSM vTPM
+  #
+  SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2DeviceLibDTpmSvsm.inf {
+    <LibraryClasses>
+      AmdSvsmLib|UefiCpuPkg/Library/AmdSvsmLibNull/AmdSvsmLibNull.inf
+  }
+  SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2InstanceLibDTpmSvsm.inf {
+    <LibraryClasses>
+      AmdSvsmLib|UefiCpuPkg/Library/AmdSvsmLibNull/AmdSvsmLibNull.inf
+  }
+
+  #
   # Hash2
   #
   SecurityPkg/Hash2DxeCrypto/Hash2DxeCrypto.inf

--- a/UefiCpuPkg/Include/Library/AmdSvsmLib.h
+++ b/UefiCpuPkg/Include/Library/AmdSvsmLib.h
@@ -98,4 +98,45 @@ AmdSvsmSnpVmsaRmpAdjust (
   IN BOOLEAN           SetVmsa
   );
 
+/**
+  Perform a SVSM_VTPM_QUERY operation
+
+  Query the support provided by the SVSM vTPM.
+
+  @param[out] PlatformCommands    It will contain a bitmap indicating the
+                                  supported vTPM platform commands.
+  @param[out] Features            It will contain a bitmap indicating the
+                                  supported vTPM features.
+
+  @retval TRUE                    The query was processed.
+  @retval FALSE                   The query was not processed.
+
+**/
+BOOLEAN
+EFIAPI
+AmdSvsmVtpmQuery (
+  OUT UINT64  *PlatformCommands,
+  OUT UINT64  *Features
+  );
+
+/**
+  Perform a SVSM_VTPM_CMD operation
+
+  Send the specified vTPM platform command to the SVSM vTPM.
+
+  @param[in, out] Buffer  It should contain the vTPM platform command
+                          request. The respective response will be returned
+                          in the same Buffer, but not all commands specify a
+                          response.
+
+  @retval TRUE            The command was processed.
+  @retval FALSE           The command was not processed.
+
+**/
+BOOLEAN
+EFIAPI
+AmdSvsmVtpmCmd (
+  IN OUT UINT8  *Buffer
+  );
+
 #endif

--- a/UefiCpuPkg/Library/AmdSvsmLibNull/AmdSvsmLibNull.c
+++ b/UefiCpuPkg/Library/AmdSvsmLibNull/AmdSvsmLibNull.c
@@ -106,3 +106,50 @@ AmdSvsmSnpVmsaRmpAdjust (
 {
   return EFI_UNSUPPORTED;
 }
+
+/**
+  Perform a SVSM_VTPM_QUERY operation
+
+  Query the support provided by the SVSM vTPM.
+
+  @param[out] PlatformCommands    It will contain a bitmap indicating the
+                                  supported vTPM platform commands.
+  @param[out] Features            It will contain a bitmap indicating the
+                                  supported vTPM features.
+
+  @retval TRUE                    The query was processed.
+  @retval FALSE                   The query was not processed.
+
+**/
+BOOLEAN
+EFIAPI
+AmdSvsmVtpmQuery (
+  OUT UINT64  *PlatformCommands,
+  OUT UINT64  *Features
+  )
+{
+  return FALSE;
+}
+
+/**
+  Perform a SVSM_VTPM_CMD operation
+
+  Send the specified vTPM platform command to the SVSM vTPM.
+
+  @param[in, out] Buffer  It should contain the vTPM platform command
+                          request. The respective response will be returned
+                          in the same Buffer, but not all commands specify a
+                          response.
+
+  @retval TRUE            The command was processed.
+  @retval FALSE           The command was not processed.
+
+**/
+BOOLEAN
+EFIAPI
+AmdSvsmVtpmCmd (
+  IN OUT UINT8  *Buffer
+  )
+{
+  return FALSE;
+}


### PR DESCRIPTION
# Description

This is version 2 of #5770.

This series adds a DTpm driver to communicate with a virtual TPM running in the Secure VM Service Module (SVSM), enabling OVMF to do measured boot in SEV-SNP confidential VMs.

SEV-SNP provides a feature known as VM Privilege Level (VMPL), which allows for services to be run in the guest at different privilege levels. By running at VMPL0 (most priviledged VM level), the SVSM can be used to provide privileged services, e.g. virtual TPM, for the guest rather than trust such services from the hypervisor.

As described in the [SVSM specification](https://www.amd.com/content/dam/amd/en/documents/epyc-technical-docs/specifications/58019.pdf), guest components can call to the SVSM vTPM through the vTPM protocol (protocol-id 2).

The vTPM protocol follows the [Microsoft TPM Simulator interface (MSSIM)](https://github.com/microsoft/ms-tpm-20-ref/blob/main/TPMCmd/Simulator/include/prototypes/Simulator_fp.h) and it supports two services:

    SVSM_VTPM_QUERY (call-id 0): query MSSIM commands and vTPM features supported
    SVSM_VTPM_CMD (call-id 1): send a MSSIM command to be run by the vTPM and get the result

The SVSM vTPM protocol is also added in this series.

- [ ] Breaking change?
- [x] Impacts security?
  - This PR touches existing TPM driver code and implements new TPM related functionality.
- [ ] Includes tests?

## How This Was Tested

This was tested with the latest COCONUT-SVSM upstream code (commit 0b8feaf9), which provides vTPM service. The instructions to build and run a guest under a SVSM can be found in the [INSTALL.md](https://github.com/coconut-svsm/svsm/blob/main/Documentation/docs/installation/INSTALL.md).

The OVMF boot message log below shows that it was able to find the SVSM vTPM and also use it for measured boot.
```
[...]
Creating MpInformation2 HOB...
Loading PEIM F12F698A-E506-4A1B-B32E-6920E55DA1C4
Loading PEIM at 0x0007FB30000 EntryPoint=0x0007FB31399 TpmMmioSevDecryptPei.efi
TpmMmioSevDecryptPeimEntryPoint
TpmMmioSevDecryptPeimEntryPoint: mapping TPM MMIO address range unencrypted
Install PPI: 35C84FF2-7BFE-453D-845F-683A492CF7B7
Loading PEIM 8AD3148F-945F-46B4-8ACD-71469EA73945
Loading PEIM at 0x0007F7FD000 EntryPoint=0x0007F7FE684 Tcg2ConfigPei.efi
Found SVSM vTPM
Tcg2ConfigPeimEntryPoint
Tcg2ConfigPeimEntryPoint: TPM2 detected
Install PPI: 7F4158D3-074D-456D-8CB2-01F9C8F79DAA
Loading PEIM 2BE1E4A6-6505-43B3-9FFC-A3C8330E0432
Loading PEIM at 0x0007F7F8000 EntryPoint=0x0007F7FAA00 TcgPei.efi
No TPM12 instance required!
Loading PEIM A0C98B77-CBA5-4BB8-993B-4AF6CE33ECE4
Loading PEIM at 0x0007F7EB000 EntryPoint=0x0007F7F364B Tcg2Pei.efi
TPM2Startup: TPM_RC_SUCCESS

[...]

Tcg2GetEventLog ... (0x2)
Tcg2GetEventLog (EventLogLocation - 7E632000)
Tcg2GetEventLog (EventLogLastEntry - 7E635BFC)
Tcg2GetEventLog (EventLogTruncated - 0)
Tcg2GetEventLog - Success
EventLogFormat: (0x2)
  Event:
    PCRIndex  - 0
    EventType - 0x00000003
    Digest    - 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
    EventSize - 0x00000025
0000: 53706563204944204576656E743033000000000000020002020000000B002000
0020: 0C00300000
  TCG_EfiSpecIDEventStruct:
    signature          - 'Spec ID Event03 '
    platformClass      - 0x00000000
    specVersion        - 2.00
    uintnSize          - 0x02
    NumberOfAlgorithms - 0x00000002
    digest(0)
      algorithmId      - 0x000B
      digestSize       - 0x0020
    digest(1)
      algorithmId      - 0x000C
      digestSize       - 0x0030
    VendorInfoSize     - 0x00
    VendorInfo         - 
  Event:
    PCRIndex  - 0
    EventType - 0x00000008
    DigestCount: 0x00000002
      HashAlgo : 0x000B
      Digest(0): 96 A2 96 D2 24 F2 85 C6 7B EE 93 C3 0F 8A 30 91 57 F0 DA A3 5D C5 B8 7E 41 0B 78 63 0A 09 CF C7 
      HashAlgo : 0x000C
      Digest(1): 1D D6 F7 B4 57 AD 88 0D 84 0D 41 C9 61 28 3B AB 68 8E 94 E4 B5 93 59 EA 45 68 65 81 E9 0F EC CE A3 C6 24 B1 22 61 13 F8 24 F3 15 EB 60 AE 0A 7C 

    EventSize - 0x00000002
```

It was checked that the existing TPM support still works by launching Ovmf (x64) in Qemu
with a regular software TPM.

## Integration Instructions

N/A

---
Changes since v1:
- Implemented comments from @kraxel, stubbing the SVSM vTPM functions for regular TPM libs
- Use proper names for SVSM guest protocol call numbers
- Applied formatting style (uncrustify)

---
Cc: @cclaudio
