### PR TITLE
License-History.txt: Reflect bugzilla migration

### DIFF
--- a/License-History.txt
+++ b/License-History.txt
@@ -31,8 +31,8 @@ Key Dates
   Proposals (RFCs):
       https://lists.01.org/pipermail/edk2-devel/2017-March/008654.html
 
-  TianoCore Bugzilla:
-      https://bugzilla.tianocore.org/show_bug.cgi?id=629
+  GitHub Issue:
+      https://github.com/tianocore/edk2/issues/7056
 
 * April 9, 2019
 
@@ -49,8 +49,8 @@ Key Dates
       https://lists.01.org/pipermail/edk2-devel/2019-February/036260.html
       https://lists.01.org/pipermail/edk2-devel/2019-March/037500.html
 
-  TianoCore Bugzilla:
-      https://bugzilla.tianocore.org/show_bug.cgi?id=1373
+  GitHub Issue:
+      https://github.com/tianocore/edk2/issues/7666
 
 --------------------------------------------------------------------------------
 License.txt: BSD 2-Clause License


### PR DESCRIPTION
# Description

Update BZ links to corresponding GitHub issues links now that the BZ -> GitHub issue migration is complete.