### PR TITLE
PrmPkg: Update SpellCheck Extended words

### DIFF
--- a/PrmPkg/PrmPkg.ci.yaml
+++ b/PrmPkg/PrmPkg.ci.yaml
@@ -100,6 +100,12 @@
           "keepoptionalheader",
           "odule",                  # note: appears in buffer ascii dump in documentation
           "oemid",
+          "prmconfig",
+          "prmcontextbufferlib",
+          "prmexportdescriptor",
+          "prminfo",
+          "prmloader",
+          "prmmodulediscoverylib",
           "prmopreg",
           "prmpecofflib",
           "prmpkg",


### PR DESCRIPTION
# Description

Add extended words to ci.yaml file for words noted by spell check when doing stuart_ci_build NO-TARGET build against PrmPkg.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

Run stuart_ci_build using NO-TARGET against PrmPkg. Fails with spelling errors before change and resolves after change.

## Integration Instructions

N/A
