### PR TITLE
OvmfPkg/OvmfXen: use PeiPcdLib for PEI_CORE

### DIFF
--- a/OvmfPkg/OvmfXen.dsc
+++ b/OvmfPkg/OvmfXen.dsc
@@ -272,6 +272,7 @@
   OemHookStatusCodeLib|MdeModulePkg/Library/OemHookStatusCodeLibNull/OemHookStatusCodeLibNull.inf
   PeCoffGetEntryPointLib|MdePkg/Library/BasePeCoffGetEntryPointLib/BasePeCoffGetEntryPointLib.inf
   PeCoffLib|MdePkg/Library/BasePeCoffLib/BasePeCoffLib.inf
+  PcdLib|MdePkg/Library/PeiPcdLib/PeiPcdLib.inf
 
 [LibraryClasses.common.PEIM]
   HobLib|MdePkg/Library/PeiHobLib/PeiHobLib.inf


### PR DESCRIPTION


# Description

Commit d64d1e195ceb ("MdeModulePkg: PeiMain: Introduce implementation of delayed dispatch") introduced a new usage of the TimerLib which uses a dynamic PCD in OvmfXen platform. But PeiMain has only access to a NULL version of PcdLib, so OvmfXen can't start.

Introduce PeiPcdLib for PEI_CORE so PeiMain can read dynamic PCDs.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Just tried to boot a VM.

## Integration Instructions

N/A
