### PR TITLE
Ovmf memory debug logging3

### DIFF
--- a/OvmfPkg/AmdSev/AmdSevX64.dsc
+++ b/OvmfPkg/AmdSev/AmdSevX64.dsc
@@ -211,6 +211,7 @@
   TdxLib|MdePkg/Library/TdxLib/TdxLib.inf
   TdxMailboxLib|OvmfPkg/Library/TdxMailboxLib/TdxMailboxLibNull.inf
   TdxHelperLib|OvmfPkg/IntelTdx/TdxHelperLib/TdxHelperLibNull.inf
+  MemDebugLogLib|OvmfPkg/Library/MemDebugLogLib/MemDebugLogLibNull.inf
 
 [LibraryClasses.common.SEC]
   TimerLib|OvmfPkg/Library/AcpiTimerLib/BaseRomAcpiTimerLib.inf

--- a/OvmfPkg/Bhyve/BhyveX64.dsc
+++ b/OvmfPkg/Bhyve/BhyveX64.dsc
@@ -243,6 +243,7 @@
   BaseCryptLib|CryptoPkg/Library/BaseCryptLib/BaseCryptLib.inf
   CcExitLib|UefiCpuPkg/Library/CcExitLibNull/CcExitLibNull.inf
   TdxLib|MdePkg/Library/TdxLib/TdxLib.inf
+  MemDebugLogLib|OvmfPkg/Library/MemDebugLogLib/MemDebugLogLibNull.inf
 
 [LibraryClasses.common.SEC]
 !ifdef $(DEBUG_ON_SERIAL_PORT)

--- a/OvmfPkg/CloudHv/CloudHvX64.dsc
+++ b/OvmfPkg/CloudHv/CloudHvX64.dsc
@@ -258,6 +258,7 @@
   TdxLib|MdePkg/Library/TdxLib/TdxLib.inf
   TdxMailboxLib|OvmfPkg/Library/TdxMailboxLib/TdxMailboxLibNull.inf
   TdxHelperLib|OvmfPkg/IntelTdx/TdxHelperLib/TdxHelperLibNull.inf
+  MemDebugLogLib|OvmfPkg/Library/MemDebugLogLib/MemDebugLogLibNull.inf
 
 [LibraryClasses.common.SEC]
   TimerLib|OvmfPkg/Library/AcpiTimerLib/BaseRomAcpiTimerLib.inf

--- a/OvmfPkg/Include/Library/MemDebugLogLib.h
+++ b/OvmfPkg/Include/Library/MemDebugLogLib.h
@@ -1,0 +1,181 @@
+/** @file
+  Interface functions for the Memory Debug Log Library.
+
+  Copyright (C) 2025, Oracle and/or its affiliates.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef _MEM_DEBUG_LOG_LIB_H_
+#define _MEM_DEBUG_LOG_LIB_H_
+
+#include <Uefi/UefiBaseType.h>
+#include <Base.h>
+
+//
+// Cap max buffer at 4MB (0x400 4K pages)
+//
+#define MAX_MEM_DEBUG_LOG_PAGES  0x400
+
+#define MEM_DEBUG_LOG_MAGIC  0x6c67646d666d766f  // "ovmfmdgl"
+
+#pragma pack(1)
+//
+// Mem Debug Log buffer header.
+// The Log buffer is circular. Only the most
+// recent messages are retained. Older messages
+// will be discarded if the buffer overflows.
+// The Debug Log starts just after the header.
+//
+typedef struct {
+  //
+  // Magic value used by tools to locate the buffer in memory
+  // This MUST be the first field of the structure.
+  UINT64             Magic;
+  //
+  // Header Size
+  // This MUST be the second field of the structure
+  //
+  UINT64             HeaderSize;
+  //
+  // Debug log size (minus header)
+  //
+  UINT64             DebugLogSize;
+  //
+  // Protect the log from potential MP access (by APs during
+  // vCPU init) to maintain integrity of the Head/Tail Offsets.
+  //
+  volatile UINT64    MemDebugLogLock;
+  //
+  // Debug log head offset
+  //
+  UINT64             DebugLogHeadOffset;
+  //
+  //  Debug log tail offset
+  //
+  UINT64             DebugLogTailOffset;
+  //
+  // Flag to indicate if the buffer wrapped and was thus truncated.
+  //
+  UINT64             Truncated;
+  //
+  // Firmware Build Version (PcdFirmwareVersionString)
+  //
+  CHAR8              FirmwareVersion[128];
+} MEM_DEBUG_LOG_HDR;
+
+//
+// HOB used to pass the mem debug log buffer addr from PEI to DXE
+//
+typedef struct {
+  EFI_PHYSICAL_ADDRESS    MemDebugLogBufAddr;
+} MEM_DEBUG_LOG_HOB_DATA;
+
+#pragma pack()
+
+/**
+  Write a CHAR8 string to the memory debug log.
+  This is the interface function used by DebugLib.
+  There are several versions for each boot
+  phase (i.e. SEC, PEI, DXE, Runtime).
+  Each version will obtain the proper memory debug log
+  buffer address and call MemDebugLogWriteBuffer().
+
+  @param[in] Buffer              The buffer containing the string of CHAR8s
+
+  @param[in] Length              The buffer length (number of CHAR8s)
+                                 not including the NULL terminator byte.
+
+  @retval RETURN_SUCCESS         String succcessfully written to the memory log buffer.
+
+  @retval RETURN_NOT_FOUND       Memory log buffer is not properly initialized.
+
+  @retval EFI_INVALID_PARAMETER   Invalid input parameters.
+**/
+EFI_STATUS
+EFIAPI
+MemDebugLogWrite (
+  IN  CHAR8  *Buffer,
+  IN  UINTN  Length
+  );
+
+/**
+  Write a CHAR8 string to a memory debug log circular
+  buffer located at the given address.
+
+  @param MemDebugLogBufAddr       Address of the memory debug log buffer.
+
+  @param Buffer                   Pointer to a CHAR8 string to write to the
+                                  debug log buffer.
+
+  @param Length                   Length of the CHAR8 string to write to the
+                                  debug log buffer. Not including NULL terminator
+                                  byte.
+
+  @retval RETURN_SUCCESS          String succcessfully written to the memory log buffer.
+
+  @retval RETURN_NOT_FOUND        Memory log buffer is not properly initialized.
+
+  @retval EFI_INVALID_PARAMETER   Invalid input parameters.
+**/
+EFI_STATUS
+EFIAPI
+MemDebugLogWriteBuffer (
+  IN EFI_PHYSICAL_ADDRESS  MemDebugLogBufAddr,
+  IN CHAR8                 *Buffer,
+  IN UINTN                 Length
+  );
+
+/**
+  Initialize the memory debug log buffer header
+
+  @param MemDebugLogBufAddr       Address of the memory debug log buffer.
+
+  @param MemDebugLogBufSize       Size of the memory debug log buffer.
+
+  @retval RETURN_SUCCESS          Log buffer successfully initialized.
+
+  @retval EFI_INVALID_PARAMETER   Invalid input parameters.
+**/
+EFI_STATUS
+EFIAPI
+MemDebugLogInit (
+  IN EFI_PHYSICAL_ADDRESS  MemDebugLogBufAddr,
+  UINT32                   MemDebugLogBufSize
+  );
+
+/**
+  Copy the memory debug log buffer
+
+  @param MemDebugLogBufDestAddr   Address of destination memory debug log buffer.
+
+  @param MemDebugLogBufSrcAddr    Address of source memory debug log buffer.
+
+  @retval RETURN_SUCCESS          Log buffer successfuly copied.
+
+  @retval EFI_INVALID_PARAMETER   Invalid input parameters.
+**/
+EFI_STATUS
+EFIAPI
+MemDebugLogCopy (
+  IN EFI_PHYSICAL_ADDRESS  MemDebugLogBufDestAddr,
+  IN EFI_PHYSICAL_ADDRESS  MemDebugLogBufSrcAddr
+  );
+
+/**
+  Invalidate the memory debug log buffer
+
+  @param MemDebugLogBufAddr       Address of the memory debug log buffer.
+
+  @retval RETURN_SUCCESS          Log buffer successfuly invalidated.
+
+  @retval EFI_INVALID_PARAMETER   Invalid input parameters.
+**/
+EFI_STATUS
+EFIAPI
+MemDebugLogInvalidate (
+  IN EFI_PHYSICAL_ADDRESS  MemDebugLogBufAddr
+  );
+
+
+#endif // _MEM_DEBUG_LOG_LIB_H_

--- a/OvmfPkg/IntelTdx/IntelTdxX64.dsc
+++ b/OvmfPkg/IntelTdx/IntelTdxX64.dsc
@@ -218,6 +218,7 @@
   TdxLib|MdePkg/Library/TdxLib/TdxLib.inf
   TdxMailboxLib|OvmfPkg/Library/TdxMailboxLib/TdxMailboxLib.inf
   PlatformInitLib|OvmfPkg/Library/PlatformInitLib/PlatformInitLib.inf
+  MemDebugLogLib|OvmfPkg/Library/MemDebugLogLib/MemDebugLogLibNull.inf
 
 [LibraryClasses.common.SEC]
   TimerLib|OvmfPkg/Library/AcpiTimerLib/BaseRomAcpiTimerLib.inf

