### PR TITLE
﻿MdeModulePkg/PciBusDxe: Fix UINT8 overflow in PciAllocateBusNumber

### DIFF
--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciLib.c
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciLib.c
@@ -1025,7 +1025,7 @@ PciAllocateBusNumber (
 {
   PCI_IO_DEVICE                      *RootBridge;
   EFI_ACPI_ADDRESS_SPACE_DESCRIPTOR  *BusNumberRanges;
-  UINT8                              NextNumber;
+  UINT16                             NextNumber;
   UINT64                             MaxNumberInRange;
 
   //
@@ -1043,18 +1043,18 @@ PciAllocateBusNumber (
   while (BusNumberRanges->Desc != ACPI_END_TAG_DESCRIPTOR) {
     MaxNumberInRange = BusNumberRanges->AddrRangeMin + BusNumberRanges->AddrLen - 1;
     if ((StartBusNumber >= BusNumberRanges->AddrRangeMin) && (StartBusNumber <=  MaxNumberInRange)) {
-      NextNumber = (UINT8)(StartBusNumber + NumberOfBuses);
+      NextNumber = (StartBusNumber + NumberOfBuses);
       while (NextNumber > MaxNumberInRange) {
         ++BusNumberRanges;
         if (BusNumberRanges->Desc == ACPI_END_TAG_DESCRIPTOR) {
           return EFI_OUT_OF_RESOURCES;
         }
 
-        NextNumber       = (UINT8)(NextNumber + (BusNumberRanges->AddrRangeMin - (MaxNumberInRange + 1)));
+        NextNumber       = (UINT16)(NextNumber + (BusNumberRanges->AddrRangeMin - (MaxNumberInRange + 1)));
         MaxNumberInRange = BusNumberRanges->AddrRangeMin + BusNumberRanges->AddrLen - 1;
       }
 
-      *NextBusNumber = NextNumber;
+      *NextBusNumber = (UINT8)NextNumber;
       return EFI_SUCCESS;
     }
 


### PR DESCRIPTION
# Description

When StartBusNumber is 0xFF NextNumber would overflow and wrap back to 0. This will be bypass check NextNumber > MaxNumberInRange as a result PCI enumeration will continue instead of breaking due to lack of resources.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

PCI hierarchy causing this issue was enumerated again with this fix and enumeration reported lack of resources as expected.

## Integration Instructions

N/A
