### PR TITLE
Do some improvement for CreateRscHandlerCallbackPacket

### DIFF
--- a/MdeModulePkg/Universal/ReportStatusCodeRouter/Pei/ReportStatusCodeRouterPei.c
+++ b/MdeModulePkg/Universal/ReportStatusCodeRouter/Pei/ReportStatusCodeRouterPei.c
@@ -57,6 +57,9 @@ CreateRscHandlerCallbackPacket (
                       sizeof (EFI_PEI_RSC_HANDLER_CALLBACK) * 64 + sizeof (UINTN)
                       );
   ASSERT (NumberOfEntries != NULL);
+  if (NumberOfEntries == NULL) {
+    return NumberOfEntries;
+  }
 
   *NumberOfEntries = 0;
 
@@ -135,6 +138,9 @@ Register (
 
   if (FreePacket == NULL) {
     FreePacket = CreateRscHandlerCallbackPacket ();
+    if (FreePacket == NULL) {
+      return EFI_OUT_OF_RESOURCES;
+    }
   }
 
   CallbackEntry                 = (EFI_PEI_RSC_HANDLER_CALLBACK *)(FreePacket + 1);


### PR DESCRIPTION
Do some improvement for CreateRscHandlerCallbackPacket:
1.Return if NumberOfEntries is NULL to avoid null pointer access, because ASSERT don't block code execution   with release version.
2.Zero Hob data when create Hob successfully. Ther previous code just zero the first UINTN.