### PR TITLE
MdeModulePkg: Require Iommu and PCI_BME

### DIFF
--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciBus.h
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciBus.h
@@ -11,6 +11,8 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #include <PiDxe.h>
 
+#include <Guid/EventGroup.h>  // MU_CHANGE
+
 #include <Protocol/LoadedImage.h>
 #include <Protocol/PciHostBridgeResourceAllocation.h>
 #include <Protocol/PciIo.h>

--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciBus.h
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciBus.h
@@ -11,7 +11,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #include <PiDxe.h>
 
-#include <Guid/EventGroup.h>  // MU_CHANGE
+#include <Guid/EventGroup.h>
 
 #include <Protocol/LoadedImage.h>
 #include <Protocol/PciHostBridgeResourceAllocation.h>

--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciBusDxe.inf
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciBusDxe.inf
@@ -94,11 +94,15 @@
   gEdkiiDeviceIdentifierTypePciGuid               ## SOMETIMES_CONSUMES
   gEfiLoadedImageDevicePathProtocolGuid           ## CONSUMES
 
+[Guids]
+  gEfiEventExitBootServicesGuid                   ## SOMETIMES_CONSUMES     ## MU_CHANGE
+
 [FeaturePcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdPciBusHotplugDeviceSupport      ## CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdPciBridgeIoAlignmentProbe       ## CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdUnalignedPciIoEnable            ## CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdPciDegradeResourceForOptionRom  ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdDeferBME                        ## MU_CHANGE
 
 [Pcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdSrIovSystemPageSize         ## SOMETIMES_CONSUMES
@@ -107,6 +111,7 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdMrIovSupport                ## CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdPciDisableBusEnumeration    ## SOMETIMES_CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdPcieResizableBarSupport     ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdDisableBMEonEBS             ## MU_CHANGE
 
 [UserExtensions.TianoCore."ExtraFiles"]
   PciBusDxeExtra.uni

--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciBusDxe.inf
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciBusDxe.inf
@@ -95,14 +95,14 @@
   gEfiLoadedImageDevicePathProtocolGuid           ## CONSUMES
 
 [Guids]
-  gEfiEventExitBootServicesGuid                   ## SOMETIMES_CONSUMES     ## MU_CHANGE
+  gEfiEventExitBootServicesGuid                   ## SOMETIMES_CONSUMES
 
 [FeaturePcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdPciBusHotplugDeviceSupport      ## CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdPciBridgeIoAlignmentProbe       ## CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdUnalignedPciIoEnable            ## CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdPciDegradeResourceForOptionRom  ## CONSUMES
-  gEfiMdeModulePkgTokenSpaceGuid.PcdDeferBME                        ## MU_CHANGE
+  gEfiMdeModulePkgTokenSpaceGuid.PcdDeferBme
 
 [Pcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdSrIovSystemPageSize         ## SOMETIMES_CONSUMES
@@ -111,7 +111,7 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdMrIovSupport                ## CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdPciDisableBusEnumeration    ## SOMETIMES_CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdPcieResizableBarSupport     ## CONSUMES
-  gEfiMdeModulePkgTokenSpaceGuid.PcdDisableBMEonEBS             ## MU_CHANGE
+  gEfiMdeModulePkgTokenSpaceGuid.PcdDisableBmeOnEbs
 
 [UserExtensions.TianoCore."ExtraFiles"]
   PciBusDxeExtra.uni

--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciDeviceSupport.c
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciDeviceSupport.c
@@ -15,8 +15,6 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 //
 LIST_ENTRY  mPciDevicePool;
 
-// MU_CHANGE Begin - Disable BME at Exit Boot Services
-
 /**
  * Disable the bus pointed to by Head.
  *
@@ -36,7 +34,7 @@ DisableBmeOnTree (
   // DisableBME on ExitBootServices should be synchonized with VTd disable - with
   // DisableBME running before VTd disable.  If the VTd disable code runs at TPL_CALLBACK,
   // then DisableBME will run before VTd disable.
-  if (!PcdGetBool (PcdDisableBMEonEBS)) {
+  if (!PcdGetBool (PcdDisableBmeOnEbs)) {
     DEBUG ((DEBUG_WARN, "%a PCI Bus Master enabled due to PCD setting\n", __func__));
     return;
   }
@@ -90,8 +88,6 @@ OnExitBootServices (
   DisableBmeOnTree (&mPciDevicePool);
 }
 
-// MU_CHANGE End
-
 /**
   Initialize the PCI devices pool.
 
@@ -101,12 +97,11 @@ InitializePciDevicePool (
   VOID
   )
 {
-  EFI_EVENT   ExitBootServicesEvent;    // MU_CHANGE
-  EFI_STATUS  Status;                   // MU_CHANGE
+  EFI_EVENT   ExitBootServicesEvent;
+  EFI_STATUS  Status;
 
   InitializeListHead (&mPciDevicePool);
 
-  // MU_CHANGE [Begin] - Disable BME on EBS
   Status = gBS->CreateEventEx (
                   EVT_NOTIFY_SIGNAL,
                   TPL_NOTIFY,
@@ -118,8 +113,6 @@ InitializePciDevicePool (
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "Unable to create ExitBootServices event. Code=%r\n", Status));
   }
-
-  // MU_CHANGE [End]
 }
 
 /**
@@ -780,14 +773,11 @@ StartPciDevicesOnBridge (
                              &Supports
                              );
 
-        // MU_CHANGE [Begin] - Defer BME enablement until PCI SetAttributes
-        if (FeaturePcdGet (PcdDeferBME)) {
+        if (FeaturePcdGet (PcdDeferBme)) {
           Supports &= (UINT64)(EFI_PCI_IO_ATTRIBUTE_IO | EFI_PCI_IO_ATTRIBUTE_MEMORY);
         } else {
           Supports &= (UINT64)EFI_PCI_DEVICE_ENABLE;
         }
-
-        // MU_CHANGE [End]
 
         PciIoDevice->PciIo.Attributes (
                              &(PciIoDevice->PciIo),
@@ -837,15 +827,13 @@ StartPciDevicesOnBridge (
                              &Supports
                              );
 
-        // MU_CHANGE Start - Defer BME enablement until PCI SetAttributes
-        if (FeaturePcdGet (PcdDeferBME)) {
+        if (FeaturePcdGet (PcdDeferBme)) {
           Supports &= (UINT64)(EFI_PCI_IO_ATTRIBUTE_IO | EFI_PCI_IO_ATTRIBUTE_MEMORY);
         } else {
           Supports &= (UINT64)EFI_PCI_DEVICE_ENABLE;
         }
 
         // Supports &= (UINT64)EFI_PCI_DEVICE_ENABLE;
-        // MU_CHANGE End
 
         PciIoDevice->PciIo.Attributes (
                              &(PciIoDevice->PciIo),

--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciEnumeratorSupport.c
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciEnumeratorSupport.c
@@ -1188,6 +1188,7 @@ DetermineDeviceAttribute (
   PCI_IO_DEVICE  *Temp;
   LIST_ENTRY     *CurrentLink;
   EFI_STATUS     Status;
+  UINT16         BridgeSupportsMaster = 0;  // MU_CHANGE
 
   //
   // For Root Bridge, just copy it by RootBridgeIo protocol
@@ -1209,6 +1210,13 @@ DetermineDeviceAttribute (
     PciIoDevice->Supports |= (UINT64)(EFI_PCI_IO_ATTRIBUTE_EMBEDDED_DEVICE |
                                       EFI_PCI_IO_ATTRIBUTE_EMBEDDED_ROM |
                                       EFI_PCI_IO_ATTRIBUTE_DUAL_ADDRESS_CYCLE);
+
+    // MU_CHANGE [Start] - Defer BME enablement until Pci SetAttributes
+    if (FeaturePcdGet (PcdDeferBME)) {
+      PciIoDevice->Supports |= EFI_PCI_IO_ATTRIBUTE_BUS_MASTER;
+    }
+
+    // MU_CHANGE [End]
   } else {
     //
     // Set the attributes to be checked for common PCI devices and PPB or P2C
@@ -1220,6 +1228,27 @@ DetermineDeviceAttribute (
               EFI_PCI_COMMAND_BUS_MASTER   |
               EFI_PCI_COMMAND_VGA_PALETTE_SNOOP;
 
+    // MU_CHANGE Start - Defer BME enablement until Pci SetAttributes
+    // This ASSUMES all P2P bridges are Bus Master capable
+    if (FeaturePcdGet (PcdDeferBME)) {
+      if (IS_PCI_BRIDGE (&PciIoDevice->Pci)) {
+        Command              &= ~EFI_PCI_COMMAND_BUS_MASTER;
+        BridgeSupportsMaster |= EFI_PCI_COMMAND_BUS_MASTER;
+        DEBUG ((
+          EFI_D_INFO,
+          "P2P PciIo=%p, Parent=%p, Command set to %x. Bus=%d,Dev=%d,Fun=%d\n",
+          &PciIoDevice->PciIo,
+          &PciIoDevice->Parent,
+          Command,
+          PciIoDevice->BusNumber,
+          PciIoDevice->DeviceNumber,
+          PciIoDevice->FunctionNumber
+          ));
+      }
+    }
+
+    // MU_CHANGE End
+
     BridgeControl = EFI_PCI_BRIDGE_CONTROL_ISA | EFI_PCI_BRIDGE_CONTROL_VGA | EFI_PCI_BRIDGE_CONTROL_VGA_16;
 
     //
@@ -1230,7 +1259,7 @@ DetermineDeviceAttribute (
     //
     // Set the supported attributes for specified PCI device
     //
-    PciSetDeviceAttribute (PciIoDevice, Command, BridgeControl, EFI_SET_SUPPORTS);
+    PciSetDeviceAttribute (PciIoDevice, Command|BridgeSupportsMaster, BridgeControl, EFI_SET_SUPPORTS); // MU_CHANGE
 
     //
     // Set the current attributes for specified PCI device

--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciEnumeratorSupport.c
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciEnumeratorSupport.c
@@ -1188,7 +1188,7 @@ DetermineDeviceAttribute (
   PCI_IO_DEVICE  *Temp;
   LIST_ENTRY     *CurrentLink;
   EFI_STATUS     Status;
-  UINT16         BridgeSupportsMaster = 0;  // MU_CHANGE
+  UINT16         BridgeSupportsMaster = 0;
 
   //
   // For Root Bridge, just copy it by RootBridgeIo protocol
@@ -1211,12 +1211,9 @@ DetermineDeviceAttribute (
                                       EFI_PCI_IO_ATTRIBUTE_EMBEDDED_ROM |
                                       EFI_PCI_IO_ATTRIBUTE_DUAL_ADDRESS_CYCLE);
 
-    // MU_CHANGE [Start] - Defer BME enablement until Pci SetAttributes
-    if (FeaturePcdGet (PcdDeferBME)) {
+    if (FeaturePcdGet (PcdDeferBme)) {
       PciIoDevice->Supports |= EFI_PCI_IO_ATTRIBUTE_BUS_MASTER;
     }
-
-    // MU_CHANGE [End]
   } else {
     //
     // Set the attributes to be checked for common PCI devices and PPB or P2C
@@ -1228,9 +1225,8 @@ DetermineDeviceAttribute (
               EFI_PCI_COMMAND_BUS_MASTER   |
               EFI_PCI_COMMAND_VGA_PALETTE_SNOOP;
 
-    // MU_CHANGE Start - Defer BME enablement until Pci SetAttributes
     // This ASSUMES all P2P bridges are Bus Master capable
-    if (FeaturePcdGet (PcdDeferBME)) {
+    if (FeaturePcdGet (PcdDeferBme)) {
       if (IS_PCI_BRIDGE (&PciIoDevice->Pci)) {
         Command              &= ~EFI_PCI_COMMAND_BUS_MASTER;
         BridgeSupportsMaster |= EFI_PCI_COMMAND_BUS_MASTER;
@@ -1247,8 +1243,6 @@ DetermineDeviceAttribute (
       }
     }
 
-    // MU_CHANGE End
-
     BridgeControl = EFI_PCI_BRIDGE_CONTROL_ISA | EFI_PCI_BRIDGE_CONTROL_VGA | EFI_PCI_BRIDGE_CONTROL_VGA_16;
 
     //
@@ -1259,7 +1253,7 @@ DetermineDeviceAttribute (
     //
     // Set the supported attributes for specified PCI device
     //
-    PciSetDeviceAttribute (PciIoDevice, Command|BridgeSupportsMaster, BridgeControl, EFI_SET_SUPPORTS); // MU_CHANGE
+    PciSetDeviceAttribute (PciIoDevice, Command|BridgeSupportsMaster, BridgeControl, EFI_SET_SUPPORTS);
 
     //
     // Set the current attributes for specified PCI device

--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciIo.c
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciIo.c
@@ -1618,6 +1618,12 @@ PciIoAttributes (
     }
   }
 
+  // RootBridgeIo doesn't support BUS_MASTER as an option. Remove BUS_MASTER
+  // from attributes going up to the HostBridge.
+  if (PciIoDevice->Parent == NULL) {
+    Attributes &= ~EFI_PCI_IO_ATTRIBUTE_BUS_MASTER;
+  }
+
   //
   // If no attributes can be supported, then return.
   // Otherwise, set the attributes that it can support.
@@ -1728,12 +1734,11 @@ PciIoAttributes (
 
   //
   // The upstream bridge should be also set to relevant attribute
-  // expect for IO, Mem and BusMaster
+  // except for IO and Mem.
   //
   UpStreamAttributes = Attributes &
                        (~(EFI_PCI_IO_ATTRIBUTE_IO     |
-                          EFI_PCI_IO_ATTRIBUTE_MEMORY |
-                          EFI_PCI_IO_ATTRIBUTE_BUS_MASTER
+                          EFI_PCI_IO_ATTRIBUTE_MEMORY
                           )
                        );
   UpStreamBridge = PciIoDevice->Parent;

--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciIo.c
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciIo.c
@@ -1007,6 +1007,14 @@ PciIoMap (
       );
   }
 
+  if (mIoMmuProtocol == NULL) {
+    gBS->LocateProtocol (
+           &gEdkiiIoMmuProtocolGuid,
+           NULL,
+           (VOID **)&mIoMmuProtocol
+           );
+  }
+
   if (mIoMmuProtocol != NULL) {
     if (!EFI_ERROR (Status)) {
       switch (Operation) {
@@ -1057,6 +1065,14 @@ PciIoUnmap (
   PCI_IO_DEVICE  *PciIoDevice;
 
   PciIoDevice = PCI_IO_DEVICE_FROM_PCI_IO_THIS (This);
+
+  if (mIoMmuProtocol == NULL) {
+    gBS->LocateProtocol (
+           &gEdkiiIoMmuProtocolGuid,
+           NULL,
+           (VOID **)&mIoMmuProtocol
+           );
+  }
 
   if (mIoMmuProtocol != NULL) {
     mIoMmuProtocol->SetAttribute (

--- a/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostBridgeDxe.inf
+++ b/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostBridgeDxe.inf
@@ -39,6 +39,11 @@
   UefiLib
   PciHostBridgeLib
   TimerLib
+  PcdLib
+  ReportStatusCodeLib
+
+[FeaturePcd]
+  gEfiMdeModulePkgTokenSpaceGuid.PcdRequireIommu
 
 [Protocols]
   gEfiCpuIo2ProtocolGuid                          ## CONSUMES

--- a/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciRootBridgeIo.c
+++ b/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciRootBridgeIo.c
@@ -11,9 +11,14 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include "PciRootBridge.h"
 #include "PciHostResource.h"
 
+#include <Library/ReportStatusCodeLib.h>
+
 #define NO_MAPPING  (VOID *) (UINTN) -1
 
 #define RESOURCE_VALID(Resource)  ((Resource)->Base <= (Resource)->Limit)
+
+#define PCI_DMA_ORDERING_ERROR_STATUS_TYPE  (EFI_ERROR_MAJOR | EFI_ERROR_CODE)
+#define PCI_DMA_ORDERING_ERROR_CODE         (EFI_IO_BUS_PCI | EFI_IOB_EC_NOT_CONFIGURED)
 
 //
 // Lookup table for increment values based on transfer widths
@@ -1325,6 +1330,7 @@ RootBridgeIoPciWrite (
   @retval EFI_UNSUPPORTED        The HostAddress cannot be mapped as a common buffer.
   @retval EFI_DEVICE_ERROR       The System hardware could not map the requested address.
   @retval EFI_OUT_OF_RESOURCES   The request could not be completed due to lack of resources.
+  @retval EFI_NOT_READY          Require IOMMU PCD has been set and request happens before IOMMU protocol install.
 **/
 EFI_STATUS
 EFIAPI
@@ -1356,6 +1362,13 @@ RootBridgeIoMap (
   }
 
   RootBridge = ROOT_BRIDGE_FROM_THIS (This);
+
+  if (FeaturePcdGet (PcdRequireIommu) && (mIoMmu == NULL)) {
+    DEBUG ((DEBUG_ERROR, "%a - mIoMmuProtocol is NULL!\n", __func__));
+    ASSERT (mIoMmu != NULL);
+    ReportStatusCode (PCI_DMA_ORDERING_ERROR_STATUS_TYPE, PCI_DMA_ORDERING_ERROR_CODE);
+    return EFI_NOT_READY;
+  }
 
   if (mIoMmu != NULL) {
     if (!RootBridge->DmaAbove4G) {
@@ -1491,6 +1504,7 @@ RootBridgeIoMap (
   @retval EFI_SUCCESS            The range was unmapped.
   @retval EFI_INVALID_PARAMETER  Mapping is not a value that was returned by Map().
   @retval EFI_DEVICE_ERROR       The data was not committed to the target system memory.
+  @retval EFI_NOT_READY          Require IOMMU PCD has been set and request happens before IOMMU protocol install.
 **/
 EFI_STATUS
 EFIAPI
@@ -1503,6 +1517,13 @@ RootBridgeIoUnmap (
   LIST_ENTRY                *Link;
   PCI_ROOT_BRIDGE_INSTANCE  *RootBridge;
   EFI_STATUS                Status;
+
+  if (FeaturePcdGet (PcdRequireIommu) && (mIoMmu == NULL)) {
+    DEBUG ((DEBUG_ERROR, "%a - mIoMmuProtocol is NULL!\n", __func__));
+    ASSERT (mIoMmu != NULL);
+    ReportStatusCode (PCI_DMA_ORDERING_ERROR_STATUS_TYPE, PCI_DMA_ORDERING_ERROR_CODE);
+    return EFI_NOT_READY;
+  }
 
   if (mIoMmu != NULL) {
     Status = mIoMmu->Unmap (
@@ -1592,6 +1613,7 @@ RootBridgeIoUnmap (
                                  attribute bits are MEMORY_WRITE_COMBINE,
                                  MEMORY_CACHED, and DUAL_ADDRESS_CYCLE.
   @retval EFI_OUT_OF_RESOURCES   The memory pages could not be allocated.
+  @retval EFI_NOT_READY          Require IOMMU PCD has been set and request happens before IOMMU protocol install.
 **/
 EFI_STATUS
 EFIAPI
@@ -1634,6 +1656,13 @@ RootBridgeIoAllocateBuffer (
   }
 
   RootBridge = ROOT_BRIDGE_FROM_THIS (This);
+
+  if (FeaturePcdGet (PcdRequireIommu) && (mIoMmu == NULL)) {
+    DEBUG ((DEBUG_ERROR, "%a - mIoMmuProtocol is NULL!\n", __func__));
+    ASSERT (mIoMmu != NULL);
+    ReportStatusCode (PCI_DMA_ORDERING_ERROR_STATUS_TYPE, PCI_DMA_ORDERING_ERROR_CODE);
+    return EFI_NOT_READY;
+  }
 
   if (mIoMmu != NULL) {
     if (!RootBridge->DmaAbove4G) {
@@ -1691,6 +1720,7 @@ RootBridgeIoAllocateBuffer (
   @retval EFI_SUCCESS            The requested memory pages were freed.
   @retval EFI_INVALID_PARAMETER  The memory range specified by HostAddress and
                                  Pages was not allocated with AllocateBuffer().
+  @retval EFI_NOT_READY          Require IOMMU PCD has been set and request happens before IOMMU protocol install.
 **/
 EFI_STATUS
 EFIAPI
@@ -1701,6 +1731,13 @@ RootBridgeIoFreeBuffer (
   )
 {
   EFI_STATUS  Status;
+
+  if (FeaturePcdGet (PcdRequireIommu) && (mIoMmu == NULL)) {
+    DEBUG ((DEBUG_ERROR, "%a - mIoMmuProtocol is NULL!\n", __func__));
+    ASSERT (mIoMmu != NULL);
+    ReportStatusCode (PCI_DMA_ORDERING_ERROR_STATUS_TYPE, PCI_DMA_ORDERING_ERROR_CODE);
+    return EFI_NOT_READY;
+  }
 
   if (mIoMmu != NULL) {
     Status = mIoMmu->FreeBuffer (

--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -996,7 +996,6 @@
   #   FALSE - Does not support process non-reset capsule image at runtime.<BR>
   # @Prompt Enable process non-reset capsule image at runtime.
   gEfiMdeModulePkgTokenSpaceGuid.PcdSupportProcessCapsuleAtRuntime|FALSE|BOOLEAN|0x00010079
-  ## MU_CHANGE
   ## Indicates that the system should not automatically enable BME on P2P bridges until a subordinate
   #  device has its Bus Master Enable bit set by a call to PciIo->SetAttributes.
   #  Note: Some UEFI drivers are not compliant and do not correctly call SetAttributes before attempting
@@ -1004,9 +1003,16 @@
   #   TRUE  - Defer BME enablement on P2P bridges.
   #   FALSE - Initialize P2P bridges with BME enabled.
   # @Prompt Defer BME enablement
-  gEfiMdeModulePkgTokenSpaceGuid.PcdDeferBME|TRUE|BOOLEAN|0x30002050
+  gEfiMdeModulePkgTokenSpaceGuid.PcdDeferBme|TRUE|BOOLEAN|0x30002050
 
-[PcdsFeatureFlag.IA32, PcdsFeatureFlag.ARM, PcdsFeatureFlag.AARCH64]
+  ## Indicates if DMA is allowed before IOMMU protocol install
+  #  If enabled, device wil assert and return EFI_DEVICE_ERROR on any DMA access before IOMMU Protocol Install.<BR><BR>
+  #   TRUE  - IOMMU protocol required for DMA access.<BR>
+  #   FALSE - DMA Access can happen before IOMMU protocol install.<BR>
+  # @Prompt Enable DMA before IOMMU protocol.
+  gEfiMdeModulePkgTokenSpaceGuid.PcdRequireIommu|TRUE|BOOLEAN|0x30001090
+
+[PcdsFeatureFlag.IA32, PcdsFeatureFlag.ARM, PcdsFeatureFlag.AARCH64, PcdsFeatureFlag.LOONGARCH64]
   gEfiMdeModulePkgTokenSpaceGuid.PcdPciDegradeResourceForOptionRom|FALSE|BOOLEAN|0x0001003a
 
 [PcdsFeatureFlag.IA32, PcdsFeatureFlag.X64]
@@ -1925,14 +1931,13 @@
   #   FALSE - BDS does not support Platform Recovery.<BR>
   # @Prompt Support Platform Recovery.
   gEfiMdeModulePkgTokenSpaceGuid.PcdPlatformRecoverySupport|TRUE|BOOLEAN|0x00010078
-  ## MU_CHANGE
   ## Indicates that the system should disable BME on all Pci2Pci bridges on Exit Boot Services
   #  Note: Some operating systems and drivers may not expect devices to be in this state, and it
   #  may cause unexpected behaviors.
   #   TRUE  - Disable BME on P2P at Exit Boot Services.
   #   FALSE - Do not disable BME on P2P at Exit Boot Services.
   # @Prompt Disable BME on Exit Boot Services
-  gEfiMdeModulePkgTokenSpaceGuid.PcdDisableBMEonEBS|TRUE|BOOLEAN|0x30002051
+  gEfiMdeModulePkgTokenSpaceGuid.PcdDisableBmeOnEbs|TRUE|BOOLEAN|0x30002051
 
   ## Specify the foreground color for Subtile text in HII Form Browser. The default value is EFI_BLUE.
   #  Only following values defined in UEFI specification are valid:<BR><BR>

--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -996,8 +996,17 @@
   #   FALSE - Does not support process non-reset capsule image at runtime.<BR>
   # @Prompt Enable process non-reset capsule image at runtime.
   gEfiMdeModulePkgTokenSpaceGuid.PcdSupportProcessCapsuleAtRuntime|FALSE|BOOLEAN|0x00010079
+  ## MU_CHANGE
+  ## Indicates that the system should not automatically enable BME on P2P bridges until a subordinate
+  #  device has its Bus Master Enable bit set by a call to PciIo->SetAttributes.
+  #  Note: Some UEFI drivers are not compliant and do not correctly call SetAttributes before attempting
+  #  DMA operations. For these drivers, this setting will cause a functionality break.
+  #   TRUE  - Defer BME enablement on P2P bridges.
+  #   FALSE - Initialize P2P bridges with BME enabled.
+  # @Prompt Defer BME enablement
+  gEfiMdeModulePkgTokenSpaceGuid.PcdDeferBME|TRUE|BOOLEAN|0x30002050
 
-[PcdsFeatureFlag.IA32, PcdsFeatureFlag.ARM, PcdsFeatureFlag.AARCH64, PcdsFeatureFlag.LOONGARCH64]
+[PcdsFeatureFlag.IA32, PcdsFeatureFlag.ARM, PcdsFeatureFlag.AARCH64]
   gEfiMdeModulePkgTokenSpaceGuid.PcdPciDegradeResourceForOptionRom|FALSE|BOOLEAN|0x0001003a
 
 [PcdsFeatureFlag.IA32, PcdsFeatureFlag.X64]
@@ -1916,6 +1925,14 @@
   #   FALSE - BDS does not support Platform Recovery.<BR>
   # @Prompt Support Platform Recovery.
   gEfiMdeModulePkgTokenSpaceGuid.PcdPlatformRecoverySupport|TRUE|BOOLEAN|0x00010078
+  ## MU_CHANGE
+  ## Indicates that the system should disable BME on all Pci2Pci bridges on Exit Boot Services
+  #  Note: Some operating systems and drivers may not expect devices to be in this state, and it
+  #  may cause unexpected behaviors.
+  #   TRUE  - Disable BME on P2P at Exit Boot Services.
+  #   FALSE - Do not disable BME on P2P at Exit Boot Services.
+  # @Prompt Disable BME on Exit Boot Services
+  gEfiMdeModulePkgTokenSpaceGuid.PcdDisableBMEonEBS|TRUE|BOOLEAN|0x30002051
 
   ## Specify the foreground color for Subtile text in HII Form Browser. The default value is EFI_BLUE.
   #  Only following values defined in UEFI specification are valid:<BR><BR>

--- a/OvmfPkg/OvmfPkgIa32.dsc
+++ b/OvmfPkg/OvmfPkgIa32.dsc
@@ -484,6 +484,8 @@
   gUefiOvmfPkgTokenSpaceGuid.PcdSecureBootSupported|TRUE
   gEfiMdeModulePkgTokenSpaceGuid.PcdRequireSelfSignedPk|TRUE
 !endif
+  gEfiMdeModulePkgTokenSpaceGuid.PcdRequireIommu|FALSE
+  gEfiMdeModulePkgTokenSpaceGuid.PcdDeferBme|FALSE
 
 [PcdsFixedAtBuild]
   gEfiMdeModulePkgTokenSpaceGuid.PcdStatusCodeMemorySize|1
@@ -516,6 +518,7 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdVpdBaseAddress|0x0
   gEfiMdeModulePkgTokenSpaceGuid.PcdStatusCodeUseSerial|FALSE
   gEfiMdeModulePkgTokenSpaceGuid.PcdStatusCodeUseMemory|TRUE
+  gEfiMdeModulePkgTokenSpaceGuid.PcdDisableBmeOnEbs|FALSE
 
   gEfiMdePkgTokenSpaceGuid.PcdReportStatusCodePropertyMask|0x07
 

--- a/OvmfPkg/OvmfPkgIa32X64.dsc
+++ b/OvmfPkg/OvmfPkgIa32X64.dsc
@@ -490,6 +490,8 @@
   gUefiOvmfPkgTokenSpaceGuid.PcdSecureBootSupported|TRUE
   gEfiMdeModulePkgTokenSpaceGuid.PcdRequireSelfSignedPk|TRUE
 !endif
+  gEfiMdeModulePkgTokenSpaceGuid.PcdRequireIommu|FALSE
+  gEfiMdeModulePkgTokenSpaceGuid.PcdDeferBme|FALSE
 
 [PcdsFixedAtBuild]
   gEfiMdeModulePkgTokenSpaceGuid.PcdStatusCodeMemorySize|1
@@ -522,6 +524,7 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdVpdBaseAddress|0x0
   gEfiMdeModulePkgTokenSpaceGuid.PcdStatusCodeUseSerial|FALSE
   gEfiMdeModulePkgTokenSpaceGuid.PcdStatusCodeUseMemory|TRUE
+  gEfiMdeModulePkgTokenSpaceGuid.PcdDisableBmeOnEbs|FALSE
 
   gEfiMdePkgTokenSpaceGuid.PcdReportStatusCodePropertyMask|0x07
 

--- a/OvmfPkg/OvmfPkgX64.dsc
+++ b/OvmfPkg/OvmfPkgX64.dsc
@@ -513,6 +513,8 @@
   gUefiOvmfPkgTokenSpaceGuid.PcdSecureBootSupported|TRUE
   gEfiMdeModulePkgTokenSpaceGuid.PcdRequireSelfSignedPk|TRUE
 !endif
+  gEfiMdeModulePkgTokenSpaceGuid.PcdRequireIommu|FALSE
+  gEfiMdeModulePkgTokenSpaceGuid.PcdDeferBme|FALSE
 
 [PcdsFixedAtBuild]
   gEfiMdeModulePkgTokenSpaceGuid.PcdStatusCodeMemorySize|1
@@ -545,6 +547,7 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdVpdBaseAddress|0x0
   gEfiMdeModulePkgTokenSpaceGuid.PcdStatusCodeUseSerial|FALSE
   gEfiMdeModulePkgTokenSpaceGuid.PcdStatusCodeUseMemory|TRUE
+  gEfiMdeModulePkgTokenSpaceGuid.PcdDisableBmeOnEbs|FALSE
 
   gEfiMdePkgTokenSpaceGuid.PcdReportStatusCodePropertyMask|0x07
 


### PR DESCRIPTION
# Description

We want to upstream the following 2 changes to edk2 for support for IOMMU and SMMU within UEFI context. 
Project Mu has a SmmuDxe driver (will also upstream to edk2) that enables DMA protection pre-os-boot. We want to have it running on all arm platforms. As a result, these changes are needed.

For security, we are setting all the added PCD's to TRUE to enforce security and safety around DMA. 
At a platform level, they can be set to FALSE there.

Require IOMMU protocol install before DMA access.
[PCI_BME] PCI Bus Master Disable


- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Tested on Qemu mu_tiano platforms as well as a physical arm device.

## Integration Instructions

These added PCD's are set to TRUE by default for security. At a platform level, we can set them to FALSE if needed.