### PR TITLE
BaseTools: ninja build system for faster builds

### DIFF
--- a/BaseTools/GNUmakefile
+++ b/BaseTools/GNUmakefile
@@ -13,12 +13,15 @@ SOURCE_SUBDIRS := $(patsubst %,Source/%,$(sort $(LANGUAGES)))
 SUBDIRS := $(SOURCE_SUBDIRS) Tests
 CLEAN_SUBDIRS := $(patsubst %,%-clean,$(sort $(SUBDIRS)))
 
-.PHONY: subdirs $(SUBDIRS)
+.PHONY: subdirs $(SUBDIRS) ninja
 subdirs: $(SUBDIRS)
 $(SUBDIRS):
 	$(MAKE) -C $@
 
 Tests: $(SOURCE_SUBDIRS)
+
+ninja:
+	for dir in $(SUBDIRS); do $(MAKE) -C $$dir ninja || exit 1; done
 
 .PHONY: $(CLEAN_SUBDIRS)
 $(CLEAN_SUBDIRS):

--- a/BaseTools/Source/C/.gitignore
+++ b/BaseTools/Source/C/.gitignore
@@ -1,0 +1,3 @@
+**/.ninja_deps
+**/.ninja_log
+**/build.ninja

--- a/BaseTools/Source/C/BrotliCompress/GNUmakefile
+++ b/BaseTools/Source/C/BrotliCompress/GNUmakefile
@@ -42,7 +42,43 @@ OBJECTS = \
   brotli/c/enc/static_dict.o \
   brotli/c/enc/utf8_util.o
 
+override NINJA_CSRCS := \
+  BrotliCompress.c \
+  brotli/c/common/platform.c \
+  brotli/c/common/shared_dictionary.c \
+  brotli/c/common/constants.c \
+  brotli/c/common/context.c \
+  brotli/c/enc/command.c \
+  brotli/c/enc/compound_dictionary.c \
+  brotli/c/enc/fast_log.c \
+  brotli/c/common/dictionary.c \
+  brotli/c/common/transform.c \
+  brotli/c/dec/bit_reader.c \
+  brotli/c/dec/decode.c \
+  brotli/c/dec/huffman.c \
+  brotli/c/dec/state.c \
+  brotli/c/enc/backward_references.c \
+  brotli/c/enc/backward_references_hq.c \
+  brotli/c/enc/bit_cost.c \
+  brotli/c/enc/block_splitter.c \
+  brotli/c/enc/brotli_bit_stream.c \
+  brotli/c/enc/cluster.c \
+  brotli/c/enc/compress_fragment.c \
+  brotli/c/enc/compress_fragment_two_pass.c \
+  brotli/c/enc/dictionary_hash.c \
+  brotli/c/enc/encode.c \
+  brotli/c/enc/encoder_dict.c \
+  brotli/c/enc/entropy_encode.c \
+  brotli/c/enc/histogram.c \
+  brotli/c/enc/literal_cost.c \
+  brotli/c/enc/memory.c \
+  brotli/c/enc/metablock.c \
+  brotli/c/enc/static_dict.c \
+  brotli/c/enc/utf8_util.c
+
+override NINJA_CXXSRCS :=
+
 include $(MAKEROOT)/Makefiles/app.makefile
 
-TOOL_INCLUDE = -I ./brotli/c/include
+TOOL_INCLUDE = -I $(MAKEROOT)/$(APPNAME)/brotli/c/include
 LIBS += -lm

--- a/BaseTools/Source/C/DevicePath/GNUmakefile
+++ b/BaseTools/Source/C/DevicePath/GNUmakefile
@@ -11,6 +11,8 @@ APPNAME = DevicePath
 
 OBJECTS = DevicePath.o UefiDevicePathLib.o DevicePathFromText.o  DevicePathUtilities.o
 
+NINJA_LIBS_DEPS = Common
+
 include $(MAKEROOT)/Makefiles/app.makefile
 
 GCCVERSION = $(shell $(CC) -dumpversion | awk -F'.' '{print $$1}')

--- a/BaseTools/Source/C/EfiRom/GNUmakefile
+++ b/BaseTools/Source/C/EfiRom/GNUmakefile
@@ -12,4 +12,6 @@ LIBS = -lCommon
 
 OBJECTS = EfiRom.o
 
+NINJA_LIBS_DEPS = Common
+
 include $(MAKEROOT)/Makefiles/app.makefile

