### PR TITLE
Improve handling of MmAccess return status

### DIFF
--- a/StandaloneMmPkg/Drivers/StandaloneMmIplPei/StandaloneMmIplPei.c
+++ b/StandaloneMmPkg/Drivers/StandaloneMmIplPei/StandaloneMmIplPei.c
@@ -675,6 +675,7 @@ ExecuteMmCoreFromMmram (
   )
 {
   EFI_STATUS                      Status;
+  EFI_STATUS                      AccessStatus;
   UINTN                           PageCount;
   VOID                            *MmHobList;
   UINTN                           MmHobSize;
@@ -823,11 +824,10 @@ Done:
     // Close all MMRAM ranges, if MmAccess is available.
     //
     for (Index = 0; Index < MmramRangeCount; Index++) {
-      Status = MmAccess->Close ((EFI_PEI_SERVICES **)GetPeiServicesTablePointer (), MmAccess, Index);
-      if (EFI_ERROR (Status)) {
-        DEBUG ((DEBUG_ERROR, "MM IPL failed to close MMRAM windows index %d - %r\n", Index, Status));
+      AccessStatus = MmAccess->Close ((EFI_PEI_SERVICES **)GetPeiServicesTablePointer (), MmAccess, Index);
+      if (EFI_ERROR (AccessStatus)) {
+        DEBUG ((DEBUG_ERROR, "MM IPL failed to close MMRAM windows index %d - %r\n", Index, AccessStatus));
         ASSERT (FALSE);
-        return Status;
       }
 
       //
@@ -838,18 +838,17 @@ Done:
       //
       // Lock the MMRAM (Note: Locking MMRAM may not be supported on all platforms)
       //
-      Status = MmAccess->Lock ((EFI_PEI_SERVICES **)GetPeiServicesTablePointer (), MmAccess, Index);
-      if (EFI_ERROR (Status)) {
+      AccessStatus = MmAccess->Lock ((EFI_PEI_SERVICES **)GetPeiServicesTablePointer (), MmAccess, Index);
+      if (EFI_ERROR (AccessStatus) && (AccessStatus != EFI_UNSUPPORTED)) {
         //
         // Print error message that the MMRAM failed to lock...
         //
-        DEBUG ((DEBUG_ERROR, "MM IPL could not lock MMRAM (Index %d) after executing MM Core %r\n", Index, Status));
+        DEBUG ((DEBUG_ERROR, "MM IPL could not lock MMRAM (Index %d) after executing MM Core %r\n", Index, AccessStatus));
         ASSERT (FALSE);
-        return Status;
       }
 
       //
-      // Print debug message that the MMRAM window is now closed.
+      // Print debug message that the MMRAM window is now locked.
       //
       DEBUG ((DEBUG_INFO, "MM IPL locked MMRAM window index %d\n", Index));
     }


### PR DESCRIPTION
# Description

Previously, if an MmAccess call failed during locking and closing a MMRAM region, the logic would bail out the entire loop, leaving subsequent regions open. Additionally, the failure status was stored in `Status`, overwriting values from earlier steps.

This update introduces proper handling for MmAccess PPI failures and ensures best-effort attempts to close and lock all regions when possible.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

This was tested on QEMU Q35 virtual platform and booted to UEFI shell.

## Integration Instructions

N/A
