### PR TITLE
Revert "SecurityPkg: CodeQL Fixes."

### DIFF
--- a/SecurityPkg/FvReportPei/FvReportPei.c
+++ b/SecurityPkg/FvReportPei/FvReportPei.c
@@ -71,10 +71,7 @@ InstallPreHashFvPpi (
             + HashSize;
 
   PreHashedFvPpi = AllocatePool (PpiSize);
-  if (PreHashedFvPpi == NULL) {
-    ASSERT (PreHashedFvPpi != NULL);
-    return;
-  }
+  ASSERT (PreHashedFvPpi != NULL);
 
   PreHashedFvPpi->FvBase   = (UINT32)(UINTN)FvBuffer;
   PreHashedFvPpi->FvLength = (UINT32)FvLength;
@@ -86,11 +83,7 @@ InstallPreHashFvPpi (
   CopyMem (HASH_VALUE_PTR (HashInfo), HashValue, HashSize);
 
   FvInfoPpiDescriptor = AllocatePool (sizeof (EFI_PEI_PPI_DESCRIPTOR));
-  if (FvInfoPpiDescriptor == NULL) {
-    ASSERT (FvInfoPpiDescriptor != NULL);
-    FreePool (PreHashedFvPpi);
-    return;
-  }
+  ASSERT (FvInfoPpiDescriptor != NULL);
 
   FvInfoPpiDescriptor->Guid  = &gEdkiiPeiFirmwareVolumeInfoPrehashedFvPpiGuid;
   FvInfoPpiDescriptor->Flags = EFI_PEI_PPI_DESCRIPTOR_PPI | EFI_PEI_PPI_DESCRIPTOR_TERMINATE_LIST;
@@ -209,11 +202,8 @@ VerifyHashedFv (
     // Copy FV to permanent memory to avoid potential TOC/TOU.
     //
     FvBuffer = AllocatePages (EFI_SIZE_TO_PAGES ((UINTN)FvInfo[FvIndex].Length));
-    if (FvBuffer == NULL) {
-      ASSERT (FvBuffer != NULL);
-      Status = EFI_OUT_OF_RESOURCES;
-      goto Done;
-    }
+
+    ASSERT (FvBuffer != NULL);
 
     if (FvShadowPpi != NULL) {
       Status = FvShadowPpi->FirmwareVolumeShadow (
@@ -389,17 +379,12 @@ CheckStoredHashFv (
                       );
   if (!EFI_ERROR (Status) && (StoredHashFvPpi != NULL) && (StoredHashFvPpi->FvNumber > 0)) {
     HashInfo = GetHashInfo (StoredHashFvPpi, BootMode);
-    if (HashInfo != NULL) {
-      Status = VerifyHashedFv (
+    Status   = VerifyHashedFv (
                  HashInfo,
                  StoredHashFvPpi->FvInfo,
                  StoredHashFvPpi->FvNumber,
                  BootMode
                  );
-    } else {
-      Status = EFI_NOT_FOUND;
-    }
-
     if (!EFI_ERROR (Status)) {
       DEBUG ((DEBUG_INFO, "OBB verification passed (%r)\r\n", Status));
 

--- a/SecurityPkg/HddPassword/HddPasswordDxe.c
+++ b/SecurityPkg/HddPassword/HddPasswordDxe.c
@@ -149,10 +149,7 @@ BuildHddPasswordDeviceInfo (
     S3InitDevicesExist = FALSE;
   } else if (Status == EFI_BUFFER_TOO_SMALL) {
     S3InitDevices = AllocatePool (S3InitDevicesLength);
-    if (S3InitDevices == NULL) {
-      ASSERT (S3InitDevices != NULL);
-      return;
-    }
+    ASSERT (S3InitDevices != NULL);
 
     Status = RestoreLockBox (
                &gS3StorageDeviceInitListGuid,
@@ -187,10 +184,7 @@ BuildHddPasswordDeviceInfo (
         FreePool (S3InitDevicesBak);
       }
 
-      if (S3InitDevices == NULL) {
-        ASSERT (S3InitDevices != NULL);
-        return;
-      }
+      ASSERT (S3InitDevices != NULL);
 
       TempDevInfo = (HDD_PASSWORD_DEVICE_INFO *)((UINTN)TempDevInfo +
                                                  sizeof (HDD_PASSWORD_DEVICE_INFO) +
@@ -2201,14 +2195,8 @@ HddPasswordFormExtractConfig (
     // followed by "&OFFSET=0&WIDTH=WWWWWWWWWWWWWWWW" followed by a Null-terminator
     //
     ConfigRequestHdr = HiiConstructConfigHdr (&mHddPasswordVendorGuid, mHddPasswordVendorStorageName, Private->DriverHandle);
-    if (ConfigRequestHdr == NULL) {
-      ASSERT (ConfigRequestHdr != NULL);
-      FreePool (IfrData);
-      return EFI_OUT_OF_RESOURCES;
-    }
-
-    Size          = (StrLen (ConfigRequestHdr) + 32 + 1) * sizeof (CHAR16);
-    ConfigRequest = AllocateZeroPool (Size);
+    Size             = (StrLen (ConfigRequestHdr) + 32 + 1) * sizeof (CHAR16);
+    ConfigRequest    = AllocateZeroPool (Size);
     ASSERT (ConfigRequest != NULL);
     AllocatedRequest = TRUE;
     UnicodeSPrint (ConfigRequest, Size, L"%s&OFFSET=0&WIDTH=%016LX", ConfigRequestHdr, (UINT64)BufferSize);
@@ -2398,11 +2386,7 @@ HddPasswordFormCallback (
           // In case goto the device configuration form, update the device form title.
           //
           ConfigFormEntry = HddPasswordGetConfigFormEntryByIndex ((UINT32)(QuestionId - KEY_HDD_DEVICE_ENTRY_BASE));
-          if (ConfigFormEntry == NULL) {
-            ASSERT (ConfigFormEntry != NULL);
-            FreePool (IfrData);
-            return EFI_NOT_FOUND;
-          }
+          ASSERT (ConfigFormEntry != NULL);
 
           DeviceFormTitleToken = (EFI_STRING_ID)STR_HDD_SECURITY_HD;
           HiiSetString (Private->HiiHandle, DeviceFormTitleToken, ConfigFormEntry->HddString, NULL);

--- a/SecurityPkg/Library/AuthVariableLib/AuthService.c
+++ b/SecurityPkg/Library/AuthVariableLib/AuthService.c
@@ -553,7 +553,7 @@ CheckSignatureListFormat (
   // Walk through the input signature list and check the data format.
   // If any signature is incorrectly formed, the whole check will fail.
   //
-  while ((SigDataSize > 0) && (SigDataSize >= (UINTN)SigList->SignatureListSize)) {
+  while ((SigDataSize > 0) && (SigDataSize >= SigList->SignatureListSize)) {
     for (Index = 0; Index < (sizeof (mSupportSigItem) / sizeof (EFI_SIGNATURE_ITEM)); Index++ ) {
       if (CompareGuid (&SigList->SignatureType, &mSupportSigItem[Index].SigType)) {
         //
@@ -1088,7 +1088,7 @@ FilterSignatureList (
   Tail = TempData;
 
   NewCertList = (EFI_SIGNATURE_LIST *)NewData;
-  while ((*NewDataSize > 0) && (*NewDataSize >= (UINTN)NewCertList->SignatureListSize)) {
+  while ((*NewDataSize > 0) && (*NewDataSize >= NewCertList->SignatureListSize)) {
     NewCert      = (EFI_SIGNATURE_DATA *)((UINT8 *)NewCertList + sizeof (EFI_SIGNATURE_LIST) + NewCertList->SignatureHeaderSize);
     NewCertCount = (NewCertList->SignatureListSize - sizeof (EFI_SIGNATURE_LIST) - NewCertList->SignatureHeaderSize) / NewCertList->SignatureSize;
 
@@ -1098,7 +1098,7 @@ FilterSignatureList (
 
       Size     = DataSize;
       CertList = (EFI_SIGNATURE_LIST *)Data;
-      while ((Size > 0) && (Size >= (UINTN)CertList->SignatureListSize)) {
+      while ((Size > 0) && (Size >= CertList->SignatureListSize)) {
         if (CompareGuid (&CertList->SignatureType, &NewCertList->SignatureType) &&
             (CertList->SignatureSize == NewCertList->SignatureSize))
         {

--- a/SecurityPkg/Library/DxeImageVerificationLib/DxeImageVerificationLib.c
+++ b/SecurityPkg/Library/DxeImageVerificationLib/DxeImageVerificationLib.c
@@ -883,7 +883,7 @@ IsCertHashFoundInDbx (
     return Status;
   }
 
-  while ((DbxSize > 0) && (SignatureListSize >= (UINTN)DbxList->SignatureListSize)) {
+  while ((DbxSize > 0) && (SignatureListSize >= DbxList->SignatureListSize)) {
     //
     // Determine Hash Algorithm of Certificate in the forbidden database.
     //
@@ -1028,7 +1028,7 @@ IsSignatureFoundInDatabase (
   // Enumerate all signature data in SigDB to check if signature exists for executable.
   //
   CertList = (EFI_SIGNATURE_LIST *)Data;
-  while ((DataSize > 0) && (DataSize >= (UINTN)CertList->SignatureListSize)) {
+  while ((DataSize > 0) && (DataSize >= CertList->SignatureListSize)) {
     CertCount = (CertList->SignatureListSize - sizeof (EFI_SIGNATURE_LIST) - CertList->SignatureHeaderSize) / CertList->SignatureSize;
     Cert      = (EFI_SIGNATURE_DATA *)((UINT8 *)CertList + sizeof (EFI_SIGNATURE_LIST) + CertList->SignatureHeaderSize);
     if ((CertList->SignatureSize == sizeof (EFI_SIGNATURE_DATA) - 1 + SignatureSize) && (CompareGuid (&CertList->SignatureType, CertType))) {
@@ -1193,7 +1193,7 @@ PassTimestampCheck (
   }
 
   CertList = (EFI_SIGNATURE_LIST *)DbtData;
-  while ((DbtDataSize > 0) && (DbtDataSize >= (UINTN)CertList->SignatureListSize)) {
+  while ((DbtDataSize > 0) && (DbtDataSize >= CertList->SignatureListSize)) {
     if (CompareGuid (&CertList->SignatureType, &gEfiCertX509Guid)) {
       Cert      = (EFI_SIGNATURE_DATA *)((UINT8 *)CertList + sizeof (EFI_SIGNATURE_LIST) + CertList->SignatureHeaderSize);
       CertCount = (CertList->SignatureListSize - sizeof (EFI_SIGNATURE_LIST) - CertList->SignatureHeaderSize) / CertList->SignatureSize;
@@ -1319,7 +1319,7 @@ IsForbiddenByDbx (
   //
   CertList     = (EFI_SIGNATURE_LIST *)Data;
   CertListSize = DataSize;
-  while ((CertListSize > 0) && (CertListSize >= (UINTN)CertList->SignatureListSize)) {
+  while ((CertListSize > 0) && (CertListSize >= CertList->SignatureListSize)) {
     if (CompareGuid (&CertList->SignatureType, &gEfiCertX509Guid)) {
       CertData  = (EFI_SIGNATURE_DATA *)((UINT8 *)CertList + sizeof (EFI_SIGNATURE_LIST) + CertList->SignatureHeaderSize);
       CertCount = (CertList->SignatureListSize - sizeof (EFI_SIGNATURE_LIST) - CertList->SignatureHeaderSize) / CertList->SignatureSize;
@@ -1524,7 +1524,7 @@ IsAllowedByDb (
   // Find X509 certificate in Signature List to verify the signature in pkcs7 signed data.
   //
   CertList = (EFI_SIGNATURE_LIST *)Data;
-  while ((DataSize > 0) && (DataSize >= (UINTN)CertList->SignatureListSize)) {
+  while ((DataSize > 0) && (DataSize >= CertList->SignatureListSize)) {
     if (CompareGuid (&CertList->SignatureType, &gEfiCertX509Guid)) {
       CertData  = (EFI_SIGNATURE_DATA *)((UINT8 *)CertList + sizeof (EFI_SIGNATURE_LIST) + CertList->SignatureHeaderSize);
       CertCount = (CertList->SignatureListSize - sizeof (EFI_SIGNATURE_LIST) - CertList->SignatureHeaderSize) / CertList->SignatureSize;
@@ -2057,9 +2057,8 @@ Failed:
   // executable information table in either case.
   //
   NameStr = ConvertDevicePathToText (File, FALSE, TRUE);
-
+  AddImageExeInfo (Action, NameStr, File, SignatureList, SignatureListSize);
   if (NameStr != NULL) {
-    AddImageExeInfo (Action, NameStr, File, SignatureList, SignatureListSize);
     DEBUG ((DEBUG_INFO, "The image doesn't pass verification: %s\n", NameStr));
     FreePool (NameStr);
   }

--- a/SecurityPkg/Library/DxeTcg2PhysicalPresenceLib/DxeTcg2PhysicalPresenceLib.c
+++ b/SecurityPkg/Library/DxeTcg2PhysicalPresenceLib/DxeTcg2PhysicalPresenceLib.c
@@ -387,10 +387,7 @@ Tcg2UserConfirm (
   NoPpiInfo   = FALSE;
   BufSize     = CONFIRM_BUFFER_SIZE;
   ConfirmText = AllocateZeroPool (BufSize);
-  if (ConfirmText == NULL) {
-    ASSERT (ConfirmText != NULL);
-    return FALSE;
-  }
+  ASSERT (ConfirmText != NULL);
 
   mTcg2PpStringPackHandle = HiiAddPackages (&gEfiTcg2PhysicalPresenceGuid, gImageHandle, DxeTcg2PhysicalPresenceLibStrings, NULL);
   ASSERT (mTcg2PpStringPackHandle != NULL);
@@ -404,20 +401,10 @@ Tcg2UserConfirm (
       TmpStr2    = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TPM_CLEAR));
 
       TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TPM_HEAD_STR));
-      if ((TmpStr1 == NULL) || (TmpStr2 == NULL)) {
-        FreePool (ConfirmText);
-        return FALSE;
-      }
-
       UnicodeSPrint (ConfirmText, BufSize, TmpStr1, TmpStr2);
       FreePool (TmpStr1);
 
       TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TPM_WARNING_CLEAR));
-      if (TmpStr1 == NULL) {
-        FreePool (ConfirmText);
-        return FALSE;
-      }
-
       StrnCatS (ConfirmText, BufSize / sizeof (CHAR16), TmpStr1, (BufSize / sizeof (CHAR16)) - StrLen (ConfirmText) - 1);
       StrnCatS (ConfirmText, BufSize / sizeof (CHAR16), L" \n\n", (BufSize / sizeof (CHAR16)) - StrLen (ConfirmText) - 1);
       FreePool (TmpStr1);
@@ -430,29 +417,14 @@ Tcg2UserConfirm (
       TmpStr2    = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TPM_CLEAR));
 
       TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TPM_PPI_HEAD_STR));
-      if ((TmpStr1 == NULL) || (TmpStr2 == NULL)) {
-        FreePool (ConfirmText);
-        return FALSE;
-      }
-
       UnicodeSPrint (ConfirmText, BufSize, TmpStr1, TmpStr2);
       FreePool (TmpStr1);
 
       TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TPM_NOTE_CLEAR));
-      if (TmpStr1 == NULL) {
-        FreePool (ConfirmText);
-        return FALSE;
-      }
-
       StrnCatS (ConfirmText, BufSize / sizeof (CHAR16), TmpStr1, (BufSize / sizeof (CHAR16)) - StrLen (ConfirmText) - 1);
       FreePool (TmpStr1);
 
       TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TPM_WARNING_CLEAR));
-      if (TmpStr1 == NULL) {
-        FreePool (ConfirmText);
-        return FALSE;
-      }
-
       StrnCatS (ConfirmText, BufSize / sizeof (CHAR16), TmpStr1, (BufSize / sizeof (CHAR16)) - StrLen (ConfirmText) - 1);
       StrnCatS (ConfirmText, BufSize / sizeof (CHAR16), L" \n\n", (BufSize / sizeof (CHAR16)) - StrLen (ConfirmText) - 1);
       FreePool (TmpStr1);
@@ -480,29 +452,14 @@ Tcg2UserConfirm (
       TmpStr2    = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TPM_SET_PCR_BANKS));
 
       TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TPM_HEAD_STR));
-      if ((TmpStr1 == NULL) || (TmpStr2 == NULL)) {
-        FreePool (ConfirmText);
-        return FALSE;
-      }
-
       UnicodeSPrint (ConfirmText, BufSize, TmpStr1, TmpStr2);
       FreePool (TmpStr1);
 
       TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TPM_WARNING_SET_PCR_BANKS_1));
-      if (TmpStr1 == NULL) {
-        FreePool (ConfirmText);
-        return FALSE;
-      }
-
       StrnCatS (ConfirmText, BufSize / sizeof (CHAR16), TmpStr1, (BufSize / sizeof (CHAR16)) - StrLen (ConfirmText) - 1);
       FreePool (TmpStr1);
 
       TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TPM_WARNING_SET_PCR_BANKS_2));
-      if (TmpStr1 == NULL) {
-        FreePool (ConfirmText);
-        return FALSE;
-      }
-
       StrnCatS (ConfirmText, BufSize / sizeof (CHAR16), TmpStr1, (BufSize / sizeof (CHAR16)) - StrLen (ConfirmText) - 1);
       FreePool (TmpStr1);
 
@@ -510,11 +467,7 @@ Tcg2UserConfirm (
       Tcg2FillBufferWithBootHashAlg (TempBuffer2, sizeof (TempBuffer2), CurrentPCRBanks);
 
       TmpStr1 = AllocateZeroPool (BufSize);
-      if (TmpStr1 == NULL) {
-        ASSERT (TmpStr1 != NULL);
-        return FALSE;
-      }
-
+      ASSERT (TmpStr1 != NULL);
       UnicodeSPrint (TmpStr1, BufSize, L"Current PCRBanks is 0x%x. (%s)\nNew PCRBanks is 0x%x. (%s)\n", CurrentPCRBanks, TempBuffer2, TpmPpCommandParameter, TempBuffer);
 
       StrnCatS (ConfirmText, BufSize / sizeof (CHAR16), TmpStr1, (BufSize / sizeof (CHAR16)) - StrLen (ConfirmText) - 1);
@@ -528,29 +481,14 @@ Tcg2UserConfirm (
       TmpStr2    = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TPM_CHANGE_EPS));
 
       TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TPM_HEAD_STR));
-      if ((TmpStr1 == NULL) || (TmpStr2 == NULL)) {
-        FreePool (ConfirmText);
-        return FALSE;
-      }
-
       UnicodeSPrint (ConfirmText, BufSize, TmpStr1, TmpStr2);
       FreePool (TmpStr1);
 
       TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TPM_WARNING_CHANGE_EPS_1));
-      if (TmpStr1 == NULL) {
-        FreePool (ConfirmText);
-        return FALSE;
-      }
-
       StrnCatS (ConfirmText, BufSize / sizeof (CHAR16), TmpStr1, (BufSize / sizeof (CHAR16)) - StrLen (ConfirmText) - 1);
       FreePool (TmpStr1);
 
       TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TPM_WARNING_CHANGE_EPS_2));
-      if (TmpStr1 == NULL) {
-        FreePool (ConfirmText);
-        return FALSE;
-      }
-
       StrnCatS (ConfirmText, BufSize / sizeof (CHAR16), TmpStr1, (BufSize / sizeof (CHAR16)) - StrLen (ConfirmText) - 1);
       FreePool (TmpStr1);
 
@@ -560,11 +498,6 @@ Tcg2UserConfirm (
       TmpStr2 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TCG_STORAGE_ENABLE_BLOCK_SID));
 
       TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TCG_STORAGE_HEAD_STR));
-      if ((TmpStr1 == NULL) || (TmpStr2 == NULL)) {
-        FreePool (ConfirmText);
-        return FALSE;
-      }
-
       UnicodeSPrint (ConfirmText, BufSize, TmpStr1, TmpStr2);
       FreePool (TmpStr1);
       break;
@@ -573,11 +506,6 @@ Tcg2UserConfirm (
       TmpStr2 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TCG_STORAGE_DISABLE_BLOCK_SID));
 
       TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TCG_STORAGE_HEAD_STR));
-      if ((TmpStr1 == NULL) || (TmpStr2 == NULL)) {
-        FreePool (ConfirmText);
-        return FALSE;
-      }
-
       UnicodeSPrint (ConfirmText, BufSize, TmpStr1, TmpStr2);
       FreePool (TmpStr1);
       break;
@@ -587,11 +515,6 @@ Tcg2UserConfirm (
       TmpStr2   = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TCG_STORAGE_PP_ENABLE_BLOCK_SID));
 
       TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TCG_STORAGE_PPI_HEAD_STR));
-      if ((TmpStr1 == NULL) || (TmpStr2 == NULL)) {
-        FreePool (ConfirmText);
-        return FALSE;
-      }
-
       UnicodeSPrint (ConfirmText, BufSize, TmpStr1, TmpStr2);
       FreePool (TmpStr1);
       break;
@@ -601,11 +524,6 @@ Tcg2UserConfirm (
       TmpStr2   = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TCG_STORAGE_PP_DISABLE_BLOCK_SID));
 
       TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TCG_STORAGE_PPI_HEAD_STR));
-      if ((TmpStr1 == NULL) || (TmpStr2 == NULL)) {
-        FreePool (ConfirmText);
-        return FALSE;
-      }
-
       UnicodeSPrint (ConfirmText, BufSize, TmpStr1, TmpStr2);
       FreePool (TmpStr1);
       break;
@@ -626,21 +544,11 @@ Tcg2UserConfirm (
       TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TPM_ACCEPT_KEY));
     }
 
-    if (TmpStr1 == NULL) {
-      FreePool (ConfirmText);
-      return FALSE;
-    }
-
     StrnCatS (ConfirmText, BufSize / sizeof (CHAR16), TmpStr1, (BufSize / sizeof (CHAR16)) - StrLen (ConfirmText) - 1);
     FreePool (TmpStr1);
 
     if (NoPpiInfo) {
       TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TPM_NO_PPI_INFO));
-      if (TmpStr1 == NULL) {
-        FreePool (ConfirmText);
-        return FALSE;
-      }
-
       StrnCatS (ConfirmText, BufSize / sizeof (CHAR16), TmpStr1, (BufSize / sizeof (CHAR16)) - StrLen (ConfirmText) - 1);
       FreePool (TmpStr1);
     }
@@ -653,31 +561,16 @@ Tcg2UserConfirm (
       TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TCG_STORAGE_ACCEPT_KEY));
     }
 
