### PR TITLE
NetworkPkg:  Add PCD for HTTP transfer buffer size

### DIFF
--- a/NetworkPkg/HttpDxe/HttpDriver.h
+++ b/NetworkPkg/HttpDxe/HttpDriver.h
@@ -3,6 +3,7 @@
 
   Copyright (c) 2015 - 2021, Intel Corporation. All rights reserved.<BR>
   (C) Copyright 2016 Hewlett Packard Enterprise Development LP<BR>
+  (c) Copyright 2025 HP Development Company, L.P.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -27,6 +28,7 @@
 #include <Library/HttpLib.h>
 #include <Library/DpcLib.h>
 #include <Library/PrintLib.h>
+#include <Library/PcdLib.h>
 
 //
 // UEFI Driver Model Protocols

--- a/NetworkPkg/HttpDxe/HttpDxe.inf
+++ b/NetworkPkg/HttpDxe/HttpDxe.inf
@@ -2,6 +2,7 @@
 #  Implementation of EFI HTTP protocol interfaces.
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation. All rights reserved.<BR>
+# (c) Copyright 2025 HP Development Company, L.P.
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -48,6 +49,7 @@
   HttpLib
   DpcLib
   PrintLib
+  PcdLib
 
 [Protocols]
   gEfiHttpServiceBindingProtocolGuid               ## BY_START
@@ -78,6 +80,7 @@
   gEfiNetworkPkgTokenSpaceGuid.PcdHttpIoTimeout              ## CONSUMES
   gEfiNetworkPkgTokenSpaceGuid.PcdHttpDnsRetryInterval       ## CONSUMES
   gEfiNetworkPkgTokenSpaceGuid.PcdHttpDnsRetryCount          ## CONSUMES
+  gEfiNetworkPkgTokenSpaceGuid.PcdHttpTransferBufferSize     ## CONSUMES
 
 [UserExtensions.TianoCore."ExtraFiles"]
   HttpDxeExtra.uni

--- a/NetworkPkg/HttpDxe/HttpProto.c
+++ b/NetworkPkg/HttpDxe/HttpProto.c
@@ -4,6 +4,7 @@
 Copyright (c) 2015, Intel Corporation. All rights reserved.<BR>
 (C) Copyright 2016 Hewlett Packard Enterprise Development LP<BR>
 Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.<BR>
