### PR TITLE
BaseTools: silence make

### DIFF
--- a/BaseTools/Conf/build_rule.template
+++ b/BaseTools/Conf/build_rule.template
@@ -418,8 +418,8 @@
         "$(GENFW)" -e $(MODULE_TYPE) -o ${dst} ${src} $(GENFW_FLAGS)
         $(CP) ${dst} $(DEBUG_DIR)
         $(CP) ${dst} $(BIN_DIR)(+)$(MODULE_NAME_GUID).efi
-        -$(CP) $(DEBUG_DIR)(+)*.map $(OUTPUT_DIR)
-        -$(CP) $(DEBUG_DIR)(+)*.pdb $(OUTPUT_DIR)
+        $(CP) $(DEBUG_DIR)(+)*.map $(OUTPUT_DIR) || true
+        $(CP) $(DEBUG_DIR)(+)*.pdb $(OUTPUT_DIR) || true
         
     <Command.XCODE>
         # tool to convert Mach-O to PE/COFF


### PR DESCRIPTION
# Description

Instead of using the '-' prefix append '|| true' to the commands where
errors should be ignored.  With the '-' prefix make will clutter the
build output with the messages about the (ignored) errors.

Changed only the GCC and CLANGDWARF rules for linux systems.

Signed-off-by: Gerd Hoffmann <kraxel@redhat.com>
