### PR TITLE
MdeModulePkg: Add NULL check for mSmmBootPerformanceTable

### DIFF
--- a/MdeModulePkg/Library/SmmCorePerformanceLib/MmCorePerformanceLib.c
+++ b/MdeModulePkg/Library/SmmCorePerformanceLib/MmCorePerformanceLib.c
@@ -11,7 +11,8 @@
 
   Copyright (c) 2006 - 2023, Intel Corporation. All rights reserved.<BR>
   (C) Copyright 2016 Hewlett Packard Enterprise Development LP<BR>
-  Copyright (c) Microsoft Corporation.
+  Copyright (c) Microsoft Corporation.<BR>
+  Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -836,6 +837,11 @@ FpdtSmiHandler (
 
       if (BootRecordOffset >= mBootRecordSize) {
         Status = EFI_INVALID_PARAMETER;
+        break;
+      }
+
+      if (mSmmBootPerformanceTable == NULL) {
+        Status = EFI_NOT_FOUND;
         break;
       }
 


### PR DESCRIPTION
In GetFpdtRecordPtr(), there is a chance when mSmmBootPerformanceTable could be set to NULL by ReallocatePool() if there is not enough memory for reallocation.

At some point later FpdtSmiHandler() tries to dereference this table in one of the cases which results in an exception.

# Description


- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested


## Integration Instructions


