### PR TITLE
Move GIC PCDs from ArmPkg to MedPkg

### DIFF
--- a/ArmPkg/ArmPkg.dec
+++ b/ArmPkg/ArmPkg.dec
@@ -342,14 +342,6 @@
   gArmTokenSpaceGuid.PcdGenericWatchdogEl2IntrNum|93|UINT32|0x00000009
 
   #
-  # ARM Generic Interrupt Controller
-  #
-  gArmTokenSpaceGuid.PcdGicDistributorBase|0|UINT64|0x0000000C
-  # Base address for the GIC Redistributor region that contains the boot CPU
-  gArmTokenSpaceGuid.PcdGicRedistributorsBase|0|UINT64|0x0000000E
-  gArmTokenSpaceGuid.PcdGicInterruptInterfaceBase|0|UINT64|0x0000000D
-
-  #
   # Bases, sizes and translation offsets of IO and MMIO spaces, respectively.
   # Note that "IO" is just another MMIO range that simulates IO space; there
   # are no special instructions to access it.

--- a/ArmPkg/ArmPkg.dec
+++ b/ArmPkg/ArmPkg.dec
@@ -348,7 +348,6 @@
   # Base address for the GIC Redistributor region that contains the boot CPU
   gArmTokenSpaceGuid.PcdGicRedistributorsBase|0|UINT64|0x0000000E
   gArmTokenSpaceGuid.PcdGicInterruptInterfaceBase|0|UINT64|0x0000000D
-  gArmTokenSpaceGuid.PcdGicSgiIntId|0|UINT32|0x00000025
 
   #
   # Bases, sizes and translation offsets of IO and MMIO spaces, respectively.

--- a/ArmPkg/Drivers/ArmGicDxe/ArmGicDxe.inf
+++ b/ArmPkg/Drivers/ArmGicDxe/ArmGicDxe.inf
@@ -54,9 +54,9 @@
   gEfiCpuArchProtocolGuid         ## CONSUMES ## NOTIFY
 
 [Pcd.common]
-  gArmTokenSpaceGuid.PcdGicDistributorBase
-  gArmTokenSpaceGuid.PcdGicRedistributorsBase
-  gArmTokenSpaceGuid.PcdGicInterruptInterfaceBase
+  gEfiMdePkgTokenSpaceGuid.PcdGicDistributorBase
+  gEfiMdePkgTokenSpaceGuid.PcdGicRedistributorsBase
+  gEfiMdePkgTokenSpaceGuid.PcdGicInterruptInterfaceBase
 
 [Depex]
   TRUE

--- a/ArmPkg/Drivers/ArmGicDxe/ArmGicV2Dxe.inf
+++ b/ArmPkg/Drivers/ArmGicDxe/ArmGicV2Dxe.inf
@@ -44,8 +44,8 @@
   gEfiCpuArchProtocolGuid         ## CONSUMES ## NOTIFY
 
 [Pcd.common]
-  gArmTokenSpaceGuid.PcdGicDistributorBase
-  gArmTokenSpaceGuid.PcdGicInterruptInterfaceBase
+  gEfiMdePkgTokenSpaceGuid.PcdGicDistributorBase
+  gEfiMdePkgTokenSpaceGuid.PcdGicInterruptInterfaceBase
 
 [Depex]
   TRUE

--- a/ArmPkg/Drivers/ArmGicDxe/ArmGicV3Dxe.inf
+++ b/ArmPkg/Drivers/ArmGicDxe/ArmGicV3Dxe.inf
@@ -50,8 +50,8 @@
   gEfiCpuArchProtocolGuid         ## CONSUMES ## NOTIFY
 
 [Pcd.common]
-  gArmTokenSpaceGuid.PcdGicDistributorBase
-  gArmTokenSpaceGuid.PcdGicRedistributorsBase
+  gEfiMdePkgTokenSpaceGuid.PcdGicDistributorBase
+  gEfiMdePkgTokenSpaceGuid.PcdGicRedistributorsBase
 
 [Depex]
   TRUE

--- a/ArmVirtPkg/ArmVirtCloudHv.dsc
+++ b/ArmVirtPkg/ArmVirtCloudHv.dsc
@@ -183,9 +183,9 @@
   #
   # ARM General Interrupt Controller
   #
-  gArmTokenSpaceGuid.PcdGicDistributorBase|0x0
-  gArmTokenSpaceGuid.PcdGicRedistributorsBase|0x0
-  gArmTokenSpaceGuid.PcdGicInterruptInterfaceBase|0x0
+  gEfiMdePkgTokenSpaceGuid.PcdGicDistributorBase|0x0
+  gEfiMdePkgTokenSpaceGuid.PcdGicRedistributorsBase|0x0
+  gEfiMdePkgTokenSpaceGuid.PcdGicInterruptInterfaceBase|0x0
 
   ## PL031 RealTimeClock
   gArmPlatformTokenSpaceGuid.PcdPL031RtcBase|0x0

--- a/ArmVirtPkg/ArmVirtKvmTool.dsc
+++ b/ArmVirtPkg/ArmVirtKvmTool.dsc
@@ -192,9 +192,9 @@
   #
   # ARM General Interrupt Controller
   #
-  gArmTokenSpaceGuid.PcdGicDistributorBase|0x0
-  gArmTokenSpaceGuid.PcdGicRedistributorsBase|0x0
-  gArmTokenSpaceGuid.PcdGicInterruptInterfaceBase|0x0
+  gEfiMdePkgTokenSpaceGuid.PcdGicDistributorBase|0x0
+  gEfiMdePkgTokenSpaceGuid.PcdGicRedistributorsBase|0x0
+  gEfiMdePkgTokenSpaceGuid.PcdGicInterruptInterfaceBase|0x0
 
   #
   # PCI settings

