### PR TITLE
For Clang use target x86_64-uefi to not include MSVC definitions

### DIFF
--- a/BaseTools/Conf/tools_def.template
+++ b/BaseTools/Conf/tools_def.template
@@ -1334,7 +1334,7 @@ DEFINE CLANGPDB_X64_PREFIX           = ENV(CLANG_BIN)
 DEFINE CLANGPDB_AARCH64_PREFIX       = ENV(CLANG_BIN)
 
 DEFINE CLANGPDB_IA32_TARGET          = -target i686-pc-windows-msvc
-DEFINE CLANGPDB_X64_TARGET           = -target x86_64-pc-windows-msvc
+DEFINE CLANGPDB_X64_TARGET           = -target x86_64-uefi
 DEFINE CLANGPDB_AARCH64_TARGET       = -target aarch64-unknown-windows-msvc
 
 DEFINE CLANGPDB_WARNING_OVERRIDES    = -Wno-parentheses-equality -Wno-tautological-compare -Wno-tautological-constant-out-of-range-compare -Wno-empty-body -Wno-varargs -Wno-unknown-warning-option -Wno-unaligned-access -Wno-microsoft-enum-forward-reference


### PR DESCRIPTION
# Description

Currently on Linux when using Clang then building StdLib fails with:

```
"clang" -MMD -MF Build/StdLib/RELEASE_CLANGPDB/X64/edk2-libc/StdLib/EfiSocketLib/EfiSocketLib/OUTPUT/DxeSupport.obj.deps -g -Os -fshort-wchar -fno-builtin -fno-strict-aliasing -Wall -Werror -Wno-array-bounds -include AutoGen.h -fno-common -fstack-protector -ffunction-sections -fdata-sections -DSTRING_ARRAY_NAME=EfiSocketLibStrings -Wno-parentheses-equality -Wno-tautological-compare -Wno-tautological-constant-out-of-range-compare -Wno-empty-body -Wno-varargs -Wno-unknown-warning-option -Wno-unaligned-access -Wno-microsoft-enum-forward-reference -fno-stack-protector -funsigned-char -ftrap-function=undefined_behavior_has_been_optimized_away_by_clang -Wno-address -Wno-shift-negative-value -Wno-unknown-pragmas -Wno-incompatible-library-redeclaration -Wno-null-dereference -mno-implicit-float -mms-bitfields -mno-stack-arg-probe -fno-omit-frame-pointer -D __GNUC__=4 -D __GNUC_MINOR__=2 -D __GNUC_PATCHLEVEL__=1 -D __MINGW32__=1 -m64 "-DEFIAPI=__attribute__((ms_abi))" -mno-red-zone -mcmodel=small -Oz -flto -target x86_64-pc-windows-msvc -fno-unwind-tables -Wno-unused-command-line-argument -c -o Build/StdLib/RELEASE_CLANGPDB/X64/edk2-libc/StdLib/EfiSocketLib/EfiSocketLib/OUTPUT/./DxeSupport.obj -Iedk2-libc/StdLib/EfiSocketLib -IBuild/StdLib/RELEASE_CLANGPDB/X64/edk2-libc/StdLib/EfiSocketLib/EfiSocketLib/DEBUG -IMdePkg -IMdePkg/Include -IMdePkg/Test/UnitTest/Include -IMdePkg/Test/Mock/Include -IMdePkg/Library/MipiSysTLib/mipisyst/library/include -IMdePkg/Include/X64 -IMdeModulePkg -IMdeModulePkg/Test/Mock/Include -IMdeModulePkg/Include -Iedk2-libc/StdLib -Iedk2-libc/StdLib/Include -Iedk2-libc/StdLib/Include/X64 edk2-libc/StdLib/EfiSocketLib/DxeSupport.c
In file included from edk2-libc/StdLib/PosixLib/Gen/access.c:14:
edk2-libc/StdLib/Include/sys/EfiCdefs.h:336:11: error: redefining builtin macro [-Werror,-Wbuiltin-macro-redefined]
  336 |   #define __STDC_VERSION__    199409L
      |           ^
Building ... edk2-libc/StdLib/PosixLib/PosixLib.inf [X64]
1 error generated.
```

This is because Clang already has builtin `__STDC_VERSION__` but because of `x86_64-pc-windows-msvc` target then `#if defined(_MSC_VER) ` is true causing to enter in this path for MSVC++ defines.

This PR fixes this issue by instead using `x86_64-uefi` target for Clang for which `_MSC_VER` won't be defined.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

On Arch Linux with Clang 21.1.8
```
export PACKAGES_PATH=edk2-libc
$ build --arch=X64 --buildtarget=RELEASE --tagname=CLANGPDB --platform=StdLib/StdLib.dsc
```

This now successfully builds.
Also tested in QEMU that simple UEFI app works fine.

## Integration Instructions

N/A
