### PR TITLE
MdePkg: Add ArmCompatSemiHostingLib

### DIFF
--- a/MdePkg/Include/Library/ArmCompatSemiHostingLib.h
+++ b/MdePkg/Include/Library/ArmCompatSemiHostingLib.h
@@ -1,0 +1,249 @@
+/** @file
+  Arm Compatible Semi Hosting library Header file
+
+  Copyright (c) 2008 - 2009, Apple Inc. All rights reserved.<BR>
+  Portions copyright (c) 2011, 2012, ARM Ltd. All rights reserved.<BR>
+  Copyright (c) 2025, Ventana Micro Systems Inc. All Rights Reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef ARM_COMPAT_SEMIHOSTING_LIB_H_
+#define ARM_COMPAT_SEMIHOSTING_LIB_H_
+
+/*
+ *  Please refer to https://github.com/ARM-software/abi-aa/blob/main/semihosting/semihosting.rst
+ *  for more information about the semihosting interface.
+ */
+
+#define SEMIHOSTING_FILE_MODE_READ    (0 << 2)
+#define SEMIHOSTING_FILE_MODE_WRITE   (1 << 2)
+#define SEMIHOSTING_FILE_MODE_APPEND  (2 << 2)
+#define SEMIHOSTING_FILE_MODE_UPDATE  (1 << 1)
+#define SEMIHOSTING_FILE_MODE_BINARY  (1 << 0)
+#define SEMIHOSTING_FILE_MODE_ASCII   (0 << 0)
+
+/**
+  Check if semihosting connection is supported.
+
+  This function determines whether a semihosting connection is currently
+  available and operational.
+
+  @retval TRUE   Semihosting connection is supported and available.
+  @retval FALSE  Semihosting is not supported or connection not established.
+**/
+BOOLEAN
+EFIAPI
+SemiHostingConnectionSupported (
+  VOID
+  );
+
+/**
+  Open a file on the host system using semihosting interface.
+
+  @param[in]  FileName   Null-terminated ASCII string of the file name.
+  @param[in]  Mode       Access mode (read, write, append, etc.).
+  @param[out] FileHandle Returned file handle identifier if successful.
+
+  @retval  RETURN_SUCCESS            File opened successfully.
+  @retval  RETURN_INVALID_PARAMETER  Invalid parameter passed.
+  @retval  RETURN_NOT_FOUND          File could not be opened.
+**/
+RETURN_STATUS
+EFIAPI
+SemiHostingFileOpen (
+  IN  CHAR8   *FileName,
+  IN  UINT32  Mode,
+  OUT UINTN   *FileHandle
+  );
+
+/**
+  Move the file position to a specified offset.
+
+  @param[in]  FileHandle  Handle of the open file.
+  @param[in]  Offset      Offset (in bytes) to seek to, relative to start of file.
+
+  @retval  RETURN_SUCCESS            File pointer repositioned successfully.
+  @retval  RETURN_ABORTED            Seek operation failed.
+**/
+RETURN_STATUS
+EFIAPI
+SemiHostingFileSeek (
+  IN UINTN  FileHandle,
+  IN UINTN  Offset
+  );
+
+/**
+  Read data from a file on the host system via semihosting.
+
+  @param[in]      FileHandle  Handle of the open file.
+  @param[in, out] Length      On input, size of Buffer in bytes.
+                              On output, number of bytes actually read.
+  @param[out]     Buffer      Buffer to store the read data.
+
+  @retval  RETURN_SUCCESS            Data read successfully.
+  @retval  RETURN_INVALID_PARAMETER  Invalid buffer or handle.
+  @retval  RETURN_ABORTED            Read failed.
+**/
+RETURN_STATUS
+EFIAPI
+SemiHostingFileRead (
+  IN     UINTN  FileHandle,
+  IN OUT UINTN  *Length,
+  OUT    VOID   *Buffer
+  );
+
+/**
+  Write data to a file on the host system via semihosting.
+
+  @param[in]      FileHandle  Handle of the open file.
+  @param[in, out] Length      On input, number of bytes to write.
+                              On output, number of bytes actually written.
+  @param[in]      Buffer      Pointer to data buffer to write.
+
+  @retval  RETURN_SUCCESS            Data written successfully.
+  @retval  RETURN_INVALID_PARAMETER  Invalid handle or buffer.
+  @retval  RETURN_ABORTED            Write operation failed.
+**/
+RETURN_STATUS
+EFIAPI
+SemiHostingFileWrite (
+  IN     UINTN  FileHandle,
+  IN OUT UINTN  *Length,
+  IN     VOID   *Buffer
+  );
+
+/**
+  Close an open file on the host system via semihosting.
+
+  @param[in]  FileHandle  Handle of the file to close.
+
+  @retval  RETURN_SUCCESS            File closed successfully.
+  @retval  RETURN_ABORTED            Close operation failed.
+**/
+RETURN_STATUS
+EFIAPI
+SemiHostingFileClose (
+  IN UINTN  FileHandle
+  );
+
+/**
+  Get the total length of a file.
+
+  @param[in]   FileHandle  Handle of the open file.
+  @param[out]  Length      Pointer to store the file length in bytes.
+
+  @retval  RETURN_SUCCESS            File length retrieved successfully.
+  @retval  RETURN_INVALID_PARAMETER  Invalid length pointer.
+  @retval  RETURN_ABORTED            Operation failed.
+**/
+RETURN_STATUS
+EFIAPI
+SemiHostingFileLength (
+  IN  UINTN  FileHandle,
+  OUT UINTN  *Length
+  );
+
+/**
+  Get a temporary name for a file from the host running the debug agent.
+
+  @param[out]  Buffer      Pointer to the buffer where the temporary name has to
+                           be stored
+  @param[in]   Identifier  File name identifier (integer in the range 0 to 255)
+  @param[in]   Length      Length of the buffer to store the temporary name
+
+  @retval  RETURN_SUCCESS            Temporary name returned
+  @retval  RETURN_INVALID_PARAMETER  Invalid buffer address
+  @retval  RETURN_ABORTED            Temporary name not returned
+
+**/
+RETURN_STATUS
+EFIAPI
+SemiHostingFileTmpName (
+  OUT  VOID   *Buffer,
+  IN   UINT8  Identifier,
+  IN   UINTN  Length
+  );
+
+/**
+  Delete a specified file on the host via semihosting.
+
+  @param[in]  FileName  Null-terminated ASCII string of the file name to remove.
+
+  @retval  RETURN_SUCCESS            File removed successfully.
+  @retval  RETURN_INVALID_PARAMETER  Invalid file name.
+  @retval  RETURN_ABORTED            File could not be removed.
+**/
+RETURN_STATUS
+EFIAPI
+SemiHostingFileRemove (
+  IN CHAR8  *FileName
+  );
+
+/**
+  Rename a specified file.
+
+  @param[in]  FileName     Name of the file to rename.
+  @param[in]  NewFileName  The new name of the file.
+
+  @retval  RETURN_SUCCESS            File Renamed
+  @retval  RETURN_INVALID_PARAMETER  Either the current or the new name is not specified
+  @retval  RETURN_ABORTED            Rename failed
+
+**/
+RETURN_STATUS
+EFIAPI
+SemiHostingFileRename (
+  IN  CHAR8  *FileName,
+  IN  CHAR8  *NewFileName
+  );
+
+/**
+  Read a single character from the host input via semihosting.
+
+  @retval  The ASCII value of the character read.
+**/
+CHAR8
+EFIAPI
+SemiHostingReadCharacter (
+  VOID
+  );
+
+/**
+  Write a single character to the host output via semihosting.
+
+  @param[in]  Character  ASCII character to write.
+
+**/
+VOID
+EFIAPI
+SemiHostingWriteCharacter (
+  IN CHAR8  Character
+  );
+
+/**
+  Write a null-terminated string to the host output via semihosting.
+
+  @param[in]  String  Pointer to a null-terminated ASCII string.
+**/
+VOID
+EFIAPI
+SemiHostingWriteString (
+  IN CHAR8  *String
+  );
+
+/**
+  Execute a command line on the host system.
+
+  @param[in]  CommandLine  Null-terminated ASCII string containing the command to execute.
+
+  @retval  The return code from the host system for the executed command.
+**/
+UINT32
+EFIAPI
+SemiHostingSystem (
+  IN CHAR8  *CommandLine
+  );
+
+#endif // ARM_COMPAT_SEMIHOSTING_LIB_H_

