### PR TITLE
MdeModulePkg BmDriverHealth.c: Support dump the driver name

### DIFF
--- a/MdeModulePkg/Library/UefiBootManagerLib/BmDriverHealth.c
+++ b/MdeModulePkg/Library/UefiBootManagerLib/BmDriverHealth.c
@@ -105,6 +105,79 @@ BmGetControllerName (
 }
 
 /**
+  Return the driver name.
+
+  @param DriverHealthHandle  The handle on which the Driver Health protocol instance is retrieved.
+
+  @return A pointer to the Unicode string to return. This Unicode string is the name of the controller
+          specified by DriverHealthHandle.
+**/
+CHAR16 *
+BmGetDriverName (
+  IN  EFI_HANDLE  DriverHealthHandle
+  )
+{
+  EFI_STATUS                   Status;
+  CHAR16                       *DriverName;
+  CHAR8                        *LanguageVariable;
+  CHAR8                        *BestLanguage;
+  BOOLEAN                      Iso639Language;
+  EFI_COMPONENT_NAME_PROTOCOL  *ComponentName;
+
+  DriverName = NULL;
+
+  //
+  // Locate Component Name (2) protocol on the driver binging handle.
+  //
+  Iso639Language = FALSE;
+  Status         = gBS->HandleProtocol (
+                          DriverHealthHandle,
+                          &gEfiComponentName2ProtocolGuid,
+                          (VOID **)&ComponentName
+                          );
+  if (EFI_ERROR (Status)) {
+    Status = gBS->HandleProtocol (
+                    DriverHealthHandle,
+                    &gEfiComponentNameProtocolGuid,
+                    (VOID **)&ComponentName
+                    );
+    if (!EFI_ERROR (Status)) {
+      Iso639Language = TRUE;
+    }
+  }
+
+  if (!EFI_ERROR (Status)) {
+    GetEfiGlobalVariable2 (Iso639Language ? L"Lang" : L"PlatformLang", (VOID **)&LanguageVariable, NULL);
+    BestLanguage = GetBestLanguage (
+                     ComponentName->SupportedLanguages,
+                     Iso639Language,
+                     (LanguageVariable != NULL) ? LanguageVariable : "",
+                     Iso639Language ? "eng" : "en-US",
+                     NULL
+                     );
+    if (LanguageVariable != NULL) {
+      FreePool (LanguageVariable);
+    }
+
+    Status = ComponentName->GetDriverName (
+                              ComponentName,
+                              BestLanguage,
+                              &DriverName
+                              );
+  }
+
+  if (!EFI_ERROR (Status)) {
+    return AllocateCopyPool (StrSize (DriverName), DriverName);
+  } else {
+    return ConvertDevicePathToText (
+             DevicePathFromHandle (DriverHealthHandle),
+             FALSE,
+             FALSE
+             );
+  }
+}
+
+/**
   Display a set of messages returned by the GetHealthStatus () service of the EFI Driver Health Protocol
 
   @param DriverHealthInfo  Pointer to the Driver Health information entry.
@@ -116,7 +189,8 @@ BmDisplayMessages (
 {
   UINTN       Index;
   EFI_STRING  String;
-  CHAR16      *ControllerName;
+  CHAR16      *ControllerName = NULL;
+  CHAR16      *DriverName = NULL;
 
   if ((DriverHealthInfo->MessageList == NULL) ||
       (DriverHealthInfo->MessageList[0].HiiHandle == NULL))
@@ -124,14 +198,18 @@ BmDisplayMessages (
     return;
   }
 
-  ControllerName = BmGetControllerName (
-                     DriverHealthInfo->DriverHealthHandle,
-                     DriverHealthInfo->ControllerHandle,
-                     DriverHealthInfo->ChildHandle
-                     );
-
-  DEBUG ((DEBUG_INFO, "Controller: %s\n", ControllerName));
-  Print (L"Controller: %s\n", ControllerName);
+  DriverName = BmGetDriverName (DriverHealthInfo->DriverHealthHandle);
+  DEBUG ((DEBUG_INFO, "Driver: %s\n", DriverName));
+  Print (L"Driver: %s\n", DriverName);
+  if (DriverHealthInfo->ControllerHandle != NULL) {
+    ControllerName = BmGetControllerName (
+                       DriverHealthInfo->DriverHealthHandle,
+                       DriverHealthInfo->ControllerHandle,
+                       DriverHealthInfo->ChildHandle
+                       );
+    DEBUG ((DEBUG_INFO, "Controller: %s\n", ControllerName));
+    Print (L"Controller: %s\n", ControllerName);
+  }
   for (Index = 0; DriverHealthInfo->MessageList[Index].HiiHandle != NULL; Index++) {
     String = HiiGetString (
                DriverHealthInfo->MessageList[Index].HiiHandle,
@@ -147,6 +225,11 @@ BmDisplayMessages (
 
   if (ControllerName != NULL) {
     FreePool (ControllerName);
+    ControllerName = NULL;
+  }
+  if (DriverName != NULL) {
+    FreePool (DriverName);
+    DriverName = NULL;
   }
 }
 
@@ -550,24 +633,40 @@ BmRepairAllControllers (
   EfiBootManagerFreeDriverHealthInfo (DriverHealthInfo, Count);
 
   DEBUG_CODE_BEGIN ();
-  CHAR16  *ControllerName;
+  CHAR16  *ControllerName = NULL;
+  CHAR16  *DriverName = NULL;
+  CHAR16  String[512];
 
   DriverHealthInfo = EfiBootManagerGetDriverHealthInfo (&Count);
   for (Index = 0; Index < Count; Index++) {
-    ControllerName = BmGetControllerName (
-                       DriverHealthInfo[Index].DriverHealthHandle,
-                       DriverHealthInfo[Index].ControllerHandle,
-                       DriverHealthInfo[Index].ChildHandle
-                       );
+    ZeroMem (String, sizeof (String));
+    DriverName = BmGetDriverName (DriverHealthInfo[Index].DriverHealthHandle);
+    ASSERT (DriverName != NULL);
+    if (DriverHealthInfo[Index].ControllerHandle == NULL) {
+      UnicodeSPrint (String, sizeof (String), L"%s", DriverName);
+    } else {
+      ControllerName = BmGetControllerName (
+                         DriverHealthInfo[Index].DriverHealthHandle,
+                         DriverHealthInfo[Index].ControllerHandle,
+                         DriverHealthInfo[Index].ChildHandle
+                         );
+      ASSERT (ControllerName != NULL);
+      UnicodeSPrint (String, sizeof (String), L"%s    %s", DriverName, ControllerName);
+    }
     DEBUG ((
       DEBUG_INFO,
       "%02d: %s - %s\n",
       Index,
-      ControllerName,
+      String,
       mBmHealthStatusText[DriverHealthInfo[Index].HealthStatus]
       ));
     if (ControllerName != NULL) {
       FreePool (ControllerName);
+      ControllerName = NULL;
+    }
+    if (DriverName != NULL) {
+      FreePool (DriverName);
+      DriverName = NULL;
     }
   }
 


### PR DESCRIPTION
Sometimes the controller name is not present, add BmGetDriverName to retrieve the driver name.(Like DriverHealthManagerDxe)

# Description



- [ ] Breaking change?
  - N/A
- [ ] Impacts security?
  - N/A
- [ ] Includes tests?
  - N/A

## How This Was Tested

Check the boot log with OVMF(IA32X64) and NIC(E1000 Driver).

Before:
```
00: <null string> - Healthy
```

After:
```
00: Intel(R) PRO/1000 9.8.62 PCI-E - Healthy
```

## Integration Instructions

N/A
