### PR TITLE
EmulatorPkg PlatformBm: Fix duplicate BootManagerMenuApp boot option issue

### DIFF
--- a/EmulatorPkg/Library/PlatformBmLib/PlatformBm.c
+++ b/EmulatorPkg/Library/PlatformBmLib/PlatformBm.c
@@ -401,9 +401,9 @@ PlatformBootManagerAfterConsole (
     case BOOT_WITH_DEFAULT_SETTINGS:
     default:
       PlatformBdsDiagnostics (IGNORE, TRUE);
-      PlatformBdsRegisterStaticBootOptions ();
       PlatformBdsConnectSequence ();
       EfiBootManagerRefreshAllBootOption ();
+      PlatformBdsRegisterStaticBootOptions ();
       EfiBootManagerSortLoadOptionVariable (LoadOptionTypeBoot, (SORT_COMPARE)CompareBootOption);
       break;
   }


### PR DESCRIPTION
# Description

Call PlatformBdsRegisterStaticBootOptions (); after EfiBootManagerRefreshAllBootOption to prevent duplicate BootManagerMenuApp boot option.

- [ ] Breaking change?
  - N/A
- [ ] Impacts security?
  - N/A
- [ ] Includes tests?
  - N/A

## How This Was Tested

Check the Boot Options.

Before: (Two BootManagerMenuApp BootOption)
```
[Bds]=============Begin Load Options Dumping ...=============
  Driver Options:
  SysPrep Options:
  Boot Options:
    Boot0005: UEFI Shell                 0x0001
    Boot0001: UEFI BootManagerMenuApp            0x0100
    Boot0002: UEFI Misc Device           0x0001
    Boot0003: UEFI Non-Block Boot Device                 0x0001
    Boot0004: UEFI BootManagerMenuApp            0x0001
    Boot0000: UEFI Enter Setup           0x0109
  PlatformRecovery Options:
    PlatformRecovery0000: Default PlatformRecovery               0x0001
[Bds]=============End Load Options Dumping=============
```

After:
```
[Bds]=============Begin Load Options Dumping ...=============
  Driver Options:
  SysPrep Options:
  Boot Options:
    Boot0004: UEFI Shell                 0x0001
    Boot0001: UEFI Misc Device           0x0001
    Boot0002: UEFI Non-Block Boot Device                 0x0001
    Boot0003: UEFI BootManagerMenuApp            0x0001
    Boot0000: UEFI Enter Setup           0x0109
  PlatformRecovery Options:
    PlatformRecovery0000: Default PlatformRecovery               0x0001
[Bds]=============End Load Options Dumping=============
```

## Integration Instructions

N/A
