### PR TITLE
MdeModulePkg: Fix clang build regressions.

### DIFF
--- a/MdeModulePkg/Core/PiSmmCore/PiSmmIpl.c
+++ b/MdeModulePkg/Core/PiSmmCore/PiSmmIpl.c
@@ -1607,11 +1607,15 @@ GetFullSmramRanges (
   UINTN                           MaxCount;
   BOOLEAN                         Rescan;
 
+  SmmConfiguration    = NULL;
+  TempSmramRanges     = NULL;
+  SmramReservedRanges = NULL;
+  SmramRanges         = NULL;
+
   //
   // Get SMM Configuration Protocol if it is present.
   //
-  SmmConfiguration = NULL;
-  Status           = gBS->LocateProtocol (&gEfiSmmConfigurationProtocolGuid, NULL, (VOID **)&SmmConfiguration);
+  Status = gBS->LocateProtocol (&gEfiSmmConfigurationProtocolGuid, NULL, (VOID **)&SmmConfiguration);
 
   //
   // Get SMRAM information.

--- a/MdeModulePkg/Universal/BdsDxe/BdsEntry.c
+++ b/MdeModulePkg/Universal/BdsDxe/BdsEntry.c
@@ -699,6 +699,7 @@ BdsEntry (
 
   HotkeyTriggered = NULL;
   Status          = EFI_SUCCESS;
+  BootSuccess     = FALSE;
 
   //
   // Insert the performance probe

--- a/MdeModulePkg/Universal/HiiDatabaseDxe/ConfigRouting.c
+++ b/MdeModulePkg/Universal/HiiDatabaseDxe/ConfigRouting.c
@@ -795,6 +795,7 @@ CompareNameElementDefault (
 
   AppendString  = NULL;
   NvConfigExist = NULL;
+  Status        = EFI_OUT_OF_RESOURCES;
   //
   // Make NvConfigPtr point to the first <NvConfig> with AltConfigHdr in DefaultAltCfgResp.
   //

--- a/MdeModulePkg/Universal/SetupBrowserDxe/IfrParse.c
+++ b/MdeModulePkg/Universal/SetupBrowserDxe/IfrParse.c
@@ -430,8 +430,11 @@ CreateStorage (
   EFI_GUID         *StorageGuid;
   CHAR8            *StorageName;
 
-  UnicodeString = NULL;
-  StorageName   = NULL;
+  UnicodeString  = NULL;
+  StorageName    = NULL;
+  BrowserStorage = NULL;
+  Storage        = NULL;
+
   switch (StorageType) {
     case EFI_HII_VARSTORE_BUFFER:
       StorageGuid = (EFI_GUID *)(CHAR8 *)&((EFI_IFR_VARSTORE *)OpCodeData)->Guid;


### PR DESCRIPTION
# Description

Address the build regressions, introduced in https://github.com/tianocore/edk2/pull/11724, https://github.com/tianocore/edk2/pull/11688, https://github.com/tianocore/edk2/pull/11686 https://github.com/tianocore/edk2/pull/11685.

These build regressions are for uninitialized variables before use.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested
Local CI using clangdwarf as tool chain target.

## Integration Instructions
No integration necessary.