### PR TITLE
MdeModulePkg/TerminalDxe: Fix handling of shift state in notifications

### DIFF
--- a/MdeModulePkg/Universal/Console/TerminalDxe/Terminal.h
+++ b/MdeModulePkg/Universal/Console/TerminalDxe/Terminal.h
@@ -241,7 +241,7 @@ TerminalConInReadKeyStroke (
 /**
   Check if the key already has been registered.
 
-  @param  RegsiteredData           A pointer to a buffer that is filled in with the
+  @param  RegisteredData           A pointer to a buffer that is filled in with the
                                    keystroke state data for the key that was
                                    registered.
   @param  InputData                A pointer to a buffer that is filled in with the
@@ -254,7 +254,7 @@ TerminalConInReadKeyStroke (
 **/
 BOOLEAN
 IsKeyRegistered (
-  IN EFI_KEY_DATA  *RegsiteredData,
+  IN EFI_KEY_DATA  *RegisteredData,
   IN EFI_KEY_DATA  *InputData
   );
 

--- a/MdeModulePkg/Universal/Console/TerminalDxe/TerminalConIn.c
+++ b/MdeModulePkg/Universal/Console/TerminalDxe/TerminalConIn.c
@@ -168,10 +168,23 @@ IsKeyRegistered (
   IN EFI_KEY_DATA  *InputData
   )
 {
+  UINT32  ShiftState;
+  UINT32  InputShiftState;
+
   ASSERT (RegsiteredData != NULL && InputData != NULL);
 
   if ((RegsiteredData->Key.ScanCode    != InputData->Key.ScanCode) ||
       (RegsiteredData->Key.UnicodeChar != InputData->Key.UnicodeChar))
+  {
+    return FALSE;
+  }
+
+  /* Do not take EFI_SHIFT_STATE_VALID flag into account when comparing shift states */
+  ShiftState      = RegsiteredData->KeyState.KeyShiftState | EFI_SHIFT_STATE_VALID;
+  InputShiftState = InputData->KeyState.KeyShiftState | EFI_SHIFT_STATE_VALID;
+
+  if ((ShiftState != InputShiftState) ||
+      (RegsiteredData->KeyState.KeyToggleState != InputData->KeyState.KeyToggleState))
   {
     return FALSE;
   }
@@ -337,6 +350,7 @@ TerminalConInRegisterKeyNotify (
   LIST_ENTRY                     *Link;
   LIST_ENTRY                     *NotifyList;
   TERMINAL_CONSOLE_IN_EX_NOTIFY  *CurrentNotify;
+  UINT32                         ShiftState;
 
   if ((KeyData == NULL) || (NotifyHandle == NULL) || (KeyNotificationFunction == NULL)) {
     return EFI_INVALID_PARAMETER;
@@ -361,6 +375,29 @@ TerminalConInRegisterKeyNotify (
         return EFI_SUCCESS;
       }
     }
+  }
+
+  //
+  // Some components might set only EFI_SHIFT_STATE_VALID flag in KeyShiftState.
+  // Treat such shift state as zero.
+  //
+  ShiftState = KeyData->KeyState.KeyShiftState & ~EFI_SHIFT_STATE_VALID;
+  if ((ShiftState != 0) || (KeyData->KeyState.KeyToggleState != 0)) {
+    //
+    // Shift state and toggle state are not transferred via serial lines, so
+    // the notification functions for the keys with nonzero KeyShiftState or
+    // KeyToggleState will never trigger with this implementation of SimpleTextInEx
+    // protocol.
+    //
+    DEBUG ((
+      DEBUG_INFO,
+      "%a: Attempt to register notifier for the key 0x%04x (scan code 0x%04x) with shift state 0x%08x and toggle state 0x%02x.\n",
+      __func__,
+      KeyData->Key.UnicodeChar,
+      KeyData->Key.ScanCode,
+      KeyData->KeyState.KeyShiftState,
+      KeyData->KeyState.KeyToggleState
+      ));
   }
 
   //

--- a/MdeModulePkg/Universal/Console/TerminalDxe/TerminalConIn.c
+++ b/MdeModulePkg/Universal/Console/TerminalDxe/TerminalConIn.c
@@ -149,9 +149,9 @@ TerminalConInReadKeyStroke (
 /**
   Check if the key already has been registered.
 
-  If both RegsiteredData and InputData is NULL, then ASSERT().
+  If both RegisteredData and InputData is NULL, then ASSERT().
 
-  @param  RegsiteredData           A pointer to a buffer that is filled in with the
+  @param  RegisteredData           A pointer to a buffer that is filled in with the
                                    keystroke state data for the key that was
                                    registered.
   @param  InputData                A pointer to a buffer that is filled in with the
@@ -164,27 +164,27 @@ TerminalConInReadKeyStroke (
 **/
 BOOLEAN
 IsKeyRegistered (
-  IN EFI_KEY_DATA  *RegsiteredData,
+  IN EFI_KEY_DATA  *RegisteredData,
   IN EFI_KEY_DATA  *InputData
   )
 {
   UINT32  ShiftState;
   UINT32  InputShiftState;
 
-  ASSERT (RegsiteredData != NULL && InputData != NULL);
+  ASSERT (RegisteredData != NULL && InputData != NULL);
 
-  if ((RegsiteredData->Key.ScanCode    != InputData->Key.ScanCode) ||
-      (RegsiteredData->Key.UnicodeChar != InputData->Key.UnicodeChar))
+  if ((RegisteredData->Key.ScanCode    != InputData->Key.ScanCode) ||
+      (RegisteredData->Key.UnicodeChar != InputData->Key.UnicodeChar))
   {
     return FALSE;
   }
 
   /* Do not take EFI_SHIFT_STATE_VALID flag into account when comparing shift states */
-  ShiftState      = RegsiteredData->KeyState.KeyShiftState | EFI_SHIFT_STATE_VALID;
+  ShiftState      = RegisteredData->KeyState.KeyShiftState | EFI_SHIFT_STATE_VALID;
   InputShiftState = InputData->KeyState.KeyShiftState | EFI_SHIFT_STATE_VALID;
 
   if ((ShiftState != InputShiftState) ||
-      (RegsiteredData->KeyState.KeyToggleState != InputData->KeyState.KeyToggleState))
+      (RegisteredData->KeyState.KeyToggleState != InputData->KeyState.KeyToggleState))
   {
     return FALSE;
   }


### PR DESCRIPTION
# Description

This patch fixes https://github.com/tianocore/edk2/issues/12281.

Currently, `TerminalConInRegisterKeyNotify()` allows registering a notification with nonzero KeyShiftState or KeyToggleState. However, `IsKeyRegistered()` ignores these when checking if the keys match.

As a result, some firmware component may successfully register a notification for, say, RCtrl+n, but the notification function will be called each time the user presses 'n', which is wrong.

Most kinds of shift states and toggle states are not transferred via a terminal line, so the notification functions for the keys with nonzero KeyShiftState or KeyToggleState should not trigger with TerminalDxe.

`TerminalConInRegisterKeyNotify()` could reject such notifications but it is unclear if it could break the existing UEFI components.

Instead, this patch adds a debug message when someone tries to register a notification with nonzero states, it also updates `IsKeyRegistered()` to take KeyShiftState and KeyToggleState into account.

This way, `IsKeyRegistered()` will treat the notifications for 'n' and 'RCtrl+n' as different ones. So, the callback function for 'RCtrl+n' will not be called when the user presses 'n'.

As it is not prohibited to set only EFI_SHIFT_STATE_VALID flag in the shift state (leaving the remaining bits zeroed), IsKeyRegistered() ignores EFI_SHIFT_STATE_VALID.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

I tested the fix using the steps to reproduce the issue described in https://github.com/tianocore/edk2/issues/12281.

Without the fix, pressing 'n' in the EFI internal shell triggered the notification for 'RCtrl+n', pressing F3 triggered the notification for 'LShift+F3'.

With the fix, neither of the notifications were triggered.

## Integration Instructions

N/A

