### PR TITLE
Fix building in C23 mode (e.g. with GCC 15.1)

### DIFF
--- a/MdeModulePkg/Universal/RegularExpressionDxe/OnigurumaUefiPort.h
+++ b/MdeModulePkg/Universal/RegularExpressionDxe/OnigurumaUefiPort.h
@@ -32,6 +32,7 @@
 typedef UINTN   size_t;
 typedef UINT32  uint32_t;
 typedef INTN    intptr_t;
+typedef INT64   ptrdiff_t;
 
 #ifndef offsetof
 #define offsetof  OFFSET_OF

--- a/RedfishPkg/Include/Library/RedfishCrtLib.h
+++ b/RedfishPkg/Include/Library/RedfishCrtLib.h
@@ -69,14 +69,17 @@
 //
 // Basic types mapping
 //
-typedef UINTN    size_t;
-typedef INTN     ssize_t;
-typedef INT32    time_t;
-typedef INT32    int32_t;
-typedef UINT32   uint32_t;
-typedef UINT16   uint16_t;
-typedef UINT8    uint8_t;
-typedef BOOLEAN  bool;
+typedef UINTN   size_t;
+typedef INTN    ssize_t;
+typedef INT32   time_t;
+typedef INT32   int32_t;
+typedef UINT32  uint32_t;
+typedef UINT16  uint16_t;
+typedef UINT8   uint8_t;
+// In C23, bool is a built-in type
+#if __STDC_VERSION__ < 202311L
+typedef BOOLEAN bool;
+#endif
 
 #define true   (1 == 1)
 #define false  (1 == 0)

--- a/SecurityPkg/DeviceSecurity/SpdmLib/Include/hal/LibspdmStdBoolAlt.h
+++ b/SecurityPkg/DeviceSecurity/SpdmLib/Include/hal/LibspdmStdBoolAlt.h
@@ -10,7 +10,10 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #ifndef LIBSPDM_STDBOOL_ALT_H
 #define LIBSPDM_STDBOOL_ALT_H
 
+// In C23, bool is a built-in type
+#if __STDC_VERSION__ < 202311L
 typedef BOOLEAN bool;
+#endif
 
 #ifndef true
 #define true  TRUE


### PR DESCRIPTION
# Description

In C23 bool is a built-in type, so it's not necessary to typedef bool.
This fixes a build error when using GCC 15. We can't add `-std=c17` to Conf/tools_def.txt because the same flags get passed to g++ when building GoogleTest, which causes an error because it's building C++ code where `-std=c17` isn't valid.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Ran `stuart_ci_build -c .pytool/CISettings.py TOOL_CHAIN_TAG=GCC`

## Integration Instructions
