### PR TITLE
BaseTools\Plugin\HostBasedUnitTestRunner: Reduce the unit test duplicate execution

### DIFF
--- a/BaseTools/Plugin/HostBasedUnitTestRunner/HostBasedUnitTestRunner.py
+++ b/BaseTools/Plugin/HostBasedUnitTestRunner/HostBasedUnitTestRunner.py
@@ -110,6 +110,14 @@ class HostBasedUnitTestRunner(IUefiBuildPlugin):
                 return 0
 
             for test in testList:
+                #
+                # The gen_code_coverage_msvc() function uses the OpenCppCoverage tool to generate code coverage data,
+                # so unit test execution for the VS20XX toolchain can be skipped in this loop.
+                #
+                if (thebuilder.env.GetValue("CODE_COVERAGE") != "FALSE") and \
+                    (thebuilder.env.GetValue("TOOL_CHAIN_TAG").startswith("VS")):
+                    continue
+
                 # Configure output name if test uses cmocka.
                 shell_env.set_shell_var(
                     'CMOCKA_XML_FILE', test + ".CMOCKA.%g." + arch + ".result.xml")


### PR DESCRIPTION
# Description

The HostBasedUnitTestRunner.py is part of unit test that used to execute unit test application and generated code coverage report. Code coverage report generation is different in the different operation system. Please refer it as below.

[Windows]
	1.Run unit test application 
	2.Adopt OpenCppCoverage tool to run unit test application to generate coverage report.
[Linux]
	1.Run unit test application to generate .gcda and .gcno data.
	2.Adopt Lcov tool to collect .gcda and .gcno data then convert it to the coverage report. 
	
According to the above description, in the Windows the unit test application will be executed twice, But it is not necessary. 
So adopt variable CODE_COVERAGE to control it, unit test application only execute once in the windows for save time.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Local unit test build under windows and Linux.

## Integration Instructions

No integration required.
Just reduce unit test execution in the Windows.
