### PR TITLE
 Use common String utilities

### DIFF
--- a/MdeModulePkg/Library/VarCheckLib/VarCheckLib.c
+++ b/MdeModulePkg/Library/VarCheckLib/VarCheckLib.c
@@ -90,29 +90,6 @@ VARIABLE_ENTRY_PROPERTY  mVarCheckVariableWithWildcardName[] = {
 };
 
 /**
-  Check if a Unicode character is an upper case hexadecimal character.
-
-  This function checks if a Unicode character is an upper case
-  hexadecimal character.  The valid upper case hexadecimal character is
-  L'0' to L'9', or L'A' to L'F'.
-
-
-  @param[in] Char       The character to check against.
-
-  @retval TRUE          If the Char is an upper case hexadecmial character.
-  @retval FALSE         If the Char is not an upper case hexadecmial character.
-
-**/
-BOOLEAN
-EFIAPI
-VarCheckInternalIsHexaDecimalDigitCharacter (
-  IN CHAR16  Char
-  )
-{
-  return (BOOLEAN)((Char >= L'0' && Char <= L'9') || (Char >= L'A' && Char <= L'F'));
-}
-
-/**
   Variable property get with wildcard name.
 
   @param[in] VariableName       Pointer to variable name.
@@ -138,10 +115,10 @@ VariablePropertyGetWithWildcardName (
       if (WildcardMatch) {
         if ((StrLen (VariableName) == StrLen (mVarCheckVariableWithWildcardName[Index].Name)) &&
             (StrnCmp (VariableName, mVarCheckVariableWithWildcardName[Index].Name, NameLength) == 0) &&
-            VarCheckInternalIsHexaDecimalDigitCharacter (VariableName[NameLength]) &&
-            VarCheckInternalIsHexaDecimalDigitCharacter (VariableName[NameLength + 1]) &&
-            VarCheckInternalIsHexaDecimalDigitCharacter (VariableName[NameLength + 2]) &&
-            VarCheckInternalIsHexaDecimalDigitCharacter (VariableName[NameLength + 3]))
+            CharIsUpperHexNum (VariableName[NameLength]) &&
+            CharIsUpperHexNum (VariableName[NameLength + 1]) &&
+            CharIsUpperHexNum (VariableName[NameLength + 2]) &&
+            CharIsUpperHexNum (VariableName[NameLength + 3]))
         {
           return &mVarCheckVariableWithWildcardName[Index].VariableProperty;
         }

--- a/MdeModulePkg/Library/VarCheckUefiLib/VarCheckUefiLibNullClass.c
+++ b/MdeModulePkg/Library/VarCheckUefiLib/VarCheckUefiLibNullClass.c
@@ -685,29 +685,6 @@ EFI_GUID  *mUefiDefinedGuid[] = {
 };
 
 /**
-  Check if a Unicode character is an upper case hexadecimal character.
-
-  This function checks if a Unicode character is an upper case
-  hexadecimal character.  The valid upper case hexadecimal character is
-  L'0' to L'9', or L'A' to L'F'.
-
-
-  @param[in] Char       The character to check against.
-
-  @retval TRUE          If the Char is an upper case hexadecmial character.
-  @retval FALSE         If the Char is not an upper case hexadecmial character.
-
-**/
-BOOLEAN
-EFIAPI
-VarCheckUefiIsHexaDecimalDigitCharacter (
-  IN CHAR16  Char
-  )
-{
-  return (BOOLEAN)((Char >= L'0' && Char <= L'9') || (Char >= L'A' && Char <= L'F'));
-}
-
-/**
 
   This code checks if variable is hardware error record variable or not.
 
@@ -731,10 +708,10 @@ IsHwErrRecVariable (
   if (!CompareGuid (VendorGuid, &gEfiHardwareErrorVariableGuid) ||
       (StrLen (VariableName) != StrLen (L"HwErrRec####")) ||
       (StrnCmp (VariableName, L"HwErrRec", StrLen (L"HwErrRec")) != 0) ||
-      !VarCheckUefiIsHexaDecimalDigitCharacter (VariableName[0x8]) ||
-      !VarCheckUefiIsHexaDecimalDigitCharacter (VariableName[0x9]) ||
-      !VarCheckUefiIsHexaDecimalDigitCharacter (VariableName[0xA]) ||
-      !VarCheckUefiIsHexaDecimalDigitCharacter (VariableName[0xB]))
+      !CharIsUpperHexNum (VariableName[0x8]) ||
+      !CharIsUpperHexNum (VariableName[0x9]) ||
+      !CharIsUpperHexNum (VariableName[0xA]) ||
+      !CharIsUpperHexNum (VariableName[0xB]))
   {
     return FALSE;
   }
@@ -780,10 +757,10 @@ GetUefiDefinedVarCheckFunction (
     for (Index = 0; Index < sizeof (mGlobalVariableList2)/sizeof (mGlobalVariableList2[0]); Index++) {
       if ((StrLen (VariableName) == StrLen (mGlobalVariableList2[Index].Name)) &&
           (StrnCmp (VariableName, mGlobalVariableList2[Index].Name, NameLength) == 0) &&
-          VarCheckUefiIsHexaDecimalDigitCharacter (VariableName[NameLength]) &&
-          VarCheckUefiIsHexaDecimalDigitCharacter (VariableName[NameLength + 1]) &&
-          VarCheckUefiIsHexaDecimalDigitCharacter (VariableName[NameLength + 2]) &&
-          VarCheckUefiIsHexaDecimalDigitCharacter (VariableName[NameLength + 3]))
+          CharIsUpperHexNum (VariableName[NameLength]) &&
+          CharIsUpperHexNum (VariableName[NameLength + 1]) &&
+          CharIsUpperHexNum (VariableName[NameLength + 2]) &&
+          CharIsUpperHexNum (VariableName[NameLength + 3]))
       {
         *VariableProperty = &(mGlobalVariableList2[Index].VariableProperty);
         return mGlobalVariableList2[Index].CheckFunction;

--- a/MdeModulePkg/Universal/Disk/UnicodeCollation/EnglishDxe/EnglishDxe.inf
+++ b/MdeModulePkg/Universal/Disk/UnicodeCollation/EnglishDxe/EnglishDxe.inf
@@ -37,6 +37,7 @@
   MdeModulePkg/MdeModulePkg.dec
 
 [LibraryClasses]
+  BaseLib
   UefiBootServicesTableLib
   UefiDriverEntryPoint
   DebugLib

--- a/MdeModulePkg/Universal/Disk/UnicodeCollation/EnglishDxe/UnicodeCollationEng.c
+++ b/MdeModulePkg/Universal/Disk/UnicodeCollation/EnglishDxe/UnicodeCollationEng.c
@@ -106,7 +106,7 @@ InitializeUnicodeCollationEng (
     mEngLowerMap[Index] = (CHAR8)Index;
     mEngInfoMap[Index]  = 0;
 
-    if (((Index >= 'a') && (Index <= 'z')) || ((Index >= 0xe0) && (Index <= 0xf6)) || ((Index >= 0xf8) && (Index <= 0xfe))) {
+    if (AsciiCharIsLowerAlpha ((CHAR8)Index) || ((Index >= 0xe0) && (Index <= 0xf6)) || ((Index >= 0xf8) && (Index <= 0xfe))) {
       Index2               = Index - 0x20;
       mEngUpperMap[Index]  = (CHAR8)Index2;
       mEngLowerMap[Index2] = (CHAR8)Index;

--- a/MdeModulePkg/Universal/Disk/UnicodeCollation/EnglishDxe/UnicodeCollationEng.h
+++ b/MdeModulePkg/Universal/Disk/UnicodeCollation/EnglishDxe/UnicodeCollationEng.h
@@ -12,6 +12,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #include <Protocol/UnicodeCollation.h>
 
+#include <Library/BaseLib.h>
 #include <Library/DebugLib.h>
 #include <Library/UefiDriverEntryPoint.h>
 #include <Library/UefiBootServicesTableLib.h>

--- a/MdePkg/Include/Library/BaseLib.h
+++ b/MdePkg/Include/Library/BaseLib.h
@@ -2667,6 +2667,100 @@ AsciiCharToUpper (
   IN      CHAR8  Chr
   );
 
+/*
+ * Unicode String / Char checker functions.
+ */
+
+/**
+  Determine if a Unicode Char is a number.
+
+  @param[in] Char         Char to analyze.
+
+  @retval TRUE            Unicode Char is a number.
+  @retval FALSE           Otherwise.
+**/
+BOOLEAN
+EFIAPI
+CharIsNum (
+  IN CHAR16  Char
+  );
+
+/**
+  Determine if a Unicode Char is a hexadecimal number.
+
+  @param[in] Char         Char to analyze.
+
+  @retval TRUE            Unicode Char is a hexadecimal number.
+  @retval FALSE           Otherwise.
+**/
+BOOLEAN
+EFIAPI
+CharIsHexNum (
+  IN CHAR16  Char
+  );
+
+/**
+  Determine if a Unicode Char is an uppercase hexadecimal number.
+
+  @param[in] Char         Char to analyze.
+
+  @retval TRUE            Unicode Char is an uppercase hexadecimal number.
+  @retval FALSE           Otherwise.
+**/
+BOOLEAN
+EFIAPI
+CharIsUpperHexNum (
+  IN CHAR16  Char
+  );
+
+/**
+  Determine if a Unicode String has only numbers.
+
+  @param[in] String       Pointer to the string to analyze.
+  @param[in] MaxSize      Maximum number of characters to analyze.
+
+  @retval TRUE            Unicode String has only numbers.
+  @retval FALSE           Unicode String has at least one other character.
+**/
+BOOLEAN
+EFIAPI
+StrnIsNum (
+  IN CONST CHAR16  *String,
+  IN       UINTN   MaxSize
+  );
+
+/**
+  Determine if a Unicode String has only hexadecimal numbers.
+
+  @param[in] String       Pointer to the string to analyze.
+  @param[in] MaxSize      Maximum number of characters to analyze.
+
+  @retval TRUE            Unicode String has only hexadecimal numbers.
+  @retval FALSE           Unicode String has at least one other character.
+**/
+BOOLEAN
+EFIAPI
+StrnIsHexNum (
+  IN CONST CHAR16  *String,
+  IN       UINTN   MaxSize
+  );
+
+/**
+  Determine if a Unicode String has only uppercase hexadecimal numbers.
+
+  @param[in] String       Pointer to the string to analyze.
+  @param[in] MaxSize      Maximum number of characters to analyze.
+
+  @retval TRUE            Unicode String has only uppercase hexadecimal numbers.
+  @retval FALSE           Unicode String has at least one other character.
+**/
+BOOLEAN
+EFIAPI
+StrnIsUpperHexNum (
+  IN CONST CHAR16  *String,
+  IN       UINTN   MaxSize
+  );
+
 /**
   Convert binary data to a Base64 encoded ascii string based on RFC4648.
 

--- a/MdePkg/Include/Library/BaseLib.h
+++ b/MdePkg/Include/Library/BaseLib.h
@@ -2668,6 +2668,220 @@ AsciiCharToUpper (
   );
 
 /*
+ * Ascii String / Char checker functions.
+ */
+
+/**
+  Determine if a Ascii Char is a lowercase letter.
+
+  @param[in] Char         Char to analyze.
+
+  @retval TRUE            Ascii Char is a lowercase letter.
+  @retval FALSE           Otherwise.
+**/
+BOOLEAN
+EFIAPI
+AsciiCharIsLowerAlpha (
+  IN CHAR8  Char
+  );
+
+/**
+  Determine if a Ascii Char is a uppercase letter.
+
+  @param[in] Char         Char to analyze.
+
+  @retval TRUE            Ascii Char is a uppercase letter.
+  @retval FALSE           Otherwise.
+**/
+BOOLEAN
+EFIAPI
+AsciiCharIsUpperAlpha (
+  IN CHAR8  Char
+  );
+
+/**
+  Determine if a Ascii Char is a letter.
+
+  @param[in] Char         Char to analyze.
+
+  @retval TRUE            Ascii Char is a letter.
+  @retval FALSE           Otherwise.
+**/
+BOOLEAN
+EFIAPI
+AsciiCharIsAlpha (
+  IN CHAR8  Char
+  );
+
+/**
+  Determine if a Ascii Char is a number.
+
+  @param[in] Char         Char to analyze.
+
+  @retval TRUE            Ascii Char is a number.
+  @retval FALSE           Otherwise.
+**/
+BOOLEAN
+EFIAPI
+AsciiCharIsNum (
+  IN CHAR8  Char
+  );
+
+/**
+  Determine if a Ascii Char is a hexadecimal number.
+
+  @param[in] Char         Char to analyze.
+
+  @retval TRUE            Ascii Char is a hexadecimal number.
+  @retval FALSE           Otherwise.
+**/
+BOOLEAN
+EFIAPI
+AsciiCharIsHexNum (
+  IN CHAR8  Char
+  );
+
+/**
+  Determine if a Ascii Char is an uppercase hexadecimal number.
+
+  @param[in] Char         Char to analyze.
+
+  @retval TRUE            Ascii Char is an uppercase hexadecimal number.
+  @retval FALSE           Otherwise.
+**/
+BOOLEAN
+EFIAPI
+AsciiCharIsUpperHexNum (
+  IN CHAR8  Char
+  );
+
+/**
+  Determine if a Ascii Char is a letter or number.
+
+  @param[in] Char         Char to analyze.
+
+  @retval TRUE            Ascii Char is a letter or number.
+  @retval FALSE           Otherwise.
+**/
+BOOLEAN
+EFIAPI
+AsciiCharIsAlphaNum (
+  IN CHAR8  Char
+  );
+
+/**
+  Determine if a Ascii String has only lowercase letters.
+
+  @param[in] String       Pointer to the string to analyze.
+  @param[in] MaxSize      Maximum number of characters to analyze.
+
+  @retval TRUE            Ascii String has only lowercase letters.
+  @retval FALSE           Ascii String has at least one other character.
+**/
+BOOLEAN
+EFIAPI
+AsciiStrnIsLowerAlpha (
+  IN CONST CHAR8  *String,
+  IN       UINTN  MaxSize
+  );
+
+/**
+  Determine if a Ascii String has only uppercase letters.
+
+  @param[in] String       Pointer to the string to analyze.
+  @param[in] MaxSize      Maximum number of characters to analyze.
+
+  @retval TRUE            Ascii String has only uppercase letters.
+  @retval FALSE           Ascii String has at least one other character.
+**/
+BOOLEAN
+EFIAPI
+AsciiStrnIsUpperAlpha (
+  IN CONST CHAR8  *String,
+  IN       UINTN  MaxSize
+  );
+
+/**
+  Determine if a Ascii String has only letters.
+
+  @param[in] String       Pointer to the string to analyze.
+  @param[in] MaxSize      Maximum number of characters to analyze.
+
+  @retval TRUE            Ascii String has only letters.
+  @retval FALSE           Ascii String has at least one other character.
+**/
+BOOLEAN
+EFIAPI
+AsciiStrnIsAlpha (
+  IN CONST CHAR8  *String,
+  IN       UINTN  MaxSize
+  );
+
+/**
+  Determine if a Ascii String has only numbers.
+
+  @param[in] String       Pointer to the string to analyze.
+  @param[in] MaxSize      Maximum number of characters to analyze.
+
+  @retval TRUE            Ascii String has only numbers.
+  @retval FALSE           Ascii String has at least one other character.
+**/
+BOOLEAN
+EFIAPI
+AsciiStrnIsNum (
+  IN CONST CHAR8  *String,
+  IN       UINTN  MaxSize
+  );
+
+/**
+  Determine if a Ascii String has only hexadecimal numbers.
+
+  @param[in] String       Pointer to the string to analyze.
+  @param[in] MaxSize      Maximum number of characters to analyze.
+
+  @retval TRUE            Ascii String has only hexadecimal numbers.
+  @retval FALSE           Ascii String has at least one other character.
+**/
+BOOLEAN
+EFIAPI
+AsciiStrnIsHexNum (
+  IN CONST CHAR8  *String,
+  IN       UINTN  MaxSize
+  );
+
+/**
+  Determine if a Ascii String has only uppercase hexadecimal numbers.
+
+  @param[in] String       Pointer to the string to analyze.
+  @param[in] MaxSize      Maximum number of characters to analyze.
+
+  @retval TRUE            Ascii String has only uppercase hexadecimal numbers.
+  @retval FALSE           Ascii String has at least one other character.
+**/
+BOOLEAN
+EFIAPI
+AsciiStrnIsUpperHexNum (
+  IN CONST CHAR8  *String,
+  IN       UINTN  MaxSize
+  );
+
+/**
+  Determine if a Ascii String has only letters or numbers.
+
+  @param[in] String       Pointer to the string to analyze.
+  @param[in] MaxSize      Maximum number of characters to analyze.
+
+  @retval TRUE            Ascii String has only letters or numbers.
+  @retval FALSE           Ascii String has at least one other character.
+**/
+BOOLEAN
+EFIAPI
+AsciiStrnIsAlphaNum (
+  IN CONST CHAR8  *String,
+  IN       UINTN  MaxSize
+  );
+
+/*
  * Unicode String / Char checker functions.
  */
 

