### PR TITLE
Fixing TemporaryRamSize Configurability option

### DIFF
--- a/IntelFsp2Pkg/FspSecCore/Ia32/FspApiEntryT.nasm
+++ b/IntelFsp2Pkg/FspSecCore/Ia32/FspApiEntryT.nasm
@@ -185,6 +185,16 @@ endstruc
 global ASM_PFX(LoadUpdPointerToECX)
 ASM_PFX(LoadUpdPointerToECX):
   ;
+  ; Inputs:
+  ;   esp -> stack with FsptUpdDataPtr parameter
+  ; Outputs:
+  ;   eax -> Address of FspInfoHeader
+  ;   ecx -> Address of FSP-T UPD structure
+  ; Register Usage:
+  ;   ebp is used for return address.
+  ;   All others reserved.
+  ;
+
   ; esp + 4 is input UPD parameter
   ; If esp + 4 is NULL the default UPD should be used
   ; ecx will be the UPD region that should be used
@@ -600,6 +610,7 @@ ASM_PFX(TempRamInitApi):
   SAVE_EDX
 
   CALL_EBP  ASM_PFX(LoadUpdPointerToECX) ; ECX for UPD param
+  mov       esi, eax                     ; eax contains FspInfoHeader address after previous call
   SAVE_ECX                               ; save UPD param to slot 3 in xmm6
 
   mov       edx, ASM_PFX(PcdGet32 (PcdTemporaryRamSize))

--- a/IntelFsp2Pkg/FspSecCore/X64/FspApiEntryT.nasm
+++ b/IntelFsp2Pkg/FspSecCore/X64/FspApiEntryT.nasm
@@ -451,19 +451,25 @@ ASM_PFX(TempRamInitApi):
   ;
   ; Save Input Parameter in YMM10
   ;
+  SAVE_RCX
+  ;
+  ; Get FspInfoHeader address
+  ;
+  CALL_RDI  ASM_PFX(AsmGetFspInfoHeaderNoStack)
+  mov       rsi, rax
+  LOAD_RCX
   cmp       rcx, 0
   jnz       ParamValid
 
   ;
   ; Fall back to default UPD
   ;
-  CALL_RDI  ASM_PFX(AsmGetFspInfoHeaderNoStack)
   xor       rcx, rcx
   mov       ecx,  DWORD [rax + 01Ch]      ; Read FsptImageBaseAddress
   add       ecx,  DWORD [rax + 024h]      ; Get Cfg Region base address = FsptImageBaseAddress + CfgRegionOffset
-ParamValid:
   SAVE_RCX
 
+ParamValid:
   mov       rdx, ASM_PFX(PcdGet32 (PcdTemporaryRamSize))
   mov       edx, DWORD [rdx]
   ;


### PR DESCRIPTION
Issue : Configuring TemporaryRamSize using FSP-T arch UPD
(added as part of Spec 2.5) is not working as expected.

Root cause : Code is reading the ImageAttribute from the wrong
address which confirms the TemporaryRamSize Configurability,
hence the TemporaryRamSize UPD is ignored. This is because
the code expects the FspInfoheader Offset to be in ESI/RSI
(from which ImageAttribute read) is not guaranteed as per the
current implementation.

Fix : Modified code to make sure that ESI/RSI contains the
FspInfoheader offset by time the code reads the ImageAttribute.

Tests : Verified the fix on Both 32 Bit and 64 Bit FSP Binaries by 
configuring the TemporaryRamSize using the FSPT Arch UPD.

Signed-off-by: Aravind P R <aravind.p.r@intel.com>

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Verified the fix on Both 32 Bit and 64 Bit FSP Binaries by configuring the TemporaryRamSize using the 
FSPT Arch UPD.

## Integration Instructions

NA
