### PR TITLE
{UefiCpuPkg,UefiPayloadPkg}: Include what you use

### DIFF
--- a/UefiCpuPkg/Library/BaseArchSupportLib/BaseArchSupportLib.inf
+++ b/UefiCpuPkg/Library/BaseArchSupportLib/BaseArchSupportLib.inf
@@ -28,3 +28,6 @@
 
 [LibraryClasses]
   BaseLib
+
+[LibraryClasses.AARCH64]
+  ArmLib

--- a/UefiPayloadPkg/UefiPayloadPkg.dsc
+++ b/UefiPayloadPkg/UefiPayloadPkg.dsc
@@ -426,11 +426,12 @@
   ArmHvcLib|ArmPkg/Library/ArmHvcLib/ArmHvcLib.inf
   ArmLib|MdePkg/Library/ArmLib/ArmBaseLib.inf
   ArmMmuLib|UefiCpuPkg/Library/ArmMmuLib/ArmMmuBaseLib.inf
+  ArmMonitorLib|ArmPkg/Library/ArmMonitorLib/ArmMonitorLib.inf
   ArmSmcLib|MdePkg/Library/ArmSmcLib/ArmSmcLib.inf
 
   BaseMemoryLib|MdePkg/Library/BaseMemoryLib/BaseMemoryLib.inf
   CacheMaintenanceLib|ArmPkg/Library/ArmCacheMaintenanceLib/ArmCacheMaintenanceLib.inf
-  EfiResetSystemLib|ArmPkg/Library/ArmPsciResetSystemLib/ArmPsciResetSystemLib.inf
+  ResetSystemLib|ArmPkg/Library/ArmPsciResetSystemLib/ArmPsciResetSystemLib.inf
   PL011UartLib|ArmPlatformPkg/Library/PL011UartLib/PL011UartLib.inf
   PL011UartClockLib|ArmPlatformPkg/Library/PL011UartClockLib/PL011UartClockLib.inf
   SerialPortLib|ArmPlatformPkg/Library/PL011SerialPortLib/PL011SerialPortLib.inf


### PR DESCRIPTION
# Description

It's apparent that this wasn't even build-tested until now. Declare the necessary packages and library classes to link against to allow this to compile.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Build UefiPayload for AARCH64 (with the CLANGDWARF compiler) before and after, and see that it now compiles successfully. Clang and GCC fail to find lto-aarch64 too, and it's unclear at this time whether it's only a local issue. To be looked into later. Consider dropping this from your tools_def.txt if you experience problems too.

## Integration Instructions

N/A
