### PR TITLE
Add Asm(Read|Write)FsBase to BaseLib for x86-64.

### DIFF
--- a/MdePkg/Include/Library/BaseLib.h
+++ b/MdePkg/Include/Library/BaseLib.h
@@ -5491,6 +5491,42 @@ AsmRmpAdjust (
   IN      UINT64  Rdx
   );
 
+/**
+  Reads the current value of the FS segment base address.
+
+  Reads and returns the current value of the FS segment base address using
+  the RDFSBASE instruction. This function is only available on X64.
+
+  Note: The function requires that CPUID.(EAX=7,ECX=0):EBX.FSGSBASE=1
+  and CR4.FSGSBASE=1.
+
+  @return The current value of the FS segment base address.
+**/
+UINT64
+EFIAPI
+AsmReadFsBase (
+  VOID
+  );
+
+/**
+  Writes a value to the FS segment base address.
+
+  Writes FsBase to the FS segment base address register using the WRFSBASE
+  instruction. This function is only available on X64.
+
+  Note: The function requires that CPUID.(EAX=7,ECX=0):EBX.FSGSBASE=1
+  and CR4.FSGSBASE=1.
+
+  @param  FsBase  The value to write to the FS segment base address.
+
+  @return  FsBase
+**/
+UINT64
+EFIAPI
+AsmWriteFsBase (
+  IN      UINT64  FsBase
+  );
+
 #endif
 
 #if defined (MDE_CPU_IA32) || defined (MDE_CPU_X64)

--- a/MdePkg/Library/BaseLib/BaseLib.inf
+++ b/MdePkg/Library/BaseLib/BaseLib.inf
@@ -332,6 +332,9 @@
   X64/XSetBv.nasm
   X64/VmgExit.nasm
   X64/VmgExitSvsm.nasm
+  X64/ReadFsBase.nasm
+  X64/WriteFsBase.nasm
+  X64/FsGsBase.c
 
 [Sources.EBC]
   Ebc/CpuBreakpoint.c

--- a/MdePkg/Library/BaseLib/BaseLibInternals.h
+++ b/MdePkg/Library/BaseLib/BaseLibInternals.h
@@ -849,6 +849,32 @@ InternalX86RdRand64  (
   OUT     UINT64  *Rand
   );
 
+  #if defined (MDE_CPU_X64)
+
+/**
+  Write FS base register.
+
+  @param FsBase  Value to write to FS base register.
+**/
+VOID
+EFIAPI
+InternalX86WriteFsBase (
+  UINT64  FsBase
+  );
+
+/**
+  Read FS base register.
+
+  @return  Value of FS base register.
+**/
+UINT64
+EFIAPI
+InternalX86ReadFsBase (
+  VOID
+  );
+
+  #endif
+
 #else
 
 #endif

