### PR TITLE
MdeModulePkg: Support conditional UFS initialization

### DIFF
--- a/MdeModulePkg/Bus/Ufs/UfsPassThruDxe/UfsPassThruHci.c
+++ b/MdeModulePkg/Bus/Ufs/UfsPassThruDxe/UfsPassThruHci.c
@@ -1862,40 +1862,42 @@ UfsEnableHostController (
     }
   }
 
-  //
-  // UFS 2.0 spec section 7.1.1 - Host Controller Initialization
-  //
-  // Reinitialize the UFS host controller if HCE bit of HC register is set.
-  //
-  Status = UfsMmioRead32 (Private, UFS_HC_ENABLE_OFFSET, &Data);
-  if (EFI_ERROR (Status)) {
-    return Status;
-  }
-
-  if ((Data & UFS_HC_HCE_EN) == UFS_HC_HCE_EN) {
+  if ((mUfsHcPlatform == NULL) || !mUfsHcPlatform->SkipHceReenable) {
     //
-    // Write a 0 to the HCE register at first to disable the host controller.
+    // UFS 2.0 spec section 7.1.1 - Host Controller Initialization
     //
-    Status = UfsMmioWrite32 (Private, UFS_HC_ENABLE_OFFSET, 0);
+    // Reinitialize the UFS host controller if HCE bit of HC register is set.
+    //
+    Status = UfsMmioRead32 (Private, UFS_HC_ENABLE_OFFSET, &Data);
     if (EFI_ERROR (Status)) {
       return Status;
     }
 
-    //
-    // Wait until HCE is read as '0' before continuing.
-    //
-    Status = UfsWaitMemSet (Private, UFS_HC_ENABLE_OFFSET, UFS_HC_HCE_EN, 0, UFS_TIMEOUT);
-    if (EFI_ERROR (Status)) {
-      return EFI_DEVICE_ERROR;
-    }
-  }
+    if ((Data & UFS_HC_HCE_EN) == UFS_HC_HCE_EN) {
+      //
+      // Write a 0 to the HCE register at first to disable the host controller.
+      //
+      Status = UfsMmioWrite32 (Private, UFS_HC_ENABLE_OFFSET, 0);
+      if (EFI_ERROR (Status)) {
+        return Status;
+      }
 
-  //
-  // Write a 1 to the HCE register to enable the UFS host controller.
-  //
-  Status = UfsMmioWrite32 (Private, UFS_HC_ENABLE_OFFSET, UFS_HC_HCE_EN);
-  if (EFI_ERROR (Status)) {
-    return Status;
+      //
+      // Wait until HCE is read as '0' before continuing.
+      //
+      Status = UfsWaitMemSet (Private, UFS_HC_ENABLE_OFFSET, UFS_HC_HCE_EN, 0, UFS_TIMEOUT);
+      if (EFI_ERROR (Status)) {
+        return EFI_DEVICE_ERROR;
+      }
+    }
+
+    //
+    // Write a 1 to the HCE register to enable the UFS host controller.
+    //
+    Status = UfsMmioWrite32 (Private, UFS_HC_ENABLE_OFFSET, UFS_HC_HCE_EN);
+    if (EFI_ERROR (Status)) {
+      return Status;
+    }
   }
 
   //
@@ -1943,6 +1945,10 @@ UfsDeviceDetection (
       DEBUG ((DEBUG_ERROR, "Failure from platform driver during EdkiiUfsHcPreLinkStartup, Status = %r\n", Status));
       return Status;
     }
+  }
+
+  if ((mUfsHcPlatform != NULL) && mUfsHcPlatform->SkipLinkStartup) {
+    return EFI_SUCCESS;
   }
 
   //

--- a/MdeModulePkg/Include/Protocol/UfsHostControllerPlatform.h
+++ b/MdeModulePkg/Include/Protocol/UfsHostControllerPlatform.h
@@ -11,7 +11,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #include <Protocol/UfsHostController.h>
 
-#define EDKII_UFS_HC_PLATFORM_PROTOCOL_VERSION  2
+#define EDKII_UFS_HC_PLATFORM_PROTOCOL_VERSION  3
 
 extern EFI_GUID  gEdkiiUfsHcPlatformProtocolGuid;
 
@@ -129,6 +129,14 @@ struct _EDKII_UFS_HC_PLATFORM_PROTOCOL {
   /// Reference Clock Frequency Ufs Card Attribute that need to be set in this Ufs Host Environment.
   ///
   EDKII_UFS_CARD_REF_CLK_FREQ_ATTRIBUTE     RefClkFreq;
+  ///
+  /// Flag to skip HCE re-enable.
+  ///
+  BOOLEAN                                   SkipHceReenable;
+  ///
+  /// Flag to skip link startup.
+  ///
+  BOOLEAN                                   SkipLinkStartup;
 };
 
 #endif


### PR DESCRIPTION
# Description
Add SkipHceReenable and SkipLinkStartup flags to
the EDKII_UFS_HC_PLATFORM_PROTOCOL to support
using a UFS controller that has already been
initialized.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested
Proper UFS initialization was verified on platforms that set and did not set the new skip flags.

## Integration Instructions
N/A
