### PR TITLE
MdePkg/DxeIoLibCpuIo2: allow use from UEFI_DRIVER

### DIFF
--- a/MdePkg/Library/DxeIoLibCpuIo2/DxeIoLibCpuIo2.inf
+++ b/MdePkg/Library/DxeIoLibCpuIo2/DxeIoLibCpuIo2.inf
@@ -16,7 +16,7 @@
   FILE_GUID                      = 33D33BF3-349E-4768-9459-836A9F7558FB
   MODULE_TYPE                    = DXE_DRIVER
   VERSION_STRING                 = 1.0
-  LIBRARY_CLASS                  = IoLib|DXE_DRIVER
+  LIBRARY_CLASS                  = IoLib|DXE_DRIVER UEFI_DRIVER UEFI_APPLICATION
   CONSTRUCTOR                    = IoLibConstructor
 
 #


### PR DESCRIPTION
# Description
On architectures without native port I/O instructions (e.g. non-x86 such as LoongArch), BaseIoLibIntrinsic cannot be used for in/out operations. Ps2KeyboardDxe depends on IoLib to access the PS/2 controller and must fall back to a protocol-based implementation.

Current DxeIoLibCpuIo2 uses:
  LIBRARY_CLASS = IoLib|DXE_DRIVER
This blocks UEFI_DRIVER modules from linking against it, even though they run in the DXE phase and can safely consume EFI_CPU_IO2_PROTOCOL.

Call flow comparison
--------------------
(x86 and other I/O-port capable arch):
  Ps2KeyboardDxe
    -> BaseIoLibIntrinsic (IoLib)
        ... -> native CPU I/O instructions (in/out)

(I/O-port-less arch):
  Ps2KeyboardDxe
    -> DxeIoLibCpuIo2 (IoLib, protocol-backed)
         ...-> CpuIo2Dxe (EFI_CPU_IO2_PROTOCOL provider)
            ......  -> MMIO / SoC-specific bus access

Solution (following DxeSmbusLib pattern)
--------
Relax LIBRARY_CLASS in DxeIoLibCpuIo2.inf:
This enables UEFI drivers to use protocol-based IoLib.

Reported-by: Chen Zhang <zhangchen@loongson.cn>
Signed-off-by: Dongyan Qian <qiandongyan@loongson.cn>
Tested-by: Yanbing Lv <lvyanbing@loongson.cn>

<_Include a description of the change and why this change was made._>

<_For each item, place an "x" in between `[` and `]` if true. Example: `[x]` (you can also check items in GitHub UI)_>

<_Create the PR as a Draft PR if it is only created to run CI checks._>

<_Delete lines in \<\> tags before creating the PR._>

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

<_Describe the test(s) that were run to verify the changes._>

## Integration Instructions

<_Describe how these changes should be integrated. Use N/A if nothing is required._>
