### PR TITLE
EmulatorPkg/Win/Host: Use safe function _vsnprintf_s()

### DIFF
--- a/EmulatorPkg/Win/Host/WinHost.c
+++ b/EmulatorPkg/Win/Host/WinHost.c
@@ -190,7 +190,7 @@ SecPrint (
 
   va_start (Marker, Format);
 
-  _vsnprintf (Buffer, sizeof (Buffer), Format, Marker);
+  _vsnprintf_s (Buffer, sizeof (Buffer), sizeof (Buffer) - 1, Format, Marker);
 
   va_end (Marker);
 


### PR DESCRIPTION
# Description

Update `SecPrint()` to use `_vsnprintf_s()` instead of `_vsnprintf()` that is a safe function and allows the defines `_CRT_SECURE_NO_WARNINGS` and `_CRT_SECURE_NO_DEPRECATE` to be removed from WinHost builds.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Build fails without `_CRT_SECURE_NO_WARNINGS` and `_CRT_SECURE_NO_DEPRECATE` defined before this change and passes without `_CRT_SECURE_NO_WARNINGS` and `_CRT_SECURE_NO_DEPRECATE` defined after this change.  No impact to EmulatorPkg boot or logs.

## Integration Instructions

N/A