--- a/OvmfPkg/Library/MemDebugLogLib/MemDebugLogCommon.c
+++ b/OvmfPkg/Library/MemDebugLogLib/MemDebugLogCommon.c
@@ -1,0 +1,288 @@
+/** @file
+  Memory Debug Log common defs/funcs to access the memory buffer.
+
+  Copyright (C) 2025, Oracle and/or its affiliates.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/PrintLib.h>
+#include <Library/SynchronizationLib.h>
+#include <Library/MemDebugLogLib.h>
+
+#define MEMDEBUGLOG_COPYSIZE  0x200
+
+STATIC
+VOID
+MemDebugLogLockInit (
+  IN volatile UINT64  *MemDebugLogLock
+  )
+{
+  InitializeSpinLock ((SPIN_LOCK *)MemDebugLogLock);
+}
+
+STATIC
+VOID
+MemDebugLogLockAcquire (
+  IN volatile UINT64  *MemDebugLogLock
+  )
+{
+  AcquireSpinLock ((SPIN_LOCK *)MemDebugLogLock);
+}
+
+STATIC
+VOID
+MemDebugLogLockRelease (
+  IN volatile UINT64  *MemDebugLogLock
+  )
+{
+  ReleaseSpinLock ((SPIN_LOCK *)MemDebugLogLock);
+}
+
+EFI_STATUS
+EFIAPI
+MemDebugLogWriteBuffer (
+  IN  EFI_PHYSICAL_ADDRESS  MemDebugLogBufAddr,
+  IN  CHAR8                 *Buffer,
+  IN  UINTN                 Length
+  )
+{
+  volatile UINT64    *MemDebugLogLock;
+  MEM_DEBUG_LOG_HDR  *MemDebugLogHdr;
+  UINTN              BufSpaceLeft;
+  CHAR8              *BufStart;
+  CHAR8              *BufHead;
+  CHAR8              *BufTail;
+  CHAR8              *BufEnd;
+
+  //
+  // NOTE: we cannot call DEBUG or ASSERT from this function.
+  //
+
+  if (!MemDebugLogBufAddr || !Buffer) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (Length == 0) {
+    return EFI_SUCCESS;
+  }
+
+  MemDebugLogHdr  = (MEM_DEBUG_LOG_HDR *)(UINTN)MemDebugLogBufAddr;
+  MemDebugLogLock = &(MemDebugLogHdr->MemDebugLogLock);
+
+  //
+  // Validate the header magic before proceeding
+  //
+  if (MemDebugLogHdr->Magic != MEM_DEBUG_LOG_MAGIC)
+  {
+    return EFI_NOT_FOUND;
+  }
+
+  if (Length >= MemDebugLogHdr->DebugLogSize) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  MemDebugLogLockAcquire (MemDebugLogLock);
+
+  BufStart = (CHAR8 *)(UINTN)(MemDebugLogBufAddr + MemDebugLogHdr->HeaderSize);
+  BufEnd   = (CHAR8 *)(UINTN)(MemDebugLogBufAddr + MemDebugLogHdr->HeaderSize + MemDebugLogHdr->DebugLogSize) - 1;
+  BufHead  = BufStart + MemDebugLogHdr->DebugLogHeadOffset;
+  BufTail  = BufStart + MemDebugLogHdr->DebugLogTailOffset;
+
+  //
+  // Maintain a circular (wrap around) log buffer
+  // NOTES:
+  // tail always points to next available slot to populate
+  // Algorithm to process/display strings from buffer in time order:
+  // 1. head==tail indicates empty buffer
+  // 2. if (head < tail), process from head (tail-head) bytes
+  // 3. if (head > tail), process from head (bufend-head) bytes
+  //                      process from bufstart (tail-bufstart) bytes
+  //
+
+  if ((BufTail + Length) <= BufEnd) {
+    //
+    //  There's enough room from tail to end of the buffer
+    //
+    CopyMem (BufTail, Buffer, Length);
+    //
+    // If we have previously wrapped around, need to keep Head updated
+    //
+    if (BufHead == (BufTail + 1)) {
+      BufHead += Length;
+      //
+      // Check if we need to wrap Head
+      //
+      if (BufHead > BufEnd) {
+        BufHead = BufStart;
+      }
+    }
+
+    BufTail += Length;
+  } else {
+    //
+    // We need to wrap around.
+    //
+    // Fill remaining buffer space with initial part of the string
+    //
+    BufSpaceLeft = (UINTN)(BufEnd - BufTail + 1);
+    CopyMem (BufTail, Buffer, BufSpaceLeft);
+
+    //
+    // Wrap to start of the buffer for the rest of the string
+    //
+    BufTail = BufStart;
+    CopyMem (BufTail, (Buffer + BufSpaceLeft), (Length - BufSpaceLeft));
+    BufTail += (Length - BufSpaceLeft);
+    BufHead  = (BufTail + 1);
+
+    MemDebugLogHdr->Truncated = 1;
+  }
+
+  //
+  // Write the new buffer offsets back to the header
+  //
+  MemDebugLogHdr->DebugLogHeadOffset = BufHead - BufStart;
+  MemDebugLogHdr->DebugLogTailOffset = BufTail - BufStart;
+
+  MemDebugLogLockRelease (MemDebugLogLock);
+
+  return EFI_SUCCESS;
+}
+
+EFI_STATUS
+EFIAPI
+MemDebugLogInit (
+  IN EFI_PHYSICAL_ADDRESS  MemDebugLogBufAddr,
+  UINT32                   MemDebugLogBufSize
+  )
+{
+  MEM_DEBUG_LOG_HDR  *MemDebugLogHdr;
+
+  if (MemDebugLogBufAddr == 0) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  ZeroMem ((VOID *)(UINTN)MemDebugLogBufAddr, MemDebugLogBufSize);
+
+  MemDebugLogHdr                     = (MEM_DEBUG_LOG_HDR *)(UINTN)MemDebugLogBufAddr;
+  MemDebugLogHdr->Magic              = MEM_DEBUG_LOG_MAGIC;
+  MemDebugLogHdr->HeaderSize         = sizeof (MEM_DEBUG_LOG_HDR);
+  MemDebugLogHdr->DebugLogSize       = (MemDebugLogBufSize - MemDebugLogHdr->HeaderSize);
+  MemDebugLogHdr->DebugLogHeadOffset = 0;
+  MemDebugLogHdr->DebugLogTailOffset = 0;
+  MemDebugLogLockInit (&(MemDebugLogHdr->MemDebugLogLock));
+  MemDebugLogHdr->Truncated = 0;
+  AsciiSPrint (MemDebugLogHdr->FirmwareVersion, 128, "%s", (CHAR16 *)PcdGetPtr (PcdFirmwareVersionString));
+
+  return EFI_SUCCESS;
+}
+
+EFI_STATUS
+EFIAPI
+MemDebugLogCopy (
+  IN EFI_PHYSICAL_ADDRESS  MemDebugLogBufDestAddr,
+  IN EFI_PHYSICAL_ADDRESS  MemDebugLogBufSrcAddr
+  )
+{
+  MEM_DEBUG_LOG_HDR  *MemDebugLogSrcHdr;
+  MEM_DEBUG_LOG_HDR  *MemDebugLogDestHdr;
+  CHAR8              *BufStart;
+  CHAR8              *BufHead;
+  CHAR8              *BufTail;
+  CHAR8              *BufEnd;
+  CHAR8              *BufPtr;
+
+  if ((MemDebugLogBufSrcAddr == 0) || (MemDebugLogBufDestAddr == 0)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  MemDebugLogSrcHdr  = (MEM_DEBUG_LOG_HDR *)(UINTN)MemDebugLogBufSrcAddr;
+  MemDebugLogDestHdr = (MEM_DEBUG_LOG_HDR *)(UINTN)MemDebugLogBufDestAddr;
+
+  BufStart = (CHAR8 *)(UINTN)(MemDebugLogBufSrcAddr + MemDebugLogSrcHdr->HeaderSize);
+  BufEnd   = (CHAR8 *)(UINTN)(MemDebugLogBufSrcAddr + MemDebugLogSrcHdr->HeaderSize + MemDebugLogSrcHdr->DebugLogSize);
+  BufHead  = BufStart + MemDebugLogSrcHdr->DebugLogHeadOffset;
+  BufTail  = BufStart + MemDebugLogSrcHdr->DebugLogTailOffset;
+
+  MemDebugLogDestHdr->Truncated = MemDebugLogSrcHdr->Truncated;
+
+  if (BufHead == BufTail) {
+    //
+    // Source Debug Log empty
+    //
+    return EFI_SUCCESS;
+  } else if (BufHead < BufTail) {
+    //
+    // Source buffer didn't wrap, so copy debug messages
+    // from Source buffer (head to tail) to the Dest buffer
+    // NOTE: we limit each copy to MEMDEBUGLOG_COPYSIZE
+    // to ensure to not copy too much at a time and ensure
+    // the dest buffer head/tail pointers are created properly.
+    //
+    for (BufPtr = BufHead; (BufTail - BufPtr) > MEMDEBUGLOG_COPYSIZE; BufPtr += MEMDEBUGLOG_COPYSIZE) {
+      MemDebugLogWriteBuffer (MemDebugLogBufDestAddr, BufPtr, MEMDEBUGLOG_COPYSIZE);
+    }
+
+    //
+    // write remaining bytes
+    //
+    MemDebugLogWriteBuffer (MemDebugLogBufDestAddr, BufPtr, (BufTail - BufPtr));
+  } else {
+    //
+    // Source buffer wrapped.
+    // First copy (bufend - head) chars from head to Dest buffer
+    //
+    for (BufPtr = BufHead; (BufEnd - BufPtr) > MEMDEBUGLOG_COPYSIZE; BufPtr += MEMDEBUGLOG_COPYSIZE) {
+      MemDebugLogWriteBuffer (MemDebugLogBufDestAddr, BufPtr, MEMDEBUGLOG_COPYSIZE);
+    }
+
+    //
+    // write remaining bytes
+    //
+    MemDebugLogWriteBuffer (MemDebugLogBufDestAddr, BufPtr, (BufEnd - BufPtr));
+
+    //
+    // Next, copy (bufend - head) chars from start to Dest buffer
+    //
+    for (BufPtr = BufStart; (BufTail - BufPtr) > MEMDEBUGLOG_COPYSIZE; BufPtr += MEMDEBUGLOG_COPYSIZE) {
+      MemDebugLogWriteBuffer (MemDebugLogBufDestAddr, BufPtr, MEMDEBUGLOG_COPYSIZE);
+    }
+
+    //
+    // write remaining bytes
+    //
+    MemDebugLogWriteBuffer (MemDebugLogBufDestAddr, BufPtr, (BufTail - BufPtr));
+  }
+
+  return EFI_SUCCESS;
+}
+
+EFI_STATUS
+EFIAPI
+MemDebugLogInvalidate (
+  IN EFI_PHYSICAL_ADDRESS  MemDebugLogBufAddr
+  )
+{
+  volatile UINT64    *MemDebugLogLock;
+  MEM_DEBUG_LOG_HDR  *MemDebugLogHdr;
+
+  if (MemDebugLogBufAddr == 0) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  MemDebugLogHdr  = (MEM_DEBUG_LOG_HDR *)(UINTN)MemDebugLogBufAddr;
+  MemDebugLogLock = &(MemDebugLogHdr->MemDebugLogLock);
+
+  MemDebugLogLockAcquire (MemDebugLogLock);
+
+  // Invalidate the MAGIC field
+  MemDebugLogHdr->Magic = 0x0;
+
+  MemDebugLogLockRelease (MemDebugLogLock);
+
+  return EFI_SUCCESS;
+}

--- a/OvmfPkg/Library/MemDebugLogLib/MemDebugLogDxe.c
+++ b/OvmfPkg/Library/MemDebugLogLib/MemDebugLogDxe.c
@@ -1,0 +1,56 @@
+/** @file
+ *
+  Memory Debug Log Library - DXE/Smm
+
+  Copyright (C) 2025, Oracle and/or its affiliates.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <PiDxe.h>
+#include <Library/HobLib.h>
+#include <Library/MemDebugLogLib.h>
+
+EFI_PHYSICAL_ADDRESS  mMemDebugLogBufAddr;
+BOOLEAN               mMemDebugLogBufAddrInit;
+
+EFI_STATUS
+EFIAPI
+MemDebugLogWrite (
+  IN  CHAR8  *Buffer,
+  IN  UINTN  Length
+  )
+{
+  EFI_HOB_GUID_TYPE       *GuidHob;
+  MEM_DEBUG_LOG_HOB_DATA  *HobData;
+  EFI_STATUS              Status;
+
+  //
+  // Init debug log buffer addr on first write
+  //
+  if (!mMemDebugLogBufAddrInit) {
+    //
+    // Obtain the Memory Debug Log buffer addr from PEI HOB
+    //
+    GuidHob = GetFirstGuidHob (&gMemDebugLogHobGuid);
+    if (GuidHob == NULL) {
+      mMemDebugLogBufAddr = 0;
+    } else {
+      //
+      // Populate the Mem Debug Log Buffer from the HOB
+      //
+      HobData             = (MEM_DEBUG_LOG_HOB_DATA *)GET_GUID_HOB_DATA (GuidHob);
+      mMemDebugLogBufAddr = HobData->MemDebugLogBufAddr;
+    }
+
+    mMemDebugLogBufAddrInit = TRUE;
+  }
+
+  if (mMemDebugLogBufAddr) {
+    Status = MemDebugLogWriteBuffer (mMemDebugLogBufAddr, Buffer, Length);
+  } else {
+    Status = EFI_NOT_FOUND;
+  }
+
+  return Status;
+}

--- a/OvmfPkg/Library/MemDebugLogLib/MemDebugLogDxeLib.inf
+++ b/OvmfPkg/Library/MemDebugLogLib/MemDebugLogDxeLib.inf
@@ -1,0 +1,37 @@
+## @file
+#  Instance of MemDebugLog Library for DXE/Smm
+#
+#  Copyright (C) 2025, Oracle and/or its affiliates.
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = MemDebugLogLib
+  FILE_GUID                      = 4988621E-8EE8-4D27-862F-EB98BD8F17E6
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = MemDebugLogLib|DXE_CORE DXE_DRIVER UEFI_DRIVER UEFI_APPLICATION SMM_CORE DXE_SMM_DRIVER
+
+
+[Sources]
+  MemDebugLogDxe.c
+  MemDebugLogCommon.c
+
+[Packages]
+  MdeModulePkg/MdeModulePkg.dec
+  MdePkg/MdePkg.dec
+  OvmfPkg/OvmfPkg.dec
+
+[LibraryClasses]
+  HobLib
+  SynchronizationLib
+
+[Guids]
+  gMemDebugLogHobGuid                      ## CONSUMES
+
+[FixedPcd]
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFirmwareVersionString ## CONSUMES

--- a/OvmfPkg/Library/MemDebugLogLib/MemDebugLogLibNull.inf
+++ b/OvmfPkg/Library/MemDebugLogLib/MemDebugLogLibNull.inf
@@ -1,0 +1,31 @@
+## @file
+#  Null Instance of MemDebugLog Library
+#
+#  Copyright (C) 2025, Oracle and/or its affiliates.
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = MemDebugLogLib
+  FILE_GUID                      = 11b4523c-2c30-44f7-9dee-e6d59eef3d04
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = MemDebugLogLib|SEC PEI_CORE PEIM DXE_CORE DXE_DRIVER DXE_RUNTIME_DRIVER UEFI_APPLICATION UEFI_DRIVER SMM_CORE DXE_SMM_DRIVER
+
+
+[Sources]
+  MemDebugLogNull.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  OvmfPkg/OvmfPkg.dec
+
+[LibraryClasses]
+
+[FixedPcd]
+
+[Guids]

--- a/OvmfPkg/Library/MemDebugLogLib/MemDebugLogNull.c
+++ b/OvmfPkg/Library/MemDebugLogLib/MemDebugLogNull.c
@@ -1,0 +1,22 @@
+/** @file
+ *
+  Memory Debug Log Library - Null.
+
+  Copyright (C) 2025, Oracle and/or its affiliates.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Library/MemDebugLogLib.h>
+
+EFI_STATUS
+EFIAPI
+MemDebugLogWrite (
+  IN  CHAR8  *Buffer,
+  IN  UINTN  Length
+  )
+{
+  // Null Instance - NOP
+  return EFI_SUCCESS;
+}

--- a/OvmfPkg/Library/MemDebugLogLib/MemDebugLogPei.c
+++ b/OvmfPkg/Library/MemDebugLogLib/MemDebugLogPei.c
@@ -1,0 +1,54 @@
+/** @file
+ *
+  Memory Debug Log Library - PEI Phase
+
+  Copyright (C) 2025, Oracle and/or its affiliates.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <PiPei.h>
+#include <Library/HobLib.h>
+#include <Library/PeiServicesLib.h>
+#include <Library/MemDebugLogLib.h>
+
+EFI_STATUS
+EFIAPI
+MemDebugLogWrite (
+  IN  CHAR8  *Buffer,
+  IN  UINTN  Length
+  )
+{
+  EFI_PHYSICAL_ADDRESS    MemDebugLogBufAddr;
+  EFI_HOB_GUID_TYPE       *GuidHob;
+  MEM_DEBUG_LOG_HOB_DATA  *HobData;
+  EFI_STATUS              Status;
+
+  GuidHob = GetFirstGuidHob (&gMemDebugLogHobGuid);
+  if (GuidHob == NULL) {
+    MemDebugLogBufAddr = 0;
+  } else {
+    HobData            = (MEM_DEBUG_LOG_HOB_DATA *)GET_GUID_HOB_DATA (GuidHob);
+    MemDebugLogBufAddr = HobData->MemDebugLogBufAddr;
+  }
+
+  if (MemDebugLogBufAddr) {
+    Status = MemDebugLogWriteBuffer (MemDebugLogBufAddr, Buffer, Length);
+  } else {
+    //
+    // HOB has not yet been created, so
+    // write to the early debug log buffer.
+    //
+    if (FixedPcdGet32 (PcdOvmfEarlyMemDebugLogBase) != 0x0) {
+      Status = MemDebugLogWriteBuffer (
+                 (EFI_PHYSICAL_ADDRESS)(UINTN)FixedPcdGet32 (PcdOvmfEarlyMemDebugLogBase),
+                 Buffer,
+                 Length
+                 );
+    } else {
+      Status = EFI_NOT_FOUND;
+    }
+  }
+
+  return Status;
+}

--- a/OvmfPkg/Library/MemDebugLogLib/MemDebugLogPeiLib.inf
+++ b/OvmfPkg/Library/MemDebugLogLib/MemDebugLogPeiLib.inf
@@ -1,0 +1,42 @@
+## @file
+#  Instance of MemDebugLog Library for PEI phase
+#
+#  Copyright (C) 2025, Oracle and/or its affiliates.
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = MemDebugLogLib
+  FILE_GUID                      = D473DE36-0D8A-4F6B-9FA0-126185F36D9D
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = MemDebugLogLib|PEI_CORE PEIM
+
+
+[Sources]
+  MemDebugLogPei.c
+  MemDebugLogCommon.c
+
+[Packages]
+  MdeModulePkg/MdeModulePkg.dec
+  MdePkg/MdePkg.dec
+  OvmfPkg/OvmfPkg.dec
+
+[LibraryClasses]
+  SynchronizationLib
+
+[FixedPcd]
+  gUefiOvmfPkgTokenSpaceGuid.PcdOvmfEarlyMemDebugLogBase
+  gUefiOvmfPkgTokenSpaceGuid.PcdOvmfEarlyMemDebugLogSize
+
+[Guids]
+  gMemDebugLogHobGuid
+
+[Ppis]
+
+[FixedPcd]
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFirmwareVersionString ## CONSUMES

--- a/OvmfPkg/Library/MemDebugLogLib/MemDebugLogRt.c
+++ b/OvmfPkg/Library/MemDebugLogLib/MemDebugLogRt.c
@@ -1,0 +1,66 @@
+/** @file
+ *
+  Memory Debug Log Library - Runtime
+
+  Copyright (C) 2025, Oracle and/or its affiliates.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <PiDxe.h>
+#include <Library/HobLib.h>
+#include <Library/MemDebugLogLib.h>
+#include <Library/UefiRuntimeLib.h>
+
+EFI_PHYSICAL_ADDRESS  mMemDebugLogBufAddr;
+BOOLEAN               mMemDebugLogBufAddrInit;
+
+EFI_STATUS
+EFIAPI
+MemDebugLogWrite (
+  IN  CHAR8  *Buffer,
+  IN  UINTN  Length
+  )
+{
+  EFI_HOB_GUID_TYPE       *GuidHob;
+  MEM_DEBUG_LOG_HOB_DATA  *HobData;
+  EFI_STATUS              Status;
+
+  //
+  // Stop logging after we have switched to virtual mode
+  // to avoid potential problems (such as crashes accessing
+  // physical pointers).
+  //
+  if (EfiGoneVirtual ()) {
+    return EFI_SUCCESS;
+  }
+
+  //
+  // Init debug log buffer addr on first write
+  //
+  if (!mMemDebugLogBufAddrInit) {
+    //
+    // Obtain the Memory Debug Log buffer addr from PEI HOB
+    //
+    GuidHob = GetFirstGuidHob (&gMemDebugLogHobGuid);
+    if (GuidHob == NULL) {
+      mMemDebugLogBufAddr = 0;
+    } else {
+      //
+      // Populate the Mem Debug Log Buffer from the HOB
+      //
+      HobData             = (MEM_DEBUG_LOG_HOB_DATA *)GET_GUID_HOB_DATA (GuidHob);
+      mMemDebugLogBufAddr = HobData->MemDebugLogBufAddr;
+    }
+
+    mMemDebugLogBufAddrInit = TRUE;
+  }
+
+  if (mMemDebugLogBufAddr) {
+    Status = MemDebugLogWriteBuffer (mMemDebugLogBufAddr, Buffer, Length);
+  } else {
+    Status = EFI_NOT_FOUND;
+  }
+
+  return Status;
+}

--- a/OvmfPkg/Library/MemDebugLogLib/MemDebugLogRtLib.inf
+++ b/OvmfPkg/Library/MemDebugLogLib/MemDebugLogRtLib.inf
@@ -1,0 +1,38 @@
+## @file
+#  Instance of MemDebugLog Library for Runtime
+#
+#  Copyright (C) 2025, Oracle and/or its affiliates.
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = MemDebugLogLib
+  FILE_GUID                      = BE0D0FFD-206C-48F3-9910-C32467567C44
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = MemDebugLogLib|DXE_RUNTIME_DRIVER
+
+
+[Sources]
+  MemDebugLogRt.c
+  MemDebugLogCommon.c
+
+[Packages]
+  MdeModulePkg/MdeModulePkg.dec
+  MdePkg/MdePkg.dec
+  OvmfPkg/OvmfPkg.dec
+
+[LibraryClasses]
+  HobLib
+  UefiRuntimeLib
+  SynchronizationLib
+
+[Guids]
+  gMemDebugLogHobGuid                      ## CONSUMES
+
+[FixedPcd]
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFirmwareVersionString ## CONSUMES

--- a/OvmfPkg/Library/MemDebugLogLib/MemDebugLogSec.c
+++ b/OvmfPkg/Library/MemDebugLogLib/MemDebugLogSec.c
@@ -1,0 +1,48 @@
+/** @file
+ *
+  Memory Debug Log Library - SEC Phase
+
+  Copyright (C) 2025, Oracle and/or its affiliates.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <Library/MemDebugLogLib.h>
+
+EFI_STATUS
+EFIAPI
+MemDebugLogWrite (
+  IN  CHAR8  *Buffer,
+  IN  UINTN  Length
+  )
+{
+  EFI_STATUS  Status;
+
+  if (FixedPcdGet32 (PcdOvmfEarlyMemDebugLogBase) != 0x0) {
+    Status = MemDebugLogWriteBuffer (
+               (EFI_PHYSICAL_ADDRESS)(UINTN)FixedPcdGet32 (PcdOvmfEarlyMemDebugLogBase),
+               Buffer,
+               Length
+               );
+  } else {
+    Status = EFI_NOT_FOUND;
+  }
+
+  return Status;
+}
+
+RETURN_STATUS
+EFIAPI
+MemDebugLogLibConstructor (
+  VOID
+  )
+{
+  if (FixedPcdGet32 (PcdOvmfEarlyMemDebugLogSize) != 0) {
+    MemDebugLogInit (
+      (EFI_PHYSICAL_ADDRESS)(UINTN)FixedPcdGet32 (PcdOvmfEarlyMemDebugLogBase),
+      (UINT32)FixedPcdGet32 (PcdOvmfEarlyMemDebugLogSize)
+      );
+  }
+
+  return RETURN_SUCCESS;
+}

--- a/OvmfPkg/Library/MemDebugLogLib/MemDebugLogSecLib.inf
+++ b/OvmfPkg/Library/MemDebugLogLib/MemDebugLogSecLib.inf
@@ -1,0 +1,38 @@
+## @file
+#  Instance of MemDebugLog Library for SEC phase
+#
+#  Copyright (C) 2025, Oracle and/or its affiliates.
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = MemDebugLogLib
+  FILE_GUID                      = 9B3A8F82-CBCE-4E3A-A3E0-DBD7172E9506
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = MemDebugLogLib|SEC
+  CONSTRUCTOR                    = MemDebugLogLibConstructor
+
+
+[Sources]
+  MemDebugLogSec.c
+  MemDebugLogCommon.c
+
+[Packages]
+  MdeModulePkg/MdeModulePkg.dec
+  MdePkg/MdePkg.dec
+  OvmfPkg/OvmfPkg.dec
+
+[LibraryClasses]
+  SynchronizationLib
+
+[FixedPcd]
+  gUefiOvmfPkgTokenSpaceGuid.PcdOvmfEarlyMemDebugLogBase
+  gUefiOvmfPkgTokenSpaceGuid.PcdOvmfEarlyMemDebugLogSize
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFirmwareVersionString ## CONSUMES
+
+[Guids]

--- a/OvmfPkg/Library/PlatformDebugLibIoPort/DebugLib.c
+++ b/OvmfPkg/Library/PlatformDebugLibIoPort/DebugLib.c
@@ -16,6 +16,7 @@
 #include <Library/PcdLib.h>
 #include <Library/BaseMemoryLib.h>
 #include <Library/DebugPrintErrorLevelLib.h>
+#include <Library/MemDebugLogLib.h>
 #include "DebugLibDetect.h"
 
 //
@@ -114,6 +115,11 @@ DebugPrintMarker (
   // Send the print string to the debug I/O port
   //
   IoWriteFifo8 (PcdGet16 (PcdDebugIoPort), Length, Buffer);
+
+  //
+  // Send string to Memory Debug Log
+  //
+  MemDebugLogWrite(Buffer, Length);
 }
 
 /**
@@ -220,6 +226,11 @@ DebugAssert (
   if (PlatformDebugLibIoPortFound ()) {
     IoWriteFifo8 (PcdGet16 (PcdDebugIoPort), Length, Buffer);
   }
+
+  //
+  // Send the string to Memory Debug Log
+  //
+  MemDebugLogWrite(Buffer, Length);
 
   //
   // Generate a Breakpoint, DeadLoop, or NOP based on PCD settings

--- a/OvmfPkg/Library/PlatformDebugLibIoPort/PlatformDebugLibIoPort.inf
+++ b/OvmfPkg/Library/PlatformDebugLibIoPort/PlatformDebugLibIoPort.inf
@@ -40,6 +40,7 @@
   PrintLib
   BaseLib
   DebugPrintErrorLevelLib
+  MemDebugLogLib
 
 [Pcd]
   gUefiOvmfPkgTokenSpaceGuid.PcdDebugIoPort                ## CONSUMES

--- a/OvmfPkg/Library/PlatformDebugLibIoPort/PlatformRomDebugLibIoPort.inf
+++ b/OvmfPkg/Library/PlatformDebugLibIoPort/PlatformRomDebugLibIoPort.inf
@@ -40,6 +40,7 @@
   PrintLib
   BaseLib
   DebugPrintErrorLevelLib
+  MemDebugLogLib
 
 [Pcd]
   gUefiOvmfPkgTokenSpaceGuid.PcdDebugIoPort                ## CONSUMES

--- a/OvmfPkg/Library/PlatformInitLib/MemDetect.c
+++ b/OvmfPkg/Library/PlatformInitLib/MemDetect.c
@@ -1504,6 +1504,20 @@ PlatformQemuInitializeRamForS3 (
         );
     }
 
+    if (FixedPcdGet32 (PcdOvmfEarlyMemDebugLogSize) != 0) {
+      //
+      // Reserve the Early Memory Debug Log buffer
+      //
+      // Since this memory range will be used on S3 resume, it must be
+      // reserved as ACPI NVS.
+      //
+      BuildMemoryAllocationHob (
+        (EFI_PHYSICAL_ADDRESS)(UINTN)FixedPcdGet32 (PcdOvmfEarlyMemDebugLogBase),
+        (UINT64)(UINTN)FixedPcdGet32 (PcdOvmfEarlyMemDebugLogSize),
+        PlatformInfoHob->S3Supported ? EfiACPIMemoryNVS : EfiBootServicesData
+        );
+    }
+
  #endif
   }
 }

--- a/OvmfPkg/Library/PlatformInitLib/PlatformInitLib.inf
+++ b/OvmfPkg/Library/PlatformInitLib/PlatformInitLib.inf
@@ -107,5 +107,8 @@
   gUefiOvmfPkgTokenSpaceGuid.PcdOvmfFlashNvStorageVariableBase
   gUefiOvmfPkgTokenSpaceGuid.PcdCfvRawDataSize
 
+  gUefiOvmfPkgTokenSpaceGuid.PcdOvmfEarlyMemDebugLogBase
+  gUefiOvmfPkgTokenSpaceGuid.PcdOvmfEarlyMemDebugLogSize
+
 [FeaturePcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdDxeIplSwitchToLongMode

--- a/OvmfPkg/MemDebugLogPei/MemDebugLog.c
+++ b/OvmfPkg/MemDebugLogPei/MemDebugLog.c
@@ -1,0 +1,174 @@
+/** @file
+
+  Memory Debug Log PEIM
+
+  Copyright (C) 2025, Oracle and/or its affiliates.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
+#include <Library/HobLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/PeiServicesLib.h>
+#include <Library/PeimEntryPoint.h>
+#include <Library/PcdLib.h>
+#include <Library/PrintLib.h>
+#include <Library/MemDebugLogLib.h>
+#include <Library/QemuFwCfgSimpleParserLib.h>
+
+EFI_STATUS
+EFIAPI
+MemDebugLogMemAvailCB (
+  IN EFI_PEI_SERVICES           **PeiServices,
+  IN EFI_PEI_NOTIFY_DESCRIPTOR  *NotifyDescriptor,
+  IN VOID                       *Ppi
+  );
+
+CONST EFI_PEI_NOTIFY_DESCRIPTOR  mMemAvailNotifyList[] = {
+  {
+    (EFI_PEI_PPI_DESCRIPTOR_NOTIFY_DISPATCH | EFI_PEI_PPI_DESCRIPTOR_TERMINATE_LIST),
+    &gEfiPeiMemoryDiscoveredPpiGuid,
+    MemDebugLogMemAvailCB
+  }
+};
+
+EFI_STATUS
+EFIAPI
+MemDebugLogMemAvailCB (
+  IN EFI_PEI_SERVICES           **PeiServices,
+  IN EFI_PEI_NOTIFY_DESCRIPTOR  *NotifyDescriptor,
+  IN VOID                       *Ppi
+  )
+{
+  UINT32                  FwCfg_MemDebugLogPages;
+  UINT32                  MemDebugLogBufPages;
+  EFI_PHYSICAL_ADDRESS    MemDebugLogBufAddr;
+  EFI_HOB_GUID_TYPE       *GuidHob;
+  MEM_DEBUG_LOG_HOB_DATA  *HobData;
+  EFI_STATUS              Status;
+
+  MemDebugLogBufPages = FixedPcdGet32 (PcdMemDebugLogPages);
+
+  //
+  // Allow FwCfg value to override Pcd.
+  //
+  Status = QemuFwCfgParseUint32 ("opt/ovmf/MemDebugLogPages", TRUE, &FwCfg_MemDebugLogPages);
+  if (Status == EFI_SUCCESS) {
+    MemDebugLogBufPages = FwCfg_MemDebugLogPages;
+  }
+
+  //
+  // Buffer size of 0 disables memory debug logging.
+  //
+  if (!MemDebugLogBufPages) {
+    MemDebugLogBufAddr = 0;
+    Status             = EFI_SUCCESS;
+    goto done;
+  }
+
+  //
+  // Cap max memory debug log size at MAX_MEM_DEBUG_LOG_PAGES
+  //
+  if (MemDebugLogBufPages > MAX_MEM_DEBUG_LOG_PAGES) {
+    DEBUG ((DEBUG_INFO, "%a: Limiting Memory Debug Log buffer to max 0x%x pages\n", __func__, MAX_MEM_DEBUG_LOG_PAGES));
+    MemDebugLogBufPages = MAX_MEM_DEBUG_LOG_PAGES;
+  }
+
+  //
+  // Allocate the memory debug log buffer.
+  // NOTE: We allocate the buffer as type EfiRuntimeServicesData
+  // as this seems to allow the buffer to persist and be
+  // accessible/modifiable throughout runtime (i.e. and avoid
+  // being locked down by the MemoryAttributesTable code).
+  //
+  Status = PeiServicesAllocatePages (
+             EfiRuntimeServicesData,
+             MemDebugLogBufPages,
+             &MemDebugLogBufAddr
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: Failed to allocate Memory Debug Log buffer: %r. Logging disabled\n", __func__, Status));
+    MemDebugLogBufAddr = 0;
+    goto done;
+  }
+
+  //
+  // Init the debug log buffer
+  //
+  Status = MemDebugLogInit (MemDebugLogBufAddr, (UINT32)EFI_PAGES_TO_SIZE ((UINTN)MemDebugLogBufPages));
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: Failed to init Memory Debug Log buffer: %r. Logging disabled\n", __func__, Status));
+    PeiServicesFreePages (MemDebugLogBufAddr, MemDebugLogBufPages);
+    MemDebugLogBufAddr = 0;
+    goto done;
+  }
+
+  //
+  // Copy over the messages from the Early Debug Log buffer.
+  //
+  if (FixedPcdGet32 (PcdOvmfEarlyMemDebugLogBase) != 0) {
+    MemDebugLogCopy (MemDebugLogBufAddr, (EFI_PHYSICAL_ADDRESS)(UINTN)FixedPcdGet32 (PcdOvmfEarlyMemDebugLogBase));
+    //
+    // Invalidate the Early buffer. This prevents any possible DEBUG()
+    // messages from populating until after we create the HOB below.
+    //
+    MemDebugLogInvalidate ((EFI_PHYSICAL_ADDRESS)(UINTN)FixedPcdGet32 (PcdOvmfEarlyMemDebugLogBase));
+  }
+
+done:
+  //
+  // Zero the early buffer if we successfully
+  // created the main memory log buffer.
+  //
+  if ((Status == EFI_SUCCESS) && (FixedPcdGet32 (PcdOvmfEarlyMemDebugLogBase) != 0)) {
+    ZeroMem (
+      (VOID *)(UINTN)FixedPcdGet32 (PcdOvmfEarlyMemDebugLogBase),
+      (UINT32)FixedPcdGet32 (PcdOvmfEarlyMemDebugLogSize)
+      );
+  }
+
+  //
+  // Create HOB to pass mem debug log buffer addr
+  //
+  Status = PeiServicesCreateHob (
+             EFI_HOB_TYPE_GUID_EXTENSION,
+             (UINT16)(sizeof (EFI_HOB_GUID_TYPE) + sizeof (MEM_DEBUG_LOG_HOB_DATA)),
+             (VOID **)&GuidHob
+             );
+  if (EFI_ERROR (Status)) {
+    if (MemDebugLogBufAddr) {
+      PeiServicesFreePages (MemDebugLogBufAddr, MemDebugLogBufPages);
+    }
+  } else {
+    //
+    // Populate the HOB
+    //
+    CopyGuid (&GuidHob->Name, &gMemDebugLogHobGuid);
+    HobData                     = (MEM_DEBUG_LOG_HOB_DATA *)GET_GUID_HOB_DATA (GuidHob);
+    HobData->MemDebugLogBufAddr = MemDebugLogBufAddr;
+  }
+
+  return Status;
+}
+
+EFI_STATUS
+EFIAPI
+MemDebugLogEntry (
+  IN       EFI_PEI_FILE_HANDLE  FileHandle,
+  IN CONST EFI_PEI_SERVICES     **PeiServices
+  )
+{
+  EFI_STATUS  Status;
+
+  //
+  // Setup callback for memory available notification
+  //
+  Status = PeiServicesNotifyPpi (mMemAvailNotifyList);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: Failed to create MemDebugLog PEIM Callback: %r. Logging disabled\n", __func__, Status));
+  }
+
+  return Status;
+}

--- a/OvmfPkg/MemDebugLogPei/MemDebugLogPei.inf
+++ b/OvmfPkg/MemDebugLogPei/MemDebugLogPei.inf
@@ -1,0 +1,65 @@
+#/** @file
+#
+#  Memory Debug Log PEIM
+#
+#  Copyright (C) 2025, Oracle and/or its affiliates.
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+#**/
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = MemDebugLogPei
+  FILE_GUID                      = 2e501046-26ae-406b-9935-084b61a12e15
+  MODULE_TYPE                    = PEIM
+  VERSION_STRING                 = 1.0
+  ENTRY_POINT                    = MemDebugLogEntry
+
+#
+#  For reference only:
+#  VALID_ARCHITECTURES           = X64
+#
+
+[Sources]
+  MemDebugLog.c
+
+[Packages]
+  MdeModulePkg/MdeModulePkg.dec
+  MdePkg/MdePkg.dec
+  OvmfPkg/OvmfPkg.dec
+
+[LibraryClasses]
+  BaseMemoryLib
+  DebugLib
+  HobLib
+  MemoryAllocationLib
+  PeiServicesLib
+  PeiServicesTablePointerLib
+  PeimEntryPoint
+  PcdLib
+  MemDebugLogLib
+
+[LibraryClasses.Ia32]
+  QemuFwCfgSimpleParserLib
+
+[LibraryClasses.X64]
+  QemuFwCfgSimpleParserLib
+
+[Ppis]
+  gEfiPeiMemoryDiscoveredPpiGuid        ## CONSUMES
+
+[Guids]
+  gMemDebugLogHobGuid
+
+[Pcd]
+
+[FeaturePcd]
+
+[FixedPcd]
+  gUefiOvmfPkgTokenSpaceGuid.PcdMemDebugLogPages          ## CONSUMES
+  gUefiOvmfPkgTokenSpaceGuid.PcdOvmfEarlyMemDebugLogBase  ## CONSUMES
+  gUefiOvmfPkgTokenSpaceGuid.PcdOvmfEarlyMemDebugLogSize  ## CONSUMES
+
+[Depex]
+  TRUE

