### PR TITLE
NetworkPkg:Resolved Coverity Issues reported in SNP Dxe.

### DIFF
--- a/NetworkPkg/SnpDxe/ComponentName.c
+++ b/NetworkPkg/SnpDxe/ComponentName.c
@@ -267,7 +267,12 @@ UpdateName (
   //
   // Remove the last '-'
   //
-  OffSet--;
+  if (OffSet > 0) {
+    OffSet--;
+  } else {
+    OffSet = 0;
+  }
+
   OffSet += UnicodeSPrint (
               HandleName + OffSet,
               sizeof (HandleName) - OffSet * sizeof (CHAR16),

--- a/NetworkPkg/SnpDxe/Get_status.c
+++ b/NetworkPkg/SnpDxe/Get_status.c
@@ -216,10 +216,6 @@ SnpUndi32GetStatus (
 
   Snp = EFI_SIMPLE_NETWORK_DEV_FROM_THIS (This);
 
-  if (Snp == NULL) {
-    return EFI_DEVICE_ERROR;
-  }
-
   OldTpl = gBS->RaiseTPL (TPL_CALLBACK);
 
   switch (Snp->Mode.State) {

--- a/NetworkPkg/SnpDxe/Initialize.c
+++ b/NetworkPkg/SnpDxe/Initialize.c
@@ -128,11 +128,13 @@ PxeInit (
       );
 
     if (Snp->TxRxBuffer != NULL) {
-      Snp->PciIo->FreeBuffer (
-                    Snp->PciIo,
-                    SNP_MEM_PAGES (Snp->TxRxBufferSize),
-                    (VOID *)Snp->TxRxBuffer
-                    );
+      if (Snp->TxRxBufferSize != 0) {
+        Snp->PciIo->FreeBuffer (
+                      Snp->PciIo,
+                      SNP_MEM_PAGES (Snp->TxRxBufferSize),
+                      (VOID *)Snp->TxRxBuffer
+                      );
+      }
     }
 
     Snp->TxRxBuffer = NULL;
@@ -195,11 +197,6 @@ SnpUndi32Initialize (
   Snp = EFI_SIMPLE_NETWORK_DEV_FROM_THIS (This);
 
   OldTpl = gBS->RaiseTPL (TPL_CALLBACK);
-
-  if (Snp == NULL) {
-    EfiStatus = EFI_INVALID_PARAMETER;
-    goto ON_EXIT;
-  }
 
   switch (Snp->Mode.State) {
     case EfiSimpleNetworkStarted:

--- a/NetworkPkg/SnpDxe/Transmit.c
+++ b/NetworkPkg/SnpDxe/Transmit.c
@@ -287,10 +287,6 @@ SnpUndi32Transmit (
 
   Snp = EFI_SIMPLE_NETWORK_DEV_FROM_THIS (This);
 
-  if (Snp == NULL) {
-    return EFI_DEVICE_ERROR;
-  }
-
   OldTpl = gBS->RaiseTPL (TPL_CALLBACK);
 
   switch (Snp->Mode.State) {


### PR DESCRIPTION
# Description
1.ComponentName.c (Overflow)
               Expression "OffSet--", which is equal to 18446744073709551615, where "OffSet" is known to be equal to 0, underflows the type that receives it.

2.SnpUndi32GetStatus,SnpUndi32Initialize,SnpUndi32Transmit (Deadcode)
               Execution is not reaching as always snp is not equal to NULL As This pointer is compared with NULL in function start Macro EFI_SIMPLE_NETWORK_DEV_FROM_THIS always return address in This pointer.

3.PxeInit(Overflow)
             Expression "Snp->TxRxBufferSize - 1U", where "Snp->TxRxBufferSize" is known to be equal to 0, underflows the type that receives it.
