### PR TITLE
[edk2-stable202508] SecurityPkg/FvReportPei: Fix regression from CodeQL fixes

### DIFF
--- a/SecurityPkg/FvReportPei/FvReportPei.c
+++ b/SecurityPkg/FvReportPei/FvReportPei.c
@@ -397,7 +397,8 @@ CheckStoredHashFv (
                  BootMode
                  );
     } else {
-      Status = EFI_NOT_FOUND;
+      DEBUG ((DEBUG_INFO, "Bypass FV hash verification\r\n"));
+      Status = EFI_SUCCESS;
     }
 
     if (!EFI_ERROR (Status)) {


### PR DESCRIPTION
# Description

PR https://github.com/tianocore/edk2/pull/11307 fixed a number of CodeQL related issues in the SecurityPkg. An update to FvReportPei introduced a behavior change that causes some FVs to fail verification.

If HashInfo is NULL, then the FV verification should be bypassed and the return status should be EFI_SUCCESS. Change the return status from EFI_NOT_FOUND to EFI_SUCCESS to match the behavior before the CodeQL related changes.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

FV verification in PEI on some platforms was failing.  With this change the FV verification in PEI worked as expected.

## Integration Instructions

N/A