-    if (TmpStr1 == NULL) {
-      FreePool (ConfirmText);
-      return FALSE;
-    }
-
     StrnCatS (ConfirmText, BufSize / sizeof (CHAR16), TmpStr1, (BufSize / sizeof (CHAR16)) - StrLen (ConfirmText) - 1);
     FreePool (TmpStr1);
 
     if (NoPpiInfo) {
       TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TCG_STORAGE_NO_PPI_INFO));
-      if (TmpStr1 == NULL) {
-        FreePool (ConfirmText);
-        return FALSE;
-      }
-
       StrnCatS (ConfirmText, BufSize / sizeof (CHAR16), TmpStr1, (BufSize / sizeof (CHAR16)) - StrLen (ConfirmText) - 1);
       FreePool (TmpStr1);
     }
 
     TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TCG_STORAGE_REJECT_KEY));
-  }
-
-  if (TmpStr1 == NULL) {
-    FreePool (ConfirmText);
-    return FALSE;
   }
 
   BufSize -= StrSize (ConfirmText);

--- a/SecurityPkg/Library/DxeTcgPhysicalPresenceLib/DxeTcgPhysicalPresenceLib.c
+++ b/SecurityPkg/Library/DxeTcgPhysicalPresenceLib/DxeTcgPhysicalPresenceLib.c
@@ -540,7 +540,7 @@ UserConfirm (
   CHAR16   *TmpStr2;
   UINTN    BufSize;
   BOOLEAN  CautionKey;
-  UINTN    Index;
+  UINT16   Index;
   CHAR16   DstStr[81];
 
   TmpStr2     = NULL;

--- a/SecurityPkg/Library/DxeTpm2MeasureBootLib/DxeTpm2MeasureBootLib.c
+++ b/SecurityPkg/Library/DxeTpm2MeasureBootLib/DxeTpm2MeasureBootLib.c
@@ -615,9 +615,6 @@ GetMeasureBootProtocols (
   @retval EFI_SUCCESS             The file specified by DevicePath and non-NULL
                                   FileBuffer did authenticate, and the platform policy dictates
                                   that the DXE Foundation may use the file.
-
-  @retval EFI_OUT_OF_RESOURCES    A necessary memory buffer could not be allocated.
-
   @retval other error value
 **/
 EFI_STATUS
@@ -711,16 +708,9 @@ DxeTpm2MeasureBootHandler (
             }
           }
 
-          if (OrigDevicePathNode != NULL) {
-            FreePool (OrigDevicePathNode);
-          }
-
+          FreePool (OrigDevicePathNode);
           OrigDevicePathNode = DuplicateDevicePath (File);
-          if (OrigDevicePathNode == NULL) {
-            ASSERT (OrigDevicePathNode != NULL);
-            return EFI_OUT_OF_RESOURCES;
-          }
-
+          ASSERT (OrigDevicePathNode != NULL);
           break;
         }
       }

