### PR TITLE
.github: Add issue automation workflows

### DIFF
--- a/.github/advanced-issue-labeler.yml
+++ b/.github/advanced-issue-labeler.yml
@@ -1,0 +1,115 @@
+# Defines the mappings between GitHub issue responses and labels applied to the issue.
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+# For more information, see:
+# https://github.com/redhat-plumbers-in-action/advanced-issue-labeler
+
+policy:
+  - section:
+
+    # Issue Template - Urgency Dropdown
+    - id: ['urgency']
+      block-list: []
+      label:
+        - name: 'priority:low'
+          keys: ['Low']
+        - name: 'priority:medium'
+          keys: ['Medium']
+        - name: 'priority:high'
+          keys: ['High']
+
+    # Issue Template - Code First
+    - id: ['code_first']
+      block-list: []
+      label:
+        - name: 'type:code-first'
+          keys: ['Yes']
+
+    # Issue Template - Fix Owner Dropdown
+    - id: ['fix_owner', 'request_owner']
+      block-list: []
+      label:
+        - name: 'state:needs-owner'
+          keys: [
+            'Someone else needs to fix it',
+            'Someone else needs to make the change',
+            'Someone else needs to implement the feature'
+            ]
+        - name: 'state:needs-triage'
+          keys: [
+            'Someone else needs to fix it',
+            'Someone else needs to make the change',
+            'Someone else needs to implement the feature'
+            ]
+
+    # Issue Template - Needs Maintainer Feedback Dropdown
+    - id: ['needs_maintainer_feedback']
+      block-list: []
+      label:
+        - name: 'state:needs-maintainer-feedback'
+          keys: ['Maintainer feedback requested']
+
+    # Issue Template - Packages Impacted
+    - id: ['packages_impacted']
+      block-list: []
+      label:
+        - name: 'package:armpkg'
+          keys: ['ArmPkg']
+        - name: 'package:armplatformpkg'
+          keys: ['ArmPlatformPkg']
+        - name: 'package:armvirtpkg'
+          keys: ['ArmVirtPkg']
+        - name: 'package:basetools'
+          keys: ['BaseTools']
+        - name: 'package:build-or-ci-code'
+          keys: ['Build or CI Code']
+        - name: 'package:cryptopkg'
+          keys: ['CryptoPkg']
+        - name: 'package:dynamictablespkg'
+          keys: ['DynamicTablesPkg']
+        - name: 'package:embeddedpkg'
+          keys: ['EmbeddedPkg']
+        - name: 'package:emulatorpkg'
+          keys: ['EmulatorPkg']
+        - name: 'package:fatpkg'
+          keys: ['FatPkg']
+        - name: 'package:fmpdevicepkg'
+          keys: ['FmpDevicePkg']
+        - name: 'package:intelfsp2pkg'
+          keys: ['IntelFsp2Pkg']
+        - name: 'package:intelfsp2wrapperpkg'
+          keys: ['IntelFsp2WrapperPkg']
+        - name: 'package:mdemodulepkg'
+          keys: ['MdeModulePkg']
+        - name: 'package:mdepkg'
+          keys: ['MdePkg']
+        - name: 'package:networkpkg'
+          keys: ['NetworkPkg']
+        - name: 'package:ovmfpkg'
+          keys: ['OvmfPkg']
+        - name: 'package:pcatchipsetpkg'
+          keys: ['PcAtChipsetPkg']
+        - name: 'package:prmpkg'
+          keys: ['PrmPkg']
+        - name: 'package:redfishpkg'
+          keys: ['RedfishPkg']
+        - name: 'package:securitypkg'
+          keys: ['SecurityPkg']
+        - name: 'package:shellpkg'
+          keys: ['ShellPkg']
+        - name: 'package:signedcapsulepkg'
+          keys: ['SignedCapsulePkg']
+        - name: 'package:sourceleveldebugpkg'
+          keys: ['SourceLevelDebugPkg']
+        - name: 'package:standalonemmpkg'
+          keys: ['StandaloneMmPkg']
+        - name: 'package:ueficpupkg'
+          keys: ['UefiCpuPkg']
+        - name: 'package:uefipayloadpkg'
+          keys: ['UefiPayloadPkg']
+        - name: 'package:unittestframeworkpkg'
+          keys: ['UnitTestFrameworkPkg']
+        - name: 'package:other'
+          keys: ['Other']

