### PR TITLE
StandaloneMmPkg: Remove Assert when gMmCommBufferHobGuid does not exist.

### DIFF
--- a/StandaloneMmPkg/Core/StandaloneMmCore.c
+++ b/StandaloneMmPkg/Core/StandaloneMmCore.c
@@ -446,8 +446,9 @@ MmCorePrepareCommunicationBuffer (
   mInternalCommBufferCopy = NULL;
 
   GuidHob = GetFirstGuidHob (&gMmCommBufferHobGuid);
-  ASSERT (GuidHob != NULL);
   if (GuidHob == NULL) {
+    DEBUG ((DEBUG_ERROR, "Failed to find MM Communication Buffer HOB\n"));
+    DEBUG ((DEBUG_ERROR, "Only Root MMI Handlers will be supported!\n"));
     return;
   }
 


### PR DESCRIPTION
# Description
When running StandaloneMmCore on a system, do not assert if gMmCommBufferHobGuid is not found. Output a debug message that details that the gMmCommBufferHobGuid was not found, that only root MmiHandlers will be dispatched.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested
Tested on virtual platform with top of tree TFA, with HOB_LIST=1 TRANSFER_LIST=1 used when building TFA.

## Integration Instructions
N/A