### PR TITLE
OvmfPkg: Fix non-position independent code in ApRunLoop.nasm

### DIFF
--- a/OvmfPkg/TdxDxe/X64/ApRunLoop.nasm
+++ b/OvmfPkg/TdxDxe/X64/ApRunLoop.nasm
@@ -125,7 +125,7 @@ AsmRelocateApResetVector:
 
 .prepareStack:
     ; The stack can then be used to switch from long mode to compatibility mode
-    mov rsp, STACK_TOP
+    lea rsp, [STACK_TOP]
 
 .loadGDT:
     cli


### PR DESCRIPTION
# Description

XCODE5 toolchain correctly reports:

Illegal text-relocations:
  text-relocation in '_AsmRelocateApMailBoxLoop'+0x7A (<...>/Build/OvmfX64/DEBUG_XCODE5/X64/OvmfPkg/TdxDxe/TdxDxe/OUTPUT/TdxDxe.lib\[4\](ApRunLoop.obj)) to 'STACK_TOP'

Since we are using DEFAULT REL in the file `lea rsp, [STACK_TOP]` is fine for the fix, we do not need `lea rsp, [rel STACK_TOP]`.

For info, code was introduced in
https://github.com/tianocore/edk2/commit/406f42cb74fbdac1fdf6a90c72fb7b4ca67107ff

cc @sunceping @lgao4 

- [ ] Breaking change?
  - NO.
- [ ] Impacts security?
  - NO.
- [ ] Includes tests?
  - NO.

## How This Was Tested

Confirm build and run, examine assembled output.

## Integration Instructions

N/A