### PR TITLE
BaseTools/GenFW: RISC-V: Detect Zicfilp extension

### DIFF
--- a/BaseTools/Source/C/GenFw/Elf64Convert.c
+++ b/BaseTools/Source/C/GenFw/Elf64Convert.c
@@ -802,6 +802,11 @@ ParseNoteSection (
       Prop2 = GNU_PROPERTY_X86_FEATURE_1_IBT;
       break;
 
+    case EM_RISCV64:
+      Prop0 = GNU_PROPERTY_RISCV64_FEATURE_1_AND;
+      Prop2 = GNU_PROPERTY_RISCV64_FEATURE_1_FCFI;
+      break;
+
     default:
       return;
     }

--- a/BaseTools/Source/C/GenFw/elf_common.h
+++ b/BaseTools/Source/C/GenFw/elf_common.h
@@ -68,6 +68,9 @@ typedef struct {
 #define GNU_PROPERTY_AARCH64_FEATURE_1_BTI  0x1
 #define GNU_PROPERTY_AARCH64_FEATURE_1_PAC  0x2
 
+#define GNU_PROPERTY_RISCV64_FEATURE_1_AND   0xc0000000
+#define GNU_PROPERTY_RISCV64_FEATURE_1_FCFI  0x1 /* zicfilp */
+
 /* Indexes into the e_ident array.  Keep synced with
    http://www.sco.com/developers/gabi/latest/ch4.eheader.html */
 #define EI_MAG0    0  /* Magic number, byte 0. */


### PR DESCRIPTION
# Description

Parse the ELF file for RISC-V Zicfilp extension support to identify forward control flow integrity (FCFI) features.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

Confirm EFI_MEMORY_ATTRIBUTES_FLAGS_RT_FORWARD_CONTROL_FLOW_GUARD bit set when EDK2 FW built with Zicfilp support by adding flag to GCC 14: "-match=rv64gc_zicfiss_zicfilp -fcf-protection=branch"

## Integration Instructions

N/A