### PR TITLE
OvmfPkg/RiscVVirt: Make SecureBootDefaultKeysInit module configurable

### DIFF
--- a/OvmfPkg/RiscVVirt/RiscVVirtQemu.dsc
+++ b/OvmfPkg/RiscVVirt/RiscVVirtQemu.dsc
@@ -35,12 +35,13 @@
   # Defines for default states.  These can be changed on the command line.
   # -D FLAG=VALUE
   #
-  DEFINE TTY_TERMINAL            = FALSE
-  DEFINE SECURE_BOOT_ENABLE      = FALSE
-  DEFINE QEMU_PV_VARS            = FALSE
-  DEFINE TPM2_ENABLE             = FALSE
-  DEFINE TPM2_CONFIG_ENABLE      = FALSE
-  DEFINE DEBUG_ON_SERIAL_PORT    = TRUE
+  DEFINE TTY_TERMINAL             = FALSE
+  DEFINE SECURE_BOOT_ENABLE       = FALSE
+  DEFINE SECURE_BOOT_DEFAULT_KEYS = FALSE
+  DEFINE QEMU_PV_VARS             = FALSE
+  DEFINE TPM2_ENABLE              = FALSE
+  DEFINE TPM2_CONFIG_ENABLE       = FALSE
+  DEFINE DEBUG_ON_SERIAL_PORT     = TRUE
 
   #
   # Shell can be useful for debugging but should not be enabled for production

--- a/OvmfPkg/RiscVVirt/RiscVVirtQemu.fdf
+++ b/OvmfPkg/RiscVVirt/RiscVVirtQemu.fdf
@@ -89,6 +89,7 @@ INF  MdeModulePkg/Universal/FaultTolerantWriteDxe/FaultTolerantWriteDxe.inf
 !endif
 !if $(SECURE_BOOT_ENABLE) == TRUE
   INF  SecurityPkg/VariableAuthenticated/SecureBootConfigDxe/SecureBootConfigDxe.inf
+  !if $(SECURE_BOOT_DEFAULT_KEYS) == TRUE
   INF  OvmfPkg/RiscVVirt/Feature/SecureBoot/SecureBootDefaultKeysInit/SecureBootDefaultKeysInit.inf
 
   FILE FREEFORM = 85254ea7-4759-4fc4-82d4-5eed5fb0a4a0 {
@@ -107,6 +108,7 @@ INF  MdeModulePkg/Universal/FaultTolerantWriteDxe/FaultTolerantWriteDxe.inf
   FILE FREEFORM = 5740766a-718e-4dc0-9935-c36f7d3f884f {
     SECTION RAW = OvmfPkg/RiscVVirt/Feature/SecureBoot/SecureBootKeys/dbx/dbxupdate_x64.bin
   }
+  !endif
 !endif
 INF  MdeModulePkg/Universal/MonotonicCounterRuntimeDxe/MonotonicCounterRuntimeDxe.inf
 INF  MdeModulePkg/Universal/ResetSystemRuntimeDxe/ResetSystemRuntimeDxe.inf


### PR DESCRIPTION
# Description
When SecureBoot is enabled, SecureBootDefaultKeysInit driver is not always used. There are alternative methods such as EnrollDefaultKeys.efi or virt-firmware. Therefore, change SecureBootDefaultKeysInit to an optional build option.

Wrap SecureBootDefaultKeysInit.inf with SECURE_BOOT_DEFAULT_KEYS condition, allowing builds to optionally disable default Secure Boot keys initialization.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested
- build -a RISCV64 -p OvmfPkg/RiscVVirt/RiscVVirtQemu.dsc -b DEBUG -t GCC5 -D SECURE_BOOT_ENABLE
- build -a RISCV64 -p OvmfPkg/RiscVVirt/RiscVVirtQemu.dsc -b DEBUG -t GCC5 -D SECURE_BOOT_ENABLE -D SECURE_BOOT_DEFAULT_KEYS

## Integration Instructions
N/A

