### PR TITLE
RedfishPkg/ConfigHandler: Implement the disconnection of Redfish tran…

### DIFF
--- a/RedfishPkg/RedfishConfigHandler/RedfishConfigHandlerCommon.h
+++ b/RedfishPkg/RedfishConfigHandler/RedfishConfigHandlerCommon.h
@@ -30,6 +30,7 @@
 //
 #include <Protocol/EdkIIRedfishCredential.h>
 #include <Protocol/EdkIIRedfishConfigHandler.h>
+#include <Protocol/RestEx.h>
 
 //
 // Driver Version

--- a/RedfishPkg/RedfishConfigHandler/RedfishConfigHandlerDriver.inf
+++ b/RedfishPkg/RedfishConfigHandler/RedfishConfigHandlerDriver.inf
@@ -55,8 +55,9 @@
   gEdkIIRedfishHostInterfaceReadyProtocolGuid  ## CONSUMES
 
 [Guids]
-  gEfiEventExitBootServicesGuid           ## CONSUMES ## Event
-  gEfiEndOfDxeEventGroupGuid              ## CONSUMES ## Event
+  gEfiEventExitBootServicesGuid                       ## CONSUMES ## Event
+  gEfiEndOfDxeEventGroupGuid                          ## CONSUMES ## Event
+  gEdkIIRedfisEventRedfishInterfaceDisconnectionGuid  ## CONSUMES ## Event
 
 [Depex]
   gEdkIIRedfishCredentialProtocolGuid

--- a/RedfishPkg/RedfishPkg.dec
+++ b/RedfishPkg/RedfishPkg.dec
@@ -116,6 +116,9 @@
   # Redfish variable guid
   gEfiRedfishVariableGuid           = { 0x85ef8dd3, 0xe606, 0x4b89, { 0x8b, 0xbd, 0x93, 0xbf, 0x5c, 0xbe, 0x1c, 0x18 } }
 
+  # Redfish Configuration Handler Disconnection
+  gEdkIIRedfisEventRedfishInterfaceDisconnectionGuid = { 0x11B81837, 0x249B, 0x4843, { 0xA5, 0x2C, 0xC8, 0x23, 0x7B, 0x35, 0xBF, 0xC2 } }
+
 [PcdsFixedAtBuild, PcdsPatchableInModule]
   #
   # This PCD is the UEFI device path which is used as the Redfish host interface.


### PR DESCRIPTION
…sport interface

Provide an event for the Redfish client to signal Redfish configuration handler driver to disconnect from the Redfish transport interface.

# Description

Redfish interface remains open when it is no longer needed. For example, the HTTP session remains open when Redfish communication is no longer needed. This results in the Redfish server having too many sessions open. Redfish server (e.g. BMC) throws out the failure of too many HTTP sessions.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

1. Boot the system with Redfish enabled.
2. Either boot to EFI shell or OS
3. Reboot the system
4. Check the Redfish server and the session remains open.

## Integration Instructions
 N/A
