### PR TITLE
EmulatorPkg: Revert Remove EmulatorPkg from CLANGPDB CI

### DIFF
--- a/EmulatorPkg/PlatformCI/.azurepipelines/Ubuntu-CLANGPDB.yml
+++ b/EmulatorPkg/PlatformCI/.azurepipelines/Ubuntu-CLANGPDB.yml
@@ -1,0 +1,102 @@
+## @file
+# Azure Pipeline build file for building a platform.
+#
+# Platform: EmulatorPkg
+# OS: Ubuntu
+# Toolchain: CLANGPDB
+#
+# Copyright (c) Microsoft Corporation.
+# Copyright (c) 2020, Intel Corporation. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+trigger: none
+
+schedules:
+- cron: "0 2 * * *"
+  displayName: Daily Build
+  branches:
+    include:
+    - master
+    - stable/*
+  always: true
+
+pr:
+  - master
+  - stable/*
+
+variables:
+  - template: ../../../.azurepipelines/templates/defaults.yml
+
+jobs:
+  - job: Platform_CI
+    variables:
+      package: 'EmulatorPkg'
+      vm_image: ${{ variables.default_linux_vm }}
+      should_run: false
+      run_flags: "MAKE_STARTUP_NSH=TRUE"
+
+    #Use matrix to speed up the build process
+    strategy:
+        matrix:
+          EmulatorPkg_X64_DEBUG:
+            Build.File: "$(package)/PlatformCI/PlatformBuild.py"
+            Build.Arch: "X64"
+            Build.Flags: "BLD_*_NO_PLATFORM_BOOT_DELAYS"
+            Build.Target: "DEBUG"
+            Run.Flags: $(run_flags)
+            Run: $(should_run)
+          EmulatorPkg_X64_RELEASE:
+            Build.File: "$(package)/PlatformCI/PlatformBuild.py"
+            Build.Arch: "X64"
+            Build.Flags: "BLD_*_NO_PLATFORM_BOOT_DELAYS"
+            Build.Target: "RELEASE"
+            Run.Flags: $(run_flags)
+            Run: $(should_run)
+          EmulatorPkg_X64_NOOPT:
+            Build.File: "$(package)/PlatformCI/PlatformBuild.py"
+            Build.Arch: "X64"
+            Build.Flags: "BLD_*_NO_PLATFORM_BOOT_DELAYS"
+            Build.Target: "NOOPT"
+            Run.Flags: $(run_flags)
+            Run: $(should_run)
+          EmulatorPkg_X64_FULL_DEBUG:
+            Build.File: "$(package)/PlatformCI/PlatformBuild.py"
+            Build.Arch: "X64"
+            Build.Flags: "BLD_*_SECURE_BOOT_ENABLE=TRUE BLD_*_NO_PLATFORM_BOOT_DELAYS"
+            Build.Target: "DEBUG"
+            Run.Flags: $(run_flags)
+            Run: $(should_run)
+          EmulatorPkg_X64_FULL_RELEASE:
+            Build.File: "$(package)/PlatformCI/PlatformBuild.py"
+            Build.Arch: "X64"
+            Build.Flags: "BLD_*_SECURE_BOOT_ENABLE=TRUE BLD_*_NO_PLATFORM_BOOT_DELAYS"
+            Build.Target: "RELEASE"
+            Run.Flags: $(run_flags)
+            Run: $(should_run)
+          EmulatorPkg_X64_FULL_NOOPT:
+            Build.File: "$(package)/PlatformCI/PlatformBuild.py"
+            Build.Arch: "X64"
+            Build.Flags: "BLD_*_SECURE_BOOT_ENABLE=TRUE BLD_*_NO_PLATFORM_BOOT_DELAYS"
+            Build.Target: "NOOPT"
+            Run.Flags: $(run_flags)
+            Run: $(should_run)
+
+    workspace:
+      clean: all
+
+    pool:
+      vmImage: $(vm_image)
+
+    container: ${{ variables.default_linux_container }}
+
+    steps:
+    - template: ../../../.azurepipelines/templates/platform-build-run-steps.yml
+      parameters:
+        tool_chain_tag: CLANGPDB
+        build_pkg: $(package)
+        build_target: $(Build.Target)
+        build_arch: $(Build.Arch)
+        build_file: $(Build.File)
+        build_flags: $(Build.Flags)
+        run_flags: $(Run.Flags)
+        usePythonVersion: '' # use Python from the container image


### PR DESCRIPTION
# Description

This reverts commit 6e39689c659dd79c3c201832d9c7a83f84536653.

EmulatorPkg was explicitly excluded from CLANGPDB CI, since it was not supported under CLANGPDB at the time the CLANG CI PR was prepared.

It is now supported so revert the commit which disabled it.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

CI

## Integration Instructions

N/A