### PR TITLE
ArmPkg/SemihostFs: fix crash when failed to open file

### DIFF
--- a/ArmPkg/Filesystem/SemihostFs/AArch64/SemihostFs.c
+++ b/ArmPkg/Filesystem/SemihostFs/AArch64/SemihostFs.c
@@ -95,10 +95,13 @@ AllocateFCB (
   SEMIHOST_FCB  *Fcb;
 
   Fcb = AllocateZeroPool (sizeof (SEMIHOST_FCB));
-  if (Fcb != NULL) {
-    CopyMem (&Fcb->File, &gSemihostFsFile, sizeof (gSemihostFsFile));
-    Fcb->Signature = SEMIHOST_FCB_SIGNATURE;
+  if (Fcb == NULL) {
+    return NULL;
   }
+
+  CopyMem (&Fcb->File, &gSemihostFsFile, sizeof (gSemihostFsFile));
+  Fcb->Signature = SEMIHOST_FCB_SIGNATURE;
+  InitializeListHead (&Fcb->Link);
 
   return Fcb;
 }
@@ -108,9 +111,6 @@ FreeFCB (
   IN SEMIHOST_FCB  *Fcb
   )
 {
-  // Remove Fcb from gFileList.
-  RemoveEntryList (&Fcb->Link);
-
   // To help debugging...
   Fcb->Signature = 0;
 
@@ -429,6 +429,9 @@ FileClose (
 
     FreePool (Fcb->FileName);
   }
+
+  // Remove Fcb from gFileList.
+  RemoveEntryList (&Fcb->Link);
 
   FreeFCB (Fcb);
 


### PR DESCRIPTION
Since FileFcb's list entry doesn't initialised at allocation,
SemihostFs reports below crash while freeing FileFcb when
get failed to size of file in FileOpen():

  ASSERT [SemihostFs] LinkedList.c(75): List->ForwardLink != ((void *) 0)

To address this, initailise list entry properly at FCB allocation
and move RemoveListEntry() to FileClose()
since the FCB entry will be on the list when VolumeOpen() or
FileOpen() is successed.

Signed-off: Yeoreum Yun <yeoreum.yun@arm.com>
