### PR TITLE
UefiPayloadPkg,SecurityPkg: add OPAL S3 lockbox handoff

### DIFF
--- a/SecurityPkg/Include/Guid/OpalDeviceLockBox.h
+++ b/SecurityPkg/Include/Guid/OpalDeviceLockBox.h
@@ -1,0 +1,34 @@
+/** @file
+  Shared OPAL S3 LockBox record definitions.
+
+Copyright (c) 2026, Star Labs Systems. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef _OPAL_DEVICE_LOCKBOX_H_
+#define _OPAL_DEVICE_LOCKBOX_H_
+
+#define OPAL_MAX_PASSWORD_SIZE  32
+
+typedef struct {
+  UINT16    Segment;
+  UINT8     Bus;
+  UINT8     Device;
+  UINT8     Function;
+  UINT8     Reserved;
+} OPAL_PCI_DEVICE;
+
+typedef struct {
+  UINT32                      Length;
+  OPAL_PCI_DEVICE             Device;
+  UINT8                       PasswordLength;
+  UINT8                       Password[OPAL_MAX_PASSWORD_SIZE];
+  UINT16                      OpalBaseComId;
+  UINT32                      DevicePathLength;
+  EFI_DEVICE_PATH_PROTOCOL    DevicePath[];
+} OPAL_DEVICE_LOCKBOX_DATA;
+
+#define OPAL_DEVICE_LOCKBOX_GUID  { 0x56a77f0d, 0x6f05, 0x4d47, { 0xb9, 0x11, 0x4f, 0x0d, 0xec, 0x5c, 0x58, 0x61 } }
+
+#endif

--- a/SecurityPkg/Tcg/Opal/OpalPassword/OpalDriver.c
+++ b/SecurityPkg/Tcg/Opal/OpalPassword/OpalDriver.c
@@ -19,11 +19,60 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 EFI_GUID  mOpalDeviceLockBoxGuid = OPAL_DEVICE_LOCKBOX_GUID;
 
 BOOLEAN                mOpalEndOfDxe            = FALSE;
+STATIC BOOLEAN         mOpalS3LockBoxBuilt      = FALSE;
 OPAL_REQUEST_VARIABLE  *mOpalRequestVariable    = NULL;
 UINTN                  mOpalRequestVariableSize = 0;
 CHAR16                 mPopUpString[100];
 
 OPAL_DRIVER  mOpalDriver;
+
+STATIC EFI_DEVICE_PATH_PROTOCOL  *mS3InitDevicesCache       = NULL;
+STATIC UINTN                     mS3InitDevicesCacheLength = 0;
+
+STATIC
+VOID
+CacheS3InitDevicesFromLockBox (
+  VOID
+  )
+{
+  EFI_STATUS  Status;
+  UINT8       DummyData;
+  UINTN       S3InitDevicesLength;
+  VOID        *S3InitDevices;
+
+  if (mS3InitDevicesCache != NULL) {
+    return;
+  }
+
+  S3InitDevices       = NULL;
+  S3InitDevicesLength = sizeof (DummyData);
+  Status              = RestoreLockBox (
+                          &gS3StorageDeviceInitListGuid,
+                          &DummyData,
+                          &S3InitDevicesLength
+                          );
+  if (Status != EFI_BUFFER_TOO_SMALL) {
+    return;
+  }
+
+  S3InitDevices = AllocatePool (S3InitDevicesLength);
+  if (S3InitDevices == NULL) {
+    return;
+  }
+
+  Status = RestoreLockBox (
+             &gS3StorageDeviceInitListGuid,
+             S3InitDevices,
+             &S3InitDevicesLength
+             );
+  if (EFI_ERROR (Status)) {
+    FreePool (S3InitDevices);
+    return;
+  }
+
+  mS3InitDevicesCache       = S3InitDevices;
+  mS3InitDevicesCacheLength = S3InitDevicesLength;
+}
 
 //
 // Globals
@@ -296,8 +345,6 @@ BuildOpalDeviceInfo (
   UINTN                     TotalDevInfoLength;
   UINT32                    DevInfoLength;
   OPAL_DRIVER_DEVICE        *TmpDev;
-  UINT8                     DummyData;
-  BOOLEAN                   S3InitDevicesExist;
   UINTN                     S3InitDevicesLength;
   EFI_DEVICE_PATH_PROTOCOL  *S3InitDevices;
   EFI_DEVICE_PATH_PROTOCOL  *S3InitDevicesBak;
@@ -321,32 +368,22 @@ BuildOpalDeviceInfo (
     return;
   }
 
-  S3InitDevicesLength = sizeof (DummyData);
-  Status              = RestoreLockBox (
-                          &gS3StorageDeviceInitListGuid,
-                          &DummyData,
-                          &S3InitDevicesLength
-                          );
-  ASSERT ((Status == EFI_NOT_FOUND) || (Status == EFI_BUFFER_TOO_SMALL));
-  if (Status == EFI_NOT_FOUND) {
-    S3InitDevices      = NULL;
-    S3InitDevicesExist = FALSE;
-  } else if (Status == EFI_BUFFER_TOO_SMALL) {
-    S3InitDevices = AllocatePool (S3InitDevicesLength);
-    ASSERT (S3InitDevices != NULL);
+  //
+  // Don't call RestoreLockBox() for gS3StorageDeviceInitListGuid here.
+  // That LockBox is typically marked RESTORE_IN_S3_ONLY by other drivers at
+  // EndOfDxe, and RestoreLockBox() may be denied later (e.g. ReadyToBoot),
+  // which would ASSERT and stop boot.
+  //
+  // Instead, take any cached list captured earlier and then overwrite/update
+  // the LockBox using SaveLockBox()/UpdateLockBox().
+  //
+  if (mS3InitDevicesCache != NULL) {
+    S3InitDevices = AllocateCopyPool (mS3InitDevicesCacheLength, mS3InitDevicesCache);
     if (S3InitDevices == NULL) {
       return;
     }
-
-    Status = RestoreLockBox (
-               &gS3StorageDeviceInitListGuid,
-               S3InitDevices,
-               &S3InitDevicesLength
-               );
-    ASSERT_EFI_ERROR (Status);
-    S3InitDevicesExist = TRUE;
   } else {
-    return;
+    S3InitDevices = NULL;
   }
 
   DevInfo = AllocateZeroPool (TotalDevInfoLength);
@@ -390,41 +427,23 @@ BuildOpalDeviceInfo (
     TmpDev      = TmpDev->Next;
   }
 
-  Status = SaveLockBox (
-             &mOpalDeviceLockBoxGuid,
-             DevInfo,
-             TotalDevInfoLength
-             );
-  ASSERT_EFI_ERROR (Status);
+  Status = SaveLockBox (&mOpalDeviceLockBoxGuid, DevInfo, TotalDevInfoLength);
+  if (Status == EFI_ALREADY_STARTED) {
+    Status = UpdateLockBox (&mOpalDeviceLockBoxGuid, 0, DevInfo, TotalDevInfoLength);
+  }
 
-  Status = SetLockBoxAttributes (
-             &mOpalDeviceLockBoxGuid,
-             LOCK_BOX_ATTRIBUTE_RESTORE_IN_S3_ONLY
-             );
-  ASSERT_EFI_ERROR (Status);
+  if (!EFI_ERROR (Status)) {
+    Status = SetLockBoxAttributes (&mOpalDeviceLockBoxGuid, LOCK_BOX_ATTRIBUTE_RESTORE_IN_S3_ONLY);
+  }
 
   S3InitDevicesLength = GetDevicePathSize (S3InitDevices);
-  if (S3InitDevicesExist) {
-    Status = UpdateLockBox (
-               &gS3StorageDeviceInitListGuid,
-               0,
-               S3InitDevices,
-               S3InitDevicesLength
-               );
-    ASSERT_EFI_ERROR (Status);
-  } else {
-    Status = SaveLockBox (
-               &gS3StorageDeviceInitListGuid,
-               S3InitDevices,
-               S3InitDevicesLength
-               );
-    ASSERT_EFI_ERROR (Status);
+  Status              = SaveLockBox (&gS3StorageDeviceInitListGuid, S3InitDevices, S3InitDevicesLength);
+  if (Status == EFI_ALREADY_STARTED) {
+    Status = UpdateLockBox (&gS3StorageDeviceInitListGuid, 0, S3InitDevices, S3InitDevicesLength);
+  }
 
-    Status = SetLockBoxAttributes (
-               &gS3StorageDeviceInitListGuid,
-               LOCK_BOX_ATTRIBUTE_RESTORE_IN_S3_ONLY
-               );
-    ASSERT_EFI_ERROR (Status);
+  if (!EFI_ERROR (Status)) {
+    Status = SetLockBoxAttributes (&gS3StorageDeviceInitListGuid, LOCK_BOX_ATTRIBUTE_RESTORE_IN_S3_ONLY);
   }
 
   ZeroMem (DevInfo, TotalDevInfoLength);
@@ -454,7 +473,7 @@ SendBlockSidCommand (
     //
     Itr = mOpalDriver.DeviceList;
     while (Itr != NULL) {
-      if (Itr->OpalDisk.SupportedAttributes.BlockSid) {
+      if (Itr->OpalDisk.SupportedAttributes.BlockSid && !Itr->OpalDisk.SentBlockSID) {
         ZeroMem (&Session, sizeof (Session));
         Session.Sscp          = Itr->OpalDisk.Sscp;
         Session.MediaId       = Itr->OpalDisk.MediaId;
@@ -494,20 +513,56 @@ OpalEndOfDxeEventNotify (
   VOID       *Context
   )
 {
-  OPAL_DRIVER_DEVICE  *TmpDev;
-
   DEBUG ((DEBUG_INFO, "%a() - enter\n", __func__));
 
   mOpalEndOfDxe = TRUE;
 
-  if (mOpalRequestVariable != NULL) {
-    //
-    // Free the OPAL request variable buffer here
-    // as the OPAL requests should have been processed.
-    //
-    FreePool (mOpalRequestVariable);
-    mOpalRequestVariable     = NULL;
-    mOpalRequestVariableSize = 0;
+  CacheS3InitDevicesFromLockBox ();
+
+  //
+  // If no any device, return directly.
+  //
+  if (mOpalDriver.DeviceList == NULL) {
+    gBS->CloseEvent (Event);
+    return;
+  }
+
+  //
+  // Send BlockSid command if needed.
+  //
+  SendBlockSidCommand ();
+
+  DEBUG ((DEBUG_INFO, "%a() - exit\n", __func__));
+
+  gBS->CloseEvent (Event);
+}
+
+/**
+  Notification function of EFI_EVENT_GROUP_READY_TO_BOOT event group.
+
+  At ReadyToBoot, storage controllers are typically connected and any OPAL
+  password prompts have already occurred. Build the LockBox used for S3 resume
+  unlock at this point so passwords are available even if the device was
+  connected after EndOfDxe.
+
+  @param  Event        Event whose notification function is being invoked.
+  @param  Context      Pointer to the notification function's context.
+
+**/
+VOID
+EFIAPI
+OpalReadyToBootEventNotify (
+  EFI_EVENT  Event,
+  VOID       *Context
+  )
+{
+  OPAL_DRIVER_DEVICE  *TmpDev;
+
+  DEBUG ((DEBUG_INFO, "%a() - enter\n", __func__));
+
+  if (mOpalS3LockBoxBuilt) {
+    gBS->CloseEvent (Event);
+    return;
   }
 
   //
@@ -519,9 +574,10 @@ OpalEndOfDxeEventNotify (
   }
 
   BuildOpalDeviceInfo ();
+  mOpalS3LockBoxBuilt = TRUE;
 
   //
-  // Zero passsword.
+  // Zero password after saving to LockBox.
   //
   TmpDev = mOpalDriver.DeviceList;
   while (TmpDev != NULL) {
@@ -530,9 +586,21 @@ OpalEndOfDxeEventNotify (
   }
 
   //
-  // Send BlockSid command if needed.
+  // Free the OPAL request variable buffer after devices have had a chance to
+  // process requests during controller connection.
   //
-  SendBlockSidCommand ();
+  if (mOpalRequestVariable != NULL) {
+    FreePool (mOpalRequestVariable);
+    mOpalRequestVariable     = NULL;
+    mOpalRequestVariableSize = 0;
+  }
+
+  if (mS3InitDevicesCache != NULL) {
+    ZeroMem (mS3InitDevicesCache, mS3InitDevicesCacheLength);
+    FreePool (mS3InitDevicesCache);
+    mS3InitDevicesCache       = NULL;
+    mS3InitDevicesCacheLength = 0;
+  }
 
   DEBUG ((DEBUG_INFO, "%a() - exit\n", __func__));
 
@@ -2608,6 +2676,7 @@ EfiDriverEntryPoint (
 {
   EFI_STATUS  Status;
   EFI_EVENT   EndOfDxeEvent;
+  EFI_EVENT   ReadyToBootEvent;
 
   Status = EfiLibInstallDriverBindingComponentName2 (
              ImageHandle,
@@ -2636,6 +2705,16 @@ EfiDriverEntryPoint (
                   NULL,
                   &gEfiEndOfDxeEventGroupGuid,
                   &EndOfDxeEvent
+                  );
+  ASSERT_EFI_ERROR (Status);
+
+  Status = gBS->CreateEventEx (
+                  EVT_NOTIFY_SIGNAL,
+                  TPL_CALLBACK,
+                  OpalReadyToBootEventNotify,
+                  NULL,
+                  &gEfiEventReadyToBootGuid,
+                  &ReadyToBootEvent
                   );
   ASSERT_EFI_ERROR (Status);
 
@@ -2681,10 +2760,6 @@ OpalEfiDriverBindingSupported (
 {
   EFI_STATUS                             Status;
   EFI_STORAGE_SECURITY_COMMAND_PROTOCOL  *SecurityCommand;
-
-  if (mOpalEndOfDxe) {
-    return EFI_UNSUPPORTED;
-  }
 
   //
   // Test EFI_STORAGE_SECURITY_COMMAND_PROTOCOL on controller Handle.
@@ -2875,6 +2950,13 @@ OpalEfiDriverBindingStart (
   // Process OPAL request from last boot.
   //
   ProcessOpalRequest (Dev);
+
+  //
+  // If this device was connected after EndOfDxe, ensure BlockSID is applied if enabled.
+  //
+  if (mOpalEndOfDxe) {
+    SendBlockSidCommand ();
+  }
 
   return EFI_SUCCESS;
 

--- a/SecurityPkg/Tcg/Opal/OpalPassword/OpalDriver.c
+++ b/SecurityPkg/Tcg/Opal/OpalPassword/OpalDriver.c
@@ -26,8 +26,40 @@ CHAR16                 mPopUpString[100];
 
 OPAL_DRIVER  mOpalDriver;
 
-STATIC EFI_DEVICE_PATH_PROTOCOL  *mS3InitDevicesCache       = NULL;
+STATIC EFI_DEVICE_PATH_PROTOCOL  *mS3InitDevicesCache      = NULL;
 STATIC UINTN                     mS3InitDevicesCacheLength = 0;
+
+STATIC
+VOID
+BuildOpalDeviceInfo (
+  VOID
+  );
+
+STATIC
+UINT16
+RefreshOpalBaseComId (
+  IN OUT OPAL_DRIVER_DEVICE  *Dev
+  )
+{
+  TCG_RESULT                   TcgResult;
+  OPAL_SESSION                 Session;
+  OPAL_DISK_SUPPORT_ATTRIBUTE  SupportedAttributes;
+  UINT16                       BaseComId;
+
+  ASSERT (Dev != NULL);
+
+  ZeroMem (&Session, sizeof (Session));
+  Session.Sscp    = Dev->Sscp;
+  Session.MediaId = Dev->MediaId;
+
+  BaseComId = Dev->OpalDisk.OpalBaseComId;
+  TcgResult = OpalGetSupportedAttributesInfo (&Session, &SupportedAttributes, &BaseComId);
+  if (TcgResult == TcgResultSuccess) {
+    Dev->OpalDisk.OpalBaseComId = BaseComId;
+  }
+
+  return Dev->OpalDisk.OpalBaseComId;
+}
 
 STATIC
 VOID
@@ -244,6 +276,8 @@ OpalSupportUpdatePassword (
 {
   CopyMem (OpalDisk->Password, Password, PasswordLength);
   OpalDisk->PasswordLength = (UINT8)PasswordLength;
+
+  BuildOpalDeviceInfo ();
 }
 
 /**
@@ -401,7 +435,7 @@ BuildOpalDeviceInfo (
       TempDevInfo
       );
     TempDevInfo->Length        = DevInfoLength;
-    TempDevInfo->OpalBaseComId = TmpDev->OpalDisk.OpalBaseComId;
+    TempDevInfo->OpalBaseComId = RefreshOpalBaseComId (TmpDev);
     CopyMem (
       TempDevInfo->Password,
       TmpDev->OpalDisk.Password,

--- a/SecurityPkg/Tcg/Opal/OpalPassword/OpalHiiFormStrings.uni
+++ b/SecurityPkg/Tcg/Opal/OpalPassword/OpalHiiFormStrings.uni
@@ -33,7 +33,7 @@
 #string STR_MAIN_GOTO_DISK_INFO_HELP             #language en-US "Select disk to see actions"
 
 #string STR_MAIN_NO_DISKS_PRESENT_LBL            #language en-US "No disks connected to system"
-#string STR_MAIN_NO_DISKS_PRESENT_LBL_HELP       #language en-US "The storage needs to be connected before EndOfDxe"
+#string STR_MAIN_NO_DISKS_PRESENT_LBL_HELP       #language en-US "Connect storage devices and ensure storage drivers are started before entering this menu."
 
 /////////////////////////////////   DISK INFO MENU FORM   /////////////////////////////////
 #string STR_DISK_INFO_SELECTED_DISK_NAME         #language en-US " "

--- a/SecurityPkg/Tcg/Opal/OpalPassword/OpalPasswordCommon.h
+++ b/SecurityPkg/Tcg/Opal/OpalPassword/OpalPasswordCommon.h
@@ -8,28 +8,9 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #pragma once
 
-#define OPAL_MAX_PASSWORD_SIZE  32
+#include <Protocol/DevicePath.h>
+#include <Guid/OpalDeviceLockBox.h>
 
 #define OPAL_DEVICE_TYPE_UNKNOWN  0x0
 #define OPAL_DEVICE_TYPE_ATA      0x1
 #define OPAL_DEVICE_TYPE_NVME     0x2
-
-typedef struct {
-  UINT16    Segment;
-  UINT8     Bus;
-  UINT8     Device;
-  UINT8     Function;
-  UINT8     Reserved;
-} OPAL_PCI_DEVICE;
-
-typedef struct {
-  UINT32                      Length;
-  OPAL_PCI_DEVICE             Device;
-  UINT8                       PasswordLength;
-  UINT8                       Password[OPAL_MAX_PASSWORD_SIZE];
-  UINT16                      OpalBaseComId;
-  UINT32                      DevicePathLength;
-  EFI_DEVICE_PATH_PROTOCOL    DevicePath[];
-} OPAL_DEVICE_LOCKBOX_DATA;
-
-#define OPAL_DEVICE_LOCKBOX_GUID  { 0x56a77f0d, 0x6f05, 0x4d47, { 0xb9, 0x11, 0x4f, 0xd, 0xec, 0x5c, 0x58, 0x61 } }

--- a/SecurityPkg/Tcg/Opal/OpalPassword/OpalPasswordDxe.inf
+++ b/SecurityPkg/Tcg/Opal/OpalPassword/OpalPasswordDxe.inf
@@ -68,6 +68,7 @@
 
 [Guids]
   gEfiEndOfDxeEventGroupGuid                    ## CONSUMES ## Event
+  gEfiEventReadyToBootGuid                      ## CONSUMES ## Event
   gS3StorageDeviceInitListGuid                  ## SOMETIMES_PRODUCES ## UNDEFINED
   gEfiIfrTianoGuid                              ## CONSUMES
 

--- a/UefiPayloadPkg/Library/LockBoxLibApmsmi/LockBoxLibApmsmi.c
+++ b/UefiPayloadPkg/Library/LockBoxLibApmsmi/LockBoxLibApmsmi.c
@@ -1,0 +1,359 @@
+/** @file
+  LockBoxLib implementation using an APMC-triggered SMI.
+
+  UefiPayloadPkg does not include the SMM LockBox infrastructure that is used
+  by typical EDK2 platforms.
+
+  For coreboot payloads that need OPAL secrets on S3 resume, use the LockBoxLib
+  API as a transport layer: forward OPAL device LockBox updates to a coreboot
+  SMM handler via an APMC-triggered SMI. Other LockBox operations are left
+  unsupported so consumers can detect that no LockBox is available.
+
+  Copyright (c) 2026, Star Labs Systems. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <Uefi.h>
+
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
+#include <Library/LockBoxLib.h>
+#include <Library/UefiBootServicesTableLib.h>
+#include <Guid/OpalDeviceLockBox.h>
+
+#define OPAL_S3_APM_CNT_SVC            0xEE
+#define OPAL_S3_SMM_SUBCMD_SET_SECRET  0x01
+
+#define OPAL_S3_SMM_CTX_SIGNATURE  SIGNATURE_32 ('O', 'P', 'S', '3')
+#define OPAL_S3_SMM_CTX_VERSION    0x0001
+
+#pragma pack(push, 1)
+typedef struct {
+  UINT32    Signature;
+  UINT16    Version;
+  UINT16    Size;
+
+  UINT8     Bus;
+  UINT8     Device;
+  UINT8     Function;
+  UINT8     Reserved0;
+
+  UINT16    OpalBaseComId;
+  UINT16    Reserved1;
+
+  UINT8     PasswordLength;
+  UINT8     Reserved2[3];
+  UINT8     Password[OPAL_MAX_PASSWORD_SIZE];
+} OPAL_S3_SMM_CTX;
+#pragma pack(pop)
+
+STATIC CONST GUID  mOpalDeviceLockBoxGuid = OPAL_DEVICE_LOCKBOX_GUID;
+
+#if defined (MDE_CPU_X64)
+//
+// Platform SMM ABI: set RAX/RBX then outb to APMC (0xB2).
+//
+
+/**
+  Trigger an SMI by writing to the APMC port.
+
+  @param[in]  Cmd    APMC command value.
+  @param[in]  Arg    Argument passed to the SMM handler.
+  @param[in]  Retry  Number of retries if the SMI is not handled.
+
+  @retval Command-dependent result from SMM.
+**/
+UINTN
+EFIAPI
+LockBoxTriggerSmi (
+  IN UINTN  Cmd,
+  IN UINTN  Arg,
+  IN UINTN  Retry
+  );
+
+#else
+
+/**
+  Stub for non-X64 builds.
+
+  @param[in]  Cmd    APMC command value.
+  @param[in]  Arg    Argument passed to the SMM handler.
+  @param[in]  Retry  Number of retries if the SMI is not handled.
+
+  @retval Command-dependent result from SMM.
+**/
+STATIC
+UINTN
+EFIAPI
+LockBoxTriggerSmi (
+  IN UINTN  Cmd,
+  IN UINTN  Arg,
+  IN UINTN  Retry
+  )
+{
+  return Cmd;
+}
+
+#endif
+
+/**
+  Send an OPAL S3 service request to coreboot SMM via APMC.
+
+  @param[in]  Subcmd   Service subcommand.
+  @param[in]  CtxPhys  Physical address of the SMM context buffer.
+
+  @retval EFI_SUCCESS         The request was handled successfully.
+  @retval EFI_DEVICE_ERROR    The SMI was not handled or returned an error.
+**/
+STATIC
+EFI_STATUS
+SendSmmSvc (
+  IN UINT8                 Subcmd,
+  IN EFI_PHYSICAL_ADDRESS  CtxPhys
+  )
+{
+  UINTN  Cmd;
+  UINTN  Result;
+
+  Cmd = (UINTN)(((UINTN)Subcmd << 8) | OPAL_S3_APM_CNT_SVC);
+
+  Result = LockBoxTriggerSmi (Cmd, (UINTN)CtxPhys, 5);
+  if (Result == Cmd) {
+    DEBUG ((DEBUG_VERBOSE, "%a(): no SMM response\n", __func__));
+    return EFI_DEVICE_ERROR;
+  }
+
+  if (Result != 0) {
+    DEBUG ((DEBUG_VERBOSE, "%a(): SMM returned error: 0x%lx\n", __func__, (UINT64)Result));
+    return EFI_DEVICE_ERROR;
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Parse an OPAL device LockBox and forward each device secret to SMM.
+
+  @param[in]  Buffer  Pointer to the LockBox payload.
+  @param[in]  Length  Size of the payload in bytes.
+**/
+STATIC
+VOID
+ForwardOpalDeviceLockBoxToSmm (
+  IN VOID   *Buffer,
+  IN UINTN  Length
+  )
+{
+  EFI_STATUS            Status;
+  EFI_PHYSICAL_ADDRESS  CtxPhys;
+  OPAL_S3_SMM_CTX       *Ctx;
+  UINT8                 *Ptr;
+  UINT8                 *End;
+  UINT32                MinRecLen;
+
+  if ((Buffer == NULL) || (Length == 0)) {
+    return;
+  }
+
+  MinRecLen = OFFSET_OF (OPAL_DEVICE_LOCKBOX_DATA, DevicePath);
+  Ptr       = (UINT8 *)Buffer;
+  End       = Ptr + Length;
+
+  CtxPhys = 0xFFFFFFFF;
+  Status  = gBS->AllocatePages (
+                   AllocateMaxAddress,
+                   EfiBootServicesData,
+                   1,
+                   &CtxPhys
+                   );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_VERBOSE, "%a(): AllocatePages() failed: %r\n", __func__, Status));
+    return;
+  }
+
+  Ctx = (OPAL_S3_SMM_CTX *)(UINTN)CtxPhys;
+  ZeroMem (Ctx, EFI_PAGE_SIZE);
+
+  while (Ptr + MinRecLen <= End) {
+    OPAL_DEVICE_LOCKBOX_DATA  *Rec;
+
+    Rec = (OPAL_DEVICE_LOCKBOX_DATA *)(VOID *)Ptr;
+    if ((Rec->Length < MinRecLen) || (Ptr + Rec->Length > End)) {
+      break;
+    }
+
+    if ((Rec->PasswordLength != 0) && (Rec->PasswordLength <= OPAL_MAX_PASSWORD_SIZE)) {
+      ZeroMem (Ctx, sizeof (*Ctx));
+      Ctx->Signature      = OPAL_S3_SMM_CTX_SIGNATURE;
+      Ctx->Version        = OPAL_S3_SMM_CTX_VERSION;
+      Ctx->Size           = sizeof (*Ctx);
+      Ctx->Bus            = Rec->Device.Bus;
+      Ctx->Device         = Rec->Device.Device;
+      Ctx->Function       = Rec->Device.Function;
+      Ctx->OpalBaseComId  = Rec->OpalBaseComId;
+      Ctx->PasswordLength = Rec->PasswordLength;
+      CopyMem (Ctx->Password, Rec->Password, Rec->PasswordLength);
+
+      Status = SendSmmSvc (OPAL_S3_SMM_SUBCMD_SET_SECRET, CtxPhys);
+      if (EFI_ERROR (Status)) {
+        DEBUG ((DEBUG_VERBOSE, "%a(): OPAL SMI handoff failed: %r\n", __func__, Status));
+      }
+
+      ZeroMem (Ctx->Password, sizeof (Ctx->Password));
+      Ctx->PasswordLength = 0;
+    }
+
+    Ptr += Rec->Length;
+  }
+
+  ZeroMem (Ctx, EFI_PAGE_SIZE);
+  gBS->FreePages (CtxPhys, 1);
+}
+
+/**
+  Save a LockBox entry.
+
+  @param[in]  Guid    LockBox GUID.
+  @param[in]  Buffer  Buffer containing the data to save.
+  @param[in]  Length  Size of the data in bytes.
+
+  @retval RETURN_SUCCESS            The entry was created.
+  @retval RETURN_INVALID_PARAMETER  Input parameters are invalid.
+  @retval RETURN_ALREADY_STARTED    An entry already exists for Guid.
+  @retval RETURN_OUT_OF_RESOURCES   Allocation failed.
+**/
+RETURN_STATUS
+EFIAPI
+SaveLockBox (
+  IN  GUID   *Guid,
+  IN  VOID   *Buffer,
+  IN  UINTN  Length
+  )
+{
+  if ((Guid == NULL) || (Buffer == NULL) || (Length == 0)) {
+    return RETURN_INVALID_PARAMETER;
+  }
+
+  if (!CompareGuid (Guid, &mOpalDeviceLockBoxGuid)) {
+    return RETURN_UNSUPPORTED;
+  }
+
+  ForwardOpalDeviceLockBoxToSmm (Buffer, Length);
+  return RETURN_SUCCESS;
+}
+
+/**
+  Set attributes for an existing LockBox entry.
+
+  @param[in]  Guid        LockBox GUID.
+  @param[in]  Attributes  Attributes to set.
+
+  @retval RETURN_SUCCESS            Attributes were updated.
+  @retval RETURN_INVALID_PARAMETER  Guid is NULL.
+  @retval RETURN_NOT_FOUND          No entry exists for Guid.
+**/
+RETURN_STATUS
+EFIAPI
+SetLockBoxAttributes (
+  IN  GUID    *Guid,
+  IN  UINT64  Attributes
+  )
+{
+  if (Guid == NULL) {
+    return RETURN_INVALID_PARAMETER;
+  }
+
+  (void)Attributes;
+  return RETURN_UNSUPPORTED;
+}
+
+/**
+  Update an existing LockBox entry at an offset.
+
+  @param[in]  Guid    LockBox GUID.
+  @param[in]  Offset  Offset within the entry to update.
+  @param[in]  Buffer  Buffer containing the new data.
+  @param[in]  Length  Size of the new data in bytes.
+
+  @retval RETURN_SUCCESS            The entry was updated.
+  @retval RETURN_INVALID_PARAMETER  Input parameters are invalid.
+  @retval RETURN_NOT_FOUND          No entry exists for Guid.
+  @retval RETURN_OUT_OF_RESOURCES   Allocation failed.
+**/
+RETURN_STATUS
+EFIAPI
+UpdateLockBox (
+  IN  GUID   *Guid,
+  IN  UINTN  Offset,
+  IN  VOID   *Buffer,
+  IN  UINTN  Length
+  )
+{
+  if ((Guid == NULL) || (Buffer == NULL) || (Length == 0)) {
+    return RETURN_INVALID_PARAMETER;
+  }
+
+  if (!CompareGuid (Guid, &mOpalDeviceLockBoxGuid)) {
+    return RETURN_UNSUPPORTED;
+  }
+
+  if (Offset != 0) {
+    return RETURN_UNSUPPORTED;
+  }
+
+  ForwardOpalDeviceLockBoxToSmm (Buffer, Length);
+  return RETURN_SUCCESS;
+}
+
+/**
+  Restore a LockBox entry into a caller-provided buffer.
+
+  @param[in]      Guid    LockBox GUID.
+  @param[in]      Buffer  Destination buffer (optional).
+  @param[in, out] Length  On input, buffer size; on output, data size (optional).
+
+  @retval RETURN_SUCCESS            Data restored successfully.
+  @retval RETURN_INVALID_PARAMETER  Input parameters are invalid.
+  @retval RETURN_NOT_FOUND          No entry exists for Guid.
+  @retval RETURN_BUFFER_TOO_SMALL   Buffer is too small; Length updated.
+  @retval RETURN_WRITE_PROTECTED    Buffer/Length not provided.
+**/
+RETURN_STATUS
+EFIAPI
+RestoreLockBox (
+  IN  GUID       *Guid,
+  IN  VOID       *Buffer  OPTIONAL,
+  IN  OUT UINTN  *Length  OPTIONAL
+  )
+{
+  if (Guid == NULL) {
+    return RETURN_INVALID_PARAMETER;
+  }
+
+  if ((Buffer == NULL) != (Length == NULL)) {
+    return RETURN_INVALID_PARAMETER;
+  }
+
+  if ((Buffer == NULL) && (Length == NULL)) {
+    return RETURN_WRITE_PROTECTED;
+  }
+
+  return RETURN_NOT_FOUND;
+}
+
+/**
+  Restore all LockBox entries in-place.
+
+  This implementation does not support restoring all entries in-place.
+
+  @retval RETURN_UNSUPPORTED  This operation is not supported.
+**/
+RETURN_STATUS
+EFIAPI
+RestoreAllLockBoxInPlace (
+  VOID
+  )
+{
+  return RETURN_UNSUPPORTED;
+}

--- a/UefiPayloadPkg/Library/LockBoxLibApmsmi/LockBoxLibApmsmi.inf
+++ b/UefiPayloadPkg/Library/LockBoxLibApmsmi/LockBoxLibApmsmi.inf
@@ -1,0 +1,35 @@
+## @file
+#  LockBoxLib implementation using an APMC-triggered SMI.
+#
+#  Copyright (c) 2026, Star Labs Systems. All rights reserved.<BR>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010019
+  BASE_NAME                      = LockBoxLibApmsmi
+  FILE_GUID                      = 6D7F4A5B-3F8B-4B1F-8A2B-6C1A6F8C9330
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = LockBoxLib
+
+[Sources]
+  LockBoxLibApmsmi.c
+
+[Sources.X64]
+  X64/LockBoxTriggerSmi.nasm
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  SecurityPkg/SecurityPkg.dec
+  UefiPayloadPkg/UefiPayloadPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  BaseMemoryLib
+  DebugLib
+  UefiBootServicesTableLib
+  MemoryAllocationLib
+

--- a/UefiPayloadPkg/Library/LockBoxLibApmsmi/X64/LockBoxTriggerSmi.nasm
+++ b/UefiPayloadPkg/Library/LockBoxLibApmsmi/X64/LockBoxTriggerSmi.nasm
@@ -1,0 +1,37 @@
+;------------------------------------------------------------------------------ ;
+; LockBox APMC SMI trigger helper
+;
+; SPDX-License-Identifier: BSD-2-Clause-Patent
+;
+; UINTN EFIAPI LockBoxTriggerSmi(UINTN Cmd, UINTN Arg, UINTN Retry)
+;  - Cmd:   RAX value (AH=subcmd, AL=cmd byte)
+;  - Arg:   RBX value (pointer/physical address in flat memory)
+;  - Retry: number of retries if SMM does not modify RAX
+;------------------------------------------------------------------------------ ;
+
+%include "Nasm.inc"
+
+DEFAULT REL
+SECTION .text
+
+global ASM_PFX(LockBoxTriggerSmi)
+ASM_PFX(LockBoxTriggerSmi):
+    push    rbx
+    mov     rax, rcx
+    mov     rbx, rdx
+@Trigger:
+    out     0b2h, al
+    cmp     rax, rcx
+    jne     @Return
+    push    rcx
+    mov     rcx, 10000
+    rep     pause
+    pop     rcx
+    cmp     r8, 0
+    je      @Return
+    dec     r8
+    jmp     @Trigger
+@Return:
+    pop     rbx
+    ret
+

--- a/UefiPayloadPkg/Library/PlatformBootManagerLib/PlatformBootManager.c
+++ b/UefiPayloadPkg/Library/PlatformBootManagerLib/PlatformBootManager.c
@@ -9,6 +9,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #include "PlatformBootManager.h"
 #include "PlatformConsole.h"
+#include <Library/Tcg2PhysicalPresenceLib.h>
 #include <Protocol/FirmwareVolume2.h>
 
 /**
@@ -319,6 +320,11 @@ PlatformBootManagerAfterConsole (
     gST->ConOut->ClearScreen (gST->ConOut);
     BootLogoEnableLogo ();
   }
+
+  //
+  // Ensure TCG2 physical presence variables are initialized (required for OPAL BlockSID UI).
+  //
+  Tcg2PhysicalPresenceLibProcessRequest (NULL);
 
   EfiBootManagerConnectAll ();
   EfiBootManagerRefreshAllBootOption ();

--- a/UefiPayloadPkg/Library/PlatformBootManagerLib/PlatformBootManagerLib.inf
+++ b/UefiPayloadPkg/Library/PlatformBootManagerLib/PlatformBootManagerLib.inf
@@ -30,6 +30,7 @@
 [Packages]
   MdePkg/MdePkg.dec
   MdeModulePkg/MdeModulePkg.dec
+  SecurityPkg/SecurityPkg.dec
   UefiPayloadPkg/UefiPayloadPkg.dec
   ShellPkg/ShellPkg.dec
 
@@ -46,6 +47,7 @@
   DevicePathLib
   HiiLib
   PrintLib
+  Tcg2PhysicalPresenceLib
   PlatformHookLib
   CapsuleLib
   HobLib

--- a/UefiPayloadPkg/UefiPayloadPkg.dsc
+++ b/UefiPayloadPkg/UefiPayloadPkg.dsc
@@ -45,6 +45,7 @@
   DEFINE NVME_ENABLE                  = TRUE
   DEFINE LOCKBOX_SUPPORT              = FALSE
   DEFINE LOAD_OPTION_ROMS             = FALSE
+  DEFINE OPAL_PASSWORD_ENABLE         = FALSE
 
   #
   # Capsule updates
@@ -353,12 +354,26 @@
 !endif
 
   DebugLib|MdeModulePkg/Library/PeiDxeDebugLibReportStatusCode/PeiDxeDebugLibReportStatusCode.inf
-!if $(LOCKBOX_SUPPORT) == TRUE
+!if $(LOCKBOX_SUPPORT) == TRUE || $(OPAL_PASSWORD_ENABLE) == TRUE
   LockBoxLib|MdeModulePkg/Library/SmmLockBoxLib/SmmLockBoxDxeLib.inf
 !else
   LockBoxLib|MdeModulePkg/Library/LockBoxNullLib/LockBoxNullLib.inf
 !endif
   FileExplorerLib|MdeModulePkg/Library/FileExplorerLib/FileExplorerLib.inf
+
+  Tcg2PhysicalPresenceLib|OvmfPkg/Library/Tcg2PhysicalPresenceLibNull/DxeTcg2PhysicalPresenceLib.inf
+
+!if $(OPAL_PASSWORD_ENABLE) == TRUE
+  TcgStorageCoreLib|SecurityPkg/Library/TcgStorageCoreLib/TcgStorageCoreLib.inf
+  TcgStorageOpalLib|SecurityPkg/Library/TcgStorageOpalLib/TcgStorageOpalLib.inf
+  #
+  # OpalPasswordDxe consumes Tcg2PhysicalPresenceLib for BlockSID support.
+  #
+  Tcg2PhysicalPresenceLib|SecurityPkg/Library/DxeTcg2PhysicalPresenceLib/DxeTcg2PhysicalPresenceLib.inf
+  Tcg2PpVendorLib|SecurityPkg/Library/Tcg2PpVendorLibNull/Tcg2PpVendorLibNull.inf
+  Tpm2CommandLib|SecurityPkg/Library/Tpm2CommandLib/Tpm2CommandLib.inf
+  Tpm2DeviceLib|SecurityPkg/Library/Tpm2DeviceLibRouter/Tpm2DeviceLibRouterDxe.inf
+!endif
 
 !if $(SECURE_BOOT_ENABLE) == TRUE
   PlatformSecureLib|SecurityPkg/Library/PlatformSecureLibNull/PlatformSecureLibNull.inf
@@ -1199,6 +1214,9 @@
 !endif
 
 [Components.X64]
+!if $(OPAL_PASSWORD_ENABLE) == TRUE
+  SecurityPkg/Tcg/Opal/OpalPassword/OpalPasswordDxe.inf
+!endif
   UefiCpuPkg/CpuDxe/CpuDxe.inf
 
 !if $(TIMER_SUPPORT) == "HPET"

--- a/UefiPayloadPkg/UefiPayloadPkg.dsc
+++ b/UefiPayloadPkg/UefiPayloadPkg.dsc
@@ -354,10 +354,14 @@
 !endif
 
   DebugLib|MdeModulePkg/Library/PeiDxeDebugLibReportStatusCode/PeiDxeDebugLibReportStatusCode.inf
-!if $(LOCKBOX_SUPPORT) == TRUE || $(OPAL_PASSWORD_ENABLE) == TRUE
-  LockBoxLib|MdeModulePkg/Library/SmmLockBoxLib/SmmLockBoxDxeLib.inf
+!if $(OPAL_PASSWORD_ENABLE) == TRUE && $(BOOTLOADER) == "COREBOOT"
+  LockBoxLib|UefiPayloadPkg/Library/LockBoxLibApmsmi/LockBoxLibApmsmi.inf
 !else
-  LockBoxLib|MdeModulePkg/Library/LockBoxNullLib/LockBoxNullLib.inf
+  !if $(LOCKBOX_SUPPORT) == TRUE || $(OPAL_PASSWORD_ENABLE) == TRUE
+    LockBoxLib|MdeModulePkg/Library/SmmLockBoxLib/SmmLockBoxDxeLib.inf
+  !else
+    LockBoxLib|MdeModulePkg/Library/LockBoxNullLib/LockBoxNullLib.inf
+  !endif
 !endif
   FileExplorerLib|MdeModulePkg/Library/FileExplorerLib/FileExplorerLib.inf
 

--- a/UefiPayloadPkg/UefiPayloadPkg.fdf
+++ b/UefiPayloadPkg/UefiPayloadPkg.fdf
@@ -249,6 +249,11 @@ INF  MdeModulePkg/Universal/MemoryTest/NullMemoryTestDxe/NullMemoryTestDxe.inf
 !endif
 INF MdeModulePkg/Universal/HiiDatabaseDxe/HiiDatabaseDxe.inf
 INF MdeModulePkg/Universal/SetupBrowserDxe/SetupBrowserDxe.inf
+!if $(OPAL_PASSWORD_ENABLE) == TRUE
+!if "X64" IN "$(ARCH)"
+INF SecurityPkg/Tcg/Opal/OpalPassword/OpalPasswordDxe.inf
+!endif
+!endif
 INF MdeModulePkg/Universal/DisplayEngineDxe/DisplayEngineDxe.inf
 INF MdeModulePkg/Universal/PlatformDriOverrideDxe/PlatformDriOverrideDxe.inf
 INF MdeModulePkg/Universal/EbcDxe/EbcDxe.inf


### PR DESCRIPTION
This refreshed branch carries the current OPAL S3 unlock flow:

- add optional OPAL password support in `UefiPayloadPkg`
- build the OPAL S3 LockBox record at `ReadyToBoot`
- share the LockBox record definition between payload and driver code
- route the LockBox handoff through the payload SMM path
- refresh the LockBox contents when the OPAL password changes

The goal is to preserve the OPAL password across S3 in a form the firmware
resume path can use without prompting again.