### PR TITLE
ArmPkg, UefiCpuPkg: Fix boot failure on FEAT_LPA-only systems without LPA2

### DIFF
--- a/UefiCpuPkg/Library/ArmMmuLib/AArch64/ArmMmuLibCore.c
+++ b/UefiCpuPkg/Library/ArmMmuLib/AArch64/ArmMmuLibCore.c
@@ -94,6 +94,7 @@ ArmMemoryAttributeToPageAttribute (
 // T0SZ can be below MIN_T0SZ when LPA2 is in use, meaning the page table starts at level -1
 #define MIN_T0SZ        16
 #define BITS_PER_LEVEL  9
+#define MAX_VA_BITS_48  48
 #define MAX_VA_BITS     52
 
 STATIC
@@ -658,8 +659,13 @@ ArmConfigureMmu (
   // into account the architectural limitations that result from UEFI's
   // use of 4 KB pages.
   //
-  MaxAddressBits = MIN (ArmGetPhysicalAddressBits (), MAX_VA_BITS);
-  MaxAddress     = LShiftU64 (1ULL, MaxAddressBits) - 1;
+  if (ArmHas52BitTgran4 ()) {
+    MaxAddressBits = MIN (ArmGetPhysicalAddressBits (), MAX_VA_BITS);
+  } else {
+    MaxAddressBits = MIN (ArmGetPhysicalAddressBits (), MAX_VA_BITS_48);
+  }
+
+  MaxAddress = LShiftU64 (1ULL, MaxAddressBits) - 1;
 
   T0SZ                = 64 - MaxAddressBits;
   RootTableEntryCount = GetRootTableEntryCount (T0SZ);


### PR DESCRIPTION

Commit 9077163 added support for 52-bit PA/VA (LPA2) in EDK2. The previous change treated the presence of FEAT_LPA as sufficient to enable 52-bit VA for 4K page granularity. Some platforms advertise FEAT_LPA but do not implement full LPA2 support for 4K PAGE_SIZE; enabling 52-bit VA on those platforms produced an invalid MMU configuration and caused boot failures.

This patch tightens the detection logic so 52-bit PA/VA (LPA2) is enabled only when the platform explicitly advertises LPA2 support. When LPA2 is not present we fall back to the previous 48-bit address limit for 4K pages, preserving correct behavior on non-LPA2 systems.

Fixes: 9077163 ("UefiCpuPkg/ArmMmuLib: Add support for LPA2")

# Description

<_Include a description of the change and why this change was made._>

<_For each item, place an "x" in between `[` and `]` if true. Example: `[x]` (you can also check items in GitHub UI)_>

<_Create the PR as a Draft PR if it is only created to run CI checks._>

<_Delete lines in \<\> tags before creating the PR._>

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

<_Describe the test(s) that were run to verify the changes._>

## Integration Instructions

<_Describe how these changes should be integrated. Use N/A if nothing is required._>
