### PR TITLE
SecurityPkg/Tpm2DeviceLibDTpm: Remove global variable for command code

### DIFF
--- a/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2DeviceLibDTpmDump.c
+++ b/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2DeviceLibDTpmDump.c
@@ -218,8 +218,6 @@ TPM2_CODE_STRING  ResponseCodeStrings[] = {
 };
 UINTN             ResponseCodeStringsCount = sizeof (ResponseCodeStrings) / sizeof (ResponseCodeStrings[0]);
 
-UINT32  mLastCommandSent = 0;
-
 /**
   This simple function will dump up to MAX_TPM_BUFFER_DUMP bytes
   of a TPM data buffer and apppend '...' if buffer is larger.
@@ -678,9 +676,6 @@ DumpTpmInputBlock (
   // If verbose, dump all of the buffer contents for deeper analysis.
   DumpTpmBuffer ("DATA:     ", MIN (InputBlockSize, NativeSize), InputBlock);
 
-  // Update the last command sent so that response parsing can have some context.
-  mLastCommandSent = NativeCode;
-
   return;
 }
 
@@ -690,13 +685,15 @@ DumpTpmInputBlock (
 
   @param[in]  OutputBlockSize  Size of the output buffer.
   @param[in]  OutputBlock      Pointer to the output buffer itself.
+  @param[in]  CommandCode      Command code for the input block.
 
 **/
 VOID
 EFIAPI
 DumpTpmOutputBlock (
   IN UINT32       OutputBlockSize,
-  IN CONST UINT8  *OutputBlock
+  IN CONST UINT8  *OutputBlock,
+  IN UINT32       CommandCode
   )
 {
   CONST TPM2_RESPONSE_HEADER  *RespHeader;
@@ -716,8 +713,8 @@ DumpTpmOutputBlock (
   DEBUG ((DEBUG_SECURITY, "Size:     %d (0x%X)\n", NativeSize, NativeSize));
 
   // Debug anything else based on the Command context.
-  if (mLastCommandSent != 0x00) {
-    switch (mLastCommandSent) {
+  if (CommandCode != 0x00) {
+    switch (CommandCode) {
       case TPM_CC_StartAuthSession:
         DumpTpmStartAuthSessionResponse (OutputBlockSize, OutputBlock);
         break;

--- a/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2Ptp.c
+++ b/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2Ptp.c
@@ -162,6 +162,7 @@ PtpCrbTpmCommand (
   UINT16      Data16;
   UINT32      Data32;
   UINT8       RetryCnt;
+  UINT32      CommandCode;
 
   DEBUG_CODE_BEGIN ();
   DumpTpmInputBlock (SizeIn, BufferIn);
@@ -336,7 +337,13 @@ PtpCrbTpmCommand (
   }
 
   DEBUG_CODE_BEGIN ();
-  DumpTpmOutputBlock (TpmOutSize, BufferOut);
+  if (SizeIn >= sizeof (TPM2_COMMAND_HEADER)) {
+    CommandCode = SwapBytes32 (((TPM2_COMMAND_HEADER *)BufferIn)->commandCode);
+  } else {
+    CommandCode = 0;
+  }
+
+  DumpTpmOutputBlock (TpmOutSize, BufferOut, CommandCode);
   DEBUG_CODE_END ();
 
   //

--- a/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2Ptp.h
+++ b/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2Ptp.h
@@ -73,12 +73,14 @@ DumpTpmInputBlock (
   a response from the TPM for maximum user-readability.
   @param[in]  OutputBlockSize  Size of the output buffer.
   @param[in]  OutputBlock      Pointer to the output buffer itself.
+  @param[in]  CommandCode      Command code for the input block.
 **/
 VOID
 EFIAPI
 DumpTpmOutputBlock (
   IN UINT32       OutputBlockSize,
-  IN CONST UINT8  *OutputBlock
+  IN CONST UINT8  *OutputBlock,
+  IN UINT32       CommandCode
   );
 
 #endif // TPM2_PTP_H_

--- a/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2Tis.c
+++ b/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2Tis.c
@@ -223,6 +223,7 @@ Tpm2TisTpmCommand (
   UINT32      TpmOutSize;
   UINT16      Data16;
   UINT32      Data32;
+  UINT32      CommandCode;
 
   DEBUG_CODE_BEGIN ();
   DumpTpmInputBlock (SizeIn, BufferIn);
@@ -370,7 +371,13 @@ Tpm2TisTpmCommand (
 
 Exit:
   DEBUG_CODE_BEGIN ();
-  DumpTpmOutputBlock (TpmOutSize, BufferOut);
+  if (SizeIn >= sizeof (TPM2_COMMAND_HEADER)) {
+    CommandCode = SwapBytes32 (((TPM2_COMMAND_HEADER *)BufferIn)->commandCode);
+  } else {
+    CommandCode = 0;
+  }
+
+  DumpTpmOutputBlock (TpmOutSize, BufferOut, CommandCode);
   DEBUG_CODE_END ();
   MmioWrite8 ((UINTN)&TisReg->Status, TIS_PC_STS_READY);
   return Status;


### PR DESCRIPTION
As a BASE type library, currently the TCG PEI driver, Tcg2Pei.inf links the library. On edk2-stable202508 version, it is found that the driver includes and updates the global variable of mLastCommandSent in debug build. Also found that the previous commit (460f270) for the library adds and uses the global variable. Updating the global variable in PEI drivers could affect the following issues. To address these issues, remove the global variable usage.

PEI ROM Boot : Global variable is not updated
PEI RAM Boot : PEI FV integration/security check is failed

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

The update has been tested and verified on AMD platforms based on the latest kernel.

## Integration Instructions

N/A
