### PR TITLE
ArmPlatformPkg/Sec: Deal with entry at EL2 with VHE enabled

### DIFF
--- a/ArmPlatformPkg/Sec/AArch64/Helper.S
+++ b/ArmPlatformPkg/Sec/AArch64/Helper.S
@@ -8,6 +8,8 @@
 #include <AsmMacroLib.h>
 #include <AArch64/AArch64.h>
 
+.set    HCR_EL2_E2H,           0x1 << 34
+
 // Setup EL1 while in EL1
 ASM_FUNC(SetupExceptionLevel1)
    mov  x5, x30                   // Save LR
@@ -28,9 +30,12 @@ ASM_FUNC(SetupExceptionLevel2)
    orr     x0, x0, #(1 << 5)      // Enable EL2 SError and Abort
    msr     hcr_el2, x0            // Write back our settings
 
-   // NB: We assume that we have not been entered on VHE systems with
-   // HCR_EL2.E2H set.
+   // Check whether we have been entered with HCR_EL2.E2H set, which is
+   // permitted to be RES1. In this case, CPTR_EL2 looks like CPACR_EL1.
+   tst     x0, #HCR_EL2_E2H
    mov     x0, #AARCH64_CPTR_DEFAULT
+   mov     x1, #CPACR_DEFAULT
+   csel    x0, x0, x1, eq
    msr     cptr_el2, x0           // Enable architectural features
 
    // Enable Timer access for non-secure EL1 and EL0


### PR DESCRIPTION
The architecture now permits HCR_EL2.E2H to be RES1, and so even though the UEFI spec is silent on the matter, entering at EL2 with VHE enabled is a condition that needs to be dealt with. In particular, virtual machines running under nested virtualization on Apple M2 or newer will enter in this manner

In this case, the CPTR_EL2 system register needs to be treated as if its layout is identical to CPACR_EL1. Not doing so may result in all kinds of surprises, but the most noticeable is an early crash on the use of FP/SIMD registers, which get disabled inadvertently by this code.
