### PR TITLE
MdeModulePkg: Enable PciBus to handle CRS responses by ignoring the device.

### DIFF
--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciEnumeratorSupport.c
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciEnumeratorSupport.c
@@ -59,19 +59,30 @@ PciDevicePresent (
                                   Pci
                                   );
 
-  if (!EFI_ERROR (Status) && ((Pci->Hdr).VendorId != 0xffff)) {
-    //
-    // Read the entire config header for the device
-    //
-    Status = PciRootBridgeIo->Pci.Read (
-                                    PciRootBridgeIo,
-                                    EfiPciWidthUint32,
-                                    Address,
-                                    sizeof (PCI_TYPE00) / sizeof (UINT32),
-                                    Pci
-                                    );
+  //
+  // The host bridge may be programmed to accept Configuration Retry Status (CRS).  If the PCI device
+  // is slow, and CRS is enabled, the VendorId may read as 0x0001 when not ready.
+  // This value is assigned to the PCI-SIG for this, and other purposes.
+  // PCI EXPRESS BASE SPECIFICATION, REV. 3.1 section 2.3.1.
+  // Skip the device, as all the other data read will be invalid.
+  //
+  if (!EFI_ERROR (Status)) {
+    if (((Pci->Hdr).VendorId != 0xffff) && ((Pci->Hdr).VendorId != 0x0001)) {
+      //
+      // Read the entire config header for the device
+      //
+      Status = PciRootBridgeIo->Pci.Read (
+                                      PciRootBridgeIo,
+                                      EfiPciWidthUint32,
+                                      Address,
+                                      sizeof (PCI_TYPE00) / sizeof (UINT32),
+                                      Pci
+                                      );
 
-    return EFI_SUCCESS;
+      return EFI_SUCCESS;
+    } else if ((Pci->Hdr).VendorId == 0x0001) {
+      DEBUG ((DEBUG_WARN, "CRS response detected.  Devices that return a CRS response during enumeration are currently ignored\n"));
+    }
   }
 
   return EFI_NOT_FOUND;


### PR DESCRIPTION
# Description

If there is a slow device on the PCI Bus, and the HostBridge is programmed to allow CRS, the slow device may return 0x0001 to inform the config space reader of the Vendor Id that pci device is not ready. The current PciBus enumerator will treat 0001 as a valid Vendor Id, but it is not. It indicates that all other config space is invalid. This code changes that operation to skip slow devices.

PCI EXPRESS BASE SPECIFICATION, REV. 3.1 section
2.3.1 Request Handling Rules.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested
Verified that with change platforms without CRS still boot. 

## Integration Instructions
No integration necessary.