### PR TITLE
BaseTools/Source/C: Disable VS flexible array member warning

### DIFF
--- a/BaseTools/Source/C/Makefiles/ms.common
+++ b/BaseTools/Source/C/Makefiles/ms.common
@@ -44,6 +44,8 @@ BIN_PATH     = $(BASE_TOOLS_PATH)\Bin\Win32
 LIB_PATH     = $(BASE_TOOLS_PATH)\Lib\Win32
 SYS_BIN_PATH = $(EDK_TOOLS_PATH)\Bin\Win32
 SYS_LIB_PATH = $(EDK_TOOLS_PATH)\Lib\Win32
+# Note: Disable flexible array member warnings
+CFLAGS = $(CFLAGS) /wd4200
 
 !ELSEIF "$(HOST_ARCH)"=="X64"
 ARCH_INCLUDE = $(EDK2_PATH)\MdePkg\Include\X64
@@ -52,6 +54,8 @@ LIB_PATH     = $(BASE_TOOLS_PATH)\Lib\Win64
 SYS_BIN_PATH = $(EDK_TOOLS_PATH)\Bin\Win64
 SYS_LIB_PATH = $(EDK_TOOLS_PATH)\Lib\Win64
 CFLAGS = $(CFLAGS) /wd4267 /wd4244 /wd4334
+# Note: Disable flexible array member warnings
+CFLAGS = $(CFLAGS) /wd4200
 
 !ELSEIF "$(HOST_ARCH)"=="ARM"
 ARCH_INCLUDE = $(EDK2_PATH)\MdePkg\Include\Arm
@@ -59,6 +63,8 @@ BIN_PATH     = $(BASE_TOOLS_PATH)\Bin\Win32
 LIB_PATH     = $(BASE_TOOLS_PATH)\Lib\Win32
 SYS_BIN_PATH = $(EDK_TOOLS_PATH)\Bin\Win32
 SYS_LIB_PATH = $(EDK_TOOLS_PATH)\Lib\Win32
+# Note: Disable flexible array member warnings
+CFLAGS = $(CFLAGS) /wd4200
 
 !ELSEIF "$(HOST_ARCH)"=="AARCH64"
 ARCH_INCLUDE = $(EDK2_PATH)\MdePkg\Include\AArch64
@@ -68,7 +74,8 @@ SYS_BIN_PATH = $(EDK_TOOLS_PATH)\Bin\Win64
 SYS_LIB_PATH = $(EDK_TOOLS_PATH)\Lib\Win64
 # Note: These are bit-width conversion related warning suppressions.
 CFLAGS = $(CFLAGS) /wd4267 /wd4244 /wd4334
-
+# Note: Disable flexible array member warnings
+CFLAGS = $(CFLAGS) /wd4200
 !ELSE
 !ERROR "Bad HOST_ARCH"
 !ENDIF


### PR DESCRIPTION
# Description

Add /wd4200 to all visual studio builds of C tools in BaseTools. This disables warnings for use of flexible array members that are allowed in edk2 include files. Some tools use include files from MdePkg that use flexible array members.

This matches the warning disables used to build structured PCD in BaseTools/Source/Python/Workspace/DscBuildData.py where flexible array members are more widely used.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

Build BaseTools before this change with flexible array member in MdePkg ACPI include files and GenFw build fails with an error.

Apply this change to add /wd4200 and GenFw build completed without error.

## Integration Instructions

N/A