--- a/MdePkg/Library/BaseLib/X64/FsGsBase.c
+++ b/MdePkg/Library/BaseLib/X64/FsGsBase.c
@@ -1,0 +1,108 @@
+/** @file
+  Provide functions to read or write FS base register.
+
+  Copyright (c) 2026, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "BaseLibInternals.h"
+#include <Register/Intel/Cpuid.h>
+
+/**
+  Worker function that returns TRUE if the CPU supports FS/GS base instructions,
+  FALSE otherwise.
+
+  @retval TRUE  The CPU supports FS/GS base instructions.
+  @retval FALSE The CPU does not support FS/GS base instructions.
+**/
+BOOLEAN
+InternalFsGsBaseSupported (
+  VOID
+  )
+{
+  UINT32                                       MaxLeaf;
+  CPUID_STRUCTURED_EXTENDED_FEATURE_FLAGS_EBX  Ebx;
+
+  AsmCpuid (CPUID_SIGNATURE, &MaxLeaf, NULL, NULL, NULL);
+  if (MaxLeaf < CPUID_STRUCTURED_EXTENDED_FEATURE_FLAGS) {
+    return FALSE;
+  }
+
+  AsmCpuidEx (
+    CPUID_STRUCTURED_EXTENDED_FEATURE_FLAGS,
+    CPUID_STRUCTURED_EXTENDED_FEATURE_FLAGS_SUB_LEAF_INFO,
+    NULL,
+    &Ebx.Uint32,
+    NULL,
+    NULL
+    );
+  return (BOOLEAN)(Ebx.Bits.FSGSBASE == 1);
+}
+
+/**
+  Worker function that returns TRUE if the CPU enables FS/GS base instructions,
+  FALSE otherwise.
+
+  @retval TRUE  The CPU enables FS/GS base instructions.
+  @retval FALSE The CPU does not enable FS/GS base instructions.
+**/
+BOOLEAN
+InternalFsGsBaseEnabled (
+  VOID
+  )
+{
+  IA32_CR4  Cr4;
+
+  Cr4.UintN = AsmReadCr4 ();
+  return (BOOLEAN)(Cr4.Bits.FSGSBASE == 1);
+}
+
+/**
+  Reads the current value of the FS segment base address.
+
+  Reads and returns the current value of the FS segment base address using
+  the RDFSBASE instruction. This function is only available on X64.
+
+  Note: The function requires that CPUID.(EAX=7,ECX=0):EBX.FSGSBASE=1
+  and CR4.FSGSBASE=1.
+
+  @return The current value of the FS segment base address.
+**/
+UINT64
+EFIAPI
+AsmReadFsBase (
+  VOID
+  )
+{
+  ASSERT (InternalFsGsBaseSupported ());
+  ASSERT (InternalFsGsBaseEnabled ());
+
+  return InternalX86ReadFsBase ();
+}
+
+/**
+  Writes a value to the FS segment base address.
+
+  Writes FsBase to the FS segment base address register using the WRFSBASE
+  instruction. This function is only available on X64.
+
+  Note: The function requires that CPUID.(EAX=7,ECX=0):EBX.FSGSBASE=1
+  and CR4.FSGSBASE=1.
+
+  @param  FsBase  The value to write to the FS segment base address.
+
+  @return  FsBase
+**/
+UINT64
+EFIAPI
+AsmWriteFsBase (
+  IN      UINT64  FsBase
+  )
+{
+  ASSERT (InternalFsGsBaseSupported ());
+  ASSERT (InternalFsGsBaseEnabled ());
+
+  InternalX86WriteFsBase (FsBase);
+  return FsBase;
+}

--- a/MdePkg/Library/BaseLib/X64/ReadFsBase.nasm
+++ b/MdePkg/Library/BaseLib/X64/ReadFsBase.nasm
@@ -1,0 +1,31 @@
+;------------------------------------------------------------------------------
+;
+; Copyright (c) 2026, Intel Corporation. All rights reserved.<BR>
+; SPDX-License-Identifier: BSD-2-Clause-Patent
+;
+; Module Name:
+;
+;   ReadFsBase.nasm
+;
+; Abstract:
+;
+;   InternalX86ReadFsBase function
+;
+; Notes:
+;
+;------------------------------------------------------------------------------
+
+    DEFAULT REL
+    SECTION .text
+
+;------------------------------------------------------------------------------
+; UINT64
+; EFIAPI
+; InternalX86ReadFsBase (
+;   VOID
+;   );
+;------------------------------------------------------------------------------
+global ASM_PFX(InternalX86ReadFsBase)
+ASM_PFX(InternalX86ReadFsBase):
+    rdfsbase rax
+    ret

--- a/MdePkg/Library/BaseLib/X64/WriteFsBase.nasm
+++ b/MdePkg/Library/BaseLib/X64/WriteFsBase.nasm
@@ -1,0 +1,31 @@
+;------------------------------------------------------------------------------
+;
+; Copyright (c) 2026, Intel Corporation. All rights reserved.<BR>
+; SPDX-License-Identifier: BSD-2-Clause-Patent
+;
+; Module Name:
+;
+;   WriteFsBase.nasm
+;
+; Abstract:
+;
+;   InternalX86WriteFsBase function
+;
+; Notes:
+;
+;------------------------------------------------------------------------------
+
+    DEFAULT REL
+    SECTION .text
+
+;------------------------------------------------------------------------------
+; VOID
+; EFIAPI
+; InternalX86WriteFsBase (
+;   UINT64  FsBase
+;   );
+;------------------------------------------------------------------------------
+global ASM_PFX(InternalX86WriteFsBase)
+ASM_PFX(InternalX86WriteFsBase):
+    wrfsbase rcx
+    ret


### PR DESCRIPTION
# Description

The PR adds Asm(Read|Write)FsBase to BaseLib for x86-64.

- [N] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [N] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [N] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested
Call AsmWriteFsBase() and use AsmReadFsBase() to check if the value is written to FSBASE.

## Integration Instructions

n/a
