### PR TITLE
MdePkg: UefiDevicePathLib: Fix missing the Display Only format of Media Device Path SubType Hard Drive.

### DIFF
--- a/MdePkg/Library/UefiDevicePathLib/DevicePathToText.c
+++ b/MdePkg/Library/UefiDevicePathLib/DevicePathToText.c
@@ -1882,7 +1882,7 @@ DevPathToTextHardDrive (
     case SIGNATURE_TYPE_MBR:
       UefiDevicePathLibCatPrint (
         Str,
-        L"HD(%d,%s,0x%08x,",
+        L"HD(%d,%s,0x%08x",
         Hd->PartitionNumber,
         L"MBR",
         *((UINT32 *)(&(Hd->Signature[0])))
@@ -1892,7 +1892,7 @@ DevPathToTextHardDrive (
     case SIGNATURE_TYPE_GUID:
       UefiDevicePathLibCatPrint (
         Str,
-        L"HD(%d,%s,%g,",
+        L"HD(%d,%s,%g",
         Hd->PartitionNumber,
         L"GPT",
         (EFI_GUID *)&(Hd->Signature[0])
@@ -1902,14 +1902,18 @@ DevPathToTextHardDrive (
     default:
       UefiDevicePathLibCatPrint (
         Str,
-        L"HD(%d,%d,0,",
+        L"HD(%d,%d,0",
         Hd->PartitionNumber,
         Hd->SignatureType
         );
       break;
   }
 
-  UefiDevicePathLibCatPrint (Str, L"0x%lx,0x%lx)", Hd->PartitionStart, Hd->PartitionSize);
+  if (DisplayOnly) {
+    UefiDevicePathLibCatPrint (Str, L")");
+  } else {
+    UefiDevicePathLibCatPrint (Str, L",0x%lx,0x%lx)", Hd->PartitionStart, Hd->PartitionSize);
+  }
 }
 
 /**


### PR DESCRIPTION
```
HD(Partition,Type,Signature,Start, Size)
HD(Partition,Type,Signature) (Display Only)
```

Reference: [UEFI Specification Version 2.1 (Errata D) (released October  2008)](https://uefi.org/sites/default/files/resources/UEFI_Spec_2_1.pdf)
