### PR TITLE
MdePkg: Updated Memory Form Factor definition per SMBIOS 3.8.0

### DIFF
--- a/MdePkg/Include/IndustryStandard/SmBios.h
+++ b/MdePkg/Include/IndustryStandard/SmBios.h
@@ -1,6 +1,7 @@
 /** @file
   Industry Standard Definitions of SMBIOS Table Specification v3.8.0.
 
+Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.<BR>
 Copyright (c) 2006 - 2024, Intel Corporation. All rights reserved.<BR>
 (C) Copyright 2015-2017 Hewlett Packard Enterprise Development LP<BR>
 (C) Copyright 2015 - 2019 Hewlett Packard Enterprise Development LP<BR>
@@ -1864,7 +1865,8 @@ typedef enum {
   MemoryFormFactorSodimm          = 0x0D,
   MemoryFormFactorSrimm           = 0x0E,
   MemoryFormFactorFbDimm          = 0x0F,
-  MemoryFormFactorDie             = 0x10
+  MemoryFormFactorDie             = 0x10,
+  MemoryFormFactorCamm            = 0x11
 } MEMORY_FORM_FACTOR;
 
 ///


### PR DESCRIPTION
This patch adds support for the new CAMM form factor defined in SMBIOS specification 3.8.0

Change-Id: Ib23b81082f59522eaee4ec5c66fa4e9bd9ed813f

# Description

This change adds a new entry for "CAMM" in the Memory Form Factor struct. SMBIOS spec 3.8.0 defines this entry
as well. The change is intended to get the edk2 code in sync with 3.8.0 spec.
The change only imapcts Mdpkg package

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.


## Integration Instructions

N/A
