### PR TITLE
DynamicTablesPkg/AcpiSsdtCpuTopologyLib: Correct _STA method for X64

### DIFF
--- a/DynamicTablesPkg/Library/Acpi/Common/AcpiSsdtCpuTopologyLib/X64/X64SsdtCpuTopologyGenerator.c
+++ b/DynamicTablesPkg/Library/Acpi/Common/AcpiSsdtCpuTopologyLib/X64/X64SsdtCpuTopologyGenerator.c
@@ -840,34 +840,34 @@ CreateTopologyFromIntC (
         return Status;
       }
     }
-  }
 
-  if (LocalApicX2ApicInfo[Index].StaToken != CM_NULL_TOKEN) {
-    Status = GetEArchCommonObjStaInfo (
-               CfgMgrProtocol,
-               LocalApicX2ApicInfo[Index].StaToken,
-               &StaInfo,
-               NULL
-               );
-    if (EFI_ERROR (Status)) {
-      ASSERT_EFI_ERROR (Status);
-      return Status;
-    }
+    if (LocalApicX2ApicInfo[Index].StaToken != CM_NULL_TOKEN) {
+      Status = GetEArchCommonObjStaInfo (
+                 CfgMgrProtocol,
+                 LocalApicX2ApicInfo[Index].StaToken,
+                 &StaInfo,
+                 NULL
+                 );
+      if (EFI_ERROR (Status)) {
+        ASSERT_EFI_ERROR (Status);
+        return Status;
+      }
 
-    /// check STA bits
-    if ((StaInfo->DeviceStatus & ~(ACPI_AML_STA_PROC_SUPPORTED)) != 0) {
-      DEBUG ((
-        DEBUG_ERROR,
-        "Unsupported STA bits set for processor %d\n",
-        LocalApicX2ApicInfo[Index].AcpiProcessorUid
-        ));
-      return EFI_UNSUPPORTED;
-    }
+      /// check STA bits
+      if ((StaInfo->DeviceStatus & ~(ACPI_AML_STA_PROC_SUPPORTED)) != 0) {
+        DEBUG ((
+          DEBUG_ERROR,
+          "Unsupported STA bits set for processor %d\n",
+          LocalApicX2ApicInfo[Index].AcpiProcessorUid
+          ));
+        return EFI_UNSUPPORTED;
+      }
 
-    Status = AmlCodeGenMethodRetInteger ("_STA", StaInfo->DeviceStatus, 0, FALSE, 0, CpuNode, NULL);
-    if (EFI_ERROR (Status)) {
-      ASSERT_EFI_ERROR (Status);
-      return Status;
+      Status = AmlCodeGenMethodRetInteger ("_STA", StaInfo->DeviceStatus, 0, FALSE, 0, CpuNode, NULL);
+      if (EFI_ERROR (Status)) {
+        ASSERT_EFI_ERROR (Status);
+        return Status;
+      }
     }
   }
 


### PR DESCRIPTION
Relocate StaToken detection and _STA method generation logic within the loop for each processor object.

# Description
   Relocate StaToken detection and _STA method generation logic within the loop for each processor object.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested
Tested on AMD X64 platform


## Integration Instructions

N/A