### PR TITLE
.pytool: Use Tianocore Uncrustify release

### DIFF
--- a/.pytool/Plugin/UncrustifyCheck/uncrustify_ext_dep.yaml
+++ b/.pytool/Plugin/UncrustifyCheck/uncrustify_ext_dep.yaml
@@ -7,10 +7,13 @@
 {
   "id": "uncrustify-ci-1",
   "scope": "cibuild",
-  "type": "nuget",
-  "name": "mu-uncrustify-release",
-  "source": "https://pkgs.dev.azure.com/projectmu/Uncrustify/_packaging/mu_uncrustify/nuget/v3/index.json",
-  "version": "73.0.8",
+  "type": "web",
+  "name": "tianocore-uncrustify-release",
+  "source": "https://github.com/tianocore/uncrustify/releases/download/73.0.10/uncrustify-release.zip",
+  "version": "73.0.10",
+  "sha256": "65d6f0f2e2bba9f25edaa1a9a5e5b9af32ba8d5c2792e467b84abfdf39b5e8ee",
+  "compression_type": "zip",
+  "internal_path": "/",
   "flags": ["set_shell_var", "host_specific"],
   "var_name": "UNCRUSTIFY_CI_PATH"
 }


### PR DESCRIPTION
# Description

Tianocore uses a customized version of Uncrustify that previously resided in https://dev.azure.com/projectmu/_git/Uncrustify.

An official fork in the Tianocore organization has been created here https://github.com/tianocore/uncrustify.

The Tianocore fork publishes its releases to a GitHub release in the repo. This is the first release from that repo:

https://github.com/tianocore/uncrustify/releases/tag/73.0.10

An advantage of this process is that the binaries for the release are simply attached on the release page in a zip file.

For example, this is the zip file for that release: https://github.com/tianocore/uncrustify/releases/download/73.0.10/uncrustify-release.zip

This eases consumption of the release, especially on non-Windows hosts versus the previous distribution method with NuGet.

This change updates the external dependency in edk2 to consume the binary from this zip file in the release of the Tianocore repo instead of the previous NuGet feed in the Azure repo.

Note: The goal is to eliminate the Tianocore fork of Uncrustify, the details for that are outside the scope of this commit.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

- Stuart update (pull the release locally)
- Run uncrustify against repo files

## Integration Instructions

- N/A