--- a/MdePkg/Library/BaseLib/BaseLibInternals.h
+++ b/MdePkg/Library/BaseLib/BaseLibInternals.h
@@ -456,25 +456,6 @@ InternalHexCharToUintn (
   );
 
 /**
-  Check if a ASCII character is a decimal character.
-
-  This internal function checks if a Unicode character is a
-  decimal character. The valid decimal character is from
-  '0' to '9'.
-
-  @param  Char  The character to check against.
-
-  @retval TRUE  If the Char is a decmial character.
-  @retval FALSE If the Char is not a decmial character.
-
-**/
-BOOLEAN
-EFIAPI
-InternalAsciiIsDecimalDigitCharacter (
-  IN      CHAR8  Char
-  );
-
-/**
   Check if a ASCII character is a hexadecimal character.
 
   This internal function checks if a ASCII character is a

--- a/MdePkg/Library/BaseLib/BaseLibInternals.h
+++ b/MdePkg/Library/BaseLib/BaseLibInternals.h
@@ -437,25 +437,6 @@ InternalLongJump (
   );
 
 /**
-  Check if a Unicode character is a decimal character.
-
-  This internal function checks if a Unicode character is a
-  decimal character. The valid decimal character is from
-  L'0' to L'9'.
-
-  @param  Char  The character to check against.
-
-  @retval TRUE  If the Char is a decmial character.
-  @retval FALSE If the Char is not a decmial character.
-
-**/
-BOOLEAN
-EFIAPI
-InternalIsDecimalDigitCharacter (
-  IN      CHAR16  Char
-  );
-
-/**
   Convert a Unicode character to numerical value.
 
   This internal function only deal with Unicode character

--- a/MdePkg/Library/BaseLib/BaseLibInternals.h
+++ b/MdePkg/Library/BaseLib/BaseLibInternals.h
@@ -456,26 +456,6 @@ InternalHexCharToUintn (
   );
 
 /**
-  Check if a Unicode character is a hexadecimal character.
-
-  This internal function checks if a Unicode character is a
-  decimal character.  The valid hexadecimal character is
-  L'0' to L'9', L'a' to L'f', or L'A' to L'F'.
-
-
-  @param  Char  The character to check against.
-
-  @retval TRUE  If the Char is a hexadecmial character.
-  @retval FALSE If the Char is not a hexadecmial character.
-
-**/
-BOOLEAN
-EFIAPI
-InternalIsHexaDecimalDigitCharacter (
-  IN      CHAR16  Char
-  );
-
-/**
   Check if a ASCII character is a decimal character.
 
   This internal function checks if a Unicode character is a

--- a/MdePkg/Library/BaseLib/BaseLibInternals.h
+++ b/MdePkg/Library/BaseLib/BaseLibInternals.h
@@ -456,26 +456,6 @@ InternalHexCharToUintn (
   );
 
 /**
-  Check if a ASCII character is a hexadecimal character.
-
-  This internal function checks if a ASCII character is a
-  decimal character.  The valid hexadecimal character is
-  L'0' to L'9', L'a' to L'f', or L'A' to L'F'.
-
-
-  @param  Char  The character to check against.
-
-  @retval TRUE  If the Char is a hexadecmial character.
-  @retval FALSE If the Char is not a hexadecmial character.
-
-**/
-BOOLEAN
-EFIAPI
-InternalAsciiIsHexaDecimalDigitCharacter (
-  IN      CHAR8  Char
-  );
-
-/**
   Convert a ASCII character to numerical value.
 
   This internal function only deal with Unicode character

--- a/MdePkg/Library/BaseLib/SafeString.c
+++ b/MdePkg/Library/BaseLib/SafeString.c
@@ -669,7 +669,7 @@ StrDecimalToUintnS (
 
   *Data = 0;
 
-  while (InternalIsDecimalDigitCharacter (*String)) {
+  while (CharIsNum (*String)) {
     //
     // If the number represented by String overflows according to the range
     // defined by UINTN, then MAX_UINTN is stored in *Data and
@@ -781,7 +781,7 @@ StrDecimalToUint64S (
 
   *Data = 0;
 
-  while (InternalIsDecimalDigitCharacter (*String)) {
+  while (CharIsNum (*String)) {
     //
     // If the number represented by String overflows according to the range
     // defined by UINT64, then MAX_UINT64 is stored in *Data and
@@ -1373,7 +1373,7 @@ StrToIpv4Address (
   SAFE_STRING_CONSTRAINT_CHECK ((Address != NULL), RETURN_INVALID_PARAMETER);
 
   for (Pointer = (CHAR16 *)String, AddressIndex = 0; AddressIndex < ARRAY_SIZE (Address->Addr) + 1;) {
-    if (!InternalIsDecimalDigitCharacter (*Pointer)) {
+    if (!CharIsNum (*Pointer)) {
       //
       // D or P contains invalid characters.
       //

--- a/MdePkg/Library/BaseLib/SafeString.c
+++ b/MdePkg/Library/BaseLib/SafeString.c
@@ -2451,7 +2451,7 @@ AsciiStrHexToUintnS (
 
   *Data = 0;
 
-  while (InternalAsciiIsHexaDecimalDigitCharacter (*String)) {
+  while (AsciiCharIsHexNum (*String)) {
     //
     // If the number represented by String overflows according to the range
     // defined by UINTN, then MAX_UINTN is stored in *Data and
@@ -2579,7 +2579,7 @@ AsciiStrHexToUint64S (
 
   *Data = 0;
 
-  while (InternalAsciiIsHexaDecimalDigitCharacter (*String)) {
+  while (AsciiCharIsHexNum (*String)) {
     //
     // If the number represented by String overflows according to the range
     // defined by UINT64, then MAX_UINT64 is stored in *Data and
@@ -3120,7 +3120,7 @@ AsciiStrToIpv6Address (
   SAFE_STRING_CONSTRAINT_CHECK ((Address != NULL), RETURN_INVALID_PARAMETER);
 
   for (Pointer = String, AddressIndex = 0; AddressIndex < ARRAY_SIZE (Address->Addr) + 1;) {
-    if (!InternalAsciiIsHexaDecimalDigitCharacter (*Pointer)) {
+    if (!AsciiCharIsHexNum (*Pointer)) {
       if (*Pointer != ':') {
         //
         // ":" or "/" should be followed by digit characters.
@@ -3165,7 +3165,7 @@ AsciiStrToIpv6Address (
       }
     }
 
-    if (!InternalAsciiIsHexaDecimalDigitCharacter (*Pointer)) {
+    if (!AsciiCharIsHexNum (*Pointer)) {
       if (*Pointer == '/') {
         //
         // Might be optional "/P" after "::".
@@ -3602,7 +3602,7 @@ AsciiStrHexToBytes (
   // 5. String shall not contains invalid hexadecimal digits.
   //
   for (Index = 0; Index < Length; Index++) {
-    if (!InternalAsciiIsHexaDecimalDigitCharacter (String[Index])) {
+    if (!AsciiCharIsHexNum (String[Index])) {
       break;
     }
   }

--- a/MdePkg/Library/BaseLib/SafeString.c
+++ b/MdePkg/Library/BaseLib/SafeString.c
@@ -2215,7 +2215,7 @@ AsciiStrDecimalToUintnS (
 
   *Data = 0;
 
-  while (InternalAsciiIsDecimalDigitCharacter (*String)) {
+  while (AsciiCharIsNum (*String)) {
     //
     // If the number represented by String overflows according to the range
     // defined by UINTN, then MAX_UINTN is stored in *Data and
@@ -2323,7 +2323,7 @@ AsciiStrDecimalToUint64S (
 
   *Data = 0;
 
-  while (InternalAsciiIsDecimalDigitCharacter (*String)) {
+  while (AsciiCharIsNum (*String)) {
     //
     // If the number represented by String overflows according to the range
     // defined by UINT64, then MAX_UINT64 is stored in *Data and
@@ -3333,7 +3333,7 @@ AsciiStrToIpv4Address (
   SAFE_STRING_CONSTRAINT_CHECK ((Address != NULL), RETURN_INVALID_PARAMETER);
 
   for (Pointer = (CHAR8 *)String, AddressIndex = 0; AddressIndex < ARRAY_SIZE (Address->Addr) + 1;) {
-    if (!InternalAsciiIsDecimalDigitCharacter (*Pointer)) {
+    if (!AsciiCharIsNum (*Pointer)) {
       //
       // D or P contains invalid characters.
       //

--- a/MdePkg/Library/BaseLib/SafeString.c
+++ b/MdePkg/Library/BaseLib/SafeString.c
@@ -915,7 +915,7 @@ StrHexToUintnS (
 
   *Data = 0;
 
-  while (InternalIsHexaDecimalDigitCharacter (*String)) {
+  while (CharIsHexNum (*String)) {
     //
     // If the number represented by String overflows according to the range
     // defined by UINTN, then MAX_UINTN is stored in *Data and
@@ -1048,7 +1048,7 @@ StrHexToUint64S (
 
   *Data = 0;
 
-  while (InternalIsHexaDecimalDigitCharacter (*String)) {
+  while (CharIsHexNum (*String)) {
     //
     // If the number represented by String overflows according to the range
     // defined by UINT64, then MAX_UINT64 is stored in *Data and
@@ -1156,7 +1156,7 @@ StrToIpv6Address (
   SAFE_STRING_CONSTRAINT_CHECK ((Address != NULL), RETURN_INVALID_PARAMETER);
 
   for (Pointer = String, AddressIndex = 0; AddressIndex < ARRAY_SIZE (Address->Addr) + 1;) {
-    if (!InternalIsHexaDecimalDigitCharacter (*Pointer)) {
+    if (!CharIsHexNum (*Pointer)) {
       if (*Pointer != L':') {
         //
         // ":" or "/" should be followed by digit characters.
@@ -1201,7 +1201,7 @@ StrToIpv6Address (
       }
     }
 
-    if (!InternalIsHexaDecimalDigitCharacter (*Pointer)) {
+    if (!CharIsHexNum (*Pointer)) {
       if (*Pointer == L'/') {
         //
         // Might be optional "/P" after "::".
@@ -1650,7 +1650,7 @@ StrHexToBytes (
   // 5. String shall not contains invalid hexadecimal digits.
   //
   for (Index = 0; Index < Length; Index++) {
-    if (!InternalIsHexaDecimalDigitCharacter (String[Index])) {
+    if (!CharIsHexNum (String[Index])) {
       break;
     }
   }

--- a/MdePkg/Library/BaseLib/String.c
+++ b/MdePkg/Library/BaseLib/String.c
@@ -526,28 +526,6 @@ StrHexToUint64 (
 }
 
 /**
-  Check if a ASCII character is a decimal character.
-
-  This internal function checks if a Unicode character is a
-  decimal character. The valid decimal character is from
-  '0' to '9'.
-
-  @param  Char  The character to check against.
-
-  @retval TRUE  If the Char is a decmial character.
-  @retval FALSE If the Char is not a decmial character.
-
-**/
-BOOLEAN
-EFIAPI
-InternalAsciiIsDecimalDigitCharacter (
-  IN      CHAR8  Char
-  )
-{
-  return (BOOLEAN)(Char >= '0' && Char <= '9');
-}
-
-/**
   Check if a ASCII character is a hexadecimal character.
 
   This internal function checks if a ASCII character is a
@@ -567,7 +545,7 @@ InternalAsciiIsHexaDecimalDigitCharacter (
   IN      CHAR8  Char
   )
 {
-  return (BOOLEAN)(InternalAsciiIsDecimalDigitCharacter (Char) ||
+  return (BOOLEAN)(AsciiCharIsNum (Char) ||
                    (Char >= 'A' && Char <= 'F') ||
                    (Char >= 'a' && Char <= 'f'));
 }

--- a/MdePkg/Library/BaseLib/String.c
+++ b/MdePkg/Library/BaseLib/String.c
@@ -266,28 +266,6 @@ StrStr (
 }
 
 /**
-  Check if a Unicode character is a decimal character.
-
-  This internal function checks if a Unicode character is a
-  decimal character. The valid decimal character is from
-  L'0' to L'9'.
-
-  @param  Char  The character to check against.
-
-  @retval TRUE  If the Char is a decmial character.
-  @retval FALSE If the Char is not a decmial character.
-
-**/
-BOOLEAN
-EFIAPI
-InternalIsDecimalDigitCharacter (
-  IN      CHAR16  Char
-  )
-{
-  return (BOOLEAN)(Char >= L'0' && Char <= L'9');
-}
-
-/**
   Convert a Unicode character to upper case only if
   it maps to a valid small-case ASCII character.
 
@@ -334,7 +312,7 @@ InternalHexCharToUintn (
   IN      CHAR16  Char
   )
 {
-  if (InternalIsDecimalDigitCharacter (Char)) {
+  if (CharIsNum (Char)) {
     return Char - L'0';
   }
 
@@ -361,7 +339,7 @@ InternalIsHexaDecimalDigitCharacter (
   IN      CHAR16  Char
   )
 {
-  return (BOOLEAN)(InternalIsDecimalDigitCharacter (Char) ||
+  return (BOOLEAN)(CharIsNum (Char) ||
                    (Char >= L'A' && Char <= L'F') ||
                    (Char >= L'a' && Char <= L'f'));
 }
@@ -773,7 +751,7 @@ InternalAsciiHexCharToUintn (
   IN      CHAR8  Char
   )
 {
-  if (InternalIsDecimalDigitCharacter (Char)) {
+  if (CharIsNum (Char)) {
     return Char - '0';
   }
 

--- a/MdePkg/Library/BaseLib/String.c
+++ b/MdePkg/Library/BaseLib/String.c
@@ -320,31 +320,6 @@ InternalHexCharToUintn (
 }
 
 /**
-  Check if a Unicode character is a hexadecimal character.
-
-  This internal function checks if a Unicode character is a
-  decimal character.  The valid hexadecimal character is
-  L'0' to L'9', L'a' to L'f', or L'A' to L'F'.
-
-
-  @param  Char  The character to check against.
-
-  @retval TRUE  If the Char is a hexadecmial character.
-  @retval FALSE If the Char is not a hexadecmial character.
-
-**/
-BOOLEAN
-EFIAPI
-InternalIsHexaDecimalDigitCharacter (
-  IN      CHAR16  Char
-  )
-{
-  return (BOOLEAN)(CharIsNum (Char) ||
-                   (Char >= L'A' && Char <= L'F') ||
-                   (Char >= L'a' && Char <= L'f'));
-}
-
-/**
   Convert a Null-terminated Unicode decimal string to a value of
   type UINTN.
 

--- a/MdePkg/Library/BaseLib/String.c
+++ b/MdePkg/Library/BaseLib/String.c
@@ -526,31 +526,6 @@ StrHexToUint64 (
 }
 
 /**
-  Check if a ASCII character is a hexadecimal character.
-
-  This internal function checks if a ASCII character is a
-  decimal character.  The valid hexadecimal character is
-  L'0' to L'9', L'a' to L'f', or L'A' to L'F'.
-
-
-  @param  Char  The character to check against.
-
-  @retval TRUE  If the Char is a hexadecmial character.
-  @retval FALSE If the Char is not a hexadecmial character.
-
-**/
-BOOLEAN
-EFIAPI
-InternalAsciiIsHexaDecimalDigitCharacter (
-  IN      CHAR8  Char
-  )
-{
-  return (BOOLEAN)(AsciiCharIsNum (Char) ||
-                   (Char >= 'A' && Char <= 'F') ||
-                   (Char >= 'a' && Char <= 'f'));
-}
-
-/**
   Returns the length of a Null-terminated ASCII string.
 
   This function returns the number of ASCII characters in the Null-terminated

--- a/MdePkg/Library/BaseLib/String.c
+++ b/MdePkg/Library/BaseLib/String.c
@@ -1637,6 +1637,383 @@ BcdToDecimal8 (
 }
 
 /*
+ * Ascii String / Char checker functions.
+ */
+
+/**
+  Determine if a Ascii Char is a lowercase letter.
+
+  @param[in] Char         Char to analyze.
+
+  @retval TRUE            Ascii Char is a lowercase letter.
+  @retval FALSE           Otherwise.
+**/
+BOOLEAN
+EFIAPI
+AsciiCharIsLowerAlpha (
+  IN CHAR8  Char
+  )
+{
+  return (Char >= 'a') && (Char <= 'z');
+}
+
+/**
+  Determine if a Ascii Char is a uppercase letter.
+
+  @param[in] Char         Char to analyze.
+
+  @retval TRUE            Ascii Char is a uppercase letter.
+  @retval FALSE           Otherwise.
+**/
+BOOLEAN
+EFIAPI
+AsciiCharIsUpperAlpha (
+  IN CHAR8  Char
+  )
+{
+  return ((Char >= 'A') && (Char <= 'Z'));
+}
+
+/**
+  Determine if a Ascii Char is a letter.
+
+  @param[in] Char         Char to analyze.
+
+  @retval TRUE            Ascii Char is a letter.
+  @retval FALSE           Otherwise.
+**/
+BOOLEAN
+EFIAPI
+AsciiCharIsAlpha (
+  IN CHAR8  Char
+  )
+{
+  return ((Char >= 'a') && (Char <= 'z')) ||
+         ((Char >= 'A') && (Char <= 'Z'));
+}
+
+/**
+  Determine if a Ascii Char is a number.
+
+  @param[in] Char         Char to analyze.
+
+  @retval TRUE            Ascii Char is a number.
+  @retval FALSE           Otherwise.
+**/
+BOOLEAN
+EFIAPI
+AsciiCharIsNum (
+  IN CHAR8  Char
+  )
+{
+  return (Char >= '0') && (Char <= '9');
+}
+
+/**
+  Determine if a Ascii Char is a hexadecimal number.
+
+  @param[in] Char         Char to analyze.
+
+  @retval TRUE            Ascii Char is a hexadecimal number.
+  @retval FALSE           Otherwise.
+**/
+BOOLEAN
+EFIAPI
+AsciiCharIsHexNum (
+  IN CHAR8  Char
+  )
+{
+  return ((Char >= '0') && (Char <= '9')) ||
+         ((Char >= 'a') && (Char <= 'f')) ||
+         ((Char >= 'A') && (Char <= 'F'));
+}
+
+/**
+  Determine if a Ascii Char is an uppercase hexadecimal number.
+
+  @param[in] Char         Char to analyze.
+
+  @retval TRUE            Ascii Char is an uppercase hexadecimal number.
+  @retval FALSE           Otherwise.
+**/
+BOOLEAN
+EFIAPI
+AsciiCharIsUpperHexNum (
+  IN CHAR8  Char
+  )
+{
+  return ((Char >= '0') && (Char <= '9')) ||
+         ((Char >= 'A') && (Char <= 'F'));
+}
+
+/**
+  Determine if a Ascii Char is a letter or number.
+
+  @param[in] Char         Char to analyze.
+
+  @retval TRUE            Ascii Char is a letter or number.
+  @retval FALSE           Otherwise.
+**/
+BOOLEAN
+EFIAPI
+AsciiCharIsAlphaNum (
+  IN CHAR8  Char
+  )
+{
+  return ((Char >= 'a') && (Char <= 'z')) ||
+         ((Char >= 'A') && (Char <= 'Z')) ||
+         ((Char >= '0') && (Char <= '9'));
+}
+
+/**
+  Determine if a Ascii String has only lowercase letters.
+
+  @param[in] String       Pointer to the string to analyze.
+  @param[in] MaxSize      Maximum number of characters to analyze.
+
+  @retval TRUE            Ascii String has only lowercase letters.
+  @retval FALSE           Ascii String has at least one other character.
+**/
+BOOLEAN
+EFIAPI
+AsciiStrnIsLowerAlpha (
+  IN CONST CHAR8  *String,
+  IN       UINTN  MaxSize
+  )
+{
+  UINTN  Count;
+
+  ASSERT (String != NULL);
+  ASSERT (MaxSize != 0);
+
+  if ((String == NULL) || (MaxSize == 0)) {
+    return FALSE;
+  }
+
+  for (Count = 0; Count < MaxSize && String[Count] != CHAR_NULL; Count++) {
+    if (!((String[Count] >= 'a') && (String[Count] <= 'z'))) {
+      return FALSE;
+    }
+  }
+
+  return TRUE;
+}
+
+/**
+  Determine if a Ascii String has only uppercase letters.
+
+  @param[in] String       Pointer to the string to analyze.
+  @param[in] MaxSize      Maximum number of characters to analyze.
+
+  @retval TRUE            Ascii String has only uppercase letters.
+  @retval FALSE           Ascii String has at least one other character.
+**/
+BOOLEAN
+EFIAPI
+AsciiStrnIsUpperAlpha (
+  IN CONST CHAR8  *String,
+  IN       UINTN  MaxSize
+  )
+{
+  UINTN  Count;
+
+  ASSERT (String != NULL);
+  ASSERT (MaxSize != 0);
+
+  if ((String == NULL) || (MaxSize == 0)) {
+    return FALSE;
+  }
+
+  for (Count = 0; Count < MaxSize && String[Count] != CHAR_NULL; Count++) {
+    if (!((String[Count] >= 'A') && (String[Count] <= 'Z'))) {
+      return FALSE;
+    }
+  }
+
+  return TRUE;
+}
+
+/**
+  Determine if a Ascii String has only letters.
+
+  @param[in] String       Pointer to the string to analyze.
+  @param[in] MaxSize      Maximum number of characters to analyze.
+
+  @retval TRUE            Ascii String has only letters.
+  @retval FALSE           Ascii String has at least one other character.
+**/
+BOOLEAN
+EFIAPI
+AsciiStrnIsAlpha (
+  IN CONST CHAR8  *String,
+  IN       UINTN  MaxSize
+  )
+{
+  UINTN  Count;
+
+  ASSERT (String != NULL);
+  ASSERT (MaxSize != 0);
+
+  if ((String == NULL) || (MaxSize == 0)) {
+    return FALSE;
+  }
+
+  for (Count = 0; Count < MaxSize && String[Count] != CHAR_NULL; Count++) {
+    if (!(((String[Count] >= 'a') && (String[Count] <= 'z')) &&
+          ((String[Count] >= 'A') && (String[Count] <= 'Z'))))
+    {
+      return FALSE;
+    }
+  }
+
+  return TRUE;
+}
+
+/**
+  Determine if a Ascii String has only numbers.
+
+  @param[in] String       Pointer to the string to analyze.
+  @param[in] MaxSize      Maximum number of characters to analyze.
+
+  @retval TRUE            Ascii String has only numbers.
+  @retval FALSE           Ascii String has at least one other character.
+**/
+BOOLEAN
+EFIAPI
+AsciiStrnIsNum (
+  IN CONST CHAR8  *String,
+  IN       UINTN  MaxSize
+  )
+{
+  UINTN  Count;
+
+  ASSERT (String != NULL);
+  ASSERT (MaxSize != 0);
+
+  if ((String == NULL) || (MaxSize == 0)) {
+    return FALSE;
+  }
+
+  for (Count = 0; Count < MaxSize && String[Count] != CHAR_NULL; Count++) {
+    if (!((String[Count] >= '0') && (String[Count] <= '9'))) {
+      return FALSE;
+    }
+  }
+
+  return TRUE;
+}
+
+/**
+  Determine if a Ascii String has only hexadecimal numbers.
+
+  @param[in] String       Pointer to the string to analyze.
+  @param[in] MaxSize      Maximum number of characters to analyze.
+
+  @retval TRUE            Ascii String has only hexadecimal numbers.
+  @retval FALSE           Ascii String has at least one other character.
+**/
+BOOLEAN
+EFIAPI
+AsciiStrnIsHexNum (
+  IN CONST CHAR8  *String,
+  IN       UINTN  MaxSize
+  )
+{
+  UINTN  Count;
+
+  ASSERT (String != NULL);
+  ASSERT (MaxSize != 0);
+
+  if ((String == NULL) || (MaxSize == 0)) {
+    return FALSE;
+  }
+
+  for (Count = 0; Count < MaxSize && String[Count] != CHAR_NULL; Count++) {
+    if (!(((String[Count] >= '0') && (String[Count] <= '9')) ||
+          ((String[Count] >= 'a') && (String[Count] <= 'f')) ||
+          ((String[Count] >= 'A') && (String[Count] <= 'F'))))
+    {
+      return FALSE;
+    }
+  }
+
+  return TRUE;
+}
+
+/**
+  Determine if a Ascii String has only uppercase hexadecimal numbers.
+
+  @param[in] String       Pointer to the string to analyze.
+  @param[in] MaxSize      Maximum number of characters to analyze.
+
+  @retval TRUE            Ascii String has only uppercase hexadecimal numbers.
+  @retval FALSE           Ascii String has at least one other character.
+**/
+BOOLEAN
+EFIAPI
+AsciiStrnIsUpperHexNum (
+  IN CONST CHAR8  *String,
+  IN       UINTN  MaxSize
+  )
+{
+  UINTN  Count;
+
+  ASSERT (String != NULL);
+  ASSERT (MaxSize != 0);
+
+  if ((String == NULL) || (MaxSize == 0)) {
+    return FALSE;
+  }
+
+  for (Count = 0; Count < MaxSize && String[Count] != CHAR_NULL; Count++) {
+    if (!(((String[Count] >= '0') && (String[Count] <= '9')) ||
+          ((String[Count] >= 'A') && (String[Count] <= 'F'))))
+    {
+      return FALSE;
+    }
+  }
+
+  return TRUE;
+}
+
+/**
+  Determine if a Ascii String has only letters or numbers.
+
+  @param[in] String       Pointer to the string to analyze.
+  @param[in] MaxSize      Maximum number of characters to analyze.
+
+  @retval TRUE            Ascii String has only letters or numbers.
+  @retval FALSE           Ascii String has at least one other character.
+**/
+BOOLEAN
+EFIAPI
+AsciiStrnIsAlphaNum (
+  IN CONST CHAR8  *String,
+  IN       UINTN  MaxSize
+  )
+{
+  UINTN  Count;
+
+  ASSERT (String != NULL);
+  ASSERT (MaxSize != 0);
+
+  if ((String == NULL) || (MaxSize == 0)) {
+    return FALSE;
+  }
+
+  for (Count = 0; Count < MaxSize && String[Count] != CHAR_NULL; Count++) {
+    if (!(((String[Count] >= 'a') && (String[Count] <= 'z')) ||
+          ((String[Count] >= 'A') && (String[Count] <= 'Z')) ||
+          ((String[Count] >= '0') && (String[Count] <= '9'))))
+    {
+      return FALSE;
+    }
+  }
+
+  return TRUE;
+}
+
+/*
  * Unicode String / Char checker functions.
  */
 

