### PR TITLE
pip-requirements: Add pylibfdt and swig

### DIFF
--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -17,3 +17,5 @@ edk2-pytool-extensions~=0.29.11
 antlr4-python3-runtime==4.9
 lcov-cobertura==2.1.1
 regex==2024.11.6
+pylibfdt==1.7.2
+pefile


### PR DESCRIPTION
# Description

pip-requirements: Add pylibfdt and PE tool and swig

1. Tool supportUPL requires libfdt support
2. Also added swig which is required by UefiPayloadPkg.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested
N /A

## Integration Instructions
N/A