### PR TITLE
OvmfPkg: Clarify Is800155Event

### DIFF
--- a/OvmfPkg/Tcg/TdTcg2Dxe/TdTcg2Dxe.c
+++ b/OvmfPkg/Tcg/TdTcg2Dxe/TdTcg2Dxe.c
@@ -806,6 +806,7 @@ TdGetEventLog (
   @retval FALSE  This is NOT a Tcg800155PlatformIdEvent.
 
 **/
+STATIC
 BOOLEAN
 Is800155Event (
   IN      VOID    *NewEventHdr,
@@ -814,18 +815,26 @@ Is800155Event (
   IN      UINT32  NewEventSize
   )
 {
-  if ((((TCG_PCR_EVENT2_HDR *)NewEventHdr)->EventType == EV_NO_ACTION) &&
-      (NewEventSize >= sizeof (TCG_Sp800_155_PlatformId_Event2)) &&
-      ((CompareMem (
-          NewEventData,
-          TCG_Sp800_155_PlatformId_Event2_SIGNATURE,
-          sizeof (TCG_Sp800_155_PlatformId_Event2_SIGNATURE) - 1
-          ) == 0) ||
-       (CompareMem (
-          NewEventData,
-          TCG_Sp800_155_PlatformId_Event3_SIGNATURE,
-          sizeof (TCG_Sp800_155_PlatformId_Event3_SIGNATURE) - 1
-          ) == 0)))
+  if (((TCG_PCR_EVENT2_HDR *)NewEventHdr)->EventType != EV_NO_ACTION) {
+    return FALSE;
+  }
+
+  if ((NewEventSize >= sizeof (TCG_Sp800_155_PlatformId_Event2)) &&
+      (CompareMem (
+         NewEventData,
+         TCG_Sp800_155_PlatformId_Event2_SIGNATURE,
+         sizeof (TCG_Sp800_155_PlatformId_Event2_SIGNATURE) - 1
+         ) == 0))
+  {
+    return TRUE;
+  }
+
+  if ((NewEventSize >= sizeof (TCG_Sp800_155_PlatformId_Event3)) &&
+      (CompareMem (
+         NewEventData,
+         TCG_Sp800_155_PlatformId_Event3_SIGNATURE,
+         sizeof (TCG_Sp800_155_PlatformId_Event3_SIGNATURE) - 1
+         ) == 0))
   {
     return TRUE;
   }

--- a/SecurityPkg/Tcg/Tcg2Dxe/Tcg2Dxe.c
+++ b/SecurityPkg/Tcg/Tcg2Dxe/Tcg2Dxe.c
@@ -798,6 +798,7 @@ Tcg2GetEventLog (
   @retval FALSE  This is NOT a Tcg800155PlatformIdEvent.
 
 **/
+STATIC
 BOOLEAN
 Is800155Event (
   IN      VOID    *NewEventHdr,
@@ -806,18 +807,26 @@ Is800155Event (
   IN      UINT32  NewEventSize
   )
 {
-  if ((((TCG_PCR_EVENT2_HDR *)NewEventHdr)->EventType == EV_NO_ACTION) &&
-      (NewEventSize >= sizeof (TCG_Sp800_155_PlatformId_Event2)) &&
-      ((CompareMem (
-          NewEventData,
-          TCG_Sp800_155_PlatformId_Event2_SIGNATURE,
-          sizeof (TCG_Sp800_155_PlatformId_Event2_SIGNATURE) - 1
-          ) == 0) ||
-       (CompareMem (
-          NewEventData,
-          TCG_Sp800_155_PlatformId_Event3_SIGNATURE,
-          sizeof (TCG_Sp800_155_PlatformId_Event3_SIGNATURE) - 1
-          ) == 0)))
+  if (((TCG_PCR_EVENT2_HDR *)NewEventHdr)->EventType != EV_NO_ACTION) {
+    return FALSE;
+  }
+
+  if ((NewEventSize >= sizeof (TCG_Sp800_155_PlatformId_Event2)) &&
+      (CompareMem (
+         NewEventData,
+         TCG_Sp800_155_PlatformId_Event2_SIGNATURE,
+         sizeof (TCG_Sp800_155_PlatformId_Event2_SIGNATURE) - 1
+         ) == 0))
+  {
+    return TRUE;
+  }
+
+  if ((NewEventSize >= sizeof (TCG_Sp800_155_PlatformId_Event3)) &&
+      (CompareMem (
+         NewEventData,
+         TCG_Sp800_155_PlatformId_Event3_SIGNATURE,
+         sizeof (TCG_Sp800_155_PlatformId_Event3_SIGNATURE) - 1
+         ) == 0))
   {
     return TRUE;
   }


### PR DESCRIPTION
The Event3 memory comparison is technically correct since the definitions of the struct types are the same. The extended bodies of the events are different. The Event2 size guard for the Event3 comparison should be split to use the Event3 in its sizeof for better clarity.

The large single condition makes the function difficult to understand, so the combined logic is split into different conditional statements.

There is no dedicated library for event Tcg event predicates to deduplicate this logic into for reuse in SecurityPkg and OvmfPkg, but I'm open to suggestion.

# Description

- [ ] Breaking change? No
- [ ] Impacts security? No
- [ ] Includes tests? No

## How This Was Tested

Internal TPM attestation tests.

## Integration Instructions

N/A