### PR TITLE
Adding FF-A memory management library

### DIFF
--- a/Maintainers.txt
+++ b/Maintainers.txt
@@ -404,6 +404,13 @@ F: MdeModulePkg/Bus/Spi/
 M: Abner Chang <abner.chang@amd.com> [changab]
 R: Brit Chesley <brit.chesley@amd.com> [BritChesley]
 
+MdeModulePkg: ARM-FFA related modules
+F: MdeModulePkg/*ArmFfa*
+F: MdeModulePkg/*/ArmFfa*/
+M: Sami Mujawar <Sami.Mujawar@arm.com> [samimujawar]
+R: Yeo Reum Yun <YeoReum.Yun@arm.com> [LeviYeoReum]
+R: Kun Qin <kun.qin@microsoft.com> [kuqin12]
+
 MdePkg
 F: MdePkg/
 W: https://github.com/tianocore/tianocore.github.io/wiki/MdePkg
@@ -447,6 +454,13 @@ F: MdePkg/Include/Library/ArmLib.h
 M: Leif Lindholm <leif.lindholm@oss.qualcomm.com> [leiflindholm]
 M: Ard Biesheuvel <ardb+tianocore@kernel.org> [ardbiesheuvel]
 M: Sami Mujawar <sami.mujawar@arm.com> [samimujawar]
+
+MdePkg: ARM-FFA related interfaces
+F: MdePkg/*ArmFfa*
+F: MdePkg/*/ArmFfa*/
+M: Sami Mujawar <Sami.Mujawar@arm.com> [samimujawar]
+R: Yeo Reum Yun <YeoReum.Yun@arm.com> [LeviYeoReum]
+R: Kun Qin <kun.qin@microsoft.com> [kuqin12]
 
 NetworkPkg
 F: NetworkPkg/

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaCommon.h
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaCommon.h
@@ -17,29 +17,7 @@
 #ifndef ARM_FFA_COMMON_LIB_H_
 #define ARM_FFA_COMMON_LIB_H_
 
-/**
- * Arguments to call FF-A request via SMC/SVC.
- */
-typedef struct ArmFfaArgs {
-  UINTN    Arg0;
-  UINTN    Arg1;
-  UINTN    Arg2;
-  UINTN    Arg3;
-  UINTN    Arg4;
-  UINTN    Arg5;
-  UINTN    Arg6;
-  UINTN    Arg7;
-  UINTN    Arg8;
-  UINTN    Arg9;
-  UINTN    Arg10;
-  UINTN    Arg11;
-  UINTN    Arg12;
-  UINTN    Arg13;
-  UINTN    Arg14;
-  UINTN    Arg15;
-  UINTN    Arg16;
-  UINTN    Arg17;
-} ARM_FFA_ARGS;
+#include <Library/ArmFfaLib.h>
 
 extern BOOLEAN  gFfaSupported;
 extern UINT16   gPartId;
