### PR TITLE
Ovmf memory debug logging2

### DIFF
--- a/OvmfPkg/Include/Library/MemDebugLogCommonLib.h
+++ b/OvmfPkg/Include/Library/MemDebugLogCommonLib.h
@@ -1,0 +1,155 @@
+/** @file
+  Memory Debug Log common defs/funcs to access the memory buffer.
+
+  Copyright (C) 2025, Oracle and/or its affiliates.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef __MEM_DEBUG_LOG_COMMON_H_
+#define __MEM_DEBUG_LOG_COMMON_H_
+
+#include <Uefi/UefiBaseType.h>
+
+//
+// Cap max buffer at 4MB (0x400 4K pages)
+//
+#define MAX_MEM_DEBUG_LOG_PAGES  0x400
+
+#define MEM_DEBUG_LOG_MAGIC1  0x646d656d666d766f  // "ovmfmemd"
+#define MEM_DEBUG_LOG_MAGIC2  0x6367616d67756265  // "ebugmagc"
+
+#pragma pack(1)
+//
+// Mem Debug Log buffer header.
+// The Log buffer is circular. Only the most
+// recent messages are retained. Older messages
+// will be discarded if the buffer overflows.
+// The Debug Log starts just after the header.
+// Versioning the structure allows for future expansion.
+//
+typedef struct {
+  //
+  // Magic values used by tools to locate the buffer in memory
+  // These MUST be the first two fields of the structure.
+  // Use a 128 bit Magic to make sure to avoid any possible
+  // collision with random data in memory.
+  UINT64             Magic1;
+  UINT64             Magic2;
+  //
+  // Structure version- MUST be third field and set to 1
+  //
+  UINT8              Version;
+  //
+  // Debug log size minus header
+  //
+  UINT32             DebugLogSize;
+  //
+  // Debug log head offset
+  //
+  UINT32             DebugLogHeadOffset;
+  //
+  //  Debug log tail offset
+  //
+  UINT32             DebugLogTailOffset;
+  //
+  // Protect the log from MP access
+  //
+  volatile UINT64    MemDebugLogLock;
+  //
+  // Flag to indicate if the buffer wrapped and was thus truncated.
+  //
+  UINT8              Truncated;
+  //
+  // Firmware Build Version (PcdFirmwareVersionString)
+  //
+  CHAR8              FirmwareVersion[32];
+} MEM_DEBUG_LOG_HDR_V1;
+
+//
+// HOB used to pass the mem debug log buffer addr from PEI to DXE
+//
+typedef struct {
+  EFI_PHYSICAL_ADDRESS    MemDebugLogBufAddr;
+} MEM_DEBUG_LOG_HOB_DATA;
+
+#pragma pack()
+
+/**
+  Write a CHAR8 string to the memory debug log circular buffer.
+
+  @param MemDebugLogBufAddr       Address of the memory debug log buffer.
+
+  @param Buffer                   Pointer to a CHAR8 string to write to the
+                                  debug log buffer.
+
+  @param Length                   Length of the CHAR8 string to write to the
+                                  debug log buffer. Not including NULL terminator
+                                  byte.
+
+  @retval RETURN_SUCCESS          String succcessfully written to the memory log buffer.
+
+  @retval RETURN_NOT_FOUND        Memory log buffer is not properly initialized.
+
+  @retval EFI_INVALID_PARAMETER   Invalid input parameters.
+**/
+EFI_STATUS
+EFIAPI
+MemDebugLogWriteCommon (
+  IN EFI_PHYSICAL_ADDRESS  MemDebugLogBufAddr,
+  IN CHAR8                 *Buffer,
+  IN UINTN                 Length
+  );
+
+/**
+  Initialize the memory debug log buffer header
+
+  @param MemDebugLogBufAddr       Address of the memory debug log buffer.
+
+  @param MemDebugLogBufSize       Size of the memory debug log buffer.
+
+  @retval RETURN_SUCCESS          Log buffer successfully initialized.
+
+  @retval EFI_INVALID_PARAMETER   Invalid input parameters.
+**/
+EFI_STATUS
+EFIAPI
+MemDebugLogInitCommon (
+  IN EFI_PHYSICAL_ADDRESS  MemDebugLogBufAddr,
+  UINT32                   MemDebugLogBufSize
+  );
+
+/**
+  Copy the memory debug log buffer
+
+  @param MemDebugLogBufDestAddr   Address of destination memory debug log buffer.
+
+  @param MemDebugLogBufSrcAddr    Address of source memory debug log buffer.
+
+  @retval RETURN_SUCCESS          Log buffer successfuly copied.
+
+  @retval EFI_INVALID_PARAMETER   Invalid input parameters.
+**/
+EFI_STATUS
+EFIAPI
+MemDebugLogCopyCommon (
+  IN EFI_PHYSICAL_ADDRESS  MemDebugLogBufDestAddr,
+  IN EFI_PHYSICAL_ADDRESS  MemDebugLogBufSrcAddr
+  );
+
+/**
+  Invalidate the memory debug log buffer
+
+  @param MemDebugLogBufAddr       Address of the memory debug log buffer.
+
+  @retval RETURN_SUCCESS          Log buffer successfuly invalidated.
+
+  @retval EFI_INVALID_PARAMETER   Invalid input parameters.
+**/
+EFI_STATUS
+EFIAPI
+MemDebugLogInvalidateCommon (
+  IN EFI_PHYSICAL_ADDRESS  MemDebugLogBufAddr
+  );
+
+#endif // __MEM_DEBUG_LOG_COMMON_H_

--- a/OvmfPkg/Include/Library/MemDebugLogLib.h
+++ b/OvmfPkg/Include/Library/MemDebugLogLib.h
@@ -1,0 +1,36 @@
+/** @file
+  Interface functions for the Memory Debug Log Library.
+
+  Copyright (C) 2025, Oracle and/or its affiliates.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef _MEM_DEBUG_LOG_LIB_H_
+#define _MEM_DEBUG_LOG_LIB_H_
+
+#include <Uefi/UefiBaseType.h>
+#include <Base.h>
+
+/**
+  Write a CHAR8 string to the memory debug log
+
+  @param[in] Buffer              The buffer containing the string of CHAR8s
+
+  @param[in] Length              The buffer length (number of CHAR8s)
+                                 not including the NULL terminator byte.
+
+  @retval RETURN_SUCCESS         String succcessfully written to the memory log buffer.
+
+  @retval RETURN_NOT_FOUND       Memory log buffer is not properly initialized.
+
+  @retval EFI_INVALID_PARAMETER   Invalid input parameters.
+**/
+EFI_STATUS
+EFIAPI
+MemDebugLogWrite (
+  IN  CHAR8  *Buffer,
+  IN  UINTN  Length
+  );
+
+#endif // _MEM_DEBUG_LOG_LIB_H_

