### PR TITLE
MdeModulePkg: ArmFfaLib: Add FFA_YIELD handling

### DIFF
--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaCommon.c
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaCommon.c
@@ -143,7 +143,7 @@ FfaArgsToEfiStatus (
      * FfaStatusToEfiStatus (FfaARgs.Arg2) returns proper EFI_STATUS.
      */
     FfaStatus = ARM_FFA_RET_NOT_SUPPORTED;
-  } else if (FfaArgs->Arg0 == ARM_FID_FFA_INTERRUPT) {
+  } else if ((FfaArgs->Arg0 == ARM_FID_FFA_INTERRUPT) || (FfaArgs->Arg0 == ARM_FID_FFA_YIELD)) {
     FfaStatus = ARM_FFA_RET_INTERRUPTED;
   } else {
     FfaStatus = ARM_FFA_RET_SUCCESS;


### PR DESCRIPTION
# Description

If a secure partition on AArch64 platforms would consume extended time to operate with peripherals, it might elect to yield the control back to normal world and expect the normal world to callback after specified period of time.

This change adds the FFA_YIELD handling from ArmFfaLib to support long operations from secure partitions.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

This was tested on proprietary hardware platforms and booted to Windows.

## Integration Instructions

Platforms will need to add a `TimerLib` instance for the corresponding phase.
