### PR TITLE
Fix sct test failures

### DIFF
--- a/MdeModulePkg/Universal/HiiDatabaseDxe/ConfigRouting.c
+++ b/MdeModulePkg/Universal/HiiDatabaseDxe/ConfigRouting.c
@@ -6246,7 +6246,7 @@ HiiConfigToBlock (
   //
   if (StrnCmp (StringPtr, L"GUID=", StrLen (L"GUID=")) != 0) {
     *Progress = StringPtr;
-    Status    = EFI_INVALID_PARAMETER;
+    Status    = EFI_NOT_FOUND;
     goto Exit;
   }
 
@@ -6298,7 +6298,7 @@ HiiConfigToBlock (
     StringPtr += Length;
     if (StrnCmp (StringPtr, L"&WIDTH=", StrLen (L"&WIDTH=")) != 0) {
       *Progress = TmpPtr;
-      Status    = EFI_INVALID_PARAMETER;
+      Status    = EFI_NOT_FOUND;
       goto Exit;
     }
 
@@ -6324,7 +6324,7 @@ HiiConfigToBlock (
     StringPtr += Length;
     if (StrnCmp (StringPtr, L"&VALUE=", StrLen (L"&VALUE=")) != 0) {
       *Progress = TmpPtr;
-      Status    = EFI_INVALID_PARAMETER;
+      Status    = EFI_NOT_FOUND;
       goto Exit;
     }
 

--- a/NetworkPkg/SnpDxe/Reset.c
+++ b/NetworkPkg/SnpDxe/Reset.c
@@ -103,7 +103,7 @@ SnpUndi32Reset (
   //
   if (!ExtendedVerification) {
     DEBUG ((DEBUG_WARN, "ExtendedVerification = %d is not implemented!\n", ExtendedVerification));
-    return EFI_INVALID_PARAMETER;
+    return EFI_UNSUPPORTED;
   }
 
   if (This == NULL) {

--- a/NetworkPkg/SnpDxe/Station_address.c
+++ b/NetworkPkg/SnpDxe/Station_address.c
@@ -153,6 +153,19 @@ PxeSetStnAddr (
        Snp->Cdb->StatCode)
       );
 
+    switch (Snp->Cdb->StatCode) {
+      case PXE_STATCODE_UNSUPPORTED:
+        return EFI_UNSUPPORTED;
+
+      case PXE_STATCODE_INVALID_CDB:
+      case PXE_STATCODE_INVALID_CPB:
+      case PXE_STATCODE_INVALID_PARAMETER:
+        return EFI_INVALID_PARAMETER;
+
+      default:
+        break;
+    }
+
     //
     // UNDI command failed.  Return UNDI status to caller.
     //

--- a/SecurityPkg/Library/DxeImageVerificationLib/DxeImageVerificationLib.c
+++ b/SecurityPkg/Library/DxeImageVerificationLib/DxeImageVerificationLib.c
@@ -1707,7 +1707,7 @@ DxeImageVerificationHandler (
   //
   // Sanity check
   //
-  if (File == NULL) {
+  if ((File == NULL) && (FileBuffer == NULL)) {
     return EFI_INVALID_PARAMETER;
   }
 


### PR DESCRIPTION
# Description

Problem Description:
SCT found some test failures.
In test case  
BS.LoadImage - LoadImage() loads image from memory.
EFI_SIMPLE_NETWORK_PROTOCOL.Reset 
HII_CONFIG_ACCESS_PROTOCOL.RouteConfig

Solution Implementation:
Modify return values to comply with SCT test.


- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Run SCT tool

## Integration Instructions

N/A