--- a/OvmfPkg/Include/Ppi/MemDebugLog.h
+++ b/OvmfPkg/Include/Ppi/MemDebugLog.h
@@ -1,0 +1,31 @@
+/** @file
+  Memory Debug Log PPI
+
+  Copyright (C) 2025, Oracle and/or its affiliates.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef __MEM_DEBUG_LOG_PPI_H_
+#define __MEM_DEBUG_LOG_PPI_H_
+
+#define MEM_DEBUG_LOG_PPI_SIGNATURE  SIGNATURE_32('M','D','B','L')
+
+#define MEM_DEBUG_LOG_PPI_VERSION  (1)
+
+typedef
+EFI_STATUS
+(EFIAPI *MEM_DEBUG_LOG_PPI_WRITE)(
+  IN  CHAR8               *Buffer,
+  IN  UINTN                Length
+  );
+
+typedef struct {
+  UINT32                     Signature;
+  UINT32                     Version;
+  MEM_DEBUG_LOG_PPI_WRITE    MemDebugLogPpiWrite;
+} MEM_DEBUG_LOG_PPI;
+
+extern  EFI_GUID  gMemDebugLogPpiGuid;
+
+#endif // __MEM_DEBUG_LOG_PPI_H_

--- a/OvmfPkg/Library/MemDebugLogCommonLib/MemDebugLogCommonLib.c
+++ b/OvmfPkg/Library/MemDebugLogCommonLib/MemDebugLogCommonLib.c
@@ -1,0 +1,291 @@
+/** @file
+  Memory Debug Log common defs/funcs to access the memory buffer.
+
+  Copyright (C) 2025, Oracle and/or its affiliates.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/PrintLib.h>
+#include <Library/SynchronizationLib.h>
+#include <Library/MemDebugLogCommonLib.h>
+
+#define MEMDEBUGLOG_COPYSIZE  0x200
+
+STATIC
+VOID
+MemDebugLogLockInit (
+  IN volatile UINT64  *MemDebugLogLock
+  )
+{
+  InitializeSpinLock ((SPIN_LOCK *)MemDebugLogLock);
+}
+
+STATIC
+VOID
+MemDebugLogLockAcquire (
+  IN volatile UINT64  *MemDebugLogLock
+  )
+{
+  AcquireSpinLock ((SPIN_LOCK *)MemDebugLogLock);
+}
+
+STATIC
+VOID
+MemDebugLogLockRelease (
+  IN volatile UINT64  *MemDebugLogLock
+  )
+{
+  ReleaseSpinLock ((SPIN_LOCK *)MemDebugLogLock);
+}
+
+EFI_STATUS
+EFIAPI
+MemDebugLogWriteCommon (
+  IN  EFI_PHYSICAL_ADDRESS  MemDebugLogBufAddr,
+  IN  CHAR8                 *Buffer,
+  IN  UINTN                 Length
+  )
+{
+  volatile UINT64       *MemDebugLogLock;
+  MEM_DEBUG_LOG_HDR_V1  *MemDebugLogHdr;
+  UINTN                 BufSpaceLeft;
+  CHAR8                 *BufStart;
+  CHAR8                 *BufHead;
+  CHAR8                 *BufTail;
+  CHAR8                 *BufEnd;
+
+  //
+  // NOTE: we cannot call DEBUG or ASSERT from this function.
+  //
+
+  if (!MemDebugLogBufAddr || !Buffer) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (Length == 0) {
+    return EFI_SUCCESS;
+  }
+
+  MemDebugLogHdr  = (MEM_DEBUG_LOG_HDR_V1 *)(UINTN)MemDebugLogBufAddr;
+  MemDebugLogLock = &(MemDebugLogHdr->MemDebugLogLock);
+
+  //
+  // Validate the header magic before proceeding
+  //
+  if ((MemDebugLogHdr->Magic1 != MEM_DEBUG_LOG_MAGIC1) ||
+      (MemDebugLogHdr->Magic2 != MEM_DEBUG_LOG_MAGIC2))
+  {
+    return EFI_NOT_FOUND;
+  }
+
+  if (Length >= MemDebugLogHdr->DebugLogSize) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  MemDebugLogLockAcquire (MemDebugLogLock);
+
+  BufStart = (CHAR8 *)(UINTN)(MemDebugLogBufAddr + sizeof (MEM_DEBUG_LOG_HDR_V1));
+  BufEnd   = (CHAR8 *)(UINTN)(MemDebugLogBufAddr + sizeof (MEM_DEBUG_LOG_HDR_V1) + MemDebugLogHdr->DebugLogSize) - 1;
+  BufHead  = BufStart + MemDebugLogHdr->DebugLogHeadOffset;
+  BufTail  = BufStart + MemDebugLogHdr->DebugLogTailOffset;
+
+  //
+  // Maintain a circular (wrap around) log buffer
+  // NOTES:
+  // tail always points to next available slot to populate
+  // Algorithm to process/display strings from buffer in time order:
+  // 1. head==tail indicates empty buffer
+  // 2. if (head < tail), process from head (tail-head) bytes
+  // 3. if (head > tail), process from head (bufend-head) bytes
+  //                      process from bufstart (tail-bufstart) bytes
+  //
+
+  if ((BufTail + Length) <= BufEnd) {
+    //
+    //  There's enough room from tail to end of the buffer
+    //
+    CopyMem (BufTail, Buffer, Length);
+    //
+    // If we have previously wrapped around, need to keep Head updated
+    //
+    if (BufHead == (BufTail + 1)) {
+      BufHead += Length;
+      //
+      // Check if we need to wrap Head
+      //
+      if (BufHead > BufEnd) {
+        BufHead = BufStart;
+      }
+    }
+
+    BufTail += Length;
+  } else {
+    //
+    // We need to wrap around.
+    //
+    // Fill remaining buffer space with initial part of the string
+    //
+    BufSpaceLeft = (UINTN)(BufEnd - BufTail + 1);
+    CopyMem (BufTail, Buffer, BufSpaceLeft);
+
+    //
+    // Wrap to start of the buffer for the rest of the string
+    //
+    BufTail = BufStart;
+    CopyMem (BufTail, (Buffer + BufSpaceLeft), (Length - BufSpaceLeft));
+    BufTail += (Length - BufSpaceLeft);
+    BufHead  = (BufTail + 1);
+
+    MemDebugLogHdr->Truncated = 1;
+  }
+
+  //
+  // Write the new buffer offsets back to the header
+  //
+  MemDebugLogHdr->DebugLogHeadOffset = BufHead - BufStart;
+  MemDebugLogHdr->DebugLogTailOffset = BufTail - BufStart;
+
+  MemDebugLogLockRelease (MemDebugLogLock);
+
+  return EFI_SUCCESS;
+}
+
+EFI_STATUS
+EFIAPI
+MemDebugLogInitCommon (
+  IN EFI_PHYSICAL_ADDRESS  MemDebugLogBufAddr,
+  UINT32                   MemDebugLogBufSize
+  )
+{
+  MEM_DEBUG_LOG_HDR_V1  *MemDebugLogHdr;
+
+  if (MemDebugLogBufAddr == 0) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  ZeroMem ((VOID *)(UINTN)MemDebugLogBufAddr, MemDebugLogBufSize);
+
+  MemDebugLogHdr                     = (MEM_DEBUG_LOG_HDR_V1 *)(UINTN)MemDebugLogBufAddr;
+  MemDebugLogHdr->Magic1             = MEM_DEBUG_LOG_MAGIC1;
+  MemDebugLogHdr->Magic2             = MEM_DEBUG_LOG_MAGIC2;
+  MemDebugLogHdr->Version            = 1;
+  MemDebugLogHdr->DebugLogSize       = (MemDebugLogBufSize - sizeof (MEM_DEBUG_LOG_HDR_V1));
+  MemDebugLogHdr->DebugLogHeadOffset = 0;
+  MemDebugLogHdr->DebugLogTailOffset = 0;
+  MemDebugLogLockInit (&(MemDebugLogHdr->MemDebugLogLock));
+  MemDebugLogHdr->Truncated = 0;
+  AsciiSPrint (MemDebugLogHdr->FirmwareVersion, 32, "%s", (CHAR16 *)PcdGetPtr (PcdFirmwareVersionString));
+
+  return EFI_SUCCESS;
+}
+
+EFI_STATUS
+EFIAPI
+MemDebugLogCopyCommon (
+  IN EFI_PHYSICAL_ADDRESS  MemDebugLogBufDestAddr,
+  IN EFI_PHYSICAL_ADDRESS  MemDebugLogBufSrcAddr
+  )
+{
+  MEM_DEBUG_LOG_HDR_V1  *MemDebugLogSrcHdr;
+  MEM_DEBUG_LOG_HDR_V1  *MemDebugLogDestHdr;
+  CHAR8                 *BufStart;
+  CHAR8                 *BufHead;
+  CHAR8                 *BufTail;
+  CHAR8                 *BufEnd;
+  CHAR8                 *BufPtr;
+
+  if ((MemDebugLogBufSrcAddr == 0) || (MemDebugLogBufDestAddr == 0)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  MemDebugLogSrcHdr  = (MEM_DEBUG_LOG_HDR_V1 *)(UINTN)MemDebugLogBufSrcAddr;
+  MemDebugLogDestHdr = (MEM_DEBUG_LOG_HDR_V1 *)(UINTN)MemDebugLogBufDestAddr;
+
+  BufStart = (CHAR8 *)(UINTN)(MemDebugLogBufSrcAddr + sizeof (MEM_DEBUG_LOG_HDR_V1));
+  BufEnd   = (CHAR8 *)(UINTN)(MemDebugLogBufSrcAddr + sizeof (MEM_DEBUG_LOG_HDR_V1) + MemDebugLogSrcHdr->DebugLogSize);
+  BufHead  = BufStart + MemDebugLogSrcHdr->DebugLogHeadOffset;
+  BufTail  = BufStart + MemDebugLogSrcHdr->DebugLogTailOffset;
+
+  MemDebugLogDestHdr->Truncated = MemDebugLogSrcHdr->Truncated;
+
+  if (BufHead == BufTail) {
+    //
+    // Source Debug Log empty
+    //
+    return EFI_SUCCESS;
+  } else if (BufHead < BufTail) {
+    //
+    // Source buffer didn't wrap, so copy debug messages
+    // from Source buffer (head to tail) to the Dest buffer
+    // NOTE: we limit each copy to MEMDEBUGLOG_COPYSIZE
+    // to ensure to not copy too much at a time and ensure
+    // the dest buffer head/tail pointers are created properly.
+    //
+    for (BufPtr = BufHead; (BufTail - BufPtr) > MEMDEBUGLOG_COPYSIZE; BufPtr += MEMDEBUGLOG_COPYSIZE) {
+      MemDebugLogWriteCommon (MemDebugLogBufDestAddr, BufPtr, MEMDEBUGLOG_COPYSIZE);
+    }
+
+    //
+    // write remaining bytes
+    //
+    MemDebugLogWriteCommon (MemDebugLogBufDestAddr, BufPtr, (BufTail - BufPtr));
+  } else {
+    //
+    // Source buffer wrapped.
+    // First copy (bufend - head) chars from head to Dest buffer
+    //
+    for (BufPtr = BufHead; (BufEnd - BufPtr) > MEMDEBUGLOG_COPYSIZE; BufPtr += MEMDEBUGLOG_COPYSIZE) {
+      MemDebugLogWriteCommon (MemDebugLogBufDestAddr, BufPtr, MEMDEBUGLOG_COPYSIZE);
+    }
+
+    //
+    // write remaining bytes
+    //
+    MemDebugLogWriteCommon (MemDebugLogBufDestAddr, BufPtr, (BufEnd - BufPtr));
+
+    //
+    // Next, copy (bufend - head) chars from start to Dest buffer
+    //
+    for (BufPtr = BufStart; (BufTail - BufPtr) > MEMDEBUGLOG_COPYSIZE; BufPtr += MEMDEBUGLOG_COPYSIZE) {
+      MemDebugLogWriteCommon (MemDebugLogBufDestAddr, BufPtr, MEMDEBUGLOG_COPYSIZE);
+    }
+
+    //
+    // write remaining bytes
+    //
+    MemDebugLogWriteCommon (MemDebugLogBufDestAddr, BufPtr, (BufTail - BufPtr));
+  }
+
+  return EFI_SUCCESS;
+}
+
+EFI_STATUS
+EFIAPI
+MemDebugLogInvalidateCommon (
+  IN EFI_PHYSICAL_ADDRESS  MemDebugLogBufAddr
+  )
+{
+  volatile UINT64       *MemDebugLogLock;
+  MEM_DEBUG_LOG_HDR_V1  *MemDebugLogHdr;
+
+  if (MemDebugLogBufAddr == 0) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  MemDebugLogHdr  = (MEM_DEBUG_LOG_HDR_V1 *)(UINTN)MemDebugLogBufAddr;
+  MemDebugLogLock = &(MemDebugLogHdr->MemDebugLogLock);
+
+  MemDebugLogLockAcquire (MemDebugLogLock);
+
+  // Invalidate the MAGIC fields
+  MemDebugLogHdr->Magic1 = 0x0;
+  MemDebugLogHdr->Magic2 = 0x0;
+
+  MemDebugLogLockRelease (MemDebugLogLock);
+
+  return EFI_SUCCESS;
+}

--- a/OvmfPkg/Library/MemDebugLogCommonLib/MemDebugLogCommonLib.inf
+++ b/OvmfPkg/Library/MemDebugLogCommonLib/MemDebugLogCommonLib.inf
@@ -1,0 +1,33 @@
+## @file
+#  MemDebugLogCommon Library
+#
+#  Copyright (C) 2025, Oracle and/or its affiliates.
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = MemDebugLogCommonLib
+  FILE_GUID                      = 23E15D02-0D51-4EF1-8A56-39A1297D72E0
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = MemDebugLogCommonLib
+
+
+[Sources]
+  MemDebugLogCommonLib.c
+
+[Packages]
+  MdeModulePkg/MdeModulePkg.dec
+  MdePkg/MdePkg.dec
+  OvmfPkg/OvmfPkg.dec
+
+[LibraryClasses]
+  SynchronizationLib
+
+[Guids]
+
+[FixedPcd]
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFirmwareVersionString ## CONSUMES

--- a/OvmfPkg/Library/MemDebugLogLib/Dxe/MemDebugLogLib.c
+++ b/OvmfPkg/Library/MemDebugLogLib/Dxe/MemDebugLogLib.c
@@ -1,0 +1,57 @@
+/** @file
+ *
+  Memory Debug Log Library - DXE/Smm
+
+  Copyright (C) 2025, Oracle and/or its affiliates.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <PiDxe.h>
+#include <Library/HobLib.h>
+#include <Library/MemDebugLogLib.h>
+#include <Library/MemDebugLogCommonLib.h>
+
+EFI_PHYSICAL_ADDRESS  mMemDebugLogBufAddr;
+BOOLEAN               mMemDebugLogBufAddrInit;
+
+EFI_STATUS
+EFIAPI
+MemDebugLogWrite (
+  IN  CHAR8  *Buffer,
+  IN  UINTN  Length
+  )
+{
+  EFI_HOB_GUID_TYPE       *GuidHob;
+  MEM_DEBUG_LOG_HOB_DATA  *HobData;
+  EFI_STATUS              Status;
+
+  //
+  // Init debug log buffer addr on first write
+  //
+  if (!mMemDebugLogBufAddrInit) {
+    //
+    // Obtain the Memory Debug Log buffer addr from PEI HOB
+    //
+    GuidHob = GetFirstGuidHob (&gMemDebugLogHobGuid);
+    if (GuidHob == NULL) {
+      mMemDebugLogBufAddr = 0;
+    } else {
+      //
+      // Populate the Mem Debug Log Buffer from the HOB
+      //
+      HobData             = (MEM_DEBUG_LOG_HOB_DATA *)GET_GUID_HOB_DATA (GuidHob);
+      mMemDebugLogBufAddr = HobData->MemDebugLogBufAddr;
+    }
+
+    mMemDebugLogBufAddrInit = TRUE;
+  }
+
+  if (mMemDebugLogBufAddr) {
+    Status = MemDebugLogWriteCommon (mMemDebugLogBufAddr, Buffer, Length);
+  } else {
+    Status = EFI_NOT_FOUND;
+  }
+
+  return Status;
+}

--- a/OvmfPkg/Library/MemDebugLogLib/Dxe/MemDebugLogLib.inf
+++ b/OvmfPkg/Library/MemDebugLogLib/Dxe/MemDebugLogLib.inf
@@ -1,0 +1,32 @@
+## @file
+#  Instance of MemDebugLog Library for DXE/Smm
+#
+#  Copyright (C) 2025, Oracle and/or its affiliates.
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = MemDebugLogLib
+  FILE_GUID                      = 4988621E-8EE8-4D27-862F-EB98BD8F17E6
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = MemDebugLogLib|DXE_CORE DXE_DRIVER UEFI_DRIVER UEFI_APPLICATION SMM_CORE DXE_SMM_DRIVER
+
+
+[Sources]
+  MemDebugLogLib.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  OvmfPkg/OvmfPkg.dec
+
+[LibraryClasses]
+  HobLib
+  MemDebugLogCommonLib
+
+[Guids]
+  gMemDebugLogHobGuid                      ## CONSUMES

--- a/OvmfPkg/Library/MemDebugLogLib/Null/MemDebugLogLib.c
+++ b/OvmfPkg/Library/MemDebugLogLib/Null/MemDebugLogLib.c
@@ -1,0 +1,22 @@
+/** @file
+ *
+  Memory Debug Log Library.
+
+  Copyright (C) 2025, Oracle and/or its affiliates.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Library/MemDebugLogLib.h>
+
+EFI_STATUS
+EFIAPI
+MemDebugLogWrite (
+  IN  CHAR8  *Buffer,
+  IN  UINTN  Length
+  )
+{
+  // Null Instance - NOP
+  return EFI_SUCCESS;
+}

--- a/OvmfPkg/Library/MemDebugLogLib/Null/MemDebugLogLib.inf
+++ b/OvmfPkg/Library/MemDebugLogLib/Null/MemDebugLogLib.inf
@@ -1,0 +1,31 @@
+## @file
+#  Null Instance of MemDebugLog Library
+#
+#  Copyright (C) 2025, Oracle and/or its affiliates.
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = MemDebugLogLib
+  FILE_GUID                      = 11b4523c-2c30-44f7-9dee-e6d59eef3d04
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = MemDebugLogLib|SEC PEI_CORE PEIM DXE_CORE DXE_DRIVER DXE_RUNTIME_DRIVER UEFI_APPLICATION UEFI_DRIVER SMM_CORE DXE_SMM_DRIVER
+
+
+[Sources]
+  MemDebugLogLib.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  OvmfPkg/OvmfPkg.dec
+
+[LibraryClasses]
+
+[FixedPcd]
+
+[Guids]

--- a/OvmfPkg/Library/MemDebugLogLib/Pei/MemDebugLogLib.c
+++ b/OvmfPkg/Library/MemDebugLogLib/Pei/MemDebugLogLib.c
@@ -1,0 +1,55 @@
+/** @file
+ *
+  Memory Debug Log Library - PEI Phase
+
+  Copyright (C) 2025, Oracle and/or its affiliates.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <PiPei.h>
+#include <Library/PeiServicesLib.h>
+#include <Library/MemDebugLogLib.h>
+#include <Library/MemDebugLogCommonLib.h>
+#include <Ppi/MemDebugLog.h>
+
+EFI_STATUS
+EFIAPI
+MemDebugLogWrite (
+  IN  CHAR8  *Buffer,
+  IN  UINTN  Length
+  )
+{
+  MEM_DEBUG_LOG_PPI  *MemDebugLogPpi;
+  EFI_STATUS         Status;
+
+  MemDebugLogPpi = NULL;
+  Status         = PeiServicesLocatePpi (
+                     &gMemDebugLogPpiGuid,
+                     0,
+                     NULL,
+                     (VOID **)&MemDebugLogPpi
+                     );
+
+  if ((Status == EFI_SUCCESS) && MemDebugLogPpi) {
+    //
+    // PPI is installed, so use the PPI
+    //
+    Status = MemDebugLogPpi->MemDebugLogPpiWrite (Buffer, Length);
+  } else {
+    //
+    // No PPI installed (yet), so write to the early debug log buffer
+    //
+    if (FixedPcdGet32 (PcdOvmfEarlyMemDebugLogBase) != 0x0) {
+      Status = MemDebugLogWriteCommon (
+                 (EFI_PHYSICAL_ADDRESS)(UINTN)FixedPcdGet32 (PcdOvmfEarlyMemDebugLogBase),
+                 Buffer,
+                 Length
+                 );
+    } else {
+      Status = EFI_NOT_FOUND;
+    }
+  }
+
+  return Status;
+}

--- a/OvmfPkg/Library/MemDebugLogLib/Pei/MemDebugLogLib.inf
+++ b/OvmfPkg/Library/MemDebugLogLib/Pei/MemDebugLogLib.inf
@@ -1,0 +1,37 @@
+## @file
+#  Instance of MemDebugLog Library for PEI phase
+#
+#  Copyright (C) 2025, Oracle and/or its affiliates.
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = MemDebugLogLib
+  FILE_GUID                      = D473DE36-0D8A-4F6B-9FA0-126185F36D9D
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = MemDebugLogLib|PEI_CORE PEIM
+
+
+[Sources]
+  MemDebugLogLib.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  OvmfPkg/OvmfPkg.dec
+
+[LibraryClasses]
+  MemDebugLogCommonLib
+
+[FixedPcd]
+  gUefiOvmfPkgTokenSpaceGuid.PcdOvmfEarlyMemDebugLogBase
+  gUefiOvmfPkgTokenSpaceGuid.PcdOvmfEarlyMemDebugLogSize
+
+[Guids]
+
+[Ppis]
+  gMemDebugLogPpiGuid                    ## CONSUMES

--- a/OvmfPkg/Library/MemDebugLogLib/Runtime/MemDebugLogLib.c
+++ b/OvmfPkg/Library/MemDebugLogLib/Runtime/MemDebugLogLib.c
@@ -1,0 +1,67 @@
+/** @file
+ *
+  Memory Debug Log Library - Runtime
+
+  Copyright (C) 2025, Oracle and/or its affiliates.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <PiDxe.h>
+#include <Library/HobLib.h>
+#include <Library/MemDebugLogLib.h>
+#include <Library/MemDebugLogCommonLib.h>
+#include <Library/UefiRuntimeLib.h>
+
+EFI_PHYSICAL_ADDRESS  mMemDebugLogBufAddr;
+BOOLEAN               mMemDebugLogBufAddrInit;
+
+EFI_STATUS
+EFIAPI
+MemDebugLogWrite (
+  IN  CHAR8  *Buffer,
+  IN  UINTN  Length
+  )
+{
+  EFI_HOB_GUID_TYPE       *GuidHob;
+  MEM_DEBUG_LOG_HOB_DATA  *HobData;
+  EFI_STATUS              Status;
+
+  //
+  // Stop logging after we have switched to virtual mode
+  // to avoid potential problems (such as crashes accessing
+  // physical pointers).
+  //
+  if (EfiGoneVirtual ()) {
+    return EFI_SUCCESS;
+  }
+
+  //
+  // Init debug log buffer addr on first write
+  //
+  if (!mMemDebugLogBufAddrInit) {
+    //
+    // Obtain the Memory Debug Log buffer addr from PEI HOB
+    //
+    GuidHob = GetFirstGuidHob (&gMemDebugLogHobGuid);
+    if (GuidHob == NULL) {
+      mMemDebugLogBufAddr = 0;
+    } else {
+      //
+      // Populate the Mem Debug Log Buffer from the HOB
+      //
+      HobData             = (MEM_DEBUG_LOG_HOB_DATA *)GET_GUID_HOB_DATA (GuidHob);
+      mMemDebugLogBufAddr = HobData->MemDebugLogBufAddr;
+    }
+
+    mMemDebugLogBufAddrInit = TRUE;
+  }
+
+  if (mMemDebugLogBufAddr) {
+    Status = MemDebugLogWriteCommon (mMemDebugLogBufAddr, Buffer, Length);
+  } else {
+    Status = EFI_NOT_FOUND;
+  }
+
+  return Status;
+}

--- a/OvmfPkg/Library/MemDebugLogLib/Runtime/MemDebugLogLib.inf
+++ b/OvmfPkg/Library/MemDebugLogLib/Runtime/MemDebugLogLib.inf
@@ -1,0 +1,33 @@
+## @file
+#  Instance of MemDebugLog Library for Runtime
+#
+#  Copyright (C) 2025, Oracle and/or its affiliates.
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = MemDebugLogLib
+  FILE_GUID                      = BE0D0FFD-206C-48F3-9910-C32467567C44
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = MemDebugLogLib|DXE_RUNTIME_DRIVER
+
+
+[Sources]
+  MemDebugLogLib.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  OvmfPkg/OvmfPkg.dec
+
+[LibraryClasses]
+  HobLib
+  MemDebugLogCommonLib
+  UefiRuntimeLib
+
+[Guids]
+  gMemDebugLogHobGuid                      ## CONSUMES

--- a/OvmfPkg/Library/MemDebugLogLib/Sec/MemDebugLogLib.c
+++ b/OvmfPkg/Library/MemDebugLogLib/Sec/MemDebugLogLib.c
@@ -1,0 +1,49 @@
+/** @file
+ *
+  Memory Debug Log Library - SEC Phase
+
+  Copyright (C) 2025, Oracle and/or its affiliates.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <Library/MemDebugLogLib.h>
+#include <Library/MemDebugLogCommonLib.h>
+
+EFI_STATUS
+EFIAPI
+MemDebugLogWrite (
+  IN  CHAR8  *Buffer,
+  IN  UINTN  Length
+  )
+{
+  EFI_STATUS  Status;
+
+  if (FixedPcdGet32 (PcdOvmfEarlyMemDebugLogBase) != 0x0) {
+    Status = MemDebugLogWriteCommon (
+               (EFI_PHYSICAL_ADDRESS)(UINTN)FixedPcdGet32 (PcdOvmfEarlyMemDebugLogBase),
+               Buffer,
+               Length
+               );
+  } else {
+    Status = EFI_NOT_FOUND;
+  }
+
+  return Status;
+}
+
+RETURN_STATUS
+EFIAPI
+MemDebugLogLibConstructor (
+  VOID
+  )
+{
+  if (FixedPcdGet32 (PcdOvmfEarlyMemDebugLogSize) != 0) {
+    MemDebugLogInitCommon (
+      (EFI_PHYSICAL_ADDRESS)(UINTN)FixedPcdGet32 (PcdOvmfEarlyMemDebugLogBase),
+      (UINT32)FixedPcdGet32 (PcdOvmfEarlyMemDebugLogSize)
+      );
+  }
+
+  return RETURN_SUCCESS;
+}

--- a/OvmfPkg/Library/MemDebugLogLib/Sec/MemDebugLogLib.inf
+++ b/OvmfPkg/Library/MemDebugLogLib/Sec/MemDebugLogLib.inf
@@ -1,0 +1,35 @@
+## @file
+#  Instance of MemDebugLog Library for SEC phase
+#
+#  Copyright (C) 2025, Oracle and/or its affiliates.
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = MemDebugLogLib
+  FILE_GUID                      = 9B3A8F82-CBCE-4E3A-A3E0-DBD7172E9506
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = MemDebugLogLib|SEC
+  CONSTRUCTOR                    = MemDebugLogLibConstructor
+
+
+[Sources]
+  MemDebugLogLib.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  OvmfPkg/OvmfPkg.dec
+
+[LibraryClasses]
+  MemDebugLogCommonLib
+
+[FixedPcd]
+  gUefiOvmfPkgTokenSpaceGuid.PcdOvmfEarlyMemDebugLogBase
+  gUefiOvmfPkgTokenSpaceGuid.PcdOvmfEarlyMemDebugLogSize
+
+[Guids]

--- a/OvmfPkg/Library/PlatformDebugLibMem/DebugLib.c
+++ b/OvmfPkg/Library/PlatformDebugLibMem/DebugLib.c
@@ -1,0 +1,350 @@
+/** @file
+  Base Debug library instance for memory debug log.
+
+  Copyright (c) 2006 - 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2012, Red Hat, Inc.<BR>
+  Copyright (C) 2025, Oracle and/or its affiliates.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Base.h>
+#include <Library/DebugLib.h>
+#include <Library/BaseLib.h>
+#include <Library/PrintLib.h>
+#include <Library/PcdLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/DebugPrintErrorLevelLib.h>
+#include <Library/MemDebugLogLib.h>
+
+//
+// Define the maximum debug and assert message length that this library supports
+//
+#define MAX_DEBUG_MESSAGE_LENGTH  0x200
+
+//
+// VA_LIST can not initialize to NULL for all compiler, so we use this to
+// indicate a null VA_LIST
+//
+VA_LIST  mVaListNull;
+
+/**
+  Prints a debug message to the debug output device if the specified error level is enabled.
+
+  If any bit in ErrorLevel is also set in DebugPrintErrorLevelLib function
+  GetDebugPrintErrorLevel (), then print the message specified by Format and the
+  associated variable argument list to the debug output device.
+
+  If Format is NULL, then ASSERT().
+
+  @param  ErrorLevel  The error level of the debug message.
+  @param  Format      Format string for the debug message to print.
+  @param  ...         Variable argument list whose contents are accessed
+                      based on the format string specified by Format.
+
+**/
+VOID
+EFIAPI
+DebugPrint (
+  IN  UINTN        ErrorLevel,
+  IN  CONST CHAR8  *Format,
+  ...
+  )
+{
+  VA_LIST  Marker;
+
+  VA_START (Marker, Format);
+  DebugVPrint (ErrorLevel, Format, Marker);
+  VA_END (Marker);
+}
+
+/**
+  Prints a debug message to the debug output device if the specified
+  error level is enabled base on Null-terminated format string and a
+  VA_LIST argument list or a BASE_LIST argument list.
+
+  If any bit in ErrorLevel is also set in DebugPrintErrorLevelLib function
+  GetDebugPrintErrorLevel (), then print the message specified by Format and
+  the associated variable argument list to the debug output device.
+
+  If Format is NULL, then ASSERT().
+
+  @param  ErrorLevel      The error level of the debug message.
+  @param  Format          Format string for the debug message to print.
+  @param  VaListMarker    VA_LIST marker for the variable argument list.
+  @param  BaseListMarker  BASE_LIST marker for the variable argument list.
+
+**/
+VOID
+DebugPrintMarker (
+  IN  UINTN        ErrorLevel,
+  IN  CONST CHAR8  *Format,
+  IN  VA_LIST      VaListMarker,
+  IN  BASE_LIST    BaseListMarker
+  )
+{
+  CHAR8  Buffer[MAX_DEBUG_MESSAGE_LENGTH];
+  UINTN  Length;
+
+  //
+  // If Format is NULL, then ASSERT().
+  //
+  ASSERT (Format != NULL);
+
+  //
+  // Check if the global mask disables this message
+  //
+  if ((ErrorLevel & GetDebugPrintErrorLevel ()) == 0) {
+    return;
+  }
+
+  //
+  // Convert the DEBUG() message to an ASCII String
+  //
+  if (BaseListMarker == NULL) {
+    Length = AsciiVSPrint (Buffer, sizeof (Buffer), Format, VaListMarker);
+  } else {
+    Length = AsciiBSPrint (Buffer, sizeof (Buffer), Format, BaseListMarker);
+  }
+
+  MemDebugLogWrite (Buffer, Length);
+}
+
+/**
+  Prints a debug message to the debug output device if the specified
+  error level is enabled.
+
+  If any bit in ErrorLevel is also set in DebugPrintErrorLevelLib function
+  GetDebugPrintErrorLevel (), then print the message specified by Format and
+  the associated variable argument list to the debug output device.
+
+  If Format is NULL, then ASSERT().
+
+  @param  ErrorLevel    The error level of the debug message.
+  @param  Format        Format string for the debug message to print.
+  @param  VaListMarker  VA_LIST marker for the variable argument list.
+
+**/
+VOID
+EFIAPI
+DebugVPrint (
+  IN  UINTN        ErrorLevel,
+  IN  CONST CHAR8  *Format,
+  IN  VA_LIST      VaListMarker
+  )
+{
+  DebugPrintMarker (ErrorLevel, Format, VaListMarker, NULL);
+}
+
+/**
+  Prints a debug message to the debug output device if the specified
+  error level is enabled.
+  This function use BASE_LIST which would provide a more compatible
+  service than VA_LIST.
+
+  If any bit in ErrorLevel is also set in DebugPrintErrorLevelLib function
+  GetDebugPrintErrorLevel (), then print the message specified by Format and
+  the associated variable argument list to the debug output device.
+
+  If Format is NULL, then ASSERT().
+
+  @param  ErrorLevel      The error level of the debug message.
+  @param  Format          Format string for the debug message to print.
+  @param  BaseListMarker  BASE_LIST marker for the variable argument list.
+
+**/
+VOID
+EFIAPI
+DebugBPrint (
+  IN  UINTN        ErrorLevel,
+  IN  CONST CHAR8  *Format,
+  IN  BASE_LIST    BaseListMarker
+  )
+{
+  DebugPrintMarker (ErrorLevel, Format, mVaListNull, BaseListMarker);
+}
+
+/**
+  Prints an assert message containing a filename, line number, and description.
+  This may be followed by a breakpoint or a dead loop.
+
+  Print a message of the form "ASSERT <FileName>(<LineNumber>): <Description>\n"
+  to the debug output device.  If DEBUG_PROPERTY_ASSERT_BREAKPOINT_ENABLED bit of
+  PcdDebugProperyMask is set then CpuBreakpoint() is called. Otherwise, if
+  DEBUG_PROPERTY_ASSERT_DEADLOOP_ENABLED bit of PcdDebugProperyMask is set then
+  CpuDeadLoop() is called.  If neither of these bits are set, then this function
+  returns immediately after the message is printed to the debug output device.
+  DebugAssert() must actively prevent recursion.  If DebugAssert() is called while
+  processing another DebugAssert(), then DebugAssert() must return immediately.
+
+  If FileName is NULL, then a <FileName> string of "(NULL) Filename" is printed.
+  If Description is NULL, then a <Description> string of "(NULL) Description" is printed.
+
+  @param  FileName     The pointer to the name of the source file that generated the assert condition.
+  @param  LineNumber   The line number in the source file that generated the assert condition
+  @param  Description  The pointer to the description of the assert condition.
+
+**/
+VOID
+EFIAPI
+DebugAssert (
+  IN CONST CHAR8  *FileName,
+  IN UINTN        LineNumber,
+  IN CONST CHAR8  *Description
+  )
+{
+  CHAR8  Buffer[MAX_DEBUG_MESSAGE_LENGTH];
+  UINTN  Length;
+
+  //
+  // Generate the ASSERT() message in Ascii format
+  //
+  Length = AsciiSPrint (
+             Buffer,
+             sizeof Buffer,
+             "ASSERT %a(%Lu): %a\n",
+             FileName,
+             (UINT64)LineNumber,
+             Description
+             );
+
+  // Send the string to Memory Debug Log
+  MemDebugLogWrite (Buffer, Length);
+
+  //
+  // Generate a Breakpoint, DeadLoop, or NOP based on PCD settings
+  //
+  if ((PcdGet8 (PcdDebugPropertyMask) & DEBUG_PROPERTY_ASSERT_BREAKPOINT_ENABLED) != 0) {
+    CpuBreakpoint ();
+  } else if ((PcdGet8 (PcdDebugPropertyMask) & DEBUG_PROPERTY_ASSERT_DEADLOOP_ENABLED) != 0) {
+    CpuDeadLoop ();
+  }
+}
+
+/**
+  Fills a target buffer with PcdDebugClearMemoryValue, and returns the target buffer.
+
+  This function fills Length bytes of Buffer with the value specified by
+  PcdDebugClearMemoryValue, and returns Buffer.
+
+  If Buffer is NULL, then ASSERT().
+  If Length is greater than (MAX_ADDRESS - Buffer + 1), then ASSERT().
+
+  @param   Buffer  The pointer to the target buffer to be filled with PcdDebugClearMemoryValue.
+  @param   Length  The number of bytes in Buffer to fill with zeros PcdDebugClearMemoryValue.
+
+  @return  Buffer  The pointer to the target buffer filled with PcdDebugClearMemoryValue.
+
+**/
+VOID *
+EFIAPI
+DebugClearMemory (
+  OUT VOID  *Buffer,
+  IN UINTN  Length
+  )
+{
+  //
+  // If Buffer is NULL, then ASSERT().
+  //
+  ASSERT (Buffer != NULL);
+
+  //
+  // SetMem() checks for the ASSERT() condition on Length and returns Buffer
+  //
+  return SetMem (Buffer, Length, PcdGet8 (PcdDebugClearMemoryValue));
+}
+
+/**
+  Returns TRUE if ASSERT() macros are enabled.
+
+  This function returns TRUE if the DEBUG_PROPERTY_DEBUG_ASSERT_ENABLED bit of
+  PcdDebugProperyMask is set.  Otherwise FALSE is returned.
+
+  @retval  TRUE    The DEBUG_PROPERTY_DEBUG_ASSERT_ENABLED bit of PcdDebugProperyMask is set.
+  @retval  FALSE   The DEBUG_PROPERTY_DEBUG_ASSERT_ENABLED bit of PcdDebugProperyMask is clear.
+
+**/
+BOOLEAN
+EFIAPI
+DebugAssertEnabled (
+  VOID
+  )
+{
+  return (BOOLEAN)((PcdGet8 (PcdDebugPropertyMask) & DEBUG_PROPERTY_DEBUG_ASSERT_ENABLED) != 0);
+}
+
+/**
+  Returns TRUE if DEBUG() macros are enabled.
+
+  This function returns TRUE if the DEBUG_PROPERTY_DEBUG_PRINT_ENABLED bit of
+  PcdDebugProperyMask is set.  Otherwise FALSE is returned.
+
+  @retval  TRUE    The DEBUG_PROPERTY_DEBUG_PRINT_ENABLED bit of PcdDebugProperyMask is set.
+  @retval  FALSE   The DEBUG_PROPERTY_DEBUG_PRINT_ENABLED bit of PcdDebugProperyMask is clear.
+
+**/
+BOOLEAN
+EFIAPI
+DebugPrintEnabled (
+  VOID
+  )
+{
+  return (BOOLEAN)((PcdGet8 (PcdDebugPropertyMask) & DEBUG_PROPERTY_DEBUG_PRINT_ENABLED) != 0);
+}
+
+/**
+  Returns TRUE if DEBUG_CODE() macros are enabled.
+
+  This function returns TRUE if the DEBUG_PROPERTY_DEBUG_CODE_ENABLED bit of
+  PcdDebugProperyMask is set.  Otherwise FALSE is returned.
+
+  @retval  TRUE    The DEBUG_PROPERTY_DEBUG_CODE_ENABLED bit of PcdDebugProperyMask is set.
+  @retval  FALSE   The DEBUG_PROPERTY_DEBUG_CODE_ENABLED bit of PcdDebugProperyMask is clear.
+
+**/
+BOOLEAN
+EFIAPI
+DebugCodeEnabled (
+  VOID
+  )
+{
+  return (BOOLEAN)((PcdGet8 (PcdDebugPropertyMask) & DEBUG_PROPERTY_DEBUG_CODE_ENABLED) != 0);
+}
+
+/**
+  Returns TRUE if DEBUG_CLEAR_MEMORY() macro is enabled.
+
+  This function returns TRUE if the DEBUG_PROPERTY_CLEAR_MEMORY_ENABLED bit of
+  PcdDebugProperyMask is set.  Otherwise FALSE is returned.
+
+  @retval  TRUE    The DEBUG_PROPERTY_CLEAR_MEMORY_ENABLED bit of PcdDebugProperyMask is set.
+  @retval  FALSE   The DEBUG_PROPERTY_CLEAR_MEMORY_ENABLED bit of PcdDebugProperyMask is clear.
+
+**/
+BOOLEAN
+EFIAPI
+DebugClearMemoryEnabled (
+  VOID
+  )
+{
+  return (BOOLEAN)((PcdGet8 (PcdDebugPropertyMask) & DEBUG_PROPERTY_CLEAR_MEMORY_ENABLED) != 0);
+}
+
+/**
+  Returns TRUE if any one of the bit is set both in ErrorLevel and PcdFixedDebugPrintErrorLevel.
+
+  This function compares the bit mask of ErrorLevel and PcdFixedDebugPrintErrorLevel.
+
+  @retval  TRUE    Current ErrorLevel is supported.
+  @retval  FALSE   Current ErrorLevel is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+DebugPrintLevelEnabled (
+  IN  CONST UINTN  ErrorLevel
+  )
+{
+  return (BOOLEAN)((ErrorLevel & PcdGet32 (PcdFixedDebugPrintErrorLevel)) != 0);
+}

--- a/OvmfPkg/Library/PlatformDebugLibMem/PlatformDebugLibMem.inf
+++ b/OvmfPkg/Library/PlatformDebugLibMem/PlatformDebugLibMem.inf
@@ -1,0 +1,44 @@
+## @file
+#  Instance of Debug Library for memory debug log.
+#  It uses Print Library to produce formatted output strings.
+#
+#  Copyright (c) 2006 - 2018, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2012, Red Hat, Inc.<BR>
+#  Copyright (C) 2025, Oracle and/or its affiliates.
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = PlatformDebugLibMem
+  FILE_GUID                      = AC6E4C66-7804-4FB2-AF3A-FB6E02461544
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = DebugLib|SEC PEI_CORE PEIM DXE_CORE DXE_DRIVER DXE_RUNTIME_DRIVER SMM_CORE DXE_SMM_DRIVER UEFI_DRIVER UEFI_APPLICATION
+
+#
+#  VALID_ARCHITECTURES           = IA32 X64 EBC
+#
+
+[Sources]
+  DebugLib.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  OvmfPkg/OvmfPkg.dec
+
+[LibraryClasses]
+  BaseMemoryLib
+  PcdLib
+  PrintLib
+  BaseLib
+  DebugPrintErrorLevelLib
+  MemDebugLogLib
+
+[Pcd]
+  gEfiMdePkgTokenSpaceGuid.PcdDebugClearMemoryValue        ## CONSUMES
+  gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask            ## CONSUMES
+  gEfiMdePkgTokenSpaceGuid.PcdFixedDebugPrintErrorLevel    ## CONSUMES

--- a/OvmfPkg/Library/PlatformInitLib/MemDetect.c
+++ b/OvmfPkg/Library/PlatformInitLib/MemDetect.c
@@ -1504,6 +1504,20 @@ PlatformQemuInitializeRamForS3 (
         );
     }
 
+    if (FixedPcdGet32 (PcdOvmfEarlyMemDebugLogSize) != 0) {
+      //
+      // Reserve the Early Memory Debug Log buffer
+      //
+      // Since this memory range will be used on S3 resume, it must be
+      // reserved as ACPI NVS.
+      //
+      BuildMemoryAllocationHob (
+        (EFI_PHYSICAL_ADDRESS)(UINTN)FixedPcdGet32 (PcdOvmfEarlyMemDebugLogBase),
+        (UINT64)(UINTN)FixedPcdGet32 (PcdOvmfEarlyMemDebugLogSize),
+        PlatformInfoHob->S3Supported ? EfiACPIMemoryNVS : EfiBootServicesData
+        );
+    }
+
  #endif
   }
 }

--- a/OvmfPkg/Library/PlatformInitLib/PlatformInitLib.inf
+++ b/OvmfPkg/Library/PlatformInitLib/PlatformInitLib.inf
@@ -107,5 +107,8 @@
   gUefiOvmfPkgTokenSpaceGuid.PcdOvmfFlashNvStorageVariableBase
   gUefiOvmfPkgTokenSpaceGuid.PcdCfvRawDataSize
 
+  gUefiOvmfPkgTokenSpaceGuid.PcdOvmfEarlyMemDebugLogBase
+  gUefiOvmfPkgTokenSpaceGuid.PcdOvmfEarlyMemDebugLogSize
+
 [FeaturePcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdDxeIplSwitchToLongMode

--- a/OvmfPkg/MemDebugLogPei/MemDebugLog.c
+++ b/OvmfPkg/MemDebugLogPei/MemDebugLog.c
@@ -1,0 +1,234 @@
+/** @file
+
+  Memory Debug Log PEIM
+
+  Copyright (C) 2025, Oracle and/or its affiliates.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
+#include <Library/HobLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/PeiServicesLib.h>
+#include <Library/PeimEntryPoint.h>
+#include <Library/PcdLib.h>
+#include <Library/PrintLib.h>
+#include <Library/MemDebugLogCommonLib.h>
+#include <Library/QemuFwCfgSimpleParserLib.h>
+#include <Ppi/MemDebugLog.h>
+
+EFI_STATUS
+EFIAPI
+MemDebugLogPpiWrite (
+  IN  CHAR8  *Buffer,
+  IN  UINTN  Length
+  );
+
+STATIC MEM_DEBUG_LOG_PPI  mMemDebugLogPpiTemplate = {
+  MEM_DEBUG_LOG_PPI_SIGNATURE,
+  MEM_DEBUG_LOG_PPI_VERSION,
+  MemDebugLogPpiWrite
+};
+
+CONST EFI_PEI_PPI_DESCRIPTOR  mMemDebugLogPpiList[] = {
+  {
+    (EFI_PEI_PPI_DESCRIPTOR_PPI | EFI_PEI_PPI_DESCRIPTOR_TERMINATE_LIST),
+    &gMemDebugLogPpiGuid,
+    &mMemDebugLogPpiTemplate
+  }
+};
+
+EFI_STATUS
+EFIAPI
+MemDebugLogMemAvailCB (
+  IN EFI_PEI_SERVICES           **PeiServices,
+  IN EFI_PEI_NOTIFY_DESCRIPTOR  *NotifyDescriptor,
+  IN VOID                       *Ppi
+  );
+
+CONST EFI_PEI_NOTIFY_DESCRIPTOR  mMemAvailNotifyList[] = {
+  {
+    (EFI_PEI_PPI_DESCRIPTOR_NOTIFY_DISPATCH | EFI_PEI_PPI_DESCRIPTOR_TERMINATE_LIST),
+    &gEfiPeiMemoryDiscoveredPpiGuid,
+    MemDebugLogMemAvailCB
+  }
+};
+
+EFI_STATUS
+EFIAPI
+MemDebugLogMemAvailCB (
+  IN EFI_PEI_SERVICES           **PeiServices,
+  IN EFI_PEI_NOTIFY_DESCRIPTOR  *NotifyDescriptor,
+  IN VOID                       *Ppi
+  )
+{
+  UINT32                  FwCfg_MemDebugLogPages;
+  UINT32                  MemDebugLogBufPages;
+  EFI_PHYSICAL_ADDRESS    MemDebugLogBufAddr;
+  EFI_HOB_GUID_TYPE       *GuidHob;
+  MEM_DEBUG_LOG_HOB_DATA  *HobData;
+  EFI_STATUS              Status;
+
+  MemDebugLogBufPages = FixedPcdGet32 (PcdMemDebugLogPages);
+
+  //
+  // Allow FwCfg value to override Pcd.
+  //
+  Status = QemuFwCfgParseUint32 ("opt/ovmf/MemDebugLogPages", TRUE, &FwCfg_MemDebugLogPages);
+  if (Status == EFI_SUCCESS) {
+    MemDebugLogBufPages = FwCfg_MemDebugLogPages;
+  }
+
+  //
+  // Buffer size of 0 disables memory debug logging.
+  //
+  if (!MemDebugLogBufPages) {
+    MemDebugLogBufAddr = 0;
+    Status             = EFI_SUCCESS;
+    goto done;
+  }
+
+  //
+  // Cap max memory debug log size at MAX_MEM_DEBUG_LOG_PAGES
+  //
+  if (MemDebugLogBufPages > MAX_MEM_DEBUG_LOG_PAGES) {
+    DEBUG ((DEBUG_INFO, "%a: Limiting Memory Debug Log buffer to max 0x%x pages\n", __func__, MAX_MEM_DEBUG_LOG_PAGES));
+    MemDebugLogBufPages = MAX_MEM_DEBUG_LOG_PAGES;
+  }
+
+  //
+  // Allocate the memory debug log buffer.
+  // NOTE: We allocate the buffer as type EfiRuntimeServicesData
+  // as this seems to allow the buffer to persist and be
+  // accessible/modifiable throughout runtime (i.e. and avoid
+  // being locked down by the MemoryAttributesTable code).
+  //
+  Status = PeiServicesAllocatePages (
+             EfiRuntimeServicesData,
+             MemDebugLogBufPages,
+             &MemDebugLogBufAddr
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: Failed to allocate Memory Debug Log buffer: %r. Logging disabled\n", __func__, Status));
+    MemDebugLogBufAddr = 0;
+    goto done;
+  }
+
+  //
+  // Init the debug log buffer
+  //
+  Status = MemDebugLogInitCommon (MemDebugLogBufAddr, (UINT32)EFI_PAGES_TO_SIZE ((UINTN)MemDebugLogBufPages));
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: Failed to init Memory Debug Log buffer: %r. Logging disabled\n", __func__, Status));
+    PeiServicesFreePages (MemDebugLogBufAddr, MemDebugLogBufPages);
+    MemDebugLogBufAddr = 0;
+    goto done;
+  }
+
+  //
+  // Copy over the messages from the Early Debug Log buffer.
+  //
+  if (FixedPcdGet32 (PcdOvmfEarlyMemDebugLogBase) != 0) {
+    MemDebugLogCopyCommon (MemDebugLogBufAddr, (EFI_PHYSICAL_ADDRESS)(UINTN)FixedPcdGet32 (PcdOvmfEarlyMemDebugLogBase));
+    //
+    // Invalidate the Early buffer. This prevents any possible DEBUG()
+    // messages from populating until after we create the PPI/HOB below.
+    //
+    MemDebugLogInvalidateCommon ((EFI_PHYSICAL_ADDRESS)(UINTN)FixedPcdGet32 (PcdOvmfEarlyMemDebugLogBase));
+  }
+
+  //
+  // Publish the Mem Debug Log PPI
+  //
+  Status = PeiServicesInstallPpi (mMemDebugLogPpiList);
+  if (EFI_ERROR (Status)) {
+    PeiServicesFreePages (MemDebugLogBufAddr, MemDebugLogBufPages);
+    MemDebugLogBufAddr = 0;
+  }
+
+done:
+  //
+  // Zero the early buffer if we successfully
+  // created the main memory log buffer.
+  //
+  if ((Status == EFI_SUCCESS) && (FixedPcdGet32 (PcdOvmfEarlyMemDebugLogBase) != 0)) {
+    ZeroMem (
+      (VOID *)(UINTN)FixedPcdGet32 (PcdOvmfEarlyMemDebugLogBase),
+      (UINT32)FixedPcdGet32 (PcdOvmfEarlyMemDebugLogSize)
+      );
+  }
+
+  //
+  // Create HOB to pass mem debug log buffer addr
+  //
+  Status = PeiServicesCreateHob (
+             EFI_HOB_TYPE_GUID_EXTENSION,
+             (UINT16)(sizeof (EFI_HOB_GUID_TYPE) + sizeof (MEM_DEBUG_LOG_HOB_DATA)),
+             (VOID **)&GuidHob
+             );
+  if (EFI_ERROR (Status)) {
+    if (MemDebugLogBufAddr) {
+      PeiServicesFreePages (MemDebugLogBufAddr, MemDebugLogBufPages);
+    }
+  } else {
+    //
+    // Populate the HOB
+    //
+    CopyGuid (&GuidHob->Name, &gMemDebugLogHobGuid);
+    HobData                     = (MEM_DEBUG_LOG_HOB_DATA *)GET_GUID_HOB_DATA (GuidHob);
+    HobData->MemDebugLogBufAddr = MemDebugLogBufAddr;
+  }
+
+  return Status;
+}
+
+EFI_STATUS
+EFIAPI
+MemDebugLogPpiWrite (
+  IN  CHAR8  *Buffer,
+  IN  UINTN  Length
+  )
+{
+  EFI_PHYSICAL_ADDRESS    MemDebugLogBufAddr;
+  EFI_HOB_GUID_TYPE       *GuidHob;
+  MEM_DEBUG_LOG_HOB_DATA  *HobData;
+  EFI_STATUS              Status;
+
+  GuidHob = GetFirstGuidHob (&gMemDebugLogHobGuid);
+  if (GuidHob == NULL) {
+    MemDebugLogBufAddr = 0;
+  } else {
+    HobData            = (MEM_DEBUG_LOG_HOB_DATA *)GET_GUID_HOB_DATA (GuidHob);
+    MemDebugLogBufAddr = HobData->MemDebugLogBufAddr;
+  }
+
+  if (MemDebugLogBufAddr) {
+    Status = MemDebugLogWriteCommon (MemDebugLogBufAddr, Buffer, Length);
+  } else {
+    Status = EFI_NOT_FOUND;
+  }
+
+  return Status;
+}
+
+EFI_STATUS
+EFIAPI
+MemDebugLogEntry (
+  IN       EFI_PEI_FILE_HANDLE  FileHandle,
+  IN CONST EFI_PEI_SERVICES     **PeiServices
+  )
+{
+  EFI_STATUS  Status;
+
+  //
+  // Setup callback for memory available notification
+  //
+  Status = PeiServicesNotifyPpi (mMemAvailNotifyList);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: Failed to create MemDebugLog PEIM Callback: %r. Logging disabled\n", __func__, Status));
+  }
+
+  return Status;
+}

--- a/OvmfPkg/MemDebugLogPei/MemDebugLogPei.inf
+++ b/OvmfPkg/MemDebugLogPei/MemDebugLogPei.inf
@@ -1,0 +1,66 @@
+#/** @file
+#
+#  Memory Debug Log PEIM
+#
+#  Copyright (C) 2025, Oracle and/or its affiliates.
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+#**/
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = MemDebugLogPei
+  FILE_GUID                      = 2e501046-26ae-406b-9935-084b61a12e15
+  MODULE_TYPE                    = PEIM
+  VERSION_STRING                 = 1.0
+  ENTRY_POINT                    = MemDebugLogEntry
+
+#
+#  For reference only:
+#  VALID_ARCHITECTURES           = X64
+#
+
+[Sources]
+  MemDebugLog.c
+
+[Packages]
+  MdeModulePkg/MdeModulePkg.dec
+  MdePkg/MdePkg.dec
+  OvmfPkg/OvmfPkg.dec
+
+[LibraryClasses]
+  BaseMemoryLib
+  DebugLib
+  HobLib
+  MemoryAllocationLib
+  PeiServicesLib
+  PeiServicesTablePointerLib
+  PeimEntryPoint
+  PcdLib
+  MemDebugLogCommonLib
+
+[LibraryClasses.Ia32]
+  QemuFwCfgSimpleParserLib
+
+[LibraryClasses.X64]
+  QemuFwCfgSimpleParserLib
+
+[Ppis]
+  gEfiPeiMemoryDiscoveredPpiGuid        ## CONSUMES
+  gMemDebugLogPpiGuid                   ## PRODUCES
+
+[Guids]
+  gMemDebugLogHobGuid
+
+[Pcd]
+
+[FeaturePcd]
+
+[FixedPcd]
+  gUefiOvmfPkgTokenSpaceGuid.PcdMemDebugLogPages          ## CONSUMES
+  gUefiOvmfPkgTokenSpaceGuid.PcdOvmfEarlyMemDebugLogBase  ## CONSUMES
+  gUefiOvmfPkgTokenSpaceGuid.PcdOvmfEarlyMemDebugLogSize  ## CONSUMES
+
+[Depex]
+  TRUE

