### PR TITLE
IntelFsp2Pkg/FspSecCore: initialize FspMode in FSP_GLOBAL_DATA

### DIFF
--- a/IntelFsp2Pkg/FspSecCore/SecFsp.c
+++ b/IntelFsp2Pkg/FspSecCore/SecFsp.c
@@ -133,7 +133,7 @@ FspGlobalDataInit (
   UINTN  Idx;
 
   //
-  // Set FSP Global Data pointer
+  // Set FSP Global Data pointer when FSP runs in API mode
   //
   SetFspGlobalDataPointer (PeiFspData);
   ZeroMem ((VOID *)PeiFspData, sizeof (FSP_GLOBAL_DATA));
@@ -141,6 +141,7 @@ FspGlobalDataInit (
   PeiFspData->Signature = FSP_GLOBAL_DATA_SIGNATURE;
   PeiFspData->Version   = FSP_GLOBAL_DATA_VERSION;
   PeiFspData->CoreStack = BootLoaderStack;
+  PeiFspData->FspMode   = FSP_IN_API_MODE;
   PeiFspData->PerfIdx   = 2;
   PeiFspData->PerfSig   = FSP_PERFORMANCE_DATA_SIGNATURE;
   //


### PR DESCRIPTION
FspSecCore only runs in API mode.
When it allocates memory in stack for FSP_GLOBAL_DATA, it does not initialize the FspMode to FSP_IN_API_MODE.

The patch enhances the code to initialize the FspMode as well.

This change does not have functionality impact as there should be some code elsewhere which sets the FspMode.
This change allows to remove the extra code logic that sets FspMode in API mode.

Cc: Chasel Chiu <chasel.chiu@intel.com>
Cc: Nate DeSimone <nathaniel.l.desimone@intel.com>
Cc: Duggapu Chinni B <chinni.b.duggapu@intel.com>
Cc: Star Zeng <star.zeng@intel.com>
Cc: Ted Kuo <ted.kuo@intel.com>
Cc: Ashraf Ali S <ashraf.ali.s@intel.com>
