### PR TITLE
MdeModulePkg: Add PCD for progress bar background color

### DIFF
--- a/MdeModulePkg/Library/DisplayUpdateProgressLibGraphics/DisplayUpdateProgressLibGraphics.c
+++ b/MdeModulePkg/Library/DisplayUpdateProgressLibGraphics/DisplayUpdateProgressLibGraphics.c
@@ -72,14 +72,14 @@ const EFI_GRAPHICS_OUTPUT_BLT_PIXEL_UNION  mLogoDetectionColorMask = {
 };
 
 //
-// Background color of progress bar.  Grey.
+// Background color of progress bar.
 //
 const EFI_GRAPHICS_OUTPUT_BLT_PIXEL_UNION  mProgressBarBackgroundColor = {
   {
-    0x80,  // Blue
-    0x80,  // Green
-    0x80,  // Red
-    0x00   // Reserved
+    ((UINT32)FixedPcdGet32 (PcdProgressBarBackgroundColor) >> 0)   & 0xFF,  // Blue
+    ((UINT32)FixedPcdGet32 (PcdProgressBarBackgroundColor) >> 8)   & 0xFF,  // Green
+    ((UINT32)FixedPcdGet32 (PcdProgressBarBackgroundColor) >> 16)  & 0xFF,  // Red
+    ((UINT32)FixedPcdGet32 (PcdProgressBarBackgroundColor) >> 24)  & 0xFF   // Reserved
   }
 };
 

--- a/MdeModulePkg/Library/DisplayUpdateProgressLibGraphics/DisplayUpdateProgressLibGraphics.inf
+++ b/MdeModulePkg/Library/DisplayUpdateProgressLibGraphics/DisplayUpdateProgressLibGraphics.inf
@@ -41,3 +41,6 @@
 [Protocols]
   gEfiGraphicsOutputProtocolGuid  # CONSUMES
   gEdkiiBootLogo2ProtocolGuid     # CONSUMES
+
+[Pcd]
+  gEfiMdeModulePkgTokenSpaceGuid.PcdProgressBarBackgroundColor  ## CONSUMES

--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -1761,6 +1761,15 @@
   # @Prompt SATA device ready for operations timoeout (s), default value is 16s.
   gEfiMdeModulePkgTokenSpaceGuid.PcdSataDeviceReadyTimeout|16|UINT8|0x00000038
 
+  ## This PCD holds the background color of progress bar. Default to Grey.
+  # Bit fields:
+  #   [31:24] - Reserved
+  #   [23:16] - Red
+  #   [15:8]  - Green
+  #   [7:0]   - Blue
+  # @Prompt Describes background color of progress bar.
+  gEfiMdeModulePkgTokenSpaceGuid.PcdProgressBarBackgroundColor|0x00808080|UINT32|0x00000039
+
 [PcdsPatchableInModule, PcdsDynamic, PcdsDynamicEx]
   ## This PCD defines the Console output row. The default value is 25 according to UEFI spec.
   #  This PCD could be set to 0 then console output would be at max column and max row.


### PR DESCRIPTION
# Description

- Add PcdProgressBarBackgroundColor to hold the background color of 
   progress bar, so that it can be changed in platform config.

Reference Bug: https://github.com/tianocore/edk2/issues/9849

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Validated on Intel platforms by Surface.

## Integration Instructions

N/A