### PR TITLE
SecurityPkg: Remove unused variable

### DIFF
--- a/SecurityPkg/Library/Tpm2CommandLib/Tpm2Capability.c
+++ b/SecurityPkg/Library/Tpm2CommandLib/Tpm2Capability.c
@@ -532,13 +532,11 @@ Tpm2GetCapabilitySupportedAndActivePcrs (
   EFI_STATUS          Status;
   TPML_PCR_SELECTION  Pcrs;
   UINTN               Index;
-  UINT8               ActivePcrBankCount;
 
   //
   // Get supported PCR
   //
-  Status             = Tpm2GetCapabilityPcrs (&Pcrs);
-  ActivePcrBankCount = 0;
+  Status = Tpm2GetCapabilityPcrs (&Pcrs);
   //
   // If error, assume that we have at least SHA-1 (and return the error.)
   //
@@ -546,7 +544,6 @@ Tpm2GetCapabilitySupportedAndActivePcrs (
     DEBUG ((DEBUG_ERROR, "GetSupportedAndActivePcrs - Tpm2GetCapabilityPcrs fail!\n"));
     *TpmHashAlgorithmBitmap = HASH_ALG_SHA1;
     *ActivePcrBanks         = HASH_ALG_SHA1;
-    ActivePcrBankCount      = 1;
   }
   //
   // Otherwise, process the return data to determine what algorithms are supported
@@ -563,7 +560,6 @@ Tpm2GetCapabilitySupportedAndActivePcrs (
           if (!IsZeroBuffer (Pcrs.pcrSelections[Index].pcrSelect, Pcrs.pcrSelections[Index].sizeofSelect)) {
             DEBUG ((DEBUG_VERBOSE, "GetSupportedAndActivePcrs - HASH_ALG_SHA1 active.\n"));
             *ActivePcrBanks |= HASH_ALG_SHA1;
-            ActivePcrBankCount++;
           }
 
           break;
@@ -573,7 +569,6 @@ Tpm2GetCapabilitySupportedAndActivePcrs (
           if (!IsZeroBuffer (Pcrs.pcrSelections[Index].pcrSelect, Pcrs.pcrSelections[Index].sizeofSelect)) {
             DEBUG ((DEBUG_VERBOSE, "GetSupportedAndActivePcrs - HASH_ALG_SHA256 active.\n"));
             *ActivePcrBanks |= HASH_ALG_SHA256;
-            ActivePcrBankCount++;
           }
 
           break;
@@ -583,7 +578,6 @@ Tpm2GetCapabilitySupportedAndActivePcrs (
           if (!IsZeroBuffer (Pcrs.pcrSelections[Index].pcrSelect, Pcrs.pcrSelections[Index].sizeofSelect)) {
             DEBUG ((DEBUG_VERBOSE, "GetSupportedAndActivePcrs - HASH_ALG_SHA384 active.\n"));
             *ActivePcrBanks |= HASH_ALG_SHA384;
-            ActivePcrBankCount++;
           }
 
           break;
@@ -593,7 +587,6 @@ Tpm2GetCapabilitySupportedAndActivePcrs (
           if (!IsZeroBuffer (Pcrs.pcrSelections[Index].pcrSelect, Pcrs.pcrSelections[Index].sizeofSelect)) {
             DEBUG ((DEBUG_VERBOSE, "GetSupportedAndActivePcrs - HASH_ALG_SHA512 active.\n"));
             *ActivePcrBanks |= HASH_ALG_SHA512;
-            ActivePcrBankCount++;
           }
 
           break;
@@ -603,7 +596,6 @@ Tpm2GetCapabilitySupportedAndActivePcrs (
           if (!IsZeroBuffer (Pcrs.pcrSelections[Index].pcrSelect, Pcrs.pcrSelections[Index].sizeofSelect)) {
             DEBUG ((DEBUG_VERBOSE, "GetSupportedAndActivePcrs - HASH_ALG_SM3_256 active.\n"));
             *ActivePcrBanks |= HASH_ALG_SM3_256;
-            ActivePcrBankCount++;
           }
 
           break;


### PR DESCRIPTION
# Description

This PR fixes a minor but genuine code linting issue which prevents XCODE5 build, and is worth fixing in its own right.

- [ ] Breaking change?
  - NO.
- [ ] Impacts security?
  - NO.
- [ ] Includes tests?
  - NO.

## How This Was Tested

Confirm valid XCODE5 build after changes. Confirm no break in EDK 2 CI.

## Integration Instructions

N/A