### PR TITLE
Add SmmCpuPlatformHookLib IsCpuSyncAlwaysNeeded interface

### DIFF
--- a/OvmfPkg/Library/SmmCpuPlatformHookLibQemu/SmmCpuPlatformHookLibQemu.c
+++ b/OvmfPkg/Library/SmmCpuPlatformHookLibQemu/SmmCpuPlatformHookLibQemu.c
@@ -131,3 +131,26 @@ SmmCpuPlatformHookBeforeMmiHandler (
 {
   return EFI_UNSUPPORTED;
 }
+
+/**
+  This function determines whether the first CPU Synchronization should be executed unconditionally
+  when a SMI occurs.
+
+  If the function returns true, it indicates that there is no need to check the system configuration
+  and status, and the first CPU Synchronization should be executed unconditionally.
+
+  If the function returns false, it indicates that the first CPU Synchronization is not executed
+  unconditionally, and the decision to synchronize should be based on the system configuration and status.
+
+  @retval TRUE   The first CPU Synchronization is executed unconditionally.
+  @retval FALSE  The first CPU Synchronization is not executed unconditionally.
+
+**/
+BOOLEAN
+EFIAPI
+IsCpuSyncAlwaysNeeded (
+  VOID
+  )
+{
+  return FALSE;
+}

--- a/UefiCpuPkg/Include/Library/SmmCpuPlatformHookLib.h
+++ b/UefiCpuPkg/Include/Library/SmmCpuPlatformHookLib.h
@@ -115,4 +115,24 @@ SmmCpuPlatformHookBeforeMmiHandler (
   VOID
   );
 
+/**
+  This function determines whether the first CPU Synchronization should be executed unconditionally
+  when a SMI occurs.
+
+  If the function returns true, it indicates that there is no need to check the system configuration
+  and status, and the first CPU Synchronization should be executed unconditionally.
+
+  If the function returns false, it indicates that the first CPU Synchronization is not executed
+  unconditionally, and the decision to synchronize should be based on the system configuration and status.
+
+  @retval TRUE   The first CPU Synchronization is executed unconditionally.
+  @retval FALSE  The first CPU Synchronization is not executed unconditionally.
+
+**/
+BOOLEAN
+EFIAPI
+IsCpuSyncAlwaysNeeded (
+  VOID
+  );
+
 #endif

--- a/UefiCpuPkg/Library/SmmCpuPlatformHookLibNull/SmmCpuPlatformHookLibNull.c
+++ b/UefiCpuPkg/Library/SmmCpuPlatformHookLibNull/SmmCpuPlatformHookLibNull.c
@@ -118,3 +118,26 @@ SmmCpuPlatformHookBeforeMmiHandler (
 {
   return EFI_UNSUPPORTED;
 }
+
+/**
+  This function determines whether the first CPU Synchronization should be executed unconditionally
+  when a SMI occurs.
+
+  If the function returns true, it indicates that there is no need to check the system configuration
+  and status, and the first CPU Synchronization should be executed unconditionally.
+
+  If the function returns false, it indicates that the first CPU Synchronization is not executed
+  unconditionally, and the decision to synchronize should be based on the system configuration and status.
+
+  @retval TRUE   The first CPU Synchronization is executed unconditionally.
+  @retval FALSE  The first CPU Synchronization is not executed unconditionally.
+
+**/
+BOOLEAN
+EFIAPI
+IsCpuSyncAlwaysNeeded (
+  VOID
+  )
+{
+  return FALSE;
+}


### PR DESCRIPTION
# Description
Determines whether all CPUs sync is needed.

This function determine if all CPUs needed to be synced unconditional during the 1st APs sync.

By default, it returns FALSE which indicates not all CPUs needed to be synced. In case of all CPUs
needed to be synced, platform specific implementation can return TRUE.

## How This Was Tested

No test except compile the code successfully as new interface not being used by other code now. Test can be done once it called by other code later. 

