### PR TITLE
MdeModulePkg-SdMmcPciHcDxe: Add missing defines in SD_MMC_HC_SLOT_CAP

### DIFF
--- a/MdeModulePkg/Bus/Pci/SdMmcPciHcDxe/SdMmcPciHci.c
+++ b/MdeModulePkg/Bus/Pci/SdMmcPciHcDxe/SdMmcPciHci.c
@@ -8,6 +8,7 @@
 
   Copyright (c) 2018-2019, NVIDIA CORPORATION. All rights reserved.
   Copyright (c) 2015 - 2020, Intel Corporation. All rights reserved.<BR>
+  Copyright (C) 2023, Apple Inc. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -59,6 +60,7 @@ DumpCapabilityReg (
   DEBUG ((DEBUG_INFO, "   SDR50  Support    %a\n", Capability->Sdr50 ? "TRUE" : "FALSE"));
   DEBUG ((DEBUG_INFO, "   SDR104 Support    %a\n", Capability->Sdr104 ? "TRUE" : "FALSE"));
   DEBUG ((DEBUG_INFO, "   DDR50  Support    %a\n", Capability->Ddr50 ? "TRUE" : "FALSE"));
+  DEBUG ((DEBUG_INFO, "   UHS-II Support    %a\n", Capability->UhsII ? "TRUE" : "FALSE"));
   DEBUG ((DEBUG_INFO, "   Driver Type A     %a\n", Capability->DriverTypeA ? "TRUE" : "FALSE"));
   DEBUG ((DEBUG_INFO, "   Driver Type C     %a\n", Capability->DriverTypeC ? "TRUE" : "FALSE"));
   DEBUG ((DEBUG_INFO, "   Driver Type D     %a\n", Capability->DriverTypeD ? "TRUE" : "FALSE"));
@@ -72,6 +74,8 @@ DumpCapabilityReg (
   DEBUG ((DEBUG_INFO, "   SDR50 Tuning      %a\n", Capability->TuningSDR50 ? "TRUE" : "FALSE"));
   DEBUG ((DEBUG_INFO, "   Retuning Mode     Mode %d\n", Capability->RetuningMod + 1));
   DEBUG ((DEBUG_INFO, "   Clock Multiplier  M = %d\n", Capability->ClkMultiplier + 1));
+  DEBUG ((DEBUG_INFO, "   ADMA3 Support     %a\n", Capability->Adma3 ? "TRUE" : "FALSE"));
+  DEBUG ((DEBUG_INFO, "   1.8V VDD2         %a\n", Capability->Vdd2Voltage18 ? "TRUE" : "FALSE"));
   DEBUG ((DEBUG_INFO, "   HS 400            %a\n", Capability->Hs400 ? "TRUE" : "FALSE"));
   return;
 }

--- a/MdeModulePkg/Bus/Pci/SdMmcPciHcDxe/SdMmcPciHci.h
+++ b/MdeModulePkg/Bus/Pci/SdMmcPciHcDxe/SdMmcPciHci.h
@@ -2,10 +2,13 @@
 
   Provides some data structure definitions used by the SD/MMC host controller driver.
 
-Copyright (c) 2018-2019, NVIDIA CORPORATION. All rights reserved.
-Copyright (c) 2015, Intel Corporation. All rights reserved.<BR>
-SPDX-License-Identifier: BSD-2-Clause-Patent
+  Copyright (c) 2018-2019, NVIDIA CORPORATION. All rights reserved.
+  Copyright (c) 2015, Intel Corporation. All rights reserved.<BR>
+  Copyright (C) 2023, Apple Inc. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
 
+  @par Specification Reference:
+    - SD Host Controller Simplified Specification, Version 4.20, July 25, 2018
 **/
 
 #ifndef _SD_MMC_PCI_HCI_H_
@@ -174,7 +177,7 @@ typedef struct {
   UINT32    Sdr50         : 1; // bit 32
   UINT32    Sdr104        : 1; // bit 33
   UINT32    Ddr50         : 1; // bit 34
-  UINT32    Reserved3     : 1; // bit 35
+  UINT32    UhsII         : 1; // bit 35
   UINT32    DriverTypeA   : 1; // bit 36
   UINT32    DriverTypeC   : 1; // bit 37
   UINT32    DriverTypeD   : 1; // bit 38
@@ -184,7 +187,10 @@ typedef struct {
   UINT32    TuningSDR50   : 1; // bit 45
   UINT32    RetuningMod   : 2; // bit 46:47
   UINT32    ClkMultiplier : 8; // bit 48:55
-  UINT32    Reserved5     : 7; // bit 56:62
+  UINT32    Reserved5     : 3; // bit 56:58
+  UINT32    Adma3         : 1; // bit 59
+  UINT32    Vdd2Voltage18 : 1; // bit 60
+  UINT32    Reserved6     : 2; // bit 61:62
   UINT32    Hs400         : 1; // bit 63
 } SD_MMC_HC_SLOT_CAP;
 


### PR DESCRIPTION
# Description

Add missing bit defines from 2.2.26 Capabilities Register (Cat.C Offset 040h)

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

- Test in system that has SD Card Host Controller

## Integration Instructions

N/A