### PR TITLE
Simple nested capsules for superior authentication

### DIFF
--- a/FmpDevicePkg/FmpDevicePkg.dec
+++ b/FmpDevicePkg/FmpDevicePkg.dec
@@ -48,6 +48,9 @@
   #                  from firmware device.
   FmpDependencyDeviceLib|Include/Library/FmpDependencyDeviceLib.h
 
+  ##  @libraryclass  Provides utilities for handling FMP payloads.
+  FmpPayloadLib|Include/Library/FmpPayloadLib.h
+
 [LibraryClasses.Common.Private]
   ##  @libraryclass  Provides services to retrieve values from a capsule's FMP
   #                  Payload Header.  The structure is not included in the

--- a/FmpDevicePkg/FmpDevicePkg.dsc
+++ b/FmpDevicePkg/FmpDevicePkg.dsc
@@ -66,6 +66,7 @@
   FmpAuthenticationLib|SecurityPkg/Library/FmpAuthenticationLibPkcs7/FmpAuthenticationLibPkcs7.inf
   CapsuleUpdatePolicyLib|FmpDevicePkg/Library/CapsuleUpdatePolicyLibNull/CapsuleUpdatePolicyLibNull.inf
   FmpPayloadHeaderLib|FmpDevicePkg/Library/FmpPayloadHeaderLibV1/FmpPayloadHeaderLibV1.inf
+  FmpPayloadLib|FmpDevicePkg/Library/FmpPayloadLib/FmpPayloadLib.inf
   FmpDeviceLib|FmpDevicePkg/Library/FmpDeviceLibNull/FmpDeviceLibNull.inf
   FmpDependencyLib|FmpDevicePkg/Library/FmpDependencyLib/FmpDependencyLib.inf
   FmpDependencyCheckLib|FmpDevicePkg/Library/FmpDependencyCheckLibNull/FmpDependencyCheckLibNull.inf
@@ -86,6 +87,7 @@
   FmpDevicePkg/Library/CapsuleUpdatePolicyLibNull/CapsuleUpdatePolicyLibNull.inf
   FmpDevicePkg/Library/CapsuleUpdatePolicyLibOnProtocol/CapsuleUpdatePolicyLibOnProtocol.inf
   FmpDevicePkg/Library/FmpPayloadHeaderLibV1/FmpPayloadHeaderLibV1.inf
+  FmpDevicePkg/Library/FmpPayloadLib/FmpPayloadLib.inf
   FmpDevicePkg/Library/FmpDeviceLibNull/FmpDeviceLibNull.inf
   FmpDevicePkg/Library/FmpDependencyLib/FmpDependencyLib.inf
   FmpDevicePkg/Library/FmpDependencyCheckLib/FmpDependencyCheckLib.inf

--- a/FmpDevicePkg/FmpDevicePkg.dsc
+++ b/FmpDevicePkg/FmpDevicePkg.dsc
@@ -102,6 +102,7 @@
     <LibraryClasses>
       CapsuleUpdatePolicyLib|FmpDevicePkg/Library/CapsuleUpdatePolicyLibNull/CapsuleUpdatePolicyLibNull.inf
   }
