### PR TITLE
ArmPkg/ArmMmuLib: Add support for LPA2

### DIFF
--- a/ArmPkg/Drivers/CpuDxe/AArch64/Mmu.c
+++ b/ArmPkg/Drivers/CpuDxe/AArch64/Mmu.c
@@ -2,7 +2,7 @@
 
 Copyright (c) 2009, Hewlett-Packard Company. All rights reserved.<BR>
 Portions copyright (c) 2010, Apple Inc. All rights reserved.<BR>
-Portions copyright (c) 2011-2021, Arm Limited. All rights reserved.<BR>
+Portions copyright (c) 2011-2025, Arm Limited. All rights reserved.<BR>
 Copyright (c) 2017, Intel Corporation. All rights reserved.<BR>
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -30,12 +30,12 @@ STATIC
 VOID
 GetRootTranslationTableInfo (
   IN  UINTN  T0SZ,
-  OUT UINTN  *RootTableLevel,
+  OUT  INTN  *RootTableLevel,
   OUT UINTN  *RootTableEntryCount
   )
 {
-  *RootTableLevel      = (T0SZ - MIN_T0SZ) / BITS_PER_LEVEL;
-  *RootTableEntryCount = TT_ENTRY_COUNT >> (T0SZ - MIN_T0SZ) % BITS_PER_LEVEL;
+  *RootTableLevel      = (INTN)(T0SZ - MIN_T0SZ) / BITS_PER_LEVEL;
+  *RootTableEntryCount = TT_ENTRY_COUNT >> (INTN)(T0SZ - MIN_T0SZ) % BITS_PER_LEVEL;
 }
 
 /**
@@ -167,7 +167,7 @@ UINT64
 GetNextEntryAttribute (
   IN     UINT64  *TableAddress,
   IN     UINTN   EntryCount,
-  IN     UINTN   TableLevel,
+  IN     INTN    TableLevel,
   IN     UINT64  BaseAddress,
   IN OUT UINT64  *PrevEntryAttribute,
   IN OUT UINT64  *StartGcdRegion
@@ -273,7 +273,7 @@ SyncCacheConfig (
   EFI_STATUS                       Status;
   UINT64                           PageAttribute;
   UINT64                           *FirstLevelTableAddress;
-  UINTN                            TableLevel;
+  INTN                             TableLevel;
   UINTN                            TableCount;
   UINTN                            NumberOfDescriptors;
   EFI_GCD_MEMORY_SPACE_DESCRIPTOR  *MemorySpaceMap;
@@ -419,7 +419,7 @@ EfiAttributeToArmAttribute (
 EFI_STATUS
 GetMemoryRegionRec (
   IN     UINT64  *TranslationTable,
-  IN     UINTN   TableLevel,
+  IN     INTN    TableLevel,
   IN     UINT64  *LastBlockEntry,
   IN OUT UINTN   *BaseAddress,
   OUT    UINTN   *RegionLength,
@@ -520,7 +520,7 @@ GetMemoryRegion (
 {
   EFI_STATUS  Status;
   UINT64      *TranslationTable;
-  UINTN       TableLevel;
+  INTN        TableLevel;
   UINTN       EntryCount;
   UINTN       T0SZ;
 

--- a/ArmPkg/Drivers/CpuDxe/AArch64/Mmu.c
+++ b/ArmPkg/Drivers/CpuDxe/AArch64/Mmu.c
@@ -18,6 +18,20 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #define MIN_T0SZ        16
 #define BITS_PER_LEVEL  9
 
+STATIC
+UINT64
+GetOutputAddress (
+  IN  UINT64   Entry,
+  IN  BOOLEAN  Lpa2Enabled
+  )
+{
+  if (Lpa2Enabled) {
+    return (Entry & TT_ADDRESS_MASK_DESCRIPTION_TABLE_LPA2) | ((Entry & TT_UPPER_ADDRESS_MASK) << (50 - 8));
+  } else {
+    return Entry & TT_ADDRESS_MASK_DESCRIPTION_TABLE;
+  }
+}
+
 /**
   Parses T0SZ to determine the level and number of entries at the root
   of the translation table.
@@ -126,8 +140,9 @@ RegionAttributeToGcdAttribute (
 STATIC
 UINT64
 GetFirstPageAttribute (
-  IN UINT64  *FirstLevelTableAddress,
-  IN UINTN   TableLevel
+  IN UINT64   *FirstLevelTableAddress,
+  IN UINTN    TableLevel,
+  IN BOOLEAN  Lpa2Enabled
   )
 {
   UINT64  FirstEntry;
@@ -139,7 +154,7 @@ GetFirstPageAttribute (
     // Only valid for Levels 0, 1 and 2
 
     // Get the attribute of the subsequent table
-    return GetFirstPageAttribute ((UINT64 *)(FirstEntry & TT_ADDRESS_MASK_DESCRIPTION_TABLE), TableLevel + 1);
+    return GetFirstPageAttribute ((UINT64 *)GetOutputAddress (FirstEntry, Lpa2Enabled), TableLevel + 1, Lpa2Enabled);
   } else if (((FirstEntry & TT_TYPE_MASK) == TT_TYPE_BLOCK_ENTRY) ||
              ((TableLevel == 3) && ((FirstEntry & TT_TYPE_MASK) == TT_TYPE_BLOCK_ENTRY_LEVEL3)))
   {
@@ -226,7 +241,7 @@ GetNextEntryAttribute (
 
       // Increase the level number and scan the sub-level table
       GetNextEntryAttribute (
-        (UINT64 *)(Entry & TT_ADDRESS_MASK_DESCRIPTION_TABLE),
+        (UINT64 *)GetOutputAddress (Entry, ArmGetTCR () & TCR_DS),
         TT_ENTRY_COUNT,
         TableLevel + 1,
         (BaseAddress + (Index * TT_ADDRESS_AT_LEVEL (TableLevel))),
@@ -314,7 +329,7 @@ SyncCacheConfig (
   GetRootTranslationTableInfo (T0SZ, &TableLevel, &TableCount);
 
   // First Attribute of the Page Tables
-  PageAttribute = GetFirstPageAttribute (FirstLevelTableAddress, TableLevel);
+  PageAttribute = GetFirstPageAttribute (FirstLevelTableAddress, TableLevel, ArmGetTCR () & TCR_DS);
 
   // We scan from the start of the memory map (ie: at the address 0x0)
   BaseAddressGcdRegion = 0x0;
@@ -443,7 +458,7 @@ GetMemoryRegionRec (
   EntryType  = *BlockEntry & TT_TYPE_MASK;
 
   if ((TableLevel < 3) && (EntryType == TT_TYPE_TABLE_ENTRY)) {
-    NextTranslationTable = (UINT64 *)(*BlockEntry & TT_ADDRESS_MASK_DESCRIPTION_TABLE);
+    NextTranslationTable = (UINT64 *)GetOutputAddress (*BlockEntry, ArmGetTCR () & TCR_DS);
 
     // The entry is a page table, so we go to the next level
     Status = GetMemoryRegionRec (

--- a/ArmPkg/Library/ArmLib/AArch64/AArch64Lib.c
+++ b/ArmPkg/Library/ArmLib/AArch64/AArch64Lib.c
@@ -109,3 +109,23 @@ ArmHasEte (
   // The ID_AA64DFR0_EL1.TraceVer field identifies the presence of FEAT_ETE.
   return ((ArmReadIdAA64Dfr0 () & AARCH64_DFR0_TRACEVER) != 0);
 }
+
+/**
+  Checks whether the CPU supports 52-bit addressing with 4KiB translation
+  granule size
+
+  @retval TRUE   52-bit addressing is implemented.
+  @retval FALSE  52-bit addressing is not implemented.
+**/
+BOOLEAN
+EFIAPI
+ArmHas52BitTgran4 (
+  VOID
+  )
+{
+  UINT64  Mmfr0;
+
+  Mmfr0 = ArmReadIdAA64Mmfr0 ();
+
+  return ((Mmfr0 & AARCH64_MMFR0_TGRAN4_MASK) == AARCH64_MMFR0_TGRAN4_52BITS);
+}

