### PR TITLE
DxeCore: Adding check for underflow/overflow when iterating through resource descriptor hobs

### DIFF
--- a/MdeModulePkg/Core/Dxe/Gcd/Gcd.c
+++ b/MdeModulePkg/Core/Dxe/Gcd/Gcd.c
@@ -2430,8 +2430,14 @@ CoreInitializeMemoryServices (
     //
     Attributes  = PhitResourceHob->ResourceAttribute;
     BaseAddress = PageAlignAddress (PhitHob->EfiMemoryTop);
-    Length      = PageAlignLength (ResourceHobMemoryTop - BaseAddress);
-    FindLargestFreeRegion (&BaseAddress, &Length, (EFI_HOB_MEMORY_ALLOCATION *)GetFirstHob (EFI_HOB_TYPE_MEMORY_ALLOCATION));
+
+    if (BaseAddress > ResourceHobMemoryTop) {
+      Length = 0;
+    } else {
+      Length = PageAlignLength (ResourceHobMemoryTop - BaseAddress);
+      FindLargestFreeRegion (&BaseAddress, &Length, (EFI_HOB_MEMORY_ALLOCATION *)GetFirstHob (EFI_HOB_TYPE_MEMORY_ALLOCATION));
+    }
+
     if (Length < MinimalMemorySizeNeeded) {
       //
       // If that range is not large enough to intialize the DXE Core, then

--- a/MdeModulePkg/Core/Dxe/Gcd/Gcd.c
+++ b/MdeModulePkg/Core/Dxe/Gcd/Gcd.c
@@ -2274,6 +2274,7 @@ CoreInitializeMemoryServices (
   EFI_HOB_GUID_TYPE            *GuidHob;
   UINT32                       ReservedCodePageNumber;
   UINT64                       MinimalMemorySizeNeeded;
+  EFI_PHYSICAL_ADDRESS         ResourceHobMemoryTop;
 
   //
   // Point at the first HOB.  This must be the PHIT HOB.
@@ -2395,7 +2396,17 @@ CoreInitializeMemoryServices (
       continue;
     }
 
-    if (PhitHob->EfiFreeMemoryTop > (ResourceHob->PhysicalStart + ResourceHob->ResourceLength)) {
+    //
+    // Check for potential overflow before addition
+    //
+    if (ResourceHob->PhysicalStart > MAX_UINT64 - ResourceHob->ResourceLength) {
+      ASSERT (FALSE);
+      ResourceHobMemoryTop = MAX_UINT64;
+    } else {
+      ResourceHobMemoryTop = ResourceHob->PhysicalStart + ResourceHob->ResourceLength;
+    }
+
+    if (PhitHob->EfiFreeMemoryTop > ResourceHobMemoryTop) {
       continue;
     }
 
@@ -2419,7 +2430,7 @@ CoreInitializeMemoryServices (
     //
     Attributes  = PhitResourceHob->ResourceAttribute;
     BaseAddress = PageAlignAddress (PhitHob->EfiMemoryTop);
-    Length      = PageAlignLength (ResourceHob->PhysicalStart + ResourceHob->ResourceLength - BaseAddress);
+    Length      = PageAlignLength (ResourceHobMemoryTop - BaseAddress);
     FindLargestFreeRegion (&BaseAddress, &Length, (EFI_HOB_MEMORY_ALLOCATION *)GetFirstHob (EFI_HOB_TYPE_MEMORY_ALLOCATION));
     if (Length < MinimalMemorySizeNeeded) {
       //
@@ -2496,7 +2507,17 @@ CoreInitializeMemoryServices (
         continue;
       }
 
-      if ((ResourceHob->PhysicalStart + ResourceHob->ResourceLength) > (EFI_PHYSICAL_ADDRESS)MAX_ALLOC_ADDRESS) {
+      //
+      // Check for potential overflow before addition
+      //
+      if (ResourceHob->PhysicalStart > MAX_UINT64 - ResourceHob->ResourceLength) {
+        ASSERT (FALSE);
+        ResourceHobMemoryTop = MAX_UINT64;
+      } else {
+        ResourceHobMemoryTop = ResourceHob->PhysicalStart + ResourceHob->ResourceLength;
+      }
+
+      if (ResourceHobMemoryTop > (EFI_PHYSICAL_ADDRESS)MAX_ALLOC_ADDRESS) {
         continue;
       }
 
@@ -2511,7 +2532,7 @@ CoreInitializeMemoryServices (
       // Skip Resource Descriptor HOBs that are not large enough to initilize the DXE Core
       //
       TestedMemoryBaseAddress = PageAlignAddress (ResourceHob->PhysicalStart);
-      TestedMemoryLength      = PageAlignLength (ResourceHob->PhysicalStart + ResourceHob->ResourceLength - TestedMemoryBaseAddress);
+      TestedMemoryLength      = PageAlignLength (ResourceHobMemoryTop - TestedMemoryBaseAddress);
       FindLargestFreeRegion (&TestedMemoryBaseAddress, &TestedMemoryLength, (EFI_HOB_MEMORY_ALLOCATION *)GetFirstHob (EFI_HOB_TYPE_MEMORY_ALLOCATION));
       if (TestedMemoryLength < MinimalMemorySizeNeeded) {
         continue;


### PR DESCRIPTION
# Description

During DXE core memory service initialization, the system would check available resource descriptor hobs against the memory top from PHIT hob.

However, it is possible that a given resource descriptor hob will not be larger than the cover the memory top, causing the Length calculation to underflow. Or the hob is not properly prepared and cause the calculation to overflow.

This change adds a check for potential underflow/overflow before performing the subtraction.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

This was tested on QEMU platform and booted to Windows desktop.

## Integration Instructions

N/A
