### PR TITLE
MdeModulePkg/Bus/Pci/PciBusDxe: Add PCD for MEM64 to PMEM64

### DIFF
--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciBusDxe.inf
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciBusDxe.inf
@@ -100,6 +100,7 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdPcieResizableBarMaxSize     ## CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdPciCrsRetryIntervalUs       ## CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdPciCrsTimeoutSeconds        ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdPciDegradeMem64toPMem64     ## CONSUMES
 
 [UserExtensions.TianoCore."ExtraFiles"]
   PciBusDxeExtra.uni

--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciResourceSupport.c
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciResourceSupport.c
@@ -1118,7 +1118,8 @@ DegradeResource (
     // (2024-04-05) for more details.
     //
     if (!BridgeSupportResourceDecode (Bridge, EFI_BRIDGE_MEM64_DECODE_SUPPORTED)) {
-      if (BridgeSupportResourceDecode (Bridge, EFI_BRIDGE_PMEM64_DECODE_SUPPORTED)) {
+      if (PcdGetBool (PcdPciDegradeMem64toPMem64) &&
+          BridgeSupportResourceDecode (Bridge, EFI_BRIDGE_PMEM64_DECODE_SUPPORTED)) {
         MergeResourceTree (
           PMem64Node,
           Mem64Node,

--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -2339,6 +2339,17 @@
   # @Prompt PCI CRS timeout in seconds.
   gEfiMdeModulePkgTokenSpaceGuid.PcdPciCrsTimeoutSeconds|0|UINT32|0x1000002B
 
+  ## Indicates if Mem64 resource requests can be allocated using the PMem64
+  #  pool during PCI enumeration in case Mem64 resources are not available.
+  #  This is supported as per PCI Base spec 6.3+. which recommends that software
+  #  should not use the prefetchable/non-prefetchable bits for determining BAR
+  #  allocations. The default is to support PI Base spec 6.3+ recommendation and
+  #  allow Mem64 to use PMem64 when needed.
+  #    TRUE  - Degrade Mem64 resources to use PMem64 when needed
+  #    FALSE - Mem64 will be degraded to Mem32 and never to PMem64
+  # @Prompt Support degrading Mem64 to PMem64 during PCI enumeration
+  gEfiMdeModulePkgTokenSpaceGuid.PcdPciDegradeMem64toPMem64|TRUE|BOOLEAN|0x1000002C
+
 [PcdsPatchableInModule]
   ## Specify memory size with page number for PEI code when
   #  Loading Module at Fixed Address feature is enabled.


### PR DESCRIPTION
# Description

Add PcdPciDegradeMem64toPMem64 to MdeModulePkg to support conversion of MEM64 to PMEM64 as recommended by PCI Base Spec 6.3+ and also support the previous behavior where MEM64 is converted to MEM32.

This allows OSes that do not support the new PCI Base Spec 6.3+ recommendation to be supported by setting PcdPciDegradeMem64toPMem64 to FALSE.

This change resolves some OS compatibility issues observed with PR https://github.com/tianocore/edk2/pull/12040


- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested


## Integration Instructions

No changes required for PCI Base Spec 6.3 recommendation that allows MEM64 -> PMEM64 conversion.

If a platform requires the legacy behavior of MEM64 -> MEM32, then add the following to platform DSC to set `PcdPciDegradeMem64toPMem64` to `FALSE`

```
gEfiMdeModulePkgTokenSpaceGuid.PcdPciDegradeMem64toPMem64|FALSE
```

