### PR TITLE
MdeModulePkg/DxeIpmiLibIpmiProtocol: Add depex

### DIFF
--- a/MdeModulePkg/Library/DxeIpmiLibIpmiProtocol/DxeIpmiLibIpmiProtocol.inf
+++ b/MdeModulePkg/Library/DxeIpmiLibIpmiProtocol/DxeIpmiLibIpmiProtocol.inf
@@ -33,4 +33,7 @@
   DebugLib
 
 [Protocols]
-  gIpmiProtocolGuid      ## SOMETIMES_CONSUMES
+  gIpmiProtocolGuid      ## CONSUMES
+
+[Depex]
+  gIpmiProtocolGuid


### PR DESCRIPTION
# Description

The library should always consume the gIpmiProtocolGuid protocol. This patch is to correct it and add the protocol GUID to Depex section to improve driver boot order.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

<_Describe the test(s) that were run to verify the changes._>

## Integration Instructions

<_Describe how these changes should be integrated. Use N/A if nothing is required._>
