### PR TITLE
BaseTools: Improve report generation for Nested Fvs.

### DIFF
--- a/BaseTools/Source/Python/build/BuildReport.py
+++ b/BaseTools/Source/Python/build/BuildReport.py
@@ -1814,13 +1814,21 @@ class FdRegionReport(object):
             for Ffs in Wa.FdfProfile.FvDict[FvName.upper()].FfsList:
                 for Section in Ffs.SectionList:
                     try:
-                        for FvSection in Section.SectionList:
-                            if FvSection.FvName in self.FvList:
-                                continue
-                            self._GuidsDb[Ffs.NameGuid.upper()] = FvSection.FvName
-                            self.FvList.append(FvSection.FvName)
-                            self.FvInfo[FvSection.FvName] = ("Nested FV", 0, 0)
-                            self._DiscoverNestedFvList(FvSection.FvName, Wa)
+                        # Handle the case where an entire FFS is a FV, and not
+                        # a sub-section of the FFS.
+                        if getattr(Section, 'FvFileName', None) is None:
+                            for FvSection in Section.SectionList:
+                                if FvSection.FvName in self.FvList:
+                                    continue
+                                self._GuidsDb[Ffs.NameGuid.upper()] = FvSection.FvName
+                                self.FvList.append(FvSection.FvName)
+                                self.FvInfo[FvSection.FvName] = ("Nested FV", 0, 0)
+                                self._DiscoverNestedFvList(FvSection.FvName, Wa)
+                        else:
+                            self._GuidsDb[Ffs.NameGuid.upper()] = Section.FvFileName
+                            self.FvList.append(Section.FvName)
+                            self.FvInfo[Section.FvName] = ("Nested FV", 0, 0)
+                            self._DiscoverNestedFvList(Section.FvName, Wa)
                     except AttributeError:
                         pass
 


### PR DESCRIPTION
# Description

Build report would only detect a nested FV if the nested FV was in a subsection of an FFS.

Modify the build report to better handle some of the variations of nested FVs.

Failing Example:

[Fv.FvName1]
  INF <path to some driver>.inf

[Fv.FvName0]
  FILE FV_IMAGE = B25ACDEF-39CE-4FA5-B50A-33E24DB1BDDF {
    SECTION FV_IMAGE = FvName1
  }

Working Example:

[Fv.FvName1]
  INF <path to some driver>.inf

[Fv.FvName0]
FILE FV_IMAGE = DA04F6BF-A0FD-47EC-928B-5101A6C95026 {
  SECTION GUIDED EE4E5898-3914-4259-9D6E-DC7BD79403CF
    PROCESSING_REQUIRED = TRUE {
      SECTION FV_IMAGE = FvName1
  }
}
- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested
Tested in a platform build using the failing example. 
After modifications to build report, nested FVs were discovered.

## Integration Instructions
N/A