--- a/OvmfPkg/OvmfPkg.dec
+++ b/OvmfPkg/OvmfPkg.dec
@@ -156,6 +156,14 @@
   #
   CpuMmuInitLib|Include/Library/CpuMmuInitLib.h
 
+  ##  @libraryclass  MemDebugLogLib
+  #
+  MemDebugLogLib|Include/Library/MemDebugLogLib.h
+
+  ##  @libraryclass  MemDebugLogCommonLib
+  #
+  MemDebugLogCommonLib|Include/Library/MemDebugLogCommonLib.h
+
 [Guids]
   gUefiOvmfPkgTokenSpaceGuid            = {0x93bb96af, 0xb9f2, 0x4eb8, {0x94, 0x62, 0xe0, 0xba, 0x74, 0x56, 0x42, 0x36}}
   gEfiXenInfoGuid                       = {0xd3b46f3b, 0xd441, 0x1244, {0x9a, 0x12, 0x0, 0x12, 0x27, 0x3f, 0xc1, 0x4d}}
@@ -179,6 +187,7 @@
   gQemuFirmwareResourceHobGuid          = {0x3cc47b04, 0x0d3e, 0xaa64, {0x06, 0xa6, 0x4b, 0xdc, 0x9a, 0x2c, 0x61, 0x19}}
   gRtcRegisterBaseAddressHobGuid        = {0x40435d97, 0xeb37, 0x4a4b, {0x7f, 0xad, 0xb7, 0xed, 0x72, 0xa1, 0x43, 0xc5}}
   gOvmfFwCfgInfoHobGuid                 = {0xa291ce0e, 0xdc09, 0x11ee, {0x9e, 0xdb, 0x73, 0x49, 0xd7, 0x92, 0xaf, 0x51}}
