### PR TITLE
MdePkg CompilerIntrinsicsLib: Unify the definitions of size_t in xxx_ms.c

### DIFF
--- a/MdePkg/Library/CompilerIntrinsicsLib/memcmp_ms.c
+++ b/MdePkg/Library/CompilerIntrinsicsLib/memcmp_ms.c
@@ -7,11 +7,7 @@
 //
 // ------------------------------------------------------------------------------
 
-#if defined (_M_ARM64)
-typedef unsigned __int64 size_t;
-#else
-typedef unsigned __int32 size_t;
-#endif
+typedef UINTN size_t;
 
 int
 memcmp (

--- a/MdePkg/Library/CompilerIntrinsicsLib/memcpy_ms.c
+++ b/MdePkg/Library/CompilerIntrinsicsLib/memcpy_ms.c
@@ -7,11 +7,7 @@
 //
 // ------------------------------------------------------------------------------
 
-#if defined (_M_ARM64)
-typedef unsigned __int64 size_t;
-#else
-typedef unsigned __int32 size_t;
-#endif
+typedef UINTN size_t;
 
 void *
 memcpy (

--- a/MdePkg/Library/CompilerIntrinsicsLib/memmove_ms.c
+++ b/MdePkg/Library/CompilerIntrinsicsLib/memmove_ms.c
@@ -7,6 +7,13 @@
 //
 // ------------------------------------------------------------------------------
 
+//
+// Starting from VS2019, the compiler recognizes memmove() as an intrinsic function,
+// so we need to use _MSC_VER to control the following logic.
+//
+
+#if defined (_MSC_VER) && (_MSC_VER >= 1920)
+
 typedef UINTN size_t;
 
 void *
@@ -45,3 +52,5 @@ memmove (
 
   return dest;
 }
+
+#endif

--- a/MdePkg/Library/CompilerIntrinsicsLib/memmove_ms.c
+++ b/MdePkg/Library/CompilerIntrinsicsLib/memmove_ms.c
@@ -7,11 +7,7 @@
 //
 // ------------------------------------------------------------------------------
 
-#if defined (_M_ARM64)
-typedef unsigned __int64 size_t;
-#else
-typedef unsigned __int32 size_t;
-#endif
+typedef UINTN size_t;
 
 void *
 memmove (

--- a/MdePkg/Library/CompilerIntrinsicsLib/memset_ms.c
+++ b/MdePkg/Library/CompilerIntrinsicsLib/memset_ms.c
@@ -7,11 +7,7 @@
 //
 // ------------------------------------------------------------------------------
 
-#if defined (_M_ARM64)
-typedef unsigned __int64 size_t;
-#else
-typedef unsigned __int32 size_t;
-#endif
+typedef UINTN size_t;
 
 void *
 memset (


### PR DESCRIPTION
Previous `typedef unsigned __int32 size_t;` would result in `"error C2371: 'size_t': redefinition; different basic types"` when using `CompilerIntrinsicsLib` in X64 builds.

Use `UINTN` in `ProcessorBind.h` instead.

# Description

- [ ] Breaking change?

- [ ] Impacts security?

- [ ] Includes tests?

## How This Was Tested

Use `-a X64` to build some modules that use `CompilerIntrinsicsLib`

```
  XXX.inf {
    <LibraryClasses>
      NULL|MdePkg/Library/CompilerIntrinsicsLib/CompilerIntrinsicsLib.inf
  }
```

## Integration Instructions

N/A
