### PR TITLE
MdeModulePkg/DxeCapsuleLibFmp:Handle single-stage capsule update failure

### DIFF
--- a/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleLib.c
+++ b/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleLib.c
@@ -1315,11 +1315,17 @@ ProcessFmpCapsuleImage (
         (HandleBuffer == NULL) ||
         (ResetRequiredBuffer == NULL))
     {
-      NotReady = TRUE;
+      if (!PcdGetBool (PcdSingleStageOnlyCapsuleUpdate)) {
+        NotReady = TRUE;
+        Status   = EFI_NOT_READY;
+      }
+
+      DEBUG ((DEBUG_ERROR, "ProcessFmpCapsuleImage: GetFmpHandleBufferByType Failed %r for UpdateImageTypeId %g \n", Status, &ImageHeader->UpdateImageTypeId));
+
       RecordFmpCapsuleStatus (
         NULL,
         CapsuleHeader,
-        EFI_NOT_READY,
+        Status,
         Index - FmpCapsuleHeader->EmbeddedDriverCount,
         ImageHeader,
         CapFileName

--- a/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleLib.inf
+++ b/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleLib.inf
@@ -70,6 +70,7 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdCodRelocationDevPath                     ## SOMETIMES_CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdCoDRelocationFileName                    ## CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdCapsuleEmbeddedDriverSupport             ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdSingleStageOnlyCapsuleUpdate             ## CONSUMES
 
 [FeaturePcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdSupportUpdateCapsuleReset ## CONSUMES

--- a/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeRuntimeCapsuleLib.inf
+++ b/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeRuntimeCapsuleLib.inf
@@ -73,6 +73,7 @@
 
 [Pcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdCapsuleEmbeddedDriverSupport             ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdSingleStageOnlyCapsuleUpdate             ## CONSUMES
 
 [Depex]
   gEfiVariableWriteArchProtocolGuid

--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -1705,6 +1705,21 @@
   # @Prompt Enable Capsule with EmbeddedDriver support.
   gEfiMdeModulePkgTokenSpaceGuid.PcdCapsuleEmbeddedDriverSupport|FALSE|BOOLEAN|0x00010021
 
+  ## Indicates whether the platform supports only SingleStage capsule updates where all
+  #  capsule images are processed before EFI_END_OF_DXE_EVENT.
+  #  This PCD indicates if SingleStage Capsule Update is supported .<BR>
+  #   TRUE  - Single Stage Only capsule update support.<BR>
+  #   FALSE - Multi Stage capsule update support.
+  #   a) If PcdSingleStageOnlyCapsuleUpdate = TRUE, BDS phase invokes ProcessCapsules() only once
+  #      before EFI_END_OF_DXE_EVENT. As system flash is locked at EFI_END_OF_DXE_EVENT,
+  #      system capsules are processed in this call. If a device capsule FMP protocol is installed
+  #      and its EmbeddedDriverCount is zero, the device capsule will also be processed during this call.
+  #   b) If PcdSingleStageOnlyCapsuleUpdate = FALSE, BDS phase invokes ProcessCapsules() a second
+  #      time after EFI_END_OF_DXE_EVENT and completion of ConnectAll(). All device capsule FMP protocols
+  #      are exposed. Capsules processed during the first call are skipped in the second.
+  # @Prompt Enable Capsule with only SingleStage support.
+  gEfiMdeModulePkgTokenSpaceGuid.PcdSingleStageOnlyCapsuleUpdate|FALSE|BOOLEAN|0x00010024
+
   ## Maximum permitted encapsulation levels of sections in a firmware volume,
   #  in the DXE phase. Minimum value is 1. Sections nested more deeply are
   #  rejected.


### PR DESCRIPTION
For platforms where ProcessCapsules() runs only once before EFI_END_OF_DXE_EVENT, updated logic so that RecordFmpCapsuleStatus() logs the actual failure status instead of EFI_NOT_READY.

This patch introduces a new PCD, PcdSingleStageOnlyCapsuleUpdate allowing platforms to handle cases where ProcessCapsules() is invoked only once.

By default, PcdSingleStageOnlyCapsuleUpdate is set to FALSE, ProcessCapsules() is called twice from the BDS phase—once before and once after EFI_END_OF_DXE_EVENT.

Inorder to manage any special handling for single stage only capsule updates, platforms must opt-in by setting PcdSingleStageOnlyCapsuleUpdate to TRUE.

# Description
Allows platforms that invoke ProcessCapsules only once to handle single-stage update scenarios. Platforms must opt-in to specify single stage only support by setting the following PCD to TRUE:

Example DSC snippet:
[PcdsFixedAtBuild]
gEfiMdeModulePkgTokenSpaceGuid.PcdSingleStageOnlyCapsuleUpdate|TRUE

- [ ] Breaking change?

- [ ] Impacts security?

- [ ] Includes tests?
   Validated system Firmware Update 

## How This Was Tested
On Qualcomm platform, different capsules are generated for different form factors. Each capsule header includes a unique UpdateImageTypeID identifying its form factor. 
Successful Scenario:
A capsule matching the platform’s expected form factor was applied, and the update completed successfully.

Negative Test Case:
When a capsule of a different form factor was applied, the update process correctly rejected it. The function GetFmpHandleBufferByType() returned EFI_NOT_FOUND and CapsuleResultFmpVariables is set to EFI_NOT_FOUND instead of EFI_NOT_READY.

## Integration Instructions

N/A
