### PR TITLE
SecurityPkg: Introduce Tpm2HelpLib

### DIFF
--- a/ArmPlatformPkg/ArmPlatformPkg.dsc
+++ b/ArmPlatformPkg/ArmPlatformPkg.dsc
@@ -88,6 +88,7 @@
   MemoryAllocationLib|EmbeddedPkg/Library/PrePiMemoryAllocationLib/PrePiMemoryAllocationLib.inf
   PrePiHobListPointerLib|ArmPlatformPkg/Library/PrePiHobListPointerLib/PrePiHobListPointerLib.inf
   Tpm2CommandLib|SecurityPkg/Library/Tpm2CommandLib/Tpm2CommandLib.inf
+  Tpm2HelpLib|SecurityPkg/Library/Tpm2HelpLib/Tpm2HelpLib.inf
   Tpm2DeviceLib|SecurityPkg/Library/Tpm2DeviceLibFfa/Tpm2DeviceSecLibFfa.inf
   HashLib|SecurityPkg/Library/HashLibTpm2/HashLibTpm2PeilessSecLib.inf
   PeilessSecMeasureLib|SecurityPkg/Library/PeilessSecMeasureLib/PeilessSecMeasureLib.inf

--- a/ArmVirtPkg/ArmVirtQemu.dsc
+++ b/ArmVirtPkg/ArmVirtQemu.dsc
@@ -78,6 +78,7 @@
 
 !if $(TPM2_ENABLE) == TRUE
   Tpm2CommandLib|SecurityPkg/Library/Tpm2CommandLib/Tpm2CommandLib.inf
+  Tpm2HelpLib|SecurityPkg/Library/Tpm2HelpLib/Tpm2HelpLib.inf
   Tcg2PhysicalPresenceLib|OvmfPkg/Library/Tcg2PhysicalPresenceLibQemu/DxeTcg2PhysicalPresenceLib.inf
   TpmMeasurementLib|SecurityPkg/Library/DxeTpmMeasurementLib/DxeTpmMeasurementLib.inf
   TpmPlatformHierarchyLib|SecurityPkg/Library/PeiDxeTpmPlatformHierarchyLib/PeiDxeTpmPlatformHierarchyLib.inf

--- a/IntelFsp2WrapperPkg/IntelFsp2WrapperPkg.dsc
+++ b/IntelFsp2WrapperPkg/IntelFsp2WrapperPkg.dsc
@@ -56,6 +56,7 @@
   FspWrapperHobProcessLib|IntelFsp2WrapperPkg/Library/PeiFspWrapperHobProcessLibSample/PeiFspWrapperHobProcessLibSample.inf
 
   Tpm2CommandLib|SecurityPkg/Library/Tpm2CommandLib/Tpm2CommandLib.inf
+  Tpm2HelpLib|SecurityPkg/Library/Tpm2HelpLib/Tpm2HelpLib.inf
 
 [LibraryClasses.common.PEIM,LibraryClasses.common.PEI_CORE]
   PeimEntryPoint|MdePkg/Library/PeimEntryPoint/PeimEntryPoint.inf

--- a/OvmfPkg/Include/Dsc/OvmfTpmLibs.dsc.inc
+++ b/OvmfPkg/Include/Dsc/OvmfTpmLibs.dsc.inc
@@ -3,6 +3,7 @@
 ##
 
 [LibraryClasses]
+  Tpm2HelpLib|SecurityPkg/Library/Tpm2HelpLib/Tpm2HelpLib.inf
 !if $(TPM2_ENABLE) == TRUE
 !if $(TPM1_ENABLE) == TRUE
   Tpm12CommandLib|SecurityPkg/Library/Tpm12CommandLib/Tpm12CommandLib.inf

--- a/OvmfPkg/IntelTdx/IntelTdxX64.dsc
+++ b/OvmfPkg/IntelTdx/IntelTdxX64.dsc
@@ -206,6 +206,7 @@
 
   Tcg2PhysicalPresenceLib|OvmfPkg/Library/Tcg2PhysicalPresenceLibNull/DxeTcg2PhysicalPresenceLib.inf
   TpmMeasurementLib|SecurityPkg/Library/DxeTpmMeasurementLib/DxeTpmMeasurementLib.inf
+  Tpm2HelpLib|SecurityPkg/Library/Tpm2HelpLib/Tpm2HelpLib.inf
 
 !include OvmfPkg/Include/Dsc/ShellLibs.dsc.inc
 

--- a/OvmfPkg/RiscVVirt/RiscVVirtQemu.dsc
+++ b/OvmfPkg/RiscVVirt/RiscVVirtQemu.dsc
@@ -135,6 +135,7 @@
 
 !if $(TPM2_ENABLE) == TRUE
   Tpm2CommandLib|SecurityPkg/Library/Tpm2CommandLib/Tpm2CommandLib.inf
+  Tpm2HelpLib|SecurityPkg/Library/Tpm2HelpLib/Tpm2HelpLib.inf
   Tcg2PhysicalPresenceLib|OvmfPkg/Library/Tcg2PhysicalPresenceLibQemu/DxeTcg2PhysicalPresenceLib.inf
   TpmMeasurementLib|SecurityPkg/Library/DxeTpmMeasurementLib/DxeTpmMeasurementLib.inf
   TpmPlatformHierarchyLib|SecurityPkg/Library/PeiDxeTpmPlatformHierarchyLib/PeiDxeTpmPlatformHierarchyLib.inf

--- a/OvmfPkg/Tcg/TdTcg2Dxe/TdTcg2Dxe.c
+++ b/OvmfPkg/Tcg/TdTcg2Dxe/TdTcg2Dxe.c
@@ -45,6 +45,7 @@
 #include <Guid/CcEventHob.h>
 #include <Library/TdxLib.h>
 #include <Library/TdxMeasurementLib.h>
+#include <Library/Tpm2HelpLib.h>
 
 #define PERF_ID_CC_TCG2_DXE  0x3130
 
@@ -78,12 +79,6 @@ typedef struct _TDX_DXE_DATA {
   CC_EVENT_LOG_AREA_STRUCT          FinalEventLogAreaStruct[CC_EVENT_LOG_AREA_COUNT_MAX];
   EFI_CC_FINAL_EVENTS_TABLE         *FinalEventsTable[CC_EVENT_LOG_AREA_COUNT_MAX];
 } TDX_DXE_DATA;
-
-typedef struct {
-  TPMI_ALG_HASH    HashAlgo;
-  UINT16           HashSize;
-  UINT32           HashMask;
-} TDX_HASH_INFO;
 
 //
 //
@@ -128,104 +123,6 @@ EFI_CC_EVENTLOG_ACPI_TABLE  mTdxEventlogAcpiTemplate = {
   0,                      // laml
   0,                      // lasa
 };
-
-//
-// Supported Hash list in Td guest.
-// Currently SHA384 is supported.
-//
-TDX_HASH_INFO  mHashInfo[] = {
-  { TPM_ALG_SHA384, SHA384_DIGEST_SIZE, HASH_ALG_SHA384 }
-};
-
-/**
-  Get hash size based on Algo
-
-  @param[in]     HashAlgo           Hash Algorithm Id.
-
-  @return Size of the hash.
-**/
-UINT16
-GetHashSizeFromAlgo (
-  IN TPMI_ALG_HASH  HashAlgo
-  )
-{
-  UINTN  Index;
-
-  for (Index = 0; Index < sizeof (mHashInfo)/sizeof (mHashInfo[0]); Index++) {
-    if (mHashInfo[Index].HashAlgo == HashAlgo) {
-      return mHashInfo[Index].HashSize;
-    }
-  }
-
-  return 0;
-}
-
-/**
-  Get hash mask based on Algo
-
-  @param[in]     HashAlgo           Hash Algorithm Id.
-
-  @return Hash mask.
-**/
-UINT32
-GetHashMaskFromAlgo (
-  IN TPMI_ALG_HASH  HashAlgo
-  )
-{
-  UINTN  Index;
-
-  for (Index = 0; Index < ARRAY_SIZE (mHashInfo); Index++) {
-    if (mHashInfo[Index].HashAlgo == HashAlgo) {
-      return mHashInfo[Index].HashMask;
-    }
-  }
-
-  ASSERT (FALSE);
-  return 0;
-}
-
-/**
-  Copy TPML_DIGEST_VALUES into a buffer
-
-  @param[in,out] Buffer             Buffer to hold copied TPML_DIGEST_VALUES compact binary.
-  @param[in]     DigestList         TPML_DIGEST_VALUES to be copied.
-  @param[in]     HashAlgorithmMask  HASH bits corresponding to the desired digests to copy.
-
-  @return The end of buffer to hold TPML_DIGEST_VALUES.
-**/
-VOID *
-CopyDigestListToBuffer (
-  IN OUT VOID            *Buffer,
-  IN TPML_DIGEST_VALUES  *DigestList,
-  IN UINT32              HashAlgorithmMask
-  )
-{
-  UINTN   Index;
-  UINT16  DigestSize;
-  UINT32  DigestListCount;
-  UINT32  *DigestListCountPtr;
-
-  DigestListCountPtr = (UINT32 *)Buffer;
-  DigestListCount    = 0;
-  Buffer             = (UINT8 *)Buffer + sizeof (DigestList->count);
-  for (Index = 0; Index < DigestList->count; Index++) {
-    if ((DigestList->digests[Index].hashAlg & HashAlgorithmMask) == 0) {
-      DEBUG ((DEBUG_ERROR, "WARNING: TD Event log has HashAlg unsupported (0x%x)\n", DigestList->digests[Index].hashAlg));
-      continue;
-    }
-
-    CopyMem (Buffer, &DigestList->digests[Index].hashAlg, sizeof (DigestList->digests[Index].hashAlg));
-    Buffer     = (UINT8 *)Buffer + sizeof (DigestList->digests[Index].hashAlg);
-    DigestSize = GetHashSizeFromAlgo (DigestList->digests[Index].hashAlg);
-    CopyMem (Buffer, &DigestList->digests[Index].digest, DigestSize);
-    Buffer = (UINT8 *)Buffer + DigestSize;
-    DigestListCount++;
-  }
-
-  WriteUnaligned32 (DigestListCountPtr, DigestListCount);
-
-  return Buffer;
-}
 
 EFI_HANDLE  mImageHandle;
 
