### PR TITLE
ArmVirtPkg/ArmVirtQemu: Add support for Memory Debug Logging

### DIFF
--- a/ArmVirtPkg/ArmVirt.dsc.inc
+++ b/ArmVirtPkg/ArmVirt.dsc.inc
@@ -47,6 +47,11 @@
   DebugLib|ArmVirtPkg/Library/DebugLibFdtPL011Uart/DebugLibFdtPL011UartRam.inf
 !endif
   DebugPrintErrorLevelLib|MdePkg/Library/BaseDebugPrintErrorLevelLib/BaseDebugPrintErrorLevelLib.inf
+!if $(DEBUG_TO_MEM)
+  MemDebugLogLib|OvmfPkg/Library/MemDebugLogLib/MemDebugLogDxeLib.inf
+!else
+  MemDebugLogLib|OvmfPkg/Library/MemDebugLogLib/MemDebugLogLibNull.inf
+!endif
 
   BaseLib|MdePkg/Library/BaseLib/BaseLib.inf
   SafeIntLib|MdePkg/Library/BaseSafeIntLib/BaseSafeIntLib.inf
@@ -191,6 +196,9 @@
 !if $(TARGET) != RELEASE
   DebugLib|ArmVirtPkg/Library/DebugLibFdtPL011Uart/DebugLibFdtPL011UartFlash.inf
 !endif
+!if $(DEBUG_TO_MEM)
+  MemDebugLogLib|OvmfPkg/Library/MemDebugLogLib/MemDebugLogLibNull.inf
+!endif
 
 [LibraryClasses.common.PEI_CORE]
   PcdLib|MdePkg/Library/PeiPcdLib/PeiPcdLib.inf
@@ -209,6 +217,9 @@
 !if $(TARGET) != RELEASE
   DebugLib|ArmVirtPkg/Library/DebugLibFdtPL011Uart/DebugLibFdtPL011UartFlash.inf
 !endif
+!if $(DEBUG_TO_MEM)
+  MemDebugLogLib|OvmfPkg/Library/MemDebugLogLib/MemDebugLogPeiCoreLib.inf
+!endif
 
 [LibraryClasses.common.PEIM]
   PcdLib|MdePkg/Library/PeiPcdLib/PeiPcdLib.inf
@@ -226,6 +237,9 @@
   SerialPortLib|ArmVirtPkg/Library/FdtPL011SerialPortLib/EarlyFdtPL011SerialPortLib.inf
 !if $(TARGET) != RELEASE
   DebugLib|ArmVirtPkg/Library/DebugLibFdtPL011Uart/DebugLibFdtPL011UartFlash.inf
+!endif
+!if $(DEBUG_TO_MEM)
+  MemDebugLogLib|OvmfPkg/Library/MemDebugLogLib/MemDebugLogPeiLib.inf
 !endif
 
 [LibraryClasses.common.UEFI_DRIVER]
@@ -258,6 +272,9 @@
   CapsuleLib|MdeModulePkg/Library/DxeCapsuleLibNull/DxeCapsuleLibNull.inf
 !if $(TARGET) != RELEASE
   DebugLib|ArmVirtPkg/Library/DebugLibFdtPL011Uart/DxeRuntimeDebugLibFdtPL011Uart.inf
+!endif
+!if $(DEBUG_TO_MEM)
+  MemDebugLogLib|OvmfPkg/Library/MemDebugLogLib/MemDebugLogRtLib.inf
 !endif
   VariablePolicyLib|MdeModulePkg/Library/VariablePolicyLib/VariablePolicyLibRuntimeDxe.inf
 

--- a/ArmVirtPkg/ArmVirtQemu.dsc
+++ b/ArmVirtPkg/ArmVirtQemu.dsc
@@ -345,6 +345,9 @@
   #
   ArmPlatformPkg/Sec/Sec.inf
   MdeModulePkg/Core/Pei/PeiMain.inf
+!if $(DEBUG_TO_MEM)
+  OvmfPkg/MemDebugLogPei/MemDebugLogPei.inf
+!endif
   ArmPlatformPkg/PlatformPei/PlatformPeim.inf
   ArmVirtPkg/MemoryInitPei/MemoryInitPeim.inf
   ArmPkg/Drivers/CpuPei/CpuPei.inf
@@ -383,6 +386,9 @@
   MdeModulePkg/Universal/PCD/Dxe/Pcd.inf {
     <LibraryClasses>
       PcdLib|MdePkg/Library/BasePcdLibNull/BasePcdLibNull.inf
+!if $(DEBUG_TO_MEM)
+      MemDebugLogLib|OvmfPkg/Library/MemDebugLogLib/MemDebugLogLibNull.inf
+!endif
   }
 
   #
