### PR TITLE
SecurityPkg: Out of bound read in HashPeImageByType()

### DIFF
--- a/SecurityPkg/Library/DxeImageVerificationLib/DxeImageVerificationLib.c
+++ b/SecurityPkg/Library/DxeImageVerificationLib/DxeImageVerificationLib.c
@@ -618,6 +618,7 @@ Done:
   @param[in]  AuthDataSize        Size of the Authenticode Signature in bytes.
 
   @retval EFI_UNSUPPORTED             Hash algorithm is not supported.
+  @retval EFI_BAD_BUFFER_SIZE         AuthData provided is invalid size.
   @retval EFI_SUCCESS                 Hash successfully.
 
 **/
@@ -629,28 +630,28 @@ HashPeImageByType (
 {
   UINT8  Index;
 
-  for (Index = 0; Index < HASHALG_MAX; Index++) {
+  //
+  // Check the Hash algorithm in PE/COFF Authenticode.
+  //    According to PKCS#7 Definition:
+  //        SignedData ::= SEQUENCE {
+  //            version Version,
+  //            digestAlgorithms DigestAlgorithmIdentifiers,
+  //            contentInfo ContentInfo,
+  //            .... }
+  //    The DigestAlgorithmIdentifiers can be used to determine the hash algorithm in PE/COFF hashing
+  //    This field has the fixed offset (+32) in final Authenticode ASN.1 data.
+  //    Fixed offset (+32) is calculated based on two bytes of length encoding.
+  //
+  if ((AuthDataSize > 1) && ((*(AuthData + 1) & TWO_BYTE_ENCODE) != TWO_BYTE_ENCODE)) {
     //
-    // Check the Hash algorithm in PE/COFF Authenticode.
-    //    According to PKCS#7 Definition:
-    //        SignedData ::= SEQUENCE {
-    //            version Version,
-    //            digestAlgorithms DigestAlgorithmIdentifiers,
-    //            contentInfo ContentInfo,
-    //            .... }
-    //    The DigestAlgorithmIdentifiers can be used to determine the hash algorithm in PE/COFF hashing
-    //    This field has the fixed offset (+32) in final Authenticode ASN.1 data.
-    //    Fixed offset (+32) is calculated based on two bytes of length encoding.
+    // Only support two bytes of Long Form of Length Encoding.
     //
-    if ((AuthDataSize > 1) && ((*(AuthData + 1) & TWO_BYTE_ENCODE) != TWO_BYTE_ENCODE)) {
-      //
-      // Only support two bytes of Long Form of Length Encoding.
-      //
-      continue;
-    }
+    return EFI_BAD_BUFFER_SIZE;
+  }
 
+  for (Index = 0; Index < HASHALG_MAX; Index++) {
     if (AuthDataSize < 32 + mHash[Index].OidLength) {
-      return EFI_UNSUPPORTED;
+      continue;
     }
 
     if (CompareMem (AuthData + 32, mHash[Index].OidValue, mHash[Index].OidLength) == 0) {

--- a/SecurityPkg/Library/DxeImageVerificationLib/DxeImageVerificationLib.c
+++ b/SecurityPkg/Library/DxeImageVerificationLib/DxeImageVerificationLib.c
@@ -642,7 +642,7 @@ HashPeImageByType (
     //    This field has the fixed offset (+32) in final Authenticode ASN.1 data.
     //    Fixed offset (+32) is calculated based on two bytes of length encoding.
     //
-    if ((*(AuthData + 1) & TWO_BYTE_ENCODE) != TWO_BYTE_ENCODE) {
+    if ((AuthDataSize > 1) && ((*(AuthData + 1) & TWO_BYTE_ENCODE) != TWO_BYTE_ENCODE)) {
       //
       // Only support two bytes of Long Form of Length Encoding.
       //

--- a/SecurityPkg/SecurityFixes.yaml
+++ b/SecurityPkg/SecurityFixes.yaml
@@ -40,3 +40,18 @@ CVE_2022_36764:
     - Library\DxeTpmMeasureBootLib\DxeTpmMeasureBootLib.c
   links:
     - https://bugzilla.tianocore.org/show_bug.cgi?id=4118
+CVE_2024_38797:
+  commit-titles:
+    - "SecurityPkg: Out of bound read in HashPeImageByType()"
+    - "SecurityPkg: Improving HashPeImageByType () logic"
+    - "SecurityPkg: Improving SecureBootConfigImpl:HashPeImageByType () logic"
+  cve: CVE-2024-38797
+  date_reported: 2024-06-04 12:00 UTC
+  description: Out of bound read in HashPeImageByType()
+  note:
+  files_impacted:
+    - SecurityPkg\Library\DxeImageVerificationLib\DxeImageVerificationLib.c
+    - SecurityPkg\VariableAuthenticated\SecureBootConfigDxe\SecureBootConfigImpl.c
+  links:
+    - https://bugzilla.tianocore.org/show_bug.cgi?id=2214
+    - https://github.com/tianocore/edk2/security/advisories/GHSA-4wjw-6xmf-44xf

--- a/SecurityPkg/VariableAuthenticated/SecureBootConfigDxe/SecureBootConfigImpl.c
+++ b/SecurityPkg/VariableAuthenticated/SecureBootConfigDxe/SecureBootConfigImpl.c
@@ -2105,30 +2105,35 @@ HashPeImageByType (
 {
   UINT8                     Index;
   WIN_CERTIFICATE_EFI_PKCS  *PkcsCertData;
+  UINT32                    PkcsCertSize;
 
   PkcsCertData = (WIN_CERTIFICATE_EFI_PKCS *)(mImageBase + mSecDataDir->Offset);
+  PkcsCertSize = mSecDataDir->SizeOfCert;
+
+  //
+  // Check the Hash algorithm in PE/COFF Authenticode.
+  //    According to PKCS#7 Definition:
+  //        SignedData ::= SEQUENCE {
+  //            version Version,
+  //            digestAlgorithms DigestAlgorithmIdentifiers,
+  //            contentInfo ContentInfo,
+  //            .... }
+  //    The DigestAlgorithmIdentifiers can be used to determine the hash algorithm in PE/COFF hashing
+  //    This field has the fixed offset (+32) in final Authenticode ASN.1 data.
+  //    Fixed offset (+32) is calculated based on two bytes of length encoding.
+  //
+  if ((PkcsCertSize > 1) && ((*(PkcsCertData->CertData + 1) & TWO_BYTE_ENCODE) != TWO_BYTE_ENCODE)) {
+    //
+    // Only support two bytes of Long Form of Length Encoding.
+    //
+    return EFI_BAD_BUFFER_SIZE;
+  }
 
   for (Index = 0; Index < HASHALG_MAX; Index++) {
-    //
-    // Check the Hash algorithm in PE/COFF Authenticode.
-    //    According to PKCS#7 Definition:
-    //        SignedData ::= SEQUENCE {
-    //            version Version,
-    //            digestAlgorithms DigestAlgorithmIdentifiers,
-    //            contentInfo ContentInfo,
-    //            .... }
-    //    The DigestAlgorithmIdentifiers can be used to determine the hash algorithm in PE/COFF hashing
-    //    This field has the fixed offset (+32) in final Authenticode ASN.1 data.
-    //    Fixed offset (+32) is calculated based on two bytes of length encoding.
-    //
-    if ((*(PkcsCertData->CertData + 1) & TWO_BYTE_ENCODE) != TWO_BYTE_ENCODE) {
-      //
-      // Only support two bytes of Long Form of Length Encoding.
-      //
+    if (PkcsCertSize < 32 + mHash[Index].OidLength) {
       continue;
     }
 
-    //
     if (CompareMem (PkcsCertData->CertData + 32, mHash[Index].OidValue, mHash[Index].OidLength) == 0) {
       break;
     }


### PR DESCRIPTION
# Description

CVE: CVE-2024-38797

In HashPeImageByType(), the hash of a PE/COFF image is calculated. This function may get untrusted input.

Inside this function, the following code verifies the loaded image has the correct format, by reading the second byte of the buffer.

```c
  if ((*(AuthData + 1) & TWO_BYTE_ENCODE) != TWO_BYTE_ENCODE) {
  	...
  }
```

Since the input image is not trusted, it may not have a second byte present to read. So this poses a potential out of bounds read error.

With the below fix, we are ensuring that we don't perform an out of bound read. i.e, we make sure that AuthDataSize is greater than 1.

```c
  if (AuthDataSize > 1 && (*(AuthData + 1) & TWO_BYTE_ENCODE) != TWO_BYTE_ENCODE){
    ...
  }
```

AuthDataSize size is verified before reading the second byte. So, if AuthDataSize is less than 2, the second byte will not be read, and the out of bound read will be prevented.

---

The logic of the function was cleaned up to provide an early exit if the untrusted data does not have enough bytes to check for a TWO_BYTE_ENCODE or if the TWO_BYTE_ENCODE is not present. 

This is slightly more efficient than checking this condition in the for loop.

Additionally, when the hash algorithm selected by Index has such a large OID that the OID Comparison couldn't be performed - this would lead to an early break rather than a OID Mismatch. This has been changed to a `continue` instead.

---

- [ ] Breaking change?
- [X] Impacts security?
   - Corrects out of bound read in HashPeImageByType ()
- [ ] Includes tests?

## How This Was Tested

Tested the patch on real platform with and without TPM connected and verified image is booting fine.

## Integration Instructions

N/A