### PR TITLE
OvmfPkg/CcExitLib: Use the proper register when filtering MSRs

### DIFF
--- a/OvmfPkg/Library/CcExitLib/CcExitVcHandler.c
+++ b/OvmfPkg/Library/CcExitLib/CcExitVcHandler.c
@@ -701,6 +701,7 @@ MsrExit (
   MSR_SVSM_CAA_REGISTER  Msr;
   UINT64                 ExitInfo1;
   UINT64                 Status;
+  UINT32                 EcxIn;
 
   ExitInfo1 = 0;
 
@@ -708,7 +709,8 @@ MsrExit (
   // The SVSM CAA MSR is a software implemented MSR and not supported
   // by the hardware, handle it directly.
   //
-  if (Regs->Rax == MSR_SVSM_CAA) {
+  EcxIn = (UINT32)(UINTN)Regs->Rcx;
+  if (EcxIn == MSR_SVSM_CAA) {
     // Writes to the SVSM CAA MSR are ignored
     if (*(InstructionData->OpCodes + 1) == 0x30) {
       return 0;


### PR DESCRIPTION
# Description

The MsrExit() routine uses an incorrect register to check for the CAA MSR. Instead of checking RCX, the input register for RDMSR/WRMSR that holds the MSR value, it is checking RAX, which results in failure to detect the CAA MSR request. The check should only be checking the lower 32-bits of the register (ECX), too.

Change the check in MsrExit() to check the MSR value contained in ECX.

Fixes: 47001ab98914 ("Ovmfpkg/CcExitLib: Provide SVSM discovery support")

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Tested by invoke RDMSR for the 0xC001F000 MSR and verifying proper operation.

## Integration Instructions

N/A
