### PR TITLE
OvmfPkg,ArmVirtPkg,NetworkPkg: Fix build with -D NETWORK_ENABLE=0

### DIFF
--- a/ArmVirtPkg/ArmVirtQemu.dsc
+++ b/ArmVirtPkg/ArmVirtQemu.dsc
@@ -486,7 +486,6 @@
   OvmfPkg/Fdt/HighMemDxe/HighMemDxe.inf
   OvmfPkg/VirtioBlkDxe/VirtioBlk.inf
   OvmfPkg/VirtioScsiDxe/VirtioScsi.inf
-  OvmfPkg/VirtioNetDxe/VirtioNet.inf
   OvmfPkg/VirtioRngDxe/VirtioRng.inf
   OvmfPkg/VirtioSerialDxe/VirtioSerial.inf {
     <PcdsFixedAtBuild>

--- a/ArmVirtPkg/ArmVirtQemuFvMain.fdf.inc
+++ b/ArmVirtPkg/ArmVirtQemuFvMain.fdf.inc
@@ -101,7 +101,9 @@ READ_LOCK_STATUS   = TRUE
   # Platform Driver
   #
   INF OvmfPkg/VirtioBlkDxe/VirtioBlk.inf
+!if $(NETWORK_ENABLE) == TRUE
   INF OvmfPkg/VirtioNetDxe/VirtioNet.inf
+!endif
   INF OvmfPkg/VirtioScsiDxe/VirtioScsi.inf
   INF OvmfPkg/VirtioRngDxe/VirtioRng.inf
   INF OvmfPkg/VirtioSerialDxe/VirtioSerial.inf

--- a/ArmVirtPkg/ArmVirtQemuKernel.dsc
+++ b/ArmVirtPkg/ArmVirtQemuKernel.dsc
@@ -379,7 +379,6 @@
   OvmfPkg/Fdt/HighMemDxe/HighMemDxe.inf
   OvmfPkg/VirtioBlkDxe/VirtioBlk.inf
   OvmfPkg/VirtioScsiDxe/VirtioScsi.inf
-  OvmfPkg/VirtioNetDxe/VirtioNet.inf
   OvmfPkg/VirtioRngDxe/VirtioRng.inf
   OvmfPkg/VirtioSerialDxe/VirtioSerial.inf
 

--- a/NetworkPkg/NetworkDynamicPcds.dsc.inc
+++ b/NetworkPkg/NetworkDynamicPcds.dsc.inc
@@ -11,15 +11,18 @@
 #
 ##
 
-#
-# IPv4 and IPv6 PXE Boot support.
-#
-!if ($(NETWORK_ENABLE) == TRUE) AND ($(NETWORK_PXE_BOOT_ENABLE) == TRUE)
-  gEfiNetworkPkgTokenSpaceGuid.PcdIPv4PXESupport|0x01
-  gEfiNetworkPkgTokenSpaceGuid.PcdIPv6PXESupport|0x01
-!endif
-#
-# IPv4 and IPv6 HTTP Boot support.
-#
+!if $(NETWORK_ENABLE) == TRUE
+  #
+  # IPv4 and IPv6 PXE Boot support.
+  #
+  !if $(NETWORK_PXE_BOOT_ENABLE) == TRUE
+    gEfiNetworkPkgTokenSpaceGuid.PcdIPv4PXESupport|0x01
+    gEfiNetworkPkgTokenSpaceGuid.PcdIPv6PXESupport|0x01
+  !endif
+
+  #
+  # IPv4 and IPv6 HTTP Boot support.
+  #
   gEfiNetworkPkgTokenSpaceGuid.PcdIPv4HttpSupport|TRUE
   gEfiNetworkPkgTokenSpaceGuid.PcdIPv6HttpSupport|TRUE
+!endif

--- a/OvmfPkg/CloudHv/CloudHvX64.fdf
+++ b/OvmfPkg/CloudHv/CloudHvX64.fdf
@@ -293,7 +293,9 @@ INF MdeModulePkg/Logo/LogoDxe.inf
   }
 !endif
 !include NetworkPkg/Network.fdf.inc
+!if $(NETWORK_ENABLE) == TRUE
   INF  OvmfPkg/VirtioNetDxe/VirtioNet.inf
+!endif
 
 INF  OvmfPkg/PlatformDxe/Platform.inf
 INF  OvmfPkg/AmdSevDxe/AmdSevDxe.inf

--- a/OvmfPkg/Microvm/MicrovmX64.fdf
+++ b/OvmfPkg/Microvm/MicrovmX64.fdf
@@ -224,7 +224,9 @@ INF MdeModulePkg/Logo/LogoDxe.inf
   }
 !endif
 !include NetworkPkg/Network.fdf.inc
+!if $(NETWORK_ENABLE) == TRUE
   INF  OvmfPkg/VirtioNetDxe/VirtioNet.inf
+!endif
 
 #
 # Usb Support

--- a/OvmfPkg/OvmfPkgIa32X64.fdf
+++ b/OvmfPkg/OvmfPkgIa32X64.fdf
@@ -272,7 +272,9 @@ INF SecurityPkg/Hash2DxeCrypto/Hash2DxeCrypto.inf
   }
 !endif
 !include NetworkPkg/Network.fdf.inc
+!if $(NETWORK_ENABLE) == TRUE
   INF  OvmfPkg/VirtioNetDxe/VirtioNet.inf
+!endif
 
 #
 # Usb Support

--- a/OvmfPkg/OvmfPkgX64.fdf
+++ b/OvmfPkg/OvmfPkgX64.fdf
@@ -290,7 +290,9 @@ INF SecurityPkg/Hash2DxeCrypto/Hash2DxeCrypto.inf
   }
 !endif
 !include NetworkPkg/Network.fdf.inc
+!if $(NETWORK_ENABLE) == TRUE
   INF  OvmfPkg/VirtioNetDxe/VirtioNet.inf
+!endif
 
 #
 # Usb Support


### PR DESCRIPTION
# Description

Previous PR https://github.com/tianocore/edk2/pull/6087 restored the ability to build OvmfPkg with -D NETWORK_ENABLE=0.

Unfortunately b3b3cfab7eb52acd77558a9727196e30d05d1f2a has broken it again, since the .dsc references to OvmfPkg/VirtioNetDxe/VirtioNet.inf were moved from outside !if $(NETWORK_ENABLE) == TRUE to inside it, while the .fdf references remained outside.

In discussion below it was decided to move the .fdf references inside the conditional, i.e. not to include VirtioNetDxe unless the rest of the network stack is being built.

Removal of VirtioNetDxe driver on -D NETWORK_ENABLE=0 has only been applied to those packages which are already using OvmfPkg/Dsc/Includes/NetworkComponents.dsc.inc.

f9408b7cc160030c3bb9627c8086a792cc2d046c introduces new PCDs which also need to be moved inside a NETWORK_ENABLE test in order to allow building with -D NETWORK_ENABLE=0, which is also done here.


- [ ] Breaking change?
  - NO
- [ ] Impacts security?
  - NO
- [ ] Includes tests?
  - NO

## How This Was Tested

 - Test building OvmfPkgX64, OvmfPkgIa32X64, ArmVirtQemu, ArmVirtQemuKernel, CloudHvX64 w/ & w/out NETWORK_ENABLE=0, and confirm VirtioNetDxe isn't/is built.
 - Test running OvmfPkgX64, OvmfPkgIa32X64, ArmVirtQemu w/ & w/out NETWORK_ENABLE=0, and confirm running normally and VirtioNetDxe.efi isn't/is loaded.

## Integration Instructions

N/A