### PR TITLE
RISC-V: Enable backtrace printing for exceptions in DEBUG builds

### DIFF
--- a/BaseTools/Conf/tools_def.template
+++ b/BaseTools/Conf/tools_def.template
@@ -1029,7 +1029,7 @@ DEFINE GCC5_ARM_ASLDLINK_FLAGS       = DEF(GCC49_ARM_ASLDLINK_FLAGS)
 DEFINE GCC5_AARCH64_ASLDLINK_FLAGS   = DEF(GCC49_AARCH64_ASLDLINK_FLAGS)
 DEFINE GCC5_ASLCC_FLAGS              = DEF(GCC49_ASLCC_FLAGS) -fno-lto
 
-DEFINE GCC5_RISCV_ALL_CC_FLAGS                    = -g -fshort-wchar -fno-strict-aliasing -Wall -Werror -Wno-array-bounds -ffunction-sections -fdata-sections -include AutoGen.h -fno-common -DSTRING_ARRAY_NAME=$(BASE_NAME)Strings -msmall-data-limit=0
+DEFINE GCC5_RISCV_ALL_CC_FLAGS                    = -g -fshort-wchar -fno-omit-frame-pointer -fno-strict-aliasing -Wall -Werror -Wno-array-bounds -ffunction-sections -fdata-sections -include AutoGen.h -fno-common -DSTRING_ARRAY_NAME=$(BASE_NAME)Strings -msmall-data-limit=0
 DEFINE GCC5_RISCV_ALL_DLINK_COMMON                = -nostdlib -Wl,-n,-q,--gc-sections -z common-page-size=0x40
 DEFINE GCC5_RISCV_ALL_DLINK_FLAGS                 = DEF(GCC5_RISCV_ALL_DLINK_COMMON) -Wl,--entry,$(IMAGE_ENTRY_POINT) -u $(IMAGE_ENTRY_POINT) -Wl,-Map,$(DEST_DIR_DEBUG)/$(BASE_NAME).map
 DEFINE GCC5_RISCV_ALL_DLINK2_FLAGS                = -Wl,--defsym=PECOFF_HEADER_SIZE=0x220,--script=$(EDK_TOOLS_PATH)/Scripts/GccBase.lds

--- a/OvmfPkg/RiscVVirt/Library/PlatformSecLib/SecEntry.S
+++ b/OvmfPkg/RiscVVirt/Library/PlatformSecLib/SecEntry.S
@@ -8,6 +8,9 @@
 #include "PlatformSecLib.h"
 
 ASM_FUNC (_ModuleEntryPoint)
+/* Prevent stack unwinding from going further */
+li    s0, 0
+
 /* Use Temp memory as the stack for calling to C code */
 li    a2, FixedPcdGet32 (PcdOvmfSecPeiTempRamBase)
 li    a3, FixedPcdGet32 (PcdOvmfSecPeiTempRamSize)

--- a/OvmfPkg/RiscVVirt/RiscVVirt.dsc.inc
+++ b/OvmfPkg/RiscVVirt/RiscVVirt.dsc.inc
@@ -153,6 +153,7 @@
   PrePiHobListPointerLib|OvmfPkg/RiscVVirt/Library/PrePiHobListPointerLib/PrePiHobListPointerLib.inf
   PrePiLib|EmbeddedPkg/Library/PrePiLib/PrePiLib.inf
   MemoryAllocationLib|EmbeddedPkg/Library/PrePiMemoryAllocationLib/PrePiMemoryAllocationLib.inf
+  CpuExceptionHandlerLib|UefiCpuPkg/Library/BaseRiscV64CpuExceptionHandlerLib/BaseRiscV64CpuExceptionHandlerSecLib.inf
 
   [LibraryClasses.common.PEI_CORE]
   HobLib|MdePkg/Library/PeiHobLib/PeiHobLib.inf

