### PR TITLE
Fix typos in some packages

### DIFF
--- a/EmulatorPkg/Library/RedfishPlatformHostInterfaceLib/RedfishPlatformHostInterfaceLib.c
+++ b/EmulatorPkg/Library/RedfishPlatformHostInterfaceLib/RedfishPlatformHostInterfaceLib.c
@@ -350,7 +350,7 @@ DumpRedfishIpProtocolData (
   @param[out] RedfishProtocolData  Pointer to retrieve REDFISH_OVER_IP_PROTOCOL_DATA.
   @param[out] RedfishProtocolDataSize  Size of REDFISH_OVER_IP_PROTOCOL_DATA.
 
-  @retval EFI_SUCESS   REDFISH_OVER_IP_PROTOCOL_DATA is returned successfully.
+  @retval EFI_SUCCESS  REDFISH_OVER_IP_PROTOCOL_DATA is returned successfully.
 **/
 EFI_STATUS
 GetRedfishRecordFromVariable (

--- a/EmulatorPkg/PlatformSmbiosDxe/PlatformSmbiosDxe.c
+++ b/EmulatorPkg/PlatformSmbiosDxe/PlatformSmbiosDxe.c
@@ -75,7 +75,7 @@ CreatePlatformSmbiosMemoryRecords (
   @param ImageHandle     Image handle this driver.
   @param SystemTable     Pointer to SystemTable.
 
-  @retval EFI_SUCESS     This function always complete successfully.
+  @retval EFI_SUCCESS    This function always complete successfully.
 
 **/
 EFI_STATUS

--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciOptionRomSupport.c
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciOptionRomSupport.c
@@ -371,7 +371,7 @@ ContainEfiImage (
   @param RomBase   Base address of Option Rom.
 
   @retval EFI_OUT_OF_RESOURCES No enough memory to hold image.
-  @retval EFI_SUCESS           Successfully loaded Option Rom.
+  @retval EFI_SUCCESS          Successfully loaded Option Rom.
 
 **/
 EFI_STATUS

--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciOptionRomSupport.h
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciOptionRomSupport.h
@@ -91,7 +91,7 @@ GetOpRomInfo (
   @param RomBase   Base address of Option Rom.
 
   @retval EFI_OUT_OF_RESOURCES No enough memory to hold image.
-  @retval EFI_SUCESS           Successfully loaded Option Rom.
+  @retval EFI_SUCCESS          Successfully loaded Option Rom.
 
 **/
 EFI_STATUS

--- a/MdeModulePkg/Core/DxeIplPeim/DxeLoad.c
+++ b/MdeModulePkg/Core/DxeIplPeim/DxeLoad.c
@@ -59,7 +59,7 @@ CONST EFI_PEI_NOTIFY_DESCRIPTOR  mMemoryDiscoveredNotifyList = {
   @param  FileHandle  Handle of the file being invoked.
   @param  PeiServices Describes the list of possible PEI Services.
 
-  @retval EFI_SUCESS  The entry point of DXE IPL PEIM executes successfully.
+  @retval EFI_SUCCESS The entry point of DXE IPL PEIM executes successfully.
   @retval Others      Some error occurs during the execution of this function.
 
 **/
@@ -80,7 +80,7 @@ PeimInitializeDxeIpl (
     Status = PeiServicesRegisterForShadow (FileHandle);
     if (Status == EFI_SUCCESS) {
       //
-      // EFI_SUCESS means it is the first time to call register for shadow.
+      // EFI_SUCCESS means it is the first time to call register for shadow.
       //
       return Status;
     }

--- a/MdeModulePkg/Include/Library/CapsuleLib.h
+++ b/MdeModulePkg/Include/Library/CapsuleLib.h
@@ -24,7 +24,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
   @param  CapsuleHeader    Pointer to the UEFI capsule image to be checked.
 
-  @retval EFI_SUCESS       Input capsule is supported by firmware.
+  @retval EFI_SUCCESS      Input capsule is supported by firmware.
   @retval EFI_UNSUPPORTED  Input capsule is not supported by the firmware.
 **/
 EFI_STATUS
@@ -41,7 +41,7 @@ SupportCapsuleImage (
 
   @param  CapsuleHeader    Pointer to the UEFI capsule image to be processed.
 
-  @retval EFI_SUCESS       Capsule Image processed successfully.
+  @retval EFI_SUCCESS      Capsule Image processed successfully.
   @retval EFI_UNSUPPORTED  Capsule image is not supported by the firmware.
 **/
 EFI_STATUS

--- a/MdeModulePkg/Include/Library/FileExplorerLib.h
+++ b/MdeModulePkg/Include/Library/FileExplorerLib.h
@@ -26,7 +26,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
                            after choose one file.
   @param  File             Return the device path for the last time chosed file.
 
-  @retval EFI_SUCESS       Choose the file success.
+  @retval EFI_SUCCESS      Choose the file success.
   @retval Other errors     Choose the file failed.
 **/
 EFI_STATUS

--- a/MdeModulePkg/Include/Protocol/FileExplorer.h
+++ b/MdeModulePkg/Include/Protocol/FileExplorer.h
@@ -48,7 +48,7 @@ BOOLEAN
                            after choose one file.
   @param  File             Return the device path for the last time chosed file.
 
-  @retval EFI_SUCESS       Choose the file success.
+  @retval EFI_SUCCESS      Choose the file success.
   @retval Other errors     Choose the file failed.
 **/
 typedef

--- a/MdeModulePkg/Library/BootMaintenanceManagerUiLib/BootMaintenanceManager.h
+++ b/MdeModulePkg/Library/BootMaintenanceManagerUiLib/BootMaintenanceManager.h
@@ -396,7 +396,7 @@ BOpt_GetBootOptions (
 
   @param CallbackData The BMM context data.
 
-  @return EFI_SUCESS The functin completes successfully.
+  @return EFI_SUCCESS          The functin completes successfully.
   @retval EFI_OUT_OF_RESOURCES Not enough memory to compete the operation.
 
 

--- a/MdeModulePkg/Library/BootMaintenanceManagerUiLib/BootOption.c
+++ b/MdeModulePkg/Library/BootMaintenanceManagerUiLib/BootOption.c
@@ -281,7 +281,7 @@ BOpt_FreeMenu (
   @param CallbackData The BMM context data.
 
   @return EFI_NOT_FOUND Fail to find "BootOrder" variable.
-  @return EFI_SUCESS    Success build boot option menu.
+  @return EFI_SUCCESS   Success build boot option menu.
 
 **/
 EFI_STATUS
@@ -669,7 +669,7 @@ BOpt_GetDriverOptionNumber (
 
   @param CallbackData The BMM context data.
 
-  @retval EFI_SUCESS           The functin completes successfully.
+  @retval EFI_SUCCESS          The functin completes successfully.
   @retval EFI_OUT_OF_RESOURCES Not enough memory to compete the operation.
   @retval EFI_NOT_FOUND        Fail to get "DriverOrder" variable.
 

--- a/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleLib.c
+++ b/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleLib.c
@@ -104,7 +104,7 @@ RecordFmpCapsuleStatusVariable (
   @param[in]  Completion  A value between 1 and 100 indicating the current
                           completion progress of the firmware update
 
-  @retval EFI_SUCESS             The capsule update progress was updated.
+  @retval EFI_SUCCESS            The capsule update progress was updated.
   @retval EFI_INVALID_PARAMETER  Completion is greater than 100%.
 **/
 EFI_STATUS
@@ -201,7 +201,7 @@ IsValidCapsuleHeader (
   @param[in]   CapsuleHeader        Points to a capsule header.
   @param[out]  EmbeddedDriverCount  The EmbeddedDriverCount in the FMP capsule.
 
-  @retval EFI_SUCESS             Input capsule is a correct FMP capsule.
+  @retval EFI_SUCCESS            Input capsule is a correct FMP capsule.
   @retval EFI_INVALID_PARAMETER  Input capsule is not a correct FMP capsule.
 **/
 EFI_STATUS
@@ -345,7 +345,7 @@ ValidateFmpCapsule (
 
   @param[in]  CapsuleHeader    Points to a capsule header.
 
-  @retval EFI_SUCESS       Input capsule is supported by firmware.
+  @retval EFI_SUCCESS      Input capsule is supported by firmware.
   @retval EFI_UNSUPPORTED  Input capsule is not supported by the firmware.
 **/
 EFI_STATUS
@@ -1198,7 +1198,7 @@ RecordFmpCapsuleStatus (
   @param[in]  CapFileName           Capsule file name.
   @param[out] ResetRequired         Indicates whether reset is required or not.
 
-  @retval EFI_SUCESS            Process Capsule Image successfully.
+  @retval EFI_SUCCESS           Process Capsule Image successfully.
   @retval EFI_UNSUPPORTED       Capsule image is not supported by the firmware.
   @retval EFI_VOLUME_CORRUPTED  FV volume in the capsule is corrupted.
   @retval EFI_OUT_OF_RESOURCES  Not enough memory.
@@ -1496,7 +1496,7 @@ IsFmpCapsule (
 
   @param[in]  CapsuleHeader    Points to a capsule header.
 
-  @retval EFI_SUCESS       Input capsule is supported by firmware.
+  @retval EFI_SUCCESS      Input capsule is supported by firmware.
   @retval EFI_UNSUPPORTED  Input capsule is not supported by the firmware.
   @retval EFI_INVALID_PARAMETER Input capsule layout is not correct
 **/
@@ -1547,7 +1547,7 @@ SupportCapsuleImage (
   @param[in]  CapFileName           Capsule file name.
   @param[out] ResetRequired         Indicates whether reset is required or not.
 
-  @retval EFI_SUCESS            Process Capsule Image successfully.
+  @retval EFI_SUCCESS           Process Capsule Image successfully.
   @retval EFI_UNSUPPORTED       Capsule image is not supported by the firmware.
   @retval EFI_VOLUME_CORRUPTED  FV volume in the capsule is corrupted.
   @retval EFI_OUT_OF_RESOURCES  Not enough memory.
@@ -1610,7 +1610,7 @@ ProcessThisCapsuleImage (
 
   @param[in]  CapsuleHeader         Points to a capsule header.
 
-  @retval EFI_SUCESS            Process Capsule Image successfully.
+  @retval EFI_SUCCESS           Process Capsule Image successfully.
   @retval EFI_UNSUPPORTED       Capsule image is not supported by the firmware.
   @retval EFI_VOLUME_CORRUPTED  FV volume in the capsule is corrupted.
   @retval EFI_OUT_OF_RESOURCES  Not enough memory.

--- a/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleProcessLib.c
+++ b/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleProcessLib.c
@@ -65,7 +65,7 @@ IsFmpCapsule (
   @param[in]   CapsuleHeader        Points to a capsule header.
   @param[out]  EmbeddedDriverCount  The EmbeddedDriverCount in the FMP capsule.
 
-  @retval EFI_SUCESS             Input capsule is a correct FMP capsule.
+  @retval EFI_SUCCESS            Input capsule is a correct FMP capsule.
   @retval EFI_INVALID_PARAMETER  Input capsule is not a correct FMP capsule.
 **/
 EFI_STATUS
@@ -139,7 +139,7 @@ UINT32      mCapsuleTotalNumber;
   @param[in]  CapFileName           Capsule file name.
   @param[out] ResetRequired         Indicates whether reset is required or not.
 
-  @retval EFI_SUCESS            Process Capsule Image successfully.
+  @retval EFI_SUCCESS           Process Capsule Image successfully.
   @retval EFI_UNSUPPORTED       Capsule image is not supported by the firmware.
   @retval EFI_VOLUME_CORRUPTED  FV volume in the capsule is corrupted.
   @retval EFI_OUT_OF_RESOURCES  Not enough memory.
@@ -159,7 +159,7 @@ ProcessThisCapsuleImage (
   @param[in]  Completion  A value between 1 and 100 indicating the current
                           completion progress of the firmware update
 
-  @retval EFI_SUCESS             The capsule update progress was updated.
+  @retval EFI_SUCCESS            The capsule update progress was updated.
   @retval EFI_INVALID_PARAMETER  Completion is greater than 100%.
 **/
 EFI_STATUS

--- a/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleProcessLibNull.c
+++ b/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleProcessLibNull.c
@@ -18,7 +18,7 @@
   @param[in]  Completion  A value between 1 and 100 indicating the current
                           completion progress of the firmware update
 
-  @retval EFI_SUCESS             The capsule update progress was updated.
+  @retval EFI_SUCCESS            The capsule update progress was updated.
   @retval EFI_INVALID_PARAMETER  Completion is greater than 100%.
 **/
 EFI_STATUS

--- a/MdeModulePkg/Library/DxeFileExplorerProtocol/DxeFileExplorerProtocol.c
+++ b/MdeModulePkg/Library/DxeFileExplorerProtocol/DxeFileExplorerProtocol.c
@@ -68,7 +68,7 @@ FileExplorerConstructor (
                            after choose one file.
   @param  File             Return the device path for the last time chosed file.
 
-  @retval EFI_SUCESS             Choose file success.
+  @retval EFI_SUCCESS            Choose file success.
   @retval EFI_INVALID_PARAMETER  Both ChooseHandler and return device path are NULL
                                  One of them must not NULL.
   @retval Other errors           Choose file failed.

--- a/MdeModulePkg/Library/FileExplorerLib/FileExplorer.c
+++ b/MdeModulePkg/Library/FileExplorerLib/FileExplorer.c
@@ -870,7 +870,7 @@ LibFindFileSystem (
   @param  MenuEntry        Input Menu info.
   @param  RetFileHandle    Return the file handle for the input device path.
 
-  @retval EFI_SUCESS       Find the file handle success.
+  @retval EFI_SUCCESS      Find the file handle success.
   @retval Other            Find the file handle failure.
 **/
 EFI_STATUS
@@ -918,7 +918,7 @@ LibGetFileHandleFromMenu (
   @param  ParentFileName   Parent file name.
   @param  DeviceHandle     Driver handle for this partition.
 
-  @retval EFI_SUCESS       Find the file handle success.
+  @retval EFI_SUCCESS      Find the file handle success.
   @retval Other            Find the file handle failure.
 **/
 EFI_STATUS
@@ -1478,7 +1478,7 @@ LibGetDevicePath (
                            after choose one file.
   @param  File             Return the device path for the last time chosed file.
 
-  @retval EFI_SUCESS             Choose file success.
+  @retval EFI_SUCCESS            Choose file success.
   @retval EFI_INVALID_PARAMETER  Both ChooseHandler and return device path are NULL
                                  One of them must not NULL.
   @retval Other errors           Choose file failed.

--- a/MdeModulePkg/Universal/DebugServicePei/DebugServicePei.c
+++ b/MdeModulePkg/Universal/DebugServicePei/DebugServicePei.c
@@ -78,7 +78,7 @@ PeiDebugAssert (
   @param  FileHandle  Handle of the file being invoked.
   @param  PeiServices Describes the list of possible PEI Services.
 
-  @retval EFI_SUCESS  The entry point of Debug Service PEIM executes successfully.
+  @retval EFI_SUCCESS The entry point of Debug Service PEIM executes successfully.
   @retval Others      Some error occurs during the execution of this function.
 
 **/

--- a/MdeModulePkg/Universal/DisplayEngineDxe/FormDisplay.c
+++ b/MdeModulePkg/Universal/DisplayEngineDxe/FormDisplay.c
@@ -2380,7 +2380,7 @@ FxConfirmPopup (
   @param  Highlight                Whether this menu will be highlight.
   @param  UpdateCol                Whether need to update the column info for Date/Time.
 
-  @retval EFI_SUCESSS              Process the user selection success.
+  @retval EFI_SUCCESS              Process the user selection success.
 
 **/
 EFI_STATUS
@@ -2627,7 +2627,7 @@ DisplayOneMenu (
 
   @param  FormData               The current form data info.
 
-  @retval EFI_SUCESSS            Process the user selection success.
+  @retval EFI_SUCCESS            Process the user selection success.
   @retval EFI_NOT_FOUND          Process option string for orderedlist/Oneof fail.
 
 **/

--- a/MdeModulePkg/Universal/DriverSampleDxe/DriverSample.c
+++ b/MdeModulePkg/Universal/DriverSampleDxe/DriverSample.c
@@ -1746,7 +1746,7 @@ DriverCallback (
   @param ImageHandle     Image handle this driver.
   @param SystemTable     Pointer to SystemTable.
 
-  @retval EFI_SUCESS     This function always complete successfully.
+  @retval EFI_SUCCESS    This function always complete successfully.
 
 **/
 EFI_STATUS

--- a/MdeModulePkg/Universal/HiiResourcesSampleDxe/HiiResourcesSample.c
+++ b/MdeModulePkg/Universal/HiiResourcesSampleDxe/HiiResourcesSample.c
@@ -57,7 +57,7 @@ HII_VENDOR_DEVICE_PATH  mHiiVendorDevicePath = {
   @param[in] ImageHandle     Image handle this driver.
   @param[in] SystemTable     Pointer to SystemTable.
 
-  @retval EFI_SUCESS     This function always complete successfully.
+  @retval EFI_SUCCESS    This function always complete successfully.
 
 **/
 EFI_STATUS

--- a/MdeModulePkg/Universal/ReportStatusCodeRouter/Pei/ReportStatusCodeRouterPei.c
+++ b/MdeModulePkg/Universal/ReportStatusCodeRouter/Pei/ReportStatusCodeRouterPei.c
@@ -275,7 +275,7 @@ ReportDispatcher (
   @param  FileHandle  Handle of the file being invoked.
   @param  PeiServices Describes the list of possible PEI Services.
 
-  @retval EFI_SUCESS  The entry point of DXE IPL PEIM executes successfully.
+  @retval EFI_SUCCESS The entry point of DXE IPL PEIM executes successfully.
 
 **/
 EFI_STATUS

--- a/MdeModulePkg/Universal/SetupBrowserDxe/Presentation.c
+++ b/MdeModulePkg/Universal/SetupBrowserDxe/Presentation.c
@@ -1004,7 +1004,7 @@ UpdateStatementStatus (
   @param Action                  The user input action request info.
   @param DefaultId               The user input default Id info.
 
-  @retval EFI_SUCESSS            This function always return successfully for now.
+  @retval EFI_SUCCESS            This function always return successfully for now.
 
 **/
 EFI_STATUS
@@ -1557,7 +1557,7 @@ ProcessQuestionConfig (
 
   @param UserInput               The user input data.
 
-  @retval EFI_SUCESSS            This function always return successfully for now.
+  @retval EFI_SUCCESS            This function always return successfully for now.
 
 **/
 EFI_STATUS
@@ -1687,7 +1687,7 @@ ProcessUserInput (
 
   Display form and wait for user to select one menu option, then return it.
 
-  @retval EFI_SUCESSS            This function always return successfully for now.
+  @retval EFI_SUCCESS            This function always return successfully for now.
 
 **/
 EFI_STATUS

--- a/MdeModulePkg/Universal/StatusCodeHandler/Pei/StatusCodeHandlerPei.c
+++ b/MdeModulePkg/Universal/StatusCodeHandler/Pei/StatusCodeHandlerPei.c
@@ -19,7 +19,7 @@
   @param  FileHandle  Handle of the file being invoked.
   @param  PeiServices Describes the list of possible PEI Services.
 
-  @retval EFI_SUCESS  The entry point of DXE IPL PEIM executes successfully.
+  @retval EFI_SUCCESS The entry point of DXE IPL PEIM executes successfully.
 
 **/
 EFI_STATUS

--- a/MdePkg/Include/Protocol/MmMp.h
+++ b/MdePkg/Include/Protocol/MmMp.h
@@ -247,14 +247,14 @@ EFI_STATUS
   via the use of a token, this function can be used to check for completion of the procedure on the AP.
   The function takes the token that was passed into the DispatchProcedure call. If the procedure
   is complete, and therefore it is now possible to run another procedure on the same AP, this function
-  returns EFI_SUCESS. In this case the status returned by the procedure that executed on the AP is
+  returns EFI_SUCCESS. In this case the status returned by the procedure that executed on the AP is
   returned in the token's Status field. If the procedure has not yet completed, then this function
   returns EFI_NOT_READY.
 
   When a non-blocking execution of a procedure is invoked with BroadcastProcedure, via the
   use of a token, this function can be used to check for completion of the procedure on all the
   broadcast APs. The function takes the token that was passed into the BroadcastProcedure
-  call. If the procedure is complete on all broadcast APs this function returns EFI_SUCESS. In this
+  call. If the procedure is complete on all broadcast APs this function returns EFI_SUCCESS. In this
   case the Status field in the token passed into the function reflects the overall result of the
   invocation, which may be EFI_SUCCESS, if all executions succeeded, or the first observed failure.
   If the procedure has not yet completed on the broadcast APs, the function returns

--- a/OvmfPkg/IncompatiblePciDeviceSupportDxe/IncompatiblePciDeviceSupport.c
+++ b/OvmfPkg/IncompatiblePciDeviceSupportDxe/IncompatiblePciDeviceSupport.c
@@ -243,7 +243,7 @@ CheckDevice (
   @param[in] ImageHandle  Image handle of this driver.
   @param[in] SystemTable  Pointer to SystemTable.
 
-  @retval EFI_SUCESS       Driver has loaded successfully.
+  @retval EFI_SUCCESS      Driver has loaded successfully.
   @retval EFI_UNSUPPORTED  PCI resource allocation has been disabled.
   @retval EFI_UNSUPPORTED  There is no 64-bit PCI MMIO aperture.
   @return                  Error codes from lower level functions.

--- a/OvmfPkg/PciHotPlugInitDxe/PciHotPlugInit.c
+++ b/OvmfPkg/PciHotPlugInitDxe/PciHotPlugInit.c
@@ -802,7 +802,7 @@ GetResourcePadding (
   @param[in] ImageHandle  Image handle of this driver.
   @param[in] SystemTable  Pointer to SystemTable.
 
-  @retval EFI_SUCESS       Driver has loaded successfully.
+  @retval EFI_SUCCESS      Driver has loaded successfully.
   @return                  Error codes from lower level functions.
 
 **/

--- a/OvmfPkg/PlatformDxe/Platform.c
+++ b/OvmfPkg/PlatformDxe/Platform.c
@@ -620,7 +620,7 @@ FreeGopModes:
 
   @param[in]  GopModes      Array of resolutions retrieved from the GOP.
 
-  @retval EFI_SUCESS  Opcodes have been successfully produced.
+  @retval EFI_SUCCESS Opcodes have been successfully produced.
 
   @return             Status codes from underlying functions. PackageList may
                       have been extended with new strings. OpCodeBuffer is
@@ -697,7 +697,7 @@ FreeOutputBuffer:
   The drop down list of video resolutions is generated from (NumGopModes,
   GopModes).
 
-  @retval EFI_SUCESS  Form successfully updated.
+  @retval EFI_SUCCESS Form successfully updated.
   @return             Status codes from underlying functions.
 
 **/
@@ -949,7 +949,7 @@ GopInstalled (
   @param[in] ImageHandle  Image handle of this driver.
   @param[in] SystemTable  Pointer to SystemTable.
 
-  @retval EFI_SUCESS            Driver has loaded successfully.
+  @retval EFI_SUCCESS           Driver has loaded successfully.
   @retval EFI_OUT_OF_RESOURCES  Failed to install HII packages.
   @return                       Error codes from lower level functions.
 

--- a/UefiCpuPkg/PiSmmCpuDxeSmm/SmmMp.c
+++ b/UefiCpuPkg/PiSmmCpuDxeSmm/SmmMp.c
@@ -260,14 +260,14 @@ SmmMpSetStartupProcedure (
   via the use of a token, this function can be used to check for completion of the procedure on the AP.
   The function takes the token that was passed into the DispatchProcedure call. If the procedure
   is complete, and therefore it is now possible to run another procedure on the same AP, this function
-  returns EFI_SUCESS. In this case the status returned by the procedure that executed on the AP is
+  returns EFI_SUCCESS. In this case the status returned by the procedure that executed on the AP is
   returned in the token's Status field. If the procedure has not yet completed, then this function
   returns EFI_NOT_READY.
 
   When a non-blocking execution of a procedure is invoked with BroadcastProcedure, via the
   use of a token, this function can be used to check for completion of the procedure on all the
   broadcast APs. The function takes the token that was passed into the BroadcastProcedure
-  call. If the procedure is complete on all broadcast APs this function returns EFI_SUCESS. In this
+  call. If the procedure is complete on all broadcast APs this function returns EFI_SUCCESS. In this
   case the Status field in the token passed into the function reflects the overall result of the
   invocation, which may be EFI_SUCCESS, if all executions succeeded, or the first observed failure.
   If the procedure has not yet completed on the broadcast APs, the function returns

--- a/UefiCpuPkg/PiSmmCpuDxeSmm/SmmMp.h
+++ b/UefiCpuPkg/PiSmmCpuDxeSmm/SmmMp.h
@@ -218,14 +218,14 @@ SmmMpSetStartupProcedure (
   via the use of a token, this function can be used to check for completion of the procedure on the AP.
   The function takes the token that was passed into the DispatchProcedure call. If the procedure
   is complete, and therefore it is now possible to run another procedure on the same AP, this function
-  returns EFI_SUCESS. In this case the status returned by the procedure that executed on the AP is
+  returns EFI_SUCCESS. In this case the status returned by the procedure that executed on the AP is
   returned in the token's Status field. If the procedure has not yet completed, then this function
   returns EFI_NOT_READY.
 
   When a non-blocking execution of a procedure is invoked with BroadcastProcedure, via the
   use of a token, this function can be used to check for completion of the procedure on all the
   broadcast APs. The function takes the token that was passed into the BroadcastProcedure
-  call. If the procedure is complete on all broadcast APs this function returns EFI_SUCESS. In this
+  call. If the procedure is complete on all broadcast APs this function returns EFI_SUCCESS. In this
   case the Status field in the token passed into the function reflects the overall result of the
   invocation, which may be EFI_SUCCESS, if all executions succeeded, or the first observed failure.
   If the procedure has not yet completed on the broadcast APs, the function returns

--- a/UefiPayloadPkg/FvbRuntimeDxe/FvbServiceSmm.c
+++ b/UefiPayloadPkg/FvbRuntimeDxe/FvbServiceSmm.c
@@ -20,7 +20,7 @@
   @param[in]  InstanceNum   The instance number which can be used as a ID
                             to locate this FwhInstance in other functions.
 
-  @retval     EFI_SUCESS    Installed successfully.
+  @retval     EFI_SUCCESS   Installed successfully.
   @retval     Else          Did not install successfully.
 
 **/

--- a/UefiPayloadPkg/PayloadLoaderPeim/FitPayloadLoaderPeim.c
+++ b/UefiPayloadPkg/PayloadLoaderPeim/FitPayloadLoaderPeim.c
@@ -375,7 +375,7 @@ FdtPpiNotifyCallback (
   Install Pei Load File PPI.
   @param  FileHandle  Handle of the file being invoked.
   @param  PeiServices Describes the list of possible PEI Services.
-  @retval EFI_SUCESS  The entry point executes successfully.
+  @retval EFI_SUCCESS The entry point executes successfully.
   @retval Others      Some error occurs during the execution of this function.
 **/
 EFI_STATUS


### PR DESCRIPTION
`EFI_SUCCESS`  is misspelled as `EFI_SUCESS`  or `EFI_SUCESSS` in MdeModulePkg, EmulatorPkg, MdePkg, OvmfPkg, UefiCpuPkg and UefiPayloadPkg, so fix it.