### PR TITLE
MdeModulePkg/PciBusDxe: Fix logic for PCI device IO BAR rejection

### DIFF
--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciEnumeratorSupport.c
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciEnumeratorSupport.c
@@ -2781,6 +2781,13 @@ IsPciDeviceRejected (
       //
       Mask      = 0xFFFFFFFC;
       TestValue = TestValue & Mask;
+      if ((TestValue != 0) && ((TestValue & 0xFFFF0000) == 0)) {
+        //
+        // IO Bar uses 16-bit decoding, pad for comparison
+        //
+        TestValue = TestValue | 0xFFFF0000;
+      }
+
       if ((TestValue != 0) && (TestValue == (OldValue & Mask))) {
         return TRUE;
       }


### PR DESCRIPTION
# Description

The current logic used to determine validity for IO BARs can fail when the BAR uses 16-bit (vs 32-bit) decoding.
When the validity check fails, the associated PCI device will be incorrectly rejected. In the case of a PCI GPU, the display will fail to initialize at boot.

Correct this issue by padding `TestValue` with 0xFFFF0000 in the case of a 16-bit decoded IO BAR, in order to match the expected value if 32-bit decoding were used.

TEST=PCI device with IO bar [0xFFC0 - 0xFFFF] is not incorrectly rejected.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

UefiPayloadPkg was built as a coreboot payload, and booted on a Chromebook with an 11th-gen Intel SoC.
Without this change, when coreboot's "top-down" resource assignment strategy is used, the display fails to init as the GPU PCI device is incorrectly removed from light enumeration, due to the IO BAR at 0xFFC0 being rejected.

## Integration Instructions

N/A
