### PR TITLE
BaseTools/Plugin/HostBasedUnitTestRunner: Add missing quotes for Windows

### DIFF
--- a/BaseTools/Plugin/HostBasedUnitTestRunner/HostBasedUnitTestRunner.py
+++ b/BaseTools/Plugin/HostBasedUnitTestRunner/HostBasedUnitTestRunner.py
@@ -340,7 +340,7 @@ class HostBasedUnitTestRunner(IUefiBuildPlugin):
         if ret != 0:
             logging.error(f"clang_gen_lcov_xml: Failed to generate coverage lcov. {output_lcov}")
             return 1
-        ret = RunCmd("lcov_cobertura",f"{output_lcov} --excludes ^.*UnitTest\|^.*MU\|^.*Mock\|^.*DEBUG -o {output_xml}")
+        ret = RunCmd("lcov_cobertura",f'{output_lcov} --excludes "^.*UnitTest\|^.*MU\|^.*Mock\|^.*DEBUG" -o {output_xml}')
         if ret != 0:
             logging.error(f"clang_gen_lcov_xml: Failed generate filtered coverage XML. {output_xml}")
             return 1


### PR DESCRIPTION
# Description

Add missing double quotes for `lcov_cobertura --excludes` option.

This resolves an issue introduced by PR #11816 that impacts all Windows CLANG environments because the Windows cmd processor required the `--excludes` option to use "" due to the regular expression characters used.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

Stuart unit test builds with Windows CLANG environments fail with an error from `lcov_cobertura`.

After this change, the builds pass with no regressions on Linux CLANG environments.

## Integration Instructions

N/A
