### PR TITLE
BaseTools: Add EDK_TOOLS_BUILD_PATH for tool output

### DIFF
--- a/BaseTools/BinWrappers/PosixLike/BrotliCompress
+++ b/BaseTools/BinWrappers/PosixLike/BrotliCompress
@@ -36,13 +36,13 @@ do
 done
 
 
-if [ -n "$WORKSPACE" ] && [ -e "$WORKSPACE/BaseTools/Build/Source/C/bin" ]
+if [ -n "$EDK_TOOLS_BUILD_PATH" ] && [ -e "$EDK_TOOLS_BUILD_PATH/Source/C/bin" ]
 then
-  if [ -e "$WORKSPACE/BaseTools/Build/Source/C/bin/$cmd" ]
+  if [ -e "$EDK_TOOLS_BUILD_PATH/Source/C/bin/$cmd" ]
   then
-    exec "$WORKSPACE/BaseTools/Build/Source/C/bin/$cmd" $QLT $ARGS
+    exec "$EDK_TOOLS_BUILD_PATH/Source/C/bin/$cmd" $QLT $ARGS
   fi
-eif [ -n "$EDK_TOOLS_PATH" ] && [ -e "$EDK_TOOLS_PATH/Source/C/bin" ]
+elif [ -n "$EDK_TOOLS_PATH" ] && [ -e "$EDK_TOOLS_PATH/Source/C/bin" ]
 then
   if [ -e "$EDK_TOOLS_PATH/Source/C/bin/$cmd" ]
   then

--- a/BaseTools/BinWrappers/PosixLike/GenericShellWrapper
+++ b/BaseTools/BinWrappers/PosixLike/GenericShellWrapper
@@ -4,11 +4,11 @@ full_cmd=${BASH_SOURCE[-1]:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for
 dir=$(dirname "$full_cmd")
 cmd=${full_cmd##*/}
 
-if [ -n "$WORKSPACE" ] && [ -e "$WORKSPACE/BaseTools/Build/Source/C/bin" ]
+if [ -n "$EDK_TOOLS_BUILD_PATH" ] && [ -e "$EDK_TOOLS_BUILD_PATH/Source/C/bin" ]
 then
-  if [ -e "$WORKSPACE/BaseTools/Build/Source/C/bin/$cmd" ]
+  if [ -e "$EDK_TOOLS_BUILD_PATH/Source/C/bin/$cmd" ]
   then
-    exec "$WORKSPACE/BaseTools/Build/Source/C/bin/$cmd" "$@"
+    exec "$EDK_TOOLS_BUILD_PATH/Source/C/bin/$cmd" "$@"
   fi
 elif [ -n "$EDK_TOOLS_PATH" ] && [ -e "$EDK_TOOLS_PATH/Source/C/bin" ]
 then

--- a/BaseTools/Source/C/GNUmakefile
+++ b/BaseTools/Source/C/GNUmakefile
@@ -13,8 +13,8 @@ else
   MAKEROOT := .
 endif
 
-ifneq ($(WORKSPACE),)
-  BUILDROOT=$(WORKSPACE)/BaseTools/Build/Source/C
+ifneq ($(EDK_TOOLS_BUILD_PATH),)
+  BUILDROOT=$(EDK_TOOLS_BUILD_PATH)/Source/C
 else
   BUILDROOT=$(abspath $(MAKEROOT))
 endif


### PR DESCRIPTION
# Description

Update BaseTools to opt-in to the out-of-tree builds of tools. If the EDK_TOOLS_BUILD_PATH environment
variable is not defined, then binary artifacts of the BaseTools C tools builds are generated in the BaseTools directory. If EDK_TOOLS_BUILD_PATH is defined, then the binary artifacts BaseTools C tools builds are
generated in path defined by the EDK_TOOLS_BUILD_PATH environment variable.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

Verify build without EDK_TOOLS_BUILD_PATH set generates tools in BaseTools and build with
EDK_TOOLS_BUILD_PATH set generate tools in that path.

## Integration Instructions

No change to preserve current BaseTools output behavior.

Set EDK_TOOLS_BUILD_PATH to specify an out-of-tree output path for BaseTools.
