### PR TITLE
DeviceManagerUiLib:Update DeviceManager form data when the form opens.

### DIFF
--- a/MdeModulePkg/Library/DeviceManagerUiLib/DeviceManager.c
+++ b/MdeModulePkg/Library/DeviceManagerUiLib/DeviceManager.c
@@ -848,7 +848,17 @@ DeviceManagerCallback (
 {
   UINTN  CurIndex;
 
-  if (Action != EFI_BROWSER_ACTION_CHANGING) {
+  if (Action == EFI_BROWSER_ACTION_FORM_OPEN) {
+    //
+    // Means enter the device manager form.
+    // Update device manager page when form opens, because options may add or remove.
+    //
+    if (QuestionId == 0x1212) {
+      CreateDeviceManagerForm (DEVICE_MANAGER_FORM_ID);
+    }
+
+    return EFI_SUCCESS;
+  } else if (Action != EFI_BROWSER_ACTION_CHANGING) {
     //
     // Do nothing for other UEFI Action. Only do call back when data is changed.
     //
@@ -925,11 +935,6 @@ DeviceManagerUiLibConstructor (
   // handles have been connected, so do it here.
   //
   EfiBootManagerConnectAll ();
-
-  //
-  // Update boot manager page
-  //
-  CreateDeviceManagerForm (DEVICE_MANAGER_FORM_ID);
 
   return EFI_SUCCESS;
 }

--- a/MdeModulePkg/Library/DeviceManagerUiLib/DeviceManagerVfr.Vfr
+++ b/MdeModulePkg/Library/DeviceManagerUiLib/DeviceManagerVfr.Vfr
@@ -28,6 +28,17 @@ formset
     title  = STRING_TOKEN(STR_EDKII_MENU_TITLE);
     subtitle text = STRING_TOKEN(STR_DEVICES_LIST);
 
+    //
+    // Add this invisable text in order to indicate enter Device Manager form.
+    //
+    suppressif TRUE;
+          text
+              help  = STRING_TOKEN(STR_EMPTY_STRING),
+              text  = STRING_TOKEN(STR_EMPTY_STRING),
+              flags = INTERACTIVE,
+              key   = 0x1212;
+    endif;
+
     label LABEL_DEVICES_LIST;
     label LABEL_END;
 


### PR DESCRIPTION

Issue link:https://github.com/tianocore/edk2/issues/10925

If new HII resource is installed, show it in DeviceManager form. If HII resource is uninstalled, remove it from DeviceManager form. So once we enter DeviceManager form, form data should be refreshed to display dynamically.

Cc: Li Chao <lichao@loongson.cn>
Cc: Qian Dongyan <qiandongyan@loongson.cn>

# Description

<_Include a description of the change and why this change was made._>

<_For each item, place an "x" in between `[` and `]` if true. Example: `[x]` (you can also check items in GitHub UI)_>

<_Create the PR as a Draft PR if it is only created to run CI checks._>

<_Delete lines in \<\> tags before creating the PR._>

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

<_Describe the test(s) that were run to verify the changes._>

## Integration Instructions

<_Describe how these changes should be integrated. Use N/A if nothing is required._>
