### PR TITLE
BaseTools: Enable GenFv Rebase function

### DIFF
--- a/BaseTools/Source/C/GenFv/GenFv.c
+++ b/BaseTools/Source/C/GenFv/GenFv.c
@@ -586,6 +586,13 @@ Returns:
     }
   }
 
+  if (InfFileName != NULL) {
+    Status = ReadXipFile (InfFileName);
+    if (EFI_ERROR (Status)) {
+      return STATUS_WARNING;
+    }
+  }
+
   if (DumpCapsule) {
     VerboseMsg ("Dump the capsule header information for the input capsule image %s", InfFileName);
     //

--- a/BaseTools/Source/C/GenFv/GenFvInternalLib.h
+++ b/BaseTools/Source/C/GenFv/GenFvInternalLib.h
@@ -186,6 +186,18 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 //
 // Private data types
 //
+typedef struct {
+    CHAR8     ModuleName[64];
+    BOOLEAN   XipEnabled;
+} MODULE_XIP_INFO;
+
+#define MAX_MODULES_TYPE      0x20
+#define MAX_XIP_LINE_LENGTH   0x20
+
+typedef struct {
+    CHAR8 FvFilePath[MAX_LONG_FILE_PATH];
+    CHAR8 ModuleType[64];
+} FILE_MODULE_TYPE;
 //
 // Component information
 //
@@ -397,6 +409,31 @@ Returns:
   EFI_INVALID_PARAMETER   A required parameter was NULL.
 
 --*/
+;
+
+EFI_STATUS
+ReadXipFile (
+  IN CONST CHAR8  *FilePath
+  )
+;
+
+BOOLEAN
+IsModuleTypeRecorded (
+  IN CONST CHAR8  *FilePath
+  )
+;
+
+VOID
+StoreModuleType (
+  IN CONST CHAR8  *FilePath
+  )
+;
+
+
+CONST CHAR8 *
+GetFileModuleType (
+  IN CONST CHAR8  *FilePath
+  )
 ;
 
 #endif

--- a/BaseTools/Source/Python/AutoGen/GenMake.py
+++ b/BaseTools/Source/Python/AutoGen/GenMake.py
@@ -348,19 +348,19 @@ all: mbuild
 # Target used when called from platform makefile, which will bypass the build of dependent libraries
 #
 
-pbuild: $(INIT_TARGET) $(BC_TARGET) $(PCH_TARGET) $(CODA_TARGET)
+pbuild: $(INIT_TARGET) $(BC_TARGET) $(PCH_TARGET) $(CODA_TARGET) write_module_type
 
 #
 # ModuleTarget
 #
 
-mbuild: $(INIT_TARGET) $(BC_TARGET) gen_libs $(PCH_TARGET) $(CODA_TARGET)
+mbuild: $(INIT_TARGET) $(BC_TARGET) gen_libs $(PCH_TARGET) $(CODA_TARGET) write_module_type
 
 #
 # Build Target used in multi-thread build mode, which will bypass the init and gen_libs targets
 #
 
-tbuild: $(BC_TARGET) $(PCH_TARGET) $(CODA_TARGET)
+tbuild: $(BC_TARGET) $(PCH_TARGET) $(CODA_TARGET) write_module_type
 
 #
 # Phony target which is used to force executing commands for a target
@@ -394,6 +394,11 @@ strdefs:
 gen_libs:
 \t${BEGIN}@"$(MAKE)" $(MAKE_FLAGS) -f ${dependent_library_build_directory}${separator}${makefile_name}
 \t${END}@cd $(MODULE_BUILD_DIR)
+
+write_module_type:
+\t-@${create_ffs_output_directory}
+\t-@echo $(MODULE_TYPE) > $(FFS_OUTPUT_DIR)${separator}Module_Type
+\t-@echo "MODULE_TYPE has been written to $(FFS_OUTPUT_DIR)\Module_Type"
 
 #
 # Build Flash Device Image
@@ -711,6 +716,7 @@ cleanlib:
             "clean_command"             : self.GetRemoveDirectoryCommand(["$(OUTPUT_DIR)"]),
             "cleanall_command"          : self.GetRemoveDirectoryCommand(["$(DEBUG_DIR)", "$(OUTPUT_DIR)"]),
             "dependent_library_build_directory" : self.LibraryBuildDirectoryList,
+            "create_ffs_output_directory": self.GetCreateDirectoryCommand(["$(FFS_OUTPUT_DIR)"]),
             "library_build_command"     : LibraryMakeCommandList,
             "file_macro"                : FileMacroList,
             "file_build_target"         : self.BuildTargetList,

--- a/BaseTools/Source/Python/AutoGen/WorkspaceAutoGen.py
+++ b/BaseTools/Source/Python/AutoGen/WorkspaceAutoGen.py
@@ -182,6 +182,7 @@ class WorkspaceAutoGen(AutoGen):
         if self.FdfFile:
             Fdf = FdfParser(self.FdfFile.Path)
             Fdf.ParseFile()
+            Fdf.AddXipInfoIntoJson(os.path.join(self.Platform.OutputDirectory, self.Platform._Target + "_" + self.Platform._Toolchain, 'FV', 'Module_Xip'), Fdf._XipDict)
             GlobalData.gFdfParser = Fdf
             if Fdf.CurrentFdName and Fdf.CurrentFdName in Fdf.Profile.FdDict:
                 FdDict = Fdf.Profile.FdDict[Fdf.CurrentFdName]

--- a/BaseTools/Source/Python/CommonDataClass/FdfClass.py
+++ b/BaseTools/Source/Python/CommonDataClass/FdfClass.py
@@ -249,6 +249,7 @@ class RuleClassObject :
         self.FvFileType = None       # for Ffs File Type
         self.KeyStringList = []
         self.KeepReloc = None
+        self.Xip = False
 
 ## Complex rule data in FDF
 #


### PR DESCRIPTION
# Description

This patch is used to enable GenFv Rebase function. 
Developer can add "Xip=TRUE" in FDF file Rule section to enable Rebase feature. After enabling, the enabled type module will be rebased while others' will not.

Rebase behavior:
[1]. If "Xip" is defined in FDF file Rule section, then the target module_type's module will be rebased when consumed by GenFV
(Added from this PR).
[2]. Else if "FvForceRebase" is defined in FDF FV section, then the all modules in this FV will be rebased when consumed by GenFV (designed in Spec).

```
Example:
[Rule.Common.PEI_CORE]
  FILE PEI_CORE = $(NAMED_GUID) {
    PE32     PE32   Align=Auto   Xip=TRUE   $(INF_OUTPUT)/$(MODULE_NAME).efi
    UI       STRING ="$(MODULE_NAME)" Optional
    VERSION  STRING ="$(INF_VERSION)" Optional BUILD_NUM=$(BUILD_NUMBER)
  }
```

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Enabled Rebase function and run the OVMFPKG in both windows and linux environment and boot in QEMU.

## Integration Instructions

No changes needed though code may use the "Xip=TRUE" to enable Rebase function as needed.
