### PR TITLE
OvmfPkg: Pass command-line args to PR Eval

### DIFF
--- a/OvmfPkg/PlatformCI/PlatformBuildLib.py
+++ b/OvmfPkg/PlatformCI/PlatformBuildLib.py
@@ -110,8 +110,21 @@ class SettingsManager(UpdateSettingsManager, SetupSettingsManager, PrEvalSetting
 
         The tuple should be (<workspace relative path to dsc file>, <input dictionary of dsc key value pairs>)
         '''
+        import re
+        import sys
+
+        cmd_line_input_vars = {}
+        for arg in sys.argv:
+            if "=" in arg:
+                key, value = arg.split("=", 1)
+                if key.startswith("-"):
+                    continue
+                if re.match(r"BLD_.+_", key):
+                    key = re.sub(r"^BLD_.+?_", "", key, count=1)
+                cmd_line_input_vars[key] = value
+
         dsc = CommonPlatform.GetDscName(",".join(self.ActualArchitectures))
-        return (f"OvmfPkg/{dsc}", {})
+        return (f"OvmfPkg/{dsc}", cmd_line_input_vars)
 
 
     # ####################################################################################### #


### PR DESCRIPTION
# Description

Allow PR eval to operate with the same input variable values as the build command would.

Because `BLD_*_SMM_REQUIRE` and `BLD_*_STANDALONE_MM_ENABLE` were not being passed to PR Eval, https://github.com/tianocore/edk2/commit/bbee92c9af59e877f9a5028140e600571faea181 was merged and broke the mainline because the MM build was not run during the [PR gate](https://dev.azure.com/tianocore/edk2-ci/_build/results?buildId=189138&view=logs&jobId=7a85138a-5e2d-569e-7f8d-012982ba61ab).

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

Local PR eval run before and after the change. After, PR eval detects the package needs to be built:

![image](https://github.com/user-attachments/assets/b6c8a06e-4e49-4baa-8a3d-106cf55351e1)

## Integration Instructions

N/A