### PR TITLE
StandaloneMmPkg/Core: Performance logging for MM driver load and start

### DIFF
--- a/StandaloneMmPkg/Core/Dispatcher.c
+++ b/StandaloneMmPkg/Core/Dispatcher.c
@@ -49,6 +49,32 @@ typedef struct {
   EFI_FIRMWARE_VOLUME_HEADER    *FwVolHeader;
 } KNOWN_FWVOL;
 
+typedef struct {
+  MEDIA_FW_VOL_FILEPATH_DEVICE_PATH    VendorDevicePath;
+  EFI_DEVICE_PATH_PROTOCOL             End;
+} FV_FILEPATH_DEVICE_PATH;
+
+FV_FILEPATH_DEVICE_PATH  MmDriverFilePath[] = {
+  {
+    MEDIA_DEVICE_PATH,
+    MEDIA_PIWG_FW_FILE_DP,
+    {
+      (UINT8)(sizeof (MEDIA_FW_VOL_FILEPATH_DEVICE_PATH)),
+      (UINT8)((sizeof (MEDIA_FW_VOL_FILEPATH_DEVICE_PATH)) >> 8)
+    },
+    { 0x0, 0x0, 0x0, { 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0 }
+    }
+  },
+  {
+    END_DEVICE_PATH_TYPE,
+    END_ENTIRE_DEVICE_PATH_SUBTYPE,
+    {
+      sizeof (EFI_DEVICE_PATH_PROTOCOL),
+      0
+    }
+  }
+};
+
 //
 // Function Prototypes
 //
@@ -201,7 +227,15 @@ MmLoadImage (
   DriverEntry->LoadedImage.ParentHandle = NULL;
   DriverEntry->LoadedImage.SystemTable  = NULL;
   DriverEntry->LoadedImage.DeviceHandle = NULL;
-  DriverEntry->LoadedImage.FilePath     = NULL;
+  DriverEntry->LoadedImage.FilePath     = AllocatePool (sizeof (FV_FILEPATH_DEVICE_PATH));
+  if (DriverEntry->LoadedImage.FilePath != NULL) {
+    CopyMem (DriverEntry->LoadedImage.FilePath, &MmDriverFilePath, sizeof (FV_FILEPATH_DEVICE_PATH));
+    CopyMem (
+      &((MEDIA_FW_VOL_FILEPATH_DEVICE_PATH *)DriverEntry->LoadedImage.FilePath)->FvFileName,
+      &DriverEntry->FileName,
+      sizeof (EFI_GUID)
+      );
+  }
 
   DriverEntry->LoadedImage.ImageBase     = (VOID *)(UINTN)DriverEntry->ImageBuffer;
   DriverEntry->LoadedImage.ImageSize     = ImageContext->ImageSize;
@@ -432,7 +466,9 @@ MmDispatcher (
       // skip the LoadImage
       //
       if (DriverEntry->ImageHandle == NULL) {
+        PERF_LOAD_IMAGE_BEGIN (NULL);
         Status = MmLoadImage (DriverEntry, &ImageContext);
+        PERF_LOAD_IMAGE_END (DriverEntry->ImageHandle);
 
         //
         // Update the driver state to reflect that it's been loaded
@@ -466,7 +502,9 @@ MmDispatcher (
       // For each MM driver, pass NULL as ImageHandle
       //
       DEBUG ((DEBUG_INFO, "StartImage - 0x%x (Standalone Mode)\n", DriverEntry->ImageEntryPoint));
+      PERF_START_IMAGE_BEGIN (DriverEntry->ImageHandle);
       Status = ((MM_IMAGE_ENTRY_POINT)(UINTN)DriverEntry->ImageEntryPoint)(DriverEntry->ImageHandle, &gMmCoreMmst);
+      PERF_START_IMAGE_END (DriverEntry->ImageHandle);
       if (EFI_ERROR (Status)) {
         DEBUG ((DEBUG_INFO, "StartImage Status - %r\n", Status));
 

--- a/StandaloneMmPkg/Core/StandaloneMmCore.h
+++ b/StandaloneMmPkg/Core/StandaloneMmCore.h
@@ -47,6 +47,7 @@
 #include <Library/PeCoffGetEntryPointLib.h>
 #include <Library/StandaloneMmMemLib.h>
 #include <Library/HobLib.h>
+#include <Library/PerformanceLib.h>
 
 #include "StandaloneMmCorePrivateData.h"
 

--- a/StandaloneMmPkg/Core/StandaloneMmCore.inf
+++ b/StandaloneMmPkg/Core/StandaloneMmCore.inf
@@ -55,6 +55,7 @@
   StandaloneMmCoreEntryPoint
   HobPrintLib
   ImagePropertiesRecordLib
+  PerformanceLib
 
 [Protocols]
   gEfiDxeMmReadyToLockProtocolGuid             ## UNDEFINED # SmiHandlerRegister

--- a/StandaloneMmPkg/StandaloneMmPkg.dsc
+++ b/StandaloneMmPkg/StandaloneMmPkg.dsc
@@ -87,6 +87,7 @@
 [LibraryClasses.common.MM_CORE_STANDALONE]
   HobLib|StandaloneMmPkg/Library/StandaloneMmCoreHobLib/StandaloneMmCoreHobLib.inf
   ArmFfaLib|ArmPkg/Library/ArmFfaLib/ArmFfaStandaloneMmCoreLib.inf
+  PerformanceLib|MdePkg/Library/BasePerformanceLibNull/BasePerformanceLibNull.inf
 
 [LibraryClasses.AARCH64.MM_CORE_STANDALONE, LibraryClasses.ARM.MM_CORE_STANDALONE]
   ArmFfaLib|ArmPkg/Library/ArmFfaLib/ArmFfaStandaloneMmCoreLib.inf


### PR DESCRIPTION
# Description

Include PerformanceLib for StandaloneMmCore, add performance logging for MM driver loading and starting.
Add FV_FILEPATH_DEVICE_PATH into Loaded Image protocol for MM driver, then StandaloneMmCorePerformanceLib can get the FILE_GUID from the device path.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

MM Boot record data for driver load and start can be found in FPDT dump on Intel platform.

## Integration Instructions

N/A