+  gMemDebugLogHobGuid                   = {0x95305139, 0xb20f, 0x4723, {0x84, 0x25, 0x62, 0x7c, 0x88, 0x8f, 0xf1, 0x21}}
 
 [Ppis]
   # PPI whose presence in the PPI database signals that the TPM base address
@@ -191,6 +200,7 @@
 
   gEfiPeiMpInitLibMpDepPpiGuid          = {0x138f9cf4, 0xf0e7, 0x4721, { 0x8f, 0x49, 0xf5, 0xff, 0xec, 0xf4, 0x2d, 0x40}}
   gEfiPeiMpInitLibUpDepPpiGuid          = {0xb590774, 0xbc67, 0x49f4, { 0xa7, 0xdb, 0xe8, 0x2e, 0x89, 0xe6, 0xb5, 0xd6}}
+  gMemDebugLogPpiGuid                   = {0xc924e4da, 0x2638, 0x43cc, {0xb8, 0x5b, 0x18, 0x47, 0x17, 0x82, 0x13, 0xce}}
 
 [Protocols]
   gVirtioDeviceProtocolGuid             = {0xfa920010, 0x6785, 0x4941, {0xb6, 0xec, 0x49, 0x8c, 0x57, 0x9f, 0x16, 0x0a}}
@@ -363,6 +373,13 @@
   gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSecSvsmCaaBase|0|UINT32|0x70
   gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSecSvsmCaaSize|0|UINT32|0x71
 
