### PR TITLE
NetworkPkg/DxeNetLib: Initialize MediaState to EFI_NOT_READY

### DIFF
--- a/NetworkPkg/Include/Library/NetLib.h
+++ b/NetworkPkg/Include/Library/NetLib.h
@@ -93,6 +93,16 @@ typedef UINT16  TCP_PORTNO;
 //
 #define MEDIA_STATE_DETECT_TIME_INTERVAL  1000000U
 
+//
+// Number of times to attempt to detect network media through SNP
+//
+#define SNP_MEDIA_DETECT_RETRY_ATTEMPTS  0
+
+//
+// Amount of time to wait for network media to be detected through SNP, in 100ns units
+//
+#define SNP_MEDIA_DETECT_WAITING_TIME  EFI_TIMER_PERIOD_SECONDS(2)
+
 #pragma pack(1)
 
 //

--- a/NetworkPkg/Library/DxeNetLib/DxeNetLib.c
+++ b/NetworkPkg/Library/DxeNetLib/DxeNetLib.c
@@ -2701,7 +2701,7 @@ NetLibDetectMediaWaitTimeout (
     return EFI_INVALID_PARAMETER;
   }
 
-  *MediaState = EFI_SUCCESS;
+  *MediaState = EFI_NOT_READY;
   MediaInfo   = NULL;
 
   //

