### PR TITLE
NetworkPkg/Ip4Dxe: Reject IPv4 addresses ending with dot

### DIFF
--- a/NetworkPkg/Ip4Dxe/Ip4Config2Nv.c
+++ b/NetworkPkg/Ip4Dxe/Ip4Config2Nv.c
@@ -67,47 +67,11 @@ Ip4Config2StrToIp (
   OUT EFI_IPv4_ADDRESS  *Ip
   )
 {
-  UINTN  Index;
-  UINTN  Number;
+  EFI_STATUS  Status;
+  CHAR16      *EndPointer;
 
-  Index = 0;
-
-  while (*Str != L'\0') {
-    if (Index > 3) {
-      return EFI_INVALID_PARAMETER;
-    }
-
-    Number = 0;
-    while ((*Str >= L'0') && (*Str <= L'9')) {
-      Number = Number * 10 + (*Str - L'0');
-      Str++;
-    }
-
-    if (Number > 0xFF) {
-      return EFI_INVALID_PARAMETER;
-    }
-
-    Ip->Addr[Index] = (UINT8)Number;
-
-    if ((*Str != L'\0') && (*Str != L'.')) {
-      //
-      // The current character should be either the NULL terminator or
-      // the dot delimiter.
-      //
-      return EFI_INVALID_PARAMETER;
-    }
-
-    if (*Str == L'.') {
-      //
-      // Skip the delimiter.
-      //
-      Str++;
-    }
-
-    Index++;
-  }
-
-  if (Index != 4) {
+  Status = StrToIpv4Address (Str, &EndPointer, (IPv4_ADDRESS *)Ip, NULL);
+  if (EFI_ERROR (Status) || (*EndPointer != L'\0')) {
     return EFI_INVALID_PARAMETER;
   }
 


### PR DESCRIPTION
This PR fixes a validation issue where the IPv4 Network Configuration 
UI accepts invalid IPv4 addresses ending with a dot.

The fix adds proper validation to reject addresses like:
- 192.168.1.10.
- 255.255.255.0.
- 1.1.1.1.

After this fix, such malformed addresses are properly rejected with 
an "Invalid" popup.

Cc: Saloni Kasbekar [saloni.kasbekar@intel.com](mailto:saloni.kasbekar@intel.com)
Cc: Zachary Clark-williams [zachary.clark-williams@intel.com](mailto:zachary.clark-williams@intel.com)
Cc: Michael D Kinney [michael.d.kinney@intel.com](mailto:michael.d.kinney@intel.com)

Signed-off-by: Abuthahir M [abuthahirm@ami.com](mailto:abuthahirm@ami.com)