### PR TITLE
BaseTools: Fix type annotations

### DIFF
--- a/BaseTools/Plugin/CodeQL/analyze/analyze_filter.py
+++ b/BaseTools/Plugin/CodeQL/analyze/analyze_filter.py
@@ -60,15 +60,15 @@ def _match_path_and_rule(
     return result
 
 
-def _parse_pattern(line: str) -> Tuple[str]:
+def _parse_pattern(line: str) -> Tuple[bool, str, str]:
     """Parses a given pattern line.
 
     Args:
         line (str): The line string that contains the rule.
 
     Returns:
-        Tuple[str]: The parsed sign, file pattern, and rule pattern from the
-                    line.
+        Tuple[bool, str, str]: The parsed sign, file pattern,
+                               and rule pattern from the line.
     """
     sep_char = ':'
     esc_char = '\\'

--- a/BaseTools/Plugin/CodeQL/integration/stuart_codeql.py
+++ b/BaseTools/Plugin/CodeQL/integration/stuart_codeql.py
@@ -29,7 +29,7 @@ def add_command_line_option(parser: ArgumentParser) -> None:
              "BaseTools/Plugin/CodeQL/Readme.md for more info.")
 
 
-def get_scopes(codeql_enabled: bool) -> Tuple[str]:
+def get_scopes(codeql_enabled: bool) -> Tuple[str, ...]:
     """Returns the active CodeQL scopes for this build.
 
     Args:


### PR DESCRIPTION
# Description

Fixed type annotations for functions:
- `def _parse_pattern(line: str) -> Tuple[str]:` -> `def _parse_pattern(line: str) -> Tuple[bool, str, str]:`
- `def get_scopes(codeql_enabled: bool) -> Tuple[str]:` -> `def get_scopes(codeql_enabled: bool) -> Tuple[str, ...]:`

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

N/A

## Integration Instructions

N/A
