### PR TITLE
UefiCpuPkg/BaseRiscVMmuLib: Support MMU page unmap

### DIFF
--- a/UefiCpuPkg/Library/BaseRiscVMmuLib/BaseRiscVMmuLib.c
+++ b/UefiCpuPkg/Library/BaseRiscVMmuLib/BaseRiscVMmuLib.c
@@ -440,7 +440,18 @@ UpdateRegionMappingRecursive (
       }
 
       EntryValue = SetPpnToPte (EntryValue, RegionStart);
-      EntryValue = SetValidPte (EntryValue);
+
+      //
+      // Unmapped memory regions must have the 'valid' bit cleared.
+      // This is because entries with 'valid' set and RWX clear are considered as "table entries"
+      // (non-leaves), and trigger the ASSERT above for reaching the leaf-level with a non-leaf.
+      //
+      if ((AttributeClearMask == PTE_ATTRIBUTES_MASK) && (AttributeSetMask == 0)) {
+        EntryValue &= ~RISCV_PG_V;
+      } else {
+        EntryValue = SetValidPte (EntryValue);
+      }
+
       ReplaceTableEntry (Entry, EntryValue, RegionStart, TableIsLive);
     }
   }

--- a/UefiCpuPkg/Library/BaseRiscVMmuLib/BaseRiscVMmuLib.c
+++ b/UefiCpuPkg/Library/BaseRiscVMmuLib/BaseRiscVMmuLib.c
@@ -532,6 +532,10 @@ GcdAttributeToPageAttribute (
   }
 
   // Determine protection attributes
+  if ((GcdAttributes & EFI_MEMORY_RP) != 0) {
+    *RiscVAttributes &= ~(UINT64)(RISCV_PG_R);
+  }
+
   if ((GcdAttributes & EFI_MEMORY_RO) != 0) {
     *RiscVAttributes &= ~(UINT64)(RISCV_PG_W);
   }


### PR DESCRIPTION
# Description

Add support for the EFI_MEMORY_RP GCD attribute, completing the support
for the standardised page attributes and thereby allowing common code to
unmap pages.

This fixes potential security vulnerabilities, as out of bounds memory
accesses can now be caught by the MMU.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [x] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

This was tested as part of https://github.com/tianocore/edk2/pull/12314

## Integration Instructions

N/A
