### PR TITLE
 MdeModulePkg SpiBus: Use correct GUID

### DIFF
--- a/MdeModulePkg/Bus/Spi/SpiBus/SpiBus.c
+++ b/MdeModulePkg/Bus/Spi/SpiBus/SpiBus.c
@@ -329,8 +329,17 @@ Transaction (
              ((SpiChip->SpiHc->Attributes & HC_SUPPORTS_WRITE_THEN_READ_OPERATIONS) != HC_SUPPORTS_WRITE_THEN_READ_OPERATIONS))
   {
     // Convert to full duplex transaction
-    DummyReadBuffer                    = AllocateZeroPool (WriteBytes);
-    DummyWriteBuffer                   = AllocateZeroPool (ReadBytes);
+    DummyReadBuffer = AllocateZeroPool (WriteBytes);
+    if (DummyReadBuffer == NULL) {
+      return EFI_OUT_OF_RESOURCES;
+    }
+
+    DummyWriteBuffer = AllocateZeroPool (ReadBytes);
+    if (DummyWriteBuffer == NULL) {
+      FreePool (DummyReadBuffer);
+      return EFI_OUT_OF_RESOURCES;
+    }
+
     SpiChip->BusTransaction.ReadBuffer = DummyReadBuffer;
     SpiChip->BusTransaction.ReadBytes  = WriteBytes;
 

--- a/MdeModulePkg/Bus/Spi/SpiBus/SpiBusDxe.c
+++ b/MdeModulePkg/Bus/Spi/SpiBus/SpiBusDxe.c
@@ -108,7 +108,7 @@ SpiBusEntry (
       // Get SpiHc from the SpiHcHandles
       Status = gBS->HandleProtocol (
                       SpiHcHandles[HcIndex],
-                      &gEfiDevicePathProtocolGuid,
+                      &gEfiSpiHcProtocolGuid,
                       (VOID **)&SpiHc
                       );
 


### PR DESCRIPTION
Fix incorrect guid in SpiBusDxe

# Description

Fix incorrect gEfiDevicePathProtocolGuid in the HandleProtocol.
Replace gEfiDevicePathProtocolGuid with gEfiSpiHcProtocolGuid to locate the spi protocol.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested
N/A

## Integration Instructions
N/A