### PR TITLE
UefiPayloadPkg/GraphicsOutputDxe: support framebuffer BAR offset

### DIFF
--- a/UefiPayloadPkg/GraphicsOutputDxe/GraphicsOutput.c
+++ b/UefiPayloadPkg/GraphicsOutputDxe/GraphicsOutput.c
@@ -435,8 +435,10 @@ GraphicsOutputDriverBindingStart (
             }
 
             if (DeviceInfo->BarIndex == MAX_UINT8) {
-              if (Resources->AddrRangeMin == GraphicsInfo->FrameBufferBase) {
-                FrameBufferBase = Resources->AddrRangeMin;
+              if (  (Resources->AddrRangeMin <= GraphicsInfo->FrameBufferBase)
+                 && (Resources->AddrRangeMin + Resources->AddrLen >= GraphicsInfo->FrameBufferBase + GraphicsInfo->FrameBufferSize))
+              {
+                FrameBufferBase = GraphicsInfo->FrameBufferBase;
                 break;
               }
             } else {


### PR DESCRIPTION
Some platforms place the linear framebuffer at an offset within the PCI
BAR (for example, Meteor Lake can use BAR2 + 0x800000). The existing
GraphicsOutputDxe validation requires the framebuffer base to match the
BAR base exactly, which rejects these configurations.

Relax the check to accept a framebuffer base within the BAR window, and
use the provided framebuffer base address when it falls within that
range.