### PR TITLE
OvmfPkg: Introduce UEFI config support for fw_cfg

### DIFF
--- a/MdeModulePkg/Include/Library/UefiBootManagerLib.h
+++ b/MdeModulePkg/Include/Library/UefiBootManagerLib.h
@@ -439,6 +439,11 @@ EfiBootManagerGetBootManagerMenu (
   EFI_BOOT_MANAGER_LOAD_OPTION  *BootOption
   );
 
+BOOLEAN
+BmIsBootManagerMenuFilePath (
+  EFI_DEVICE_PATH_PROTOCOL  *DevicePath
+  );
+
 /**
   Get the next possible full path pointing to the load option.
   The routine doesn't guarantee the returned full path points to an existing

--- a/MdeModulePkg/Library/UefiBootManagerLib/BmBoot.c
+++ b/MdeModulePkg/Library/UefiBootManagerLib/BmBoot.c
@@ -2503,6 +2503,8 @@ BmRegisterBootManagerMenu (
   OUT EFI_BOOT_MANAGER_LOAD_OPTION  *BootOption
   )
 {
+  DEBUG ((DEBUG_INFO, "BmRegisterBootManagerMenu\n"));
+
   EFI_STATUS                Status;
   CHAR16                    *Description;
   UINTN                     DescriptionLength;
@@ -2609,6 +2611,8 @@ EfiBootManagerGetBootManagerMenu (
   EFI_BOOT_MANAGER_LOAD_OPTION  *BootOption
   )
 {
+  DEBUG ((DEBUG_INFO, "EfiBootManagerGetBootManagerMenu\n"));
+
   EFI_STATUS                    Status;
   UINTN                         BootOptionCount;
   EFI_BOOT_MANAGER_LOAD_OPTION  *BootOptions;
@@ -2639,8 +2643,10 @@ EfiBootManagerGetBootManagerMenu (
   // Automatically create the Boot#### for Boot Manager Menu when not found.
   //
   if (Index == BootOptionCount) {
+    DEBUG ((DEBUG_INFO, "Menu non trovato, aggiungo\n"));
     return BmRegisterBootManagerMenu (BootOption);
   } else {
+    DEBUG ((DEBUG_INFO, "Menu trovato!\n"));
     return EFI_SUCCESS;
   }
 }

--- a/MdeModulePkg/Library/UefiBootManagerLib/BmHotkey.c
+++ b/MdeModulePkg/Library/UefiBootManagerLib/BmHotkey.c
@@ -550,6 +550,8 @@ BmRegisterHotkeyNotify (
   UINTN       Index;
   VOID        *NotifyHandle;
 
+  DEBUG ((DEBUG_INFO, "BmRegisterHotkeyNotify\n"));
+
   for (Index = 0; Index < Hotkey->CodeCount; Index++) {
     Status = TxtInEx->RegisterKeyNotify (
                         TxtInEx,
@@ -661,6 +663,8 @@ BmProcessKeyOption (
   IN EFI_BOOT_MANAGER_KEY_OPTION  *KeyOption
   )
 {
+  DEBUG ((DEBUG_INFO, "BmProcessKeyOption\n"));
+
   EFI_STATUS                         Status;
   EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL  *TxtInEx;
   EFI_HANDLE                         *Handles;
@@ -976,6 +980,8 @@ EfiBootManagerAddKeyOptionVariable (
   ...
   )
 {
+  DEBUG ((DEBUG_INFO, "Vorrei registrare tasto\n"));
+
   EFI_STATUS                   Status;
   VA_LIST                      Args;
   VOID                         *BootOption;

--- a/MdeModulePkg/Universal/BdsDxe/BdsDxe.inf
+++ b/MdeModulePkg/Universal/BdsDxe/BdsDxe.inf
@@ -98,6 +98,7 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdTestKeyUsed                       ## CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdCapsuleOnDiskSupport              ## CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdPlatformRecoverySupport           ## CONSUMES
+  gEfiMdePkgTokenSpaceGuid.PcdBootMenuEnabled
 
 [Depex]
   TRUE

--- a/MdeModulePkg/Universal/BdsDxe/BdsEntry.c
+++ b/MdeModulePkg/Universal/BdsDxe/BdsEntry.c
@@ -987,9 +987,13 @@ BdsEntry (
   DEBUG_CODE_END ();
 
   //
-  // BootManagerMenu doesn't contain the correct information when return status is EFI_NOT_FOUND.
+  // Disable BootManagerMenu boot if PcdBootMenuEnabled is set to FALSE.
   //
-  BootManagerMenuStatus = EfiBootManagerGetBootManagerMenu (&BootManagerMenu);
+  if (!PcdGetBool (PcdBootMenuEnabled)) {
+    BootManagerMenuStatus = EFI_NOT_FOUND;
+  } else {
+    BootManagerMenuStatus = EfiBootManagerGetBootManagerMenu (&BootManagerMenu);
+  }
 
   BootFwUi         = (BOOLEAN)((OsIndication & EFI_OS_INDICATIONS_BOOT_TO_FW_UI) != 0);
   PlatformRecovery = (BOOLEAN)((OsIndication & EFI_OS_INDICATIONS_START_PLATFORM_RECOVERY) != 0);

--- a/MdePkg/MdePkg.dec
+++ b/MdePkg/MdePkg.dec
@@ -2602,5 +2602,8 @@
   # @Prompt Memory encryption attribute
   gEfiMdePkgTokenSpaceGuid.PcdConfidentialComputingGuestAttr|0|UINT64|0x0000002e
 
+[PcdsDynamic, PcdsDynamicEx]
+  gEfiMdePkgTokenSpaceGuid.PcdBootMenuEnabled|TRUE|BOOLEAN|0x0000002f
+
 [UserExtensions.TianoCore."ExtraFiles"]
   MdePkgExtra.uni

--- a/OvmfPkg/Library/PlatformBootManagerLib/BdsPlatform.c
+++ b/OvmfPkg/Library/PlatformBootManagerLib/BdsPlatform.c
@@ -383,6 +383,35 @@ RestrictBootOptionsToFirmware (
 }
 
 VOID
+RemoveBootManager (
+  VOID
+  )
+{
+  EFI_BOOT_MANAGER_LOAD_OPTION  *BootOptions;
+  UINTN                         BootOptionCount;
+  UINTN                         Index;
+
+  BootOptions = EfiBootManagerGetLoadOptions (
+                  &BootOptionCount,
+                  LoadOptionTypeBoot
+                  );
+
+  for (Index = 0; Index < BootOptionCount; ++Index) {
+    if (BmIsBootManagerMenuFilePath (BootOptions[Index].FilePath)) {
+      //
+      // Delete the boot option.
+      //
+      EfiBootManagerDeleteLoadOptionVariable (
+        BootOptions[Index].OptionNumber,
+        LoadOptionTypeBoot
+        );
+    }
+  }
+
+  EfiBootManagerFreeLoadOptions (BootOptions, BootOptionCount);
+}
+
+VOID
 PlatformRegisterOptionsAndKeys (
   VOID
   )

--- a/OvmfPkg/Library/PlatformBootManagerLib/PlatformBootManagerLib.inf
+++ b/OvmfPkg/Library/PlatformBootManagerLib/PlatformBootManagerLib.inf
@@ -69,6 +69,7 @@
   gEfiMdePkgTokenSpaceGuid.PcdUartDefaultDataBits         ## CONSUMES
   gEfiMdePkgTokenSpaceGuid.PcdUartDefaultParity           ## CONSUMES
   gEfiMdePkgTokenSpaceGuid.PcdUartDefaultStopBits         ## CONSUMES
+  gEfiMdePkgTokenSpaceGuid.PcdBootMenuEnabled
 
 [Pcd.IA32, Pcd.X64]
   gEfiMdePkgTokenSpaceGuid.PcdFSBClock

--- a/OvmfPkg/RUNTIME_CONFIG.md
+++ b/OvmfPkg/RUNTIME_CONFIG.md
@@ -36,6 +36,16 @@ qemu-system-x86_64 \
 ```
 
 
+## Firmware Config: opt/org.tianocore/FirmwareSetupSupport
+
+As the name suggests, this enables/disables Firmware setup support.  Default:
+enabled.  Usage:
+
+```
+qemu-system-x86_64 -fw_cfg name=opt/org.tianocore/FirmwareSetupSupport,string=no
+```
+
+
 ## TLS: etc/edk2/https/ciphers
 
 Configres the allowed TLS chiper suites.  Using the host's system


### PR DESCRIPTION
# Description

This PR is linked to #6494. This is to disable the UEFI config using fw_cfg from QEMU cli.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Run QEMU on X86-64 with and without the fw_cfg flag set.
For reference qemu -fw_cfg name=opt/org.tianocore/FirmwareSetupSupport=no
UEFI Shell fails to boot when the value is set to no.

## Integration Instructions

N/A
