### PR TITLE
CI: Install a fresh python virtual env every time (Linux)

### DIFF
--- a/.azurepipelines/templates/platform-build-run-steps.yml
+++ b/.azurepipelines/templates/platform-build-run-steps.yml
@@ -55,7 +55,12 @@ steps:
     architecture: "x64"
   condition: ne('${{ parameters.usePythonVersion }}', '')
 
-- script: pip install -r pip-requirements.txt --upgrade
+- bash: |
+    virtualenv ~/venv
+    . ~/venv/bin/activate
+    echo "##vso[task.setvariable variable=VIRTUAL_ENV]${VIRTUAL_ENV}"
+    echo "##vso[task.prependpath]${VIRTUAL_ENV}/bin"
+    pip install -r pip-requirements.txt --upgrade
   displayName: 'Install/Upgrade pip modules'
 
 # Set default

--- a/.azurepipelines/templates/pr-gate-steps.yml
+++ b/.azurepipelines/templates/pr-gate-steps.yml
@@ -32,7 +32,12 @@ steps:
     architecture: "x64"
   condition: ne('${{ parameters.usePythonVersion }}', '')
 
-- script: pip install -r pip-requirements.txt --upgrade
+- bash: |
+    virtualenv ~/venv
+    . ~/venv/bin/activate
+    echo "##vso[task.setvariable variable=VIRTUAL_ENV]${VIRTUAL_ENV}"
+    echo "##vso[task.prependpath]${VIRTUAL_ENV}/bin"
+    pip install -r pip-requirements.txt --upgrade
   displayName: 'Install/Upgrade pip modules'
 
 # Set default


### PR DESCRIPTION

# Description

Install a fresh python virtual environment every time to ensure
correct permissions and compatibility of the packages.
This is more robust than relying on being able to upgrade
an existing one.

pip upgrades are currently failing due to incorrect file permissions
in the container image virtual environment.

Let's not make use of the venv in the container and set up a fresh one
each time.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Test CI runs, for example #10796

## Integration Instructions 

--