--- a/MdePkg/Include/AArch64/AArch64.h
+++ b/MdePkg/Include/AArch64/AArch64.h
@@ -1,7 +1,7 @@
 /** @file
 
   Copyright (c) 2008 - 2009, Apple Inc. All rights reserved.<BR>
-  Copyright (c) 2011 - 2021, Arm Limited. All rights reserved.<BR>
+  Copyright (c) 2011 - 2025, Arm Limited. All rights reserved.<BR>
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -26,7 +26,12 @@
 #define AARCH64_CPTR_RES1     0x33ff
 #define AARCH64_CPTR_DEFAULT  AARCH64_CPTR_RES1
 
-// ID_AA64MMFR1 - AArch64 Memory Model Feature Register 0 definitions
+// ID_AA64MMFR0 - AArch64 Memory Model Feature Register 0 definitions
+#define AARCH64_MMFR0_TGRAN4_52BITS  (0x1UL << 28)
+#define AARCH64_MMFR0_TGRAN4_FIELD   (28)
+#define AARCH64_MMFR0_TGRAN4_MASK    (0xFUL << AARCH64_MMFR0_TGRAN4_FIELD)
+
+// ID_AA64MMFR1 - AArch64 Memory Model Feature Register 1 definitions
 #define AARCH64_MMFR1_VH  (0xF << 8)
 
 // ID_AA64PFR0 - AArch64 Processor Feature Register 0 definitions

--- a/MdePkg/Include/AArch64/AArch64Mmu.h
+++ b/MdePkg/Include/AArch64/AArch64Mmu.h
@@ -1,6 +1,6 @@
 /** @file
 *
-*  Copyright (c) 2011-2021, Arm Limited. All rights reserved.<BR>
+*  Copyright (c) 2011-2025, Arm Limited. All rights reserved.<BR>
 *
 *  SPDX-License-Identifier: BSD-2-Clause-Patent
 *
@@ -48,6 +48,9 @@
 #define TT_ADDRESS_MASK_BLOCK_ENTRY        (0xFFFFFFFFFULL << 12)
 #define TT_ADDRESS_MASK_DESCRIPTION_TABLE  (0xFFFFFFFFFULL << 12)
 
+#define TT_ADDRESS_MASK_BLOCK_ENTRY_LPA2        (0x3FFFFFFFFFULL << 12)
+#define TT_ADDRESS_MASK_DESCRIPTION_TABLE_LPA2  (0x3FFFFFFFFFULL << 12)
+
 #define TT_TYPE_MASK                0x3
 #define TT_TYPE_TABLE_ENTRY         0x3
 #define TT_TYPE_BLOCK_ENTRY         0x1
@@ -69,10 +72,14 @@
 #define TT_AF  BIT10
 #define TT_NG  BIT11
 
+// Valid for !FEAT_LPA2 (52-bit output address)
 #define TT_SH_NON_SHAREABLE    (0x0 << 8)
 #define TT_SH_OUTER_SHAREABLE  (0x2 << 8)
 #define TT_SH_INNER_SHAREABLE  (0x3 << 8)
 #define TT_SH_MASK             (0x3 << 8)
+
+// Valid for FEAT_LPA2 (52-bit output address)
+#define TT_UPPER_ADDRESS_MASK  (0x3 << 8)
 
 #define TT_PXN_MASK  BIT53
 #define TT_UXN_MASK  BIT54                              // EL1&0
@@ -101,6 +108,7 @@
 #define TCR_PS_4TB    (3UL << 16)
 #define TCR_PS_16TB   (4UL << 16)
 #define TCR_PS_256TB  (5UL << 16)
+#define TCR_PS_4PB    (6UL << 16)
 
 #define TCR_TG0_4KB  (0UL << 14)
 #define TCR_TG1_4KB  (2UL << 30)
@@ -111,12 +119,17 @@
 #define TCR_IPS_4TB    (3ULL << 32)
 #define TCR_IPS_16TB   (4ULL << 32)
 #define TCR_IPS_256TB  (5ULL << 32)
+#define TCR_IPS_4PB    (6ULL << 32)
+
+#define TCR_IPS_MASK  (7ULL << 32)
 
 #define TCR_EPD1  (1UL << 23)
 
 #define TTBR_ASID_FIELD  (48)
 #define TTBR_ASID_MASK   (0xFF << TTBR_ASID_FIELD)
 #define TTBR_BADDR_MASK  (0xFFFFFFFFFFFF )                     // The width of this field depends on the values in TxSZ. Addr occupies bottom 48bits
+
+#define TCR_DS  (1UL << 59)
 
 #define TCR_EL1_T0SZ_FIELD   (0)
 #define TCR_EL1_EPD0_FIELD   (7)
@@ -186,6 +199,7 @@
 #define TCR_PASZ_42BITS_4TB    (0x3UL)
 #define TCR_PASZ_44BITS_16TB   (0x4UL)
 #define TCR_PASZ_48BITS_256TB  (0x5UL)
+#define TCR_PASZ_52BITS_4PB    (0x6UL)
 
 // The value written to the T*SZ fields are defined as 2^(64-T*SZ). So a 39Bit
 // Virtual address range for 512GB of virtual space sets T*SZ to 25

--- a/MdePkg/Include/Library/ArmLib.h
+++ b/MdePkg/Include/Library/ArmLib.h
@@ -755,4 +755,17 @@ ArmHasEte (
   VOID
   );
 
+/**
+  Checks whether the CPU supports 52-bit addressing with 4KiB translation
+  granule size
+
+  @retval TRUE   52-bit addressing is implemented.
+  @retval FALSE  52-bit addressing is not implemented.
+**/
+BOOLEAN
+EFIAPI
+ArmHas52BitTgran4 (
+  VOID
+  );
+
 #endif // ARM_LIB_H_


### PR DESCRIPTION
# Description

Add support for LPA2 (52-bit physical addressing).

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Booted to UEFI shell on FVP Versatile Express model with and without LPA2 enabled.

## Integration Instructions

N/A