### PR TITLE
Maintainers.txt: Add new maintainer to BaseTools section

### DIFF
--- a/Maintainers.txt
+++ b/Maintainers.txt
@@ -170,6 +170,7 @@ F: BaseTools/
 W: https://github.com/tianocore/tianocore.github.io/wiki/BaseTools
 M: Rebecca Cran <rebecca@bsdio.com> [bexcran]
 M: Liming Gao <gaoliming@byosoft.com.cn> [lgao4]
+M: Guillermo Antonio Palomino Sosa <guillermo.a.palomino.sosa@intel.com> [gapalomi]
 R: Bob Feng <bob.c.feng@intel.com> [BobCF]
 R: Yuwei Chen <yuwei.chen@intel.com> [YuweiChen1110]
 


### PR DESCRIPTION
- Updated Maintainers.txt to include Guillermo Antonio Palomino Sosa as a maintainer for the BaseTools section.
- Added his contact information: email and GitHub username.

# Description

This change updates the Maintainers.txt file to include Guillermo Antonio Palomino Sosa as a maintainer for the BaseTools section. 

- [ ] Breaking change?
  - **Breaking change** - No, this PR does not cause any break in build or boot behavior.
- [ ] Impacts security?
  - **Security** - No, this PR does not have a direct security impact.
- [ ] Includes tests?
  - **Tests** - No, this PR does not include any explicit test code.

## How This Was Tested

N/A - This change is documentation-only and does not affect functionality.

## Integration Instructions

N/A - No integration steps are required for this documentation update.
