### PR TITLE
BaseTools: Scripts: efi_debugging.py: search for EFI_SYSTEM_TABLE_POI…

### DIFF
--- a/BaseTools/Scripts/efi_debugging.py
+++ b/BaseTools/Scripts/efi_debugging.py
@@ -33,6 +33,7 @@ import os
 import uuid
 import struct
 import re
+import zlib
 from ctypes import c_char, c_uint8, c_uint16, c_uint32, c_uint64, c_void_p
 from ctypes import ARRAY, sizeof
 from ctypes import Structure, LittleEndianStructure
@@ -1770,8 +1771,10 @@ class EfiConfigurationTable:
     def __init__(self, file, gST_addr=None):
         self._file = file
         if gST_addr is None:
-            # ToDo add code to search for gST via EFI_SYSTEM_TABLE_POINTER
-            return
+            # search for gST via EFI_SYSTEM_TABLE_POINTER
+            system_table_pointer = self._get_system_table_pointer()
+            if not system_table_pointer is None:
+                gST_addr = system_table_pointer.EfiSystemTableBase
 
         gST = self._ctype_read(EFI_SYSTEM_TABLE, gST_addr)
         self.read_efi_config_table(gST.NumberOfTableEntries,
@@ -1795,6 +1798,33 @@ class EfiConfigurationTable:
 
         data = self._file.read(sizeof(ctype_struct))
         return ctype_struct.from_buffer(bytearray(data))
+
+    def _get_system_table_pointer(self):
+        start_addr = 0x0
+        end_addr = 0xf0000000
+        alignment = 0x00400000
+        pattern_guid = 0x5453595320494249
+
+        system_table_pointer = None
+
+        current_addr = start_addr
+        while current_addr < end_addr:
+            try:
+                self._file.seek(current_addr)
+                data = self._file.read(sizeof(EFI_SYSTEM_TABLE_POINTER))
+            except:
+                current_addr = current_addr + alignment
+                continue
+
+            system_table_pointer = EFI_SYSTEM_TABLE_POINTER.from_buffer(bytearray(data))
+            if system_table_pointer.Signature == pattern_guid:
+                buf1 = bytearray(system_table_pointer)[:16]
+                crc32_value = zlib.crc32(buf1)
+                crc32_value = zlib.crc32(b'\0\0\0\0', crc32_value)
+                if crc32_value == system_table_pointer.Crc32:
+                    break
+            current_addr = current_addr + alignment
+        return system_table_pointer
 
     @ classmethod
     def read_efi_config_table(cls, table_cnt, table_ptr, ctype_read):


### PR DESCRIPTION
…NTER

Add code to search for gST via EFI_SYSTEM_TABLE_POINTER.

# Description

I'm working on using the efi_debugging.py to qemu and real hardware. I need to search
for the SYSTEM_TABLE address through memory. 

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

I directly test it on qemu.

## Integration Instructions

N/A