### PR TITLE
UnitTestFrameworkPkg: Avoid duplicate library function names

### DIFF
--- a/UnitTestFrameworkPkg/Library/UnitTestPeiServicesTablePointerLib/UnitTestPeiServicesTablePointerLib.c
+++ b/UnitTestFrameworkPkg/Library/UnitTestPeiServicesTablePointerLib/UnitTestPeiServicesTablePointerLib.c
@@ -37,8 +37,8 @@ EFI_PEI_SERVICES  mPeiServices = {
   UnitTestFfsFindSectionData, // FfsFindSectionData
 
   UnitTestInstallPeiMemory, // InstallPeiMemory
-  UnitTestAllocatePages,    // AllocatePages
-  UnitTestAllocatePool,     // AllocatePool
+  UnitTestPeiAllocatePages, // AllocatePages
+  UnitTestPeiAllocatePool,  // AllocatePool
   (EFI_PEI_COPY_MEM)CopyMem,
   (EFI_PEI_SET_MEM)SetMem,
 
@@ -55,7 +55,7 @@ EFI_PEI_SERVICES  mPeiServices = {
   UnitTestFfsFindSectionData3, // FfsFindSectionData3
   UnitTestFfsGetFileInfo2,     // FfsGetFileInfo2
   UnitTestResetSystem2,        // ResetSystem2
-  UnitTestFreePages,           // FreePages
+  UnitTestPeiFreePages,        // FreePages
 };
 
 PEI_CORE_INSTANCE  mPrivateData;

--- a/UnitTestFrameworkPkg/Library/UnitTestPeiServicesTablePointerLib/UnitTestPeiServicesTablePointerLib.h
+++ b/UnitTestFrameworkPkg/Library/UnitTestPeiServicesTablePointerLib/UnitTestPeiServicesTablePointerLib.h
@@ -430,7 +430,7 @@ UnitTestInstallPeiMemory (
 **/
 EFI_STATUS
 EFIAPI
-UnitTestAllocatePages (
+UnitTestPeiAllocatePages (
   IN CONST EFI_PEI_SERVICES      **PeiServices,
   IN       EFI_MEMORY_TYPE       MemoryType,
   IN       UINTN                 Pages,
@@ -455,7 +455,7 @@ UnitTestAllocatePages (
 **/
 EFI_STATUS
 EFIAPI
-UnitTestAllocatePool (
+UnitTestPeiAllocatePool (
   IN CONST EFI_PEI_SERVICES  **PeiServices,
   IN       UINTN             Size,
   OUT      VOID              **Buffer
@@ -644,7 +644,7 @@ Frees memory pages.
 **/
 EFI_STATUS
 EFIAPI
-UnitTestFreePages (
+UnitTestPeiFreePages (
   IN CONST EFI_PEI_SERVICES  **PeiServices,
   IN EFI_PHYSICAL_ADDRESS    Memory,
   IN UINTN                   Pages

--- a/UnitTestFrameworkPkg/Library/UnitTestPeiServicesTablePointerLib/UnitTestPeiServicesTablePointerLibMisc.c
+++ b/UnitTestFrameworkPkg/Library/UnitTestPeiServicesTablePointerLib/UnitTestPeiServicesTablePointerLibMisc.c
@@ -176,7 +176,7 @@ UnitTestInstallPeiMemory (
 **/
 EFI_STATUS
 EFIAPI
-UnitTestAllocatePages (
+UnitTestPeiAllocatePages (
   IN CONST EFI_PEI_SERVICES      **PeiServices,
   IN       EFI_MEMORY_TYPE       MemoryType,
   IN       UINTN                 Pages,
@@ -204,7 +204,7 @@ UnitTestAllocatePages (
 **/
 EFI_STATUS
 EFIAPI
-UnitTestAllocatePool (
+UnitTestPeiAllocatePool (
   IN CONST EFI_PEI_SERVICES  **PeiServices,
   IN       UINTN             Size,
   OUT      VOID              **Buffer
@@ -420,7 +420,7 @@ Frees memory pages.
 **/
 EFI_STATUS
 EFIAPI
-UnitTestFreePages (
+UnitTestPeiFreePages (
   IN CONST EFI_PEI_SERVICES  **PeiServices,
   IN EFI_PHYSICAL_ADDRESS    Memory,
   IN UINTN                   Pages


### PR DESCRIPTION
There are duplicate library function names between 2 Unit Test libraries (UnitTestPeiServicesTablePointerLib and UnitTestUefiBootServicesTableLib). There are 3 functions (UnitTestAllocatePages, UnitTestAllocatePool and UnitTestFreePage). This update avoids the duplication and prevents a build error when building a Unit Test application that links the libraries based on UnitTestFrameworkPkg.

Build Error Example : 
UnitTestUefiBootServicesTableLib.lib(UnitTestUefiBootServicesTableLibMemory.obj) : error LNK2005: _UnitTestAllocatePages already defined in UnitTestPeiServicesTablePointerLib.lib(UnitTestPeiServicesTablePointerLibMisc.obj)
UnitTestUefiBootServicesTableLib.lib(UnitTestUefiBootServicesTableLibMemory.obj) : error LNK2005: _UnitTestAllocatePool already defined in UnitTestPeiServicesTablePointerLib.lib(UnitTestPeiServicesTablePointerLibMisc.obj)
UnitTestUefiBootServicesTableLib.lib(UnitTestUefiBootServicesTableLibMemory.obj) : error LNK2005: _UnitTestFreePages already defined in UnitTestPeiServicesTablePointerLib.lib(UnitTestPeiServicesTablePointerLibMisc.obj)

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

In AMD EDKII bios, there was the build issue with a Unit Test application for AGESA module. As fixing the issue, the update has been verified on AMD EDKII bios.

## Integration Instructions

N/A
