### PR TITLE
MdeModulePkg/HiiDatabaseDxe: Fix BlockSize length

### DIFF
--- a/MdeModulePkg/Universal/HiiDatabaseDxe/String.c
+++ b/MdeModulePkg/Universal/HiiDatabaseDxe/String.c
@@ -1000,7 +1000,7 @@ SetStringWorker (
     case EFI_HII_SIBT_STRING_SCSU_FONT:
     case EFI_HII_SIBT_STRINGS_SCSU:
     case EFI_HII_SIBT_STRINGS_SCSU_FONT:
-      BlockSize  = OldBlockSize + StrLen (String);
+      BlockSize  = OldBlockSize + StrSize (String);
       BlockSize -= AsciiStrSize ((CHAR8 *)StringTextPtr);
       Block      = AllocateZeroPool (BlockSize);
       if (Block == NULL) {


### PR DESCRIPTION
# Description

The BlockSize calculation was missing the 0 terminator which caused the string block to shrink by 1 every time the string was processed. Therefore causing memory corruptions, because the string took more memory space as was allocated for the string block therefore corrupting the memory pool at the end (which caused an ASSERT upon trying to free it).

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [x] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

No more ASSERTS from the memory allocator.

## Integration Instructions

N/A