### PR TITLE
MdeModulePkg,BaseTools: Fix assert if string default is 0 in vfr defination.

### DIFF
--- a/BaseTools/Source/C/VfrCompile/VfrSyntax.g
+++ b/BaseTools/Source/C/VfrCompile/VfrSyntax.g
@@ -2,6 +2,7 @@
 Vfr Syntax
 
 Copyright (c) 2004 - 2025, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2025, Loongson Technology Corporation Limited. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 --*/
@@ -1618,7 +1619,7 @@ vfrConstantValueField[UINT8 Type, EFI_IFR_TYPE_VALUE &Value, BOOLEAN &ListType] 
                                                            $Value.b      = _STOU8(N1->getText(), N1->getLine());
                                                          break;
                                                          case EFI_IFR_TYPE_STRING :
-                                                           $Value.string = _STOU16(N1->getText(), N1->getLine());
+                                                           _PCATCH (VFR_RETURN_INVALID_PARAMETER, N1->getLine(), "string type can't be numeric constant.");
                                                          break;
                                                          case EFI_IFR_TYPE_TIME :
                                                          case EFI_IFR_TYPE_DATE :
@@ -3127,7 +3128,7 @@ vfrStatementString :
      UINT8 StringMaxSize;
   >>
   L:String                                             << SObj.SetLineNo(L->getLine()); gIsStringOp = TRUE;>>
-  vfrQuestionHeader[SObj] ","
+  vfrQuestionHeader[SObj] ","                          << _GET_CURRQEST_VARTINFO().mVarType = EFI_IFR_TYPE_STRING;>>
   { F:FLAGS "=" vfrStringFlagsField[SObj, F->getLine()] "," }
   {
     Key "=" KN:Number ","                              << AssignQuestionKey (SObj, KN); >>

--- a/MdeModulePkg/Universal/HiiDatabaseDxe/ConfigRouting.c
+++ b/MdeModulePkg/Universal/HiiDatabaseDxe/ConfigRouting.c
@@ -2,6 +2,7 @@
 Implementation of interfaces function for EFI_HII_CONFIG_ROUTING_PROTOCOL.
 
 Copyright (c) 2007 - 2018, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2025, Loongson Technology Corporation Limited. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -4265,7 +4266,7 @@ GenerateAltConfigResp (
         // Convert Value to a hex string in "%x" format
         // NOTE: This is in the opposite byte that GUID and PATH use
         //
-        if (BlockData->OpCode == EFI_IFR_STRING_OP) {
+        if ((BlockData->OpCode == EFI_IFR_STRING_OP) && (DefaultValueData->Value.string != 0)) {
           DefaultString = InternalGetString (HiiHandle, DefaultValueData->Value.string);
           TmpBuffer     = AllocateZeroPool (Width);
           ASSERT (TmpBuffer != NULL);


### PR DESCRIPTION
REF: https://github.com/tianocore/edk2/issues/11256

If  default string is set 0  in vfr string definition, current VfrCompile can nor check this  illegal operation and generate string opcode with value 0. But this will trigger assert in `InternalGetString` function. To Solve this problem, two parts of works is done:
1. If numeric string default is encountered, throw a invalid parameter error to break VfrCompile.
2. Add a check whether StringId is 0  before invoking `InternalGetString` function to avoid assert.

# Description

<_Include a description of the change and why this change was made._>

<_For each item, place an "x" in between `[` and `]` if true. Example: `[x]` (you can also check items in GitHub UI)_>

<_Create the PR as a Draft PR if it is only created to run CI checks._>

<_Delete lines in \<\> tags before creating the PR._>

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

<_Describe the test(s) that were run to verify the changes._>

## Integration Instructions

<_Describe how these changes should be integrated. Use N/A if nothing is required._>
