### PR TITLE
BaseTools/GenFw: Add --no-debug to skip debug information generation and enable for Release builds

### DIFF
--- a/BaseTools/Conf/tools_def.template
+++ b/BaseTools/Conf/tools_def.template
@@ -2045,6 +2045,7 @@ RELEASE_XCODE5_X64_CC_FLAGS   = -target x86_64-pc-win32-macho -c    -Os       -W
 ##################
 *_*_*_GENFW_PATH                   = GenFw
 *_*_*_GENFW_FLAGS                  =
+RELEASE_*_*_GENFW_FLAGS            = --no-debug
 
 ##################
 # Asl Compiler definitions

--- a/BaseTools/Source/C/GenFw/Elf32Convert.c
+++ b/BaseTools/Source/C/GenFw/Elf32Convert.c
@@ -426,7 +426,9 @@ ScanSections32 (
     assert (FALSE);
   }
 
-  mDebugOffset = DebugRvaAlign(mCoffOffset);
+  if (!mSkipDebugInfo) {
+    mDebugOffset = DebugRvaAlign(mCoffOffset);
+  }
   mCoffOffset = CoffAlign(mCoffOffset);
 
   if (SectionCount > 1 && mOutImageType == FW_EFI_IMAGE) {
@@ -470,18 +472,20 @@ ScanSections32 (
     Warning (NULL, 0, 0, NULL, "Multiple sections in %s are merged into 1 data section. Source level debug might not work correctly.", mInImageName);
   }
 
-  //
-  // Make room for .debug data in .data (or .text if .data is empty) instead of
-  // putting it in a section of its own. This is explicitly allowed by the
-  // PE/COFF spec, and prevents bloat in the binary when using large values for
-  // section alignment.
-  //
-  if (SectionCount > 0) {
-    mDebugOffset = DebugRvaAlign(mCoffOffset);
+  if (!mSkipDebugInfo) {
+    //
+    // Make room for .debug data in .data (or .text if .data is empty) instead of
+    // putting it in a section of its own. This is explicitly allowed by the
+    // PE/COFF spec, and prevents bloat in the binary when using large values for
+    // section alignment.
+    //
+    if (SectionCount > 0) {
+      mDebugOffset = DebugRvaAlign(mCoffOffset);
+    }
+    mCoffOffset = mDebugOffset + sizeof(EFI_IMAGE_DEBUG_DIRECTORY_ENTRY) +
+                  sizeof(EFI_IMAGE_DEBUG_CODEVIEW_NB10_ENTRY) +
+                  strlen(mInImageName) + 1;
   }
-  mCoffOffset = mDebugOffset + sizeof(EFI_IMAGE_DEBUG_DIRECTORY_ENTRY) +
-                sizeof(EFI_IMAGE_DEBUG_CODEVIEW_NB10_ENTRY) +
-                strlen(mInImageName) + 1;
 
   mCoffOffset = CoffAlign(mCoffOffset);
   if (SectionCount == 0) {

--- a/BaseTools/Source/C/GenFw/Elf64Convert.c
+++ b/BaseTools/Source/C/GenFw/Elf64Convert.c
@@ -940,7 +940,9 @@ ScanSections64 (
     assert (FALSE);
   }
 
-  mDebugOffset = DebugRvaAlign(mCoffOffset);
+  if (!mSkipDebugInfo) {
+    mDebugOffset = DebugRvaAlign(mCoffOffset);
+  }
   mCoffOffset = CoffAlign(mCoffOffset);
 
   if (SectionCount > 1 && mOutImageType == FW_EFI_IMAGE) {
@@ -979,27 +981,29 @@ ScanSections64 (
     }
   }
 
-  //
-  // Make room for .debug data in .data (or .text if .data is empty) instead of
-  // putting it in a section of its own. This is explicitly allowed by the
-  // PE/COFF spec, and prevents bloat in the binary when using large values for
-  // section alignment.
-  //
-  if (SectionCount > 0) {
-    mDebugOffset = DebugRvaAlign(mCoffOffset);
-  }
-  mCoffOffset = mDebugOffset + sizeof(EFI_IMAGE_DEBUG_DIRECTORY_ENTRY) +
-                sizeof(EFI_IMAGE_DEBUG_CODEVIEW_NB10_ENTRY) +
-                strlen(mInImageName) + 1;
+  if (!mSkipDebugInfo) {
+    //
+    // Make room for .debug data in .data (or .text if .data is empty) instead of
+    // putting it in a section of its own. This is explicitly allowed by the
+    // PE/COFF spec, and prevents bloat in the binary when using large values for
+    // section alignment.
+    //
+    if (SectionCount > 0) {
+      mDebugOffset = DebugRvaAlign(mCoffOffset);
+    }
+    mCoffOffset = mDebugOffset + sizeof(EFI_IMAGE_DEBUG_DIRECTORY_ENTRY) +
+                  sizeof(EFI_IMAGE_DEBUG_CODEVIEW_NB10_ENTRY) +
+                  strlen(mInImageName) + 1;
 
-  //
-  // Add more space in the .debug data region for the DllCharacteristicsEx
-  // field.
-  //
-  if (mDllCharacteristicsEx != 0) {
-    mCoffOffset = DebugRvaAlign(mCoffOffset) +
-                  sizeof (EFI_IMAGE_DEBUG_DIRECTORY_ENTRY) +
-                  sizeof (EFI_IMAGE_DEBUG_EX_DLLCHARACTERISTICS_ENTRY);
+    //
+    // Add more space in the .debug data region for the DllCharacteristicsEx
+    // field.
+    //
+    if (mDllCharacteristicsEx != 0) {
+      mCoffOffset = DebugRvaAlign(mCoffOffset) +
+                    sizeof (EFI_IMAGE_DEBUG_DIRECTORY_ENTRY) +
+                    sizeof (EFI_IMAGE_DEBUG_EX_DLLCHARACTERISTICS_ENTRY);
+    }
   }
 
   mCoffOffset = CoffAlign(mCoffOffset);

--- a/BaseTools/Source/C/GenFw/ElfConvert.c
+++ b/BaseTools/Source/C/GenFw/ElfConvert.c
@@ -220,8 +220,10 @@ ConvertElf (
   //
   // Write debug info.
   //
-  VerboseMsg ("Write debug info.");
-  ElfFunctions.WriteDebug ();
+  if (!mSkipDebugInfo) {
+    VerboseMsg ("Write debug info.");
+    ElfFunctions.WriteDebug ();
+  }
 
   //
   // For PRM Driver to Write export info.

--- a/BaseTools/Source/C/GenFw/ElfConvert.h
+++ b/BaseTools/Source/C/GenFw/ElfConvert.h
@@ -25,6 +25,7 @@ extern UINT32 mTableOffset;
 extern UINT32 mOutImageType;
 extern UINT32 mFileBufferSize;
 extern BOOLEAN mExportFlag;
+extern BOOLEAN mSkipDebugInfo;
 
 //
 // Common EFI specific data.

--- a/BaseTools/Source/C/GenFw/GenFw.c
+++ b/BaseTools/Source/C/GenFw/GenFw.c
@@ -89,6 +89,7 @@ UINT32 mOutImageType = FW_DUMMY_IMAGE;
 BOOLEAN mIsConvertXip = FALSE;
 BOOLEAN mExportFlag = FALSE;
 BOOLEAN mNoNxCompat = FALSE;
+BOOLEAN mSkipDebugInfo = FALSE;
 
 STATIC
 EFI_STATUS
@@ -251,6 +252,9 @@ Returns:
                         to MINOR.\n");
   fprintf (stdout, "  --keepzeropending     Don't strip zero pending of .reloc.\n\
                         This option can be used together with -e or -t.\n\
+                        It doesn't work for other options.\n");
+  fprintf (stdout, "  --no-debug            Skip debug information generation.\n\
+                        This option can be used together with -e.\n\
                         It doesn't work for other options.\n");
   fprintf (stdout, "  -r, --replace         Overwrite the input file with the output content.\n\
                         If more input files are specified,\n\
@@ -1418,6 +1422,13 @@ Returns:
 
     if (stricmp (argv[0], "--keepzeropending") == 0) {
       KeepZeroPendingFlag = TRUE;
+      argc --;
+      argv ++;
+      continue;
+    }
+
+    if (stricmp (argv[0], "--no-debug") == 0) {
+      mSkipDebugInfo = TRUE;
       argc --;
       argv ++;
       continue;


### PR DESCRIPTION
Add support for skipping PE/COFF debug directory generation when converting ELF binaries to PE/COFF format. This allows reducing binary size in Release builds by omitting debug information.
    
A new --no-debug option is added to GenFw. When specified, debug space allocation is skipped in ScanSections32() and ScanSections64(), and debug directory and CodeView entries are not written to the output PE/COFF file.
    
The --no-debug flag can only be used with the -e (ELF) conversion option.
    
Debug builds remain unchanged and continue to include debug information. Release builds now automatically exclude debug information for smaller binaries.

# Description

This change adds a new command line option to GenFw that allows skipping debug information generation in PE/COFF binaries. This is useful for Release builds where debug information is not needed, reducing the final binary size.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

Built GenFw with the changes and verified that the --no-debug flag correctly skips debug directory generation when specified.

## Integration Instructions

N/A
