### PR TITLE
ShellPkg Http.c: Remove extra `\n` when using `-m` param

### DIFF
--- a/ShellPkg/DynamicCommand/HttpDynamicCommand/Http.c
+++ b/ShellPkg/DynamicCommand/HttpDynamicCommand/Http.c
@@ -1690,7 +1690,7 @@ GetResponse (
     if (!EFI_ERROR (gRT->GetTime (&EndTime, NULL))) {
       ElapsedSeconds = EfiTimeToEpoch (&EndTime) - EfiTimeToEpoch (&StartTime);
       Print (
-        L",%a%Lus\n",
+        L",%a%Lus",
         ElapsedSeconds ? " " : " < ",
         ElapsedSeconds > 1 ? (UINT64)ElapsedSeconds : 1
         );


### PR DESCRIPTION
There is already `PRINT_HII (STRING_TOKEN (STR_GEN_CRLF), NULL);` after `DownloadFile()`, remove this extra `\n` to avoid printing extra blank lines.

# Description

- [ ] Breaking change?
  - N/A
- [ ] Impacts security?
  - N/A
- [ ] Includes tests?
  - N/A

## How This Was Tested

Compare the output info of `http http://192.168.10.23:5000/BIN/BIOS.bin -m` cmd.

before:
```
FS0:\> http http://192.168.10.23:5000/BIN/BIOS.bin -m
[=======================================>]   32768 Kb, 44s

FS0:\>
```

after:
```
FS0:\> http http://192.168.10.23:5000/BIN/BIOS.bin -m
[=======================================>]   32768 Kb, 44s
FS0:\>
```

## Integration Instructions

N/A
