### PR TITLE
OvmfPkg: Add C runtime apis referenced by Boringssl

### DIFF
--- a/CryptoPkg/Library/BaseCryptLib/BaseCryptLib.inf
+++ b/CryptoPkg/Library/BaseCryptLib/BaseCryptLib.inf
@@ -65,6 +65,7 @@
   SysCall/CrtWrapper.c
   SysCall/TimerWrapper.c
   SysCall/BaseMemAllocation.c
+  SysCall/CrtUtils.c
 
 [Sources.Ia32]
   Rand/CryptRandTsc.c
@@ -99,6 +100,7 @@
   PrintLib
   UefiBootServicesTableLib
   SynchronizationLib
+  SafeIntLib
 
 [Protocols]
   gEfiMpServiceProtocolGuid

--- a/CryptoPkg/Library/BaseCryptLib/PeiCryptLib.inf
+++ b/CryptoPkg/Library/BaseCryptLib/PeiCryptLib.inf
@@ -71,6 +71,7 @@
   SysCall/CrtWrapper.c
   SysCall/ConstantTimeClock.c
   SysCall/BaseMemAllocation.c
+  SysCall/CrtUtils.c
 
 [Packages]
   MdePkg/MdePkg.dec
@@ -87,6 +88,7 @@
   PeiServicesTablePointerLib
   PeiServicesLib
   SynchronizationLib
+  SafeIntLib
 
 [Ppis]
   gEfiPeiMpServicesPpiGuid

--- a/CryptoPkg/Library/BaseCryptLib/SecCryptLib.inf
+++ b/CryptoPkg/Library/BaseCryptLib/SecCryptLib.inf
@@ -60,6 +60,7 @@
   SysCall/CrtWrapper.c
   SysCall/ConstantTimeClock.c
   SysCall/BaseMemAllocation.c
+  SysCall/CrtUtils.c
 
 [Packages]
   MdePkg/MdePkg.dec
@@ -73,6 +74,7 @@
   OpensslLib
   IntrinsicLib
   PrintLib
+  SafeIntLib
 
 #
 # Remove these [BuildOptions] after this library is cleaned up

--- a/CryptoPkg/Library/BaseCryptLib/SmmCryptLib.inf
+++ b/CryptoPkg/Library/BaseCryptLib/SmmCryptLib.inf
@@ -68,6 +68,7 @@
   SysCall/CrtWrapper.c
   SysCall/ConstantTimeClock.c
   SysCall/BaseMemAllocation.c
+  SysCall/CrtUtils.c
 
 [Sources.Ia32]
   Rand/CryptRandTsc.c
@@ -94,6 +95,7 @@
   PrintLib
   MmServicesTableLib
   SynchronizationLib
+  SafeIntLib
 
 #
 # Remove these [BuildOptions] after this library is cleaned up

--- a/CryptoPkg/Library/BaseCryptLib/SysCall/CrtUtils.c
+++ b/CryptoPkg/Library/BaseCryptLib/SysCall/CrtUtils.c
@@ -1,0 +1,92 @@
+/** @file
+  C Run-Time Libraries (CRT) Utility apis for BoringSSL-based
+  Cryptographic Library.
+
+Copyright (c) 2009 - 2017, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <CrtLibSupport.h>
+#include <Uefi/UefiBaseType.h>
+#include <Library/RngLib.h>
+#include <Library/SafeIntLib.h>
+
+/* Performs a binary search */
+void *
+bsearch (
+  const void *key,
+  const void *base,
+  size_t nmemb,
+  size_t size,
+  int         ( *compar )(const void *, const void *)
+  )
+{
+  void           *Mid;
+  int            Sign;
+  RETURN_STATUS  Status = RETURN_INVALID_PARAMETER;
+  size_t         Result;
+
+  if (!key || !base || !nmemb || !size) {
+    return NULL;
+  }
+
+  Status = SafeUintnMult ((UINTN)size, (UINTN)(nmemb/2), (UINTN *)&Result);
+
+  if ((Status == RETURN_BUFFER_TOO_SMALL) ||
+      (Status == RETURN_INVALID_PARAMETER))
+  {
+    return NULL;
+  }
+
+  while (nmemb > 0) {
+    Mid  = (char *)base + size * (nmemb/2);
+    Sign = compar (key, Mid);
+    if (Sign < 0) {
+      nmemb /= 2;
+    } else if (Sign > 0) {
+      base   = (char *)Mid + size;
+      nmemb -= nmemb/2 + 1;
+    } else {
+      return Mid;
+    }
+  }
+
+  return NULL;
+}
+
+/* Returns entropy of requested length in provided buffer */
+int
+getentropy (
+  void    *buffer,
+  size_t  length
+  )
+{
+  UINT8   *EntropyBuffer = (UINT8 *)buffer;
+  UINTN   Index;
+  UINT64  RandNum;
+  UINTN   CopyLength;
+
+  if (length > GETENTROPY_MAX) {
+    errno = EIO;
+    return -1;
+  }
+
+  if (EntropyBuffer == NULL) {
+    errno = EFAULT;
+    return -1;
+  }
+
+  for (Index = 0; Index < length; Index += sizeof (UINT64)) {
+    if (!GetRandomNumber64 (&RandNum)) {
+      errno = ENOSYS;
+      return -1;
+    }
+
+    CopyLength =
+      (length - Index >= sizeof (UINT64)) ? sizeof (UINT64) : (length - Index);
+    CopyMem (EntropyBuffer + Index, &RandNum, CopyLength);
+  }
+
+  return 0;
+}

