### PR TITLE
OvmfPkg/Sec: Refactor SevEsIsEnabled condition in SecCoreStartupWithS…

### DIFF
--- a/OvmfPkg/Sec/SecMain.c
+++ b/OvmfPkg/Sec/SecMain.c
@@ -883,23 +883,20 @@ SecCoreStartupWithStack (
     //
     AsmWriteIdtr (&IdtDescriptor);
     InitializeCpuExceptionHandlers (NULL);
-  }
-
-  ProcessLibraryConstructorList ();
-
-  if (!SevEsIsEnabled ()) {
-    //
-    // For non SEV-ES guests, just load the IDTR.
-    //
-    AsmWriteIdtr (&IdtDescriptor);
-  } else {
     //
     // Under SEV-ES, the hypervisor can't modify CR0 and so can't enable
     // caching in order to speed up the boot. Enable caching early for
     // an SEV-ES guest.
     //
     AsmEnableCache ();
+  } else {
+    //
+    // For non SEV-ES guests, just load the IDTR.
+    //
+    AsmWriteIdtr (&IdtDescriptor);
   }
+
+  ProcessLibraryConstructorList ();
 
  #if defined (TDX_GUEST_SUPPORTED)
   if (CcProbe () == CcGuestTypeIntelTdx) {


### PR DESCRIPTION
# Description
This PR makes small refactor in SecCoreStartupWithStack() function particularly combines two SEV condition check one for loading IDT and initializing exceptions, and the other is enabling caches for SEV guests.

Since AsmWriteIdtr() and AsmEnableCache() don't depend on any library constructor, it is safe to combine those two conditions into one which makes code flow like this:

If it is SEV guest : 
  - Write to IDTR
  - Initialize exceptions.
  - Then enable caches.

else : 
  - for non SEV guests just load IDT into IDTR
 
And then call ProcessLibraryConstructorList (). Thus eliminating the condition below ProcessLibraryConstructorList(), because it is not needed anymore.

- [x] Breaking change?
  - No breakage observed
- [ ] Impacts security?
  - NO
- [ ] Includes tests?
  - NO

## How This Was Tested
On OVMF image with platform architecture is X64
## Integration Instructions
N/A
