### PR TITLE
MdeModulePkg/Bus/Usb/UsbBusDxe: USB Device Enumeration Compatibility for Non-Compliant Devices

### DIFF
--- a/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbBus.h
+++ b/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbBus.h
@@ -123,7 +123,7 @@ typedef struct _USB_HUB_API    USB_HUB_API;
 //
 // Send clear feature request timeout, set by experience
 //
-#define USB_CLEAR_FEATURE_REQUEST_TIMEOUT  10
+#define USB_CLEAR_FEATURE_REQUEST_TIMEOUT  10000    // EDK uses 10.  Change for AMD
 
 //
 // Bus raises TPL to TPL_NOTIFY to serialize all its operations
@@ -142,6 +142,16 @@ typedef struct _USB_HUB_API    USB_HUB_API;
 
 #define USB_BUS_FROM_THIS(a) \
           CR(a, USB_BUS, BusId, USB_BUS_SIGNATURE)
+
+#define USB_CONFIG_DESC_DEF_ALLOC_LEN  255
+
+typedef enum {
+  UsbEnumScriptEdk2    = 0,         // 0   :EDK2 flow
+  UsbEnumScriptRsrv    = 1,         // 1   :Reserved flow - EDK2
+  UsbEnumScriptLinux   = 2,         // 2   :Linux flow
+  UsbEnumScriptWin     = 3,         // 3   :Window flow
+  UsbEnumScriptUnknown = 0xFF,      // 0xff:Unknow flow
+} USB_ENUM_SCRIPT_TYPE;
 
 //
 // Used to locate USB_BUS
@@ -188,6 +198,8 @@ struct _USB_DEVICE {
   UINT8                                 ParentPort; // Start at 0
   UINT8                                 Tier;
   BOOLEAN                               DisconnectFail;
+  BOOLEAN                               IsSSDev;
+  UINT8                                 EnumScript;
 };
 
 //
@@ -279,7 +291,7 @@ struct _USB_HUB_API {
   USB_HUB_RELEASE               Release;
 };
 
