### PR TITLE
MdePkg: Add PCIe capability structures for DPC and DLF

### DIFF
--- a/MdePkg/Include/IndustryStandard/PciExpress21.h
+++ b/MdePkg/Include/IndustryStandard/PciExpress21.h
@@ -30,9 +30,17 @@
   (((Offset) & 0xfff) | (((Function) & 0x07) << 12) | (((Device) & 0x1f) << 15) | (((Bus) & 0xff) << 20))
 
 #pragma pack(1)
-///
-/// PCI Express Capability Structure
-///
+
+//
+// PCI Express Capability Structure version 2.
+// Mandatory for PCI Express devices. If not present it is not PCI Express device, thus no extended config space.
+// Version 1 ends at PCI_CAPABILITY_PCIEXP::RootStatus register.
+// Version 2 extends version 1 up to PCI_CAPABILITY_PCIEXP::SlotStatus2 register.
+//
+#define PCI_EXPRESS_CAPABILITY_ID    0x0010
+#define PCI_EXPRESS_CAPABILITY_VER1  0x1
+#define PCI_EXPRESS_CAPABILITY_VER2  0x2
+
 typedef union {
   struct {
     UINT16    Version                : 4;
@@ -410,7 +418,7 @@ typedef struct {
   PCI_REG_PCIE_SLOT_STATUS           SlotStatus;
   PCI_REG_PCIE_ROOT_CONTROL          RootControl;
   PCI_REG_PCIE_ROOT_CAPABILITY       RootCapability;
-  PCI_REG_PCIE_ROOT_STATUS           RootStatus;
+  PCI_REG_PCIE_ROOT_STATUS           RootStatus;                  // Offset 20 size 4 - Ver1 ends here
   PCI_REG_PCIE_DEVICE_CAPABILITY2    DeviceCapability2;
   PCI_REG_PCIE_DEVICE_CONTROL2       DeviceControl2;
   UINT16                             DeviceStatus2;
@@ -432,11 +440,14 @@ typedef struct {
 //
 // for SR-IOV
 //
-#define EFI_PCIE_CAPABILITY_ID_ARI    0x0E
-#define EFI_PCIE_CAPABILITY_ID_ATS    0x0F
-#define EFI_PCIE_CAPABILITY_ID_SRIOV  0x10
+#define EFI_PCIE_CAPABILITY_ID_ARI    PCI_EXPRESS_EXTENDED_CAPABILITY_ARI_CAPABILITY_ID
+#define EFI_PCIE_CAPABILITY_ID_ATS    PCI_EXPRESS_EXTENDED_CAPABILITY_ATS_ID
+#define EFI_PCIE_CAPABILITY_ID_SRIOV  PCI_EXPRESS_EXTENDED_CAPABILITY_SRIOV_ID
 #define EFI_PCIE_CAPABILITY_ID_MRIOV  0x11
 
+//
+// Single Root IO Virtualization (SR-IOV) Extended Capability Structure.
+//
 #define PCI_EXPRESS_EXTENDED_CAPABILITY_SRIOV_ID    0x0010
 #define PCI_EXPRESS_EXTENDED_CAPABILITY_SRIOV_VER1  0x1
 
@@ -740,10 +751,9 @@ typedef struct {
 
 #define GET_TPH_TABLE_SIZE(x)  ((x->TphRequesterCapability & 0x7FF0000)>>16) * sizeof(UINT16)
 
-/// Address Translation Services Extended Capability Structure
-///
-/// Based on section 5.1 of PCI Express Address Translation Services Specification 1.1
-///@{
+//
+// Address Translation Services (ATS) Extended Capability Structure.
+//
 #define PCI_EXPRESS_EXTENDED_CAPABILITY_ATS_ID    0x000F
 #define PCI_EXPRESS_EXTENDED_CAPABILITY_ATS_VER1  0x1
 
@@ -771,7 +781,6 @@ typedef struct {
   PCI_EXPRESS_EXTENDED_CAPABILITIES_ATS_CAPABILITY    Capability;
   PCI_EXPRESS_EXTENDED_CAPABILITIES_ATS_CONTROL       Control;
 } PCI_EXPRESS_EXTENDED_CAPABILITIES_ATS;
-///@}
 
 #pragma pack()
 

--- a/MdePkg/Include/IndustryStandard/PciExpress31.h
+++ b/MdePkg/Include/IndustryStandard/PciExpress31.h
@@ -15,6 +15,74 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #pragma pack(1)
 
+//
+// Downstream Port Containment (DPC) Extended Capability.
+//
+#define PCI_EXPRESS_EXTENDED_CAPABILITY_DPC_ID  0x001D
+
+typedef union {
+  struct {
+    UINT16    DpcInterruptMsgNo             : 5;    // [4:0]
+    UINT16    RpExtensionsForDpc            : 1;    // [5]
+    UINT16    PoisonedTlpEgressBlockingSupp : 1;    // [6]
+    UINT16    DpcSoftwareTriggerSupp        : 1;    // [7]
+    UINT16    RpPioLogSize                  : 4;    // [11:8] Bits [3:0] of log size
+    UINT16    DlActiveErrCorSignalingSupp   : 1;    // [12]
+    UINT16    RpPioLogSizeExt               : 1;    // [13]   Bit [4] of log size
+    UINT16    Reserved                      : 2;    // [15:14]
+  } Bits;
+  UINT32    Uint16;
+} PCI_EXPRESS_REG_DPC_CAPABILITY;
+
+typedef union {
+  struct {
+    UINT16    DpcTriggerEn                : 2;    // [1:0]
+    UINT16    DpcCompletionCtl            : 1;    // [2]
+    UINT16    DpcInterruptEn              : 1;    // [3]
+    UINT16    DpcErrCorEn                 : 1;    // [4]
+    UINT16    PoisonedTlpEgressBlockingEn : 1;    // [5]
+    UINT16    DpcSoftwareTrigger          : 1;    // [6]
+    UINT16    DlActiveErrCorEn            : 1;    // [7]
+    UINT16    DpcSigSfwEn                 : 1;    // [8]
+    UINT16    Reserved                    : 7;    // [15:9]
+  } Bits;
+  UINT16    Uint16;
+} PCI_EXPRESS_REG_DPC_CONTROL;
+
+typedef union {
+  struct {
+    UINT16    DpcTriggerStatus          : 1;    // [0]
+    UINT16    DpcTriggerReason          : 2;    // [2:1]
+    UINT16    DpcInterruptStatus        : 1;    // [3]
+    UINT16    DpcRpBusy                 : 1;    // [4]
+    UINT16    DpcTriggerReasonExtension : 2;    // [6:5]
+    UINT16    Reserved0                 : 1;    // [7]
+    UINT16    RpPioFirstErrorPointer    : 5;    // [12:8]
+    UINT16    DpcSigSfwStatus           : 1;    // [13]
+    UINT16    Reserved1                 : 2;    // [15:14]
+  } Bits;
+  UINT16    Uint16;
+} PCI_EXPRESS_REG_DPC_STATUS;
+
+typedef struct {
+  PCI_EXPRESS_EXTENDED_CAPABILITIES_HEADER    Header;
+  PCI_EXPRESS_REG_DPC_CAPABILITY              Capability;         // Offset 04h size 2
+  PCI_EXPRESS_REG_DPC_CONTROL                 Control;            // Offset 06h size 2
+  PCI_EXPRESS_REG_DPC_STATUS                  Status;             // Offset 08h size 2
+  UINT16                                      ErrSourceId;        // Offset 0Ah size 2
+  UINT32                                      RpPioStatus;        // Offset 0Ch size 4
+  UINT32                                      RpPioMask;          // Offset 10h size 4
+  UINT32                                      RpPioSeverity;      // Offset 14h size 4
+  UINT32                                      RpPioSysErr;        // Offset 18h size 4
+  UINT32                                      RpPioException;     // Offset 1Ch size 4
+  UINT32                                      RpPioHdrLog[4];     // Offset 20h size 16 header log DW 1-4
+  UINT32                                      RpPioImpSpecLog;    // Offset 30h size 4
+  UINT32                                      RpPioHdrLogExt[10]; // Offset 34h size 40 header log DW 5-14
+} PCI_EXPRESS_EXTENDED_CAPABILITIES_DPC;
+
+//
+// L1 PM Substates Extended Capability.
+//
 #define PCI_EXPRESS_EXTENDED_CAPABILITY_L1_PM_SUBSTATES_ID    0x001E
 #define PCI_EXPRESS_EXTENDED_CAPABILITY_L1_PM_SUBSTATES_VER1  0x1
 
@@ -67,31 +135,32 @@ typedef struct {
   PCI_EXPRESS_REG_L1_PM_SUBSTATES_CONTROL2      Control2;
 } PCI_EXPRESS_EXTENDED_CAPABILITIES_L1_PM_SUBSTATES;
 
-/// Process Address Space ID Extended Capability Structure
-///
-/// Based on section 7.29 of PCI Express Base Specification 3.1
-///@{
+//
+// Process Address Space ID (PASID) Extended Capability Structure.
+//
 #define PCI_EXPRESS_EXTENDED_CAPABILITY_PASID_ID    0x001B
 #define PCI_EXPRESS_EXTENDED_CAPABILITY_PASID_VER1  0x1
 
 typedef union {
   struct {
-    UINT16    PasidSupport             : 1;
-    UINT16    ExecutePermissionSupport : 1;
-    UINT16    PrivilegedModeSupport    : 1;
-    UINT16    Reserved1                : 5;
-    UINT16    MaxPasidWidth            : 5;
-    UINT16    Reserved2                : 3;
+    UINT16    Reserved0                     : 1;    // [0]
+    UINT16    ExecutePermissionSupport      : 1;    // [1]
+    UINT16    PrivilegedModeSupport         : 1;    // [2]
+    UINT16    TranslatedReqWithPasidSupport : 1;    // [3]
+    UINT16    Reserved1                     : 4;    // [7:4]
+    UINT16    MaxPasidWidth                 : 5;    // [12:8]
+    UINT16    Reserved2                     : 3;    // [15:13]
   } Bits;
   UINT16    Uint16;
 } PCI_EXPRESS_EXTENDED_CAPABILITIES_PASID_CAPABILITY;
 
 typedef union {
   struct {
-    UINT16    PasidEnable             : 1;
-    UINT16    ExecutePermissionEnable : 1;
-    UINT16    PrivilegedModeEnable    : 1;
-    UINT16    Reserved                : 13;
+    UINT16    PasidEnable                  : 1;    // [0]
+    UINT16    ExecutePermissionEnable      : 1;    // [1]
+    UINT16    PrivilegedModeEnable         : 1;    // [2]
+    UINT16    TranslatedReqWithPasidEnable : 1;    // [3]
+    UINT16    Reserved                     : 12;
   } Bits;
   UINT16    Uint16;
 } PCI_EXPRESS_EXTENDED_CAPABILITIES_PASID_CONTROL;
@@ -101,7 +170,6 @@ typedef struct {
   PCI_EXPRESS_EXTENDED_CAPABILITIES_PASID_CAPABILITY    Capability;
   PCI_EXPRESS_EXTENDED_CAPABILITIES_PASID_CONTROL       Control;
 } PCI_EXPRESS_EXTENDED_CAPABILITIES_PASID;
-///@}
 
 #pragma pack()
 

--- a/MdePkg/Include/IndustryStandard/PciExpress40.h
+++ b/MdePkg/Include/IndustryStandard/PciExpress40.h
@@ -16,47 +16,79 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #pragma pack(1)
 
-/// Precision Time Management Extended Capability definitions.
-///
-/// Based on section 7.9.16 of PCI Express Base Specification 4.0.
-///@{
+//
+// Precision Time Measurement (PTM) Extended Capability.
+//
 #define PCI_EXPRESS_EXTENDED_CAPABILITY_PTM_ID    0x001F
 #define PCI_EXPRESS_EXTENDED_CAPABILITY_PTM_VER1  0x1
 
-#define PCI_EXPRESS_EXTENDED_CAPABILITIES_PTM_CAPABILITY_OFFSET  0x04
-#define PCI_EXPRESS_EXTENDED_CAPABILITIES_PTM_CONTROL_OFFSET     0x08
-
 typedef union {
   struct {
-    UINT32    PTMRequesterCapable                  : 1;
-    UINT32    PTMResponderCapable                  : 1;
-    UINT32    PTMRootCapable                       : 1;
-    UINT32    ePTMCapable                          : 1;
-    UINT32    PTMPropagationDelayAdaptationCapable : 1;
-    UINT32    Reserved                             : 3;
-    UINT32    LocalClockGranularity                : 8;
-    UINT32    Reserved2                            : 16;
+    UINT32    PtmRequesterCapable             : 1;    // [0]
+    UINT32    PtmResponderCapable             : 1;    // [1]
+    UINT32    PtmRootCapable                  : 1;    // [2]
+    UINT32    EPtmCapable                     : 1;    // [3]
+    UINT32    PtmPropatagionDelayAdaptCapable : 1;    // [4]
+    UINT32    Reserved0                       : 3;    // [7:5]
+    UINT32    LocalClockGranularity           : 8;    // [15:8]
+    UINT32    Reserved1                       : 16;   // [31:16]
   } Bits;
   UINT32    Uint32;
 } PCI_EXPRESS_EXTENDED_CAPABILITIES_PTM_CAPABILITY;
 
 typedef union {
   struct {
-    UINT32    PTMEnable            : 1;
-    UINT32    RootSelect           : 1;
-    UINT32    Reserved             : 6;
-    UINT32    EffectiveGranularity : 8;
-    UINT32    Reserved2            : 16;
+    UINT32    PtmEnable            : 1;    // [0]
+    UINT32    RootSelect           : 1;    // [1]
+    UINT32    Reserved0            : 6;    // [7:2]
+    UINT32    EffectiveGranularity : 8;    // [15:8]
+    UINT32    Reserved1            : 16;   // [31:16]
   } Bits;
   UINT32    Uint32;
 } PCI_EXPRESS_EXTENDED_CAPABILITIES_PTM_CONTROL;
 
 typedef struct {
   PCI_EXPRESS_EXTENDED_CAPABILITIES_HEADER            Header;
-  PCI_EXPRESS_EXTENDED_CAPABILITIES_PTM_CAPABILITY    Capability;
-  PCI_EXPRESS_EXTENDED_CAPABILITIES_PTM_CONTROL       Control;
+  PCI_EXPRESS_EXTENDED_CAPABILITIES_PTM_CAPABILITY    Capability; // Offset 04h size 4
+  PCI_EXPRESS_EXTENDED_CAPABILITIES_PTM_CONTROL       Control;    // Offset 08h size 4
 } PCI_EXPRESS_EXTENDED_CAPABILITIES_PTM;
-///@}
+
+//
+// Data Link Feature (DLF) Extended Capability.
+//
+#define PCI_EXPRESS_EXTENDED_CAPABILITY_DLF_ID  0x0025
+
+typedef union {
+  struct {
+    UINT32    LocalScaledFlowControlSupported : 1;    // [0]
+    UINT32    LocalImmediateReadiness         : 1;    // [1]
+    UINT32    LocalExtendedVcCount            : 3;    // [4:2]
+    UINT32    LocalL0pExitLatency             : 3;    // [7:5]
+    UINT32    Reserved0                       : 15;   // [22:8]
+    UINT32    Reserved1                       : 8;    // [30:23]
+    UINT32    DataLinkFeatureExchangeEnable   : 1;    // [31]
+  } Bits;
+  UINT32    Uint32;
+} PCI_EXPRESS_REG_DLF_CAPABILITY;
+
+typedef union {
+  struct {
+    UINT32    RemoteScaledFlowControlSupported : 1;    // [0]
+    UINT32    RemoteImmediateReadiness         : 1;    // [1]
+    UINT32    ExtendedVcCound                  : 3;    // [4:2]
+    UINT32    RemoteL0pExitLatency             : 3;    // [7:5]
+    UINT32    Reserved0                        : 15;   // [22:8]
+    UINT32    Reserved1                        : 8;    // [30:23]
+    UINT32    DataLinkFeatureStatusValid       : 1;    // [31]
+  } Bits;
+  UINT32    Uint32;
+} PCI_EXPRESS_REG_DLF_STATUS;
+
+typedef struct {
+  PCI_EXPRESS_EXTENDED_CAPABILITIES_HEADER    Header;
+  PCI_EXPRESS_REG_DLF_CAPABILITY              Capability;
+  PCI_EXPRESS_REG_DLF_STATUS                  Status;
+} PCI_EXPRESS_EXTENDED_CAPABILITIES_DLF;
 
 /// The Physical Layer PCI Express Extended Capability definitions.
 ///


### PR DESCRIPTION
Add definitions for PCIe Downstream Port Containment (DPC) Extended Capability as defined in spec 6.2.
Add definitions for PCIe Data Link Feature (DLF) Extended Capability as defined in spec 6.2.
Update existing definitions for PCIe Process Address Space ID (PASID) as defined in spec 6.2 .
Update existing definitions for Precision Time Measurement (PTM) to follow camel case, definition is current for spec 6.2.

- [ ] Breaking change?
  - No
- [ ] Impacts security?
  - No
- [ ] Includes tests?
  - No

## How This Was Tested

Tested in recently developed Intel server platforms.

## Integration Instructions

None
