### PR TITLE
EmulatorPkg: Fix enum type mismatch warning treated as error

### DIFF
--- a/EmulatorPkg/Win/Host/WinGopScreen.c
+++ b/EmulatorPkg/Win/Host/WinGopScreen.c
@@ -423,7 +423,7 @@ WinNtWndBlt (
     return (EFI_STATUS)RStatus;
   }
 
-  if (BltOperation != EfiBltVideoToBltBuffer) {
+  if (BltOperation != EfiUgaVideoToBltBuffer) {
     //
     // Mark the area we just blted as Invalid so WM_PAINT will update.
     //


### PR DESCRIPTION
# Description

Issue: While building edk2, the compiler threw a warning
       that was treated as an eror which halted the build
       process.

Root Cause: The error was due to a comparison between two
            different enum types.

Code Fix: WinGopScreen.c: In function WinNtWndBlt, changed
          the comparison between an enum type
	  "EFI_UGA_BLT_OPERATION" and "EFI_GRAPHICS_OUTPUT_BLT_OPERATION"
	  to "EFI_UGA_BLT_OPERATION".

Test: The compiled image runs successfully on QEMU.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.
