### PR TITLE
ArmPkg: ArmPsciResetSystemLib: PSCI warm reset fix

### DIFF
--- a/ArmPkg/Library/ArmPsciResetSystemLib/ArmPsciResetSystemLib.c
+++ b/ArmPkg/Library/ArmPsciResetSystemLib/ArmPsciResetSystemLib.c
@@ -71,13 +71,16 @@ ResetWarm (
 {
   ARM_MONITOR_ARGS  Args;
 
-  Args.Arg0 = ARM_SMC_ID_PSCI_SYSTEM_RESET2_AARCH64;
+  Args.Arg0 = ARM_SMC_ID_PSCI_FEATURES;
+  Args.Arg1 = ARM_SMC_ID_PSCI_SYSTEM_RESET2_AARCH64;
 
   // Is SYSTEM_RESET2 supported?
   ArmMonitorCall (&Args);
   if (Args.Arg0 == ARM_SMC_PSCI_RET_SUCCESS) {
     // Send PSCI SYSTEM_RESET2 command
     Args.Arg0 = ARM_SMC_ID_PSCI_SYSTEM_RESET2_AARCH64;
+    Args.Arg1 = 0; // Reset type
+    // cookie does not matter with reset type 0
 
     ArmMonitorCall (&Args);
   } else {


### PR DESCRIPTION
# Description

This resolves an issue in the ResetWarm() routine where the warm reset was being attempted twice instead of querying for PSCI SYSTEM_RESET2 support. In addition, it ensures that the monitor args are zero'd prior to monitor calls.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

The change was tested warm reset flow with this change, confirmed that SYSTEM_RESET2 works as expected.

## Integration Instructions

N/A