--- a/BaseTools/Source/C/GNUmakefile
+++ b/BaseTools/Source/C/GNUmakefile
@@ -41,7 +41,15 @@ endif
 
 export HOST_ARCH
 
-MAKEROOT = .
+MAKEROOT ?= $(CURDIR)
+export MAKEROOT
+
+NINJA := $(shell which ninja-build 2>/dev/null || which ninja 2>/dev/null)
+NINJAFLAGS =
+ifneq (,$(filter -j%,$(MAKEFLAGS)))
+  NUMJOBS = $(patsubst -j%,%,$(filter -j%,$(MAKEFLAGS)))
+  NINJAFLAGS += -j$(NUMJOBS)
+endif
 
 include Makefiles/header.makefile
 
@@ -84,6 +92,17 @@ $(patsubst %,%-clean,$(sort $(SUBDIRS))):
 
 $(VFRAUTOGEN): VfrCompile/VfrSyntax.g
 	$(MAKE) -C VfrCompile VfrLexer.h
+
+.PHONY: ninja
+ninja:
+	for dir in $(LIBRARIES); do $(MAKE) -C $$dir ninja_lib; done
+	for dir in $(APPLICATIONS); do $(MAKE) -C $$dir ninja_app; done
+	@echo "pool link_pool" > build.ninja
+	@echo "  depth = 10" >> build.ninja
+	@echo "" >> build.ninja
+	for dir in $(LIBRARIES); do echo "subninja $${dir}/build.ninja" >> build.ninja; done
+	for dir in $(APPLICATIONS); do echo "subninja $${dir}/build.ninja" >> build.ninja; done
+	$(NINJA) $(NINJAFLAGS)
 
 clean:  $(patsubst %,%-clean,$(sort $(SUBDIRS)))
 

--- a/BaseTools/Source/C/GenCrc32/GNUmakefile
+++ b/BaseTools/Source/C/GenCrc32/GNUmakefile
@@ -12,4 +12,6 @@ LIBS = -lCommon
 
 OBJECTS = GenCrc32.o
 
+NINJA_LIBS_DEPS = Common
+
 include $(MAKEROOT)/Makefiles/app.makefile

--- a/BaseTools/Source/C/GenFfs/GNUmakefile
+++ b/BaseTools/Source/C/GenFfs/GNUmakefile
@@ -10,7 +10,8 @@ APPNAME = GenFfs
 
 OBJECTS = GenFfs.o
 
+NINJA_LIBS_DEPS = Common
+
 include $(MAKEROOT)/Makefiles/app.makefile
 
 LIBS = -lCommon
-

--- a/BaseTools/Source/C/GenFv/GNUmakefile
+++ b/BaseTools/Source/C/GenFv/GNUmakefile
@@ -10,6 +10,8 @@ APPNAME = GenFv
 
 OBJECTS = GenFv.o GenFvInternalLib.o
 
+NINJA_LIBS_DEPS = Common
+
 include $(MAKEROOT)/Makefiles/app.makefile
 
 LIBS = -lCommon

--- a/BaseTools/Source/C/GenFw/GNUmakefile
+++ b/BaseTools/Source/C/GenFw/GNUmakefile
@@ -10,6 +10,8 @@ APPNAME = GenFw
 
 OBJECTS = GenFw.o ElfConvert.o Elf32Convert.o Elf64Convert.o
 
+NINJA_LIBS_DEPS = Common
+
 include $(MAKEROOT)/Makefiles/app.makefile
 
 LIBS = -lCommon

--- a/BaseTools/Source/C/GenSec/GNUmakefile
+++ b/BaseTools/Source/C/GenSec/GNUmakefile
@@ -10,6 +10,8 @@ APPNAME = GenSec
 
 OBJECTS = GenSec.o
 
+NINJA_LIBS_DEPS = Common
+
 include $(MAKEROOT)/Makefiles/app.makefile
 
 LIBS = -lCommon

--- a/BaseTools/Source/C/LzmaCompress/GNUmakefile
+++ b/BaseTools/Source/C/LzmaCompress/GNUmakefile
@@ -22,6 +22,20 @@ OBJECTS = \
   $(SDK_C)/7zStream.o \
   $(SDK_C)/Bra86.o
 
