### PR TITLE
BaseTools: Fix missing module PCD in compile information of build report

### DIFF
--- a/BaseTools/Source/Python/build/BuildReport.py
+++ b/BaseTools/Source/Python/build/BuildReport.py
@@ -2388,7 +2388,7 @@ class BuildReport(object):
 
                         # PCD's in module
                         module_report_data["Pcd"] = []
-                        for data_pcd in module.LibraryPcdList:
+                        for data_pcd in module.ModulePcdList + module.LibraryPcdList:
                             module_report_data["Pcd"].append({"Space": data_pcd.TokenSpaceGuidCName,
                                                               "Name": data_pcd.TokenCName,
                                                               "Value": data_pcd.TokenValue,


### PR DESCRIPTION
Module PCD in compile information is missed in module_report.json

