### PR TITLE
UefiPayloadPkg: Fixup capsule updates with coreboot support

### DIFF
--- a/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLib.c
+++ b/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLib.c
@@ -22,6 +22,7 @@
 #include <PiDxe.h>
 #include <Guid/FirmwareInfoGuid.h>
 #include <Guid/SystemResourceTable.h>
+#include <Library/BaseLib.h>
 #include <Library/BaseMemoryLib.h>
 #include <Library/DebugLib.h>
 #include <Library/FmpDeviceLib.h>
@@ -39,20 +40,20 @@
 
 #pragma pack(1)
 typedef struct {
-  CHAR8   Signature[8];
-  UINT8   VerMajor;
-  UINT8   VerMinor;
-  UINT64  Base;
-  UINT32  Size;
-  CHAR8   Name[32];
-  UINT16  AreaCount;
+  CHAR8     Signature[8];
+  UINT8     VerMajor;
+  UINT8     VerMinor;
+  UINT64    Base;
+  UINT32    Size;
+  CHAR8     Name[32];
+  UINT16    AreaCount;
 } FMAP_HEADER;
 
 typedef struct {
-  UINT32  Offset;
-  UINT32  Size;
-  CHAR8   Name[32];
-  UINT16  Flags;
+  UINT32    Offset;
+  UINT32    Size;
+  CHAR8     Name[32];
+  UINT16    Flags;
 } FMAP_AREA;
 #pragma pack()
 
