### PR TITLE
MdeModulePkg: Make noisy log DEBUG_VERBOSE

### DIFF
--- a/MdeModulePkg/Bus/Pci/PciSioSerialDxe/SerialIo.c
+++ b/MdeModulePkg/Bus/Pci/PciSioSerialDxe/SerialIo.c
@@ -140,9 +140,9 @@ VerifyUartParameters (
   }
 
   Percent = DivU64x32 (MultU64x32 (BaudRate, 100), ComputedBaudRate);
-  DEBUG ((DEBUG_INFO, "ClockRate = %d\n", ClockRate));
-  DEBUG ((DEBUG_INFO, "Divisor   = %ld\n", ComputedDivisor));
-  DEBUG ((DEBUG_INFO, "BaudRate/Actual (%ld/%d) = %d%%\n", BaudRate, ComputedBaudRate, Percent));
+  DEBUG ((DEBUG_VERBOSE, "ClockRate = %d\n", ClockRate));
+  DEBUG ((DEBUG_VERBOSE, "Divisor   = %ld\n", ComputedDivisor));
+  DEBUG ((DEBUG_VERBOSE, "BaudRate/Actual (%ld/%d) = %d%%\n", BaudRate, ComputedBaudRate, Percent));
 
   //
   // If the requested BaudRate is not supported:
@@ -188,9 +188,9 @@ VerifyUartParameters (
     return FALSE;
   }
 
-  DEBUG ((DEBUG_INFO, "ClockRate = %d\n", ClockRate));
-  DEBUG ((DEBUG_INFO, "Divisor   = %ld\n", ComputedDivisor));
-  DEBUG ((DEBUG_INFO, "BaudRate/Actual (%ld/%d) = %d%%\n", BaudRate, ComputedBaudRate, Percent));
+  DEBUG ((DEBUG_VERBOSE, "ClockRate = %d\n", ClockRate));
+  DEBUG ((DEBUG_VERBOSE, "Divisor   = %ld\n", ComputedDivisor));
+  DEBUG ((DEBUG_VERBOSE, "BaudRate/Actual (%ld/%d) = %d%%\n", BaudRate, ComputedBaudRate, Percent));
 
   if (ActualBaudRate != NULL) {
     *ActualBaudRate = ComputedBaudRate;


### PR DESCRIPTION
# Description

For bootup of VMs with multiple accelerators, these logging instructions flood the logs for a good 30 seconds.
Originally found by Gary Zibrat.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

Google internal testing confirms performance improvements.

## Integration Instructions

N/A
