### PR TITLE
IntelFsp2Pkg/FspApiEntry: Reserve 32B when calling C function in 64bit

### DIFF
--- a/IntelFsp2Pkg/FspSecCore/X64/FspApiEntryCommon.nasm
+++ b/IntelFsp2Pkg/FspSecCore/X64/FspApiEntryCommon.nasm
@@ -52,7 +52,9 @@ FspApiCommon1:
   PUSHA_64
   mov    rdx, rcx           ; move ApiParam to rdx
   mov    rcx, rax           ; move ApiIdx to rcx
+  sub    rsp, 0x28
   call   ASM_PFX(FspApiCallingCheck)
+  add    rsp, 0x28
   cmp    rax, 0
   jz     FspApiCommon2
   mov    [rsp + STACK_SAVED_RAX_OFFSET], rax


### PR DESCRIPTION
After bootloader calls FSP API mode, I found the RDI register is changed in same case.
Below is the first line of function FspApiCallingCheck in assembly dump
  mov qword ptr [rsp+0x8],rbx
We can see compiler will use rsp+0x8 for some purpose, while rsp+0x8 is used to save RDI by FSP in code before.

According to the x86-64 calling convention, caller is responsible for allocating 32 bytes of "shadow space" on the stack right before calling the function (regardless of the actual number of parameters used). However FSP code doesn't reserve 32 bytes before calling FspApiCallingCheck C function in 64bit.

The patch fixes it by reserving the 32 bytes before calling C routine.

