### PR TITLE
CloudHv: Disable PcdFirstTimeWakeUpAPsBySipi

### DIFF
--- a/OvmfPkg/CloudHv/CloudHvX64.dsc
+++ b/OvmfPkg/CloudHv/CloudHvX64.dsc
@@ -577,6 +577,14 @@
 
   gEfiMdeModulePkgTokenSpaceGuid.PcdUse1GPageTable|TRUE
 
+  #
+  # PcdFirstTimeWakeUpAPsBySipi determines whether to employ
+  # SIPI instead of the INIT-SIPI-SIPI sequence during APs
+  # initialization. Deactivate this parameter to preserve
+  # the original execution of INIT-SIPI-SIPI.
+  #
+  gUefiCpuPkgTokenSpaceGuid.PcdFirstTimeWakeUpAPsBySipi|FALSE
+
 ################################################################################
 #
 # Pcd Dynamic Section - list of all EDK II PCD Entries defined by this Platform


### PR DESCRIPTION

# Description

Disable PcdFirstTimeWakeUpAPsBySipi to use INIT-SIPI-SIPI sequence to wakeup APs.

INIT-SIPI-SIPI sequence is not yet supported by mshv hypervisor. Don't use this sequence to wake up APs.


## How This Was Tested

I confirmed cloud-hypervisor was able to start Linux and Windows VMs with multiple vCPUs with this change.

## Integration Instructions

N/A