--- a/OvmfPkg/Microvm/MicrovmX64.dsc
+++ b/OvmfPkg/Microvm/MicrovmX64.dsc
@@ -249,6 +249,7 @@
   TdxLib|MdePkg/Library/TdxLib/TdxLib.inf
   TdxMailboxLib|OvmfPkg/Library/TdxMailboxLib/TdxMailboxLibNull.inf
   TdxHelperLib|OvmfPkg/IntelTdx/TdxHelperLib/TdxHelperLibNull.inf
+  MemDebugLogLib|OvmfPkg/Library/MemDebugLogLib/MemDebugLogLibNull.inf
 
 [LibraryClasses.common.SEC]
   QemuFwCfgLib|OvmfPkg/Library/QemuFwCfgLib/QemuFwCfgSecLib.inf

--- a/OvmfPkg/OvmfPkg.dec
+++ b/OvmfPkg/OvmfPkg.dec
@@ -156,6 +156,10 @@
   #
   CpuMmuInitLib|Include/Library/CpuMmuInitLib.h
 
+  ##  @libraryclass  MemDebugLogLib
+  #
+  MemDebugLogLib|Include/Library/MemDebugLogLib.h
+
 [Guids]
   gUefiOvmfPkgTokenSpaceGuid            = {0x93bb96af, 0xb9f2, 0x4eb8, {0x94, 0x62, 0xe0, 0xba, 0x74, 0x56, 0x42, 0x36}}
   gEfiXenInfoGuid                       = {0xd3b46f3b, 0xd441, 0x1244, {0x9a, 0x12, 0x0, 0x12, 0x27, 0x3f, 0xc1, 0x4d}}
