### PR TITLE
CryptoPkg/BaseCryptLibMbedTls : Add strncpy() support to SecCryptLib

### DIFF
--- a/CryptoPkg/Library/BaseCryptLibMbedTls/SysCall/CrtWrapper.c
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/SysCall/CrtWrapper.c
@@ -47,6 +47,26 @@ strchr (
   return ScanMem8 (str, AsciiStrSize (str), (char)ch);
 }
 
+char *
+strncpy (
+  char        *strDest,
+  const char  *strSource,
+  size_t      count
+  )
+{
+  UINTN  DestMax = MAX_STRING_SIZE;
+
+  if (count < MAX_STRING_SIZE) {
+    DestMax = count + 1;
+  } else {
+    count = MAX_STRING_SIZE-1;
+  }
+
+  AsciiStrnCpyS (strDest, DestMax, strSource, (UINTN)count);
+
+  return strDest;
+}
+
 /**strcmp function. **/
 int
 strcmp (

--- a/CryptoPkg/Library/BaseCryptLibMbedTls/SysCall/DummyOpensslSupport.c
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/SysCall/DummyOpensslSupport.c
@@ -262,26 +262,6 @@ strcpy (
   return strDest;
 }
 
-char *
-strncpy (
-  char        *strDest,
-  const char  *strSource,
-  size_t      count
-  )
-{
-  UINTN  DestMax = MAX_STRING_SIZE;
-
-  if (count < MAX_STRING_SIZE) {
-    DestMax = count + 1;
-  } else {
-    count = MAX_STRING_SIZE-1;
-  }
-
-  AsciiStrnCpyS (strDest, DestMax, strSource, (UINTN)count);
-
-  return strDest;
-}
-
 //
 // -- Character Classification Routines --
 //


### PR DESCRIPTION
Move strncpy() from DummyOpensslSupport.c to CrtWrapper.c under SysCall folder

# Description

Move strncpy() from DummyOpensslSupport.c to CrtWrapper.c under SysCall folder

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior? No
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact? No
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests. Build test

## How This Was Tested

  Build test

## Integration Instructions

  N/A