### PR TITLE
UnitTestFrameworkPkg: Add -Wno-write-strings to host unit tests

### DIFF
--- a/UnitTestFrameworkPkg/UnitTestFrameworkPkgHost.dsc.inc
+++ b/UnitTestFrameworkPkg/UnitTestFrameworkPkgHost.dsc.inc
@@ -71,6 +71,7 @@
   #
   # GCC
   #
+  GCC:*_*_*_CC_FLAGS       =  -Wno-write-strings
   GCC:*_*_IA32_DLINK_FLAGS == -o $(BIN_DIR)/$(MODULE_NAME_GUID) -m32 -no-pie
   GCC:*_*_X64_DLINK_FLAGS  == -o $(BIN_DIR)/$(MODULE_NAME_GUID) -m64 -no-pie
   #


### PR DESCRIPTION
# Description

Disable write strings warning for host-based unit test builds when building modules of type HOST_APPLICATION.

Modules of type HOST_APPLICATION may compile and link code under test into the host-based unit test. When building GoogleTest based unit tests, the G++ compiler is used. The G++ compiler is stricter than GCC for passing a const string into a function parameter that is not const. This is not a warning for GCC build of firmware code. But GoogleTest builds that use g++ detect as a warning and that breaks the build.

The firmware code under test can not be changed, so the warning -Wno-write-strings is added to CC_FLAGS to ignore this warning.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

Linux/GCC host-based unit test build using GoogleTest halted with warning -Wno-write-strings when passing
a const string to a firmware API that is not declared as const.  Build passes after this change.

## Integration Instructions
