### PR TITLE
PrePiLib missing header used in file

### DIFF
--- a/EmbeddedPkg/Include/Library/PrePiLib.h
+++ b/EmbeddedPkg/Include/Library/PrePiLib.h
@@ -11,6 +11,7 @@
 #define __PRE_PI_LIB_H__
 
 #include <Guid/ExtractSection.h>
+#include <Pi/PiPeiCis.h>
 
 /**
   This service enables discovery of additional firmware volumes.


### PR DESCRIPTION
# Description

PrePiLib.h is missing the header file that defines the structures used in the file.

Namely
 - EFI_PEI_FV_HANDLE
 - EFI_PEI_FILE_HANDLE
 
- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

Without linking magic, using this file causes the linker to explode.

## Integration Instructions

N/A