### PR TITLE
MdeModulePkg: Bus,Universal,Core CodeQl Changes.

### DIFF
--- a/.pytool/CISettings.py
+++ b/.pytool/CISettings.py
@@ -13,7 +13,6 @@ from edk2toolext.invocables.edk2_ci_build import CiBuildSettingsManager
 from edk2toolext.invocables.edk2_setup import SetupSettingsManager, RequiredSubmodule
 from edk2toolext.invocables.edk2_update import UpdateSettingsManager
 from edk2toolext.invocables.edk2_pr_eval import PrEvalSettingsManager
-from edk2toollib.utility_functions import GetHostInfo
 from pathlib import Path
 
 
@@ -174,6 +173,11 @@ class Settings(CiBuildSettingsManager, UpdateSettingsManager, SetupSettingsManag
                     shell_environment.GetBuildVars().SetValue(
                         "STUART_CODEQL_AUDIT_ONLY",
                         "TRUE",
+                        "Set in CISettings.py")
+                    shell_environment.GetBuildVars().SetValue(
+                        "STUART_CODEQL_FILTER_FILES",
+                        os.path.join(self.GetWorkspaceRoot(),
+                                     "CodeQlFilters.yml"),
                         "Set in CISettings.py")
             except NameError:
                 pass

--- a/CodeQlFilters.yml
+++ b/CodeQlFilters.yml
@@ -1,0 +1,21 @@
+## @file
+# CodeQL Result Filters to suppress
+#
+# Note:
+#    It is recommended paths begin with `**/`. This enables filtering of the
+#    files that may result in projects placing edk2 as a subfolder in the
+#    project.
+#
+# Copyright (c) Microsoft Corporation
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+{
+  "Filters":
+    [
+      "-**/MdeModulePkg/Universal/EbcDxe/EbcDebugger/EdbCmdBreakpoint.c:cpp/missing-null-test",
+      "-**/MdeModulePkg/Core/Pei/FwVol/FwVol.c:cpp/missing-null-test",
+      "-**/MdeModulePkg/Bus/Ufs/UfsBlockIoPei/UfsHci.c:cpp/missing-null-test",
+      "-**/MdeModulePkg/Universal/RegularExpressionDxe/oniguruma/src/**/*:**",
+    ]
+}

--- a/MdeModulePkg/Bus/Ata/AtaAtapiPassThru/IdeMode.c
+++ b/MdeModulePkg/Bus/Ata/AtaAtapiPassThru/IdeMode.c
@@ -943,7 +943,7 @@ AtaPioDataInOut (
   IN     ATA_NONBLOCK_TASK      *Task
   )
 {
-  UINTN       WordCount;
+  UINT64      WordCount;
   UINTN       Increment;
   UINT16      *Buffer16;
   EFI_STATUS  Status;

--- a/MdeModulePkg/Bus/Ata/AtaBusDxe/AtaPassThruExecute.c
+++ b/MdeModulePkg/Bus/Ata/AtaBusDxe/AtaPassThruExecute.c
@@ -929,11 +929,19 @@ EXIT:
     if (EFI_ERROR (Status)) {
       OldTpl                   = gBS->RaiseTPL (TPL_NOTIFY);
       Token->TransactionStatus = Status;
-      *EventCount              = (*EventCount) - (TempCount - Index);
-      *IsError                 = TRUE;
+      if (EventCount != NULL) {
+        *EventCount = (*EventCount) - (TempCount - Index);
+      }
 
-      if (*EventCount == 0) {
+      if (IsError != NULL) {
+        *IsError = TRUE;
+      }
+
+      if ((EventCount != NULL) && (*EventCount == 0)) {
         FreePool (EventCount);
+      }
+
+      if (IsError != NULL) {
         FreePool (IsError);
       }
 

--- a/MdeModulePkg/Bus/Pci/EhciDxe/EhciUrb.c
+++ b/MdeModulePkg/Bus/Pci/EhciDxe/EhciUrb.c
@@ -468,7 +468,7 @@ EhcCreateQtds (
   //
   // Insert the status packet for control transfer
   //
-  if (Ep->Type == EHC_CTRL_TRANSFER) {
+  if ((Ep->Type == EHC_CTRL_TRANSFER) && (StatusQtd != NULL)) {
     InsertTailList (&Qh->Qtds, &StatusQtd->QtdList);
   }
 

--- a/MdeModulePkg/Bus/Pci/EhciPei/EhciUrb.c
+++ b/MdeModulePkg/Bus/Pci/EhciPei/EhciUrb.c
@@ -456,7 +456,7 @@ EhcCreateQtds (
   //
   // Insert the status packet for control transfer
   //
-  if (Ep->Type == EHC_CTRL_TRANSFER) {
+  if ((Ep->Type == EHC_CTRL_TRANSFER) && (StatusQtd != NULL)) {
     InsertTailList (&Qh->Qtds, &StatusQtd->QtdList);
   }
 

--- a/MdeModulePkg/Bus/Pci/IdeBusPei/AtapiPeim.c
+++ b/MdeModulePkg/Bus/Pci/IdeBusPei/AtapiPeim.c
@@ -564,7 +564,7 @@ AtapiEnumerateDevices (
   //
   // Using Command and Control Regs Base Address to fill other registers.
   //
-  for (Index1 = 0; Index1 < IdeEnabledNumber; Index1++) {
+  for (Index1 = 0; (UINT32)Index1 < IdeEnabledNumber; Index1++) {
     CommandBlockBaseAddr                             = IdeRegsBaseAddr[Index1].CommandBlockBaseAddr;
     AtapiBlkIoDev->IdeIoPortReg[Index1].Data         = CommandBlockBaseAddr;
     AtapiBlkIoDev->IdeIoPortReg[Index1].Reg1.Feature = (UINT16)(CommandBlockBaseAddr + 0x1);

--- a/MdeModulePkg/Bus/Pci/NonDiscoverablePciDeviceDxe/NonDiscoverablePciDeviceIo.c
+++ b/MdeModulePkg/Bus/Pci/NonDiscoverablePciDeviceDxe/NonDiscoverablePciDeviceIo.c
@@ -289,6 +289,8 @@ PciIoMemRead (
   EFI_ACPI_ADDRESS_SPACE_DESCRIPTOR  *Desc;
   EFI_STATUS                         Status;
 
+  Desc = NULL;
+
   if (Buffer == NULL) {
     return EFI_INVALID_PARAMETER;
   }
@@ -376,6 +378,8 @@ PciIoMemWrite (
   VOID                               *Address;
   EFI_ACPI_ADDRESS_SPACE_DESCRIPTOR  *Desc;
   EFI_STATUS                         Status;
+
+  Desc = NULL; // MS_CHANGE for vs2017
 
   if (Buffer == NULL) {
     return EFI_INVALID_PARAMETER;
@@ -1008,7 +1012,7 @@ NonCoherentPciIoFreeBuffer (
     }
   }
 
-  if (!Found) {
+  if (!Found || (Alloc == NULL)) {
     ASSERT_EFI_ERROR (EFI_NOT_FOUND);
     return EFI_NOT_FOUND;
   }
@@ -1111,7 +1115,8 @@ NonCoherentPciIoAllocateBuffer (
   NON_DISCOVERABLE_DEVICE_UNCACHED_ALLOCATION  *Alloc;
   VOID                                         *AllocAddress;
 
-  MemType = EFI_MEMORY_XP;
+  MemType      = EFI_MEMORY_XP;
+  AllocAddress = NULL; // MS_CHANGE for vs2017
 
   if (HostAddress == NULL) {
     return EFI_INVALID_PARAMETER;
@@ -1272,6 +1277,8 @@ NonCoherentPciIoMap (
   VOID                                  *AllocAddress;
   EFI_GCD_MEMORY_SPACE_DESCRIPTOR       GcdDescriptor;
   BOOLEAN                               Bounce;
+
+  AllocAddress = NULL; // MS_CHANGE for vs2017
 
   if ((HostAddress   == NULL) ||
       (NumberOfBytes == NULL) ||
@@ -1639,6 +1646,8 @@ PciIoGetBarAttributes (
   EFI_ACPI_ADDRESS_SPACE_DESCRIPTOR  *BarDesc;
   EFI_ACPI_END_TAG_DESCRIPTOR        *End;
   EFI_STATUS                         Status;
+
+  BarDesc = NULL; // MS_CHANGE for vs2017
 
   if ((Supports == NULL) && (Resources == NULL)) {
     return EFI_INVALID_PARAMETER;

--- a/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressPassthru.c
+++ b/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressPassthru.c
@@ -219,10 +219,10 @@ NvmeCreatePrpList (
   OUT VOID                     **Mapping
   )
 {
-  UINTN                 PrpEntryNo;
+  UINT64                PrpEntryNo;
   UINT64                PrpListBase;
-  UINTN                 PrpListIndex;
-  UINTN                 PrpEntryIndex;
+  UINT64                PrpListIndex;
+  UINT64                PrpEntryIndex;
   UINT64                Remainder;
   EFI_PHYSICAL_ADDRESS  PrpListPhyAddr;
   UINTN                 Bytes;

--- a/MdeModulePkg/Bus/Pci/NvmExpressPei/NvmExpressPeiHci.c
+++ b/MdeModulePkg/Bus/Pci/NvmExpressPei/NvmExpressPeiHci.c
@@ -564,14 +564,16 @@ NvmeControllerInit (
   //
   // Dump the NVME controller implementation version
   //
-  NVME_GET_VER (Private, &Ver);
-  DEBUG ((DEBUG_INFO, "NVME controller implementation version: %d.%d\n", Ver.Mjr, Ver.Mnr));
+  Status = NVME_GET_VER (Private, &Ver);
+  if (!EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_INFO, "NVME controller implementation version: %d.%d\n", Ver.Mjr, Ver.Mnr));
+  }
 
   //
   // Read the controller Capabilities register and verify that the NVM command set is supported
   //
-  NVME_GET_CAP (Private, &Private->Cap);
-  if ((Private->Cap.Css & BIT0) == 0) {
+  Status = NVME_GET_CAP (Private, &Private->Cap);
+  if ( !EFI_ERROR (Status) && ((Private->Cap.Css & BIT0) == 0)) {
     DEBUG ((DEBUG_ERROR, "%a: The NVME controller doesn't support NVMe command set.\n", __func__));
     return EFI_UNSUPPORTED;
   }

--- a/MdeModulePkg/Bus/Pci/NvmExpressPei/NvmExpressPeiPassThru.c
+++ b/MdeModulePkg/Bus/Pci/NvmExpressPei/NvmExpressPeiPassThru.c
@@ -27,12 +27,12 @@ NvmeCreatePrpList (
   IN     UINTN                             Pages
   )
 {
-  UINTN                 PrpEntryNo;
+  UINT64                PrpEntryNo;
   UINTN                 PrpListNo;
   UINT64                PrpListBase;
   VOID                  *PrpListHost;
   UINTN                 PrpListIndex;
-  UINTN                 PrpEntryIndex;
+  UINT64                PrpEntryIndex;
   UINT64                Remainder;
   EFI_PHYSICAL_ADDRESS  PrpListPhyAddr;
   UINTN                 Bytes;

--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciBus.c
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciBus.c
@@ -371,13 +371,15 @@ PciBusDriverBindingStart (
   if (gFullEnumeration) {
     gFullEnumeration = FALSE;
 
-    Status = gBS->InstallProtocolInterface (
-                    &PciRootBridgeIo->ParentHandle,
-                    &gEfiPciEnumerationCompleteProtocolGuid,
-                    EFI_NATIVE_INTERFACE,
-                    NULL
-                    );
-    ASSERT_EFI_ERROR (Status);
+    if (PciRootBridgeIo != NULL) {
+      Status = gBS->InstallProtocolInterface (
+                      &PciRootBridgeIo->ParentHandle,
+                      &gEfiPciEnumerationCompleteProtocolGuid,
+                      EFI_NATIVE_INTERFACE,
+                      NULL
+                      );
+      ASSERT_EFI_ERROR (Status);
+    }
   }
 
   return Status;

--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciDeviceSupport.c
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciDeviceSupport.c
@@ -772,7 +772,11 @@ StartPciDevices (
   LIST_ENTRY     *CurrentLink;
 
   RootBridge = GetRootBridgeByHandle (Controller);
-  ASSERT (RootBridge != NULL);
+  if (RootBridge == NULL ) {
+    ASSERT (RootBridge != NULL);
+    return EFI_NOT_READY;
+  }
+
   ThisHostBridge = RootBridge->PciRootBridgeIo->ParentHandle;
 
   CurrentLink = mPciDevicePool.ForwardLink;

--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciIo.c
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciIo.c
@@ -1446,6 +1446,9 @@ SupportPaletteSnoopAttributes (
   //
   if (Temp->Parent == PciIoDevice->Parent) {
     Status = PCI_READ_COMMAND_REGISTER (Temp, &VGACommand);
+    if (EFI_ERROR (Status)) {
+      return EFI_UNSUPPORTED;
+    }
 
     //
     // If they are on the same bus, either one can

--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciOptionRomSupport.c
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciOptionRomSupport.c
@@ -717,7 +717,9 @@ ProcessOpRomImage (
     EfiOpRomImageNode.EndingOffset   = (UINTN)RomBarOffset + ImageSize - 1 - (UINTN)RomBar;
 
     PciOptionRomImageDevicePath = AppendDevicePathNode (PciDevice->DevicePath, &EfiOpRomImageNode.Header);
-    ASSERT (PciOptionRomImageDevicePath != NULL);
+    if (PciOptionRomImageDevicePath == NULL) {
+      return EFI_NOT_FOUND;
+    }
 
     //
     // load image and start image

--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciResourceSupport.c
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciResourceSupport.c
@@ -448,13 +448,15 @@ GetResourceFromDevice (
                  (PciDev->PciBar)[Index].BarType,
                  PciResUsageTypical
                  );
+        if (Node != NULL) {
+          InsertResourceNode (
+            Mem32Node,
+            Node
+            );
 
-        InsertResourceNode (
-          Mem32Node,
-          Node
-          );
+          ResourceRequested = TRUE;
+        }
 
-        ResourceRequested = TRUE;
         break;
 
       case PciBarTypeMem64:
@@ -467,13 +469,15 @@ GetResourceFromDevice (
                  PciBarTypeMem64,
                  PciResUsageTypical
                  );
+        if (Node != NULL) {
+          InsertResourceNode (
+            Mem64Node,
+            Node
+            );
 
-        InsertResourceNode (
-          Mem64Node,
-          Node
-          );
+          ResourceRequested = TRUE;
+        }
 
-        ResourceRequested = TRUE;
         break;
 
       case PciBarTypePMem64:
@@ -486,13 +490,15 @@ GetResourceFromDevice (
                  PciBarTypePMem64,
                  PciResUsageTypical
                  );
+        if (Node != NULL) {
+          InsertResourceNode (
+            PMem64Node,
+            Node
+            );
 
-        InsertResourceNode (
-          PMem64Node,
-          Node
-          );
+          ResourceRequested = TRUE;
+        }
 
-        ResourceRequested = TRUE;
         break;
 
       case PciBarTypePMem32:
@@ -505,12 +511,14 @@ GetResourceFromDevice (
                  PciBarTypePMem32,
                  PciResUsageTypical
                  );
+        if (Node != NULL) {
+          InsertResourceNode (
+            PMem32Node,
+            Node
+            );
+          ResourceRequested = TRUE;
+        }
 
-        InsertResourceNode (
-          PMem32Node,
-          Node
-          );
-        ResourceRequested = TRUE;
         break;
 
       case PciBarTypeIo16:
@@ -524,12 +532,14 @@ GetResourceFromDevice (
                  PciBarTypeIo16,
                  PciResUsageTypical
                  );
+        if (Node != NULL) {
+          InsertResourceNode (
+            IoNode,
+            Node
+            );
+          ResourceRequested = TRUE;
+        }
 
-        InsertResourceNode (
-          IoNode,
-          Node
-          );
-        ResourceRequested = TRUE;
         break;
 
       case PciBarTypeUnknown:
@@ -555,11 +565,12 @@ GetResourceFromDevice (
                  PciBarTypeMem32,
                  PciResUsageTypical
                  );
-
-        InsertResourceNode (
-          Mem32Node,
-          Node
-          );
+        if (Node != NULL) {
+          InsertResourceNode (
+            Mem32Node,
+            Node
+            );
+        }
 
         break;
 
@@ -573,11 +584,12 @@ GetResourceFromDevice (
                  PciBarTypeMem64,
                  PciResUsageTypical
                  );
-
-        InsertResourceNode (
-          Mem64Node,
-          Node
-          );
+        if (Node != NULL) {
+          InsertResourceNode (
+            Mem64Node,
+            Node
+            );
+        }
 
         break;
 
@@ -591,11 +603,12 @@ GetResourceFromDevice (
                  PciBarTypePMem64,
                  PciResUsageTypical
                  );
-
-        InsertResourceNode (
-          PMem64Node,
-          Node
-          );
+        if (Node != NULL) {
+          InsertResourceNode (
+            PMem64Node,
+            Node
+            );
+        }
 
         break;
 
@@ -609,11 +622,13 @@ GetResourceFromDevice (
                  PciBarTypePMem32,
                  PciResUsageTypical
                  );
+        if (Node != NULL) {
+          InsertResourceNode (
+            PMem32Node,
+            Node
+            );
+        }
 
-        InsertResourceNode (
-          PMem32Node,
-          Node
-          );
         break;
 
       case PciBarTypeIo16:
@@ -819,6 +834,32 @@ CreateResourceMap (
                        PciBarTypePMem64,
                        PciResUsageTypical
                        );
+
+      if ((IoBridge == NULL) || (Mem32Bridge == NULL) || (PMem32Bridge == NULL) ||
+          (Mem64Bridge == NULL) || (PMem64Bridge == NULL))
+      {
+        if (IoBridge != NULL) {
+          FreePool (IoBridge);
+        }
+
+        if (Mem32Bridge != NULL) {
+          FreePool (Mem32Bridge);
+        }
+
+        if (PMem32Bridge != NULL) {
+          FreePool (PMem32Bridge);
+        }
+
+        if (Mem64Bridge != NULL) {
+          FreePool (Mem64Bridge);
+        }
+
+        if (PMem64Bridge != NULL) {
+          FreePool (PMem64Bridge);
+        }
+
+        return;
+      }
 
       //
       // Recursively create resource map on this bridge
@@ -1813,11 +1854,13 @@ ResourcePaddingForCardBusBridge (
            PciBarTypeMem32,
            PciResUsagePadding
            );
-
-  InsertResourceNode (
-    Mem32Node,
-    Node
-    );
+  ASSERT (Node != NULL);
+  if (Node != NULL) {
+    InsertResourceNode (
+      Mem32Node,
+      Node
+      );
+  }
 
   //
   // Memory Base/Limit Register 1
@@ -1832,10 +1875,13 @@ ResourcePaddingForCardBusBridge (
            PciResUsagePadding
            );
 
-  InsertResourceNode (
-    PMem32Node,
-    Node
-    );
+  ASSERT (Node != NULL);
+  if (Node != NULL) {
+    InsertResourceNode (
+      PMem32Node,
+      Node
+      );
+  }
 
   //
   // Io Base/Limit
@@ -1850,10 +1896,13 @@ ResourcePaddingForCardBusBridge (
            PciResUsagePadding
            );
 
-  InsertResourceNode (
-    IoNode,
-    Node
-    );
+  ASSERT (Node != NULL);
+  if (Node != NULL) {
+    InsertResourceNode (
+      IoNode,
+      Node
+      );
+  }
 
   //
   // Io Base/Limit
@@ -1868,10 +1917,13 @@ ResourcePaddingForCardBusBridge (
            PciResUsagePadding
            );
 
-  InsertResourceNode (
-    IoNode,
-    Node
-    );
+  ASSERT (Node != NULL);
+  if (Node != NULL) {
+    InsertResourceNode (
+      IoNode,
+      Node
+      );
+  }
 }
 
 /**
@@ -2142,10 +2194,13 @@ ApplyResourcePadding (
                  PciBarTypeIo16,
                  PciResUsagePadding
                  );
-        InsertResourceNode (
-          IoNode,
-          Node
-          );
+
+        if (Node != NULL) {
+          InsertResourceNode (
+            IoNode,
+            Node
+            );
+        }
       }
 
       Ptr++;
@@ -2167,10 +2222,12 @@ ApplyResourcePadding (
                      PciBarTypePMem32,
                      PciResUsagePadding
                      );
-            InsertResourceNode (
-              PMem32Node,
-              Node
-              );
+            if (Node != NULL) {
+              InsertResourceNode (
+                PMem32Node,
+                Node
+                );
+            }
           }
 
           Ptr++;
@@ -2190,10 +2247,12 @@ ApplyResourcePadding (
                      PciBarTypeMem32,
                      PciResUsagePadding
                      );
-            InsertResourceNode (
-              Mem32Node,
-              Node
-              );
+            if (Node != NULL) {
+              InsertResourceNode (
+                Mem32Node,
+                Node
+                );
+            }
           }
 
           Ptr++;
@@ -2215,10 +2274,12 @@ ApplyResourcePadding (
                      PciBarTypePMem64,
                      PciResUsagePadding
                      );
-            InsertResourceNode (
-              PMem64Node,
-              Node
-              );
+            if (Node != NULL) {
+              InsertResourceNode (
+                PMem64Node,
+                Node
+                );
+            }
           }
 
           Ptr++;
@@ -2238,10 +2299,12 @@ ApplyResourcePadding (
                      PciBarTypeMem64,
                      PciResUsagePadding
                      );
-            InsertResourceNode (
-              Mem64Node,
-              Node
-              );
+            if (Node != NULL) {
+              InsertResourceNode (
+                Mem64Node,
+                Node
+                );
+            }
           }
 
           Ptr++;

--- a/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostBridge.c
+++ b/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostBridge.c
@@ -667,7 +667,10 @@ ResourceConflict (
                 RootBridgeCount * (TypeMax * sizeof (EFI_ACPI_ADDRESS_SPACE_DESCRIPTOR) + sizeof (EFI_ACPI_END_TAG_DESCRIPTOR)) +
                 sizeof (EFI_ACPI_END_TAG_DESCRIPTOR)
                 );
-  ASSERT (Resources != NULL);
+  if (Resources == NULL) {
+    ASSERT (Resources != NULL);
+    return;
+  }
 
   for (Link = GetFirstNode (&HostBridge->RootBridges), Descriptor = Resources
        ; !IsNull (&HostBridge->RootBridges, Link)

--- a/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciRootBridgeIo.c
+++ b/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciRootBridgeIo.c
@@ -246,7 +246,7 @@ CreateRootBridge (
     }
 
     RootBridge->ResAllocNode[Index].Type = Index;
-    if (Bridge->ResourceAssigned && (Aperture->Limit >= Aperture->Base)) {
+    if (Bridge->ResourceAssigned && (Aperture != NULL) && (Aperture->Limit >= Aperture->Base)) {
       //
       // Base in ResAllocNode is a host address, while Base in Aperture is a
       // device address.

--- a/MdeModulePkg/Bus/Pci/PciSioSerialDxe/SerialIo.c
+++ b/MdeModulePkg/Bus/Pci/PciSioSerialDxe/SerialIo.c
@@ -1234,7 +1234,7 @@ SerialRead (
   )
 {
   SERIAL_DEV  *SerialDevice;
-  UINT32      Index;
+  UINTN       Index;
   UINT8       *CharBuffer;
   UINTN       Elapsed;
   EFI_STATUS  Status;

--- a/MdeModulePkg/Bus/Pci/SdMmcPciHcDxe/SdMmcPciHcDxe.c
+++ b/MdeModulePkg/Bus/Pci/SdMmcPciHcDxe/SdMmcPciHcDxe.c
@@ -545,6 +545,7 @@ SdMmcPciHcDriverBindingStart (
   EFI_PCI_IO_PROTOCOL       *PciIo;
   UINT64                    Supports;
   UINT64                    PciAttributes;
+  UINT8                     SlotMax;
   UINT8                     SlotNum;
   UINT8                     FirstBar;
   UINT8                     Slot;
@@ -647,7 +648,13 @@ SdMmcPciHcDriverBindingStart (
   }
 
   Support64BitDma = TRUE;
-  for (Slot = FirstBar; Slot < (FirstBar + SlotNum); Slot++) {
+  Status          = SafeUint8Add (FirstBar, SlotNum, &SlotMax);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "[%a] Overflow when calculating SlotMax!\n", __func__));
+    goto Done;
+  }
+
+  for (Slot = FirstBar; Slot < SlotMax; Slot++) {
     Private->Slot[Slot].Enable = TRUE;
     //
     // Get SD/MMC Pci Host Controller Version

--- a/MdeModulePkg/Bus/Pci/SdMmcPciHcDxe/SdMmcPciHcDxe.h
+++ b/MdeModulePkg/Bus/Pci/SdMmcPciHcDxe/SdMmcPciHcDxe.h
@@ -25,6 +25,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/UefiLib.h>
 #include <Library/DevicePathLib.h>
 #include <Library/PcdLib.h>
+#include <Library/SafeIntLib.h> // MU_CHANGE - CodeQL Change - Enable SafeIntLib usage
 
 #include <Protocol/DevicePath.h>
 #include <Protocol/PciIo.h>

--- a/MdeModulePkg/Bus/Pci/SdMmcPciHcDxe/SdMmcPciHcDxe.inf
+++ b/MdeModulePkg/Bus/Pci/SdMmcPciHcDxe/SdMmcPciHcDxe.inf
@@ -57,6 +57,7 @@
   UefiDriverEntryPoint
   DebugLib
   PcdLib
+  SafeIntLib # MU_CHANGE - CodeQL Change
 
 [Protocols]
   gEdkiiSdMmcOverrideProtocolGuid               ## SOMETIMES_CONSUMES

--- a/MdeModulePkg/Bus/Pci/SdMmcPciHcDxe/SdMmcPciHci.c
+++ b/MdeModulePkg/Bus/Pci/SdMmcPciHcDxe/SdMmcPciHci.c
@@ -1476,7 +1476,7 @@ BuildAdmaDescTable (
   EFI_PHYSICAL_ADDRESS  Data;
   UINT64                DataLen;
   UINT64                Entries;
-  UINT32                Index;
+  UINT64                Index;
   UINT64                Remaining;
   UINT64                Address;
   UINTN                 TableSize;

--- a/MdeModulePkg/Bus/Pci/SdMmcPciHcPei/SdMmcPciHcPei.c
+++ b/MdeModulePkg/Bus/Pci/SdMmcPciHcPei/SdMmcPciHcPei.c
@@ -84,6 +84,7 @@ InitializeSdMmcHcPeim (
   UINT8                       SubClass;
   UINT8                       BaseClass;
   UINT8                       SlotInfo;
+  UINT8                       SlotMax;
   UINT8                       SlotNum;
   UINT8                       FirstBar;
   UINT8                       Index;
@@ -133,7 +134,13 @@ InitializeSdMmcHcPeim (
           SlotNum  = (*(SD_MMC_HC_PEI_SLOT_INFO *)&SlotInfo).SlotNum + 1;
           ASSERT ((FirstBar + SlotNum) < MAX_SD_MMC_SLOTS);
 
-          for (Index = 0, Slot = FirstBar; Slot < (FirstBar + SlotNum); Index++, Slot++) {
+          Status = SafeUint8Add (FirstBar, SlotNum, &SlotMax);
+          if (EFI_ERROR (Status)) {
+            DEBUG ((DEBUG_ERROR, "[%a] Overflow when calculating SlotMax!\n", __func__));
+            return Status;
+          }
+
+          for (Index = 0, Slot = FirstBar; Slot < SlotMax; Index++, Slot++) {
             //
             // Get the SD/MMC Pci host controller's MMIO region size.
             //

--- a/MdeModulePkg/Bus/Pci/SdMmcPciHcPei/SdMmcPciHcPei.h
+++ b/MdeModulePkg/Bus/Pci/SdMmcPciHcPei/SdMmcPciHcPei.h
@@ -21,6 +21,7 @@
 #include <Library/PciLib.h>
 #include <Library/PeiServicesLib.h>
 #include <Library/MemoryAllocationLib.h>
+#include <Library/SafeIntLib.h> // MU_CHANGE - CodeQL Change - Enable SafeIntLib usage
 
 #define SD_MMC_HC_PEI_SIGNATURE  SIGNATURE_32 ('S', 'D', 'M', 'C')
 

--- a/MdeModulePkg/Bus/Pci/SdMmcPciHcPei/SdMmcPciHcPei.inf
+++ b/MdeModulePkg/Bus/Pci/SdMmcPciHcPei/SdMmcPciHcPei.inf
@@ -37,6 +37,7 @@
   PeiServicesLib
   MemoryAllocationLib
   PeimEntryPoint
+  SafeIntLib # MU_CHANGE - CodeQL Change
 
 [Pcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdSdMmcPciHostControllerMmioBase   ## CONSUMES

--- a/MdeModulePkg/Bus/Pci/UhciPei/UhcPeim.c
+++ b/MdeModulePkg/Bus/Pci/UhciPei/UhcPeim.c
@@ -272,7 +272,8 @@ UhcControlTransfer (
 
   StatusReg = UhcDev->UsbHostControllerBaseAddress + USBSTS;
 
-  PktID = INPUT_PACKET_ID;
+  PktID   = INPUT_PACKET_ID;
+  DataMap = NULL;
 
   RequestMap = NULL;
 
@@ -546,6 +547,7 @@ UhcBulkTransfer (
   PtrTD      = NULL;
   PtrFirstTD = NULL;
   PtrPreTD   = NULL;
+  DataMap    = NULL;
   DataLen    = 0;
 
   ShortPacketEnable = FALSE;
@@ -2848,6 +2850,8 @@ InitializeMemoryManagement (
   EFI_STATUS            Status;
   UINTN                 MemPages;
 
+  MemoryHeader = NULL;
+
   MemPages = NORMAL_MEMORY_BLOCK_UNIT_IN_PAGES;
   Status   = CreateMemoryBlock (UhcDev, &MemoryHeader, MemPages);
   if (EFI_ERROR (Status)) {
@@ -2885,6 +2889,8 @@ UhcAllocatePool (
   EFI_STATUS            Status;
 
   *Pool = NULL;
+
+  NewMemoryHeader = NULL;
 
   MemoryHeader = UhcDev->Header1;
 

--- a/MdeModulePkg/Bus/Pci/XhciDxe/XhciSched.c
+++ b/MdeModulePkg/Bus/Pci/XhciDxe/XhciSched.c
@@ -514,7 +514,11 @@ XhcInitSched (
   Entries = (Xhc->MaxSlotsEn + 1) * sizeof (UINT64);
   Dcbaa   = UsbHcAllocateMem (Xhc->MemPool, Entries, FALSE);
   ASSERT (Dcbaa != NULL);
-  ZeroMem (Dcbaa, Entries);
+  if (Dcbaa != NULL) {
+    ZeroMem (Dcbaa, Entries);
+  } else {
+    return;
+  }
 
   //
   // A Scratchpad Buffer is a PAGESIZE block of system memory located on a PAGESIZE boundary.
@@ -804,6 +808,10 @@ CreateEventRing (
   Buf  = UsbHcAllocateMem (Xhc->MemPool, Size, TRUE);
   ASSERT (Buf != NULL);
   ASSERT (((UINTN)Buf & 0x3F) == 0);
+  if (Buf == NULL) {
+    return;
+  }
+
   ZeroMem (Buf, Size);
 
   EventRing->EventRingSeg0    = Buf;
@@ -823,6 +831,10 @@ CreateEventRing (
   Buf  = UsbHcAllocateMem (Xhc->MemPool, Size, FALSE);
   ASSERT (Buf != NULL);
   ASSERT (((UINTN)Buf & 0x3F) == 0);
+  if (Buf == NULL) {
+    return;
+  }
+
   ZeroMem (Buf, Size);
 
   ERSTBase              = (EVENT_RING_SEG_TABLE_ENTRY *)Buf;
@@ -901,6 +913,10 @@ CreateTransferRing (
   Buf = UsbHcAllocateMem (Xhc->MemPool, sizeof (TRB_TEMPLATE) * TrbNum, TRUE);
   ASSERT (Buf != NULL);
   ASSERT (((UINTN)Buf & 0x3F) == 0);
+  if (Buf == NULL) {
+    return;
+  }
+
   ZeroMem (Buf, sizeof (TRB_TEMPLATE) * TrbNum);
 
   TransferRing->RingSeg0    = Buf;
@@ -1044,7 +1060,7 @@ IsTransferRingTrb (
     // If the checked TRB is the link TRB at the end of the transfer ring,
     // recircle it to the head of the ring.
     //
-    if (CheckedTrb->Type == TRB_TYPE_LINK) {
+    if ((CheckedTrb != NULL) && (CheckedTrb->Type == TRB_TYPE_LINK)) {
       LinkTrb    = (LINK_TRB *)CheckedTrb;
       PhyAddr    = (EFI_PHYSICAL_ADDRESS)(LinkTrb->PtrLo | LShiftU64 ((UINT64)LinkTrb->PtrHi, 32));
       CheckedTrb = (TRB_TEMPLATE *)(UINTN)UsbHcGetHostAddrForPciAddr (Xhc->MemPool, (VOID *)(UINTN)PhyAddr, sizeof (TRB_TEMPLATE), FALSE);
@@ -1157,6 +1173,10 @@ XhcCheckUrbResult (
     //
     PhyAddr = (EFI_PHYSICAL_ADDRESS)(EvtTrb->TRBPtrLo | LShiftU64 ((UINT64)EvtTrb->TRBPtrHi, 32));
     TRBPtr  = (TRB_TEMPLATE *)(UINTN)UsbHcGetHostAddrForPciAddr (Xhc->MemPool, (VOID *)(UINTN)PhyAddr, sizeof (TRB_TEMPLATE), FALSE);
+    if (TRBPtr == NULL) {
+      ASSERT (TRBPtr != NULL);
+      goto EXIT;
+    }
 
     //
     // Update the status of URB including the pending URB, the URB that is currently checked,
@@ -2200,6 +2220,10 @@ XhcInitializeDeviceSlot (
   InputContext = UsbHcAllocateMem (Xhc->MemPool, sizeof (INPUT_CONTEXT), FALSE);
   ASSERT (InputContext != NULL);
   ASSERT (((UINTN)InputContext & 0x3F) == 0);
+  if (InputContext == NULL) {
+    return RETURN_OUT_OF_RESOURCES;
+  }
+
   ZeroMem (InputContext, sizeof (INPUT_CONTEXT));
 
   Xhc->UsbDevContext[SlotId].InputContext = (VOID *)InputContext;
@@ -2303,6 +2327,10 @@ XhcInitializeDeviceSlot (
   OutputContext = UsbHcAllocateMem (Xhc->MemPool, sizeof (DEVICE_CONTEXT), FALSE);
   ASSERT (OutputContext != NULL);
   ASSERT (((UINTN)OutputContext & 0x3F) == 0);
+  if (OutputContext == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
   ZeroMem (OutputContext, sizeof (DEVICE_CONTEXT));
 
   Xhc->UsbDevContext[SlotId].OutputContext = OutputContext;
@@ -2426,6 +2454,10 @@ XhcInitializeDeviceSlot64 (
   InputContext = UsbHcAllocateMem (Xhc->MemPool, sizeof (INPUT_CONTEXT_64), FALSE);
   ASSERT (InputContext != NULL);
   ASSERT (((UINTN)InputContext & 0x3F) == 0);
+  if (InputContext == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
   ZeroMem (InputContext, sizeof (INPUT_CONTEXT_64));
 
   Xhc->UsbDevContext[SlotId].InputContext = (VOID *)InputContext;
@@ -2529,6 +2561,10 @@ XhcInitializeDeviceSlot64 (
   OutputContext = UsbHcAllocateMem (Xhc->MemPool, sizeof (DEVICE_CONTEXT_64), FALSE);
   ASSERT (OutputContext != NULL);
   ASSERT (((UINTN)OutputContext & 0x3F) == 0);
+  if (OutputContext == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
   ZeroMem (OutputContext, sizeof (DEVICE_CONTEXT_64));
 
   Xhc->UsbDevContext[SlotId].OutputContext = OutputContext;

--- a/MdeModulePkg/Bus/Pci/XhciPei/UsbHcMem.c
+++ b/MdeModulePkg/Bus/Pci/XhciPei/UsbHcMem.c
@@ -32,6 +32,8 @@ UsbHcAllocMemBlock (
   UINTN                 PageNumber;
   EFI_PHYSICAL_ADDRESS  TempPtr;
 
+  Mapping = NULL;
+
   PageNumber = EFI_SIZE_TO_PAGES (sizeof (USBHC_MEM_BLOCK));
   Status     = PeiServicesAllocatePages (
                  EfiBootServicesData,

--- a/MdeModulePkg/Bus/Scsi/ScsiDiskDxe/ScsiDisk.c
+++ b/MdeModulePkg/Bus/Scsi/ScsiDiskDxe/ScsiDisk.c
@@ -2535,8 +2535,8 @@ ScsiDiskInquiryDevice (
   EFI_SCSI_SENSE_DATA                    *SenseDataArray;
   UINTN                                  NumberOfSenseKeys;
   EFI_STATUS                             Status;
-  UINT8                                  MaxRetry;
-  UINT8                                  Index;
+  UINT32                                 MaxRetry;
+  UINT32                                 Index;
   EFI_SCSI_SUPPORTED_VPD_PAGES_VPD_PAGE  *SupportedVpdPages;
   EFI_SCSI_BLOCK_LIMITS_VPD_PAGE         *BlockLimits;
   UINTN                                  PageLength;
@@ -2619,7 +2619,7 @@ ScsiDiskInquiryDevice (
         //
         // Locate the code for the Block Limits VPD page
         //
-        for (Index = 0; Index < PageLength; Index++) {
+        for (Index = 0; (UINTN)Index < PageLength; Index++) {
           //
           // Sanity check
           //

--- a/MdeModulePkg/Bus/Sd/EmmcBlockIoPei/EmmcHcMem.c
+++ b/MdeModulePkg/Bus/Sd/EmmcBlockIoPei/EmmcHcMem.c
@@ -30,6 +30,7 @@ EmmcPeimAllocMemBlock (
 
   TempPtr = NULL;
   Block   = NULL;
+  Mapping = NULL;
 
   Status = PeiServicesAllocatePool (sizeof (EMMC_PEIM_MEM_BLOCK), &TempPtr);
   if (EFI_ERROR (Status)) {

--- a/MdeModulePkg/Bus/Sd/EmmcBlockIoPei/EmmcHci.c
+++ b/MdeModulePkg/Bus/Sd/EmmcBlockIoPei/EmmcHci.c
@@ -934,7 +934,7 @@ BuildAdmaDescTable (
   EFI_PHYSICAL_ADDRESS  Data;
   UINT64                DataLen;
   UINT64                Entries;
-  UINT32                Index;
+  UINT64                Index;
   UINT64                Remaining;
   UINT32                Address;
 

--- a/MdeModulePkg/Bus/Sd/SdBlockIoPei/SdHcMem.c
+++ b/MdeModulePkg/Bus/Sd/SdBlockIoPei/SdHcMem.c
@@ -30,6 +30,7 @@ SdPeimAllocMemBlock (
 
   TempPtr = NULL;
   Block   = NULL;
+  Mapping = NULL;
 
   Status = PeiServicesAllocatePool (sizeof (SD_PEIM_MEM_BLOCK), &TempPtr);
   if (EFI_ERROR (Status)) {

--- a/MdeModulePkg/Bus/Ufs/UfsBlockIoPei/UfsHcMem.c
+++ b/MdeModulePkg/Bus/Ufs/UfsBlockIoPei/UfsHcMem.c
@@ -31,6 +31,7 @@ UfsPeimAllocMemBlock (
 
   TempPtr = NULL;
   Block   = NULL;
+  Mapping = NULL;
 
   Status = PeiServicesAllocatePool (sizeof (UFS_PEIM_MEM_BLOCK), &TempPtr);
   if (EFI_ERROR (Status)) {

--- a/MdeModulePkg/Bus/Ufs/UfsBlockIoPei/UfsHci.c
+++ b/MdeModulePkg/Bus/Ufs/UfsBlockIoPei/UfsHci.c
@@ -317,7 +317,7 @@ UfsInitUtpPrdt (
   IN  UINT32      BufferSize
   )
 {
-  UINT32  PrdtIndex;
+  UINTN   PrdtIndex;
   UINT32  RemainingLen;
   UINT8   *Remaining;
   UINTN   PrdtNumber;
@@ -553,7 +553,7 @@ UfsCreateDMCommandDesc (
 
   if (((Opcode != UtpQueryFuncOpcodeRdFlag) && (Opcode != UtpQueryFuncOpcodeSetFlag) &&
        (Opcode != UtpQueryFuncOpcodeClrFlag) && (Opcode != UtpQueryFuncOpcodeTogFlag) &&
-       (Opcode != UtpQueryFuncOpcodeRdAttr)) && ((DataSize == 0) || (Data == NULL)))
+       (Opcode != UtpQueryFuncOpcodeRdAttr)) && ((DataSize != 0) && (Data == NULL)))
   {
     return EFI_INVALID_PARAMETER;
   }

--- a/MdeModulePkg/Bus/Ufs/UfsPassThruDxe/UfsPassThruHci.c
+++ b/MdeModulePkg/Bus/Ufs/UfsPassThruDxe/UfsPassThruHci.c
@@ -405,7 +405,7 @@ UfsInitUtpPrdt (
   Remaining    = Buffer;
   PrdtNumber   = (UINTN)DivU64x32 ((UINT64)BufferSize + UFS_MAX_DATA_LEN_PER_PRD - 1, UFS_MAX_DATA_LEN_PER_PRD);
 
-  for (PrdtIndex = 0; PrdtIndex < PrdtNumber; PrdtIndex++) {
+  for (PrdtIndex = 0; (UINTN)PrdtIndex < PrdtNumber; PrdtIndex++) {
     if (RemainingLen < UFS_MAX_DATA_LEN_PER_PRD) {
       Prdt[PrdtIndex].DbCount = (UINT32)RemainingLen - 1;
     } else {

--- a/MdeModulePkg/Core/Dxe/Hand/Handle.c
+++ b/MdeModulePkg/Core/Dxe/Hand/Handle.c
@@ -1287,7 +1287,7 @@ Done:
     // Keep Interface unmodified in case of any Error
     // except EFI_ALREADY_STARTED and EFI_UNSUPPORTED.
     //
-    if (!EFI_ERROR (Status) || (Status == EFI_ALREADY_STARTED)) {
+    if ((!EFI_ERROR (Status) || (Status == EFI_ALREADY_STARTED)) && (Prot != NULL)) {
       //
       // According to above logic, if 'Prot' is NULL, then the 'Status' must be
       // EFI_UNSUPPORTED. Here the 'Status' is not EFI_UNSUPPORTED, so 'Prot'

--- a/MdeModulePkg/Core/Dxe/Image/Image.c
+++ b/MdeModulePkg/Core/Dxe/Image/Image.c
@@ -162,7 +162,10 @@ PeCoffEmuProtocolNotify (
     }
 
     Entry = AllocateZeroPool (sizeof (*Entry));
-    ASSERT (Entry != NULL);
+    if (Entry == NULL) {
+      ASSERT (Entry != NULL);
+      break;
+    }
 
     Entry->Emulator    = Emulator;
     Entry->MachineType = Entry->Emulator->MachineType;
@@ -1260,6 +1263,11 @@ CoreLoadImageCommon (
         // LoadFile () may cause the device path of the Handle be updated.
         //
         OriginalFilePath = AppendDevicePath (DevicePathFromHandle (DeviceHandle), Node);
+        if (OriginalFilePath == NULL) {
+          Image  = NULL;
+          Status = EFI_OUT_OF_RESOURCES;
+          goto Done;
+        }
       }
     }
   }

--- a/MdeModulePkg/Core/Dxe/Mem/MemoryProfileRecord.c
+++ b/MdeModulePkg/Core/Dxe/Mem/MemoryProfileRecord.c
@@ -1274,8 +1274,11 @@ CoreUpdateProfileFree (
       }
     }
 
-    ASSERT (DriverInfoData != NULL);
-    ASSERT (AllocInfoData != NULL);
+    if ((DriverInfoData == NULL) || (AllocInfoData == NULL)) {
+      ASSERT (DriverInfoData != NULL);
+      ASSERT (AllocInfoData != NULL);
+      return EFI_NOT_FOUND;
+    }
 
     Found = TRUE;
 

--- a/MdeModulePkg/Core/Dxe/Mem/Page.c
+++ b/MdeModulePkg/Core/Dxe/Mem/Page.c
@@ -339,7 +339,12 @@ CoreFreeMemoryMapStack (
     //
     Entry = AllocateMemoryMapEntry ();
 
-    ASSERT (Entry);
+    // If entry allocation failed once, it is unlikely to succeed moving forward
+    // However, we can try since we're in the middle of moving list nodes
+    if (Entry == NULL) {
+      ASSERT (Entry != NULL);
+      continue;
+    }
 
     //
     // Update to proper entry
@@ -876,7 +881,7 @@ CoreConvertPagesEx (
       }
     }
 
-    if (Link == &gMemoryMap) {
+    if ((Link == &gMemoryMap) || (Entry == NULL)) {
       DEBUG ((DEBUG_ERROR | DEBUG_PAGE, "ConvertPages: failed to find range %lx - %lx\n", Start, End));
       return EFI_NOT_FOUND;
     }
@@ -898,8 +903,11 @@ CoreConvertPagesEx (
     // if that's all we've got
     //
     RangeEnd = End;
+    if (Entry == NULL) {
+      ASSERT (Entry != NULL);
+      return EFI_NOT_FOUND;
+    }
 
-    ASSERT (Entry != NULL);
     if (Entry->End < End) {
       RangeEnd = Entry->End;
     }

--- a/MdeModulePkg/Core/Dxe/Mem/Pool.c
+++ b/MdeModulePkg/Core/Dxe/Mem/Pool.c
@@ -427,6 +427,10 @@ CoreAllocatePoolI (
     NoPages  = EFI_SIZE_TO_PAGES (Size) + EFI_SIZE_TO_PAGES (Granularity) - 1;
     NoPages &= ~(UINTN)(EFI_SIZE_TO_PAGES (Granularity) - 1);
     Head     = CoreAllocatePoolPagesI (PoolType, NoPages, Granularity, NeedGuard);
+    if (Head == NULL) {
+      return NULL;
+    }
+
     if (NeedGuard) {
       Head = AdjustPoolHeadA ((EFI_PHYSICAL_ADDRESS)(UINTN)Head, NoPages, Size);
     }

--- a/MdeModulePkg/Core/Dxe/Misc/MemoryAttributesTable.c
+++ b/MdeModulePkg/Core/Dxe/Misc/MemoryAttributesTable.c
@@ -149,7 +149,10 @@ InstallMemoryAttributesTable (
 
   do {
     MemoryMap = AllocatePool (MemoryMapSize);
-    ASSERT (MemoryMap != NULL);
+    if (MemoryMap == NULL) {
+      ASSERT (MemoryMap != NULL);
+      return;
+    }
 
     Status = CoreGetMemoryMapWithSeparatedImageSection (
                &MemoryMapSize,
@@ -180,7 +183,12 @@ InstallMemoryAttributesTable (
   // Allocate MemoryAttributesTable
   //
   MemoryAttributesTable = AllocatePool (sizeof (EFI_MEMORY_ATTRIBUTES_TABLE) + DescriptorSize * RuntimeEntryCount);
-  ASSERT (MemoryAttributesTable != NULL);
+  if (MemoryAttributesTable == NULL) {
+    ASSERT (MemoryAttributesTable != NULL);
+    FreePool (MemoryMapStart);
+    return;
+  }
+
   MemoryAttributesTable->Version         = EFI_MEMORY_ATTRIBUTES_TABLE_VERSION;
   MemoryAttributesTable->NumberOfEntries = RuntimeEntryCount;
   MemoryAttributesTable->DescriptorSize  = (UINT32)DescriptorSize;

--- a/MdeModulePkg/Core/Dxe/SectionExtraction/CoreSectionExtraction.c
+++ b/MdeModulePkg/Core/Dxe/SectionExtraction/CoreSectionExtraction.c
@@ -626,7 +626,10 @@ CreateGuidedExtractionRpnEvent (
   // Allocate new event structure and context
   //
   Context = AllocatePool (sizeof (RPN_EVENT_CONTEXT));
-  ASSERT (Context != NULL);
+  if (Context == NULL) {
+    ASSERT (Context != NULL);
+    return;
+  }
 
   Context->ChildNode    = ChildNode;
   Context->ParentStream = ParentStream;

--- a/MdeModulePkg/Core/DxeIplPeim/DxeLoad.c
+++ b/MdeModulePkg/Core/DxeIplPeim/DxeLoad.c
@@ -162,7 +162,11 @@ InstallIplPermanentMemoryPpis (
   //
   if (ExtractHandlerNumber > 0) {
     GuidPpi = (EFI_PEI_PPI_DESCRIPTOR *)AllocatePool (ExtractHandlerNumber * sizeof (EFI_PEI_PPI_DESCRIPTOR));
-    ASSERT (GuidPpi != NULL);
+    if (GuidPpi == NULL) {
+      ASSERT (GuidPpi != NULL);
+      return EFI_OUT_OF_RESOURCES;
+    }
+
     while (ExtractHandlerNumber-- > 0) {
       GuidPpi->Flags = EFI_PEI_PPI_DESCRIPTOR_PPI | EFI_PEI_PPI_DESCRIPTOR_TERMINATE_LIST;
       GuidPpi->Ppi   = (VOID *)&mCustomGuidedSectionExtractionPpi;

--- a/MdeModulePkg/Core/Pei/FwVol/FwVol.c
+++ b/MdeModulePkg/Core/Pei/FwVol/FwVol.c
@@ -338,7 +338,7 @@ FindFileEx (
   FileOffset = (UINT32)((UINT8 *)FfsFileHeader - (UINT8 *)FwVolHeader);
   ASSERT (FileOffset <= 0xFFFFFFFF);
 
-  while (FileOffset < (FvLength - sizeof (EFI_FFS_FILE_HEADER))) {
+  while ((UINTN)FileOffset < (UINTN)(FvLength - sizeof (EFI_FFS_FILE_HEADER))) {
     //
     // Get FileState which is the highest bit of the State
     //
@@ -792,7 +792,7 @@ ProcessSection (
 {
   EFI_STATUS                             Status;
   UINT32                                 SectionLength;
-  UINT32                                 ParsedLength;
+  UINTN                                  ParsedLength;
   EFI_PEI_GUIDED_SECTION_EXTRACTION_PPI  *GuidSectionPpi;
   EFI_PEI_DECOMPRESS_PPI                 *DecompressPpi;
   VOID                                   *PpiOutput;

--- a/MdeModulePkg/Core/Pei/Hob/Hob.c
+++ b/MdeModulePkg/Core/Pei/Hob/Hob.c
@@ -17,7 +17,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
   @retval EFI_SUCCESS                  Get the pointer of HOB List
   @retval EFI_NOT_AVAILABLE_YET        the HOB List is not yet published
-  @retval EFI_INVALID_PARAMETER        HobList is NULL (in debug mode)
+  @retval EFI_INVALID_PARAMETER        HobList is NULL
 
 **/
 EFI_STATUS
@@ -32,13 +32,9 @@ PeiGetHobList (
   //
   // Only check this parameter in debug mode
   //
-
-  DEBUG_CODE_BEGIN ();
   if (HobList == NULL) {
     return EFI_INVALID_PARAMETER;
   }
-
-  DEBUG_CODE_END ();
 
   PrivateData = PEI_CORE_INSTANCE_FROM_PS_THIS (PeiServices);
 

--- a/MdeModulePkg/Core/Pei/Ppi/Ppi.c
+++ b/MdeModulePkg/Core/Pei/Ppi/Ppi.c
@@ -163,7 +163,7 @@ ConvertPpiPointers (
   IN PEI_CORE_INSTANCE           *PrivateData
   )
 {
-  UINT8  Index;
+  UINTN  Index;
 
   //
   // Convert normal PPIs.
@@ -217,7 +217,7 @@ ConvertPpiPointersFv (
   IN  UINTN              FvSize
   )
 {
-  UINT8                             Index;
+  UINTN                             Index;
   UINTN                             Offset;
   BOOLEAN                           OffsetPositive;
   EFI_PEI_FIRMWARE_VOLUME_INFO_PPI  *FvInfoPpi;
@@ -324,16 +324,7 @@ ConvertPpiPointersFv (
 
     Guid = PrivateData->PpiData.PpiList.PpiPtrs[Index].Ppi->Guid;
     for (GuidIndex = 0; GuidIndex < ARRAY_SIZE (GuidCheckList); ++GuidIndex) {
-      //
-      // Don't use CompareGuid function here for performance reasons.
-      // Instead we compare the GUID as INT32 at a time and branch
-      // on the first failed comparison.
-      //
-      if ((((INT32 *)Guid)[0] == ((INT32 *)GuidCheckList[GuidIndex])[0]) &&
-          (((INT32 *)Guid)[1] == ((INT32 *)GuidCheckList[GuidIndex])[1]) &&
-          (((INT32 *)Guid)[2] == ((INT32 *)GuidCheckList[GuidIndex])[2]) &&
-          (((INT32 *)Guid)[3] == ((INT32 *)GuidCheckList[GuidIndex])[3]))
-      {
+      if (CompareGuid (Guid, GuidCheckList[GuidIndex]) == 0) {
         FvInfoPpi = PrivateData->PpiData.PpiList.PpiPtrs[Index].Ppi->Ppi;
         DEBUG ((DEBUG_VERBOSE, "      FvInfo: %p -> ", FvInfoPpi->FvInfo));
         if ((UINTN)FvInfoPpi->FvInfo == OrgFvHandle) {

--- a/MdeModulePkg/Core/PiSmmCore/HeapGuard.c
+++ b/MdeModulePkg/Core/PiSmmCore/HeapGuard.c
@@ -268,7 +268,10 @@ FindGuardedMemoryMap (
       Size = (mLevelMask[GUARDED_HEAP_MAP_TABLE_DEPTH - mMapLevel - 1] + 1)
              * GUARDED_HEAP_MAP_ENTRY_BYTES;
       MapMemory = (UINT64)(UINTN)PageAlloc (EFI_SIZE_TO_PAGES (Size));
-      ASSERT (MapMemory != 0);
+      if (MapMemory == 0) {
+        ASSERT (MapMemory != 0);
+        return 0;
+      }
 
       SetMem ((VOID *)(UINTN)MapMemory, Size, 0);
 

--- a/MdeModulePkg/Core/PiSmmCore/MemoryAttributesTable.c
+++ b/MdeModulePkg/Core/PiSmmCore/MemoryAttributesTable.c
@@ -433,6 +433,8 @@ SmmInstallImageRecord (
   UINTN                      Index;
   EFI_SMM_DRIVER_ENTRY       DriverEntry;
 
+  HandleBuffer = NULL;
+
   Status = SmmLocateHandleBuffer (
              ByProtocol,
              &gEfiLoadedImageProtocolGuid,
@@ -469,7 +471,9 @@ SmmInstallImageRecord (
     SmmInsertImageRecord (&DriverEntry);
   }
 
-  FreePool (HandleBuffer);
+  if (HandleBuffer != NULL) {
+    FreePool (HandleBuffer);
+  }
 }
 
 /**

--- a/MdeModulePkg/Core/PiSmmCore/Page.c
+++ b/MdeModulePkg/Core/PiSmmCore/Page.c
@@ -165,7 +165,11 @@ CoreFreeMemoryMapStack (
     // Deque an memory map entry from mFreeMemoryMapEntryList
     //
     Entry = AllocateMemoryMapEntry ();
-    ASSERT (Entry);
+    if (Entry == NULL) {
+      ASSERT (Entry);
+      mFreeMapStack -= 1;
+      return;
+    }
 
     //
     // Update to proper entry

--- a/MdeModulePkg/Core/PiSmmCore/PiSmmIpl.c
+++ b/MdeModulePkg/Core/PiSmmCore/PiSmmIpl.c
@@ -1606,6 +1606,9 @@ GetFullSmramRanges (
   EFI_SMM_RESERVED_SMRAM_REGION   *SmramReservedRanges;
   UINTN                           MaxCount;
   BOOLEAN                         Rescan;
+  BOOLEAN                         Failed;
+
+  Failed = FALSE;
 
   //
   // Get SMM Configuration Protocol if it is present.
@@ -1650,7 +1653,11 @@ GetFullSmramRanges (
     *FullSmramRangeCount = SmramRangeCount + AdditionSmramRangeCount;
     Size                 = (*FullSmramRangeCount) * sizeof (EFI_SMRAM_DESCRIPTOR);
     FullSmramRanges      = (EFI_SMRAM_DESCRIPTOR *)AllocateZeroPool (Size);
-    ASSERT (FullSmramRanges != NULL);
+    if (FullSmramRanges == NULL) {
+      ASSERT (FullSmramRanges != NULL);
+      Failed = TRUE;
+      goto Done;
+    }
 
     Status = mSmmAccess->GetCapabilities (mSmmAccess, &Size, FullSmramRanges);
     ASSERT_EFI_ERROR (Status);
@@ -1697,18 +1704,34 @@ GetFullSmramRanges (
 
   Size                = MaxCount * sizeof (EFI_SMM_RESERVED_SMRAM_REGION);
   SmramReservedRanges = (EFI_SMM_RESERVED_SMRAM_REGION *)AllocatePool (Size);
-  ASSERT (SmramReservedRanges != NULL);
+
+  if (SmramReservedRanges == NULL) {
+    ASSERT (SmramReservedRanges != NULL);
+    Failed = TRUE;
+    goto Done;
+  }
+
   for (Index = 0; Index < SmramReservedCount; Index++) {
     CopyMem (&SmramReservedRanges[Index], &SmmConfiguration->SmramReservedRegions[Index], sizeof (EFI_SMM_RESERVED_SMRAM_REGION));
   }
 
   Size            = MaxCount * sizeof (EFI_SMRAM_DESCRIPTOR);
   TempSmramRanges = (EFI_SMRAM_DESCRIPTOR *)AllocatePool (Size);
-  ASSERT (TempSmramRanges != NULL);
+  if (TempSmramRanges == NULL) {
+    ASSERT (TempSmramRanges != NULL);
+    Failed = TRUE;
+    goto Done;
+  }
+
   TempSmramRangeCount = 0;
 
   SmramRanges = (EFI_SMRAM_DESCRIPTOR *)AllocatePool (Size);
-  ASSERT (SmramRanges != NULL);
+  if (SmramRanges == NULL) {
+    ASSERT (SmramRanges != NULL);
+    Failed = TRUE;
+    goto Done;
+  }
+
   Status = mSmmAccess->GetCapabilities (mSmmAccess, &Size, SmramRanges);
   ASSERT_EFI_ERROR (Status);
 
@@ -1765,7 +1788,12 @@ GetFullSmramRanges (
   // Sort the entries
   //
   FullSmramRanges = AllocateZeroPool ((TempSmramRangeCount + AdditionSmramRangeCount) * sizeof (EFI_SMRAM_DESCRIPTOR));
-  ASSERT (FullSmramRanges != NULL);
+  if (FullSmramRanges == NULL) {
+    ASSERT (FullSmramRanges != NULL);
+    Failed = TRUE;
+    goto Done;
+  }
+
   *FullSmramRangeCount = 0;
   do {
     for (Index = 0; Index < TempSmramRangeCount; Index++) {
@@ -1789,9 +1817,22 @@ GetFullSmramRanges (
   ASSERT (*FullSmramRangeCount == TempSmramRangeCount);
   *FullSmramRangeCount += AdditionSmramRangeCount;
 
-  FreePool (SmramRanges);
-  FreePool (SmramReservedRanges);
-  FreePool (TempSmramRanges);
+Done:
+  if (SmramRanges != NULL) {
+    FreePool (SmramRanges);
+  }
+
+  if (SmramReservedRanges != NULL) {
+    FreePool (SmramReservedRanges);
+  }
+
+  if (TempSmramRanges != NULL) {
+    FreePool (TempSmramRanges);
+  }
+
+  if (Failed) {
+    return NULL;
+  }
 
   return FullSmramRanges;
 }

--- a/MdeModulePkg/Core/PiSmmCore/Pool.c
+++ b/MdeModulePkg/Core/PiSmmCore/Pool.c
@@ -210,8 +210,11 @@ InternalFreePoolByIndex (
   FreePoolHdr->Header.Signature = 0;
   FreePoolHdr->Header.Available = TRUE;
   FreePoolHdr->Header.Type      = 0;
-  PoolTail->Signature           = 0;
-  PoolTail->Size                = 0;
+  if (PoolTail != NULL) {
+    PoolTail->Signature = 0;
+    PoolTail->Size      = 0;
+  }
+
   ASSERT (PoolIndex < MAX_POOL_INDEX);
   InsertHeadList (&mSmmPoolLists[SmmPoolType][PoolIndex], &FreePoolHdr->Link);
   return EFI_SUCCESS;

--- a/MdeModulePkg/Core/PiSmmCore/SmiHandlerProfile.c
+++ b/MdeModulePkg/Core/PiSmmCore/SmiHandlerProfile.c
@@ -344,7 +344,9 @@ GetSmmLoadedImage (
 
     if (RealImageBase != 0) {
       PdbString = PeCoffLoaderGetPdbPointer ((VOID *)(UINTN)RealImageBase);
-      DEBUG ((DEBUG_INFO, "       pdb - %a\n", PdbString));
+      if (PdbString != NULL) {
+        DEBUG ((DEBUG_INFO, "       pdb - %a\n", PdbString));
+      }
     } else {
       PdbString = NULL;
     }

--- a/MdeModulePkg/Core/PiSmmCore/SmramProfileRecord.c
+++ b/MdeModulePkg/Core/PiSmmCore/SmramProfileRecord.c
@@ -1393,8 +1393,11 @@ SmmCoreUpdateProfileFree (
       }
     }
 
-    ASSERT (DriverInfoData != NULL);
-    ASSERT (AllocInfoData != NULL);
+    if ((DriverInfoData == NULL) || (AllocInfoData == NULL)) {
+      ASSERT (DriverInfoData != NULL);
+      ASSERT (AllocInfoData != NULL);
+      return EFI_NOT_FOUND;
+    }
 
     Found = TRUE;
 
@@ -1686,7 +1689,7 @@ SmramProfileCopyData (
   LIST_ENTRY                       *FreePoolList;
   FREE_POOL_HEADER                 *Pool;
   UINTN                            PoolListIndex;
-  UINT32                           Index;
+  UINTN                            Index;
   MEMORY_PROFILE_FREE_MEMORY       *FreeMemory;
   MEMORY_PROFILE_MEMORY_RANGE      *MemoryRange;
   MEMORY_PROFILE_DESCRIPTOR        *MemoryProfileDescriptor;
@@ -1805,7 +1808,7 @@ SmramProfileCopyData (
         }
       }
 
-      FreeMemory->FreeMemoryEntryCount = Index;
+      FreeMemory->FreeMemoryEntryCount = (UINT32)Index;
 
       RemainingSize -= sizeof (MEMORY_PROFILE_FREE_MEMORY);
       ProfileBuffer  = (UINT8 *)ProfileBuffer + sizeof (MEMORY_PROFILE_FREE_MEMORY);

--- a/MdeModulePkg/Universal/BdsDxe/BdsEntry.c
+++ b/MdeModulePkg/Universal/BdsDxe/BdsEntry.c
@@ -829,23 +829,25 @@ BdsEntry (
   //
   if (PlatformDefaultBootOptionValid && PcdGetBool (PcdPlatformRecoverySupport)) {
     LoadOptions = EfiBootManagerGetLoadOptions (&LoadOptionCount, LoadOptionTypePlatformRecovery);
-    if (EfiBootManagerFindLoadOption (&PlatformDefaultBootOption, LoadOptions, LoadOptionCount) == -1) {
-      for (Index = 0; Index < LoadOptionCount; Index++) {
-        //
-        // The PlatformRecovery#### options are sorted by OptionNumber.
-        // Find the the smallest unused number as the new OptionNumber.
-        //
-        if (LoadOptions[Index].OptionNumber != Index) {
-          break;
+    if (LoadOptions != NULL) {
+      if (EfiBootManagerFindLoadOption (&PlatformDefaultBootOption, LoadOptions, LoadOptionCount) == -1) {
+        for (Index = 0; Index < LoadOptionCount; Index++) {
+          //
+          // The PlatformRecovery#### options are sorted by OptionNumber.
+          // Find the the smallest unused number as the new OptionNumber.
+          //
+          if (LoadOptions[Index].OptionNumber != Index) {
+            break;
+          }
         }
+
+        PlatformDefaultBootOption.OptionNumber = Index;
+        Status                                 = EfiBootManagerLoadOptionToVariable (&PlatformDefaultBootOption);
+        ASSERT_EFI_ERROR (Status);
       }
 
-      PlatformDefaultBootOption.OptionNumber = Index;
-      Status                                 = EfiBootManagerLoadOptionToVariable (&PlatformDefaultBootOption);
-      ASSERT_EFI_ERROR (Status);
+      EfiBootManagerFreeLoadOptions (LoadOptions, LoadOptionCount);
     }
-
-    EfiBootManagerFreeLoadOptions (LoadOptions, LoadOptionCount);
   }
 
   FreePool (FilePath);
@@ -897,8 +899,10 @@ BdsEntry (
   // Execute Driver Options
   //
   LoadOptions = EfiBootManagerGetLoadOptions (&LoadOptionCount, LoadOptionTypeDriver);
-  ProcessLoadOptions (LoadOptions, LoadOptionCount);
-  EfiBootManagerFreeLoadOptions (LoadOptions, LoadOptionCount);
+  if (LoadOptions != NULL) {
+    ProcessLoadOptions (LoadOptions, LoadOptionCount);
+    EfiBootManagerFreeLoadOptions (LoadOptions, LoadOptionCount);
+  }
 
   //
   // Connect consoles
@@ -1033,8 +1037,10 @@ BdsEntry (
     // Execute SysPrep####
     //
     LoadOptions = EfiBootManagerGetLoadOptions (&LoadOptionCount, LoadOptionTypeSysPrep);
-    ProcessLoadOptions (LoadOptions, LoadOptionCount);
-    EfiBootManagerFreeLoadOptions (LoadOptions, LoadOptionCount);
+    if (LoadOptions != NULL) {
+      ProcessLoadOptions (LoadOptions, LoadOptionCount);
+      EfiBootManagerFreeLoadOptions (LoadOptions, LoadOptionCount);
+    }
 
     //
     // Execute Key####
@@ -1090,9 +1096,12 @@ BdsEntry (
       //
       // Retry to boot if any of the boot succeeds
       //
+      BootSuccess = FALSE;
       LoadOptions = EfiBootManagerGetLoadOptions (&LoadOptionCount, LoadOptionTypeBoot);
-      BootSuccess = BootBootOptions (LoadOptions, LoadOptionCount, (BootManagerMenuStatus != EFI_NOT_FOUND) ? &BootManagerMenu : NULL);
-      EfiBootManagerFreeLoadOptions (LoadOptions, LoadOptionCount);
+      if (LoadOptions != NULL) {
+        BootSuccess = BootBootOptions (LoadOptions, LoadOptionCount, (BootManagerMenuStatus != EFI_NOT_FOUND) ? &BootManagerMenu : NULL);
+        EfiBootManagerFreeLoadOptions (LoadOptions, LoadOptionCount);
+      }
     } while (BootSuccess);
   }
 
@@ -1103,8 +1112,10 @@ BdsEntry (
   if (!BootSuccess) {
     if (PcdGetBool (PcdPlatformRecoverySupport)) {
       LoadOptions = EfiBootManagerGetLoadOptions (&LoadOptionCount, LoadOptionTypePlatformRecovery);
-      ProcessLoadOptions (LoadOptions, LoadOptionCount);
-      EfiBootManagerFreeLoadOptions (LoadOptions, LoadOptionCount);
+      if (LoadOptions != NULL) {
+        ProcessLoadOptions (LoadOptions, LoadOptionCount);
+        EfiBootManagerFreeLoadOptions (LoadOptions, LoadOptionCount);
+      }
     } else if (PlatformDefaultBootOptionValid) {
       //
       // When platform recovery is not enabled, still boot to platform default file path.

--- a/MdeModulePkg/Universal/BootManagerPolicyDxe/BootManagerPolicyDxe.c
+++ b/MdeModulePkg/Universal/BootManagerPolicyDxe/BootManagerPolicyDxe.c
@@ -48,7 +48,7 @@ ConnectAllAndCreateNetworkDeviceList (
   }
 
   Devices = NULL;
-  while (HandleCount-- != 0) {
+  while (HandleCount-- != 0 && Handles != NULL) {
     Status = gBS->HandleProtocol (Handles[HandleCount], &gEfiDevicePathProtocolGuid, (VOID **)&SingleDevice);
     if (EFI_ERROR (Status) || (SingleDevice == NULL)) {
       continue;

--- a/MdeModulePkg/Universal/CapsulePei/UefiCapsule.c
+++ b/MdeModulePkg/Universal/CapsulePei/UefiCapsule.c
@@ -1277,7 +1277,7 @@ CreateState (
   UINTN                          Size;
   EFI_PHYSICAL_ADDRESS           NewBuffer;
   UINTN                          CapsuleNumber;
-  UINT32                         Index;
+  UINTN                          Index;
   EFI_PHYSICAL_ADDRESS           BaseAddress;
   UINT64                         Length;
 

--- a/MdeModulePkg/Universal/Disk/UdfDxe/FileName.c
+++ b/MdeModulePkg/Universal/Disk/UdfDxe/FileName.c
@@ -84,7 +84,7 @@ ExcludeTrailingBackslashes (
   }
 
   TempString = String;
-  while (*TempString != L'\0' && *TempString == L'\\') {
+  while (*TempString == L'\\') {
     TempString++;
   }
 

--- a/MdeModulePkg/Universal/Disk/UdfDxe/FileSystemOperations.c
+++ b/MdeModulePkg/Universal/Disk/UdfDxe/FileSystemOperations.c
@@ -1939,7 +1939,7 @@ FindFile (
     }
 
     CopyMem ((VOID *)&PreviousFile, (VOID *)File, sizeof (UDF_FILE_INFO));
-    if ((*FilePath != L'\0') && (*FilePath == L'\\')) {
+    if ((*FilePath == L'\\')) {
       FilePath++;
     }
   }

--- a/MdeModulePkg/Universal/DisplayEngineDxe/FormDisplay.c
+++ b/MdeModulePkg/Universal/DisplayEngineDxe/FormDisplay.c
@@ -1154,6 +1154,9 @@ ProcessStringForDateTime (
     Date = (EFI_IFR_DATE *)Statement->OpCode;
   } else if (Statement->OpCode->OpCode == EFI_IFR_TIME_OP) {
     Time = (EFI_IFR_TIME *)Statement->OpCode;
+  } else {
+    // If not in a time/date opcode, exit.
+    return;
   }
 
   //
@@ -1178,7 +1181,7 @@ ProcessStringForDateTime (
   //
   // Enable to suppress field in the opcode base on the flag.
   //
-  if (Statement->OpCode->OpCode == EFI_IFR_DATE_OP) {
+  if ((Statement->OpCode->OpCode == EFI_IFR_DATE_OP) && (Date != NULL)) {
     //
     // OptionString format is: <**:  **: ****>
     //                        |month|day|year|
@@ -1203,7 +1206,7 @@ ProcessStringForDateTime (
       //
       SetUnicodeMem (&OptionString[0], 4, L' ');
     }
-  } else if (Statement->OpCode->OpCode == EFI_IFR_TIME_OP) {
+  } else if ((Statement->OpCode->OpCode == EFI_IFR_TIME_OP) && (Time != NULL)) {
     //
     // OptionString format is: <**:  **:    **>
     //                        |hour|minute|second|
@@ -1558,7 +1561,9 @@ FindTopOfScreenMenu (
     }
   } else {
     TopOfScreen = Link;
-    *SkipValue  = PreviousMenuOption->Skip - Rows;
+    if (PreviousMenuOption != NULL) {
+      *SkipValue = PreviousMenuOption->Skip - Rows;
+    }
   }
 
   return TopOfScreen;
@@ -2917,7 +2922,10 @@ UiDisplayMenu (
         if (SkipHighLight) {
           SkipHighLight = FALSE;
           MenuOption    = SavedMenuOption;
-          RefreshKeyHelp (gFormData, SavedMenuOption->ThisTag, FALSE);
+          if (SavedMenuOption != NULL) {
+            RefreshKeyHelp (gFormData, SavedMenuOption->ThisTag, FALSE);
+          }
+
           break;
         }
 
@@ -3001,26 +3009,28 @@ UiDisplayMenu (
             // Don't print anything if it is a NULL help token
             //
             ASSERT (MenuOption != NULL);
-            HelpInfo       = ((EFI_IFR_STATEMENT_HEADER *)((CHAR8 *)MenuOption->ThisTag->OpCode + sizeof (EFI_IFR_OP_HEADER)))->Help;
-            Statement      = MenuOption->ThisTag;
-            StatementValue = &Statement->CurrentValue;
-            if ((HelpInfo == 0) || !IsSelectable (MenuOption)) {
-              if (((Statement->OpCode->OpCode == EFI_IFR_DATE_OP) && (StatementValue->Value.date.Month == 0xff)) || ((Statement->OpCode->OpCode == EFI_IFR_TIME_OP) && (StatementValue->Value.time.Hour == 0xff))) {
-                StringPtr = GetToken (STRING_TOKEN (GET_TIME_FAIL), gHiiHandle);
+            if (MenuOption != NULL) {
+              HelpInfo       = ((EFI_IFR_STATEMENT_HEADER *)((CHAR8 *)MenuOption->ThisTag->OpCode + sizeof (EFI_IFR_OP_HEADER)))->Help;
+              Statement      = MenuOption->ThisTag;
+              StatementValue = &Statement->CurrentValue;
+              if ((HelpInfo == 0) || !IsSelectable (MenuOption)) {
+                if (((Statement->OpCode->OpCode == EFI_IFR_DATE_OP) && (StatementValue->Value.date.Month == 0xff)) || ((Statement->OpCode->OpCode == EFI_IFR_TIME_OP) && (StatementValue->Value.time.Hour == 0xff))) {
+                  StringPtr = GetToken (STRING_TOKEN (GET_TIME_FAIL), gHiiHandle);
+                } else {
+                  StringPtr = GetToken (STRING_TOKEN (EMPTY_STRING), gHiiHandle);
+                }
               } else {
-                StringPtr = GetToken (STRING_TOKEN (EMPTY_STRING), gHiiHandle);
-              }
-            } else {
-              if (((Statement->OpCode->OpCode == EFI_IFR_DATE_OP) && (StatementValue->Value.date.Month == 0xff)) || ((Statement->OpCode->OpCode == EFI_IFR_TIME_OP) && (StatementValue->Value.time.Hour == 0xff))) {
-                StringRightPtr = GetToken (HelpInfo, gFormData->HiiHandle);
-                StringErrorPtr = GetToken (STRING_TOKEN (GET_TIME_FAIL), gHiiHandle);
-                StringPtr      = AllocateZeroPool ((StrLen (StringRightPtr) + StrLen (StringErrorPtr)+ 1) * sizeof (CHAR16));
-                StrCpyS (StringPtr, StrLen (StringRightPtr) + StrLen (StringErrorPtr) + 1, StringRightPtr);
-                StrCatS (StringPtr, StrLen (StringRightPtr) + StrLen (StringErrorPtr) + 1, StringErrorPtr);
-                FreePool (StringRightPtr);
-                FreePool (StringErrorPtr);
-              } else {
-                StringPtr = GetToken (HelpInfo, gFormData->HiiHandle);
+                if (((Statement->OpCode->OpCode == EFI_IFR_DATE_OP) && (StatementValue->Value.date.Month == 0xff)) || ((Statement->OpCode->OpCode == EFI_IFR_TIME_OP) && (StatementValue->Value.time.Hour == 0xff))) {
+                  StringRightPtr = GetToken (HelpInfo, gFormData->HiiHandle);
+                  StringErrorPtr = GetToken (STRING_TOKEN (GET_TIME_FAIL), gHiiHandle);
+                  StringPtr      = AllocateZeroPool ((StrLen (StringRightPtr) + StrLen (StringErrorPtr)+ 1) * sizeof (CHAR16));
+                  StrCpyS (StringPtr, StrLen (StringRightPtr) + StrLen (StringErrorPtr) + 1, StringRightPtr);
+                  StrCatS (StringPtr, StrLen (StringRightPtr) + StrLen (StringErrorPtr) + 1, StringErrorPtr);
+                  FreePool (StringRightPtr);
+                  FreePool (StringErrorPtr);
+                } else {
+                  StringPtr = GetToken (HelpInfo, gFormData->HiiHandle);
+                }
               }
             }
           }
@@ -3258,36 +3268,38 @@ UiDisplayMenu (
             // ignore the selection and go back to reading keys.
             //
             ASSERT (MenuOption != NULL);
-            if (IsListEmpty (&gMenuOption) || MenuOption->GrayOut || MenuOption->ReadOnly) {
-              ControlFlag = CfReadKey;
-              break;
-            }
-
-            Statement = MenuOption->ThisTag;
-            if (  (Statement->OpCode->OpCode == EFI_IFR_DATE_OP)
-               || (Statement->OpCode->OpCode == EFI_IFR_TIME_OP)
-               || ((Statement->OpCode->OpCode == EFI_IFR_NUMERIC_OP) && (GetFieldFromNum (Statement->OpCode) != 0))
-                  )
-            {
-              if (Key.UnicodeChar == '+') {
-                gDirection = SCAN_RIGHT;
-              } else {
-                gDirection = SCAN_LEFT;
+            if (MenuOption != NULL ) {
+              if (IsListEmpty (&gMenuOption) || MenuOption->GrayOut || MenuOption->ReadOnly) {
+                ControlFlag = CfReadKey;
+                break;
               }
 
-              Status = ProcessOptions (MenuOption, TRUE, &OptionString, TRUE);
-              if (OptionString != NULL) {
-                FreePool (OptionString);
-              }
+              Statement = MenuOption->ThisTag;
+              if (  (Statement->OpCode->OpCode == EFI_IFR_DATE_OP)
+                 || (Statement->OpCode->OpCode == EFI_IFR_TIME_OP)
+                 || ((Statement->OpCode->OpCode == EFI_IFR_NUMERIC_OP) && (GetFieldFromNum (Statement->OpCode) != 0))
+                    )
+              {
+                if (Key.UnicodeChar == '+') {
+                  gDirection = SCAN_RIGHT;
+                } else {
+                  gDirection = SCAN_LEFT;
+                }
 
-              if (EFI_ERROR (Status)) {
-                //
-                // Repaint to clear possible error prompt pop-up
-                //
-                Repaint = TRUE;
-                NewLine = TRUE;
-              } else {
-                ControlFlag = CfExit;
+                Status = ProcessOptions (MenuOption, TRUE, &OptionString, TRUE);
+                if (OptionString != NULL) {
+                  FreePool (OptionString);
+                }
+
+                if (EFI_ERROR (Status)) {
+                  //
+                  // Repaint to clear possible error prompt pop-up
+                  //
+                  Repaint = TRUE;
+                  NewLine = TRUE;
+                } else {
+                  ControlFlag = CfExit;
+                }
               }
             }
 
@@ -3309,8 +3321,10 @@ UiDisplayMenu (
             }
 
             ASSERT (MenuOption != NULL);
-            if ((MenuOption->ThisTag->OpCode->OpCode == EFI_IFR_CHECKBOX_OP) && !MenuOption->GrayOut && !MenuOption->ReadOnly) {
-              ScreenOperation = UiSelect;
+            if (MenuOption != NULL) {
+              if ((MenuOption->ThisTag->OpCode->OpCode == EFI_IFR_CHECKBOX_OP) && !MenuOption->GrayOut && !MenuOption->ReadOnly) {
+                ScreenOperation = UiSelect;
+              }
             }
 
             break;
@@ -3395,38 +3409,40 @@ UiDisplayMenu (
         ControlFlag = CfRepaint;
 
         ASSERT (MenuOption != NULL);
-        Statement = MenuOption->ThisTag;
-        if (Statement->OpCode->OpCode == EFI_IFR_TEXT_OP) {
-          break;
-        }
-
-        switch (Statement->OpCode->OpCode) {
-          case EFI_IFR_REF_OP:
-          case EFI_IFR_ACTION_OP:
-          case EFI_IFR_RESET_BUTTON_OP:
-            ControlFlag = CfExit;
+        if (MenuOption != NULL ) {
+          Statement = MenuOption->ThisTag;
+          if (Statement->OpCode->OpCode == EFI_IFR_TEXT_OP) {
             break;
+          }
 
-          default:
-            //
-            // Editable Questions: oneof, ordered list, checkbox, numeric, string, password
-            //
-            RefreshKeyHelp (gFormData, Statement, TRUE);
-            Status = ProcessOptions (MenuOption, TRUE, &OptionString, TRUE);
-
-            if (OptionString != NULL) {
-              FreePool (OptionString);
-            }
-
-            if (EFI_ERROR (Status)) {
-              Repaint = TRUE;
-              NewLine = TRUE;
-              RefreshKeyHelp (gFormData, Statement, FALSE);
-              break;
-            } else {
+          switch (Statement->OpCode->OpCode) {
+            case EFI_IFR_REF_OP:
+            case EFI_IFR_ACTION_OP:
+            case EFI_IFR_RESET_BUTTON_OP:
               ControlFlag = CfExit;
               break;
-            }
+
+            default:
+              //
+              // Editable Questions: oneof, ordered list, checkbox, numeric, string, password
+              //
+              RefreshKeyHelp (gFormData, Statement, TRUE);
+              Status = ProcessOptions (MenuOption, TRUE, &OptionString, TRUE);
+
+              if (OptionString != NULL) {
+                FreePool (OptionString);
+              }
+
+              if (EFI_ERROR (Status)) {
+                Repaint = TRUE;
+                NewLine = TRUE;
+                RefreshKeyHelp (gFormData, Statement, FALSE);
+                break;
+              } else {
+                ControlFlag = CfExit;
+                break;
+              }
+          }
         }
 
         break;
@@ -3449,28 +3465,28 @@ UiDisplayMenu (
 
       case CfUiHotKey:
         ControlFlag = CfRepaint;
-
         ASSERT (HotKey != NULL);
 
-        if (FxConfirmPopup (HotKey->Action)) {
-          gUserInput->Action = HotKey->Action;
-          if ((HotKey->Action & BROWSER_ACTION_DEFAULT) == BROWSER_ACTION_DEFAULT) {
-            gUserInput->DefaultId = HotKey->DefaultId;
-          }
+        if (HotKey != NULL ) {
+          if (FxConfirmPopup (HotKey->Action)) {
+            gUserInput->Action = HotKey->Action;
+            if ((HotKey->Action & BROWSER_ACTION_DEFAULT) == BROWSER_ACTION_DEFAULT) {
+              gUserInput->DefaultId = HotKey->DefaultId;
+            }
 
-          ControlFlag = CfExit;
-        } else {
-          Repaint     = TRUE;
-          NewLine     = TRUE;
-          ControlFlag = CfRepaint;
+            ControlFlag = CfExit;
+          } else {
+            Repaint     = TRUE;
+            NewLine     = TRUE;
+            ControlFlag = CfRepaint;
+          }
         }
 
         break;
 
       case CfUiLeft:
         ControlFlag = CfRepaint;
-        ASSERT (MenuOption != NULL);
-        if ((MenuOption->ThisTag->OpCode->OpCode == EFI_IFR_DATE_OP) || (MenuOption->ThisTag->OpCode->OpCode == EFI_IFR_TIME_OP)) {
+        if ((MenuOption != NULL) && ((MenuOption->ThisTag->OpCode->OpCode == EFI_IFR_DATE_OP) || (MenuOption->ThisTag->OpCode->OpCode == EFI_IFR_TIME_OP))) {
           if (MenuOption->Sequence != 0) {
             //
             // In the middle or tail of the Date/Time op-code set, go left.
@@ -3484,8 +3500,7 @@ UiDisplayMenu (
 
       case CfUiRight:
         ControlFlag = CfRepaint;
-        ASSERT (MenuOption != NULL);
-        if ((MenuOption->ThisTag->OpCode->OpCode == EFI_IFR_DATE_OP) || (MenuOption->ThisTag->OpCode->OpCode == EFI_IFR_TIME_OP)) {
+        if ((MenuOption != NULL) && ((MenuOption->ThisTag->OpCode->OpCode == EFI_IFR_DATE_OP) || (MenuOption->ThisTag->OpCode->OpCode == EFI_IFR_TIME_OP))) {
           if (MenuOption->Sequence != 2) {
             //
             // In the middle or tail of the Date/Time op-code set, go left.
@@ -3934,9 +3949,12 @@ BrowserStatusProcess (
   TimeOutEvent         = NULL;
   RefreshIntervalEvent = NULL;
   OpCodeBuf            = NULL;
-  if (gFormData->HighLightedStatement != NULL) {
-    OpCodeBuf = gFormData->HighLightedStatement->OpCode;
+  if (gFormData->HighLightedStatement == NULL) {
+    // Ensure there is a highlighted statement, otherwise exit
+    return;
   }
+
+  OpCodeBuf = gFormData->HighLightedStatement->OpCode;
 
   if (gFormData->BrowserStatus == (BROWSER_WARNING_IF)) {
     ASSERT (OpCodeBuf != NULL && OpCodeBuf->OpCode == EFI_IFR_WARNING_IF_OP);

--- a/MdeModulePkg/Universal/DisplayEngineDxe/InputHandler.c
+++ b/MdeModulePkg/Universal/DisplayEngineDxe/InputHandler.c
@@ -1531,7 +1531,9 @@ TheKey:
             HighlightOptionIndex--;
 
             ASSERT (CurrentOption != NULL);
-            SwapListEntries (CurrentOption->Link.BackLink, &CurrentOption->Link);
+            if (CurrentOption != NULL ) {
+              SwapListEntries (CurrentOption->Link.BackLink, &CurrentOption->Link);
+            }
           }
         }
 
@@ -1561,7 +1563,9 @@ TheKey:
             HighlightOptionIndex++;
 
             ASSERT (CurrentOption != NULL);
-            SwapListEntries (&CurrentOption->Link, CurrentOption->Link.ForwardLink);
+            if (CurrentOption != NULL) {
+              SwapListEntries (&CurrentOption->Link, CurrentOption->Link.ForwardLink);
+            }
           }
         }
 
@@ -1656,7 +1660,7 @@ TheKey:
             //
             // Restore link list order for orderedlist
             //
-            if (OrderedList) {
+            if (OrderedList && (OrderList != NULL)) {
               HiiValue.Type      = ValueType;
               HiiValue.Value.u64 = 0;
               for (Index = 0; Index < OrderList->MaxContainers; Index++) {
@@ -1687,7 +1691,7 @@ TheKey:
         //
         // return the current selection
         //
-        if (OrderedList) {
+        if (OrderedList && (OrderList != NULL)) {
           ReturnValue = AllocateZeroPool (Question->CurrentValue.BufferLen);
           ASSERT (ReturnValue != NULL);
           Index = 0;
@@ -1713,17 +1717,20 @@ TheKey:
           }
         } else {
           ASSERT (CurrentOption != NULL);
-          gUserInput->InputValue.Type = CurrentOption->OptionOpCode->Type;
-          if (IsValuesEqual (&Question->CurrentValue.Value, &CurrentOption->OptionOpCode->Value, gUserInput->InputValue.Type)) {
-            return EFI_DEVICE_ERROR;
-          } else {
-            SetValuesByType (&gUserInput->InputValue.Value, &CurrentOption->OptionOpCode->Value, gUserInput->InputValue.Type);
+
+          if (CurrentOption != NULL) {
+            gUserInput->InputValue.Type = CurrentOption->OptionOpCode->Type;
+            if (IsValuesEqual (&Question->CurrentValue.Value, &CurrentOption->OptionOpCode->Value, gUserInput->InputValue.Type)) {
+              return EFI_DEVICE_ERROR;
+            } else {
+              SetValuesByType (&gUserInput->InputValue.Value, &CurrentOption->OptionOpCode->Value, gUserInput->InputValue.Type);
+            }
           }
+
+          gST->ConOut->SetAttribute (gST->ConOut, SavedAttribute);
+
+          return EFI_SUCCESS;
         }
-
-        gST->ConOut->SetAttribute (gST->ConOut, SavedAttribute);
-
-        return EFI_SUCCESS;
 
       default:
         break;

--- a/MdeModulePkg/Universal/DriverHealthManagerDxe/DriverHealthManagerDxe.c
+++ b/MdeModulePkg/Universal/DriverHealthManagerDxe/DriverHealthManagerDxe.c
@@ -528,8 +528,9 @@ DriverHealthManagerRepairNotify (
   @param Handle         Handle to the HII package list.
   @param FormsetGuid    Return the formset GUID.
 
-  @retval EFI_SUCCESS   The formset is found successfully.
-  @retval EFI_NOT_FOUND The formset cannot be found.
+  @retval EFI_SUCCESS           The formset is found successfully.
+  @retval EFI_NOT_FOUND         The formset cannot be found.
+  @retval EFI_OUT_OF_RESOURCES  Failed to find enough free memory
 **/
 EFI_STATUS
 DriverHealthManagerGetFormsetId (
@@ -557,7 +558,10 @@ DriverHealthManagerGetFormsetId (
   Status         = mDriverHealthManagerDatabase->ExportPackageLists (mDriverHealthManagerDatabase, Handle, &BufferSize, HiiPackageList);
   if (Status == EFI_BUFFER_TOO_SMALL) {
     HiiPackageList = AllocatePool (BufferSize);
-    ASSERT (HiiPackageList != NULL);
+    if (HiiPackageList == NULL) {
+      ASSERT (HiiPackageList != NULL);
+      return EFI_OUT_OF_RESOURCES;
+    }
 
     Status = mDriverHealthManagerDatabase->ExportPackageLists (mDriverHealthManagerDatabase, Handle, &BufferSize, HiiPackageList);
   }
@@ -567,46 +571,48 @@ DriverHealthManagerGetFormsetId (
   }
 
   ASSERT (HiiPackageList != NULL);
+  if (HiiPackageList != NULL) {
+    //
+    // Get Form package from this HII package List
+    //
+    for (Offset = sizeof (EFI_HII_PACKAGE_LIST_HEADER); Offset < ReadUnaligned32 (&HiiPackageList->PackageLength); Offset += PackageHeader.Length) {
+      Package = ((UINT8 *)HiiPackageList) + Offset;
+      CopyMem (&PackageHeader, Package, sizeof (EFI_HII_PACKAGE_HEADER));
 
-  //
-  // Get Form package from this HII package List
-  //
-  for (Offset = sizeof (EFI_HII_PACKAGE_LIST_HEADER); Offset < ReadUnaligned32 (&HiiPackageList->PackageLength); Offset += PackageHeader.Length) {
-    Package = ((UINT8 *)HiiPackageList) + Offset;
-    CopyMem (&PackageHeader, Package, sizeof (EFI_HII_PACKAGE_HEADER));
+      if (PackageHeader.Type == EFI_HII_PACKAGE_FORMS) {
+        //
+        // Search FormSet in this Form Package
+        //
 
-    if (PackageHeader.Type == EFI_HII_PACKAGE_FORMS) {
-      //
-      // Search FormSet in this Form Package
-      //
+        for (Offset2 = sizeof (EFI_HII_PACKAGE_HEADER); Offset2 < PackageHeader.Length; Offset2 += ((EFI_IFR_OP_HEADER *)OpCodeData)->Length) {
+          OpCodeData = Package + Offset2;
 
-      for (Offset2 = sizeof (EFI_HII_PACKAGE_HEADER); Offset2 < PackageHeader.Length; Offset2 += ((EFI_IFR_OP_HEADER *)OpCodeData)->Length) {
-        OpCodeData = Package + Offset2;
-
-        if ((((EFI_IFR_OP_HEADER *)OpCodeData)->OpCode == EFI_IFR_FORM_SET_OP) &&
-            (((EFI_IFR_OP_HEADER *)OpCodeData)->Length > OFFSET_OF (EFI_IFR_FORM_SET, Flags)))
-        {
-          //
-          // Try to compare against formset class GUID
-          //
-          NumberOfClassGuid = (UINT8)(((EFI_IFR_FORM_SET *)OpCodeData)->Flags & 0x3);
-          ClassGuid         = (EFI_GUID *)(OpCodeData + sizeof (EFI_IFR_FORM_SET));
-          for (Index = 0; Index < NumberOfClassGuid; Index++) {
-            if (CompareGuid (&gEfiHiiDriverHealthFormsetGuid, &ClassGuid[Index])) {
-              CopyMem (FormsetGuid, &((EFI_IFR_FORM_SET *)OpCodeData)->Guid, sizeof (EFI_GUID));
-              FreePool (HiiPackageList);
-              return EFI_SUCCESS;
+          if ((((EFI_IFR_OP_HEADER *)OpCodeData)->OpCode == EFI_IFR_FORM_SET_OP) &&
+              (((EFI_IFR_OP_HEADER *)OpCodeData)->Length > OFFSET_OF (EFI_IFR_FORM_SET, Flags)))
+          {
+            //
+            // Try to compare against formset class GUID
+            //
+            NumberOfClassGuid = (UINT8)(((EFI_IFR_FORM_SET *)OpCodeData)->Flags & 0x3);
+            ClassGuid         = (EFI_GUID *)(OpCodeData + sizeof (EFI_IFR_FORM_SET));
+            for (Index = 0; Index < NumberOfClassGuid; Index++) {
+              if (CompareGuid (&gEfiHiiDriverHealthFormsetGuid, &ClassGuid[Index])) {
+                CopyMem (FormsetGuid, &((EFI_IFR_FORM_SET *)OpCodeData)->Guid, sizeof (EFI_GUID));
+                FreePool (HiiPackageList);
+                return EFI_SUCCESS;
+              }
             }
           }
         }
       }
     }
+
+    //
+    // Form package not found in this Package List
+    //
+    FreePool (HiiPackageList);
   }
 
-  //
-  // Form package not found in this Package List
-  //
-  FreePool (HiiPackageList);
   return EFI_NOT_FOUND;
 }
 
@@ -891,28 +897,29 @@ DriverHealthManagerCleanDynamicString (
   BufferSize      = sizeof (EFI_HII_PACKAGE_LIST_HEADER) + FixedStringSize + sizeof (EFI_HII_PACKAGE_HEADER);
   HiiPackageList  = AllocatePool (BufferSize);
   ASSERT (HiiPackageList != NULL);
+  if (HiiPackageList != NULL ) {
+    HiiPackageList->PackageLength = (UINT32)BufferSize;
+    CopyMem (&HiiPackageList->PackageListGuid, &gEfiCallerIdGuid, sizeof (EFI_GUID));
 
-  HiiPackageList->PackageLength = (UINT32)BufferSize;
-  CopyMem (&HiiPackageList->PackageListGuid, &gEfiCallerIdGuid, sizeof (EFI_GUID));
+    PackageHeader = (EFI_HII_PACKAGE_HEADER *)(HiiPackageList + 1);
+    CopyMem (PackageHeader, STRING_ARRAY_NAME + sizeof (UINT32), FixedStringSize);
 
-  PackageHeader = (EFI_HII_PACKAGE_HEADER *)(HiiPackageList + 1);
-  CopyMem (PackageHeader, STRING_ARRAY_NAME + sizeof (UINT32), FixedStringSize);
+    PackageHeader         = (EFI_HII_PACKAGE_HEADER *)((UINT8 *)PackageHeader + PackageHeader->Length);
+    PackageHeader->Type   = EFI_HII_PACKAGE_END;
+    PackageHeader->Length = sizeof (EFI_HII_PACKAGE_HEADER);
 
-  PackageHeader         = (EFI_HII_PACKAGE_HEADER *)((UINT8 *)PackageHeader + PackageHeader->Length);
-  PackageHeader->Type   = EFI_HII_PACKAGE_END;
-  PackageHeader->Length = sizeof (EFI_HII_PACKAGE_HEADER);
+    Status = mDriverHealthManagerDatabase->UpdatePackageList (
+                                             mDriverHealthManagerDatabase,
+                                             mDriverHealthManagerHiiHandle,
+                                             HiiPackageList
+                                             );
+    ASSERT_EFI_ERROR (Status);
 
-  Status = mDriverHealthManagerDatabase->UpdatePackageList (
-                                           mDriverHealthManagerDatabase,
-                                           mDriverHealthManagerHiiHandle,
-                                           HiiPackageList
-                                           );
-  ASSERT_EFI_ERROR (Status);
-
-  //
-  // Form package not found in this Package List
-  //
-  FreePool (HiiPackageList);
+    //
+    // Form package not found in this Package List
+    //
+    FreePool (HiiPackageList);
+  }
 }
 
 /**

--- a/MdeModulePkg/Universal/EbcDxe/EbcDebugger/EdbCmdBreakpoint.c
+++ b/MdeModulePkg/Universal/EbcDxe/EbcDebugger/EdbCmdBreakpoint.c
@@ -324,6 +324,8 @@ DebuggerBreakpointSet (
   UINTN       Address;
   EFI_STATUS  Status;
 
+  Address = 0;
+
   if (CommandArg == NULL) {
     EDBPrint (L"BreakpointSet Argument error!\n");
     return EFI_DEBUG_CONTINUE;

--- a/MdeModulePkg/Universal/EbcDxe/EbcDebugger/EdbCmdSymbol.c
+++ b/MdeModulePkg/Universal/EbcDxe/EbcDebugger/EdbCmdSymbol.c
@@ -568,6 +568,8 @@ DebuggerUnloadSymbol (
   UINTN       Index;
   VOID        *BufferPtr;
 
+  BufferPtr = NULL;
+
   //
   // Check the argument
   //
@@ -703,6 +705,8 @@ DebuggerLoadCode (
   CHAR16      *FileName;
   CHAR16      *MapFileName;
 
+  Buffer = NULL;
+
   //
   // Check the argument
   //
@@ -800,6 +804,7 @@ DebuggerUnloadCode (
   EFI_STATUS  Status;
   VOID        *BufferPtr;
 
+  BufferPtr = NULL;
   //
   // Check the argument
   //

--- a/MdeModulePkg/Universal/EbcDxe/EbcDebugger/EdbSupportString.c
+++ b/MdeModulePkg/Universal/EbcDxe/EbcDebugger/EdbSupportString.c
@@ -25,27 +25,30 @@ Xtoi (
   CHAR16  TempChar;
   UINTN   MaxVal;
 
-  ASSERT (Str != NULL);
+  if (Str == NULL) {
+    ASSERT (Str != NULL);
+    return 0;
+  }
 
   MaxVal = (UINTN)-1 >> 4;
   //
   // skip preceeding white space
   //
-  while (*Str != '\0' && *Str == ' ') {
+  while (*Str == ' ') {
     Str += 1;
   }
 
   //
   // skip preceeding zeros
   //
-  while (*Str != '\0' && *Str == '0') {
+  while (*Str == '0') {
     Str += 1;
   }
 
   //
   // skip preceeding white space
   //
-  if ((*Str != '\0') && ((*Str == 'x') || (*Str == 'X'))) {
+  if (((*Str == 'x') || (*Str == 'X'))) {
     Str += 1;
   }
 
@@ -98,21 +101,21 @@ LXtoi (
   //
   // skip preceeding white space
   //
-  while (*Str != '\0' && *Str == ' ') {
+  while (*Str == ' ') {
     Str += 1;
   }
 
   //
   // skip preceeding zeros
   //
-  while (*Str != '\0' && *Str == '0') {
+  while (*Str == '0') {
     Str += 1;
   }
 
   //
   // skip preceeding white space
   //
-  if ((*Str != '\0') && ((*Str == 'x') || (*Str == 'X'))) {
+  if (((*Str == 'x') || (*Str == 'X'))) {
     Str += 1;
   }
 
@@ -168,7 +171,7 @@ Atoi (
   //
   // skip preceeding white space
   //
-  while (*Str != '\0' && *Str == ' ') {
+  while (*Str == ' ') {
     Str += 1;
   }
 
@@ -217,21 +220,21 @@ AsciiXtoi (
   //
   // skip preceeding white space
   //
-  while (*Str != '\0' && *Str == ' ') {
+  while (*Str == ' ') {
     Str += 1;
   }
 
   //
   // skip preceeding zeros
   //
-  while (*Str != '\0' && *Str == '0') {
+  while (*Str == '0') {
     Str += 1;
   }
 
   //
   // skip preceeding white space
   //
-  if ((*Str != '\0') && ((*Str == 'x') || (*Str == 'X'))) {
+  if (((*Str == 'x') || (*Str == 'X'))) {
     Str += 1;
   }
 
@@ -286,7 +289,7 @@ AsciiAtoi (
   //
   // skip preceeding white space
   //
-  while (*Str != '\0' && *Str == ' ') {
+  while (*Str == ' ') {
     Str += 1;
   }
 

--- a/MdeModulePkg/Universal/EbcDxe/EbcDebugger/EdbSymbol.c
+++ b/MdeModulePkg/Universal/EbcDxe/EbcDebugger/EdbSymbol.c
@@ -1268,13 +1268,14 @@ EdbLoadCodBySymbolByIec (
         // get function name, function name is followed by char 0x09.
         //
         FieldBuffer = AsciiStrGetNewTokenField (LineBuffer, Char);
-        ASSERT (FieldBuffer != NULL);
-        if (AsciiStriCmp (FieldBuffer, Name) == 0) {
-          BufferStart   = FieldBuffer;
-          CodParseState = EdbEbcCodParseStateSymbolStart;
-        }
+        if (FieldBuffer != NULL) {
+          if (AsciiStriCmp (FieldBuffer, Name) == 0) {
+            BufferStart   = FieldBuffer;
+            CodParseState = EdbEbcCodParseStateSymbolStart;
+          }
 
-        PatchForAsciiStrTokenAfter (FieldBuffer, 0x9);
+          PatchForAsciiStrTokenAfter (FieldBuffer, 0x9);
+        }
 
         //
         // Get next line

--- a/MdeModulePkg/Universal/FaultTolerantWriteDxe/FtwMisc.c
+++ b/MdeModulePkg/Universal/FaultTolerantWriteDxe/FtwMisc.c
@@ -856,7 +856,7 @@ FtwGetLastWriteRecord (
   OUT EFI_FAULT_TOLERANT_WRITE_RECORD  **FtwWriteRecord
   )
 {
-  UINTN                            Index;
+  UINT64                           Index;
   EFI_FAULT_TOLERANT_WRITE_RECORD  *FtwRecord;
 
   *FtwWriteRecord = NULL;

--- a/MdeModulePkg/Universal/FaultTolerantWritePei/FaultTolerantWritePei.c
+++ b/MdeModulePkg/Universal/FaultTolerantWritePei/FaultTolerantWritePei.c
@@ -102,7 +102,7 @@ FtwGetLastWriteRecord (
   //
   // Try to find the last write record "that has not completed"
   //
-  for (Index = 0; Index < FtwWriteHeader->NumberOfWrites; Index += 1) {
+  for (Index = 0; (UINT64)Index < FtwWriteHeader->NumberOfWrites; Index += 1) {
     if (FtwRecord->DestinationComplete != FTW_VALID_STATE) {
       //
       // The last write record is found
@@ -261,7 +261,7 @@ PeimFaultTolerantWriteInitialize (
 
     if (!EFI_ERROR (Status)) {
       ASSERT (FtwLastWriteRecord != NULL);
-      if ((FtwLastWriteRecord->SpareComplete == FTW_VALID_STATE) && (FtwLastWriteRecord->DestinationComplete != FTW_VALID_STATE)) {
+      if ((FtwLastWriteRecord != NULL) && (FtwLastWriteRecord->SpareComplete == FTW_VALID_STATE) && (FtwLastWriteRecord->DestinationComplete != FTW_VALID_STATE)) {
         //
         // If FTW last write was still in progress with SpareComplete set and DestinationComplete not set.
         // It means the target buffer has been backed up in spare block, then target block has been erased,

--- a/MdeModulePkg/Universal/RegularExpressionDxe/RegularExpressionDxe.c
+++ b/MdeModulePkg/Universal/RegularExpressionDxe/RegularExpressionDxe.c
@@ -81,7 +81,7 @@ OnigurumaMatch (
   INT32           OnigResult;
   OnigErrorInfo   ErrorInfo;
   OnigUChar       ErrorMessage[ONIG_MAX_ERROR_MESSAGE_LEN];
-  UINT32          Index;
+  UINTN           Index;
   OnigUChar       *Start;
   EFI_STATUS      Status;
 

--- a/MdeModulePkg/Universal/ReportStatusCodeRouter/Smm/ReportStatusCodeRouterCommon.c
+++ b/MdeModulePkg/Universal/ReportStatusCodeRouter/Smm/ReportStatusCodeRouterCommon.c
@@ -66,7 +66,10 @@ Register (
   }
 
   CallbackEntry = (MM_RSC_HANDLER_CALLBACK_ENTRY *)AllocatePool (sizeof (MM_RSC_HANDLER_CALLBACK_ENTRY));
-  ASSERT (CallbackEntry != NULL);
+  if (CallbackEntry == NULL) {
+    ASSERT (CallbackEntry != NULL);
+    return EFI_OUT_OF_RESOURCES;
+  }
 
   CallbackEntry->Signature          = MM_RSC_HANDLER_CALLBACK_ENTRY_SIGNATURE;
   CallbackEntry->RscHandlerCallback = Callback;

--- a/MdeModulePkg/Universal/SetupBrowserDxe/Setup.c
+++ b/MdeModulePkg/Universal/SetupBrowserDxe/Setup.c
@@ -306,7 +306,11 @@ UiCopyMenuList (
     Link     = GetNextNode (CurrentMenuListHead, Link);
 
     NewMenuEntry = AllocateZeroPool (sizeof (FORM_ENTRY_INFO));
-    ASSERT (NewMenuEntry != NULL);
+    if (NewMenuEntry == NULL) {
+      ASSERT (NewMenuEntry != NULL);
+      return;
+    }
+
     NewMenuEntry->Signature = FORM_ENTRY_INFO_SIGNATURE;
     NewMenuEntry->HiiHandle = MenuList->HiiHandle;
     CopyMem (&NewMenuEntry->FormSetGuid, &MenuList->FormSetGuid, sizeof (EFI_GUID));
@@ -340,48 +344,51 @@ LoadAllHiiFormset (
   //
   HiiHandles = HiiGetHiiHandles (NULL);
   ASSERT (HiiHandles != NULL);
+  if (HiiHandles != NULL) {
+    //
+    // Search for formset of each class type
+    //
+    for (Index = 0; HiiHandles[Index] != NULL; Index++) {
+      //
+      // Check HiiHandles[Index] does exist in global maintain list.
+      //
+      if (GetFormSetFromHiiHandle (HiiHandles[Index]) != NULL) {
+        continue;
+      }
 
-  //
-  // Search for formset of each class type
-  //
-  for (Index = 0; HiiHandles[Index] != NULL; Index++) {
-    //
-    // Check HiiHandles[Index] does exist in global maintain list.
-    //
-    if (GetFormSetFromHiiHandle (HiiHandles[Index]) != NULL) {
-      continue;
+      //
+      // Initilize FormSet Setting
+      //
+      LocalFormSet = AllocateZeroPool (sizeof (FORM_BROWSER_FORMSET));
+      ASSERT (LocalFormSet != NULL);
+      if (LocalFormSet != NULL ) {
+        mSystemLevelFormSet = LocalFormSet;
+
+        ZeroMem (&ZeroGuid, sizeof (ZeroGuid));
+        Status = InitializeFormSet (HiiHandles[Index], &ZeroGuid, LocalFormSet);
+        if (EFI_ERROR (Status) || IsListEmpty (&LocalFormSet->FormListHead)) {
+          DestroyFormSet (LocalFormSet);
+          continue;
+        }
+
+        InitializeCurrentSetting (LocalFormSet);
+
+        //
+        // Initilize Questions' Value
+        //
+        Status = LoadFormSetConfig (NULL, LocalFormSet);
+        if (EFI_ERROR (Status)) {
+          DestroyFormSet (LocalFormSet);
+          continue;
+        }
+      }
     }
 
     //
-    // Initilize FormSet Setting
+    // Free resources, and restore gOldFormSet and gClassOfVfr
     //
-    LocalFormSet = AllocateZeroPool (sizeof (FORM_BROWSER_FORMSET));
-    ASSERT (LocalFormSet != NULL);
-    mSystemLevelFormSet = LocalFormSet;
-
-    ZeroMem (&ZeroGuid, sizeof (ZeroGuid));
-    Status = InitializeFormSet (HiiHandles[Index], &ZeroGuid, LocalFormSet);
-    if (EFI_ERROR (Status) || IsListEmpty (&LocalFormSet->FormListHead)) {
-      DestroyFormSet (LocalFormSet);
-      continue;
-    }
-
-    InitializeCurrentSetting (LocalFormSet);
-
-    //
-    // Initilize Questions' Value
-    //
-    Status = LoadFormSetConfig (NULL, LocalFormSet);
-    if (EFI_ERROR (Status)) {
-      DestroyFormSet (LocalFormSet);
-      continue;
-    }
+    FreePool (HiiHandles);
   }
-
-  //
-  // Free resources, and restore gOldFormSet and gClassOfVfr
-  //
-  FreePool (HiiHandles);
 
   mSystemLevelFormSet = OldFormset;
 }
@@ -410,7 +417,11 @@ PopupErrorMessage (
 
   if (OpCode != NULL) {
     Statement = AllocateZeroPool (sizeof (FORM_DISPLAY_ENGINE_STATEMENT));
-    ASSERT (Statement != NULL);
+    if (Statement == NULL) {
+      ASSERT (Statement != NULL);
+      return BROWSER_ACTION_NONE;
+    }
+
     Statement->OpCode                     = OpCode;
     gDisplayFormData.HighLightedStatement = Statement;
   }
@@ -505,7 +516,11 @@ SendForm (
 
   for (Index = 0; Index < HandleCount; Index++) {
     Selection = AllocateZeroPool (sizeof (UI_MENU_SELECTION));
-    ASSERT (Selection != NULL);
+    if (Selection == NULL) {
+      ASSERT (Selection != NULL);
+      Status = EFI_OUT_OF_RESOURCES;
+      break;
+    }
 
     Selection->Handle = Handles[Index];
     if (FormSetGuid != NULL) {
@@ -517,7 +532,11 @@ SendForm (
 
     do {
       FormSet = AllocateZeroPool (sizeof (FORM_BROWSER_FORMSET));
-      ASSERT (FormSet != NULL);
+      if (FormSet == NULL) {
+        ASSERT (FormSet != NULL);
+        Status = EFI_OUT_OF_RESOURCES;
+        break;
+      }
 
       //
       // Validate the HiiHandle
@@ -654,18 +673,21 @@ ProcessStorage (
     //
     StrPtr = StrStr (ConfigResp, L"PATH");
     ASSERT (StrPtr != NULL);
-    StrPtr     = StrStr (StrPtr, L"&");
-    StrPtr    += 1;
-    BufferSize = StrSize (StrPtr);
+    if (StrPtr != NULL) {
+      StrPtr     = StrStr (StrPtr, L"&");
+      StrPtr    += 1;
+      BufferSize = StrSize (StrPtr);
 
-    //
-    // Copy the data if the input buffer is bigger enough.
-    //
-    if (*ResultsDataSize >= BufferSize) {
-      StrCpyS (*ResultsData, *ResultsDataSize / sizeof (CHAR16), StrPtr);
+      //
+      // Copy the data if the input buffer is bigger enough.
+      //
+      if (*ResultsDataSize >= BufferSize) {
+        StrCpyS (*ResultsData, *ResultsDataSize / sizeof (CHAR16), StrPtr);
+      }
+
+      *ResultsDataSize = BufferSize;
     }
 
-    *ResultsDataSize = BufferSize;
     FreePool (ConfigResp);
   } else {
     //
@@ -677,7 +699,10 @@ ProcessStorage (
     BufferSize = (TmpSize + StrLen (BrowserStorage->ConfigHdr) + 2) * sizeof (CHAR16);
     MaxLen     = BufferSize / sizeof (CHAR16);
     ConfigResp = AllocateZeroPool (BufferSize);
-    ASSERT (ConfigResp != NULL);
+    if (ConfigResp == NULL) {
+      ASSERT (ConfigResp != NULL);
+      return EFI_OUT_OF_RESOURCES;
+    }
 
     StrCpyS (ConfigResp, MaxLen, BrowserStorage->ConfigHdr);
     StrCatS (ConfigResp, MaxLen, L"&");
@@ -1088,7 +1113,10 @@ NewStringCat (
 
   MaxLen    = (StrSize (*Dest) + StrSize (Src) - 1) / sizeof (CHAR16);
   NewString = AllocateZeroPool (MaxLen * sizeof (CHAR16));
-  ASSERT (NewString != NULL);
+  if (NewString == NULL) {
+    ASSERT (NewString != NULL);
+    return;
+  }
 
   StrCpyS (NewString, MaxLen, *Dest);
   StrCatS (NewString, MaxLen, Src);
@@ -1823,7 +1851,10 @@ GetQuestionValue (
     // Allocate buffer include '\0'
     MaxLen        = Length + 1;
     ConfigRequest = AllocateZeroPool (MaxLen * sizeof (CHAR16));
-    ASSERT (ConfigRequest != NULL);
+    if (ConfigRequest == NULL) {
+      ASSERT (ConfigRequest != NULL);
+      return EFI_OUT_OF_RESOURCES;
+    }
 
     StrCpyS (ConfigRequest, MaxLen, FormsetStorage->ConfigHdr);
     if (IsBufferStorage) {
@@ -2089,7 +2120,11 @@ SetQuestionValue (
         Value     = NULL;
         BufferLen = ((StrLen ((CHAR16 *)Src) * 4) + 1) * sizeof (CHAR16);
         Value     = AllocateZeroPool (BufferLen);
-        ASSERT (Value != NULL);
+        if (Value == NULL) {
+          ASSERT (Value != NULL);
+          return EFI_OUT_OF_RESOURCES;
+        }
+
         //
         // Convert Unicode String to Config String, e.g. "ABCD" => "0041004200430044"
         //
@@ -2108,7 +2143,11 @@ SetQuestionValue (
       } else {
         BufferLen = StorageWidth * 2 + 1;
         Value     = AllocateZeroPool (BufferLen * sizeof (CHAR16));
-        ASSERT (Value != NULL);
+        if (Value == NULL) {
+          ASSERT (Value != NULL);
+          return EFI_OUT_OF_RESOURCES;
+        }
+
         //
         // Convert Buffer to Hex String
         //
@@ -2153,7 +2192,10 @@ SetQuestionValue (
     ASSERT (FormsetStorage != NULL);
     MaxLen     = StrLen (FormsetStorage->ConfigHdr) + Length + 1;
     ConfigResp = AllocateZeroPool (MaxLen * sizeof (CHAR16));
-    ASSERT (ConfigResp != NULL);
+    if (ConfigResp == NULL) {
+      ASSERT (ConfigResp != NULL);
+      return EFI_OUT_OF_RESOURCES;
+    }
 
     StrCpyS (ConfigResp, MaxLen, FormsetStorage->ConfigHdr);
     if (IsBufferStorage) {
@@ -2725,15 +2767,16 @@ ValidateHiiHandle (
 
   HiiHandles = HiiGetHiiHandles (NULL);
   ASSERT (HiiHandles != NULL);
-
-  for (Index = 0; HiiHandles[Index] != NULL; Index++) {
-    if (HiiHandles[Index] == HiiHandle) {
-      Find = TRUE;
-      break;
+  if (HiiHandles != NULL) {
+    for (Index = 0; HiiHandles[Index] != NULL; Index++) {
+      if (HiiHandles[Index] == HiiHandle) {
+        Find = TRUE;
+        break;
+      }
     }
-  }
 
-  FreePool (HiiHandles);
+    FreePool (HiiHandles);
+  }
 
   return Find;
 }
@@ -2909,7 +2952,11 @@ FindQuestionFromProgress (
       // For Name/Value type, Skip the ConfigHdr part.
       //
       EndStr = StrStr (Progress, L"PATH=");
-      ASSERT (EndStr != NULL);
+      if (EndStr == NULL) {
+        ASSERT (EndStr != NULL);
+        return FALSE;
+      }
+
       while (*EndStr != '&') {
         EndStr++;
       }
@@ -2920,7 +2967,11 @@ FindQuestionFromProgress (
       // For Buffer type, Skip the ConfigHdr part.
       //
       EndStr = StrStr (Progress, L"&OFFSET=");
-      ASSERT (EndStr != NULL);
+      if (EndStr == NULL) {
+        ASSERT (EndStr != NULL);
+        return FALSE;
+      }
+
       *EndStr = '\0';
     }
 
@@ -2937,7 +2988,9 @@ FindQuestionFromProgress (
     //
     EndStr = StrStr (Progress, L"=");
     ASSERT (EndStr != NULL);
-    *EndStr = '\0';
+    if (EndStr != NULL) {
+      *EndStr = '\0';
+    }
   } else {
     //
     // For Buffer type, the data is "OFFSET=0x####&WIDTH=0x####&VALUE=0x####",
@@ -2945,7 +2998,9 @@ FindQuestionFromProgress (
     //
     EndStr = StrStr (Progress, L"&VALUE=");
     ASSERT (EndStr != NULL);
-    *EndStr = '\0';
+    if (EndStr != NULL) {
+      *EndStr = '\0';
+    }
   }
 
   //
@@ -3003,10 +3058,12 @@ FindQuestionFromProgress (
   //
   // restore the OffsetWidth string to the original format.
   //
-  if (Storage->Type == EFI_HII_VARSTORE_NAME_VALUE) {
-    *EndStr = '=';
-  } else {
-    *EndStr = '&';
+  if (EndStr != NULL) {
+    if (Storage->Type == EFI_HII_VARSTORE_NAME_VALUE) {
+      *EndStr = '=';
+    } else {
+      *EndStr = '&';
+    }
   }
 
   return (BOOLEAN)(*RetForm != NULL);
@@ -3060,14 +3117,19 @@ GetSyncRestoreConfigRequest (
     //
     EndStr = StrStr (Progress, L"=");
     ASSERT (EndStr != NULL);
-    *EndStr = L'\0';
+    if (EndStr != NULL) {
+      *EndStr = L'\0';
+    }
+
     //
     // Find the ConfigHdr in ConfigRequest.
     //
     ConfigHdrEndStr = StrStr (ConfigRequest, L"PATH=");
     ASSERT (ConfigHdrEndStr != NULL);
-    while (*ConfigHdrEndStr != L'&') {
-      ConfigHdrEndStr++;
+    if (ConfigHdrEndStr != NULL) {
+      while (*ConfigHdrEndStr != L'&') {
+        ConfigHdrEndStr++;
+      }
     }
   } else {
     //
@@ -3076,7 +3138,10 @@ GetSyncRestoreConfigRequest (
     //
     EndStr = StrStr (Progress, L"&VALUE=");
     ASSERT (EndStr != NULL);
-    *EndStr = L'\0';
+    if (EndStr != NULL) {
+      *EndStr = L'\0';
+    }
+
     //
     // Find the ConfigHdr in ConfigRequest.
     //
@@ -3088,30 +3153,39 @@ GetSyncRestoreConfigRequest (
   //
   ElementStr = StrStr (ConfigRequest, Progress);
   ASSERT (ElementStr != NULL);
-  //
-  // To get the RestoreConfigRequest.
-  //
-  RestoreEleSize        = StrSize (ElementStr);
-  TotalSize             = (ConfigHdrEndStr - ConfigRequest) * sizeof (CHAR16) + RestoreEleSize + sizeof (CHAR16);
-  *RestoreConfigRequest = AllocateZeroPool (TotalSize);
-  ASSERT (*RestoreConfigRequest != NULL);
-  StrnCpyS (*RestoreConfigRequest, TotalSize / sizeof (CHAR16), ConfigRequest, ConfigHdrEndStr - ConfigRequest);
-  StrCatS (*RestoreConfigRequest, TotalSize / sizeof (CHAR16), ElementStr);
-  //
-  // To get the SyncConfigRequest.
-  //
-  SyncSize           = StrSize (ConfigRequest) - RestoreEleSize + sizeof (CHAR16);
-  *SyncConfigRequest = AllocateZeroPool (SyncSize);
-  ASSERT (*SyncConfigRequest != NULL);
-  StrnCpyS (*SyncConfigRequest, SyncSize / sizeof (CHAR16), ConfigRequest, SyncSize / sizeof (CHAR16) - 1);
+  if (ElementStr != NULL) {
+    //
+    // To get the RestoreConfigRequest.
+    //
+    RestoreEleSize        = StrSize (ElementStr);
+    TotalSize             = (ConfigHdrEndStr - ConfigRequest) * sizeof (CHAR16) + RestoreEleSize + sizeof (CHAR16);
+    *RestoreConfigRequest = AllocateZeroPool (TotalSize);
+    ASSERT (*RestoreConfigRequest != NULL);
+    if (*RestoreConfigRequest != NULL) {
+      StrnCpyS (*RestoreConfigRequest, TotalSize / sizeof (CHAR16), ConfigRequest, ConfigHdrEndStr - ConfigRequest);
+      StrCatS (*RestoreConfigRequest, TotalSize / sizeof (CHAR16), ElementStr);
+    }
+
+    //
+    // To get the SyncConfigRequest.
+    //
+    SyncSize           = StrSize (ConfigRequest) - RestoreEleSize + sizeof (CHAR16);
+    *SyncConfigRequest = AllocateZeroPool (SyncSize);
+    ASSERT (*SyncConfigRequest != NULL);
+    if (*SyncConfigRequest != NULL) {
+      StrnCpyS (*SyncConfigRequest, SyncSize / sizeof (CHAR16), ConfigRequest, SyncSize / sizeof (CHAR16) - 1);
+    }
+  }
 
   //
   // restore the Progress string to the original format.
   //
-  if (Storage->Type == EFI_HII_VARSTORE_NAME_VALUE) {
-    *EndStr = L'=';
-  } else {
-    *EndStr = L'&';
+  if (EndStr != NULL) {
+    if (Storage->Type == EFI_HII_VARSTORE_NAME_VALUE) {
+      *EndStr = L'=';
+    } else {
+      *EndStr = L'&';
+    }
   }
 }
 
@@ -3134,22 +3208,27 @@ ConfirmSaveFail (
   CHAR16  *StringBuffer;
   UINT32  RetVal;
 
+  RetVal = BROWSER_ACTION_UNREGISTER;
+
   FormTitle = GetToken (TitleId, HiiHandle);
+  if (FormTitle != NULL) {
+    StringBuffer = AllocateZeroPool (256 * sizeof (CHAR16));
+    ASSERT (StringBuffer != NULL);
+    if (StringBuffer != NULL) {
+      UnicodeSPrint (
+        StringBuffer,
+        24 * sizeof (CHAR16) + StrSize (FormTitle),
+        L"Submit Fail For Form: %s.",
+        FormTitle
+        );
 
-  StringBuffer = AllocateZeroPool (256 * sizeof (CHAR16));
-  ASSERT (StringBuffer != NULL);
+      RetVal = PopupErrorMessage (BROWSER_SUBMIT_FAIL, NULL, NULL, StringBuffer);
 
-  UnicodeSPrint (
-    StringBuffer,
-    24 * sizeof (CHAR16) + StrSize (FormTitle),
-    L"Submit Fail For Form: %s.",
-    FormTitle
-    );
+      FreePool (StringBuffer);
+    }
 
-  RetVal = PopupErrorMessage (BROWSER_SUBMIT_FAIL, NULL, NULL, StringBuffer);
-
-  FreePool (StringBuffer);
-  FreePool (FormTitle);
+    FreePool (FormTitle);
+  }
 
   return RetVal;
 }
@@ -3173,22 +3252,27 @@ ConfirmNoSubmitFail (
   CHAR16  *StringBuffer;
   UINT32  RetVal;
 
+  RetVal = BROWSER_ACTION_UNREGISTER;
+
   FormTitle = GetToken (TitleId, HiiHandle);
+  if (FormTitle != NULL) {
+    StringBuffer = AllocateZeroPool (256 * sizeof (CHAR16));
+    ASSERT (StringBuffer != NULL);
+    if (StringBuffer != NULL) {
+      UnicodeSPrint (
+        StringBuffer,
+        24 * sizeof (CHAR16) + StrSize (FormTitle),
+        L"NO_SUBMIT_IF error For Form: %s.",
+        FormTitle
+        );
 
-  StringBuffer = AllocateZeroPool (256 * sizeof (CHAR16));
-  ASSERT (StringBuffer != NULL);
+      RetVal = PopupErrorMessage (BROWSER_SUBMIT_FAIL_NO_SUBMIT_IF, NULL, NULL, StringBuffer);
 
-  UnicodeSPrint (
-    StringBuffer,
-    24 * sizeof (CHAR16) + StrSize (FormTitle),
-    L"NO_SUBMIT_IF error For Form: %s.",
-    FormTitle
-    );
+      FreePool (StringBuffer);
+    }
 
-  RetVal = PopupErrorMessage (BROWSER_SUBMIT_FAIL_NO_SUBMIT_IF, NULL, NULL, StringBuffer);
-
-  FreePool (StringBuffer);
-  FreePool (FormTitle);
+    FreePool (FormTitle);
+  }
 
   return RetVal;
 }
@@ -3632,8 +3716,10 @@ SubmitForFormSet (
         gCurrentSelection->Action = UI_ACTION_REFRESH_FORMSET;
         gCurrentSelection->Handle = FormSet->HiiHandle;
         CopyGuid (&gCurrentSelection->FormSetGuid, &FormSet->Guid);
-        gCurrentSelection->FormId     = Form->FormId;
-        gCurrentSelection->QuestionId = Question->QuestionId;
+        gCurrentSelection->FormId = Form->FormId;
+        if (Question != NULL) {
+          gCurrentSelection->QuestionId = Question->QuestionId;
+        }
 
         Status = EFI_UNSUPPORTED;
       }
@@ -4302,16 +4388,17 @@ ReGetDefault:
       if (HiiValue->Type == EFI_IFR_TYPE_STRING) {
         NewString = GetToken (Question->HiiValue.Value.string, FormSet->HiiHandle);
         ASSERT (NewString != NULL);
+        if (NewString != NULL) {
+          ASSERT (StrLen (NewString) * sizeof (CHAR16) <= Question->StorageWidth);
+          if (StrLen (NewString) * sizeof (CHAR16) <= Question->StorageWidth) {
+            ZeroMem (Question->BufferValue, Question->StorageWidth);
+            CopyMem (Question->BufferValue, NewString, StrSize (NewString));
+          } else {
+            CopyMem (Question->BufferValue, NewString, Question->StorageWidth);
+          }
 
-        ASSERT (StrLen (NewString) * sizeof (CHAR16) <= Question->StorageWidth);
-        if (StrLen (NewString) * sizeof (CHAR16) <= Question->StorageWidth) {
-          ZeroMem (Question->BufferValue, Question->StorageWidth);
-          CopyMem (Question->BufferValue, NewString, StrSize (NewString));
-        } else {
-          CopyMem (Question->BufferValue, NewString, Question->StorageWidth);
+          FreePool (NewString);
         }
-
-        FreePool (NewString);
       }
 
       return Status;
@@ -5285,7 +5372,11 @@ RemoveConfigRequest (
   //
   if (Storage->BrowserStorage->Type == EFI_HII_VARSTORE_NAME_VALUE) {
     RequestElement = StrStr (ConfigRequest, L"PATH");
-    ASSERT (RequestElement != NULL);
+    if (RequestElement == NULL) {
+      ASSERT (RequestElement != NULL);
+      return;
+    }
+
     RequestElement = StrStr (RequestElement, SearchKey);
   } else {
     RequestElement = StrStr (ConfigRequest, SearchKey);
@@ -5480,6 +5571,7 @@ ConfigRequestAdjust (
     // "&Name1&Name2" section for EFI_HII_VARSTORE_NAME_VALUE storage
     //
     SearchKey = L"&";
+    ValueKey  = L"";
   } else {
     //
     // "&OFFSET=####&WIDTH=####" section for EFI_HII_VARSTORE_BUFFER storage
@@ -5493,7 +5585,12 @@ ConfigRequestAdjust (
   //
   if (Storage->Type == EFI_HII_VARSTORE_NAME_VALUE) {
     RequestElement = StrStr (ConfigRequest, L"PATH");
-    ASSERT (RequestElement != NULL);
+
+    if (RequestElement == NULL) {
+      ASSERT (RequestElement != NULL);
+      return FALSE;
+    }
+
     RequestElement = StrStr (RequestElement, SearchKey);
   } else {
     RequestElement = StrStr (ConfigRequest, SearchKey);
@@ -5515,19 +5612,23 @@ ConfigRequestAdjust (
         ASSERT (NextRequestElement != NULL);
       }
 
-      //
-      // Replace "&" with '\0'.
-      //
-      *NextRequestElement = L'\0';
+      if (NextRequestElement != NULL) {
+        //
+        // Replace "&" with '\0'.
+        //
+        *NextRequestElement = L'\0';
+      }
     } else {
       if (RespString && (Storage->Type == EFI_HII_VARSTORE_EFI_VARIABLE_BUFFER)) {
         NextElementBakup   = NextRequestElement;
         NextRequestElement = StrStr (RequestElement, ValueKey);
         ASSERT (NextRequestElement != NULL);
-        //
-        // Replace "&" with '\0'.
-        //
-        *NextRequestElement = L'\0';
+        if (NextRequestElement != NULL) {
+          //
+          // Replace "&" with '\0'.
+          //
+          *NextRequestElement = L'\0';
+        }
       }
     }
 
@@ -5622,7 +5723,11 @@ LoadStorage (
     //
     StrLen        = StrSize (Storage->ConfigHdr) + 20 * sizeof (CHAR16);
     ConfigRequest = AllocateZeroPool (StrLen);
-    ASSERT (ConfigRequest != NULL);
+    if (ConfigRequest == NULL) {
+      ASSERT (ConfigRequest != NULL);
+      return;
+    }
+
     UnicodeSPrint (
       ConfigRequest,
       StrLen,
@@ -5883,7 +5988,10 @@ GetIfrBinaryData (
   Status         = mHiiDatabase->ExportPackageLists (mHiiDatabase, Handle, &BufferSize, HiiPackageList);
   if (Status == EFI_BUFFER_TOO_SMALL) {
     HiiPackageList = AllocatePool (BufferSize);
-    ASSERT (HiiPackageList != NULL);
+    if (HiiPackageList == NULL) {
+      ASSERT (HiiPackageList != NULL);
+      return EFI_OUT_OF_RESOURCES;
+    }
 
     Status = mHiiDatabase->ExportPackageLists (mHiiDatabase, Handle, &BufferSize, HiiPackageList);
   }
@@ -5892,7 +6000,10 @@ GetIfrBinaryData (
     return Status;
   }
 
-  ASSERT (HiiPackageList != NULL);
+  if (HiiPackageList == NULL ) {
+    ASSERT (HiiPackageList != NULL);
+    return EFI_NOT_FOUND;
+  }
 
   //
   // Get Form package from this HII package List
@@ -6082,51 +6193,52 @@ SaveBrowserContext (
 
   Context = AllocatePool (sizeof (BROWSER_CONTEXT));
   ASSERT (Context != NULL);
+  if (Context != NULL) {
+    Context->Signature = BROWSER_CONTEXT_SIGNATURE;
 
-  Context->Signature = BROWSER_CONTEXT_SIGNATURE;
+    //
+    // Save FormBrowser context
+    //
+    Context->Selection         = gCurrentSelection;
+    Context->ResetRequired     = gResetRequiredFormLevel;
+    Context->FlagReconnect     = gFlagReconnect;
+    Context->CallbackReconnect = gCallbackReconnect;
+    Context->ExitRequired      = gExitRequired;
+    Context->HiiHandle         = mCurrentHiiHandle;
+    Context->FormId            = mCurrentFormId;
+    CopyGuid (&Context->FormSetGuid, &mCurrentFormSetGuid);
+    Context->SystemLevelFormSet    = mSystemLevelFormSet;
+    Context->CurFakeQestId         = mCurFakeQestId;
+    Context->HiiPackageListUpdated = mHiiPackageListUpdated;
+    Context->FinishRetrieveCall    = mFinishRetrieveCall;
 
-  //
-  // Save FormBrowser context
-  //
-  Context->Selection         = gCurrentSelection;
-  Context->ResetRequired     = gResetRequiredFormLevel;
-  Context->FlagReconnect     = gFlagReconnect;
-  Context->CallbackReconnect = gCallbackReconnect;
-  Context->ExitRequired      = gExitRequired;
-  Context->HiiHandle         = mCurrentHiiHandle;
-  Context->FormId            = mCurrentFormId;
-  CopyGuid (&Context->FormSetGuid, &mCurrentFormSetGuid);
-  Context->SystemLevelFormSet    = mSystemLevelFormSet;
-  Context->CurFakeQestId         = mCurFakeQestId;
-  Context->HiiPackageListUpdated = mHiiPackageListUpdated;
-  Context->FinishRetrieveCall    = mFinishRetrieveCall;
+    //
+    // Save the menu history data.
+    //
+    InitializeListHead (&Context->FormHistoryList);
+    while (!IsListEmpty (&mPrivateData.FormBrowserEx2.FormViewHistoryHead)) {
+      MenuList = FORM_ENTRY_INFO_FROM_LINK (mPrivateData.FormBrowserEx2.FormViewHistoryHead.ForwardLink);
+      RemoveEntryList (&MenuList->Link);
 
-  //
-  // Save the menu history data.
-  //
-  InitializeListHead (&Context->FormHistoryList);
-  while (!IsListEmpty (&mPrivateData.FormBrowserEx2.FormViewHistoryHead)) {
-    MenuList = FORM_ENTRY_INFO_FROM_LINK (mPrivateData.FormBrowserEx2.FormViewHistoryHead.ForwardLink);
-    RemoveEntryList (&MenuList->Link);
+      InsertTailList (&Context->FormHistoryList, &MenuList->Link);
+    }
 
-    InsertTailList (&Context->FormHistoryList, &MenuList->Link);
+    //
+    // Save formset list.
+    //
+    InitializeListHead (&Context->FormSetList);
+    while (!IsListEmpty (&gBrowserFormSetList)) {
+      FormSet = FORM_BROWSER_FORMSET_FROM_LINK (gBrowserFormSetList.ForwardLink);
+      RemoveEntryList (&FormSet->Link);
+
+      InsertTailList (&Context->FormSetList, &FormSet->Link);
+    }
+
+    //
+    // Insert to FormBrowser context list
+    //
+    InsertHeadList (&gBrowserContextList, &Context->Link);
   }
-
-  //
-  // Save formset list.
-  //
-  InitializeListHead (&Context->FormSetList);
-  while (!IsListEmpty (&gBrowserFormSetList)) {
-    FormSet = FORM_BROWSER_FORMSET_FROM_LINK (gBrowserFormSetList.ForwardLink);
-    RemoveEntryList (&FormSet->Link);
-
-    InsertTailList (&Context->FormSetList, &FormSet->Link);
-  }
-
-  //
-  // Insert to FormBrowser context list
-  //
-  InsertHeadList (&gBrowserContextList, &Context->Link);
 }
 
 /**
@@ -6305,7 +6417,7 @@ PasswordCheck (
   Question     = GetBrowserStatement (Statement);
   ASSERT (Question != NULL);
 
-  if ((Question->QuestionFlags & EFI_IFR_FLAG_CALLBACK) == EFI_IFR_FLAG_CALLBACK) {
+  if ((Question != NULL) && ((Question->QuestionFlags & EFI_IFR_FLAG_CALLBACK) == EFI_IFR_FLAG_CALLBACK)) {
     if (ConfigAccess == NULL) {
       return EFI_UNSUPPORTED;
     }
@@ -6487,7 +6599,11 @@ RegisterHotKey (
   // Create new Key, and add it into List.
   //
   HotKey = AllocateZeroPool (sizeof (BROWSER_HOT_KEY));
-  ASSERT (HotKey != NULL);
+  if (HotKey == NULL) {
+    ASSERT (HotKey != NULL);
+    return EFI_OUT_OF_RESOURCES;
+  }
+
   HotKey->Signature = BROWSER_HOT_KEY_SIGNATURE;
   HotKey->KeyData   = AllocateCopyPool (sizeof (EFI_INPUT_KEY), KeyData);
   InsertTailList (&gBrowserHotKeyList, &HotKey->Link);
@@ -6598,17 +6714,13 @@ ExecuteAction (
   FORM_BROWSER_FORMSET  *FormSet;
   FORM_BROWSER_FORM     *Form;
 
-  if ((gBrowserSettingScope < SystemLevel) && (gCurrentSelection == NULL)) {
+  if ((gBrowserSettingScope < SystemLevel) || (gCurrentSelection == NULL)) {
     return EFI_NOT_READY;
   }
 
   Status  = EFI_SUCCESS;
-  FormSet = NULL;
-  Form    = NULL;
-  if (gBrowserSettingScope < SystemLevel) {
-    FormSet = gCurrentSelection->FormSet;
-    Form    = gCurrentSelection->Form;
-  }
+  FormSet = gCurrentSelection->FormSet;
+  Form    = gCurrentSelection->Form;
 
   //
   // Executet the discard action.

--- a/MdeModulePkg/Universal/Variable/Pei/Variable.c
+++ b/MdeModulePkg/Universal/Variable/Pei/Variable.c
@@ -858,6 +858,7 @@ FindVariableEx (
   VARIABLE_STORE_HEADER  *VariableStoreHeader;
   VARIABLE_INDEX_TABLE   *IndexTable;
   VARIABLE_HEADER        *VariableHeader;
+  BOOLEAN                Valid;
 
   VariableStoreHeader = StoreInfo->VariableStoreHeader;
 
@@ -894,8 +895,8 @@ FindVariableEx (
       ASSERT (Index < sizeof (IndexTable->Index) / sizeof (IndexTable->Index[0]));
       Offset  += IndexTable->Index[Index];
       MaxIndex = (VARIABLE_HEADER *)((UINT8 *)IndexTable->StartPtr + Offset);
-      GetVariableHeader (StoreInfo, MaxIndex, &VariableHeader);
-      if (CompareWithValidVariable (StoreInfo, MaxIndex, VariableHeader, VariableName, VendorGuid, PtrTrack) == EFI_SUCCESS) {
+      Valid    = GetVariableHeader (StoreInfo, MaxIndex, &VariableHeader);
+      if (Valid && (CompareWithValidVariable (StoreInfo, MaxIndex, VariableHeader, VariableName, VendorGuid, PtrTrack) == EFI_SUCCESS)) {
         if (VariableHeader->State == (VAR_IN_DELETED_TRANSITION & VAR_ADDED)) {
           InDeletedVariable = PtrTrack->CurrPtr;
         } else {


### PR DESCRIPTION
# Description

Last of codeql changes for MdeModulePkg.


With this set of changes, and the changes in the rest of the PRs, codeql for ModeModulePkg
was reporting no failures.

To get to the final state, the introduction of a CodeQlFilter.yml file was needed. This was to
suppress errors coming from the oniguruma submodules, and for 3 false positives 
where codeql was detecting missing null tests, but null was a valid input option.


- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested
Local CI.

## Integration Instructions
No Integration necessary.
