### PR TITLE
MdeModulePkg/Spi: Remove ASSERT checking

### DIFF
--- a/MdeModulePkg/Bus/Spi/SpiNorFlashJedecSfdp/SpiNorFlash.c
+++ b/MdeModulePkg/Bus/Spi/SpiNorFlashJedecSfdp/SpiNorFlash.c
@@ -48,9 +48,8 @@ FillWriteBuffer (
   UINT32  Index;
   UINT8   SfdpAddressBytes;
 
-  if ((Instance == NULL) || (WriteBuffer == NULL)) {
+  if ((Instance == NULL)) {
     ASSERT (Instance != NULL);
-    ASSERT (WriteBuffer != NULL);
     return 0;
   }
 


### PR DESCRIPTION
Remove the WriteBuff null check because passing NULL
 to the function is a valid use case, not an error condition.

# Description

Remove ASSERT checking in the function FillWriteBuffer, becasue the passing NULL to
 the function is a valid use case, not an error condition.
Example: TransactionBufferLength = FillWriteBuffer (
                              Instance,
                              SPI_FLASH_RDSR,
                              SPI_FLASH_RDSR_DUMMY,
                              SPI_FLASH_RDSR_ADDR_BYTES,
                              FALSE,
                              0,
                              0,
                              NULL  //*WriteBuffer//
                              );

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

N/A

## Integration Instructions

N/A
