### PR TITLE
EmbeddedPkg: Ensure variables initialized.

### DIFF
--- a/EmbeddedPkg/Library/PrePiLib/FwVol.c
+++ b/EmbeddedPkg/Library/PrePiLib/FwVol.c
@@ -296,10 +296,13 @@ FfsProcessSection (
   UINT32                    CompressedDataLength;
   BOOLEAN                   Found;
 
-  Found         = FALSE;
-  *OutputBuffer = NULL;
-  ParsedLength  = 0;
-  Status        = EFI_NOT_FOUND;
+  Found             = FALSE;
+  *OutputBuffer     = NULL;
+  ParsedLength      = 0;
+  Status            = EFI_NOT_FOUND;
+  ScratchBufferSize = 0;
+  DstBufferSize     = 0;
+
   while (ParsedLength < SectionSize) {
     if (IS_SECTION2 (Section)) {
       ASSERT (SECTION2_SIZE (Section) > 0x00FFFFFF);


### PR DESCRIPTION
# Description
Ensure that variables are initialized prior to their use. There is a codepath that would result in an uninitialized variable being used. Caught by ARM64 compiler.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested
Local CI and running on virtual platform.

## Integration Instructions
No integration necessary.