### PR TITLE
EmbeddedPkg/Universal/MmcDxe: Reorder multi-block abort sequence

### DIFF
--- a/EmbeddedPkg/Universal/MmcDxe/MmcBlockIo.c
+++ b/EmbeddedPkg/Universal/MmcDxe/MmcBlockIo.c
@@ -195,6 +195,13 @@ MmcTransferBlock (
     }
   }
 
+  if (BufferSize > This->Media->BlockSize) {
+    Status = MmcStopTransmission (MmcHost);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_BLKIO, "%a(): MmcStopTransmission Error and Status:%r\n", __func__, Status));
+    }
+  }
+
   // Command 13 - Read status and wait for programming to complete (return to tran)
   Timeout     = MMCI0_TIMEOUT;
   CmdArg      = MmcHostInstance->CardInfo.RCA << 16;
@@ -210,15 +217,6 @@ MmcTransferBlock (
         break;  // Prevents delay once finished
       }
     }
-  }
-
-  if (BufferSize > This->Media->BlockSize) {
-    Status = MmcHost->SendCommand (MmcHost, MMC_CMD12, 0);
-    if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_BLKIO, "%a(): Error and Status:%r\n", __func__, Status));
-    }
-
-    MmcHost->ReceiveResponse (MmcHost, MMC_RESPONSE_TYPE_R1b, Response);
   }
 
   Status = MmcNotifyState (MmcHostInstance, MmcTransferState);


### PR DESCRIPTION
# Description

This change moves multi-block stop transmission scenario (CMD12) before getting card status (CMD13).

This follows the abort sequence mentioned in:
SD Host Controller Simplified Specification Version 4.20, Section 3.8.1 Abort Command Sequence

Additionally, make use of MmcStopTransmission to remove duplicate code.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Tested on KV260 (new EDK-II port)

## Integration Instructions

N/A
