### PR TITLE
MdeModulePkg: OvmfPkg: SecurityPkg: ShellPkg: fix [-Werror=maybe-uninitialized]

### DIFF
--- a/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressMediaSanitize.c
+++ b/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressMediaSanitize.c
@@ -360,6 +360,8 @@ NvmExpressMediaClear (
     return EFI_INVALID_PARAMETER;
   }
 
+  Status = EFI_SUCCESS;
+
   //
   // Per NIST 800-88r1, one or more pass of writes may be alteratively used.
   //

--- a/MdeModulePkg/Core/Dxe/Hand/Handle.c
+++ b/MdeModulePkg/Core/Dxe/Hand/Handle.c
@@ -1107,6 +1107,8 @@ CoreOpenProtocol (
     return EFI_INVALID_PARAMETER;
   }
 
+  Prot = NULL;
+
   //
   // Lock the protocol database
   //

--- a/MdeModulePkg/Core/Pei/Dispatcher/Dispatcher.c
+++ b/MdeModulePkg/Core/Pei/Dispatcher/Dispatcher.c
@@ -1564,6 +1564,11 @@ EvacuateTempRam (
   DEBUG ((DEBUG_VERBOSE, "Beginning evacuation of content in temporary RAM.\n"));
 
   //
+  // By default migrate all FVs and copy raw data
+  //
+  FvMigrationFlags = FLAGS_FV_RAW_DATA_COPY;
+
+  //
   // Migrate PPI Pointers of PEI_CORE from temporary memory to newly loaded PEI_CORE in permanent memory.
   //
   Status = PeiLocatePpi ((CONST EFI_PEI_SERVICES **)&Private->Ps, &gEfiPeiCoreFvLocationPpiGuid, 0, NULL, (VOID **)&PeiCoreFvLocationPpi);
@@ -1617,11 +1622,6 @@ EvacuateTempRam (
           //
           return EFI_SUCCESS;
         }
-
-        //
-        // Migrate all FVs and copy raw data
-        //
-        FvMigrationFlags = FLAGS_FV_RAW_DATA_COPY;
       } else {
         for (Index = 0; Index < MigrationInfo->ToMigrateFvCount; Index++) {
           ToMigrateFvInfo = ((TO_MIGRATE_FV_INFO *)(MigrationInfo + 1)) + Index;

--- a/OvmfPkg/Library/GenericQemuLoadImageLib/GenericQemuLoadImageLib.c
+++ b/OvmfPkg/Library/GenericQemuLoadImageLib/GenericQemuLoadImageLib.c
@@ -253,6 +253,7 @@ QemuLoadKernelImage (
     goto CloseRoot;
   }
 
+  CommandLine = NULL;
   if (CommandLineSize == 0) {
     KernelLoadedImage->LoadOptionsSize = 0;
   } else {

--- a/SecurityPkg/RandomNumberGenerator/RngDxe/ArmTrng.c
+++ b/SecurityPkg/RandomNumberGenerator/RngDxe/ArmTrng.c
@@ -44,6 +44,10 @@ GenerateEntropy (
   UINTN       Index;
   UINTN       MaxBits;
 
+  if ((Length == 0) || (Entropy == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
   ZeroMem (Entropy, Length);
 
   RequiredEntropyBits  = (Length << 3);
@@ -67,5 +71,5 @@ GenerateEntropy (
     Index                += (EntropyBits >> 3);
   } // while
 
-  return Status;
+  return EFI_SUCCESS;
 }

--- a/ShellPkg/Library/UefiShellDebug1CommandsLib/Dmem.c
+++ b/ShellPkg/Library/UefiShellDebug1CommandsLib/Dmem.c
@@ -192,6 +192,8 @@ GetImageExecutionInfo (
 
   ptr = (CHAR8 *)ExecInfoTablePtr + 1;
 
+  Status = EFI_NOT_FOUND;
+
   for (Image = 0; Image < *NumberOfImages; Image++, ptr += InfoPtr->InfoSize) {
     InfoPtr   = (EFI_IMAGE_EXECUTION_INFO *)ptr;
     ImagePath = (CHAR16 *)(InfoPtr + 1);
@@ -287,6 +289,7 @@ DisplayConformanceProfiles (
   UINTN                           Profile;
   EFI_CONFORMANCE_PROFILES_TABLE  *ConfProfTable;
 
+  Status      = EFI_SUCCESS;
   ShellStatus = SHELL_SUCCESS;
 
   if (Address != 0) {
@@ -571,19 +574,19 @@ ShellCommandRunDmem (
             HiiDatabaseExportBufferAddress,
             ConformanceProfileTableAddress
             );
-        }
 
-        if (ShellCommandLineGetFlag (Package, L"-verbose")) {
-          if (ShellStatus == SHELL_SUCCESS) {
-            ShellStatus = DisplayRtProperties (RtPropertiesTableAddress);
-          }
+          if (ShellCommandLineGetFlag (Package, L"-verbose")) {
+            if (ShellStatus == SHELL_SUCCESS) {
+              ShellStatus = DisplayRtProperties (RtPropertiesTableAddress);
+            }
 
-          if (ShellStatus == SHELL_SUCCESS) {
-            ShellStatus = DisplayImageExecutionEntries (ImageExecutionTableAddress);
-          }
+            if (ShellStatus == SHELL_SUCCESS) {
+              ShellStatus = DisplayImageExecutionEntries (ImageExecutionTableAddress);
+            }
 
-          if (ShellStatus == SHELL_SUCCESS) {
-            ShellStatus = DisplayConformanceProfiles (ConformanceProfileTableAddress);
+            if (ShellStatus == SHELL_SUCCESS) {
+              ShellStatus = DisplayConformanceProfiles (ConformanceProfileTableAddress);
+            }
           }
         }
       } else {


### PR DESCRIPTION
# Description

Sometimes I compile projects using old gcc (gcc-8.1.0)
This time I've tried to build ArmVirtPkg/ArmVirtQemu.dsc  and OvmfPkg/OvmfPkgIa{32,64}.dsc
and found a bunch of similar warnings preventing from complete project build.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

The changes look trivial. 

## Integration Instructions
N/A