### PR TITLE
StandaloneMmPkg Core: Treat no DEPEX as TRUE

### DIFF
--- a/StandaloneMmPkg/Core/Dependency.c
+++ b/StandaloneMmPkg/Core/Dependency.c
@@ -182,12 +182,10 @@ MmIsSchedulable (
 
   if (DriverEntry->Depex == NULL) {
     //
-    // A NULL Depex means that the MM driver is not built correctly.
-    // All MM drivers must have a valid depex expression.
+    // If there is no DEPEX, assume the module can be executed
     //
-    DEBUG ((DEBUG_DISPATCH, "  RESULT = FALSE (Depex is empty)\n"));
-    ASSERT (FALSE);
-    return FALSE;
+    DEBUG ((DEBUG_DISPATCH, "  RESULT = TRUE (No DEPEX)\n"));
+    return TRUE;
   }
 
   //


### PR DESCRIPTION
Treat no DEPEX as TRUE, then the DEPEX section can be eliminated if a driver can be assured to have no
DEPEX needed.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Declare build rule in fdf to eliminate DEPEX section. 

## Integration Instructions

N/A
