### PR TITLE
CryptoPkg: Alternative Openssl NASM/GAS optimized file selection

### DIFF
--- a/CryptoPkg/CryptoPkgFeatureFlagPcds.dsc.inc
+++ b/CryptoPkg/CryptoPkgFeatureFlagPcds.dsc.inc
@@ -10,15 +10,8 @@
 [PcdsFeatureFlag]
 #
 # Use Openssl NASM assembly source files that assume Windows calling convention
-# if the family is MSFT or the toolchain is CLANGPDB for Windows or Linux.
-# Also use Openssl NASM assembly source files that assume Windows calling
-# convention if host-based unit tests are being build for Windows.
-# Otherwise, the Openssl .S assembly source files that assume the Linux calling
-# convention.
+# if the family is MSFT or CLANGPDB for Windows or Linux.
 #
 !if "$(FAMILY)" == "MSFT" || "$(TOOL_CHAIN_TAG)" == "CLANGPDB"
-gEfiCryptoPkgTokenSpaceGuid.PcdOpensslLibAssemblySourceStyleNasm|TRUE
-!endif
-!if $(HOST_BASED_UNIT_TESTING_ENABLED) AND $(WIN_HOST_BUILD)
 gEfiCryptoPkgTokenSpaceGuid.PcdOpensslLibAssemblySourceStyleNasm|TRUE
 !endif

--- a/EmulatorPkg/EmulatorPkg.dsc
+++ b/EmulatorPkg/EmulatorPkg.dsc
@@ -222,11 +222,12 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdPeiCoreImageLoaderSearchTeSectionFirst|FALSE
   gEfiMdeModulePkgTokenSpaceGuid.PcdDxeIplBuildPageTables|FALSE
   gEmulatorPkgTokenSpaceGuid.PcdEmulatorLazyLoadSymbols|FALSE
-!if $(WIN_MINGW32_BUILD)
+!if $(WIN_HOST_BUILD)
   #
-  # When WIN_MINGW32_BUILD is set, -target is set to build Windows application.
-  # Set PcdOpensslLibAssemblySourceStyleNasm to TRUE to use Openssl NASM
-  # source files that assume a Windows calling convention.
+  # When WIN_HOST_BUILD is set, the default compiler calling convention is set
+  # to Windows calling convention for building a Windows application. Set
+  # PcdOpensslLibAssemblySourceStyleNasm to TRUE to use Openssl NASM source
+  # files that assume a Windows calling convention.
   #
   gEfiCryptoPkgTokenSpaceGuid.PcdOpensslLibAssemblySourceStyleNasm|TRUE
 !endif

--- a/UnitTestFrameworkPkg/Library/UnitTestDebugAssertLib/UnitTestDebugAssertLibHost.inf
+++ b/UnitTestFrameworkPkg/Library/UnitTestDebugAssertLib/UnitTestDebugAssertLibHost.inf
@@ -21,10 +21,21 @@
 [Packages]
   MdePkg/MdePkg.dec
   UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+  CryptoPkg/CryptoPkg.dec
 
 [LibraryClasses]
   BaseLib
   UnitTestLib
+
+[FeaturePcd]
+  #
+  # PcdOpensslLibAssemblySourceStyleNasm is not used by this library
+  #
+  # Add reference to PcdOpensslLibAssemblySourceStyleNasm in this NULL library
+  # instance that is included in every host-based unit test build to support
+  # setting PcdOpensslLibAssemblySourceStyleNasm in UnitTestFrameworkPkgHost.dsc.inc
+  #
+  gEfiCryptoPkgTokenSpaceGuid.PcdOpensslLibAssemblySourceStyleNasm
 
 [BuildOptions]
   MSFT:*_*_*_CC_FLAGS   == /c /Zi /Od

--- a/UnitTestFrameworkPkg/UnitTestFrameworkPkg.ci.yaml
+++ b/UnitTestFrameworkPkg/UnitTestFrameworkPkg.ci.yaml
@@ -44,7 +44,8 @@
     "DependencyCheck": {
         "AcceptableDependencies": [
             "MdePkg/MdePkg.dec",
-            "UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec"
+            "UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec",
+            "CryptoPkg/CryptoPkg.dec"
         ],
         # For host based unit tests
         "AcceptableDependencies-HOST_APPLICATION":[],

--- a/UnitTestFrameworkPkg/UnitTestFrameworkPkgHost.dsc.inc
+++ b/UnitTestFrameworkPkg/UnitTestFrameworkPkgHost.dsc.inc
@@ -9,8 +9,6 @@
 !include UnitTestFrameworkPkg/UnitTestFrameworkPkgCommon.dsc.inc
 
 [Defines]
-  HOST_BASED_UNIT_TESTING_ENABLED = TRUE
-
   #
   # Host based unit test builds only support NOOPT build target
   #
@@ -21,6 +19,17 @@
   #
   UNIT_TESTING_CODE_COVERAGE_ENABLE     = TRUE
   UNIT_TESTING_ADDRESS_SANITIZER_ENABLE = TRUE
+
+[PcdsFeatureFlag]
+!if $(WIN_HOST_BUILD)
+  #
+  # When WIN_HOST_BUILD is set, the default compiler calling convention is set
+  # to Windows calling convention for building a Windows application. Set
+  # PcdOpensslLibAssemblySourceStyleNasm to TRUE to use Openssl NASM source
+  # files that assume a Windows calling convention.
+  #
+  gEfiCryptoPkgTokenSpaceGuid.PcdOpensslLibAssemblySourceStyleNasm|TRUE
+!endif
 
 [LibraryClasses.common.HOST_APPLICATION]
   BaseLib|MdePkg/Library/BaseLib/UnitTestHostBaseLib.inf


### PR DESCRIPTION
# Description

Remove HOST_BASED_UNIT_TESTING_ENABLED define and instead, update UnitTestFrameworkPkgHost.dsc.inc to set PcdOpensslLibAssemblySourceStyleNasm. This change requires PcdOpensslLibAssemblySourceStyleNasm to be referenced in at least one INF in all host-based unit test builds, so PcdOpensslLibAssemblySourceStyleNasm is added to UnitTestDebugAssersLibHost which is the only NULL library instance that is unconditionally added to every host-based unit test build. Since this adds a reference to the CryptoPkg from the UnitTestFrameworkPkg, UnitTestFrameworkPkg.ci.yaml has to add CryptoPkg to the set of Acceptable Dependencies.

This change allows the CryptoPkg to set PcdOpensslLibAssemblySourceStyleNasm for firmware builds and for EmulatorPkg.dsc and UnitTestFrameworkPkgHost.dsc.inc to set PcdOpensslLibAssemblySourceStyleNasm for HOST_APPLICATIONs.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

Verified CryptoPkg builds for fw and host applications

## Integration Instructions

N/A
