### PR TITLE
Added configuration to run makefile script to specify using GNU Make …

### DIFF
--- a/BaseTools/Scripts/RunMakefile.py
+++ b/BaseTools/Scripts/RunMakefile.py
@@ -149,6 +149,8 @@ if __name__ == '__main__':
   CommandLine.append(gArgs.BuildType)
   if sys.platform == "win32":
     CommandLine = 'nmake /f %s' % (' '.join(CommandLine))
+  if 'bsd' in sys.platform:
+    CommandLine = 'gmake -f %s' % (' '.join(CommandLine))
   else:
     CommandLine = 'make -f %s' % (' '.join(CommandLine))
 


### PR DESCRIPTION
…command on BSD systems

# Description

Added an if statement to to RunMakefile.py script to detect BSD systems and specify running the GNU Make command to allow seamless compilation on those platforms.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - No. In fact, it solves a problem involving the build process on BSD systems.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - No.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - No.

## How This Was Tested

I cloned the source tree on my BSD system and attempted to build that which I previously couldn't, even after setting environment variables.

## Integration Instructions

N/A
