### PR TITLE
LoongArch: Fixed a MP wake up bug and enabled IPI vectors.

### DIFF
--- a/UefiCpuPkg/Library/CpuExceptionHandlerLib/LoongArch/ExceptionCommon.h
+++ b/UefiCpuPkg/Library/CpuExceptionHandlerLib/LoongArch/ExceptionCommon.h
@@ -10,7 +10,12 @@
 #ifndef EXCEPTION_COMMON_H_
 #define EXCEPTION_COMMON_H_
 
+#include <Base.h>
+
 #define MAX_DEBUG_MESSAGE_LENGTH  0x100
+#define SMP_BOOT_CPU              BIT0
+#define SMP_RESCHEDULE            BIT1
+#define SMP_CALL_FUNCTION         BIT2
 
 extern INTN  mExceptionKnownNameNum;
 extern INTN  mInterruptKnownNameNum;

--- a/UefiCpuPkg/Library/CpuExceptionHandlerLib/LoongArch/LoongArch64/ExceptionHandlerAsm.S
+++ b/UefiCpuPkg/Library/CpuExceptionHandlerLib/LoongArch/LoongArch64/ExceptionHandlerAsm.S
@@ -250,7 +250,7 @@ ASM_PFX(ExceptionEntryStart):
 
   csrrd   $t0, LOONGARCH_CSR_EUEN
   andi    $t0, $t0, CSR_EUEN_FPEN
-  beqz    $t0, PushRegDone
+  beqz    $t0, EntryConmmonHanlder
 
   fst.d  $fa0, $sp, 0 * RSIZE
   fst.d  $fa1, $sp, 1 * RSIZE
@@ -311,52 +311,6 @@ ASM_PFX(ExceptionEntryStart):
   //
   // Push exception context down
   //
-
-PushRegDone:
-  //
-  // Process IPI only when mailbox3 is NULL and mailbox0 is no-NULL.
-  //
-  li.d      $t0, LOONGARCH_IOCSR_MBUF0
-  iocsrrd.d $a0, $t0
-  beqz      $a0, EntryConmmonHanlder
-
-  li.d      $t0, LOONGARCH_IOCSR_MBUF3
-  iocsrrd.d $t1, $t0
-  bnez      $t1, EntryConmmonHanlder
-
-  csrrd     $t0, LOONGARCH_CSR_ESTAT
-  srli.d    $t0, $t0, 12
-  andi      $t0, $t0, 0x1
-  beqz      $t0, EntryConmmonHanlder
-
-  //
-  // Clean up current processor mailbox 0 and mailbox 3.
-  //
-  li.d      $t0, LOONGARCH_IOCSR_MBUF0
-  iocsrwr.d $zero, $t0
-  li.d      $t0, LOONGARCH_IOCSR_MBUF3
-  iocsrwr.d $zero, $t0
-
-  //
-  // Clear IPI interrupt.
-  //
-  li.d      $t0, LOONGARCH_IOCSR_IPI_STATUS
-  iocsrrd.w $t1, $t0
-  li.d      $t0, LOONGARCH_IOCSR_IPI_CLEAR
-  iocsrwr.w $t1, $t0
-
-  //
-  // Only kernel stage BSP calls IPI without parameters. Clean up the PIE and make sure
-  // global interrupts are turned off for the current processor when jumping to the kernel.
-  //
-  csrwr     $a0, LOONGARCH_CSR_ERA         // Update ERA
-  li.w      $t0, BIT2                      // IE
-  csrxchg   $zero, $t0, LOONGARCH_CSR_PRMD // Clean PIE
-
-  //
-  // Return this exception and jump to kernel using ERA.
-  //
-  ertn
 
 EntryConmmonHanlder:
   addi.d  $sp, $sp, -(GP_REG_CONTEXT_SIZE + CSR_REG_CONTEXT_SIZE)

--- a/UefiCpuPkg/Library/MpInitLib/LoongArch64/MpLib.c
+++ b/UefiCpuPkg/Library/MpInitLib/LoongArch64/MpLib.c
@@ -14,7 +14,8 @@
 
 #define INVALID_APIC_ID  0xFFFFFFFF
 
