### PR TITLE
BaseTools: Dump library dependency chain on build failure

### DIFF
--- a/BaseTools/Source/Python/Workspace/WorkspaceCommon.py
+++ b/BaseTools/Source/Python/Workspace/WorkspaceCommon.py
@@ -90,6 +90,16 @@ def GetDeclaredPcd(Platform, BuildDatabase, Arch, Target, Toolchain, additionalP
 def GetLibraryInstances(Module, Platform, BuildDatabase, Arch, Target, Toolchain):
     return GetModuleLibInstances(Module, Platform, BuildDatabase, Arch, Target, Toolchain,Platform.MetaFile,EdkLogger)
 
+def GenerateDependencyDump(ConsumedByList, M, Level, Visited):
+    if M in Visited:
+        return []
+    Visited.add(M)
+    Indentation = "\t" * Level
+    DependencyDump = [f"{Indentation}consumed by {M}"]
+    for m in ConsumedByList[M]:
+        DependencyDump.extend(GenerateDependencyDump(ConsumedByList, m, Level + 1, Visited))
+    return DependencyDump
+
 def GetModuleLibInstances(Module, Platform, BuildDatabase, Arch, Target, Toolchain, FileName = '', EdkLogger = None):
     if Module.LibInstances:
         return Module.LibInstances
@@ -133,9 +143,11 @@ def GetModuleLibInstances(Module, Platform, BuildDatabase, Arch, Target, Toolcha
                     if LibraryPath is None:
                         if not Module.LibraryClass:
                             EdkLogger.error("build", RESOURCE_NOT_AVAILABLE,
-                                            "Instance of library class [%s] is not found" % LibraryClassName,
+                                            f"Instance of library class [{LibraryClassName}] is not found for"
+                                            f" module [{Module}], [{LibraryClassName}] is:",
                                             File=FileName,
-                                            ExtraData="in [%s] [%s]\n\tconsumed by module [%s]" % (str(M), Arch, str(Module)))
+                                            ExtraData="\n\t".join(GenerateDependencyDump(ConsumedByList, M, 0, set()))
+                                            )
                         else:
                             return []
 


### PR DESCRIPTION
When a module M depends on L1, which depends on L2, which depends on L3, the build fails when the library instance of L3 cannot be found according to the library class-instance mapping configuration specified in the DSC file.
When such failure happens, the build tool only prints that the instance of L3 required by module M cannot be found. But it does not tell how L3 is required by M.

The change enhances build tool to print the entire dependency chain when such failure happens.
With the change, the new error message will be as follows:

<dsc-path>(...): error 4000: Instance of library class [L3] is not found for module [M], [L3] is:
  consumed by <instance of L2>
    consumed by <instance of L1>

# Description

<_Include a description of the change and why this change was made._>

<_For each item, place an "x" in between `[` and `]` if true. Example: `[x]` (you can also check items in GitHub UI)_>

<_Create the PR as a Draft PR if it is only created to run CI checks._>

<_Delete lines in \<\> tags before creating the PR._>

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

<_Describe the test(s) that were run to verify the changes._>

## Integration Instructions

<_Describe how these changes should be integrated. Use N/A if nothing is required._>
