### PR TITLE
NetworkPkg: fix No PXE boot item

### DIFF
--- a/NetworkPkg/Library/DxeNetLib/DxeNetLib.inf
+++ b/NetworkPkg/Library/DxeNetLib/DxeNetLib.inf
@@ -68,6 +68,3 @@
 
 [FixedPcd]
   gEfiMdePkgTokenSpaceGuid.PcdEnforceSecureRngAlgorithms ## CONSUMES
-
-[Depex]
-  gEfiRngProtocolGuid


### PR DESCRIPTION
REF:https://github.com/tianocore/tianocore.github.io/issues/82

Due to commit [NetworkPkg: SECURITY PATCH CVE-2023-45237][1] applied,  
run qemu with OVMF.fd, no VirtIO RNG, then press ESC, no PXE boot item  
'UEFI PXEv4 (MAC address)' is available
```
$ qemu-system-x86_64 -nographic \
   -drive if=pflash,format=raw,file=path-to/OVMF.fd
  ┌─────────────────────────────────┐
  │   Please select boot device:    │
  ├─────────────────────────────────┤
  │EFI Firmware Setup               │
  │EFI Internal Shell               │
  ├─────────────────────────────────┤
  │    ↑ and ↓ to move selection    │
  │   ENTER to select boot device   │
  │           ESC to exit           │
  └─────────────────────────────────┘
```
As comparing, run qemu with OVMF.fd and VirtIO RNG, then press ESC, the PXE boot item is available
```
$ qemu-system-x86_64 -nographic \
   -drive if=pflash,format=raw,file=path-to/OVMF.fd \
   -object rng-random,filename=/dev/urandom,id=rng0 \
   -device virtio-rng-pci,rng=rng0
  ┌───────────────────────────────────┐
  │    Please select boot device:     │
  ├───────────────────────────────────┤
  │EFI Firmware Setup                 │
  │UEFI PXEv4 (MAC:525400123456)      │
  │EFI Internal Shell                 │
  ├───────────────────────────────────┤
  │     ↑ and ↓ to move selection     │
  │    ENTER to select boot device    │
  │            ESC to exit            │
  └───────────────────────────────────┘
```
In commit [1], it used a Weak PseudoRandom Number Generator to instead of
NET_RANDOM (NetRandomInitSeed ()), if the platform does not have any one of
the UEFI defined secure RNG algorithms then the driver will assert.

This commit get NET_RANDOM (NetRandomInitSeed ()) back if call PseudoRandom failed,
remove gEfiRngProtocolGuid from Depex section to allow sometime consume. 
After apply this commit, run qemu with OVMF.fd and no VirtIO RNG, press ESC:
```
$ qemu-system-x86_64 -nographic \
   -drive if=pflash,format=raw,file=path-to/OVMF.fd
  ┌───────────────────────────────────┐
  │    Please select boot device:     │
  ├───────────────────────────────────┤
  │EFI Firmware Setup                 │
  │UEFI PXEv4 (MAC:525400123456)      │
  │EFI Internal Shell                 │
  ├───────────────────────────────────┤
  │     ↑ and ↓ to move selection     │
  │    ENTER to select boot device    │
  │            ESC to exit            │
  └───────────────────────────────────┘
```
And no regression to run qemu with OVMF.fd and VirtIO RNG, then press ESC, 
```
$ qemu-system-x86_64 -nographic \
   -drive if=pflash,format=raw,file=path-to/OVMF.fd \
   -object rng-random,filename=/dev/urandom,id=rng0 \
   -device virtio-rng-pci,rng=rng0
  ┌───────────────────────────────────┐
  │    Please select boot device:     │
  ├───────────────────────────────────┤
  │EFI Firmware Setup                 │
  │UEFI PXEv4 (MAC:525400123456)      │
  │EFI Internal Shell                 │
  ├───────────────────────────────────┤
  │     ↑ and ↓ to move selection     │
  │    ENTER to select boot device    │
  │            ESC to exit            │
  └───────────────────────────────────┘
```
[1] https://github.com/tianocore/edk2/commit/4c4ceb2ceb

