### PR TITLE
NetworkPkg/HttpBootDxe: Update HTTP Boot to wait for IPv6 duplicate address detection to finish

### DIFF
--- a/NetworkPkg/HttpBootDxe/HttpBootDhcp6.h
+++ b/NetworkPkg/HttpBootDxe/HttpBootDhcp6.h
@@ -16,6 +16,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #define HTTP_BOOT_IP6_ROUTE_TABLE_TIMEOUT  10
 #define HTTP_BOOT_DEFAULT_HOPLIMIT         64
 #define HTTP_BOOT_DEFAULT_LIFETIME         50000
+#define HTTP_BOOT_DAD_ADDITIONAL_DELAY     30000000   // 3 seconds
 
 #define HTTP_BOOT_DHCP6_ENTERPRISE_NUM      343     // TODO: IANA TBD: temporarily using Intel's
 #define HTTP_BOOT_DHCP6_MAX_BOOT_FILE_SIZE  65535   //   It's a limitation of bit length, 65535*512 bytes.


### PR DESCRIPTION
# Description

Align HTTP Boot behavior with PXE by inserting a delay to wait for IPv6 Duplicate Address Detection (DAD) to complete before issuing DHCPv6 requests. This avoids EFI_NO_MAPPING errors caused by early DHCP attempts before a valid IPv6 address is ready.

Problem:
On some platforms, HTTP boot over IPv6 fails with EFI_NO_MAPPING during initial DHCPv6 attempts. The failure is due to the system trying to send Solicit messages before IPv6 DAD finishes, resulting in no usable IP address at that time.

Solution:
Insert a retry mechanism to poll DAD completion when the initial call to Dhcp6->Start() fails with EFI_NO_MAPPING. This behavior mirrors PXE's handling, where it waits for a valid IPv6 address to be assigned before retrying the DHCPv6 flow.

Reference: PXE DAD wait logic implemented in "PxeBcDhcp6.c", see commit "[ed2bfec](https://github.com/tianocore/edk2/commit/ed2bfecbcd6eed998be628b310bf89705fdb586c)".

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

- Set up an HTTP IPv6 boot environment.
- Confirmed `EFI_NO_MAPPING` no longer occurs after inserting the delay.
- Verified successful HTTP boot.

## Integration Instructions

N/A
