### PR TITLE
SecurityPkg-Tpm2DeviceLibDTpm: Check SNP enabled prior to using AmdSvsmLib

### DIFF
--- a/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2DeviceLibDTpmSvsm.inf
+++ b/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2DeviceLibDTpmSvsm.inf
@@ -64,3 +64,4 @@
   gEfiSecurityPkgTokenSpaceGuid.PcdCRBIdleByPass             ## PRODUCES
   gEfiSecurityPkgTokenSpaceGuid.PcdSvsmVTpmPresence          ## PRODUCES
   gEfiSecurityPkgTokenSpaceGuid.PcdSvsmVTpmBufferPtr         ## PRODUCES
+  gEfiMdePkgTokenSpaceGuid.PcdConfidentialComputingGuestAttr ## CONSUMES

--- a/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2InstanceLibDTpmSvsm.inf
+++ b/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2InstanceLibDTpmSvsm.inf
@@ -58,3 +58,4 @@
   gEfiSecurityPkgTokenSpaceGuid.PcdCRBIdleByPass           ## PRODUCES
   gEfiSecurityPkgTokenSpaceGuid.PcdSvsmVTpmPresence        ## PRODUCES
   gEfiSecurityPkgTokenSpaceGuid.PcdSvsmVTpmBufferPtr       ## PRODUCES
+  gEfiMdePkgTokenSpaceGuid.PcdConfidentialComputingGuestAttr ## CONSUMES


### PR DESCRIPTION
# Description

This patch fixes boot failures observed on SEV and SEV-ES VMs using OvmfPkg broken by https://github.com/tianocore/edk2/pull/6527.

AmdSvsmLib currently doesn't check if SNP enabled, thus using AmdSvsmLib may errantly cause the caller code to believe SVSM is present. This can lead to boot failure on non-SNP enabled VMs.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?

## How This Was Tested

Compiled OVMF target (but not tested) on edk2 upstream code following instructions https://github.com/tianocore/tianocore.github.io/wiki/Common-instructions

Compiled and tested on internal edk2 fork on SEV VM boot-up using internal hypervisor.

## Integration Instructions

N/A
