### PR TITLE
UefiPayloadPkg: Set PixelsPerScanLine property in GraphicInfo HOB

### DIFF
--- a/UefiPayloadPkg/Library/FdtParserLib/FdtParserLib.c
+++ b/UefiPayloadPkg/Library/FdtParserLib/FdtParserLib.c
@@ -378,6 +378,9 @@ ParseFrameBuffer (
       GmaStr++;
       DEBUG ((DEBUG_INFO, "  display (%s)", GmaStr));
     }
+
+    // In most case, PixelsPerScanLine is identical to HorizontalResolution
+    GraphicsInfo->GraphicsMode.PixelsPerScanLine = GraphicsInfo->GraphicsMode.HorizontalResolution;
   }
 
   return GmaStr;


### PR DESCRIPTION
# Description

PixelsPerScanLine is required in some UEFI capable OS distribution. To align with simple-framebuffer definition in kernel Documentation: devicetree/bindings/display/simple-framebuffer.txt, no property node will be introduced for PixelsPerScanLine.

Set value of PixelsPerScanLine to HorizontalResolution, as they are identical in most cases.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - N/A
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - N/A
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - N/A

## How This Was Tested
Tested with ESXi image

## Integration Instructions
N/A