### PR TITLE
MdeModulePkg: Fix wide characters can not display issue.

### DIFF
--- a/MdeModulePkg/Library/CustomizedDisplayLib/CustomizedDisplayLibInternal.c
+++ b/MdeModulePkg/Library/CustomizedDisplayLib/CustomizedDisplayLibInternal.c
@@ -3,6 +3,7 @@
   This library class defines a set of interfaces to customize Display module
 
 Copyright (c) 2013-2018, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2025, Loongson Technology Corporation Limited. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -859,10 +860,7 @@ PrintInternal (
   )
 {
   CHAR16  *Buffer;
-  CHAR16  *BackupBuffer;
   UINTN   Index;
-  UINTN   PreviousIndex;
-  UINTN   Count;
   UINTN   TotalCount;
   UINTN   PrintWidth;
   UINTN   CharWidth;
@@ -870,10 +868,8 @@ PrintInternal (
   //
   // For now, allocate an arbitrarily long buffer
   //
-  Buffer       = AllocateZeroPool (0x10000);
-  BackupBuffer = AllocateZeroPool (0x10000);
+  Buffer = AllocateZeroPool (0x10000);
   ASSERT (Buffer);
-  ASSERT (BackupBuffer);
 
   if (Column != (UINTN)-1) {
     Out->SetCursorPosition (Out, Column, Row);
@@ -884,73 +880,42 @@ PrintInternal (
   Out->Mode->Attribute = Out->Mode->Attribute & 0x7f;
 
   Out->SetAttribute (Out, Out->Mode->Attribute);
+  Out->OutputString (Out, Buffer);
 
-  Index         = 0;
-  PreviousIndex = 0;
-  Count         = 0;
-  TotalCount    = 0;
-  PrintWidth    = 0;
-  CharWidth     = 1;
+  Index      = 0;
+  TotalCount = 0;
+  PrintWidth = 0;
+  CharWidth  = 1;
 
   do {
-    for ( ; (Buffer[Index] != NARROW_CHAR) && (Buffer[Index] != WIDE_CHAR) && (Buffer[Index] != 0); Index++) {
-      BackupBuffer[Index] = Buffer[Index];
-    }
-
     if (Buffer[Index] == 0) {
       break;
     }
 
-    //
-    // Print this out, we are about to switch widths
-    //
-    Out->OutputString (Out, &BackupBuffer[PreviousIndex]);
-    Count       = StrLen (&BackupBuffer[PreviousIndex]);
-    PrintWidth += Count * CharWidth;
-    TotalCount += Count;
-
-    //
-    // Preserve the current index + 1, since this is where we will start printing from next
-    //
-    PreviousIndex = Index + 1;
-
-    //
-    // We are at a narrow or wide character directive.  Set attributes and strip it and print it
-    //
-    if (Buffer[Index] == NARROW_CHAR) {
-      //
-      // Preserve bits 0 - 6 and zero out the rest
-      //
-      Out->Mode->Attribute = Out->Mode->Attribute & 0x7f;
-      Out->SetAttribute (Out, Out->Mode->Attribute);
-      CharWidth = 1;
-    } else {
-      //
-      // Must be wide, set bit 7 ON
-      //
-      Out->Mode->Attribute = Out->Mode->Attribute | EFI_WIDE_ATTRIBUTE;
-      Out->SetAttribute (Out, Out->Mode->Attribute);
-      CharWidth = 2;
+    switch (Buffer[Index]) {
+      case NARROW_CHAR:
+        CharWidth = 1;
+        break;
+      case WIDE_CHAR:
+        CharWidth = 2;
+        break;
+      default:
+        PrintWidth += CharWidth;
+        TotalCount += 1;
+        break;
     }
 
     Index++;
   } while (Buffer[Index] != 0);
 
   //
-  // We hit the end of the string - print it
+  // We hit the end of the string - fill remaining space with SPACE.
   //
-  Out->OutputString (Out, &BackupBuffer[PreviousIndex]);
-  Count       = StrLen (&BackupBuffer[PreviousIndex]);
-  PrintWidth += Count * CharWidth;
-  TotalCount += Count;
   if (PrintWidth < Width) {
-    Out->Mode->Attribute = Out->Mode->Attribute & 0x7f;
-    Out->SetAttribute (Out, Out->Mode->Attribute);
     Out->OutputString (Out, &mSpaceBuffer[SPACE_BUFFER_SIZE - Width + PrintWidth]);
   }
 
   FreePool (Buffer);
-  FreePool (BackupBuffer);
   return TotalCount;
 }
 

--- a/MdeModulePkg/Universal/Console/GraphicsConsoleDxe/GraphicsConsole.c
+++ b/MdeModulePkg/Universal/Console/GraphicsConsoleDxe/GraphicsConsole.c
@@ -2,6 +2,7 @@
   This is the main routine for initializing the Graphics Console support routines.
 
 Copyright (c) 2006 - 2022, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2025, Loongson Technology Corporation Limited. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -1095,6 +1096,14 @@ GraphicsConsoleConOutTestString (
   Count = 0;
 
   while (WString[Count] != 0) {
+    //
+    // In TerminalConOutOutputString(), WIDE_CHAR/NARROW_CHAR will be ignored.
+    // So, WString contains WIDE_CHAR/NARROW_CHAR is also valid.
+    //
+    if ((WString[Count] == WIDE_CHAR) || (WString[Count] == NARROW_CHAR)) {
+      continue;
+    }
+
     Status = mHiiFont->GetGlyph (
                          mHiiFont,
                          WString[Count],

--- a/MdeModulePkg/Universal/Console/TerminalDxe/Terminal.h
+++ b/MdeModulePkg/Universal/Console/TerminalDxe/Terminal.h
@@ -4,6 +4,7 @@
 Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.<BR>
 Copyright (c) 2006 - 2019, Intel Corporation. All rights reserved.<BR>
 Copyright (C) 2016 Silicon Graphics, Inc. All rights reserved.<BR>
+Copyright (c) 2025, Loongson Technology Corporation Limited. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -17,6 +18,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Guid/PcAnsi.h>
 #include <Guid/TtyTerm.h>
 #include <Guid/StatusCodeDataTypeVariable.h>
+#include <Guid/MdeModuleHii.h>
 
 #include <Protocol/SimpleTextOut.h>
 #include <Protocol/SerialIo.h>

--- a/MdeModulePkg/Universal/Console/TerminalDxe/TerminalConOut.c
+++ b/MdeModulePkg/Universal/Console/TerminalDxe/TerminalConOut.c
@@ -4,6 +4,7 @@
 Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.<BR>
 Copyright (c) 2006 - 2018, Intel Corporation. All rights reserved.<BR>
 Copyright (C) 2016 Silicon Graphics, Inc. All rights reserved.<BR>
+Copyright (c) 2025, Loongson Technology Corporation Limited. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -216,6 +217,13 @@ TerminalConOutOutputString (
           );
 
   for ( ; *WString != CHAR_NULL; WString++) {
+    //
+    // Skip WIDE_CHAR/NARROW_CHAR, because they are not displayable.
+    //
+    if ((*WString == WIDE_CHAR) || (*WString == NARROW_CHAR)) {
+      continue;
+    }
+
     switch (TerminalDevice->TerminalType) {
       case TerminalTypePcAnsi:
       case TerminalTypeVt100:


### PR DESCRIPTION
Issue link: https://github.com/tianocore/edk2/issues/11299

According to UEFI Spec, only Bit0...6 is valid in mode attribute, other bits are undefined and must be 0. So attribute with EFI_WIDE_ATTRIBUTE is unacceptable as EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL.SetAttribute() input parameter. In current PrintInternal function, wide character removed WIDE_CHAR, and is used as EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL.OutputString() input parameter. So, wide character is mistakenly be treated as narrow character.

Because EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL.OutputString() can handle unicode string with NARROW_CHAR and WIDE_CHAR, we can directly invoke OutputString() with whole unicode string instead of separated wide/narrow string. And then, the logic of computing unicode string width is also simplified.

By the way, fix TestString() to be compatible with wide/narrow string in GraphicsConsole driver and fix OutputString() to skip wide/narrow char in TerminalDxe.