--- a/UefiCpuPkg/Library/BaseRiscV64CpuExceptionHandlerLib/Backtrace.c
+++ b/UefiCpuPkg/Library/BaseRiscV64CpuExceptionHandlerLib/Backtrace.c
@@ -1,0 +1,175 @@
+/** @file
+  RISC-V backtrace implementation.
+
+  Copyright (c) 2016 - 2022, Hewlett Packard Enterprise Development LP. All rights reserved.<BR>
+  Copyright (c) 2011 - 2014, ARM Ltd. All rights reserved.<BR>
+  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2025, Ventana Micro Systems Inc. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "Backtrace.h"
+
+#define MAX_STACK_FRAME_SIZE  SIZE_16KB
+
+STATIC
+INTN
+CheckFpValid (
+  IN UINTN  Fp,
+  IN UINTN  Sp
+  )
+{
+  UINTN  Low, High;
+
+  Low  = Sp + 2 * sizeof (UINTN);
+  High = ALIGN_VALUE (Sp, MAX_STACK_FRAME_SIZE);
+
+  return !(Fp < Low || Fp > High || Fp & 0x07);
+}
+
+STATIC
+CONST CHAR8 *
+BaseName (
+  IN  CONST CHAR8  *FullName
+  )
+{
+  CONST CHAR8  *Str;
+
+  Str = FullName + AsciiStrLen (FullName);
+
+  while (--Str > FullName) {
+    if ((*Str == '/') || (*Str == '\\')) {
+      return Str + 1;
+    }
+  }
+
+  return Str;
+}
+
+/**
+  Helper for displaying a backtrace.
+
+  @param Regs       Pointer to SMODE_TRAP_REGISTERS.
+  @param FirstPdb   Pointer to the first symbol file used.
+  @param ListImage  If true, only show the full path to symbol file, else
+                    show the PC value and its decoded components.
+**/
+STATIC
+VOID
+DumpCpuBacktraceHelper (
+  IN  SMODE_TRAP_REGISTERS  *Regs,
+  IN  CHAR8                 *FirstPdb,
+  IN  BOOLEAN               ListImage
+  )
+{
+  UINTN    ImageBase;
+  UINTN    PeCoffSizeOfHeader;
+  BOOLEAN  IsLeaf;
+  UINTN    RootFp;
+  UINTN    RootRa;
+  UINTN    Sp;
+  UINTN    Fp;
+  UINTN    Ra;
+  UINTN    Idx;
+  CHAR8    *Pdb;
+  CHAR8    *PrevPdb;
+
+  RootRa = Regs->ra;
+  RootFp = Regs->s0;
+
+  Idx     = 0;
+  IsLeaf  = TRUE;
+  Fp      = RootFp;
+  Ra      = RootRa;
+  PrevPdb = FirstPdb;
+  while (Fp != 0) {
+    Pdb = GetImageName (Ra, &ImageBase, &PeCoffSizeOfHeader);
+    if (Pdb != NULL) {
+      if (Pdb != PrevPdb) {
+        Idx++;
+        if (ListImage) {
+          DEBUG ((DEBUG_ERROR, "[% 2d] %a\n", Idx, Pdb));
+        }
+
+        PrevPdb = Pdb;
+      }
+
+      if (!ListImage) {
+        DEBUG ((
+          DEBUG_ERROR,
+          "PC 0x%012lx (0x%012lx+0x%08x) [% 2d] %a\n",
+          Ra,
+          ImageBase,
+          Ra - ImageBase,
+          Idx,
+          BaseName (Pdb)
+          ));
+      }
+    } else if (!ListImage) {
+      DEBUG ((DEBUG_ERROR, "PC 0x%012lx\n", Ra));
+    }
+
+    /*
+     * After the prologue, the frame pointer register s0 will point
+     * to the Canonical Frame Address or CFA, which is the stack
+     * pointer value on entry to the current procedure. The previous
+     * frame pointer and return address pair will reside just prior
+     * to the current stack address held in s0. This puts the return
+     * address at s0 - XLEN/8, and the previous frame pointer at
+     * s0 - 2 * XLEN/8.
+     */
+    Sp  = Fp;
+    Fp -= sizeof (UINTN) * 2;
+    Ra  = *(UINTN *)(Fp + sizeof (UINTN));
+    Fp  = *(UINTN *)(Fp);
+    if (IsLeaf && CheckFpValid (Ra, Sp)) {
+      /* We hit function where ra is not saved on the stack */
+      Fp = Ra;
+      Ra = RootRa;
+    }
+
+    IsLeaf = FALSE;
+  }
+}
+
+/**
+  Display a backtrace.
+
+  @param SystemContext  Pointer to EFI_SYSTEM_CONTEXT.
+**/
+VOID
+EFIAPI
+DumpCpuBacktrace (
+  IN EFI_SYSTEM_CONTEXT  SystemContext
+  )
+{
+  SMODE_TRAP_REGISTERS  *Regs;
+  CHAR8                 *Pdb;
+  UINTN                 ImageBase;
+  UINTN                 PeCoffSizeOfHeader;
+
+  Regs = (SMODE_TRAP_REGISTERS *)SystemContext.SystemContextRiscV64;
+  Pdb  = GetImageName (Regs->sepc, &ImageBase, &PeCoffSizeOfHeader);
+  if (Pdb != NULL) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "PC 0x%012lx (0x%012lx+0x%08x) [ 0] %a\n",
+      Regs->sepc,
+      ImageBase,
+      Regs->sepc - ImageBase,
+      BaseName (Pdb)
+      ));
+  } else {
+    DEBUG ((DEBUG_ERROR, "PC 0x%012lx\n", Regs->sepc));
+  }
+
+  DumpCpuBacktraceHelper (Regs, Pdb, FALSE);
+
+  if (Pdb != NULL) {
+    DEBUG ((DEBUG_ERROR, "\n[ 0] %a\n", Pdb));
+  }
+
+  DumpCpuBacktraceHelper (Regs, Pdb, TRUE);
+}

