### PR TITLE
MdeModulePkg: Add a check and close BlockIo2 protocol in DiskIoDriverBindingStart.

### DIFF
--- a/MdeModulePkg/Universal/Disk/DiskIoDxe/DiskIo.c
+++ b/MdeModulePkg/Universal/Disk/DiskIoDxe/DiskIo.c
@@ -226,6 +226,15 @@ ErrorExit:
            This->DriverBindingHandle,
            ControllerHandle
            );
+    
+    if (gDiskIoPrivateDataTemplate.BlockIo2 != NULL) {
+      gBS->CloseProtocol (
+             ControllerHandle,
+             &gEfiBlockIoProtocolGuid,
+             This->DriverBindingHandle,
+             ControllerHandle
+             );
+    }
   }
 
 ErrorExit1:


### PR DESCRIPTION
MdeModulePkg: Add a check and close BlockIo2 protocol in DiskIoDriverBindingStart.

REF: https://github.com/tianocore/edk2/issues/10727

The check needs to be added for the BlockIo2 protocol in the ErrorExit, and it should be closed properly if the BlockIo2 protocol is opened.

# Description

During the DiskIoDriverBindingStart, both the BlockIo and BlockIo2 protocols are opened for the specified controller handle. The Instance->SharedWorkingBuffer is then allocated based on the BlockSize. If the BlockSize is zero, indicating that the handle does not support Read/Write operations, the buffer will not be allocated. A NULL check is performed on the SharedWorkingBuffer, and if it is NULL, the process jumps to the ErrorExit. In the ErrorExit section, only the BlockIo protocol is closed, while the BlockIo2 protocol remains open.
