### PR TITLE
MdePkg: Add PCIe capability structures for DPC and DLF

### DIFF
--- a/MdePkg/Include/IndustryStandard/Pci30.h
+++ b/MdePkg/Include/IndustryStandard/Pci30.h
@@ -42,7 +42,7 @@
 ///
 /// PCI Capability List IDs and records
 ///
-#define EFI_PCI_CAPABILITY_ID_PCIEXP  0x10
+#define EFI_PCI_CAPABILITY_ID_PCIEXP  0x10  // Obsolete, use PCI_EXPRESS_CAPABILITY_ID
 
 #pragma pack(1)
 

--- a/MdePkg/Include/IndustryStandard/PciExpress21.h
+++ b/MdePkg/Include/IndustryStandard/PciExpress21.h
@@ -31,8 +31,13 @@
 
 #pragma pack(1)
 ///
-/// PCI Express Capability Structure
+/// PCI Express Capability Structure version 2.
+/// Mandatory for PCI Express devices. If not present it is not PCI Express device, thus no extended config space.
 ///
+#define PCI_EXPRESS_CAPABILITY_ID         0x0010
+#define PCI_EXPRESS_CAPABILITY_VER1       0x1    // Version 1 ends at PCI_CAPABILITY_PCIEXP::RootStatus register
+#define PCI_EXPRESS_CAPABILITY_VER2       0x2    // Version 2 extends version 1 up to PCI_CAPABILITY_PCIEXP::SlotStatus2 register
+
 typedef union {
   struct {
     UINT16    Version                : 4;
@@ -396,29 +401,29 @@ typedef union {
 } PCI_REG_PCIE_SLOT_CAPABILITY2;
 
 typedef struct {
-  EFI_PCI_CAPABILITY_HDR             Hdr;
-  PCI_REG_PCIE_CAPABILITY            Capability;
-  PCI_REG_PCIE_DEVICE_CAPABILITY     DeviceCapability;
-  PCI_REG_PCIE_DEVICE_CONTROL        DeviceControl;
-  PCI_REG_PCIE_DEVICE_STATUS         DeviceStatus;
-  PCI_REG_PCIE_LINK_CAPABILITY       LinkCapability;
-  PCI_REG_PCIE_LINK_CONTROL          LinkControl;
-  PCI_REG_PCIE_LINK_STATUS           LinkStatus;
-  PCI_REG_PCIE_SLOT_CAPABILITY       SlotCapability;
-  PCI_REG_PCIE_SLOT_CONTROL          SlotControl;
-  PCI_REG_PCIE_SLOT_STATUS           SlotStatus;
-  PCI_REG_PCIE_ROOT_CONTROL          RootControl;
-  PCI_REG_PCIE_ROOT_CAPABILITY       RootCapability;
-  PCI_REG_PCIE_ROOT_STATUS           RootStatus;
-  PCI_REG_PCIE_DEVICE_CAPABILITY2    DeviceCapability2;
-  PCI_REG_PCIE_DEVICE_CONTROL2       DeviceControl2;
-  UINT16                             DeviceStatus2;
-  PCI_REG_PCIE_LINK_CAPABILITY2      LinkCapability2;
-  PCI_REG_PCIE_LINK_CONTROL2         LinkControl2;
-  PCI_REG_PCIE_LINK_STATUS2          LinkStatus2;
-  PCI_REG_PCIE_SLOT_CAPABILITY2      SlotCapability2;
-  UINT16                             SlotControl2;
-  UINT16                             SlotStatus2;
+  EFI_PCI_CAPABILITY_HDR             Hdr;                         // Offset 00 size 2
+  PCI_REG_PCIE_CAPABILITY            Capability;                  // Offset 02 size 2
+  PCI_REG_PCIE_DEVICE_CAPABILITY     DeviceCapability;            // Offset 04 size 4
+  PCI_REG_PCIE_DEVICE_CONTROL        DeviceControl;               // Offset 08 size 2
+  PCI_REG_PCIE_DEVICE_STATUS         DeviceStatus;                // Offset 0A size 2
+  PCI_REG_PCIE_LINK_CAPABILITY       LinkCapability;              // Offset 0C size 4
+  PCI_REG_PCIE_LINK_CONTROL          LinkControl;                 // Offset 10 size 2
+  PCI_REG_PCIE_LINK_STATUS           LinkStatus;                  // Offset 12 size 2
+  PCI_REG_PCIE_SLOT_CAPABILITY       SlotCapability;              // Offset 14 size 4
+  PCI_REG_PCIE_SLOT_CONTROL          SlotControl;                 // Offset 18 size 2
+  PCI_REG_PCIE_SLOT_STATUS           SlotStatus;                  // Offset 1A size 2
+  PCI_REG_PCIE_ROOT_CONTROL          RootControl;                 // Offset 1C size 2
+  PCI_REG_PCIE_ROOT_CAPABILITY       RootCapability;              // Offset 1E size 2
+  PCI_REG_PCIE_ROOT_STATUS           RootStatus;                  // Offset 20 size 4 - Ver1 ends here
+  PCI_REG_PCIE_DEVICE_CAPABILITY2    DeviceCapability2;           // Offset 24 size 4
+  PCI_REG_PCIE_DEVICE_CONTROL2       DeviceControl2;              // Offset 28 size 2
+  UINT16                             DeviceStatus2;               // Offset 2A size 2
+  PCI_REG_PCIE_LINK_CAPABILITY2      LinkCapability2;             // Offset 2C size 4
+  PCI_REG_PCIE_LINK_CONTROL2         LinkControl2;                // Offset 30 size 2
+  PCI_REG_PCIE_LINK_STATUS2          LinkStatus2;                 // Offset 32 size 2
+  PCI_REG_PCIE_SLOT_CAPABILITY2      SlotCapability2;             // Offset 34 size 4
+  UINT16                             SlotControl2;                // Offset 38 size 2
+  UINT16                             SlotStatus2;                 // Offset 3A size 2
 } PCI_CAPABILITY_PCIEXP;
 
 #define EFI_PCIE_CAPABILITY_BASE_OFFSET                           0x100
@@ -429,15 +434,15 @@ typedef struct {
 #define EFI_PCIE_CAPABILITY_DEVICE_CONTROL_2_ARI_FORWARDING       0x20
 
 //
-// for SR-IOV
+// Single Root IO Virtualization (SR-IOV) Extended Capability Structure.
 //
-#define EFI_PCIE_CAPABILITY_ID_ARI    0x0E
-#define EFI_PCIE_CAPABILITY_ID_ATS    0x0F
-#define EFI_PCIE_CAPABILITY_ID_SRIOV  0x10
-#define EFI_PCIE_CAPABILITY_ID_MRIOV  0x11
+#define EFI_PCIE_CAPABILITY_ID_ARI    0x0E  // Obsolete, use PCI_EXPRESS_EXTENDED_CAPABILITY_ARI_CAPABILITY_ID
+#define EFI_PCIE_CAPABILITY_ID_ATS    0x0F  // Obsolete, use PCI_EXPRESS_EXTENDED_CAPABILITY_ATS_ID
+#define EFI_PCIE_CAPABILITY_ID_SRIOV  0x10  // Obsolete, use PCI_EXPRESS_EXTENDED_CAPABILITY_SRIOV_ID
+#define EFI_PCIE_CAPABILITY_ID_MRIOV  0x11  // Obsolete, deprecated in 6.0
 
-#define PCI_EXPRESS_EXTENDED_CAPABILITY_SRIOV_ID    0x0010
-#define PCI_EXPRESS_EXTENDED_CAPABILITY_SRIOV_VER1  0x1
+#define PCI_EXPRESS_EXTENDED_CAPABILITY_SRIOV_ID               0x0010
+#define PCI_EXPRESS_EXTENDED_CAPABILITY_SRIOV_VER1             0x1
 
 typedef struct {
   UINT32    CapabilityHeader;
@@ -739,12 +744,13 @@ typedef struct {
 
 #define GET_TPH_TABLE_SIZE(x)  ((x->TphRequesterCapability & 0x7FF0000)>>16) * sizeof(UINT16)
 
-/// Address Translation Services Extended Capability Structure
+///
+/// Address Translation Services (ATS) Extended Capability Structure
 ///
 /// Based on section 5.1 of PCI Express Address Translation Services Specification 1.1
 ///@{
-#define PCI_EXPRESS_EXTENDED_CAPABILITY_ATS_ID    0x000F
-#define PCI_EXPRESS_EXTENDED_CAPABILITY_ATS_VER1  0x1
+#define PCI_EXPRESS_EXTENDED_CAPABILITY_ATS_ID     0x000F
+#define PCI_EXPRESS_EXTENDED_CAPABILITY_ATS_VER1   0x1
 
 typedef union {
   struct {
@@ -766,12 +772,13 @@ typedef union {
 } PCI_EXPRESS_EXTENDED_CAPABILITIES_ATS_CONTROL;
 
 typedef struct {
-  PCI_EXPRESS_EXTENDED_CAPABILITIES_HEADER            Header;
-  PCI_EXPRESS_EXTENDED_CAPABILITIES_ATS_CAPABILITY    Capability;
-  PCI_EXPRESS_EXTENDED_CAPABILITIES_ATS_CONTROL       Control;
+  PCI_EXPRESS_EXTENDED_CAPABILITIES_HEADER         Header;
+  PCI_EXPRESS_EXTENDED_CAPABILITIES_ATS_CAPABILITY Capability;
+  PCI_EXPRESS_EXTENDED_CAPABILITIES_ATS_CONTROL    Control;
 } PCI_EXPRESS_EXTENDED_CAPABILITIES_ATS;
 ///@}
 
 #pragma pack()
 
 #endif
+

--- a/MdePkg/Include/IndustryStandard/PciExpress31.h
+++ b/MdePkg/Include/IndustryStandard/PciExpress31.h
@@ -15,6 +15,111 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #pragma pack(1)
 
+/*
+ * Process Address Space ID (PASID) Extended Capability Structure.
+ */
+#define PCI_EXPRESS_EXTENDED_CAPABILITY_PASID_ID     0x001B
+#define PCI_EXPRESS_EXTENDED_CAPABILITY_PASID_VER1   0x1
+
+typedef union {
+  struct {
+    UINT16    Reserved0                     : 1,  // [0]
+              ExecutePermissionSupport      : 1,  // [1]
+              PrivilegedModeSupport         : 1,  // [2]
+              TranslatedReqWithPasidSupport : 1,  // [3]
+              Reserved1                     : 3,  // [7:4]
+              MaxPasidWidth                 : 5,  // [12:8]
+              Reserved2                     : 3;  // [15:13]
+  } Bits;
+  UINT16    Uint16;
+} PCI_EXPRESS_EXTENDED_CAPABILITIES_PASID_CAPABILITY;
+
+typedef union {
+  struct {
+    UINT16    PasidEnable                   : 1,  // [0]
+              ExecutePermissionEnable       : 1,  // [1]
+              PrivilegedModeEnable          : 1,  // [2]
+              TranslatedReqWithPasidEnable  : 1,  // [3]
+              Reserved                      :12;
+  } Bits;
+  UINT16    Uint16;
+} PCI_EXPRESS_EXTENDED_CAPABILITIES_PASID_CONTROL;
+
+typedef struct {
+  PCI_EXPRESS_EXTENDED_CAPABILITIES_HEADER           Header;
+  PCI_EXPRESS_EXTENDED_CAPABILITIES_PASID_CAPABILITY Capability;
+  PCI_EXPRESS_EXTENDED_CAPABILITIES_PASID_CONTROL    Control;
+} PCI_EXPRESS_EXTENDED_CAPABILITIES_PASID;
+
+/*
+ * Downstream Port Containment (DPC) Extended Capability.
+ */
+#define PCI_EXPRESS_EXTENDED_CAPABILITY_DPC_ID       0x001D
+
+typedef union {
+  struct {
+    UINT16    DpcInterruptMsgNo             : 5,  // [4:0]
+              RpExtensionsForDpc            : 1,  // [5]
+              PoisonedTlpEgressBlockingSupp : 1,  // [6]
+              DpcSoftwareTriggerSupp        : 1,  // [7]
+              RpPioLogSize                  : 4,  // [11:8] Bits [3:0] of log size
+              DlActiveErrCorSignalingSupp   : 1,  // [12]
+              RpPioLogSizeExt               : 1,  // [13]   Bit [4] of log size
+              Reserved                      : 2;  // [15:14]
+  } Bits;
+  UINT32      Uint16;
+} PCI_EXPRESS_REG_DPC_CAPABILITY;
+
+typedef union {
+  struct {
+    UINT16    DpcTriggerEn                  : 2,  // [1:0]
+              DpcCompletionCtl              : 1,  // [2]
+              DpcInterruptEn                : 1,  // [3]
+              DpcErrCorEn                   : 1,  // [4]
+              PoisonedTlpEgressBlockingEn   : 1,  // [5]
+              DpcSoftwareTrigger            : 1,  // [6]
+              DlActiveErrCorEn              : 1,  // [7]
+              DpcSigSfwEn                   : 1,  // [8]
+              Reserved                      : 7;  // [15:9]
+  } Bits;
+  UINT16      Uint16;
+} PCI_EXPRESS_REG_DPC_CONTROL;
+
+typedef union {
+  struct {
+    UINT16    DpcTriggerStatus              : 1,  // [0]
+              DpcTriggerReason              : 2,  // [2:1]
+              DpcInterruptStatus            : 1,  // [3]
+              DpcRpBusy                     : 1,  // [4]
+              DpcTriggerReasonExtension     : 2,  // [6:5]
+              Reserved0                     : 1,  // [7]
+              RpPioFirstErrorPointer        : 5,  // [12:8]
+              DpcSigSfwStatus               : 1,  // [13]
+              Reserved1                     : 2;  // [15:14]
+  } Bits;
+  UINT16      Uint16;
+} PCI_EXPRESS_REG_DPC_STATUS;
+
+typedef struct {
+  PCI_EXPRESS_EXTENDED_CAPABILITIES_HEADER  Header;
+  PCI_EXPRESS_REG_DPC_CAPABILITY            Capability;         // Offset 04h size 2
+  PCI_EXPRESS_REG_DPC_CONTROL               Control;            // Offset 06h size 2
+  PCI_EXPRESS_REG_DPC_STATUS                Status;             // Offset 08h size 2
+  UINT16                                    ErrSourceId;        // Offset 0Ah size 2
+  UINT32                                    RpPioStatus;        // Offset 0Ch size 4
+  UINT32                                    RpPioMask;          // Offset 10h size 4
+  UINT32                                    RpPioSeverity;      // Offset 14h size 4
+  UINT32                                    RpPioSysErr;        // Offset 18h size 4
+  UINT32                                    RpPioException;     // Offset 1Ch size 4
+  UINT32                                    RpPioHdrLog[4];     // Offset 20h size 16 header log DW 1-4
+  UINT32                                    RpPioImpSpecLog;    // Offset 30h size 4
+  UINT32                                    RpPioHdrLogExt[10]; // Offset 34h size 40 header log DW 5-14
+} PCI_EXPRESS_EXTENDED_CAPABILITIES_DPC;
+
+
+/*
+ * L1 PM Substates Extended Capability.
+ */
 #define PCI_EXPRESS_EXTENDED_CAPABILITY_L1_PM_SUBSTATES_ID    0x001E
 #define PCI_EXPRESS_EXTENDED_CAPABILITY_L1_PM_SUBSTATES_VER1  0x1
 
@@ -67,42 +172,44 @@ typedef struct {
   PCI_EXPRESS_REG_L1_PM_SUBSTATES_CONTROL2      Control2;
 } PCI_EXPRESS_EXTENDED_CAPABILITIES_L1_PM_SUBSTATES;
 
-/// Process Address Space ID Extended Capability Structure
-///
-/// Based on section 7.29 of PCI Express Base Specification 3.1
-///@{
-#define PCI_EXPRESS_EXTENDED_CAPABILITY_PASID_ID    0x001B
-#define PCI_EXPRESS_EXTENDED_CAPABILITY_PASID_VER1  0x1
+
+/*
+ * Precision Time Measurement (PTM) Extended Capability.
+ */
+#define PCI_EXPRESS_EXTENDED_CAPABILITY_PTM_ID   0x001F
 
 typedef union {
   struct {
-    UINT16    PasidSupport             : 1;
-    UINT16    ExecutePermissionSupport : 1;
-    UINT16    PrivilegedModeSupport    : 1;
-    UINT16    Reserved1                : 5;
-    UINT16    MaxPasidWidth            : 5;
-    UINT16    Reserved2                : 3;
+    UINT32    PtmRequesterCapable             : 1,  // [0]
+              PtrmResponderCapable            : 1,  // [1]
+              PtmRootCapable                  : 1,  // [2]
+              EPtmCapable                     : 1,  // [3]
+              PtmPropatagionDelayAdaptCapable : 1,  // [4]
+              Reserved0                       : 3,  // [7:5]
+              LocalClockGranularity           : 8,  // [15:8]
+              Reserved1                       :16;  // [31:16]
   } Bits;
-  UINT16    Uint16;
-} PCI_EXPRESS_EXTENDED_CAPABILITIES_PASID_CAPABILITY;
+  UINT32      Uint32;
+} PCI_EXPRESS_REG_PTM_CAPABILITY;
 
 typedef union {
   struct {
-    UINT16    PasidEnable             : 1;
-    UINT16    ExecutePermissionEnable : 1;
-    UINT16    PrivilegedModeEnable    : 1;
-    UINT16    Reserved                : 13;
+    UINT32    PtmEnable                       : 1,  // [0]
+              RootSelect                      : 1,  // [1]
+              Reserved0                       : 6,  // [7:2]
+              EffectiveGranularity            : 8,  // [15:8]
+              Reserved1                       :16;  // [31:16]
   } Bits;
-  UINT16    Uint16;
-} PCI_EXPRESS_EXTENDED_CAPABILITIES_PASID_CONTROL;
+  UINT32      Uint32;
+} PCI_EXPRESS_REG_PTM_CONTROL;
 
 typedef struct {
-  PCI_EXPRESS_EXTENDED_CAPABILITIES_HEADER              Header;
-  PCI_EXPRESS_EXTENDED_CAPABILITIES_PASID_CAPABILITY    Capability;
-  PCI_EXPRESS_EXTENDED_CAPABILITIES_PASID_CONTROL       Control;
-} PCI_EXPRESS_EXTENDED_CAPABILITIES_PASID;
-///@}
+  PCI_EXPRESS_EXTENDED_CAPABILITIES_HEADER       Header;
+  PCI_EXPRESS_REG_PTM_CAPABILITY                 Capability; // Offset 04h size 4
+  PCI_EXPRESS_REG_PTM_CONTROL                    Control;    // Offset 08h size 4
+} PCI_EXPRESS_EXTENDED_CAPABILITIES_PTM;
 
 #pragma pack()
 
 #endif
+

--- a/MdePkg/Include/IndustryStandard/PciExpress40.h
+++ b/MdePkg/Include/IndustryStandard/PciExpress40.h
@@ -16,47 +16,42 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #pragma pack(1)
 
-/// Precision Time Management Extended Capability definitions.
-///
-/// Based on section 7.9.16 of PCI Express Base Specification 4.0.
-///@{
-#define PCI_EXPRESS_EXTENDED_CAPABILITY_PTM_ID    0x001F
-#define PCI_EXPRESS_EXTENDED_CAPABILITY_PTM_VER1  0x1
-
-#define PCI_EXPRESS_EXTENDED_CAPABILITIES_PTM_CAPABILITY_OFFSET  0x04
-#define PCI_EXPRESS_EXTENDED_CAPABILITIES_PTM_CONTROL_OFFSET     0x08
+/*
+ * Data Link Feature (DLF) Extended Capability.
+ */
+#define PCI_EXPRESS_EXTENDED_CAPABILITY_DLF_ID   0x0025
 
 typedef union {
   struct {
-    UINT32    PTMRequesterCapable                  : 1;
-    UINT32    PTMResponderCapable                  : 1;
-    UINT32    PTMRootCapable                       : 1;
-    UINT32    ePTMCapable                          : 1;
-    UINT32    PTMPropagationDelayAdaptationCapable : 1;
-    UINT32    Reserved                             : 3;
-    UINT32    LocalClockGranularity                : 8;
-    UINT32    Reserved2                            : 16;
+    UINT32    LocalScaledFlowControlSupported    : 1,  // [0]
+              LocalImmediateReadiness            : 1,  // [1]
+              LocalExtendedVcCount               : 3,  // [4:2]
+              LocalL0pExitLatency                : 3,  // [7:5]
+              Reserved0                          :15,  // [22:8]
+              Reserved1                          : 8,  // [30:23]
+              DataLinkFeatureExchangeEnable      : 1;  // [31]
   } Bits;
-  UINT32    Uint32;
-} PCI_EXPRESS_EXTENDED_CAPABILITIES_PTM_CAPABILITY;
+  UINT32      Uint32;
+} PCI_EXPRESS_REG_DLF_CAPABILITY;
 
 typedef union {
   struct {
-    UINT32    PTMEnable            : 1;
-    UINT32    RootSelect           : 1;
-    UINT32    Reserved             : 6;
-    UINT32    EffectiveGranularity : 8;
-    UINT32    Reserved2            : 16;
+    UINT32    RemoteScaledFlowControlSupported   : 1,  // [0]
+              RemoteImmediateReadiness           : 1,  // [1]
+              ExtendedVcCound                    : 3,  // [4:2]
+              RemoteL0pExitLatency               : 3,  // [7:5]
+              Reserved0                          :15,  // [22:8]
+              Reserved1                          : 8,  // [30:23]
+              DataLinkFeatureStatusValid         : 1;  // [31]
   } Bits;
-  UINT32    Uint32;
-} PCI_EXPRESS_EXTENDED_CAPABILITIES_PTM_CONTROL;
+  UINT32      Uint32;
+} PCI_EXPRESS_REG_DLF_STATUS;
 
 typedef struct {
-  PCI_EXPRESS_EXTENDED_CAPABILITIES_HEADER            Header;
-  PCI_EXPRESS_EXTENDED_CAPABILITIES_PTM_CAPABILITY    Capability;
-  PCI_EXPRESS_EXTENDED_CAPABILITIES_PTM_CONTROL       Control;
-} PCI_EXPRESS_EXTENDED_CAPABILITIES_PTM;
-///@}
+  PCI_EXPRESS_EXTENDED_CAPABILITIES_HEADER       Header;
+  PCI_EXPRESS_REG_DLF_CAPABILITY                 Capability;
+  PCI_EXPRESS_REG_DLF_STATUS                     Status;
+} PCI_EXPRESS_EXTENDED_CAPABILITIES_DLF;
 
 /// The Physical Layer PCI Express Extended Capability definitions.
 ///


### PR DESCRIPTION
Add definitions for Downstream Port Containment (DPC) Extended Capability. Add definitions for Data Link Feature (DLF).
Update existing definitions for PASID and Precision Time Measurement (PTM) and move it from PciExpress40.h to PciExpress31.h as it was defined in PCIe 3.1. Mark some duplicate symbols 'obsolete' to remove in future.

# Description

<_Include a description of the change and why this change was made._>

<_For each item, place an "x" in between `[` and `]` if true. Example: `[x]` (you can also check items in GitHub UI)_>

<_Create the PR as a Draft PR if it is only created to run CI checks._>

<_Delete lines in \<\> tags before creating the PR._>

- [ ] Breaking change?
  - No
- [ ] Impacts security?
  - No
- [ ] Includes tests?
  - No

## How This Was Tested

Tested in recently developed Intel server platforms.

## Integration Instructions

N/A
