### PR TITLE
3945_arm_cca_v5_s3: Initial patches for enabling RME support

### DIFF
--- a/EmbeddedPkg/Library/PrePiMemoryAllocationLib/MemoryAllocationLib.c
+++ b/EmbeddedPkg/Library/PrePiMemoryAllocationLib/MemoryAllocationLib.c
@@ -282,6 +282,40 @@ FreePages (
 }
 
 /**
+  Frees one or more 4KB pages that were previously allocated with one of the aligned page
+  allocation functions in the Memory Allocation Library.
+
+  Frees the number of 4KB pages specified by Pages from the buffer specified by Buffer.  Buffer
+  must have been allocated on a previous call to the aligned page allocation services of the Memory
+  Allocation Library.  If it is not possible to free allocated pages, then this function will
+  perform no actions.
+
+  If Buffer was not allocated with an aligned page allocation function in the Memory Allocation
+  Library, then ASSERT().
+  If Pages is zero, then ASSERT().
+
+  @param  Buffer                Pointer to the buffer of pages to free.
+  @param  Pages                 The number of 4 KB pages to free.
+
+**/
+VOID
+EFIAPI
+FreeAlignedPages (
+  IN VOID   *Buffer,
+  IN UINTN  Pages
+  )
+{
+  ASSERT (ADDRESS_IS_ALIGNED (Buffer, EFI_PAGE_SIZE));
+  ASSERT (Pages != 0);
+  // For now, we do not support the ability to free pages in the PrePei Memory Allocator.
+  // The allocated memory is lost.
+  DEBUG ((
+    DEBUG_INFO,
+    "PrePei allocator cannot free pages; allocated memory is not reclaimed.\n"
+    ));
+}
+
+/**
   Allocates a buffer of type EfiBootServicesData.
 
   Allocates the number bytes specified by AllocationSize of type EfiBootServicesData and returns a

--- a/MdePkg/Include/AArch64/AArch64.h
+++ b/MdePkg/Include/AArch64/AArch64.h
@@ -36,6 +36,7 @@
 // ID_AA64PFR0 - AArch64 Processor Feature Register 0 definitions
 #define AARCH64_PFR0_FP   (0xF << 16)
 #define AARCH64_PFR0_GIC  (0xF << 24)
+#define AARCH64_PFR0_RME  (0xFULL << 52)
 
 // ID_AA64PFR2 - AArch64 Processor Feature Register 2 definitions
 #define AARCH64_PFR2_GCIE  (0xF << 12)

--- a/MdePkg/Include/Library/ArmLib.h
+++ b/MdePkg/Include/Library/ArmLib.h
@@ -1,7 +1,7 @@
 /** @file
 
   Copyright (c) 2008 - 2009, Apple Inc. All rights reserved.<BR>
-  Copyright (c) 2011 - 2016, ARM Ltd. All rights reserved.<BR>
+  Copyright (c) 2011 - 2023, Arm Limited. All rights reserved.<BR>
   Copyright (c) 2020 - 2021, NUVIA Inc. All rights reserved.<BR>
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -719,5 +719,16 @@ ArmHasEte (
 BOOLEAN
 EFIAPI
 ArmHas52BitTgran4 (
+  VOID
+  );
+
+/** Checks if RME is implemented.
+
+   @retval TRUE  RME is implemented.
+   @retval FALSE RME is not implemented.
+**/
+BOOLEAN
+EFIAPI
+ArmHasRme (
   VOID
   );

--- a/MdePkg/Library/ArmLib/AArch64/AArch64Lib.c
+++ b/MdePkg/Library/ArmLib/AArch64/AArch64Lib.c
@@ -1,7 +1,7 @@
 /** @file
 
   Copyright (c) 2008 - 2009, Apple Inc. All rights reserved.<BR>
-  Portions copyright (c) 2011 - 2014, ARM Ltd. All rights reserved.<BR>
+  Portions copyright (c) 2011 - 2023, Arm Limited. All rights reserved.<BR>
   Copyright (c) 2021, NUVIA Inc. All rights reserved.<BR>
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -126,4 +126,18 @@ ArmHas52BitTgran4 (
   Mmfr0 = ArmReadIdAA64Mmfr0 ();
 
   return ((Mmfr0 & AARCH64_MMFR0_TGRAN4_MASK) == AARCH64_MMFR0_TGRAN4_52BITS);
+}
+
+/** Checks if RME is implemented.
+
+   @retval TRUE  RME is implemented.
+   @retval FALSE RME is not implemented.
+**/
+BOOLEAN
+EFIAPI
+ArmHasRme (
+  VOID
+  )
+{
+  return ((ArmReadIdAA64Pfr0 () & AARCH64_PFR0_RME) != 0);
 }

