### PR TITLE
NetworkPkg: Remove redundant Status initializations and fix unhandled errors

### DIFF
--- a/NetworkPkg/Dhcp6Dxe/Dhcp6Io.c
+++ b/NetworkPkg/Dhcp6Dxe/Dhcp6Io.c
@@ -2300,8 +2300,6 @@ Dhcp6HandleReplyMsg (
   ASSERT (Instance->IaCb.Ia != NULL);
   ASSERT (Packet != NULL);
 
-  Status = EFI_SUCCESS;
-
   if (Packet->Dhcp6.Header.MessageType != Dhcp6MsgReply) {
     return EFI_DEVICE_ERROR;
   }

--- a/NetworkPkg/DnsDxe/DnsDhcp.c
+++ b/NetworkPkg/DnsDxe/DnsDhcp.c
@@ -474,6 +474,14 @@ GetDns4ServerFromDhcp4 (
   ParaList[1]->Data[0] = DHCP4_TAG_DNS_SERVER;
 
   Status = Dhcp4->Build (Dhcp4, &SeedPacket, 0, NULL, 2, ParaList, &Token.Packet);
+  if (EFI_ERROR (Status)) {
+    goto ON_EXIT;
+  }
+
+  if (Token.Packet == NULL) {
+    Status = EFI_NOT_FOUND;
+    goto ON_EXIT;
+  }
 
   Token.Packet->Dhcp4.Header.Xid = Random;
 

--- a/NetworkPkg/DnsDxe/DnsDriver.c
+++ b/NetworkPkg/DnsDxe/DnsDriver.c
@@ -236,8 +236,7 @@ DnsCreateService (
   EFI_STATUS   Status;
   DNS_SERVICE  *DnsSb;
 
-  Status = EFI_SUCCESS;
-  DnsSb  = NULL;
+  DnsSb = NULL;
 
   *Service = NULL;
 
@@ -427,8 +426,6 @@ DnsDriverEntryPoint (
   )
 {
   EFI_STATUS  Status;
-
-  Status = EFI_SUCCESS;
 
   //
   // Install the Dns4 Driver Binding Protocol.

--- a/NetworkPkg/DnsDxe/DnsProtocol.c
+++ b/NetworkPkg/DnsDxe/DnsProtocol.c
@@ -71,7 +71,6 @@ Dns4GetModeData (
   ServerList = NULL;
   CacheItem  = NULL;
   CacheList  = NULL;
-  Status     = EFI_SUCCESS;
 
   if ((This == NULL) || (DnsModeData == NULL)) {
     return EFI_INVALID_PARAMETER;
@@ -354,7 +353,6 @@ Dns4HostNameToIp (
 
   EFI_TPL  OldTpl;
 
-  Status     = EFI_SUCCESS;
   Item       = NULL;
   QueryName  = NULL;
   TokenEntry = NULL;
@@ -611,7 +609,6 @@ Dns4GeneralLookUp (
 
   EFI_TPL  OldTpl;
 
-  Status     = EFI_SUCCESS;
   TokenEntry = NULL;
   Packet     = NULL;
 
@@ -753,8 +750,6 @@ Dns4UpdateDnsCache (
 {
   EFI_STATUS  Status;
   EFI_TPL     OldTpl;
-
-  Status = EFI_SUCCESS;
 
   if ((DnsCacheEntry.HostName == NULL) || (DnsCacheEntry.IpAddress == NULL) || (DnsCacheEntry.Timeout == 0)) {
     return EFI_INVALID_PARAMETER;
@@ -924,7 +919,6 @@ Dns6GetModeData (
   ServerList = NULL;
   CacheItem  = NULL;
   CacheList  = NULL;
-  Status     = EFI_SUCCESS;
 
   if ((This == NULL) || (DnsModeData == NULL)) {
     return EFI_INVALID_PARAMETER;
@@ -1200,7 +1194,6 @@ Dns6HostNameToIp (
 
   EFI_TPL  OldTpl;
 
-  Status     = EFI_SUCCESS;
   Item       = NULL;
   QueryName  = NULL;
   TokenEntry = NULL;
@@ -1460,7 +1453,6 @@ Dns6GeneralLookUp (
 
   EFI_TPL  OldTpl;
 
-  Status     = EFI_SUCCESS;
   TokenEntry = NULL;
   Packet     = NULL;
 
@@ -1603,8 +1595,6 @@ Dns6UpdateDnsCache (
 {
   EFI_STATUS  Status;
   EFI_TPL     OldTpl;
-
-  Status = EFI_SUCCESS;
 
   if ((DnsCacheEntry.HostName == NULL) || (DnsCacheEntry.IpAddress == NULL) || (DnsCacheEntry.Timeout == 0)) {
     return EFI_INVALID_PARAMETER;

--- a/NetworkPkg/HttpBootDxe/HttpBootImpl.c
+++ b/NetworkPkg/HttpBootDxe/HttpBootImpl.c
@@ -313,8 +313,6 @@ HttpBootDhcp (
     return EFI_NOT_STARTED;
   }
 
-  Status = EFI_DEVICE_ERROR;
-
   if (!Private->UsingIpv6) {
     //
     // Start D.O.R.A process to get a IPv4 address and other boot information.

--- a/NetworkPkg/HttpDxe/HttpProto.c
+++ b/NetworkPkg/HttpDxe/HttpProto.c
@@ -1521,7 +1521,6 @@ HttpTransmitTcp (
   UINTN              RecordCount;
   UINTN              RemainingLen;
 
-  Status            = EFI_SUCCESS;
   TlsRecord         = NULL;
   PayloadSize       = 0;
   TempFragment.Len  = 0;

--- a/NetworkPkg/HttpDxe/HttpsSupport.c
+++ b/NetworkPkg/HttpDxe/HttpsSupport.c
@@ -818,9 +818,6 @@ TlsCommonTransmit (
       );
 
     HttpInstance->Tcp4TlsTxToken.Packet.TxData = (EFI_TCP4_TRANSMIT_DATA *)Data;
-
-    Status = EFI_DEVICE_ERROR;
-
     //
     // Transmit the packet.
     //
@@ -852,8 +849,6 @@ TlsCommonTransmit (
       );
 
     HttpInstance->Tcp6TlsTxToken.Packet.TxData = (EFI_TCP6_TRANSMIT_DATA *)Data;
-
-    Status = EFI_DEVICE_ERROR;
 
     //
     // Transmit the packet.
@@ -1452,7 +1447,6 @@ TlsCloseSession (
   NET_BUF  *PacketOut;
   UINT8    *DataOut;
 
-  Status    = EFI_SUCCESS;
   BufferOut = NULL;
   PacketOut = NULL;
   DataOut   = NULL;
@@ -1574,7 +1568,6 @@ TlsProcessMessage (
   EFI_TLS_FRAGMENT_DATA  *OriginalFragmentTable;
   UINTN                  Index;
 
-  Status                = EFI_SUCCESS;
   Buffer                = NULL;
   BufferSize            = 0;
   BytesCopied           = 0;
@@ -1704,7 +1697,6 @@ HttpsReceive (
   UINT8              *GetSessionDataBuffer;
   UINTN              GetSessionDataBufferSize;
 
-  Status                   = EFI_SUCCESS;
   Pdu                      = NULL;
   BufferIn                 = NULL;
   BufferInSize             = 0;

--- a/NetworkPkg/HttpDxe/HttpsSupport.c
+++ b/NetworkPkg/HttpDxe/HttpsSupport.c
@@ -1909,6 +1909,11 @@ HttpsReceive (
       CopyMem (DataOut, BufferOut, BufferOutSize);
 
       Status = TlsCommonTransmit (HttpInstance, PacketOut);
+      if (EFI_ERROR (Status)) {
+        NetbufFree (PacketOut);
+        FreePool (BufferOut);
+        return Status;
+      }
 
       NetbufFree (PacketOut);
     }

--- a/NetworkPkg/Ip4Dxe/Ip4Config2Impl.c
+++ b/NetworkPkg/Ip4Dxe/Ip4Config2Impl.c
@@ -947,16 +947,7 @@ Ip4StartAutoConfig (
                   EFI_OPEN_PROTOCOL_BY_DRIVER
                   );
   if (EFI_ERROR (Status)) {
-    NetLibDestroyServiceChild (
-      IpSb->Controller,
-      IpSb->Image,
-      &gEfiDhcp4ServiceBindingProtocolGuid,
-      Instance->Dhcp4Handle
-      );
-
-    Instance->Dhcp4Handle = NULL;
-
-    return Status;
+    goto Error;
   }
 
   //
@@ -965,6 +956,10 @@ Ip4StartAutoConfig (
   //
   Dhcp4  = Instance->Dhcp4;
   Status = Dhcp4->GetModeData (Dhcp4, &Dhcp4Mode);
+  if (EFI_ERROR (Status)) {
+    goto Error;
+  }
+
   if (Dhcp4Mode.State == Dhcp4Bound) {
     Ip4Config2OnDhcp4Complete (NULL, Instance);
 
@@ -987,25 +982,7 @@ Ip4StartAutoConfig (
 
   Status = Dhcp4->Configure (Dhcp4, &Dhcp4Mode.ConfigData);
   if (EFI_ERROR (Status)) {
-    gBS->CloseProtocol (
-           Instance->Dhcp4Handle,
-           &gEfiDhcp4ProtocolGuid,
-           IpSb->Image,
-           IpSb->Controller
-           );
-
-    NetLibDestroyServiceChild (
-      IpSb->Controller,
-      IpSb->Image,
-      &gEfiDhcp4ServiceBindingProtocolGuid,
-      Instance->Dhcp4Handle
-      );
-
-    Instance->Dhcp4 = NULL;
-
-    Instance->Dhcp4Handle = NULL;
-
-    return Status;
+    goto Error;
   }
 
   //
@@ -1036,6 +1013,29 @@ Ip4StartAutoConfig (
   DispatchDpc ();
 
   return EFI_SUCCESS;
+
+Error:
+  if (Instance->Dhcp4 != NULL) {
+    gBS->CloseProtocol (
+           Instance->Dhcp4Handle,
+           &gEfiDhcp4ProtocolGuid,
+           IpSb->Image,
+           IpSb->Controller
+           );
+
+    Instance->Dhcp4 = NULL;
+  }
+
+  NetLibDestroyServiceChild (
+    IpSb->Controller,
+    IpSb->Image,
+    &gEfiDhcp4ServiceBindingProtocolGuid,
+    Instance->Dhcp4Handle
+    );
+
+  Instance->Dhcp4Handle = NULL;
+
+  return Status;
 }
 
 /**

--- a/NetworkPkg/Ip4Dxe/Ip4Config2Nv.c
+++ b/NetworkPkg/Ip4Dxe/Ip4Config2Nv.c
@@ -535,7 +535,6 @@ Ip4Config2ConvertIfrNvDataToConfigNvData (
   UINTN          DataSize;
   EFI_INPUT_KEY  Key;
 
-  Status    = EFI_SUCCESS;
   Ip4Cfg2   = &Instance->Ip4Config2;
   Ip4NvData = &Instance->Ip4NvData;
 
@@ -878,7 +877,6 @@ Ip4FormExtractConfig (
     return EFI_INVALID_PARAMETER;
   }
 
-  Status             = EFI_SUCCESS;
   IfrFormNvData      = NULL;
   ConfigRequest      = NULL;
   FormResult         = NULL;

--- a/NetworkPkg/Ip6Dxe/Ip6Nd.c
+++ b/NetworkPkg/Ip6Dxe/Ip6Nd.c
@@ -1001,7 +1001,6 @@ Ip6InitDADProcess (
     return EFI_SUCCESS;
   }
 
-  Status   = EFI_SUCCESS;
   IpSb     = IpIf->Service;
   DadXmits = &IpSb->Ip6ConfigInstance.DadXmits;
 

--- a/NetworkPkg/MnpDxe/MnpConfig.c
+++ b/NetworkPkg/MnpDxe/MnpConfig.c
@@ -1199,8 +1199,6 @@ MnpStart (
   MNP_DEVICE_DATA  *MnpDeviceData;
 
   NET_CHECK_SIGNATURE (MnpServiceData, MNP_SERVICE_DATA_SIGNATURE);
-
-  Status        = EFI_SUCCESS;
   MnpDeviceData = MnpServiceData->MnpDeviceData;
 
   if (!IsConfigUpdate) {
@@ -1330,19 +1328,19 @@ MnpStop (
     //
     //  The system poll in on, cancel the poll timer.
     //
-    Status                          = gBS->SetTimer (MnpDeviceData->PollTimer, TimerCancel, 0);
+    gBS->SetTimer (MnpDeviceData->PollTimer, TimerCancel, 0);
     MnpDeviceData->EnableSystemPoll = FALSE;
   }
 
   //
   // Cancel the timeout timer.
   //
-  Status = gBS->SetTimer (MnpDeviceData->TimeoutCheckTimer, TimerCancel, 0);
+  gBS->SetTimer (MnpDeviceData->TimeoutCheckTimer, TimerCancel, 0);
 
   //
   // Cancel the media detect timer.
   //
-  Status = gBS->SetTimer (MnpDeviceData->MediaDetectTimer, TimerCancel, 0);
+  gBS->SetTimer (MnpDeviceData->MediaDetectTimer, TimerCancel, 0);
 
   //
   // Stop the simple network.
@@ -1421,8 +1419,6 @@ MnpConfigureInstance (
     //
     return EFI_UNSUPPORTED;
   }
-
-  Status = EFI_SUCCESS;
 
   MnpServiceData = Instance->MnpServiceData;
   MnpDeviceData  = MnpServiceData->MnpDeviceData;

--- a/NetworkPkg/Mtftp4Dxe/Mtftp4Rrq.c
+++ b/NetworkPkg/Mtftp4Dxe/Mtftp4Rrq.c
@@ -91,8 +91,6 @@ Mtftp4RrqSendAck (
   NET_BUF            *Packet;
   EFI_STATUS         Status;
 
-  Status = EFI_SUCCESS;
-
   Packet = NetbufAlloc (sizeof (EFI_MTFTP4_ACK_HEADER));
   if (Packet == NULL) {
     return EFI_OUT_OF_RESOURCES;
@@ -252,7 +250,6 @@ Mtftp4RrqHandleData (
   INTN        Expected;
 
   *Completed = FALSE;
-  Status     = EFI_SUCCESS;
   BlockNum   = NTOHS (Packet->Data.Block);
   Expected   = Mtftp4GetNextBlockNum (&Instance->Blocks);
 

--- a/NetworkPkg/Mtftp6Dxe/Mtftp6Rrq.c
+++ b/NetworkPkg/Mtftp6Dxe/Mtftp6Rrq.c
@@ -30,8 +30,6 @@ Mtftp6RrqSendAck (
   NET_BUF            *Packet;
   EFI_STATUS         Status;
 
-  Status = EFI_SUCCESS;
-
   //
   // Allocate net buffer to create ack packet.
   //
@@ -222,7 +220,6 @@ Mtftp6RrqHandleData (
   INTN        Expected;
 
   *IsCompleted = FALSE;
-  Status       = EFI_SUCCESS;
   BlockNum     = NTOHS (Packet->Data.Block);
   Expected     = Mtftp6GetNextBlockNum (&Instance->BlkList);
 

--- a/NetworkPkg/SnpDxe/Initialize.c
+++ b/NetworkPkg/SnpDxe/Initialize.c
@@ -35,8 +35,6 @@ PxeInit (
     return EFI_DEVICE_ERROR;
   }
 
-  Status = EFI_SUCCESS;
-
   Cpb = Snp->Cpb;
   if (Snp->TxRxBufferSize != 0) {
     Status = Snp->PciIo->AllocateBuffer (

--- a/NetworkPkg/TcpDxe/SockInterface.c
+++ b/NetworkPkg/TcpDxe/SockInterface.c
@@ -941,8 +941,6 @@ SockCancel (
 {
   EFI_STATUS  Status;
 
-  Status = EFI_SUCCESS;
-
   ASSERT (SockStream == Sock->Type);
 
   Status = EfiAcquireLockOrFail (&(Sock->Lock));

--- a/NetworkPkg/TlsAuthConfigDxe/TlsAuthConfigImpl.c
+++ b/NetworkPkg/TlsAuthConfigDxe/TlsAuthConfigImpl.c
@@ -1397,8 +1397,7 @@ TlsAuthConfigAccessCallback (
   EFI_HII_POPUP_PROTOCOL        *HiiPopUp;
   EFI_HII_POPUP_SELECTION       PopUpSelect;
 
-  Status = EFI_SUCCESS;
-  File   = NULL;
+  File = NULL;
 
   if ((This == NULL) || (Value == NULL) || (ActionRequest == NULL)) {
     return EFI_INVALID_PARAMETER;

--- a/NetworkPkg/UefiPxeBcDxe/PxeBcBoot.c
+++ b/NetworkPkg/UefiPxeBcDxe/PxeBcBoot.c
@@ -610,7 +610,6 @@ PxeBcDhcp6BootInfo (
 
   PxeBc       = &Private->PxeBc;
   Mode        = PxeBc->Mode;
-  Status      = EFI_SUCCESS;
   *BufferSize = 0;
 
   //

--- a/NetworkPkg/UefiPxeBcDxe/PxeBcDhcp4.c
+++ b/NetworkPkg/UefiPxeBcDxe/PxeBcDhcp4.c
@@ -1387,9 +1387,8 @@ PxeBcDhcp4Discover (
     return Status;
   }
 
-  Mode   = Private->PxeBc.Mode;
-  Dhcp4  = Private->Dhcp4;
-  Status = EFI_SUCCESS;
+  Mode  = Private->PxeBc.Mode;
+  Dhcp4 = Private->Dhcp4;
 
   ZeroMem (&Token, sizeof (EFI_DHCP4_TRANSMIT_RECEIVE_TOKEN));
 
@@ -1668,8 +1667,6 @@ PxeBcDhcp4Dora (
   EFI_STATUS               Status;
 
   ASSERT (Dhcp4 != NULL);
-
-  Status  = EFI_SUCCESS;
   PxeMode = Private->PxeBc.Mode;
 
   //

--- a/NetworkPkg/UefiPxeBcDxe/PxeBcDhcp6.c
+++ b/NetworkPkg/UefiPxeBcDxe/PxeBcDhcp6.c
@@ -1710,7 +1710,6 @@ PxeBcRegisterIp6Address (
   EFI_IPv6_ADDRESS               *Ip6Addr;
   UINTN                          Index;
 
-  Status    = EFI_SUCCESS;
   MappedEvt = NULL;
   Ip6Addr   = NULL;
   DataSize  = sizeof (EFI_IP6_CONFIG_POLICY);
@@ -2352,7 +2351,6 @@ PxeBcDhcp6Sarr (
   UINTN                                     DataSize;
   EFI_IP6_CONFIG_DUP_ADDR_DETECT_TRANSMITS  DadXmits;
 
-  Status  = EFI_SUCCESS;
   PxeMode = Private->PxeBc.Mode;
   Ip6Cfg  = Private->Ip6Cfg;
   Timer   = NULL;

--- a/NetworkPkg/UefiPxeBcDxe/PxeBcImpl.c
+++ b/NetworkPkg/UefiPxeBcDxe/PxeBcImpl.c
@@ -435,7 +435,6 @@ EfiPxeBcDhcp (
     return EFI_INVALID_PARAMETER;
   }
 
-  Status                  = EFI_SUCCESS;
   Private                 = PXEBC_PRIVATE_DATA_FROM_PXEBC (This);
   Mode                    = Private->PxeBc.Mode;
   Mode->IcmpErrorReceived = FALSE;
@@ -2041,8 +2040,6 @@ EfiPxeBcSetStationIP (
 
   Private = PXEBC_PRIVATE_DATA_FROM_PXEBC (This);
   Mode    = Private->PxeBc.Mode;
-  Status  = EFI_SUCCESS;
-
   if (!Mode->UsingIpv6 &&
       (NewSubnetMask != NULL) &&
       !IP4_IS_VALID_NETMASK (NTOHL (NewSubnetMask->Addr[0])))
@@ -2381,7 +2378,6 @@ EfiPxeLoadFile (
   Private    = VirtualNic->Private;
   PxeBc      = &Private->PxeBc;
   UsingIpv6  = FALSE;
-  Status     = EFI_DEVICE_ERROR;
 
   //
   // Check media status before PXE start

--- a/NetworkPkg/UefiPxeBcDxe/PxeBcMtftp.c
+++ b/NetworkPkg/UefiPxeBcDxe/PxeBcMtftp.c
@@ -131,7 +131,6 @@ PxeBcMtftp6GetFileSize (
   EFI_STATUS           Status;
 
   *BufferSize               = 0;
-  Status                    = EFI_DEVICE_ERROR;
   Mtftp6                    = Private->Mtftp6;
   Packet                    = NULL;
   Option                    = NULL;
@@ -274,7 +273,6 @@ PxeBcMtftp6ReadFile (
   UINT8                WindowsizeBuf[10];
   EFI_STATUS           Status;
 
-  Status                    = EFI_DEVICE_ERROR;
   Mtftp6                    = Private->Mtftp6;
   OptCnt                    = 0;
   Config->InitialServerPort = PXEBC_BS_DOWNLOAD_PORT;
@@ -363,7 +361,6 @@ PxeBcMtftp6WriteFile (
   UINT8                OptBuf[128];
   EFI_STATUS           Status;
 
-  Status                    = EFI_DEVICE_ERROR;
   Mtftp6                    = Private->Mtftp6;
   OptCnt                    = 0;
   Config->InitialServerPort = PXEBC_BS_DOWNLOAD_PORT;
@@ -441,7 +438,6 @@ PxeBcMtftp6ReadDirectory (
   UINT8                WindowsizeBuf[10];
   EFI_STATUS           Status;
 
-  Status                    = EFI_DEVICE_ERROR;
   Mtftp6                    = Private->Mtftp6;
   OptCnt                    = 0;
   Config->InitialServerPort = PXEBC_BS_DOWNLOAD_PORT;
@@ -610,7 +606,6 @@ PxeBcMtftp4GetFileSize (
   EFI_STATUS           Status;
 
   *BufferSize               = 0;
-  Status                    = EFI_DEVICE_ERROR;
   Mtftp4                    = Private->Mtftp4;
   Packet                    = NULL;
   Option                    = NULL;
@@ -753,7 +748,6 @@ PxeBcMtftp4ReadFile (
   UINT8                WindowsizeBuf[10];
   EFI_STATUS           Status;
 
-  Status                    = EFI_DEVICE_ERROR;
   Mtftp4                    = Private->Mtftp4;
   OptCnt                    = 0;
   Config->InitialServerPort = PXEBC_BS_DOWNLOAD_PORT;
@@ -842,7 +836,6 @@ PxeBcMtftp4WriteFile (
   UINT8                OptBuf[128];
   EFI_STATUS           Status;
 
-  Status                    = EFI_DEVICE_ERROR;
   Mtftp4                    = Private->Mtftp4;
   OptCnt                    = 0;
   Config->InitialServerPort = PXEBC_BS_DOWNLOAD_PORT;
@@ -920,7 +913,6 @@ PxeBcMtftp4ReadDirectory (
   UINT8                WindowsizeBuf[10];
   EFI_STATUS           Status;
 
-  Status                    = EFI_DEVICE_ERROR;
   Mtftp4                    = Private->Mtftp4;
   OptCnt                    = 0;
   Config->InitialServerPort = PXEBC_BS_DOWNLOAD_PORT;

--- a/NetworkPkg/WifiConnectionManagerDxe/WifiConnectionMgrImpl.c
+++ b/NetworkPkg/WifiConnectionManagerDxe/WifiConnectionMgrImpl.c
@@ -267,7 +267,6 @@ WifiMgrStartScan (
 
   Nic->ScanState  = WifiMgrScanning;
   OldTpl          = gBS->RaiseTPL (TPL_CALLBACK);
-  Status          = EFI_SUCCESS;
   HiddenSSIdList  = NULL;
   HiddenSSIdCount = Nic->Private->HiddenNetworkCount;
   HiddenSSIdIndex = 0;
@@ -1399,7 +1398,6 @@ WifiMgrDisconnectToNetwork (
   }
 
   OldTpl      = gBS->RaiseTPL (TPL_CALLBACK);
-  Status      = EFI_SUCCESS;
   ConfigToken = AllocateZeroPool (sizeof (WIFI_MGR_MAC_CONFIG_TOKEN));
   if (ConfigToken == NULL) {
     gBS->RestoreTPL (OldTpl);


### PR DESCRIPTION
## Summary

This patch series cleans up redundant `EFI_STATUS` variable initializations
across 14 NetworkPkg drivers, and fixes two cases where function return
values were not checked.

## Changes

### Bug Fixes
- **DnsDxe**: Add missing NULL check and error return for `Dhcp4->Build()`
  in `GetDns4ServerFromDhcp4`. Without this check, a NULL `Token.Packet`
  could be dereferenced.
- **HttpDxe**: Add missing error check with proper resource cleanup after
  `TlsCommonTransmit()` in `HttpsReceive`. A failure was previously silently
  ignored, leaking `PacketOut` and `BufferOut`.

### Code Cleanup
The following drivers had local `Status` variables initialized to a fixed
value (`EFI_SUCCESS` or `EFI_DEVICE_ERROR`) at declaration, then
unconditionally overwritten before any use. These redundant initializations
have been removed:

- Dhcp6Dxe
- DnsDxe
- HttpBootDxe
- HttpDxe
- Ip4Dxe
- Ip6Dxe
- MnpDxe
- Mtftp4Dxe
- Mtftp6Dxe
- SnpDxe
- TcpDxe
- TlsAuthConfigDxe
- UefiPxeBcDxe
- WifiConnectionManagerDxe

## Cc
Cc: Saloni Kasbekar <saloni.kasbekar@intel.com>
Cc: Zachary Clark-williams <zachary.clark-williams@intel.com>