### PR TITLE
UefipayloadPkg/PlatformBootManager: Clear text from screen once timeo…

### DIFF
--- a/MdeModulePkg/Universal/BdsDxe/BdsEntry.c
+++ b/MdeModulePkg/Universal/BdsDxe/BdsEntry.c
@@ -332,6 +332,7 @@ BdsWait (
     if (HotkeyTriggered != NULL) {
       Status = BdsWaitForSingleEvent (HotkeyTriggered, EFI_TIMER_PERIOD_SECONDS (1));
       if (!EFI_ERROR (Status)) {
+        TimeoutRemain = 0;
         break;
       }
     } else {

--- a/UefiPayloadPkg/Library/PlatformBootManagerLib/PlatformBootManager.c
+++ b/UefiPayloadPkg/Library/PlatformBootManagerLib/PlatformBootManager.c
@@ -344,6 +344,11 @@ PlatformBootManagerWaitCallback (
   UINT16  TimeoutRemain
   )
 {
+  /* Clear text from screen once timeout expires */
+  if (TimeoutRemain == 0) {
+    gST->ConOut->ClearScreen (gST->ConOut);
+    BootLogoEnableLogo ();
+  }
   return;
 }
 


### PR DESCRIPTION
…ut expires

Clear text once key press tiemout expires in preparation to boot the default boot option.

