### PR TITLE
OvmfPkg/RiscVVirt/PlatformPei: Do not set PcdTpmBaseAddress to garbage

### DIFF
--- a/OvmfPkg/RiscVVirt/PlatformPei/PlatformPeim.c
+++ b/OvmfPkg/RiscVVirt/PlatformPei/PlatformPeim.c
@@ -120,6 +120,11 @@ SetupTPMResources (
   UINT64        TpmBaseSize;
 
   //
+  // Empty TpmBaseSize indicates no TPM found.
+  //
+  TpmBaseSize = 0;
+
+  //
   // Set Parent to suppress incorrect compiler/analyzer warnings.
   //
   Parent = 0;
@@ -200,7 +205,7 @@ SetupTPMResources (
     }
   }
 
-  if (TpmBase) {
+  if (TpmBaseSize > 0) {
     BuildResourceDescriptorHob (
       EFI_RESOURCE_MEMORY_MAPPED_IO,
       EFI_RESOURCE_ATTRIBUTE_PRESENT     |


### PR DESCRIPTION
# Description

If OVMF was built for RISC-V with TPM2 support but run without a TPM2 device, it crashed during start:

```
Loading PEIM at 0x000FFFB9000 EntryPoint=0x000FFFB9240 Tcg2ConfigPei.efi
!!!! RISCV64 Exception Type - 0000000000000005(EXCEPT_RISCV_LOAD_ACCESS_FAULT) !!!!
     t0 = 0x00000000000000010        t1 = 0x000000000FC01EDF8
     t2 = 0x00000000000000000        t3 = 0x0FFFFFFFFBF7F2B0C
     t4 = 0x00000000000009F2F        t5 = 0x00000000000004889
     t6 = 0x00000000000000061        s0 = 0x000000000FC01F358
     s1 = 0x00000000020000000        s2 = 0x00000000000000001
     s3 = 0x00000000000000001        s4 = 0x000000000FFE00000
     s5 = 0x00000000000000C00        s6 = 0x00000000000000001
     s7 = 0x00000000000000004        s8 = 0x00000000000002000
     s9 = 0x000000000800436F4       s10 = 0x00000000000000000
    s11 = 0x00000000000000000        a0 = 0x00000000000000001
     a1 = 0x00000000000000003        a2 = 0x000000000FC01F346
     a3 = 0x00000000000000000        a4 = 0x00000000000000003
     a5 = 0x00000000000000003        a6 = 0x00000000000004889
     a7 = 0x000000000000000AB      zero = 0x00000000000000000
     ra = 0x000000000FFFBB5B2        sp = 0x000000000FFFD57A4
     gp = 0x00000000000000000        tp = 0x00000000080049000
   sepc = 0x000000000FFFBB5C6   sstatus = 0x08000000200006100
  stval = 0x00000000000000003
PC 0x0000FFFBB5C6
PC 0x0000FFFBB5B2
PC 0x0000FFFBAA42
PC 0x0000FFFBAB84
PC 0x0000FFFBA9AC
PC 0x0000FFFBA94C
PC 0x0000FFFB93C6
PC 0x0000FFFB92AA
PC 0x0000FFFE7F98
PC 0x0000FFFDD0C0
PC 0x00002001993C
[...]
```

If there is no TPM device in the device tree, the TpmBase variable is not
initialized and contains garbage.

Instead of using 0 as sentinel (which may be a valid address), check the
size instead, which cannot be 0 for a memory-mapped device.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

OVMF was built with

```
build -D RISCVVIRT_PEI_BOOTING -D TPM2_ENABLE -D TPM2_CONFIG_ENABLE -D SECURE_BOOT_ENABLE -a RISCV64 -p OvmfPkg/RiscVVirt/RiscVVirtQemu.dsc -b DEBUG -t GCC5
```

and then tested with QEMU using

```
truncate -s 32M Build/RiscVVirtQemu/DEBUG_GCC5/FV/RISCV_VIRT_*.fd
qemu-system-riscv64 -M virt -drive file=Build/RiscVVirtQemu/DEBUG_GCC5/FV/RISCV_VIRT_CODE.fd,if=pflash,readonly=on -drive file=Build/RiscVVirtQemu/DEBUG_GCC5/FV/RISCV_VIRT_VARS.fd,if=pflash -serial stdio
qemu-system-riscv64 -M virt,acpi=off -chardev socket,id=chrtpm,path=/tmp/tpm0/swtpm-sock -tpmdev emulator,id=tpm0,chardev=chrtpm -device tpm-tis-device,tpmdev=tpm0 -drive file=Build/RiscVVirtQemu/DEBUG_GCC5/FV/RISCV_VIRT_CODE.fd,if=pflash,readonly=on -drive file=Build/RiscVVirtQemu/DEBUG_GCC5/FV/RISCV_VIRT_VARS.fd,if=pflash -serial stdio
```

## Integration Instructions

N/A

CC @pttuan
