### PR TITLE
Configure FUA in SCSI command properly

### DIFF
--- a/MdeModulePkg/Bus/Scsi/ScsiDiskDxe/ScsiDisk.c
+++ b/MdeModulePkg/Bus/Scsi/ScsiDiskDxe/ScsiDisk.c
@@ -4555,7 +4555,8 @@ BackOff:
                       DataBuffer,
                       DataLength,
                       StartLba,
-                      SectorCount
+                      SectorCount,
+                      ScsiDiskDevice->FuaMode
                       );
   if ((ReturnStatus == EFI_NOT_READY) || (ReturnStatus == EFI_BAD_BUFFER_SIZE)) {
     *NeedRetry = TRUE;
@@ -4802,7 +4803,8 @@ BackOff:
                       DataBuffer,
                       DataLength,
                       StartLba,
-                      SectorCount
+                      SectorCount,
+                      ScsiDiskDevice->FuaMode
                       );
   if ((ReturnStatus == EFI_NOT_READY) || (ReturnStatus == EFI_BAD_BUFFER_SIZE)) {
     *NeedRetry = TRUE;

--- a/MdeModulePkg/Bus/Scsi/ScsiDiskDxe/ScsiDisk.c
+++ b/MdeModulePkg/Bus/Scsi/ScsiDiskDxe/ScsiDisk.c
@@ -337,6 +337,7 @@ ScsiDiskDriverBindingStart (
   ScsiDiskDevice->UnmapInfo.MaxBlkDespCnt           = 1;
   ScsiDiskDevice->BlockLimitsVpdSupported           = FALSE;
   ScsiDiskDevice->Handle                            = Controller;
+  ScsiDiskDevice->FuaMode                           = TRUE;
   InitializeListHead (&ScsiDiskDevice->AsyncTaskQueue);
 
   ScsiIo->GetDeviceType (ScsiIo, &(ScsiDiskDevice->DeviceType));
@@ -2537,6 +2538,18 @@ ScsiDiskDetectMedia (
     }
   }
 
+  //
+  // Get FUA Mode
+  //
+  for (Retry = 0; Retry < MaxRetry; Retry++) {
+    if (ScsiDiskDevice->DeviceType == EFI_SCSI_TYPE_DISK) {
+      Status = ScsiDiskFuaMode (ScsiDiskDevice);
+      if (!EFI_ERROR (Status)) {
+        break;
+      }
+    }
+  }
+
   if (ScsiDiskDevice->BlkIo.Media->MediaId != OldMedia.MediaId) {
     //
     // Media change information got from the device
@@ -4397,6 +4410,95 @@ BackOff:
   }
 
   return ReturnStatus;
+}
+
+/**
+  Get FUA Mode for the storage.
+
+  @param   ScsiDiskDevice    The pointer of SCSI_DISK_DEV.
+
+  @return  EFI_STATUS is returned by calling ScsiDiskFuaMode().
+**/
+EFI_STATUS
+ScsiDiskFuaMode (
+  IN     SCSI_DISK_DEV  *ScsiDiskDevice
+  )
+{
+  UINT8       HostAdapterStatus;
+  UINT8       TargetStatus;
+  UINT8       SenseDataLength;
+  UINT8       Buffer[CACHE_MODE_PAGE_LEN];
+  UINT32      BufferLength;
+  EFI_STATUS  ReturnStatus;
+  BOOLEAN     DpoFua;
+  BOOLEAN     WriteCaching;
+
+  SenseDataLength = 0;
+  BufferLength    = CACHE_MODE_PAGE_LEN;
+  DpoFua          = TRUE;
+  WriteCaching    = TRUE;
+  //
+  // Execute Mode Sense Command here to get the support of FUA
+  // through Mode page. FUA support locates in Mode parameter
+  // header that can be gotten through any Mode page.
+  // Here, Caching Mode Page (08) is used.
+  //
+  ReturnStatus = ScsiModeSense10Command (
+                   ScsiDiskDevice->ScsiIo,
+                   SCSI_DISK_TIMEOUT,
+                   NULL,
+                   &SenseDataLength,
+                   &HostAdapterStatus,
+                   &TargetStatus,
+                   Buffer,
+                   &BufferLength,
+                   1,                      // Not return any block descriptors
+                   0x10,                   // Default threshold values
+                   0x08                    // Caching Mode Page (08h)
+                   );
+  if (ReturnStatus != EFI_SUCCESS) {
+    //
+    // Mode Sense Command fails
+    //
+    return EFI_DEVICE_ERROR;
+  }
+
+  //
+  // Page code locates at the byte 8(bit0 to bit5),
+  // byte 0 after the 8 bytes Mode parameter header(10).
+  //
+  if ((Buffer[8] & 0x08) != 0x08) {
+    //
+    // Return page is not right
+    //
+    return EFI_DEVICE_ERROR;
+  }
+
+  //
+  // DPOFUA locates at the byte 3(bit4) in
+  // the Mode parameter header(10).
+  //
+  if ((Buffer[3] & 0x10) == 0x00) {
+    //
+    // 'DPOFUA' is disabled
+    //
+    DpoFua = FALSE;
+  }
+
+  //
+  // Caching Mode locates at the byte 10(bit2),
+  // byte 2 after the 8 bytes Mode parameter header(10).
+  //
+  if ((Buffer[10] & 0x04) == 0x00) {
+    //
+    // 'write through' cache is enabled.
+    //
+    WriteCaching = FALSE;
+  }
+
+  ScsiDiskDevice->FuaMode = DpoFua || WriteCaching;
+
+  return EFI_SUCCESS;
 }
 
 /**

--- a/MdeModulePkg/Bus/Scsi/ScsiDiskDxe/ScsiDisk.h
+++ b/MdeModulePkg/Bus/Scsi/ScsiDiskDxe/ScsiDisk.h
@@ -92,6 +92,11 @@ typedef struct {
   // The queue for asynchronous task requests
   //
   LIST_ENTRY                               AsyncTaskQueue;
+
+  //
+  // The flag indicates FUA support
+  //
+  BOOLEAN                                  FuaMode;
 } SCSI_DISK_DEV;
 
 #define SCSI_DISK_DEV_FROM_BLKIO(a)     CR (a, SCSI_DISK_DEV, BlkIo, SCSI_DISK_DEV_SIGNATURE)
@@ -192,6 +197,13 @@ extern EFI_COMPONENT_NAME2_PROTOCOL  gScsiDiskComponentName2;
 // to respond command.
 //
 #define SCSI_DISK_TIMEOUT  EFI_TIMER_PERIOD_SECONDS (30)
+
+//
+// The length of Mode parameter header(10) is 8 bytes. The
+// length of Caching Mode page is 20 bytes. Without block
+// descriptors, the buffer for Caching Mode page is 28.
+//
+#define CACHE_MODE_PAGE_LEN  28
 
 /**
   Test to see if this driver supports ControllerHandle.
@@ -1589,4 +1601,15 @@ BOOLEAN
 DetermineInstallStorageSecurity (
   IN  SCSI_DISK_DEV  *ScsiDiskDevice,
   IN  EFI_HANDLE     ChildHandle
+  );
+
+/**
+  Get FUA Mode for the storage.
+
+  @param   ScsiDiskDevice    The pointer of SCSI_DISK_DEV.
+
+**/
+EFI_STATUS
+ScsiDiskFuaMode (
+  IN     SCSI_DISK_DEV  *ScsiDiskDevice
   );

