### PR TITLE
BaseTools: Skip directories with code extensions in the name

### DIFF
--- a/BaseTools/Plugin/DebugMacroCheck/DebugMacroCheck.py
+++ b/BaseTools/Plugin/DebugMacroCheck/DebugMacroCheck.py
@@ -429,7 +429,7 @@ def check_macros_in_directory(directory: PurePath,
 
         files = []
         for file in root_directory.rglob('*'):
-            if file.suffix in extensions:
+            if file.suffix in extensions and not file.is_dir:
                 files.append(Path(file))
 
             # Give an indicator progress is being made


### PR DESCRIPTION
# Description

Currently openssl has an Open Quantum Safe provider submodule with directories like `oqs-provider/oqs-template/oqsprov/oqsprov.c` or `oqs-provider/oqs-template/oqsprov/oqsprov/oqsprov_capabilities.c` that are used as templates, but DebugMacroCheck tries to read them as a file when recursively traversing the subdirectories.

Fail message:

```
  File "/usr/lib/python3.10/pathlib.py", line 1119, in open
    return self._accessor.open(self, mode, buffering, encoding, errors,
  IsADirectoryError: [Errno 21] Is a directory: '/CryptoPkg/Library/OpensslLib/openssl/oqs-provider/oqs-template/oqsprov/oqsprov.c'
```

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

```
git submodule update --init --recursive

stuart_ci_build -c .pytool/CISettings.py -v -p CryptoPkg,EmbeddedPkg,FatPkg,MdeModulePkg,MdePkg,NetworkPkg,PcAtChipsetPkg,SecurityPkg,ShellPkg,UefiCpuPkg,OvmfPkg -a $ARCH TOOL_CHAIN_TAG=$TOOL_CHAIN
```

## Integration Instructions

N/A
