### PR TITLE
Add MRDIMM (0x08) entry to MemoryDeviceMemoryTechnologyTable

### DIFF
--- a/MdePkg/Include/IndustryStandard/SmBios.h
+++ b/MdePkg/Include/IndustryStandard/SmBios.h
@@ -1905,7 +1905,8 @@ typedef enum {
   MemoryTypeHBM2                     = 0x21,
   MemoryTypeDdr5                     = 0x22,
   MemoryTypeLpddr5                   = 0x23,
-  MemoryTypeHBM3                     = 0x24
+  MemoryTypeHBM3                     = 0x24,
+  MemoryTypeMrDimm                   = 0x25
 } MEMORY_DEVICE_TYPE;
 
 ///
@@ -1944,7 +1945,8 @@ typedef enum {
   // This definition is updated to represent Intel
   // Optane DC Persistent Memory in SMBIOS spec 3.4.0
   //
-  MemoryTechnologyIntelOptanePersistentMemory = 0x07
+  MemoryTechnologyIntelOptanePersistentMemory = 0x07,
+  MemoryTechnologyMrDimmDeprecated            = 0x08
 } MEMORY_DEVICE_TECHNOLOGY;
 
 ///

--- a/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/QueryTable.c
+++ b/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/QueryTable.c
@@ -2883,6 +2883,14 @@ TABLE_ITEM  MemoryDeviceTypeTable[] = {
   {
     MemoryTypeLpddr5,
     L"  LPDDR5"
+  },
+  {
+    MemoryTypeHBM3,
+    L"  HBM3 (High Bandwidth Memory Generation 3)"
+  },
+  {
+    MemoryTypeMrDimm,
+    L"  MRDIMM (Multi-Channel RDIMM)"
   }
 };
 
@@ -2973,6 +2981,10 @@ TABLE_ITEM  MemoryDeviceMemoryTechnologyTable[] = {
   {
     MemoryTechnologyIntelOptanePersistentMemory,
     L" Intel Optane Persistent Memory"
+  },
+  {
+    MemoryTechnologyMrDimmDeprecated,
+    L" MRDIMM"
   }
 };
 


### PR DESCRIPTION
# Description
added the MRDIMM (0x08) entry to the MemoryDeviceMemoryTechnologyTable in QueryTable.c.
This enables proper display and decoding of MRDIMM memory technology in SMBIOS Type 17 structures.

fix bug: https://github.com/tianocore/edk2/issues/11449


## How This Was Tested

How This Was Tested
local test pass

## Integration Instructions

![Uploading image.png…]()
