### PR TITLE
DynamicTablesPkg: container ProcId for PPTT/SSDT

### DIFF
--- a/DynamicTablesPkg/Library/Acpi/Common/AcpiPpttLib/PpttGenerator.c
+++ b/DynamicTablesPkg/Library/Acpi/Common/AcpiPpttLib/PpttGenerator.c
@@ -488,6 +488,7 @@ AddProcHierarchyNodes (
   PPTT_NODE_INDEXER  *ProcNodeIterator;
   UINT32             NodeCount;
   UINT32             Length;
+  UINT32             ProcContainerIndex;
 
   ASSERT (
     (Generator != NULL) &&
@@ -515,6 +516,7 @@ AddProcHierarchyNodes (
   }
 
   UniqueGicCRefCount = 0;
+  ProcContainerIndex = 0;
 
   while (NodeCount-- != 0) {
     ProcInfoNode = (CM_ARCH_COMMON_PROC_HIERARCHY_INFO *)ProcNodeIterator->Object;
@@ -605,17 +607,28 @@ AddProcHierarchyNodes (
       // Default invalid ACPI Processor ID to 0
       ProcStruct->AcpiProcessorId = 0;
     } else if (ProcInfoNode->AcpiIdObjectToken == CM_NULL_TOKEN) {
-      Status = EFI_INVALID_PARAMETER;
-      DEBUG ((
-        DEBUG_ERROR,
-        "ERROR: PPTT: The 'ACPI Processor ID valid' flag is set but no " \
-        "ACPI ID Reference object token was provided. " \
-        "AcpiIdObjectToken = %p. RequestorToken = %p. Status = %r\n",
-        ProcInfoNode->AcpiIdObjectToken,
-        ProcInfoNode->Token,
-        Status
-        ));
-      return Status;
+      if (IS_PROC_NODE_LEAF (ProcInfoNode)) {
+        Status = EFI_INVALID_PARAMETER;
+        DEBUG ((
+          DEBUG_ERROR,
+          "ERROR: PPTT: The 'ACPI Processor ID valid' flag is set but no " \
+          "ACPI ID Reference object token was provided. " \
+          "AcpiIdObjectToken = %p. RequestorToken = %p. Status = %r\n",
+          ProcInfoNode->AcpiIdObjectToken,
+          ProcInfoNode->Token,
+          Status
+          ));
+        return Status;
+      }
+
+      // Node is a ProcContainer with a valid ID
+
+      if (ProcInfoNode->OverrideNameUidEnabled) {
+        ProcStruct->AcpiProcessorId = ProcInfoNode->OverrideUid;
+      } else {
+        // Note: This value MUST match the value assigned to the _UID in SsdtCpuTopologyGenerator.c
+        ProcStruct->AcpiProcessorId = ProcContainerIndex++;
+      }
     } else {
       Status = GetEArmObjGicCInfo (
                  CfgMgrProtocol,

--- a/DynamicTablesPkg/Library/Acpi/Common/AcpiSsdtCpuTopologyLib/SsdtCpuTopologyGenerator.c
+++ b/DynamicTablesPkg/Library/Acpi/Common/AcpiSsdtCpuTopologyLib/SsdtCpuTopologyGenerator.c
@@ -935,11 +935,11 @@ CheckProcNode (
 
   // Check Leaf specific flags.
   if (IsLeaf) {
-    InvalidFlags |= ((NodeFlags & PPTT_LEAF_MASK) != PPTT_LEAF_MASK);
+    InvalidFlags |= ((NodeFlags & PPTT_VALID_LEAF_MASK) != PPTT_VALID_LEAF_MASK);
     // Must have Physical Package flag somewhere in the hierarchy
     InvalidFlags |= !(HasPhysicalPackageBit || PackageNodeSeen);
   } else {
-    InvalidFlags |= ((NodeFlags & PPTT_LEAF_MASK) != 0);
+    InvalidFlags |= ((NodeFlags & PPTT_LEAF_FLAG_MASK) != 0);
   }
 
   if (InvalidFlags) {
@@ -957,7 +957,7 @@ CheckProcNode (
 
 /** Create an AML representation of the Cpu topology.
 
-  A processor container is by extension any non-leave device in the cpu topology.
+  A processor container is by extension any non-leaf device in the cpu topology.
 
   @param [in] Generator               The SSDT Cpu Topology generator.
   @param [in] CfgMgrProtocol          Pointer to the Configuration Manager

--- a/DynamicTablesPkg/Library/Acpi/Common/AcpiSsdtCpuTopologyLib/SsdtCpuTopologyGenerator.h
+++ b/DynamicTablesPkg/Library/Acpi/Common/AcpiSsdtCpuTopologyLib/SsdtCpuTopologyGenerator.h
@@ -42,8 +42,11 @@
           (EFI_ACPI_6_3_PPTT_NODE_IS_NOT_LEAF << 3))
 
 // Leaf nodes specific mask.
-#define PPTT_LEAF_MASK  ((EFI_ACPI_6_3_PPTT_PROCESSOR_ID_VALID << 1) |        \
-                         (EFI_ACPI_6_3_PPTT_NODE_IS_LEAF << 3))
+#define PPTT_VALID_LEAF_MASK  ((EFI_ACPI_6_3_PPTT_PROCESSOR_ID_VALID << 1) |  \
+                               (EFI_ACPI_6_3_PPTT_NODE_IS_LEAF << 3))
+
+// Mask for the LEAF flag.
+#define PPTT_LEAF_FLAG_MASK  (EFI_ACPI_6_3_PPTT_NODE_IS_LEAF << 3)
 
 /** LPI states are stored in the ASL namespace at '\_SB_.Lxxx',
     with xxx being the node index of the LPI state.


### PR DESCRIPTION
# Description

The current PPTT and SSDT code only allows for
AcpiProcessorId to be set/valid for leaf nodes,
but the ACPI spec allows (and in some cases
requires) it to be set for processor containers in the hierarchy as well.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

In use at NVIDIA since the EDK2 August 2024 stable release. Not tested on the tip of EDK2.

## Integration Instructions

N/A
