### PR TITLE
ArmPkg/Library: fix: Incorrect SectionLength Calculation.

### DIFF
--- a/ArmPkg/Library/DebugAgentSymbolsBaseLib/DebugAgentSymbolsBaseLib.c
+++ b/ArmPkg/Library/DebugAgentSymbolsBaseLib/DebugAgentSymbolsBaseLib.c
@@ -196,7 +196,7 @@ GetImageContext (
     // SectionLength is adjusted it is 4 byte aligned.
     // Go to the next section
     //
-    SectionLength = FFS_FILE_SIZE (FfsHeader);
+    SectionLength = SECTION_SIZE (Section);
     SectionLength = GET_OCCUPIED_SIZE (SectionLength, 4);
     ASSERT (SectionLength != 0);
     ParsedLength += SectionLength;


### PR DESCRIPTION
# Description

This PR addresses the fix for Incorrect SectionLength calculation.

Ref:[059332b]

Rootcause:  The SectionLength was incorrectly computed using the FFS_FILE_SIZE() macro. This macro operates on the EFI_FFS_FILE_HEADER structure, which is incompatible with the SECTION_SIZE header format.
This mismatch introduces a potential defect due to inaccurate section size calculation.

Solution: To ensure correctness and structural alignment, SectionLength must be computed using the SECTION_SIZE macro defined in MdePkg\Include\Pi\PiFirmwareFile.h. This macro performs size extraction using byte-wise access.

cc: @lgao4 
cc: @ardbiesheuvel 
cc: @leiflindholm 
cc: @vishalo 

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested


## Integration Instructions

N/A
