### PR TITLE
Extend MM communication v3 to ARM and UEFI variable modules

### DIFF
--- a/ArmPkg/Drivers/MmCommunicationDxe/MmCommunication.c
+++ b/ArmPkg/Drivers/MmCommunicationDxe/MmCommunication.c
@@ -18,6 +18,7 @@
 #include <Library/UefiRuntimeServicesTableLib.h>
 
 #include <Protocol/MmCommunication2.h>
+#include <Protocol/MmCommunication3.h>
 
 #include <IndustryStandard/ArmStdSmc.h>
 #include <IndustryStandard/ArmFfaSvc.h>
@@ -148,6 +149,181 @@ SendSpmMmCommunicate (
 
   This function provides a service to send and receive messages from a registered UEFI service.
 
+  @param[in, out] CommBufferPhysical  Physical address of the MM communication buffer
+  @param[in, out] CommBufferVirtual   Virtual address of the MM communication buffer
+  @param[in, out] CommSize            The size of the data buffer being passed in. On input,
+                                      when not omitted, the buffer should cover EFI_MM_COMMUNICATE_HEADER
+                                      and the value of MessageLength field. On exit, the size
+                                      of data being returned. Zero if the handler does not
+                                      wish to reply with any data. This parameter is optional
+                                      and may be NULL.
+
+  @retval EFI_SUCCESS            The message was successfully posted.
+  @retval EFI_INVALID_PARAMETER  CommBufferPhysical or CommBufferVirtual was NULL, or
+                                 integer value pointed by CommSize does not cover
+                                 EFI_MM_COMMUNICATE_HEADER and the value of MessageLength
+                                 field.
+  @retval EFI_BAD_BUFFER_SIZE    The buffer is too large for the MM implementation.
+                                 If this error is returned, the MessageLength field
+                                 in the CommBuffer header or the integer pointed by
+                                 CommSize, are updated to reflect the maximum payload
+                                 size the implementation can accommodate.
+  @retval EFI_ACCESS_DENIED      The CommunicateBuffer parameter or CommSize parameter,
+                                 if not omitted, are in address range that cannot be
+                                 accessed by the MM environment.
+
+**/
+STATIC
+EFI_STATUS
+EFIAPI
+MmCommunicationCommon (
+  IN OUT VOID   *CommBufferPhysical,
+  IN OUT VOID   *CommBufferVirtual,
+  IN OUT UINTN  *CommSize OPTIONAL
+  )
+{
+  EFI_MM_COMMUNICATE_HEADER     *CommunicateHeader;
+  EFI_MM_COMMUNICATE_HEADER_V3  *CommunicateHeaderV3;
+  UINTN                         BufferSize;
+  UINTN                         *MessageSize;
+  UINTN                         HeaderSize;
+  EFI_STATUS                    Status;
+
+  Status     = EFI_ACCESS_DENIED;
+  BufferSize = 0;
+
+  //
+  // Check parameters
+  //
+  if ((CommBufferVirtual == NULL) || (CommBufferPhysical == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Status              = EFI_SUCCESS;
+  CommunicateHeader   = CommBufferVirtual;
+  CommunicateHeaderV3 = NULL;
+  // CommBuffer is a mandatory parameter. Hence, Rely on
+  // MessageLength + Header to ascertain the
+  // total size of the communication payload rather than
+  // rely on optional CommSize parameter
+  if (CompareGuid (
+        &CommunicateHeader->HeaderGuid,
+        &gEfiMmCommunicateHeaderV3Guid
+        ))
+  {
+    CommunicateHeaderV3 = (EFI_MM_COMMUNICATE_HEADER_V3 *)CommBufferVirtual;
+    BufferSize          = CommunicateHeaderV3->BufferSize;
+    MessageSize         = &CommunicateHeaderV3->MessageSize;
+    HeaderSize          = sizeof (EFI_MM_COMMUNICATE_HEADER_V3);
+  } else {
+    BufferSize = CommunicateHeader->MessageLength +
+                 sizeof (CommunicateHeader->HeaderGuid) +
+                 sizeof (CommunicateHeader->MessageLength);
+    MessageSize = &CommunicateHeader->MessageLength;
+    HeaderSize  = sizeof (CommunicateHeader->HeaderGuid) +
+                  sizeof (CommunicateHeader->MessageLength);
+  }
+
+  // If CommSize is not omitted, perform size inspection before proceeding.
+  if (CommSize != NULL) {
+    // This case can be used by the consumer of this driver to find out the
+    // max size that can be used for allocating CommBuffer.
+    if ((*CommSize == 0) ||
+        (*CommSize > mNsCommBuffMemRegion.Length))
+    {
+      *CommSize = mNsCommBuffMemRegion.Length;
+      Status    = EFI_BAD_BUFFER_SIZE;
+    }
+
+    //
+    // CommSize should cover at least MessageLength + sizeof (EFI_MM_COMMUNICATE_HEADER);
+    //
+    if (*CommSize < BufferSize) {
+      Status = EFI_INVALID_PARAMETER;
+    }
+  }
+
+  //
+  // If the message length is 0 or greater than what can be tolerated by the MM
+  // environment then return the expected size.
+  //
+  if ((*MessageSize == 0) ||
+      (BufferSize > mNsCommBuffMemRegion.Length))
+  {
+    *MessageSize = mNsCommBuffMemRegion.Length - HeaderSize;
+    Status       = EFI_BAD_BUFFER_SIZE;
+  }
+
+  // MessageLength or CommSize check has failed, return here.
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  // Copy Communication Payload
+  CopyMem ((VOID *)mNsCommBuffMemRegion.VirtualBase, CommBufferVirtual, BufferSize);
+
+  if (IsFfaSupported ()) {
+    Status = SendFfaMmCommunicate ();
+  } else {
+    Status = SendSpmMmCommunicate ();
+  }
+
+  if (!EFI_ERROR (Status)) {
+    ZeroMem (CommBufferVirtual, BufferSize);
+    // On successful return, the size of data being returned is inferred from
+    // MessageLength + Header.
+    CommunicateHeader = (EFI_MM_COMMUNICATE_HEADER *)mNsCommBuffMemRegion.VirtualBase;
+    if ((CommunicateHeaderV3 != NULL) && !CompareGuid (
+                                            &CommunicateHeader->HeaderGuid,
+                                            &gEfiMmCommunicateHeaderV3Guid
+                                            ))
+    {
+      // Sanity check to make sure we are still using v3
+      DEBUG ((
+        DEBUG_ERROR,
+        "%a Expected v3 header, but got v1 header! %g\n",
+        __func__,
+        &CommunicateHeader->HeaderGuid
+        ));
+      return EFI_INVALID_PARAMETER;
+    }
+
+    if (CommunicateHeaderV3 != NULL) {
+      CommunicateHeaderV3 = (EFI_MM_COMMUNICATE_HEADER_V3 *)CommunicateHeader;
+      BufferSize          = CommunicateHeaderV3->BufferSize;
+    } else {
+      BufferSize = CommunicateHeader->MessageLength +
+                   sizeof (CommunicateHeader->HeaderGuid) +
+                   sizeof (CommunicateHeader->MessageLength);
+    }
+
+    if (BufferSize > mNsCommBuffMemRegion.Length) {
+      // Something bad has happened, we should have landed in ARM_SMC_MM_RET_NO_MEMORY
+      Status = EFI_BAD_BUFFER_SIZE;
+      DEBUG ((
+        DEBUG_ERROR,
+        "%a Returned buffer exceeds communication buffer limit. Has: 0x%llx vs. max: 0x%llx!\n",
+        __func__,
+        BufferSize,
+        (UINTN)mNsCommBuffMemRegion.Length
+        ));
+    } else {
+      CopyMem (
+        CommBufferVirtual,
+        (VOID *)mNsCommBuffMemRegion.VirtualBase,
+        BufferSize
+        );
+    }
+  }
+
+  return Status;
+}
+
+/**
+  Communicates with a registered handler.
+
+  This function provides a service to send and receive messages from a registered UEFI service.
+
   @param[in] This                     The EFI_MM_COMMUNICATION_PROTOCOL instance.
   @param[in, out] CommBufferPhysical  Physical address of the MM communication buffer
   @param[in, out] CommBufferVirtual   Virtual address of the MM communication buffer
@@ -182,104 +358,26 @@ MmCommunication2Communicate (
   IN OUT UINTN                             *CommSize OPTIONAL
   )
 {
-  EFI_MM_COMMUNICATE_HEADER  *CommunicateHeader;
-  UINTN                      BufferSize;
-  EFI_STATUS                 Status;
+  return MmCommunicationCommon (
+           CommBufferPhysical,
+           CommBufferVirtual,
+           CommSize
+           );
+}
 
-  Status     = EFI_ACCESS_DENIED;
-  BufferSize = 0;
-
-  //
-  // Check parameters
-  //
-  if ((CommBufferVirtual == NULL) || (CommBufferPhysical == NULL)) {
-    return EFI_INVALID_PARAMETER;
-  }
-
-  Status            = EFI_SUCCESS;
-  CommunicateHeader = CommBufferVirtual;
-  // CommBuffer is a mandatory parameter. Hence, Rely on
-  // MessageLength + Header to ascertain the
-  // total size of the communication payload rather than
-  // rely on optional CommSize parameter
-  BufferSize = CommunicateHeader->MessageLength +
-               sizeof (CommunicateHeader->HeaderGuid) +
-               sizeof (CommunicateHeader->MessageLength);
-
-  // If CommSize is not omitted, perform size inspection before proceeding.
-  if (CommSize != NULL) {
-    // This case can be used by the consumer of this driver to find out the
-    // max size that can be used for allocating CommBuffer.
-    if ((*CommSize == 0) ||
-        (*CommSize > mNsCommBuffMemRegion.Length))
-    {
-      *CommSize = mNsCommBuffMemRegion.Length;
-      Status    = EFI_BAD_BUFFER_SIZE;
-    }
-
-    //
-    // CommSize should cover at least MessageLength + sizeof (EFI_MM_COMMUNICATE_HEADER);
-    //
-    if (*CommSize < BufferSize) {
-      Status = EFI_INVALID_PARAMETER;
-    }
-  }
-
-  //
-  // If the message length is 0 or greater than what can be tolerated by the MM
-  // environment then return the expected size.
-  //
-  if ((CommunicateHeader->MessageLength == 0) ||
-      (BufferSize > mNsCommBuffMemRegion.Length))
-  {
-    CommunicateHeader->MessageLength = mNsCommBuffMemRegion.Length -
-                                       sizeof (CommunicateHeader->HeaderGuid) -
-                                       sizeof (CommunicateHeader->MessageLength);
-    Status = EFI_BAD_BUFFER_SIZE;
-  }
-
-  // MessageLength or CommSize check has failed, return here.
-  if (EFI_ERROR (Status)) {
-    return Status;
-  }
-
-  // Copy Communication Payload
-  CopyMem ((VOID *)mNsCommBuffMemRegion.VirtualBase, CommBufferVirtual, BufferSize);
-
-  if (IsFfaSupported ()) {
-    Status = SendFfaMmCommunicate ();
-  } else {
-    Status = SendSpmMmCommunicate ();
-  }
-
-  if (!EFI_ERROR (Status)) {
-    ZeroMem (CommBufferVirtual, BufferSize);
-    // On successful return, the size of data being returned is inferred from
-    // MessageLength + Header.
-    CommunicateHeader = (EFI_MM_COMMUNICATE_HEADER *)mNsCommBuffMemRegion.VirtualBase;
-    BufferSize        = CommunicateHeader->MessageLength +
-                        sizeof (CommunicateHeader->HeaderGuid) +
-                        sizeof (CommunicateHeader->MessageLength);
-    if (BufferSize > mNsCommBuffMemRegion.Length) {
-      // Something bad has happened, we should have landed in ARM_SMC_MM_RET_NO_MEMORY
-      Status = EFI_BAD_BUFFER_SIZE;
-      DEBUG ((
-        DEBUG_ERROR,
-        "%a Returned buffer exceeds communication buffer limit. Has: 0x%llx vs. max: 0x%llx!\n",
-        __func__,
-        BufferSize,
-        (UINTN)mNsCommBuffMemRegion.Length
-        ));
-    } else {
-      CopyMem (
-        CommBufferVirtual,
-        (VOID *)mNsCommBuffMemRegion.VirtualBase,
-        BufferSize
-        );
-    }
-  }
-
-  return Status;
+EFI_STATUS
+EFIAPI
+MmCommunication3Communicate (
+  IN CONST EFI_MM_COMMUNICATION3_PROTOCOL  *This,
+  IN OUT VOID                              *CommBufferPhysical,
+  IN OUT VOID                              *CommBufferVirtual
+  )
+{
+  return MmCommunicationCommon (
+           CommBufferPhysical,
+           CommBufferVirtual,
+           NULL
+           );
 }
 
 //
@@ -287,6 +385,13 @@ MmCommunication2Communicate (
 //
 STATIC EFI_MM_COMMUNICATION2_PROTOCOL  mMmCommunication2 = {
   MmCommunication2Communicate
+};
+
+//
+// MM Communication Protocol instance
+//
+STATIC EFI_MM_COMMUNICATION3_PROTOCOL  mMmCommunication3 = {
+  MmCommunication3Communicate
 };
 
 /**
@@ -682,11 +787,13 @@ MmCommunication2Initialize (
   }
 
   // Install the communication protocol
-  Status = gBS->InstallProtocolInterface (
+  Status = gBS->InstallMultipleProtocolInterfaces (
                   &mMmCommunicateHandle,
                   &gEfiMmCommunication2ProtocolGuid,
-                  EFI_NATIVE_INTERFACE,
-                  &mMmCommunication2
+                  &mMmCommunication2,
+                  &gEfiMmCommunication3ProtocolGuid,
+                  &mMmCommunication3,
+                  NULL
                   );
   if (EFI_ERROR (Status)) {
     DEBUG ((

--- a/ArmPkg/Drivers/MmCommunicationDxe/MmCommunication.inf
+++ b/ArmPkg/Drivers/MmCommunicationDxe/MmCommunication.inf
@@ -43,11 +43,13 @@
 [Protocols]
   gEfiDxeMmReadyToLockProtocolGuid              ## UNDEFINED # SmiHandlerRegister
   gEfiMmCommunication2ProtocolGuid              ## PRODUCES
+  gEfiMmCommunication3ProtocolGuid              ## PRODUCES
 
 [Guids]
   gEfiEndOfDxeEventGroupGuid
   gEfiEventExitBootServicesGuid
   gEfiEventReadyToBootGuid
+  gEfiMmCommunicateHeaderV3Guid
 
 [Pcd.common]
   gArmTokenSpaceGuid.PcdMmBufferBase

--- a/ArmPkg/Drivers/MmCommunicationPei/MmCommunicationPei.inf
+++ b/ArmPkg/Drivers/MmCommunicationPei/MmCommunicationPei.inf
@@ -37,8 +37,12 @@
 [Protocols]
   gEfiMmCommunication2ProtocolGuid
 
+[Guids]
+  gEfiMmCommunicateHeaderV3Guid
+
 [Ppis]
   gEfiPeiMmCommunicationPpiGuid     ## PRODUCES
+  gEfiPeiMmCommunication3PpiGuid    ## PRODUCES
 
 [Depex]
   TRUE

--- a/ArmPkg/Drivers/StandaloneMmCpu/EventHandle.c
+++ b/ArmPkg/Drivers/StandaloneMmCpu/EventHandle.c
@@ -39,7 +39,8 @@ MmFoundationEntryRegister (
 // maintained in single global variable because StandaloneMm is UP-migratable
 // (which means it cannot run concurrently)
 //
-EFI_MM_COMMUNICATE_HEADER  *gGuidedEventContext = NULL;
+EFI_MM_COMMUNICATE_HEADER     *gGuidedEventContext   = NULL;
+EFI_MM_COMMUNICATE_HEADER_V3  *gGuidedEventContextV3 = NULL;
 
 EFI_MM_CONFIGURATION_PROTOCOL  mMmConfig = {
   0,
@@ -89,8 +90,19 @@ PiMmStandaloneMmCpuDriverEntry (
   }
 
   // Find out the size of the buffer passed
-  CommBufferSize = ((EFI_MM_COMMUNICATE_HEADER *)CommBufferAddr)->MessageLength +
-                   sizeof (EFI_MM_COMMUNICATE_HEADER);
+  if (CompareGuid (
+        &((EFI_MM_COMMUNICATE_HEADER *)CommBufferAddr)->HeaderGuid,
+        &gEfiMmCommunicateHeaderV3Guid
+        ))
+  {
+    // This is a v3 header
+    CommBufferSize = ((EFI_MM_COMMUNICATE_HEADER_V3 *)CommBufferAddr)->BufferSize;
+  } else {
+    // This is a v1 header
+    // Find out the size of the buffer passed
+    CommBufferSize = ((EFI_MM_COMMUNICATE_HEADER *)CommBufferAddr)->MessageLength +
+                     OFFSET_OF (EFI_MM_COMMUNICATE_HEADER, Data);
+  }
 
   // Now that the secure world can see the normal world buffer, allocate
   // memory to copy the communication buffer to the secure world.
@@ -188,19 +200,41 @@ PiMmCpuTpFwRootMmiHandler (
     return EFI_NOT_FOUND;
   }
 
-  DEBUG ((
-    DEBUG_INFO,
-    "CommBuffer - 0x%x, CommBufferSize - 0x%x\n",
-    gGuidedEventContext,
-    gGuidedEventContext->MessageLength
-    ));
+  if (CompareGuid (
+        &gGuidedEventContext->HeaderGuid,
+        &gEfiMmCommunicateHeaderV3Guid
+        ))
+  {
+    gGuidedEventContextV3 = (EFI_MM_COMMUNICATE_HEADER_V3 *)gGuidedEventContext;
+    DEBUG ((
+      DEBUG_INFO,
+      "CommBuffer - 0x%x, CommBufferSize - 0x%llx, MessageSize - 0x%llx\n",
+      gGuidedEventContextV3,
+      gGuidedEventContextV3->BufferSize,
+      gGuidedEventContextV3->MessageSize
+      ));
 
-  Status = mMmst->MmiManage (
-                    &gGuidedEventContext->HeaderGuid,
-                    NULL,
-                    gGuidedEventContext->Data,
-                    &gGuidedEventContext->MessageLength
-                    );
+    Status = mMmst->MmiManage (
+                      &gGuidedEventContextV3->MessageGuid,
+                      NULL,
+                      gGuidedEventContextV3->MessageData,
+                      (UINTN *)(&gGuidedEventContextV3->MessageSize)
+                      );
+  } else {
+    DEBUG ((
+      DEBUG_INFO,
+      "CommBuffer - 0x%x, CommBufferSize - 0x%x\n",
+      gGuidedEventContext,
+      gGuidedEventContext->MessageLength
+      ));
+
+    Status = mMmst->MmiManage (
+                      &gGuidedEventContext->HeaderGuid,
+                      NULL,
+                      gGuidedEventContext->Data,
+                      (UINTN *)(&gGuidedEventContext->MessageLength)
+                      );
+  }
 
   if (Status != EFI_SUCCESS) {
     DEBUG ((DEBUG_WARN, "Unable to manage Guided Event - %d\n", Status));

--- a/ArmPkg/Drivers/StandaloneMmCpu/StandaloneMmCpu.inf
+++ b/ArmPkg/Drivers/StandaloneMmCpu/StandaloneMmCpu.inf
@@ -46,6 +46,7 @@
   gZeroGuid
   gMpInformationHobGuid
   gEfiStandaloneMmNonSecureBufferGuid
+  gEfiMmCommunicateHeaderV3Guid
 
 [Depex]
   TRUE

--- a/ArmPkg/Library/ArmStandaloneMmCoreEntryPoint/ArmStandaloneMmCoreEntryPoint.c
+++ b/ArmPkg/Library/ArmStandaloneMmCoreEntryPoint/ArmStandaloneMmCoreEntryPoint.c
@@ -36,6 +36,7 @@
 #include <Library/BaseMemoryLib.h>
 #include <Library/SerialPortLib.h>
 #include <Library/StandaloneMmMmuLib.h>
+#include <Library/SafeIntLib.h>
 #include <Library/PcdLib.h>
 
 #include <IndustryStandard/ArmStdSmc.h>
@@ -45,6 +46,8 @@
 
 #include <Protocol/PiMmCpuDriverEp.h>
 #include <Protocol/MmCommunication.h>
+#include <Protocol/MmCommunication2.h>
+#include <Protocol/MmCommunication3.h>
 
 extern EFI_MM_SYSTEM_TABLE  gMmCoreMmst;
 
@@ -443,7 +446,9 @@ GetServiceType (
   IN EFI_GUID  *ServiceGuid
   )
 {
-  if (CompareGuid (ServiceGuid, &gEfiMmCommunication2ProtocolGuid)) {
+  if (CompareGuid (ServiceGuid, &gEfiMmCommunication2ProtocolGuid) ||
+      CompareGuid (ServiceGuid, &gEfiMmCommunication3ProtocolGuid))
+  {
     return ServiceTypeMmCommunication;
   }
 
@@ -467,10 +472,14 @@ ValidateMmCommBufferAddr (
   IN UINTN  CommBufferAddr
   )
 {
-  UINT64  NsCommBufferEnd;
-  UINT64  SCommBufferEnd;
-  UINT64  CommBufferEnd;
-  UINT64  CommBufferRange;
+  UINT64                        NsCommBufferEnd;
+  UINT64                        SCommBufferEnd;
+  UINT64                        CommBufferEnd;
+  UINT64                        CommBufferRange;
+  UINT64                        BufferSize;
+  UINT64                        BufferEnd;
+  EFI_MM_COMMUNICATE_HEADER_V3  *CommBufferHeaderV3;
+  EFI_STATUS                    Status;
 
   NsCommBufferEnd = mNsCommBuffer->PhysicalStart + mNsCommBuffer->PhysicalSize;
   SCommBufferEnd  = mSCommBuffer->PhysicalStart + mSCommBuffer->PhysicalSize;
@@ -493,11 +502,36 @@ ValidateMmCommBufferAddr (
     return EFI_ACCESS_DENIED;
   }
 
-  // perform bounds check.
-  if (((CommBufferAddr + sizeof (EFI_MM_COMMUNICATE_HEADER) +
-        ((EFI_MM_COMMUNICATE_HEADER *)CommBufferAddr)->MessageLength)) >
-      CommBufferEnd)
+  if (CompareGuid (
+        &((EFI_MM_COMMUNICATE_HEADER *)CommBufferAddr)->HeaderGuid,
+        &gEfiMmCommunicateHeaderV3Guid
+        ))
   {
+    CommBufferHeaderV3 = (EFI_MM_COMMUNICATE_HEADER_V3 *)CommBufferAddr;
+    Status             = SafeUint64Add (
+                           CommBufferHeaderV3->MessageSize,
+                           sizeof (EFI_MM_COMMUNICATE_HEADER_V3),
+                           &BufferSize
+                           );
+    if (EFI_ERROR (Status)) {
+      return EFI_ACCESS_DENIED;
+    }
+  } else {
+    BufferSize = ((EFI_MM_COMMUNICATE_HEADER *)CommBufferAddr)->MessageLength +
+                 OFFSET_OF (EFI_MM_COMMUNICATE_HEADER, Data);
+  }
+
+  Status = SafeUint64Add (
+             CommBufferAddr,
+             BufferSize,
+             &BufferEnd
+             );
+  if (EFI_ERROR (Status)) {
+    return EFI_ACCESS_DENIED;
+  }
+
+  // perform bounds check.
+  if (BufferEnd > CommBufferEnd) {
     return EFI_ACCESS_DENIED;
   }
 

--- a/ArmPkg/Library/ArmStandaloneMmCoreEntryPoint/ArmStandaloneMmCoreEntryPoint.inf
+++ b/ArmPkg/Library/ArmStandaloneMmCoreEntryPoint/ArmStandaloneMmCoreEntryPoint.inf
@@ -59,6 +59,7 @@
 [Protocols]
   gEdkiiPiMmCpuDriverEpProtocolGuid
   gEfiMmCommunication2ProtocolGuid
+  gEfiMmCommunication3ProtocolGuid
 
 [Pcd]
   gArmTokenSpaceGuid.PcdStMmStackSize

--- a/MdeModulePkg/Core/PiSmmCore/PiSmmIpl.c
+++ b/MdeModulePkg/Core/PiSmmCore/PiSmmIpl.c
@@ -737,6 +737,13 @@ MmCommunicationMmCommunicate3 (
   }
 
   CommunicateHeader = (EFI_MM_COMMUNICATE_HEADER_V3 *)CommBufferVirtual;
+  if (!CompareGuid (
+         &CommunicateHeader->HeaderGuid,
+         &gEfiMmCommunicateHeaderV3Guid
+         ))
+  {
+    return EFI_INVALID_PARAMETER;
+  }
 
   Status = SafeUint64Add (sizeof (EFI_MM_COMMUNICATE_HEADER_V3), CommunicateHeader->MessageSize, &MinCommSize);
   if (EFI_ERROR (Status)) {

--- a/MdeModulePkg/Include/Guid/SmmVariableCommon.h
+++ b/MdeModulePkg/Include/Guid/SmmVariableCommon.h
@@ -81,7 +81,8 @@ typedef struct {
 ///
 /// Size of SMM communicate header, without including the payload.
 ///
-#define SMM_COMMUNICATE_HEADER_SIZE  (OFFSET_OF (EFI_MM_COMMUNICATE_HEADER, Data))
+#define SMM_COMMUNICATE_HEADER_SIZE     (OFFSET_OF (EFI_MM_COMMUNICATE_HEADER, Data))
+#define SMM_COMMUNICATE_HEADER_SIZE_V3  (sizeof (EFI_MM_COMMUNICATE_HEADER_V3))
 
 ///
 /// Size of SMM variable communicate header, without including the payload.

--- a/MdeModulePkg/Universal/Variable/MmVariablePei/MmVariablePei.h
+++ b/MdeModulePkg/Universal/Variable/MmVariablePei/MmVariablePei.h
@@ -23,6 +23,7 @@
 
 #include <Ppi/ReadOnlyVariable2.h>
 #include <Ppi/MmCommunication.h>
+#include <Ppi/MmCommunication3.h>
 
 #include <Protocol/SmmVariable.h>
 #include <Protocol/MmCommunication.h>

--- a/MdeModulePkg/Universal/Variable/MmVariablePei/MmVariablePei.inf
+++ b/MdeModulePkg/Universal/Variable/MmVariablePei/MmVariablePei.inf
@@ -34,7 +34,11 @@
 
 [Ppis]
   gEfiPeiReadOnlyVariable2PpiGuid         ## PRODUCES
-  gEfiPeiMmCommunicationPpiGuid           ## CONSUMES
+  gEfiPeiMmCommunication3PpiGuid          ## CONSUMES
+  gEfiPeiMmCommunicationPpiGuid           ## SOMETIMES_CONSUMES
+
+[Guids]
+  gEfiMmCommunicateHeaderV3Guid
 
 [Depex]
-  gEfiPeiMmCommunicationPpiGuid
+  gEfiPeiMmCommunicationPpiGuid OR gEfiPeiMmCommunication3PpiGuid

--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxe.inf
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxe.inf
@@ -66,6 +66,7 @@
   gEfiVariableWriteArchProtocolGuid             ## PRODUCES
   gEfiVariableArchProtocolGuid                  ## PRODUCES
   gEfiMmCommunication2ProtocolGuid              ## CONSUMES
+  gEfiMmCommunication3ProtocolGuid              ## CONSUMES
   ## CONSUMES
   ## NOTIFY
   ## UNDEFINED # Used to do smm communication
@@ -113,9 +114,10 @@
   gEfiEndOfDxeEventGroupGuid
   gEfiDeviceSignatureDatabaseGuid
   gEdkiiVariableRuntimeCacheInfoHobGuid
+  gEfiMmCommunicateHeaderV3Guid
 
 [Depex]
-  gEfiMmCommunication2ProtocolGuid
+  gEfiMmCommunication2ProtocolGuid OR gEfiMmCommunication3ProtocolGuid
 
 [UserExtensions.TianoCore."ExtraFiles"]
   VariableSmmRuntimeDxeExtra.uni


### PR DESCRIPTION
# Description

This change adds support of MM communicate v3 for ARM based drivers and moved variable driver to use MM communicate v3.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

This change was tested on QEMU Q35 and SBSA machines and booted to UEFI shell.

## Integration Instructions

N/A
