### PR TITLE
MdeModulePkg/ConSplitterDxe: Set default ConOut mode to 0

### DIFF
--- a/MdeModulePkg/Universal/Console/ConSplitterDxe/ConSplitter.c
+++ b/MdeModulePkg/Universal/Console/ConSplitterDxe/ConSplitter.c
@@ -1346,6 +1346,11 @@ ConSplitterConOutDriverBindingStart (
     FreePool (Info);
   }
 
+  Status = gST->ConOut->SetMode (gST->ConOut, 0);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
   return Status;
 }
 


### PR DESCRIPTION
# Description

REF: https://github.com/tianocore/edk2/issues/11765

The ConSplitterDxe driver was defaulting to the Console Output (ConOut) MaxMode immediately after its virtual protocols were installed. This MaxMode often exceeded the actual resolution or capability of the physical console device, leading to severe display corruption and incorrect line wrapping/positioning. This commit changes the default mode to 0, guaranteeing stable display behavior upon system boot.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested
1. Build ovmf
build -a X64 -p OvmfPkg/OvmfPkgX64.dsc -t GCC5

2. Run OVMF
qemu-system-x86_64
-m 2G \
-machine q35,accel=kvm \
-cpu host \
-bios ~/Workspace/edk2/Build/OvmfX64/DEBUG_GCC5/FV/OVMF.fd \
-net none \
-nographic

## Integration Instructions
N/A

