### PR TITLE
MdeModulePkg/HiiDatabaseDxe: Remove efivarstore check for string load…

### DIFF
--- a/MdeModulePkg/Universal/HiiDatabaseDxe/ConfigRouting.c
+++ b/MdeModulePkg/Universal/HiiDatabaseDxe/ConfigRouting.c
@@ -3016,6 +3016,10 @@ ParseIfrData (
           goto Done;
         }
 
+        if (IfrEfiVarStoreTmp == NULL) {
+          break;
+        }
+
         //
         // Set default value base on the DefaultId list get from IFR data.
         //
@@ -3026,11 +3030,6 @@ ParseIfrData (
           if (NvDefaultStoreSize > sizeof (PCD_NV_STORE_DEFAULT_BUFFER_HEADER)) {
             StringData = AllocateZeroPool (VarWidth*2);
             if (StringData == NULL) {
-              Status = EFI_OUT_OF_RESOURCES;
-              goto Done;
-            }
-
-            if (IfrEfiVarStoreTmp == NULL) {
               Status = EFI_OUT_OF_RESOURCES;
               goto Done;
             }


### PR DESCRIPTION
# Description

Remove efivarstore IFR buffer check when string load default. In the case of varstore type IFR, it will be NULL.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

1.	Boot to both VarStore and EfiVarStore type IFR setup pages,
        check string load default function works for EfiVarStore type IFR pages.
2.	Entering every formset , should be load success without ASSERT.

## Integration Instructions

N/A