### PR TITLE
BaseTools: Remove stale reference to Common directory

### DIFF
--- a/BaseTools/Source/Python/Workspace/DscBuildData.py
+++ b/BaseTools/Source/Python/Workspace/DscBuildData.py
@@ -110,7 +110,6 @@ $(APPFILE): $(APPLICATION)
 
 PcdGccMakefile = '''
 MAKEROOT ?= $(EDK_TOOLS_PATH)%sSource%sC
-LIBS = -lCommon
 '''%(os.sep, os.sep)
 
 variablePattern = re.compile(r'[\t\s]*0[xX][a-fA-F0-9]+$')


### PR DESCRIPTION
# Description

- This is no more required as `PcdValueCommon.c` is copied to 
   `PcdValueInit` directory

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Validated in Linux OVMF build with structured PCD variables.

## Integration Instructions

N/A