### PR TITLE
Edk2 usb bus dxe enhancement

### DIFF
--- a/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbBus.h
+++ b/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbBus.h
@@ -123,7 +123,7 @@ typedef struct _USB_HUB_API    USB_HUB_API;
 //
 // Send clear feature request timeout, set by experience
 //
-#define USB_CLEAR_FEATURE_REQUEST_TIMEOUT  10
+#define USB_CLEAR_FEATURE_REQUEST_TIMEOUT  10000    // EDK uses 10.  Change for AMD
 
 //
 // Bus raises TPL to TPL_NOTIFY to serialize all its operations
@@ -142,6 +142,16 @@ typedef struct _USB_HUB_API    USB_HUB_API;
 
 #define USB_BUS_FROM_THIS(a) \
           CR(a, USB_BUS, BusId, USB_BUS_SIGNATURE)
+
+#define USB_CONFIG_DESC_DEF_ALLOC_LEN  255
+
+typedef enum {
+  UsbEnumScriptEdk2    = 0,         // 0   :EDK2 flow
+  UsbEnumScriptRsrv    = 1,         // 1   :Reserved flow - EDK2
+  UsbEnumScriptLinux   = 2,         // 2   :Linux flow
+  UsbEnumScriptWin     = 3,         // 3   :Window flow
+  UsbEnumScriptUnknown = 0xFF,      // 0xff:Unknow flow
+} USB_ENUM_SCRIPT_TYPE;
 
 //
 // Used to locate USB_BUS
@@ -189,6 +199,7 @@ struct _USB_DEVICE {
   UINT8                                 Tier;
   BOOLEAN                               DisconnectFail;
   BOOLEAN                               IsSSDev;
+  UINT8                                 EnumScript;
 };
 
 //

--- a/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbBus.h
+++ b/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbBus.h
@@ -280,7 +280,7 @@ struct _USB_HUB_API {
   USB_HUB_RELEASE               Release;
 };
 
