### PR TITLE
SecurityPkg/Tcg2ConfigPei: Add gEfiPeiMemoryDiscoveredPpiGuid dependency 

### DIFF
--- a/SecurityPkg/Tcg/Tcg2Config/Tcg2ConfigPei.inf
+++ b/SecurityPkg/Tcg/Tcg2Config/Tcg2ConfigPei.inf
@@ -5,6 +5,7 @@
 #  NOTE: This module is only for reference only, each platform should have its own setup page.
 #
 # Copyright (c) 2015 - 2024, Intel Corporation. All rights reserved.<BR>
+# Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.<BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -72,7 +73,8 @@
 
 [Depex]
   gEfiPeiMasterBootModePpiGuid AND
-  gEfiPeiReadOnlyVariable2PpiGuid
+  gEfiPeiReadOnlyVariable2PpiGuid AND
+  gEfiPeiMemoryDiscoveredPpiGuid
 
 [UserExtensions.TianoCore."ExtraFiles"]
   Tcg2ConfigPeiExtra.uni


### PR DESCRIPTION
# Description
Introduce a dependency on gEfiPeiMemoryDiscoveredPpiGuid to ensure proper PPI sequencing and prevent failures when locating gEfiPeiReadOnlyVariable2PpiGuid.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Tested on AMD platforms.

## Integration Instructions

N/A