### PR TITLE
UefiCpuPkg/PiSmmCpuDxeSmm: Fix SMRAM memory leak during S3 resume

### DIFF
--- a/UefiCpuPkg/PiSmmCpuDxeSmm/MpService.c
+++ b/UefiCpuPkg/PiSmmCpuDxeSmm/MpService.c
@@ -1868,6 +1868,10 @@ InitializeMpSyncData (
   UINTN  CpuIndex;
 
   if (mSmmMpSyncData != NULL) {
+    if (mSmmMpSyncData->SyncContext != NULL) {
+      SmmCpuSyncContextDeinit (mSmmMpSyncData->SyncContext);
+    }
+
     //
     // mSmmMpSyncDataSize includes one structure of SMM_DISPATCHER_MP_SYNC_DATA, one
     // CpuData array of SMM_CPU_DATA_BLOCK and one CandidateBsp array of BOOLEAN.
@@ -1968,6 +1972,7 @@ InitializeMpServiceData (
   mSmmMpSyncData = (SMM_DISPATCHER_MP_SYNC_DATA *)AllocatePages (EFI_SIZE_TO_PAGES (mSmmMpSyncDataSize));
   ASSERT (mSmmMpSyncData != NULL);
 
+  ZeroMem (mSmmMpSyncData, mSmmMpSyncDataSize);
   RelaxedMode = FALSE;
   GetSmmCpuSyncConfigData (&RelaxedMode, NULL, NULL);
   mCpuSmmSyncMode = RelaxedMode ? MmCpuSyncModeRelaxedAp : MmCpuSyncModeTradition;


### PR DESCRIPTION
# Description

SyncContext of SMM_DISPATCHER_MP_SYNC_DATA was dynamically allocated from SMRAM. The memory was not freed before reallocation in S3 resume path. This could lead to:
1. Memory leak in SMRAM.
2. Potential S3 resume failure after repeated S3 tests due to SMRAM exhaustion.

This change releases the SyncContext memory before reallocating it.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested
Run S3 cycling test for over 5000 cycles.

## Integration Instructions
N/A