### PR TITLE
Add 18 register support for SMC and SVC calls for AArch64 platforms

### DIFF
--- a/ArmPkg/ArmPkg.dsc
+++ b/ArmPkg/ArmPkg.dsc
@@ -178,6 +178,7 @@
   ArmPkg/Drivers/ArmPsciMpServicesDxe/ArmPsciMpServicesDxe.inf
   ArmPkg/Drivers/MmCommunicationDxe/MmCommunication.inf
   ArmPkg/Library/ArmMmuLib/ArmMmuPeiLib.inf
+  ArmPkg/Library/SecurePartitionEntryPoint/SecurePartitionEntryPoint.inf
 
 [Components.AARCH64, Components.ARM]
   ArmPkg/Library/StandaloneMmMmuLib/ArmMmuStandaloneMmLib.inf

--- a/ArmPkg/Include/Library/ArmFfaLib.h
+++ b/ArmPkg/Include/Library/ArmFfaLib.h
@@ -42,8 +42,35 @@ typedef struct DirectMsgArgs {
   /// Implementation define argument 3, this will be set to/from x6(v1) or x7(v2)
   UINTN    Arg3;
 
-  /// Implementation define argument 4, this will be set to/from x7(v1) or ignored (v2)
+  /// Implementation define argument 4, this will be set to/from x7(v1) or x8 (v2)
   UINTN    Arg4;
+
+  /// Implementation define argument 5, this will be ignored (v1) or set to/from x9(v2)
+  UINTN    Arg5;
+
+  /// Implementation define argument 6, this will be ignored (v1) or set to/from x10(v2)
+  UINTN    Arg6;
+
+  /// Implementation define argument 7, this will be ignored (v1) or set to/from x11(v2)
+  UINTN    Arg7;
+
+  /// Implementation define argument 8, this will be ignored (v1) or set to/from x12(v2)
+  UINTN    Arg8;
+
+  /// Implementation define argument 9, this will be ignored (v1) or set to/from x13(v2)
+  UINTN    Arg9;
+
+  /// Implementation define argument 10, this will be ignored (v1) or set to/from x14(v2)
+  UINTN    Arg10;
+
+  /// Implementation define argument 11, this will be ignored (v1) or set to/from x15(v2)
+  UINTN    Arg11;
+
+  /// Implementation define argument 12, this will be ignored (v1) or set to/from x16(v2)
+  UINTN    Arg12;
+
+  /// Implementation define argument 13, this will be ignored (v1) or set to/from x17(v2)
+  UINTN    Arg13;
 } DIRECT_MSG_ARGS;
 
 /**

--- a/ArmPkg/Include/Library/ArmSmcLib.h
+++ b/ArmPkg/Include/Library/ArmSmcLib.h
@@ -23,6 +23,16 @@ typedef struct {
   UINTN    Arg5;
   UINTN    Arg6;
   UINTN    Arg7;
+  UINTN    Arg8;
+  UINTN    Arg9;
+  UINTN    Arg10;
+  UINTN    Arg11;
+  UINTN    Arg12;
+  UINTN    Arg13;
+  UINTN    Arg14;
+  UINTN    Arg15;
+  UINTN    Arg16;
+  UINTN    Arg17;
 } ARM_SMC_ARGS;
 
 /**

--- a/ArmPkg/Include/Library/ArmStandaloneMmCoreEntryPoint.h
+++ b/ArmPkg/Include/Library/ArmStandaloneMmCoreEntryPoint.h
@@ -23,8 +23,10 @@
 #ifndef __STANDALONEMMCORE_ENTRY_POINT_H__
 #define __STANDALONEMMCORE_ENTRY_POINT_H__
 
+#include <Library/PcdLib.h>
 #include <Library/ArmSvcLib.h>
 #include <Library/ArmFfaLib.h>
+#include <Library/ArmFfaLibEx.h>
 #include <Library/PeCoffLib.h>
 #include <Library/FvLib.h>
 
@@ -136,13 +138,13 @@ typedef struct FfaMsgInfo {
  */
 typedef struct {
   /// Service guid
-  EFI_GUID           HeaderGuid;
+  EFI_GUID              HeaderGuid;
 
   /// Length of Message. In case of misc service, sizeof (EventSvcArgs)
-  UINTN              MessageLength;
+  UINTN                 MessageLength;
 
   /// Delivered register values.
-  DIRECT_MSG_ARGS    DirectMsgArgs;
+  DIRECT_MSG_ARGS       DirectMsgArgs;
 } MISC_MM_COMMUNICATE_BUFFER;
 
 typedef struct {

--- a/ArmPkg/Include/Library/ArmSvcLib.h
+++ b/ArmPkg/Include/Library/ArmSvcLib.h
@@ -22,6 +22,16 @@ typedef struct {
   UINTN    Arg5;
   UINTN    Arg6;
   UINTN    Arg7;
+  UINTN    Arg8;
+  UINTN    Arg9;
+  UINTN    Arg10;
+  UINTN    Arg11;
+  UINTN    Arg12;
+  UINTN    Arg13;
+  UINTN    Arg14;
+  UINTN    Arg15;
+  UINTN    Arg16;
+  UINTN    Arg17;
 } ARM_SVC_ARGS;
 
 /**

--- a/ArmPkg/Library/ArmSmcLib/AArch64/ArmSmc.S
+++ b/ArmPkg/Library/ArmSmcLib/AArch64/ArmSmc.S
@@ -9,9 +9,15 @@
 
 ASM_FUNC(ArmCallSmc)
   // Push x0 on the stack - The stack must always be quad-word aligned
+  str   x19, [sp, #-16]!
   str   x0, [sp, #-16]!
 
   // Load the SMC arguments values into the appropriate registers
+  ldp   x16, x17, [x0, #128]
+  ldp   x14, x15, [x0, #112]
+  ldp   x12, x13, [x0, #96]
+  ldp   x10, x11, [x0, #80]
+  ldp   x8, x9, [x0, #64]
   ldp   x6, x7, [x0, #48]
   ldp   x4, x5, [x0, #32]
   ldp   x2, x3, [x0, #16]
@@ -20,13 +26,22 @@ ASM_FUNC(ArmCallSmc)
   smc   #0
 
   // Pop the ARM_SMC_ARGS structure address from the stack into x9
-  ldr   x9, [sp], #16
+  ldr   x19, [sp], #16
 
   // Store the SMC returned values into the ARM_SMC_ARGS structure.
   // A SMC call can return up to 4 values - we do not need to store back x4-x7.
-  stp   x2, x3, [x9, #16]
-  stp   x0, x1, [x9, #0]
+  stp   x16, x17, [x19, #128]
+  stp   x14, x15, [x19, #112]
+  stp   x12, x13, [x19, #96]
+  stp   x10, x11, [x19, #80]
+  stp   x8, x9, [x19, #64]
+  stp   x6, x7, [x19, #48]
+  stp   x4, x5, [x19, #32]
+  stp   x2, x3, [x19, #16]
+  stp   x0, x1, [x19, #0]
 
-  mov   x0, x9
+  mov   x0, x19
+
+  ldr   x19, [sp], #16
 
   ret

--- a/ArmPkg/Library/ArmStandaloneMmCoreEntryPoint/AArch64/ModuleEntryPoint.S
+++ b/ArmPkg/Library/ArmStandaloneMmCoreEntryPoint/AArch64/ModuleEntryPoint.S
@@ -17,7 +17,7 @@
 #
 #------------------------------------------------------------------------------
 
-#include <AArch64/AsmMacroLib.h>
+#include <AsmMacroIoLibV8.h>
 #include <IndustryStandard/ArmMmSvc.h>
 #include <IndustryStandard/ArmFfaSvc.h>
 #include <Uefi/UefiBaseType.h>

--- a/ArmPkg/Library/ArmStandaloneMmCoreEntryPoint/Arm/ModuleEntryPoint.S
+++ b/ArmPkg/Library/ArmStandaloneMmCoreEntryPoint/Arm/ModuleEntryPoint.S
@@ -17,7 +17,7 @@
 #
 #------------------------------------------------------------------------------
 
-#include <Arm/AsmMacroLib.h>
+#include <AsmMacroIoLib.h>
 #include <IndustryStandard/ArmMmSvc.h>
 #include <IndustryStandard/ArmFfaSvc.h>
 #include <Uefi/UefiBaseType.h>

--- a/ArmPkg/Library/ArmStandaloneMmCoreEntryPoint/ArmStandaloneMmCoreEntryPoint.c
+++ b/ArmPkg/Library/ArmStandaloneMmCoreEntryPoint/ArmStandaloneMmCoreEntryPoint.c
@@ -767,11 +767,21 @@ InitializeMiscMmCommunicateBuffer (
 {
   ZeroMem (Buffer, sizeof (MISC_MM_COMMUNICATE_BUFFER));
 
-  Buffer->MessageLength      = sizeof (DIRECT_MSG_ARGS);
-  Buffer->DirectMsgArgs.Arg0 = EventSvcArgs->Arg4;
-  Buffer->DirectMsgArgs.Arg1 = EventSvcArgs->Arg5;
-  Buffer->DirectMsgArgs.Arg2 = EventSvcArgs->Arg6;
-  Buffer->DirectMsgArgs.Arg3 = EventSvcArgs->Arg7;
+  Buffer->MessageLength       = sizeof (DIRECT_MSG_ARGS_EX);
+  Buffer->DirectMsgArgs.Arg0  = EventSvcArgs->Arg4;
+  Buffer->DirectMsgArgs.Arg1  = EventSvcArgs->Arg5;
+  Buffer->DirectMsgArgs.Arg2  = EventSvcArgs->Arg6;
+  Buffer->DirectMsgArgs.Arg3  = EventSvcArgs->Arg7;
+  Buffer->DirectMsgArgs.Arg4  = EventSvcArgs->Arg8;
+  Buffer->DirectMsgArgs.Arg5  = EventSvcArgs->Arg9;
+  Buffer->DirectMsgArgs.Arg6  = EventSvcArgs->Arg10;
+  Buffer->DirectMsgArgs.Arg7  = EventSvcArgs->Arg11;
+  Buffer->DirectMsgArgs.Arg8  = EventSvcArgs->Arg12;
+  Buffer->DirectMsgArgs.Arg9  = EventSvcArgs->Arg13;
+  Buffer->DirectMsgArgs.Arg10 = EventSvcArgs->Arg14;
+  Buffer->DirectMsgArgs.Arg11 = EventSvcArgs->Arg15;
+  Buffer->DirectMsgArgs.Arg12 = EventSvcArgs->Arg16;
+  Buffer->DirectMsgArgs.Arg13 = EventSvcArgs->Arg17;
   CopyGuid (&Buffer->HeaderGuid, ServiceGuid);
 }
 

--- a/ArmPkg/Library/ArmSvcLib/AArch64/ArmSvc.S
+++ b/ArmPkg/Library/ArmSvcLib/AArch64/ArmSvc.S
@@ -12,13 +12,19 @@
 
 ASM_FUNC(ArmCallSvc)
   // Push frame pointer and return address on the stack
-  stp   x29, x30, [sp, #-32]!
+  stp   x29, x30, [sp, #-48]!
   mov   x29, sp
 
   // Push x0 on the stack - The stack must always be quad-word aligned
-  str   x0, [sp, #16]
+  str   x19, [sp, #16]
+  str   x0, [sp, #32]
 
   // Load the SVC arguments values into the appropriate registers
+  ldp   x16, x17, [x0, #128]
+  ldp   x14, x15, [x0, #112]
+  ldp   x12, x13, [x0, #96]
+  ldp   x10, x11, [x0, #80]
+  ldp   x8, x9, [x0, #64]
   ldp   x6, x7, [x0, #48]
   ldp   x4, x5, [x0, #32]
   ldp   x2, x3, [x0, #16]
@@ -30,16 +36,23 @@ ASM_FUNC(ArmCallSvc)
   isb
 
   // Pop the ARM_SVC_ARGS structure address from the stack into x9
-  ldr   x9, [sp, #16]
+  ldr   x19, [sp, #32]
 
   // Store the SVC returned values into the ARM_SVC_ARGS structure.
   // A SVC call can return up to 8 values
-  stp   x0, x1, [x9, #0]
-  stp   x2, x3, [x9, #16]
-  stp   x4, x5, [x9, #32]
-  stp   x6, x7, [x9, #48]
+  stp   x16, x17, [x19, #128]
+  stp   x14, x15, [x19, #112]
+  stp   x12, x13, [x19, #96]
+  stp   x10, x11, [x19, #80]
+  stp   x8, x9, [x19, #64]
+  stp   x6, x7, [x19, #48]
+  stp   x4, x5, [x19, #32]
+  stp   x2, x3, [x19, #16]
+  stp   x0, x1, [x19, #0]
 
-  mov   x0, x9
+  mov   x0, x19
 
-  ldp   x29, x30, [sp], #32
+  ldr   x19, [sp, #16]
+
+  ldp   x29, x30, [sp], #48
   ret


### PR DESCRIPTION
# Description

Current SMC and SVC only supports up to 8 registers.

However, the FF-A spec has definition for FFA direct request 2 which could use up to 18 registers.

This change is added to support such use case.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

This was tested on QEMU SBSA and booted to Windows

## Integration Instructions

N/A
