### PR TITLE
BaseTools: FMMT: Fix FFS replace no-op in LZMA guided section

### DIFF
--- a/BaseTools/Source/Python/FMMT/core/FvHandler.py
+++ b/BaseTools/Source/Python/FMMT/core/FvHandler.py
@@ -259,6 +259,17 @@ class FvHandler:
             elif len(CompressedData) > len(TargetTree.Data.OriData):
                 New_Pad_Size = GetPadSize(len(CompressedData), SECTION_COMMON_ALIGNMENT)
                 self.Remain_New_Free_Space = len(CompressedData) + New_Pad_Size - len(TargetTree.Data.OriData) - len(TargetTree.Data.PadData)
+                if self.Remain_New_Free_Space <= 0:
+                    # Update section header size to reflect the new compressed data length.
+                    Size_delta = len(CompressedData) - len(TargetTree.Data.OriData)
+                    ChangeSize(TargetTree, -Size_delta)
+                    # Recalculate PadData to keep alignment with the new compressed size.
+                    if TargetTree.NextRel:
+                        TargetTree.Data.PadData = b'\x00' * New_Pad_Size
+                    else:
+                        TargetTree.Data.PadData = b''
+                    # Commit the new compressed blob so Encapsulation writes the updated content.
+                    TargetTree.Data.OriData = CompressedData
                 self.Status = True
                 self.ModifyTest(TargetTree, self.Remain_New_Free_Space)
 


### PR DESCRIPTION
# Description

When replacing an FFS whose LZMA recompression delta exactly fits within the existing PadData (Remain_New_Free_Space == 0), the output binary was byte-for-byte identical to the input, the merge appeared to succeed but no change was written.

Root cause: in the 'CompressedData > OriData' branch of 'CompressSectionData', 'TargetTree.Data.OriData' was never updated before calling 'ModifyTest'. With 'Remain_New_Free_Space == 0', 'ModifyTest' falls into the 'else' branch and calls 'CompressData()', which is a no-op because 'Status' is already 'True', leaving the stale LZMA blob in place.

Fix: pre-update 'OriData', 'ChangeSize', and 'PadData' when 'Remain_New_Free_Space <= 0', guarded so the '> 0' path (which relies on 'ModifyTest' to propagate the update up the tree) is unaffected.

| OriData   | CompressedData | Delta | Remain_New_Free_Space | Before Fix                        | After Fix         |
|-----------|----------------|-------|-----------------------|-----------------------------------|-------------------|
| 1,441,373 | 1,441,376      | +3    | 0 (absorbed by Pad)   | no-op: output identical to input  | driver updated    |
| 1,441,373 | 1,441,579      | +206  | +204                  | working: delta propagated up tree | no regression     |

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

**Before fix:** input BIOS and output BIOS were byte-for-byte identical during FMMT replace operation (verified with binary comparison).
**After fix:** the files differ and the updated driver is present in the output image as confirmed by re-parsing output with FMMT.

## Integration Instructions

N/A
