### PR TITLE
ArmPkg/ArmPsciMpServices: Prevent SIMD traps on secondary cores

### DIFF
--- a/ArmPkg/Drivers/ArmPsciMpServicesDxe/MpFuncs.S
+++ b/ArmPkg/Drivers/ArmPsciMpServicesDxe/MpFuncs.S
@@ -20,6 +20,7 @@ GCC_ASM_IMPORT (gApStackSize)
 GCC_ASM_IMPORT (gTcr)
 GCC_ASM_IMPORT (gTtbr0)
 GCC_ASM_IMPORT (gMair)
+GCC_ASM_IMPORT (ArmEnableVFP)
 
 GCC_ASM_EXPORT (ApEntryPoint)
 
@@ -65,6 +66,7 @@ ASM_PFX(ApEntryPoint):
   mul x3, x2, x1              // x3 = (ProcessorIndex + 1) * gApStackSize
   add sp, x0, x3              // sp = gApStacksBase + x3
   mov x29, xzr
+  bl ArmEnableVFP             // Do not trap SIMD instructions
   bl ApProcedure              // doesn't return
 
 ProcessorNotFound:


### PR DESCRIPTION
# Description
On AArch64, PrePi/SEC configures the primary core to avoid trapping VFP/SIMD exceptions.However, when ArmPsciMpServicesDxe enables secondary cores, FP/SIMD access is not configured, causing traps on SIMD instructions.

Set FPEN bits 21:20[1] in CPACR_EL1 for secondary cores to allow FP/SIMD instructions at EL1 and prevent VFP exceptions from being trapped.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested
Tested on internal platform

## Integration Instructions
N/A
