### PR TITLE
ArmVirt: move Defines section to new include file

### DIFF
--- a/ArmVirtPkg/ArmVirt.dsc.inc
+++ b/ArmVirtPkg/ArmVirt.dsc.inc
@@ -8,38 +8,6 @@
 #
 #
 
-[Defines]
-
-  #
-  # Shell can be useful for debugging but should not be enabled for production
-  #
-  DEFINE BUILD_SHELL             = TRUE
-
-  DEFINE DEBUG_PRINT_ERROR_LEVEL = 0x8000004F
-
-# Dynamic stack cookies pushes the FD size up slightly over 2MB
-!if $(TARGET) != NOOPT && $(ARCH) == ARM
-  DEFINE FD_SIZE_IN_MB    = 2
-!else
-  DEFINE FD_SIZE_IN_MB    = 3
-!endif
-
-!if $(FD_SIZE_IN_MB) == 2
-  DEFINE FD_SIZE          = 0x200000
-  DEFINE FD_NUM_BLOCKS    = 0x200
-!endif
-!if $(FD_SIZE_IN_MB) == 3
-  DEFINE FD_SIZE          = 0x300000
-  DEFINE FD_NUM_BLOCKS    = 0x300
-!endif
-
-# Dynamic stack cookies are not supported on ARM
-!if $(ARCH) == ARM
-  DEFINE CUSTOM_STACK_CHECK_LIB = STATIC
-!else
-  DEFINE CUSTOM_STACK_CHECK_LIB = DYNAMIC
-!endif
-
 [BuildOptions.common.EDKII.DXE_CORE,BuildOptions.common.EDKII.DXE_DRIVER,BuildOptions.common.EDKII.UEFI_DRIVER,BuildOptions.common.EDKII.UEFI_APPLICATION]
   GCC:*_*_*_DLINK_FLAGS = -z common-page-size=0x1000
 

--- a/ArmVirtPkg/ArmVirtCloudHv.dsc
+++ b/ArmVirtPkg/ArmVirtCloudHv.dsc
@@ -29,7 +29,7 @@
   DEFINE SECURE_BOOT_ENABLE      = FALSE
 
 # This comes before MdeLibs to ensure stack cookie configuration is chosen
-!include ArmVirtPkg/ArmVirt.dsc.inc
+!include ArmVirtPkg/ArmVirtDefines.dsc.inc
 
 [LibraryClasses.common]
   ArmLib|ArmPkg/Library/ArmLib/ArmBaseLib.inf
@@ -59,6 +59,7 @@
   TpmPlatformHierarchyLib|SecurityPkg/Library/PeiDxeTpmPlatformHierarchyLibNull/PeiDxeTpmPlatformHierarchyLib.inf
 
 !include MdePkg/MdeLibs.dsc.inc
+!include ArmVirtPkg/ArmVirt.dsc.inc
 
 [LibraryClasses.common.PEIM]
   ArmVirtMemInfoLib|ArmVirtPkg/Library/CloudHvVirtMemInfoLib/CloudHvVirtMemInfoPeiLib.inf

--- a/ArmVirtPkg/ArmVirtDefines.dsc.inc
+++ b/ArmVirtPkg/ArmVirtDefines.dsc.inc
@@ -1,0 +1,35 @@
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+
+[Defines]
+
+  #
+  # Shell can be useful for debugging but should not be enabled for production
+  #
+  DEFINE BUILD_SHELL             = TRUE
+
+  DEFINE DEBUG_PRINT_ERROR_LEVEL = 0x8000004F
+
+# Dynamic stack cookies pushes the FD size up slightly over 2MB
+!if $(TARGET) != NOOPT && $(ARCH) == ARM
+  DEFINE FD_SIZE_IN_MB    = 2
+!else
+  DEFINE FD_SIZE_IN_MB    = 3
+!endif
+
+!if $(FD_SIZE_IN_MB) == 2
+  DEFINE FD_SIZE          = 0x200000
+  DEFINE FD_NUM_BLOCKS    = 0x200
+!endif
+!if $(FD_SIZE_IN_MB) == 3
+  DEFINE FD_SIZE          = 0x300000
+  DEFINE FD_NUM_BLOCKS    = 0x300
+!endif
+
+# Dynamic stack cookies are not supported on ARM
+!if $(ARCH) == ARM
+  DEFINE CUSTOM_STACK_CHECK_LIB = STATIC
+!else
+  DEFINE CUSTOM_STACK_CHECK_LIB = DYNAMIC
+!endif

