### PR TITLE
OvmfPkg: make legacy direct kernel loader code nx clean

### DIFF
--- a/OvmfPkg/Library/LoadLinuxLib/Linux.c
+++ b/OvmfPkg/Library/LoadLinuxLib/Linux.c
@@ -168,7 +168,7 @@ LoadLinuxAllocateKernelPages (
                       );
     Status = gBS->AllocatePages (
                     AllocateAddress,
-                    EfiLoaderData,
+                    EfiLoaderCode,
                     Pages,
                     &KernelAddress
                     );


### PR DESCRIPTION
kernel pages are code not data.

Signed-off-by: Gerd Hoffmann <kraxel@redhat.com>
