### PR TITLE
MdeModulePkg|UsbBusDxe: support USB Interface Association

### DIFF
--- a/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbBusDxe.inf
+++ b/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbBusDxe.inf
@@ -2,6 +2,7 @@
 #  The Usb Bus Dxe driver is used to enumerate and manage all attached usb devices.
 #
 #  Copyright (c) 2006 - 2018, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2025, American Megatrends International, LLC. All rights reserved.<BR>
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -40,10 +41,11 @@
   UsbUtility.c
   UsbDesc.h
   UsbBus.h
+  UsbIntfAssoc.c
 
 [Packages]
   MdePkg/MdePkg.dec
-
+  MdeModulePkg/MdeModulePkg.dec
 
 [LibraryClasses]
   MemoryAllocationLib
@@ -58,6 +60,7 @@
 
 [Protocols]
   gEfiUsbIoProtocolGuid                         ## BY_START
+  gEdkiiUsbInterfaceAssociationProtocolGuid
   ## TO_START
   ## BY_START
   gEfiDevicePathProtocolGuid

--- a/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbDesc.h
+++ b/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbDesc.h
@@ -3,6 +3,7 @@
     Manage Usb Descriptor List
 
 Copyright (c) 2007 - 2014, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2025, American Megatrends International, LLC. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -11,6 +12,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #define _USB_DESCRIPTOR_H_
 
 #define USB_MAX_INTERFACE_SETTING  256
+#define USB_MAX_ASSOCIATION        16
 
 //
 // The RequestType in EFI_USB_DEVICE_REQUEST is composed of
