### PR TITLE
StandaloneMmPkg: Implement IPL in DXE and support platform-specific launches

### DIFF
--- a/OvmfPkg/OvmfPkgX64.dsc
+++ b/OvmfPkg/OvmfPkgX64.dsc
@@ -221,6 +221,7 @@
 !else
   CcProbeLib|MdePkg/Library/CcProbeLibNull/CcProbeLibNull.inf
 !if $(STANDALONE_MM_ENABLE) == TRUE
+  MmIplPlatformHookLib|StandaloneMmPkg/Library/MmIplPlatformHookLibNull/MmIplPlatformHookLibNull.inf
   MmPlatformHobProducerLib|OvmfPkg/Library/MmPlatformHobProducerLibOvmf/MmPlatformHobProducerLibOvmf.inf
 !endif
 !endif

--- a/StandaloneMmPkg/Drivers/StandaloneMmIplPei/MmFoundationHob.c
+++ b/StandaloneMmPkg/Drivers/StandaloneMmIplPei/MmFoundationHob.c
@@ -1067,6 +1067,16 @@ CreateMmFoundationHobList (
   UsedSize += HobLength;
 
   //
+  // Platforms may use the DXE IPL when CpuMpPei isn't or cannot be used.
+  // In this case, there is no Mp Information2 HOB in the primary list, so, build it here.
+  //
+  if (HobLength == 0) {
+    HobLength = GetRemainingHobSize (*FoundationHobSize, UsedSize);
+    MmIplBuildMpInformationHob (FoundationHobList + UsedSize, &HobLength);
+    UsedSize += HobLength;
+  }
+
+  //
   // Build ACPI variable HOB
   //
   HobLength = GetRemainingHobSize (*FoundationHobSize, UsedSize);

--- a/StandaloneMmPkg/Drivers/StandaloneMmIplPei/MmFoundationHob.c
+++ b/StandaloneMmPkg/Drivers/StandaloneMmIplPei/MmFoundationHob.c
@@ -290,7 +290,7 @@ MmIplBuildMmramDescriptorHob (
 
   This function builds a customized HOB tagged with a GUID for identification, copies the
   input data to the HOB data field and returns the start address of the GUID HOB data.
-  If new HOB buffer is NULL or the GUID HOB could not found, then ASSERT().
+  If new HOB buffer is NULL, then ASSERT().
 
   @param[in]       HobBuffer            The pointer of HOB buffer.
   @param[in, out]  HobBufferSize        The available size of the HOB buffer when as input.
@@ -311,7 +311,10 @@ MmIplCopyGuidHob (
 
   UsedSize = 0;
   GuidHob  = GetFirstGuidHob (Guid);
-  ASSERT (GuidHob != NULL);
+
+  if (GuidHob == NULL) {
+    DEBUG ((DEBUG_WARN, "GUIDed HOB %g could not be found\n", Guid));
+  }
 
   while (GuidHob != NULL) {
     if (*HobBufferSize >= UsedSize + GuidHob->HobLength) {

--- a/StandaloneMmPkg/Drivers/StandaloneMmIplPei/StandaloneMmIplCommon.c
+++ b/StandaloneMmPkg/Drivers/StandaloneMmIplPei/StandaloneMmIplCommon.c
@@ -267,6 +267,9 @@ MmIplAllocateMmramPage (
                                                             sizeof (EFI_MMRAM_HOB_DESCRIPTOR_BLOCK) + ((FullMmramRangeCount - 1) * sizeof (EFI_MMRAM_DESCRIPTOR))
                                                             );
   ASSERT (NewDescriptorBlock != NULL);
+  if (NewDescriptorBlock == NULL) {
+    return 0;
+  }
 
   NewDescriptorBlock->NumberOfMmReservedRegions = FullMmramRangeCount;
   FullMmramRanges                               = NewDescriptorBlock->Descriptor;

--- a/StandaloneMmPkg/Drivers/StandaloneMmIplPei/StandaloneMmIplCommon.c
+++ b/StandaloneMmPkg/Drivers/StandaloneMmIplPei/StandaloneMmIplCommon.c
@@ -224,7 +224,7 @@ FindLargestMmramRange (
   Allocate available MMRAM for MM core image.
 
   @param[in]  Pages                     Page count of MM core image.
-  @param[out] NewBlock                  Pointer of new mmram block HOB.
+  @param[out] NewBlock                  Pointer to new MMRAM blocks.
 
   @return  EFI_PHYSICAL_ADDRESS         Address for MM core image to be loaded in MMRAM.
 **/
@@ -262,8 +262,7 @@ MmIplAllocateMmramPage (
   // 2. Split the largest region and mark the allocated region as ALLOCATED
   //
   FullMmramRangeCount = CurrentBlock->NumberOfMmReservedRegions + 1;
-  NewDescriptorBlock  = (EFI_MMRAM_HOB_DESCRIPTOR_BLOCK *)BuildGuidHob (
-                                                            &gEfiSmmSmramMemoryGuid,
+  NewDescriptorBlock  = (EFI_MMRAM_HOB_DESCRIPTOR_BLOCK *)AllocatePool (
                                                             sizeof (EFI_MMRAM_HOB_DESCRIPTOR_BLOCK) + ((FullMmramRangeCount - 1) * sizeof (EFI_MMRAM_DESCRIPTOR))
                                                             );
   ASSERT (NewDescriptorBlock != NULL);
@@ -293,11 +292,6 @@ MmIplAllocateMmramPage (
   Allocated->PhysicalStart = Largest->PhysicalStart + Largest->PhysicalSize;
   Allocated->RegionState   = Largest->RegionState | EFI_ALLOCATED;
   Allocated->PhysicalSize  = EFI_PAGES_TO_SIZE (Pages);
-
-  //
-  // Scrub old one
-  //
-  ZeroMem (&MmramInfoHob->Name, sizeof (MmramInfoHob->Name));
 
   //
   // New MMRAM descriptor block
@@ -427,6 +421,7 @@ ExecuteMmCoreFromMmram (
       Entry = (MM_FOUNDATION_ENTRY_POINT)(UINTN)ImageContext.EntryPoint;
       Entry (MmHobList);
       FreePages (MmHobList, EFI_SIZE_TO_PAGES (MmHobSize));
+      FreePool (Block);
     }
   }
 

--- a/StandaloneMmPkg/Drivers/StandaloneMmIplPei/StandaloneMmIplCommon.c
+++ b/StandaloneMmPkg/Drivers/StandaloneMmIplPei/StandaloneMmIplCommon.c
@@ -327,10 +327,6 @@ ExecuteMmCoreFromMmram (
   PE_COFF_LOADER_IMAGE_CONTEXT    ImageContext;
   MM_FOUNDATION_ENTRY_POINT       Entry;
   EFI_MMRAM_HOB_DESCRIPTOR_BLOCK  *Block;
-  EFI_PEI_MM_ACCESS_PPI           *MmAccess;
-  UINTN                           Size;
-  UINTN                           Index;
-  UINTN                           MmramRangeCount;
 
   MmFvBase = 0;
   MmFvSize = 0;
@@ -341,37 +337,11 @@ ExecuteMmCoreFromMmram (
   ASSERT_EFI_ERROR (Status);
 
   //
-  // Prepare an MM access PPI for MM RAM.
+  // Open all MMRAM ranges if MmAccess is available.
   //
-  MmAccess        = NULL;
-  MmramRangeCount = 0;
-  Status          = PeiServicesLocatePpi (
-                      &gEfiPeiMmAccessPpiGuid,
-                      0,
-                      NULL,
-                      (VOID **)&MmAccess
-                      );
-  if (!EFI_ERROR (Status)) {
-    //
-    // Open all MMRAM ranges, if MmAccess is available.
-    //
-    Size   = 0;
-    Status = MmAccess->GetCapabilities ((EFI_PEI_SERVICES **)GetPeiServicesTablePointer (), MmAccess, &Size, NULL);
-    if (Status != EFI_BUFFER_TOO_SMALL) {
-      // This is not right...
-      ASSERT (Status == EFI_BUFFER_TOO_SMALL);
-      return EFI_DEVICE_ERROR;
-    }
-
-    MmramRangeCount = Size / sizeof (EFI_MMRAM_DESCRIPTOR);
-    for (Index = 0; Index < MmramRangeCount; Index++) {
-      Status = MmAccess->Open ((EFI_PEI_SERVICES **)GetPeiServicesTablePointer (), MmAccess, Index);
-      if (EFI_ERROR (Status)) {
-        DEBUG ((DEBUG_ERROR, "MM IPL failed to open MMRAM windows index %d - %r\n", Index, Status));
-        ASSERT_EFI_ERROR (Status);
-        goto Done;
-      }
-    }
+  Status = MmAccessOpen ();
+  if (EFI_ERROR (Status)) {
+    goto Done;
   }
 
   //
@@ -458,42 +428,7 @@ ExecuteMmCoreFromMmram (
   }
 
 Done:
-  if (MmAccess != NULL) {
-    //
-    // Close all MMRAM ranges, if MmAccess is available.
-    //
-    for (Index = 0; Index < MmramRangeCount; Index++) {
-      Status = MmAccess->Close ((EFI_PEI_SERVICES **)GetPeiServicesTablePointer (), MmAccess, Index);
-      if (EFI_ERROR (Status)) {
-        DEBUG ((DEBUG_ERROR, "MM IPL failed to close MMRAM windows index %d - %r\n", Index, Status));
-        ASSERT (FALSE);
-        return Status;
-      }
-
-      //
-      // Print debug message that the MMRAM window is now closed.
-      //
-      DEBUG ((DEBUG_INFO, "MM IPL closed MMRAM window index %d\n", Index));
-
-      //
-      // Lock the MMRAM (Note: Locking MMRAM may not be supported on all platforms)
-      //
-      Status = MmAccess->Lock ((EFI_PEI_SERVICES **)GetPeiServicesTablePointer (), MmAccess, Index);
-      if (EFI_ERROR (Status)) {
-        //
-        // Print error message that the MMRAM failed to lock...
-        //
-        DEBUG ((DEBUG_ERROR, "MM IPL could not lock MMRAM (Index %d) after executing MM Core %r\n", Index, Status));
-        ASSERT (FALSE);
-        return Status;
-      }
-
-      //
-      // Print debug message that the MMRAM window is now closed.
-      //
-      DEBUG ((DEBUG_INFO, "MM IPL locked MMRAM window index %d\n", Index));
-    }
-  }
+  Status = MmAccessClose ();
 
   return Status;
 }

--- a/StandaloneMmPkg/Drivers/StandaloneMmIplPei/StandaloneMmIplCommon.c
+++ b/StandaloneMmPkg/Drivers/StandaloneMmIplPei/StandaloneMmIplCommon.c
@@ -1,0 +1,536 @@
+/** @file
+  MM IPL that loads the MM Core into MMRAM.
+
+  Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "StandaloneMmIplPei.h"
+
+/**
+  Create HOB list for Standalone MM core.
+
+  @param[out]  HobSize              HOB size of fundation and platform HOB list.
+  @param[in]   MmCommBuffer         Pointer of MM communication buffer.
+  @param[in]   MmFvBase             Base of MM FV which included MM core driver.
+  @param[in]   MmFvSize             Size of MM FV which included MM core driver.
+  @param[in]   MmCoreFileName       File GUID of MM core driver.
+  @param[in]   MmCoreImageAddress   Address of MM core image.
+  @param[in]   MmCoreImageSize      Size of MM core image.
+  @param[in]   MmCoreEntryPoint     Entry point of MM core driver.
+  @param[in]   Block                Pointer of MMRAM descriptor block.
+
+  @retval HobList              If fundation and platform HOBs not existed,
+                               it is pointed to PEI HOB List. If existed,
+                               it is pointed to fundation and platform HOB list.
+**/
+VOID *
+CreateMmHobList (
+  OUT UINTN                           *HobSize,
+  IN  MM_COMM_BUFFER                  *MmCommBuffer,
+  IN  EFI_PHYSICAL_ADDRESS            MmFvBase,
+  IN  UINT64                          MmFvSize,
+  IN  EFI_GUID                        *MmCoreFileName,
+  IN  PHYSICAL_ADDRESS                MmCoreImageAddress,
+  IN  UINT64                          MmCoreImageSize,
+  IN  PHYSICAL_ADDRESS                MmCoreEntryPoint,
+  IN  EFI_MMRAM_HOB_DESCRIPTOR_BLOCK  *Block
+  )
+{
+  EFI_STATUS                 Status;
+  VOID                       *HobList;
+  VOID                       *PlatformHobList;
+  UINTN                      PlatformHobSize;
+  UINTN                      BufferSize;
+  UINTN                      FoundationHobSize;
+  EFI_HOB_MEMORY_ALLOCATION  *MmProfileDataHob;
+  UINTN                      PhitHobSize;
+  VOID                       *HobEnd;
+
+  //
+  // Get platform HOBs
+  //
+  PlatformHobSize = 0;
+  Status          = CreateMmPlatformHob (NULL, &PlatformHobSize);
+  if (Status == RETURN_BUFFER_TOO_SMALL) {
+    if (PlatformHobSize == 0) {
+      DEBUG ((DEBUG_ERROR, "%a: PlatformHobSize is zero, cannot create MM HOBs\n", __func__));
+      ASSERT (PlatformHobSize != 0);
+      return NULL;
+    }
+
+    //
+    // Create platform HOBs for MM foundation to get MMIO HOB data.
+    //
+    PlatformHobList = AllocatePages (EFI_SIZE_TO_PAGES (PlatformHobSize));
+    if (PlatformHobList == NULL) {
+      DEBUG ((DEBUG_ERROR, "%a: Out of resource to create platform MM HOBs\n", __func__));
+      ASSERT (PlatformHobList != NULL);
+      return NULL;
+    }
+
+    BufferSize = PlatformHobSize;
+    Status     = CreateMmPlatformHob (PlatformHobList, &PlatformHobSize);
+    if (BufferSize != PlatformHobSize) {
+      DEBUG ((DEBUG_ERROR, "%a: CreateMmPlatformHob returned unexpected size (%d != %d)\n", __func__, BufferSize, PlatformHobSize));
+      FreePages (PlatformHobList, EFI_SIZE_TO_PAGES (PlatformHobSize));
+      return NULL;
+    }
+  }
+
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: CreateMmPlatformHob failed (%r)\n", __func__, Status));
+    return NULL;
+  }
+
+  //
+  // Build memory allocation HOB in PEI HOB list for MM profile data.
+  //
+  MmProfileDataHob = NULL;
+  if (FeaturePcdGet (PcdCpuSmmProfileEnable)) {
+    MmProfileDataHob = BuildMmProfileDataHobInPeiHobList ();
+  }
+
+  //
+  // Get size of foundation HOBs
+  //
+  FoundationHobSize = 0;
+  Status            = CreateMmFoundationHobList (
+                        NULL,
+                        &FoundationHobSize,
+                        PlatformHobList,
+                        PlatformHobSize,
+                        MmFvBase,
+                        MmFvSize,
+                        MmCoreFileName,
+                        MmCoreImageAddress,
+                        MmCoreImageSize,
+                        MmCoreEntryPoint,
+                        MmProfileDataHob,
+                        Block
+                        );
+  if (PlatformHobSize != 0) {
+    FreePages (PlatformHobList, EFI_SIZE_TO_PAGES (PlatformHobSize));
+  }
+
+  ASSERT (Status == RETURN_BUFFER_TOO_SMALL);
+  ASSERT (FoundationHobSize != 0);
+
+  PhitHobSize = sizeof (EFI_HOB_HANDOFF_INFO_TABLE);
+  //
+  // Final result includes: PHIT HOB, Platform HOBs, Foundation HOBs and an END node.
+  //
+  *HobSize = PhitHobSize + PlatformHobSize + FoundationHobSize + sizeof (EFI_HOB_GENERIC_HEADER);
+  HobList  = AllocatePages (EFI_SIZE_TO_PAGES (*HobSize));
+  ASSERT (HobList != NULL);
+  if (HobList == NULL) {
+    DEBUG ((DEBUG_ERROR, "Out of resource to create MM HOBs\n"));
+    CpuDeadLoop ();
+  }
+
+  HobEnd = (UINT8 *)(UINTN)HobList + PhitHobSize + PlatformHobSize + FoundationHobSize;
+  //
+  // Create MmHobHandoffInfoTable
+  //
+  CreateMmHobHandoffInfoTable (HobList, HobEnd);
+
+  //
+  // Get platform HOBs
+  //
+  Status = CreateMmPlatformHob ((UINT8 *)HobList + PhitHobSize, &PlatformHobSize);
+  ASSERT_EFI_ERROR (Status);
+
+  //
+  // Get foundation HOBs
+  //
+  Status = CreateMmFoundationHobList (
+             (UINT8 *)HobList + PhitHobSize + PlatformHobSize,
+             &FoundationHobSize,
+             HobList,
+             PlatformHobSize,
+             MmFvBase,
+             MmFvSize,
+             MmCoreFileName,
+             MmCoreImageAddress,
+             MmCoreImageSize,
+             MmCoreEntryPoint,
+             MmProfileDataHob,
+             Block
+             );
+  ASSERT_EFI_ERROR (Status);
+
+  //
+  // Create MM HOB list end.
+  //
+  MmIplCreateHob (HobEnd, EFI_HOB_TYPE_END_OF_HOB_LIST, sizeof (EFI_HOB_GENERIC_HEADER));
+
+  return HobList;
+}
+
+/**
+  Find largest unallocated MMRAM in current MMRAM descriptor block
+
+  @param[in, out] LagestMmramRangeIndex  Lagest mmram range index.
+  @param[in]      CurrentBlock           Current MMRAM descriptor block.
+
+**/
+VOID
+FindLargestMmramRange (
+  IN OUT UINTN                       *LagestMmramRangeIndex,
+  IN EFI_MMRAM_HOB_DESCRIPTOR_BLOCK  *CurrentBlock
+  )
+{
+  UINTN                 Index;
+  UINT64                MaxSize;
+  BOOLEAN               Found;
+  EFI_MMRAM_DESCRIPTOR  *MmramRanges;
+
+  MmramRanges = CurrentBlock->Descriptor;
+
+  //
+  // Find largest Mmram range.
+  //
+  Found = FALSE;
+  for (Index = 0, MaxSize = SIZE_256KB - EFI_PAGE_SIZE; Index < CurrentBlock->NumberOfMmReservedRegions; Index++) {
+    //
+    // Skip any MMRAM region that is already allocated, needs testing, or needs ECC initialization
+    //
+    if ((MmramRanges[Index].RegionState & (EFI_ALLOCATED | EFI_NEEDS_TESTING | EFI_NEEDS_ECC_INITIALIZATION)) != 0) {
+      continue;
+    }
+
+    if (MmramRanges[Index].CpuStart >= BASE_1MB) {
+      if ((MmramRanges[Index].CpuStart + MmramRanges[Index].PhysicalSize) <= BASE_4GB) {
+        if (MmramRanges[Index].PhysicalSize >= MaxSize) {
+          Found                  = TRUE;
+          *LagestMmramRangeIndex = Index;
+          MaxSize                = MmramRanges[Index].PhysicalSize;
+        }
+      }
+    }
+  }
+
+  if (Found == FALSE) {
+    DEBUG ((DEBUG_ERROR, "Not found largest unlocated MMRAM\n"));
+    ASSERT (FALSE);
+    CpuDeadLoop ();
+  }
+
+  return;
+}
+
+/**
+  Allocate available MMRAM for MM core image.
+
+  @param[in]  Pages                     Page count of MM core image.
+  @param[out] NewBlock                  Pointer of new mmram block HOB.
+
+  @return  EFI_PHYSICAL_ADDRESS         Address for MM core image to be loaded in MMRAM.
+**/
+EFI_PHYSICAL_ADDRESS
+MmIplAllocateMmramPage (
+  IN  UINTN                           Pages,
+  OUT EFI_MMRAM_HOB_DESCRIPTOR_BLOCK  **NewBlock
+  )
+{
+  UINTN                           LagestMmramRangeIndex;
+  UINT32                          FullMmramRangeCount;
+  EFI_HOB_GUID_TYPE               *MmramInfoHob;
+  EFI_MMRAM_DESCRIPTOR            *Largest;
+  EFI_MMRAM_DESCRIPTOR            *Allocated;
+  EFI_MMRAM_DESCRIPTOR            *FullMmramRanges;
+  EFI_MMRAM_HOB_DESCRIPTOR_BLOCK  *CurrentBlock;
+  EFI_MMRAM_HOB_DESCRIPTOR_BLOCK  *NewDescriptorBlock;
+
+  MmramInfoHob = GetFirstGuidHob (&gEfiSmmSmramMemoryGuid);
+  ASSERT (MmramInfoHob != NULL);
+  if (MmramInfoHob == NULL) {
+    DEBUG ((DEBUG_WARN, "SmramMemoryReserve HOB not found\n"));
+    return 0;
+  }
+
+  CurrentBlock = (EFI_MMRAM_HOB_DESCRIPTOR_BLOCK *)(GET_GUID_HOB_DATA (MmramInfoHob));
+
+  //
+  // 1. Find largest unallocated MMRAM region
+  //
+  FindLargestMmramRange (&LagestMmramRangeIndex, CurrentBlock);
+  ASSERT (LagestMmramRangeIndex < CurrentBlock->NumberOfMmReservedRegions);
+
+  //
+  // 2. Split the largest region and mark the allocated region as ALLOCATED
+  //
+  FullMmramRangeCount = CurrentBlock->NumberOfMmReservedRegions + 1;
+  NewDescriptorBlock  = (EFI_MMRAM_HOB_DESCRIPTOR_BLOCK *)BuildGuidHob (
+                                                            &gEfiSmmSmramMemoryGuid,
+                                                            sizeof (EFI_MMRAM_HOB_DESCRIPTOR_BLOCK) + ((FullMmramRangeCount - 1) * sizeof (EFI_MMRAM_DESCRIPTOR))
+                                                            );
+  ASSERT (NewDescriptorBlock != NULL);
+
+  NewDescriptorBlock->NumberOfMmReservedRegions = FullMmramRangeCount;
+  FullMmramRanges                               = NewDescriptorBlock->Descriptor;
+
+  //
+  // Get current MMRAM descriptors and fill to the full MMRAM ranges
+  //
+  CopyMem (NewDescriptorBlock->Descriptor, CurrentBlock->Descriptor, CurrentBlock->NumberOfMmReservedRegions * sizeof (EFI_MMRAM_DESCRIPTOR));
+
+  Largest = &FullMmramRanges[LagestMmramRangeIndex];
+  ASSERT ((Largest->PhysicalSize & EFI_PAGE_MASK) == 0);
+  ASSERT (Largest->PhysicalSize > EFI_PAGES_TO_SIZE (Pages));
+
+  Allocated = &NewDescriptorBlock->Descriptor[NewDescriptorBlock->NumberOfMmReservedRegions - 1];
+
+  //
+  // Allocate MMRAM
+  //
+  Largest->PhysicalSize   -= EFI_PAGES_TO_SIZE (Pages);
+  Allocated->CpuStart      = Largest->CpuStart + Largest->PhysicalSize;
+  Allocated->PhysicalStart = Largest->PhysicalStart + Largest->PhysicalSize;
+  Allocated->RegionState   = Largest->RegionState | EFI_ALLOCATED;
+  Allocated->PhysicalSize  = EFI_PAGES_TO_SIZE (Pages);
+
+  //
+  // Scrub old one
+  //
+  ZeroMem (&MmramInfoHob->Name, sizeof (MmramInfoHob->Name));
+
+  //
+  // New MMRAM descriptor block
+  //
+  *NewBlock = NewDescriptorBlock;
+
+  return Allocated->CpuStart;
+}
+
+/**
+  Load the MM Core image into MMRAM and executes the MM Core from MMRAM.
+
+  @param[in] MmCommBuffer               MM communicate buffer
+
+  @return    EFI_STATUS                 Execute MM core successfully.
+             Other                      Execute MM core failed.
+**/
+EFI_STATUS
+ExecuteMmCoreFromMmram (
+  IN  MM_COMM_BUFFER  *MmCommBuffer
+  )
+{
+  EFI_STATUS                      Status;
+  UINTN                           PageCount;
+  VOID                            *MmHobList;
+  UINTN                           MmHobSize;
+  EFI_GUID                        MmCoreFileName;
+  UINTN                           MmFvSize;
+  EFI_PHYSICAL_ADDRESS            MmFvBase;
+  PE_COFF_LOADER_IMAGE_CONTEXT    ImageContext;
+  MM_FOUNDATION_ENTRY_POINT       Entry;
+  EFI_MMRAM_HOB_DESCRIPTOR_BLOCK  *Block;
+  EFI_PEI_MM_ACCESS_PPI           *MmAccess;
+  UINTN                           Size;
+  UINTN                           Index;
+  UINTN                           MmramRangeCount;
+
+  MmFvBase = 0;
+  MmFvSize = 0;
+  //
+  // Search all Firmware Volumes for a PE/COFF image in a file of type MM_CORE_STANDALONE.
+  //
+  Status = LocateMmCoreFv (&MmFvBase, &MmFvSize, &MmCoreFileName, &ImageContext.Handle);
+  ASSERT_EFI_ERROR (Status);
+
+  //
+  // Prepare an MM access PPI for MM RAM.
+  //
+  MmAccess        = NULL;
+  MmramRangeCount = 0;
+  Status          = PeiServicesLocatePpi (
+                      &gEfiPeiMmAccessPpiGuid,
+                      0,
+                      NULL,
+                      (VOID **)&MmAccess
+                      );
+  if (!EFI_ERROR (Status)) {
+    //
+    // Open all MMRAM ranges, if MmAccess is available.
+    //
+    Size   = 0;
+    Status = MmAccess->GetCapabilities ((EFI_PEI_SERVICES **)GetPeiServicesTablePointer (), MmAccess, &Size, NULL);
+    if (Status != EFI_BUFFER_TOO_SMALL) {
+      // This is not right...
+      ASSERT (Status == EFI_BUFFER_TOO_SMALL);
+      return EFI_DEVICE_ERROR;
+    }
+
+    MmramRangeCount = Size / sizeof (EFI_MMRAM_DESCRIPTOR);
+    for (Index = 0; Index < MmramRangeCount; Index++) {
+      Status = MmAccess->Open ((EFI_PEI_SERVICES **)GetPeiServicesTablePointer (), MmAccess, Index);
+      if (EFI_ERROR (Status)) {
+        DEBUG ((DEBUG_ERROR, "MM IPL failed to open MMRAM windows index %d - %r\n", Index, Status));
+        ASSERT_EFI_ERROR (Status);
+        goto Done;
+      }
+    }
+  }
+
+  //
+  // Initialize ImageContext
+  //
+  ImageContext.ImageRead = PeCoffLoaderImageReadFromMemory;
+
+  //
+  // Get information about the image being loaded
+  //
+  Status = PeCoffLoaderGetImageInfo (&ImageContext);
+  if (EFI_ERROR (Status)) {
+    goto Done;
+  }
+
+  PageCount = (UINTN)EFI_SIZE_TO_PAGES ((UINTN)ImageContext.ImageSize + ImageContext.SectionAlignment);
+
+  //
+  // Allocate memory for the image being loaded from unallocated mmram range
+  //
+  ImageContext.ImageAddress = MmIplAllocateMmramPage (PageCount, &Block);
+  if (ImageContext.ImageAddress == 0) {
+    Status = EFI_NOT_FOUND;
+    goto Done;
+  }
+
+  //
+  // Align buffer on section boundary
+  //
+  ImageContext.ImageAddress += ImageContext.SectionAlignment - 1;
+  ImageContext.ImageAddress &= ~((EFI_PHYSICAL_ADDRESS)ImageContext.SectionAlignment - 1);
+
+  //
+  // Print debug message showing MM Core load address.
+  //
+  DEBUG ((DEBUG_INFO, "StandaloneMM IPL loading MM Core at MMRAM address %p\n", (VOID *)(UINTN)ImageContext.ImageAddress));
+
+  //
+  // Load the image to our new buffer
+  //
+  Status = PeCoffLoaderLoadImage (&ImageContext);
+  if (!EFI_ERROR (Status)) {
+    //
+    // Relocate the image in our new buffer
+    //
+    Status = PeCoffLoaderRelocateImage (&ImageContext);
+    if (!EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_INFO, "MmCoreImageBase  - 0x%016lx\n", ImageContext.ImageAddress));
+      DEBUG ((DEBUG_INFO, "MmCoreImageSize  - 0x%016lx\n", ImageContext.ImageSize));
+
+      //
+      // Flush the instruction cache so the image data are written before we execute it
+      //
+      InvalidateInstructionCacheRange ((VOID *)(UINTN)ImageContext.ImageAddress, (UINTN)ImageContext.ImageSize);
+
+      //
+      // Create HOB list for Standalone MM Core.
+      //
+      MmHobSize = 0;
+      MmHobList = CreateMmHobList (
+                    &MmHobSize,
+                    MmCommBuffer,
+                    MmFvBase,
+                    MmFvSize,
+                    &MmCoreFileName,
+                    ImageContext.ImageAddress,
+                    EFI_PAGES_TO_SIZE (PageCount),
+                    ImageContext.EntryPoint,
+                    Block
+                    );
+
+      //
+      // Print debug message showing Standalone MM Core entry point address.
+      //
+      DEBUG ((DEBUG_INFO, "StandaloneMM IPL calling Standalone MM Core at MMRAM address - 0x%016lx\n", ImageContext.EntryPoint));
+
+      //
+      // Execute image
+      //
+      Entry = (MM_FOUNDATION_ENTRY_POINT)(UINTN)ImageContext.EntryPoint;
+      Entry (MmHobList);
+      FreePages (MmHobList, EFI_SIZE_TO_PAGES (MmHobSize));
+    }
+  }
+
+Done:
+  if (MmAccess != NULL) {
+    //
+    // Close all MMRAM ranges, if MmAccess is available.
+    //
+    for (Index = 0; Index < MmramRangeCount; Index++) {
+      Status = MmAccess->Close ((EFI_PEI_SERVICES **)GetPeiServicesTablePointer (), MmAccess, Index);
+      if (EFI_ERROR (Status)) {
+        DEBUG ((DEBUG_ERROR, "MM IPL failed to close MMRAM windows index %d - %r\n", Index, Status));
+        ASSERT (FALSE);
+        return Status;
+      }
+
+      //
+      // Print debug message that the MMRAM window is now closed.
+      //
+      DEBUG ((DEBUG_INFO, "MM IPL closed MMRAM window index %d\n", Index));
+
+      //
+      // Lock the MMRAM (Note: Locking MMRAM may not be supported on all platforms)
+      //
+      Status = MmAccess->Lock ((EFI_PEI_SERVICES **)GetPeiServicesTablePointer (), MmAccess, Index);
+      if (EFI_ERROR (Status)) {
+        //
+        // Print error message that the MMRAM failed to lock...
+        //
+        DEBUG ((DEBUG_ERROR, "MM IPL could not lock MMRAM (Index %d) after executing MM Core %r\n", Index, Status));
+        ASSERT (FALSE);
+        return Status;
+      }
+
+      //
+      // Print debug message that the MMRAM window is now closed.
+      //
+      DEBUG ((DEBUG_INFO, "MM IPL locked MMRAM window index %d\n", Index));
+    }
+  }
+
+  return Status;
+}
+
+/**
+  Dispatch StandaloneMm drivers in MM.
+
+  StandaloneMm core will exit when MmEntryPoint was registered in CPU
+  StandaloneMm driver, and issue a software SMI by communicate mode to
+  dispatch other StandaloneMm drivers.
+
+  @retval  EFI_SUCCESS      Dispatch StandaloneMm drivers successfully.
+  @retval  Other            Dispatch StandaloneMm drivers failed.
+
+**/
+EFI_STATUS
+MmIplDispatchMmDrivers (
+  VOID
+  )
+{
+  EFI_STATUS                 Status;
+  UINTN                      Size;
+  EFI_MM_COMMUNICATE_HEADER  CommunicateHeader;
+
+  //
+  // Use Guid to initialize EFI_MM_COMMUNICATE_HEADER structure
+  //
+  CopyGuid (&CommunicateHeader.HeaderGuid, &gEventMmDispatchGuid);
+  CommunicateHeader.MessageLength = 1;
+  CommunicateHeader.Data[0]       = 0;
+
+  //
+  // Generate the Software SMI and return the result
+  //
+  Size   = sizeof (CommunicateHeader);
+  Status = Communicate (NULL, &CommunicateHeader, &Size);
+  ASSERT_EFI_ERROR (Status);
+
+  return Status;
+}

--- a/StandaloneMmPkg/Drivers/StandaloneMmIplPei/StandaloneMmIplDxe.c
+++ b/StandaloneMmPkg/Drivers/StandaloneMmIplPei/StandaloneMmIplDxe.c
@@ -1,0 +1,371 @@
+/** @file
+  MM IPL that loads the MM Core into MMRAM during DXE.
+
+  Copyright (c) 2025, 9elements GmbH.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "StandaloneMmIplPei.h"
+#include <Library/UefiBootServicesTableLib.h>
+#include <Protocol/FirmwareVolume2.h>
+#include <Protocol/FirmwareVolumeBlock.h>
+#include <Protocol/MmAccess.h>
+#include <Protocol/MmCommunication.h>
+#include <Protocol/MpService.h>
+#include <Guid/MpInformation2.h>
+
+STATIC VOID  *MmCoreBufferAddress = NULL;
+
+/**
+  Communicates with a registered handler.
+
+  This function provides a service to send and receive messages from a registered UEFI service.
+
+  @param[in] This                The EFI_PEI_MM_COMMUNICATION_PPI instance.
+  @param[in, out] CommBuffer     A pointer to the buffer to convey into MMRAM.
+  @param[in, out] CommSize       The size of the data buffer being passed in.On exit, the size of data
+                                 being returned. Zero if the handler does not wish to reply with any data.
+
+  @retval EFI_SUCCESS            The message was successfully posted.
+  @retval EFI_INVALID_PARAMETER  The CommBuffer was NULL.
+  @retval EFI_NOT_STARTED        The service is NOT started.
+**/
+EFI_STATUS
+EFIAPI
+Communicate (
+  IN CONST EFI_PEI_MM_COMMUNICATION_PPI  *This,
+  IN OUT VOID                            *CommBuffer,
+  IN OUT UINTN                           *CommSize
+  )
+{
+  EFI_MM_COMMUNICATION_PROTOCOL  *MmCommunication;
+  EFI_STATUS                     Status;
+
+  Status = gBS->LocateProtocol (&gEfiMmCommunicationProtocolGuid, NULL, (VOID **)&MmCommunication);
+  ASSERT_EFI_ERROR (Status);
+
+  return MmCommunication->Communicate (MmCommunication, CommBuffer, CommSize);
+}
+
+/**
+  Search all the available firmware volumes for MM Core driver.
+
+  @param  MmFvBase             Base address of FV which included MM Core driver.
+  @param  MmFvSize             Size of FV which included MM Core driver.
+  @param  MmCoreFileName       GUID of MM Core.
+  @param  MmCoreImageAddress   MM Core image address.
+
+  @retval EFI_SUCCESS          The specified FFS section was returned.
+  @retval EFI_NOT_FOUND        The specified FFS section could not be found.
+
+**/
+EFI_STATUS
+LocateMmCoreFv (
+  OUT EFI_PHYSICAL_ADDRESS  *MmFvBase,
+  OUT UINTN                 *MmFvSize,
+  OUT EFI_GUID              *MmCoreFileName,
+  OUT VOID                  **MmCoreImageAddress
+  )
+{
+  EFI_FV_FILETYPE                      FileType;
+  EFI_STATUS                           Status;
+  EFI_HANDLE                           *HandleBuffer;
+  UINTN                                HandleCount;
+  UINTN                                IndexFv;
+  EFI_FIRMWARE_VOLUME2_PROTOCOL        *Fv;
+  UINTN                                Key;
+  EFI_GUID                             NameGuid;
+  EFI_FV_FILE_ATTRIBUTES               Attributes;
+  UINTN                                Size;
+  UINT32                               AuthenticationStatus;
+  EFI_HANDLE                           FvHandle;
+  EFI_FIRMWARE_VOLUME_BLOCK2_PROTOCOL  *Fvb;
+  EFI_FIRMWARE_VOLUME_HEADER           *FwVolHeader;
+
+  *MmCoreImageAddress = NULL;
+
+  //
+  // First, find the FV with MM core.
+  //
+  FileType = EFI_FV_FILETYPE_MM_CORE_STANDALONE;
+
+  //
+  // Locate all available FVs.
+  //
+  HandleBuffer = NULL;
+  Status       = gBS->LocateHandleBuffer (
+                        ByProtocol,
+                        &gEfiFirmwareVolume2ProtocolGuid,
+                        NULL,
+                        &HandleCount,
+                        &HandleBuffer
+                        );
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  //
+  // Go through FVs one by one to find the required section data.
+  //
+  for (IndexFv = 0; IndexFv < HandleCount; IndexFv++) {
+    Status = gBS->HandleProtocol (
+                    HandleBuffer[IndexFv],
+                    &gEfiFirmwareVolume2ProtocolGuid,
+                    (VOID **)&Fv
+                    );
+    if (EFI_ERROR (Status)) {
+      continue;
+    }
+
+    //
+    // Use Firmware Volume 2 Protocol to search for a file of type FileType in all FVs.
+    //
+    Key    = 0;
+    Status = Fv->GetNextFile (Fv, &Key, &FileType, &NameGuid, &Attributes, &Size);
+    if (EFI_ERROR (Status)) {
+      continue;
+    }
+
+    //
+    // Fv File with the required FV file type is found.
+    // Search the section file in the found FV file.
+    //
+    Size   = 0;
+    Status = Fv->ReadSection (
+                   Fv,
+                   &NameGuid,
+                   EFI_SECTION_PE32,
+                   0,
+                   MmCoreImageAddress,
+                   &Size,
+                   &AuthenticationStatus
+                   );
+    if (!EFI_ERROR (Status)) {
+      goto Found;
+    }
+  }
+
+  //
+  // The required FFS section file is not found.
+  //
+  if (IndexFv == HandleCount) {
+    Status = EFI_NOT_FOUND;
+  }
+
+Found:
+  if (HandleBuffer != NULL) {
+    FvHandle = HandleBuffer[IndexFv];
+    FreePool (HandleBuffer);
+  }
+
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  //
+  // Stash this to free when done.
+  //
+  MmCoreBufferAddress = *MmCoreImageAddress;
+
+  //
+  // Now, retrieve the other requested parameters.
+  //
+  CopyMem (MmCoreFileName, &NameGuid, sizeof (EFI_GUID));
+
+  Status = gBS->HandleProtocol (
+                  FvHandle,
+                  &gEfiFirmwareVolumeBlock2ProtocolGuid,
+                  (VOID **)&Fvb
+                  );
+  ASSERT_EFI_ERROR (Status);
+
+  Status = Fvb->GetPhysicalAddress (
+                  Fvb,
+                  MmFvBase
+                  );
+  ASSERT_EFI_ERROR (Status);
+
+  FwVolHeader = (EFI_FIRMWARE_VOLUME_HEADER *)(UINTN)*MmFvBase;
+  *MmFvSize   = FwVolHeader->FvLength;
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Open all MMRAM ranges if platform provides an MmAccess implementation.
+  If it does, it's likely required to be able to use MMRAM.
+
+  @retval EFI_SUCCESS       MMRAM is opened.
+  @retval EFI_DEVICE_ERROR  MMRAM could not be opened.
+
+**/
+EFI_STATUS
+MmAccessOpen (
+  VOID
+  )
+{
+  EFI_MM_ACCESS_PROTOCOL  *MmAccess;
+  EFI_STATUS              Status;
+
+  //
+  // Open all MMRAM ranges, if MmAccess is available.
+  //
+  Status = gBS->LocateProtocol (&gEfiMmAccessProtocolGuid, NULL, (VOID **)&MmAccess);
+  if (!EFI_ERROR (Status)) {
+    Status = MmAccess->Open (MmAccess);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "MM IPL failed to open MMRAM window - %r\n", Status));
+      ASSERT_EFI_ERROR (Status);
+      return EFI_DEVICE_ERROR;
+    }
+
+    //
+    // Print debug message that the MMRAM window is now opened.
+    //
+    DEBUG ((DEBUG_INFO, "MM IPL opened MMRAM window\n"));
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Close and lock all MMRAM ranges if platform provides an MmAccess implementation.
+  If it does, it's likely required for security reasons.
+
+**/
+EFI_STATUS
+MmAccessClose (
+  VOID
+  )
+{
+  EFI_MM_ACCESS_PROTOCOL  *MmAccess;
+  EFI_STATUS              Status;
+
+  //
+  // Close all MMRAM ranges, if MmAccess is available.
+  //
+  Status = gBS->LocateProtocol (&gEfiMmAccessProtocolGuid, NULL, (VOID **)&MmAccess);
+  if (!EFI_ERROR (Status)) {
+    Status = MmAccess->Close (MmAccess);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "MM IPL failed to close MMRAM window - %r\n", Status));
+      ASSERT_EFI_ERROR (Status);
+      return EFI_DEVICE_ERROR;
+    }
+
+    //
+    // Print debug message that the MMRAM window is now closed.
+    //
+    DEBUG ((DEBUG_INFO, "MM IPL closed MMRAM window\n"));
+
+    //
+    // Lock the MMRAM (Note: Locking MMRAM may not be supported on all platforms)
+    //
+    Status = MmAccess->Lock (MmAccess);
+    if (EFI_ERROR (Status)) {
+      //
+      // Print error message that the MMRAM failed to lock...
+      //
+      DEBUG ((DEBUG_ERROR, "MM IPL could not lock MMRAM window after executing MM Core - %r\n", Status));
+      ASSERT_EFI_ERROR (Status);
+      return EFI_DEVICE_ERROR;
+    }
+
+    //
+    // Print debug message that the MMRAM window is now locked.
+    //
+    DEBUG ((DEBUG_INFO, "MM IPL locked MMRAM window\n"));
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This is the callback function on end of PEI.
+
+  This callback is used for call MmEndOfPeiHandler in standalone MM core.
+
+  @retval  EFI_SUCCESS       Exit boot services successfully.
+  @retval  Other             Exit boot services failed.
+**/
+EFI_STATUS
+EFIAPI
+SignalEndOfPei (
+  VOID
+  )
+{
+  EFI_MM_COMMUNICATE_HEADER  CommunicateHeader;
+  UINTN                      Size;
+  EFI_STATUS                 Status;
+
+  //
+  // Use Guid to initialize EFI_MM_COMMUNICATE_HEADER structure
+  //
+  CopyGuid (&CommunicateHeader.HeaderGuid, &gEfiMmEndOfPeiProtocol);
+  CommunicateHeader.MessageLength = 1;
+  CommunicateHeader.Data[0]       = 0;
+
+  //
+  // Generate the Software SMI and return the result
+  //
+  Size   = sizeof (CommunicateHeader);
+  Status = Communicate (NULL, &CommunicateHeader, &Size);
+  ASSERT_EFI_ERROR (Status);
+
+  return Status;
+}
+
+/**
+  The Entry Point for MmCommunicateDxe driver.
+
+  @param  ImageHandle    The firmware allocated handle for the EFI image.
+  @param  SystemTable    A pointer to the EFI System Table.
+
+  @retval EFI_SUCCESS    The entry point is executed successfully.
+  @retval Other          Some error occurred when executing this entry point.
+
+**/
+EFI_STATUS
+EFIAPI
+StandaloneMmIplDxeEntry (
+  IN EFI_HANDLE        ImageHandle,
+  IN EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  EFI_HOB_GUID_TYPE  *GuidHob;
+  MM_COMM_BUFFER     *MmCommBuffer;
+  EFI_STATUS         Status;
+
+  //
+  // Retrieve communication buffer HOB.
+  //
+  GuidHob = GetFirstGuidHob (&gMmCommBufferHobGuid);
+  if (GuidHob == NULL) {
+    DEBUG ((DEBUG_ERROR, "StandaloneMmIplDxe used without platform support!\n"));
+    return EFI_UNSUPPORTED;
+  }
+
+  MmCommBuffer = GET_GUID_HOB_DATA (GuidHob);
+
+  //
+  // Locate and execute Mm Core to dispatch MM drivers.
+  //
+  Status = ExecuteMmCoreFromMmram (MmCommBuffer);
+  ASSERT_EFI_ERROR (Status);
+
+  FreePool (MmCoreBufferAddress);
+
+  //
+  // Dispatch StandaloneMm drivers in MM
+  //
+  Status = MmIplDispatchMmDrivers ();
+  ASSERT_EFI_ERROR (Status);
+
+  //
+  // Call MmEndOfPeiHandler in MM core
+  //
+  SignalEndOfPei ();
+
+  return EFI_SUCCESS;
+}

--- a/StandaloneMmPkg/Drivers/StandaloneMmIplPei/StandaloneMmIplDxe.inf
+++ b/StandaloneMmPkg/Drivers/StandaloneMmIplPei/StandaloneMmIplDxe.inf
@@ -1,0 +1,86 @@
+## @file
+#  This module provide a Standalone MM compliant implementation of the MM IPL.
+#
+#  Copyright (c) 2025, 9elements GmbH.<BR>
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x0001001A
+  BASE_NAME                      = StandaloneMmIplDxe
+  FILE_GUID                      = 4C5D5F73-3616-4D37-8459-3ACA6E2D8FC5
+  MODULE_TYPE                    = DXE_DRIVER
+  VERSION_STRING                 = 1.0
+  PI_SPECIFICATION_VERSION       = 0x00010032
+  ENTRY_POINT                    = StandaloneMmIplDxeEntry
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = X64
+#
+
+[Sources]
+  StandaloneMmIplCommon.c
+  StandaloneMmIplDxe.c
+  StandaloneMmIplPei.h
+  MmFoundationHob.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  StandaloneMmPkg/StandaloneMmPkg.dec
+  UefiCpuPkg/UefiCpuPkg.dec
+
+[LibraryClasses]
+  UefiDriverEntryPoint
+  UefiBootServicesTableLib
+  DxeServicesLib
+  DebugLib
+  HobLib
+  MemoryAllocationLib
+  BaseLib
+  BaseMemoryLib
+  PeCoffLib
+  CacheMaintenanceLib
+  MmPlatformHobProducerLib
+  MmIplPlatformHookLib
+
+[Guids]
+  gMmCommBufferHobGuid
+  gEfiSmmSmramMemoryGuid
+  gEventMmDispatchGuid
+  gSmmBaseHobGuid
+  gMpInformation2HobGuid
+  gEfiAcpiVariableGuid
+  gMmAcpiS3EnableHobGuid
+  gMmCpuSyncConfigHobGuid
+  gMmProfileDataHobGuid
+  gMmUnblockRegionHobGuid
+  gMmStatusCodeUseSerialHobGuid
+  gEfiMmCommunicateHeaderV3Guid
+  gEfiHobMemoryAllocModuleGuid
+
+[Protocols]
+  gEfiMmCommunicationProtocolGuid
+  gEfiFirmwareVolume2ProtocolGuid
+  gEfiFirmwareVolumeBlock2ProtocolGuid
+  gEfiMmAccessProtocolGuid
+  gEfiMmEndOfPeiProtocol
+  gEfiMpServiceProtocolGuid
+
+[Pcd]
+  gEfiMdeModulePkgTokenSpaceGuid.PcdAcpiS3Enable                   ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdStatusCodeUseSerial            ## CONSUMES
+  gUefiCpuPkgTokenSpaceGuid.PcdCpuSmmSyncMode                      ## CONSUMES
+  gUefiCpuPkgTokenSpaceGuid.PcdCpuSmmApSyncTimeout                 ## CONSUMES
+  gUefiCpuPkgTokenSpaceGuid.PcdCpuSmmApSyncTimeout2                ## CONSUMES
+  gUefiCpuPkgTokenSpaceGuid.PcdCpuSmmProfileEnable                 ## CONSUMES
+  gUefiCpuPkgTokenSpaceGuid.PcdCpuSmmProfileSize                   ## CONSUMES
+
+[Pcd.X64]
+  gUefiCpuPkgTokenSpaceGuid.PcdCpuSmmRestrictedMemoryAccess        ## CONSUMES
+
+[Depex]
+  gEfiMmCommunicationProtocolGuid AND gEfiMpServiceProtocolGuid

--- a/StandaloneMmPkg/Drivers/StandaloneMmIplPei/StandaloneMmIplPei.c
+++ b/StandaloneMmPkg/Drivers/StandaloneMmIplPei/StandaloneMmIplPei.c
@@ -625,6 +625,24 @@ MmIplBuildCommBufferHob (
 }
 
 /**
+  Builds MP information HOB using MP services.
+  Should only be used in the absence of CpuMpPei.
+
+**/
+VOID
+MmIplBuildMpInformationHob (
+  IN UINT8      *HobBuffer,
+  IN OUT UINTN  *HobBufferSize
+  )
+{
+  //
+  // DEPEX guarantees that the HOB was already produced.
+  // Therefore, this function should never be called.
+  //
+  ASSERT (FALSE);
+}
+
+/**
   The Entry Point for MM IPL at PEI stage.
 
   Load MM Core into MMRAM.

--- a/StandaloneMmPkg/Drivers/StandaloneMmIplPei/StandaloneMmIplPei.c
+++ b/StandaloneMmPkg/Drivers/StandaloneMmIplPei/StandaloneMmIplPei.c
@@ -7,6 +7,10 @@
 **/
 
 #include "StandaloneMmIplPei.h"
+#include <Library/PeiServicesLib.h>
+#include <Library/PeiServicesTablePointerLib.h>
+#include <Ppi/MmControl.h>
+#include <Ppi/MmCoreFvLocationPpi.h>
 
 EFI_PEI_MM_COMMUNICATION_PPI   mMmCommunicationPpi  = { Communicate };
 EFI_PEI_MM_COMMUNICATION3_PPI  mMmCommunication3Ppi = { Communicate3 };
@@ -23,6 +27,27 @@ EFI_PEI_PPI_DESCRIPTOR  mPpiList[] = {
     &mMmCommunication3Ppi
   }
 };
+
+/**
+  This is the callback function on end of PEI.
+
+  This callback is used for call MmEndOfPeiHandler in standalone MM core.
+
+  @param   PeiServices       General purpose services available to every PEIM.
+  @param   NotifyDescriptor  The notification structure this PEIM registered on install.
+  @param   Ppi               Pointer to the PPI data associated with this function.
+
+  @retval  EFI_SUCCESS       Exit boot services successfully.
+  @retval  Other             Exit boot services failed.
+**/
+STATIC
+EFI_STATUS
+EFIAPI
+EndOfPeiCallback (
+  IN  EFI_PEI_SERVICES           **PeiServices,
+  IN  EFI_PEI_NOTIFY_DESCRIPTOR  *NotifyDescriptor,
+  IN  VOID                       *Ppi
+  );
 
 EFI_PEI_NOTIFY_DESCRIPTOR  mNotifyList = {
   EFI_PEI_PPI_DESCRIPTOR_NOTIFY_CALLBACK | EFI_PEI_PPI_DESCRIPTOR_TERMINATE_LIST,
@@ -366,496 +391,6 @@ LocateMmCoreFv (
 }
 
 /**
-  Create HOB list for Standalone MM core.
-
-  @param[out]  HobSize              HOB size of fundation and platform HOB list.
-  @param[in]   MmCommBuffer         Pointer of MM communication buffer.
-  @param[in]   MmFvBase             Base of MM FV which included MM core driver.
-  @param[in]   MmFvSize             Size of MM FV which included MM core driver.
-  @param[in]   MmCoreFileName       File GUID of MM core driver.
-  @param[in]   MmCoreImageAddress   Address of MM core image.
-  @param[in]   MmCoreImageSize      Size of MM core image.
-  @param[in]   MmCoreEntryPoint     Entry point of MM core driver.
-  @param[in]   Block                Pointer of MMRAM descriptor block.
-
-  @retval HobList              If fundation and platform HOBs not existed,
-                               it is pointed to PEI HOB List. If existed,
-                               it is pointed to fundation and platform HOB list.
-**/
-VOID *
-CreateMmHobList (
-  OUT UINTN                           *HobSize,
-  IN  MM_COMM_BUFFER                  *MmCommBuffer,
-  IN  EFI_PHYSICAL_ADDRESS            MmFvBase,
-  IN  UINT64                          MmFvSize,
-  IN  EFI_GUID                        *MmCoreFileName,
-  IN  PHYSICAL_ADDRESS                MmCoreImageAddress,
-  IN  UINT64                          MmCoreImageSize,
-  IN  PHYSICAL_ADDRESS                MmCoreEntryPoint,
-  IN  EFI_MMRAM_HOB_DESCRIPTOR_BLOCK  *Block
-  )
-{
-  EFI_STATUS                 Status;
-  VOID                       *HobList;
-  VOID                       *PlatformHobList;
-  UINTN                      PlatformHobSize;
-  UINTN                      BufferSize;
-  UINTN                      FoundationHobSize;
-  EFI_HOB_MEMORY_ALLOCATION  *MmProfileDataHob;
-  UINTN                      PhitHobSize;
-  VOID                       *HobEnd;
-
-  //
-  // Get platform HOBs
-  //
-  PlatformHobSize = 0;
-  Status          = CreateMmPlatformHob (NULL, &PlatformHobSize);
-  if (Status == RETURN_BUFFER_TOO_SMALL) {
-    if (PlatformHobSize == 0) {
-      DEBUG ((DEBUG_ERROR, "%a: PlatformHobSize is zero, cannot create MM HOBs\n", __func__));
-      ASSERT (PlatformHobSize != 0);
-      return NULL;
-    }
-
-    //
-    // Create platform HOBs for MM foundation to get MMIO HOB data.
-    //
-    PlatformHobList = AllocatePages (EFI_SIZE_TO_PAGES (PlatformHobSize));
-    if (PlatformHobList == NULL) {
-      DEBUG ((DEBUG_ERROR, "%a: Out of resource to create platform MM HOBs\n", __func__));
-      ASSERT (PlatformHobList != NULL);
-      return NULL;
-    }
-
-    BufferSize = PlatformHobSize;
-    Status     = CreateMmPlatformHob (PlatformHobList, &PlatformHobSize);
-    if (BufferSize != PlatformHobSize) {
-      DEBUG ((DEBUG_ERROR, "%a: CreateMmPlatformHob returned unexpected size (%d != %d)\n", __func__, BufferSize, PlatformHobSize));
-      FreePages (PlatformHobList, EFI_SIZE_TO_PAGES (PlatformHobSize));
-      return NULL;
-    }
-  }
-
-  if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: CreateMmPlatformHob failed (%r)\n", __func__, Status));
-    return NULL;
-  }
-
-  //
-  // Build memory allocation HOB in PEI HOB list for MM profile data.
-  //
-  MmProfileDataHob = NULL;
-  if (FeaturePcdGet (PcdCpuSmmProfileEnable)) {
-    MmProfileDataHob = BuildMmProfileDataHobInPeiHobList ();
-  }
-
-  //
-  // Get size of foundation HOBs
-  //
-  FoundationHobSize = 0;
-  Status            = CreateMmFoundationHobList (
-                        NULL,
-                        &FoundationHobSize,
-                        PlatformHobList,
-                        PlatformHobSize,
-                        MmFvBase,
-                        MmFvSize,
-                        MmCoreFileName,
-                        MmCoreImageAddress,
-                        MmCoreImageSize,
-                        MmCoreEntryPoint,
-                        MmProfileDataHob,
-                        Block
-                        );
-  if (PlatformHobSize != 0) {
-    FreePages (PlatformHobList, EFI_SIZE_TO_PAGES (PlatformHobSize));
-  }
-
-  ASSERT (Status == RETURN_BUFFER_TOO_SMALL);
-  ASSERT (FoundationHobSize != 0);
-
-  PhitHobSize = sizeof (EFI_HOB_HANDOFF_INFO_TABLE);
-  //
-  // Final result includes: PHIT HOB, Platform HOBs, Foundation HOBs and an END node.
-  //
-  *HobSize = PhitHobSize + PlatformHobSize + FoundationHobSize + sizeof (EFI_HOB_GENERIC_HEADER);
-  HobList  = AllocatePages (EFI_SIZE_TO_PAGES (*HobSize));
-  ASSERT (HobList != NULL);
-  if (HobList == NULL) {
-    DEBUG ((DEBUG_ERROR, "Out of resource to create MM HOBs\n"));
-    CpuDeadLoop ();
-  }
-
-  HobEnd = (UINT8 *)(UINTN)HobList + PhitHobSize + PlatformHobSize + FoundationHobSize;
-  //
-  // Create MmHobHandoffInfoTable
-  //
-  CreateMmHobHandoffInfoTable (HobList, HobEnd);
-
-  //
-  // Get platform HOBs
-  //
-  Status = CreateMmPlatformHob ((UINT8 *)HobList + PhitHobSize, &PlatformHobSize);
-  ASSERT_EFI_ERROR (Status);
-
-  //
-  // Get foundation HOBs
-  //
-  Status = CreateMmFoundationHobList (
-             (UINT8 *)HobList + PhitHobSize + PlatformHobSize,
-             &FoundationHobSize,
-             HobList,
-             PlatformHobSize,
-             MmFvBase,
-             MmFvSize,
-             MmCoreFileName,
-             MmCoreImageAddress,
-             MmCoreImageSize,
-             MmCoreEntryPoint,
-             MmProfileDataHob,
-             Block
-             );
-  ASSERT_EFI_ERROR (Status);
-
-  //
-  // Create MM HOB list end.
-  //
-  MmIplCreateHob (HobEnd, EFI_HOB_TYPE_END_OF_HOB_LIST, sizeof (EFI_HOB_GENERIC_HEADER));
-
-  return HobList;
-}
-
-/**
-  Find largest unallocated MMRAM in current MMRAM descriptor block
-
-  @param[in, out] LagestMmramRangeIndex  Lagest mmram range index.
-  @param[in]      CurrentBlock           Current MMRAM descriptor block.
-
-**/
-VOID
-FindLargestMmramRange (
-  IN OUT UINTN                       *LagestMmramRangeIndex,
-  IN EFI_MMRAM_HOB_DESCRIPTOR_BLOCK  *CurrentBlock
-  )
-{
-  UINTN                 Index;
-  UINT64                MaxSize;
-  BOOLEAN               Found;
-  EFI_MMRAM_DESCRIPTOR  *MmramRanges;
-
-  MmramRanges = CurrentBlock->Descriptor;
-
-  //
-  // Find largest Mmram range.
-  //
-  Found = FALSE;
-  for (Index = 0, MaxSize = SIZE_256KB - EFI_PAGE_SIZE; Index < CurrentBlock->NumberOfMmReservedRegions; Index++) {
-    //
-    // Skip any MMRAM region that is already allocated, needs testing, or needs ECC initialization
-    //
-    if ((MmramRanges[Index].RegionState & (EFI_ALLOCATED | EFI_NEEDS_TESTING | EFI_NEEDS_ECC_INITIALIZATION)) != 0) {
-      continue;
-    }
-
-    if (MmramRanges[Index].CpuStart >= BASE_1MB) {
-      if ((MmramRanges[Index].CpuStart + MmramRanges[Index].PhysicalSize) <= BASE_4GB) {
-        if (MmramRanges[Index].PhysicalSize >= MaxSize) {
-          Found                  = TRUE;
-          *LagestMmramRangeIndex = Index;
-          MaxSize                = MmramRanges[Index].PhysicalSize;
-        }
-      }
-    }
-  }
-
-  if (Found == FALSE) {
-    DEBUG ((DEBUG_ERROR, "Not found largest unlocated MMRAM\n"));
-    ASSERT (FALSE);
-    CpuDeadLoop ();
-  }
-
-  return;
-}
-
-/**
-  Allocate available MMRAM for MM core image.
-
-  @param[in]  Pages                     Page count of MM core image.
-  @param[out] NewBlock                  Pointer of new mmram block HOB.
-
-  @return  EFI_PHYSICAL_ADDRESS         Address for MM core image to be loaded in MMRAM.
-**/
-EFI_PHYSICAL_ADDRESS
-MmIplAllocateMmramPage (
-  IN  UINTN                           Pages,
-  OUT EFI_MMRAM_HOB_DESCRIPTOR_BLOCK  **NewBlock
-  )
-{
-  UINTN                           LagestMmramRangeIndex;
-  UINT32                          FullMmramRangeCount;
-  EFI_HOB_GUID_TYPE               *MmramInfoHob;
-  EFI_MMRAM_DESCRIPTOR            *Largest;
-  EFI_MMRAM_DESCRIPTOR            *Allocated;
-  EFI_MMRAM_DESCRIPTOR            *FullMmramRanges;
-  EFI_MMRAM_HOB_DESCRIPTOR_BLOCK  *CurrentBlock;
-  EFI_MMRAM_HOB_DESCRIPTOR_BLOCK  *NewDescriptorBlock;
-
-  MmramInfoHob = GetFirstGuidHob (&gEfiSmmSmramMemoryGuid);
-  ASSERT (MmramInfoHob != NULL);
-  if (MmramInfoHob == NULL) {
-    DEBUG ((DEBUG_WARN, "SmramMemoryReserve HOB not found\n"));
-    return 0;
-  }
-
-  CurrentBlock = (EFI_MMRAM_HOB_DESCRIPTOR_BLOCK *)(GET_GUID_HOB_DATA (MmramInfoHob));
-
-  //
-  // 1. Find largest unallocated MMRAM region
-  //
-  FindLargestMmramRange (&LagestMmramRangeIndex, CurrentBlock);
-  ASSERT (LagestMmramRangeIndex < CurrentBlock->NumberOfMmReservedRegions);
-
-  //
-  // 2. Split the largest region and mark the allocated region as ALLOCATED
-  //
-  FullMmramRangeCount = CurrentBlock->NumberOfMmReservedRegions + 1;
-  NewDescriptorBlock  = (EFI_MMRAM_HOB_DESCRIPTOR_BLOCK *)BuildGuidHob (
-                                                            &gEfiSmmSmramMemoryGuid,
-                                                            sizeof (EFI_MMRAM_HOB_DESCRIPTOR_BLOCK) + ((FullMmramRangeCount - 1) * sizeof (EFI_MMRAM_DESCRIPTOR))
-                                                            );
-  ASSERT (NewDescriptorBlock != NULL);
-
-  NewDescriptorBlock->NumberOfMmReservedRegions = FullMmramRangeCount;
-  FullMmramRanges                               = NewDescriptorBlock->Descriptor;
-
-  //
-  // Get current MMRAM descriptors and fill to the full MMRAM ranges
-  //
-  CopyMem (NewDescriptorBlock->Descriptor, CurrentBlock->Descriptor, CurrentBlock->NumberOfMmReservedRegions * sizeof (EFI_MMRAM_DESCRIPTOR));
-
-  Largest = &FullMmramRanges[LagestMmramRangeIndex];
-  ASSERT ((Largest->PhysicalSize & EFI_PAGE_MASK) == 0);
-  ASSERT (Largest->PhysicalSize > EFI_PAGES_TO_SIZE (Pages));
-
-  Allocated = &NewDescriptorBlock->Descriptor[NewDescriptorBlock->NumberOfMmReservedRegions - 1];
-
-  //
-  // Allocate MMRAM
-  //
-  Largest->PhysicalSize   -= EFI_PAGES_TO_SIZE (Pages);
-  Allocated->CpuStart      = Largest->CpuStart + Largest->PhysicalSize;
-  Allocated->PhysicalStart = Largest->PhysicalStart + Largest->PhysicalSize;
-  Allocated->RegionState   = Largest->RegionState | EFI_ALLOCATED;
-  Allocated->PhysicalSize  = EFI_PAGES_TO_SIZE (Pages);
-
-  //
-  // Scrub old one
-  //
-  ZeroMem (&MmramInfoHob->Name, sizeof (MmramInfoHob->Name));
-
-  //
-  // New MMRAM descriptor block
-  //
-  *NewBlock = NewDescriptorBlock;
-
-  return Allocated->CpuStart;
-}
-
-/**
-  Load the MM Core image into MMRAM and executes the MM Core from MMRAM.
-
-  @param[in] MmCommBuffer               MM communicate buffer
-
-  @return    EFI_STATUS                 Execute MM core successfully.
-             Other                      Execute MM core failed.
-**/
-EFI_STATUS
-ExecuteMmCoreFromMmram (
-  IN  MM_COMM_BUFFER  *MmCommBuffer
-  )
-{
-  EFI_STATUS                      Status;
-  UINTN                           PageCount;
-  VOID                            *MmHobList;
-  UINTN                           MmHobSize;
-  EFI_GUID                        MmCoreFileName;
-  UINTN                           MmFvSize;
-  EFI_PHYSICAL_ADDRESS            MmFvBase;
-  PE_COFF_LOADER_IMAGE_CONTEXT    ImageContext;
-  MM_FOUNDATION_ENTRY_POINT       Entry;
-  EFI_MMRAM_HOB_DESCRIPTOR_BLOCK  *Block;
-  EFI_PEI_MM_ACCESS_PPI           *MmAccess;
-  UINTN                           Size;
-  UINTN                           Index;
-  UINTN                           MmramRangeCount;
-
-  MmFvBase = 0;
-  MmFvSize = 0;
-  //
-  // Search all Firmware Volumes for a PE/COFF image in a file of type MM_CORE_STANDALONE.
-  //
-  Status = LocateMmCoreFv (&MmFvBase, &MmFvSize, &MmCoreFileName, &ImageContext.Handle);
-  ASSERT_EFI_ERROR (Status);
-
-  //
-  // Prepare an MM access PPI for MM RAM.
-  //
-  MmAccess        = NULL;
-  MmramRangeCount = 0;
-  Status          = PeiServicesLocatePpi (
-                      &gEfiPeiMmAccessPpiGuid,
-                      0,
-                      NULL,
-                      (VOID **)&MmAccess
-                      );
-  if (!EFI_ERROR (Status)) {
-    //
-    // Open all MMRAM ranges, if MmAccess is available.
-    //
-    Size   = 0;
-    Status = MmAccess->GetCapabilities ((EFI_PEI_SERVICES **)GetPeiServicesTablePointer (), MmAccess, &Size, NULL);
-    if (Status != EFI_BUFFER_TOO_SMALL) {
-      // This is not right...
-      ASSERT (Status == EFI_BUFFER_TOO_SMALL);
-      return EFI_DEVICE_ERROR;
-    }
-
-    MmramRangeCount = Size / sizeof (EFI_MMRAM_DESCRIPTOR);
-    for (Index = 0; Index < MmramRangeCount; Index++) {
-      Status = MmAccess->Open ((EFI_PEI_SERVICES **)GetPeiServicesTablePointer (), MmAccess, Index);
-      if (EFI_ERROR (Status)) {
-        DEBUG ((DEBUG_ERROR, "MM IPL failed to open MMRAM windows index %d - %r\n", Index, Status));
-        ASSERT_EFI_ERROR (Status);
-        goto Done;
-      }
-    }
-  }
-
-  //
-  // Initialize ImageContext
-  //
-  ImageContext.ImageRead = PeCoffLoaderImageReadFromMemory;
-
-  //
-  // Get information about the image being loaded
-  //
-  Status = PeCoffLoaderGetImageInfo (&ImageContext);
-  if (EFI_ERROR (Status)) {
-    goto Done;
-  }
-
-  PageCount = (UINTN)EFI_SIZE_TO_PAGES ((UINTN)ImageContext.ImageSize + ImageContext.SectionAlignment);
-
-  //
-  // Allocate memory for the image being loaded from unallocated mmram range
-  //
-  ImageContext.ImageAddress = MmIplAllocateMmramPage (PageCount, &Block);
-  if (ImageContext.ImageAddress == 0) {
-    Status = EFI_NOT_FOUND;
-    goto Done;
-  }
-
-  //
-  // Align buffer on section boundary
-  //
-  ImageContext.ImageAddress += ImageContext.SectionAlignment - 1;
-  ImageContext.ImageAddress &= ~((EFI_PHYSICAL_ADDRESS)ImageContext.SectionAlignment - 1);
-
-  //
-  // Print debug message showing MM Core load address.
-  //
-  DEBUG ((DEBUG_INFO, "StandaloneMM IPL loading MM Core at MMRAM address %p\n", (VOID *)(UINTN)ImageContext.ImageAddress));
-
-  //
-  // Load the image to our new buffer
-  //
-  Status = PeCoffLoaderLoadImage (&ImageContext);
-  if (!EFI_ERROR (Status)) {
-    //
-    // Relocate the image in our new buffer
-    //
-    Status = PeCoffLoaderRelocateImage (&ImageContext);
-    if (!EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_INFO, "MmCoreImageBase  - 0x%016lx\n", ImageContext.ImageAddress));
-      DEBUG ((DEBUG_INFO, "MmCoreImageSize  - 0x%016lx\n", ImageContext.ImageSize));
-
-      //
-      // Flush the instruction cache so the image data are written before we execute it
-      //
-      InvalidateInstructionCacheRange ((VOID *)(UINTN)ImageContext.ImageAddress, (UINTN)ImageContext.ImageSize);
-
-      //
-      // Create HOB list for Standalone MM Core.
-      //
-      MmHobSize = 0;
-      MmHobList = CreateMmHobList (
-                    &MmHobSize,
-                    MmCommBuffer,
-                    MmFvBase,
-                    MmFvSize,
-                    &MmCoreFileName,
-                    ImageContext.ImageAddress,
-                    EFI_PAGES_TO_SIZE (PageCount),
-                    ImageContext.EntryPoint,
-                    Block
-                    );
-
-      //
-      // Print debug message showing Standalone MM Core entry point address.
-      //
-      DEBUG ((DEBUG_INFO, "StandaloneMM IPL calling Standalone MM Core at MMRAM address - 0x%016lx\n", ImageContext.EntryPoint));
-
-      //
-      // Execute image
-      //
-      Entry = (MM_FOUNDATION_ENTRY_POINT)(UINTN)ImageContext.EntryPoint;
-      Entry (MmHobList);
-      FreePages (MmHobList, EFI_SIZE_TO_PAGES (MmHobSize));
-    }
-  }
-
-Done:
-  if (MmAccess != NULL) {
-    //
-    // Close all MMRAM ranges, if MmAccess is available.
-    //
-    for (Index = 0; Index < MmramRangeCount; Index++) {
-      Status = MmAccess->Close ((EFI_PEI_SERVICES **)GetPeiServicesTablePointer (), MmAccess, Index);
-      if (EFI_ERROR (Status)) {
-        DEBUG ((DEBUG_ERROR, "MM IPL failed to close MMRAM windows index %d - %r\n", Index, Status));
-        ASSERT (FALSE);
-        return Status;
-      }
-
-      //
-      // Print debug message that the MMRAM window is now closed.
-      //
-      DEBUG ((DEBUG_INFO, "MM IPL closed MMRAM window index %d\n", Index));
-
-      //
-      // Lock the MMRAM (Note: Locking MMRAM may not be supported on all platforms)
-      //
-      Status = MmAccess->Lock ((EFI_PEI_SERVICES **)GetPeiServicesTablePointer (), MmAccess, Index);
-      if (EFI_ERROR (Status)) {
-        //
-        // Print error message that the MMRAM failed to lock...
-        //
-        DEBUG ((DEBUG_ERROR, "MM IPL could not lock MMRAM (Index %d) after executing MM Core %r\n", Index, Status));
-        ASSERT (FALSE);
-        return Status;
-      }
-
-      //
-      // Print debug message that the MMRAM window is now closed.
-      //
-      DEBUG ((DEBUG_INFO, "MM IPL locked MMRAM window index %d\n", Index));
-    }
-  }
-
-  return Status;
-}
-
-/**
   This is the callback function on end of PEI.
 
   This callback is used for call MmEndOfPeiHandler in standalone MM core.
@@ -867,6 +402,7 @@ Done:
   @retval  EFI_SUCCESS       Exit boot services successfully.
   @retval  Other             Exit boot services failed.
 **/
+STATIC
 EFI_STATUS
 EFIAPI
 EndOfPeiCallback (
@@ -883,43 +419,6 @@ EndOfPeiCallback (
   // Use Guid to initialize EFI_MM_COMMUNICATE_HEADER structure
   //
   CopyGuid (&CommunicateHeader.HeaderGuid, &gEfiMmEndOfPeiProtocol);
-  CommunicateHeader.MessageLength = 1;
-  CommunicateHeader.Data[0]       = 0;
-
-  //
-  // Generate the Software SMI and return the result
-  //
-  Size   = sizeof (CommunicateHeader);
-  Status = Communicate (NULL, &CommunicateHeader, &Size);
-  ASSERT_EFI_ERROR (Status);
-
-  return Status;
-}
-
-/**
-  Dispatch StandaloneMm drivers in MM.
-
-  StandaloneMm core will exit when MmEntryPoint was registered in CPU
-  StandaloneMm driver, and issue a software SMI by communicate mode to
-  dispatch other StandaloneMm drivers.
-
-  @retval  EFI_SUCCESS      Dispatch StandaloneMm drivers successfully.
-  @retval  Other            Dispatch StandaloneMm drivers failed.
-
-**/
-EFI_STATUS
-MmIplDispatchMmDrivers (
-  VOID
-  )
-{
-  EFI_STATUS                 Status;
-  UINTN                      Size;
-  EFI_MM_COMMUNICATE_HEADER  CommunicateHeader;
-
-  //
-  // Use Guid to initialize EFI_MM_COMMUNICATE_HEADER structure
-  //
-  CopyGuid (&CommunicateHeader.HeaderGuid, &gEventMmDispatchGuid);
   CommunicateHeader.MessageLength = 1;
   CommunicateHeader.Data[0]       = 0;
 

--- a/StandaloneMmPkg/Drivers/StandaloneMmIplPei/StandaloneMmIplPei.h
+++ b/StandaloneMmPkg/Drivers/StandaloneMmIplPei/StandaloneMmIplPei.h
@@ -17,6 +17,7 @@
 #include <Library/MemoryAllocationLib.h>
 #include <Library/PeiServicesLib.h>
 #include <Library/MmUnblockMemoryLib.h>
+#include <Library/BaseLib.h>
 #include <Library/BaseMemoryLib.h>
 #include <Library/PeCoffLib.h>
 #include <Library/CacheMaintenanceLib.h>

--- a/StandaloneMmPkg/Drivers/StandaloneMmIplPei/StandaloneMmIplPei.h
+++ b/StandaloneMmPkg/Drivers/StandaloneMmIplPei/StandaloneMmIplPei.h
@@ -21,7 +21,6 @@
 #include <Library/PcdLib.h>
 #include <Library/PeCoffLib.h>
 #include <Library/CacheMaintenanceLib.h>
-#include <Ppi/MmAccess.h>
 #include <Ppi/MmCommunication.h>
 #include <Ppi/MmCommunication3.h>
 #include <Protocol/MmCommunication.h>
@@ -174,6 +173,26 @@ LocateMmCoreFv (
   OUT UINTN                 *MmFvSize,
   OUT EFI_GUID              *MmCoreFileName,
   OUT VOID                  **MmCoreImageAddress
+  );
+
+/**
+  Open all MMRAM ranges if platform provides an MmAccess implementation.
+  If it does, it's likely required to be able to use MMRAM.
+
+**/
+EFI_STATUS
+MmAccessOpen (
+  VOID
+  );
+
+/**
+  Close and lock all MMRAM ranges if platform provides an MmAccess implementation.
+  If it does, it's likely required for security reasons.
+
+**/
+EFI_STATUS
+MmAccessClose (
+  VOID
   );
 
 /**

--- a/StandaloneMmPkg/Drivers/StandaloneMmIplPei/StandaloneMmIplPei.h
+++ b/StandaloneMmPkg/Drivers/StandaloneMmIplPei/StandaloneMmIplPei.h
@@ -25,6 +25,7 @@
 #include <Ppi/MmCommunication3.h>
 #include <Protocol/MmCommunication.h>
 #include <Library/MmPlatformHobProducerLib.h>
+#include <Library/MmIplPlatformHookLib.h>
 
 /**
   Communicates with a registered handler.

--- a/StandaloneMmPkg/Drivers/StandaloneMmIplPei/StandaloneMmIplPei.h
+++ b/StandaloneMmPkg/Drivers/StandaloneMmIplPei/StandaloneMmIplPei.h
@@ -156,6 +156,17 @@ CreateMmHobHandoffInfoTable (
   );
 
 /**
+  Builds MP information HOB using MP services.
+  Should only be used in the absence of CpuMpPei.
+
+**/
+VOID
+MmIplBuildMpInformationHob (
+  IN UINT8      *HobBuffer,
+  IN OUT UINTN  *HobBufferSize
+  );
+
+/**
   Search all the available firmware volumes for MM Core driver.
 
   @param  MmFvBase             Base address of FV which included MM Core driver.

--- a/StandaloneMmPkg/Drivers/StandaloneMmIplPei/StandaloneMmIplPei.inf
+++ b/StandaloneMmPkg/Drivers/StandaloneMmIplPei/StandaloneMmIplPei.inf
@@ -47,6 +47,7 @@
   CacheMaintenanceLib
   PeiServicesTablePointerLib
   MmPlatformHobProducerLib
+  MmIplPlatformHookLib
 
 [Guids]
   gMmCommBufferHobGuid

--- a/StandaloneMmPkg/Drivers/StandaloneMmIplPei/StandaloneMmIplPei.inf
+++ b/StandaloneMmPkg/Drivers/StandaloneMmIplPei/StandaloneMmIplPei.inf
@@ -23,6 +23,7 @@
 #
 
 [Sources]
+  StandaloneMmIplCommon.c
   StandaloneMmIplPei.c
   StandaloneMmIplPei.h
   MmFoundationHob.c

--- a/StandaloneMmPkg/Drivers/StandaloneMmIplPei/StandaloneMmIplPei.inf
+++ b/StandaloneMmPkg/Drivers/StandaloneMmIplPei/StandaloneMmIplPei.inf
@@ -40,9 +40,11 @@
   HobLib
   MemoryAllocationLib
   MmUnblockMemoryLib
+  BaseLib
   BaseMemoryLib
   PeCoffLib
   CacheMaintenanceLib
+  PeiServicesTablePointerLib
   MmPlatformHobProducerLib
 
 [Guids]
@@ -58,6 +60,7 @@
   gMmUnblockRegionHobGuid
   gMmStatusCodeUseSerialHobGuid
   gEfiMmCommunicateHeaderV3Guid
+  gEfiHobMemoryAllocModuleGuid
 
 [Ppis]
   gEfiPeiMmControlPpiGuid

--- a/StandaloneMmPkg/Include/Library/MmIplPlatformHookLib.h
+++ b/StandaloneMmPkg/Include/Library/MmIplPlatformHookLib.h
@@ -1,0 +1,43 @@
+/** @file
+  This library allows platforms to customize MM loading and calling.
+
+  Copyright (c) 2025, 9elements GmbH. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef _MM_IPL_PLATFORM_HOOK_LIB_H_
+#define _MM_IPL_PLATFORM_HOOK_LIB_H_
+
+#include <PiPei.h>
+#include <Library/PeCoffLib.h>
+
+/**
+  Performs platform specific tasks to alter how MM is loaded.
+
+  @retval EFI_SUCCESS       The platform hook completes successfully.
+  @retval Other values      The platform hook cannot complete due to some error.
+
+**/
+EFI_STATUS
+EFIAPI
+PlatformHookBeforeMmLoad (
+  IN PE_COFF_LOADER_IMAGE_CONTEXT  *ImageContext
+  );
+
+/**
+  Allows platforms to override how MM is called, rather than calling the entrypoint.
+
+  @retval EFI_SUCCESS       The platform hook completes successfully.
+  @retval Other values      The platform hook cannot complete due to some error.
+
+**/
+EFI_STATUS
+EFIAPI
+PlatformHookCallMmCore (
+  IN     PE_COFF_LOADER_IMAGE_CONTEXT  *ImageContext,
+  IN     VOID                          *Context,
+  IN OUT EFI_STATUS                    *PiMmCoreStatus
+  );
+
+#endif

--- a/StandaloneMmPkg/Library/MmIplPlatformHookLibNull/MmIplPlatformHookLibNull.c
+++ b/StandaloneMmPkg/Library/MmIplPlatformHookLibNull/MmIplPlatformHookLibNull.c
@@ -1,0 +1,45 @@
+/** @file
+  This library allows platforms to customize MM loading and calling.
+
+  Copyright (c) 2025, 9elements GmbH. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <PiPei.h>
+#include <Library/MmIplPlatformHookLib.h>
+#include <Library/PeCoffLib.h>
+
+/**
+  Performs platform specific tasks to alter how MM is loaded.
+
+  @retval EFI_SUCCESS       The platform hook completes successfully.
+  @retval Other values      The platform hook cannot complete due to some error.
+
+**/
+EFI_STATUS
+EFIAPI
+PlatformHookBeforeMmLoad (
+  IN PE_COFF_LOADER_IMAGE_CONTEXT  *ImageContext
+  )
+{
+  return EFI_UNSUPPORTED;
+}
+
+/**
+  Allows platforms to override how MM is called, rather than calling the entrypoint.
+
+  @retval EFI_SUCCESS       The platform hook completes successfully.
+  @retval Other values      The platform hook cannot complete due to some error.
+
+**/
+EFI_STATUS
+EFIAPI
+PlatformHookCallMmCore (
+  IN     PE_COFF_LOADER_IMAGE_CONTEXT  *ImageContext,
+  IN     VOID                          *Context,
+  IN OUT EFI_STATUS                    *PiMmCoreStatus
+  )
+{
+  return EFI_UNSUPPORTED;
+}

--- a/StandaloneMmPkg/Library/MmIplPlatformHookLibNull/MmIplPlatformHookLibNull.inf
+++ b/StandaloneMmPkg/Library/MmIplPlatformHookLibNull/MmIplPlatformHookLibNull.inf
@@ -1,0 +1,23 @@
+## @file
+#  NULL instance of MmIplPlatformHookLib
+#
+#  Copyright (c) 2025, 9elements GmbH.<BR>
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x0001001A
+  BASE_NAME                      = MmIplPlatformHookLibNull
+  FILE_GUID                      = 7E486268-BDFE-486F-A843-50BB1BA7C21F
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  PI_SPECIFICATION_VERSION       = 0x00010032
+  LIBRARY_CLASS                  = MmIplPlatformHookLib
+
+[Sources]
+  MmIplPlatformHookLibNull.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  StandaloneMmPkg/StandaloneMmPkg.dec

--- a/StandaloneMmPkg/StandaloneMmPkg.dec
+++ b/StandaloneMmPkg/StandaloneMmPkg.dec
@@ -19,6 +19,8 @@
   Include
 
 [LibraryClasses]
+  ##  @libraryclass  Provide platform specific hooks for MM IPL.
+  MmIplPlatformHookLib|Include/Library/MmIplPlatformHookLib.h
 
   ##  @libraryclass  Defines a set of helper methods.
   FvLib|Include/Library/FvLib.h

--- a/StandaloneMmPkg/StandaloneMmPkg.dsc
+++ b/StandaloneMmPkg/StandaloneMmPkg.dsc
@@ -101,6 +101,7 @@
   UefiDriverEntryPoint|MdePkg/Library/UefiDriverEntryPoint/UefiDriverEntryPoint.inf
   MemoryAllocationLib|MdePkg/Library/UefiMemoryAllocationLib/UefiMemoryAllocationLib.inf
   UefiBootServicesTableLib|MdePkg/Library/UefiBootServicesTableLib/UefiBootServicesTableLib.inf
+  DxeServicesLib|MdePkg/Library/DxeServicesLib/DxeServicesLib.inf
   HobLib|MdePkg/Library/DxeHobLib/DxeHobLib.inf
   UefiLib|MdePkg/Library/UefiLib/UefiLib.inf
   UefiRuntimeServicesTableLib|MdePkg/Library/UefiRuntimeServicesTableLib/UefiRuntimeServicesTableLib.inf
@@ -157,6 +158,7 @@
 
 [Components.X64]
   StandaloneMmPkg/Drivers/StandaloneMmIplPei/StandaloneMmIplPei.inf
+  StandaloneMmPkg/Drivers/StandaloneMmIplPei/StandaloneMmIplDxe.inf
 
 ###################################################################################################
 #

--- a/StandaloneMmPkg/StandaloneMmPkg.dsc
+++ b/StandaloneMmPkg/StandaloneMmPkg.dsc
@@ -60,6 +60,7 @@
   VariableMmDependency|StandaloneMmPkg/Library/VariableMmDependency/VariableMmDependency.inf
   HobPrintLib|MdeModulePkg/Library/HobPrintLib/HobPrintLib.inf
   MmPlatformHobProducerLib|StandaloneMmPkg/Library/MmPlatformHobProducerLibNull/MmPlatformHobProducerLibNull.inf
+  MmIplPlatformHookLib|StandaloneMmPkg/Library/MmIplPlatformHookLibNull/MmIplPlatformHookLibNull.inf
   ImagePropertiesRecordLib|MdeModulePkg/Library/ImagePropertiesRecordLib/ImagePropertiesRecordLib.inf
   PeCoffGetEntryPointLib|MdePkg/Library/BasePeCoffGetEntryPointLib/BasePeCoffGetEntryPointLib.inf
 
@@ -149,6 +150,7 @@
   StandaloneMmPkg/Library/VariableMmDependency/VariableMmDependency.inf
   StandaloneMmPkg/Library/SmmLockBoxMmDependency/SmmLockBoxMmDependency.inf
   StandaloneMmPkg/Library/MmPlatformHobProducerLibNull/MmPlatformHobProducerLibNull.inf
+  StandaloneMmPkg/Library/MmIplPlatformHookLibNull/MmIplPlatformHookLibNull.inf
   StandaloneMmPkg/Drivers/MmCommunicationDxe/MmCommunicationDxe.inf
   StandaloneMmPkg/Drivers/MmCommunicationNotifyDxe/MmCommunicationNotifyDxe.inf
   StandaloneMmPkg/Library/StandaloneMmExtractGuidedSectionLib/StandaloneMmExtractGuidedSectionLib.inf


### PR DESCRIPTION
# Description

coreboot's UefiPayload is preparing to use the standalone MM environment for supporting payload features that run in an SMM/MM environment, such as authenticated variables. This requires some of the following changes, some of which enhance common code too:

UefiPayload skips the PEI phase, so factor out the PEI-specific logic into a PEI-specific files, and implement a DXE variant of the MM IPL. An MM using this IPL has the same TCB as SMM, so the new IPL is presumed okay, but platforms should consider which IPL they need because this grows their TCB. As a side-effect, this makes integrating an MM environment into a platform with a 32-bit PEI easier: they can simply defer loading MM until DXE. If platforms with 32-bit PEIs should actually be officially supported, however, it would be better to have a module to do a mode switch instead, or implement this in the MM core entrypoint library.

coreboot's use of standalone MM (called "payload MM," and found at the patch series containing https://review.coreboot.org/c/coreboot/+/79870) is similar to Arm's usage in that a trusted environment is already initialised, and standalone MM is being allowed in to SMRAM too. Since SMRAM is already locked down, we need a platform-specific mechanism to get inside. coreboot exposes an SMI handler for this purpose, that allows one core/module to be copied in and called. As standalone MM may service other such environments, we implement a new library for the IPL that hooks the calling of the MM core, allowing platforms to provide their own way for this, and falling back to a plain function call otherwise. An example of this can be found at https://github.com/benjamindoron/edk2/commit/ece725ab15bd173ad2d48cbc480d89e93f084f08, which will be upstreamed in time.

As neither coreboot's payload MM nor Arm's usage of standalone MM use PiSmmCpuStandaloneMm, this means that even HOBs copied by common code might not actually be needed, and so, their absence might not be a problem. Therefore, drop the assertion in MmIplCopyGuidHob.

- [x] Breaking change?
  - **Breaking change**: MmIplPlatformHookLib must be defined. Platforms intending to preserve the current behaviour should use MmIplPlatformHookLibNull.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

This was tested against coreboot, with the patch-series that includes https://review.coreboot.org/c/coreboot/+/79870 applied, and a UefiPayload with the additional payload MM support. As mentioned above, there is no PR for that yet, one will be prepared in time when ready (which also depends on this going in). https://github.com/benjamindoron/coreboot and https://github.com/benjamindoron/edk2/tree/dev/uefipayload are the tested trees, with all patches applied.

## Integration Instructions

Standalone MM platforms must now define MmIplPlatformHookLib.
