### PR TITLE
Add GCC flags to disable format-security warnings when disabling format warnings

### DIFF
--- a/CryptoPkg/Library/MbedTlsLib/MbedTlsLib.inf
+++ b/CryptoPkg/Library/MbedTlsLib/MbedTlsLib.inf
@@ -130,11 +130,11 @@
   #   -Werror=unused-but-set-variable: Warn whenever a local variable is assigned to, but otherwise unused (aside from its declaration).
   #
   GCC:*_*_IA32_CC_FLAGS    = -U_WIN32 -U_WIN64 -Wno-error=maybe-uninitialized -Wno-error=unused-but-set-variable
-  GCC:*_*_X64_CC_FLAGS     = -U_WIN32 -U_WIN64 -Wno-error=maybe-uninitialized -Wno-error=format -Wno-format -Wno-error=unused-but-set-variable -DNO_MSABI_VA_FUNCS
+  GCC:*_*_X64_CC_FLAGS     = -U_WIN32 -U_WIN64 -Wno-error=maybe-uninitialized -Wno-error=format -Wno-error=format-security -Wno-format -Wno-format-security -Wno-error=unused-but-set-variable -DNO_MSABI_VA_FUNCS
   GCC:*_*_ARM_CC_FLAGS     =  -Wno-error=maybe-uninitialized -Wno-error=unused-but-set-variable
-  GCC:*_*_AARCH64_CC_FLAGS =  -Wno-error=maybe-uninitialized -Wno-format -Wno-error=unused-but-set-variable -Wno-error=format
-  GCC:*_*_RISCV64_CC_FLAGS =  -Wno-error=maybe-uninitialized -Wno-format -Wno-error=unused-but-set-variable
-  GCC:*_*_LOONGARCH64_CC_FLAGS =  -Wno-error=maybe-uninitialized -Wno-format -Wno-error=unused-but-set-variable
+  GCC:*_*_AARCH64_CC_FLAGS =  -Wno-error=maybe-uninitialized -Wno-format -Wno-format-security -Wno-error=unused-but-set-variable -Wno-error=format
+  GCC:*_*_RISCV64_CC_FLAGS =  -Wno-error=maybe-uninitialized -Wno-format -Wno-format-security -Wno-error=unused-but-set-variable
+  GCC:*_*_LOONGARCH64_CC_FLAGS =  -Wno-error=maybe-uninitialized -Wno-format -Wno-format-security -Wno-error=unused-but-set-variable
   GCC:*_CLANGDWARF_*_CC_FLAGS = -std=gnu99 -Wno-error=uninitialized
   GCC:*_CLANGPDB_*_CC_FLAGS = -std=c99 -Wno-error=uninitialized -Wno-error=incompatible-pointer-types -Wno-error=pointer-sign -Wno-error=implicit-function-declaration -Wno-error=ignored-pragma-optimize
 

--- a/CryptoPkg/Library/MbedTlsLib/MbedTlsLibFull.inf
+++ b/CryptoPkg/Library/MbedTlsLib/MbedTlsLibFull.inf
@@ -134,11 +134,11 @@
   #   -Werror=unused-but-set-variable: Warn whenever a local variable is assigned to, but otherwise unused (aside from its declaration).
   #
   GCC:*_*_IA32_CC_FLAGS    = -U_WIN32 -U_WIN64 -Wno-error=maybe-uninitialized -Wno-error=unused-but-set-variable
-  GCC:*_*_X64_CC_FLAGS     = -U_WIN32 -U_WIN64 -Wno-error=maybe-uninitialized -Wno-error=format -Wno-format -Wno-error=unused-but-set-variable -DNO_MSABI_VA_FUNCS
+  GCC:*_*_X64_CC_FLAGS     = -U_WIN32 -U_WIN64 -Wno-error=maybe-uninitialized -Wno-error=format -Wno-error=format-security -Wno-format -Wno-format-security -Wno-error=unused-but-set-variable -DNO_MSABI_VA_FUNCS
   GCC:*_*_ARM_CC_FLAGS     =  -Wno-error=maybe-uninitialized -Wno-error=unused-but-set-variable
