### PR TITLE
OvmfPkg/IntelTdx: disable shell by default

### DIFF
--- a/OvmfPkg/IntelTdx/IntelTdxX64.dsc
+++ b/OvmfPkg/IntelTdx/IntelTdxX64.dsc
@@ -34,7 +34,7 @@
   #
   # Shell can be useful for debugging but should not be enabled for production
   #
-  DEFINE BUILD_SHELL             = TRUE
+  DEFINE BUILD_SHELL             = FALSE
 
   #
   # Device drivers


### PR DESCRIPTION
Comment says it shouldn't be enabled for production. A secure default is likely more sane for TDX.

# Description

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Applied patch downstream and omitted previously used `-DBUILD_SHELL=FALSE`.

## Integration Instructions

Users who previously built  without `-DBUILD_SHELL=FALSE` do need to explicitly enable shell via `-DBUILD_SHELL=TRUE` if they want to keep that behavior.
