### PR TITLE
MdePkg/BaseCpuLib: Add Vector initialization support for RISC-V

### DIFF
--- a/MdePkg/Include/Library/CpuLib.h
+++ b/MdePkg/Include/Library/CpuLib.h
@@ -122,4 +122,17 @@ DisableFloatingPointUnits (
 
 #endif
 
+#if defined (MDE_CPU_RISCV64)
+
+/**
+  Initialize the CPU Vector units.
+**/
+VOID
+EFIAPI
+InitializeVectorUnits (
+  VOID
+  );
+
+#endif
+
 #endif

--- a/MdePkg/Include/Register/RiscV64/RiscVEncoding.h
+++ b/MdePkg/Include/Register/RiscV64/RiscVEncoding.h
@@ -27,6 +27,7 @@
 #define SSTATUS_SPIE        MSTATUS_SPIE
 #define SSTATUS_SPP_SHIFT   MSTATUS_SPP_SHIFT
 #define SSTATUS_SPP         MSTATUS_SPP
+#define SSTATUS_VS          0x00000600UL
 
 #define IRQ_S_SOFT    1
 #define IRQ_VS_SOFT   2

--- a/MdePkg/Library/BaseCpuLib/BaseCpuLib.inf
+++ b/MdePkg/Library/BaseCpuLib/BaseCpuLib.inf
@@ -58,6 +58,7 @@
 [Sources.RISCV64]
   RiscV/Cpu.S             | GCC
   RiscV/InitializeFpu.S   | GCC
+  RiscV/InitializeVector.S  | GCC
 
 [Sources.LOONGARCH64]
   LoongArch/CpuFlushTlb.S   | GCC

--- a/MdePkg/Library/BaseCpuLib/RiscV/InitializeVector.S
+++ b/MdePkg/Library/BaseCpuLib/RiscV/InitializeVector.S
@@ -1,0 +1,18 @@
+//
+// Enable Vector for RISC-V
+//
+// Copyright (c) 2026, ZTE Inc. All rights reserved.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+#include <Register/RiscV64/RiscVImpl.h>
+
+.global ASM_PFX(InitializeVectorUnits)
+
+ASM_PFX(InitializeVectorUnits):
+    csrr  a0, CSR_SSTATUS
+    li    a1, SSTATUS_VS
+    or    a0, a0, a1
+    csrw  CSR_SSTATUS, a0
+    li    a0, 0
+    ret

--- a/UefiCpuPkg/CpuDxeRiscV64/CpuDxe.c
+++ b/UefiCpuPkg/CpuDxeRiscV64/CpuDxe.c
@@ -363,6 +363,11 @@ InitializeCpu (
   InitializeFloatingPointUnits ();
 
   //
+  // Initialize Vector
+  //
+  InitializeVectorUnits ();
+
+  //
   // Install Boot protocol
   //
   Status = gBS->InstallProtocolInterface (


### PR DESCRIPTION
Add InitializeVectorUnits function to Enable RISC-V vector.

# Description
https://github.com/tianocore/edk2/issues/11965
The edk2 firmware enables the CSR_SSTATUS.VS bit default on RISC-V, allowing the BOOTRISCV64.EFI program to use vector instructions.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Use the BOOTRISCV64.EFI  compiled by GCC14,  the qemu-kvm GUEST start success

## Integration Instructions

N/A
