### PR TITLE
DynamicTablesPkg: Add SLIT table generator library

### DIFF
--- a/DynamicTablesPkg/DynamicTables.dsc.inc
+++ b/DynamicTablesPkg/DynamicTables.dsc.inc
@@ -39,6 +39,7 @@
   DynamicTablesPkg/Library/Acpi/Common/AcpiSpcrLib/AcpiSpcrLib.inf
   DynamicTablesPkg/Library/Acpi/Common/AcpiSratLib/AcpiSratLib.inf
   DynamicTablesPkg/Library/Acpi/Common/AcpiTpm2Lib/AcpiTpm2Lib.inf
+  DynamicTablesPkg/Library/Acpi/Common/AcpiSlitLib/AcpiSlitLib.inf
   DynamicTablesPkg/Library/Acpi/Common/AcpiSpmiLib/AcpiSpmiLib.inf
 
   # AML Fixup (Common)
@@ -72,6 +73,7 @@
       #   Common
       NULL|DynamicTablesPkg/Library/Acpi/Common/AcpiFadtLib/AcpiFadtLib.inf
       NULL|DynamicTablesPkg/Library/Acpi/Common/AcpiSratLib/AcpiSratLib.inf
+      NULL|DynamicTablesPkg/Library/Acpi/Common/AcpiSlitLib/AcpiSlitLib.inf
       NULL|DynamicTablesPkg/Library/Acpi/Common/AcpiSpmiLib/AcpiSpmiLib.inf
       #   X64 specific
       NULL|DynamicTablesPkg/Library/Acpi/X64/AcpiFacsLib/AcpiFacsLib.inf
@@ -110,6 +112,7 @@
       NULL|DynamicTablesPkg/Library/Acpi/Common/AcpiPpttLib/AcpiPpttLib.inf
       NULL|DynamicTablesPkg/Library/Acpi/Common/AcpiRawLib/AcpiRawLib.inf
       NULL|DynamicTablesPkg/Library/Acpi/Common/AcpiSpcrLib/AcpiSpcrLib.inf
+      NULL|DynamicTablesPkg/Library/Acpi/Common/AcpiSlitLib/AcpiSlitLib.inf
       NULL|DynamicTablesPkg/Library/Acpi/Common/AcpiSpmiLib/AcpiSpmiLib.inf
       NULL|DynamicTablesPkg/Library/Acpi/Common/AcpiSratLib/AcpiSratLib.inf
       NULL|DynamicTablesPkg/Library/Acpi/Common/AcpiTpm2Lib/AcpiTpm2Lib.inf

--- a/DynamicTablesPkg/Include/AcpiTableGenerator.h
+++ b/DynamicTablesPkg/Include/AcpiTableGenerator.h
@@ -80,6 +80,8 @@ The Dynamic Tables Framework implements the following ACPI table generators:
             Configuration Manager and builds the SPMI table.
   - FACS  : The FACS generator collates the FACS information from the
             Configuration Manager and builds the FACS table.
+  - SLIT  : The SLIT generator collates the SLIT information from the
+            Configuration Manager and builds the SLIT table.
 */
 
 /** The ACPI_TABLE_GENERATOR_ID type describes ACPI table generator ID.
@@ -114,6 +116,7 @@ typedef enum StdAcpiTableId {
   EStdAcpiTableIdSsdtHpet,                      ///< SSDT HPET Generator
   EStdAcpiTableIdSpmi,                          ///< SPMI Generator
   EStdAcpiTableIdFacs,                          ///< FACS Generator
+  EStdAcpiTableIdSlit,                          ///< SLIT Generator
   EStdAcpiTableIdMax
 } ESTD_ACPI_TABLE_ID;
 

--- a/DynamicTablesPkg/Include/ArchCommonNameSpaceObjects.h
+++ b/DynamicTablesPkg/Include/ArchCommonNameSpaceObjects.h
@@ -20,6 +20,11 @@
 
 #include <IndustryStandard/Tpm2Acpi.h>
 
+/**
+  The maximum number of SLIT localities supported by the SLIT table.
+*/
+#define EARCH_COMMON_SLIT_LOCALITY_MAX  16
+
 /** The EARCH_COMMON_OBJECT_ID enum describes the Object IDs
     in the Arch Common Namespace
 */
