### PR TITLE
UefiPayloadPkg: Align base address for ACPI region

### DIFF
--- a/UefiPayloadPkg/Library/FdtParserLib/FdtParserLib.c
+++ b/UefiPayloadPkg/Library/FdtParserLib/FdtParserLib.c
@@ -60,6 +60,8 @@ typedef enum {
                                        EFI_PCI_IO_ATTRIBUTE_ISA_IO | \
                                        EFI_PCI_IO_ATTRIBUTE_ISA_MOTHERBOARD_IO)
 
+#define UPL_ALIGN_DOWN(Addr)  ((UINT64)(Addr) & ~(UINT64)(EFI_PAGE_SIZE - 1))
+
 extern VOID                         *mHobList;
 UNIVERSAL_PAYLOAD_PCI_ROOT_BRIDGES  *mPciRootBridgeInfo = NULL;
 INT32                               mNode[0x500]        = { 0 };
@@ -289,7 +291,12 @@ ParseReservedMemory (
         BuildMemoryAllocationHob (StartAddress, NumberOfBytes, EfiACPIMemoryNVS);
       } else if (AsciiStrnCmp (TempStr, "acpi", AsciiStrLen ("acpi")) == 0) {
         DEBUG ((DEBUG_INFO, "  acpi, StartAddress:%x, NumberOfBytes:%x\n", StartAddress, NumberOfBytes));
-        BuildMemoryAllocationHob (StartAddress, NumberOfBytes, EfiBootServicesData);
+
+        BuildMemoryAllocationHob (
+          UPL_ALIGN_DOWN (StartAddress),
+          ALIGN_VALUE (NumberOfBytes, EFI_PAGE_SIZE),
+          EfiBootServicesData
+          );
         PlatformAcpiTable = BuildGuidHob (&gUniversalPayloadAcpiTableGuid, sizeof (UNIVERSAL_PAYLOAD_ACPI_TABLE));
         if (PlatformAcpiTable != NULL) {
           DEBUG ((DEBUG_INFO, " build gUniversalPayloadAcpiTableGuid , NumberOfBytes:%x\n", NumberOfBytes));


### PR DESCRIPTION
# Description
In platform which support ACPI 2.0 only, the base address of ACPI region is not page aligned. This unalinged base address leads to failure at BuildMemoryAllocationHob when parsing ACPI node in FdtParserLib, before building gUniversalPayloadAcpiTableGuid GUID HOB.

Align base address of ACPI region down to EFI_PAGE_SIZE to make sure base address always aligned.

FYI. These is log snippet read from Bare Metal hardware platform which supports ACPI 2.0:
efi: SMBIOS 3.0=0xf7e90000 ACPI 2.0=0xf472f018


- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - N/A
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - N/A
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - N/A

## How This Was Tested

<_Describe the test(s) that were run to verify the changes._>

## Validated at both QEMU and Bare Metal platform which support ACPI 2.0 only.

<_Describe how these changes should be integrated. Use N/A if nothing is required._>