--- a/ArmVirtPkg/ArmVirtQemu.dsc
+++ b/ArmVirtPkg/ArmVirtQemu.dsc
@@ -267,9 +267,9 @@
   #
   # ARM General Interrupt Controller
   #
-  gArmTokenSpaceGuid.PcdGicDistributorBase|0x0
-  gArmTokenSpaceGuid.PcdGicRedistributorsBase|0x0
-  gArmTokenSpaceGuid.PcdGicInterruptInterfaceBase|0x0
+  gEfiMdePkgTokenSpaceGuid.PcdGicDistributorBase|0x0
+  gEfiMdePkgTokenSpaceGuid.PcdGicRedistributorsBase|0x0
+  gEfiMdePkgTokenSpaceGuid.PcdGicInterruptInterfaceBase|0x0
 
   ## PL031 RealTimeClock
   gArmPlatformTokenSpaceGuid.PcdPL031RtcBase|0x0

--- a/ArmVirtPkg/ArmVirtQemuKernel.dsc
+++ b/ArmVirtPkg/ArmVirtQemuKernel.dsc
@@ -230,9 +230,9 @@
   #
   # ARM General Interrupt Controller
   #
-  gArmTokenSpaceGuid.PcdGicDistributorBase|0x0
-  gArmTokenSpaceGuid.PcdGicRedistributorsBase|0x0
-  gArmTokenSpaceGuid.PcdGicInterruptInterfaceBase|0x0
+  gEfiMdePkgTokenSpaceGuid.PcdGicDistributorBase|0x0
+  gEfiMdePkgTokenSpaceGuid.PcdGicRedistributorsBase|0x0
+  gEfiMdePkgTokenSpaceGuid.PcdGicInterruptInterfaceBase|0x0
 
   ## PL031 RealTimeClock
   gArmPlatformTokenSpaceGuid.PcdPL031RtcBase|0x0

--- a/ArmVirtPkg/ArmVirtXen.dsc
+++ b/ArmVirtPkg/ArmVirtXen.dsc
@@ -126,9 +126,9 @@
   #
   # ARM General Interrupt Controller
   #
-  gArmTokenSpaceGuid.PcdGicDistributorBase|0x0
-  gArmTokenSpaceGuid.PcdGicRedistributorsBase|0x0
-  gArmTokenSpaceGuid.PcdGicInterruptInterfaceBase|0x0
+  gEfiMdePkgTokenSpaceGuid.PcdGicDistributorBase|0x0
+  gEfiMdePkgTokenSpaceGuid.PcdGicRedistributorsBase|0x0
+  gEfiMdePkgTokenSpaceGuid.PcdGicInterruptInterfaceBase|0x0
 
   gEfiMdePkgTokenSpaceGuid.PcdPlatformBootTimeOut|3
 

--- a/ArmVirtPkg/Library/ArmVirtGicArchLib/ArmVirtGicArchLib.inf
+++ b/ArmVirtPkg/Library/ArmVirtGicArchLib/ArmVirtGicArchLib.inf
@@ -36,9 +36,9 @@
   gFdtClientProtocolGuid                                ## CONSUMES
 
 [Pcd]
-  gArmTokenSpaceGuid.PcdGicDistributorBase
-  gArmTokenSpaceGuid.PcdGicRedistributorsBase
-  gArmTokenSpaceGuid.PcdGicInterruptInterfaceBase
+  gEfiMdePkgTokenSpaceGuid.PcdGicDistributorBase
+  gEfiMdePkgTokenSpaceGuid.PcdGicRedistributorsBase
+  gEfiMdePkgTokenSpaceGuid.PcdGicInterruptInterfaceBase
 
 [Depex]
   gFdtClientProtocolGuid

--- a/MdePkg/MdePkg.dec
+++ b/MdePkg/MdePkg.dec
@@ -2483,6 +2483,15 @@
   # @Prompt Time-out for a request, internal
   gEfiMdePkgTokenSpaceGuid.PcdIpmiSerialRequestRetryInterval|60000|UINT32|0x00000055
 
+[PcdsFixedAtBuild.AARCH64, PcdsFixedAtBuild.ARM, PcdsDynamic.AARCH64, PcdsDynamic.ARM]
+  #
+  # ARM Generic Interrupt Controller
+  #
+  gEfiMdePkgTokenSpaceGuid.PcdGicDistributorBase|0|UINT64|0x00000056
+  # Base address for the GIC Redistributor region that contains the boot CPU
+  gEfiMdePkgTokenSpaceGuid.PcdGicRedistributorsBase|0|UINT64|0x00000057
+  gEfiMdePkgTokenSpaceGuid.PcdGicInterruptInterfaceBase|0|UINT64|0x00000058
+
 [PcdsFixedAtBuild.AARCH64, PcdsPatchableInModule.AARCH64]
   ## GUID identifying the Rng algorithm implemented by CPU instruction.
   # @Prompt CPU Rng algorithm's GUID.


### PR DESCRIPTION
# Description

As discussed in this topic: https://edk2.groups.io/g/devel/topic/patch_v5_2_6/102725178, move GIC PCDs from ArmPkg to MdePkg.

Update usage of GIC PCDs usage to adapt changes.

Cherry-pick from:
https://github.com/leiflindholm/edk2/commit/ed2e0db
https://github.com/leiflindholm/edk2/commit/87fe6ff
https://github.com/leiflindholm/edk2/commit/91567fb

- [ ] Breaking change?
  - N/A
- [ ] Impacts security?
  - **Security** - N/A
- [ ] Includes tests?
  - **Tests** -N/A

