### PR TITLE
SecurityPkg/Tcg2Smm: harden NVS/SMI state initialization

### DIFF
--- a/SecurityPkg/Tcg/Tcg2Smm/Tcg2Smm.c
+++ b/SecurityPkg/Tcg/Tcg2Smm/Tcg2Smm.c
@@ -19,8 +19,8 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 EFI_SMM_VARIABLE_PROTOCOL  *mSmmVariable = NULL;
 TCG_NVS                    *mTcgNvs      = NULL;
-UINTN                      mPpSoftwareSmi;
-UINTN                      mMcSoftwareSmi;
+UINTN                      mPpSoftwareSmi = MAX_UINTN;
+UINTN                      mMcSoftwareSmi = MAX_UINTN;
 EFI_HANDLE                 mReadyToLockHandle;
 
 /**
@@ -144,6 +144,11 @@ PhysicalPresenceCallback (
   UINT32  OperationRequest;
   UINT32  RequestParameter;
 
+  if (mTcgNvs == NULL) {
+    DEBUG ((DEBUG_ERROR, "[%a] mTcgNvs has not been initialized yet\n", __func__));
+    return EFI_SUCCESS;
+  }
+
   if (mTcgNvs->PhysicalPresence.Parameter == TCG_ACPI_FUNCTION_RETURN_REQUEST_RESPONSE_TO_OS) {
     mTcgNvs->PhysicalPresence.ReturnCode = Tcg2PhysicalPresenceLibReturnOperationResponseToOsFunction (
                                              &MostRecentRequest,
@@ -233,6 +238,8 @@ InitializeTcgCommon (
   PpSwHandle         = NULL;
   McSwHandle         = NULL;
   NotifyHandle       = NULL;
+  mPpSoftwareSmi     = MAX_UINTN;
+  mMcSoftwareSmi     = MAX_UINTN;
 
   // Register a root handler to communicate the NVS region and SMI channel between MM and DXE
   Status = gMmst->MmiHandlerRegister (TpmNvsCommunciate, &gTpmNvsMmGuid, &mReadyToLockHandle);


### PR DESCRIPTION
Motivation
Prevent unsafe dereference and ambiguous SMI state when a Software SMI runs before the MM/DXE NVS exchange completes, which could cause an SMM crash/DoS or expose undefined SMI values.
Description
Initialize mPpSoftwareSmi and mMcSoftwareSmi to MAX_UINTN to avoid exposing uninitialized SMI values.
Add a defensive NULL check for mTcgNvs at the start of PhysicalPresenceCallback() and return safely with a debug message if the NVS region is not yet initialized.
Reinitialize mPpSoftwareSmi/mMcSoftwareSmi to MAX_UINTN during InitializeTcgCommon() to ensure consistent startup state.
Testing
Ran git diff --check and git status --short to validate the working tree and ensure the patch staged/committed; both checks passed.
Performed code discovery/searches with rg to verify related SMM communication and buffer-validation paths (e.g. SmmIsBufferOutsideSmmValid) and confirmed the change complements existing validation logic.
Verified the patch file was applied and committed (SecurityPkg/Tcg/Tcg2Smm/Tcg2Smm.c) and the commit message SecurityPkg/Tcg2Smm: harden NVS/SMI state initialization was created successfully.