### PR TITLE
MdePkg: Acpi66: Add defined IOVT Signature

### DIFF
--- a/MdePkg/Include/IndustryStandard/Acpi66.h
+++ b/MdePkg/Include/IndustryStandard/Acpi66.h
@@ -3425,6 +3425,11 @@ typedef struct {
 #define EFI_ACPI_6_6_IO_REMAPPING_TABLE_SIGNATURE  SIGNATURE_32('I', 'O', 'R', 'T')
 
 ///
+/// "IOVT" I/O Virtualization Table
+///
+#define EFI_ACPI_6_6_IO_VIRTUALIZATION_TABLE_SIGNATURE  SIGNATURE_32('I', 'O', 'V', 'T')
+
+///
 /// "IVRS" I/O Virtualization Reporting Structure
 ///
 #define EFI_ACPI_6_6_IO_VIRTUALIZATION_REPORTING_STRUCTURE_SIGNATURE  SIGNATURE_32('I', 'V', 'R', 'S')


### PR DESCRIPTION
ACPI 6.6 introduced new Virtualization Table for LoongArch. This follow-up will provide configuration for IOMMU.

REF: https://uefi.org/sites/default/files/resources/ACPI_Spec_6.6.pdf
Table5.6: “IOVT” I/O Virtualization Table.

Reported-by: Xianglai Li <lixianglai@loongson.cn>
Signed-off-by: Dongyan Qian <qiandongyan@loongson.cn>

# Description

<_Include a description of the change and why this change was made._>

<_For each item, place an "x" in between `[` and `]` if true. Example: `[x]` (you can also check items in GitHub UI)_>

<_Create the PR as a Draft PR if it is only created to run CI checks._>

<_Delete lines in \<\> tags before creating the PR._>

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

<_Describe the test(s) that were run to verify the changes._>

## Integration Instructions

<_Describe how these changes should be integrated. Use N/A if nothing is required._>
