### PR TITLE
SecurityPkg: Revert Codeql to FvReportPei

### DIFF
--- a/SecurityPkg/FvReportPei/FvReportPei.c
+++ b/SecurityPkg/FvReportPei/FvReportPei.c
@@ -108,7 +108,7 @@ InstallPreHashFvPpi (
   @param[in]  FvNumber            Length of the FV.
   @param[in]  BootMode            Length of the FV.
 
-  @retval EFI_SUCCESS           The given FV is integrate.
+  @retval EFI_SUCCESS           The given FV is integrated, hash verification is bypassed, or hash matches.
   @retval EFI_VOLUME_CORRUPTED  The given FV is corrupted (hash mismatch).
   @retval EFI_UNSUPPORTED       The hash algorithm is not supported.
 **/
@@ -389,16 +389,12 @@ CheckStoredHashFv (
                       );
   if (!EFI_ERROR (Status) && (StoredHashFvPpi != NULL) && (StoredHashFvPpi->FvNumber > 0)) {
     HashInfo = GetHashInfo (StoredHashFvPpi, BootMode);
-    if (HashInfo != NULL) {
-      Status = VerifyHashedFv (
-                 HashInfo,
-                 StoredHashFvPpi->FvInfo,
-                 StoredHashFvPpi->FvNumber,
-                 BootMode
-                 );
-    } else {
-      Status = EFI_NOT_FOUND;
-    }
+    Status = VerifyHashedFv (
+                HashInfo,
+                StoredHashFvPpi->FvInfo,
+                StoredHashFvPpi->FvNumber,
+                BootMode
+                );
 
     if (!EFI_ERROR (Status)) {
       DEBUG ((DEBUG_INFO, "OBB verification passed (%r)\r\n", Status));


### PR DESCRIPTION


# Description

HashInfo may be NULL and should return EFI_SUCCESS.

This change reverts the change for CodeQL so that
EFI_SUCCESS may be returned.

See https://github.com/tianocore/edk2/pull/11307

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

N/A

## Integration Instructions

N/A