### PR TITLE
DynamicTablesPkg: Resolve cppcheck findings in macros

### DIFF
--- a/DynamicTablesPkg/Include/ConfigurationManagerObject.h
+++ b/DynamicTablesPkg/Include/ConfigurationManagerObject.h
@@ -140,8 +140,8 @@ typedef struct CmObjDescriptor {
   @retval Returns the Configuration Manager Object ID.
 **/
 #define CREATE_CM_OBJECT_ID(NameSpaceId, ObjectId)                           \
-          ((((NameSpaceId) & NAMESPACE_ID_MASK) << NAMESPACE_ID_BIT_SHIFT) | \
-            ((ObjectId) & OBJECT_ID_MASK))
+          (((((CM_OBJECT_ID)NameSpaceId) & NAMESPACE_ID_MASK) << NAMESPACE_ID_BIT_SHIFT) | \
+            (((CM_OBJECT_ID)ObjectId) & OBJECT_ID_MASK))
 
 /** This macro returns a Configuration Manager Object ID
     in the Standard Object Namespace.

--- a/DynamicTablesPkg/Include/TableGenerator.h
+++ b/DynamicTablesPkg/Include/TableGenerator.h
@@ -194,9 +194,9 @@ typedef enum TableGeneratorNameSpace {
   @return a TableGeneratorId calculated from the inputs.
 **/
 #define CREATE_TABLE_GEN_ID(TableType, TableNameSpaceId, TableId)      \
-          ((((TableType) << TABLE_TYPE_BIT_SHIFT) & TABLE_TYPE_MASK) | \
-           (((TableNameSpaceId) << TABLE_NAMESPACE_ID_BIT_SHIFT) &     \
-             TABLE_NAMESPACEID_MASK) | ((TableId) & TABLE_ID_MASK))
+          (((((TABLE_GENERATOR_ID)TableType) << TABLE_TYPE_BIT_SHIFT) & TABLE_TYPE_MASK) | \
+           ((((TABLE_GENERATOR_ID)TableNameSpaceId) << TABLE_NAMESPACE_ID_BIT_SHIFT) &     \
+             TABLE_NAMESPACEID_MASK) | (((TABLE_GENERATOR_ID)TableId) & TABLE_ID_MASK))
 
 /** Starting bit position for MAJOR revision
 */


### PR DESCRIPTION
# Description

The CREATE_CM_OBJECT_ID() and CREATE_TABLE_GEN_ID() macros shift an enum by 31 bits.  As enums are signed integers, this generates a portability finding from cppcheck.  To resolve the finding, we'll cast the enum values to the type expected as output from the macro.

Reviewed-by: Girish Mahadevan <gmahadevan@nvidia.com>


- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

cppcheck finding is resolved.  DynPkg tests continue to pass.

## Integration Instructions
N/A