### PR TITLE
BaseTools: Fix Macro Expansion on Machine Architecture for Components

### DIFF
--- a/BaseTools/Source/Python/Workspace/MetaFileParser.py
+++ b/BaseTools/Source/Python/Workspace/MetaFileParser.py
@@ -1,7 +1,7 @@
 ## @file
 # This file is used to parse meta files
 #
-# Copyright (c) 2008 - 2018, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2008 - 2025, Intel Corporation. All rights reserved.<BR>
 # (C) Copyright 2015-2018 Hewlett Packard Enterprise Development LP<BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -1388,7 +1388,7 @@ class DscParser(MetaFileParser):
         self._SectionsMacroDict.clear()
         GlobalData.gPlatformDefines = {}
 
-        # Get all macro and PCD which has straitforward value
+        # Get all macro and PCD which has straightforward value
         self.__RetrievePcdValue()
         self._Content = self._RawTable.GetAll()
         self._ContentIndex = 0
@@ -1464,7 +1464,7 @@ class DscParser(MetaFileParser):
                                 self._ValueList[0],
                                 self._ValueList[1],
                                 self._ValueList[2],
-                                S1,
+                                self._Scope[0][0],
                                 S2,
                                 S3,
                                 NewOwner,
@@ -1711,6 +1711,7 @@ class DscParser(MetaFileParser):
 
     def __ProcessComponent(self):
         self._ValueList[0] = ReplaceMacro(self._ValueList[0], self._Macros)
+        self._Scope[0][0] = ReplaceMacro(self._Scope[0][0], self._Macros)
 
     def __ProcessBuildOption(self):
         self._ValueList = [ReplaceMacro(Value, self._Macros, RaiseError=False)


### PR DESCRIPTION
# Description

BaseTools currently does not expand macros for component architecture when nested !include directives are used. This breaks use cases like `[Component.$(DXE_ARCH)]`.

The fix is to add explicit macro expansion when computing the Arch value for component lines in the DscParser class.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

1. Run `build_bios.py -p BoardX58Ich10` in edk2-platforms/Platform/Intel. A correct workspace to run this build can be generated using `edkrepo clone <workspace_dir_name> Intel-MinPlatform`.
2. Note that BaseTools fails with the message: `Module NetworkPkg/DpcDxe/DpcDxe.inf NOT found in DSC file; Is it really a binary module?`
3. Apply this patch and note that BaseTools is now able to run the build successfully.

## Integration Instructions

N/A
