### PR TITLE
Revert "Support multiple modes for SetMode function"

### DIFF
--- a/MdeModulePkg/Universal/Console/TerminalDxe/Terminal.c
+++ b/MdeModulePkg/Universal/Console/TerminalDxe/Terminal.c
@@ -2,7 +2,6 @@
   Produces Simple Text Input Protocol, Simple Text Input Extended Protocol and
   Simple Text Output Protocol upon Serial IO Protocol.
 
-Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.<BR>
 Copyright (c) 2006 - 2019, Intel Corporation. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -115,10 +114,7 @@ TERMINAL_DEV  mTerminalDevTemplate = {
 TERMINAL_CONSOLE_MODE_DATA  mTerminalConsoleModeData[] = {
   { 80,  25 },
   { 80,  50 },
-  { 100, 31 },  //  800 x 600
-  { 128, 40 },  // 1024 x 768
-  { 160, 42 },  // 1280 x 800
-  { 240, 56 },  // 1920 x 1080
+  { 100, 31 },
   //
   // New modes can be added here.
   //

--- a/MdeModulePkg/Universal/Console/TerminalDxe/Terminal.h
+++ b/MdeModulePkg/Universal/Console/TerminalDxe/Terminal.h
@@ -1,7 +1,6 @@
 /** @file
   Header file for Terminal driver.
 
-Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.<BR>
 Copyright (c) 2006 - 2019, Intel Corporation. All rights reserved.<BR>
 Copyright (C) 2016 Silicon Graphics, Inc. All rights reserved.<BR>
 Copyright (c) 2025, Loongson Technology Corporation Limited. All rights reserved.<BR>
@@ -165,8 +164,6 @@ typedef union {
 #define ROW_OFFSET                 2
 #define COLUMN_OFFSET              5
 #define FW_BACK_OFFSET             2
-#define RESIZE_ROW_OFFSET          4
-#define RESIZE_COLUMN_OFFSET       8
 
 typedef struct {
   UINT16    Unicode;

--- a/MdeModulePkg/Universal/Console/TerminalDxe/TerminalConOut.c
+++ b/MdeModulePkg/Universal/Console/TerminalDxe/TerminalConOut.c
@@ -1,7 +1,6 @@
 /** @file
   Implementation for EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL protocol.
 
-Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.<BR>
 Copyright (c) 2006 - 2018, Intel Corporation. All rights reserved.<BR>
 Copyright (C) 2016 Silicon Graphics, Inc. All rights reserved.<BR>
 Copyright (c) 2025, Loongson Technology Corporation Limited. All rights reserved.<BR>
@@ -76,7 +75,6 @@ UNICODE_TO_CHAR  UnicodeToPcAnsiOrAscii[] = {
 };
 
 CHAR16  mSetModeString[]           = { ESC, '[', '=', '3', 'h', 0 };
-CHAR16  mSetModeStringResize[]     = { ESC, '[', '8', ';', '0', '0', '0', ';', '0', '0', '0', 't', '0', 0 };
 CHAR16  mSetAttributeString[]      = { ESC, '[', '0', 'm', ESC, '[', '4', '0', 'm', ESC, '[', '4', '0', 'm', 0 };
 CHAR16  mClearScreenString[]       = { ESC, '[', '2', 'J', 0 };
 CHAR16  mSetCursorPositionString[] = { ESC, '[', '0', '0', ';', '0', '0', 'H', 0 };
@@ -463,6 +461,7 @@ TerminalConOutQueryMode (
   Implements EFI_SIMPLE_TEXT_OUT.SetMode().
 
   Set the terminal to a specified display mode.
+  In this driver, we only support mode 0.
 
   @param This          Indicates the calling context.
   @param ModeNumber    The text mode to set.
@@ -482,36 +481,14 @@ TerminalConOutSetMode (
 {
   EFI_STATUS    Status;
   TERMINAL_DEV  *TerminalDevice;
-  CHAR16        *String;
-  UINTN         Columns;
-  UINTN         Rows;
 
   //
-  // Get Terminal device data structure pointer.
+  //  get Terminal device data structure pointer.
   //
   TerminalDevice = TERMINAL_CON_OUT_DEV_FROM_THIS (This);
 
   if (ModeNumber >= (UINTN)This->Mode->MaxMode) {
     return EFI_UNSUPPORTED;
-  }
-
-  //
-  // Configure terminal string for the text mode to set.
-  //
-  if (ModeNumber == 0) {
-    String = mSetModeString;
-  } else {
-    Columns = TerminalDevice->TerminalConsoleModeData[ModeNumber].Columns;
-    Rows    = TerminalDevice->TerminalConsoleModeData[ModeNumber].Rows;
-
-    mSetModeStringResize[RESIZE_ROW_OFFSET + 0]    = (CHAR16)('0' + (Rows / 100));
-    mSetModeStringResize[RESIZE_ROW_OFFSET + 1]    = (CHAR16)('0' + ((Rows - ((Rows / 100) * 100)) / 10));
-    mSetModeStringResize[RESIZE_ROW_OFFSET + 2]    = (CHAR16)('0' + (Rows % 10));
-    mSetModeStringResize[RESIZE_COLUMN_OFFSET + 0] = (CHAR16)('0' + (Columns / 100));
-    mSetModeStringResize[RESIZE_COLUMN_OFFSET + 1] = (CHAR16)('0' + ((Columns - ((Columns / 100) * 100)) / 10));
-    mSetModeStringResize[RESIZE_COLUMN_OFFSET + 2] = (CHAR16)('0' + (Columns % 10));
-
-    String = mSetModeStringResize;
   }
 
   //
@@ -522,7 +499,7 @@ TerminalConOutSetMode (
   This->ClearScreen (This);
 
   TerminalDevice->OutputEscChar = TRUE;
-  Status                        = This->OutputString (This, String);
+  Status                        = This->OutputString (This, mSetModeString);
   TerminalDevice->OutputEscChar = FALSE;
 
   if (EFI_ERROR (Status)) {


### PR DESCRIPTION


This reverts commit 9224a2b91764ab17b2c1dbc9fdcb012eaed62da6, which causes corruption on the QEMU serial console when using ArmVirtQemu, and presumably other arch ports that target QEMU as well.

Reproducer:

  qemu-system-aarch64 -M virt -cpu host -accel kvm -net none -nographic  -m 1g \
              -bios .../edk2/Build/ArmVirtQemu-AARCH64/DEBUG_CLANGDWARF/FV/QEMU_EFI.fd

<img width="516" height="441" alt="corruption #1" src="https://github.com/user-attachments/assets/8c518954-1fb2-4ebb-8d5c-651a1b68ebe6" />
<img width="2540" height="1318" alt="corruption #2" src="https://github.com/user-attachments/assets/8e83cc34-3e03-4f83-8319-7d7dd97f2727" />
<img width="2534" height="1317" alt="corruption #3" src="https://github.com/user-attachments/assets/71f86729-8fb8-4556-8fc9-e192b636e295" />
