### PR TITLE
UnitTestFrameworkPkg: Fix spelling issues

### DIFF
--- a/UnitTestFrameworkPkg/ReadMe.md
+++ b/UnitTestFrameworkPkg/ReadMe.md
@@ -1034,7 +1034,7 @@ file. This provides the default defines and library class mappings requires for 
 Lastly, in the case that the test build has specific dependent libraries associated with it,
 they should be added in the \<LibraryClasses\> sub-section for the INF file in the
 `[Components]` section of the DSC file. Note that it is within this sub-section where you can
-control whether the design or mock version of a component is linked into the test exectuable.
+control whether the design or mock version of a component is linked into the test executable.
 
 See this example in `SecurityPkgHostTest.dsc` where the `SecureBootVariableLib` design is
 being tested using mock versions of `UefiRuntimeServicesTableLib`, `PlatformPKProtectionLib`,
@@ -1263,7 +1263,7 @@ uses the same test fixture and makes use of its `RtServicesMock`, `Status`, and
 `SecureBootMode` variables.
 
 ```cpp
-TEST_F(SetSecureBootModeTest, PropogateModeToSetVar) {
+TEST_F(SetSecureBootModeTest, PropagateModeToSetVar) {
   EXPECT_CALL(RtServicesMock,
     gRT_SetVariable(
       Char16StrEq(EFI_CUSTOM_MODE_NAME),

--- a/UnitTestFrameworkPkg/UnitTestFrameworkPkg.ci.yaml
+++ b/UnitTestFrameworkPkg/UnitTestFrameworkPkg.ci.yaml
@@ -117,7 +117,8 @@
             "fexceptions",  # build flag for gtest
             "corthon",      # Contact GitHub account in Readme
             "mdkinney",     # Contact GitHub account in Readme
-            "spbrogan"      # Contact GitHub account in Readme
+            "spbrogan",     # Contact GitHub account in Readme
+            "uintn"
         ],
         "IgnoreStandardPaths": [],   # Standard Plugin defined paths that should be ignore
         "AdditionalIncludePaths": [] # Additional paths to spell check (wildcards supported)


### PR DESCRIPTION
# Description

Add "uintn" to extended words in ci.yaml and fix typos.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

Run stuart_ci_build for NO-TARGET against UnitTestFrameworkPkg and spelling errors detected.

Spelling errors resolved after applying this change.

## Integration Instructions

N/A
