### PR TITLE
MdeModulePkg/AcpiTableDxe:Created EfiACPIReclaimMemory for ACPIHOB RSDP

### DIFF
--- a/MdeModulePkg/Universal/Acpi/AcpiTableDxe/AcpiTableProtocol.c
+++ b/MdeModulePkg/Universal/Acpi/AcpiTableDxe/AcpiTableProtocol.c
@@ -1953,9 +1953,10 @@ InstallAcpiTableFromHob (
   @param  AcpiTableInstance  Protocol instance private data.
   @param  GuidHob            GUID HOB header.
 
-  @return EFI_SUCCESS        The function completed successfully.
-  @return EFI_NOT_FOUND      The function doesn't find the Rsdp from AcpiSiliconHob.
-  @return EFI_ABORTED        The function could not complete successfully.
+  @return EFI_SUCCESS           The function completed successfully.
+  @return EFI_NOT_FOUND         The function doesn't find the Rsdp from AcpiSiliconHob.
+  @return EFI_ABORTED           The function could not complete successfully.
+  @retval EFI_OUT_OF_RESOURCES  Memory allocation failed.
 
 **/
 EFI_STATUS
@@ -1980,6 +1981,7 @@ InstallAcpiTableFromAcpiSiliconHob (
   UINTN                                         TotalSocTablesize;
   UINT8                                         *Pointer;
   EFI_MEMORY_TYPE                               AcpiAllocateMemoryType;
+  UINTN                                         AcpiRsdpSize;
 
   DEBUG ((DEBUG_INFO, "InstallAcpiTableFromAcpiSiliconHob - Start\n"));
   //
@@ -2003,12 +2005,50 @@ InstallAcpiTableFromAcpiSiliconHob (
   //
   SiAcpiHobRsdp = (EFI_ACPI_3_0_ROOT_SYSTEM_DESCRIPTION_POINTER *)(UINTN)(AcpiSiliconHob->Rsdp);
   if (SiAcpiHobRsdp == NULL) {
-    DEBUG ((DEBUG_ERROR, "InstallAcpiTableFromAcpiSiliconHob: Fail to locate RSDP Acpi table!!\n"));
+    DEBUG ((DEBUG_ERROR, "InstallAcpiTableFromAcpiSiliconHob: Fail to locate RSDP Acpi table from AcpiSiliconHob!!\n"));
     return EFI_NOT_FOUND;
+  } else {
+    DEBUG ((DEBUG_INFO, "ACPI HOB RSDP address : 0x%016lx\n", SiAcpiHobRsdp));
   }
 
-  DEBUG ((DEBUG_INFO, "Silicon ACPI RSDP address : 0x%016lx\n", SiAcpiHobRsdp));
-  AcpiTableInstance->Rsdp3 = SiAcpiHobRsdp;
+  //
+  // Reserved the ACPI reclaim memory for new RSDP space.
+  //
+  AcpiRsdpSize = sizeof (EFI_ACPI_3_0_ROOT_SYSTEM_DESCRIPTION_POINTER);
+  if (mAcpiTableAllocType != AllocateAnyPages) {
+    PageAddress = 0xFFFFFFFF;
+    Status      = gBS->AllocatePages (
+                         mAcpiTableAllocType,
+                         AcpiAllocateMemoryType,
+                         EFI_SIZE_TO_PAGES (AcpiRsdpSize),
+                         &PageAddress
+                         );
+  } else {
+    Status = gBS->AllocatePool (
+                    AcpiAllocateMemoryType,
+                    AcpiRsdpSize,
+                    (VOID **)&Pointer
+                    );
+  }
+
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "Fail to allocate EfiACPIReclaimMemory for RSDP. Status : %r\n", Status));
+    return Status;
+  } else {
+    if (mAcpiTableAllocType != AllocateAnyPages) {
+      Pointer = (UINT8 *)(UINTN)PageAddress;
+    }
+  }
+
+  ZeroMem (Pointer, AcpiRsdpSize);
+  //
+  // Copy RSDP content from ACPI Hob to the ACPI table Instance.
+  //
+  AcpiTableInstance->Rsdp3 = (EFI_ACPI_3_0_ROOT_SYSTEM_DESCRIPTION_POINTER *)Pointer;
+  CopyMem (AcpiTableInstance->Rsdp3, SiAcpiHobRsdp, sizeof (EFI_ACPI_3_0_ROOT_SYSTEM_DESCRIPTION_POINTER));
+  SiAcpiHobRsdp = AcpiTableInstance->Rsdp3;
+
+  DEBUG ((DEBUG_INFO, "Current ACPI RSDP address : 0x%016lx\n", SiAcpiHobRsdp));
 
   //
   // Got XSDT address from RSDP table.
@@ -2016,7 +2056,7 @@ InstallAcpiTableFromAcpiSiliconHob (
   Buffer            = (UINT8 *)(UINTN)(SiAcpiHobRsdp->XsdtAddress);
   SiCommonAcpiTable = (EFI_ACPI_DESCRIPTION_HEADER *)Buffer;
 
-  DEBUG ((DEBUG_INFO, "Silicon ACPI XSDT address : 0x%016lx\n", SiCommonAcpiTable));
+  DEBUG ((DEBUG_INFO, "ACPI HOB XSDT address : 0x%016lx\n", SiCommonAcpiTable));
 
   if (SiCommonAcpiTable->Length <= sizeof (EFI_ACPI_DESCRIPTION_HEADER)) {
     DEBUG ((DEBUG_ERROR, "XSDT length is incorrect\n"));
@@ -2068,7 +2108,10 @@ InstallAcpiTableFromAcpiSiliconHob (
 
   ZeroMem (Pointer, TotalSocTablesize);
   AcpiTableInstance->Xsdt = (EFI_ACPI_DESCRIPTION_HEADER *)(UINTN)Pointer;
-
+  //
+  // Update the XsdtAddress of the AcpiTableInstance's Rsdp3
+  //
+  AcpiTableInstance->Rsdp3->XsdtAddress = (UINT64)(UINTN)AcpiTableInstance->Xsdt;
   //
   // Initial XSDT table content.
   //
@@ -2200,7 +2243,7 @@ InstallAcpiTableFromAcpiSiliconHob (
       }
 
       if (((EFI_ACPI_DESCRIPTION_HEADER *)NeedToInstallTable)->Signature == EFI_ACPI_3_0_FIRMWARE_ACPI_CONTROL_STRUCTURE_SIGNATURE) {
-        Status = AddTableToList (AcpiTableInstance, NeedToInstallTable, TRUE, Version, TRUE, &TableKey);
+        Status = AddTableToList (AcpiTableInstance, NeedToInstallTable, TRUE, Version, FALSE, &TableKey);
         if (EFI_ERROR (Status)) {
           DEBUG ((DEBUG_ERROR, "Fail to add FACS in the DXE Table list!\n"));
           ASSERT_EFI_ERROR (Status);


### PR DESCRIPTION
# Description
The RSDP table come from ACPI HOB which may no store in the EfiACPIReclaimMemory-type memory. 
Therefore need to reserve an  EfiACPIReclaimMemory-type memory for it.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested
SUT boots to the operation system.

## Integration Instructions
None