@@ -179,6 +183,7 @@
   gQemuFirmwareResourceHobGuid          = {0x3cc47b04, 0x0d3e, 0xaa64, {0x06, 0xa6, 0x4b, 0xdc, 0x9a, 0x2c, 0x61, 0x19}}
   gRtcRegisterBaseAddressHobGuid        = {0x40435d97, 0xeb37, 0x4a4b, {0x7f, 0xad, 0xb7, 0xed, 0x72, 0xa1, 0x43, 0xc5}}
   gOvmfFwCfgInfoHobGuid                 = {0xa291ce0e, 0xdc09, 0x11ee, {0x9e, 0xdb, 0x73, 0x49, 0xd7, 0x92, 0xaf, 0x51}}
+  gMemDebugLogHobGuid                   = {0x95305139, 0xb20f, 0x4723, {0x84, 0x25, 0x62, 0x7c, 0x88, 0x8f, 0xf1, 0x21}}
 
 [Ppis]
   # PPI whose presence in the PPI database signals that the TPM base address
@@ -363,6 +368,13 @@
   gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSecSvsmCaaBase|0|UINT32|0x70
   gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSecSvsmCaaSize|0|UINT32|0x71
 
+  ## The base address and size of the early memory debug log used in SEC
+  #  and early PEI phases - i.e. prior to memory being initialized.
+  #  If this is set in the .fdf, the platform is responsible to
+  #  reserve this area from DXE phase overwrites.
+  gUefiOvmfPkgTokenSpaceGuid.PcdOvmfEarlyMemDebugLogBase|0|UINT32|0x7a
+  gUefiOvmfPkgTokenSpaceGuid.PcdOvmfEarlyMemDebugLogSize|0|UINT32|0x7b
+
 [PcdsDynamic, PcdsDynamicEx]
   gUefiOvmfPkgTokenSpaceGuid.PcdEmuVariableEvent|0|UINT64|2
   gUefiOvmfPkgTokenSpaceGuid.PcdOvmfFlashVariablesEnable|FALSE|BOOLEAN|0x10
