### PR TITLE
RedfishPkg/ConfigHandler: Redfish transport interface disconnection

### DIFF
--- a/RedfishPkg/RedfishConfigHandler/RedfishConfigHandlerCommon.h
+++ b/RedfishPkg/RedfishConfigHandler/RedfishConfigHandlerCommon.h
@@ -30,6 +30,7 @@
 //
 #include <Protocol/EdkIIRedfishCredential.h>
 #include <Protocol/EdkIIRedfishConfigHandler.h>
+#include <Protocol/RestEx.h>
 
 //
 // Driver Version

--- a/RedfishPkg/RedfishConfigHandler/RedfishConfigHandlerDriver.inf
+++ b/RedfishPkg/RedfishConfigHandler/RedfishConfigHandlerDriver.inf
@@ -55,8 +55,9 @@
   gEdkIIRedfishHostInterfaceReadyProtocolGuid  ## CONSUMES
 
 [Guids]
-  gEfiEventExitBootServicesGuid           ## CONSUMES ## Event
-  gEfiEndOfDxeEventGroupGuid              ## CONSUMES ## Event
+  gEfiEventExitBootServicesGuid                       ## CONSUMES ## Event
+  gEfiEndOfDxeEventGroupGuid                          ## CONSUMES ## Event
+  gEdkIIRedfisEventRedfishInterfaceDisconnectionGuid  ## CONSUMES ## Event
 
 [Depex]
   gEdkIIRedfishCredentialProtocolGuid

--- a/RedfishPkg/RedfishPkg.dec
+++ b/RedfishPkg/RedfishPkg.dec
@@ -116,6 +116,9 @@
   # Redfish variable guid
   gEfiRedfishVariableGuid           = { 0x85ef8dd3, 0xe606, 0x4b89, { 0x8b, 0xbd, 0x93, 0xbf, 0x5c, 0xbe, 0x1c, 0x18 } }
 
+  # Redfish Configuration Handler Disconnection
+  gEdkIIRedfisEventRedfishInterfaceDisconnectionGuid = { 0x11B81837, 0x249B, 0x4843, { 0xA5, 0x2C, 0xC8, 0x23, 0x7B, 0x35, 0xBF, 0xC2 } }
+
 [PcdsFixedAtBuild, PcdsPatchableInModule]
   #
   # This PCD is the UEFI device path which is used as the Redfish host interface.


### PR DESCRIPTION
Provide an event for the Redfish client to signal Redfish configuration handler driver to disconnect from the Redfish transport interface.

# Description

Provide an event for the Redfish client to signal Redfish
configuration handler driver to disconnect from the Redfish
transport interface.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

While Redfish is enabled, reboot the system to see if the HTTP session is closed on BMC side.

## Integration Instructions

N/A
