### PR TITLE
 MdePkg: Introduce EFI_DT_FIXUP_PROTOCOL protocol

### DIFF
--- a/MdePkg/Include/Protocol/DtFixup.h
+++ b/MdePkg/Include/Protocol/DtFixup.h
@@ -1,0 +1,50 @@
+/** @file
+
+  Copyright (c) 2025, Heinrich Schuchardt.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+/*
+  DT Fix-up Protocol.
+  Lets firmware patch a flattened-device-tree and reserve memory ranges.
+
+  Related docs:
+  https://github.com/U-Boot-EFI/EFI_DT_FIXUP_PROTOCOL
+*/
+
+#ifndef DT_FIXUP_PROTOCOL_H_
+#define DT_FIXUP_PROTOCOL_H_
+
+#include <Uefi/UefiBaseType.h>
+
+//
+// {e617d64c-fe08-46da-f4dc-bbd5870c7300}
+//
+#define DT_FIXUP_PROTOCOL_GUID \
+  { 0xe617d64c, 0xfe08, 0x46da, { 0xf4, 0xdc, 0xbb, 0xd5, 0x87, 0x0c, 0x73, 0x00 } }
+
+#define DT_FIXUP_PROTOCOL_REVISION  0x00010000
+
+typedef struct _DT_FIXUP_PROTOCOL DT_FIXUP_PROTOCOL;
+
+#define DT_FIXUP_APPLY_FIXUPS    0x00000001
+#define DT_FIXUP_RESERVE_MEMORY  0x00000002
+#define DT_FIXUP_ALL             (DT_FIXUP_APPLY_FIXUPS | DT_FIXUP_RESERVE_MEMORY)
+
+typedef
+EFI_STATUS
+(EFIAPI *DT_FIXUP)(
+  IN DT_FIXUP_PROTOCOL *This,
+  IN OUT VOID          *Fdt,
+  IN OUT UINTN         *BufferSize,
+  IN UINT32            Flags
+  );
+
+struct _DT_FIXUP_PROTOCOL {
+  UINT64      Revision;
+  DT_FIXUP    Fixup;
+};
+
+#endif // DT_FIXUP_PROTOCOL_H_


### PR DESCRIPTION
# Description

Adds the EFI_DT_FIXUP_PROTOCOL header. This protocol allows firmware to apply boot-time fixups and process memory reservations from the device tree. It is expected to be invoked by the boot manager before passing the updated device tree to the OS.

This protocol is used by:

1. Android Generic Bootloader (GBL)
2. Systemd-boot, Systemd-stub
3. Ubuntu's grub2

Original proposal:
https://github.com/U-Boot-EFI/EFI_DT_FIXUP_PROTOCOL

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Used by GBL on top of QCOM EDK2-based FW.

## Integration Instructions

N/A
