### PR TITLE
ShellPkg/Library: Remove unnecessary error check

### DIFF
--- a/ShellPkg/Library/UefiShellDriver1CommandsLib/Connect.c
+++ b/ShellPkg/Library/UefiShellDriver1CommandsLib/Connect.c
@@ -520,10 +520,6 @@ ShellCommandRunConnect (
         }
 
         Handle1 = ConvertHandleIndexToHandle ((UINTN)Intermediate);
-        if (EFI_ERROR (Status)) {
-          ShellPrintHiiEx (-1, -1, NULL, STRING_TOKEN (STR_GEN_INV_HANDLE), gShellDriver1HiiHandle, L"connect", Param1);
-          ShellStatus = SHELL_INVALID_PARAMETER;
-        }
       } else {
         Handle1 = NULL;
       }


### PR DESCRIPTION
Remove the error handling from the connect.c file as it is redundant.

# Description

<_Remove the error handling from connect.c as it is redundant. The same condition is validated, making this check unnecessary.._>

## Integration Instructions

<_ N/A_>
