### PR TITLE
BaseTools: Fix parallel build

### DIFF
--- a/BaseTools/Source/Python/AutoGen/GenMake.py
+++ b/BaseTools/Source/Python/AutoGen/GenMake.py
@@ -774,7 +774,7 @@ cleanlib:
                                 SecDepsFileList.append(SecCmdList[index + 1])
                             index = index + 1
                         if CmdName == 'Trim':
-                            SecDepsFileList.append(os.path.join('$(DEBUG_DIR)', os.path.basename(OutputFile).replace('offset', 'efi')))
+                            SecDepsFileList.append(os.path.join('$(OUTPUT_DIR)', os.path.basename(OutputFile).replace('offset', 'efi')))
                         if OutputFile.endswith('.ui') or OutputFile.endswith('.ver'):
                             SecDepsFileList.append(os.path.join('$(MODULE_DIR)', '$(MODULE_FILE)'))
                         self.FfsOutputFileList.append((OutputFile, ' '.join(SecDepsFileList), SecCmdStr))


### PR DESCRIPTION


# Description

When EDK2's build tool is invoked by a make started with -j command-line switch it inherits the parallel build settings through the MAKEFLAGS env variable. In highly parallel builds it may lead to build failures with the following error message:

```
make[1]: *** No rule to make target
'<PATH>/AARCH64/MdeModulePkg/Application/UiApp/UiApp/DEBUG/UiApp.efi', needed by
'<PATH>/FV/Ffs/462CAA21-7614-4503-836E-8AB6F4662331UiApp/UiApp.offset'. Stop.
```

The root cause is the following rule generated by GenMake:

```
$(FFS_OUTPUT_DIR)/UiApp.offset : $(DEBUG_DIR)/UiApp.efi
```

The `$(DEBUG_DIR)/UiApp.efi` target does not exist in the makefile and is created as a side-effect of the `$(OUTPUT_DIR)/UiApp.efi`

This change replaces the non-existent dependency with the correct one and fixes parallel build issue.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

`build` tool was invoked to build EDK2 image from the top-level `Makefile` using `make -j` invocation. Without the change build failed, with the change it successfully passed.

## Integration Instructions

N/A
