### PR TITLE
MdePkg/BasePeCoffLib: Fix use of uninitialized var after SafeIntLib fix

### DIFF
--- a/MdePkg/Library/BasePeCoffLib/BasePeCoff.c
+++ b/MdePkg/Library/BasePeCoffLib/BasePeCoff.c
@@ -1056,6 +1056,7 @@ PeCoffLoaderRelocateImage (
     RelocDir = &Hdr.Te->DataDirectory[0];
   }
 
+  RelocBase = RelocBaseEnd = NULL;
   if ((RelocDir != NULL) && (RelocDir->Size > 0)) {
     Status = SafeUint32Add (RelocDir->VirtualAddress, (RelocDir->Size - 1), &EndAddress);
     if (!RETURN_ERROR (Status)) {
@@ -1072,11 +1073,6 @@ PeCoffLoaderRelocateImage (
       DEBUG ((DEBUG_ERROR, "Relocation block is not valid\n"));
       return RETURN_LOAD_ERROR;
     }
-  } else {
-    //
-    // Set base and end to bypass processing below.
-    //
-    RelocBase = RelocBaseEnd = NULL;
   }
 
   RelocBaseOrg = RelocBase;


### PR DESCRIPTION
SafeIntLib is only safe if it is used correctly, and if it signals an overflow, the error must be handled, rather than limping on and using garbage data from the stack, as this may turn out to be more dangerous than using the overflowed value.

So initialize RelocBase to NULL as it will get tested even in case of overflow, and this will prevent it from being initialized as expected.
