### PR TITLE
MdeModulePkg/Core: Prevent possible premature handle removal

### DIFF
--- a/MdeModulePkg/Core/Dxe/Hand/Handle.c
+++ b/MdeModulePkg/Core/Dxe/Hand/Handle.c
@@ -131,6 +131,43 @@ CoreValidateHandle (
 }
 
 /**
+  Remove handle from handle database and free it.
+
+  @param UserHandle    Handle to be removed from list
+
+  @return EFI_SUCCESS   the handle is removed
+  @return EFI_NOT_READY the handle has one or more protocols installed
+ **/
+STATIC
+EFI_STATUS
+CoreRemoveHandleFromHandleList (
+  IN EFI_HANDLE  UserHandle
+  )
+{
+  IHANDLE  *Handle;
+
+  Handle = UserHandle;
+
+  if (!IsListEmpty (&Handle->Protocols)) {
+    return EFI_NOT_READY;
+  }
+
+  //
+  // If there are no more interfaces for the handle, free the handle
+  //
+  Handle->Signature = 0;
+  OrderedCollectionDelete (
+    gOrderedHandleList,
+    OrderedCollectionFind (gOrderedHandleList, Handle),
+    NULL
+    );
+  RemoveEntryList (&Handle->AllHandles);
+  CoreFreePool (Handle);
+
+  return EFI_SUCCESS;
+}
+
+/**
   Finds the protocol entry for the requested protocol.
   The gProtocolDatabaseLock must be owned
 
@@ -788,9 +825,7 @@ CoreDisconnectControllersUsingProtocolInterface (
 }
 
 /**
-  Uninstalls all instances of a protocol:interfacer from a handle.
-  If the last protocol interface is remove from the handle, the
-  handle is freed.
+  Internal function that removes protocol interface from handle.
 
   @param  UserHandle             The handle to remove the protocol handler from
   @param  Protocol               The protocol, of protocol:interface, to remove
@@ -798,11 +833,9 @@ CoreDisconnectControllersUsingProtocolInterface (
 
   @retval EFI_INVALID_PARAMETER  Protocol is NULL.
   @retval EFI_SUCCESS            Protocol interface successfully uninstalled.
-
-**/
+ **/
 EFI_STATUS
