### PR TITLE
Resolved Coverity Issues in Http Dxe

### DIFF
--- a/NetworkPkg/HttpDxe/HttpImpl.c
+++ b/NetworkPkg/HttpDxe/HttpImpl.c
@@ -1108,10 +1108,6 @@ HttpResponseWorker (
     // Search for Status Code.
     //
     StatusCodeStr = HttpHeaders + AsciiStrLen (HTTP_VERSION_STR) + 1;
-    if (StatusCodeStr == NULL) {
-      Status = EFI_NOT_READY;
-      goto Error;
-    }
 
     StatusCode = AsciiStrDecimalToUintn (StatusCodeStr);
 

--- a/NetworkPkg/HttpDxe/HttpsSupport.c
+++ b/NetworkPkg/HttpDxe/HttpsSupport.c
@@ -732,7 +732,6 @@ TlsConfigureSession (
       // the caller. The failure is pushed back to TLS DXE driver if the
       // HTTP communication actually requires certificate.
       //
-      Status = EFI_SUCCESS;
     } else {
       DEBUG ((DEBUG_ERROR, "TLS Certificate Config Error!\n"));
       return Status;
@@ -1250,7 +1249,13 @@ TlsConnectSession (
   // Transmit ClientHello
   //
   PacketOut = NetbufAlloc ((UINT32)BufferOutSize);
-  DataOut   = NetbufAllocSpace (PacketOut, (UINT32)BufferOutSize, NET_BUF_TAIL);
+
+  if (PacketOut == NULL) {
+    FreePool (BufferOut);
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  DataOut = NetbufAllocSpace (PacketOut, (UINT32)BufferOutSize, NET_BUF_TAIL);
   if (DataOut == NULL) {
     FreePool (BufferOut);
     return EFI_OUT_OF_RESOURCES;
@@ -1336,7 +1341,13 @@ TlsConnectSession (
       // Transmit the response packet.
       //
       PacketOut = NetbufAlloc ((UINT32)BufferOutSize);
-      DataOut   = NetbufAllocSpace (PacketOut, (UINT32)BufferOutSize, NET_BUF_TAIL);
+
+      if (PacketOut == NULL) {
+        FreePool (BufferOut);
+        return EFI_OUT_OF_RESOURCES;
+      }
+
+      DataOut = NetbufAllocSpace (PacketOut, (UINT32)BufferOutSize, NET_BUF_TAIL);
       if (DataOut == NULL) {
         FreePool (BufferOut);
         return EFI_OUT_OF_RESOURCES;
@@ -1493,7 +1504,13 @@ TlsCloseSession (
   }
 
   PacketOut = NetbufAlloc ((UINT32)BufferOutSize);
-  DataOut   = NetbufAllocSpace (PacketOut, (UINT32)BufferOutSize, NET_BUF_TAIL);
+
+  if (PacketOut == NULL) {
+    FreePool (BufferOut);
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  DataOut = NetbufAllocSpace (PacketOut, (UINT32)BufferOutSize, NET_BUF_TAIL);
   if (DataOut == NULL) {
     FreePool (BufferOut);
     return EFI_OUT_OF_RESOURCES;
@@ -1781,7 +1798,13 @@ HttpsReceive (
 
         if (BufferOutSize != 0) {
           PacketOut = NetbufAlloc ((UINT32)BufferOutSize);
-          DataOut   = NetbufAllocSpace (PacketOut, (UINT32)BufferOutSize, NET_BUF_TAIL);
+
+          if (PacketOut == NULL) {
+            FreePool (BufferOut);
+            return EFI_OUT_OF_RESOURCES;
+          }
+
+          DataOut = NetbufAllocSpace (PacketOut, (UINT32)BufferOutSize, NET_BUF_TAIL);
           if (DataOut == NULL) {
             FreePool (BufferOut);
             return EFI_OUT_OF_RESOURCES;
@@ -1873,7 +1896,13 @@ HttpsReceive (
 
     if (BufferOutSize != 0) {
       PacketOut = NetbufAlloc ((UINT32)BufferOutSize);
-      DataOut   = NetbufAllocSpace (PacketOut, (UINT32)BufferOutSize, NET_BUF_TAIL);
+
+      if (PacketOut == NULL) {
+        FreePool (BufferOut);
+        return EFI_OUT_OF_RESOURCES;
+      }
+
+      DataOut = NetbufAllocSpace (PacketOut, (UINT32)BufferOutSize, NET_BUF_TAIL);
       if (DataOut == NULL) {
         FreePool (BufferOut);
         return EFI_OUT_OF_RESOURCES;


### PR DESCRIPTION

# Description
1.HttpResponseWorker(DEADCODE)
The result of pointer arithmetic "HttpHeaders+AsciiStrLen("HTTP/1.1") + 1" is never null.
2.HttpsSupport.c (NULL_RETURNS)
NetbufAlloc might return null pointer ,so assigning "NULL" to "PacketOut" and "DataOut" pointer.

Solution:
1.Removed the NULL Check for "StatusCodeStr"
2.Added Null Check for PacketOut and returned EFI_OUT_OF_RESOURCES on NULL case.