@@ -490,6 +496,9 @@
     <LibraryClasses>
       DevicePathLib|MdePkg/Library/UefiDevicePathLib/UefiDevicePathLib.inf
       PcdLib|MdePkg/Library/BasePcdLibNull/BasePcdLibNull.inf
+!if $(DEBUG_TO_MEM)
+      MemDebugLogLib|OvmfPkg/Library/MemDebugLogLib/MemDebugLogLibNull.inf
+!endif
   }
   MdeModulePkg/Universal/DisplayEngineDxe/DisplayEngineDxe.inf
   MdeModulePkg/Universal/SetupBrowserDxe/SetupBrowserDxe.inf

--- a/ArmVirtPkg/ArmVirtQemu.fdf
+++ b/ArmVirtPkg/ArmVirtQemu.fdf
@@ -106,6 +106,9 @@ READ_LOCK_STATUS   = TRUE
 
   INF ArmPlatformPkg/Sec/Sec.inf
   INF MdeModulePkg/Core/Pei/PeiMain.inf
+!if $(DEBUG_TO_MEM)
+INF  OvmfPkg/MemDebugLogPei/MemDebugLogPei.inf
+!endif
   INF ArmPlatformPkg/PlatformPei/PlatformPeim.inf
   INF ArmVirtPkg/MemoryInitPei/MemoryInitPeim.inf
   INF ArmPkg/Drivers/CpuPei/CpuPei.inf

--- a/ArmVirtPkg/Library/DebugLibFdtPL011Uart/DebugLib.c
+++ b/ArmVirtPkg/Library/DebugLibFdtPL011Uart/DebugLib.c
@@ -24,6 +24,7 @@
 #include <Library/PcdLib.h>
 #include <Library/BaseMemoryLib.h>
 #include <Library/DebugPrintErrorLevelLib.h>
+#include <Library/MemDebugLogLib.h>
 
 #include "Write.h"
 
