### PR TITLE
ArmPlatformPkg/PL011UartLib : Fix SetControl() SCT conformance

### DIFF
--- a/ArmPlatformPkg/Library/PL011UartLib/PL011UartLib.c
+++ b/ArmPlatformPkg/Library/PL011UartLib/PL011UartLib.c
@@ -22,10 +22,22 @@
 #define FRACTION_PART_MASK          ((1 << FRACTION_PART_SIZE_IN_BITS) - 1)
 
 //
-// EFI_SERIAL_SOFTWARE_LOOPBACK_ENABLE is the only
-// control bit that is not supported.
+// Per UEFI spec, only these control bits are allowed to be set.
 //
-STATIC CONST UINT32  mInvalidControlBits = EFI_SERIAL_SOFTWARE_LOOPBACK_ENABLE;
+STATIC CONST UINT32  mAllowedControlBits =
+  EFI_SERIAL_CLEAR_TO_SEND |
+  EFI_SERIAL_DATA_SET_READY |
+  EFI_SERIAL_RING_INDICATE |
+  EFI_SERIAL_CARRIER_DETECT |
+  EFI_SERIAL_SOFTWARE_LOOPBACK_ENABLE |
+  EFI_SERIAL_OUTPUT_BUFFER_EMPTY |
+  EFI_SERIAL_INPUT_BUFFER_EMPTY;
+
+//
+// platform-specific bits that are not supported by this device.
+//
+STATIC CONST UINT32  mPlatformInvalidControlBits =
+  EFI_SERIAL_SOFTWARE_LOOPBACK_ENABLE;
 
 /**
 
@@ -274,7 +286,11 @@ PL011UartSetControl (
 {
   UINT32  Bits;
 
-  if ((Control & mInvalidControlBits) != 0) {
+  if ((Control & ~mAllowedControlBits) != 0) {
+    return RETURN_UNSUPPORTED;
+  }
+
+  if ((Control & mPlatformInvalidControlBits) != 0) {
     return RETURN_UNSUPPORTED;
   }
 


### PR DESCRIPTION
# Description

The PL011UartLib SetControl() is failing the SCT test for SerialIoBBTestConformance (00605CBC-3965-4B61-A254-2B2B723172EA), which is trying to set bits that are not supported per UEFI spec.

Add proper argument check for valid bits, and confirm that test passes.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

EDK2 SCT test SerialIoBBTestConformance (00605CBC-3965-4B61-A254-2B2B723172EA) on RPi4, with failure without this patch [shown here](https://github.com/pftf/acs-reports/blob/master/v1.17%2B/sct-tianocore/Overall/Summary.log)

Also tested by @wangsim on NVIDIA GB300, test results: [SetControl_Conf_0_0_B7767573-DEE3-424C-991C-1F5581433F02.log](https://github.com/user-attachments/files/24942344/SetControl_Conf_0_0_B7767573-DEE3-424C-991C-1F5581433F02.log)


## Integration Instructions

N/A