### PR TITLE
MdeModulePkg: Usb cumulative codeql issues.

### DIFF
--- a/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbBus.c
+++ b/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbBus.c
@@ -739,7 +739,7 @@ UsbIoGetStringDescriptor (
   EFI_USB_STRING_DESCRIPTOR  *StrDesc;
   EFI_TPL                    OldTpl;
   UINT8                      *Buf;
-  UINT8                      Index;
+  UINT16                     Index;
   EFI_STATUS                 Status;
 
   if ((StringIndex == 0) || (LangID == 0)) {

--- a/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbEnumer.c
+++ b/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbEnumer.c
@@ -330,7 +330,7 @@ UsbSelectSetting (
     }
   }
 
-  if (Index == IfDesc->NumOfSetting) {
+  if ((Index == IfDesc->NumOfSetting) || (Setting == NULL)) {
     return EFI_NOT_FOUND;
   }
 
@@ -393,7 +393,7 @@ UsbSelectConfig (
     }
   }
 
-  if (Index == DevDesc->Desc.NumConfigurations) {
+  if ((Index == DevDesc->Desc.NumConfigurations) || (ConfigDesc == NULL)) {
     return EFI_NOT_FOUND;
   }
 

--- a/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbHub.c
+++ b/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbHub.c
@@ -596,7 +596,7 @@ UsbHubInit (
     }
   }
 
-  if (Index == NumEndpoints) {
+  if ((Index == NumEndpoints) || (EpDesc == NULL)) {
     DEBUG ((DEBUG_ERROR, "UsbHubInit: no interrupt endpoint found for hub %d\n", HubDev->Address));
     return EFI_DEVICE_ERROR;
   }

--- a/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbUtility.c
+++ b/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbUtility.c
@@ -850,6 +850,7 @@ UsbBusAddWantedUsbIoDP (
   EFI_STATUS                Status;
   EFI_DEVICE_PATH_PROTOCOL  *DevicePathPtr;
 
+  DevicePathPtr = NULL;
   //
   // Check whether remaining device path is valid
   //
@@ -894,9 +895,12 @@ UsbBusAddWantedUsbIoDP (
   }
 
   ASSERT (DevicePathPtr != NULL);
-  Status = AddUsbDPToList (DevicePathPtr, &Bus->WantedUsbIoDPList);
-  ASSERT (!EFI_ERROR (Status));
-  FreePool (DevicePathPtr);
+  if (DevicePathPtr != NULL) {
+    Status = AddUsbDPToList (DevicePathPtr, &Bus->WantedUsbIoDPList);
+    ASSERT (!EFI_ERROR (Status));
+    FreePool (DevicePathPtr);
+  }
+
   return EFI_SUCCESS;
 }
 
@@ -953,7 +957,9 @@ UsbBusIsWantedUsbIO (
   // Create new Usb device path according to the usb part in UsbIo full device path
   //
   DevicePathPtr = GetUsbDPFromFullDP (UsbIf->DevicePath);
-  ASSERT (DevicePathPtr != NULL);
+  if (DevicePathPtr == NULL) {
+    return FALSE;
+  }
 
   DoConvert       = FALSE;
   WantedListIndex = WantedUsbIoDPListPtr->ForwardLink;

--- a/MdeModulePkg/Bus/Usb/UsbKbDxe/KeyBoard.c
+++ b/MdeModulePkg/Bus/Usb/UsbKbDxe/KeyBoard.c
@@ -437,16 +437,17 @@ GetCurrentKeyboardLayout (
   if (Status == EFI_BUFFER_TOO_SMALL) {
     KeyboardLayout = AllocatePool (Length);
     ASSERT (KeyboardLayout != NULL);
-
-    Status = HiiDatabase->GetKeyboardLayout (
-                            HiiDatabase,
-                            NULL,
-                            &Length,
-                            KeyboardLayout
-                            );
-    if (EFI_ERROR (Status)) {
-      FreePool (KeyboardLayout);
-      KeyboardLayout = NULL;
+    if (KeyboardLayout != NULL) {
+      Status = HiiDatabase->GetKeyboardLayout (
+                              HiiDatabase,
+                              NULL,
+                              &Length,
+                              KeyboardLayout
+                              );
+      if (EFI_ERROR (Status)) {
+        FreePool (KeyboardLayout);
+        KeyboardLayout = NULL;
+      }
     }
   }
 
@@ -683,7 +684,10 @@ SetKeyboardLayoutEvent (
   //
   TableEntry    = GetKeyDescriptor (UsbKeyboardDevice, 0x58);
   KeyDescriptor = GetKeyDescriptor (UsbKeyboardDevice, 0x28);
-  CopyMem (TableEntry, KeyDescriptor, sizeof (EFI_KEY_DESCRIPTOR));
+
+  if ((TableEntry != NULL) && (KeyDescriptor != NULL)) {
+    CopyMem (TableEntry, KeyDescriptor, sizeof (EFI_KEY_DESCRIPTOR));
+  }
 
   FreePool (KeyboardLayout);
 }

--- a/MdeModulePkg/Bus/Usb/UsbMouseAbsolutePointerDxe/UsbMouseAbsolutePointer.c
+++ b/MdeModulePkg/Bus/Usb/UsbMouseAbsolutePointerDxe/UsbMouseAbsolutePointer.c
@@ -160,7 +160,11 @@ USBMouseAbsolutePointerDriverBindingStart (
   }
 
   UsbMouseAbsolutePointerDevice = AllocateZeroPool (sizeof (USB_MOUSE_ABSOLUTE_POINTER_DEV));
-  ASSERT (UsbMouseAbsolutePointerDevice != NULL);
+  if (UsbMouseAbsolutePointerDevice == NULL) {
+    ASSERT (UsbMouseAbsolutePointerDevice != NULL);
+    Status = EFI_OUT_OF_RESOURCES;
+    goto ErrorExit;
+  }
 
   UsbMouseAbsolutePointerDevice->UsbIo     = UsbIo;
   UsbMouseAbsolutePointerDevice->Signature = USB_MOUSE_ABSOLUTE_POINTER_DEV_SIGNATURE;
@@ -631,7 +635,11 @@ InitializeUsbMouseDevice (
   }
 
   ReportDesc = AllocateZeroPool (MouseHidDesc->HidClassDesc[0].DescriptorLength);
-  ASSERT (ReportDesc != NULL);
+  if (ReportDesc == NULL) {
+    ASSERT (ReportDesc != NULL);
+    FreePool (Buf);
+    return EFI_OUT_OF_RESOURCES;
+  }
 
   Status = UsbGetReportDescriptor (
              UsbIo,


### PR DESCRIPTION
# Description

Running Codeql on the MdeModulePkg\Bus\Usb drivers results in codeql errors stemming for the following two checks.

- cpp/comparison-with-wider-type
- cpp/overflow-buffer

- [ ] Breaking change?
- [x] Impacts security?
- [ ] Includes tests?

## How This Was Tested
Local CI, booting virtual platform with no ill effects.

## Integration Instructions
No integration necessary