### PR TITLE
MdeModulePkg/Universal/DriverSampleDxe: Fix VFR warnings

### DIFF
--- a/MdeModulePkg/Universal/DriverSampleDxe/Vfr.vfr
+++ b/MdeModulePkg/Universal/DriverSampleDxe/Vfr.vfr
@@ -186,7 +186,6 @@ formset
                  // CHECKBOX_DEFAULT_MFG indicate EFI_IFR_CHECKBOX_DEFAULT_MFG.
                  //
                  flags    = CHECKBOX_DEFAULT | CHECKBOX_DEFAULT_MFG,
-                 default  = TRUE,
         endcheckbox;
       endif;
     endif;


### PR DESCRIPTION
# Description

Remove `default` from checkbox statement that is not part of the checkbox statement syntax to remove VFR compiler warning.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

Build without this change generates a warning from the VFR compiler.

With this change, the warning is not generated.

## Integration Instructions

N/A
