### PR TITLE
MdeModulePkg: Add Segment info promt for PCIe enumeration.

### DIFF
--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciCommand.c
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciCommand.c
@@ -199,10 +199,15 @@ LocatePciExpressCapabilityRegBlock (
   OUT UINT32            *NextRegBlock OPTIONAL
   )
 {
-  EFI_STATUS  Status;
-  UINT32      CapabilityPtr;
-  UINT32      CapabilityEntry;
-  UINT16      CapabilityID;
+  EFI_STATUS                       Status;
+  UINT32                           CapabilityPtr;
+  UINT32                           CapabilityEntry;
+  UINT16                           CapabilityID;
+  UINT32                           Seg;
+  EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL  *PciRootBridgeIo;
+
+  PciRootBridgeIo = PciIoDevice->PciRootBridgeIo;
+  Seg = PciRootBridgeIo->SegmentNumber;
 
   //
   // To check the capability of this device supports
@@ -236,8 +241,9 @@ LocatePciExpressCapabilityRegBlock (
     if (CapabilityEntry == MAX_UINT32) {
       DEBUG ((
         DEBUG_WARN,
-        "%a: [%02x|%02x|%02x] failed to access config space at offset 0x%x\n",
+        "%a: [%04x|%02x|%02x|%02x] failed to access config space at offset 0x%x\n",
         __func__,
+        Seg,
         PciIoDevice->BusNumber,
         PciIoDevice->DeviceNumber,
         PciIoDevice->FunctionNumber,

--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciEnumerator.c
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciEnumerator.c
@@ -934,6 +934,8 @@ PciHostBridgeAdjustAllocation (
   UINTN                                          ResType;
   EFI_STATUS                                     Status;
   EFI_RESOURCE_ALLOC_FAILURE_ERROR_DATA_PAYLOAD  AllocFailExtendedData;
+  EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL                *PciRootBridgeIo;
+  UINT32                                         Seg;
 
   PciResNode = NULL;
   ZeroMem (RemovedPciDev, 5 * sizeof (PCI_IO_DEVICE *));
@@ -973,6 +975,9 @@ PciHostBridgeAdjustAllocation (
       continue;
     }
 
+    PciRootBridgeIo = PciResNode->PciDev->PciRootBridgeIo;
+    Seg = PciRootBridgeIo->SegmentNumber;
+
     //
     // Check if the device has been removed before
     //
@@ -993,7 +998,8 @@ PciHostBridgeAdjustAllocation (
     if (Status == EFI_SUCCESS) {
       DEBUG ((
         DEBUG_ERROR,
-        "PciBus: [%02x|%02x|%02x] was rejected due to resource confliction.\n",
+        "PciBus: [%04x|%02x|%02x|%02x] was rejected due to resource confliction.\n",
+        Seg,
         PciResNode->PciDev->BusNumber,
         PciResNode->PciDev->DeviceNumber,
         PciResNode->PciDev->FunctionNumber

--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciEnumeratorSupport.c
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciEnumeratorSupport.c
@@ -220,18 +220,23 @@ PciSearchDevice (
   OUT PCI_IO_DEVICE  **PciDevice
   )
 {
-  PCI_IO_DEVICE  *PciIoDevice;
-  BOOLEAN        IgnoreOptionRom;
+  PCI_IO_DEVICE                    *PciIoDevice;
+  BOOLEAN                          IgnoreOptionRom;
+  UINT32                           Seg;
+  EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL  *PciRootBridgeIo;
 
   PciIoDevice     = NULL;
   IgnoreOptionRom = FALSE;
+  PciRootBridgeIo = Bridge->PciRootBridgeIo;
+  Seg = PciRootBridgeIo->SegmentNumber;
 
   DEBUG ((
     DEBUG_INFO,
-    "PciBus: Discovered %s @ [%02x|%02x|%02x]  [VID = 0x%x, DID = 0x%0x]\n",
+    "PciBus: Discovered %s @ [%04x|%02x|%02x|%02x]  [VID = 0x%x, DID = 0x%0x]\n",
     IS_PCI_BRIDGE (Pci) ?     L"PPB" :
     IS_CARDBUS_BRIDGE (Pci) ? L"P2C" :
     L"PCI",
+    Seg,
     Bus,
     Device,
     Func,


### PR DESCRIPTION
https://bugzilla.tianocore.org/show_bug.cgi?id=4783

For platforms supporting multi-segments, the edk2 would only print Bus,Dev,Func info but ignore the segments info which would cause duplicate device scanning info.

Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Ray Ni <ray.ni@intel.com>

Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>
Reviewed-by: Ray Ni <ray.ni@intel.com>

# Description

<_Include a description of the change and why this change was made._>

<_For each item, place an "x" in between `[` and `]` if true. Example: `[x]` (you can also check items in GitHub UI)_>

<_Create the PR as a Draft PR if it is only created to run CI checks._>

<_Delete lines in \<\> tags before creating the PR._>

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

<_Describe the test(s) that were run to verify the changes._>

## Integration Instructions

<_Describe how these changes should be integrated. Use N/A if nothing is required._>
