### PR TITLE
DynamicTablesPkg: Adds X64 support ACPI SSDT PCIE table generator

### DIFF
--- a/DynamicTablesPkg/Include/ArchCommonNameSpaceObjects.h
+++ b/DynamicTablesPkg/Include/ArchCommonNameSpaceObjects.h
@@ -200,6 +200,9 @@ typedef struct CmArchCommonPciAddressMapInfo {
    - 1: I/O Space
    - 2: 32-bit-address Memory Space
    - 3: 64-bit-address Memory Space
+   - 4: Word I/O Space
+   - 5: 32-bit-address uncache Memory Space
+   - 6: 64-bit-address uncache Memory Space
   */
   UINT8     SpaceCode;
 

--- a/DynamicTablesPkg/Include/ArchCommonNameSpaceObjects.h
+++ b/DynamicTablesPkg/Include/ArchCommonNameSpaceObjects.h
@@ -73,6 +73,7 @@ typedef enum ArchCommonObjectID {
   EArchCommonObjSpcrInfo,                       ///< 45 - Serial Terminal and Interrupt Info
   EArchCommonObjTpm2DeviceInfo,                 ///< 46 - TPM2 Device Info
   EArchCommonObjMcfgPciConfigSpaceInfo,         ///< 47 - MCFG PCI Configuration Space Info
+  EArchCommonObjPrtInfo,                        ///< 48 - Pci Interrupt Map Info
   EArchCommonObjMax
 } EARCH_COMMON_OBJECT_ID;
 
@@ -267,6 +268,19 @@ typedef struct CmArchCommonPciInterruptMapInfo {
   */
   CM_ARCH_COMMON_GENERIC_INTERRUPT    IntcInterrupt;
 } CM_ARCH_COMMON_PCI_INTERRUPT_MAP_INFO;
+
+/** A structure that describes a PCI Routing Table (PRT) Info.
+  Cf ACPI spec 6.5
+  s6.2.13 _PRT (PCI Routing Table)
+
+  ID: EArchCommonObjPrtInfo
+*/
+typedef struct CmArchCommonPrtInfo {
+  UINT32             Address;
+  UINT8              Pin;
+  CM_OBJECT_TOKEN    SourceToken;
+  UINT32             SourceIndex;
+} CM_ARCH_COMMON_PRT_INFO;
 
 /** A structure that describes the Memory Affinity Structure (Type 1) in SRAT
 

--- a/DynamicTablesPkg/Include/ArchCommonNameSpaceObjects.h
+++ b/DynamicTablesPkg/Include/ArchCommonNameSpaceObjects.h
@@ -74,6 +74,7 @@ typedef enum ArchCommonObjectID {
   EArchCommonObjTpm2DeviceInfo,                 ///< 46 - TPM2 Device Info
   EArchCommonObjMcfgPciConfigSpaceInfo,         ///< 47 - MCFG PCI Configuration Space Info
   EArchCommonObjPrtInfo,                        ///< 48 - Pci Interrupt Map Info
+  EArchCommonObjPciRootBridgeInfo,              ///< 49 - Pci root bridge Info
   EArchCommonObjMax
 } EARCH_COMMON_OBJECT_ID;
 
@@ -185,6 +186,10 @@ typedef struct CmArchCommonPciConfigSpaceInfo {
   /// Optional field: Reference Token for interrupt mapping.
   /// Token identifying a CM_ARCH_COMMON_OBJ_REF structure.
   CM_OBJECT_TOKEN    InterruptMapToken;
+
+  /// Optional field: Reference Token for PCI root bridge PRT information.
+  /// Token identifying a CM_ARCH_COMMON_OBJ_REF structure.
+  CM_OBJECT_TOKEN    RootBridgeInfoToken;
 } CM_ARCH_COMMON_PCI_CONFIG_SPACE_INFO;
 
 /** A structure that describes a PCI Address Map.
@@ -281,6 +286,14 @@ typedef struct CmArchCommonPrtInfo {
   CM_OBJECT_TOKEN    SourceToken;
   UINT32             SourceIndex;
 } CM_ARCH_COMMON_PRT_INFO;
+
+/** A structure that describes a Root bridge PCI Routing Table (PRT) Info.
+  Cf ACPI spec 6.5
+  s6.2.13 _PRT (PCI Routing Table)
+
+  ID: EArchCommonObjPciRootBridgeInfo
+*/
+typedef CM_ARCH_COMMON_PRT_INFO CM_ARCH_COMMON_PCI_ROOT_BRIDGE_INFO;
 
 /** A structure that describes the Memory Affinity Structure (Type 1) in SRAT
 

--- a/DynamicTablesPkg/Library/Acpi/Common/AcpiSsdtPcieLib/SsdtPcieGenerator.c
+++ b/DynamicTablesPkg/Library/Acpi/Common/AcpiSsdtPcieLib/SsdtPcieGenerator.c
@@ -2,6 +2,7 @@
   SSDT Pcie Table Generator.
 
   Copyright (c) 2021 - 2022, Arm Limited. All rights reserved.<BR>
+  Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -608,7 +609,77 @@ GeneratePciCrs (
                    NULL
                    );
         break;
+      case PCI_SS_IO_WORD:
+        ASSERT ((AddrMapInfo->PciAddress & ~MAX_UINT16) == 0);
+        ASSERT (((AddrMapInfo->PciAddress + AddrMapInfo->AddressSize - 1) & ~MAX_UINT16) == 0);
+        ASSERT (((Translation ? AddrMapInfo->CpuAddress - AddrMapInfo->PciAddress : 0) & ~MAX_UINT16) == 0);
+        ASSERT ((AddrMapInfo->AddressSize & ~MAX_UINT16) == 0);
+        Status = AmlCodeGenRdWordIo (
+                   FALSE,
+                   TRUE,
+                   TRUE,
+                   IsPosDecode,
+                   3,
+                   0,
+                   AddrMapInfo->PciAddress,
+                   AddrMapInfo->PciAddress + AddrMapInfo->AddressSize - 1,
+                   Translation ? AddrMapInfo->CpuAddress - AddrMapInfo->PciAddress : 0,
+                   AddrMapInfo->AddressSize,
+                   0,
+                   NULL,
+                   TRUE,
+                   FALSE,
+                   CrsNode,
+                   NULL
+                   );
+        break;
+      case PCI_SS_M32_UC:
+        ASSERT ((AddrMapInfo->PciAddress & ~MAX_UINT32) == 0);
+        ASSERT (((AddrMapInfo->PciAddress + AddrMapInfo->AddressSize - 1) & ~MAX_UINT32) == 0);
+        ASSERT (((Translation ? AddrMapInfo->CpuAddress - AddrMapInfo->PciAddress : 0) & ~MAX_UINT32) == 0);
+        ASSERT ((AddrMapInfo->AddressSize & ~MAX_UINT32) == 0);
 
+        Status = AmlCodeGenRdDWordMemory (
+                   FALSE,
+                   IsPosDecode,
+                   TRUE,
+                   TRUE,
+                   AmlMemoryNonCacheable,
+                   TRUE,
+                   0,
+                   (UINT32)(AddrMapInfo->PciAddress),
+                   (UINT32)(AddrMapInfo->PciAddress + AddrMapInfo->AddressSize - 1),
+                   (UINT32)(Translation ? AddrMapInfo->CpuAddress - AddrMapInfo->PciAddress : 0),
+                   (UINT32)(AddrMapInfo->AddressSize),
+                   0,
+                   NULL,
+                   AmlAddressRangeMemory,
+                   TRUE,
+                   CrsNode,
+                   NULL
+                   );
+        break;
+      case PCI_SS_M64_UC:
+        Status = AmlCodeGenRdQWordMemory (
+                   FALSE,
+                   IsPosDecode,
+                   TRUE,
+                   TRUE,
+                   AmlMemoryNonCacheable,
+                   TRUE,
+                   0,
+                   AddrMapInfo->PciAddress,
+                   AddrMapInfo->PciAddress + AddrMapInfo->AddressSize - 1,
+                   Translation ? AddrMapInfo->CpuAddress - AddrMapInfo->PciAddress : 0,
+                   AddrMapInfo->AddressSize,
+                   0,
+                   NULL,
+                   AmlAddressRangeMemory,
+                   TRUE,
+                   CrsNode,
+                   NULL
+                   );
+        break;
       default:
         Status = EFI_INVALID_PARAMETER;
     } // switch

--- a/DynamicTablesPkg/Library/Acpi/Common/AcpiSsdtPcieLib/SsdtPcieGenerator.h
+++ b/DynamicTablesPkg/Library/Acpi/Common/AcpiSsdtPcieLib/SsdtPcieGenerator.h
@@ -2,6 +2,8 @@
   SSDT Pcie Table Generator.
 
   Copyright (c) 2021, Arm Limited. All rights reserved.<BR>
+  Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
   @par Reference(s):
@@ -20,10 +22,13 @@
 
   This can also be denoted as space code, address space or ss.
 */
-#define PCI_SS_CONFIG  0
-#define PCI_SS_IO      1
-#define PCI_SS_M32     2
-#define PCI_SS_M64     3
+#define PCI_SS_CONFIG   0
+#define PCI_SS_IO       1
+#define PCI_SS_M32      2
+#define PCI_SS_M64      3
+#define PCI_SS_IO_WORD  4
+#define PCI_SS_M32_UC   5
+#define PCI_SS_M64_UC   6
 
 /** Maximum Pci root complexes supported by this generator.
 

--- a/DynamicTablesPkg/Library/Common/TableHelperLib/ConfigurationManagerObjectParser.c
+++ b/DynamicTablesPkg/Library/Common/TableHelperLib/ConfigurationManagerObjectParser.c
@@ -882,6 +882,15 @@ STATIC CONST CM_OBJ_PARSER  CmArchCommonObjSpcrInfoParser[] = {
   { "TerminalType",  1, "0x%x", NULL }
 };
 
+/** A parser for EArchCommonObjPrtInfo.
+*/
+STATIC CONST CM_OBJ_PARSER  CmArchCommonObjPrtInfoParser[] = {
+  { "Address",     4,                        "0x%x", NULL },
+  { "Pin",         1,                        "0x%x", NULL },
+  { "SourceToken", sizeof (CM_OBJECT_TOKEN), "0x%p", NULL },
+  { "SourceIndex", 4,                        "0x%x", NULL }
+};
+
 /** A parser for Arch Common namespace objects.
 */
 STATIC CONST CM_OBJ_PARSER_ARRAY  ArchCommonNamespaceObjectParser[] = {
@@ -932,6 +941,7 @@ STATIC CONST CM_OBJ_PARSER_ARRAY  ArchCommonNamespaceObjectParser[] = {
   CM_PARSER_ADD_OBJECT (EArchCommonObjMemoryCacheInfo,              CmArchCommonMemoryCacheInfo),
   CM_PARSER_ADD_OBJECT (EArchCommonObjSpcrInfo,                     CmArchCommonObjSpcrInfoParser),
   CM_PARSER_ADD_OBJECT (EArchCommonObjMcfgPciConfigSpaceInfo,       CmArchCommonPciConfigSpaceInfoParser),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjPrtInfo,                      CmArchCommonObjPrtInfoParser),
   CM_PARSER_ADD_OBJECT_RESERVED (EArchCommonObjMax)
 };
 

--- a/DynamicTablesPkg/Library/Common/TableHelperLib/ConfigurationManagerObjectParser.c
+++ b/DynamicTablesPkg/Library/Common/TableHelperLib/ConfigurationManagerObjectParser.c
@@ -942,6 +942,7 @@ STATIC CONST CM_OBJ_PARSER_ARRAY  ArchCommonNamespaceObjectParser[] = {
   CM_PARSER_ADD_OBJECT (EArchCommonObjSpcrInfo,                     CmArchCommonObjSpcrInfoParser),
   CM_PARSER_ADD_OBJECT (EArchCommonObjMcfgPciConfigSpaceInfo,       CmArchCommonPciConfigSpaceInfoParser),
   CM_PARSER_ADD_OBJECT (EArchCommonObjPrtInfo,                      CmArchCommonObjPrtInfoParser),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjPciRootBridgeInfo,            CmArchCommonObjPrtInfoParser),
   CM_PARSER_ADD_OBJECT_RESERVED (EArchCommonObjMax)
 };
 


### PR DESCRIPTION
# Description

    Since X64 platforms do not use FDT,
    the PCIE SSDT has been enhanced to include root bridge _PRT information,
    using a token to provide details about the PCI routing table for the root bridge.

    This update includes:
    - Introduces the _PRT configuration object for PCI routing tables,
           in accordance with ACPI specification 6.5, section 6.2.13.
    - Updates _CRS to support
         WordIo and uncached PCIe resources in _CRS.
    - Addition of the EArchCommonObjPciRootBridgeInfo configuration object to provide PCI routing data.
    - Parser enhancements to support EArchCommonObjPciRootBridgeInfo.
    - Adds RootBridgeInfoToken to CM_ARCH_COMMON_PCI_CONFIG_SPACE_INFO structure,
       which holds the token for the root bridge information.
    - Updates to the PCIE SSDT generator to detect and utilize the root bridge information token.
      When the token is present, the generator reads the configuration and creates the _PRT accordingly.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Tested on AMD platform by generating ACPI tables.

## Integration Instructions

N/A
