### PR TITLE
Last LBA missed on NvmExpressMediaClear

### DIFF
--- a/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressMediaSanitize.c
+++ b/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressMediaSanitize.c
@@ -373,7 +373,7 @@ NvmExpressMediaClear (
   // Per NIST 800-88r1, one or more pass of writes may be alteratively used.
   //
   for (TotalPassCount = 0; TotalPassCount < PassCount; TotalPassCount++) {
-    for (SectorOffset = 0; SectorOffset < Media->LastBlock; SectorOffset++ ) {
+    for (SectorOffset = 0; SectorOffset <= Media->LastBlock; SectorOffset++ ) {
       Status = Device->BlockIo.WriteBlocks (
                                  &Device->BlockIo,
                                  MediaId,

--- a/MdePkg/Include/Protocol/BlockIo.h
+++ b/MdePkg/Include/Protocol/BlockIo.h
@@ -171,7 +171,8 @@ typedef struct {
   UINT32     IoAlign;
 
   ///
-  /// The last logical block address on the device.
+  /// The last logical block address on the device (inclusive).
+  /// This is generally the total number of user addressable blocks minus one.
   /// If the media changes, then this field is updated.
   ///
   EFI_LBA    LastBlock;


### PR DESCRIPTION
Off by one error in the code of NvmExpressMediaClear() causes the last LBA to be missed when clearing the media. This patch fixes the issue by adjusting the loop condition to ensure that all LBAs are cleared properly.


- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Host based unit tests and code inspection

## Integration Instructions

n/a
