### PR TITLE
PrmPkg: Handle Non-Existent MMIO and Align Signature to Spec

### DIFF
--- a/PrmPkg/Include/PrmDataBuffer.h
+++ b/PrmPkg/Include/PrmDataBuffer.h
@@ -12,7 +12,7 @@
 
 #include <Uefi.h>
 
-#define PRM_DATA_BUFFER_HEADER_SIGNATURE  SIGNATURE_32('P','R','M','D')
+#define PRM_DATA_BUFFER_HEADER_SIGNATURE  SIGNATURE_32('P','R','M','S')
 
 #pragma pack(push, 1)
 


### PR DESCRIPTION
# Description

This commit consists of two commits:

PrmPkg: PRM support for non-existent MMIO ranges
--
This is regarding PRM modules that are describing MMIO ranges.

When PrmConfigDxe is calling GetMemorySpaceDescriptor() with a memory range that is visible to the boot processor but has not been added to the memory map GetMemorySpaceDescriptor() will return EFI_SUCCESS and then return a memory descriptor indicating that the region is non-existent. This causes SetRuntimeMemoryRangeAttributes() to believe that the region has already been added to the memory map and will eventually cause an ASSERT.

This PR allows for SetRuntimeMemoryRangeAttributes() to treat a non-existent MMIO range the same as a range that triggered a EFI_NOT_FOUND error response from GetMemorySpaceDescriptor().

PrmPkg: Align Data Buffer Signature to Spec
--
edk2's PRM Data Buffer Signature is 'PRMD', however PRM spec 1.0 section 4.2.1 Static Data Buffer indicates that the signature should be 'PRMS'.

This commit aligns edk2's signature definition with the spec.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Tested on a platform that had an MMIO range for a PRM module in non-existent memory.

## Integration Instructions

N/A.