@@ -442,6 +454,12 @@
   # invoking the OS loader. This may be needed to work around problematic
   # builds of shim that use the protocol incorrectly.
   gUefiOvmfPkgTokenSpaceGuid.PcdUninstallMemAttrProtocol|FALSE|BOOLEAN|0x67
+
+  ##
+  # Default size of the memory DEBUG log buffer (in pages).
+  # The buffer is circular. So, if size is exceeded, older
+  # messages will be overwritten by more recent messages.
+  gUefiOvmfPkgTokenSpaceGuid.PcdMemDebugLogPages|32|UINT32|0x7c
 
 [PcdsFeatureFlag]
   gUefiOvmfPkgTokenSpaceGuid.PcdQemuBootOrderPciTranslation|TRUE|BOOLEAN|0x1c

--- a/OvmfPkg/OvmfPkgIa32.dsc
+++ b/OvmfPkg/OvmfPkgIa32.dsc
@@ -246,6 +246,7 @@
   TdxLib|MdePkg/Library/TdxLib/TdxLib.inf
   TdxMailboxLib|OvmfPkg/Library/TdxMailboxLib/TdxMailboxLibNull.inf
   TdxHelperLib|OvmfPkg/IntelTdx/TdxHelperLib/TdxHelperLibNull.inf