-EFIAPI
-CoreUninstallProtocolInterface (
+CoreUninstallProtocolInterfacesInternal (
   IN EFI_HANDLE  UserHandle,
   IN EFI_GUID    *Protocol,
   IN VOID        *Interface
@@ -882,25 +915,44 @@ CoreUninstallProtocolInterface (
     Status = EFI_SUCCESS;
   }
 
-  //
-  // If there are no more handlers for the handle, free the handle
-  //
-  if (IsListEmpty (&Handle->Protocols)) {
-    Handle->Signature = 0;
-    OrderedCollectionDelete (
-      gOrderedHandleList,
-      OrderedCollectionFind (gOrderedHandleList, Handle),
-      NULL
-      );
-    RemoveEntryList (&Handle->AllHandles);
-    CoreFreePool (Handle);
-  }
-
 Done:
   //
   // Done, unlock the database and return
   //
   CoreReleaseProtocolLock ();
+  return Status;
+}
+
+/**
+  Uninstalls all instances of a protocol:interface from a handle.
+  If the last protocol interface is removed from the handle, the
+  handle is freed.
+
+  @param  UserHandle             The handle to remove the protocol handler from
+  @param  Protocol               The protocol, of protocol:interface, to remove
+  @param  Interface              The interface, of protocol:interface, to remove
+
+  @retval EFI_INVALID_PARAMETER  Protocol is NULL.
+  @retval EFI_SUCCESS            Protocol interface successfully uninstalled.
+
+**/
+EFI_STATUS
+EFIAPI
+CoreUninstallProtocolInterface (
+  IN EFI_HANDLE  UserHandle,
+  IN EFI_GUID    *Protocol,
+  IN VOID        *Interface
+  )
+{
+  EFI_STATUS  Status;
+
+  Status = CoreUninstallProtocolInterfacesInternal (UserHandle, Protocol, Interface);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Status = CoreRemoveHandleFromHandleList (UserHandle);
+
   return Status;
 }
 
@@ -954,7 +1006,7 @@ CoreUninstallMultipleProtocolInterfaces (
     //
     // Uninstall it
     //
-    Status = CoreUninstallProtocolInterface (Handle, Protocol, Interface);
+    Status = CoreUninstallProtocolInterfacesInternal (Handle, Protocol, Interface);
   }
 
   VA_END (Args);
@@ -976,6 +1028,8 @@ CoreUninstallMultipleProtocolInterfaces (
 
     VA_END (Args);
     Status = EFI_INVALID_PARAMETER;
+  } else {
+    Status = CoreRemoveHandleFromHandleList (Handle);
   }
 
   return Status;

--- a/MdeModulePkg/Core/Dxe/Hand/Handle.c
+++ b/MdeModulePkg/Core/Dxe/Hand/Handle.c
@@ -131,6 +131,50 @@ CoreValidateHandle (
 }
 
 /**
+  Remove handle from handle database and free it.
+
+  @param UserHandle    Handle to be removed from list
+
+  @return EFI_SUCCESS   the handle is removed
+  @return EFI_NOT_READY the handle has one or more protocols installed
+ **/
+STATIC
+EFI_STATUS
+CoreRemoveHandleFromHandleList (
+  IN EFI_HANDLE  UserHandle
+  )
+{
+  IHANDLE  *Handle;
+
+  Handle = UserHandle;
+
+  //
+  // Lock the protocol database
+  //
+  CoreAcquireProtocolLock ();
+
+  if (!IsListEmpty (&Handle->Protocols)) {
+    CoreReleaseProtocolLock ();
+    return EFI_INVALID_PARAMETER;
+  }
+
+  //
+  // If there are no more interfaces for the handle, free the handle
+  //
+  Handle->Signature = 0;
+  OrderedCollectionDelete (
+    gOrderedHandleList,
+    OrderedCollectionFind (gOrderedHandleList, Handle),
+    NULL
+    );
+  RemoveEntryList (&Handle->AllHandles);
+  CoreFreePool (Handle);
+  CoreReleaseProtocolLock ();
+
+  return EFI_SUCCESS;
+}
+
+/**
   Finds the protocol entry for the requested protocol.
   The gProtocolDatabaseLock must be owned
 
@@ -788,9 +832,7 @@ CoreDisconnectControllersUsingProtocolInterface (
 }
 
 /**
-  Uninstalls all instances of a protocol:interfacer from a handle.
-  If the last protocol interface is remove from the handle, the
-  handle is freed.
+  Internal function that removes protocol interface from handle.
 
   @param  UserHandle             The handle to remove the protocol handler from
   @param  Protocol               The protocol, of protocol:interface, to remove
@@ -798,11 +840,9 @@ CoreDisconnectControllersUsingProtocolInterface (
 
   @retval EFI_INVALID_PARAMETER  Protocol is NULL.
   @retval EFI_SUCCESS            Protocol interface successfully uninstalled.
-
-**/
+ **/
 EFI_STATUS
-EFIAPI
-CoreUninstallProtocolInterface (
+CoreUninstallProtocolInterfacesInternal (
   IN EFI_HANDLE  UserHandle,
   IN EFI_GUID    *Protocol,
   IN VOID        *Interface
@@ -882,25 +922,44 @@ CoreUninstallProtocolInterface (
     Status = EFI_SUCCESS;
   }
 
-  //
-  // If there are no more handlers for the handle, free the handle
-  //
-  if (IsListEmpty (&Handle->Protocols)) {
-    Handle->Signature = 0;
-    OrderedCollectionDelete (
-      gOrderedHandleList,
-      OrderedCollectionFind (gOrderedHandleList, Handle),
-      NULL
-      );
-    RemoveEntryList (&Handle->AllHandles);
-    CoreFreePool (Handle);
-  }
-
 Done:
   //
   // Done, unlock the database and return
   //
   CoreReleaseProtocolLock ();
+  return Status;
+}
+
+/**
+  Uninstalls all instances of a protocol:interface from a handle.
+  If the last protocol interface is removed from the handle, the
+  handle is freed.
+
+  @param  UserHandle             The handle to remove the protocol handler from
+  @param  Protocol               The protocol, of protocol:interface, to remove
+  @param  Interface              The interface, of protocol:interface, to remove
+
+  @retval EFI_INVALID_PARAMETER  Protocol is NULL.
+  @retval EFI_SUCCESS            Protocol interface successfully uninstalled.
+
+**/
+EFI_STATUS
+EFIAPI
+CoreUninstallProtocolInterface (
+  IN EFI_HANDLE  UserHandle,
+  IN EFI_GUID    *Protocol,
+  IN VOID        *Interface
+  )
+{
+  EFI_STATUS  Status;
+
+  Status = CoreUninstallProtocolInterfacesInternal (UserHandle, Protocol, Interface);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Status = CoreRemoveHandleFromHandleList (UserHandle);
+
   return Status;
 }
 
@@ -954,7 +1013,7 @@ CoreUninstallMultipleProtocolInterfaces (
     //
     // Uninstall it
     //
-    Status = CoreUninstallProtocolInterface (Handle, Protocol, Interface);
+    Status = CoreUninstallProtocolInterfacesInternal (Handle, Protocol, Interface);
   }
 
   VA_END (Args);
@@ -976,6 +1035,8 @@ CoreUninstallMultipleProtocolInterfaces (
 
     VA_END (Args);
     Status = EFI_INVALID_PARAMETER;
+  } else {
+    Status = CoreRemoveHandleFromHandleList (Handle);
   }
 
   return Status;

--- a/UnitTestFrameworkPkg/Library/UnitTestUefiBootServicesTableLib/UnitTestUefiBootServicesTableLibProtocol.c
+++ b/UnitTestFrameworkPkg/Library/UnitTestUefiBootServicesTableLib/UnitTestUefiBootServicesTableLibProtocol.c
@@ -49,6 +49,38 @@ UnitTestValidateHandle (
 }
 
 /**
+  Remove handle from handle database and free it.
+
+  @param UserHandle    Handle to be removed from list
+
+  @return EFI_SUCCESS   the handle is removed
+  @return EFI_NOT_READY the handle has one or more protocols installed
+ **/
+STATIC
+EFI_STATUS
+UnitTestRemoveHandleFromHandleList (
+  IN EFI_HANDLE  UserHandle
+  )
+{
+  IHANDLE  *Handle;
+
+  Handle = UserHandle;
+
+  if (!IsListEmpty (&Handle->Protocols)) {
+    return EFI_NOT_READY;
+  }
+
+  //
+  // If there are no more interfaces for the handle, free the handle
+  //
+  Handle->Signature = 0;
+  RemoveEntryList (&Handle->AllHandles);
+  FreePool (Handle);
+
+  return EFI_SUCCESS;
+}
+
+/**
   Finds the protocol entry for the requested protocol.
 
   @param  Protocol               The ID of the protocol
@@ -723,9 +755,7 @@ UnitTestReinstallProtocolInterface (
 }
 
 /**
-  Uninstalls all instances of a protocol:interfacer from a handle.
-  If the last protocol interface is remove from the handle, the
-  handle is freed.
+  Internal function that removes protocol interface from handle.
 
   @param  UserHandle             The handle to remove the protocol handler from
   @param  Protocol               The protocol, of protocol:interface, to remove
@@ -733,11 +763,9 @@ UnitTestReinstallProtocolInterface (
 
   @retval EFI_INVALID_PARAMETER  Protocol is NULL.
   @retval EFI_SUCCESS            Protocol interface successfully uninstalled.
-
-**/
+ **/
 EFI_STATUS
-EFIAPI
-UnitTestUninstallProtocolInterface (
+UnitTestUninstallProtocolInterfaceInternal (
   IN EFI_HANDLE  UserHandle,
   IN EFI_GUID    *Protocol,
   IN VOID        *Interface
@@ -812,16 +840,40 @@ UnitTestUninstallProtocolInterface (
     Status = EFI_SUCCESS;
   }
 
-  //
-  // If there are no more handlers for the handle, free the handle
-  //
-  if (IsListEmpty (&Handle->Protocols)) {
-    Handle->Signature = 0;
-    RemoveEntryList (&Handle->AllHandles);
-    FreePool (Handle);
+Done:
+  return Status;
+}
+
+/**
+  Uninstalls all instances of a protocol:interface from a handle.
+  If the last protocol interface is removed from the handle, the
+  handle is freed.
+
+  @param  UserHandle             The handle to remove the protocol handler from
+  @param  Protocol               The protocol, of protocol:interface, to remove
+  @param  Interface              The interface, of protocol:interface, to remove
+
+  @retval EFI_INVALID_PARAMETER  Protocol is NULL.
+  @retval EFI_SUCCESS            Protocol interface successfully uninstalled.
+
+**/
+EFI_STATUS
+EFIAPI
+UnitTestUninstallProtocolInterface (
+  IN EFI_HANDLE  UserHandle,
+  IN EFI_GUID    *Protocol,
+  IN VOID        *Interface
+  )
+{
+  EFI_STATUS  Status;
+
+  Status = UnitTestUninstallProtocolInterfaceInternal (UserHandle, Protocol, Interface);
+  if (EFI_ERROR (Status)) {
+    return Status;
   }
 
-Done:
+  Status = UnitTestRemoveHandleFromHandleList (UserHandle);
+
   return Status;
 }
 
@@ -1622,7 +1674,7 @@ UnitTestUninstallMultipleProtocolInterfaces (
     //
     // Uninstall it
     //
-    Status = UnitTestUninstallProtocolInterface (Handle, Protocol, Interface);
+    Status = UnitTestUninstallProtocolInterfaceInternal (Handle, Protocol, Interface);
   }
 
   VA_END (Args);
@@ -1644,6 +1696,8 @@ UnitTestUninstallMultipleProtocolInterfaces (
 
     VA_END (Args);
     Status = EFI_INVALID_PARAMETER;
+  } else {
+    Status = UnitTestRemoveHandleFromHandleList (Handle);
   }
 
   return Status;

--- a/UnitTestFrameworkPkg/Library/UnitTestUefiBootServicesTableLib/UnitTestUefiBootServicesTableLibProtocol.c
+++ b/UnitTestFrameworkPkg/Library/UnitTestUefiBootServicesTableLib/UnitTestUefiBootServicesTableLibProtocol.c
@@ -49,6 +49,38 @@ UnitTestValidateHandle (
 }
 
 /**
+  Remove handle from handle database and free it.
+
+  @param UserHandle    Handle to be removed from list
+
+  @return EFI_SUCCESS   the handle is removed
+  @return EFI_NOT_READY the handle has one or more protocols installed
+ **/
+STATIC
+EFI_STATUS
+UnitTestRemoveHandleFromHandleList (
+  IN EFI_HANDLE  UserHandle
+  )
+{
+  IHANDLE  *Handle;
+
+  Handle = UserHandle;
+
+  if (!IsListEmpty (&Handle->Protocols)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  //
+  // If there are no more interfaces for the handle, free the handle
+  //
+  Handle->Signature = 0;
+  RemoveEntryList (&Handle->AllHandles);
+  FreePool (Handle);
+
+  return EFI_SUCCESS;
+}
+
+/**
   Finds the protocol entry for the requested protocol.
 
   @param  Protocol               The ID of the protocol
@@ -723,9 +755,7 @@ UnitTestReinstallProtocolInterface (
 }
 
 /**
-  Uninstalls all instances of a protocol:interfacer from a handle.
-  If the last protocol interface is remove from the handle, the
-  handle is freed.
+  Internal function that removes protocol interface from handle.
 
   @param  UserHandle             The handle to remove the protocol handler from
   @param  Protocol               The protocol, of protocol:interface, to remove
@@ -733,11 +763,9 @@ UnitTestReinstallProtocolInterface (
 
   @retval EFI_INVALID_PARAMETER  Protocol is NULL.
   @retval EFI_SUCCESS            Protocol interface successfully uninstalled.
-
-**/
+ **/
 EFI_STATUS
-EFIAPI
-UnitTestUninstallProtocolInterface (
+UnitTestUninstallProtocolInterfaceInternal (
   IN EFI_HANDLE  UserHandle,
   IN EFI_GUID    *Protocol,
   IN VOID        *Interface
@@ -812,16 +840,40 @@ UnitTestUninstallProtocolInterface (
     Status = EFI_SUCCESS;
   }
 
-  //
-  // If there are no more handlers for the handle, free the handle
-  //
-  if (IsListEmpty (&Handle->Protocols)) {
-    Handle->Signature = 0;
-    RemoveEntryList (&Handle->AllHandles);
-    FreePool (Handle);
+Done:
+  return Status;
+}
+
+/**
+  Uninstalls all instances of a protocol:interface from a handle.
+  If the last protocol interface is removed from the handle, the
+  handle is freed.
+
+  @param  UserHandle             The handle to remove the protocol handler from
+  @param  Protocol               The protocol, of protocol:interface, to remove
+  @param  Interface              The interface, of protocol:interface, to remove
+
+  @retval EFI_INVALID_PARAMETER  Protocol is NULL.
+  @retval EFI_SUCCESS            Protocol interface successfully uninstalled.
+
+**/
+EFI_STATUS
+EFIAPI
+UnitTestUninstallProtocolInterface (
+  IN EFI_HANDLE  UserHandle,
+  IN EFI_GUID    *Protocol,
+  IN VOID        *Interface
+  )
+{
+  EFI_STATUS  Status;
+
+  Status = UnitTestUninstallProtocolInterfaceInternal (UserHandle, Protocol, Interface);
+  if (EFI_ERROR (Status)) {
+    return Status;
   }
 
-Done:
+  Status = UnitTestRemoveHandleFromHandleList (UserHandle);
+
   return Status;
 }
 
@@ -1622,7 +1674,7 @@ UnitTestUninstallMultipleProtocolInterfaces (
     //
     // Uninstall it
     //
-    Status = UnitTestUninstallProtocolInterface (Handle, Protocol, Interface);
+    Status = UnitTestUninstallProtocolInterfaceInternal (Handle, Protocol, Interface);
   }
 
   VA_END (Args);
@@ -1644,6 +1696,8 @@ UnitTestUninstallMultipleProtocolInterfaces (
 
     VA_END (Args);
     Status = EFI_INVALID_PARAMETER;
+  } else {
+    Status = UnitTestRemoveHandleFromHandleList (Handle);
   }
 
   return Status;


### PR DESCRIPTION
# Description
    
fixes: #11114
    
According to UEFI spec function UinstallMultipleProtocolInterfaces() dictate if any issues happen after one or more protocols uninstalled with UinstallProtocolInterface, all protocols uninstalled prior the error should be reinstalled with InstallProtocolInterface().
    
However, the current implementation of UninstallProtocolInterface() if there is no interface left on the handle it will remove that handle and free it. This later causes UninstallMultipleProtocolInterfaces() to get back invalid freed handle and fail to reinstall protocols.

To fix that, these patches introduce an internal function for UinstallProtocolInterface() which both implementations could use. This preserves the API while making each function handle it's own handle removal independent. Thus both UinstallProtocolInterface() and UinstallMultipleProtocolInterfaces() will use those internal functions.

For more information please refer to linked issue which provides test case and steps to reproduce.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

On OVMF X64. For patch reproduction and test case has been provided in the linked issue.

## Integration Instructions
N/A