### PR TITLE
MdeModulePkg : Clear keyboard queue buffer after reading

### DIFF
--- a/MdeModulePkg/Bus/Isa/Ps2KeyboardDxe/Ps2KbdCtrller.c
+++ b/MdeModulePkg/Bus/Isa/Ps2KeyboardDxe/Ps2KbdCtrller.c
@@ -650,6 +650,8 @@ PopScancodeBufHead (
     if (Buf != NULL) {
       Buf[Index] = Queue->Buffer[Queue->Head];
     }
+
+    Queue->Buffer[Queue->Head] = 0;
   }
 
   return EFI_SUCCESS;

--- a/MdeModulePkg/Bus/Isa/Ps2KeyboardDxe/Ps2KbdTextIn.c
+++ b/MdeModulePkg/Bus/Isa/Ps2KeyboardDxe/Ps2KbdTextIn.c
@@ -51,6 +51,7 @@ PopEfikeyBufHead (
     CopyMem (KeyData, &Queue->Buffer[Queue->Head], sizeof (EFI_KEY_DATA));
   }
 
+  ZeroMem (&Queue->Buffer[Queue->Head], sizeof (EFI_KEY_DATA));
   Queue->Head = (Queue->Head + 1) % KEYBOARD_EFI_KEY_MAX_COUNT;
   return EFI_SUCCESS;
 }

--- a/MdeModulePkg/Bus/Usb/UsbKbDxe/KeyBoard.c
+++ b/MdeModulePkg/Bus/Usb/UsbKbDxe/KeyBoard.c
@@ -1840,7 +1840,7 @@ Dequeue (
   }
 
   CopyMem (Item, Queue->Buffer[Queue->Head], ItemSize);
-
+  ZeroMem (Queue->Buffer[Queue->Head], ItemSize);
   //
   // Adjust the head pointer of the FIFO keyboard buffer.
   //

--- a/MdeModulePkg/Universal/Console/ConSplitterDxe/ConSplitter.c
+++ b/MdeModulePkg/Universal/Console/ConSplitterDxe/ConSplitter.c
@@ -3308,6 +3308,7 @@ ConSplitterTextInExDequeueKey (
     &Private->KeyQueue[1],
     Private->CurrentNumberOfKeys * sizeof (EFI_KEY_DATA)
     );
+  ZeroMem (&Private->KeyQueue[Private->CurrentNumberOfKeys], sizeof (EFI_KEY_DATA));
   return EFI_SUCCESS;
 }
 

--- a/MdeModulePkg/Universal/Console/TerminalDxe/TerminalConIn.c
+++ b/MdeModulePkg/Universal/Console/TerminalDxe/TerminalConIn.c
@@ -760,7 +760,8 @@ RawFiFoRemoveOneKey (
     return FALSE;
   }
 
-  *Output = TerminalDevice->RawFiFo->Data[Head];
+  *Output                             = TerminalDevice->RawFiFo->Data[Head];
+  TerminalDevice->RawFiFo->Data[Head] = 0;
 
   TerminalDevice->RawFiFo->Head = (UINT8)((Head + 1) % (RAW_FIFO_MAX_NUMBER + 1));
 
@@ -881,6 +882,7 @@ EfiKeyFiFoForNotifyRemoveOneKey (
   }
 
   CopyMem (Output, &EfiKeyFiFo->Data[Head], sizeof (EFI_INPUT_KEY));
+  ZeroMem (&EfiKeyFiFo->Data[Head], sizeof (EFI_INPUT_KEY));
 
   EfiKeyFiFo->Head = (UINT8)((Head + 1) % (FIFO_MAX_NUMBER + 1));
 
@@ -1032,6 +1034,7 @@ EfiKeyFiFoRemoveOneKey (
   }
 
   CopyMem (Output, &TerminalDevice->EfiKeyFiFo->Data[Head], sizeof (EFI_INPUT_KEY));
+  ZeroMem (&TerminalDevice->EfiKeyFiFo->Data[Head], sizeof (EFI_INPUT_KEY));
 
   TerminalDevice->EfiKeyFiFo->Head = (UINT8)((Head + 1) % (FIFO_MAX_NUMBER + 1));
 
@@ -1142,7 +1145,8 @@ UnicodeFiFoRemoveOneKey (
   Head = TerminalDevice->UnicodeFiFo->Head;
   ASSERT (Head < FIFO_MAX_NUMBER + 1);
 
-  *Output = TerminalDevice->UnicodeFiFo->Data[Head];
+  *Output                                 = TerminalDevice->UnicodeFiFo->Data[Head];
+  TerminalDevice->UnicodeFiFo->Data[Head] = 0;
 
   TerminalDevice->UnicodeFiFo->Head = (UINT8)((Head + 1) % (FIFO_MAX_NUMBER + 1));
 }


### PR DESCRIPTION
# Description

When entering a password, the password keystrokes are stored in a circular queue. This queue is not cleared after password entry, making it possible to snoop some or all of the password characters later by direct examination of the memory which was used as the circular queue, leading to possible information disclosure or escalation of privilege. 

To prevent exposure of the password string, clear the queue buffer by filling it with zeros after reading.
[BZ4760](https://github.com/tianocore/edk2/security/advisories/GHSA-q2c6-37h5-7cwf)

- [ ] Breaking change?
- [x] Impacts security?
  - Password keystrokes may be disclosed in memory.
- [ ] Includes tests?

## How This Was Tested

Modified HelloWorld UEFI shell application to peek the last user input keystroke data from keyboard queue buffer via the EFI_SIMPLE_TEXT_INPUT_PROTOCOL pointer. Ensure that the keystroke data in the keyboard queue buffer is cleared.
[TestCode](https://github.com/NickWangInsyde/edk2/commit/b637b1058e8f7c8d24d3899d030a8a9a7723649f)

## Integration Instructions

N/A
