### PR TITLE
BaseTools/PatchCheck.py: Skip length check for Co-authored-by line

### DIFF
--- a/BaseTools/Scripts/PatchCheck.py
+++ b/BaseTools/Scripts/PatchCheck.py
@@ -314,6 +314,7 @@ class CommitMessageCheck:
                 not lines[i].startswith('Reported-by:') and
                 not lines[i].startswith('Suggested-by:') and
                 not lines[i].startswith('Signed-off-by:') and
+                not lines[i].startswith('Co-authored-by:') and
                 not lines[i].startswith('Cc:')):
                 #
                 # Print a warning if body line is longer than 75 characters


### PR DESCRIPTION
# Description

Skip length check for Co-authored-by line

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

N/A

## Integration Instructions

N/A
