### PR TITLE
OvmfPkg/IntelTdx: add TdxDxeCpuExceptionHandlerLib for IST skip

### DIFF
--- a/OvmfPkg/IntelTdx/IntelTdxX64.dsc
+++ b/OvmfPkg/IntelTdx/IntelTdxX64.dsc
@@ -252,7 +252,7 @@
   DebugLib|OvmfPkg/Library/PlatformDebugLibIoPort/PlatformDebugLibIoPort.inf
 !endif
   ExtractGuidedSectionLib|MdePkg/Library/DxeExtractGuidedSectionLib/DxeExtractGuidedSectionLib.inf
-  CpuExceptionHandlerLib|UefiCpuPkg/Library/CpuExceptionHandlerLib/DxeCpuExceptionHandlerLib.inf
+  CpuExceptionHandlerLib|OvmfPkg/IntelTdx/TdxCpuExceptionHandlerLib/TdxDxeCpuExceptionHandlerLib.inf
   PcdLib|MdePkg/Library/DxePcdLib/DxePcdLib.inf
 
 [LibraryClasses.common.DXE_RUNTIME_DRIVER]
@@ -308,7 +308,7 @@
   PlatformBmPrintScLib|OvmfPkg/Library/PlatformBmPrintScLib/PlatformBmPrintScLib.inf
   QemuBootOrderLib|OvmfPkg/Library/QemuBootOrderLib/QemuBootOrderLib.inf
   PlatformBootManagerCommonLib|OvmfPkg/Library/PlatformBootManagerCommonLib/PlatformBootManagerCommonLib.inf
-  CpuExceptionHandlerLib|UefiCpuPkg/Library/CpuExceptionHandlerLib/DxeCpuExceptionHandlerLib.inf
+  CpuExceptionHandlerLib|OvmfPkg/IntelTdx/TdxCpuExceptionHandlerLib/TdxDxeCpuExceptionHandlerLib.inf
   LockBoxLib|OvmfPkg/Library/LockBoxLib/LockBoxDxeLib.inf
   PciLib|OvmfPkg/Library/DxePciLibI440FxQ35/DxePciLibI440FxQ35.inf
   MpInitLib|UefiCpuPkg/Library/MpInitLib/DxeMpInitLib.inf

