### PR TITLE
RedfishPkg/RedfishHttpDxe : Fix the incorrect length of the Basic Auth

### DIFF
--- a/RedfishPkg/RedfishHttpDxe/RedfishHttpDxe.c
+++ b/RedfishPkg/RedfishHttpDxe/RedfishHttpDxe.c
@@ -3,6 +3,7 @@
   for EDK2 Redfish Feature driver to do HTTP operations.
 
   Copyright (c) 2023-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.<BR>
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -399,7 +400,7 @@ RedfishCreateRedfishService (
 
       Status = Base64Encode (
                  (CONST UINT8 *)BasicAuthString,
-                 BasicAuthStrSize,
+                 AsciiStrLen (BasicAuthString),
                  EncodedAuthString,
                  &EncodedAuthStrSize
                  );
@@ -411,7 +412,7 @@ RedfishCreateRedfishService (
 
         Status = Base64Encode (
                    (CONST UINT8 *)BasicAuthString,
-                   BasicAuthStrSize,
+                   AsciiStrLen (BasicAuthString),
                    EncodedAuthString,
                    &EncodedAuthStrSize
                    );


### PR DESCRIPTION
Use AsciiStrLen function instead of AsciiStrSize to determine the length of Basic Auth string.

# Description
Use AsciiStrSize, which leads to the incorrect length of the Basic Auth string.
Use AsciiStrLen function instead of AsciiStrSize.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?


## How This Was Tested
 The change was tested on Redfish simulator.

## Integration Instructions
None