@@ -62,8 +64,15 @@ typedef struct {
 } USB_INTERFACE_DESC;
 
 typedef struct {
-  EFI_USB_CONFIG_DESCRIPTOR    Desc;
-  USB_INTERFACE_DESC           **Interfaces;
+  EFI_USB_INTERFACE_ASSOCIATION_DESCRIPTOR    Desc;
+  USB_INTERFACE_DESC                          **Interfaces;
+} USB_INTERFACE_ASSOCIATION_DESC;
+
+typedef struct {
+  EFI_USB_CONFIG_DESCRIPTOR         Desc;
+  USB_INTERFACE_ASSOCIATION_DESC    *Iads[USB_MAX_ASSOCIATION];
+  UINT8                             NumOfIads;
+  USB_INTERFACE_DESC                **Interfaces;
 } USB_CONFIG_DESC;
 
 typedef struct {

--- a/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbEnumer.c
+++ b/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbEnumer.c
@@ -3,6 +3,7 @@
     Usb bus enumeration support.
 
 Copyright (c) 2007 - 2018, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2025, American Megatrends International, LLC. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -42,6 +43,41 @@ UsbGetEndpointDesc (
 }
 
 /**
+  Check if given Usb interface is a part of Usb association.
+
+  @param[in]  Device    The device may have the interface association descriptor.
+  @param[in]  IfDesc    The interface descriptor to check for.
+  @param[out] IfAssoc   The USB association device pointer.
+
+  @retval EFI_SUCCESS   IfDesc is found within associations, IfAssoc has valid pointer.
+  @retval EFI_NOT_FOUND IfDesc does no belong to any association.
+
+**/
+EFI_STATUS
+GetInterfaceAssociation (
+  IN USB_DEVICE          *Device,
+  IN USB_INTERFACE_DESC  *IfDesc,
+  OUT USB_ASSOCIATION    **IfAssoc
+  )
+{
+  UINTN            Index;
+  UINTN            i;
+  USB_ASSOCIATION  *Ia;
+
+  for (Index = 0; Index < Device->NumOfAssociation; Index++) {
+    Ia = Device->Associations[Index];
+    for (i = 0; i < Ia->IaDesc->Desc.InterfaceCount; i++) {
+      if (IfDesc->Settings[0]->Desc.InterfaceNumber == Ia->IaDesc->Interfaces[i]->Settings[0]->Desc.InterfaceNumber) {
+        *IfAssoc = Ia;
+        return EFI_SUCCESS;
+      }
+    }
+  }
+
+  return EFI_NOT_FOUND;
+}
+
+/**
   Free the resource used by USB interface.
 
   @param  UsbIf                 The USB interface to free.
@@ -54,9 +90,25 @@ UsbFreeInterface (
   IN USB_INTERFACE  *UsbIf
   )
 {
-  EFI_STATUS  Status;
+  EFI_STATUS       Status;
+  USB_ASSOCIATION  *UsbIa;
 
-  UsbCloseHostProtoByChild (UsbIf->Device->Bus, UsbIf->Handle);
+  Status = GetInterfaceAssociation (UsbIf->Device, UsbIf->IfDesc, &UsbIa);
+
+  if (!EFI_ERROR (Status)) {
+    //
+    // Close USB Interface Association Protocol by Child
+    //
+    Status = gBS->CloseProtocol (
+                    UsbIa->Handle,
+                    &gEdkiiUsbInterfaceAssociationProtocolGuid,
+                    mUsbBusDriverBinding.DriverBindingHandle,
+                    UsbIf->Handle
+                    );
+    DEBUG ((DEBUG_INFO, "UsbFreeInterface: close IAD protocol by child, %r\n", Status));
+  } else {
+    UsbCloseHostProtoByChild (UsbIf->Device->Bus, UsbIf->Handle);
+  }
 
   Status = gBS->UninstallMultipleProtocolInterfaces (
                   UsbIf->Handle,
@@ -73,7 +125,66 @@ UsbFreeInterface (
 
     FreePool (UsbIf);
   } else {
-    UsbOpenHostProtoByChild (UsbIf->Device->Bus, UsbIf->Handle);
+    Status = GetInterfaceAssociation (UsbIf->Device, UsbIf->IfDesc, &UsbIa);
+
+    if (!EFI_ERROR (Status)) {
+      //
+      // Reopen USB Interface Assiciation Protocol by Child
+      //
+      Status = gBS->OpenProtocol (
+                      UsbIa->Handle,
+                      &gEdkiiUsbInterfaceAssociationProtocolGuid,
+                      (VOID **)&UsbIa,
+                      mUsbBusDriverBinding.DriverBindingHandle,
+                      UsbIf->Handle,
+                      EFI_OPEN_PROTOCOL_BY_CHILD_CONTROLLER
+                      );
+      DEBUG ((DEBUG_INFO, "UsbFreeInterface: reopen IAD for child, Status = %r\n", Status));
+    } else {
+      //
+      // Reopen USB Host Controller Protocol by Child
+      //
+      Status = UsbOpenHostProtoByChild (UsbIf->Device->Bus, UsbIf->Handle);
+      DEBUG ((DEBUG_INFO, "UsbFreeInterface: reopen host controller for child, Status = %r\n", Status));
+    }
+  }
+
+  return Status;
+}
+
+/**
+  Free the resource used by USB association.
+
+  @param  UsbIa                 The USB association to free.
+
+  @retval EFI_ACCESS_DENIED     The Usb association resource is still occupied.
+  @retval EFI_SUCCESS           The Usb association resource is freed.
+
+**/
+EFI_STATUS
+UsbFreeAssociation (
+  IN USB_ASSOCIATION  *UsbIa
+  )
+{
+  EFI_STATUS  Status;
+
+  Status = gBS->UninstallMultipleProtocolInterfaces (
+                  UsbIa->Handle,
+                  &gEfiDevicePathProtocolGuid,
+                  UsbIa->DevicePath,
+                  &gEdkiiUsbInterfaceAssociationProtocolGuid,
+                  &UsbIa->UsbIaProtocol,
+                  NULL
+                  );
+
+  if (!EFI_ERROR (Status)) {
+    if (UsbIa->DevicePath != NULL) {
+      FreePool (UsbIa->DevicePath);
+    }
+
+    FreePool (UsbIa);
+  } else {
+    UsbOpenHostProtoByChild (UsbIa->Device->Bus, UsbIa->Handle);
   }
 
   return Status;
@@ -82,6 +193,7 @@ UsbFreeInterface (
 /**
   Create an interface for the descriptor IfDesc. Each
   device's configuration can have several interfaces.
+  Interface may belong to interface association.
 
   @param  Device                The device has the interface descriptor.
   @param  IfDesc                The interface descriptor.
@@ -95,10 +207,12 @@ UsbCreateInterface (
   IN USB_INTERFACE_DESC  *IfDesc
   )
 {
-  USB_DEVICE_PATH  UsbNode;
-  USB_INTERFACE    *UsbIf;
-  USB_INTERFACE    *HubIf;
-  EFI_STATUS       Status;
+  USB_DEVICE_PATH           UsbNode;
+  USB_INTERFACE             *UsbIf;
+  USB_INTERFACE             *HubIf;
+  USB_ASSOCIATION           *UsbIa;
+  EFI_DEVICE_PATH_PROTOCOL  *DevicePathProtocol;
+  EFI_STATUS                Status;
 
   UsbIf = AllocateZeroPool (sizeof (USB_INTERFACE));
 
@@ -128,10 +242,17 @@ UsbCreateInterface (
 
   SetDevicePathNodeLength (&UsbNode.Header, sizeof (UsbNode));
 
-  HubIf = Device->ParentIf;
-  ASSERT (HubIf != NULL);
+  Status = GetInterfaceAssociation (Device, IfDesc, &UsbIa);
 
-  UsbIf->DevicePath = AppendDevicePathNode (HubIf->DevicePath, &UsbNode.Header);
+  if (!EFI_ERROR (Status)) {
+    DevicePathProtocol = UsbIa->DevicePath;
+  } else {
+    HubIf = Device->ParentIf;
+    ASSERT (HubIf != NULL);
+    DevicePathProtocol = HubIf->DevicePath;
+  }
+
+  UsbIf->DevicePath = AppendDevicePathNode (DevicePathProtocol, &UsbNode.Header);
 
   if (UsbIf->DevicePath == NULL) {
     DEBUG ((DEBUG_ERROR, "UsbCreateInterface: failed to create device path\n"));
@@ -154,10 +275,28 @@ UsbCreateInterface (
     goto ON_ERROR;
   }
 
-  //
-  // Open USB Host Controller Protocol by Child
-  //
-  Status = UsbOpenHostProtoByChild (Device->Bus, UsbIf->Handle);
+  Status = GetInterfaceAssociation (Device, IfDesc, &UsbIa);
+
+  if (!EFI_ERROR (Status)) {
+    //
+    // Open USB Interface Assiciation Protocol by Child
+    //
+    Status = gBS->OpenProtocol (
+                    UsbIa->Handle,
+                    &gEdkiiUsbInterfaceAssociationProtocolGuid,
+                    (VOID **)&UsbIa,
+                    mUsbBusDriverBinding.DriverBindingHandle,
+                    UsbIf->Handle,
+                    EFI_OPEN_PROTOCOL_BY_CHILD_CONTROLLER
+                    );
+    DEBUG ((DEBUG_INFO, "UsbCreateInterface: open IAD for child, Status = %r\n", Status));
+  } else {
+    //
+    // Open USB Host Controller Protocol by Child
+    //
+    Status = UsbOpenHostProtoByChild (Device->Bus, UsbIf->Handle);
+    DEBUG ((DEBUG_INFO, "UsbCreateInterface: open host controller for child, Status = %r\n", Status));
+  }
 
   if (EFI_ERROR (Status)) {
     gBS->UninstallMultipleProtocolInterfaces (
@@ -181,6 +320,112 @@ ON_ERROR:
   }
 
   FreePool (UsbIf);
+  return NULL;
+}
+
+/**
+  Create an interface association instance and install protocols to manage it.
+
+  @param  Device        The Usb device that has the interface association.
+  @param  Index         The interface association index within Device.
+  @param  IfAssocDesc   The interface association descriptor.
+
+  @return The created USB interface association, or NULL.
+
+**/
+USB_ASSOCIATION *
+UsbCreateAssociation (
+  IN USB_DEVICE                      *Device,
+  IN UINT8                           Index,
+  IN USB_INTERFACE_ASSOCIATION_DESC  *IfAssocDesc
+  )
+{
+  USB_DEVICE_PATH  UsbNode;
+  USB_ASSOCIATION  *UsbAssoc;
+  EFI_STATUS       Status;
+
+  UsbAssoc = AllocateZeroPool (sizeof (USB_ASSOCIATION));
+
+  if (UsbAssoc == NULL) {
+    return NULL;
+  }
+
+  UsbAssoc->Signature = USB_ASSOCIATION_SIGNATURE;
+  UsbAssoc->Device    = Device;
+  UsbAssoc->IaDesc    = IfAssocDesc;
+
+  CopyMem (
+    &(UsbAssoc->UsbIaProtocol),
+    &mUsbIaProtocol,
+    sizeof (EDKII_USB_INTERFACE_ASSOCIATION_PROTOCOL)
+    );
+
+  //
+  // Install USB association protocols
+  //
+  // Device path protocol for the association has the USB node similar to the
+  // one installed for USB interface.
+  //
+
+  UsbNode.Header.Type      = MESSAGING_DEVICE_PATH;
+  UsbNode.Header.SubType   = MSG_USB_DP;
+  UsbNode.ParentPortNumber = Device->ParentPort;
+  UsbNode.InterfaceNumber  = Index;
+
+  SetDevicePathNodeLength (&UsbNode.Header, sizeof (UsbNode));
+
+  ASSERT (Device->ParentIf != NULL);
+
+  UsbAssoc->DevicePath = AppendDevicePathNode (Device->ParentIf->DevicePath, &UsbNode.Header);
+
+  if (UsbAssoc->DevicePath == NULL) {
+    DEBUG ((DEBUG_ERROR, "UsbCreateAssociation: failed to create device path\n"));
+
+    Status = EFI_OUT_OF_RESOURCES;
+    goto ON_ERROR;
+  }
+
+  Status = gBS->InstallMultipleProtocolInterfaces (
+                  &UsbAssoc->Handle,
+                  &gEfiDevicePathProtocolGuid,
+                  UsbAssoc->DevicePath,
+                  &gEdkiiUsbInterfaceAssociationProtocolGuid,
+                  &UsbAssoc->UsbIaProtocol,
+                  NULL
+                  );
+
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "UsbCreateAssociation: failed to install UsbIad - %r\n", Status));
+    goto ON_ERROR;
+  }
+
+  //
+  // Open USB Host Controller Protocol by Child
+  //
+  Status = UsbOpenHostProtoByChild (Device->Bus, UsbAssoc->Handle);
+
+  if (EFI_ERROR (Status)) {
+    gBS->UninstallMultipleProtocolInterfaces (
+           UsbAssoc->Handle,
+           &gEfiDevicePathProtocolGuid,
+           UsbAssoc->DevicePath,
+           &gEdkiiUsbInterfaceAssociationProtocolGuid,
+           &UsbAssoc->UsbIaProtocol,
+           NULL
+           );
+
+    DEBUG ((DEBUG_ERROR, "UsbCreateAssociation: failed to open host for child - %r\n", Status));
+    goto ON_ERROR;
+  }
+
+  return UsbAssoc;
+
+ON_ERROR:
+  if (UsbAssoc->DevicePath != NULL) {
+    FreePool (UsbAssoc->DevicePath);
+  }
+
+  FreePool (UsbAssoc);
   return NULL;
 }
 
