### PR TITLE
UnitTestFrameworkPkg: Use 8MB stack for MSFT and CLANGPDB

### DIFF
--- a/UnitTestFrameworkPkg/UnitTestFrameworkPkgHost.dsc.inc
+++ b/UnitTestFrameworkPkg/UnitTestFrameworkPkgHost.dsc.inc
@@ -87,7 +87,7 @@
   #
   # Set MSFT HOST_APPLICATION options
   #
-  MSFT:*_*_*_DLINK_FLAGS            == /nologo /SUBSYSTEM:CONSOLE /DEBUG /out:"$(BIN_DIR)\$(MODULE_NAME_GUID).exe" /pdb:"$(BIN_DIR)\$(MODULE_NAME_GUID).pdb" /WHOLEARCHIVE
+  MSFT:*_*_*_DLINK_FLAGS            == /nologo /SUBSYSTEM:CONSOLE /DEBUG /out:"$(BIN_DIR)\$(MODULE_NAME_GUID).exe" /pdb:"$(BIN_DIR)\$(MODULE_NAME_GUID).pdb" /WHOLEARCHIVE /STACK:0x00800000,0x00800000
 
   MSFT:*_VS2015_IA32_DLINK_FLAGS    = /LIBPATH:"%VS2015_PREFIX%Lib" /LIBPATH:"%VS2015_PREFIX%VC\Lib" /LIBPATH:"%UniversalCRTSdkDir%lib\%UCRTVersion%\ucrt\x86" /LIBPATH:"%WindowsSdkDir%lib\%WindowsSDKLibVersion%\um\x86"
   MSFT:*_VS2015x86_IA32_DLINK_FLAGS = /LIBPATH:"%VS2015_PREFIX%Lib" /LIBPATH:"%VS2015_PREFIX%VC\Lib" /LIBPATH:"%UniversalCRTSdkDir%lib\%UCRTVersion%\ucrt\x86" /LIBPATH:"%WindowsSdkDir%lib\%WindowsSDKLibVersion%\um\x86"
@@ -132,7 +132,7 @@
   #
   # Set CLANGPDB HOST_APPLICATION options
   #
-  CLANGPDB:*_*_*_DLINK_FLAGS   == /nologo /SUBSYSTEM:CONSOLE /DEBUG /out:"$(BIN_DIR)\$(MODULE_NAME_GUID).exe" /pdb:"$(BIN_DIR)\$(MODULE_NAME_GUID).pdb" /WHOLEARCHIVE
+  CLANGPDB:*_*_*_DLINK_FLAGS   == /nologo /SUBSYSTEM:CONSOLE /DEBUG /out:"$(BIN_DIR)\$(MODULE_NAME_GUID).exe" /pdb:"$(BIN_DIR)\$(MODULE_NAME_GUID).pdb" /WHOLEARCHIVE /STACK:0x00800000,0x00800000
   CLANGPDB:*_*_X64_DLINK_FLAGS  = /LIBPATH:"%VCToolsInstallDir%lib\x64" /LIBPATH:"%UniversalCRTSdkDir%lib\%UCRTVersion%\ucrt\x64" /LIBPATH:"%WindowsSdkDir%lib\%WindowsSDKLibVersion%\um\x64"
 !if $(UNIT_TESTING_ADDRESS_SANITIZER_ENABLE)
   CLANGPDB:*_*_X64_DLINK_FLAGS  = clang_rt.profile-x86_64.lib clang_rt.asan_dynamic-x86_64.lib clang_rt.asan_dynamic_runtime_thunk-x86_64.lib


### PR DESCRIPTION
# Description

Linux/GCC host-based unit test application builds use a default stack size of 8MB. Windows/VS20xx and Windows/CLANGPDB host-based unit test application builds use a default stack size of 1MB. This can allow Linux unit tests to pass and Windows unit tests to fail with stack overflow if large local variables are used. ASAN increases stack usage, so this condition can occur more frequently when ASAN enabled.

Update MSFT and CLANGPDB for host-based unit tests to use a default stack size of 8MB so all tool chains use the same default stack size for host-based unit tests.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

Observed unit tests that fails with stack overflow exception with VS20xx, but not GCC.  With this change, the stack overflow exception does not occur and the same unit tests results are generated by both VS20xx and GCC.

## Integration Instructions

N/A