@@ -120,6 +121,13 @@ DebugPrintMarker (
   // Send the print string to a Serial Port
   //
   DebugLibFdtPL011UartWrite ((UINT8 *)Buffer, AsciiStrLen (Buffer));
+
+  //
+  // Send string to Memory Debug Log if enabled
+  //
+  if (MemDebugLogEnabled ()) {
+    MemDebugLogWrite ((CHAR8 *)Buffer, AsciiStrLen (Buffer));
+  }
 }
 
 /**
@@ -216,6 +224,13 @@ DebugAssert (
   // Send the print string to the Console Output device
   //
   DebugLibFdtPL011UartWrite ((UINT8 *)Buffer, AsciiStrLen (Buffer));
+
+  //
+  // Send the string to Memory Debug Log
+  //
+  if (MemDebugLogEnabled ()) {
+    MemDebugLogWrite ((CHAR8 *)Buffer, AsciiStrLen (Buffer));
+  }
 
   //
   // Generate a Breakpoint, DeadLoop, or NOP based on PCD settings

--- a/ArmVirtPkg/Library/DebugLibFdtPL011Uart/DebugLibFdtPL011UartFlash.inf
+++ b/ArmVirtPkg/Library/DebugLibFdtPL011Uart/DebugLibFdtPL011UartFlash.inf
@@ -40,6 +40,7 @@
   PL011UartLib
   PcdLib
   PrintLib
+  MemDebugLogLib
 
 [Pcd]
   gUefiOvmfPkgTokenSpaceGuid.PcdDeviceTreeInitialBaseAddress # Flash.c

--- a/ArmVirtPkg/Library/DebugLibFdtPL011Uart/DebugLibFdtPL011UartRam.inf
+++ b/ArmVirtPkg/Library/DebugLibFdtPL011Uart/DebugLibFdtPL011UartRam.inf
@@ -34,6 +34,7 @@
   ArmPlatformPkg/ArmPlatformPkg.dec
   ArmVirtPkg/ArmVirtPkg.dec
   MdePkg/MdePkg.dec
+  OvmfPkg/OvmfPkg.dec
 
 [LibraryClasses]
   BaseLib
@@ -43,6 +44,7 @@
   PL011UartLib
   PcdLib
   PrintLib
+  MemDebugLogLib
 
 [Pcd]
   gEfiMdePkgTokenSpaceGuid.PcdDebugClearMemoryValue

--- a/ArmVirtPkg/Library/DebugLibFdtPL011Uart/DxeRuntimeDebugLibFdtPL011Uart.inf
+++ b/ArmVirtPkg/Library/DebugLibFdtPL011Uart/DxeRuntimeDebugLibFdtPL011Uart.inf
@@ -35,6 +35,7 @@
   ArmPlatformPkg/ArmPlatformPkg.dec
   ArmVirtPkg/ArmVirtPkg.dec
   MdePkg/MdePkg.dec
+  OvmfPkg/OvmfPkg.dec
 
 [LibraryClasses]
   BaseLib
@@ -44,6 +45,7 @@
   PL011UartLib
   PcdLib
   PrintLib
+  MemDebugLogLib
 
 [Pcd]
   gEfiMdePkgTokenSpaceGuid.PcdDebugClearMemoryValue

--- a/OvmfPkg/Library/MemDebugLogLib/MemDebugLogPeiCore.c
+++ b/OvmfPkg/Library/MemDebugLogLib/MemDebugLogPeiCore.c
@@ -11,8 +11,6 @@
 #include <Library/PeiServicesLib.h>
 #include <Library/MemDebugLogLib.h>
 
-EFI_PHYSICAL_ADDRESS  mMemDebugLogBufAddr;
-BOOLEAN               mMemDebugLogBufAddrInit;
 
 EFI_STATUS
 EFIAPI
@@ -21,23 +19,20 @@ MemDebugLogWrite (
   IN  UINTN  Length
   )
 {
-  EFI_STATUS  Status;
+  EFI_PHYSICAL_ADDRESS  MemDebugLogBufAddr;
+  EFI_STATUS            Status;
 
-  if (!mMemDebugLogBufAddrInit) {
-    //
-    // Obtain the Memory Debug Log buffer addr from HOB
-    // NOTE: This is expected to fail until the HOB is created.
-    //
-    Status = MemDebugLogAddrFromHOB (&mMemDebugLogBufAddr);
-    if (EFI_ERROR (Status)) {
-      mMemDebugLogBufAddr = 0;
-    } else {
-      mMemDebugLogBufAddrInit = TRUE;
-    }
+  //
+  // Obtain the Memory Debug Log buffer addr from HOB
+  // NOTE: This is expected to fail until the HOB is created.
+  //
+  Status = MemDebugLogAddrFromHOB (&MemDebugLogBufAddr);
+  if (EFI_ERROR (Status)) {
+    MemDebugLogBufAddr = 0;
   }
 
-  if (mMemDebugLogBufAddr) {
-    Status = MemDebugLogWriteBuffer (mMemDebugLogBufAddr, Buffer, Length);
+  if (MemDebugLogBufAddr) {
+    Status = MemDebugLogWriteBuffer (MemDebugLogBufAddr, Buffer, Length);
   } else {
     //
     // HOB has not yet been created, so


### PR DESCRIPTION
# Description

Memory Debug Logging was recently added to OVMF. Extend the feature to the ArmVirtQemu build via the following changes:

1. Add MemDebugLogPei PEIM and MemDebugLogLib library to the ArmVirtQemu build files - optionally enabled with the -D DEBUG_TO_MEM build option.
2. Add call to MemDebugLogWrite() to DebugLibFdtPL011Uart DebugLib library used by the ArmVirtQemu build.
3. It seems that FwCfg is not supported in PEI phase with ArmVirtQemu, thus #ifdef out support for opt/ovmf/MemDebugLogPages FwCfg option - which allows the configurable size of the memory debug log buffer. The PCD must be used to specify the size.
4. Since global variables are not allowed in PEI on AARCH64, remove the global variables optimizations in PEI_CORE/PEI versions of MemDebugLogLib.

NOTE: An "early" debug log buffer is not used (as is used with OVMF) to capture very early PEI and SEC phase debug messages. Thus only messages which happen after memory becomes available in PEI phase are are included in the memory debug message buffer with the ArmVirtQemu build. This should be sufficient most debug situations.

Cc: Gerd Hoffmann <kraxel@redhat.com>
Cc: Ard Biesheuvel <ardb+tianocore@kernel.org>
Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Sami Mujawar <sami.mujawar@arm.com>
Cc: Leif Lindholm <leif.lindholm@oss.qualcomm.com>


- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested
ArmVirtQemu build was tested with the -D DEBUG_TO_MEM build option which produced
Memory Debug Log memory buffer containing debug messages.

## Integration Instructions

N/A