--- a/UefiCpuPkg/Include/Library/ArmMmuLib.h
+++ b/UefiCpuPkg/Include/Library/ArmMmuLib.h
@@ -82,3 +82,54 @@ BOOLEAN
 ArmLpa2Enabled (
   VOID
   );
+
+/**
+  Configure the protection attribute for the page tables
+  describing the memory region.
+
+  The IPA space of a Realm is divided into two halves:
+    - Protected IPA space and
+    - Unprotected IPA space.
+
+  Software in a Realm should treat the most significant bit of an
+  IPA as a protection attribute.
+
+  A Protected IPA is an address in the lower half of a Realms IPA
+  space. The most significant bit of a Protected IPA is 0.
+
+  An Unprotected IPA is an address in the upper half of a Realms
+  IPA space. The most significant bit of an Unprotected IPA is 1.
+
+  Note:
+  - Configuring the memory region as Unprotected IPA enables the
+    Realm to share the memory region with the Host.
+  - This function updates the page table entries to reflect the
+    protection attribute.
+  - A separate call to transition the memory range using the Realm
+    Service Interface (RSI) RSI_IPA_STATE_SET command is additionally
+    required and is expected to be done outside this function.
+  - The caller must ensure that this function call is invoked by code
+    executing within the Realm.
+
+    @param [in]  BaseAddress  Base address of the memory region.
+    @param [in]  Length       Length of the memory region.
+    @param [in]  IpaWidth     IPA width of the Realm.
+    @param [in]  Share        If TRUE, set the most significant
+                              bit of the IPA to configure the memory
+                              region as Unprotected IPA.
+                              If FALSE, clear the most significant
+                              bit of the IPA to configure the memory
+                              region as Protected IPA.
+
+    @retval EFI_SUCCESS            IPA protection attribute updated.
+    @retval EFI_INVALID_PARAMETER  A parameter is invalid.
+    @retval EFI_UNSUPPORTED        RME is not supported.
+**/
+EFI_STATUS
+EFIAPI
+ArmCcaSetMemoryProtectionAttribute (
+  IN  EFI_PHYSICAL_ADDRESS  BaseAddress,
+  IN  UINT64                Length,
+  IN  UINT64                IpaWidth,
+  IN  BOOLEAN               Share
+  );

