### PR TITLE
Arm transfer list lib

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -35,3 +35,6 @@
 [submodule "SecurityPkg/DeviceSecurity/SpdmLib/libspdm"]
 	path = SecurityPkg/DeviceSecurity/SpdmLib/libspdm
 	url = https://github.com/DMTF/libspdm.git
+[submodule "ArmPkg/Library/ArmTransferListLib/libtl"]
+	path = ArmPkg/Library/ArmTransferListLib/libtl
+	url = https://review.trustedfirmware.org/shared/transfer-list-library.git

--- a/ArmPkg/Include/IndustryStandard/ArmTransferList.h
+++ b/ArmPkg/Include/IndustryStandard/ArmTransferList.h
@@ -30,16 +30,27 @@
  * For register convention, please see below:
  * https://github.com/FirmwareHandoff/firmware_handoff/blob/main/source/register_conventions.rst
  */
+#ifndef REGISTER_CONVENTION_VERSION_SHIFT_64
 #define REGISTER_CONVENTION_VERSION_SHIFT_64  (32)
+#endif
+
 #define TRANSFER_LIST_SIGNATURE_MASK_64       \
   ((1ULL << REGISTER_CONVENTION_VERSION_SHIFT_64) - 1)
 
+#ifndef REGISTER_CONVENTION_VERSION_SHIFT_32
 #define REGISTER_CONVENTION_VERSION_SHIFT_32  (24)
+#endif
+
 #define TRANSFER_LIST_SIGNATURE_MASK_32       \
   ((1UL << REGISTER_CONVENTION_VERSION_SHIFT_32) - 1)
 
+#ifndef REGISTER_CONVENTION_VERSION_MASK
 #define REGISTER_CONVENTION_VERSION_MASK  (0xff)
