### PR TITLE
MdeModulePkg: Application cumulative codeql issues.

### DIFF
--- a/MdeModulePkg/Application/BootManagerMenuApp/BootManagerMenu.c
+++ b/MdeModulePkg/Application/BootManagerMenuApp/BootManagerMenu.c
@@ -1096,69 +1096,71 @@ BootManagerMenuEntry (
   // Initialize Boot menu data
   //
   Status = InitializeBootMenuData (BootOption, BootOptionCount, &BootMenuData);
-  //
-  // According to boot menu data to draw boot popup menu
-  //
-  DrawBootPopupMenu (&BootMenuData);
+  if (!EFI_ERROR (Status)) {
+    //
+    // According to boot menu data to draw boot popup menu
+    //
+    DrawBootPopupMenu (&BootMenuData);
 
-  //
-  // check user input to determine want to re-draw or boot from user selected item
-  //
-  ExitApplication = FALSE;
-  while (!ExitApplication) {
-    gBS->WaitForEvent (1, &gST->ConIn->WaitForKey, &Index);
-    Status = gST->ConIn->ReadKeyStroke (gST->ConIn, &Key);
-    if (!EFI_ERROR (Status)) {
-      switch (Key.UnicodeChar) {
-        case CHAR_NULL:
-          switch (Key.ScanCode) {
-            case SCAN_UP:
-              SelectItem = BootMenuData.SelectItem == 0 ? BootMenuData.ItemCount - 1 : BootMenuData.SelectItem - 1;
-              BootMenuSelectItem (SelectItem, &BootMenuData);
-              break;
+    //
+    // check user input to determine want to re-draw or boot from user selected item
+    //
+    ExitApplication = FALSE;
+    while (!ExitApplication) {
+      gBS->WaitForEvent (1, &gST->ConIn->WaitForKey, &Index);
+      Status = gST->ConIn->ReadKeyStroke (gST->ConIn, &Key);
+      if (!EFI_ERROR (Status)) {
+        switch (Key.UnicodeChar) {
+          case CHAR_NULL:
+            switch (Key.ScanCode) {
+              case SCAN_UP:
+                SelectItem = BootMenuData.SelectItem == 0 ? BootMenuData.ItemCount - 1 : BootMenuData.SelectItem - 1;
+                BootMenuSelectItem (SelectItem, &BootMenuData);
+                break;
 
-            case SCAN_DOWN:
-              SelectItem = BootMenuData.SelectItem == BootMenuData.ItemCount - 1 ? 0 : BootMenuData.SelectItem + 1;
-              BootMenuSelectItem (SelectItem, &BootMenuData);
-              break;
+              case SCAN_DOWN:
+                SelectItem = BootMenuData.SelectItem == BootMenuData.ItemCount - 1 ? 0 : BootMenuData.SelectItem + 1;
+                BootMenuSelectItem (SelectItem, &BootMenuData);
+                break;
 
-            case SCAN_ESC:
-              gST->ConOut->ClearScreen (gST->ConOut);
-              ExitApplication = TRUE;
-              //
-              // Set boot resolution for normal boot
-              //
-              BdsSetConsoleMode (FALSE);
-              break;
+              case SCAN_ESC:
+                gST->ConOut->ClearScreen (gST->ConOut);
+                ExitApplication = TRUE;
+                //
+                // Set boot resolution for normal boot
+                //
+                BdsSetConsoleMode (FALSE);
+                break;
 
-            default:
-              break;
-          }
+              default:
+                break;
+            }
 
-          break;
+            break;
 
-        case CHAR_CARRIAGE_RETURN:
-          gST->ConOut->ClearScreen (gST->ConOut);
-          //
-          // Set boot resolution for normal boot
-          //
-          BdsSetConsoleMode (FALSE);
-          BootFromSelectOption (BootOption, BootOptionCount, BootMenuData.SelectItem);
-          //
-          // Back to boot manager menu again, set back to setup resolution
-          //
-          BdsSetConsoleMode (TRUE);
-          DrawBootPopupMenu (&BootMenuData);
-          break;
+          case CHAR_CARRIAGE_RETURN:
+            gST->ConOut->ClearScreen (gST->ConOut);
+            //
+            // Set boot resolution for normal boot
+            //
+            BdsSetConsoleMode (FALSE);
+            BootFromSelectOption (BootOption, BootOptionCount, BootMenuData.SelectItem);
+            //
+            // Back to boot manager menu again, set back to setup resolution
+            //
+            BdsSetConsoleMode (TRUE);
+            DrawBootPopupMenu (&BootMenuData);
+            break;
 
-        default:
-          break;
+          default:
+            break;
+        }
       }
     }
-  }
 
-  EfiBootManagerFreeLoadOptions (BootOption, BootOptionCount);
-  FreePool (BootMenuData.PtrTokens);
+    EfiBootManagerFreeLoadOptions (BootOption, BootOptionCount);
+    FreePool (BootMenuData.PtrTokens);
+  }
 
   HiiRemovePackages (gStringPackHandle);
 

--- a/MdeModulePkg/Application/CapsuleApp/CapsuleDump.c
+++ b/MdeModulePkg/Application/CapsuleApp/CapsuleDump.c
@@ -993,7 +993,7 @@ DumpProvisionedCapsule (
       //
       // Display description and device path
       //
-      GetEfiSysPartitionFromBootOptionFilePath (BootNextOptionEntry.FilePath, &DevicePath, &Fs);
+      Status = GetEfiSysPartitionFromBootOptionFilePath (BootNextOptionEntry.FilePath, &DevicePath, &Fs);
       if (!EFI_ERROR (Status)) {
         Print (L"Capsules are provisioned on BootOption: %s\n", BootNextOptionEntry.Description);
         Print (L"    %s %s\n", ShellProtocol->GetMapFromDevicePath (&DevicePath), ConvertDevicePathToText (DevicePath, TRUE, TRUE));

--- a/MdeModulePkg/Application/CapsuleApp/CapsuleOnDisk.c
+++ b/MdeModulePkg/Application/CapsuleApp/CapsuleOnDisk.c
@@ -518,7 +518,11 @@ GetUpdateFileSystem (
     // If map is assigned, try to get ESP from mapped Fs.
     //
     DevicePath = DuplicateDevicePath (MappedDevicePath);
-    Status     = GetEfiSysPartitionFromDevPath (DevicePath, &FullPath, Fs);
+    if (DevicePath == NULL) {
+      return EFI_OUT_OF_RESOURCES;
+    }
+
+    Status = GetEfiSysPartitionFromDevPath (DevicePath, &FullPath, Fs);
     if (EFI_ERROR (Status)) {
       Print (L"Error: Cannot get EFI system partition from '%s' - %r\n", Map, Status);
       return EFI_NOT_FOUND;

--- a/MdeModulePkg/Application/SmiHandlerProfileInfo/SmiHandlerProfileInfo.c
+++ b/MdeModulePkg/Application/SmiHandlerProfileInfo/SmiHandlerProfileInfo.c
@@ -610,7 +610,12 @@ DumpSmiHandler (
 
         Print (L">\n");
         ImageStruct = GetImageFromRef ((UINTN)SmiHandlerStruct->ImageRef);
-        NameString  = GetDriverNameString (ImageStruct);
+        if (ImageStruct != NULL) {
+          NameString = GetDriverNameString (ImageStruct);
+        } else {
+          NameString = "\0";
+        }
+
         Print (L"      <Module RefId=\"0x%x\" Name=\"%a\">\n", SmiHandlerStruct->ImageRef, NameString);
         if ((ImageStruct != NULL) && (ImageStruct->PdbStringOffset != 0)) {
           Print (L"      <Pdb>%a</Pdb>\n", (UINT8 *)ImageStruct + ImageStruct->PdbStringOffset);

--- a/MdeModulePkg/Application/UiApp/FrontPage.c
+++ b/MdeModulePkg/Application/UiApp/FrontPage.c
@@ -205,40 +205,43 @@ UpdateFrontPageForm (
   //
   StartOpCodeHandle = HiiAllocateOpCodeHandle ();
   ASSERT (StartOpCodeHandle != NULL);
+  if (StartOpCodeHandle != NULL) {
+    EndOpCodeHandle = HiiAllocateOpCodeHandle ();
+    ASSERT (EndOpCodeHandle != NULL);
+    if (EndOpCodeHandle != NULL) {
+      //
+      // Create Hii Extend Label OpCode as the start opcode
+      //
+      StartGuidLabel               = (EFI_IFR_GUID_LABEL *)HiiCreateGuidOpCode (StartOpCodeHandle, &gEfiIfrTianoGuid, NULL, sizeof (EFI_IFR_GUID_LABEL));
+      StartGuidLabel->ExtendOpCode = EFI_IFR_EXTEND_OP_LABEL;
+      StartGuidLabel->Number       = LABEL_FRONTPAGE_INFORMATION;
+      //
+      // Create Hii Extend Label OpCode as the end opcode
+      //
+      EndGuidLabel               = (EFI_IFR_GUID_LABEL *)HiiCreateGuidOpCode (EndOpCodeHandle, &gEfiIfrTianoGuid, NULL, sizeof (EFI_IFR_GUID_LABEL));
+      EndGuidLabel->ExtendOpCode = EFI_IFR_EXTEND_OP_LABEL;
+      EndGuidLabel->Number       = LABEL_END;
 
-  EndOpCodeHandle = HiiAllocateOpCodeHandle ();
-  ASSERT (EndOpCodeHandle != NULL);
-  //
-  // Create Hii Extend Label OpCode as the start opcode
-  //
-  StartGuidLabel               = (EFI_IFR_GUID_LABEL *)HiiCreateGuidOpCode (StartOpCodeHandle, &gEfiIfrTianoGuid, NULL, sizeof (EFI_IFR_GUID_LABEL));
-  StartGuidLabel->ExtendOpCode = EFI_IFR_EXTEND_OP_LABEL;
-  StartGuidLabel->Number       = LABEL_FRONTPAGE_INFORMATION;
-  //
-  // Create Hii Extend Label OpCode as the end opcode
-  //
-  EndGuidLabel               = (EFI_IFR_GUID_LABEL *)HiiCreateGuidOpCode (EndOpCodeHandle, &gEfiIfrTianoGuid, NULL, sizeof (EFI_IFR_GUID_LABEL));
-  EndGuidLabel->ExtendOpCode = EFI_IFR_EXTEND_OP_LABEL;
-  EndGuidLabel->Number       = LABEL_END;
+      //
+      // Updata Front Page form
+      //
+      UiCustomizeFrontPage (
+        gFrontPagePrivate.HiiHandle,
+        StartOpCodeHandle
+        );
 
-  //
-  // Updata Front Page form
-  //
-  UiCustomizeFrontPage (
-    gFrontPagePrivate.HiiHandle,
-    StartOpCodeHandle
-    );
+      HiiUpdateForm (
+        gFrontPagePrivate.HiiHandle,
+        &mFrontPageGuid,
+        FRONT_PAGE_FORM_ID,
+        StartOpCodeHandle,
+        EndOpCodeHandle
+        );
+      HiiFreeOpCodeHandle (EndOpCodeHandle);
+    }
 
-  HiiUpdateForm (
-    gFrontPagePrivate.HiiHandle,
-    &mFrontPageGuid,
-    FRONT_PAGE_FORM_ID,
-    StartOpCodeHandle,
-    EndOpCodeHandle
-    );
-
-  HiiFreeOpCodeHandle (StartOpCodeHandle);
-  HiiFreeOpCodeHandle (EndOpCodeHandle);
+    HiiFreeOpCodeHandle (StartOpCodeHandle);
+  }
 }
 
 /**
@@ -976,7 +979,9 @@ InitializeUserInterface (
   UiSetConsoleMode (FALSE);
 
   UninitializeStringSupport ();
-  HiiRemovePackages (HiiHandle);
+  if (HiiHandle != NULL) {
+    HiiRemovePackages (HiiHandle);
+  }
 
   return EFI_SUCCESS;
 }

--- a/MdeModulePkg/Application/VariableInfo/VariableInfo.c
+++ b/MdeModulePkg/Application/VariableInfo/VariableInfo.c
@@ -131,7 +131,12 @@ PrintInfoFromSmm (
     Entry = (EFI_MEMORY_DESCRIPTOR *)((UINT8 *)Entry + PiSmmCommunicationRegionTable->DescriptorSize);
   }
 
-  ASSERT (CommBuffer != NULL);
+  if (CommBuffer == NULL) {
+    Print (L"Warning: No SMM communication buffer found!\n");
+    ASSERT (CommBuffer != NULL);
+    return EFI_NOT_FOUND;
+  }
+
   ZeroMem (CommBuffer, RealCommSize);
 
   Print (L"SMM Driver Non-Volatile Variables:\n");


### PR DESCRIPTION


# Description
Running Codeql on MdeModulePkg/Application results in codeql errors stemming for the following three checks.

- cpp/comparison-with-wider-type
- cpp/overflow-buffer
- cpp/missing-null-test

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested
Local CI, booting Virtual platform with no ill effects.

## Integration Instructions
No integration necessary.