### PR TITLE
CapsuleApp: Fix proper return after capsule update

### DIFF
--- a/MdeModulePkg/Application/CapsuleApp/CapsuleApp.c
+++ b/MdeModulePkg/Application/CapsuleApp/CapsuleApp.c
@@ -1029,6 +1029,7 @@ UefiMain (
     Status = gRT->UpdateCapsule (CapsuleHeaderArray, CapsuleNum, (UINTN)BlockDescriptors);
     if (Status != EFI_SUCCESS) {
       Print (L"CapsuleApp: failed to update capsule - %r\n", Status);
+      goto Done;
     }
   }
 


### PR DESCRIPTION
After a failed capsule updated it returns 0 and not Status failure.

Tested-by: Ilias Apalodimas <ilias.apalodimas@linaro.org>
Signed-off-by: Javier Tia <javier.tia@linaro.org>

# Description

<_Include a description of the change and why this change was made._>

self-explanatory by the change.

<_For each item, place an "x" in between `[` and `]` if true. Example: `[x]` (you can also check items in GitHub UI)_>

<_Create the PR as a Draft PR if it is only created to run CI checks._>

<_Delete lines in \<\> tags before creating the PR._>

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

<_Describe the test(s) that were run to verify the changes._>

Before this change it returns 0:
```
CapsuleApp: failed to update capsule - Security Violation
0x0
```
After this change:
```
CapsuleApp: failed to update capsule - Security Violation
0x1A
```

## Integration Instructions

<_Describe how these changes should be integrated. Use N/A if nothing is required._>
