### PR TITLE
MdePkg/Library: Remove unused gEfiDevicePathProtocolGuid

### DIFF
--- a/MdePkg/Library/UefiDevicePathLib/UefiDevicePathLibBase.inf
+++ b/MdePkg/Library/UefiDevicePathLib/UefiDevicePathLibBase.inf
@@ -68,7 +68,6 @@
   gEfiPersistentVirtualCdGuid
 
 [Protocols]
-  gEfiDevicePathProtocolGuid                    ## SOMETIMES_CONSUMES
   gEfiDebugPortProtocolGuid                     ## UNDEFINED
 
 [Pcd]


### PR DESCRIPTION
Remove unused gEfiDevicePathProtocolGuid in Base UefiDevicePathLib since it's not used.

# Description

No impact
