### PR TITLE
MdePkg BaseLib: Make __chkstk work for MSFT as well

### DIFF
--- a/MdePkg/Library/BaseLib/BaseLib.inf
+++ b/MdePkg/Library/BaseLib/BaseLib.inf
@@ -331,7 +331,7 @@
   X64/XSetBv.nasm
   X64/VmgExit.nasm
   X64/VmgExitSvsm.nasm
-  ChkStkGcc.c  | GCC
+  ChkStk.c
 
 [Sources.EBC]
   Ebc/CpuBreakpoint.c

--- a/MdePkg/Library/BaseLib/ChkStk.c
+++ b/MdePkg/Library/BaseLib/ChkStk.c
@@ -1,5 +1,5 @@
 /** @file
-  Provides hack function for passng GCC build.
+  Provides hack function for passng GCC/MSFT build.
 
   Copyright (c) 2006 - 2018, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -9,7 +9,7 @@
 #include "BaseLibInternals.h"
 
 /**
-  Hack function for passing GCC build.
+  Hack function for passing GCC/MSFT build.
 **/
 VOID
 __chkstk (

--- a/MdePkg/Library/BaseLib/UnitTestHostBaseLib.inf
+++ b/MdePkg/Library/BaseLib/UnitTestHostBaseLib.inf
@@ -168,7 +168,7 @@
   X86SpeculationBarrier.c
   X64/GccInline.c | GCC
   X64/RdRand.nasm
-  ChkStkGcc.c  | GCC
+  ChkStk.c
   X86UnitTestHost.c
   IntelTdxNull.c
 


### PR DESCRIPTION
# Description

REF: https://learn.microsoft.com/en-us/windows/win32/devnotes/-win32-__chkstk

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

Add the following code in HelloWorld.c and build it

```
  UINTN   BigArray[1024 * 1024] = {0};

  DEBUG ((DEBUG_INFO, "Test: %x\n", BigArray[0]));
```

## Integration Instructions

