### PR TITLE
Enable cast-function-type-mismatch warning on CLANG toolchains

### DIFF
--- a/BaseTools/Conf/tools_def.template
+++ b/BaseTools/Conf/tools_def.template
@@ -1337,7 +1337,7 @@ DEFINE CLANGPDB_IA32_TARGET          = -target i686-pc-windows-msvc
 DEFINE CLANGPDB_X64_TARGET           = -target x86_64-pc-windows-msvc
 DEFINE CLANGPDB_AARCH64_TARGET       = -target aarch64-unknown-windows-msvc
 
-DEFINE CLANGPDB_WARNING_OVERRIDES    = -Wno-parentheses-equality -Wno-tautological-compare -Wno-tautological-constant-out-of-range-compare -Wno-empty-body -Wno-varargs -Wno-unknown-warning-option -Wno-unaligned-access -Wno-microsoft-enum-forward-reference
+DEFINE CLANGPDB_WARNING_OVERRIDES    = -Wno-parentheses-equality -Wno-tautological-compare -Wno-tautological-constant-out-of-range-compare -Wno-empty-body -Wno-varargs -Wno-unknown-warning-option -Wno-unaligned-access -Wno-microsoft-enum-forward-reference -Wcast-function-type-mismatch
 DEFINE CLANGPDB_ALL_CC_FLAGS         = DEF(GCC_ALL_CC_FLAGS) DEF(CLANGPDB_WARNING_OVERRIDES) -fno-stack-protector -funsigned-char -ftrap-function=undefined_behavior_has_been_optimized_away_by_clang -Wno-address -Wno-shift-negative-value -Wno-unknown-pragmas -Wno-incompatible-library-redeclaration -Wno-null-dereference -mno-implicit-float -mms-bitfields -mno-stack-arg-probe -fno-omit-frame-pointer -D __GNUC__=4 -D __GNUC_MINOR__=2 -D __GNUC_PATCHLEVEL__=1 -D __MINGW32__=1
 
 ###########################
@@ -1494,7 +1494,7 @@ DEFINE CLANGDWARF_X64_DLINK2_FLAGS        = -Wl,--defsym=PECOFF_HEADER_SIZE=0x22
 DEFINE CLANGDWARF_IA32_TARGET             = -target i686-pc-linux-gnu
 DEFINE CLANGDWARF_X64_TARGET              = -target x86_64-pc-linux-gnu
 
-DEFINE CLANGDWARF_WARNING_OVERRIDES    = -Wno-parentheses-equality -Wno-empty-body -Wno-varargs -Wno-unknown-warning-option -Wno-unaligned-access
+DEFINE CLANGDWARF_WARNING_OVERRIDES    = -Wno-parentheses-equality -Wno-empty-body -Wno-varargs -Wno-unknown-warning-option -Wno-unaligned-access -Wcast-function-type-mismatch
 DEFINE CLANGDWARF_ALL_CC_FLAGS         = DEF(GCC_ALL_CC_FLAGS) DEF(CLANGDWARF_WARNING_OVERRIDES) -fno-stack-protector -mms-bitfields -Wno-address -Wno-shift-negative-value -Wno-unknown-pragmas -Wno-incompatible-library-redeclaration -fno-asynchronous-unwind-tables -msoft-float -mno-implicit-float  -ftrap-function=undefined_behavior_has_been_optimized_away_by_clang -funsigned-char -fno-ms-extensions -Wno-null-dereference
 
 ###########################

--- a/CryptoPkg/Library/BaseCryptLib/Pem/CryptPem.c
+++ b/CryptoPkg/Library/BaseCryptLib/Pem/CryptPem.c
@@ -20,22 +20,23 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
   @retval  The number of characters in the passphrase or 0 if an error occurred.
 
 **/
