### PR TITLE
NetworkPkg: Fix unhandled Status and refactor answer loop

### DIFF
--- a/NetworkPkg/DnsDxe/DnsImpl.c
+++ b/NetworkPkg/DnsDxe/DnsImpl.c
@@ -1165,10 +1165,9 @@ ParseDnsResponse (
   Dns4TokenEntry = NULL;
   Dns6TokenEntry = NULL;
 
-  IpCount          = 0;
-  RRCount          = 0;
-  AnswerSectionNum = 0;
-  CNameTtl         = 0;
+  IpCount  = 0;
+  RRCount  = 0;
+  CNameTtl = 0;
 
   HostAddr4 = NULL;
   HostAddr6 = NULL;
@@ -1378,8 +1377,6 @@ ParseDnsResponse (
     }
   }
 
-  Status = EFI_NOT_FOUND;
-
   //
   // Get Answer name
   //
@@ -1388,7 +1385,11 @@ ParseDnsResponse (
   //
   // Processing AnswerSection.
   //
-  while (AnswerSectionNum < DnsHeader->AnswersNum) {
+  if (DnsHeader->AnswersNum == 0) {
+    Status = EFI_NOT_FOUND;
+  }
+
+  for (AnswerSectionNum = 0; AnswerSectionNum < DnsHeader->AnswersNum; AnswerSectionNum++) {
     //
     // Check whether the remaining packet length is available or not.
     //
@@ -1635,7 +1636,6 @@ ParseDnsResponse (
     // Find next one
     //
     AnswerName = (CHAR8 *)AnswerSection + sizeof (*AnswerSection) + AnswerSection->DataLength;
-    AnswerSectionNum++;
   }
 
   if (Instance->Service->IpVersion == IP_VERSION_4) {

--- a/NetworkPkg/Ip4Dxe/Ip4Config2Nv.c
+++ b/NetworkPkg/Ip4Dxe/Ip4Config2Nv.c
@@ -575,7 +575,7 @@ Ip4Config2ConvertIfrNvDataToConfigNvData (
                                    sizeof (EFI_IP4_CONFIG2_POLICY),
                                    &Ip4NvData->Policy
                                    );
-    return EFI_SUCCESS;
+    return Status;
   }
 
   if (IfrFormNvData->DhcpEnable == TRUE) {


### PR DESCRIPTION
## Summary

This patch series addresses two issues raised as review comments on PR #12332.

## Changes

### Bug Fix

- **Ip4Dxe**: In `Ip4Config2ConvertIfrNvDataToConfigNvData()`, when the
  policy is changed away from a static configuration (`PolicyChanged` is
  `TRUE`), the first call to `Ip4Cfg2->SetData()` was not checking its
  return value and unconditionally returned `EFI_SUCCESS`. Fixed to check
  and return `Status` on error, consistent with the second `SetData` call
  in the same function.

### Code Cleanup

- **DnsDxe**: In `ParseDnsResponse()`, the answer section loop used a
  `while` loop with a manual counter increment at the bottom. Converted to
  an equivalent `for` loop to make initialization, condition, and increment
  explicit. Also replaced the unconditional `Status = EFI_NOT_FOUND`
  pre-assignment with a conditional that only sets `Status` when the loop
  is never entered (`DnsHeader->AnswersNum == 0`), making uninitialized
  `Status` paths easier to spot.

## Ref

Raised as review comments on: #12332

## Cc
Cc: Saloni Kasbekar <saloni.kasbekar@intel.com>
Cc: Zachary Clark-williams <zachary.clark-williams@intel.com>