### PR TITLE
WifiConnectionManager: PreScan Check for Connect

### DIFF
--- a/NetworkPkg/WifiConnectionManagerDxe/WifiConnectionMgrImpl.c
+++ b/NetworkPkg/WifiConnectionManagerDxe/WifiConnectionMgrImpl.c
@@ -1489,7 +1489,25 @@ WifiMgrOnTimerTick (
   }
 
   Nic = (WIFI_MGR_DEVICE_DATA *)Context;
+  if (Nic->ConnectPendingNetwork == NULL) {
+    DEBUG ((DEBUG_INFO, "[WiFi Connection Manager] No profile for connection, no scan triggered!\n"));
+    gBS->CloseEvent (Event);
+    return;
+  }
+
+  if (StrLen (Nic->ConnectPendingNetwork->SSId) < SSID_MIN_LEN) {
+    DEBUG ((DEBUG_INFO, "[WiFi Connection Manager] Invalid SSID length for connection, no scan triggered!\n"));
+    gBS->CloseEvent (Event);
+    return;
+  }
+
   NET_CHECK_SIGNATURE (Nic, WIFI_MGR_DEVICE_DATA_SIGNATURE);
+
+  if ((Nic->ConnectState == WifiMgrConnectedToAp) || (Nic->ConnectState == WifiMgrConnectingToAp)) {
+    DEBUG ((DEBUG_INFO, "[WiFi Connection Manager] Already connecting to AP, no scan triggered!\n"));
+    gBS->CloseEvent (Event);
+    return;
+  }
 
   Status = WifiMgrGetLinkState (Nic, &LinkState);
   if (EFI_ERROR (Status)) {


### PR DESCRIPTION
# Description

When the Wifi network is enabled the connection
manager will trigger a network scan without a
profile to use. If there is a connected network
or attempting a connection, the scan will
interrupt and break the connection.

Fix - The Wifi Connection Manager will check for
SSID length longer than the minimum SSID length,
and if the state is not in connecting or
connected. Only of SSID string length is over the
defined minimum and state are not connected then
it will attempt the network scan as normal.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

This change was tested on platforms with Wifi connections established and tested if this fixes the break in the current connect as well if this change breaks anything when the platform is supposed to scan correctly.

## Integration Instructions

N/A
