### PR TITLE
add svsm variable store support

### DIFF
--- a/MdePkg/Include/Register/Amd/Svsm.h
+++ b/MdePkg/Include/Register/Amd/Svsm.h
@@ -103,6 +103,7 @@ typedef union {
 #define SVSM_PROTOCOL_CORE         0
 #define SVSM_PROTOCOL_ATTESTATION  1
 #define SVSM_PROTOCOL_VTPM         2
+#define SVSM_UEFI_MM_PROTOCOL      4
 /// @}
 
 /// SVSM Core Protocol calls
@@ -121,6 +122,14 @@ typedef union {
 /// @{
 #define SVSM_VTPM_QUERY  0
 #define SVSM_VTPM_CMD    1
+/// @}
+
+/// SVSM UEFI MM Protocol calls
+/// @{
+#define SVSM_UEFI_MM_QUERY    1
+#define SVSM_UEFI_MM_SETUP    2
+#define SVSM_UEFI_MM_RESET    3
+#define SVSM_UEFI_MM_REQUEST  4
 /// @}
 
 #endif

--- a/OvmfPkg/Library/AmdSvsmLib/AmdSvsmLib.c
+++ b/OvmfPkg/Library/AmdSvsmLib/AmdSvsmLib.c
@@ -593,3 +593,27 @@ AmdSvsmVtpmCmd (
 
   return (Ret == 0) ? TRUE : FALSE;
 }
+
+BOOLEAN
+EFIAPI
+AmdSvsmUefiMmCall (
+  IN  UINT32  CallId,
+  IN  UINT64  Rcx,
+  IN  UINT64  Rdx
+  )
+{
+  SVSM_CALL_DATA  SvsmCallData;
+  SVSM_FUNCTION   Function;
+  UINTN           Ret;
+
+  Function.Id.Protocol = SVSM_UEFI_MM_PROTOCOL;
+  Function.Id.CallId   = CallId;
+
+  SvsmCallData.Caa   = (SVSM_CAA *)AmdSvsmSnpGetCaa ();
+  SvsmCallData.RaxIn = Function.Uint64;
+  SvsmCallData.RcxIn = Rcx;
+  SvsmCallData.RdxIn = Rdx;
+
+  Ret = SvsmMsrProtocol (&SvsmCallData);
+  return (Ret == 0) ? TRUE : FALSE;
+}

--- a/OvmfPkg/Library/PlatformBootManagerLib/PlatformBootManagerLib.inf
+++ b/OvmfPkg/Library/PlatformBootManagerLib/PlatformBootManagerLib.inf
@@ -64,6 +64,7 @@
   gUefiOvmfPkgTokenSpaceGuid.PcdOvmfFlashVariablesEnable
   gUefiOvmfPkgTokenSpaceGuid.PcdOvmfHostBridgePciDevId
   gUefiOvmfPkgTokenSpaceGuid.PcdBootRestrictToFirmware
+  gUefiOvmfPkgTokenSpaceGuid.PcdUninstallMemAttrProtocol
   gEfiMdeModulePkgTokenSpaceGuid.PcdAcpiS3Enable
   gEfiMdePkgTokenSpaceGuid.PcdPlatformBootTimeOut
   gEfiMdePkgTokenSpaceGuid.PcdUartDefaultBaudRate         ## CONSUMES
@@ -82,6 +83,7 @@
   gEfiDxeSmmReadyToLockProtocolGuid             # PROTOCOL SOMETIMES_PRODUCED
   gEfiLoadedImageProtocolGuid                   # PROTOCOL SOMETIMES_PRODUCED
   gEfiFirmwareVolume2ProtocolGuid               # PROTOCOL SOMETIMES_CONSUMED
+  gEfiMemoryAttributeProtocolGuid
 
 [Guids]
   gEfiEndOfDxeEventGroupGuid

--- a/OvmfPkg/VirtMmCommunicationDxe/Svsm.c
+++ b/OvmfPkg/VirtMmCommunicationDxe/Svsm.c
@@ -1,0 +1,71 @@
+/** @file
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Library/BaseLib.h>
+
+#include <Library/AmdSvsmLib.h>
+#include <Register/Amd/Msr.h>
+#include <Register/Amd/Svsm.h>
+
+#include "VirtMmCommunication.h"
+
+BOOLEAN
+EFIAPI
+VirtMmSvsmProbe (
+  VOID
+  )
+{
+  if (!AmdSvsmIsSvsmPresent ()) {
+    DEBUG ((DEBUG_VERBOSE, "%a: no SVSM present\n", __func__));
+    return FALSE;
+  }
+
+  if (!AmdSvsmUefiMmCall (SVSM_UEFI_MM_QUERY, 0, 0)) {
+    DEBUG ((DEBUG_VERBOSE, "%a: SVSM UEFI MM protocol not supported\n", __func__));
+    return FALSE;
+  }
+
+  DEBUG ((DEBUG_INFO, "%a: query ok\n", __func__));
+  return TRUE;
+}
+
+EFI_STATUS
+EFIAPI
+VirtMmSvsmInit (
+  VOID
+  )
+{
+  UINT64  Rcx, Rdx;
+
+  ASSERT (AmdSvsmIsSvsmPresent ());
+
+  AmdSvsmUefiMmCall (SVSM_UEFI_MM_RESET, 0, 0);
+
+  Rcx = (UINT64)(UINTN)mCommunicateBufferPhys;
+  Rdx = MAX_BUFFER_SIZE;
+  if (!AmdSvsmUefiMmCall (SVSM_UEFI_MM_SETUP, Rcx, Rdx)) {
+    DEBUG ((DEBUG_ERROR, "%a: SVSM_UEFI_MM_SETUP failed\n", __func__));
+    return EFI_DEVICE_ERROR;
+  }
+
+  return EFI_SUCCESS;
+}
+
+EFI_STATUS
+EFIAPI
+VirtMmSvsmComm (
+  VOID
+  )
+{
+  ASSERT (AmdSvsmIsSvsmPresent ());
+
+  if (!AmdSvsmUefiMmCall (SVSM_UEFI_MM_REQUEST, 0, 0)) {
+    DEBUG ((DEBUG_ERROR, "%a: SVSM_UEFI_MM_REQUEST failed\n", __func__));
+    return EFI_DEVICE_ERROR;
+  }
+
+  return EFI_SUCCESS;
+}

--- a/OvmfPkg/VirtMmCommunicationDxe/SvsmNull.c
+++ b/OvmfPkg/VirtMmCommunicationDxe/SvsmNull.c
@@ -1,0 +1,34 @@
+/** @file
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Library/BaseLib.h>
+
+BOOLEAN
+EFIAPI
+VirtMmSvsmProbe (
+  VOID
+  )
+{
+  return FALSE;
+}
+
+EFI_STATUS
+EFIAPI
+VirtMmSvsmInit (
+  VOID
+  )
+{
+  return EFI_UNSUPPORTED;
+}
+
+EFI_STATUS
+EFIAPI
+VirtMmSvsmComm (
+  VOID
+  )
+{
+  return EFI_UNSUPPORTED;
+}

--- a/OvmfPkg/VirtMmCommunicationDxe/VirtMmCommunication.c
+++ b/OvmfPkg/VirtMmCommunicationDxe/VirtMmCommunication.c
@@ -20,7 +20,8 @@
 
 VOID                  *mCommunicateBuffer;
 EFI_PHYSICAL_ADDRESS  mCommunicateBufferPhys;
-BOOLEAN               mUsePioTransfer = FALSE;
+BOOLEAN               mHaveSvsmProtocol = FALSE;
+BOOLEAN               mUsePioTransfer   = FALSE;
 
 // Notification event when virtual address map is set.
 STATIC EFI_EVENT  mSetVirtualAddressMapEvent;
@@ -142,7 +143,17 @@ VirtMmCommunication2Communicate (
     return Status;
   }
 
-  if (mUsePioTransfer) {
+  if (mHaveSvsmProtocol) {
+    CopyMem (mCommunicateBuffer, CommBufferVirtual, BufferSize);
+
+    Status = VirtMmSvsmComm ();
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_WARN, "%a: svsm comm error: %r\n", __func__, Status));
+      return Status;
+    }
+
+    CopyMem (CommBufferVirtual, mCommunicateBuffer, BufferSize);
+  } else if (mUsePioTransfer) {
     Status = VirtMmHwPioTransfer (CommBufferVirtual, BufferSize, TRUE);
     if (EFI_ERROR (Status)) {
       DEBUG ((DEBUG_WARN, "%a: pio write error: %r\n", __func__, Status));
@@ -220,14 +231,16 @@ VirtMmNotifySetVirtualAddressMap (
       ));
   }
 
-  Status = VirtMmHwVirtMap ();
-  if (EFI_ERROR (Status)) {
-    DEBUG ((
-      DEBUG_ERROR,
-      "%a: VirtMmHwVirtMap failed. Status: %r\n",
-      __func__,
-      Status
-      ));
+  if (!mHaveSvsmProtocol) {
+    Status = VirtMmHwVirtMap ();
+    if (EFI_ERROR (Status)) {
+      DEBUG ((
+        DEBUG_ERROR,
+        "%a: VirtMmHwVirtMap failed. Status: %r\n",
+        __func__,
+        Status
+        ));
+    }
   }
 }
 
@@ -309,12 +322,20 @@ VirtMmCommunication2Initialize (
   }
 
   mCommunicateBufferPhys = (EFI_PHYSICAL_ADDRESS)(UINTN)(mCommunicateBuffer);
-  Status                 = VirtMmHwInit ();
+
+  if (VirtMmSvsmProbe ()) {
+    mHaveSvsmProtocol = TRUE;
+    Status            = VirtMmSvsmInit ();
+  } else {
+    Status = VirtMmHwInit ();
+  }
+
   if (EFI_ERROR (Status)) {
     DEBUG ((
       DEBUG_ERROR,
-      "%a: Failed to init HW: %r\n",
+      "%a: Failed to init %a: %r\n",
       __func__,
+      mHaveSvsmProtocol ? "SVSM" : "HW",
       Status
       ));
     goto FreeBufferPages;

--- a/OvmfPkg/VirtMmCommunicationDxe/VirtMmCommunication.h
+++ b/OvmfPkg/VirtMmCommunicationDxe/VirtMmCommunication.h
@@ -50,4 +50,24 @@ VirtMmHwPioTransfer (
   BOOLEAN  ToDevice
   );
 
+/* svsm hooks */
+
+BOOLEAN
+EFIAPI
+VirtMmSvsmProbe (
+  VOID
+  );
+
+EFI_STATUS
+EFIAPI
+VirtMmSvsmInit (
+  VOID
+  );
+
+EFI_STATUS
+EFIAPI
+VirtMmSvsmComm (
+  VOID
+  );
+
 #endif /* _VIRT_MM_COMM_DXE_H_ */

--- a/OvmfPkg/VirtMmCommunicationDxe/VirtMmCommunication.inf
+++ b/OvmfPkg/VirtMmCommunicationDxe/VirtMmCommunication.inf
@@ -21,15 +21,20 @@
 #  QemuX64.c
   QemuHwInfo.c
   QemuMmio.c
+  Svsm.c
 
 [Sources.AARCH64, Sources.ARM]
   QemuFdt.c
   QemuMmio.c
+  SvsmNull.c
 
 [Packages]
   MdePkg/MdePkg.dec
   MdeModulePkg/MdeModulePkg.dec
   OvmfPkg/OvmfPkg.dec
+
+[Packages.X64]
+  UefiCpuPkg/UefiCpuPkg.dec
 
 [Packages.AARCH64, Packages.ARM]
   EmbeddedPkg/EmbeddedPkg.dec
@@ -45,6 +50,7 @@
 [LibraryClasses.X64]
   DxeHardwareInfoLib
   QemuFwCfgLib
+  AmdSvsmLib
 
 [LibraryClasses.AARCH64, LibraryClasses.ARM]
   FdtLib

--- a/UefiCpuPkg/Include/Library/AmdSvsmLib.h
+++ b/UefiCpuPkg/Include/Library/AmdSvsmLib.h
@@ -139,4 +139,12 @@ AmdSvsmVtpmCmd (
   IN OUT UINT8  *Buffer
   );
 
+BOOLEAN
+EFIAPI
+AmdSvsmUefiMmCall (
+  IN  UINT32  CallId,
+  IN  UINT64  Rcx,
+  IN  UINT64  Rdx
+  );
+
 #endif

--- a/UefiCpuPkg/Library/AmdSvsmLibNull/AmdSvsmLibNull.c
+++ b/UefiCpuPkg/Library/AmdSvsmLibNull/AmdSvsmLibNull.c
@@ -153,3 +153,14 @@ AmdSvsmVtpmCmd (
 {
   return FALSE;
 }
+
+BOOLEAN
+EFIAPI
+AmdSvsmUefiMmCall (
+  IN  UINT32  CallId,
+  IN  UINT64  Rcx,
+  IN  UINT64  Rdx
+  )
+{
+  return FALSE;
+}


### PR DESCRIPTION
- **OvmfPkg/X64: add opt/org.tianocore/UninstallMemAttrProtocol support**
- **MdePkg/Svsm: add SVSM_UEFI_MM_PROTOCOL**
- **UefiCpuPkg/AmdSvsmLib: add AmdSvsmUefiMmCall**
- **OvmfPkg/AmdSvsmLib: add AmdSvsmUefiMmCall**
- **OvmfPkg/VirtMmCommunicationDxe: add SVSM support**

Extend VirtMmCommunicationDxe so it can talk to both
qemu and svsm variable store.

Current status:
- works fine before ExitBootServices.
- linux pagefaults when setting EFI vars.

Looks like AmdSvsmLib needs some fixes so
it works properly with runtime services.
