### PR TITLE
PcAtChipsetPkg: Remove redundant ASSERT in HPET driver

### DIFF
--- a/PcAtChipsetPkg/HpetTimerDxe/HpetTimer.c
+++ b/PcAtChipsetPkg/HpetTimerDxe/HpetTimer.c
@@ -2,6 +2,8 @@
   Timer Architectural Protocol module using High Precision Event Timer (HPET)
 
   Copyright (c) 2011 - 2018, Intel Corporation. All rights reserved.<BR>
+  Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -795,11 +797,9 @@ TimerDriverInitialize (
   mHpetGeneralConfiguration.Uint64 = HpetRead (HPET_GENERAL_CONFIGURATION_OFFSET);
 
   //
-  // If Revision is not valid, then ASSERT() and unload the driver because the HPET
+  // If Revision is not valid, then unload the driver because the HPET
   // device is not present.
   //
-  ASSERT (mHpetGeneralCapabilities.Uint64 != 0);
-  ASSERT (mHpetGeneralCapabilities.Uint64 != 0xFFFFFFFFFFFFFFFFULL);
   if ((mHpetGeneralCapabilities.Uint64 == 0) || (mHpetGeneralCapabilities.Uint64 == 0xFFFFFFFFFFFFFFFFULL)) {
     DEBUG ((DEBUG_ERROR, "HPET device is not present.  Unload HPET driver.\n"));
     return EFI_DEVICE_ERROR;


### PR DESCRIPTION
Eliminate the redundant ASSERT in the HPET driver
that triggers when HPET capabilities cannot be read.

The driver will return an error code and unload gracefully.

Thus, the unnecessary ASSERT is removed.

Cc: Ray Ni <ray.ni@intel.com>

# Description
Removes unnecessary ASSERT.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Tested on AMD platform

## Integration Instructions

N/A