### PR TITLE
SecurityPkg/AuthVariableLib: Fix memory leak on RsaGetPublicKeyFromX509

### DIFF
--- a/SecurityPkg/Library/AuthVariableLib/AuthService.c
+++ b/SecurityPkg/Library/AuthVariableLib/AuthService.c
@@ -20,6 +20,7 @@
 
 Copyright (c) 2009 - 2019, Intel Corporation. All rights reserved.<BR>
 Copyright (c) Microsoft Corporation.
+(c) Copyright 2025 HP Development Company, L.P.
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -587,13 +588,9 @@ CheckSignatureListFormat (
       // Try to retrieve the RSA public key from the X.509 certificate.
       // If this operation fails, it's not a valid certificate.
       //
-      RsaContext = RsaNew ();
-      if (RsaContext == NULL) {
-        return EFI_INVALID_PARAMETER;
-      }
-
-      CertData = (EFI_SIGNATURE_DATA *)((UINT8 *)SigList + sizeof (EFI_SIGNATURE_LIST) + SigList->SignatureHeaderSize);
-      CertLen  = SigList->SignatureSize - sizeof (EFI_GUID);
+      CertData   = (EFI_SIGNATURE_DATA *)((UINT8 *)SigList + sizeof (EFI_SIGNATURE_LIST) + SigList->SignatureHeaderSize);
+      CertLen    = SigList->SignatureSize - sizeof (EFI_GUID);
+      RsaContext = NULL;
       if (!RsaGetPublicKeyFromX509 (CertData->SignatureData, CertLen, &RsaContext)) {
         RsaFree (RsaContext);
         return EFI_INVALID_PARAMETER;


### PR DESCRIPTION

# Description

RsaGetPublicKeyFromX509  allocates memory for RsaContext parameter and the memory allocated earlier is not necessary

Signed-off-by: Anbazhagan Baraneedharan [anbazhagan@hp.com](mailto:anbazhagan@hp.com)
