### PR TITLE
ArmVirtPkg: turn off debug logging for VirtioSerialDxe

### DIFF
--- a/ArmVirtPkg/ArmVirtQemu.dsc
+++ b/ArmVirtPkg/ArmVirtQemu.dsc
@@ -450,7 +450,10 @@
   OvmfPkg/VirtioScsiDxe/VirtioScsi.inf
   OvmfPkg/VirtioNetDxe/VirtioNet.inf
   OvmfPkg/VirtioRngDxe/VirtioRng.inf
-  OvmfPkg/VirtioSerialDxe/VirtioSerial.inf
+  OvmfPkg/VirtioSerialDxe/VirtioSerial.inf {
+    <PcdsFixedAtBuild>
+      gEfiMdePkgTokenSpaceGuid.PcdDebugPrintErrorLevel|0
+  }
   OvmfPkg/VirtioKeyboardDxe/VirtioKeyboard.inf
 
   #


### PR DESCRIPTION
When running the verbose builds on arm for development and testing
it is quite convenient to use virtio serial to interact with the
system because console and logging are separated then.  Except that
the virtio serial driver spams the debug log in that case.  Set the
debug level for the driver to zero to avoid that.

Signed-off-by: Gerd Hoffmann <kraxel@redhat.com>
