### PR TITLE
OvmfPkg/RiscVVirt/PlatformSecLib: Actually reserve handoff region

### DIFF
--- a/OvmfPkg/RiscVVirt/Library/PlatformSecLib/SecEntry.S
+++ b/OvmfPkg/RiscVVirt/Library/PlatformSecLib/SecEntry.S
@@ -15,7 +15,7 @@ li    s0, 0
 li    a2, FixedPcdGet32 (PcdOvmfSecPeiTempRamBase)
 li    a3, FixedPcdGet32 (PcdOvmfSecPeiTempRamSize)
 
-/* Reserve region to store handoff data
+/* Reserve region to store handoff data */
 li    a4, SEC_HANDOFF_DATA_RESERVE_SIZE
 sub   a3, a3, a4
 


### PR DESCRIPTION
# Description

An unterminated comment meant that the handoff region wasn't reserved. This will result in stack corruption.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

This is a port of https://github.com/tianocore/edk2-platforms/pull/898, which was tested by booting the QEMU virt board. As OVMF uses similar logic, it's assumed this is correct and necessary here too.

## Integration Instructions

N/A
