### PR TITLE
OvmfPkg/TdxDxe: Clear GPR Mask for RBX

### DIFF
--- a/OvmfPkg/TdxDxe/X64/ApRunLoop.nasm
+++ b/OvmfPkg/TdxDxe/X64/ApRunLoop.nasm
@@ -20,7 +20,7 @@ SECTION .text
 
 BITS 64
 
-%define TDVMCALL_EXPOSE_REGS_MASK       0xffcc
+%define TDVMCALL_EXPOSE_REGS_MASK       0xffc4
 %define TDVMCALL                        0x0
 %define EXIT_REASON_CPUID               0xa
 


### PR DESCRIPTION
Refer to intel-tdx-module-api spec section 5.5.21, GPR mask
(TDVMCALL_EXPOSE_REGS_MASK) is a bitmap that controls which
part of the guest TD GPR and XMM state is passed as-is to
the VMM and back.
- A bit value of 0 indicates that the corresponding register
   is saved by the Intel TDX module and not passed as-is to
   Host VMM.
- A bit value of 1 indicates that the corresponding register
   is passed as-is to the host VMM.

Currently, RBX is used as the mailbox address in ApRunLoop.nasm,
the corresponding bit value of RBX in MASK(Bit 3) is set as 1 which
means the value is passed to Host VMM as-is and it can be changed by
Host VMM.

So the bitmask shall be set as 0 to avoid this situation.

Reference:
[TDX-API]: intel-tdx-module-abi-spec
https://cdrdv2.intel.com/v1/dl/getContent/733579

Cc: Erdem Aktas <erdemaktas@google.com>
Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Min Xu <min.m.xu@intel.com>
Cc: Gerd Hoffmann <kraxel@redhat.com>
Cc: Hunter Adrian <adrian.hunter@intel.com>
Signed-off-by: Ceping Sun <cepingx.sun@intel.com>

# Description

<_Include a description of the change and why this change was made._>

<_For each item, place an "x" in between `[` and `]` if true. Example: `[x]` (you can also check items in GitHub UI)_>

<_Create the PR as a Draft PR if it is only created to run CI checks._>

<_Delete lines in \<\> tags before creating the PR._>

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Tested on intel platform without problem.

## Integration Instructions

<_Describe how these changes should be integrated. Use N/A if nothing is required._>