### PR TITLE
MdeModulePkg: DxeMain: Honor memory bin during memory map merging

### DIFF
--- a/MdeModulePkg/Core/Dxe/DxeMain.h
+++ b/MdeModulePkg/Core/Dxe/DxeMain.h
@@ -2804,4 +2804,22 @@ CoreInitializeHandleServices (
   VOID
   );
 
+/**
+  Helper function to compare two EFI_MEMORY_TYPE_INFORMATION entries by their
+  alignment granularity.
+
+  @param  Entry1    The first EFI_MEMORY_TYPE_STATISTICS entry to compare.
+  @param  Entry2    The second EFI_MEMORY_TYPE_STATISTICS entry to compare.
+
+  @return < 0 if Entry1 has a larger alignment granularity than Entry2.
+          > 0 if Entry1 has a smaller alignment granularity than Entry2.
+          = 0 if both entries have the same alignment granularity.
+**/
+INTN
+EFIAPI
+CompareMemTypeInfoByAlignment (
+  IN CONST VOID  *Entry1,
+  IN CONST VOID  *Entry2
+  );
+
 #endif


### PR DESCRIPTION
# Description

The current memory map merging logic in `CoreAddRange` only checks the memory type without considering the bin type.

However, the `CoreGetMemoryMap` routine will only report the entries that are entirely inside a specific bin type. This will confuse the consumer and report false free memory that belongs to special memory buckets.

This change fixes the issue by gating the merging logic by checking the bin type first. The merging is only allowed either if the bin type is not one of the special types, or if the bin type is the same for both entries.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

This change was tested on both virtual platform and proprietary hardware platforms and ensure that the check asserts no longer trip.

## Integration Instructions

N/A