--- a/MdePkg/Library/ArmCompatSemiHostingLib/ArmCompatSemiHostingLib.c
+++ b/MdePkg/Library/ArmCompatSemiHostingLib/ArmCompatSemiHostingLib.c
@@ -1,0 +1,431 @@
+/** @file
+
+  Copyright (c) 2008 - 2009, Apple Inc. All rights reserved.<BR>
+  Copyright (c) 2013 - 2021, Arm Limited. All rights reserved.<BR>
+  Copyright (c) 2025, Ventana Micro Systems Inc. All Rights Reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+#include <Base.h>
+
+#include <Library/ArmCompatSemiHostingLib.h>
+#include <Library/BaseLib.h>
+#include "SemiHostingPrivate.h"
+
+STATIC BOOLEAN  mSemiHostingChecked   = FALSE;
+STATIC BOOLEAN  mSemiHostingSupported = TRUE;
+
+/**
+  Check if semihosting connection is supported.
+
+  This function determines whether a semihosting connection is currently
+  available and operational.
+
+  @retval TRUE   Semihosting connection is supported and available.
+  @retval FALSE  Semihosting is not supported or connection not established.
+**/
+BOOLEAN
+EFIAPI
+SemiHostingConnectionSupported (
+  VOID
+  )
+{
+  BOOLEAN  SemiHostingSupported;
+
+  if (!mSemiHostingChecked) {
+    SemiHostingSupported = (SemiHostingConnectionEnabled () != 0);
+    mSemiHostingChecked  = TRUE;
+  }
+
+  mSemiHostingSupported = SemiHostingSupported;
+  return SemiHostingSupported;
+}
+
+/**
+  Open a file on the host system using semihosting interface.
+
+  @param[in]  FileName   Null-terminated ASCII string of the file name.
+  @param[in]  Mode       Access mode (read, write, append, etc.).
+  @param[out] FileHandle Returned file handle identifier if successful.
+
+  @retval  RETURN_SUCCESS            File opened successfully.
+  @retval  RETURN_INVALID_PARAMETER  Invalid parameter passed.
+  @retval  RETURN_NOT_FOUND          File could not be opened.
+**/
+RETURN_STATUS
+EFIAPI
+SemiHostingFileOpen (
+  IN  CHAR8   *FileName,
+  IN  UINT32  Mode,
+  OUT UINTN   *FileHandle
+  )
+{
+  SEMIHOSTING_FILE_OPEN_BLOCK  OpenBlock;
+  INT32                        Result;
+
+  if (FileHandle == NULL) {
+    return RETURN_INVALID_PARAMETER;
+  }
+
+  // Remove any leading separator (e.g.: '\'). EFI Shell adds one.
+  if (*FileName == '\\') {
+    FileName++;
+  }
+
+  OpenBlock.FileName   = FileName;
+  OpenBlock.Mode       = Mode;
+  OpenBlock.NameLength = AsciiStrLen (FileName);
+
+  Result = SEMIHOSTING_SYS_OPEN (&OpenBlock);
+
+  if (Result == -1) {
+    return RETURN_NOT_FOUND;
+  } else {
+    *FileHandle = Result;
+    return RETURN_SUCCESS;
+  }
+}
+
+/**
+  Move the file position to a specified offset.
+
+  @param[in]  FileHandle  Handle of the open file.
+  @param[in]  Offset      Offset (in bytes) to seek to, relative to start of file.
+
+  @retval  RETURN_SUCCESS            File pointer repositioned successfully.
+  @retval  RETURN_ABORTED            Seek operation failed.
+**/
+RETURN_STATUS
+EFIAPI
+SemiHostingFileSeek (
+  IN UINTN  FileHandle,
+  IN UINTN  Offset
+  )
+{
+  SEMIHOSTING_FILE_SEEK_BLOCK  SeekBlock;
+  INT32                        Result;
+
+  SeekBlock.Handle   = FileHandle;
+  SeekBlock.Location = Offset;
+
+  Result = SEMIHOSTING_SYS_SEEK (&SeekBlock);
+
+  if (Result < 0) {
+    return RETURN_ABORTED;
+  } else {
+    return RETURN_SUCCESS;
+  }
+}
+
+/**
+  Read data from a file on the host system via semihosting.
+
+  @param[in]      FileHandle  Handle of the open file.
+  @param[in, out] Length      On input, size of Buffer in bytes.
+                              On output, number of bytes actually read.
+  @param[out]     Buffer      Buffer to store the read data.
+
+  @retval  RETURN_SUCCESS            Data read successfully.
+  @retval  RETURN_INVALID_PARAMETER  Invalid buffer or handle.
+  @retval  RETURN_ABORTED            Read failed.
+**/
+RETURN_STATUS
+EFIAPI
+SemiHostingFileRead (
+  IN     UINTN  FileHandle,
+  IN OUT UINTN  *Length,
+  OUT    VOID   *Buffer
+  )
+{
+  SEMIHOSTING_FILE_READ_WRITE_BLOCK  ReadBlock;
+  UINT32                             Result;
+
+  if ((Length == NULL) || (Buffer == NULL)) {
+    return RETURN_INVALID_PARAMETER;
+  }
+
+  ReadBlock.Handle = FileHandle;
+  ReadBlock.Buffer = Buffer;
+  ReadBlock.Length = *Length;
+
+  Result = SEMIHOSTING_SYS_READ (&ReadBlock);
+
+  if ((*Length != 0) && (Result == *Length)) {
+    return RETURN_ABORTED;
+  } else {
+    *Length -= Result;
+    return RETURN_SUCCESS;
+  }
+}
+
+/**
+  Write data to a file on the host system via semihosting.
+
+  @param[in]      FileHandle  Handle of the open file.
+  @param[in, out] Length      On input, number of bytes to write.
+                              On output, number of bytes actually written.
+  @param[in]      Buffer      Pointer to data buffer to write.
+
+  @retval  RETURN_SUCCESS            Data written successfully.
+  @retval  RETURN_INVALID_PARAMETER  Invalid handle or buffer.
+  @retval  RETURN_ABORTED            Write operation failed.
+**/
+RETURN_STATUS
+EFIAPI
+SemiHostingFileWrite (
+  IN     UINTN  FileHandle,
+  IN OUT UINTN  *Length,
+  IN     VOID   *Buffer
+  )
+{
+  SEMIHOSTING_FILE_READ_WRITE_BLOCK  WriteBlock;
+
+  if ((Length == NULL) || (Buffer == NULL)) {
+    return RETURN_INVALID_PARAMETER;
+  }
+
+  WriteBlock.Handle = FileHandle;
+  WriteBlock.Buffer = Buffer;
+  WriteBlock.Length = *Length;
+
+  *Length = SEMIHOSTING_SYS_WRITE (&WriteBlock);
+
+  if (*Length != 0) {
+    return RETURN_ABORTED;
+  } else {
+    return RETURN_SUCCESS;
+  }
+}
+
+/**
+  Close an open file on the host system via semihosting.
+
+  @param[in]  FileHandle  Handle of the file to close.
+
+  @retval  RETURN_SUCCESS            File closed successfully.
+  @retval  RETURN_ABORTED            Close operation failed.
+**/
+RETURN_STATUS
+EFIAPI
+SemiHostingFileClose (
+  IN UINTN  FileHandle
+  )
+{
+  if (SEMIHOSTING_SYS_CLOSE (&FileHandle) == -1) {
+    return RETURN_ABORTED;
+  } else {
+    return RETURN_SUCCESS;
+  }
+}
+
+/**
+  Get the total length of a file.
+
+  @param[in]   FileHandle  Handle of the open file.
+  @param[out]  Length      Pointer to store the file length in bytes.
+
+  @retval  RETURN_SUCCESS            File length retrieved successfully.
+  @retval  RETURN_INVALID_PARAMETER  Invalid length pointer.
+  @retval  RETURN_ABORTED            Operation failed.
+**/
+RETURN_STATUS
+EFIAPI
+SemiHostingFileLength (
+  IN  UINTN  FileHandle,
+  OUT UINTN  *Length
+  )
+{
+  INT32  Result;
+
+  if (Length == NULL) {
+    return RETURN_INVALID_PARAMETER;
+  }
+
+  Result = SEMIHOSTING_SYS_FLEN (&FileHandle);
+
+  if (Result == -1) {
+    return RETURN_ABORTED;
+  } else {
+    *Length = Result;
+    return RETURN_SUCCESS;
+  }
+}
+
+/**
+  Get a temporary name for a file from the host running the debug agent.
+
+  @param[out]  Buffer      Pointer to the buffer where the temporary name has to
+                           be stored
+  @param[in]   Identifier  File name identifier (integer in the range 0 to 255)
+  @param[in]   Length      Length of the buffer to store the temporary name
+
+  @retval  RETURN_SUCCESS            Temporary name returned
+  @retval  RETURN_INVALID_PARAMETER  Invalid buffer address
+  @retval  RETURN_ABORTED            Temporary name not returned
+
+**/
+RETURN_STATUS
+EFIAPI
+SemiHostingFileTmpName (
+  OUT  VOID   *Buffer,
+  IN   UINT8  Identifier,
+  IN   UINTN  Length
+  )
+{
+  SEMIHOSTING_FILE_TMPNAME_BLOCK  TmpNameBlock;
+  INT32                           Result;
+
+  if (Buffer == NULL) {
+    return RETURN_INVALID_PARAMETER;
+  }
+
+  TmpNameBlock.Buffer     = Buffer;
+  TmpNameBlock.Identifier = Identifier;
+  TmpNameBlock.Length     = Length;
+
+  Result = SEMIHOSTING_SYS_TMPNAME (&TmpNameBlock);
+
+  if (Result != 0) {
+    return RETURN_ABORTED;
+  } else {
+    return RETURN_SUCCESS;
+  }
+}
+
+/**
+  Delete a specified file on the host via semihosting.
+
+  @param[in]  FileName  Null-terminated ASCII string of the file name to remove.
+
+  @retval  RETURN_SUCCESS            File removed successfully.
+  @retval  RETURN_INVALID_PARAMETER  Invalid file name.
+  @retval  RETURN_ABORTED            File could not be removed.
+**/
+RETURN_STATUS
+EFIAPI
+SemiHostingFileRemove (
+  IN CHAR8  *FileName
+  )
+{
+  SEMIHOSTING_FILE_REMOVE_BLOCK  RemoveBlock;
+  UINT32                         Result;
+
+  if (FileName == NULL) {
+    return RETURN_INVALID_PARAMETER;
+  }
+
+  // Remove any leading separator (e.g.: '\'). EFI Shell adds one.
+  if (*FileName == '\\') {
+    FileName++;
+  }
+
+  RemoveBlock.FileName   = FileName;
+  RemoveBlock.NameLength = AsciiStrLen (FileName);
+
+  Result = SEMIHOSTING_SYS_REMOVE (&RemoveBlock);
+
+  if (Result == 0) {
+    return RETURN_SUCCESS;
+  } else {
+    return RETURN_ABORTED;
+  }
+}
+
+/**
+  Rename a specified file.
+
+  @param[in]  FileName     Name of the file to rename.
+  @param[in]  NewFileName  The new name of the file.
+
+  @retval  RETURN_SUCCESS            File Renamed
+  @retval  RETURN_INVALID_PARAMETER  Either the current or the new name is not specified
+  @retval  RETURN_ABORTED            Rename failed
+
+**/
+RETURN_STATUS
+EFIAPI
+SemiHostingFileRename (
+  IN  CHAR8  *FileName,
+  IN  CHAR8  *NewFileName
+  )
+{
+  SEMIHOSTING_FILE_RENAME_BLOCK  RenameBlock;
+  INT32                          Result;
+
+  if ((FileName == NULL) || (NewFileName == NULL)) {
+    return RETURN_INVALID_PARAMETER;
+  }
+
+  RenameBlock.FileName          = FileName;
+  RenameBlock.FileNameLength    = AsciiStrLen (FileName);
+  RenameBlock.NewFileName       = NewFileName;
+  RenameBlock.NewFileNameLength = AsciiStrLen (NewFileName);
+
+  Result = SEMIHOSTING_SYS_RENAME (&RenameBlock);
+
+  if (Result != 0) {
+    return RETURN_ABORTED;
+  } else {
+    return RETURN_SUCCESS;
+  }
+}
+
+/**
+  Read a single character from the host input via semihosting.
+
+  @retval  The ASCII value of the character read.
+**/
+CHAR8
+EFIAPI
+SemiHostingReadCharacter (
+  VOID
+  )
+{
+  return SEMIHOSTING_SYS_READC ();
+}
+
+/**
+  Write a single character to the host output via semihosting.
+
+  @param[in]  Character  ASCII character to write.
+
+**/
+VOID
+EFIAPI
+SemiHostingWriteCharacter (
+  IN CHAR8  Character
+  )
+{
+  SEMIHOSTING_SYS_WRITEC (&Character);
+}
+
+/**
+  Write a null-terminated string to the host output via semihosting.
+
+  @param[in]  String  Pointer to a null-terminated ASCII string.
+**/
+VOID
+EFIAPI
+SemiHostingWriteString (
+  IN CHAR8  *String
+  )
+{
+  SEMIHOSTING_SYS_WRITE0 (String);
+}
+
+/**
+  Execute a command line on the host system.
+
+  @param[in]  CommandLine  Null-terminated ASCII string containing the command to execute.
+
+  @retval  The return code from the host system for the executed command.
+**/
+UINT32
+EFIAPI
+SemiHostingSystem (
+  IN CHAR8  *CommandLine
+  )
+{
+  return SEMIHOSTING_SYS_SYSTEM (CommandLine);
+}