@@ -56,18 +34,6 @@ EFI_STATUS
 EFIAPI
 FfaArgsToEfiStatus (
   IN ARM_FFA_ARGS  *FfaArgs
-  );
-
-/**
-  Trigger FF-A ABI call according to PcdFfaLibConduitSmc.
-
-  @param [in out]  FfaArgs        Ffa arguments
-
-**/
-VOID
-EFIAPI
-ArmCallFfa (
-  IN OUT ARM_FFA_ARGS  *FfaArgs
   );
 
 /**

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaRxTxMapStmm.c
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaRxTxMapStmm.c
@@ -1,0 +1,321 @@
+/** @file
+  Arm Ffa library common code.
+
+  Copyright (c) 2024, Arm Limited. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+   @par Glossary:
+     - FF-A - Firmware Framework for Arm A-profile
+
+   @par Reference(s):
+     - Arm Firmware Framework for Arm A-Profile v1.3 ALP1: [https://developer.arm.com/documentation/den0077/l]
+
+**/
+#include <Uefi.h>
+#include <Pi/PiMultiPhase.h>
+
+#include <Library/ArmLib.h>
+#include <Library/ArmFfaLib.h>
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/PcdLib.h>
+#include <Library/MmServicesTableLib.h>
+
+#include <IndustryStandard/ArmFfaSvc.h>
+#include <Guid/ArmFfaRxTxBufferInfo.h>
+
+#include "ArmFfaCommon.h"
+#include "ArmFfaRxTxMap.h"
+
+EFI_HANDLE                 mArmFfaRxTxBufferStmmInfoHandle = NULL;
+ARM_FFA_RX_TX_BUFFER_INFO  *mArmFfaRxTxBufferStmmInfo      = NULL;
+
+/**
+  Get mapped Rx/Tx buffers.
+
+  @param [out]   TxBuffer         Address of TxBuffer
+  @param [out]   TxBufferSize     Size of TxBuffer
+  @param [out]   RxBuffer         Address of RxBuffer
+  @param [out]   RxBufferSize     Size of RxBuffer
+
+  @retval EFI_SUCCESS
+  @retval Others             Error.
+
+**/
+EFI_STATUS
+EFIAPI
+ArmFfaLibGetRxTxBuffers (
+  OUT VOID    **TxBuffer OPTIONAL,
+  OUT UINT64  *TxBufferSize OPTIONAL,
+  OUT VOID    **RxBuffer OPTIONAL,
+  OUT UINT64  *RxBufferSize OPTIONAL
+  )
+{
+  UINTN  TxBufferAddr;
+  UINTN  RxBufferAddr;
+
+  EFI_STATUS  Status = gMmst->MmLocateProtocol (
+                                &gArmFfaRxTxBufferInfoGuid,
+                                NULL,
+                                (VOID **)&mArmFfaRxTxBufferStmmInfo
+                                );
+
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: Failed to locate Rx/Tx buffer protocol... Status: %r\n", __func__, Status));
+    return Status;
+  }
+
+  TxBufferAddr = (UINTN)mArmFfaRxTxBufferStmmInfo->TxBufferAddr;
+  RxBufferAddr = (UINTN)mArmFfaRxTxBufferStmmInfo->RxBufferAddr;
+
+  if ((TxBufferAddr == 0x00) || (RxBufferAddr == 0x00)) {
+    return EFI_NOT_READY;
+  }
+
+  if (TxBuffer != NULL) {
+    *TxBuffer = (VOID *)TxBufferAddr;
+  }
+
+  if (TxBufferSize != NULL) {
+    *TxBufferSize = mArmFfaRxTxBufferStmmInfo->TxBufferSize;
+  }
+
+  if (RxBuffer != NULL) {
+    *RxBuffer = (VOID *)RxBufferAddr;
+  }
+
+  if (RxBufferSize != NULL) {
+    *RxBufferSize = mArmFfaRxTxBufferStmmInfo->RxBufferSize;
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Mapping Rx/Tx buffers.
+  This function is only called in ArmFfaLibConstructor because
+  Rx/Tx buffer is registered only once per partition.
+
+  @retval EFI_SUCCESS
+  @retval EFI_ALREADY_STARTED     Rx/Tx buffer already mapped.
+  @retval EFI_OUT_OF_RESOURCE     Out of memory
+  @retval EFI_INVALID_PARAMETER   Invalid alignment of Rx/Tx buffer
+  @retval Others                  Error
+
+**/
+EFI_STATUS
+EFIAPI
+ArmFfaLibRxTxMap (
+  IN VOID
+  )
+{
+  EFI_STATUS    Status;
+  ARM_FFA_ARGS  FfaArgs;
+  UINTN         Property1;
+  UINTN         Property2;
+  UINTN         MinSizeAndAlign;
+  UINTN         MaxSize;
+  VOID          *Buffers;
+  VOID          *TxBuffer;
+  VOID          *RxBuffer;
+  UINT64        BufferSize;
+
+  Status = gMmst->MmLocateProtocol (
+                    &gArmFfaRxTxBufferInfoGuid,
+                    NULL,
+                    (VOID **)&mArmFfaRxTxBufferStmmInfo
+                    );
+  if (!EFI_ERROR (Status)) {
+    // Great, we got what we need.
+    return EFI_ALREADY_STARTED;
+  }
+
+  Status = ArmFfaLibGetFeatures (
+             ARM_FID_FFA_RXTX_MAP,
+             FFA_RXTX_MAP_INPUT_PROPERTY_DEFAULT,
+             &Property1,
+             &Property2
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: Failed to get RX/TX buffer property... Status: %r\n",
+      __func__,
+      Status
+      ));
+    return Status;
+  }
+
+  ZeroMem (&FfaArgs, sizeof (ARM_FFA_ARGS));
+
+  MinSizeAndAlign =
+    ((Property1 >>
+      ARM_FFA_BUFFER_MINSIZE_AND_ALIGN_SHIFT) &
+     ARM_FFA_BUFFER_MINSIZE_AND_ALIGN_MASK);
+
+  switch (MinSizeAndAlign) {
+    case ARM_FFA_BUFFER_MINSIZE_AND_ALIGN_4K:
+      MinSizeAndAlign = SIZE_4KB;
+      break;
+    case ARM_FFA_BUFFER_MINSIZE_AND_ALIGN_16K:
+      MinSizeAndAlign = SIZE_16KB;
+      break;
+    case ARM_FFA_BUFFER_MINSIZE_AND_ALIGN_64K:
+      MinSizeAndAlign = SIZE_64KB;
+      break;
+    default:
+      DEBUG ((DEBUG_ERROR, "%a: Invalid MinSizeAndAlign: 0x%x\n", __func__, MinSizeAndAlign));
+      return EFI_UNSUPPORTED;
+  }
+
+  MaxSize = (Property1 >> ARM_FFA_BUFFER_MAXSIZE_PAGE_COUNT_SHIFT) &
+            ARM_FFA_BUFFER_MAXSIZE_PAGE_COUNT_MASK;
+
+  MaxSize = ((MaxSize == 0) ? MAX_UINTN : (MaxSize * MinSizeAndAlign));
+
+  if ((MinSizeAndAlign > (PcdGet64 (PcdFfaTxRxPageCount) * EFI_PAGE_SIZE)) ||
+      (MaxSize < (PcdGet64 (PcdFfaTxRxPageCount) * EFI_PAGE_SIZE)))
+  {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: Buffer is too small! MinSize: 0x%x, MaxSize: 0x%x, PageCount: %d\n",
+      __func__,
+      MinSizeAndAlign,
+      MaxSize,
+      PcdGet64 (PcdFfaTxRxPageCount)
+      ));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Buffers = AllocateAlignedPages ((PcdGet64 (PcdFfaTxRxPageCount) * 2), MinSizeAndAlign);
+  if (Buffers == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  BufferSize = PcdGet64 (PcdFfaTxRxPageCount) * EFI_PAGE_SIZE;
+  TxBuffer   = Buffers;
+  RxBuffer   = Buffers + BufferSize;
+
+  FfaArgs.Arg0 = ARM_FID_FFA_RXTX_MAP;
+  FfaArgs.Arg1 = (UINTN)TxBuffer;
+  FfaArgs.Arg2 = (UINTN)RxBuffer;
+
+  /*
+   * PcdFfaTxRxPageCount sets with count of EFI_PAGE_SIZE granularity
+   * But, PageCounts for Tx/Rx buffer should set with
+   * count of Tx/Rx Buffer's MinSizeAndAlign. granularity.
+   */
+  FfaArgs.Arg3 = PcdGet64 (PcdFfaTxRxPageCount) / EFI_SIZE_TO_PAGES (MinSizeAndAlign);
+
+  ArmCallFfa (&FfaArgs);
+
+  Status = FfaArgsToEfiStatus (&FfaArgs);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: Failed to map Rx/Tx buffer. Status: %r\n",
+      __func__,
+      Status
+      ));
+    goto ErrorHandler;
+  }
+
+  mArmFfaRxTxBufferStmmInfo = AllocateZeroPool (sizeof (ARM_FFA_RX_TX_BUFFER_INFO));
+  if (mArmFfaRxTxBufferStmmInfo == NULL) {
+    Status = EFI_OUT_OF_RESOURCES;
+    goto ErrorHandler;
+  }
+
+  mArmFfaRxTxBufferStmmInfo->TxBufferAddr = TxBuffer;
+  mArmFfaRxTxBufferStmmInfo->RxBufferAddr = RxBuffer;
+  mArmFfaRxTxBufferStmmInfo->TxBufferSize = BufferSize;
+  mArmFfaRxTxBufferStmmInfo->RxBufferSize = BufferSize;
+
+  Status = gMmst->MmInstallProtocolInterface (
+                    &mArmFfaRxTxBufferStmmInfoHandle,
+                    &gArmFfaRxTxBufferInfoGuid,
+                    EFI_NATIVE_INTERFACE,
+                    mArmFfaRxTxBufferStmmInfo
+                    );
+
+  return Status;
+
+ErrorHandler:
+  FreeAlignedPages (Buffers, (PcdGet64 (PcdFfaTxRxPageCount) * 2));
+  TxBuffer = NULL;
+  RxBuffer = NULL;
+
+  return Status;
+}
+
+/**
+  Unmap Rx/Tx buffer.
+  This function is only called in Exit boot service because
+  Rx/Tx buffer is registered only once per partition.
+
+  @retval EFI_SUCCESS
+  @retval EFI_INVALID_PARAMETERS               Already unregistered
+  @retval EFI_UNSUPPORTED                      Not supported
+
+**/
+EFI_STATUS
+EFIAPI
+ArmFfaLibRxTxUnmap (
+  IN VOID
+  )
+{
+  EFI_STATUS    Status;
+  ARM_FFA_ARGS  FfaArgs;
+  VOID          *Buffers;
+
+  if (mArmFfaRxTxBufferStmmInfoHandle == NULL) {
+    // This means that the agent tried to unmap the buffers before even know them.
+    // Let's be a nice player...
+    return EFI_UNSUPPORTED;
+  }
+
+  ZeroMem (&FfaArgs, sizeof (ARM_FFA_ARGS));
+
+  FfaArgs.Arg0 = ARM_FID_FFA_RXTX_UNMAP;
+  FfaArgs.Arg1 = (gPartId << ARM_FFA_SOURCE_EP_SHIFT);
+
+  ArmCallFfa (&FfaArgs);
+
+  Status = FfaArgsToEfiStatus (&FfaArgs);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  /*
+   * Rx/Tx Buffer are allocated with continuous pages.
+   * and start address of these pages is set on PcdFfaTxBuffer.
+   * See ArmFfaLibRxTxMap().
+   */
+  Buffers = (VOID *)(UINTN)mArmFfaRxTxBufferStmmInfo->TxBufferAddr;
+  if (Buffers != NULL) {
+    FreeAlignedPages (Buffers, (EFI_SIZE_TO_PAGES (mArmFfaRxTxBufferStmmInfo->TxBufferSize) * 2));
+  }
+
+  Status = gMmst->MmUninstallProtocolInterface (
+                    mArmFfaRxTxBufferStmmInfoHandle,
+                    &gArmFfaRxTxBufferInfoGuid,
+                    mArmFfaRxTxBufferStmmInfo
+                    );
+
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: Failed to uninstall Rx/Tx buffer protocol... Status: %r\n",
+      __func__,
+      Status
+      ));
+    return Status;
+  }
+
+  FreePool (mArmFfaRxTxBufferStmmInfo);
+  mArmFfaRxTxBufferStmmInfo = NULL;
+
+  return EFI_SUCCESS;
+}

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaStandaloneMmCoreLib.inf
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaStandaloneMmCoreLib.inf
@@ -20,6 +20,8 @@
   ArmFfaCommon.h
   ArmFfaCommon.c
   ArmFfaStandaloneMmLib.c
+  ArmFfaRxTxMap.h
+  ArmFfaRxTxMapStmm.c
 
 [Packages]
   MdePkg/MdePkg.dec
@@ -31,6 +33,11 @@
   BaseLib
   BaseMemoryLib
   DebugLib
