### PR TITLE
MdeModulePkg: SectionExtractionPei cumulative codeql issues.

### DIFF
--- a/MdeModulePkg/Universal/SectionExtractionPei/SectionExtractionPei.c
+++ b/MdeModulePkg/Universal/SectionExtractionPei/SectionExtractionPei.c
@@ -251,12 +251,15 @@ SectionExtractionPeiEntry (
   if (ExtractHandlerNumber > 0) {
     GuidPpi = (EFI_PEI_PPI_DESCRIPTOR *)AllocatePool (ExtractHandlerNumber * sizeof (EFI_PEI_PPI_DESCRIPTOR));
     ASSERT (GuidPpi != NULL);
-    while (ExtractHandlerNumber-- > 0) {
-      GuidPpi->Flags = EFI_PEI_PPI_DESCRIPTOR_PPI | EFI_PEI_PPI_DESCRIPTOR_TERMINATE_LIST;
-      GuidPpi->Ppi   = (VOID *)&mCustomGuidedSectionExtractionPpi;
-      GuidPpi->Guid  = &ExtractHandlerGuidTable[ExtractHandlerNumber];
-      Status         = PeiServicesInstallPpi (GuidPpi++);
-      ASSERT_EFI_ERROR (Status);
+
+    if (GuidPpi != NULL) {
+      while (ExtractHandlerNumber-- > 0) {
+        GuidPpi->Flags = EFI_PEI_PPI_DESCRIPTOR_PPI | EFI_PEI_PPI_DESCRIPTOR_TERMINATE_LIST;
+        GuidPpi->Ppi   = (VOID *)&mCustomGuidedSectionExtractionPpi;
+        GuidPpi->Guid  = &ExtractHandlerGuidTable[ExtractHandlerNumber];
+        Status         = PeiServicesInstallPpi (GuidPpi++);
+        ASSERT_EFI_ERROR (Status);
+      }
     }
   }
 


### PR DESCRIPTION

# Description

Running Codeql on MdeModulePkg/Universal/SectionExtractionPei drivers results in codeql errors stemming from missing null tests.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested
Local CI and booting virtual platform with no ill effects.

## Integration Instructions
No integration necessary.