### PR TITLE
BaseTools: Reject the null body of commit message in PatchCheck script

### DIFF
--- a/BaseTools/Scripts/PatchCheck.py
+++ b/BaseTools/Scripts/PatchCheck.py
@@ -4,6 +4,7 @@
 #  Copyright (c) 2015 - 2021, Intel Corporation. All rights reserved.<BR>
 #  Copyright (C) 2020, Red Hat, Inc.<BR>
 #  Copyright (c) 2020 - 2023, Arm Limited. All rights reserved.<BR>
+#  Copyright (c) 2026, Loongson Technology Corporation Limited. All rights reserved.<BR>
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -304,6 +305,7 @@ class CommitMessageCheck:
             self.error('Second line of commit message should be ' +
                        'empty.')
 
+        found_body_line = False
         for i in range(2, count):
             if (len(lines[i]) >= 76 and
                 len(lines[i].split()) > 1 and
@@ -323,6 +325,19 @@ class CommitMessageCheck:
                     (i + 1, len(lines[i]))
                     )
                 print(lines[i])
+            if (not found_body_line and
+                lines[i].strip() != '' and
+                not lines[i].startswith('git-svn-id:') and
+                not lines[i].startswith('Reviewed-by') and
+                not lines[i].startswith('Acked-by:') and
+                not lines[i].startswith('Tested-by:') and
+                not lines[i].startswith('Reported-by:') and
+                not lines[i].startswith('Suggested-by:') and
+                not lines[i].startswith('Signed-off-by:') and
+                not lines[i].startswith('Cc:')):
+                found_body_line = True
+        if not found_body_line:
+            self.error('The commit body lines are not found')
 
         last_sig_line = None
         for i in range(count - 1, 0, -1):


### PR DESCRIPTION
# Description

Current PatchCheck script allows null body of commit message. The patch adds a check for such case. If the body of commit message is null, an error will be throwed.


- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Create a commit with subject line, Signed-off-by line and null body message:
```
Author: Qihang Gao <gaoqihang@loongson.cn>
Date:   Mon Mar 2 16:31:28 2026 +0800

    TEST NULL COMMIT MESSAGE
    
    Signed-off-by: Qihang Gao <gaoqihang@loongson.cn>

diff --git a/testfile b/testfile
new file mode 100644
index 00000000..e69de29b
```

Run Command:`python3 BaseTools/Scripts/PatchCheck.py 0001-TEST-NULL-COMMIT-MESSAGE.patch`, the output is:
```
Checking patch file: 0001-TEST-NULL-COMMIT-MESSAGE.patch
TEST NULL COMMIT MESSAGE
The commit message format is not valid:
 * The commit body lines are not found
https://www.tianocore.org/tianocore-wiki.github.io/development/contribution-guides/commit_message_format.html
The code passed all checks.
```



## Integration Instructions

N/A
