### PR TITLE
.github: Use valid Fedora 43 image for BuildPlatform workflow

### DIFF
--- a/.github/workflows/BuildPlatform.yml
+++ b/.github/workflows/BuildPlatform.yml
@@ -61,7 +61,7 @@ jobs:
 
     runs-on: ${{ inputs.runs-on }}
     container:
-      image: ${{ startswith(inputs.runs-on, 'ubuntu') && 'ghcr.io/tianocore/containers/fedora-43-v:latest' || '' }}
+      image: ${{ startswith(inputs.runs-on, 'ubuntu') && 'ghcr.io/tianocore/containers/fedora-43-dev:latest' || '' }}
 
     steps:
       - name: Checkout


### PR DESCRIPTION
# Description

commit 96158b3 had a typo that updated fedora to an invalid container. This was not caught in the workflows pre-CI as this particular workflow only runs post-merge.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Ran Workflow on this branch

## Integration Instructions

N/A
