### PR TITLE
Add support for HTTP Boot through Proxy Server

### DIFF
--- a/MdeModulePkg/Library/UefiBootManagerLib/BmBootDescription.c
+++ b/MdeModulePkg/Library/UefiBootManagerLib/BmBootDescription.c
@@ -649,8 +649,8 @@ BmGetNetworkDescription (
   //   ....../Mac(...)[/Vlan(...)][/Wi-Fi(...)]/IPv6(...)
   //
   // The HTTP device path is like:
-  //   ....../Mac(...)[/Vlan(...)][/Wi-Fi(...)]/IPv4(...)[/Dns(...)]/Uri(...)
-  //   ....../Mac(...)[/Vlan(...)][/Wi-Fi(...)]/IPv6(...)[/Dns(...)]/Uri(...)
+  //   ....../Mac(...)[/Vlan(...)][/Wi-Fi(...)]/IPv4(...)[/Dns(...)][/Uri(...)]/Uri(...)
+  //   ....../Mac(...)[/Vlan(...)][/Wi-Fi(...)]/IPv6(...)[/Dns(...)][/Uri(...)]/Uri(...)
   //
   while (!IsDevicePathEnd (DevicePath) &&
          ((DevicePathType (DevicePath) != MESSAGING_DEVICE_PATH) ||

--- a/MdePkg/Include/Protocol/Http.h
+++ b/MdePkg/Include/Protocol/Http.h
@@ -189,10 +189,25 @@ typedef struct {
   /// The URI of a remote host. From the information in this field, the HTTP instance
   /// will be able to determine whether to use HTTP or HTTPS and will also be able to
   /// determine the port number to use. If no port number is specified, port 80 (HTTP)
-  /// is assumed. See RFC 3986 for more details on URI syntax.
+  /// or 443 (HTTPS) is assumed. See RFC 3986 for more details on URI syntax.
   ///
   CHAR16             *Url;
 } EFI_HTTP_REQUEST_DATA;
+
+///
+/// EFI_HTTP_CONNECT_REQUEST_DATA
+///
+typedef struct {
+  EFI_HTTP_REQUEST_DATA    Base;
+  ///
+  /// The URI of an Proxy Host. This field will be NULL if there is no Proxy Host
+  /// in the device path. From the information in this field, the HTTP instance will
+  /// be able to determine whether to use HTTP or HTTPS and will also be able to
+  /// determine the port number to use. If no port number is specified, port 80 (HTTP)
+  /// or 443 (HTTPS) is assumed. See RFC 3986 for more details on URI syntax.
+  ///
+  CHAR16                   *ProxyUrl;
+} EFI_HTTP_CONNECT_REQUEST_DATA;
 
 ///
 /// EFI_HTTP_RESPONSE_DATA

--- a/NetworkPkg/HttpBootDxe/HttpBootClient.h
+++ b/NetworkPkg/HttpBootDxe/HttpBootClient.h
@@ -87,6 +87,21 @@ HttpBootCreateHttpIo (
   );
 
 /**
+  This function establishes a connection through a proxy server
+
+  @param[in]       Private         The pointer to the driver's private data.
+
+  @retval EFI_SUCCESS              Connection successful.
+  @retval EFI_OUT_OF_RESOURCES     Could not allocate needed resources
+  @retval Others                   Unexpected error happened.
+
+**/
+EFI_STATUS
+HttpBootConnectProxy (
+  IN     HTTP_BOOT_PRIVATE_DATA  *Private
+  );
+
+/**
   This function download the boot file by using UEFI HTTP protocol.
 
   @param[in]       Private         The pointer to the driver's private data.

--- a/NetworkPkg/HttpBootDxe/HttpBootConfigNVDataStruc.h
+++ b/NetworkPkg/HttpBootDxe/HttpBootConfigNVDataStruc.h
@@ -27,7 +27,8 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #define FORMID_MAIN_FORM  1
 
-#define KEY_INITIATOR_URI  0x101
+#define KEY_INITIATOR_URI        0x101
+#define KEY_INITIATOR_PROXY_URI  0x102
 
 #define HTTP_BOOT_DEFAULT_DESCRIPTION_STR  L"UEFI HTTP"
 
@@ -37,6 +38,7 @@ typedef struct _HTTP_BOOT_CONFIG_IFR_NVDATA {
   UINT8     Padding;
   CHAR16    Description[DESCRIPTION_STR_MAX_SIZE];
   CHAR16    Uri[URI_STR_MAX_SIZE];
+  CHAR16    ProxyUri[URI_STR_MAX_SIZE];
 } HTTP_BOOT_CONFIG_IFR_NVDATA;
 #pragma pack()
 

--- a/NetworkPkg/HttpBootDxe/HttpBootConfigStrings.uni
+++ b/NetworkPkg/HttpBootDxe/HttpBootConfigStrings.uni
@@ -18,4 +18,6 @@
 #string STR_BOOT_URI_PROMPT                   #language en-US "Boot URI"
 #string STR_BOOT_URI_HELP                     #language en-US "A new Boot Option will be created according to this Boot URI."
 #string STR_BOOT_DESCRIPTION_PROMPT           #language en-US "Input the description"
+#string STR_BOOT_PROXY_URI_PROMPT             #language en-US "Proxy URI"
+#string STR_BOOT_PROXY_URI_HELP               #language en-US "Proxy URI through which to connect to Boot URI"
 #string STR_NULL_STRING                       #language en-US ""

--- a/NetworkPkg/HttpBootDxe/HttpBootConfigVfr.vfr
+++ b/NetworkPkg/HttpBootDxe/HttpBootConfigVfr.vfr
@@ -44,6 +44,15 @@ formset
             minsize = URI_STR_MIN_SIZE,
             maxsize = URI_STR_MAX_SIZE,
     endstring;
+
+    string  varid   = HTTP_BOOT_CONFIG_IFR_NVDATA.ProxyUri,
+            prompt  = STRING_TOKEN(STR_BOOT_PROXY_URI_PROMPT),
+            help    = STRING_TOKEN(STR_BOOT_PROXY_URI_HELP),
+            flags   = INTERACTIVE,
+            key     = KEY_INITIATOR_PROXY_URI,
+            minsize = URI_STR_MIN_SIZE,
+            maxsize = URI_STR_MAX_SIZE,
+    endstring;
   endform;
 
 endformset;

--- a/NetworkPkg/HttpBootDxe/HttpBootDxe.h
+++ b/NetworkPkg/HttpBootDxe/HttpBootDxe.h
@@ -226,6 +226,12 @@ struct _HTTP_BOOT_PRIVATE_DATA {
   VOID                                         *FilePathUriParser;
 
   //
+  // URI string for the Proxy host if BootFileUri contains a Proxy
+  // URI in the path
+  //
+  CHAR8                                        *ProxyUri;
+
+  //
   // Cached HTTP data
   //
   LIST_ENTRY                                   CacheList;

--- a/NetworkPkg/HttpBootDxe/HttpBootImpl.c
+++ b/NetworkPkg/HttpBootDxe/HttpBootImpl.c
@@ -123,19 +123,21 @@ HttpBootStart (
 {
   UINTN       Index;
   EFI_STATUS  Status;
-  CHAR8       *Uri;
+  CHAR8       *ProxyUri;
+  CHAR8       *EndPointUri;
 
-  Uri = NULL;
+  ProxyUri    = NULL;
+  EndPointUri = NULL;
 
   if ((Private == NULL) || (FilePath == NULL)) {
     return EFI_INVALID_PARAMETER;
   }
 
   //
-  // Check the URI in the input FilePath, in order to see whether it is
+  // Check the URIs in the input FilePath, in order to see whether it is
   // required to boot from a new specified boot file.
   //
-  Status = HttpBootParseFilePath (FilePath, &Uri);
+  Status = HttpBootParseFilePath (FilePath, &ProxyUri, &EndPointUri);
   if (EFI_ERROR (Status)) {
     return EFI_INVALID_PARAMETER;
   }
@@ -151,28 +153,21 @@ HttpBootStart (
     // recorded before.
     //
     if ((UsingIpv6 != Private->UsingIpv6) ||
-        ((Uri != NULL) && (AsciiStrCmp (Private->BootFileUri, Uri) != 0)))
+        ((EndPointUri != NULL) && (AsciiStrCmp (Private->BootFileUri, EndPointUri) != 0)))
     {
       //
       // Restart is required, first stop then continue this start function.
       //
       Status = HttpBootStop (Private);
       if (EFI_ERROR (Status)) {
-        if (Uri != NULL) {
-          FreePool (Uri);
-        }
-
-        return Status;
+        goto ERROR;
       }
     } else {
       //
       // Restart is not required.
       //
-      if (Uri != NULL) {
-        FreePool (Uri);
-      }
-
-      return EFI_ALREADY_STARTED;
+      Status = EFI_ALREADY_STARTED;
+      goto ERROR;
     }
   }
 
@@ -184,17 +179,16 @@ HttpBootStart (
   } else if (!UsingIpv6 && (Private->Ip4Nic != NULL)) {
     Private->UsingIpv6 = FALSE;
   } else {
-    if (Uri != NULL) {
-      FreePool (Uri);
-    }
-
-    return EFI_UNSUPPORTED;
+    Status = EFI_UNSUPPORTED;
+    goto ERROR;
   }
 
   //
-  // Record the specified URI and prepare the URI parser if needed.
+  // Record the specified URIs and prepare the URI parser if needed.
   //
-  Private->FilePathUri = Uri;
+  Private->ProxyUri    = ProxyUri;
+  Private->FilePathUri = EndPointUri;
+
   if (Private->FilePathUri != NULL) {
     Status = HttpParseUrl (
                Private->FilePathUri,
@@ -203,8 +197,7 @@ HttpBootStart (
                &Private->FilePathUriParser
                );
     if (EFI_ERROR (Status)) {
-      FreePool (Private->FilePathUri);
-      return Status;
+      goto ERROR;
     }
   }
 
@@ -236,6 +229,17 @@ HttpBootStart (
   Print (L"\n>>Start HTTP Boot over IPv%d", Private->UsingIpv6 ? 6 : 4);
 
   return EFI_SUCCESS;
+
+ERROR:
+  if (ProxyUri != NULL) {
+    FreePool (ProxyUri);
+  }
+
+  if (EndPointUri != NULL) {
+    FreePool (EndPointUri);
+  }
+
+  return Status;
 }
 
 /**
@@ -618,6 +622,11 @@ HttpBootStop (
   if (Private->LastModifiedOrEtag != NULL) {
     FreePool (Private->LastModifiedOrEtag);
     Private->LastModifiedOrEtag = NULL;
+  }
+
+  if (Private->ProxyUri != NULL) {
+    FreePool (Private->ProxyUri);
+    Private->ProxyUri = NULL;
   }
 
   ZeroMem (Private->OfferBuffer, sizeof (Private->OfferBuffer));

--- a/NetworkPkg/HttpBootDxe/HttpBootImpl.c
+++ b/NetworkPkg/HttpBootDxe/HttpBootImpl.c
@@ -319,7 +319,11 @@ HttpBootGetBootFileCaller (
   UINT32                    Retries;
 
   if (Private->BootFileSize == 0) {
-    State = GetBootFileHead;
+    if (Private->ProxyUri != NULL) {
+      State = ConnectToProxy;
+    } else {
+      State = GetBootFileHead;
+    }
   } else {
     State = LoadBootFile;
   }
@@ -368,6 +372,16 @@ HttpBootGetBootFileCaller (
           State = GetBootFileError;
         } else {
           State = LoadBootFile;
+        }
+
+        break;
+
+      case ConnectToProxy:
+        Status = HttpBootConnectProxy (Private);
+        if (Status == EFI_SUCCESS) {
+          State = GetBootFileHead;
+        } else {
+          State = GetBootFileError;
         }
 
         break;

--- a/NetworkPkg/HttpBootDxe/HttpBootImpl.h
+++ b/NetworkPkg/HttpBootDxe/HttpBootImpl.h
@@ -14,6 +14,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 typedef enum {
   GetBootFileHead,
   GetBootFileGet,
+  ConnectToProxy,
   LoadBootFile,
   GetBootFileError
 } HTTP_GET_BOOT_FILE_STATE;

--- a/NetworkPkg/HttpBootDxe/HttpBootSupport.h
+++ b/NetworkPkg/HttpBootDxe/HttpBootSupport.h
@@ -136,19 +136,22 @@ HttpBootCheckUriScheme (
 /**
   Get the URI address string from the input device path.
 
-  Caller need to free the buffer in the UriAddress pointer.
+  Caller needs to free the buffers returned by this function.
 
-  @param[in]   FilePath         Pointer to the device path which contains a URI device path node.
-  @param[out]  UriAddress       The URI address string extract from the device path.
+  @param[in]   FilePath           Pointer to the device path which contains a URI device path node.
+  @param[out]  ProxyUriAddress    The proxy URI address string extract from the device path (if it exists)
+  @param[out]  EndPointUriAddress The endpoint URI address string for the endpoint host.
 
   @retval EFI_SUCCESS            The URI string is returned.
+  @retval EFI_INVALID_PARAMETER  Parameters are NULL or device path is invalid.
   @retval EFI_OUT_OF_RESOURCES   Failed to allocate memory.
 
 **/
 EFI_STATUS
 HttpBootParseFilePath (
-  IN     EFI_DEVICE_PATH_PROTOCOL  *FilePath,
-  OUT CHAR8                        **UriAddress
+  IN  EFI_DEVICE_PATH_PROTOCOL  *FilePath,
+  OUT CHAR8                     **ProxyUriAddress,
+  OUT CHAR8                     **EndPointUriAddress
   );
 
 /**

--- a/NetworkPkg/HttpDxe/HttpDriver.h
+++ b/NetworkPkg/HttpDxe/HttpDriver.h
@@ -26,6 +26,7 @@
 #include <Library/NetLib.h>
 #include <Library/HttpLib.h>
 #include <Library/DpcLib.h>
+#include <Library/PrintLib.h>
 
 //
 // UEFI Driver Model Protocols
@@ -64,6 +65,7 @@
 // Driver Version
 //
 #define HTTP_DRIVER_VERSION  0xa
+#define URI_STR_MAX_SIZE     255
 
 //
 // Protocol instances

--- a/NetworkPkg/HttpDxe/HttpDxe.inf
+++ b/NetworkPkg/HttpDxe/HttpDxe.inf
@@ -47,6 +47,7 @@
   NetLib
   HttpLib
   DpcLib
+  PrintLib
 
 [Protocols]
   gEfiHttpServiceBindingProtocolGuid               ## BY_START

--- a/NetworkPkg/HttpDxe/HttpImpl.c
+++ b/NetworkPkg/HttpDxe/HttpImpl.c
@@ -163,6 +163,7 @@ EfiHttpConfigure (
     HttpInstance->TimeOutMillisec    = HttpConfigData->TimeOutMillisec;
     HttpInstance->LocalAddressIsIPv6 = HttpConfigData->LocalAddressIsIPv6;
     HttpInstance->ConnectionClose    = FALSE;
+    HttpInstance->ProxyConnected     = FALSE;
 
     if (HttpConfigData->LocalAddressIsIPv6) {
       CopyMem (
@@ -231,37 +232,49 @@ EfiHttpRequest (
   IN  EFI_HTTP_TOKEN     *Token
   )
 {
-  EFI_HTTP_MESSAGE       *HttpMsg;
-  EFI_HTTP_REQUEST_DATA  *Request;
-  VOID                   *UrlParser;
-  EFI_STATUS             Status;
-  CHAR8                  *HostName;
-  UINTN                  HostNameSize;
-  UINT16                 RemotePort;
-  HTTP_PROTOCOL          *HttpInstance;
-  BOOLEAN                Configure;
-  BOOLEAN                ReConfigure;
-  BOOLEAN                TlsConfigure;
-  CHAR8                  *RequestMsg;
-  CHAR8                  *Url;
-  UINTN                  UrlLen;
-  CHAR16                 *HostNameStr;
-  HTTP_TOKEN_WRAP        *Wrap;
-  CHAR8                  *FileUrl;
-  UINTN                  RequestMsgSize;
+  EFI_HTTP_MESSAGE               *HttpMsg;
+  EFI_HTTP_REQUEST_DATA          *Request;
+  VOID                           *UrlParser;
+  VOID                           *EndPointUrlParser;
+  EFI_STATUS                     Status;
+  CHAR8                          *HostName;
+  UINTN                          HostNameSize;
+  UINT16                         RemotePort;
+  HTTP_PROTOCOL                  *HttpInstance;
+  BOOLEAN                        Configure;
+  BOOLEAN                        ReConfigure;
+  BOOLEAN                        TlsConfigure;
+  CHAR8                          *RequestMsg;
+  CHAR8                          *Url;
+  UINTN                          UrlLen;
+  CHAR8                          *ProxyUrl;
+  UINTN                          ProxyUrlLen;
+  CHAR8                          *ParseUrl;
+  CHAR16                         *HostNameStr;
+  HTTP_TOKEN_WRAP                *Wrap;
+  CHAR8                          *FileUrl;
+  UINTN                          RequestMsgSize;
+  UINT16                         EndPointRemotePort;
+  CHAR8                          *EndPointUrlMsg;
+  EFI_HTTP_CONNECT_REQUEST_DATA  *ConnRequest;
 
   //
   // Initializations
   //
-  Url          = NULL;
-  UrlParser    = NULL;
-  RemotePort   = 0;
-  HostName     = NULL;
-  RequestMsg   = NULL;
-  HostNameStr  = NULL;
-  Wrap         = NULL;
-  FileUrl      = NULL;
-  TlsConfigure = FALSE;
+  Url                = NULL;
+  ProxyUrl           = NULL;
+  UrlParser          = NULL;
+  EndPointUrlParser  = NULL;
+  RemotePort         = 0;
+  HostName           = NULL;
+  RequestMsg         = NULL;
+  HostNameStr        = NULL;
+  Wrap               = NULL;
+  FileUrl            = NULL;
+  TlsConfigure       = FALSE;
+  EndPointUrlMsg     = NULL;
+  EndPointRemotePort = 0;
+  ConnRequest        = NULL;
 
   if ((This == NULL) || (Token == NULL)) {
     return EFI_INVALID_PARAMETER;
@@ -275,14 +288,27 @@ EfiHttpRequest (
   Request = HttpMsg->Data.Request;
 
   //
-  // Only support GET, HEAD, DELETE, PATCH, PUT and POST method in current implementation.
+  // Only support GET, HEAD, DELETE, CONNECT, PATCH, PUT and POST method in current implementation.
   //
-  if ((Request != NULL) && (Request->Method != HttpMethodGet) &&
-      (Request->Method != HttpMethodHead) && (Request->Method != HttpMethodDelete) &&
-      (Request->Method != HttpMethodPut) && (Request->Method != HttpMethodPost) &&
-      (Request->Method != HttpMethodPatch))
-  {
-    return EFI_UNSUPPORTED;
+  if (Request != NULL) {
+    switch (Request->Method) {
+      case HttpMethodGet:
+      case HttpMethodHead:
+      case HttpMethodDelete:
+      case HttpMethodPut:
+      case HttpMethodPost:
+      case HttpMethodPatch:
+        break;
+      case HttpMethodConnect:
+        ConnRequest = (EFI_HTTP_CONNECT_REQUEST_DATA *)Request;
+        if (ConnRequest->ProxyUrl == NULL) {
+          return EFI_INVALID_PARAMETER;
+        }
+
+        break;
+      default:
+        return EFI_UNSUPPORTED;
+    }
   }
 
   HttpInstance = HTTP_INSTANCE_FROM_PROTOCOL (This);
@@ -337,7 +363,7 @@ EfiHttpRequest (
     }
 
     //
-    // Parse the URI of the remote host.
+    // Parse the Request URI.
     //
     Url    = HttpInstance->Url;
     UrlLen = StrLen (Request->Url) + 1;
@@ -356,6 +382,29 @@ EfiHttpRequest (
     }
 
     UnicodeStrToAsciiStrS (Request->Url, Url, UrlLen);
+
+    //
+    // In case of HTTP Connect, parse proxy URI from Request.
+    //
+    if (Request->Method == HttpMethodConnect) {
+      ProxyUrl    = HttpInstance->ProxyUrl;
+      ProxyUrlLen = StrLen (ConnRequest->ProxyUrl) + 1;
+      if (ProxyUrlLen > HttpInstance->ProxyUrlLen) {
+        ProxyUrl = AllocateZeroPool (ProxyUrlLen);
+        if (ProxyUrl == NULL) {
+          return EFI_OUT_OF_RESOURCES;
+        }
+
+        if (HttpInstance->ProxyUrl != NULL) {
+          FreePool (HttpInstance->ProxyUrl);
+        }
+
+        HttpInstance->ProxyUrl    = ProxyUrl;
+        HttpInstance->ProxyUrlLen = ProxyUrlLen;
+      }
+
+      UnicodeStrToAsciiStrS (ConnRequest->ProxyUrl, ProxyUrl, ProxyUrlLen);
+    }
 
     //
     // From the information in Url, the HTTP instance will
@@ -385,13 +434,26 @@ EfiHttpRequest (
       TlsConfigure = TRUE;
     }
 
-    UrlParser = NULL;
-    Status    = HttpParseUrl (Url, (UINT32)AsciiStrLen (Url), FALSE, &UrlParser);
+    //
+    // Setup RemoteAddress and RemotePort of HttpInstance.
+    //
+    if (Request->Method == HttpMethodConnect) {
+      // Case 1: HTTP Connect request
+      ParseUrl = ProxyUrl;
+    } else if (HttpInstance->ProxyConnected == TRUE) {
+      // Case 2: Other HTTP request (proxy connected)
+      ParseUrl = HttpInstance->ProxyUrl;
+    } else {
+      // Case 3: Other HTTP request (proxy not connected)
+      ParseUrl = Url;
+    }
+
+    Status = HttpParseUrl (ParseUrl, (UINT32)AsciiStrLen (ParseUrl), FALSE, &UrlParser);
     if (EFI_ERROR (Status)) {
       goto Error1;
     }
 
-    Status = HttpUrlGetHostName (Url, UrlParser, &HostName);
+    Status = HttpUrlGetHostName (ParseUrl, UrlParser, &HostName);
     if (EFI_ERROR (Status)) {
       goto Error1;
     }
@@ -409,7 +471,7 @@ EfiHttpRequest (
       }
     }
 
-    Status = HttpUrlGetPort (Url, UrlParser, &RemotePort);
+    Status = HttpUrlGetPort (ParseUrl, UrlParser, &RemotePort);
     if (EFI_ERROR (Status)) {
       if (HttpInstance->UseHttps) {
         RemotePort = HTTPS_DEFAULT_PORT;
@@ -505,7 +567,7 @@ EfiHttpRequest (
     if (!HttpInstance->LocalAddressIsIPv6) {
       Status = NetLibAsciiStrToIp4 (HostName, &HttpInstance->RemoteAddr);
     } else {
-      Status = HttpUrlGetIp6 (Url, UrlParser, &HttpInstance->RemoteIpv6Addr);
+      Status = HttpUrlGetIp6 (ParseUrl, UrlParser, &HttpInstance->RemoteIpv6Addr);
     }
 
     if (EFI_ERROR (Status)) {
@@ -603,27 +665,74 @@ EfiHttpRequest (
   //
   // Create request message.
   //
-  FileUrl = Url;
-  if ((Url != NULL) && (*FileUrl != '/')) {
+  if ((Request != NULL) && (Request->Method == HttpMethodConnect)) {
     //
-    // Convert the absolute-URI to the absolute-path
+    // HTTP Connect shall contain EndPoint host name in URI
     //
-    while (*FileUrl != ':') {
-      FileUrl++;
-    }
-
-    if ((*(FileUrl+1) == '/') && (*(FileUrl+2) == '/')) {
-      FileUrl += 3;
-      while (*FileUrl != '/') {
-        FileUrl++;
-      }
-    } else {
-      Status = EFI_INVALID_PARAMETER;
+    Status = HttpParseUrl (Url, (UINT32)AsciiStrLen (Url), FALSE, &EndPointUrlParser);
+    if (EFI_ERROR (Status)) {
       goto Error3;
     }
-  }
 
-  Status = HttpGenRequestMessage (HttpMsg, FileUrl, &RequestMsg, &RequestMsgSize);
+    Status = HttpUrlGetHostName (
+               Url,
+               EndPointUrlParser,
+               &HttpInstance->EndPointHostName
+               );
+    if (EFI_ERROR (Status)) {
+      goto Error3;
+    }
+
+    Status = HttpUrlGetPort (Url, EndPointUrlParser, &EndPointRemotePort);
+    if (EFI_ERROR (Status)) {
+      if (IsHttpsUrl (Url)) {
+        EndPointRemotePort = HTTPS_DEFAULT_PORT;
+      } else {
+        EndPointRemotePort = HTTP_DEFAULT_PORT;
+      }
+    }
+
+    EndPointUrlMsg = AllocateZeroPool (URI_STR_MAX_SIZE);
+    if (EndPointUrlMsg == NULL) {
+      Status = EFI_OUT_OF_RESOURCES;
+      goto Error3;
+    }
+
+    AsciiSPrint (
+      EndPointUrlMsg,
+      URI_STR_MAX_SIZE,
+      "%a:%d",
+      HttpInstance->EndPointHostName,
+      EndPointRemotePort
+      );
+
+    Status = HttpGenRequestMessage (HttpMsg, EndPointUrlMsg, &RequestMsg, &RequestMsgSize);
+
+    FreePool (EndPointUrlMsg);
+    HttpUrlFreeParser (EndPointUrlParser);
+  } else {
+    FileUrl = Url;
+    if ((Url != NULL) && (*FileUrl != '/')) {
+      //
+      // Convert the absolute-URI to the absolute-path
+      //
+      while (*FileUrl != ':') {
+        FileUrl++;
+      }
+
+      if ((*(FileUrl+1) == '/') && (*(FileUrl+2) == '/')) {
+        FileUrl += 3;
+        while (*FileUrl != '/') {
+          FileUrl++;
+        }
+      } else {
+        Status = EFI_INVALID_PARAMETER;
+        goto Error3;
+      }
+    }
+
+    Status = HttpGenRequestMessage (HttpMsg, FileUrl, &RequestMsg, &RequestMsgSize);
+  }
 
   if (EFI_ERROR (Status) || (NULL == RequestMsg)) {
     goto Error3;
@@ -658,6 +767,10 @@ EfiHttpRequest (
   }
 
   DispatchDpc ();
+
+  if (HttpInstance->Method == HttpMethodConnect) {
+    HttpInstance->ProxyConnected = TRUE;
+  }
 
   if (HostName != NULL) {
     FreePool (HostName);
@@ -704,6 +817,14 @@ Error2:
   }
 
 Error1:
+  if (EndPointUrlMsg != NULL) {
+    FreePool (EndPointUrlMsg);
+  }
+
+  if (EndPointUrlParser != NULL) {
+    HttpUrlFreeParser (EndPointUrlParser);
+  }
+
   if (HostName != NULL) {
     FreePool (HostName);
   }

--- a/NetworkPkg/HttpDxe/HttpProto.c
+++ b/NetworkPkg/HttpDxe/HttpProto.c
@@ -852,6 +852,19 @@ HttpCleanProtocol (
     HttpInstance->UrlLen = 0;
   }
 
+  if (HttpInstance->ProxyUrl != NULL) {
+    FreePool (HttpInstance->ProxyUrl);
+    HttpInstance->ProxyUrl    = NULL;
+    HttpInstance->ProxyUrlLen = 0;
+  }
+
+  if (HttpInstance->EndPointHostName != NULL) {
+    FreePool (HttpInstance->EndPointHostName);
+    HttpInstance->EndPointHostName = NULL;
+  }
+
+  HttpInstance->ProxyConnected = FALSE;
+
   NetMapClean (&HttpInstance->TxTokens);
   NetMapClean (&HttpInstance->RxTokens);
 

--- a/NetworkPkg/HttpDxe/HttpProto.c
+++ b/NetworkPkg/HttpDxe/HttpProto.c
@@ -1224,6 +1224,7 @@ HttpConfigureTcp6 (
   connect one TLS session if required.
 
   @param[in]  HttpInstance       The HTTP instance private data.
+  @param[in]  TlsConfigure       The Flag indicates whether it's the new Tls session.
 
   @retval EFI_SUCCESS            The TCP connection is established.
   @retval EFI_NOT_READY          TCP4 protocol child is not created or configured.
@@ -1232,7 +1233,8 @@ HttpConfigureTcp6 (
 **/
 EFI_STATUS
 HttpConnectTcp4 (
-  IN  HTTP_PROTOCOL  *HttpInstance
+  IN  HTTP_PROTOCOL  *HttpInstance,
+  IN  BOOLEAN        TlsConfigure
   )
 {
   EFI_STATUS                 Status;
@@ -1255,16 +1257,18 @@ HttpConnectTcp4 (
     return Status;
   }
 
-  if (Tcp4State == Tcp4StateEstablished) {
+  if ((Tcp4State == Tcp4StateEstablished) && (!HttpInstance->ProxyConnected || !TlsConfigure)) {
     return EFI_SUCCESS;
-  } else if (Tcp4State > Tcp4StateEstablished ) {
+  } else if (Tcp4State > Tcp4StateEstablished) {
     HttpCloseConnection (HttpInstance);
   }
 
-  Status = HttpCreateConnection (HttpInstance);
-  if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "Tcp4 Connection fail - %x\n", Status));
-    return Status;
+  if (!HttpInstance->ProxyConnected) {
+    Status = HttpCreateConnection (HttpInstance);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "Tcp4 Connection fail - %x\n", Status));
+      return Status;
+    }
   }
 
   //
