### PR TITLE
EmulatorPkg: Remove IA32 PR Gate CI Runs

### DIFF
--- a/EmulatorPkg/PlatformCI/.azurepipelines/Windows-VS.yml
+++ b/EmulatorPkg/PlatformCI/.azurepipelines/Windows-VS.yml
@@ -59,27 +59,6 @@ jobs:
             Build.Target: "NOOPT"
             Run.Flags: $(run_flags)
             Run: $(should_run)
-          EmulatorPkg_IA32_DEBUG:
-            Build.File: "$(package)/PlatformCI/PlatformBuild.py"
-            Build.Arch: "IA32 "
-            Build.Flags: "BLD_*_NO_PLATFORM_BOOT_DELAYS"
-            Build.Target: "DEBUG"
-            Run.Flags: $(run_flags)
-            Run: $(should_run)
-          EmulatorPkg_IA32_RELEASE:
-            Build.File: "$(package)/PlatformCI/PlatformBuild.py"
-            Build.Arch: "IA32 "
-            Build.Flags: "BLD_*_NO_PLATFORM_BOOT_DELAYS"
-            Build.Target: "RELEASE"
-            Run.Flags: $(run_flags)
-            Run: $(should_run)
-          EmulatorPkg_IA32_NOOPT:
-            Build.File: "$(package)/PlatformCI/PlatformBuild.py"
-            Build.Arch: "IA32 "
-            Build.Flags: "BLD_*_NO_PLATFORM_BOOT_DELAYS"
-            Build.Target: "NOOPT"
-            Run.Flags: $(run_flags)
-            Run: $(should_run)
           EmulatorPkg_X64_FULL_DEBUG:
             Build.File: "$(package)/PlatformCI/PlatformBuild.py"
             Build.Arch: "X64"
@@ -97,27 +76,6 @@ jobs:
           EmulatorPkg_X64_FULL_NOOPT:
             Build.File: "$(package)/PlatformCI/PlatformBuild.py"
             Build.Arch: "X64"
-            Build.Flags: "BLD_*_SECURE_BOOT_ENABLE=TRUE BLD_*_NO_PLATFORM_BOOT_DELAYS"
-            Build.Target: "NOOPT"
-            Run.Flags: $(run_flags)
-            Run: $(should_run)
-          EmulatorPkg_IA32_FULL_DEBUG:
-            Build.File: "$(package)/PlatformCI/PlatformBuild.py"
-            Build.Arch: "IA32"
-            Build.Flags: "BLD_*_SECURE_BOOT_ENABLE=TRUE BLD_*_NO_PLATFORM_BOOT_DELAYS"
-            Build.Target: "DEBUG"
-            Run.Flags: $(run_flags)
-            Run: $(should_run)
-          EmulatorPkg_IA32_FULL_RELEASE:
-            Build.File: "$(package)/PlatformCI/PlatformBuild.py"
-            Build.Arch: "IA32"
-            Build.Flags: "BLD_*_SECURE_BOOT_ENABLE=TRUE BLD_*_NO_PLATFORM_BOOT_DELAYS"
-            Build.Target: "RELEASE"
-            Run.Flags: $(run_flags)
-            Run: $(should_run)
-          EmulatorPkg_IA32_FULL_NOOPT:
-            Build.File: "$(package)/PlatformCI/PlatformBuild.py"
-            Build.Arch: "IA32"
             Build.Flags: "BLD_*_SECURE_BOOT_ENABLE=TRUE BLD_*_NO_PLATFORM_BOOT_DELAYS"
             Build.Target: "NOOPT"
             Run.Flags: $(run_flags)


### PR DESCRIPTION
# Description

As discussed in various forums, it has been agreed to remove EmulatorPkg IA32 from PR gate CI runs. If there is community interest, it can be run nightly and bugfixes accepted for it. IA32 DXE platforms are considered legacy and not a first class architecture in edk2.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

N/A.

## Integration Instructions

N/A.
