### PR TITLE
MdeModulePkg: Fix boot failure intrioduced by #11807

### DIFF
--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciOptionRomSupport.c
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciOptionRomSupport.c
@@ -706,7 +706,7 @@ ProcessOpRomImage (
     // Skip the EFI PCI Option ROM image if it's machine type is not supported
     // and the native image is only considered.
     //
-    if (!EFI_IMAGE_MACHINE_TYPE_SUPPORTED (EfiRomHeader->EfiMachineType) && (NativeOnly == TRUE)) {
+    if (EFI_IMAGE_MACHINE_TYPE_SUPPORTED (EfiRomHeader->EfiMachineType) ^ (NativeOnly == TRUE)) {
       goto NextImage;
     }
 


### PR DESCRIPTION
# Description

The changes introduced by #11807 resulted boot hang on platforms where one OpRom image is present. Due two calls to ProcessOpRomImage() which in turns two calls to AddDriver() respectively. This behaiviour resulted the same image device path to be appended twice in PCI_DRIVER_OVERRIDE_LIST. Which resulted breakage in those environment. 

This also has side effect on iteration done by EFI_BUS_SPECIFIC_DRIVER_OVERRIDE_PROTOCOL.GetDriver when getting the image handle via device path, which resulted the same image handle to be retrieved and stored twice.

Solution is, making sure only once is appended to the list and skipping it, if already appended. 

I am welcome to more solutions that could fix that bug.

- [ ] Breaking change?
  - NO
- [ ] Impacts security?
  - NO
- [ ] Includes tests?
  - NO

## How This Was Tested
On OVMF X64 build target DEBUG, run under qemu.
## Integration Instructions
N/A