@@ -64,13 +65,13 @@ typedef struct {
 #define REGION_MANIFEST_VERSION    1
 
 typedef struct {
-  UINT32  Signature;
-  UINT16  Version;
-  UINT16  EntryCount;
+  UINT32    Signature;
+  UINT16    Version;
+  UINT16    EntryCount;
 } REGION_MANIFEST_TRAILER;
 
 typedef struct {
-  CHAR8  RegionName[16];
+  CHAR8    RegionName[16];
 } REGION_MANIFEST_ENTRY;
 
 STATIC
@@ -224,13 +225,13 @@ LoadFlashFmap (
   OUT VOID               **FlashFmapBuffer
   )
 {
-  EFI_STATUS    Status;
-  CONST CHAR8   FmapAreaName[16] = "FMAP";
-  UINTN         FmapAreaOffset;
-  UINTN         FmapAreaSize;
-  VOID          *Buffer;
-  UINTN         FoundOffset;
-  UINTN         FoundLength;
+  EFI_STATUS   Status;
+  CONST CHAR8  FmapAreaName[16] = "FMAP";
+  UINTN        FmapAreaOffset;
+  UINTN        FmapAreaSize;
+  VOID         *Buffer;
+  UINTN        FoundOffset;
+  UINTN        FoundLength;
 
   if ((CapsuleFmapHeader == NULL) || (CapsuleFmapAreas == NULL) || (FlashFmapHeader == NULL) || (FlashFmapAreas == NULL) || (FlashFmapBuffer == NULL)) {
     return EFI_INVALID_PARAMETER;
@@ -290,11 +291,11 @@ LoadFlashFmap (
 STATIC
 EFI_STATUS
 LocateRegionManifest (
-  IN  CONST UINT8               *Image,
-  IN  UINTN                     ImageSize,
-  OUT UINTN                     *EntryCount,
+  IN  CONST UINT8                  *Image,
+  IN  UINTN                        ImageSize,
+  OUT UINTN                        *EntryCount,
   OUT CONST REGION_MANIFEST_ENTRY  **Entries,
-  OUT UINTN                     *FirmwareImageSize
+  OUT UINTN                        *FirmwareImageSize
   )
 {
   CONST REGION_MANIFEST_TRAILER  *Trailer;
@@ -352,42 +353,21 @@ FindFmapRegion (
   )
 {
   UINTN  Index;
-  UINTN  CharIndex;
+  CHAR8  FmapName[33];
+  CHAR8  ManifestName[17];
 
   for (Index = 0; Index < AreaCount; ++Index) {
     //
     // Manifest names are 16-byte, zero-padded strings, while FMAP uses 32-byte
-    // names. Compare the first 16 bytes, ensuring the FMAP name does not have
-    // additional non-zero characters beyond the manifest name.
+    // names. Convert both to NUL-terminated strings and compare.
     //
-    for (CharIndex = 0; CharIndex < 16; ++CharIndex) {
-      if (Areas[Index].Name[CharIndex] != Name[CharIndex]) {
-        break;
-      }
+    CopyMem (FmapName, Areas[Index].Name, 32);
+    FmapName[32] = '\0';
+    CopyMem (ManifestName, Name, 16);
+    ManifestName[16] = '\0';
 
-      if (Name[CharIndex] == 0) {
-        break;
-      }
-    }
-
-    if (CharIndex == 16) {
-      if (Areas[Index].Name[16] != 0) {
-        continue;
-      }
-    } else {
-      if (Areas[Index].Name[CharIndex] != 0) {
-        continue;
-      }
-
-      for (; CharIndex < 16; ++CharIndex) {
-        if (Name[CharIndex] != 0) {
-          break;
-        }
-      }
-
-      if (CharIndex != 16) {
-        continue;
-      }
+    if (AsciiStrCmp (FmapName, ManifestName) != 0) {
+      continue;
     }
 
     *RegionOffset = (UINTN)FmapHeader->Base + Areas[Index].Offset;
@@ -898,11 +878,11 @@ FmpDeviceCheckImageWithStatus (
   OUT UINT32      *LastAttemptStatus
   )
 {
-  EFI_STATUS  Status;
-  UINTN       FwSize;
-  UINTN       BlockSize;
-  UINTN       ManifestEntries;
-  UINTN       FirmwareImageSize;
+  EFI_STATUS                   Status;
+  UINTN                        FwSize;
+  UINTN                        BlockSize;
+  UINTN                        ManifestEntries;
+  UINTN                        FirmwareImageSize;
   CONST REGION_MANIFEST_ENTRY  *ManifestList;
 
   if ((Image == NULL) || (ImageUpdatable == NULL)) {
@@ -1085,6 +1065,12 @@ IncrementProgress (
 /**
   Read an arbitrary flash range into a buffer.
 
+  @param[in]  BlockSize  Flash block size, in bytes.
+  @param[in]  FlashSize  Total flash size, in bytes.
+  @param[in]  Offset     Offset from the start of flash, in bytes.
+  @param[in]  Length     Number of bytes to read.
+  @param[out] Buffer     Destination buffer for the flash contents.
+
   @retval EFI_SUCCESS            The range was read successfully.
   @retval EFI_DEVICE_ERROR       A read failed.
   @retval EFI_INVALID_PARAMETER  Input parameters were invalid.
@@ -1146,6 +1132,17 @@ ReadFlashRange (
 
   This helper preserves bytes outside the requested range within any partially
   covered flash block by read-modify-writing the full block.
+
+  @param[in]      BlockSize            Flash block size, in bytes.
+  @param[in]      Image                Source image buffer.
+  @param[in]      ImageSize            Size of Image, in bytes.
+  @param[in]      RangeOffset          Offset within Image for the update range, in bytes.
+  @param[in]      RangeSize            Size of the update range, in bytes.
+  @param[in,out]  BlockBuffer          Scratch buffer, at least BlockSize bytes.
+  @param[in]      Progress             Optional progress callback.
+  @param[in]      TotalSteps           Total number of progress reporting steps.
+  @param[in,out]  Step                 Current step counter for progress reporting.
+  @param[in,out]  ShouldReportProgress Progress reporting enabled flag.
 
   @retval EFI_SUCCESS            The range was updated successfully.
   @retval EFI_DEVICE_ERROR       A read/erase/write failed.
@@ -1469,31 +1466,31 @@ FmpDeviceSetImageWithStatus (
   OUT UINT32                                         *LastAttemptStatus
   )
 {
-  EFI_STATUS   Status;
-  UINTN        BlockSize;
-  UINTN        BlockCount;
-  UINTN        Block;
-  UINTN        EntryIndex;
-  UINTN        NumBytes;
-  UINTN        TotalSteps;
-  UINTN        Step;
-  BOOLEAN      ShouldReportProgress;
-  VOID         *ReadBuffer;
-  CONST UINT8  *WriteNext;
-  UINTN        ManifestEntryCount;
+  EFI_STATUS                   Status;
+  UINTN                        BlockSize;
+  UINTN                        BlockCount;
+  UINTN                        Block;
+  UINTN                        EntryIndex;
+  UINTN                        NumBytes;
+  UINTN                        TotalSteps;
+  UINTN                        Step;
+  BOOLEAN                      ShouldReportProgress;
+  VOID                         *ReadBuffer;
+  CONST UINT8                  *WriteNext;
+  UINTN                        ManifestEntryCount;
   CONST REGION_MANIFEST_ENTRY  *ManifestEntries;
-  UINTN        BaseImageSize;
-  BOOLEAN      UseManifest;
-  BOOLEAN      UseBiosRegion;
-  UINTN        BiosOffset;
-  UINTN        BiosSize;
-  CONST FMAP_HEADER  *FmapHeader;
-  CONST FMAP_AREA    *FmapAreas;
-  UINTN              FmapOffset;
-  UINTN              FmapLength;
-  VOID               *FlashFmapBuffer;
-  FMAP_HEADER        *FlashFmapHeader;
-  FMAP_AREA          *FlashFmapAreas;
+  UINTN                        BaseImageSize;
+  BOOLEAN                      UseManifest;
+  BOOLEAN                      UseBiosRegion;
+  UINTN                        BiosOffset;
+  UINTN                        BiosSize;
+  CONST FMAP_HEADER            *FmapHeader;
+  CONST FMAP_AREA              *FmapAreas;
+  UINTN                        FmapOffset;
+  UINTN                        FmapLength;
+  VOID                         *FlashFmapBuffer;
+  FMAP_HEADER                  *FlashFmapHeader;
+  FMAP_AREA                    *FlashFmapAreas;
 
   *LastAttemptStatus = LAST_ATTEMPT_STATUS_ERROR_UNSUCCESSFUL;
   BlockCount         = 0;
@@ -1521,7 +1518,7 @@ FmpDeviceSetImageWithStatus (
   // Discover optional manifest and FMAP. If anything looks off, fall back to
   // legacy full-flash behavior.
   //
-  BaseImageSize     = ImageSize;
+  BaseImageSize      = ImageSize;
   ManifestEntryCount = 0;
   ManifestEntries    = NULL;
   UseManifest        = FALSE;
@@ -1541,12 +1538,29 @@ FmpDeviceSetImageWithStatus (
     BaseImageSize      = ImageSize;
     ManifestEntryCount = 0;
     ManifestEntries    = NULL;
+  } else {
+    DEBUG ((
+      DEBUG_INFO,
+      "%a(): found region manifest (%u entr%s), base image size 0x%x\n",
+      __func__,
+      (UINT32)ManifestEntryCount,
+      (ManifestEntryCount == 1) ? "y" : "ies",
+      (UINT32)BaseImageSize
+      ));
   }
 
   Status = LocateFmapInImage (Image, BaseImageSize, &FmapOffset, &FmapLength);
   if (!EFI_ERROR (Status) && ((FmapOffset + FmapLength) <= BaseImageSize)) {
     FmapHeader = (CONST FMAP_HEADER *)((CONST UINT8 *)Image + FmapOffset);
     FmapAreas  = (CONST FMAP_AREA *)((CONST UINT8 *)FmapHeader + sizeof (FMAP_HEADER));
+
+    DEBUG ((
+      DEBUG_INFO,
+      "%a(): found FMAP at 0x%x (%u areas)\n",
+      __func__,
+      (UINT32)FmapOffset,
+      (UINT32)FmapHeader->AreaCount
+      ));
   }
 
   if ((ManifestEntryCount > 0) && (FmapHeader != NULL) && (FmapHeader->AreaCount > 0)) {
@@ -1562,6 +1576,13 @@ FmpDeviceSetImageWithStatus (
     if (!EFI_ERROR (FindFmapRegion (FmapHeader, FmapAreas, FmapHeader->AreaCount, SiBiosName, &BiosOffset, &BiosSize))) {
       if ((BiosSize != 0) && ((BiosOffset + BiosSize) <= BaseImageSize)) {
         UseBiosRegion = TRUE;
+        DEBUG ((
+          DEBUG_INFO,
+          "%a(): no manifest, using SI_BIOS (0x%x+0x%x)\n",
+          __func__,
+          (UINT32)BiosOffset,
+          (UINT32)BiosSize
+          ));
       }
     }
   }
@@ -1578,27 +1599,37 @@ FmpDeviceSetImageWithStatus (
     //
     BOOLEAN     LayoutMismatch;
     EFI_STATUS  FlashFmapStatus;
+    UINTN       MismatchIndex;
+    UINTN       CapsuleRegionOffset;
+    UINTN       CapsuleRegionSize;
+    UINTN       FlashRegionOffset;
+    UINTN       FlashRegionSize;
 
-    LayoutMismatch = FALSE;
-    FlashFmapStatus = LoadFlashFmap (
-                        BlockSize,
-                        BaseImageSize,
-                        FmapHeader,
-                        FmapAreas,
-                        &FlashFmapHeader,
-                        &FlashFmapAreas,
-                        &FlashFmapBuffer
-                        );
+    LayoutMismatch      = FALSE;
+    MismatchIndex       = MAX_UINTN;
+    CapsuleRegionOffset = 0;
+    CapsuleRegionSize   = 0;
+    FlashRegionOffset   = 0;
+    FlashRegionSize     = 0;
+    FlashFmapStatus     = LoadFlashFmap (
+                            BlockSize,
+                            BaseImageSize,
+                            FmapHeader,
+                            FmapAreas,
+                            &FlashFmapHeader,
+                            &FlashFmapAreas,
+                            &FlashFmapBuffer
+                            );
     if (EFI_ERROR (FlashFmapStatus)) {
       LayoutMismatch = TRUE;
+      DEBUG ((DEBUG_WARN, "%a(): failed to load flash FMAP: %r\n", __func__, FlashFmapStatus));
     }
 
     TotalSteps = 0;
     for (EntryIndex = 0; EntryIndex < ManifestEntryCount; ++EntryIndex) {
       UINTN  RegionOffset;
       UINTN  RegionSize;
-      UINTN  FlashRegionOffset;
-      UINTN  FlashRegionSize;
+      CHAR8  RegionName[17];
 
       Status = FindFmapRegion (
                  FmapHeader,
@@ -1609,9 +1640,23 @@ FmpDeviceSetImageWithStatus (
                  &RegionSize
                  );
       if (EFI_ERROR (Status) || (RegionSize == 0) || ((RegionOffset + RegionSize) > BaseImageSize)) {
+        CopyMem (RegionName, ManifestEntries[EntryIndex].RegionName, 16);
+        RegionName[16] = 0;
+        DEBUG ((DEBUG_ERROR, "%a(): invalid manifest region '%a'\n", __func__, RegionName));
         UseManifest = FALSE;
         break;
       }
+
+      CopyMem (RegionName, ManifestEntries[EntryIndex].RegionName, 16);
+      RegionName[16] = 0;
+      DEBUG ((
+        DEBUG_INFO,
+        "%a(): manifest region '%a' capsule 0x%x+0x%x\n",
+        __func__,
+        RegionName,
+        (UINT32)RegionOffset,
+        (UINT32)RegionSize
+        ));
 
       if (!LayoutMismatch) {
         Status = FindFmapRegion (
@@ -1623,7 +1668,14 @@ FmpDeviceSetImageWithStatus (
                    &FlashRegionSize
                    );
         if (EFI_ERROR (Status) || (FlashRegionOffset != RegionOffset) || (FlashRegionSize != RegionSize)) {
-          LayoutMismatch = TRUE;
+          LayoutMismatch      = TRUE;
+          MismatchIndex       = EntryIndex;
+          CapsuleRegionOffset = RegionOffset;
+          CapsuleRegionSize   = RegionSize;
+          if (EFI_ERROR (Status)) {
+            FlashRegionOffset = 0;
+            FlashRegionSize   = 0;
+          }
         }
       }
 
@@ -1641,14 +1693,39 @@ FmpDeviceSetImageWithStatus (
       // flashing the full BIOS region from the new image.
       //
       CONST CHAR8  SiBiosName[16] = "SI_BIOS";
+      CHAR8        RegionName[17];
 
       UseManifest   = FALSE;
       UseBiosRegion = FALSE;
 
+      if (MismatchIndex != MAX_UINTN) {
+        CopyMem (RegionName, ManifestEntries[MismatchIndex].RegionName, 16);
+        RegionName[16] = 0;
+        DEBUG ((
+          DEBUG_WARN,
+          "%a(): FMAP layout mismatch for '%a': flash 0x%x+0x%x vs capsule 0x%x+0x%x\n",
+          __func__,
+          RegionName,
+          (UINT32)FlashRegionOffset,
+          (UINT32)FlashRegionSize,
+          (UINT32)CapsuleRegionOffset,
+          (UINT32)CapsuleRegionSize
+          ));
+      }
+
       if (!EFI_ERROR (FindFmapRegion (FmapHeader, FmapAreas, FmapHeader->AreaCount, SiBiosName, &BiosOffset, &BiosSize))) {
         if ((BiosSize != 0) && ((BiosOffset + BiosSize) <= BaseImageSize)) {
           UseBiosRegion = TRUE;
+          DEBUG ((
+            DEBUG_WARN,
+            "%a(): flashing SI_BIOS instead (0x%x+0x%x)\n",
+            __func__,
+            (UINT32)BiosOffset,
+            (UINT32)BiosSize
+            ));
         }
+      } else {
+        DEBUG ((DEBUG_WARN, "%a(): unable to locate SI_BIOS for fallback\n", __func__));
       }
     }
   }

--- a/UefiPayloadPkg/Library/PlatformBootManagerLib/PlatformBootManager.c
+++ b/UefiPayloadPkg/Library/PlatformBootManagerLib/PlatformBootManager.c
@@ -231,6 +231,8 @@ PlatformBootManagerBeforeConsole (
   EFI_INPUT_KEY                 CustomKey;
   EFI_INPUT_KEY                 Down;
   EFI_BOOT_MANAGER_LOAD_OPTION  BootOption;
+  EDKII_PLATFORM_LOGO_PROTOCOL  *PlatformLogo;
+  BOOLEAN                       ConsoleInitialized;
 
   //
   // Register ENTER as CONTINUE key
@@ -267,8 +269,18 @@ PlatformBootManagerBeforeConsole (
   //
   // Process update capsules that don't contain embedded drivers.
   //
+  ConsoleInitialized = FALSE;
   if (GetBootModeHob () == BOOT_ON_FLASH_UPDATE) {
     // TODO: when enabling capsule support for laptops, add a battery check here
+    PlatformConsoleInit ();
+    ConsoleInitialized = TRUE;
+
+    Status = gBS->LocateProtocol (&gEdkiiPlatformLogoProtocolGuid, NULL, (VOID **)&PlatformLogo);
+    if (!EFI_ERROR (Status) && (gST != NULL) && (gST->ConOut != NULL)) {
+      gST->ConOut->ClearScreen (gST->ConOut);
+      BootLogoEnableLogo ();
+    }
+
     Status = ProcessCapsules ();
     if (EFI_ERROR (Status)) {
       DEBUG ((DEBUG_ERROR, "%a(): ProcessCapsule() failed with: %r\n", __func__, Status));
@@ -286,7 +298,9 @@ PlatformBootManagerBeforeConsole (
   //
   EfiBootManagerDispatchDeferredImages ();
 
-  PlatformConsoleInit ();
+  if (!ConsoleInitialized) {
+    PlatformConsoleInit ();
+  }
 }
 
 /**

--- a/UefiPayloadPkg/Tools/AppendRmapManifest.py
+++ b/UefiPayloadPkg/Tools/AppendRmapManifest.py
@@ -1,0 +1,137 @@
+## @file
+# Append an RMAP region manifest trailer to a firmware image.
+#
+# The manifest is a simple list of FMAP region names the firmware update
+# should program. It is consumed by the UefiPayloadPkg FMP device library.
+# If the manifest is absent, firmware falls back to full-flash updates.
+#
+# Copyright (c) 2025, 3mdeb Sp. z o.o. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+
+import argparse
+import os
+import struct
+import sys
+import subprocess
+
+#
+# Globals for help information
+#
+__prog__        = 'AppendRmapManifest'
+__description__ = 'Append an RMAP manifest trailer listing FMAP regions to flash.'
+__copyright__   = 'Copyright (c) 2025, 3mdeb Sp. z o.o. All rights reserved.'
+
+# SIGNATURE_32('R','M','A','P')
+RMAP_SIGNATURE = 0x50414D52
+RMAP_VERSION   = 1
+ENTRY_SIZE     = 16
+
+
+def build_manifest(region_names):
+    """Return the encoded manifest bytes for the given region names."""
+    entries = []
+    for name in region_names:
+        try:
+            encoded = name.encode('ascii')
+        except UnicodeError:
+            raise ValueError("Region name '{}' is not ASCII".format(name))
+        if len(encoded) > ENTRY_SIZE:
+            raise ValueError("Region name '{}' longer than {} bytes".format(name, ENTRY_SIZE))
+        entries.append(struct.pack('<{}s'.format(ENTRY_SIZE), encoded))
+
+    trailer = struct.pack('<IHH', RMAP_SIGNATURE, RMAP_VERSION, len(entries))
+    return b''.join(entries) + trailer
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__description__)
+    parser.add_argument('input', help='Input firmware image (FMP payload)')
+    parser.add_argument('-o', '--output', help='Output path (default: overwrite input)')
+    parser.add_argument(
+        '-r',
+        '--region',
+        action='append',
+        dest='regions',
+        required=True,
+        help='FMAP region name to flash (repeat for multiple regions)'
+    )
+    parser.add_argument('--fmp-guid', help='FMP/ESRT ImageTypeId GUID for the capsule payload')
+    parser.add_argument('--fw-version', type=int, default=1, help='Firmware version for capsule payload')
+    parser.add_argument('--lsv', type=int, default=0, help='Lowest supported version for capsule payload')
+    parser.add_argument('--update-image-index', type=int, help='UpdateImageIndex for the capsule payload')
+    parser.add_argument('--capsule-guid', help='(Deprecated) Ignored when using GenerateCapsule')
+    parser.add_argument('--embedded-driver', help='Optional embedded driver (.efi) to include in capsule')
+    parser.add_argument('--capflag', default='PersistAcrossReset',
+                        choices=['PersistAcrossReset', 'InitiateReset'],
+                        help='Capsule flag (default: PersistAcrossReset)')
+    parser.add_argument('--cap-output', help='Optional .cap output; enables capsule build via GenerateCapsule')
+    parser.add_argument('--generatecapsule', default='BaseTools/BinWrappers/PosixLike/GenerateCapsule',
+                        help='Path to GenerateCapsule wrapper')
+
+    args = parser.parse_args()
+
+    out_path = args.output or args.input
+    try:
+        with open(args.input, 'rb') as infile:
+            image = infile.read()
+    except IOError as exc:
+        print("error: failed to read '{}': {}".format(args.input, exc), file=sys.stderr)
+        return 1
+
+    try:
+        manifest = build_manifest(args.regions)
+    except ValueError as exc:
+        print("error: {}".format(exc), file=sys.stderr)
+        return 1
+
+    try:
+        with open(out_path, 'wb') as outfile:
+            outfile.write(image)
+            outfile.write(manifest)
+    except IOError as exc:
+        print("error: failed to write '{}': {}".format(out_path, exc), file=sys.stderr)
+        return 1
+
+    print("Appended {} region(s) manifest to {}".format(len(args.regions), os.path.abspath(out_path)))
+
+    if not args.cap_output:
+        return 0
+
+    if not args.fmp_guid:
+        print("error: --fmp-guid is required when building a capsule", file=sys.stderr)
+        return 1
+
+    if args.capsule_guid:
+        print("warning: --capsule-guid is deprecated and ignored by GenerateCapsule", file=sys.stderr)
+
+    generate_capsule_cmd = [
+        args.generatecapsule,
+        '-e',
+        '--guid', args.fmp_guid,
+        '--fw-version', str(args.fw_version),
+        '--lsv', str(args.lsv),
+        '--capflag', args.capflag,
+        '-o', args.cap_output,
+    ]
+
+    if args.update_image_index is not None:
+        generate_capsule_cmd += ['--update-image-index', str(args.update_image_index)]
+
+    if args.embedded_driver:
+        generate_capsule_cmd += ['--embedded-driver', args.embedded_driver]
+
+    generate_capsule_cmd += [out_path]
+
+    try:
+        subprocess.check_call(generate_capsule_cmd)
+    except subprocess.CalledProcessError as exc:
+        print("error: GenerateCapsule failed: {}".format(exc), file=sys.stderr)
+        return 1
+
+    print("Built capsule {}".format(os.path.abspath(args.cap_output)))
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/UefiPayloadPkg/UefiPayloadPkg.dsc
+++ b/UefiPayloadPkg/UefiPayloadPkg.dsc
@@ -293,13 +293,10 @@
   !if $(CAPSULE_SUPPORT) == TRUE
   CapsuleLib|MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleLib.inf
   BmpSupportLib|MdeModulePkg/Library/BaseBmpSupportLib/BaseBmpSupportLib.inf
-    !if $(BOOTSPLASH_IMAGE)
-    # Note, however, that DisplayUpdateProgressLibGraphics aborts firmware
-    # update if GOP is missing, so text progress works in more environments.
-    DisplayUpdateProgressLib|MdeModulePkg/Library/DisplayUpdateProgressLibGraphics/DisplayUpdateProgressLibGraphics.inf
-    !else
-    DisplayUpdateProgressLib|MdeModulePkg/Library/DisplayUpdateProgressLibText/DisplayUpdateProgressLibText.inf
-    !endif
+  # Use the graphics implementation for update progress.
+  # BOOT_ON_FLASH_UPDATE initializes the graphics console before
+  # processing capsules.
+  DisplayUpdateProgressLib|MdeModulePkg/Library/DisplayUpdateProgressLibGraphics/DisplayUpdateProgressLibGraphics.inf
   # If there are no specific checks to do, null-library suffices
   CapsuleUpdatePolicyLib|FmpDevicePkg/Library/CapsuleUpdatePolicyLibNull/CapsuleUpdatePolicyLibNull.inf
   FmpAuthenticationLib|SecurityPkg/Library/FmpAuthenticationLibPkcs7/FmpAuthenticationLibPkcs7.inf

--- a/UefiPayloadPkg/UefiPayloadPkg.dsc
+++ b/UefiPayloadPkg/UefiPayloadPkg.dsc
@@ -237,6 +237,7 @@
   BaseMemoryLib|MdePkg/Library/BaseMemoryLibRepStr/BaseMemoryLibRepStr.inf
   SynchronizationLib|MdePkg/Library/BaseSynchronizationLib/BaseSynchronizationLib.inf
   PrintLib|MdePkg/Library/BasePrintLib/BasePrintLib.inf
+  FileHandleLib|MdePkg/Library/UefiFileHandleLib/UefiFileHandleLib.inf
   CpuLib|MdePkg/Library/BaseCpuLib/BaseCpuLib.inf
   IoLib|MdePkg/Library/BaseIoLibIntrinsic/BaseIoLibIntrinsic.inf
 !if $(PCIE_BASE_SUPPORT) == FALSE
@@ -628,6 +629,8 @@
 
   ## Whether FMP capsules are enabled.
   gEfiMdeModulePkgTokenSpaceGuid.PcdCapsuleFmpSupport|$(CAPSULE_SUPPORT)
+  ## Whether embedded drivers in FMP capsules are supported (opt-in).
+  gEfiMdeModulePkgTokenSpaceGuid.PcdCapsuleEmbeddedDriverSupport|FALSE
 
 !if $(CRYPTO_PROTOCOL_SUPPORT) == TRUE
 !if $(CRYPTO_DRIVER_EXTERNAL_SUPPORT) == FALSE
@@ -981,6 +984,9 @@
   }
   MdeModulePkg/Application/BootManagerMenuApp/BootManagerMenuApp.inf
 !if $(CAPSULE_SUPPORT) == TRUE
+!if "$(CAPSULE_MAIN_FW_GUID)" == ""
+  !error "CAPSULE_MAIN_FW_GUID must be set when CAPSULE_SUPPORT is TRUE"
+!endif
   # Build FmpDxe meant for the inclusion into an update capsule as an embedded driver.
   FmpDevicePkg/FmpDxe/FmpDxe.inf {
     <Defines>

--- a/UefiPayloadPkg/UefiPayloadPkg.dsc
+++ b/UefiPayloadPkg/UefiPayloadPkg.dsc
@@ -54,6 +54,7 @@
   #
   DEFINE CAPSULE_SUPPORT              = FALSE
   DEFINE CAPSULE_MAIN_FW_GUID         =
+  DEFINE CAPSULE_EMBED_FMP_DXE        = FALSE
 
   #
   # Crypto Support
@@ -984,7 +985,8 @@
 !if "$(CAPSULE_MAIN_FW_GUID)" == ""
   !error "CAPSULE_MAIN_FW_GUID must be set when CAPSULE_SUPPORT is TRUE"
 !endif
-  # Build FmpDxe meant for the inclusion into an update capsule as an embedded driver.
+  # Build FmpDxe (either included in the payload FV or embedded into an update
+  # capsule, depending on CAPSULE_EMBED_FMP_DXE).
   FmpDevicePkg/FmpDxe/FmpDxe.inf {
     <Defines>
       # FmpDxe interprets its FILE_GUID as firmware GUID.  This allows including

--- a/UefiPayloadPkg/UefiPayloadPkg.fdf
+++ b/UefiPayloadPkg/UefiPayloadPkg.fdf
@@ -144,6 +144,14 @@ APRIORI DXE {
   INF  MdeModulePkg/Universal/ReportStatusCodeRouter/RuntimeDxe/ReportStatusCodeRouterRuntimeDxe.inf
   INF  MdeModulePkg/Universal/StatusCodeHandler/RuntimeDxe/StatusCodeHandlerRuntimeDxe.inf
   INF  UefiPayloadPkg/BlSupportDxe/BlSupportDxe.inf
+!if $(CAPSULE_SUPPORT) == TRUE
+    INF  UefiPayloadPkg/GraphicsOutputDxe/GraphicsOutputDxe.inf
+    !if $(BOOTSPLASH_IMAGE)
+      INF  MdeModulePkg/Universal/Acpi/BootGraphicsResourceTableDxe/BootGraphicsResourceTableDxe.inf
+      INF  MdeModulePkg/Universal/HiiDatabaseDxe/HiiDatabaseDxe.inf
+      INF  MdeModulePkg/Logo/LogoDxe.inf
+    !endif
+  !endif
 }
 
 #

--- a/UefiPayloadPkg/UefiPayloadPkg.fdf
+++ b/UefiPayloadPkg/UefiPayloadPkg.fdf
@@ -381,6 +381,9 @@ INF ShellPkg/Application/Shell/Shell.inf
 # Capsules
 #
 !if $(CAPSULE_SUPPORT) == TRUE
+!if $(CAPSULE_EMBED_FMP_DXE) == FALSE
+INF  FILE_GUID = $(CAPSULE_MAIN_FW_GUID) FmpDevicePkg/FmpDxe/FmpDxe.inf
+!endif
 INF MdeModulePkg/Universal/EsrtDxe/EsrtDxe.inf
 !endif
 


### PR DESCRIPTION
This PR improves capsule-based firmware updates for `UefiPayloadPkg` by:

- Restricting flashing scope using an appended FMAP manifest trailer (RMAP v1)
  so updates can target specific FMAP regions instead of full-chip.
- Providing safe fallbacks:
  - If no manifest is present but FMAP is available, flash only `SI_BIOS`.
  - If requested region layout mismatches between running flash and capsule,
    fall back to flashing `SI_BIOS`.
- Adding tooling support via `UefiPayloadPkg/Tools/AppendRmapManifest.py` to
  append the manifest trailer and optionally invoke `GenerateCapsule`
  (including an optional embedded driver).
- Improving update UX when `CAPSULE_SUPPORT` is enabled:
  - Always use `DisplayUpdateProgressLibGraphics` for capsule progress.
  - In `BOOT_ON_FLASH_UPDATE`, initialize the console and render the
    bootsplash *before* processing capsules, and add the required DXE
    modules to the APRIORI list (gated by `CAPSULE_SUPPORT`) so graphics
    progress is available early.

## Embedded driver support

- This PR keeps building `FmpDxe` for use as an embedded capsule driver, but
  leaves `PcdCapsuleEmbeddedDriverSupport` **disabled by default** (opt-in).
  Platforms that generate capsules with embedded drivers must enable the PCD.

## Testing

- `BaseTools/Scripts/PatchCheck.py` on the series
- Local `stuart` builds for `UefiPayloadPkg` (DEBUG/RELEASE) with
  `TOOL_CHAIN_TAG=GCC`
- Flash drive with updated COREBOOT and EC regions
- Flash device with updated COREBOOT and EC regions, and FMAP increased my 0x100,  to check SI_BIOS failover