### PR TITLE
.azurepipelines: Make 'Set PATH' step check OS rather than toolchain

### DIFF
--- a/.azurepipelines/templates/platform-build-run-steps.yml
+++ b/.azurepipelines/templates/platform-build-run-steps.yml
@@ -43,7 +43,7 @@ steps:
     echo "##vso[task.prependpath]${HOME}/.local/bin"
     echo "new PATH=${PATH}"
   displayName: Set PATH
-  condition: eq('${{ parameters.tool_chain_tag }}', 'GCC')
+  condition: eq(variables['Agent.OS'], 'Linux')
 
 - checkout: self
   clean: true

--- a/.azurepipelines/templates/pr-gate-steps.yml
+++ b/.azurepipelines/templates/pr-gate-steps.yml
@@ -21,7 +21,7 @@ steps:
     echo "##vso[task.prependpath]${HOME}/.local/bin"
     echo "new PATH=${PATH}"
   displayName: Set PATH
-  condition: eq('${{ parameters.tool_chain_tag }}', 'GCC')
+  condition: eq(variables['Agent.OS'], 'Linux')
 
 - checkout: self
   clean: true


### PR DESCRIPTION
# Description

The 'Set PATH' step added by becff4f473e27ba0a0d8a40e0071531abdb67872 is explicitly Linux only, so here we update `pr-gate-steps.yml` and `platform-build-run-steps.yml` to directly check `Agent.OS` rather than relying on the toolchain as an indicator of the OS, since the existing logic amounts to assuming that toolchains are OS specific, which is incorrect and will matter more now that CLANGPDB is planned to be more extensively used on Windows.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

CI

## Integration Instructions

N/A
