### PR TITLE
MdeModulePkg: FvSimpleFileSystemDxe cumulative codeql issues.

### DIFF
--- a/MdeModulePkg/Universal/FvSimpleFileSystemDxe/FvSimpleFileSystem.c
+++ b/MdeModulePkg/Universal/FvSimpleFileSystemDxe/FvSimpleFileSystem.c
@@ -562,6 +562,10 @@ FvSimpleFileSystemOpen (
       // NewFileNameLength = FileNameLength + 1 + 4 = (Number of non-null character) + (file extension) + (a null character)
       NewFileNameLength     = FileNameLength + 1 + 4;
       FileNameWithExtension = AllocatePool (NewFileNameLength * 2);
+      if (FileNameWithExtension == NULL) {
+        return EFI_OUT_OF_RESOURCES;
+      }
+
       StrCpyS (FileNameWithExtension, NewFileNameLength, FileName);
       StrCatS (FileNameWithExtension, NewFileNameLength, L".EFI");
 

--- a/MdeModulePkg/Universal/FvSimpleFileSystemDxe/FvSimpleFileSystemEntryPoint.c
+++ b/MdeModulePkg/Universal/FvSimpleFileSystemDxe/FvSimpleFileSystemEntryPoint.c
@@ -450,7 +450,10 @@ FvSimpleFileSystemDriverStart (
   // Create an instance
   //
   Instance = AllocateZeroPool (sizeof (FV_FILESYSTEM_INSTANCE));
-  ASSERT (Instance != NULL);
+  if (Instance == NULL) {
+    ASSERT (Instance != NULL);
+    return EFI_OUT_OF_RESOURCES;
+  }
 
   Instance->Root       = NULL;
   Instance->FvProtocol = FvProtocol;


### PR DESCRIPTION

# Description
Running Codeql on MdeModulePkg/Universal/FvSimpleFileSystemDxe drivers results in codeql errors stemming from missing null tests.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested
Local CI, booting Virtual platform with no ill effects.

## Integration Instructions
No integration necessary.