### PR TITLE
pip-requirements.txt: Update pip modules

### DIFF
--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -12,8 +12,8 @@
 # https://www.python.org/dev/peps/pep-0440/#version-specifiers
 ##
 
-edk2-pytool-library~=0.21.9
-edk2-pytool-extensions~=0.27.10
+edk2-pytool-library~=0.23.0
+edk2-pytool-extensions~=0.29.0
 antlr4-python3-runtime>=4.7.1
-lcov-cobertura==2.0.2
-regex==2024.7.24
+lcov-cobertura==2.1.1
+regex==2024.11.6


### PR DESCRIPTION
# Description

Updates from dependabot for pytools have been accumulating over
time. This updates the modules to latest.

`edk2-pytool-library` changes:

https://github.com/tianocore/edk2-pytool-library/compare/v0.21.9...v0.23.0

`edk2-pytool-extensions` changes:

https://github.com/tianocore/edk2-pytool-extensions/compare/v0.27.10...v0.29.0

Other pip modules are updated to latest versions tested alongside these pytool versions.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

- CI
- Pytools integration and unit tests

## Integration Instructions

Notes:

In these releases, Python 3.10 is a Minimum Supported Version while 3.11, 3.12, and 3.13 are official versions. For more details:

https://github.com/tianocore/edk2-pytool-extensions/blob/master/docs/contributor/python_msv.md