### PR TITLE
MdeModulePkg: Optimize the code handling of hotkey registration

### DIFF
--- a/MdeModulePkg/Universal/DisplayEngineDxe/FormDisplay.c
+++ b/MdeModulePkg/Universal/DisplayEngineDxe/FormDisplay.c
@@ -4330,14 +4330,18 @@ InitializeDisplayEngine (
     HotKey.ScanCode    = SCAN_F10;
     NewString          = HiiGetString (gHiiHandle, STRING_TOKEN (FUNCTION_TEN_STRING), NULL);
     ASSERT (NewString != NULL);
-    FormBrowserEx2->RegisterHotKey (&HotKey, BROWSER_ACTION_SUBMIT, 0, NewString);
-    FreePool (NewString);
+    if (NewString != NULL) {
+      FormBrowserEx2->RegisterHotKey (&HotKey, BROWSER_ACTION_SUBMIT, 0, NewString);
+      FreePool (NewString);
+    }
 
     HotKey.ScanCode = SCAN_F9;
     NewString       = HiiGetString (gHiiHandle, STRING_TOKEN (FUNCTION_NINE_STRING), NULL);
     ASSERT (NewString != NULL);
-    FormBrowserEx2->RegisterHotKey (&HotKey, BROWSER_ACTION_DEFAULT, EFI_HII_DEFAULT_CLASS_STANDARD, NewString);
-    FreePool (NewString);
+    if (NewString != NULL) {
+      FormBrowserEx2->RegisterHotKey (&HotKey, BROWSER_ACTION_DEFAULT, EFI_HII_DEFAULT_CLASS_STANDARD, NewString);
+      FreePool (NewString);
+    }
   }
 
   return EFI_SUCCESS;

--- a/MdeModulePkg/Universal/DriverSampleDxe/DriverSample.c
+++ b/MdeModulePkg/Universal/DriverSampleDxe/DriverSample.c
@@ -2201,11 +2201,18 @@ DriverSampleInit (
     HotKey.ScanCode = SCAN_F10;
     NewString       = HiiGetString (mPrivateData->HiiHandle[0], STRING_TOKEN (FUNCTION_TEN_STRING), NULL);
     ASSERT (NewString != NULL);
-    FormBrowserEx->RegisterHotKey (&HotKey, BROWSER_ACTION_SUBMIT, 0, NewString);
+    if (NewString != NULL) {
+      FormBrowserEx->RegisterHotKey (&HotKey, BROWSER_ACTION_SUBMIT, 0, NewString);
+      FreePool (NewString);
+    }
+
     HotKey.ScanCode = SCAN_F9;
     NewString       = HiiGetString (mPrivateData->HiiHandle[0], STRING_TOKEN (FUNCTION_NINE_STRING), NULL);
     ASSERT (NewString != NULL);
-    FormBrowserEx->RegisterHotKey (&HotKey, BROWSER_ACTION_DEFAULT, EFI_HII_DEFAULT_CLASS_STANDARD, NewString);
+    if (NewString != NULL) {
+      FormBrowserEx->RegisterHotKey (&HotKey, BROWSER_ACTION_DEFAULT, EFI_HII_DEFAULT_CLASS_STANDARD, NewString);
+      FreePool (NewString);
+    }
   }
 
   //


### PR DESCRIPTION
# Description

The return value of HiiGetString function should be freed by using FreePool().
By the way, add a check for NewString before calling RegisterHotKey().
Following Mike and Ashraf's susggestion, ASSERT is preserved.

## How This Was Tested

N/A

## Integration Instructions

N/A
