### PR TITLE
SecurityPkg/HashLibTpm2: Fix unused variable usage

### DIFF
--- a/SecurityPkg/Library/HashLibTpm2/HashLibTpm2PeilessSecLib.c
+++ b/SecurityPkg/Library/HashLibTpm2/HashLibTpm2PeilessSecLib.c
@@ -586,9 +586,7 @@ HasLibTpm2PeilessSecLibConstructor (
   }
 
   TcgPcrEvent             = (TCG_PCR_EVENT *)EventLog;
-  TcgEfiSpecIdEventStruct = (TCG_EfiSpecIDEventStruct *)
-                            (EventLog + OFFSET_OF (TCG_PCR_EVENT, Event));
-
+  TcgEfiSpecIdEventStruct = (TCG_EfiSpecIDEventStruct *)TcgPcrEvent->Event;
   CopyMem (&NumberOfAlgorithms, TcgEfiSpecIdEventStruct + 1, sizeof (NumberOfAlgorithms));
   DigestSize = (TCG_EfiSpecIdEventAlgorithmSize *)((UINT8 *)TcgEfiSpecIdEventStruct + sizeof (*TcgEfiSpecIdEventStruct) + sizeof (NumberOfAlgorithms));
 


### PR DESCRIPTION
# Description

There is an unused variable in SecurityPkg/Library/HashLibTpm2/HashLibTpm2PeilessSecLib.c which is spotted by CLANG builds.

The correct fix here is not to just remove the unused assignment, but rather to fix the line following it, which should have been using the unused value in the way that it now does.

Fixes: https://github.com/tianocore/edk2/commit/9c651ef83a74d83219075316aa5d1c189ed608c8

- [ ] Breaking change?
  - NO.
- [ ] Impacts security?
  - NO.
- [ ] Includes tests?
  - NO.

## How This Was Tested

CI. Peer advice. Has not been run.

## Integration Instructions

N/A