### PR TITLE
BaseTools/WindowsVsToolChain.py: Minor code style updates

### DIFF
--- a/BaseTools/Plugin/WindowsVsToolChain/WindowsVsToolChain.py
+++ b/BaseTools/Plugin/WindowsVsToolChain/WindowsVsToolChain.py
@@ -407,8 +407,8 @@ class WindowsVsToolChain(IUefiBuildPlugin):
                 vc_tools_install_dir = shell_env.get_shell_var("VCToolsInstallDir")
                 if vc_tools_install_dir:
                     ia32_dll_path = os.path.join(vc_tools_install_dir, 'bin', 'Hostx64', 'x86')
-                    if os.path.exists (ia32_dll_path):
-                        shell_env.append_path(os.path.join (vc_tools_install_dir, 'bin', 'Hostx64', 'x86'))
+                    if os.path.exists(ia32_dll_path):
+                        shell_env.append_path(ia32_dll_path)
                     else:
                         self.Logger.warning("IA32 toolchain DLLs not found in expected path %s. IA32 unit tests may fail to run." % ia32_dll_path)
 


### PR DESCRIPTION
# Description

cc @mdkinney  - Assuming you agree with these? Apologies for not catching in the original PR. I was aiming to remove the path duplication (which I think is worth doing), so removed the extra space in the method call at the same time.

Fixes: 0b867b65a2c1b30a822e09572323495478778e81

- [ ] Breaking change
- [ ] Impacts security
- [ ] Includes tests

## How This Was Tested

N/A

## Integration Instructions

N/A