### PR TITLE
OvmfPkg/BaseMemEncryptTdxLib: fix variable uninitialized error

### DIFF
--- a/OvmfPkg/Library/BaseMemEncryptTdxLib/MemoryEncryption.c
+++ b/OvmfPkg/Library/BaseMemEncryptTdxLib/MemoryEncryption.c
@@ -586,6 +586,8 @@ SetOrClearSharedBit (
     return EFI_DEVICE_ERROR;
   }
 
+  Status = EFI_SUCCESS;
+
   //
   // If changing shared to private, must accept-page again
   //


### PR DESCRIPTION
# Description

While compiling the project, I was getting the error bellow. Whenever Mode wasn't ClearSharedBit, the Status variable was uninitialized but being used by the DEBUG call. This patch initializes Status with EFI_SUCCESS to address the problem.

```console
./OvmfPkg/Library/BaseMemEncryptTdxLib/MemoryEncryption.c:592:7: error: variable 'Status' is used uninitialized whenever 'if' condition is false [-Werror,-Wsometimes-uninitialized]
  if (Mode == ClearSharedBit) {
      ^~~~~~~~~~~~~~~~~~~~~~
./OvmfPkg/Library/BaseMemEncryptTdxLib/MemoryEncryption.c:616:5: note: uninitialized use occurs here
    Status
    ^~~~~~
./MdePkg/Include/Library/DebugLib.h:425:24: note: expanded from macro 'DEBUG'
      _DEBUGLIB_DEBUG (Expression);       \
                       ^~~~~~~~~~
./MdePkg/Include/Library/DebugLib.h:378:49: note: expanded from macro '_DEBUGLIB_DEBUG'
#define _DEBUGLIB_DEBUG(Expression)  DebugPrint Expression
                                                ^~~~~~~~~~
./OvmfPkg/Library/BaseMemEncryptTdxLib/MemoryEncryption.c:592:3: note: remove the 'if' if its condition is always true
  if (Mode == ClearSharedBit) {
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
./OvmfPkg/Library/BaseMemEncryptTdxLib/MemoryEncryption.c:529:39: note: initialize the variable 'Status' to silence this warning
  EFI_STATUS                    Status;
                                      ^
                                       = 0
```

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Compiled the project again.

## Integration Instructions

N/A
