### PR TITLE
MdePkg/Include: PciExpress60: Add DOE support and definitions

### DIFF
--- a/MdePkg/Include/IndustryStandard/PciExpress60.h
+++ b/MdePkg/Include/IndustryStandard/PciExpress60.h
@@ -33,6 +33,22 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #define EFI_PCIE_CAPABILITY_DEVICE_CONTROL_3_OFFSET       0x08
 #define EFI_PCIE_CAPABILITY_DEVICE_STATUS_3_OFFSET        0x0C
 
+//
+// The Data Object Exchange PCI Express Extended Capability definitions.
+// Based on section 7.9.24 of PCI Express Base Specification 6.0.
+//
+#define PCI_EXPRESS_EXTENDED_CAPABILITY_DOE_ID    0x002E
+#define PCI_EXPRESS_EXTENDED_CAPABILITY_DOE_VER1  0x1
+
+//
+// Register offsets from Data Object Exchange PCIe Ext Cap Header
+//
+#define PCI_EXPRESS_REG_DOE_CAPABILITIES_OFFSET        0x04
+#define PCI_EXPRESS_REG_DOE_CONTROL_OFFSET             0x08
+#define PCI_EXPRESS_REG_DOE_STATUS_OFFSET              0x0C
+#define PCI_EXPRESS_REG_DOE_WRITE_DATA_MAILBOX_OFFSET  0x10
+#define PCI_EXPRESS_REG_DOE_READ_DATA_MAILBOX_OFFSET   0x14
+
 #pragma pack(1)
 
 typedef union {
@@ -116,6 +132,53 @@ typedef union {
   UINT32    Uint32;
 } PCI_REG_PCIE_DEVICE_STATUS3;
 
+typedef union {
+  struct {
+    UINT32    InterruptSupport          : 1;      // bit 0
+    UINT32    DoeInterruptMessageNumber : 11;     // bit 1:11
+    UINT32    Reserved                  : 20;     // Reserved bit 12:31
+  } Bits;
+  UINT32    Uint32;
+} PCI_EXPRESS_REG_DOE_CAPABILITIES;
+
+typedef union {
+  struct {
+    UINT32    DoeAbort           : 1;             // bit 0
+    UINT32    DoeInterruptEnable : 1;             // bit 1
+    UINT32    Reserved           : 29;            // Reserved bit 2:30
+    UINT32    DoeGo              : 1;             // bit 31
+  } Bits;
+  UINT32    Uint32;
+} PCI_EXPRESS_REG_DOE_CONTROL;
+
+typedef union {
+  struct {
+    UINT32    DoeBusy            : 1;             // bit 0
+    UINT32    DoeInterruptStatus : 1;             // bit 1
+    UINT32    DoeError           : 1;             // bit 2
+    UINT32    Reserved           : 28;            // Reserved bit 3:30
+    UINT32    DataObjectReady    : 1;             // bit 31
+  } Bits;
+  UINT32    Uint32;
+} PCI_EXPRESS_REG_DOE_STATUS;
+
+typedef struct {
+  PCI_EXPRESS_EXTENDED_CAPABILITIES_HEADER    Header;
+  PCI_EXPRESS_REG_DOE_CAPABILITIES            Capability;
+  PCI_EXPRESS_REG_DOE_CONTROL                 Control;
+  PCI_EXPRESS_REG_DOE_STATUS                  Status;
+  UINT32                                      DoeWriteDataMailbox;
+  UINT32                                      DoeReadDataMailbox;
+} PCI_EXPRESS_EXTENDED_CAPABILITIES_DOE;
+
+typedef struct {
+  UINT32    Header1;                              // Vendor ID and Data Object Type
+  UINT32    Header2;                              // Length
+  UINT32    Dw0;                                  // Data Object DWORD 0
+} PCI_EXPRESS_DOE_DISCOVERY_PACKET;
+
 #pragma pack()
+
+#define EFI_PCIE_CAPABILITY_ID_DOE  0x2E
 
 #endif


### PR DESCRIPTION
# Description

This is used to define the EFI_PCIE_CAPABILITY_ID_DOE macro.

This is split out of https://github.com/tianocore/edk2/pull/5715

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Running against a DOE device in QEMU. See https://github.com/tianocore/edk2/pull/5715 for more details

## Integration Instructions

N/A
