### PR TITLE
UefiCpuPkg/CpuDxe: fix page table walk in confidential VM

### DIFF
--- a/UefiCpuPkg/CpuDxe/CpuPageTable.c
+++ b/UefiCpuPkg/CpuDxe/CpuPageTable.c
@@ -975,6 +975,7 @@ RefreshGcdMemoryAttributesFromPaging (
   UINT64                           Capabilities;
   UINT64                           NewAttributes;
   UINTN                            Index;
+  UINT64                           AddressEncMask;
 
   //
   // Assuming that memory space map returned is sorted already; otherwise sort
@@ -1056,9 +1057,17 @@ RefreshGcdMemoryAttributesFromPaging (
         }
 
         //
+        // Get the mask for the memory encryption bit for Tdx and Sev
+        //
+        AddressEncMask = PcdGet64 (PcdPteMemoryEncryptionAddressOrMask);
+        if (AddressEncMask == 0) {
+          AddressEncMask = PcdGet64 (PcdTdxSharedBitMask);
+        }
+
+        //
         // Note current memory space might start in the middle of a page
         //
-        PageStartAddress = (*PageEntry) & (UINT64)PageAttributeToMask (PageAttribute);
+        PageStartAddress = (*PageEntry) & (UINT64)PageAttributeToMask (PageAttribute) & ~AddressEncMask;
         PageLength       = PageAttributeToLength (PageAttribute) - (BaseAddress - PageStartAddress);
         Attributes       = GetAttributesFromPageEntry (PageEntry);
       }


### PR DESCRIPTION
`PageStartAddress` variable was not set correctly because the encryption bit was not considered, which broke the page walk logic.

This resulted in a Page Fault when booting a CVM when PcdNullPointerDetectionPropertyMask was set.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Tested on SNP and TDX.

## Integration Instructions

<_Describe how these changes should be integrated. Use N/A if nothing is required._>