@@ -346,7 +243,7 @@ InitNoActionEvent (
   if ((mTdxDxeData.BsCap.HashAlgorithmBitmap & EFI_CC_BOOT_HASH_ALG_SHA384) != 0) {
     HashAlgId = TPM_ALG_SHA384;
     CopyMem (DigestBuffer, &HashAlgId, sizeof (TPMI_ALG_HASH));
-    DigestBuffer += sizeof (TPMI_ALG_HASH) + GetHashSizeFromAlgo (HashAlgId);
+    DigestBuffer += sizeof (TPMI_ALG_HASH) + Tpm2GetHashSizeFromAlgo (HashAlgId);
     DigestListCount++;
   }
 
@@ -605,7 +502,7 @@ DumpCcEvent (
   for (DigestIndex = 0; DigestIndex < DigestCount; DigestIndex++) {
     DEBUG ((DEBUG_INFO, "      HashAlgo : 0x%04x\n", HashAlgo));
     DEBUG ((DEBUG_INFO, "      Digest(%d): \n", DigestIndex));
-    DigestSize = GetHashSizeFromAlgo (HashAlgo);
+    DigestSize = Tpm2GetHashSizeFromAlgo (HashAlgo);
     InternalDumpHex (DigestBuffer, DigestSize);
     //
     // Prepare next
@@ -647,7 +544,7 @@ GetCcEventSize (
   HashAlgo     = CcEvent->Digests.digests[0].hashAlg;
   DigestBuffer = (UINT8 *)&CcEvent->Digests.digests[0].digest;
   for (DigestIndex = 0; DigestIndex < DigestCount; DigestIndex++) {
-    DigestSize = GetHashSizeFromAlgo (HashAlgo);
+    DigestSize = Tpm2GetHashSizeFromAlgo (HashAlgo);
     //
     // Prepare next
     //
@@ -1078,7 +975,7 @@ GetDigestListBinSize (
     TotalSize    += sizeof (HashAlg);
     DigestListBin = (UINT8 *)DigestListBin + sizeof (HashAlg);
 
-    DigestSize    = GetHashSizeFromAlgo (HashAlg);
+    DigestSize    = Tpm2GetHashSizeFromAlgo (HashAlg);
     TotalSize    += DigestSize;
     DigestListBin = (UINT8 *)DigestListBin + DigestSize;
   }
@@ -1121,7 +1018,7 @@ CopyDigestListBinToBuffer (
   for (Index = 0; Index < Count; Index++) {
     HashAlg       = ReadUnaligned16 (DigestListBin);
     DigestListBin = (UINT8 *)DigestListBin + sizeof (HashAlg);
-    DigestSize    = GetHashSizeFromAlgo (HashAlg);
+    DigestSize    = Tpm2GetHashSizeFromAlgo (HashAlg);
 
     if ((HashAlg & HashAlgorithmMask) != 0) {
       CopyMem (Buffer, &HashAlg, sizeof (HashAlg));
@@ -1129,7 +1026,7 @@ CopyDigestListBinToBuffer (
       CopyMem (Buffer, DigestListBin, DigestSize);
       Buffer = (UINT8 *)Buffer + DigestSize;
       DigestListCount++;
-      (*HashAlgorithmMaskCopied) |= GetHashMaskFromAlgo (HashAlg);
+      (*HashAlgorithmMaskCopied) |= Tpm2GetHashMaskFromAlgo (HashAlg);
     } else {
       DEBUG ((DEBUG_ERROR, "WARNING: CopyDigestListBinToBuffer Event log has HashAlg unsupported by PCR bank (0x%x)\n", HashAlg));
     }
@@ -1178,7 +1075,7 @@ TdxDxeLogHashEvent (
   CcEvent.MrIndex   = NewEventHdr->MrIndex;
   CcEvent.EventType = NewEventHdr->EventType;
   DigestBuffer      = (UINT8 *)&CcEvent.Digests;
-  EventSizePtr      = CopyDigestListToBuffer (DigestBuffer, DigestList, HASH_ALG_SHA384);
+  EventSizePtr      = Tpm2CopyDigestListToBuffer (DigestBuffer, DigestList, HASH_ALG_SHA384);
   CopyMem (EventSizePtr, &NewEventHdr->EventSize, sizeof (NewEventHdr->EventSize));
 
   //

--- a/OvmfPkg/Tcg/TdTcg2Dxe/TdTcg2Dxe.inf
+++ b/OvmfPkg/Tcg/TdTcg2Dxe/TdTcg2Dxe.inf
@@ -50,6 +50,7 @@
   TpmMeasurementLib
   TdxLib
   TdxMeasurementLib
+  Tpm2HelpLib
 
 [Guids]
   ## SOMETIMES_CONSUMES     ## Variable:L"SecureBoot"

--- a/SecurityPkg/Include/Library/Tpm2HelpLib.h
+++ b/SecurityPkg/Include/Library/Tpm2HelpLib.h
@@ -1,0 +1,186 @@
+/** @file
+  Declares reusable TPM 2.0 data helper routines that are independent
+  of TPM command/device communication libraries. Includes serialization
+  and parsing helpers for common TPM data structures.
+
+Copyright (c) Microsoft Corporation.
+Copyright (c) 2013 - 2024, Intel Corporation. All rights reserved. <BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#pragma once
+
+#include <IndustryStandard/Tpm20.h>
+
+/**
+  Return size of digest.
+
+  @param[in] HashAlgo  Hash algorithm
+
+  @return size of digest
+**/
+UINT16
+EFIAPI
+Tpm2GetHashSizeFromAlgo (
+  IN TPMI_ALG_HASH  HashAlgo
+  );
+
+/**
+  Get hash mask from algorithm.
+
+  @param[in] HashAlgo   Hash algorithm
+
+  @return Hash mask
+**/
+UINT32
+EFIAPI
+Tpm2GetHashMaskFromAlgo (
+  IN TPMI_ALG_HASH  HashAlgo
+  );
+
+/**
+  Copy AuthSessionIn to TPM2 command buffer.
+
+  @param [in]  AuthSessionIn   Input AuthSession data
+  @param [out] AuthSessionOut  Output AuthSession data in TPM2 command buffer
+
+  @return AuthSession size
+**/
+UINT32
+EFIAPI
+Tpm2CopyAuthSessionCommand (
+  IN      TPMS_AUTH_COMMAND  *AuthSessionIn  OPTIONAL,
+  OUT     UINT8              *AuthSessionOut
+  );
+
+/**
+  Copy AuthSessionIn from TPM2 response buffer.
+
+  @param [in]  AuthSessionIn   Input AuthSession data in TPM2 response buffer
+  @param [out] AuthSessionOut  Output AuthSession data
+
+  @return AuthSession size
+**/
+UINT32
+EFIAPI
+Tpm2CopyAuthSessionResponse (
+  IN      UINT8               *AuthSessionIn,
+  OUT     TPMS_AUTH_RESPONSE  *AuthSessionOut OPTIONAL
+  );
+
+/**
+  Return if hash alg is supported in HashAlgorithmMask.
+
+  @param HashAlg            Hash algorithm to be checked.
+  @param HashAlgorithmMask  Bitfield of allowed hash algorithms.
+
+  @retval TRUE  Hash algorithm is supported.
+  @retval FALSE Hash algorithm is not supported.
+**/
+BOOLEAN
+EFIAPI
+Tpm2IsHashAlgSupportedInHashAlgorithmMask (
+  IN TPMI_ALG_HASH  HashAlg,
+  IN UINT32         HashAlgorithmMask
+  );
+
+/**
+  Copy TPML_DIGEST_VALUES into a buffer
+
+  @param[in,out] Buffer             Buffer to hold copied TPML_DIGEST_VALUES compact binary.
+  @param[in]     DigestList         TPML_DIGEST_VALUES to be copied.
+  @param[in]     HashAlgorithmMask  HASH bits corresponding to the desired digests to copy.
+
+  @return The end of buffer to hold TPML_DIGEST_VALUES.
+**/
+VOID *
+EFIAPI
+Tpm2CopyDigestListToBuffer (
+  IN OUT VOID            *Buffer,
+  IN TPML_DIGEST_VALUES  *DigestList,
+  IN UINT32              HashAlgorithmMask
+  );
+
+/**
+  Copy a buffer into a TPML_DIGEST_VALUES structure.
+
+  @param[in]     Buffer             Buffer to hold TPML_DIGEST_VALUES compact binary.
+  @param[in]     BufferSize         Size of Buffer.
+  @param[out]    DigestList         TPML_DIGEST_VALUES.
+
+  @return EFI_STATUS
+  @retval EFI_SUCCESS               Buffer was successfully copied to Digest List.
+  @retval EFI_BAD_BUFFER_SIZE       Bad buffer size passed to function.
+  @retval EFI_INVALID_PARAMETER     Invalid parameter passed to function: NULL pointer or
+                                    BufferSize bigger than TPML_DIGEST_VALUES
+**/
+EFI_STATUS
+EFIAPI
+Tpm2CopyBufferToDigestList (
+  IN CONST  VOID                *Buffer,
+  IN        UINTN               BufferSize,
+  OUT       TPML_DIGEST_VALUES  *DigestList
+  );
+
+/**
+  Get TPML_DIGEST_VALUES data size.
+
+  @param[in]     DigestList    TPML_DIGEST_VALUES data.
+
+  @return TPML_DIGEST_VALUES data size.
+**/
+UINT32
+EFIAPI
+Tpm2GetDigestListSize (
+  IN TPML_DIGEST_VALUES  *DigestList
+  );
+
+/**
+  Get TPML_DIGEST_VALUES data size from HashAlgorithmMask
+
+  @param[in]     HashAlgorithmMask    Bitfield of allowed hash algorithms
+
+  @return TPML_DIGEST_VALUES data size.
+**/
+UINT32
+EFIAPI
+Tpm2GetDigestListSizeFromHashAlgorithmMask (
+  IN UINT32  HashAlgorithmMask
+  );
+
+/**
+  This function get digest from digest list.
+
+  @param[in]  HashAlg       Digest algorithm
+  @param[in]  DigestList    Digest list
+  @param[out] Digest        Digest
+
+  @retval EFI_SUCCESS            Digest is found and returned.
+  @retval EFI_NOT_FOUND          Digest is not found.
+  @retval EFI_INVALID_PARAMETER  DigestList or Digest invalid.
+**/
+EFI_STATUS
+EFIAPI
+Tpm2GetDigestFromDigestList (
+  IN TPMI_ALG_HASH       HashAlg,
+  IN TPML_DIGEST_VALUES  *DigestList,
+  OUT VOID               *Digest
+  );
+
+/**
+  Check if all hash algorithms supported in HashAlgorithmMask are
+  present in the DigestList.
+
+  @param DigestList         Digest list
+  @param HashAlgorithmMask  Bitfield of allowed hash algorithms.
+
+  @retval TRUE  All hash algorithms present.
+  @retval FALSE Some hash algorithms not present.
+**/
+BOOLEAN
+EFIAPI
+Tpm2IsDigestListInSyncWithHashAlgorithmMask (
+  IN TPML_DIGEST_VALUES  *DigestList,
+  IN UINT32              HashAlgorithmMask
+  );

--- a/SecurityPkg/Library/HashLibBaseCryptoRouter/HashLibBaseCryptoRouterCommon.c
+++ b/SecurityPkg/Library/HashLibBaseCryptoRouter/HashLibBaseCryptoRouterCommon.c
@@ -29,7 +29,7 @@ TPM2_HASH_MASK  mTpm2HashMask[] = {
 };
 
 /**
-  The function get hash mask info from algorithm.
+  The function get hash mask info from GUID.
 
   @param HashGuid Hash Guid
 
@@ -37,7 +37,7 @@ TPM2_HASH_MASK  mTpm2HashMask[] = {
 **/
 UINT32
 EFIAPI
-Tpm2GetHashMaskFromAlgo (
+Tpm2GetHashMaskFromGuid (
   IN EFI_GUID  *HashGuid
   )
 {

--- a/SecurityPkg/Library/HashLibBaseCryptoRouter/HashLibBaseCryptoRouterCommon.h
+++ b/SecurityPkg/Library/HashLibBaseCryptoRouter/HashLibBaseCryptoRouterCommon.h
@@ -2,6 +2,7 @@
   This is BaseCrypto router support function definition.
 
 Copyright (c) 2013 - 2016, Intel Corporation. All rights reserved. <BR>
+Copyright (c) Microsoft Corporation.
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -9,7 +10,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #pragma once
 
 /**
-  The function get hash mask info from algorithm.
+  The function get hash mask info from GUID.
 
   @param HashGuid Hash Guid
 
@@ -17,7 +18,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 UINT32
 EFIAPI
-Tpm2GetHashMaskFromAlgo (
+Tpm2GetHashMaskFromGuid (
   IN EFI_GUID  *HashGuid
   );
 

--- a/SecurityPkg/Library/HashLibBaseCryptoRouter/HashLibBaseCryptoRouterDxe.c
+++ b/SecurityPkg/Library/HashLibBaseCryptoRouter/HashLibBaseCryptoRouterDxe.c
@@ -80,7 +80,7 @@ HashStart (
   ASSERT (HashCtx != NULL);
 
   for (Index = 0; Index < mHashInterfaceCount; Index++) {
-    HashMask = Tpm2GetHashMaskFromAlgo (&mHashInterface[Index].HashGuid);
+    HashMask = Tpm2GetHashMaskFromGuid (&mHashInterface[Index].HashGuid);
     if ((HashMask & PcdGet32 (PcdTpm2HashMask)) != 0) {
       mHashInterface[Index].HashInit (&HashCtx[Index]);
     }
@@ -121,7 +121,7 @@ HashUpdate (
   HashCtx = (HASH_HANDLE *)HashHandle;
 
   for (Index = 0; Index < mHashInterfaceCount; Index++) {
-    HashMask = Tpm2GetHashMaskFromAlgo (&mHashInterface[Index].HashGuid);
+    HashMask = Tpm2GetHashMaskFromGuid (&mHashInterface[Index].HashGuid);
     if ((HashMask & PcdGet32 (PcdTpm2HashMask)) != 0) {
       mHashInterface[Index].HashUpdate (HashCtx[Index], DataToHash, DataToHashLen);
     }
@@ -215,7 +215,7 @@ HashCompleteAndExtend (
   ZeroMem (DigestList, sizeof (*DigestList));
 
   for (Index = 0; Index < mHashInterfaceCount; Index++) {
-    HashMask = Tpm2GetHashMaskFromAlgo (&mHashInterface[Index].HashGuid);
+    HashMask = Tpm2GetHashMaskFromGuid (&mHashInterface[Index].HashGuid);
     if ((HashMask & PcdGet32 (PcdTpm2HashMask)) != 0) {
       mHashInterface[Index].HashUpdate (HashCtx[Index], DataToHash, DataToHashLen);
       mHashInterface[Index].HashFinal (HashCtx[Index], &Digest);
@@ -309,7 +309,7 @@ RegisterHashInterfaceLib (
   //
   // Check allow
   //
-  HashMask     = Tpm2GetHashMaskFromAlgo (&HashInterface->HashGuid);
+  HashMask     = Tpm2GetHashMaskFromGuid (&HashInterface->HashGuid);
   Tpm2HashMask = PcdGet32 (PcdTpm2HashMask);
 
   if ((Tpm2HashMask != 0) &&

--- a/SecurityPkg/Library/HashLibBaseCryptoRouter/HashLibBaseCryptoRouterDxe.c
+++ b/SecurityPkg/Library/HashLibBaseCryptoRouter/HashLibBaseCryptoRouterDxe.c
@@ -12,6 +12,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/BaseLib.h>
 #include <Library/BaseMemoryLib.h>
 #include <Library/Tpm2CommandLib.h>
+#include <Library/Tpm2HelpLib.h>
 #include <Library/DebugLib.h>
 #include <Library/MemoryAllocationLib.h>
 #include <Library/PcdLib.h>
@@ -234,7 +235,7 @@ HashCompleteAndExtend (
     ASSERT_EFI_ERROR (Status);
     ActivePcrBanks = ActivePcrBanks & mSupportedHashMaskCurrent;
     ZeroMem (&TcgPcrEvent2Digest, sizeof (TcgPcrEvent2Digest));
-    BufferPtr         = CopyDigestListToBuffer (&TcgPcrEvent2Digest, DigestList, ActivePcrBanks);
+    BufferPtr         = Tpm2CopyDigestListToBuffer (&TcgPcrEvent2Digest, DigestList, ActivePcrBanks);
     DigestListBinSize = (UINT32)((UINT8 *)BufferPtr - (UINT8 *)&TcgPcrEvent2Digest);
 
     //

--- a/SecurityPkg/Library/HashLibBaseCryptoRouter/HashLibBaseCryptoRouterDxe.inf
+++ b/SecurityPkg/Library/HashLibBaseCryptoRouter/HashLibBaseCryptoRouterDxe.inf
@@ -40,6 +40,7 @@
   BaseMemoryLib
   DebugLib
   Tpm2CommandLib
+  Tpm2HelpLib
   MemoryAllocationLib
   PcdLib
 

--- a/SecurityPkg/Library/HashLibBaseCryptoRouter/HashLibBaseCryptoRouterPei.c
+++ b/SecurityPkg/Library/HashLibBaseCryptoRouter/HashLibBaseCryptoRouterPei.c
@@ -155,7 +155,7 @@ HashStart (
   ASSERT (HashCtx != NULL);
 
   for (Index = 0; Index < HashInterfaceHob->HashInterfaceCount; Index++) {
-    HashMask = Tpm2GetHashMaskFromAlgo (&HashInterfaceHob->HashInterface[Index].HashGuid);
+    HashMask = Tpm2GetHashMaskFromGuid (&HashInterfaceHob->HashInterface[Index].HashGuid);
     if ((HashMask & PcdGet32 (PcdTpm2HashMask)) != 0) {
       HashInterfaceHob->HashInterface[Index].HashInit (&HashCtx[Index]);
     }
@@ -202,7 +202,7 @@ HashUpdate (
   HashCtx = (HASH_HANDLE *)HashHandle;
 
   for (Index = 0; Index < HashInterfaceHob->HashInterfaceCount; Index++) {
-    HashMask = Tpm2GetHashMaskFromAlgo (&HashInterfaceHob->HashInterface[Index].HashGuid);
+    HashMask = Tpm2GetHashMaskFromGuid (&HashInterfaceHob->HashInterface[Index].HashGuid);
     if ((HashMask & PcdGet32 (PcdTpm2HashMask)) != 0) {
       HashInterfaceHob->HashInterface[Index].HashUpdate (HashCtx[Index], DataToHash, DataToHashLen);
     }
@@ -254,7 +254,7 @@ HashCompleteAndExtend (
   ZeroMem (DigestList, sizeof (*DigestList));
 
   for (Index = 0; Index < HashInterfaceHob->HashInterfaceCount; Index++) {
-    HashMask = Tpm2GetHashMaskFromAlgo (&HashInterfaceHob->HashInterface[Index].HashGuid);
+    HashMask = Tpm2GetHashMaskFromGuid (&HashInterfaceHob->HashInterface[Index].HashGuid);
     if ((HashMask & PcdGet32 (PcdTpm2HashMask)) != 0) {
       HashInterfaceHob->HashInterface[Index].HashUpdate (HashCtx[Index], DataToHash, DataToHashLen);
       HashInterfaceHob->HashInterface[Index].HashFinal (HashCtx[Index], &Digest);
@@ -336,7 +336,7 @@ RegisterHashInterfaceLib (
   //
   // Check allow
   //
-  HashMask     = Tpm2GetHashMaskFromAlgo (&HashInterface->HashGuid);
+  HashMask     = Tpm2GetHashMaskFromGuid (&HashInterface->HashGuid);
   Tpm2HashMask = PcdGet32 (PcdTpm2HashMask);
 
   if ((Tpm2HashMask != 0) &&

--- a/SecurityPkg/Library/PeilessSecMeasureLib/PeilessSecMeasureLib.c
+++ b/SecurityPkg/Library/PeilessSecMeasureLib/PeilessSecMeasureLib.c
@@ -17,6 +17,7 @@
 #include <Library/DebugLib.h>
 #include <Library/BaseMemoryLib.h>
 #include <Library/Tpm2CommandLib.h>
+#include <Library/Tpm2HelpLib.h>
 #include <Library/HashLib.h>
 #include <Library/HobLib.h>
 #include <Library/MemoryAllocationLib.h>
@@ -68,12 +69,12 @@ LogHashEvent (
   UINT8           *DigestBuffer;
 
   //
-  // Use GetDigestListSize (DigestList) in the GUID HOB DataLength calculation
+  // Use Tpm2GetDigestListSize (DigestList) in the GUID HOB DataLength calculation
   // to reserve enough buffer to hold TPML_DIGEST_VALUES compact binary.
   //
   HobData = BuildGuidHob (
               &gTcgEvent2EntryHobGuid,
-              sizeof (TcgPcrEvent2->PCRIndex) + sizeof (TcgPcrEvent2->EventType) + GetDigestListSize (DigestList) + sizeof (TcgPcrEvent2->EventSize) + NewEventHdr->EventSize
+              sizeof (TcgPcrEvent2->PCRIndex) + sizeof (TcgPcrEvent2->EventType) + Tpm2GetDigestListSize (DigestList) + sizeof (TcgPcrEvent2->EventSize) + NewEventHdr->EventSize
               );
   if (HobData == NULL) {
     return EFI_OUT_OF_RESOURCES;
@@ -90,7 +91,7 @@ LogHashEvent (
    *     - TPM_ALG_SHA384
    *     - TPM_ALG_SHA512
    */
-  DigestBuffer = CopyDigestListToBuffer (
+  DigestBuffer = Tpm2CopyDigestListToBuffer (
                    DigestBuffer,
                    DigestList,
                    TPM_ALG_SHA256 | TPM_ALG_SHA384 | TPM_ALG_SHA512

--- a/SecurityPkg/Library/PeilessSecMeasureLib/PeilessSecMeasureLib.inf
+++ b/SecurityPkg/Library/PeilessSecMeasureLib/PeilessSecMeasureLib.inf
@@ -38,6 +38,7 @@
   HashLib
   PrePiLib
   Tpm2CommandLib
+  Tpm2HelpLib
 
 [Guids]
   gTcgEvent2EntryHobGuid

--- a/SecurityPkg/Library/Tpm2CommandLib/Tpm2CommandLib.inf
+++ b/SecurityPkg/Library/Tpm2CommandLib/Tpm2CommandLib.inf
@@ -48,3 +48,4 @@
   BaseMemoryLib
   DebugLib
   Tpm2DeviceLib
+  Tpm2HelpLib

--- a/SecurityPkg/Library/Tpm2CommandLib/Tpm2DictionaryAttack.c
+++ b/SecurityPkg/Library/Tpm2CommandLib/Tpm2DictionaryAttack.c
@@ -8,6 +8,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #include <IndustryStandard/UefiTcgPlatform.h>
 #include <Library/Tpm2CommandLib.h>
+#include <Library/Tpm2HelpLib.h>
 #include <Library/Tpm2DeviceLib.h>
 #include <Library/BaseMemoryLib.h>
 #include <Library/BaseLib.h>
@@ -85,7 +86,7 @@ Tpm2DictionaryAttackLockReset (
   Buffer = (UINT8 *)&SendBuffer.AuthSession;
 
   // sessionInfoSize
-  SessionInfoSize            = CopyAuthSessionCommand (AuthSession, Buffer);
+  SessionInfoSize            = Tpm2CopyAuthSessionCommand (AuthSession, Buffer);
   Buffer                    += SessionInfoSize;
   SendBuffer.AuthSessionSize = SwapBytes32 (SessionInfoSize);
 
@@ -167,7 +168,7 @@ Tpm2DictionaryAttackParameters (
   Buffer = (UINT8 *)&SendBuffer.AuthSession;
 
   // sessionInfoSize
-  SessionInfoSize            = CopyAuthSessionCommand (AuthSession, Buffer);
+  SessionInfoSize            = Tpm2CopyAuthSessionCommand (AuthSession, Buffer);
   Buffer                    += SessionInfoSize;
   SendBuffer.AuthSessionSize = SwapBytes32 (SessionInfoSize);
 

--- a/SecurityPkg/Library/Tpm2CommandLib/Tpm2EnhancedAuthorization.c
+++ b/SecurityPkg/Library/Tpm2CommandLib/Tpm2EnhancedAuthorization.c
@@ -8,6 +8,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #include <IndustryStandard/UefiTcgPlatform.h>
 #include <Library/Tpm2CommandLib.h>
+#include <Library/Tpm2HelpLib.h>
 #include <Library/Tpm2DeviceLib.h>
 #include <Library/BaseMemoryLib.h>
 #include <Library/BaseLib.h>
@@ -121,7 +122,7 @@ Tpm2PolicySecret (
   Buffer = (UINT8 *)&SendBuffer.AuthSession;
 
   // sessionInfoSize
-  SessionInfoSize            = CopyAuthSessionCommand (AuthSession, Buffer);
+  SessionInfoSize            = Tpm2CopyAuthSessionCommand (AuthSession, Buffer);
   Buffer                    += SessionInfoSize;
   SendBuffer.AuthSessionSize = SwapBytes32 (SessionInfoSize);
 

--- a/SecurityPkg/Library/Tpm2CommandLib/Tpm2Help.c
+++ b/SecurityPkg/Library/Tpm2CommandLib/Tpm2Help.c
@@ -9,23 +9,10 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <IndustryStandard/UefiTcgPlatform.h>
 #include <Library/Tpm2CommandLib.h>
 #include <Library/Tpm2DeviceLib.h>
+#include <Library/Tpm2HelpLib.h>
 #include <Library/BaseMemoryLib.h>
 #include <Library/BaseLib.h>
 #include <Library/DebugLib.h>
-
-typedef struct {
-  TPMI_ALG_HASH    HashAlgo;
-  UINT16           HashSize;
-  UINT32           HashMask;
-} INTERNAL_HASH_INFO;
-
-STATIC INTERNAL_HASH_INFO  mHashInfo[] = {
-  { TPM_ALG_SHA1,    SHA1_DIGEST_SIZE,    HASH_ALG_SHA1    },
-  { TPM_ALG_SHA256,  SHA256_DIGEST_SIZE,  HASH_ALG_SHA256  },
-  { TPM_ALG_SM3_256, SM3_256_DIGEST_SIZE, HASH_ALG_SM3_256 },
-  { TPM_ALG_SHA384,  SHA384_DIGEST_SIZE,  HASH_ALG_SHA384  },
-  { TPM_ALG_SHA512,  SHA512_DIGEST_SIZE,  HASH_ALG_SHA512  },
-};
 
 /**
   Return size of digest.
@@ -40,15 +27,7 @@ GetHashSizeFromAlgo (
   IN TPMI_ALG_HASH  HashAlgo
   )
 {
-  UINTN  Index;
-
-  for (Index = 0; Index < sizeof (mHashInfo)/sizeof (mHashInfo[0]); Index++) {
-    if (mHashInfo[Index].HashAlgo == HashAlgo) {
-      return mHashInfo[Index].HashSize;
-    }
-  }
-
-  return 0;
+  return Tpm2GetHashSizeFromAlgo (HashAlgo);
 }
 
 /**
@@ -64,15 +43,7 @@ GetHashMaskFromAlgo (
   IN TPMI_ALG_HASH  HashAlgo
   )
 {
-  UINTN  Index;
-
-  for (Index = 0; Index < sizeof (mHashInfo)/sizeof (mHashInfo[0]); Index++) {
-    if (mHashInfo[Index].HashAlgo == HashAlgo) {
-      return mHashInfo[Index].HashMask;
-    }
-  }
-
-  return 0;
+  return Tpm2GetHashMaskFromAlgo (HashAlgo);
 }
 
 /**
@@ -90,54 +61,7 @@ CopyAuthSessionCommand (
   OUT     UINT8              *AuthSessionOut
   )
 {
-  UINT8  *Buffer;
-
-  Buffer = (UINT8 *)AuthSessionOut;
-
-  //
-  // Add in Auth session
-  //
-  if (AuthSessionIn != NULL) {
-    //  sessionHandle
-    WriteUnaligned32 ((UINT32 *)Buffer, SwapBytes32 (AuthSessionIn->sessionHandle));
-    Buffer += sizeof (UINT32);
-
-    // nonce
-    WriteUnaligned16 ((UINT16 *)Buffer, SwapBytes16 (AuthSessionIn->nonce.size));
-    Buffer += sizeof (UINT16);
-
-    CopyMem (Buffer, AuthSessionIn->nonce.buffer, AuthSessionIn->nonce.size);
-    Buffer += AuthSessionIn->nonce.size;
-
-    // sessionAttributes
-    *(UINT8 *)Buffer = *(UINT8 *)&AuthSessionIn->sessionAttributes;
-    Buffer++;
-
-    // hmac
-    WriteUnaligned16 ((UINT16 *)Buffer, SwapBytes16 (AuthSessionIn->hmac.size));
-    Buffer += sizeof (UINT16);
-
-    CopyMem (Buffer, AuthSessionIn->hmac.buffer, AuthSessionIn->hmac.size);
-    Buffer += AuthSessionIn->hmac.size;
-  } else {
-    //  sessionHandle
-    WriteUnaligned32 ((UINT32 *)Buffer, SwapBytes32 (TPM_RS_PW));
-    Buffer += sizeof (UINT32);
-
-    // nonce = nullNonce
-    WriteUnaligned16 ((UINT16 *)Buffer, SwapBytes16 (0));
-    Buffer += sizeof (UINT16);
-
-    // sessionAttributes = 0
-    *(UINT8 *)Buffer = 0x00;
-    Buffer++;
-
-    // hmac = nullAuth
-    WriteUnaligned16 ((UINT16 *)Buffer, SwapBytes16 (0));
-    Buffer += sizeof (UINT16);
-  }
-
-  return (UINT32)((UINTN)Buffer - (UINTN)AuthSessionOut);
+  return Tpm2CopyAuthSessionCommand (AuthSessionIn, AuthSessionOut);
 }
 
 /**
@@ -156,42 +80,7 @@ CopyAuthSessionResponse (
   OUT     TPMS_AUTH_RESPONSE  *AuthSessionOut OPTIONAL
   )
 {
-  UINT8               *Buffer;
-  TPMS_AUTH_RESPONSE  LocalAuthSessionOut;
-
-  if (AuthSessionOut == NULL) {
-    AuthSessionOut = &LocalAuthSessionOut;
-  }
-
-  Buffer = (UINT8 *)AuthSessionIn;
-
-  // nonce
-  AuthSessionOut->nonce.size = SwapBytes16 (ReadUnaligned16 ((UINT16 *)Buffer));
-  Buffer                    += sizeof (UINT16);
-  if (AuthSessionOut->nonce.size > sizeof (TPMU_HA)) {
-    DEBUG ((DEBUG_ERROR, "CopyAuthSessionResponse - nonce.size error %x\n", AuthSessionOut->nonce.size));
-    return 0;
-  }
-
-  CopyMem (AuthSessionOut->nonce.buffer, Buffer, AuthSessionOut->nonce.size);
-  Buffer += AuthSessionOut->nonce.size;
-
-  // sessionAttributes
-  *(UINT8 *) &AuthSessionOut->sessionAttributes = *(UINT8 *)Buffer;
-  Buffer++;
-
-  // hmac
-  AuthSessionOut->hmac.size = SwapBytes16 (ReadUnaligned16 ((UINT16 *)Buffer));
-  Buffer                   += sizeof (UINT16);
-  if (AuthSessionOut->hmac.size > sizeof (TPMU_HA)) {
-    DEBUG ((DEBUG_ERROR, "CopyAuthSessionResponse - hmac.size error %x\n", AuthSessionOut->hmac.size));
-    return 0;
-  }
-
-  CopyMem (AuthSessionOut->hmac.buffer, Buffer, AuthSessionOut->hmac.size);
-  Buffer += AuthSessionOut->hmac.size;
-
-  return (UINT32)((UINTN)Buffer - (UINTN)AuthSessionIn);
+  return Tpm2CopyAuthSessionResponse (AuthSessionIn, AuthSessionOut);
 }
 
 /**
@@ -210,40 +99,7 @@ IsHashAlgSupportedInHashAlgorithmMask (
   IN UINT32         HashAlgorithmMask
   )
 {
-  switch (HashAlg) {
-    case TPM_ALG_SHA1:
-      if ((HashAlgorithmMask & HASH_ALG_SHA1) != 0) {
-        return TRUE;
-      }
-
-      break;
-    case TPM_ALG_SHA256:
-      if ((HashAlgorithmMask & HASH_ALG_SHA256) != 0) {
-        return TRUE;
-      }
-
-      break;
-    case TPM_ALG_SHA384:
-      if ((HashAlgorithmMask & HASH_ALG_SHA384) != 0) {
-        return TRUE;
-      }
-
-      break;
-    case TPM_ALG_SHA512:
-      if ((HashAlgorithmMask & HASH_ALG_SHA512) != 0) {
-        return TRUE;
-      }
-
-      break;
-    case TPM_ALG_SM3_256:
-      if ((HashAlgorithmMask & HASH_ALG_SM3_256) != 0) {
-        return TRUE;
-      }
-
-      break;
-  }
-
-  return FALSE;
+  return Tpm2IsHashAlgSupportedInHashAlgorithmMask (HashAlg, HashAlgorithmMask);
 }
 
 /**
@@ -263,31 +119,7 @@ CopyDigestListToBuffer (
   IN UINT32              HashAlgorithmMask
   )
 {
-  UINTN   Index;
-  UINT16  DigestSize;
-  UINT32  DigestListCount;
-  UINT32  *DigestListCountPtr;
-
-  DigestListCountPtr = (UINT32 *)Buffer;
-  DigestListCount    = 0;
-  Buffer             = (UINT8 *)Buffer + sizeof (DigestList->count);
-  for (Index = 0; Index < DigestList->count; Index++) {
-    if (!IsHashAlgSupportedInHashAlgorithmMask (DigestList->digests[Index].hashAlg, HashAlgorithmMask)) {
-      DEBUG ((DEBUG_ERROR, "WARNING: TPM2 Event log has HashAlg unsupported by PCR bank (0x%x)\n", DigestList->digests[Index].hashAlg));
-      continue;
-    }
-
-    CopyMem (Buffer, &DigestList->digests[Index].hashAlg, sizeof (DigestList->digests[Index].hashAlg));
-    Buffer     = (UINT8 *)Buffer + sizeof (DigestList->digests[Index].hashAlg);
-    DigestSize = GetHashSizeFromAlgo (DigestList->digests[Index].hashAlg);
-    CopyMem (Buffer, &DigestList->digests[Index].digest, DigestSize);
-    Buffer = (UINT8 *)Buffer + DigestSize;
-    DigestListCount++;
-  }
-
-  WriteUnaligned32 (DigestListCountPtr, DigestListCount);
-
-  return Buffer;
+  return Tpm2CopyDigestListToBuffer (Buffer, DigestList, HashAlgorithmMask);
 }
 
 /**
@@ -310,45 +142,7 @@ CopyBufferToDigestList (
   OUT       TPML_DIGEST_VALUES  *DigestList
   )
 {
-  EFI_STATUS   Status;
-  UINTN        Index;
-  UINT16       DigestSize;
-  CONST UINT8  *BufferPtr;
-
-  Status = EFI_INVALID_PARAMETER;
-
-  if ((Buffer == NULL) || (DigestList == NULL) || (BufferSize > sizeof (TPML_DIGEST_VALUES))) {
-    return EFI_INVALID_PARAMETER;
-  }
-
-  DigestList->count = SwapBytes32 (ReadUnaligned32 ((CONST UINT32 *)Buffer));
-  if (DigestList->count > HASH_COUNT) {
-    return EFI_INVALID_PARAMETER;
-  }
-
-  BufferPtr = (CONST UINT8 *)Buffer +  sizeof (UINT32);
-  for (Index = 0; Index < DigestList->count; Index++) {
-    if (BufferPtr - (CONST UINT8 *)Buffer + sizeof (UINT16) > BufferSize) {
-      Status = EFI_BAD_BUFFER_SIZE;
-      break;
-    } else {
-      DigestList->digests[Index].hashAlg = SwapBytes16 (ReadUnaligned16 ((CONST UINT16 *)BufferPtr));
-    }
-
-    BufferPtr += sizeof (UINT16);
-    DigestSize = GetHashSizeFromAlgo (DigestList->digests[Index].hashAlg);
-    if (BufferPtr - (CONST UINT8 *)Buffer + (UINTN)DigestSize > BufferSize) {
-      Status = EFI_BAD_BUFFER_SIZE;
-      break;
-    } else {
-      CopyMem (&DigestList->digests[Index].digest, BufferPtr, DigestSize);
-    }
-
-    BufferPtr += DigestSize;
-    Status     = EFI_SUCCESS;
-  }
-
-  return Status;
+  return Tpm2CopyBufferToDigestList (Buffer, BufferSize, DigestList);
 }
 
 /**
@@ -364,17 +158,7 @@ GetDigestListSize (
   IN TPML_DIGEST_VALUES  *DigestList
   )
 {
-  UINTN   Index;
-  UINT16  DigestSize;
-  UINT32  TotalSize;
-
-  TotalSize = sizeof (DigestList->count);
-  for (Index = 0; Index < DigestList->count; Index++) {
-    DigestSize = GetHashSizeFromAlgo (DigestList->digests[Index].hashAlg);
-    TotalSize += sizeof (DigestList->digests[Index].hashAlg) + DigestSize;
-  }
-
-  return TotalSize;
+  return Tpm2GetDigestListSize (DigestList);
 }
 
 /**
@@ -390,17 +174,7 @@ GetDigestListSizeFromHashAlgorithmMask (
   IN UINT32  HashAlgorithmMask
   )
 {
-  UINTN   Index;
-  UINT32  TotalSize;
-
-  TotalSize = sizeof (UINT32);
-  for (Index = 0; Index < ARRAY_SIZE (mHashInfo); Index++) {
-    if ((mHashInfo[Index].HashMask & HashAlgorithmMask) != 0) {
-      TotalSize += sizeof (TPMI_ALG_HASH) + mHashInfo[Index].HashSize;
-    }
-  }
-
-  return TotalSize;
+  return Tpm2GetDigestListSizeFromHashAlgorithmMask (HashAlgorithmMask);
 }
 
 /**
@@ -421,20 +195,5 @@ GetDigestFromDigestList (
   OUT VOID               *Digest
   )
 {
-  UINTN   Index;
-  UINT16  DigestSize;
-
-  DigestSize = GetHashSizeFromAlgo (HashAlg);
-  for (Index = 0; Index < DigestList->count; Index++) {
-    if (DigestList->digests[Index].hashAlg == HashAlg) {
-      CopyMem (
-        Digest,
-        &DigestList->digests[Index].digest,
-        DigestSize
-        );
-      return EFI_SUCCESS;
-    }
-  }
-
-  return EFI_NOT_FOUND;
+  return Tpm2GetDigestFromDigestList (HashAlg, DigestList, Digest);
 }

--- a/SecurityPkg/Library/Tpm2CommandLib/Tpm2Hierarchy.c
+++ b/SecurityPkg/Library/Tpm2CommandLib/Tpm2Hierarchy.c
@@ -8,6 +8,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #include <IndustryStandard/UefiTcgPlatform.h>
 #include <Library/Tpm2CommandLib.h>
+#include <Library/Tpm2HelpLib.h>
 #include <Library/Tpm2DeviceLib.h>
 #include <Library/BaseMemoryLib.h>
 #include <Library/BaseLib.h>
@@ -157,7 +158,7 @@ Tpm2SetPrimaryPolicy (
   Buffer = (UINT8 *)&SendBuffer.AuthSession;
 
   // sessionInfoSize
-  SessionInfoSize            = CopyAuthSessionCommand (AuthSession, Buffer);
+  SessionInfoSize            = Tpm2CopyAuthSessionCommand (AuthSession, Buffer);
   Buffer                    += SessionInfoSize;
   SendBuffer.AuthSessionSize = SwapBytes32 (SessionInfoSize);
 
@@ -239,7 +240,7 @@ Tpm2Clear (
   Buffer = (UINT8 *)&Cmd.AuthSession;
 
   // sessionInfoSize
-  SessionInfoSize       = CopyAuthSessionCommand (AuthSession, Buffer);
+  SessionInfoSize       = Tpm2CopyAuthSessionCommand (AuthSession, Buffer);
   Buffer               += SessionInfoSize;
   Cmd.AuthorizationSize = SwapBytes32 (SessionInfoSize);
 
@@ -329,7 +330,7 @@ Tpm2ClearControl (
   Buffer = (UINT8 *)&Cmd.AuthSession;
 
   // sessionInfoSize
-  SessionInfoSize       = CopyAuthSessionCommand (AuthSession, Buffer);
+  SessionInfoSize       = Tpm2CopyAuthSessionCommand (AuthSession, Buffer);
   Buffer               += SessionInfoSize;
   Cmd.AuthorizationSize = SwapBytes32 (SessionInfoSize);
 
@@ -428,7 +429,7 @@ Tpm2HierarchyChangeAuth (
   Buffer = (UINT8 *)&Cmd.AuthSession;
 
   // sessionInfoSize
-  SessionInfoSize       = CopyAuthSessionCommand (AuthSession, Buffer);
+  SessionInfoSize       = Tpm2CopyAuthSessionCommand (AuthSession, Buffer);
   Buffer               += SessionInfoSize;
   Cmd.AuthorizationSize = SwapBytes32 (SessionInfoSize);
 
@@ -534,7 +535,7 @@ Tpm2ChangeEPS (
   Buffer = (UINT8 *)&Cmd.AuthSession;
 
   // sessionInfoSize
-  SessionInfoSize       = CopyAuthSessionCommand (AuthSession, Buffer);
+  SessionInfoSize       = Tpm2CopyAuthSessionCommand (AuthSession, Buffer);
   Buffer               += SessionInfoSize;
   Cmd.AuthorizationSize = SwapBytes32 (SessionInfoSize);
 
@@ -632,7 +633,7 @@ Tpm2ChangePPS (
   Buffer = (UINT8 *)&Cmd.AuthSession;
 
   // sessionInfoSize
-  SessionInfoSize       = CopyAuthSessionCommand (AuthSession, Buffer);
+  SessionInfoSize       = Tpm2CopyAuthSessionCommand (AuthSession, Buffer);
   Buffer               += SessionInfoSize;
   Cmd.AuthorizationSize = SwapBytes32 (SessionInfoSize);
 
@@ -734,7 +735,7 @@ Tpm2HierarchyControl (
   Buffer = (UINT8 *)&Cmd.AuthSession;
 
   // sessionInfoSize
-  SessionInfoSize       = CopyAuthSessionCommand (AuthSession, Buffer);
+  SessionInfoSize       = Tpm2CopyAuthSessionCommand (AuthSession, Buffer);
   Buffer               += SessionInfoSize;
   Cmd.AuthorizationSize = SwapBytes32 (SessionInfoSize);
 

--- a/SecurityPkg/Library/Tpm2CommandLib/Tpm2Integrity.c
+++ b/SecurityPkg/Library/Tpm2CommandLib/Tpm2Integrity.c
@@ -8,6 +8,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #include <IndustryStandard/UefiTcgPlatform.h>
 #include <Library/Tpm2CommandLib.h>
+#include <Library/Tpm2HelpLib.h>
 #include <Library/Tpm2DeviceLib.h>
 #include <Library/BaseMemoryLib.h>
 #include <Library/BaseLib.h>
@@ -115,7 +116,7 @@ Tpm2PcrExtend (
   Buffer = (UINT8 *)&Cmd.AuthSessionPcr;
 
   // sessionInfoSize
-  SessionInfoSize       = CopyAuthSessionCommand (NULL, Buffer);
+  SessionInfoSize       = Tpm2CopyAuthSessionCommand (NULL, Buffer);
   Buffer               += SessionInfoSize;
   Cmd.AuthorizationSize = SwapBytes32 (SessionInfoSize);
 
@@ -127,7 +128,7 @@ Tpm2PcrExtend (
   for (Index = 0; Index < Digests->count; Index++) {
     WriteUnaligned16 ((UINT16 *)Buffer, SwapBytes16 (Digests->digests[Index].hashAlg));
     Buffer    += sizeof (UINT16);
-    DigestSize = GetHashSizeFromAlgo (Digests->digests[Index].hashAlg);
+    DigestSize = Tpm2GetHashSizeFromAlgo (Digests->digests[Index].hashAlg);
     if (DigestSize == 0) {
       DEBUG ((DEBUG_ERROR, "Unknown hash algorithm %d\r\n", Digests->digests[Index].hashAlg));
       return EFI_DEVICE_ERROR;
@@ -247,7 +248,7 @@ Tpm2PcrEvent (
   Buffer = (UINT8 *)&Cmd.AuthSessionPcr;
 
   // sessionInfoSize
-  SessionInfoSize       = CopyAuthSessionCommand (NULL, Buffer);
+  SessionInfoSize       = Tpm2CopyAuthSessionCommand (NULL, Buffer);
   Buffer               += SessionInfoSize;
   Cmd.AuthorizationSize = SwapBytes32 (SessionInfoSize);
 
@@ -304,7 +305,7 @@ Tpm2PcrEvent (
   for (Index = 0; Index < Digests->count; Index++) {
     Digests->digests[Index].hashAlg = SwapBytes16 (ReadUnaligned16 ((UINT16 *)Buffer));
     Buffer                         += sizeof (UINT16);
-    DigestSize                      = GetHashSizeFromAlgo (Digests->digests[Index].hashAlg);
+    DigestSize                      = Tpm2GetHashSizeFromAlgo (Digests->digests[Index].hashAlg);
     if (DigestSize == 0) {
       DEBUG ((DEBUG_ERROR, "Unknown hash algorithm %d\r\n", Digests->digests[Index].hashAlg));
       return EFI_DEVICE_ERROR;
@@ -507,7 +508,7 @@ Tpm2PcrAllocate (
   Buffer = (UINT8 *)&Cmd.AuthSession;
 
   // sessionInfoSize
-  SessionInfoSize     = CopyAuthSessionCommand (AuthSession, Buffer);
+  SessionInfoSize     = Tpm2CopyAuthSessionCommand (AuthSession, Buffer);
   Buffer             += SessionInfoSize;
   Cmd.AuthSessionSize = SwapBytes32 (SessionInfoSize);
 

--- a/SecurityPkg/Library/Tpm2CommandLib/Tpm2Miscellaneous.c
+++ b/SecurityPkg/Library/Tpm2CommandLib/Tpm2Miscellaneous.c
@@ -8,6 +8,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #include <IndustryStandard/UefiTcgPlatform.h>
 #include <Library/Tpm2CommandLib.h>
+#include <Library/Tpm2HelpLib.h>
 #include <Library/Tpm2DeviceLib.h>
 #include <Library/BaseMemoryLib.h>
 #include <Library/BaseLib.h>
@@ -73,7 +74,7 @@ Tpm2SetAlgorithmSet (
   Buffer = (UINT8 *)&SendBuffer.AuthSession;
 
   // sessionInfoSize
-  SessionInfoSize            = CopyAuthSessionCommand (AuthSession, Buffer);
+  SessionInfoSize            = Tpm2CopyAuthSessionCommand (AuthSession, Buffer);
   Buffer                    += SessionInfoSize;
   SendBuffer.AuthSessionSize = SwapBytes32 (SessionInfoSize);
 

--- a/SecurityPkg/Library/Tpm2CommandLib/Tpm2NVStorage.c
+++ b/SecurityPkg/Library/Tpm2CommandLib/Tpm2NVStorage.c
@@ -8,6 +8,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #include <IndustryStandard/UefiTcgPlatform.h>
 #include <Library/Tpm2CommandLib.h>
+#include <Library/Tpm2HelpLib.h>
 #include <Library/Tpm2DeviceLib.h>
 #include <Library/BaseMemoryLib.h>
 #include <Library/BaseLib.h>
@@ -328,7 +329,7 @@ Tpm2NvDefineSpace (
   Buffer = (UINT8 *)&SendBuffer.AuthSession;
 
   // sessionInfoSize
-  SessionInfoSize            = CopyAuthSessionCommand (AuthSession, Buffer);
+  SessionInfoSize            = Tpm2CopyAuthSessionCommand (AuthSession, Buffer);
   Buffer                    += SessionInfoSize;
   SendBuffer.AuthSessionSize = SwapBytes32 (SessionInfoSize);
 
@@ -465,7 +466,7 @@ Tpm2NvUndefineSpace (
   Buffer = (UINT8 *)&SendBuffer.AuthSession;
 
   // sessionInfoSize
-  SessionInfoSize            = CopyAuthSessionCommand (AuthSession, Buffer);
+  SessionInfoSize            = Tpm2CopyAuthSessionCommand (AuthSession, Buffer);
   Buffer                    += SessionInfoSize;
   SendBuffer.AuthSessionSize = SwapBytes32 (SessionInfoSize);
 
@@ -576,7 +577,7 @@ Tpm2NvRead (
   Buffer = (UINT8 *)&SendBuffer.AuthSession;
 
   // sessionInfoSize
-  SessionInfoSize            = CopyAuthSessionCommand (AuthSession, Buffer);
+  SessionInfoSize            = Tpm2CopyAuthSessionCommand (AuthSession, Buffer);
   Buffer                    += SessionInfoSize;
   SendBuffer.AuthSessionSize = SwapBytes32 (SessionInfoSize);
 
@@ -723,7 +724,7 @@ Tpm2NvWrite (
   Buffer = (UINT8 *)&SendBuffer.AuthSession;
 
   // sessionInfoSize
-  SessionInfoSize            = CopyAuthSessionCommand (AuthSession, Buffer);
+  SessionInfoSize            = Tpm2CopyAuthSessionCommand (AuthSession, Buffer);
   Buffer                    += SessionInfoSize;
   SendBuffer.AuthSessionSize = SwapBytes32 (SessionInfoSize);
 
@@ -852,7 +853,7 @@ Tpm2NvReadLock (
   Buffer = (UINT8 *)&SendBuffer.AuthSession;
 
   // sessionInfoSize
-  SessionInfoSize            = CopyAuthSessionCommand (AuthSession, Buffer);
+  SessionInfoSize            = Tpm2CopyAuthSessionCommand (AuthSession, Buffer);
   Buffer                    += SessionInfoSize;
   SendBuffer.AuthSessionSize = SwapBytes32 (SessionInfoSize);
 
@@ -940,7 +941,7 @@ Tpm2NvWriteLock (
   Buffer = (UINT8 *)&SendBuffer.AuthSession;
 
   // sessionInfoSize
-  SessionInfoSize            = CopyAuthSessionCommand (AuthSession, Buffer);
+  SessionInfoSize            = Tpm2CopyAuthSessionCommand (AuthSession, Buffer);
   Buffer                    += SessionInfoSize;
   SendBuffer.AuthSessionSize = SwapBytes32 (SessionInfoSize);
 
@@ -1025,7 +1026,7 @@ Tpm2NvGlobalWriteLock (
   Buffer = (UINT8 *)&SendBuffer.AuthSession;
 
   // sessionInfoSize
-  SessionInfoSize            = CopyAuthSessionCommand (AuthSession, Buffer);
+  SessionInfoSize            = Tpm2CopyAuthSessionCommand (AuthSession, Buffer);
   Buffer                    += SessionInfoSize;
   SendBuffer.AuthSessionSize = SwapBytes32 (SessionInfoSize);
 
@@ -1115,7 +1116,7 @@ Tpm2NvExtend (
   Buffer = (UINT8 *)&SendBuffer.AuthSession;
 
   // sessionInfoSize
-  SessionInfoSize            = CopyAuthSessionCommand (AuthSession, Buffer);
+  SessionInfoSize            = Tpm2CopyAuthSessionCommand (AuthSession, Buffer);
   Buffer                    += SessionInfoSize;
   SendBuffer.AuthSessionSize = SwapBytes32 (SessionInfoSize);
 

--- a/SecurityPkg/Library/Tpm2CommandLib/Tpm2Sequences.c
+++ b/SecurityPkg/Library/Tpm2CommandLib/Tpm2Sequences.c
@@ -8,6 +8,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #include <IndustryStandard/UefiTcgPlatform.h>
 #include <Library/Tpm2CommandLib.h>
+#include <Library/Tpm2HelpLib.h>
 #include <Library/Tpm2DeviceLib.h>
 #include <Library/BaseMemoryLib.h>
 #include <Library/BaseLib.h>
@@ -207,7 +208,7 @@ Tpm2SequenceUpdate (
   BufferPtr = (UINT8 *)&Cmd.AuthSessionSeq;
 
   // sessionInfoSize
-  SessionInfoSize       = CopyAuthSessionCommand (NULL, BufferPtr);
+  SessionInfoSize       = Tpm2CopyAuthSessionCommand (NULL, BufferPtr);
   BufferPtr            += SessionInfoSize;
   Cmd.AuthorizationSize = SwapBytes32 (SessionInfoSize);
 
@@ -312,11 +313,11 @@ Tpm2EventSequenceComplete (
   BufferPtr = (UINT8 *)&Cmd.AuthSessionPcr;
 
   // sessionInfoSize
-  SessionInfoSize = CopyAuthSessionCommand (NULL, BufferPtr);
+  SessionInfoSize = Tpm2CopyAuthSessionCommand (NULL, BufferPtr);
   BufferPtr      += SessionInfoSize;
 
   // sessionInfoSize
-  SessionInfoSize2      = CopyAuthSessionCommand (NULL, BufferPtr);
+  SessionInfoSize2      = Tpm2CopyAuthSessionCommand (NULL, BufferPtr);
   BufferPtr            += SessionInfoSize2;
   Cmd.AuthorizationSize = SwapBytes32 (SessionInfoSize + SessionInfoSize2);
 
@@ -380,7 +381,7 @@ Tpm2EventSequenceComplete (
     Results->digests[Index].hashAlg = SwapBytes16 (ReadUnaligned16 ((UINT16 *)BufferPtr));
     BufferPtr                      += sizeof (UINT16);
 
-    DigestSize = GetHashSizeFromAlgo (Results->digests[Index].hashAlg);
+    DigestSize = Tpm2GetHashSizeFromAlgo (Results->digests[Index].hashAlg);
     if (DigestSize == 0) {
       DEBUG ((DEBUG_ERROR, "EventSequenceComplete: Unknown hash algorithm %d\r\n", Results->digests[Index].hashAlg));
       return EFI_DEVICE_ERROR;
@@ -439,7 +440,7 @@ Tpm2SequenceComplete (
   BufferPtr = (UINT8 *)&Cmd.AuthSessionSeq;
 
   // sessionInfoSize
-  SessionInfoSize       = CopyAuthSessionCommand (NULL, BufferPtr);
+  SessionInfoSize       = Tpm2CopyAuthSessionCommand (NULL, BufferPtr);
   BufferPtr            += SessionInfoSize;
   Cmd.AuthorizationSize = SwapBytes32 (SessionInfoSize);
 

--- a/SecurityPkg/Library/Tpm2HelpLib/Tpm2Help.c
+++ b/SecurityPkg/Library/Tpm2HelpLib/Tpm2Help.c
@@ -1,0 +1,562 @@
+/** @file
+  Defines reusable TPM 2.0 data helper routines that are independent
+  of TPM command/device communication libraries. Includes serialization
+  and parsing helpers for common TPM data structures.
+
+Copyright (c) Microsoft Corporation.
+Copyright (c) 2013 - 2018, Intel Corporation. All rights reserved. <BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <IndustryStandard/UefiTcgPlatform.h>
+#include <Library/Tpm2HelpLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/BaseLib.h>
+#include <Library/DebugLib.h>
+
+typedef struct {
+  TPMI_ALG_HASH    HashAlgo;
+  UINT16           HashSize;
+  UINT32           HashMask;
+} INTERNAL_HASH_INFO;
+
+STATIC INTERNAL_HASH_INFO  mHashInfo[] = {
+  { TPM_ALG_SHA1,    SHA1_DIGEST_SIZE,    HASH_ALG_SHA1    },
+  { TPM_ALG_SHA256,  SHA256_DIGEST_SIZE,  HASH_ALG_SHA256  },
+  { TPM_ALG_SM3_256, SM3_256_DIGEST_SIZE, HASH_ALG_SM3_256 },
+  { TPM_ALG_SHA384,  SHA384_DIGEST_SIZE,  HASH_ALG_SHA384  },
+  { TPM_ALG_SHA512,  SHA512_DIGEST_SIZE,  HASH_ALG_SHA512  },
+};
+
+/**
+  Check if DigestList has an entry for HashAlg.
+
+  @param DigestList         Digest list.
+  @param HashAlg            Hash algorithm id.
+
+  @retval TRUE  Match found.
+  @retval FALSE No match found.
+**/
+STATIC
+BOOLEAN
+CheckDigestListForHashAlg (
+  IN TPML_DIGEST_VALUES  *DigestList,
+  IN TPM_ALG_ID          HashAlg
+  )
+{
+  UINT32  Index;
+
+  if (DigestList->count > HASH_COUNT) {
+    return FALSE;
+  }
+
+  for (Index = 0; Index < DigestList->count; Index++) {
+    if (DigestList->digests[Index].hashAlg == HashAlg) {
+      DEBUG ((DEBUG_INFO, "Hash alg 0x%x found in DigestList.\n", HashAlg));
+      return TRUE;
+    }
+  }
+
+  DEBUG ((DEBUG_INFO, "Hash alg 0x%x not found in DigestList.\n", HashAlg));
+  return FALSE;
+}
+
+/**
+  Return size of digest.
+
+  @param[in] HashAlgo  Hash algorithm
+
+  @return size of digest
+**/
+UINT16
+EFIAPI
+Tpm2GetHashSizeFromAlgo (
+  IN TPMI_ALG_HASH  HashAlgo
+  )
+{
+  UINTN  Index;
+
+  for (Index = 0; Index < sizeof (mHashInfo)/sizeof (mHashInfo[0]); Index++) {
+    if (mHashInfo[Index].HashAlgo == HashAlgo) {
+      return mHashInfo[Index].HashSize;
+    }
+  }
+
+  return 0;
+}
+
+/**
+  Get hash mask from algorithm.
+
+  @param[in] HashAlgo   Hash algorithm
+
+  @return Hash mask
+**/
+UINT32
+EFIAPI
+Tpm2GetHashMaskFromAlgo (
+  IN TPMI_ALG_HASH  HashAlgo
+  )
+{
+  UINTN  Index;
+
+  for (Index = 0; Index < sizeof (mHashInfo)/sizeof (mHashInfo[0]); Index++) {
+    if (mHashInfo[Index].HashAlgo == HashAlgo) {
+      return mHashInfo[Index].HashMask;
+    }
+  }
+
+  return 0;
+}
+
+/**
+  Copy AuthSessionIn to TPM2 command buffer.
+
+  @param [in]  AuthSessionIn   Input AuthSession data
+  @param [out] AuthSessionOut  Output AuthSession data in TPM2 command buffer
+
+  @return AuthSession size
+**/
+UINT32
+EFIAPI
+Tpm2CopyAuthSessionCommand (
+  IN      TPMS_AUTH_COMMAND  *AuthSessionIn  OPTIONAL,
+  OUT     UINT8              *AuthSessionOut
+  )
+{
+  UINT8  *Buffer;
+
+  if (AuthSessionOut == NULL) {
+    return 0;
+  }
+
+  Buffer = (UINT8 *)AuthSessionOut;
+
+  //
+  // Add in Auth session
+  //
+  if (AuthSessionIn != NULL) {
+    //  sessionHandle
+    WriteUnaligned32 ((UINT32 *)Buffer, SwapBytes32 (AuthSessionIn->sessionHandle));
+    Buffer += sizeof (UINT32);
+
+    // nonce
+    WriteUnaligned16 ((UINT16 *)Buffer, SwapBytes16 (AuthSessionIn->nonce.size));
+    Buffer += sizeof (UINT16);
+
+    CopyMem (Buffer, AuthSessionIn->nonce.buffer, AuthSessionIn->nonce.size);
+    Buffer += AuthSessionIn->nonce.size;
+
+    // sessionAttributes
+    *(UINT8 *)Buffer = *(UINT8 *)&AuthSessionIn->sessionAttributes;
+    Buffer++;
+
+    // hmac
+    WriteUnaligned16 ((UINT16 *)Buffer, SwapBytes16 (AuthSessionIn->hmac.size));
+    Buffer += sizeof (UINT16);
+
+    CopyMem (Buffer, AuthSessionIn->hmac.buffer, AuthSessionIn->hmac.size);
+    Buffer += AuthSessionIn->hmac.size;
+  } else {
+    //  sessionHandle
+    WriteUnaligned32 ((UINT32 *)Buffer, SwapBytes32 (TPM_RS_PW));
+    Buffer += sizeof (UINT32);
+
+    // nonce = nullNonce
+    WriteUnaligned16 ((UINT16 *)Buffer, SwapBytes16 (0));
+    Buffer += sizeof (UINT16);
+
+    // sessionAttributes = 0
+    *(UINT8 *)Buffer = 0x00;
+    Buffer++;
+
+    // hmac = nullAuth
+    WriteUnaligned16 ((UINT16 *)Buffer, SwapBytes16 (0));
+    Buffer += sizeof (UINT16);
+  }
+
+  return (UINT32)((UINTN)Buffer - (UINTN)AuthSessionOut);
+}
+
+/**
+  Copy AuthSessionIn from TPM2 response buffer.
+
+  @param [in]  AuthSessionIn   Input AuthSession data in TPM2 response buffer
+  @param [out] AuthSessionOut  Output AuthSession data
+
+  @return 0    copy failed
+          else AuthSession size
+**/
+UINT32
+EFIAPI
+Tpm2CopyAuthSessionResponse (
+  IN      UINT8               *AuthSessionIn,
+  OUT     TPMS_AUTH_RESPONSE  *AuthSessionOut OPTIONAL
+  )
+{
+  UINT8               *Buffer;
+  TPMS_AUTH_RESPONSE  LocalAuthSessionOut;
+
+  if (AuthSessionOut == NULL) {
+    AuthSessionOut = &LocalAuthSessionOut;
+  }
+
+  if (AuthSessionIn == NULL) {
+    return 0;
+  }
+
+  Buffer = (UINT8 *)AuthSessionIn;
+
+  // nonce
+  AuthSessionOut->nonce.size = SwapBytes16 (ReadUnaligned16 ((UINT16 *)Buffer));
+  Buffer                    += sizeof (UINT16);
+  if (AuthSessionOut->nonce.size > sizeof (TPMU_HA)) {
+    DEBUG ((DEBUG_ERROR, "Tpm2CopyAuthSessionResponse - nonce.size error %x\n", AuthSessionOut->nonce.size));
+    return 0;
+  }
+
+  CopyMem (AuthSessionOut->nonce.buffer, Buffer, AuthSessionOut->nonce.size);
+  Buffer += AuthSessionOut->nonce.size;
+
+  // sessionAttributes
+  *(UINT8 *) &AuthSessionOut->sessionAttributes = *(UINT8 *)Buffer;
+  Buffer++;
+
+  // hmac
+  AuthSessionOut->hmac.size = SwapBytes16 (ReadUnaligned16 ((UINT16 *)Buffer));
+  Buffer                   += sizeof (UINT16);
+  if (AuthSessionOut->hmac.size > sizeof (TPMU_HA)) {
+    DEBUG ((DEBUG_ERROR, "Tpm2CopyAuthSessionResponse - hmac.size error %x\n", AuthSessionOut->hmac.size));
+    return 0;
+  }
+
+  CopyMem (AuthSessionOut->hmac.buffer, Buffer, AuthSessionOut->hmac.size);
+  Buffer += AuthSessionOut->hmac.size;
+
+  return (UINT32)((UINTN)Buffer - (UINTN)AuthSessionIn);
+}
+
+/**
+  Return if hash alg is supported in HashAlgorithmMask.
+
+  @param HashAlg            Hash algorithm to be checked.
+  @param HashAlgorithmMask  Bitfield of allowed hash algorithms.
+
+  @retval TRUE  Hash algorithm is supported.
+  @retval FALSE Hash algorithm is not supported.
+**/
+BOOLEAN
+EFIAPI
+Tpm2IsHashAlgSupportedInHashAlgorithmMask (
+  IN TPMI_ALG_HASH  HashAlg,
+  IN UINT32         HashAlgorithmMask
+  )
+{
+  switch (HashAlg) {
+    case TPM_ALG_SHA1:
+      if ((HashAlgorithmMask & HASH_ALG_SHA1) != 0) {
+        return TRUE;
+      }
+
+      break;
+    case TPM_ALG_SHA256:
+      if ((HashAlgorithmMask & HASH_ALG_SHA256) != 0) {
+        return TRUE;
+      }
+
+      break;
+    case TPM_ALG_SHA384:
+      if ((HashAlgorithmMask & HASH_ALG_SHA384) != 0) {
+        return TRUE;
+      }
+
+      break;
+    case TPM_ALG_SHA512:
+      if ((HashAlgorithmMask & HASH_ALG_SHA512) != 0) {
+        return TRUE;
+      }
+
+      break;
+    case TPM_ALG_SM3_256:
+      if ((HashAlgorithmMask & HASH_ALG_SM3_256) != 0) {
+        return TRUE;
+      }
+
+      break;
+  }
+
+  return FALSE;
+}
+
+/**
+  Copy TPML_DIGEST_VALUES into a buffer
+
+  @param[in,out] Buffer             Buffer to hold copied TPML_DIGEST_VALUES compact binary.
+  @param[in]     DigestList         TPML_DIGEST_VALUES to be copied.
+  @param[in]     HashAlgorithmMask  HASH bits corresponding to the desired digests to copy.
+
+  @return The end of buffer to hold TPML_DIGEST_VALUES, NULL otherwise.
+**/
+VOID *
+EFIAPI
+Tpm2CopyDigestListToBuffer (
+  IN OUT VOID            *Buffer,
+  IN TPML_DIGEST_VALUES  *DigestList,
+  IN UINT32              HashAlgorithmMask
+  )
+{
+  UINTN   Index;
+  UINT16  DigestSize;
+  UINT32  DigestListCount;
+  UINT32  *DigestListCountPtr;
+
+  if ((Buffer == NULL) || (DigestList == NULL)) {
+    return NULL;
+  }
+
+  if (DigestList->count > HASH_COUNT) {
+    return NULL;
+  }
+
+  DigestListCountPtr = (UINT32 *)Buffer;
+  DigestListCount    = 0;
+  Buffer             = (UINT8 *)Buffer + sizeof (DigestList->count);
+  for (Index = 0; Index < DigestList->count; Index++) {
+    if (!Tpm2IsHashAlgSupportedInHashAlgorithmMask (DigestList->digests[Index].hashAlg, HashAlgorithmMask)) {
+      DEBUG ((DEBUG_ERROR, "WARNING: TPM2 Event log has HashAlg unsupported by PCR bank (0x%x)\n", DigestList->digests[Index].hashAlg));
+      continue;
+    }
+
+    CopyMem (Buffer, &DigestList->digests[Index].hashAlg, sizeof (DigestList->digests[Index].hashAlg));
+    Buffer     = (UINT8 *)Buffer + sizeof (DigestList->digests[Index].hashAlg);
+    DigestSize = Tpm2GetHashSizeFromAlgo (DigestList->digests[Index].hashAlg);
+    CopyMem (Buffer, &DigestList->digests[Index].digest, DigestSize);
+    Buffer = (UINT8 *)Buffer + DigestSize;
+    DigestListCount++;
+  }
+
+  WriteUnaligned32 (DigestListCountPtr, DigestListCount);
+
+  return Buffer;
+}
+
+/**
+  Copy a buffer into a TPML_DIGEST_VALUES structure.
+
+  @param[in]     Buffer             Buffer to hold TPML_DIGEST_VALUES compact binary.
+  @param[in]     BufferSize         Size of Buffer.
+  @param[out]    DigestList         TPML_DIGEST_VALUES.
+
+  @return EFI_STATUS
+  @retval EFI_SUCCESS               Buffer was successfully copied to Digest List.
+  @retval EFI_BAD_BUFFER_SIZE       Bad buffer size passed to function.
+  @retval EFI_INVALID_PARAMETER     Invalid parameter passed to function: NULL pointer or
+                                    BufferSize bigger than TPML_DIGEST_VALUES
+**/
+EFI_STATUS
+EFIAPI
+Tpm2CopyBufferToDigestList (
+  IN CONST  VOID                *Buffer,
+  IN        UINTN               BufferSize,
+  OUT       TPML_DIGEST_VALUES  *DigestList
+  )
+{
+  EFI_STATUS   Status;
+  UINTN        Index;
+  UINT16       DigestSize;
+  CONST UINT8  *BufferPtr;
+
+  if ((Buffer == NULL) || (DigestList == NULL) || (BufferSize > sizeof (TPML_DIGEST_VALUES))) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  DigestList->count = SwapBytes32 (ReadUnaligned32 ((CONST UINT32 *)Buffer));
+  if (DigestList->count > HASH_COUNT) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Status    = EFI_INVALID_PARAMETER;
+  BufferPtr = (CONST UINT8 *)Buffer +  sizeof (UINT32);
+  for (Index = 0; Index < DigestList->count; Index++) {
+    if (BufferPtr - (CONST UINT8 *)Buffer + sizeof (UINT16) > BufferSize) {
+      Status = EFI_BAD_BUFFER_SIZE;
+      break;
+    } else {
+      DigestList->digests[Index].hashAlg = SwapBytes16 (ReadUnaligned16 ((CONST UINT16 *)BufferPtr));
+    }
+
+    BufferPtr += sizeof (UINT16);
+    DigestSize = Tpm2GetHashSizeFromAlgo (DigestList->digests[Index].hashAlg);
+    if (BufferPtr - (CONST UINT8 *)Buffer + (UINTN)DigestSize > BufferSize) {
+      Status = EFI_BAD_BUFFER_SIZE;
+      break;
+    } else {
+      CopyMem (&DigestList->digests[Index].digest, BufferPtr, DigestSize);
+    }
+
+    BufferPtr += DigestSize;
+    Status     = EFI_SUCCESS;
+  }
+
+  return Status;
+}
+
+/**
+  Get TPML_DIGEST_VALUES data size.
+
+  @param[in]     DigestList    TPML_DIGEST_VALUES data.
+
+  @return TPML_DIGEST_VALUES data size, 0 otherwise.
+**/
+UINT32
+EFIAPI
+Tpm2GetDigestListSize (
+  IN TPML_DIGEST_VALUES  *DigestList
+  )
+{
+  UINTN   Index;
+  UINT16  DigestSize;
+  UINT32  TotalSize;
+
+  if (DigestList == NULL) {
+    return 0;
+  }
+
+  if (DigestList->count > HASH_COUNT) {
+    return 0;
+  }
+
+  TotalSize = sizeof (DigestList->count);
+  for (Index = 0; Index < DigestList->count; Index++) {
+    DigestSize = Tpm2GetHashSizeFromAlgo (DigestList->digests[Index].hashAlg);
+    TotalSize += sizeof (DigestList->digests[Index].hashAlg) + DigestSize;
+  }
+
+  return TotalSize;
+}
+
+/**
+  Get TPML_DIGEST_VALUES data size from HashAlgorithmMask
+
+  @param[in]     HashAlgorithmMask    Bitfield of allowed hash algorithms
+
+  @return TPML_DIGEST_VALUES data size.
+**/
+UINT32
+EFIAPI
+Tpm2GetDigestListSizeFromHashAlgorithmMask (
+  IN UINT32  HashAlgorithmMask
+  )
+{
+  UINTN   Index;
+  UINT32  TotalSize;
+
+  TotalSize = sizeof (UINT32);
+  for (Index = 0; Index < ARRAY_SIZE (mHashInfo); Index++) {
+    if ((mHashInfo[Index].HashMask & HashAlgorithmMask) != 0) {
+      TotalSize += sizeof (TPMI_ALG_HASH) + mHashInfo[Index].HashSize;
+    }
+  }
+
+  return TotalSize;
+}
+
+/**
+  This function get digest from digest list.
+
+  @param[in]  HashAlg       Digest algorithm
+  @param[in]  DigestList    Digest list
+  @param[out] Digest        Digest
+
+  @retval EFI_SUCCESS            Digest is found and returned.
+  @retval EFI_NOT_FOUND          Digest is not found.
+  @retval EFI_INVALID_PARAMETER  DigestList or Digest invalid.
+**/
+EFI_STATUS
+EFIAPI
+Tpm2GetDigestFromDigestList (
+  IN TPMI_ALG_HASH       HashAlg,
+  IN TPML_DIGEST_VALUES  *DigestList,
+  OUT VOID               *Digest
+  )
+{
+  UINTN   Index;
+  UINT16  DigestSize;
+
+  if ((DigestList == NULL) || (Digest == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (DigestList->count > HASH_COUNT) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  DigestSize = Tpm2GetHashSizeFromAlgo (HashAlg);
+  for (Index = 0; Index < DigestList->count; Index++) {
+    if (DigestList->digests[Index].hashAlg == HashAlg) {
+      CopyMem (
+        Digest,
+        &DigestList->digests[Index].digest,
+        DigestSize
+        );
+      return EFI_SUCCESS;
+    }
+  }
+
+  return EFI_NOT_FOUND;
+}
+
+/**
+  Check if all hash algorithms supported in HashAlgorithmMask are
+  present in the DigestList.
+
+  @param DigestList         Digest list.
+  @param HashAlgorithmMask  Bitfield of allowed hash algorithms.
+
+  @retval TRUE  All hash algorithms present.
+  @retval FALSE Some hash algorithms not present.
+**/
+BOOLEAN
+EFIAPI
+Tpm2IsDigestListInSyncWithHashAlgorithmMask (
+  IN TPML_DIGEST_VALUES  *DigestList,
+  IN UINT32              HashAlgorithmMask
+  )
+{
+  if (DigestList == NULL) {
+    return FALSE;
+  }
+
+  if ((HashAlgorithmMask & HASH_ALG_SHA1) != 0) {
+    if (!CheckDigestListForHashAlg (DigestList, TPM_ALG_SHA1)) {
+      return FALSE;
+    }
+  }
+
+  if ((HashAlgorithmMask & HASH_ALG_SHA256) != 0) {
+    if (!CheckDigestListForHashAlg (DigestList, TPM_ALG_SHA256)) {
+      return FALSE;
+    }
+  }
+
+  if ((HashAlgorithmMask & HASH_ALG_SHA384) != 0) {
+    if (!CheckDigestListForHashAlg (DigestList, TPM_ALG_SHA384)) {
+      return FALSE;
+    }
+  }
+
+  if ((HashAlgorithmMask & HASH_ALG_SHA512) != 0) {
+    if (!CheckDigestListForHashAlg (DigestList, TPM_ALG_SHA512)) {
+      return FALSE;
+    }
+  }
+
+  if ((HashAlgorithmMask & HASH_ALG_SM3_256) != 0) {
+    if (!CheckDigestListForHashAlg (DigestList, TPM_ALG_SM3_256)) {
+      return FALSE;
+    }
+  }
+
+  return TRUE;
+}

--- a/SecurityPkg/Library/Tpm2HelpLib/Tpm2HelpLib.inf
+++ b/SecurityPkg/Library/Tpm2HelpLib/Tpm2HelpLib.inf
@@ -1,0 +1,30 @@
+## @file
+#  Provides reusable TPM 2.0 data helper routines that are independent
+#  of TPM command/device communication libraries. Includes serialization
+#  and parsing helpers for common TPM data structures.
+#
+# Copyright (c) 2013 - 2018, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = Tpm2HelpLib
+  FILE_GUID                      = DDFCEB08-9CE3-4CB8-ABBD-D32925E8CAAB
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = Tpm2HelpLib
+
+[Sources]
+  Tpm2Help.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  SecurityPkg/SecurityPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  BaseMemoryLib
+  DebugLib

--- a/SecurityPkg/SecurityPkg.dec
+++ b/SecurityPkg/SecurityPkg.dec
@@ -46,6 +46,10 @@
   #
   Tpm2CommandLib|Include/Library/Tpm2CommandLib.h
 
+  ##  @libraryclass  Provides helper functions for interfacing with TPM 2.0 data.
+  #
+  Tpm2HelpLib|Include/Library/Tpm2HelpLib.h
+
   ##  @libraryclass  Provides interfaces on how to access TPM 2.0 hardware device.
   #
   Tpm2DeviceLib|Include/Library/Tpm2DeviceLib.h

--- a/SecurityPkg/SecurityPkg.dsc
+++ b/SecurityPkg/SecurityPkg.dsc
@@ -55,6 +55,7 @@
   TpmMeasurementLib|SecurityPkg/Library/DxeTpmMeasurementLib/DxeTpmMeasurementLib.inf
   Tpm12CommandLib|SecurityPkg/Library/Tpm12CommandLib/Tpm12CommandLib.inf
   Tpm2CommandLib|SecurityPkg/Library/Tpm2CommandLib/Tpm2CommandLib.inf
+  Tpm2HelpLib|SecurityPkg/Library/Tpm2HelpLib/Tpm2HelpLib.inf
   Tcg2PhysicalPresenceLib|SecurityPkg/Library/DxeTcg2PhysicalPresenceLib/DxeTcg2PhysicalPresenceLib.inf
   TcgPpVendorLib|SecurityPkg/Library/TcgPpVendorLibNull/TcgPpVendorLibNull.inf
   Tcg2PpVendorLib|SecurityPkg/Library/Tcg2PpVendorLibNull/Tcg2PpVendorLibNull.inf
@@ -239,6 +240,7 @@
   SecurityPkg/Library/HashLibBaseCryptoRouter/HashLibBaseCryptoRouterPei.inf
 
   SecurityPkg/Library/Tpm2CommandLib/Tpm2CommandLib.inf
+  SecurityPkg/Library/Tpm2HelpLib/Tpm2HelpLib.inf
   SecurityPkg/Library/Tpm2DeviceLibTcg2/Tpm2DeviceLibTcg2.inf
   SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2DeviceLibDTpm.inf
   SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2InstanceLibDTpm.inf

--- a/SecurityPkg/Tcg/Tcg2Dxe/Tcg2Dxe.c
+++ b/SecurityPkg/Tcg/Tcg2Dxe/Tcg2Dxe.c
@@ -38,6 +38,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/MemoryAllocationLib.h>
 #include <Library/PrintLib.h>
 #include <Library/Tpm2CommandLib.h>
+#include <Library/Tpm2HelpLib.h>
 #include <Library/PcdLib.h>
 #include <Library/UefiLib.h>
 #include <Library/Tpm2DeviceLib.h>
@@ -205,35 +206,35 @@ InitNoActionEvent (
   if ((mTcgDxeData.BsCap.ActivePcrBanks & EFI_TCG2_BOOT_HASH_ALG_SHA1) != 0) {
     HashAlgId = TPM_ALG_SHA1;
     CopyMem (DigestBuffer, &HashAlgId, sizeof (TPMI_ALG_HASH));
-    DigestBuffer += sizeof (TPMI_ALG_HASH) + GetHashSizeFromAlgo (HashAlgId);
+    DigestBuffer += sizeof (TPMI_ALG_HASH) + Tpm2GetHashSizeFromAlgo (HashAlgId);
     DigestListCount++;
   }
 
   if ((mTcgDxeData.BsCap.ActivePcrBanks & EFI_TCG2_BOOT_HASH_ALG_SHA256) != 0) {
     HashAlgId = TPM_ALG_SHA256;
     CopyMem (DigestBuffer, &HashAlgId, sizeof (TPMI_ALG_HASH));
-    DigestBuffer += sizeof (TPMI_ALG_HASH) + GetHashSizeFromAlgo (HashAlgId);
+    DigestBuffer += sizeof (TPMI_ALG_HASH) + Tpm2GetHashSizeFromAlgo (HashAlgId);
     DigestListCount++;
   }
 
   if ((mTcgDxeData.BsCap.ActivePcrBanks & EFI_TCG2_BOOT_HASH_ALG_SHA384) != 0) {
     HashAlgId = TPM_ALG_SHA384;
     CopyMem (DigestBuffer, &HashAlgId, sizeof (TPMI_ALG_HASH));
-    DigestBuffer += sizeof (TPMI_ALG_HASH) + GetHashSizeFromAlgo (HashAlgId);
+    DigestBuffer += sizeof (TPMI_ALG_HASH) + Tpm2GetHashSizeFromAlgo (HashAlgId);
     DigestListCount++;
   }
 
   if ((mTcgDxeData.BsCap.ActivePcrBanks & EFI_TCG2_BOOT_HASH_ALG_SHA512) != 0) {
     HashAlgId = TPM_ALG_SHA512;
     CopyMem (DigestBuffer, &HashAlgId, sizeof (TPMI_ALG_HASH));
-    DigestBuffer += sizeof (TPMI_ALG_HASH) + GetHashSizeFromAlgo (HashAlgId);
+    DigestBuffer += sizeof (TPMI_ALG_HASH) + Tpm2GetHashSizeFromAlgo (HashAlgId);
     DigestListCount++;
   }
 
   if ((mTcgDxeData.BsCap.ActivePcrBanks & EFI_TCG2_BOOT_HASH_ALG_SM3_256) != 0) {
     HashAlgId = TPM_ALG_SM3_256;
     CopyMem (DigestBuffer, &HashAlgId, sizeof (TPMI_ALG_HASH));
-    DigestBuffer += sizeof (TPMI_ALG_HASH) + GetHashSizeFromAlgo (HashAlgId);
+    DigestBuffer += sizeof (TPMI_ALG_HASH) + Tpm2GetHashSizeFromAlgo (HashAlgId);
     DigestListCount++;
   }
 
@@ -552,7 +553,7 @@ DumpEvent2 (
   for (DigestIndex = 0; DigestIndex < DigestCount; DigestIndex++) {
     DEBUG ((DEBUG_SECURITY, "      HashAlgo : 0x%04x\n", HashAlgo));
     DEBUG ((DEBUG_SECURITY, "      Digest(%d): ", DigestIndex));
-    DigestSize = GetHashSizeFromAlgo (HashAlgo);
+    DigestSize = Tpm2GetHashSizeFromAlgo (HashAlgo);
     for (Index = 0; Index < DigestSize; Index++) {
       DEBUG ((DEBUG_SECURITY, "%02x ", DigestBuffer[Index]));
     }
@@ -598,7 +599,7 @@ GetPcrEvent2Size (
   HashAlgo     = TcgPcrEvent2->Digest.digests[0].hashAlg;
   DigestBuffer = (UINT8 *)&TcgPcrEvent2->Digest.digests[0].digest;
   for (DigestIndex = 0; DigestIndex < DigestCount; DigestIndex++) {
-    DigestSize = GetHashSizeFromAlgo (HashAlgo);
+    DigestSize = Tpm2GetHashSizeFromAlgo (HashAlgo);
     //
     // Prepare next
     //
@@ -1056,7 +1057,7 @@ GetDigestListBinSize (
     TotalSize    += sizeof (HashAlg);
     DigestListBin = (UINT8 *)DigestListBin + sizeof (HashAlg);
 
-    DigestSize    = GetHashSizeFromAlgo (HashAlg);
+    DigestSize    = Tpm2GetHashSizeFromAlgo (HashAlg);
     TotalSize    += DigestSize;
     DigestListBin = (UINT8 *)DigestListBin + DigestSize;
   }
@@ -1099,15 +1100,15 @@ CopyDigestListBinToBuffer (
   for (Index = 0; Index < Count; Index++) {
     HashAlg       = ReadUnaligned16 (DigestListBin);
     DigestListBin = (UINT8 *)DigestListBin + sizeof (HashAlg);
-    DigestSize    = GetHashSizeFromAlgo (HashAlg);
+    DigestSize    = Tpm2GetHashSizeFromAlgo (HashAlg);
 
-    if (IsHashAlgSupportedInHashAlgorithmMask (HashAlg, HashAlgorithmMask)) {
+    if (Tpm2IsHashAlgSupportedInHashAlgorithmMask (HashAlg, HashAlgorithmMask)) {
       CopyMem (Buffer, &HashAlg, sizeof (HashAlg));
       Buffer = (UINT8 *)Buffer + sizeof (HashAlg);
       CopyMem (Buffer, DigestListBin, DigestSize);
       Buffer = (UINT8 *)Buffer + DigestSize;
       DigestListCount++;
-      (*HashAlgorithmMaskCopied) |= GetHashMaskFromAlgo (HashAlg);
+      (*HashAlgorithmMaskCopied) |= Tpm2GetHashMaskFromAlgo (HashAlg);
     } else {
       DEBUG ((DEBUG_ERROR, "WARNING: CopyDigestListBinToBuffer Event log has HashAlg unsupported by PCR bank (0x%x)\n", HashAlg));
     }
@@ -1150,7 +1151,7 @@ TcgDxeLogHashEvent (
     if ((mTcgDxeData.BsCap.SupportedEventLogs & mTcg2EventInfo[Index].LogFormat) != 0) {
       switch (mTcg2EventInfo[Index].LogFormat) {
         case EFI_TCG2_EVENT_LOG_FORMAT_TCG_1_2:
-          Status = GetDigestFromDigestList (TPM_ALG_SHA1, DigestList, &NewEventHdr->Digest);
+          Status = Tpm2GetDigestFromDigestList (TPM_ALG_SHA1, DigestList, &NewEventHdr->Digest);
           if (!EFI_ERROR (Status)) {
             //
             // Enter critical region
@@ -1179,7 +1180,7 @@ TcgDxeLogHashEvent (
           TcgPcrEvent2.PCRIndex  = NewEventHdr->PCRIndex;
           TcgPcrEvent2.EventType = NewEventHdr->EventType;
           DigestBuffer           = (UINT8 *)&TcgPcrEvent2.Digest;
-          EventSizePtr           = CopyDigestListToBuffer (DigestBuffer, DigestList, mTcgDxeData.BsCap.ActivePcrBanks);
+          EventSizePtr           = Tpm2CopyDigestListToBuffer (DigestBuffer, DigestList, mTcgDxeData.BsCap.ActivePcrBanks);
           CopyMem (EventSizePtr, &NewEventHdr->EventSize, sizeof (NewEventHdr->EventSize));
 
           //

--- a/SecurityPkg/Tcg/Tcg2Dxe/Tcg2Dxe.inf
+++ b/SecurityPkg/Tcg/Tcg2Dxe/Tcg2Dxe.inf
@@ -64,6 +64,7 @@
   ReportStatusCodeLib
   Tcg2PhysicalPresenceLib
   PeCoffLib
+  Tpm2HelpLib
 
 [Guids]
   ## SOMETIMES_CONSUMES     ## Variable:L"SecureBoot"

--- a/SecurityPkg/Tcg/Tcg2Pei/Tcg2Pei.c
+++ b/SecurityPkg/Tcg/Tcg2Pei/Tcg2Pei.c
@@ -29,6 +29,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/PeiServicesLib.h>
 #include <Library/PeimEntryPoint.h>
 #include <Library/Tpm2CommandLib.h>
+#include <Library/Tpm2HelpLib.h>
 #include <Library/Tpm2DeviceLib.h>
 #include <Library/HashLib.h>
 #include <Library/HobLib.h>
@@ -389,7 +390,7 @@ LogHashEvent (
       DEBUG ((DEBUG_INFO, "  LogFormat - 0x%08x\n", mTcg2EventInfo[Index].LogFormat));
       switch (mTcg2EventInfo[Index].LogFormat) {
         case EFI_TCG2_EVENT_LOG_FORMAT_TCG_1_2:
-          Status = GetDigestFromDigestList (TPM_ALG_SHA1, DigestList, &NewEventHdr->Digest);
+          Status = Tpm2GetDigestFromDigestList (TPM_ALG_SHA1, DigestList, &NewEventHdr->Digest);
           if (!EFI_ERROR (Status)) {
             HobData = BuildGuidHob (
                         &gTcgEventEntryHobGuid,
@@ -408,12 +409,12 @@ LogHashEvent (
           break;
         case EFI_TCG2_EVENT_LOG_FORMAT_TCG_2:
           //
-          // Use GetDigestListSize (DigestList) in the GUID HOB DataLength calculation
+          // Use Tpm2GetDigestListSize (DigestList) in the GUID HOB DataLength calculation
           // to reserve enough buffer to hold TPML_DIGEST_VALUES compact binary.
           //
           HobData = BuildGuidHob (
                       &gTcgEvent2EntryHobGuid,
-                      sizeof (TcgPcrEvent2->PCRIndex) + sizeof (TcgPcrEvent2->EventType) + GetDigestListSize (DigestList) + sizeof (TcgPcrEvent2->EventSize) + NewEventHdr->EventSize
+                      sizeof (TcgPcrEvent2->PCRIndex) + sizeof (TcgPcrEvent2->EventType) + Tpm2GetDigestListSize (DigestList) + sizeof (TcgPcrEvent2->EventSize) + NewEventHdr->EventSize
                       );
           if (HobData == NULL) {
             RetStatus = EFI_OUT_OF_RESOURCES;
@@ -424,7 +425,7 @@ LogHashEvent (
           TcgPcrEvent2->PCRIndex  = NewEventHdr->PCRIndex;
           TcgPcrEvent2->EventType = NewEventHdr->EventType;
           DigestBuffer            = (UINT8 *)&TcgPcrEvent2->Digest;
-          DigestBuffer            = CopyDigestListToBuffer (DigestBuffer, DigestList, PcdGet32 (PcdTpm2HashMask));
+          DigestBuffer            = Tpm2CopyDigestListToBuffer (DigestBuffer, DigestList, PcdGet32 (PcdTpm2HashMask));
           CopyMem (DigestBuffer, &NewEventHdr->EventSize, sizeof (TcgPcrEvent2->EventSize));
           DigestBuffer = DigestBuffer + sizeof (TcgPcrEvent2->EventSize);
           CopyMem (DigestBuffer, NewEventData, NewEventHdr->EventSize);
@@ -687,7 +688,7 @@ MeasureFvImage (
       PreHashInfo = (HASH_INFO *)(PrehashedFvPpi + 1);
       for (Index = 0, DigestCount = 0; Index < PrehashedFvPpi->Count; Index++) {
         DEBUG ((DEBUG_INFO, "Hash Algo ID in PrehashedFvPpi=0x%x\n", PreHashInfo->HashAlgoId));
-        HashAlgoMask = GetHashMaskFromAlgo (PreHashInfo->HashAlgoId);
+        HashAlgoMask = Tpm2GetHashMaskFromAlgo (PreHashInfo->HashAlgoId);
         if ((Tpm2HashMask & HashAlgoMask) != 0 ) {
           //
           // Hash is required, copy it to DigestList

--- a/SecurityPkg/Tcg/Tcg2Pei/Tcg2Pei.inf
+++ b/SecurityPkg/Tcg/Tcg2Pei/Tcg2Pei.inf
@@ -55,6 +55,7 @@
   ReportStatusCodeLib
   ResetSystemLib
   PrintLib
+  Tpm2HelpLib
 
 [Guids]
   gTcgEventEntryHobGuid                                                ## PRODUCES               ## HOB


### PR DESCRIPTION
# Description

Decoupled Tpm2Help.c from Tpm2CommandLib. This allows for use of the helper functions without the need to include Tpm2CommandLib and Tpm2DeviceLib which is usually tied to the TPM and TPM communication.

There are cases where you may need to generate a HOB for pre-DXE measurements. These cases utilize these helper functions but do not require Tpm2CommandLib or Tpm2DeviceLib as there is no communication to the TPM needed. An example is there is no Tpm2DeviceLib for SEC.

- [x] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Ran CI locallly.

## Integration Instructions

Include Tpm2HelpLib in place of Tpm2CommandLib if necessary, otherwise, just add Tpm2HelpLib to the .inf and include the header in the .c.

The helper functions in Tpm2Help.c in Tpm2CommandLib are deprecated as of the inclusion of this library. They are wrappers in place of the Tpm2HelpLib versions. Update all calls to Tpm2Help.c functions to use Tpm2HelpLib versions instead.
