### PR TITLE
BaseTools/FMMT: Fix errors when operating the FV with CRC32 section

### DIFF
--- a/BaseTools/Source/Python/FMMT/core/BinaryFactoryProduct.py
+++ b/BaseTools/Source/Python/FMMT/core/BinaryFactoryProduct.py
@@ -2,6 +2,7 @@
 # This file is used to implement of the various bianry parser.
 #
 # Copyright (c) 2021-, Intel Corporation. All rights reserved.<BR>
+# Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.<BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 ##
 import copy
@@ -136,9 +137,6 @@ class SectionProduct(BinaryProduct):
             if (Rel_Offset+Section_Info.HeaderLength+len(Section_Info.Data) != Data_Size):
                 Pad_Size = GetPadSize(Section_Info.Size, SECTION_COMMON_ALIGNMENT)
                 Section_Info.PadData = Pad_Size * b'\x00'
-            if Section_Info.Header.Type == 0x02:
-                Section_Info.DOffset = Section_Offset + Section_Info.ExtHeader.DataOffset + Rel_Whole_Offset
-                Section_Info.Data = Whole_Data[Rel_Offset+Section_Info.ExtHeader.DataOffset: Rel_Offset+Section_Info.Size]
             if Section_Info.Header.Type == 0x14:
                 ParTree.Data.Version = Section_Info.ExtHeader.GetVersionString()
             if Section_Info.Header.Type == 0x15:
@@ -179,9 +177,6 @@ class FfsProduct(BinaryProduct):
             if (Rel_Offset+Section_Info.HeaderLength+len(Section_Info.Data) != Data_Size):
                 Pad_Size = GetPadSize(Section_Info.Size, SECTION_COMMON_ALIGNMENT)
                 Section_Info.PadData = Pad_Size * b'\x00'
-            if Section_Info.Header.Type == 0x02:
-                Section_Info.DOffset = Section_Offset + Section_Info.ExtHeader.DataOffset + Rel_Whole_Offset
-                Section_Info.Data = Whole_Data[Rel_Offset+Section_Info.ExtHeader.DataOffset: Rel_Offset+Section_Info.Size]
             # If Section is Version or UI type, it saves the version and UI info of its parent Ffs.
             if Section_Info.Header.Type == 0x14:
                 ParTree.Data.Version = Section_Info.ExtHeader.GetVersionString()


### PR DESCRIPTION
Currently the FMMT tool supports CRC32 GUID section (Ref. GuidTools.py, FmmtConf.ini). But it is found that there are errors for the FV with CRC32 section. For example, the errors are checked on the following commands.

--v : Show FV information except for the FV
--a : Show "Target Fv not found!!!" when adding an FFS file to the FV
--d : Show "Target Ffs not found!!!" when deleting an FFS file in the FV

They are caused by the mismatch for CRC32 section data between the FMMT and GenCrc32 tools. The FMMT tool returns CRC32 section data without CRC checksum field (4 bytes). The GenCrc32 tool (with -d option, verify CRC32 value for the input file) requires CRC32 section data including CRC checksum field (4 bytes).

Fix the issue through adjusting the section data to include CRC checksum field. Currently DataOffset field for CRC32 GUID section is reported as 0x1C differently (GUID Section header length: 0x18 + Checksum field: 0x4). Instead of DataOffset field that includes CRC checksum field, configure the section data based on the offset from section header length (0x18) that was previously calculated. This update enables GUID sections to use the same offset consistently.

Ref>
FmmtConf.ini : 
fc1bcdb0-7d31-49aa-936a-a4600d9dd083 CRC32 GenCrc32

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

The update has been tested and verified on AMD platforms that enable CRC32 GUID section for DXE FV compact.

## Integration Instructions

N/A
