### PR TITLE
fix misspellings in source code

### DIFF
--- a/ArmVirtPkg/Library/CloudHvVirtMemInfoLib/CloudHvVirtMemInfoLib.c
+++ b/ArmVirtPkg/Library/CloudHvVirtMemInfoLib/CloudHvVirtMemInfoLib.c
@@ -103,7 +103,7 @@ CloudHvVirtMemInfoPeiLibConstructor (
           CurBase + CurSize - 1
           ));
 
-        // We should build Hob seperately for the memory node except the first one
+        // We should build Hob separately for the memory node except the first one
         if (CurBase != MemBase) {
           BuildResourceDescriptorHob (
             EFI_RESOURCE_SYSTEM_MEMORY,

--- a/EmulatorPkg/Include/Protocol/EmuThunk.h
+++ b/EmulatorPkg/Include/Protocol/EmuThunk.h
@@ -175,7 +175,7 @@ VOID
   Enumerates the current set of protocol instances that abstract OS services from EFI.
 
   A given protocol can have multiple instances. Usually a protocol is configured via a
-  single PCD string. The data associated for each instance is seperated via a ! in the string.
+  single PCD string. The data associated for each instance is separated via a ! in the string.
   EMU_IO_THUNK_PROTOCOL_CLOSE.ConfigString will contain the information in the PCD string up to the next !.
   Thus each instance has a unique ConfigString.
 

--- a/MdeModulePkg/Bus/Pci/PciSioSerialDxe/Serial.h
+++ b/MdeModulePkg/Bus/Pci/PciSioSerialDxe/Serial.h
@@ -176,7 +176,7 @@ typedef union {
 typedef union {
   struct {
     UINT8    TrFIFOE  : 1; ///< Transmit and Receive FIFO Enable
-    UINT8    ResetRF  : 1; ///< Reset Reciever FIFO
+    UINT8    ResetRF  : 1; ///< Reset Receiver FIFO
     UINT8    ResetTF  : 1; ///< Reset Transmistter FIFO
     UINT8    Dms      : 1; ///< DMA Mode Select
     UINT8    Reserved : 1;

--- a/MdeModulePkg/Bus/Ufs/UfsPassThruDxe/UfsPassThru.c
+++ b/MdeModulePkg/Bus/Ufs/UfsPassThruDxe/UfsPassThru.c
@@ -740,7 +740,7 @@ UfsPassThruDriverBindingSupported (
 }
 
 /**
-  Finishes device initialization by setting fDeviceInit flag and waiting untill device responds by
+  Finishes device initialization by setting fDeviceInit flag and waiting until device responds by
   clearing it.
 
   @param[in] Private  Pointer to the UFS_PASS_THRU_PRIVATE_DATA.

--- a/MdeModulePkg/Include/Library/ImagePropertiesRecordLib.h
+++ b/MdeModulePkg/Include/Library/ImagePropertiesRecordLib.h
@@ -56,7 +56,7 @@ typedef struct {
                                                   OUT:  The size, in bytes, of the used descriptors of the split
                                                         memory map
   @param[in, out] MemoryMap                       IN:   A pointer to the buffer containing the current memory map.
-                                                        This buffer must have enough space to accomodate the "worst case"
+                                                        This buffer must have enough space to accommodate the "worst case"
                                                         scenario where every image in ImageRecordList needs a new descriptor
                                                         to describe its code and data sections.
                                                   OUT:  A pointer to the updated memory map with separated image section

--- a/MdeModulePkg/Library/FileExplorerLib/FileExplorer.c
+++ b/MdeModulePkg/Library/FileExplorerLib/FileExplorer.c
@@ -987,7 +987,7 @@ LibGetFileHandleFromDevicePath (
 
   //
   // Parse each MEDIA_FILEPATH_DP node. There may be more than one, since the
-  // directory information and filename can be seperate. The goal is to inch
+  // directory information and filename can be separate. The goal is to inch
   // our way down each device path node and close the previous node
   //
   DevicePathNode = TempDevicePathNode;

--- a/MdeModulePkg/Library/ImagePropertiesRecordLib/ImagePropertiesRecordLib.c
+++ b/MdeModulePkg/Library/ImagePropertiesRecordLib/ImagePropertiesRecordLib.c
@@ -461,7 +461,7 @@ SplitRecord (
                                                   OUT:  The size, in bytes, of the used descriptors of the split
                                                         memory map
   @param[in, out] MemoryMap                       IN:   A pointer to the buffer containing the current memory map.
-                                                        This buffer must have enough space to accomodate the "worst case"
+                                                        This buffer must have enough space to accommodate the "worst case"
                                                         scenario where every image in ImageRecordList needs a new descriptor
                                                         to describe its code and data sections.
                                                   OUT:  A pointer to the updated memory map with separated image section

--- a/MdeModulePkg/Library/VarCheckHiiLib/VarCheckHiiLibStandaloneMm.c
+++ b/MdeModulePkg/Library/VarCheckHiiLib/VarCheckHiiLibStandaloneMm.c
@@ -136,7 +136,7 @@ VarCheckHiiLibConstructorStandaloneMm (
 
   DEBUG ((DEBUG_INFO, "%a: starts.\n", __func__));
   //
-  // Register a handler to recieve the HII variable checking data.
+  // Register a handler to receive the HII variable checking data.
   //
   Status = gMmst->MmiHandlerRegister (VarCheckHiiLibReceiveHiiBinHandler, &gVarCheckReceivedHiiBinHandlerGuid, &DispatchHandle);
   if (EFI_ERROR (Status)) {

--- a/MdeModulePkg/Library/VarCheckPolicyLib/VarCheckPolicyLib.c
+++ b/MdeModulePkg/Library/VarCheckPolicyLib/VarCheckPolicyLib.c
@@ -48,7 +48,7 @@ UINTN   mPaginationCacheSize      = 0;
 UINT32  mCurrentPaginationCommand = 0;
 
 /**
-  MM Communication Handler to recieve commands from the DXE protocol for
+  MM Communication Handler to receive commands from the DXE protocol for
   Variable Policies. This communication channel is used to register new policies
   and poll and toggle the enforcement of variable policies.
 

--- a/MdeModulePkg/Universal/DebugSupportDxe/Ia32/AsmFuncs.nasm
+++ b/MdeModulePkg/Universal/DebugSupportDxe/Ia32/AsmFuncs.nasm
@@ -166,7 +166,7 @@ ASM_PFX(CommonIdtEntry):
 ;;              eflags from interrupted task
 ;;              CS from interrupted task
 ;;              EIP from interrupted task
-;;              Error code <-------------------- Only present for some exeption types
+;;              Error code <-------------------- Only present for some exception types
 ;;
 ;;
 

--- a/MdeModulePkg/Universal/DebugSupportDxe/X64/AsmFuncs.nasm
+++ b/MdeModulePkg/Universal/DebugSupportDxe/X64/AsmFuncs.nasm
@@ -169,7 +169,7 @@ ASM_PFX(CommonIdtEntry):
 ;;              rflags from interrupted task
 ;;              CS from interrupted task
 ;;              RIP from interrupted task
-;;              Error code <-------------------- Only present for some exeption types
+;;              Error code <-------------------- Only present for some exception types
 ;;
 ;;              Vector Number <----------------- pushed in our IDT Entry
 ;;

--- a/MdeModulePkg/Universal/EbcDxe/EbcDebugger/EdbSymbol.c
+++ b/MdeModulePkg/Universal/EbcDxe/EbcDebugger/EdbSymbol.c
@@ -2142,7 +2142,7 @@ EdbPrintSource (
   *(UINT8 *)FuncEnd = 0;
 
   //
-  // seperate buffer by \n, so that \r can be added.
+  // separate buffer by \n, so that \r can be added.
   //
   FuncIndex = FuncStart;
   while (*FuncIndex != 0) {

--- a/MdePkg/Include/Protocol/MmPeriodicTimerDispatch.h
+++ b/MdePkg/Include/Protocol/MmPeriodicTimerDispatch.h
@@ -37,7 +37,7 @@
 ///      The resulting MMI will occur every 64ms with the child called back on
 ///      every 47th MMI.
 ///      NOTE: the child driver should be aware that this will result in more
-///        MMIs occuring during system runtime which can negatively impact system
+///        MMIs occurring during system runtime which can negatively impact system
 ///        performance.
 ///
 typedef struct {

--- a/MdePkg/Include/Protocol/Shell.h
+++ b/MdePkg/Include/Protocol/Shell.h
@@ -730,7 +730,7 @@ EFI_STATUS
   device path. If there is an exact match, the mapping is returned and *DevicePath
   points to the end-of-device-path node.
 
-  If there are multiple map names they will be semi-colon seperated in the
+  If there are multiple map names they will be semi-colon separated in the
   NULL-terminated string.
 
   @param[in, out] DevicePath     On entry, points to a device path pointer. On

--- a/MdePkg/Include/Protocol/SmmPeriodicTimerDispatch2.h
+++ b/MdePkg/Include/Protocol/SmmPeriodicTimerDispatch2.h
@@ -35,7 +35,7 @@
 ///      The resulting SMI will occur every 64ms with the child called back on
 ///      every 47th SMI.
 ///      NOTE: the child driver should be aware that this will result in more
-///        SMIs occuring during system runtime which can negatively impact system
+///        SMIs occurring during system runtime which can negatively impact system
 ///        performance.
 ///
 typedef struct {

--- a/NetworkPkg/Include/Protocol/WiFiProfileSyncProtocol.h
+++ b/NetworkPkg/Include/Protocol/WiFiProfileSyncProtocol.h
@@ -47,7 +47,7 @@ EFI_STATUS
   );
 
 /**
-  Saves the WiFi connection status recieved by the WiFiConnectionManager when
+  Saves the WiFi connection status received by the WiFiConnectionManager when
   in a KVM OR One Click Recovery WLAN recovery flow. Input as
   EFI_80211_CONNECT_NETWORK_RESULT_CODE then converted and stored as EFI_STATUS type.
 

--- a/NetworkPkg/WifiConnectionManagerDxe/WifiConnectionMgrMisc.c
+++ b/NetworkPkg/WifiConnectionManagerDxe/WifiConnectionMgrMisc.c
@@ -45,7 +45,7 @@ WifiMgrInternalEmptyFunction (
 }
 
 /**
-  Convert the mac address into a hexadecimal encoded ":" seperated string.
+  Convert the mac address into a hexadecimal encoded ":" separated string.
 
   @param[in]  Mac     The mac address.
   @param[in]  StrSize The size, in bytes, of the output buffer specified by Str.

--- a/NetworkPkg/WifiConnectionManagerDxe/WifiConnectionMgrMisc.h
+++ b/NetworkPkg/WifiConnectionManagerDxe/WifiConnectionMgrMisc.h
@@ -24,7 +24,7 @@ WifiMgrInternalEmptyFunction (
   );
 
 /**
-  Convert the mac address into a hexadecimal encoded ":" seperated string.
+  Convert the mac address into a hexadecimal encoded ":" separated string.
 
   @param[in]  Mac     The mac address
   @param[in]  StrSize The size, in bytes, of the output buffer specified by Str

--- a/OvmfPkg/OvmfPkg.dec
+++ b/OvmfPkg/OvmfPkg.dec
@@ -338,7 +338,7 @@
   gUefiOvmfPkgTokenSpaceGuid.PcdBfvRawDataSize|0|UINT32|0x57
 
   ## The base address and size of the SEV-SNP Secrets Area that contains
-  #  the VM platform communication key used to send and recieve the
+  #  the VM platform communication key used to send and receive the
   #  messages to the PSP. If this is set in the .fdf, the platform
   #  is responsible to reserve this area from DXE phase overwrites.
   gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSnpSecretsBase|0|UINT32|0x58

--- a/RedfishPkg/RedfishRestExDxe/RedfishRestExDriver.h
+++ b/RedfishPkg/RedfishRestExDxe/RedfishRestExDriver.h
@@ -374,7 +374,7 @@ RedfishRestExEventService (
   );
 
 /**
-  Create a new TLS session becuase the previous on is closed.
+  Create a new TLS session because the previous on is closed.
   status.
 
   @param[in]  Instance            Pointer to EFI_REST_EX_PROTOCOL instance for a particular

--- a/RedfishPkg/RedfishRestExDxe/RedfishRestExInternal.h
+++ b/RedfishPkg/RedfishRestExDxe/RedfishRestExInternal.h
@@ -337,7 +337,7 @@ RedfishRestExEventService (
   );
 
 /**
-  Create a new TLS session becuase the previous on is closed.
+  Create a new TLS session because the previous on is closed.
   status.
 
   @param[in]  Instance            Pointer to EFI_REST_EX_PROTOCOL instance for a particular

--- a/ShellPkg/Include/Library/ShellLib.h
+++ b/ShellPkg/Include/Library/ShellLib.h
@@ -699,7 +699,7 @@ typedef enum {
   TypeValue,        ///< A flag that has some data following it with a space (IE "-a 1").
   TypePosition,     ///< Some data that did not follow a parameter (IE "filename.txt").
   TypeStart,        ///< A flag that has variable value appended to the end (IE "-ad", "-afd", "-adf", etc...).
-  TypeDoubleValue,  ///< A flag that has 2 space seperated value data following it (IE "-a 1 2").
+  TypeDoubleValue,  ///< A flag that has 2 space separated value data following it (IE "-a 1 2").
   TypeMaxValue,     ///< A flag followed by all the command line data before the next flag.
   TypeTimeValue,    ///< A flag that has a time value following it (IE "-a -5:00").
   TypeMax,

--- a/ShellPkg/Library/UefiShellLib/UefiShellLib.c
+++ b/ShellPkg/Library/UefiShellLib/UefiShellLib.c
@@ -347,7 +347,7 @@ ShellLibConstructorWorker (
 
   if (gEfiShellProtocol == NULL) {
     //
-    // Moved to seperate function due to complexity
+    // Moved to separate function due to complexity
     //
     Status = ShellFindSE2 (ImageHandle);
 

--- a/UefiCpuPkg/Library/MpInitLib/X64/AmdSev.nasm
+++ b/UefiCpuPkg/Library/MpInitLib/X64/AmdSev.nasm
@@ -267,7 +267,7 @@ BITS 64
 
     ;
     ; Get RDX reset value before changing stacks since the
-    ; new stack won't be able to accomodate a #VC exception.
+    ; new stack won't be able to accommodate a #VC exception.
     ;
     push       rax
     push       rbx


### PR DESCRIPTION
# Description

No functional change here.  Fix misspellings in code comments.  Using "Global" as package, since the fixes are spread throughout the code base.

- [ ] Breaking change?

No, not a breaking change.

- [ ] Impacts security?

No impact to security.

- [ ] Includes tests?

No test code included nor required

## How This Was Tested

N/A, this is just fixing misspellings in code comments

## Integration Instructions

N/A, this is just fixing misspellings in code comments