-  GCC:*_*_AARCH64_CC_FLAGS =  -Wno-error=maybe-uninitialized -Wno-format -Wno-error=unused-but-set-variable -Wno-error=format
-  GCC:*_*_RISCV64_CC_FLAGS =  -Wno-error=maybe-uninitialized -Wno-format -Wno-error=unused-but-set-variable
-  GCC:*_*_LOONGARCH64_CC_FLAGS =  -Wno-error=maybe-uninitialized -Wno-format -Wno-error=unused-but-set-variable
+  GCC:*_*_AARCH64_CC_FLAGS =  -Wno-error=maybe-uninitialized -Wno-format -Wno-format-security -Wno-error=unused-but-set-variable -Wno-error=format
+  GCC:*_*_RISCV64_CC_FLAGS =  -Wno-error=maybe-uninitialized -Wno-format -Wno-format-security -Wno-error=unused-but-set-variable
+  GCC:*_*_LOONGARCH64_CC_FLAGS =  -Wno-error=maybe-uninitialized -Wno-format -Wno-format-security -Wno-error=unused-but-set-variable
   GCC:*_CLANGDWARF_*_CC_FLAGS = -std=gnu99 -Wno-error=uninitialized
   GCC:*_CLANGPDB_*_CC_FLAGS = -std=c99 -Wno-error=uninitialized -Wno-error=incompatible-pointer-types -Wno-error=pointer-sign -Wno-error=implicit-function-declaration -Wno-error=ignored-pragma-optimize
 

--- a/CryptoPkg/Library/OpensslLib/OpensslLib.inf
+++ b/CryptoPkg/Library/OpensslLib/OpensslLib.inf
@@ -749,11 +749,11 @@
   #   -Werror=unused-but-set-variable: Warn whenever a local variable is assigned to, but otherwise unused (aside from its declaration).
   #
   GCC:*_*_IA32_CC_FLAGS    = -U_WIN32 -U_WIN64 $(OPENSSL_FLAGS) $(OPENSSL_FLAGS_NOASM) -Wno-error=maybe-uninitialized -Wno-error=unused-but-set-variable
-  GCC:*_*_X64_CC_FLAGS     = -U_WIN32 -U_WIN64 $(OPENSSL_FLAGS) $(OPENSSL_FLAGS_NOASM) -Wno-error=maybe-uninitialized -Wno-error=format -Wno-format -Wno-error=unused-but-set-variable -DNO_MSABI_VA_FUNCS
+  GCC:*_*_X64_CC_FLAGS     = -U_WIN32 -U_WIN64 $(OPENSSL_FLAGS) $(OPENSSL_FLAGS_NOASM) -Wno-error=maybe-uninitialized -Wno-error=format -Wno-error=format-security -Wno-format -Wno-format-security -Wno-error=unused-but-set-variable -DNO_MSABI_VA_FUNCS
   GCC:*_*_ARM_CC_FLAGS     = $(OPENSSL_FLAGS) -Wno-error=maybe-uninitialized -Wno-error=unused-but-set-variable
