### PR TITLE
Allow SNP for ArmVirtQemu and ArmVirtQemuKernel.

### DIFF
--- a/ArmVirtPkg/ArmVirtQemu.dsc
+++ b/ArmVirtPkg/ArmVirtQemu.dsc
@@ -48,10 +48,6 @@
 # This comes at the beginning of includes to pick all relevant defines early on.
 !include ArmVirtPkg/ArmVirtStackCookies.dsc.inc
 
-!if $(NETWORK_SNP_ENABLE) == TRUE
-  !error "NETWORK_SNP_ENABLE is IA32/X64/EBC only"
-!endif
-
 !include NetworkPkg/NetworkDefines.dsc.inc
 
 !include MdePkg/MdeLibs.dsc.inc

--- a/ArmVirtPkg/ArmVirtQemuKernel.dsc
+++ b/ArmVirtPkg/ArmVirtQemuKernel.dsc
@@ -45,10 +45,6 @@
 # This comes at the beginning of includes to pick all relevant defines early on.
 !include ArmVirtPkg/ArmVirtStackCookies.dsc.inc
 
-!if $(NETWORK_SNP_ENABLE) == TRUE
-  !error "NETWORK_SNP_ENABLE is IA32/X64/EBC only"
-!endif
-
 !include NetworkPkg/NetworkDefines.dsc.inc
 
 !include MdePkg/MdeLibs.dsc.inc


### PR DESCRIPTION
# Description

Modern ARM server platforms support SNP for PXE boot. 

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

I tested PXE boot with ArmVirtQemu and needed to enable SNP. I used qemu with `-cpu cortex-a76 -M virt -device virtio-rng-pci` and my driver specific flags, and the Undi entrypoint was called.

## Integration Instructions

N/A