### PR TITLE
[edk2-stable202602] BaseTools revert out of tree builds

### DIFF
--- a/BaseTools/BinWrappers/PosixLike/BrotliCompress
+++ b/BaseTools/BinWrappers/PosixLike/BrotliCompress
@@ -36,13 +36,7 @@ do
 done
 
 
-if [ -n "$WORKSPACE" ] && [ -e "$WORKSPACE/BaseTools/Build/Source/C/bin" ]
-then
-  if [ -e "$WORKSPACE/BaseTools/Build/Source/C/bin/$cmd" ]
-  then
-    exec "$WORKSPACE/BaseTools/Build/Source/C/bin/$cmd" $QLT $ARGS
-  fi
-eif [ -n "$EDK_TOOLS_PATH" ] && [ -e "$EDK_TOOLS_PATH/Source/C/bin" ]
+if [ -n "$EDK_TOOLS_PATH" ] && [ -e "$EDK_TOOLS_PATH/Source/C/bin" ]
 then
   if [ -e "$EDK_TOOLS_PATH/Source/C/bin/$cmd" ]
   then

--- a/BaseTools/BinWrappers/PosixLike/GenericShellWrapper
+++ b/BaseTools/BinWrappers/PosixLike/GenericShellWrapper
@@ -4,13 +4,7 @@ full_cmd=${BASH_SOURCE[-1]:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for
 dir=$(dirname "$full_cmd")
 cmd=${full_cmd##*/}
 
-if [ -n "$WORKSPACE" ] && [ -e "$WORKSPACE/BaseTools/Build/Source/C/bin" ]
-then
-  if [ -e "$WORKSPACE/BaseTools/Build/Source/C/bin/$cmd" ]
-  then
-    exec "$WORKSPACE/BaseTools/Build/Source/C/bin/$cmd" "$@"
-  fi
-elif [ -n "$EDK_TOOLS_PATH" ] && [ -e "$EDK_TOOLS_PATH/Source/C/bin" ]
+if [ -n "$EDK_TOOLS_PATH" ] && [ -e "$EDK_TOOLS_PATH/Source/C/bin" ]
 then
   if [ -e "$EDK_TOOLS_PATH/Source/C/bin/$cmd" ]
   then

--- a/BaseTools/Source/C/GNUmakefile
+++ b/BaseTools/Source/C/GNUmakefile
@@ -13,12 +13,6 @@ else
   MAKEROOT := .
 endif
 
-ifneq ($(WORKSPACE),)
-  BUILDROOT=$(WORKSPACE)/BaseTools/Build/Source/C
-else
-  BUILDROOT=$(abspath $(MAKEROOT))
-endif
-
 include Makefiles/header.makefile
 
 export PYTHON_COMMAND
@@ -44,29 +38,28 @@ APPLICATIONS = \
 
 SUBDIRS := $(LIBRARIES) $(APPLICATIONS)
 
-$(LIBRARIES): $(BUILDROOT)/libs
-$(APPLICATIONS): $(LIBRARIES) $(BUILDROOT)/bin
+$(LIBRARIES): $(MAKEROOT)/libs
+$(APPLICATIONS): $(LIBRARIES) $(MAKEROOT)/bin
 
 .PHONY: outputdirs
 makerootdir:
-	-$(MD) $(BUILDROOT)
+	-$(MD) $(MAKEROOT)
 
 .PHONY: subdirs $(SUBDIRS)
 subdirs: $(SUBDIRS)
 $(SUBDIRS):
-	-$(MD) $(BUILDROOT)/$@
-	$(MAKE) OBJDIR=$(BUILDROOT)/$@ BUILDROOT=$(BUILDROOT) -C $@
+	$(MAKE) -C $@
 
 .PHONY: $(patsubst %,%-clean,$(sort $(SUBDIRS)))
 $(patsubst %,%-clean,$(sort $(SUBDIRS))):
-	-$(MAKE) OBJDIR=$(BUILDROOT)/$(@:-clean=) BUILDROOT=$(BUILDROOT) -C $(@:-clean=) clean
+	-$(MAKE) -C $(@:-clean=) clean
 
 clean:  $(patsubst %,%-clean,$(sort $(SUBDIRS)))
 
 clean: localClean
 
 localClean:
-	$(RM) $(BUILDROOT)/bin/*
-	-$(RD) $(BUILDROOT)/libs $(BUILDROOT)/bin
+	$(RM) $(MAKEROOT)/bin/*
+	-$(RD) $(MAKEROOT)/libs $(MAKEROOT)/bin
 
 include Makefiles/footer.makefile

--- a/BaseTools/Source/C/Makefiles/app.makefile
+++ b/BaseTools/Source/C/Makefiles/app.makefile
@@ -6,19 +6,16 @@
 #
 
 MAKEROOT ?= ../..
-BUILDROOT ?= $(MAKEROOT)
-OBJDIR ?= .
-OBJECTS := $(addprefix $(OBJDIR)/,$(OBJECTS))
 
 include $(MAKEROOT)/Makefiles/header.makefile
 
-APPLICATION = $(BUILDROOT)/bin/$(APPNAME)
+APPLICATION = $(MAKEROOT)/bin/$(APPNAME)
 
 .PHONY:all
-all: $(BUILDROOT)/bin $(APPLICATION)
+all: $(MAKEROOT)/bin $(APPLICATION)
 
 $(APPLICATION): $(OBJECTS)
-	$(LINKER) -o $(APPLICATION) $(LDFLAGS) $(OBJECTS) -L$(BUILDROOT)/libs $(LIBS)
+	$(LINKER) -o $(APPLICATION) $(LDFLAGS) $(OBJECTS) -L$(MAKEROOT)/libs $(LIBS)
 ifeq (Windows, $(findstring Windows,$(OS)))
 	$(CP) $(APPLICATION).exe $(BIN_PATH)
 endif

--- a/BaseTools/Source/C/Makefiles/footer.makefile
+++ b/BaseTools/Source/C/Makefiles/footer.makefile
@@ -7,37 +7,24 @@
 
 DEPFILES = $(OBJECTS:%.o=%.d)
 
-$(BUILDROOT)/libs-$(HOST_ARCH):
-	$(MD) $(BUILDROOT)/libs-$(HOST_ARCH)
+$(MAKEROOT)/libs-$(HOST_ARCH):
+	$(MD) $(MAKEROOT)/libs-$(HOST_ARCH)
 
 .PHONY: install
-install: $(BUILDROOT)/libs-$(HOST_ARCH) $(LIBRARY)
-	$(CP) $(LIBRARY) $(BUILDROOT)/libs-$(HOST_ARCH)
+install: $(MAKEROOT)/libs-$(HOST_ARCH) $(LIBRARY)
+	$(CP) $(LIBRARY) $(MAKEROOT)/libs-$(HOST_ARCH)
 
 $(LIBRARY): $(OBJECTS)
 	$(AR) crs $@ $^
 
-$(OBJDIR)/%.o : %.c
-	@$(MD) $(@D)
+%.o : %.c
 	$(CC)  -c $(CPPFLAGS) $(CFLAGS) $< -o $@
 
-$(OBJDIR)/%.o : %.cpp
-	@$(MD) $(@D)
+%.o : %.cpp
 	$(CXX) -c $(CPPFLAGS) $(CXXFLAGS) $< -o $@
-
-$(OBJECTS): | $(OBJDIR)
-
-$(OBJDIR)/%.d : %.c
-	@set -e; rm -f $@; \
-		$(MD) $(@D); \
-		$(CC) -M $(CPPFLAGS) $< > $@.$$$$; \
-		sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' < $@.$$$$ > $@; \
-		rm -f $@.$$$$
 
 .PHONY: clean
 clean:
 	$(RM) $(OBJECTS) $(LIBRARY) $(DEPFILES)
 
-ifneq ($(MAKECMDGOALS), clean)
 -include $(DEPFILES)
-endif

--- a/BaseTools/Source/C/Makefiles/header.makefile
+++ b/BaseTools/Source/C/Makefiles/header.makefile
@@ -206,16 +206,11 @@ LDFLAGS += $(EXTRA_LDFLAGS)
 
 all:
 
-$(BUILDROOT)/libs:
-	$(MD) $(BUILDROOT)/libs
+$(MAKEROOT)/libs:
+	$(MD) $(MAKEROOT)/libs
 
-$(BUILDROOT)/bin:
-	$(MD) $(BUILDROOT)/bin
+$(MAKEROOT)/bin:
+	$(MD) $(MAKEROOT)/bin
 ifeq (Windows, $(findstring Windows,$(OS)))
 	$(MD) $(BIN_PATH)
-endif
-
-ifdef OBJDIR
-$(OBJDIR):
-	$(MD) $(OBJDIR)
 endif

--- a/BaseTools/Source/C/Makefiles/lib.makefile
+++ b/BaseTools/Source/C/Makefiles/lib.makefile
@@ -5,14 +5,10 @@
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 
-BUILDROOT ?= $(MAKEROOT)
-OBJDIR ?= .
-OBJECTS := $(addprefix $(OBJDIR)/,$(OBJECTS))
-
 include $(MAKEROOT)/Makefiles/header.makefile
 
-LIBRARY = $(BUILDROOT)/libs/lib$(LIBNAME).a
+LIBRARY = $(MAKEROOT)/libs/lib$(LIBNAME).a
 
-all: $(BUILDROOT)/libs $(LIBRARY)
+all: $(MAKEROOT)/libs $(LIBRARY)
 
 include $(MAKEROOT)/Makefiles/footer.makefile

--- a/BaseTools/Source/C/VfrCompile/GNUmakefile
+++ b/BaseTools/Source/C/VfrCompile/GNUmakefile
@@ -8,16 +8,14 @@
 MAKEROOT ?= ..
 
 APPNAME = VfrCompile
-BUILDROOT ?= $(MAKEROOT)
-OBJDIR ?= $(abspath .)
 
 LIBS = -lCommon
 
 TOOL_INCLUDE = -I Pccts/h
 
+#OBJECTS = VfrSyntax.o VfrServices.o DLGLexer.o EfiVfrParser.o ATokenBuffer.o DLexerBase.o AParser.o
 OBJECTS = AParser.o DLexerBase.o ATokenBuffer.o EfiVfrParser.o VfrLexer.o VfrSyntax.o \
           VfrFormPkg.o VfrError.o VfrUtilityLib.o VfrCompiler.o
-OBJECTS := $(addprefix $(OBJDIR)/,$(OBJECTS))
 CLANG := $(findstring clang,$(shell $(CC) --version))
 ifneq ($(CLANG),)
 VFR_CPPFLAGS = -Wno-deprecated-register -std=c++14 -DPCCTS_USE_NAMESPACE_STD $(CPPFLAGS)
@@ -32,18 +30,22 @@ VFR_LFLAGS = $(EXTRA_LDFLAGS)
 
 LINKER = $(CXX)
 
+EXTRA_CLEAN_OBJECTS = EfiVfrParser.cpp EfiVfrParser.h VfrParser.dlg VfrTokens.h VfrLexer.cpp VfrLexer.h VfrSyntax.cpp tokens.h
+
+MAKEROOT ?= ../..
+
 include $(MAKEROOT)/Makefiles/header.makefile
 
-APPLICATION = $(BUILDROOT)/bin/$(APPNAME)
+APPLICATION = $(MAKEROOT)/bin/$(APPNAME)
 
-BIN_DIR=$(OBJDIR)
+BIN_DIR=.
 export BIN_DIR
 
 .PHONY:all
-all: $(BUILDROOT)/bin $(APPLICATION)
+all: $(MAKEROOT)/bin $(APPLICATION)
 
 $(APPLICATION): $(OBJECTS)
-	$(LINKER) -o $(APPLICATION) $(VFR_LFLAGS) $(OBJECTS) -L$(BUILDROOT)/libs $(LIBS)
+	$(LINKER) -o $(APPLICATION) $(VFR_LFLAGS) $(OBJECTS) -L$(MAKEROOT)/libs $(LIBS)
 ifeq (Windows, $(findstring Windows,$(OS)))
 	$(CP) $(APPLICATION).exe $(BIN_PATH)
 endif
@@ -52,42 +54,35 @@ VfrCompiler.o: ../Include/Common/BuildVersion.h
 
 include $(MAKEROOT)/Makefiles/footer.makefile
 
-GEN_SYNTAX_FILES := $(addprefix $(OBJDIR)/,VfrSyntax.cpp EfiVfrParser.cpp EfiVfrParser.h VfrParser.dlg VfrTokens.h)
-$(GEN_SYNTAX_FILES): $(OBJDIR)/antlr VfrSyntax.g
-	$(OBJDIR)/antlr -CC -e3 -ck 3 -k 2 -fl VfrParser.dlg -ft VfrTokens.h -o $(OBJDIR) VfrSyntax.g
+VfrSyntax.cpp EfiVfrParser.cpp EfiVfrParser.h VfrParser.dlg VfrTokens.h: Pccts/antlr/antlr VfrSyntax.g
+	Pccts/antlr/antlr -CC -e3 -ck 3 -k 2 -fl VfrParser.dlg -ft VfrTokens.h -o . VfrSyntax.g
 
-GEN_LEXER_FILES := $(addprefix $(OBJDIR)/,VfrLexer.cpp VfrLexer.h)
-$(GEN_LEXER_FILES): $(OBJDIR)/dlg $(OBJDIR)/VfrParser.dlg
-	$(OBJDIR)/dlg -C2 -i -CC -cl VfrLexer -o $(OBJDIR) $(OBJDIR)/VfrParser.dlg
+VfrLexer.cpp VfrLexer.h: Pccts/dlg/dlg VfrParser.dlg
+	Pccts/dlg/dlg -C2 -i -CC -cl VfrLexer -o . VfrParser.dlg
 
-EXTRA_CLEAN_OBJECTS = $(GEN_SYNTAX_FILES) $(GEN_LEXER_FILES)
+Pccts/antlr/antlr:
+	$(MAKE) -C Pccts/antlr
 
-$(OBJDIR)/Pccts/antlr $(OBJDIR)/Pccts/dlg:
-	$(MD) $@
+Pccts/dlg/dlg:
+	$(MAKE) -C Pccts/dlg
 
-$(OBJDIR)/antlr: | $(OBJDIR)/Pccts/antlr
-	$(MAKE) OBJDIR=$(OBJDIR)/Pccts/antlr -C Pccts/antlr
-
-$(OBJDIR)/dlg: | $(OBJDIR)/Pccts/dlg
-	$(MAKE) OBJDIR=$(OBJDIR)/Pccts/dlg -C Pccts/dlg
-
-$(OBJDIR)/ATokenBuffer.o: Pccts/h/ATokenBuffer.cpp
+ATokenBuffer.o: Pccts/h/ATokenBuffer.cpp
 	$(CXX) -c $(VFR_CPPFLAGS) $(INC) $(VFR_CXXFLAGS) $? -o $@
 
-$(OBJDIR)/DLexerBase.o: Pccts/h/DLexerBase.cpp
+DLexerBase.o: Pccts/h/DLexerBase.cpp
 	$(CXX) -c $(VFR_CPPFLAGS) $(INC) $(VFR_CXXFLAGS) $? -o $@
 
-$(OBJDIR)/AParser.o: Pccts/h/AParser.cpp
+AParser.o: Pccts/h/AParser.cpp
 	$(CXX) -c $(VFR_CPPFLAGS) $(INC) $(VFR_CXXFLAGS) $? -o $@
 
-$(OBJDIR)/VfrSyntax.o: $(OBJDIR)/VfrSyntax.cpp
+VfrSyntax.o: VfrSyntax.cpp
 	$(CXX) -c $(VFR_CPPFLAGS) $(INC) $(VFR_CXXFLAGS) $? -o $@
 
 clean: localClean
 
 localClean:
-	$(MAKE) OBJDIR=$(OBJDIR)/Pccts/antlr -C Pccts/antlr clean
-	$(MAKE) OBJDIR=$(OBJDIR)/Pccts/dlg -C Pccts/dlg clean
+	$(MAKE) -C Pccts/antlr clean
+	$(MAKE) -C Pccts/dlg clean
 	$(RM) $(EXTRA_CLEAN_OBJECTS)
 ifeq (Windows, $(findstring Windows,$(OS)))
 	$(RM) $(BIN_PATH)/$(APPNAME).exe

--- a/BaseTools/Source/C/VfrCompile/Pccts/antlr/makefile
+++ b/BaseTools/Source/C/VfrCompile/Pccts/antlr/makefile
@@ -184,7 +184,6 @@ CPPFLAGS=
 #CFLAGS= -O -I. -I$(SET) -I$(PCCTS_H) -DUSER_ZZSYN -woff 3262
 OBJ=antlr.o scan.o err.o bits.o build.o fset2.o fset.o gen.o  \
         globals.o hash.o lex.o main.o misc.o set.o pred.o egman.o mrhoist.o fcache.o
-OBJ := $(addprefix $(OBJDIR)/,$(OBJ))
 
 $(BIN_DIR)/antlr : $(OBJ) $(SRC)
 		$(CC) $(CFLAGS) -o $(BIN_DIR)/antlr $(OBJ)
@@ -202,17 +201,17 @@ SRC=antlr.c scan.c err.c bits.c build.c fset2.c fset.c gen.c globals.c \
 #antlr.c stdpccts.h parser.dlg tokens.h err.c : antlr.g
 #	$(ANTLR) -gh antlr.g
 
-$(OBJDIR)/antlr.o : antlr.c mode.h tokens.h
+antlr.o : antlr.c mode.h tokens.h
 
-$(OBJDIR)/scan.o : scan.c mode.h tokens.h
+scan.o : scan.c mode.h tokens.h
 
 #scan.c mode.h: parser.dlg
 #	$(DLG) -C2 parser.dlg scan.c
 
-$(OBJDIR)/set.o : $(SET)/set.c
-	$(CC) $(CFLAGS) -c -o $@ $<
+set.o : $(SET)/set.c
+	$(CC) $(CFLAGS) -c -o set.o $(SET)/set.c
 
-$(OBJDIR)/%.o : %.c
+%.o : %.c
 	$(CC) -c $(CFLAGS) $(CPPFLAGS) $< -o $@
 
 #
@@ -221,7 +220,7 @@ $(OBJDIR)/%.o : %.c
 
 #clean up all the intermediate files
 clean:
-	$(RM) $(BIN_DIR)$(SEP)antlr $(OBJDIR)$(SEP)*.$(OBJ_EXT) core
+	$(RM) $(BIN_DIR)$(SEP)antlr *.$(OBJ_EXT) core
 
 #remove everything in clean plus the PCCTS files generated
 scrub:

--- a/BaseTools/Source/C/VfrCompile/Pccts/dlg/makefile
+++ b/BaseTools/Source/C/VfrCompile/Pccts/dlg/makefile
@@ -137,7 +137,6 @@ OBJ_EXT=o
 OUT_OBJ = -o
 OBJ = dlg_p.o dlg_a.o main.o err.o set.o support.o output.o \
         relabel.o automata.o
-OBJ := $(addprefix $(OBJDIR)/,$(OBJ))
 
 $(BIN_DIR)/dlg : $(OBJ) $(SRC)
 		$(CC) $(CFLAGS) -o $(BIN_DIR)/dlg $(OBJ)
@@ -151,19 +150,19 @@ SRC = dlg_p.c dlg_a.c main.c err.c $(SET)/set.c support.c output.c \
 #dlg_a.c mode.h : parser.dlg
 #	$(DLG) -C2 parser.dlg dlg_a.c
 
-$(OBJDIR)/dlg_p.$(OBJ_EXT) : dlg_p.c dlg.h tokens.h mode.h
-	$(CC) $(CFLAGS) -o $@ -c dlg_p.c
+dlg_p.$(OBJ_EXT) : dlg_p.c dlg.h tokens.h mode.h
+	$(CC) $(CFLAGS) -c dlg_p.c
 
-$(OBJDIR)/dlg_a.$(OBJ_EXT) : dlg_a.c dlg.h tokens.h mode.h
-	$(CC) $(CFLAGS) -o $@ -c dlg_a.c
+dlg_a.$(OBJ_EXT) : dlg_a.c dlg.h tokens.h mode.h
+	$(CC) $(CFLAGS) -c dlg_a.c
 
-$(OBJDIR)/main.$(OBJ_EXT) : main.c dlg.h
-	$(CC) $(CFLAGS) -o $@ -c main.c
+main.$(OBJ_EXT) : main.c dlg.h
+	$(CC) $(CFLAGS) -c main.c
 
-$(OBJDIR)/set.$(OBJ_EXT) : $(SET)/set.c
-	$(CC) -c $(CFLAGS) -o $@ $(SET)/set.c
+set.$(OBJ_EXT) : $(SET)/set.c
+	$(CC) -c $(CFLAGS) $(SET)/set.c
 
-$(OBJDIR)/%.o : %.c
+%.o : %.c
 	$(CC) -c $(CFLAGS) $(CPPFLAGS) $< -o $@
 
 lint:
@@ -171,4 +170,4 @@ lint:
 
 #clean up all the intermediate files
 clean:
-	$(RM) $(BIN_DIR)$(SEP)dlg $(OBJDIR)$(SEP)*.$(OBJ_EXT) core
+	$(RM) $(BIN_DIR)$(SEP)dlg *.$(OBJ_EXT) core

--- a/BaseTools/Source/Python/Workspace/DscBuildData.py
+++ b/BaseTools/Source/Python/Workspace/DscBuildData.py
@@ -2942,8 +2942,7 @@ class DscBuildData(PlatformBuildClassObject):
         else:
             AppSuffix = '.exe' if sys.platform == "win32" else ''
             MakeApp = MakeApp + PcdGccMakefile
-            MakeApp = MakeApp + 'OBJDIR = %s\n' % self.OutputPath
-            MakeApp = MakeApp + 'APPFILE = %s%s%s%s\n' % (self.OutputPath, os.sep, PcdValueInitName, AppSuffix) + 'APPNAME = %s\n' % (PcdValueInitName) + 'OBJECTS = %s.o %s.o\n' % (PcdValueInitName, PcdValueCommonName) + \
+            MakeApp = MakeApp + 'APPFILE = %s%s%s%s\n' % (self.OutputPath, os.sep, PcdValueInitName, AppSuffix) + 'APPNAME = %s\n' % (PcdValueInitName) + 'OBJECTS = %s/%s.o %s.o\n' % (self.OutputPath, PcdValueInitName, os.path.join(self.OutputPath, PcdValueCommonName)) + \
                     'include $(MAKEROOT)/Makefiles/app.makefile\n' + 'TOOL_INCLUDE +='
 
         IncSearchList = []


### PR DESCRIPTION
# Description

Revert "BaseTools: Add support for out-of-tree builds"

This reverts commit 3fe1d56cc98e011bbde8348f13dfa5e38c95f49e and f0542ae07d5e5e4d311bf8ae33bf26b4b1acf9f4.

PR https://github.com/tianocore/edk2/pull/11757 introduced a "Breaking Change" feature for out of tree builds of tools.

This breaking change is blocking testing of edk2-stable202602 due to side effects on building FitGen tool in edk2-platforms.

Revert this feature for the edk2-stable202602 release and work on this feature after the release.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

Verified BaseTools builds from Windows and Liniux work after this change

## Integration Instructions

N/A