### PR TITLE
NvmExpressMediaClear: Fix BufferSize value in writeblocks call.

### DIFF
--- a/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressMediaSanitize.c
+++ b/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressMediaSanitize.c
@@ -355,13 +355,17 @@ NvmExpressMediaClear (
   }
 
   //
-  // If an invalid buffer or buffer size is sent, the Media Clear operation
-  // cannot be performed as it requires a native WRITE command. The overwrite
-  // buffer must have granularity of a namespace block size.
+  // If an invalid buffer is sent, the Media Clear operation
+  // cannot be performed as it requires a native WRITE command.
   //
   if (SectorOwBuffer == NULL) {
     return EFI_INVALID_PARAMETER;
   }
+
+  //
+  // Since the parameters do not include OwBuffer Size, the size of the overwrite buffer is assumed to be equal
+  // to the block size of the media.
+  //
 
   Status = EFI_SUCCESS;
 
@@ -373,9 +377,9 @@ NvmExpressMediaClear (
       Status = Device->BlockIo.WriteBlocks (
                                  &Device->BlockIo,
                                  MediaId,
-                                 SectorOffset,  // Sector/LBA offset (increment each pass)
-                                 1,             // Write one sector per write
-                                 SectorOwBuffer // overwrite buffer
+                                 SectorOffset,                   // Sector/LBA offset (increment each pass)
+                                 (UINTN)Device->Media.BlockSize, // Write one block/sector at a time with overwrite buffer
+                                 SectorOwBuffer                  // overwrite buffer
                                  );
     }
 


### PR DESCRIPTION
NvmExpressMediaClear requires that the overwrite buffer be the same size as the block size of the media but then WriteBlocks expects BufferSize in bytes. NvmExpressMediaClear was hardcoded to call using 1.  This causes the WriteBlocks to fail.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Host based unit tests.

## Integration Instructions

N/A
