### PR TITLE
UefiPayloadPkg: hide boot hints when timeout is zero

### DIFF
--- a/UefiPayloadPkg/Library/PlatformBootManagerLib/PlatformBootManager.c
+++ b/UefiPayloadPkg/Library/PlatformBootManagerLib/PlatformBootManager.c
@@ -355,6 +355,10 @@ PlatformBootManagerAfterConsole (
   //
   PlatformRegisterFvBootOption (&gUefiShellFileGuid, L"UEFI Shell", LOAD_OPTION_ACTIVE);
 
+  if (PcdGet16 (PcdPlatformBootTimeOut) == 0) {
+    return;
+  }
+
   if (FixedPcdGetBool (PcdBootManagerEscape)) {
     Print (
       L"\n"


### PR DESCRIPTION
When the configured boot timeout is zero, there is no countdown window for
users to act on. Hide the boot hint text in that case so the front page
does not advertise keys that cannot be used before control is handed off.