### PR TITLE
BdsDxe: Connect all controllers before PXE boot to expose SNP on all NICs

### DIFF
--- a/MdeModulePkg/Universal/BdsDxe/BdsEntry.c
+++ b/MdeModulePkg/Universal/BdsDxe/BdsEntry.c
@@ -948,6 +948,8 @@ BdsEntry (
     Print (L"**  WARNING: Test Key is used.  **\n");
   }
 
+  EfiBootManagerConnectAll ();
+
   //
   // Boot to Boot Manager Menu when EFI_OS_INDICATIONS_BOOT_TO_FW_UI is set. Skip HotkeyBoot
   //


### PR DESCRIPTION
# Problem statement

When booting via UEFI PXE on OVMF, only the network interface selected by the active PXE Boot option is connected by BDS and receives EFI_SIMPLE_NETWORK_PROTOCOL (SNP).

All other network controllers remain unconnected at the time the PXE NBP is executed, even though:
* the corresponding devices are present,
* the required DXE drivers are available,

As a result, EFI applications that enumerate network interfaces via SNP (for example snp.efi from iPXE) can only see a single interface under OVMF, while on real hardware vendor UEFI implementations typically expose SNP on all available NICs.

This makes it difficult to develop and test multi-interface SNP-based EFI applications in OVMF/QEMU environments.

# Root cause

In the current OVMF boot flow:
* BDS connects only the controllers required to satisfy the selected PXE Boot option.
* Other controllers are left unconnected.
* Consequently, EFI_SIMPLE_NETWORK_PROTOCOL is installed only on the boot-time NIC.

# Tested configurations

* QEMU + OVMF (DEBUG build)
* Multiple virtio-net interfaces
* UEFI PXE boot
* snp.efi enumeration of multiple network interfaces
* virtio-rng present (required for network stack initialization)