### PR TITLE
OvmfPkg: Prevent ./build.sh from building X64 when legacy IA32 is specified

### DIFF
--- a/OvmfPkg/build.sh
+++ b/OvmfPkg/build.sh
@@ -153,6 +153,10 @@ if [[ "$ARCH_IA32" == "yes" && "$ARCH_X64" == "yes" ]]; then
   BUILD_OPTIONS="$BUILD_OPTIONS -a IA32 -a X64"
   PLATFORM_BUILD_DIR=Ovmf3264
   BUILD_ROOT_ARCH=X64
+elif [[ "$ARCH_IA32" == "yes" && "$ARCH_X64" == "no" ]]; then
+    echo "Unsupported architecture '-a IA32'"
+    echo "Only '-a IA32 -a X64' or '-a X64' are supported"
+    exit 1
 else
   PROCESSOR=X64
   Processor=X64


### PR DESCRIPTION
# Description

1fb88ffe284782cc79e306306b8d19829b6248b7 removed OVMF IA32, but unfortunately left the legacy flag `-a IA32` which previously triggered that build in `OvmfPkg/build.sh` as building X64 instead (even though `-a IA32 -a X64` to build IA32X64 still worked correctly).

This was followed by 2a6708a786eb0f0e9b979cd93c5dc12c42e337a1, which removed `OvmfPkg/build.sh` support for the `-a IA32` flag altogether, fixing the problem introduced by 1fb88ffe284782cc79e306306b8d19829b6248b7, but also removing support for IA32X64.

As per https://github.com/tianocore/edk2/issues/11725, there should be no need to remove IA32X64 support from `build.sh`. This first commit here reverts 2a6708a786eb0f0e9b979cd93c5dc12c42e337a1 to restore support for building IA32X64. The second commit fixes the mentioned issue with 1fb88ffe284782cc79e306306b8d19829b6248b7.

- [ ] Breaking change?
  - NO.
- [ ] Impacts security?
  - NO.
- [ ] Includes tests?
  - NO.

## How This Was Tested

Confirm builds supported packages, and refuses to build no longer supported package.

## Integration Instructions

N/A