### PR TITLE
MdeModulePkg PciBus: Add bus check in PciAllocateBusNumber

### DIFF
--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciLib.c
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciLib.c
@@ -1044,6 +1044,11 @@ PciAllocateBusNumber (
     MaxNumberInRange = BusNumberRanges->AddrRangeMin + BusNumberRanges->AddrLen - 1;
     if ((StartBusNumber >= BusNumberRanges->AddrRangeMin) && (StartBusNumber <=  MaxNumberInRange)) {
       NextNumber = (UINT8)(StartBusNumber + NumberOfBuses);
+      if (NextNumber < StartBusNumber) {
+        DEBUG ((DEBUG_ERROR, "%a: Bus number overflow. StartBusNumber: %d, NumberOfBuses: %d\n",  __func__, StartBusNumber, NumberOfBuses));
+        return EFI_OUT_OF_RESOURCES;
+      }
+
       while (NextNumber > MaxNumberInRange) {
         ++BusNumberRanges;
         if (BusNumberRanges->Desc == ACPI_END_TAG_DESCRIPTOR) {


### PR DESCRIPTION
# Description
Add the checker to make sure bus number not overflow in PciAllocateBusNumber.

- [ ] Breaking change?
If platform has the wrong usage, this change will not allocate the wrong bus number.  
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested
Build pass, and boot to shell on the real platform. 

## Integration Instructions
N/A
