### PR TITLE
BaseTools: Fix error messages in GnuMakeUtils script

### DIFF
--- a/BaseTools/Source/C/Makefiles/GnuMakeUtils.py
+++ b/BaseTools/Source/C/Makefiles/GnuMakeUtils.py
@@ -229,18 +229,18 @@ def main():
                 if os.path.isfile(file):
                     os.remove(file)
                 else:
-                    sys.stderr.writelines(['{} is not a file.'.format(file)])
+                    sys.stderr.writelines(['{} is not a file.\n'.format(file)])
             else:
-                sys.stderr.writelines(['File {} does not exist.'.format(file)])
+                sys.stderr.writelines(['File {} does not exist.\n'.format(file)])
     elif sys.argv[1] == 'md':
         path = os.path.normpath(sys.argv[2])
         if not os.path.exists(path):
             os.makedirs(path)
         else:
             if os.path.isdir(path):
-                sys.stderr.writelines(['Directory {} already exists.'.format(path)])
+                sys.stderr.writelines(['Directory {} already exists.\n'.format(path)])
             else:
-                sys.stderr.writelines(['{} is a file.'.format(path)])
+                sys.stderr.writelines(['{} is a file.\n'.format(path)])
                 return 1
     elif sys.argv[1] == 'rd':
         paths = [os.path.normpath(x) for x in sys.argv[2:]]
@@ -249,9 +249,9 @@ def main():
                 if os.path.isdir(path):
                     shutil.rmtree(path)
                 else:
-                    sys.stderr.writelines(['{} is not a directory.'.format(path)])
+                    sys.stderr.writelines(['{} is not a directory.\n'.format(path)])
             else:
-                sys.stderr.writelines(['Directory {} does not exist.'.format(path)])
+                sys.stderr.writelines(['Directory {} does not exist.\n'.format(path)])
     elif sys.argv[1] == 'rm_pyc_files':
         path = os.path.normpath(sys.argv[2])
         files = glob.glob(os.path.join(path, '*.pyc'))
@@ -260,14 +260,14 @@ def main():
                 if os.path.isfile(file):
                     os.remove(file)
                 else:
-                    sys.stderr.writelines(['{} is not a file.'.format(file)])
+                    sys.stderr.writelines(['{} is not a file.\n'.format(file)])
             else:
-                sys.stderr.writelines(['File {} does not exist.'.format(file)])
+                sys.stderr.writelines(['File {} does not exist.\n'.format(file)])
         py_cache = os.path.join(path, '__pycache__')
         if os.path.isdir(py_cache):
             shutil.rmtree(py_cache)
     else:
-        sys.stderr.writelines(['Unsupported command.'])
+        sys.stderr.writelines(['Unsupported command.\n'])
         return 1
     return 0
 


### PR DESCRIPTION
# Description

Add newlines to the error messages in the GnuMakeUtils script. `writelines` function does not add newlines automatically so the print is merged with a line that is printed next.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

```
make -C BaseTools
```

The output is:
```
make[1]: Entering directory '/host/BaseTools/Source/C'
python3 ./Makefiles/GnuMakeUtils.py md .
Directory . already exists.
python3 ./Makefiles/GnuMakeUtils.py md ./libs
```

## Integration Instructions

