### PR TITLE
NetworkPkg: Ip4Dxe/Ip6Dxe: Set SB notify to NULL after event close

### DIFF
--- a/NetworkPkg/Ip4Dxe/Ip4Config2Impl.c
+++ b/NetworkPkg/Ip4Dxe/Ip4Config2Impl.c
@@ -935,6 +935,7 @@ Ip4StartAutoConfig (
 
   if (Instance->Dhcp4SbNotifyEvent != NULL) {
     gBS->CloseEvent (Instance->Dhcp4SbNotifyEvent);
+    Instance->Dhcp4SbNotifyEvent = NULL;
   }
 
   Status = gBS->OpenProtocol (

--- a/NetworkPkg/Ip6Dxe/Ip6ConfigImpl.c
+++ b/NetworkPkg/Ip6Dxe/Ip6ConfigImpl.c
@@ -227,6 +227,7 @@ Ip6ConfigStartStatefulAutoConfig (
 
   if (Instance->Dhcp6SbNotifyEvent != NULL) {
     gBS->CloseEvent (Instance->Dhcp6SbNotifyEvent);
+    Instance->Dhcp6SbNotifyEvent = NULL;
   }
 
   Status = gBS->OpenProtocol (


### PR DESCRIPTION
# Description

Ip4StartAutoConfig() and Ip6ConfigStartStatefulAutoConfig() close the DHCP service binding notify event when the service child is successfully created, but do not NULL the instance field afterward.

On re-entry, the stale handle passes the non-NULL condition and is closed a second time, which results in a page fault with memory protections enabled.

This change sets the event field to NULL immediately after CloseEvent() so that subsequent calls skip attempting to close the event again.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

PXE boot with USB HUB connected NIC and memory protections enabled.

Repro snippets from debug log:

```
[CoreCreateEventInternal]: EVENT CREATED. D6A2CB7F-6A18-4E2F-B43B-9920A733700A
...
[Ip4StartAutoConfig]: EVENT CLOSED. 9FB1A1F3-3B71-4324-B39A-745CBB015FFF
[CoreCloseEvent]: EVENT CLOSED. D6A2CB7F-6A18-4E2F-B43B-9920A733700A
...
[Ip4StartAutoConfig]: EVENT CLOSED. 9FB1A1F3-3B71-4324-B39A-745CBB015FFF
[CoreCloseEvent]: EVENT CLOSED. D6A2CB7F-6A18-4E2F-B43B-9920A733700A
```

## Integration Instructions

N/A