+  MemDebugLogLib|OvmfPkg/Library/MemDebugLogLib/MemDebugLogLibNull.inf
 
 [LibraryClasses.common.SEC]
   TimerLib|OvmfPkg/Library/AcpiTimerLib/BaseRomAcpiTimerLib.inf

--- a/OvmfPkg/OvmfPkgIa32X64.dsc
+++ b/OvmfPkg/OvmfPkgIa32X64.dsc
@@ -251,6 +251,7 @@
   TdxLib|MdePkg/Library/TdxLib/TdxLib.inf
   TdxMailboxLib|OvmfPkg/Library/TdxMailboxLib/TdxMailboxLibNull.inf
   TdxHelperLib|OvmfPkg/IntelTdx/TdxHelperLib/TdxHelperLibNull.inf
+  MemDebugLogLib|OvmfPkg/Library/MemDebugLogLib/MemDebugLogLibNull.inf
 
 [LibraryClasses.common.SEC]
   TimerLib|OvmfPkg/Library/AcpiTimerLib/BaseRomAcpiTimerLib.inf

--- a/OvmfPkg/OvmfPkgIa32X64.dsc
+++ b/OvmfPkg/OvmfPkgIa32X64.dsc
@@ -251,7 +251,11 @@
   TdxLib|MdePkg/Library/TdxLib/TdxLib.inf
   TdxMailboxLib|OvmfPkg/Library/TdxMailboxLib/TdxMailboxLibNull.inf
   TdxHelperLib|OvmfPkg/IntelTdx/TdxHelperLib/TdxHelperLibNull.inf
+!if $(DEBUG_TO_MEM)
+  MemDebugLogLib|OvmfPkg/Library/MemDebugLogLib/MemDebugLogDxeLib.inf
+!else
   MemDebugLogLib|OvmfPkg/Library/MemDebugLogLib/MemDebugLogLibNull.inf
+!endif
 
 [LibraryClasses.common.SEC]
   TimerLib|OvmfPkg/Library/AcpiTimerLib/BaseRomAcpiTimerLib.inf
@@ -260,6 +264,9 @@
   DebugLib|MdePkg/Library/BaseDebugLibSerialPort/BaseDebugLibSerialPort.inf
 !else
   DebugLib|OvmfPkg/Library/PlatformDebugLibIoPort/PlatformRomDebugLibIoPort.inf
+!endif
+!if $(DEBUG_TO_MEM)
+  MemDebugLogLib|OvmfPkg/Library/MemDebugLogLib/MemDebugLogSecLib.inf
 !endif
   ReportStatusCodeLib|MdeModulePkg/Library/PeiReportStatusCodeLib/PeiReportStatusCodeLib.inf
   ExtractGuidedSectionLib|MdePkg/Library/BaseExtractGuidedSectionLib/BaseExtractGuidedSectionLib.inf
@@ -287,6 +294,9 @@
 !else
   DebugLib|OvmfPkg/Library/PlatformDebugLibIoPort/PlatformRomDebugLibIoPort.inf
 !endif
+!if $(DEBUG_TO_MEM)
+  MemDebugLogLib|OvmfPkg/Library/MemDebugLogLib/MemDebugLogPeiLib.inf
+!endif
   PeCoffLib|MdePkg/Library/BasePeCoffLib/BasePeCoffLib.inf
 
 [LibraryClasses.common.PEIM]
@@ -302,6 +312,9 @@
   DebugLib|MdePkg/Library/BaseDebugLibSerialPort/BaseDebugLibSerialPort.inf
 !else
   DebugLib|OvmfPkg/Library/PlatformDebugLibIoPort/PlatformRomDebugLibIoPort.inf
