### PR TITLE
StandaloneMmPkg/StandaloneMmIplPei: Optimize CreateMmPlatformHob calls

### DIFF
--- a/StandaloneMmPkg/Drivers/StandaloneMmIplPei/StandaloneMmIplPei.c
+++ b/StandaloneMmPkg/Drivers/StandaloneMmIplPei/StandaloneMmIplPei.c
@@ -2,6 +2,7 @@
   MM IPL that load the MM Core into MMRAM at PEI stage
 
   Copyright (c) 2024 - 2025, Intel Corporation. All rights reserved.<BR>
+  Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -467,9 +468,6 @@ CreateMmHobList (
                         MmProfileDataHob,
                         Block
                         );
-  if (PlatformHobSize != 0) {
-    FreePages (PlatformHobList, EFI_SIZE_TO_PAGES (PlatformHobSize));
-  }
 
   ASSERT (Status == RETURN_BUFFER_TOO_SMALL);
   ASSERT (FoundationHobSize != 0);
@@ -493,10 +491,12 @@ CreateMmHobList (
   CreateMmHobHandoffInfoTable (HobList, HobEnd);
 
   //
-  // Get platform HOBs
+  // Copy platform HOBs
   //
-  Status = CreateMmPlatformHob ((UINT8 *)HobList + PhitHobSize, &PlatformHobSize);
-  ASSERT_EFI_ERROR (Status);
+  if (PlatformHobSize != 0) {
+    CopyMem ((VOID *)((UINT8 *)HobList + PhitHobSize), PlatformHobList, PlatformHobSize);
+    FreePages (PlatformHobList, EFI_SIZE_TO_PAGES (PlatformHobSize));
+  }
 
   //
   // Get foundation HOBs


### PR DESCRIPTION
Currently MM IPL calls 3 times for CreateMmPlatformHob platform library function. The second and third calls intend to copy platform HOBs to the target buffer. In the code flow, it is found that they can be optimized as one call. It is expected to reduce time caused by the library call and make the driver better for the library usage.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

The update has been verified on AMD platform that enables StandaloneMmPkg.

## Integration Instructions

N/A