### PR TITLE
MdeModulePkg/ArmFfaLib: Implement base instance of ArmFfaLib

### DIFF
--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaLibBase.c
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaLibBase.c
@@ -1,0 +1,57 @@
+/** @file
+  This file is originally sourced from ArmFfaStandaloneMmLib, with
+  Rx/Tx-related APIs removed to focus exclusively on FFA primitives.
+
+  Provides FF-A ABI Library used in all environments.
+
+  Copyright (c) 2024, Arm Limited. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+   @par Glossary:
+     - FF-A - Firmware Framework for Arm A-profile
+
+   @par Reference(s):
+     - Arm Firmware Framework for Arm A-Profile [https://developer.arm.com/documentation/den0077/latest]
+
+**/
+
+#include <Uefi.h>
+#include <Pi/PiBootMode.h>
+#include <Pi/PiHob.h>
+
+#include <Library/DebugLib.h>
+
+#include "ArmFfaCommon.h"
+
+/**
+  ArmFfaLib Constructor.
+
+  @retval EFI_SUCCESS            Success
+  @retval Others                 Error
+
+**/
+EFI_STATUS
+EFIAPI
+ArmFfaLibBaseConstructor (
+  VOID
+  )
+{
+  EFI_STATUS  Status;
+
+  Status = ArmFfaLibCommonInit ();
+  if (Status == EFI_UNSUPPORTED) {
+    /*
+     * EFI_UNSUPPORTED means FF-A interface isn't available.
+     * However, for Standalone MM modules, FF-A availability is not required.
+     * i.e. Standalone MM could use SpmMm as a legitimate protocol.
+     * Thus, returning EFI_SUCCESS here to avoid the entrypoint to assert.
+     */
+    return EFI_SUCCESS;
+  }
+
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a failed. Status = %r\n", __func__, Status));
+  }
+
+  return Status;
+}

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaLibBase.inf
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaLibBase.inf
@@ -1,0 +1,46 @@
+## @file
+#  This file is originally sourced from ArmFfaStandaloneMmLib, with
+#  Rx/Tx-related APIs removed to focus exclusively on FFA primitives.
+#  Provides FF-A ABI Library used in all environments.
+#
+#  Copyright (c) 2024, Arm Limited. All rights reserved.<BR>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION                    = 0x0001001B
+  BASE_NAME                      = ArmFfaLibBase
+  FILE_GUID                      = D79FF75E-AD0A-4074-A335-2084533744AF
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  PI_SPECIFICATION_VERSION       = 0x00010032
+  LIBRARY_CLASS                  = ArmFfaLib
+  CONSTRUCTOR                    = ArmFfaLibBaseConstructor
+
+[Sources]
+  ArmFfaCommon.h
+  ArmFfaCommon.c
+  ArmFfaLibBase.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+
+[LibraryClasses]
+  ArmSmcLib
+  ArmSvcLib
+  BaseLib
+  BaseMemoryLib
+  DebugLib
+  HobLib
+  PcdLib
+  MemoryAllocationLib
+  TimerLib
+
+[Pcd]
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFfaLibConduitSmc
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFfaTxRxPageCount
+
+[Guids]
+  gArmFfaRxTxBufferInfoGuid

--- a/MdeModulePkg/MdeModulePkg.dsc
+++ b/MdeModulePkg/MdeModulePkg.dsc
@@ -539,6 +539,7 @@
   MdeModulePkg/Library/ArmFfaLib/ArmFfaDxeLib.inf
   MdeModulePkg/Library/ArmFfaLib/ArmFfaStandaloneMmCoreLib.inf
   MdeModulePkg/Library/ArmFfaLib/ArmFfaStandaloneMmLib.inf
+  MdeModulePkg/Library/ArmFfaLib/ArmFfaLibBase.inf
 
 [BuildOptions]
 


### PR DESCRIPTION
# Description

Current usage of Rx/Tx buffer is unnecessarily pulling in UEFI framework related data usage, i.e. PEI, DXE, STMM, etc. This is undesirable for components that only needs to use the basic functionalities.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Ran CI locally

## Integration Instructions

Normal integration instructions. If wanting to use this library, add it to the corresponding .inf as well as the .dsc for your platform.
