### PR TITLE
MdeModulePkg/UfsPassThruDxe: Correct size in UfsHc->FreeBuffer call

### DIFF
--- a/MdeModulePkg/Bus/Ufs/UfsPassThruDxe/UfsPassThruHci.c
+++ b/MdeModulePkg/Bus/Ufs/UfsPassThruDxe/UfsPassThruHci.c
@@ -1808,7 +1808,7 @@ UfsAllocateAlignCommonBuffer (
   if (EFI_ERROR (Status) || (Bytes != EFI_PAGES_TO_SIZE (EFI_SIZE_TO_PAGES (Size)))) {
     UfsHc->FreeBuffer (
              UfsHc,
-             EFI_PAGES_TO_SIZE (EFI_SIZE_TO_PAGES (Size)),
+             EFI_SIZE_TO_PAGES (Size),
              *CmdDescHost
              );
     *CmdDescHost = NULL;
@@ -1825,7 +1825,7 @@ UfsAllocateAlignCommonBuffer (
              );
     UfsHc->FreeBuffer (
              UfsHc,
-             EFI_PAGES_TO_SIZE (EFI_SIZE_TO_PAGES (Size)),
+             EFI_SIZE_TO_PAGES (Size),
              *CmdDescHost
              );
     *CmdDescMapping = NULL;


### PR DESCRIPTION
# Description

UfsHc->FreeBuffer accepts page numbers rather than bytes as its size argument. Fix two positions where wrong size were passed.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Only building test was done for UfsPassThruDxe.

## Integration Instructions

N/A
