### PR TITLE
MdeModulePkg/TerminalDxe: Support multiple modes for SetMode function

### DIFF
--- a/MdeModulePkg/Universal/Console/TerminalDxe/Terminal.c
+++ b/MdeModulePkg/Universal/Console/TerminalDxe/Terminal.c
@@ -2,6 +2,7 @@
   Produces Simple Text Input Protocol, Simple Text Input Extended Protocol and
   Simple Text Output Protocol upon Serial IO Protocol.
 
+Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.<BR>
 Copyright (c) 2006 - 2019, Intel Corporation. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -114,7 +115,10 @@ TERMINAL_DEV  mTerminalDevTemplate = {
 TERMINAL_CONSOLE_MODE_DATA  mTerminalConsoleModeData[] = {
   { 80,  25 },
   { 80,  50 },
-  { 100, 31 },
+  { 100, 31 },  //  800 x 600
+  { 128, 40 },  // 1024 x 768
+  { 160, 42 },  // 1280 x 800
+  { 240, 56 },  // 1920 x 1080
   //
   // New modes can be added here.
   //

--- a/MdeModulePkg/Universal/Console/TerminalDxe/Terminal.h
+++ b/MdeModulePkg/Universal/Console/TerminalDxe/Terminal.h
@@ -1,6 +1,7 @@
 /** @file
   Header file for Terminal driver.
 
+Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.<BR>
 Copyright (c) 2006 - 2019, Intel Corporation. All rights reserved.<BR>
 Copyright (C) 2016 Silicon Graphics, Inc. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -162,6 +163,8 @@ typedef union {
 #define ROW_OFFSET                 2
 #define COLUMN_OFFSET              5
 #define FW_BACK_OFFSET             2
+#define RESIZE_ROW_OFFSET          4
+#define RESIZE_COLUMN_OFFSET       8
 
 typedef struct {
   UINT16    Unicode;

--- a/MdeModulePkg/Universal/Console/TerminalDxe/TerminalConOut.c
+++ b/MdeModulePkg/Universal/Console/TerminalDxe/TerminalConOut.c
@@ -1,6 +1,7 @@
 /** @file
   Implementation for EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL protocol.
 
+Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.<BR>
 Copyright (c) 2006 - 2018, Intel Corporation. All rights reserved.<BR>
 Copyright (C) 2016 Silicon Graphics, Inc. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -74,6 +75,7 @@ UNICODE_TO_CHAR  UnicodeToPcAnsiOrAscii[] = {
 };
 
 CHAR16  mSetModeString[]           = { ESC, '[', '=', '3', 'h', 0 };
+CHAR16  mSetModeStringResize[]     = { ESC, '[', '8', ';', '0', '0', '0', ';', '0', '0', '0', 't', '0', 0 };
 CHAR16  mSetAttributeString[]      = { ESC, '[', '0', 'm', ESC, '[', '4', '0', 'm', ESC, '[', '4', '0', 'm', 0 };
 CHAR16  mClearScreenString[]       = { ESC, '[', '2', 'J', 0 };
 CHAR16  mSetCursorPositionString[] = { ESC, '[', '0', '0', ';', '0', '0', 'H', 0 };
@@ -453,7 +455,6 @@ TerminalConOutQueryMode (
   Implements EFI_SIMPLE_TEXT_OUT.SetMode().
 
   Set the terminal to a specified display mode.
-  In this driver, we only support mode 0.
 
   @param This          Indicates the calling context.
   @param ModeNumber    The text mode to set.
@@ -473,14 +474,36 @@ TerminalConOutSetMode (
 {
   EFI_STATUS    Status;
   TERMINAL_DEV  *TerminalDevice;
+  CHAR16        *String;
+  UINTN         Columns;
+  UINTN         Rows;
 
   //
-  //  get Terminal device data structure pointer.
+  // Get Terminal device data structure pointer.
   //
   TerminalDevice = TERMINAL_CON_OUT_DEV_FROM_THIS (This);
 
   if (ModeNumber >= (UINTN)This->Mode->MaxMode) {
     return EFI_UNSUPPORTED;
+  }
+
+  //
+  // Configure terminal string for the text mode to set.
+  //
+  if (ModeNumber == 0) {
+    String = mSetModeString;
+  } else {
+    Columns = TerminalDevice->TerminalConsoleModeData[ModeNumber].Columns;
+    Rows    = TerminalDevice->TerminalConsoleModeData[ModeNumber].Rows;
+
+    mSetModeStringResize[RESIZE_ROW_OFFSET + 0]    = (CHAR16)('0' + (Rows / 100));
+    mSetModeStringResize[RESIZE_ROW_OFFSET + 1]    = (CHAR16)('0' + ((Rows - ((Rows / 100) * 100)) / 10));
+    mSetModeStringResize[RESIZE_ROW_OFFSET + 2]    = (CHAR16)('0' + (Rows % 10));
+    mSetModeStringResize[RESIZE_COLUMN_OFFSET + 0] = (CHAR16)('0' + (Columns / 100));
+    mSetModeStringResize[RESIZE_COLUMN_OFFSET + 1] = (CHAR16)('0' + ((Columns - ((Columns / 100) * 100)) / 10));
+    mSetModeStringResize[RESIZE_COLUMN_OFFSET + 2] = (CHAR16)('0' + (Columns % 10));
+
+    String = mSetModeStringResize;
   }
 
   //
@@ -491,7 +514,7 @@ TerminalConOutSetMode (
   This->ClearScreen (This);
 
   TerminalDevice->OutputEscChar = TRUE;
-  Status                        = This->OutputString (This, mSetModeString);
+  Status                        = This->OutputString (This, String);
   TerminalDevice->OutputEscChar = FALSE;
 
   if (EFI_ERROR (Status)) {


### PR DESCRIPTION
When the terminal driver is active, currently terminals available through SetMode function are limited to mode 0 (80x25) despite multiple modes are configured as MaxMode value (e.g. 3 modes in mTerminalConsoleModeData list). Improve the function to support multiple modes based on the value. Additionally add more modes that match with the GraphicsConsoleDxe driver. This update is expected to help the symptom that the Setup or Shell screen becomes smaller due to the text mode.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

It has been verified on some AMD platforms that require the improvement.

## Integration Instructions

N/A
