### PR TITLE
BaseTools: use double hyphens for CLANGPDB llvm-rc

### DIFF
--- a/BaseTools/Conf/build_rule.template
+++ b/BaseTools/Conf/build_rule.template
@@ -723,7 +723,7 @@
     #
     <Command.MSFT, Command.INTEL, Command.GCC, Command.CLANGPDB, Command.CLANGDWARF>
         "$(GENFW)" -o $(OUTPUT_DIR)(+)$(MODULE_NAME)hii.rc -g $(MODULE_GUID) $(GENFWHII_FLAGS) $(HII_BINARY_PACKAGES) $(GENFW_FLAGS)
-        "$(RC)" $(RC_FLAGS) $(OUTPUT_DIR)(+)$(MODULE_NAME)hii.rc
+        "$(RC)" $(RC_FLAGS) -- $(OUTPUT_DIR)(+)$(MODULE_NAME)hii.rc
         -$(CP) $(OUTPUT_DIR)(+)$(MODULE_NAME)hii.res $(OUTPUT_DIR)(+)$(MODULE_NAME)hii.rc
         $(CP) $(OUTPUT_DIR)(+)$(MODULE_NAME)hii.rc ${dst}
 


### PR DESCRIPTION
# Description

When compiling rc files in OSX, llvm-rc treats '/Fo/PathToFile' as a positional argument. This results in the error "Exactly one input file should be provided". Using double hyphens llvm splits all data on the left side as options and data on the right side as positional arguments.

See: https://llvm.org/docs/CommandLine.html
Section: Specifying positional options with hyphens

- [ ] Breaking change
- [ ] Impacts security
- [ ] Includes tests

## How This Was Tested

CI

## Integration Instructions

N/A
