### PR TITLE
Make MM buffer related structures packed

### DIFF
--- a/MdeModulePkg/Include/Guid/MmCommBuffer.h
+++ b/MdeModulePkg/Include/Guid/MmCommBuffer.h
@@ -47,6 +47,9 @@ typedef struct {
   ///
   BOOLEAN    IsCommBufferValid;
 
+  /// For padding purpose
+  UINT8      Reserved[7];
+
   ///
   /// The return status when returning from MM to non-MM.
   ///


### PR DESCRIPTION
Make sure MM buffer structures are packed as different FW modules access them.

# Description

Create packed structures which describe MM info. These structures are used across different FW compoents (sometimes non edk2).

- [ ] Breaking change?
No
- [ ] Impacts security?
No
- [ ] Includes tests?
No

Change was tested on RISC-V MM implementation to be upstreamed later.