-  GCC:*_*_AARCH64_CC_FLAGS = $(OPENSSL_FLAGS) -Wno-error=maybe-uninitialized -Wno-format -Wno-error=unused-but-set-variable -Wno-error=format
-  GCC:*_*_RISCV64_CC_FLAGS = $(OPENSSL_FLAGS) -Wno-error=maybe-uninitialized -Wno-format -Wno-error=unused-but-set-variable
-  GCC:*_*_LOONGARCH64_CC_FLAGS = $(OPENSSL_FLAGS) -Wno-error=maybe-uninitialized -Wno-format -Wno-error=unused-but-set-variable
+  GCC:*_*_AARCH64_CC_FLAGS = $(OPENSSL_FLAGS) -Wno-error=maybe-uninitialized -Wno-format -Wno-format-security -Wno-error=unused-but-set-variable -Wno-error=format
+  GCC:*_*_RISCV64_CC_FLAGS = $(OPENSSL_FLAGS) -Wno-error=maybe-uninitialized -Wno-format -Wno-format-security -Wno-error=unused-but-set-variable
+  GCC:*_*_LOONGARCH64_CC_FLAGS = $(OPENSSL_FLAGS) -Wno-error=maybe-uninitialized -Wno-format -Wno-format-security -Wno-error=unused-but-set-variable
   GCC:*_CLANGDWARF_*_CC_FLAGS = -std=c99 -Wno-error=uninitialized -Wno-error=incompatible-pointer-types -Wno-error=pointer-sign -Wno-error=implicit-function-declaration -Wno-error=ignored-pragma-optimize
   GCC:*_CLANGPDB_*_CC_FLAGS = -std=c99 -Wno-error=uninitialized -Wno-error=incompatible-pointer-types -Wno-error=pointer-sign -Wno-error=implicit-function-declaration -Wno-error=ignored-pragma-optimize -Wno-error=unused-function
   # Revisit after switching to 3.0 branch

--- a/CryptoPkg/Library/OpensslLib/OpensslLibAccel.inf
+++ b/CryptoPkg/Library/OpensslLib/OpensslLibAccel.inf
@@ -2139,7 +2139,7 @@
   #   -Werror=unused-but-set-variable: Warn whenever a local variable is assigned to, but otherwise unused (aside from its declaration).
   #
   GCC:*_*_IA32_CC_FLAGS    = -U_WIN32 -U_WIN64 $(OPENSSL_FLAGS) $(OPENSSL_FLAGS_IA32) -Wno-error=maybe-uninitialized -Wno-error=unused-but-set-variable
-  GCC:*_*_X64_CC_FLAGS     = -U_WIN32 -U_WIN64 $(OPENSSL_FLAGS) $(OPENSSL_FLAGS_X64) -Wno-error=maybe-uninitialized -Wno-error=format -Wno-format -Wno-error=unused-but-set-variable -DNO_MSABI_VA_FUNCS
+  GCC:*_*_X64_CC_FLAGS     = -U_WIN32 -U_WIN64 $(OPENSSL_FLAGS) $(OPENSSL_FLAGS_X64) -Wno-error=maybe-uninitialized -Wno-error=format -Wno-error=format-security -Wno-format -Wno-format-security -Wno-error=unused-but-set-variable -DNO_MSABI_VA_FUNCS
   GCC:*_CLANGDWARF_*_CC_FLAGS = -std=gnu99 -Wno-error=uninitialized -Wno-error=incompatible-pointer-types -Wno-error=pointer-sign -Wno-error=implicit-function-declaration -Wno-error=ignored-pragma-optimize
   GCC:*_CLANGPDB_*_CC_FLAGS = -std=c99 -Wno-error=uninitialized -Wno-error=incompatible-pointer-types -Wno-error=pointer-sign -Wno-error=implicit-function-declaration -Wno-error=ignored-pragma-optimize -Wno-error=unused-function
   # Revisit after switching to 3.0 branch
@@ -2167,7 +2167,7 @@
   XCODE:*_*_IA32_CC_FLAGS   = -mmmx -msse -U_WIN32 -U_WIN64 $(OPENSSL_FLAGS) $(OPENSSL_FLAGS_IA32) -w -std=c99 -Wno-error=uninitialized -DOPENSSL_NO_APPLE_CRYPTO_RANDOM
   XCODE:*_*_X64_CC_FLAGS    = -mmmx -msse -U_WIN32 -U_WIN64 $(OPENSSL_FLAGS) $(OPENSSL_FLAGS_X64) -w -std=c99 -Wno-error=uninitialized -DOPENSSL_NO_APPLE_CRYPTO_RANDOM
 