+  ## The base address and size of the early memory debug log used in SEC
+  #  and early PEI phases - i.e. prior to memory being initialized.
+  #  If this is set in the .fdf, the platform is responsible to
+  #  reserve this area from DXE phase overwrites.
+  gUefiOvmfPkgTokenSpaceGuid.PcdOvmfEarlyMemDebugLogBase|0|UINT32|0x7a
+  gUefiOvmfPkgTokenSpaceGuid.PcdOvmfEarlyMemDebugLogSize|0|UINT32|0x7b
+
 [PcdsDynamic, PcdsDynamicEx]
   gUefiOvmfPkgTokenSpaceGuid.PcdEmuVariableEvent|0|UINT64|2
   gUefiOvmfPkgTokenSpaceGuid.PcdOvmfFlashVariablesEnable|FALSE|BOOLEAN|0x10
@@ -442,6 +459,12 @@
   # invoking the OS loader. This may be needed to work around problematic
   # builds of shim that use the protocol incorrectly.
   gUefiOvmfPkgTokenSpaceGuid.PcdUninstallMemAttrProtocol|FALSE|BOOLEAN|0x67
+
+  ##
+  # Default size of the memory DEBUG log buffer (in pages).
+  # The buffer is circular. So, if size is exceeded, older
+  # messages will be overwritten by more recent messages.
+  gUefiOvmfPkgTokenSpaceGuid.PcdMemDebugLogPages|32|UINT32|0x7c
 
 [PcdsFeatureFlag]
   gUefiOvmfPkgTokenSpaceGuid.PcdQemuBootOrderPciTranslation|TRUE|BOOLEAN|0x1c

