### PR TITLE
Add VS Code GitHub issues notebook

### DIFF
--- a/contrib/Issues.github-issues
+++ b/contrib/Issues.github-issues
@@ -1,0 +1,72 @@
+[
+  {
+    "kind": 1,
+    "language": "markdown",
+    "value": "# Tianocore GitHub Issue Dashboard\r\n\r\nThis notebook displays issues in [Tianocore](https://www.tianocore.org/) GitHub repositories."
+  },
+  {
+    "kind": 2,
+    "language": "github-issues",
+    "value": "// List of tianocore repos to include in results\r\n$repos=repo:tianocore/edk2 repo:tianocore/edk2-platforms repo:tianocore/containers repo:tianocore/edk2-non-osi repo:tianocore/edk2-test repo:tianocore/edk2-basetools repo:tianocore/edk2-libc repo:tianocore/edk2-pytool-library repo:tianocore/edk2-pytool-extensions repo:tianocore/edk2-edkrepo repo:tianocore/edk2-edkrepo-manifest"
+  },
+  {
+    "kind": 1,
+    "language": "markdown",
+    "value": "📬 All Open Issues"
+  },
+  {
+    "kind": 2,
+    "language": "github-issues",
+    "value": "$repos is:open is:issue archived:false"
+  },
+  {
+    "kind": 1,
+    "language": "markdown",
+    "value": "🔎 All Untriaged Issues"
+  },
+  {
+    "kind": 2,
+    "language": "github-issues",
+    "value": "$repos is:open is:issue archived:false label:state:needs-triage"
+  },
+  {
+    "kind": 1,
+    "language": "markdown",
+    "value": "❓ All Open Issues Without An Owner"
+  },
+  {
+    "kind": 2,
+    "language": "github-issues",
+    "value": "$repos is:open is:issue archived:false label:state:needs-owner"
+  },
+  {
+    "kind": 1,
+    "language": "markdown",
+    "value": "⏲️ All Open Issues Marked Stale"
+  },
+  {
+    "kind": 2,
+    "language": "github-issues",
+    "value": "$repos is:open is:issue archived:false label:state:stale"
+  },
+  {
+    "kind": 1,
+    "language": "markdown",
+    "value": "❗All High Priority Issues"
+  },
+  {
+    "kind": 2,
+    "language": "github-issues",
+    "value": "$repos is:open is:issue archived:false label:priority:high"
+  },
+  {
+    "kind": 1,
+    "language": "markdown",
+    "value": "🗒️ Issues That Need Maintainer Feedback"
+  },
+  {
+    "kind": 2,
+    "language": "github-issues",
+    "value": "$repos is:open is:issue archived:false label:state:needs-maintainer-feedback"
+  }
+]


### PR DESCRIPTION
# Description

Filters issues in a notebook in VS Code based on common search criteria.

Additional search qualifiers can be added per this documentation: https://docs.github.com/search-github/searching-on-github/searching-issues-and-pull-requests

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

- View in VS Code with [GitHub Issues Notebook](https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-github-issue-notebooks)

## Integration Instructions

- N/A