### PR TITLE
UefiCpuPkg/BaseRiscV64CpuTimerLib: Add constructor function to initialize mTimeBase and fix incorrect performance counter range

### DIFF
--- a/UefiCpuPkg/Library/BaseRiscV64CpuTimerLib/CpuTimerLib.c
+++ b/UefiCpuPkg/Library/BaseRiscV64CpuTimerLib/CpuTimerLib.c
@@ -151,7 +151,7 @@ UINT64
 EFIAPI
 GetPerformanceCounterProperties (
   OUT      UINT64 *StartValue, OPTIONAL
-  OUT      UINT64                    *EndValue     OPTIONAL
+  OUT      UINT64   *EndValue     OPTIONAL
   )
 {
   VOID                    *Hob;
@@ -165,7 +165,7 @@ GetPerformanceCounterProperties (
   }
 
   if (EndValue != NULL) {
-    *EndValue = 32 - 1;
+    *EndValue = MAX_UINT64;
   }
 
   if (mTimeBase != 0) {


### PR DESCRIPTION
# Description

- Resolve issue https://github.com/tianocore/edk2/issues/11747 correctly by ensuring mTimeBase is initialized in the constructor, preventing EFI runtime functions from accessing HOB data when mTimeBase has not yet been initialized. This approach still allows PEI modules to read HOB data directly to retrieve the timer frequency, since mTimeBase remains zero when residing in read‑only memory.
- Correct the performance counter range.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

N/A

## Integration Instructions

N/A