+!endif
+!if $(DEBUG_TO_MEM)
+  MemDebugLogLib|OvmfPkg/Library/MemDebugLogLib/MemDebugLogPeiLib.inf
 !endif
   PeCoffLib|MdePkg/Library/BasePeCoffLib/BasePeCoffLib.inf
   ResourcePublicationLib|MdePkg/Library/PeiResourcePublicationLib/PeiResourcePublicationLib.inf
@@ -347,6 +360,9 @@
   DebugLib|MdePkg/Library/BaseDebugLibSerialPort/BaseDebugLibSerialPort.inf
 !else
   DebugLib|OvmfPkg/Library/PlatformDebugLibIoPort/PlatformDebugLibIoPort.inf
+!endif
+!if $(DEBUG_TO_MEM)
+  MemDebugLogLib|OvmfPkg/Library/MemDebugLogLib/MemDebugLogRtLib.inf
 !endif
   UefiRuntimeLib|MdePkg/Library/UefiRuntimeLib/UefiRuntimeLib.inf
   BaseCryptLib|CryptoPkg/Library/BaseCryptLib/RuntimeCryptLib.inf
@@ -692,6 +708,9 @@
   # PEI Phase modules
   #
   MdeModulePkg/Core/Pei/PeiMain.inf
+!if $(DEBUG_TO_MEM)
+  OvmfPkg/MemDebugLogPei/MemDebugLogPei.inf
+!endif
   MdeModulePkg/Universal/PCD/Pei/Pcd.inf  {
     <LibraryClasses>
       PcdLib|MdePkg/Library/BasePcdLibNull/BasePcdLibNull.inf
@@ -738,6 +757,9 @@
   MdeModulePkg/Universal/PCD/Dxe/Pcd.inf  {
    <LibraryClasses>
       PcdLib|MdePkg/Library/BasePcdLibNull/BasePcdLibNull.inf
+!if $(DEBUG_TO_MEM)
+      MemDebugLogLib|OvmfPkg/Library/MemDebugLogLib/MemDebugLogLibNull.inf
+!endif
   }
 
   MdeModulePkg/Core/RuntimeDxe/RuntimeDxe.inf
@@ -815,6 +837,9 @@
     <LibraryClasses>
       DevicePathLib|MdePkg/Library/UefiDevicePathLib/UefiDevicePathLib.inf
       PcdLib|MdePkg/Library/BasePcdLibNull/BasePcdLibNull.inf
+!if $(DEBUG_TO_MEM)
+      MemDebugLogLib|OvmfPkg/Library/MemDebugLogLib/MemDebugLogLibNull.inf
+!endif
   }
   MdeModulePkg/Universal/Disk/DiskIoDxe/DiskIoDxe.inf
   MdeModulePkg/Universal/Disk/PartitionDxe/PartitionDxe.inf

--- a/OvmfPkg/OvmfPkgIa32X64.fdf
+++ b/OvmfPkg/OvmfPkgIa32X64.fdf
@@ -82,9 +82,12 @@ gUefiOvmfPkgTokenSpaceGuid.PcdOvmfWorkAreaBase|gUefiOvmfPkgTokenSpaceGuid.PcdOvm
 0x010000|0x010000
 gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSecPeiTempRamBase|gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSecPeiTempRamSize
 
-0x020000|0x0E0000
+0x020000|0x0D0000
 gUefiOvmfPkgTokenSpaceGuid.PcdOvmfPeiMemFvBase|gUefiOvmfPkgTokenSpaceGuid.PcdOvmfPeiMemFvSize
 FV = PEIFV
+
+0x0F0000|0x10000
+gUefiOvmfPkgTokenSpaceGuid.PcdOvmfEarlyMemDebugLogBase|gUefiOvmfPkgTokenSpaceGuid.PcdOvmfEarlyMemDebugLogSize
 
 0x100000|0xE80000
 gUefiOvmfPkgTokenSpaceGuid.PcdOvmfDxeMemFvBase|gUefiOvmfPkgTokenSpaceGuid.PcdOvmfDxeMemFvSize
@@ -152,6 +155,9 @@ READ_LOCK_CAP      = TRUE
 READ_LOCK_STATUS   = TRUE
 
 APRIORI PEI {
+!if $(DEBUG_TO_MEM)
+  INF  OvmfPkg/MemDebugLogPei/MemDebugLogPei.inf
+!endif
   INF  MdeModulePkg/Universal/PCD/Pei/Pcd.inf
 }
 
@@ -162,6 +168,9 @@ INF  MdeModulePkg/Core/Pei/PeiMain.inf
 INF  MdeModulePkg/Universal/PCD/Pei/Pcd.inf
 INF  MdeModulePkg/Universal/ReportStatusCodeRouter/Pei/ReportStatusCodeRouterPei.inf
 INF  MdeModulePkg/Universal/StatusCodeHandler/Pei/StatusCodeHandlerPei.inf
+!if $(DEBUG_TO_MEM)
+INF  OvmfPkg/MemDebugLogPei/MemDebugLogPei.inf
+!endif
 INF  OvmfPkg/PlatformPei/PlatformPei.inf
 INF  MdeModulePkg/Core/DxeIplPeim/DxeIpl.inf
 INF  UefiCpuPkg/Universal/Acpi/S3Resume2Pei/S3Resume2Pei.inf

--- a/OvmfPkg/OvmfPkgX64.dsc
+++ b/OvmfPkg/OvmfPkgX64.dsc
@@ -267,6 +267,7 @@
   CcExitLib|OvmfPkg/Library/CcExitLib/CcExitLib.inf
   TdxLib|MdePkg/Library/TdxLib/TdxLib.inf
   TdxMailboxLib|OvmfPkg/Library/TdxMailboxLib/TdxMailboxLib.inf
+  MemDebugLogLib|OvmfPkg/Library/MemDebugLogLib/MemDebugLogLibNull.inf
 
 [LibraryClasses.common.SEC]
   TimerLib|OvmfPkg/Library/AcpiTimerLib/BaseRomAcpiTimerLib.inf

--- a/OvmfPkg/OvmfPkgX64.dsc
+++ b/OvmfPkg/OvmfPkgX64.dsc
@@ -267,7 +267,11 @@
   CcExitLib|OvmfPkg/Library/CcExitLib/CcExitLib.inf
   TdxLib|MdePkg/Library/TdxLib/TdxLib.inf
   TdxMailboxLib|OvmfPkg/Library/TdxMailboxLib/TdxMailboxLib.inf
+!if $(DEBUG_TO_MEM)
+  MemDebugLogLib|OvmfPkg/Library/MemDebugLogLib/MemDebugLogDxeLib.inf
+!else
   MemDebugLogLib|OvmfPkg/Library/MemDebugLogLib/MemDebugLogLibNull.inf
+!endif
 
 [LibraryClasses.common.SEC]
   TimerLib|OvmfPkg/Library/AcpiTimerLib/BaseRomAcpiTimerLib.inf
@@ -276,6 +280,9 @@
   DebugLib|MdePkg/Library/BaseDebugLibSerialPort/BaseDebugLibSerialPort.inf
 !else
   DebugLib|OvmfPkg/Library/PlatformDebugLibIoPort/PlatformRomDebugLibIoPort.inf
+!endif
+!if $(DEBUG_TO_MEM)
+  MemDebugLogLib|OvmfPkg/Library/MemDebugLogLib/MemDebugLogSecLib.inf
 !endif
   ReportStatusCodeLib|MdeModulePkg/Library/PeiReportStatusCodeLib/PeiReportStatusCodeLib.inf
   ExtractGuidedSectionLib|MdePkg/Library/BaseExtractGuidedSectionLib/BaseExtractGuidedSectionLib.inf
@@ -306,6 +313,9 @@
 !else
   DebugLib|OvmfPkg/Library/PlatformDebugLibIoPort/PlatformRomDebugLibIoPort.inf
 !endif
+!if $(DEBUG_TO_MEM)
+  MemDebugLogLib|OvmfPkg/Library/MemDebugLogLib/MemDebugLogPeiLib.inf
+!endif
   PeCoffLib|MdePkg/Library/BasePeCoffLib/BasePeCoffLib.inf
   CcProbeLib|OvmfPkg/Library/CcProbeLib/SecPeiCcProbeLib.inf
 
@@ -322,6 +332,9 @@
   DebugLib|MdePkg/Library/BaseDebugLibSerialPort/BaseDebugLibSerialPort.inf
 !else
   DebugLib|OvmfPkg/Library/PlatformDebugLibIoPort/PlatformRomDebugLibIoPort.inf
+!endif
+!if $(DEBUG_TO_MEM)
+  MemDebugLogLib|OvmfPkg/Library/MemDebugLogLib/MemDebugLogPeiLib.inf
 !endif
   PeCoffLib|MdePkg/Library/BasePeCoffLib/BasePeCoffLib.inf
   ResourcePublicationLib|MdePkg/Library/PeiResourcePublicationLib/PeiResourcePublicationLib.inf
@@ -371,6 +384,9 @@
   DebugLib|MdePkg/Library/BaseDebugLibSerialPort/BaseDebugLibSerialPort.inf
 !else
   DebugLib|OvmfPkg/Library/PlatformDebugLibIoPort/PlatformDebugLibIoPort.inf
+!endif
+!if $(DEBUG_TO_MEM)
+  MemDebugLogLib|OvmfPkg/Library/MemDebugLogLib/MemDebugLogRtLib.inf
 !endif
   UefiRuntimeLib|MdePkg/Library/UefiRuntimeLib/UefiRuntimeLib.inf
   BaseCryptLib|CryptoPkg/Library/BaseCryptLib/RuntimeCryptLib.inf
@@ -722,6 +738,9 @@
   # PEI Phase modules
   #
   MdeModulePkg/Core/Pei/PeiMain.inf
