### PR TITLE
Add RAS support for RISC-V Architecture

### DIFF
--- a/MdeModulePkg/MdeModulePkg.dsc
+++ b/MdeModulePkg/MdeModulePkg.dsc
@@ -541,5 +541,13 @@
   MdeModulePkg/Library/ArmFfaLib/ArmFfaStandaloneMmLib.inf
   MdeModulePkg/Library/ArmFfaConsoleDebugLib/ArmFfaConsoleDebugStandaloneMmLib.inf
 
+[Components.RISCV64]
+  MdeModulePkg/Universal/Acpi/AcpiHardwareErrorTableDxe/HardwareErrorSourceTableDxe.inf {
+    <LibraryClasses>
+      DxeRiscvMpxyLib|MdePkg/Library/DxeRiscvMpxyLib/DxeRiscvMpxy.inf
+      DxeRasAgentClientLib|MdePkg/Library/DxeRiscvRasAgentClientLib/DxeRiscvRasAgentClientLib.inf
+      RiscVSbiLib|MdePkg/Library/BaseRiscVSbiLib/BaseRiscVSbiLib.inf
+  }
+
 [BuildOptions]
 

--- a/MdeModulePkg/Universal/Acpi/AcpiHardwareErrorTableDxe/HardwareErrorSourceTableDxe.c
+++ b/MdeModulePkg/Universal/Acpi/AcpiHardwareErrorTableDxe/HardwareErrorSourceTableDxe.c
@@ -1,0 +1,380 @@
+/** @file
+  This module installs the ACPI Hardware Error Source Table (HEST).
+
+  @par Glossary:
+    - HEST - Hardware Error Source Table
+    - RAS  - Reliability, Availability, and Serviceability
+    - MPXY - Message Proxy extension in the RISC-V SBI specification
+
+  Copyright (c) 2026, Qualcomm Technologies, Inc. and/or its subsidiaries.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <Base.h>
+#include <Uefi.h>
+
+#include <IndustryStandard/Acpi.h>
+
+#include <Protocol/AcpiTable.h>
+
+#include <Guid/EventGroup.h>
+
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/UefiBootServicesTableLib.h>
+#include <Library/DebugLib.h>
+#include <Library/PcdLib.h>
+#include <Library/SafeIntLib.h>
+#include <Library/BaseRiscVSbiLib.h>
+
+#include <Library/DxeRiscvMpxy.h>
+#include <Library/DxeRasAgentClient.h>
+
+EFI_EVENT  mHestReadyToBootEvent;
+UINTN      mHestTableKey = 0;
+
+#define STATUS_BLOCK_SIZE  1024
+
+#define HEST_TO_BASE_ERROR_STRUCTURE(_table)                            \
+  (EFI_ACPI_6_6_GENERIC_HARDWARE_ERROR_SOURCE_VERSION_2_STRUCTURE *)    \
+    ((UINT8 *)(_table) +                                                \
+     sizeof (EFI_ACPI_6_6_HARDWARE_ERROR_SOURCE_TABLE_HEADER));
+
+//
+// ACPI Hardware Error Source Table template
+//
+EFI_ACPI_6_6_HARDWARE_ERROR_SOURCE_TABLE_HEADER  mHestTemplate = {
+  {
+    EFI_ACPI_6_6_HARDWARE_ERROR_SOURCE_TABLE_SIGNATURE,
+    sizeof (EFI_ACPI_6_6_HARDWARE_ERROR_SOURCE_TABLE_HEADER),
+    EFI_ACPI_6_6_HARDWARE_ERROR_SOURCE_TABLE_REVISION, // Revision
+    0x00,                                              // Checksum will be updated at runtime
+    //
+    // It is expected that these values will be updated at EntryPoint.
+    //
+    { 0x00 },   // OEM ID is a 6 bytes long field
+    0x00,       // OEM Table ID(8 bytes long)
+    0x00,       // OEM Revision
+    0x00,       // Creator ID
+    0x00,       // Creator Revision
+  },
+  0             // Number of error source
+};
+
+/**
+  Close all currently opened RAS agent channels.
+
+  @param[in] RasAgentChannelIds  Array of RAS agent channel IDs.
+  @param[in] NumChannelIds       Number of valid channel IDs in RasAgentChannelIds.
+
+  @return  This function does not return a value.
+**/
+STATIC
+VOID
+CloseRasChannels (
+  IN UINT32  *RasAgentChannelIds,
+  IN UINT32  NumChannelIds
+  )
+{
+  UINT32  ChannelIndex;
+
+  for (ChannelIndex = 0; ChannelIndex < NumChannelIds; ChannelIndex++) {
+    RacCloseRasAgentChannel (RasAgentChannelIds[ChannelIndex]);
+  }
+}
+
+/**
+  Initialize RAS agent channels and compute total number of error sources.
+
+  This initializes the RAS client library, discovers RAS agent channel IDs,
+  opens each channel, and accumulates the global error source count into
+  mHestTemplate.ErrorSourceCount.
+
+  @param[out] RasAgentChannelIds  Buffer receiving discovered channel IDs.
+  @param[out] NumChannelIds       Number of channel IDs discovered.
+
+  @retval EFI_SUCCESS  Initialization and channel probing completed successfully.
+  @retval Others       Error returned by RacInit(), RacGetRasAgentMpxyChannelId(),
+                       RacOpenRasAgentChannel(), or RacGetNumberErrorSources().
+**/
+STATIC
+EFI_STATUS
+InitializeRasChannels (
+  OUT UINT32  *RasAgentChannelIds,
+  OUT UINT32  *NumChannelIds
+  )
+{
+  EFI_STATUS  Status;
+  UINT32      ChannelIndex;
+  UINT32      NumSources;
+
+  Status = RacInit ();
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Status = RacGetRasAgentMpxyChannelId (
+             MAX_RAS_AGENTS,
+             RasAgentChannelIds,
+             NumChannelIds
+             );
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  mHestTemplate.ErrorSourceCount = 0;
+  for (ChannelIndex = 0; ChannelIndex < *NumChannelIds; ChannelIndex++) {
+    Status = RacOpenRasAgentChannel (RasAgentChannelIds[ChannelIndex]);
+    if (EFI_ERROR (Status)) {
+      CloseRasChannels (RasAgentChannelIds, ChannelIndex);
+      return Status;
+    }
+
+    Status = RacGetNumberErrorSources (RasAgentChannelIds[ChannelIndex], &NumSources);
+    if (EFI_ERROR (Status)) {
+      CloseRasChannels (RasAgentChannelIds, ChannelIndex + 1);
+      return Status;
+    }
+
+    mHestTemplate.ErrorSourceCount += NumSources;
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Populate HEST generic hardware error source structures from RAS descriptors.
+
+  For each discovered RAS channel, this function fetches source IDs and then
+  source descriptors, copying each descriptor into the destination HEST array.
+
+  @param[in]  RasAgentChannelIds    Array of RAS agent channel IDs.
+  @param[in]  NumChannelIds         Number of valid entries in RasAgentChannelIds.
+  @param[out] BaseErrSrcStructure   Destination buffer for GHESv2 structures.
+
+  @retval EFI_SUCCESS  All descriptors were fetched and copied successfully.
+  @retval Others       Error returned by RacGetErrorSourceIDList() or
+                       RacGetErrorSourceDescriptor().
+**/
+STATIC
+EFI_STATUS
+PopulateErrorSourceStructures (
+  IN  UINT32                                                          *RasAgentChannelIds,
+  IN  UINT32                                                          NumChannelIds,
+  OUT EFI_ACPI_6_6_GENERIC_HARDWARE_ERROR_SOURCE_VERSION_2_STRUCTURE  *BaseErrSrcStructure
+  )
+{
+  EFI_STATUS                                                      Status;
+  UINT32                                                          NumSources;
+  UINT32                                                          *ErrSources;
+  UINT32                                                          ErrDescSize;
+  UINTN                                                           DescriptorType;
+  VOID                                                            *ErrDesc;
+  UINT32                                                          ChannelIndex;
+  UINT32                                                          Index;
+  EFI_ACPI_6_6_GENERIC_HARDWARE_ERROR_SOURCE_VERSION_2_STRUCTURE  *TmpErrSrc;
+
+  TmpErrSrc = BaseErrSrcStructure;
+
+  for (ChannelIndex = 0; ChannelIndex < NumChannelIds; ChannelIndex++) {
+    Status = RacGetErrorSourceIDList (
+               RasAgentChannelIds[ChannelIndex],
+               &ErrSources,
+               &NumSources
+               );
+    if (EFI_ERROR (Status)) {
+      return Status;
+    }
+
+    for (Index = 0; Index < NumSources; Index++) {
+      Status = RacGetErrorSourceDescriptor (
+                 RasAgentChannelIds[ChannelIndex],
+                 ErrSources[Index],
+                 &DescriptorType,
+                 &ErrDesc,
+                 &ErrDescSize
+                 );
+      if (EFI_ERROR (Status)) {
+        return Status;
+      }
+
+      ASSERT (DescriptorType == DtGhesV2);
+      CopyMem (TmpErrSrc, ErrDesc, ErrDescSize);
+      TmpErrSrc++;
+    }
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Finalize and install the HEST ACPI table.
+
+  This function updates the HEST header fields (Length and Checksum) and
+  publishes the table through EFI_ACPI_TABLE_PROTOCOL.
+
+  @param[in] AcpiTableProtocol  Pointer to installed ACPI table protocol.
+  @param[in] HestTable          Pointer to HEST buffer to install.
+  @param[in] HestTableSize      Size in bytes of HestTable.
+
+  @retval EFI_SUCCESS  The ACPI table was installed successfully.
+  @retval Others       Error returned by InstallAcpiTable().
+**/
+STATIC
+EFI_STATUS
+InstallHestTable (
+  IN EFI_ACPI_TABLE_PROTOCOL  *AcpiTableProtocol,
+  IN VOID                     *HestTable,
+  IN UINT32                   HestTableSize
+  )
+{
+  EFI_STATUS                   Status;
+  EFI_ACPI_DESCRIPTION_HEADER  *Header;
+
+  Header           = &((EFI_ACPI_6_6_HARDWARE_ERROR_SOURCE_TABLE_HEADER *)HestTable)->Header;
+  Header->Length   = HestTableSize;
+  Header->Checksum = 0;
+  Header->Checksum = CalculateCheckSum8 ((UINT8 *)HestTable, HestTableSize);
+
+  Status = AcpiTableProtocol->InstallAcpiTable (
+                                AcpiTableProtocol,
+                                HestTable,
+                                HestTableSize,
+                                &mHestTableKey
+                                );
+
+  return Status;
+}
+
+/**
+  Notify function for event group EFI_EVENT_GROUP_READY_TO_BOOT. This is used to
+  install the Hardware Error Source Table.
+
+  @param[in]  Event   The Event that is being processed.
+  @param[in]  Context The Event Context.
+
+**/
+VOID
+EFIAPI
+HestReadyToBootEventNotify (
+  IN EFI_EVENT  Event,
+  IN VOID       *Context
+  )
+{
+  EFI_STATUS                                                      Status;
+  EFI_ACPI_TABLE_PROTOCOL                                         *AcpiTableProtocol;
+  VOID                                                            *HestTable;
+  UINTN                                                           HestPages;
+  UINT32                                                          HestTableSize;
+  UINT32                                                          RasAgentChannelIds[MAX_RAS_AGENTS];
+  UINT32                                                          NumChannelIds;
+  EFI_ACPI_6_6_GENERIC_HARDWARE_ERROR_SOURCE_VERSION_2_STRUCTURE  *BaseErrSrcStructure;
+
+  NumChannelIds = 0;
+  HestTable     = NULL;
+
+  Status = gBS->LocateProtocol (
+                  &gEfiAcpiTableProtocolGuid,
+                  NULL,
+                  (VOID **)&AcpiTableProtocol
+                  );
+  if (EFI_ERROR (Status)) {
+    return;
+  }
+
+  Status = InitializeRasChannels (RasAgentChannelIds, &NumChannelIds);
+  if (EFI_ERROR (Status)) {
+    return;
+  }
+
+  DEBUG ((DEBUG_INFO, "Number of error sources across all RAS agents: %u\n", mHestTemplate.ErrorSourceCount));
+
+  HestTableSize = sizeof (mHestTemplate) +
+                  sizeof (EFI_ACPI_6_6_GENERIC_HARDWARE_ERROR_SOURCE_VERSION_2_STRUCTURE)
+                  * mHestTemplate.ErrorSourceCount;
+  HestPages = EFI_SIZE_TO_PAGES (HestTableSize);
+  HestTable = AllocateAlignedPages (HestPages, SIZE_4KB);
+
+  if (HestTable == NULL) {
+    Status = EFI_OUT_OF_RESOURCES;
+    goto Exit;
+  }
+
+  CopyMem (HestTable, &mHestTemplate, sizeof (mHestTemplate));
+  BaseErrSrcStructure = HEST_TO_BASE_ERROR_STRUCTURE (HestTable);
+
+  Status = PopulateErrorSourceStructures (
+             RasAgentChannelIds,
+             NumChannelIds,
+             BaseErrSrcStructure
+             );
+  if (EFI_ERROR (Status)) {
+    goto Exit;
+  }
+
+  Status = InstallHestTable (AcpiTableProtocol, HestTable, HestTableSize);
+  if (EFI_ERROR (Status)) {
+    goto Exit;
+  }
+
+Exit:
+  if (HestTable != NULL) {
+    FreeAlignedPages (HestTable, HestPages);
+  }
+
+  CloseRasChannels (RasAgentChannelIds, NumChannelIds);
+}
+
+/**
+  The module Entry Point of the Hardware Error Source Table DXE driver.
+
+  @param[in]  ImageHandle    The firmware allocated handle for the EFI image.
+  @param[in]  SystemTable    A pointer to the EFI System Table.
+
+  @retval EFI_SUCCESS    The entry point is executed successfully.
+  @retval Other          Some error occurs when executing this entry point.
+
+**/
+EFI_STATUS
+EFIAPI
+HardwareErrorSourceDxeEntryPoint (
+  IN EFI_HANDLE        ImageHandle,
+  IN EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  EFI_STATUS                   Status;
+  EFI_ACPI_DESCRIPTION_HEADER  *Header;
+
+  //
+  // Update Header fields of HEST
+  //
+  Header = &mHestTemplate.Header;
+  ZeroMem (Header->OemId, sizeof (Header->OemId));
+  CopyMem (
+    Header->OemId,
+    PcdGetPtr (PcdAcpiDefaultOemId),
+    MIN (PcdGetSize (PcdAcpiDefaultOemId), sizeof (Header->OemId))
+    );
+
+  Header->OemTableId      = PcdGet64 (PcdAcpiDefaultOemTableId);
+  Header->OemRevision     = PcdGet32 (PcdAcpiDefaultOemRevision);
+  Header->CreatorId       = PcdGet32 (PcdAcpiDefaultCreatorId);
+  Header->CreatorRevision = PcdGet32 (PcdAcpiDefaultCreatorRevision);
+
+  //
+  // Register notify function to install HEST on ReadyToBoot Event.
+  //
+  Status = gBS->CreateEventEx (
+                  EVT_NOTIFY_SIGNAL,
+                  TPL_CALLBACK,
+                  HestReadyToBootEventNotify,
+                  NULL,
+                  &gEfiEventReadyToBootGuid,
+                  &mHestReadyToBootEvent
+                  );
+
+  ASSERT_EFI_ERROR (Status);
+
+  return Status;
+}

--- a/MdeModulePkg/Universal/Acpi/AcpiHardwareErrorTableDxe/HardwareErrorSourceTableDxe.inf
+++ b/MdeModulePkg/Universal/Acpi/AcpiHardwareErrorTableDxe/HardwareErrorSourceTableDxe.inf
@@ -1,0 +1,61 @@
+## @file
+#  This module install ACPI Hardware Error Source Table (HEST)
+#
+#  Copyright (c) 2026, Qualcomm Technologies, Inc. and/or its subsidiaries.
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x0001001B
+  BASE_NAME                      = HardwareErrorSourceTableDxe
+  MODULE_UNI_FILE                = HardwareErrorSourceTableDxe.uni
+  FILE_GUID                      = 79ecd602-f3b0-4780-9eed-d744229428e3
+  MODULE_TYPE                    = UEFI_DRIVER
+  VERSION_STRING                 = 1.0
+  ENTRY_POINT                    = HardwareErrorSourceDxeEntryPoint
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = RISCV64
+#
+
+[Sources]
+  HardwareErrorSourceTableDxe.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+
+[LibraryClasses]
+  BaseLib
+  BaseMemoryLib
+  DebugLib
+  MemoryAllocationLib
+  PcdLib
+  SafeIntLib
+  UefiBootServicesTableLib
+  UefiDriverEntryPoint
+  UefiLib
+
+[LibraryClasses.RISCV64]
+  DxeRiscvMpxyLib
+  DxeRasAgentClientLib
+  RiscVSbiLib
+
+[Protocols]
+  gEfiAcpiTableProtocolGuid                     ## CONSUMES
+
+[Pcd]
+  gEfiMdeModulePkgTokenSpaceGuid.PcdAcpiDefaultOemId            ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdAcpiDefaultOemTableId       ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdAcpiDefaultOemRevision      ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdAcpiDefaultCreatorId        ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdAcpiDefaultCreatorRevision  ## CONSUMES
+
+[Guids]
+  gEfiEventReadyToBootGuid                      ## CONSUMES ## Event
+
+[UserExtensions.TianoCore."ExtraFiles"]
+  HardwareErrorSourceTableDxeExtra.uni

--- a/MdeModulePkg/Universal/Acpi/AcpiHardwareErrorTableDxe/HardwareErrorSourceTableDxe.uni
+++ b/MdeModulePkg/Universal/Acpi/AcpiHardwareErrorTableDxe/HardwareErrorSourceTableDxe.uni
@@ -1,0 +1,14 @@
+// /** @file
+// This module install ACPI Hardware Error Source Table (HEST).
+//
+// Copyright (c) 2026, Qualcomm Technologies, Inc.<BR>
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+// **/
+
+
+#string STR_MODULE_ABSTRACT             #language en-US "Installs ACPI Hardware Error Source Table (HEST)"
+
+#string STR_MODULE_DESCRIPTION          #language en-US "This module installs the ACPI Hardware Error Source Table (HEST)"
+

--- a/MdeModulePkg/Universal/Acpi/AcpiHardwareErrorTableDxe/HardwareErrorSourceTableDxeExtra.uni
+++ b/MdeModulePkg/Universal/Acpi/AcpiHardwareErrorTableDxe/HardwareErrorSourceTableDxeExtra.uni
@@ -1,0 +1,12 @@
+// /** @file
+// HardwareErrorSourceTableDxe Localized Strings and Content
+//
+// Copyright (c) 2026, Qualcomm Technologies, Inc.<BR>
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+// **/
+
+#string STR_PROPERTIES_MODULE_NAME  #language en-US "ACPI Hardware Error Source Table DXE Driver"
+
+

--- a/MdePkg/Include/Library/BaseRiscVSbiLib.h
+++ b/MdePkg/Include/Library/BaseRiscVSbiLib.h
@@ -131,3 +131,9 @@ RiscVSbiEcall (
   IN UINTN      Fid,
   IN UINTN      Ext
   );
+
+EFI_STATUS
+EFIAPI
+SbiProbeExtension (
+  IN UINTN  Extension
+  );

--- a/MdePkg/Include/Library/BaseRiscVSbiLib.h
+++ b/MdePkg/Include/Library/BaseRiscVSbiLib.h
@@ -62,8 +62,12 @@
 #define SBI_ERR_ALREADY_AVAILABLE  -6
 #define SBI_ERR_ALREADY_STARTED    -7
 #define SBI_ERR_ALREADY_STOPPED    -8
-
-#define SBI_LAST_ERR  SBI_ERR_ALREADY_STOPPED
+#define SBI_ERR_NO_SHMEM           -9
+#define SBI_ERR_INVALID_STATE      -10
+#define SBI_ERR_BAD_RANGE          -11
+#define SBI_ERR_NOT_IMPLEMENTED    -12
+#define SBI_ERR_TIMEOUT            -13
+#define SBI_ERR_IO                 -14
 
 //
 // EDK2 OpenSBI firmware extension return status.

--- a/MdePkg/Include/Library/BaseRiscVSbiLib.h
+++ b/MdePkg/Include/Library/BaseRiscVSbiLib.h
@@ -22,8 +22,9 @@
 #define SBI_EXT_0_1_CONSOLE_GETCHAR  0x2
 #define SBI_EXT_BASE                 0x10
 #define SBI_EXT_DBCN                 0x4442434E
-#define SBI_EXT_TIME                 0x54494D45
+#define SBI_EXT_MPXY                 0x4D505859
 #define SBI_EXT_SRST                 0x53525354
+#define SBI_EXT_TIME                 0x54494D45
 
 /* SBI function IDs for base extension */
 #define SBI_EXT_BASE_SPEC_VERSION   0x0
@@ -44,6 +45,20 @@
 
 /* SBI function IDs for SRST extension */
 #define SBI_EXT_SRST_RESET  0x0
+
+/* SBI function IDs. for MPXY extension */
+#define SBI_EXT_MPXY_GET_SHMEM_SIZE           0x0
+#define SBI_EXT_MPXY_SET_SHMEM                0x1
+#define SBI_EXT_MPXY_GET_CHANNEL_IDS          0x2
+#define SBI_EXT_MPXY_READ_ATTRS               0x3
+#define SBI_EXT_MPXY_WRITE_ATTRS              0x4
+#define SBI_EXT_MPXY_SEND_MSG_WITH_RESP       0x5
+#define SBI_EXT_MPXY_SEND_MSG_NO_RESP         0x6
+#define SBI_EXT_MPXY_GET_NOTIFICATION_EVENTS  0x7
+
+/* SBI flags for MPXY Set Shared Memory operation */
+#define SBI_EXT_MPXY_SHMEM_FLAG_OVERWRITE         0x0
+#define SBI_EXT_MPXY_SHMEM_FLAG_OVERWRITE_RETURN  0x1
 
 #define SBI_SRST_RESET_TYPE_SHUTDOWN     0x0
 #define SBI_SRST_RESET_TYPE_COLD_REBOOT  0x1

--- a/MdePkg/Include/Library/DxeRasAgentClient.h
+++ b/MdePkg/Include/Library/DxeRasAgentClient.h
@@ -1,0 +1,150 @@
+/** @file
+  This module provides communication with RAS Agent over RPMI/MPXY.
+
+  @par Glossary:
+    - RPMI - RAS Platform Management Interface
+    - MPXY - Message Proxy extension in the RISC-V SBI specification
+
+  Copyright (c) 2026, Qualcomm Technologies, Inc.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#pragma once
+
+#include <Uefi.h>
+
+//
+// Limit the maximum number of agents tracked by this library instance.
+// This is intentionally capped to match the MPXY channel-list chunk size.
+//
+#define MAX_RAS_AGENTS  64
+
+typedef enum {
+  DtGhesV2,
+  NumErrDescTypes
+} ERROR_DESCRIPTOR_TYPE;
+
+#define ERROR_DESCRIPTOR_TYPE_SHIFT  4
+#define MAX_ERROR_DESCRIPTOR_TYPES   (0x1UL << ERROR_DESCRIPTOR_TYPE_SHIFT)
+#define ERROR_DESCRIPTOR_TYPE_MASK   (MAX_ERROR_DESCRIPTOR_TYPES - 1)
+
+/**
+  Initialize the RAS agent client
+
+  @retval EFI_SUCCESS  If initialization is successful
+**/
+EFI_STATUS
+EFIAPI
+RacInit (
+  VOID
+  );
+
+/**
+   Get number of RAS agents present
+
+   @retval Returns number of RAS agents present
+**/
+EFI_STATUS
+EFIAPI
+RacGetNumRasAgents (
+  VOID
+  );
+
+/**
+   Get the list of RAS agent MPXY channel Ids
+
+   @param[in]  ChannelIdSize   Sizeof the buffer provided to fetch list of channel Ids
+   @param[out] ChannelId       Pointer to the buffer to fetch list of channel Ids
+   @param[out] NumChannelIds   Number of channel Ids put in the buffer
+
+   @retval EFI_SUCCESS on success
+   @retval EFI_INVALID_PARAMETER if any parameters are invalid
+**/
+EFI_STATUS
+EFIAPI
+RacGetRasAgentMpxyChannelId (
+  IN  UINT32  ChannelIdSize,
+  OUT UINT32  *ChannelId,
+  OUT UINT32  *NumChannelIds
+  );
+
+/**
+   Open a RAS agent's MPXY channel
+
+   @param[in] ChannelId  RAS agent's MPXY channel
+   @retval EFI_SUCCESS on success
+   @retval EFI errors as returned by `SbiMpxyChannelOpen`
+**/
+EFI_STATUS
+EFIAPI
+RacOpenRasAgentChannel (
+  IN  UINT32  ChannelId
+  );
+
+/**
+   Close a RAS agent's MPXY channel
+
+   @param[in] ChannelId  RAS agent's MPXY channel
+   @retval    EFI_SUCCESS on success
+   @retval    EFI_ABORTED if a found context has zero reference count
+   @retval    EFI errors as returned by `SbiMpxyChannelClose`
+**/
+EFI_STATUS
+EFIAPI
+RacCloseRasAgentChannel (
+  IN  UINT32  ChannelId
+  );
+
+/**
+  Get the number of hardware error sources from the RAS Agent
+
+  @param NumErrorSources  Pointer to an array of 32-bit integers which will
+                          contain number of hardware error sources available.
+
+  @retval EFI_SUCCESS  If fetching the number of error sources succeeded.
+**/
+EFI_STATUS
+EFIAPI
+RacGetNumberErrorSources (
+  IN  UINT32  ChannelId,
+  OUT UINT32  *NumErrorSources
+  );
+
+/**
+  Get the list of hardware error source IDs from the RAS Agent
+
+  @param ErrorSourceList  Will contain pointer to error of 32-bit integers
+                          containing the error source IDs.
+  @param NumSources       Will contain the number of IDs in *ErrorSourceList
+
+  @retval EFI_SUCCESS  If fetching the error source IDs succeeded.
+**/
+EFI_STATUS
+EFIAPI
+RacGetErrorSourceIDList (
+  IN  UINT32  ChannelId,
+  OUT UINT32  **ErrorSourceList,
+  OUT UINT32  *NumSources
+  );
+
+/**
+  Get the hardware error source descriptor for a given error source ID.
+
+  @param SourceID  Error source ID for which descriptor is to be fetched
+  @param DescriptorType  Type of error descriptor (GHES version 2 or platform specific).
+  @param ErrorDescriptor  Pointer to buffer containing the descriptor. The caller
+                         must free the buffer when done.
+  @param ErrorDescriptorSize  Size of the error descriptor buffer in ErrorDescriptor
+
+  @retval EFI_SUCCESS  On success.
+**/
+EFI_STATUS
+EFIAPI
+RacGetErrorSourceDescriptor (
+  IN  UINT32  ChannelId,
+  IN  UINT32  SourceID,
+  OUT UINTN   *DescriptorType,
+  OUT VOID    **ErrorDescriptor,
+  OUT UINT32  *ErrorDescriptorSize
+  );

--- a/MdePkg/Include/Library/DxeRiscvMpxy.h
+++ b/MdePkg/Include/Library/DxeRiscvMpxy.h
@@ -1,0 +1,124 @@
+/** @file
+  This module implements functions used by MPXY clients.
+
+  @par Glossary:
+    - MPXY - Message Proxy extension in the RISC-V SBI specification
+
+  Copyright (c) 2026, Qualcomm Technologies, Inc.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#pragma once
+
+#include <Uefi.h>
+
+typedef enum {
+  MpxyChanAttrProtId,
+  MpxyChanAttrProtVersion,
+  MpxyChanAttrMsgDataMaxLen,
+  MpxyChanAttrMsgSendTimeout,
+  MpxyChanAttrMsgCompletionTimeout,
+  MpxyChanAttrChannelCapability,
+  MpxyChanAttrSseEventId,
+  MpxyChanAttrMsiControl,
+  MpxyChanAttrMsiAddrLow,
+  MpxyChanAttrMsiAddrHigh,
+  MpxyChanAttrMsiData,
+  MpxyChanAttrEventStateControl,
+  MpxyChanAttrMax
+} MPXY_CHAN_ATTR;
+
+#define MPXY_MSG_PROTO_ATTR_START  0x80000000
+#define MPXY_MSG_PROTO_ATTR_END    0xffffffff
+
+/**
+  Get the list of channels available on MPXY.
+
+  @param[in] StartIndex - Index to start reading from. Initially it will be zero,
+             after subsequent reads, it will be the last index read + 1.
+  @param[out] List of the channels available.
+  @param[out] Number of channels remaining.
+  @param[out] Number of channels returned in this read.
+
+  @retval EFI_SUCCESS   If list of channels was obtained successfully.
+**/
+EFI_STATUS
+EFIAPI
+SbiMpxyGetChannelList (
+  IN  UINTN  StartIndex,
+  OUT UINTN  *ChannelList,
+  OUT UINTN  *Remaining,
+  OUT UINTN  *Returned
+  );
+
+/**
+  Read the attributes (both base and protocol specific) of a channel
+
+  @param[in] Channel for which attributes are to be read
+  @param[in] The base attribute ID
+  @param[in] Number of attributes to be read
+  @param[out] Attributes read from channel from base attributes Id
+
+  @retval EFI_SUCCESS If the attributes were read successfully
+**/
+
+EFI_STATUS
+EFIAPI
+SbiMpxyReadChannelAttrs (
+  IN UINTN    ChannelId,
+  IN UINT32   BaseAttrId,
+  IN UINT32   NrAttrs,
+  OUT UINT32  *Attrs
+  );
+
+/**
+  Open specified MPXY channel for communication. It will allocate the shared
+  memory or resize the previous one if required.
+
+  @param[in] ChannelId  The channel to be initialized
+  @retval EFI_SUCCESS   If the allocation or resize of shared memory was
+                        successfully done.
+**/
+EFI_STATUS
+EFIAPI
+SbiMpxyChannelOpen (
+  IN UINTN  ChannelId
+  );
+
+/**
+  Close the specified MPXY channel.
+
+  @param[in] ChannelId  The channel to be uninitialized
+  @retval EFI_SUCCESS   If the allocation or resize of shared memory was
+                        successfully done.
+**/
+EFI_STATUS
+EFIAPI
+SbiMpxyChannelClose (
+  IN UINTN  ChannelId
+  );
+
+/**
+  Send a message with response over Mpxy.
+
+  @param[in] ChannelId       The Channel on which message would be sent
+  @param[in] MessageId       Message protocol specific message identification
+  @param[in] MessageDataLen  Length of the message to be sent
+  @param[in] Message         Pointer to buffer containing message
+  @param[in] Response        Pointer to buffer to which response should be written
+  @param[in] ResponseLen     Pointer where the size of response should be written
+
+  @retval EFI_SUCCESS    The shared memory was disabled
+  @retval Other          Some error occurred during the operation.
+**/
+EFI_STATUS
+EFIAPI
+SbiMpxySendMessage (
+  IN UINTN   ChannelId,
+  IN UINTN   MessageId,
+  IN VOID    *Message,
+  IN UINTN   MessageDataLen,
+  OUT VOID   *Response,
+  OUT UINTN  *ResponseLen
+  );

--- a/MdePkg/Library/BaseRiscVSbiLib/BaseRiscVSbiLib.c
+++ b/MdePkg/Library/BaseRiscVSbiLib/BaseRiscVSbiLib.c
@@ -115,6 +115,21 @@ TranslateError (
     case SBI_ERR_ALREADY_AVAILABLE:
       return EFI_ALREADY_STARTED;
       break;
+    case SBI_ERR_NO_SHMEM:
+      return EFI_OUT_OF_RESOURCES;
+      break;
+    case SBI_ERR_INVALID_STATE:
+      return EFI_ABORTED;
+      break;
+    case SBI_ERR_BAD_RANGE:
+      return EFI_NOT_FOUND;
+      break;
+    case SBI_ERR_NOT_IMPLEMENTED:
+      return EFI_UNSUPPORTED;
+      break;
+    case SBI_ERR_TIMEOUT:
+      return EFI_TIMEOUT;
+      break;
     default:
       //
       // Reaches here only if SBI has defined a new error type

--- a/MdePkg/Library/BaseRiscVSbiLib/BaseRiscVSbiLib.c
+++ b/MdePkg/Library/BaseRiscVSbiLib/BaseRiscVSbiLib.c
@@ -182,3 +182,28 @@ SbiSystemReset (
 
   return TranslateError (Ret.Error);
 }
+
+/**
+  Probe support for an extension in OpenSBI
+
+  Check if the extension is supported by SBI.
+
+  @param    Extension   Extension ID to be probed
+**/
+EFI_STATUS
+EFIAPI
+SbiProbeExtension (
+  IN UINTN  Extension
+  )
+{
+  SBI_RET  Ret;
+
+  Ret = SbiCall (
+          SBI_EXT_BASE,
+          SBI_EXT_BASE_PROBE_EXT,
+          1,
+          Extension
+          );
+
+  return TranslateError (Ret.Error);
+}

--- a/MdePkg/Library/DxeRiscvMpxyLib/DxeRiscvMpxy.c
+++ b/MdePkg/Library/DxeRiscvMpxyLib/DxeRiscvMpxy.c
@@ -1,0 +1,673 @@
+/** @file
+  This module implements functions used by MPXY clients.
+
+  @par Glossary:
+    - MPXY - Message Proxy extension in the RISC-V SBI specification
+
+  Copyright (c) 2026, Qualcomm Technologies, Inc.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+#include <Base.h>
+#include <Uefi.h>
+
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/BaseRiscVSbiLib.h>
+#include <Library/DebugLib.h>
+#include <Library/DxeRiscvMpxy.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/PcdLib.h>
+#include <Library/SafeIntLib.h>
+#include <Library/UefiBootServicesTableLib.h>
+#include <Library/UefiRuntimeServicesTableLib.h>
+
+#define MPXY_INVALID_SHMEM_ADDR  MAX_UINTN
+#define MAX_MPXY_OPEN_CHANNELS   32
+
+STATIC VOID  *mNonChanTempShmem     = NULL;
+STATIC VOID  *mNonChanTempShmemPhys = NULL;
+
+typedef struct {
+  BOOLEAN    InUse;
+  UINTN      ChannelId;
+  VOID       *ShmemVirt;
+  VOID       *ShmemPhys;
+  UINTN      NrEfiPages;
+  UINT32     MsgDataMaxLen;
+  UINTN      RefCount;
+} MPXY_CHANNEL_CONTEXT;
+
+STATIC MPXY_CHANNEL_CONTEXT  mMpxyChannelCtx[MAX_MPXY_OPEN_CHANNELS];
+
+///
+/// Set Virtual Address Map Event
+///
+STATIC EFI_EVENT  mDxeRiscVMpxyLibVirtualNotifyEvent = NULL;
+
+/**
+  Convert the physical channel shared memory address.
+
+  @param[in]    Event   The event that is being processed.
+  @param[in]    Context The Event Context.
+**/
+VOID
+EFIAPI
+DxeRiscVMpxyLibVirtualNotify (
+  IN EFI_EVENT  Event,
+  IN VOID       *Context
+  )
+{
+  UINTN  Index;
+
+  //
+  // If there have been no runtime registrations, then just return
+  //
+  if (mNonChanTempShmem == NULL) {
+    return;
+  }
+
+  for (Index = 0; Index < MAX_MPXY_OPEN_CHANNELS; Index++) {
+    if (mMpxyChannelCtx[Index].InUse && (mMpxyChannelCtx[Index].ShmemVirt != NULL)) {
+      gRT->ConvertPointer (0, (VOID **)&mMpxyChannelCtx[Index].ShmemVirt);
+    }
+  }
+
+  gRT->ConvertPointer (0, (VOID **)&mNonChanTempShmem);
+}
+
+/**
+  Find the channel context structure from a given ChannelID.
+
+  @param[in]    ChannelId   Id of the channel being searched
+
+  @retval On success, pointer to a MPXY channel context, NULL otherwise
+**/
+STATIC
+MPXY_CHANNEL_CONTEXT *
+FindChannelContext (
+  IN UINTN  ChannelId
+  )
+{
+  UINTN  Index;
+
+  for (Index = 0; Index < MAX_MPXY_OPEN_CHANNELS; Index++) {
+    if (mMpxyChannelCtx[Index].InUse && (mMpxyChannelCtx[Index].ChannelId == ChannelId)) {
+      return &mMpxyChannelCtx[Index];
+    }
+  }
+
+  return NULL;
+}
+
+/**
+   Allocate a free channel context.
+
+   @retval Pointer to free channel context
+**/
+STATIC
+MPXY_CHANNEL_CONTEXT *
+AllocChannelContext (
+  VOID
+  )
+{
+  UINTN  Index;
+
+  for (Index = 0; Index < MAX_MPXY_OPEN_CHANNELS; Index++) {
+    if (!mMpxyChannelCtx[Index].InUse) {
+      return &mMpxyChannelCtx[Index];
+    }
+  }
+
+  return NULL;
+}
+
+/**
+   Get the size of shared memory for MPXY set with SBI.
+
+   @param[out]    ShmemSize    Size of the shared memory
+   @retval EFI_SUCCESS on success
+   @retval Error as returned by SBI translated to corresponding EFI error
+**/
+STATIC
+EFI_STATUS
+EFIAPI
+SbiMpxyGetShmemSize (
+  OUT UINT64  *ShmemSize
+  )
+{
+  SBI_RET  Ret;
+
+  if (ShmemSize == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Ret = SbiCall (
+          SBI_EXT_MPXY,
+          SBI_EXT_MPXY_GET_SHMEM_SIZE,
+          0
+          );
+
+  if (Ret.Error == SBI_SUCCESS) {
+    *ShmemSize = Ret.Value;
+    return EFI_SUCCESS;
+  }
+
+  return TranslateError (Ret.Error);
+}
+
+/**
+   Set shared memory for communication over MPXY channel. Optionally
+   previous address can be read.
+
+   @param[in]  ShmemPhys        Physical address of shared memory
+   @param[in]  ShmemVirt        Virtual address of shared memory
+   @param[out] PrevShmemPhys    Physical address previously set
+   @param[in]  ReadBackOldShmem Flag to read the previous physical address
+
+   @retval EFI_SUCCESS On success
+   @retval Error returned by SBI translated to corresponding EFI error
+ **/
+STATIC
+EFI_STATUS
+EFIAPI
+SbiMpxySetShmem (
+  IN UINTN   ShmemPhys,
+  IN UINTN   ShmemVirt,
+  OUT UINTN  *PrevShmemPhys,
+  BOOLEAN    ReadBackOldShmem
+  )
+{
+  SBI_RET  Ret;
+  UINTN    Flags;
+  UINTN    ShmemPhysLo;
+  UINTN    ShmemPhysHi;
+  UINTN    *PrevMemDet;
+
+  if (ReadBackOldShmem && ((PrevShmemPhys == NULL) || (ShmemVirt == 0))) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Flags = ReadBackOldShmem ?
+          SBI_EXT_MPXY_SHMEM_FLAG_OVERWRITE_RETURN :
+          SBI_EXT_MPXY_SHMEM_FLAG_OVERWRITE;
+
+  if (ShmemPhys == MPXY_INVALID_SHMEM_ADDR) {
+    ShmemPhysLo = MAX_UINTN;
+    ShmemPhysHi = MAX_UINTN;
+  } else {
+    ShmemPhysLo = ShmemPhys;
+    /* Upper XLEN bits are unused for native-width addresses. */
+    ShmemPhysHi = 0;
+  }
+
+  Ret = SbiCall (
+          SBI_EXT_MPXY,
+          SBI_EXT_MPXY_SET_SHMEM,
+          3,
+          ShmemPhysLo,
+          ShmemPhysHi,
+          Flags
+          );
+
+  if (Ret.Error != SBI_SUCCESS) {
+    return TranslateError (Ret.Error);
+  }
+
+  if (ReadBackOldShmem) {
+    PrevMemDet = (UINTN *)ShmemVirt;
+    if ((PrevMemDet[0] == MAX_UINTN) && (PrevMemDet[1] == MAX_UINTN)) {
+      *PrevShmemPhys = MPXY_INVALID_SHMEM_ADDR;
+    } else {
+      *PrevShmemPhys = PrevMemDet[0];
+    }
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+   Get list of MPXY channels available in SBI.
+
+   @param[in]  StartIndex    First channel ID to start list from
+   @param[out] ChannelList   Array of the MPXY channels IDs returned by SBI
+   @param[out] Remaining     Pointer containing the number of channel Ids to be read
+   @param[out] Returned      Pointer to the number of channel Ids returned in this call
+
+   @retval EFI_SUCCESS on success
+   @retval EFI_NOT_READY if library is not initialised
+   @retval EFI error translated from error returned by SBI
+**/
+EFI_STATUS
+EFIAPI
+SbiMpxyGetChannelList (
+  IN  UINTN  StartIndex,
+  OUT UINTN  *ChannelList,
+  OUT UINTN  *Remaining,
+  OUT UINTN  *Returned
+  )
+{
+  UINTN       OldShmemPhys;
+  EFI_STATUS  Status;
+  EFI_STATUS  RestoreStatus;
+  SBI_RET     Ret;
+  UINT32      *Shmem;
+  UINTN       Index;
+
+  if ((ChannelList == NULL) || (Remaining == NULL) || (Returned == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (mNonChanTempShmem == NULL) {
+    return EFI_NOT_READY;
+  }
+
+  Shmem = mNonChanTempShmem;
+
+  /* Set the shared memory to memory allocated for non-channel specific reads */
+  Status = SbiMpxySetShmem (
+             (UINTN)mNonChanTempShmemPhys,
+             (UINTN)mNonChanTempShmem,
+             &OldShmemPhys,
+             TRUE /* Read back the old address */
+             );
+
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Ret = SbiCall (
+          SBI_EXT_MPXY,
+          SBI_EXT_MPXY_GET_CHANNEL_IDS,
+          1,
+          StartIndex
+          );
+
+  if (Ret.Error != SBI_SUCCESS) {
+    Status = TranslateError (Ret.Error);
+    goto RestoreShmem;
+  }
+
+  /* Index 0 contains number of channels pending to be read */
+  *Remaining = Shmem[0];
+
+  /* Number of channels returned */
+  if (Shmem[1] > 0) {
+    for (Index = 0; Index < Shmem[1]; Index++) {
+      ChannelList[Index] = Shmem[Index + 2];
+    }
+  }
+
+  *Returned = Shmem[1];
+
+  /* Switch back to old shared memory */
+  Status = EFI_SUCCESS;
+
+RestoreShmem:
+  RestoreStatus = SbiMpxySetShmem (
+                    OldShmemPhys,
+                    MPXY_INVALID_SHMEM_ADDR,
+                    NULL,
+                    FALSE /* Read back the old address */
+                    );
+  if (EFI_ERROR (RestoreStatus)) {
+    return RestoreStatus;
+  }
+
+  return Status;
+}
+
+/**
+   Read MPXY channel attributes from the SBI.
+
+   @param[in]  ChannelId    ID of the channel to read attributes
+   @param[in]  BaseAttrId   Base Attribute ID from where to read attributes
+   @param[in]  NrAttrs      Number of attributes to read
+   @param[out] Attrs        Array of the attributes read
+
+   @retval EFI_SUCCESS on success
+   @retval EFI_NOT_READY if MPXY library is not initialized
+   @retval EFI error translated from SBI error code
+ **/
+EFI_STATUS
+EFIAPI
+SbiMpxyReadChannelAttrs (
+  IN UINTN    ChannelId,
+  IN UINT32   BaseAttrId,
+  IN UINT32   NrAttrs,
+  OUT UINT32  *Attrs
+  )
+{
+  UINTN       OldShmemPhys;
+  EFI_STATUS  Status;
+  EFI_STATUS  RestoreStatus;
+  SBI_RET     Ret;
+
+  if ((Attrs == NULL) || (NrAttrs == 0)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (mNonChanTempShmem == NULL) {
+    return EFI_NOT_READY;
+  }
+
+  /* Set the shared memory to memory allocated for non-channel specific reads */
+  Status = SbiMpxySetShmem (
+             (UINTN)mNonChanTempShmemPhys,
+             (UINTN)mNonChanTempShmem,
+             &OldShmemPhys,
+             TRUE /* Read back the old address */
+             );
+
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Ret = SbiCall (
+          SBI_EXT_MPXY,
+          SBI_EXT_MPXY_READ_ATTRS,
+          3,
+          ChannelId,
+          BaseAttrId, /* Base attribute Id */
+          NrAttrs     /* Number of attributes */
+          );
+
+  if (Ret.Error != SBI_SUCCESS) {
+    Status = TranslateError (Ret.Error);
+    goto RestoreShmem;
+  }
+
+  CopyMem (
+    Attrs,
+    mNonChanTempShmem,
+    sizeof (UINT32) * NrAttrs
+    );
+
+  Status = EFI_SUCCESS;
+
+RestoreShmem:
+  RestoreStatus = SbiMpxySetShmem (
+                    OldShmemPhys,
+                    MPXY_INVALID_SHMEM_ADDR,
+                    NULL,
+                    FALSE /* Read back the old address */
+                    );
+  if (EFI_ERROR (RestoreStatus)) {
+    return RestoreStatus;
+  }
+
+  return Status;
+}
+
+/**
+   Open an MPXY channel identified by the channel Id.
+
+   @param[in] ChannelId    Id of the channel to be opened
+
+   @retval EFI_SUCCESS On success
+   @retval EFI_NOT_READY if library is not initialized
+   @retval EFI_INVALID_PARAMETER if Channel information or Channel Is is wrong
+   @retval EFI_OUT_OF_RESOURCES if new channel cannot be allocated or allocation
+           of the shared memory fails
+**/
+EFI_STATUS
+EFIAPI
+SbiMpxyChannelOpen (
+  IN UINTN  ChannelId
+  )
+{
+  MPXY_CHANNEL_CONTEXT  *ChannelCtx;
+  UINT32                Attributes[MpxyChanAttrMax]; // space to read id and version
+  UINT32                ChanDataLen;
+  VOID                  *SbiShmem;
+  UINTN                 NrEfiPages;
+  EFI_STATUS            Status;
+
+  if (mNonChanTempShmem == NULL) {
+    return EFI_NOT_READY;
+  }
+
+  ChannelCtx = FindChannelContext (ChannelId);
+  if (ChannelCtx != NULL) {
+    ChannelCtx->RefCount++;
+    return EFI_SUCCESS;
+  }
+
+  Status = SbiMpxyReadChannelAttrs (
+             ChannelId,
+             0,
+             MpxyChanAttrMax,
+             &Attributes[0]
+             );
+
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  ChanDataLen = Attributes[MpxyChanAttrMsgDataMaxLen];
+  if (ChanDataLen == 0) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  NrEfiPages = EFI_SIZE_TO_PAGES (ChanDataLen);
+
+  ChannelCtx = AllocChannelContext ();
+  if (ChannelCtx == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  SbiShmem = AllocateAlignedRuntimePages (NrEfiPages, EFI_PAGE_SIZE);
+  if (SbiShmem == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  ZeroMem (ChannelCtx, sizeof (*ChannelCtx));
+  ChannelCtx->InUse         = TRUE;
+  ChannelCtx->ChannelId     = ChannelId;
+  ChannelCtx->ShmemVirt     = SbiShmem;
+  ChannelCtx->ShmemPhys     = SbiShmem;
+  ChannelCtx->NrEfiPages    = NrEfiPages;
+  ChannelCtx->MsgDataMaxLen = ChanDataLen;
+  ChannelCtx->RefCount      = 1;
+
+  return EFI_SUCCESS;
+}
+
+/**
+   Close a given MPXY channel.
+
+   @param[in] ChannelId   Id of the channel to be closed
+
+   @retval EFI_SUCCESS on success
+   @retval EFI_NOT_FOUND is context related to ChannelId could not be found
+**/
+EFI_STATUS
+EFIAPI
+SbiMpxyChannelClose (
+  IN UINTN  ChannelId
+  )
+{
+  MPXY_CHANNEL_CONTEXT  *ChannelCtx;
+
+  ChannelCtx = FindChannelContext (ChannelId);
+  if (ChannelCtx == NULL) {
+    return EFI_NOT_FOUND;
+  }
+
+  if (ChannelCtx->RefCount > 1) {
+    ChannelCtx->RefCount--;
+    return EFI_SUCCESS;
+  }
+
+  if ((ChannelCtx->ShmemVirt != NULL) && (ChannelCtx->NrEfiPages != 0)) {
+    FreeAlignedPages (ChannelCtx->ShmemVirt, ChannelCtx->NrEfiPages);
+  }
+
+  ZeroMem (ChannelCtx, sizeof (*ChannelCtx));
+  return EFI_SUCCESS;
+}
+
+/**
+   Send a message over an MPXY channel.
+
+   @param[in] ChannelId     Id of the channel on which message is to be sent
+   @param[in] MessageId     Id of the message being sent
+   @param[in] Message       Pointer to the buffer containing the message
+   @param[in] MessageDataLen Size of the message being sent
+   @param[out] Response     Pointer to the buffer on which response will be received
+   @param[out] ResponseLen  Size of the response
+
+   @retval EFI_SUCCESS on success
+   @retval EFI_NOT_READY if channel context is not found or is invalid
+   @retval EFI_INVALID_PARAMETER if length of the message data is more than channel can carry
+   @retval EFI error translated from error returned by SBI
+**/
+EFI_STATUS
+EFIAPI
+SbiMpxySendMessage (
+  IN UINTN   ChannelId,
+  IN UINTN   MessageId,
+  IN VOID    *Message,
+  IN UINTN   MessageDataLen,
+  OUT VOID   *Response,
+  OUT UINTN  *ResponseLen
+  )
+{
+  MPXY_CHANNEL_CONTEXT  *ChannelCtx;
+  SBI_RET               Ret;
+  EFI_STATUS            Status;
+  EFI_STATUS            RestoreStatus;
+  UINTN                 PrevShmemPhys;
+  UINTN                 Virt;
+
+  if (mNonChanTempShmem == NULL) {
+    return EFI_NOT_READY;
+  }
+
+  ChannelCtx = FindChannelContext (ChannelId);
+  if ((ChannelCtx == NULL) || !ChannelCtx->InUse || (ChannelCtx->ShmemVirt == NULL)) {
+    return EFI_NOT_READY;
+  }
+
+  if (MessageDataLen > ChannelCtx->MsgDataMaxLen) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Status = SbiMpxySetShmem (
+             (UINTN)ChannelCtx->ShmemPhys,
+             (UINTN)ChannelCtx->ShmemVirt,
+             &PrevShmemPhys,
+             TRUE
+             );
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Virt = (UINTN)ChannelCtx->ShmemVirt;
+
+  /* Copy message to Hart's shared memory */
+  CopyMem (
+    (VOID *)Virt,
+    Message,
+    MessageDataLen
+    );
+
+  Ret = SbiCall (
+          SBI_EXT_MPXY,
+          SBI_EXT_MPXY_SEND_MSG_WITH_RESP,
+          3,
+          ChannelId,
+          MessageId,
+          MessageDataLen
+          );
+
+  if ((Ret.Error == SBI_SUCCESS) && (Response != NULL)) {
+    /* Copy the response to out buffer */
+    CopyMem (
+      Response,
+      (const VOID *)Virt,
+      Ret.Value
+      );
+    if (ResponseLen != NULL) {
+      *ResponseLen = Ret.Value;
+    }
+  }
+
+  RestoreStatus = SbiMpxySetShmem (
+                    PrevShmemPhys,
+                    MPXY_INVALID_SHMEM_ADDR,
+                    NULL,
+                    FALSE
+                    );
+
+  if (EFI_ERROR (RestoreStatus)) {
+    return RestoreStatus;
+  }
+
+  return TranslateError (Ret.Error);
+}
+
+/**
+  Constructor allocates the global memory to store the registered guid and Handler list.
+
+  @param  ImageHandle   The firmware allocated handle for the EFI image.
+  @param  SystemTable   A pointer to the EFI System Table.
+
+  @retval  RETURN_SUCCESS            Allocated the global memory space to store guid and function tables.
+  @retval  RETURN_OUT_OF_RESOURCES   Not enough memory to allocate.
+**/
+RETURN_STATUS
+EFIAPI
+SbiMpxyLibConstructor (
+  IN EFI_HANDLE        ImageHandle,
+  IN EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  EFI_STATUS  Status;
+  UINT64      ShmemSize;
+
+  Status = SbiProbeExtension (SBI_EXT_MPXY);
+
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Status = SbiMpxyGetShmemSize (&ShmemSize);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  //
+  // Allocate memory to be shared with OpenSBI for initial MPXY communications
+  // until channels are initialized by their respective drivers.
+  //
+  mNonChanTempShmem = AllocateAlignedRuntimePages (
+                        EFI_SIZE_TO_PAGES (ShmemSize),
+                        ShmemSize // Align
+                        );
+
+  if (mNonChanTempShmem == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  mNonChanTempShmemPhys = mNonChanTempShmem;
+
+  //
+  // Register SetVirtualAddressMap () notify function
+  //
+  Status = gBS->CreateEvent (
+                  EVT_SIGNAL_VIRTUAL_ADDRESS_CHANGE,
+                  TPL_NOTIFY,
+                  DxeRiscVMpxyLibVirtualNotify,
+                  NULL,
+                  &mDxeRiscVMpxyLibVirtualNotifyEvent
+                  );
+  if (EFI_ERROR (Status)) {
+    FreeAlignedPages (mNonChanTempShmem, EFI_SIZE_TO_PAGES (ShmemSize));
+    mNonChanTempShmem     = NULL;
+    mNonChanTempShmemPhys = NULL;
+    return Status;
+  }
+
+  return Status;
+}

--- a/MdePkg/Library/DxeRiscvMpxyLib/DxeRiscvMpxy.inf
+++ b/MdePkg/Library/DxeRiscvMpxyLib/DxeRiscvMpxy.inf
@@ -1,0 +1,30 @@
+# @file
+# Provides implementation of the library to communicate over SBI MPXY on RISC-V architecture
+#
+# @copyright
+# Copyright (c) Qualcomm Technologies, Inc. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION     = 1.27
+  BASE_NAME       = DxeRiscvMpxyLib
+  MODULE_UNI_FILE = DxeRiscvMpxy.uni
+  FILE_GUID       = 8e992db5-4383-4023-a24e-7c99955bde80
+  MODULE_TYPE     = DXE_DRIVER
+  VERSION_STRING  = 1.0
+  LIBRARY_CLASS   = DxeRiscvMpxyLib|DXE_DRIVER DXE_RUNTIME_DRIVER UEFI_APPLICATION UEFI_DRIVER
+  CONSTRUCTOR     = SbiMpxyLibConstructor
+
+[Packages]
+  MdePkg/MdePkg.dec
+
+[Sources]
+  DxeRiscvMpxy.c
+
+[LibraryClasses]
+  DebugLib
+  UefiBootServicesTableLib
+  RiscVSbiLib
+  SafeIntLib

--- a/MdePkg/Library/DxeRiscvMpxyLib/DxeRiscvMpxy.uni
+++ b/MdePkg/Library/DxeRiscvMpxyLib/DxeRiscvMpxy.uni
@@ -1,0 +1,15 @@
+// @file
+// Instance of SBI MPXY library for RISC-V architecutre.
+//
+// MpxyLib.
+//
+// Copyright (c) Qualcomm Technologies, Inc.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+
+#string STR_MODULE_ABSTRACT     #language en-US "Instance of SbiMpxy Library"
+
+#string STR_MODULE_DESCRIPTION  #language en-US "Library that provides implementation of SBI Mpxy on RISC-V architecture"
+

--- a/MdePkg/Library/DxeRiscvRasAgentClientLib/DxeRiscvRasAgentClient.c
+++ b/MdePkg/Library/DxeRiscvRasAgentClientLib/DxeRiscvRasAgentClient.c
@@ -1,0 +1,681 @@
+/** @file
+  This module provides communication with RAS Agent over RPMI/MPXY.
+
+  @par Glossary:
+    - RAS  - Reliability, Availability, and Serviceability
+    - RPMI - RAS Platform Management Interface
+    - MPXY - Message Proxy extension in the RISC-V SBI specification
+
+  Copyright (c) 2026, Qualcomm Technologies, Inc.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <Base.h>
+#include <Uefi.h>
+
+#include <IndustryStandard/Acpi.h>
+
+#include <Protocol/AcpiTable.h>
+
+#include <Guid/EventGroup.h>
+
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+
+#include <Library/MemoryAllocationLib.h>
+#include <Library/UefiBootServicesTableLib.h>
+#include <Library/DebugLib.h>
+#include <Library/PcdLib.h>
+#include <Library/SafeIntLib.h>
+#include <Library/BaseRiscVSbiLib.h>
+
+#include <Library/DxeRiscvMpxy.h>
+#include <Library/DxeRasAgentClient.h>
+
+#include "DxeRiscvRasAgentClientPrivate.h"
+
+STATIC RAS_AGENT_CONTEXT  RasAgentContexts[MAX_RAS_AGENTS];
+STATIC BOOLEAN            mRacLibraryInitialized = FALSE;
+STATIC UINT32             mNumRasAgents;
+STATIC UINT32             mRasAgentChannelIds[MAX_RAS_AGENTS];
+#define RAS_AGENT_CHANNEL_LIST_SIZE  ARRAY_SIZE (mRasAgentChannelIds)
+
+/**
+   Probe RAS agent and return its MPXY channel id.
+
+   @param[in]  ChannelIdSize   Size of ChannelId buffer.
+   @param[out] ChannelId       Buffer to hold channel IDs.
+   @param[out] NumChannelIds   Number of channel IDs found.
+
+   @retval EFI_SUCCESS            Operation succeeded.
+   @retval EFI_UNSUPPORTED        No RAS agent found.
+   @retval EFI_INVALID_PARAMETER  One or more parameters are invalid.
+   @retval Other                  Error returned by SBI, translated to EFI.
+**/
+STATIC
+EFI_STATUS
+ProbeRasAgentMpxyChannelId (
+  IN  UINT32  ChannelIdSize,
+  OUT UINT32  *ChannelId,
+  OUT UINT32  *NumChannelIds
+  )
+{
+  UINTN       ChannelList[MAX_MPXY_CHANNELS];
+  UINTN       Returned;
+  UINTN       Remaining;
+  UINTN       StartIndex;
+  EFI_STATUS  Status;
+  BOOLEAN     ParsingDone;
+  UINTN       OIndex;
+  UINTN       Index;
+  UINT32      RasSrvGroup;
+  UINT32      NumSrvGroups;
+
+  StartIndex   = 0;
+  ParsingDone  = FALSE;
+  NumSrvGroups = 0;
+
+  if ((ChannelId == NULL) || (NumChannelIds == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (ChannelIdSize < MAX_RAS_AGENTS) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  while (!ParsingDone) {
+    Status = SbiMpxyGetChannelList (
+               StartIndex, /* Start index */
+               &ChannelList[0],
+               &Remaining,
+               &Returned
+               );
+
+    if (Status != EFI_SUCCESS) {
+      if ((Status == EFI_LOAD_ERROR) ||
+          (Status == EFI_NOT_READY)  ||
+          (Status == EFI_UNSUPPORTED))
+      {
+        return EFI_UNSUPPORTED;
+      }
+
+      return Status;
+    }
+
+    /* This read has returned zero and we still haven't got what we need */
+    if (Returned == 0) {
+      return EFI_UNSUPPORTED;
+    }
+
+    for (OIndex = 0; OIndex < Returned; OIndex++) {
+      Index  = ChannelList[OIndex];
+      Status = SbiMpxyReadChannelAttrs (
+                 Index,
+                 MPXY_MSG_PROTO_ATTR_START, /* Base attribute Id */
+                 1,                         /* Number of attributes to be read */
+                 &RasSrvGroup
+                 );
+
+      if (Status != EFI_SUCCESS) {
+        continue;
+      }
+
+      /* Unlikely, but if more RAS agents are found than supported,
+         move forward with only max number of RAS agents supported.
+         Display a warning in such case.
+      */
+      if (RasSrvGroup == RAS_SRV_GRP_ID) {
+        if (NumSrvGroups >= MAX_RAS_AGENTS) {
+          DEBUG ((
+            DEBUG_WARN,
+            "Total RAS agents so far %u is more than supported (%u)\n",
+            NumSrvGroups,
+            MAX_RAS_AGENTS
+            ));
+          NumSrvGroups--;
+          Status = EFI_SUCCESS;
+          goto ParseDone;
+        }
+
+        ChannelId[NumSrvGroups] = Index;
+        NumSrvGroups++;
+        continue;
+      }
+    }
+
+    /* Read if some more to be read else we are done parsing */
+    if (Remaining != 0) {
+      StartIndex = Returned;
+      continue;
+    } else {
+      ParsingDone = TRUE;
+    }
+  }
+
+ParseDone:
+  *NumChannelIds = NumSrvGroups;
+
+  return Status;
+}
+
+/**
+   Get number of RAS agents present.
+
+   @retval Returns number of RAS agents present.
+**/
+EFI_STATUS
+EFIAPI
+RacGetNumRasAgents (
+  VOID
+  )
+{
+  if (!mRacLibraryInitialized) {
+    DEBUG ((DEBUG_ERROR, "%a: library not initialized\n", __func__));
+    return EFI_NOT_READY;
+  }
+
+  return mNumRasAgents;
+}
+
+/**
+   Get the list of RAS agent MPXY channel IDs.
+
+   @param[in]  ChannelIdSize   Size of buffer used to fetch channel IDs.
+   @param[out] ChannelId       Pointer to buffer used to fetch channel IDs.
+   @param[out] NumChannelIds   Number of channel IDs put in the buffer.
+
+   @retval EFI_SUCCESS            Operation succeeded.
+   @retval EFI_INVALID_PARAMETER  One or more parameters are invalid.
+**/
+EFI_STATUS
+EFIAPI
+RacGetRasAgentMpxyChannelId (
+  IN  UINT32  ChannelIdSize,
+  OUT UINT32  *ChannelId,
+  OUT UINT32  *NumChannelIds
+  )
+{
+  UINT32  Index;
+
+  if ((ChannelId == NULL) || (NumChannelIds == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (ChannelIdSize < mNumRasAgents) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  for (Index = 0; Index < mNumRasAgents; Index++) {
+    ChannelId[Index] = mRasAgentChannelIds[Index];
+  }
+
+  *NumChannelIds = mNumRasAgents;
+
+  return EFI_SUCCESS;
+}
+
+/**
+   Initialize RAS agent client library.
+
+   @retval EFI_SUCCESS  Operation succeeded.
+   @retval Other        Error returned by ProbeRasAgentMpxyChannelId().
+**/
+EFI_STATUS
+EFIAPI
+RacInit (
+  VOID
+  )
+{
+  EFI_STATUS  Status;
+  UINT32      Index;
+
+  if (!mRacLibraryInitialized) {
+    Status = ProbeRasAgentMpxyChannelId (
+               RAS_AGENT_CHANNEL_LIST_SIZE,
+               mRasAgentChannelIds,
+               &mNumRasAgents
+               );
+    if (EFI_ERROR (Status)) {
+      return Status;
+    }
+
+    for (Index = 0; Index < MAX_RAS_AGENTS; Index++) {
+      RasAgentContexts[Index].RefCount      = 0;
+      RasAgentContexts[Index].MpxyChannelId = INVALID_MPXY_CHANNELID;
+    }
+
+    mRacLibraryInitialized = TRUE;
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+   Check if a channel id is valid.
+
+   @param[in]  ChannelId  RAS agent's MPXY channel.
+
+   @retval TRUE   Channel id is valid.
+   @retval FALSE  Channel id is invalid.
+**/
+STATIC
+BOOLEAN
+RacChannelIdValid (
+  IN  UINT32  ChannelId
+  )
+{
+  UINT32  Index;
+
+  if (!mRacLibraryInitialized) {
+    return FALSE;
+  }
+
+  for (Index = 0; Index < mNumRasAgents; Index++) {
+    if (mRasAgentChannelIds[Index] == ChannelId) {
+      return TRUE;
+    }
+  }
+
+  return FALSE;
+}
+
+/**
+   Find a RAS agent context for a given MPXY channel ID.
+
+   @param[in] ChannelId  RAS agent's MPXY channel
+
+   @retval Pointer to RAS context if found
+   @retval NULL if not found
+**/
+STATIC
+RAS_AGENT_CONTEXT *
+FindRasAgentContext (
+  IN UINT32  ChannelId
+  )
+{
+  UINT32  Index;
+
+  for (Index = 0; Index < MAX_RAS_AGENTS; Index++) {
+    if (RasAgentContexts[Index].MpxyChannelId == ChannelId) {
+      return &RasAgentContexts[Index];
+    }
+  }
+
+  return NULL;
+}
+
+/**
+   Allocate a free RAS agent context for a given channel ID.
+
+   @param[in] ChannelId  Channel ID for which context is to be allocated.
+
+   @retval Pointer to the allocated RAS context.
+   @retval NULL if no free context is found.
+**/
+STATIC
+RAS_AGENT_CONTEXT *
+AllocRasAgentContext (
+  IN  UINT32  ChannelId
+  )
+{
+  UINT32  Index;
+
+  for (Index = 0; Index < MAX_RAS_AGENTS; Index++) {
+    if (RasAgentContexts[Index].MpxyChannelId == INVALID_MPXY_CHANNELID) {
+      RasAgentContexts[Index].MpxyChannelId = ChannelId;
+      RasAgentContexts[Index].RefCount++;
+
+      return &RasAgentContexts[Index];
+    }
+  }
+
+  return NULL;
+}
+
+/**
+   Free a RAS agent context when the reference count becomes zero.
+
+   @param[in]  Context  Pointer to the RAS agent context to be freed
+**/
+STATIC
+VOID
+FreeRasAgentContext (
+  IN  RAS_AGENT_CONTEXT  *Context
+  )
+{
+  if (Context == NULL) {
+    return;
+  }
+
+  if (Context->RefCount == 0) {
+    return;
+  }
+
+  Context->RefCount--;
+
+  if (Context->RefCount == 0) {
+    Context->MpxyChannelId = INVALID_MPXY_CHANNELID;
+    Context->RefCount      = 0;
+  }
+}
+
+/**
+   Open a RAS agent's MPXY channel.
+
+   @param[in] ChannelId  RAS agent's MPXY channel
+   @retval    EFI_SUCCESS on success
+   @retval    EFI_ABORTED if a found context has zero reference count
+   @retval    EFI errors as returned by `SbiMpxyChannelOpen`
+**/
+EFI_STATUS
+EFIAPI
+RacOpenRasAgentChannel (
+  IN  UINT32  ChannelId
+  )
+{
+  RAS_AGENT_CONTEXT  *ChannelContext;
+  EFI_STATUS         Status;
+
+  if (!RacChannelIdValid (ChannelId)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  ChannelContext = FindRasAgentContext (ChannelId);
+  if (ChannelContext != NULL) {
+    ChannelContext->RefCount++;
+    return EFI_SUCCESS;
+  }
+
+  ChannelContext = AllocRasAgentContext (ChannelId);
+  if (ChannelContext == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  Status = SbiMpxyChannelOpen (ChannelId);
+  if (Status != EFI_SUCCESS) {
+    FreeRasAgentContext (ChannelContext);
+    return Status;
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+   Close a RAS agent's MPXY channel.
+
+   @param[in] ChannelId  RAS agent's MPXY channel
+   @retval    EFI_SUCCESS on success
+   @retval    EFI_ABORTED if a found context has zero reference count
+   @retval    EFI errors as returned by `SbiMpxyChannelClose`
+**/
+EFI_STATUS
+EFIAPI
+RacCloseRasAgentChannel (
+  IN  UINT32  ChannelId
+  )
+{
+  RAS_AGENT_CONTEXT  *ChannelContext;
+  EFI_STATUS         Status;
+
+  if (!RacChannelIdValid (ChannelId)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  ChannelContext = FindRasAgentContext (ChannelId);
+  if (ChannelContext != NULL) {
+    ChannelContext->RefCount++;
+    return EFI_SUCCESS;
+  }
+
+  ChannelContext = AllocRasAgentContext (ChannelId);
+  if (ChannelContext == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  Status = SbiMpxyChannelClose (ChannelId);
+  if (Status != EFI_SUCCESS) {
+    return Status;
+  }
+
+  FreeRasAgentContext (ChannelContext);
+
+  return EFI_SUCCESS;
+}
+
+/**
+   Get the number of error sources present in the system.
+
+   @param[in]  ChannelId        RAS agent's MPXY channel.
+   @param[out] NumErrorSources  Number of error sources present.
+
+   @retval EFI_SUCCESS            Operation succeeded.
+   @retval EFI_NOT_READY          Library/channel is not initialized.
+   @retval EFI_INVALID_PARAMETER  One or more parameters are invalid.
+   @retval EFI_DEVICE_ERROR       RAS agent returned an error status.
+**/
+EFI_STATUS
+EFIAPI
+RacGetNumberErrorSources (
+  IN  UINT32  ChannelId,
+  OUT UINT32  *NumErrorSources
+  )
+{
+  NUM_ERR_SRC_RESP      RasMsgBuf;
+  EFI_STATUS            Status;
+  RAS_RPMI_RESP_HEADER  *RespHdr;
+  UINTN                 RespLen;
+  RAS_AGENT_CONTEXT     *Context;
+
+  RespHdr = &RasMsgBuf.RespHdr;
+  RespLen = sizeof (RasMsgBuf);
+  Context = NULL;
+
+  if (!mRacLibraryInitialized) {
+    return EFI_NOT_READY;
+  }
+
+  if (!RacChannelIdValid (ChannelId)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Context = FindRasAgentContext (ChannelId);
+
+  if (Context == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  /* Check if the channel is opened */
+  if (Context->RefCount == 0) {
+    return EFI_NOT_READY;
+  }
+
+  ZeroMem (&RasMsgBuf, sizeof (RasMsgBuf));
+
+  Status = SbiMpxySendMessage (
+             ChannelId,
+             RAS_GET_NUM_ERR_SRCS,
+             &RasMsgBuf,
+             sizeof (UINT32),
+             (VOID *)&RasMsgBuf,
+             &RespLen
+             );
+  if (Status != EFI_SUCCESS) {
+    return Status;
+  }
+
+  if (RespHdr->Status != 0) {
+    return EFI_DEVICE_ERROR;
+  }
+
+  *NumErrorSources = RasMsgBuf.NumErrorSources;
+
+  return EFI_SUCCESS;
+}
+
+/**
+   Get the list of hardware error source IDs from the RAS Agent.
+
+   @param[in]   ChannelId        RAS agent's MPXY channel.
+   @param[out]  ErrorSourceList  Returned pointer to list of source IDs.
+   @param[out]  NumSources       Number of source IDs in ErrorSourceList.
+
+   @retval EFI_SUCCESS            The error source list was fetched.
+   @retval EFI_NOT_READY          Library/channel is not initialized.
+   @retval EFI_INVALID_PARAMETER  One or more parameters are invalid.
+   @retval EFI_DEVICE_ERROR       RAS agent returned an error status.
+**/
+EFI_STATUS
+EFIAPI
+RacGetErrorSourceIDList (
+  IN  UINT32  ChannelId,
+  OUT UINT32  **ErrorSourceList,
+  OUT UINT32  *NumSources
+  )
+{
+  UINT32                *RespData;
+  RAS_RPMI_RESP_HEADER  *RespHdr;
+  EFI_STATUS            Status;
+  UINTN                 RespLen;
+  RAS_AGENT_CONTEXT     *Context;
+
+  if (!mRacLibraryInitialized) {
+    return EFI_NOT_READY;
+  }
+
+  if (!RacChannelIdValid (ChannelId)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (ErrorSourceList == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Context = FindRasAgentContext (ChannelId);
+  if (Context == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (Context->RefCount == 0) {
+    return EFI_NOT_READY;
+  }
+
+  ZeroMem (&Context->SourceListResp, sizeof (ERROR_SOURCE_LIST_RESP));
+
+  RespData = &Context->SourceListResp.ErrSourceList[0];
+  RespHdr  = &Context->SourceListResp.RespHdr;
+  RespLen  = sizeof (ERROR_SOURCE_LIST_RESP);
+
+  Status = SbiMpxySendMessage (
+             ChannelId,
+             RAS_GET_ERR_SRCS_ID_LIST,
+             &Context->SourceListResp,
+             sizeof (ERROR_SOURCE_LIST_RESP),
+             &Context->SourceListResp,
+             &RespLen
+             );
+
+  if (Status != EFI_SUCCESS) {
+    return Status;
+  }
+
+  if (RespHdr->Status != 0) {
+    return EFI_DEVICE_ERROR;
+  }
+
+  *NumSources      = RespHdr->Returned;
+  *ErrorSourceList = RespData;
+
+  return EFI_SUCCESS;
+}
+
+/**
+   Get the hardware error source descriptor for an error source ID.
+
+   @param[in]   ChannelId             RAS agent's MPXY channel.
+   @param[in]   SourceID              Error source ID.
+   @param[out]  DescriptorType        Descriptor type.
+   @param[out]  ErrorDescriptor       Pointer to descriptor buffer.
+   @param[out]  ErrorDescriptorSize   Size of descriptor buffer.
+
+   @retval EFI_SUCCESS            Descriptor was fetched.
+   @retval EFI_NOT_READY          Library/channel is not initialized.
+   @retval EFI_INVALID_PARAMETER  One or more parameters are invalid.
+   @retval EFI_DEVICE_ERROR       RAS agent returned an error status.
+**/
+EFI_STATUS
+EFIAPI
+RacGetErrorSourceDescriptor (
+  IN  UINT32  ChannelId,
+  IN  UINT32  SourceID,
+  OUT UINTN   *DescriptorType,
+  OUT VOID    **ErrorDescriptor,
+  OUT UINT32  *ErrorDescriptorSize
+  )
+{
+  ERR_DESC_RESP         *Resp;
+  UINTN                 RespLen;
+  EFI_STATUS            Status;
+  RAS_RPMI_RESP_HEADER  *RspHdr;
+  UINT8                 *Desc;
+  UINT32                *EID;
+  RAS_AGENT_CONTEXT     *Context;
+
+  RespLen = sizeof (ERR_DESC_RESP);
+  Resp    = NULL;
+  Context = NULL;
+
+  if (!mRacLibraryInitialized) {
+    return EFI_NOT_READY;
+  }
+
+  if (!RacChannelIdValid (ChannelId)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Context = FindRasAgentContext (ChannelId);
+  if (Context == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (Context->RefCount == 0) {
+    return EFI_NOT_READY;
+  }
+
+  Resp = &Context->DescResp;
+  EID  = (UINT32 *)Resp;
+  ZeroMem (Resp, sizeof (ERR_DESC_RESP));
+  RspHdr = &Resp->RspHdr;
+  Desc   = &Resp->Desc[0];
+  *EID   = SourceID;
+
+  Status = SbiMpxySendMessage (
+             ChannelId,
+             RAS_GET_ERR_SRC_DESC,
+             Resp,
+             sizeof (ERR_DESC_RESP),
+             Resp,
+             &RespLen
+             );
+
+  if (Status != EFI_SUCCESS) {
+    return Status;
+  }
+
+  if (RspHdr->Status != 0) {
+    return EFI_DEVICE_ERROR;
+  }
+
+  if (RspHdr->Remaining != 0) {
+    return EFI_DEVICE_ERROR;
+  }
+
+  *DescriptorType = RspHdr->Flags & ERROR_DESCRIPTOR_TYPE_MASK;
+
+  ASSERT (*DescriptorType < MAX_ERROR_DESCRIPTOR_TYPES);
+
+  *ErrorDescriptor     = (VOID *)Desc;
+  *ErrorDescriptorSize = RspHdr->Returned;
+
+  return EFI_SUCCESS;
+}

--- a/MdePkg/Library/DxeRiscvRasAgentClientLib/DxeRiscvRasAgentClientLib.inf
+++ b/MdePkg/Library/DxeRiscvRasAgentClientLib/DxeRiscvRasAgentClientLib.inf
@@ -1,0 +1,31 @@
+# @file
+# Provides implementation of the library class RasAgentClient for RAS on RISC-V architecture
+#
+# @copyright
+# Copyright (c) Qualcomm Technologies, Inc.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION     = 1.27
+  BASE_NAME       = DxeRasAgentClientLib
+  MODULE_UNI_FILE = DxeRiscvRasAgentClient.uni
+  FILE_GUID       = d1342a6d-43fb-41e4-a998-2227461c1901
+  MODULE_TYPE     = DXE_DRIVER
+  VERSION_STRING  = 1.0
+  LIBRARY_CLASS   = DxeRasAgentClientLib|DXE_DRIVER DXE_RUNTIME_DRIVER UEFI_APPLICATION UEFI_DRIVER
+
+[Packages]
+  MdePkg/MdePkg.dec
+
+[Sources]
+  DxeRiscvRasAgentClient.c
+  DxeRiscvRasAgentClientPrivate.h
+
+[LibraryClasses]
+  DebugLib
+  UefiBootServicesTableLib
+  RiscVSbiLib
+  SafeIntLib
+  DxeRiscvMpxyLib

--- a/MdePkg/Library/DxeRiscvRasAgentClientLib/DxeRiscvRasAgentClientPrivate.h
+++ b/MdePkg/Library/DxeRiscvRasAgentClientLib/DxeRiscvRasAgentClientPrivate.h
@@ -1,0 +1,61 @@
+/** @file
+  Private definitions for the DXE RAS agent client library.
+
+  @par Glossary:
+    - RAS  - Reliability, Availability, and Serviceability
+    - RPMI - RAS Platform Management Interface
+    - MPXY - Message Proxy extension in the RISC-V SBI specification
+
+  Copyright (c) 2026, Qualcomm Technologies, Inc.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#pragma once
+
+#include <Uefi.h>
+
+#define MAX_MPXY_CHANNELS  64
+
+#define RAS_SRV_GRP_ID  0xC
+#define MAX_SOURCES     512
+#define MAX_DESC_SIZE   1024
+
+#define INVALID_MPXY_CHANNELID  0xFFFFFFFFUL
+
+/* RAS Agent Services on MPXY/RPMI */
+#define RAS_ENABLE_NOTIFICATION   0x1
+#define RAS_GET_NUM_ERR_SRCS      0x2
+#define RAS_GET_ERR_SRCS_ID_LIST  0x3
+#define RAS_GET_ERR_SRC_DESC      0x4
+
+#pragma pack(push, 4)
+typedef struct {
+  UINT32    Status;
+  UINT32    Flags;
+  UINT32    Remaining;
+  UINT32    Returned;
+} RAS_RPMI_RESP_HEADER;
+
+typedef struct {
+  RAS_RPMI_RESP_HEADER    RespHdr;
+  UINT32                  NumErrorSources;
+} NUM_ERR_SRC_RESP;
+
+typedef struct {
+  RAS_RPMI_RESP_HEADER    RespHdr;
+  UINT32                  ErrSourceList[MAX_SOURCES];
+} ERROR_SOURCE_LIST_RESP;
+
+typedef struct {
+  RAS_RPMI_RESP_HEADER    RspHdr;
+  UINT8                   Desc[MAX_DESC_SIZE];
+} ERR_DESC_RESP;
+
+typedef struct {
+  UINT32                    MpxyChannelId;
+  UINT32                    RefCount;
+  ERR_DESC_RESP             DescResp;
+  ERROR_SOURCE_LIST_RESP    SourceListResp;
+} RAS_AGENT_CONTEXT;
+#pragma pack(pop)

--- a/MdePkg/MdePkg.dec
+++ b/MdePkg/MdePkg.dec
@@ -352,6 +352,7 @@
 [LibraryClasses.RISCV64]
   ##  @libraryclass  Provides function to make ecalls to SBI
   BaseRiscVSbiLib|Include/Library/BaseRiscVSbiLib.h
+  DxeRiscvMpxyLib|Include/Library/DxeRiscvMpxy.h
 
 [LibraryClasses.AARCH64]
   ##  @libraryclass  Provides an interface to Arm registers.

--- a/MdePkg/MdePkg.dec
+++ b/MdePkg/MdePkg.dec
@@ -309,6 +309,10 @@
   #
   StackCheckLib|Include/Library/StackCheckLib.h
 
+  ##  @libraryclass Provides the RAS agent client to retrieve error source informations.
+  #
+  DxeRasAgentClientLib|Include/Library/DxeRasAgentClient.h
+
 [LibraryClasses.IA32, LibraryClasses.X64, LibraryClasses.AARCH64]
   ##  @libraryclass  Provides services to generate random number.
   #

--- a/MdePkg/MdePkg.dsc
+++ b/MdePkg/MdePkg.dsc
@@ -216,6 +216,7 @@
   MdePkg/Library/BaseSerialPortLibRiscVSbiLib/BaseSerialPortLibRiscVSbiLibRam.inf
   MdePkg/Library/PeiServicesTablePointerLibRiscV/PeiServicesTablePointerLib.inf
   MdePkg/Library/DxeRiscvMpxyLib/DxeRiscvMpxy.inf
+  MdePkg/Library/DxeRiscvRasAgentClientLib/DxeRiscvRasAgentClientLib.inf
 
 [Components.LOONGARCH64]
   MdePkg/Library/PeiServicesTablePointerLibKs0/PeiServicesTablePointerLibKs0.inf

--- a/MdePkg/MdePkg.dsc
+++ b/MdePkg/MdePkg.dsc
@@ -215,6 +215,7 @@
   MdePkg/Library/BaseSerialPortLibRiscVSbiLib/BaseSerialPortLibRiscVSbiLib.inf
   MdePkg/Library/BaseSerialPortLibRiscVSbiLib/BaseSerialPortLibRiscVSbiLibRam.inf
   MdePkg/Library/PeiServicesTablePointerLibRiscV/PeiServicesTablePointerLib.inf
+  MdePkg/Library/DxeRiscvMpxyLib/DxeRiscvMpxy.inf
 
 [Components.LOONGARCH64]
   MdePkg/Library/PeiServicesTablePointerLibKs0/PeiServicesTablePointerLibKs0.inf

--- a/OvmfPkg/RiscVVirt/RiscVVirtQemu.dsc
+++ b/OvmfPkg/RiscVVirt/RiscVVirtQemu.dsc
@@ -112,6 +112,8 @@
   QemuFwCfgSimpleParserLib|OvmfPkg/Library/QemuFwCfgSimpleParserLib/QemuFwCfgSimpleParserLib.inf
   QemuLoadImageLib|OvmfPkg/Library/GenericQemuLoadImageLib/GenericQemuLoadImageLib.inf
 
+  DxeRiscvMpxyLib|MdePkg/Library/DxeRiscvMpxyLib/DxeRiscvMpxy.inf
+  DxeRasAgentClientLib|MdePkg/Library/DxeRiscvRasAgentClientLib/DxeRiscvRasAgentClientLib.inf
   TimerLib|UefiCpuPkg/Library/BaseRiscV64CpuTimerLib/BaseRiscV64CpuTimerLib.inf
   VirtNorFlashDeviceLib|OvmfPkg/Library/VirtNorFlashDeviceLib/VirtNorFlashDeviceLib.inf
   VirtNorFlashPlatformLib|OvmfPkg/RiscVVirt/Library/VirtNorFlashPlatformLib/VirtNorFlashDeviceTreeLib.inf
@@ -577,6 +579,7 @@
   #
   OvmfPkg/PlatformHasAcpiDtDxe/PlatformHasAcpiDtDxe.inf
   MdeModulePkg/Universal/Acpi/BootGraphicsResourceTableDxe/BootGraphicsResourceTableDxe.inf
+  MdeModulePkg/Universal/Acpi/AcpiHardwareErrorTableDxe/HardwareErrorSourceTableDxe.inf
   OvmfPkg/AcpiPlatformDxe/AcpiPlatformDxe.inf {
     <LibraryClasses>
       NULL|OvmfPkg/Fdt/FdtPciPcdProducerLib/FdtPciPcdProducerLib.inf

--- a/OvmfPkg/RiscVVirt/RiscVVirtQemu.fdf
+++ b/OvmfPkg/RiscVVirt/RiscVVirtQemu.fdf
@@ -201,6 +201,7 @@ INF  OvmfPkg/SmbiosPlatformDxe/SmbiosPlatformDxe.inf
 INF  OvmfPkg/PlatformHasAcpiDtDxe/PlatformHasAcpiDtDxe.inf
 INF  MdeModulePkg/Universal/Acpi/AcpiTableDxe/AcpiTableDxe.inf
 INF  MdeModulePkg/Universal/Acpi/BootGraphicsResourceTableDxe/BootGraphicsResourceTableDxe.inf
+INF  MdeModulePkg/Universal/Acpi/AcpiHardwareErrorTableDxe/HardwareErrorSourceTableDxe.inf
 INF  OvmfPkg/AcpiPlatformDxe/AcpiPlatformDxe.inf
 
 #


### PR DESCRIPTION
# Description
Add RAS support for RISC-V Architecture

- Add support for APEI HEST table generation
- Add RAS Client for RISC-V to query error sources from RAS agent

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?
- **Tests** - Does this PR include any explicit test code?
No

## How This Was Tested

Tested with Qemu

## Integration Instructions
Nothing required
