### PR TITLE
OvmfPkg/X64: add opt/org.tianocore/UninstallMemAttrProtocol support

### DIFF
--- a/OvmfPkg/Library/PlatformBootManagerLib/BdsPlatform.c
+++ b/OvmfPkg/Library/PlatformBootManagerLib/BdsPlatform.c
@@ -1837,6 +1837,49 @@ SaveS3BootScript (
 }
 
 /**
+  Uninstall the EFI memory attribute protocol if it exists.
+**/
+STATIC
+VOID
+UninstallEfiMemoryAttributesProtocol (
+  VOID
+  )
+{
+  EFI_STATUS  Status;
+  EFI_HANDLE  Handle;
+  UINTN       Size;
+  VOID        *MemoryAttributeProtocol;
+
+  Size   = sizeof (Handle);
+  Status = gBS->LocateHandle (
+                  ByProtocol,
+                  &gEfiMemoryAttributeProtocolGuid,
+                  NULL,
+                  &Size,
+                  &Handle
+                  );
+
+  if (EFI_ERROR (Status)) {
+    ASSERT (Status == EFI_NOT_FOUND);
+    return;
+  }
+
+  Status = gBS->HandleProtocol (
+                  Handle,
+                  &gEfiMemoryAttributeProtocolGuid,
+                  &MemoryAttributeProtocol
+                  );
+  ASSERT_EFI_ERROR (Status);
+
+  Status = gBS->UninstallProtocolInterface (
+                  Handle,
+                  &gEfiMemoryAttributeProtocolGuid,
+                  MemoryAttributeProtocol
+                  );
+  ASSERT_EFI_ERROR (Status);
+}
+
+/**
   Do the platform specific action after the console is ready
 
   Possible things that can be done in PlatformBootManagerAfterConsole:
@@ -1856,6 +1899,7 @@ PlatformBootManagerAfterConsole (
   )
 {
   EFI_BOOT_MODE  BootMode;
+  BOOLEAN        Uninstall;
 
   DEBUG ((DEBUG_INFO, "PlatformBootManagerAfterConsole\n"));
 
@@ -1899,6 +1943,25 @@ PlatformBootManagerAfterConsole (
   // Write qemu bootorder to efi variables
   //
   StoreQemuBootOrder ();
+
+  //
+  // Work around shim's terminally broken use of the EFI memory attributes
+  // protocol, by uninstalling it if requested on the QEMU command line.
+  //
+  // E.g.,
+  //       -fw_cfg opt/org.tianocore/UninstallMemAttrProtocol,string=y
+  //
+  Uninstall = FixedPcdGetBool (PcdUninstallMemAttrProtocol);
+  QemuFwCfgParseBool ("opt/org.tianocore/UninstallMemAttrProtocol", &Uninstall);
+  DEBUG ((
+    DEBUG_WARN,
+    "%a: %auninstalling EFI memory protocol\n",
+    __func__,
+    Uninstall ? "" : "not "
+    ));
+  if (Uninstall) {
+    UninstallEfiMemoryAttributesProtocol ();
+  }
 
   //
   // Process QEMU's -kernel command line option

--- a/OvmfPkg/Library/PlatformBootManagerLib/PlatformBootManagerLib.inf
+++ b/OvmfPkg/Library/PlatformBootManagerLib/PlatformBootManagerLib.inf
@@ -63,6 +63,7 @@
   gUefiOvmfPkgTokenSpaceGuid.PcdOvmfFlashVariablesEnable
   gUefiOvmfPkgTokenSpaceGuid.PcdOvmfHostBridgePciDevId
   gUefiOvmfPkgTokenSpaceGuid.PcdBootRestrictToFirmware
+  gUefiOvmfPkgTokenSpaceGuid.PcdUninstallMemAttrProtocol
   gEfiMdeModulePkgTokenSpaceGuid.PcdAcpiS3Enable
   gEfiMdePkgTokenSpaceGuid.PcdPlatformBootTimeOut
   gEfiMdePkgTokenSpaceGuid.PcdUartDefaultBaudRate         ## CONSUMES
@@ -81,6 +82,7 @@
   gEfiDxeSmmReadyToLockProtocolGuid             # PROTOCOL SOMETIMES_PRODUCED
   gEfiLoadedImageProtocolGuid                   # PROTOCOL SOMETIMES_PRODUCED
   gEfiFirmwareVolume2ProtocolGuid               # PROTOCOL SOMETIMES_CONSUMED
+  gEfiMemoryAttributeProtocolGuid
 
 [Guids]
   gEfiEndOfDxeEventGroupGuid


### PR DESCRIPTION
Add support for opt/org.tianocore/UninstallMemAttrProtocol, to allow
turning off EFI_MEMORY_ATTRIBUTE_PROTOCOL, simliar to ArmVirtPkg.

Signed-off-by: Gerd Hoffmann <kraxel@redhat.com>

# rant

I *hate* to do this, but things are breaking left and right.  This time
it is not shim, 15.8 works fine and almost everyone has rolled out
updates meanwhile.  But now grub gets the NX stuff wrong, and following
that the linux kernel efi stub pagefaults.

Apparently it happens due something in the huge pile of distro
downstream patches doing some stupid legacy x86 linux things.

Vanilla 2.12 grub is doing fine.
aarch64 is doing fine too.
Even `chainloader $vmlinuz` works.
Only `linux $vmlinux` on x64 distro builds explodes ...
