### PR TITLE
NetworkPkg/SnpDxe: Fix Snp used uninitialized

### DIFF
--- a/NetworkPkg/SnpDxe/Snp.c
+++ b/NetworkPkg/SnpDxe/Snp.c
@@ -324,6 +324,8 @@ SimpleNetworkDriverStart (
 
   DEBUG ((DEBUG_NET, "\nSnpNotifyNetworkInterfaceIdentifier()  "));
 
+  Snp = NULL;
+
   Status = gBS->OpenProtocol (
                   Controller,
                   &gEfiDevicePathProtocolGuid,


### PR DESCRIPTION
# Description

NetworkPkg/SnpDxe: Fix Snp used uninitialized

Ensures the Snp Structure is initialized as NULL.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Tested via build and on physical device

## Integration Instructions

N/A