--- a/.github/workflows/issue-assignment.yml
+++ b/.github/workflows/issue-assignment.yml
@@ -1,0 +1,56 @@
+# Actions that should occur when a GitHub issue is assigned.
+#
+# Currently this will remove the `state:needs-owner` label when the issue is assigned to an owner.
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+
+name: React to Issue Assignment
+
+on:
+  issues:
+    types: assigned
+
+jobs:
+  adjust-labels:
+    name: Adjust Issue Labels
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      issues: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Remove Labels
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # All labels here will be removed if present in the issue
+          LABELS_TO_REMOVE=("state:needs-owner")
+
+          # Gather issue context information
+          ISSUE_NUMBER=$(jq --raw-output .issue.number "$GITHUB_EVENT_PATH")
+          OWNER=$(jq --raw-output .repository.owner.login "$GITHUB_EVENT_PATH")
+          REPO=$(jq --raw-output .repository.name "$GITHUB_EVENT_PATH")
+          LABELS=$(curl -s \
+                        -H "Accept: application/vnd.github+json" \
+                        -H "Authorization: Bearer $GITHUB_TOKEN" \
+                        -H "X-GitHub-Api-Version: 2022-11-28" \
+                        https://api.github.com/repos/$OWNER/$REPO/issues/$ISSUE_NUMBER/labels | jq -r '.[].name')
+
+          # Remove labels
+          for LABEL in "${LABELS_TO_REMOVE[@]}"; do
+            if echo "$LABELS" | grep -q "$LABEL"; then
+              curl -X DELETE \
+                   -s \
+                   -H "Accept: application/vnd.github+json" \
+                   -H "Authorization: Bearer $GITHUB_TOKEN" \
+                   -H "X-GitHub-Api-Version: 2022-11-28" \
+                   https://api.github.com/repos/$OWNER/$REPO/issues/$ISSUE_NUMBER/labels/"$LABEL" > /dev/null
+              echo "$LABEL removed from issue #$ISSUE_NUMBER"
+            else
+              echo "$LABEL not found on issue #$ISSUE_NUMBER"
+            fi
+          done

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -1,0 +1,57 @@
+# This workflow assists with initial triage of new issues by applying labels
+# based on data provided in the issue.
+#
+# Configuration file that maps issue form input values to labels:
+#   advanced-issue-labeler.yml
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+# For more information, see:
+# https://github.com/stefanbuck/github-issue-parser
+# https://github.com/redhat-plumbers-in-action/advanced-issue-labeler
+
+name: Issue Triage Workflow
+
+on:
+  issues:
+    types: [ opened ]
+
+jobs:
+  triage_issue:
+    name: Triage Issue
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        template: [ bug_report.yml, documentation_request.yml, feature_request.yml ]
+
+    permissions:
+      issues: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Parse Issue Form
+        uses: stefanbuck/github-issue-parser@v3
+        id: issue-parser
+        with:
+          issue-body: ${{ github.event.issue.body }}
+          template-path: .github/ISSUE_TEMPLATE/${{ matrix.template }}
+
+      - name: Apply Labels from Triage
+        uses: redhat-plumbers-in-action/advanced-issue-labeler@v3
+        with:
+          issue-form: ${{ steps.issue-parser.outputs.jsonString }}
+          template: ${{ matrix.template }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update Assignee
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FIX_OWNER: ${{ steps.issue-parser.outputs.issueparser_fix_owner }}
+        run: |
+          if [[ $FIX_OWNER == "I will fix it" ]] || [[ $FIX_OWNER == "I will make the change" ]] || [[ $FIX_OWNER == "I will implement the feature" ]]
+          then
+            gh issue edit ${{ github.event.issue.html_url }} --add-assignee ${{ github.event.issue.user.login }}
+          fi

--- a/.github/workflows/scheduled-maintenance.yml
+++ b/.github/workflows/scheduled-maintenance.yml
@@ -1,0 +1,52 @@
+# This workflow performs scheduled maintenance tasks.
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+
+name: Scheduled Maintenance
+
+on:
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    # Run every hour - https://crontab.guru/#0_*_*_*_*
+    - cron:  '0 * * * *'
+  workflow_dispatch:
+
+jobs:
+  repo_cleanup:
+    runs-on: ubuntu-latest
+
+    permissions:
+      pull-requests: write
+      issues: write
+
+    steps:
+      - name: Prune Won't Fix Pull Requests
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api \
+            -H "Accept: application/vnd.github+json" \
+            /repos/${GITHUB_REPOSITORY}/pulls | jq -r '.[]' | jq -rc '.html_url,.labels' | \
+          while read -r html_url ; do
+            read -r labels
+            if [[ $labels == *"state:wont-fix"* ]]; then
+              gh pr close $html_url -c "Closed due to being marked as wont fix" --delete-branch
+            fi
+          done
+
+      - name: Prune Won't Fix Issues
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ env.REPOSITORY_NAME }}
+        run: |
+          gh api \
+            -H "Accept: application/vnd.github+json" \
+            /repos/${GITHUB_REPOSITORY}/issues | jq -r '.[]' | jq -rc '.html_url,.labels' | \
+          while read -r html_url ; do
+            read -r labels
+            if [[ $labels == *"state:wont-fix"* ]]; then
+              gh issue close $html_url -c "Closed due to being marked as wont fix" -r "not planned"
+            fi
+          done


### PR DESCRIPTION
# Description

REF: https://github.com/tianocore/edk2/discussions/5926

Adds workflows to manage labels on issues based on issue content.

Workflows:

- `issue-assignment` - Performs actions when an issue is assigned.
  - Currently, removed the `state:needs-owner` label.
- `issue-triage` - Assigns initial labels to the issue based on data entered when the issue was created.
  - The policies for applying labels are defined in
    - `advanced-issue-labeler.yml`
	- Note: Based on https://github.com/marketplace/actions/advanced-issue-labeler
- `scheduled-maintenance` - Runs every hour to perform clean up work need on issues.
  - Currently, closes issues that have had the `state:wont-fix` label applied.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

- Tested on edk2 fork.

## Integration Instructions

- N/A - Impacts GitHub issue usage on the tianocore/edk2 repo.