### PR TITLE
MdeModulePkg: Fix FreePages not existent memory

### DIFF
--- a/MdeModulePkg/Core/Dxe/Mem/Page.c
+++ b/MdeModulePkg/Core/Dxe/Mem/Page.c
@@ -1772,7 +1772,8 @@ CoreFreePages (
     // free memory that is marked RO, which can crash the core if DebugClearMemory is enabled or can be passed out to a
     // driver in the next AllocatePages() call, which can cause a crash later on. It is deemed lower risk to leak the
     // memory than to attempt to fix up the attributes as that requires syncing the GCD and the page table.
-    if (EFI_ERROR (Status) || (Attributes & EFI_MEMORY_RO) || (Attributes & EFI_MEMORY_RP)) {
+    if ((Status == EFI_NO_MAPPING) ||
+        (!EFI_ERROR (Status) && ((Attributes & EFI_MEMORY_RO) || (Attributes & EFI_MEMORY_RP)))) {
       DEBUG ((
         DEBUG_WARN,
         "%a: Memory %llx for %llx Pages failed to get attributes with status %r or it is read-only or read-protected. "


### PR DESCRIPTION
# Description

Commit 2d69507a4dde02f1abf20c7eb3a43d1d3ef6b98f added an attribute check to prevent freeing memory that is read-only, read-protected, or for which attribute retrieval fails. In such cases the code returned EFI_SUCCESS and leaked the memory.

This introduced a regression in the System Architecture Compliance Suite (ACS) BS.FreePages – Not Existent Memory test.
Link: https://github.com/tianocore/edk2-test/blob/edk2-test-stable202509/uefi-sct/Doc/TestCaseSpec/03_Services_Boot_Services.md#freepages Test number: 5.1.2.2.1

GetMemoryAttributes() returns EFI_UNSUPPORTED for memory regions outside system memory. The previous change treated all errors as a reason to leak memory, while only the EFI_NO_MAPPING error code should trigger that behavior. As a result, freeing non-existent memory incorrectly returned EFI_SUCCESS instead of EFI_NOT_FOUND.

To fix this, memory is now leaked only when:
- GetMemoryAttributes() returns EFI_NO_MAPPING (inconsistent attributes), or
- GetMemoryAttributes() succeeds and the pages are marked RO or RP.

All other errors fall through to CoreInternalFreePages(), restoring the previous and correct behavior.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Tested by running ACS on a custom FVP

## Integration Instructions

N/A
