### PR TITLE
.pytool: HostUnitTestCompilerPlugin: support single module build

### DIFF
--- a/.pytool/Plugin/HostUnitTestCompilerPlugin/HostUnitTestCompilerPlugin.py
+++ b/.pytool/Plugin/HostUnitTestCompilerPlugin/HostUnitTestCompilerPlugin.py
@@ -9,8 +9,9 @@ import os
 import re
 from edk2toollib.uefi.edk2.parsers.dsc_parser import DscParser
 from edk2toolext.environment.plugintypes.ci_build_plugin import ICiBuildPlugin
+from edk2toolext.environment.plugintypes.uefi_build_plugin import IUefiBuildPlugin
+from edk2toolext.environment.plugin_manager import PluginDescriptor, PluginManager
 from edk2toolext.environment.uefi_build import UefiBuilder
-from edk2toolext import edk2_logging
 from edk2toolext.environment.var_dict import VarDict
 from edk2toollib.utility_functions import GetHostInfo
 
@@ -88,6 +89,7 @@ class HostUnitTestCompilerPlugin(ICiBuildPlugin):
     def RunBuildPlugin(self, packagename, Edk2pathObj, pkgconfig, environment, PLM, PLMHelper, tc, output_stream=None):
         self._env = environment
         environment.SetValue("CI_BUILD_TYPE", "host_unit_test", "Set in HostUnitTestCompilerPlugin")
+        environment.SetValue("CI_PACKAGE_NAME", packagename, "Set in HostUnitTestCompilerPlugin")
 
         # Parse the config for required DscPath element
         if "DscPath" not in pkgconfig:
@@ -128,9 +130,7 @@ class HostUnitTestCompilerPlugin(ICiBuildPlugin):
                 raise RuntimeError("Can't Change TARGET_ARCH as required")
 
         # Parse DSC to check for SUPPORTED_ARCHITECTURES
-        dp = DscParser()
-        dp.SetBaseAbsPath(Edk2pathObj.WorkspacePath)
-        dp.SetPackagePaths(Edk2pathObj.PackagePathList)
+        dp = DscParser().SetEdk2Path(Edk2pathObj)
         dp.ParseFile(AP_Path)
         if "SUPPORTED_ARCHITECTURES" in dp.LocalVars:
             SUPPORTED_ARCHITECTURES = dp.LocalVars["SUPPORTED_ARCHITECTURES"].split('|')
@@ -139,17 +139,31 @@ class HostUnitTestCompilerPlugin(ICiBuildPlugin):
             # Skip if there is no intersection between SUPPORTED_ARCHITECTURES and TARGET_ARCHITECTURES
             if len(set(SUPPORTED_ARCHITECTURES) & set(TARGET_ARCHITECTURES)) == 0:
                 tc.SetSkipped()
-                tc.LogStdError("No supported architecutres to build for host unit tests")
+                tc.LogStdError("No supported architectures to build for host unit tests")
                 return -1
 
         uefiBuilder = UefiBuilder()
         # do all the steps
         # WorkSpace, PackagesPath, PInHelper, PInManager
+        # Skip post build plugins and run only host-based-tests manually
+        uefiBuilder.SkipPostBuild = True
         ret = uefiBuilder.Go(Edk2pathObj.WorkspacePath, os.pathsep.join(Edk2pathObj.PackagePathList), PLMHelper, PLM)
         if ret != 0:  # failure:
             tc.SetFailed("Compile failed for {0}".format(packagename), "Compile_FAILED")
             tc.LogStdError("{0} Compile failed with error code {1} ".format(AP_Path, ret))
             return 1
+
+        def host_test_filter(plugin: PluginDescriptor) -> bool:
+            return plugin.descriptor['scope'] == 'host-based-test'
+
+        build_plugins = PLM.GetPluginsOfClass(IUefiBuildPlugin)
+        host_test_plugins = filter(host_test_filter, build_plugins)
+
+        for plugin in host_test_plugins:
+            if plugin.Obj.do_post_build(uefiBuilder) != 0:
+                tc.SetFailed("Host Based Unit Test failed for {0}".format(packagename), "HostUnitTest_FAILED")
+                tc.LogStdError("Host Based Unit Test failed for {0} ".format(packagename))
+                return 1
 
         else:
             tc.SetSuccess()

--- a/.pytool/Plugin/HostUnitTestCompilerPlugin/Readme.md
+++ b/.pytool/Plugin/HostUnitTestCompilerPlugin/Readme.md
@@ -3,6 +3,10 @@
 A CiBuildPlugin that compiles the dsc for host based unit test apps.
 An IUefiBuildPlugin may be attached to this plugin that will run the unit tests and collect the results after successful compilation.
 
+To run the unit tests and collect the results after successful compilation, The
+host UnitTest Compliler Plugin will execute any IUefiBuildPlugin that has the
+scope 'host-based-test'.
+
 ## Configuration
 
 The package relative path of the DSC file to build.
@@ -17,8 +21,20 @@ The package relative path of the DSC file to build.
 
 Package relative path to the DSC file to build.
 
+## Running a single test
+
+It is possible to compile and run only a single test. This is useful when writing a test or running a test that is failing.
+Below is an example command to build and run only a single test
+
+`stuart_ci_build -c .pytool/CISettings.py -p MdePkg BUILDMODULE=MdePkg/Test/GoogleTest/Library/StackCheckLib/GoogleTestStackCheckLib.inf -d HostUnitTestCompilerPlugin=run`
+
+The important parts to note is:
+
+1. `BUILDMODULE=<PATH>` is package path relative
+2. `-d` is used to disable all CI plugins
+3. `HostUnitTestCompilerPlugin=run` is used to re-enable this plugin.
+
 ## Copyright
 
 Copyright (c) Microsoft Corporation.
 SPDX-License-Identifier: BSD-2-Clause-Patent
-


### PR DESCRIPTION
# Description

This commit updates the HostUnitTestCompilerPlugin to support building and running a single host based unit test utilizing the `BUILDMODULE` command line argument. Prior to this change, one could use the `BUILDMODULE` command line argument to only build a host based unit test, however the test would not be executed.

After this change, A developer can specify `BUILDMODULE` to build a specific host based unit test and run it with a single command.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

CI continues to pass, and local usage of command line interface works as expected.

## Integration Instructions

N/A
