### PR TITLE
MdeModulePkg: UefiBootManagerLib Change default alignment for ramdisk.

### DIFF
--- a/MdeModulePkg/Library/UefiBootManagerLib/BmBoot.c
+++ b/MdeModulePkg/Library/UefiBootManagerLib/BmBoot.c
@@ -1404,7 +1404,7 @@ BmDestroyRamDisk (
 
   Status = mRamDisk->Unregister (RamDiskDevicePath);
   ASSERT_EFI_ERROR (Status);
-  FreePages (RamDiskBuffer, RamDiskSizeInPages);
+  FreeAlignedPages (RamDiskBuffer, RamDiskSizeInPages);
 }
 
 /**
@@ -1454,8 +1454,12 @@ BmExpandLoadFile (
 
   //
   // The load option resides in a RAM disk.
+  // Use a reasonable default of 2MB for alignment as the ramdisk device is
+  // implemented as an NVDIMM persistent memory and operating systems may
+  // wish to map this with huge page support.
   //
-  FileBuffer = AllocateReservedPages (EFI_SIZE_TO_PAGES (BufferSize));
+
+  FileBuffer = AllocateAlignedReservedPages (EFI_SIZE_TO_PAGES (BufferSize), SIZE_2MB);
   if (FileBuffer == NULL) {
     DEBUG_CODE_BEGIN ();
     EFI_DEVICE_PATH  *LoadFilePath;
@@ -1496,7 +1500,7 @@ BmExpandLoadFile (
 
   Status = LoadFile->LoadFile (LoadFile, FilePath, TRUE, &BufferSize, FileBuffer);
   if (EFI_ERROR (Status)) {
-    FreePages (FileBuffer, EFI_SIZE_TO_PAGES (BufferSize));
+    FreeAlignedPages (FileBuffer, EFI_SIZE_TO_PAGES (BufferSize));
     return NULL;
   }
 


### PR DESCRIPTION
# Description
The ramdisk is modelled as an NVDIMM which have a naturally higher alignment than 4K. Operating systems may wish to map NVDIMMs using large pages, so force the allocation alignment to 2MB.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested
Testing using HTTP ramdisk boot, targeting a windows image.

## Integration Instructions
No integration necessary.