### PR TITLE
NetworkPkg/DxeNetLib: Make NetLibDetectMedia() calls at TPL_CALLBACK

### DIFF
--- a/NetworkPkg/Library/DxeNetLib/DxeNetLib.c
+++ b/NetworkPkg/Library/DxeNetLib/DxeNetLib.c
@@ -2696,6 +2696,7 @@ NetLibDetectMediaWaitTimeout (
   EFI_STATUS                        TimerStatus;
   EFI_EVENT                         Timer;
   UINT64                            TimeRemained;
+  EFI_TPL                           OldTpl;
 
   if (MediaState == NULL) {
     return EFI_INVALID_PARAMETER;
@@ -2719,6 +2720,7 @@ NetLibDetectMediaWaitTimeout (
                   (VOID *)&Aip
                   );
   if (EFI_ERROR (Status)) {
+    OldTpl       = gBS->RaiseTPL (TPL_CALLBACK);
     MediaPresent = TRUE;
     Status       = NetLibDetectMedia (ServiceHandle, &MediaPresent);
     if (!EFI_ERROR (Status)) {
@@ -2728,6 +2730,8 @@ NetLibDetectMediaWaitTimeout (
         *MediaState = EFI_NO_MEDIA;
       }
     }
+
+    gBS->RestoreTPL (OldTpl);
 
     //
     // NetLibDetectMedia doesn't support EFI_NOT_READY status, return now!
@@ -2756,6 +2760,7 @@ NetLibDetectMediaWaitTimeout (
       //
       // If gEfiAdapterInfoMediaStateGuid is not supported, call NetLibDetectMedia to get media state!
       //
+      OldTpl       = gBS->RaiseTPL (TPL_CALLBACK);
       MediaPresent = TRUE;
       Status       = NetLibDetectMedia (ServiceHandle, &MediaPresent);
       if (!EFI_ERROR (Status)) {
@@ -2765,6 +2770,8 @@ NetLibDetectMediaWaitTimeout (
           *MediaState = EFI_NO_MEDIA;
         }
       }
+
+      gBS->RestoreTPL (OldTpl);
 
       return Status;
     }


### PR DESCRIPTION
# Description

Ensures that calls to NetLibDetectMedia() in
NetLibDetectMediaWaitTimeout() are made at least at TPL_CALLBACK.

There are cases where NetLibDetectMedia() is being called at TPL_APPLICATION and a teardown of the network interface occurring at TPL_CALLBACK can interrrupt the media detection process, leading to errors using the Simple Network Protocol.

For example, if a USB NIC is connected and removed during the media detection process.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

- PXE server setup on a separate device (TFTP + DHCP)
- On DUT, set PXE boot as the first boot option
- Boot
- Wait for PXE boot over IPv4 to start
- Unplug a USB hub during network media detection

## Integration Instructions

- N/A