### PR TITLE
.mergify: Set max parallel checks to 1

### DIFF
--- a/.mergify/config.yml
+++ b/.mergify/config.yml
@@ -24,6 +24,9 @@
 #
 ##
 
+merge_queue:
+  max_parallel_checks: 1
+
 queue_rules:
   - name: default
     queue_conditions:


### PR DESCRIPTION
# Description

Set max parallel checks to 1 to disable speculative checks.

This has become a required setting for Mergify to work.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

## Integration Instructions
