### PR TITLE
BaseTools/GenFv: Ensure the minimum pad file size for the FV with VTF

### DIFF
--- a/BaseTools/Source/C/GenFv/GenFvInternalLib.c
+++ b/BaseTools/Source/C/GenFv/GenFvInternalLib.c
@@ -3153,7 +3153,6 @@ Returns:
 --*/
 {
   UINTN               CurrentOffset;
-  UINTN               OrigOffset;
   UINTN               Index;
   FILE                *fpin;
   UINTN               FfsFileSize;
@@ -3162,11 +3161,11 @@ Returns:
   UINT32              FfsHeaderSize;
   EFI_FFS_FILE_HEADER FfsHeader;
   UINTN               VtfFileSize;
-  UINTN               MaxPadFileSize;
+  UINTN               VtfPadSize;
 
   FvExtendHeaderSize = 0;
-  MaxPadFileSize = 0;
   VtfFileSize = 0;
+  VtfPadSize = 0;
   fpin  = NULL;
   Index = 0;
 
@@ -3274,12 +3273,8 @@ Returns:
         //
         // Only EFI_FFS_FILE_HEADER is needed for a pad section.
         //
-        OrigOffset    = CurrentOffset;
         CurrentOffset = (CurrentOffset + FfsHeaderSize + sizeof(EFI_FFS_FILE_HEADER) + FfsAlignment - 1) & ~(FfsAlignment - 1);
         CurrentOffset -= FfsHeaderSize;
-        if ((CurrentOffset - OrigOffset) > MaxPadFileSize) {
-          MaxPadFileSize = CurrentOffset - OrigOffset;
-        }
       }
     }
 
@@ -3304,9 +3299,18 @@ Returns:
 
   if (FvInfoPtr->Size == 0) {
     //
+    // Vtf file should be bottom aligned at end of block.
+    // If it is not aligned, insert EFI_FFS_FILE_HEADER to ensure the minimum pad file size for left space.
+    //
+    if ((VtfFileSize > 0) && (CurrentOffset % FvInfoPtr->FvBlocks[0].Length)) {
+      VtfPadSize = sizeof (EFI_FFS_FILE_HEADER);
+    }
+
+    //
     // Update FvInfo data
     //
-    FvInfoPtr->FvBlocks[0].NumBlocks = CurrentOffset / FvInfoPtr->FvBlocks[0].Length + ((CurrentOffset % FvInfoPtr->FvBlocks[0].Length)?1:0);
+    FvInfoPtr->FvBlocks[0].NumBlocks = ((CurrentOffset + VtfPadSize) / FvInfoPtr->FvBlocks[0].Length) +
+                                       (((CurrentOffset + VtfPadSize) % FvInfoPtr->FvBlocks[0].Length) ? 1 : 0);
     FvInfoPtr->Size = FvInfoPtr->FvBlocks[0].NumBlocks * FvInfoPtr->FvBlocks[0].Length;
     FvInfoPtr->FvBlocks[1].NumBlocks = 0;
     FvInfoPtr->FvBlocks[1].Length = 0;
@@ -3316,6 +3320,23 @@ Returns:
     //
     Error (NULL, 0, 3000, "Invalid", "the required fv image size 0x%x exceeds the set fv image size 0x%x", (unsigned) CurrentOffset, (unsigned) FvInfoPtr->Size);
     return EFI_INVALID_PARAMETER;
+  } else if ((VtfFileSize > 0) &&
+             (FvInfoPtr->Size > CurrentOffset) &&
+             ((FvInfoPtr->Size - CurrentOffset) < sizeof (EFI_FFS_FILE_HEADER)))
+  {
+    //
+    // Not invalid
+    //
+    Error (
+      NULL,
+      0,
+      3000,
+      "Invalid",
+      "the required fv image size = 0x%x. the set fv image size = 0x%x. Free space left is not enough to add a pad file (0x18)",
+      (unsigned)CurrentOffset,
+      (unsigned)FvInfoPtr->Size
+      );
+    return EFI_INVALID_PARAMETER;
   }
 
   //
@@ -3323,12 +3344,6 @@ Returns:
   //
   mFvTotalSize = FvInfoPtr->Size;
   mFvTakenSize = CurrentOffset;
-  if ((mFvTakenSize == mFvTotalSize) && (MaxPadFileSize > 0)) {
-    //
-    // This FV means TOP FFS has been taken. Then, check whether there is padding data for use.
-    //
-    mFvTakenSize = mFvTakenSize - MaxPadFileSize;
-  }
 
   return EFI_SUCCESS;
 }


### PR DESCRIPTION
In case of the FV with VTF, the left size should be enough to add the minimum pad file size (EFI_FFS_FILE_HEADER, 0x18). It prevents the build error, "GenFv: ERROR 0006: invalid FFS file header checksum" caused by the pad file overwriting some header data in VTF. This includes these updates for CalculateFvSize() function.

1. If NumBlocks is not defined, ensure the minimum pad file size for the left size (if the pad file is required as VTF is not bottom aligned at end of block, insert EFI_FFS_FILE_HEADER to ensure the pad file size)
2. If NumBlocks is defined, report more clear error message (the required fv image size = 0x%x. the set fv image size = 0x%x. Free space left is not enough to add a pad file (0x18))
3. Remove MaxPadFileSize, which is reported when the taken size is same as the total size. It can not be the actual left size to add an FFS file. It causes confusion when referring to the build log (FV Space Information)

How to reproduce the case/issue on EDK2 codebase: 
1. Clone the TianoCore master codebase (e.g. 3/5 master).
2. Build any one of the OVMF's arch projects. (e.g. OvmfPkg/OvmfPkgX64.dsc).
3. Take the free space size value of SECFV (e.g. 0x12345 free from the build messages of FV Space Information).
```
FV Space Information
SECFV [34%Full] 212992 (0x34000) total, 74480 (0x122f0) used, 138512 (0x21d10) free
```
4. Add a line to OvmfPkg\ResetVector\Ia16\ResetVectorVtf0.asm to fill up that FV's free space up to "0x10" bytes left. (e.g. TIMES (0x12345-0x10) DB 0).
```
TIMES (0x21d10-0x10) DB 0
```
5. Rebuild the OVMF project. Then the build error is raised.
```
Generating SECFV FV
#### ['GenFv', '-a', 'C:\\Develop\\OvmfPkgX64.0305\\Build\\OvmfX64\\DEBUG_VS2019\\FV\\Ffs\\SECFV.inf', '-o', 'C:\\Develop\\OvmfPkgX64.0305\\Build\\OvmfX64\\DEBUG_VS2019\\FV\\SECFV.Fv', '-i', 'C:\\Develop\\OvmfPkgX64.0305\\Build\\OvmfX64\\DEBUG_VS2019\\FV\\SECFV.inf']
Return Value = 2
GenFv: ERROR 0006: invalid FFS file header checksum
  Ffs file with Guid 00F0AA10-0010-F800-8566-336AE8F78F09
GenFv: ERROR 3000: Invalid
  Could not update the reset vector.
```  
- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

We have met the build issue and verified the update on AMD EDK2 bios.

## Integration Instructions

N/A