--- a/ArmVirtPkg/ArmVirtKvmTool.dsc
+++ b/ArmVirtPkg/ArmVirtKvmTool.dsc
@@ -32,13 +32,14 @@
 
 
 # This comes before MdeLibs to ensure stack cookie configuration is chosen
-!include ArmVirtPkg/ArmVirt.dsc.inc
+!include ArmVirtPkg/ArmVirtDefines.dsc.inc
 
 !if $(ARCH) == AARCH64
 !include DynamicTablesPkg/DynamicTables.dsc.inc
 !endif
 
 !include MdePkg/MdeLibs.dsc.inc
+!include ArmVirtPkg/ArmVirt.dsc.inc
 
 [LibraryClasses.common]
   ArmLib|ArmPkg/Library/ArmLib/ArmBaseLib.inf

--- a/ArmVirtPkg/ArmVirtQemu.dsc
+++ b/ArmVirtPkg/ArmVirtQemu.dsc
@@ -52,9 +52,10 @@
 !include NetworkPkg/NetworkDefines.dsc.inc
 
 # This comes before MdeLibs to ensure stack cookie configuration is chosen
-!include ArmVirtPkg/ArmVirt.dsc.inc
+!include ArmVirtPkg/ArmVirtDefines.dsc.inc
 
 !include MdePkg/MdeLibs.dsc.inc
+!include ArmVirtPkg/ArmVirt.dsc.inc
 
 [LibraryClasses.common]
   ArmLib|ArmPkg/Library/ArmLib/ArmBaseLib.inf

--- a/ArmVirtPkg/ArmVirtQemuKernel.dsc
+++ b/ArmVirtPkg/ArmVirtQemuKernel.dsc
@@ -49,9 +49,10 @@
 !include NetworkPkg/NetworkDefines.dsc.inc
 
 # This comes before MdeLibs to ensure stack cookie configuration is chosen
-!include ArmVirtPkg/ArmVirt.dsc.inc
+!include ArmVirtPkg/ArmVirtDefines.dsc.inc
 
 !include MdePkg/MdeLibs.dsc.inc
+!include ArmVirtPkg/ArmVirt.dsc.inc
 
 [LibraryClasses.common]
   ArmLib|ArmPkg/Library/ArmLib/ArmBaseLib.inf

--- a/ArmVirtPkg/ArmVirtXen.dsc
+++ b/ArmVirtPkg/ArmVirtXen.dsc
@@ -24,9 +24,10 @@
   FLASH_DEFINITION               = ArmVirtPkg/ArmVirtXen.fdf
 
 # This comes before MdeLibs to ensure stack cookie configuration is chosen
-!include ArmVirtPkg/ArmVirt.dsc.inc
+!include ArmVirtPkg/ArmVirtDefines.dsc.inc
 
 !include MdePkg/MdeLibs.dsc.inc
+!include ArmVirtPkg/ArmVirt.dsc.inc
 
 [LibraryClasses]
   SerialPortLib|OvmfPkg/Library/XenConsoleSerialPortLib/XenConsoleSerialPortLib.inf


### PR DESCRIPTION
    The [Defines] section must be processed before including MdeLibs.dsc.inc
    so the correct stack cookie library can be picked.
    
    The other sections (especially [LibraryClasses]) should be processed
    afterwards so ArmVirt.dsc.inc can override the defaults choosen by
    MdeLibs.dsc.inc.
    
    Implement that by splitting the ArmVirt.dsc.inc include file into two,
    with the new file carrying the [Defines] section.
