### PR TITLE
MdePkg/BasePeCoffLib: Remove DEBUG() statements from runtime code

### DIFF
--- a/MdePkg/Library/BasePeCoffLib/BasePeCoff.c
+++ b/MdePkg/Library/BasePeCoffLib/BasePeCoff.c
@@ -1845,11 +1845,15 @@ PeCoffLoaderRelocateImageForRuntime (
     }
 
     if ((RelocBase == NULL) || (RelocBaseEnd == NULL) || ((UINTN)RelocBaseEnd < (UINTN)RelocBase)) {
-      DEBUG ((DEBUG_ERROR, "Relocation block is not valid\n"));
+      //
+      // relocation block is not valid, just return
+      //
       return;
     }
   } else {
-    DEBUG ((DEBUG_ERROR, "Cannot find relocations, cannot continue to relocate the image\n"));
+    //
+    // Cannot find relocations, cannot continue to relocate the image, ASSERT for this invalid image.
+    //
     ASSERT (FALSE);
     return;
   }


### PR DESCRIPTION
PeCoffLoaderRelocateImageForRuntime() executes after boot services, and so it should not use DEBUG() prints at all, given that these may rely on MMIO mappings or other boot time facilities that are no longer available.

So revert the changes in aedcaa3df8a2 ("MdePkg: Fix overflow issue in PeCoffLoaderRelocateImageForRuntime") that replaced code comments with DEBUG() statements.
