### PR TITLE
UefiPayloadPkg: Fix the declaration of BL_CAPSULE_CALLBACK

### DIFF
--- a/UefiPayloadPkg/Include/Library/BlParseLib.h
+++ b/UefiPayloadPkg/Include/Library/BlParseLib.h
@@ -27,7 +27,7 @@ typedef RETURN_STATUS \
   VOID              *Param
   );
 
-typedef VOID \
+typedef VOID EFIAPI \
 (*BL_CAPSULE_CALLBACK) (
   EFI_PHYSICAL_ADDRESS  BaseAddress,
   UINT64                Length


### PR DESCRIPTION
…E_CALLBACK

When I attempted to compile using gcc with BOOTLOADER=COREBOOT, a type error occurred.

```
/home/merle/workspaces/tianocore/edk2/UefiPayloadPkg/UefiPayloadEntry/UefiPayloadEntry.c:476:27: error: passing argument 1 of ‘ParseCapsules’ from incompatible pointer type [-Wincompatible-pointer-types]
  476 |   Status = ParseCapsules (BuildCvHob);
      |                           ^~~~~~~~~~
      |                           |
      |                           void (__attribute__((ms_abi)) *)(EFI_PHYSICAL_ADDRESS,  UINT64) {aka void (__attribute__((ms_abi)) *)(long long unsigned int,  long long unsigned int)}
In file included from /home/merle/workspaces/tianocore/edk2/UefiPayloadPkg/UefiPayloadEntry/UefiPayloadEntry.h:24,
                 from /home/merle/workspaces/tianocore/edk2/UefiPayloadPkg/UefiPayloadEntry/UefiPayloadEntry.c:12:
/home/merle/workspaces/tianocore/edk2/UefiPayloadPkg/Include/Library/BlParseLib.h:184:27: note: expected ‘BL_CAPSULE_CALLBACK’ {aka ‘void (*)(long long unsigned int,  long long unsigned int)’} but argument is of type ‘void (__attribute__((ms_abi)) *)(EFI_PHYSICAL_ADDRESS,  UINT64)’ {aka ‘void (__attribute__((ms_abi)) *)(long long unsigned int,  long long unsigned int)’}
  184 |   IN BL_CAPSULE_CALLBACK  CapsuleCallback
      |      ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~
make: *** [GNUmakefile:379: /home/merle/workspaces/tianocore/Build/UefiPayloadPkgLegacy/RELEASE_GCC5/X64/UefiPayloadPkg/UefiPayloadEntry/UefiPayloadEntry/OUTPUT/UefiPayloadEntry.obj] Error 1

```

# Description


- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

## Integration Instructions