### PR TITLE
BaseTools: Add gcov_info to GCC linker script

### DIFF
--- a/BaseTools/Scripts/GccBase.lds
+++ b/BaseTools/Scripts/GccBase.lds
@@ -5,6 +5,7 @@
   Copyright (c) 2010 - 2021, Intel Corporation. All rights reserved.<BR>
   Copyright (c) 2015, Linaro Ltd. All rights reserved.<BR>
   (C) Copyright 2016 Hewlett Packard Enterprise Development LP<BR>
+  Copyright (C) 2025, Microsoft Corporation. All rights reserved.<BR>
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -77,6 +78,12 @@ SECTIONS {
     *(.got.plt)
   }
   ASSERT(SIZEOF(.got.plt) == 0 || SIZEOF(.got.plt) == 0xc || SIZEOF(.got.plt) == 0x18, "Unexpected GOT/PLT entries detected!")
+
+  .gcov_info : {
+    PROVIDE (__gcov_info_start = .);
+    KEEP (*(.gcov_info))
+    PROVIDE (__gcov_info_end = .);
+  }
 
   /*
    * Retain the GNU build id but in a non-allocatable section so GenFw


### PR DESCRIPTION
# Description

GCC is capable of adding code coverage sections that are filled in at runtime. This change collects those sections into the final binary so that the code coverage data are available for dumping and post-processing using gcov.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Test shell app compiled with gcc --coverage and linked with this GccBase.lds was run under QEMU.

## Integration Instructions

N/A
