### PR TITLE
UefiPayloadPkg: Add StackCheckLib to fix FIT build issue

### DIFF
--- a/UefiPayloadPkg/UefiPayloadEntry/FitUniversalPayloadEntry.inf
+++ b/UefiPayloadPkg/UefiPayloadEntry/FitUniversalPayloadEntry.inf
@@ -61,6 +61,7 @@
   HobPrintLib
   CustomFdtNodeParserLib
   PcdLib
+  StackCheckLib
 
 [Guids]
   gEfiMemoryTypeInformationGuid


### PR DESCRIPTION
Commit efbf5ed moves StackCheckLibStaticInit to StackCheckLib, and each SEC module has a dependency on StatckCheckLib now.

Add StatckCheckLib in FitUniversalPayloadEntry.inf to fix build issue.