+override NINJA_CSRCS := \
+  LzmaCompress.c \
+  $(SDK_C)/Alloc.c \
+  $(SDK_C)/LzFind.c \
+  $(SDK_C)/LzmaDec.c \
+  $(SDK_C)/LzmaEnc.c \
+  $(SDK_C)/7zFile.c \
+  $(SDK_C)/7zStream.c \
+  $(SDK_C)/Bra86.c
+
+override NINJA_CXXSRCS :=
+
+NINJA_LIBS_DEPS = Common
+
 include $(MAKEROOT)/Makefiles/app.makefile
 
 CFLAGS += -D_7ZIP_ST

--- a/BaseTools/Source/C/Makefiles/app.makefile
+++ b/BaseTools/Source/C/Makefiles/app.makefile
@@ -11,12 +11,25 @@ include $(MAKEROOT)/Makefiles/header.makefile
 
 APPLICATION = $(MAKEROOT)/bin/$(APPNAME)
 
-.PHONY:all
+NINJA_BUILD_DEPS =
+ifneq ($(NINJA_LIBS_DEPS),)
+  NINJA_BUILD_DEPS +=  || $(foreach lib,$(NINJA_LIBS_DEPS),"$(MAKEROOT)/libs/lib$(subst -l,,$(lib)).a")
+endif
+
+.PHONY:all ninja
 all: $(MAKEROOT)/bin $(APPLICATION)
 
 $(APPLICATION): $(OBJECTS)
 	$(LINKER) -o $(APPLICATION) $(LDFLAGS) $(OBJECTS) -L$(MAKEROOT)/libs $(LIBS)
 
 $(OBJECTS): $(MAKEROOT)/Include/Common/BuildVersion.h
+
+ninja_app: ninja_build
+	@echo "" >> build.ninja
+	@echo "rule link_$(NINJA_ID)" >> build.ninja
+	@echo "  pool = link_pool" >> build.ninja
+	@echo "  command = $(LINKER) -o \044out $(LDFLAGS) \044in -L$(MAKEROOT)/libs $(LIBS)" >> build.ninja
+	@echo "" >> build.ninja
+	@echo "build $(APPLICATION): link_$(NINJA_ID) $(NINJA_OBJECTS)$(NINJA_BUILD_DEPS)" >> build.ninja
 
 include $(MAKEROOT)/Makefiles/footer.makefile

--- a/BaseTools/Source/C/Makefiles/header.makefile
+++ b/BaseTools/Source/C/Makefiles/header.makefile
@@ -134,6 +134,19 @@ CXXFLAGS += $(BUILD_OPTFLAGS)
 # keep EXTRA_LDFLAGS last
 LDFLAGS += $(EXTRA_LDFLAGS)
 
+NINJA_DIR =
+ifneq ($(APPNAME),)
+  NINJA_DIR = $(APPNAME)
+else ifneq ($(LIBNAME),)
+  NINJA_DIR = $(LIBNAME)
+else ifneq ($(APPLICATIONS),)
+# The root makefile cannot define APPNAME/LIBNAME. APPLICATIONS is a unique
+#   variable for the root makefile that is unlikely to be used in subfolders.
+  $(error "Neither APPNAME nor LIBNAME is defined. At least one of them must be defined")
+endif
+NINJA_ID := $(shell base64 < /dev/random | tr -dc 'A-Za-z0-9' | head -c 5)
+NINJA_OBJECTS := $(foreach obj,$(OBJECTS),"$(NINJA_DIR)/$(obj)")
+
 .PHONY: all
 .PHONY: install
 .PHONY: clean

--- a/BaseTools/Source/C/Makefiles/lib.makefile
+++ b/BaseTools/Source/C/Makefiles/lib.makefile
@@ -11,4 +11,12 @@ LIBRARY = $(MAKEROOT)/libs/lib$(LIBNAME).a
 
 all: $(MAKEROOT)/libs $(LIBRARY)
 
+ninja_lib: ninja_build
+	@echo "" >> build.ninja
+	@echo "rule link_$(NINJA_ID)" >> build.ninja
+	@echo "  pool = link_pool" >> build.ninja
+	@echo "  command = $(AR) crs \044out \044in" >> build.ninja
+	@echo "" >> build.ninja
+	@echo "build $(LIBRARY): link_$(NINJA_ID) $(NINJA_OBJECTS)" >> build.ninja
+
 include $(MAKEROOT)/Makefiles/footer.makefile

--- a/BaseTools/Source/C/TianoCompress/GNUmakefile
+++ b/BaseTools/Source/C/TianoCompress/GNUmakefile
@@ -12,4 +12,6 @@ LIBS = -lCommon
 
 OBJECTS = TianoCompress.o
 
