### PR TITLE
MdeModulePkg: PCI_BME PCI Bus Master Disable

### DIFF
--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciBus.h
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciBus.h
@@ -11,6 +11,8 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #include <PiDxe.h>
 
+#include <Guid/EventGroup.h>
+
 #include <Protocol/LoadedImage.h>
 #include <Protocol/PciHostBridgeResourceAllocation.h>
 #include <Protocol/PciIo.h>

--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciBusDxe.inf
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciBusDxe.inf
@@ -94,11 +94,15 @@
   gEdkiiDeviceIdentifierTypePciGuid               ## SOMETIMES_CONSUMES
   gEfiLoadedImageDevicePathProtocolGuid           ## CONSUMES
 
+[Guids]
+  gEfiEventExitBootServicesGuid                   ## SOMETIMES_CONSUMES
+
 [FeaturePcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdPciBusHotplugDeviceSupport      ## CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdPciBridgeIoAlignmentProbe       ## CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdUnalignedPciIoEnable            ## CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdPciDegradeResourceForOptionRom  ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdDeferBme
 
 [Pcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdSrIovSystemPageSize         ## SOMETIMES_CONSUMES
@@ -107,6 +111,7 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdMrIovSupport                ## CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdPciDisableBusEnumeration    ## SOMETIMES_CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdPcieResizableBarSupport     ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdDisableBmeOnEbs
 
 [UserExtensions.TianoCore."ExtraFiles"]
   PciBusDxeExtra.uni

--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciDeviceSupport.c
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciDeviceSupport.c
@@ -16,6 +16,79 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 LIST_ENTRY  mPciDevicePool;
 
 /**
+ * Disable the bus pointed to by Head.
+ *
+ * @param Head     A pointer to the list entry you want to disable.
+ *
+ * @return VOID
+ */
+VOID
+DisableBmeOnTree (
+  IN LIST_ENTRY  *Head
+  )
+{
+  LIST_ENTRY     *CurrentLink;
+  PCI_IO_DEVICE  *PciIoDevice;
+  UINT16         Command;
+
+  // DisableBME on ExitBootServices should be synchonized with IoMmu/Smmu disable - with
+  // DisableBME running before IoMmu/Smmu disable.  If the IoMmu/Smmu disable code runs at TPL_CALLBACK,
+  // then DisableBME will run before IoMmu/Smmu disable.
+  if (!PcdGetBool (PcdDisableBmeOnEbs)) {
+    DEBUG ((DEBUG_WARN, "%a PCI Bus Master enabled due to PCD setting\n", __func__));
+    return;
+  }
+
+  CurrentLink = Head->ForwardLink;
+  while (CurrentLink != NULL && CurrentLink != Head) {
+    PciIoDevice = PCI_IO_DEVICE_FROM_LINK (CurrentLink);
+    //
+    // Turn off all children's Bus Master, if any
+    //
+    DisableBmeOnTree (&PciIoDevice->ChildList);
+
+    // If this is a P2P Bridge, disable the Bridge's Bus Master.
+    if (IS_PCI_BRIDGE (&PciIoDevice->Pci)) {
+      PCI_READ_COMMAND_REGISTER (PciIoDevice, &Command);
+      if (EFI_PCI_COMMAND_BUS_MASTER == (Command & EFI_PCI_COMMAND_BUS_MASTER)) {
+        Command &= ~EFI_PCI_COMMAND_BUS_MASTER;
+        PCI_SET_COMMAND_REGISTER (PciIoDevice, Command);
+        DEBUG ((
+          EFI_D_INFO,
+          "P2P BME-DISABLED PciIo=%p, Command=%x, Bus=%d,Dev=%d,Fun=%d\n",
+          &PciIoDevice->PciIo,
+          Command,
+          PciIoDevice->BusNumber,
+          PciIoDevice->DeviceNumber,
+          PciIoDevice->FunctionNumber
+          ));
+      }
+    }
+
+    CurrentLink = CurrentLink->ForwardLink;
+  }
+}
+
+/**
+ * On ExitBootServices handler.  Inspect all P2P bridges, and
+ * disable Bus Master on any that were enabled during BDS.
+ *
+ * @param Event
+ * @param Context
+ *
+ * @return VOID EFIAPI
+ */
+VOID
+EFIAPI
+OnExitBootServices (
+  IN      EFI_EVENT  Event,
+  IN      VOID       *Context
+  )
+{
+  DisableBmeOnTree (&mPciDevicePool);
+}
+
+/**
   Initialize the PCI devices pool.
 
 **/
@@ -24,7 +97,22 @@ InitializePciDevicePool (
   VOID
   )
 {
+  EFI_EVENT   ExitBootServicesEvent;
+  EFI_STATUS  Status;
+
   InitializeListHead (&mPciDevicePool);
+
+  Status = gBS->CreateEventEx (
+                  EVT_NOTIFY_SIGNAL,
+                  TPL_NOTIFY,
+                  OnExitBootServices,
+                  NULL,
+                  &gEfiEventExitBootServicesGuid,
+                  &ExitBootServicesEvent
+                  );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "Unable to create ExitBootServices event. Code=%r\n", Status));
+  }
 }
 
 /**
@@ -684,7 +772,13 @@ StartPciDevicesOnBridge (
                              0,
                              &Supports
                              );
-        Supports &= (UINT64)EFI_PCI_DEVICE_ENABLE;
+
+        if (FeaturePcdGet (PcdDeferBme)) {
+          Supports &= (UINT64)(EFI_PCI_IO_ATTRIBUTE_IO | EFI_PCI_IO_ATTRIBUTE_MEMORY);
+        } else {
+          Supports &= (UINT64)EFI_PCI_DEVICE_ENABLE;
+        }
+
         PciIoDevice->PciIo.Attributes (
                              &(PciIoDevice->PciIo),
                              EfiPciIoAttributeOperationEnable,
@@ -732,7 +826,16 @@ StartPciDevicesOnBridge (
                              0,
                              &Supports
                              );
-        Supports &= (UINT64)EFI_PCI_DEVICE_ENABLE;
+
+        // Defer BME enablement until PCI SetAttributes
+        if (FeaturePcdGet (PcdDeferBme)) {
+          Supports &= (UINT64)(EFI_PCI_IO_ATTRIBUTE_IO | EFI_PCI_IO_ATTRIBUTE_MEMORY);
+        } else {
+          Supports &= (UINT64)EFI_PCI_DEVICE_ENABLE;
+        }
+
+        // Supports &= (UINT64)EFI_PCI_DEVICE_ENABLE;
+
         PciIoDevice->PciIo.Attributes (
                              &(PciIoDevice->PciIo),
                              EfiPciIoAttributeOperationEnable,

--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciEnumeratorSupport.c
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciEnumeratorSupport.c
@@ -1188,6 +1188,9 @@ DetermineDeviceAttribute (
   PCI_IO_DEVICE  *Temp;
   LIST_ENTRY     *CurrentLink;
   EFI_STATUS     Status;
+  UINT16         BridgeSupportsMaster;
+
+  BridgeSupportsMaster = 0;
 
   //
   // For Root Bridge, just copy it by RootBridgeIo protocol
@@ -1209,6 +1212,11 @@ DetermineDeviceAttribute (
     PciIoDevice->Supports |= (UINT64)(EFI_PCI_IO_ATTRIBUTE_EMBEDDED_DEVICE |
                                       EFI_PCI_IO_ATTRIBUTE_EMBEDDED_ROM |
                                       EFI_PCI_IO_ATTRIBUTE_DUAL_ADDRESS_CYCLE);
+
+    // Defer BME enablement until Pci SetAttributes
+    if (FeaturePcdGet (PcdDeferBme)) {
+      PciIoDevice->Supports |= EFI_PCI_IO_ATTRIBUTE_BUS_MASTER;
+    }
   } else {
     //
     // Set the attributes to be checked for common PCI devices and PPB or P2C
@@ -1220,6 +1228,25 @@ DetermineDeviceAttribute (
               EFI_PCI_COMMAND_BUS_MASTER   |
               EFI_PCI_COMMAND_VGA_PALETTE_SNOOP;
 
+    // Defer BME enablement until Pci SetAttributes
+    // This ASSUMES all P2P bridges are Bus Master capable
+    if (FeaturePcdGet (PcdDeferBme)) {
+      if (IS_PCI_BRIDGE (&PciIoDevice->Pci)) {
+        Command              &= ~EFI_PCI_COMMAND_BUS_MASTER;
+        BridgeSupportsMaster |= EFI_PCI_COMMAND_BUS_MASTER;
+        DEBUG ((
+          EFI_D_INFO,
+          "P2P PciIo=%p, Parent=%p, Command set to %x. Bus=%d,Dev=%d,Fun=%d\n",
+          &PciIoDevice->PciIo,
+          &PciIoDevice->Parent,
+          Command,
+          PciIoDevice->BusNumber,
+          PciIoDevice->DeviceNumber,
+          PciIoDevice->FunctionNumber
+          ));
+      }
+    }
+
     BridgeControl = EFI_PCI_BRIDGE_CONTROL_ISA | EFI_PCI_BRIDGE_CONTROL_VGA | EFI_PCI_BRIDGE_CONTROL_VGA_16;
 
     //
@@ -1230,7 +1257,7 @@ DetermineDeviceAttribute (
     //
     // Set the supported attributes for specified PCI device
     //
-    PciSetDeviceAttribute (PciIoDevice, Command, BridgeControl, EFI_SET_SUPPORTS);
+    PciSetDeviceAttribute (PciIoDevice, Command|BridgeSupportsMaster, BridgeControl, EFI_SET_SUPPORTS);
 
     //
     // Set the current attributes for specified PCI device

--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciIo.c
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciIo.c
@@ -1618,6 +1618,12 @@ PciIoAttributes (
     }
   }
 
+  // RootBridgeIo doesn't support BUS_MASTER as an option. Remove BUS_MASTER
+  // from attributes going up to the HostBridge.
+  if (PciIoDevice->Parent == NULL) {
+    Attributes &= ~EFI_PCI_IO_ATTRIBUTE_BUS_MASTER;
+  }
+
   //
   // If no attributes can be supported, then return.
   // Otherwise, set the attributes that it can support.
@@ -1728,12 +1734,11 @@ PciIoAttributes (
 
   //
   // The upstream bridge should be also set to relevant attribute
-  // expect for IO, Mem and BusMaster
+  // except for IO and Mem.
   //
   UpStreamAttributes = Attributes &
                        (~(EFI_PCI_IO_ATTRIBUTE_IO     |
-                          EFI_PCI_IO_ATTRIBUTE_MEMORY |
-                          EFI_PCI_IO_ATTRIBUTE_BUS_MASTER
+                          EFI_PCI_IO_ATTRIBUTE_MEMORY
                           )
                        );
   UpStreamBridge = PciIoDevice->Parent;

--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -997,6 +997,15 @@
   # @Prompt Enable process non-reset capsule image at runtime.
   gEfiMdeModulePkgTokenSpaceGuid.PcdSupportProcessCapsuleAtRuntime|FALSE|BOOLEAN|0x00010079
 
+  ## Indicates that the system should not automatically enable BME on P2P bridges until a subordinate
+  #  device has its Bus Master Enable bit set by a call to PciIo->SetAttributes.
+  #  Note: Some UEFI drivers are not compliant and do not correctly call SetAttributes before attempting
+  #  DMA operations. For these drivers, this setting will cause a functionality break.
+  #   TRUE  - Defer BME enablement on P2P bridges.
+  #   FALSE - Initialize P2P bridges with BME enabled.
+  # @Prompt Defer BME enablement
+  gEfiMdeModulePkgTokenSpaceGuid.PcdDeferBme|TRUE|BOOLEAN|0x30002050
+
 [PcdsFeatureFlag.IA32, PcdsFeatureFlag.ARM, PcdsFeatureFlag.AARCH64, PcdsFeatureFlag.LOONGARCH64]
   gEfiMdeModulePkgTokenSpaceGuid.PcdPciDegradeResourceForOptionRom|FALSE|BOOLEAN|0x0001003a
 
@@ -1916,6 +1925,14 @@
   #   FALSE - BDS does not support Platform Recovery.<BR>
   # @Prompt Support Platform Recovery.
   gEfiMdeModulePkgTokenSpaceGuid.PcdPlatformRecoverySupport|TRUE|BOOLEAN|0x00010078
+
+  ## Indicates that the system should disable BME on all Pci2Pci bridges on Exit Boot Services
+  #  Note: Some operating systems and drivers may not expect devices to be in this state, and it
+  #  may cause unexpected behaviors.
+  #   TRUE  - Disable BME on P2P at Exit Boot Services.
+  #   FALSE - Do not disable BME on P2P at Exit Boot Services.
+  # @Prompt Disable BME on Exit Boot Services
+  gEfiMdeModulePkgTokenSpaceGuid.PcdDisableBmeOnEbs|TRUE|BOOLEAN|0x30002051
 
   ## Specify the foreground color for Subtile text in HII Form Browser. The default value is EFI_BLUE.
   #  Only following values defined in UEFI specification are valid:<BR><BR>

--- a/OvmfPkg/OvmfPkgIa32.dsc
+++ b/OvmfPkg/OvmfPkgIa32.dsc
@@ -475,6 +475,7 @@
   gUefiOvmfPkgTokenSpaceGuid.PcdSecureBootSupported|TRUE
   gEfiMdeModulePkgTokenSpaceGuid.PcdRequireSelfSignedPk|TRUE
 !endif
+  gEfiMdeModulePkgTokenSpaceGuid.PcdDeferBme|FALSE
 
 [PcdsFixedAtBuild]
   gEfiMdeModulePkgTokenSpaceGuid.PcdStatusCodeMemorySize|1
@@ -507,6 +508,7 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdVpdBaseAddress|0x0
   gEfiMdeModulePkgTokenSpaceGuid.PcdStatusCodeUseSerial|FALSE
   gEfiMdeModulePkgTokenSpaceGuid.PcdStatusCodeUseMemory|TRUE
+  gEfiMdeModulePkgTokenSpaceGuid.PcdDisableBmeOnEbs|FALSE
 
   gEfiMdePkgTokenSpaceGuid.PcdReportStatusCodePropertyMask|0x07
 

--- a/OvmfPkg/OvmfPkgIa32X64.dsc
+++ b/OvmfPkg/OvmfPkgIa32X64.dsc
@@ -481,6 +481,7 @@
   gUefiOvmfPkgTokenSpaceGuid.PcdSecureBootSupported|TRUE
   gEfiMdeModulePkgTokenSpaceGuid.PcdRequireSelfSignedPk|TRUE
 !endif
+  gEfiMdeModulePkgTokenSpaceGuid.PcdDeferBme|FALSE
 
 [PcdsFixedAtBuild]
   gEfiMdeModulePkgTokenSpaceGuid.PcdStatusCodeMemorySize|1
@@ -513,6 +514,7 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdVpdBaseAddress|0x0
   gEfiMdeModulePkgTokenSpaceGuid.PcdStatusCodeUseSerial|FALSE
   gEfiMdeModulePkgTokenSpaceGuid.PcdStatusCodeUseMemory|TRUE
+  gEfiMdeModulePkgTokenSpaceGuid.PcdDisableBmeOnEbs|FALSE
 
   gEfiMdePkgTokenSpaceGuid.PcdReportStatusCodePropertyMask|0x07
 

--- a/OvmfPkg/OvmfPkgX64.dsc
+++ b/OvmfPkg/OvmfPkgX64.dsc
@@ -504,6 +504,7 @@
   gUefiOvmfPkgTokenSpaceGuid.PcdSecureBootSupported|TRUE
   gEfiMdeModulePkgTokenSpaceGuid.PcdRequireSelfSignedPk|TRUE
 !endif
+  gEfiMdeModulePkgTokenSpaceGuid.PcdDeferBme|FALSE
 
 [PcdsFixedAtBuild]
   gEfiMdeModulePkgTokenSpaceGuid.PcdStatusCodeMemorySize|1
@@ -536,6 +537,7 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdVpdBaseAddress|0x0
   gEfiMdeModulePkgTokenSpaceGuid.PcdStatusCodeUseSerial|FALSE
   gEfiMdeModulePkgTokenSpaceGuid.PcdStatusCodeUseMemory|TRUE
+  gEfiMdeModulePkgTokenSpaceGuid.PcdDisableBmeOnEbs|FALSE
 
   gEfiMdePkgTokenSpaceGuid.PcdReportStatusCodePropertyMask|0x07
 


### PR DESCRIPTION
# Description

We want to upstream the following changes to edk2 for safe behavior around PCI BME. 
Project Mu has a SmmuDxe driver and other IoMmu protocol related changes (will also upstream to edk2) that enables DMA protection pre-os-boot. We want to have it running on all arm platforms. As a result, these changes are needed.

For security, we are setting all the added PCD's to TRUE to enforce security and safety around DMA.
At a platform level, they can be set to FALSE there.

Per [Microsoft DMA Protection Requirements](https://learn.microsoft.com/en-us/windows-hardware/design/device-experiences/oem-kernel-dma-protection) and @vincent-j-zimmer's https://www.intel.com/content/dam/develop/external/us/en/documents/intel-whitepaper-using-iommu-for-dma-protection-in-uefi-820238.pdf

https://tianocore-docs.github.io/edk2-UefiDriverWritersGuide/draft/4_general_driver_design_guidelines/42_maximize_platform_compatibility/427_dma.html#427-dma - In addition, UEFI drivers must always use I/O abstractions to setup and complete DMA transactions.

- System firmware must protect against pre-boot DMA attacks by implementing DMA isolation of all DMA capable devices' IO buffers pre-ExitBootServices().
- System firmware must disable the Bus Master Enable (BME) bit for all PCI root ports, that do not have children devices required to perform DMA between ExitBootServices() and the device driver being started by the OS.
- At ExitBootServices(), the IOMMU must be restored by system firmware to power ON state.
- No device may perform DMA outside of RMRR regions (Intel) or IVMD blocks (AMD) after ExitBootServices() until the devices’ respective OS drivers are loaded and started by PnP.
- Performing DMA outside of RMRR regions or IVMD blocks after ExitBootServices() and prior to the device driver start by the OS will result in an IOMMU fault and potentially a system bug check ([0xE6](https://learn.microsoft.com/en-us/windows-hardware/drivers/debugger/bug-check-0xe6--driver-verifier-dma-violation)).

[PCI_BME] PCI Bus Master Disable

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Tested on Qemu mu_tiano platforms as well as a physical arm device.

## Integration Instructions

These added PCD's are set to TRUE by default for security. At a platform level, we can set them to FALSE if needed.





