### PR TITLE
OvmfPkg/GenericQemuLoadImageLib: fix cmdline + initrd handling

### DIFF
--- a/OvmfPkg/Library/GenericQemuLoadImageLib/GenericQemuLoadImageLib.c
+++ b/OvmfPkg/Library/GenericQemuLoadImageLib/GenericQemuLoadImageLib.c
@@ -294,7 +294,11 @@ QemuLoadKernelImage (
 
   Status = GetQemuKernelLoaderBlobSize (Root, L"cmdline", &CommandLineSize);
   if (EFI_ERROR (Status)) {
-    goto CloseRoot;
+    if (Status == EFI_NOT_FOUND) {
+      CommandLineSize = 0;
+    } else {
+      goto CloseRoot;
+    }
   }
 
   if (CommandLineSize == 0) {
@@ -337,7 +341,11 @@ QemuLoadKernelImage (
 
   Status = GetQemuKernelLoaderBlobSize (Root, L"initrd", &InitrdSize);
   if (EFI_ERROR (Status)) {
-    goto FreeCommandLine;
+    if (Status == EFI_NOT_FOUND) {
+      InitrdSize = 0;
+    } else {
+      goto FreeCommandLine;
+    }
   }
 
   if (InitrdSize > 0) {


### PR DESCRIPTION
Commit 459f5ffa24ae ("OvmfPkg/QemuKernelLoaderFsDxe: rework direct
kernel boot filesystem") has a small change in behavior:  In case
there is no data the file is not created and attempts to open file
return EFI_NOT_FOUND.  Old behavior was to add a zero-length file
to the filesystem.

Fix GenericQemuLoadImageLib to handle EFI_NOT_FOUND correctly for
'initrd' and 'cmdline'.

Reported-by: Srikanth Aithal <sraithal@amd.com>
Signed-off-by: Gerd Hoffmann <kraxel@redhat.com>
