### PR TITLE
NetworkPkg: CodeQL Fixes 

### DIFF
--- a/NetworkPkg/Application/VConfig/VConfig.c
+++ b/NetworkPkg/Application/VConfig/VConfig.c
@@ -651,18 +651,40 @@ VlanConfigMain (
 
   if (ShellCommandLineGetFlag (List, L"-l")) {
     Str = ShellCommandLineGetValue (List, L"-l");
+    // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+    if (Str == NULL) {
+      ShellPrintHiiEx (-1, -1, NULL, STRING_TOKEN (STR_VCONFIG_NO_IF), mHiiHandle);
+      goto Exit;
+    }
+
+    // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
     DisplayVlan ((CHAR16 *)Str);
     goto Exit;
   }
 
   if (ShellCommandLineGetFlag (List, L"-a")) {
     Str = ShellCommandLineGetValue (List, L"-a");
+    // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+    if (Str == NULL) {
+      ShellPrintHiiEx (-1, -1, NULL, STRING_TOKEN (STR_VCONFIG_NO_IF), mHiiHandle);
+      goto Exit;
+    }
+
+    // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
     AddVlan ((CHAR16 *)Str);
+
     goto Exit;
   }
 
   if (ShellCommandLineGetFlag (List, L"-d")) {
     Str = ShellCommandLineGetValue (List, L"-d");
+    // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+    if (Str == NULL) {
+      ShellPrintHiiEx (-1, -1, NULL, STRING_TOKEN (STR_VCONFIG_NO_IF), mHiiHandle);
+      goto Exit;
+    }
+
+    // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
     DeleteVlan ((CHAR16 *)Str);
     goto Exit;
   }

--- a/NetworkPkg/Dhcp4Dxe/Dhcp4Impl.c
+++ b/NetworkPkg/Dhcp4Dxe/Dhcp4Impl.c
@@ -1359,7 +1359,13 @@ PxeDhcpInput (
   }
 
   Packet = (EFI_DHCP4_PACKET *)NetbufAllocSpace (Wrap, Len, NET_BUF_TAIL);
-  ASSERT (Packet != NULL);
+  // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+  if (Packet == NULL) {
+    ASSERT (Packet != NULL);
+    goto RESTART;
+  }
+
+  // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
 
   Packet->Size   = Len;
   Head           = &Packet->Dhcp4.Header;

--- a/NetworkPkg/DnsDxe/DnsImpl.c
+++ b/NetworkPkg/DnsDxe/DnsImpl.c
@@ -440,8 +440,8 @@ Dns4CopyConfigure (
   IN  EFI_DNS4_CONFIG_DATA  *Src
   )
 {
-  UINTN   Len;
-  UINT32  Index;
+  UINTN  Len;
+  UINTN  Index;  // MU_CHANGE - CodeQL Change - comparison-with-wider-type
 
   CopyMem (Dst, Src, sizeof (*Dst));
   Dst->DnsServerList = NULL;

--- a/NetworkPkg/HttpBootDxe/HttpBootConfig.c
+++ b/NetworkPkg/HttpBootDxe/HttpBootConfig.c
@@ -324,8 +324,14 @@ HttpBootFormExtractConfig (
     // followed by "&OFFSET=0&WIDTH=WWWWWWWWWWWWWWWW" followed by a Null-terminator
     //
     ConfigRequestHdr = HiiConstructConfigHdr (&gHttpBootConfigGuid, mHttpBootConfigStorageName, CallbackInfo->ChildHandle);
-    Size             = (StrLen (ConfigRequestHdr) + 32 + 1) * sizeof (CHAR16);
-    ConfigRequest    = AllocateZeroPool (Size);
+    // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+    if (ConfigRequestHdr == NULL) {
+      return EFI_OUT_OF_RESOURCES;
+    }
+
+    // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
+    Size          = (StrLen (ConfigRequestHdr) + 32 + 1) * sizeof (CHAR16);
+    ConfigRequest = AllocateZeroPool (Size);
     if (ConfigRequest == NULL) {
       return EFI_OUT_OF_RESOURCES;
     }
@@ -683,16 +689,21 @@ HttpBootConfigFormInit (
                       STRING_TOKEN (STR_HTTP_BOOT_CONFIG_FORM_HELP),
                       NULL
                       );
-    UnicodeSPrint (MenuString, 128, L"%s (MAC:%s)", OldMenuString, MacString);
-    HiiSetString (
-      CallbackInfo->RegisteredHandle,
-      STRING_TOKEN (STR_HTTP_BOOT_CONFIG_FORM_HELP),
-      MenuString,
-      NULL
-      );
+    // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+    if (OldMenuString != NULL) {
+      UnicodeSPrint (MenuString, 128, L"%s (MAC:%s)", OldMenuString, MacString);
+      HiiSetString (
+        CallbackInfo->RegisteredHandle,
+        STRING_TOKEN (STR_HTTP_BOOT_CONFIG_FORM_HELP),
+        MenuString,
+        NULL
+        );
 
+      FreePool (OldMenuString);
+    }
+
+    // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
     FreePool (MacString);
-    FreePool (OldMenuString);
 
     CallbackInfo->Initialized = TRUE;
     return EFI_SUCCESS;

