### PR TITLE
MdeModulePkg: Shortcircuit GCD Dumping Logic if Not Printing

### DIFF
--- a/MdeModulePkg/Core/Dxe/Gcd/Gcd.c
+++ b/MdeModulePkg/Core/Dxe/Gcd/Gcd.c
@@ -153,6 +153,13 @@ CoreDumpGcdMemorySpaceMap (
   EFI_GCD_MEMORY_SPACE_DESCRIPTOR  *MemorySpaceMap;
   UINTN                            Index;
 
+  // The compiler is not smart enough to compile out the whole function if DEBUG_GCD is not enabled, so we end up
+  // looping through the GCD every time it gets updated, which wastes a lot of needless cycles if we aren't going to
+  // print it. So shortcircuit and jump out if we don't need to print it.
+  if (!DebugPrintLevelEnabled (DEBUG_GCD)) {
+    return;
+  }
+
   Status = CoreGetMemorySpaceMap (&NumberOfDescriptors, &MemorySpaceMap);
   ASSERT (Status == EFI_SUCCESS && MemorySpaceMap != NULL);
 
@@ -198,6 +205,13 @@ CoreDumpGcdIoSpaceMap (
   UINTN                        NumberOfDescriptors;
   EFI_GCD_IO_SPACE_DESCRIPTOR  *IoSpaceMap;
   UINTN                        Index;
+
+  // The compiler is not smart enough to compile out the whole function if DEBUG_GCD is not enabled, so we end up
+  // looping through the GCD every time it gets updated, which wastes a lot of needless cycles if we aren't going to
+  // print it. So shortcircuit and jump out if we don't need to print it.
+  if (!DebugPrintLevelEnabled (DEBUG_GCD)) {
+    return;
+  }
 
   Status = CoreGetIoSpaceMap (&NumberOfDescriptors, &IoSpaceMap);
   ASSERT (Status == EFI_SUCCESS && IoSpaceMap != NULL);


### PR DESCRIPTION
# Description

CoreDumpGcdMemorySpaceMap() gets called on every update to the GCD, but it only prints if DEBUG_GCD is set. However, the compiler is not smart enough to remove all of this logic if we are not printing anything, so we end up needlessly allocating memory for the copy of the map and spending many cycles looping through each entry, only to not print anything.

This code is compiled out on release builds, but slows down debug builds that aren't printing at DEBUG_GCD level.

This patch updates CoreDumpGcdMemorySpaceMap() to shortcircuit and immediately exit if DEBUG_GCD is not set. It also adds the same logic to CoreDumpGcdIoSpaceMap(), which is called less frequently, but has the same issue.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Tested by booting to shell.

## Integration Instructions

N/A.
