### PR TITLE
.azurepipelines: Add CLANGPDB Windows CI

### DIFF
--- a/.azurepipelines/Windows-CLANGPDB.yml
+++ b/.azurepipelines/Windows-CLANGPDB.yml
@@ -1,0 +1,35 @@
+## @file
+# Azure Pipeline build file for a build using Windows and CLANGPDB
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+trigger: none
+
+schedules:
+- cron: "0 7 * * *"
+  displayName: Daily Build
+  branches:
+    include:
+    - master
+    - stable/*
+  always: true
+
+pr:
+- master
+- stable/*
+
+variables:
+  - template: templates/defaults.yml
+
+jobs:
+- template: templates/pr-gate-build-job.yml
+  parameters:
+    tool_chain_tag: 'CLANGPDB'
+    vm_image: ${{ variables.default_windows_vm }}
+    arch_list: "X64,AARCH64"
+    usePythonVersion: ${{ variables.default_python_version }}
+    extra_install_step:
+    - powershell: choco install opencppcoverage; Write-Host "##vso[task.prependpath]C:\Program Files\OpenCppCoverage"
+      displayName: Install Code Coverage Tool
+      condition: and(gt(variables.pkg_count, 0), succeeded())


### PR DESCRIPTION
# Description

Currently, CLANGPDB CI is only tested on Ubuntu. In addition, AARCH64 is only tested on Ubuntu for any CI. While unfortunate to add extra CI, this ensures that CLANGPDB for X64 and AARCH64 builds on Windows, which is currently missing coverage.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Testing with running the pipeline in a fork.

## Integration Instructions

N/A.