--- a/MdePkg/Library/BaseLib/String.c
+++ b/MdePkg/Library/BaseLib/String.c
@@ -1682,3 +1682,168 @@ BcdToDecimal8 (
   ASSERT ((Value & 0xf) < 0xa);
   return (UINT8)((Value >> 4) * 10 + (Value & 0xf));
 }
+
+/*
+ * Unicode String / Char checker functions.
+ */
+
+/**
+  Determine if a Unicode Char is a number.
+
+  @param[in] Char         Char to analyze.
+
+  @retval TRUE            Unicode Char is a number.
+  @retval FALSE           Otherwise.
+**/
+BOOLEAN
+EFIAPI
+CharIsNum (
+  IN CHAR16  Char
+  )
+{
+  return (Char >= L'0') && (Char <= L'9');
+}
+
+/**
+  Determine if a Unicode Char is a hexadecimal number.
+
+  @param[in] Char         Char to analyze.
+
+  @retval TRUE            Unicode Char is a hexadecimal number.
+  @retval FALSE           Otherwise.
+**/
+BOOLEAN
+EFIAPI
+CharIsHexNum (
+  IN CHAR16  Char
+  )
+{
+  return ((Char >= L'0') && (Char <= L'9')) ||
+         ((Char >= L'a') && (Char <= L'f')) ||
+         ((Char >= L'A') && (Char <= L'F'));
+}
+
+/**
+  Determine if a Unicode Char is an uppercase hexadecimal number.
+
+  @param[in] Char         Char to analyze.
+
+  @retval TRUE            Unicode Char is an uppercase hexadecimal number.
+  @retval FALSE           Otherwise.
+**/
+BOOLEAN
+EFIAPI
+CharIsUpperHexNum (
+  IN CHAR16  Char
+  )
+{
+  return ((Char >= L'0') && (Char <= L'9')) ||
+         ((Char >= L'A') && (Char <= L'F'));
+}
+
+/**
+  Determine if a Unicode String has only numbers.
+
+  @param[in] String       Pointer to the string to analyze.
+  @param[in] MaxSize      Maximum number of characters to analyze.
+
+  @retval TRUE            Unicode String has only numbers.
+  @retval FALSE           Unicode String has at least one other character.
+**/
+BOOLEAN
+EFIAPI
+StrnIsNum (
+  IN CONST CHAR16  *String,
+  IN       UINTN   MaxSize
+  )
+{
+  UINTN  Count;
+
+  ASSERT (String != NULL);
+  ASSERT (MaxSize != 0);
+
+  if ((String == NULL) || (MaxSize == 0)) {
+    return FALSE;
+  }
+
+  for (Count = 0; Count < MaxSize && String[Count] != CHAR_NULL; Count++) {
+    if (!((String[Count] >= L'0') && (String[Count] <= L'9'))) {
+      return FALSE;
+    }
+  }
+
+  return TRUE;
+}
+
+/**
+  Determine if a Unicode String has only hexadecimal numbers.
+
+  @param[in] String       Pointer to the string to analyze.
+  @param[in] MaxSize      Maximum number of characters to analyze.
+
+  @retval TRUE            Unicode String has only hexadecimal numbers.
+  @retval FALSE           Unicode String has at least one other character.
+**/
+BOOLEAN
+EFIAPI
+StrnIsHexNum (
+  IN CONST CHAR16  *String,
+  IN       UINTN   MaxSize
+  )
+{
+  UINTN  Count;
+
+  ASSERT (String != NULL);
+  ASSERT (MaxSize != 0);
+
+  if ((String == NULL) || (MaxSize == 0)) {
+    return FALSE;
+  }
+
+  for (Count = 0; Count < MaxSize && String[Count] != CHAR_NULL; Count++) {
+    if (!(((String[Count] >= L'0') && (String[Count] <= L'9')) ||
+          ((String[Count] >= L'a') && (String[Count] <= L'f')) ||
+          ((String[Count] >= L'A') && (String[Count] <= L'F'))))
+    {
+      return FALSE;
+    }
+  }
+
+  return TRUE;
+}
+
+/**
+  Determine if a Unicode String has only uppercase hexadecimal numbers.
+
+  @param[in] String       Pointer to the string to analyze.
+  @param[in] MaxSize      Maximum number of characters to analyze.
+
+  @retval TRUE            Unicode String has only uppercase hexadecimal numbers.
+  @retval FALSE           Unicode String has at least one other character.
+**/
+BOOLEAN
+EFIAPI
+StrnIsUpperHexNum (
+  IN CONST CHAR16  *String,
+  IN       UINTN   MaxSize
+  )
+{
+  UINTN  Count;
+
+  ASSERT (String != NULL);
+  ASSERT (MaxSize != 0);
+
+  if ((String == NULL) || (MaxSize == 0)) {
+    return FALSE;
+  }
+
+  for (Count = 0; Count < MaxSize && String[Count] != CHAR_NULL; Count++) {
+    if (!(((String[Count] >= L'0') && (String[Count] <= L'9')) ||
+          ((String[Count] >= L'A') && (String[Count] <= L'F'))))
+    {
+      return FALSE;
+    }
+  }
+
+  return TRUE;
+}

