### PR TITLE
BaseTools/EfiRom: fix compiler warning

### DIFF
--- a/BaseTools/Source/C/EfiRom/EfiRom.c
+++ b/BaseTools/Source/C/EfiRom/EfiRom.c
@@ -44,7 +44,6 @@ Returns:
   FILE_LIST *FList;
   UINT32    TotalSize;
   UINT32    Size;
-  CHAR8     *Ptr0;
 
   SetUtilityName(UTILITY_NAME);
 
@@ -75,7 +74,7 @@ Returns:
   //
   if (mOptions.DumpOption == 1) {
     if (mOptions.FileList != NULL) {
-      if ((Ptr0 = strstr ((CONST CHAR8 *) mOptions.FileList->FileName, DEFAULT_OUTPUT_EXTENSION)) != NULL) {
+      if (strstr ((CONST CHAR8 *) mOptions.FileList->FileName, DEFAULT_OUTPUT_EXTENSION) != NULL) {
         DumpImage (mOptions.FileList);
         goto BailOut;
       } else {


### PR DESCRIPTION
# Description

New warning after updating gcc:

EfiRom.c: In function ‘main’:
EfiRom.c:78:17: error: assignment discards ‘const’ qualifier from pointer target type [-Werror=discarded-qualifiers]

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

Build BaseTools on Fedora/rawhide

## Integration Instructions

N/A
