### PR TITLE
Update Standalone MM PEI IPL hob handling

### DIFF
--- a/StandaloneMmPkg/Drivers/StandaloneMmIplPei/MmFoundationHob.c
+++ b/StandaloneMmPkg/Drivers/StandaloneMmIplPei/MmFoundationHob.c
@@ -1026,9 +1026,12 @@ CreateMmFoundationHobList (
   //
   // Build ACPI variable HOB
   //
-  HobLength = GetRemainingHobSize (*FoundationHobSize, UsedSize);
-  MmIplCopyGuidHob (FoundationHobList + UsedSize, &HobLength, &gEfiAcpiVariableGuid, FALSE);
-  UsedSize += HobLength;
+  if (PcdGetBool (PcdAcpiS3Enable)) {
+    // Only check on this variable when S3 needs it.
+    HobLength = GetRemainingHobSize (*FoundationHobSize, UsedSize);
+    MmIplCopyGuidHob (FoundationHobList + UsedSize, &HobLength, &gEfiAcpiVariableGuid, FALSE);
+    UsedSize += HobLength;
+  }
 
   if (FeaturePcdGet (PcdCpuSmmProfileEnable)) {
     //


### PR DESCRIPTION
# Description

This change guards the `gEfiAcpiVariableGuid` inside `PcdAcpiS3Enable` as this is only needed for S3 context related data. The current requires this hob to be created otherwise the module will assert.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

This was tested on QEMU Q35 platform and booted to UEFI shell.

## Integration Instructions

N/A
