### PR TITLE
MdePkg: Update BASE_CR macro in Base.h for a Coverity error

### DIFF
--- a/MdePkg/Include/Base.h
+++ b/MdePkg/Include/Base.h
@@ -888,7 +888,7 @@ STATIC_ASSERT (ALIGNOF (__VERIFY_INT32_ENUM_SIZE) == sizeof (__VERIFY_INT32_ENUM
   @return  A pointer to the structure from one of it's elements.
 
 **/
-#define BASE_CR(Record, TYPE, Field)  ((TYPE *) ((CHAR8 *) (Record) - OFFSET_OF (TYPE, Field)))
+#define BASE_CR(Record, TYPE, Field)  ((TYPE *) (VOID *) ((CHAR8 *) (Record) - OFFSET_OF (TYPE, Field)))
 
 /**
   Checks whether a value is a power of two.


### PR DESCRIPTION
Coverity is a static analysis tool. It detects the macro as an error (case to incompatible type, cert_exp39_c_violation). The update resolves the error and supports compliance with the static tool.

For example,
MdeModulePkg\Universal\HiiDatabaseDxe\Database.c

Code : 
Entry = BASE_CR (Link, VARSTORAGE_DEFAULT_DATA, Entry);

Coverity Error : 
(3) Event cast_to_incompatible_type: Casting "(CHAR8 *)Link - 0ULL" of type "CHAR8 *" to incompatible type "VARSTORAGE_DEFAULT_DATA *".
(4) Event assign: Assigning: "Entry" = "(VARSTORAGE_DEFAULT_DATA *)((CHAR8 *)Link - 0ULL)".
Also see events: [[cert_exp39_c_violation](https://wiki.sei.cmu.edu/confluence/display/c/EXP39-C.+Do+not+access+a+variable+through+a+pointer+of+an+incompatible+type)]

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

The update has been tested and verified on AMD EDKII bios. With it, the Coverity error is resolved.

## Integration Instructions

N/A
