### PR TITLE
OvmfPkg/CcExitLib: Initialize XCr0 in else-path to fix build error

### DIFF
--- a/OvmfPkg/Library/CcExitLib/CcExitVcHandler.c
+++ b/OvmfPkg/Library/CcExitLib/CcExitVcHandler.c
@@ -1448,6 +1448,8 @@ CpuidExit (
     Cr4.UintN           = AsmReadCr4 ();
     Ghcb->SaveArea.XCr0 = (Cr4.Bits.OSXSAVE == 1) ? AsmXGetBv (0) : 1;
     XCr0                = (Cr4.Bits.OSXSAVE == 1) ? AsmXGetBv (0) : 1;
+  } else {
+    XCr0 = 0;
   }
 
   if (SnpEnabled ()) {


### PR DESCRIPTION
# Description
Add an else-path to explicitly set XCr0 to 0 when EaxIn is not CPUID_EXTENDED_STATE. This ensures XCr0 is initialized across all logic paths and resolves the GCC build error regarding a potential uninitialized variable.

These changes were implemented based on the feedback provided
https://github.com/tianocore/edk2/pull/12104#discussion_r2754533648


- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested
build -a X64 -p OvmfPkg/OvmfPkgX64.dsc -t GCC5

## Integration Instructions
N/A
