### PR TITLE
EmulatorPkg/Win/Host: Fix loaded DLL page protections

### DIFF
--- a/EmulatorPkg/Win/Host/WinHost.c
+++ b/EmulatorPkg/Win/Host/WinHost.c
@@ -1217,14 +1217,14 @@ PeCoffLoaderRelocateImageExtraAction (
         }
 
         //
-        // Loop over every DWORD in memory and compute the union of the memory
+        // Loop over every byte in memory and compute the union of the memory
         // access bits.
         //
         End        = (UINTN)Library + (UINTN)PeCoffImageContext.ImageSize;
         RegionBase = (UINTN)Library;
         RegionSize = 0;
         Flags      = 0;
-        for (Base = (UINTN)Library + sizeof (UINT32); Base < End; Base += sizeof (UINT32)) {
+        for (Base = (UINTN)Library; Base < End; Base++) {
           for (Index = 0; Index < NumberOfSections; Index++) {
             if ((SectionData[Index].Base <= Base) &&
                 ((SectionData[Index].Base + SectionData[Index].Size) > Base))
@@ -1234,10 +1234,10 @@ PeCoffLoaderRelocateImageExtraAction (
           }
 
           //
-          // When a new page is reached configure the memory access for the
-          // previous page.
+          // When end of current page is reached configure the memory access for
+          // the current page.
           //
-          if (Base % SIZE_4KB == 0) {
+          if (IS_ALIGNED (Base + 1, SIZE_4KB)) {
             RegionSize += SIZE_4KB;
             if ((Flags & EFI_IMAGE_SCN_MEM_WRITE) == EFI_IMAGE_SCN_MEM_WRITE) {
               if ((Flags & EFI_IMAGE_SCN_MEM_EXECUTE) == EFI_IMAGE_SCN_MEM_EXECUTE) {
@@ -1263,7 +1263,7 @@ PeCoffLoaderRelocateImageExtraAction (
             }
 
             Flags      = 0;
-            RegionBase = Base;
+            RegionBase = Base + 1;
             RegionSize = 0;
           }
         }


### PR DESCRIPTION
# Description

PR #4874 improved the source level debug of the EmulatorPkg.

The current algorithm evaluates page protection in sections of a PE/COFF image at DWORD granularity and it skips the evaluation of the first DWORD of the PE/COFF image.

If a PE/COFF section has a VirtualSize that is ends in first 4 bytes of a 4KB page, then the PE/COFF section protection attributes for that section are not applied to that page due to the DWORD stride.

For example, a .text section with a VirtualSize of 0x1001, 0x1002, 0x1003, or 0x1004 followed by non .text section will not apply the PAGE_EXECUTE_READ attribute to the second page of the .text section and execution of code at the end of that .text section generates an access violation exception.

The fix is to change the stride for evaluating page protection attributes from DWORD to BYTE.

The loop is also updated to include evaluation of the first DWORD of the PE/COFF image.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

VS2019 NOOPT build would not boot due to an exception executing instruction at end of .text section for a function in PeiCore.efi that ended in the first 4 bytes of a 4KB page.  PeiCore.efi had the following .text section with a virtual size of 0x19004 that ended in the first 4 bytes of a 4KB page.

```
SECTION HEADER #1
   .text name
   19004 virtual size
    1000 virtual address (0000000000011000 to 000000000002A003)
   1A000 size of raw data
    1000 file pointer to raw data (00001000 to 0001AFFF)
       0 file pointer to relocation table
       0 file pointer to line numbers
       0 number of relocations
       0 number of line numbers
68000020 flags
         Code
         Not Paged
         Execute Read
```

After applying this change, the VS2019 NOOPT build booted as expected. This change only modified WinHost.exe with no changes to the PeiCore.efi PE/COFF image.

## Integration Instructions

N/A