--- a/OvmfPkg/OvmfPkgIa32X64.dsc
+++ b/OvmfPkg/OvmfPkgIa32X64.dsc
@@ -251,12 +251,19 @@
   TdxLib|MdePkg/Library/TdxLib/TdxLib.inf
   TdxMailboxLib|OvmfPkg/Library/TdxMailboxLib/TdxMailboxLibNull.inf
   TdxHelperLib|OvmfPkg/IntelTdx/TdxHelperLib/TdxHelperLibNull.inf
+!if $(DEBUG_TO_MEM)
+  MemDebugLogCommonLib|OvmfPkg/Library/MemDebugLogCommonLib/MemDebugLogCommonLib.inf
+  MemDebugLogLib|OvmfPkg/Library/MemDebugLogLib/Dxe/MemDebugLogLib.inf
+!endif
 
 [LibraryClasses.common.SEC]
   TimerLib|OvmfPkg/Library/AcpiTimerLib/BaseRomAcpiTimerLib.inf
   QemuFwCfgLib|OvmfPkg/Library/QemuFwCfgLib/QemuFwCfgSecLib.inf
 !ifdef $(DEBUG_ON_SERIAL_PORT)
   DebugLib|MdePkg/Library/BaseDebugLibSerialPort/BaseDebugLibSerialPort.inf
+!elseif $(DEBUG_TO_MEM)
+  DebugLib|OvmfPkg/Library/PlatformDebugLibMem/PlatformDebugLibMem.inf
+  MemDebugLogLib|OvmfPkg/Library/MemDebugLogLib/Sec/MemDebugLogLib.inf
 !else
   DebugLib|OvmfPkg/Library/PlatformDebugLibIoPort/PlatformRomDebugLibIoPort.inf
 !endif
@@ -283,6 +290,9 @@
   PeCoffGetEntryPointLib|MdePkg/Library/BasePeCoffGetEntryPointLib/BasePeCoffGetEntryPointLib.inf
 !ifdef $(DEBUG_ON_SERIAL_PORT)
   DebugLib|MdePkg/Library/BaseDebugLibSerialPort/BaseDebugLibSerialPort.inf
+!elseif $(DEBUG_TO_MEM)
+  DebugLib|OvmfPkg/Library/PlatformDebugLibMem/PlatformDebugLibMem.inf
+  MemDebugLogLib|OvmfPkg/Library/MemDebugLogLib/Pei/MemDebugLogLib.inf
 !else
   DebugLib|OvmfPkg/Library/PlatformDebugLibIoPort/PlatformRomDebugLibIoPort.inf
 !endif
@@ -299,6 +309,9 @@
   PeCoffGetEntryPointLib|MdePkg/Library/BasePeCoffGetEntryPointLib/BasePeCoffGetEntryPointLib.inf
 !ifdef $(DEBUG_ON_SERIAL_PORT)
   DebugLib|MdePkg/Library/BaseDebugLibSerialPort/BaseDebugLibSerialPort.inf
+!elseif $(DEBUG_TO_MEM)
+  DebugLib|OvmfPkg/Library/PlatformDebugLibMem/PlatformDebugLibMem.inf
+  MemDebugLogLib|OvmfPkg/Library/MemDebugLogLib/Pei/MemDebugLogLib.inf
 !else
   DebugLib|OvmfPkg/Library/PlatformDebugLibIoPort/PlatformRomDebugLibIoPort.inf
 !endif
@@ -324,6 +337,8 @@
   ReportStatusCodeLib|MdeModulePkg/Library/DxeReportStatusCodeLib/DxeReportStatusCodeLib.inf
 !ifdef $(DEBUG_ON_SERIAL_PORT)
   DebugLib|MdePkg/Library/BaseDebugLibSerialPort/BaseDebugLibSerialPort.inf
+!elseif $(DEBUG_TO_MEM)
+  DebugLib|OvmfPkg/Library/PlatformDebugLibMem/PlatformDebugLibMem.inf
 !else
   DebugLib|OvmfPkg/Library/PlatformDebugLibIoPort/PlatformDebugLibIoPort.inf
 !endif
@@ -344,6 +359,9 @@
   ReportStatusCodeLib|MdeModulePkg/Library/RuntimeDxeReportStatusCodeLib/RuntimeDxeReportStatusCodeLib.inf
 !ifdef $(DEBUG_ON_SERIAL_PORT)
   DebugLib|MdePkg/Library/BaseDebugLibSerialPort/BaseDebugLibSerialPort.inf
