### PR TITLE
MdeModulePkg/XhciDxe: Non-zero start/stop values in XhcGetElapsedTicks

### DIFF
--- a/MdeModulePkg/Bus/Pci/XhciDxe/Xhci.c
+++ b/MdeModulePkg/Bus/Pci/XhciDxe/Xhci.c
@@ -2397,7 +2397,7 @@ XhcGetElapsedTicks (
     // Counter counts upwards, check for an overflow condition
     //
     if (*PreviousTick > CurrentTick) {
-      Delta = (mXhciPerformanceCounterEndValue - *PreviousTick) + CurrentTick;
+      Delta = (CurrentTick - mXhciPerformanceCounterStartValue) + (mXhciPerformanceCounterEndValue - *PreviousTick);
     } else {
       Delta = CurrentTick - *PreviousTick;
     }
@@ -2406,7 +2406,7 @@ XhcGetElapsedTicks (
     // Counter counts downwards, check for an underflow condition
     //
     if (*PreviousTick < CurrentTick) {
-      Delta = (mXhciPerformanceCounterStartValue - CurrentTick) + *PreviousTick;
+      Delta = (mXhciPerformanceCounterStartValue - CurrentTick) + (*PreviousTick - mXhciPerformanceCounterEndValue);
     } else {
       Delta = *PreviousTick - CurrentTick;
     }


### PR DESCRIPTION
# Description

Resurrect Patrick Henz's patch for https://bugzilla.tianocore.org/show_bug.cgi?id=4578. Resolve rebase conflict from commit ff4c49a5ee38 ("MdeModulePkg/Bus: Fix XhciDxe Linker Issues", 2023-12-06): rename "mPerformanceCounter*" to "mXhciPerformanceCounter*".

The implementation of XhcGetElapsedTicks did not account for non-zero start and stop values for the performance counter timer, potentially resulting in an incorrect elapsed tick count getting returned to the caller. Account for non-zero start and stop values when calculating the elapsed tick count.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Booted UefiShell.iso in OVMF via a USB CD-ROM attached to a qemu-xhci USB controller. See related instructions in the message of commit f9c59fa44ae29924781e235b9709a8119f62f1c3.
~~~
[Bds]Booting UEFI QEMU QEMU USB HARDDRIVE 1-0000:00:02.0:00.0-1
[Bds] Expand PciRoot(0x0)/Pci(0x2,0x0)/Pci(0x0,0x0)/USB(0x0,0x0) -> PciRoot(0x0)/Pci(0x2,0x0)/Pci(0x0,0x0)/USB(0x0,0x0)/CDROM(0x0,0x84,0x43C0)/\EFI\BOOT\BOOTX64.EFI
[Security] 3rd party image[0] can be loaded after EndOfDxe: PciRoot(0x0)/Pci(0x2,0x0)/Pci(0x0,0x0)/USB(0x0,0x0)/CDROM(0x0,0x84,0x43C0)/\EFI\BOOT\BOOTX64.EFI.
~~~

## Integration Instructions

N/A
