### PR TITLE
NetworkPkg:Resolved Coverity Issues reported in ARPDxe,DnsDxe,HttpBootDxe

### DIFF
--- a/NetworkPkg/ArpDxe/ArpImpl.c
+++ b/NetworkPkg/ArpDxe/ArpImpl.c
@@ -1097,6 +1097,7 @@ ArpSendFrame (
   if (Packet == NULL) {
     DEBUG ((DEBUG_ERROR, "ArpSendFrame: Allocate memory for Packet failed.\n"));
     ASSERT (Packet != NULL);
+    goto CLEAN_EXIT;
   }
 
   TmpPtr = Packet;

--- a/NetworkPkg/DnsDxe/DnsImpl.c
+++ b/NetworkPkg/DnsDxe/DnsImpl.c
@@ -1258,6 +1258,12 @@ ParseDnsResponse (
     }
 
     ASSERT (Item != NULL);
+    if (Item == NULL) {
+      *Completed = FALSE;
+      Status     = EFI_ABORTED;
+      goto ON_EXIT;
+    }
+
     Dns4TokenEntry = (DNS4_TOKEN_ENTRY *)(Item->Key);
   } else {
     if (!IsValidDnsResponse (
@@ -1274,6 +1280,12 @@ ParseDnsResponse (
     }
 
     ASSERT (Item != NULL);
+    if (Item == NULL) {
+      *Completed = FALSE;
+      Status     = EFI_ABORTED;
+      goto ON_EXIT;
+    }
+
     Dns6TokenEntry = (DNS6_TOKEN_ENTRY *)(Item->Key);
   }
 
@@ -1498,6 +1510,10 @@ ParseDnsResponse (
           // This is address entry, get Data.
           //
           ASSERT (Dns4TokenEntry != NULL);
+          if (Dns4TokenEntry == NULL) {
+            Status = EFI_ABORTED;
+            goto ON_EXIT;
+          }
 
           if (AnswerSection->DataLength != 4) {
             Status = EFI_ABORTED;
@@ -1560,6 +1576,10 @@ ParseDnsResponse (
           // This is address entry, get Data.
           //
           ASSERT (Dns6TokenEntry != NULL);
+          if (Dns6TokenEntry == NULL) {
+            Status = EFI_ABORTED;
+            goto ON_EXIT;
+          }
 
           if (AnswerSection->DataLength != 16) {
             Status = EFI_ABORTED;

--- a/NetworkPkg/HttpBootDxe/HttpBootClient.c
+++ b/NetworkPkg/HttpBootDxe/HttpBootClient.c
@@ -197,8 +197,14 @@ HttpBootDhcp4ExtractUriInfo (
   EFI_DHCP4_PACKET_OPTION       *Option;
   EFI_STATUS                    Status;
 
+  SelectIndex = 0;
+
   ASSERT (Private != NULL);
   ASSERT (Private->SelectIndex != 0);
+  if (Private->SelectIndex != 0) {
+    SelectIndex = Private->SelectIndex - 1;
+  }
+
   SelectIndex = Private->SelectIndex - 1;
   ASSERT (SelectIndex < HTTP_BOOT_OFFER_MAX_NUM);
 
@@ -341,8 +347,14 @@ HttpBootDhcp6ExtractUriInfo (
   CHAR16                        *HostNameStr;
   EFI_STATUS                    Status;
 
+  SelectIndex = 0;
+
   ASSERT (Private != NULL);
   ASSERT (Private->SelectIndex != 0);
+  if (Private->SelectIndex != 0) {
+    SelectIndex = Private->SelectIndex - 1;
+  }
+
   SelectIndex = Private->SelectIndex - 1;
   ASSERT (SelectIndex < HTTP_BOOT_OFFER_MAX_NUM);
 
@@ -464,7 +476,7 @@ HttpBootDhcp6ExtractUriInfo (
                Private->BootFileUriParser,
                &HostName
                );
-    if (EFI_ERROR (Status)) {
+    if (EFI_ERROR (Status) || (HostName == NULL)) {
       goto Error;
     }
 

--- a/NetworkPkg/HttpBootDxe/HttpBootDhcp4.c
+++ b/NetworkPkg/HttpBootDxe/HttpBootDhcp4.c
@@ -664,7 +664,9 @@ HttpBootDhcp4CallBack (
       if (Private->SelectIndex == 0) {
         Status = EFI_ABORTED;
       } else {
-        *NewPacket = &Private->OfferBuffer[Private->SelectIndex - 1].Dhcp4.Packet.Offer;
+        if (NewPacket != NULL) {
+          *NewPacket = &Private->OfferBuffer[Private->SelectIndex - 1].Dhcp4.Packet.Offer;
+        }
       }
 
       break;

--- a/NetworkPkg/HttpBootDxe/HttpBootDxe.c
+++ b/NetworkPkg/HttpBootDxe/HttpBootDxe.c
@@ -56,6 +56,9 @@ HttpBootCheckIpv6Support (
   UINTN                             InfoBlockSize;
 
   ASSERT (Private != NULL && Ipv6Support != NULL);
+  if ((Private == NULL) || (Ipv6Support == NULL)) {
+    return EFI_NOT_FOUND;
+  }
 
   //
   // Check whether the UNDI supports IPv6 by NII protocol.


### PR DESCRIPTION
# Description

NetworkPkg:Resolved Coverity Issues reported in ARPDxe,DnsDxe,HttpBootDxe

1.ArpSendFrame (FORWARD_NULL)
Comparing "Packet" to null implies that "Packet" might be null

2.ParseDnsResponse(REVERSE_NULL)
       Directly dereferencing pointer "Item.Null-checking "Item" suggests that it may be null,
but it has already been dereferenced on all paths leading to the check in ON_COMPLETE

3.HttpBootDhcp6ExtractUriInfo:
Dereferencing pointer "HostName" which Null-checking "HostName" in before calling HttpBootDns()  suggests that it may be null

4.HttpBootCheckIpv6Support;
Null-checking "Private" in ON_ERROR in HttpBootIp6DxeDriverBindingStart suggests that it may be null, but it has already been dereferenced on HttpBootCheckIpv6Support HttpBootCheckIpv6Support() argument can be passed with NULL in HttpBootIp6DxeDriverBindingStart()

5.HttpBootDhcp6ExtractUriInfo,HttpBootDhcp4ExtractUriInfo: Expression "Private->SelectIndex-1", which is equal to 18446744073709551615, where "Private->SelectIndex" is known to be equal to 0, underflows the type that receives it.
HttpBootDhcp4CallBack:
Dereferencing pointer "NewPacket" which will be NULL when caller passed as NULL.

