### PR TITLE
MdeModulePkg/NetworkCommon: Add PCD for USB network periodic timer

### DIFF
--- a/MdeModulePkg/Bus/Usb/UsbNetwork/NetworkCommon/DriverBinding.c
+++ b/MdeModulePkg/Bus/Usb/UsbNetwork/NetworkCommon/DriverBinding.c
@@ -2,6 +2,7 @@
   This file contains code for USB network binding driver
 
   Copyright (c) 2023, American Megatrends International LLC. All rights reserved.<BR>
+  Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
@@ -358,7 +359,12 @@ NetworkCommonDriverStart (
 
   ZeroMem (&NicDevice->NicInfo.Request, sizeof (EFI_USB_DEVICE_REQUEST));
 
-  Status = UsbEth->UsbEthInterrupt (UsbEth, TRUE, NETWORK_COMMON_POLLING_INTERVAL, &NicDevice->NicInfo.Request);
+  STATIC_ASSERT (
+    FixedPcdGet8 (PcdUsbNetworkPeriodicTimerInterval) >= 1,
+    "The polling interval must be between 1 and 255 (milliseconds)."
+    );
+
+  Status = UsbEth->UsbEthInterrupt (UsbEth, TRUE, (UINTN)PcdGet8 (PcdUsbNetworkPeriodicTimerInterval), &NicDevice->NicInfo.Request);
   ASSERT_EFI_ERROR (Status);
 
   Status = gBS->InstallMultipleProtocolInterfaces (

--- a/MdeModulePkg/Bus/Usb/UsbNetwork/NetworkCommon/DriverBinding.h
+++ b/MdeModulePkg/Bus/Usb/UsbNetwork/NetworkCommon/DriverBinding.h
@@ -2,6 +2,7 @@
   Header file for for USB network common driver
 
   Copyright (c) 2023, American Megatrends International LLC. All rights reserved.<BR>
+  Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
@@ -20,11 +21,10 @@
 #include <Protocol/NetworkInterfaceIdentifier.h>
 #include <Protocol/UsbEthernetProtocol.h>
 
-#define NETWORK_COMMON_DRIVER_VERSION    1
-#define NETWORK_COMMON_POLLING_INTERVAL  0x10
-#define RX_BUFFER_COUNT                  32
-#define TX_BUFFER_COUNT                  32
-#define MEMORY_REQUIRE                   0
+#define NETWORK_COMMON_DRIVER_VERSION  1
+#define RX_BUFFER_COUNT                32
+#define TX_BUFFER_COUNT                32
+#define MEMORY_REQUIRE                 0
 
 #define UNDI_DEV_SIGNATURE  SIGNATURE_32('u','n','d','i')
 #define UNDI_DEV_FROM_THIS(a)  CR(a, NIC_DEVICE, NiiProtocol, UNDI_DEV_SIGNATURE)

--- a/MdeModulePkg/Bus/Usb/UsbNetwork/NetworkCommon/NetworkCommon.inf
+++ b/MdeModulePkg/Bus/Usb/UsbNetwork/NetworkCommon/NetworkCommon.inf
@@ -2,6 +2,7 @@
 #   This is Usb Network Common driver for DXE phase.
 #
 # Copyright (c) 2023, American Megatrends International LLC. All rights reserved.<BR>
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.<BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 ##
 
@@ -43,6 +44,7 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdEnableUsbNetworkRateLimiting
   gEfiMdeModulePkgTokenSpaceGuid.PcdUsbNetworkRateLimitingCredit
   gEfiMdeModulePkgTokenSpaceGuid.PcdUsbNetworkRateLimitingFactor
+  gEfiMdeModulePkgTokenSpaceGuid.PcdUsbNetworkPeriodicTimerInterval
 
 [Depex]
   TRUE

--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -9,7 +9,7 @@
 # (C) Copyright 2016 - 2019 Hewlett Packard Enterprise Development LP<BR>
 # Copyright (c) 2017, AMD Incorporated. All rights reserved.<BR>
 # Copyright (c) Microsoft Corporation.<BR>
-# Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.<BR>
+# Copyright (C) 2024 - 2026 Advanced Micro Devices, Inc. All rights reserved.<BR>
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries. All rights reserved.<BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -1218,6 +1218,14 @@
   #   FALSE - Efi boot options will not be retried.
   # @Prompt Enable infinite retries during BDS.
   gEfiMdeModulePkgTokenSpaceGuid.PcdSupportInfiniteBootRetries|FALSE|BOOLEAN|0x40000152
+
+  ## The value of USB network periodic timer for asynchronous transfers.
+  #  The polling interval must be between 1 and 255 (milliseconds).
+  #  A value of 0 is invalid and will cause EFI_INVALID_PARAMETER to be returned.
+  #  Default value is 16ms, to be consistent with the previous hardcoded value.
+  # @Prompt USB Network periodic timer interval for asynchronous transfers in ms.
+  # @ValidRange 0x80000001 | 1 - 255
+  gEfiMdeModulePkgTokenSpaceGuid.PcdUsbNetworkPeriodicTimerInterval|16|UINT8|0x30001063
 
 [PcdsFixedAtBuild, PcdsPatchableInModule]
   ## Dynamic type PCD can be registered callback function for Pcd setting action.


### PR DESCRIPTION
Replace the hardcoded NETWORK_COMMON_POLLING_INTERVAL (0x10 = 16ms) with a new PCD PcdUsbNetworkPeriodicalTimer, allowing platforms to configure the asynchronous transfer interval for USB network devices.

The default value of 16ms preserves existing behaviour.

Per UEFI Specification Section 17.1.1.5,
EFI_USB_IO_PROTOCOL.UsbAsyncInterruptTransfer(), the PollingInterval parameter must be between 1 and 255 milliseconds; a value of 0 returns EFI_INVALID_PARAMETER. The PCD is declared with a @ValidRange of 1-255 and an ASSERT guards against a zero value at runtime.

# Description

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Tested on AMD platforms

## Integration Instructions

N/A