### PR TITLE
SecurityPkg/Tpm2InstanceLibFfa: Fix constructor wrong name

### DIFF
--- a/SecurityPkg/Library/Tpm2DeviceLibFfa/Tpm2InstanceLibFfa.c
+++ b/SecurityPkg/Library/Tpm2DeviceLibFfa/Tpm2InstanceLibFfa.c
@@ -33,7 +33,7 @@ TPM2_DEVICE_INTERFACE  mFfaTpm2InternalTpm2Device = {
 **/
 EFI_STATUS
 EFIAPI
-Tpm2DeviceLibFfaConstructor (
+Tpm2InstanceLibFfaConstructor (
   VOID
   )
 {


### PR DESCRIPTION
Fix unmatched constructor name of Tpm2InstanceLibFfa.