### PR TITLE
ArmVirtPkg: Increase firmware size

### DIFF
--- a/ArmVirtPkg/ArmVirt.dsc.inc
+++ b/ArmVirtPkg/ArmVirt.dsc.inc
@@ -17,12 +17,8 @@
 
   DEFINE DEBUG_PRINT_ERROR_LEVEL = 0x8000004F
 
-# Dynamic stack cookies pushes the FD size up slightly over 2MB
-!if $(TARGET) != NOOPT
-  DEFINE FD_SIZE_IN_MB    = 2
-!else
-  DEFINE FD_SIZE_IN_MB    = 3
-!endif
+# Various builds now exceed 2MB so choose 3MB as the default.
+DEFINE FD_SIZE_IN_MB    = 3
 
 !if $(FD_SIZE_IN_MB) == 2
   DEFINE FD_SIZE          = 0x200000


### PR DESCRIPTION
# Description

Although almost all tool chain plus package combinations currently stay under the 2MB firmware size, except for NOOPT builds, ArmVirtQemu DEBUG built with CLANGDWARF now sneaks over.

Noting that images will be padded to 64MB for before use anyway, we now choose 3MB as the default for all. But keep the 2MB vs. 3MB code which checks FD_SIZE_IN_MB, in this and other files, available for reference the next time a size change is needed.

- [ ] Breaking change?
  - NO.
- [ ] Impacts security?
  - NO.
- [ ] Includes tests?
  - NO.

## How This Was Tested

CI

## Integration Instructions

N/A