### PR TITLE
MdePkg: Expand max debug message length to 0x200

### DIFF
--- a/MdePkg/Library/BaseDebugLibSerialPort/DebugLib.c
+++ b/MdePkg/Library/BaseDebugLibSerialPort/DebugLib.c
@@ -24,7 +24,7 @@
 //
 // Define the maximum debug and assert message length that this library supports
 //
-#define MAX_DEBUG_MESSAGE_LENGTH  0x100
+#define MAX_DEBUG_MESSAGE_LENGTH  0x200
 
 //
 // VA_LIST can not initialize to NULL for all compiler, so we use this to

--- a/MdePkg/Library/DxeRuntimeDebugLibSerialPort/DebugLib.c
+++ b/MdePkg/Library/DxeRuntimeDebugLibSerialPort/DebugLib.c
@@ -26,7 +26,7 @@ STATIC BOOLEAN    mEfiAtRuntime = FALSE;
 //
 // Define the maximum debug and assert message length that this library supports
 //
-#define MAX_DEBUG_MESSAGE_LENGTH  0x100
+#define MAX_DEBUG_MESSAGE_LENGTH  0x200
 
 //
 // VA_LIST can not initialize to NULL for all compiler, so we use this to

--- a/MdePkg/Library/UefiDebugLibConOut/DebugLib.c
+++ b/MdePkg/Library/UefiDebugLibConOut/DebugLib.c
@@ -18,7 +18,7 @@
 //
 // Define the maximum debug and assert message length that this library supports
 //
-#define MAX_DEBUG_MESSAGE_LENGTH  0x100
+#define MAX_DEBUG_MESSAGE_LENGTH  0x200
 
 //
 // VA_LIST can not initialize to NULL for all compiler, so we use this to

--- a/MdePkg/Library/UefiDebugLibDebugPortProtocol/DebugLib.c
+++ b/MdePkg/Library/UefiDebugLibDebugPortProtocol/DebugLib.c
@@ -20,7 +20,7 @@
 //
 // Define the maximum debug and assert message length that this library supports
 //
-#define MAX_DEBUG_MESSAGE_LENGTH  0x100
+#define MAX_DEBUG_MESSAGE_LENGTH  0x200
 
 //
 // Define the timeout for EFI_DEBUGPORT_PROTOCOL.Write

--- a/MdePkg/Library/UefiDebugLibStdErr/DebugLib.c
+++ b/MdePkg/Library/UefiDebugLibStdErr/DebugLib.c
@@ -18,7 +18,7 @@
 //
 // Define the maximum debug and assert message length that this library supports
 //
-#define MAX_DEBUG_MESSAGE_LENGTH  0x100
+#define MAX_DEBUG_MESSAGE_LENGTH  0x200
 
 //
 // VA_LIST can not initialize to NULL for all compiler, so we use this to


### PR DESCRIPTION
If string length is longer than 0x100, debug output will be truncated. Change MAX_DEBUG_MESSAGE_LENGTH to 0x200. This value can meet most scenarios.
Same commit(https://github.com/tianocore/edk2/commit/b5d1dc94d08acf4bb8b95fe50baff3d605714015) is submitted in OvmfPkg.