+NINJA_LIBS_DEPS = Common
+
 include $(MAKEROOT)/Makefiles/app.makefile

--- a/BaseTools/Source/C/VfrCompile/GNUmakefile
+++ b/BaseTools/Source/C/VfrCompile/GNUmakefile
@@ -11,7 +11,7 @@ APPNAME = VfrCompile
 
 LIBS = -lCommon
 
-TOOL_INCLUDE = -I Pccts/h
+TOOL_INCLUDE = -I $(MAKEROOT)/$(APPNAME)/Pccts/h
 
 #OBJECTS = VfrSyntax.o VfrServices.o DLGLexer.o EfiVfrParser.o ATokenBuffer.o DLexerBase.o AParser.o
 OBJECTS = AParser.o DLexerBase.o ATokenBuffer.o EfiVfrParser.o VfrLexer.o VfrSyntax.o \
@@ -38,7 +38,42 @@ include $(MAKEROOT)/Makefiles/header.makefile
 
 APPLICATION = $(MAKEROOT)/bin/$(APPNAME)
 
-.PHONY:all
+override NINJA_CSRCS :=
+override NINJA_CXXSRCS :=
+
+ANTLR_OBJECTS = \
+  $(NINJA_DIR)/Pccts/antlr/antlr.o \
+  $(NINJA_DIR)/Pccts/antlr/scan.o \
+  $(NINJA_DIR)/Pccts/antlr/err.o \
+  $(NINJA_DIR)/Pccts/antlr/bits.o \
+  $(NINJA_DIR)/Pccts/antlr/build.o \
+  $(NINJA_DIR)/Pccts/antlr/fset2.o \
+  $(NINJA_DIR)/Pccts/antlr/fset.o \
+  $(NINJA_DIR)/Pccts/antlr/gen.o \
+  $(NINJA_DIR)/Pccts/antlr/globals.o \
+  $(NINJA_DIR)/Pccts/antlr/hash.o \
+  $(NINJA_DIR)/Pccts/antlr/lex.o \
+  $(NINJA_DIR)/Pccts/antlr/main.o \
+  $(NINJA_DIR)/Pccts/antlr/misc.o \
+  $(NINJA_DIR)/Pccts/antlr/pred.o \
+  $(NINJA_DIR)/Pccts/antlr/egman.o \
+  $(NINJA_DIR)/Pccts/antlr/mrhoist.o \
+  $(NINJA_DIR)/Pccts/antlr/fcache.o
+
+DLG_OBJECTS = \
+  $(NINJA_DIR)/Pccts/dlg/dlg_p.o \
+  $(NINJA_DIR)/Pccts/dlg/dlg_a.o \
+  $(NINJA_DIR)/Pccts/dlg/main.o \
+  $(NINJA_DIR)/Pccts/dlg/err.o \
+  $(NINJA_DIR)/Pccts/dlg/support.o \
+  $(NINJA_DIR)/Pccts/dlg/output.o \
+  $(NINJA_DIR)/Pccts/dlg/relabel.o \
+  $(NINJA_DIR)/Pccts/dlg/automata.o
+
+ANTLR_BUILDS := $(foreach file,$(ANTLR_OBJECTS),"build $(file): cc_tools_$(NINJA_ID) $(subst .o,,$(file)).c")
+DLG_BUILDS := $(foreach file,$(DLG_OBJECTS),"build $(file): cc_tools_$(NINJA_ID) $(subst .o,,$(file)).c")
+
+.PHONY:all ninja
 all: $(MAKEROOT)/bin $(APPLICATION)
 
 $(APPLICATION): $(OBJECTS)
@@ -71,6 +106,60 @@ AParser.o: Pccts/h/AParser.cpp
 
 VfrSyntax.o: VfrSyntax.cpp
 	$(CXX) -c $(VFR_CPPFLAGS) $(INC) $(VFR_CXXFLAGS) $? -o $@
