### PR TITLE
MdeModulePkg: Update to support mouse z-axis in ConSplitterDxe

### DIFF
--- a/MdeModulePkg/Bus/Usb/UsbMouseAbsolutePointerDxe/UsbMouseAbsolutePointer.c
+++ b/MdeModulePkg/Bus/Usb/UsbMouseAbsolutePointerDxe/UsbMouseAbsolutePointer.c
@@ -663,7 +663,7 @@ InitializeUsbMouseDevice (
 
   UsbMouseAbsolutePointerDev->Mode.AbsoluteMaxX = 1024;
   UsbMouseAbsolutePointerDev->Mode.AbsoluteMaxY = 1024;
-  UsbMouseAbsolutePointerDev->Mode.AbsoluteMaxZ = 0;
+  UsbMouseAbsolutePointerDev->Mode.AbsoluteMaxZ = 1024;
   UsbMouseAbsolutePointerDev->Mode.AbsoluteMinX = 0;
   UsbMouseAbsolutePointerDev->Mode.AbsoluteMinY = 0;
   UsbMouseAbsolutePointerDev->Mode.AbsoluteMinZ = 0;

--- a/MdeModulePkg/Bus/Usb/UsbMouseDxe/UsbMouse.c
+++ b/MdeModulePkg/Bus/Usb/UsbMouseDxe/UsbMouse.c
@@ -675,7 +675,7 @@ InitializeUsbMouseDevice (
 
   UsbMouseDev->Mode.ResolutionX = 8;
   UsbMouseDev->Mode.ResolutionY = 8;
-  UsbMouseDev->Mode.ResolutionZ = 0;
+  UsbMouseDev->Mode.ResolutionZ = 8;
 
   //
   // Set boot protocol for the USB mouse.


### PR DESCRIPTION
# Description

If `AbsoluteMaxZ`/`ResolutionZ` is 0, it means z-axis is not supported. When getting AbsolutePointer/SimplePointer Protocol Interface and mouse state from `gST->ConsoleInHandle`, `AbsoluteMaxZ`/`ResolutionZ` is checked, so AbsState.CurrentZ/SimpleState.RelativeMovementZ is always 0.

Assign a valid value to `AbsoluteMaxZ`/`ResolutionZ` to indicate z-axis support.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Get `gEfiAbsolutePointerProtocolGuid` or `gEfiSimplePointerProtocolGuid` from `gST->ConsoleInHandle`,
then use `GetState`  to retrieves the current state of a pointer device, and print AbsState.CurrentZ/SimpleState.RelativeMovementZ.

## Integration Instructions

N/A