@@ -59,6 +64,7 @@ typedef enum ArchCommonObjectID {
   EArchCommonObjPssInfo,                        ///< 32 - P-State status (PSS) Info
   EArchCommonObjPpcInfo,                        ///< 33 - P-State control (PPC) Info
   EArchCommonObjStaInfo,                        ///< 34 - _STA (Device Status) Info
+  EArchCommonObjSlitInfo,                       ///< 35 - SLIT Info
   EArchCommonObjMax
 } EARCH_COMMON_OBJECT_ID;
 
@@ -811,6 +817,20 @@ typedef struct CmArchCommonStaInfo {
   /// Device Status
   UINT32    DeviceStatus;
 } CM_ARCH_COMMON_STA_INFO;
+
+/**
+  A structure that describes the SLIT (System Locality Information Table)
+    information.
+
+    ID: EArchCommonObjSlitInfo
+*/
+typedef struct CmArchCommonSlitInfo {
+  /// The number of localities supported by the SLIT table.
+  UINT8    NumberOfSystemLocalities;
+
+  /// The distance between each pair of localities.
+  UINT8    Entity[EARCH_COMMON_SLIT_LOCALITY_MAX * EARCH_COMMON_SLIT_LOCALITY_MAX];
+} CM_ARCH_COMMON_SLIT_INFO;
 
 #pragma pack()
 

--- a/DynamicTablesPkg/Library/Acpi/Common/AcpiSlitLib/AcpiSlitLib.inf
+++ b/DynamicTablesPkg/Library/Acpi/Common/AcpiSlitLib/AcpiSlitLib.inf
@@ -1,0 +1,28 @@
+## @file
+#  SLIT Table Generator
+#
+#  Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION    = 1.30
+  BASE_NAME      = AcpiSlitLib
+  FILE_GUID      = 5735C624-E8ED-426C-8292-6712EF4D8329
+  VERSION_STRING = 1.0
+  MODULE_TYPE    = DXE_DRIVER
+  LIBRARY_CLASS  = NULL|DXE_DRIVER
+  CONSTRUCTOR    = AcpiSlitLibConstructor
+  DESTRUCTOR     = AcpiSlitLibDestructor
+
+[Sources]
+  SlitGenerator.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  DynamicTablesPkg/DynamicTablesPkg.dec
+
+[LibraryClasses]
+  BaseLib

