### PR TITLE
BaseTools/build: Reduce special FV full to warning

### DIFF
--- a/BaseTools/Source/Python/build/build.py
+++ b/BaseTools/Source/Python/build/build.py
@@ -2431,9 +2431,18 @@ class Build():
                         if len(NameValue) == 2 and NameValue[0].strip() == 'EFI_FV_SPACE_SIZE':
                             FreeSizeValue = int(NameValue[1].strip(), 0)
                             if FreeSizeValue < Threshold:
-                                EdkLogger.error("build", FV_FREESIZE_ERROR,
-                                                '%s FV free space %d is not enough to meet with the required spare space %d set by -D FV_SPARE_SPACE_THRESHOLD option.' % (
-                                                    FvName, FreeSizeValue, Threshold))
+                                if FreeSizeValue == 0:
+                                    # A free size of 0 means the FV is exactly 100% full which usually indicates a special
+                                    # FV for a region that contains a fixed size image with special alignment requirements
+                                    # with potentiaily a fixed address. Log a warning for review, but do not generate an
+                                    # error.
+                                    EdkLogger.warn("build", FV_FREESIZE_ERROR,
+                                                    '%s FV free space %d is not enough to meet with the required spare space %d set by -D FV_SPARE_SPACE_THRESHOLD option.' % (
+                                                        FvName, FreeSizeValue, Threshold))
+                                else:
+                                    EdkLogger.error("build", FV_FREESIZE_ERROR,
+                                                    '%s FV free space %d is not enough to meet with the required spare space %d set by -D FV_SPARE_SPACE_THRESHOLD option.' % (
+                                                        FvName, FreeSizeValue, Threshold))
                             break
 
     ## Generate GuidedSectionTools.txt in the FV directories.


### PR DESCRIPTION
# Description

If an FV_SPARE_SPACE_THRESHOLD is enabled and an FV is 100% full with 0 bytes free, then this is likely a special FV that may have alignment requirements
for the FFS file for both the start address and the length and the FFS file consumes all the available FV space.

Reduce FV_SPARE_SPACE_THRESHOLD from an error to a warning if this FV 0 bytes free condition is
detected.

PR #10828 introduced the generation of these error conditions for an FV with large alignment requirements. The pad region before the aligned FFS file used to be counted as free space even though it could never be used due to the alignment requirements. There was actually no free space available. PR #10828 fixed the free space calculation to properly show it as 0 bytes free, and this change then caused build error when FV_SPARE_SPACE_THRESHOLD feature was enabled. The
reduction to a warning for this condition allows the build to complete with errors and also provides a
build log warning message for review.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

Build breaks with an error message for special FV with FFS file with large start address and length alignment requirements when FV_SPARE_SPACE_THRESHOLD  is enabled. The FFS file consumes all the remaining space of the FV and this is the expected behavior and no error should be generated.

Disabling FV_SPARE_SPACE_THRESHOLD avoids the error.

Applied this code change with FV_SPARE_SPACE_THRESHOLD enabled and the build completes with any errors and generates a warning for the FV that is completely full.

## Integration Instructions

N/A
