### PR TITLE
OvmfPkg/XenPvBlkDxe: Advertise the correct IO alignment

### DIFF
--- a/OvmfPkg/XenPvBlkDxe/XenPvBlkDxe.c
+++ b/OvmfPkg/XenPvBlkDxe/XenPvBlkDxe.c
@@ -299,6 +299,8 @@ XenPvBlkDxeDriverBindingStart (
     Media->BlockSize = Dev->MediaInfo.SectorSize;
   }
 
+  Media->IoAlign = Dev->MediaInfo.SectorSize;
+
   //
   // Sectors is express as 512B unit, size of disk is "Sectors * 512",
   // independently from SectorSize.


### PR DESCRIPTION
# Description

The function XenPvBlockAsyncIo expects a sector-aligned buffer but the advertised alignment is always 512. Consequently, booting from the Rocky Linux 9.6 disc (using a 2048 sector size) fails with an assertion in XenPvBlockAsyncIo.

Adverstise the correct IO alignment to fix the assertion failure.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Manually tested installation of Rocky Linux 9.6 on XenServer using a virtual DVD provided by iDRAC. Before, the change, it hit an assertion failure. After the change, it completed successfully.

## Integration Instructions

N/A
