### PR TITLE
UefiPayloadPkg: Drop SmbiosVersionLib for SmbiosDxe on AArch64

### DIFF
--- a/UefiPayloadPkg/UefiPayloadPkg.dsc
+++ b/UefiPayloadPkg/UefiPayloadPkg.dsc
@@ -1158,10 +1158,7 @@
   OvmfPkg/VirtioFsDxe/VirtioFsDxe.inf
 
   # SMBIOS Support
-  MdeModulePkg/Universal/SmbiosDxe/SmbiosDxe.inf {
-    <LibraryClasses>
-      NULL|OvmfPkg/Library/SmbiosVersionLib/DetectSmbiosVersionLib.inf
-  }
+  MdeModulePkg/Universal/SmbiosDxe/SmbiosDxe.inf
 
   # PCI support
   UefiCpuPkg/CpuMmio2Dxe/CpuMmio2Dxe.inf {


### PR DESCRIPTION
OVMF SmbiosVersionLib applies to QEMU SMBIOS only, it does not work on Bare Metal platform. Drop SmbiosVersionLib dependency for SmbiosDxe on AArch64 architecture.
