### PR TITLE
Enable x2apic sec

### DIFF
--- a/MdePkg/Include/ConfidentialComputingGuestAttr.h
+++ b/MdePkg/Include/ConfidentialComputingGuestAttr.h
@@ -27,6 +27,8 @@ typedef enum {
   CCAttrAmdSevEs  = 0x101,
   CCAttrAmdSevSnp = 0x102,
 
+  /* The AMD SEV-SNP Alternate Injection feature is enabled in SEV_STATUS */
+  CCAttrFeatureAmdSevSnpAlternateInjection = 0x0000000000020000,
   /* The guest is running with Intel TDX memory encryption enabled. */
   CCAttrIntelTdx = 0x200,
 

--- a/OvmfPkg/Include/Library/MemEncryptSevLib.h
+++ b/OvmfPkg/Include/Library/MemEncryptSevLib.h
@@ -240,4 +240,15 @@ MemEncryptSevSnpPreValidateSystemRam (
   IN UINTN             NumPages
   );
 
+/**
+  Returns a boolean to indicate whether Alternate Injection is enabled.
+
+  @retval TRUE           Alternate Injection is enabled
+  @retval FALSE          Alternate Injection is not enabled
+**/
+BOOLEAN
+EFIAPI
+MemEncryptSevSnpAlternateInjectionIsEnabled (
+  VOID
+  );
 #endif // _MEM_ENCRYPT_SEV_LIB_H_

--- a/OvmfPkg/Library/AmdSvsmLib/AmdSvsmLib.c
+++ b/OvmfPkg/Library/AmdSvsmLib/AmdSvsmLib.c
@@ -12,6 +12,7 @@
 #include <Library/AmdSvsmLib.h>
 #include <Register/Amd/Msr.h>
 #include <Register/Amd/Svsm.h>
+#include <Library/MemEncryptSevLib.h>
 
 #define PAGES_PER_2MB_ENTRY  512
 
@@ -592,4 +593,19 @@ AmdSvsmVtpmCmd (
   Ret = SvsmMsrProtocol (&SvsmCallData);
 
   return (Ret == 0) ? TRUE : FALSE;
+}
+
+/**
+  Check Alternate Injection enablement.
+  @retval TRUE                 Alternate Injection enabled
+  @retval FALSE                Alternate Injection not enabled
+
+**/
+BOOLEAN
+EFIAPI
+AlternateInjectionEnabled (
+  VOID
+  )
+{
+       return MemEncryptSevSnpAlternateInjectionIsEnabled();
 }

--- a/OvmfPkg/Library/AmdSvsmLib/AmdSvsmLib.inf
+++ b/OvmfPkg/Library/AmdSvsmLib/AmdSvsmLib.inf
@@ -32,6 +32,8 @@
   BaseLib
   BaseMemoryLib
   DebugLib
+  MemEncryptSevLib
+
 
 [Pcd]
   gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSnpSecretsBase

--- a/OvmfPkg/Library/BaseMemEncryptSevLib/DxeMemEncryptSevLibInternal.c
+++ b/OvmfPkg/Library/BaseMemEncryptSevLib/DxeMemEncryptSevLibInternal.c
@@ -59,6 +59,8 @@ AmdMemEncryptionAttrCheck (
       return CurrentLevel == CCAttrAmdSevSnp;
     case CCAttrFeatureAmdSevEsDebugVirtualization:
       return !!(CurrentAttr & CCAttrFeatureAmdSevEsDebugVirtualization);
+    case CCAttrFeatureAmdSevSnpAlternateInjection:
+      return !!(CurrentAttr & CCAttrFeatureAmdSevSnpAlternateInjection);
     default:
       return FALSE;
   }
@@ -179,4 +181,19 @@ MemEncryptSevEsDebugVirtualizationIsEnabled (
   )
 {
   return ConfidentialComputingGuestHas (CCAttrFeatureAmdSevEsDebugVirtualization);
+}
+
+/**
+  Returns a boolean to indicate whether Alternate Injection is enabled.
+
+  @retval TRUE           Alternate Injection is enabled
+  @retval FALSE          Alternate Injection is not enabled
+**/
+BOOLEAN
+EFIAPI
+MemEncryptSevSnpAlternateInjectionIsEnabled (
+  VOID
+  )
+{
+  return ConfidentialComputingGuestHas (CCAttrFeatureAmdSevSnpAlternateInjection);
 }

--- a/OvmfPkg/Library/BaseMemEncryptSevLib/PeiMemEncryptSevLibInternal.c
+++ b/OvmfPkg/Library/BaseMemEncryptSevLib/PeiMemEncryptSevLibInternal.c
@@ -160,3 +160,21 @@ MemEncryptSevEsDebugVirtualizationIsEnabled (
 
   return Msr.Bits.DebugVirtualization ? TRUE : FALSE;
 }
+
+/**
+  Returns a boolean to indicate whether DebugVirtualization is enabled.
+
+  @retval TRUE           AlternateInjection is enabled
+  @retval FALSE          AlternateInjection is not enabled
+**/
+BOOLEAN
+EFIAPI
+MemEncryptSevSnpAlternateInjectionIsEnabled (
+  VOID
+  )
+{
+  MSR_SEV_STATUS_REGISTER  Msr;
+
+  Msr.Uint32 = InternalMemEncryptSevStatus ();
+  return Msr.Bits.AlternateInjection ? TRUE : FALSE;
+}

--- a/OvmfPkg/Library/BaseMemEncryptSevLib/SecMemEncryptSevLibInternal.c
+++ b/OvmfPkg/Library/BaseMemEncryptSevLib/SecMemEncryptSevLibInternal.c
@@ -185,3 +185,21 @@ MemEncryptSevLocateInitialSmramSaveStateMapPages (
 {
   return RETURN_UNSUPPORTED;
 }
+
+/**
+  Returns a boolean to indicate whether Alternate Injection is enabled.
+
+  @retval TRUE           AlternateInjection is enabled
+  @retval FALSE          AlternateInjection is not enabled
+**/
+BOOLEAN
+EFIAPI
+MemEncryptSevSnpAlternateInjectionIsEnabled (
+  VOID
+  )
+{
+  MSR_SEV_STATUS_REGISTER  Msr;
+
+  Msr.Uint32 = InternalMemEncryptSevStatus ();
+  return Msr.Bits.AlternateInjection ? TRUE : FALSE;
+}

--- a/OvmfPkg/PlatformPei/AmdSev.c
+++ b/OvmfPkg/PlatformPei/AmdSev.c
@@ -529,6 +529,10 @@ AmdSevInitialize (
     CCGuestAttr |= CCAttrFeatureAmdSevEsDebugVirtualization;
   }
 
+  if (MemEncryptSevSnpAlternateInjectionIsEnabled ()) {
+    CCGuestAttr |= CCAttrFeatureAmdSevSnpAlternateInjection;
+  }
+
   PcdStatus = PcdSet64S (PcdConfidentialComputingGuestAttr, CCGuestAttr);
 
   ASSERT_RETURN_ERROR (PcdStatus);

--- a/OvmfPkg/Sec/SecMain.c
+++ b/OvmfPkg/Sec/SecMain.c
@@ -32,6 +32,8 @@
 #include <Register/Intel/ArchitecturalMsr.h>
 #include <Register/Intel/Cpuid.h>
 #include "AmdSev.h"
+#include <Library/AmdSvsmLib.h>
+#include <Library/MemEncryptSevLib.h>
 
 #define SEC_IDT_ENTRY_COUNT  34
 
@@ -974,6 +976,13 @@ SecCoreStartupWithStack (
   //
   IoWrite8 (0x21, 0xff);
   IoWrite8 (0xA1, 0xff);
+
+  // Enable X2APIC mode if Alternate Injection is enabled.
+  if (AmdSvsmIsSvsmPresent()) {
+       if (AlternateInjectionEnabled()){
+           SetApicMode (LOCAL_APIC_MODE_X2APIC);
+       }
+  }
 
   //
   // Initialize Local APIC Timer hardware and disable Local APIC Timer

--- a/OvmfPkg/Sec/SecMain.inf
+++ b/OvmfPkg/Sec/SecMain.inf
@@ -57,6 +57,7 @@
   CcProbeLib
   CpuPageTableLib
   StackCheckLib
+  AmdSvsmLib
 
 [Ppis]
   gEfiTemporaryRamSupportPpiGuid                # PPI ALWAYS_PRODUCED

--- a/UefiCpuPkg/Include/Library/AmdSvsmLib.h
+++ b/UefiCpuPkg/Include/Library/AmdSvsmLib.h
@@ -139,4 +139,16 @@ AmdSvsmVtpmCmd (
   IN OUT UINT8  *Buffer
   );
 
+/**
+  Check Alternate Injection enablement.
+  @retval TRUE                 Alternate Injection enabled
+  @retval FALSE                Alternate Injection not enabled
+
+**/
+BOOLEAN
+EFIAPI
+AlternateInjectionEnabled (
+   VOID
+   );
+
 #endif

--- a/UefiCpuPkg/Library/AmdSvsmLibNull/AmdSvsmLibNull.c
+++ b/UefiCpuPkg/Library/AmdSvsmLibNull/AmdSvsmLibNull.c
@@ -153,3 +153,18 @@ AmdSvsmVtpmCmd (
 {
   return FALSE;
 }
+
+/**
+  Check Alternate Injection enablement.
+  @retval TRUE                 Alternate Injection enabled
+  @retval FALSE                Alternate Injection not enabled
+
+**/
+BOOLEAN
+EFIAPI
+AlternateInjectionEnabled (
+   VOID
+   )
+{
+   return FALSE;
+}

--- a/UefiCpuPkg/Library/MpInitLib/MpLib.c
+++ b/UefiCpuPkg/Library/MpInitLib/MpLib.c
@@ -3317,6 +3317,8 @@ AmdMemEncryptionAttrCheck (
       return CurrentLevel == CCAttrAmdSevSnp;
     case CCAttrFeatureAmdSevEsDebugVirtualization:
       return !!(CurrentAttr & CCAttrFeatureAmdSevEsDebugVirtualization);
+    case CCAttrFeatureAmdSevSnpAlternateInjection:
+      return !!(CurrentAttr & CCAttrFeatureAmdSevSnpAlternateInjection);
     default:
       return FALSE;
   }


### PR DESCRIPTION
This is a RFC pull request for this: (https://edk2.groups.io/g/devel/message/121291)
"I am currently working on enabling Alternate Injection for AMD SEV-SNP guests and have encountered a design issue.

The Alternate Injection specification, which is still preliminary, defines a so-called SVSM APIC protocol through a subset
of X2APIC MSRs while timer support is configurable.
[ This means, if timer functionality is not supported, the guest must rely on the hypervisor to emulate timer
 support through use of the #HV Timer GHCB protocol. ]

When the OVMF firmware starts, it is in XAPIC mode by default and then, later, during the init phase it switches the guest to X2APIC.
However, with Alternate Injection enabled, the OVMF in its very first phase - SEC - does XAPIC accesses.

The SVSM, however, which is part of the guest, uses the so-called SVSM APIC protocol which uses a subset of the X2APIC MSRs.

The OVMF, however, assumes it starts off in XAPIC memory-mapped mode and thus there's a protocol mismatch of sorts
because with Alternate Injection already enabled in the SEC phase, it mandates X2APIC MSR accesses.

The registers (timer registers) when not handled by SVSM will get routed to the hypervisor (KVM) which at that point is operating the guest
in XAPIC mode until the PEI phase switches to X2APIC.

If X2APIC enablement is moved from the PEI to the SEC phase, the problem can be resolved. I have tested it and it works.
However, I dont know if there is any concern or potential design issues with that move.

Do folks think this is ok to do - i.e., move the X2APIC enablement to the SEC phase?

Or do you have any suggestions for a better solution?"

Ard suggested that I should send it this way in order to collect some comments on the approach. 

Thank you for taking a look and sorry if have not done something right because I am new. 
