### PR TITLE
.azurepipelines/templates: Remove `echo new PATH` from 'Set PATH' task

### DIFF
--- a/.azurepipelines/templates/platform-build-run-steps.yml
+++ b/.azurepipelines/templates/platform-build-run-steps.yml
@@ -41,7 +41,6 @@ parameters:
 steps:
 - bash: |
     echo "##vso[task.prependpath]${HOME}/.local/bin"
-    echo "new PATH=${PATH}"
   displayName: Set PATH
   condition: eq(variables['Agent.OS'], 'Linux')
 

--- a/.azurepipelines/templates/pr-gate-steps.yml
+++ b/.azurepipelines/templates/pr-gate-steps.yml
@@ -19,7 +19,6 @@ parameters:
 steps:
 - bash: |
     echo "##vso[task.prependpath]${HOME}/.local/bin"
-    echo "new PATH=${PATH}"
   displayName: Set PATH
   condition: eq(variables['Agent.OS'], 'Linux')
 


### PR DESCRIPTION
# Description

The `echo "new PATH=${PATH}"` line  used in the `Set PATH` tasks added by becff4f473e27ba0a0d8a40e0071531abdb67872 is misleading: it echoes the pre-existing PATH without any changes - which is as expected, as `task.prependpath` modifies PATH only for subsequent tasks: https://learn.microsoft.com/en-us/azure/devops/pipelines/scripts/logging-commands?view=azure-devops&tabs=bash#prependpath-prepend-a-path-to-the--path-environment-variable

<img width="666" height="300" alt="image" src="https://github.com/user-attachments/assets/6c3aad2a-6c28-49af-a56f-b3d84d2b4403" />

Alternative approaches would be:
 - Ignore this
 - Duplicate the calculation so that we can echo what will be set
 - Update the message to say that it echoes the path before the change
 - Add an extra step which displays the path after it has been set

This PR proposes just removing the echo, since it is misleading as is, and it seems that no proportionately lightweight fix is available.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

CI

## Integration Instructions

N/A