### PR TITLE
BaseTools: Fix check and error message by moving the use of the variable

### DIFF
--- a/BaseTools/toolsetup.bat
+++ b/BaseTools/toolsetup.bat
@@ -243,15 +243,15 @@ if /I "%1"=="/?" goto Usage
     ) else (
       set EDK_TOOLS_BIN=%EDK_TOOLS_PATH%\Bin\Win32
     )
-    if not defined FORCE_REBUILD (
-      if not defined REBUILD (
-        if not exist "%EDK_TOOLS_BIN%" (
-          echo.
-          echo !!! ERROR !!! Cannot find BaseTools Bin Win32!!!
-          echo Please check the directory %EDK_TOOLS_BIN%
-          echo Or configure EDK_TOOLS_BIN env to point to Bin directory.
-          echo.
-        )
+  )
+  if not defined FORCE_REBUILD (
+    if not defined REBUILD (
+      if not exist "%EDK_TOOLS_BIN%" (
+        echo.
+        echo !!! ERROR !!! Cannot find BaseTools Bin Win32!!!
+        echo Please check the directory %EDK_TOOLS_BIN%
+        echo Or configure EDK_TOOLS_BIN env to point to Bin directory.
+        echo.
       )
     )
   )
@@ -285,15 +285,15 @@ if /I "%1"=="/?" goto Usage
     ) else (
       set EDK_TOOLS_BIN=%EDK_TOOLS_PATH%\Bin\Win32
     )
-    if not defined FORCE_REBUILD (
-      if not defined REBUILD (
-        if not exist "%EDK_TOOLS_BIN%" (
-          echo.
-          echo !!! ERROR !!! Cannot find BaseTools Bin Win32!!!
-          echo Please check the directory %EDK_TOOLS_BIN%
-          echo Or configure EDK_TOOLS_BIN env to point to Bin directory.
-          echo.
-        )
+  )
+  if not defined FORCE_REBUILD (
+    if not defined REBUILD (
+      if not exist "%EDK_TOOLS_BIN%" (
+        echo.
+        echo !!! ERROR !!! Cannot find BaseTools Bin Win32!!!
+        echo Please check the directory %EDK_TOOLS_BIN%
+        echo Or configure EDK_TOOLS_BIN env to point to Bin directory.
+        echo.
       )
     )
   )


### PR DESCRIPTION
# Description
ToolSetup.bat had a bug where the check for %EDK_TOOLS_BIN% was happening inside the same code block where it was assigned, so the check was failing. 
I moved the check outside of the code block (if statement) where it is assigned (in 2 locations) and now it works as expected. 
fixes #11744

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested
I verified that the error is now reported correctly, with the missing path being displayed on the screen.

## Integration Instructions
N/A

