### PR TITLE
SecurityPkg/FvReportPei: Add explicit handling for the case where there is only one FV.

### DIFF
--- a/SecurityPkg/FvReportPei/FvReportPei.c
+++ b/SecurityPkg/FvReportPei/FvReportPei.c
@@ -252,16 +252,27 @@ VerifyHashedFv (
     FvInfo[FvIndex].Base = (UINT64)(UINTN)FvBuffer;
   }
 
-  //
-  // Check final hash for all FVs.
-  //
-  if ((FvHashValue == HashValue) ||
-      (AlgInfo->HashAll (HashValue, FvHashValue - HashValue, FvHashValue) &&
-       (CompareMem (HashInfo->Hash, FvHashValue, AlgInfo->HashSize) == 0)))
-  {
-    Status = EFI_SUCCESS;
+  if (FvNumber == 1) {
+    //
+    // Directly compare the single FV's hash
+    //
+    if (CompareMem (HashInfo->Hash, HashValue, AlgInfo->HashSize) == 0) {
+      Status = EFI_SUCCESS;
+    } else {
+      Status = EFI_VOLUME_CORRUPTED;
+    }
   } else {
-    Status = EFI_VOLUME_CORRUPTED;
+    //
+    // Check final hash for all FVs. Handle multiple FVs
+    //
+    if ((FvHashValue == HashValue) ||
+        (AlgInfo->HashAll (HashValue, FvHashValue - HashValue, FvHashValue) &&
+         (CompareMem (HashInfo->Hash, FvHashValue, AlgInfo->HashSize) == 0)))
+    {
+      Status = EFI_SUCCESS;
+    } else {
+      Status = EFI_VOLUME_CORRUPTED;
+    }
   }
 
 Done:


### PR DESCRIPTION
# Description
there is a potential issue in the code when handling a single Firmware Volume (FV) report. Specifically, the problem lies in the logic for calculating and verifying the hash values for the FVs.

Key Issue:
The code assumes that there are multiple FVs when calculating the hash values. If there is only one FV, the logic for handling FvHashValue and HashValue might not work as intended.

FvHashValue == HashValue: This condition is true only if no hash values were calculated (e.g., no FVs were processed). For a single FV, this condition might incorrectly pass or fail depending on how FvHashValue is updated.
AlgInfo->HashAll: This function calculates the hash for all FVs. If there is only one FV, the range FvHashValue - HashValue might not be handled correctly, leading to incorrect hash verification.
CompareMem: The comparison might fail if the calculated hash (FvHashValue) is not properly updated or initialized for a single FV.

Potential Bug:
If there is only one FV, the code might:

Skip the hash calculation for the single FV due to incorrect pointer arithmetic or logic.
Fail to verify the hash because FvHashValue is not updated correctly.
Incorrectly report EFI_VOLUME_CORRUPTED even if the single FV is valid.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested
Only report 1 FV info and the code able to return success result. 

## Integration Instructions
N/A
