### PR TITLE
Fix MP services over PSCI module

### DIFF
--- a/ArmPkg/Drivers/ArmPsciMpServicesDxe/ArmPsciMpServicesDxe.c
+++ b/ArmPkg/Drivers/ArmPsciMpServicesDxe/ArmPsciMpServicesDxe.c
@@ -1333,7 +1333,7 @@ MpServicesInitialize (
   ASSERT (gApStacksBase != NULL);
 
   for (Index = 0; Index < mCpuMpData.NumberOfProcessors; Index++) {
-    if (GET_MPIDR_AFFINITY_BITS (ArmReadMpidr ()) == CoreInfo[Index].Mpidr) {
+    if (GET_MPIDR_AFFINITY_BITS (ArmReadMpidr ()) == GET_MPIDR_AFFINITY_BITS (CoreInfo[Index].Mpidr)) {
       IsBsp = TRUE;
     } else {
       IsBsp = FALSE;

--- a/ArmPkg/Drivers/ArmPsciMpServicesDxe/ArmPsciMpServicesDxe.c
+++ b/ArmPkg/Drivers/ArmPsciMpServicesDxe/ArmPsciMpServicesDxe.c
@@ -887,7 +887,9 @@ EnableDisableAP (
     return EFI_INVALID_PARAMETER;
   }
 
-  if (GetApState (CpuData) != CpuStateIdle) {
+  if ((GetApState (CpuData) != CpuStateIdle) &&
+      (GetApState (CpuData) != CpuStateFinished))
+  {
     return EFI_UNSUPPORTED;
   }
 


### PR DESCRIPTION
# Description

This change fixes 2 logical issues in the `ArmPsciMpServicesDxe` module:

1. An issue with `EnableDisableAP` function where the function will be rejected if the previous AP operation ended up with timer expiration.
2. An issue with MPIDR usage, where the non-affinity bits are not filtered when comparing the CPU info data from the hob and register readings.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

This change was tested on QEMU SBSA virtual platform as well as proprietary hardware platform and can successfully disable/enable APs.

## Integration Instructions

N/A
