### PR TITLE
UefiCpuPkg: Add StmmCore for IntelMmSaveStateLib,SmmCpuPlatformHookLibNull.

### DIFF
--- a/UefiCpuPkg/Library/MmSaveStateLib/IntelMmSaveStateLib.inf
+++ b/UefiCpuPkg/Library/MmSaveStateLib/IntelMmSaveStateLib.inf
@@ -16,7 +16,7 @@
   FILE_GUID                      = 37E8137B-9F74-4250-8951-7A970A3C39C0
   MODULE_TYPE                    = DXE_SMM_DRIVER
   VERSION_STRING                 = 1.0
-  LIBRARY_CLASS                  = MmSaveStateLib|DXE_SMM_DRIVER MM_STANDALONE
+  LIBRARY_CLASS                  = MmSaveStateLib|DXE_SMM_DRIVER MM_STANDALONE MM_CORE_STANDALONE
 
 [Sources]
   MmSaveState.h

--- a/UefiCpuPkg/Library/SmmCpuPlatformHookLibNull/SmmCpuPlatformHookLibNull.inf
+++ b/UefiCpuPkg/Library/SmmCpuPlatformHookLibNull/SmmCpuPlatformHookLibNull.inf
@@ -18,7 +18,7 @@
   FILE_GUID                      = D6494E1B-E06F-4ab5-B64D-48B25AA9EB33
   MODULE_TYPE                    = DXE_DRIVER
   VERSION_STRING                 = 1.0
-  LIBRARY_CLASS                  = SmmCpuPlatformHookLib|DXE_SMM_DRIVER MM_STANDALONE
+  LIBRARY_CLASS                  = SmmCpuPlatformHookLib|DXE_SMM_DRIVER MM_STANDALONE MM_CORE_STANDALONE
 
 #
 # The following information is for reference only and not required by the build tools.


### PR DESCRIPTION
# Description


IntelMmSaveStateLib and SmmCpuPlatformHookLibNull were limited to DXE_SMM_DRIVER MM_STANDALONE
in https://github.com/tianocore/edk2/pull/5805. Previously the supported modules were not limited.

Add MM_CORE_STANDALONE as a supported module type for these libraries to support a StmmCore
implementation that requires it.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested
Compile failed prior to fix, compiled correctly after. 

## Integration Instructions
N/A