### PR TITLE
OvmfPkg/RisvVVirt: Add missing Tcg2ConfigPei and Tcg2Pei modules in FV

### DIFF
--- a/OvmfPkg/RiscVVirt/RiscVVirtQemu.dsc
+++ b/OvmfPkg/RiscVVirt/RiscVVirtQemu.dsc
@@ -322,7 +322,6 @@
       NULL|MdeModulePkg/Library/LzmaCustomDecompressLib/LzmaCustomDecompressLib.inf
   }
 !if $(TPM2_ENABLE) == TRUE
-  OvmfPkg/Tcg/Tcg2Config/Tcg2ConfigPei.inf
   SecurityPkg/Tcg/Tcg2Pei/Tcg2Pei.inf {
     <LibraryClasses>
       Tpm2DeviceLib|SecurityPkg/Library/Tpm2DeviceLibRouter/Tpm2DeviceLibRouterPei.inf
@@ -338,6 +337,9 @@
     <LibraryClasses>
       TpmPlatformHierarchyLib|SecurityPkg/Library/PeiDxeTpmPlatformHierarchyLib/PeiDxeTpmPlatformHierarchyLib.inf
   }
+!if $(TPM2_CONFIG_ENABLE) == TRUE
+  OvmfPkg/Tcg/Tcg2Config/Tcg2ConfigPei.inf
+!endif
 !endif
 !else
   UefiCpuPkg/SecCore/SecCoreNative.inf {

--- a/OvmfPkg/RiscVVirt/RiscVVirtQemu.fdf
+++ b/OvmfPkg/RiscVVirt/RiscVVirtQemu.fdf
@@ -283,6 +283,12 @@ INF  UefiCpuPkg/SecCore/SecCoreNative.inf
   INF  MdeModulePkg/Universal/PCD/Pei/Pcd.inf
   INF  MdeModulePkg/Universal/Variable/Pei/VariablePei.inf
   INF  MdeModulePkg/Core/DxeIplPeim/DxeIpl.inf
+!if $(TPM2_ENABLE) == TRUE
+  INF SecurityPkg/Tcg/Tcg2Pei/Tcg2Pei.inf
+!if $(TPM2_CONFIG_ENABLE) == TRUE
+  INF OvmfPkg/Tcg/Tcg2Config/Tcg2ConfigPei.inf
+!endif
+!endif
 !endif
 
 FILE FV_IMAGE = 9E21FD93-9C72-4c15-8C4B-E77F1DB2D792 {


### PR DESCRIPTION
# Description

Resolve an issue where the TPM2 device failed to be detected because the Tcg2ConfigPei and Tcg2Pei modules were not included in the firmware volume.

This fix the issue: https://github.com/tianocore/edk2/issues/11360

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested
Please refer to https://github.com/tianocore/edk2/issues/11360 for how to test this patch.

## Integration Instructions
N/A
