### PR TITLE
Mde/MdeModule: Extend incompatible Pci Devcies to account for OptionRoms.

### DIFF
--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciEnumerator.c
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciEnumerator.c
@@ -300,10 +300,13 @@ ProcessOptionRom (
     }
 
     if ((Temp->RomSize != 0) && (Temp->RomSize <= MaxLength)) {
-      //
-      // Load and process the option rom
-      //
-      LoadOpRomImage (Temp, RomBase);
+      if (!Temp->IgnoreROM) {
+        DEBUG ((DEBUG_INFO, "Loading option rom from device at BDF=%u/%u/%u\n", Temp->BusNumber, Temp->DeviceNumber, Temp->FunctionNumber));
+        //
+        // Load and process the option rom
+        //
+        LoadOpRomImage (Temp, RomBase);
+      }
     }
 
     CurrentLink = CurrentLink->ForwardLink;

--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciEnumeratorSupport.c
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciEnumeratorSupport.c
@@ -1392,6 +1392,12 @@ UpdatePciInfo (
       continue;
     }
 
+    if (Ptr->ResType == INCOMPATIBLE_ACPI_ADDRESS_SPACE_TYPE_ROM) {
+      PciIoDevice->IgnoreROM = TRUE;
+      Ptr++;
+      continue;
+    }
+
     for (BarIndex = 0; BarIndex < PCI_MAX_BAR; BarIndex++) {
       if ((Ptr->AddrTranslationOffset != MAX_UINT64) &&
           (Ptr->AddrTranslationOffset != MAX_UINT8) &&

--- a/MdePkg/Include/Protocol/IncompatiblePciDeviceSupport.h
+++ b/MdePkg/Include/Protocol/IncompatiblePciDeviceSupport.h
@@ -29,7 +29,7 @@
   devices still depends on the implementation of the PCI bus driver. The PCI bus
   driver may fully, partially, or not even support these incompatible devices.
 
-  During PCI bus enumeration, the PCI bus driver will probe the PCI Base Address
+  During PCI bus enumeration, the PCI bus driver will probe the PCI Base Addressa
   Registers (BARs) for each PCI device regardless of whether the PCI device is
   incompatible or not to determine the resource requirements so that the PCI bus
   driver can invoke the proper PCI resources for them.  Generally, this resource
@@ -77,6 +77,15 @@
   { \
     0xeb23f55a, 0x7863, 0x4ac2, {0x8d, 0x3d, 0x95, 0x65, 0x35, 0xde, 0x03, 0x75} \
   }
+
+///
+/// Extension to Acpi10.h for describing the ROM BAR as the incompatible BAR.
+///
+/// Specifying the ROM bar as incompatible indicates to the PciBusDxe driver to
+/// ignore the ROM BAR altogether.  Currently, ACPI only defines 0x01-0x03 for
+/// MEM, IO, BUS.
+///
+#define INCOMPATIBLE_ACPI_ADDRESS_SPACE_TYPE_ROM  0x0F
 
 ///
 /// Forward declaration for EFI_INCOMPATIBLE_PCI_DEVICE_SUPPORT_PROTOCOL


### PR DESCRIPTION
# Description
The existing incompatible PciDeviceSupport allows for addressing BARs that are incompatible.
Extend the support to allow for reporting that a device's OptionRom is incompatible as well.


- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested
Ran on a platform using a [gEfiIncompatiblePciDeviceSupportProtocolGuid](https://github.com/microsoft/mu_plus/blob/1d5fda37f1b83265a3aebb1e629127301b420417/MsCorePkg/IncompatiblePciDevices/NoOptionRomsAllowed/NoOptionRomsAllowed.inf) which prevented any option roms from executing. 

## Integration Instructions
Platforms will have the capability of installing their own instance of gEfiIncompatiblePciDeviceSupportProtocolGuid which reports that a device option rom is not able to be supported. 
