### PR TITLE
Fix misleading RFC 5970 comment in bootfile-url handling

### DIFF
--- a/NetworkPkg/UefiPxeBcDxe/PxeBcDhcp6.c
+++ b/NetworkPkg/UefiPxeBcDxe/PxeBcDhcp6.c
@@ -415,10 +415,16 @@ PxeBcExtractBootFileUrl (
   //
 
   //
-  // Based upon RFC 5970 and UEFI 2.6, bootfile-url format can be
-  // tftp://[SERVER_ADDRESS]/BOOTFILE_NAME or tftp://domain_name/BOOTFILE_NAME
-  // As an example where the BOOTFILE_NAME is the EFI loader and
-  // SERVER_ADDRESS is the ASCII encoding of an IPV6 address.
+  // According to RFC 5970, the Boot File URL option does not restrict the
+  // download protocol, but only requires a valid URL. Although HTTP is
+  // recommended for network booting, the URL may also follow a TFTP-style
+  // format. This function expects URLs of the form:
+  //     protocol://[SERVER_ADDRESS]/BOOTFILE_NAME  or
+  //     protocol://domain_name/BOOTFILE_NAME
+  // where SERVER_ADDRESS is an ASCII-encoded IPv6 address and BOOTFILE_NAME
+  // typically denotes the EFI loader.
+  //
+  // Note: Currently, only the TFTP protocol is implemented.
   //
   PrefixLen = (UINT16)AsciiStrLen (PXEBC_DHCP6_BOOT_FILE_URL_PREFIX);
 


### PR DESCRIPTION
# Description

Fixes: https://github.com/tianocore/edk2/issues/10742

This change corrects the misleading comment regarding RFC 5970 in the PxeBcDxe
module.

The previous comment incorrectly suggested that the Boot File URL option in RFC 5970 limits the download protocol. While the RFC allows various protocols, the current implementation only supports TFTP.

This patch updates the comment to clarify the current situation.

No functional code changes were made; this is a documentation fix.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  -  No, this is a comment-only change.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - No, this is a documentation fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - No, since it only modifies comments.

## How This Was Tested

The change was reviewed manually to ensure the corrected comment accurately
reflects the intended meaning of RFC 5970.

## Integration Instructions

No special integration steps are required, as this is a documentation fix.