### PR TITLE
Fix VariableSmmRuntimeDxe MM communicate v3 buffer sizing

### DIFF
--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxe.c
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxe.c
@@ -1815,8 +1815,13 @@ SmmVariableReady (
   //
   Status = GetVariablePayloadSize (&mVariableBufferPayloadSize);
   ASSERT_EFI_ERROR (Status);
-  mVariableBufferSize = SMM_COMMUNICATE_HEADER_SIZE + SMM_VARIABLE_COMMUNICATE_HEADER_SIZE + mVariableBufferPayloadSize;
-  mVariableBuffer     = AllocateRuntimePool (mVariableBufferSize);
+  if (mMmCommunication3 != NULL) {
+    mVariableBufferSize = SMM_COMMUNICATE_HEADER_SIZE_V3 + SMM_VARIABLE_COMMUNICATE_HEADER_SIZE + mVariableBufferPayloadSize;
+  } else {
+    mVariableBufferSize = SMM_COMMUNICATE_HEADER_SIZE + SMM_VARIABLE_COMMUNICATE_HEADER_SIZE + mVariableBufferPayloadSize;
+  }
+
+  mVariableBuffer = AllocateRuntimePool (mVariableBufferSize);
   ASSERT (mVariableBuffer != NULL);
 
   //


### PR DESCRIPTION
## How This Was Tested

Tested on real hardware, now work as expected.

# Description

Fix VariableSmmRuntimeDxe MM communicate v3 buffer sizing

This change fixes `VariableSmmRuntimeDxe` to size its runtime communication buffer correctly when `EFI_MM_COMMUNICATION3_PROTOCOL` is available.

Since 202511 branch, the variable runtime path can use MM communicate v3, which requires the larger `EFI_MM_COMMUNICATE_HEADER_V3` header (56KB vs 24KB), but the driver was still allocating the buffer using the legacy header size. When the caller invokes the get variable API with a large enough buffer, the runtime code check will fail due to the buffer size cap logic.

This update makes the allocation v3-aware so the runtime variable communication buffer matches the header format actually in use and avoids failures on larger variable transactions.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Tested on real hardware, now work as expected.

## Integration Instructions

N/A
