### PR TITLE
CryptoPkg: Add API to set TLS security level.

### DIFF
--- a/CryptoPkg/Driver/Crypto.c
+++ b/CryptoPkg/Driver/Crypto.c
@@ -5104,6 +5104,50 @@ CryptoServiceTlsSetCertRevocationList (
 }
 
 /**
+  Set the specified server name in Server/Client.
+
+  @param[in]  Tls           Pointer to the TLS object.
+  @param[in]  SslCtx        Pointer to the SSL object.
+  @param[in]  HostName      The specified server name to be set.
+
+  @retval  EFI_SUCCESS      The Server Name was set successfully.
+  @retval  EFI_UNSUPPORTED  Failed to set the Server Name.
+**/
+EFI_STATUS
+EFIAPI
+CryptoServiceTlsSetServerName (
+  VOID   *Tls,
+  VOID   *SslCtx,
+  CHAR8  *HostName
+  )
+{
+  return CALL_BASECRYPTLIB (TlsSet.Services.ServerName, TlsSetServerName, (Tls, SslCtx, HostName), EFI_UNSUPPORTED);
+  
+/**
+  Set the Tls security level.
+
+  This function Set the Tls security level.
+  If Tls is NULL, nothing is done.
+
+  @param[in]  Tls                Pointer to the TLS object.
+  @param[in]  Level              Pointer to the Tls Security level need to set.
+
+  @retval  EFI_SUCCESS           The Tls security level was set successfully.
+  @retval  EFI_INVALID_PARAMETER The parameters are invalid.
+  @retval  EFI_UNSUPPORTED       The requested TLS set security level is not supported.
+
+**/
+EFI_STATUS
+EFIAPI
+CryptoServiceTlsSetSecurityLevel (
+  IN VOID   *Tls,
+  IN UINT8  Level
+  )
+{
+  return CALL_BASECRYPTLIB (TlsSet.Services.SecurityLevel, TlsSetSecurityLevel, (Tls, Level), EFI_UNSUPPORTED);
+}
+
+/**
   Set the signature algorithm list to used by the TLS object.
 
   This function sets the signature algorithms for use by a specified TLS object.
@@ -7116,4 +7160,7 @@ const EDKII_CRYPTO_PROTOCOL  mEdkiiCrypto = {
   CryptoServicePkcs1v2Decrypt,
   CryptoServiceRsaOaepEncrypt,
   CryptoServiceRsaOaepDecrypt,
+  /// Tls Set (Continued)
+  CryptoServiceTlsSetServerName,
+  CryptoServiceTlsSetSecurityLevel,
 };

--- a/CryptoPkg/Include/Library/BaseCryptLib.h
+++ b/CryptoPkg/Include/Library/BaseCryptLib.h
@@ -69,6 +69,9 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #define AES_BLOCK_SIZE  16
 
 ///
+/// TLS Maximum security level
+#define MAX_SECURITY_LEVEL  5
+///
 /// RSA Key Tags Definition used in RsaSetKey() function for key component identification.
 ///
 typedef enum {
@@ -2263,6 +2266,24 @@ RsaOaepDecrypt (
   IN   UINT16  DigestLen   OPTIONAL,
   OUT  UINT8   **OutData,
   OUT  UINTN   *OutDataSize
+  );
+
+/**
+  This function Set the Tls security level.
+  If Tls is NULL, nothing is done.
+
+  @param[in]  Tls                Pointer to the TLS object.
+  @param[in]  Level              Tls Security level need to set.
+
+  @retval  EFI_SUCCESS           The Tls security level was set successfully.
+  @retval  EFI_INVALID_PARAMETER The parameters are invalid.
+
+**/
+EFI_STATUS
+EFIAPI
+TlsSetSecurityLevel (
+  IN VOID   *Tls,
+  IN UINT8  Level
   );
 
 /**

--- a/CryptoPkg/Include/Library/TlsLib.h
+++ b/CryptoPkg/Include/Library/TlsLib.h
@@ -628,6 +628,26 @@ TlsSetEcCurve (
   );
 
 /**
+  Set the Tls security level.
+
+  This function Set the Tls security level.
+  If Tls is NULL, nothing is done.
+
+  @param[in]  Tls                Pointer to the TLS object.
+  @param[in]  Level              Tls Security level need to set.
+
+  @retval  EFI_SUCCESS           The Tls security level was set successfully.
+  @retval  EFI_INVALID_PARAMETER The parameters are invalid.
+
+**/
+EFI_STATUS
+EFIAPI
+TlsSetSecurityLevel (
+  IN VOID   *Tls,
+  IN UINT8  Level
+  );
+
+/**
   Gets the protocol version used by the specified TLS connection.
 
   This function returns the protocol version used by the specified TLS

--- a/CryptoPkg/Include/Pcd/PcdCryptoServiceFamilyEnable.h
+++ b/CryptoPkg/Include/Pcd/PcdCryptoServiceFamilyEnable.h
@@ -327,6 +327,8 @@ typedef struct {
       UINT8    HostPrivateKeyEx   : 1;
       UINT8    SignatureAlgoList  : 1;
       UINT8    EcCurve            : 1;
+      UINT8    ServerName         : 1;
+      UINT8    SecurityLevel      : 1;
     } Services;
     UINT32    Family;
   } TlsSet;

--- a/CryptoPkg/Library/BaseCryptLibOnProtocolPpi/CryptLib.c
+++ b/CryptoPkg/Library/BaseCryptLibOnProtocolPpi/CryptLib.c
@@ -4382,6 +4382,30 @@ TlsSetEcCurve (
 }
 
 /**
+  Set the Tls security level.
+
+  This function Set the Tls security level.
+  If Tls is NULL, nothing is done.
+
+  @param[in]  Tls                Pointer to the TLS object.
+  @param[in]  Level              Tls Security level need to set.
+
+  @retval  EFI_SUCCESS           The Tls security level was set successfully.
+  @retval  EFI_INVALID_PARAMETER The parameters are invalid.
+  @retval  EFI_UNSUPPORTED       The requested TLS set security level is not supported.
+
+**/
+EFI_STATUS
+EFIAPI
+TlsSetSecurityLevel (
+  IN VOID   *Tls,
+  IN UINT8  Level
+  )
+{
+  CALL_CRYPTO_SERVICE (TlsSetSecurityLevel, (Tls, Level), EFI_UNSUPPORTED);
+}
+
+/**
   Gets the protocol version used by the specified TLS connection.
 
   This function returns the protocol version used by the specified TLS

--- a/CryptoPkg/Library/TlsLib/TlsConfig.c
+++ b/CryptoPkg/Library/TlsLib/TlsConfig.c
@@ -1113,6 +1113,45 @@ TlsSetEcCurve (
 }
 
 /**
+  Set the Tls security level.
+
+  This function Set the Tls security level.
+  If Tls is NULL, nothing is done.
+
+  @param[in]  Tls                Pointer to the TLS object.
+  @param[in]  Level              Tls Security level need to set.
+
+  @retval  EFI_SUCCESS           The Tls security level was set successfully.
+  @retval  EFI_INVALID_PARAMETER The parameters are invalid.
+  @retval  EFI_UNSUPPORTED       The requested TLS set security level is not supported.
+
+**/
+EFI_STATUS
+EFIAPI
+TlsSetSecurityLevel (
+  IN VOID   *Tls,
+  IN UINT8  Level
+  )
+{
+  TLS_CONNECTION  *TlsConn;
+
+  TlsConn = (TLS_CONNECTION *)Tls;
+
+  if ((TlsConn == NULL) || (TlsConn->Ssl == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  // The security level shouldn't exceeds the maximum limit.
+  if (Level > MAX_SECURITY_LEVEL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  SSL_set_security_level (TlsConn->Ssl, Level);
+
+  return EFI_SUCCESS;
+}
+
+/**
   Gets the protocol version used by the specified TLS connection.
 
   This function returns the protocol version used by the specified TLS

--- a/CryptoPkg/Library/TlsLib/TlsInit.c
+++ b/CryptoPkg/Library/TlsLib/TlsInit.c
@@ -188,7 +188,7 @@ TlsNew (
   //
   // This retains compatibility with previous version of OpenSSL.
   //
-  SSL_set_security_level (TlsConn->Ssl, 0);
+  SSL_set_security_level (TlsConn->Ssl, 3);
 
   //
   // Initialize the created SSL Object

--- a/CryptoPkg/Library/TlsLibNull/TlsConfigNull.c
+++ b/CryptoPkg/Library/TlsLibNull/TlsConfigNull.c
@@ -379,6 +379,31 @@ TlsSetEcCurve (
 }
 
 /**
+  Set the Tls security level.
+
+  This function Set the Tls security level.
+  If Tls is NULL, nothing is done.
+
+  @param[in]  Tls                Pointer to the TLS object.
+  @param[in]  Level              Tls Security level need to set.
+
+  @retval  EFI_SUCCESS           The Tls security level was set successfully.
+  @retval  EFI_INVALID_PARAMETER The parameters are invalid.
+  @retval  EFI_UNSUPPORTED       The requested TLS set security level is not supported.
+
+**/
+EFI_STATUS
+EFIAPI
+TlsSetSecurityLevel (
+  IN VOID   *Tls,
+  IN UINT8  Level
+  )
+{
+  ASSERT (FALSE);
+  return EFI_UNSUPPORTED;
+}
+
+/**
   Gets the protocol version used by the specified TLS connection.
 
   This function returns the protocol version used by the specified TLS

--- a/CryptoPkg/Private/Protocol/Crypto.h
+++ b/CryptoPkg/Private/Protocol/Crypto.h
@@ -21,7 +21,7 @@
 /// the EDK II Crypto Protocol is extended, this version define must be
 /// increased.
 ///
-#define EDKII_CRYPTO_VERSION  17
+#define EDKII_CRYPTO_VERSION  19
 
 ///
 /// EDK II Crypto Protocol forward declaration
@@ -3952,6 +3952,27 @@ EFI_STATUS
   );
 
 /**
+  Set the Tls security level.
+
+  This function Set the Tls security level.
+  If Tls is NULL, nothing is done.
+
+  @param[in]  Tls                Pointer to the TLS object.
+  @param[in]  Level              Pointer to the Tls Security level need to set.
+  @param[in]  DataSize           Size of level, it should be sizeof (UINT8)
+
+  @retval  EFI_SUCCESS           The Tls security level was set successfully.
+  @retval  EFI_INVALID_PARAMETER The parameters are invalid.
+
+**/
+typedef
+EFI_STATUS
+(EFIAPI *EDKII_CRYPTO_TLS_SET_SECURITY_LEVEL)(
+  IN VOID    *Tls,
+  IN UINT8   Level
+  );
+
+/**
   Gets the protocol version used by the specified TLS connection.
 
   This function returns the protocol version used by the specified TLS
@@ -5710,6 +5731,9 @@ struct _EDKII_CRYPTO_PROTOCOL {
   EDKII_CRYPTO_PKCS1V2_DECRYPT                        Pkcs1v2Decrypt;
   EDKII_CRYPTO_RSA_OAEP_ENCRYPT                       RsaOaepEncrypt;
   EDKII_CRYPTO_RSA_OAEP_DECRYPT                       RsaOaepDecrypt;
+  /// TLS Set(continued)
+  EDKII_CRYPTO_TLS_SET_SERVER_NAME                    TlsSetServerName;
+  EDKII_CRYPTO_TLS_SET_SECURITY_LEVEL                 TlsSetSecurityLevel;
 };
 
 extern GUID  gEdkiiCryptoProtocolGuid;


### PR DESCRIPTION
Add an API to set the user preferred TLS security level.

# Description

According to the [OpenSSL 3.5 documentation](https://docs.openssl.org/3.5/man3/SSL_CTX_set_security_level/), setting the TLS security level to 0 permits all protocols and cipher suites, effectively disabling security restrictions. we have set the TLS security level to 2 by default. Additionally, we have provided an API that allows users to customize the security level based on their requirements.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## Integration Instructions

<N/A>
