### PR TITLE
ShellPkg: Fix cd .. & Tab key in External shell

### DIFF
--- a/ShellPkg/Application/Shell/ShellParametersProtocol.c
+++ b/ShellPkg/Application/Shell/ShellParametersProtocol.c
@@ -403,29 +403,26 @@ CreatePopulateInstallShellParametersProtocol (
   //
   // Populate the 3 faked file systems...
   //
+  (*NewShellParameters)->StdIn  = &FileInterfaceStdIn;
+  (*NewShellParameters)->StdOut = &FileInterfaceStdOut;
+  (*NewShellParameters)->StdErr = &FileInterfaceStdErr;
   if (*RootShellInstance) {
-    (*NewShellParameters)->StdIn  = &FileInterfaceStdIn;
-    (*NewShellParameters)->StdOut = &FileInterfaceStdOut;
-    (*NewShellParameters)->StdErr = &FileInterfaceStdErr;
-    Status                        = gBS->InstallProtocolInterface (
-                                           &gImageHandle,
-                                           &gEfiShellParametersProtocolGuid,
-                                           EFI_NATIVE_INTERFACE,
-                                           (VOID *)(*NewShellParameters)
-                                           );
+    Status = gBS->InstallProtocolInterface (
+                    &gImageHandle,
+                    &gEfiShellParametersProtocolGuid,
+                    EFI_NATIVE_INTERFACE,
+                    (VOID *)(*NewShellParameters)
+                    );
   } else {
     //
     // copy from the existing ones
     //
-    (*NewShellParameters)->StdIn  = ShellInfoObject.OldShellParameters->StdIn;
-    (*NewShellParameters)->StdOut = ShellInfoObject.OldShellParameters->StdOut;
-    (*NewShellParameters)->StdErr = ShellInfoObject.OldShellParameters->StdErr;
-    Status                        = gBS->ReinstallProtocolInterface (
-                                           gImageHandle,
-                                           &gEfiShellParametersProtocolGuid,
-                                           (VOID *)ShellInfoObject.OldShellParameters,
-                                           (VOID *)(*NewShellParameters)
-                                           );
+    Status = gBS->ReinstallProtocolInterface (
+                    gImageHandle,
+                    &gEfiShellParametersProtocolGuid,
+                    (VOID *)ShellInfoObject.OldShellParameters,
+                    (VOID *)(*NewShellParameters)
+                    );
   }
 
   return (Status);

--- a/ShellPkg/Application/Shell/ShellProtocol.c
+++ b/ShellPkg/Application/Shell/ShellProtocol.c
@@ -3251,7 +3251,7 @@ EfiShellSetCurDir (
       return (EFI_INVALID_PARAMETER);
     }
 
-    //    gShellCurMapping = MapListItem;
+    //  gShellCurMapping = MapListItem;
     if (DirectoryName != NULL) {
       //
       // change current dir on that file system

--- a/ShellPkg/Library/UefiShellCommandLib/UefiShellCommandLib.c
+++ b/ShellPkg/Library/UefiShellCommandLib/UefiShellCommandLib.c
@@ -1533,27 +1533,28 @@ ShellCommandCreateInitialMappingsAndPaths (
     //
     if (gShellCurMapping != NULL) {
       gShellCurMapping = NULL;
-      CurDir           = gEfiShellProtocol->GetEnv (L"cwd");
-      if (CurDir != NULL) {
-        MapName = AllocateCopyPool (StrSize (CurDir), CurDir);
-        if (MapName == NULL) {
-          return EFI_OUT_OF_RESOURCES;
-        }
+    }
 
-        SplitCurDir = StrStr (MapName, L":");
-        if (SplitCurDir == NULL) {
-          SHELL_FREE_NON_NULL (MapName);
-          return EFI_UNSUPPORTED;
-        }
-
-        *(SplitCurDir + 1) = CHAR_NULL;
-        MapListItem        = ShellCommandFindMapItem (MapName);
-        if (MapListItem != NULL) {
-          gShellCurMapping = MapListItem;
-        }
-
-        SHELL_FREE_NON_NULL (MapName);
+    CurDir = gEfiShellProtocol->GetEnv (L"cwd");
+    if (CurDir != NULL) {
+      MapName = AllocateCopyPool (StrSize (CurDir), CurDir);
+      if (MapName == NULL) {
+        return EFI_OUT_OF_RESOURCES;
       }
+
+      SplitCurDir = StrStr (MapName, L":");
+      if (SplitCurDir == NULL) {
+        SHELL_FREE_NON_NULL (MapName);
+        return EFI_UNSUPPORTED;
+      }
+
+      *(SplitCurDir + 1) = CHAR_NULL;
+      MapListItem        = ShellCommandFindMapItem (MapName);
+      if (MapListItem != NULL) {
+        gShellCurMapping = MapListItem;
+      }
+
+      SHELL_FREE_NON_NULL (MapName);
     }
   } else {
     Count = (UINTN)-1;


### PR DESCRIPTION
# Description

Resolved issue where 'cd ..' did not navigate backward due to the current directory not being updated properly in the external shell. Also fixed Tab key behavior in the external shell, which displayed files inside FS0:\EFI\Boot as current directory is not updated in FileInterfaceStdInRead.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Copy the Shell.efi into USB.
In shell boot the efi from Efi/boot.
In external shell, give cd .. command and tab key.

## Integration Instructions

NA
