### PR TITLE
Fix string comparisons in python

### DIFF
--- a/BaseTools/Source/Python/FMMT/core/BiosTree.py
+++ b/BaseTools/Source/Python/FMMT/core/BiosTree.py
@@ -28,9 +28,9 @@ PECOFF_TREE = 'PECOFF_TREE'
 RootType = [ROOT_TREE, ROOT_FV_TREE, ROOT_FFS_TREE, ROOT_SECTION_TREE]
 FvType = [FV_TREE, SEC_FV_TREE]
 FfsType = [FFS_TREE, FFS_PAD]
-SecType = SECTION_TREE
+SecType = [SECTION_TREE]
 ElfType = [ROOT_ELF_TREE, ELF_TREE]
-PeCoffTree = PECOFF_TREE
+PeCoffTree = [PECOFF_TREE]
 
 class BIOSTREE:
     def __init__(self, NodeName: str) -> None:
@@ -250,3 +250,4 @@ class BIOSTREE:
             TreeInfo[key].setdefault('Files',[]).append( item.ExportTree())
 
         return TreeInfo
+


### PR DESCRIPTION
# Description

The old comparisons worked by luck that none of them were a sub-string
of another. This fixes that.

In python `'ABC' in 'ABC'` is True, but so is `'AB' in 'ABC'`.
The old code checked the type of data using (in some cases) code like
`Type in TypeStr`, which would erroneously evaluate to True if `Type`
was a substring of `TypeStr`.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

## Integration Instructions
