### PR TITLE
SecurityPkg/Tcg2Config: Add PcdTpmDefaultDevice for platform customiz…

### DIFF
--- a/SecurityPkg/SecurityPkg.dec
+++ b/SecurityPkg/SecurityPkg.dec
@@ -466,6 +466,13 @@
   # @Prompt TPM type detection.
   gEfiSecurityPkgTokenSpaceGuid.PcdTpmAutoDetection|TRUE|BOOLEAN|0x00010011
 
+  ## This PCD specifies the default TPM device type when no configuration exists.<BR><BR>
+  #  0 - TPM_DEVICE_NULL<BR>
+  #  1 - TPM_DEVICE_1_2<BR>
+  #  2 - TPM_DEVICE_2_0_DTPM<BR>
+  # @Prompt Default TPM device type
+  gEfiSecurityPkgTokenSpaceGuid.PcdTpmDefaultDevice|0x1|UINT8|0x00010028
+
   ## This PCD indicates TPM base address.<BR><BR>
   # @Prompt TPM device address.
   gEfiSecurityPkgTokenSpaceGuid.PcdTpmBaseAddress|0xFED40000|UINT64|0x00010012

--- a/SecurityPkg/Tcg/Tcg2Config/Tcg2ConfigPei.inf
+++ b/SecurityPkg/Tcg/Tcg2Config/Tcg2ConfigPei.inf
@@ -68,6 +68,7 @@
   gEfiSecurityPkgTokenSpaceGuid.PcdTpmInstanceGuid                 ## PRODUCES
   gEfiSecurityPkgTokenSpaceGuid.PcdTpmInitializationPolicy         ## PRODUCES
   gEfiSecurityPkgTokenSpaceGuid.PcdTpmAutoDetection                ## CONSUMES
+  gEfiSecurityPkgTokenSpaceGuid.PcdTpmDefaultDevice                ## CONSUMES
   gEfiSecurityPkgTokenSpaceGuid.PcdTcgPhysicalPresenceInterfaceVer
 
 [Depex]

--- a/SecurityPkg/Tcg/Tcg2Config/Tcg2ConfigPeim.c
+++ b/SecurityPkg/Tcg/Tcg2Config/Tcg2ConfigPeim.c
@@ -144,9 +144,10 @@ Tcg2ConfigPeimEntryPoint (
                           );
   if (EFI_ERROR (Status)) {
     //
-    // Variable not ready, set default value
+    // Variable not ready, use PCD default value
     //
-    Tcg2Configuration.TpmDevice = TPM_DEVICE_DEFAULT;
+    Tcg2Configuration.TpmDevice = PcdGet8 (PcdTpmDefaultDevice);
+    DEBUG ((DEBUG_INFO, "Using PCD default TpmDevice=%d\n", Tcg2Configuration.TpmDevice));
   }
 
   //


### PR DESCRIPTION
…ation

Currently, when the TCG2_CONFIGURATION NVRAM variable doesn't exist (e.g., first boot or after NVRAM clear), Tcg2ConfigPeim uses a hardcoded default value (TPM_DEVICE_1_2 via TPM_DEVICE_DEFAULT macro). This prevents platforms from customizing the default TPM device type without modifying EDK2 code.

This is problematic for:
- Modern platforms that use TPM 2.0 by default
- Platforms with non-standard TPM configurations (e.g., I2C-based TPMs) that cannot rely on auto-detection
- Maintaining platform-specific policy outside of generic EDK2 code

This patch introduces a new PCD: PcdTpmDefaultDevice This allows platforms to configure their default TPM device type via DSC files:
  gEfiSecurityPkgTokenSpaceGuid.PcdTpmDefaultDevice|2  # TPM 2.0 DTPM

Changes:
1. Read PcdTpmDefaultDevice instead of using hardcoded TPM_DEVICE_DEFAULT when TCG2_CONFIGURATION variable doesn't exist
2. Fall back to configured TpmDevice value when auto-detection returns TPM_DEVICE_NULL
3. Add debug logging for better visibility of TPM configuration flow

The change is backward compatible - platforms that don't customize PcdTpmDefaultDevice will continue to use the default value of TPM_DEVICE_1_2 (defined in SecurityPkg.dec).

# Description

<_Include a description of the change and why this change was made._>

<_For each item, place an "x" in between `[` and `]` if true. Example: `[x]` (you can also check items in GitHub UI)_>

<_Create the PR as a Draft PR if it is only created to run CI checks._>

<_Delete lines in \<\> tags before creating the PR._>

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

<_Describe the test(s) that were run to verify the changes._>

## Integration Instructions

<_Describe how these changes should be integrated. Use N/A if nothing is required._>
