### PR TITLE
Global: Fix the issue that Depex sections exist in the INF files of UEFI_DRIVER or UEFI_APPLICATION

### DIFF
--- a/BaseTools/Source/Python/Workspace/InfBuildData.py
+++ b/BaseTools/Source/Python/Workspace/InfBuildData.py
@@ -772,6 +772,15 @@ class InfBuildData(ModuleBuildClassObject):
             return RetVal
 
         RecordList = self._RawData[MODEL_EFI_DEPEX, self._Arch]
+
+        # If the module is not a library (no LIBRARY_CLASS in the [Defines] section) and the MODULE_TYPE is
+        # SEC, SMM_CORE, DXE_CORE, PEI_CORE, UEFI_DRIVER, UEFI_APPLICATION or HOST_APPLICATION a Depex section
+        # is not permitted.
+        if len(self.LibraryClass) == 0 and len(RecordList) != 0:
+            if self.ModuleType in [SUP_MODULE_SEC, SUP_MODULE_SMM_CORE, SUP_MODULE_DXE_CORE, SUP_MODULE_PEI_CORE, SUP_MODULE_UEFI_DRIVER, \
+                SUP_MODULE_UEFI_APPLICATION, SUP_MODULE_HOST_APPLICATION]:
+                EdkLogger.warn(None, "[Depex] section is not permitted for [%s] module" % self.ModuleType, File=self.MetaFile)
+
         # PEIM and DXE drivers must have a valid [Depex] section
         if len(self.LibraryClass) == 0 and len(RecordList) == 0:
             if self.ModuleType == SUP_MODULE_DXE_DRIVER or self.ModuleType == SUP_MODULE_PEIM or self.ModuleType == SUP_MODULE_DXE_SMM_DRIVER or \

--- a/NetworkPkg/TcpDxe/TcpDxe.inf
+++ b/NetworkPkg/TcpDxe/TcpDxe.inf
@@ -88,8 +88,5 @@
   gEfiHashAlgorithmMD5Guid                      ## CONSUMES
   gEfiHashAlgorithmSha256Guid                   ## CONSUMES
 
-[Depex]
-  gEfiHash2ServiceBindingProtocolGuid
-
 [UserExtensions.TianoCore."ExtraFiles"]
   TcpDxeExtra.uni


### PR DESCRIPTION
# Description

Fixes https://github.com/tianocore/edk2/issues/12276

The INF specification said:

> If the module is not a library (no LIBRARY_CLASS in the [Defines] section) and the MODULE_TYPE is SEC, SMM_CORE, DXE_CORE, PEI_CORE, UEFI_DRIVER, UEFI_APPLICATION or HOST_APPLICATION a Depex section is not permitted. 

Thus, this series of patches does the following:
- Remove improper Depex section in UEFI_DRIVER and UEFI_APPLICATION.
- Adds a check when retrieving dependency expression in BaseTools. If the module has [Depex] section but it's not permitted by INF specification, just throw warning message t instead of break the building proccess.


- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

- github CI check is passed. 
- Build every platform, check if there is building failure. Run the following commands for instance: 
`build -a X64 -t GCC -p RedfishPkg/RedfishPkg.dsc`
`build -a X64 -t GCC -p NetworkPkg/NetworkPkg.dsc`
`build -a X64 -t GCC -p MdeModulePkg/MdeModulePkg.dsc`
`build -a X64 -t GCC -p MdePkg/MdePkg.dsc`
`build -a X64 -t GCC -p ShellPkg/ShellPkg.dsc`
`...`
- Add [Depex] in UEFI_DRIVER or UEFI_APPLICATION, building process will not be breaken in BaseTools and a warning message will be throwed when build the driver:
`[Depex] section is not permitted for UEFI_DRIVER/UEFI_APPLICATION module`

## Integration Instructions

Once the PR is merged, all UEFI drivers and uefi applications with [Depex] section will not be blocked by BaseTools when building but only warning message is throwed. If the driver is UEFI driver, remove Depex from INF file and check dependent protocol in driver binding Start() function or notify function if necessary.