### PR TITLE
MdeModulePkg/Core/Dxe: Fix HeapGuard mem bin conflict

### DIFF
--- a/MdeModulePkg/Core/Dxe/Mem/HeapGuard.c
+++ b/MdeModulePkg/Core/Dxe/Mem/HeapGuard.c
@@ -817,18 +817,30 @@ UnsetGuardForMemory (
   @param[in]  Start           Start address of free memory block.
   @param[in]  Size            Size of free memory block.
   @param[in]  SizeRequested   Size of memory to allocate.
+  @param[out] GuardedStart    Start address of required range including
+                              any needed guard page.
+  @param[out] GuardedEnd      End address of required range including
+                              any needed guard page.
 
   @return The end address of memory block found.
   @return 0 if no enough space for the required size of memory and its Guard.
 **/
 UINT64
 AdjustMemoryS (
-  IN UINT64  Start,
-  IN UINT64  Size,
-  IN UINT64  SizeRequested
+  IN UINT64   Start,
+  IN UINT64   Size,
+  IN UINT64   SizeRequested,
+  OUT UINT64  *GuardedStart,
+  OUT UINT64  *GuardedEnd
   )
 {
-  UINT64  Target;
+  UINT64   Target;
+  BOOLEAN  NeedHeadGuard;
+  BOOLEAN  NeedTailGuard;
+
+  if ((GuardedStart == NULL) || (GuardedEnd == NULL)) {
+    return 0;
+  }
 
   //
   // UEFI spec requires that allocated pool must be 8-byte aligned. If it's
@@ -845,7 +857,8 @@ AdjustMemoryS (
     return 0;
   }
 
-  if (!IsGuardPage (Start + Size)) {
+  NeedTailGuard = !IsGuardPage (Start + Size);
+  if (NeedTailGuard) {
     // No Guard at tail to share. One more page is needed.
     Target -= EFI_PAGES_TO_SIZE (1);
   }
@@ -862,6 +875,11 @@ AdjustMemoryS (
       return 0;
     }
   }
+
+  NeedHeadGuard = !IsGuardPage (Target - EFI_PAGES_TO_SIZE (1));
+
+  *GuardedStart = NeedHeadGuard ? (Target - EFI_PAGES_TO_SIZE (1)) : Target;
+  *GuardedEnd   = NeedTailGuard ? (Target + SizeRequested) : (Target + SizeRequested - 1);
 
   // OK, we have enough pages for memory and its Guards. Return the End of the
   // free space.

--- a/MdeModulePkg/Core/Dxe/Mem/HeapGuard.h
+++ b/MdeModulePkg/Core/Dxe/Mem/HeapGuard.h
@@ -278,15 +278,21 @@ AdjustMemoryF (
   @param[in]  Start           Start address of free memory block.
   @param[in]  Size            Size of free memory block.
   @param[in]  SizeRequested   Size of memory to allocate.
+  @param[out] GuardedStart    Start address of required range including
+                              any needed guard page.
+  @param[out] GuardedEnd      End address of required range including
+                              any needed guard page.
 
   @return The end address of memory block found.
   @return 0 if no enough space for the required size of memory and its Guard.
 **/
 UINT64
 AdjustMemoryS (
-  IN UINT64  Start,
-  IN UINT64  Size,
-  IN UINT64  SizeRequested
+  IN UINT64   Start,
+  IN UINT64   Size,
+  IN UINT64   SizeRequested,
+  OUT UINT64  *GuardedStart,
+  OUT UINT64  *GuardedEnd
   );
 
 /**

--- a/MdeModulePkg/Core/Dxe/Mem/Imem.h
+++ b/MdeModulePkg/Core/Dxe/Mem/Imem.h
@@ -116,6 +116,21 @@ CoreReleaseMemoryLock (
   VOID
   );
 
+//
+// Entry for tracking the memory regions for each memory type to coalesce similar memory types
+//
+typedef struct {
+  EFI_PHYSICAL_ADDRESS    BaseAddress;
+  EFI_PHYSICAL_ADDRESS    MaximumAddress;
+  UINT64                  CurrentNumberOfPages;
+  UINT64                  NumberOfPages;
+  UINTN                   InformationIndex;
+  BOOLEAN                 Special;
+  BOOLEAN                 Runtime;
+} EFI_MEMORY_TYPE_STATISTICS;
+
+extern EFI_MEMORY_TYPE_STATISTICS  mMemoryTypeStatistics[EfiMaxMemoryType + 1];
+
 /**
   Allocates pages from the memory map.
 

--- a/MdeModulePkg/Core/Dxe/Mem/Page.c
+++ b/MdeModulePkg/Core/Dxe/Mem/Page.c
@@ -11,18 +11,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include "HeapGuard.h"
 #include <Pi/PiDxeCis.h>
 
-//
-// Entry for tracking the memory regions for each memory type to coalesce similar memory types
-//
-typedef struct {
-  EFI_PHYSICAL_ADDRESS    BaseAddress;
-  EFI_PHYSICAL_ADDRESS    MaximumAddress;
-  UINT64                  CurrentNumberOfPages;
-  UINT64                  NumberOfPages;
-  UINTN                   InformationIndex;
-  BOOLEAN                 Special;
-  BOOLEAN                 Runtime;
-} EFI_MEMORY_TYPE_STATISTICS;
+// EFI_MEMORY_TYPE_STATISTICS typedef is in Imem.h (shared with HeapGuard.c)
 
 //
 // MemoryMap - The current memory map
@@ -164,6 +153,51 @@ MemoryRegionsIntersect (
   ASSERT (Start2 <= End2);
 
   return ((Start1 <= End2) && (Start2 <= End1));
+}
+
+/**
+  Validate that an allocation range does not overlap any non-matching special
+  memory type bin.
+
+  @param[in]  Start    Start address of allocation range to validate.
+  @param[in]  End      End address of allocation range to validate.
+  @param[in]  NewType  Requested memory type for the allocation.
+
+  @retval TRUE   Allocation range is valid for NewType.
+  @retval FALSE  Allocation range overlaps a non-matching special bin.
+**/
+static
+BOOLEAN
+RangeFitsSpecialBins (
+  IN EFI_PHYSICAL_ADDRESS  Start,
+  IN EFI_PHYSICAL_ADDRESS  End,
+  IN EFI_MEMORY_TYPE       NewType
+  )
+{
+  EFI_MEMORY_TYPE  CheckType;
+
+  ASSERT (Start <= End);
+
+  for (CheckType = (EFI_MEMORY_TYPE)0; CheckType < EfiMaxMemoryType; CheckType++) {
+    if ((CheckType == NewType) ||
+        !mMemoryTypeStatistics[CheckType].Special ||
+        (mMemoryTypeStatistics[CheckType].NumberOfPages == 0))
+    {
+      continue;
+    }
+
+    if (MemoryRegionsIntersect (
+          Start,
+          End,
+          mMemoryTypeStatistics[CheckType].BaseAddress,
+          mMemoryTypeStatistics[CheckType].MaximumAddress
+          ))
+    {
+      return FALSE;
+    }
+  }
+
+  return TRUE;
 }
 
 /**
@@ -735,6 +769,7 @@ CoreAddMemoryDescriptor (
   UINTN                 FreeIndex;
   UINT64                Alignment;
   UINT64                BinSize;
+  BOOLEAN               OldOnGuarding;
 
   if ((Start & EFI_PAGE_MASK) != 0) {
     return;
@@ -799,14 +834,22 @@ CoreAddMemoryDescriptor (
       gMemoryTypeInformation[Index].NumberOfPages = (UINT32)EFI_SIZE_TO_PAGES ((UINTN)BinSize);
 
       //
-      // Allocate pages for the current memory type from the top of available memory
+      // Allocate pages for the current memory type from the top of available memory.
+      // Suppress HeapGuard for bin setup -- these are pre-reserved ranges, not
+      // individual allocations that need overflow detection.  Guard pages on bin
+      // allocations would be freed in Phase 3 and reused by other types, causing
+      // cross-type CoreMemoryMapSanityCheck violations.  Consumer allocations
+      // within bins still get full guard protection.
       //
-      Status = CoreAllocatePages (
-                 AllocateAnyPages,
-                 Type,
-                 gMemoryTypeInformation[Index].NumberOfPages,
-                 &mMemoryTypeStatistics[Type].BaseAddress
-                 );
+      OldOnGuarding = mOnGuarding;
+      mOnGuarding   = TRUE;
+      Status        = CoreAllocatePages (
+                        AllocateAnyPages,
+                        Type,
+                        gMemoryTypeInformation[Index].NumberOfPages,
+                        &mMemoryTypeStatistics[Type].BaseAddress
+                        );
+      mOnGuarding = OldOnGuarding;
       if (EFI_ERROR (Status)) {
         //
         // If an error occurs allocating the pages for the current memory type, then
@@ -1233,6 +1276,8 @@ CoreFindFreePagesI (
   UINT64      DescStart;
   UINT64      DescEnd;
   UINT64      DescNumberOfBytes;
+  UINT64      GuardedStart;
+  UINT64      GuardedEnd;
   LIST_ENTRY  *Link;
   MEMORY_MAP  *Entry;
 
@@ -1327,9 +1372,15 @@ CoreFindFreePagesI (
           DescEnd = AdjustMemoryS (
                       DescEnd + 1 - DescNumberOfBytes,
                       DescNumberOfBytes,
-                      NumberOfBytes
+                      NumberOfBytes,
+                      &GuardedStart,
+                      &GuardedEnd
                       );
           if (DescEnd == 0) {
+            continue;
+          }
+
+          if (!RangeFitsSpecialBins (GuardedStart, GuardedEnd, NewType)) {
             continue;
           }
         }
@@ -1481,8 +1532,11 @@ CoreInternalAllocatePages (
   UINT64           Start;
   UINT64           NumberOfBytes;
   UINT64           End;
+  UINT64           GuardedStart;
+  UINT64           GuardedEnd;
   UINT64           MaxAddress;
   UINTN            Alignment;
+  UINTN            GuardedPages;
   EFI_MEMORY_TYPE  CheckType;
 
   if ((UINT32)Type >= MaxAllocateType) {
@@ -1601,6 +1655,20 @@ CoreInternalAllocatePages (
         {
           return EFI_NOT_FOUND;
         }
+      }
+    }
+
+    if (NeedGuard) {
+      GuardedStart = Start;
+      GuardedPages = NumberOfPages;
+      AdjustMemoryA (&GuardedStart, &GuardedPages);
+      GuardedEnd = GuardedStart + EFI_PAGES_TO_SIZE (GuardedPages) - 1;
+
+      if ((GuardedStart > GuardedEnd) ||
+          (GuardedEnd > MaxAddress) ||
+          !RangeFitsSpecialBins (GuardedStart, GuardedEnd, MemoryType))
+      {
+        return EFI_NOT_FOUND;
       }
     }
   }


### PR DESCRIPTION
# Description

HeapGuard should not make memory type bin decisions.
Update AdjustMemoryS() to return the guard-expanded allocation range,
and let Page.c validate that range against special memory type bins.
Also apply the same validation to guarded AllocateAddress requests.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [x] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

CI workflows are running as expected and all checks pass.
Special pool tests also pass for all memory types.

## Integration Instructions

N/A
