### PR TITLE
UefiCpuPkg: Add back gEdkiiPeiMpServices2PpiGuid

### DIFF
--- a/MdePkg/Include/Ppi/MpServices2.h
+++ b/MdePkg/Include/Ppi/MpServices2.h
@@ -280,15 +280,13 @@ struct _EFI_PEI_MP_SERVICES2_PPI {
 
 extern EFI_GUID  gEfiPeiMpServices2PpiGuid;
 
-// For backwards compatability. To be removed.
-#ifdef ENABLE_DEPRECATED_EDKII_MP_SERVICES2
-
+//
+// The EDK II PEI MP Services 2 PPI has been replaced by the PEI MP Services 2
+// PPI in the MdePkg. The following definitions are only present for backwards
+// compatibility and will be removed in the future.
+//
 #define EDKII_PEI_MP_SERVICES2_PPI_GUID  EFI_PEI_MP_SERVICES2_PPI_GUID
 
 typedef EFI_PEI_MP_SERVICES2_PPI EDKII_PEI_MP_SERVICES2_PPI;
-
-#define gEdkiiPeiMpServices2PpiGuid  gEfiPeiMpServices2PpiGuid
-
-#endif
 
 #endif

--- a/MdePkg/MdePkg.ci.yaml
+++ b/MdePkg/MdePkg.ci.yaml
@@ -165,6 +165,7 @@
             "gEfiPeiMmAccessPpiGuid=gPeiSmmAccessPpiGuid",
             "gPeiSmmControlPpiGuid=gEfiPeiMmControlPpiGuid",
             "gEfiPeiMmCommunicationPpiGuid=gEfiPeiSmmCommunicationPpiGuid",
+            "gEdkiiPeiMpServices2PpiGuid=gEfiPeiMpServices2PpiGuid",
             ]
     },
 

--- a/UefiCpuPkg/UefiCpuPkg.ci.yaml
+++ b/UefiCpuPkg/UefiCpuPkg.ci.yaml
@@ -74,7 +74,7 @@
         "IgnoreGuidName": ["SecCore", "ResetVector"], # Expected duplication for gEfiFirmwareVolumeTopFileGuid
         "IgnoreGuidValue": [],
         "IgnoreFoldersAndFiles": [],
-        "IgnoreDuplicates": []
+        "IgnoreDuplicates": ["gEdkiiPeiMpServices2PpiGuid=gEfiPeiMpServices2PpiGuid"]
     },
     "LibraryClassCheck": {
         "IgnoreHeaderFile": []

--- a/UefiCpuPkg/UefiCpuPkg.dec
+++ b/UefiCpuPkg/UefiCpuPkg.dec
@@ -148,6 +148,13 @@
 #
 
 [Ppis]
+  #
+  # The EDK II PEI MP Services 2 PPI has been replaced by the PEI MP Services 2 PPI
+  # in the MdePkg. The following definition is only present for backwards compatibility
+  # and will be removed in the future.
+  #
+  gEdkiiPeiMpServices2PpiGuid =    { 0x5cb9cb3d, 0x31a4, 0x480c, { 0x94, 0x98, 0x29, 0xd2, 0x69, 0xba, 0xcf, 0xba}}
+
   ## Include/Ppi/ShadowMicrocode.h
   gEdkiiPeiShadowMicrocodePpiGuid = { 0x430f6965, 0x9a69, 0x41c5, { 0x93, 0xed, 0x8b, 0xf0, 0x64, 0x35, 0xc1, 0xc6 }}
 


### PR DESCRIPTION
# Description

Commit aef50446ced0662c8dfd968ab0ea05cc88b989ae
removed gEdkiiPeiMpServices2PpiGuid from UefiCpuPkg.dec which causes build breaks if an INF [Ppis] section lists gEdkiiPeiMpServices2PpiGuid. There is no method for a DEC file for conditionally declare a PPI.

In order to support the migration from use of
gEdkiiPeiMpServices2PpiGuid to the preferred use of the gPeiMpServices2Ppi, add gEdkiiPeiMpServices2PpiGuid back to the UefiCpuPkg.dec and update MpServices2.h in MdePkg to define EDKII_PEI_MP_SERVICES2_PPI_GUID and
EDKII_PEI_MP_SERVICES2_PPI.

All references to the EDK II PEI MP Services 2 PPI can be removed after all downstream consumers have had a chance to perform the migration.


- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

## Integration Instructions
