### PR TITLE
MdeModulePkg: SmmCommunicationBuffer cumulative codeql issues.

### DIFF
--- a/MdeModulePkg/Universal/SmmCommunicationBufferDxe/SmmCommunicationBufferDxe.c
+++ b/MdeModulePkg/Universal/SmmCommunicationBufferDxe/SmmCommunicationBufferDxe.c
@@ -63,6 +63,10 @@ SmmCommunicationBufferEntryPoint (
   //
   PiSmmCommunicationRegionTable = AllocateReservedPool (sizeof (EDKII_PI_SMM_COMMUNICATION_REGION_TABLE) + DescriptorSize);
   ASSERT (PiSmmCommunicationRegionTable != NULL);
+  if (PiSmmCommunicationRegionTable == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
   ZeroMem (PiSmmCommunicationRegionTable, sizeof (EDKII_PI_SMM_COMMUNICATION_REGION_TABLE) + DescriptorSize);
 
   PiSmmCommunicationRegionTable->Version         = EDKII_PI_SMM_COMMUNICATION_REGION_TABLE_VERSION;


### PR DESCRIPTION

# Description
Running Codeql on MdeModulePkg/Universal/SmmCommunicationBuffer drivers results in codeql errors stemming from missing null tests.


- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested
Local CI and booting virtual platform with no ill effects.

## Integration Instructions
No integration necessary.