### PR TITLE
MdeModulePkg: Fix regressions from 11687, 11689.

### DIFF
--- a/MdeModulePkg/Universal/BdsDxe/BdsEntry.c
+++ b/MdeModulePkg/Universal/BdsDxe/BdsEntry.c
@@ -832,24 +832,31 @@ BdsEntry (
   // file path for removable media if the platform supports Platform Recovery.
   //
   if (PlatformDefaultBootOptionValid && PcdGetBool (PcdPlatformRecoverySupport)) {
+    //
+    // Get the current PlatformRecovery options. Check if the platform recovery already exists, or
+    // find the next unused platform recovery option number so it can be created
+    //
+    Index       = 0;
     LoadOptions = EfiBootManagerGetLoadOptions (&LoadOptionCount, LoadOptionTypePlatformRecovery);
-    if ((LoadOptions != NULL) &&  (EfiBootManagerFindLoadOption (&PlatformDefaultBootOption, LoadOptions, LoadOptionCount) == -1)) {
-      for (Index = 0; Index < LoadOptionCount; Index++) {
-        //
-        // The PlatformRecovery#### options are sorted by OptionNumber.
-        // Find the the smallest unused number as the new OptionNumber.
-        //
-        if (LoadOptions[Index].OptionNumber != Index) {
-          break;
+    if (LoadOptions != NULL) {
+      if (EfiBootManagerFindLoadOption (&PlatformDefaultBootOption, LoadOptions, LoadOptionCount) == -1) {
+        for ( ; Index < LoadOptionCount; Index++) {
+          //
+          // The PlatformRecovery#### options are sorted by OptionNumber.
+          // Find the the smallest unused number as the new OptionNumber.
+          //
+          if (LoadOptions[Index].OptionNumber != Index) {
+            break;
+          }
         }
       }
 
-      PlatformDefaultBootOption.OptionNumber = Index;
-      Status                                 = EfiBootManagerLoadOptionToVariable (&PlatformDefaultBootOption);
-      ASSERT_EFI_ERROR (Status);
+      EfiBootManagerFreeLoadOptions (LoadOptions, LoadOptionCount);
     }
 
-    EfiBootManagerFreeLoadOptions (LoadOptions, LoadOptionCount);
+    PlatformDefaultBootOption.OptionNumber = Index;
+    Status                                 = EfiBootManagerLoadOptionToVariable (&PlatformDefaultBootOption);
+    ASSERT_EFI_ERROR (Status);
   }
 
   FreePool (FilePath);

--- a/MdeModulePkg/Universal/DisplayEngineDxe/InputHandler.c
+++ b/MdeModulePkg/Universal/DisplayEngineDxe/InputHandler.c
@@ -1719,20 +1719,19 @@ TheKey:
         } else {
           if (CurrentOption == NULL) {
             ASSERT (CurrentOption != NULL);
-            break;
-          }
-
-          gUserInput->InputValue.Type = CurrentOption->OptionOpCode->Type;
-          if (IsValuesEqual (&Question->CurrentValue.Value, &CurrentOption->OptionOpCode->Value, gUserInput->InputValue.Type)) {
-            return EFI_DEVICE_ERROR;
           } else {
-            SetValuesByType (&gUserInput->InputValue.Value, &CurrentOption->OptionOpCode->Value, gUserInput->InputValue.Type);
+            gUserInput->InputValue.Type = CurrentOption->OptionOpCode->Type;
+            if (IsValuesEqual (&Question->CurrentValue.Value, &CurrentOption->OptionOpCode->Value, gUserInput->InputValue.Type)) {
+              return EFI_DEVICE_ERROR;
+            } else {
+              SetValuesByType (&gUserInput->InputValue.Value, &CurrentOption->OptionOpCode->Value, gUserInput->InputValue.Type);
+            }
           }
-
-          gST->ConOut->SetAttribute (gST->ConOut, SavedAttribute);
-
-          return EFI_SUCCESS;
         }
+
+        gST->ConOut->SetAttribute (gST->ConOut, SavedAttribute);
+
+        return EFI_SUCCESS;
 
       default:
         break;


### PR DESCRIPTION
# Description
11687 introduced a null check and break on the orderedlist carriage return input handler. The carriage return is a special case that should result in exiting the menu, but the null check that prevented null pointer access changed the logic to continue in the input wait loop.

Removed the break while still preventing null variable access and allow function to exit.

11689 introduced checks on the call to EfiBootManagerGetLoadOptions, but this encounterd a problem with the way that a default platform recovery option was created.
The default platform recovery option was attempting to go through existing recovery options to get the next available recovery option number. The introduced null check short circuited these additional calls and resulted in the platform recovery option not being created.

Modified the logic to no longer attempt to access recovery options when non exist, and still create the default platform recovery option.
- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested
Booting AmdSevBuild.py on 202511 and latest and have matching output
Local Platform CI with GCC, CLANGPDB and VS2022.

## Integration Instructions
No integration necessary. 