-  GCC:*_*_AARCH64_CC_FLAGS    = $(OPENSSL_FLAGS) $(OPENSSL_FLAGS_AARCH64) -Wno-error=format -Wno-format -D_BITS_STDINT_UINTN_H -D_BITS_STDINT_INTN_H
+  GCC:*_*_AARCH64_CC_FLAGS    = $(OPENSSL_FLAGS) $(OPENSSL_FLAGS_AARCH64) -Wno-error=format -Wno-error=format-security -Wno-format -Wno-format-security -D_BITS_STDINT_UINTN_H -D_BITS_STDINT_INTN_H
 
   #
   # AARCH64 uses strict alignment and avoids SIMD registers for code that may execute

--- a/CryptoPkg/Library/OpensslLib/OpensslLibCrypto.inf
+++ b/CryptoPkg/Library/OpensslLib/OpensslLibCrypto.inf
@@ -700,11 +700,11 @@
   #   -Werror=unused-but-set-variable: Warn whenever a local variable is assigned to, but otherwise unused (aside from its declaration).
   #
   GCC:*_*_IA32_CC_FLAGS    = -U_WIN32 -U_WIN64 $(OPENSSL_FLAGS) $(OPENSSL_FLAGS_NOASM) -Wno-error=maybe-uninitialized -Wno-error=unused-but-set-variable
-  GCC:*_*_X64_CC_FLAGS     = -U_WIN32 -U_WIN64 $(OPENSSL_FLAGS) $(OPENSSL_FLAGS_NOASM) -Wno-error=maybe-uninitialized -Wno-error=format -Wno-format -Wno-error=unused-but-set-variable -DNO_MSABI_VA_FUNCS
+  GCC:*_*_X64_CC_FLAGS     = -U_WIN32 -U_WIN64 $(OPENSSL_FLAGS) $(OPENSSL_FLAGS_NOASM) -Wno-error=maybe-uninitialized -Wno-error=format -Wno-error=format-security -Wno-format -Wno-format-security -Wno-error=unused-but-set-variable -DNO_MSABI_VA_FUNCS
   GCC:*_*_ARM_CC_FLAGS     = $(OPENSSL_FLAGS) -Wno-error=maybe-uninitialized -Wno-error=unused-but-set-variable
-  GCC:*_*_AARCH64_CC_FLAGS = $(OPENSSL_FLAGS) -Wno-error=maybe-uninitialized -Wno-format -Wno-error=unused-but-set-variable -Wno-error=format
-  GCC:*_*_RISCV64_CC_FLAGS = $(OPENSSL_FLAGS) -Wno-error=maybe-uninitialized -Wno-format -Wno-error=unused-but-set-variable
-  GCC:*_*_LOONGARCH64_CC_FLAGS = $(OPENSSL_FLAGS) -Wno-error=maybe-uninitialized -Wno-format -Wno-error=unused-but-set-variable
+  GCC:*_*_AARCH64_CC_FLAGS = $(OPENSSL_FLAGS) -Wno-error=maybe-uninitialized -Wno-format -Wno-format-security -Wno-error=unused-but-set-variable -Wno-error=format
+  GCC:*_*_RISCV64_CC_FLAGS = $(OPENSSL_FLAGS) -Wno-error=maybe-uninitialized -Wno-format -Wno-format-security -Wno-error=unused-but-set-variable
+  GCC:*_*_LOONGARCH64_CC_FLAGS = $(OPENSSL_FLAGS) -Wno-error=maybe-uninitialized -Wno-format -Wno-format-security -Wno-error=unused-but-set-variable
   GCC:*_CLANGDWARF_*_CC_FLAGS = -std=c99 -Wno-error=uninitialized -Wno-error=incompatible-pointer-types -Wno-error=pointer-sign -Wno-error=implicit-function-declaration -Wno-error=ignored-pragma-optimize
   GCC:*_CLANGPDB_*_CC_FLAGS = -std=c99 -Wno-error=uninitialized -Wno-error=incompatible-pointer-types -Wno-error=pointer-sign -Wno-error=implicit-function-declaration -Wno-error=ignored-pragma-optimize -Wno-error=unused-function
   # Revisit after switching to 3.0 branch