--- a/MdePkg/Library/ArmCompatSemiHostingLib/ArmCompatSemiHostingLib.inf
+++ b/MdePkg/Library/ArmCompatSemiHostingLib/ArmCompatSemiHostingLib.inf
@@ -1,0 +1,25 @@
+## @file
+#
+#  Copyright (c) 2025, Ventana Micro Systems Inc. All Rights Reserved.<BR>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION         = 1.30
+  BASE_NAME           = ArmCompatSemiHostingLib
+  FILE_GUID           = 357168a8-ec03-4e74-bb04-d3f1f092bb44
+  MODULE_TYPE         = BASE
+  VERSION_STRING      = 1.0
+  LIBRARY_CLASS       = ArmCompatSemiHostingLib
+
+[Sources.common]
+  ArmCompatSemiHostingLib.c
+  SemiHostingPrivate.h
+
+[Sources.RISCV64]
+  RiscV/SemiHostingCall.S
+
+[Packages]
+  MdePkg/MdePkg.dec

--- a/MdePkg/Library/ArmCompatSemiHostingLib/RiscV/SemiHostingCall.S
+++ b/MdePkg/Library/ArmCompatSemiHostingLib/RiscV/SemiHostingCall.S
@@ -1,0 +1,67 @@
+/** @file
+*
+*  Copyright (c) 2025, Ventana Micro Systems Inc. All Rights Reserved.<BR>
+*
+*  SPDX-License-Identifier: BSD-2-Clause-Patent
+*
+**/
+
+#include <Base.h>
+#include <Register/RiscV64/RiscVImpl.h>
+
+.text
+.align 4
+
+//
+// Semi hosting calling
+//
+// @param a0: Operation number.
+// @param a1: System block address.
+//
+// @retval a0 : return value.
+ASM_FUNC (SemiHostingCall)
+  .option push
+  .option norvc
+
+  slli zero, zero, 0x1f
+  ebreak
+  srai zero, zero, 7
+
+  .option pop
+ret
+
+//
+// Check if semi hosting connection enabled
+//
+// @retval a0 : 0 if not enabled, otherwise enabled.
+ASM_FUNC (
+  SemiHostingConnectionEnabled
+  )
+  .option push
+  .option norvc
+
+j _TestSemihostStrap
+
+_SemiHostingStrap:
+  csrr  t1, sepc
+  addi t1, t1, 4
+  csrw sepc, t1
+  // strap happens when semi hosting not supported
+  add t2, zero, zero
+  sret
+
+_TestSemihostStrap:
+  // use t2 for return value
+  li  t2, 1
+  lla t0, _SemiHostingStrap
+  csrrw t0, stvec, t0
+  // trying semi hosting call: a0=SYS_ERRNO(0x13), a1=0
+  li a0, 0x13
+  li a1, 0
+  slli zero, zero, 0x1f
+  ebreak
+  srai zero, zero, 7
+  csrw stvec, t0
+  addi a0, t2, 0
+  .option pop
+  ret

