### PR TITLE
Adjust LoongArch exception handler and enable some base libraries on LoongArch VM

### DIFF
--- a/OvmfPkg/LoongArchVirt/LoongArchVirtQemu.dsc
+++ b/OvmfPkg/LoongArchVirt/LoongArchVirtQemu.dsc
@@ -156,6 +156,18 @@
   FileExplorerLib                  | MdeModulePkg/Library/FileExplorerLib/FileExplorerLib.inf
   ImagePropertiesRecordLib         | MdeModulePkg/Library/ImagePropertiesRecordLib/ImagePropertiesRecordLib.inf
 
+  #
+  # CryptoPkg libraries needed by multiple firmware features
+  #
+  IntrinsicLib                     | CryptoPkg/Library/IntrinsicLib/IntrinsicLib.inf
+!if $(NETWORK_TLS_ENABLE) == TRUE
+  OpensslLib                       | CryptoPkg/Library/OpensslLib/OpensslLib.inf
+!else
+  OpensslLib                       | CryptoPkg/Library/OpensslLib/OpensslLibCrypto.inf
+!endif
+  BaseCryptLib                     | CryptoPkg/Library/BaseCryptLib/BaseCryptLib.inf
+  RngLib                           | MdeModulePkg/Library/BaseRngLibTimerLib/BaseRngLibTimerLib.inf
+
 !if $(HTTP_BOOT_ENABLE) == TRUE
   HttpLib                          | MdeModulePkg/Library/DxeHttpLib/DxeHttpLib.inf
 !endif

