### PR TITLE
OvmfPkg/LoongArchVirt: Move FirmwarePerformancePei to PEI driver region

### DIFF
--- a/OvmfPkg/LoongArchVirt/LoongArchVirtQemu.dsc
+++ b/OvmfPkg/LoongArchVirt/LoongArchVirtQemu.dsc
@@ -510,6 +510,7 @@
     <LibraryClasses>
       PcdLib|MdePkg/Library/PeiPcdLib/PeiPcdLib.inf
   }
+  MdeModulePkg/Universal/Acpi/FirmwarePerformanceDataTablePei/FirmwarePerformancePei.inf
 
   #
   # DXE Phase modules
@@ -732,7 +733,6 @@
   #
 !include OvmfPkg/Include/Dsc/ShellComponents.dsc.inc
 
-  MdeModulePkg/Universal/Acpi/FirmwarePerformanceDataTablePei/FirmwarePerformancePei.inf
   MdeModulePkg/Universal/Acpi/FirmwarePerformanceDataTableDxe/FirmwarePerformanceDxe.inf
   ShellPkg/DynamicCommand/DpDynamicCommand/DpDynamicCommand.inf {
     <PcdsFixedAtBuild>

--- a/OvmfPkg/LoongArchVirt/LoongArchVirtQemu.fdf
+++ b/OvmfPkg/LoongArchVirt/LoongArchVirtQemu.fdf
@@ -1,6 +1,6 @@
 ## @file
 #
-#  Copyright (c) 2024 Loongson Technology Corporation Limited. All rights reserved.<BR>
+#  Copyright (c) 2024-2026 Loongson Technology Corporation Limited. All rights reserved.<BR>
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -207,7 +207,6 @@ INF  OvmfPkg/VirtioFsDxe/VirtioFsDxe.inf
 #
 INF ShellPkg/Application/Shell/Shell.inf
 
-INF MdeModulePkg/Universal/Acpi/FirmwarePerformanceDataTablePei/FirmwarePerformancePei.inf
 INF MdeModulePkg/Universal/Acpi/FirmwarePerformanceDataTableDxe/FirmwarePerformanceDxe.inf
 INF ShellPkg/DynamicCommand/DpDynamicCommand/DpDynamicCommand.inf
 
@@ -251,6 +250,7 @@ INF  MdeModulePkg/Core/Pei/PeiMain.inf
 INF  MdeModulePkg/Universal/PCD/Pei/Pcd.inf
 INF  OvmfPkg/LoongArchVirt/PlatformPei/PlatformPei.inf
 INF  MdeModulePkg/Core/DxeIplPeim/DxeIpl.inf
+INF  MdeModulePkg/Universal/Acpi/FirmwarePerformanceDataTablePei/FirmwarePerformancePei.inf
 
 #
 # DXE Phase modules


### PR DESCRIPTION
# Description

In order to facilitate management, move FirmwarePerformancePei driver to PEI driver region. In this case, all PEI drivers are together.

## How This Was Tested

Boot Loongarch64 vitual machine successfully.

## Integration Instructions

N/A
