### PR TITLE
UefiPayloadPkg: UefiPayloadEntry: Don't use reserved DRAM for EfiBootServices

### DIFF
--- a/UefiPayloadPkg/Library/CbParseLib/CbParseLib.c
+++ b/UefiPayloadPkg/Library/CbParseLib/CbParseLib.c
@@ -400,15 +400,6 @@ ParseMemoryInfo (
     MemoryMap.Size = cb_unpack64 (Range->size);
     MemoryMap.Type = (UINT8)Range->type;
     MemoryMap.Flag = 0;
-    DEBUG ((
-      DEBUG_INFO,
-      "%d. %016lx - %016lx [%02x]\n",
-      Index,
-      MemoryMap.Base,
-      MemoryMap.Base + MemoryMap.Size - 1,
-      MemoryMap.Type
-      ));
-
     MemInfoCallback (&MemoryMap, Params);
   }
 


### PR DESCRIPTION
# Description

Recent AMD platforms reserve parts of the lower DRAM where UefiPayload is being loaded to and since UefiPayloadEntry doesn't care, it uses the reserved memory for HOB and memory allocation.

The bootloader cannot prevent this, as it can only place the UEFI FV in usable DRAM, but it has no control over EfiBootService memory allocations.

This issue prevents boot on those platforms without any specific error message. It's not vendor specific and can happen on every platform.

Add the same logic as used on UniversalPayload and do the following:
- Walk bootloader provided memory information
- Skip everything that's not marked as usable DRAM
- Align entries to 1MiB boundary
- Don't use memory above 4GiB on x86_32
- Skip memory ranges too small
- Don't use memory currently occupied by the UEFI FV itself

Once a useable memory range is found pass it to HobConstructor().

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Booted on AMD/glinda, that reserved memory at 2000000h.

## Integration Instructions

N/A
