### PR TITLE
MdeModulePkg/DxeMain: Add debug code for Event Group notify functions

### DIFF
--- a/MdeModulePkg/Core/Dxe/Event/Event.c
+++ b/MdeModulePkg/Core/Dxe/Event/Event.c
@@ -3,6 +3,7 @@
 
 Copyright (c) 2006 - 2017, Intel Corporation. All rights reserved.<BR>
 (C) Copyright 2015 Hewlett Packard Enterprise Development LP<BR>
+Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -183,6 +184,13 @@ CoreDispatchEventNotifies (
     // Notify this event
     //
     ASSERT (Event->NotifyFunction != NULL);
+
+    if ((Event->Type & EVT_NOTIFY_SIGNAL) != 0) {
+      if (!IsZeroGuid (&Event->EventGroup) && !CompareGuid (&Event->EventGroup, &gIdleLoopEventGuid)) {
+        DEBUG ((DEBUG_EVENT, "Run Event Group Notify: %g (%p)\n", &Event->EventGroup, Event->NotifyFunction));
+      }
+    }
+
     Event->NotifyFunction (Event, Event->NotifyContext);
 
     //
@@ -485,7 +493,11 @@ CoreCreateEventInternal (
 
   CoreAcquireEventLock ();
 
-  if ((Type & EVT_NOTIFY_SIGNAL) != 0x00000000) {
+  if ((Type & EVT_NOTIFY_SIGNAL) != 0) {
+    if (!IsZeroGuid (&IEvent->EventGroup) && !CompareGuid (&IEvent->EventGroup, &gIdleLoopEventGuid)) {
+      DEBUG ((DEBUG_EVENT, "Register Event Group Notify: %g (%p)\n", &IEvent->EventGroup, IEvent->NotifyFunction));
+    }
+
     //
     // The Event's NotifyFunction must be queued whenever the event is signaled
     //


### PR DESCRIPTION
There are a lot of notify callback events for Event Groups. Usually they are not reported unless there is a debug code in the callback itself. The debug message helps to check which/when the callback is registered and executed in POST. Also helps to notice the callback sequence. It depends on DEBUG_EVENT flag enabled by PcdFixedDebugPrintErrorLevel PCD token.

Enablement : 
Set DEBUG_EVENT flag to PcdFixedDebugPrintErrorLevel PCD token.
```c
# DEBUG_EVENT  0x00080000  // Event messages.
``` 

Major Event Groups : 
```c
gEfiEndOfDxeEventGroupGuid          = {0X02CE967A, 0XDD7E, 0X4FFC, {0X9E, 0XE7, 0X81, 0X0C, 0XF0, 0X47, 0X08, 0X80}}
gEfiEventReadyToBootGuid            = {0X7CE88FB3, 0X4BD7, 0X4679, {0X87, 0XA8, 0XA8, 0XD8, 0XDE, 0XE5, 0X0D, 0X2B}}
gEfiEventAfterReadyToBootGuid       = {0X3A2A00AD, 0X98B9, 0X4CDF, {0XA4, 0X78, 0X70, 0X27, 0X77, 0XF1, 0XC1, 0X0B}}
gEfiEventBeforeExitBootServicesGuid = {0X8BE0E274, 0X3970, 0X4B44, {0X80, 0XC5, 0X1A, 0XB9, 0X50, 0X2F, 0X3B, 0XFC}}
gEfiEventExitBootServicesGuid       = {0X27ABF055, 0XB1B8, 0X4C26, {0X80, 0X48, 0X74, 0X8F, 0X37, 0XBA, 0XA2, 0XDF}}
``` 
Sample Debug Messages :
...
MpInitLibInitialize: ProcessorIndex=0 CpuCount=16
AP Loop Mode is 2
AP Vector: non-16-bit = 6F598000/48D
FirstMpHandOff->WaitLoopExecutionMode: 0008, sizeof (VOID *): 0008
AP Page Table Buffer Size = 4000
**Register Event Group Notify: 27ABF055-B1B8-4C26-8048-748F37BAA2DF (6F2095D8)**
Register Event Group Notify: 2A571201-4966-47F6-8B86-F31E41F32F10 (6F2095D8)
Detect CPU count: 16
InstallProtocolInterface: 3FDDA605-A76E-4F46-AD29-12F4531B3D08 6F214270
...
LockBoxGuid - 627EE2DA-3BF9-439B-929F-2E0E6E9DBA62, SmramBuffer - 0x7B2E7000, Length - 0x18
SmmLockBoxSmmLib SaveLockBox - Exit (Success)
SmmLockBoxSmmLib SetLockBoxAttributes - Enter
SmmLockBoxSmmLib SetLockBoxAttributes - Exit (Success)
**Run Event Group Notify: 27ABF055-B1B8-4C26-8048-748F37BAA2DF (6F2095D8)**
MpInitChangeApLoopCallback() done!
...
- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

The update has been tested and verified on AMD platforms.

## Integration Instructions

N/A
