### PR TITLE
MdeModulePkg/DxeCorePerformanceLib: Fix incorrect size calculation

### DIFF
--- a/MdeModulePkg/Library/DxeCorePerformanceLib/DxeCorePerformanceLib.c
+++ b/MdeModulePkg/Library/DxeCorePerformanceLib/DxeCorePerformanceLib.c
@@ -320,11 +320,12 @@ InternalGetSmmPerfData (
               // Note: Maximum comm buffer data payload size is ReservedMemSize - SMM_BOOT_RECORD_COMM_SIZE
               BootRecordDataPayloadSize = MIN (
                                             ReservedMemSize - SMM_BOOT_RECORD_COMM_SIZE,
-                                            SmmBootRecordDataSize - SmmBootRecordDataRetrieved - SMM_BOOT_RECORD_COMM_SIZE
+                                            SmmBootRecordDataSize - SmmBootRecordDataRetrieved
                                             );
+              SmmCommData->BootRecordSize = BootRecordDataPayloadSize;
 
               MmCommBufferHeader->MessageLength = sizeof (SMM_BOOT_RECORD_COMMUNICATE) + BootRecordDataPayloadSize;
-              CommSize                          = sizeof (EFI_MM_COMMUNICATE_HEADER) + (UINTN)MmCommBufferHeader->MessageLength;
+              CommSize                          = OFFSET_OF (EFI_MM_COMMUNICATE_HEADER, Data) + (UINTN)MmCommBufferHeader->MessageLength;
 
               Status = Communication->Communicate (Communication, SmmBootRecordCommBuffer, &CommSize);
               ASSERT_EFI_ERROR (Status);


### PR DESCRIPTION
# Description

Fix the issues found on Intel platform:
##

Issue1:  After enabling the MM performance, boot fails with assert issue at https://github.com/tianocore/edk2/blob/master/StandaloneMmPkg/Drivers/MmCommunicationDxe/MmCommunicationDxe.c#L279
Root cause: CommSize value is incorrect.
Fix: Set CommSize to OFFSET_OF (EFI_MM_COMMUNICATE_HEADER, Data) + (UINTN)MmCommBufferHeader->MessageLength
##

Issue2: Hang when execute 'dp' command under UEFI shell.
Root cause: The Smm Boot Record data is all 0, causing a dead loop when 'dp' parses the smm data. BootRecordDataPayloadSize is incorrect, smaller than the actual size of the Smm Boot Record data, causing failure of copying data from SMM to comm buffer:
https://github.com/tianocore/edk2/blob/master/MdeModulePkg/Library/SmmCorePerformanceLib/MmCorePerformanceLib.c#L865
Fix: Set BootRecordDataPayloadSize to SmmBootRecordDataSize - SmmBootRecordDataRetrieved
##

Issue3: When the size of Smm Boot Record data is larger than FixedCommBuffer Size, 'dp' command hang.
Root cause: SmmCommData->BootRecordSize is set to the total size of the entire Smm Boot record data, larger than the max size that FpdtSmiHandler could copy:
https://github.com/tianocore/edk2/blob/master/MdeModulePkg/Library/SmmCorePerformanceLib/MmCorePerformanceLib.c#L842
Fix: Set SmmCommData->BootRecordSize to BootRecordDataPayloadSize
##

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

Run performance records from Standalone MM for the cases:
1. Smm Boot record data is smaller than FixedCommBuffer Size.
3. Smm Boot record data is larger than FixedCommBuffer Size.

## Integration Instructions

N/A
