### PR TITLE
EmulatorPkg: Fix  build failure with StackCheckLib

### DIFF
--- a/EmulatorPkg/Unix/Host/Host.inf
+++ b/EmulatorPkg/Unix/Host/Host.inf
@@ -116,7 +116,7 @@
 [BuildOptions]
   GCC:*_*_*_CC_FLAGS    == -g -fshort-wchar -fno-strict-aliasing -Wall -malign-double -idirafter/usr/include -c -include $(DEST_DIR_DEBUG)/AutoGen.h -DSTRING_ARRAY_NAME=$(BASE_NAME)Strings
   GCC:*_*_IA32_CC_FLAGS  = -m32
-  GCC:*_*_X64_CC_FLAGS   = -m64 "-DEFIAPI=__attribute__((ms_abi))" -flto -DUSING_LTO -Os
+  GCC:*_*_X64_CC_FLAGS   = -m64 "-DEFIAPI=__attribute__((ms_abi))" -fno-lto -Os
 
   GCC:*_*_*_DLINK_FLAGS    == -o $(BIN_DIR)/Host -z noexecstack -L/usr/X11R6/lib
   GCC:*_*_IA32_DLINK_FLAGS  = -m32


### PR DESCRIPTION
# Description

When Host module in EmulatorPkg is linking against StackCheckLib, it fails. Because, StackCheckLib tries to link with libraries with LTO enabled specifically DebugLib. and this results linker to not able resolve DebugLib symbols. Because LTO disabled in StackCheckLib.

Disable LTO for Host module to mitigate the issue. There is no performance impact is observed on build envirnment. However binary size is enlarged from 303 KB to 305 KB, 2 KB extra for binary size when LTO disabled.

NOTE: Adding DebugLib into StackCheckLib INF file alone won't fix the issue.

Fixes: #11797

- [ ] Breaking change?
  - NO
- [ ] Impacts security?
  - NO
- [ ] Includes tests?
  - NO

## How This Was Tested
```
source edksetup.sh
build -a X64 -p EmulatorPkg/EmulatorPkg.dsc -b DEBUG -t GCC5 -DCUSTOM_STACK_CHECK_LIB=STATIC
```
## Integration Instructions
N/A