### PR TITLE
ArmPlatformPkg: Restore LzmaDecompressLib to PeilessSec

### DIFF
--- a/ArmPlatformPkg/ArmPlatformPkg.dsc
+++ b/ArmPlatformPkg/ArmPlatformPkg.dsc
@@ -49,6 +49,7 @@
   IoLib|MdePkg/Library/BaseIoLibIntrinsic/BaseIoLibIntrinsic.inf
   LcdHwLib|ArmPlatformPkg/Library/LcdHwNullLib/LcdHwNullLib.inf
   LcdPlatformLib|ArmPlatformPkg/Library/LcdPlatformNullLib/LcdPlatformNullLib.inf
+  LzmaDecompressLib|MdeModulePkg/Library/LzmaCustomDecompressLib/LzmaCustomDecompressLib.inf
   MemoryAllocationLib|MdePkg/Library/UefiMemoryAllocationLib/UefiMemoryAllocationLib.inf
   MemoryInitPeiLib|ArmPlatformPkg/MemoryInitPei/MemoryInitPeiLib.inf
   PcdLib|MdePkg/Library/BasePcdLibNull/BasePcdLibNull.inf

--- a/ArmPlatformPkg/PeilessSec/PeilessSec.inf
+++ b/ArmPlatformPkg/PeilessSec/PeilessSec.inf
@@ -43,6 +43,7 @@
   DebugAgentLib
   DebugLib
   HobLib
+  LzmaDecompressLib
   MemoryInitPeiLib
   PerformanceLib
   PlatformPeiLib


### PR DESCRIPTION
# Description

PeilessSec was created when PrePiUniCore was deprecated in these two commits:
[91117d70d89fbef4d7cac2d57854fa613716ca4d](https://github.com/tianocore/edk2/commit/91117d70d89fbef4d7cac2d57854fa613716ca4d) and
[5749b70b5a892e1cf0f2bfa37865a552ba8f96e5](https://github.com/tianocore/edk2/commit/5749b70b5a892e1cf0f2bfa37865a552ba8f96e5)

However, when PrePiUniCore was copied, it dropped LzmaDecompressLib from the library class list in the inf. This breaks platforms using this INF, as they are structured to have PeilessSec.inf in an FV with an LZMA compressed FV that contains DxeMain.inf, which is then executed next. Without LzmaDecompressLib's constructor run, no guided section extract handlers are registered for these sections and executes halts in SEC with an ASSERT.

This patch adds LzmaDecompressLib back to PeilessSec.inf and ArmPlatformPkg's DSC. With this change, platforms using PeilessSec.inf can boot again.

I also confirmed that this is not needed in ArmPlatformPkg/Sec/Sec.inf.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Tested on a platform using PeilessSec.inf that was formerly using PrePiUniCore.inf that was failing to boot. Boot now succeeds.

## Integration Instructions

N/A.
