### PR TITLE
RedfishPkg/RedfishPlatformConfig: Expose suppressed HII options on Re…

### DIFF
--- a/RedfishPkg/RedfishPlatformConfigDxe/RedfishPlatformConfigDxe.c
+++ b/RedfishPkg/RedfishPlatformConfigDxe/RedfishPlatformConfigDxe.c
@@ -1666,7 +1666,7 @@ RedfishPlatformConfigProtocolGetValue (
     goto RELEASE_RESOURCE;
   }
 
-  if (TargetStatement->Suppressed) {
+  if (TargetStatement->Suppressed && !RedfishPlatformConfigFeatureProp (REDFISH_PLATFORM_CONFIG_ALLOW_SUPPRESSED)) {
     Status = EFI_ACCESS_DENIED;
     goto RELEASE_RESOURCE;
   }
@@ -2289,7 +2289,7 @@ RedfishPlatformConfigProtocolGetDefaultValue (
     goto RELEASE_RESOURCE;
   }
 
-  if (TargetStatement->Suppressed) {
+  if (TargetStatement->Suppressed && !RedfishPlatformConfigFeatureProp (REDFISH_PLATFORM_CONFIG_ALLOW_SUPPRESSED)) {
     Status = EFI_ACCESS_DENIED;
     goto RELEASE_RESOURCE;
   }


### PR DESCRIPTION
…dfish service

When REDFISH_PLATFORM_CONFIG_ALLOW_SUPPRESSED is set in PcdRedfishPlatformConfigFeatureProperty, HII suppressed options should be exposed to Redfish BIOS resource.

# Description

RedfishPlatformConfigProtocolGetValue () ignores HII suppressed option. When REDFISH_PLATFORM_CONFIG_ALLOW_SUPPRESSED is set in PcdRedfishPlatformConfigFeatureProperty, HII suppressed options should be exposed to Redfish BIOS resource.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Set REDFISH_PLATFORM_CONFIG_ALLOW_SUPPRESSED in PcdRedfishPlatformConfigFeatureProperty, check if HII suppressed options are provisioned to Redfish BIOS resource or not.

## Integration Instructions

