### PR TITLE
MdeModulePkg/Pei: Update image section alignment cast

### DIFF
--- a/MdeModulePkg/Core/Pei/Image/Image.c
+++ b/MdeModulePkg/Core/Pei/Image/Image.c
@@ -402,7 +402,7 @@ LoadAndRelocatePeCoffImage (
       if (ImageContext.SectionAlignment > EFI_PAGE_SIZE) {
         ImageContext.ImageAddress =
           (ImageContext.ImageAddress + ImageContext.SectionAlignment - 1) &
-          ~((UINTN)ImageContext.SectionAlignment - 1);
+          ~((EFI_PHYSICAL_ADDRESS)ImageContext.SectionAlignment - 1);
       }
 
       //


### PR DESCRIPTION
# Description

MSVC 14.44.35207 reports the following warning:

```
MdeModulePkg\Core\Pei\Image\Image.c(405): '~': zero extending
  'UINT32' to 'PHYSICAL_ADDRESS' of greater size.
```

This change casts the section alignment to `EFI_PHYSICAL_ADDRESS` to ensure consistent alignment mask generation.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

- CI
- Build with MSVC 14.44.35207

## Integration Instructions

- N/A