### PR TITLE
NetworkPkg/HttpBootDxe: Add all events to HttpBootHttpCallback()

### DIFF
--- a/NetworkPkg/HttpBootDxe/HttpBootImpl.c
+++ b/NetworkPkg/HttpBootDxe/HttpBootImpl.c
@@ -978,9 +978,8 @@ EFI_HTTP_BOOT_CALLBACK_PROTOCOL  gHttpBootDxeHttpBootCallback = {
 /**
   Callback function that is invoked when an HTTP event occurs during HTTP Boot.
 
-  This function handles TLS-related events (HttpEventTlsConnectSession and
-  HttpEventTlsConfigured) and prints error messages to the screen when a TLS
-  error is encountered during the HTTP Boot process.
+  This function handles all HTTP callback events and prints error messages
+  to the screen when an error is encountered during the HTTP Boot process.
 
   @param[in]  This              Pointer to the EDKII_HTTP_CALLBACK_PROTOCOL instance.
   @param[in]  Event             The event that occurs in the current state.
@@ -996,8 +995,20 @@ HttpBootHttpCallback (
 {
   if (EFI_ERROR (EventStatus)) {
     switch (Event) {
+      case HttpEventDns:
+        AsciiPrint ("\n  Error: DNS resolution failed - %r.\n", EventStatus);
+        break;
+
+      case HttpEventConnectTcp:
+        AsciiPrint ("\n  Error: TCP connection failed - %r.\n", EventStatus);
+        break;
+
       case HttpEventTlsConnectSession:
         AsciiPrint ("\n  Error: TLS session connection failed - %r.\n", EventStatus);
+        break;
+
+      case HttpEventInitSession:
+        AsciiPrint ("\n  Error: HTTP session initialization failed - %r.\n", EventStatus);
         break;
 
       case HttpEventTlsConfigured:
@@ -1005,6 +1016,7 @@ HttpBootHttpCallback (
         break;
 
       default:
+        AsciiPrint ("\n  Error: Unknown HTTP event - %r.\n", EventStatus);
         break;
     }
   }

--- a/NetworkPkg/HttpBootDxe/HttpBootImpl.h
+++ b/NetworkPkg/HttpBootDxe/HttpBootImpl.h
@@ -56,9 +56,8 @@ extern EFI_HTTP_BOOT_CALLBACK_PROTOCOL  gHttpBootDxeHttpBootCallback;
 /**
   Callback function that is invoked when an HTTP event occurs during HTTP Boot.
 
-  This function handles TLS-related events (HttpEventTlsConnectSession and
-  HttpEventTlsConfigured) and prints error messages to the screen when a TLS
-  error is encountered during the HTTP Boot process.
+  This function handles all HTTP callback events and prints error messages
+  to the screen when an error is encountered during the HTTP Boot process.
 
   @param[in]  This              Pointer to the EDKII_HTTP_CALLBACK_PROTOCOL instance.
   @param[in]  Event             The event that occurs in the current state.


### PR DESCRIPTION
Include other events from EDKII_HTTP_CALLBACK_EVENT to print failure information in the event of HTTP Boot failure

# Description

Add other non-TLS events to the print failure information during HTTP Boot flow for better end user experience

- [ ] Breaking change?

- [ ] Impacts security?

- [ ] Includes tests?

## How This Was Tested

Verified failure prints during HTTP Boot flow

## Integration Instructions

N/A
