### PR TITLE
OvmfPkg/VirtioSerialDxe: respond CONSOLE_PORT with PORT_OPEN

### DIFF
--- a/OvmfPkg/VirtioSerialDxe/VirtioSerial.c
+++ b/OvmfPkg/VirtioSerialDxe/VirtioSerial.c
@@ -165,6 +165,7 @@ VirtioSerialRxControl (
         if (Control.Id < MAX_PORTS) {
           VirtioSerialPortSetConsole (Dev, Control.Id);
           Dev->NumConsoles++;
+          VirtioSerialPortSetDeviceOpen (Dev, Control.Id, 1);
         }
 
         break;


### PR DESCRIPTION
# Description

The VirtIO spec states the following (from https://docs.oasis-open.org/virtio/virtio/v1.3/virtio-v1.3.html#x1-3330002):

> Upon receipt of a VIRTIO_CONSOLE_CONSOLE_PORT message, the driver SHOULD treat the port in a manner suitable for text console access and MUST respond with a VIRTIO_CONSOLE_PORT_OPEN message, which MUST have value set to 1

The current driver implementation, however, does not comply with that and only send PORT_OPEN messages when receiving PORT_OPEN messages. This causes a problem in platforms like Apple's Virtualization Framework, where PORT_OPEN messages are not sent back to the driver after CONSOLE_PORT messages, a behaviour that is compliant with the specification.

This patch addresses this issue by always responding CONSOLE_PORT messages with PORT_OPEN messages.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

The driver was compiled and tested on QEMU and Virtualization Framework VMs.

## Integration Instructions

N/A
