### PR TITLE
MdeModulePkg/Library: make ArmFfaPeiLib available early PEIM stage

### DIFF
--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaPeiLib.inf
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaPeiLib.inf
@@ -44,5 +44,5 @@
 [Guids]
   gArmFfaRxTxBufferInfoGuid
 
-[Depex]
+[Ppis]
   gEfiPeiMemoryDiscoveredPpiGuid


### PR DESCRIPTION
commit 26fb5edff397 ("MdeModulePkg/ArmFfaLib: Add depex on gEfiPeiMemoryDiscoveredPpiGuid") restricts ArmFfaPeiLib usage only after PEI phase can be used permanent memory. However, This would be problem for PEIM which runs before gEfiPeiMemoryDiscoveredPpiGuid Ppi installed. (i.e) Tcg2Pei PEIM.

To resolve this, remove dependency on gEfiPeiMemoryDiscoveredPpiGuid and let ArmFfaPeiLib remap the Rx/Tx buffer after
gEfiPeiMemoryDiscoveredPpiGuid is installed so that ArmFfaPeiLib can be used with temporary memory.

Signed-off-by: Yeoreum Yun <yeoreum.yun@arm.com>
Fixes: 26fb5edff397 ("MdeModulePkg/ArmFfaLib: Add depex on gEfiPeiMemoryDiscoveredPpiGuid")

## How This Was Tested

Run FVP-RevC with Tcg2Pei, VariableService and MmcommunicationPei.