### PR TITLE
MdeModulePkg/UsbBusDxe: Improve USB enumerating process

### DIFF
--- a/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbBus.h
+++ b/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbBus.h
@@ -143,6 +143,16 @@ typedef struct _USB_HUB_API    USB_HUB_API;
 #define USB_BUS_FROM_THIS(a) \
           CR(a, USB_BUS, BusId, USB_BUS_SIGNATURE)
 
+#define USB_CONFIG_DESC_DEF_ALLOC_LEN  255
+
+typedef enum {
+  UsbEnumScriptEdk2    = 0,         // 0   :EDK2 flow
+  UsbEnumScriptRsrv    = 1,         // 1   :Reserved flow - EDK2
+  UsbEnumScriptLinux   = 2,         // 2   :Linux flow
+  UsbEnumScriptWin     = 3,         // 3   :Window flow
+  UsbEnumScriptUnknown = 0xFF,      // 0xff:Unknow flow
+} USB_ENUM_SCRIPT_TYPE;
+
 //
 // Used to locate USB_BUS
 // UsbBusProtocol is the private protocol.
@@ -188,6 +198,7 @@ struct _USB_DEVICE {
   UINT8                                 ParentPort; // Start at 0
   UINT8                                 Tier;
   BOOLEAN                               DisconnectFail;
+  UINT8                                 EnumScript;
 };
 
 //

--- a/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbDesc.c
+++ b/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbDesc.c
@@ -611,6 +611,21 @@ UsbGetDevDesc (
   if (EFI_ERROR (Status)) {
     gBS->FreePool (DevDesc);
   } else {
+    // Do DevDesc sanity check
+    if (  (DevDesc->Desc.DescriptorType != USB_DESC_TYPE_DEVICE)
+       || (DevDesc->Desc.Length != sizeof (EFI_USB_DEVICE_DESCRIPTOR))
+       || (  (UsbDev->Speed != EFI_USB_SPEED_SUPER)
+          && (DevDesc->Desc.MaxPacketSize0 != 8)
+          && (DevDesc->Desc.MaxPacketSize0 != 16)
+          && (DevDesc->Desc.MaxPacketSize0 != 32)
+          && (DevDesc->Desc.MaxPacketSize0 != 64))
+       || (DevDesc->Desc.NumConfigurations == 0))
+    {
+      gBS->FreePool (DevDesc);
+      Status = EFI_DEVICE_ERROR;
+      return Status;
+    }
+
     UsbDev->DevDesc = DevDesc;
   }
 
@@ -751,12 +766,31 @@ UsbGetOneConfig (
   EFI_USB_CONFIG_DESCRIPTOR  Desc;
   EFI_STATUS                 Status;
   VOID                       *Buf;
+  UINT8                      BufDesc[USB_CONFIG_DESC_DEF_ALLOC_LEN];
 
   //
   // First get four bytes which contains the total length
   // for this configuration.
   //
-  Status = UsbCtrlGetDesc (UsbDev, USB_DESC_TYPE_CONFIG, Index, 0, &Desc, 8);
+  switch (UsbDev->EnumScript) {
+    case UsbEnumScriptWin:
+      ZeroMem (BufDesc, USB_CONFIG_DESC_DEF_ALLOC_LEN);
+      Status = UsbCtrlGetDesc (UsbDev, USB_DESC_TYPE_CONFIG, Index, 0, BufDesc, USB_CONFIG_DESC_DEF_ALLOC_LEN);
+      if (!EFI_ERROR (Status)) {
+        CopyMem (&Desc, BufDesc, sizeof (EFI_USB_CONFIG_DESCRIPTOR));
+      }
+
+      break;
+    case UsbEnumScriptLinux:
+      Status = UsbCtrlGetDesc (UsbDev, USB_DESC_TYPE_CONFIG, Index, 0, &Desc, sizeof (EFI_USB_CONFIG_DESCRIPTOR));
+      break;
+    case UsbEnumScriptRsrv:
+    case UsbEnumScriptEdk2:
+    case UsbEnumScriptUnknown:
+    default:
+      Status = UsbCtrlGetDesc (UsbDev, USB_DESC_TYPE_CONFIG, Index, 0, &Desc, 8);
+      break;
+  }
 
   if (EFI_ERROR (Status)) {
     DEBUG ((
@@ -784,13 +818,17 @@ UsbGetOneConfig (
     return NULL;
   }
 
-  Status = UsbCtrlGetDesc (UsbDev, USB_DESC_TYPE_CONFIG, Index, 0, Buf, Desc.TotalLength);
+  if ((UsbDev->EnumScript == UsbEnumScriptWin) && (Desc.TotalLength <= USB_CONFIG_DESC_DEF_ALLOC_LEN)) {
+    CopyMem (Buf, BufDesc, Desc.TotalLength);
+  } else {
+    Status = UsbCtrlGetDesc (UsbDev, USB_DESC_TYPE_CONFIG, Index, 0, Buf, Desc.TotalLength);
 
-  if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "UsbGetOneConfig: failed to get full descript - %r\n", Status));
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "UsbGetOneConfig: failed to get full descript - %r\n", Status));
 
-    FreePool (Buf);
-    return NULL;
+      FreePool (Buf);
+      return NULL;
+    }
   }
 
   return Buf;


### PR DESCRIPTION
MdeModulePkg/UsbBusDxe: Improve USB enumerating process

The patch enhances the USB enumeration process in EDK2 to improve
compatibility with non-standards-compliant devices that may fail during
standard enumeration sequences.
The suggested solution is based on USB specifications and references
implementations from both Linux and Windows environments.

[Suggested solution]
- Integrated a retry mechanism to sequentially execute enumeration scripts,
  inspired by the enumeration flows of Windows, Linux, and EDK2.
  This improves robustness when handling corner-case devices.
- Do sanity check while the device report the device descriptor.
- AMD XHCI might need to wait for more time while sending the CLEAR_FEATURE
  reuqest.

Signed-off-by: Marlboro_Chuang <marlboro.chuang@dell.com>