### PR TITLE
IntelFsp2Pkg/Tools/ConfigEditor: Fixed YAML data overwrite issue

### DIFF
--- a/IntelFsp2Pkg/Tools/ConfigEditor/GenYamlCfg.py
+++ b/IntelFsp2Pkg/Tools/ConfigEditor/GenYamlCfg.py
@@ -1537,7 +1537,7 @@ option format '%s' !" % option)
                 return
             act_cfg = self.get_item_by_index(cfgs['indx'])
             actual_offset = act_cfg['offset'] - struct_info['offset']
-            if force or act_cfg['value'] == '':
+            if act_cfg['value'] == '':
                 value = get_bits_from_bytes(full_bytes,
                                             actual_offset,
                                             act_cfg['length'])


### PR DESCRIPTION
Problem Description:
The condition if force or act_cfg['value'] == '' in _set_field_value() caused valid YAML values 
to be wrongly overwritten with binary data. 
Since force=True made the condition always true, correct YAML entries like "0xFE02C000" were replaced 
by binary values such as "0x01010101", leading to corrupted configurations and incorrect FSP settings.

Solution Implementation:
The condition was updated to if act_cfg['value'] == '', removing the force dependency. 
This ensures binary data is used only when the YAML value is empty, 
preserving valid configurations and preventing overwrites.