### PR TITLE
ShellPkg: Updated Memory Form Factor definition per SMBIOS 3.8.0

### DIFF
--- a/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/QueryTable.c
+++ b/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/QueryTable.c
@@ -4,7 +4,7 @@
 
   Copyright (c) 2005 - 2024, Intel Corporation. All rights reserved.<BR>
   (C) Copyright 2016-2019 Hewlett Packard Enterprise Development LP<BR>
-  Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -2748,6 +2748,10 @@ TABLE_ITEM  MemoryDeviceFormFactorTable[] = {
   {
     MemoryFormFactorDie,
     L"  Die"
+  },
+  {
+    MemoryFormFactorCamm,
+    L"  CAMM"
   }
 };
 


### PR DESCRIPTION
This patch adds additional support for the new CAMM form factor defined in SMBIOS specification 3.8.0

# Description

This change extends the Memory Form Factor Table to include the new entry for "CAMM". SMBIOS spec 3.8.0 defines this entry as well. The change is intended to get the edk2 code in sync with 3.8.0 spec.
The change only impacts ShellPkg package and it is a follow up to the corresponding change in MdPkg to add the CAMM entry (PR #10965)

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.


## Integration Instructions
N/A