--- a/OvmfPkg/IntelTdx/TdxCpuExceptionHandlerLib/DxeException.c
+++ b/OvmfPkg/IntelTdx/TdxCpuExceptionHandlerLib/DxeException.c
@@ -1,0 +1,138 @@
+/** @file
+  CPU exception handler library implementation for DXE modules.
+  TDX-aware variant: skips IST setup when running as a TDX guest.
+
+  Copyright (c) 2013 - 2022, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <PiDxe.h>
+#include "CpuExceptionCommon.h"
+#include <Library/DebugLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/UefiBootServicesTableLib.h>
+
+CONST UINTN  mDoFarReturnFlag = 0;
+
+RESERVED_VECTORS_DATA      mReservedVectorsData[CPU_INTERRUPT_NUM];
+EFI_CPU_INTERRUPT_HANDLER  mExternalInterruptHandlerTable[CPU_INTERRUPT_NUM];
+EXCEPTION_HANDLER_DATA     mExceptionHandlerData = {
+  CPU_INTERRUPT_NUM,
+  0,                     // To be fixed
+  mReservedVectorsData,
+  mExternalInterruptHandlerTable
+};
+
+UINT8  mBuffer[CPU_STACK_SWITCH_EXCEPTION_NUMBER * CPU_KNOWN_GOOD_STACK_SIZE
+               + CPU_TSS_GDT_SIZE];
+
+/**
+  Common exception handler.
+
+  @param ExceptionType  Exception type.
+  @param SystemContext  Pointer to EFI_SYSTEM_CONTEXT.
+**/
+VOID
+EFIAPI
+CommonExceptionHandler (
+  IN EFI_EXCEPTION_TYPE  ExceptionType,
+  IN EFI_SYSTEM_CONTEXT  SystemContext
+  )
+{
+  CommonExceptionHandlerWorker (ExceptionType, SystemContext, &mExceptionHandlerData);
+}
+
+/**
+  Initializes all CPU exceptions entries and provides the default exception handlers.
+
+  Caller should try to get an array of interrupt and/or exception vectors that are in use and need to
+  persist by EFI_VECTOR_HANDOFF_INFO defined in PI 1.3 specification.
+  If caller cannot get reserved vector list or it does not exists, set VectorInfo to NULL.
+  If VectorInfo is not NULL, the exception vectors will be initialized per vector attribute accordingly.
+
+  @param[in]  VectorInfo    Pointer to reserved vector list.
+
+  @retval EFI_SUCCESS           CPU Exception Entries have been successfully initialized
+                                with default exception handlers.
+  @retval EFI_INVALID_PARAMETER VectorInfo includes the invalid content if VectorInfo is not NULL.
+  @retval EFI_UNSUPPORTED       This function is not supported.
+
+**/
+EFI_STATUS
+EFIAPI
+InitializeCpuExceptionHandlers (
+  IN EFI_VECTOR_HANDOFF_INFO  *VectorInfo OPTIONAL
+  )
+{
+  InitializeSpinLock (&mExceptionHandlerData.DisplayMessageSpinLock);
+  return InitializeCpuExceptionHandlersWorker (VectorInfo, &mExceptionHandlerData);
+}
+
+/**
+  Registers a function to be called from the processor interrupt handler.
+
+  This function registers and enables the handler specified by InterruptHandler for a processor
+  interrupt or exception type specified by InterruptType. If InterruptHandler is NULL, then the
+  handler for the processor interrupt or exception type specified by InterruptType is uninstalled.
+  The installed handler is called once for each processor interrupt or exception.
+  NOTE: This function should be invoked after InitializeCpuExceptionHandlers() is invoked,
+  otherwise EFI_UNSUPPORTED returned.
+
+  @param[in]  InterruptType     Defines which interrupt or exception to hook.
+  @param[in]  InterruptHandler  A pointer to a function of type EFI_CPU_INTERRUPT_HANDLER that is called
+                                when a processor interrupt occurs. If this parameter is NULL, then the handler
+                                will be uninstalled.
+
+  @retval EFI_SUCCESS           The handler for the processor interrupt was successfully installed or uninstalled.
+  @retval EFI_ALREADY_STARTED   InterruptHandler is not NULL, and a handler for InterruptType was
+                                previously installed.
+  @retval EFI_INVALID_PARAMETER InterruptHandler is NULL, and a handler for InterruptType was not
+                                previously installed.
+  @retval EFI_UNSUPPORTED       The interrupt specified by InterruptType is not supported,
+                                or this function is not supported.
+**/
+EFI_STATUS
+EFIAPI
+RegisterCpuInterruptHandler (
+  IN EFI_EXCEPTION_TYPE         InterruptType,
+  IN EFI_CPU_INTERRUPT_HANDLER  InterruptHandler
+  )
+{
+  return RegisterCpuInterruptHandlerWorker (InterruptType, InterruptHandler, &mExceptionHandlerData);
+}
+
+/**
+  Setup separate stacks for certain exception handlers.
+  If the input Buffer and BufferSize are both NULL, use global variable if possible.
+
+  This library is built exclusively for TDX guests, where the LTR (Load Task
+  Register) instruction causes an unconditional #UD.  The initial TD vCPU state
+  per the Intel TDX architecture specification has TR.Selector = 0 and
+  TR.Base = 0, so there is no usable TSS to write IST entries into.  IST-based
+  separate exception stacks cannot be configured inside a TDX guest.
+
+  @param[in]       Buffer        Point to buffer used to separate exception stack.
+  @param[in, out]  BufferSize    On input, it indicates the byte size of Buffer.
+                                 If the size is not enough, the return status will
+                                 be EFI_BUFFER_TOO_SMALL, and output BufferSize
+                                 will be the size it needs.
+
+  @retval EFI_SUCCESS             The stacks are assigned successfully.
+  @retval EFI_UNSUPPORTED         This function is not supported.
+  @retval EFI_BUFFER_TOO_SMALL    This BufferSize is too small.
+**/
+EFI_STATUS
+EFIAPI
+InitializeSeparateExceptionStacks (
+  IN     VOID   *Buffer,
+  IN OUT UINTN  *BufferSize
+  )
+{
+  //
+  // LTR is not permitted inside a TDX guest (#UD). The initial TDX vCPU
+  // state has TR.Selector = 0 and TR.Base = 0, so no usable TSS exists to
+  // write IST entries into.  Skip IST setup entirely.
+  //
+  return EFI_SUCCESS;
+}