+!elseif $(DEBUG_TO_MEM)
+  DebugLib|OvmfPkg/Library/PlatformDebugLibMem/PlatformDebugLibMem.inf
+  MemDebugLogLib|OvmfPkg/Library/MemDebugLogLib/Runtime/MemDebugLogLib.inf
 !else
   DebugLib|OvmfPkg/Library/PlatformDebugLibIoPort/PlatformDebugLibIoPort.inf
 !endif
@@ -366,6 +384,8 @@
   ReportStatusCodeLib|MdeModulePkg/Library/DxeReportStatusCodeLib/DxeReportStatusCodeLib.inf
 !ifdef $(DEBUG_ON_SERIAL_PORT)
   DebugLib|MdePkg/Library/BaseDebugLibSerialPort/BaseDebugLibSerialPort.inf
+!elseif $(DEBUG_TO_MEM)
+  DebugLib|OvmfPkg/Library/PlatformDebugLibMem/PlatformDebugLibMem.inf
 !else
   DebugLib|OvmfPkg/Library/PlatformDebugLibIoPort/PlatformDebugLibIoPort.inf
 !endif
@@ -383,6 +403,8 @@
   UefiScsiLib|MdePkg/Library/UefiScsiLib/UefiScsiLib.inf
 !ifdef $(DEBUG_ON_SERIAL_PORT)
   DebugLib|MdePkg/Library/BaseDebugLibSerialPort/BaseDebugLibSerialPort.inf
+!elseif $(DEBUG_TO_MEM)
+  DebugLib|OvmfPkg/Library/PlatformDebugLibMem/PlatformDebugLibMem.inf
 !else
   DebugLib|OvmfPkg/Library/PlatformDebugLibIoPort/PlatformDebugLibIoPort.inf
 !endif
@@ -414,6 +436,8 @@
   ReportStatusCodeLib|MdeModulePkg/Library/DxeReportStatusCodeLib/DxeReportStatusCodeLib.inf
 !ifdef $(DEBUG_ON_SERIAL_PORT)
   DebugLib|MdePkg/Library/BaseDebugLibSerialPort/BaseDebugLibSerialPort.inf
+!elseif $(DEBUG_TO_MEM)
+  DebugLib|OvmfPkg/Library/PlatformDebugLibMem/PlatformDebugLibMem.inf
 !else
   DebugLib|OvmfPkg/Library/PlatformDebugLibIoPort/PlatformDebugLibIoPort.inf
 !endif
@@ -431,6 +455,8 @@
   SmmServicesTableLib|MdePkg/Library/SmmServicesTableLib/SmmServicesTableLib.inf
 !ifdef $(DEBUG_ON_SERIAL_PORT)
   DebugLib|MdePkg/Library/BaseDebugLibSerialPort/BaseDebugLibSerialPort.inf
+!elseif $(DEBUG_TO_MEM)
+  DebugLib|OvmfPkg/Library/PlatformDebugLibMem/PlatformDebugLibMem.inf
 !else
   DebugLib|OvmfPkg/Library/PlatformDebugLibIoPort/PlatformDebugLibIoPort.inf
 !endif
@@ -455,6 +481,8 @@
   SmmServicesTableLib|MdeModulePkg/Library/PiSmmCoreSmmServicesTableLib/PiSmmCoreSmmServicesTableLib.inf
 !ifdef $(DEBUG_ON_SERIAL_PORT)
   DebugLib|MdePkg/Library/BaseDebugLibSerialPort/BaseDebugLibSerialPort.inf
+!elseif $(DEBUG_TO_MEM)
+  DebugLib|OvmfPkg/Library/PlatformDebugLibMem/PlatformDebugLibMem.inf
 !else
   DebugLib|OvmfPkg/Library/PlatformDebugLibIoPort/PlatformDebugLibIoPort.inf
 !endif
@@ -691,6 +719,9 @@
   # PEI Phase modules
   #
   MdeModulePkg/Core/Pei/PeiMain.inf
+!if $(DEBUG_TO_MEM)
+  OvmfPkg/MemDebugLogPei/MemDebugLogPei.inf
+!endif
   MdeModulePkg/Universal/PCD/Pei/Pcd.inf  {
     <LibraryClasses>
       PcdLib|MdePkg/Library/BasePcdLibNull/BasePcdLibNull.inf
@@ -737,6 +768,9 @@
   MdeModulePkg/Universal/PCD/Dxe/Pcd.inf  {
    <LibraryClasses>
       PcdLib|MdePkg/Library/BasePcdLibNull/BasePcdLibNull.inf
+!if $(DEBUG_TO_MEM)
+      MemDebugLogLib|OvmfPkg/Library/MemDebugLogLib/Null/MemDebugLogLib.inf
+!endif
   }
 
   MdeModulePkg/Core/RuntimeDxe/RuntimeDxe.inf
@@ -814,6 +848,9 @@
     <LibraryClasses>
       DevicePathLib|MdePkg/Library/UefiDevicePathLib/UefiDevicePathLib.inf
       PcdLib|MdePkg/Library/BasePcdLibNull/BasePcdLibNull.inf
+!if $(DEBUG_TO_MEM)
+      MemDebugLogLib|OvmfPkg/Library/MemDebugLogLib/Null/MemDebugLogLib.inf
+!endif
   }
   MdeModulePkg/Universal/Disk/DiskIoDxe/DiskIoDxe.inf
   MdeModulePkg/Universal/Disk/PartitionDxe/PartitionDxe.inf

--- a/OvmfPkg/OvmfPkgIa32X64.fdf
+++ b/OvmfPkg/OvmfPkgIa32X64.fdf
@@ -82,9 +82,12 @@ gUefiOvmfPkgTokenSpaceGuid.PcdOvmfWorkAreaBase|gUefiOvmfPkgTokenSpaceGuid.PcdOvm
 0x010000|0x010000
 gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSecPeiTempRamBase|gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSecPeiTempRamSize
 
-0x020000|0x0E0000
+0x020000|0x0D0000
 gUefiOvmfPkgTokenSpaceGuid.PcdOvmfPeiMemFvBase|gUefiOvmfPkgTokenSpaceGuid.PcdOvmfPeiMemFvSize
 FV = PEIFV
+
+0x0F0000|0x10000
+gUefiOvmfPkgTokenSpaceGuid.PcdOvmfEarlyMemDebugLogBase|gUefiOvmfPkgTokenSpaceGuid.PcdOvmfEarlyMemDebugLogSize
 
 0x100000|0xE80000
 gUefiOvmfPkgTokenSpaceGuid.PcdOvmfDxeMemFvBase|gUefiOvmfPkgTokenSpaceGuid.PcdOvmfDxeMemFvSize
@@ -152,6 +155,9 @@ READ_LOCK_CAP      = TRUE
 READ_LOCK_STATUS   = TRUE
 
 APRIORI PEI {
+!if $(DEBUG_TO_MEM)
+  INF  OvmfPkg/MemDebugLogPei/MemDebugLogPei.inf
+!endif
   INF  MdeModulePkg/Universal/PCD/Pei/Pcd.inf
 }
 
@@ -162,6 +168,9 @@ INF  MdeModulePkg/Core/Pei/PeiMain.inf
 INF  MdeModulePkg/Universal/PCD/Pei/Pcd.inf
 INF  MdeModulePkg/Universal/ReportStatusCodeRouter/Pei/ReportStatusCodeRouterPei.inf
 INF  MdeModulePkg/Universal/StatusCodeHandler/Pei/StatusCodeHandlerPei.inf
+!if $(DEBUG_TO_MEM)
+INF  OvmfPkg/MemDebugLogPei/MemDebugLogPei.inf
+!endif
 INF  OvmfPkg/PlatformPei/PlatformPei.inf
 INF  MdeModulePkg/Core/DxeIplPeim/DxeIpl.inf
 INF  UefiCpuPkg/Universal/Acpi/S3Resume2Pei/S3Resume2Pei.inf

--- a/OvmfPkg/OvmfPkgX64.dsc
+++ b/OvmfPkg/OvmfPkgX64.dsc
@@ -266,12 +266,19 @@
   CcExitLib|OvmfPkg/Library/CcExitLib/CcExitLib.inf
   TdxLib|MdePkg/Library/TdxLib/TdxLib.inf
   TdxMailboxLib|OvmfPkg/Library/TdxMailboxLib/TdxMailboxLib.inf
+!if $(DEBUG_TO_MEM)
+  MemDebugLogCommonLib|OvmfPkg/Library/MemDebugLogCommonLib/MemDebugLogCommonLib.inf
+  MemDebugLogLib|OvmfPkg/Library/MemDebugLogLib/Dxe/MemDebugLogLib.inf
+!endif
 
 [LibraryClasses.common.SEC]
   TimerLib|OvmfPkg/Library/AcpiTimerLib/BaseRomAcpiTimerLib.inf
   QemuFwCfgLib|OvmfPkg/Library/QemuFwCfgLib/QemuFwCfgSecLib.inf
 !ifdef $(DEBUG_ON_SERIAL_PORT)
   DebugLib|MdePkg/Library/BaseDebugLibSerialPort/BaseDebugLibSerialPort.inf
+!elseif $(DEBUG_TO_MEM)
+  DebugLib|OvmfPkg/Library/PlatformDebugLibMem/PlatformDebugLibMem.inf
+  MemDebugLogLib|OvmfPkg/Library/MemDebugLogLib/Sec/MemDebugLogLib.inf
 !else
   DebugLib|OvmfPkg/Library/PlatformDebugLibIoPort/PlatformRomDebugLibIoPort.inf
 !endif
@@ -301,6 +308,9 @@
   PeCoffGetEntryPointLib|MdePkg/Library/BasePeCoffGetEntryPointLib/BasePeCoffGetEntryPointLib.inf
 !ifdef $(DEBUG_ON_SERIAL_PORT)
   DebugLib|MdePkg/Library/BaseDebugLibSerialPort/BaseDebugLibSerialPort.inf
+!elseif $(DEBUG_TO_MEM)
+  DebugLib|OvmfPkg/Library/PlatformDebugLibMem/PlatformDebugLibMem.inf
+  MemDebugLogLib|OvmfPkg/Library/MemDebugLogLib/Pei/MemDebugLogLib.inf
 !else
   DebugLib|OvmfPkg/Library/PlatformDebugLibIoPort/PlatformRomDebugLibIoPort.inf
 !endif
@@ -318,6 +328,9 @@
   PeCoffGetEntryPointLib|MdePkg/Library/BasePeCoffGetEntryPointLib/BasePeCoffGetEntryPointLib.inf
 !ifdef $(DEBUG_ON_SERIAL_PORT)
   DebugLib|MdePkg/Library/BaseDebugLibSerialPort/BaseDebugLibSerialPort.inf
+!elseif $(DEBUG_TO_MEM)
+  DebugLib|OvmfPkg/Library/PlatformDebugLibMem/PlatformDebugLibMem.inf
+  MemDebugLogLib|OvmfPkg/Library/MemDebugLogLib/Pei/MemDebugLogLib.inf
 !else
   DebugLib|OvmfPkg/Library/PlatformDebugLibIoPort/PlatformRomDebugLibIoPort.inf
 !endif
@@ -347,6 +360,8 @@
   ReportStatusCodeLib|MdeModulePkg/Library/DxeReportStatusCodeLib/DxeReportStatusCodeLib.inf
 !ifdef $(DEBUG_ON_SERIAL_PORT)
   DebugLib|MdePkg/Library/BaseDebugLibSerialPort/BaseDebugLibSerialPort.inf
+!elseif $(DEBUG_TO_MEM)
+  DebugLib|OvmfPkg/Library/PlatformDebugLibMem/PlatformDebugLibMem.inf
 !else
   DebugLib|OvmfPkg/Library/PlatformDebugLibIoPort/PlatformDebugLibIoPort.inf
 !endif
@@ -367,6 +382,9 @@
   ReportStatusCodeLib|MdeModulePkg/Library/RuntimeDxeReportStatusCodeLib/RuntimeDxeReportStatusCodeLib.inf
 !ifdef $(DEBUG_ON_SERIAL_PORT)
   DebugLib|MdePkg/Library/BaseDebugLibSerialPort/BaseDebugLibSerialPort.inf
