### PR TITLE
ShellPkg: Disable the shell when UEFI Secure Boot is on

### DIFF
--- a/ShellPkg/Application/Shell/Shell.c
+++ b/ShellPkg/Application/Shell/Shell.c
@@ -358,6 +358,17 @@ UefiMain (
   EFI_HANDLE                      ConInHandle;
   EFI_SIMPLE_TEXT_INPUT_PROTOCOL  *OldConIn;
   SPLIT_LIST                      *Split;
+  UINT8                           *SecureBoot;
+
+  // If Secure Boot is enabled, do not launch the UEFI shell
+  SecureBoot = NULL;
+  GetEfiGlobalVariable2 (EFI_SECURE_BOOT_MODE_NAME, (VOID **)&SecureBoot, NULL);
+  if ((SecureBoot != NULL) && (*SecureBoot == SECURE_BOOT_MODE_ENABLE)) {
+    FreePool (SecureBoot);
+    return EFI_SECURITY_VIOLATION;
+  } else if (SecureBoot != NULL) {
+    FreePool (SecureBoot);
+  }
 
   if (PcdGet8 (PcdShellSupportLevel) > 3) {
     return (EFI_UNSUPPORTED);

--- a/ShellPkg/Application/Shell/Shell.h
+++ b/ShellPkg/Application/Shell/Shell.h
@@ -14,6 +14,8 @@
 
 #include <Guid/ShellVariableGuid.h>
 #include <Guid/ShellAliasGuid.h>
+#include <Guid/GlobalVariable.h>
+#include <Guid/ImageAuthentication.h>
 
 #include <Protocol/LoadedImage.h>
 #include <Protocol/SimpleTextOut.h>


### PR DESCRIPTION
When UEFI Secure Boot is on, we should not allow for the UEFI shell to be used. As such, disabling it in that scenario.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [x] Impacts security?
  - The UEFI shell is known as insecure.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Has been on AWS since a while, see https://github.com/aws/uefi/blob/5c3ac896feea3923a96944dc23e808385939c0a1/edk2-stable202211/0032-edk2-stable202211-uefi-shell-Disable-the-shell-when-UEFI-Secure-Boot-is-on.patch

## Integration Instructions

N/A