### PR TITLE
MdeModulePkg/ArmFfaLib: Add depex on gEfiPeiMemoryDiscoveredPpiGuid

### DIFF
--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaPeiLib.inf
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaPeiLib.inf
@@ -1,7 +1,7 @@
 ## @file
 #  Provides FF-A ABI Library used in PEI Driver.
 #
-#  Copyright (c) 2024, Arm Limited. All rights reserved.<BR>
+#  Copyright (c) 2024-2025, Arm Limited. All rights reserved.<BR>
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 ##
@@ -43,3 +43,6 @@
 
 [Guids]
   gArmFfaRxTxBufferInfoGuid
+
+[Depex]
+  gEfiPeiMemoryDiscoveredPpiGuid


### PR DESCRIPTION
If ArmFfaLibRxTxMap is called before permanent memory is installed the memory allocated for the FF-A buffers will be migrated to the permanent memory after it is installed without updating gArmFfaRxTxBufferInfoGuid or unmapping the old buffers and mapping the updated buffers.

An ASSERT in MemoryServices at ExitBootServices is triggered when ArmFfaDxeLib tries to call FreeAlignedPages on the original buffer reference.

Add depex on gEfiPeiMemoryDiscoveredPpiGuid for ArmFfaPeiLib so any Peims that use FF-A are only dispatched after permanent memory is available.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

N/A

## Integration Instructions

N/A
