### PR TITLE
MdeModulePkg/UefiBootManagerLib: Fix crash when no load options are found

### DIFF
--- a/MdeModulePkg/Library/UefiBootManagerLib/BmLoadOption.c
+++ b/MdeModulePkg/Library/UefiBootManagerLib/BmLoadOption.c
@@ -437,6 +437,11 @@ EfiBootManagerSortLoadOptionVariable (
 
   LoadOption = EfiBootManagerGetLoadOptions (&LoadOptionCount, OptionType);
 
+  if (LoadOptionCount == 0) {
+    DEBUG ((DEBUG_INFO, "No load options found\n"));
+    return;
+  }
+
   //
   // Insertion sort algorithm
   //


### PR DESCRIPTION

# Description

Fix crash when no load options are found
Do not attempt to sort the load options when there are none.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Validated API returns with no issues when no boot options are detected.

## Integration Instructions

N/A
