### PR TITLE
NvmExpressDriverBindingStart: early return leaks Private and protocol opens

### DIFF
--- a/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpress.c
+++ b/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpress.c
@@ -986,6 +986,14 @@ NvmExpressDriverBindingStart (
                   );
 
   if (EFI_ERROR (Status) && (Status != EFI_ALREADY_STARTED)) {
+    DEBUG ((DEBUG_ERROR, "%a: failed to open PCI I/O protocol (%r)\n", __func__, Status));
+    // need to free the device path protocol if it was opened successfully
+    gBS->CloseProtocol (
+           Controller,
+           &gEfiDevicePathProtocolGuid,
+           This->DriverBindingHandle,
+           Controller
+           );
     return Status;
   }
 
@@ -996,7 +1004,7 @@ NvmExpressDriverBindingStart (
     Private = AllocateZeroPool (sizeof (NVME_CONTROLLER_PRIVATE_DATA));
 
     if (Private == NULL) {
-      DEBUG ((DEBUG_ERROR, "NvmExpressDriverBindingStart: allocating pool for Nvme Private Data failed!\n"));
+      DEBUG ((DEBUG_ERROR, "%a: allocating pool for Nvme Private Data failed!\n", __func__));
       Status = EFI_OUT_OF_RESOURCES;
       goto Exit;
     }
@@ -1012,7 +1020,8 @@ NvmExpressDriverBindingStart (
                       );
 
     if (EFI_ERROR (Status)) {
-      return Status;
+      DEBUG ((DEBUG_ERROR, "%a: failed to get PCI attributes (%r)\n", __func__, Status));
+      goto Exit;
     }
 
     //


### PR DESCRIPTION

After allocating Private via AllocateZeroPool and successfully opening both gEfiDevicePathProtocolGuid and gEfiPciIoProtocolGuid BY_DRIVER, the function attempts PciIo->Attributes(EfiPciIoAttributeOperationGet) If this call fails, the code executes return Status instead of goto Exit.

Trigger path:

NvmExpressDriverBindingStart is called.
OpenProtocol for DevicePath succeeds (opens BY_DRIVER). OpenProtocol for PciIo succeeds (opens BY_DRIVER). AllocateZeroPool for Private succeeds.
PciIo->Attributes(Get) returns an error.
return Status bypasses the Exit: label.

Consequence:
Memory leak of NVME_CONTROLLER_PRIVATE_DATA. Two protocols remain opened BY_DRIVER on the controller handle, preventing other drivers from binding.



- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

review

## Integration Instructions

n/a
