### PR TITLE
MdeModulePkg: Add PcdDelayedDispatchMaxEntries

### DIFF
--- a/MdeModulePkg/Core/Pei/Dispatcher/Dispatcher.c
+++ b/MdeModulePkg/Core/Pei/Dispatcher/Dispatcher.c
@@ -134,9 +134,15 @@ PeiDelayedDispatchRegister (
   }
 
   // Check for available entry slots
-  ASSERT (DelayedDispatchTable->Count <= DELAYED_DISPATCH_MAX_ENTRIES);
-  if (DelayedDispatchTable->Count == DELAYED_DISPATCH_MAX_ENTRIES) {
-    DEBUG ((DEBUG_ERROR, "%a Too many entries requested\n", __func__));
+  if (DelayedDispatchTable->Count >= PcdGet32 (PcdDelayedDispatchMaxEntries)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a DelayedDispatchTable->Count = %d. PcdDelayedDispatchMaxEntries (%d) is too small.\n",
+      __func__,
+      DelayedDispatchTable->Count,
+      PcdGet32 (PcdDelayedDispatchMaxEntries)
+      ));
+    ASSERT (DelayedDispatchTable->Count < PcdGet32 (PcdDelayedDispatchMaxEntries));
     Status = EFI_OUT_OF_RESOURCES;
     goto Exit;
   }
@@ -1807,7 +1813,7 @@ PeiDispatcher (
     if (GuidHob != NULL) {
       Private->DelayedDispatchTable = (DELAYED_DISPATCH_TABLE *)(GET_GUID_HOB_DATA (GuidHob));
     } else {
-      TableSize                     = sizeof (DELAYED_DISPATCH_TABLE) + ((DELAYED_DISPATCH_MAX_ENTRIES - 1) * sizeof (DELAYED_DISPATCH_ENTRY));
+      TableSize                     = sizeof (DELAYED_DISPATCH_TABLE) + (PcdGet32 (PcdDelayedDispatchMaxEntries) * sizeof (DELAYED_DISPATCH_ENTRY));
       Private->DelayedDispatchTable = BuildGuidHob (&gEfiDelayedDispatchTableGuid, TableSize);
       if (Private->DelayedDispatchTable != NULL) {
         ZeroMem (Private->DelayedDispatchTable, TableSize);

--- a/MdeModulePkg/Core/Pei/PeiMain.inf
+++ b/MdeModulePkg/Core/Pei/PeiMain.inf
@@ -121,6 +121,7 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdMigrateTemporaryRamFirmwareVolumes      ## CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdDelayedDispatchMaxDelayUs               ## CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdDelayedDispatchCompletionTimeoutUs      ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdDelayedDispatchMaxEntries               ## CONSUMES
 
 # [BootMode]
 # S3_RESUME             ## SOMETIMES_CONSUMES

--- a/MdeModulePkg/Include/Guid/DelayedDispatch.h
+++ b/MdeModulePkg/Include/Guid/DelayedDispatch.h
@@ -1,7 +1,7 @@
 /** @file
   Definition for structure & defines exported by Delayed Dispatch PPI
 
-  Copyright (c), Microsoft Corporation.
+  Copyright (c) Microsoft Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -14,11 +14,6 @@
 #define EFI_DELAYED_DISPATCH_TABLE_GUID  {\
   0x4b733449, 0x8eff, 0x488c, { 0x92, 0x1a, 0x15, 0x4a, 0xda, 0x25, 0x18, 0x07 } \
   }
-
-//
-// Maximal number of Delayed Dispatch entries supported
-//
-#define DELAYED_DISPATCH_MAX_ENTRIES  8
 
 //
 // Internal structure for delayed dispatch entries.
@@ -37,7 +32,7 @@ typedef struct {
 typedef struct {
   UINT32                    Count;
   UINT32                    DispCount;
-  DELAYED_DISPATCH_ENTRY    Entry[DELAYED_DISPATCH_MAX_ENTRIES];
+  DELAYED_DISPATCH_ENTRY    Entry[];   // Number of entries is based on PcdDelayedDispatchMaxEntries
 } DELAYED_DISPATCH_TABLE;
 
 #pragma pack (pop)

--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -1735,6 +1735,10 @@
   # @Prompt UFS device initial completion timoeout (us), default value is 600ms.
   gEfiMdeModulePkgTokenSpaceGuid.PcdUfsInitialCompletionTimeout|600000|UINT32|0x00000036
 
+  ## Delayed Dispatch Max Entries
+  # @Prompt Maximum number of delayed dispatch entries. Default value is 8.
+  gEfiMdeModulePkgTokenSpaceGuid.PcdDelayedDispatchMaxEntries|8|UINT32|0x00000037
+
 [PcdsPatchableInModule, PcdsDynamic, PcdsDynamicEx]
   ## This PCD defines the Console output row. The default value is 25 according to UEFI spec.
   #  This PCD could be set to 0 then console output would be at max column and max row.


### PR DESCRIPTION
# Description

The current fixed value of 8 for `DELAYED_DISPATCH_MAX_ENTRIES` is
not large enough to accommodate platform usage. This change replaces
the macro with a FixedAtBuild PCD that can be configured by
platforms.

In the case the default PCD value is too small, an error message
explaining that the PCD should be updated will be printed followed
by an assert.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

- MdeModulePkg CI
- Integrate into a platform with >8 delayed dispatch entries and
  `PcdDelayedDispatchMaxEntries` set to a platform-specific value.

## Integration Instructions

- No action needed. A platform can choose to configure `PcdDelayedDispatchMaxEntries` as needed.