### PR TITLE
MdePkg: Add ACPI CEDT table structures

### DIFF
--- a/MdePkg/Include/IndustryStandard/Acpi64.h
+++ b/MdePkg/Include/IndustryStandard/Acpi64.h
@@ -2856,6 +2856,144 @@ typedef struct {
 #define EFI_ACPI_6_4_PHAT_FIRMWARE_HEALTH_DATA_RECORD_UNKNOWN          0x02
 #define EFI_ACPI_6_4_PHAT_FIRMWARE_HEALTH_DATA_RECORD_ADVISORY         0x03
 
+///
+/// CEDT Table Revision
+///
+#define EFI_ACPI_6_4_CEDT_CXL_EARLY_DISCOVERY_TABLE_REVISION_01  0x01
+
+///
+/// CEDT Structure Type
+///
+#define EFI_ACPI_6_4_CEDT_STRUCTURE_TYPE_CXL_HOST_BRIDGE_STRUCTURE                   0x00
+#define EFI_ACPI_6_4_CEDT_STRUCTURE_TYPE_CXL_FIXED_MEMORY_WINDOW_STRUCTURE           0x01
+#define EFI_ACPI_6_4_CEDT_STRUCTURE_TYPE_CXL_XOR_INTERLEAVE_MATH_STRUCTURE           0x02
+#define EFI_ACPI_6_4_CEDT_STRUCTURE_TYPE_RCEC_DOWNSTREAM_PORT_ASSOCIATION_STRUCTURE  0x03
+
+///
+/// CEDT CXL Host Bridge Structure
+///
+typedef struct {
+  UINT8     Type;  // Set to EFI_ACPI_6_4_CEDT_STRUCTURE_TYPE_CXL_HOST_BRIDGE_STRUCTURE
+  UINT8     Reserved0;
+  UINT16    RecordLength;
+  UINT32    Uid;
+  UINT32    CxlVersion;
+  UINT32    Reserved1;
+  UINT64    Base;
+  UINT64    Length;
+} EFI_ACPI_6_4_CEDT_CXL_HOST_BRIDGE_STRUCTURE;
+
+///
+/// CEDT CXL Version
+///
+#define EFI_ACPI_6_4_CEDT_CXL_HOST_BRIDGE_STRUCTURE_CXL_VERSION_RCH  0x00
+#define EFI_ACPI_6_4_CEDT_CXL_HOST_BRIDGE_STRUCTURE_CXL_VERSION_HB   0x01
+
+///
+/// CEDT CXL Fixed Memory Window Structure
+///
+typedef struct {
+  UINT8     Type;  // Set to EFI_ACPI_6_4_CEDT_STRUCTURE_TYPE_CXL_FIXED_MEMORY_WINDOW_STRUCTURE
+  UINT8     Reserved0;
+  UINT16    RecordLength;
+  UINT32    Reserved1;
+  UINT64    BaseHpa;
+  UINT64    WindowSize;
+  UINT8     EncodedNumberOfInterleaveWays;
+  UINT8     InterleaveArithmetic;
+  UINT16    Reserved2;
+  UINT32    HostBridgeInterleaveGranularity;
+  UINT16    WindowRestrictions;
+  UINT16    QtgId;
+  UINT32    InterleaveTargetList[];
+} EFI_ACPI_6_4_CEDT_CXL_FIXED_MEMORY_WINDOW_STRUCTURE;
+
+///
+/// CEDT Fixed Memory Window Structure Host Bridge Interleave Ways
+///
+#define EFI_ACPI_6_4_CEDT_CXL_FIXED_MEMORY_WINDOW_STRUCTURE_INTERLEAVE_WAYS_NONE    0x0
+#define EFI_ACPI_6_4_CEDT_CXL_FIXED_MEMORY_WINDOW_STRUCTURE_INTERLEAVE_WAYS_2_WAY   0x1
+#define EFI_ACPI_6_4_CEDT_CXL_FIXED_MEMORY_WINDOW_STRUCTURE_INTERLEAVE_WAYS_4_WAY   0x2
+#define EFI_ACPI_6_4_CEDT_CXL_FIXED_MEMORY_WINDOW_STRUCTURE_INTERLEAVE_WAYS_8_WAY   0x3
+#define EFI_ACPI_6_4_CEDT_CXL_FIXED_MEMORY_WINDOW_STRUCTURE_INTERLEAVE_WAYS_16_WAY  0x4
+#define EFI_ACPI_6_4_CEDT_CXL_FIXED_MEMORY_WINDOW_STRUCTURE_INTERLEAVE_WAYS_3_WAY   0x8
+#define EFI_ACPI_6_4_CEDT_CXL_FIXED_MEMORY_WINDOW_STRUCTURE_INTERLEAVE_WAYS_6_WAY   0x9
+#define EFI_ACPI_6_4_CEDT_CXL_FIXED_MEMORY_WINDOW_STRUCTURE_INTERLEAVE_WAYS_12_WAY  0xA
+
+///
+/// CEDT Fixed Memory Window Structure Interleave Arithmetic Type
+///
+#define EFI_ACPI_6_4_CEDT_CXL_FIXED_MEMORY_WINDOW_STRUCTURE_INTERLEAVE_ARITHMETIC_STANDARD_MODULO  0x00
+#define EFI_ACPI_6_4_CEDT_CXL_FIXED_MEMORY_WINDOW_STRUCTURE_INTERLEAVE_ARITHMETIC_MODULO_XOR       0x01
+
+///
+/// CEDT Host Bridge Interleave Granularity
+///
+#define EFI_ACPI_6_4_CEDT_CXL_HOST_BRIDGE_INTERLEAVE_GRANULARITY_256B    0x0
+#define EFI_ACPI_6_4_CEDT_CXL_HOST_BRIDGE_INTERLEAVE_GRANULARITY_512B    0x1
+#define EFI_ACPI_6_4_CEDT_CXL_HOST_BRIDGE_INTERLEAVE_GRANULARITY_1024B   0x2
+#define EFI_ACPI_6_4_CEDT_CXL_HOST_BRIDGE_INTERLEAVE_GRANULARITY_2048B   0x3
+#define EFI_ACPI_6_4_CEDT_CXL_HOST_BRIDGE_INTERLEAVE_GRANULARITY_4096B   0x4
+#define EFI_ACPI_6_4_CEDT_CXL_HOST_BRIDGE_INTERLEAVE_GRANULARITY_8192B   0x5
+#define EFI_ACPI_6_4_CEDT_CXL_HOST_BRIDGE_INTERLEAVE_GRANULARITY_16384B  0x6
+
+///
+/// CEDT Fixed Memory Window Structure Window Restriction
+///
+#define EFI_ACPI_6_4_CEDT_CXL_FIXED_MEMORY_WINDOW_STRUCTURE_WINDOW_RESTRICTIONS_DEVICE_COHERENT             BIT0
+#define EFI_ACPI_6_4_CEDT_CXL_FIXED_MEMORY_WINDOW_STRUCTURE_WINDOW_RESTRICTIONS_HOST_ONLY_COHERENT          BIT1
+#define EFI_ACPI_6_4_CEDT_CXL_FIXED_MEMORY_WINDOW_STRUCTURE_WINDOW_RESTRICTIONS_VOLATILE                    BIT2
+#define EFI_ACPI_6_4_CEDT_CXL_FIXED_MEMORY_WINDOW_STRUCTURE_WINDOW_RESTRICTIONS_PERSISTENT                  BIT3
+#define EFI_ACPI_6_4_CEDT_CXL_FIXED_MEMORY_WINDOW_STRUCTURE_WINDOW_RESTRICTIONS_FIXED_DEVICE_CONFIGURATION  BIT4
+
+///
+/// CEDT CXL XOR Interleave Math Structure
+///
+typedef struct {
+  UINT8     Type;  // Set to EFI_ACPI_6_4_CEDT_STRUCTURE_TYPE_CXL_XOR_INTERLEAVE_MATH_STRUCTURE
+  UINT8     Reserved0;
+  UINT16    RecordLength;
+  UINT16    Reserved1;
+  UINT8     HostBridgeInterleaveGranularity;
+  UINT8     NumberOfBitmapEntries;
+  UINT64    XormapList[];
+} EFI_ACPI_6_4_CEDT_CXL_XOR_INTERLEAVE_MATH_STRUCTURE;
+
+///
+/// CEDT RCEC Downstream Port Association Structure
+///
+typedef struct {
+  UINT8     Type;  // Set to EFI_ACPI_6_4_CEDT_STRUCTURE_TYPE_RCEC_DOWNSTREAM_PORT_ASSOCIATION_STRUCTURE
+  UINT8     Reserved0;
+  UINT16    RecordLength;
+  UINT16    RcecSegmentNumber;
+  UINT16    RcecBusDeviceFunction;
+  UINT8     ProtocolType;
+  UINT64    BaseAddress;
+} EFI_ACPI_6_4_CEDT_RCEC_DOWNSTREAM_PORT_ASSOCIATION_STRUCTURE;
+
+///
+/// CEDT RCEC Protocol Type
+///
+#define EFI_ACPI_6_4_CEDT_RCEC_PROTOCOL_TYPE_CXL_IO        0x00
+#define EFI_ACPI_6_4_CEDT_RCEC_PROTOCOL_TYPE_CXL_CACHEMEM  0x01
+
+///
+/// CXL Early Discovery Table ("CEDT") Format
+///
+typedef struct {
+  EFI_ACPI_DESCRIPTION_HEADER    Header;
+
+  // CedtStructure is a heterogeneous, packed list of any of the following:
+  //   - CXL Host Bridge Structure
+  //   - CXL Fixed Memory Window Structure
+  //   - CXL XOR Interleave Math Structure
+  //   - RCEC Downstream Port Association Structure
+  // The structures share common Type and RecordLength fields that are used to
+  // identify the type of structure and traverse the list.
+  UINT8    CedtStructure[];
+} EFI_ACPI_6_4_CXL_EARLY_DISCOVERY_TABLE;
+
 //
 // Known table signatures
 //
@@ -2889,6 +3027,11 @@ typedef struct {
 /// "CDIT" Component Distance Information Table
 ///
 #define EFI_ACPI_6_4_COMPONENT_DISTANCE_INFORMATION_TABLE_SIGNATURE  SIGNATURE_32('C', 'D', 'I', 'T')
+
+///
+/// "CEDT" CXL Early Discovery Table
+///
+#define EFI_ACPI_6_4_CXL_EARLY_DISCOVERY_TABLE_SIGNATURE  SIGNATURE_32('C', 'E', 'D', 'T')
 
 ///
 /// "CPEP" Corrected Platform Error Polling Table


### PR DESCRIPTION
Add structures for the ACPI table CEDT as defined in the CXL 3.0 specification

# Description

Adding definitions for the ACPI CEDT table defined in CXL.

- [ ] Breaking change?
  - No.
- [ ] Impacts security?
  - No.
- [ ] Includes tests?
  - No.

## How This Was Tested

Type definitions only; verified in local build.

## Integration Instructions

N/A
