### PR TITLE
BaseTools/AutoGen: GenMake response file quotes strings

### DIFF
--- a/BaseTools/Source/Python/AutoGen/GenMake.py
+++ b/BaseTools/Source/Python/AutoGen/GenMake.py
@@ -899,9 +899,20 @@ cleanlib:
                                 break
 
                         if self._AutoGenObject.ToolChainFamily == 'GCC':
-                            RespDict[Key] = Value.replace('\\', '/')
-                        else:
-                            RespDict[Key] = Value
+                            #
+                            # Replace '\' with '/' in the response file.
+                            # Skip content within "" or \"\"
+                            #
+                            ValueList = re.split(r'("|\\"|\s+)', Value)
+                            Skip = False
+                            for i, v in enumerate(ValueList):
+                                if v in ('"', '\\"'):
+                                    Skip = not Skip
+                                elif not Skip:
+                                    ValueList[i] = v.replace('\\', '/')
+                            Value = ''.join(ValueList)
+                        RespDict[Key] = Value
+
                         for Target in BuildTargets:
                             for i, SingleCommand in enumerate(BuildTargets[Target].Commands):
                                 if FlagDict[Flag]['Macro'] in SingleCommand:


### PR DESCRIPTION
# Description

If command line options are moved into a response file of a GCC family build, then the file path separators are converted from '\\' to '/'. However, this can corrupt command line options that are quoted strings.

Update GenMake to no convert '\\' to '/' in quoted strings.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

Added CC_FLAGS to EmulatorPkg build to increase line length to force response file generation and added additional command line parameters with various file paths and quoted strings:

| Input | Before Change | Correct | After Change |
| ----- | -------|  ------ | ------ | 
| "Hello" | "Hello" | YES | "Hello" |
| L\\"Hello\\" | L/"Hello/" | NO | L\\"Hello\\" |
| "a/b/c/d" | "a/b/c/d" | YES | "a/b/c/d" |
| "a\b\c\d" | "a/b/c/d" | NO | "a\b\c\d" |
| L\\"a/b/c/d\\" | L/"a/b/c/d/" | NO | L\\"a/b/c/d\\" |
| L\\"a\b\c\d\\" | L/"a/b/c/d/" | NO | L\\"a\b\c\d\\" |
| a/b/c/d | a/b/c/d | YES | a/b/c/d |
| a\b\c\d | a/b/c/d | YES | a/b/c/d |

## Integration Instructions

N/A
