### PR TITLE
MdeModulePkg/Ps2KeyboardDxe: use MMIO when PcdPciIoTranslation is set

### DIFF
--- a/MdeModulePkg/Bus/Isa/Ps2KeyboardDxe/Ps2KbdCtrller.c
+++ b/MdeModulePkg/Bus/Isa/Ps2KeyboardDxe/Ps2KbdCtrller.c
@@ -689,7 +689,19 @@ KeyReadDataRegister (
   )
 
 {
-  return IoRead8 (ConsoleIn->DataRegisterAddress);
+  UINT32  Port;
+  UINT64  Translation;
+  UINT64  MmioAddress;
+
+  Port        = ConsoleIn->DataRegisterAddress;
+  Translation = PcdGet64 (PcdPciIoTranslation);
+  if (Translation != 0) {
+    MmioAddress = Translation + Port;
+    ASSERT (MmioAddress >= Port);
+    return MmioRead8 ((UINTN)MmioAddress);
+  }
+
+  return IoRead8 (Port);
 }
 
 /**
@@ -705,7 +717,19 @@ KeyWriteDataRegister (
   IN UINT8                    Data
   )
 {
-  IoWrite8 (ConsoleIn->DataRegisterAddress, Data);
+  UINT32  Port;
+  UINT64  Translation;
+  UINT64  MmioAddress;
+
+  Port        = ConsoleIn->DataRegisterAddress;
+  Translation = PcdGet64 (PcdPciIoTranslation);
+  if (Translation != 0) {
+    MmioAddress = Translation + Port;
+    ASSERT (MmioAddress >= Port);
+    MmioWrite8 ((UINTN)MmioAddress, Data);
+  } else {
+    IoWrite8 (Port, Data);
+  }
 }
 
 /**
@@ -721,7 +745,19 @@ KeyReadStatusRegister (
   IN KEYBOARD_CONSOLE_IN_DEV  *ConsoleIn
   )
 {
-  return IoRead8 (ConsoleIn->StatusRegisterAddress);
+  UINT32  Port;
+  UINT64  Translation;
+  UINT64  MmioAddress;
+
+  Port        = ConsoleIn->StatusRegisterAddress;
+  Translation = PcdGet64 (PcdPciIoTranslation);
+  if (Translation != 0) {
+    MmioAddress = Translation + Port;
+    ASSERT (MmioAddress >= Port);
+    return MmioRead8 ((UINTN)MmioAddress);
+  }
+
+  return IoRead8 (Port);
 }
 
 /**
@@ -737,7 +773,19 @@ KeyWriteCommandRegister (
   IN UINT8                    Data
   )
 {
-  IoWrite8 (ConsoleIn->CommandRegisterAddress, Data);
+  UINT32  Port;
+  UINT64  Translation;
+  UINT64  MmioAddress;
+
+  Port        = ConsoleIn->CommandRegisterAddress;
+  Translation = PcdGet64 (PcdPciIoTranslation);
+  if (Translation != 0) {
+    MmioAddress = Translation + Port;
+    ASSERT (MmioAddress >= Port);
+    MmioWrite8 ((UINTN)MmioAddress, Data);
+  } else {
+    IoWrite8 (Port, Data);
+  }
 }
 
 /**

--- a/MdeModulePkg/Bus/Isa/Ps2KeyboardDxe/Ps2KeyboardDxe.inf
+++ b/MdeModulePkg/Bus/Isa/Ps2KeyboardDxe/Ps2KeyboardDxe.inf
@@ -64,6 +64,7 @@
 
 [Pcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdFastPS2Detection             ## SOMETIMES_CONSUMES
+  gEfiMdePkgTokenSpaceGuid.PcdPciIoTranslation                   ## CONSUMES
 
 #
 # [Event]


### PR DESCRIPTION
On IA32/X64, legacy port I/O is available and IoRead/IoWrite works as-is. On LOONGARCH/ARM/RISC-V there is no port I/O, and platforms usually expose a translated MMIO window for legacy I/O ranges.

This change reads PcdPciIoTranslation and, when non-zero, performs MMIO accesses at (Translation + Port) instead of using IoRead/IoWrite. When the PCD is zero, behavior is unchanged and IoRead/IoWrite is used.

Implementation details:
- Add small helpers to select MmioRead*/MmioWrite* vs IoRead*/IoWrite*.
- Use FixedPcdGet64(PcdPciIoTranslation) when possible to avoid runtime PCD reads in hot paths.
- Update all keyboard status/data accessors to the new helpers.
- Wire up INF: add Pcd and LibraryClasses entries.

This keeps x86 behavior identical and enables the driver to work on LOONGARCH/ARM/RISC-V platforms that map legacy I/O through MMIO.

Cc: Chao Li <lichao@loongson.cn>
Cc: Gao Qihang <gaoqihang@loongson.cn>
Signed-off-by: Dongyan Qian <qiandongyan@loongson.cn>
Tested-by: Chen Zhang <zhangchen@loongson.cn>

# Description

<_Include a description of the change and why this change was made._>

<_For each item, place an "x" in between `[` and `]` if true. Example: `[x]` (you can also check items in GitHub UI)_>

<_Create the PR as a Draft PR if it is only created to run CI checks._>

<_Delete lines in \<\> tags before creating the PR._>

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

<_Describe the test(s) that were run to verify the changes._>

## Integration Instructions

<_Describe how these changes should be integrated. Use N/A if nothing is required._>
