### PR TITLE
MdeModulePkg/AcpiTableDxe: Free the Hob memory

### DIFF
--- a/MdeModulePkg/Universal/Acpi/AcpiTableDxe/AcpiTableProtocol.c
+++ b/MdeModulePkg/Universal/Acpi/AcpiTableDxe/AcpiTableProtocol.c
@@ -2197,6 +2197,11 @@ InstallAcpiTableFromAcpiSiliconHob (
         if (FeaturePcdGet (PcdInstallAcpiSdtProtocol)) {
           SdtNotifyAcpiList (AcpiTableInstance, Version, TableKey);
         }
+
+        //
+        // Free the memory allocated for the ACPI table during the PEI phase.
+        //
+        FreePool (SocEntryTable);
       }
     }
 
@@ -2236,6 +2241,10 @@ InstallAcpiTableFromAcpiSiliconHob (
               }
             }
 
+            //
+            // Free the memory allocated for the DSDT table during the PEI phase.
+            //
+            FreePool (NeedToInstallTable);
             DEBUG ((DEBUG_INFO, "Installed DSDT in the DXE Table list!\n"));
           }
         } else {
@@ -2280,6 +2289,10 @@ InstallAcpiTableFromAcpiSiliconHob (
               }
             }
 
+            //
+            // Free the memory allocated for the FACS table during the PEI phase.
+            //
+            FreePool (NeedToInstallTable);
             DEBUG ((DEBUG_INFO, "Installed FACS in the DXE Table list!\n"));
           }
         } else {
@@ -2290,6 +2303,11 @@ InstallAcpiTableFromAcpiSiliconHob (
       }
     }
   }
+
+  //
+  // Free the memory allocated for the XSDT table during the PEI phase.
+  //
+  FreePool (SiCommonAcpiTable);
 
   DEBUG ((DEBUG_INFO, "InstallAcpiTableFromAcpiSiliconHob - End\n"));
   return Status;


### PR DESCRIPTION

# Description
Some ACPI tables are allocated the memory and full initialized during the PEI phase. After these tables are passed to 
the DXE phase and installed in the ACPI-type memory, the original memory allocated for ACPI tables in the PEI phase 
is no longer needed and should be be freed.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested
Boots to the OS.

## Integration Instructions
None
