### PR TITLE
MdePkg: fix fru device description string copy error.

### DIFF
--- a/MdePkg/Include/IndustryStandard/IpmiNetFnStorage.h
+++ b/MdePkg/Include/IndustryStandard/IpmiNetFnStorage.h
@@ -11,6 +11,7 @@
   and Appendix H, Sub-function Assignments.
 
   Copyright (c) 1999 - 2018, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2025 - Nvidia Corporation.  All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
@@ -320,9 +321,9 @@ typedef union {
 
 typedef union {
   struct {
-    UINT8    Length     : 4;
+    UINT8    Length     : 5;
     UINT8    Reserved   : 1;
-    UINT8    StringType : 3;
+    UINT8    StringType : 2;
   } Bits;
   UINT8    Uint8;
 } IPMI_SDR_RECORD_DEV_ID_STR_TYPE_LENGTH;


### PR DESCRIPTION
As per IPMI spec, fru string can be maximum of 16 bytes length and fru length field can take 5 bits (to hold values up to 16 - 10000b).

Current implementation allocates only 4 bits for Fru String Length and this is causing an error when 16 bytes length fru string needs to be copied as the first 4 bits in 0x10 is 0.

Fixed the structure IPMI_SDR_RECORD_DEV_ID_STR_TYPE_LENGTH, by allocating 5 bits for Length field as per the spec instead of 4.
