### PR TITLE
EmulatorPkg/Application/RedfishPlatformConfig: Add EndPointer parameter to StrDecimalToUintnS for potential use

### DIFF
--- a/EmulatorPkg/Application/RedfishPlatformConfig/RedfishPlatformConfig.c
+++ b/EmulatorPkg/Application/RedfishPlatformConfig/RedfishPlatformConfig.c
@@ -93,6 +93,7 @@ UefiMain (
   EFI_IPv4_ADDRESS  RedfishServiceIpAddress;
   EFI_IPv4_ADDRESS  RedfishServiceIpMask;
   UINTN             RedfishServiceIpPort;
+  CHAR16            *EndPointer = NULL;
 
   Status = GetArg ();
   if (EFI_ERROR (Status)) {
@@ -136,7 +137,7 @@ UefiMain (
       return Status;
     }
 
-    ReturnStatus = StrDecimalToUintnS (Argv[6], NULL, &RedfishServiceIpPort);
+    ReturnStatus = StrDecimalToUintnS (Argv[6], &EndPointer, &RedfishServiceIpPort);
     if (RETURN_ERROR (ReturnStatus)) {
       PrintHelp ();
       return Status;
@@ -231,7 +232,7 @@ UefiMain (
       return Status;
     }
 
-    ReturnStatus = StrDecimalToUintnS (Argv[4], NULL, &RedfishServiceIpPort);
+    ReturnStatus = StrDecimalToUintnS (Argv[4], &EndPointer, &RedfishServiceIpPort);
     if (RETURN_ERROR (ReturnStatus)) {
       PrintHelp ();
       return Status;


### PR DESCRIPTION
Now transfer null parameter to StrDecimalToUintnS as fllows:
ReturnStatus = StrDecimalToUintnS (Argv[6], NULL, &RedfishServiceIpPort);
It's not convenient to debug when have problems, because there are no return value.
So, Add EndPointer parameter to StrDecimalToUintnS for potential use.
