### PR TITLE
PrmPkg: Correct the flags for GCC compiler

### DIFF
--- a/PrmPkg/Samples/PrmSampleAcpiParameterBufferModule/PrmSampleAcpiParameterBufferModule.inf
+++ b/PrmPkg/Samples/PrmSampleAcpiParameterBufferModule/PrmSampleAcpiParameterBufferModule.inf
@@ -8,6 +8,7 @@
 #
 #  Copyright (c) Microsoft Corporation
 #  Copyright (c) 2022, Arm Limited. All rights reserved.<BR>
+#  Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -41,5 +42,6 @@
   MSFT:*_*_*_DLINK_FLAGS  = /DLL /SUBSYSTEM:CONSOLE /VERSION:1.0
   MSFT:*_*_*_GENFW_FLAGS = --keepoptionalheader
 
-  GCC:*_*_AARCH64_GENFW_FLAGS = --prm
-  GCC:*_*_AARCH64_DLINK_FLAGS = -Wl,--no-gc-sections -Wl,--require-defined=PrmModuleExportDescriptor -Wl,--require-defined=CheckParamBufferPrmHandler
+  GCC:*_*_*_GENFW_FLAGS = --prm
+  GCC:*_*_*_DLINK_FLAGS = -Wl,--no-gc-sections -Wl,--require-defined=PrmModuleExportDescriptor -Wl,--require-defined=CheckParamBufferPrmHandler
+  GCC:*_*_X64_OBJCOPY_STRIPFLAG = --keep-symbol=PrmModuleExportDescriptor --keep-symbol=CheckParamBufferPrmHandler

--- a/PrmPkg/Samples/PrmSampleContextBufferModule/PrmSampleContextBufferModule.inf
+++ b/PrmPkg/Samples/PrmSampleContextBufferModule/PrmSampleContextBufferModule.inf
@@ -8,6 +8,7 @@
 #  Copyright (c) 2020, Intel Corporation. All rights reserved.<BR>
 #  Copyright (c) Microsoft Corporation
 #  Copyright (c) 2022, Arm Limited. All rights reserved.<BR>
+#  Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -44,5 +45,6 @@
   MSFT:*_*_*_DLINK_FLAGS  = /DLL /SUBSYSTEM:CONSOLE /VERSION:1.0
   MSFT:*_*_*_GENFW_FLAGS = --keepoptionalheader
 
-  GCC:*_*_AARCH64_GENFW_FLAGS = --keepoptionalheader --prm
-  GCC:*_*_AARCH64_DLINK_FLAGS = -Wl,--no-gc-sections -Wl,--require-defined=PrmModuleExportDescriptor -Wl,--require-defined=CheckStaticDataBufferPrmHandler
+  GCC:*_*_*_GENFW_FLAGS = --keepoptionalheader --prm
+  GCC:*_*_*_DLINK_FLAGS = -Wl,--no-gc-sections -Wl,--require-defined=PrmModuleExportDescriptor -Wl,--require-defined=CheckStaticDataBufferPrmHandler
+  GCC:*_*_X64_OBJCOPY_STRIPFLAG = --keep-symbol=PrmModuleExportDescriptor --keep-symbol=CheckStaticDataBufferPrmHandler


### PR DESCRIPTION
# Description

Correct the GCC GenFw and ld flag to build PRM run time modules.
These changes are made for X64 GCC compiler, current present for AARCH64 only.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested
Build on Ubuntu environment

## Integration Instructions
N/A
