### PR TITLE
StandaloneMmPkg Core: Check PE section finding status

### DIFF
--- a/StandaloneMmPkg/Core/Dispatcher.c
+++ b/StandaloneMmPkg/Core/Dispatcher.c
@@ -377,9 +377,6 @@ MmGetDepexSectionAndPreProccess (
       //
       DriverEntry->DepexProtocolError = TRUE;
     } else {
-      //
-      // If no Depex assume depend on all architectural protocols
-      //
       DriverEntry->Depex              = NULL;
       DriverEntry->Dependent          = TRUE;
       DriverEntry->DepexProtocolError = FALSE;

--- a/StandaloneMmPkg/Core/FwVol.c
+++ b/StandaloneMmPkg/Core/FwVol.c
@@ -222,7 +222,12 @@ MmCoreFfsFindMmDriver (
       Status = FfsFindSectionData (EFI_SECTION_PE32, FileHeader, &Pe32Data, &Pe32DataSize);
       DEBUG ((DEBUG_INFO, "Find PE data - 0x%x\n", Pe32Data));
       DepexStatus = FfsFindSectionData (EFI_SECTION_MM_DEPEX, FileHeader, &Depex, &DepexSize);
-      if (!EFI_ERROR (DepexStatus)) {
+      if (DepexStatus == EFI_NOT_FOUND) {
+        Depex     = NULL;
+        DepexSize = 0;
+      }
+
+      if (!EFI_ERROR (Status)) {
         MmAddToDriverList (FwVolHeader, Pe32Data, Pe32DataSize, Depex, DepexSize, &FileHeader->Name);
       }
     }


### PR DESCRIPTION
StandaloneMmPkg Core: Check PE section finding status
The code should check PE section finding status instead of
DEPEX section finding status for the driver to be added into list.
It is a supplementary patch for https://github.com/tianocore/edk2/commit/37db80097dbe4d1487191422240bdc0a9ad8d963 to support no DEPEX case.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested
Create no depex case and make sure it can be dispatched correctly.

## Integration Instructions
N/A
