### PR TITLE
UefiCpuPkg/MpInitLib: Fix possible debug log spam in FillExchangeInfo…

### DIFF
--- a/UefiCpuPkg/Library/MpInitLib/MpLib.c
+++ b/UefiCpuPkg/Library/MpInitLib/MpLib.c
@@ -1038,7 +1038,6 @@ FillExchangeInfoData (
   //
   Cr4.UintN                        = AsmReadCr4 ();
   ExchangeInfo->Enable5LevelPaging = (BOOLEAN)(Cr4.Bits.LA57 == 1);
-  DEBUG ((DEBUG_INFO, "%a: 5-Level Paging = %d\n", gEfiCallerBaseName, ExchangeInfo->Enable5LevelPaging));
 
   ExchangeInfo->SevEsIsEnabled        = CpuMpData->SevEsIsEnabled;
   ExchangeInfo->SevSnpIsEnabled       = CpuMpData->SevSnpIsEnabled;


### PR DESCRIPTION
# Description
The message log in FillExchangeInfoData() is always unconditionally printed every time the function called. Due frequent call of this function it could result to repeatedly being logged more than once.
    
Remove the debug log since there are already other places being logged
the availability of 5-Level paging. This makes the log unnecessary.

On my test environment it have been logged 9 times at minimum and more depending usage of services StartupAllAps() and StartupThisAp() since most of the time Aps are waken by complete INIT-SIPI-SIPI in my case.

- [ ] Breaking change?
  - NO
- [ ] Impacts security?
  - NO
- [ ] Includes tests?
  - NO

## How This Was Tested
qemu with OVMF X64 image

## Integration Instructions
N/A