### PR TITLE
ArmVirtPkg: allow runtime control of serial debug log level via DT

### DIFF
--- a/ArmVirtPkg/Include/Guid/EarlyPL011BaseAddress.h
+++ b/ArmVirtPkg/Include/Guid/EarlyPL011BaseAddress.h
@@ -21,9 +21,15 @@ typedef struct {
   //
   // for SerialPortLib and console IO
   //
-  UINT64    ConsoleAddress;
+  UINT64     ConsoleAddress;
   //
   // for DebugLib; may equal ConsoleAddress if there's only one PL011 UART
   //
-  UINT64    DebugAddress;
+  UINT64     DebugAddress;
+  //
+  // for DebugLib: Serial debug log level override from the "edk2,debug-level" DT property.
+  // DebugLevel is only valid when DebugLevelSet is TRUE.
+  //
+  UINT32     DebugLevel;
+  BOOLEAN    DebugLevelSet;
 } EARLY_PL011_BASE_ADDRESS;

--- a/ArmVirtPkg/Library/DebugLibFdtPL011Uart/DebugLib.c
+++ b/ArmVirtPkg/Library/DebugLibFdtPL011Uart/DebugLib.c
@@ -94,17 +94,28 @@ DebugPrintMarker (
   IN  BASE_LIST    BaseListMarker
   )
 {
-  CHAR8  Buffer[MAX_DEBUG_MESSAGE_LENGTH];
+  CHAR8       Buffer[MAX_DEBUG_MESSAGE_LENGTH];
+  UINT32      SerialDebugLevel;
+  UINT32      DebugLevel;
+  EFI_STATUS  Status;
 
   //
   // If Format is NULL, then ASSERT().
   //
   ASSERT (Format != NULL);
 
+  DebugLevel = GetDebugPrintErrorLevel ();
+
+  Status = GetSerialDebugLogRuntime (&SerialDebugLevel);
+  if (EFI_ERROR (Status)) {
+    SerialDebugLevel = DebugLevel;
+  }
+
   //
-  // Check driver debug mask value and global mask
+  // SerialDebugLevel can be more verbose than DebugLevel.
+  // Check if we have something to print
   //
-  if ((ErrorLevel & GetDebugPrintErrorLevel ()) == 0) {
+  if (((ErrorLevel & DebugLevel) == 0) && ((ErrorLevel & SerialDebugLevel) == 0)) {
     return;
   }
 
@@ -118,10 +129,17 @@ DebugPrintMarker (
   }
 
   //
-  // Send string to Memory Debug Log if enabled
+  // Send string to Memory Debug Log if enabled and error level matches
   //
-  if (MemDebugLogEnabled ()) {
+  if (((ErrorLevel & DebugLevel) != 0)  && MemDebugLogEnabled ()) {
     MemDebugLogWrite ((CHAR8 *)Buffer, AsciiStrLen (Buffer));
+  }
+
+  //
+  // Check runtime debug mask value and global mask
+  //
+  if ((ErrorLevel & SerialDebugLevel) == 0) {
+    return;
   }
 
   //

--- a/ArmVirtPkg/Library/DebugLibFdtPL011Uart/Flash.c
+++ b/ArmVirtPkg/Library/DebugLibFdtPL011Uart/Flash.c
@@ -105,3 +105,34 @@ DebugLibFdtPL011UartWrite (
 
   return PL011UartWrite ((UINTN)DebugAddress, Buffer, NumberOfBytes);
 }
+
+EFI_STATUS
+GetSerialDebugLogRuntime (
+  UINT32  *Value
+  )
+{
+  CONST VOID        *DeviceTree;
+  RETURN_STATUS     Status;
+  FDT_SERIAL_PORTS  Ports;
+
+  if (Value == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  DeviceTree = (VOID *)(UINTN)PcdGet64 (PcdDeviceTreeInitialBaseAddress);
+  if (DeviceTree == NULL) {
+    return EFI_NOT_FOUND;
+  }
+
+  Status = FdtSerialGetPorts (DeviceTree, "arm,pl011", &Ports);
+  if (RETURN_ERROR (Status)) {
+    return Status;
+  }
+
+  if (Ports.DebugLevelSet) {
+    *Value = Ports.DebugLevel;
+    return EFI_SUCCESS;
+  }
+
+  return EFI_NOT_FOUND;
+}

--- a/ArmVirtPkg/Library/DebugLibFdtPL011Uart/Ram.c
+++ b/ArmVirtPkg/Library/DebugLibFdtPL011Uart/Ram.c
@@ -20,6 +20,8 @@
 
 UINTN          mDebugLibFdtPL011UartAddress;
 RETURN_STATUS  mDebugLibFdtPL011UartPermanentStatus = RETURN_SUCCESS;
+BOOLEAN        mRuntimeDebugLevelSet;
+UINT32         mRuntimeDebugLevel;
 
 /**
   Statefully initialize both the library instance and the debug PL011 UART.
@@ -61,6 +63,9 @@ Initialize (
     Status = RETURN_NOT_FOUND;
     goto Failed;
   }
+
+  mRuntimeDebugLevelSet = UartBase->DebugLevelSet;
+  mRuntimeDebugLevel    = UartBase->DebugLevel;
 
   BaudRate         = (UINTN)PcdGet64 (PcdUartDefaultBaudRate);
   ReceiveFifoDepth = 0; // Use the default value for Fifo depth
@@ -121,4 +126,28 @@ DebugLibFdtPL011UartWrite (
   }
 
   return PL011UartWrite (mDebugLibFdtPL011UartAddress, Buffer, NumberOfBytes);
+}
+
+EFI_STATUS
+GetSerialDebugLogRuntime (
+  UINT32  *Value
+  )
+{
+  RETURN_STATUS  Status;
+
+  if (Value == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Status = Initialize ();
+  if (RETURN_ERROR (Status)) {
+    return Status;
+  }
+
+  if (mRuntimeDebugLevelSet) {
+    *Value = mRuntimeDebugLevel;
+    return EFI_SUCCESS;
+  }
+
+  return EFI_NOT_FOUND;
 }

--- a/ArmVirtPkg/Library/DebugLibFdtPL011Uart/Write.h
+++ b/ArmVirtPkg/Library/DebugLibFdtPL011Uart/Write.h
@@ -34,3 +34,18 @@ DebugLibFdtPL011UartWrite (
   IN UINT8  *Buffer,
   IN UINTN  NumberOfBytes
   );
+
+/**
+  Retrieve the serial port runtime debug log level from the device tree.
+
+  @param[out] Value  On success, the debug log level bitmask read from the
+                     "edk2,debug-level" property of a PL011 UART node.
+
+  @retval EFI_SUCCESS            The debug level was retrieved successfully.
+  @retval EFI_INVALID_PARAMETER  Value is NULL.
+  @retval EFI_NOT_FOUND          The debug level is not available.
+**/
+EFI_STATUS
+GetSerialDebugLogRuntime (
+  UINT32  *Value
+  );

--- a/ArmVirtPkg/Library/PlatformPeiLib/PlatformPeiLib.c
+++ b/ArmVirtPkg/Library/PlatformPeiLib/PlatformPeiLib.c
@@ -77,6 +77,9 @@ PlatformPeim (
 
   Status = FdtSerialGetPorts (Base, "arm,pl011", &Ports);
   if (!EFI_ERROR (Status)) {
+    UartHobData->DebugLevel    = Ports.DebugLevel;
+    UartHobData->DebugLevelSet = Ports.DebugLevelSet;
+
     if (Ports.NumberOfPorts == 1) {
       //
       // Just one UART; direct both SerialPortLib+console and DebugLib to it.

--- a/OvmfPkg/Include/Library/FdtSerialPortAddressLib.h
+++ b/OvmfPkg/Include/Library/FdtSerialPortAddressLib.h
@@ -11,8 +11,10 @@
 #include <Base.h>
 
 typedef struct {
-  UINTN     NumberOfPorts;
-  UINT64    BaseAddress[2];
+  UINTN      NumberOfPorts;
+  UINT64     BaseAddress[2];
+  UINT32     DebugLevel;
+  BOOLEAN    DebugLevelSet;
 } FDT_SERIAL_PORTS;
 
 /**

--- a/OvmfPkg/Library/FdtSerialPortAddressLib/FdtSerialPortAddressLib.c
+++ b/OvmfPkg/Library/FdtSerialPortAddressLib/FdtSerialPortAddressLib.c
@@ -104,12 +104,14 @@ FdtSerialGetPorts (
   }
 
   Ports->NumberOfPorts = 0;
+  Ports->DebugLevelSet = FALSE;
   Node                 = FdtNextNode (DeviceTree, 0, NULL);
   while ((Node > 0) &&
          (Ports->NumberOfPorts < ARRAY_SIZE (Ports->BaseAddress)))
   {
-    CONST CHAR8  *CompatProp;
-    INT32        PropSize;
+    CONST UINT32  *DebugLevelProp;
+    CONST CHAR8   *CompatProp;
+    INT32         PropSize;
 
     CompatProp = FdtGetProp (DeviceTree, Node, "compatible", &PropSize);
     if (CompatProp != NULL) {
@@ -131,6 +133,12 @@ FdtSerialGetPorts (
           Ports->BaseAddress[Ports->NumberOfPorts++] = BaseAddress;
         }
       }
+    }
+
+    DebugLevelProp = FdtGetProp (DeviceTree, Node, "edk2,debug-level", &PropSize);
+    if ((DebugLevelProp != NULL) && (PropSize == sizeof (UINT32))) {
+      Ports->DebugLevel    = Fdt32ToCpu (*DebugLevelProp);
+      Ports->DebugLevelSet = TRUE;
     }
 
     Node = FdtNextNode (DeviceTree, Node, NULL);


### PR DESCRIPTION
Add support for a device-tree property "edk2,debug-level" on PL011 UART nodes. When present, this 32-bit cell overrides the compiled-in DebugPrintErrorLevel for serial port output, allowing the serial verbosity to be tuned at boot time without rebuilding the firmware.

When this property is not present, the original behavior (serial output follows DebugPrintErrorLevel) is preserved.

The memory debug log continues to use the compiled-in level.

Example DT snippet:

  pl011@9000000 {
      compatible = "arm,pl011";
      edk2,debug-level = <0x80000000>;
      ...
  };

# Description

<_Include a description of the change and why this change was made._>

<_For each item, place an "x" in between `[` and `]` if true. Example: `[x]` (you can also check items in GitHub UI)_>

<_Create the PR as a Draft PR if it is only created to run CI checks._>

<_Delete lines in \<\> tags before creating the PR._>

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

QEMU changes: 

https://lore.kernel.org/qemu-devel/20260311-edk2_arm_serial-v1-1-c25e237116f3@redhat.com/

## Integration Instructions

<_Describe how these changes should be integrated. Use N/A if nothing is required._>
