### PR TITLE
Sathya/variable policy

### DIFF
--- a/MdeModulePkg/Universal/CapsuleRuntimeDxe/CapsuleRuntimeDxe.inf
+++ b/MdeModulePkg/Universal/CapsuleRuntimeDxe/CapsuleRuntimeDxe.inf
@@ -64,6 +64,7 @@
   PrintLib
   BaseMemoryLib
   CacheMaintenanceLib
+  VariablePolicyHelperLib
 
 [LibraryClasses.X64]
   UefiLib
@@ -81,7 +82,7 @@
 [Protocols.X64]
   ## UNDEFINED ## NOTIFY
   ## SOMETIMES_CONSUMES
-  gEdkiiVariableLockProtocolGuid
+  gEdkiiVariablePolicyProtocolGuid
 
 [FeaturePcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdSupportUpdateCapsuleReset        ## CONSUMES

--- a/MdeModulePkg/Universal/CapsuleRuntimeDxe/X64/SaveLongModeContext.c
+++ b/MdeModulePkg/Universal/CapsuleRuntimeDxe/X64/SaveLongModeContext.c
@@ -11,7 +11,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #include <Protocol/Capsule.h>
 #include <Protocol/DxeSmmReadyToLock.h>
-#include <Protocol/VariableLock.h>
+#include <Library/VariablePolicyHelperLib.h>
 
 #include <Guid/CapsuleVendor.h>
 #include <Guid/AcpiS3Context.h>
@@ -68,7 +68,7 @@ AllocateReservedMemoryBelow4G (
 }
 
 /**
-  Register callback function upon VariableLockProtocol
+  Register callback function upon VariablePolicyProtocol
   to lock EFI_CAPSULE_LONG_MODE_BUFFER_NAME variable to avoid malicious code to update it.
 
   @param[in] Event    Event whose notification function is being invoked.
@@ -82,14 +82,24 @@ VariableLockCapsuleLongModeBufferVariable (
   )
 {
   EFI_STATUS                    Status;
-  EDKII_VARIABLE_LOCK_PROTOCOL  *VariableLock;
+  IN EDKII_VARIABLE_POLICY_PROTOCOL  *VariablePolicy;
 
   //
-  // Mark EFI_CAPSULE_LONG_MODE_BUFFER_NAME variable to read-only if the Variable Lock protocol exists
+  // Mark EFI_CAPSULE_LONG_MODE_BUFFER_NAME variable to read-only if the Variable Policy protocol exists
   //
-  Status = gBS->LocateProtocol (&gEdkiiVariableLockProtocolGuid, NULL, (VOID **)&VariableLock);
+  Status = gBS->LocateProtocol (&gEdkiiVariablePolicyProtocolGuid, NULL, (VOID **)&VariablePolicy);
   if (!EFI_ERROR (Status)) {
-    Status = VariableLock->RequestToLock (VariableLock, EFI_CAPSULE_LONG_MODE_BUFFER_NAME, &gEfiCapsuleVendorGuid);
+    Status = RegisterBasicVariablePolicy (
+            VariablePolicy,
+            &gEfiCapsuleVendorGuid,
+            EFI_CAPSULE_LONG_MODE_BUFFER_NAME,
+            VARIABLE_POLICY_NO_MIN_SIZE,
+            VARIABLE_POLICY_NO_MAX_SIZE,
+            VARIABLE_POLICY_NO_MUST_ATTR,
+            VARIABLE_POLICY_NO_CANT_ATTR,
+            VARIABLE_POLICY_TYPE_LOCK_NOW
+            );
+    DEBUG ((DEBUG_INFO, "Status of RegisterBasicVariablePolicy for (%s) - %r\n", EFI_CAPSULE_LONG_MODE_BUFFER_NAME, Status));
     ASSERT_EFI_ERROR (Status);
   }
 }
@@ -177,11 +187,11 @@ PrepareContextForCapsulePei (
                   );
   if (!EFI_ERROR (Status)) {
     //
-    // Register callback function upon VariableLockProtocol
+    // Register callback function upon VariablePolicyProtocol
     // to lock EFI_CAPSULE_LONG_MODE_BUFFER_NAME variable to avoid malicious code to update it.
     //
     EfiCreateProtocolNotifyEvent (
-      &gEdkiiVariableLockProtocolGuid,
+      &gEdkiiVariablePolicyProtocolGuid,
       TPL_CALLBACK,
       VariableLockCapsuleLongModeBufferVariable,
       NULL,

--- a/MdeModulePkg/Universal/EsrtDxe/EsrtDxe.c
+++ b/MdeModulePkg/Universal/EsrtDxe/EsrtDxe.c
@@ -480,17 +480,37 @@ EsrtDxeLockEsrtRepository (
   )
 {
   EFI_STATUS                    Status;
-  EDKII_VARIABLE_LOCK_PROTOCOL  *VariableLock;
+  IN EDKII_VARIABLE_POLICY_PROTOCOL  *VariablePolicy;
 
   //
-  // Mark ACPI_GLOBAL_VARIABLE variable to read-only if the Variable Lock protocol exists
+  // Mark ACPI_GLOBAL_VARIABLE variable to read-only if the Variable Policy protocol exists
   //
-  Status = gBS->LocateProtocol (&gEdkiiVariableLockProtocolGuid, NULL, (VOID **)&VariableLock);
+  Status = gBS->LocateProtocol (&gEdkiiVariablePolicyProtocolGuid, NULL, (VOID **)&VariablePolicy);
   if (!EFI_ERROR (Status)) {
-    Status = VariableLock->RequestToLock (VariableLock, EFI_ESRT_FMP_VARIABLE_NAME, &gEfiCallerIdGuid);
+    Status = RegisterBasicVariablePolicy (
+              VariablePolicy,
+              &gEfiCallerIdGuid,
+              EFI_ESRT_FMP_VARIABLE_NAME,
+              VARIABLE_POLICY_NO_MIN_SIZE,
+              VARIABLE_POLICY_NO_MAX_SIZE,
+              VARIABLE_POLICY_NO_MUST_ATTR,
+              VARIABLE_POLICY_NO_CANT_ATTR,
+              VARIABLE_POLICY_TYPE_LOCK_NOW
+              );
+
     DEBUG ((DEBUG_INFO, "EsrtDxe Lock EsrtFmp Variable Status 0x%x", Status));
 
-    Status = VariableLock->RequestToLock (VariableLock, EFI_ESRT_NONFMP_VARIABLE_NAME, &gEfiCallerIdGuid);
+    Status = RegisterBasicVariablePolicy (
+              VariablePolicy,
+              &gEfiCallerIdGuid,
+              EFI_ESRT_NONFMP_VARIABLE_NAME,
+              VARIABLE_POLICY_NO_MIN_SIZE,
+              VARIABLE_POLICY_NO_MAX_SIZE,
+              VARIABLE_POLICY_NO_MUST_ATTR,
+              VARIABLE_POLICY_NO_CANT_ATTR,
+              VARIABLE_POLICY_TYPE_LOCK_NOW
+              );
+
     DEBUG ((DEBUG_INFO, "EsrtDxe Lock EsrtNonFmp Variable Status 0x%x", Status));
   }
 

--- a/MdeModulePkg/Universal/EsrtDxe/EsrtDxe.inf
+++ b/MdeModulePkg/Universal/EsrtDxe/EsrtDxe.inf
@@ -43,6 +43,7 @@
   DxeServicesTableLib
   UefiBootServicesTableLib
   UefiRuntimeServicesTableLib
+  VariablePolicyHelperLib                 
 
 [Guids]
   gEfiSystemResourceTableGuid             ## PRODUCES             ## SystemTable
@@ -51,7 +52,7 @@
 [Protocols]
   gEfiFirmwareManagementProtocolGuid      ## SOMETIMES_CONSUMES
   gEsrtManagementProtocolGuid             ## PRODUCES
-  gEdkiiVariableLockProtocolGuid          ## SOMETIMES_CONSUMES
+  gEdkiiVariablePolicyProtocolGuid        ## SOMETIMES_CONSUMES
 
 [Pcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdMaxFmpEsrtCacheNum                  ## CONSUMES

--- a/MdeModulePkg/Universal/EsrtDxe/EsrtImpl.h
+++ b/MdeModulePkg/Universal/EsrtDxe/EsrtImpl.h
@@ -25,7 +25,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #include <Protocol/FirmwareManagement.h>
 #include <Protocol/EsrtManagement.h>
-#include <Protocol/VariableLock.h>
+#include <Library/VariablePolicyHelperLib.h>
 
 //
 // Name of  Variable for Non-FMP ESRT Repository

--- a/MdeModulePkg/Universal/PCD/Dxe/Pcd.c
+++ b/MdeModulePkg/Universal/PCD/Dxe/Pcd.c
@@ -167,7 +167,7 @@ PcdDxeInit (
   // to lock the variables referenced by DynamicHii PCDs with RO property set in *.dsc.
   //
   EfiCreateProtocolNotifyEvent (
-    &gEdkiiVariableLockProtocolGuid,
+    &gEdkiiVariablePolicyProtocolGuid,
     TPL_CALLBACK,
     VariableLockCallBack,
     NULL,

--- a/MdeModulePkg/Universal/PCD/Dxe/Pcd.inf
+++ b/MdeModulePkg/Universal/PCD/Dxe/Pcd.inf
@@ -322,6 +322,7 @@
   BaseLib
   PcdLib
   DxeServicesLib
+  VariablePolicyHelperLib
 
 [Guids]
   gPcdDataBaseHobGuid                           ## SOMETIMES_CONSUMES  ## HOB
@@ -335,7 +336,7 @@
   gEfiGetPcdInfoProtocolGuid                    ## SOMETIMES_PRODUCES
   ## NOTIFY
   ## SOMETIMES_CONSUMES
-  gEdkiiVariableLockProtocolGuid
+  gEdkiiVariablePolicyProtocolGuid
 
 [Pcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdVpdBaseAddress      ## SOMETIMES_CONSUMES

--- a/MdeModulePkg/Universal/PCD/Dxe/Service.c
+++ b/MdeModulePkg/Universal/PCD/Dxe/Service.c
@@ -1839,13 +1839,13 @@ SetPtrTypeSize (
 
   @param[in] IsPeiDb        If TRUE, the pcd entry is initialized in PEI phase,
                             If FALSE, the pcd entry is initialized in DXE phase.
-  @param[in] VariableLock   Pointer to VariableLockProtocol.
+  @param[in] VariableLock   Pointer to VariablePolicyProtocol.
 
 **/
 VOID
 VariableLockDynamicHiiPcd (
   IN BOOLEAN                       IsPeiDb,
-  IN EDKII_VARIABLE_LOCK_PROTOCOL  *VariableLock
+  IN EDKII_VARIABLE_POLICY_PROTOCOL  *VariablePolicy
   )
 {
   EFI_STATUS         Status;
@@ -1890,7 +1890,17 @@ VariableLockDynamicHiiPcd (
         GuidTable   = (EFI_GUID *)((UINT8 *)Database + Database->GuidTableOffset);
         Guid        = GuidTable + VariableHead->GuidTableIndex;
         Name        = (UINT16 *)(StringTable + VariableHead->StringIndex);
-        Status      = VariableLock->RequestToLock (VariableLock, Name, Guid);
+        Status = RegisterBasicVariablePolicy (
+                      VariablePolicy,
+                      Guid,
+                      Name,
+                      VARIABLE_POLICY_NO_MIN_SIZE,
+                      VARIABLE_POLICY_NO_MAX_SIZE,
+                      VARIABLE_POLICY_NO_MUST_ATTR,
+                      VARIABLE_POLICY_NO_CANT_ATTR,
+                      VARIABLE_POLICY_TYPE_LOCK_NOW
+                  );
+
         ASSERT_EFI_ERROR (Status);
       }
     }
@@ -1898,7 +1908,7 @@ VariableLockDynamicHiiPcd (
 }
 
 /**
-  VariableLockProtocol callback
+  VariablePolicyProtocol callback
   to lock the variables referenced by DynamicHii PCDs with RO property set in *.dsc.
 
   @param[in] Event      Event whose notification function is being invoked.
@@ -1913,11 +1923,11 @@ VariableLockCallBack (
   )
 {
   EFI_STATUS                    Status;
-  EDKII_VARIABLE_LOCK_PROTOCOL  *VariableLock;
+  EDKII_VARIABLE_POLICY_PROTOCOL    *VariablePolicy;
 
-  Status = gBS->LocateProtocol (&gEdkiiVariableLockProtocolGuid, NULL, (VOID **)&VariableLock);
+  Status = gBS->LocateProtocol (&gEdkiiVariablePolicyProtocolGuid, NULL, (VOID **)&VariablePolicy);
   if (!EFI_ERROR (Status)) {
-    VariableLockDynamicHiiPcd (TRUE, VariableLock);
-    VariableLockDynamicHiiPcd (FALSE, VariableLock);
+    VariableLockDynamicHiiPcd (TRUE, VariablePolicy);
+    VariableLockDynamicHiiPcd (FALSE, VariablePolicy);
   }
 }

--- a/MdeModulePkg/Universal/PCD/Dxe/Service.h
+++ b/MdeModulePkg/Universal/PCD/Dxe/Service.h
@@ -17,7 +17,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Protocol/PcdInfo.h>
 #include <Protocol/PiPcdInfo.h>
 #include <Protocol/VarCheck.h>
-#include <Protocol/VariableLock.h>
+#include <Library/VariablePolicyHelperLib.h>
 #include <Library/BaseLib.h>
 #include <Library/DebugLib.h>
 #include <Library/UefiLib.h>

--- a/SecurityPkg/Library/DxeTcg2PhysicalPresenceLib/DxeTcg2PhysicalPresenceLib.c
+++ b/SecurityPkg/Library/DxeTcg2PhysicalPresenceLib/DxeTcg2PhysicalPresenceLib.c
@@ -15,7 +15,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <PiDxe.h>
 
 #include <Protocol/Tcg2Protocol.h>
-#include <Protocol/VariableLock.h>
+#include <Library/VariablePolicyHelperLib.h>
 #include <Library/DebugLib.h>
 #include <Library/BaseMemoryLib.h>
 #include <Library/UefiRuntimeServicesTableLib.h>
@@ -918,20 +918,26 @@ Tcg2PhysicalPresenceLibProcessRequest (
   EFI_STATUS                        Status;
   UINTN                             DataSize;
   EFI_TCG2_PHYSICAL_PRESENCE        TcgPpData;
-  EDKII_VARIABLE_LOCK_PROTOCOL      *VariableLockProtocol;
+  EDKII_VARIABLE_POLICY_PROTOCOL    *VariablePolicyProtocol;
   EFI_TCG2_PHYSICAL_PRESENCE_FLAGS  PpiFlags;
 
   //
   // This flags variable controls whether physical presence is required for TPM command.
   // It should be protected from malicious software. We set it as read-only variable here.
   //
-  Status = gBS->LocateProtocol (&gEdkiiVariableLockProtocolGuid, NULL, (VOID **)&VariableLockProtocol);
+  Status = gBS->LocateProtocol (&gEdkiiVariablePolicyProtocolGuid, NULL, (VOID **)&VariablePolicyProtocol);
   if (!EFI_ERROR (Status)) {
-    Status = VariableLockProtocol->RequestToLock (
-                                     VariableLockProtocol,
-                                     TCG2_PHYSICAL_PRESENCE_FLAGS_VARIABLE,
-                                     &gEfiTcg2PhysicalPresenceGuid
-                                     );
+    Status = RegisterBasicVariablePolicy (
+                VariablePolicyProtocol,
+                &gEfiTcg2PhysicalPresenceGuid,
+                TCG2_PHYSICAL_PRESENCE_FLAGS_VARIABLE,
+                VARIABLE_POLICY_NO_MIN_SIZE,
+                VARIABLE_POLICY_NO_MAX_SIZE,
+                VARIABLE_POLICY_NO_MUST_ATTR,
+                VARIABLE_POLICY_NO_CANT_ATTR,
+                VARIABLE_POLICY_TYPE_LOCK_NOW
+               );
+
     if (EFI_ERROR (Status)) {
       DEBUG ((DEBUG_ERROR, "[TPM2] Error when lock variable %s, Status = %r\n", TCG2_PHYSICAL_PRESENCE_FLAGS_VARIABLE, Status));
       ASSERT_EFI_ERROR (Status);

--- a/SecurityPkg/Library/DxeTcg2PhysicalPresenceLib/DxeTcg2PhysicalPresenceLib.inf
+++ b/SecurityPkg/Library/DxeTcg2PhysicalPresenceLib/DxeTcg2PhysicalPresenceLib.inf
@@ -50,10 +50,11 @@
   HobLib
   Tpm2CommandLib
   Tcg2PpVendorLib
+  VariablePolicyHelperLib
 
 [Protocols]
   gEfiTcg2ProtocolGuid                 ## SOMETIMES_CONSUMES
-  gEdkiiVariableLockProtocolGuid       ## SOMETIMES_CONSUMES
+  gEdkiiVariablePolicyProtocolGuid       ## SOMETIMES_CONSUMES
 
 [Pcd]
   gEfiSecurityPkgTokenSpaceGuid.PcdTcg2PhysicalPresenceFlags       ## SOMETIMES_CONSUMES

--- a/SecurityPkg/Library/DxeTcgPhysicalPresenceLib/DxeTcgPhysicalPresenceLib.c
+++ b/SecurityPkg/Library/DxeTcgPhysicalPresenceLib/DxeTcgPhysicalPresenceLib.c
@@ -16,7 +16,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <PiDxe.h>
 
 #include <Protocol/TcgService.h>
-#include <Protocol/VariableLock.h>
+#include <Library/VariablePolicyHelperLib.h>
 #include <Library/DebugLib.h>
 #include <Library/BaseMemoryLib.h>
 #include <Library/UefiRuntimeServicesTableLib.h>
@@ -1189,7 +1189,7 @@ TcgPhysicalPresenceLibProcessRequest (
   UINTN                         DataSize;
   EFI_PHYSICAL_PRESENCE         TcgPpData;
   EFI_TCG_PROTOCOL              *TcgProtocol;
-  EDKII_VARIABLE_LOCK_PROTOCOL  *VariableLockProtocol;
+  EDKII_VARIABLE_POLICY_PROTOCOL  *VariablePolicyProtocol;
   EFI_PHYSICAL_PRESENCE_FLAGS   PpiFlags;
 
   Status = gBS->LocateProtocol (&gEfiTcgProtocolGuid, NULL, (VOID **)&TcgProtocol);
@@ -1229,13 +1229,19 @@ TcgPhysicalPresenceLibProcessRequest (
   // This flags variable controls whether physical presence is required for TPM command.
   // It should be protected from malicious software. We set it as read-only variable here.
   //
-  Status = gBS->LocateProtocol (&gEdkiiVariableLockProtocolGuid, NULL, (VOID **)&VariableLockProtocol);
+  Status = gBS->LocateProtocol (&gEdkiiVariablePolicyProtocolGuid, NULL, (VOID **)&VariablePolicyProtocol);
   if (!EFI_ERROR (Status)) {
-    Status = VariableLockProtocol->RequestToLock (
-                                     VariableLockProtocol,
-                                     PHYSICAL_PRESENCE_FLAGS_VARIABLE,
-                                     &gEfiPhysicalPresenceGuid
-                                     );
+    Status = RegisterBasicVariablePolicy (
+              VariablePolicyProtocol,
+              &gEfiPhysicalPresenceGuid,
+              PHYSICAL_PRESENCE_FLAGS_VARIABLE,
+              VARIABLE_POLICY_NO_MIN_SIZE,
+              VARIABLE_POLICY_NO_MAX_SIZE,
+              VARIABLE_POLICY_NO_MUST_ATTR,
+              VARIABLE_POLICY_NO_CANT_ATTR,
+              VARIABLE_POLICY_TYPE_LOCK_NOW
+              );
+
     if (EFI_ERROR (Status)) {
       DEBUG ((DEBUG_ERROR, "[TPM] Error when lock variable %s, Status = %r\n", PHYSICAL_PRESENCE_FLAGS_VARIABLE, Status));
       ASSERT_EFI_ERROR (Status);

--- a/SecurityPkg/Library/DxeTcgPhysicalPresenceLib/DxeTcgPhysicalPresenceLib.inf
+++ b/SecurityPkg/Library/DxeTcgPhysicalPresenceLib/DxeTcgPhysicalPresenceLib.inf
@@ -50,10 +50,11 @@
   PrintLib
   HiiLib
   TcgPpVendorLib
+  VariablePolicyHelperLib
 
 [Protocols]
   gEfiTcgProtocolGuid                   ## SOMETIMES_CONSUMES
-  gEdkiiVariableLockProtocolGuid        ## SOMETIMES_CONSUMES
+  gEdkiiVariablePolicyProtocolGuid        ## SOMETIMES_CONSUMES
 
 [Guids]
   ## SOMETIMES_CONSUMES ## HII


### PR DESCRIPTION
# Description

The gEdkiiVariableLockProtocolGuid used for variable locking is deprecated.
It is replaced by gEdkiiVariablePolicyProtocolGuid, where
DxeRequestToLock() is replaced by RegisterBasicVariablePolicy().

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Tried to access the locked variables after EndOfDxe event.
(Tried to access in UEFI Shell).

## Integration Instructions

N/A
