### PR TITLE
OvmfPkg/HardwareInfoLib: Reserve device type ID for SVSM

### DIFF
--- a/OvmfPkg/Library/HardwareInfoLib/HardwareInfoTypesLib.h
+++ b/OvmfPkg/Library/HardwareInfoLib/HardwareInfoTypesLib.h
@@ -18,8 +18,9 @@
 // types which have an associated type definition
 //
 typedef enum {
-  HardwareInfoTypeUndefined  = 0,
-  HardwareInfoTypeHostBridge = 1,
+  HardwareInfoTypeUndefined      = 0,
+  HardwareInfoTypeHostBridge     = 1,
+  HardwareInfoTypeSvsmVirtioMmio = 0x1000,
 
   HardwareInfoTypeMax
 } HARDWARE_INFO_TYPE;


### PR DESCRIPTION
# Description

Reserve a new device type ID for Virtio MMIO devices intended to be used by
the Secure VM Service Module (SVSM).

Coconut SVSM will be using a Virtio-Blk device via the MMIO transport to
persist state, when running under Qemu. The guest OS shall not try to use the device.

The HardwareInfoLib is an ideal channel to communicate the device
information to the SVSM, due to its simplicity and flexibility to
include arbitrary information, and since it does not interfere with
regular hardware configuration mechanisms of the guest OS.

This device type is intended for the SVSM only and no code is added
to EDK2 that makes use of it.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested
- N/A
## Integration Instructions
- N/A
