### PR TITLE
UnitTestFrameworkPkg : Align C++ std version

### DIFF
--- a/UnitTestFrameworkPkg/UnitTestFrameworkPkgHost.dsc.inc
+++ b/UnitTestFrameworkPkg/UnitTestFrameworkPkgHost.dsc.inc
@@ -185,8 +185,8 @@
   #
   MSFT:*_*_*_CXX_FLAGS         = /std:c++20 /Zc:strictStrings- /wd4244
   GCC:*_*_*_CXX_FLAGS          = -std=c++20
-  GCC:*_CLANGDWARF_*_CXX_FLAGS = -std=c++17
-  CLANGPDB:*_*_*_CXX_FLAGS     = -std=c++17
+  GCC:*_CLANGDWARF_*_CXX_FLAGS = -std=c++20
+  CLANGPDB:*_*_*_CXX_FLAGS     = -std=c++20
   #
   # CLANGDWARF and CLANGPDB: Some gtest c++ sources generate undefined
   # behavior that is never triggered. Map trap functions to abort() to


### PR DESCRIPTION
# Description
The C++ standard version doesn't align in the current UnitTestFrameworkPkg, that may caused C++ compiler flow cannot be aligned. it may caused potential issue.


- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested
None

## Integration Instructions
Ensure each compiler adopt same C++ language standard version.