@@ -237,6 +482,41 @@ UsbCreateDevice (
 }
 
 /**
+  Connect USB controller at TPL_CALLBACK
+
+  This function is called in both UsbIoControlTransfer and
+  the timer callback in hub enumeration. So, at least it is
+  called at TPL_CALLBACK. Some driver sitting on USB has
+  twisted TPL used. It should be no problem for us to connect
+  or disconnect at CALLBACK.
+
+  @param  Handle        Controller handle to be connected
+
+**/
+EFI_STATUS
+UsbConnectController (
+  EFI_HANDLE  Handle
+  )
+{
+  EFI_STATUS  Status;
+  EFI_TPL     OldTpl;
+
+  OldTpl = UsbGetCurrentTpl ();
+  DEBUG ((DEBUG_INFO, "UsbConnectDriver: TPL before connect is %d, %p\n", (UINT32)OldTpl, Handle));
+
+  gBS->RestoreTPL (TPL_CALLBACK);
+
+  Status = gBS->ConnectController (Handle, NULL, NULL, TRUE);
+
+  DEBUG ((DEBUG_INFO, "UsbConnectDriver: TPL after connect is %d\n", (UINT32)UsbGetCurrentTpl ()));
+  ASSERT (UsbGetCurrentTpl () == TPL_CALLBACK);
+
+  gBS->RaiseTPL (OldTpl);
+
+  return Status;
+}
+
+/**
   Connect the USB interface with its driver. EFI USB bus will
   create a USB interface for each separate interface descriptor.
 
@@ -252,7 +532,6 @@ UsbConnectDriver (
   )
 {
   EFI_STATUS  Status;
-  EFI_TPL     OldTpl;
 
   Status = EFI_SUCCESS;
 
@@ -265,29 +544,11 @@ UsbConnectDriver (
     Status = mUsbHubApi.Init (UsbIf);
   } else {
     //
-    // This function is called in both UsbIoControlTransfer and
-    // the timer callback in hub enumeration. So, at least it is
-    // called at TPL_CALLBACK. Some driver sitting on USB has
-    // twisted TPL used. It should be no problem for us to connect
-    // or disconnect at CALLBACK.
-    //
-
-    //
     // Only recursively wanted usb child device
     //
     if (UsbBusIsWantedUsbIO (UsbIf->Device->Bus, UsbIf)) {
-      OldTpl = UsbGetCurrentTpl ();
-      DEBUG ((DEBUG_INFO, "UsbConnectDriver: TPL before connect is %d, %p\n", (UINT32)OldTpl, UsbIf->Handle));
-
-      gBS->RestoreTPL (TPL_CALLBACK);
-
-      Status           = gBS->ConnectController (UsbIf->Handle, NULL, NULL, TRUE);
+      Status           = UsbConnectController (UsbIf->Handle);
       UsbIf->IsManaged = (BOOLEAN) !EFI_ERROR (Status);
-
-      DEBUG ((DEBUG_INFO, "UsbConnectDriver: TPL after connect is %d\n", (UINT32)UsbGetCurrentTpl ()));
-      ASSERT (UsbGetCurrentTpl () == TPL_CALLBACK);
-
-      gBS->RaiseTPL (OldTpl);
     }
   }
 
@@ -378,6 +639,7 @@ UsbSelectConfig (
   USB_INTERFACE       *UsbIf;
   EFI_STATUS          Status;
   UINT8               Index;
+  USB_ASSOCIATION     *UsbIa;
 
   //
   // Locate the active config, then set the device's pointer
@@ -393,7 +655,7 @@ UsbSelectConfig (
     }
   }
 
-  if (Index == DevDesc->Desc.NumConfigurations) {
+  if ((ConfigDesc == NULL) || (Index == DevDesc->Desc.NumConfigurations)) {
     return EFI_NOT_FOUND;
   }
 
@@ -405,6 +667,19 @@ UsbSelectConfig (
     ConfigValue,
     Device->Address
     ));
+
+  //
+  // Create interfaces for each USB interface association descriptor.
+  //
+  Device->NumOfAssociation = ConfigDesc->NumOfIads;
+
+  for (Index = 0; Index < ConfigDesc->NumOfIads; Index++) {
+    DEBUG ((DEBUG_INFO, "UsbSelectConfig: process IAD %d\n", Index));
+
+    UsbIa = UsbCreateAssociation (Device, Index, ConfigDesc->Iads[Index]);
+    ASSERT (Index < USB_MAX_ASSOCIATION);
+    Device->Associations[Index] = UsbIa;
+  }
 
   //
   // Create interfaces for each USB interface descriptor.
@@ -448,7 +723,53 @@ UsbSelectConfig (
 
   Device->NumOfInterface = Index;
 
+  //
+  // Connect association device drivers. Connection may fail if if device driver has been already
+  // started for any UsbIo that belongs to the association.
+  //
+  for (Index = 0; Index < Device->NumOfAssociation; Index++) {
+    Status                                 = gBS->ConnectController (Device->Associations[Index]->Handle, NULL, NULL, TRUE);
+    Device->Associations[Index]->IsManaged = (BOOLEAN) !EFI_ERROR (Status);
+
+    DEBUG ((DEBUG_INFO, "UsbSelectConfig: association driver connect: %r\n", Status));
+  }
+
   return EFI_SUCCESS;
+}
+
+/**
+  Disconnect USB controller at TPL_CALLBACK
+
+  This function is called in both UsbIoControlTransfer and
+  the timer callback in hub enumeration. So, at least it is
+  called at TPL_CALLBACK. Some driver sitting on USB has
+  twisted TPL used. It should be no problem for us to connect
+  or disconnect at CALLBACK.
+
+  @param  Handle        Controller handle to be disconnected
+
+**/
+EFI_STATUS
+UsbDisconnectController (
+  EFI_HANDLE  Handle
+  )
+{
+  EFI_TPL     OldTpl;
+  EFI_STATUS  Status;
+
+  OldTpl = UsbGetCurrentTpl ();
+  DEBUG ((DEBUG_INFO, "UsbDisconnectDriver: old TPL is %d, %p\n", (UINT32)OldTpl, Handle));
+
+  gBS->RestoreTPL (TPL_CALLBACK);
+
+  Status = gBS->DisconnectController (Handle, NULL, NULL);
+
+  DEBUG ((DEBUG_INFO, "UsbDisconnectDriver: TPL after disconnect is %d, %d\n", (UINT32)UsbGetCurrentTpl (), Status));
+  ASSERT (UsbGetCurrentTpl () == TPL_CALLBACK);
+
+  gBS->RaiseTPL (OldTpl);
+
+  return Status;
 }
 
 /**
@@ -462,7 +783,6 @@ UsbDisconnectDriver (
   IN USB_INTERFACE  *UsbIf
   )
 {
-  EFI_TPL     OldTpl;
   EFI_STATUS  Status;
 
   //
@@ -473,27 +793,11 @@ UsbDisconnectDriver (
   if (UsbIf->IsHub) {
     Status = UsbIf->HubApi->Release (UsbIf);
   } else if (UsbIf->IsManaged) {
-    //
-    // This function is called in both UsbIoControlTransfer and
-    // the timer callback in hub enumeration. So, at least it is
-    // called at TPL_CALLBACK. Some driver sitting on USB has
-    // twisted TPL used. It should be no problem for us to connect
-    // or disconnect at CALLBACK.
-    //
-    OldTpl = UsbGetCurrentTpl ();
-    DEBUG ((DEBUG_INFO, "UsbDisconnectDriver: old TPL is %d, %p\n", (UINT32)OldTpl, UsbIf->Handle));
+    Status = UsbDisconnectController (UsbIf->Handle);
 
-    gBS->RestoreTPL (TPL_CALLBACK);
-
-    Status = gBS->DisconnectController (UsbIf->Handle, NULL, NULL);
     if (!EFI_ERROR (Status)) {
       UsbIf->IsManaged = FALSE;
     }
-
-    DEBUG ((DEBUG_INFO, "UsbDisconnectDriver: TPL after disconnect is %d, %d\n", (UINT32)UsbGetCurrentTpl (), Status));
-    ASSERT (UsbGetCurrentTpl () == TPL_CALLBACK);
-
-    gBS->RaiseTPL (OldTpl);
   }
 
   return Status;
@@ -510,10 +814,11 @@ UsbRemoveConfig (
   IN USB_DEVICE  *Device
   )
 {
-  USB_INTERFACE  *UsbIf;
-  UINTN          Index;
-  EFI_STATUS     Status;
-  EFI_STATUS     ReturnStatus;
+  USB_INTERFACE    *UsbIf;
+  USB_ASSOCIATION  *UsbIa;
+  UINTN            Index;
+  EFI_STATUS       Status;
+  EFI_STATUS       ReturnStatus;
 
   //
   // Remove each interface of the device
@@ -543,6 +848,35 @@ UsbRemoveConfig (
   }
 
   Device->ActiveConfig = NULL;
+
+  if (EFI_ERROR (ReturnStatus)) {
+    return ReturnStatus;
+  }
+
+  // ReturnStatus is EFI_SUCCESS
+
+  //
+  // Remove each interface association
+  //
+  for (Index = 0; Index < Device->NumOfAssociation; Index++) {
+    UsbIa = Device->Associations[Index];
+
+    Status = UsbDisconnectController (UsbIa->Handle);
+    if (!EFI_ERROR (Status)) {
+      Status = UsbFreeAssociation (UsbIa);
+      DEBUG ((DEBUG_INFO, "UsbRemoveConfig: free association: %r\n", Status));
+      if (EFI_ERROR (Status)) {
+        UsbConnectController (UsbIa->Handle);
+      }
+    }
+
+    if (!EFI_ERROR (Status)) {
+      Device->Associations[Index] = NULL;
+    } else {
+      ReturnStatus = Status;
+    }
+  }
+
   return ReturnStatus;
 }
 

--- a/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbIntfAssoc.c
+++ b/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbIntfAssoc.c
@@ -1,0 +1,153 @@
+/** @file
+
+  Usb Interface Association Protocol implementation.
+
+Copyright (c) 2025, American Megatrends International, LLC. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "UsbBus.h"
+
+/**
+  Get the interface from interface association.
+
+  @param[in]  UsbIa   A pointer to the interface association data.
+  @param[in]  InterfaceNumber Interface to look for inside the association.
+
+  @retval A pointer to the interface data
+  @retval NULL  Interface is not found in the association.
+
+**/
+USB_INTERFACE_DESC *
+UsbAssocFindInterface (
+  IN USB_ASSOCIATION  *UsbIa,
+  IN UINT8            InterfaceNumber
+  )
+{
+  UINT8  Index;
+  UINT8  Intrf;
+
+  Intrf = UsbIa->IaDesc->Desc.FirstInterface;
+  for (Index = 0; Index < UsbIa->IaDesc->Desc.InterfaceCount; Index++) {
+    if (InterfaceNumber == Intrf) {
+      return UsbIa->IaDesc->Interfaces[Index];
+    }
+
+    Intrf++;
+  }
+
+  DEBUG ((DEBUG_ERROR, "UsbAssocFindInterface: interface 0x%x does not belong to this association\n", InterfaceNumber));
+  return NULL;
+}
+
+/**
+  Get the USB Interface Association Descriptor from the current USB configuration.
+
+  @param[in] This              A pointer to the EDKII_USB_INTERFACE_ASSOCIATION_PROTOCOL instance.
+  @param[out] Descriptor       A pointer to the caller allocated USB Interface Association Descriptor.
+
+  @retval EFI_SUCCESS           The descriptor was retrieved successfully.
+  @retval EFI_INVALID_PARAMETER Descriptor is NULL.
+
+**/
+EFI_STATUS
+EFIAPI
+UsbIaGetAssociationDescriptor (
+  IN  EDKII_USB_INTERFACE_ASSOCIATION_PROTOCOL  *This,
+  OUT EFI_USB_INTERFACE_ASSOCIATION_DESCRIPTOR  *Descriptor
+  )
+{
+  USB_ASSOCIATION  *UsbIa;
+  EFI_TPL          OldTpl;
+  EFI_STATUS       Status;
+
+  OldTpl = gBS->RaiseTPL (USB_BUS_TPL);
+
+  Status = EFI_SUCCESS;
+
+  ASSERT (Descriptor != NULL);
+  if (Descriptor == NULL) {
+    Status = EFI_INVALID_PARAMETER;
+    goto ON_EXIT;
+  }
+
+  UsbIa = USB_ASSOCIATION_FROM_USBIA (This);
+  CopyMem (Descriptor, &(UsbIa->IaDesc->Desc), sizeof (EFI_USB_INTERFACE_ASSOCIATION_DESCRIPTOR));
+
+ON_EXIT:
+  gBS->RestoreTPL (OldTpl);
+
+  return Status;
+}
+
+/**
+  Retrieve the details of the requested interface that belongs to USB association.
+
+  @param[in] This              A pointer to the EDKII_USB_INTERFACE_ASSOCIATION_PROTOCOL instance.
+  @param[in] InterfaceNumber   Interface number.
+  @param[out] UsbIo            A pointer to the caller allocated UsbIo protocol.
+  @param[out] SettingsCount    A pointer to the caller allocated number of settings for this interface.
+
+  @retval EFI_SUCCESS           Output parameters were updated successfully.
+  @retval EFI_INVALID_PARAMETER UsbIo or SettuntsCount is NULL.
+  @retval EFI_NOT_FOUND         Interface does not belong to this interface association.
+
+**/
+EFI_STATUS
+EFIAPI
+UsbIaGetAssociateSettings (
+  IN  EDKII_USB_INTERFACE_ASSOCIATION_PROTOCOL  *This,
+  IN  UINT8                                     InterfaceNumber,
+  OUT EFI_USB_IO_PROTOCOL                       **UsbIo,
+  OUT UINTN                                     *SettingsCount
+  )
+{
+  USB_ASSOCIATION     *UsbIa;
+  EFI_TPL             OldTpl;
+  UINT8               Index;
+  EFI_STATUS          Status;
+  USB_DEVICE          *Device;
+  USB_INTERFACE_DESC  *IfDesc;
+
+  OldTpl = gBS->RaiseTPL (USB_BUS_TPL);
+
+  ASSERT ((UsbIo != NULL) && (SettingsCount != NULL));
+  if ((UsbIo == NULL) || (SettingsCount == NULL)) {
+    Status =  EFI_INVALID_PARAMETER;
+    goto  ON_EXIT;
+  }
+
+  UsbIa = USB_ASSOCIATION_FROM_USBIA (This);
+
+  IfDesc = UsbAssocFindInterface (UsbIa, InterfaceNumber);
+  if (IfDesc == NULL) {
+    Status = EFI_NOT_FOUND;
+    goto ON_EXIT;
+  }
+
+  *SettingsCount = IfDesc->NumOfSetting - 1;
+
+  //
+  // Find UsbIo protocol for this interface
+  //
+  Device = UsbIa->Device;
+  Status = EFI_NOT_FOUND;
+
+  for (Index = 0; Index < Device->NumOfInterface; Index++) {
+    if (Device->Interfaces[Index]->IfSetting->Desc.InterfaceNumber == InterfaceNumber) {
+      *UsbIo = &Device->Interfaces[Index]->UsbIo;
+      Status = EFI_SUCCESS;
+      break;
+    }
+  }
+
+ON_EXIT:
+  gBS->RestoreTPL (OldTpl);
+  return Status;
+}
+
+EDKII_USB_INTERFACE_ASSOCIATION_PROTOCOL  mUsbIaProtocol = {
+  UsbIaGetAssociationDescriptor,
+  UsbIaGetAssociateSettings
+};

