### PR TITLE
OvmfPkg: MmPlatformHobProducerLibOvmf: Fixing misplaced PCDs

### DIFF
--- a/OvmfPkg/Library/MmPlatformHobProducerLibOvmf/MmPlatformHobProducerLibOvmf.c
+++ b/OvmfPkg/Library/MmPlatformHobProducerLibOvmf/MmPlatformHobProducerLibOvmf.c
@@ -103,14 +103,14 @@ CreateMmPlatformHob (
                           EFI_RESOURCE_ATTRIBUTE_INITIALIZED |
                           EFI_RESOURCE_ATTRIBUTE_UNCACHEABLE |
                           EFI_RESOURCE_ATTRIBUTE_TESTED;
-  Hob.PhysicalStart  = PcdGet32 (PcdOvmfFlashNvStorageVariableBase);
+  Hob.PhysicalStart  = PcdGet32 (PcdCpuLocalApicBaseAddress);
   Hob.ResourceLength = SIZE_1MB;
   ZeroMem (&(Hob.Owner), sizeof (EFI_GUID));
   CopyMem ((UINT8 *)Buffer + Size, &Hob, sizeof (EFI_HOB_RESOURCE_DESCRIPTOR));
   Size += sizeof (EFI_HOB_RESOURCE_DESCRIPTOR);
   NumberOfHobResourceDescriptor++;
 
-  // Variable Storage
+  // flash device
   Hob.Header.HobType    = EFI_HOB_TYPE_RESOURCE_DESCRIPTOR;
   Hob.Header.HobLength  = (UINT16)sizeof (EFI_HOB_RESOURCE_DESCRIPTOR);
   Hob.ResourceType      = EFI_RESOURCE_MEMORY_MAPPED_IO;
@@ -118,8 +118,8 @@ CreateMmPlatformHob (
                           EFI_RESOURCE_ATTRIBUTE_INITIALIZED |
                           EFI_RESOURCE_ATTRIBUTE_UNCACHEABLE |
                           EFI_RESOURCE_ATTRIBUTE_TESTED;
-  Hob.PhysicalStart  = PcdGet32 (PcdCpuLocalApicBaseAddress);
-  Hob.ResourceLength = PcdGet32 (PcdFlashNvStorageVariableSize);
+  Hob.PhysicalStart  = PcdGet32 (PcdOvmfFdBaseAddress);
+  Hob.ResourceLength = PcdGet32 (PcdOvmfFirmwareFdSize);
   ZeroMem (&(Hob.Owner), sizeof (EFI_GUID));
   CopyMem ((UINT8 *)Buffer + Size, &Hob, sizeof (EFI_HOB_RESOURCE_DESCRIPTOR));
   Size += sizeof (EFI_HOB_RESOURCE_DESCRIPTOR);

--- a/OvmfPkg/Library/MmPlatformHobProducerLibOvmf/MmPlatformHobProducerLibOvmf.inf
+++ b/OvmfPkg/Library/MmPlatformHobProducerLibOvmf/MmPlatformHobProducerLibOvmf.inf
@@ -42,10 +42,8 @@
 
 [Pcd]
   gUefiCpuPkgTokenSpaceGuid.PcdCpuLocalApicBaseAddress
-  gUefiOvmfPkgTokenSpaceGuid.PcdOvmfFlashNvStorageVariableBase
-  gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageVariableSize
-  gEfiMdeModulePkgTokenSpaceGuid.PcdPteMemoryEncryptionAddressOrMask
-  gEfiMdePkgTokenSpaceGuid.PcdConfidentialComputingGuestAttr
+  gUefiOvmfPkgTokenSpaceGuid.PcdOvmfFdBaseAddress
+  gUefiOvmfPkgTokenSpaceGuid.PcdOvmfFirmwareFdSize
 
 [Depex]
   gEfiPeiMmAccessPpiGuid


### PR DESCRIPTION
# Description

The original implementation misplaced the base addresses and lengths for their corresponding resource descriptor HOBs. It was functional because the size reported was large enough to cover all necessary usages.

This change fixed the misplacement and reports the entire FD flash region when launching the MM foundation.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

This was tested locally and booted to UEFI shell.

## Integration Instructions

N/A