--- a/NetworkPkg/HttpBootDxe/HttpBootSupport.c
+++ b/NetworkPkg/HttpBootDxe/HttpBootSupport.c
@@ -723,6 +723,8 @@ HttpBootCheckImageType (
   CHAR8            *FilePath;
   CHAR8            *FilePost;
 
+  FilePath = NULL;  // MU_CHANGE - CodeQL Change - conditionallyuninitializedvariable
+
   if ((Uri == NULL) || (UriParser == NULL) || (ImageType == NULL)) {
     return EFI_INVALID_PARAMETER;
   }

--- a/NetworkPkg/HttpDxe/HttpsSupport.c
+++ b/NetworkPkg/HttpDxe/HttpsSupport.c
@@ -388,7 +388,7 @@ TlsConfigCertificate (
   EFI_STATUS          Status;
   UINT8               *CACert;
   UINTN               CACertSize;
-  UINT32              Index;
+  UINTN               Index;          // MU_CHANGE - CodeQL Change - comparison-with-wider-type
   EFI_SIGNATURE_LIST  *CertList;
   EFI_SIGNATURE_DATA  *Cert;
   UINTN               CertArraySizeInBytes;
@@ -1254,16 +1254,19 @@ TlsConnectSession (
   //
   // Transmit ClientHello
   //
+  // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
   PacketOut = NetbufAlloc ((UINT32)BufferOutSize);
-
   if (PacketOut == NULL) {
     FreePool (BufferOut);
     return EFI_OUT_OF_RESOURCES;
   }
 
+  // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
+
   DataOut = NetbufAllocSpace (PacketOut, (UINT32)BufferOutSize, NET_BUF_TAIL);
   if (DataOut == NULL) {
     FreePool (BufferOut);
+    NetbufFree (PacketOut); // MU_CHANGE - CodeQL Change
     return EFI_OUT_OF_RESOURCES;
   }
 
@@ -1346,8 +1349,8 @@ TlsConnectSession (
       //
       // Transmit the response packet.
       //
+      // MU_CHANGE [BEGIN] - CodeQL change
       PacketOut = NetbufAlloc ((UINT32)BufferOutSize);
-
       if (PacketOut == NULL) {
         FreePool (BufferOut);
         return EFI_OUT_OF_RESOURCES;
@@ -1356,9 +1359,12 @@ TlsConnectSession (
       DataOut = NetbufAllocSpace (PacketOut, (UINT32)BufferOutSize, NET_BUF_TAIL);
       if (DataOut == NULL) {
         FreePool (BufferOut);
+        NetbufFree (PacketOut);
+
         return EFI_OUT_OF_RESOURCES;
       }
 
+      // MU_CHANGE [END] - CodeQL change
       CopyMem (DataOut, BufferOut, BufferOutSize);
 
       Status = TlsCommonTransmit (HttpInstance, PacketOut);
@@ -1510,15 +1516,20 @@ TlsCloseSession (
   }
 
   PacketOut = NetbufAlloc ((UINT32)BufferOutSize);
-
+  // MU_CHANGE [BEGIN] - CodeQL change
   if (PacketOut == NULL) {
     FreePool (BufferOut);
     return EFI_OUT_OF_RESOURCES;
   }
 
+  // MU_CHANGE [END] - CodeQL change
+
   DataOut = NetbufAllocSpace (PacketOut, (UINT32)BufferOutSize, NET_BUF_TAIL);
   if (DataOut == NULL) {
     FreePool (BufferOut);
+    // MU_CHANGE [BEGIN] - CodeQL change
+    NetbufFree (PacketOut);
+    // MU_CHANGE [END] - CodeQL change
     return EFI_OUT_OF_RESOURCES;
   }
 
@@ -1802,9 +1813,9 @@ HttpsReceive (
           return Status;
         }
 
+        // MU_CHANGE [BEGIN] - CodeQL change
         if (BufferOutSize != 0) {
           PacketOut = NetbufAlloc ((UINT32)BufferOutSize);
-
           if (PacketOut == NULL) {
             FreePool (BufferOut);
             return EFI_OUT_OF_RESOURCES;
@@ -1813,9 +1824,11 @@ HttpsReceive (
           DataOut = NetbufAllocSpace (PacketOut, (UINT32)BufferOutSize, NET_BUF_TAIL);
           if (DataOut == NULL) {
             FreePool (BufferOut);
+            NetbufFree (PacketOut);
             return EFI_OUT_OF_RESOURCES;
           }
 
+          // MU_CHANGE [END] - CodeQL change
           CopyMem (DataOut, BufferOut, BufferOutSize);
 
           Status = TlsCommonTransmit (HttpInstance, PacketOut);
@@ -1900,9 +1913,9 @@ HttpsReceive (
       return Status;
     }
 
+    // MU_CHANGE [BEGIN] - CodeQL change
     if (BufferOutSize != 0) {
       PacketOut = NetbufAlloc ((UINT32)BufferOutSize);
-
       if (PacketOut == NULL) {
         FreePool (BufferOut);
         return EFI_OUT_OF_RESOURCES;
@@ -1911,9 +1924,11 @@ HttpsReceive (
       DataOut = NetbufAllocSpace (PacketOut, (UINT32)BufferOutSize, NET_BUF_TAIL);
       if (DataOut == NULL) {
         FreePool (BufferOut);
+        NetbufFree (PacketOut);
         return EFI_OUT_OF_RESOURCES;
       }
 
+      // MU_CHANGE [END] - CodeQL change
       CopyMem (DataOut, BufferOut, BufferOutSize);
 
       Status = TlsCommonTransmit (HttpInstance, PacketOut);

--- a/NetworkPkg/HttpUtilitiesDxe/HttpUtilitiesDxe.c
+++ b/NetworkPkg/HttpUtilitiesDxe/HttpUtilitiesDxe.c
@@ -27,7 +27,7 @@ HttpUtilitiesDxeUnload (
   EFI_STATUS                   Status;
   UINTN                        HandleNum;
   EFI_HANDLE                   *HandleBuffer;
-  UINT32                       Index;
+  UINTN                        Index;           // MU_CHANGE - CodeQL Change - comparison-with-wider-type
   EFI_HTTP_UTILITIES_PROTOCOL  *HttpUtilitiesProtocol;
 
   HandleBuffer = NULL;

--- a/NetworkPkg/IScsiDxe/IScsiConfig.c
+++ b/NetworkPkg/IScsiDxe/IScsiConfig.c
@@ -3053,8 +3053,16 @@ IScsiFormExtractConfig (
     // followed by "&OFFSET=0&WIDTH=WWWWWWWWWWWWWWWW" followed by a Null-terminator
     //
     ConfigRequestHdr = HiiConstructConfigHdr (&gIScsiConfigGuid, mVendorStorageName, Private->DriverHandle);
-    Size             = (StrLen (ConfigRequestHdr) + 32 + 1) * sizeof (CHAR16);
-    ConfigRequest    = AllocateZeroPool (Size);
+    // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+    if (ConfigRequestHdr == NULL) {
+      FreePool (IfrNvData);
+      FreePool (InitiatorName);
+      return EFI_OUT_OF_RESOURCES;
+    }
+
+    // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
+    Size          = (StrLen (ConfigRequestHdr) + 32 + 1) * sizeof (CHAR16);
+    ConfigRequest = AllocateZeroPool (Size);
     if (ConfigRequest == NULL) {
       FreePool (IfrNvData);
       FreePool (InitiatorName);

--- a/NetworkPkg/IScsiDxe/IScsiDhcp6.c
+++ b/NetworkPkg/IScsiDxe/IScsiDhcp6.c
@@ -37,7 +37,7 @@ IScsiDhcp6ExtractRootPath (
   ISCSI_ROOT_PATH_FIELD        Fields[RP_FIELD_IDX_MAX];
   ISCSI_ROOT_PATH_FIELD        *Field;
   UINT32                       FieldIndex;
-  UINT8                        Index;
+  UINT16                       Index;  // MU_CHANGE - CodeQL Change - comparison-with-wider-type
   ISCSI_SESSION_CONFIG_NVDATA  *ConfigNvData;
   EFI_IP_ADDRESS               Ip;
   UINT8                        IpMode;

--- a/NetworkPkg/IScsiDxe/IScsiDriver.c
+++ b/NetworkPkg/IScsiDxe/IScsiDriver.c
@@ -361,7 +361,7 @@ IScsiStart (
   LIST_ENTRY                       *NextEntry;
   ISCSI_ATTEMPT_CONFIG_NVDATA      *AttemptConfigData;
   ISCSI_SESSION                    *Session;
-  UINT8                            Index;
+  UINTN                            Index; // MU_CHANGE - CodeQL Change - comparison-with-wider-type
   EFI_EXT_SCSI_PASS_THRU_PROTOCOL  *ExistIScsiExtScsiPassThru;
   ISCSI_DRIVER_DATA                *ExistPrivate;
   UINT8                            *AttemptConfigOrder;

--- a/NetworkPkg/IScsiDxe/IScsiIbft.c
+++ b/NetworkPkg/IScsiDxe/IScsiIbft.c
@@ -318,7 +318,13 @@ IScsiFillNICAndTargetSections (
     // Get Nic Info: VLAN tag, Mac address, PCI location.
     //
     NicInfo = IScsiGetNicInfoByIndex (Attempt->NicIndex);
-    ASSERT (NicInfo != NULL);
+    // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+    if (NicInfo == NULL) {
+      ASSERT (NicInfo != NULL);
+      break;
+    }
+
+    // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
 
     Nic->VLanTag = NicInfo->VlanId;
     CopyMem (Nic->Mac, &NicInfo->PermanentAddress, sizeof (Nic->Mac));

--- a/NetworkPkg/IScsiDxe/IScsiMisc.c
+++ b/NetworkPkg/IScsiDxe/IScsiMisc.c
@@ -822,7 +822,8 @@ IScsiCreateAttempts (
   UINT8                        Index;
   EFI_STATUS                   Status;
 
-  for (Index = 1; Index <= AttemptNum; Index++) {
+  for (Index = 1; (UINTN)Index <= AttemptNum; Index++) {
+    // MU_CHANGE - CodeQL Change - comparison-with-wider-type
     //
     // Get the initialized attempt order. This is used to essure creating attempts by order.
     //
@@ -2219,7 +2220,13 @@ IScsiGetConfigData (
     //
 
     NicInfo = IScsiGetNicInfoByIndex (mPrivate->CurrentNic);
-    ASSERT (NicInfo != NULL);
+    // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+    if (NicInfo == NULL) {
+      ASSERT (NicInfo != NULL);
+      break;
+    }
+
+    // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
     IScsiMacAddrToStr (&NicInfo->PermanentAddress, NicInfo->HwAddressSize, NicInfo->VlanId, MacString);
     UnicodeSPrint (
       mPrivate->PortString,

--- a/NetworkPkg/Ip4Dxe/Ip4Config2Nv.c
+++ b/NetworkPkg/Ip4Dxe/Ip4Config2Nv.c
@@ -944,8 +944,15 @@ Ip4FormExtractConfig (
       // followed by "&OFFSET=0&WIDTH=WWWWWWWWWWWWWWWW" followed by a Null-terminator
       //
       ConfigRequestHdr = HiiConstructConfigHdr (&gIp4Config2NvDataGuid, mIp4Config2StorageName, Private->ChildHandle);
-      Size             = (StrLen (ConfigRequestHdr) + 32 + 1) * sizeof (CHAR16);
-      ConfigRequest    = AllocateZeroPool (Size);
+      // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+      if (ConfigRequestHdr == NULL) {
+        Status = EFI_OUT_OF_RESOURCES;
+        goto Failure;
+      }
+
+      // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+      Size          = (StrLen (ConfigRequestHdr) + 32 + 1) * sizeof (CHAR16);
+      ConfigRequest = AllocateZeroPool (Size);
       if (ConfigRequest == NULL) {
         Status = EFI_OUT_OF_RESOURCES;
         goto Failure;
@@ -1376,24 +1383,30 @@ Ip4Config2FormInit (
                       STRING_TOKEN (STR_IP4_CONFIG2_FORM_HELP),
                       NULL
                       );
-    UnicodeSPrint (MenuString, 128, L"%s (MAC:%s)", OldMenuString, MacString);
-    HiiSetString (
-      CallbackInfo->RegisteredHandle,
-      STRING_TOKEN (STR_IP4_CONFIG2_FORM_HELP),
-      MenuString,
-      NULL
-      );
+    // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+    if (OldMenuString != NULL) {
+      UnicodeSPrint (MenuString, 128, L"%s (MAC:%s)", OldMenuString, MacString);
+      HiiSetString (
+        CallbackInfo->RegisteredHandle,
+        STRING_TOKEN (STR_IP4_CONFIG2_FORM_HELP),
+        MenuString,
+        NULL
+        );
 
-    UnicodeSPrint (PortString, 128, L"MAC:%s", MacString);
-    HiiSetString (
-      CallbackInfo->RegisteredHandle,
-      STRING_TOKEN (STR_IP4_DEVICE_FORM_HELP),
-      PortString,
-      NULL
-      );
+      UnicodeSPrint (PortString, 128, L"MAC:%s", MacString);
+      HiiSetString (
+        CallbackInfo->RegisteredHandle,
+        STRING_TOKEN (STR_IP4_DEVICE_FORM_HELP),
+        PortString,
+        NULL
+        );
+
+      FreePool (OldMenuString);
+    }
 
     FreePool (MacString);
-    FreePool (OldMenuString);
+
+    // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
 
     return EFI_SUCCESS;
   }

--- a/NetworkPkg/Ip4Dxe/Ip4Icmp.c
+++ b/NetworkPkg/Ip4Dxe/Ip4Icmp.c
@@ -230,7 +230,14 @@ Ip4IcmpReplyEcho (
   // update is omitted.
   //
   Icmp = (IP4_ICMP_QUERY_HEAD *)NetbufGetByte (Data, 0, NULL);
-  ASSERT (Icmp != NULL);
+  // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+  if (Icmp == NULL) {
+    ASSERT (Icmp != NULL);
+    Status = EFI_INVALID_PARAMETER;
+    goto ON_EXIT;
+  }
+
+  // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
   Icmp->Head.Type     = ICMP_ECHO_REPLY;
   Icmp->Head.Checksum = 0;
   Icmp->Head.Checksum = (UINT16)(~NetblockChecksum ((UINT8 *)Icmp, Data->TotalSize));

--- a/NetworkPkg/Ip4Dxe/Ip4Input.c
+++ b/NetworkPkg/Ip4Dxe/Ip4Input.c
@@ -862,7 +862,13 @@ Ip4AccpetFrame (
   }
 
   Head = (IP4_HEAD *)NetbufGetByte (Packet, 0, NULL);
-  ASSERT (Head != NULL);
+  // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+  if (Head == NULL) {
+    ASSERT (Head != NULL);
+    goto RESTART;
+  }
+
+  // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
   OptionLen = (Head->HeadLen << 2) - IP4_MIN_HEADLEN;
   if (OptionLen > 0) {
     Option = (UINT8 *)(Head + 1);
@@ -916,7 +922,13 @@ Ip4AccpetFrame (
     }
 
     Head = (IP4_HEAD *)NetbufGetByte (Packet, 0, NULL);
-    ASSERT (Head != NULL);
+    // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+    if (Head == NULL) {
+      ASSERT (Head != NULL);
+      goto RESTART;
+    }
+
+    // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
     Status = Ip4PreProcessPacket (
                IpSb,
                &Packet,
@@ -1306,7 +1318,13 @@ Ip4InstanceDeliverPacket (
         // may be not continuous before the data.
         //
         Head = NetbufAllocSpace (Dup, IP4_MAX_HEADLEN, NET_BUF_HEAD);
-        ASSERT (Head != NULL);
+        // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+        if (Head == NULL) {
+          ASSERT (Head != NULL);
+          return EFI_OUT_OF_RESOURCES;
+        }
+
+        // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
 
         Dup->Ip.Ip4 = (IP4_HEAD *)Head;
 

--- a/NetworkPkg/Ip6Dxe/Ip6ConfigImpl.c
+++ b/NetworkPkg/Ip6Dxe/Ip6ConfigImpl.c
@@ -864,19 +864,26 @@ Ip6ManualAddrDadCallback (
         // data with those passed.
         //
         PassedAddr = (EFI_IP6_CONFIG_MANUAL_ADDRESS *)AllocatePool (Item->DataSize);
-        ASSERT (PassedAddr != NULL);
+        // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+        if (PassedAddr == NULL) {
+          ASSERT (PassedAddr != NULL);
+          Item->Data.Ptr = NULL;
+          Item->Status   = EFI_OUT_OF_RESOURCES;
+        } else {
+          Item->Data.Ptr = PassedAddr;
+          Item->Status   = EFI_SUCCESS;
 
-        Item->Data.Ptr = PassedAddr;
-        Item->Status   = EFI_SUCCESS;
+          while (!NetMapIsEmpty (&Instance->DadPassedMap)) {
+            ManualAddr = (EFI_IP6_CONFIG_MANUAL_ADDRESS *)NetMapRemoveHead (&Instance->DadPassedMap, NULL);
+            CopyMem (PassedAddr, ManualAddr, sizeof (EFI_IP6_CONFIG_MANUAL_ADDRESS));
 
-        while (!NetMapIsEmpty (&Instance->DadPassedMap)) {
-          ManualAddr = (EFI_IP6_CONFIG_MANUAL_ADDRESS *)NetMapRemoveHead (&Instance->DadPassedMap, NULL);
-          CopyMem (PassedAddr, ManualAddr, sizeof (EFI_IP6_CONFIG_MANUAL_ADDRESS));
+            PassedAddr++;
+          }
 
-          PassedAddr++;
+          ASSERT ((UINTN)PassedAddr - (UINTN)Item->Data.Ptr == Item->DataSize);
         }
 
-        ASSERT ((UINTN)PassedAddr - (UINTN)Item->Data.Ptr == Item->DataSize);
+        // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
       }
     } else {
       //

--- a/NetworkPkg/Ip6Dxe/Ip6ConfigNv.c
+++ b/NetworkPkg/Ip6Dxe/Ip6ConfigNv.c
@@ -1407,9 +1407,24 @@ Ip6FormExtractConfig (
                          mIp6ConfigStorageName,
                          Private->ChildHandle
                          );
+    // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+    if (ConfigRequestHdr == NULL) {
+      Status = EFI_OUT_OF_RESOURCES;
+      goto Exit;
+    }
+
+    // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
+
     Size          = (StrLen (ConfigRequestHdr) + 32 + 1) * sizeof (CHAR16);
     ConfigRequest = AllocateZeroPool (Size);
-    ASSERT (ConfigRequest != NULL);
+    // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+    if (ConfigRequest == NULL) {
+      ASSERT (ConfigRequest != NULL);
+      Status = EFI_OUT_OF_RESOURCES;
+      goto Exit;
+    }
+
+    // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
     AllocatedRequest = TRUE;
     UnicodeSPrint (
       ConfigRequest,
@@ -1994,25 +2009,30 @@ Ip6ConfigFormInit (
                       CallbackInfo->RegisteredHandle,
                       STRING_TOKEN (STR_IP6_CONFIG_FORM_HELP),
                       NULL
-                      )
-    ;
-    UnicodeSPrint (MenuString, 128, L"%s (MAC:%s)", OldMenuString, MacString);
-    HiiSetString (
-      CallbackInfo->RegisteredHandle,
-      STRING_TOKEN (STR_IP6_CONFIG_FORM_HELP),
-      MenuString,
-      NULL
-      );
-    UnicodeSPrint (PortString, 128, L"MAC:%s", MacString);
-    HiiSetString (
-      CallbackInfo->RegisteredHandle,
-      STRING_TOKEN (STR_IP6_DEVICE_FORM_HELP),
-      PortString,
-      NULL
-      );
+                      );
+    // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+    if (OldMenuString != NULL) {
+      UnicodeSPrint (MenuString, 128, L"%s (MAC:%s)", OldMenuString, MacString);
+      HiiSetString (
+        CallbackInfo->RegisteredHandle,
+        STRING_TOKEN (STR_IP6_CONFIG_FORM_HELP),
+        MenuString,
+        NULL
+        );
+      UnicodeSPrint (PortString, 128, L"MAC:%s", MacString);
+      HiiSetString (
+        CallbackInfo->RegisteredHandle,
+        STRING_TOKEN (STR_IP6_DEVICE_FORM_HELP),
+        PortString,
+        NULL
+        );
+
+      FreePool (OldMenuString);
+    }
 
     FreePool (MacString);
-    FreePool (OldMenuString);
+
+    // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
 
     InitializeListHead (&Instance->Ip6NvData.ManualAddress);
     InitializeListHead (&Instance->Ip6NvData.GatewayAddress);

--- a/NetworkPkg/Ip6Dxe/Ip6If.c
+++ b/NetworkPkg/Ip6Dxe/Ip6If.c
@@ -705,7 +705,14 @@ Ip6SendFrame (
   //
 
   NeighborCache = Ip6FindNeighborEntry (IpSb, NextHop);
-  ASSERT (NeighborCache != NULL);
+  // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+  if (NeighborCache == NULL) {
+    ASSERT (NeighborCache != NULL);
+    Status = EFI_NOT_FOUND;
+    goto Error;
+  }
+
+  // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
 
   if (NeighborCache->Interface == NULL) {
     NeighborCache->Interface = Interface;

--- a/NetworkPkg/Ip6Dxe/Ip6Input.c
+++ b/NetworkPkg/Ip6Dxe/Ip6Input.c
@@ -331,7 +331,13 @@ Ip6Reassemble (
     // Revert IP head to network order.
     //
     DupHead = NetbufGetByte (Duplicate, 0, NULL);
-    ASSERT (DupHead != NULL);
+    // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+    if (DupHead == NULL) {
+      ASSERT (DupHead != NULL);
+      goto Error;
+    }
+
+    // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
     Duplicate->Ip.Ip6 = Ip6NtohHead ((EFI_IP6_HEADER *)DupHead);
     Assemble->Packet  = Duplicate;
 
@@ -399,7 +405,14 @@ Ip6Reassemble (
     // the Fragment Header is excluded.
     //
     TmpPacket = NetbufGetFragment (Fragment, 0, This->HeadLen, 0);
-    ASSERT (TmpPacket != NULL);
+    // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+    if (TmpPacket == NULL) {
+      ASSERT (TmpPacket != NULL);
+      Ip6FreeAssembleEntry (Assemble);
+      goto Error;
+    }
+
+    // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
 
     NET_LIST_FOR_EACH (Cur, ListHead) {
       //
@@ -1302,19 +1315,20 @@ Ip6InstanceFrameAcceptable (
   //
   ExtHdrs = NetbufGetByte (Packet, 0, NULL);
 
-  if (!Ip6IsExtsValid (
-         IpInstance->Service,
-         Packet,
-         &Head->NextHeader,
-         ExtHdrs,
-         (UINT32)Head->PayloadLength,
-         TRUE,
-         NULL,
-         &Proto,
-         NULL,
-         NULL,
-         NULL
-         ))
+  if ((ExtHdrs == NULL) || !Ip6IsExtsValid (
+                              // // MU_CHANGE - CodeQL Change - unguardednullreturndereference
+                              IpInstance->Service,
+                              Packet,
+                              &Head->NextHeader,
+                              ExtHdrs,
+                              (UINT32)Head->PayloadLength,
+                              TRUE,
+                              NULL,
+                              &Proto,
+                              NULL,
+                              NULL,
+                              NULL
+                              ))
   {
     return FALSE;
   }
@@ -1336,20 +1350,20 @@ Ip6InstanceFrameAcceptable (
       //
       ErrMsgPayloadLen = NTOHS (Icmp.IpHead.PayloadLength);
       ErrMsgPayload    = NetbufGetByte (Packet, sizeof (Icmp), NULL);
-
-      if (!Ip6IsExtsValid (
-             NULL,
-             NULL,
-             &Icmp.IpHead.NextHeader,
-             ErrMsgPayload,
-             ErrMsgPayloadLen,
-             TRUE,
-             NULL,
-             &Proto,
-             NULL,
-             NULL,
-             NULL
-             ))
+      if ((ErrMsgPayload == NULL) || !Ip6IsExtsValid (
+                                        // MU_CHANGE - CodeQL Change - unguardednullreturndereference
+                                        NULL,
+                                        NULL,
+                                        &Icmp.IpHead.NextHeader,
+                                        ErrMsgPayload,
+                                        ErrMsgPayloadLen,
+                                        TRUE,
+                                        NULL,
+                                        &Proto,
+                                        NULL,
+                                        NULL,
+                                        NULL
+                                        ))
       {
         return FALSE;
       }
@@ -1506,7 +1520,13 @@ Ip6InstanceDeliverPacket (
       // may be not continuous before the data.
       //
       Head = NetbufAllocSpace (Dup, sizeof (EFI_IP6_HEADER), NET_BUF_HEAD);
-      ASSERT (Head != NULL);
+      // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+      if (Head == NULL) {
+        ASSERT (Head != NULL);
+        return EFI_OUT_OF_RESOURCES;
+      }
+
+      // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
       Dup->Ip.Ip6 = (EFI_IP6_HEADER *)Head;
 
       CopyMem (Head, Packet->Ip.Ip6, sizeof (EFI_IP6_HEADER));

--- a/NetworkPkg/Ip6Dxe/Ip6Mld.c
+++ b/NetworkPkg/Ip6Dxe/Ip6Mld.c
@@ -181,7 +181,14 @@ Ip6SendMldReport (
   // Fill a IPv6 Router Alert option in a Hop-by-Hop Options Header
   //
   Options = NetbufAllocSpace (Packet, (UINT32)OptionLen, FALSE);
-  ASSERT (Options != NULL);
+  // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+  if (Options == NULL) {
+    ASSERT (Options != NULL);
+    NetbufFree (Packet);
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
   Status = Ip6FillHopByHop (Options, &OptionLen, IP6_ICMP);
   if (EFI_ERROR (Status)) {
     NetbufFree (Packet);
@@ -193,7 +200,14 @@ Ip6SendMldReport (
   // Fill in MLD message - Report
   //
   MldHead = (IP6_MLD_HEAD *)NetbufAllocSpace (Packet, sizeof (IP6_MLD_HEAD), FALSE);
-  ASSERT (MldHead != NULL);
+  // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+  if (MldHead == NULL) {
+    ASSERT (MldHead != NULL);
+    NetbufFree (Packet);
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
   ZeroMem (MldHead, sizeof (IP6_MLD_HEAD));
   MldHead->Head.Type = ICMP_V6_LISTENER_REPORT;
   MldHead->Head.Code = 0;
@@ -285,7 +299,15 @@ Ip6SendMldDone (
   // Fill a IPv6 Router Alert option in a Hop-by-Hop Options Header
   //
   Options = NetbufAllocSpace (Packet, (UINT32)OptionLen, FALSE);
-  ASSERT (Options != NULL);
+  // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+  if (Options == NULL) {
+    ASSERT (Options != NULL);
+    NetbufFree (Packet);
+    Packet = NULL;
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
   Status = Ip6FillHopByHop (Options, &OptionLen, IP6_ICMP);
   if (EFI_ERROR (Status)) {
     NetbufFree (Packet);
@@ -297,7 +319,14 @@ Ip6SendMldDone (
   // Fill in MLD message - Done
   //
   MldHead = (IP6_MLD_HEAD *)NetbufAllocSpace (Packet, sizeof (IP6_MLD_HEAD), FALSE);
-  ASSERT (MldHead != NULL);
+  // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+  if (MldHead == NULL) {
+    ASSERT (MldHead != NULL);
+    NetbufFree (Packet);
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
   ZeroMem (MldHead, sizeof (IP6_MLD_HEAD));
   MldHead->Head.Type = ICMP_V6_LISTENER_DONE;
   MldHead->Head.Code = 0;

--- a/NetworkPkg/Ip6Dxe/Ip6Nd.c
+++ b/NetworkPkg/Ip6Dxe/Ip6Nd.c
@@ -1175,7 +1175,14 @@ Ip6SendRouterSolicit (
   //
 
   IcmpHead = (IP6_ICMP_INFORMATION_HEAD *)NetbufAllocSpace (Packet, sizeof (IP6_ICMP_INFORMATION_HEAD), FALSE);
-  ASSERT (IcmpHead != NULL);
+  // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+  if (IcmpHead == NULL) {
+    ASSERT (IcmpHead != NULL);
+    NetbufFree (Packet);
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
   ZeroMem (IcmpHead, sizeof (IP6_ICMP_INFORMATION_HEAD));
   IcmpHead->Head.Type = ICMP_V6_ROUTER_SOLICIT;
   IcmpHead->Head.Code = 0;
@@ -1187,7 +1194,14 @@ Ip6SendRouterSolicit (
                                                  sizeof (IP6_ETHER_ADDR_OPTION),
                                                  FALSE
                                                  );
-    ASSERT (LinkLayerOption != NULL);
+    // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+    if (LinkLayerOption == NULL) {
+      ASSERT (LinkLayerOption != NULL);
+      NetbufFree (Packet);
+      return EFI_OUT_OF_RESOURCES;
+    }
+
+    // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
     LinkLayerOption->Type   = Ip6OptionEtherSource;
     LinkLayerOption->Length = (UINT8)sizeof (IP6_ETHER_ADDR_OPTION);
     CopyMem (LinkLayerOption->EtherAddr, SourceLinkAddress, 6);
@@ -1281,7 +1295,14 @@ Ip6SendNeighborAdvertise (
   //
 
   IcmpHead = (IP6_ICMP_INFORMATION_HEAD *)NetbufAllocSpace (Packet, sizeof (IP6_ICMP_INFORMATION_HEAD), FALSE);
-  ASSERT (IcmpHead != NULL);
+  // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+  if (IcmpHead == NULL) {
+    ASSERT (IcmpHead != NULL);
+    NetbufFree (Packet);
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
   ZeroMem (IcmpHead, sizeof (IP6_ICMP_INFORMATION_HEAD));
   IcmpHead->Head.Type = ICMP_V6_NEIGHBOR_ADVERTISE;
   IcmpHead->Head.Code = 0;
@@ -1299,7 +1320,14 @@ Ip6SendNeighborAdvertise (
   }
 
   Target = (EFI_IPv6_ADDRESS *)NetbufAllocSpace (Packet, sizeof (EFI_IPv6_ADDRESS), FALSE);
-  ASSERT (Target != NULL);
+  // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+  if (Target == NULL) {
+    ASSERT (Target != NULL);
+    NetbufFree (Packet);
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
   IP6_COPY_ADDRESS (Target, TargetIp6Address);
 
   LinkLayerOption = (IP6_ETHER_ADDR_OPTION *)NetbufAllocSpace (
@@ -1307,7 +1335,14 @@ Ip6SendNeighborAdvertise (
                                                sizeof (IP6_ETHER_ADDR_OPTION),
                                                FALSE
                                                );
-  ASSERT (LinkLayerOption != NULL);
+  // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+  if (LinkLayerOption == NULL) {
+    ASSERT (LinkLayerOption != NULL);
+    NetbufFree (Packet);
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
   LinkLayerOption->Type   = Ip6OptionEtherTarget;
   LinkLayerOption->Length = 1;
   CopyMem (LinkLayerOption->EtherAddr, TargetLinkAddress, 6);
@@ -1415,13 +1450,26 @@ Ip6SendNeighborSolicit (
   // Fill in the ICMP header, Target address, and Source link-layer address.
   //
   IcmpHead = (IP6_ICMP_INFORMATION_HEAD *)NetbufAllocSpace (Packet, sizeof (IP6_ICMP_INFORMATION_HEAD), FALSE);
-  ASSERT (IcmpHead != NULL);
+  // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+  if (IcmpHead == NULL) {
+    ASSERT (IcmpHead != NULL);
+    NetbufFree (Packet);
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
   ZeroMem (IcmpHead, sizeof (IP6_ICMP_INFORMATION_HEAD));
   IcmpHead->Head.Type = ICMP_V6_NEIGHBOR_SOLICIT;
   IcmpHead->Head.Code = 0;
 
   Target = (EFI_IPv6_ADDRESS *)NetbufAllocSpace (Packet, sizeof (EFI_IPv6_ADDRESS), FALSE);
-  ASSERT (Target != NULL);
+  // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+  if (Target == NULL) {
+    ASSERT (Target != NULL);
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
   IP6_COPY_ADDRESS (Target, TargetIp6Address);
 
   LinkLayerOption = NULL;
@@ -1434,7 +1482,14 @@ Ip6SendNeighborSolicit (
                                                  sizeof (IP6_ETHER_ADDR_OPTION),
                                                  FALSE
                                                  );
-    ASSERT (LinkLayerOption != NULL);
+    // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+    if (LinkLayerOption == NULL) {
+      ASSERT (LinkLayerOption != NULL);
+      NetbufFree (Packet);
+      return EFI_OUT_OF_RESOURCES;
+    }
+
+    // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
     LinkLayerOption->Type   = Ip6OptionEtherSource;
     LinkLayerOption->Length = 1;
     CopyMem (LinkLayerOption->EtherAddr, SourceLinkAddress, 6);
@@ -1523,7 +1578,13 @@ Ip6ProcessNeighborSolicit (
     OptionLen = (UINT16)(Head->PayloadLength - IP6_ND_LENGTH);
     if (OptionLen != 0) {
       Option = NetbufGetByte (Packet, IP6_ND_LENGTH, NULL);
-      ASSERT (Option != NULL);
+      // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+      if (Option == NULL) {
+        ASSERT (Option != NULL);
+        goto Exit;
+      }
+
+      // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
 
       //
       // All included options should have a length that is greater than zero.
@@ -1754,8 +1815,15 @@ Ip6ProcessNeighborAdvertise (
   } else {
     OptionLen = (UINT16)(Head->PayloadLength - IP6_ND_LENGTH);
     if (OptionLen != 0) {
+      // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
       Option = NetbufGetByte (Packet, IP6_ND_LENGTH, NULL);
-      ASSERT (Option != NULL);
+      if (Option == NULL) {
+        ASSERT (Option != NULL);
+        Status = EFI_OUT_OF_RESOURCES;
+        goto Exit;
+      }
+
+      // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
 
       //
       // All included options should have a length that is greater than zero.
@@ -2012,8 +2080,13 @@ Ip6ProcessRouterAdvertise (
   OptionLen = (UINT16)(Head->PayloadLength - IP6_RA_LENGTH);
   if (OptionLen != 0) {
     Option = NetbufGetByte (Packet, IP6_RA_LENGTH, NULL);
-    ASSERT (Option != NULL);
+    // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+    if (Option == NULL) {
+      ASSERT (Option != NULL);
+      goto Exit;
+    }
 
+    // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
     if (!Ip6IsNDOptionValid (Option, OptionLen)) {
       goto Exit;
     }
@@ -2478,8 +2551,15 @@ Ip6ProcessRedirect (
   //
   OptionLen = (UINT16)(Head->PayloadLength - IP6_REDITECT_LENGTH);
   if (OptionLen != 0) {
+    // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
     Option = NetbufGetByte (Packet, IP6_REDITECT_LENGTH, NULL);
-    ASSERT (Option != NULL);
+    if (Option == NULL) {
+      ASSERT (Option != NULL);
+      Status = EFI_OUT_OF_RESOURCES;
+      goto Exit;
+    }
+
+    // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
 
     if (!Ip6IsNDOptionValid (Option, OptionLen)) {
       goto Exit;

--- a/NetworkPkg/Ip6Dxe/Ip6Output.c
+++ b/NetworkPkg/Ip6Dxe/Ip6Output.c
@@ -294,6 +294,8 @@ Ip6SelectInterface (
   IP6_INTERFACE     *IpIf;
   BOOLEAN           Exist;
 
+  IpIf = NULL; // MU_CHANGE - CodeQL Change - conditionallyuninitializedvariable
+
   NET_CHECK_SIGNATURE (IpSb, IP6_SERVICE_SIGNATURE);
   ASSERT (Destination != NULL && Source != NULL);
 
@@ -609,7 +611,13 @@ Ip6Output (
       }
 
       IcmpHead = (IP6_ICMP_HEAD *)NetbufGetByte (Packet, 0, NULL);
-      ASSERT (IcmpHead != NULL);
+      // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+      if (IcmpHead == NULL) {
+        ASSERT (IcmpHead != NULL);
+        return EFI_INVALID_PARAMETER;
+      }
+
+      // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
       if (IcmpHead->Checksum == 0) {
         Checksum = &IcmpHead->Checksum;
       }
@@ -843,13 +851,27 @@ Ip6Output (
       // be fragmented below.
       //
       TmpPacket = NetbufGetFragment (Packet, 0, Packet->TotalSize, FragmentHdrsLen);
-      ASSERT (TmpPacket != NULL);
+      // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+      if (TmpPacket == NULL) {
+        ASSERT (TmpPacket != NULL);
+        Status = EFI_OUT_OF_RESOURCES;
+        goto Error;
+      }
+
+      // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
 
       //
       // Allocate the space to contain the fragmentable hdrs and copy the data.
       //
       Buf = NetbufAllocSpace (TmpPacket, FragmentHdrsLen, TRUE);
-      ASSERT (Buf != NULL);
+      // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+      if (Buf == NULL) {
+        ASSERT (Buf != NULL);
+        Status = EFI_OUT_OF_RESOURCES;
+        goto Error;
+      }
+
+      // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
       CopyMem (Buf, ExtHdrs + UnFragmentHdrsLen, FragmentHdrsLen);
 
       //

--- a/NetworkPkg/Library/DxeHttpIoLib/DxeHttpIoLib.c
+++ b/NetworkPkg/Library/DxeHttpIoLib/DxeHttpIoLib.c
@@ -535,12 +535,24 @@ HttpIoSendChunkedTransfer (
       }
 
       NewHeaders = AllocateZeroPool ((RequestMessage->HeaderCount + AddNewHeader) * sizeof (EFI_HTTP_HEADER));
+      // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+      if (NewHeaders == NULL) {
+        return EFI_OUT_OF_RESOURCES;
+      }
+
+      // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
       CopyMem ((VOID *)NewHeaders, (VOID *)RequestMessage->Headers, RequestMessage->HeaderCount * sizeof (EFI_HTTP_HEADER));
       if (AddNewHeader == 0) {
         //
         // Override content-length to Transfer-Encoding.
         //
-        ContentLengthHeader             = HttpFindHeader (RequestMessage->HeaderCount, NewHeaders, HTTP_HEADER_CONTENT_LENGTH);
+        ContentLengthHeader = HttpFindHeader (RequestMessage->HeaderCount, NewHeaders, HTTP_HEADER_CONTENT_LENGTH);
+        // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+        if (ContentLengthHeader == NULL) {
+          return EFI_INVALID_PARAMETER;
+        }
+
+        // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
         ContentLengthHeader->FieldName  = NULL;
         ContentLengthHeader->FieldValue = NULL;
       } else {

--- a/NetworkPkg/Library/DxeHttpLib/DxeHttpLib.c
+++ b/NetworkPkg/Library/DxeHttpLib/DxeHttpLib.c
@@ -752,6 +752,12 @@ HttpUrlGetPort (
   }
 
   Status =  AsciiStrDecimalToUintnS (Url + Parser->FieldData[HTTP_URI_FIELD_PORT].Offset, (CHAR8 **)NULL, &Data);
+  // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+  if (EFI_ERROR (Status)) {
+    goto ON_EXIT;
+  }
+
+  // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
 
   if (EFI_ERROR (Status) || (Data > HTTP_URI_PORT_MAX_NUM)) {
     Status = EFI_INVALID_PARAMETER;

--- a/NetworkPkg/Library/DxeNetLib/NetBuffer.c
+++ b/NetworkPkg/Library/DxeNetLib/NetBuffer.c
@@ -303,6 +303,13 @@ NetbufDuplicate (
   NetbufReserve (Duplicate, HeadSpace);
 
   Dst = NetbufAllocSpace (Duplicate, Nbuf->TotalSize, NET_BUF_TAIL);
+  // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+  if (Dst == NULL) {
+    ASSERT (Dst != NULL);
+    return NULL;
+  }
+
+  // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
   NetbufCopy (Nbuf, 0, Nbuf->TotalSize, Dst);
 
   return Duplicate;

--- a/NetworkPkg/MnpDxe/MnpConfig.c
+++ b/NetworkPkg/MnpDxe/MnpConfig.c
@@ -225,7 +225,8 @@ MnpAddFreeTxBuf (
   ASSERT ((Count > 0) && (MnpDeviceData->BufferLength > 0));
 
   Status = EFI_SUCCESS;
-  for (Index = 0; Index < Count; Index++) {
+  for (Index = 0; (UINTN)Index < Count; Index++) {
+    // MU_CHANGE - CodeQL Change - comparison-with-wider-type
     TxBufWrap = (MNP_TX_BUF_WRAP *)AllocatePool (OFFSET_OF (MNP_TX_BUF_WRAP, TxBuf) + MnpDeviceData->BufferLength);
     if (TxBufWrap == NULL) {
       DEBUG ((DEBUG_ERROR, "MnpAddFreeTxBuf: TxBuf Alloc failed.\n"));

--- a/NetworkPkg/MnpDxe/MnpIo.c
+++ b/NetworkPkg/MnpDxe/MnpIo.c
@@ -621,7 +621,13 @@ MnpAnalysePacket (
   // Get the packet buffer.
   //
   BufPtr = NetbufGetByte (Nbuf, 0, NULL);
-  ASSERT (BufPtr != NULL);
+  // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+  if (BufPtr == NULL) {
+    ASSERT (BufPtr != NULL);
+    return;
+  }
+
+  // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
 
   //
   // Set the initial values.
@@ -873,7 +879,13 @@ MnpReceivePacket (
   Nbuf   = MnpDeviceData->RxNbufCache;
   BufLen = Nbuf->TotalSize;
   BufPtr = NetbufGetByte (Nbuf, 0, NULL);
-  ASSERT (BufPtr != NULL);
+  // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+  if (BufPtr == NULL) {
+    ASSERT (BufPtr != NULL);
+    return EFI_DEVICE_ERROR;
+  }
+
+  // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
 
   //
   // Receive packet through Snp.

--- a/NetworkPkg/MnpDxe/MnpMain.c
+++ b/NetworkPkg/MnpDxe/MnpMain.c
@@ -517,6 +517,8 @@ MnpTransmit (
   UINT32             PktLen;
   EFI_TPL            OldTpl;
 
+  PktBuf = NULL; // MU_CHANGE - CodeQL Change - conditionallyuninitializedvariable
+
   if ((This == NULL) || (Token == NULL)) {
     return EFI_INVALID_PARAMETER;
   }

--- a/NetworkPkg/MnpDxe/MnpVlan.c
+++ b/NetworkPkg/MnpDxe/MnpVlan.c
@@ -131,7 +131,13 @@ MnpRemoveVlanTag (
   // Get the packet buffer.
   //
   Packet = NetbufGetByte (Nbuf, 0, NULL);
-  ASSERT (Packet != NULL);
+  // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+  if (Packet == NULL) {
+    ASSERT (Packet != NULL);
+    return FALSE;
+  }
+
+  // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
 
   //
   // Check whether this is VLAN tagged frame by Ether Type

--- a/NetworkPkg/Mtftp4Dxe/Mtftp4Rrq.c
+++ b/NetworkPkg/Mtftp4Dxe/Mtftp4Rrq.c
@@ -103,7 +103,14 @@ Mtftp4RrqSendAck (
                                sizeof (EFI_MTFTP4_ACK_HEADER),
                                FALSE
                                );
-  ASSERT (Ack != NULL);
+  // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+  if (Ack == NULL) {
+    ASSERT (Ack != NULL);
+    NetbufFree (Packet);
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
 
   Ack->Ack.OpCode   = HTONS (EFI_MTFTP4_OPCODE_ACK);
   Ack->Ack.Block[0] = HTONS (BlkNo);
@@ -713,7 +720,14 @@ Mtftp4RrqInput (
     NetbufCopy (UdpPacket, 0, Len, (UINT8 *)Packet);
   } else {
     Packet = (EFI_MTFTP4_PACKET *)NetbufGetByte (UdpPacket, 0, NULL);
-    ASSERT (Packet != NULL);
+    // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+    if (Packet == NULL) {
+      ASSERT (Packet != NULL);
+      Status = EFI_OUT_OF_RESOURCES;
+      goto ON_EXIT;
+    }
+
+    // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
   }
 
   Opcode = NTOHS (Packet->OpCode);

--- a/NetworkPkg/Mtftp4Dxe/Mtftp4Support.c
+++ b/NetworkPkg/Mtftp4Dxe/Mtftp4Support.c
@@ -303,7 +303,14 @@ Mtftp4SendRequest (
   }
 
   Packet = (EFI_MTFTP4_PACKET *)NetbufAllocSpace (Nbuf, BufferLength, FALSE);
-  ASSERT (Packet != NULL);
+  // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+  if (Packet == NULL) {
+    ASSERT (Packet != NULL);
+    NetbufFree (Nbuf);
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
 
   Packet->OpCode = HTONS (Instance->Operation);
   BufferLength  -= sizeof (Packet->OpCode);
@@ -366,7 +373,14 @@ Mtftp4SendError (
   }
 
   TftpError = (EFI_MTFTP4_PACKET *)NetbufAllocSpace (Packet, Len, FALSE);
-  ASSERT (TftpError != NULL);
+  // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+  if (TftpError == NULL) {
+    ASSERT (TftpError != NULL);
+    NetbufFree (Packet);
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
 
   TftpError->OpCode          = HTONS (EFI_MTFTP4_OPCODE_ERROR);
   TftpError->Error.ErrorCode = HTONS (ErrCode);
@@ -462,7 +476,13 @@ Mtftp4SendPacket (
   // to the connected port
   //
   Buffer = NetbufGetByte (Packet, 0, NULL);
-  ASSERT (Buffer != NULL);
+  // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+  if (Buffer == NULL) {
+    ASSERT (Buffer != NULL);
+    return EFI_DEVICE_ERROR;
+  }
+
+  // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
   OpCode = NTOHS (*(UINT16 *)Buffer);
 
   if ((OpCode == EFI_MTFTP4_OPCODE_RRQ) ||
@@ -520,7 +540,13 @@ Mtftp4Retransmit (
   // Set the requests to the listening port, other packets to the connected port
   //
   Buffer = NetbufGetByte (Instance->LastPacket, 0, NULL);
-  ASSERT (Buffer != NULL);
+  // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+  if (Buffer == NULL) {
+    ASSERT (Buffer != NULL);
+    return EFI_DEVICE_ERROR;
+  }
+
+  // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
   OpCode = NTOHS (*(UINT16 *)Buffer);
 
   if ((OpCode == EFI_MTFTP4_OPCODE_RRQ) || (OpCode == EFI_MTFTP4_OPCODE_DIR) ||

--- a/NetworkPkg/Mtftp4Dxe/Mtftp4Wrq.c
+++ b/NetworkPkg/Mtftp4Dxe/Mtftp4Wrq.c
@@ -44,7 +44,14 @@ Mtftp4WrqSendBlock (
   }
 
   Packet = (EFI_MTFTP4_PACKET *)NetbufAllocSpace (UdpPacket, MTFTP4_DATA_HEAD_LEN, FALSE);
-  ASSERT (Packet != NULL);
+  // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+  if (Packet == NULL) {
+    ASSERT (Packet != NULL);
+    NetbufFree (UdpPacket);
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
 
   Packet->Data.OpCode = HTONS (EFI_MTFTP4_OPCODE_DATA);
   Packet->Data.Block  = HTONS (BlockNum);
@@ -387,7 +394,14 @@ Mtftp4WrqInput (
     NetbufCopy (UdpPacket, 0, Len, (UINT8 *)Packet);
   } else {
     Packet = (EFI_MTFTP4_PACKET *)NetbufGetByte (UdpPacket, 0, NULL);
-    ASSERT (Packet != NULL);
+    // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+    if (Packet == NULL) {
+      ASSERT (Packet != NULL);
+      Status = EFI_OUT_OF_RESOURCES;
+      goto ON_EXIT;
+    }
+
+    // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
   }
 
   Opcode = NTOHS (Packet->OpCode);

--- a/NetworkPkg/Mtftp6Dxe/Mtftp6Rrq.c
+++ b/NetworkPkg/Mtftp6Dxe/Mtftp6Rrq.c
@@ -46,7 +46,14 @@ Mtftp6RrqSendAck (
                                sizeof (EFI_MTFTP6_ACK_HEADER),
                                FALSE
                                );
-  ASSERT (Ack != NULL);
+  // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+  if (Ack == NULL) {
+    NetbufFree (Packet);
+    ASSERT (Ack != NULL);
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
 
   Ack->Ack.OpCode   = HTONS (EFI_MTFTP6_OPCODE_ACK);
   Ack->Ack.Block[0] = HTONS (BlockNum);
@@ -758,7 +765,14 @@ Mtftp6RrqInput (
     NetbufCopy (UdpPacket, 0, Len, (UINT8 *)Packet);
   } else {
     Packet = (EFI_MTFTP6_PACKET *)NetbufGetByte (UdpPacket, 0, NULL);
-    ASSERT (Packet != NULL);
+    // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+    if (Packet == NULL) {
+      ASSERT (Packet != NULL);
+      Status = EFI_OUT_OF_RESOURCES;
+      goto ON_EXIT;
+    }
+
+    // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
   }
 
   Opcode = NTOHS (Packet->OpCode);

--- a/NetworkPkg/Mtftp6Dxe/Mtftp6Support.c
+++ b/NetworkPkg/Mtftp6Dxe/Mtftp6Support.c
@@ -515,7 +515,14 @@ Mtftp6SendRequest (
   // Copy the opcode, filename and mode into packet.
   //
   Packet = (EFI_MTFTP6_PACKET *)NetbufAllocSpace (Nbuf, BufferLength, FALSE);
-  ASSERT (Packet != NULL);
+  // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+  if (Packet == NULL) {
+    ASSERT (Packet != NULL);
+    NetbufFree (Nbuf);
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
 
   Packet->OpCode = HTONS (Operation);
   BufferLength  -= sizeof (Packet->OpCode);
@@ -673,7 +680,13 @@ Mtftp6TransmitPacket (
   Instance->PacketToLive = Instance->IsMaster ? Instance->Timeout : (Instance->Timeout * 2);
 
   Temp = (UINT16 *)NetbufGetByte (Packet, 0, NULL);
-  ASSERT (Temp != NULL);
+  // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+  if (Temp == NULL) {
+    ASSERT (Temp != NULL);
+    return EFI_DEVICE_ERROR;
+  }
+
+  // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
 
   Value  = *Temp;
   OpCode = NTOHS (Value);

--- a/NetworkPkg/Mtftp6Dxe/Mtftp6Wrq.c
+++ b/NetworkPkg/Mtftp6Dxe/Mtftp6Wrq.c
@@ -48,8 +48,14 @@ Mtftp6WrqSendBlock (
                                   MTFTP6_DATA_HEAD_LEN,
                                   FALSE
                                   );
-  ASSERT (Packet != NULL);
+  // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+  if (Packet == NULL) {
+    ASSERT (Packet != NULL);
+    NetbufFree (UdpPacket);
+    return EFI_OUT_OF_RESOURCES;
+  }
 
+  // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
   Packet->Data.OpCode = HTONS (EFI_MTFTP6_OPCODE_DATA);
   Packet->Data.Block  = HTONS (BlockNum);
 
@@ -436,7 +442,14 @@ Mtftp6WrqInput (
     NetbufCopy (UdpPacket, 0, Len, (UINT8 *)Packet);
   } else {
     Packet = (EFI_MTFTP6_PACKET *)NetbufGetByte (UdpPacket, 0, NULL);
-    ASSERT (Packet != NULL);
+    // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+    if (Packet == NULL) {
+      ASSERT (Packet != NULL);
+      Status = EFI_OUT_OF_RESOURCES;
+      goto ON_EXIT;
+    }
+
+    // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
   }
 
   Opcode = NTOHS (Packet->OpCode);

--- a/NetworkPkg/TcpDxe/SockImpl.c
+++ b/NetworkPkg/TcpDxe/SockImpl.c
@@ -110,7 +110,13 @@ SockTcpDataToRcv (
   // Get the first socket receive buffer
   //
   RcvBufEntry = SockBufFirst (SockBuffer);
-  ASSERT (RcvBufEntry != NULL);
+  // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+  if (RcvBufEntry == NULL) {
+    ASSERT (RcvBufEntry != NULL);
+    return 0;
+  }
+
+  // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
 
   TcpRsvData = (TCP_RSV_DATA *)RcvBufEntry->ProtoData;
 

--- a/NetworkPkg/TcpDxe/TcpInput.c
+++ b/NetworkPkg/TcpDxe/TcpInput.c
@@ -734,7 +734,13 @@ TcpInput (
   Tcb    = NULL;
 
   Head = (TCP_HEAD *)NetbufGetByte (Nbuf, 0, NULL);
-  ASSERT (Head != NULL);
+  // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+  if (Head == NULL) {
+    ASSERT (Head != NULL);
+    goto DISCARD;
+  }
+
+  // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
 
   if (Nbuf->TotalSize < sizeof (TCP_HEAD)) {
     DEBUG ((DEBUG_NET, "TcpInput: received a malformed packet\n"));
@@ -787,6 +793,12 @@ TcpInput (
   }
 
   Seg = TcpFormatNetbuf (Tcb, Nbuf);
+  // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+  if (Seg == NULL) {
+    goto DISCARD;
+  }
+
+  // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
 
   //
   // RFC1122 recommended reaction to illegal option
@@ -1589,7 +1601,13 @@ TcpIcmpInput (
   }
 
   Head = (TCP_HEAD *)NetbufGetByte (Nbuf, 0, NULL);
-  ASSERT (Head != NULL);
+  // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+  if (Head == NULL) {
+    ASSERT (Head != NULL);
+    goto CLEAN_EXIT;
+  }
+
+  // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
 
   Tcb = TcpLocateTcb (
           Head->DstPort,
@@ -1618,7 +1636,8 @@ TcpIcmpInput (
                     &IcmpErrNotify
                     );
 
-  if (IcmpErrNotify) {
+  if (EFI_ERROR (IcmpErrStatus) && IcmpErrNotify) {
+    // MU_CHANGE - CodeQL Change - conditionally-uninitialized-variable
     SOCK_ERROR (Tcb->Sk, IcmpErrStatus);
   }
 

--- a/NetworkPkg/TcpDxe/TcpMisc.c
+++ b/NetworkPkg/TcpDxe/TcpMisc.c
@@ -890,7 +890,13 @@ TcpFormatNetbuf (
 
   Seg  = TCPSEG_NETBUF (Nbuf);
   Head = (TCP_HEAD *)NetbufGetByte (Nbuf, 0, NULL);
-  ASSERT (Head != NULL);
+  // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+  if (Head == NULL) {
+    ASSERT (Head != NULL);
+    return NULL;
+  }
+
+  // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
 
   Nbuf->Tcp = Head;
 
@@ -1146,7 +1152,14 @@ TcpResetConnection (
                         NET_BUF_TAIL
                         );
 
-  ASSERT (Nhead != NULL);
+  // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+  if (Nhead == NULL) {
+    ASSERT (Nhead != NULL);
+    NetbufFree (Nbuf);
+    return;
+  }
+
+  // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
 
   Nbuf->Tcp = Nhead;
 

--- a/NetworkPkg/TcpDxe/TcpOption.c
+++ b/NetworkPkg/TcpDxe/TcpOption.c
@@ -130,7 +130,13 @@ TcpSynBuildOption (
              NET_BUF_HEAD
              );
 
-    ASSERT (Data != NULL);
+    // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+    if (Data == NULL) {
+      ASSERT (Data != NULL);
+      return 0;  // Returning Len of 0 if we fail allocating space
+    }
+
+    // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
     Len += TCP_OPTION_TS_ALIGNED_LEN;
 
     TcpPutUint32 (Data, TCP_OPTION_TS_FAST);
@@ -154,7 +160,13 @@ TcpSynBuildOption (
              NET_BUF_HEAD
              );
 
-    ASSERT (Data != NULL);
+    // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+    if (Data == NULL) {
+      ASSERT (Data != NULL);
+      return 0; // Returning Len of 0 if we fail allocating space
+    }
+
+    // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
 
     Len += TCP_OPTION_WS_ALIGNED_LEN;
     TcpPutUint32 (Data, TCP_OPTION_WS_FAST | TcpComputeScale (Tcb));
@@ -164,7 +176,13 @@ TcpSynBuildOption (
   // Build the MSS option.
   //
   Data = NetbufAllocSpace (Nbuf, TCP_OPTION_MSS_LEN, 1);
-  ASSERT (Data != NULL);
+  // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+  if (Data == NULL) {
+    ASSERT (Data != NULL);
+    return 0; // Returning Len of 0 if we fail allocating space
+  }
+
+  // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
 
   Len += TCP_OPTION_MSS_LEN;
   TcpPutUint32 (Data, TCP_OPTION_MSS_FAST | Tcb->RcvMss);
@@ -206,7 +224,13 @@ TcpBuildOption (
              NET_BUF_HEAD
              );
 
-    ASSERT (Data != NULL);
+    // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+    if (Data == NULL) {
+      ASSERT (Data != NULL);
+      return 0;
+    }
+
+    // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
     Len += TCP_OPTION_TS_ALIGNED_LEN;
 
     TcpPutUint32 (Data, TCP_OPTION_TS_FAST);

--- a/NetworkPkg/TcpDxe/TcpOutput.c
+++ b/NetworkPkg/TcpDxe/TcpOutput.c
@@ -306,7 +306,13 @@ TcpTransmitSegment (
                        NET_BUF_HEAD
                        );
 
-  ASSERT (Head != NULL);
+  // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+  if (Head == NULL) {
+    ASSERT (Head != NULL);
+    return -1;
+  }
+
+  // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
 
   Nbuf->Tcp = Head;
 
@@ -496,7 +502,13 @@ TcpGetSegmentSndQue (
   //
   if (CopyLen != 0) {
     Data = NetbufAllocSpace (Nbuf, CopyLen, NET_BUF_TAIL);
-    ASSERT (Data != NULL);
+    // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+    if (Data == NULL) {
+      ASSERT (Data != NULL);
+      goto OnError;
+    }
+
+    // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
 
     if ((INT32)NetbufCopy (Node, Offset, CopyLen, Data) != CopyLen) {
       goto OnError;
@@ -560,8 +572,14 @@ TcpGetSegmentSock (
     // copy data to the segment.
     //
     Data = NetbufAllocSpace (Nbuf, Len, NET_BUF_TAIL);
-    ASSERT (Data != NULL);
+    // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+    if (Data == NULL) {
+      ASSERT (Data != NULL);
+      NetbufFree (Nbuf);
+      return NULL;
+    }
 
+    // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
     DataGet = SockGetDataToSend (Tcb->Sk, 0, Len, Data);
   }
 
@@ -608,6 +626,12 @@ TcpGetSegment (
     Nbuf = TcpGetSegmentSndQue (Tcb, Seq, Len);
   } else {
     Nbuf = TcpGetSegmentSock (Tcb, Seq, Len);
+    // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+  }
+
+  if (Nbuf == NULL) {
+    return NULL;
+    // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
   }
 
   if (TcpVerifySegment (Nbuf) == 0) {
@@ -1124,7 +1148,14 @@ TcpSendReset (
                         NET_BUF_TAIL
                         );
 
-  ASSERT (Nhead != NULL);
+  // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+  if (Nhead == NULL) {
+    ASSERT (Nhead != NULL);
+    NetbufFree (Nbuf);
+    return -1;
+  }
+
+  // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
 
   Nbuf->Tcp   = Nhead;
   Nhead->Flag = TCP_FLG_RST;

--- a/NetworkPkg/TlsAuthConfigDxe/TlsAuthConfigImpl.c
+++ b/NetworkPkg/TlsAuthConfigDxe/TlsAuthConfigImpl.c
@@ -127,7 +127,7 @@ UpdateDeletePage (
   )
 {
   EFI_STATUS          Status;
-  UINT32              Index;
+  UINTN               Index;              // MU_CHANGE - CodeQL Change - comparison-with-wider-type
   UINTN               CertCount;
   UINTN               GuidIndex;
   VOID                *StartOpCodeHandle;
@@ -318,7 +318,7 @@ DeleteCert (
   UINT8               *Data;
   UINT8               *OldData;
   UINT32              Attr;
-  UINT32              Index;
+  UINTN               Index;              // MU_CHANGE - CodeQL Change - comparison-with-wider-type
   EFI_SIGNATURE_LIST  *CertList;
   EFI_SIGNATURE_LIST  *NewCertList;
   EFI_SIGNATURE_DATA  *Cert;
@@ -614,7 +614,13 @@ ExtractFileNameFromDevicePath (
 
   ASSERT (DevicePath != NULL);
 
-  String      = DevicePathToStr (DevicePath);
+  String = DevicePathToStr (DevicePath);
+  // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+  if (String == NULL) {
+    return NULL;
+  }
+
+  // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
   MatchString = String;
   LastMatch   = String;
   FileName    = NULL;
@@ -1225,9 +1231,23 @@ TlsAuthConfigAccessExtractConfig (
     // followed by "&OFFSET=0&WIDTH=WWWWWWWWWWWWWWWW" followed by a Null-terminator
     //
     ConfigRequestHdr = HiiConstructConfigHdr (&gTlsAuthConfigGuid, mTlsAuthConfigStorageName, Private->DriverHandle);
-    Size             = (StrLen (ConfigRequestHdr) + 32 + 1) * sizeof (CHAR16);
-    ConfigRequest    = AllocateZeroPool (Size);
-    ASSERT (ConfigRequest != NULL);
+    // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+    if (ConfigRequestHdr == NULL) {
+      return EFI_OUT_OF_RESOURCES;
+    }
+
+    // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
+    Size          = (StrLen (ConfigRequestHdr) + 32 + 1) * sizeof (CHAR16);
+    ConfigRequest = AllocateZeroPool (Size);
+    // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+    if (ConfigRequest == NULL) {
+      ASSERT (ConfigRequest != NULL);
+      FreePool (ConfigRequestHdr);
+      return EFI_OUT_OF_RESOURCES;
+    }
+
+    // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
+
     AllocatedRequest = TRUE;
     UnicodeSPrint (ConfigRequest, Size, L"%s&OFFSET=0&WIDTH=%016LX", ConfigRequestHdr, (UINT64)BufferSize);
     FreePool (ConfigRequestHdr);

--- a/NetworkPkg/TlsDxe/TlsDriver.c
+++ b/NetworkPkg/TlsDxe/TlsDriver.c
@@ -156,7 +156,7 @@ TlsUnload (
   EFI_STATUS                    Status;
   UINTN                         HandleNum;
   EFI_HANDLE                    *HandleBuffer;
-  UINT32                        Index;
+  UINTN                         Index;            // MU_CHANGE - CodeQL Change - comparison-with-wider-type
   EFI_SERVICE_BINDING_PROTOCOL  *ServiceBinding;
   TLS_SERVICE                   *TlsService;
 

--- a/NetworkPkg/Udp4Dxe/Udp4Impl.c
+++ b/NetworkPkg/Udp4Dxe/Udp4Impl.c
@@ -1599,7 +1599,14 @@ Udp4Demultiplex (
   // Get the datagram header from the packet buffer.
   //
   Udp4Header = (EFI_UDP_HEADER *)NetbufGetByte (Packet, 0, NULL);
-  ASSERT (Udp4Header != NULL);
+  // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+  if (Udp4Header == NULL) {
+    ASSERT (Udp4Header != NULL);
+    NetbufFree (Packet);
+    return;
+  }
+
+  // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
 
   if (Udp4Header->Checksum != 0) {
     //
@@ -1714,7 +1721,14 @@ Udp4SendPortUnreach (
   // Allocate space for the IP4_ICMP_ERROR_HEAD.
   //
   IcmpErrHdr = (IP4_ICMP_ERROR_HEAD *)NetbufAllocSpace (Packet, Len, FALSE);
-  ASSERT (IcmpErrHdr != NULL);
+  // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+  if (IcmpErrHdr == NULL) {
+    ASSERT (IcmpErrHdr != NULL);
+    NetbufFree (Packet);
+    return;
+  }
+
+  // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
 
   //
   // Set the required fields for the icmp port unreachable message.
@@ -1789,7 +1803,14 @@ Udp4IcmpHandler (
   }
 
   Udp4Header = (EFI_UDP_HEADER *)NetbufGetByte (Packet, 0, NULL);
-  ASSERT (Udp4Header != NULL);
+  // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+  if (Udp4Header == NULL) {
+    ASSERT (Udp4Header != NULL);
+    NetbufFree (Packet);
+    return;
+  }
+
+  // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
 
   CopyMem (&Udp4Session.SourceAddress, &NetSession->Source, sizeof (EFI_IPv4_ADDRESS));
   CopyMem (&Udp4Session.DestinationAddress, &NetSession->Dest, sizeof (EFI_IPv4_ADDRESS));

--- a/NetworkPkg/Udp4Dxe/Udp4Main.c
+++ b/NetworkPkg/Udp4Dxe/Udp4Main.c
@@ -563,7 +563,14 @@ Udp4Transmit (
   *((UINTN *)&Packet->ProtoData[0]) = (UINTN)(Udp4Service->IpIo);
 
   Udp4Header = (EFI_UDP_HEADER *)NetbufAllocSpace (Packet, UDP4_HEADER_SIZE, TRUE);
-  ASSERT (Udp4Header != NULL);
+  // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+  if (Udp4Header == NULL) {
+    ASSERT (Udp4Header != NULL);
+    Status = EFI_OUT_OF_RESOURCES;
+    goto ON_EXIT;
+  }
+
+  /// MU_CHANGE End - CodeQL Change - unguardednullreturndereference
 
   ConfigData = &Instance->ConfigData;
 

--- a/NetworkPkg/UefiPxeBcDxe/PxeBcDhcp4.c
+++ b/NetworkPkg/UefiPxeBcDxe/PxeBcDhcp4.c
@@ -1368,7 +1368,7 @@ PxeBcDhcp4Discover (
   EFI_DHCP4_TRANSMIT_RECEIVE_TOKEN  Token;
   BOOLEAN                           IsBCast;
   EFI_STATUS                        Status;
-  UINT16                            RepIndex;
+  UINT32                            RepIndex; // MU_CHANGE - CodeQL Change - comparison-with-wider-type
   UINT16                            SrvIndex;
   UINT16                            TryIndex;
   EFI_DHCP4_LISTEN_POINT            ListenPoint;

--- a/NetworkPkg/VlanConfigDxe/VlanConfigImpl.c
+++ b/NetworkPkg/VlanConfigDxe/VlanConfigImpl.c
@@ -113,9 +113,23 @@ VlanExtractConfig (
     // followed by "&OFFSET=0&WIDTH=WWWWWWWWWWWWWWWW" followed by a Null-terminator
     //
     ConfigRequestHdr = HiiConstructConfigHdr (&gVlanConfigFormSetGuid, mVlanStorageName, PrivateData->DriverHandle);
-    Size             = (StrLen (ConfigRequestHdr) + 32 + 1) * sizeof (CHAR16);
-    ConfigRequest    = AllocateZeroPool (Size);
-    ASSERT (ConfigRequest != NULL);
+    // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+    if (ConfigRequestHdr == NULL) {
+      return EFI_OUT_OF_RESOURCES;
+    }
+
+    // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
+    Size          = (StrLen (ConfigRequestHdr) + 32 + 1) * sizeof (CHAR16);
+    ConfigRequest = AllocateZeroPool (Size);
+    // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+    if (ConfigRequest == NULL) {
+      ASSERT (ConfigRequest != NULL);
+      FreePool (ConfigRequestHdr);
+      return EFI_OUT_OF_RESOURCES;
+    }
+
+    // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
+
     AllocatedRequest = TRUE;
     UnicodeSPrint (ConfigRequest, Size, L"%s&OFFSET=0&WIDTH=%016LX", ConfigRequestHdr, (UINT64)BufferSize);
     FreePool (ConfigRequestHdr);
@@ -244,7 +258,13 @@ VlanCallback (
   // Get Browser data
   //
   Configuration = AllocateZeroPool (sizeof (VLAN_CONFIGURATION));
-  ASSERT (Configuration != NULL);
+  // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+  if (Configuration == NULL) {
+    ASSERT (Configuration != NULL);
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
   HiiGetBrowserData (&gVlanConfigFormSetGuid, mVlanStorageName, sizeof (VLAN_CONFIGURATION), (UINT8 *)Configuration);
 
   VlanConfig = PrivateData->VlanConfig;
@@ -374,11 +394,22 @@ VlanUpdateForm (
   // Init OpCode Handle
   //
   StartOpCodeHandle = HiiAllocateOpCodeHandle ();
-  ASSERT (StartOpCodeHandle != NULL);
+  // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+  if (StartOpCodeHandle == NULL) {
+    ASSERT (StartOpCodeHandle != NULL);
+    return;
+  }
+
+  // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
 
   EndOpCodeHandle = HiiAllocateOpCodeHandle ();
-  ASSERT (EndOpCodeHandle != NULL);
+  // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+  if (EndOpCodeHandle == NULL) {
+    ASSERT (EndOpCodeHandle != NULL);
+    return;
+  }
 
+  // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
   //
   // Create Hii Extend Label OpCode as the start opcode
   //
@@ -431,7 +462,13 @@ VlanUpdateForm (
     *String = 0;
 
     StringId = HiiSetString (PrivateData->HiiHandle, 0, VlanStr, NULL);
-    ASSERT (StringId != 0);
+    // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
+    if (StringId == 0) {
+      ASSERT (StringId != 0);
+      continue;
+    }
+
+    // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
 
     HiiCreateCheckBoxOpCode (
       StartOpCodeHandle,

--- a/NetworkPkg/WifiConnectionManagerDxe/WifiConnectionMgrHiiConfigAccess.c
+++ b/NetworkPkg/WifiConnectionManagerDxe/WifiConnectionMgrHiiConfigAccess.c
@@ -268,7 +268,7 @@ WifiMgrGetStrAKMList (
   IN  WIFI_MGR_NETWORK_PROFILE  *Profile
   )
 {
-  UINT8   Index;
+  UINT16  Index; // MU_CHANGE - CodeQL Change - comparison-with-wider-type
   UINT16  AKMSuiteCount;
   CHAR16  *AKMListDisplay;
   UINTN   Length;
@@ -327,7 +327,7 @@ WifiMgrGetStrCipherList (
   IN  WIFI_MGR_NETWORK_PROFILE  *Profile
   )
 {
-  UINT8   Index;
+  UINT16  Index; // MU_CHANGE - CodeQL Change - comparison-with-wider-type
   UINT16  CipherSuiteCount;
   CHAR16  *CipherListDisplay;
 


### PR DESCRIPTION
# Description

This PR Includes changes across the NetworkPkg for the following CodeQL rules:
- cpp/comparison-with-wider-type
- cpp/overflow-buffer
- cpp/redundant-null-check-param
- cpp/uselesstest

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [X] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Various fixes that may have security impact that codeql has detected.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Being built on real platforms both client and server

## Integration Instructions

N/A