--- a/MdePkg/Library/BasePrintLib/PrintLibInternal.c
+++ b/MdePkg/Library/BasePrintLib/PrintLibInternal.c
@@ -755,7 +755,7 @@ BasePrintLibSPrintMarker (
             case '7':
             case '8':
             case '9':
-              for (Count = 0; ((FormatCharacter >= '0') &&  (FormatCharacter <= '9')); ) {
+              for (Count = 0; AsciiCharIsNum ((UINT8)FormatCharacter); ) {
                 Count           = (Count * 10) + FormatCharacter - '0';
                 Format         += BytesPerFormatCharacter;
                 FormatCharacter = ((*Format & 0xff) | ((BytesPerFormatCharacter == 1) ? 0 : (*(Format + 1) << 8))) & FormatMask;

--- a/NetworkPkg/IScsiDxe/IScsiDhcp.c
+++ b/NetworkPkg/IScsiDxe/IScsiDhcp.c
@@ -121,7 +121,7 @@ IScsiDhcpExtractRootPath (
   //
   // Server name is expressed as domain name, just save it.
   //
-  if ((!NET_IS_DIGIT (*(Field->Str))) && (*(Field->Str) != '[')) {
+  if ((!AsciiCharIsNum (*(Field->Str))) && (*(Field->Str) != '[')) {
     ConfigNvData->DnsMode = TRUE;
     if ((Field->Len + 2) > sizeof (ConfigNvData->TargetUrl)) {
       return EFI_INVALID_PARAMETER;

--- a/NetworkPkg/IScsiDxe/IScsiProto.c
+++ b/NetworkPkg/IScsiDxe/IScsiProto.c
@@ -1133,7 +1133,7 @@ IScsiUpdateTargetAddress (
     // The domainname can be specified as either a DNS host name, adotted-decimal IPv4 address,
     // or a bracketed IPv6 address as specified in [RFC2732].
     //
-    if (NET_IS_DIGIT (TargetAddress[0])) {
+    if (AsciiCharIsNum (TargetAddress[0])) {
       //
       // The domainname of the target is presented in a dotted-decimal IPv4 address format.
       //
@@ -2030,15 +2030,15 @@ IScsiNormalizeName (
   UINTN  Index;
 
   for (Index = 0; Index < Len; Index++) {
-    if (NET_IS_UPPER_CASE_CHAR (Name[Index])) {
+    if (AsciiCharIsUpperAlpha (Name[Index])) {
       //
       // Convert the upper-case characters to lower-case ones.
       //
       Name[Index] = (CHAR8)(Name[Index] - 'A' + 'a');
     }
 
-    if (!NET_IS_LOWER_CASE_CHAR (Name[Index]) &&
-        !NET_IS_DIGIT (Name[Index]) &&
+    if (!AsciiCharIsLowerAlpha (Name[Index]) &&
+        !AsciiCharIsNum (Name[Index]) &&
         (Name[Index] != '-') &&
         (Name[Index] != '.') &&
         (Name[Index] != ':')

--- a/NetworkPkg/Include/Library/NetLib.h
+++ b/NetworkPkg/Include/Library/NetLib.h
@@ -530,11 +530,7 @@ extern IP4_ADDR  gIp4AllMasks[IP4_MASK_NUM];
 
 extern EFI_IPv4_ADDRESS  mZeroIp4Addr;
 
-#define NET_IS_DIGIT(Ch)            (('0' <= (Ch)) && ((Ch) <= '9'))
-#define NET_IS_HEX(Ch)              ((('0' <= (Ch)) && ((Ch) <= '9')) || (('A' <= (Ch)) && ((Ch) <= 'F')) || (('a' <= (Ch)) && ((Ch) <= 'f')))
-#define NET_ROUNDUP(size, unit)     (((size) + (unit) - 1) & (~((unit) - 1)))
-#define NET_IS_LOWER_CASE_CHAR(Ch)  (('a' <= (Ch)) && ((Ch) <= 'z'))
-#define NET_IS_UPPER_CASE_CHAR(Ch)  (('A' <= (Ch)) && ((Ch) <= 'Z'))
+#define NET_ROUNDUP(size, unit)  (((size) + (unit) - 1) & (~((unit) - 1)))
 
 #define TICKS_PER_MS      10000U
 #define TICKS_PER_SECOND  10000000U

--- a/NetworkPkg/Library/DxeHttpLib/DxeHttpLib.c
+++ b/NetworkPkg/Library/DxeHttpLib/DxeHttpLib.c
@@ -49,7 +49,7 @@ UriPercentDecode (
   while (Index < BufferLength) {
     if (Buffer[Index] == '%') {
       if ((Index + 1 >= BufferLength) || (Index + 2 >= BufferLength) ||
-          !NET_IS_HEX_CHAR (Buffer[Index+1]) || !NET_IS_HEX_CHAR (Buffer[Index+2]))
+          !AsciiCharIsHexNum (Buffer[Index+1]) || !AsciiCharIsHexNum (Buffer[Index+2]))
       {
         return EFI_INVALID_PARAMETER;
       }
@@ -743,7 +743,7 @@ HttpUrlGetPort (
   PortString[ResultLength] = '\0';
 
   while (Index < ResultLength) {
-    if (!NET_IS_DIGIT (PortString[Index])) {
+    if (!AsciiCharIsNum (PortString[Index])) {
       Status = EFI_INVALID_PARAMETER;
       goto ON_EXIT;
     }
@@ -1239,7 +1239,7 @@ HttpParseMessageBody (
         Parser->CurrentChunkSize = 0;
         Parser->State            = BodyParserChunkSize;
       case BodyParserChunkSize:
-        if (!NET_IS_HEX_CHAR (*Char)) {
+        if (!AsciiCharIsHexNum (*Char)) {
           if (*Char == ';') {
             Parser->State = BodyParserChunkExtStart;
             Char++;

--- a/NetworkPkg/Library/DxeHttpLib/DxeHttpLib.h
+++ b/NetworkPkg/Library/DxeHttpLib/DxeHttpLib.h
@@ -25,11 +25,6 @@ Header file for HttpLib.
 #define HTTP_VERSION_CRLF_STR  " HTTP/1.1\r\n"
 #define EMPTY_SPACE            " "
 
-#define NET_IS_HEX_CHAR(Ch)   \
-  ((('0' <= (Ch)) && ((Ch) <= '9')) ||  \
-   (('A' <= (Ch)) && ((Ch) <= 'F')) ||  \
-   (('a' <= (Ch)) && ((Ch) <= 'f')))
-
 //
 // Field index of the HTTP URL parse result.
 //

--- a/NetworkPkg/Mtftp4Dxe/Mtftp4Option.c
+++ b/NetworkPkg/Mtftp4Dxe/Mtftp4Option.c
@@ -79,7 +79,7 @@ NetStringToU32 (
 
   Num = 0;
 
-  for ( ; NET_IS_DIGIT (*Str); Str++) {
+  for ( ; AsciiCharIsNum (*Str); Str++) {
     Num = Num * 10 + (*Str - '0');
   }
 
@@ -110,7 +110,7 @@ NetStringToIp (
   Addr = 0;
 
   for (Index = 0; Index < 4; Index++) {
-    if (!NET_IS_DIGIT (*Str)) {
+    if (!AsciiCharIsNum (*Str)) {
       return EFI_INVALID_PARAMETER;
     }
 
@@ -125,7 +125,7 @@ NetStringToIp (
     //
     // Skip all the digitals and check whether the separator is the dot
     //
-    while (NET_IS_DIGIT (*Str)) {
+    while (AsciiCharIsNum (*Str)) {
       Str++;
     }
 
@@ -346,7 +346,7 @@ Mtftp4ExtractMcast (
 
     Option->McastPort = (UINT16)Num;
 
-    while (NET_IS_DIGIT (*Value)) {
+    while (AsciiCharIsNum (*Value)) {
       Value++;
     }
   }
@@ -368,7 +368,7 @@ Mtftp4ExtractMcast (
 
   Option->Master = (BOOLEAN)(Num == 1);
 
-  while (NET_IS_DIGIT (*Value)) {
+  while (AsciiCharIsNum (*Value)) {
     Value++;
   }
 

--- a/NetworkPkg/Mtftp6Dxe/Mtftp6Option.c
+++ b/NetworkPkg/Mtftp6Dxe/Mtftp6Option.c
@@ -95,7 +95,7 @@ Mtftp6ParseMcastOption (
 
     ExtInfo->McastPort = (UINT16)Num;
 
-    while (NET_IS_DIGIT (*Str)) {
+    while (AsciiCharIsNum (*Str)) {
       Str++;
     }
   }
@@ -117,7 +117,7 @@ Mtftp6ParseMcastOption (
 
   ExtInfo->IsMaster = (BOOLEAN)(Num == 1);
 
-  while (NET_IS_DIGIT (*Str)) {
+  while (AsciiCharIsNum (*Str)) {
     Str++;
   }
 

--- a/ShellPkg/Include/Library/ShellLib.h
+++ b/ShellPkg/Include/Library/ShellLib.h
@@ -1148,26 +1148,6 @@ ShellCopySearchAndReplace (
   );
 
 /**
-  Check if a Unicode character is a hexadecimal character.
-
-  This internal function checks if a Unicode character is a
-  numeric character.  The valid hexadecimal characters are
-  L'0' to L'9', L'a' to L'f', or L'A' to L'F'.
-
-
-  @param  Char  The character to check against.
-
-  @retval TRUE  The Char is a hexadecmial character.
-  @retval FALSE The Char is not a hexadecmial character.
-
-**/
-BOOLEAN
-EFIAPI
-ShellIsHexaDecimalDigitCharacter (
-  IN      CHAR16  Char
-  );
-
-/**
   Check if a Unicode character is a decimal character.
 
   This internal function checks if a Unicode character is a

--- a/ShellPkg/Include/Library/ShellLib.h
+++ b/ShellPkg/Include/Library/ShellLib.h
@@ -1147,26 +1147,6 @@ ShellCopySearchAndReplace (
   IN CONST BOOLEAN  ParameterReplacing
   );
 
-/**
-  Check if a Unicode character is a decimal character.
-
-  This internal function checks if a Unicode character is a
-  decimal character.  The valid characters are
-  L'0' to L'9'.
-
-
-  @param  Char  The character to check against.
-
-  @retval TRUE  The Char is a hexadecmial character.
-  @retval FALSE The Char is not a hexadecmial character.
-
-**/
-BOOLEAN
-EFIAPI
-ShellIsDecimalDigitCharacter (
-  IN      CHAR16  Char
-  );
-
 ///
 /// What type of answer is requested.
 ///

--- a/ShellPkg/Library/UefiShellDebug1CommandsLib/SetVar.c
+++ b/ShellPkg/Library/UefiShellDebug1CommandsLib/SetVar.c
@@ -39,7 +39,7 @@ typedef union {
   @param[in] String  The CHAR16 string to check.
 
   @retval FALSE  A character has been found in String for which
-                 ShellIsHexaDecimalDigitCharacter() returned FALSE.
+                 CharIsHexNum() returned FALSE.
 
   @retval TRUE   Otherwise. (Note that this covers the case when String is
                  empty.)
@@ -52,7 +52,7 @@ IsStringOfHexNibbles (
   CONST CHAR16  *Pos;
 
   for (Pos = String; *Pos != L'\0'; ++Pos) {
-    if (!ShellIsHexaDecimalDigitCharacter (*Pos)) {
+    if (!CharIsHexNum (*Pos)) {
       return FALSE;
     }
   }

--- a/ShellPkg/Library/UefiShellLevel1CommandsLib/For.c
+++ b/ShellPkg/Library/UefiShellLevel1CommandsLib/For.c
@@ -41,7 +41,7 @@ ShellIsValidForNumber (
     }
   }
 
-  if (!ShellIsDecimalDigitCharacter (*Number)) {
+  if (!CharIsNum (*Number)) {
     return (FALSE);
   }
 

--- a/ShellPkg/Library/UefiShellLevel2CommandsLib/Map.c
+++ b/ShellPkg/Library/UefiShellLevel2CommandsLib/Map.c
@@ -92,7 +92,7 @@ SearchList (
       *TempSpot = CHAR_NULL;
     }
 
-    while (SkipTrailingNumbers && (ShellIsDecimalDigitCharacter (TempList[StrLen (TempList)-1]) || TempList[StrLen (TempList)-1] == L':')) {
+    while (SkipTrailingNumbers && (CharIsNum (TempList[StrLen (TempList)-1]) || TempList[StrLen (TempList)-1] == L':')) {
       TempList[StrLen (TempList)-1] = CHAR_NULL;
     }
 

--- a/ShellPkg/Library/UefiShellLevel2CommandsLib/TimeDate.c
+++ b/ShellPkg/Library/UefiShellLevel2CommandsLib/TimeDate.c
@@ -46,7 +46,7 @@ InternalIsTimeLikeString (
   //
   // the first char must be numeric.
   //
-  if (!ShellIsDecimalDigitCharacter (*String)) {
+  if (!CharIsNum (*String)) {
     return (FALSE);
   }
 
@@ -63,7 +63,7 @@ InternalIsTimeLikeString (
       continue;
     }
 
-    if (!ShellIsDecimalDigitCharacter (*String)) {
+    if (!CharIsNum (*String)) {
       return (FALSE);
     }
   }

--- a/ShellPkg/Library/UefiShellLevel3CommandsLib/Cls.c
+++ b/ShellPkg/Library/UefiShellLevel3CommandsLib/Cls.c
@@ -102,7 +102,7 @@ ShellCommandRunCls (
         ShellStatus = SHELL_INVALID_PARAMETER;
       } else {
         if (BackColorStr != NULL) {
-          if ((ShellStrToUintn (BackColorStr) > 7) || (StrLen (BackColorStr) > 1) || (!ShellIsDecimalDigitCharacter (*BackColorStr))) {
+          if ((ShellStrToUintn (BackColorStr) > 7) || (StrLen (BackColorStr) > 1) || (!CharIsNum (*BackColorStr))) {
             ShellPrintHiiDefaultEx (STRING_TOKEN (STR_GEN_PARAM_INV), gShellLevel3HiiHandle, L"cls", BackColorStr);
             ShellStatus = SHELL_INVALID_PARAMETER;
           } else {
@@ -134,7 +134,7 @@ ShellCommandRunCls (
             }
 
             if (ForeColorStr != NULL) {
-              if ((ShellStrToUintn (ForeColorStr) > 15) || (StrLen (ForeColorStr) > 2) || (!ShellIsDecimalDigitCharacter (*ForeColorStr))) {
+              if ((ShellStrToUintn (ForeColorStr) > 15) || (StrLen (ForeColorStr) > 2) || (!CharIsNum (*ForeColorStr))) {
                 ShellPrintHiiDefaultEx (STRING_TOKEN (STR_GEN_PARAM_INV), gShellLevel3HiiHandle, L"cls", ForeColorStr);
                 ShellStatus = SHELL_INVALID_PARAMETER;
               } else {

--- a/ShellPkg/Library/UefiShellLib/UefiShellLib.c
+++ b/ShellPkg/Library/UefiShellLib/UefiShellLib.c
@@ -154,28 +154,6 @@ FullyQualifyPath (
 }
 
 /**
-  Check if a Unicode character is a hexadecimal character.
-
-  This internal function checks if a Unicode character is a
-  numeric character.  The valid hexadecimal characters are
-  L'0' to L'9', L'a' to L'f', or L'A' to L'F'.
-
-  @param  Char  The character to check against.
-
-  @retval TRUE  If the Char is a hexadecmial character.
-  @retval FALSE If the Char is not a hexadecmial character.
-
-**/
-BOOLEAN
-EFIAPI
-ShellIsHexaDecimalDigitCharacter (
-  IN      CHAR16  Char
-  )
-{
-  return (BOOLEAN)((Char >= L'0' && Char <= L'9') || (Char >= L'A' && Char <= L'F') || (Char >= L'a' && Char <= L'f'));
-}
-
-/**
   Check if a Unicode character is a decimal character.
 
   This internal function checks if a Unicode character is a
@@ -3907,7 +3885,7 @@ InternalShellIsHexOrDecimalNumber (
     }
 
     if (Hex) {
-      if (!ShellIsHexaDecimalDigitCharacter (*String)) {
+      if (!CharIsHexNum (*String)) {
         return (FALSE);
       }
     } else {
@@ -4056,7 +4034,7 @@ InternalShellStrHexToUint64 (
 
   Result = 0;
 
-  while (ShellIsHexaDecimalDigitCharacter (*String)) {
+  while (CharIsHexNum (*String)) {
     //
     // If the Hex Number represented by String overflows according
     // to the range defined by UINT64, then return EFI_DEVICE_ERROR.

--- a/ShellPkg/Library/UefiShellLib/UefiShellLib.c
+++ b/ShellPkg/Library/UefiShellLib/UefiShellLib.c
@@ -154,29 +154,6 @@ FullyQualifyPath (
 }
 
 /**
-  Check if a Unicode character is a decimal character.
-
-  This internal function checks if a Unicode character is a
-  decimal character.  The valid characters are
-  L'0' to L'9'.
-
-
-  @param  Char  The character to check against.
-
-  @retval TRUE  If the Char is a hexadecmial character.
-  @retval FALSE If the Char is not a hexadecmial character.
-
-**/
-BOOLEAN
-EFIAPI
-ShellIsDecimalDigitCharacter (
-  IN      CHAR16  Char
-  )
-{
-  return (BOOLEAN)(Char >= L'0' && Char <= L'9');
-}
-
-/**
   Helper function to find ShellEnvironment2 for constructor.
 
   @param[in] ImageHandle    A copy of the calling image's handle.
@@ -3889,7 +3866,7 @@ InternalShellIsHexOrDecimalNumber (
         return (FALSE);
       }
     } else {
-      if (!ShellIsDecimalDigitCharacter (*String)) {
+      if (!CharIsNum (*String)) {
         return (FALSE);
       }
     }
@@ -3947,7 +3924,7 @@ InternalShellHexCharToUintn (
   IN      CHAR16  Char
   )
 {
-  if (ShellIsDecimalDigitCharacter (Char)) {
+  if (CharIsNum (Char)) {
     return Char - L'0';
   }
 
@@ -4127,7 +4104,7 @@ InternalShellStrDecimalToUint64 (
     return (EFI_SUCCESS);
   }
 
-  while (ShellIsDecimalDigitCharacter (*String)) {
+  while (CharIsNum (*String)) {
     //
     // If the number represented by String overflows according
     // to the range defined by UINT64, then return EFI_DEVICE_ERROR.

--- a/ShellPkg/Library/UefiShellNetwork2CommandsLib/Ifconfig6.c
+++ b/ShellPkg/Library/UefiShellNetwork2CommandsLib/Ifconfig6.c
@@ -698,7 +698,7 @@ IfConfig6ParseDadXmits (
   *Xmits = 0;
 
   while (*ValStr != L'\0') {
-    if ((*ValStr <= L'9') && (*ValStr >= L'0')) {
+    if (CharIsNum (*ValStr)) {
       *Xmits = (*Xmits * 10) + (*ValStr - L'0');
     } else {
       return EFI_INVALID_PARAMETER;

--- a/ShellPkg/Test/Mock/Include/GoogleTest/Library/MockShellLib.h
+++ b/ShellPkg/Test/Mock/Include/GoogleTest/Library/MockShellLib.h
@@ -309,12 +309,6 @@ struct MockShellLib {
 
   MOCK_FUNCTION_DECLARATION (
     BOOLEAN,
-    ShellIsHexaDecimalDigitCharacter,
-    (IN CHAR16  Char)
-    );
-
-  MOCK_FUNCTION_DECLARATION (
-    BOOLEAN,
     ShellIsDecimalDigitCharacter,
     (IN CHAR16  Char)
     );

--- a/ShellPkg/Test/Mock/Include/GoogleTest/Library/MockShellLib.h
+++ b/ShellPkg/Test/Mock/Include/GoogleTest/Library/MockShellLib.h
@@ -308,12 +308,6 @@ struct MockShellLib {
     );
 
   MOCK_FUNCTION_DECLARATION (
-    BOOLEAN,
-    ShellIsDecimalDigitCharacter,
-    (IN CHAR16  Char)
-    );
-
-  MOCK_FUNCTION_DECLARATION (
     EFI_STATUS,
     ShellPromptForResponse,
     (IN     SHELL_PROMPT_REQUEST_TYPE  Type,

--- a/ShellPkg/Test/Mock/Library/GoogleTest/MockShellLib/MockShellLib.cpp
+++ b/ShellPkg/Test/Mock/Library/GoogleTest/MockShellLib/MockShellLib.cpp
@@ -56,7 +56,6 @@ MOCK_FUNCTION_DEFINITION (MockShellLib, ShellStrToUintn, 1, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockShellLib, ShellHexStrToUintn, 1, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockShellLib, StrnCatGrow, 4, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockShellLib, ShellCopySearchAndReplace, 7, EFIAPI);
-MOCK_FUNCTION_DEFINITION (MockShellLib, ShellIsDecimalDigitCharacter, 1, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockShellLib, ShellPromptForResponse, 3, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockShellLib, ShellPromptForResponseHii, 4, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockShellLib, ShellIsHexOrDecimalNumber, 3, EFIAPI);

--- a/ShellPkg/Test/Mock/Library/GoogleTest/MockShellLib/MockShellLib.cpp
+++ b/ShellPkg/Test/Mock/Library/GoogleTest/MockShellLib/MockShellLib.cpp
@@ -56,7 +56,6 @@ MOCK_FUNCTION_DEFINITION (MockShellLib, ShellStrToUintn, 1, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockShellLib, ShellHexStrToUintn, 1, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockShellLib, StrnCatGrow, 4, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockShellLib, ShellCopySearchAndReplace, 7, EFIAPI);
-MOCK_FUNCTION_DEFINITION (MockShellLib, ShellIsHexaDecimalDigitCharacter, 1, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockShellLib, ShellIsDecimalDigitCharacter, 1, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockShellLib, ShellPromptForResponse, 3, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockShellLib, ShellPromptForResponseHii, 4, EFIAPI);

--- a/SignedCapsulePkg/Library/IniParsingLib/IniParsingLib.c
+++ b/SignedCapsulePkg/Library/IniParsingLib/IniParsingLib.c
@@ -64,38 +64,6 @@ typedef struct {
 } INI_PARSING_LIB_CONTEXT;
 
 /**
-  Return if the digital char is valid.
-
-  @param[in] DigitalChar    The digital char to be checked.
-  @param[in] IncludeHex     If it include HEX char.
-
-  @retval TRUE   The digital char is valid.
-  @retval FALSE  The digital char is invalid.
-**/
-BOOLEAN
-IsValidDigitalChar (
-  IN CHAR8    DigitalChar,
-  IN BOOLEAN  IncludeHex
-  )
-{
-  if ((DigitalChar >= '0') && (DigitalChar <= '9')) {
-    return TRUE;
-  }
-
-  if (IncludeHex) {
-    if ((DigitalChar >= 'a') && (DigitalChar <= 'f')) {
-      return TRUE;
-    }
-
-    if ((DigitalChar >= 'A') && (DigitalChar <= 'F')) {
-      return TRUE;
-    }
-  }
-
-  return FALSE;
-}
-
-/**
   Return if the name char is valid.
 
   @param[in] NameChar    The name char to be checked.
@@ -144,15 +112,11 @@ IsValidDigital (
   IN BOOLEAN  IncludeHex
   )
 {
-  UINTN  Index;
-
-  for (Index = 0; Index < Length; Index++) {
-    if (!IsValidDigitalChar (Digital[Index], IncludeHex)) {
-      return FALSE;
-    }
+  if (IncludeHex) {
+    return AsciiStrnIsHexNum (Digital, Length);
   }
 
-  return TRUE;
+  return AsciiStrnIsNum (Digital, Length);
 }
 
 /**


### PR DESCRIPTION
# Description

This is a trimmed version of https://github.com/tianocore/edk2/pull/11839. Functions checking non-numbers related Unicode chars/strings have been removed.

---

The edk2 repository contains multiple local implementations of string utilities:

- checking a string/char uppercase/lowercase/alphanumerical/hexadecimal compliance
- replacing uppercase string/char to lowercase (or conversely)

Add string/char utilities to BaseLib and remove some of the local implementations.
Not all implementations have been replaced, but this is a first step.
