### PR TITLE
BaseTools: Add BUILDRULEFAMILY for CLANGDWARF

### DIFF
--- a/BaseTools/Conf/build_rule.template
+++ b/BaseTools/Conf/build_rule.template
@@ -293,6 +293,9 @@
     <Command.CLANGPDB>
         "$(DLINK)" /OUT:${dst} $(DLINK_FLAGS) $(DLINK_SPATH) @$(STATIC_LIBRARY_FILES_LIST) $(DLINK2_FLAGS)
 
+    <Command.CLANGDWARF>
+        "$(DLINK)" -o ${dst} $(DLINK_FLAGS) -Wl,--start-group,@$(STATIC_LIBRARY_FILES_LIST),--end-group $(CC_FLAGS) $(DLINK2_FLAGS)
+
     <Command.GCC>
         "$(DLINK)" -o ${dst} $(DLINK_FLAGS) -Wl,--start-group,@$(STATIC_LIBRARY_FILES_LIST),--end-group $(CC_FLAGS) $(DLINK2_FLAGS)
         "$(OBJCOPY)" $(OBJCOPY_FLAGS) ${dst}
@@ -350,6 +353,16 @@
         $(CP) ${dst} $(BIN_DIR)(+)$(MODULE_NAME_GUID).efi
         -$(CP) $(DEBUG_DIR)(+)*.map $(OUTPUT_DIR)
         -$(CP) $(DEBUG_DIR)(+)*.pdb $(OUTPUT_DIR) 
+
+    <Command.CLANGDWARF>
+        $(CP) ${src} $(DEBUG_DIR)(+)$(MODULE_NAME).debug
+        -$(CP) $(DEBUG_DIR)(+)$(MODULE_NAME).debug $(BIN_DIR)(+)$(MODULE_NAME_GUID).debug
+
+        "$(GENFW)" -e $(MODULE_TYPE) -o ${dst} ${src} $(GENFW_FLAGS)
+        $(CP) ${dst} $(DEBUG_DIR)
+        $(CP) ${dst} $(BIN_DIR)(+)$(MODULE_NAME_GUID).efi
+        -$(CP) $(DEBUG_DIR)(+)*.map $(OUTPUT_DIR)
+
     <Command.GCC>
         $(CP) ${src} $(DEBUG_DIR)(+)$(MODULE_NAME).debug
         "$(OBJCOPY)" $(OBJCOPY_STRIPFLAG) ${src}

--- a/BaseTools/Conf/tools_def.template
+++ b/BaseTools/Conf/tools_def.template
@@ -1993,6 +1993,7 @@ NOOPT_CLANGPDB_X64_GENFW_FLAGS      = --keepexceptiontable
 #
 ####################################################################################
 *_CLANGDWARF_*_*_FAMILY             = GCC
+*_CLANGDWARF_*_*_BUILDRULEFAMILY    = CLANGDWARF
 
 *_CLANGDWARF_*_MAKE_PATH            = ENV(CLANG_HOST_BIN)make
 *_CLANGDWARF_*_*_DLL                = ENV(CLANGDWARF_DLL)


### PR DESCRIPTION
Commit c6f47e6 removed BUILDRULEFAMILY for CLANGDWARF. Adding CLANGDWARF back as a BUILDRULEFAMILY to match CLANGPDB.

Add CLANGDWARF specific build rules -  based on GCC, and remove steps not required for CLANGDWARF.

Remove following irrelevant steps and logs:
...
"objcopy not needed ..."
"--strip-unneded ..."
"--add-gnu-debuglink ..."
...

# Description

Original PR https://github.com/tianocore/edk2/pull/6251 was auto-closed.

## How This Was Tested
- Build  SBSA Qemu using GCC5 and CLANGDWARF (AARCH64)
- Tested on internal platform

