### PR TITLE
MdePkg: Add manageability status code defined in PI 1.9 Spec.

### DIFF
--- a/MdePkg/Include/Pi/PiStatusCode.h
+++ b/MdePkg/Include/Pi/PiStatusCode.h
@@ -2,6 +2,7 @@
   StatusCode related definitions in PI.
 
 Copyright (c) 2009 - 2018, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
   @par Revision Reference:
@@ -140,6 +141,7 @@ typedef struct {
 #define EFI_COMPUTING_UNIT_CACHE               (EFI_COMPUTING_UNIT | 0x00040000)
 #define EFI_COMPUTING_UNIT_MEMORY              (EFI_COMPUTING_UNIT | 0x00050000)
 #define EFI_COMPUTING_UNIT_CHIPSET             (EFI_COMPUTING_UNIT | 0x00060000)
+#define EFI_COMPUTING_UNIT_MANAGEABILITY       (EFI_COMPUTING_UNIT | 0x00070000)
 ///@}
 
 ///
@@ -341,6 +343,16 @@ typedef struct {
 #define EFI_CHIPSET_EC_DXE_NB_ERROR     (EFI_SUBCLASS_SPECIFIC | 0x00000001)
 #define EFI_CHIPSET_EC_DXE_SB_ERROR     (EFI_SUBCLASS_SPECIFIC | 0x00000002)
 #define EFI_CHIPSET_EC_INTRUDER_DETECT  (EFI_SUBCLASS_SPECIFIC | 0x00000003)
+///@}
+
+///
+/// Computing Unit Manageability Subclass Error Code definitions.
+/// The detail information is reported by REPORT_STATUS_CODE_WITH_EXTENDED_DATA
+//  with ASCII string in EFI_STATUS_CODE_STRING_DATA.
+///@{
+#define EFI_MANAGEABILITY_EC_REDFISH_COMMUNICATION_ERROR         (EFI_SUBCLASS_SPECIFIC | 0x00000000)
+#define EFI_MANAGEABILITY_EC_REDFISH_HOST_INTERFACE_ERROR        (EFI_SUBCLASS_SPECIFIC | 0x00000001)
+#define EFI_MANAGEABILITY_EC_REDFISH_BOOTSTRAP_CREDENTIAL_ERROR  (EFI_SUBCLASS_SPECIFIC | 0x00000002)
 ///@}
 
 ///


### PR DESCRIPTION
# Description

REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4483

This change introduces EFI_COMPUTING_UNIT_MANAGEABILITY status code. EFI_COMPUTING_UNIT_MANAGEABILITY is created as one of the subclasses in computing unit class. EFI_COMPUTING_UNIT_MANAGEABILITY will be used in edk2 RedfishPkg and edk2-redfish-client RedfishClientPkg to report Redfish operation errors. It will also be used to report errors in edk2-platforms ManageabilityPkg.

PI 1.9 specification, 6.4.1.4.9. Manageability Subclass:
* https://uefi.org/specs/PI/1.9/V3_Status_Codes.html#manageability-subclass

RFC:
* https://edk2.groups.io/g/devel/message/105525
* https://edk2.groups.io/g/devel/message/105595
* https://edk2.groups.io/g/rfc/message/802

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Build pass

## Integration Instructions

N/A
