### PR TITLE
MdeModulePkg/ConSplitterDxe: Add debug log for console output modes

### DIFF
--- a/MdeModulePkg/Universal/Console/ConSplitterDxe/ConSplitter.c
+++ b/MdeModulePkg/Universal/Console/ConSplitterDxe/ConSplitter.c
@@ -1290,8 +1290,11 @@ ConSplitterConOutDriverBindingStart (
   EFI_STATUS                            Status;
   EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL       *TextOut;
   EFI_GRAPHICS_OUTPUT_PROTOCOL          *GraphicsOutput;
+  UINT32                                ModeIndex;
   UINTN                                 SizeOfInfo;
   EFI_GRAPHICS_OUTPUT_MODE_INFORMATION  *Info;
+  UINTN                                 Columns;
+  UINTN                                 Rows;
 
   //
   // Start ConSplitter on ControllerHandle, and create the virtual
@@ -1345,6 +1348,22 @@ ConSplitterConOutDriverBindingStart (
 
     FreePool (Info);
   }
+
+  DEBUG_CODE_BEGIN ();
+  for (ModeIndex = 0; ModeIndex < (UINTN)gST->ConOut->Mode->MaxMode; ModeIndex++) {
+    Status = gST->ConOut->QueryMode (gST->ConOut, ModeIndex, &Columns, &Rows);
+    if (!EFI_ERROR (Status)) {
+      DEBUG ((
+        DEBUG_INFO,
+        "ConsoleOut - Mode = %d, Column = %u, Row = %u\n",
+        ModeIndex,
+        Columns,
+        Rows
+        ));
+    }
+  }
+
+  DEBUG_CODE_END ();
 
   return Status;
 }


### PR DESCRIPTION
Add a debug log in ConSplitterConOutDriverBindingStart() to print each available console output mode by calling QueryMode() on gST->ConOut. This helps verify the aggregated console modes after a new output device is added. No change in RELEASE builds.

# Description
The ConSplitter driver manages GraphicsConsoleDxe, TerminalDxe, with the final console output mode being the intersection of the modes from these drivers. This change adds a modification that allows available modes to be diagnosed and logged in the debug log, eliminating the need to use the mode command in the shell for this information.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested
1. build -a X64 -p OvmfPkg/OvmfPkgX64.dsc -t GCC5
2. qemu-system-x86_64 \
  -pflash /home/r1chard/Workspace/edk2/Build/OvmfX64/DEBUG_GCC5/FV/OVMF.fd \
  -hda fat:rw:hda-contents \
  -net none \
  -debugcon file:debug.log \
  -global isa-debugcon.iobase=0x402  \
  -nographic
3. After checking the debug.log, you will find
```
ConsoleOut - Mode = 0, Column = 80, Row = 25
ConsoleOut - Mode = 1, Column = 80, Row = 50
ConsoleOut - Mode = 2, Column = 100, Row = 31
ConsoleOut - Mode = 3, Column = 128, Row = 40
ConsoleOut - Mode = 4, Column = 160, Row = 42
ConsoleOut - Mode = 5, Column = 240, Row = 56
```

## Integration Instructions
N/A
