### PR TITLE
MdeModulePkg/Bus/Pci: Add a PCI to control removal of devices

### DIFF
--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciBusDxe.inf
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciBusDxe.inf
@@ -107,6 +107,7 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdMrIovSupport                ## CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdPciDisableBusEnumeration    ## SOMETIMES_CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdPcieResizableBarSupport     ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdRemoveRejectedDevices       ## CONSUMES
 
 [UserExtensions.TianoCore."ExtraFiles"]
   PciBusDxeExtra.uni

--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciEnumeratorSupport.c
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciEnumeratorSupport.c
@@ -2585,7 +2585,9 @@ PciEnumeratorLight (
       //
       // Remove those PCI devices which are rejected when full enumeration
       //
-      RemoveRejectedPciDevices (RootBridgeDev->Handle, RootBridgeDev);
+      if (FixedPcdGetBool (PcdRemoveRejectedDevices)) {
+        RemoveRejectedPciDevices (RootBridgeDev->Handle, RootBridgeDev);
+      }
 
       //
       // Process option rom light

--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -2278,6 +2278,10 @@
   # @Prompt The value is use for Usb Network rate limiting supported.
   gEfiMdeModulePkgTokenSpaceGuid.PcdUsbNetworkRateLimitingFactor|100|UINT32|0x10000028
 
+  ## Remove PCI devices that are deemed invalid.
+  # @Prompt The value will determine whether devices are removed or not.
+  gEfiMdeModulePkgTokenSpaceGuid.PcdRemoveRejectedDevices|FALSE|BOOLEAN|0x10000029
+
 [PcdsPatchableInModule]
   ## Specify memory size with page number for PEI code when
   #  Loading Module at Fixed Address feature is enabled.

--- a/MdeModulePkg/MdeModulePkg.uni
+++ b/MdeModulePkg/MdeModulePkg.uni
@@ -1361,6 +1361,8 @@
 
 #string STR_gEfiMdeModulePkgTokenSpaceGuid_PcdPcieResizableBarSupport_PROMPT #language en-US "Enable PCIe Resizable BAR Capability Supported"
 
+#string STR_gEfiMdeModulePkgTokenSpaceGuid.PcdRemoveRejectedDevices_PROMPT "Don't remove PCI devices due to all read-write bits set."
+
 #string STR_gEfiMdeModulePkgTokenSpaceGuid_PcdPcieResizableBarSupport_HELP #language en-US "Indicates if the PCIe Resizable BAR Capability Supported.<BR><BR>\n"
                                                                                             "TRUE  - PCIe Resizable BAR Capability is supported.<BR>\n"
                                                                                             "FALSE - PCIe Resizable BAR Capability is not supported.<BR>"


### PR DESCRIPTION
edk2 will remove devices that have all read-write bits set, believing they are invalid. This is not the case with bootloaders such as coreboot.

Add a Pcd to control this, defaulting to true to not change the existing behavour, but allow these bootloaders to work as intended.

