### PR TITLE
Pr 11293

### DIFF
--- a/ArmPlatformPkg/Library/PL011SerialPortLib/PL011SerialPortLib.c
+++ b/ArmPlatformPkg/Library/PL011SerialPortLib/PL011SerialPortLib.c
@@ -37,11 +37,11 @@ SerialPortInitialize (
   EFI_STATUS          Status;
   UINT8               Scratch;
 
-  BaudRate         = FixedPcdGet64 (PcdUartDefaultBaudRate);
+  BaudRate         = PcdGet64 (PcdUartDefaultBaudRate);
   ReceiveFifoDepth = 0;         // Use default FIFO depth
-  Parity           = (EFI_PARITY_TYPE)FixedPcdGet8 (PcdUartDefaultParity);
-  DataBits         = FixedPcdGet8 (PcdUartDefaultDataBits);
-  StopBits         = (EFI_STOP_BITS_TYPE)FixedPcdGet8 (PcdUartDefaultStopBits);
+  Parity           = (EFI_PARITY_TYPE)PcdGet8 (PcdUartDefaultParity);
+  DataBits         = PcdGet8 (PcdUartDefaultDataBits);
+  StopBits         = (EFI_STOP_BITS_TYPE)PcdGet8 (PcdUartDefaultStopBits);
 
   Status = PL011UartInitializePort (
              (UINTN)PcdGet64 (PcdSerialRegisterBase),

--- a/ArmPlatformPkg/Library/PL011SerialPortLib/PL011SerialPortLib.inf
+++ b/ArmPlatformPkg/Library/PL011SerialPortLib/PL011SerialPortLib.inf
@@ -33,7 +33,7 @@
 [Pcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdSerialRegisterBase
 
-[FixedPcd]
+[Pcd]
   gEfiMdePkgTokenSpaceGuid.PcdUartDefaultBaudRate
   gEfiMdePkgTokenSpaceGuid.PcdUartDefaultDataBits
   gEfiMdePkgTokenSpaceGuid.PcdUartDefaultParity

--- a/ArmPlatformPkg/Library/PL011UartLib/PL011UartLib.c
+++ b/ArmPlatformPkg/Library/PL011UartLib/PL011UartLib.c
@@ -193,7 +193,7 @@ PL011UartInitializePort (
       return RETURN_INVALID_PARAMETER;
     }
 
-    Divisor    = (UartClkInHz * 4) / *BaudRate;
+    Divisor    = (UINT32)((UartClkInHz * 4) / *BaudRate);
     Integer    = Divisor >> FRACTION_PART_SIZE_IN_BITS;
     Fractional = Divisor & FRACTION_PART_MASK;
   }


### PR DESCRIPTION
# Description

1.ArmPlatformPkg/PL011SerialPortLib : Changing the PCD type to support dynamic.

Convert UART configuration PCDs from FixedPcd to dynamic Pcd to enable
runtime modification of serial port parameters.

Changes made:

Replace FixedPcdGet64/FixedPcdGet8 calls with PcdGet64/PcdGet8 for:
PcdUartDefaultBaudRate
PcdUartDefaultParity
PcdUartDefaultDataBits
PcdUartDefaultStopBits
Update INF file to declare these PCDs under [Pcd] section instead of [FixedPcd]

2.ArmPlatformPkg/PL011UartLib : Data loss when converting from UINT64 to UINT32.

Add an explicit (UINT32) cast to the assignment.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Tested with internal platform and it is working

## Integration Instructions

N\A
