### PR TITLE
StandaloneMmPkg: Add gEfiStandaloneMmNonSecureBufferGuid.

### DIFF
--- a/StandaloneMmPkg/Core/StandaloneMmCore.c
+++ b/StandaloneMmPkg/Core/StandaloneMmCore.c
@@ -446,9 +446,12 @@ MmCorePrepareCommunicationBuffer (
   mInternalCommBufferCopy = NULL;
 
   GuidHob = GetFirstGuidHob (&gMmCommBufferHobGuid);
-  ASSERT (GuidHob != NULL);
   if (GuidHob == NULL) {
-    return;
+    GuidHob = GetFirstGuidHob (&gEfiStandaloneMmNonSecureBufferGuid);
+    if (GuidHob == NULL) {
+      ASSERT (GuidHob != NULL);
+      return;
+    }
   }
 
   mMmCommunicationBuffer = (MM_COMM_BUFFER *)GET_GUID_HOB_DATA (GuidHob);

--- a/StandaloneMmPkg/Core/StandaloneMmCore.inf
+++ b/StandaloneMmPkg/Core/StandaloneMmCore.inf
@@ -84,6 +84,7 @@
   gEfiSmmSmramMemoryGuid
   gEdkiiPiSmmMemoryAttributesTableGuid
   gEfiMmPeiMmramMemoryReserveGuid
+  gEfiStandaloneMmNonSecureBufferGuid
 
 [Pcd]
   gStandaloneMmPkgTokenSpaceGuid.PcdFwVolMmMaxEncapsulationDepth    ##CONSUMES


### PR DESCRIPTION
# Description

The MM communication buffer for x86 relies on gMmCommBufferHobGuid existing. For platforms making use of TFA, a different hob, gEfiStandaloneMmNonSecureBufferGuid, is used as the equivalent of the communication buffer.

Add the gEfiStandaloneMmNonSecureBufferGuid as a fall back when gMmCommBufferHobGuid does not exist.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested
Booted on virtual platform using top of tree TFA.

## Integration Instructions
N/A