### PR TITLE
MdePkg/Include: Use _Static_assert for clang and GNUC

### DIFF
--- a/MdePkg/Include/Base.h
+++ b/MdePkg/Include/Base.h
@@ -800,12 +800,14 @@ typedef UINTN *BASE_LIST;
   @param  Message     Raised compiler diagnostic message when expression is false.
 
 **/
-#ifdef MDE_CPU_EBC
-#define STATIC_ASSERT(Expression, Message)
-#elif defined (_MSC_EXTENSIONS) || defined (__cplusplus)
+#if defined (__cplusplus)
+#define STATIC_ASSERT  static_assert
+#elif defined (__GNUC__) || defined (__clang__)
+#define STATIC_ASSERT  _Static_assert
+#elif defined (_MSC_EXTENSIONS)
 #define STATIC_ASSERT  static_assert
 #else
-#define STATIC_ASSERT  _Static_assert
+  #error STATIC_ASSERT() definiton not available
 #endif
 
 //


### PR DESCRIPTION
# Description

The clang compiler generates the following error

```error: use of 'static_assert' without inclusion of <assert.h>```

This is due to the use of the MSC Extension `static_assert`. Use `_Static_assert` instead for clang and GNUC compilers.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

EmulatorPkg CLANGDWARF builds under Linux can reproduce this error before this change, and are resolved after this change.

## Integration Instructions

N/A