--- a/MdeModulePkg/Include/Protocol/UsbAssociationIo.h
+++ b/MdeModulePkg/Include/Protocol/UsbAssociationIo.h
@@ -1,0 +1,81 @@
+/** @file
+  EFI Usb Interface Association protocol.
+
+  This protocol is used by USB drivers, running in the EFI boot services
+  environment to access USB devices that implement their configurations
+  using interface association: USB cameras, USB audio devices, USB modems, etc.
+
+  Copyright (c) 2025, American Megatrends International LLC. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef __USB_ASSOCIATION_IO_H__
+#define __USB_ASSOCIATION_IO_H__
+
+#include <IndustryStandard/Usb.h>
+#include <Protocol/UsbIo.h>
+
+typedef USB_INTERFACE_ASSOCIATION_DESCRIPTOR EFI_USB_INTERFACE_ASSOCIATION_DESCRIPTOR;
+
+//
+// Global ID for the USB IAD Protocol
+//
+#define EDKII_USB_INTERFACE_ASSOCIATION_PROTOCOL_GUID \
+  { \
+    0xf4279fb1, 0xef1e, 0x4346, { 0xab, 0x32, 0x3f, 0xe3, 0x86, 0xee, 0xb4, 0x52 } \
+  }
+
+typedef struct _EDKII_USB_INTERFACE_ASSOCIATION_PROTOCOL EDKII_USB_INTERFACE_ASSOCIATION_PROTOCOL;
+
+/**
+  Get the USB Interface Association Descriptor from the current USB configuration.
+
+  @param[in]  This              A pointer to the EFI_USB_IA_PROTOCOL instance.
+  @param[out]  Descriptor       A pointer to the caller allocated USB Interface Association Descriptor.
+
+  @retval EFI_SUCCESS           The descriptor was retrieved successfully.
+  @retval EFI_INVALID_PARAMETER Descriptor is NULL.
+
+**/
+typedef
+EFI_STATUS
+(EFIAPI *EDKII_USB_IA_GET_ASSOCIATION_DESCRIPTOR)(
+  IN  EDKII_USB_INTERFACE_ASSOCIATION_PROTOCOL  *This,
+  OUT EFI_USB_INTERFACE_ASSOCIATION_DESCRIPTOR  *Descriptor
+  );
+
+/**
+  Retrieve the details of the requested interface that belongs to USB association.
+
+  @param[in] This              A pointer to the EFI_USB_IA_PROTOCOL instance.
+  @param[in] InterfaceNumber   Interface number.
+  @param[out] UsbIo            A pointer to the caller allocated UsbIo protocol.
+  @param[out] SettingsCount    A pointer to the caller allocated number of settings for this interface.
+
+  @retval EFI_SUCCESS           Output parameters were updated successfully.
+  @retval EFI_INVALID_PARAMETER UsbIo or SettuntsCount is NULL.
+  @retval EFI_NOT_FOUND         Interface does not belong to this interface association.
+
+**/
+typedef
+EFI_STATUS
+(EFIAPI *EDKII_USB_IA_GET_ASSOCIATE_SETTINGS)(
+  IN  EDKII_USB_INTERFACE_ASSOCIATION_PROTOCOL  *This,
+  IN  UINT8                                     InterfaceNumber,
+  OUT EFI_USB_IO_PROTOCOL                       **UsbIo,
+  OUT UINTN                                     *SettingsCount
+  );
+
+/**
+  USB interface association protocol functions.
+
+**/
+struct _EDKII_USB_INTERFACE_ASSOCIATION_PROTOCOL {
+  EDKII_USB_IA_GET_ASSOCIATION_DESCRIPTOR    UsbIaGetAssociationDescriptor;
+  EDKII_USB_IA_GET_ASSOCIATE_SETTINGS        UsbIaGetAssociateSettings;
+};
+
+extern EFI_GUID  gEdkiiUsbInterfaceAssociationProtocolGuid;
+
+#endif

