### PR TITLE
FmpDevicePkg/FmpDxe: Improve handling of XDR certs

### DIFF
--- a/FmpDevicePkg/FmpDxe/FmpDxe.c
+++ b/FmpDevicePkg/FmpDxe/FmpDxe.c
@@ -923,8 +923,7 @@ CheckTheImageInternal (
         break;
       }
 
-      PublicKeyDataXdr += PublicKeyDataLength;
-      PublicKeyDataXdr  = (UINT8 *)ALIGN_POINTER (PublicKeyDataXdr, sizeof (UINT32));
+      PublicKeyDataXdr += ALIGN_VALUE (PublicKeyDataLength, 4);
     }
   }
 


### PR DESCRIPTION
# Description
The current implementation for XDR certificate handling assumes the PublicKeyDataXdr buffer is 4-byte aligned. This is not always the case. For example, if PublicKeyDataXdr=0x02, and the length is 0x05, the correct offset should be 0x2 + align_up(0x5, 4) -> 0x2 + 0x8 = 0xA. The current logic produces align_up(0x2 + 0x5, 4) -> align_up(0x7, 4) = 0x8.

RFC XDR reference on 4-byte alignment. https://www.rfc-editor.org/rfc/rfc4506#page-16
```
   (4) Why is the XDR unit four bytes wide?

   There is a tradeoff in choosing the XDR unit size.  Choosing a small
   size, such as two, makes the encoded data small, but causes alignment
   problems for machines that aren't aligned on these boundaries.  A
   large size, such as eight, means the data will be aligned on
   virtually every machine, but causes the encoded data to grow too big.
   We chose four as a compromise.  Four is big enough to support most
   architectures efficiently, except for rare machines such as the
   eight-byte-aligned Cray*.  Four is also small enough to keep the
   encoded data restricted to a reasonable size.
```

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested
Verified this change properly aligns the PublicKeyDataXdr pointer to the next certificate in the list, even when the initial pointer is not 4-byte aligned.

## Integration Instructions
N/A
