### PR TITLE
MdeModulePkg/Variable/RuntimeDxe: Do not clobber Attributes on error

### DIFF
--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxe.c
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxe.c
@@ -13,6 +13,7 @@
 
   InitCommunicateBuffer() is really function to check the variable data size.
 
+Copyright (c) 2026, ARM Ltd. All rights reserved.<BR>
 Copyright (c) 2010 - 2024, Intel Corporation. All rights reserved.<BR>
 Copyright (c) Microsoft Corporation.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -760,10 +761,10 @@ FindVariableInSmm (
     // Only update DataSize when needed
     //
     *DataSize = SmmVariableHeader->DataSize;
-  }
 
-  if (Attributes != NULL) {
-    *Attributes = SmmVariableHeader->Attributes;
+    if (Attributes != NULL) {
+      *Attributes = SmmVariableHeader->Attributes;
+    }
   }
 
   if (EFI_ERROR (Status)) {


### PR DESCRIPTION
# Description

`FindVariableInSmm()` copied `Attributes` from the SMM response back to the caller even when `GetVariable` returned an error (e.g. `EFI_NOT_FOUND`). In the `EFI_NOT_FOUND` case, the returned `Attributes` value is 0, which overwrote the caller-provided `Attributes`.

This differs from the native `VariableServiceGetVariable()` path, which only updates `Attributes` on `EFI_SUCCESS` or `EFI_BUFFER_TOO_SMALL`. In the SMM path, clobbering `Attributes` on error can cause subsequent `SetVariable` calls to use incorrect attributes (e.g. losing `TIME_BASED_AUTH`), which breaks UEFI-SCT authenticated variable tests when using the SMM gateway backend.

Only copy `Attributes` back to the caller on `EFI_SUCCESS` or `EFI_BUFFER_TOO_SMALL`, preserving the caller-provided value on errors.

Allows [BlackBoxTest/AuthVariableServicesBBTestFunction - "SetVariable with one old timestamp, the return status should be EFI_SECURITY_VIOLATION"](https://github.com/tianocore/edk2-test/blob/master/uefi-sct/SctPkg/TestCase/UEFI/EFI/RuntimeServices/VariableServices/BlackBoxTest/AuthVariableServicesBBTestFunction.c#L1030) tests to pass correctly when using SMM gateway.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact? 
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Manual run of UEFI SCT test as part of [Arm SystemReady ACS (v25.04_SR_3.0.1)](https://github.com/ARM-software/arm-systemready/tree/v25.04_SR_3.0.1).

Final output:

```
Returned Status Code: Success

AuthVar_Func: [PASSED]
Passes........... 16
Warnings......... 0
Errors........... 0
```

## Integration Instructions

N/A
