### PR TITLE
Add CompilerIntrinsicsLib to BasePrintLib.inf.

### DIFF
--- a/MdePkg/Library/BasePrintLib/BasePrintLib.inf
+++ b/MdePkg/Library/BasePrintLib/BasePrintLib.inf
@@ -34,6 +34,7 @@
 
 
 [LibraryClasses]
+  CompilerIntrinsicsLib
   DebugLib
   BaseLib
   PcdLib


### PR DESCRIPTION
# Description
This is to fix:
```
 /usr/lib/aarch64-linux-gnu/bin/ld: /tmp/cczqHYdu.ltrans0.ltrans.o: in function `UnicodeVSPrint':
 ...MdePkg/Library/BasePrintLib/PrintLib.c:73:(.text.UnicodeVSPrint+0x48): undefined reference to `memcpy'
```
```
  return BasePrintLibSPrintMarker ((CHAR8 *)StartOfBuffer, BufferSize >> 1, FORMAT_UNICODE | OUTPUT_UNICODE, (CHAR8 *)FormatString, Marker, NULL);
```
presumably passing `VA_LIST Marker` by value.

Maybe EDK2 should avoid copying struct/union/va_list, or passing/returning by value?

- [x] Breaking change?
  - I think so, maybe, it breaks people's builds, that do not have CompilerIntrinsicsLib in *.dsc?
- [ ] Impacts security?
  - No.
- [ ] Includes tests?
  - No.

## How This Was Tested

Local builds.

## Integration Instructions

N/A?