### PR TITLE
MdePkg: Add ACPI 5.1 table definition for WAET

### DIFF
--- a/MdePkg/Include/IndustryStandard/Acpi51.h
+++ b/MdePkg/Include/IndustryStandard/Acpi51.h
@@ -1835,6 +1835,25 @@ typedef struct {
 } EFI_ACPI_5_1_EINJ_TRIGGER_ACTION_TABLE;
 
 ///
+/// Windows ACPI Emulated devices Table
+///
+typedef struct {
+  EFI_ACPI_DESCRIPTION_HEADER    Header;
+  ///
+  /// Container of a bitmask of Windows behavior that this system requires
+  /// Bit 0 - RTC good
+  /// Bit 1 - ACPI PM timer good
+  ///
+  UINT32                         EmulatedDeviceFlags;
+} EFI_ACPI_5_1_WAET_TABLE;
+
+///
+/// WAET Flags. All other bits are reserved and must be 0.
+///
+#define EFI_ACPI_5_1_WAET_FLAGS_RTC_GOOD            BIT0
+#define EFI_ACPI_5_1_WAET_FLAGS_ACPI_PM_TIMER_GOOD  BIT1
+
+///
 /// Platform Communications Channel Table (PCCT)
 ///
 typedef struct {


### PR DESCRIPTION
This is a struct needed for virtualizing Windows.

https://uefi.org/acpi entry for WAET links to
https://learn.microsoft.com/en-us/previous-versions/gg487524(v=msdn.10)

which describes the 32-bit flags field with bits 0 and 1 defined.

# Description

- [ ] Breaking change? No
- [ ] Impacts security? No
- [ ] Includes tests? No

## How This Was Tested

Definition only. Part of upstreaming effort for Google fork of EDK2.
