### PR TITLE
UefiPayloadPkg: seed memory type information from vars

### DIFF
--- a/UefiPayloadPkg/Library/PlatformBootManagerLib/PlatformBootManager.c
+++ b/UefiPayloadPkg/Library/PlatformBootManagerLib/PlatformBootManager.c
@@ -320,8 +320,19 @@ PlatformBootManagerAfterConsole (
     BootLogoEnableLogo ();
   }
 
-  EfiBootManagerConnectAll ();
-  EfiBootManagerRefreshAllBootOption ();
+  if (GetBootModeHob () != BOOT_ON_S4_RESUME) {
+    EfiBootManagerConnectAll ();
+    EfiBootManagerRefreshAllBootOption ();
+  } else {
+    //
+    // Avoid a global ConnectAll()/RefreshAllBootOption() on S4 resume.
+    //
+    // Connecting removable media here makes the final DXE handle graph and memory
+    // allocation pattern depend on USB and SD presence. That can perturb the EFI
+    // memory map enough to break OS hibernation resume if devices are inserted or
+    // removed while the system is in S4.
+    //
+  }
 
   //
   // Active BOOT_ON_FLASH_UPDATE mode means that at least one capsule has been

--- a/UefiPayloadPkg/UefiPayloadEntry/FitUniversalPayloadEntry.c
+++ b/UefiPayloadPkg/UefiPayloadEntry/FitUniversalPayloadEntry.c
@@ -447,14 +447,10 @@ FitBuildHobs (
   //
   // To create Memory Type Information HOB
   //
-  GuidHob = GetFirstGuidHob (&gEfiMemoryTypeInformationGuid);
-  if (GuidHob == NULL) {
-    BuildGuidDataHob (
-      &gEfiMemoryTypeInformationGuid,
-      mDefaultMemoryTypeInformation,
-      sizeof (mDefaultMemoryTypeInformation)
-      );
-  }
+  BuildMemoryTypeInformationHob (
+    mDefaultMemoryTypeInformation,
+    sizeof (mDefaultMemoryTypeInformation)
+    );
 
   //
   // Create guid hob for acpi board information

--- a/UefiPayloadPkg/UefiPayloadEntry/FitUniversalPayloadEntry.inf
+++ b/UefiPayloadPkg/UefiPayloadEntry/FitUniversalPayloadEntry.inf
@@ -24,6 +24,7 @@
 [Sources]
   FitUniversalPayloadEntry.c
   LoadDxeCore.c
+  MemoryTypeInformationHob.c
   PrintHob.c
   AcpiTable.c
 
@@ -39,6 +40,7 @@
   X64/VirtualMemory.c
   X64/DxeLoadFunc.c
   X64/DxeLoadFuncFit.c
+  X64/TriggerSmi.nasm
 
 [Sources.RISCV64]
   RiscV64/DxeLoadFunc.c
@@ -87,6 +89,9 @@
   gUniversalPayloadPciRootBridgeInfoGuid
   gUniversalPayloadSmbios3TableGuid
   gUniversalPayloadDeviceTreeGuid
+  gEfiSmmStoreInfoHobGuid
+  gEfiVariableGuid
+  gEfiAuthenticatedVariableGuid
 
 [FeaturePcd.IA32]
   gEfiMdeModulePkgTokenSpaceGuid.PcdDxeIplSwitchToLongMode      ## CONSUMES

--- a/UefiPayloadPkg/UefiPayloadEntry/MemoryTypeInformationHob.c
+++ b/UefiPayloadPkg/UefiPayloadEntry/MemoryTypeInformationHob.c
@@ -1,0 +1,512 @@
+/** @file
+
+  Build the Memory Type Information HOB from the persisted variable store.
+
+  Copyright (c) 2026, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "UefiPayloadEntry.h"
+
+#include <Guid/VariableFormat.h>
+#include <Guid/SmmStoreInfoGuid.h>
+
+#define SMMSTORE_RET_SUCCESS      0
+#define SMMSTORE_RET_FAILURE      1
+#define SMMSTORE_RET_UNSUPPORTED  2
+#define SMMSTORE_CMD_RAW_READ     5
+
+typedef struct {
+  UINT32    BufSize;
+  UINT32    BufOffset;
+  UINT32    BlockId;
+} SMM_STORE_PARAMS_READ;
+
+typedef union {
+  SMM_STORE_PARAMS_READ    Read;
+} SMM_STORE_COM_BUF;
+
+#if defined (MDE_CPU_X64)
+UINTN
+EFIAPI
+TriggerSmi (
+  IN UINTN  Cmd,
+  IN UINTN  Arg,
+  IN UINTN  Retry
+  );
+
+#endif
+
+STATIC
+BOOLEAN
+ValidateMemoryTypeInfoVariable (
+  IN EFI_MEMORY_TYPE_INFORMATION  *MemoryData,
+  IN UINTN                        MemoryDataSize
+  )
+{
+  UINTN  Count;
+  UINTN  Index;
+
+  if (MemoryData == NULL) {
+    return FALSE;
+  }
+
+  Count = MemoryDataSize / sizeof (*MemoryData);
+  if ((Count == 0) || (Count * sizeof (*MemoryData) != MemoryDataSize)) {
+    return FALSE;
+  }
+
+  if (MemoryData[Count - 1].Type != EfiMaxMemoryType) {
+    return FALSE;
+  }
+
+  for (Index = 0; Index < Count - 1; Index++) {
+    if (MemoryData[Index].Type >= EfiMaxMemoryType) {
+      return FALSE;
+    }
+  }
+
+  return TRUE;
+}
+
+STATIC
+VARIABLE_STORE_STATUS
+GetVariableStoreStatus (
+  IN VARIABLE_STORE_HEADER  *VariableStoreHeader
+  )
+{
+  if ((CompareGuid (&VariableStoreHeader->Signature, &gEfiAuthenticatedVariableGuid) ||
+       CompareGuid (&VariableStoreHeader->Signature, &gEfiVariableGuid)) &&
+      (VariableStoreHeader->Format == VARIABLE_STORE_FORMATTED) &&
+      (VariableStoreHeader->State == VARIABLE_STORE_HEALTHY))
+  {
+    return EfiValid;
+  }
+
+  return EfiInvalid;
+}
+
+STATIC
+BOOLEAN
+IsValidVariableHeader (
+  IN VARIABLE_HEADER  *Variable,
+  IN VARIABLE_HEADER  *VariableStoreEnd
+  )
+{
+  return (BOOLEAN)(
+                   (Variable != NULL) &&
+                   (Variable < VariableStoreEnd) &&
+                   (Variable->StartId == VARIABLE_DATA)
+                   );
+}
+
+STATIC
+UINTN
+GetVariableHeaderSize (
+  IN BOOLEAN  Authenticated
+  )
+{
+  return Authenticated ? sizeof (AUTHENTICATED_VARIABLE_HEADER) : sizeof (VARIABLE_HEADER);
+}
+
+STATIC
+UINTN
+NameSizeOfVariable (
+  IN VARIABLE_HEADER  *Variable,
+  IN BOOLEAN          Authenticated
+  )
+{
+  AUTHENTICATED_VARIABLE_HEADER  *AuthenticatedVariable;
+
+  AuthenticatedVariable = (AUTHENTICATED_VARIABLE_HEADER *)Variable;
+  if (Authenticated) {
+    if ((AuthenticatedVariable->State == (UINT8)-1) ||
+        (AuthenticatedVariable->NameSize == MAX_UINT32) ||
+        (AuthenticatedVariable->DataSize == MAX_UINT32) ||
+        (AuthenticatedVariable->Attributes == MAX_UINT32))
+    {
+      return 0;
+    }
+
+    return AuthenticatedVariable->NameSize;
+  }
+
+  if ((Variable->State == (UINT8)-1) ||
+      (Variable->NameSize == MAX_UINT32) ||
+      (Variable->DataSize == MAX_UINT32) ||
+      (Variable->Attributes == MAX_UINT32))
+  {
+    return 0;
+  }
+
+  return Variable->NameSize;
+}
+
+STATIC
+UINTN
+DataSizeOfVariable (
+  IN VARIABLE_HEADER  *Variable,
+  IN BOOLEAN          Authenticated
+  )
+{
+  AUTHENTICATED_VARIABLE_HEADER  *AuthenticatedVariable;
+
+  AuthenticatedVariable = (AUTHENTICATED_VARIABLE_HEADER *)Variable;
+  if (Authenticated) {
+    if ((AuthenticatedVariable->State == (UINT8)-1) ||
+        (AuthenticatedVariable->NameSize == MAX_UINT32) ||
+        (AuthenticatedVariable->DataSize == MAX_UINT32) ||
+        (AuthenticatedVariable->Attributes == MAX_UINT32))
+    {
+      return 0;
+    }
+
+    return AuthenticatedVariable->DataSize;
+  }
+
+  if ((Variable->State == (UINT8)-1) ||
+      (Variable->NameSize == MAX_UINT32) ||
+      (Variable->DataSize == MAX_UINT32) ||
+      (Variable->Attributes == MAX_UINT32))
+  {
+    return 0;
+  }
+
+  return Variable->DataSize;
+}
+
+STATIC
+CHAR16 *
+GetVariableNamePtr (
+  IN VARIABLE_HEADER  *Variable,
+  IN BOOLEAN          Authenticated
+  )
+{
+  return (CHAR16 *)((UINTN)Variable + GetVariableHeaderSize (Authenticated));
+}
+
+STATIC
+EFI_GUID *
+GetVendorGuidPtr (
+  IN VARIABLE_HEADER  *Variable,
+  IN BOOLEAN          Authenticated
+  )
+{
+  AUTHENTICATED_VARIABLE_HEADER  *AuthenticatedVariable;
+
+  AuthenticatedVariable = (AUTHENTICATED_VARIABLE_HEADER *)Variable;
+  return Authenticated ? &AuthenticatedVariable->VendorGuid : &Variable->VendorGuid;
+}
+
+STATIC
+UINT8 *
+GetVariableDataPtr (
+  IN VARIABLE_HEADER  *Variable,
+  IN BOOLEAN          Authenticated
+  )
+{
+  UINTN  Offset;
+
+  Offset  = (UINTN)GetVariableNamePtr (Variable, Authenticated);
+  Offset += NameSizeOfVariable (Variable, Authenticated);
+  Offset += GET_PAD_SIZE (NameSizeOfVariable (Variable, Authenticated));
+  return (UINT8 *)Offset;
+}
+
+STATIC
+VARIABLE_HEADER *
+GetNextVariablePtr (
+  IN VARIABLE_HEADER  *Variable,
+  IN BOOLEAN          Authenticated
+  )
+{
+  UINTN  Offset;
+
+  Offset  = (UINTN)GetVariableDataPtr (Variable, Authenticated);
+  Offset += DataSizeOfVariable (Variable, Authenticated);
+  Offset += GET_PAD_SIZE (DataSizeOfVariable (Variable, Authenticated));
+  return (VARIABLE_HEADER *)HEADER_ALIGN (Offset);
+}
+
+STATIC
+VARIABLE_HEADER *
+GetStartPointer (
+  IN VARIABLE_STORE_HEADER  *VariableStoreHeader
+  )
+{
+  return (VARIABLE_HEADER *)HEADER_ALIGN (VariableStoreHeader + 1);
+}
+
+STATIC
+VARIABLE_HEADER *
+GetEndPointer (
+  IN VARIABLE_STORE_HEADER  *VariableStoreHeader
+  )
+{
+  return (VARIABLE_HEADER *)HEADER_ALIGN ((UINTN)VariableStoreHeader + VariableStoreHeader->Size);
+}
+
+STATIC
+BOOLEAN
+FindVariableInStore (
+  IN  VARIABLE_STORE_HEADER  *VariableStoreHeader,
+  IN  CHAR16                 *VariableName,
+  IN  EFI_GUID               *VendorGuid,
+  OUT UINT8                  **VariableData,
+  OUT UINTN                  *VariableDataSize
+  )
+{
+  BOOLEAN          Authenticated;
+  BOOLEAN          FoundAdded;
+  UINTN            NameSize;
+  VARIABLE_HEADER  *Candidate;
+  VARIABLE_HEADER  *NextVariable;
+  VARIABLE_HEADER  *Variable;
+  VARIABLE_HEADER  *VariableStoreEnd;
+
+  if ((VariableStoreHeader == NULL) ||
+      (VariableName == NULL) ||
+      (VendorGuid == NULL) ||
+      (VariableData == NULL) ||
+      (VariableDataSize == NULL))
+  {
+    return FALSE;
+  }
+
+  if (GetVariableStoreStatus (VariableStoreHeader) != EfiValid) {
+    return FALSE;
+  }
+
+  Authenticated    = CompareGuid (&VariableStoreHeader->Signature, &gEfiAuthenticatedVariableGuid);
+  NameSize         = StrSize (VariableName);
+  Candidate        = NULL;
+  FoundAdded       = FALSE;
+  Variable         = GetStartPointer (VariableStoreHeader);
+  VariableStoreEnd = GetEndPointer (VariableStoreHeader);
+
+  while (IsValidVariableHeader (Variable, VariableStoreEnd)) {
+    if ((NameSizeOfVariable (Variable, Authenticated) == NameSize) &&
+        CompareGuid (GetVendorGuidPtr (Variable, Authenticated), VendorGuid) &&
+        (CompareMem (GetVariableNamePtr (Variable, Authenticated), VariableName, NameSize) == 0))
+    {
+      if (Variable->State == VAR_ADDED) {
+        Candidate  = Variable;
+        FoundAdded = TRUE;
+      } else if ((Variable->State == (VAR_IN_DELETED_TRANSITION & VAR_ADDED)) && !FoundAdded) {
+        Candidate = Variable;
+      }
+    }
+
+    NextVariable = GetNextVariablePtr (Variable, Authenticated);
+    if ((NextVariable <= Variable) || (NextVariable > VariableStoreEnd)) {
+      break;
+    }
+
+    Variable = NextVariable;
+  }
+
+  if (Candidate == NULL) {
+    return FALSE;
+  }
+
+  *VariableData     = GetVariableDataPtr (Candidate, Authenticated);
+  *VariableDataSize = DataSizeOfVariable (Candidate, Authenticated);
+  return TRUE;
+}
+
+#if defined (MDE_CPU_X64)
+STATIC
+EFI_STATUS
+SmmStoreRawRead (
+  IN CONST SMMSTORE_INFO  *SmmStoreInfo,
+  IN SMM_STORE_COM_BUF    *CommandBuffer
+  )
+{
+  UINTN  Result;
+  UINTN  Command;
+
+  Command = ((UINTN)SMMSTORE_CMD_RAW_READ << 8) | SmmStoreInfo->ApmCmd;
+  Result  = TriggerSmi (Command, (UINTN)CommandBuffer, 5);
+  if (Result == Command) {
+    return EFI_NO_RESPONSE;
+  }
+
+  if (Result == SMMSTORE_RET_SUCCESS) {
+    return EFI_SUCCESS;
+  }
+
+  if (Result == SMMSTORE_RET_UNSUPPORTED) {
+    return EFI_UNSUPPORTED;
+  }
+
+  return EFI_DEVICE_ERROR;
+}
+
+STATIC
+EFI_STATUS
+ReadSmmStoreBytes (
+  IN     UINTN  Offset,
+  IN OUT UINTN  *Size,
+  OUT    VOID   *Buffer
+  )
+{
+  UINTN              Block;
+  UINTN              BlockOffset;
+  UINT8              *ByteBuffer;
+  UINTN              ChunkSize;
+  SMM_STORE_COM_BUF  CommandBuffer;
+  EFI_HOB_GUID_TYPE  *GuidHob;
+  UINTN              RemainingSize;
+  EFI_STATUS         Status;
+  SMMSTORE_INFO      *SmmStoreInfo;
+  UINTN              TotalReadSize;
+
+  if ((Size == NULL) || (Buffer == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  GuidHob = GetFirstGuidHob (&gEfiSmmStoreInfoHobGuid);
+  if (GuidHob == NULL) {
+    return EFI_NO_MEDIA;
+  }
+
+  SmmStoreInfo = (SMMSTORE_INFO *)GET_GUID_HOB_DATA (GuidHob);
+  if ((SmmStoreInfo->BlockSize == 0) ||
+      (SmmStoreInfo->NumBlocks == 0) ||
+      (SmmStoreInfo->ComBufferSize == 0) ||
+      (SmmStoreInfo->ComBuffer == 0))
+  {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  RemainingSize = *Size;
+  TotalReadSize = 0;
+  ByteBuffer    = (UINT8 *)Buffer;
+
+  while (RemainingSize > 0) {
+    Block       = Offset / SmmStoreInfo->BlockSize;
+    BlockOffset = Offset % SmmStoreInfo->BlockSize;
+    if (Block >= SmmStoreInfo->NumBlocks) {
+      *Size = TotalReadSize;
+      return EFI_END_OF_MEDIA;
+    }
+
+    ChunkSize = MIN (RemainingSize, (UINTN)SmmStoreInfo->BlockSize - BlockOffset);
+    if (BlockOffset >= SmmStoreInfo->ComBufferSize) {
+      *Size = TotalReadSize;
+      return EFI_BAD_BUFFER_SIZE;
+    }
+
+    ChunkSize = MIN (ChunkSize, (UINTN)SmmStoreInfo->ComBufferSize - BlockOffset);
+    ZeroMem (&CommandBuffer, sizeof (CommandBuffer));
+    CommandBuffer.Read.BufSize   = (UINT32)ChunkSize;
+    CommandBuffer.Read.BufOffset = (UINT32)BlockOffset;
+    CommandBuffer.Read.BlockId   = (UINT32)Block;
+
+    Status = SmmStoreRawRead (SmmStoreInfo, &CommandBuffer);
+    if (EFI_ERROR (Status)) {
+      *Size = TotalReadSize;
+      return Status;
+    }
+
+    CopyMem (ByteBuffer, (VOID *)(UINTN)(SmmStoreInfo->ComBuffer + BlockOffset), ChunkSize);
+
+    ByteBuffer    += ChunkSize;
+    Offset        += ChunkSize;
+    RemainingSize -= ChunkSize;
+    TotalReadSize += ChunkSize;
+  }
+
+  *Size = TotalReadSize;
+  return EFI_SUCCESS;
+}
+
+#else
+STATIC
+EFI_STATUS
+ReadSmmStoreBytes (
+  IN     UINTN  Offset,
+  IN OUT UINTN  *Size,
+  OUT    VOID   *Buffer
+  )
+{
+  return EFI_UNSUPPORTED;
+}
+
+#endif
+
+VOID
+BuildMemoryTypeInformationHob (
+  IN EFI_MEMORY_TYPE_INFORMATION  *DefaultMemoryTypeInformation,
+  IN UINTN                        DefaultMemoryTypeInformationSize
+  )
+{
+  EFI_FIRMWARE_VOLUME_HEADER  FirmwareVolumeHeader;
+  VARIABLE_STORE_HEADER       VariableStoreHeader;
+  UINT8                       *VariableData;
+  UINTN                       VariableDataSize;
+  VARIABLE_STORE_HEADER       *VariableStore;
+  UINTN                       VariableStoreSize;
+  EFI_STATUS                  Status;
+
+  if (GetFirstGuidHob (&gEfiMemoryTypeInformationGuid) != NULL) {
+    return;
+  }
+
+  VariableStore = NULL;
+  VariableDataSize = sizeof (FirmwareVolumeHeader);
+  Status           = ReadSmmStoreBytes (0, &VariableDataSize, &FirmwareVolumeHeader);
+  if (!EFI_ERROR (Status) &&
+      (FirmwareVolumeHeader.Signature == EFI_FVH_SIGNATURE) &&
+      (FirmwareVolumeHeader.HeaderLength >= sizeof (EFI_FIRMWARE_VOLUME_HEADER)))
+  {
+    VariableDataSize = sizeof (VariableStoreHeader);
+    Status           = ReadSmmStoreBytes (
+                         FirmwareVolumeHeader.HeaderLength,
+                         &VariableDataSize,
+                         &VariableStoreHeader
+                         );
+    if (!EFI_ERROR (Status) &&
+        (GetVariableStoreStatus (&VariableStoreHeader) == EfiValid) &&
+        (VariableStoreHeader.Size >= sizeof (VARIABLE_STORE_HEADER)) &&
+        (VariableStoreHeader.Size <= SIZE_16MB))
+    {
+      VariableStoreSize = VariableStoreHeader.Size;
+      VariableStore     = AllocatePages (EFI_SIZE_TO_PAGES (VariableStoreSize));
+      if (VariableStore != NULL) {
+        Status = ReadSmmStoreBytes (
+                   FirmwareVolumeHeader.HeaderLength,
+                   &VariableStoreSize,
+                   VariableStore
+                   );
+        if (!EFI_ERROR (Status) &&
+            FindVariableInStore (
+              VariableStore,
+              EFI_MEMORY_TYPE_INFORMATION_VARIABLE_NAME,
+              &gEfiMemoryTypeInformationGuid,
+              &VariableData,
+              &VariableDataSize
+              ) &&
+            ValidateMemoryTypeInfoVariable ((EFI_MEMORY_TYPE_INFORMATION *)VariableData, VariableDataSize))
+        {
+          BuildGuidDataHob (
+            &gEfiMemoryTypeInformationGuid,
+            VariableData,
+            VariableDataSize
+            );
+        }
+
+        FreePages (VariableStore, EFI_SIZE_TO_PAGES (VariableStoreSize));
+      }
+    }
+  }
+
+  if (GetFirstGuidHob (&gEfiMemoryTypeInformationGuid) == NULL) {
+    BuildGuidDataHob (
+      &gEfiMemoryTypeInformationGuid,
+      DefaultMemoryTypeInformation,
+      DefaultMemoryTypeInformationSize
+      );
+  }
+}

--- a/UefiPayloadPkg/UefiPayloadEntry/UefiPayloadEntry.c
+++ b/UefiPayloadPkg/UefiPayloadEntry/UefiPayloadEntry.c
@@ -602,8 +602,7 @@ _ModuleEntryPoint (
   //
   // Create Memory Type Information HOB
   //
-  BuildGuidDataHob (
-    &gEfiMemoryTypeInformationGuid,
+  BuildMemoryTypeInformationHob (
     mDefaultMemoryTypeInformation,
     sizeof (mDefaultMemoryTypeInformation)
     );

--- a/UefiPayloadPkg/UefiPayloadEntry/UefiPayloadEntry.h
+++ b/UefiPayloadPkg/UefiPayloadEntry/UefiPayloadEntry.h
@@ -18,6 +18,7 @@
 #include <Library/HobLib.h>
 #include <Library/PcdLib.h>
 #include <Guid/MemoryAllocationHob.h>
+#include <Guid/MemoryTypeInformation.h>
 #include <Library/IoLib.h>
 #include <Library/PeCoffLib.h>
 #include <Library/BlParseLib.h>
@@ -180,6 +181,12 @@ HandOffToDxeCore (
 EFI_STATUS
 FixUpPcdDatabase (
   IN  EFI_FIRMWARE_VOLUME_HEADER  *DxeFv
+  );
+
+VOID
+BuildMemoryTypeInformationHob (
+  IN EFI_MEMORY_TYPE_INFORMATION  *DefaultMemoryTypeInformation,
+  IN UINTN                        DefaultMemoryTypeInformationSize
   );
 
 /**

--- a/UefiPayloadPkg/UefiPayloadEntry/UefiPayloadEntry.inf
+++ b/UefiPayloadPkg/UefiPayloadEntry/UefiPayloadEntry.inf
@@ -24,6 +24,7 @@
 [Sources]
   UefiPayloadEntry.c
   LoadDxeCore.c
+  MemoryTypeInformationHob.c
   AcpiTable.c
 
 [Sources.Ia32]
@@ -36,6 +37,7 @@
   X64/VirtualMemory.h
   X64/VirtualMemory.c
   X64/DxeLoadFunc.c
+  X64/TriggerSmi.nasm
 
 [Sources.AARCH64]
   AArch64/DxeHandoff.c
@@ -72,6 +74,8 @@
   gUniversalPayloadSerialPortInfoGuid
   gEfiFirmwareInfoHobGuid
   gEfiSmmStoreInfoHobGuid
+  gEfiVariableGuid
+  gEfiAuthenticatedVariableGuid
 
 [FeaturePcd.IA32]
   gEfiMdeModulePkgTokenSpaceGuid.PcdDxeIplSwitchToLongMode      ## CONSUMES

--- a/UefiPayloadPkg/UefiPayloadEntry/UniversalPayloadEntry.c
+++ b/UefiPayloadPkg/UefiPayloadEntry/UniversalPayloadEntry.c
@@ -494,13 +494,10 @@ _ModuleEntryPoint (
   //
   // Create Memory Type Information HOB
   //
-  if (GetFirstGuidHob (&gEfiMemoryTypeInformationGuid) == NULL) {
-    BuildGuidDataHob (
-      &gEfiMemoryTypeInformationGuid,
-      mDefaultMemoryTypeInformation,
-      sizeof (mDefaultMemoryTypeInformation)
-      );
-  }
+  BuildMemoryTypeInformationHob (
+    mDefaultMemoryTypeInformation,
+    sizeof (mDefaultMemoryTypeInformation)
+    );
 
   FixUpPcdDatabase (DxeFv);
   Status = UniversalLoadDxeCore (DxeFv, &DxeCoreEntryPoint);

--- a/UefiPayloadPkg/UefiPayloadEntry/UniversalPayloadEntry.inf
+++ b/UefiPayloadPkg/UefiPayloadEntry/UniversalPayloadEntry.inf
@@ -20,6 +20,7 @@
 [Sources]
   UniversalPayloadEntry.c
   LoadDxeCore.c
+  MemoryTypeInformationHob.c
   PrintHob.c
   AcpiTable.c
 [Sources.Ia32]
@@ -31,6 +32,7 @@
   X64/VirtualMemory.h
   X64/VirtualMemory.c
   X64/DxeLoadFunc.c
+  X64/TriggerSmi.nasm
 [Sources.AARCH64]
   AArch64/DxeHandoff.c
 [Packages]
@@ -67,6 +69,9 @@
   gUniversalPayloadAcpiTableGuid
   gUniversalPayloadPciRootBridgeInfoGuid
   gUniversalPayloadSmbios3TableGuid
+  gEfiSmmStoreInfoHobGuid
+  gEfiVariableGuid
+  gEfiAuthenticatedVariableGuid
 [FeaturePcd.IA32]
   gEfiMdeModulePkgTokenSpaceGuid.PcdDxeIplSwitchToLongMode      ## CONSUMES
 [FeaturePcd.X64]

--- a/UefiPayloadPkg/UefiPayloadEntry/X64/TriggerSmi.nasm
+++ b/UefiPayloadPkg/UefiPayloadEntry/X64/TriggerSmi.nasm
@@ -1,0 +1,40 @@
+;------------------------------------------------------------------------------ ;
+; Copyright (c) 2022, 9elements GmbH. All rights reserved.<BR>
+; SPDX-License-Identifier: BSD-2-Clause-Patent
+;
+;-------------------------------------------------------------------------------
+
+%include "Nasm.inc"
+
+DEFAULT REL
+SECTION .text
+
+;UINTN
+;EFIAPI
+;TriggerSmi (
+;  UINTN   Cmd,
+;  UINTN   Arg,
+;  UINTN   Retry
+;  )
+
+global ASM_PFX(TriggerSmi)
+ASM_PFX(TriggerSmi):
+    push    rbx
+    mov     rax, rcx
+    mov     rbx, rdx
+@Trigger:
+    out     0b2h, al
+
+    cmp     rax, rcx
+    jne     @Return
+    push    rcx
+    mov     rcx, 10000
+    rep     pause
+    pop     rcx
+    cmp     r8, 0
+    je      @Return
+    dec     r8
+    jmp     @Trigger
+@Return:
+    pop     rbx
+    ret


### PR DESCRIPTION
This branch now carries two related payload fixes:

- seed the memory type information table from the variable store contents
- skip `EfiBootManagerConnectAll()` only on S4 resume

The first change keeps the payload memory-type table in sync with stored
variables. The second avoids the AMI-style S4 resume path from reconnecting
all devices before the OS resume handoff.