### PR TITLE
StandaloneMmPkg: Fix potentially unintialized local Variables

### DIFF
--- a/StandaloneMmPkg/Core/Pool.c
+++ b/StandaloneMmPkg/Core/Pool.c
@@ -110,6 +110,8 @@ InternalAllocPoolByIndex (
   FREE_POOL_HEADER      *Hdr;
   EFI_PHYSICAL_ADDRESS  Address;
 
+  Address = 0;
+
   ASSERT (PoolIndex <= MAX_POOL_INDEX);
   Status = EFI_SUCCESS;
   Hdr    = NULL;
@@ -199,6 +201,8 @@ MmInternalAllocatePool (
   EFI_STATUS            Status;
   EFI_PHYSICAL_ADDRESS  Address;
   UINTN                 PoolIndex;
+
+  Address = 0;
 
   if ((PoolType != EfiRuntimeServicesCode) &&
       (PoolType != EfiRuntimeServicesData))

--- a/StandaloneMmPkg/Core/StandaloneMmCore.c
+++ b/StandaloneMmPkg/Core/StandaloneMmCore.c
@@ -446,6 +446,7 @@ MmCorePrepareCommunicationBuffer (
 
   mMmCommunicationBuffer  = NULL;
   mInternalCommBufferCopy = NULL;
+  Buffer                  = 0;
 
   GuidHob = GetFirstGuidHob (&gMmCommBufferHobGuid);
   if (GuidHob == NULL) {

--- a/StandaloneMmPkg/Library/StandaloneMmCoreMemoryAllocationLib/StandaloneMmCoreMemoryAllocationLib.c
+++ b/StandaloneMmPkg/Library/StandaloneMmCoreMemoryAllocationLib/StandaloneMmCoreMemoryAllocationLib.c
@@ -38,6 +38,8 @@ InternalAllocatePages (
   EFI_STATUS            Status;
   EFI_PHYSICAL_ADDRESS  Memory;
 
+  Memory = 0;
+
   if (Pages == 0) {
     return NULL;
   }
@@ -178,6 +180,8 @@ InternalAllocateAlignedPages (
   UINTN                 AlignmentMask;
   UINTN                 UnalignedPages;
   UINTN                 RealPages;
+
+  Memory = 0;
 
   //
   // Alignment must be a power of two or zero.

--- a/StandaloneMmPkg/Library/StandaloneMmMemoryAllocationLib/StandaloneMmMemoryAllocationLib.c
+++ b/StandaloneMmPkg/Library/StandaloneMmMemoryAllocationLib/StandaloneMmMemoryAllocationLib.c
@@ -37,6 +37,8 @@ InternalAllocatePages (
   EFI_STATUS            Status;
   EFI_PHYSICAL_ADDRESS  Memory;
 
+  Memory = 0;
+
   if (Pages == 0) {
     return NULL;
   }
@@ -177,6 +179,8 @@ InternalAllocateAlignedPages (
   UINTN                 AlignmentMask;
   UINTN                 UnalignedPages;
   UINTN                 RealPages;
+
+  Memory = 0;
 
   //
   // Alignment must be a power of two or zero.


### PR DESCRIPTION
# Description

This PR addresses fix for potentially uninitialized local variables

The static analysis flagged this as a potential issue because the variable lacks an explicit initializer. Hence added Initialization wherever necessary.

Similar fix also presents in MdeModulePkg/PiSmmCore
Refer: [89558f1]

This commit also addresses the fix for coverity issue "UNINIT"


- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested


## Integration Instructions

 N/A
