### PR TITLE
ArmPkg/Include: fix usage of wrong macro in ARM_GIC_ICDICTR_GET_SPI_MAX_INTID

### DIFF
--- a/ArmPkg/Include/Library/ArmGicLib.h
+++ b/ArmPkg/Include/Library/ArmGicLib.h
@@ -47,7 +47,7 @@
 
 // Extracts the maximum SPI IntId from TypeReg.
 #define ARM_GIC_ICDICTR_GET_SPI_MAX_INTID(TypeReg) \
-  ARM_GIC_ICDICTR_SPI_RANGE_TO_MAX_INTID(ARM_GIC_ICDICTR_GET_EXT_SPI_RANGE(TypeReg))
+  ARM_GIC_ICDICTR_SPI_RANGE_TO_MAX_INTID(ARM_GIC_ICDICTR_GET_SPI_RANGE(TypeReg))
 
 #define ARM_GIC_ICDICTR_EXT_SPI_ENABLED      (1 << 8) // Extended SPI enabled bit.
 #define ARM_GIC_ICDICTR_EXT_SPI_RANGE_SHIFT  (27)     // Extended SPI range position.


### PR DESCRIPTION
To get a SPI_MAX_INTID, interrupt controller type Register should be masked with ARM_GIC_ICDICTR_GET_SPI_RANGE.
However, since ARM_GIC_ICDICTR_SPI_RANGE_TO_MAX_INTID macro uses ARM_GIC_ICDICTR_GET_EXT_SPI_RANGE mask, it returns wrong SPI_MAX_INITID.

This makes a failure of loading GenericWatchDog in FVP RevC model.

Signed-off-by: Yeoreum Yun <yeoreum.yun@arm.com>
Fixes: d6d2f68e3801 ("ArmPkg/Drivers/ArmGicDxe: ...")

