### PR TITLE
OvmfPkg/OvmfXen: Switch timer library to support x2APIC mode

### DIFF
--- a/OvmfPkg/OvmfXen.dsc
+++ b/OvmfPkg/OvmfXen.dsc
@@ -124,7 +124,7 @@
 
 [LibraryClasses]
   PcdLib|MdePkg/Library/BasePcdLibNull/BasePcdLibNull.inf
-  TimerLib|MdePkg/Library/SecPeiDxeTimerLibCpu/SecPeiDxeTimerLibCpu.inf
+  TimerLib|UefiCpuPkg/Library/SecPeiDxeTimerLibUefiCpu/SecPeiDxeTimerLibUefiCpu.inf
   ResetSystemLib|OvmfPkg/Library/ResetSystemLib/BaseResetSystemLibXen.inf
   PrintLib|MdePkg/Library/BasePrintLib/BasePrintLib.inf
   BaseMemoryLib|MdePkg/Library/BaseMemoryLibRepStr/BaseMemoryLibRepStr.inf


### PR DESCRIPTION


# Description

The SecPeiDxeTimerLibCpu library from the MdePkg accesses the Local APIC timer exclusively via MMIO and explicitly asserts that x2APIC mode is not enabled. This causes failures when vCPUs are pre-enabled in x2APIC mode, which might be necessary for domains with more than 128 vCPUs. So, this commit switches the TimerLib to SecPeiDxeTimerLibUefiCpu from the UefiCpuPkg, which auto-detects the APIC mode and transparently uses MSR-based access for x2APIC or MMIO for xAPIC.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Booted a Xen guest with more than 128 vCPUs and forced all vCPUs to X2APIC mode. Currently it fails with an assert in the  timer library. With the new timer library it passes because this one also supports X2APIC. While the old one doesn't.

## Integration Instructions
N/A
