### PR TITLE
Use (VOID) cast for intentionally ignored gBS->SetTimer() return values

### DIFF
--- a/ArmPkg/Drivers/ArmPsciMpServicesDxe/ArmPsciMpServicesDxe.c
+++ b/ArmPkg/Drivers/ArmPsciMpServicesDxe/ArmPsciMpServicesDxe.c
@@ -1147,11 +1147,11 @@ CheckAllAPsStatus (
     return;
   }
 
-  gBS->SetTimer (
-         mCpuMpData.CheckAllAPsEvent,
-         TimerCancel,
-         0
-         );
+  (VOID)gBS->SetTimer (
+               mCpuMpData.CheckAllAPsEvent,
+               TimerCancel,
+               0
+               );
 
   if (mCpuMpData.FailedListIndex == 0) {
     if (mCpuMpData.FailedList != NULL) {

--- a/EmulatorPkg/CpuRuntimeDxe/MpService.c
+++ b/EmulatorPkg/CpuRuntimeDxe/MpService.c
@@ -727,11 +727,11 @@ CpuMpServicesStartupThisAP (
   if (WaitEvent != NULL) {
     // Non Blocking
     gMPSystem.WaitEvent = WaitEvent;
-    gBS->SetTimer (
-           gMPSystem.ProcessorData[ProcessorNumber].CheckThisAPEvent,
-           TimerPeriodic,
-           gPollInterval
-           );
+    (VOID)gBS->SetTimer (
+                 gMPSystem.ProcessorData[ProcessorNumber].CheckThisAPEvent,
+                 TimerPeriodic,
+                 gPollInterval
+                 );
     return EFI_SUCCESS;
   }
 
@@ -1120,11 +1120,11 @@ CpuCheckAllAPsStatus (
     return;
   }
 
-  gBS->SetTimer (
-         gMPSystem.CheckAllAPsEvent,
-         TimerCancel,
-         0
-         );
+  (VOID)gBS->SetTimer (
+               gMPSystem.CheckAllAPsEvent,
+               TimerCancel,
+               0
+               );
 
   if (gMPSystem.FailedListIndex == 0) {
     if (gMPSystem.FailedList != NULL) {

--- a/MdeModulePkg/Bus/Isa/Ps2MouseDxe/Ps2Mouse.c
+++ b/MdeModulePkg/Bus/Isa/Ps2MouseDxe/Ps2Mouse.c
@@ -492,7 +492,7 @@ PS2MouseDriverStop (
   //
   // Cancel mouse data polling timer, close timer event
   //
-  gBS->SetTimer (MouseDev->TimerEvent, TimerCancel, 0);
+  (VOID)gBS->SetTimer (MouseDev->TimerEvent, TimerCancel, 0);
   gBS->CloseEvent (MouseDev->TimerEvent);
 
   //

--- a/MdeModulePkg/Bus/Pci/EhciDxe/Ehci.c
+++ b/MdeModulePkg/Bus/Pci/EhciDxe/Ehci.c
@@ -2047,7 +2047,7 @@ EhcDriverBindingStop (
   // Stop AsyncRequest Polling timer then stop the EHCI driver
   // and uninstall the EHCI protocl.
   //
-  gBS->SetTimer (Ehc->PollTimer, TimerCancel, EHC_ASYNC_POLL_INTERVAL);
+  (VOID)gBS->SetTimer (Ehc->PollTimer, TimerCancel, EHC_ASYNC_POLL_INTERVAL);
   EhcHaltHC (Ehc, EHC_GENERIC_TIMEOUT);
 
   if (Ehc->PollTimer != NULL) {

--- a/MdeModulePkg/Bus/Pci/XhciDxe/Xhci.c
+++ b/MdeModulePkg/Bus/Pci/XhciDxe/Xhci.c
@@ -1930,7 +1930,7 @@ XhcExitBootService (
   // Stop AsyncRequest Polling timer then stop the XHCI driver
   // and uninstall the XHCI protocl.
   //
-  gBS->SetTimer (Xhc->PollTimer, TimerCancel, 0);
+  (VOID)gBS->SetTimer (Xhc->PollTimer, TimerCancel, 0);
   XhcHaltHC (Xhc, XHC_GENERIC_TIMEOUT);
 
   if (Xhc->PollTimer != NULL) {
@@ -2255,7 +2255,7 @@ XhcDriverBindingStop (
   // Stop AsyncRequest Polling timer then stop the XHCI driver
   // and uninstall the XHCI protocl.
   //
-  gBS->SetTimer (Xhc->PollTimer, TimerCancel, 0);
+  (VOID)gBS->SetTimer (Xhc->PollTimer, TimerCancel, 0);
 
   //
   // Disable the device slots occupied by these devices on its downstream ports.

--- a/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbHub.c
+++ b/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbHub.c
@@ -1243,7 +1243,7 @@ UsbRootHubRelease (
 {
   DEBUG ((DEBUG_INFO, "UsbRootHubRelease: root hub released for hub %p\n", HubIf));
 
-  gBS->SetTimer (HubIf->HubNotify, TimerCancel, USB_ROOTHUB_POLL_INTERVAL);
+  (VOID)gBS->SetTimer (HubIf->HubNotify, TimerCancel, USB_ROOTHUB_POLL_INTERVAL);
   gBS->CloseEvent (HubIf->HubNotify);
 
   return EFI_SUCCESS;

--- a/MdeModulePkg/Bus/Usb/UsbKbDxe/KeyBoard.c
+++ b/MdeModulePkg/Bus/Usb/UsbKbDxe/KeyBoard.c
@@ -998,11 +998,11 @@ KeyboardHandler (
     //
     UsbKeyboardDevice->RepeatKey = 0;
 
-    gBS->SetTimer (
-           UsbKeyboardDevice->RepeatTimer,
-           TimerCancel,
-           USBKBD_REPEAT_RATE
-           );
+    (VOID)gBS->SetTimer (
+                 UsbKeyboardDevice->RepeatTimer,
+                 TimerCancel,
+                 USBKBD_REPEAT_RATE
+                 );
 
     if ((Result & EFI_USB_ERR_STALL) == EFI_USB_ERR_STALL) {
       UsbClearEndpointHalt (
@@ -1028,11 +1028,11 @@ KeyboardHandler (
     //
     // EFI_USB_INTERRUPT_DELAY is defined in USB standard for error handling.
     //
-    gBS->SetTimer (
-           UsbKeyboardDevice->DelayedRecoveryEvent,
-           TimerRelative,
-           EFI_USB_INTERRUPT_DELAY
-           );
+    (VOID)gBS->SetTimer (
+                 UsbKeyboardDevice->DelayedRecoveryEvent,
+                 TimerRelative,
+                 EFI_USB_INTERRUPT_DELAY
+                 );
 
     return EFI_DEVICE_ERROR;
   }
@@ -1149,11 +1149,11 @@ KeyboardHandler (
   // If original repeat key is released, cancel the repeat timer
   //
   if (UsbKeyboardDevice->RepeatKey == 0) {
-    gBS->SetTimer (
-           UsbKeyboardDevice->RepeatTimer,
-           TimerCancel,
-           USBKBD_REPEAT_RATE
-           );
+    (VOID)gBS->SetTimer (
+                 UsbKeyboardDevice->RepeatTimer,
+                 TimerCancel,
+                 USBKBD_REPEAT_RATE
+                 );
   }
 
   //
@@ -1226,11 +1226,11 @@ KeyboardHandler (
     // to trigger the repeat timer when the key is hold long
     // enough time.
     //
-    gBS->SetTimer (
-           UsbKeyboardDevice->RepeatTimer,
-           TimerRelative,
-           USBKBD_REPEAT_DELAY
-           );
+    (VOID)gBS->SetTimer (
+                 UsbKeyboardDevice->RepeatTimer,
+                 TimerRelative,
+                 USBKBD_REPEAT_DELAY
+                 );
     UsbKeyboardDevice->RepeatKey = NewRepeatKey;
   }
 
@@ -1928,11 +1928,11 @@ USBKeyboardRepeatHandler (
     //
     // Set repeat rate for next repeat key generation.
     //
-    gBS->SetTimer (
-           UsbKeyboardDevice->RepeatTimer,
-           TimerRelative,
-           USBKBD_REPEAT_RATE
-           );
+    (VOID)gBS->SetTimer (
+                 UsbKeyboardDevice->RepeatTimer,
+                 TimerRelative,
+                 USBKBD_REPEAT_RATE
+                 );
   }
 }
 

--- a/MdeModulePkg/Bus/Usb/UsbMouseAbsolutePointerDxe/UsbMouseAbsolutePointer.c
+++ b/MdeModulePkg/Bus/Usb/UsbMouseAbsolutePointerDxe/UsbMouseAbsolutePointer.c
@@ -800,11 +800,11 @@ OnMouseInterruptComplete (
     //
     // EFI_USB_INTERRUPT_DELAY is defined in USB standard for error handling.
     //
-    gBS->SetTimer (
-           UsbMouseAbsolutePointerDevice->DelayedRecoveryEvent,
-           TimerRelative,
-           EFI_USB_INTERRUPT_DELAY
-           );
+    (VOID)gBS->SetTimer (
+                 UsbMouseAbsolutePointerDevice->DelayedRecoveryEvent,
+                 TimerRelative,
+                 EFI_USB_INTERRUPT_DELAY
+                 );
     return EFI_DEVICE_ERROR;
   }
 

--- a/MdeModulePkg/Bus/Usb/UsbMouseDxe/UsbMouse.c
+++ b/MdeModulePkg/Bus/Usb/UsbMouseDxe/UsbMouse.c
@@ -792,11 +792,11 @@ OnMouseInterruptComplete (
     //
     // EFI_USB_INTERRUPT_DELAY is defined in USB standard for error handling.
     //
-    gBS->SetTimer (
-           UsbMouseDevice->DelayedRecoveryEvent,
-           TimerRelative,
-           EFI_USB_INTERRUPT_DELAY
-           );
+    (VOID)gBS->SetTimer (
+                 UsbMouseDevice->DelayedRecoveryEvent,
+                 TimerRelative,
+                 EFI_USB_INTERRUPT_DELAY
+                 );
     return EFI_DEVICE_ERROR;
   }
 

--- a/MdeModulePkg/Bus/Usb/UsbNetwork/NetworkCommon/PxeFunction.c
+++ b/MdeModulePkg/Bus/Usb/UsbNetwork/NetworkCommon/PxeFunction.c
@@ -175,7 +175,7 @@ UndiStart (
   } else {
     if (Nic->RateLimitingEnable == TRUE) {
       if (!EventError) {
-        gBS->SetTimer (&Nic->RateLimiter, TimerCancel, 0);
+        (VOID)gBS->SetTimer (&Nic->RateLimiter, TimerCancel, 0);
       }
 
       if (Nic->RateLimiter) {
@@ -244,7 +244,7 @@ UndiStop (
   Nic->State              = PXE_STATFLAGS_GET_STATE_STOPPED;
 
   if (Nic->RateLimitingEnable == TRUE) {
-    gBS->SetTimer (&Nic->RateLimiter, TimerCancel, 0);
+    (VOID)gBS->SetTimer (&Nic->RateLimiter, TimerCancel, 0);
     gBS->CloseEvent (&Nic->RateLimiter);
   }
 

--- a/MdeModulePkg/Universal/BdsDxe/BdsEntry.c
+++ b/MdeModulePkg/Universal/BdsDxe/BdsEntry.c
@@ -242,11 +242,11 @@ BdsWaitForSingleEvent (
       //
       // Set the timer event
       //
-      gBS->SetTimer (
-             TimerEvent,
-             TimerRelative,
-             Timeout
-             );
+      (VOID)gBS->SetTimer (
+                   TimerEvent,
+                   TimerRelative,
+                   Timeout
+                   );
 
       //
       // Wait for the original event or the timer

--- a/MdeModulePkg/Universal/Console/TerminalDxe/TerminalConIn.c
+++ b/MdeModulePkg/Universal/Console/TerminalDxe/TerminalConIn.c
@@ -1252,11 +1252,11 @@ UnicodeToEfiKeyFlushState (
   //
   // Cancel the timer.
   //
-  gBS->SetTimer (
-         TerminalDevice->TwoSecondTimeOut,
-         TimerCancel,
-         0
-         );
+  (VOID)gBS->SetTimer (
+               TerminalDevice->TwoSecondTimeOut,
+               TimerCancel,
+               0
+               );
 
   TerminalDevice->InputState = INPUT_STATE_DEFAULT;
 }

--- a/MdeModulePkg/Universal/DisplayEngineDxe/FormDisplay.c
+++ b/MdeModulePkg/Universal/DisplayEngineDxe/FormDisplay.c
@@ -1440,11 +1440,11 @@ UiWaitForEvent (
     //
     // Set the timer event
     //
-    gBS->SetTimer (
-           TimerEvent,
-           TimerRelative,
-           Timeout
-           );
+    (VOID)gBS->SetTimer (
+                 TimerEvent,
+                 TimerRelative,
+                 Timeout
+                 );
   }
 
   WaitList[0] = Event;

--- a/MdeModulePkg/Universal/EbcDxe/EbcDebugger/EdbSupportUI.c
+++ b/MdeModulePkg/Universal/EbcDxe/EbcDebugger/EdbSupportUI.c
@@ -66,11 +66,11 @@ WaitForSingleEvent (
       //
       // Set the timer event
       //
-      gBS->SetTimer (
-             TimerEvent,
-             TimerRelative,
-             Timeout
-             );
+      (VOID)gBS->SetTimer (
+                   TimerEvent,
+                   TimerRelative,
+                   Timeout
+                   );
 
       //
       // Wait for the original event or the timer

--- a/NetworkPkg/ArpDxe/ArpDriver.c
+++ b/NetworkPkg/ArpDxe/ArpDriver.c
@@ -195,7 +195,7 @@ ArpCleanService (
     //
     // Cancel and close the PeriodicTimer.
     //
-    gBS->SetTimer (ArpService->PeriodicTimer, TimerCancel, 0);
+    (VOID)gBS->SetTimer (ArpService->PeriodicTimer, TimerCancel, 0);
     gBS->CloseEvent (ArpService->PeriodicTimer);
   }
 

--- a/NetworkPkg/Dhcp4Dxe/Dhcp4Driver.c
+++ b/NetworkPkg/Dhcp4Dxe/Dhcp4Driver.c
@@ -158,7 +158,7 @@ Dhcp4CloseService (
   }
 
   if (DhcpSb->Timer != NULL) {
-    gBS->SetTimer (DhcpSb->Timer, TimerCancel, 0);
+    (VOID)gBS->SetTimer (DhcpSb->Timer, TimerCancel, 0);
     gBS->CloseEvent (DhcpSb->Timer);
 
     DhcpSb->Timer = NULL;

--- a/NetworkPkg/HttpDxe/HttpImpl.c
+++ b/NetworkPkg/HttpDxe/HttpImpl.c
@@ -1195,7 +1195,7 @@ HttpResponseWorker (
 
     Status = HttpTcpReceiveHeader (HttpInstance, &SizeofHeaders, &BufferSize, HttpInstance->TimeoutEvent);
 
-    gBS->SetTimer (HttpInstance->TimeoutEvent, TimerCancel, 0);
+    (VOID)gBS->SetTimer (HttpInstance->TimeoutEvent, TimerCancel, 0);
 
     if (EFI_ERROR (Status)) {
       goto Error;
@@ -1490,7 +1490,7 @@ HttpResponseWorker (
 
     Status = HttpsReceive (HttpInstance, &Fragment, HttpInstance->TimeoutEvent);
 
-    gBS->SetTimer (HttpInstance->TimeoutEvent, TimerCancel, 0);
+    (VOID)gBS->SetTimer (HttpInstance->TimeoutEvent, TimerCancel, 0);
 
     if (EFI_ERROR (Status)) {
       goto Error2;

--- a/NetworkPkg/HttpDxe/HttpProto.c
+++ b/NetworkPkg/HttpDxe/HttpProto.c
@@ -1305,7 +1305,7 @@ HttpConnectTcp4 (
     Status = TlsConnectSession (HttpInstance, HttpInstance->TimeoutEvent);
     HttpNotify (HttpEventTlsConnectSession, Status);
 
-    gBS->SetTimer (HttpInstance->TimeoutEvent, TimerCancel, 0);
+    (VOID)gBS->SetTimer (HttpInstance->TimeoutEvent, TimerCancel, 0);
 
     if (EFI_ERROR (Status)) {
       TlsCloseTxRxEvent (HttpInstance);
@@ -1402,7 +1402,7 @@ HttpConnectTcp6 (
     Status = TlsConnectSession (HttpInstance, HttpInstance->TimeoutEvent);
     HttpNotify (HttpEventTlsConnectSession, Status);
 
-    gBS->SetTimer (HttpInstance->TimeoutEvent, TimerCancel, 0);
+    (VOID)gBS->SetTimer (HttpInstance->TimeoutEvent, TimerCancel, 0);
 
     if (EFI_ERROR (Status)) {
       TlsCloseTxRxEvent (HttpInstance);

--- a/NetworkPkg/IScsiDxe/IScsiProto.c
+++ b/NetworkPkg/IScsiDxe/IScsiProto.c
@@ -142,7 +142,7 @@ IScsiConnLogin (
   // Try to establish the tcp connection.
   //
   Status = TcpIoConnect (&Conn->TcpIo, Conn->TimeoutEvent);
-  gBS->SetTimer (Conn->TimeoutEvent, TimerCancel, 0);
+  (VOID)gBS->SetTimer (Conn->TimeoutEvent, TimerCancel, 0);
 
   if (EFI_ERROR (Status)) {
     return Status;
@@ -3097,7 +3097,7 @@ IScsiExecuteScsiCommand (
 ON_EXIT:
 
   if (TimeoutEvent != NULL) {
-    gBS->SetTimer (TimeoutEvent, TimerCancel, 0);
+    (VOID)gBS->SetTimer (TimeoutEvent, TimerCancel, 0);
   }
 
   if (Tcb != NULL) {

--- a/NetworkPkg/Ip4Dxe/Ip4Config2Nv.c
+++ b/NetworkPkg/Ip4Dxe/Ip4Config2Nv.c
@@ -772,7 +772,7 @@ Ip4Config2ConvertIfrNvDataToConfigNvData (
                           );
 
     if (Status == EFI_NOT_READY) {
-      gBS->SetTimer (TimeoutEvent, TimerRelative, 50000000);
+      (VOID)gBS->SetTimer (TimeoutEvent, TimerRelative, 50000000);
       while (EFI_ERROR (gBS->CheckEvent (TimeoutEvent))) {
         if (IsAddressOk) {
           Status = EFI_SUCCESS;

--- a/NetworkPkg/Ip4Dxe/Ip4Driver.c
+++ b/NetworkPkg/Ip4Dxe/Ip4Driver.c
@@ -412,14 +412,14 @@ Ip4CleanService (
   IpSb->State = IP4_SERVICE_DESTROY;
 
   if (IpSb->Timer != NULL) {
-    gBS->SetTimer (IpSb->Timer, TimerCancel, 0);
+    (VOID)gBS->SetTimer (IpSb->Timer, TimerCancel, 0);
     gBS->CloseEvent (IpSb->Timer);
 
     IpSb->Timer = NULL;
   }
 
   if (IpSb->ReconfigCheckTimer != NULL) {
-    gBS->SetTimer (IpSb->ReconfigCheckTimer, TimerCancel, 0);
+    (VOID)gBS->SetTimer (IpSb->ReconfigCheckTimer, TimerCancel, 0);
     gBS->CloseEvent (IpSb->ReconfigCheckTimer);
 
     IpSb->ReconfigCheckTimer = NULL;

--- a/NetworkPkg/Ip6Dxe/Ip6ConfigNv.c
+++ b/NetworkPkg/Ip6Dxe/Ip6ConfigNv.c
@@ -1189,7 +1189,7 @@ Ip6ConvertIfrNvDataToConfigNvDataAdvanced (
                           (VOID *)ManualAddress
                           );
     if (Status == EFI_NOT_READY) {
-      gBS->SetTimer (TimeoutEvent, TimerRelative, 50000000);
+      (VOID)gBS->SetTimer (TimeoutEvent, TimerRelative, 50000000);
       while (EFI_ERROR (gBS->CheckEvent (TimeoutEvent))) {
         if (IsAddressOk) {
           Status = EFI_SUCCESS;

--- a/NetworkPkg/Ip6Dxe/Ip6Driver.c
+++ b/NetworkPkg/Ip6Dxe/Ip6Driver.c
@@ -153,14 +153,14 @@ Ip6CleanService (
   IpSb->State = IP6_SERVICE_DESTROY;
 
   if (IpSb->Timer != NULL) {
-    gBS->SetTimer (IpSb->Timer, TimerCancel, 0);
+    (VOID)gBS->SetTimer (IpSb->Timer, TimerCancel, 0);
     gBS->CloseEvent (IpSb->Timer);
 
     IpSb->Timer = NULL;
   }
 
   if (IpSb->FasterTimer != NULL) {
-    gBS->SetTimer (IpSb->FasterTimer, TimerCancel, 0);
+    (VOID)gBS->SetTimer (IpSb->FasterTimer, TimerCancel, 0);
     gBS->CloseEvent (IpSb->FasterTimer);
 
     IpSb->FasterTimer = NULL;

--- a/NetworkPkg/Ip6Dxe/Ip6Nd.c
+++ b/NetworkPkg/Ip6Dxe/Ip6Nd.c
@@ -937,8 +937,8 @@ Ip6OnDADFinished (
     //
     IpSb->LinkLocalDadFail = TRUE;
     IpSb->Mnp->Configure (IpSb->Mnp, NULL);
-    gBS->SetTimer (IpSb->Timer, TimerCancel, 0);
-    gBS->SetTimer (IpSb->FasterTimer, TimerCancel, 0);
+    (VOID)gBS->SetTimer (IpSb->Timer, TimerCancel, 0);
+    (VOID)gBS->SetTimer (IpSb->FasterTimer, TimerCancel, 0);
     return;
   }
 

--- a/NetworkPkg/Library/DxeHttpIoLib/DxeHttpIoLib.c
+++ b/NetworkPkg/Library/DxeHttpIoLib/DxeHttpIoLib.c
@@ -411,7 +411,7 @@ HttpIoRecvResponse (
     //
     // Remove timeout timer from the event list.
     //
-    gBS->SetTimer (HttpIo->TimeoutEvent, TimerCancel, 0);
+    (VOID)gBS->SetTimer (HttpIo->TimeoutEvent, TimerCancel, 0);
     return Status;
   }
 
@@ -425,7 +425,7 @@ HttpIoRecvResponse (
   //
   // Remove timeout timer from the event list.
   //
-  gBS->SetTimer (HttpIo->TimeoutEvent, TimerCancel, 0);
+  (VOID)gBS->SetTimer (HttpIo->TimeoutEvent, TimerCancel, 0);
 
   if (!HttpIo->IsRxDone) {
     //

--- a/NetworkPkg/Library/DxeNetLib/DxeNetLib.c
+++ b/NetworkPkg/Library/DxeNetLib/DxeNetLib.c
@@ -313,10 +313,10 @@ SyslogSendPacket (
     // Status is EFI_NOT_READY. Restart the timer event and
     // call Snp->Transmit again.
     //
-    gBS->SetTimer (TimeoutEvent, TimerRelative, NET_SYSLOG_TX_TIMEOUT);
+    (VOID)gBS->SetTimer (TimeoutEvent, TimerRelative, NET_SYSLOG_TX_TIMEOUT);
   }
 
-  gBS->SetTimer (TimeoutEvent, TimerCancel, 0);
+  (VOID)gBS->SetTimer (TimeoutEvent, TimerCancel, 0);
 
 ON_EXIT:
   gBS->CloseEvent (TimeoutEvent);

--- a/NetworkPkg/MnpDxe/MnpConfig.c
+++ b/NetworkPkg/MnpDxe/MnpConfig.c
@@ -1330,19 +1330,19 @@ MnpStop (
     //
     //  The system poll in on, cancel the poll timer.
     //
-    Status                          = gBS->SetTimer (MnpDeviceData->PollTimer, TimerCancel, 0);
+    (VOID)gBS->SetTimer (MnpDeviceData->PollTimer, TimerCancel, 0);
     MnpDeviceData->EnableSystemPoll = FALSE;
   }
 
   //
   // Cancel the timeout timer.
   //
-  Status = gBS->SetTimer (MnpDeviceData->TimeoutCheckTimer, TimerCancel, 0);
+  (VOID)gBS->SetTimer (MnpDeviceData->TimeoutCheckTimer, TimerCancel, 0);
 
   //
   // Cancel the media detect timer.
   //
-  Status = gBS->SetTimer (MnpDeviceData->MediaDetectTimer, TimerCancel, 0);
+  (VOID)gBS->SetTimer (MnpDeviceData->MediaDetectTimer, TimerCancel, 0);
 
   //
   // Stop the simple network.

--- a/NetworkPkg/TcpDxe/TcpDriver.c
+++ b/NetworkPkg/TcpDxe/TcpDriver.c
@@ -146,7 +146,7 @@ TcpDestroyTimer (
     return;
   }
 
-  gBS->SetTimer (mTcpTimer.TimerEvent, TimerCancel, 0);
+  (VOID)gBS->SetTimer (mTcpTimer.TimerEvent, TimerCancel, 0);
   gBS->CloseEvent (mTcpTimer.TimerEvent);
   mTcpTimer.TimerEvent = NULL;
 }

--- a/NetworkPkg/Udp4Dxe/Udp4Impl.c
+++ b/NetworkPkg/Udp4Dxe/Udp4Impl.c
@@ -359,7 +359,7 @@ Udp4CleanService (
   //
   // Cancel the TimeoutEvent timer.
   //
-  gBS->SetTimer (Udp4Service->TimeoutEvent, TimerCancel, 0);
+  (VOID)gBS->SetTimer (Udp4Service->TimeoutEvent, TimerCancel, 0);
 
   //
   // Close the TimeoutEvent timer.

--- a/NetworkPkg/UefiPxeBcDxe/PxeBcImpl.c
+++ b/NetworkPkg/UefiPxeBcDxe/PxeBcImpl.c
@@ -1172,7 +1172,7 @@ EfiPxeBcUdpWrite (
   //
   // Start a timer as timeout event for this blocking API.
   //
-  gBS->SetTimer (Private->UdpTimeOutEvent, TimerRelative, PXEBC_UDP_TIMEOUT);
+  (VOID)gBS->SetTimer (Private->UdpTimeOutEvent, TimerRelative, PXEBC_UDP_TIMEOUT);
 
   if (Mode->UsingIpv6) {
     //
@@ -1228,7 +1228,7 @@ EfiPxeBcUdpWrite (
                );
   }
 
-  gBS->SetTimer (Private->UdpTimeOutEvent, TimerCancel, 0);
+  (VOID)gBS->SetTimer (Private->UdpTimeOutEvent, TimerCancel, 0);
 
   //
   // Reset the UdpWrite instance.
@@ -1371,7 +1371,7 @@ EfiPxeBcUdpRead (
   //
   // Start a timer as timeout event for this blocking API.
   //
-  gBS->SetTimer (Private->UdpTimeOutEvent, TimerRelative, PXEBC_UDP_TIMEOUT);
+  (VOID)gBS->SetTimer (Private->UdpTimeOutEvent, TimerRelative, PXEBC_UDP_TIMEOUT);
   Mode->IcmpErrorReceived = FALSE;
 
   //
@@ -1421,7 +1421,7 @@ EfiPxeBcUdpRead (
     Mode->IcmpErrorReceived = TRUE;
   }
 
-  gBS->SetTimer (Private->UdpTimeOutEvent, TimerCancel, 0);
+  (VOID)gBS->SetTimer (Private->UdpTimeOutEvent, TimerCancel, 0);
 
   if (IsMatched) {
     //

--- a/NetworkPkg/WifiConnectionManagerDxe/WifiConnectionMgrDriver.c
+++ b/NetworkPkg/WifiConnectionManagerDxe/WifiConnectionMgrDriver.c
@@ -334,7 +334,7 @@ WifiMgrDxeDriverBindingStart (
 
 ERROR4:
 
-  gBS->SetTimer (Nic->TickTimer, TimerCancel, 0);
+  (VOID)gBS->SetTimer (Nic->TickTimer, TimerCancel, 0);
   OldTpl = gBS->RaiseTPL (TPL_CALLBACK);
   RemoveEntryList (&Nic->Link);
   mPrivate->NicCount--;
@@ -453,7 +453,7 @@ WifiMgrDxeDriverBindingStop (
   //
   // Close Event
   //
-  gBS->SetTimer (Nic->TickTimer, TimerCancel, 0);
+  (VOID)gBS->SetTimer (Nic->TickTimer, TimerCancel, 0);
   gBS->CloseEvent (Nic->TickTimer);
 
   //

--- a/NetworkPkg/WifiConnectionManagerDxe/WifiConnectionMgrHiiConfigAccess.c
+++ b/NetworkPkg/WifiConnectionManagerDxe/WifiConnectionMgrHiiConfigAccess.c
@@ -1664,7 +1664,7 @@ WifiMgrDxeHiiConfigAccessCallback (
         Status = gBS->SetTimer (Private->CurrentNic->TickTimer, TimerPeriodic, EFI_TIMER_PERIOD_MILLISECONDS (500));
         if (EFI_ERROR (Status)) {
           DEBUG ((DEBUG_WARN, "[WiFi Connection Manager] Error: Failed to set timer for connect action!"));
-          gBS->SetTimer (Private->CurrentNic->TickTimer, TimerCancel, 0);
+          (VOID)gBS->SetTimer (Private->CurrentNic->TickTimer, TimerCancel, 0);
         }
 
         break;
@@ -1921,7 +1921,7 @@ WifiMgrDxeHiiConfigAccessCallback (
         Status = gBS->SetTimer (Private->CurrentNic->TickTimer, TimerPeriodic, EFI_TIMER_PERIOD_MILLISECONDS (500));
         if (EFI_ERROR (Status)) {
           DEBUG ((DEBUG_WARN, "[WiFi Connection Manager] Error: Failed to set timer for connect action!"));
-          gBS->SetTimer (Private->CurrentNic->TickTimer, TimerCancel, 0);
+          (VOID)gBS->SetTimer (Private->CurrentNic->TickTimer, TimerCancel, 0);
         }
 
         break;

--- a/NetworkPkg/WifiConnectionManagerDxe/WifiConnectionMgrImpl.c
+++ b/NetworkPkg/WifiConnectionManagerDxe/WifiConnectionMgrImpl.c
@@ -1177,7 +1177,7 @@ WifiMgrOnConnectFinished (
   }
 
   ConfigToken->Nic->ConnectState = WifiMgrConnectedToAp;
-  gBS->SetTimer (ConfigToken->Nic->TickTimer, TimerCancel, 0);
+  (VOID)gBS->SetTimer (ConfigToken->Nic->TickTimer, TimerCancel, 0);
   WifiMgrUpdateConnectMessage (ConfigToken->Nic, TRUE, NULL);
 
 Exit:
@@ -1492,7 +1492,7 @@ WifiMgrOnTimerTick (
   Nic = (WIFI_MGR_DEVICE_DATA *)Context;
   if ((Nic->ConnectPendingNetwork == NULL) && !Nic->HasDisconnectPendingNetwork) {
     DEBUG ((DEBUG_VERBOSE, "[WiFi Connection Manager] No profile for connection, no scan triggered!\n"));
-    gBS->SetTimer (Nic->TickTimer, TimerCancel, 0);
+    (VOID)gBS->SetTimer (Nic->TickTimer, TimerCancel, 0);
     return;
   }
 

--- a/OvmfPkg/XenBusDxe/XenStore.c
+++ b/OvmfPkg/XenBusDxe/XenStore.c
@@ -415,7 +415,7 @@ XenStoreWaitForEvent (
   EFI_EVENT   WaitList[2];
 
   gBS->CreateEvent (EVT_TIMER, 0, NULL, NULL, &TimerEvent);
-  gBS->SetTimer (TimerEvent, TimerRelative, Timeout);
+  (VOID)gBS->SetTimer (TimerEvent, TimerRelative, Timeout);
 
   WaitList[0] = xs.EventChannelEvent;
   WaitList[1] = TimerEvent;

--- a/ShellPkg/DynamicCommand/HttpDynamicCommand/Http.c
+++ b/ShellPkg/DynamicCommand/HttpDynamicCommand/Http.c
@@ -1045,7 +1045,7 @@ WaitForCompletion (
     }
   }
 
-  gBS->SetTimer (WaitEvt, TimerCancel, 0);
+  (VOID)gBS->SetTimer (WaitEvt, TimerCancel, 0);
   gBS->CloseEvent (WaitEvt);
 
   if (*CallBackComplete) {

--- a/ShellPkg/Library/UefiShellNetwork1CommandsLib/Ifconfig.c
+++ b/ShellPkg/Library/UefiShellNetwork1CommandsLib/Ifconfig.c
@@ -1057,7 +1057,7 @@ IfConfigSetInterfaceInfo (
                               );
 
       if (Status == EFI_NOT_READY) {
-        gBS->SetTimer (TimeOutEvt, TimerRelative, 50000000);
+        (VOID)gBS->SetTimer (TimeOutEvt, TimerRelative, 50000000);
 
         while (EFI_ERROR (gBS->CheckEvent (TimeOutEvt))) {
           if (IsAddressOk) {

--- a/ShellPkg/Library/UefiShellNetwork1CommandsLib/Ping.c
+++ b/ShellPkg/Library/UefiShellNetwork1CommandsLib/Ping.c
@@ -294,7 +294,7 @@ GetTimerPeriod (
 
   gBS->RestoreTPL (OldTpl);
 
-  gBS->SetTimer (TimerEvent, TimerCancel, 0);
+  (VOID)gBS->SetTimer (TimerEvent, TimerCancel, 0);
   gBS->CloseEvent (TimerEvent);
 
   TimerPeriod = StallCounter / RttTimerTick;
@@ -363,7 +363,7 @@ PingFreeRttTimer (
   )
 {
   if (Private->RttTimer != NULL) {
-    gBS->SetTimer (Private->RttTimer, TimerCancel, 0);
+    (VOID)gBS->SetTimer (Private->RttTimer, TimerCancel, 0);
     gBS->CloseEvent (Private->RttTimer);
   }
 }
@@ -1493,7 +1493,7 @@ ON_STAT:
   //
   // Display the statistics in all.
   //
-  gBS->SetTimer (Private->Timer, TimerCancel, 0);
+  (VOID)gBS->SetTimer (Private->Timer, TimerCancel, 0);
 
   if (Private->TxCount != 0) {
     ShellPrintHiiDefaultEx (

--- a/ShellPkg/Library/UefiShellNetwork2CommandsLib/Ifconfig6.c
+++ b/ShellPkg/Library/UefiShellNetwork2CommandsLib/Ifconfig6.c
@@ -1408,7 +1408,7 @@ IfConfig6SetInterfaceInfo (
                        &CurDadXmits
                        );
 
-        gBS->SetTimer (TimeOutEvt, TimerRelative, 50000000 + 10000000 * CurDadXmits);
+        (VOID)gBS->SetTimer (TimeOutEvt, TimerRelative, 50000000 + 10000000 * CurDadXmits);
 
         while (EFI_ERROR (gBS->CheckEvent (TimeOutEvt))) {
           if (IsAddressOk) {

--- a/ShellPkg/Library/UefiShellNetwork2CommandsLib/Ping6.c
+++ b/ShellPkg/Library/UefiShellNetwork2CommandsLib/Ping6.c
@@ -165,7 +165,7 @@ Ping6GetTimerPeriod (
 
   gBS->RestoreTPL (OldTpl);
 
-  gBS->SetTimer (TimerEvent, TimerCancel, 0);
+  (VOID)gBS->SetTimer (TimerEvent, TimerCancel, 0);
   gBS->CloseEvent (TimerEvent);
 
   return StallCounter / RttTimerTick;
@@ -229,7 +229,7 @@ Ping6FreeRttTimer (
   )
 {
   if (Private->RttTimer != NULL) {
-    gBS->SetTimer (Private->RttTimer, TimerCancel, 0);
+    (VOID)gBS->SetTimer (Private->RttTimer, TimerCancel, 0);
     gBS->CloseEvent (Private->RttTimer);
   }
 }
@@ -1169,7 +1169,7 @@ ON_STAT:
   //
   // Display the statistics in all.
   //
-  gBS->SetTimer (Private->Timer, TimerCancel, 0);
+  (VOID)gBS->SetTimer (Private->Timer, TimerCancel, 0);
 
   if (Private->TxCount != 0) {
     ShellPrintHiiDefaultEx (


### PR DESCRIPTION
When gBS->SetTimer() is called and the return value is intentionally
not used, cast to (VOID) to make the intent explicit to static analysis
tools and code reviewers, rather than silently discarding the return value.

This fixes all 66 bare gBS->SetTimer() call sites across 6 packages
(39 files):

- NetworkPkg (19 files)
- MdeModulePkg (12 files)
- ShellPkg (5 files)
- EmulatorPkg (1 file)
- ArmPkg (1 file)
- OvmfPkg (1 file)

Each package is in a separate commit for independent review.


Cc: Saloni Kasbekar <saloni.kasbekar@intel.com>
Cc: Zachary Clark-williams <zachary.clark-williams@intel.com>
Cc: Michael D Kinney [michael.d.kinney@intel.com](mailto:michael.d.kinney@intel.com)

Signed-off-by: Abuthahir M [abuthahirm@ami.com](mailto:abuthahirm@ami.com)