+!if $(DEBUG_TO_MEM)
+  OvmfPkg/MemDebugLogPei/MemDebugLogPei.inf
+!endif
   MdeModulePkg/Universal/PCD/Pei/Pcd.inf  {
     <LibraryClasses>
       PcdLib|MdePkg/Library/BasePcdLibNull/BasePcdLibNull.inf
@@ -796,6 +815,9 @@
   MdeModulePkg/Universal/PCD/Dxe/Pcd.inf  {
    <LibraryClasses>
       PcdLib|MdePkg/Library/BasePcdLibNull/BasePcdLibNull.inf
+!if $(DEBUG_TO_MEM)
+      MemDebugLogLib|OvmfPkg/Library/MemDebugLogLib/MemDebugLogLibNull.inf
+!endif
   }
 
   MdeModulePkg/Core/RuntimeDxe/RuntimeDxe.inf
@@ -896,6 +918,9 @@
     <LibraryClasses>
       DevicePathLib|MdePkg/Library/UefiDevicePathLib/UefiDevicePathLib.inf
       PcdLib|MdePkg/Library/BasePcdLibNull/BasePcdLibNull.inf
+!if $(DEBUG_TO_MEM)
+      MemDebugLogLib|OvmfPkg/Library/MemDebugLogLib/MemDebugLogLibNull.inf
+!endif
   }
   MdeModulePkg/Universal/Disk/DiskIoDxe/DiskIoDxe.inf
   MdeModulePkg/Universal/Disk/PartitionDxe/PartitionDxe.inf

--- a/OvmfPkg/OvmfPkgX64.fdf
+++ b/OvmfPkg/OvmfPkgX64.fdf
@@ -103,9 +103,12 @@ gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSecApicPageTableBase|gUefiOvmfPkgTokenSpaceGui
 0x011000|0x00F000
 gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSecPeiTempRamBase|gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSecPeiTempRamSize
 
-0x020000|0x0E0000
+0x020000|0x0D0000
 gUefiOvmfPkgTokenSpaceGuid.PcdOvmfPeiMemFvBase|gUefiOvmfPkgTokenSpaceGuid.PcdOvmfPeiMemFvSize
 FV = PEIFV
+
+0x0F0000|0x10000
+gUefiOvmfPkgTokenSpaceGuid.PcdOvmfEarlyMemDebugLogBase|gUefiOvmfPkgTokenSpaceGuid.PcdOvmfEarlyMemDebugLogSize
 
 0x100000|0xE80000
 gUefiOvmfPkgTokenSpaceGuid.PcdOvmfDxeMemFvBase|gUefiOvmfPkgTokenSpaceGuid.PcdOvmfDxeMemFvSize
@@ -173,6 +176,9 @@ READ_LOCK_CAP      = TRUE
 READ_LOCK_STATUS   = TRUE
 
 APRIORI PEI {
+!if $(DEBUG_TO_MEM)
+  INF  OvmfPkg/MemDebugLogPei/MemDebugLogPei.inf
+!endif
   INF  MdeModulePkg/Universal/PCD/Pei/Pcd.inf
 }
 
@@ -183,6 +189,9 @@ INF  MdeModulePkg/Core/Pei/PeiMain.inf
 INF  MdeModulePkg/Universal/PCD/Pei/Pcd.inf
 INF  MdeModulePkg/Universal/ReportStatusCodeRouter/Pei/ReportStatusCodeRouterPei.inf
 INF  MdeModulePkg/Universal/StatusCodeHandler/Pei/StatusCodeHandlerPei.inf
+!if $(DEBUG_TO_MEM)
+INF  OvmfPkg/MemDebugLogPei/MemDebugLogPei.inf
+!endif
 !if $(CC_MEASUREMENT_ENABLE) == TRUE
   INF  OvmfPkg/Tcg/TdTcg2Pei/TdTcg2Pei.inf
 !endif

--- a/OvmfPkg/OvmfXen.dsc
+++ b/OvmfPkg/OvmfXen.dsc
@@ -235,6 +235,7 @@
   BaseCryptLib|CryptoPkg/Library/BaseCryptLib/BaseCryptLib.inf
   CcExitLib|UefiCpuPkg/Library/CcExitLibNull/CcExitLibNull.inf
   TdxLib|MdePkg/Library/TdxLib/TdxLib.inf
+  MemDebugLogLib|OvmfPkg/Library/MemDebugLogLib/MemDebugLogLibNull.inf
 
 [LibraryClasses.common.SEC]
   QemuFwCfgLib|OvmfPkg/Library/QemuFwCfgLib/QemuFwCfgSecLib.inf


### PR DESCRIPTION
# Description

OVMF Memory Debug Logging Support

This PR address comments made in previous PR: https://github.com/tianocore/edk2/pull/10996


Overview:

This PR adds support to log OVMF debug messages to a memory buffer. The memory buffer can be extracted from a VM's QEMU process (or a core file) to debug issues.


Background:

OVMF currently offers 2 methods to collect debug messages:
  1.  debugcon - i.e. via the debug IO port and logged by QEMU to a host disk file
  2.  the serial port/console (-D DEBUG_ON_SERIAL_PORT).

  Both of these methods are impractical under normal VM operation. They increase VM boot time, clutter the serial console, and use host disk resources. In contrast, logging the debug messages to memory is fast and takes no disk resources allowing it to be enabled by default for customer environments. This allows for "first-time" issue analysis, negating the need to reproduce issues with debug messages enabled, which makes for a much better customer experience should an issue occur.


Code Overview:

The code introduces a new PEIM:

    OvmfPkg/MemDebugLogPei: When memory becomes available, this PEIM allocates the main memory debug log buffer and installs a HOB containing the address of the memory log buffer.

The code also introduces 1 new library:

    OvmfPkg/Library/MemDebugLogLib: This library implements the key MemDebugLogWrite() function (called by DebugLib). There is a different implementation of MemDebugLogWrite() for the different module types (i.e. SEC, PEIM, DXE, Runtime). See more detail below. This library also contains core functions to manage access to the memory debug log circular buffer (these "common" functions are used by both this library and the new MemDebugLogPei PEIM)

A bit of complication arises from the the fact that main memory is not available until the PEI phase and several debug messages are logged before then. To remedy this, the code makes use of a "early" memory buffer (taken from the top of PeiMemFvBase) which is used to log the initial (pre-memory) messages. Once memory becomes available, the PEIM code allocates the main memory debug log buffer, copies the messages from the early buffer and installs a HOB containing the main memory buffer address.

Thus, the SEC version of MemDebugLogLib:MemDebugLogWrite() writes debug messages to the "early" debug log buffer. The PEIM version of MemDebugLogLib:MemDebugLogWrite() also writes initial messages to the early buffer until the MemDebugLogPei HOB is installed. Once the HOB is installed the PEI version of MemDebugLogLib:MemDebugLogWrite() switches to write to the main memory buffer (obtaining the main memory buffer address from the HOB). The DXE and runtime versions of the MemDebugLogLib:MemDebugLogWrite() write to the main memory debug log buffer (by also using the HOB). The runtime version of MemDebugLogLib:MemDebugLogWrite() (used by DXE_RUNTIME_DRIVER type drivers) will allow memory debug log writes until the OS makes the SetVirtualAddressMap() BS call - at which point memory debug logging ends.

The OvmfPkg/Library/PlatformDebugLibIoPort library was modified to also write debug messages to memory. This allows both writes to debugcon and memory simultaneously.

Putting it all together, when debugcon is configured in the build (the default), the OVMF debug message call sequence is:
 1. OVMF code makes DEBUG() call - which ends up calling DebugPrintMarker() from OvmfPkg/Library/PlatformDebugLibIoPort/DebugLib.c
 2. DebugPrintMarker() was modified to call MemDebugLogWrite()
 3. MemDebugLogWrite() (from OvmfPkg/Library/MemDebugLogLib) obtains the address of either the "early" memory log buffer or the main memory log buffer - depending on the type of module (SEC, PEI, DXE, etc) - and calls MemDebugLogWriteBuffer()
 4. MemDebugLogWriteBuffer() handles the details of writing the debug message to the circular memory log buffer.

The feature (i.e. the new library and PEIM) are disabled by default and are enabled via the new "DEBUG_TO_MEM" build flag (which can be enabled on the build command line - similar to DEBUG_ON_SERIAL_PORT).


Notes:

The debug log memory buffer size can be configured via FwCfg and is circular - i.e. only the most recent debug messages are retained if the memory buffer overflows. This is appropriate as typically only the most recent debug messages are relevant when debugging an issue. The code currently defaults to a 32 page (128K) sized memory debug log buffer (the default is configured via a PCD).

A host-side tool/utility can be easily implemented to search the VM's QEMU memory regions to locate the OVMF memory debug log buffer (located on a page boundary), decipher the buffer header and display the circular buffer contents (debug messages). We (Oracle) already have such a utility which can extract the OVMF memory debug log from a live QEMU process or a QEMU core file.

This feature doesn't work with Confidential Computing VMs as the guest memory is encrypted and thus not readable from the host. A future enhancement could possibly be made to mark the OVMF memory debug log buffer as unencrypted (?) TBD

This PR only covers OVMF (x86_64) but was written to be easily extended to AAVMF (Arm) in a future PR. TBD


- [x ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

OVMF builds for both OvmfPkgIa32X64.dsc and OvmfPkgX64.dsc (both with and without -D DEBUG_TO_MEM) were built/tested and the OVMF Memory Debug Log extracted from the VM's QEMU process (by a custom utility) and assessed for correctness.

## Integration Instructions

N/A
