### PR TITLE
NetworkPkg/IScsiDxe:Fix for out of bound memory access for bz4207 (CVE-2024-38805)

### DIFF
--- a/NetworkPkg/IScsiDxe/IScsiProto.c
+++ b/NetworkPkg/IScsiDxe/IScsiProto.c
@@ -1903,9 +1903,8 @@ IScsiBuildKeyValueList (
       Data++;
     }
 
-    if (*Data == '=') {
+    if ((Len > 0) && (*Data == '=')) {
       *Data = '\0';
-
       Data++;
       Len--;
     } else {
@@ -1917,8 +1916,17 @@ IScsiBuildKeyValueList (
 
     InsertTailList (ListHead, &KeyValuePair->List);
 
-    Data += AsciiStrLen (KeyValuePair->Value) + 1;
-    Len  -= (UINT32)AsciiStrLen (KeyValuePair->Value) + 1;
+    while ((Len > 0) && (*Data != '\0')) {
+      Len--;
+      Data++;
+    }
+
+    if ((Len > 0) && (*Data == '\0')) {
+      Data++;
+      Len--;
+    } else {
+      goto ON_ERROR;
+    }
   }
 
   return ListHead;


### PR DESCRIPTION
# Description

A malicious iSCSI target could reply to the iSCSI initiator with a malformed packet, causing out-of-bounds memory reads and writes. This most likely leads to a denial of service, as the write primitive should not be exploitable.

To Fix this,
In IScsiBuildKeyValueList, check if we have any data left (Len > 0) before advancing the Data pointer and reducing Len. Avoids wrapping Len. Also replace the AsciiStrLen() call with an open-coded loop which likewise checks Len to make sure we don't overrun the buffer.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

<_Describe the test(s) that were run to verify the changes._>

## Integration Instructions

<_Describe how these changes should be integrated. Use N/A if nothing is required._>