@@ -1316,6 +1320,7 @@ HttpConnectTcp4 (
   connect one TLS session if required.
 
   @param[in]  HttpInstance       The HTTP instance private data.
+  @param[in]  TlsConfigure       The Flag indicates whether it's the new Tls session.
 
   @retval EFI_SUCCESS            The TCP connection is established.
   @retval EFI_NOT_READY          TCP6 protocol child is not created or configured.
@@ -1324,7 +1329,8 @@ HttpConnectTcp4 (
 **/
 EFI_STATUS
 HttpConnectTcp6 (
-  IN  HTTP_PROTOCOL  *HttpInstance
+  IN  HTTP_PROTOCOL  *HttpInstance,
+  IN  BOOLEAN        TlsConfigure
   )
 {
   EFI_STATUS                 Status;
@@ -1348,16 +1354,18 @@ HttpConnectTcp6 (
     return Status;
   }
 
-  if (Tcp6State == Tcp6StateEstablished) {
+  if ((Tcp6State == Tcp6StateEstablished) && (!HttpInstance->ProxyConnected || !TlsConfigure)) {
     return EFI_SUCCESS;
-  } else if (Tcp6State > Tcp6StateEstablished ) {
+  } else if (Tcp6State > Tcp6StateEstablished) {
     HttpCloseConnection (HttpInstance);
   }
 
-  Status = HttpCreateConnection (HttpInstance);
-  if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "Tcp6 Connection fail - %x\n", Status));
-    return Status;
+  if (!HttpInstance->ProxyConnected) {
+    Status = HttpCreateConnection (HttpInstance);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "Tcp6 Connection fail - %x\n", Status));
+      return Status;
+    }
   }
 
   //
