### PR TITLE
ShellPkg: Add PCIe boundary check function for config space access

### DIFF
--- a/ShellPkg/Library/UefiShellDebug1CommandsLib/Pci.c
+++ b/ShellPkg/Library/UefiShellDebug1CommandsLib/Pci.c
@@ -1813,7 +1813,7 @@ PciPrintClassCode (
 
   if (IncludePIF) {
     //
-    // Print base class, sub class, and programming inferface name
+    // Print base class, sub class, and programming interface name
     //
     ShellPrintDefaultEx (
       L"%s - %s - %s",
@@ -1835,7 +1835,7 @@ PciPrintClassCode (
 
 /**
   This function finds out the protocol which is in charge of the given
-  segment, and its bus range covers the current bus number. It lookes
+  segment, and its bus range covers the current bus number. It looks
   each instances of RootBridgeIoProtocol handle, until the one meets the
   criteria is found.
 
@@ -2367,7 +2367,7 @@ CHAR16  *DevicePortTypeTable[] = {
   L"PCI Express Endpoint",
   L"Legacy PCI Express Endpoint",
   L"Unknown Type",
-  L"Unknonw Type",
+  L"Unknown Type",
   L"Root Port of PCI Express Root Complex",
   L"Upstream Port of PCI Express Switch",
   L"Downstream Port of PCI Express Switch",
@@ -2987,7 +2987,7 @@ Done:
 
 /**
   This function finds out the protocol which is in charge of the given
-  segment, and its bus range covers the current bus number. It lookes
+  segment, and its bus range covers the current bus number. It looks
   each instances of RootBridgeIoProtocol handle, until the one meets the
   criteria is found.
 
@@ -3077,7 +3077,7 @@ PciGetProtocolAndResource (
   EFI_STATUS  Status;
 
   //
-  // Get inferface from protocol
+  // Get interface from protocol
   //
   Status = gBS->HandleProtocol (
                   Handle,


### PR DESCRIPTION
# Description

1. Add BoundaryCheck function for PCIe extended capability structures
   to prevent reads beyond the 4KB PCIe configuration space limit.
   The function calculates whether the requested size would cause an
   access beyond the boundary and truncates the size if necessary,
   while warning the user about the truncation.

2. Enhance DVSEC capability structure size calculation method. Size is
   now obtained from the DesignatedVendorSpecificHeader1.Bits.DvsecLength
   register.

3. fix some typo in the source code

Issue: https://github.com/tianocore/edk2/issues/11554


- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Tested with internal platform and it is working

## Integration Instructions

N\A
