### PR TITLE
DynamicTablePkg: fix typo SmbiosSmcLib

### DIFF
--- a/DynamicTablesPkg/DynamicTablesPkg.dec
+++ b/DynamicTablesPkg/DynamicTablesPkg.dec
@@ -56,7 +56,7 @@
   Tpm2DeviceTableLib|Include/Library/Tpm2DeviceTableLib.h
 
   ##  @libraryclass  Defines a set of SMBIOS related SMC helper methods.
-  SmcbiosSmbLib|Include/Library/SmbiosSmcLib.h
+  SmbiosSmcLib|Include/Library/SmbiosSmcLib.h
 
 [LibraryClasses.AARCH64]
   ##  @libraryclass  Defines a set of APIs to populate CmObj using SCMI.


### PR DESCRIPTION
# Description

Fix typo SmbiosSmcLib in DynamicTablePkg.dec.

Signed-off-by: Yeoreum Yun <yeoreum.yun@arm.com>

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Build on ArmVExpressPkg and ArmJunoPkg.

## Integration Instructions

N/A