### PR TITLE
ArmPkg/Library: change transfer list's checksum calculation

### DIFF
--- a/ArmPkg/Library/ArmTransferListLib/ArmTransferListLib.c
+++ b/ArmPkg/Library/ArmTransferListLib/ArmTransferListLib.c
@@ -16,6 +16,45 @@
 #include <Library/HobLib.h>
 
 /**
+  Returns the xor of all elements in a buffer in unit of UINT8.
+  During calculation, the carry bits are dropped.
+
+  This function calculates the xor value of all elements in a buffer
+  in unit of UINT8 start from Zero.
+  The result is returned as UINT8. If Length is Zero, then Zero is
+  returned.
+
+  If Buffer is NULL, then ASSERT().
+  If Length is greater than (MAX_ADDRESS - Buffer + 1), then ASSERT().
+
+  @param[in]  Buffer      The pointer to the buffer to carry out the xor operation.
+  @param[in]  Length      The size, in bytes, of Buffer.
+
+  @return CheckSum    The xor of Buffer calculated from Zero.
+
+**/
+STATIC
+UINT8
+EFIAPI
+CalculateXor8 (
+  IN      CONST UINT8  *Buffer,
+  IN      UINTN        Length
+  )
+{
+  UINT8  CheckSum;
+  UINTN  Count;
+
+  ASSERT (Buffer != NULL);
+  ASSERT (Length <= (MAX_ADDRESS - ((UINTN)Buffer) + 1));
+
+  for (CheckSum = 0, Count = 0; Count < Length; Count++) {
+    CheckSum ^= *(Buffer + Count);
+  }
+
+  return CheckSum;
+}
+
+/**
   Get the TransferList from HOB list.
 
   @param[out] TransferList  TransferList
@@ -76,7 +115,7 @@ TransferListVerifyChecksum (
     return TRUE;
   }
 
-  return (CalculateSum8 ((UINT8 *)TransferListHeader, TransferListHeader->UsedSize) == 0);
+  return (CalculateXor8 ((UINT8 *)TransferListHeader, TransferListHeader->UsedSize) == 0);
 }
 
 /**


### PR DESCRIPTION
# Description

Since the commit ae94bd1ff5b5 ("Switch to an xor for the checksum") in
firmware handoff specification [0],
the checksum calculation method is changed
from additive sum to XOR in 2023.

To align with this specification,
TF-A updates the method in last month by:
  commit e2fc189e1bd1 ("fix: use XOR for checksum") in libtl [1].

Before the above commit, ArmTransferListLib is implemented with
additive sum for checksum to align with TF-A once.

As transfer list library used by TF-A updates the
calculation method for checksum according to the specification,
let's update the checksum calculation method in ArmTransferListLib.

Link: https://github.com/FirmwareHandoff/firmware_handoff/commit/ae94bd1ff5b5d4a1024782934df8299b4c8d097b [0]
Link: https://review.trustedfirmware.org/plugins/gitiles/shared/transfer-list-library/+/1712685fdfaa0fa8887026a77568d2039a0c37f5 [1]
Signed-off-by: Yeoreum Yun <yeoreum.yun@arm.com>

- [X] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

With the latest TF-A, test on booting with transfer list in FVP RevC model.

## Integration Instructions

N/A