@@ -1453,7 +1461,7 @@ HttpInitSession (
     //
     // Connect TCP.
     //
-    Status = HttpConnectTcp4 (HttpInstance);
+    Status = HttpConnectTcp4 (HttpInstance, TlsConfigure);
     if (EFI_ERROR (Status)) {
       return Status;
     }
@@ -1471,7 +1479,7 @@ HttpInitSession (
     //
     // Connect TCP.
     //
-    Status = HttpConnectTcp6 (HttpInstance);
+    Status = HttpConnectTcp6 (HttpInstance, TlsConfigure);
     if (EFI_ERROR (Status)) {
       return Status;
     }

--- a/NetworkPkg/HttpDxe/HttpProto.h
+++ b/NetworkPkg/HttpDxe/HttpProto.h
@@ -408,6 +408,7 @@ HttpConfigureTcp6 (
   connect one TLS session if required.
 
   @param[in]  HttpInstance       The HTTP instance private data.
+  @param[in]  TlsConfigure       The Flag indicates whether it's the new Tls session.
 
   @retval EFI_SUCCESS            The TCP connection is established.
   @retval EFI_NOT_READY          TCP4 protocol child is not created or configured.
@@ -416,7 +417,8 @@ HttpConfigureTcp6 (
 **/
 EFI_STATUS
 HttpConnectTcp4 (
-  IN  HTTP_PROTOCOL  *HttpInstance
+  IN  HTTP_PROTOCOL  *HttpInstance,
+  IN  BOOLEAN        TlsConfigure
   );
 
 /**
@@ -424,6 +426,7 @@ HttpConnectTcp4 (
   connect one TLS session if required.
 
   @param[in]  HttpInstance       The HTTP instance private data.
+  @param[in]  TlsConfigure       The Flag indicates whether it's the new Tls session.
 
   @retval EFI_SUCCESS            The TCP connection is established.
   @retval EFI_NOT_READY          TCP6 protocol child is not created or configured.
@@ -432,7 +435,8 @@ HttpConnectTcp4 (
 **/
 EFI_STATUS
 HttpConnectTcp6 (
-  IN  HTTP_PROTOCOL  *HttpInstance
+  IN  HTTP_PROTOCOL  *HttpInstance,
+  IN  BOOLEAN        TlsConfigure
   );
 
 /**

--- a/NetworkPkg/HttpDxe/HttpProto.h
+++ b/NetworkPkg/HttpDxe/HttpProto.h
@@ -168,6 +168,14 @@ typedef struct _HTTP_PROTOCOL {
   UINTN                             UrlLen;
 
   //
+  // Proxy support
+  //
+  CHAR8                             *ProxyUrl;
+  UINTN                             ProxyUrlLen;
+  BOOLEAN                           ProxyConnected;
+  CHAR8                             *EndPointHostName;
+
+  //
   // Https Support
   //
   BOOLEAN                           UseHttps;

--- a/NetworkPkg/HttpDxe/HttpsSupport.c
+++ b/NetworkPkg/HttpDxe/HttpsSupport.c
@@ -656,11 +656,17 @@ TlsConfigureSession (
   //
   // TlsConfigData initialization
   //
-  HttpInstance->TlsConfigData.ConnectionEnd       = EfiTlsClient;
-  HttpInstance->TlsConfigData.VerifyMethod        = EFI_TLS_VERIFY_PEER;
-  HttpInstance->TlsConfigData.VerifyHost.Flags    = EFI_TLS_VERIFY_FLAG_NONE;
-  HttpInstance->TlsConfigData.VerifyHost.HostName = HttpInstance->RemoteHost;
-  HttpInstance->TlsConfigData.SessionState        = EfiTlsSessionNotStarted;
+  HttpInstance->TlsConfigData.ConnectionEnd    = EfiTlsClient;
+  HttpInstance->TlsConfigData.VerifyMethod     = EFI_TLS_VERIFY_PEER;
+  HttpInstance->TlsConfigData.VerifyHost.Flags = EFI_TLS_VERIFY_FLAG_NONE;
+  HttpInstance->TlsConfigData.SessionState     = EfiTlsSessionNotStarted;
+
+  if (HttpInstance->ProxyConnected) {
+    ASSERT (HttpInstance->EndPointHostName != NULL);
+    HttpInstance->TlsConfigData.VerifyHost.HostName = HttpInstance->EndPointHostName;
+  } else {
+    HttpInstance->TlsConfigData.VerifyHost.HostName = HttpInstance->RemoteHost;
+  }
 
   //
   // EfiTlsConnectionEnd,


### PR DESCRIPTION
# Description

Adds new feature to support HTTP Boot through Proxy Server. Adds HTTP CONNECT flow to connect through Proxy Server to then use HTTP GET/HEAD to retrieve Endpoint Server boot file.

Implementation based on UEFI Specification v2.11 as follows - 
Section 24.7.3.1 - Updated code to recognize device path with ProxyURI included
Section 24.7.10 - Updated code to use HTTP CONNECT method to connect to Proxy Server and use it to forward the HEAD/GET request to Endpoint Server's BootURI.
Section 29.6.6 - Added EFI_HTTP_CONNECT_REQUEST_DATA structure for HttpMethodConnect usage in EFI_HTTP_PROTOCOL.Request() 

REF - #10239 

- [ ] Breaking change?

- [ ] Impacts security?

- [ ] Includes tests?

## How This Was Tested

Verified as part of Edk2-staging branch. Also tested on CI.

## Integration Instructions

N/A
