### PR TITLE
RedfishPkg/PlatformConfig: Delete a few debug messages

### DIFF
--- a/RedfishPkg/RedfishPlatformConfigDxe/RedfishPlatformConfigDxe.c
+++ b/RedfishPkg/RedfishPlatformConfigDxe/RedfishPlatformConfigDxe.c
@@ -545,7 +545,6 @@ OneOfStatementToAttributeValues (
       Values->ValueArray[Index].ValueDisplayName = HiiGetEnglishAsciiString (HiiHandle, Option->Text);
       Values->ValueArray[Index].ValueName        = HiiGetRedfishAsciiString (HiiHandle, SchemaName, Option->Text);
       if (Values->ValueArray[Index].ValueName == NULL) {
-        DEBUG ((DEBUG_MANAGEABILITY, "%a: Redfish x-UEFI string is not found.\n", __func__));
         //
         // No x-UEFI-redfish string defined. Try to get string in English.
         //
@@ -1320,7 +1319,6 @@ HiiValueToRedfishValue (
 
       RedfishValue->Value.Buffer = HiiGetRedfishAsciiString (HiiHandle, FullSchema, StringId);
       if (RedfishValue->Value.Buffer == NULL) {
-        DEBUG ((DEBUG_MANAGEABILITY, "%a: Redfish x-UEFI string is not found.\n", __func__));
         //
         // No x-UEFI-redfish string defined. Try to get string in English.
         //

--- a/RedfishPkg/RedfishPlatformConfigDxe/RedfishPlatformConfigImpl.c
+++ b/RedfishPkg/RedfishPlatformConfigDxe/RedfishPlatformConfigImpl.c
@@ -374,7 +374,6 @@ HiiGetRedfishAsciiString (
 
   HiiString = HiiGetRedfishString (HiiHandle, Language, StringId);
   if (HiiString == NULL) {
-    DEBUG ((DEBUG_ERROR, "%a: Can not find string ID: 0x%x with %a\n", __func__, StringId, Language));
     return NULL;
   }
 


### PR DESCRIPTION
# Description

Delete debug messages for the x-uefi string searching to reduce the messages when DEBUG_MANAGEBAILITY is enabled.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

N/A

## Integration Instructions

N/A
