### PR TITLE
OvmfPkg/PlatformDxe: register log buffer as efi config table

### DIFF
--- a/OvmfPkg/PlatformDxe/Platform.inf
+++ b/OvmfPkg/PlatformDxe/Platform.inf
@@ -36,6 +36,7 @@
   DebugLib
   DevicePathLib
   HiiLib
+  HobLib
   MemoryAllocationLib
   PrintLib
   UefiBootServicesTableLib
@@ -59,6 +60,7 @@
 [Guids]
   gEfiIfrTianoGuid
   gOvmfPlatformConfigGuid
+  gMemDebugLogHobGuid
 
 [Depex]
   gEfiHiiConfigRoutingProtocolGuid  AND


### PR DESCRIPTION
If a memory debug log buffer is present, register the buffer location as
config table so the OS can find and show it.

Signed-off-by: Gerd Hoffmann <kraxel@redhat.com>