+  MmServicesTableLib
 
 [Pcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdFfaLibConduitSmc
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFfaTxRxPageCount
+
+[Guids]
+  gArmFfaRxTxBufferInfoGuid

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaStandaloneMmLib.inf
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaStandaloneMmLib.inf
@@ -20,6 +20,8 @@
   ArmFfaCommon.h
   ArmFfaCommon.c
   ArmFfaStandaloneMmLib.c
+  ArmFfaRxTxMap.h
+  ArmFfaRxTxMapStmm.c
 
 [Packages]
   MdePkg/MdePkg.dec
@@ -31,7 +33,12 @@
   BaseLib
   BaseMemoryLib
   DebugLib
+  MmServicesTableLib
 
 [Pcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdFfaLibConduitSmc
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFfaTxRxPageCount
+
+[Guids]
+  gArmFfaRxTxBufferInfoGuid
 

--- a/MdePkg/Include/IndustryStandard/ArmFfaMemMgmt.h
+++ b/MdePkg/Include/IndustryStandard/ArmFfaMemMgmt.h
@@ -1,0 +1,325 @@
+/** @file
+  Memory management protocol definitions as specfied in the FF-A Memory Management
+  v1.3 APL1 specification.
+
+  Copyright 2021 The Hafnium Authors.
+  Copyright (c), Microsoft Corporation.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+  @par Glossary:
+    - FF-A  - Firmware Framework for Arm A-profile
+
+  @par Reference(s):
+    - FF-A Version 1.3 ALP1 [https://developer.arm.com/documentation/den0077/l]
+    - FF-A Memory Management Protocol 1.3 ALP1 [https://developer.arm.com/documentation/den0140/f]
+
+**/
+
+#ifndef ARM_FFA_MEM_MGMT_H_
+#define ARM_FFA_MEM_MGMT_H_
+
+/**
+  Data access attributes in a memory access permission descriptor. This corresponds
+  to table 1.15 of the FF-A v1.3 APL1, "Memory access permissions descriptor",
+  bits[1:0].
+**/
+#define FFA_DATA_ACCESS_NOT_SPECIFIED  0
+#define FFA_DATA_ACCESS_RO             1
+#define FFA_DATA_ACCESS_RW             2
+#define FFA_DATA_ACCESS_RESERVED       3
+
+/**
+  Intruction access attributes in a memory access permission descriptor.
+
+  This corresponds to table 1.15 of the FF-A Memory Management v1.3 APL1, "Memory
+  access permissions descriptor", bits[3:2].
+**/
+#define FFA_INSTRUCTION_ACCESS_NOT_SPECIFIED  0
+#define FFA_INSTRUCTION_ACCESS_NX             1
+#define FFA_INSTRUCTION_ACCESS_X              2
+#define FFA_INSTRUCTION_ACCESS_RESERVED       3
+
+/**
+  Memory access permission struct definition of memory access permissions descriptor.
+
+  This corresponds to table 1.15 of the FF-A Memory Management v1.3 APL1, "Memory
+  region attributes descriptor".
+**/
+typedef struct {
+  UINT8    DataAccess        : 2;
+  UINT8    InstructionAccess : 2;
+  UINT8    Reservd           : 4;
+} FFA_MEMORY_ACCESS_PERMISSIONS;
+
+/**
+  Memory shareability attributes in a memory region attributes descriptor.
+
+  This corresponds to table 1.18 of the FF-A Memory Management v1.3 APL1, "Memory
+  region attributes descriptor", bits[1:0].
+**/
+#define FFA_MEMORY_SHARE_NON_SHAREABLE  0
+#define FFA_MEMORY_SHARE_RESERVED       1
+#define FFA_MEMORY_OUTER_SHAREABLE      2
+#define FFA_MEMORY_INNER_SHAREABLE      3
+
+/**
+  Memory cacheability or device memory attributes in a memory region attributes
+  descriptor.
+
+  This corresponds to table 1.18 of the FF-A Memory Management v1.3 APL1, "Memory
+  region attributes descriptor", bits[3:2].
+**/
+#define FFA_MEMORY_CACHE_RESERVED       0x0
+#define FFA_MEMORY_CACHE_NON_CACHEABLE  0x1
+#define FFA_MEMORY_CACHE_RESERVED_1     0x2
+#define FFA_MEMORY_CACHE_WRITE_BACK     0x3
+#define FFA_MEMORY_DEV_NGNRNE           0x0
+#define FFA_MEMORY_DEV_NGNRE            0x1
+#define FFA_MEMORY_DEV_NGRE             0x2
+#define FFA_MEMORY_DEV_GRE              0x3
+
+/**
+  Memory type in a memory region attributes descriptor.
+
+  This corresponds to table 1.18 of the FF-A Memory Management v1.3 APL1, "Memory
+  region attributes descriptor", bits[5:4].
+**/
+#define FFA_MEMORY_NOT_SPECIFIED_MEM  0
+#define FFA_MEMORY_DEVICE_MEM         1
+#define FFA_MEMORY_NORMAL_MEM         2
+
+/**
+  FF-A Memory Management v1.3 APL1 Table 1.18 "Memory region attributes descriptor"
+  bits[6]. Per section 1.10.4.1, NS bit is reserved for FFA_MEM_DONATE/LEND/SHARE
+  and FFA_MEM_RETRIEVE_REQUEST.
+**/
+#define FFA_MEMORY_SECURITY_SECURE      0
+#define FFA_MEMORY_SECURITY_NON_SECURE  1
+
+/**
+  Reserved bits (SBZ) of a memory region attributes descriptor.
+
+  This corresponds to table 1.18 of the FF-A Memory Management v1.3 APL1, "Memory
+  region attributes descriptor", bits[15:7].
+**/
+#define FFA_MEMORY_ATTRIBUTES_MBZ_MASK  0xFF80U
+
+/**
+  Memory region attributes struct definition of memory region attribute descriptor.
+
+  This corresponds to table 1.18 of the FF-A Memory Management v1.3 APL1, "Memory
+  region attributes descriptor".
+**/
+typedef struct {
+  UINT16    Shareability : 2;
+  UINT16    Cacheability : 2;
+  UINT16    Type         : 2;
+  UINT16    Security     : 1;
+  UINT16    Reserved     : 9;
+} FFA_MEMORY_ATTRIBUTES;
+
+/**
+  A set of contiguous pages which is part of a memory region.
+
+  This corresponds to table 1.14 of the the FF-A Memory Management v1.3 APL1, "Constituent
+  memory region descriptor".
+**/
+typedef struct {
+  /**
+    The base IPA of the constituent memory region, aligned to 4 kiB page
+    size granularity.
+  **/
+  UINT64    Address;
+  /** The number of 4 kiB pages in the constituent memory region. **/
+  UINT32    PageCount;
+  /** Reserved field, SBZ. **/
+  UINT32    Reserved;
+} FFA_MEMORY_REGION_CONSTITUENT;
+
+/**
+  A set of pages comprising a memory region.
+
+  This corresponds to table 1.13 of the FF-A Memory Management v1.3 APL1, "Composite
+  memory region descriptor".
+**/
+typedef struct {
+  /**
+   The total number of 4 kiB pages included in this memory region. This
+   must be equal to the sum of page counts specified in each
+   `FFA_MEMORY_REGION_CONSTITUENT`.
+  **/
+  UINT32                           TotalPageCount;
+
+  /**
+   The number of constituents (`FFA_MEMORY_REGION_CONSTITUENT`)
+   included in this memory region range.
+  **/
+  UINT32                           ConstituentCount;
+  /** Reserved field, SBZ. */
+  UINT64                           Reserved;
+  /** An array of `ConstituentCount` memory region constituents. */
+  FFA_MEMORY_REGION_CONSTITUENT    Constituents[];
+} FFA_COMPOSITE_MEMORY_REGION;
+
+/**
+  Flags to indicate properties of memory management ABI being invoked.
+
+  This corresponds to table 1.17 of the FF-A Memory Management v1.3 APL1, "Flags
+  Flags usage in FFA_MEM_RETRIEVE_REQ and FFA_MEM_RETRIEVE_RESP ABIs", Bit[0].
+**/
+#define FFA_MEMORY_ACCESS_PERMISSION_FLAG_MASK           ((0x1U) << 0)
+#define FFA_MEMORY_ACCESS_PERMISSION_FLAG_UNSPECIFIED    ((0x0U) << 0)
+#define FFA_MEMORY_ACCESS_PERMISSION_FLAG_RETRIEVAL      ((0x0U) << 0)
+#define FFA_MEMORY_ACCESS_PERMISSION_FLAG_NON_RETRIEVAL  ((0x1U) << 0)
+
+/**
+  Memory region attributes descriptor.
+
+  This corresponds to table 1.15 of the FF-A Memory Management v1.3 APL1, "Memory
+  access permissions descriptor".
+**/
+typedef struct {
+  /** The ID of the VM to which the memory is being given or shared. **/
+  UINT16                           ReceiverId;
+
+  /**
+   The permissions with which the memory region should be mapped in the
+   receiver's page table.
+  **/
+  FFA_MEMORY_ACCESS_PERMISSIONS    Permissions;
+
+  /**
+   Flags used during FFA_MEM_RETRIEVE_REQ and FFA_MEM_RETRIEVE_RESP
+   for memory regions with multiple borrowers.
+  **/
+  UINT8                            Flags;
+} FFA_MEMORY_ACCESS_PERMISSIONS_DESCRIPTOR;
+
+/**
+  Endpoint memory access descriptor.
+
+  This corresponds to table 1.16 of the FF-A Memory Management v1.3 APL1, "Endpoint
+  memory access descriptor".
+**/
+typedef struct {
+  FFA_MEMORY_ACCESS_PERMISSIONS_DESCRIPTOR    ReceiverPermissions;
+
+  /**
+    Offset in bytes from the start of the outer `FFA_MEMORY_TRANSACTION_DESCRIPTOR` to
+    an `FFA_COMPOSITE_MEMORY_REGION` struct.
+  **/
+  UINT32                                      CompositeMemoryRegionOffset;
+  UINT8                                       ImpementationDefined[16];
+  UINT64                                      Reserved;
+} FFA_ENDPOINT_MEMORY_ACCESS_DESCRIPTOR;
+
+/**
+  Clear memory region contents after unmapping it from the sender and before
+  mapping it for any receiver.
+
+  This corresponds to table 1.22 of the FF-A Memory Management v1.3 APL1, "Flags
+  usage in FFA_MEM_RETRIEVE_REQ ABI", bits[0].
+**/
+#define FFA_MEMORY_REGION_FLAG_CLEAR  0x1
+
+/**
+  Whether the hypervisor may time slice the memory sharing or retrieval
+  operation.
+
+  This corresponds to table 1.22 of the FF-A Memory Management v1.3 APL1, "Flags
+  usage in FFA_MEM_RETRIEVE_REQ ABI", bits[1].
+**/
+#define FFA_MEMORY_REGION_FLAG_TIME_SLICE  0x2
+
+/**
+  Whether the hypervisor should clear the memory region after the receiver
+  relinquishes it or is aborted.
+
+  This corresponds to table 1.22 of the FF-A Memory Management v1.3 APL1, "Flags
+  usage in FFA_MEM_RETRIEVE_REQ ABI", bits[2].
+**/
+#define FFA_MEMORY_REGION_FLAG_CLEAR_RELINQUISH  0x4
+
+/**
+  Transaction type for memory region retrieval.
+
+  This corresponds to table 1.22 of the FF-A Memory Management v1.3 APL1, "Flags
+  usage in FFA_MEM_RETRIEVE_REQ ABI", bits[3].
+**/
+#define FFA_MEMORY_REGION_TRANSACTION_TYPE_MASK         ((0x3U) << 3)
+#define FFA_MEMORY_REGION_TRANSACTION_TYPE_UNSPECIFIED  ((0x0U) << 3)
+#define FFA_MEMORY_REGION_TRANSACTION_TYPE_SHARE        ((0x1U) << 3)
+#define FFA_MEMORY_REGION_TRANSACTION_TYPE_LEND         ((0x2U) << 3)
+#define FFA_MEMORY_REGION_TRANSACTION_TYPE_DONATE       ((0x3U) << 3)
+
+/**
+  Address range hint for memory region retrieval.
+
+  This corresponds to table 1.22 of the FF-A Memory Management v1.3 APL1, "Flags
+  usage in FFA_MEM_RETRIEVE_REQ ABI", bits[9:5].
+**/
+#define FFA_MEMORY_REGION_ADDRESS_RANGE_HINT_VALID  ((0x1U) << 9)
+#define FFA_MEMORY_REGION_ADDRESS_RANGE_HINT_MASK   ((0xFU) << 5)
+
+/**
+  On retrieve request, bypass the multi-borrower check.
+
+  This corresponds to table 1.22 of the FF-A Memory Management v1.3 APL1, "Flags
+  usage in FFA_MEM_RETRIEVE_REQ ABI", bits[10].
+**/
+#define FFA_MEMORY_REGION_FLAG_BYPASS_BORROWERS_CHECK  (0x1U << 10)
+
+/**
+  Information about a set of pages which are being shared.
+
+  This corresponds to table 1.20 of the FF-A Memory Management v1.3 APL1, "Memory
+  transaction descriptor". Note that it is also used for retrieve requests and responses.
+**/
+typedef struct {
+  /**
+    The ID of the VM which originally sent the memory region, i.e. the
+    owner.
+  **/
+  UINT16                   SenderId;
+  FFA_MEMORY_ATTRIBUTES    Attributes;
+  /** Flags to control behaviour of the transaction. **/
+  UINT32                   Flags;
+  UINT64                   Handle;
+
+  /**
+    An implementation defined value associated with the receiver and the
+    memory region.
+  **/
+  UINT64                   Tag;
+  /** Size of the memory access descriptor. **/
+  UINT32                   MemoryAccessDescSize;
+
+  /**
+    The number of `FFA_ENDPOINT_MEMORY_ACCESS_DESCRIPTOR` entries included in this
+    transaction.
+  **/
+  UINT32                   ReceiverCount;
+
+  /**
+    Offset to the 'FFA_ENDPOINT_MEMORY_ACCESS_DESCRIPTOR' field, which relates to
+    the memory access descriptors.
+  **/
+  UINT32                   ReceiversOffset;
+  /** Reserved field (12 bytes) SBZ. */
+  UINT8                    Reserved[12];
+} FFA_MEMORY_TRANSACTION_DESCRIPTOR;
+
+/**
+  Descriptor used for FFA_MEM_RELINQUISH requests. This corresponds to table
+  2.25 of the FF-A Memory Management v1.3 APL1, "Descriptor to relinquish a memory
+  region".
+**/
+typedef struct {
+  UINT64    Handle;
+  UINT32    Flags;
+  UINT32    EndpointCount;
+  UINT16    Endpoints[];
+} FFA_MEM_RELINQUISH_DESCRIPTOR;
+
+#endif

--- a/MdePkg/Include/Library/ArmFfaLib.h
+++ b/MdePkg/Include/Library/ArmFfaLib.h
@@ -23,6 +23,30 @@
 
 #include <Library/ArmSmcLib.h>
 
+/**
+ * Arguments to call FF-A request via SMC/SVC.
+ */
+typedef struct ArmFfaArgs {
+  UINTN    Arg0;
+  UINTN    Arg1;
+  UINTN    Arg2;
+  UINTN    Arg3;
+  UINTN    Arg4;
+  UINTN    Arg5;
+  UINTN    Arg6;
+  UINTN    Arg7;
+  UINTN    Arg8;
+  UINTN    Arg9;
+  UINTN    Arg10;
+  UINTN    Arg11;
+  UINTN    Arg12;
+  UINTN    Arg13;
+  UINTN    Arg14;
+  UINTN    Arg15;
+  UINTN    Arg16;
+  UINTN    Arg17;
+} ARM_FFA_ARGS;
+
 #define FFA_RXTX_MAP_INPUT_PROPERTY_DEFAULT  0x00
 
 /** Implementation define arguments used in
@@ -72,6 +96,18 @@ typedef struct DirectMsgArgs {
   /// Implementation define argument 13, this will be set to/from x17(v2)
   UINTN    Arg13;
 } DIRECT_MSG_ARGS;
+
+/**
+  Trigger FF-A ABI call according to PcdFfaLibConduitSmc.
+
+  @param [in, out]  FfaArgs        Ffa arguments
+
+**/
+VOID
+EFIAPI
+ArmCallFfa (
+  IN OUT ARM_FFA_ARGS  *FfaArgs
+  );
 
 /**
   Convert EFI_STATUS to FFA return code.

--- a/MdePkg/Include/Library/ArmFfaMemMgmtLib.h
+++ b/MdePkg/Include/Library/ArmFfaMemMgmtLib.h
@@ -1,0 +1,289 @@
+/** @file
+  Library definition for FF-A memory management protocol.
+
+  Copyright (c) 2020 - 2022, Arm Ltd. All rights reserved.<BR>
+  Copyright (c), Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef ARM_FFA_MEM_MGMT_LIB_H_
+#define ARM_FFA_MEM_MGMT_LIB_H_
+
+#include <Uefi.h>
+
+/**
+  @brief      Starts a transaction to transfer of ownership of a memory region
+              from a Sender endpoint to a Receiver endpoint.
+
+  @param[in]  TotalLength     Total length of the memory transaction descriptor
+                              in bytes
+  @param[in]  FragmentLength  Length in bytes of the memory transaction descriptor
+                              passed in this ABI invocation
+  @param[in]  BufferAddr      Base address of a buffer allocated by the Owner and
+                              distinct from the TX buffer
+  @param[in]  PageCount       Number of 4K pages in the buffer allocated by the
+                              Owner and distinct from the TX buffer
+  @param[out] Handle          Globally unique Handle to identify the memory region
+                              upon successful transmission of the transaction descriptor.
+
+  @retval     The translated FF-A error status code
+**/
+EFI_STATUS
+EFIAPI
+ArmFfaMemLibDonate (
+  IN UINT32   TotalLength,
+  IN UINT32   FragmentLength,
+  IN VOID     *BufferAddr,
+  IN UINT32   PageCount,
+  OUT UINT64  *Handle
+  );
+
+/**
+  @brief      Starts a transaction to transfer of ownership of a memory region
+              from a Sender endpoint to a Receiver endpoint.
+
+  @param[in]  TotalLength     Total length of the memory transaction descriptor
+                              in bytes
+  @param[in]  FragmentLength  Length in bytes of the memory transaction descriptor
+                              passed in this ABI invocation
+  @param[out] Handle          Globally unique Handle to identify the memory region
+                              upon successful transmission of the transaction descriptor.
+
+  @retval     The translated FF-A error status code
+**/
+EFI_STATUS
+EFIAPI
+ArmFfaMemLibDonateRxTx (
+  IN   UINT32  TotalLength,
+  IN   UINT32  FragmentLength,
+  OUT  UINT64  *Handle
+  );
+
+/**
+  @brief      Starts a transaction to transfer an Owner’s access to a memory
+              region and  grant access to it to one or more Borrowers.
+
+  @param[in]  TotalLength     Total length of the memory transaction descriptor
+                              in bytes
+  @param[in]  FragmentLength  Length in bytes of the memory transaction
+                              descriptor passed in this ABI invocation
+  @param[in]  BufferAddr      Base address of a buffer allocated by the Owner
+                              and distinct from the TX buffer
+  @param[in]  PageCount       Number of 4K pages in the buffer allocated by
+                              the Owner and distinct from the TX buffer
+  @param[out] Handle          Globally unique Handle to identify the memory
+                              region upon successful transmission of the
+                              transaction descriptor.
+
+  @retval     The translated FF-A error status code
+**/
+EFI_STATUS
+EFIAPI
+ArmFfaMemLibLend (
+  IN UINT32   TotalLength,
+  IN UINT32   FragmentLength,
+  IN VOID     *BufferAddr,
+  IN UINT32   PageCount,
+  OUT UINT64  *Handle
+  );
+
+/**
+  @brief      Starts a transaction to transfer an Owner’s access to a memory
+              region and  grant access to it to one or more Borrowers through
+              Rx/Tx buffer.
+
+  @param[in]  TotalLength     Total length of the memory transaction descriptor
+                              in bytes
+  @param[in]  FragmentLength  Length in bytes of the memory transaction descriptor
+                              passed in this ABI invocation
+  @param[out] Handle          Globally unique Handle to identify the memory region
+                              upon successful transmission of the transaction descriptor.
+
+  @retval     The translated FF-A error status code
+**/
+EFI_STATUS
+EFIAPI
+ArmFfaMemLibLendRxTx (
+  IN UINT32   TotalLength,
+  IN UINT32   FragmentLength,
+  OUT UINT64  *Handle
+  );
+
+/**
+  @brief      Starts a transaction to grant access to a memory region to one or
+              more Borrowers.
+
+  @param[in]  TotalLength     Total length of the memory transaction descriptor
+                              in bytes
+  @param[in]  FragmentLength  Length in bytes of the memory transaction descriptor
+                              passed in this ABI invocation
+  @param[in]  BufferAddr      Base address of a buffer allocated by the Owner and
+                              distinct from the TX buffer
+  @param[in]  PageCount       Number of 4K pages in the buffer allocated by the
+                              Owner and distinct from the TX buffer
+  @param[out] Handle          Globally unique Handle to identify the memory region
+                              upon successful transmission of the transaction descriptor.
+
+  @retval     The translated FF-A error status code
+**/
+EFI_STATUS
+EFIAPI
+ArmFfaMemLibShare (
+  IN UINT32   TotalLength,
+  IN UINT32   FragmentLength,
+  IN VOID     *BufferAddr,
+  IN UINT32   PageCount,
+  OUT UINT64  *Handle
+  );
+
+/**
+  @brief      Starts a transaction to grant access to a memory region to one or
+              more Borrowers through Rx/Tx buffer.
+
+  @param[in]  TotalLength     Total length of the memory transaction descriptor
+                              in bytes
+  @param[in]  FragmentLength  Length in bytes of the memory transaction descriptor
+                              passed in this ABI invocation
+  @param[out] Handle          Globally unique Handle to identify the memory region
+                              upon successful transmission of the transaction descriptor.
+
+  @retval     The translated FF-A error status code
+**/
+EFI_STATUS
+EFIAPI
+ArmFfaMemLibShareRxTx (
+  IN UINT32   TotalLength,
+  IN UINT32   FragmentLength,
+  OUT UINT64  *Handle
+  );
+
+/**
+  @brief      Requests completion of a donate, lend or share memory management
+              transaction.
+
+  @param[in]  TotalLength         Total length of the memory transaction descriptor
+                                  in bytes
+  @param[in]  FragmentLength      Length in bytes of the memory transaction descriptor
+                                  passed in this ABI invocation
+  @param[in]  BufferAddr          Base address of a buffer allocated by the Owner
+                                  and distinct from the TX buffer
+  @param[in]  PageCount           Number of 4K pages in the buffer allocated by
+                                  the Owner and distinct from the TX buffer
+  @param[out] RespTotalLength     Total length of the response memory transaction
+                                  descriptor in bytes
+  @param[out] RespFragmentLength  Length in bytes of the response memory transaction
+                                  descriptor passed in this ABI invocation
+
+  @retval     The translated FF-A error status code
+**/
+EFI_STATUS
+EFIAPI
+ArmFfaMemLibRetrieveReq (
+  IN UINT32   TotalLength,
+  IN UINT32   FragmentLength,
+  IN VOID     *BufferAddr,
+  IN UINT32   PageCount,
+  OUT UINT32  *RespTotalLength,
+  OUT UINT32  *RespFragmentLength
+  );
+
+/**
+  @brief      Requests completion of a donate, lend or share memory management
+              transaction through Rx/Tx buffer.
+
+  @param[in]  TotalLength         Total length of the memory transaction descriptor
+                                  in bytes
+  @param[in]  FragmentLength      Length in bytes of the memory transaction descriptor
+                                  passed in this ABI invocation
+  @param[out] RespTotalLength     Total length of the response memory transaction
+                                  descriptor in bytes
+  @param[out] RespFragmentLength  Length in bytes of the response memory transaction
+                                  descriptor passed in this ABI invocation
+
+  @retval     The translated FF-A error status code
+**/
+EFI_STATUS
+EFIAPI
+ArmFfaMemLibRetrieveReqRxTx (
+  IN UINT32   TotalLength,
+  IN UINT32   FragmentLength,
+  OUT UINT32  *RespTotalLength,
+  OUT UINT32  *RespFragmentLength
+  );
+
+/**
+  @brief      Starts a transaction to transfer access to a shared or lent
+              memory region from a Borrower back to its Owner.
+
+  @retval     The translated FF-A error status code
+**/
+EFI_STATUS
+EFIAPI
+ArmFfaMemLibRelinquish (
+  VOID
+  );
+
+/**
+  @brief      Restores exclusive access to a memory region back to its Owner.
+
+  @param[in]  Handle  Globally unique Handle to identify the memory region
+  @param[in]  Flags   Flags for modifying the reclaim behavior
+
+  @retval     The translated FF-A error status code
+**/
+EFI_STATUS
+EFIAPI
+ArmFfaMemLibReclaim (
+  IN UINT64  Handle,
+  IN UINT32  Flags
+  );
+
+/**
+  @brief       Queries the memory attributes of a memory region. This function
+               can only access the regions of the SP's own translation regine.
+               Moreover this interface is only available in the boot phase,
+               i.e. before invoking FFA_MSG_WAIT interface.
+
+  @param[in]   BaseAddr     Base VA of a translation granule whose
+                            permission attributes must be returned.
+  @param[in]   PageCount    Number of translation granule size pages from the
+                            Base address whose permissions must be returned.
+                            This is calculated as Input Page count + 1.
+  @param[out]  MemoryPerm   Permission attributes of the memory region
+
+  @retval      The translated FF-A error status code
+**/
+EFI_STATUS
+EFIAPI
+ArmFfaMemLibPermGet (
+  IN CONST VOID  *BaseAddr,
+  IN UINT32      PageCount,
+  OUT UINT32     *MemoryPerm
+  );
+
+/**
+  @brief       Sets the memory attributes of a memory regions. This function
+               can only access the regions of the SP's own translation regine.
+               Moreover this interface is only available in the boot phase,
+               i.e. before invoking FFA_MSG_WAIT interface.
+
+  @param[in]   BaseAddr     Base VA of a memory region whose permission
+                            attributes must be set.
+  @param[in]   PageCount    Number of translation granule size pages
+                            starting from the Base address whose permissions
+                            must be set.
+  @param[in]   MemoryPerm   Permission attributes to be set for the memory
+                            region.
+
+  @retval      The translated FF-A error status code
+**/
+EFI_STATUS
+EFIAPI
+ArmFfaMemLibPermSet (
+  IN CONST VOID  *BaseAddr,
+  IN UINT32      PageCount,
+  IN UINT32      MemoryPerm
+  );
+
+#endif // ARM_FFA_MEM_MGMT_LIB_H_

--- a/MdePkg/Library/ArmFfaMemMgmtLib/ArmFfaMemMgmtLib.c
+++ b/MdePkg/Library/ArmFfaMemMgmtLib/ArmFfaMemMgmtLib.c
@@ -1,0 +1,618 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+/** @file
+  This library implements the FF-A memory manage protocol.
+
+  Copyright (c) 2020-2022, Arm Limited and Contributors. All rights reserved.
+  Copyright (c), Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+   @par Glossary:
+     - FF-A - Firmware Framework for Arm A-profile
+
+   @par Reference(s):
+     - Arm Firmware Framework for Arm A-Profile v1.3 ALP1: [https://developer.arm.com/documentation/den0077/l]
+     - FF-A Memory Management Protocol [https://developer.arm.com/documentation/den0140/f]
+
+**/
+
+#include <Uefi.h>
+#include <IndustryStandard/ArmFfaMemMgmt.h>
+#include <Library/BaseLib.h>
+#include <Library/DebugLib.h>
+#include <Library/ArmFfaLib.h>
+#include <Library/ArmFfaMemMgmtLib.h>
+#include <Library/BaseMemoryLib.h>
+
+/**
+  @brief      Starts a transaction to transfer of ownership of a memory region
+              from a Sender endpoint to a Receiver endpoint.
+
+  @param[in]  TotalLength     Total length of the memory transaction descriptor
+                              in bytes
+  @param[in]  FragmentLength  Length in bytes of the memory transaction descriptor
+                              passed in this ABI invocation
+  @param[in]  BufferAddr      Base address of a buffer allocated by the Owner and
+                              distinct from the TX buffer
+  @param[in]  PageCount       Number of 4K pages in the buffer allocated by the
+                              Owner and distinct from the TX buffer
+  @param[out] Handle          Globally unique Handle to identify the memory region
+                              upon successful transmission of the transaction descriptor.
+
+  @retval     The translated FF-A error status code
+**/
+EFI_STATUS
+EFIAPI
+ArmFfaMemLibDonate (
+  IN UINT32   TotalLength,
+  IN UINT32   FragmentLength,
+  IN VOID     *BufferAddr,
+  IN UINT32   PageCount,
+  OUT UINT64  *Handle
+  )
+{
+  ARM_FFA_ARGS  FfaArgs;
+  EFI_STATUS    Status;
+
+  if (Handle == NULL) {
+    DEBUG ((DEBUG_ERROR, "%a: Handle is NULL\n", __func__));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  FfaArgs.Arg0 = ((UINTN)BufferAddr > MAX_UINT32) ? ARM_FID_FFA_MEM_DONATE_AARCH64 : ARM_FID_FFA_MEM_DONATE_AARCH32;
+
+  Status = ArmFfaLibGetFeatures (
+             FfaArgs.Arg0,
+             0,
+             &FfaArgs.Arg1,
+             &FfaArgs.Arg2
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: Failed to get FFA_MEM_DONATE feature... Status: %r\n", __func__, Status));
+    *Handle = 0U;
+    return Status;
+  }
+
+  FfaArgs.Arg1 = TotalLength;
+  FfaArgs.Arg2 = FragmentLength;
+  FfaArgs.Arg3 = (UINTN)BufferAddr;
+  FfaArgs.Arg4 = PageCount;
+
+  ArmCallFfa (&FfaArgs);
+
+  if (FfaArgs.Arg0 == ARM_FID_FFA_ERROR) {
+    *Handle = 0U;
+    return FfaStatusToEfiStatus (FfaArgs.Arg2);
+  }
+
+  /**
+    There are no 64-bit parameters returned with FFA_SUCCESS, the SPMC
+    will use the default 32-bit version.
+  **/
+  ASSERT (FfaArgs.Arg0 == ARM_FID_FFA_SUCCESS_AARCH32);
+  *Handle = ((UINT64)FfaArgs.Arg3 << 32) | FfaArgs.Arg2;
+  return EFI_SUCCESS;
+}
+
+/**
+  @brief      Starts a transaction to transfer of ownership of a memory region
+              from a Sender endpoint to a Receiver endpoint.
+
+  @param[in]  TotalLength     Total length of the memory transaction descriptor
+                              in bytes
+  @param[in]  FragmentLength  Length in bytes of the memory transaction descriptor
+                              passed in this ABI invocation
+  @param[out] Handle          Globally unique Handle to identify the memory region
+                              upon successful transmission of the transaction descriptor.
+
+  @retval     The translated FF-A error status code
+**/
+EFI_STATUS
+EFIAPI
+ArmFfaMemLibDonateRxTx (
+  IN   UINT32  TotalLength,
+  IN   UINT32  FragmentLength,
+  OUT  UINT64  *Handle
+  )
+{
+  return ArmFfaMemLibDonate (TotalLength, FragmentLength, NULL, 0, Handle);
+}
+
+/**
+  @brief      Starts a transaction to transfer an Owner’s access to a memory
+              region and  grant access to it to one or more Borrowers.
+
+  @param[in]  TotalLength     Total length of the memory transaction descriptor
+                              in bytes
+  @param[in]  FragmentLength  Length in bytes of the memory transaction
+                              descriptor passed in this ABI invocation
+  @param[in]  BufferAddr      Base address of a buffer allocated by the Owner
+                              and distinct from the TX buffer
+  @param[in]  PageCount       Number of 4K pages in the buffer allocated by
+                              the Owner and distinct from the TX buffer
+  @param[out] Handle          Globally unique Handle to identify the memory
+                              region upon successful transmission of the
+                              transaction descriptor.
+
+  @retval     The translated FF-A error status code
+**/
+EFI_STATUS
+EFIAPI
+ArmFfaMemLibLend (
+  IN UINT32   TotalLength,
+  IN UINT32   FragmentLength,
+  IN VOID     *BufferAddr,
+  IN UINT32   PageCount,
+  OUT UINT64  *Handle
+  )
+{
+  ARM_FFA_ARGS  FfaArgs;
+  EFI_STATUS    Status;
+
+  if (Handle == NULL) {
+    DEBUG ((DEBUG_ERROR, "%a: Handle is NULL\n", __func__));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  FfaArgs.Arg0 = ((UINTN)BufferAddr > MAX_UINT32) ? ARM_FID_FFA_MEM_LEND_AARCH64 : ARM_FID_FFA_MEM_LEND_AARCH32;
+
+  Status = ArmFfaLibGetFeatures (
+             FfaArgs.Arg0,
+             0,
+             &FfaArgs.Arg1,
+             &FfaArgs.Arg2
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: Failed to get FFA_MEM_LEND feature... Status: %r\n", __func__, Status));
+    *Handle = 0U;
+    return Status;
+  }
+
+  FfaArgs.Arg1 = TotalLength;
+  FfaArgs.Arg2 = FragmentLength;
+  FfaArgs.Arg3 = (UINTN)BufferAddr;
+  FfaArgs.Arg4 = PageCount;
+
+  ArmCallFfa (&FfaArgs);
+
+  if (FfaArgs.Arg0 == ARM_FID_FFA_ERROR) {
+    *Handle = 0U;
+    return FfaStatusToEfiStatus (FfaArgs.Arg2);
+  }
+
+  /**
+    There are no 64-bit parameters returned with FFA_SUCCESS, the SPMC
+    will use the default 32-bit version.
+  **/
+  ASSERT (FfaArgs.Arg0 == ARM_FID_FFA_SUCCESS_AARCH32);
+  *Handle = ((UINT64)FfaArgs.Arg3 << 32) | FfaArgs.Arg2;
+  return EFI_SUCCESS;
+}
+
+/**
+  @brief      Starts a transaction to transfer an Owner’s access to a memory
+              region and  grant access to it to one or more Borrowers through
+              Rx/Tx buffer.
+
+  @param[in]  TotalLength     Total length of the memory transaction descriptor
+                              in bytes
+  @param[in]  FragmentLength  Length in bytes of the memory transaction descriptor
+                              passed in this ABI invocation
+  @param[out] Handle          Globally unique Handle to identify the memory region
+                              upon successful transmission of the transaction descriptor.
+
+  @retval     The translated FF-A error status code
+**/
+EFI_STATUS
+EFIAPI
+ArmFfaMemLibLendRxTx (
+  IN UINT32   TotalLength,
+  IN UINT32   FragmentLength,
+  OUT UINT64  *Handle
+  )
+{
+  return ArmFfaMemLibLend (TotalLength, FragmentLength, NULL, 0, Handle);
+}
+
+/**
+  @brief      Starts a transaction to grant access to a memory region to one or
+              more Borrowers.
+
+  @param[in]  TotalLength     Total length of the memory transaction descriptor
+                              in bytes
+  @param[in]  FragmentLength  Length in bytes of the memory transaction descriptor
+                              passed in this ABI invocation
+  @param[in]  BufferAddr      Base address of a buffer allocated by the Owner and
+                              distinct from the TX buffer
+  @param[in]  PageCount       Number of 4K pages in the buffer allocated by the
+                              Owner and distinct from the TX buffer
+  @param[out] Handle          Globally unique Handle to identify the memory region
+                              upon successful transmission of the transaction descriptor.
+
+  @retval     The translated FF-A error status code
+**/
+EFI_STATUS
+EFIAPI
+ArmFfaMemLibShare (
+  IN UINT32   TotalLength,
+  IN UINT32   FragmentLength,
+  IN VOID     *BufferAddr,
+  IN UINT32   PageCount,
+  OUT UINT64  *Handle
+  )
+{
+  ARM_FFA_ARGS  FfaArgs;
+  EFI_STATUS    Status;
+
+  if (Handle == NULL) {
+    DEBUG ((DEBUG_ERROR, "%a: Handle is NULL\n", __func__));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  FfaArgs.Arg0 = ((UINTN)BufferAddr > MAX_UINT32) ? ARM_FID_FFA_MEM_SHARE_AARCH64 : ARM_FID_FFA_MEM_SHARE_AARCH32;
+
+  Status = ArmFfaLibGetFeatures (
+             FfaArgs.Arg0,
+             0,
+             &FfaArgs.Arg1,
+             &FfaArgs.Arg2
+             );
+
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: Failed to get FFA_MEM_SHARE feature... Status: %r\n", __func__, Status));
+    *Handle = 0U;
+    return Status;
+  }
+
+  FfaArgs.Arg1 = TotalLength;
+  FfaArgs.Arg2 = FragmentLength;
+  FfaArgs.Arg3 = (UINTN)BufferAddr;
+  FfaArgs.Arg4 = PageCount;
+
+  ArmCallFfa (&FfaArgs);
+
+  if (FfaArgs.Arg0 == ARM_FID_FFA_ERROR) {
+    *Handle = 0U;
+    return FfaStatusToEfiStatus (FfaArgs.Arg2);
+  }
+
+  /**
+    There are no 64-bit parameters returned with FFA_SUCCESS, the SPMC
+    will use the default 32-bit version.
+  **/
+  ASSERT (FfaArgs.Arg0 == ARM_FID_FFA_SUCCESS_AARCH32);
+  *Handle = ((UINT64)FfaArgs.Arg3 << 32) | FfaArgs.Arg2;
+  return EFI_SUCCESS;
+}
+
+/**
+  @brief      Starts a transaction to grant access to a memory region to one or
+              more Borrowers through Rx/Tx buffer.
+
+  @param[in]  TotalLength     Total length of the memory transaction descriptor
+                              in bytes
+  @param[in]  FragmentLength  Length in bytes of the memory transaction descriptor
+                              passed in this ABI invocation
+  @param[out] Handle          Globally unique Handle to identify the memory region
+                              upon successful transmission of the transaction descriptor.
+
+  @retval     The translated FF-A error status code
+**/
+EFI_STATUS
+EFIAPI
+ArmFfaMemLibShareRxTx (
+  IN UINT32   TotalLength,
+  IN UINT32   FragmentLength,
+  OUT UINT64  *Handle
+  )
+{
+  return ArmFfaMemLibShare (TotalLength, FragmentLength, NULL, 0, Handle);
+}
+
+/**
+  @brief      Requests completion of a donate, lend or share memory management
+              transaction.
+
+  @param[in]  TotalLength         Total length of the memory transaction descriptor
+                                  in bytes
+  @param[in]  FragmentLength      Length in bytes of the memory transaction descriptor
+                                  passed in this ABI invocation
+  @param[in]  BufferAddr          Base address of a buffer allocated by the Owner
+                                  and distinct from the TX buffer
+  @param[in]  PageCount           Number of 4K pages in the buffer allocated by
+                                  the Owner and distinct from the TX buffer
+  @param[out] RespTotalLength     Total length of the response memory transaction
+                                  descriptor in bytes
+  @param[out] RespFragmentLength  Length in bytes of the response memory transaction
+                                  descriptor passed in this ABI invocation
+
+  @retval     The translated FF-A error status code
+**/
+EFI_STATUS
+EFIAPI
+ArmFfaMemLibRetrieveReq (
+  IN UINT32   TotalLength,
+  IN UINT32   FragmentLength,
+  IN VOID     *BufferAddr,
+  IN UINT32   PageCount,
+  OUT UINT32  *RespTotalLength,
+  OUT UINT32  *RespFragmentLength
+  )
+{
+  ARM_FFA_ARGS  FfaArgs;
+  EFI_STATUS    Status;
+
+  if ((RespTotalLength == NULL) || (RespFragmentLength == NULL)) {
+    DEBUG ((DEBUG_ERROR, "%a: Handle is NULL\n", __func__));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  FfaArgs.Arg0 = ((UINTN)BufferAddr > MAX_UINT32) ? ARM_FID_FFA_MEM_RETRIEVE_REQ_AARCH64 : ARM_FID_FFA_MEM_RETRIEVE_REQ_AARCH32;
+
+  Status = ArmFfaLibGetFeatures (
+             FfaArgs.Arg0,
+             0,
+             &FfaArgs.Arg1,
+             &FfaArgs.Arg2
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: Failed to get FFA_MEM_RETRIEVE_REQ feature... Status: %r\n", __func__, Status));
+    *RespTotalLength    = 0U;
+    *RespFragmentLength = 0U;
+    return Status;
+  }
+
+  FfaArgs.Arg1 = TotalLength;
+  FfaArgs.Arg2 = FragmentLength;
+  FfaArgs.Arg3 = (UINTN)BufferAddr;
+  FfaArgs.Arg4 = PageCount;
+
+  ArmCallFfa (&FfaArgs);
+
+  if (FfaArgs.Arg0 == ARM_FID_FFA_ERROR) {
+    *RespTotalLength    = 0U;
+    *RespFragmentLength = 0U;
+    return FfaStatusToEfiStatus (FfaArgs.Arg2);
+  }
+
+  ASSERT (FfaArgs.Arg0 == ARM_FID_FFA_MEM_RETRIEVE_RESP);
+  *RespTotalLength    = FfaArgs.Arg1;
+  *RespFragmentLength = FfaArgs.Arg2;
+  return EFI_SUCCESS;
+}
+
+/**
+  @brief      Requests completion of a donate, lend or share memory management
+              transaction through Rx/Tx buffer.
+
+  @param[in]  TotalLength         Total length of the memory transaction descriptor
+                                  in bytes
+  @param[in]  FragmentLength      Length in bytes of the memory transaction descriptor
+                                  passed in this ABI invocation
+  @param[out] RespTotalLength     Total length of the response memory transaction
+                                  descriptor in bytes
+  @param[out] RespFragmentLength  Length in bytes of the response memory transaction
+                                  descriptor passed in this ABI invocation
+
+  @retval     The translated FF-A error status code
+**/
+EFI_STATUS
+EFIAPI
+ArmFfaMemLibRetrieveReqRxTx (
+  IN UINT32   TotalLength,
+  IN UINT32   FragmentLength,
+  OUT UINT32  *RespTotalLength,
+  OUT UINT32  *RespFragmentLength
+  )
+{
+  return ArmFfaMemLibRetrieveReq (
+           TotalLength,
+           FragmentLength,
+           NULL,
+           0,
+           RespTotalLength,
+           RespFragmentLength
+           );
+}
+
+/**
+  @brief      Starts a transaction to transfer access to a shared or lent
+              memory region from a Borrower back to its Owner.
+
+  @retval     The translated FF-A error status code
+**/
+EFI_STATUS
+EFIAPI
+ArmFfaMemLibRelinquish (
+  VOID
+  )
+{
+  ARM_FFA_ARGS  FfaArgs;
+  EFI_STATUS    Status;
+
+  FfaArgs.Arg0 = ARM_FID_FFA_MEM_RETRIEVE_RELINQUISH;
+
+  Status = ArmFfaLibGetFeatures (
+             FfaArgs.Arg0,
+             0,
+             &FfaArgs.Arg1,
+             &FfaArgs.Arg2
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: Failed to get FFA_MEM_RETRIEVE_RELINQUISH feature... Status: %r\n", __func__, Status));
+    return Status;
+  }
+
+  ArmCallFfa (&FfaArgs);
+
+  if (FfaArgs.Arg0 == ARM_FID_FFA_ERROR) {
+    return FfaStatusToEfiStatus (FfaArgs.Arg2);
+  }
+
+  ASSERT (FfaArgs.Arg0 == ARM_FID_FFA_SUCCESS_AARCH32);
+  return EFI_SUCCESS;
+}
+
+/**
+  @brief      Restores exclusive access to a memory region back to its Owner.
+
+  @param[in]  Handle  Globally unique Handle to identify the memory region
+  @param[in]  Flags   Flags for modifying the reclaim behavior
+
+  @retval     The translated FF-A error status code
+**/
+EFI_STATUS
+EFIAPI
+ArmFfaMemLibReclaim (
+  IN UINT64  Handle,
+  IN UINT32  Flags
+  )
+{
+  ARM_FFA_ARGS  FfaArgs;
+  EFI_STATUS    Status;
+  UINT32        HandleHi = 0;
+  UINT32        HandleLo = 0;
+
+  FfaArgs.Arg0 = ARM_FID_FFA_MEM_RETRIEVE_RECLAIM;
+
+  Status = ArmFfaLibGetFeatures (
+             FfaArgs.Arg0,
+             0,
+             &FfaArgs.Arg1,
+             &FfaArgs.Arg2
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: Failed to get FFA_MEM_RETRIEVE_RECLAIM feature... Status: %r\n", __func__, Status));
+    return Status;
+  }
+
+  HandleHi = (Handle >> 32) & MAX_UINT32;
+  HandleLo = Handle & MAX_UINT32;
+
+  FfaArgs.Arg1 = HandleLo;
+  FfaArgs.Arg2 = HandleHi;
+  FfaArgs.Arg3 = Flags;
+
+  ArmCallFfa (&FfaArgs);
+
+  if (FfaArgs.Arg0 == ARM_FID_FFA_ERROR) {
+    return FfaStatusToEfiStatus (FfaArgs.Arg2);
+  }
+
+  ASSERT (FfaArgs.Arg0 == ARM_FID_FFA_SUCCESS_AARCH32);
+  return EFI_SUCCESS;
+}
+
+/**
+  @brief       Queries the memory attributes of a memory region. This function
+               can only access the regions of the SP's own translation regine.
+               Moreover this interface is only available in the boot phase,
+               i.e. before invoking FFA_MSG_WAIT interface.
+
+  @param[in]   BaseAddr     Base VA of a translation granule whose
+                            permission attributes must be returned.
+  @param[in]   PageCount    Number of translation granule size pages from the
+                            Base address whose permissions must be returned.
+                            This is calculated as Input Page count + 1.
+  @param[out]  MemoryPerm   Permission attributes of the memory region
+
+  @retval      The translated FF-A error status code
+**/
+EFI_STATUS
+EFIAPI
+ArmFfaMemLibPermGet (
+  IN CONST VOID  *BaseAddr,
+  IN UINT32      PageCount,
+  OUT UINT32     *MemoryPerm
+  )
+{
+  ARM_FFA_ARGS  FfaArgs;
+  EFI_STATUS    Status;
+
+  if (MemoryPerm == NULL) {
+    DEBUG ((DEBUG_ERROR, "%a: Handle is NULL\n", __func__));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  FfaArgs.Arg0 = ((UINTN)BaseAddr > MAX_UINT32) ? ARM_FID_FFA_MEM_PERM_GET_AARCH64 : ARM_FID_FFA_MEM_PERM_GET_AARCH32;
+
+  Status = ArmFfaLibGetFeatures (
+             FfaArgs.Arg0,
+             0,
+             &FfaArgs.Arg1,
+             &FfaArgs.Arg2
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: Failed to get FFA_MEM_PERM_GET feature... Status: %r\n", __func__, Status));
+    return Status;
+  }
+
+  FfaArgs.Arg1 = (UINTN)BaseAddr;
+  FfaArgs.Arg2 = PageCount;
+
+  ArmCallFfa (&FfaArgs);
+
+  if (FfaArgs.Arg0 == ARM_FID_FFA_ERROR) {
+    return FfaStatusToEfiStatus (FfaArgs.Arg2);
+  }
+
+  ASSERT (FfaArgs.Arg0 == ARM_FID_FFA_SUCCESS_AARCH32);
+  *MemoryPerm = FfaArgs.Arg2;
+  return EFI_SUCCESS;
+}
+
+/**
+  @brief       Sets the memory attributes of a memory regions. This function
+               can only access the regions of the SP's own translation regine.
+               Moreover this interface is only available in the boot phase,
+               i.e. before invoking FFA_MSG_WAIT interface.
+
+  @param[in]   BaseAddr     Base VA of a memory region whose permission
+                            attributes must be set.
+  @param[in]   PageCount    Number of translation granule size pages
+                            starting from the Base address whose permissions
+                            must be set.
+  @param[in]   MemoryPerm   Permission attributes to be set for the memory
+                            region.
+
+  @retval      The translated FF-A error status code
+**/
+EFI_STATUS
+EFIAPI
+ArmFfaMemLibPermSet (
+  IN CONST VOID  *BaseAddr,
+  IN UINT32      PageCount,
+  IN UINT32      MemoryPerm
+  )
+{
+  ARM_FFA_ARGS  FfaArgs;
+  EFI_STATUS    Status;
+
+  ASSERT ((MemoryPerm & ARM_FFA_MEM_PERM_RESERVED_MASK) == 0);
+
+  FfaArgs.Arg0 = ((UINTN)BaseAddr > MAX_UINT32) ? ARM_FID_FFA_MEM_PERM_SET_AARCH64 : ARM_FID_FFA_MEM_PERM_SET_AARCH32;
+
+  Status = ArmFfaLibGetFeatures (
+             FfaArgs.Arg0,
+             0,
+             &FfaArgs.Arg1,
+             &FfaArgs.Arg2
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: Failed to get FFA_MEM_PERM_SET feature... Status: %r\n", __func__, Status));
+    return Status;
+  }
+
+  FfaArgs.Arg1 = (UINTN)BaseAddr;
+  FfaArgs.Arg2 = PageCount;
+  FfaArgs.Arg3 = MemoryPerm;
+
+  ArmCallFfa (&FfaArgs);
+
+  if (FfaArgs.Arg0 == ARM_FID_FFA_ERROR) {
+    return FfaStatusToEfiStatus (FfaArgs.Arg2);
+  }
+
+  ASSERT (FfaArgs.Arg0 == ARM_FID_FFA_SUCCESS_AARCH32);
+  return EFI_SUCCESS;
+}

--- a/MdePkg/Library/ArmFfaMemMgmtLib/ArmFfaMemMgmtLib.inf
+++ b/MdePkg/Library/ArmFfaMemMgmtLib/ArmFfaMemMgmtLib.inf
@@ -1,0 +1,26 @@
+#/** @file
+#
+#  Component description file for ArmFfaMemMgmtLib module
+#
+#  Copyright (c), Microsoft Corporation.
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+#**/
+
+[Defines]
+  INF_VERSION                    = 1.29
+  BASE_NAME                      = ArmFfaMemMgmtLib
+  FILE_GUID                      = CC121A12-7C90-46BB-89B8-5F5BAEEFFF12
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = ArmFfaMemMgmtLib
+
+[Sources.common]
+  ArmFfaMemMgmtLib.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+
+[LibraryClasses]
+  DebugLib
+  ArmFfaLib

--- a/MdePkg/MdePkg.dec
+++ b/MdePkg/MdePkg.dec
@@ -370,6 +370,10 @@
   #
   ArmFfaLib|Include/Library/ArmFfaLib.h
 
+  ## @libraryclass  Provides an interface to Arm's Firmware Framework for A-profile (FF-A) memory management functions.
+  #
+  ArmFfaMemMgmtLib|Include/Library/ArmFfaMemMgmtLib.h
+
 [Guids]
   #
   # GUID defined in UEFI2.1/UEFI2.0/EFI1.1

--- a/MdePkg/MdePkg.dsc
+++ b/MdePkg/MdePkg.dsc
@@ -210,6 +210,7 @@
   MdePkg/Library/ArmSmcLib/ArmSmcLib.inf
   MdePkg/Library/ArmSmcLibNull/ArmSmcLibNull.inf
   MdePkg/Library/ArmSvcLib/ArmSvcLib.inf
+  MdePkg/Library/ArmFfaMemMgmtLib/ArmFfaMemMgmtLib.inf
 
 [Components.RISCV64]
   MdePkg/Library/BaseRiscVSbiLib/BaseRiscVSbiLib.inf


### PR DESCRIPTION
# Description

This change adds the FF-A memory management protocol implementation according to https://developer.arm.com/documentation/den0140/latest/

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

This change was tested on QEMU SBSA and proprietary hardware with Hafnium as the SPMC.

## Integration Instructions

Add `ArmFfaMemMgmtLib|MdePkg/Library/ArmFfaMemMgmtLib/ArmFfaMemMgmtLib.inf` to platform DSC.