-EFI_GUID  mCpuInitMpLibHobGuid = CPU_INIT_MP_LIB_HOB_GUID;
+EFI_GUID                 mCpuInitMpLibHobGuid    = CPU_INIT_MP_LIB_HOB_GUID;
+PROCESSOR_RESOURCE_DATA  *mProcessorResourceData = NULL;
 
 /**
   Get the Application Processors state.
@@ -223,12 +224,6 @@ CollectProcessorCount (
   IN CPU_MP_DATA  *CpuMpData
   )
 {
-  PROCESSOR_RESOURCE_DATA  *ProcessorResourceData;
-  CPU_INFO_IN_HOB          *CpuInfoInHob;
-  UINTN                    Index;
-
-  ProcessorResourceData = NULL;
-
   //
   // Set the default loop mode for APs.
   //
@@ -240,16 +235,11 @@ CollectProcessorCount (
   // as the first broadcast method to wake up all APs, and all of APs will read NODE0
   // Core0 Mailbox0 in an infinit loop.
   //
-  ProcessorResourceData = GetProcessorResourceDataFromGuidedHob ();
+  mProcessorResourceData = GetProcessorResourceDataFromGuidedHob ();
 
-  if (ProcessorResourceData != NULL) {
+  if (mProcessorResourceData != NULL) {
     CpuMpData->ApLoopMode = ApInHltLoop;
-    CpuMpData->CpuCount   = ProcessorResourceData->NumberOfProcessor;
-    CpuInfoInHob          = (CPU_INFO_IN_HOB *)(UINTN)(CpuMpData->CpuInfoInHob);
-
-    for (Index = 0; Index < CpuMpData->CpuCount; Index++) {
-      CpuInfoInHob[Index].ApicId = ProcessorResourceData->ApicId[Index];
-    }
+    CpuMpData->CpuCount   = mProcessorResourceData->NumberOfProcessor;
   }
 
   //
@@ -380,15 +370,15 @@ ApWakeupFunction (
     //
     InterlockedIncrement ((UINT32 *)&CpuMpData->FinishedCount);
 
-    while (TRUE) {
-      //
-      // Clean per-core mail box registers.
-      //
-      IoCsrWrite64 (LOONGARCH_IOCSR_MBUF0, 0x0);
-      IoCsrWrite64 (LOONGARCH_IOCSR_MBUF1, 0x0);
-      IoCsrWrite64 (LOONGARCH_IOCSR_MBUF2, 0x0);
-      IoCsrWrite64 (LOONGARCH_IOCSR_MBUF3, 0x0);
+    //
+    // Clean per-core mail box registers.
+    //
+    IoCsrWrite64 (LOONGARCH_IOCSR_MBUF0, 0x0);
+    IoCsrWrite64 (LOONGARCH_IOCSR_MBUF1, 0x0);
+    IoCsrWrite64 (LOONGARCH_IOCSR_MBUF2, 0x0);
+    IoCsrWrite64 (LOONGARCH_IOCSR_MBUF3, 0x0);
 
+    while (TRUE) {
       //
       // Enable IPI interrupt and global interrupt
       //
@@ -699,19 +689,19 @@ WakeUpAP (
     DEBUG ((DEBUG_INFO, "%a: func 0x%llx, ExchangeInfo 0x%llx\n", __func__, ApWakeupFunction, (UINTN)ExchangeInfo));
     if (CpuMpData->ApLoopMode == ApInHltLoop) {
       for (Index = 0; Index < CpuMpData->CpuCount; Index++) {
-        if (Index != CpuMpData->BspNumber) {
+        if (mProcessorResourceData->ApicId[Index] != CpuMpData->BspNumber) {
           IoCsrWrite64 (
             LOONGARCH_IOCSR_MBUF_SEND,
             (IOCSR_MBUF_SEND_BLOCKING |
              (IOCSR_MBUF_SEND_BOX_HI (0x3) << IOCSR_MBUF_SEND_BOX_SHIFT) |
-             (CpuInfoInHob[Index].ApicId << IOCSR_MBUF_SEND_CPU_SHIFT) |
+             (mProcessorResourceData->ApicId[Index] << IOCSR_MBUF_SEND_CPU_SHIFT) |
              ((UINTN)(ExchangeInfo) & IOCSR_MBUF_SEND_H32_MASK))
             );
           IoCsrWrite64 (
             LOONGARCH_IOCSR_MBUF_SEND,
             (IOCSR_MBUF_SEND_BLOCKING |
              (IOCSR_MBUF_SEND_BOX_LO (0x3) << IOCSR_MBUF_SEND_BOX_SHIFT) |
-             (CpuInfoInHob[Index].ApicId << IOCSR_MBUF_SEND_CPU_SHIFT) |
+             (mProcessorResourceData->ApicId[Index] << IOCSR_MBUF_SEND_CPU_SHIFT) |
              ((UINTN)ExchangeInfo) << IOCSR_MBUF_SEND_BUF_SHIFT)
             );
 
@@ -719,14 +709,14 @@ WakeUpAP (
             LOONGARCH_IOCSR_MBUF_SEND,
             (IOCSR_MBUF_SEND_BLOCKING |
              (IOCSR_MBUF_SEND_BOX_HI (0x0) << IOCSR_MBUF_SEND_BOX_SHIFT) |
-             (CpuInfoInHob[Index].ApicId << IOCSR_MBUF_SEND_CPU_SHIFT) |
+             (mProcessorResourceData->ApicId[Index] << IOCSR_MBUF_SEND_CPU_SHIFT) |
              ((UINTN)(ApWakeupFunction) & IOCSR_MBUF_SEND_H32_MASK))
             );
           IoCsrWrite64 (
             LOONGARCH_IOCSR_MBUF_SEND,
             (IOCSR_MBUF_SEND_BLOCKING |
              (IOCSR_MBUF_SEND_BOX_LO (0x0) << IOCSR_MBUF_SEND_BOX_SHIFT) |
-             (CpuInfoInHob[Index].ApicId << IOCSR_MBUF_SEND_CPU_SHIFT) |
+             (mProcessorResourceData->ApicId[Index] << IOCSR_MBUF_SEND_CPU_SHIFT) |
              ((UINTN)ApWakeupFunction) << IOCSR_MBUF_SEND_BUF_SHIFT)
             );
 
@@ -736,7 +726,7 @@ WakeUpAP (
           IoCsrWrite64 (
             LOONGARCH_IOCSR_IPI_SEND,
             (IOCSR_MBUF_SEND_BLOCKING |
-             (CpuInfoInHob[Index].ApicId << IOCSR_MBUF_SEND_CPU_SHIFT) |
+             (mProcessorResourceData->ApicId[Index] << IOCSR_MBUF_SEND_CPU_SHIFT) |
              0x2 // Bit 2
             )
             );
@@ -1360,7 +1350,7 @@ MpInitLibInitialize (
   //
   // Set BSP basic information
   //
-  InitializeApData (CpuMpData, 0, 0);
+  InitializeApData (CpuMpData, CpuMpData->BspNumber, 0);
 
   //
   // Set up APs wakeup signal buffer and initialization APs ApicId status.

--- a/UefiCpuPkg/Library/MpInitLib/LoongArch64/MpLib.c
+++ b/UefiCpuPkg/Library/MpInitLib/LoongArch64/MpLib.c
@@ -727,9 +727,12 @@ WakeUpAP (
             LOONGARCH_IOCSR_IPI_SEND,
             (IOCSR_MBUF_SEND_BLOCKING |
              (mProcessorResourceData->ApicId[Index] << IOCSR_MBUF_SEND_CPU_SHIFT) |
-             0x2 // Bit 2
+             0x2 // SMP_CALL_FUNCTION
             )
             );
+
+          MemoryFence ();
+          MicroSecondDelay (100); // Delay 100ms after send IPI.
         }
       }
     } else {
@@ -757,15 +760,18 @@ WakeUpAP (
           *(UINT32 *)CpuData->StartupApSignal = WAKEUP_AP_SIGNAL;
 
           //
-          // Send IPI 4 interrupt to wake up APs.
+          // Send IPI 2 interrupt to wake up APs.
           //
           IoCsrWrite64 (
             LOONGARCH_IOCSR_IPI_SEND,
             (IOCSR_MBUF_SEND_BLOCKING |
              (CpuInfoInHob[Index].ApicId << IOCSR_MBUF_SEND_CPU_SHIFT) |
-             0x2 // Bit 2
+             0x1 // SMP_RESCHEDULE
             )
             );
+
+          MemoryFence ();
+          MicroSecondDelay (100); // Delay 100ms after send IPI.
         }
       }
 
@@ -789,15 +795,18 @@ WakeUpAP (
       *(UINT32 *)CpuData->StartupApSignal = WAKEUP_AP_SIGNAL;
 
       //
-      // Send IPI 4 interrupt to wake up APs.
+      // Send IPI 2 interrupt to wake up APs.
       //
       IoCsrWrite64 (
         LOONGARCH_IOCSR_IPI_SEND,
         (IOCSR_MBUF_SEND_BLOCKING |
          (CpuInfoInHob[ProcessorNumber].ApicId << IOCSR_MBUF_SEND_CPU_SHIFT) |
-         0x2 // Bit 2
+         0x1 // SMP_RESCHEDULE
         )
         );
+
+      MemoryFence ();
+      MicroSecondDelay (100); // Delay 100ms after send IPI.
 
       //
       // Wait specified AP waken up


### PR DESCRIPTION
# Description

1. Fix a bug about MP init on LoongArch
2. Enable the IPI vectors on LoongArch

## How This Was Tested

Using out-of-order wake-up APs, they can start correctly.

## Integration Instructions

<N/A>