--- a/UefiCpuPkg/Library/BaseRiscV64CpuExceptionHandlerLib/Backtrace.h
+++ b/UefiCpuPkg/Library/BaseRiscV64CpuExceptionHandlerLib/Backtrace.h
@@ -1,0 +1,57 @@
+/** @file
+
+  RISC-V backtrace definition file.
+
+  Copyright (c) 2025, Ventana Micro Systems Inc. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef BACKTRACE_H_
+#define BACKTRACE_H_
+
+#include <PiPei.h>
+#include <Uefi.h>
+#include <Library/DebugLib.h>
+#include <Library/BaseLib.h>
+#include <Library/PeCoffExtraActionLib.h>
+#include <Library/PeCoffGetEntryPointLib.h>
+#include <Library/UefiLib.h>
+#include <Guid/DebugImageInfoTable.h>
+#include "CpuExceptionHandlerLib.h"
+
+/**
+  Use the EFI Debug Image Table to lookup the FaultAddress and find which PE/COFF image
+  it came from. As long as the PE/COFF image contains a debug directory entry a
+  string can be returned. For ELF and Mach-O images the string points to the Mach-O or ELF
+  image. Microsoft tools contain a pointer to the PDB file that contains the debug information.
+
+  @param  FaultAddress         Address to find PE/COFF image for.
+  @param  ImageBase            Return load address of found image
+  @param  PeCoffSizeOfHeaders  Return the size of the PE/COFF header for the image that was found
+
+  @retval NULL                 FaultAddress not in a loaded PE/COFF image.
+  @retval                      Path and file name of PE/COFF image.
+
+**/
+CHAR8 *
+EFIAPI
+GetImageName (
+  IN  UINTN  FaultAddress,
+  OUT UINTN  *ImageBase,
+  OUT UINTN  *PeCoffSizeOfHeaders
+  );
+
+/**
+  Display a backtrace.
+
+  @param SystemContext  Pointer to EFI_SYSTEM_CONTEXT.
+**/
+VOID
+EFIAPI
+DumpCpuBacktrace (
+  IN EFI_SYSTEM_CONTEXT  SystemContext
+  );
+
+#endif // BACKTRACE_H_

