### PR TITLE
MdeModulePkg/PciBusDxe: Pcd to ignore I/O Space BARs.

### DIFF
--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciBusDxe.inf
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciBusDxe.inf
@@ -99,6 +99,7 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdPciBridgeIoAlignmentProbe       ## CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdUnalignedPciIoEnable            ## CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdPciDegradeResourceForOptionRom  ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdPciIgnoreIoSpaceBars            ## CONSUMES
 
 [Pcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdSrIovSystemPageSize         ## SOMETIMES_CONSUMES

--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciEnumeratorSupport.c
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciEnumeratorSupport.c
@@ -1800,6 +1800,15 @@ PciParseBar (
     //
     // Device I/Os
     //
+    if (PcdGetBool (PcdPciIgnoreIoSpaceBars)) {
+      PciIoDevice->PciBar[BarIndex].BarType     = PciBarTypeUnknown;
+      PciIoDevice->PciBar[BarIndex].BaseAddress = 0;
+      PciIoDevice->PciBar[BarIndex].Length      = 0;
+      PciIoDevice->PciBar[BarIndex].Alignment   = 0;
+
+      return Offset + 4;
+    }
+
     Mask = 0xfffffffc;
 
     if ((Value & 0xFFFF0000) != 0) {

--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -991,6 +991,14 @@
   # @Prompt Enable process non-reset capsule image at runtime.
   gEfiMdeModulePkgTokenSpaceGuid.PcdSupportProcessCapsuleAtRuntime|FALSE|BOOLEAN|0x00010079
 
+  ## Indicates whether PCI I/O Space BARs should be ignored.
+  #  This PCD allows platforms that only support MMIO BARs and not I/O Space BARs to
+  #  ignore I/O Space requests.<BR><BR>
+  #   TRUE  - Ignore BARs requesting I/O Space.<BR>
+  #   FALSE - Do not ignore BARs requesting I/O Space.<BR>
+  # @Prompt Ignore I/O Space BARs
+  gEfiMdeModulePkgTokenSpaceGuid.PcdPciIgnoreIoSpaceBars|FALSE|BOOLEAN|0x0001007A
+
 [PcdsFeatureFlag.IA32, PcdsFeatureFlag.ARM, PcdsFeatureFlag.AARCH64, PcdsFeatureFlag.LOONGARCH64]
   gEfiMdeModulePkgTokenSpaceGuid.PcdPciDegradeResourceForOptionRom|FALSE|BOOLEAN|0x0001003a
 


### PR DESCRIPTION
# Description

PCIe enumeration fails if an endpoint requests I/O space BARs if the platform does not support I/O space. While I/O space is traditionally supported in x86_64, platforms using an Arm architecture may or may not support I/O space. In the case where I/O space is not supported, the platform needs a mechanism to decide whether to gracefully ignore I/O space BARs instead of PciBus bailing out during enumeration.

This change adds PcdPciIgnoreIoSpaceBars to allow the platform to specify that I/O space BARs should be ignored. Endpoints will not receive I/O resources, but they will continue to receive Memory BAR resources.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

ARM64 platform boot with a mix of PCIe endpoints that request and do not request I/O Space BARs

## Integration Instructions

N/A