--- a/OvmfPkg/IntelTdx/TdxCpuExceptionHandlerLib/TdxDxeCpuExceptionHandlerLib.inf
+++ b/OvmfPkg/IntelTdx/TdxCpuExceptionHandlerLib/TdxDxeCpuExceptionHandlerLib.inf
@@ -1,0 +1,62 @@
+## @file
+#  CPU Exception Handler library instance for DXE modules.
+#  This is a TDX-aware override of UefiCpuPkg DxeCpuExceptionHandlerLib.
+#  IST-based separate exception stacks are skipped for TDX guests because
+#  LTR is not permitted inside a TDX guest and TR.Base is always 0 at entry.
+#
+#  Copyright (c) 2013 - 2018, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2024, Loongson Technology Corporation Limited. All rights reserved.<BR>
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = TdxDxeCpuExceptionHandlerLib
+  FILE_GUID                      = 53CF3DC8-5A73-4B0A-A1BA-C7E8DC4DD26B
+  MODULE_TYPE                    = DXE_DRIVER
+  VERSION_STRING                 = 1.1
+  LIBRARY_CLASS                  = CpuExceptionHandlerLib|DXE_CORE DXE_DRIVER UEFI_APPLICATION
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = X64
+#
+
+[Sources.X64]
+  ../../../UefiCpuPkg/Library/CpuExceptionHandlerLib/X64/ArchExceptionHandler.c
+  ../../../UefiCpuPkg/Library/CpuExceptionHandlerLib/X64/ArchInterruptDefs.h
+  ../../../UefiCpuPkg/Library/CpuExceptionHandlerLib/X64/ExceptionHandlerAsm.nasm
+
+[Sources]
+  ../../../UefiCpuPkg/Library/CpuExceptionHandlerLib/CpuExceptionCommon.h
+  ../../../UefiCpuPkg/Library/CpuExceptionHandlerLib/CpuExceptionCommon.c
+  ../../../UefiCpuPkg/Library/CpuExceptionHandlerLib/PeiDxeSmmCpuException.c
+  DxeException.c
+
+[Pcd]
+  gEfiMdeModulePkgTokenSpaceGuid.PcdCpuStackGuard
+  gUefiCpuPkgTokenSpaceGuid.PcdCpuStackSwitchExceptionList
+  gUefiCpuPkgTokenSpaceGuid.PcdCpuKnownGoodStackSize
+
+[FeaturePcd]
+  gUefiCpuPkgTokenSpaceGuid.PcdCpuSmmStackGuard                    ## CONSUMES
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  UefiCpuPkg/UefiCpuPkg.dec
+
+[LibraryClasses.common]
+  BaseLib
+  DebugLib
+  MemoryAllocationLib
+  PeCoffGetEntryPointLib
+  PrintLib
+  SerialPortLib
+  SynchronizationLib
+
+[LibraryClasses.X64]
+  CcExitLib
+  LocalApicLib


### PR DESCRIPTION
In a TDX guest, the LTR (Load Task Register) instruction causes an unconditional #UD.  The initial TD vCPU state per the Intel TDX architecture specification has TR.Selector = 0 and TR.Base = 0, so there is no usable TSS to write IST entries into.  IST-based separate exception stacks cannot be configured at all inside a TDX guest.
ArchSetupExceptionStack calls AsmWriteTr (LTR) unconditionally, which causes CpuDxe to crash before BDS is reached.  The same code path is triggered for every AP via InitializeMpExceptionStackSwitchHandlers in CpuDxe/CpuMp.c, which dispatches InitializeExceptionStackSwitchHandlers to all processors and calls InitializeSeparateExceptionStacks for each.

Fix: introduce OvmfPkg/IntelTdx/TdxCpuExceptionHandlerLib, a thin OvmfPkg-local override of DxeCpuExceptionHandlerLib where InitializeSeparateExceptionStacks unconditionally returns EFI_SUCCESS
with BufferSize left at 0. 
The wrapper in CpuMp.c treats this as a successful no-op (Status == EFI_SUCCESS, BufferSize == 0) for every processor and skips the second allocation and setup round entirely, so AsmWriteTr is never reached on BSP or any AP.

Point IntelTdxX64.dsc DXE_CORE and DXE_DRIVER entries at the new library rather than modifying the upstream UefiCpuPkg library directly.

Fixes: e67f405713f0 ("UefiCpuPkg: Always Initialize Separate AP Exception Stacks")
# Description

<_Include a description of the change and why this change was made._>

<_For each item, place an "x" in between `[` and `]` if true. Example: `[x]` (you can also check items in GitHub UI)_>

<_Create the PR as a Draft PR if it is only created to run CI checks._>

<_Delete lines in \<\> tags before creating the PR._>

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

<_Describe the test(s) that were run to verify the changes._>

## Integration Instructions

<_Describe how these changes should be integrated. Use N/A if nothing is required._>
