### PR TITLE
NetworkPkg:Resolved Coverity Issues in MnpDxe

### DIFF
--- a/NetworkPkg/MnpDxe/MnpConfig.c
+++ b/NetworkPkg/MnpDxe/MnpConfig.c
@@ -1305,6 +1305,10 @@ MnpStop (
   MnpDeviceData = MnpServiceData->MnpDeviceData;
   ASSERT (MnpDeviceData->ConfiguredChildrenNumber > 0);
 
+  if (MnpDeviceData->ConfiguredChildrenNumber <= 0) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
   //
   // Configure the receive filters.
   //

--- a/NetworkPkg/MnpDxe/MnpIo.c
+++ b/NetworkPkg/MnpDxe/MnpIo.c
@@ -325,6 +325,9 @@ MnpInstanceDeliverPacket (
   }
 
   ASSERT (Instance->RcvdPacketQueueSize != 0);
+  if (Instance->RcvdPacketQueueSize <= 0) {
+    return EFI_OUT_OF_RESOURCES;
+  }
 
   RxDataWrap = NET_LIST_HEAD (&Instance->RcvdPacketQueue, MNP_RXDATA_WRAP, WrapEntry);
   if (RxDataWrap->Nbuf->RefCnt > 2) {


### PR DESCRIPTION
Resolved INTEGER_OVERFLOW Coverity Issues in MNP Dxe 1.MnpStop,MnpInstanceDeliverPacket
Expression "MnpDeviceData->ConfiguredChildrenNumber--" and Instance->RcvdPacketQueueSize-- where Both variables are known to be equal to 0,underflows the type that receives it.

# Description

