### PR TITLE
Revert "ArmPkg, UefiCpuPkg: Fix boot failure on FEAT_LPA-only systems without LPA2

### DIFF
--- a/UefiCpuPkg/Library/ArmMmuLib/AArch64/ArmMmuLibCore.c
+++ b/UefiCpuPkg/Library/ArmMmuLib/AArch64/ArmMmuLibCore.c
@@ -94,7 +94,6 @@ ArmMemoryAttributeToPageAttribute (
 // T0SZ can be below MIN_T0SZ when LPA2 is in use, meaning the page table starts at level -1
 #define MIN_T0SZ        16
 #define BITS_PER_LEVEL  9
-#define MAX_VA_BITS_48  48
 #define MAX_VA_BITS     52
 
 STATIC
@@ -659,13 +658,8 @@ ArmConfigureMmu (
   // into account the architectural limitations that result from UEFI's
   // use of 4 KB pages.
   //
-  if (ArmHas52BitTgran4 ()) {
-    MaxAddressBits = MIN (ArmGetPhysicalAddressBits (), MAX_VA_BITS);
-  } else {
-    MaxAddressBits = MIN (ArmGetPhysicalAddressBits (), MAX_VA_BITS_48);
-  }
-
-  MaxAddress = LShiftU64 (1ULL, MaxAddressBits) - 1;
+  MaxAddressBits = MIN (ArmGetPhysicalAddressBits (), MAX_VA_BITS);
+  MaxAddress     = LShiftU64 (1ULL, MaxAddressBits) - 1;
 
   T0SZ                = 64 - MaxAddressBits;
   RootTableEntryCount = GetRootTableEntryCount (T0SZ);


### PR DESCRIPTION
 PR [tianocore#11961](https://github.com/tianocore/edk2/pull/11961) introduced commit 1a4c4fb,
("ArmPkg, UefiCpuPkg: Fix boot failure on FEAT_LPA-only systems without LPA2") that is not an useful solution to fix the issue in reading the register id_aa64mmfr0_el1. CPU vendors should override the value in the function "ArmGetPhysicalAddressBits" instead changing the value of "MAX_VA_BITS".

The possible solution for CPU vendors, who want to fix the issue on returning value from `ArmGetPhysicalAddressBits`

The example for CPU which supports 48 bits physical address

```
ASM_FUNC(ArmGetPhysicalAddressBits)
    mrs   x0, id_aa64mmfr0_el1
    adr   x1, .LPARanges
    and   x0, x0, #0xf
    ldrb  w0, [x1, x0]
    cmp   w0, #48
    b.ne  .OverrideCpuReg
    ret
.OverrideCpuReg:
    mov   w0, #48
    ret
```