### PR TITLE
RedfishPkg/HiiUtilityLib: Fix incorrect type assignment

### DIFF
--- a/OvmfPkg/RUNTIME_CONFIG.md
+++ b/OvmfPkg/RUNTIME_CONFIG.md
@@ -2,7 +2,7 @@
 
 Some aspects of OVMF can be configured from the host, mostly by adding
 firmware config files using the qemu command line option `-fw_cfg`.
-The official namespace prefix for edk2 is `opt/org.tianocore/` which
+The official namespace prefix for edk2 is `opt/org.tianocode/` which
 is used by most options.  Some options are elsewhere for historical
 reasons.
 
@@ -113,16 +113,6 @@ a workaround for a bug in shim version 15.6.  Usage:
 
 ```
 qemu-system-x86_64 -fw_cfg name=opt/org.tianocore/UninstallMemAttrProtocol,string=yes
-```
-
-
-## Shell: opt/org.tianocore/EFIShellSupport
-
-This enables/disables the EFI shell.
-Default: enabled.  Usage:
-
-```
-qemu-system-x86_64 -fw_cfg name=opt/org.tianocore/EFIShellSupport,string=no
 ```
 
 

--- a/OvmfPkg/RUNTIME_CONFIG.md
+++ b/OvmfPkg/RUNTIME_CONFIG.md
@@ -2,7 +2,7 @@
 
 Some aspects of OVMF can be configured from the host, mostly by adding
 firmware config files using the qemu command line option `-fw_cfg`.
-The official namespace prefix for edk2 is `opt/org.tianocode/` which
+The official namespace prefix for edk2 is `opt/org.tianocore/` which
 is used by most options.  Some options are elsewhere for historical
 reasons.
 
@@ -113,6 +113,16 @@ a workaround for a bug in shim version 15.6.  Usage:
 
 ```
 qemu-system-x86_64 -fw_cfg name=opt/org.tianocore/UninstallMemAttrProtocol,string=yes
+```
+
+
+## Shell: opt/org.tianocore/EFIShellSupport
+
+This enables/disables the EFI shell.
+Default: enabled.  Usage:
+
+```
+qemu-system-x86_64 -fw_cfg name=opt/org.tianocore/EFIShellSupport,string=no
 ```
 
 

--- a/RedfishPkg/Library/HiiUtilityLib/HiiUtilityInternal.c
+++ b/RedfishPkg/Library/HiiUtilityLib/HiiUtilityInternal.c
@@ -4125,7 +4125,12 @@ EvaluateHiiExpression (
           goto Done;
         }
 
-        Value = (EFI_HII_VALUE *)&Question->Value;
+        Status = HiiStatementValueToHiiValue (&Question->Value, Value);
+        if (EFI_ERROR (Status)) {
+          ReleaseHiiValue (Value);
+          Value->Type = EFI_IFR_TYPE_UNDEFINED;
+        }
+
         break;
 
       case EFI_IFR_SECURITY_OP:
@@ -4334,7 +4339,11 @@ EvaluateHiiExpression (
           //
           // push the questions' value on to the expression stack
           //
-          Value = (EFI_HII_VALUE *)&Question->Value;
+          Status = HiiStatementValueToHiiValue (&Question->Value, Value);
+          if (EFI_ERROR (Status)) {
+            ReleaseHiiValue (Value);
+            Value->Type = EFI_IFR_TYPE_UNDEFINED;
+          }
         }
 
         break;
@@ -4461,7 +4470,12 @@ EvaluateHiiExpression (
           break;
         }
 
-        Value = (EFI_HII_VALUE *)&Question->Value;
+        Status = HiiStatementValueToHiiValue (&Question->Value, Value);
+        if (EFI_ERROR (Status)) {
+          ReleaseHiiValue (Value);
+          Value->Type = EFI_IFR_TYPE_UNDEFINED;
+        }
+
         break;
 
       case EFI_IFR_STRING_REF2_OP:


### PR DESCRIPTION
Fix incorrect type assignment in EvaluateHiiExpression function.
Replaced direct assignment of 'Value = (EFI_HII_VALUE *)&Question->Value' with 
the correct usage of  HiiStatementValueToHiiValue function. 
This resolves the issue where EFI_HII_VALUE and HII_STATEMENT_VALUE types are incompatible,
ensuring proper handling of Question->Value.