### PR TITLE
MdeModulePkg/UnicodeCollation: Fix uninitialized variable usage

### DIFF
--- a/MdeModulePkg/Universal/Disk/UnicodeCollation/EnglishDxe/UnicodeCollationEng.c
+++ b/MdeModulePkg/Universal/Disk/UnicodeCollation/EnglishDxe/UnicodeCollationEng.c
@@ -96,6 +96,8 @@ InitializeUnicodeCollationEng (
   UINTN       Index;
   UINTN       Index2;
 
+  Status = EFI_SUCCESS;
+
   //
   // Initialize mapping tables for the supported languages
   //


### PR DESCRIPTION
# Description

Build failed with the below error:
error: variable 'Status' is used uninitialized when 
PcdUnicodeCollation2Support is FALSE.

Fixing this issue by initializing Status unconditionally.

This is a regression issue caused by below Edk2 commit a46697f73532dbaa84babacc887cd5ccd8c4fdc2

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

After initialization of Status build passed.

## Integration Instructions

NA
