### PR TITLE
OvmfPkg: Use user-specified opt/ovmf/X-PciMmio64Mb value unconditionally

### DIFF
--- a/OvmfPkg/Include/Library/PlatformInitLib.h
+++ b/OvmfPkg/Include/Library/PlatformInitLib.h
@@ -37,6 +37,7 @@ typedef struct {
 
   UINT64               PcdPciMmio64Base;
   UINT64               PcdPciMmio64Size;
+  BOOLEAN              PcdPciMmio64Override;
   UINT32               PcdPciMmio32Base;
   UINT32               PcdPciMmio32Size;
   UINT64               PcdPciIoBase;

--- a/OvmfPkg/Library/PlatformInitLib/MemDetect.c
+++ b/OvmfPkg/Library/PlatformInitLib/MemDetect.c
@@ -556,7 +556,8 @@ PlatformGetFirstNonAddress (
       break;
     case EFI_SUCCESS:
       if (FwCfgPciMmio64Mb <= 0x1000000) {
-        PlatformInfoHob->PcdPciMmio64Size = LShiftU64 (FwCfgPciMmio64Mb, 20);
+        PlatformInfoHob->PcdPciMmio64Size     = LShiftU64 (FwCfgPciMmio64Mb, 20);
+        PlatformInfoHob->PcdPciMmio64Override = TRUE;
         break;
       }
 
@@ -795,8 +796,10 @@ PlatformDynamicMmioWindow (
   AddrSpace = LShiftU64 (1, PlatformInfoHob->PhysMemAddressWidth);
   MmioSpace = LShiftU64 (1, PlatformInfoHob->PhysMemAddressWidth - 3);
 
-  if ((PlatformInfoHob->PcdPciMmio64Size < MmioSpace) &&
-      (PlatformInfoHob->PcdPciMmio64Base + MmioSpace < AddrSpace))
+  if (PlatformInfoHob->PcdPciMmio64Override) {
+    DEBUG ((DEBUG_INFO, "%a: using fwcfg override for mmio window\n", __func__));
+  } else if ((PlatformInfoHob->PcdPciMmio64Size < MmioSpace) &&
+             (PlatformInfoHob->PcdPciMmio64Base + MmioSpace < AddrSpace))
   {
     DEBUG ((DEBUG_INFO, "%a: using dynamic mmio window\n", __func__));
     DEBUG ((DEBUG_INFO, "%a:   Addr Space 0x%Lx (%Ld GB)\n", __func__, AddrSpace, RShiftU64 (AddrSpace, 30)));


### PR DESCRIPTION
# Description

Prior to this change, OVMF considers opt/ovmf/X-PciMmio64Mb to be the _minimum_ aperture size, allowing us to force the window to be larger but not smaller than what PlatformDynamicMmioWindow calculates.

This change adjusts OVMF so that a smaller value for the aperture is honored.

Context:
Due to an inefficiency in the way older host kernels manage pfnmaps for guest VM memory ranges [0], guests with large-BAR GPUs passed-through have a very long (multiple minutes) initialization time when the MMIO window advertised by OVMF is sufficiently sized for the passed-through BARs (i.e., the correct OVMF behavior). However, on older distro series such as Ubuntu Jammy, users have benefited from fast guest boot times when OVMF advertised an MMIO window that was too small to accommodate the full BAR, since this resulted in the long PCI initialization process being skipped (and retried later, if pci=realloc pci=nocrs were set).

While the root cause is being fully addressed in the upstream kernel [1], the solution relies on huge pfnmap support, which is a substantial series with many ABI changes that is unlikely to land in many LTS and legacy distro kernels, including those of Ubuntu Noble. As a result, the only kernel improvement supported on those kernels is this patch [2], which reduces the extra boot time by about half. Unfortunately, that boot time is still an average of 1-3 minutes longer per-VM-boot than what can be achieved when the host is running a version of OVMF without PlatformDynamicMmioWindow (PDMW) support (introduced in [3])

Since there is no way to force the use of the classic MMIO window size[4] in any version of OVMF after [3], and since we have a use case for such functionality on legacy distro kernels that would yield significant, recurring compute time savings across all impacted VMs, this change to this knob's behavior seems appropriate.

[0]: https://lore.kernel.org/all/CAHTA-uYp07FgM6T1OZQKqAdSA5JrZo0ReNEyZgQZub4mDRrV5w@mail.gmail.com/
[1]: https://lore.kernel.org/all/20250205231728.2527186-1-alex.williamson@redhat.com/
[2]: https://lore.kernel.org/all/20250111210652.402845-1-alex.williamson@redhat.com/
[3]: ecb778d
[4]: https://edk2.groups.io/g/devel/topic/109651206?p=Created,,,20,1,0,0


- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

I have verified that this knob works as expected for values large enough for the GPU MMIO windows (as supported by the original behavior) and for values smaller than what PDMW computes (newly introduced by this patch).
On DGX H100, forcing a value of 1024 (lower than required for passed-through GPUs) results in desired fast boot time, with GPUs still being usable as long as pci=nocrs pci=realloc are set in the guest, even on legacy kernels. I also observed no regressions, and no change in behavior when X-PciMmio64Mb is absent or above the PDMW-calculated value.

## Integration Instructions

Specify a fw_cfg value for X-PciMmio64Mb.

Ex: Small value via libvirt xml, which results in fast boot (but requires `pci=realloc pci=nocrs` on H100):
```
  <qemu:commandline>
    <qemu:arg value='-fw_cfg'/>
    <qemu:arg value='name=opt/ovmf/X-PciMmio64Mb,string=1024'/>
  </qemu:commandline>
```

Ex: Large value via libvirt xml (behavior unchanged from current OVMF handling on H100, since this is a large enough aperture for my GPUs):
```
  <qemu:commandline>
    <qemu:arg value='-fw_cfg'/>
    <qemu:arg value='name=opt/ovmf/X-PciMmio64Mb,string=262144'/>
  </qemu:commandline>
```