### PR TITLE
OvmfPkg/PlatformBmPrintScLib: hint at Secure Boot verification

### DIFF
--- a/OvmfPkg/Library/PlatformBmPrintScLib/StatusCodeHandler.c
+++ b/OvmfPkg/Library/PlatformBmPrintScLib/StatusCodeHandler.c
@@ -214,14 +214,20 @@ HandleStatusCode (
       DevPathString
       );
   } else {
+    EFI_STATUS  ReturnStatus;
+
+    ReturnStatus = ((EFI_RETURN_STATUS_EXTENDED_DATA *)Data)->ReturnStatus;
     Print (
-      L"%a: failed to %a %s \"%s\" from %s: %r\n",
+      L"%a: failed to %a %s \"%s\" from %s: %r%a\n",
       gEfiCallerBaseName,
       Value == mLoadFail ? "load" : "start",
       BootOptionName,
       BmBootOption.Description,
       DevPathString,
-      ((EFI_RETURN_STATUS_EXTENDED_DATA *)Data)->ReturnStatus
+      ReturnStatus,
+      ((ReturnStatus == EFI_SECURITY_VIOLATION ||
+        (Value == mLoadFail && ReturnStatus == EFI_ACCESS_DENIED)) ?
+       " -- rejected probably by Secure Boot" : "")
       );
   }
 


### PR DESCRIPTION
# Description

The UEFI spec 2.11 documents `EFI_SECURITY_VIOLATION` for both `gBS->LoadImage()` and `gBS->StartImage()` as

> [`Image` was loaded and an `ImageHandle` was created with a valid `EFI_LOADED_IMAGE_PROTOCOL`. However,] the current platform policy specifies that the image should not be started.

Additionally, the spec documents `EFI_ACCESS_DENIED` for `gBS->LoadImage()` as

> `Image` was not loaded because the platform policy prohibits the image from being loaded. `NULL` is returned in `ImageHandle`.

When image loading/starting fails under the above conditions (according to the status code being reported), print a hint about Secure Boot. This should help users diagnose and fix their Secure Boot configuration.

Updates: 77874ceebb118cd58f518cbf6bcb63f47c993ec0
Fixes: https://github.com/tianocore/edk2/issues/10901

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

On RHEL-9.6, used the following libvirt domain XML (excerpt):

~~~
  <os>
    <type arch='x86_64' machine='q35'>hvm</type>
    <loader readonly='yes' secure='yes' type='pflash' format='raw'>.../edk2/Build/Ovmf3264/NOOPT_GCC5/FV/OVMF_CODE.fd</loader>
    <nvram template='/usr/share/OVMF/OVMF_VARS.secboot.fd' format='raw'/>
  </os>
  <features>
    <smm state='on'/>
  </features>
  <devices>
    <disk type='file' device='cdrom'>
      <source file='/usr/share/OVMF/UefiShell.iso'/>
      <target dev='sdb' bus='usb'/>
      <boot order='1'/>
    </disk>
  </devices>
~~~

See the resultant screenshot attached:

![Screenshot_ovmf fedora q35_2025-06-07_15:12:00](https://github.com/user-attachments/assets/663f2b66-a8b7-4d3c-8d10-eeb16c1a02f5)

## Integration Instructions

N/A