--- a/CryptoPkg/Library/OpensslLib/OpensslLibFull.inf
+++ b/CryptoPkg/Library/OpensslLib/OpensslLibFull.inf
@@ -806,11 +806,11 @@
   #   -Werror=unused-but-set-variable: Warn whenever a local variable is assigned to, but otherwise unused (aside from its declaration).
   #
   GCC:*_*_IA32_CC_FLAGS    = -U_WIN32 -U_WIN64 $(OPENSSL_FLAGS) $(OPENSSL_FLAGS_NOASM) -Wno-error=maybe-uninitialized -Wno-error=unused-but-set-variable
-  GCC:*_*_X64_CC_FLAGS     = -U_WIN32 -U_WIN64 $(OPENSSL_FLAGS) $(OPENSSL_FLAGS_NOASM) -Wno-error=maybe-uninitialized -Wno-error=format -Wno-format -Wno-error=unused-but-set-variable -DNO_MSABI_VA_FUNCS
+  GCC:*_*_X64_CC_FLAGS     = -U_WIN32 -U_WIN64 $(OPENSSL_FLAGS) $(OPENSSL_FLAGS_NOASM) -Wno-error=maybe-uninitialized -Wno-error=format -Wno-error=format-security -Wno-format -Wno-format-security -Wno-error=unused-but-set-variable -DNO_MSABI_VA_FUNCS
   GCC:*_*_ARM_CC_FLAGS     = $(OPENSSL_FLAGS) -Wno-error=maybe-uninitialized -Wno-error=unused-but-set-variable
-  GCC:*_*_AARCH64_CC_FLAGS = $(OPENSSL_FLAGS) -Wno-error=maybe-uninitialized -Wno-format -Wno-error=unused-but-set-variable -Wno-error=format
-  GCC:*_*_RISCV64_CC_FLAGS = $(OPENSSL_FLAGS) -Wno-error=maybe-uninitialized -Wno-format -Wno-error=unused-but-set-variable
-  GCC:*_*_LOONGARCH64_CC_FLAGS = $(OPENSSL_FLAGS) -Wno-error=maybe-uninitialized -Wno-format -Wno-error=unused-but-set-variable
+  GCC:*_*_AARCH64_CC_FLAGS = $(OPENSSL_FLAGS) -Wno-error=maybe-uninitialized -Wno-format -Wno-format-security -Wno-error=unused-but-set-variable -Wno-error=format
+  GCC:*_*_RISCV64_CC_FLAGS = $(OPENSSL_FLAGS) -Wno-error=maybe-uninitialized -Wno-format -Wno-format-security -Wno-error=unused-but-set-variable
+  GCC:*_*_LOONGARCH64_CC_FLAGS = $(OPENSSL_FLAGS) -Wno-error=maybe-uninitialized -Wno-format -Wno-format-security -Wno-error=unused-but-set-variable
   GCC:*_CLANGDWARF_*_CC_FLAGS = -std=c99 -Wno-error=uninitialized -Wno-error=incompatible-pointer-types -Wno-error=pointer-sign -Wno-error=implicit-function-declaration -Wno-error=ignored-pragma-optimize
   GCC:*_CLANGPDB_*_CC_FLAGS = -std=c99 -Wno-error=uninitialized -Wno-error=incompatible-pointer-types -Wno-error=pointer-sign -Wno-error=implicit-function-declaration -Wno-error=ignored-pragma-optimize -Wno-error=unused-function
   # Revisit after switching to 3.0 branch

--- a/CryptoPkg/Library/OpensslLib/OpensslLibFullAccel.inf
+++ b/CryptoPkg/Library/OpensslLib/OpensslLibFullAccel.inf
@@ -2300,7 +2300,7 @@
   #   -Werror=unused-but-set-variable: Warn whenever a local variable is assigned to, but otherwise unused (aside from its declaration).
   #
   GCC:*_*_IA32_CC_FLAGS    = -U_WIN32 -U_WIN64 $(OPENSSL_FLAGS) $(OPENSSL_FLAGS_IA32) -Wno-error=maybe-uninitialized -Wno-error=unused-but-set-variable
