### PR TITLE
Solving potential null pointer dereference in SpiNorFlashJedecSfdp

### DIFF
--- a/MdeModulePkg/Bus/Spi/SpiNorFlashJedecSfdp/SpiNorFlash.c
+++ b/MdeModulePkg/Bus/Spi/SpiNorFlashJedecSfdp/SpiNorFlash.c
@@ -48,7 +48,17 @@ FillWriteBuffer (
   UINT32  Index;
   UINT8   SfdpAddressBytes;
 
-  SfdpAddressBytes = (UINT8)Instance->SfdpBasicFlash->AddressBytes;
+  if ((Instance == NULL) || (WriteBuffer == NULL)) {
+    ASSERT (Instance != NULL);
+    ASSERT (WriteBuffer != NULL);
+    return 0;
+  }
+
+  if (Instance->SfdpBasicFlash == NULL) {
+    SfdpAddressBytes = 0;
+  } else {
+    SfdpAddressBytes = (UINT8)Instance->SfdpBasicFlash->AddressBytes;
+  }
 
   // Copy Opcode into Write Buffer
   Instance->SpiTransactionWriteBuffer[0] = Opcode;


### PR DESCRIPTION
# Description

`Instance->SfdpBasicFlash` can be used before initializing.

Example code flow:
- CreateSpiNorFlashSfdpInstance: Allocate pool for `Instance`
    - InitialSpiNorFlashSfdpInstance
        - ReadSfdp
            - ReadSfdpHeader
                - FillWriteBuffer: Dereferencing `Instance->SfdpBasicFlash`
            - ReadSfdpBasicParameterTable: Allocate pool for `Instance->SfdpBasicFlash`


- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Test with NULL Detection feature enabled, an exception was fixed by this code change.

## Integration Instructions

NA
