### PR TITLE
FatPkg: CI: Add PrEval entry

### DIFF
--- a/FatPkg/FatPkg.ci.yaml
+++ b/FatPkg/FatPkg.ci.yaml
@@ -6,6 +6,9 @@
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 ##
 {
+    "PrEval": {
+        "DscPath": "FatPkg.dsc",
+    },
     "LicenseCheck": {
         "IgnoreFiles": []
     },
@@ -60,7 +63,7 @@
             "FFFFFFFFL",
             "CDVOL",
             "DMDEPKG",
-            "lba's"
+            "lba's",
         ]
     }
 }


### PR DESCRIPTION


# Description

Adds a PrEval entry to the package's ci.yaml file which is used to verify if the package uses a particular library instance when that library instance file (INF) is updated.

When a library instance file (INF) is updated, PrEval will review each package's DSC as described in the ci.yaml file to determine if the package uses said library instance. If the package does use the library instance, it will be built and tested to ensure the package is not broken from the change.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested
Local CI.

## Integration Instructions
N/A