+!elseif $(DEBUG_TO_MEM)
+  DebugLib|OvmfPkg/Library/PlatformDebugLibMem/PlatformDebugLibMem.inf
+  MemDebugLogLib|OvmfPkg/Library/MemDebugLogLib/Runtime/MemDebugLogLib.inf
 !else
   DebugLib|OvmfPkg/Library/PlatformDebugLibIoPort/PlatformDebugLibIoPort.inf
 !endif
@@ -389,6 +407,8 @@
   ReportStatusCodeLib|MdeModulePkg/Library/DxeReportStatusCodeLib/DxeReportStatusCodeLib.inf
 !ifdef $(DEBUG_ON_SERIAL_PORT)
   DebugLib|MdePkg/Library/BaseDebugLibSerialPort/BaseDebugLibSerialPort.inf
+!elseif $(DEBUG_TO_MEM)
+  DebugLib|OvmfPkg/Library/PlatformDebugLibMem/PlatformDebugLibMem.inf
 !else
   DebugLib|OvmfPkg/Library/PlatformDebugLibIoPort/PlatformDebugLibIoPort.inf
 !endif
@@ -406,6 +426,8 @@
   UefiScsiLib|MdePkg/Library/UefiScsiLib/UefiScsiLib.inf
 !ifdef $(DEBUG_ON_SERIAL_PORT)
   DebugLib|MdePkg/Library/BaseDebugLibSerialPort/BaseDebugLibSerialPort.inf
+!elseif $(DEBUG_TO_MEM)
+  DebugLib|OvmfPkg/Library/PlatformDebugLibMem/PlatformDebugLibMem.inf
 !else
   DebugLib|OvmfPkg/Library/PlatformDebugLibIoPort/PlatformDebugLibIoPort.inf
 !endif
@@ -438,6 +460,8 @@
   ReportStatusCodeLib|MdeModulePkg/Library/DxeReportStatusCodeLib/DxeReportStatusCodeLib.inf
 !ifdef $(DEBUG_ON_SERIAL_PORT)
   DebugLib|MdePkg/Library/BaseDebugLibSerialPort/BaseDebugLibSerialPort.inf
+!elseif $(DEBUG_TO_MEM)
+  DebugLib|OvmfPkg/Library/PlatformDebugLibMem/PlatformDebugLibMem.inf
 !else
   DebugLib|OvmfPkg/Library/PlatformDebugLibIoPort/PlatformDebugLibIoPort.inf
 !endif
@@ -455,6 +479,8 @@
   SmmServicesTableLib|MdePkg/Library/SmmServicesTableLib/SmmServicesTableLib.inf
 !ifdef $(DEBUG_ON_SERIAL_PORT)
   DebugLib|MdePkg/Library/BaseDebugLibSerialPort/BaseDebugLibSerialPort.inf
+!elseif $(DEBUG_TO_MEM)
+  DebugLib|OvmfPkg/Library/PlatformDebugLibMem/PlatformDebugLibMem.inf
 !else
   DebugLib|OvmfPkg/Library/PlatformDebugLibIoPort/PlatformDebugLibIoPort.inf
 !endif
@@ -478,6 +504,8 @@
   SmmServicesTableLib|MdeModulePkg/Library/PiSmmCoreSmmServicesTableLib/PiSmmCoreSmmServicesTableLib.inf
 !ifdef $(DEBUG_ON_SERIAL_PORT)
   DebugLib|MdePkg/Library/BaseDebugLibSerialPort/BaseDebugLibSerialPort.inf
+!elseif $(DEBUG_TO_MEM)
+  DebugLib|OvmfPkg/Library/PlatformDebugLibMem/PlatformDebugLibMem.inf
 !else
   DebugLib|OvmfPkg/Library/PlatformDebugLibIoPort/PlatformDebugLibIoPort.inf
 !endif
@@ -716,6 +744,9 @@
   # PEI Phase modules
   #
   MdeModulePkg/Core/Pei/PeiMain.inf
+!if $(DEBUG_TO_MEM)
+  OvmfPkg/MemDebugLogPei/MemDebugLogPei.inf
+!endif
   MdeModulePkg/Universal/PCD/Pei/Pcd.inf  {
     <LibraryClasses>
       PcdLib|MdePkg/Library/BasePcdLibNull/BasePcdLibNull.inf
@@ -790,6 +821,9 @@
   MdeModulePkg/Universal/PCD/Dxe/Pcd.inf  {
    <LibraryClasses>
       PcdLib|MdePkg/Library/BasePcdLibNull/BasePcdLibNull.inf
+!if $(DEBUG_TO_MEM)
+      MemDebugLogLib|OvmfPkg/Library/MemDebugLogLib/Null/MemDebugLogLib.inf
+!endif
   }
 
   MdeModulePkg/Core/RuntimeDxe/RuntimeDxe.inf
@@ -890,6 +924,9 @@
     <LibraryClasses>
       DevicePathLib|MdePkg/Library/UefiDevicePathLib/UefiDevicePathLib.inf
       PcdLib|MdePkg/Library/BasePcdLibNull/BasePcdLibNull.inf
+!if $(DEBUG_TO_MEM)
+      MemDebugLogLib|OvmfPkg/Library/MemDebugLogLib/Null/MemDebugLogLib.inf
+!endif
   }
   MdeModulePkg/Universal/Disk/DiskIoDxe/DiskIoDxe.inf
   MdeModulePkg/Universal/Disk/PartitionDxe/PartitionDxe.inf

--- a/OvmfPkg/OvmfPkgX64.fdf
+++ b/OvmfPkg/OvmfPkgX64.fdf
@@ -103,9 +103,12 @@ gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSecApicPageTableBase|gUefiOvmfPkgTokenSpaceGui
 0x011000|0x00F000
 gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSecPeiTempRamBase|gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSecPeiTempRamSize
 
-0x020000|0x0E0000
+0x020000|0x0D0000
 gUefiOvmfPkgTokenSpaceGuid.PcdOvmfPeiMemFvBase|gUefiOvmfPkgTokenSpaceGuid.PcdOvmfPeiMemFvSize
 FV = PEIFV
+
+0x0F0000|0x10000
+gUefiOvmfPkgTokenSpaceGuid.PcdOvmfEarlyMemDebugLogBase|gUefiOvmfPkgTokenSpaceGuid.PcdOvmfEarlyMemDebugLogSize
 
 0x100000|0xE80000
 gUefiOvmfPkgTokenSpaceGuid.PcdOvmfDxeMemFvBase|gUefiOvmfPkgTokenSpaceGuid.PcdOvmfDxeMemFvSize
@@ -173,6 +176,9 @@ READ_LOCK_CAP      = TRUE
 READ_LOCK_STATUS   = TRUE
 
 APRIORI PEI {
+!if $(DEBUG_TO_MEM)
+  INF  OvmfPkg/MemDebugLogPei/MemDebugLogPei.inf
+!endif
   INF  MdeModulePkg/Universal/PCD/Pei/Pcd.inf
 }
 
@@ -183,6 +189,9 @@ INF  MdeModulePkg/Core/Pei/PeiMain.inf
 INF  MdeModulePkg/Universal/PCD/Pei/Pcd.inf
 INF  MdeModulePkg/Universal/ReportStatusCodeRouter/Pei/ReportStatusCodeRouterPei.inf
 INF  MdeModulePkg/Universal/StatusCodeHandler/Pei/StatusCodeHandlerPei.inf
+!if $(DEBUG_TO_MEM)
+INF  OvmfPkg/MemDebugLogPei/MemDebugLogPei.inf
+!endif
 !if $(CC_MEASUREMENT_ENABLE) == TRUE
   INF  OvmfPkg/Tcg/TdTcg2Pei/TdTcg2Pei.inf
 !endif


### PR DESCRIPTION
# Description

OVMF Memory Debug Logging Support

Overview:

This PR adds support to log OVMF debug messages to a memory buffer. The memory buffer can be extracted from a VM's QEMU process (or a core file) to debug issues.

Background:

OVMF currently offers 2 methods to collect debug messages - via the "debug IO port" (logged by QEMU to a host disk file) and via the serial port (-D DEBUG_ON_SERIAL_PORT). Both of these methods are impractical under normal VM operation. They increase VM boot time, clutter the serial port, and use host disk resources. In contrast, logging the debug messages to memory is fast and takes no disk resources allowing it to be enabled by default for customer environments. This allows for "first-time" issue analysis, negating the need to reproduce issues with debug messages enabled, which makes for a much better customer experience should an issue occur.

Code Overview:

The code introduces 3 new libraries:

  * OvmfPkg/Library/PlatformDebugLibMem: New DebugLib class library which logs debug messages to memory. This library was derived from PlatformDebugLibIoPort - simply altered to pass the debug message to MemDebugLogWrite() instead of writing the debug message to the debug IO port.
   
  * OvmfPkg/Library/MemDebugLogCommonLib: Library to manage access to the memory debug log circular buffer.
    
  * OvmfPkg/Library/MemDebugLogLib: Library which implements the key MemDebugLogWrite() function (called by PlatformDebugLibMem). There is a different implementation of this library for the various boot phases/module types (i.e. SEC, PEIM, DXE, Runtime). See more detail below.

The code also introduces a new PEIM:

  * OvmfPkg/MemDebugLogPei: When memory becomes available, this PEIM allocates the main memory debug log buffer and installs a PPI containing a function to write to the main memory buffer.

A bit of complication arises from the the fact that main memory is not available until the PEI phase and several debug messages are logged before then. To remedy this, the code makes use of a "early" memory buffer (taken from PeiMemFvBase) which is used to log the initial (pre-memory) messages. Once memory becomes available, the PEIM code allocates the main memory debug log buffer, copies the messages from the early buffer and then switches to use the main memory buffer (by installing a PPI/HOB).

Thus, the SEC version of MemDebugLogLib writes debug messages to the "early" debug log buffer. The PEIM version of MemDebugLogLib also writes initial messages to the early buffer until the MemDebugLogPei PPI is installed. Once the PPI is installed the PEI version of MemDebugLogLib switches to use the PPI. The DXE and runtime versions of the MemDebugLogLib write to the main memory debug log buffer (obtaining the address of the buffer via a HOB). The runtime version of MemDebugLogLib (used by DXE_RUNTIME_DRIVER type drivers) will allow debug writes until the OS makes the SetVirtualAddressMap() BS call.

All calls to MemDebugLogWrite() eventually end up calling MemDebugLogWriteCommon() (from MemDebugLogCommonLib) - which handles the details of maintaining the circular debug log buffer and header (with head/tail pointers, etc.). Since it is theoretically possible for multiple vcpus to attempt to write debug messages simultaneously (during vcpu init), the library uses a spinlock to protect the critical sections when accessing the buffer.

The feature (i.e. the new libraries and PEIM) are disabled by default and are enabled via the new "DEBUG_TO_MEM" build flag (which can be enabled on the build command line - similar to DEBUG_ON_SERIAL_PORT).

Notes:

  The debug log memory buffer size can be configured via FwCfg and is circular - i.e. only the most recent debug messages are retained if the memory buffer overflows. This is appropriate as typically only the most recent debug messages are relevant when debugging an issue. The code currently defaults to a 32 page (128K) sized memory debug log buffer (the default is configured via a PCD).

  A host-side tool/utility can be easily implemented to search the VM's QEMU memory regions to locate the OVMF memory debug log buffer (located on a page boundary), decipher the buffer header and display the circular buffer contents (debug messages). We (Oracle) already have such a utility which can extract the OVMF memory debug log from a live QEMU process or a QEMU core file.
    
  This feature doesn't work with Confidential Computing VMs as the guest memory is encrypted and thus not readable from the host. A future enhancement could possibly be made to mark the OVMF memory debug log buffer as unencrypted (?) TBD
    
  This PR only covers OVMF (x86_64) but was written to be easily extended to AAVMF (Arm) in a future PR. TBD



- [x] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

OVMF builds for both OvmfPkgIa32X64.dsc and OvmfPkgX64.dsc (both with and without -D DEBUG_TO_MEM) were built/tested and the OVMF Memory Debug Log extracted from the VM's QEMU process (by a custom utility) and assessed for correctness.

## Integration Instructions

N/A
