### PR TITLE
OvmfPkg/QemuKernelLoaderFsDxe: root directory name should be ""

### DIFF
--- a/OvmfPkg/QemuKernelLoaderFsDxe/QemuKernelLoaderFsDxe.c
+++ b/OvmfPkg/QemuKernelLoaderFsDxe/QemuKernelLoaderFsDxe.c
@@ -279,7 +279,7 @@ QemuKernelBlobTypeToFileInfo (
     // getting file info about the root directory
     //
     DEBUG ((DEBUG_INFO, "%a: file info: directory\n", __func__));
-    Name      = L"\\";
+    Name      = L"";
     FileSize  = mKernelBlobCount;
     Attribute = EFI_FILE_READ_ONLY | EFI_FILE_DIRECTORY;
   } else {


### PR DESCRIPTION
UEFI spec says so, fix it.

https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-file-info

Reported-by: Laszlo Ersek <laszlo.ersek@posteo.net>
Signed-off-by: Gerd Hoffmann <kraxel@redhat.com>
