### PR TITLE
.github/upl-build.yml: switch to windows-2025

### DIFF
--- a/.github/workflows/upl-build.yml
+++ b/.github/workflows/upl-build.yml
@@ -17,7 +17,7 @@ jobs:
   build_vs2022:
     strategy:
       matrix:
-        os: [windows-latest]
+        os: [windows-2025]
         python-version: ['3.12']
         tool-chain: ['VS2022']
         target: ['DEBUG']


### PR DESCRIPTION
windows-latest will be migrated to the Windows Server 2025 soon, and currently UPL will automatically switch over.

Going forward UPL will explicitly set the version of Windows so we do not automatically switch to newer version without verification.

Set to windows-2025 for now.

# Description

<_Include a description of the change and why this change was made._>

<_For each item, place an "x" in between `[` and `]` if true. Example: `[x]` (you can also check items in GitHub UI)_>

<_Create the PR as a Draft PR if it is only created to run CI checks._>

<_Delete lines in \<\> tags before creating the PR._>

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

<_Describe the test(s) that were run to verify the changes._>

## Integration Instructions

<_Describe how these changes should be integrated. Use N/A if nothing is required._>