--- a/DynamicTablesPkg/Library/Acpi/Common/AcpiSlitLib/SlitGenerator.c
+++ b/DynamicTablesPkg/Library/Acpi/Common/AcpiSlitLib/SlitGenerator.c
@@ -1,0 +1,281 @@
+/** @file
+  SLIT Table Generator
+
+  Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <Library/DebugLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Protocol/AcpiTable.h>
+
+// Module specific include files.
+#include <AcpiTableGenerator.h>
+#include <ConfigurationManagerObject.h>
+#include <ConfigurationManagerHelper.h>
+#include <Library/TableHelperLib.h>
+#include <Protocol/ConfigurationManagerProtocol.h>
+
+/** Standard SLIT Generator
+
+Requirements:
+  The following Configuration Manager Object(s) are required by
+  this Generator:
+  - EArchCommonObjSlitInfo
+*/
+
+/** Retrieve the SLIT interface information. */
+GET_OBJECT_LIST (
+  EObjNameSpaceArchCommon,
+  EArchCommonObjSlitInfo,
+  CM_ARCH_COMMON_SLIT_INFO
+  );
+
+/** Construct the SLIT ACPI table.
+
+  This function invokes the Configuration Manager protocol interface
+  to get the required hardware information for generating the ACPI
+  table.
+
+  If this function allocates any resources then they must be freed
+  in the FreeXXXXTableResources function.
+
+  @param [in]  This           Pointer to the table generator.
+  @param [in]  AcpiTableInfo  Pointer to the ACPI Table Info.
+  @param [in]  CfgMgrProtocol Pointer to the Configuration Manager
+                                Protocol Interface.
+  @param [out] Table          Pointer to the constructed ACPI Table.
+
+  @retval EFI_SUCCESS           Table generated successfully.
+  @retval EFI_INVALID_PARAMETER A parameter is invalid.
+  @retval EFI_NOT_FOUND         The required object was not found.
+  @retval EFI_BAD_BUFFER_SIZE   The size returned by the Configuration
+                                Manager is less than the Object size for the
+                                requested object.
+**/
+STATIC
+EFI_STATUS
+EFIAPI
+BuildSlitTable (
+  IN  CONST ACPI_TABLE_GENERATOR                  *CONST  This,
+  IN  CONST CM_STD_OBJ_ACPI_TABLE_INFO            *CONST  AcpiTableInfo,
+  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST  CfgMgrProtocol,
+  OUT       EFI_ACPI_DESCRIPTION_HEADER          **CONST  Table
+  )
+{
+  CM_ARCH_COMMON_SLIT_INFO  *SlitInfo;
+  EFI_STATUS                Status;
+  UINTN                     Col;
+  UINTN                     Row;
+
+  EFI_ACPI_6_5_SYSTEM_LOCALITY_DISTANCE_INFORMATION_TABLE_HEADER  *AcpiSlitTable;
+
+  ASSERT (This != NULL);
+  ASSERT (AcpiTableInfo != NULL);
+  ASSERT (CfgMgrProtocol != NULL);
+  ASSERT (Table != NULL);
+  ASSERT (AcpiTableInfo->TableGeneratorId == This->GeneratorID);
+  ASSERT (AcpiTableInfo->AcpiTableSignature == This->AcpiTableSignature);
+
+  if ((AcpiTableInfo->AcpiTableRevision < This->MinAcpiTableRevision) ||
+      (AcpiTableInfo->AcpiTableRevision > This->AcpiTableRevision))
+  {
+    DEBUG ((
+      DEBUG_ERROR,
+      "ERROR: SLIT: Requested table revision = %d, is not supported."
+      "Supported table revision: Minimum = %d, Maximum = %d\n",
+      AcpiTableInfo->AcpiTableRevision,
+      This->MinAcpiTableRevision,
+      This->AcpiTableRevision
+      ));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  *Table = NULL;
+
+  Status = GetEArchCommonObjSlitInfo (
+             CfgMgrProtocol,
+             CM_NULL_TOKEN,
+             &SlitInfo,
+             NULL
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "ERROR: SLIT: Failed to retrieve interface type and base address.\n"
+      ));
+    return Status;
+  }
+
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "ERROR: SLIT: Failed to retrieve SLIT information. Status = %r\n",
+      Status
+      ));
+    return Status;
+  }
+
+  if (SlitInfo == NULL) {
+    DEBUG ((DEBUG_ERROR, "ERROR: SLIT: No SLIT information provided by configuration manager.\n"));
+    return EFI_NOT_FOUND;
+  }
+
+  if (SlitInfo->NumberOfSystemLocalities > EARCH_COMMON_SLIT_LOCALITY_MAX) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "ERROR: SLIT: Number of system localities (%d) exceeds maximum (%d).\n",
+      SlitInfo->NumberOfSystemLocalities,
+      EARCH_COMMON_SLIT_LOCALITY_MAX
+      ));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (SlitInfo->NumberOfSystemLocalities == 0) {
+    DEBUG ((DEBUG_ERROR, "ERROR: SLIT: Number of system localities is zero.\n"));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  for (Row = 0; Row < SlitInfo->NumberOfSystemLocalities; Row++) {
+    for (Col = 0; Col < SlitInfo->NumberOfSystemLocalities; Col++) {
+      if (SlitInfo->Entity[Row + Col] < 0x10) {
+        DEBUG ((
+          DEBUG_ERROR,
+          "ERROR: SLIT: Distance between localities (%d, %d) is less than 0x10.\n",
+          Row,
+          Col
+          ));
+        return EFI_INVALID_PARAMETER;
+      }
+
+      if ((Row == Col) && (SlitInfo->Entity[Row + Col] != 0x10)) {
+        DEBUG ((
+          DEBUG_ERROR,
+          "ERROR: SLIT: Distance between localities (%d, %d) is not 0x10.\n",
+          Row,
+          Col
+          ));
+        return EFI_INVALID_PARAMETER;
+      }
+    }
+  }
+
+  AcpiSlitTable = AllocateZeroPool (
+                    sizeof (EFI_ACPI_6_5_SYSTEM_LOCALITY_DISTANCE_INFORMATION_TABLE_HEADER) +
+                    (sizeof (UINT8) * SlitInfo->NumberOfSystemLocalities * SlitInfo->NumberOfSystemLocalities)
+                    );
+  if (AcpiSlitTable == NULL) {
+    DEBUG ((DEBUG_ERROR, "ERROR: SLIT: Failed to allocate memory for SLIT table.\n"));
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  AcpiSlitTable->NumberOfSystemLocalities = SlitInfo->NumberOfSystemLocalities;
+  CopyMem (
+    (UINT8 *)AcpiSlitTable + sizeof (EFI_ACPI_6_5_SYSTEM_LOCALITY_DISTANCE_INFORMATION_TABLE_HEADER),
+    SlitInfo->Entity,
+    SlitInfo->NumberOfSystemLocalities * SlitInfo->NumberOfSystemLocalities
+    );
+  Status = AddAcpiHeader (
+             CfgMgrProtocol,
+             This,
+             (EFI_ACPI_DESCRIPTION_HEADER *)&AcpiSlitTable,
+             AcpiTableInfo,
+             (sizeof (EFI_ACPI_6_5_SYSTEM_LOCALITY_DISTANCE_INFORMATION_TABLE_HEADER) +
+              sizeof (UINT8) * SlitInfo->NumberOfSystemLocalities * SlitInfo->NumberOfSystemLocalities)
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "ERROR: SLIT: Failed to add ACPI header. Status = %r\n",
+      Status
+      ));
+  }
+
+  *Table = (EFI_ACPI_DESCRIPTION_HEADER *)AcpiSlitTable;
+  return Status;
+}
+
+/** This macro defines the SLIT Table Generator revision.
+*/
+#define SLIT_GENERATOR_REVISION  CREATE_REVISION (1, 0)
+
+/** The interface for the SLIT Table Generator.
+*/
+STATIC
+CONST
+ACPI_TABLE_GENERATOR  SpmiGenerator = {
+  // Generator ID
+  CREATE_STD_ACPI_TABLE_GEN_ID (EStdAcpiTableIdSlit),
+  // Generator Description
+  L"ACPI.STD.SLIT.GENERATOR",
+  // ACPI Table Signature
+  EFI_ACPI_6_5_SYSTEM_LOCALITY_INFORMATION_TABLE_SIGNATURE,
+  // ACPI Table Revision supported by this Generator
+  EFI_ACPI_6_5_SYSTEM_LOCALITY_DISTANCE_INFORMATION_TABLE_REVISION,
+  // Minimum supported ACPI Table Revision
+  EFI_ACPI_6_5_SYSTEM_LOCALITY_DISTANCE_INFORMATION_TABLE_REVISION,
+  // Creator ID
+  TABLE_GENERATOR_CREATOR_ID,
+  // Creator Revision
+  SLIT_GENERATOR_REVISION,
+  // Build Table function
+  BuildSlitTable,
+  // Free Resource function
+  NULL,
+  // Extended build function not needed
+  NULL,
+  // Extended build function not implemented by the generator.
+  // Hence extended free resource function is not required.
+  NULL
+};
+
+/** Register the Generator with the ACPI Table Factory.
+
+  @param [in]  ImageHandle  The handle to the image.
+  @param [in]  SystemTable  Pointer to the System Table.
+
+  @retval EFI_SUCCESS           The Generator is registered.
+  @retval EFI_INVALID_PARAMETER A parameter is invalid.
+  @retval EFI_ALREADY_STARTED   The Generator for the Table ID
+                                is already registered.
+**/
+EFI_STATUS
+EFIAPI
+AcpiSlitLibConstructor (
+  IN  EFI_HANDLE        ImageHandle,
+  IN  EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  EFI_STATUS  Status;
+
+  Status = RegisterAcpiTableGenerator (&SpmiGenerator);
+  DEBUG ((DEBUG_INFO, "SLIT: Register Generator. Status = %r\n", Status));
+  ASSERT_EFI_ERROR (Status);
+  return Status;
+}
+
+/** Deregister the Generator from the ACPI Table Factory.
+
+  @param [in]  ImageHandle  The handle to the image.
+  @param [in]  SystemTable  Pointer to the System Table.
+
+  @retval EFI_SUCCESS           The Generator is deregistered.
+  @retval EFI_INVALID_PARAMETER A parameter is invalid.
+  @retval EFI_NOT_FOUND         The Generator is not registered.
+**/
+EFI_STATUS
+EFIAPI
+AcpiSlitLibDestructor (
+  IN  EFI_HANDLE        ImageHandle,
+  IN  EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  EFI_STATUS  Status;
+
+  Status = DeregisterAcpiTableGenerator (&SpmiGenerator);
+  DEBUG ((DEBUG_INFO, "SLIT: Deregister Generator. Status = %r\n", Status));
+  ASSERT_EFI_ERROR (Status);
+  return Status;
+}