--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -10,6 +10,7 @@
 # Copyright (c) 2017, AMD Incorporated. All rights reserved.<BR>
 # Copyright (c) Microsoft Corporation.<BR>
 # Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.<BR>
+# Copyright (C) 2025 American Megatrends International, LLC. All rights reserved.<BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -734,6 +735,9 @@
 
   ## Include/Protocol/PlatformBootManager.h
   gEdkiiPlatformBootManagerProtocolGuid = { 0xaa17add4, 0x756c, 0x460d, { 0x94, 0xb8, 0x43, 0x88, 0xd7, 0xfb, 0x3e, 0x59 } }
+
+  ## Include/Protocol/UsbAssociationIo.h
+  gEdkiiUsbInterfaceAssociationProtocolGuid = { 0xf4279fb1, 0xef1e, 0x4346, { 0xab, 0x32, 0x3f, 0xe3, 0x86, 0xee, 0xb4, 0x52 }}
 
 #
 # [Error.gEfiMdeModulePkgTokenSpaceGuid]


### PR DESCRIPTION
# Description
USB Interface Association is a group of UsbIo that implement a USB function. UEFI device driver manages multiple UsbIo instances. Examples of such devices are: USB camera, USB serial, USB network, etc.

Current approach for supporting these devices is to respond on UsbIo installation and analyze if the current UsbIo belongs to the USB association. This algorithm is based on assumptions that may not be correct for different device configurations. Having USB association protocol that reports its associates (UsbIo) simplifies the USB device driver.

For the USB configurations that implement USB association the UsbDxeBus driver:
- creates USB association device
- installs device path
- installs USB association IO protocol

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested
<_Describe the test(s) that were run to verify the changes._>

## Integration Instructions
<_Describe how these changes should be integrated. Use N/A if nothing is required._>