--- a/UefiCpuPkg/Library/BaseRiscV64CpuExceptionHandlerLib/BacktraceHelper.c
+++ b/UefiCpuPkg/Library/BaseRiscV64CpuExceptionHandlerLib/BacktraceHelper.c
@@ -1,0 +1,71 @@
+/** @file
+  RISC-V backtrace helper functions.
+
+  Copyright (c) 2016 - 2022, Hewlett Packard Enterprise Development LP. All rights reserved.<BR>
+  Copyright (c) 2011 - 2014, ARM Ltd. All rights reserved.<BR>
+  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2025, Ventana Micro Systems Inc. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "Backtrace.h"
+
+/**
+  Use the EFI Debug Image Table to lookup the FaultAddress and find which PE/COFF image
+  it came from. As long as the PE/COFF image contains a debug directory entry a
+  string can be returned. For ELF and Mach-O images the string points to the Mach-O or ELF
+  image. Microsoft tools contain a pointer to the PDB file that contains the debug information.
+
+  @param  FaultAddress         Address to find PE/COFF image for.
+  @param  ImageBase            Return load address of found image
+  @param  PeCoffSizeOfHeaders  Return the size of the PE/COFF header for the image that was found
+
+  @retval NULL                 FaultAddress not in a loaded PE/COFF image.
+  @retval                      Path and file name of PE/COFF image.
+
+**/
+CHAR8 *
+EFIAPI
+GetImageName (
+  IN  UINTN  FaultAddress,
+  OUT UINTN  *ImageBase,
+  OUT UINTN  *PeCoffSizeOfHeaders
+  )
+{
+  EFI_STATUS                         Status;
+  EFI_DEBUG_IMAGE_INFO_TABLE_HEADER  *DebugTableHeader;
+  EFI_DEBUG_IMAGE_INFO               *DebugTable;
+  UINTN                              Entry;
+  CHAR8                              *Address;
+
+  Status = EfiGetSystemConfigurationTable (&gEfiDebugImageInfoTableGuid, (VOID **)&DebugTableHeader);
+  if (EFI_ERROR (Status)) {
+    return NULL;
+  }
+
+  DebugTable = DebugTableHeader->EfiDebugImageInfoTable;
+  if (DebugTable == NULL) {
+    return NULL;
+  }
+
+  Address = (CHAR8 *)(UINTN)FaultAddress;
+  for (Entry = 0; Entry < DebugTableHeader->TableSize; Entry++, DebugTable++) {
+    if (DebugTable->NormalImage != NULL) {
+      if ((DebugTable->NormalImage->ImageInfoType == EFI_DEBUG_IMAGE_INFO_TYPE_NORMAL) &&
+          (DebugTable->NormalImage->LoadedImageProtocolInstance != NULL))
+      {
+        if ((Address >= (CHAR8 *)DebugTable->NormalImage->LoadedImageProtocolInstance->ImageBase) &&
+            (Address <= ((CHAR8 *)DebugTable->NormalImage->LoadedImageProtocolInstance->ImageBase + DebugTable->NormalImage->LoadedImageProtocolInstance->ImageSize)))
+        {
+          *ImageBase           = (UINTN)DebugTable->NormalImage->LoadedImageProtocolInstance->ImageBase;
+          *PeCoffSizeOfHeaders = PeCoffGetSizeOfHeaders ((VOID *)(UINTN)*ImageBase);
+          return PeCoffLoaderGetPdbPointer (DebugTable->NormalImage->LoadedImageProtocolInstance->ImageBase);
+        }
+      }
+    }
+  }
+
+  return NULL;
+}

--- a/UefiCpuPkg/Library/BaseRiscV64CpuExceptionHandlerLib/BacktraceHelperSec.c
+++ b/UefiCpuPkg/Library/BaseRiscV64CpuExceptionHandlerLib/BacktraceHelperSec.c
@@ -1,0 +1,42 @@
+/** @file
+  RISC-V backtrace helper functions for SEC.
+
+  Copyright (c) 2025, Ventana Micro Systems Inc. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "Backtrace.h"
+
+/**
+  Use the EFI Debug Image Table to lookup the FaultAddress and find which PE/COFF image
+  it came from. As long as the PE/COFF image contains a debug directory entry a
+  string can be returned. For ELF and Mach-O images the string points to the Mach-O or ELF
+  image. Microsoft tools contain a pointer to the PDB file that contains the debug information.
+
+  @param  FaultAddress         Address to find PE/COFF image for.
+  @param  ImageBase            Return load address of found image
+  @param  PeCoffSizeOfHeaders  Return the size of the PE/COFF header for the image that was found
+
+  @retval NULL                 FaultAddress not in a loaded PE/COFF image.
+  @retval                      Path and file name of PE/COFF image.
+
+**/
+CHAR8 *
+EFIAPI
+GetImageName (
+  IN  UINTN  FaultAddress,
+  OUT UINTN  *ImageBase,
+  OUT UINTN  *PeCoffSizeOfHeaders
+  )
+{
+  //
+  // This function is not implemented in SEC phase.
+  // It should be implemented in DXE phase.
+  //
+  *ImageBase           = 0;
+  *PeCoffSizeOfHeaders = 0;
+
+  return NULL;
+}

--- a/UefiCpuPkg/Library/BaseRiscV64CpuExceptionHandlerLib/BaseRiscV64CpuExceptionHandlerLib.inf
+++ b/UefiCpuPkg/Library/BaseRiscV64CpuExceptionHandlerLib/BaseRiscV64CpuExceptionHandlerLib.inf
@@ -1,7 +1,8 @@
 ## @file
 # RISC-V CPU Exception Handler Library
 #
