### PR TITLE
.azurepipelines: Fix the commented filename in two template files

### DIFF
--- a/.azurepipelines/templates/basetools-build-steps.yml
+++ b/.azurepipelines/templates/basetools-build-steps.yml
@@ -1,5 +1,5 @@
 ## @file
-# File templates/basetools-build-job.yml
+# File templates/basetools-build-steps.yml
 #
 # template file to build basetools
 #

--- a/.azurepipelines/templates/platform-build-run-steps.yml
+++ b/.azurepipelines/templates/platform-build-run-steps.yml
@@ -1,6 +1,6 @@
 
 ## @file
-# File steps.yml
+# File templates/platform-build-run-steps.yml
 #
 # template file containing the steps to build
 #


### PR DESCRIPTION
# Description

The six .yml files in .azurepipelines/templates each include their own filename in their header comment, but in these two files the name is now wrong, so fix this.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

N/A

## Integration Instructions

N/A
