### PR TITLE
ArmPkg: Add HobLib to ArmStandaloneMmCoreEntryPoint.

### DIFF
--- a/ArmPkg/Library/ArmStandaloneMmCoreEntryPoint/ArmStandaloneMmCoreEntryPoint.inf
+++ b/ArmPkg/Library/ArmStandaloneMmCoreEntryPoint/ArmStandaloneMmCoreEntryPoint.inf
@@ -48,6 +48,7 @@
   ArmTransferListLib
   ArmFfaLib
   StackCheckLib
+  HobLib
 
 [Guids]
   gMpInformationHobGuid


### PR DESCRIPTION
# Description

ArmStandaloneMmCoreEntryPoint makes use of GetNextHob which comes from HobLib. The inf does not specify
HobLib has one of its library classes. Specify
HobLib in the LibraryClasses section of the
inf.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested
Found build break during CI of a component that was using ArmStandaloneMmCoreEntryPoint for unreferenced external GetNextHob.
After adding HobLib to section, CI build completed successfully.


## Integration Instructions
No integration necessary.