### PR TITLE
UefiPayloadPkg: Add 4KB align for DXE_DRIVER, DXE_CORE, UEFI_DRIVER and UEFI_APPLICATION.

### DIFF
--- a/UefiPayloadPkg/UefiPayloadPkg.dsc
+++ b/UefiPayloadPkg/UefiPayloadPkg.dsc
@@ -195,6 +195,37 @@
 [BuildOptions.AARCH64.EDKII.DXE_RUNTIME_DRIVER]
   GCC:*_*_*_DLINK_FLAGS      = -z common-page-size=0x10000
 
+#
+# Use FV_SECTION_ALIGNMENT for set Image Section Alignment for DXE_DRIVERs, DXE_CORE,
+# UEFI_DRIVERs, UEFI_APPLICATION and DXE_SMM_DRIVERs.
+# The main purpose of this parameter is to set the alignment to EFI_PAGE_SIZE.
+# This is necessary for creating protection images by ProtectUefiImage().
+# This setting can significantly increase the size of payload.
+#
+!ifdef FV_SECTION_ALIGNMENT
+  [BuildOptions.common.EDKII.DXE_DRIVER, BuildOptions.common.EDKII.DXE_CORE]
+    GCC:*_*_*_DLINK_FLAGS      = -z common-page-size=$(FV_SECTION_ALIGNMENT)
+    XCODE:*_*_*_DLINK_FLAGS    = -seg1addr 0x1000 -segalign 0x1000
+    XCODE:*_*_*_MTOC_FLAGS     = -align 0x1000
+    CLANGPDB:*_*_*_DLINK_FLAGS = /ALIGN:4096
+    MSFT:*_*_*_DLINK_FLAGS     = /ALIGN:4096
+
+  [BuildOptions.common.EDKII.UEFI_DRIVER, BuildOptions.common.EDKII.UEFI_APPLICATION]
+    GCC:*_*_*_DLINK_FLAGS      = -z common-page-size=$(FV_SECTION_ALIGNMENT)
+    XCODE:*_*_*_DLINK_FLAGS    = -seg1addr 0x1000 -segalign 0x1000
+    XCODE:*_*_*_MTOC_FLAGS     = -align 0x1000
+    CLANGPDB:*_*_*_DLINK_FLAGS = /ALIGN:4096
+    MSFT:*_*_*_DLINK_FLAGS     = /ALIGN:4096
+
+  [BuildOptions.common.EDKII.DXE_SMM_DRIVER]
+    GCC:*_*_*_DLINK_FLAGS      = -z common-page-size=$(FV_SECTION_ALIGNMENT)
+    XCODE:*_*_*_DLINK_FLAGS    = -seg1addr 0x1000 -segalign 0x1000
+    XCODE:*_*_*_MTOC_FLAGS     = -align 0x1000
+    CLANGPDB:*_*_*_DLINK_FLAGS = /ALIGN:4096
+    MSFT:*_*_*_DLINK_FLAGS     = /ALIGN:4096
+!endif
+
+
 ################################################################################
 #
 # SKU Identification section - list of all SKU IDs supported by this Platform.


### PR DESCRIPTION
Most of the drivers have an alignment of 0x40, which is specified in the file tools_def.txt by default. This ends the
CreateImagePropertiesRecord() function with a failure (!!!!!!!!  Image Section Alignment(0x40) does not match Required Alignment (0x1000) !!!!!!!!).

# Description

<_Include a description of the change and why this change was made._>

<_For each item, place an "x" in between `[` and `]` if true. Example: `[x]` (you can also check items in GitHub UI)_>

<_Create the PR as a Draft PR if it is only created to run CI checks._>

<_Delete lines in \<\> tags before creating the PR._>

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

<_Describe the test(s) that were run to verify the changes._>

## Integration Instructions

<_Describe how these changes should be integrated. Use N/A if nothing is required._>
