### PR TITLE
PrmPkg: PrmSample Make build options Clang/Gcc compatible.

### DIFF
--- a/PrmPkg/Include/Prm.h
+++ b/PrmPkg/Include/Prm.h
@@ -15,9 +15,9 @@
 #include <PrmContextBuffer.h>
 
 #if defined (_MSC_VER)
-#define PRM_EXPORT_API  __declspec(dllexport)
+#define PRM_EXPORT_API  volatile __declspec(dllexport)
 #elif defined (__GNUC__)
-#define PRM_EXPORT_API  __attribute__ ((visibility ("default")))
+#define PRM_EXPORT_API  __attribute__((used)) __attribute__ ((visibility ("default")))
 #else
 #define PRM_EXPORT_API
 #endif

--- a/PrmPkg/Readme.md
+++ b/PrmPkg/Readme.md
@@ -73,11 +73,6 @@ on IA32 with the unique UEFI configuration required.
 * AArch64
     ``build -p PrmPkg/PrmPkg.dsc -a AARCH64 -t GCC5``
 
-   > ***Note***: Only builds with the GCC5 toolchain have been tested.
-   > ***Note***: For builds with the GCC5 toolchain, the PrmModuleExportDescriptor and any other handler entry points
-   symbols, to be listed in the PRMT, must be explicitly preserved by enumerating these in the AARCH64 linker flags.
-   The --require-defined linker flag must be used for each symbol to be preserved.
-
 ### PRM Platform GUID
 
 **IMPORTANT** PRM has a concept of a "Platform GUID" which associates a specific platform with a set of PRM modules

--- a/PrmPkg/Samples/PrmSampleAcpiParameterBufferModule/PrmSampleAcpiParameterBufferModule.inf
+++ b/PrmPkg/Samples/PrmSampleAcpiParameterBufferModule/PrmSampleAcpiParameterBufferModule.inf
@@ -43,5 +43,4 @@
   MSFT:*_*_*_GENFW_FLAGS = --keepoptionalheader
 
   GCC:*_*_*_GENFW_FLAGS = --prm
-  GCC:*_*_*_DLINK_FLAGS = -Wl,--no-gc-sections -Wl,--require-defined=PrmModuleExportDescriptor -Wl,--require-defined=CheckParamBufferPrmHandler
-  GCC:*_*_X64_OBJCOPY_STRIPFLAG = --keep-symbol=PrmModuleExportDescriptor --keep-symbol=CheckParamBufferPrmHandler
+  GCC:*_*_*_DLINK_FLAGS = -Wl,--no-gc-sections

--- a/PrmPkg/Samples/PrmSampleContextBufferModule/PrmSampleContextBufferModule.inf
+++ b/PrmPkg/Samples/PrmSampleContextBufferModule/PrmSampleContextBufferModule.inf
@@ -46,5 +46,4 @@
   MSFT:*_*_*_GENFW_FLAGS = --keepoptionalheader
 
   GCC:*_*_*_GENFW_FLAGS = --keepoptionalheader --prm
-  GCC:*_*_*_DLINK_FLAGS = -Wl,--no-gc-sections -Wl,--require-defined=PrmModuleExportDescriptor -Wl,--require-defined=CheckStaticDataBufferPrmHandler
-  GCC:*_*_X64_OBJCOPY_STRIPFLAG = --keep-symbol=PrmModuleExportDescriptor --keep-symbol=CheckStaticDataBufferPrmHandler
+  GCC:*_*_*_DLINK_FLAGS = -Wl,--no-gc-sections


### PR DESCRIPTION
# Description

While attempting to compile PrmSampleAcpiParameterBufferModule and PrmSampleContextBufferModule with ClangDwarf under windows, errors occured because PRM used custom buildoption --require-defined. This is not universally supported by all clang linkers, specifically the ld.lld that is distributed with windows clang installations.

Switch to using -Wl,-u,<symbol to export> ensures that the associated symbol is in the final binary, even if its not referenced, and it is supported by both clang and gcc.


- [ ] Breaking change?

- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested
Local platform build

## Integration Instructions
No integration necessary.