-# Copyright (c) 2022-2023, Ventana Micro Systems Inc. All rights reserved.<BR>
+# Copyright (c) 2022-2025, Ventana Micro Systems Inc. All rights reserved.<BR>
+# Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
 #
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -14,7 +15,7 @@
   FILE_GUID                      = 6AB0D5FD-E615-45A3-9374-E284FB061FC9
   MODULE_TYPE                    = BASE
   VERSION_STRING                 = 1.0
-  LIBRARY_CLASS                  = CpuExceptionHandlerLib
+  LIBRARY_CLASS                  = CpuExceptionHandlerLib|PEIM DXE_CORE DXE_DRIVER
 
 #
 # The following information is for reference only and not required by the build tools.
@@ -26,6 +27,9 @@
   SupervisorTrapHandler.S
   CpuExceptionHandlerLib.c
   CpuExceptionHandlerLib.h
+  Backtrace.c
+  Backtrace.h
+  BacktraceHelper.c
 
 [Packages]
   MdePkg/MdePkg.dec
@@ -40,3 +44,6 @@
   PeCoffGetEntryPointLib
   MemoryAllocationLib
   DebugLib
+
+[Guids]
+  gEfiDebugImageInfoTableGuid

--- a/UefiCpuPkg/Library/BaseRiscV64CpuExceptionHandlerLib/BaseRiscV64CpuExceptionHandlerSecLib.inf
+++ b/UefiCpuPkg/Library/BaseRiscV64CpuExceptionHandlerLib/BaseRiscV64CpuExceptionHandlerSecLib.inf
@@ -1,0 +1,44 @@
+## @file
+# RISC-V CPU Exception Handler Library for SEC
+#
+# Copyright (c) 2025, Ventana Micro Systems Inc. All rights reserved.<BR>
+#
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 1.30
+  BASE_NAME                      = BaseRiscV64CpuExceptionHandlerLibSec
+  MODULE_UNI_FILE                = BaseRiscV64CpuExceptionHandlerLib.uni
+  FILE_GUID                      = 6D3A9D64-91F2-4A71-8A5F-5C4E1EDE93BE
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = CpuExceptionHandlerLib|SEC
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = RISCV64
+#
+
+[Sources]
+  SupervisorTrapHandler.S
+  CpuExceptionHandlerLib.c
+  CpuExceptionHandlerLib.h
+  Backtrace.c
+  Backtrace.h
+  BacktraceHelperSec.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  UefiCpuPkg/UefiCpuPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  SerialPortLib
+  PrintLib
+  SynchronizationLib
+  MemoryAllocationLib
+  DebugLib

--- a/UefiCpuPkg/UefiCpuPkg.dsc
+++ b/UefiCpuPkg/UefiCpuPkg.dsc
@@ -219,6 +219,7 @@
 
 [Components.RISCV64]
   UefiCpuPkg/Library/BaseRiscV64CpuExceptionHandlerLib/BaseRiscV64CpuExceptionHandlerLib.inf
+  UefiCpuPkg/Library/BaseRiscV64CpuExceptionHandlerLib/BaseRiscV64CpuExceptionHandlerSecLib.inf
   UefiCpuPkg/Library/BaseRiscV64CpuTimerLib/BaseRiscV64CpuTimerLib.inf
   UefiCpuPkg/Library/BaseRiscVMmuLib/BaseRiscVMmuLib.inf
   UefiCpuPkg/CpuTimerDxeRiscV64/CpuTimerDxeRiscV64.inf


### PR DESCRIPTION
# Description

Enable backtrace printing for exceptions in DEBUG builds.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

Confirmed backtrace printed in exception

