### PR TITLE
RedfishPkg/PlatformConfig: Use en-US if no x-uefi-redfish string

### DIFF
--- a/RedfishPkg/RedfishPlatformConfigDxe/RedfishPlatformConfigDxe.c
+++ b/RedfishPkg/RedfishPlatformConfigDxe/RedfishPlatformConfigDxe.c
@@ -542,8 +542,19 @@ OneOfStatementToAttributeValues (
     }
 
     if (Option->Text != 0) {
-      Values->ValueArray[Index].ValueName        = HiiGetRedfishAsciiString (HiiHandle, SchemaName, Option->Text);
       Values->ValueArray[Index].ValueDisplayName = HiiGetEnglishAsciiString (HiiHandle, Option->Text);
+      Values->ValueArray[Index].ValueName        = HiiGetRedfishAsciiString (HiiHandle, SchemaName, Option->Text);
+      if (Values->ValueArray[Index].ValueName == NULL) {
+        DEBUG ((DEBUG_MANAGEABILITY, "%a: Redfish x-UEFI string is not found.\n", __func__));
+        //
+        // No x-UEFI-redfish string defined. Try to get string in English.
+        //
+        Values->ValueArray[Index].ValueName =
+          AllocateCopyPool (AsciiStrSize (Values->ValueArray[Index].ValueDisplayName), (VOID *)Values->ValueArray[Index].ValueDisplayName);
+        if (Values->ValueArray[Index].ValueName == NULL) {
+          DEBUG ((DEBUG_MANAGEABILITY, "%a: Both Redfish and English string are not found.\n", __func__));
+        }
+      }
     }
 
     Index += 1;
@@ -1309,8 +1320,16 @@ HiiValueToRedfishValue (
 
       RedfishValue->Value.Buffer = HiiGetRedfishAsciiString (HiiHandle, FullSchema, StringId);
       if (RedfishValue->Value.Buffer == NULL) {
-        Status = EFI_OUT_OF_RESOURCES;
-        break;
+        DEBUG ((DEBUG_MANAGEABILITY, "%a: Redfish x-UEFI string is not found.\n", __func__));
+        //
+        // No x-UEFI-redfish string defined. Try to get string in English.
+        //
+        RedfishValue->Value.Buffer = HiiGetEnglishAsciiString (HiiHandle, StringId);
+        if (RedfishValue->Value.Buffer == NULL) {
+          DEBUG ((DEBUG_MANAGEABILITY, "%a: Both Redfish and English string are not found.\n", __func__));
+          Status = EFI_OUT_OF_RESOURCES;
+          break;
+        }
       }
 
       RedfishValue->Type = RedfishValueTypeString;
@@ -1399,6 +1418,18 @@ HiiValueToRedfishValue (
         }
 
         RedfishValue->Value.StringArray[Index] = HiiGetRedfishAsciiString (HiiHandle, FullSchema, StringIdArray[Index]);
+        if (RedfishValue->Value.StringArray[Index] == NULL) {
+          DEBUG ((DEBUG_MANAGEABILITY, "%a: Redfish x-UEFI string is not found.\n", __func__));
+          //
+          // No x-UEFI-redfish string defined. Try to get string in English.
+          //
+          RedfishValue->Value.StringArray[Index] = HiiGetEnglishAsciiString (HiiHandle, StringIdArray[Index]);
+          if (RedfishValue->Value.StringArray[Index] == NULL) {
+            DEBUG ((DEBUG_MANAGEABILITY, "%a: Both Redfish and English string are not found.\n", __func__));
+            Status = EFI_OUT_OF_RESOURCES;
+          }
+        }
+
         ASSERT (RedfishValue->Value.StringArray[Index] != NULL);
       }
 
@@ -1418,6 +1449,7 @@ HiiValueToRedfishValue (
 
       RedfishValue->Value.Buffer = HiiGetRedfishAsciiString (HiiHandle, FullSchema, HiiStatement->ExtraData.TextTwo);
       if (RedfishValue->Value.Buffer == NULL) {
+        DEBUG ((DEBUG_MANAGEABILITY, "%a: Redfish x-UEFI string is not found.\n", __func__));
         //
         // No x-UEFI-redfish string defined. Try to get string in English.
         //


### PR DESCRIPTION
Search en-US HII value string if x-uefi-redfish language of the value string is not found. Because not all of the HII value strings have the x-uefi-redfish language string define, such as "Enabled" or "Disabled".

# Description

Search en-US HII value string if x-uefi-redfish language of the value string is not found. Because not all of the HII value string has the x-uefi-redfish language string. Such as "Enabled" or "Disabled".

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

If there is no x-uefi-redfish language of the value string in the HII string database, HiiGetRedfishAsciiString returns the NULL string.

## Integration Instructions
N/A