### PR TITLE
.mergify/config.yml: Use rebase for update_method

### DIFF
--- a/.mergify/config.yml
+++ b/.mergify/config.yml
@@ -34,6 +34,7 @@ queue_rules:
       - label=push
     merge_method: rebase
     update_bot_account: tianocore-issues
+    update_method: rebase
 
 pull_request_rules:
   - name: Automatically merge a PR when all required checks pass and 'push' label is present


### PR DESCRIPTION
# Description

The mergify configuration file documentation \[1\] says:

1. `update_method` is a queue rule that is the "method to use to update the pull request with its base branch when the check is done in place"
2. `update_method` has the following possible values:
   - `null` (default)
   - `merge`
   - `rebase`
3. "When `null`, defaults to `merge` except if `merge_method` is `fast-forward` then it defaults to `rebase`.

Today, mergify makes merge commits into PR branches instead of rebases. We would prefer rebases were done instead.

It is difficult to test mergify configuration changes because it only applies when in the default branch (master). This change is made to attempt to perform rebases per the documentation.

\[1\]: https://docs.mergify.com/configuration/file-format/

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

- Like in the past, mergify config changes are typically verified once merged and activated.

## Integration Instructions

- N/A