### PR TITLE
CryptoPkg/BaseCryptLibMbedTls: Fix X509GetIssuerName and X509FormatDateTime

### DIFF
--- a/CryptoPkg/Library/BaseCryptLibMbedTls/Pk/CryptX509.c
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/Pk/CryptX509.c
@@ -1125,7 +1125,6 @@ X509GetIssuerName (
 {
   mbedtls_x509_crt  Crt;
   INT32             Ret;
-  BOOLEAN           Status;
 
   if (Cert == NULL) {
     return FALSE;
@@ -1138,24 +1137,16 @@ X509GetIssuerName (
   Ret = mbedtls_x509_crt_parse_der (&Crt, Cert, CertSize);
 
   if (Ret == 0) {
-    if (*CertIssuerSize < Crt.serial.len) {
-      *CertIssuerSize = Crt.serial.len;
-      Status          = FALSE;
-      goto Cleanup;
-    }
-
     if (CertIssuer != NULL) {
-      CopyMem (CertIssuer, Crt.serial.p, Crt.serial.len);
+      CopyMem (CertIssuer, Crt.issuer_raw.p, Crt.issuer_raw.len);
     }
 
-    *CertIssuerSize = Crt.serial.len;
-    Status          = TRUE;
+    *CertIssuerSize = Crt.issuer_raw.len;
   }
 
-Cleanup:
   mbedtls_x509_crt_free (&Crt);
 
-  return Status;
+  return Ret == 0;
 }
 
 /**

--- a/CryptoPkg/Library/BaseCryptLibMbedTls/Pk/CryptX509.c
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/Pk/CryptX509.c
@@ -1923,18 +1923,18 @@ X509FormatDateTime (
 
   Tm = (mbedtls_x509_time *)DateTime;
 
-  Tm->year = (DateTimeStr[0] + '0') * 1000 + (DateTimeStr[1] + '0') * 100 +
-             (DateTimeStr[2] + '0') * 10 + (DateTimeStr[3] + '0') * 1;
+  Tm->year = (DateTimeStr[0] - '0') * 1000 + (DateTimeStr[1] - '0') * 100 +
+             (DateTimeStr[2] - '0') * 10 + (DateTimeStr[3] - '0') * 1;
 
-  Tm->mon = (DateTimeStr[4] + '0') * 10 + (DateTimeStr[5] + '0') * 1;
+  Tm->mon = (DateTimeStr[4] - '0') * 10 + (DateTimeStr[5] - '0') * 1;
 
-  Tm->day = (DateTimeStr[6] + '0') * 10 + (DateTimeStr[7] + '0') * 1;
+  Tm->day = (DateTimeStr[6] - '0') * 10 + (DateTimeStr[7] - '0') * 1;
 
-  Tm->hour = (DateTimeStr[8] + '0') * 10 + (DateTimeStr[9] + '0') * 1;
+  Tm->hour = (DateTimeStr[8] - '0') * 10 + (DateTimeStr[9] - '0') * 1;
 
-  Tm->min = (DateTimeStr[10] + '0') * 10 + (DateTimeStr[11] + '0') * 1;
+  Tm->min = (DateTimeStr[10] - '0') * 10 + (DateTimeStr[11] - '0') * 1;
 
-  Tm->sec = (DateTimeStr[12] + '0') * 10 + (DateTimeStr[13] + '0') * 1;
+  Tm->sec = (DateTimeStr[12] - '0') * 10 + (DateTimeStr[13] - '0') * 1;
 
   return TRUE;
 }


### PR DESCRIPTION
# Description

This PR modifies two functions:

- **X509GetIssuerName** was not returning the Issuer Name, instead it was returning serial member from mbedtls_x509_crt struct;
- **X509FormatDateTime** was incorrectly converting char to int.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Tested building OvmfPkgX64 with MbedTLS instead of OpenSSL to use with SecurityPkg/DeviceSecurity.

## Integration Instructions

N/A
