### PR TITLE
Smm cpu wait all aps fix

### DIFF
--- a/UefiCpuPkg/PiSmmCpuDxeSmm/MpService.c
+++ b/UefiCpuPkg/PiSmmCpuDxeSmm/MpService.c
@@ -236,12 +236,14 @@ SmmWaitForApArrival (
   UINTN    Index;
   UINT32   DelayedCount;
   UINT32   BlockedCount;
+  UINT32   DisabledCount;
   BOOLEAN  SyncNeeded;
 
   PERF_FUNCTION_BEGIN ();
 
-  DelayedCount = 0;
-  BlockedCount = 0;
+  DelayedCount  = 0;
+  BlockedCount  = 0;
+  DisabledCount = 0;
 
   ASSERT (SmmCpuSyncGetArrivedCpuCount (mSmmMpSyncData->SyncContext) <= mNumberOfCpus);
 
@@ -327,11 +329,13 @@ SmmWaitForApArrival (
   }
 
   if (!mSmmMpSyncData->AllApArrivedWithException) {
+    DEBUG ((DEBUG_ERROR, "SmmWaitForApArrival: Failed to wait all APs enter SMI!\n"));
+
     //
-    // Check for the Blocked & Delayed Case.
+    // Check for the Disabled & Blocked & Delayed Case.
     //
-    GetSmmDelayedBlockedDisabledCount (&DelayedCount, &BlockedCount, NULL);
-    DEBUG ((DEBUG_INFO, "SmmWaitForApArrival: Delayed AP Count = %d, Blocked AP Count = %d\n", DelayedCount, BlockedCount));
+    GetSmmDelayedBlockedDisabledCount (&DelayedCount, &BlockedCount, &DisabledCount);
+    DEBUG ((DEBUG_INFO, "SmmWaitForApArrival: Delayed AP Count = %d, Blocked AP Count = %d, Disabled AP Count = %d\n", DelayedCount, BlockedCount, DisabledCount));
   }
 
   PERF_FUNCTION_END ();


### PR DESCRIPTION
# Description

Set AllApArrivedWithException to TRUE if the 1st timeout sync is skipped but all APs have arrived, then set AllApArrivedWithException to TRUE.

This PR also refines the debug log in the SmmWaitForApArrival.

## How This Was Tested

Pass normal boot.