### PR TITLE
BaseTools: use double hyphens for CLANGPDB llvm-rc

### DIFF
--- a/BaseTools/Conf/build_rule.template
+++ b/BaseTools/Conf/build_rule.template
@@ -706,9 +706,13 @@
     <OutputFile.XCODE>
         $(OUTPUT_DIR)(+)$(MODULE_NAME)hii.rc
 
-    <Command.MSFT, Command.INTEL, Command.CLANGPDB>
+    <Command.MSFT, Command.INTEL>
         "$(GENFW)" -o $(OUTPUT_DIR)(+)$(MODULE_NAME)hii.rc -g $(MODULE_GUID) --hiipackage $(HII_BINARY_PACKAGES) $(GENFW_FLAGS)
         "$(RC)" /Fo${dst} $(OUTPUT_DIR)(+)$(MODULE_NAME)hii.rc
+
+    <Command.CLANGPDB>
+        "$(GENFW)" -o $(OUTPUT_DIR)(+)$(MODULE_NAME)hii.rc -g $(MODULE_GUID) --hiipackage $(HII_BINARY_PACKAGES) $(GENFW_FLAGS)
+        "$(RC)" /Fo${dst} -- $(OUTPUT_DIR)(+)$(MODULE_NAME)hii.rc
 
     <Command.GCC>
         "$(GENFW)" -o $(OUTPUT_DIR)(+)$(MODULE_NAME)hii.rc -g $(MODULE_GUID) --hiibinpackage $(HII_BINARY_PACKAGES) $(GENFW_FLAGS)


### PR DESCRIPTION
# Description

When compiling rc files in OSX, llvm-rc treats '/Fo/PathToFile' as a positional argument. This results in the error "Exactly one input file should be provided". Using double hyphens llvm splits all data on the left side as options and data on the right side as positional arguments.

See: https://llvm.org/docs/CommandLine.html
Section: Specifying positional options with hyphens

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Run the following command on OS X(M3) and Linux(x64):

```
build -a X64 -t CLANGPDB -p OvmfPkg/OvmfPkgX64.dsc -b DEBUG
```

## Integration Instructions

N/A