+
+
+# The source code licence for Pccts is not clearly defined. I'm not sure
+#   if editing its makefiles is allowed. The build is invoked without
+#   automatically generating a ninja file.
+ninja_antlr_tools:
+	@echo "rule link_tools_$(NINJA_ID)" > build.ninja
+	@echo "  pool = link_pool" >> build.ninja
+	@echo "  command = $(LINKER) $(LDFLAGS) -o \044out \044in" >> build.ninja
+	@echo "" >> build.ninja
+	@echo "rule cc_tools_$(NINJA_ID)" >> build.ninja
+	@echo "  deps = gcc" >> build.ninja
+	@echo "  depfile = \044out.d" >> build.ninja
+	@echo "  command = $(CC) -O -I$(NINJA_DIR)/Pccts/dlg -I$(NINJA_DIR)/Pccts/support/set -I$(NINJA_DIR)/Pccts/h -DUSER_ZZSYN -DZZLEXBUFSIZE=65536 -c \044in -o \044out" >> build.ninja
+	@echo "" >> build.ninja
+	@printf "%s\n" $(ANTLR_BUILDS) >> build.ninja
+	@printf "%s\n" $(DLG_BUILDS) >> build.ninja
+	@echo "build $(NINJA_DIR)/Pccts/support/set/set.o: cc_tools_$(NINJA_ID) $(NINJA_DIR)/Pccts/support/set/set.c" >> build.ninja
+	@echo "build $(NINJA_DIR)/Pccts/antlr/antlr: link_tools_$(NINJA_ID) $(NINJA_DIR)/Pccts/support/set/set.o $(ANTLR_OBJECTS)" >> build.ninja
+	@echo "build $(NINJA_DIR)/Pccts/dlg/dlg: link_tools_$(NINJA_ID) $(NINJA_DIR)/Pccts/support/set/set.o $(DLG_OBJECTS)" >> build.ninja
+
+ninja_app: ninja_antlr_tools
+	@echo "" >> build.ninja
+	@echo "rule antlr_$(NINJA_ID)" >> build.ninja
+	@echo "  depfile = \044out.d" >> build.ninja
+	@echo "  command = $(NINJA_DIR)/Pccts/antlr/antlr -CC -e3 -ck 3 -k 2 -fl VfrParser.dlg -ft VfrTokens.h -o $(NINJA_DIR)/ \044in" >> build.ninja
+	@echo "" >> build.ninja
+	@echo "rule dlg_$(NINJA_ID)" >> build.ninja
+	@echo "  depfile = \044out.d" >> build.ninja
+	@echo "  command = $(NINJA_DIR)/Pccts/dlg/dlg -C2 -i -CC -cl VfrLexer -o $(NINJA_DIR)/ \044in" >> build.ninja
+	@echo "" >> build.ninja
+	@echo "rule cxx_vfr_$(NINJA_ID)" >> build.ninja
+	@echo "  deps = gcc" >> build.ninja
+	@echo "  depfile = \044out.d" >> build.ninja
+	@echo "  command = $(CXX) -c $(VFR_CPPFLAGS) $(INC) $(VFR_CXXFLAGS) \044in -o \044out" >> build.ninja
+	@echo "" >> build.ninja
+	@echo "build $(NINJA_DIR)/AParser.o: cxx_vfr_$(NINJA_ID) $(NINJA_DIR)/Pccts/h/AParser.cpp" >> build.ninja
+	@echo "build $(NINJA_DIR)/DLexerBase.o: cxx_vfr_$(NINJA_ID) $(NINJA_DIR)/Pccts/h/DLexerBase.cpp" >> build.ninja
+	@echo "build $(NINJA_DIR)/ATokenBuffer.o: cxx_vfr_$(NINJA_ID) $(NINJA_DIR)/Pccts/h/ATokenBuffer.cpp" >> build.ninja
+	@echo "build $(NINJA_DIR)/EfiVfrParser.cpp $(NINJA_DIR)/VfrParser.dlg: antlr_$(NINJA_ID) $(NINJA_DIR)/VfrSyntax.g || $(NINJA_DIR)/AParser.o $(NINJA_DIR)/DLexerBase.o $(NINJA_DIR)/ATokenBuffer.o $(NINJA_DIR)/Pccts/antlr/antlr" >> build.ninja
+	@echo "build $(NINJA_DIR)/EfiVfrParser.o: cxx_vfr_$(NINJA_ID) $(NINJA_DIR)/EfiVfrParser.cpp || $(NINJA_DIR)/EfiVfrParser.cpp" >> build.ninja
+	@echo "build $(NINJA_DIR)/VfrSyntax.cpp $(NINJA_DIR)/VfrLexer.cpp $(NINJA_DIR)/VfrFormPkg.cpp $(NINJA_DIR)/VfrError.cpp $(NINJA_DIR)/VfrUtilityLib.cpp $(NINJA_DIR)/VfrCompiler.cpp: dlg_$(NINJA_ID) $(NINJA_DIR)/VfrParser.dlg || $(NINJA_DIR)/EfiVfrParser.o $(NINJA_DIR)/Pccts/dlg/dlg" >> build.ninja
+	@echo "build $(NINJA_DIR)/VfrLexer.o: cxx_vfr_$(NINJA_ID) $(NINJA_DIR)/VfrLexer.cpp || $(NINJA_DIR)/EfiVfrParser.o" >> build.ninja
+	@echo "build $(NINJA_DIR)/VfrSyntax.o: cxx_vfr_$(NINJA_ID) $(NINJA_DIR)/VfrSyntax.cpp || $(NINJA_DIR)/EfiVfrParser.o" >> build.ninja
+	@echo "build $(NINJA_DIR)/VfrFormPkg.o: cxx_vfr_$(NINJA_ID) $(NINJA_DIR)/VfrFormPkg.cpp || $(NINJA_DIR)/EfiVfrParser.o" >> build.ninja
+	@echo "build $(NINJA_DIR)/VfrError.o: cxx_vfr_$(NINJA_ID) $(NINJA_DIR)/VfrError.cpp || $(NINJA_DIR)/EfiVfrParser.o" >> build.ninja
+	@echo "build $(NINJA_DIR)/VfrUtilityLib.o: cxx_vfr_$(NINJA_ID) $(NINJA_DIR)/VfrUtilityLib.cpp || $(NINJA_DIR)/EfiVfrParser.o" >> build.ninja
+	@echo "build $(NINJA_DIR)/VfrCompiler.o: cxx_vfr_$(NINJA_ID) $(NINJA_DIR)/VfrCompiler.cpp || $(NINJA_DIR)/EfiVfrParser.o" >> build.ninja
+	@echo "" >> build.ninja
+	@echo "rule link_$(NINJA_ID)" >> build.ninja
+	@echo "  pool = link_pool" >> build.ninja
+	@echo "  command = $(LINKER) -o \044out $(LDFLAGS) \044in -L$(MAKEROOT)/libs $(LIBS)" >> build.ninja
+	@echo "" >> build.ninja
+	@echo "build $(APPLICATION): link_$(NINJA_ID) $(NINJA_OBJECTS) || $(MAKEROOT)/libs/libCommon.a" >> build.ninja
 
 clean: localClean
 

