### PR TITLE
RedfishPkg/ConfigHandler: Remove [Depex] section from INF file

### DIFF
--- a/RedfishPkg/RedfishConfigHandler/RedfishConfigHandlerCommon.c
+++ b/RedfishPkg/RedfishConfigHandler/RedfishConfigHandlerCommon.c
@@ -3,6 +3,7 @@
 
   (C) Copyright 2021 Hewlett Packard Enterprise Development LP<BR>
   Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.<BR>
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -33,6 +34,18 @@ RedfishConfigOnEndOfDxe (
 {
   EFI_STATUS  Status;
 
+  //
+  // Locate Redfish Credential Protocol to get credential for
+  // accessing to Redfish service.
+  //
+  if (gCredential == NULL) {
+    Status = gBS->LocateProtocol (&gEdkIIRedfishCredentialProtocolGuid, NULL, (VOID **)&gCredential);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a: Failed to locate Redfish Credential Protocol.\n", __func__));
+      return;
+    }
+  }
+
   Status = gCredential->StopService (gCredential, ServiceStopTypeSecureBootDisabled);
   if (EFI_ERROR (Status) && (Status != EFI_UNSUPPORTED)) {
     DEBUG ((DEBUG_ERROR, "Redfish credential protocol failed to stop service on EndOfDxe: %r", Status));
@@ -60,6 +73,18 @@ RedfishConfigOnExitBootService (
   )
 {
   EFI_STATUS  Status;
+
+  //
+  // Locate Redfish Credential Protocol to get credential for
+  // accessing to Redfish service.
+  //
+  if (gCredential == NULL) {
+    Status = gBS->LocateProtocol (&gEdkIIRedfishCredentialProtocolGuid, NULL, (VOID **)&gCredential);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a: Failed to locate Redfish Credential Protocol.\n", __func__));
+      return;
+    }
+  }
 
   Status = gCredential->StopService (gCredential, ServiceStopTypeExitBootService);
   if (EFI_ERROR (Status) && (Status != EFI_UNSUPPORTED)) {
@@ -102,29 +127,15 @@ RedfishConfigDriverCommonUnload (
   This is the common code for Redfish configuration UEFI and DXE driver
   initialization.
 
-  @param[in]  ImageHandle       The firmware allocated handle for the UEFI image.
-  @param[in]  SystemTable       A pointer to the EFI System Table.
-
   @retval EFI_SUCCESS           The operation completed successfully.
   @retval Others                An unexpected error occurred.
 **/
 EFI_STATUS
 RedfishConfigCommonInit (
-  IN EFI_HANDLE        ImageHandle,
-  IN EFI_SYSTEM_TABLE  *SystemTable
+  VOID
   )
 {
   EFI_STATUS  Status;
-
-  //
-  // Locate Redfish Credential Protocol to get credential for
-  // accessing to Redfish service.
-  //
-  Status = gBS->LocateProtocol (&gEdkIIRedfishCredentialProtocolGuid, NULL, (VOID **)&gCredential);
-  if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: No Redfish Credential Protocol is installed on system.", __func__));
-    return Status;
-  }
 
   //
   // Create EndOfDxe Event.

--- a/RedfishPkg/RedfishConfigHandler/RedfishConfigHandlerCommon.h
+++ b/RedfishPkg/RedfishConfigHandler/RedfishConfigHandlerCommon.h
@@ -3,6 +3,7 @@
   and DXE driver.
 
   (C) Copyright 2021 Hewlett Packard Enterprise Development LP<BR>
+  Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.<BR>
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -63,16 +64,12 @@ RedfishConfigDriverCommonUnload (
   This is the common code for Redfish configuration UEFI and DXE driver
   initialization.
 
-  @param[in]  ImageHandle       The firmware allocated handle for the UEFI image.
-  @param[in]  SystemTable       A pointer to the EFI System Table.
-
   @retval EFI_SUCCESS           The operation completed successfully.
   @retval Others                An unexpected error occurred.
 **/
 EFI_STATUS
 RedfishConfigCommonInit (
-  IN EFI_HANDLE        ImageHandle,
-  IN EFI_SYSTEM_TABLE  *SystemTable
+  VOID
   );
 
 /**

--- a/RedfishPkg/RedfishConfigHandler/RedfishConfigHandlerDriver.c
+++ b/RedfishPkg/RedfishConfigHandler/RedfishConfigHandlerDriver.c
@@ -5,6 +5,7 @@
 
   Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
   (C) Copyright 2021 Hewlett Packard Enterprise Development LP<BR>
+  Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.<BR>
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -130,9 +131,10 @@ RedfishConfigDriverBindingSupported (
   IN EFI_DEVICE_PATH_PROTOCOL     *RemainingDevicePath OPTIONAL
   )
 {
-  EFI_REST_EX_PROTOCOL  *RestEx;
-  EFI_STATUS            Status;
-  EFI_HANDLE            ChildHandle;
+  EFI_REST_EX_PROTOCOL               *RestEx;
+  EFI_STATUS                         Status;
+  EFI_HANDLE                         ChildHandle;
+  EDKII_REDFISH_CREDENTIAL_PROTOCOL  *TestCredentialProtocol;
 
   ChildHandle = NULL;
 
@@ -171,6 +173,18 @@ RedfishConfigDriverBindingSupported (
     &gEfiRestExServiceBindingProtocolGuid,
     ChildHandle
     );
+
+  //
+  // Check if the Redfish credential protocol is installed or not.
+  //
+  Status = gBS->LocateProtocol (&gEdkIIRedfishCredentialProtocolGuid, NULL, (VOID **)&TestCredentialProtocol);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: No Redfish Credential Protocol is installed on system.", __func__));
+    return EFI_UNSUPPORTED;
+  }
+
+  DEBUG ((DEBUG_MANAGEABILITY, "%a: Redfish Credential Protocol is found.\n", __func__));
+
   return Status;
 }
 
@@ -331,6 +345,7 @@ RedfishServiceDiscoveredCallback (
       gRedfishConfigData.RedfishServiceInfo.RedfishServiceProductVer   = RedfishInstance->Information.ProductVer;
       gRedfishConfigData.RedfishServiceInfo.RedfishServiceUseHttps     = RedfishInstance->Information.UseHttps;
       gRedfishServiceDiscovered                                        = TRUE;
+      DEBUG ((DEBUG_MANAGEABILITY, "%a: Redfish service %s is discovered!\n", __func__, gRedfishConfigData.RedfishServiceInfo.RedfishServiceUuid));
     }
 
     //
@@ -591,10 +606,13 @@ RedfishConfigHandlerDriverEntryPoint (
     return Status;
   }
 
-  Status = RedfishConfigCommonInit (ImageHandle, SystemTable);
+  Status = RedfishConfigCommonInit ();
   if (EFI_ERROR (Status)) {
-    gBS->CloseEvent (gEfiRedfishDiscoverProtocolEvent);
-    gEfiRedfishDiscoverProtocolEvent = NULL;
+    if (gEfiRedfishDiscoverProtocolEvent != NULL) {
+      gBS->CloseEvent (gEfiRedfishDiscoverProtocolEvent);
+      gEfiRedfishDiscoverProtocolEvent = NULL;
+    }
+
     return Status;
   }
 

--- a/RedfishPkg/RedfishConfigHandler/RedfishConfigHandlerDriver.inf
+++ b/RedfishPkg/RedfishConfigHandler/RedfishConfigHandlerDriver.inf
@@ -5,6 +5,7 @@
 #  Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
 #  (C) Copyright 2021 Hewlett Packard Enterprise Development LP<BR>
 #  Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#  Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.<BR>
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -49,10 +50,9 @@
   gEdkIIRedfishCredentialProtocolGuid          ## CONSUMES
   gEdkIIRedfishConfigHandlerProtocolGuid       ## CONSUMES
   gEdkIIRedfishHostInterfaceReadyProtocolGuid  ## CONSUMES
+  gEdkIIRedfishCredentialProtocolGuid          ## CONSUMES
 
 [Guids]
-  gEfiEventExitBootServicesGuid           ## CONSUMES ## Event
-  gEfiEndOfDxeEventGroupGuid              ## CONSUMES ## Event
+  gEfiEventExitBootServicesGuid                ## CONSUMES ## Event
+  gEfiEndOfDxeEventGroupGuid                   ## CONSUMES ## Event
 
-[Depex]
-  gEdkIIRedfishCredentialProtocolGuid


### PR DESCRIPTION
UEFI driver shouldn't have the [Depex] section in INF file. Remove Redfish Credential Protocol in the dependency section and locate it when the UEFI driver is connected to execute.

# Description
fixes: #12394

UEFI driver shouldn't have a [Depex] section.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested
Verified the functionality on AMD platform.

## Integration Instructions
N/A
