### PR TITLE
UefiPkg/PiSmmCpuDxeSmm: Set SmmProfile Variable only for SMM Mode.

### DIFF
--- a/UefiCpuPkg/PiSmmCpuDxeSmm/SmmProfile.c
+++ b/UefiCpuPkg/PiSmmCpuDxeSmm/SmmProfile.c
@@ -749,6 +749,7 @@ InitSmmProfileInternal (
   UINTN       MsrDsAreaSizePerCpu;
   UINT64      SmmProfileSize;
 
+  Status        = EFI_SUCCESS;
   mPFEntryCount = (UINTN *)AllocateZeroPool (sizeof (UINTN) * mMaxNumberOfCpus);
   ASSERT (mPFEntryCount != NULL);
   mLastPFEntryValue = (UINT64 (*)[MAX_PF_ENTRY_COUNT])AllocateZeroPool (
@@ -840,12 +841,14 @@ InitSmmProfileInternal (
   //
   // Start SMM profile when SmmReadyToLock protocol is installed.
   //
-  Status = gMmst->MmRegisterProtocolNotify (
-                    &gEfiSmmReadyToLockProtocolGuid,
-                    InitSmmProfileCallBack,
-                    &Registration
-                    );
-  ASSERT_EFI_ERROR (Status);
+  if (!mIsStandaloneMm) {
+    Status = gMmst->MmRegisterProtocolNotify (
+                      &gEfiSmmReadyToLockProtocolGuid,
+                      InitSmmProfileCallBack,
+                      &Registration
+                      );
+    ASSERT_EFI_ERROR (Status);
+  }
 
   return;
 }


### PR DESCRIPTION
For PiSmmCpuDxeSmm driver. There is SetVariable logic for SmmProfile data. In traditional SMM Mode, still set the SmmProfile variable. But for standalone remove the SetVariable logic.

# Description

<_Include a description of the change and why this change was made._>

<_For each item, place an "x" in between `[` and `]` if true. Example: `[x]` (you can also check items in GitHub UI)_>

<_Create the PR as a Draft PR if it is only created to run CI checks._>

<_Delete lines in \<\> tags before creating the PR._>

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

<_Describe the test(s) that were run to verify the changes._>

## Integration Instructions

<_Describe how these changes should be integrated. Use N/A if nothing is required._>
