### PR TITLE
MdeModulePkg/AcpiTableDxe:Fixed exception when enable SpecialPool

### DIFF
--- a/MdeModulePkg/Universal/Acpi/AcpiTableDxe/AcpiTableProtocol.c
+++ b/MdeModulePkg/Universal/Acpi/AcpiTableDxe/AcpiTableProtocol.c
@@ -2162,32 +2162,41 @@ InstallAcpiTableFromAcpiSiliconHob (
         NeedToInstallTable = (VOID *)(UINTN)((EFI_ACPI_3_0_FIXED_ACPI_DESCRIPTION_TABLE *)SocEntryTable)->XDsdt;
       } else if (((EFI_ACPI_3_0_FIXED_ACPI_DESCRIPTION_TABLE *)SocEntryTable)->Dsdt != 0) {
         NeedToInstallTable = (VOID *)(UINTN)((EFI_ACPI_3_0_FIXED_ACPI_DESCRIPTION_TABLE *)SocEntryTable)->Dsdt;
+      } else {
+        //
+        // The XDsdt or Dsdt not be detected, so set NeedToInstallTable to NULL to skip Dsdt installation.
+        //
+        NeedToInstallTable = NULL;
       }
 
-      //
-      // if signature can not be found from the XDsdt / Dsdt field then skip it.
-      //
-      if (((EFI_ACPI_DESCRIPTION_HEADER *)NeedToInstallTable)->Signature == EFI_ACPI_3_0_DIFFERENTIATED_SYSTEM_DESCRIPTION_TABLE_SIGNATURE) {
-        Status = AddTableToList (AcpiTableInstance, NeedToInstallTable, TRUE, Version, TRUE, &TableKey);
-        if (EFI_ERROR (Status)) {
-          DEBUG ((DEBUG_ERROR, "Fail to add DSDT in the DXE Table list!\n"));
-          ASSERT_EFI_ERROR (Status);
-          break;
-        } else {
-          Status = PublishTables (AcpiTableInstance, Version);
-          if (!EFI_ERROR (Status)) {
-            //
-            // Add a new table successfully, notify registed callback
-            //
-            if (FeaturePcdGet (PcdInstallAcpiSdtProtocol)) {
-              SdtNotifyAcpiList (AcpiTableInstance, Version, TableKey);
+      if (NeedToInstallTable != NULL) {
+        //
+        // if signature can not be found from the XDsdt / Dsdt field then skip it.
+        //
+        if (((EFI_ACPI_DESCRIPTION_HEADER *)NeedToInstallTable)->Signature == EFI_ACPI_3_0_DIFFERENTIATED_SYSTEM_DESCRIPTION_TABLE_SIGNATURE) {
+          Status = AddTableToList (AcpiTableInstance, NeedToInstallTable, TRUE, Version, TRUE, &TableKey);
+          if (EFI_ERROR (Status)) {
+            DEBUG ((DEBUG_ERROR, "Fail to add DSDT in the DXE Table list!\n"));
+            ASSERT_EFI_ERROR (Status);
+            break;
+          } else {
+            Status = PublishTables (AcpiTableInstance, Version);
+            if (!EFI_ERROR (Status)) {
+              //
+              // Add a new table successfully, notify registed callback
+              //
+              if (FeaturePcdGet (PcdInstallAcpiSdtProtocol)) {
+                SdtNotifyAcpiList (AcpiTableInstance, Version, TableKey);
+              }
             }
-          }
 
-          DEBUG ((DEBUG_INFO, "Installed DSDT in the DXE Table list!\n"));
+            DEBUG ((DEBUG_INFO, "Installed DSDT in the DXE Table list!\n"));
+          }
+        } else {
+          DEBUG ((DEBUG_ERROR, "The DSDT content is not correct, then skip it!\n"));
         }
       } else {
-        DEBUG ((DEBUG_ERROR, "The DSDT content is not correct, then skip it!\n"));
+        DEBUG ((DEBUG_ERROR, "The DSDT Table not initialized during PEI phase yet.\n"));
       }
 
       //
@@ -2197,29 +2206,41 @@ InstallAcpiTableFromAcpiSiliconHob (
         NeedToInstallTable = (VOID *)(UINTN)((EFI_ACPI_3_0_FIXED_ACPI_DESCRIPTION_TABLE *)SocEntryTable)->XFirmwareCtrl;
       } else if (((EFI_ACPI_3_0_FIXED_ACPI_DESCRIPTION_TABLE *)SocEntryTable)->FirmwareCtrl != 0) {
         NeedToInstallTable = (VOID *)(UINTN)((EFI_ACPI_3_0_FIXED_ACPI_DESCRIPTION_TABLE *)SocEntryTable)->FirmwareCtrl;
+      } else {
+        //
+        // The XFirmwareCtrl or FirmwareCtrl not be detected, so set NeedToInstallTable to NULL to skip Facs installation.
+        //
+        NeedToInstallTable = NULL;
       }
 
-      if (((EFI_ACPI_DESCRIPTION_HEADER *)NeedToInstallTable)->Signature == EFI_ACPI_3_0_FIRMWARE_ACPI_CONTROL_STRUCTURE_SIGNATURE) {
-        Status = AddTableToList (AcpiTableInstance, NeedToInstallTable, TRUE, Version, TRUE, &TableKey);
-        if (EFI_ERROR (Status)) {
-          DEBUG ((DEBUG_ERROR, "Fail to add FACS in the DXE Table list!\n"));
-          ASSERT_EFI_ERROR (Status);
-          break;
-        } else {
-          Status = PublishTables (AcpiTableInstance, Version);
-          if (!EFI_ERROR (Status)) {
-            //
-            // Add a new table successfully, notify registed callback
-            //
-            if (FeaturePcdGet (PcdInstallAcpiSdtProtocol)) {
-              SdtNotifyAcpiList (AcpiTableInstance, Version, TableKey);
+      if (NeedToInstallTable != NULL) {
+        //
+        // if signature can not be found from the XFirmwareCtrl / FirmwareCtrl field then skip it.
+        //
+        if (((EFI_ACPI_DESCRIPTION_HEADER *)NeedToInstallTable)->Signature == EFI_ACPI_3_0_FIRMWARE_ACPI_CONTROL_STRUCTURE_SIGNATURE) {
+          Status = AddTableToList (AcpiTableInstance, NeedToInstallTable, TRUE, Version, TRUE, &TableKey);
+          if (EFI_ERROR (Status)) {
+            DEBUG ((DEBUG_ERROR, "Fail to add FACS in the DXE Table list!\n"));
+            ASSERT_EFI_ERROR (Status);
+            break;
+          } else {
+            Status = PublishTables (AcpiTableInstance, Version);
+            if (!EFI_ERROR (Status)) {
+              //
+              // Add a new table successfully, notify registed callback
+              //
+              if (FeaturePcdGet (PcdInstallAcpiSdtProtocol)) {
+                SdtNotifyAcpiList (AcpiTableInstance, Version, TableKey);
+              }
             }
-          }
 
-          DEBUG ((DEBUG_INFO, "Installed FACS in the DXE Table list!\n"));
+            DEBUG ((DEBUG_INFO, "Installed FACS in the DXE Table list!\n"));
+          }
+        } else {
+          DEBUG ((DEBUG_ERROR, "The FACS content is not correct, then skip it!\n"));
         }
       } else {
-        DEBUG ((DEBUG_ERROR, "The FACS content is not correct, then skip it!\n"));
+        DEBUG ((DEBUG_ERROR, "The FACS Table not initialized during PEI phase yet.\n"));
       }
     }
   }


### PR DESCRIPTION
# Description
In some corner cases the NeedToInstallTable not been initialized
in the InstallAcpiTableFromAcpiSiliconHob (), which caused memory 
exception by enable special pool function.

This patch initialized NeedToInstallTable in any conidiation during
InstallAcpiTableFromAcpiSiliconHob ().

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested
SUT boots to operation system with below conidiations
  1. Without install DSDT or FACS during the PEI phase.
  2. Build BIOS with enable SpecialPool

## Integration Instructions

None
