### PR TITLE
StandaloneMmPkg: Introduce a PCD to disable shadow boot FV

### DIFF
--- a/StandaloneMmPkg/Core/StandaloneMmCore.inf
+++ b/StandaloneMmPkg/Core/StandaloneMmCore.inf
@@ -85,6 +85,7 @@
 [Pcd]
   gStandaloneMmPkgTokenSpaceGuid.PcdFwVolMmMaxEncapsulationDepth    ##CONSUMES
   gStandaloneMmPkgTokenSpaceGuid.PcdRestartMmDispatcherOnceMmEntryRegistered    ##CONSUMES
+  gStandaloneMmPkgTokenSpaceGuid.PcdShadowBfv    ##CONSUMES
 
 #
 # This configuration fails for CLANGPDB, which does not support PIE in the GCC

--- a/StandaloneMmPkg/StandaloneMmPkg.dec
+++ b/StandaloneMmPkg/StandaloneMmPkg.dec
@@ -55,6 +55,13 @@
   # @Prompt Maximum permitted FwVol section nesting depth (exclusive) in MM.
   gStandaloneMmPkgTokenSpaceGuid.PcdFwVolMmMaxEncapsulationDepth|0x10|UINT32|0x00000001
 
+  ## Option to make shadow copy of boot firmware volume while loading drivers.
+  #  This options is useful when the BFV is not located in the Flash area
+  #  but is in the RAM instead and therefore no shadow copy is needed.
+  #   TRUE  - Default. Make a shadow copy of the boot firmware volume.
+  #   FALSE - Disable shadow copy of the boot firmware volume.
+  gStandaloneMmPkgTokenSpaceGuid.PcdShadowBfv|TRUE|BOOLEAN|0x00000003
+
 [PcdsFeatureFlag]
   ## Indicates if restart MM Dispatcher once MM Entry Point is registered.<BR><BR>
   #   TRUE  - Restart MM Dispatcher once MM Entry Point is registered.<BR>


### PR DESCRIPTION
On some Arm platforms the boot firmware volume passed in the HOB by the secure world firmware (TF-A) is never freed and is always mapped as read-only.

On such platforms the heap memory can be saved by disabling the shadow copy of the boot firmware volume. This is useful as on some platforms the amount of memory available is limited.

Therefore, introduce a PCD PcdShadowBfv that platforms can configure to disable the shadow boot FV. 
This PCD is set to TRUE by default.