### PR TITLE
MdeModulePkg/UsbMassStorageDxe: Remove Port Reset

### DIFF
--- a/MdeModulePkg/Bus/Usb/UsbMassStorageDxe/UsbMassBoot.c
+++ b/MdeModulePkg/Bus/Usb/UsbMassStorageDxe/UsbMassBoot.c
@@ -210,7 +210,7 @@ UsbBootExecCmd (
   //
   // If command execution failed, then retrieve error info via sense request.
   //
-  DEBUG ((DEBUG_ERROR, "UsbBootExecCmd: %r to Exec 0x%x Cmd (Result = %x)\n", Status, *(UINT8 *)Cmd, CmdResult));
+  DEBUG ((DEBUG_INFO, "UsbBootExecCmd: %r to Exec 0x%x Cmd (Result = %x)\n", Status, *(UINT8 *)Cmd, CmdResult));
   return UsbBootRequestSense (UsbMass);
 }
 

--- a/MdeModulePkg/Bus/Usb/UsbMassStorageDxe/UsbMassBot.c
+++ b/MdeModulePkg/Bus/Usb/UsbMassStorageDxe/UsbMassBot.c
@@ -449,8 +449,7 @@ UsbBotExecCommand (
 
   @param  Context               The context of the BOT protocol, that is,
                                 USB_BOT_PROTOCOL.
-  @param  ExtendedVerification  If FALSE, just issue Bulk-Only Mass Storage Reset request.
-                                If TRUE, additionally reset parent hub port.
+  @param  ExtendedVerification  ExtendedVerification is ignored in this implementation.
 
   @retval EFI_SUCCESS           The device is reset.
   @retval Others                Failed to reset the device..
@@ -469,16 +468,6 @@ UsbBotResetDevice (
   UINT32                  Timeout;
 
   UsbBot = (USB_BOT_PROTOCOL *)Context;
-
-  if (ExtendedVerification) {
-    //
-    // If we need to do strictly reset, reset its parent hub port
-    //
-    Status = UsbBot->UsbIo->UsbPortReset (UsbBot->UsbIo);
-    if (EFI_ERROR (Status)) {
-      return EFI_DEVICE_ERROR;
-    }
-  }
 
   //
   // Issue a class specific Bulk-Only Mass Storage Reset request,


### PR DESCRIPTION
# Description

During USB mass storage enumeration, if a USB transfer fails due to any other reason, UsbMassStorageDxe will attempt to reset the device. With the commit ed07a2bb11 ("MdeModulePkg/UsbBusDxe: USB issue fix when the port reset"), UsbIoPortReset now tears down the USB device context and reinstalls it (via DisconnectController & ConnectController).

This process is not handled by the UsbMassDriver, causing the upper layer to access an old pointer that has been freed during the teardown, leading to a crash.

Example:

UsbMassReadBlocks (Failed)
 -> UsbMassReset
   -> UsbBotResetDevice
     -> UsbIoPortReset (teardown + reinstall and return)
Now the UsbBot context pointer is invalidated and pointing to freed memory.
     -> UsbBot->UsbIo->UsbControlTransfer() therefore accesses a invalid pointer and crashes.

The fix is to ignore the ExtendedVerification, which is supposed to perform a more exhaustive verification operation during the reset.  In MassStorageDxe, ExtendedVerification perform the parent port reset (UsbIoPortReset).  Ultimately, the MassStorage device should not reset the parent port due to a transfer error.  By not performing any extended verification, the teardown is prevented, thereby avoiding the crash.

A second minor fix is included to reduce the log level from DEBUG to INFO for commands that result in responses containing a non-zero status code. When encountering a device that constantly has transfer errors this would lead to excessive log spam.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Tested against several USB mass storage devices (SSD, spinning HDDs) which for some reason seemed to encounter transfer errors that were easily triggering a crash before this change. Note this PR is not aimed at fixing the underlying transfer errors but rather to at least avoid crashing due to invalid pointer access.

## Integration Instructions

N/A
