### PR TITLE
Pg/kvmtool serial ports

### DIFF
--- a/ArmVirtPkg/KvmtoolCfgMgrDxe/ConfigurationManager.c
+++ b/ArmVirtPkg/KvmtoolCfgMgrDxe/ConfigurationManager.c
@@ -106,6 +106,15 @@ EDKII_PLATFORM_REPOSITORY_INFO  mKvmtoolPlatRepositoryInfo = {
       NULL
     },
     //
+    // SSDT Serial Port Table
+    //
+    {
+      EFI_ACPI_6_3_SECONDARY_SYSTEM_DESCRIPTION_TABLE_SIGNATURE,
+      0, // Unused
+      CREATE_STD_ACPI_TABLE_GEN_ID (EStdAcpiTableIdSsdtSerialPort),
+      NULL
+    },
+    //
     // PCI MCFG Table
     //
     {

--- a/ArmVirtPkg/KvmtoolCfgMgrDxe/ConfigurationManager.h
+++ b/ArmVirtPkg/KvmtoolCfgMgrDxe/ConfigurationManager.h
@@ -63,7 +63,7 @@ typedef EFI_STATUS (*CM_OBJECT_HANDLER_PROC) (
 ///
 /// The number of ACPI tables to install
 ///
-#define PLAT_ACPI_TABLE_COUNT  10
+#define PLAT_ACPI_TABLE_COUNT  11
 
 ///
 /// A structure describing the platform configuration


### PR DESCRIPTION
# Description

This patch:
- Generates SSDT tables describing missing serial ports
- Fixes the detection condition to remove IORT table in presence of GIC version < 3


## How This Was Tested

Tested by running kvmtool on a platform with GicV2 and GicV3 to compare the number of ACPI tables generated.
