### PR TITLE
BaseTools: Improve BaseTools/Source/C build flags

### DIFF
--- a/BaseTools/Source/C/Makefiles/header.makefile
+++ b/BaseTools/Source/C/Makefiles/header.makefile
@@ -158,16 +158,16 @@ BUILD_OPTFLAGS = -O2 $(EXTRA_OPTFLAGS)
 
 ifeq ($(DARWIN),Darwin)
 # assume clang or clang compatible flags on OS X
-CFLAGS = -MD -fshort-wchar -fno-strict-aliasing -Wall -Werror \
+CFLAGS = -MD -fno-strict-aliasing -Wall -Werror \
 -Wno-deprecated-declarations -Wno-self-assign -Wno-unused-result -nostdlib -g
 else
 ifneq ($(CLANG),)
-CFLAGS = -MD -fshort-wchar -fno-strict-aliasing -fwrapv \
+CFLAGS = -MD -fno-strict-aliasing -fwrapv \
 -fno-delete-null-pointer-checks -Wall -Werror \
 -Wno-deprecated-declarations -Wno-self-assign \
 -Wno-unused-result -nostdlib -g
 else
-CFLAGS = -MD -fshort-wchar -fno-strict-aliasing -fwrapv \
+CFLAGS = -MD -fno-strict-aliasing -fwrapv \
 -fno-delete-null-pointer-checks -Wall -Werror \
 -Wno-deprecated-declarations -Wno-stringop-truncation -Wno-restrict \
 -Wno-unused-result -nostdlib -g
@@ -180,6 +180,12 @@ else
 LDFLAGS =
 CXXFLAGS = -Wno-unused-result
 endif
+
+CPPFLAGS += -fshort-wchar -flto -DUSING_LTO
+ifeq ($(HOST_ARCH), X64)
+  CPPFLAGS += "-DEFIAPI=__attribute__((ms_abi))"
+endif
+
 ifeq ($(HOST_ARCH), IA32)
 #
 # Snow Leopard  is a 32-bit and 64-bit environment. uname -m returns i386, but gcc defaults


### PR DESCRIPTION
# Description

`-fshort-wchar` was previously applied to gcc commands in BaseTools/Source/C builds, but not to g++ commands. This should be applied to both or neither. This appears to date back to 00588512dc05929ff5a9a52830724bee16f72c40 when `%.o : %.cpp` support was added.

We additionally add `-DEFIAPI=__attribute__((ms_abi))` to X64 builds to match the UEFI convention in these builds (which is also the purpose of `-fshort-wchar`).

We also enable LTO, which is a nice-to-have, but also, interestingly, having it enabled is required for glibc 2.39 runtime hardening to catch genuine errors in VfrCompile, c.f. https://github.com/tianocore/edk2/pull/11777.

Note that the affected files within BaseTools/Source/C (those that include the changed file, and all those that those include) are:

```
Makefiles/app.makefile
Makefiles/lib.makefile
GNUmakefile
VfrCompile/GNUmakefile
Makefiles/footer.makefile
Makefiles/header.makefile
```

Note also that in VfrCompile/GNUmakefile these changes apply to g++ if put into CPPFLAGS, but not if put into CXXFLAGS.

- [ ] Breaking change?
  - NO.
- [ ] Impacts security?
  - NO.
- [ ] Includes tests?
  - NO.

## How This Was Tested

Confirm application of these flags in build log output. Confirm correct behaviour of everything.

## Integration Instructions

N/A