### PR TITLE
StandaloneMmPkg/Core: Performance logging for MM driver load and start

### DIFF
--- a/StandaloneMmPkg/Core/StandaloneMmCore.h
+++ b/StandaloneMmPkg/Core/StandaloneMmCore.h
@@ -47,6 +47,7 @@
 #include <Library/PeCoffGetEntryPointLib.h>
 #include <Library/StandaloneMmMemLib.h>
 #include <Library/HobLib.h>
+#include <Library/PerformanceLib.h>
 
 #include "StandaloneMmCorePrivateData.h"
 

--- a/StandaloneMmPkg/Core/StandaloneMmCore.inf
+++ b/StandaloneMmPkg/Core/StandaloneMmCore.inf
@@ -55,6 +55,7 @@
   StandaloneMmCoreEntryPoint
   HobPrintLib
   ImagePropertiesRecordLib
+  PerformanceLib
 
 [Protocols]
   gEfiDxeMmReadyToLockProtocolGuid             ## UNDEFINED # SmiHandlerRegister

--- a/StandaloneMmPkg/StandaloneMmPkg.dsc
+++ b/StandaloneMmPkg/StandaloneMmPkg.dsc
@@ -87,6 +87,7 @@
 [LibraryClasses.common.MM_CORE_STANDALONE]
   HobLib|StandaloneMmPkg/Library/StandaloneMmCoreHobLib/StandaloneMmCoreHobLib.inf
   ArmFfaLib|ArmPkg/Library/ArmFfaLib/ArmFfaStandaloneMmCoreLib.inf
+  PerformanceLib|MdePkg/Library/BasePerformanceLibNull/BasePerformanceLibNull.inf
 
 [LibraryClasses.AARCH64.MM_CORE_STANDALONE, LibraryClasses.ARM.MM_CORE_STANDALONE]
   ArmFfaLib|ArmPkg/Library/ArmFfaLib/ArmFfaStandaloneMmCoreLib.inf


### PR DESCRIPTION
# Description

Include PerformanceLib for StandaloneMmCore, add performance logging for MM driver loading and starting.
Add FV_FILEPATH_DEVICE_PATH into Loaded Image protocol for MM driver, then StandaloneMmCorePerformanceLib can get the FILE_GUID from the device path.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

MM Boot record data for driver load and start can be found in FPDT dump on Intel platform.

## Integration Instructions

N/A
