### PR TITLE
MdeModulePkg: Remove unused variables

### DIFF
--- a/MdeModulePkg/Library/CustomizedDisplayLib/CustomizedDisplayLib.c
+++ b/MdeModulePkg/Library/CustomizedDisplayLib/CustomizedDisplayLib.c
@@ -432,7 +432,6 @@ CreateDialog (
   UINTN          LargestString;
   UINTN          LineNum;
   UINTN          Index;
-  UINTN          Count;
   CHAR16         Character;
   UINTN          Start;
   UINTN          End;
@@ -503,9 +502,8 @@ CreateDialog (
   PrintCharAt ((UINTN)-1, (UINTN)-1, Character);
   Character = BOXDRAW_VERTICAL;
 
-  Count = 0;
   VA_START (Marker, Key);
-  for (Index = Top; Index + 2 < Bottom; Index++, Count++) {
+  for (Index = Top; Index + 2 < Bottom; Index++) {
     String = VA_ARG (Marker, CHAR16 *);
 
     if (String[0] == CHAR_NULL) {

--- a/MdeModulePkg/Universal/DisplayEngineDxe/ProcessOptions.c
+++ b/MdeModulePkg/Universal/DisplayEngineDxe/ProcessOptions.c
@@ -587,7 +587,6 @@ CreateSharedPopUp (
   )
 {
   UINTN   Index;
-  UINTN   Count;
   CHAR16  Character;
   UINTN   Start;
   UINTN   End;
@@ -627,8 +626,7 @@ CreateSharedPopUp (
   PrintCharAt ((UINTN)-1, (UINTN)-1, Character);
   Character = BOXDRAW_VERTICAL;
 
-  Count = 0;
-  for (Index = Top; Index + 2 < Bottom; Index++, Count++) {
+  for (Index = Top; Index + 2 < Bottom; Index++) {
     String = VA_ARG (Marker, CHAR16 *);
 
     //

--- a/MdeModulePkg/Universal/SmbiosMeasurementDxe/SmbiosMeasurementDxe.c
+++ b/MdeModulePkg/Universal/SmbiosMeasurementDxe/SmbiosMeasurementDxe.c
@@ -218,14 +218,12 @@ GetSmbiosStringById (
   OUT  UINTN                    *StringLen
   )
 {
-  UINTN  Size;
   UINTN  StrLen;
   CHAR8  *CharInStr;
   UINTN  StringsNumber;
   CHAR8  *String;
 
   CharInStr     = (CHAR8 *)Head + Head->Length;
-  Size          = Head->Length;
   StringsNumber = 0;
   StrLen        = 0;
   //
@@ -234,7 +232,6 @@ GetSmbiosStringById (
   String = NULL;
   while (*CharInStr != 0 || *(CharInStr+1) != 0) {
     if (*CharInStr == 0) {
-      Size += 1;
       CharInStr++;
     }
 
@@ -256,7 +253,6 @@ GetSmbiosStringById (
     // forward the pointer
     //
     CharInStr     += StrLen;
-    Size          += StrLen;
     StringsNumber += 1;
     if (StringsNumber == StringId) {
       break;


### PR DESCRIPTION
GCC 16 spots some occurrences where variables are initialized and updated, but never read back, breaking the build. Just drop them.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.
