### PR TITLE
SecurityPkg/SecureBootConfigDxe: Enhance help in Delete Signature page

### DIFF
--- a/SecurityPkg/VariableAuthenticated/SecureBootConfigDxe/SecureBootConfigImpl.c
+++ b/SecurityPkg/VariableAuthenticated/SecureBootConfigDxe/SecureBootConfigImpl.c
@@ -1,6 +1,7 @@
 /** @file
   HII Config Access protocol implementation of SecureBoot configuration module.
 
+Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.<BR>
 Copyright (c) 2011 - 2018, Intel Corporation. All rights reserved.<BR>
 (C) Copyright 2018 Hewlett Packard Enterprise Development LP<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -14,6 +15,14 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/BaseCryptLib.h>
 #include <Library/SecureBootVariableLib.h>
 #include <Library/SecureBootVariableProvisionLib.h>
+
+EFI_STATUS
+FormatHelpInfo (
+  IN     SECUREBOOT_CONFIG_PRIVATE_DATA  *PrivateData,
+  IN     EFI_SIGNATURE_LIST              *ListEntry,
+  IN     EFI_SIGNATURE_DATA              *DataEntry,
+  OUT EFI_STRING_ID                      *StringId
+  );
 
 CHAR16  mSecureBootStorageName[] = L"SECUREBOOT_CONFIGURATION";
 
@@ -2619,55 +2628,46 @@ UpdateDeletePage (
   GuidIndex    = 0;
 
   while ((ItemDataSize > 0) && (ItemDataSize >= CertList->SignatureListSize)) {
-    if (CompareGuid (&CertList->SignatureType, &gEfiCertRsa2048Guid)) {
-      Help = STRING_TOKEN (STR_CERT_TYPE_RSA2048_SHA256_GUID);
-    } else if (CompareGuid (&CertList->SignatureType, &gEfiCertX509Guid)) {
-      Help = STRING_TOKEN (STR_CERT_TYPE_PCKS7_GUID);
-    } else if (CompareGuid (&CertList->SignatureType, &gEfiCertSha1Guid)) {
-      Help = STRING_TOKEN (STR_CERT_TYPE_SHA1_GUID);
-    } else if (CompareGuid (&CertList->SignatureType, &gEfiCertSha256Guid)) {
-      Help = STRING_TOKEN (STR_CERT_TYPE_SHA256_GUID);
-    } else if (CompareGuid (&CertList->SignatureType, &gEfiCertX509Sha256Guid)) {
-      Help = STRING_TOKEN (STR_CERT_TYPE_X509_SHA256_GUID);
-    } else if (CompareGuid (&CertList->SignatureType, &gEfiCertX509Sha384Guid)) {
-      Help = STRING_TOKEN (STR_CERT_TYPE_X509_SHA384_GUID);
-    } else if (CompareGuid (&CertList->SignatureType, &gEfiCertX509Sha512Guid)) {
-      Help = STRING_TOKEN (STR_CERT_TYPE_X509_SHA512_GUID);
-    } else {
-      //
-      // The signature type is not supported in current implementation.
-      //
+    if (CompareGuid (&CertList->SignatureType, &gEfiCertRsa2048Guid) ||
+        CompareGuid (&CertList->SignatureType, &gEfiCertX509Guid) ||
+        CompareGuid (&CertList->SignatureType, &gEfiCertSha1Guid) ||
+        CompareGuid (&CertList->SignatureType, &gEfiCertSha256Guid) ||
+        CompareGuid (&CertList->SignatureType, &gEfiCertX509Sha256Guid) ||
+        CompareGuid (&CertList->SignatureType, &gEfiCertX509Sha384Guid) ||
+        CompareGuid (&CertList->SignatureType, &gEfiCertX509Sha512Guid)
+        )
+    {
+      CertCount = (CertList->SignatureListSize - sizeof (EFI_SIGNATURE_LIST) - CertList->SignatureHeaderSize) / CertList->SignatureSize;
+      for (Index = 0; Index < CertCount; Index++) {
+        Cert = (EFI_SIGNATURE_DATA *)((UINT8 *)CertList
+                                      + sizeof (EFI_SIGNATURE_LIST)
+                                      + CertList->SignatureHeaderSize
+                                      + Index * CertList->SignatureSize);
+        //
+        // Display GUID and help
+        //
+        GuidToString (&Cert->SignatureOwner, GuidStr, 100);
+        GuidID = HiiSetString (PrivateData->HiiHandle, 0, GuidStr, NULL);
+
+        Status = FormatHelpInfo (PrivateData, CertList, Cert, &Help);
+        if (!EFI_ERROR (Status)) {
+          HiiCreateCheckBoxOpCode (
+            StartOpCodeHandle,
+            (EFI_QUESTION_ID)(QuestionIdBase + GuidIndex++),
+            0,
+            0,
+            GuidID,
+            Help,
+            EFI_IFR_FLAG_CALLBACK,
+            0,
+            NULL
+            );
+        }
+      }
+
       ItemDataSize -= CertList->SignatureListSize;
       CertList      = (EFI_SIGNATURE_LIST *)((UINT8 *)CertList + CertList->SignatureListSize);
-      continue;
     }
-
-    CertCount = (CertList->SignatureListSize - sizeof (EFI_SIGNATURE_LIST) - CertList->SignatureHeaderSize) / CertList->SignatureSize;
-    for (Index = 0; Index < CertCount; Index++) {
-      Cert = (EFI_SIGNATURE_DATA *)((UINT8 *)CertList
-                                    + sizeof (EFI_SIGNATURE_LIST)
-                                    + CertList->SignatureHeaderSize
-                                    + Index * CertList->SignatureSize);
-      //
-      // Display GUID and help
-      //
-      GuidToString (&Cert->SignatureOwner, GuidStr, 100);
-      GuidID = HiiSetString (PrivateData->HiiHandle, 0, GuidStr, NULL);
-      HiiCreateCheckBoxOpCode (
-        StartOpCodeHandle,
-        (EFI_QUESTION_ID)(QuestionIdBase + GuidIndex++),
-        0,
-        0,
-        GuidID,
-        Help,
-        EFI_IFR_FLAG_CALLBACK,
-        0,
-        NULL
-        );
-    }
-
-    ItemDataSize -= CertList->SignatureListSize;
-    CertList      = (EFI_SIGNATURE_LIST *)((UINT8 *)CertList + CertList->SignatureListSize);
   }
 
 ON_EXIT:


### PR DESCRIPTION
Currently "Delete Signature" Setup page lists enrolled signatures, and each signature is shown with signature GUID (prompt) and type (help). It is possible for some signatures to be shown with same signature GUID and type. In this case, it is difficult to identify the target signature to delete. The update enhances help information to distinguish signatures.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

It has been tested and verified on AMD platforms that include the update. The Setup page works as expected.

## Integration Instructions

N/A