### PR TITLE
NetworkPkg:Resolved Coverity Issues in UefiPxeBcDxe

### DIFF
--- a/NetworkPkg/UefiPxeBcDxe/PxeBcDhcp4.c
+++ b/NetworkPkg/UefiPxeBcDxe/PxeBcDhcp4.c
@@ -1025,8 +1025,13 @@ PxeBcHandleDhcp4Offer (
   EFI_PXE_BASE_CODE_MODE    *Mode;
   EFI_DHCP4_PACKET          *Ack;
 
+  SelectIndex = 0;
+
   ASSERT (Private->SelectIndex > 0);
-  SelectIndex = (UINT32)(Private->SelectIndex - 1);
+  if (Private->SelectIndex > 0) {
+    SelectIndex = (UINT32)(Private->SelectIndex - 1);
+  }
+
   ASSERT (SelectIndex < PXEBC_OFFER_MAX_NUM);
   Cache4  = &Private->OfferBuffer[SelectIndex].Dhcp4;
   Options = Cache4->OptList;
@@ -1250,15 +1255,6 @@ PxeBcDhcp4CallBack (
       //
       CopyMem (&Mode->DhcpDiscover.Dhcpv4, &Packet->Dhcp4, Packet->Length);
 
-    case Dhcp4SendRequest:
-      if (Packet->Length > PXEBC_DHCP4_PACKET_MAX_SIZE) {
-        //
-        // If the to be sent packet exceeds the maximum length, abort the DHCP process.
-        //
-        Status = EFI_ABORTED;
-        break;
-      }
-
       if (Mode->SendGUID) {
         //
         // Send the system Guid instead of the MAC address as the hardware address if required.
@@ -1460,6 +1456,10 @@ PxeBcDhcp4Discover (
 
   if (EFI_ERROR (Status)) {
     return Status;
+  }
+
+  if (Token.Packet == NULL) {
+    return EFI_NOT_FOUND;
   }
 
   if (Mode->SendGUID) {

--- a/NetworkPkg/UefiPxeBcDxe/PxeBcDhcp6.c
+++ b/NetworkPkg/UefiPxeBcDxe/PxeBcDhcp6.c
@@ -1423,9 +1423,14 @@ PxeBcHandleDhcp6Offer (
   UINT32                    SelectIndex;
   UINT32                    Index;
 
+  SelectIndex = 0;
+
   ASSERT (Private != NULL);
   ASSERT (Private->SelectIndex > 0);
-  SelectIndex = (UINT32)(Private->SelectIndex - 1);
+  if (Private->SelectIndex > 0) {
+    SelectIndex = (UINT32)(Private->SelectIndex - 1);
+  }
+
   ASSERT (SelectIndex < PXEBC_OFFER_MAX_NUM);
   Cache6 = &Private->OfferBuffer[SelectIndex].Dhcp6;
   Status = EFI_SUCCESS;
@@ -2436,7 +2441,7 @@ PxeBcDhcp6Sarr (
       return Status;
     }
 
-    GetMappingTimeOut = TICKS_PER_SECOND * DadXmits.DupAddrDetectTransmits + PXEBC_DAD_ADDITIONAL_DELAY;
+    GetMappingTimeOut = TICKS_PER_SECOND * (UINT64)DadXmits.DupAddrDetectTransmits + PXEBC_DAD_ADDITIONAL_DELAY;
     Status            = gBS->SetTimer (Timer, TimerRelative, GetMappingTimeOut);
     if (EFI_ERROR (Status)) {
       gBS->CloseEvent (Timer);

--- a/NetworkPkg/UefiPxeBcDxe/PxeBcDriver.c
+++ b/NetworkPkg/UefiPxeBcDxe/PxeBcDriver.c
@@ -110,6 +110,9 @@ PxeBcDestroyIp4Children (
   )
 {
   ASSERT (Private != NULL);
+  if (Private == NULL) {
+    return;
+  }
 
   if (Private->ArpChild != NULL) {
     //
@@ -294,6 +297,9 @@ PxeBcDestroyIp6Children (
   )
 {
   ASSERT (Private != NULL);
+  if (Private == NULL) {
+    return;
+  }
 
   if (Private->Ip6Child != NULL) {
     //
@@ -565,6 +571,10 @@ PxeBcCreateIp4Children (
   EFI_IP4_MODE_DATA            Ip4ModeData;
   PXEBC_PRIVATE_PROTOCOL       *Id;
   EFI_SIMPLE_NETWORK_PROTOCOL  *Snp;
+
+  if (Private == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
 
   if (Private->Ip4Nic != NULL) {
     //


### PR DESCRIPTION
# Description

1.PxeBcHandleDhcp4Offer
        Expression "Private->SelectIndex - 1", where "Private->SelectIndex" is known to be equal to 0, underflows the type that receives it. 

2.PxeBcDhcp4Discover
          Directly dereferencing pointer "Token.Packet" which might have NULL , As Token.Packet is checked against NULL in the function Exit line no 1587. 

3.PxeBcHandleDhcp6Offer
            Expression "Private->SelectIndex - 1", where "Private->SelectIndex" is known to be equal to 0,underflows the type that receives it.

 4.PxeBcDhcp6Sarr
            Potentially overflowing expression "10000000U*DadXmits.DupAddrDetectTransmits" with type "unsigned int" (32 bits, unsigned)

5.PxeBcDriver.c
          Private Data might be dereferencing the NULL pointer in some scenario, And also private is checked against null in function's Exit. For Example: below code checked private with NULL pointer in PxeBcStart()
  if (FirstStart && Private != NULL) {
            FreePool (Private):

6.PxeBcDhcp4CallBack:
             case Dhcp4SendRequest is not reachable ,because PxeBcDhcp4CallBack returned in the beginning if Dhcp4Event is Dhcp4SendRequest.