-INTN
+STATIC
+int
 PasswordCallback (
   OUT  CHAR8  *Buf,
-  IN   INTN   Size,
-  IN   INTN   Flag,
+  IN   int    Size,
+  IN   int    Flag,
   IN   VOID   *Key
   )
 {
-  INTN  KeyLength;
+  int  KeyLength;
 
   ZeroMem ((VOID *)Buf, (UINTN)Size);
   if (Key != NULL) {
     //
     // Duplicate key phrase directly.
     //
-    KeyLength = (INTN)AsciiStrLen ((CHAR8 *)Key);
+    KeyLength = (int)AsciiStrLen ((CHAR8 *)Key);
     KeyLength = (KeyLength > Size) ? Size : KeyLength;
     CopyMem (Buf, Key, (UINTN)KeyLength);
     return KeyLength;

--- a/MdeModulePkg/Core/Dxe/DxeMain.h
+++ b/MdeModulePkg/Core/Dxe/DxeMain.h
@@ -2044,94 +2044,289 @@ CoreDisplayDiscoveredNotDispatched (
   );
 
 /**
-  Place holder function until all the Boot Services and Runtime Services are
-  available.
+  Place holder function until all the Boot Services and Runtime Services are available.
 
-  @param  Arg1                   Undefined
+  @param  Count                  Undefined
 
   @return EFI_NOT_AVAILABLE_YET
 
 **/
 EFI_STATUS
 EFIAPI
-CoreEfiNotAvailableYetArg1 (
-  UINTN  Arg1
+CoreEfiNotAvailableYetGetNextMonotonicCount (
+  OUT UINT64  *Count
   );
 
 /**
   Place holder function until all the Boot Services and Runtime Services are available.
 
-  @param  Arg1                   Undefined
-  @param  Arg2                   Undefined
+  @param  Data                   Undefined
+  @param  DataSize               Undefined
+  @param  Crc32                  Undefined
 
   @return EFI_NOT_AVAILABLE_YET
 
 **/
 EFI_STATUS
 EFIAPI
-CoreEfiNotAvailableYetArg2 (
-  UINTN  Arg1,
-  UINTN  Arg2
+CoreEfiNotAvailableYetCalculateCrc32 (
+  IN  VOID    *Data,
+  IN  UINTN   DataSize,
+  OUT UINT32  *Crc32
   );
 
 /**
   Place holder function until all the Boot Services and Runtime Services are available.
 
-  @param  Arg1                   Undefined
-  @param  Arg2                   Undefined
-  @param  Arg3                   Undefined
+  @param  Time                   Undefined
+  @param  Capabilities           Undefined
 
   @return EFI_NOT_AVAILABLE_YET
 
 **/
 EFI_STATUS
 EFIAPI
-CoreEfiNotAvailableYetArg3 (
-  UINTN  Arg1,
-  UINTN  Arg2,
-  UINTN  Arg3
+CoreEfiNotAvailableYetGetTime (
+  OUT  EFI_TIME               *Time,
+  OUT  EFI_TIME_CAPABILITIES  *Capabilities OPTIONAL
   );
 
 /**
   Place holder function until all the Boot Services and Runtime Services are available.
 
-  @param  Arg1                   Undefined
-  @param  Arg2                   Undefined
-  @param  Arg3                   Undefined
-  @param  Arg4                   Undefined
+  @param  Time                   Undefined
 
   @return EFI_NOT_AVAILABLE_YET
 
 **/
 EFI_STATUS
 EFIAPI
-CoreEfiNotAvailableYetArg4 (
-  UINTN  Arg1,
-  UINTN  Arg2,
-  UINTN  Arg3,
-  UINTN  Arg4
+CoreEfiNotAvailableYetSetTime (
+  IN  EFI_TIME  *Time
   );
 
 /**
   Place holder function until all the Boot Services and Runtime Services are available.
 
-  @param  Arg1                   Undefined
-  @param  Arg2                   Undefined
-  @param  Arg3                   Undefined
-  @param  Arg4                   Undefined
-  @param  Arg5                   Undefined
+  @param  Enabled                Undefined
+  @param  Pending                Undefined
+  @param  Time                   Undefined
 
   @return EFI_NOT_AVAILABLE_YET
 
 **/
 EFI_STATUS
 EFIAPI
-CoreEfiNotAvailableYetArg5 (
-  UINTN  Arg1,
-  UINTN  Arg2,
-  UINTN  Arg3,
-  UINTN  Arg4,
-  UINTN  Arg5
+CoreEfiNotAvailableYetGetWakeupTime (
+  OUT BOOLEAN   *Enabled,
+  OUT BOOLEAN   *Pending,
+  OUT EFI_TIME  *Time
+  );
+
+/**
+  Place holder function until all the Boot Services and Runtime Services are available.
+
+  @param  Enable                 Undefined
+  @param  Time                   Undefined
+
+  @return EFI_NOT_AVAILABLE_YET
+
+**/
+EFI_STATUS
+EFIAPI
+CoreEfiNotAvailableYetSetWakeupTime (
+  IN  BOOLEAN   Enable,
+  IN  EFI_TIME  *Time   OPTIONAL
+  );
+
+/**
+  Place holder function until all the Boot Services and Runtime Services are available.
+
+  @param  MemoryMapSize          Undefined
+  @param  DescriptorSize         Undefined
+  @param  DescriptorVersion      Undefined
+  @param  VirtualMap             Undefined
+
+  @return EFI_NOT_AVAILABLE_YET
+
+**/
+EFI_STATUS
+EFIAPI
+CoreEfiNotAvailableYetSetVirtualAddressMap (
+  IN  UINTN                  MemoryMapSize,
+  IN  UINTN                  DescriptorSize,
+  IN  UINT32                 DescriptorVersion,
+  IN  EFI_MEMORY_DESCRIPTOR  *VirtualMap
+  );
+
+/**
+  Place holder function until all the Boot Services and Runtime Services are available.
+
+  @param  DebugDisposition       Undefined
+  @param  Address                Undefined
+
+  @return EFI_NOT_AVAILABLE_YET
+
+**/
+EFI_STATUS
+EFIAPI
+CoreEfiNotAvailableYetConvertPointer (
+  IN     UINTN  DebugDisposition,
+  IN OUT VOID   **Address
+  );
+
+/**
+  Place holder function until all the Boot Services and Runtime Services are available.
+
+  @param  VariableName           Undefined
+  @param  VendorGuid             Undefined
+  @param  Attributes             Undefined
+  @param  DataSize               Undefined
+  @param  Data                   Undefined
+
+  @return EFI_NOT_AVAILABLE_YET
+
+**/
+EFI_STATUS
+EFIAPI
+CoreEfiNotAvailableYetGetVariable (
+  IN     CHAR16    *VariableName,
+  IN     EFI_GUID  *VendorGuid,
+  OUT    UINT32    *Attributes     OPTIONAL,
+  IN OUT UINTN     *DataSize,
+  OUT    VOID      *Data           OPTIONAL
+  );
+
+/**
+  Place holder function until all the Boot Services and Runtime Services are available.
+
+  @param  VariableNameSize       Undefined
+  @param  VariableName           Undefined
+  @param  VendorGuid             Undefined
+
+  @return EFI_NOT_AVAILABLE_YET
+
+**/
+EFI_STATUS
+EFIAPI
+CoreEfiNotAvailableYetGetNextVariableName (
+  IN OUT UINTN     *VariableNameSize,
+  IN OUT CHAR16    *VariableName,
+  IN OUT EFI_GUID  *VendorGuid
+  );
+
+/**
+  Place holder function until all the Boot Services and Runtime Services are available.
+
+  @param  VariableName           Undefined
+  @param  VendorGuid             Undefined
+  @param  Attributes             Undefined
+  @param  DataSize               Undefined
+  @param  Data                   Undefined
+
+  @return EFI_NOT_AVAILABLE_YET
+
+**/
+EFI_STATUS
+EFIAPI
+CoreEfiNotAvailableYetSetVariable (
+  IN  CHAR16    *VariableName,
+  IN  EFI_GUID  *VendorGuid,
+  IN  UINT32    Attributes,
+  IN  UINTN     DataSize,
+  IN  VOID      *Data
+  );
+
+/**
+  Place holder function until all the Boot Services and Runtime Services are available.
+
+  @param  HighCount              Undefined
+
+  @return EFI_NOT_AVAILABLE_YET
+
+**/
+EFI_STATUS
+EFIAPI
+CoreEfiNotAvailableYetGetNextHighMonotonicCount (
+  OUT UINT32  *HighCount
+  );
+
+/**
+  Place holder function until all the Boot Services and Runtime Services are available.
+
+  @param  ResetType              Undefined
+  @param  ResetStatus            Undefined
+  @param  DataSize               Undefined
+  @param  ResetData              Undefined
+
+  @return EFI_NOT_AVAILABLE_YET
+
+**/
+VOID
+EFIAPI
+CoreEfiNotAvailableYetResetSystem (
+  IN EFI_RESET_TYPE  ResetType,
+  IN EFI_STATUS      ResetStatus,
+  IN UINTN           DataSize,
+  IN VOID            *ResetData OPTIONAL
+  );
+
+/**
+  Place holder function until all the Boot Services and Runtime Services are available.
+
+  @param  CapsuleHeaderArray     Undefined
+  @param  CapsuleCount           Undefined
+  @param  ScatterGatherList      Undefined
+
+  @return EFI_NOT_AVAILABLE_YET
+
+**/
+EFI_STATUS
+EFIAPI
+CoreEfiNotAvailableYetUpdateCapsule (
+  IN EFI_CAPSULE_HEADER    **CapsuleHeaderArray,
+  IN UINTN                 CapsuleCount,
+  IN EFI_PHYSICAL_ADDRESS  ScatterGatherList   OPTIONAL
+  );
+
+/**
+  Place holder function until all the Boot Services and Runtime Services are available.
+
+  @param  CapsuleHeaderArray     Undefined
+  @param  CapsuleCount           Undefined
+  @param  MaximumCapsuleSize     Undefined
+  @param  ResetType              Undefined
+
+  @return EFI_NOT_AVAILABLE_YET
+
+**/
+EFI_STATUS
+EFIAPI
+CoreEfiNotAvailableYetQueryCapsuleCapabilities (
+  IN  EFI_CAPSULE_HEADER  **CapsuleHeaderArray,
+  IN  UINTN               CapsuleCount,
+  OUT UINT64              *MaximumCapsuleSize,
+  OUT EFI_RESET_TYPE      *ResetType
+  );
+
+/**
+  Place holder function until all the Boot Services and Runtime Services are available.
+
+  @param  Attributes                        Undefined
+  @param  MaximumVariableStorageSize        Undefined
+  @param  RemainingVariableStorageSize      Undefined
+  @param  MaximumVariableSize               Undefined
+
+  @return EFI_NOT_AVAILABLE_YET
+
+**/
+EFI_STATUS
+EFIAPI
+CoreEfiNotAvailableYetQueryVariableInfo (
+  IN  UINT32  Attributes,
+  OUT UINT64  *MaximumVariableStorageSize,
+  OUT UINT64  *RemainingVariableStorageSize,
+  OUT UINT64  *MaximumVariableSize
   );
 
 /**

--- a/MdeModulePkg/Core/Dxe/DxeMain/DxeMain.c
+++ b/MdeModulePkg/Core/Dxe/DxeMain/DxeMain.c
@@ -35,6 +35,69 @@ EFI_SMM_BASE2_PROTOCOL  *gSmmBase2 = NULL;
 EFI_GUID                   *gDxeCoreFileName;
 EFI_LOADED_IMAGE_PROTOCOL  *gDxeCoreLoadedImage;
 
+/**
+  Copies a source buffer to a destination buffer, and returns the destination buffer.
+
+  This function copies Length bytes from SourceBuffer to DestinationBuffer, and returns
+  DestinationBuffer.  The implementation must be reentrant, and it must handle the case
+  where SourceBuffer overlaps DestinationBuffer.
+
+  If Length is greater than (MAX_ADDRESS - DestinationBuffer + 1), then ASSERT().
+  If Length is greater than (MAX_ADDRESS - SourceBuffer + 1), then ASSERT().
+
+  @param  DestinationBuffer   The pointer to the destination buffer of the memory copy.
+  @param  SourceBuffer        The pointer to the source buffer of the memory copy.
+  @param  Length              The number of bytes to copy from SourceBuffer to DestinationBuffer.
+
+  @return None.
+
+**/
+STATIC
+VOID
+EFIAPI
+EfiCopyMem (
+  IN VOID   *DestinationBuffer,
+  IN VOID   *SourceBuffer,
+  IN UINTN  Length
+  )
+{
+  CopyMem (
+    DestinationBuffer,
+    SourceBuffer,
+    Length
+    );
+}
+
+/**
+  Fills a target buffer with a byte value, and returns the target buffer.
+
+  This function fills Length bytes of Buffer with Value.
+
+  If Length is greater than (MAX_ADDRESS - Buffer + 1), then ASSERT().
+
+  @param  Buffer    The memory to set.
+  @param  Length    The number of bytes to set.
+  @param  Value     The value with which to fill Length bytes of Buffer.
+
+  @return None.
+
+**/
+STATIC
+VOID
+EFIAPI
+EfiSetMem (
+  IN VOID   *Buffer,
+  IN UINTN  Length,
+  IN UINT8  Value
+  )
+{
+  SetMem (
+    Buffer,
+    Length,
+    Value
+    );
+}
+
 //
 // DXE Core Module Variables
 //
@@ -87,8 +150,8 @@ EFI_BOOT_SERVICES  mBootServices = {
   (EFI_INSTALL_MULTIPLE_PROTOCOL_INTERFACES)CoreInstallMultipleProtocolInterfaces,        // InstallMultipleProtocolInterfaces
   (EFI_UNINSTALL_MULTIPLE_PROTOCOL_INTERFACES)CoreUninstallMultipleProtocolInterfaces,    // UninstallMultipleProtocolInterfaces
   (EFI_CALCULATE_CRC32)CoreEfiNotAvailableYetArg3,                                        // CalculateCrc32
-  (EFI_COPY_MEM)CopyMem,                                                                  // CopyMem
-  (EFI_SET_MEM)SetMem,                                                                    // SetMem
+  (EFI_COPY_MEM)EfiCopyMem,                                                               // CopyMem
+  (EFI_SET_MEM)EfiSetMem,                                                                 // SetMem
   (EFI_CREATE_EVENT_EX)CoreCreateEventEx                                                  // CreateEventEx
 };
 

--- a/MdeModulePkg/Core/Dxe/DxeMain/DxeMain.c
+++ b/MdeModulePkg/Core/Dxe/DxeMain/DxeMain.c
@@ -136,7 +136,7 @@ EFI_BOOT_SERVICES  mBootServices = {
   (EFI_EXIT)CoreExit,                                                                     // Exit
   (EFI_IMAGE_UNLOAD)CoreUnloadImage,                                                      // UnloadImage
   (EFI_EXIT_BOOT_SERVICES)CoreExitBootServices,                                           // ExitBootServices
-  (EFI_GET_NEXT_MONOTONIC_COUNT)CoreEfiNotAvailableYetArg1,                               // GetNextMonotonicCount
+  (EFI_GET_NEXT_MONOTONIC_COUNT)CoreEfiNotAvailableYetGetNextMonotonicCount,              // GetNextMonotonicCount
   (EFI_STALL)CoreStall,                                                                   // Stall
   (EFI_SET_WATCHDOG_TIMER)CoreSetWatchdogTimer,                                           // SetWatchdogTimer
   (EFI_CONNECT_CONTROLLER)CoreConnectController,                                          // ConnectController
@@ -149,7 +149,7 @@ EFI_BOOT_SERVICES  mBootServices = {
   (EFI_LOCATE_PROTOCOL)CoreLocateProtocol,                                                // LocateProtocol
   (EFI_INSTALL_MULTIPLE_PROTOCOL_INTERFACES)CoreInstallMultipleProtocolInterfaces,        // InstallMultipleProtocolInterfaces
   (EFI_UNINSTALL_MULTIPLE_PROTOCOL_INTERFACES)CoreUninstallMultipleProtocolInterfaces,    // UninstallMultipleProtocolInterfaces
-  (EFI_CALCULATE_CRC32)CoreEfiNotAvailableYetArg3,                                        // CalculateCrc32
+  (EFI_CALCULATE_CRC32)CoreEfiNotAvailableYetCalculateCrc32,                              // CalculateCrc32
   (EFI_COPY_MEM)EfiCopyMem,                                                               // CopyMem
   (EFI_SET_MEM)EfiSetMem,                                                                 // SetMem
   (EFI_CREATE_EVENT_EX)CoreCreateEventEx                                                  // CreateEventEx
@@ -213,20 +213,20 @@ EFI_RUNTIME_SERVICES  mEfiRuntimeServicesTableTemplate = {
     0,                                                            // CRC32
     0                                                             // Reserved
   },
-  (EFI_GET_TIME)CoreEfiNotAvailableYetArg2,                       // GetTime
-  (EFI_SET_TIME)CoreEfiNotAvailableYetArg1,                       // SetTime
-  (EFI_GET_WAKEUP_TIME)CoreEfiNotAvailableYetArg3,                // GetWakeupTime
-  (EFI_SET_WAKEUP_TIME)CoreEfiNotAvailableYetArg2,                // SetWakeupTime
-  (EFI_SET_VIRTUAL_ADDRESS_MAP)CoreEfiNotAvailableYetArg4,        // SetVirtualAddressMap
-  (EFI_CONVERT_POINTER)CoreEfiNotAvailableYetArg2,                // ConvertPointer
-  (EFI_GET_VARIABLE)CoreEfiNotAvailableYetArg5,                   // GetVariable
-  (EFI_GET_NEXT_VARIABLE_NAME)CoreEfiNotAvailableYetArg3,         // GetNextVariableName
-  (EFI_SET_VARIABLE)CoreEfiNotAvailableYetArg5,                   // SetVariable
-  (EFI_GET_NEXT_HIGH_MONO_COUNT)CoreEfiNotAvailableYetArg1,       // GetNextHighMonotonicCount
-  (EFI_RESET_SYSTEM)CoreEfiNotAvailableYetArg4,                   // ResetSystem
-  (EFI_UPDATE_CAPSULE)CoreEfiNotAvailableYetArg3,                 // UpdateCapsule
-  (EFI_QUERY_CAPSULE_CAPABILITIES)CoreEfiNotAvailableYetArg4,     // QueryCapsuleCapabilities
-  (EFI_QUERY_VARIABLE_INFO)CoreEfiNotAvailableYetArg4             // QueryVariableInfo
+  (EFI_GET_TIME)CoreEfiNotAvailableYetGetTime,                                    // GetTime
+  (EFI_SET_TIME)CoreEfiNotAvailableYetSetTime,                                    // SetTime
+  (EFI_GET_WAKEUP_TIME)CoreEfiNotAvailableYetGetWakeupTime,                       // GetWakeupTime
+  (EFI_SET_WAKEUP_TIME)CoreEfiNotAvailableYetSetWakeupTime,                       // SetWakeupTime
+  (EFI_SET_VIRTUAL_ADDRESS_MAP)CoreEfiNotAvailableYetSetVirtualAddressMap,        // SetVirtualAddressMap
+  (EFI_CONVERT_POINTER)CoreEfiNotAvailableYetConvertPointer,                      // ConvertPointer
+  (EFI_GET_VARIABLE)CoreEfiNotAvailableYetGetVariable,                            // GetVariable
+  (EFI_GET_NEXT_VARIABLE_NAME)CoreEfiNotAvailableYetGetNextVariableName,          // GetNextVariableName
+  (EFI_SET_VARIABLE)CoreEfiNotAvailableYetSetVariable,                            // SetVariable
+  (EFI_GET_NEXT_HIGH_MONO_COUNT)CoreEfiNotAvailableYetGetNextHighMonotonicCount,  // GetNextHighMonotonicCount
+  (EFI_RESET_SYSTEM)CoreEfiNotAvailableYetResetSystem,                            // ResetSystem
+  (EFI_UPDATE_CAPSULE)CoreEfiNotAvailableYetUpdateCapsule,                        // UpdateCapsule
+  (EFI_QUERY_CAPSULE_CAPABILITIES)CoreEfiNotAvailableYetQueryCapsuleCapabilities, // QueryCapsuleCapabilities
+  (EFI_QUERY_VARIABLE_INFO)CoreEfiNotAvailableYetQueryVariableInfo                // QueryVariableInfo
 };
 
 EFI_RUNTIME_ARCH_PROTOCOL  gRuntimeTemplate = {
@@ -666,15 +666,15 @@ DxeMain (
   Place holder function until all the Boot Services and Runtime Services are
   available.
 
-  @param  Arg1                   Undefined
+  @param  Count                  Undefined
 
   @return EFI_NOT_AVAILABLE_YET
 
 **/
 EFI_STATUS
 EFIAPI
-CoreEfiNotAvailableYetArg1 (
-  UINTN  Arg1
+CoreEfiNotAvailableYetGetNextMonotonicCount (
+  OUT UINT64  *Count
   )
 {
   //
@@ -689,17 +689,19 @@ CoreEfiNotAvailableYetArg1 (
 /**
   Place holder function until all the Boot Services and Runtime Services are available.
 
-  @param  Arg1                   Undefined
-  @param  Arg2                   Undefined
+  @param  Data                   Undefined
+  @param  DataSize               Undefined
+  @param  Crc32                  Undefined
 
   @return EFI_NOT_AVAILABLE_YET
 
 **/
 EFI_STATUS
 EFIAPI
-CoreEfiNotAvailableYetArg2 (
-  UINTN  Arg1,
-  UINTN  Arg2
+CoreEfiNotAvailableYetCalculateCrc32 (
+  IN  VOID    *Data,
+  IN  UINTN   DataSize,
+  OUT UINT32  *Crc32
   )
 {
   //
@@ -714,19 +716,17 @@ CoreEfiNotAvailableYetArg2 (
 /**
   Place holder function until all the Boot Services and Runtime Services are available.
 
-  @param  Arg1                   Undefined
-  @param  Arg2                   Undefined
-  @param  Arg3                   Undefined
+  @param  Time                   Undefined
+  @param  Capabilities           Undefined
 
   @return EFI_NOT_AVAILABLE_YET
 
 **/
 EFI_STATUS
 EFIAPI
-CoreEfiNotAvailableYetArg3 (
-  UINTN  Arg1,
-  UINTN  Arg2,
-  UINTN  Arg3
+CoreEfiNotAvailableYetGetTime (
+  OUT  EFI_TIME               *Time,
+  OUT  EFI_TIME_CAPABILITIES  *Capabilities OPTIONAL
   )
 {
   //
@@ -741,21 +741,15 @@ CoreEfiNotAvailableYetArg3 (
 /**
   Place holder function until all the Boot Services and Runtime Services are available.
 
-  @param  Arg1                   Undefined
-  @param  Arg2                   Undefined
-  @param  Arg3                   Undefined
-  @param  Arg4                   Undefined
+  @param  Time                   Undefined
 
   @return EFI_NOT_AVAILABLE_YET
 
 **/
 EFI_STATUS
 EFIAPI
-CoreEfiNotAvailableYetArg4 (
-  UINTN  Arg1,
-  UINTN  Arg2,
-  UINTN  Arg3,
-  UINTN  Arg4
+CoreEfiNotAvailableYetSetTime (
+  IN  EFI_TIME  *Time
   )
 {
   //
@@ -770,23 +764,322 @@ CoreEfiNotAvailableYetArg4 (
 /**
   Place holder function until all the Boot Services and Runtime Services are available.
 
-  @param  Arg1                   Undefined
-  @param  Arg2                   Undefined
-  @param  Arg3                   Undefined
-  @param  Arg4                   Undefined
-  @param  Arg5                   Undefined
+  @param  Enabled                Undefined
+  @param  Pending                Undefined
+  @param  Time                   Undefined
 
   @return EFI_NOT_AVAILABLE_YET
 
 **/
 EFI_STATUS
 EFIAPI
-CoreEfiNotAvailableYetArg5 (
-  UINTN  Arg1,
-  UINTN  Arg2,
-  UINTN  Arg3,
-  UINTN  Arg4,
-  UINTN  Arg5
+CoreEfiNotAvailableYetGetWakeupTime (
+  OUT BOOLEAN   *Enabled,
+  OUT BOOLEAN   *Pending,
+  OUT EFI_TIME  *Time
+  )
+{
+  //
+  // This function should never be executed.  If it does, then the architectural protocols
+  // have not been designed correctly.  The CpuBreakpoint () is commented out for now until the
+  // DXE Core and all the Architectural Protocols are complete.
+  //
+
+  return EFI_NOT_AVAILABLE_YET;
+}
+
+/**
+  Place holder function until all the Boot Services and Runtime Services are available.
+
+  @param  Enable                 Undefined
+  @param  Time                   Undefined
+
+  @return EFI_NOT_AVAILABLE_YET
+
+**/
+EFI_STATUS
+EFIAPI
+CoreEfiNotAvailableYetSetWakeupTime (
+  IN  BOOLEAN   Enable,
+  IN  EFI_TIME  *Time   OPTIONAL
+  )
+{
+  //
+  // This function should never be executed.  If it does, then the architectural protocols
+  // have not been designed correctly.  The CpuBreakpoint () is commented out for now until the
+  // DXE Core and all the Architectural Protocols are complete.
+  //
+
+  return EFI_NOT_AVAILABLE_YET;
+}
+
+/**
+  Place holder function until all the Boot Services and Runtime Services are available.
+
+  @param  MemoryMapSize          Undefined
+  @param  DescriptorSize         Undefined
+  @param  DescriptorVersion      Undefined
+  @param  VirtualMap             Undefined
+
+  @return EFI_NOT_AVAILABLE_YET
+
+**/
+EFI_STATUS
+EFIAPI
+CoreEfiNotAvailableYetSetVirtualAddressMap (
+  IN  UINTN                  MemoryMapSize,
+  IN  UINTN                  DescriptorSize,
+  IN  UINT32                 DescriptorVersion,
+  IN  EFI_MEMORY_DESCRIPTOR  *VirtualMap
+  )
+{
+  //
+  // This function should never be executed.  If it does, then the architectural protocols
+  // have not been designed correctly.  The CpuBreakpoint () is commented out for now until the
+  // DXE Core and all the Architectural Protocols are complete.
+  //
+
+  return EFI_NOT_AVAILABLE_YET;
+}
+
+/**
+  Place holder function until all the Boot Services and Runtime Services are available.
+
+  @param  DebugDisposition       Undefined
+  @param  Address                Undefined
+
+  @return EFI_NOT_AVAILABLE_YET
+
+**/
+EFI_STATUS
+EFIAPI
+CoreEfiNotAvailableYetConvertPointer (
+  IN     UINTN  DebugDisposition,
+  IN OUT VOID   **Address
+  )
+{
+  //
+  // This function should never be executed.  If it does, then the architectural protocols
+  // have not been designed correctly.  The CpuBreakpoint () is commented out for now until the
+  // DXE Core and all the Architectural Protocols are complete.
+  //
+
+  return EFI_NOT_AVAILABLE_YET;
+}
+
+/**
+  Place holder function until all the Boot Services and Runtime Services are available.
+
+  @param  VariableName           Undefined
+  @param  VendorGuid             Undefined
+  @param  Attributes             Undefined
+  @param  DataSize               Undefined
+  @param  Data                   Undefined
+
+  @return EFI_NOT_AVAILABLE_YET
+
+**/
+EFI_STATUS
+EFIAPI
+CoreEfiNotAvailableYetGetVariable (
+  IN     CHAR16    *VariableName,
+  IN     EFI_GUID  *VendorGuid,
+  OUT    UINT32    *Attributes     OPTIONAL,
+  IN OUT UINTN     *DataSize,
+  OUT    VOID      *Data           OPTIONAL
+  )
+{
+  //
+  // This function should never be executed.  If it does, then the architectural protocols
+  // have not been designed correctly.  The CpuBreakpoint () is commented out for now until the
+  // DXE Core and all the Architectural Protocols are complete.
+  //
+
+  return EFI_NOT_AVAILABLE_YET;
+}
+
+/**
+  Place holder function until all the Boot Services and Runtime Services are available.
+
+  @param  VariableNameSize       Undefined
+  @param  VariableName           Undefined
+  @param  VendorGuid             Undefined
+
+  @return EFI_NOT_AVAILABLE_YET
+
+**/
+EFI_STATUS
+EFIAPI
+CoreEfiNotAvailableYetGetNextVariableName (
+  IN OUT UINTN     *VariableNameSize,
+  IN OUT CHAR16    *VariableName,
+  IN OUT EFI_GUID  *VendorGuid
+  )
+{
+  //
+  // This function should never be executed.  If it does, then the architectural protocols
+  // have not been designed correctly.  The CpuBreakpoint () is commented out for now until the
+  // DXE Core and all the Architectural Protocols are complete.
+  //
+
+  return EFI_NOT_AVAILABLE_YET;
+}
+
+/**
+  Place holder function until all the Boot Services and Runtime Services are available.
+
+  @param  VariableName           Undefined
+  @param  VendorGuid             Undefined
+  @param  Attributes             Undefined
+  @param  DataSize               Undefined
+  @param  Data                   Undefined
+
+  @return EFI_NOT_AVAILABLE_YET
+
+**/
+EFI_STATUS
+EFIAPI
+CoreEfiNotAvailableYetSetVariable (
+  IN  CHAR16    *VariableName,
+  IN  EFI_GUID  *VendorGuid,
+  IN  UINT32    Attributes,
+  IN  UINTN     DataSize,
+  IN  VOID      *Data
+  )
+{
+  //
+  // This function should never be executed.  If it does, then the architectural protocols
+  // have not been designed correctly.  The CpuBreakpoint () is commented out for now until the
+  // DXE Core and all the Architectural Protocols are complete.
+  //
+
+  return EFI_NOT_AVAILABLE_YET;
+}
+
+/**
+  Place holder function until all the Boot Services and Runtime Services are available.
+
+  @param  HighCount              Undefined
+
+  @return EFI_NOT_AVAILABLE_YET
+
+**/
+EFI_STATUS
+EFIAPI
+CoreEfiNotAvailableYetGetNextHighMonotonicCount (
+  OUT UINT32  *HighCount
+  )
+{
+  //
+  // This function should never be executed.  If it does, then the architectural protocols
+  // have not been designed correctly.  The CpuBreakpoint () is commented out for now until the
+  // DXE Core and all the Architectural Protocols are complete.
+  //
+
+  return EFI_NOT_AVAILABLE_YET;
+}
+
+/**
+  Place holder function until all the Boot Services and Runtime Services are available.
+
+  @param  ResetType              Undefined
+  @param  ResetStatus            Undefined
+  @param  DataSize               Undefined
+  @param  ResetData              Undefined
+
+  @return EFI_NOT_AVAILABLE_YET
+
+**/
+VOID
+EFIAPI
+CoreEfiNotAvailableYetResetSystem (
+  IN EFI_RESET_TYPE  ResetType,
+  IN EFI_STATUS      ResetStatus,
+  IN UINTN           DataSize,
+  IN VOID            *ResetData OPTIONAL
+  )
+{
+  //
+  // This function should never be executed.  If it does, then the architectural protocols
+  // have not been designed correctly.  The CpuBreakpoint () is commented out for now until the
+  // DXE Core and all the Architectural Protocols are complete.
+  //
+}
+
+/**
+  Place holder function until all the Boot Services and Runtime Services are available.
+
+  @param  CapsuleHeaderArray     Undefined
+  @param  CapsuleCount           Undefined
+  @param  ScatterGatherList      Undefined
+
+  @return EFI_NOT_AVAILABLE_YET
+
+**/
+EFI_STATUS
+EFIAPI
+CoreEfiNotAvailableYetUpdateCapsule (
+  IN EFI_CAPSULE_HEADER    **CapsuleHeaderArray,
+  IN UINTN                 CapsuleCount,
+  IN EFI_PHYSICAL_ADDRESS  ScatterGatherList   OPTIONAL
+  )
+{
+  //
+  // This function should never be executed.  If it does, then the architectural protocols
+  // have not been designed correctly.  The CpuBreakpoint () is commented out for now until the
+  // DXE Core and all the Architectural Protocols are complete.
+  //
+
+  return EFI_NOT_AVAILABLE_YET;
+}
+
+/**
+  Place holder function until all the Boot Services and Runtime Services are available.
+
+  @param  CapsuleHeaderArray     Undefined
+  @param  CapsuleCount           Undefined
+  @param  MaximumCapsuleSize     Undefined
+  @param  ResetType              Undefined
+
+  @return EFI_NOT_AVAILABLE_YET
+
+**/
+EFI_STATUS
+EFIAPI
+CoreEfiNotAvailableYetQueryCapsuleCapabilities (
+  IN  EFI_CAPSULE_HEADER  **CapsuleHeaderArray,
+  IN  UINTN               CapsuleCount,
+  OUT UINT64              *MaximumCapsuleSize,
+  OUT EFI_RESET_TYPE      *ResetType
+  )
+{
+  //
+  // This function should never be executed.  If it does, then the architectural protocols
+  // have not been designed correctly.  The CpuBreakpoint () is commented out for now until the
+  // DXE Core and all the Architectural Protocols are complete.
+  //
+
+  return EFI_NOT_AVAILABLE_YET;
+}
+
+/**
+  Place holder function until all the Boot Services and Runtime Services are available.
+
+  @param  Attributes                        Undefined
+  @param  MaximumVariableStorageSize        Undefined
+  @param  RemainingVariableStorageSize      Undefined
+  @param  MaximumVariableSize               Undefined
+
+  @return EFI_NOT_AVAILABLE_YET
+
+**/
+EFI_STATUS
+EFIAPI
+CoreEfiNotAvailableYetQueryVariableInfo (
+  IN  UINT32  Attributes,
+  OUT UINT64  *MaximumVariableStorageSize,
+  OUT UINT64  *RemainingVariableStorageSize,
+  OUT UINT64  *MaximumVariableSize
   )
 {
   //

--- a/MdeModulePkg/Core/Pei/PeiMain/PeiMain.c
+++ b/MdeModulePkg/Core/Pei/PeiMain/PeiMain.c
@@ -19,6 +19,69 @@ EFI_PEI_PPI_DESCRIPTOR  mMigrateTempRamPpi = {
   NULL
 };
 
+/**
+  Copies a source buffer to a destination buffer, and returns the destination buffer.
+
+  This function copies Length bytes from SourceBuffer to DestinationBuffer, and returns
+  DestinationBuffer.  The implementation must be reentrant, and it must handle the case
+  where SourceBuffer overlaps DestinationBuffer.
+
+  If Length is greater than (MAX_ADDRESS - DestinationBuffer + 1), then ASSERT().
+  If Length is greater than (MAX_ADDRESS - SourceBuffer + 1), then ASSERT().
+
+  @param  DestinationBuffer   The pointer to the destination buffer of the memory copy.
+  @param  SourceBuffer        The pointer to the source buffer of the memory copy.
+  @param  Length              The number of bytes to copy from SourceBuffer to DestinationBuffer.
+
+  @return None.
+
+**/
+STATIC
+VOID
+EFIAPI
+EfiCopyMem (
+  IN VOID   *DestinationBuffer,
+  IN VOID   *SourceBuffer,
+  IN UINTN  Length
+  )
+{
+  CopyMem (
+    DestinationBuffer,
+    SourceBuffer,
+    Length
+    );
+}
+
+/**
+  Fills a target buffer with a byte value, and returns the target buffer.
+
+  This function fills Length bytes of Buffer with Value.
+
+  If Length is greater than (MAX_ADDRESS - Buffer + 1), then ASSERT().
+
+  @param  Buffer    The memory to set.
+  @param  Length    The number of bytes to set.
+  @param  Value     The value with which to fill Length bytes of Buffer.
+
+  @return None.
+
+**/
+STATIC
+VOID
+EFIAPI
+EfiSetMem (
+  IN VOID   *Buffer,
+  IN UINTN  Length,
+  IN UINT8  Value
+  )
+{
+  SetMem (
+    Buffer,
+    Length,
+    Value
+    );
+}
+
 ///
 /// Pei service instance
 ///
@@ -48,8 +111,8 @@ EFI_PEI_SERVICES  gPs = {
   PeiInstallPeiMemory,
   PeiAllocatePages,
   PeiAllocatePool,
-  (EFI_PEI_COPY_MEM)CopyMem,
-  (EFI_PEI_SET_MEM)SetMem,
+  EfiCopyMem,
+  EfiSetMem,
 
   PeiReportStatusCode,
   PeiResetSystem,

--- a/MdeModulePkg/Core/PiSmmCore/PiSmmCore.c
+++ b/MdeModulePkg/Core/PiSmmCore/PiSmmCore.c
@@ -27,12 +27,12 @@ EFI_SMM_SYSTEM_TABLE2  gSmmCoreSmst = {
   SmmInstallConfigurationTable,
   {
     {
-      (EFI_SMM_CPU_IO2)SmmEfiNotAvailableYetArg5,        // SmmMemRead
-      (EFI_SMM_CPU_IO2)SmmEfiNotAvailableYetArg5         // SmmMemWrite
+      (EFI_SMM_CPU_IO2)SmmEfiNotAvailableYetMmCpuIo,        // SmmMemRead
+      (EFI_SMM_CPU_IO2)SmmEfiNotAvailableYetMmCpuIo         // SmmMemWrite
     },
     {
-      (EFI_SMM_CPU_IO2)SmmEfiNotAvailableYetArg5,        // SmmIoRead
-      (EFI_SMM_CPU_IO2)SmmEfiNotAvailableYetArg5         // SmmIoWrite
+      (EFI_SMM_CPU_IO2)SmmEfiNotAvailableYetMmCpuIo,        // SmmIoRead
+      (EFI_SMM_CPU_IO2)SmmEfiNotAvailableYetMmCpuIo         // SmmIoWrite
     }
   },
   SmmAllocatePool,
@@ -111,23 +111,23 @@ EFI_LOADED_IMAGE_PROTOCOL  *mSmmCoreLoadedImage;
 
   Note: This function is only used by SMRAM invocation.  It is never used by DXE invocation.
 
-  @param  Arg1                   Undefined
-  @param  Arg2                   Undefined
-  @param  Arg3                   Undefined
-  @param  Arg4                   Undefined
-  @param  Arg5                   Undefined
+  @param  This                   Undefined
+  @param  Width                  Undefined
+  @param  Address                Undefined
+  @param  Count                  Undefined
+  @param  Buffer                 Undefined
 
   @return EFI_NOT_AVAILABLE_YET
 
 **/
 EFI_STATUS
 EFIAPI
-SmmEfiNotAvailableYetArg5 (
-  UINTN  Arg1,
-  UINTN  Arg2,
-  UINTN  Arg3,
-  UINTN  Arg4,
-  UINTN  Arg5
+SmmEfiNotAvailableYetMmCpuIo (
+  IN     CONST EFI_MM_CPU_IO_PROTOCOL  *This,
+  IN     EFI_MM_IO_WIDTH               Width,
+  IN     UINT64                        Address,
+  IN     UINTN                         Count,
+  IN OUT VOID                          *Buffer
   )
 {
   //

--- a/MdeModulePkg/Core/PiSmmCore/PiSmmCore.h
+++ b/MdeModulePkg/Core/PiSmmCore/PiSmmCore.h
@@ -854,23 +854,23 @@ SmmEndOfS3ResumeHandler (
 /**
   Place holder function until all the SMM System Table Service are available.
 
-  @param  Arg1                   Undefined
-  @param  Arg2                   Undefined
-  @param  Arg3                   Undefined
-  @param  Arg4                   Undefined
-  @param  Arg5                   Undefined
+  @param  This                   Undefined
+  @param  Width                  Undefined
+  @param  Address                Undefined
+  @param  Count                  Undefined
+  @param  Buffer                 Undefined
 
   @return EFI_NOT_AVAILABLE_YET
 
 **/
 EFI_STATUS
 EFIAPI
-SmmEfiNotAvailableYetArg5 (
-  UINTN  Arg1,
-  UINTN  Arg2,
-  UINTN  Arg3,
-  UINTN  Arg4,
-  UINTN  Arg5
+SmmEfiNotAvailableYetMmCpuIo (
+  IN     CONST EFI_MM_CPU_IO_PROTOCOL  *This,
+  IN     EFI_MM_IO_WIDTH               Width,
+  IN     UINT64                        Address,
+  IN     UINTN                         Count,
+  IN OUT VOID                          *Buffer
   );
 
 //

--- a/MdeModulePkg/Universal/EbcDxe/EbcInt.c
+++ b/MdeModulePkg/Universal/EbcDxe/EbcInt.c
@@ -186,11 +186,18 @@ InitEbcVmTestProtocol (
   @return EFI_UNSUPPORTED  This function always return EFI_UNSUPPORTED status.
 
 **/
+STATIC
 EFI_STATUS
 EFIAPI
 EbcVmTestUnsupported (
-  VOID
-  );
+  IN EFI_EBC_VM_TEST_PROTOCOL  *This,
+  IN CHAR16                    *AsmText,
+  IN OUT INT8                  *Buffer,
+  IN OUT UINTN                 *BufferLen
+  )
+{
+  return EFI_UNSUPPORTED;
+}
 
 /**
   Registers a callback function that the EBC interpreter calls to flush the
@@ -375,6 +382,27 @@ EbcIsImageSupported (
 }
 
 /**
+  This is a wrapper for the Flush callback routine needed for type compatibility.
+
+  @param  Start  The beginning physical address to flush from the processor's instruction cache.
+  @param  Length The number of bytes to flush from the processor's instruction cache.
+
+  @retval EFI_SUCCESS            The function completed successfully.
+
+**/
+STATIC
+EFI_STATUS
+EFIAPI
+EbcInvalidateInstructionCache (
+  IN EFI_PHYSICAL_ADDRESS  Start,
+  IN UINT64                Length
+  )
+{
+  InvalidateInstructionCacheRange ((VOID *)(UINTN)Start, (UINTN)Length);
+  return EFI_SUCCESS;
+}
+
+/**
   Register a supported PE/COFF image with the emulator. After this call
   completes successfully, the PE/COFF image may be started as usual, and
   it is the responsibility of the emulator implementation that any branch
@@ -428,7 +456,7 @@ EbcRegisterImage (
 
   EbcRegisterICacheFlush (
     NULL,
-    (EBC_ICACHE_FLUSH)InvalidateInstructionCacheRange
+    EbcInvalidateInstructionCache
     );
 
   return EbcCreateThunk (
@@ -1510,8 +1538,8 @@ InitEbcVmTestProtocol (
   EbcVmTestProtocol->Execute = (EBC_VM_TEST_EXECUTE)EbcExecuteInstructions;
 
   DEBUG_CODE_BEGIN ();
-  EbcVmTestProtocol->Assemble    = (EBC_VM_TEST_ASM)EbcVmTestUnsupported;
-  EbcVmTestProtocol->Disassemble = (EBC_VM_TEST_DASM)EbcVmTestUnsupported;
+  EbcVmTestProtocol->Assemble    = EbcVmTestUnsupported;
+  EbcVmTestProtocol->Disassemble = EbcVmTestUnsupported;
   DEBUG_CODE_END ();
 
   //
@@ -1524,21 +1552,6 @@ InitEbcVmTestProtocol (
   }
 
   return Status;
-}
-
-/**
-  Returns the EFI_UNSUPPORTED Status.
-
-  @return EFI_UNSUPPORTED  This function always return EFI_UNSUPPORTED status.
-
-**/
-EFI_STATUS
-EFIAPI
-EbcVmTestUnsupported (
-  VOID
-  )
-{
-  return EFI_UNSUPPORTED;
 }
 
 /**

--- a/RedfishPkg/PrivateLibrary/RedfishCrtLib/RedfishCrtLib.c
+++ b/RedfishPkg/PrivateLibrary/RedfishCrtLib/RedfishCrtLib.c
@@ -12,7 +12,6 @@
 #include <Uefi.h>
 #include <Library/RedfishCrtLib.h>
 #include <Library/MemoryAllocationLib.h>
-#include <Library/SortLib.h>
 #include <Library/UefiRuntimeServicesTableLib.h>
 
 int   errno            = 0;
@@ -25,6 +24,98 @@ char  errnum_message[] = "We don't support to map errnum to the error message on
 #define GLOBAL_USED
 #endif
 int  GLOBAL_USED  _fltused;
+
+typedef
+int
+(*SORT_COMPARE)(
+  IN  VOID  *Buffer1,
+  IN  VOID  *Buffer2
+  );
+
+//
+// Duplicated from EDKII BaseSortLib for qsort() wrapper
+//
+STATIC
+VOID
+QuickSortWorker (
+  IN OUT    VOID          *BufferToSort,
+  IN CONST  UINTN         Count,
+  IN CONST  UINTN         ElementSize,
+  IN        SORT_COMPARE  CompareFunction,
+  IN        VOID          *Buffer
+  )
+{
+  VOID   *Pivot;
+  UINTN  LoopCount;
+  UINTN  NextSwapLocation;
+
+  ASSERT (BufferToSort    != NULL);
+  ASSERT (CompareFunction != NULL);
+  ASSERT (Buffer          != NULL);
+
+  if ((Count < 2) || (ElementSize  < 1)) {
+    return;
+  }
+
+  NextSwapLocation = 0;
+
+  //
+  // Pick a pivot (we choose last element)
+  //
+  Pivot = ((UINT8 *)BufferToSort + ((Count - 1) * ElementSize));
+
+  //
+  // Now get the pivot such that all on "left" are below it
+  // and everything "right" are above it
+  //
+  for (LoopCount = 0; LoopCount < Count - 1; LoopCount++) {
+    //
+    // If the element is less than the pivot
+    //
+    if (CompareFunction ((VOID *)((UINT8 *)BufferToSort + ((LoopCount) * ElementSize)), Pivot) <= 0) {
+      //
+      // Swap
+      //
+      CopyMem (Buffer, (UINT8 *)BufferToSort + (NextSwapLocation * ElementSize), ElementSize);
+      CopyMem ((UINT8 *)BufferToSort + (NextSwapLocation * ElementSize), (UINT8 *)BufferToSort + ((LoopCount) * ElementSize), ElementSize);
+      CopyMem ((UINT8 *)BufferToSort + ((LoopCount) * ElementSize), Buffer, ElementSize);
+
+      //
+      // Increment NextSwapLocation
+      //
+      NextSwapLocation++;
+    }
+  }
+
+  //
+  // Swap pivot to its final position (NextSwapLocation)
+  //
+  CopyMem (Buffer, Pivot, ElementSize);
+  CopyMem (Pivot, (UINT8 *)BufferToSort + (NextSwapLocation * ElementSize), ElementSize);
+  CopyMem ((UINT8 *)BufferToSort + (NextSwapLocation * ElementSize), Buffer, ElementSize);
+
+  //
+  // Now recurse on 2 partial lists.  Neither of these will have the 'pivot' element.
+  // IE list is sorted left half, pivot element, sorted right half...
+  //
+  QuickSortWorker (
+    BufferToSort,
+    NextSwapLocation,
+    ElementSize,
+    CompareFunction,
+    Buffer
+    );
+
+  QuickSortWorker (
+    (UINT8 *)BufferToSort + (NextSwapLocation + 1) * ElementSize,
+    Count - NextSwapLocation - 1,
+    ElementSize,
+    CompareFunction,
+    Buffer
+    );
+
+  return;
+}
 
 /**
   Determine if a particular character is an alphanumeric character
@@ -786,10 +877,26 @@ qsort (
   int ( *compare )(const void *, const void *)
   )
 {
+  VOID  *Buffer;
+
   ASSERT (base    != NULL);
   ASSERT (compare != NULL);
 
-  PerformQuickSort (base, (UINTN)num, (UINTN)width, (SORT_COMPARE)compare);
+  //
+  // Use CRT-style malloc to cover BS and RT memory allocation.
+  //
+  Buffer = malloc (width);
+  if (Buffer == NULL) {
+    ASSERT (Buffer != NULL);
+    return;
+  }
+
+  //
+  // Re-use PerformQuickSort() function Implementation in EDKII BaseSortLib.
+  //
+  QuickSortWorker (base, (UINTN)num, (UINTN)width, (SORT_COMPARE)compare, Buffer);
+
+  free (Buffer);
   return;
 }
 

--- a/RedfishPkg/PrivateLibrary/RedfishCrtLib/RedfishCrtLib.inf
+++ b/RedfishPkg/PrivateLibrary/RedfishCrtLib/RedfishCrtLib.inf
@@ -29,7 +29,6 @@
 
 [LibraryClasses]
   BaseLib
-  SortLib
   DebugLib
   MemoryAllocationLib
   UefiRuntimeServicesTableLib

--- a/RedfishPkg/RedfishComponents.dsc.inc
+++ b/RedfishPkg/RedfishComponents.dsc.inc
@@ -16,15 +16,9 @@
 !if $(REDFISH_ENABLE) == TRUE
   RedfishPkg/RestJsonStructureDxe/RestJsonStructureDxe.inf
   RedfishPkg/RedfishHostInterfaceDxe/RedfishHostInterfaceDxe.inf
-  RedfishPkg/RedfishRestExDxe/RedfishRestExDxe.inf  {
-    <LibraryClasses>
-      SortLib|MdeModulePkg/Library/BaseSortLib/BaseSortLib.inf
-  }
+  RedfishPkg/RedfishRestExDxe/RedfishRestExDxe.inf
   RedfishPkg/RedfishCredentialDxe/RedfishCredentialDxe.inf
-  RedfishPkg/RedfishDiscoverDxe/RedfishDiscoverDxe.inf  {
-    <LibraryClasses>
-      SortLib|MdeModulePkg/Library/BaseSortLib/BaseSortLib.inf
-  }
+  RedfishPkg/RedfishDiscoverDxe/RedfishDiscoverDxe.inf
   RedfishPkg/RedfishConfigHandler/RedfishConfigHandlerDriver.inf
   RedfishPkg/RedfishPlatformConfigDxe/RedfishPlatformConfigDxe.inf
   MdeModulePkg/Universal/RegularExpressionDxe/RegularExpressionDxe.inf

--- a/RedfishPkg/RedfishPkg.dsc
+++ b/RedfishPkg/RedfishPkg.dsc
@@ -46,7 +46,6 @@
   RedfishPlatformCredentialLib|RedfishPkg/Library/PlatformCredentialLibNull/PlatformCredentialLibNull.inf
   RedfishContentCodingLib|RedfishPkg/Library/RedfishContentCodingLibNull/RedfishContentCodingLibNull.inf
   ReportStatusCodeLib|MdeModulePkg/Library/DxeReportStatusCodeLib/DxeReportStatusCodeLib.inf
-  SortLib|MdeModulePkg/Library/UefiSortLib/UefiSortLib.inf
   RedfishPlatformWantedDeviceLib|RedfishPkg/Library/RedfishPlatformWantedDeviceLibNull/RedfishPlatformWantedDeviceLibNull.inf
 
   # NULL instance of IPMI related library.

--- a/StandaloneMmPkg/Core/StandaloneMmCore.c
+++ b/StandaloneMmPkg/Core/StandaloneMmCore.c
@@ -33,12 +33,12 @@ EFI_MM_SYSTEM_TABLE  gMmCoreMmst = {
   // I/O Service
   {
     {
-      (EFI_MM_CPU_IO)MmEfiNotAvailableYetArg5,        // MmMemRead
-      (EFI_MM_CPU_IO)MmEfiNotAvailableYetArg5         // MmMemWrite
+      (EFI_MM_CPU_IO)MmEfiNotAvailableYetMmCpuIo,        // MmMemRead
+      (EFI_MM_CPU_IO)MmEfiNotAvailableYetMmCpuIo         // MmMemWrite
     },
     {
-      (EFI_MM_CPU_IO)MmEfiNotAvailableYetArg5,        // MmIoRead
-      (EFI_MM_CPU_IO)MmEfiNotAvailableYetArg5         // MmIoWrite
+      (EFI_MM_CPU_IO)MmEfiNotAvailableYetMmCpuIo,        // MmIoRead
+      (EFI_MM_CPU_IO)MmEfiNotAvailableYetMmCpuIo         // MmIoWrite
     }
   },
   // Runtime memory services
@@ -87,23 +87,23 @@ VOID            *mInternalCommBufferCopy;
 
   Note: This function is only used by MMRAM invocation.  It is never used by DXE invocation.
 
-  @param  Arg1                   Undefined
-  @param  Arg2                   Undefined
-  @param  Arg3                   Undefined
-  @param  Arg4                   Undefined
-  @param  Arg5                   Undefined
+  @param  This                   Undefined
+  @param  Width                  Undefined
+  @param  Address                Undefined
+  @param  Count                  Undefined
+  @param  Buffer                 Undefined
 
   @return EFI_NOT_AVAILABLE_YET
 
 **/
 EFI_STATUS
 EFIAPI
-MmEfiNotAvailableYetArg5 (
-  UINTN  Arg1,
-  UINTN  Arg2,
-  UINTN  Arg3,
-  UINTN  Arg4,
-  UINTN  Arg5
+MmEfiNotAvailableYetMmCpuIo (
+  IN     CONST EFI_MM_CPU_IO_PROTOCOL  *This,
+  IN     EFI_MM_IO_WIDTH               Width,
+  IN     UINT64                        Address,
+  IN     UINTN                         Count,
+  IN OUT VOID                          *Buffer
   )
 {
   //

--- a/StandaloneMmPkg/Core/StandaloneMmCore.h
+++ b/StandaloneMmPkg/Core/StandaloneMmCore.h
@@ -768,23 +768,23 @@ MmEndOfDxeHandler (
 /**
   Place holder function until all the MM System Table Service are available.
 
-  @param  Arg1                   Undefined
-  @param  Arg2                   Undefined
-  @param  Arg3                   Undefined
-  @param  Arg4                   Undefined
-  @param  Arg5                   Undefined
+  @param  This                   Undefined
+  @param  Width                  Undefined
+  @param  Address                Undefined
+  @param  Count                  Undefined
+  @param  Buffer                 Undefined
 
   @return EFI_NOT_AVAILABLE_YET
 
 **/
 EFI_STATUS
 EFIAPI
-MmEfiNotAvailableYetArg5 (
-  UINTN  Arg1,
-  UINTN  Arg2,
-  UINTN  Arg3,
-  UINTN  Arg4,
-  UINTN  Arg5
+MmEfiNotAvailableYetMmCpuIo (
+  IN     CONST EFI_MM_CPU_IO_PROTOCOL  *This,
+  IN     EFI_MM_IO_WIDTH               Width,
+  IN     UINT64                        Address,
+  IN     UINTN                         Count,
+  IN OUT VOID                          *Buffer
   );
 
 //

--- a/UefiCpuPkg/PiSmmCpuDxeSmm/SmmCpuMemoryManagement.c
+++ b/UefiCpuPkg/PiSmmCpuDxeSmm/SmmCpuMemoryManagement.c
@@ -511,13 +511,16 @@ ConvertMemoryPageAttributes (
 
   @param[in,out] Buffer  Pointer to private data buffer.
 **/
-VOID
+STATIC
+EFI_STATUS
 EFIAPI
 FlushTlbOnCurrentProcessor (
   IN OUT VOID  *Buffer
   )
 {
   CpuFlushTlb ();
+
+  return EFI_SUCCESS;
 }
 
 /**
@@ -530,7 +533,7 @@ FlushTlbForAll (
 {
   FlushTlbOnCurrentProcessor (NULL);
   InternalSmmStartupAllAPs (
-    (EFI_AP_PROCEDURE2)FlushTlbOnCurrentProcessor,
+    FlushTlbOnCurrentProcessor,
     0,
     NULL,
     NULL,

--- a/UnitTestFrameworkPkg/Library/UnitTestPeiServicesTablePointerLib/UnitTestPeiServicesTablePointerLib.c
+++ b/UnitTestFrameworkPkg/Library/UnitTestPeiServicesTablePointerLib/UnitTestPeiServicesTablePointerLib.c
@@ -10,6 +10,69 @@
 
 #include "UnitTestPeiServicesTablePointerLib.h"
 
+/**
+  Copies a source buffer to a destination buffer, and returns the destination buffer.
+
+  This function copies Length bytes from SourceBuffer to DestinationBuffer, and returns
+  DestinationBuffer.  The implementation must be reentrant, and it must handle the case
+  where SourceBuffer overlaps DestinationBuffer.
+
+  If Length is greater than (MAX_ADDRESS - DestinationBuffer + 1), then ASSERT().
+  If Length is greater than (MAX_ADDRESS - SourceBuffer + 1), then ASSERT().
+
+  @param  DestinationBuffer   The pointer to the destination buffer of the memory copy.
+  @param  SourceBuffer        The pointer to the source buffer of the memory copy.
+  @param  Length              The number of bytes to copy from SourceBuffer to DestinationBuffer.
+
+  @return None.
+
+**/
+STATIC
+VOID
+EFIAPI
+EfiCopyMem (
+  IN VOID   *DestinationBuffer,
+  IN VOID   *SourceBuffer,
+  IN UINTN  Length
+  )
+{
+  CopyMem (
+    DestinationBuffer,
+    SourceBuffer,
+    Length
+    );
+}
+
+/**
+  Fills a target buffer with a byte value, and returns the target buffer.
+
+  This function fills Length bytes of Buffer with Value.
+
+  If Length is greater than (MAX_ADDRESS - Buffer + 1), then ASSERT().
+
+  @param  Buffer    The memory to set.
+  @param  Length    The number of bytes to set.
+  @param  Value     The value with which to fill Length bytes of Buffer.
+
+  @return None.
+
+**/
+STATIC
+VOID
+EFIAPI
+EfiSetMem (
+  IN VOID   *Buffer,
+  IN UINTN  Length,
+  IN UINT8  Value
+  )
+{
+  SetMem (
+    Buffer,
+    Length,
+    Value
+    );
+}
+
 ///
 /// Pei service instance
 ///
@@ -39,8 +102,8 @@ EFI_PEI_SERVICES  mPeiServices = {
   UnitTestInstallPeiMemory, // InstallPeiMemory
   UnitTestPeiAllocatePages, // AllocatePages
   UnitTestPeiAllocatePool,  // AllocatePool
-  (EFI_PEI_COPY_MEM)CopyMem,
-  (EFI_PEI_SET_MEM)SetMem,
+  EfiCopyMem,
+  EfiSetMem,
 
   UnitTestReportStatusCode, // ReportStatusCode
   UnitTestResetSystem,      // ResetSystem

--- a/UnitTestFrameworkPkg/Library/UnitTestUefiBootServicesTableLib/UnitTestUefiBootServicesTableLib.c
+++ b/UnitTestFrameworkPkg/Library/UnitTestUefiBootServicesTableLib/UnitTestUefiBootServicesTableLib.c
@@ -16,6 +16,69 @@
 
 #include "UnitTestUefiBootServicesTableLib.h"
 
+/**
+  Copies a source buffer to a destination buffer, and returns the destination buffer.
+
+  This function copies Length bytes from SourceBuffer to DestinationBuffer, and returns
+  DestinationBuffer.  The implementation must be reentrant, and it must handle the case
+  where SourceBuffer overlaps DestinationBuffer.
+
+  If Length is greater than (MAX_ADDRESS - DestinationBuffer + 1), then ASSERT().
+  If Length is greater than (MAX_ADDRESS - SourceBuffer + 1), then ASSERT().
+
+  @param  DestinationBuffer   The pointer to the destination buffer of the memory copy.
+  @param  SourceBuffer        The pointer to the source buffer of the memory copy.
+  @param  Length              The number of bytes to copy from SourceBuffer to DestinationBuffer.
+
+  @return None.
+
+**/
+STATIC
+VOID
+EFIAPI
+EfiCopyMem (
+  IN VOID   *DestinationBuffer,
+  IN VOID   *SourceBuffer,
+  IN UINTN  Length
+  )
+{
+  CopyMem (
+    DestinationBuffer,
+    SourceBuffer,
+    Length
+    );
+}
+
+/**
+  Fills a target buffer with a byte value, and returns the target buffer.
+
+  This function fills Length bytes of Buffer with Value.
+
+  If Length is greater than (MAX_ADDRESS - Buffer + 1), then ASSERT().
+
+  @param  Buffer    The memory to set.
+  @param  Length    The number of bytes to set.
+  @param  Value     The value with which to fill Length bytes of Buffer.
+
+  @return None.
+
+**/
+STATIC
+VOID
+EFIAPI
+EfiSetMem (
+  IN VOID   *Buffer,
+  IN UINTN  Length,
+  IN UINT8  Value
+  )
+{
+  SetMem (
+    Buffer,
+    Length,
+    Value
+    );
+}
+
 EFI_HANDLE        gImageHandle = NULL;
 EFI_SYSTEM_TABLE  *gST         = NULL;
 
@@ -68,8 +131,8 @@ STATIC EFI_BOOT_SERVICES  mBootServices = {
   (EFI_INSTALL_MULTIPLE_PROTOCOL_INTERFACES)UnitTestInstallMultipleProtocolInterfaces,        // InstallMultipleProtocolInterfaces
   (EFI_UNINSTALL_MULTIPLE_PROTOCOL_INTERFACES)UnitTestUninstallMultipleProtocolInterfaces,    // UninstallMultipleProtocolInterfaces
   (EFI_CALCULATE_CRC32)UnitTestCalculateCrc32,                                                // CalculateCrc32
-  (EFI_COPY_MEM)CopyMem,                                                                      // CopyMem
-  (EFI_SET_MEM)SetMem,                                                                        // SetMem
+  (EFI_COPY_MEM)EfiCopyMem,                                                                   // CopyMem
+  (EFI_SET_MEM)EfiSetMem,                                                                     // SetMem
   (EFI_CREATE_EVENT_EX)UnitTestCreateEventEx                                                  // CreateEventEx
 };
 


### PR DESCRIPTION
# Description

This PR continues the approach of trying to enable warnings which can be enabled, in order to catch more real errors.

Based on the fixes needed for EDK 2 to compile with the warning enabled, it is believed that at least some of these are genuine issues which we would like to catch automatically.

This warning is enabled by default on recent versions of Apple Clang, but not LLVM Clang.

Add commits which fix reliance on undefined behaviour caught by this warning, then enable for CLANG toolchains.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

CI

## Integration Instructions

N/A