### PR TITLE
CryptoPkg/BaseCryptLib: Fix mktime() coding style issue

### DIFF
--- a/CryptoPkg/Library/BaseCryptLib/SysCall/TimerWrapper.c
+++ b/CryptoPkg/Library/BaseCryptLib/SysCall/TimerWrapper.c
@@ -148,15 +148,15 @@ mktime (
   struct tm  *t
   )
 {
-  EFI_TIME  Time = {
-    .Year     = (UINT16)t->tm_year,
-    .Month    = (UINT8)t->tm_mon,
-    .Day      = (UINT8)t->tm_mday,
-    .Hour     = (UINT8)t->tm_hour,
-    .Minute   = (UINT8)t->tm_min,
-    .Second   = (UINT8)t->tm_sec,
-    .TimeZone = EFI_UNSPECIFIED_TIMEZONE,
-  };
+  EFI_TIME  Time;
+
+  Time.Year     = (UINT16)t->tm_year;
+  Time.Month    = (UINT8)t->tm_mon;
+  Time.Day      = (UINT8)t->tm_mday;
+  Time.Hour     = (UINT8)t->tm_hour;
+  Time.Minute   = (UINT8)t->tm_min;
+  Time.Second   = (UINT8)t->tm_sec;
+  Time.TimeZone = EFI_UNSPECIFIED_TIMEZONE;
 
   return CalculateTimeT (&Time);
 }


### PR DESCRIPTION
Move local variable init to C statements to follow coding standard and remove the use of field names in structure initialization to maximize compiler compatibility.

This issue was introduced by PR #6185

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Build breaks with VS2015 before this change.  Passes VS2015 build after this change.

## Integration Instructions

N/A