### PR TITLE
OvmfPkg/PlatformDebugLibIoPort: Add check for MemDebugLogWrite

### DIFF
--- a/OvmfPkg/Library/PlatformDebugLibIoPort/DebugLib.c
+++ b/OvmfPkg/Library/PlatformDebugLibIoPort/DebugLib.c
@@ -235,7 +235,9 @@ DebugAssert (
   //
   // Send the string to Memory Debug Log
   //
-  MemDebugLogWrite (Buffer, Length);
+  if (MemDebugLogEnabled ()) {
+    MemDebugLogWrite (Buffer, Length);
+  }
 
   //
   // Generate a Breakpoint, DeadLoop, or NOP based on PCD settings


### PR DESCRIPTION
This check is present for every call to `MemDebugLogWrite` but it is missing here. This may cause an unwanted write to the buffer, when the buffer's address is not null and MemDebug is disabled.

# Description

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

<_Describe the test(s) that were run to verify the changes._>

## Integration Instructions

<_Describe how these changes should be integrated. Use N/A if nothing is required._>
