### PR TITLE
Revert "MdeModulePkg: PciBusDxe: Degrade MEM64 to PMEM64 when bridge lacks MEM64"

### DIFF
--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciResourceSupport.c
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciResourceSupport.c
@@ -1000,19 +1000,6 @@ ResourcePaddingPolicy (
   PMEM64 -> PMEM32 -> MEM32
   IO32   -> IO16.
 
-  Additionally, if the upstream bridge supports PMEM64 but not MEM64,
-  MEM64 resources are degraded to PMEM64 to enable 64-bit allocation
-  through the bridge's prefetchable window. So the below degradation
-  path is also now supported:
-
-  MEM64  -> PMEM64
-
-  This is safe per PCI-SIG's ECN title "Removing Prefetchable Terminology"
-  (2024-04-05).
-
-  The terms prefetchable and non-prefetchable have also been removed from
-  the PCIe base specification starting with version 6.3.
-
   @param Bridge     Pci device instance.
   @param Mem32Node  Resource info node for 32-bit memory.
   @param PMem32Node Resource info node for 32-bit Prefetchable Memory.
@@ -1103,34 +1090,14 @@ DegradeResource (
       );
   } else {
     //
-    // If the upstream bridge does not support MEM64, check if we can
-    // degrade to PMEM64 first, instead of degrading to MEM32 directly.
-    //
-    // This is allowed per PCIe Base Spec 6.3+ which removes the terms
-    // prefetchable/non-prefetchable from the specification.
-    // The distinction originally only described P2P bridge read-ahead
-    // behavior, not resource allocation policy.
-    //
-    // We will still fall back and degrade to MEM32 if the upstream
-    // bridge lacks PMEM64 support.
-    //
-    // Refer to PCI-SIG ECN "Removing Prefetchable Terminology"
-    // (2024-04-05) for more details.
+    // if the bridge does not support MEM64, degrade MEM64 to MEM32
     //
     if (!BridgeSupportResourceDecode (Bridge, EFI_BRIDGE_MEM64_DECODE_SUPPORTED)) {
-      if (BridgeSupportResourceDecode (Bridge, EFI_BRIDGE_PMEM64_DECODE_SUPPORTED)) {
-        MergeResourceTree (
-          PMem64Node,
-          Mem64Node,
-          TRUE
-          );
-      } else {
-        MergeResourceTree (
-          Mem32Node,
-          Mem64Node,
-          TRUE
-          );
-      }
+      MergeResourceTree (
+        Mem32Node,
+        Mem64Node,
+        TRUE
+        );
     }
 
     //


### PR DESCRIPTION
# Description

This reverts commit f6489621b8ae1164c5e4930902988ba7c86847ba from PR #12040.

A number of compatibility issues have been reported with this change to the PciBusDxe behavior. Revert this change at this time to give time for all the issues to be reviewed and options for supporting this new behavior to be evaluated and fully validated.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

## Integration Instructions

N/A