### PR TITLE
SecurityPkg/Tpm2CommandLib: Update not found RC for Public NV Read

### DIFF
--- a/SecurityPkg/Library/Tpm2CommandLib/Tpm2NVStorage.c
+++ b/SecurityPkg/Library/Tpm2CommandLib/Tpm2NVStorage.c
@@ -229,6 +229,7 @@ Tpm2NvReadPublic (
     case TPM_RC_SUCCESS:
       // return data
       break;
+    case TPM_RC_HANDLE:
     case TPM_RC_HANDLE + RC_NV_ReadPublic_nvIndex: // TPM_RC_NV_DEFINED:
       return EFI_NOT_FOUND;
     case TPM_RC_VALUE + RC_NV_ReadPublic_nvIndex:


### PR DESCRIPTION
# Description

Currently a EFI_DEVICE_ERROR is returned if `TPM_RC_HANDLE` is the return code from a TPM2_NV_ReadPublic command. However, in the TCG TPM Library Part 3: Commands specification, `TPM_RC_HANDLE` is a return code if:

  1. An Index does not exist that corresponds to the handle (TPM_RC_HANDLE)
  2. The hierarchy associated with the existing NV Index is not enabled (TPM_RC_HANDLE)

Therefore, return EFI_NOT_FOUND in this case, since that more precisely allows a caller to identify this condition and act on it as opposed to a more generic device error.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

- Verified `EFI_NOT_FOUND` is returned when the return code is `0x8B` in `Tpm2NvReadPublic()`.

## Integration Instructions

Review the new conditions for `EFI_NOT_FOUND` and adjust any status code handling if necessary.