### PR TITLE
MdeModulePkg/UefiBootManagerLib: Apply var policy to HDDP

### DIFF
--- a/MdeModulePkg/Library/UefiBootManagerLib/BmLoadOption.c
+++ b/MdeModulePkg/Library/UefiBootManagerLib/BmLoadOption.c
@@ -9,8 +9,6 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #include "InternalBm.h"
 
-#include <Library/VariablePolicyHelperLib.h>
-
 GLOBAL_REMOVE_IF_UNREFERENCED
 CHAR16  *mBmLoadOptionName[] = {
   L"Driver",

--- a/MdeModulePkg/Library/UefiBootManagerLib/InternalBm.h
+++ b/MdeModulePkg/Library/UefiBootManagerLib/InternalBm.h
@@ -44,6 +44,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Protocol/RamDisk.h>
 #include <Protocol/DeferredImageLoad.h>
 #include <Protocol/PlatformBootManager.h>
+#include <Protocol/VariablePolicy.h>
 
 #include <Guid/MemoryTypeInformation.h>
 #include <Guid/FileInfo.h>
@@ -71,6 +72,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/CapsuleLib.h>
 #include <Library/PerformanceLib.h>
 #include <Library/HiiLib.h>
+#include <Library/VariablePolicyHelperLib.h>
 
 #if !defined (EFI_REMOVABLE_MEDIA_FILE_NAME)
   #if defined (MDE_CPU_EBC)

--- a/MdeModulePkg/Library/UefiBootManagerLib/UefiBootManagerLib.inf
+++ b/MdeModulePkg/Library/UefiBootManagerLib/UefiBootManagerLib.inf
@@ -101,7 +101,7 @@
   gEfiDevicePathProtocolGuid                    ## SOMETIMES_CONSUMES
   gEfiBootLogoProtocolGuid                      ## SOMETIMES_CONSUMES
   gEfiSimpleTextInputExProtocolGuid             ## SOMETIMES_CONSUMES
-  gEdkiiVariablePolicyProtocolGuid              ## SOMETIMES_CONSUMES
+  gEdkiiVariablePolicyProtocolGuid              ## SOMETIMES_CONSUMES ## NOTIFY
   gEfiGraphicsOutputProtocolGuid                ## SOMETIMES_CONSUMES
   gEfiUsbIoProtocolGuid                         ## SOMETIMES_CONSUMES
   gEfiNvmExpressPassThruProtocolGuid            ## SOMETIMES_CONSUMES


### PR DESCRIPTION
# Description

Applies variable policy to the "HDDP" UEFI variable in the mBmHardDriveBootVariableGuid vendor namespace to ensure a minimum allowed size and expected attributes are present.

A protocol notify is used to handle different platform scenarios where this instance of UefiBootManagerLib may be linked.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

- Verified `"HDDP"` policy is registered as requested.
- Verified the protocol notify function is invoked if the variable policy protocol is installed.
- Verified the notify gracefully handles the case when policy is already applied to the variable.

## Integration Instructions

This applies a variable policy so that the variable is set as expected in current implementation. No further work should be necessary if the current implementation is used.