--- a/BaseTools/Source/C/VolInfo/GNUmakefile
+++ b/BaseTools/Source/C/VolInfo/GNUmakefile
@@ -10,6 +10,8 @@ APPNAME = VolInfo
 
 OBJECTS = VolInfo.o
 
+NINJA_LIBS_DEPS = Common
+
 include $(MAKEROOT)/Makefiles/app.makefile
 
 LIBS = -lCommon

--- a/BaseTools/Source/Python/GNUmakefile
+++ b/BaseTools/Source/Python/GNUmakefile
@@ -5,7 +5,9 @@
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 
-all:
+all: ninja
+
+ninja:
 
 clean:
 	find . -name '*.pyc' -exec rm '{}' ';'

--- a/BaseTools/Tests/GNUmakefile
+++ b/BaseTools/Tests/GNUmakefile
@@ -5,10 +5,12 @@
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 
-all: test
+all: test ninja
 
 test:
 	@if command -v "${PYTHON_COMMAND}" >/dev/null 2>&1; then ${PYTHON_COMMAND} RunTests.py; else python RunTests.py; fi
+
+ninja: test
 
 clean:
 	find . -name '*.pyc' -exec rm '{}' ';'


### PR DESCRIPTION
# Description

The current makefiles are executed sequentially. The VfrCompile build also includes an antlr build that generates code over a long period of time. Ninja allows to parallelise builds of different utilities and build them 2.5 times faster.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

```
[] for i in $(seq 1 500); do make -C BaseTools clean >/dev/null 2>&1; time make -C BaseTools >/dev/null; done

real	0m22.448s
real	0m22.244s
real	0m22.269s
real	0m22.344s
real	0m22.224s
```

```
[] for i in $(seq 1 500); do make -C BaseTools clean >/dev/null 2>&1; time make -C BaseTools ninja >/dev/null; done

real	0m9.488s
real	0m9.453s
real	0m9.582s
real	0m9.605s
real	0m9.644s
```

## Integration Instructions

N/A