--- a/UefiCpuPkg/Library/ArmMmuLib/AArch64/ArmMmuLibCore.c
+++ b/UefiCpuPkg/Library/ArmMmuLib/AArch64/ArmMmuLibCore.c
@@ -523,10 +523,26 @@ FillTranslationTable (
   IN  BOOLEAN                       Lpa2Enabled
   )
 {
+  UINT64  CcaProtectionAttribute;
+
+  //
+  // The CCA protection attribute corresponds to the (IPA_WIDTH - 1) bit of the
+  // Realm address space. The VA and PA for a region are expected to differ only
+  // in this bit. Derive the attribute by XORing the two addresses.
+  //
+  // NOTE: If more than one bit differs, the memory map is misconfigured.
+  //
+  CcaProtectionAttribute = MemoryRegion->VirtualBase ^ MemoryRegion->PhysicalBase;
+
+  //
+  // Ensure only one bit is set.
+  //
+  ASSERT (((CcaProtectionAttribute & (CcaProtectionAttribute - 1)) == 0));
+
   return UpdateRegionMapping (
            MemoryRegion->VirtualBase,
            MemoryRegion->Length,
-           ArmMemoryAttributeToPageAttribute (MemoryRegion->Attributes) | TT_AF,
+           ArmMemoryAttributeToPageAttribute (MemoryRegion->Attributes) | TT_AF | CcaProtectionAttribute,
            0,
            RootTable,
            FALSE,

--- a/UefiCpuPkg/Library/ArmMmuLib/AArch64/ArmMmuLibCore.c
+++ b/UefiCpuPkg/Library/ArmMmuLib/AArch64/ArmMmuLibCore.c
@@ -1,11 +1,20 @@
 /** @file
 *  File managing the MMU for ARMv8 architecture
 *
-*  Copyright (c) 2011-2025, ARM Limited. All rights reserved.
+*  Copyright (c) 2011-2026, ARM Limited. All rights reserved.
 *  Copyright (c) 2016, Linaro Limited. All rights reserved.
 *  Copyright (c) 2017, Intel Corporation. All rights reserved.<BR>
 *
 *  SPDX-License-Identifier: BSD-2-Clause-Patent
+*
+*  @par Glossary:
+*    - Rsi or RSI   - Realm Service Interface
+*    - IPA          - Intermediate Physical Address
+*    - RIPAS        - Realm IPA state
+*
+*  @par Reference(s):
+*   - Realm Management Monitor (RMM) Specification, version 1.0-rel0
+*     (https://developer.arm.com/documentation/den0137/)
 *
 **/
 
@@ -102,14 +111,18 @@ VOID
 SetOutputAddress (
   IN  UINTN    *Entry,
   IN  UINTN    Address,
-  IN  BOOLEAN  Lpa2Enabled
+  IN  BOOLEAN  Lpa2Enabled,
+  IN  UINT64   CcaProtectionAttribute
   )
 {
+  /*
+   * Preserve the CCA protection attribute bit.
+   */
   if (Lpa2Enabled) {
-    *Entry &= ~(TT_ADDRESS_MASK_BLOCK_ENTRY_LPA2 | TT_UPPER_ADDRESS_MASK);
+    *Entry &= (~(TT_ADDRESS_MASK_BLOCK_ENTRY_LPA2 | TT_UPPER_ADDRESS_MASK) | CcaProtectionAttribute);
     *Entry |= ((UINTN)Address & TT_ADDRESS_MASK_BLOCK_ENTRY_LPA2) | (((UINTN)Address >> 50) << 8);
   } else {
-    *Entry &= ~TT_ADDRESS_MASK_BLOCK_ENTRY;
+    *Entry &= (~TT_ADDRESS_MASK_BLOCK_ENTRY | CcaProtectionAttribute);
     *Entry |= (Address & TT_ADDRESS_MASK_BLOCK_ENTRY);
   }
 }
@@ -118,13 +131,18 @@ STATIC
 UINT64
 GetOutputAddress (
   IN  UINT64   Entry,
-  IN  BOOLEAN  Lpa2Enabled
+  IN  BOOLEAN  Lpa2Enabled,
+  IN  UINT64   CcaProtectionAttribute
   )
 {
+  /*
+   * Preserve the CCA protection attribute bit.
+   */
   if (Lpa2Enabled) {
-    return (Entry & TT_ADDRESS_MASK_BLOCK_ENTRY_LPA2) | ((Entry & TT_UPPER_ADDRESS_MASK) << (50 - 8));
+    return (Entry & TT_ADDRESS_MASK_BLOCK_ENTRY_LPA2) | ((Entry & TT_UPPER_ADDRESS_MASK) << (50 - 8)) |
+           (Entry & CcaProtectionAttribute);
   } else {
-    return Entry & TT_ADDRESS_MASK_BLOCK_ENTRY;
+    return Entry & (TT_ADDRESS_MASK_BLOCK_ENTRY | CcaProtectionAttribute);
   }
 }
 
@@ -199,7 +217,8 @@ VOID
 FreePageTablesRecursive (
   IN  UINT64   *TranslationTable,
   IN  UINTN    Level,
-  IN  BOOLEAN  Lpa2Enabled
+  IN  BOOLEAN  Lpa2Enabled,
+  IN  UINT64   CcaProtectionAttribute
   )
 {
   UINTN  Index;
@@ -212,10 +231,12 @@ FreePageTablesRecursive (
         FreePageTablesRecursive (
           (VOID *)GetOutputAddress (
                     TranslationTable[Index],
-                    Lpa2Enabled
+                    Lpa2Enabled,
+                    CcaProtectionAttribute
                     ),
           Level + 1,
-          Lpa2Enabled
+          Lpa2Enabled,
+          CcaProtectionAttribute
           );
       }
     }
@@ -267,7 +288,8 @@ UpdateRegionMappingRecursive (
   IN  INTN     Level,
   IN  BOOLEAN  IsRootTable,
   IN  BOOLEAN  TableIsLive,
-  IN  BOOLEAN  Lpa2Enabled
+  IN  BOOLEAN  Lpa2Enabled,
+  IN  UINT64   CcaProtectionAttribute
   )
 {
   UINTN       BlockShift;
@@ -359,7 +381,7 @@ UpdateRegionMappingRecursive (
             TablesToFree[1] = TranslationTable;
           }
 
-          TranslationTable = (VOID *)GetOutputAddress (*Entry, Lpa2Enabled);
+          TranslationTable = (VOID *)GetOutputAddress (*Entry, Lpa2Enabled, CcaProtectionAttribute);
           NextTableIsLive  = TableIsLive;
         } else {
           if (!ArmMmuEnabled ()) {
@@ -386,7 +408,8 @@ UpdateRegionMappingRecursive (
                        Level + 1,
                        FALSE,
                        FALSE,
-                       Lpa2Enabled
+                       Lpa2Enabled,
+                       CcaProtectionAttribute
                        );
             if (EFI_ERROR (Status)) {
               //
@@ -402,7 +425,7 @@ UpdateRegionMappingRecursive (
           NextTableIsLive = FALSE;
         }
       } else {
-        TranslationTable = (VOID *)GetOutputAddress (*Entry, Lpa2Enabled);
+        TranslationTable = (VOID *)GetOutputAddress (*Entry, Lpa2Enabled, CcaProtectionAttribute);
         NextTableIsLive  = TableIsLive;
       }
 
@@ -418,7 +441,8 @@ UpdateRegionMappingRecursive (
                  Level + 1,
                  FALSE,
                  NextTableIsLive,
-                 Lpa2Enabled
+                 Lpa2Enabled,
+                 CcaProtectionAttribute
                  );
       if (EFI_ERROR (Status)) {
         if (!IsTableEntry (*Entry, Level)) {
@@ -429,7 +453,7 @@ UpdateRegionMappingRecursive (
           // possible for existing table entries, since we cannot revert the
           // modifications we made to the subhierarchy it represents.)
           //
-          FreePageTablesRecursive (TranslationTable, Level + 1, Lpa2Enabled);
+          FreePageTablesRecursive (TranslationTable, Level + 1, Lpa2Enabled, CcaProtectionAttribute);
         }
 
         return Status;
@@ -437,7 +461,7 @@ UpdateRegionMappingRecursive (
 
       if (!IsTableEntry (*Entry, Level)) {
         EntryValue = TT_TYPE_TABLE_ENTRY;
-        SetOutputAddress (&EntryValue, (UINTN)TranslationTable, Lpa2Enabled);
+        SetOutputAddress (&EntryValue, (UINTN)TranslationTable, Lpa2Enabled, CcaProtectionAttribute);
 
         ReplaceTableEntry (
           Entry,
@@ -450,7 +474,7 @@ UpdateRegionMappingRecursive (
     } else {
       EntryValue = (*Entry & AttributeClearMask) | AttributeSetMask;
       // Below clears shareability bits when LPA2 is in use
-      SetOutputAddress (&EntryValue, RegionStart, Lpa2Enabled);
+      SetOutputAddress (&EntryValue, RegionStart, Lpa2Enabled, CcaProtectionAttribute);
       EntryValue |= (Level == 3) ? TT_TYPE_BLOCK_ENTRY_LEVEL3
                                  : TT_TYPE_BLOCK_ENTRY;
 
@@ -484,7 +508,8 @@ UpdateRegionMapping (
   IN  UINT64   AttributeClearMask,
   IN  UINT64   *RootTable,
   IN  BOOLEAN  TableIsLive,
-  IN  BOOLEAN  Lpa2Enabled
+  IN  BOOLEAN  Lpa2Enabled,
+  IN  UINT64   CcaProtectionAttribute
   )
 {
   UINTN  T0SZ;
@@ -511,7 +536,8 @@ UpdateRegionMapping (
            GetRootTableLevel (T0SZ),
            TRUE,
            TableIsLive,
-           Lpa2Enabled
+           Lpa2Enabled,
+           CcaProtectionAttribute
            );
 }
 
@@ -546,7 +572,8 @@ FillTranslationTable (
            0,
            RootTable,
            FALSE,
-           Lpa2Enabled
+           Lpa2Enabled,
+           CcaProtectionAttribute
            );
 }
 
@@ -677,7 +704,8 @@ ArmSetMemoryAttributes (
            PageAttributeMask,
            ArmGetTTBR0BaseAddress (),
            TRUE,
-           ArmLpa2Enabled ()
+           ArmLpa2Enabled (),
+           0
            );
 }
 
@@ -922,4 +950,125 @@ ArmMmuBaseLibConstructor (
   }
 
   return RETURN_SUCCESS;
+}
+
+/**
+  Configure the protection attribute for the page tables
+  describing the memory region.
+
+  The IPA space of a Realm is divided into two halves:
+    - Protected IPA space and
+    - Unprotected IPA space.
+
+  Software in a Realm should treat the most significant bit of an
+  IPA as a protection attribute.
+
+  A Protected IPA is an address in the lower half of a Realms IPA
+  space. The most significant bit of a Protected IPA is 0.
+
+  An Unprotected IPA is an address in the upper half of a Realms
+  IPA space. The most significant bit of an Unprotected IPA is 1.
+
+  Note:
+  - Configuring the memory region as Unprotected IPA enables the
+    Realm to share the memory region with the Host.
+  - This function updates the page table entries to reflect the
+    protection attribute.
+  - A separate call to transition the memory range using the Realm
+    Service Interface (RSI) RSI_IPA_STATE_SET command is additionally
+    required and is expected to be done outside this function.
+  - The caller must ensure that this function call is invoked by code
+    executing within the Realm.
+
+    @param [in]  BaseAddress  Base address of the memory region.
+    @param [in]  Length       Length of the memory region.
+    @param [in]  IpaWidth     IPA width of the Realm.
+    @param [in]  Share        If TRUE, set the most significant
+                              bit of the IPA to configure the memory
+                              region as Unprotected IPA.
+                              If FALSE, clear the most significant
+                              bit of the IPA to configure the memory
+                              region as Protected IPA.
+
+    @retval EFI_SUCCESS            IPA protection attribute updated.
+    @retval EFI_INVALID_PARAMETER  A parameter is invalid.
+    @retval EFI_UNSUPPORTED        RME is not supported.
+**/
+EFI_STATUS
+EFIAPI
+ArmCcaSetMemoryProtectionAttribute (
+  IN  EFI_PHYSICAL_ADDRESS  BaseAddress,
+  IN  UINT64                Length,
+  IN  UINT64                IpaWidth,
+  IN  BOOLEAN               Share
+  )
+{
+  UINT64  Attributes;
+  UINT64  Mask;
+  UINT64  CcaProtectionAttribute;
+  UINT64  TopBits;
+  UINT64  MaxAddressBits;
+
+  if ((Length == 0) || (IpaWidth == 0) ||
+      !IS_ALIGNED (Length, EFI_PAGE_SIZE) ||
+      !IS_ALIGNED (BaseAddress, EFI_PAGE_SIZE))
+  {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (!ArmHasRme ()) {
+    return EFI_UNSUPPORTED;
+  }
+
+  if (ArmHas52BitTgran4 ()) {
+    MaxAddressBits = MIN (ArmGetPhysicalAddressBits (), MAX_VA_BITS);
+  } else {
+    MaxAddressBits = MIN (ArmGetPhysicalAddressBits (), MAX_VA_BITS_48);
+  }
+
+  if (IpaWidth > MaxAddressBits) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  CcaProtectionAttribute = 1ULL << (IpaWidth - 1);
+
+  if (ArmLpa2Enabled ()) {
+    /*
+     * For LPA2, the top IPA bits (e.g., bits 50..51) map into upper page table
+     * attributes in a packed form. Extract those top IPA bits and move them to
+     * the encoding expected in the Attributes field.
+     *
+     * TopBits calculation: use BIT51|BIT50 to detect whether the protection bit
+     * sits in the top IPA range, then translate to the TTBR/LPA2 attribute
+     * position. (See ARM ARM: translation-table entry formats for LPA2).
+     */
+    TopBits = CcaProtectionAttribute & (BIT51 | BIT50);
+    if (TopBits != 0) {
+      CcaProtectionAttribute = ((TopBits >> 0x32) & 0x3) << 8;
+    }
+  }
+
+  if (Share) {
+    Attributes = CcaProtectionAttribute;
+  } else {
+    Attributes = 0;
+  }
+
+  if (ArmLpa2Enabled ()) {
+    Mask = ~(TT_ADDRESS_MASK_BLOCK_ENTRY_LPA2 | TT_UPPER_ADDRESS_MASK |
+             CcaProtectionAttribute);
+  } else {
+    Mask = ~(TT_ADDRESS_MASK_BLOCK_ENTRY | CcaProtectionAttribute);
+  }
+
+  return UpdateRegionMapping (
+           BaseAddress,
+           Length,
+           Attributes,
+           Mask,
+           ArmGetTTBR0BaseAddress (),
+           TRUE,
+           ArmLpa2Enabled (),
+           CcaProtectionAttribute
+           );
 }


### PR DESCRIPTION
# Initial patches for enabling RME support

This is an initial set of patches that:
- Implement a helper function to detect RME support
- Add an API to set/clear the Arm CCA memory protect attribute bit in the page tables
- Preserve the Realm protection attribute bit
- Add a missing implementation of FreeAlignedPages() in PrePiMemoryAllocationLib.

Note: This is a PR series that includes patches from PR https://github.com/tianocore/edk2/pull/12224

- [ ] Breaking change?
  - NO
- [ ] Impacts security?
  - NO
- [ ] Includes tests?
  - No explicit test, run Kvmtool guest firmware.

## How This Was Tested
Only build tested.  Actual functionality can only be tested when the remaining patches from PR https://github.com/tianocore/edk2/pull/12224 are integrated in the future.

## Integration Instructions
N/A