+  FmpDevicePkg/SealedCapsulesDxe/SealedCapsulesDxe.inf
   FmpDevicePkg/FmpDxe/FmpDxe.inf {
     <Defines>
       #

--- a/FmpDevicePkg/Include/Library/FmpPayloadLib.h
+++ b/FmpDevicePkg/Include/Library/FmpPayloadLib.h
@@ -1,0 +1,32 @@
+/** @file
+  Functions to deal with an FMP payload in a transparent way.
+
+  Copyright (c) 2026, 3mdeb Sp. z o.o. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#pragma once
+
+/**
+  Retrieves range of memory that corresponds to data within FMP payload.
+
+  @param[in]   FmpPayload       Start of an FMP payload.
+  @param[in]   FmpPayloadSize   Length of the FMP payload.
+  @param[out]  PayloadData      Start of data within the payload.
+  @param[out]  PayloadDataSize  Length of the data.
+
+  @retval EFI_INVALID_PARAMETER  Any of pointer parameters is NULL.
+                                 Payload is malformed.
+  @retval EFI_SUCCESS            Output parameters were set successfully.
+
+**/
+EFI_STATUS
+EFIAPI
+FmpPayloadGetData (
+  IN  VOID   *FmpPayload,
+  IN  UINTN  FmpPayloadSize,
+  OUT VOID   **PayloadData,
+  OUT UINTN  *PayloadDataSize
+  );

--- a/FmpDevicePkg/Library/FmpPayloadHeaderLibV1/FmpPayloadHeaderLibV1.inf
+++ b/FmpDevicePkg/Library/FmpPayloadHeaderLibV1/FmpPayloadHeaderLibV1.inf
@@ -17,7 +17,7 @@
   FILE_GUID                      = 98A79A6C-513C-4E72-8375-39C0A7244C4B
   MODULE_TYPE                    = DXE_DRIVER
   VERSION_STRING                 = 1.0
-  LIBRARY_CLASS                  = FmpPayloadHeaderLib|DXE_DRIVER UEFI_DRIVER UEFI_APPLICATION
+  LIBRARY_CLASS                  = FmpPayloadHeaderLib|DXE_DRIVER DXE_RUNTIME_DRIVER UEFI_DRIVER UEFI_APPLICATION
 
 [Sources]
   FmpPayloadHeaderLib.c

--- a/FmpDevicePkg/Library/FmpPayloadLib/FmpPayloadLib.c
+++ b/FmpDevicePkg/Library/FmpPayloadLib/FmpPayloadLib.c
@@ -1,0 +1,56 @@
+/** @file
+  Functions to deal with an FMP payload in a transparent way.
+
+  Copyright (c) 2026, 3mdeb Sp. z o.o. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Library/FmpPayloadLib.h>
+
+#include <Library/FmpPayloadHeaderLib.h>
+
+/**
+  Retrieves range of memory that corresponds to data within FMP payload.
+
+  @param[in]   FmpPayload       Start of an FMP payload.
+  @param[in]   FmpPayloadSize   Length of the FMP payload.
+  @param[out]  PayloadData      Start of data within the payload.
+  @param[out]  PayloadDataSize  Length of the data.
+
+  @retval EFI_INVALID_PARAMETER  Any of pointer parameters is NULL.
+                                 Payload is malformed.
+  @retval EFI_SUCCESS            Output parameters were set successfully.
+
+**/
+EFI_STATUS
+EFIAPI
+FmpPayloadGetData (
+  IN  VOID   *FmpPayload,
+  IN  UINTN  FmpPayloadSize,
+  OUT VOID   **PayloadData,
+  OUT UINTN  *PayloadDataSize
+  )
+{
+  EFI_STATUS  Status;
+  UINT32      FmpHeaderSize;
+
+  if ((FmpPayload == NULL) || (PayloadData == NULL) || (PayloadDataSize == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Status = GetFmpPayloadHeaderSize (FmpPayload, FmpPayloadSize, &FmpHeaderSize);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  if (FmpPayloadSize < FmpHeaderSize) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  *PayloadData     = (UINT8 *)FmpPayload + FmpHeaderSize;
+  *PayloadDataSize = FmpPayloadSize - FmpHeaderSize;
+
+  return EFI_SUCCESS;
+}

--- a/FmpDevicePkg/Library/FmpPayloadLib/FmpPayloadLib.inf
+++ b/FmpDevicePkg/Library/FmpPayloadLib/FmpPayloadLib.inf
@@ -1,0 +1,25 @@
+## @file
+#  Functions to deal with an FMP payload in a transparent way.
+#
+#  Copyright (c) 2026, 3mdeb Sp. z o.o. All rights reserved.<BR>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = FmpPayloadLib
+  FILE_GUID                      = E06A8E16-B880-4CC1-BA30-1D8BC2C29256
+  MODULE_TYPE                    = DXE_DRIVER
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = FmpPayloadLib|DXE_DRIVER DXE_RUNTIME_DRIVER UEFI_DRIVER UEFI_APPLICATION
+
+[Sources]
+  FmpPayloadLib.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  FmpDevicePkg/FmpDevicePkg.dec
+
+[LibraryClasses]
+  FmpPayloadHeaderLib

--- a/FmpDevicePkg/Library/FmpPayloadLib/FmpPayloadLib.uni
+++ b/FmpDevicePkg/Library/FmpPayloadLib/FmpPayloadLib.uni
@@ -1,0 +1,12 @@
+// /** @file
+// Functions to deal with an FMP payload in a transparent way.
+//
+// Copyright (c) 2026, 3mdeb Sp. z o.o. All rights reserved.<BR>
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+// **/
+
+#string STR_MODULE_ABSTRACT     #language en-US  "Functions to deal with an FMP payload in a transparent way."
+
+#string STR_MODULE_DESCRIPTION  #language en-US  "Functions to deal with an FMP payload in a transparent way."

--- a/FmpDevicePkg/SealedCapsulesDxe/SealedCapsulesDxe.c
+++ b/FmpDevicePkg/SealedCapsulesDxe/SealedCapsulesDxe.c
@@ -1,0 +1,412 @@
+/** @file
+  Sealed Capsules DXE driver implementing CAPSULE_TRANSFORMATION_PROTOCOL.
+
+  Caution: This module requires additional review when modified.
+  This module will have external input - capsule image.
+  This external input must be validated carefully to avoid security issues like
+  buffer overflow, integer overflow.
+
+  Copyright (c) 2026, 3mdeb Sp. z o.o. All rights reserved.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <PiDxe.h>
+
+#include <Guid/FmpCapsule.h>
+#include <Guid/ImageAuthentication.h>
+
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
+#include <Library/FmpAuthenticationLib.h>
+#include <Library/FmpPayloadLib.h>
+#include <Library/PcdLib.h>
+#include <Library/UefiBootServicesTableLib.h>
+
+#include <Protocol/CapsuleTransformation.h>
+#include <Protocol/FirmwareManagement.h>
+
+//
+// A sealed capsule is an FMP capsule that acts as a container for the real FMP
+// capsule.  The two-level structure is meant to reuse as much as possible of
+// the existing functionality but address the fact that FMP signs each payload
+// individually instead of a capsule as a whole.  Signing a capsule in its
+// entirety avoids the need to use a separate mechanism to authenticate embedded
+// drivers as well as prevents repacking the capsule to modify its unsigned
+// parts in any way.
+//
+// The outer capsule (container) can have no embedded drivers, no dependencies
+// and only one payload.  Its target GUID is ignored.  The only function it has
+// is authenticating its payload which is the real (inner) capsule.  For flags
+// of outer and inner capsules must match as capsule dispatching depends on
+// them.
+//
+// Following a successful authentication the outer capsule is essentially
+// discarded and the inner one is processed in its place.  This process is
+// transparent for the capsule processing mechanism which initially cares only
+// if an outer capsule looks like an FMP capsule and then sees the inner
+// capsule.
+//
+// Description of a sealed capsule in terms of structures and their properties:
+//
+//    Outer/top capsule
+//    |
+//    |-- EFI_CAPSULE_HEADER
+//    |   |-- GUID: FMP capsule
+//    |   `-- flags: same as for the inner/nested capsule
+//    |
+//    `-- EFI_FIRMWARE_MANAGEMENT_CAPSULE_HEADER
+//        |-- embedded drivers: none
+//        |-- dependencies: none
+//        `-- payloads (exactly one):
+//            |-- EFI_FIRMWARE_MANAGEMENT_CAPSULE_IMAGE_HEADER
+//            |-- EFI_FIRMWARE_IMAGE_AUTHENTICATION
+//            |   `-- signed with root key embedded into BIOS
+//            |-- FMP_PAYLOAD_HEADER
+//            |   `-- fields aren't meaningful beyond size of payload's data
+//            `-- Inner/nested capsule
+//
+//    Inner/nested capsule
+//    |
+//    |-- EFI_CAPSULE_HEADER
+//    |   |-- GUID: FMP capsule
+//    |   `-- flags: same as for the outer/top capsule
+//    |
+//    `-- EFI_FIRMWARE_MANAGEMENT_CAPSULE_HEADER
+//        |-- embedded drivers: any
+//        |-- dependencies: any
+//        `-- payloads (any, showing just one):
+//            |-- EFI_FIRMWARE_MANAGEMENT_CAPSULE_IMAGE_HEADER
+//            |-- EFI_FIRMWARE_IMAGE_AUTHENTICATION
+//            |   `-- signed with a test key to satisfy FmpDxe
+//            |-- FMP_PAYLOAD_HEADER
+//            |   `-- fields describe system firmware to be updated
+//            `-- Firmware update image
+//
+
+/**
+  Checks if a GUID is an FMP capsule GUID or not.
+
+  @param[in] CapsuleGuid  A pointer to EFI_GUID.
+
+  @retval TRUE   It is an FMP capsule GUID.
+  @retval FALSE  It is not an FMP capsule GUID.
+**/
+STATIC
+BOOLEAN
+IsFmpCapsuleGuid (
+  IN CONST EFI_GUID  *CapsuleGuid
+  )
+{
+  return CompareGuid (&gEfiFmpCapsuleGuid, CapsuleGuid);
+}
+
+/**
+  Validate capsule header for basic sanity.
+
+  @param[in]  CapsuleHeader  Points to a capsule header.
+  @param[in]  CapsuleSize    Size of the whole capsule image.
+
+  @retval TRUE   It is a valid capsule header.
+  @retval FALSE  It is not a valid capsule header.
+**/
+STATIC
+BOOLEAN
+IsValidCapsuleHeader (
+  IN CONST EFI_CAPSULE_HEADER  *CapsuleHeader,
+  IN UINT64                    CapsuleSize
+  )
+{
+  return (CapsuleHeader->CapsuleImageSize == CapsuleSize) &&
+         (CapsuleHeader->HeaderSize < CapsuleHeader->CapsuleImageSize);
+}
+
+/**
+  Verify the signature of an outer FMP capsule image.
+
+  @param[in]  ImageHeader  Points to the image header of the outer FMP capsule.
+
+  @retval EFI_SUCCESS             Signature is valid.
+  @retval EFI_UNSUPPORTED         Signature is using an unexpected format.
+  @retval EFI_ABORTED             Root key is not available.
+  @retval EFI_SECURITY_VIOLATION  Signature doesn't correspond to any known root key.
+**/
+STATIC
+EFI_STATUS
+CheckFmpImageSignature (
+  IN EFI_FIRMWARE_MANAGEMENT_CAPSULE_IMAGE_HEADER  *ImageHeader
+  )
+{
+  EFI_FIRMWARE_IMAGE_AUTHENTICATION  *ImageAuthenticationHeader;
+  GUID                               *CertType;
+  UINT8                              *PublicKeyDataXdr;
+  UINT8                              *PublicKeyDataXdrEnd;
+  UINTN                              PublicKeyDataLength;
+  UINTN                              Index;
+  EFI_STATUS                         Status;
+
+  PublicKeyDataXdr    = PcdGetPtr (PcdFmpDevicePkcs7CertBufferXdr);
+  PublicKeyDataXdrEnd = PublicKeyDataXdr + PcdGetSize (PcdFmpDevicePkcs7CertBufferXdr);
+
+  if ((PublicKeyDataXdr == NULL) || (PublicKeyDataXdr == PublicKeyDataXdrEnd)) {
+    DEBUG ((DEBUG_ERROR, "%a(): invalid PKCS7 XDR, aborting.\n", __func__));
+    return EFI_ABORTED;
+  }
+
+  ImageAuthenticationHeader = (EFI_FIRMWARE_IMAGE_AUTHENTICATION *)&ImageHeader[1];
+
+  CertType = &ImageAuthenticationHeader->AuthInfo.CertType;
+  if (!CompareGuid (&gEfiCertPkcs7Guid, CertType)) {
+    DEBUG ((DEBUG_INFO, "%a(): unexpected certificate type: %g\n", __func__, CertType));
+    return EFI_UNSUPPORTED;
+  }
+
+  //
+  // Structure of PcdFmpDevicePkcs7CertBufferXdr:
+  //  - an entry:
+  //    + length of a public key as 32-bit big-endian
+  //    + a public key
+  //    + padding to 4-byte boundary (unnecessary for the last element)
+  //  - other entries follow
+  //
+  for (Index = 0; PublicKeyDataXdr < PublicKeyDataXdrEnd; Index++) {
+    DEBUG ((
+      DEBUG_INFO,
+      "%a(): certificate #%d [%p..%p].\n",
+      __func__,
+      Index,
+      PublicKeyDataXdr,
+      PublicKeyDataXdrEnd
+      ));
+
+    if (PublicKeyDataXdr + sizeof (UINT32) > PublicKeyDataXdrEnd) {
+      DEBUG ((DEBUG_ERROR, "%a(): certificate size extends beyond end of PCD, skipping it.\n", __func__));
+      return EFI_ABORTED;
+    }
+
+    PublicKeyDataLength = SwapBytes32 (*(UINT32 *)PublicKeyDataXdr);
+    PublicKeyDataXdr   += sizeof (UINT32);
+    if (PublicKeyDataXdr + PublicKeyDataLength > PublicKeyDataXdrEnd) {
+      DEBUG ((DEBUG_ERROR, "%a(): certificate extends beyond end of PCD, skipping it.\n", __func__));
+      return EFI_ABORTED;
+    }
+
+    Status = AuthenticateFmpImage (
+               ImageAuthenticationHeader,
+               ImageHeader->UpdateImageSize,
+               PublicKeyDataXdr,
+               PublicKeyDataLength
+               );
+    if (!EFI_ERROR (Status)) {
+      return EFI_SUCCESS;
+    }
+
+    PublicKeyDataXdr += PublicKeyDataLength;
+    PublicKeyDataXdr  = (UINT8 *)ALIGN_POINTER (PublicKeyDataXdr, sizeof (UINT32));
+  }
+
+  return EFI_SECURITY_VIOLATION;
+}
+
+/**
+  Optionally transform a capsule out of an outer one.
+
+  Caution: This function may receive untrusted input.
+
+  This function validates the fields in EFI_FIRMWARE_MANAGEMENT_CAPSULE_HEADER
+  and EFI_FIRMWARE_MANAGEMENT_CAPSULE_IMAGE_HEADER.
+
+  This function checks if the payload is an FMP capsule.
+
+  @param[in]      This                 A pointer to a CAPSULE_TRANSFORMATION_PROTOCOL.
+  @param[in, out] CapsuleHeader        A pointer to a capsule header.
+                                       On input points to the original capsule header.
+                                       On output points to the transformed capsule header.
+
+  @retval EFI_SUCCESS             The capsule has been transformed successfully.
+  @retval EFI_INVALID_PARAMETER   An input pointer is NULL or some capsule check has failed.
+  @retval EFI_UNSUPPORTED         The outer capsule is not an FMP capsule, contains an embedded
+                                  driver or multiple payloads, uses old payload format, is not
+                                  signed, or uses an unexpected signature format.
+  @retval EFI_SECURITY_VIOLATION  The inner capsule is not authentic.
+  @retval Others                  Statuses returned by AuthenticateFmpImage().
+**/
+STATIC
+EFI_STATUS
+EFIAPI
+CapsuleTransformationImpl (
+  IN     CAPSULE_TRANSFORMATION_PROTOCOL  *This,
+  IN OUT EFI_CAPSULE_HEADER               **CapsuleHeader
+  )
+{
+  EFI_FIRMWARE_MANAGEMENT_CAPSULE_HEADER        *OuterFmpHeader;
+  EFI_FIRMWARE_MANAGEMENT_CAPSULE_IMAGE_HEADER  *OuterImageHeader;
+  EFI_FIRMWARE_IMAGE_AUTHENTICATION             *OuterAuthenticationHeader;
+  UINTN                                         OuterAuthDataSize;
+  UINTN                                         StartOfPayload;
+  UINT64                                        *OuterOffsetList;
+  EFI_STATUS                                    Status;
+  EFI_CAPSULE_HEADER                            *InnerCapsuleHeader;
+  EFI_CAPSULE_HEADER                            *OuterCapsuleHeader;
+  UINTN                                         InnerCapsuleSize;
+  UINTN                                         OuterCapsulePayloadSize;
+
+  if ((CapsuleHeader == NULL) || (*CapsuleHeader == NULL)) {
+    DEBUG ((DEBUG_ERROR, "%a(): input pointer is NULL.\n", __func__));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  OuterCapsuleHeader = *CapsuleHeader;
+  if (OuterCapsuleHeader->HeaderSize >= OuterCapsuleHeader->CapsuleImageSize) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a(): outer capsule's header is too large (0x%lx >= 0x%lx).\n",
+      __func__,
+      OuterCapsuleHeader->HeaderSize,
+      OuterCapsuleHeader->CapsuleImageSize
+      ));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (!IsFmpCapsuleGuid (&OuterCapsuleHeader->CapsuleGuid)) {
+    DEBUG ((DEBUG_ERROR, "%a(): outer capsule is not an FMP capsule.\n", __func__));
+    return EFI_UNSUPPORTED;
+  }
+
+  OuterFmpHeader = (EFI_FIRMWARE_MANAGEMENT_CAPSULE_HEADER *)((UINT8 *)OuterCapsuleHeader + OuterCapsuleHeader->HeaderSize);
+  if (OuterFmpHeader->PayloadItemCount != 1) {
+    DEBUG ((DEBUG_ERROR, "%a(): multiple payloads in the outer capsule.\n", __func__));
+    return EFI_UNSUPPORTED;
+  }
+
+  if (OuterFmpHeader->EmbeddedDriverCount != 0) {
+    DEBUG ((DEBUG_ERROR, "%a(): embedded driver inside the outer capsule.\n", __func__));
+    return EFI_UNSUPPORTED;
+  }
+
+  OuterOffsetList  = (UINT64 *)&OuterFmpHeader[1];
+  OuterImageHeader = (EFI_FIRMWARE_MANAGEMENT_CAPSULE_IMAGE_HEADER *)((UINT8 *)OuterFmpHeader + OuterOffsetList[0]);
+
+  if (OuterImageHeader->Version < EFI_FIRMWARE_MANAGEMENT_CAPSULE_IMAGE_HEADER_INIT_VERSION) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a(): outer capsule version must be at least %d, got %d.\n",
+      __func__,
+      EFI_FIRMWARE_MANAGEMENT_CAPSULE_IMAGE_HEADER_INIT_VERSION,
+      OuterImageHeader->Version
+      ));
+    return EFI_UNSUPPORTED;
+  }
+
+  if (OuterImageHeader->ImageCapsuleSupport != CAPSULE_SUPPORT_AUTHENTICATION) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a(): outer capsule must support auth but not dependencies, got 0x%x.\n",
+      __func__,
+      OuterImageHeader->ImageCapsuleSupport
+      ));
+    return EFI_UNSUPPORTED;
+  }
+
+  Status = CheckFmpImageSignature (OuterImageHeader);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a(): the capsule failed to authenticate: %r.\n", __func__, Status));
+    return Status;
+  }
+
+  OuterAuthenticationHeader = (EFI_FIRMWARE_IMAGE_AUTHENTICATION *)&OuterImageHeader[1];
+
+  OuterAuthDataSize = OuterAuthenticationHeader->AuthInfo.Hdr.dwLength + sizeof (OuterAuthenticationHeader->MonotonicCount);
+
+  StartOfPayload = (UINTN)OuterAuthenticationHeader + OuterAuthDataSize;
+  if ((StartOfPayload < (UINTN)OuterAuthenticationHeader) ||
+      (StartOfPayload >= (UINTN)OuterAuthenticationHeader + OuterImageHeader->UpdateImageSize))
+  {
+    DEBUG ((DEBUG_ERROR, "%a(): pointer overflow on handling payload image.\n", __func__));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (OuterImageHeader->UpdateImageSize < OuterAuthDataSize) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a(): outer image is shorter than authentication data: 0x%x < 0x%lx.\n",
+      __func__,
+      OuterImageHeader->UpdateImageSize,
+      OuterAuthDataSize
+      ));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  OuterCapsulePayloadSize = OuterImageHeader->UpdateImageSize - OuterAuthDataSize;
+
+  Status = FmpPayloadGetData (
+             (VOID *)StartOfPayload,
+             OuterCapsulePayloadSize,
+             (VOID **)&InnerCapsuleHeader,
+             &InnerCapsuleSize
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a(): failed to extract FMP data: %r.\n", __func__, Status));
+    return Status;
+  }
+
+  if (InnerCapsuleSize < sizeof (EFI_CAPSULE_HEADER)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a(): outer payload is smaller than a capsule header (0x%lx < 0x%lx).\n",
+      __func__,
+      InnerCapsuleSize,
+      sizeof (EFI_CAPSULE_HEADER)
+      ));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (!IsValidCapsuleHeader (InnerCapsuleHeader, InnerCapsuleSize)) {
+    DEBUG ((DEBUG_ERROR, "%a(): outer payload is not a capsule.\n", __func__));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (!IsFmpCapsuleGuid (&InnerCapsuleHeader->CapsuleGuid)) {
+    DEBUG ((DEBUG_ERROR, "%a(): nested capsule is not an FMP capsule.\n", __func__));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if ((OuterCapsuleHeader->HeaderSize != InnerCapsuleHeader->HeaderSize) ||
+      (OuterCapsuleHeader->Flags != InnerCapsuleHeader->Flags))
+  {
+    DEBUG ((DEBUG_ERROR, "%a(): parameters of outer and nested capsules don't match!\n", __func__));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  *CapsuleHeader = InnerCapsuleHeader;
+
+  return EFI_SUCCESS;
+}
+
+STATIC CAPSULE_TRANSFORMATION_PROTOCOL  mCapsuleTransformationProtocol = {
+  CapsuleTransformationImpl,
+};
+
+/**
+  Driver entry point.  Installs CAPSULE_TRANSFORMATION_PROTOCOL.
+
+  @param[in] ImageHandle  The firmware allocated handle for the EFI image.
+  @param[in] SystemTable  A pointer to the EFI System Table.
+
+  @retval EFI_SUCCESS  Protocol was installed successfully.
+  @retval Others       Protocol installation failed.
+**/
+EFI_STATUS
+EFIAPI
+EntryPoint (
+  IN EFI_HANDLE        ImageHandle,
+  IN EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  return gBS->InstallMultipleProtocolInterfaces (
+                &ImageHandle,
+                &gCapsuleTransformationProtocolGuid,
+                &mCapsuleTransformationProtocol,
+                NULL
+                );
+}

--- a/FmpDevicePkg/SealedCapsulesDxe/SealedCapsulesDxe.inf
+++ b/FmpDevicePkg/SealedCapsulesDxe/SealedCapsulesDxe.inf
@@ -1,0 +1,47 @@
+## @file
+# This DXE driver implements CAPSULE_TRANSFORMATION_PROTOCOL to unseal outer
+# FMP capsule and extract the authenticated inner FMP capsule.
+#
+# Copyright (c) 2026, 3mdeb Sp. z o.o. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = SealedCapsulesDxe
+  FILE_GUID                      = 920689E3-C573-45E1-9736-142A21B5411D
+  MODULE_TYPE                    = DXE_DRIVER
+  VERSION_STRING                 = 1.0
+  ENTRY_POINT                    = EntryPoint
+
+[Sources]
+  SealedCapsulesDxe.c
+
+[Packages]
+  FmpDevicePkg/FmpDevicePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  MdePkg/MdePkg.dec
+
+[LibraryClasses]
+  BaseLib
+  BaseMemoryLib
+  DebugLib
+  FmpAuthenticationLib
+  FmpPayloadLib
+  PcdLib
+  UefiBootServicesTableLib
+  UefiDriverEntryPoint
+
+[Pcd]
+  gFmpDevicePkgTokenSpaceGuid.PcdFmpDevicePkcs7CertBufferXdr  ## CONSUMES
+
+[Guids]
+  gEfiCertPkcs7Guid   ## CONSUMES
+  gEfiFmpCapsuleGuid  ## CONSUMES
+
+[Protocols]
+  gCapsuleTransformationProtocolGuid  ## PRODUCES
+
+[Depex]
+  TRUE

--- a/MdeModulePkg/Include/Protocol/CapsuleTransformation.h
+++ b/MdeModulePkg/Include/Protocol/CapsuleTransformation.h
@@ -1,0 +1,49 @@
+/** @file
+  This file declares a protocol to transform a capsule.
+
+  It is essentially a hook into capsule processing mechanism that can be used
+  to additionally validate a capsule or pre-process it and return a different
+  capsule to be processed in its place.
+
+  Copyright (c) 2026, 3mdeb Sp. z o.o. All rights reserved.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#pragma once
+
+#define CAPSULE_TRANSFORMATION_PROTOCOL_GUID \
+  { 0xdc20bf2b, 0x0769, 0x4489, { 0x81, 0xde, 0x7f, 0x9e, 0x38, 0x03, 0x05, 0x14 }}
+
+typedef struct _CAPSULE_TRANSFORMATION_PROTOCOL CAPSULE_TRANSFORMATION_PROTOCOL;
+
+/**
+  Optionally transform a capsule.
+
+  @param[in]      This           A pointer to a CAPSULE_TRANSFORMATION_PROTOCOL.
+  @param[in, out] CapsuleHeader  A pointer to a capsule header.
+                                 On input points to the original capsule header.
+                                 On output points to the transformed capsule header (which
+                                 may be the original one).
+
+  @retval EFI_SUCCESS             The capsule has been transformed successfully or needs no
+                                  transformation.
+  @retval EFI_INVALID_PARAMETER   An input pointer is NULL or some capsule check or
+                                  transformation has failed.
+  @retval Others                  Other implementation-specific error.
+**/
+typedef
+EFI_STATUS
+(EFIAPI *TRANSFORM_CAPSULE)(
+  IN     CAPSULE_TRANSFORMATION_PROTOCOL  *This,
+  IN OUT EFI_CAPSULE_HEADER               **CapsuleHeader
+  );
+
+///
+/// Provides a hook into capsule processing mechanism to perform custom
+/// preprocessing of a capsule.
+///
+struct _CAPSULE_TRANSFORMATION_PROTOCOL {
+  TRANSFORM_CAPSULE    Transform;
+};
+
+extern EFI_GUID  gCapsuleTransformationProtocolGuid;

--- a/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleLib.inf
+++ b/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleLib.inf
@@ -82,6 +82,7 @@
   gEfiBlockIoProtocolGuid                       ## CONSUMES
   gEfiDiskIoProtocolGuid                        ## CONSUMES
   gEdkiiVariablePolicyProtocolGuid              ## CONSUMES
+  gCapsuleTransformationProtocolGuid            ## SOMETIMES_CONSUMES
 
 [Guids]
   gEfiFmpCapsuleGuid                      ## SOMETIMES_CONSUMES ## GUID

--- a/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleProcessLib.c
+++ b/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleProcessLib.c
@@ -15,6 +15,7 @@
 **/
 
 #include <PiDxe.h>
+#include <Protocol/CapsuleTransformation.h>
 #include <Protocol/EsrtManagement.h>
 #include <Protocol/FirmwareManagementProgress.h>
 
@@ -34,6 +35,21 @@
 #include <IndustryStandard/WindowsUxCapsule.h>
 
 extern EDKII_FIRMWARE_MANAGEMENT_PROGRESS_PROTOCOL  *mFmpProgress;
+
+/**
+  Record capsule status variable.
+
+  @param[in] CapsuleHeader  The capsule image header
+  @param[in] CapsuleStatus  The capsule process stauts
+
+  @retval EFI_SUCCESS          The capsule status variable is recorded.
+  @retval EFI_OUT_OF_RESOURCES No resource to record the capsule status variable.
+**/
+EFI_STATUS
+RecordCapsuleStatusVariable (
+  IN EFI_CAPSULE_HEADER  *CapsuleHeader,
+  IN EFI_STATUS          CapsuleStatus
+  );
 
 /**
   Return if this FMP is a system FMP or a device FMP, based upon CapsuleHeader.
@@ -129,6 +145,8 @@ VOID        **mCapsulePtr;
 CHAR16      **mCapsuleNamePtr;
 EFI_STATUS  *mCapsuleStatusArray;
 UINT32      mCapsuleTotalNumber;
+
+STATIC CAPSULE_TRANSFORMATION_PROTOCOL  *CapsuleTransformation;
 
 /**
   The firmware implements to process the capsule image.
@@ -572,16 +590,50 @@ ProcessTheseCapsules (
       // Call capsule library to process capsule image.
       //
       EmbeddedDriverCount = 0;
-      if (IsFmpCapsule (CapsuleHeader)) {
-        Status = ValidateFmpCapsule (CapsuleHeader, &EmbeddedDriverCount);
+      if (!IsFmpCapsule (CapsuleHeader)) {
+        mCapsuleStatusArray[Index] = EFI_ABORTED;
+        continue;
+      }
+
+      Status = ValidateFmpCapsule (CapsuleHeader, &EmbeddedDriverCount);
+      if (EFI_ERROR (Status)) {
+        DEBUG ((DEBUG_ERROR, "ValidateFmpCapsule failed with %r. Ignore!\n", Status));
+        mCapsuleStatusArray[Index] = EFI_ABORTED;
+        continue;
+      }
+
+      if (CapsuleTransformation != NULL) {
+        Status = CapsuleTransformation->Transform (CapsuleTransformation, &CapsuleHeader);
         if (EFI_ERROR (Status)) {
-          DEBUG ((DEBUG_ERROR, "ValidateFmpCapsule failed. Ignore!\n"));
+          DEBUG ((DEBUG_ERROR, "Capsule transformation failed with %r. Ignore!\n", Status));
+          if ((Status == EFI_INVALID_PARAMETER) || (Status == EFI_UNSUPPORTED) || (Status == EFI_SECURITY_VIOLATION)) {
+            //
+            // Report issues with the capsule to the user.
+            //
+            RecordCapsuleStatusVariable (CapsuleHeader, Status);
+          }
+
           mCapsuleStatusArray[Index] = EFI_ABORTED;
           continue;
         }
-      } else {
-        mCapsuleStatusArray[Index] = EFI_ABORTED;
-        continue;
+
+        if (!IsFmpCapsule (CapsuleHeader)) {
+          mCapsuleStatusArray[Index] = EFI_ABORTED;
+          continue;
+        }
+
+        //
+        // Re-validate the capsule after the transformation and obtain updated
+        // driver count.
+        //
+        Status = ValidateFmpCapsule (CapsuleHeader, &EmbeddedDriverCount);
+        if (EFI_ERROR (Status)) {
+          DEBUG ((DEBUG_ERROR, "ValidateFmpCapsule failed for transformed capsule with %r. Ignore!\n", Status));
+          mCapsuleStatusArray[Index] = EFI_ABORTED;
+          continue;
+        }
+
+        DEBUG ((DEBUG_INFO, "New EmbeddedDriverCount: %d\n", EmbeddedDriverCount));
       }
 
       if ((!FirstRound) || (EmbeddedDriverCount == 0)) {
@@ -680,6 +732,19 @@ ProcessCapsules (
   EFI_STATUS  Status;
 
   if (!mDxeCapsuleLibEndOfDxe) {
+    //
+    // The lookup for this protocol must happen on the first call to not pick up
+    // an implementation provided by an embedded driver of some capsule.
+    //
+    Status = gBS->LocateProtocol (
+                    &gCapsuleTransformationProtocolGuid,
+                    NULL,
+                    (VOID **)&CapsuleTransformation
+                    );
+    if (!EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_INFO, "Discovered CapsuleTransformation protocol\n"));
+    }
+
     Status = ProcessTheseCapsules (TRUE);
 
     //

--- a/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeRuntimeCapsuleLib.inf
+++ b/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeRuntimeCapsuleLib.inf
@@ -57,6 +57,7 @@
   gEfiFirmwareManagementProtocolGuid            ## CONSUMES
   gEdkiiVariableLockProtocolGuid                ## SOMETIMES_CONSUMES
   gEdkiiFirmwareManagementProgressProtocolGuid  ## SOMETIMES_CONSUMES
+  gCapsuleTransformationProtocolGuid            ## SOMETIMES_CONSUMES
 
 [Guids]
   gEfiFmpCapsuleGuid                      ## SOMETIMES_CONSUMES ## GUID

--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -762,6 +762,9 @@
   ## Include/Protocol/CxlIo.h
   gEdkiiCxlIoProtocolGuid = { 0x8FAC60B2, 0xBBC1, 0x41DE, {0xA7, 0x97, 0x98, 0x75, 0xCD, 0xD3, 0xA8, 0xF8 } }
 
+  ## Include/Protocol/CapsuleTransformation.h
+  gCapsuleTransformationProtocolGuid = { 0xdc20bf2b, 0x0769, 0x4489, { 0x81, 0xde, 0x7f, 0x9e, 0x38, 0x03, 0x05, 0x14 }}
+
 [PcdsFeatureFlag]
   ## Indicates if the platform can support update capsule across a system reset.<BR><BR>
   #   TRUE  - Supports update capsule across a system reset.<BR>

--- a/UefiPayloadPkg/UefiPayloadPkg.dsc
+++ b/UefiPayloadPkg/UefiPayloadPkg.dsc
@@ -54,7 +54,12 @@
   # CAPSULE_MAIN_FW_GUID specifies GUID to be used by FmpDxe when
   # CAPSULE_SUPPORT is set to TRUE
   #
+  # SEALED_CAPSULES requires that a real capsule is the payload of another
+  # capsule that serves as a container and ensures authenticity and integrity
+  # of the real capsule as a whole.
+  #
   DEFINE CAPSULE_SUPPORT              = FALSE
+  DEFINE SEALED_CAPSULES              = FALSE
   DEFINE CAPSULE_MAIN_FW_GUID         =
 
   #
@@ -311,6 +316,7 @@
   FmpDependencyDeviceLib|FmpDevicePkg/Library/FmpDependencyDeviceLibNull/FmpDependencyDeviceLibNull.inf
   FmpDependencyLib|FmpDevicePkg/Library/FmpDependencyLib/FmpDependencyLib.inf
   FmpPayloadHeaderLib|FmpDevicePkg/Library/FmpPayloadHeaderLibV1/FmpPayloadHeaderLibV1.inf
+  FmpPayloadLib|FmpDevicePkg/Library/FmpPayloadLib/FmpPayloadLib.inf
   !else
   CapsuleLib|MdeModulePkg/Library/DxeCapsuleLibNull/DxeCapsuleLibNull.inf
   !endif
@@ -519,7 +525,7 @@
 !endif
 
 [LibraryClasses.common.DXE_RUNTIME_DRIVER]
-!if $(SECURE_BOOT_ENABLE) == TRUE
+!if $(SECURE_BOOT_ENABLE) == TRUE || $(CAPSULE_SUPPORT) == TRUE
   BaseCryptLib|CryptoPkg/Library/BaseCryptLib/RuntimeCryptLib.inf
 !endif
   PcdLib|MdePkg/Library/DxePcdLib/DxePcdLib.inf
@@ -632,6 +638,11 @@
 
   ## Whether FMP capsules are enabled.
   gEfiMdeModulePkgTokenSpaceGuid.PcdCapsuleFmpSupport|$(CAPSULE_SUPPORT)
+!if $(SEALED_CAPSULES)
+  gEfiMdeModulePkgTokenSpaceGuid.PcdCapsuleEmbeddedDriverSupport|TRUE
+  # Root key for signing the outer capsule.
+  !include BaseTools/Source/Python/Pkcs7Sign/TestRoot.cer.gFmpDevicePkgTokenSpaceGuid.PcdFmpDevicePkcs7CertBufferXdr.inc
+!endif
 
 !if $(CRYPTO_PROTOCOL_SUPPORT) == TRUE
 !if $(CRYPTO_DRIVER_EXTERNAL_SUPPORT) == FALSE
@@ -1008,6 +1019,9 @@
 !endif
   }
   MdeModulePkg/Universal/EsrtDxe/EsrtDxe.inf
+!if $(SEALED_CAPSULES)
+  FmpDevicePkg/SealedCapsulesDxe/SealedCapsulesDxe.inf
+!endif
 !endif
 
 

--- a/UefiPayloadPkg/UefiPayloadPkg.fdf
+++ b/UefiPayloadPkg/UefiPayloadPkg.fdf
@@ -374,6 +374,9 @@ INF ShellPkg/Application/Shell/Shell.inf
 #
 !if $(CAPSULE_SUPPORT) == TRUE
 INF MdeModulePkg/Universal/EsrtDxe/EsrtDxe.inf
+!if $(SEALED_CAPSULES) == TRUE
+INF FmpDevicePkg/SealedCapsulesDxe/SealedCapsulesDxe.inf
+!endif
 !endif
 
 !if $(UNIVERSAL_PAYLOAD) == TRUE


### PR DESCRIPTION
## Description

This PR presents a slightly different take on capsule authentication than what's already available.  The idea is to embed one FMP capsule (inner) as a payload of another FMP capsule (outer) to take advantage of payload signing and in this way ensure authenticity of the embedded capsule as a whole with all payloads and embedded drivers in a specific order.  This approach is drastically simpler than `SignedCapsulePkg` [was](https://github.com/tianocore/edk2/pull/12537) and is convenient to use with first-stage firmware like `coreboot`.

#### Motivation

The format of update capsules employs signing on a per-payload basis (excluding `EFI_FIRMWARE_MANAGEMENT_CAPSULE_IMAGE_HEADER` at the start).  This means that neither embedded DXE drivers nor capsule flags are covered by any signature.

The situation is fine if `FmpDxe` is part of the firmware and capsules contain nothing but a payload.  However, embedding `FmpDxe` into capsules is much more flexible as it avoids hard-coding how a particular firmware is updated.

A significant problem in the latter case is that `FmpDxe` stores the root key used for payload verification and making `FmpDxe` an embedded driver results in capsules validating themselves (still can work as an integrity check, but not for authentication).

Of course, embedded drivers could be taken care of by SecureBoot, but that's not the context it was designed for (e.g., it can be turned off and also uses unrelated set of keys) and it still can't address validation of a capsule as a whole allowing it to be repacked to add/remove payloads or drivers (should be of minor concern, but still).

#### SignedCapsulePkg

`SignedCapsulePkg` was one way of addressing the issue which was done by creating a firmware volume and using it as a payload in a capsule.  During an update a proxy FMP implementation that lived in the firmware authenticated the payload, mounted it as a volume, dispatched drivers in it and invoked real FMP implementation provided by one of those drivers.

#### Proposed solution

To work around capsules not being signed as a whole some kind of container is needed.  And since a capsule is sort of a container, why not put one capsule as a payload of another capsule?  The only extra step for the firmware is checking the signature and peeling off the outer capsule before handling the inner one.

That's very little extra code which was implemented by a new optional `CapsuleTransformation` protocol.  If an instance of the protocol is found, `DxeCapsuleLibFmp` passes each capsule through it for validation/unpacking and then processes the result.  The protocol is generic enough to have multiple implementations that do things differently, the only requirement is that capsules are of FMP type (both input and output) which is already the case.

This way capsule images are still of FMP type, they just have two layers to them and a few restrictions on the contents of the outer capsule.  Building such capsules merely requires a second invocation of `GenerateCapsule`, which is a trivial extra step.

**Pros**:
 - authenticates the capsule as a whole
 - the implementation and usage are quite straightforward
 - doesn't introduce any new entities, just reuses an existing one twice
 - works about the same as capsules already do
 - unlike `SignedCapsulePkg`, this approach is non-intrusive and is orthogonal to other facets of capsule updates and should be compatible with, for example, https://github.com/tianocore/edk2/pull/12053

**Cons**:
 - in a way, this is an abuse of the capsule format which wasn't meant to work in this manner; however, any solution which addresses shortcomings of the format will have to not "comply" with it in some way
 - at the moment both inner and outer capsules need to sign payloads because `FmpDxe` rejects unsigned ones; this can be changed, but doesn't necessarily need to because inner capsule can simply use a test key with minimal overhead

#### Implementation

Targets integration between coreboot and EDK.  There are [scripts](https://github.com/Dasharo/coreboot/commit/db7f1badb3925ba0e1f6d5bb9de2dc2dd15b41cb) to build and test the whole thing in QEMU in 3 simple steps.

The code addition is quite small (if one ignores boilerplate and moving some code around).  The most important changes are in [`MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleProcessLib.c`](https://github.com/Dasharo/edk2-upstream/blob/up/nested-capsules/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleProcessLib.c#L605-L637) where a new [`CapsuleTransformation` protocol](https://github.com/Dasharo/edk2-upstream/blob/up/nested-capsules/MdePkg/Include/Protocol/CapsuleTransformation.h) is hooked and in [`FmpDevicePkg/SealedCapsulesDxe/SealedCapsulesDxe.c`](https://github.com/Dasharo/edk2-upstream/blob/up/nested-capsules/FmpDevicePkg/SealedCapsulesDxe/SealedCapsulesDxe.c) where it's implemented.

~~Additionally, detection of a test root key has been extracted to a separate library and a DXE has been added to invoke it from the firmware in cases when `FmpDxe` is not part of the firmware itself.  Without this change not compiling `FmpDxe` into the firmware made this warning disappear.~~  Removed from this PR to make it smaller, the main functionality does not depend on these changes in any way.  Will be sent separately after this PR is handled (mainly useful combined with this PR, so not sending both at the same time).

Here is an "illustration" of outer and inner capsules which may be helpful to understand the approach in more detail:

https://github.com/tianocore/edk2/blob/88d3ec697a09ac16ad8ba91964b80c5c10137b1a/FmpDevicePkg/SealedCapsulesDxe/SealedCapsulesDxe.c#L52-L84

#### Building/Testing

```bash
git clone --branch up/uefi-capsules-q35-nested https://github.com/Dasharo/coreboot.git coreboot
cd coreboot
./nested-poc-build-firmware
./nested-poc-make-capsules
./nested-poc-run-qemu
```

`qemu-disk/bad.cap` is signed with keys from `other-keys/` and results in security violation error:

```
Shell> fs0:\CapsuleApp.efi fs0:\bad.cap
... reboot ...
Shell> fs0:\CapsuleApp.efi -S
CapsuleMax - CapsuleFFFF
CapsuleLast - Capsule0000
CapsuleName: Capsule0000
  Capsule Guid: 6DCBD5ED-E82D-4C44-BDA1-7194199AD92A
  Capsule ProcessedTime: 03/06/2026  19:26
  Capsule Status: Security Violation
```

`qemu-disk/good.cap` is signed with test keys (EDK uses these by default) and successfully updates firmware (variables aren't preserved, so successful status isn't reported):

```
Shell> fs0:\CapsuleApp.efi fs0:\good.cap
... reboot ...
Shell> fs0:\CapsuleApp.efi -S
CapsuleMax - CapsuleFFFF
```

#### Questions

- [ ] Breaking change?
  - No, the change is opt-in and should not cause any breakage.
- [ ] Impacts security?
  - In a sense that this is about authentication and processing of untrusted input.
- [ ] Includes tests?
  - No.
 
## How This Was Tested

This implementation is tested in downstream EDK2 using [OSFV](https://github.com/Dasharo/open-source-firmware-validation/blob/develop/dasharo-stability/capsule-update.robot) test suite.  Tests cover things like successful update, wrong GUID, invalid signatures and a few other aspects which are out of scope of this PR.  Robot's logs are available at https://github.com/Dasharo/dasharo-issues/issues/1443#issuecomment-4311229142 for MSI Z-690 DDR4, NovaCustom V540TND and QEMU targets.

## Integration Instructions

* Setting `gFmpDevicePkgTokenSpaceGuid.PcdFmpDevicePkcs7CertBufferXdr` to production root key(s) in the firmware.
* Setting `gFmpDevicePkgTokenSpaceGuid.PcdFmpDevicePkcs7CertBufferXdr` to any (likely just public EDK2 test key) root key for `FmpDxe`.  The exact key doesn't matter, as long as the inner capsule successfully validates itself.
* Wrapping actual firmware update capsule (signed with test key) into another one (signed with production key) the same way the first one is built.