### PR TITLE
MdeModulePkg/ArmFfaLib: Add HobLib to StMm instances

### DIFF
--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaDxeLib.inf
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaDxeLib.inf
@@ -33,6 +33,7 @@
   BaseMemoryLib
   DebugLib
   HobLib
+  MemoryAllocationLib
 
 [Pcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdFfaLibConduitSmc

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaPeiLib.inf
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaPeiLib.inf
@@ -33,6 +33,7 @@
   BaseMemoryLib
   DebugLib
   HobLib
+  MemoryAllocationLib
 
 [Pcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdFfaLibConduitSmc

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaSecLib.inf
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaSecLib.inf
@@ -33,6 +33,7 @@
   BaseMemoryLib
   DebugLib
   HobLib
+  MemoryAllocationLib
 
 [Pcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdFfaLibConduitSmc

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaStandaloneMmCoreLib.inf
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaStandaloneMmCoreLib.inf
@@ -34,6 +34,7 @@
   BaseMemoryLib
   DebugLib
   HobLib
+  MemoryAllocationLib
   MmServicesTableLib
 
 [Pcd]

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaStandaloneMmLib.inf
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaStandaloneMmLib.inf
@@ -34,6 +34,7 @@
   BaseMemoryLib
   DebugLib
   HobLib
+  MemoryAllocationLib
   MmServicesTableLib
 
 [Pcd]


### PR DESCRIPTION
# Description

ArmFfaCommon.c is built by both ArmFfaStandaloneMmCoreLib and ArmFfaStandaloneMmLib. It links against HobLiib APIs such as `GetFirstHob()`. Right now, the symbols fail to link:

```
lld-link: error: undefined symbol: GetFirstHob
          ArmFfaStandaloneMmCoreLib.lib(ArmFfaCommon.obj)
```

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

- CI
- Integrating the library instances into a platform build

## Integration Instructions

- The platform needs to define `HobLib` instances for the `MM_CORE_STANDALONE` and `MM_STANDALONE` module types.