-#define USB_US_LAND_ID  0x0409
+#define USB_US_LANG_ID  0x0409
 
 #define DEVICE_PATH_LIST_ITEM_SIGNATURE  SIGNATURE_32('d','p','l','i')
 typedef struct _DEVICE_PATH_LIST_ITEM {

--- a/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbDesc.c
+++ b/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbDesc.c
@@ -9,6 +9,8 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #include "UsbBus.h"
 
+#define INTERFACE_NOT_SET  0xFF
+
 /**
   Free the interface setting descriptor.
 
@@ -112,6 +114,22 @@ UsbFreeDevDesc (
     }
 
     FreePool (DevDesc->Configs);
+  }
+
+  if (DevDesc->BOSDesc != NULL) {
+    FreePool (DevDesc->BOSDesc);
+  }
+
+  if (DevDesc->StrDescManufacturerUS != NULL) {
+    FreePool (DevDesc->StrDescManufacturerUS);
+  }
+
+  if (DevDesc->StrDescProductUS != NULL) {
+    FreePool (DevDesc->StrDescProductUS);
+  }
+
+  if (DevDesc->StrDescSerialNumberUS != NULL) {
+    FreePool (DevDesc->StrDescSerialNumberUS);
   }
 
   FreePool (DevDesc);
@@ -320,6 +338,46 @@ ON_ERROR:
 }
 
 /**
+  Parse the BOS descriptor and check if it is a SS device.
+
+  @param  DescBuf               The buffer of raw descriptor.
+  @param  Len                   The length of the raw descriptor buffer.
+
+  @return TRUE                  The device is a SS device
+          FALSE                 The device is not a SS device
+
+**/
+BOOLEAN
+UsbIsSSDevice (
+  IN UINT8  *DescBuf,
+  IN UINTN  Len
+  )
+{
+  UINT8             *NextCap;
+  UINT8             Index;
+  UINT8             NumCapDesc;
+  USB_BOS_DESC      *BOSDesc;
+  USB_DEV_CAP_DESC  *DevCapDesc;
+
+  BOSDesc = (USB_BOS_DESC *)DescBuf;
+  if ((BOSDesc->DescriptorType != USB_DESC_TYPE_BOS) || (Len == 0)) {
+    return FALSE;
+  }
+
+  NumCapDesc = BOSDesc->NumDeviceCaps;
+  NextCap    = DescBuf + BOSDesc->Length;
+
+  for (Index = 0; Index < NumCapDesc; Index++, NextCap += DevCapDesc->Length) {
+    DevCapDesc = (USB_DEV_CAP_DESC  *)NextCap;
+    if ((DevCapDesc->DescriptorType == USB_BOS_DESC_TYPE_CAP) && (DevCapDesc->DevCapabilityType == USB_BOS_CAP_SS_USB)) {
+      return TRUE;
+    }
+  }
+
+  return FALSE;
+}
+
+/**
   Parse the configuration descriptor and its interfaces.
 
   @param  DescBuf               The buffer of raw descriptor.
@@ -340,6 +398,7 @@ UsbParseConfigDesc (
   UINTN                  Index;
   UINTN                  NumIf;
   UINTN                  Consumed;
+  UINT8                  FirstIntfNum = INTERFACE_NOT_SET;
 
   ASSERT (DescBuf != NULL);
 
@@ -394,10 +453,19 @@ UsbParseConfigDesc (
   while (Len >= sizeof (EFI_USB_INTERFACE_DESCRIPTOR)) {
     Setting = UsbParseInterfaceDesc (DescBuf, Len, &Consumed);
 
+    // Usb standard spec expects the interface number to start from 0.
+    // Some devices might have the first interface number not equal to zero.
+    // This is a work around for these devices. For example, Dell WWAN DW2811e
+    if (Setting != NULL) {
+      if (FirstIntfNum == INTERFACE_NOT_SET) {
+        FirstIntfNum = Setting->Desc.InterfaceNumber;
+      }
+    }
+
     if (Setting == NULL) {
       DEBUG ((DEBUG_ERROR, "UsbParseConfigDesc: warning: failed to get interface setting, stop parsing now.\n"));
       break;
-    } else if (Setting->Desc.InterfaceNumber >= NumIf) {
+    } else if (Setting->Desc.InterfaceNumber >= (NumIf + FirstIntfNum)) {
       DEBUG ((DEBUG_ERROR, "UsbParseConfigDesc: malformatted interface descriptor\n"));
 
       UsbFreeInterfaceDesc (Setting);
@@ -407,7 +475,7 @@ UsbParseConfigDesc (
     //
     // Insert the descriptor to the corresponding set.
     //
-    Interface = Config->Interfaces[Setting->Desc.InterfaceNumber];
+    Interface = Config->Interfaces[(Setting->Desc.InterfaceNumber - FirstIntfNum)];
 
     if (Interface->NumOfSetting >= USB_MAX_INTERFACE_SETTING) {
       goto ON_ERROR;
@@ -611,7 +679,82 @@ UsbGetDevDesc (
   if (EFI_ERROR (Status)) {
     gBS->FreePool (DevDesc);
   } else {
+    // Do DevDesc sanity check
+    if (  (DevDesc->Desc.DescriptorType != USB_DESC_TYPE_DEVICE)
+       || (DevDesc->Desc.Length != sizeof (EFI_USB_DEVICE_DESCRIPTOR))
+       || (  (UsbDev->Speed != EFI_USB_SPEED_SUPER)
+          && (DevDesc->Desc.MaxPacketSize0 != 8)
+          && (DevDesc->Desc.MaxPacketSize0 != 16)
+          && (DevDesc->Desc.MaxPacketSize0 != 32)
+          && (DevDesc->Desc.MaxPacketSize0 != 64))
+       || (DevDesc->Desc.NumConfigurations == 0))
+    {
+      gBS->FreePool (DevDesc);
+      Status = EFI_DEVICE_ERROR;
+      return Status;
+    }
+
     UsbDev->DevDesc = DevDesc;
+  }
+
+  return Status;
+}
+
+/**
+  Get the device BOS descriptor for the device.
+
+  @param  UsbDev                The Usb device to retrieve descriptor from.
+
+  @retval EFI_SUCCESS           The device descriptor is returned.
+  @retval EFI_OUT_OF_RESOURCES  Failed to allocate memory.
+
+**/
+EFI_STATUS
+UsbGetDevBOSDesc (
+  IN USB_DEVICE  *UsbDev
+  )
+{
+  UINT8       *Buf;
+  UINTN       TotalLength;
+  EFI_STATUS  Status;
+
+  Buf = AllocateZeroPool (sizeof (USB_BOS_DESC));
+  if (Buf == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  Status = UsbCtrlGetDesc (
+             UsbDev,
+             USB_DESC_TYPE_BOS,
+             0,
+             0,
+             Buf,
+             sizeof (USB_BOS_DESC)
+             );
+  if (!EFI_ERROR (Status)) {
+    TotalLength = ((USB_BOS_DESC *)Buf)->TotalLength;
+    gBS->FreePool (Buf);
+    Buf = NULL;
+    Buf = AllocateZeroPool (TotalLength);
+    if (Buf == NULL) {
+      return EFI_OUT_OF_RESOURCES;
+    }
+
+    Status = UsbCtrlGetDesc (
+               UsbDev,
+               USB_DESC_TYPE_BOS,
+               0,
+               0,
+               Buf,
+               TotalLength
+               );
+
+    if (EFI_ERROR (Status)) {
+      gBS->FreePool (Buf);
+      Buf = NULL;
+    }
+
+    UsbDev->DevDesc->BOSDesc = Buf;
   }
 
   return Status;
@@ -640,40 +783,89 @@ UsbGetOneString (
   EFI_STATUS                 Status;
   UINT8                      *Buf;
 
-  //
-  // First get two bytes which contains the string length.
-  //
-  Status = UsbCtrlGetDesc (UsbDev, USB_DESC_TYPE_STRING, Index, LangId, &Desc, 2);
+  EFI_USB_STRING_DESCRIPTOR  *CachedDesc = NULL;
 
   //
-  // Reject if Length even cannot cover itself, or odd because Unicode string byte length should be even.
+  //  If the String is cached and LangId = US, just return the cached string descriptor
   //
+  if ((LangId == USB_US_LANG_ID) && (Index > 0)) {
+    Buf = NULL;
+
+    if (Index == UsbDev->DevDesc->Desc.StrManufacturer) {
+      if (UsbDev->DevDesc->StrDescManufacturerUS != NULL) {
+        CachedDesc = (EFI_USB_STRING_DESCRIPTOR *)UsbDev->DevDesc->StrDescManufacturerUS;
+        Buf        = AllocateZeroPool (CachedDesc->Length);
+        CopyMem (Buf, (UINT8 *)CachedDesc, CachedDesc->Length);
+      }
+    } else if (Index == UsbDev->DevDesc->Desc.StrProduct) {
+      if (UsbDev->DevDesc->StrDescProductUS != NULL) {
+        CachedDesc = (EFI_USB_STRING_DESCRIPTOR *)UsbDev->DevDesc->StrDescProductUS;
+        Buf        = AllocateZeroPool (CachedDesc->Length);
+        CopyMem (Buf, (UINT8 *)CachedDesc, CachedDesc->Length);
+      }
+    } else if (Index == UsbDev->DevDesc->Desc.StrSerialNumber) {
+      if (UsbDev->DevDesc->StrDescSerialNumberUS != NULL) {
+        CachedDesc = (EFI_USB_STRING_DESCRIPTOR *)UsbDev->DevDesc->StrDescSerialNumberUS;
+        Buf        = AllocateZeroPool (CachedDesc->Length);
+        CopyMem (Buf, (UINT8 *)CachedDesc, CachedDesc->Length);
+      }
+    } else {
+      Buf = NULL;
+    }
+
+    if (Buf != NULL) {
+      return (EFI_USB_STRING_DESCRIPTOR *)Buf;
+    }
+  }
+
+  //
+  // Copy the mechanism from Linux Driver to get the better compatibility. see usb_string_sub.
+  //
+  Buf    = AllocateZeroPool (256);
+  Status = UsbCtrlGetDesc (UsbDev, USB_DESC_TYPE_STRING, Index, LangId, Buf, 255);
   if (EFI_ERROR (Status) ||
-      (Desc.Length < OFFSET_OF (EFI_USB_STRING_DESCRIPTOR, Length) + sizeof (Desc.Length)) ||
-      (Desc.Length % 2 != 0)
-      )
+      (((EFI_USB_STRING_DESCRIPTOR *)Buf)->Length < OFFSET_OF (EFI_USB_STRING_DESCRIPTOR, Length) + sizeof (((EFI_USB_STRING_DESCRIPTOR *)Buf)->Length)) ||
+      (((EFI_USB_STRING_DESCRIPTOR *)Buf)->Length % 2 != 0))
   {
-    return NULL;
-  }
-
-  Buf = AllocateZeroPool (Desc.Length);
-
-  if (Buf == NULL) {
-    return NULL;
-  }
-
-  Status = UsbCtrlGetDesc (
-             UsbDev,
-             USB_DESC_TYPE_STRING,
-             Index,
-             LangId,
-             Buf,
-             Desc.Length
-             );
-
-  if (EFI_ERROR (Status)) {
+    DEBUG ((EFI_D_ERROR, "UsbGetOneString: Get 255 bytes path failed, Status = %r\n", Status));
     FreePool (Buf);
-    return NULL;
+    Buf = NULL;
+
+    //
+    // First get two bytes which contains the string length.
+    //
+    Status = UsbCtrlGetDesc (UsbDev, USB_DESC_TYPE_STRING, Index, LangId, &Desc, 2);
+
+    //
+    // Reject if Length even cannot cover itself, or odd because Unicode string byte length should be even.
+    //
+    if (EFI_ERROR (Status) ||
+        (Desc.Length < OFFSET_OF (EFI_USB_STRING_DESCRIPTOR, Length) + sizeof (Desc.Length)) ||
+        (Desc.Length % 2 != 0)
+        )
+    {
+      return NULL;
+    }
+
+    Buf = AllocateZeroPool (Desc.Length);
+
+    if (Buf == NULL) {
+      return NULL;
+    }
+
+    Status = UsbCtrlGetDesc (
+               UsbDev,
+               USB_DESC_TYPE_STRING,
+               Index,
+               LangId,
+               Buf,
+               Desc.Length
+               );
+
+    if (EFI_ERROR (Status)) {
+      FreePool (Buf);
+      return NULL;
+    }
   }
 
   return (EFI_USB_STRING_DESCRIPTOR *)Buf;
@@ -725,6 +917,51 @@ UsbBuildLangTable (
 
   UsbDev->TotalLangId = (UINT16)Max;
 
+  //
+  // Some SMART Technologies key says that it supports LangId=0 only, but it
+  // responds to USB_US_LANG_ID (English). This is a workaround for all such keys.
+  //
+  if ((UsbDev->TotalLangId == 1) && (UsbDev->LangId[0] == 0)) {
+    UsbDev->LangId[0] = USB_US_LANG_ID;
+  }
+
+  //
+  // Some devices need to get the string immediately after SW get the first String descriptor
+  // for supported language.
+  //
+  gBS->FreePool (Desc);
+  Desc = NULL;
+  if (UsbDev->DevDesc->Desc.StrManufacturer != 0) {
+    Desc = UsbGetOneString (UsbDev, UsbDev->DevDesc->Desc.StrManufacturer, UsbDev->LangId[0]);
+    if (UsbDev->LangId[0] == USB_US_LANG_ID) {
+      UsbDev->DevDesc->StrDescManufacturerUS = (UINT8 *)Desc;
+    }
+
+    Desc = NULL;
+  }
+
+  if (UsbDev->DevDesc->Desc.StrProduct != 0) {
+    Desc = UsbGetOneString (UsbDev, UsbDev->DevDesc->Desc.StrProduct, UsbDev->LangId[0]);
+    if (UsbDev->LangId[0] == USB_US_LANG_ID) {
+      UsbDev->DevDesc->StrDescProductUS = (UINT8 *)Desc;
+    }
+
+    Desc = NULL;
+  }
+
+  if (UsbDev->DevDesc->Desc.StrSerialNumber != 0) {
+    Desc = UsbGetOneString (UsbDev, UsbDev->DevDesc->Desc.StrSerialNumber, UsbDev->LangId[0]);
+    if (UsbDev->LangId[0] == USB_US_LANG_ID) {
+      UsbDev->DevDesc->StrDescSerialNumberUS = (UINT8 *)Desc;
+    }
+
+    Desc = NULL;
+  }
+
+  if (Desc == NULL) {
+    return Status;
+  }
+
 ON_EXIT:
   gBS->FreePool (Desc);
   return Status;
@@ -751,12 +988,31 @@ UsbGetOneConfig (
   EFI_USB_CONFIG_DESCRIPTOR  Desc;
   EFI_STATUS                 Status;
   VOID                       *Buf;
+  UINT8                      BufDesc[USB_CONFIG_DESC_DEF_ALLOC_LEN];
 
   //
   // First get four bytes which contains the total length
   // for this configuration.
   //
-  Status = UsbCtrlGetDesc (UsbDev, USB_DESC_TYPE_CONFIG, Index, 0, &Desc, 8);
+  switch (UsbDev->EnumScript) {
+    case UsbEnumScriptWin:
+      ZeroMem (BufDesc, USB_CONFIG_DESC_DEF_ALLOC_LEN);
+      Status = UsbCtrlGetDesc (UsbDev, USB_DESC_TYPE_CONFIG, Index, 0, BufDesc, USB_CONFIG_DESC_DEF_ALLOC_LEN);
+      if (!EFI_ERROR (Status)) {
+        CopyMem (&Desc, BufDesc, sizeof (EFI_USB_CONFIG_DESCRIPTOR));
+      }
+
+      break;
+    case UsbEnumScriptLinux:
+      Status = UsbCtrlGetDesc (UsbDev, USB_DESC_TYPE_CONFIG, Index, 0, &Desc, sizeof (EFI_USB_CONFIG_DESCRIPTOR));
+      break;
+    case UsbEnumScriptRsrv:
+    case UsbEnumScriptEdk2:
+    case UsbEnumScriptUnknown:
+    default:
+      Status = UsbCtrlGetDesc (UsbDev, USB_DESC_TYPE_CONFIG, Index, 0, &Desc, 8);
+      break;
+  }
 
   if (EFI_ERROR (Status)) {
     DEBUG ((
@@ -784,13 +1040,17 @@ UsbGetOneConfig (
     return NULL;
   }
 
-  Status = UsbCtrlGetDesc (UsbDev, USB_DESC_TYPE_CONFIG, Index, 0, Buf, Desc.TotalLength);
+  if ((UsbDev->EnumScript == UsbEnumScriptWin) && (Desc.TotalLength <= USB_CONFIG_DESC_DEF_ALLOC_LEN)) {
+    CopyMem (Buf, BufDesc, Desc.TotalLength);
+  } else {
+    Status = UsbCtrlGetDesc (UsbDev, USB_DESC_TYPE_CONFIG, Index, 0, Buf, Desc.TotalLength);
 
-  if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "UsbGetOneConfig: failed to get full descript - %r\n", Status));
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "UsbGetOneConfig: failed to get full descript - %r\n", Status));
 
-    FreePool (Buf);
-    return NULL;
+      FreePool (Buf);
+      return NULL;
+    }
   }
 
   return Buf;
@@ -882,6 +1142,16 @@ UsbBuildDescTable (
     }
 
     DevDesc->Configs[Index] = ConfigDesc;
+  }
+
+  if (DevDesc->Desc.BcdUSB >= 0x210) {
+    Status = UsbGetDevBOSDesc (UsbDev);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((EFI_D_INFO, "UsbBuildDescTable: get BOS descriptor %r\n", Status));
+    } else {
+      UsbDev->IsSSDev = UsbIsSSDevice (UsbDev->DevDesc->BOSDesc, (UINTN)((USB_BOS_DESC *)(UsbDev->DevDesc->BOSDesc))->TotalLength);
+      DEBUG ((EFI_D_INFO, "UsbBuildDescTable: get BOS descriptor %r, UsbDev->IsSSDev = %d\n", Status, UsbDev->IsSSDev));
+    }
   }
 
   //

--- a/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbDesc.h
+++ b/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbDesc.h
@@ -69,7 +69,36 @@ typedef struct {
 typedef struct {
   EFI_USB_DEVICE_DESCRIPTOR    Desc;
   USB_CONFIG_DESC              **Configs;
+  UINT8                        *BOSDesc;
+  UINT8                        *StrDescManufacturerUS;
+  UINT8                        *StrDescProductUS;
+  UINT8                        *StrDescSerialNumberUS;
 } USB_DEVICE_DESC;
+
+#pragma pack(1)
+
+///
+/// Binary Device Object Store (BOS)
+/// USB 3.0 spec, Section 9.6.2
+///
+#define USB_DESC_TYPE_BOS      0x0F
+#define USB_BOS_DESC_TYPE_CAP  0x10
+#define USB_BOS_CAP_SS_USB     0x03
+typedef struct {
+  UINT8     Length;
+  UINT8     DescriptorType;
+  UINT16    TotalLength;
+  UINT8     NumDeviceCaps;
+} USB_BOS_DESC;
+
+typedef struct {
+  UINT8    Length;
+  UINT8    DescriptorType;
+  UINT8    DevCapabilityType;
+  UINT8    CapData[1];
+} USB_DEV_CAP_DESC;
+
+#pragma pack()
 
 /**
   USB standard control transfer support routine. This

--- a/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbEnumer.c
+++ b/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbEnumer.c
@@ -233,6 +233,8 @@ UsbCreateDevice (
   Device->ParentIf   = ParentIf;
   Device->ParentPort = ParentPort;
   Device->Tier       = (UINT8)(ParentIf->Device->Tier + 1);
+  Device->IsSSDev    = FALSE;
+  Device->EnumScript = 0;
   return Device;
 }
 
@@ -415,6 +417,19 @@ UsbSelectConfig (
     // the endpoint toggles to zero for its endpoints.
     //
     IfDesc = ConfigDesc->Interfaces[Index];
+
+    //
+    // Protect against hang. This is added to work around faulty device like Digidesign Mbox3 mini
+    //
+    if ((IfDesc == NULL) || (IfDesc->Settings[0] ==  NULL)) {
+      //
+      // If UsbCreateDesc() bailed on an interface or endpoint desc, don't try to
+      // configure that interface here.
+      //
+      DEBUG ((EFI_D_INFO, "UsbSelectConfig: Skipping uninitialized interface %d.\n", Index));
+      continue;
+    }
+
     UsbSelectSetting (IfDesc, IfDesc->Settings[0]->Desc.AlternateSetting);
 
     //
@@ -673,6 +688,7 @@ UsbEnumerateNewDev (
   UINTN                Address;
   UINT8                Config;
   EFI_STATUS           Status;
+  UINT8                RetryCount;
 
   Parent  = HubIf->Device;
   Bus     = Parent->Bus;
@@ -706,6 +722,9 @@ UsbEnumerateNewDev (
     return EFI_OUT_OF_RESOURCES;
   }
 
+  RetryCount = 3;
+
+DeviceRetry:
   //
   // OK, now identify the device speed. After reset, hub
   // fully knows the actual device speed.
@@ -717,9 +736,12 @@ UsbEnumerateNewDev (
     goto ON_ERROR;
   }
 
+  Child->EnumScript = RetryCount;
+
   if (!USB_BIT_IS_SET (PortState.PortStatus, USB_PORT_STAT_CONNECTION)) {
     DEBUG ((DEBUG_ERROR, "UsbEnumerateNewDev: No device present at port %d\n", Port));
-    Status = EFI_NOT_FOUND;
+    Status     = EFI_NOT_FOUND;
+    RetryCount = 0;
     goto ON_ERROR;
   } else if (USB_BIT_IS_SET (PortState.PortStatus, USB_PORT_STAT_SUPER_SPEED)) {
     Child->Speed      = EFI_USB_SPEED_SUPER;
@@ -773,17 +795,22 @@ UsbEnumerateNewDev (
   // ADDRESS state. Address zero is reserved for root hub.
   //
   ASSERT (Bus->MaxDevices <= 256);
-  for (Address = 1; Address < Bus->MaxDevices; Address++) {
-    if (Bus->Devices[Address] == NULL) {
-      break;
+  if (Child->Address == 0) {
+    for (Address = 1; Address < Bus->MaxDevices; Address++) {
+      if (Bus->Devices[Address] == NULL) {
+        break;
+      }
     }
-  }
 
-  if (Address >= Bus->MaxDevices) {
-    DEBUG ((DEBUG_ERROR, "UsbEnumerateNewDev: address pool is full for port %d\n", Port));
+    if (Address >= Bus->MaxDevices) {
+      DEBUG ((DEBUG_ERROR, "UsbEnumerateNewDev: address pool is full for port %d\n", Port));
 
-    Status = EFI_ACCESS_DENIED;
-    goto ON_ERROR;
+      Status = EFI_ACCESS_DENIED;
+      goto ON_ERROR;
+    }
+  } else {
+    Address        = Child->Address;
+    Child->Address = 0;
   }
 
   Status                = UsbSetAddress (Child, (UINT8)Address);
@@ -823,6 +850,18 @@ UsbEnumerateNewDev (
     goto ON_ERROR;
   }
 
+  // Below code is ensuring the device can be executed with SS.
+  // Some device FW might execute with SS later but it would produce failure if the device is already enumerated with HS.
+  if (  (RetryCount > 0)
+     && (Bus->Usb2Hc != NULL)
+     && (Bus->Usb2Hc->MajorRevision >= 0x3)
+     && (Child->IsSSDev)
+     && (Child->Speed < EFI_USB_SPEED_SUPER)
+     && (Child->DevDesc->Desc.DeviceClass != USB_HUB_CLASS_CODE))
+  {
+    goto ON_ERROR;
+  }
+
   //
   // Select a default configuration: UEFI must set the configuration
   // before the driver can connect to the device.
@@ -858,6 +897,30 @@ UsbEnumerateNewDev (
   return EFI_SUCCESS;
 
 ON_ERROR:
+  //
+  // Do the error handling with retry counter.
+  //
+  Status = HubApi->GetPortStatus (HubIf, Port, &PortState);
+  if (EFI_ERROR (Status) || (!USB_BIT_IS_SET (PortState.PortStatus, USB_PORT_STAT_CONNECTION))) {
+    DEBUG ((DEBUG_ERROR, "Device is gone. Don't reset the port\n"));
+    Status = EFI_NOT_FOUND;
+  }
+
+  if (!EFI_ERROR (Status) && (RetryCount > 0)) {
+    RetryCount--;
+    DEBUG ((DEBUG_INFO, "Reset the port due to Error\n"));
+    if ((Child != NULL) && (Child->DevDesc != NULL)) {
+      UsbFreeDevDesc (Child->DevDesc);
+      Child->DevDesc = NULL;
+    }
+
+    Status = HubApi->ResetPort (HubIf, Port);
+    if (!EFI_ERROR (Status)) {
+      gBS->Stall (USB_WAIT_PORT_STABLE_STALL);
+      goto DeviceRetry;
+    }
+  }
+
   //
   // If reach here, it means the enumeration process on a given port is interrupted due to error.
   // The s/w resources, including the assigned address(Address) and the allocated usb device data

--- a/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbUtility.c
+++ b/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbUtility.c
@@ -1036,6 +1036,7 @@ UsbBusRecursivelyConnectWantedUsbIo (
   UINTN                     UsbIoHandleCount;
   EFI_HANDLE                *UsbIoBuffer;
   EFI_DEVICE_PATH_PROTOCOL  *UsbIoDevicePath;
+  EFI_TPL                   Tpl;
 
   if (UsbBusId == NULL) {
     return EFI_INVALID_PARAMETER;
@@ -1094,9 +1095,17 @@ UsbBusRecursivelyConnectWantedUsbIo (
         // Recursively connect the wanted Usb Io handle
         //
         DEBUG ((DEBUG_INFO, "UsbBusRecursivelyConnectWantedUsbIo: TPL before connect is %d\n", (UINT32)UsbGetCurrentTpl ()));
+        Tpl = UsbGetCurrentTpl ();
+        if (Tpl < TPL_CALLBACK) {
+          Tpl = gBS->RaiseTPL (TPL_CALLBACK);
+        }
+
         Status           = gBS->ConnectController (UsbIf->Handle, NULL, NULL, TRUE);
         UsbIf->IsManaged = (BOOLEAN) !EFI_ERROR (Status);
         DEBUG ((DEBUG_INFO, "UsbBusRecursivelyConnectWantedUsbIo: TPL after connect is %d\n", (UINT32)UsbGetCurrentTpl ()));
+        if (Tpl < TPL_CALLBACK) {
+          gBS->RestoreTPL (Tpl);
+        }
       }
     }
   }


### PR DESCRIPTION
This patch enhances the USB enumeration process in EDK2 to improve compatibility with non-standards-compliant devices that may fail during standard enumeration sequences. The solution is based on USB specifications and references implementations from both Linux and Windows environments.

[Suggested Solution]
Enumeration Script Optimization:
Integrated a retry mechanism to sequentially execute enumeration scripts, inspired by the enumeration flows of Windows, Linux, and EDK2. This improves robustness when handling edge-case devices.

BOS Descriptor Check for SuperSpeed Devices:
Some SuperSpeed-capable devices may fall back to High-Speed mode and cause subsequent commands to fail. We now check the BOS descriptor to verify SuperSpeed support and trigger a port reset if needed to re-enumerate the device properly.

Manufacturer String Descriptor Caching:
Certain devices require immediate follow-up commands after reading the LANGID string to fetch Manufacturer, Product, or SerialNumber strings. These strings are now cached after initial retrieval to allow UsbIoGetStringDescriptor() to return them directly, improving efficiency and stability.

TPL Handling in UsbBusRecursivelyConnectWantedUsbIo: Refactored to adopt the TPL handling mechanism from UsbConnectDriver, enabling ConnectController() to operate correctly at TPL_CALLBACK level for safer driver connection.
