### PR TITLE
Add minimum Python version badges

### DIFF
--- a/EmulatorPkg/PlatformCI/ReadMe.md
+++ b/EmulatorPkg/PlatformCI/ReadMe.md
@@ -18,7 +18,8 @@ supported and are described below.
 
 ## EDK2 Developer environment
 
-- [Python 3.8.x - Download & Install](https://www.python.org/downloads/)
+![Minimum Python Version](https://img.shields.io/badge/dynamic/toml?url=https%3A%2F%2Fraw.githubusercontent.com%2Ftianocore%2Fedk2-pytool-extensions%2Frefs%2Fheads%2Fmaster%2Fpyproject.toml&query=%24.%5B'requires-python'%5D&style=for-the-badge&logo=python&logoColor=ffd343&label=Minimum%20Python%20Version%20for%20CI&color=3776ab&link=https%3A%2F%2Fwww.python.org%2Fdownloads%2F)
+
 - [GIT - Download & Install](https://git-scm.com/download/)
 - [Edk2 Source](https://github.com/tianocore/edk2)
 - For building Basetools and other host applications

--- a/OvmfPkg/PlatformCI/ReadMe.md
+++ b/OvmfPkg/PlatformCI/ReadMe.md
@@ -18,7 +18,8 @@ supported and are described below.
 
 ## EDK2 Developer environment
 
-- [Python 3.8.x - Download & Install](https://www.python.org/downloads/)
+![Minimum Python Version](https://img.shields.io/badge/dynamic/toml?url=https%3A%2F%2Fraw.githubusercontent.com%2Ftianocore%2Fedk2-pytool-extensions%2Frefs%2Fheads%2Fmaster%2Fpyproject.toml&query=%24.%5B'requires-python'%5D&style=for-the-badge&logo=python&logoColor=ffd343&label=Minimum%20Python%20Version%20for%20CI&color=3776ab&link=https%3A%2F%2Fwww.python.org%2Fdownloads%2F)
+
 - [GIT - Download & Install](https://git-scm.com/download/)
 - [QEMU - Download, Install, and add to your path](https://www.qemu.org/download/)
 - [Edk2 Source](https://github.com/tianocore/edk2)

--- a/ReadMe.rst
+++ b/ReadMe.rst
@@ -5,6 +5,13 @@ EDK II Project
 A modern, feature-rich, cross-platform firmware development
 environment for the UEFI and PI specifications from www.uefi.org.
 
+.. image:: https://img.shields.io/badge/dynamic/toml?url=https%3A%2F%2Fraw.githubusercontent.com%2Ftianocore%2Fedk2-pytool-extensions%2Frefs%2Fheads%2Fmaster%2Fpyproject.toml&query=%24.%5B'requires-python'%5D&style=for-the-badge&logo=python&logoColor=ffd343&label=Minimum%20Python%20Version%20for%20CI&color=3776ab&link=https%3A%2F%2Fwww.python.org%2Fdownloads%2F
+   :alt: CI Minimum Python Version
+
+It is recommended to install this Python version to run the full set of scripts that enable CI in the project.
+
+Other Python requirements for build can be found in the `EDK II Build Instructions <https://github.com/tianocore/tianocore.github.io/wiki/Build-Instructions/>`__.
+
 Core CI Build Status
 --------------------
 


### PR DESCRIPTION
# Description

The Python version used for build and CI should always be at least the minimum version supported by edk2-pytool-extensions. A badge is added that keeps this information dynamically up-to-date based on the minimum version specified in edk2-pytool-extensions [pyproject.toml](https://github.com/tianocore/edk2-pytool-extensions/blob/master/pyproject.toml) file.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

- Check badges in files on fork

## Integration Instructions

- N/A