### PR TITLE
UefiCpuPkg/MpInitLibUp: Fix #UD exception due to NULL pointer deref

### DIFF
--- a/UefiCpuPkg/Library/MpInitLibUp/MpInitLibUp.c
+++ b/UefiCpuPkg/Library/MpInitLibUp/MpInitLibUp.c
@@ -68,8 +68,18 @@ MpInitLibGetNumberOfProcessors (
   OUT UINTN  *NumberOfEnabledProcessors OPTIONAL
   )
 {
-  *NumberOfProcessors        = 1;
-  *NumberOfEnabledProcessors = 1;
+  if ((NumberOfProcessors == NULL) && (NumberOfEnabledProcessors == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (NumberOfProcessors != NULL) {
+    *NumberOfProcessors = 1;
+  }
+
+  if (NumberOfEnabledProcessors != NULL) {
+    *NumberOfEnabledProcessors = 1;
+  }
+
   return EFI_SUCCESS;
 }
 


### PR DESCRIPTION
# Description

In MpInitLibUp, MpInitLibGetNumberOfProcessors() unconditionally dereferences the NumberOfProcessors and NumberOfEnabledProcessors parameters. However, the API specification marks both as OPTIONAL.

When callers (like InitializeExceptionStackSwitchHandlers in UefiCpuPkg/CpuMpPei/CpuMpPei.c) pass NULL for NumberOfEnabledProcessors, GCC's Link-Time Optimization (LTO) detects an unconditional NULL pointer dereference. Since this is Undefined Behavior, GCC emits a 'ud2' (Invalid Opcode) instruction at the dereference site. This leads to an unexpected #UD exception during the boot process of uniprocessor guests like TDX VMs.

This patch fixes the issue by adding appropriate NULL checks before dereferencing the pointers. It also returns EFI_INVALID_PARAMETER if both arguments are NULL, ensuring compliance with the MpInitLib specification.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

```
./qemu-system-x86_64 -accel kvm \
    -cpu host \
    -object tdx-guest,id=tdx0 \
    -machine q35,confidential-guest-support=tdx0 \
    -bios OVMF.fd \
    -vga none \
    -nodefaults \
    -serial mon:stdio
```

Without this patch, OVMF panics as in #11991 .

## Integration Instructions

N/A