### PR TITLE
Utf8 ci plugins

### DIFF
--- a/.pytool/Plugin/EccCheck/EccCheck.py
+++ b/.pytool/Plugin/EccCheck/EccCheck.py
@@ -144,7 +144,7 @@ class EccCheck(ICiBuildPlugin):
         #
         params = "diff --output={} --unified=0 origin/master HEAD".format(temp_diff_output)
         RunCmd("git", params)
-        with open(temp_diff_output) as file:
+        with open(temp_diff_output, encoding='utf8') as file:
             patch = file.read().strip().split('\n')
         return patch
 
@@ -163,7 +163,7 @@ class EccCheck(ICiBuildPlugin):
         params = "diff --output={} --diff-filter=dr --name-status origin/master HEAD".format(temp_diff_output)
         RunCmd("git", params)
         dir_list = []
-        with open(temp_diff_output) as file:
+        with open(temp_diff_output, encoding='utf8') as file:
             dir_list = file.read().strip().split('\n')
 
         modify_dir_list = []
@@ -271,7 +271,7 @@ class EccCheck(ICiBuildPlugin):
         modify_file_path = os.path.join(temp_path, modify_file)
         if not os.path.exists (modify_file_path):
             return comment_range
-        with open(modify_file_path) as f:
+        with open(modify_file_path, encoding='utf8') as f:
             line_no = 1
             Start = False
             for line in f:
@@ -319,7 +319,7 @@ class EccCheck(ICiBuildPlugin):
         row_lines = []
         ignore_error_code = self.GetIgnoreErrorCode()
         if os.path.exists(ecc_csv):
-            with open(ecc_csv) as csv_file:
+            with open(ecc_csv, encoding='utf8') as csv_file:
                 reader = csv.reader(csv_file)
                 for row in reader:
                     for modify_file in ecc_diff_range:

--- a/.pytool/Plugin/LicenseCheck/LicenseCheck.py
+++ b/.pytool/Plugin/LicenseCheck/LicenseCheck.py
@@ -70,7 +70,7 @@ class LicenseCheck(ICiBuildPlugin):
         temp_diff_output = os.path.join (temp_path, 'diff.txt')
         params = "diff --output={} --unified=0 origin/master HEAD".format(temp_diff_output)
         RunCmd("git", params)
-        with open(temp_diff_output) as file:
+        with open(temp_diff_output, encoding='utf8') as file:
             patch = file.read().strip().split("\n")
         # Delete temp directory
         if os.path.exists(temp_path):


### PR DESCRIPTION
# Description

The `LicenseCheck` and `EccCheck` plugins currently fail if a file contains characters outside the platform-dependent encoding returned from `locale.getencoding()`.

This change updates the encoding to utf-8 so the plugin is more robust while continuing to support backward compatibility with the ASCII range.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

- Run against files with Unicode characters and verify no exceptions are thrown

## Integration Instructions

- N/A