--- a/MdePkg/Library/ArmCompatSemiHostingLib/SemiHostingPrivate.h
+++ b/MdePkg/Library/ArmCompatSemiHostingLib/SemiHostingPrivate.h
@@ -1,0 +1,76 @@
+/** @file
+
+  Copyright (c) 2008 - 2009, Apple Inc. All rights reserved.<BR>
+  Copyright (c) 2013 - 2021, Arm Limited. All rights reserved.<BR>
+  Copyright (c) 2025, Ventana Micro Systems Inc. All Rights Reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef SEMIHOSTING_PRIVATE_H_
+#define SEMIHOSTING_PRIVATE_H_
+
+typedef struct {
+  CHAR8    *FileName;
+  UINTN    Mode;
+  UINTN    NameLength;
+} SEMIHOSTING_FILE_OPEN_BLOCK;
+
+typedef struct {
+  UINTN    Handle;
+  VOID     *Buffer;
+  UINTN    Length;
+} SEMIHOSTING_FILE_READ_WRITE_BLOCK;
+
+typedef struct {
+  UINTN    Handle;
+  UINTN    Location;
+} SEMIHOSTING_FILE_SEEK_BLOCK;
+
+typedef struct {
+  VOID     *Buffer;
+  UINTN    Identifier;
+  UINTN    Length;
+} SEMIHOSTING_FILE_TMPNAME_BLOCK;
+
+typedef struct {
+  CHAR8    *FileName;
+  UINTN    NameLength;
+} SEMIHOSTING_FILE_REMOVE_BLOCK;
+
+typedef struct {
+  CHAR8    *FileName;
+  UINTN    FileNameLength;
+  CHAR8    *NewFileName;
+  UINTN    NewFileNameLength;
+} SEMIHOSTING_FILE_RENAME_BLOCK;
+
+UINT32
+EFIAPI
+SemiHostingCall (
+  IN UINT32  Operation,
+  IN UINTN   SystemBlockAddress
+  );
+
+UINT32
+EFIAPI
+SemiHostingConnectionEnabled (
+  VOID
+  );
+
+#define SEMIHOSTING_SYS_OPEN(OpenBlock)        SemiHostingCall(0x01, (UINTN)(OpenBlock))
+#define SEMIHOSTING_SYS_CLOSE(Handle)          SemiHostingCall(0x02, (UINTN)(Handle))
+#define SEMIHOSTING_SYS_WRITE0(String)         SemiHostingCall(0x04, (UINTN)(String))
+#define SEMIHOSTING_SYS_WRITEC(Character)      SemiHostingCall(0x03, (UINTN)(Character))
+#define SEMIHOSTING_SYS_WRITE(WriteBlock)      SemiHostingCall(0x05, (UINTN)(WriteBlock))
+#define SEMIHOSTING_SYS_READ(ReadBlock)        SemiHostingCall(0x06, (UINTN)(ReadBlock))
+#define SEMIHOSTING_SYS_READC()                SemiHostingCall(0x07, (UINTN)(0))
+#define SEMIHOSTING_SYS_SEEK(SeekBlock)        SemiHostingCall(0x0A, (UINTN)(SeekBlock))
+#define SEMIHOSTING_SYS_FLEN(Handle)           SemiHostingCall(0x0C, (UINTN)(Handle))
+#define SEMIHOSTING_SYS_TMPNAME(TmpNameBlock)  SemiHostingCall(0x0D, (UINTN)(TmpNameBlock))
+#define SEMIHOSTING_SYS_REMOVE(RemoveBlock)    SemiHostingCall(0x0E, (UINTN)(RemoveBlock))
+#define SEMIHOSTING_SYS_RENAME(RenameBlock)    SemiHostingCall(0x0F, (UINTN)(RenameBlock))
+#define SEMIHOSTING_SYS_SYSTEM(SystemBlock)    SemiHostingCall(0x12, (UINTN)(SystemBlock))
+
+#endif // SEMIHOSTING_PRIVATE_H_

--- a/MdePkg/MdePkg.dec
+++ b/MdePkg/MdePkg.dec
@@ -309,6 +309,10 @@
   #
   StackCheckLib|Include/Library/StackCheckLib.h
 
+  ##  @libraryclass  Provides APIs for Arm Compatible Semi Hosting interface
+  #
+  ArmCompatSemiHostingLib|Include/Library/ArmCompatSemiHostingLib.h
+
 [LibraryClasses.IA32, LibraryClasses.X64, LibraryClasses.AARCH64]
   ##  @libraryclass  Provides services to generate random number.
   #

--- a/MdePkg/MdePkg.dsc
+++ b/MdePkg/MdePkg.dsc
@@ -213,6 +213,7 @@
   MdePkg/Library/BaseSerialPortLibRiscVSbiLib/BaseSerialPortLibRiscVSbiLib.inf
   MdePkg/Library/BaseSerialPortLibRiscVSbiLib/BaseSerialPortLibRiscVSbiLibRam.inf
   MdePkg/Library/PeiServicesTablePointerLibRiscV/PeiServicesTablePointerLib.inf
+  MdePkg/Library/ArmCompatSemiHostingLib/ArmCompatSemiHostingLib.inf
 
 [Components.LOONGARCH64]
   MdePkg/Library/PeiServicesTablePointerLibKs0/PeiServicesTablePointerLibKs0.inf


### PR DESCRIPTION
Introduces a semi-hosting library adhering to the ARM protocol, enabling communication with a host computer via a debugger.

A complete documentation of the protocol is available at the https://github.com/ARM-software/abi-aa/blob/main/semihosting/semihosting.rst

RISC-V binary interface documentation is available at the https://github.com/riscv-non-isa/riscv-semihosting/blob/main/riscv-semihosting.adoc

This library incorporates code from ArmPkg/Library/SemihostLib with some cleanup and clarification.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

Tested on RISC-V with Console and Simple File System on host environment.

## Integration Instructions