--- a/NetworkPkg/Library/DxeNetLib/DxeNetLib.c
+++ b/NetworkPkg/Library/DxeNetLib/DxeNetLib.c
@@ -2438,7 +2438,168 @@ NetLibGetMacString (
 }
 
 /**
-  Detect media status for specified network device.
+  Get media status from Simple Network Protocol (SNP).
+
+  This function calls EFI_SIMPLE_NETWORK_PROTOCOL.GetStatus() to refresh
+  the media state and returns the current MediaPresent field from the SNP
+  mode data.
+
+  @param[in]  Snp           The Simple Network Protocol instance.
+  @param[out] MediaPresent  The pointer to receive the media present status.
+
+  @retval EFI_SUCCESS           MediaPresent is returned successfully.
+  @retval EFI_INVALID_PARAMETER Snp is NULL or MediaPresent is NULL.
+  @retval Others                Error returned by Snp->GetStatus().
+
+**/
+STATIC
+EFI_STATUS
+NetLibSnpGetMediaStatus (
+  IN  EFI_SIMPLE_NETWORK_PROTOCOL  *Snp,
+  OUT BOOLEAN                      *MediaPresent
+  )
+{
+  EFI_STATUS  Status;
+  UINT32      InterruptStatus;
+
+  if ((Snp == NULL) || (MediaPresent == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Status = Snp->GetStatus (Snp, &InterruptStatus, NULL);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  *MediaPresent = Snp->Mode->MediaPresent;
+  return EFI_SUCCESS;
+}
+
+/**
+  Normalize media-detection status from SNP.
+
+  This is used to apply any transformations needed to media detection status
+  based on platform configuration.
+
+  @param[in]  Status      The status value to normalize.
+  @param[out] MediaState  Optional pointer to update based on policy applied
+                          to media state.
+
+  @retval EFI_SUCCESS      Media detection is considered successful.
+  @retval Others           An error status indicating media detection failure.
+
+**/
+STATIC
+EFI_STATUS
+NetLibNormalizeMediaReturnStatus (
+  IN  EFI_STATUS  Status,
+  OUT EFI_STATUS  *MediaState OPTIONAL
+  )
+{
+  if (Status == EFI_UNSUPPORTED) {
+    if (MediaState != NULL) {
+      *MediaState = EFI_SUCCESS;
+    }
+
+    DEBUG ((DEBUG_ERROR, "NetLib: SNP MEDIA DETECTION FAILED!\n"));
+    DEBUG ((DEBUG_ERROR, "        Media detection was not available through AIP or UNDI.\n"));
+    DEBUG ((DEBUG_ERROR, "        A workaround to treat unsupported media detection as success is activated.\n"));
+    DEBUG ((DEBUG_ERROR, "        Check with your NIC OPROM vendor to determine how proper detection"));
+    DEBUG ((DEBUG_ERROR, "        can be supported on your platform.\n"));
+
+    return EFI_SUCCESS;
+  }
+
+  return Status;
+}
+
+/**
+  Wait for media to become present using Simple Network Protocol (SNP).
+
+  This helper polls SNP media state using GetStatus(). It returns immediately
+  if media is already present or if the timeout is zero. Otherwise, it waits in
+  MEDIA_STATE_DETECT_TIME_INTERVAL increments until media becomes present or the
+  timeout expires.
+
+  @param[in]  Snp           The Simple Network Protocol instance to query.
+  @param[in]  Timeout       The maximum number of 100ns units to wait. Zero
+                            means detect once and return immediately.
+  @param[out] MediaPresent  The pointer to receive the media present state.
+                            The value should be set to FALSE for this function
+                            to check for media presence.
+
+  @retval EFI_SUCCESS       Media is present or detected within the timeout.
+  @retval EFI_DEVICE_ERROR  Failed to create or use the timer event.
+  @retval EFI_TIMEOUT       The timeout expired before media became present.
+  @retval Others            Error returned by NetLibSnpGetMediaStatus().
+
+**/
+STATIC
+EFI_STATUS
+NetLibSnpWaitForMediaPresent (
+  IN  EFI_SIMPLE_NETWORK_PROTOCOL  *Snp,
+  IN  UINT64                       Timeout,
+  OUT BOOLEAN                      *MediaPresent
+  )
+{
+  EFI_STATUS  Status;
+  EFI_STATUS  TimerStatus;
+  EFI_EVENT   Timer;
+  INT64       TimeRemaining;
+
+  Status = NetLibSnpGetMediaStatus (Snp, MediaPresent);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  if (*MediaPresent || (Timeout == 0)) {
+    return EFI_SUCCESS;
+  }
+
+  Timer         = NULL;
+  TimeRemaining = MIN (Timeout, MAX_INT64);
+  Status        = gBS->CreateEvent (EVT_TIMER, TPL_CALLBACK, NULL, NULL, &Timer);
+  if (EFI_ERROR (Status)) {
+    return EFI_DEVICE_ERROR;
+  }
+
+  do {
+    Status = gBS->SetTimer (
+                    Timer,
+                    TimerRelative,
+                    MEDIA_STATE_DETECT_TIME_INTERVAL
+                    );
+    if (EFI_ERROR (Status)) {
+      gBS->CloseEvent (Timer);
+      return EFI_DEVICE_ERROR;
+    }
+
+    do {
+      TimerStatus = gBS->CheckEvent (Timer);
+      if (!EFI_ERROR (TimerStatus)) {
+        TimeRemaining -= MEDIA_STATE_DETECT_TIME_INTERVAL;
+        Status         = NetLibSnpGetMediaStatus (Snp, MediaPresent);
+        if (EFI_ERROR (Status)) {
+          gBS->CloseEvent (Timer);
+          return Status;
+        }
+
+        if (*MediaPresent) {
+          gBS->CloseEvent (Timer);
+          return EFI_SUCCESS;
+        }
+      }
+    } while (TimerStatus == EFI_NOT_READY);
+  } while (TimeRemaining >= MEDIA_STATE_DETECT_TIME_INTERVAL);
+
+  *MediaPresent = FALSE;
+  gBS->CloseEvent (Timer);
+
+  return EFI_TIMEOUT;
+}
+
+/**
+  Detect media status for a network device using SNP with timeout support.
 
   If MediaPresent is NULL, then ASSERT().
 
@@ -2448,7 +2609,9 @@ NetLibGetMacString (
   present, it return directly; if media not present, it will stop SNP and then
   restart SNP to get the latest media status, this give chance to get the correct
   media status for old UNDI driver which doesn't support reporting media status
-  from GET_STATUS command.
+  from GET_STATUS command. After SNP is initialized, it polls Snp->GetStatus()
+  for up to Timeout's value to allow media to become present.
+
   Note: there will be two limitations for current algorithm:
   1) for UNDI with this capability, in case of cable is not attached, there will
      be an redundant Stop/Start() process;
@@ -2459,31 +2622,36 @@ NetLibGetMacString (
 
   @param[in]   ServiceHandle    The handle where network service binding protocols are
                                 installed on.
+  @param[in]   Timeout          The maximum number of 100ns units to wait for media to
+                                become present after SNP is initialized. Zero value
+                                means detect once and return immediately.
   @param[out]  MediaPresent     The pointer to store the media status.
 
   @retval EFI_SUCCESS           Media detection success.
   @retval EFI_INVALID_PARAMETER ServiceHandle is not valid network device handle.
   @retval EFI_UNSUPPORTED       Network device does not support media detection.
   @retval EFI_DEVICE_ERROR      SNP is in unknown state.
+  @retval EFI_TIMEOUT           The timeout expired before media became present.
 
 **/
+STATIC
 EFI_STATUS
-EFIAPI
-NetLibDetectMedia (
+NetLibDetectSnpMediaWithTimeoutInternal (
   IN  EFI_HANDLE  ServiceHandle,
+  IN  UINT64      Timeout,
   OUT BOOLEAN     *MediaPresent
   )
 {
   EFI_STATUS                   Status;
   EFI_HANDLE                   SnpHandle;
   EFI_SIMPLE_NETWORK_PROTOCOL  *Snp;
-  UINT32                       InterruptStatus;
   UINT32                       OldState;
   EFI_MAC_ADDRESS              *MCastFilter;
   UINT32                       MCastFilterCount;
   UINT32                       EnableFilterBits;
   UINT32                       DisableFilterBits;
   BOOLEAN                      ResetMCastFilters;
+  EFI_STATUS                   WaitStatus;
 
   ASSERT (MediaPresent != NULL);
 
@@ -2503,19 +2671,15 @@ NetLibDetectMedia (
     return EFI_UNSUPPORTED;
   }
 
-  //
-  // Invoke Snp->GetStatus() to refresh MediaPresent field in SNP mode data
-  //
-  Status = Snp->GetStatus (Snp, &InterruptStatus, NULL);
+  Status = NetLibSnpGetMediaStatus (Snp, MediaPresent);
   if (EFI_ERROR (Status)) {
     return Status;
   }
 
-  if (Snp->Mode->MediaPresent) {
+  if (*MediaPresent) {
     //
     // Media is present, return directly
     //
-    *MediaPresent = TRUE;
     return EFI_SUCCESS;
   }
 
@@ -2582,10 +2746,7 @@ NetLibDetectMedia (
       goto Exit;
     }
 
-    //
-    // Here we get the correct media status
-    //
-    *MediaPresent = Snp->Mode->MediaPresent;
+    WaitStatus = NetLibSnpWaitForMediaPresent (Snp, Timeout, MediaPresent);
 
     //
     // Restore SNP receive filter settings
@@ -2598,12 +2759,15 @@ NetLibDetectMedia (
                     MCastFilterCount,
                     MCastFilter
                     );
-
     if (MCastFilter != NULL) {
       FreePool (MCastFilter);
     }
 
-    return Status;
+    if (EFI_ERROR (Status)) {
+      return Status;
+    }
+
+    return WaitStatus;
   }
 
   //
@@ -2628,15 +2792,14 @@ NetLibDetectMedia (
     goto Exit;
   }
 
-  //
-  // Here we get the correct media status
-  //
-  *MediaPresent = Snp->Mode->MediaPresent;
+  WaitStatus = NetLibSnpWaitForMediaPresent (Snp, Timeout, MediaPresent);
 
   //
   // Shut down the simple network
   //
   Snp->Shutdown (Snp);
+
+  Status = WaitStatus;
 
 Exit:
   if (OldState == EfiSimpleNetworkStopped) {
@@ -2654,6 +2817,192 @@ Exit:
 }
 
 /**
+  Detect media status for specified network device.
+
+  If MediaPresent is NULL, then ASSERT().
+
+  @param[in]   ServiceHandle    The handle where network service binding protocols are
+                                installed on.
+  @param[out]  MediaPresent     The pointer to store the media status.
+
+  @retval EFI_SUCCESS           Media detection success.
+  @retval EFI_INVALID_PARAMETER ServiceHandle is not valid network device handle.
+  @retval EFI_UNSUPPORTED       Network device does not support media detection.
+  @retval EFI_DEVICE_ERROR      SNP is in unknown state.
+  @retval EFI_TIMEOUT           The timeout expired before media became present.
+
+**/
+EFI_STATUS
+EFIAPI
+NetLibDetectMedia (
+  IN  EFI_HANDLE  ServiceHandle,
+  OUT BOOLEAN     *MediaPresent
+  )
+{
+  return NetLibNormalizeMediaReturnStatus (
+           NetLibDetectSnpMediaWithTimeoutInternal (ServiceHandle, 0, MediaPresent),
+           NULL
+           );
+}
+
+/**
+  Detect media state for a network device with timeout support.
+
+  This helper calls NetLibDetectSnpMediaWithTimeoutInternal() with the provided
+  timeout and retries the operation up to RetryCount times.
+
+  On success, the detected media state is reported via MediaState as
+  EFI_SUCCESS when media is present or EFI_NO_MEDIA when it is not.
+
+  @param[in]  ServiceHandle  The handle where network service binding protocols are
+                             installed on.
+  @param[in]  Timeout        The maximum number of 100ns units to wait. A value of
+                             zero means detect once and return immediately.
+  @param[in]  RetryCount     The number of attempts to call
+                             NetLibDetectSnpMediaWithTimeoutInternal().
+  @param[out] MediaState     The pointer to receive the detected media state.
+
+  @retval EFI_SUCCESS           Media detection succeeded or completed within timeout.
+  @retval EFI_INVALID_PARAMETER ServiceHandle is not valid network device handle
+                                (as determined by NetLibDetectSnpMediaWithTimeoutInternal()) or the
+                                MediaState pointer is NULL.
+  @retval EFI_TIMEOUT           The timeout expired before media state could be
+                                determined.
+  @retval Others                An error returned by NetLibDetectSnpMediaWithTimeoutInternal().
+
+**/
+STATIC
+EFI_STATUS
+NetLibDetectSnpMediaWithRetry (
+  IN  EFI_HANDLE  ServiceHandle,
+  IN  UINT64      Timeout,
+  IN  UINTN       RetryCount,
+  OUT EFI_STATUS  *MediaState
+  )
+{
+  EFI_STATUS  Status;
+  BOOLEAN     MediaPresent;
+  EFI_TPL     OldTpl;
+  UINTN       Attempt;
+  UINTN       AttemptCount;
+
+  if (MediaState == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Status       = EFI_TIMEOUT;
+  MediaPresent = FALSE;
+  AttemptCount = (RetryCount == 0) ? 1 : RetryCount;
+
+  for (Attempt = 0; Attempt < AttemptCount; Attempt++) {
+    OldTpl = gBS->RaiseTPL (TPL_CALLBACK);
+    Status = NetLibDetectSnpMediaWithTimeoutInternal (ServiceHandle, Timeout, &MediaPresent);
+    gBS->RestoreTPL (OldTpl);
+    if (!EFI_ERROR (Status)) {
+      *MediaState = MediaPresent ? EFI_SUCCESS : EFI_NO_MEDIA;
+      return EFI_SUCCESS;
+    }
+
+    *MediaState = EFI_NOT_READY;
+  }
+
+  return Status;
+}
+
+/**
+  Detect media state through Adapter Information Protocol with timeout support.
+
+  This helper polls EFI_ADAPTER_INFORMATION_PROTOCOL->GetInformation() for
+  gEfiAdapterInfoMediaStateGuid at fixed intervals until a definite media
+  state is returned or the timeout expires.
+
+  The detected state is reported via MediaState when successful.
+
+  @param[in]  Aip         The Adapter Information Protocol instance to query.
+  @param[in]  Timeout     The maximum number of 100ns units to wait.
+  @param[out] MediaState  The pointer to receive the detected media state.
+
+  @retval EFI_SUCCESS           Media state was retrieved successfully.
+  @retval EFI_INVALID_PARAMETER Aip is NULL or MediaState pointer is NULL.
+  @retval EFI_DEVICE_ERROR      Failed to create or use the timer event.
+  @retval EFI_TIMEOUT           The timeout expired before media state could be
+                                determined.
+  @retval Others                Error returned by Aip->GetInformation().
+
+**/
+STATIC
+EFI_STATUS
+NetLibAipWaitForMediaState (
+  IN  EFI_ADAPTER_INFORMATION_PROTOCOL  *Aip,
+  IN  UINT64                            Timeout,
+  OUT EFI_STATUS                        *MediaState
+  )
+{
+  EFI_STATUS                    Status;
+  EFI_STATUS                    TimerStatus;
+  EFI_EVENT                     Timer;
+  INT64                         TimeRemaining;
+  UINTN                         DataSize;
+  EFI_ADAPTER_INFO_MEDIA_STATE  *MediaInfo;
+
+  if ((Aip == NULL) || (MediaState == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  MediaInfo = NULL;
+
+  Timer         = NULL;
+  TimeRemaining = MIN (Timeout, MAX_INT64);
+  Status        = gBS->CreateEvent (EVT_TIMER, TPL_CALLBACK, NULL, NULL, &Timer);
+  if (EFI_ERROR (Status)) {
+    return EFI_DEVICE_ERROR;
+  }
+
+  do {
+    Status = gBS->SetTimer (
+                    Timer,
+                    TimerRelative,
+                    MEDIA_STATE_DETECT_TIME_INTERVAL
+                    );
+    if (EFI_ERROR (Status)) {
+      gBS->CloseEvent (Timer);
+      return EFI_DEVICE_ERROR;
+    }
+
+    do {
+      TimerStatus = gBS->CheckEvent (Timer);
+      if (!EFI_ERROR (TimerStatus)) {
+        TimeRemaining -= MEDIA_STATE_DETECT_TIME_INTERVAL;
+        Status         = Aip->GetInformation (
+                                Aip,
+                                &gEfiAdapterInfoMediaStateGuid,
+                                (VOID **)&MediaInfo,
+                                &DataSize
+                                );
+        if (!EFI_ERROR (Status)) {
+          *MediaState = MediaInfo->MediaState;
+          FreePool (MediaInfo);
+        } else {
+          if (MediaInfo != NULL) {
+            FreePool (MediaInfo);
+          }
+
+          gBS->CloseEvent (Timer);
+          return Status;
+        }
+      }
+    } while (TimerStatus == EFI_NOT_READY);
+  } while (*MediaState == EFI_NOT_READY && TimeRemaining >= MEDIA_STATE_DETECT_TIME_INTERVAL);
+
+  gBS->CloseEvent (Timer);
+  if ((*MediaState == EFI_NOT_READY) && (TimeRemaining < MEDIA_STATE_DETECT_TIME_INTERVAL)) {
+    return EFI_TIMEOUT;
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
 
   Detect media state for a network device. This routine will wait for a period of time at
   a specified checking interval when a certain network is under connecting until connection
@@ -2662,13 +3011,14 @@ Exit:
   connected state, connecting state and no media state respectively. When function detects
   the current state is EFI_NOT_READY, it will loop to wait for next time's check until state
   turns to be EFI_SUCCESS or EFI_NO_MEDIA. If Aip protocol is not supported, function will
-  call NetLibDetectMedia() and return state directly.
+  call NetLibDetectSnpMediaWithRetry() and wait for media to be present with a retry mechanism
+  and a minimal timeout.
 
   @param[in]   ServiceHandle    The handle where network service binding protocols are
                                 installed on.
   @param[in]   Timeout          The maximum number of 100ns units to wait when network
-                                is connecting. Zero value means detect once and return
-                                immediately.
+                                is connecting using AIP. Zero value means detect once and
+                                return immediately.
   @param[out]  MediaState       The pointer to the detected media state.
 
   @retval EFI_SUCCESS           Media detection success.
@@ -2691,11 +3041,7 @@ NetLibDetectMediaWaitTimeout (
   EFI_SIMPLE_NETWORK_PROTOCOL       *Snp;
   EFI_ADAPTER_INFORMATION_PROTOCOL  *Aip;
   EFI_ADAPTER_INFO_MEDIA_STATE      *MediaInfo;
-  BOOLEAN                           MediaPresent;
   UINTN                             DataSize;
-  EFI_STATUS                        TimerStatus;
-  EFI_EVENT                         Timer;
-  UINT64                            TimeRemained;
 
   if (MediaState == NULL) {
     return EFI_INVALID_PARAMETER;
@@ -2719,20 +3065,10 @@ NetLibDetectMediaWaitTimeout (
                   (VOID *)&Aip
                   );
   if (EFI_ERROR (Status)) {
-    MediaPresent = TRUE;
-    Status       = NetLibDetectMedia (ServiceHandle, &MediaPresent);
-    if (!EFI_ERROR (Status)) {
-      if (MediaPresent) {
-        *MediaState = EFI_SUCCESS;
-      } else {
-        *MediaState = EFI_NO_MEDIA;
-      }
-    }
-
-    //
-    // NetLibDetectMedia doesn't support EFI_NOT_READY status, return now!
-    //
-    return Status;
+    return NetLibNormalizeMediaReturnStatus (
+             NetLibDetectSnpMediaWithRetry (ServiceHandle, SNP_MEDIA_DETECT_WAITING_TIME, SNP_MEDIA_DETECT_RETRY_ATTEMPTS, MediaState),
+             MediaState
+             );
   }
 
   Status = Aip->GetInformation (
@@ -2752,79 +3088,13 @@ NetLibDetectMediaWaitTimeout (
       FreePool (MediaInfo);
     }
 
-    if (Status == EFI_UNSUPPORTED) {
-      //
-      // If gEfiAdapterInfoMediaStateGuid is not supported, call NetLibDetectMedia to get media state!
-      //
-      MediaPresent = TRUE;
-      Status       = NetLibDetectMedia (ServiceHandle, &MediaPresent);
-      if (!EFI_ERROR (Status)) {
-        if (MediaPresent) {
-          *MediaState = EFI_SUCCESS;
-        } else {
-          *MediaState = EFI_NO_MEDIA;
-        }
-      }
-
-      return Status;
-    }
-
-    return Status;
+    return NetLibNormalizeMediaReturnStatus (
+             NetLibDetectSnpMediaWithRetry (ServiceHandle, SNP_MEDIA_DETECT_WAITING_TIME, SNP_MEDIA_DETECT_RETRY_ATTEMPTS, MediaState),
+             MediaState
+             );
   }
 
-  //
-  // Loop to check media state
-  //
-
-  Timer        = NULL;
-  TimeRemained = Timeout;
-  Status       = gBS->CreateEvent (EVT_TIMER, TPL_CALLBACK, NULL, NULL, &Timer);
-  if (EFI_ERROR (Status)) {
-    return EFI_DEVICE_ERROR;
-  }
-
-  do {
-    Status = gBS->SetTimer (
-                    Timer,
-                    TimerRelative,
-                    MEDIA_STATE_DETECT_TIME_INTERVAL
-                    );
-    if (EFI_ERROR (Status)) {
-      gBS->CloseEvent (Timer);
-      return EFI_DEVICE_ERROR;
-    }
-
-    do {
-      TimerStatus = gBS->CheckEvent (Timer);
-      if (!EFI_ERROR (TimerStatus)) {
-        TimeRemained -= MEDIA_STATE_DETECT_TIME_INTERVAL;
-        Status        = Aip->GetInformation (
-                               Aip,
-                               &gEfiAdapterInfoMediaStateGuid,
-                               (VOID **)&MediaInfo,
-                               &DataSize
-                               );
-        if (!EFI_ERROR (Status)) {
-          *MediaState = MediaInfo->MediaState;
-          FreePool (MediaInfo);
-        } else {
-          if (MediaInfo != NULL) {
-            FreePool (MediaInfo);
-          }
-
-          gBS->CloseEvent (Timer);
-          return Status;
-        }
-      }
-    } while (TimerStatus == EFI_NOT_READY);
-  } while (*MediaState == EFI_NOT_READY && TimeRemained >= MEDIA_STATE_DETECT_TIME_INTERVAL);
-
-  gBS->CloseEvent (Timer);
-  if ((*MediaState == EFI_NOT_READY) && (TimeRemained < MEDIA_STATE_DETECT_TIME_INTERVAL)) {
-    return EFI_TIMEOUT;
-  } else {
-    return EFI_SUCCESS;
-  }
+  return NetLibAipWaitForMediaState (Aip, Timeout, MediaState);
 }
 
 /**


### PR DESCRIPTION
# Description

Initializes the `MediaState` output parameter to `EFI_NOT_READY` at the start of `DxeNetLibGetMediaState()`. This ensures that the status only reflects a successful media state after either `NetLibDetectMedia()` or `GetInfomation()` confirms media is present.

---

Upon extensive testing of the above change, it was found the some UNDI drivers do not report that they support media presence, yet they otherwise work. Second, it was found that if SNP media presence is used, it does not wait at all, causing premature failures. Thirdly, it was found that those premature failures can cause SNP shutdown and reinitialization to occur multiple times, unnecessarily.

That led to the second commit being added, described below. It maintains backward compatibility with UNDI drivers that do not indicate they support media presence correctly.

---

NetworkPkg: Add timeout polling for PXE media detection

Simplify the `NetLibDetectMediaWaitTimeout()` execution flow and add a
timeout on non-AIP media detection to allow NICs sufficient time to
initialize and report media state.

---

This single holistic change address two problems:

Problem 1: Network devices should properly report media presence.

The previous implementation checked `Aip->GetInformation()` and fell
back to `Snp->GetStatus()` and then returned media is present if SNP
returned that it did not support media detection.

In the end, this falsely reported media presence over the years has
led to even more UNDI drivers not supporting media presence properly
because of this behavior.

Problem 2: Multiple SNP shutdown and reinitialization processes can
occur impacting performance and stability.

`NetLibDetectMediaWaitTimeout()` in `DxeNetLib` is called ~15 places
in the codebase. Multiple callers might call into the function for
the same NIC such as `Dhcp4Dxe`, `PxeBcDxe`, etc.

For example:

```
  Snp->undi.initialize()  <-- By SimpleNetworkDriverStart

  Snp->undi.initialize()   <-- By NetLibDetectMedia()
  Snp->undi.initialize()  8000h:6h
  Snp->undi.initialize()

  Snp->undi.initialize()  <-- By NetLibDetectMedia()
  Snp->undi.initialize()  8000h:6h
  Snp->undi.initialize()
```

Initialization might also occur multiple times in the same flow, for
example, when `SnpUndi32Initialize()` first calls with
`PXE_OPFLAGS_INITIALIZE_DETECT_CABLE` and if that fails, again with
`PXE_OPFLAGS_INITIALIZE_DO_NOT_DETECT_CABLE`.

Collectively this can lead to SNP shutting down and reinitializing
multiple times when it might not need to impacting stability and
performance.

---

Notes:

1. The 20 second value (`PXEBC_CHECK_MEDIA_WAITING_TIME`) often given
   as the timeout (`Timeout` argument) to
   `NetLibDetectMediaWaitTimeout()` is not used for
   `NetLibDetectMedia()` flows, only `Aip->GetInformation()` calls.
2. We know some NICs take at least 1.5+ seconds to report back media
   presence after initialization when going through the
   `NetLibDetectMedia()` flow. That function supports two methods for
   media presence detection through SNP to the underlying UNDI driver
   (1) `GET_STATUS` command and (2) a flow to stop and restart SNP for
   drivers that do not support the `GET_STATUS` command.

---

This change solves the following problems:

1. Allows sufficient time for SNP to report media presence instead of
   simply returning.
2. Makes it clear to platform owners when media detection is not able
   to be determined so it is simply set to "media is present" to
   satisfy NIC FW that does not support actual media detection.
3. Partially due to (1) (and TPL guards recently introduced), prevent
   multiple SNP shutdown and reinitialization processes from occurring
   which thrash NIC stability and impact network boot performance.

This change intentionally maintains the same behavior when actual
media presence cannot be determined (i.e. AIP and SNP do not support
media detection) to be backward compatible.

---

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

- PXE server setup on a separate device (TFTP + DHCP)

- Physical x86 client platform PXE boot
  - Does not need NIC OPROM workaround
- Physical x86 server platform PXE boot
  - Uses NIC OPROM workaround
 
## Integration Instructions

- N/A