### PR TITLE
OvmfPkg/OvmfXen: Switch timer library to support x2APIC mode

### DIFF
--- a/OvmfPkg/OvmfXen.dsc
+++ b/OvmfPkg/OvmfXen.dsc
@@ -124,7 +124,7 @@
 
 [LibraryClasses]
   PcdLib|MdePkg/Library/BasePcdLibNull/BasePcdLibNull.inf
-  TimerLib|MdePkg/Library/SecPeiDxeTimerLibCpu/SecPeiDxeTimerLibCpu.inf
+  TimerLib|UefiCpuPkg/Library/SecPeiDxeTimerLibUefiCpu/SecPeiDxeTimerLibUefiCpu.inf
   ResetSystemLib|OvmfPkg/Library/ResetSystemLib/BaseResetSystemLibXen.inf
   PrintLib|MdePkg/Library/BasePrintLib/BasePrintLib.inf
   BaseMemoryLib|MdePkg/Library/BaseMemoryLibRepStr/BaseMemoryLibRepStr.inf


### PR DESCRIPTION
# Description

The SecPeiDxeTimerLibCpu library from the MdePkg accesses the Local APIC timer exclusively via MMIO and explicitly asserts that x2APIC mode is not enabled. This causes failures when vCPUs are pre-enabled in x2APIC mode, which might be necessary for domains with more than 128 vCPUs. So, this commit switches the TimerLib to SecPeiDxeTimerLibUefiCpu from the UefiCpuPkg, which delegates APIC mode handling to the LocalApicLib. OvmfXen already uses BaseXApicX2ApicLib as its LocalApicLib, which transparently supports both xAPIC (MMIO) and x2APIC (MSR) modes.

new PR based on: https://github.com/tianocore/edk2/pull/12148

@tperard : I have addressed your comment, and fixed the commit message.

## How This Was Tested

Tested with a PVH VM, with the following parameters:

```
type='pvh'
kernel='/usr/share/edk2/OVMF-debug.fd'

memory = 3072
vcpus = 4
sdl = 0
vnc = 0
serial='pty'
name = "ovmf"
disk = [
## This line works in OVMF, but Linux will not look at CDROM over PV interface
  '/mnt/debian-live-12.4.0-amd64-standard.iso,,hdc,cdrom',
## This works for both Linux and OVMF, and archlinux ISO can boot.
  '/mnt/debian-live-12.4.0-amd64-standard.iso,,hdd,r',
]
on_reboot = 'destroy'
```

and xl create -c foo.pvh. I see OVMF booting properly. Although I don't see my Linux booting afterwards. I think there is an issue with disk command? It then jumps into the EDKII menu and BIOS settings. It doesn't fail with an error with the timer driver or so. So, I think we should be good for PVH as well.

## Integration Instructions

n/a
