### PR TITLE
MdePkg/IndustryStandard: Fix typos in IoRemappingTable.h

### DIFF
--- a/MdePkg/Include/IndustryStandard/IoRemappingTable.h
+++ b/MdePkg/Include/IndustryStandard/IoRemappingTable.h
@@ -145,7 +145,7 @@ typedef struct {
 } EFI_ACPI_6_0_IO_REMAPPING_ITS_NODE;
 
 ///
-/// Node type 1: root complex node
+/// Node type 2: root complex node
 ///
 typedef struct {
   EFI_ACPI_6_0_IO_REMAPPING_NODE    Node;
@@ -164,7 +164,7 @@ typedef struct {
 } EFI_ACPI_6_0_IO_REMAPPING_RC_NODE;
 
 ///
-/// Node type 2: named component node
+/// Node type 1: named component node
 ///
 typedef struct {
   EFI_ACPI_6_0_IO_REMAPPING_NODE    Node;


### PR DESCRIPTION
# Description

This corrects the value of the type `Named Component` and `Root Complex` in the structure comments, according to the DEN0049E_IO_Remapping_Table specification [1], table 2.

![image](https://github.com/user-attachments/assets/64d4ef98-4f40-4bf6-80d7-a2e42b3dd78b)


[1] https://developer.arm.com/documentation/den0049/latest

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

N/A.

## Integration Instructions

N/A.