### PR TITLE
CryptoPkg: revert BUFSIZ macro definition from commit 456dd8b99f00

### DIFF
--- a/CryptoPkg/Library/Include/CrtLibSupport.h
+++ b/CryptoPkg/Library/Include/CrtLibSupport.h
@@ -25,17 +25,6 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #define MAX_STRING_SIZE  0x1000
 
 //
-// We already have "no-ui" in out Configure invocation.
-// but the code still fails to compile.
-// Ref:  https://github.com/openssl/openssl/issues/8904
-//
-// This is defined in CRT library(stdio.h).
-//
-#ifndef BUFSIZ
-#define BUFSIZ  8192
-#endif
-
-//
 // OpenSSL relies on explicit configuration for word size in crypto/bn,
 // but we want it to be automatically inferred from the target. So we
 // bypass what's in <openssl/opensslconf.h> for OPENSSL_SYS_UEFI, and


### PR DESCRIPTION
# Description

OpenSSL ticket <https://github.com/openssl/openssl/issues/8904> has been fixed in OpenSSL commit 2e9d61ecd81a ("crypto/evp/evp_key.c: #define BUFSIZ if <stdio.h> doesn't #define it", 2019-05-27).

We should simplify "CryptoPkg/Library/Include/CrtLibSupport.h" and back out the change made to that file by edk2 commit 456dd8b99f00 ("CryptoPkg: Upgrade OpenSSL to 1.1.1b", 2019-06-03).

Ref: https://bugzilla.tianocore.org/show_bug.cgi?id=1897

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Build-tested with:
~~~
build -a X64 -b NOOPT -p CryptoPkg/CryptoPkg.dsc -t GCC5
build -a X64 -b NOOPT -p CryptoPkg/CryptoPkgMbedTls.dsc -t GCC5
~~~

## Integration Instructions

N/A