Shell> mm 0xffff
!!!! RISCV64 Exception Type - 000000000000000D(EXCEPT_RISCV_LOAD_ACCESS_PAGE_FAULT) !!!!
     t0 = 0x00000000000000001	     t1 = 0x00000003F0000003F
     t2 = 0x0000000000000FFF6	     t3 = 0x00000000000000000
     t4 = 0x00000000000000000	     t5 = 0x0000000017EC84E96
     t6 = 0x00000000000000008	     s0 = 0x00000000083FFF180
     s1 = 0x00000000083FFF230	     s2 = 0x00000000000000001
     s3 = 0x0000000000000FFFF	     s4 = 0x00000000000000001
     s5 = 0x0000000000000FFFF	     s6 = 0x00000000000000000
     s7 = 0x0000000017F834E08	     s8 = 0x00000000000000020
     s9 = 0x00000000000000000	    s10 = 0x00000000000000000
    s11 = 0x000000000000000FF	     a0 = 0x00000000083FFF230
     a1 = 0x0000000000000FFFE	     a2 = 0x00000000000000001
     a3 = 0x00000000083FFF22F	     a4 = 0x0000000000000FFFF
     a5 = 0x00000000000000001	     a6 = 0x00000000083FFF230
     a7 = 0x000000000834E12E8	   zero = 0x00000000000000000
     ra = 0x0000000017EAF6B34	     sp = 0x0000000017F87BF92
     gp = 0x00000000000000000	     tp = 0x00000000080048000
   sepc = 0x0000000017EAF6C02	sstatus = 0x08000000200006120
  stval = 0x0000000000000FFFF	
PC 0x00017EAF6C02 (0x00017EAF0000+0x00006C02) [ 0] Shell.dll
PC 0x00017EAF6B34 (0x00017EAF0000+0x00006B34) [ 0] Shell.dll
PC 0x00017EAF6B34 (0x00017EAF0000+0x00006B34) [ 0] Shell.dll
PC 0x00017EB39C0E (0x00017EAF0000+0x00049C0E) [ 0] Shell.dll
PC 0x00017EB3A7EC (0x00017EAF0000+0x0004A7EC) [ 0] Shell.dll
PC 0x00017EB0416C (0x00017EAF0000+0x0001416C) [ 0] Shell.dll
PC 0x00017EB0C8EC (0x00017EAF0000+0x0001C8EC) [ 0] Shell.dll
PC 0x00017EB0C662 (0x00017EAF0000+0x0001C662) [ 0] Shell.dll
PC 0x00017EB0C42A (0x00017EAF0000+0x0001C42A) [ 0] Shell.dll
PC 0x00017EB0AD0A (0x00017EAF0000+0x0001AD0A) [ 0] Shell.dll
PC 0x00017EB0B206 (0x00017EAF0000+0x0001B206) [ 0] Shell.dll
PC 0x00017EB0A498 (0x00017EAF0000+0x0001A498) [ 0] Shell.dll
PC 0x00017EAF0F6E (0x00017EAF0000+0x00000F6E) [ 0] Shell.dll
PC 0x00017EAF028E (0x00017EAF0000+0x0000028E) [ 0] Shell.dll
PC 0x0000834C85D0 (0x0000834AC000+0x0001C5D0) [ 1] DxeCore.dll
PC 0x00017ECFB240 (0x00017ECE9000+0x00012240) [ 2] UiApp.dll
PC 0x00017ED01AEC (0x00017ECE9000+0x00018AEC) [ 2] UiApp.dll
PC 0x00017F73D968 (0x00017F725000+0x00018968) [ 3] SetupBrowser.dll
PC 0x00017F740B3E (0x00017F725000+0x0001BB3E) [ 3] SetupBrowser.dll
PC 0x00017F72BB28 (0x00017F725000+0x00006B28) [ 3] SetupBrowser.dll
PC 0x00017ECF6572 (0x00017ECE9000+0x0000D572) [ 4] UiApp.dll
PC 0x00017ECF6450 (0x00017ECE9000+0x0000D450) [ 4] UiApp.dll
PC 0x00017ECE9A46 (0x00017ECE9000+0x00000A46) [ 4] UiApp.dll
PC 0x00017ECE928E (0x00017ECE9000+0x0000028E) [ 4] UiApp.dll
PC 0x0000834C85D0 (0x0000834AC000+0x0001C5D0) [ 5] DxeCore.dll
PC 0x00017F710576 (0x00017F703000+0x0000D576) [ 6] BdsDxe.dll
PC 0x00017F713F6C (0x00017F703000+0x00010F6C) [ 6] BdsDxe.dll
PC 0x00017F70B8B2 (0x00017F703000+0x000088B2) [ 6] BdsDxe.dll
PC 0x0000834B632E (0x0000834AC000+0x0000A32E) [ 7] DxeCore.dll
PC 0x0000834AC792 (0x0000834AC000+0x00000792) [ 7] DxeCore.dll
PC 0x0000834AC3C0 (0x0000834AC000+0x000003C0) [ 7] DxeCore.dll
PC 0x000020006886
PC 0x00002000693E
PC 0x0000200004F6

## Integration Instructions

N/A
