### PR TITLE
WifiConnectionManagerDxe: clear timers not events

### DIFF
--- a/NetworkPkg/WifiConnectionManagerDxe/WifiConnectionMgrHiiConfigAccess.c
+++ b/NetworkPkg/WifiConnectionManagerDxe/WifiConnectionMgrHiiConfigAccess.c
@@ -1664,7 +1664,8 @@ WifiMgrDxeHiiConfigAccessCallback (
 
         Status = gBS->SetTimer (Private->CurrentNic->TickTimer, TimerPeriodic, EFI_TIMER_PERIOD_MILLISECONDS (500));
         if (EFI_ERROR (Status)) {
-          gBS->CloseEvent (Private->CurrentNic->TickTimer);
+          DEBUG ((DEBUG_WARN, "[WiFi Connection Manager] Error: Failed to set timer for connect action!"));
+          gBS->SetTimer (Private->CurrentNic->TickTimer, TimerCancel, 0);
         }
 
         break;
@@ -1920,7 +1921,8 @@ WifiMgrDxeHiiConfigAccessCallback (
 
         Status = gBS->SetTimer (Private->CurrentNic->TickTimer, TimerPeriodic, EFI_TIMER_PERIOD_MILLISECONDS (500));
         if (EFI_ERROR (Status)) {
-          gBS->CloseEvent (Private->CurrentNic->TickTimer);
+          DEBUG ((DEBUG_WARN, "[WiFi Connection Manager] Error: Failed to set timer for connect action!"));
+          gBS->SetTimer (Private->CurrentNic->TickTimer, TimerCancel, 0);
         }
 
         break;


### PR DESCRIPTION
# Description

Replace timer eventclose with scan timerset in WifiConnectionManagerDxe. This change ensures that the driver sets and manages scan timers correctly without requiring a reload when the user enables WiFi and initiates a scan for available networks.

By using scan timerset directly, the driver maintains consistent behavior across WiFi sessions and avoids redundant event handling.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
No
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
No
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
No

## How This Was Tested

Testing with commit 42f17cd for use of timer set vs. the event. All tests passed.

## Integration Instructions

Flash new image with restart.
