### PR TITLE
IntelFsp2WrapperPkg: Save FspHobListPtr Right After FspMemoryInit Exits

### DIFF
--- a/IntelFsp2WrapperPkg/FspmWrapperPeim/FspmWrapperPeim.c
+++ b/IntelFsp2WrapperPkg/FspmWrapperPeim/FspmWrapperPeim.c
@@ -125,6 +125,17 @@ PeiFspMemoryInit (
   Status                = CallFspMemoryInit (FspmUpdDataPtr, &FspHobListPtr);
 
   //
+  // FspHobList is not complete at this moment.
+  // Save FspHobList pointer to hob, so that it can be got later
+  //
+  HobData = BuildGuidHob (
+              &gFspHobGuid,
+              sizeof (VOID *)
+              );
+  ASSERT (HobData != NULL);
+  CopyMem (HobData, &FspHobListPtr, sizeof (FspHobListPtr));
+
+  //
   // Reset the system if FSP API returned FSP_STATUS_RESET_REQUIRED status
   //
   if ((Status >= FSP_STATUS_RESET_REQUIRED_COLD) && (Status <= FSP_STATUS_RESET_REQUIRED_8)) {
@@ -166,17 +177,6 @@ PeiFspMemoryInit (
   ASSERT (FspHobListPtr != NULL);
 
   PostFspmHobProcess (FspHobListPtr);
-
-  //
-  // FspHobList is not complete at this moment.
-  // Save FspHobList pointer to hob, so that it can be got later
-  //
-  HobData = BuildGuidHob (
-              &gFspHobGuid,
-              sizeof (VOID *)
-              );
-  ASSERT (HobData != NULL);
-  CopyMem (HobData, &FspHobListPtr, sizeof (FspHobListPtr));
 
   return Status;
 }

--- a/IntelFsp2WrapperPkg/Library/FspWrapperMultiPhaseProcessLib/FspWrapperMultiPhaseProcessLib.inf
+++ b/IntelFsp2WrapperPkg/Library/FspWrapperMultiPhaseProcessLib/FspWrapperMultiPhaseProcessLib.inf
@@ -38,10 +38,15 @@
   FspWrapperPlatformLib
   PeiServicesLib
   FspWrapperPlatformMultiPhaseLib
+  BaseMemoryLib
+  HobLib
 
 [Ppis]
   gEfiPeiReadOnlyVariable2PpiGuid
   gEdkiiPeiVariablePpiGuid
+
+[Guids]
+  gFspHobGuid       ## CONSUMES
 
 [Pcd]
   gIntelFsp2WrapperTokenSpaceGuid.PcdFspmBaseAddress       ## CONSUMES


### PR DESCRIPTION
# Description

Save FspHobList pointer to HOB right after FspMemoryInit exits so that FspHobList pointer is available when performing platform related reset in CallFspWrapperResetSystem(). Some platforms may consume FSP HOBs prior to performing platform related reset.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

This PR was tested with FSP-M, FSP-S, FSP multi-phase memory initialization and FSP multi-phase silicon initialization enabled. And it's confirmed in the test that the bootloader can successfully get and save the FspHobList pointer in different phases.

## Integration Instructions
N/A