-#define REGISTER_CONVENTION_VERSION       (1)
+#endif
+
+#ifndef REGISTER_CONVENTION_VERSION
+#define REGISTER_CONVENTION_VERSION  (1)
+#endif
 
 #define CREATE_TRANSFER_LIST_HANDOFF_X1_VALUE(version)    \
   ((TRANSFER_LIST_SIGNATURE &                             \
@@ -129,12 +140,10 @@ typedef struct TransferListHeader {
 /*
  * Transfer entry in transfer list starts with the following header.
  */
+#pragma pack(1)
 typedef struct TransferEntryHeader {
   /// The entry type identifier.
-  UINT16    TagId;
-
-  /// Reserved.
-  UINT8     Reserved0;
+  UINT32    TagId : 24;
 
   /// The size of this entry header in bytes.
   UINT8     HeaderSize;
@@ -142,6 +151,7 @@ typedef struct TransferEntryHeader {
   /// The size of the data content in bytes.
   UINT32    DataSize;
 } TRANSFER_ENTRY_HEADER;
+#pragma pack()
 
 /*
  * TPM event log information entry,

--- a/ArmPkg/Include/Library/ArmTransferListLib.h
+++ b/ArmPkg/Include/Library/ArmTransferListLib.h
@@ -80,7 +80,7 @@ TRANSFER_ENTRY_HEADER *
 EFIAPI
 TransferListFindFirstEntry (
   IN TRANSFER_LIST_HEADER  *TransferListHeader,
-  IN UINT16                TagId
+  IN UINT32                TagId
   );
 
 /**
@@ -101,7 +101,7 @@ EFIAPI
 TransferListFindNextEntry (
   IN TRANSFER_LIST_HEADER   *TransferListHeader,
   IN TRANSFER_ENTRY_HEADER  *CurrentEntry,
-  IN UINT16                 TagId
+  IN UINT32                 TagId
   );
 
 /**
@@ -169,7 +169,7 @@ TRANSFER_ENTRY_HEADER *
 EFIAPI
 TransferListFindEntry (
   IN TRANSFER_LIST_HEADER  *TransferListHeader,
-  IN UINT16                TagId
+  IN UINT32                TagId
   );
 
 /**

--- a/ArmPkg/Include/Library/ArmTransferListLib.h
+++ b/ArmPkg/Include/Library/ArmTransferListLib.h
@@ -194,4 +194,192 @@ TransferListGetEventLog (
   OUT UINT32               *EventLogFlags       OPTIONAL
   );
 
+/**
+  Ensure a valid Transfer List exists at the specified buffer.
+
+  If a valid header is present it is returned; otherwise a new empty Transfer
+  List is initialized in-place using the provided capacity.
+
+  @param[in,out]  TransferListBase      Base address of the buffer/region.
+  @param[in]      TransferListCapacity  Total capacity (bytes) of the buffer.
+
+  @return Pointer to the Transfer List header on success; NULL on failure.
+**/
+TRANSFER_LIST_HEADER *
+EFIAPI
+TransferListEnsure (
+  IN OUT VOID   *TransferListBase,
+  IN     UINTN  TransferListCapacity
+  );
+
+/**
+  Relocate an existing Transfer List to a new buffer with the given capacity.
+
+  Useful when the Transfer List must grow beyond its current region (e.g., when
+  backed by a fixed flash window).
+
+  @param[in]   TransferListHeader    Pointer to the current Transfer List header.
+  @param[out]  DestinationBase       Destination buffer address.
+  @param[in]   DestinationCapacity   Capacity in bytes of the destination buffer.
+
+  @return Pointer to the relocated Transfer List header; NULL on failure.
+**/
+TRANSFER_LIST_HEADER *
+EFIAPI
+TransferListRelocate (
+  IN  TRANSFER_LIST_HEADER  *TransferListHeader,
+  OUT VOID                  *DestinationBase,
+  IN  UINTN                 DestinationCapacity
+  );
+
+/**
+  Append a new Transfer Entry.
+
+  @param[in,out]  TransferListHeader  Pointer to the Transfer List header.
+  @param[in]      TagId               Full (up to 24-bit) tag identifier.
+  @param[in]      DataSize            Payload size in bytes.
+  @param[in]      Data                Optional source buffer (may be NULL).
+
+  @retval NULL      Append failed (e.g., insufficient capacity).
+  @retval non-NULL  Pointer to the newly added entry.
+**/
+TRANSFER_ENTRY_HEADER *
+EFIAPI
+TransferListAdd (
+  IN OUT TRANSFER_LIST_HEADER  *TransferListHeader,
+  IN     UINT32                TagId,
+  IN     UINT32                DataSize,
+  IN     CONST VOID            *Data   OPTIONAL
+  );
+
+/**
+  Resize an existing Transfer Entry payload.
+
+  On growth, subsequent entries may be moved to make room. On shrink, space is
+  reclaimed. Call TransferListUpdateChecksum() after modifications.
+
+  @param[in,out]  TransferListHeader  Pointer to the Transfer List header.
+  @param[in,out]  Entry               Entry to resize.
+  @param[in]      NewDataSize         New payload size in bytes.
+
+  @retval TRUE   Resize succeeded; Entry remains valid.
+  @retval FALSE  Resize failed (e.g., insufficient capacity).
+**/
+BOOLEAN
+EFIAPI
+TransferListSetDataSize (
+  IN OUT TRANSFER_LIST_HEADER   *TransferListHeader,
+  IN OUT TRANSFER_ENTRY_HEADER  *Entry,
+  IN     UINT32                 NewDataSize
+  );
+
+/**
+  Remove a Transfer Entry.
+
+  After removal, the Transfer List is compacted as required by the underlying
+  implementation. Call TransferListUpdateChecksum() if not done automatically.
+
+  @param[in,out]  TransferListHeader  Pointer to the Transfer List header.
+  @param[in,out]  Entry               Entry to remove.
+
+  @retval TRUE   Entry removed.
+  @retval FALSE  Removal failed.
+**/
+BOOLEAN
+EFIAPI
+TransferListRemove (
+  IN OUT TRANSFER_LIST_HEADER   *TransferListHeader,
+  IN OUT TRANSFER_ENTRY_HEADER  *Entry
+  );
+
+/**
+  Optional reverse iterator: return the previous entry.
+
+  @param[in]  TransferListHeader  TL header.
+  @param[in]  CurrentEntry        Current entry.
+
+  @retval NULL      No previous entry.
+  @retval non-NULL  Previous entry.
+**/
+TRANSFER_ENTRY_HEADER *
+EFIAPI
+TransferListGetPrevEntry (
+  TRANSFER_LIST_HEADER   *TransferListHeader,
+  TRANSFER_ENTRY_HEADER  *CurrentEntry
+  );
+
+/**
+  Find the first Transfer Entry whose full TagId (up to 24 bits) matches.
+
+  This is a thin wrapper over the underlying implementation. It returns the
+  first matching entry, or NULL if no match exists.
+
+  @param[in]  TransferListHeader  Pointer to the Transfer List header.
+  @param[in]  TagId               Full tag identifier to match.
+
+  @retval NULL      No matching entry or TransferListHeader is NULL.
+  @retval non-NULL  Pointer to the first matching entry.
+**/
+
+TRANSFER_ENTRY_HEADER *
+EFIAPI
+TransferListFindEntryByTag  (
+  IN TRANSFER_LIST_HEADER  *TransferListHeader,
+  IN UINT32                TagId
+  );
+
+/**
+  Read the first entry matching the full TagId (up to 24-bit).
+
+  @param[in]   TransferListHeader   Pointer to the Transfer List header.
+  @param[in]   TagId                Full tag identifier to match.
+  @param[out]  EntryOut             On success, receives the entry pointer.
+  @param[out]  EntryDataOut         Optional; receives pointer to entry data.
+  @param[out]  EntryDataSizeOut     Optional; receives data size in bytes.
+
+  @retval EFI_SUCCESS      Match found and output parameters set.
+  @retval EFI_NOT_FOUND    No entry with TagId.
+  @retval EFI_INVALID_PARAMETER  TransferListHeader or EntryOut is NULL.
+**/
+EFI_STATUS
+EFIAPI
+TransferListReadEntryByTag (
+  IN  TRANSFER_LIST_HEADER   *TransferListHeader,
+  IN  UINT32                 TagId,
+  OUT TRANSFER_ENTRY_HEADER  **EntryOut,
+  OUT VOID                   **EntryDataOut     OPTIONAL,
+  OUT UINT32                 *EntryDataSizeOut  OPTIONAL
+  );
+
+/**
+  Update (or create) an entry by TagId.
+
+  If an entry with TagId exists, it is resized if needed and the payload is
+  overwritten with Data (if Data is not NULL). If no entry exists and
+  CreateIfMissing is TRUE, a new entry is appended (aligned to Alignment if
+  non-zero). The Transfer List checksum is updated on success.
+
+  @param[in,out]  TransferListHeader   Pointer to the Transfer List header.
+  @param[in]      TagId                Full tag identifier to update.
+  @param[in]      Data                 Source buffer (may be NULL to only resize).
+  @param[in]      DataSize             Size of Data in bytes.
+  @param[in]      CreateIfMissing      If TRUE, create the entry when missing.
+  @param[in]      AlignmentLog2        Optional power-of-two alignment (0 to use default).
+
+  @retval EFI_SUCCESS           Entry updated or created.
+  @retval EFI_NOT_FOUND         Entry not found and CreateIfMissing is FALSE.
+  @retval EFI_BUFFER_TOO_SMALL  Not enough capacity to add/resize.
+  @retval EFI_INVALID_PARAMETER TransferListHeader is NULL.
+**/
+EFI_STATUS
+EFIAPI
+TransferListUpdateEntryByTag (
+  IN OUT TRANSFER_LIST_HEADER  *TransferListHeader,
+  IN     UINT32                TagId,
+  IN     CONST VOID            *Data        OPTIONAL,
+  IN     UINT32                DataSize,
+  IN     BOOLEAN               CreateIfMissing,
+  IN     UINT8                 AlignmentLog2
+  );
+
 #endif // ARM_TRANSFER_LIST_LIB_

--- a/ArmPkg/Library/ArmTransferListLib/ArmTransferListLib.c
+++ b/ArmPkg/Library/ArmTransferListLib/ArmTransferListLib.c
@@ -10,10 +10,21 @@
 **/
 
 #include <Base.h>
-#include <Library/ArmTransferListLib.h>
 #include <Library/BaseLib.h>
 #include <Library/DebugLib.h>
+#include <libtl/include/transfer_list.h>
+#include <Library/ArmTransferListLib.h>
 #include <Library/HobLib.h>
+
+STATIC_ASSERT (
+  sizeof (TRANSFER_LIST_HEADER) == sizeof (struct transfer_list_header),
+  "TRANSFER_LIST_HEADER size mismatch"
+  );
+
+STATIC_ASSERT (
+  sizeof (TRANSFER_ENTRY_HEADER) == sizeof (struct transfer_list_entry),
+  "TRANSFER_ENTRY_HEADER size mismatch"
+  );
 
 /**
   Get the TransferList from HOB list.
@@ -68,24 +79,59 @@ TransferListVerifyChecksum (
   IN TRANSFER_LIST_HEADER  *TransferListHeader
   )
 {
-  if (TransferListHeader == NULL) {
-    return FALSE;
-  }
-
-  if ((TransferListHeader->Flags & TRANSFER_LIST_FL_HAS_CHECKSUM) == 0) {
-    return TRUE;
-  }
-
-  return (CalculateSum8 ((UINT8 *)TransferListHeader, TransferListHeader->UsedSize) == 0);
+  return transfer_list_verify_checksum ((struct transfer_list_header *)TransferListHeader);
 }
 
 /**
-  This function checks the header of the Transfer List.
+  This helper maps Transfer List operation modes to corresponding libtl ops.
 
-  @param [in]   TransferListHeader       Pointer to the Transfer List Header
+  @param[in]  ops                     libtl Operation modes.
 
-  @return TRANSFER_LIST_OPS code indicating the validity of the Transfer List
+  @retval TRANSFER_LIST_OPS_ALL       Header is valid and usable (read/write).
+  @retval TRANSFER_LIST_OPS_RO        Header is valid but only supports read-only
+                                      operations.
+  @retval TRANSFER_LIST_OPS_CUSTOM    Header is valid but requires custom handling
+                                      due to a version mismatch.
+  @retval TRANSFER_LIST_OPS_INVALID   Header is invalid or unsupported.
+**/
+static TRANSFER_LIST_OPS
+MapLibtlOps (
+  enum transfer_list_ops  ops
+  )
+{
+  TRANSFER_LIST_OPS  Status;
 
+  switch (ops) {
+    case TL_OPS_ALL:
+      Status = TRANSFER_LIST_OPS_ALL;
+      break;
+    case TL_OPS_RO:
+      Status = TRANSFER_LIST_OPS_RO;
+      break;
+    case TL_OPS_CUS:
+      Status = TRANSFER_LIST_OPS_CUSTOM;
+      break;
+    default:
+      Status = TRANSFER_LIST_OPS_INVALID;
+  }
+
+  return Status;
+}
+
+/**
+  Check the Transfer List header and return an operation mode.
+
+  This function forwards to transfer_list_check_header() (libtl) and converts
+  the returned libtl operation code into the TRANSFER_LIST_OPS enum.
+
+  @param[in]  TransferListHeader      Pointer to the Transfer List header.
+
+  @retval TRANSFER_LIST_OPS_ALL       Header is valid and usable (read/write).
+  @retval TRANSFER_LIST_OPS_RO        Header is valid but only supports read-only
+                                      operations.
+  @retval TRANSFER_LIST_OPS_CUSTOM    Header is valid but requires custom handling
+                                      due to a version mismatch.
+  @retval TRANSFER_LIST_OPS_INVALID   Header is invalid or unsupported.
 **/
 TRANSFER_LIST_OPS
 EFIAPI
@@ -93,48 +139,7 @@ TransferListCheckHeader (
   IN TRANSFER_LIST_HEADER  *TransferListHeader
   )
 {
-  if (TransferListHeader == NULL) {
-    return TRANSFER_LIST_OPS_INVALID;
-  }
-
-  if (TransferListHeader->Signature != TRANSFER_LIST_SIGNATURE_64) {
-    DEBUG ((DEBUG_ERROR, "Bad transfer list signature 0x%x\n", TransferListHeader->Signature));
-    return TRANSFER_LIST_OPS_INVALID;
-  }
-
-  if (TransferListHeader->TotalSize == 0) {
-    DEBUG ((DEBUG_ERROR, "Bad transfer list total size 0x%x\n", TransferListHeader->TotalSize));
-    return TRANSFER_LIST_OPS_INVALID;
-  }
-
-  if (TransferListHeader->UsedSize > TransferListHeader->TotalSize) {
-    DEBUG ((DEBUG_ERROR, "Bad transfer list used size 0x%x\n", TransferListHeader->UsedSize));
-    return TRANSFER_LIST_OPS_INVALID;
-  }
-
-  if (TransferListHeader->HeaderSize != sizeof (TRANSFER_LIST_HEADER)) {
-    DEBUG ((DEBUG_ERROR, "Bad transfer list header size 0x%x\n", TransferListHeader->HeaderSize));
-    return TRANSFER_LIST_OPS_INVALID;
-  }
-
-  if (TransferListVerifyChecksum (TransferListHeader) == FALSE) {
-    DEBUG ((DEBUG_ERROR, "Bad transfer list checksum 0x%x\n", TransferListHeader->Checksum));
-    return TRANSFER_LIST_OPS_INVALID;
-  }
-
-  if (TransferListHeader->Version == 0) {
-    DEBUG ((DEBUG_ERROR, "Transfer list version is invalid\n"));
-    return TRANSFER_LIST_OPS_INVALID;
-  } else if (TransferListHeader->Version == ARM_FW_HANDOFF_PROTOCOL_VERSION) {
-    DEBUG ((DEBUG_INFO | DEBUG_LOAD, "Transfer list version is valid for all operations\n"));
-    return TRANSFER_LIST_OPS_ALL;
-  } else if (TransferListHeader->Version > ARM_FW_HANDOFF_PROTOCOL_VERSION) {
-    DEBUG ((DEBUG_INFO | DEBUG_LOAD, "Transfer list version is valid for read-only\n"));
-    return TRANSFER_LIST_OPS_RO;
-  }
-
-  DEBUG ((DEBUG_INFO | DEBUG_LOAD, "Old or custom transfer list version is detected\n"));
-  return TRANSFER_LIST_OPS_CUSTOM;
+  return MapLibtlOps (transfer_list_check_header ((const struct transfer_list_header *)TransferListHeader));
 }
 
 /**
@@ -151,7 +156,7 @@ TransferListGetFirstEntry (
   IN TRANSFER_LIST_HEADER  *TransferListHeader
   )
 {
-  return TransferListGetNextEntry (TransferListHeader, NULL);
+  return (TRANSFER_ENTRY_HEADER *)transfer_list_next ((struct transfer_list_header *)TransferListHeader, NULL);
 }
 
 /**
@@ -173,35 +178,7 @@ TransferListGetNextEntry (
   IN TRANSFER_ENTRY_HEADER  *CurrentEntry
   )
 {
-  TRANSFER_ENTRY_HEADER  *Entry;
-  UINTN                  CurrentAddr;
-  UINTN                  EndAddr;
-
-  if (TransferListHeader == NULL) {
-    return NULL;
-  }
-
-  EndAddr = (UINTN)TransferListHeader + TransferListHeader->UsedSize;
-
-  if (CurrentEntry != NULL) {
-    CurrentAddr = (UINTN)CurrentEntry + CurrentEntry->HeaderSize + CurrentEntry->DataSize;
-  } else {
-    CurrentAddr = (UINTN)TransferListHeader + TransferListHeader->HeaderSize;
-  }
-
-  CurrentAddr = ALIGN_VALUE (CurrentAddr, (1 << TransferListHeader->Alignment));
-
-  Entry = (TRANSFER_ENTRY_HEADER *)CurrentAddr;
-
-  if (((CurrentAddr + sizeof (TRANSFER_LIST_HEADER)) < CurrentAddr) ||
-      ((CurrentAddr + sizeof (TRANSFER_ENTRY_HEADER)) > EndAddr) ||
-      ((CurrentAddr + Entry->HeaderSize + Entry->DataSize) < CurrentAddr) ||
-      ((CurrentAddr + Entry->HeaderSize + Entry->DataSize) > EndAddr))
-  {
-    return NULL;
-  }
-
-  return Entry;
+  return (TRANSFER_ENTRY_HEADER *)transfer_list_next ((struct transfer_list_header *)TransferListHeader, (struct transfer_list_entry *)CurrentEntry);
 }
 
 /**
@@ -218,18 +195,10 @@ TRANSFER_ENTRY_HEADER *
 EFIAPI
 TransferListFindFirstEntry (
   IN TRANSFER_LIST_HEADER  *TransferListHeader,
-  IN UINT16                TagId
+  IN UINT32                TagId
   )
 {
-  TRANSFER_ENTRY_HEADER  *Entry;
-
-  Entry = TransferListGetFirstEntry (TransferListHeader);
-
-  while ((Entry != NULL) && ((Entry->TagId != TagId) || Entry->Reserved0 != 0)) {
-    Entry = TransferListGetNextEntry (TransferListHeader, Entry);
-  }
-
-  return Entry;
+  return (TRANSFER_ENTRY_HEADER *)transfer_list_find ((struct transfer_list_header *)TransferListHeader, TagId);
 }
 
 /**
@@ -250,7 +219,7 @@ EFIAPI
 TransferListFindNextEntry (
   IN TRANSFER_LIST_HEADER   *TransferListHeader,
   IN TRANSFER_ENTRY_HEADER  *CurrentEntry,
-  IN UINT16                 TagId
+  IN UINT32                 TagId
   )
 {
   TRANSFER_ENTRY_HEADER  *Entry;
@@ -261,7 +230,7 @@ TransferListFindNextEntry (
     Entry = TransferListGetNextEntry (TransferListHeader, CurrentEntry);
   }
 
-  while ((Entry != NULL) && ((Entry->TagId != TagId) || Entry->Reserved0 != 0)) {
+  while ((Entry != NULL) && ((Entry->TagId & 0xFFFFFF) != (TagId & 0xFFFFFF))) {
     Entry = TransferListGetNextEntry (TransferListHeader, Entry);
   }
 
@@ -286,7 +255,7 @@ TransferListGetEntryData (
     return NULL;
   }
 
-  return (VOID *)((UINTN)TransferEntry + TransferEntry->HeaderSize);
+  return transfer_list_entry_data ((struct transfer_list_entry *)TransferEntry);
 }
 
 /**
@@ -301,14 +270,14 @@ TRANSFER_ENTRY_HEADER *
 EFIAPI
 TransferListFindEntry (
   IN TRANSFER_LIST_HEADER  *TransferListHeader,
-  IN UINT16                TagId
+  IN UINT32                TagId
   )
 {
   TRANSFER_ENTRY_HEADER  *Entry = NULL;
 
   do {
     Entry = TransferListGetNextEntry (TransferListHeader, Entry);
-  } while ((Entry != NULL) && (Entry->TagId != TagId));
+  } while ((Entry != NULL) && ((Entry->TagId & 0xFFFFFF) != (TagId & 0xFFFFFF)));
 
   return Entry;
 }
@@ -402,7 +371,7 @@ TransferListDump (
     }
 
     DEBUG ((DEBUG_INFO | DEBUG_LOAD, "Entry %d:\n", Idx++));
-    DEBUG ((DEBUG_INFO | DEBUG_LOAD, "tag_id     0x%x\n", Entry->TagId));
+    DEBUG ((DEBUG_INFO | DEBUG_LOAD, "TagId     0x%x\n", Entry->TagId));
     DEBUG ((DEBUG_INFO | DEBUG_LOAD, "hdr_size   0x%x\n", Entry->HeaderSize));
     DEBUG ((DEBUG_INFO | DEBUG_LOAD, "data_size  0x%x\n", Entry->DataSize));
     DEBUG ((DEBUG_INFO | DEBUG_LOAD, "data_addr  0x%lx\n", (UINTN)TransferListGetEntryData (Entry)));

--- a/ArmPkg/Library/ArmTransferListLib/ArmTransferListLib.inf
+++ b/ArmPkg/Library/ArmTransferListLib/ArmTransferListLib.inf
@@ -32,6 +32,9 @@
 
 [LibraryClasses]
   BaseLib
+  BaseMemoryLib
+  DebugLib
+  HobLib
 
 [Guids]
   gArmTransferListHobGuid

--- a/ArmPkg/Library/ArmTransferListLib/ArmTransferListLib.inf
+++ b/ArmPkg/Library/ArmTransferListLib/ArmTransferListLib.inf
@@ -2,7 +2,7 @@
 #  Library that implements the helper functions to parse and pack a
 #  Transfer List according to the A-profile Firmware Handoff Specification.
 #
-#  Copyright (c) 2024, Arm Limited. All rights reserved.<BR>
+#  Copyright (c) 2024-2025, Arm Limited. All rights reserved.<BR>
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -16,8 +16,15 @@
   VERSION_STRING                 = 1.0
   LIBRARY_CLASS                  = ArmTransferListLib
 
+  DEFINE TL_LIB_PATH             = libtl
+  DEFINE TL_LIB_INCLUDE_PATH     = $(TL_LIB_PATH)/include
+
 [Sources]
   ArmTransferListLib.c
+  $(TL_LIB_PATH)/src/generic/transfer_list.c
+  $(TL_LIB_PATH)/src/generic/logging.c
+  $(TL_LIB_INCLUDE_PATH)/transfer_list.h
+  $(TL_LIB_INCLUDE_PATH)/logging.h
 
 [Packages]
   ArmPkg/ArmPkg.dec


### PR DESCRIPTION
**# Description**

This series of commits introduces support for the Transfer List Library (libtl) in ArmPkg/ArmTransferListLib.

The goal is to align EDK2 with the Firmware Handoff Specification by reusing the common libtl implementation instead of maintaining separate custom logic.
ArmTransferListLib now acts as a thin wrapper around libtl, exposing the same functionality via an EDK2-style API so platform code can work with Transfer Lists consistently.

**Summary of changes**

- Add libtl as a git submodule under ArmPkg/Library/ArmTransferListLib/libtl.
- Update ArmTransferListLib.inf to build with libtl sources.
- Replace previous in-tree custom Transfer List handling with calls into libtl.
- Add STATIC_ASSERTs to guarantee structure size/layout matches libtl.
- Guard register-convention macros in ArmTransferList.h to avoid conflicts with libtl headers.
- Extend ArmTransferListLib with additional wrapper APIs and helpers.

This ensures EDK2 stays aligned with the libtl reference implementation and avoids duplication.

Breaking change?
No. Existing ArmTransferListLib API continues to be provided, now backed by libtl.

Impacts security?
No direct security changes. Transfer List parsing continues to validate headers and sizes.

Includes tests?
No new unit tests. Verified manually with builds and integration tests on platform firmware.

**How This Was Tested**

- Built ArmPkg successfully for AARCH64 target.
- Validated that ArmTransferListLib links against libtl sources.
- Ran integration tests on platform firmware (Phoenix/FVP) confirming TL handoff still functions.
- Verified structure layout compatibility with libtl using STATIC_ASSERT.
- Tested with ftpm branch for any issues .

**Integration Instructions**

No special integration steps required.
Consumers of ArmTransferListLib continue to include <Library/ArmTransferListLib.h> and link as before.
