### PR TITLE
NetworkPkg: Condition Misconfiguration - The Length of IPv6 Prefix Equals 128 Should Be Included

### DIFF
--- a/NetworkPkg/Ip6Dxe/Ip6Icmp.c
+++ b/NetworkPkg/Ip6Dxe/Ip6Icmp.c
@@ -467,14 +467,14 @@ Ip6GetPrefix (
   UINT8  Mask;
   UINT8  Value;
 
-  ASSERT ((Prefix != NULL) && (PrefixLength < IP6_PREFIX_MAX));
+  ASSERT ((Prefix != NULL) && (PrefixLength <= IP6_PREFIX_MAX));
 
   if (PrefixLength == 0) {
     ZeroMem (Prefix, sizeof (EFI_IPv6_ADDRESS));
     return;
   }
 
-  if (PrefixLength >= IP6_PREFIX_MAX) {
+  if (PrefixLength > IP6_PREFIX_MAX) {
     return;
   }
 

--- a/NetworkPkg/Library/DxeNetLib/DxeNetLib.c
+++ b/NetworkPkg/Library/DxeNetLib/DxeNetLib.c
@@ -844,7 +844,7 @@ NetIp6IsNetEqual (
   UINT8  Bit;
   UINT8  Mask;
 
-  ASSERT ((Ip1 != NULL) && (Ip2 != NULL) && (PrefixLength < IP6_PREFIX_MAX));
+  ASSERT ((Ip1 != NULL) && (Ip2 != NULL) && (PrefixLength <= IP6_PREFIX_MAX));
 
   if (PrefixLength == 0) {
     return TRUE;


### PR DESCRIPTION
# Description

When the length of IPv6 prefix is 128, the if and ASSERT statement incorrectly exclude the case when it equals 128. This value should be included. 

Update to make sure the length of IPv6 prefix is 128 will not be excluded.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Setup IPv6 PXE server and connect with DUT, IPv6 PXE boot of DUT should not be blocked if IPv6 prefix length is 128.

## Integration Instructions

N/A
