### PR TITLE
UefiCpuPkg: BaseRiscVMmuLib: Fix the logic toggling the interrupt state

### DIFF
--- a/UefiCpuPkg/Library/BaseRiscVMmuLib/BaseRiscVMmuLib.c
+++ b/UefiCpuPkg/Library/BaseRiscVMmuLib/BaseRiscVMmuLib.c
@@ -651,6 +651,7 @@ RiscVMmuSetSatpMode  (
   UINTN                            NumberOfDescriptors;
   UINTN                            Index;
   EFI_STATUS                       Status;
+  BOOLEAN                          InterruptState;
 
   if (SatpMode > PcdGet32 (PcdCpuRiscVMmuMaxSatpMode)) {
     return EFI_DEVICE_ERROR;
@@ -720,9 +721,7 @@ RiscVMmuSetSatpMode  (
 
   FreePool ((VOID *)MemoryMap);
 
-  if (GetInterruptState ()) {
-    DisableInterrupts ();
-  }
+  InterruptState = SaveAndDisableInterrupts ();
 
   Ppn = (UINT64)TranslationTable >> RISCV_MMU_PAGE_SHIFT;
   ASSERT (!(Ppn & ~(SATP64_PPN)));
@@ -745,9 +744,7 @@ RiscVMmuSetSatpMode  (
 
   RiscVLocalTlbFlushAll ();
 
-  if (GetInterruptState ()) {
-    EnableInterrupts ();
-  }
+  SetInterruptState (InterruptState);
 
   return Status;
 }


### PR DESCRIPTION
# Description

`GetInterruptState` ultimately queries the hardware, which means that once the first check disables interrupts, they won't be enabled later.

The proper way to do this is with `SaveAndDisableInterrupts`.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Booted the QEMU virt board to the shell.

## Integration Instructions

N/A
