### PR TITLE
MdeModulePkg: DxeMain: Honor memory bucket during memory map merging

### DIFF
--- a/MdeModulePkg/Core/Dxe/Mem/Imem.h
+++ b/MdeModulePkg/Core/Dxe/Mem/Imem.h
@@ -146,6 +146,21 @@ CoreInternalAllocatePages (
   IN BOOLEAN                   NeedGuard
   );
 
+/**
+  Get the memory bucket type for a given memory range.
+
+  @param  PhysicalStart  The address of the first byte in the memory region.
+  @param  PhysicalEnd    The address of the last byte in the memory region.
+
+  @return The memory type for the bucket that contains the given physical address range.
+          If the address range does not match any special bucket, it returns EfiMaxMemoryType.
+**/
+EFI_MEMORY_TYPE
+GetBucketMemoryType (
+  IN EFI_PHYSICAL_ADDRESS  PhysicalStart,
+  IN EFI_PHYSICAL_ADDRESS  PhysicalEnd
+  );
+
 //
 // Internal Global data
 //

--- a/MdeModulePkg/Core/Dxe/Mem/Page.c
+++ b/MdeModulePkg/Core/Dxe/Mem/Page.c
@@ -96,6 +96,16 @@ EFI_MEMORY_TYPE_INFORMATION  gMemoryTypeInformation[EfiMaxMemoryType + 1] = {
 GLOBAL_REMOVE_IF_UNREFERENCED   BOOLEAN  gLoadFixedAddressCodeMemoryReady = FALSE;
 
 /**
+  Internal function.  Moves any memory descriptors that are on the
+  temporary descriptor stack to heap.
+
+**/
+VOID
+CoreFreeMemoryMapStack (
+  VOID
+  );
+
+/**
   Enter critical section by gaining lock on gMemoryLock.
 
 **/
@@ -142,6 +152,98 @@ RemoveMemoryMapEntry (
 }
 
 /**
+  Helper function to evaluate if memory regions intersect.
+
+  @param  Start1     The address of the first byte in the first memory region.
+  @param  End1       The address of the last byte in the first memory region.
+  @param  Start2     The address of the first byte in the second memory region.
+  @param  End2       The address of the last byte in the second memory region.
+
+  @return TRUE if the memory regions intersect, FALSE otherwise.
+**/
+STATIC
+BOOLEAN
+MemoryRegionsIntersect (
+  IN EFI_PHYSICAL_ADDRESS  Start1,
+  IN EFI_PHYSICAL_ADDRESS  End1,
+  IN EFI_PHYSICAL_ADDRESS  Start2,
+  IN EFI_PHYSICAL_ADDRESS  End2
+  )
+{
+  return (((Start1 <= End2) && (Start2 <= Start1)) ||
+          ((Start2 <= End1) && (Start1 <= Start2)));
+}
+
+/**
+  Get the memory bucket type for a given memory range.
+
+  @param  PhysicalStart  The address of the first byte in the memory region.
+  @param  PhysicalEnd    The address of the last byte in the memory region.
+
+  @return The memory type for the bucket that contains the given physical address range.
+          If the address range does not match any special bucket, it returns EfiMaxMemoryType.
+**/
+EFI_MEMORY_TYPE
+GetBucketMemoryType (
+  IN EFI_PHYSICAL_ADDRESS  PhysicalStart,
+  IN EFI_PHYSICAL_ADDRESS  PhysicalEnd
+  )
+{
+  EFI_MEMORY_TYPE  BucketType;
+
+  // Find the bucket type for the incoming memory region.
+  for (BucketType = (EFI_MEMORY_TYPE)0; BucketType < EfiMaxMemoryType; BucketType++) {
+    //
+    // If the number of pages for this memory type is not zero, the input region
+    // better be within the same bucket. We only care about the special memory type
+    // here because we need these buckets to remain consistent so that the OS resume
+    // logic can work properly. The same applies to the memory allocation logic.
+    //
+    if (mMemoryTypeStatistics[BucketType].Special && (mMemoryTypeStatistics[BucketType].NumberOfPages != 0)) {
+      if ((PhysicalStart >= mMemoryTypeStatistics[BucketType].BaseAddress) &&
+          (PhysicalEnd <= mMemoryTypeStatistics[BucketType].MaximumAddress))
+      {
+        break;
+      } else if (MemoryRegionsIntersect (
+                   PhysicalStart,
+                   PhysicalEnd,
+                   mMemoryTypeStatistics[BucketType].BaseAddress,
+                   mMemoryTypeStatistics[BucketType].MaximumAddress
+                   ))
+      {
+        // The start and end overlap the bucket, but not fully inclusive. We should not allow this.
+        DEBUG ((
+          DEBUG_ERROR,
+          "%a: %lx-%lx intersects bucket type %d (%lx-%lx)\n",
+          __func__,
+          PhysicalStart,
+          PhysicalEnd,
+          BucketType,
+          mMemoryTypeStatistics[BucketType].BaseAddress,
+          mMemoryTypeStatistics[BucketType].MaximumAddress
+          ));
+
+        ASSERT (FALSE);
+      }
+    }
+  }
+
+  // If we can find the bucket type, use it to guide the merging logic below.
+  // Otherwise, we will not care about the bucket type.
+  if (BucketType >= EfiMaxMemoryType) {
+    DEBUG ((
+      DEBUG_PAGE,
+      "%a: defaulting to max for %lx -%lx\n",
+      __func__,
+      PhysicalStart,
+      PhysicalEnd
+      ));
+  }
+
+  return BucketType;
+}
+
+/**
   Internal function.  Adds a ranges to the memory map.
   The range must not already exist in the map.
 
@@ -161,13 +263,74 @@ CoreAddRange (
   IN UINT64                Attribute
   )
 {
-  LIST_ENTRY  *Link;
-  MEMORY_MAP  *Entry;
+  LIST_ENTRY       *Link;
+  MEMORY_MAP       *Entry;
+  EFI_MEMORY_TYPE  BucketType;
+  EFI_MEMORY_TYPE  MergeType;
+  BOOLEAN          Break;
 
   ASSERT ((Start & EFI_PAGE_MASK) == 0);
   ASSERT (End > Start);
 
   ASSERT_LOCKED (&gMemoryLock);
+
+  // Find the bucket type for the incoming memory region.
+  Break = FALSE;
+  for (BucketType = (EFI_MEMORY_TYPE)0; BucketType < EfiMaxMemoryType; BucketType++) {
+    //
+    // If the number of pages for this memory type is not zero, the input region better
+    // be within the same bucket. Otherwise, we will handle the ones we care about,
+    // the special memory types, in chunks.
+    //
+    if (mMemoryTypeStatistics[BucketType].Special && (mMemoryTypeStatistics[BucketType].NumberOfPages != 0)) {
+      if ((Start <= mMemoryTypeStatistics[BucketType].MaximumAddress) &&
+          (End > mMemoryTypeStatistics[BucketType].MaximumAddress))
+      {
+        //
+        // The start overlaps the bucket, so we let self-recursion handle the tail, and we
+        // handle the head.
+        //
+        // |----------|---Special Memory Bucket---|----------|
+        // |--------------^---------------------------^------|
+        // |------------Start------------------------End-----|
+        //
+        CoreAddRange (
+          Type,
+          mMemoryTypeStatistics[BucketType].MaximumAddress + 1,
+          End,
+          Attribute
+          );
+        CoreFreeMemoryMapStack ();
+        End   = mMemoryTypeStatistics[BucketType].MaximumAddress;
+        Break = TRUE;
+      }
+
+      if ((Start < mMemoryTypeStatistics[BucketType].BaseAddress) &&
+          (End >= mMemoryTypeStatistics[BucketType].BaseAddress))
+      {
+        // The end overlaps the bucket, so we let self-recursion handle the head, and we
+        // handle the tail.
+        //
+        // |----------|---Special Memory Bucket---|----------|
+        // |------^-------------------^----------------------|
+        // |----Start----------------End---------------------|
+        //
+        CoreAddRange (
+          Type,
+          Start,
+          mMemoryTypeStatistics[BucketType].BaseAddress - 1,
+          Attribute
+          );
+        CoreFreeMemoryMapStack ();
+        Start = mMemoryTypeStatistics[BucketType].BaseAddress;
+        Break = TRUE;
+      }
+
+      if (Break) {
+        break;
+      }
+    }
+  }
 
   DEBUG ((DEBUG_PAGE, "AddRange: %lx-%lx to %d\n", Start, End, Type));
 
@@ -210,7 +373,8 @@ CoreAddRange (
   // and the same Attribute
   //
 
-  Link = gMemoryMap.ForwardLink;
+  MergeType = GetBucketMemoryType (Start, End);
+  Link      = gMemoryMap.ForwardLink;
   while (Link != &gMemoryMap) {
     Entry = CR (Link, MEMORY_MAP, Link, MEMORY_MAP_SIGNATURE);
     Link  = Link->ForwardLink;
@@ -221,6 +385,14 @@ CoreAddRange (
 
     if (Entry->Attribute != Attribute) {
       continue;
+    }
+
+    if (MergeType != EfiMaxMemoryType) {
+      // We are in the midst of merging memory descriptors, so we can only merge
+      // with the same type as the merge type.
+      if (MergeType != GetBucketMemoryType (Entry->Start, Entry->End)) {
+        continue;
+      }
     }
 
     if (Entry->End + 1 == Start) {
@@ -2028,6 +2200,28 @@ CoreGetMemoryMap (
             (Entry->End   <= mMemoryTypeStatistics[Type].MaximumAddress))
         {
           MemoryMap->Type = Type;
+        } else if (mMemoryTypeStatistics[Type].Special &&
+                   (mMemoryTypeStatistics[Type].NumberOfPages > 0) &&
+                   MemoryRegionsIntersect (
+                     Entry->Start,
+                     Entry->End,
+                     mMemoryTypeStatistics[Type].BaseAddress,
+                     mMemoryTypeStatistics[Type].MaximumAddress
+                     ))
+        {
+          // There is partial overlap with a special memory type bin.
+          // This is not allowed, so we will not change the type.
+          DEBUG ((
+            DEBUG_ERROR,
+            "%a: Memory Map entry partially overlaps with a special memory type bin. Bucket Type %d, Type %d, Start 0x%lx, End 0x%lx\n",
+            __func__,
+            Type,
+            Entry->Type,
+            Entry->Start,
+            Entry->End
+            ));
+
+          ASSERT (FALSE);
         }
       }
     }


### PR DESCRIPTION
# Description

The current memory map merging logic in `CoreAddRange` only checks the memory type without considering the bucket type.

However, the `CoreGetMemoryMap` routine will only report the entries that are entirely inside a specific bucket type. This will confuse the consumer and report false free memory that belongs to special memory buckets.

This change fixes the issue by gating the merging logic by checking the bucket type first. The merging is only allowed either if the bucket type is not one of the special types, or if the bucket type is the same for both entries.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

This is tested on proprietary hardware platform as well as QEMU virtual platforms.

## Integration Instructions

N/A
