### PR TITLE
StandaloneMmPkg/Core/Dispatcher: Use more generic MMRAM term in comment

### DIFF
--- a/StandaloneMmPkg/Core/Dispatcher.c
+++ b/StandaloneMmPkg/Core/Dispatcher.c
@@ -125,7 +125,7 @@ BOOLEAN  gDispatcherRunning = FALSE;
 BOOLEAN  gRequestDispatch = FALSE;
 
 /**
-  Loads an EFI image into SMRAM.
+  Loads an EFI image into MMRAM.
 
   @param  DriverEntry             EFI_MM_DRIVER_ENTRY instance
   @param  ImageContext            Allocated ImageContext to be filled out by this function
@@ -225,7 +225,7 @@ MmLoadImage (
 
   //
   // Fill in the remaining fields of the Loaded Image Protocol instance.
-  // Note: ImageBase is an SMRAM address that can not be accessed outside of SMRAM if SMRAM window is closed.
+  // Note: ImageBase is an MMRAM address that can not be accessed outside of MMRAM if MMRAM window is closed.
   //
   DriverEntry->LoadedImage.Revision     = EFI_LOADED_IMAGE_PROTOCOL_REVISION;
   DriverEntry->LoadedImage.ParentHandle = NULL;


### PR DESCRIPTION
In StandaloneMmPkg/Core/Dispatcher.c, a comment referred to SMRAM. SMRAM is specific to the x86 architecture.
The StandaloneMmPkg is designed to be architecture-agnostic. This commit updates the comment to use the more generic term MMRAM (Management Mode RAM) to better reflect the nature of the package.

# Description

In StandaloneMmPkg/Core/Dispatcher.c, a comment referred to SMRAM. SMRAM is specific to the x86 architecture.
The StandaloneMmPkg is designed to be architecture-agnostic. This commit updates the comment to use the more generic term MMRAM (Management Mode RAM) to better reflect the nature of the package.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

N/A

## Integration Instructions

N/A
