### PR TITLE
UefiPayloadPkg/CbParseLib: Use CRC32 function compatible with coreboot

### DIFF
--- a/UefiPayloadPkg/Library/CbParseLib/CbParseLib.c
+++ b/UefiPayloadPkg/Library/CbParseLib/CbParseLib.c
@@ -76,6 +76,43 @@ CbCheckSum16 (
 }
 
 /**
+  Coreboot implements a CRC32 checksum which differs from the one in EDK2. This function
+  calculates the CRC32 checksum of a given buffer with the coreboot implementation.
+
+  @param  Buffer      The pointer to the buffer of which to calculate the CRC32.
+  @param  Length      The size, in bytes, of Buffer.
+
+  @return Crc         The CRC32 checksum of Buffer.
+
+**/
+UINT32
+CbCalculateCrc32 (
+  IN  VOID   *Buffer,
+  IN  UINTN  Length
+  )
+{
+  UINT32  Crc;
+  UINT8   *Ptr;
+  UINTN   Idx;
+  UINTN   BitIdx;
+
+  Crc = 0;
+  for (Idx = 0, Ptr = Buffer; Idx < Length; Idx++, Ptr++) {
+    Crc ^= (UINT32)*Ptr << 24;
+
+    for (BitIdx = 0; BitIdx < 8; BitIdx++) {
+      if ((Crc & 0x80000000UL) != 0) {
+        Crc = ((Crc << 1) ^ 0x04C11DB7UL);
+      } else {
+        Crc <<= 1;
+      }
+    }
+  }
+
+  return Crc;
+}
+
+/**
   Check the coreboot table if it is valid.
 
   @param  Header            Pointer to coreboot table


### PR DESCRIPTION
EDK2's CalculateCrc32() does not match the CRC32 implementation used by
coreboot (non-reflected, init 0, poly 0x04C11DB7, no final xor). As a
result, CRC32 fields produced by coreboot cannot be validated with the
EDK2 helper.

Add CbCalculateCrc32() to CbParseLib to compute CRC32 values compatible
with coreboot.