### PR TITLE
MdeModulePkg/UsbKbDxe: Handle Ctrl+Alt+Del reset at TPL_CALLBACK

### DIFF
--- a/MdeModulePkg/Bus/Usb/UsbKbDxe/EfiKey.c
+++ b/MdeModulePkg/Bus/Usb/UsbKbDxe/EfiKey.c
@@ -563,6 +563,7 @@ USBKeyboardDriverBindingStop (
   gBS->CloseEvent (UsbKeyboardDevice->SimpleInput.WaitForKey);
   gBS->CloseEvent (UsbKeyboardDevice->SimpleInputEx.WaitForKeyEx);
   gBS->CloseEvent (UsbKeyboardDevice->KeyNotifyProcessEvent);
+  gBS->CloseEvent (UsbKeyboardDevice->CtrlAltDelEvent);
   KbdFreeNotifyList (&UsbKeyboardDevice->NotifyList);
 
   ReleaseKeyboardLayoutResources (UsbKeyboardDevice);

--- a/MdeModulePkg/Bus/Usb/UsbKbDxe/EfiKey.h
+++ b/MdeModulePkg/Bus/Usb/UsbKbDxe/EfiKey.h
@@ -153,6 +153,9 @@ typedef struct {
   USB_NS_KEY                           *CurrentNsKey;
   EFI_KEY_DESCRIPTOR                   *KeyConvertionTable;
   EFI_EVENT                            KeyboardLayoutEvent;
+
+  // Event to handle Ctrl + Alt + Del key
+  EFI_EVENT                            CtrlAltDelEvent;
 } USB_KB_DEV;
 
 //


### PR DESCRIPTION
Defer the Ctrl+Alt+Del ResetSystem invocation to TPL_CALLBACK in the UsbKbDxe override. Previously the reset was performed directly in the key-processing path, which could occur at an elevated task priority and lead to contention or multiple system-control calls.

This change introduces a dedicated event and a pending flag on the USB_KB_DEV instance. When Ctrl and Alt modifiers accompany Delete, the driver sets the pending flag and signals an event, the event callback consumes the request and performs a warm reset at TPL_CALLBACK.

@vishalo @leiflindholm 