--- a/DynamicTablesPkg/Library/Common/TableHelperLib/ConfigurationManagerObjectParser.c
+++ b/DynamicTablesPkg/Library/Common/TableHelperLib/ConfigurationManagerObjectParser.c
@@ -757,6 +757,23 @@ STATIC CONST CM_OBJ_PARSER  CmArchCommonStaInfoParser[] = {
   { "DeviceStatus", 4, "0x%x", NULL }
 };
 
+/** A parser for EArchCommonObjSlitInfo.
+*/
+STATIC CONST CM_OBJ_PARSER  CmArchCommonSlitInfoParser[] = {
+  {
+    "NumberOfSystemLocalities",
+    1,
+    "0x%x",
+    NULL
+  },
+  {
+    "Entity",
+    (EARCH_COMMON_SLIT_LOCALITY_MAX * EARCH_COMMON_SLIT_LOCALITY_MAX),
+    "0x%x",
+    NULL
+  }
+};
+
 /** A parser for Arch Common namespace objects.
 */
 STATIC CONST CM_OBJ_PARSER_ARRAY  ArchCommonNamespaceObjectParser[] = {
@@ -795,6 +812,7 @@ STATIC CONST CM_OBJ_PARSER_ARRAY  ArchCommonNamespaceObjectParser[] = {
   CM_PARSER_ADD_OBJECT (EArchCommonObjPssInfo,                     CmArchCommonPssInfoParser),
   CM_PARSER_ADD_OBJECT (EArchCommonObjPpcInfo,                     CmArchCommonPpcInfoParser),
   CM_PARSER_ADD_OBJECT (EArchCommonObjStaInfo,                     CmArchCommonStaInfoParser),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjSlitInfo,                    CmArchCommonSlitInfoParser),
   CM_PARSER_ADD_OBJECT_RESERVED (EArchCommonObjMax)
 };
 

--- a/DynamicTablesPkg/Readme.md
+++ b/DynamicTablesPkg/Readme.md
@@ -507,6 +507,7 @@ The CM_OBJECT_ID type is used to identify the Configuration Manager
 |  32   | Processor P-State Status Info             | |
 |  33   | Processor P-State Capability Info         | |
 |  34   | _STA Device Status Info                   | |
+|  35   | SLIT distance Info                        | |
 |  `*`  | All other values are reserved.            | |
 
 #### Object ID's in the X64 Namespace:


### PR DESCRIPTION
Introduce a common architecture SLIT table generator library that retrieves locality domain distance information from the configuration manager and generates the table accordingly.

# Description
Adds a new library to generate SLIT table.
Reads the configuration information from the configuration manager,
such has number of localities and distance between each localities.
Finally generate the ACPI SLIT table.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Tested on AMD platform
## Integration Instructions

N/A