### PR TITLE
Fixes for `GenerateCapsule.py --decode`

### DIFF
--- a/BaseTools/Source/Python/Capsule/GenerateCapsule.py
+++ b/BaseTools/Source/Python/Capsule/GenerateCapsule.py
@@ -433,8 +433,13 @@ if __name__ == '__main__':
                                             DepexExp
                                             ))
 
-    def GenerateOutputJson (PayloadJsonDescriptorList):
+    def GenerateOutputJson (PayloadJsonDescriptorList, EmbeddedDriverPaths):
         PayloadJson = {
+                          "EmbeddedDrivers" : [
+                              {
+                                  "Driver": DriverPath
+                              }for DriverPath in EmbeddedDriverPaths
+                          ],
                           "Payloads" : [
                               {
                                   "Guid": str(PayloadDescriptor.Guid).upper(),
@@ -815,6 +820,8 @@ if __name__ == '__main__':
             except Exception as Msg:
                 print ('GenerateCapsule: error: ' + str(Msg))
                 sys.exit (1)
+
+        EmbeddedDriverPaths = []
         try:
             Result = UefiCapsuleHeader.Decode (Buffer)
             if len (Result) > 0:
@@ -989,10 +996,12 @@ if __name__ == '__main__':
                         print ('GenerateCapsule: error: can not write embedded driver file {File}'.format (File = EmbeddedDriverPath))
                         sys.exit (1)
 
+                    EmbeddedDriverPaths.append (EmbeddedDriverPath)
+
         except Exception as Msg:
             print ('GenerateCapsule: error: can not decode capsule: ' + str(Msg))
             sys.exit (1)
-        GenerateOutputJson(PayloadJsonDescriptorList)
+        GenerateOutputJson (PayloadJsonDescriptorList, EmbeddedDriverPaths)
         PayloadIndex = 0
         for SinglePayloadDescriptor in PayloadDescriptorList:
             if args.OutputFile is None:

--- a/BaseTools/Source/Python/Capsule/GenerateCapsule.py
+++ b/BaseTools/Source/Python/Capsule/GenerateCapsule.py
@@ -472,6 +472,8 @@ if __name__ == '__main__':
                 del PayloadField ['OpenSslTrustedPublicCertFile']
             if PayloadJsonDescriptorList[Index].SigningToolPath is None:
                 del PayloadField ['SigningToolPath']
+            if PayloadJsonDescriptorList[Index].DepexExp is None:
+                del PayloadField ['Dependencies']
             Index = Index + 1
         Result = json.dumps (PayloadJson, indent=4, sort_keys=True, separators=(',', ': '))
         with open (OutputJsonFile, 'w') as OutputFile:

--- a/BaseTools/Source/Python/Capsule/GenerateCapsule.py
+++ b/BaseTools/Source/Python/Capsule/GenerateCapsule.py
@@ -925,7 +925,7 @@ if __name__ == '__main__':
                                            HashAlgorithm = SinglePayloadDescriptor.HashAlgorithm,
                                            Verbose = args.Verbose
                                            )
-                          else:
+                          elif SinglePayloadDescriptor.UseOpenSsl:
                               CertData = VerifyPayloadOpenSsl (
                                            FmpAuthHeader.Payload + struct.pack ('<Q', FmpAuthHeader.MonotonicCount),
                                            FmpAuthHeader.CertData,


### PR DESCRIPTION
# Description

This is a follow-up on https://github.com/tianocore/edk2/pull/5807, addressing some more issues with unpacking capsules.

See individual commits for explanation of what they are fixing.

- [ ] Breaking change?
  - No, unless somebody relied on the ability to specify only some OpenSSL-related options for `--decode` and still get signature verification.
- [ ] Impacts security?
  - No.
- [ ] Includes tests?
  - No.

## How This Was Tested

Ran `--decode` on a capsule, then packed it back using `--encode` with no modifications.  This didn't work previously due to `"Dependencies": "None"`, it would also built a capsule without DXEs because those weren't mentioned in the JSON made by `--decode`.

## Integration Instructions

N/A
