### PR TITLE
Maintainers.txt: Update reviewer for OvmfPkg/Confidential Computing

### DIFF
--- a/Maintainers.txt
+++ b/Maintainers.txt
@@ -514,7 +514,7 @@ F: OvmfPkg/ResetVector/
 F: OvmfPkg/Sec/
 R: Erdem Aktas <erdemaktas@google.com> [ruleof2]
 R: Jiewen Yao <jiewen.yao@intel.com> [jyao1]
-R: Min Xu <min.m.xu@intel.com> [mxu9]
+R: Stanislaw Grams <stanislaw.grams@intel.com> [sgrams]
 R: Tom Lendacky <thomas.lendacky@amd.com> [tlendacky]
 R: Michael Roth <michael.roth@amd.com> [mdroth]
 


### PR DESCRIPTION
# Description
Stanislaw Grams replaces Min Xu as the reviewer for patches to OvmfPkg/Confidential Computing