### PR TITLE
NetworkPkg: Resolved Coverity Issues in DHCP4Dxe and DHCP6Dxe

### DIFF
--- a/NetworkPkg/Dhcp4Dxe/Dhcp4Io.c
+++ b/NetworkPkg/Dhcp4Dxe/Dhcp4Io.c
@@ -521,7 +521,10 @@ DhcpChooseOffer (
   DhcpSb->Selected  = Selected;
   DhcpSb->LastOffer = NULL;
   DhcpSb->Para      = NULL;
-  DhcpValidateOptions (Selected, &DhcpSb->Para);
+  Status            = DhcpValidateOptions (Selected, &DhcpSb->Para);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
 
   //
   // A bootp offer has been selected, save the lease status,
@@ -1226,7 +1229,9 @@ DhcpSendMessage (
     }
   } else if (Type == DHCP_MSG_DECLINE) {
     ASSERT (SeedHead != NULL);
-    IpAddr = EFI_IP4 (SeedHead->YourAddr);
+    if (SeedHead != NULL) {
+      IpAddr = EFI_IP4 (SeedHead->YourAddr);
+    }
   }
 
   if (IpAddr != 0) {

--- a/NetworkPkg/Dhcp4Dxe/Dhcp4Option.c
+++ b/NetworkPkg/Dhcp4Dxe/Dhcp4Option.c
@@ -184,6 +184,9 @@ DhcpOptionIsValid (
   }
 
   ASSERT (Unit != 0);
+  if (Unit == 0) {
+    return FALSE;
+  }
 
   //
   // Validate that the option appears in the full units.

--- a/NetworkPkg/Dhcp6Dxe/Dhcp6Io.c
+++ b/NetworkPkg/Dhcp6Dxe/Dhcp6Io.c
@@ -2886,7 +2886,7 @@ ON_CONTINUE:
              0
              );
 ON_EXIT:
-  if (EFI_ERROR (Status)) {
+  if (EFI_ERROR (Status) && (Instance->Config != NULL)) {
     Dhcp6CleanupSession (Instance, Status);
   }
 }
@@ -3302,7 +3302,11 @@ Dhcp6OnTimerTick (
       //
       // Retransmit the last sent packet again.
       //
-      Dhcp6TransmitPacket (Instance, TxCb->TxPacket, TxCb->Elapsed);
+      Status = Dhcp6TransmitPacket (Instance, TxCb->TxPacket, TxCb->Elapsed);
+      if (EFI_ERROR (Status)) {
+        return;
+      }
+
       TxCb->SolicitRetry = FALSE;
       if (TxCb->TxPacket->Dhcp6.Header.MessageType == Dhcp6MsgSolicit) {
         TxCb->SolicitRetry = TRUE;


### PR DESCRIPTION
# Description

1.DhcpChooseOffer(CHECKED_RETURN)
Calling "DhcpValidateOptions" without checking return value as is done elsewhere 6 out of 7 times. 2.DhcpSendMessage(FORWARD_NULL)
SeedHead can be dereferencing the null pointer when Seed is NULL. 3.Dhcp6GetMappingTimeOut(OVERFLOW_BEFORE_WIDEN)
Potentially overflowing expression "10000000U * DadXmits.DupAddrDetectTransmits" with type "unsigned int"(32 bits) 4.Dhcp6DepriveAddress(INTEGER_OVERFLOW)
Expression "AddressCount - 1U", where "AddressCount" is known to be equal to 0, underflows the type that receives it. 5.Dhcp6CalculateLeaseTime(INTEGER_OVERFLOW)
When IaCb->Ia->IaAddressCount is less than 0 ,Expression "MinLt * 8U", overflows the type that receives it


