### PR TITLE
BaseTools: fix building with GCC16's new unused-but-set-variable

### DIFF
--- a/BaseTools/Source/C/Common/StringFuncs.c
+++ b/BaseTools/Source/C/Common/StringFuncs.c
@@ -110,7 +110,6 @@ SplitStringByWhitespace (
   CHAR8       *EndOfSubString;
   CHAR8       *EndOfString;
   STRING_LIST *Output;
-  UINTN       Item;
 
   String = CloneString (String);
   if (String == NULL) {
@@ -120,7 +119,8 @@ SplitStringByWhitespace (
 
   Output = NewStringList ();
 
-  for (Pos = String, Item = 0; Pos < EndOfString; Item++) {
+  Pos = String;
+  while (Pos < EndOfString) {
     while (isspace ((int)*Pos)) {
       Pos++;
     }


### PR DESCRIPTION
GCC 16 has a strictier approach to unused variables (documented at https://gcc.gnu.org/gcc-16/porting_to.html). And, in fact, Item is never actually read, so we can just get rid of it.

Fixes: #12043