-#define USB_US_LAND_ID  0x0409
+#define USB_US_LANG_ID  0x0409
 
 #define DEVICE_PATH_LIST_ITEM_SIGNATURE  SIGNATURE_32('d','p','l','i')
 typedef struct _DEVICE_PATH_LIST_ITEM {

--- a/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbBus.h
+++ b/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbBus.h
@@ -188,6 +188,7 @@ struct _USB_DEVICE {
   UINT8                                 ParentPort; // Start at 0
   UINT8                                 Tier;
   BOOLEAN                               DisconnectFail;
+  BOOLEAN                               IsSSDev;
 };
 
 //

--- a/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbDesc.c
+++ b/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbDesc.c
@@ -9,6 +9,8 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #include "UsbBus.h"
 
+#define INTERFACE_NOT_SET  0xFF
+
 /**
   Free the interface setting descriptor.
 
@@ -396,6 +398,7 @@ UsbParseConfigDesc (
   UINTN                  Index;
   UINTN                  NumIf;
   UINTN                  Consumed;
+  UINT8                  FirstIntfNum = INTERFACE_NOT_SET;
 
   ASSERT (DescBuf != NULL);
 
@@ -450,10 +453,19 @@ UsbParseConfigDesc (
   while (Len >= sizeof (EFI_USB_INTERFACE_DESCRIPTOR)) {
     Setting = UsbParseInterfaceDesc (DescBuf, Len, &Consumed);
 
+    // Usb standard spec expects the interface number to start from 0.
+    // Some devices might have the first interface number not equal to zero.
+    // This is a work around for these devices. For example, Dell WWAN DW2811e
+    if (Setting != NULL) {
+      if (FirstIntfNum == INTERFACE_NOT_SET) {
+        FirstIntfNum = Setting->Desc.InterfaceNumber;
+      }
+    }
+
     if (Setting == NULL) {
       DEBUG ((DEBUG_ERROR, "UsbParseConfigDesc: warning: failed to get interface setting, stop parsing now.\n"));
       break;
-    } else if (Setting->Desc.InterfaceNumber >= NumIf) {
+    } else if (Setting->Desc.InterfaceNumber >= (NumIf + FirstIntfNum)) {
       DEBUG ((DEBUG_ERROR, "UsbParseConfigDesc: malformatted interface descriptor\n"));
 
       UsbFreeInterfaceDesc (Setting);
@@ -463,7 +475,7 @@ UsbParseConfigDesc (
     //
     // Insert the descriptor to the corresponding set.
     //
-    Interface = Config->Interfaces[Setting->Desc.InterfaceNumber];
+    Interface = Config->Interfaces[(Setting->Desc.InterfaceNumber - FirstIntfNum)];
 
     if (Interface->NumOfSetting >= USB_MAX_INTERFACE_SETTING) {
       goto ON_ERROR;

--- a/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbDesc.c
+++ b/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbDesc.c
@@ -118,6 +118,18 @@ UsbFreeDevDesc (
     FreePool (DevDesc->BOSDesc);
   }
 
+  if (DevDesc->StrDescManufacturerUS != NULL) {
+    FreePool (DevDesc->StrDescManufacturerUS);
+  }
+
+  if (DevDesc->StrDescProductUS != NULL) {
+    FreePool (DevDesc->StrDescProductUS);
+  }
+
+  if (DevDesc->StrDescSerialNumberUS != NULL) {
+    FreePool (DevDesc->StrDescSerialNumberUS);
+  }
+
   FreePool (DevDesc);
 }
 
@@ -744,40 +756,89 @@ UsbGetOneString (
   EFI_STATUS                 Status;
   UINT8                      *Buf;
 
-  //
-  // First get two bytes which contains the string length.
-  //
-  Status = UsbCtrlGetDesc (UsbDev, USB_DESC_TYPE_STRING, Index, LangId, &Desc, 2);
+  EFI_USB_STRING_DESCRIPTOR  *CachedDesc = NULL;
 
   //
-  // Reject if Length even cannot cover itself, or odd because Unicode string byte length should be even.
+  //  If the String is cached and LangId = US, just return the cached string descriptor
   //
+  if ((LangId == USB_US_LANG_ID) && (Index > 0)) {
+    Buf = NULL;
+
+    if (Index == UsbDev->DevDesc->Desc.StrManufacturer) {
+      if (UsbDev->DevDesc->StrDescManufacturerUS != NULL) {
+        CachedDesc = (EFI_USB_STRING_DESCRIPTOR *)UsbDev->DevDesc->StrDescManufacturerUS;
+        Buf        = AllocateZeroPool (CachedDesc->Length);
+        CopyMem (Buf, (UINT8 *)CachedDesc, CachedDesc->Length);
+      }
+    } else if (Index == UsbDev->DevDesc->Desc.StrProduct) {
+      if (UsbDev->DevDesc->StrDescProductUS != NULL) {
+        CachedDesc = (EFI_USB_STRING_DESCRIPTOR *)UsbDev->DevDesc->StrDescProductUS;
+        Buf        = AllocateZeroPool (CachedDesc->Length);
+        CopyMem (Buf, (UINT8 *)CachedDesc, CachedDesc->Length);
+      }
+    } else if (Index == UsbDev->DevDesc->Desc.StrSerialNumber) {
+      if (UsbDev->DevDesc->StrDescSerialNumberUS != NULL) {
+        CachedDesc = (EFI_USB_STRING_DESCRIPTOR *)UsbDev->DevDesc->StrDescSerialNumberUS;
+        Buf        = AllocateZeroPool (CachedDesc->Length);
+        CopyMem (Buf, (UINT8 *)CachedDesc, CachedDesc->Length);
+      }
+    } else {
+      Buf = NULL;
+    }
+
+    if (Buf != NULL) {
+      return (EFI_USB_STRING_DESCRIPTOR *)Buf;
+    }
+  }
+
+  //
+  // Copy the mechanism from Linux Driver to get the better compatibility. see usb_string_sub.
+  //
+  Buf    = AllocateZeroPool (256);
+  Status = UsbCtrlGetDesc (UsbDev, USB_DESC_TYPE_STRING, Index, LangId, Buf, 255);
   if (EFI_ERROR (Status) ||
-      (Desc.Length < OFFSET_OF (EFI_USB_STRING_DESCRIPTOR, Length) + sizeof (Desc.Length)) ||
-      (Desc.Length % 2 != 0)
-      )
+      (((EFI_USB_STRING_DESCRIPTOR *)Buf)->Length < OFFSET_OF (EFI_USB_STRING_DESCRIPTOR, Length) + sizeof (((EFI_USB_STRING_DESCRIPTOR *)Buf)->Length)) ||
+      (((EFI_USB_STRING_DESCRIPTOR *)Buf)->Length % 2 != 0))
   {
-    return NULL;
-  }
-
-  Buf = AllocateZeroPool (Desc.Length);
-
-  if (Buf == NULL) {
-    return NULL;
-  }
-
-  Status = UsbCtrlGetDesc (
-             UsbDev,
-             USB_DESC_TYPE_STRING,
-             Index,
-             LangId,
-             Buf,
-             Desc.Length
-             );
-
-  if (EFI_ERROR (Status)) {
+    DEBUG ((EFI_D_ERROR, "UsbGetOneString: Get 255 bytes path failed, Status = %r\n", Status));
     FreePool (Buf);
-    return NULL;
+    Buf = NULL;
+
+    //
+    // First get two bytes which contains the string length.
+    //
+    Status = UsbCtrlGetDesc (UsbDev, USB_DESC_TYPE_STRING, Index, LangId, &Desc, 2);
+
+    //
+    // Reject if Length even cannot cover itself, or odd because Unicode string byte length should be even.
+    //
+    if (EFI_ERROR (Status) ||
+        (Desc.Length < OFFSET_OF (EFI_USB_STRING_DESCRIPTOR, Length) + sizeof (Desc.Length)) ||
+        (Desc.Length % 2 != 0)
+        )
+    {
+      return NULL;
+    }
+
+    Buf = AllocateZeroPool (Desc.Length);
+
+    if (Buf == NULL) {
+      return NULL;
+    }
+
+    Status = UsbCtrlGetDesc (
+               UsbDev,
+               USB_DESC_TYPE_STRING,
+               Index,
+               LangId,
+               Buf,
+               Desc.Length
+               );
+
+    if (EFI_ERROR (Status)) {
+      FreePool (Buf);
+      return NULL;
+    }
   }
 
   return (EFI_USB_STRING_DESCRIPTOR *)Buf;
@@ -828,6 +889,51 @@ UsbBuildLangTable (
   }
 
   UsbDev->TotalLangId = (UINT16)Max;
+
+  //
+  // Some SMART Technologies key says that it supports LangId=0 only, but it
+  // responds to USB_US_LANG_ID (English). This is a workaround for all such keys.
+  //
+  if ((UsbDev->TotalLangId == 1) && (UsbDev->LangId[0] == 0)) {
+    UsbDev->LangId[0] = USB_US_LANG_ID;
+  }
+
+  //
+  // Some devices need to get the string immediately after SW get the first String descriptor
+  // for supported language.
+  //
+  gBS->FreePool (Desc);
+  Desc = NULL;
+  if (UsbDev->DevDesc->Desc.StrManufacturer != 0) {
+    Desc = UsbGetOneString (UsbDev, UsbDev->DevDesc->Desc.StrManufacturer, UsbDev->LangId[0]);
+    if (UsbDev->LangId[0] == USB_US_LANG_ID) {
+      UsbDev->DevDesc->StrDescManufacturerUS = (UINT8 *)Desc;
+    }
+
+    Desc = NULL;
+  }
+
+  if (UsbDev->DevDesc->Desc.StrProduct != 0) {
+    Desc = UsbGetOneString (UsbDev, UsbDev->DevDesc->Desc.StrProduct, UsbDev->LangId[0]);
+    if (UsbDev->LangId[0] == USB_US_LANG_ID) {
+      UsbDev->DevDesc->StrDescProductUS = (UINT8 *)Desc;
+    }
+
+    Desc = NULL;
+  }
+
+  if (UsbDev->DevDesc->Desc.StrSerialNumber != 0) {
+    Desc = UsbGetOneString (UsbDev, UsbDev->DevDesc->Desc.StrSerialNumber, UsbDev->LangId[0]);
+    if (UsbDev->LangId[0] == USB_US_LANG_ID) {
+      UsbDev->DevDesc->StrDescSerialNumberUS = (UINT8 *)Desc;
+    }
+
+    Desc = NULL;
+  }
+
+  if (Desc == NULL) {
+    return Status;
+  }
 
 ON_EXIT:
   gBS->FreePool (Desc);

--- a/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbDesc.c
+++ b/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbDesc.c
@@ -114,6 +114,10 @@ UsbFreeDevDesc (
     FreePool (DevDesc->Configs);
   }
 
+  if (DevDesc->BOSDesc != NULL) {
+    FreePool (DevDesc->BOSDesc);
+  }
+
   FreePool (DevDesc);
 }
 
@@ -317,6 +321,46 @@ ON_EXIT:
 ON_ERROR:
   UsbFreeInterfaceDesc (Setting);
   return NULL;
+}
+
+/**
+  Parse the BOS descriptor and check if it is a SS device.
+
+  @param  DescBuf               The buffer of raw descriptor.
+  @param  Len                   The length of the raw descriptor buffer.
+
+  @return TRUE                  The device is a SS device
+          FALSE                 The device is not a SS device
+
+**/
+BOOLEAN
+UsbIsSSDevice (
+  IN UINT8  *DescBuf,
+  IN UINTN  Len
+  )
+{
+  UINT8             *NextCap;
+  UINT8             Index;
+  UINT8             NumCapDesc;
+  USB_BOS_DESC      *BOSDesc;
+  USB_DEV_CAP_DESC  *DevCapDesc;
+
+  BOSDesc = (USB_BOS_DESC *)DescBuf;
+  if ((BOSDesc->DescriptorType != USB_DESC_TYPE_BOS) || (Len == 0)) {
+    return FALSE;
+  }
+
+  NumCapDesc = BOSDesc->NumDeviceCaps;
+  NextCap    = DescBuf + BOSDesc->Length;
+
+  for (Index = 0; Index < NumCapDesc; Index++, NextCap += DevCapDesc->Length) {
+    DevCapDesc = (USB_DEV_CAP_DESC  *)NextCap;
+    if ((DevCapDesc->DescriptorType == USB_BOS_DESC_TYPE_CAP) && (DevCapDesc->DevCapabilityType == USB_BOS_CAP_SS_USB)) {
+      return TRUE;
+    }
+  }
+
+  return FALSE;
 }
 
 /**
@@ -618,6 +662,66 @@ UsbGetDevDesc (
 }
 
 /**
+  Get the device BOS descriptor for the device.
+
+  @param  UsbDev                The Usb device to retrieve descriptor from.
+
+  @retval EFI_SUCCESS           The device descriptor is returned.
+  @retval EFI_OUT_OF_RESOURCES  Failed to allocate memory.
+
+**/
+EFI_STATUS
+UsbGetDevBOSDesc (
+  IN USB_DEVICE  *UsbDev
+  )
+{
+  UINT8       *Buf;
+  UINTN       TotalLength;
+  EFI_STATUS  Status;
+
+  Buf = AllocateZeroPool (sizeof (USB_BOS_DESC));
+  if (Buf == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  Status = UsbCtrlGetDesc (
+             UsbDev,
+             USB_DESC_TYPE_BOS,
+             0,
+             0,
+             Buf,
+             sizeof (USB_BOS_DESC)
+             );
+  if (!EFI_ERROR (Status)) {
+    TotalLength = ((USB_BOS_DESC *)Buf)->TotalLength;
+    gBS->FreePool (Buf);
+    Buf = NULL;
+    Buf = AllocateZeroPool (TotalLength);
+    if (Buf == NULL) {
+      return EFI_OUT_OF_RESOURCES;
+    }
+
+    Status = UsbCtrlGetDesc (
+               UsbDev,
+               USB_DESC_TYPE_BOS,
+               0,
+               0,
+               Buf,
+               TotalLength
+               );
+
+    if (EFI_ERROR (Status)) {
+      gBS->FreePool (Buf);
+      Buf = NULL;
+    }
+
+    UsbDev->DevDesc->BOSDesc = Buf;
+  }
+
+  return Status;
+}
+
+/**
   Retrieve the indexed string for the language. It requires two
   steps to get a string, first to get the string's length. Then
   the string itself.
@@ -882,6 +986,16 @@ UsbBuildDescTable (
     }
 
     DevDesc->Configs[Index] = ConfigDesc;
+  }
+
+  if (DevDesc->Desc.BcdUSB >= 0x210) {
+    Status = UsbGetDevBOSDesc (UsbDev);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((EFI_D_INFO, "UsbBuildDescTable: get BOS descriptor %r\n", Status));
+    } else {
+      UsbDev->IsSSDev = UsbIsSSDevice (UsbDev->DevDesc->BOSDesc, (UINTN)((USB_BOS_DESC *)(UsbDev->DevDesc->BOSDesc))->TotalLength);
+      DEBUG ((EFI_D_INFO, "UsbBuildDescTable: get BOS descriptor %r, UsbDev->IsSSDev = %d\n", Status, UsbDev->IsSSDev));
+    }
   }
 
   //

--- a/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbDesc.h
+++ b/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbDesc.h
@@ -69,7 +69,33 @@ typedef struct {
 typedef struct {
   EFI_USB_DEVICE_DESCRIPTOR    Desc;
   USB_CONFIG_DESC              **Configs;
+  UINT8                        *BOSDesc;
 } USB_DEVICE_DESC;
+
+#pragma pack(1)
+
+///
+/// Binary Device Object Store (BOS)
+/// USB 3.0 spec, Section 9.6.2
+///
+#define USB_DESC_TYPE_BOS      0x0F
+#define USB_BOS_DESC_TYPE_CAP  0x10
+#define USB_BOS_CAP_SS_USB     0x03
+typedef struct {
+  UINT8     Length;
+  UINT8     DescriptorType;
+  UINT16    TotalLength;
+  UINT8     NumDeviceCaps;
+} USB_BOS_DESC;
+
+typedef struct {
+  UINT8    Length;
+  UINT8    DescriptorType;
+  UINT8    DevCapabilityType;
+  UINT8    CapData[1];
+} USB_DEV_CAP_DESC;
+
+#pragma pack()
 
 /**
   USB standard control transfer support routine. This

--- a/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbDesc.h
+++ b/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbDesc.h
@@ -70,6 +70,9 @@ typedef struct {
   EFI_USB_DEVICE_DESCRIPTOR    Desc;
   USB_CONFIG_DESC              **Configs;
   UINT8                        *BOSDesc;
+  UINT8                        *StrDescManufacturerUS;
+  UINT8                        *StrDescProductUS;
+  UINT8                        *StrDescSerialNumberUS;
 } USB_DEVICE_DESC;
 
 #pragma pack(1)

--- a/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbEnumer.c
+++ b/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbEnumer.c
@@ -416,6 +416,19 @@ UsbSelectConfig (
     // the endpoint toggles to zero for its endpoints.
     //
     IfDesc = ConfigDesc->Interfaces[Index];
+
+    //
+    // Protect against hang. This is added to work around faulty device like Digidesign Mbox3 mini
+    //
+    if ((IfDesc == NULL) || (IfDesc->Settings[0] ==  NULL)) {
+      //
+      // If UsbCreateDesc() bailed on an interface or endpoint desc, don't try to
+      // configure that interface here.
+      //
+      DEBUG ((EFI_D_INFO, "UsbSelectConfig: Skipping uninitialized interface %d.\n", Index));
+      continue;
+    }
+
     UsbSelectSetting (IfDesc, IfDesc->Settings[0]->Desc.AlternateSetting);
 
     //


### PR DESCRIPTION

1. 
MdeModulePkg/Bus/Usb/UsbBusDxe: Fix UsbPortReset might run into
recursive loop once the device FW can not recover by PortReset.

UsbSelectConfig will introduce the UsbConnectDriver call.
If this UsbPortReset is happened in the Usb device driver Start()
routine and the device FW can not be recovered by PortReset, the
UsbSelectConfig will introduce the recursive loop.

[Suggested solution]
Since UsbPortReset should not change the Bus Topology, the Reset flow
should only SetAddress and reconfigure the device.


2. 
MdeModulePkg/Bus/Usb/UsbBusDxe: USB Device Enumeration Compatibility for
Non-Compliant Devices

The patch enhances the USB enumeration process in EDK2 to improve
compatibility with non-standards-compliant devices that may fail during
standard enumeration sequences.
The suggested solution is based on USB specifications and references
implementations from both Linux and Windows environments.

[Suggested solution]
- Integrated a retry mechanism to sequentially execute enumeration scripts,
  inspired by the enumeration flows of Windows, Linux, and EDK2.
  This improves robustness when handling corner-case devices.
- Do sanity check while the device report the device descriptor.
- AMD XHCI might need to wait for more time while sending the CLEAR_FEATURE
  reuqest.

3. 
MdeModulePkg/Bus/Usb/UsbBusDxe: A quirk in the Interface descriptor for
InterfaceNumber

Some specific device requires a quirk in the Interface descriptor for
InterfaceNumber to work properly

[Suggested Solution]
Implement the mechanism to ensure the first InterfaceNumber not equal
to zero.


4. 
MdeModulePkg/Bus/Usb/UsbBusDxe: Manufacturer String Descriptor Caching

Certain devices require immediate follow-up commands after reading the LANGID
string to fetch Manufacturer, Product, or SerialNumber strings.

[Suggested Solution]
These strings are now cached after initial retrieval to allow
UsbIoGetStringDescriptor() to return them directly, improving efficiency
and stability.


5. 
MdeModulePkg/Bus/Usb/UsbBusDxe: TPL Handling in
UsbBusRecursivelyConnectWantedUsbIo

[Suggested Solution]
Refactored to adopt the TPL handling mechanism from UsbConnectDriver(),
enabling ConnectController() to operate correctly at TPL_CALLBACK level
for the driver connection.


6. 
MdeModulePkg/Bus/Usb/UsbBusDxe: BOS Descriptor Check for SuperSpeed Devices

Some SuperSpeed-capable devices may fall back to High-Speed mode and
cause subsequent commands to fail.

[Suggested Solution]
Check the BOS descriptor to verify SuperSpeed support and trigger a
port reset if needed to re-enumerate the device properly.