### PR TITLE
ArmPkg/CpuDxe: Support multiple entries in RegionIsSystemMemory check

### DIFF
--- a/ArmPkg/Drivers/CpuDxe/MemoryAttribute.c
+++ b/ArmPkg/Drivers/CpuDxe/MemoryAttribute.c
@@ -9,7 +9,7 @@
 #include "CpuDxe.h"
 
 /**
-  Check whether the provided memory range is covered by a single entry of type
+  Check whether the provided memory range is covered by one or more entries of type
   EfiGcdSystemMemory in the GCD memory map.
 
   @param  BaseAddress       The physical address that is the start address of
@@ -26,22 +26,25 @@ RegionIsSystemMemory (
   )
 {
   EFI_GCD_MEMORY_SPACE_DESCRIPTOR  GcdDescriptor;
-  EFI_PHYSICAL_ADDRESS             GcdEndAddress;
+  EFI_PHYSICAL_ADDRESS             CurrentAddress;
+  EFI_PHYSICAL_ADDRESS             EndAddress;
   EFI_STATUS                       Status;
 
-  Status = gDS->GetMemorySpaceDescriptor (BaseAddress, &GcdDescriptor);
-  if (EFI_ERROR (Status) ||
-      (GcdDescriptor.GcdMemoryType != EfiGcdMemoryTypeSystemMemory))
-  {
-    return FALSE;
+  CurrentAddress = BaseAddress;
+  EndAddress     = BaseAddress + Length;
+
+  while (CurrentAddress < EndAddress) {
+    Status = gDS->GetMemorySpaceDescriptor (CurrentAddress, &GcdDescriptor);
+    if (EFI_ERROR (Status) ||
+        (GcdDescriptor.GcdMemoryType != EfiGcdMemoryTypeSystemMemory))
+    {
+      return FALSE;
+    }
+
+    CurrentAddress = GcdDescriptor.BaseAddress + GcdDescriptor.Length;
   }
 
-  GcdEndAddress = GcdDescriptor.BaseAddress + GcdDescriptor.Length;
-
-  //
-  // Return TRUE if the GCD descriptor covers the range entirely
-  //
-  return GcdEndAddress >= (BaseAddress + Length);
+  return TRUE;
 }
 
 /**


### PR DESCRIPTION
# Description
The check performed by RegionIsSystemMemory is not necessarily limited to a single entry of type EfiGcdSystemMemory in the GCD memory map. For example, when a memory region spans multiple contiguous GCD entries, the current implementation returns False even though the entire range is system memory.

Therefore, this modification expands the RegionIsSystemMemory check to support multiple contiguous entries.

Fixes: https://github.com/tianocore/edk2/issues/12363

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested
Use the GetMemoryAttributes function for testing.

## Integration Instructions
N/A
