### PR TITLE
Fix incremental build issue of Structure PCD

### DIFF
--- a/BaseTools/Source/Python/Workspace/DscBuildData.py
+++ b/BaseTools/Source/Python/Workspace/DscBuildData.py
@@ -2858,6 +2858,8 @@ class DscBuildData(PlatformBuildClassObject):
         if SkipPcdValueInit:
             return self.GetStructurePcdSet(PcdRecordOutputValueFile)
 
+        CurrStructuredPcdsData = json.loads(json.dumps(StructuredPcdsData, indent=2))
+
         InitByteValue = ""
         CApp = PcdMainCHeader
 
@@ -3011,9 +3013,9 @@ class DscBuildData(PlatformBuildClassObject):
         SearchPathList.append(os.path.normpath(mws.join(GlobalData.gGlobalDefines["EDK_TOOLS_PATH"], "BaseTools/Source/C/Common")))
         SearchPathList.extend(str(item) for item in IncSearchList)
         IncFileList = GetDependencyList(IncludeFileFullPaths, SearchPathList)
-        StructuredPcdsData["OBJECTS"] = {}
+        CurrStructuredPcdsData["OBJECTS"] = {}
         for include_file in IncFileList:
-            StructuredPcdsData["OBJECTS"][include_file] = os.path.getmtime(include_file)
+            CurrStructuredPcdsData["OBJECTS"][include_file] = os.path.getmtime(include_file)
             MakeApp += "$(OBJECTS) : %s\n" % include_file
         if sys.platform == "win32":
             PcdValueCommonPath = os.path.normpath(mws.join(GlobalData.gGlobalDefines["EDK_TOOLS_PATH"], "Source\\C\\Common\\PcdValueCommon.c"))
@@ -3123,7 +3125,7 @@ class DscBuildData(PlatformBuildClassObject):
         # update the record as PCD Input has been changed if its incremental build
         #
         with open(StructuredPcdsDataPath, 'w') as file:
-            json.dump(StructuredPcdsData, file, indent=2)
+            json.dump(CurrStructuredPcdsData, file, indent=2)
 
         # Copy update output file for each Arch
         shutil.copyfile(OutputValueFile, PcdRecordOutputValueFile)

--- a/BaseTools/Source/Python/Workspace/DscBuildData.py
+++ b/BaseTools/Source/Python/Workspace/DscBuildData.py
@@ -2815,7 +2815,8 @@ class DscBuildData(PlatformBuildClassObject):
                 "PcdFieldValueFromComm": Pcd.PcdFieldValueFromComm,
                 "PcdFieldValueFromFdf": Pcd.PcdFieldValueFromFdf,
                 "DefaultFromDSC": Pcd.DefaultFromDSC,
-                "PcdFiledValueFromDscComponent": Pcd.PcdFiledValueFromDscComponent
+                "PcdFiledValueFromDscComponent": Pcd.PcdFiledValueFromDscComponent,
+                "SkuOverrideValues": Pcd.SkuOverrideValues
             }
 
         # Store the CC Flags


### PR DESCRIPTION
# Description

Fixes: #12136

Pcd.SkuOverrideValues ​​contains DSC global settings.
Add it to StructuredPcdsData.json to ensure that
incremental buildscan proceed correctly after
modifying the DSC global structure pcd settings.

StructuredPcdsData contains objects that may change before
being saved to a JSON file. This commit ensures that
the object is the original object when saved,
so that it can be compared.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

1.

* Build EmulatorPkg with REDFISH_ENABLE = TRUE
* Check Build\EmulatorX64\DEBUG_VS2022\PcdValueInit\X64\Output.txt
* Modify gEfiRedfishPkgTokenSpaceGuid.PcdRedfishRestExServiceDevicePath.DevicePath value, build again
* Check Build\EmulatorX64\DEBUG_VS2022\PcdValueInit\X64\Output.txt again

Output.txt should be modified

2.

* Move gEfiRedfishPkgTokenSpaceGuid.PcdRedfishRestExServiceDevicePath.DevicePath to RedfishPkg/RedfishHostInterfaceDxe/RedfishHostInterfaceDxe.inf module scop
* build twice and check if PcdValueInit always update

PcdValueInit should not be modified at second build

## Integration Instructions

N/A
