### PR TITLE
ArmPkg,UefiCpuPkg: fix boot failure on LPA supported platforms

### DIFF
--- a/UefiCpuPkg/Library/ArmMmuLib/AArch64/ArmMmuLibCore.c
+++ b/UefiCpuPkg/Library/ArmMmuLib/AArch64/ArmMmuLibCore.c
@@ -94,6 +94,7 @@ ArmMemoryAttributeToPageAttribute (
 // T0SZ can be below MIN_T0SZ when LPA2 is in use, meaning the page table starts at level -1
 #define MIN_T0SZ        16
 #define BITS_PER_LEVEL  9
+#define MAX_VA_BITS_48  48
 #define MAX_VA_BITS     52
 
 STATIC
@@ -658,7 +659,10 @@ ArmConfigureMmu (
   // into account the architectural limitations that result from UEFI's
   // use of 4 KB pages.
   //
-  MaxAddressBits = MIN (ArmGetPhysicalAddressBits (), MAX_VA_BITS);
+  if (ArmHas52BitTgran4 ())
+    MaxAddressBits = MIN (ArmGetPhysicalAddressBits (), MAX_VA_BITS);
+  else
+    MaxAddressBits = MIN (ArmGetPhysicalAddressBits (), MAX_VA_BITS_48);
   MaxAddress     = LShiftU64 (1ULL, MaxAddressBits) - 1;
 
   T0SZ                = 64 - MaxAddressBits;


### PR DESCRIPTION
Commit 90771630bfe added support to enable 52 PA and VA support in EDK2. This is getting enabled for the FEAT_LPA supported platforms which does not support 52 VA for 4K PAGE_SIZE.

Adding fix to support 52 PA, only when LPA2 is supported otherwise fallback to 48.

Fixes: 90771630bfe ("UefiCpuPkg/ArmMmuLib: Add support for LPA2")

# Description

<_Include a description of the change and why this change was made._>

<_For each item, place an "x" in between `[` and `]` if true. Example: `[x]` (you can also check items in GitHub UI)_>

<_Create the PR as a Draft PR if it is only created to run CI checks._>

<_Delete lines in \<\> tags before creating the PR._>

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

<_Describe the test(s) that were run to verify the changes._>

## Integration Instructions

<_Describe how these changes should be integrated. Use N/A if nothing is required._>
