### PR TITLE
MdeModulePkg: Disk cumulative codeql issues.

### DIFF
--- a/MdeModulePkg/Universal/Disk/CdExpressPei/PeiCdExpress.c
+++ b/MdeModulePkg/Universal/Disk/CdExpressPei/PeiCdExpress.c
@@ -199,13 +199,13 @@ UpdateBlocksAndVolumes (
     }
 
     PeiServices = (EFI_PEI_SERVICES  **)GetPeiServicesTablePointer ();
-    if (BlockIo2) {
+    if (BlockIo2 && (BlockIo2Ppi != NULL)) {
       Status = BlockIo2Ppi->GetNumberOfBlockDevices (
                               PeiServices,
                               BlockIo2Ppi,
                               &NumberBlockDevices
                               );
-    } else {
+    } else if (BlockIoPpi != NULL) {
       Status = BlockIoPpi->GetNumberOfBlockDevices (
                              PeiServices,
                              BlockIoPpi,
@@ -221,7 +221,7 @@ UpdateBlocksAndVolumes (
     // Just retrieve the first block, should emulate all blocks.
     //
     for (IndexBlockDevice = 1; IndexBlockDevice <= NumberBlockDevices && PrivateData->CapsuleCount < PEI_CD_EXPRESS_MAX_CAPSULE_NUMBER; IndexBlockDevice++) {
-      if (BlockIo2) {
+      if (BlockIo2 && (BlockIo2Ppi != NULL)) {
         Status = BlockIo2Ppi->GetBlockDeviceMediaInfo (
                                 PeiServices,
                                 BlockIo2Ppi,
@@ -240,7 +240,7 @@ UpdateBlocksAndVolumes (
         DEBUG ((DEBUG_INFO, "PeiCdExpress InterfaceType is %d\n", Media2.InterfaceType));
         DEBUG ((DEBUG_INFO, "PeiCdExpress MediaPresent is %d\n", Media2.MediaPresent));
         DEBUG ((DEBUG_INFO, "PeiCdExpress BlockSize is  0x%x\n", Media2.BlockSize));
-      } else {
+      } else if (BlockIoPpi != NULL) {
         Status = BlockIoPpi->GetBlockDeviceMediaInfo (
                                PeiServices,
                                BlockIoPpi,

--- a/MdeModulePkg/Universal/Disk/DiskIoDxe/DiskIo.c
+++ b/MdeModulePkg/Universal/Disk/DiskIoDxe/DiskIo.c
@@ -997,10 +997,13 @@ DiskIo2ReadWriteDisk (
   //
   if (!Blocking && IsListEmpty (SubtasksPtr)) {
     EfiAcquireLock (&Instance->TaskQueueLock);
-    RemoveEntryList (&Task->Link);
+    if (Task != NULL) {
+      RemoveEntryList (&Task->Link);
+    }
+
     EfiReleaseLock (&Instance->TaskQueueLock);
 
-    if (!EFI_ERROR (Status) && (Task->Token != NULL)) {
+    if (!EFI_ERROR (Status) && (Task != NULL) && (Task->Token != NULL)) {
       //
       // Task->Token should be set to NULL by the DiskIo2OnReadWriteComplete
       // It it's not, that means the non-blocking request was downgraded to blocking request.

--- a/MdeModulePkg/Universal/Disk/PartitionDxe/Mbr.c
+++ b/MdeModulePkg/Universal/Disk/PartitionDxe/Mbr.c
@@ -359,7 +359,7 @@ PartitionInstallMbrChildHandles (
       if (ExtMbrStartingLba == 0) {
         break;
       }
-    } while (ExtMbrStartingLba  < ParentHdDev.PartitionSize);
+    } while ((UINT64)ExtMbrStartingLba  < ParentHdDev.PartitionSize);
   }
 
 Done:

--- a/MdeModulePkg/Universal/Disk/RamDiskDxe/RamDiskProtocol.c
+++ b/MdeModulePkg/Universal/Disk/RamDiskDxe/RamDiskProtocol.c
@@ -167,7 +167,11 @@ RamDiskPublishNfit (
   ASSERT (Status == EFI_BUFFER_TOO_SMALL);
   do {
     MemoryMap = (EFI_MEMORY_DESCRIPTOR *)AllocatePool (MemoryMapSize);
-    ASSERT (MemoryMap != NULL);
+    if (MemoryMap == NULL) {
+      ASSERT (MemoryMap != NULL);
+      return EFI_OUT_OF_RESOURCES;
+    }
+
     Status = gBS->GetMemoryMap (
                     &MemoryMapSize,
                     MemoryMap,
@@ -234,7 +238,7 @@ RamDiskPublishNfit (
     }
   }
 
-  if (!EFI_ERROR (Status)) {
+  if (!EFI_ERROR (Status) && (TableHeader != NULL)) {
     //
     // A NFIT is already in the ACPI table.
     //

--- a/MdeModulePkg/Universal/Disk/UdfDxe/FileSystemOperations.c
+++ b/MdeModulePkg/Universal/Disk/UdfDxe/FileSystemOperations.c
@@ -1449,6 +1449,8 @@ InternalFindFile (
   CHAR16                          FoundFileName[UDF_FILENAME_LENGTH];
   VOID                            *CompareFileEntry;
 
+  CompareFileEntry = NULL;
+
   //
   // Check if both Parent->FileIdentifierDesc and Icb are NULL.
   //


### PR DESCRIPTION

# Description

Running Codeql on MdeModulePkg/Universal/Disk/ drivers results in codeql errors stemming for the following two checks.

- cpp/comparison-with-wider-type
- cpp/overflow-buffer
- cpp/missing-null-test


- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested
Local CI, booting Virutal platform with no ill effects.

## Integration Instructions
No integration necessary.