--- a/MdePkg/Include/Library/UefiScsiLib.h
+++ b/MdePkg/Include/Library/UefiScsiLib.h
@@ -653,6 +653,7 @@ ScsiRead10Command (
   @param[in, out] DataLength           The length of data buffer.
   @param[in]      StartLba             The start address of LBA.
   @param[in]      SectorSize           The number of contiguous logical blocks of data that shall be transferred.
+  @param[in]      SetFua               If TRUE, FUA bit will be set.
 
   @retval  EFI_SUCCESS                 Command is executed successfully.
   @retval  EFI_BAD_BUFFER_SIZE         The SCSI Request Packet was executed, but the entire DataBuffer could
@@ -678,7 +679,8 @@ ScsiWrite10Command (
   IN OUT VOID                  *DataBuffer   OPTIONAL,
   IN OUT UINT32                *DataLength,
   IN     UINT32                StartLba,
-  IN     UINT32                SectorSize
+  IN     UINT32                SectorSize,
+  IN     BOOLEAN               SetFua
   );
 
 /**
@@ -773,6 +775,7 @@ ScsiRead16Command (
   @param[in, out] DataLength           The length of data buffer.
   @param[in]      StartLba             The start address of LBA.
   @param[in]      SectorSize           The number of contiguous logical blocks of data that shall be transferred.
+  @param[in]      SetFua               If TRUE, FUA bit will be set.
 
   @retval  EFI_SUCCESS                 Command is executed successfully.
   @retval  EFI_BAD_BUFFER_SIZE         The SCSI Request Packet was executed, but the entire DataBuffer could
@@ -798,7 +801,8 @@ ScsiWrite16Command (
   IN OUT VOID                  *DataBuffer   OPTIONAL,
   IN OUT UINT32                *DataLength,
   IN     UINT64                StartLba,
-  IN     UINT32                SectorSize
+  IN     UINT32                SectorSize,
+  IN     BOOLEAN               SetFua
   );
 
 /**

--- a/MdePkg/Library/UefiScsiLib/UefiScsiLib.c
+++ b/MdePkg/Library/UefiScsiLib/UefiScsiLib.c
@@ -1028,7 +1028,8 @@ ScsiWrite10Command (
   IN OUT VOID                  *DataBuffer   OPTIONAL,
   IN OUT UINT32                *DataLength,
   IN     UINT32                StartLba,
-  IN     UINT32                SectorSize
+  IN     UINT32                SectorSize,
+  IN     BOOLEAN               SetFua
   )
 {
   EFI_SCSI_IO_SCSI_REQUEST_PACKET  CommandPacket;
@@ -1053,7 +1054,10 @@ ScsiWrite10Command (
   // Fill Cdb for Write (10) Command
   //
   Cdb[0] = EFI_SCSI_OP_WRITE10;
-  Cdb[1] = EFI_SCSI_BLOCK_FUA;
+  if (SetFua) {
+    Cdb[1] = EFI_SCSI_BLOCK_FUA;
+  }
+
   WriteUnaligned32 ((UINT32 *)&Cdb[2], SwapBytes32 (StartLba));
   WriteUnaligned16 ((UINT16 *)&Cdb[7], SwapBytes16 ((UINT16)SectorSize));
 
@@ -1202,6 +1206,7 @@ ScsiRead16Command (
   @param[in, out] DataLength           The length of data buffer.
   @param[in]      StartLba             The start address of LBA.
   @param[in]      SectorSize           The number of contiguous logical blocks of data that shall be transferred.
+  @param[in]      SetFua               If TRUE, the FUA bit will be set.
 
   @retval  EFI_SUCCESS                 Command is executed successfully.
   @retval  EFI_BAD_BUFFER_SIZE         The SCSI Request Packet was executed, but the entire DataBuffer could
@@ -1227,7 +1232,8 @@ ScsiWrite16Command (
   IN OUT VOID                  *DataBuffer   OPTIONAL,
   IN OUT UINT32                *DataLength,
   IN     UINT64                StartLba,
-  IN     UINT32                SectorSize
+  IN     UINT32                SectorSize,
+  IN     BOOLEAN               SetFua
   )
 {
   EFI_SCSI_IO_SCSI_REQUEST_PACKET  CommandPacket;
@@ -1252,7 +1258,10 @@ ScsiWrite16Command (
   // Fill Cdb for Write (16) Command
   //
   Cdb[0] = EFI_SCSI_OP_WRITE16;
-  Cdb[1] = EFI_SCSI_BLOCK_FUA;
+  if (SetFua) {
+    Cdb[1] = EFI_SCSI_BLOCK_FUA;
+  }
+
   WriteUnaligned64 ((UINT64 *)&Cdb[2], SwapBytes64 (StartLba));
   WriteUnaligned32 ((UINT32 *)&Cdb[10], SwapBytes32 (SectorSize));
 
@@ -1830,7 +1839,8 @@ ScsiWrite10CommandEx (
              DataBuffer,
              DataLength,
              StartLba,
-             SectorSize
+             SectorSize,
+             TRUE
              );
   }
 
@@ -2196,7 +2206,8 @@ ScsiWrite16CommandEx (
              DataBuffer,
              DataLength,
              StartLba,
-             SectorSize
+             SectorSize,
+             TRUE
              );
   }
 


### PR DESCRIPTION
# Description

Windows Server 2025 guest may fail to boot if the system disk(vhost-scsi device) doesn't support FUA and it is also configured as "write through". When the booting failure happens, the SCSI command fails with EFI_SCSI_SK_ILLEGAL_REQUEST and EFI_SCSI_ASC_INVALID_FIELD. This is due to the FUA bit is forcefully set in all SCSI Write commands. This patch checks the Write Caching and FUA support of disk device and configures the FUA bit properly in the SCSI command.

- [ ] Breaking change?
  - No
- [ ] Impacts security?
  - No
- [ ] Includes tests?
  - No

## How This Was Tested

Boot Windows 2025 guest from vhost-scsi disk device that doesn't support FUA and is also configured as "write through".

## Integration Instructions

N/A
