### PR TITLE
ShellPkg/AcpiView: Avoid mutating HEST hardware bank count during parse

### DIFF
--- a/ShellPkg/Library/UefiShellAcpiViewCommandLib/Parsers/Hest/HestParser.c
+++ b/ShellPkg/Library/UefiShellAcpiViewCommandLib/Parsers/Hest/HestParser.c
@@ -2,6 +2,7 @@
   HEST table parser
 
   Copyright (c) 2024, Arm Limited.
+  Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
   @par Specification Reference:
@@ -16,9 +17,9 @@
 #include "AcpiView.h"
 
 STATIC ACPI_DESCRIPTION_HEADER_INFO  mAcpiHdrInfo;
-STATIC UINT32                        *mHestErrorSourceCount;
-STATIC UINT16                        *mHestErrorSourceType;
-STATIC UINT8                         *mHestIA32HardwareBankCount;
+STATIC CONST UINT32                  *mHestErrorSourceCount;
+STATIC CONST UINT16                  *mHestErrorSourceType;
+STATIC CONST UINT8                   *mHestIA32HardwareBankCount;
 
 /**
   An String array for Error Notification Structure's type.
@@ -550,8 +551,6 @@ DumpIA32ArchMachineCheckErrorBankStructure (
     *Offset +=
       sizeof (EFI_ACPI_6_5_IA32_ARCHITECTURE_MACHINE_CHECK_ERROR_BANK_STRUCTURE);
   }
-
-  *mHestIA32HardwareBankCount = 0;
 
   return EFI_SUCCESS;
 }


### PR DESCRIPTION
Remove post-parse write to mHestIA32HardwareBankCount.

Keep HEST parsing read-only.

# Description

*mHestIA32HardwareBankCount = 0 line in code corrupts the ACPI HEST table data Hardware bank count to zero.
mHestIA32HardwareBankCount points into the parsed HEST table data (input buffer). Writing through it modifies ACPI table contents during parsing, which should be read-only behavior.

- [ ] Breaking change?
  - No.
- [ ] Impacts security?
  - No.
- [ ] Includes tests?
  - No.
 
## How This Was Tested

Boot to UEFI shell without this change and run acpiview -s HEST. 
Boot to OS, HEST table is corrupted. dmesg shows errors for HEST.

Boot to UEFI shell with this change and run acpiview -s HEST. 
Boot to OS, HEST table is correct. dmesg shows no errors for HEST.
 
## Integration Instructions

