### PR TITLE
NetworkPkg unit test CLANG build fixes for UefiPxeBcDxe and Dhcp6Dxe

### DIFF
--- a/NetworkPkg/Dhcp6Dxe/GoogleTest/Dhcp6IoGoogleTest.cpp
+++ b/NetworkPkg/Dhcp6Dxe/GoogleTest/Dhcp6IoGoogleTest.cpp
@@ -746,8 +746,9 @@ TEST_F (Dhcp6SeekStsOptionTest, SeekIATAOptionExpectFail) {
   UINT32        SearchPattern       = SEARCH_PATTERN;
   UINT16        SearchPatternLength = SEARCH_PATTERN_LEN;
   UINT16        *Len                = NULL;
-  EFI_DHCP6_IA  Ia                  = { 0 };
+  EFI_DHCP6_IA  Ia;
 
+  ZeroMem (&Ia, sizeof (Ia));
   Ia.Descriptor.Type                = DHCPV6_OPTION_IA_TA;
   Ia.IaAddressCount                 = 1;
   Ia.IaAddress[0].PreferredLifetime = 0xDEADBEEF;
@@ -800,8 +801,9 @@ TEST_F (Dhcp6SeekStsOptionTest, SeekIANAOptionExpectSuccess) {
   UINT8         *Option             = NULL;
   UINT32        SearchPattern       = SEARCH_PATTERN;
   UINT16        SearchPatternLength = SEARCH_PATTERN_LEN;
-  EFI_DHCP6_IA  Ia                  = { 0 };
+  EFI_DHCP6_IA  Ia;
 
+  ZeroMem (&Ia, sizeof (Ia));
   Ia.Descriptor.Type                = DHCPV6_OPTION_IA_NA;
   Ia.IaAddressCount                 = 1;
   Ia.IaAddress[0].PreferredLifetime = 0x11111111;

--- a/NetworkPkg/UefiPxeBcDxe/GoogleTest/PxeBcDhcp6GoogleTest.cpp
+++ b/NetworkPkg/UefiPxeBcDxe/GoogleTest/PxeBcDhcp6GoogleTest.cpp
@@ -37,6 +37,7 @@ typedef struct {
 ///////////////////////////////////////////////////////////////////////////////
 
 EFI_STATUS
+EFIAPI
 MockUdpWrite (
   IN EFI_PXE_BASE_CODE_PROTOCOL      *This,
   IN UINT16                          OpFlags,
@@ -55,6 +56,7 @@ MockUdpWrite (
 }
 
 EFI_STATUS
+EFIAPI
 MockUdpRead (
   IN EFI_PXE_BASE_CODE_PROTOCOL      *This,
   IN UINT16                          OpFlags,
@@ -72,6 +74,7 @@ MockUdpRead (
 }
 
 EFI_STATUS
+EFIAPI
 MockConfigure (
   IN EFI_UDP6_PROTOCOL     *This,
   IN EFI_UDP6_CONFIG_DATA  *UdpConfigData OPTIONAL


### PR DESCRIPTION
# Description

CLANGDWARF generates a build error for calling convention
mismatch in UdpRead(), UdpWrite(), and Configure() mock
functions in the UefiPxeBcDxe unit tests.  Add EFIAPI so mock 
function matches function prototype of function being mocked.

CLANGDWARF generates build error for missing braces when
initializing a complex structure in Dhcp6Dxe unit tests. Change 
initialization of EFI_DHCP6_IA local variable to a call to ZeroMem()
instead.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

Host-based unit tests builds with CLANGDWARF failed due to EFIAPI mismatches and missing braces in GoogleTest source files.
After these changes, the host-based unit tests builds passed.

## Integration Instructions

N/A