### PR TITLE
NetworkPkg/UefiPxeBcDxe: Bugfix for pxe driver

### DIFF
--- a/NetworkPkg/UefiPxeBcDxe/PxeBcDriver.c
+++ b/NetworkPkg/UefiPxeBcDxe/PxeBcDriver.c
@@ -246,7 +246,9 @@ PxeBcDestroyIp4Children (
            &Private->PxeBc,
            NULL
            );
-    FreePool (Private->Ip4Nic->DevicePath);
+    if (Private->Ip4Nic->DevicePath != NULL) {
+      FreePool (Private->Ip4Nic->DevicePath);
+    }
 
     if (Private->Snp != NULL) {
       //
@@ -407,7 +409,9 @@ PxeBcDestroyIp6Children (
            &Private->PxeBc,
            NULL
            );
-    FreePool (Private->Ip6Nic->DevicePath);
+    if (Private->Ip6Nic->DevicePath != NULL) {
+      FreePool (Private->Ip6Nic->DevicePath);
+    }
 
     if (Private->Snp != NULL) {
       //


### PR DESCRIPTION
Ensure the poniter is not null before free it

# Description


During stress testing of PXE boot, the following message occasionally appeared:  
```
ASSERT_EFI_ERROR (Status = Invalid Parameter)  
ASSERT [UefiPxeBcDxe] /home/Bill.Li/code/build-platform/corsica/uefi/edk2/MdePkg/Library/UefiMemoryAllocationLib/MemoryAllocationLib.c(813): !EFI_ERROR (Status)
```
After debugging, I found that the pointer `Ip4nic->DevicePath` was null when being freed.


## How This Was Tested


Perform PXE boot testing using Qemu and VirtioNet NIC.
## Integration Instructions

N/A
