### PR TITLE
RedfishPkg: Fix missing dependency when interigating with EmulatorPkg

### DIFF
--- a/RedfishPkg/RedfishLibs.dsc.inc
+++ b/RedfishPkg/RedfishLibs.dsc.inc
@@ -22,5 +22,8 @@
   HiiUtilityLib|RedfishPkg/Library/HiiUtilityLib/HiiUtilityLib.inf
   RedfishPlatformConfigLib|RedfishPkg/Library/RedfishPlatformConfigLib/RedfishPlatformConfigLib.inf
   RedfishHttpLib|RedfishPkg/Library/RedfishHttpLib/RedfishHttpLib.inf
+  RedfishPlatformWantedDeviceLib|RedfishPkg/Library/RedfishPlatformWantedDeviceLibNull/RedfishPlatformWantedDeviceLibNull.inf
+  IpmiLib|MdeModulePkg/Library/BaseIpmiLibNull/BaseIpmiLibNull.inf
+  RedfishContentCodingLib|RedfishPkg/Library/RedfishContentCodingLibNull/RedfishContentCodingLibNull.inf
 !endif
 

--- a/RedfishPkg/RedfishPkg.dec
+++ b/RedfishPkg/RedfishPkg.dec
@@ -128,6 +128,7 @@
     MdeModulePkg/MdeModulePkg.dec
     RedfishPkg/RedfishPkg.dec
   }
+
   #
   # This PCD indicates the EFI REST EX access mode to Redfish service.
   # Default is set to out of band access.


### PR DESCRIPTION
# Description

When Redfish is enabled on EmulatorPkg it fails to build due missing instances of RedfishPlatformWantedDeviceLib, IpmiLib and RedfishContentCodingLib libraries. Add those library instances to DSC include file so EmulatorPkg could detect it.

Also, add gEfiRedfishClientPkgTokenSpaceGuid to DEC file of RedfishPkg which EmulatorPkg depends on.

Those two solutions fix following errors when building EmulatorPkg with Redfish:

Note: this below block contains multiple build fails with different library instances
```
build.py...
/home/khaalid/edk2/EmulatorPkg/EmulatorPkg.dsc(...): error 4000: Instance of library class [RedfishPlatformWantedDeviceLib] is not found for module [/home/khaalid/edk2/RedfishPkg/RedfishRestExDxe/RedfishRestExDxe.inf], [RedfishPlatformWantedDeviceLib] is:
        consumed by /home/khaalid/edk2/RedfishPkg/RedfishRestExDxe/RedfishRestExDxe.inf

build.py...
/home/khaalid/edk2/EmulatorPkg/EmulatorPkg.dsc(...): error 4000: Instance of library class [IpmiLib] is not found for module [/home/khaalid/edk2/RedfishPkg/RedfishCredentialDxe/RedfishCredentialDxe.inf], [IpmiLib] is:
        consumed by /home/khaalid/edk2/RedfishPkg/Library/RedfishPlatformCredentialIpmiLib/RedfishPlatformCredentialIpmiLib.inf
 
build.py...
/home/khaalid/edk2/EmulatorPkg/EmulatorPkg.dsc(...): error 4000: Instance of library class [RedfishContentCodingLib] is not found for module [/home/khaalid/edk2/RedfishPkg/RedfishHttpDxe/RedfishHttpDxe.inf], [RedfishContentCodingLib] is:
        consumed by /home/khaalid/edk2/RedfishPkg/RedfishHttpDxe/RedfishHttpDxe.inf

```

When the PCD is missing it fails with following:
```
build.py...
/home/khaalid/edk2/EmulatorPkg/EmulatorPkg.dsc(300): error F001: Pcd (gEfiRedfishClientPkgTokenSpaceGuid.PcdRedfishServiceEtagSupported) defined in DSC is not declared in DEC files referenced in INF files in FDF. Arch: ['X64']
```

- [ ] Breaking change?
  - NO
- [ ] Impacts security?
  - NO
- [ ] Includes tests?
  - NO

## How This Was Tested
```
build -a X64 -p EmulatorPkg/EmulatorPkg.dsc -t GCC5 -b DEBUG -DREDFISH_ENABLE=1
```
## Integration Instructions
N/A