--- a/CryptoPkg/Library/BaseCryptLib/SysCall/CrtWrapper.c
+++ b/CryptoPkg/Library/BaseCryptLib/SysCall/CrtWrapper.c
@@ -8,6 +8,9 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
 #include <CrtLibSupport.h>
+#include <Uefi/UefiBaseType.h>
+#include <Library/RngLib.h>
+#include <Library/SafeIntLib.h>
 
 int  errno = 0;
 
@@ -580,13 +583,97 @@ fopen (
 
 size_t
 fread (
-  void    *b,
-  size_t  c,
-  size_t  i,
-  FILE    *f
+  void    *ptr,
+  size_t  size,
+  size_t  nmemb,
+  FILE    *stream
   )
 {
   return 0;
+}
+
+int
+fputs (
+  const char  *s,
+  FILE        *stream
+  )
+{
+  return -1;
+}
+
+int
+fflush (
+  FILE  *stream
+  )
+{
+  return -1;
+}
+
+int
+ferror (
+  FILE  *stream
+  )
+{
+  return -1;
+}
+
+int
+fseek (
+  FILE  *stream,
+  long  offset,
+  int   whence
+  )
+{
+  return -1;
+}
+
+int
+feof (
+  FILE  *stream
+  )
+{
+  return -1;
+}
+
+int
+ftell (
+  FILE  *stream
+  )
+{
+  return -1;
+}
+
+char *
+fgets (
+  char  *s,
+  int   size,
+  FILE  *stream
+  )
+{
+  return NULL;
+}
+
+char *
+strdup (
+  char  *s
+  )
+{
+  UINTN  Length;
+  VOID   *Buffer;
+
+  if (!s) {
+    return NULL;
+  }
+
+  Length = strlen (s);
+
+  Buffer = malloc (Length);
+  if (Buffer == NULL) {
+    return NULL;
+  }
+
+  strncpy (Buffer, s, Length);
+  return Buffer;
 }
 
 uid_t

--- a/CryptoPkg/Library/Include/CrtLibSupport.h
+++ b/CryptoPkg/Library/Include/CrtLibSupport.h
@@ -68,16 +68,22 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 //
 // Definitions for global constants used by CRT library routines
 //
-#define EINVAL        22              /* Invalid argument */
-#define EAFNOSUPPORT  47              /* Address family not supported by protocol family */
-#define INT_MAX       0x7FFFFFFF      /* Maximum (signed) int value */
-#define INT_MIN       (-INT_MAX-1)    /* Minimum (signed) int value */
-#define LONG_MAX      0X7FFFFFFFL     /* max value for a long */
-#define LONG_MIN      (-LONG_MAX-1)   /* min value for a long */
-#define UINT_MAX      0xFFFFFFFF      /* Maximum unsigned int value */
-#define ULONG_MAX     0xFFFFFFFF      /* Maximum unsigned long value */
-#define CHAR_BIT      8               /* Number of bits in a char */
-#define SIZE_MAX      0xFFFFFFFF      /* Maximum unsigned size_t */
+#define ENOENT          2
+#define EIO             5              /* I/O error */
+#define ENOMEM          11             /* Out of memory */
+#define EFAULT          14             /* Bad address */
+#define EINVAL          22             /* Invalid argument */
+#define ENOSYS          38             /* Function not implemented */
+#define EAFNOSUPPORT    47             /* Address family not supported */
+#define GETENTROPY_MAX  256
+#define INT_MAX         0x7FFFFFFF     /* Maximum (signed) int value */
+#define INT_MIN         (-INT_MAX-1)   /* Minimum (signed) int value */
+#define LONG_MAX        0X7FFFFFFFL    /* max value for a long */
+#define LONG_MIN        (-LONG_MAX-1)  /* min value for a long */
+#define UINT_MAX        0xFFFFFFFF     /* Maximum unsigned int value */
+#define ULONG_MAX       0xFFFFFFFF     /* Maximum unsigned long value */
+#define CHAR_BIT        8              /* Number of bits in a char */
+#define SIZE_MAX        0xFFFFFFFF     /* Maximum unsigned size_t */
 
 //
 // Address families.
@@ -92,22 +98,57 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #define NS_INADDRSZ   4   /*%< IPv4 T_A */
 #define NS_IN6ADDRSZ  16  /*%< IPv6 T_AAAA */
 
+/* Defines for Boringssl build */
+#define PRIx8           "x"
+#define PRIx16          "x"
+#define PRIx32          "x"
+#define PRIx64          __PRI64_PREFIX "x"
+#define PRIX32          "X"
+#define __PRI64_PREFIX  "l"
+#define PRIu64          __PRI64_PREFIX "u"
+
+#define INT32_MIN    -0x80000000
+#define INT32_MAX    0x7FFFFFFF
+#define PTRDIFF_MAX  0x7FFFFFFFFFFFFFFF
+#define INT64_C(c)  c ## L
+
+#ifndef __INT64_C
+#define __INT64_C(c)  c ## L
+#endif
+
+#define INT64_MIN  (-__INT64_C(0x7FFFFFFFFFFFFFFF)-1)
+#define INT64_MAX  (__INT64_C(0x7FFFFFFFFFFFFFFF))
+typedef int int32_t;
+
+#ifndef UINT64_C
+#define UINT64_C(c)  c ## UL
+#endif
+
+#ifndef UINT64_MAX
+#define UINT64_MAX  0xFFFFFFFFFFFFFFFFULL
+#endif
+
+#ifndef UINT32_MAX
+#define UINT32_MAX  0xFFFFFFFF
+#endif
+
 //
 // Basic types mapping
 //
-typedef UINTN   size_t;
-typedef UINTN   off_t;
-typedef UINTN   u_int;
-typedef UINTN   intptr_t;
-typedef INTN    ptrdiff_t;
-typedef INTN    ssize_t;
-typedef INT64   time_t;
-typedef UINT8   __uint8_t;
-typedef UINT8   sa_family_t;
-typedef UINT8   u_char;
-typedef UINT32  uid_t;
-typedef UINT32  gid_t;
-typedef CHAR16  wchar_t;
+typedef UINTN  size_t;
+typedef UINTN  off_t;
+typedef UINTN  u_int;
+typedef UINTN  intptr_t;
+typedef INTN   ptrdiff_t;
+typedef INTN   ssize_t;
+typedef INT64  time_t;
+typedef UINT8  __uint8_t;
+typedef UINT8  sa_family_t;
+typedef UINT8  u_char;
+typedef UINT32 uid_t;
+typedef UINT32 gid_t;
+typedef CHAR16 wchar_t;
+typedef short  int16_t;
 
 //
 // File operations are not required for EFI building,
@@ -424,6 +465,66 @@ char *
 strcat (
   char        *strDest,
   const char  *strSource
+  );
+
+int
+fflush (
+  FILE  *stream
+  );
+
+int
+ferror (
+  FILE  *stream
+  );
+
+int
+fseek (
+  FILE  *stream,
+  long  offset,
+  int   whence
+  );
+
+int
+feof (
+  FILE  *stream
+  );
+
+char *
+fgets (
+  char  *s,
+  int   size,
+  FILE  *stream
+  );
+
+int
+ftell (
+  FILE  *stream
+  );
+
+int
+fputs (
+  const char  *s,
+  FILE        *stream
+  );
+
+char *
+strdup (
+  char  *s
+  );
+
+void *
+bsearch (
+  const void *key,
+  const void *base,
+  size_t nmemb,
+  size_t size,
+  int       ( *compar )(const void *, const void *)
+  );
+
+int
+getentropy (
+  void    *buffer,
+  size_t  length
   );
 
 //


### PR DESCRIPTION

# Description
As part of the effort to get Boringssl to work with EDK2, there are many C runtime apis that get referenced and are currently not implemented in EDK2. This change adds those apis to edk2. In particular, this change adds the following :

Stubs for file functions. These have been implemented to return -1 rather than 0 since there is no file system support. This will ensure that any calls into these apis will return failure.

Implementations of the following api which are referenced and used by Boringssl code :
strdup : string duplication function
bsearch : binary search
getentropy : return entropy of requested length

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

## Integration Instructions
NA

