### PR TITLE
EmbeddedPkg/TimeBaseLib: aligning year with UEFI specification

### DIFF
--- a/EmbeddedPkg/Library/TimeBaseLib/TimeBaseLib.c
+++ b/EmbeddedPkg/Library/TimeBaseLib/TimeBaseLib.c
@@ -271,8 +271,8 @@ IsTimeValid (
   )
 {
   // Check the input parameters are within the range specified by UEFI
-  if ((Time->Year  < 2000)              ||
-      (Time->Year   > 2099)              ||
+  if ((Time->Year  < 1900)              ||
+      (Time->Year   > 9999)              ||
       (Time->Month  < 1)              ||
       (Time->Month  > 12)              ||
       (!IsDayValid (Time))              ||


### PR DESCRIPTION
According to the UEFI Specification version 2.11, the valid range for the Year field in the EFI_TIME structure is from 1900 to 9999. Currently IsTimeValid() checks a restricted range 2000 - 2099. 
 
Update range in TimeBaseLib.c to match UEFI specification.


## How This Was Tested

Run EDK2-test(SCT) suite with the following fix to verify result.

https://github.com/tianocore/edk2-test/pull/267