--- a/UefiCpuPkg/Library/CpuExceptionHandlerLib/LoongArch/DxeExceptionLib.c
+++ b/UefiCpuPkg/Library/CpuExceptionHandlerLib/LoongArch/DxeExceptionLib.c
@@ -115,23 +115,22 @@ CommonExceptionHandler (
     // Interrupt
     //
     InterruptType = GetInterruptType (SystemContext);
-    if (InterruptType == 0xFF) {
-      ExceptionType = InterruptType;
-    } else {
+    if (InterruptType != 0xFF) {
       if ((ExternalInterruptHandler != NULL) && (ExternalInterruptHandler[InterruptType] != NULL)) {
         ExternalInterruptHandler[InterruptType](InterruptType, SystemContext);
         return;
       }
     }
-  } else if (ExceptionType == EXCEPT_LOONGARCH_FPD) {
-    EnableFloatingPointUnits ();
-    InitializeFloatingPointUnits ();
-    return;
   } else {
     //
     // Exception
     //
-    ExceptionType >>= CSR_ESTAT_EXC_SHIFT;
+    if (ExceptionType == EXCEPT_LOONGARCH_FPD) {
+      EnableFloatingPointUnits ();
+      InitializeFloatingPointUnits ();
+      return;
+    }
+
     if ((ExceptionHandler != NULL) && (ExceptionHandler[ExceptionType] != NULL)) {
       ExceptionHandler[ExceptionType](ExceptionType, SystemContext);
       return;

--- a/UefiCpuPkg/Library/CpuExceptionHandlerLib/LoongArch/ExceptionCommon.c
+++ b/UefiCpuPkg/Library/CpuExceptionHandlerLib/LoongArch/ExceptionCommon.c
@@ -43,8 +43,24 @@ CONST CHAR8  *mExceptionNameStr[]    = {
   "#GCXC - Guest CSR Software/Hardware Change exception",
   "#TBR - TLB refill exception" // !!! NOTICE: Because the TLB refill exception is not instructed in ECODE, so the TLB refill exception must be the last one!
 };
+CONST CHAR8  *mInterruptNameStr[] = {
+  "#SIP0 - Software interrupt 0",
+  "#SIP1 - Software interrupt 1",
+  "#IP0 - Hardware interrupt 0",
+  "#IP1 - Hardware interrupt 1",
+  "#IP2 - Hardware interrupt 2",
+  "#IP3 - Hardware interrupt 3",
+  "#IP4 - Hardware interrupt 4",
+  "#IP5 - Hardware interrupt 5",
+  "#IP6 - Hardware interrupt 6",
+  "#IP7 - Hardware interrupt 7",
+  "#PMC - Performance counter overflow interrupt",
+  "#TIMER - Timer interrupt",
+  "#IPI - Inter-Processor interrupt"
+};
 
 INTN  mExceptionKnownNameNum = (sizeof (mExceptionNameStr) / sizeof (CHAR8 *));
+INTN  mInterruptKnownNameNum = (sizeof (mInterruptNameStr) / sizeof (CHAR8 *));
 
 /**
   Get ASCII format string exception name by exception type.
@@ -61,6 +77,26 @@ GetExceptionNameStr (
 {
   if ((UINTN)ExceptionType < mExceptionKnownNameNum) {
     return mExceptionNameStr[ExceptionType];
+  } else {
+    return mExceptionReservedStr;
+  }
+}
+
+/**
+  Get ASCII format string interrupt name by exception type.
+
+  @param InterruptType  Interrupt type.
+
+  @return  ASCII format string interrupt name.
+
+**/
+CONST CHAR8 *
+GetInterruptNameStr (
+  IN EFI_EXCEPTION_TYPE  InterruptType
+  )
+{
+  if ((UINTN)InterruptType < mInterruptKnownNameNum) {
+    return mInterruptNameStr[InterruptType];
   } else {
     return mExceptionReservedStr;
   }

--- a/UefiCpuPkg/Library/CpuExceptionHandlerLib/LoongArch/ExceptionCommon.h
+++ b/UefiCpuPkg/Library/CpuExceptionHandlerLib/LoongArch/ExceptionCommon.h
@@ -13,6 +13,7 @@
 #define MAX_DEBUG_MESSAGE_LENGTH  0x100
 
 extern INTN  mExceptionKnownNameNum;
+extern INTN  mInterruptKnownNameNum;
 
 /**
   Get ASCII format string exception name by exception type.
@@ -25,6 +26,19 @@ extern INTN  mExceptionKnownNameNum;
 CONST CHAR8 *
 GetExceptionNameStr (
   IN EFI_EXCEPTION_TYPE  ExceptionType
+  );
+
+/**
+  Get ASCII format string interrupt name by exception type.
+
+  @param InterruptType  Interrupt type.
+
+  @return  ASCII format string interrupt name.
+
+**/
+CONST CHAR8 *
+GetInterruptNameStr (
+  IN EFI_EXCEPTION_TYPE  InterruptType
   );
 
 /**

--- a/UefiCpuPkg/Library/CpuExceptionHandlerLib/LoongArch/LoongArch64/ArchExceptionHandler.c
+++ b/UefiCpuPkg/Library/CpuExceptionHandlerLib/LoongArch/LoongArch64/ArchExceptionHandler.c
@@ -27,7 +27,7 @@ GetExceptionType (
 {
   EFI_EXCEPTION_TYPE  ExceptionType;
 
-  ExceptionType = (SystemContext.SystemContextLoongArch64->ESTAT & CSR_ESTAT_EXC);
+  ExceptionType = (SystemContext.SystemContextLoongArch64->ESTAT & CSR_ESTAT_EXC) >> CSR_ESTAT_EXC_SHIFT;
   return ExceptionType;
 }
 

--- a/UefiCpuPkg/Library/CpuExceptionHandlerLib/LoongArch/LoongArch64/ArchExceptionHandler.c
+++ b/UefiCpuPkg/Library/CpuExceptionHandlerLib/LoongArch/LoongArch64/ArchExceptionHandler.c
@@ -96,6 +96,17 @@ DumpCpuContext (
     );
 
   //
+  // Dump interrupt type if the exception type is INT.
+  //
+  if (ExceptionType == EXCEPT_LOONGARCH_INT) {
+    InternalPrintMessage (
+      "\n!!!! Unhandled interrupt Type - %02x(%a) !!!!\n",
+      GetInterruptType (SystemContext),
+      GetInterruptNameStr (GetInterruptType (SystemContext))
+      );
+  }
+
+  //
   // Dump TLB refill ERA and BADV
   //
   if (ExceptionType == (mExceptionKnownNameNum - 1)) {

--- a/UefiCpuPkg/Library/CpuExceptionHandlerLib/LoongArch/SecPeiExceptionLib.c
+++ b/UefiCpuPkg/Library/CpuExceptionHandlerLib/LoongArch/SecPeiExceptionLib.c
@@ -68,14 +68,7 @@ CommonExceptionHandler (
       //
       IpiInterruptHandler (InterruptType, SystemContext);
       return;
-    } else {
-      ExceptionType = InterruptType;
     }
-  } else {
-    //
-    // Exception
-    //
-    ExceptionType >>= CSR_ESTAT_EXC_SHIFT;
   }
 
   DefaultExceptionHandler (ExceptionType, SystemContext);


### PR DESCRIPTION
# Description

Patch1: There is a problem with LoongArch64 exception handler, it returns a unhandled value when we get an exception type, the correct value should be right shifted 16 bits, so fix it. Increased the max number of exception handlers to 23.
Patch2: Added interrupt type dump function on LoongArch.
Patch3: BaseCryptLib, RngLib, IntrinsicLib and OpensslLib are enabled by default on LoongArch VM, since some APPs or OS require them.

## How This Was Tested

Build OvmfPkg/LoongArchVirt/LoongArchVirtQemu.dsc and run it.

## Integration Instructions

N/A.
