### PR TITLE
BaseTools: Fix Debug Macro Checking to Include Scanning Files

### DIFF
--- a/BaseTools/Plugin/DebugMacroCheck/DebugMacroCheck.py
+++ b/BaseTools/Plugin/DebugMacroCheck/DebugMacroCheck.py
@@ -429,7 +429,7 @@ def check_macros_in_directory(directory: PurePath,
 
         files = []
         for file in root_directory.rglob('*'):
-            if file.suffix in extensions and not file.is_dir:
+            if file.suffix in extensions and not file.is_dir():
                 files.append(Path(file))
 
             # Give an indicator progress is being made

--- a/DynamicTablesPkg/Library/Acpi/X64/AcpiFacsLib/FacsGenerator.c
+++ b/DynamicTablesPkg/Library/Acpi/X64/AcpiFacsLib/FacsGenerator.c
@@ -269,7 +269,7 @@ FacsUpdateTableInfo (
   {
     DEBUG ((
       DEBUG_ERROR,
-      "ERROR: FACS: Invalid Flags. Flags = 0x%x, OSPM Flags = 0x%x.\n",
+      "ERROR: FACS: Invalid Flags. Flags = 0x%x, OSPM Flags = 0x%x.\n"
       "       64-bit wake is not supported but 64-bit wake flag is set.\n",
       FacsInfo->Flags,
       FacsInfo->OspmFlags


### PR DESCRIPTION
# Description

- In the commit 42a141800c0c26a09d2344e84a89ce4097a263ae there was a misuse of "is_dir" method.

- Treating it as an object rather than function call, which caused if-condition to always as "false".

- No files would be added to scanning list due to incorrect usage.

- This patch corrects the issue by properly using "is_dir()".

- [ ] Breaking change?
  - No, this change is bug-fix only.

- [ ] Impacts security?
  - No, this change do not include any security-related change.

- [X] Includes tests?
  - This change passed the EDK-II CI build without any issue.

## How This Was Tested

- Check the pytool plugin could be executed correctly.

## Integration Instructions

- N/A.