+(c) Copyright 2025 HP Development Company, L.P.
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -1090,8 +1091,8 @@ HttpConfigureTcp4 (
   IP4_COPY_ADDRESS (&Tcp4AP->RemoteAddress, &HttpInstance->RemoteAddr);
 
   Tcp4Option                      = Tcp4CfgData->ControlOption;
-  Tcp4Option->ReceiveBufferSize   = HTTP_BUFFER_SIZE_DEAULT;
-  Tcp4Option->SendBufferSize      = HTTP_BUFFER_SIZE_DEAULT;
+  Tcp4Option->ReceiveBufferSize   = PcdGet32 (PcdHttpTransferBufferSize);
+  Tcp4Option->SendBufferSize      = PcdGet32 (PcdHttpTransferBufferSize);
   Tcp4Option->MaxSynBackLog       = HTTP_MAX_SYN_BACK_LOG;
   Tcp4Option->ConnectionTimeout   = HTTP_CONNECTION_TIMEOUT;
   Tcp4Option->DataRetries         = HTTP_DATA_RETRIES;
@@ -1174,8 +1175,8 @@ HttpConfigureTcp6 (
   IP6_COPY_ADDRESS (&Tcp6Ap->RemoteAddress, &HttpInstance->RemoteIpv6Addr);
 
   Tcp6Option                      = Tcp6CfgData->ControlOption;
-  Tcp6Option->ReceiveBufferSize   = HTTP_BUFFER_SIZE_DEAULT;
-  Tcp6Option->SendBufferSize      = HTTP_BUFFER_SIZE_DEAULT;
+  Tcp6Option->ReceiveBufferSize   = PcdGet32 (PcdHttpTransferBufferSize);
+  Tcp6Option->SendBufferSize      = PcdGet32 (PcdHttpTransferBufferSize);
   Tcp6Option->MaxSynBackLog       = HTTP_MAX_SYN_BACK_LOG;
   Tcp6Option->ConnectionTimeout   = HTTP_CONNECTION_TIMEOUT;
   Tcp6Option->DataRetries         = HTTP_DATA_RETRIES;

--- a/NetworkPkg/HttpDxe/HttpProto.h
+++ b/NetworkPkg/HttpDxe/HttpProto.h
@@ -4,6 +4,7 @@
 Copyright (c) 2015, Intel Corporation. All rights reserved.<BR>
 (C) Copyright 2016 Hewlett Packard Enterprise Development LP<BR>
 Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.<BR>
+(c) Copyright 2025 HP Development Company, L.P.
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -38,7 +39,6 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 //
 #define HTTP_TOS_DEAULT           8
 #define HTTP_TTL_DEAULT           255
-#define HTTP_BUFFER_SIZE_DEAULT   0x200000
 #define HTTP_MAX_SYN_BACK_LOG     5
 #define HTTP_CONNECTION_TIMEOUT   60
 #define HTTP_DATA_RETRIES         12

--- a/NetworkPkg/NetworkPkg.dec
+++ b/NetworkPkg/NetworkPkg.dec
@@ -6,6 +6,7 @@
 # Copyright (c) 2009 - 2021, Intel Corporation. All rights reserved.<BR>
 # (C) Copyright 2015-2020 Hewlett Packard Enterprise Development LP<BR>
 # Copyright (c) Microsoft Corporation
+# (c) Copyright 2025 HP Development Company, L.P.
 #
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -185,6 +186,12 @@
   ## The Retry Count of HTTP DNS if no DNS response received after Retry Interval.
   # @Prompt The value of Retry Count,  Default value is 0.
   gEfiNetworkPkgTokenSpaceGuid.PcdHttpDnsRetryCount|0|UINT32|0x00000011
+
+  ## The default size of the HTTP transfer data buffer in bytes.
+  # This size is used for HTTP transfers, with a default value of 2MB.
+  # Increasing the buffer size can enhance performance for high-bandwidth connections.
+  # However, reducing the buffer size can reduce packet loss in low-bandwidth scenarios.
+  gEfiNetworkPkgTokenSpaceGuid.PcdHttpTransferBufferSize|0x200000|UINT32|0x00000014
 
 [UserExtensions.TianoCore."ExtraFiles"]
   NetworkPkgExtra.uni

--- a/NetworkPkg/NetworkPkg.uni
+++ b/NetworkPkg/NetworkPkg.uni
@@ -4,6 +4,7 @@
 // This package provides network modules that conform to UEFI 2.4 specification.
 //
 // Copyright (c) 2009 - 2021, Intel Corporation. All rights reserved.<BR>
+// (c) Copyright 2025 HP Development Company, L.P.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -122,3 +123,10 @@
 
 #string STR_gEfiNetworkPkgTokenSpaceGuid_PcdHttpDnsRetryCount_HELP  #language en-US "This value is used to configure the Retry Count of HTTP DNS if "
                                                                                 "no DNS response received after Retry Interval. The default value set is 0."
+
+#string STR_gEfiNetworkPkgTokenSpaceGuid_PcdHttpTransferBufferSize_PROMPT  #language en-US "HTTP default transfer buffer size"
+
+#string STR_gEfiNetworkPkgTokenSpaceGuid_PcdHttpTransferBufferSize_HELP  #language en-US "This value is used to configure the default transfer buffer size for HTTP."
+                                                                                     "The default value set is 2MB. Larger buffer sizes can improve performance "
+                                                                                     "for high-bandwidth connections. However, smaller buffer size can reduce packet loss "
+                                                                                     "in low-bandwidth scenarios."


### PR DESCRIPTION
# Description

Current HTTP transfer size have a default value of 2M. 
This PCD change allows the platform code to change the transfer buffer size.
Based on the network bandwidth, the buffer size can be adjusted to improve performance.
Large buffer size provides better performance in high-bandwidth connections.
However, small buffer size helps to reduce packet loss in low-bandwidth scenarios.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Verified basic HTTP file download still works.

## Integration Instructions

N/A
