### PR TITLE
UefiPayloadPkg: Add macroes to control settings and build options

### DIFF
--- a/UefiPayloadPkg/UefiPayloadPkg.dsc
+++ b/UefiPayloadPkg/UefiPayloadPkg.dsc
@@ -160,6 +160,14 @@
   #
   DEFINE SECURE_BOOT_ENABLE       = FALSE
 
+  #
+  # Flat DeviceTree handoff option:
+  #   FALSE: Handover HobList to Payload
+  #   TRUE:  Handover FDT to Payload
+  #
+  #
+  HAND_OFF_FDT_ENABLE       = FALSE
+
 [BuildOptions]
   *_*_*_CC_FLAGS                 = -D DISABLE_NEW_DEPRECATED_INTERFACES
 !if $(USE_CBMEM_FOR_CONSOLE) == FALSE
@@ -556,8 +564,7 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdVpdBaseAddress|0x0
   gEfiMdeModulePkgTokenSpaceGuid.PcdStatusCodeUseMemory|FALSE
   gEfiMdeModulePkgTokenSpaceGuid.PcdUse1GPageTable|TRUE
-  gUefiPayloadPkgTokenSpaceGuid.PcdHandOffFdtEnable|FALSE
-
+  gUefiPayloadPkgTokenSpaceGuid.PcdHandOffFdtEnable|$(HAND_OFF_FDT_ENABLE)
 
   gEfiMdeModulePkgTokenSpaceGuid.PcdBootManagerMenuFile|{ 0x21, 0xaa, 0x2c, 0x46, 0x14, 0x76, 0x03, 0x45, 0x83, 0x6e, 0x8a, 0xb6, 0xf4, 0x66, 0x23, 0x31 }
   gUefiPayloadPkgTokenSpaceGuid.PcdPcdDriverFile|{ 0x57, 0x72, 0xcf, 0x80, 0xab, 0x87, 0xf9, 0x47, 0xa3, 0xfe, 0xD5, 0x0B, 0x76, 0xd8, 0x95, 0x41 }

--- a/UefiPayloadPkg/UefiPayloadPkg.dsc
+++ b/UefiPayloadPkg/UefiPayloadPkg.dsc
@@ -175,6 +175,7 @@
   INTEL:RELEASE_*_*_CC_FLAGS     = /D MDEPKG_NDEBUG
   MSFT:RELEASE_*_*_CC_FLAGS      = /D MDEPKG_NDEBUG
 !endif
+  *_*_*_CC_FLAGS                 = $(APPEND_CC_FLAGS)
 
 [BuildOptions.AARCH64]
   GCC:*_*_*_CC_FLAGS         = -mcmodel=tiny -mstrict-align

--- a/UefiPayloadPkg/UniversalPayloadBuild.py
+++ b/UefiPayloadPkg/UniversalPayloadBuild.py
@@ -164,6 +164,14 @@ def BuildUniversalPayload(Args):
         for MacroItem in Args.Macro:
             Defines += " -D {}".format (MacroItem)
 
+    if (Args.add_cc_flags!= None):
+        CcFlags = " ".join(Args.add_cc_flags)
+
+        # Wrap the CC flags with double quotes since we might have plenty of
+        # specified build options
+        FinalFlags = f'"{CcFlags}"'
+        Defines += " -D APPEND_CC_FLAGS={}".format (FinalFlags)
+
     #
     # Building DXE core and DXE drivers as DXEFV.
     #
@@ -330,6 +338,7 @@ def main():
     parser.add_argument("-f", "--Fit", action='store_true', help='Build UniversalPayload file as UniversalPayload.fit', default=False)
     parser.add_argument('-l', "--LoadAddress", type=int, help='Specify payload load address', default =0x000800000)
     parser.add_argument('-c', '--DscPath', type=str, default="UefiPayloadPkg/UefiPayloadPkg.dsc", help='Path to the DSC file')
+    parser.add_argument('-ac', '--add_cc_flags', action='append', help='Add specified CC compile flags')
 
     args = parser.parse_args()
 


### PR DESCRIPTION
# Description

Add macro DISABLE_MMX_SSE to disable MMX and SSE usages in build time for IA32 and X64 to avoid MMX and SSE usages.

Add macro to control HandOffFdt configuration, PcdHandOffFdtEnable can be enabled without editing source code


- [ ] Breaking change?
  - N/A

- [ ] Impacts security?
  - **Security** - N/A

- [ ] Includes tests?
  - **Tests** - N/A


## How This Was Tested

Validated for both X64 and ARM64 with QEMU

## Integration Instructions

python UefiPayloadPkg/UniversalPayloadBuild.py -t GCC5 -b DEBUG --Fit -DDISABLE_MMX_SSE=TRUE -DHAND_OFF_FDT_ENABLE=TRUE