--- a/SecurityPkg/Library/HashInstanceLibSha1/HashInstanceLibSha1.c
+++ b/SecurityPkg/Library/HashInstanceLibSha1/HashInstanceLibSha1.c
@@ -56,10 +56,7 @@ Sha1HashInit (
 
   CtxSize = Sha1GetContextSize ();
   Sha1Ctx = AllocatePool (CtxSize);
-  if (Sha1Ctx == NULL) {
-    ASSERT (Sha1Ctx != NULL);
-    return EFI_OUT_OF_RESOURCES;
-  }
+  ASSERT (Sha1Ctx != NULL);
 
   Sha1Init (Sha1Ctx);
 

--- a/SecurityPkg/Library/HashInstanceLibSha256/HashInstanceLibSha256.c
+++ b/SecurityPkg/Library/HashInstanceLibSha256/HashInstanceLibSha256.c
@@ -56,10 +56,7 @@ Sha256HashInit (
 
   CtxSize   = Sha256GetContextSize ();
   Sha256Ctx = AllocatePool (CtxSize);
-  if (Sha256Ctx == NULL) {
-    ASSERT (Sha256Ctx != NULL);
-    return EFI_OUT_OF_RESOURCES;
-  }
+  ASSERT (Sha256Ctx != NULL);
 
   Sha256Init (Sha256Ctx);
 

--- a/SecurityPkg/Library/HashLibBaseCryptoRouter/HashLibBaseCryptoRouterDxe.c
+++ b/SecurityPkg/Library/HashLibBaseCryptoRouter/HashLibBaseCryptoRouterDxe.c
@@ -80,11 +80,6 @@ HashStart (
 
   for (Index = 0; Index < mHashInterfaceCount; Index++) {
     HashMask = Tpm2GetHashMaskFromAlgo (&mHashInterface[Index].HashGuid);
-    if (HashCtx == NULL) {
-      // If we fail to get the hash mask we don't have resources.
-      return EFI_OUT_OF_RESOURCES;
-    }
-
     if ((HashMask & PcdGet32 (PcdTpm2HashMask)) != 0) {
       mHashInterface[Index].HashInit (&HashCtx[Index]);
     }
@@ -283,16 +278,8 @@ HashAndExtend (
 
   CheckSupportedHashMaskMismatch ();
 
-  Status = HashStart (&HashHandle);
-  if (EFI_ERROR (Status)) {
-    return Status;
-  }
-
-  Status = HashUpdate (HashHandle, DataToHash, DataToHashLen);
-  if (EFI_ERROR (Status)) {
-    return Status;
-  }
-
+  HashStart (&HashHandle);
+  HashUpdate (HashHandle, DataToHash, DataToHashLen);
   Status = HashCompleteAndExtend (HashHandle, PcrIndex, NULL, 0, DigestList);
 
   return Status;

--- a/SecurityPkg/Library/HashLibBaseCryptoRouter/HashLibBaseCryptoRouterPei.c
+++ b/SecurityPkg/Library/HashLibBaseCryptoRouter/HashLibBaseCryptoRouterPei.c
@@ -106,10 +106,7 @@ CheckSupportedHashMaskMismatch (
   HASH_INTERFACE_HOB  *HashInterfaceHobLast;
 
   HashInterfaceHobLast = InternalGetHashInterfaceHob (&gZeroGuid);
-  if (HashInterfaceHobLast == NULL) {
-    ASSERT (HashInterfaceHobLast != NULL);
-    return;
-  }
+  ASSERT (HashInterfaceHobLast != NULL);
 
   if ((HashInterfaceHobLast->SupportedHashMask != 0) &&
       (HashInterfaceHobCurrent->SupportedHashMask != HashInterfaceHobLast->SupportedHashMask))
@@ -155,10 +152,7 @@ HashStart (
   CheckSupportedHashMaskMismatch (HashInterfaceHob);
 
   HashCtx = AllocatePool (sizeof (*HashCtx) * HashInterfaceHob->HashInterfaceCount);
-  if (HashCtx == NULL) {
-    ASSERT (HashCtx != NULL);
-    return EFI_OUT_OF_RESOURCES;
-  }
+  ASSERT (HashCtx != NULL);
 
   for (Index = 0; Index < HashInterfaceHob->HashInterfaceCount; Index++) {
     HashMask = Tpm2GetHashMaskFromAlgo (&HashInterfaceHob->HashInterface[Index].HashGuid);
@@ -311,16 +305,8 @@ HashAndExtend (
 
   CheckSupportedHashMaskMismatch (HashInterfaceHob);
 
-  Status = HashStart (&HashHandle);
-  if (EFI_ERROR (Status)) {
-    return Status;
-  }
-
-  Status = HashUpdate (HashHandle, DataToHash, DataToHashLen);
-  if (EFI_ERROR (Status)) {
-    return Status;
-  }
-
+  HashStart (&HashHandle);
+  HashUpdate (HashHandle, DataToHash, DataToHashLen);
   Status = HashCompleteAndExtend (HashHandle, PcrIndex, NULL, 0, DigestList);
 
   return Status;

--- a/SecurityPkg/Library/SecureBootVariableProvisionLib/SecureBootVariableProvisionLib.c
+++ b/SecurityPkg/Library/SecureBootVariableProvisionLib/SecureBootVariableProvisionLib.c
@@ -59,11 +59,7 @@ SecureBootFetchData (
   *SigListOut   = NULL;
   *SigListsSize = 0;
   CertInfo      = AllocatePool (sizeof (SECURE_BOOT_CERTIFICATE_INFO));
-  if (CertInfo == NULL) {
-    return EFI_OUT_OF_RESOURCES;
-  }
-
-  NewCertInfo = CertInfo;
+  NewCertInfo   = CertInfo;
   while (1) {
     if (NewCertInfo == NULL) {
       Status = EFI_OUT_OF_RESOURCES;
@@ -97,9 +93,6 @@ SecureBootFetchData (
                       sizeof (SECURE_BOOT_CERTIFICATE_INFO) * (KeyIndex + 1),
                       CertInfo
                       );
-      if (NewCertInfo == NULL) {
-        goto Cleanup;
-      }
     }
 
     if (Status == EFI_NOT_FOUND) {

--- a/SecurityPkg/Library/TcgEventLogRecordLib/TcgEventLogRecordLib.c
+++ b/SecurityPkg/Library/TcgEventLogRecordLib/TcgEventLogRecordLib.c
@@ -106,7 +106,7 @@ MeasureFirmwareBlob (
   {
     if (Description != NULL) {
       AsciiSPrint ((CHAR8 *)FvBlob2.BlobDescription, sizeof (FvBlob2.BlobDescription), "%a", Description);
-    } else if (FvName != NULL) {
+    } else {
       AsciiSPrint ((CHAR8 *)FvBlob2.BlobDescription, sizeof (FvBlob2.BlobDescription), "Fv(%g)", FvName);
     }
 

--- a/SecurityPkg/Library/Tpm12DeviceLibDTpm/Tpm12Tis.c
+++ b/SecurityPkg/Library/Tpm12DeviceLibDTpm/Tpm12Tis.c
@@ -270,7 +270,7 @@ Tpm12TisTpmCommand (
 {
   EFI_STATUS  Status;
   UINT16      BurstCount;
-  UINTN       Index;
+  UINT32      Index;
   UINT32      TpmOutSize;
   UINT16      Data16;
   UINT32      Data32;

--- a/SecurityPkg/RandomNumberGenerator/RngDxe/Rand/AesCore.c
+++ b/SecurityPkg/RandomNumberGenerator/RngDxe/Rand/AesCore.c
@@ -230,8 +230,6 @@ AesEncrypt (
   UINTN    NbIndex;
   UINTN    Round;
 
-  EFI_STATUS  Status;
-
   if ((Key == NULL) || (InData == NULL) || (OutData == NULL)) {
     return EFI_INVALID_PARAMETER;
   }
@@ -239,10 +237,7 @@ AesEncrypt (
   //
   // Expands AES Key for encryption.
   //
-  Status = AesExpandKey (Key, 128, &AesKey);
-  if (EFI_ERROR (Status)) {
-    return Status;
-  }
+  AesExpandKey (Key, 128, &AesKey);
 
   Nr = AesKey.Nk + 6;
   Ek = AesKey.EncKey;

--- a/SecurityPkg/Tcg/Opal/OpalPassword/OpalDriver.c
+++ b/SecurityPkg/Tcg/Opal/OpalPassword/OpalDriver.c
@@ -2224,7 +2224,7 @@ ProcessOpalRequest (
   //
   TempVariable = Variable;
   while ((VariableSize > sizeof (OPAL_REQUEST_VARIABLE)) &&
-         (VariableSize >= (UINTN)TempVariable->Length) &&
+         (VariableSize >= TempVariable->Length) &&
          (TempVariable->Length > sizeof (OPAL_REQUEST_VARIABLE)))
   {
     DevicePathInVariable     = (EFI_DEVICE_PATH_PROTOCOL *)((UINTN)TempVariable + sizeof (OPAL_REQUEST_VARIABLE));

--- a/SecurityPkg/Tcg/Opal/OpalPassword/OpalHii.c
+++ b/SecurityPkg/Tcg/Opal/OpalPassword/OpalHii.c
@@ -113,7 +113,7 @@ GetSavedOpalRequest (
 
   TempVariable = Variable;
   while ((VariableSize > sizeof (OPAL_REQUEST_VARIABLE)) &&
-         (VariableSize >= (UINTN)TempVariable->Length) &&
+         (VariableSize >= TempVariable->Length) &&
          (TempVariable->Length > sizeof (OPAL_REQUEST_VARIABLE)))
   {
     DevicePathInVariable     = (EFI_DEVICE_PATH_PROTOCOL *)((UINTN)TempVariable + sizeof (OPAL_REQUEST_VARIABLE));
@@ -193,7 +193,7 @@ SaveOpalRequest (
     TempVariable     = Variable;
     TempVariableSize = VariableSize;
     while ((TempVariableSize > sizeof (OPAL_REQUEST_VARIABLE)) &&
-           (TempVariableSize >= (UINTN)TempVariable->Length) &&
+           (TempVariableSize >= TempVariable->Length) &&
            (TempVariable->Length > sizeof (OPAL_REQUEST_VARIABLE)))
     {
       DevicePathInVariable     = (EFI_DEVICE_PATH_PROTOCOL *)((UINTN)TempVariable + sizeof (OPAL_REQUEST_VARIABLE));
@@ -226,11 +226,7 @@ SaveOpalRequest (
       DevicePathSize  = GetDevicePathSize (DevicePath);
       NewVariableSize = VariableSize + sizeof (OPAL_REQUEST_VARIABLE) + DevicePathSize;
       NewVariable     = AllocatePool (NewVariableSize);
-      if (NewVariable == NULL) {
-        ASSERT (NewVariable != NULL);
-        return;
-      }
-
+      ASSERT (NewVariable != NULL);
       CopyMem (NewVariable, Variable, VariableSize);
       TempVariable         = (OPAL_REQUEST_VARIABLE *)((UINTN)NewVariable + VariableSize);
       TempVariable->Length = (UINT32)(sizeof (OPAL_REQUEST_VARIABLE) + DevicePathSize);
@@ -243,11 +239,7 @@ SaveOpalRequest (
     DevicePathSize  = GetDevicePathSize (DevicePath);
     NewVariableSize = sizeof (OPAL_REQUEST_VARIABLE) + DevicePathSize;
     NewVariable     = AllocatePool (NewVariableSize);
-    if (NewVariable == NULL) {
-      ASSERT (NewVariable != NULL);
-      return;
-    }
-
+    ASSERT (NewVariable != NULL);
     NewVariable->Length = (UINT32)(sizeof (OPAL_REQUEST_VARIABLE) + DevicePathSize);
     CopyMem (&NewVariable->OpalRequest, &OpalRequest, sizeof (OPAL_REQUEST));
     DevicePathInVariable = (EFI_DEVICE_PATH_PROTOCOL *)((UINTN)NewVariable + sizeof (OPAL_REQUEST_VARIABLE));
@@ -1119,13 +1111,8 @@ ExtractConfig (
     //
     DriverHandle     = HiiGetDriverImageHandleCB ();
     ConfigRequestHdr = HiiConstructConfigHdr (&gHiiSetupVariableGuid, OpalPasswordStorageName, DriverHandle);
-    if (ConfigRequestHdr == NULL) {
-      ASSERT (ConfigRequestHdr != NULL);
-      return EFI_OUT_OF_RESOURCES;
-    }
-
-    Size          = (StrLen (ConfigRequestHdr) + 32 + 1) * sizeof (CHAR16);
-    ConfigRequest = AllocateZeroPool (Size);
+    Size             = (StrLen (ConfigRequestHdr) + 32 + 1) * sizeof (CHAR16);
+    ConfigRequest    = AllocateZeroPool (Size);
     if (ConfigRequest == NULL) {
       return EFI_OUT_OF_RESOURCES;
     }

--- a/SecurityPkg/Tcg/Tcg2Config/Tcg2ConfigDriver.c
+++ b/SecurityPkg/Tcg/Tcg2Config/Tcg2ConfigDriver.c
@@ -103,11 +103,7 @@ InitializeTcg2VersionInfo (
                        TCG2_VERSION_NAME,
                        PrivateData->DriverHandle
                        );
-  if (ConfigRequestHdr == NULL) {
-    ASSERT (ConfigRequestHdr != NULL);
-    return;
-  }
-
+  ASSERT (ConfigRequestHdr != NULL);
   DataSize = sizeof (Tcg2Version);
   Status   = gRT->GetVariable (
                     TCG2_VERSION_NAME,

--- a/SecurityPkg/Tcg/Tcg2Dxe/Tcg2Dxe.c
+++ b/SecurityPkg/Tcg/Tcg2Dxe/Tcg2Dxe.c
@@ -626,7 +626,7 @@ DumpEventLog (
   TCG_PCR_EVENT_HDR         *EventHdr;
   TCG_PCR_EVENT2            *TcgPcrEvent2;
   TCG_EfiSpecIDEventStruct  *TcgEfiSpecIdEventStruct;
-  UINT64                    NumberOfEvents;
+  UINTN                     NumberOfEvents;
 
   if (!DebugPrintLevelEnabled (DEBUG_SECURITY)) {
     return;
@@ -637,7 +637,7 @@ DumpEventLog (
   switch (EventLogFormat) {
     case EFI_TCG2_EVENT_LOG_FORMAT_TCG_1_2:
       EventHdr = (TCG_PCR_EVENT_HDR *)(UINTN)EventLogLocation;
-      while ((EFI_PHYSICAL_ADDRESS)(UINTN)EventHdr <= EventLogLastEntry) {
+      while ((UINTN)EventHdr <= EventLogLastEntry) {
         DumpEvent (EventHdr);
         EventHdr = (TCG_PCR_EVENT_HDR *)((UINTN)EventHdr + sizeof (TCG_PCR_EVENT_HDR) + EventHdr->EventSize);
       }
@@ -668,7 +668,7 @@ DumpEventLog (
       DumpTcgEfiSpecIdEventStruct (TcgEfiSpecIdEventStruct);
 
       TcgPcrEvent2 = (TCG_PCR_EVENT2 *)((UINTN)TcgEfiSpecIdEventStruct + GetTcgEfiSpecIdEventStructSize (TcgEfiSpecIdEventStruct));
-      while ((EFI_PHYSICAL_ADDRESS)(UINTN)TcgPcrEvent2 <= EventLogLastEntry) {
+      while ((UINTN)TcgPcrEvent2 <= EventLogLastEntry) {
         DumpEvent2 (TcgPcrEvent2);
         TcgPcrEvent2 = (TCG_PCR_EVENT2 *)((UINTN)TcgPcrEvent2 + GetPcrEvent2Size (TcgPcrEvent2));
       }

--- a/SecurityPkg/Tcg/TcgConfigDxe/TcgConfigImpl.c
+++ b/SecurityPkg/Tcg/TcgConfigDxe/TcgConfigImpl.c
@@ -193,19 +193,9 @@ TcgExtractConfig (
     // followed by "&OFFSET=0&WIDTH=WWWWWWWWWWWWWWWW" followed by a Null-terminator
     //
     ConfigRequestHdr = HiiConstructConfigHdr (&gTcgConfigFormSetGuid, mTcgStorageName, PrivateData->DriverHandle);
-    if (ConfigRequestHdr == NULL) {
-      ASSERT (ConfigRequestHdr != NULL);
-      return EFI_OUT_OF_RESOURCES;
-    }
-
-    Size          = (StrLen (ConfigRequestHdr) + 32 + 1) * sizeof (CHAR16);
-    ConfigRequest = AllocateZeroPool (Size);
-    if (ConfigRequest == NULL) {
-      ASSERT (ConfigRequest != NULL);
-      FreePool (ConfigRequestHdr);
-      return EFI_OUT_OF_RESOURCES;
-    }
-
+    Size             = (StrLen (ConfigRequestHdr) + 32 + 1) * sizeof (CHAR16);
+    ConfigRequest    = AllocateZeroPool (Size);
+    ASSERT (ConfigRequest != NULL);
     AllocatedRequest = TRUE;
     UnicodeSPrint (ConfigRequest, Size, L"%s&OFFSET=0&WIDTH=%016LX", ConfigRequestHdr, sizeof (TCG_CONFIGURATION));
     FreePool (ConfigRequestHdr);

--- a/SecurityPkg/Tcg/TcgDxe/TcgDxe.c
+++ b/SecurityPkg/Tcg/TcgDxe/TcgDxe.c
@@ -286,10 +286,7 @@ TpmCommHashAll (
 
   CtxSize = Sha1GetContextSize ();
   Sha1Ctx = AllocatePool (CtxSize);
-  if (Sha1Ctx == NULL) {
-    ASSERT (Sha1Ctx != NULL);
-    return EFI_OUT_OF_RESOURCES;
-  }
+  ASSERT (Sha1Ctx != NULL);
 
   Sha1Init (Sha1Ctx);
   Sha1Update (Sha1Ctx, Data, DataLen);

--- a/SecurityPkg/VariableAuthenticated/SecureBootConfigDxe/SecureBootConfigFileExplorer.c
+++ b/SecurityPkg/VariableAuthenticated/SecureBootConfigDxe/SecureBootConfigFileExplorer.c
@@ -98,11 +98,7 @@ ExtractFileNameFromDevicePath (
 
   ASSERT (DevicePath != NULL);
 
-  String = DevicePathToStr (DevicePath);
-  if (String == NULL) {
-    return NULL;
-  }
-
+  String      = DevicePathToStr (DevicePath);
   MatchString = String;
   LastMatch   = String;
   FileName    = NULL;

--- a/SecurityPkg/VariableAuthenticated/SecureBootConfigDxe/SecureBootConfigImpl.c
+++ b/SecurityPkg/VariableAuthenticated/SecureBootConfigDxe/SecureBootConfigImpl.c
@@ -1095,7 +1095,7 @@ IsSignatureFoundInDatabase (
   // Enumerate all signature data in SigDB to check if signature exists for executable.
   //
   CertList = (EFI_SIGNATURE_LIST *)Data;
-  while ((DataSize > 0) && (DataSize >= (UINTN)CertList->SignatureListSize)) {
+  while ((DataSize > 0) && (DataSize >= CertList->SignatureListSize)) {
     CertCount = (CertList->SignatureListSize - sizeof (EFI_SIGNATURE_LIST) - CertList->SignatureHeaderSize) / CertList->SignatureSize;
     Cert      = (EFI_SIGNATURE_DATA *)((UINT8 *)CertList + sizeof (EFI_SIGNATURE_LIST) + CertList->SignatureHeaderSize);
     if ((CertList->SignatureSize == sizeof (EFI_SIGNATURE_DATA) - 1 + SignatureSize) && (CompareGuid (&CertList->SignatureType, &gEfiCertX509Guid))) {
@@ -1173,10 +1173,7 @@ CalculateCertHash (
   //
   CtxSize = mHash[HashAlg].GetContextSize ();
   HashCtx = AllocatePool (CtxSize);
-  if (HashCtx == NULL) {
-    ASSERT (HashCtx != NULL);
-    return FALSE;
-  }
+  ASSERT (HashCtx != NULL);
 
   //
   // 2. Initialize a hash context.
@@ -1264,7 +1261,7 @@ IsCertHashFoundInDbx (
   // Check whether the certificate hash exists in the forbidden database.
   //
   DbxList = (EFI_SIGNATURE_LIST *)Data;
-  while ((DataSize > 0) && (DataSize >= (UINTN)DbxList->SignatureListSize)) {
+  while ((DataSize > 0) && (DataSize >= DbxList->SignatureListSize)) {
     //
     // Determine Hash Algorithm of Certificate in the forbidden database.
     //
@@ -1351,7 +1348,7 @@ GetSignaturelistOffset (
 
   SigList     = Database;
   SiglistSize = DatabaseSize;
-  while ((SiglistSize > 0) && (SiglistSize >= (UINTN)SigList->SignatureListSize)) {
+  while ((SiglistSize > 0) && (SiglistSize >= SigList->SignatureListSize)) {
     if (CompareGuid (&SigList->SignatureType, SignatureType)) {
       *Offset = DatabaseSize - SiglistSize;
       return TRUE;
@@ -1891,10 +1888,7 @@ HashPeImage (
   CtxSize = mHash[HashAlg].GetContextSize ();
 
   HashCtx = AllocatePool (CtxSize);
-  if (HashCtx == NULL) {
-    ASSERT (HashCtx != NULL);
-    goto Done;
-  }
+  ASSERT (HashCtx != NULL);
 
   // 1.  Load the image header into memory.
 
@@ -2546,7 +2540,7 @@ UpdateDeletePage (
   )
 {
   EFI_STATUS          Status;
-  UINTN               Index;
+  UINT32              Index;
   UINTN               CertCount;
   UINTN               GuidIndex;
   VOID                *StartOpCodeHandle;
@@ -2730,7 +2724,7 @@ DeleteKeyExchangeKey (
   UINT8               *Data;
   UINT8               *OldData;
   UINT32              Attr;
-  UINTN               Index;
+  UINT32              Index;
   EFI_SIGNATURE_LIST  *CertList;
   EFI_SIGNATURE_LIST  *NewCertList;
   EFI_SIGNATURE_DATA  *Cert;
@@ -2934,7 +2928,7 @@ DeleteSignature (
   UINT8               *Data;
   UINT8               *OldData;
   UINT32              Attr;
-  UINTN               Index;
+  UINT32              Index;
   EFI_SIGNATURE_LIST  *CertList;
   EFI_SIGNATURE_LIST  *NewCertList;
   EFI_SIGNATURE_DATA  *Cert;
@@ -3212,7 +3206,7 @@ DeleteSignatureEx (
     //
     //  Traverse to target EFI_SIGNATURE_LIST but others will be skipped.
     //
-    while ((RemainingSize > 0) && (RemainingSize >= (UINTN)ListWalker->SignatureListSize) && ListIndex < PrivateData->ListIndex) {
+    while ((RemainingSize > 0) && (RemainingSize >= ListWalker->SignatureListSize) && ListIndex < PrivateData->ListIndex) {
       CopyMem ((UINT8 *)NewVariableData + Offset, ListWalker, ListWalker->SignatureListSize);
       Offset += ListWalker->SignatureListSize;
 
@@ -3519,19 +3513,9 @@ SecureBootExtractConfig (
     // followed by "&OFFSET=0&WIDTH=WWWWWWWWWWWWWWWW" followed by a Null-terminator
     //
     ConfigRequestHdr = HiiConstructConfigHdr (&gSecureBootConfigFormSetGuid, mSecureBootStorageName, PrivateData->DriverHandle);
-    if (ConfigRequestHdr == NULL) {
-      ASSERT (ConfigRequestHdr != NULL);
-      return EFI_OUT_OF_RESOURCES;
-    }
-
-    Size          = (StrLen (ConfigRequestHdr) + 32 + 1) * sizeof (CHAR16);
-    ConfigRequest = AllocateZeroPool (Size);
-    if (ConfigRequest == NULL) {
-      ASSERT (ConfigRequest != NULL);
-      FreePool (ConfigRequestHdr);
-      return EFI_OUT_OF_RESOURCES;
-    }
-
+    Size             = (StrLen (ConfigRequestHdr) + 32 + 1) * sizeof (CHAR16);
+    ConfigRequest    = AllocateZeroPool (Size);
+    ASSERT (ConfigRequest != NULL);
     AllocatedRequest = TRUE;
     UnicodeSPrint (ConfigRequest, Size, L"%s&OFFSET=0&WIDTH=%016LX", ConfigRequestHdr, (UINT64)BufferSize);
     FreePool (ConfigRequestHdr);
@@ -3810,7 +3794,7 @@ LoadSignatureList (
 
   RemainingSize = DataSize;
   ListWalker    = (EFI_SIGNATURE_LIST *)VariableData;
-  while ((RemainingSize > 0) && (RemainingSize >= (UINTN)ListWalker->SignatureListSize)) {
+  while ((RemainingSize > 0) && (RemainingSize >= ListWalker->SignatureListSize)) {
     if (CompareGuid (&ListWalker->SignatureType, &gEfiCertRsa2048Guid)) {
       ListType = STRING_TOKEN (STR_LIST_TYPE_RSA2048_SHA256);
     } else if (CompareGuid (&ListWalker->SignatureType, &gEfiCertX509Guid)) {
@@ -4226,7 +4210,7 @@ LoadSignatureData (
   VOID                *EndOpCodeHandle;
   UINTN               DataSize;
   UINTN               RemainingSize;
-  UINT64              Index;
+  UINT16              Index;
   UINT8               *VariableData;
   CHAR16              VariableName[BUFFER_MAX_SIZE];
   CHAR16              NameBuffer[BUFFER_MAX_SIZE];
@@ -4310,7 +4294,7 @@ LoadSignatureData (
   //
   // Skip signature list.
   //
-  while ((RemainingSize > 0) && (RemainingSize >= (UINTN)ListWalker->SignatureListSize) && ListIndex-- > 0) {
+  while ((RemainingSize > 0) && (RemainingSize >= ListWalker->SignatureListSize) && ListIndex-- > 0) {
     RemainingSize -= ListWalker->SignatureListSize;
     ListWalker     = (EFI_SIGNATURE_LIST *)((UINT8 *)ListWalker + ListWalker->SignatureListSize);
   }


### PR DESCRIPTION
# Description

This reverts commit ba6a8eb045aededbc1472cce7314ab1911f0ea1c.

PR https://github.com/tianocore/edk2/pull/11307 introduced a logic change that caused regressions in FV verification on some platforms. This PR is being reverted to restore the prior logic.

The Code QL fixes in https://github.com/tianocore/edk2/pull/11307 can be resubmitted without the logic change along with one commit for each type of Code QL issue being addressed.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

## Integration Instructions

N/A
