### PR TITLE
MdePkg/DebugLib: Add null pointer check to CR macro

### DIFF
--- a/MdePkg/Include/Library/DebugLib.h
+++ b/MdePkg/Include/Library/DebugLib.h
@@ -657,11 +657,12 @@ UnitTestDebugAssert (
 **/
 #if !defined (MDEPKG_NDEBUG)
 #define CR(Record, TYPE, Field, TestSignature)                                              \
+    ((Record == NULL) ? (TYPE *) (_ASSERT (CR has Null Pointer), Record) :                    \
     (DebugAssertEnabled () && (BASE_CR (Record, TYPE, Field)->Signature != TestSignature)) ?  \
     (TYPE *) (_ASSERT (CR has Bad Signature), Record) :                                       \
     (BASE_CR (Record, TYPE, Field)->Signature != TestSignature) ?                             \
     NULL :                                                                                    \
-    BASE_CR (Record, TYPE, Field)
+    BASE_CR (Record, TYPE, Field))
 #else
 #define CR(Record, TYPE, Field, TestSignature)                                              \
     (BASE_CR (Record, TYPE, Field)->Signature != TestSignature) ?                           \


### PR DESCRIPTION
- Added a null pointer check in the CR macro.
- If Record is NULL, an assertion is triggered.
- This change improves the CR by preventing dereferencing of null pointers.

REF: https://github.com/tianocore/edk2/issues/10510

# Description

<_Include a description of the change and why this change was made._>

<_For each item, place an "x" in between `[` and `]` if true. Example: `[x]` (you can also check items in GitHub UI)_>

<_Create the PR as a Draft PR if it is only created to run CI checks._>

<_Delete lines in \<\> tags before creating the PR._>

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

<_Describe the test(s) that were run to verify the changes._>

## Integration Instructions

<_Describe how these changes should be integrated. Use N/A if nothing is required._>
