### PR TITLE
UnitTestFrameworkPkg: Make global variables not static

### DIFF
--- a/UnitTestFrameworkPkg/Library/UnitTestUefiBootServicesTableLib/UnitTestUefiBootServicesTableLibProtocol.c
+++ b/UnitTestFrameworkPkg/Library/UnitTestUefiBootServicesTableLib/UnitTestUefiBootServicesTableLibProtocol.c
@@ -8,10 +8,10 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #include "UnitTestUefiBootServicesTableLibProtocol.h"
 
-STATIC LIST_ENTRY  mProtocolDatabase       = INITIALIZE_LIST_HEAD_VARIABLE (mProtocolDatabase);
-STATIC LIST_ENTRY  gHandleList             = INITIALIZE_LIST_HEAD_VARIABLE (gHandleList);
-STATIC UINT64      gHandleDatabaseKey      = 0;
-STATIC UINTN       mEfiLocateHandleRequest = 0;
+LIST_ENTRY  mProtocolDatabase       = INITIALIZE_LIST_HEAD_VARIABLE (mProtocolDatabase);
+LIST_ENTRY  gHandleList             = INITIALIZE_LIST_HEAD_VARIABLE (gHandleList);
+UINT64      gHandleDatabaseKey      = 0;
+UINTN       mEfiLocateHandleRequest = 0;
 
 //
 // Helper Functions

--- a/UnitTestFrameworkPkg/Library/UnitTestUefiBootServicesTableLib/UnitTestUefiBootServicesTableLibProtocol.c
+++ b/UnitTestFrameworkPkg/Library/UnitTestUefiBootServicesTableLib/UnitTestUefiBootServicesTableLibProtocol.c
@@ -655,7 +655,7 @@ Done:
     // There was an error, clean up
     //
     if (Prot != NULL) {
-      UnitTestFreePool (Prot);
+      FreePool (Prot);
     }
 
     DEBUG ((DEBUG_ERROR, "InstallProtocolInterface: %g %p failed with %r\n", Protocol, Interface, Status));

--- a/UnitTestFrameworkPkg/Library/UnitTestUefiBootServicesTableLib/UnitTestUefiBootServicesTableLibProtocol.c
+++ b/UnitTestFrameworkPkg/Library/UnitTestUefiBootServicesTableLib/UnitTestUefiBootServicesTableLibProtocol.c
@@ -538,7 +538,7 @@ UnitTestInstallProtocolInterfaceNotify (
   //
   // Print debug message
   //
-  UT_LOG_INFO ("InstallProtocolInterface: %g %p\n", Protocol, Interface);
+  DEBUG ((DEBUG_INFO, "InstallProtocolInterface: %g %p\n", Protocol, Interface));
 
   Status = EFI_OUT_OF_RESOURCES;
   Prot   = NULL;


### PR DESCRIPTION
# Description

UnitTestUefiBootServicesTableLib keeps its state in static global variables. Change them to not static to make them reachable from outside of this lib. That way other modules can reset lib's state between test cases if needed. Resolves #11659.
Changes debug log printing macro from UT_LOG_INFO to DEBUG. Resolves #11670.
Changes one instance of UnitTestFreePool to FreePool, to match how given memory was allocated (AllocZeroPool)

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested
Exact copy of this code is in use for SMM functional tests in an Intel private repository

## Integration Instructions
N/A
