### PR TITLE
ArmPlatformPkg: Update transfer list register usage before stack setup

### DIFF
--- a/ArmPlatformPkg/PeilessSec/AArch64/ModuleEntryPoint.S
+++ b/ArmPlatformPkg/PeilessSec/AArch64/ModuleEntryPoint.S
@@ -20,8 +20,8 @@ ASM_FUNC(_ModuleEntryPoint)
   // Skip TransferList init if x2 is not equal to 0
   cbnz  x2, _SkipTransferList
 
-  // Set the TransferList Base Address from register x3
-  mov   x6, x3
+  // Set the TransferList Base Address from register x3 to TPIDRRO_EL0
+  msr   TPIDRRO_EL0, x3
 
 _SkipTransferList:
   // Do early platform specific actions
@@ -93,7 +93,7 @@ _GetStackBase:
   sub   x1, x1, x2
 
   // Pass Transfer List Base Address
-  mov   x2, x6
+  mrs   x2, TPIDRRO_EL0
   // Move sec startup address into a data register
   // Ensure we're jumping to FV version of the code (not boot remapped alias)
   ldr   x4, =ASM_PFX(CEntryPoint)


### PR DESCRIPTION
Previously register x6 was used to temporarily hold the transfer list address before the stack was setup and the jump to C code. This however is not working for RPi3, platform code uses w6 which aliases x6 causing overwrites.
Instead we now use TPIDRRO_EL0  to temporarily hold the value.
This is inspired by PEI using TPIDR_EL0 to store the PEI services table pointer.

# Description

Use TPIDRRO_EL0 instead of x6 to temporarily hold the transfer list address before the stack is setup.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Tested on RPi3

## Integration Instructions

N/A