### PR TITLE
CryptoPkg: Use RngLib to get Random number.

### DIFF
--- a/CryptoPkg/Library/BaseCryptLib/BaseCryptLib.inf
+++ b/CryptoPkg/Library/BaseCryptLib/BaseCryptLib.inf
@@ -99,6 +99,7 @@
   PrintLib
   UefiBootServicesTableLib
   SynchronizationLib
+  RngLib
 
 [Protocols]
   gEfiMpServiceProtocolGuid

--- a/CryptoPkg/Library/BaseCryptLib/Rand/CryptRand.c
+++ b/CryptoPkg/Library/BaseCryptLib/Rand/CryptRand.c
@@ -9,11 +9,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include "InternalCryptLib.h"
 #include <openssl/rand.h>
 #include <openssl/evp.h>
-
-//
-// Default seed for UEFI Crypto Library
-//
-CONST UINT8  DefaultSeed[] = "UEFI Crypto Library default seed";
+#include <Library/RngLib.h>
 
 /**
   Sets up the seed value for the pseudorandom number generator.
@@ -38,6 +34,8 @@ RandomSeed (
   IN  UINTN         SeedSize
   )
 {
+  UINT32  RandomNumber;
+
   if (SeedSize > INT_MAX) {
     return FALSE;
   }
@@ -49,7 +47,11 @@ RandomSeed (
   if (Seed != NULL) {
     RAND_seed (Seed, (UINT32)SeedSize);
   } else {
-    RAND_seed (DefaultSeed, sizeof (DefaultSeed));
+    if (!GetRandomNumber32 (&RandomNumber)) {
+      return FALSE;
+    }
+
+    RAND_seed (&RandomNumber, sizeof (RandomNumber));
   }
 
   if (RAND_status () == 1) {

--- a/CryptoPkg/Library/BaseCryptLib/Rand/CryptRandTsc.c
+++ b/CryptoPkg/Library/BaseCryptLib/Rand/CryptRandTsc.c
@@ -10,6 +10,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <openssl/rand.h>
 #include <openssl/evp.h>
 #include <Library/PrintLib.h>
+#include <Library/RngLib.h>
 
 /**
   Sets up the seed value for the pseudorandom number generator.
@@ -34,7 +35,7 @@ RandomSeed (
   IN  UINTN         SeedSize
   )
 {
-  CHAR8  DefaultSeed[128];
+  UINT32  RandomNumber;
 
   if (SeedSize > INT_MAX) {
     return FALSE;
@@ -47,17 +48,12 @@ RandomSeed (
   if (Seed != NULL) {
     RAND_seed (Seed, (UINT32)SeedSize);
   } else {
-    //
-    // Retrieve current time.
-    //
-    AsciiSPrint (
-      DefaultSeed,
-      sizeof (DefaultSeed),
-      "UEFI Crypto Library default seed (%ld)",
-      AsmReadTsc ()
-      );
+    // Use RngLib to get the RandomNumber.
+    if (!GetRandomNumber32 (&RandomNumber)) {
+      return FALSE;
+    }
 
-    RAND_seed (DefaultSeed, sizeof (DefaultSeed));
+    RAND_seed (&RandomNumber, sizeof (RandomNumber));
   }
 
   if (RAND_status () == 1) {

--- a/CryptoPkg/Library/BaseCryptLib/RuntimeCryptLib.inf
+++ b/CryptoPkg/Library/BaseCryptLib/RuntimeCryptLib.inf
@@ -98,6 +98,7 @@
   OpensslLib
   IntrinsicLib
   PrintLib
+  RngLib
 
 #
 # Remove these [BuildOptions] after this library is cleaned up

--- a/CryptoPkg/Library/BaseCryptLib/SmmCryptLib.inf
+++ b/CryptoPkg/Library/BaseCryptLib/SmmCryptLib.inf
@@ -94,6 +94,7 @@
   PrintLib
   MmServicesTableLib
   SynchronizationLib
+  RngLib
 
 #
 # Remove these [BuildOptions] after this library is cleaned up


### PR DESCRIPTION
REF: https://github.com/tianocore/edk2/issues/11002

Use RngLib to get the Random number instead of passing the Default seed when the seed value is NULL and Seed size is zero.

# Description

Add an implementation to use the RngLib to get the RandomNumber instead of passing the predictable default seed value when the RandomSeed() is called with seed value NULL and Seed size zero.