### PR TITLE
ArmPkg: remove ArmGicAcknowledgeInterrupt function.

### DIFF
--- a/ArmPkg/Drivers/ArmGic/ArmGicLib.c
+++ b/ArmPkg/Drivers/ArmGic/ArmGicLib.c
@@ -154,55 +154,6 @@ ArmGicSendSgiTo (
     );
 }
 
-/*
- * Acknowledge and return the value of the Interrupt Acknowledge Register
- *
- * InterruptId is returned separately from the register value because in
- * the GICv2 the register value contains the CpuId and InterruptId while
- * in the GICv3 the register value is only the InterruptId.
- *
- * @param GicInterruptInterfaceBase   Base Address of the GIC CPU Interface
- * @param InterruptId                 InterruptId read from the Interrupt
- *                                    Acknowledge Register
- *
- * @retval value returned by the Interrupt Acknowledge Register
- *
- */
-UINTN
-EFIAPI
-ArmGicAcknowledgeInterrupt (
-  IN  UINTN  GicInterruptInterfaceBase,
-  OUT UINTN  *InterruptId
-  )
-{
-  UINTN                  Value;
-  UINTN                  IntId;
-  ARM_GIC_ARCH_REVISION  Revision;
-
-  ASSERT (InterruptId != NULL);
-  Revision = ArmGicGetSupportedArchRevision ();
-  if (Revision == ARM_GIC_ARCH_REVISION_2) {
-    Value = ArmGicV2AcknowledgeInterrupt (GicInterruptInterfaceBase);
-    IntId = Value & ARM_GIC_ICCIAR_ACKINTID;
-  } else if (Revision == ARM_GIC_ARCH_REVISION_3) {
-    Value = ArmGicV3AcknowledgeInterrupt ();
-    IntId = Value;
-  } else {
-    ASSERT_EFI_ERROR (EFI_UNSUPPORTED);
-    // Report Spurious interrupt which is what the above controllers would
-    // return if no interrupt was available
-    Value = 1023;
-  }
-
-  if (InterruptId != NULL) {
-    // InterruptId is required for the caller to know if a valid or spurious
-    // interrupt has been read
-    *InterruptId = IntId;
-  }
-
-  return Value;
-}
-
 VOID
 EFIAPI
 ArmGicEndOfInterrupt (

--- a/ArmPkg/Include/Library/ArmGicLib.h
+++ b/ArmPkg/Include/Library/ArmGicLib.h
@@ -172,27 +172,6 @@ ArmGicSendSgiTo (
   IN  UINT8  SgiId
   );
 
-/*
- * Acknowledge and return the value of the Interrupt Acknowledge Register
- *
- * InterruptId is returned separately from the register value because in
- * the GICv2 the register value contains the CpuId and InterruptId while
- * in the GICv3 the register value is only the InterruptId.
- *
- * @param GicInterruptInterfaceBase   Base Address of the GIC CPU Interface
- * @param InterruptId                 InterruptId read from the Interrupt
- *                                    Acknowledge Register
- *
- * @retval value returned by the Interrupt Acknowledge Register
- *
- */
-UINTN
-EFIAPI
-ArmGicAcknowledgeInterrupt (
-  IN  UINTN  GicInterruptInterfaceBase,
-  OUT UINTN  *InterruptId
-  );
-
 VOID
 EFIAPI
 ArmGicEndOfInterrupt (


### PR DESCRIPTION
A compiler warning was detected that 'IntId' could be used uninitialized in the `else` branch.
Since there are no consumers of this function, it was decided to remove this function completely.

This solution was suggested at https://github.com/tianocore/edk2/pull/10603#discussion_r1910202751

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

None

## Integration Instructions

N/A