### PR TITLE
MdeModulePkg/PeiDxeDebugLibReportStatusCode: Fix runtime log level ha…

### DIFF
--- a/MdeModulePkg/Library/PeiDxeDebugLibReportStatusCode/DebugLib.c
+++ b/MdeModulePkg/Library/PeiDxeDebugLibReportStatusCode/DebugLib.c
@@ -589,9 +589,11 @@ DebugClearMemoryEnabled (
 }
 
 /**
-  Returns TRUE if any one of the bit is set both in ErrorLevel and PcdFixedDebugPrintErrorLevel.
+  Returns TRUE if any bit in ErrorLevel is enabled by both the runtime
+  debug level and the build-time debug mask.
 
-  This function compares the bit mask of ErrorLevel and PcdFixedDebugPrintErrorLevel.
+  This function checks ErrorLevel against GetDebugPrintErrorLevel() and
+  PcdFixedDebugPrintErrorLevel
 
   @retval  TRUE    Current ErrorLevel is supported.
   @retval  FALSE   Current ErrorLevel is not supported.
@@ -600,8 +602,18 @@ DebugClearMemoryEnabled (
 BOOLEAN
 EFIAPI
 DebugPrintLevelEnabled (
-  IN  CONST UINTN  ErrorLevel
+  IN CONST UINTN  ErrorLevel
   )
 {
-  return (BOOLEAN)((ErrorLevel & PcdGet32 (PcdFixedDebugPrintErrorLevel)) != 0);
+  UINTN  RuntimeErrorLevel;
+  UINTN  BuildTimeErrorLevel;
+
+  RuntimeErrorLevel   = GetDebugPrintErrorLevel ();
+  BuildTimeErrorLevel = PcdGet32 (PcdFixedDebugPrintErrorLevel);
+
+  //
+  // Runtime debug logs are printed only when the runtime debug level
+  // is a subset of the build-time debug level.
+  //
+  return ((ErrorLevel & RuntimeErrorLevel & BuildTimeErrorLevel) != 0);
 }


### PR DESCRIPTION
EFIDebug variable based runtime log level changes do not take effect because DebugPrintLevelEnabled() does not evaluate the runtime log level function and instead uses the PCD-based function.

Update DebugPrintLevelEnabled() to use GetDebugPrintErrorLevel(), which correctly resolves the active debug error level by checking the EFI variable and falling back to PCD when needed.

With this change, runtime updates to the EFIDebug log level take effect as expected.

Fixes: #12275

# Description

Fix runtime debug log level handling so that changes to the Runtime log level
take effect immediately. 

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested
Built and tested on internal platform by setting and clearing  EFIDebug and confirmed appropriate logs are seen.

- Set WARN logs - WARN logs are seen.

setvar EFIDebug -guid 59d1c24f-50f1-401a-b101-f33e0daed443 -bs -nv =0x80000006

- Clear WARN logs - WARN logs are not seen.

setvar EFIDebug -guid 59d1c24f-50f1-401a-b101-f33e0daed443 -bs -nv =0x80000000

## Integration Instructions
N/A

