### PR TITLE
CryptoPkg: Remove unused variable

### DIFF
--- a/CryptoPkg/Library/BaseCryptLibMbedTls/Pk/CryptX509.c
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/Pk/CryptX509.c
@@ -128,7 +128,6 @@ X509ConstructCertificateStackV (
 {
   UINT8             *Cert;
   UINTN             CertSize;
-  INT32             Index;
   INT32             Ret;
   mbedtls_x509_crt  *Crt;
 
@@ -148,7 +147,7 @@ X509ConstructCertificateStackV (
     *X509Stack = (UINT8 *)Crt;
   }
 
-  for (Index = 0; ; Index++) {
+  while (TRUE) {
     //
     // If Cert is NULL, then it is the end of the list.
     //


### PR DESCRIPTION
# Description

This was found building `ArmVirtQemu` using CLANGDWARF with `unused-but-set-variable` warning enabled.

If this and the other recent minor code fixes can be accepted, it should be possible to do a PR enabling/re-enabling the warnings in CLANGDWARF and CLANGPDB which can catch these issues just as well as XCODE5 can. However, none of these toolchains are currently included in EDK 2 CI.

A project further down the line is to make a PR offering to include at least the CLANG toolchains in CI, for exactly the purpose of catching these minor code nits which also, less often, pick up real code bugs. [[ref]](https://github.com/tianocore/containers/pull/101) [[comment]](https://github.com/tianocore/edk2/pull/11442)

- [ ] Breaking change?
  - NO.
- [ ] Impacts security?
  - NO.
- [ ] Includes tests?
  - NO.

## How This Was Tested

Confirm build after fix with the same error reporting enabled.

## Integration Instructions

N/A
