### PR TITLE
ArmPkg/ArmScmiDxe: Avoid 64-bit access from compiler optimization

### DIFF
--- a/ArmPkg/Drivers/ArmScmiDxe/ArmScmiClockProtocolPrivate.h
+++ b/ArmPkg/Drivers/ArmScmiDxe/ArmScmiClockProtocolPrivate.h
@@ -16,8 +16,8 @@
 
 // Clock rate in two 32bit words.
 typedef struct {
-  UINT32    Low;
-  UINT32    High;
+  volatile UINT32    Low;
+  volatile UINT32    High;
 } CLOCK_RATE_DWORD;
 
 // Format of the returned rate array. Linear or Non-linear,.RatesFlag Bit[12]


### PR DESCRIPTION
In ScmiClockProtocol.c, the ClockRateSet function contains the following assignments:
    ClockRateSetAttributes->Rate.Low  = (UINT32)Rate;
    ClockRateSetAttributes->Rate.High = (UINT32)(Rate >> 32);

In some cases, the compiler may optimize these two 32-bit accesses into a single 64-bit access. This behavior is problematic when the SCMI message payload only supports 32-bit accesses, leading to hardware faults.

This patch ensures the compiler performs two distinct 32-bit writes, preventing unsafe 64-bit memory access.