### PR TITLE
MdeModulePkg: StatusCodeHandler Stmm remove assert.

### DIFF
--- a/MdeModulePkg/Universal/StatusCodeHandler/Smm/StatusCodeHandlerStandalone.c
+++ b/MdeModulePkg/Universal/StatusCodeHandler/Smm/StatusCodeHandlerStandalone.c
@@ -29,11 +29,12 @@ IsStatusCodeUsingSerialPort (
   MM_STATUS_CODE_USE_SERIAL  *StatusCodeUseSerialHob;
 
   Hob = GetFirstGuidHob (&gMmStatusCodeUseSerialHobGuid);
-  ASSERT (Hob != NULL);
+  if (Hob != NULL) {
+    StatusCodeUseSerialHob = (MM_STATUS_CODE_USE_SERIAL *)GET_GUID_HOB_DATA (Hob);
+    return StatusCodeUseSerialHob->StatusCodeUseSerial;
+  }
 
-  StatusCodeUseSerialHob = (MM_STATUS_CODE_USE_SERIAL *)GET_GUID_HOB_DATA (Hob);
-
-  return StatusCodeUseSerialHob->StatusCodeUseSerial;
+  return FALSE;
 }
 
 /**


### PR DESCRIPTION
# Description

In StandaloneMM mode, IsStatusCodeUsingSerialPort is expecting to find gMmStatusCodeUseSerialHobGuid, and will assert if it is not found.

Change the logic so that if the Guided Hob is not found, to let the function return FALSE and progress without serial messages.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested
A platform which did not provide a gMmStatusCodeUseSerialHobGuid would assert.
After changing, the platform proceeds to boot.

## Integration Instructions
No integration necessary. 