### PR TITLE
BaseTools/tools_def: Use MSVC ABI for CLANGPDB Targets

### DIFF
--- a/BaseTools/Conf/tools_def.template
+++ b/BaseTools/Conf/tools_def.template
@@ -1932,11 +1932,11 @@ RELEASE_GCC_LOONGARCH64_CC_FLAGS       = DEF(GCC5_LOONGARCH64_CC_FLAGS) -Wno-unu
 DEFINE CLANGPDB_IA32_PREFIX          = ENV(CLANG_BIN)
 DEFINE CLANGPDB_X64_PREFIX           = ENV(CLANG_BIN)
 
-DEFINE CLANGPDB_IA32_TARGET          = -target i686-unknown-windows-gnu
-DEFINE CLANGPDB_X64_TARGET           = -target x86_64-unknown-windows-gnu
+DEFINE CLANGPDB_IA32_TARGET          = -target i686-pc-windows-msvc
+DEFINE CLANGPDB_X64_TARGET           = -target x86_64-pc-windows-msvc
 
 DEFINE CLANGPDB_WARNING_OVERRIDES    = -Wno-parentheses-equality -Wno-tautological-compare -Wno-tautological-constant-out-of-range-compare -Wno-empty-body -Wno-unused-const-variable -Wno-varargs -Wno-unknown-warning-option -Wno-unused-but-set-variable -Wno-unused-const-variable -Wno-unaligned-access -Wno-microsoft-enum-forward-reference
-DEFINE CLANGPDB_ALL_CC_FLAGS         = DEF(GCC48_ALL_CC_FLAGS) DEF(CLANGPDB_WARNING_OVERRIDES) -fno-stack-protector -funsigned-char -ftrap-function=undefined_behavior_has_been_optimized_away_by_clang -Wno-address -Wno-shift-negative-value -Wno-unknown-pragmas -Wno-incompatible-library-redeclaration -Wno-null-dereference -mno-implicit-float -mms-bitfields -mno-stack-arg-probe -nostdlib -nostdlibinc -fseh-exceptions
+DEFINE CLANGPDB_ALL_CC_FLAGS         = DEF(GCC48_ALL_CC_FLAGS) DEF(CLANGPDB_WARNING_OVERRIDES) -fno-stack-protector -funsigned-char -ftrap-function=undefined_behavior_has_been_optimized_away_by_clang -Wno-address -Wno-shift-negative-value -Wno-unknown-pragmas -Wno-incompatible-library-redeclaration -Wno-null-dereference -mno-implicit-float -mms-bitfields -mno-stack-arg-probe -nostdlib -nostdlibinc -fno-omit-frame-pointer -U _MSC_VER -D __GNUC__
 
 ###########################
 # CLANGPDB IA32 definitions


### PR DESCRIPTION
# Description

Update the CLANGPDB toolchain configuration to use MSVC ABI targets and retain frame pointers in generated code. This improves compatibility with the Microsoft Debug Interface Access (DIA) SDK and improves debuggability with any debugger that uses the Microsoft PDB parser, for example the Visual Studio debugger or windbg.

Without these changes, code generated by the Clang compiler will have a mix of calling conventions. With the current configuration, any function declared with EFIAPI will use the Microsoft x64 calling convention. However, the default calling convention will be the SysV x64 calling convention. This mixing of calling conventions prevents debuggers from decoding the call stack.

With these changes, only the Microsoft x64 calling convention will be used. These modifications enable debuggers to properly parse and display call stacks on binaries built with the CLANGPDB toolchain.

The changes include:
- Switch from GNU ABI target (`*-unknown-windowsl-gnu`) to MSVC ABI targets (`*-pc-windows-msvc`) for both IA32 and X64 architectures.
- Remove `-fseh-exceptions` as not supported.
- Add `-fno-omit-frame-pointer` as required for call stack.
- Undefine the `_MSC_VER` macro, and define the `__GNUC__` macro, so that pre-processor conditionals will continue to function as expected.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

- Confirmed that call stacks are now visible in debuggers when using CLANGPDB compiled images.
- Confirmed that all edk2 packages that support building with CLANGPDB continue to build.
- Confirmed that the Intel platforms in edk2-platforms that support building with CLANGPDB continue to build.

## Integration Instructions

N/A
