### PR TITLE
MdePkg/BaseFdtLib: Cleanup unused Macros and unused string apis

### DIFF
--- a/MdePkg/Library/BaseFdtLib/LibFdtSupport.h
+++ b/MdePkg/Library/BaseFdtLib/LibFdtSupport.h
@@ -3,6 +3,7 @@
   libfdt library.
 
   Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -54,12 +55,6 @@ memcmp      (
   size_t
   );
 
-int
-strcmp      (
-  const char *,
-  const char *
-  );
-
 char *
 strchr     (
   const char *,
@@ -88,19 +83,15 @@ strcpy (
 //
 // Macros that directly map functions to BaseLib, BaseMemoryLib, and DebugLib functions
 //
-#define memcpy(dest, source, count)         CopyMem(dest,source, (UINTN)(count))
-#define memset(dest, ch, count)             SetMem(dest, (UINTN)(count),(UINT8)(ch))
-#define memchr(buf, ch, count)              ScanMem8(buf, (UINTN)(count),(UINT8)ch)
-#define memcmp(buf1, buf2, count)           (int)(CompareMem(buf1, buf2, (UINTN)(count)))
-#define memmove(dest, source, count)        CopyMem(dest, source, (UINTN)(count))
-#define strlen(str)                         (size_t)(AsciiStrLen(str))
-#define strnlen(str, count)                 (size_t)(AsciiStrnLenS(str, count))
-#define strncpy(strDest, strSource, count)  AsciiStrnCpyS(strDest, MAX_STRING_SIZE, strSource, (UINTN)count)
-#define strcat(strDest, strSource)          AsciiStrCatS(strDest, MAX_STRING_SIZE, strSource)
-#define strchr(str, ch)                     ScanMem8(str, AsciiStrSize (str), (UINT8)ch)
-#define strcmp(string1, string2, count)     (int)(AsciiStrCmp(string1, string2))
-#define strncmp(string1, string2, count)    (int)(AsciiStrnCmp(string1, string2, (UINTN)(count)))
-#define strrchr(str, ch)                    fdt_strrchr(str, ch)
-#define strtoul(ptr, end_ptr, base)         fdt_strtoul(ptr, end_ptr, base)
+#define memcpy(dest, source, count)   CopyMem(dest,source, (UINTN)(count))
+#define memset(dest, ch, count)       SetMem(dest, (UINTN)(count),(UINT8)(ch))
+#define memchr(buf, ch, count)        ScanMem8(buf, (UINTN)(count),(UINT8)ch)
+#define memcmp(buf1, buf2, count)     (int)(CompareMem(buf1, buf2, (UINTN)(count)))
+#define memmove(dest, source, count)  CopyMem(dest, source, (UINTN)(count))
+#define strlen(str)                   (size_t)(AsciiStrLen(str))
+#define strnlen(str, count)           (size_t)(AsciiStrnLenS(str, count))
+#define strchr(str, ch)               ScanMem8(str, AsciiStrSize (str), (UINT8)ch)
+#define strrchr(str, ch)              fdt_strrchr(str, ch)
+#define strtoul(ptr, end_ptr, base)   fdt_strtoul(ptr, end_ptr, base)
 
 #endif /* FDT_LIB_SUPPORT_H_ */


### PR DESCRIPTION
Removed legacy macros and string helper APIs that are no longer used
in the BaseFdtLib implementation. Specifically:
- Dropped strcmp macro that incorrectly expected 3 arguments but
  ignored the third parameter.
- Cleaned up other unused macros and redundant string APIs.

These changes align with the current upstream libfdt module and
reduce dead code.

# Description

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.
  
Hii @leiflindholm , @vishalo 
could you please review the PR. This PR addresses the cleanup of unused macros.

## How This Was Tested

Tested on internal platforms.

## Integration Instructions

N/A
