### PR TITLE
UefiCpuPkg/CpuExceptionHandlerLib:  Add LOONGARCH_IOCSR_MBUF3 RereadCount

### DIFF
--- a/UefiCpuPkg/Library/CpuExceptionHandlerLib/LoongArch/LoongArch64/ArchExceptionHandler.c
+++ b/UefiCpuPkg/Library/CpuExceptionHandlerLib/LoongArch/LoongArch64/ArchExceptionHandler.c
@@ -244,6 +244,7 @@ IpiInterruptHandler (
   UINTN  ResumeVector = 0;
   UINTN  Parameter    = 0;
   UINTN  IpiStatus    = 0;
+  UINT8  RereadCount  = 10;
 
   IpiStatus = IoCsrRead32 (LOONGARCH_IOCSR_IPI_STATUS);
 
@@ -277,7 +278,7 @@ IpiInterruptHandler (
         //
         do {
           Parameter = IoCsrRead32 (LOONGARCH_IOCSR_MBUF3);
-        } while (!Parameter);
+        } while (!Parameter && --RereadCount);
 
         //
         // Get the parameter if populated.


### PR DESCRIPTION

# Description

If the multi-core IPI trapping into an SMP_CALL_FUNCTION interrupt is used, then the Context will be allowed to be null.


## How This Was Tested

Tested on LoongArch-3C6000 platform



## Integration Instructions

N/A