### PR TITLE
MdeModulePkg/FaultTolerantWriteDxe: Add validation for FtwWorkSpaceHeader

### DIFF
--- a/MdeModulePkg/Universal/FaultTolerantWriteDxe/FtwMisc.c
+++ b/MdeModulePkg/Universal/FaultTolerantWriteDxe/FtwMisc.c
@@ -1300,7 +1300,10 @@ InitFtwProtocol (
   // Refresh the working space data from working block
   //
   Status = WorkSpaceRefresh (FtwDevice);
-  ASSERT_EFI_ERROR (Status);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "Ftw: Init.. WorkSpaceRefresh failed: Status = %r\n", Status));
+  }
+
   //
   // If the working block workspace is not valid, try the spare block
   //

--- a/MdeModulePkg/Universal/FaultTolerantWriteDxe/UpdateWorkingBlock.c
+++ b/MdeModulePkg/Universal/FaultTolerantWriteDxe/UpdateWorkingBlock.c
@@ -286,6 +286,10 @@ WorkSpaceRefresh (
     return EFI_ABORTED;
   }
 
+  if (!IsValidWorkSpace (FtwDevice->FtwWorkSpaceHeader)) {
+    return EFI_ABORTED;
+  }
+
   //
   // Refresh the FtwLastWriteHeader
   //


### PR DESCRIPTION


# Description

Fixes https://github.com/tianocore/edk2/issues/11118

Add validation for FtwWorkSpaceHeader within the
WorkSpaceRefresh() function to address an issue where the variable store cannot recover from the FTW spare block if the variable store is erased or corrupted during an FTW write or reclaim operation.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Flash UEFI with the corrupted variable store dumped from the failed device. The device should boot successfully and recover the variable store from the FTW spare block.
No regressions observed.

## Integration Instructions

N/A
