### PR TITLE
MdeModulePkg: address VarCheckHiiLib build failures

### DIFF
--- a/MdeModulePkg/Library/VarCheckHiiLib/VarCheckHiiLibStandaloneMm.c
+++ b/MdeModulePkg/Library/VarCheckHiiLib/VarCheckHiiLibStandaloneMm.c
@@ -57,7 +57,7 @@ VarCheckHiiLibReceiveHiiBinHandler (
   //
   // If input is invalid, stop processing this SMI
   //
-  if ((CommBuffer == NULL) || (CommBufferSize == NULL)) {
+  if ((DispatchHandle == NULL) || (CommBuffer == NULL) || (CommBufferSize == NULL)) {
     return EFI_INVALID_PARAMETER;
   }
 
@@ -75,15 +75,15 @@ VarCheckHiiLibReceiveHiiBinHandler (
   }
 
   CopyMem (mMmReceivedVarCheckHiiBin, CommBuffer, mMmReceivedVarCheckHiiBinSize);
-  if (DispatchHandle != NULL) {
-    Status = gMmst->MmiHandlerUnRegister (DispatchHandle);
-  }
+
+  Status = gMmst->MmiHandlerUnRegister (DispatchHandle);
 
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a: Failed to unregister handler - %r!\n", __func__, Status));
-  } else {
-    DEBUG ((DEBUG_INFO, "%a: Handler unregistered successfully.\n", __func__));
+    return Status;
   }
+
+  DEBUG ((DEBUG_INFO, "%a: Handler unregistered successfully.\n", __func__));
 
   return EFI_SUCCESS;
 }

--- a/MdeModulePkg/Library/VarCheckHiiLib/VarCheckHiiLibStandaloneMm.c
+++ b/MdeModulePkg/Library/VarCheckHiiLib/VarCheckHiiLibStandaloneMm.c
@@ -58,7 +58,7 @@ VarCheckHiiLibReceiveHiiBinHandler (
   // If input is invalid, stop processing this SMI
   //
   if ((CommBuffer == NULL) || (CommBufferSize == NULL)) {
-    return EFI_SUCCESS;
+    return EFI_INVALID_PARAMETER;
   }
 
   mMmReceivedVarCheckHiiBinSize = *CommBufferSize;


### PR DESCRIPTION
While attempting to build MdeModulePkg.dsc for other reasons, I was blocked by a compiler error:
```
/work/git/edk2/MdeModulePkg/Library/VarCheckHiiLib/VarCheckHiiLibStandaloneMm.c:78:7: error: variable 'Status' is used uninitialized whenever 'if' condition is false [-Werror,-Wsometimes-uninitialized]
   78 |   if (DispatchHandle != NULL) {
      |       ^~~~~~~~~~~~~~~~~~~~~~
/work/git/edk2/MdeModulePkg/Library/VarCheckHiiLib/VarCheckHiiLibStandaloneMm.c:82:18: note: uninitialized use occurs here
   82 |   if (EFI_ERROR (Status)) {
      |                  ^~~~~~
```

Then when I looked at the code, I noticed the documented return values are not what the function returns.

I do think there are additional issues with this code; CommBuffer and CommBufferSize are documented as needing to be not-NULL, but are declared as OPTIONAL.