### PR TITLE
Fix retry logic in UFS device detection APIs

### DIFF
--- a/MdeModulePkg/Bus/Ufs/UfsBlockIoPei/UfsHci.c
+++ b/MdeModulePkg/Bus/Ufs/UfsBlockIoPei/UfsHci.c
@@ -1555,7 +1555,8 @@ UfsDeviceDetection (
   for (Retry = 0; Retry < 3; Retry++) {
     Status = UfsExecUicCommands (Private, UfsUicDmeLinkStartup, 0, 0, 0);
     if (EFI_ERROR (Status)) {
-      return EFI_DEVICE_ERROR;
+      DEBUG ((DEBUG_ERROR, "[%a] UfsExecUicCommands failed with Status=%r\n", __func__, Status));
+      continue;
     }
 
     //
@@ -1567,7 +1568,8 @@ UfsDeviceDetection (
       Address = Private->UfsHcBase + UFS_HC_IS_OFFSET;
       Status  = UfsWaitMemSet (Address, UFS_HC_IS_ULSS, UFS_HC_IS_ULSS, UFS_TIMEOUT);
       if (EFI_ERROR (Status)) {
-        return EFI_DEVICE_ERROR;
+        DEBUG ((DEBUG_ERROR, "[%a] UfsWaitMemSet failed with Status=%r\n", __func__, Status));
+        continue;
       }
     } else {
       DEBUG ((DEBUG_INFO, "UfsblockioPei: found a attached UFS device\n"));

--- a/MdeModulePkg/Bus/Ufs/UfsPassThruDxe/UfsPassThruHci.c
+++ b/MdeModulePkg/Bus/Ufs/UfsPassThruDxe/UfsPassThruHci.c
@@ -1964,18 +1964,21 @@ UfsDeviceDetection (
     LinkStartupCommand.Arg3   = 0;
     Status                    = UfsExecUicCommands (Private, &LinkStartupCommand);
     if (EFI_ERROR (Status)) {
-      return EFI_DEVICE_ERROR;
+      DEBUG ((DEBUG_ERROR, "[%a] UfsExecUicCommands failed with Status=%r\n", __func__, Status));
+      continue;
     }
 
     Status = UfsMmioRead32 (Private, UFS_HC_STATUS_OFFSET, &Data);
     if (EFI_ERROR (Status)) {
-      return EFI_DEVICE_ERROR;
+      DEBUG ((DEBUG_ERROR, "[%a] UfsMmioRead32 failed with Status=%r\n", __func__, Status));
+      continue;
     }
 
     if ((Data & UFS_HC_HCS_DP) == 0) {
       Status = UfsWaitMemSet (Private, UFS_HC_IS_OFFSET, UFS_HC_IS_ULSS, UFS_HC_IS_ULSS, UFS_TIMEOUT);
       if (EFI_ERROR (Status)) {
-        return EFI_DEVICE_ERROR;
+        DEBUG ((DEBUG_ERROR, "[%a] UfsWaitMemSet failed with Status=%r\n", __func__, Status));
+        continue;
       }
     } else {
       return EFI_SUCCESS;


### PR DESCRIPTION
# Description
Fix the logic in the UFS device detection APIs

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested
Boot tested

## Integration Instructions
N/A