### PR TITLE
BaseTools: Fix type annotations

### DIFF
--- a/BaseTools/Plugin/CodeQL/analyze/analyze_filter.py
+++ b/BaseTools/Plugin/CodeQL/analyze/analyze_filter.py
@@ -60,15 +60,15 @@ def _match_path_and_rule(
     return result
 
 
-def _parse_pattern(line: str) -> Tuple[str]:
+def _parse_pattern(line: str) -> Tuple[bool, str, str]:
     """Parses a given pattern line.
 
     Args:
         line (str): The line string that contains the rule.
 
     Returns:
-        Tuple[str]: The parsed sign, file pattern, and rule pattern from the
-                    line.
+        Tuple[bool, str, str]: The parsed sign, file pattern, and rule pattern
+                               from the line.
     """
     sep_char = ':'
     esc_char = '\\'

--- a/BaseTools/Plugin/CodeQL/integration/stuart_codeql.py
+++ b/BaseTools/Plugin/CodeQL/integration/stuart_codeql.py
@@ -29,7 +29,7 @@ def add_command_line_option(parser: ArgumentParser) -> None:
              "BaseTools/Plugin/CodeQL/Readme.md for more info.")
 
 
-def get_scopes(codeql_enabled: bool) -> Tuple[str]:
+def get_scopes(codeql_enabled: bool) -> Tuple[str, ...]:
     """Returns the active CodeQL scopes for this build.
 
     Args:

--- a/BaseTools/Source/C/VfrCompile/Pccts/KNOWN_PROBLEMS.txt
+++ b/BaseTools/Source/C/VfrCompile/Pccts/KNOWN_PROBLEMS.txt
@@ -107,7 +107,7 @@
 	***** If I change it to:
 	*****    if ( token!='\0' && token!='}' && token!= ')' ) return -1;
 	*****
-	***** It succeeds, but I'm not sure this is the corrrect approach.
+	***** It succeeds, but I'm not sure this is the correct approach.
 	*****
 	    *g = g1;
 	    return 1;

--- a/BaseTools/Source/Python/AutoGen/AutoGenWorker.py
+++ b/BaseTools/Source/Python/AutoGen/AutoGenWorker.py
@@ -305,8 +305,8 @@ class AutoGenWorkerInProcess(mp.Process):
             self.cache_q.put("CacheDone")
 
     def printStatus(self):
-        print("Processs ID: %d Run %d modules in AutoGen " % (os.getpid(),len(AutoGen.Cache())))
-        print("Processs ID: %d Run %d modules in AutoGenInfo " % (os.getpid(),len(AutoGenInfo.GetCache())))
+        print("Process ID: %d Run %d modules in AutoGen " % (os.getpid(),len(AutoGen.Cache())))
+        print("Process ID: %d Run %d modules in AutoGenInfo " % (os.getpid(),len(AutoGenInfo.GetCache())))
         groupobj = {}
         for buildobj in BuildDB.BuildObject.GetCache().values():
             if str(buildobj).lower().endswith("dec"):
@@ -326,6 +326,6 @@ class AutoGenWorkerInProcess(mp.Process):
                 except:
                     groupobj['inf'] = [str(buildobj)]
 
-        print("Processs ID: %d Run %d pkg in WDB " % (os.getpid(),len(groupobj.get("dec",[]))))
-        print("Processs ID: %d Run %d pla in WDB " % (os.getpid(),len(groupobj.get("dsc",[]))))
-        print("Processs ID: %d Run %d inf in WDB " % (os.getpid(),len(groupobj.get("inf",[]))))
+        print("Process ID: %d Run %d pkg in WDB " % (os.getpid(),len(groupobj.get("dec",[]))))
+        print("Process ID: %d Run %d pla in WDB " % (os.getpid(),len(groupobj.get("dsc",[]))))
+        print("Process ID: %d Run %d inf in WDB " % (os.getpid(),len(groupobj.get("inf",[]))))


### PR DESCRIPTION
Fixed type annotations for functions:
- `def _parse_pattern(line: str) -> Tuple[str]:` -> `def _parse_pattern(line: str) -> Tuple[bool, str, str]:`
- `def get_scopes(codeql_enabled: bool) -> Tuple[str]:` -> `def get_scopes(codeql_enabled: bool) -> Tuple[str, ...]:`

Fix typos:
- `corrrect` -> `correct`
- `Processs` -> `Process`
