### PR TITLE
OvmfPkg/OvmfPkgX64: Expose DEBUG_TO_MEM as a build option

### DIFF
--- a/OvmfPkg/OvmfPkgX64.dsc
+++ b/OvmfPkg/OvmfPkgX64.dsc
@@ -35,6 +35,7 @@
   DEFINE STANDALONE_MM_ENABLE    = FALSE
   DEFINE SOURCE_DEBUG_ENABLE     = FALSE
   DEFINE CC_MEASUREMENT_ENABLE   = TRUE
+  DEFINE DEBUG_TO_MEM            = FALSE
 
 !include OvmfPkg/Include/Dsc/OvmfTpmDefines.dsc.inc
 


### PR DESCRIPTION
# Description
OvmfPkgX64.dsc has several build options, but some are missing from the top definition list. This makes it difficult for users to identify all available configuration flags.

Add DEBUG_TO_MEM to the [Defines] section with a default value of FALSE to improve visibility.

This change has no functional impact.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested
build -a X64 -p OvmfPkg/OvmfPkgX64.dsc -t GCC5  -D DEBUG_TO_MEM

## Integration Instructions
N/A 