-  GCC:*_*_X64_CC_FLAGS     = -U_WIN32 -U_WIN64 $(OPENSSL_FLAGS) $(OPENSSL_FLAGS_X64) -Wno-error=maybe-uninitialized -Wno-error=format -Wno-format -Wno-error=unused-but-set-variable -DNO_MSABI_VA_FUNCS
+  GCC:*_*_X64_CC_FLAGS     = -U_WIN32 -U_WIN64 $(OPENSSL_FLAGS) $(OPENSSL_FLAGS_X64) -Wno-error=maybe-uninitialized -Wno-error=format -Wno-error=format-security -Wno-format -Wno-format-security -Wno-error=unused-but-set-variable -DNO_MSABI_VA_FUNCS
   GCC:*_CLANGDWARF_*_CC_FLAGS = -std=gnu99 -Wno-error=uninitialized -Wno-error=incompatible-pointer-types -Wno-error=pointer-sign -Wno-error=implicit-function-declaration -Wno-error=ignored-pragma-optimize
   GCC:*_CLANGPDB_*_CC_FLAGS = -std=c99 -Wno-error=uninitialized -Wno-error=incompatible-pointer-types -Wno-error=pointer-sign -Wno-error=implicit-function-declaration -Wno-error=ignored-pragma-optimize -Wno-error=unused-function
   # Revisit after switching to 3.0 branch
@@ -2328,7 +2328,7 @@
   XCODE:*_*_IA32_CC_FLAGS   = -mmmx -msse -U_WIN32 -U_WIN64 $(OPENSSL_FLAGS) $(OPENSSL_FLAGS_IA32) -w -std=c99 -Wno-error=uninitialized -DOPENSSL_NO_APPLE_CRYPTO_RANDOM
   XCODE:*_*_X64_CC_FLAGS    = -mmmx -msse -U_WIN32 -U_WIN64 $(OPENSSL_FLAGS) $(OPENSSL_FLAGS_X64) -w -std=c99 -Wno-error=uninitialized -DOPENSSL_NO_APPLE_CRYPTO_RANDOM
 
-  GCC:*_*_AARCH64_CC_FLAGS    = $(OPENSSL_FLAGS) $(OPENSSL_FLAGS_AARCH64) -Wno-error=format -Wno-format -D_BITS_STDINT_UINTN_H -D_BITS_STDINT_INTN_H
+  GCC:*_*_AARCH64_CC_FLAGS    = $(OPENSSL_FLAGS) $(OPENSSL_FLAGS_AARCH64) -Wno-error=format -Wno-error=format-security -Wno-format -Wno-format-security -D_BITS_STDINT_UINTN_H -D_BITS_STDINT_INTN_H
 
   #
   # AARCH64 uses strict alignment and avoids SIMD registers for code that may execute


### PR DESCRIPTION
# Description

~This is required for GCC 13.3 compatibility or it triggers a warning, which causes the build to fail.~

Fixes GCC compiler warning (fatal): `‘-Wformat-security’ ignored without ‘-Wformat’ [-Werror=format-security]` by explicitly disabling `format-security` warnings when `format` warnings are being disabled.

Fixes #11186 

Performed changes by running:

```console
find CryptoPkg -type f -name '*.inf' -exec sed -i 's|-Wno-format |-Wno-format -Wno-format-security |g' '{}' \;
find CryptoPkg -type f -name '*.inf' -exec sed -i 's|-Wno-error=format |-Wno-error=format -Wno-error=format-security |g' '{}' \;
```

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Built OVMF locally with

```
build -a X64 -b DEBUG -d 9 -t GCC5 -p OvmfPkg/OvmfPkgX64.dsc -Y COMPILE_INFO -y edk2/Build/report.txt -D SECURE_BOOT_ENABLE=1 -D SMM_REQUIRE=1 -D TPM1_ENABLE=1 -D TPM2_ENABLE=1 -D NETWORK_TLS_ENABLE=1 -D NETWORK_IP6_ENABLE=1 -D NETWORK_HTTP_BOOT_ENABLE=1
```

## Integration Instructions

N/A