### PR TITLE
BaseTools: Reject Inline Comments in tools_def

### DIFF
--- a/BaseTools/Source/Python/Common/ToolDefClassObject.py
+++ b/BaseTools/Source/Python/Common/ToolDefClassObject.py
@@ -108,6 +108,10 @@ class ToolDefClassObject(object):
             if Line == "" or Line[0] == '#':
                 continue
 
+            if '#' in Line:
+                EdkLogger.error("tools_def.txt parser", FILE_PARSE_FAILURE,
+                                "tools_def.txt: Inline comments are not allowed. Line: " + str(Index + 1))
+
             if Line.startswith("!include"):
                 IncFile = Line[8:].strip()
                 Done, IncFile = self.ExpandMacros(IncFile)


### PR DESCRIPTION
# Description

There is a bug in BaseTools currently when an inline comment is used in tools_def. The comment is not
stripped out and wreaks havoc down the line,
causing BaseTools to get confused elsewhere and
drop build options it should be applying.

This becomes very confusing to debug because build options are just suddenly missing.

This fixes that behavior by following the [build spec](https://tianocore-docs.github.io/edk2-BuildSpecification/draft/5_meta-data_file_specifications/52_tools_def_txt.html#52-tools-deftxt) which states:

`Comments are only allows on separate lines and may not be appended appear on actual entry lines.`

Now if an inline comment is encountered the build will fail with an explanation instead of randomly failing down the line:

<img width="821" height="370" alt="image" src="https://github.com/user-attachments/assets/7c794443-88f3-430f-a310-86656e49fef3" />

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Tested by adding an line comment to first `CLANGPDB_ALL_CC_FLAGS` and then `DEBUG_CLANGPDB_AARCH64_CC_FLAGS` in tools_def.txt and seeing `stuart_build -c ArmVirtPkg\PlatformCI\QemuBuild.py TOOL_CHAIN_TAG=CLANGPDB --clean` fail with flags dropped, e.g. for the first case it loses a lot flags, including the target:

```text
"clang" -MMD -MF D:\r\edk2\Build\ArmVirtQemu-AArch64\DEBUG_CLANGPDB\AARCH64\MdePkg\Library\UefiMemoryAllocationLib\UefiMemoryAllocationLib\OUTPUT\MemoryAllocationLib.obj.deps -g -Os -fshort-wchar -fno-builtin -fno-strict-aliasing -Wall -Werror -Wno-array-bounds -include AutoGen.h -fno-common -fstack-protector -ffunction-sections -fdata-sections -DSTRING_ARRAY_NAME=UefiMemoryAllocationLibStrings -Wno-parentheses-equality -Wno-tautological-compare -Wno-tautological-constant-out-of-range-compare -Wno-empty-body -Wno-varargs -Wno-unknown-warning-option -Wno-unaligned-access -Wno-microsoft-enum-forward-reference -fno-stack-protector -funsigned-char -ftrap-function=undefined_behavior_has_been_optimized_away_by_clang -Wno-address -Wno-shift-negative-value -Wno-unknown-pragmas -Wno-incompatible-library-redeclaration -Wno-null-dereference -mno-implicit-float -mms-bitfields -mno-stack-arg-probe -fno-omit-frame-pointer -D __GNUC__=4 -D __GNUC_MINOR__=2 -D __GNUC_PATCHLEVEL__=1 -D __MINGW32__=1 -c -o D:\r\edk2\Build\ArmVirtQemu-AArch64\DEBUG_CLANGPDB\AARCH64\MdePkg\Library\UefiMemoryAllocationLib\UefiMemoryAllocationLib\OUTPUT\.\MemoryAllocationLib.obj -ID:\r\edk2\MdePkg\Library\UefiMemoryAllocationLib  -ID:\r\edk2\Build\ArmVirtQemu-AArch64\DEBUG_CLANGPDB\AARCH64\MdePkg\Library\UefiMemoryAllocationLib\UefiMemoryAllocationLib\DEBUG  -ID:\r\edk2\MdePkg  -ID:\r\edk2\MdePkg\Include  -ID:\r\edk2\MdePkg\Test\UnitTest\Include  -ID:\r\edk2\MdePkg\Test\Mock\Include  -ID:\r\edk2\MdePkg\Library\MipiSysTLib\mipisyst\library\include  -ID:\r\edk2\MdePkg\Include\AArch64 D:\r\edk2\MdePkg\Library\UefiMemoryAllocationLib\MemoryAllocationLib.c
INFO - Building ... D:\r\edk2\ArmVirtPkg\Library\DebugLibFdtPL011Uart\DebugLibFdtPL011UartRam.inf [AARCH64]
INFO - clang: error: unsupported option '-mstrict-align' for target 'x86_64-pc-windows-msvc'
```

After this change, the build breaks with the inline comments and specifies why and where.

## Integration Instructions

N/A.
