### PR TITLE
BaseTools: fix cross-compilation of antlr & dlg

### DIFF
--- a/BaseTools/Source/C/VfrCompile/GNUmakefile
+++ b/BaseTools/Source/C/VfrCompile/GNUmakefile
@@ -32,6 +32,9 @@ LINKER = $(CXX)
 
 EXTRA_CLEAN_OBJECTS = EfiVfrParser.cpp EfiVfrParser.h VfrParser.dlg VfrTokens.h VfrLexer.cpp VfrLexer.h VfrSyntax.cpp tokens.h
 
+CC_FOR_BUILD ?= $(CC)
+CXX_FOR_BUILD ?= $(CXX)
+
 MAKEROOT ?= ../..
 
 include $(MAKEROOT)/Makefiles/header.makefile
@@ -55,10 +58,10 @@ VfrLexer.cpp VfrLexer.h: Pccts/dlg/dlg VfrParser.dlg
 	Pccts/dlg/dlg -C2 -i -CC -cl VfrLexer -o . VfrParser.dlg
 
 Pccts/antlr/antlr:
-	BIN_DIR='.' $(MAKE) -C Pccts/antlr
+	BIN_DIR='.' $(MAKE) -C Pccts/antlr CC=$(CC_FOR_BUILD) CXX=$(CXX_FOR_BUILD)
 
 Pccts/dlg/dlg:
-	BIN_DIR='.' $(MAKE) -C Pccts/dlg
+	BIN_DIR='.' $(MAKE) -C Pccts/dlg CC=$(CC_FOR_BUILD) CXX=$(CXX_FOR_BUILD)
 
 ATokenBuffer.o: Pccts/h/ATokenBuffer.cpp
 	$(CXX) -c $(VFR_CPPFLAGS) $(INC) $(VFR_CXXFLAGS) $? -o $@


### PR DESCRIPTION
antlr and dlg need to run on the build system, so we need to allow users to provide a way to specify a compiler

# Description

<_Include a description of the change and why this change was made._>

<_For each item, place an "x" in between `[` and `]` if true. Example: `[x]` (you can also check items in GitHub UI)_>

<_Create the PR as a Draft PR if it is only created to run CI checks._>

<_Delete lines in \<\> tags before creating the PR._>

- [ ] ~~Breaking change?~~
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] ~~Impacts security?~~
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] ~~Includes tests?~~
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

By cross-compilling

## Integration Instructions

<_Describe how these changes should be integrated. Use N/A if nothing is required._>
