### PR TITLE
CryptoPkg/OpensslLib: Add NDEBUG flag for GCC Release builds

### DIFF
--- a/CryptoPkg/Library/OpensslLib/OpensslLib.inf
+++ b/CryptoPkg/Library/OpensslLib/OpensslLib.inf
@@ -772,6 +772,7 @@
   #                   types appropriate to the format string specified.
   #   -Werror=unused-but-set-variable: Warn whenever a local variable is assigned to, but otherwise unused (aside from its declaration).
   #
+  GCC:RELEASE_*_*_CC_FLAGS = -DNDEBUG
   GCC:*_*_IA32_CC_FLAGS    = -U_WIN32 -U_WIN64 $(OPENSSL_FLAGS) $(OPENSSL_FLAGS_NOASM) -Wno-error=maybe-uninitialized -Wno-error=unused-but-set-variable
   GCC:*_*_X64_CC_FLAGS     = -U_WIN32 -U_WIN64 $(OPENSSL_FLAGS) $(OPENSSL_FLAGS_NOASM) -Wno-error=maybe-uninitialized -Wno-error=format -Wno-format -Wno-error=unused-but-set-variable -DNO_MSABI_VA_FUNCS
   GCC:*_*_AARCH64_CC_FLAGS = $(OPENSSL_FLAGS) -Wno-error=maybe-uninitialized -Wno-format -Wno-error=unused-but-set-variable -Wno-error=format

--- a/CryptoPkg/Library/OpensslLib/OpensslLibCrypto.inf
+++ b/CryptoPkg/Library/OpensslLib/OpensslLibCrypto.inf
@@ -722,6 +722,7 @@
   #                   types appropriate to the format string specified.
   #   -Werror=unused-but-set-variable: Warn whenever a local variable is assigned to, but otherwise unused (aside from its declaration).
   #
+  GCC:RELEASE_*_*_CC_FLAGS = -DNDEBUG
   GCC:*_*_IA32_CC_FLAGS    = -U_WIN32 -U_WIN64 $(OPENSSL_FLAGS) $(OPENSSL_FLAGS_NOASM) -Wno-error=maybe-uninitialized -Wno-error=unused-but-set-variable
   GCC:*_*_X64_CC_FLAGS     = -U_WIN32 -U_WIN64 $(OPENSSL_FLAGS) $(OPENSSL_FLAGS_NOASM) -Wno-error=maybe-uninitialized -Wno-error=format -Wno-format -Wno-error=unused-but-set-variable -DNO_MSABI_VA_FUNCS
   GCC:*_*_AARCH64_CC_FLAGS = $(OPENSSL_FLAGS) -Wno-error=maybe-uninitialized -Wno-format -Wno-error=unused-but-set-variable -Wno-error=format


### PR DESCRIPTION
The OpenSSL build system enables debug information by default unless NDEBUG is defined. This results in debug symbols being included in GCC Release builds.

Add the NDEBUG flag to the GCC Release build flags to properly disable debug information and align with standard Release build practices.

# Description

This change adds the NDEBUG preprocessor flag to the GCC Release build configuration for OpenSSL libraries in CryptoPkg. Without this flag, OpenSSL's build system includes debug symbols in Release builds, which is inconsistent with standard Release build practices.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

Built UEFI firmware with GCC in Release mode and verified that debug symbols are no longer present in the OpenSSL library binaries.

## Integration Instructions

N/A - This is a build configuration change that takes effect automatically during Release builds.
