### PR TITLE
SecurityPkg: Move Platform Lockdown to EndOfDxe event

### DIFF
--- a/SecurityPkg/Tcg/Tcg2PlatformDxe/Tcg2PlatformDxe.inf
+++ b/SecurityPkg/Tcg/Tcg2PlatformDxe/Tcg2PlatformDxe.inf
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
-###
+##
 
 [Defines]
   INF_VERSION                    = 0x00010017
@@ -25,6 +25,7 @@
   UefiBootServicesTableLib
   UefiDriverEntryPoint
   DebugLib
+  HobLib
   UefiLib
   TpmPlatformHierarchyLib
 
@@ -36,8 +37,8 @@
 [Sources]
   Tcg2PlatformDxe.c
 
-[Protocols]
-  gEfiDxeSmmReadyToLockProtocolGuid             ## SOMETIMES_CONSUMES ## NOTIFY
+[Guids]
+  gEfiEndOfDxeEventGroupGuid             ## SOMETIMES_CONSUMES ## NOTIFY
 
 [Depex]
   gEfiTcg2ProtocolGuid


### PR DESCRIPTION
# Description

TPM update flows typically require Platform Auth and typically capsule processor runs in BDS, so deferring until ReadyToBoot in BOOT_ON_FLASH_UPDATE permits TPM capsule update to complete.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Ran CI locally

## Integration Instructions

N/A
