### PR TITLE
BaseTools: Fix FMMT Compress wrong behavior

### DIFF
--- a/BaseTools/Source/Python/FMMT/core/FvHandler.py
+++ b/BaseTools/Source/Python/FMMT/core/FvHandler.py
@@ -248,8 +248,8 @@ class FvHandler:
             elif len(CompressedData) > len(TargetTree.Data.OriData):
                 New_Pad_Size = GetPadSize(len(CompressedData), SECTION_COMMON_ALIGNMENT)
                 self.Remain_New_Free_Space = len(CompressedData) + New_Pad_Size - len(TargetTree.Data.OriData) - len(TargetTree.Data.PadData)
-                self.ModifyTest(TargetTree, self.Remain_New_Free_Space)
                 self.Status = True
+                self.ModifyTest(TargetTree, self.Remain_New_Free_Space)
 
     def ModifyTest(self, ParTree, Needed_Space: int) -> None:
         # If have needed space, will find if there have free space in parent tree, meanwhile update the node data.


### PR DESCRIPTION
# Description

When using the replace function, if the replaced file located in a compress section, then the tool will re-build the section. As the compress status set in the wrong place, in some situation, the compress will do twice times which is a wrong behavior.

This patch is used to fix this issue.

Cc: Rebecca Cran <rebecca@bsdio.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Bob Feng <bob.c.feng@intel.com>
Cc: Ashraf Ali S <ashraf.ali.s@intel.com>

- [ ] Breaking change?
  No
- [ ] Impacts security?
  No
- [ ] Includes tests?
  No

## How This Was Tested

successfully build and boot in OVMFPKG

## Integration Instructions

N/A
