### PR TITLE
MdeModulePkg/PciHostBridgeDxe: Ignore unsupported I/O BARs.

### DIFF
--- a/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostBridge.c
+++ b/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostBridge.c
@@ -1569,6 +1569,14 @@ SubmitResources (
         RootBridge->ResAllocNode[Type].Length    = Descriptor->AddrLen;
         RootBridge->ResAllocNode[Type].Alignment = Descriptor->AddrRangeMax;
         RootBridge->ResAllocNode[Type].Status    = ResSubmitted;
+        //
+        // If the PCI root bridge does not support IO space, do not submit requested resources
+        // for allocation.
+        //
+        if ((Type == TypeIo) && (RootBridge->Io.Base > RootBridge->Io.Limit)) {
+          DEBUG ((DEBUG_INFO, " I/O: Resource not submitted. Unsupported aperture.\n"));
+          RootBridge->ResAllocNode[Type].Status = ResNone;
+        }
       }
 
       RootBridge->ResourceSubmitted = TRUE;


### PR DESCRIPTION
# Description
Bootup fails when an endpoint requests I/O space BARs and the Root Bridge does not support I/O space causing a resource conflict during bus enumeration. While I/O space is traditionally supported in x86_64, platforms using an Arm architecture may or may not support I/O space.

This change adds logic allowing the platform to detect I/O space support for each Root Bridge and prevent submission of the required I/O resources for allocation when unsupported. Endpoints will not receive I/O resources, but they will continue to receive Memory BAR resources.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

- Boot on ARM64 platform with a mix of PCIe endpoints that request and do not request I/O Space BARs.

## Integration Instructions

- N/A
