### PR TITLE
ArmPkg/Library/ArmTransferList: TransferList checksum correction; use…

### DIFF
--- a/ArmPkg/Library/ArmTransferListLib/ArmTransferListLib.c
+++ b/ArmPkg/Library/ArmTransferListLib/ArmTransferListLib.c
@@ -16,6 +16,30 @@
 #include <Library/HobLib.h>
 
 /**
+  Compute the byte-wise XOR over the used portion of a Transfer List.
+
+  @param[in]  TransferListHeader   Pointer to the Transfer List Header.
+
+  @retval 0-255   XOR of all bytes across the used portion.
+**/
+STATIC
+UINT8
+CalculateXor8 (
+  IN TRANSFER_LIST_HEADER  *TransferListHeader
+  )
+{
+  UINT8  Xor;
+  UINTN  Index;
+
+  Xor = 0;
+  for (Index = 0; Index < TransferListHeader->UsedSize; Index++) {
+    Xor ^= ((UINT8 *)TransferListHeader)[Index];
+  }
+
+  return Xor;
+}
+
+/**
   Get the TransferList from HOB list.
 
   @param[out] TransferList  TransferList
@@ -76,7 +100,7 @@ TransferListVerifyChecksum (
     return TRUE;
   }
 
-  return (CalculateSum8 ((UINT8 *)TransferListHeader, TransferListHeader->UsedSize) == 0);
+  return (CalculateXor8 (TransferListHeader) == 0);
 }
 
 /**


### PR DESCRIPTION
… XOR

Change checksum logic from sum to XOR, matching the specification. Update TransferListVerifyChecksum function accordingly.

# Description

The Firmware Handoff spec 1.0 changed the checksum approach
> The checksum is set to a value such that the XOR over every byte in the
> {tl_base_pa, …, tl_base_pa + used_size - 1} address range is equal to 0.

This patch updates how we calculate the checksum and also the TransferListVerifyChecksum function where its used.



- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Tested on FVP and a PoC on RPi3

## Integration Instructions

N/A