### PR TITLE
UefiCpuPkg: Update exception vector for LoongArch64

### DIFF
--- a/UefiCpuPkg/Library/CpuExceptionHandlerLib/LoongArch/LoongArch64/ArchExceptionHandler.c
+++ b/UefiCpuPkg/Library/CpuExceptionHandlerLib/LoongArch/LoongArch64/ArchExceptionHandler.c
@@ -248,57 +248,49 @@ IpiInterruptHandler (
 
   IpiStatus = IoCsrRead32 (LOONGARCH_IOCSR_IPI_STATUS);
 
-  //
-  // Clear interrupt.
-  //
-  IoCsrWrite32 (LOONGARCH_IOCSR_IPI_CLEAR, IpiStatus);
-
   if ((IpiStatus & SMP_RESCHEDULE) != 0) {
+    //
+    // Clear current IPI interrupt bit.
+    //
+    IoCsrWrite32 (LOONGARCH_IOCSR_IPI_CLEAR, (IpiStatus & SMP_RESCHEDULE));
+
     MemoryFence ();
     return;
-  } else {
-    if (((IpiStatus & SMP_BOOT_CPU) != 0) || ((IpiStatus & SMP_CALL_FUNCTION) != 0)) {
-      //
-      // Confirm that the mail box message has arrived.
-      //
-      do {
-        ResumeVector = IoCsrRead32 (LOONGARCH_IOCSR_MBUF0);
-      } while (!ResumeVector);
+  } else if ((IpiStatus & SMP_CALL_FUNCTION) != 0) {
+    //
+    // Clear current IPI interrupt bit.
+    //
+    IoCsrWrite32 (LOONGARCH_IOCSR_IPI_CLEAR, (IpiStatus & SMP_CALL_FUNCTION));
 
-      //
-      // Get the resume vector if populated.
-      //
-      ResumeVector = IoCsrRead64 (LOONGARCH_IOCSR_MBUF0);
+    //
+    // Confirm that the mail box message has arrived.
+    //
+    do {
+      ResumeVector = IoCsrRead32 (LOONGARCH_IOCSR_MBUF0);
+    } while (!ResumeVector);
 
-      if ((IpiStatus & SMP_BOOT_CPU) != 0) {
-        SystemContext.SystemContextLoongArch64->PRMD &= ~((UINT64)BIT2); // Clean PIE
-      } else if ((IpiStatus & SMP_CALL_FUNCTION) != 0) {
-        //
-        // Confirm that the mail box message has arrived.
-        //
-        do {
-          Parameter = IoCsrRead32 (LOONGARCH_IOCSR_MBUF3);
-        } while (!Parameter && --RereadCount);
+    //
+    // Get the resume vector if populated.
+    //
+    ResumeVector = IoCsrRead64 (LOONGARCH_IOCSR_MBUF0);
 
-        //
-        // Get the parameter if populated.
-        //
-        Parameter = IoCsrRead64 (LOONGARCH_IOCSR_MBUF3);
+    //
+    // Confirm that the mail box message has arrived.
+    //
+    do {
+      Parameter = IoCsrRead32 (LOONGARCH_IOCSR_MBUF3);
+    } while (!Parameter && --RereadCount);
 
-        //
-        // Set $a0 as APIC ID and $a1 as parameter value.
-        //
-        SystemContext.SystemContextLoongArch64->R4 = CsrRead (LOONGARCH_CSR_CPUID);
-        SystemContext.SystemContextLoongArch64->R5 = Parameter;
-      }
-    } else {
-      InternalPrintMessage (
-        "Core %d: Should never be here, IPI Status = %d.\n",
-        CsrRead (LOONGARCH_CSR_CPUID),
-        IpiStatus
-        );
-      DefaultExceptionHandler (EXCEPT_LOONGARCH_INT, SystemContext);
-    }
+    //
+    // Get the parameter if populated.
+    //
+    Parameter = IoCsrRead64 (LOONGARCH_IOCSR_MBUF3);
+
+    //
+    // Set $a0 as APIC ID and $a1 as parameter value.
+    //
+    SystemContext.SystemContextLoongArch64->R4 = CsrRead (LOONGARCH_CSR_CPUID);
+    SystemContext.SystemContextLoongArch64->R5 = Parameter;
 
     //
     // Clean up current processor mailbox 0 and mailbox 3.
@@ -310,6 +302,13 @@ IpiInterruptHandler (
     // Set the ERA to the resume vector sent by caller.
     //
     SystemContext.SystemContextLoongArch64->ERA = ResumeVector;
+  } else {
+    InternalPrintMessage (
+      "Core %d: Should never be here, IPI Status = %d.\n",
+      CsrRead (LOONGARCH_CSR_CPUID),
+      IpiStatus
+      );
+    DefaultExceptionHandler (EXCEPT_LOONGARCH_INT, SystemContext);
   }
 
   MemoryFence ();

--- a/UefiCpuPkg/Library/CpuExceptionHandlerLib/LoongArch/LoongArch64/ExceptionHandlerAsm.S
+++ b/UefiCpuPkg/Library/CpuExceptionHandlerLib/LoongArch/LoongArch64/ExceptionHandlerAsm.S
@@ -11,6 +11,8 @@
 #include <Library/BaseLib.h>
 #include <Library/CpuLib.h>
 #include <Register/LoongArch64/Csr.h>
+#include <Protocol/DebugSupport.h>
+#include "ExceptionCommon.h"
 
 #define RSIZE                 8           // 64 bit mode register size
 #define GP_REG_CONTEXT_SIZE   32 * RSIZE  // General-purpose registers size
@@ -250,7 +252,7 @@ ASM_PFX(ExceptionEntryStart):
 
   csrrd   $t0, LOONGARCH_CSR_EUEN
   andi    $t0, $t0, CSR_EUEN_FPEN
-  beqz    $t0, EntryConmmonHanlder
+  beqz    $t0, ExcVectorDispatcher
 
   fst.d  $fa0, $sp, 0 * RSIZE
   fst.d  $fa1, $sp, 1 * RSIZE
@@ -312,7 +314,129 @@ ASM_PFX(ExceptionEntryStart):
   // Push exception context down
   //
 
-EntryConmmonHanlder:
+ExcVectorDispatcher:
+  csrrd     $t0, LOONGARCH_CSR_ESTAT
+  li.d      $t1, CSR_ESTAT_EXC
+  and       $t1, $t0, $t1
+  srli.d    $t1, $t1, CSR_ESTAT_EXC_SHIFT
+  beqz      $t1, IntVectorDispatcher // If Ecode is 0, it indicates that an interrupt has occurred.
+  b         EntryCommonHandler       // Currently, other exception should be handled using C code.
+
+IntVectorDispatcher:
+  srli.d    $t1, $t0, EXCEPT_LOONGARCH_INT_TIMER
+  andi      $t1, $t1, BIT0
+  bnez      $t1, TimerVector
+
+  srli.d    $t1, $t0, EXCEPT_LOONGARCH_INT_IPI
+  andi      $t1, $t1, BIT0
+  bnez      $t1, IpiVector
+
+  srli.d    $t1, $t0, EXCEPT_LOONGARCH_INT_PMC
+  andi      $t1, $t1, BIT0
+  bnez      $t1, PmcVector
+
+  srli.d    $t1, $t0, EXCEPT_LOONGARCH_INT_IP7
+  andi      $t1, $t1, BIT0
+  bnez      $t1, HwIpVector
+
+  srli.d    $t1, $t0, EXCEPT_LOONGARCH_INT_IP6
+  andi      $t1, $t1, BIT0
+  bnez      $t1, HwIpVector
+
+  srli.d    $t1, $t0, EXCEPT_LOONGARCH_INT_IP5
+  andi      $t1, $t1, BIT0
+  bnez      $t1, HwIpVector
+
+  srli.d    $t1, $t0, EXCEPT_LOONGARCH_INT_IP4
+  andi      $t1, $t1, BIT0
+  bnez      $t1, HwIpVector
+
+  srli.d    $t1, $t0, EXCEPT_LOONGARCH_INT_IP3
+  andi      $t1, $t1, BIT0
+  bnez      $t1, HwIpVector
+
+  srli.d    $t1, $t0, EXCEPT_LOONGARCH_INT_IP2
+  andi      $t1, $t1, BIT0
+  bnez      $t1, HwIpVector
+
+  srli.d    $t1, $t0, EXCEPT_LOONGARCH_INT_IP1
+  andi      $t1, $t1, BIT0
+  bnez      $t1, HwIpVector
+
+  srli.d    $t1, $t0, EXCEPT_LOONGARCH_INT_IP0
+  andi      $t1, $t1, BIT0
+  bnez      $t1, HwIpVector
+
+  srli.d    $t1, $t0, EXCEPT_LOONGARCH_INT_SIP1
+  andi      $t1, $t1, BIT0
+  bnez      $t1, SwIpVector
+
+  srli.d    $t1, $t0, EXCEPT_LOONGARCH_INT_SIP0
+  andi      $t1, $t1, BIT0
+  bnez      $t1, SwIpVector
+
+  b         EntryCommonHandler // Never shouldn't be here, go to the C code to dump the context.
+
+TimerVector:
+PmcVector:
+HwIpVector:
+SwIpVector:
+  b         EntryCommonHandler // Timer, PMC, HWINT, SWINT should be handled using C code.
+
+IpiVector:
+  //
+  // Get the IPI vector.
+  //
+  li.d      $t0, LOONGARCH_IOCSR_IPI_STATUS
+  iocsrrd.w $t1, $t0
+
+  //
+  // SMP_BOOT_CPU vector, fast path.
+  //
+  andi      $t1, $t1, SMP_BOOT_CPU
+  beqz      $t1, EntryCommonHandler
+
+  //
+  // Clear current IPI interrupt bit.
+  //
+  li.d      $t0, LOONGARCH_IOCSR_IPI_CLEAR
+  iocsrwr.w $t1, $t0
+
+  //
+  // Get the resume vector.
+  //
+TryReadResumeVector:
+  li.d      $t0, LOONGARCH_IOCSR_MBUF0
+  iocsrrd.w $a0, $t0
+  bnez      $a0, ReadRealResumeVector
+  b         TryReadResumeVector
+ReadRealResumeVector:
+  iocsrrd.d $a0, $t0
+
+  //
+  // Clean up current processor mailbox 0.
+  //
+  li.d      $t0, LOONGARCH_IOCSR_MBUF0
+  iocsrwr.d $zero, $t0
+
+  //
+  // The SMP_BOOT_CPU vector should never be returned. Clean up the PIE and ensure that
+  // global interrupts are turned off for the current processor for handover.
+  //
+  csrwr     $a0, LOONGARCH_CSR_ERA         // Update ERA
+  li.w      $t0, BIT2                      // IE
+  csrxchg   $zero, $t0, LOONGARCH_CSR_PRMD // Clean PIE
+
+  //
+  // Use ERA to jump to next stage.
+  //
+  ertn
+
+  //
+  // End of IpiVector fast path.
+  //
+
+EntryCommonHandler:
   addi.d  $sp, $sp, -(GP_REG_CONTEXT_SIZE + CSR_REG_CONTEXT_SIZE)
   move    $a0, $sp
   la.abs  $ra, ExceptionEntry


### PR DESCRIPTION
# Description

An exception and interrupt vector table was added to the ASM file, a fast path was created for the IPI SMP_BOOT_CPU vector, and the C version of the SMP_BOOT_CPU handler was removed.

## How This Was Tested

Apply the patch and build OvmfPkg/LoongArchVirt/, then use the FV to boot on a KVM with more than 1 core and check if it can boot into the operating system.

## Integration Instructions

N/A
