### PR TITLE
Global: optimise StandaloneMmMmuLib with FF-A v1.3 and change ArmFfaGetVersion()'s argument type

### DIFF
--- a/ArmPkg/Drivers/MmCommunicationDxe/MmCommunication.c
+++ b/ArmPkg/Drivers/MmCommunicationDxe/MmCommunication.c
@@ -495,23 +495,18 @@ GetFfaCompatibility (
   )
 {
   EFI_STATUS  Status;
-  UINT16      CurrentMajorVersion;
-  UINT16      CurrentMinorVersion;
+  UINT32      CurrentVersion;
 
   Status = ArmFfaLibGetVersion (
-             ARM_FFA_MAJOR_VERSION,
-             ARM_FFA_MINOR_VERSION,
-             &CurrentMajorVersion,
-             &CurrentMinorVersion
+             ARM_FFA_CREATE_VERSION (ARM_FFA_MAJOR_VERSION, ARM_FFA_MINOR_VERSION),
+             &CurrentVersion
              );
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "Failed to get FF-A version. Status: %r\n", Status));
     return EFI_UNSUPPORTED;
   }
 
-  if ((ARM_FFA_MAJOR_VERSION != CurrentMajorVersion) ||
-      (ARM_FFA_MINOR_VERSION > CurrentMinorVersion))
-  {
+  if (!ARM_FFA_ABI_COMPATIBLE (CurrentVersion, ARM_FFA_MAJOR_VERSION, ARM_FFA_MINOR_VERSION)) {
     DEBUG ((
       DEBUG_ERROR,
       "Incompatible FF-A Versions for MM_COMM.\n" \
@@ -519,8 +514,8 @@ GetFfaCompatibility (
       "Current Version: Major=0x%x, Minor>=0x%x.\n",
       ARM_FFA_MAJOR_VERSION,
       ARM_FFA_MINOR_VERSION,
-      CurrentMajorVersion,
-      CurrentMinorVersion
+      ARM_FFA_MAJOR_VERSION_GET (CurrentVersion),
+      ARM_FFA_MINOR_VERSION_GET (CurrentVersion)
       ));
     return EFI_UNSUPPORTED;
   }
@@ -528,8 +523,8 @@ GetFfaCompatibility (
   DEBUG ((
     DEBUG_INFO,
     "FF-A Version for MM_COMM: Major=0x%x, Minor=0x%x\n",
-    CurrentMajorVersion,
-    CurrentMinorVersion
+    ARM_FFA_MAJOR_VERSION_GET (CurrentVersion),
+    ARM_FFA_MINOR_VERSION_GET (CurrentVersion)
     ));
 
   return EFI_SUCCESS;

--- a/ArmPkg/Drivers/MmCommunicationPei/MmCommunicationPei.c
+++ b/ArmPkg/Drivers/MmCommunicationPei/MmCommunicationPei.c
@@ -91,22 +91,17 @@ GetFfaCompatibility (
   )
 {
   EFI_STATUS  Status;
-  UINT16      CurrentMajorVersion;
-  UINT16      CurrentMinorVersion;
+  UINT32      CurrentVersion;
 
   Status = ArmFfaLibGetVersion (
-             ARM_FFA_MAJOR_VERSION,
-             ARM_FFA_MINOR_VERSION,
-             &CurrentMajorVersion,
-             &CurrentMinorVersion
+             ARM_FFA_CREATE_VERSION (ARM_FFA_MAJOR_VERSION, ARM_FFA_MINOR_VERSION),
+             &CurrentVersion
              );
   if (EFI_ERROR (Status)) {
     return EFI_UNSUPPORTED;
   }
 
-  if ((ARM_FFA_MAJOR_VERSION != CurrentMajorVersion) ||
-      (ARM_FFA_MINOR_VERSION > CurrentMinorVersion))
-  {
+  if (!ARM_FFA_ABI_COMPATIBLE (CurrentVersion, ARM_FFA_MAJOR_VERSION, ARM_FFA_MINOR_VERSION)) {
     DEBUG ((
       DEBUG_INFO,
       "Incompatible FF-A Versions for MM_COMM.\n" \
@@ -114,8 +109,8 @@ GetFfaCompatibility (
       "Current Version: Major=0x%x, Minor>=0x%x.\n",
       ARM_FFA_MAJOR_VERSION,
       ARM_FFA_MINOR_VERSION,
-      CurrentMajorVersion,
-      CurrentMinorVersion
+      ARM_FFA_MAJOR_VERSION_GET (CurrentVersion),
+      ARM_FFA_MINOR_VERSION_GET (CurrentVersion)
       ));
     return EFI_UNSUPPORTED;
   }
@@ -123,8 +118,8 @@ GetFfaCompatibility (
   DEBUG ((
     DEBUG_INFO,
     "FF-A Version for MM_COMM: Major=0x%x, Minor=0x%x\n",
-    CurrentMajorVersion,
-    CurrentMinorVersion
+    ARM_FFA_MAJOR_VERSION_GET (CurrentVersion),
+    ARM_FFA_MINOR_VERSION_GET (CurrentVersion)
     ));
 
   return EFI_SUCCESS;

--- a/ArmPkg/Library/ArmStandaloneMmCoreEntryPoint/ArmStandaloneMmCoreEntryPoint.c
+++ b/ArmPkg/Library/ArmStandaloneMmCoreEntryPoint/ArmStandaloneMmCoreEntryPoint.c
@@ -76,6 +76,7 @@ GetCommProtocol (
   EFI_STATUS    Status;
   UINT16        RequestMajorVersion;
   UINT16        RequestMinorVersion;
+  UINT32        CurrentVersion;
   UINT16        CurrentMajorVersion;
   UINT16        CurrentMinorVersion;
   ARM_SVC_ARGS  SvcArgs;
@@ -84,13 +85,13 @@ GetCommProtocol (
   RequestMinorVersion = ARM_FFA_MINOR_VERSION;
 
   Status = ArmFfaLibGetVersion (
-             RequestMajorVersion,
-             RequestMinorVersion,
-             &CurrentMajorVersion,
-             &CurrentMinorVersion
+             ARM_FFA_CREATE_VERSION (RequestMajorVersion, RequestMinorVersion),
+             &CurrentVersion
              );
   if (!EFI_ERROR (Status)) {
-    *CommProtocol = CommProtocolFfa;
+    *CommProtocol       = CommProtocolFfa;
+    CurrentMajorVersion = ARM_FFA_MAJOR_VERSION_GET (CurrentVersion);
+    CurrentMinorVersion = ARM_FFA_MINOR_VERSION_GET (CurrentVersion);
   } else {
     ZeroMem (&SvcArgs, sizeof (ARM_SVC_ARGS));
     SvcArgs.Arg0 = ARM_FID_SPM_MM_VERSION_AARCH32;

--- a/ArmPkg/Library/StandaloneMmMmuLib/ArmMmuStandaloneMmLib.c
+++ b/ArmPkg/Library/StandaloneMmMmuLib/ArmMmuStandaloneMmLib.c
@@ -35,6 +35,9 @@
   StMM Core invokes this library before constructors are called and before the
   StMM image itself is relocated.
 
+  @param[out]     MajorVersion        Major Version of ABI.
+  @param[out]     MinorVersion        Minor Version of ABI.
+
   @retval TRUE            Use FF-A MemPerm ABIs.
   @retval FALSE           Use MM MemPerm ABIs.
 
@@ -43,20 +46,21 @@ STATIC
 BOOLEAN
 EFIAPI
 IsFfaMemoryAbiSupported (
-  IN VOID
+  OUT UINT16  *MajorVersion,
+  OUT UINT16  *MinorVersion
   )
 {
   EFI_STATUS  Status;
-  UINT16      CurrentMajorVersion;
-  UINT16      CurrentMinorVersion;
+
+  *MajorVersion = 0;
+  *MinorVersion = 0;
 
   Status = ArmFfaLibGetVersion (
              ARM_FFA_MAJOR_VERSION,
              ARM_FFA_MINOR_VERSION,
-             &CurrentMajorVersion,
-             &CurrentMinorVersion
+             MajorVersion,
+             MinorVersion
              );
-
   if (EFI_ERROR (Status)) {
     return FALSE;
   }
@@ -147,8 +151,13 @@ SendMemoryPermissionRequest (
 /** Request the permission attributes of a memory region from S-EL0.
 
   @param [in]   UseFfaAbis           Use FF-A abis or not.
+  @param [in]   AbiMajorVersion      ABI Major Version
+  @param [in]   AbiMinorVersion      ABI Minor Version
   @param [in]   BaseAddress          Base address for the memory region.
+  @param [in]   Length               Size of memory region.
   @param [out]  MemoryAttributes     Pointer to return the memory attributes.
+  @param [out]  PageCount            Number of page sharing the same attribute from
+                                     BaseAddress
 
   @retval EFI_SUCCESS             Request successfull.
   @retval EFI_INVALID_PARAMETER   A parameter is invalid.
@@ -165,8 +174,12 @@ STATIC
 EFI_STATUS
 GetMemoryPermissions (
   IN     BOOLEAN               UseFfaAbis,
+  IN     UINT16                AbiMajorVersion,
+  IN     UINT16                AbiMinorVersion,
   IN     EFI_PHYSICAL_ADDRESS  BaseAddress,
-  OUT    UINT32                *MemoryAttributes
+  IN     UINT64                Length,
+  OUT    UINT32                *MemoryAttributes,
+  OUT    UINT32                *PageCount
   )
 {
   EFI_STATUS    Status;
@@ -187,11 +200,34 @@ GetMemoryPermissions (
   SvcArgs.Arg0 = Fid;
   SvcArgs.Arg1 = BaseAddress;
 
+  if (UseFfaAbis && ((AbiMajorVersion > 1) || (AbiMinorVersion > 2))) {
+    /*
+     * The input page count is encoded as (page count - 1),
+     * so subtract 1 from the actual page count.
+     * See the FF-A Memory Management Protocol Spec version 1.3-ALP1
+     * 2.8 FFA_MEM_PERM_GET
+     */
+    SvcArgs.Arg2 = EFI_SIZE_TO_PAGES (Length) - 1;
+  }
+
   Status = SendMemoryPermissionRequest (UseFfaAbis, &SvcArgs, &Ret);
   if (EFI_ERROR (Status)) {
     *MemoryAttributes = 0;
+    *PageCount        = 0;
   } else {
     *MemoryAttributes = Ret;
+    if (UseFfaAbis && ((AbiMajorVersion > 1) || (AbiMinorVersion > 2))) {
+      /*
+       * The output page count is encoded as (page count - 1),
+       * so add 1 to get the actual page count.
+       * See the FF-A Memory Management Protocol Spec version 1.3-ALP1
+       * 2.8 FFA_MEM_PERM_GET
+       */
+      *PageCount = SvcArgs.Arg3 + 1;
+      ASSERT (*PageCount > EFI_SIZE_TO_PAGES (Length));
+    } else {
+      *PageCount = 1;
+    }
   }
 
   return Status;
@@ -253,16 +289,28 @@ ArmSetMemoryRegionNoExec (
   UINT32      MemoryAttributes;
   UINT32      PermissionRequest;
   BOOLEAN     UseFfaAbis;
+  UINT16      MajorVersion;
+  UINT16      MinorVersion;
   UINTN       Size;
+  UINT32      PageCount;
 
-  UseFfaAbis = IsFfaMemoryAbiSupported ();
-  Size       = EFI_PAGE_SIZE;
+  UseFfaAbis = IsFfaMemoryAbiSupported (&MajorVersion, &MinorVersion);
 
   while (Length > 0) {
-    Status = GetMemoryPermissions (UseFfaAbis, BaseAddress, &MemoryAttributes);
+    Status = GetMemoryPermissions (
+               UseFfaAbis,
+               MajorVersion,
+               MinorVersion,
+               BaseAddress,
+               Length,
+               &MemoryAttributes,
+               &PageCount
+               );
     if (EFI_ERROR (Status)) {
       break;
     }
+
+    Size = EFI_PAGES_TO_SIZE (PageCount);
 
     if (UseFfaAbis) {
       PermissionRequest = ARM_FFA_SET_MEM_ATTR_MAKE_PERM_REQUEST (
@@ -307,16 +355,28 @@ ArmClearMemoryRegionNoExec (
   UINT32      MemoryAttributes;
   UINT32      PermissionRequest;
   BOOLEAN     UseFfaAbis;
+  UINT16      MajorVersion;
+  UINT16      MinorVersion;
   UINTN       Size;
+  UINT32      PageCount;
 
-  UseFfaAbis = IsFfaMemoryAbiSupported ();
-  Size       = EFI_PAGE_SIZE;
+  UseFfaAbis = IsFfaMemoryAbiSupported (&MajorVersion, &MinorVersion);
 
   while (Length > 0) {
-    Status = GetMemoryPermissions (UseFfaAbis, BaseAddress, &MemoryAttributes);
+    Status = GetMemoryPermissions (
+               UseFfaAbis,
+               MajorVersion,
+               MinorVersion,
+               BaseAddress,
+               Length,
+               &MemoryAttributes,
+               &PageCount
+               );
     if (EFI_ERROR (Status)) {
       break;
     }
+
+    Size = EFI_PAGES_TO_SIZE (PageCount);
 
     if (UseFfaAbis) {
       PermissionRequest = ARM_FFA_SET_MEM_ATTR_MAKE_PERM_REQUEST (
@@ -361,16 +421,28 @@ ArmSetMemoryRegionReadOnly (
   UINT32      MemoryAttributes;
   UINT32      PermissionRequest;
   BOOLEAN     UseFfaAbis;
+  UINT16      MajorVersion;
+  UINT16      MinorVersion;
   UINTN       Size;
+  UINT32      PageCount;
 
-  UseFfaAbis = IsFfaMemoryAbiSupported ();
-  Size       = EFI_PAGE_SIZE;
+  UseFfaAbis = IsFfaMemoryAbiSupported (&MajorVersion, &MinorVersion);
 
   while (Length > 0) {
-    Status = GetMemoryPermissions (UseFfaAbis, BaseAddress, &MemoryAttributes);
+    Status = GetMemoryPermissions (
+               UseFfaAbis,
+               MajorVersion,
+               MinorVersion,
+               BaseAddress,
+               Length,
+               &MemoryAttributes,
+               &PageCount
+               );
     if (EFI_ERROR (Status)) {
       break;
     }
+
+    Size = EFI_PAGES_TO_SIZE (PageCount);
 
     if (UseFfaAbis) {
       PermissionRequest = ARM_FFA_SET_MEM_ATTR_MAKE_PERM_REQUEST (
@@ -415,16 +487,28 @@ ArmClearMemoryRegionReadOnly (
   UINT32      MemoryAttributes;
   UINT32      PermissionRequest;
   BOOLEAN     UseFfaAbis;
+  UINT16      MajorVersion;
+  UINT16      MinorVersion;
   UINTN       Size;
+  UINT32      PageCount;
 
-  UseFfaAbis = IsFfaMemoryAbiSupported ();
-  Size       = EFI_PAGE_SIZE;
+  UseFfaAbis = IsFfaMemoryAbiSupported (&MajorVersion, &MinorVersion);
 
   while (Length > 0) {
-    Status = GetMemoryPermissions (UseFfaAbis, BaseAddress, &MemoryAttributes);
+    Status = GetMemoryPermissions (
+               UseFfaAbis,
+               MajorVersion,
+               MinorVersion,
+               BaseAddress,
+               Length,
+               &MemoryAttributes,
+               &PageCount
+               );
     if (EFI_ERROR (Status)) {
       break;
     }
+
+    Size = EFI_PAGES_TO_SIZE (PageCount);
 
     if (UseFfaAbis) {
       PermissionRequest = ARM_FFA_SET_MEM_ATTR_MAKE_PERM_REQUEST (

--- a/ArmPkg/Library/StandaloneMmMmuLib/ArmMmuStandaloneMmLib.c
+++ b/ArmPkg/Library/StandaloneMmMmuLib/ArmMmuStandaloneMmLib.c
@@ -35,8 +35,7 @@
   StMM Core invokes this library before constructors are called and before the
   StMM image itself is relocated.
 
-  @param[out]     MajorVersion        Major Version of ABI.
-  @param[out]     MinorVersion        Minor Version of ABI.
+  @param[out]             Version        Version of FF-A ABI.
 
   @retval TRUE            Use FF-A MemPerm ABIs.
   @retval FALSE           Use MM MemPerm ABIs.
@@ -46,20 +45,16 @@ STATIC
 BOOLEAN
 EFIAPI
 IsFfaMemoryAbiSupported (
-  OUT UINT16  *MajorVersion,
-  OUT UINT16  *MinorVersion
+  OUT UINT32  *Version
   )
 {
   EFI_STATUS  Status;
 
-  *MajorVersion = 0;
-  *MinorVersion = 0;
+  *Version = 0;
 
   Status = ArmFfaLibGetVersion (
-             ARM_FFA_MAJOR_VERSION,
-             ARM_FFA_MINOR_VERSION,
-             MajorVersion,
-             MinorVersion
+             ARM_FFA_CREATE_VERSION (ARM_FFA_MAJOR_VERSION, ARM_FFA_MINOR_VERSION),
+             Version
              );
   if (EFI_ERROR (Status)) {
     return FALSE;
@@ -151,8 +146,7 @@ SendMemoryPermissionRequest (
 /** Request the permission attributes of a memory region from S-EL0.
 
   @param [in]   UseFfaAbis           Use FF-A abis or not.
-  @param [in]   AbiMajorVersion      ABI Major Version
-  @param [in]   AbiMinorVersion      ABI Minor Version
+  @param [in]   AbiVersion           ABI Version
   @param [in]   BaseAddress          Base address for the memory region.
   @param [in]   Length               Size of memory region.
   @param [out]  MemoryAttributes     Pointer to return the memory attributes.
@@ -174,8 +168,7 @@ STATIC
 EFI_STATUS
 GetMemoryPermissions (
   IN     BOOLEAN               UseFfaAbis,
-  IN     UINT16                AbiMajorVersion,
-  IN     UINT16                AbiMinorVersion,
+  IN     UINT32                AbiVersion,
   IN     EFI_PHYSICAL_ADDRESS  BaseAddress,
   IN     UINT64                Length,
   OUT    UINT32                *MemoryAttributes,
@@ -200,7 +193,7 @@ GetMemoryPermissions (
   SvcArgs.Arg0 = Fid;
   SvcArgs.Arg1 = BaseAddress;
 
-  if (UseFfaAbis && ((AbiMajorVersion > 1) || (AbiMinorVersion > 2))) {
+  if (UseFfaAbis && ARM_FFA_ABI_MINIMUM (AbiVersion, 1, 3)) {
     /*
      * The input page count is encoded as (page count - 1),
      * so subtract 1 from the actual page count.
@@ -216,7 +209,7 @@ GetMemoryPermissions (
     *PageCount        = 0;
   } else {
     *MemoryAttributes = Ret;
-    if (UseFfaAbis && ((AbiMajorVersion > 1) || (AbiMinorVersion > 2))) {
+    if (UseFfaAbis && ARM_FFA_ABI_MINIMUM (AbiVersion, 1, 3)) {
       /*
        * The output page count is encoded as (page count - 1),
        * so add 1 to get the actual page count.
@@ -289,18 +282,16 @@ ArmSetMemoryRegionNoExec (
   UINT32      MemoryAttributes;
   UINT32      PermissionRequest;
   BOOLEAN     UseFfaAbis;
-  UINT16      MajorVersion;
-  UINT16      MinorVersion;
+  UINT32      Version;
   UINTN       Size;
   UINT32      PageCount;
 
-  UseFfaAbis = IsFfaMemoryAbiSupported (&MajorVersion, &MinorVersion);
+  UseFfaAbis = IsFfaMemoryAbiSupported (&Version);
 
   while (Length > 0) {
     Status = GetMemoryPermissions (
                UseFfaAbis,
-               MajorVersion,
-               MinorVersion,
+               Version,
                BaseAddress,
                Length,
                &MemoryAttributes,
@@ -355,18 +346,16 @@ ArmClearMemoryRegionNoExec (
   UINT32      MemoryAttributes;
   UINT32      PermissionRequest;
   BOOLEAN     UseFfaAbis;
-  UINT16      MajorVersion;
-  UINT16      MinorVersion;
+  UINT32      Version;
   UINTN       Size;
   UINT32      PageCount;
 
-  UseFfaAbis = IsFfaMemoryAbiSupported (&MajorVersion, &MinorVersion);
+  UseFfaAbis = IsFfaMemoryAbiSupported (&Version);
 
   while (Length > 0) {
     Status = GetMemoryPermissions (
                UseFfaAbis,
-               MajorVersion,
-               MinorVersion,
+               Version,
                BaseAddress,
                Length,
                &MemoryAttributes,
@@ -421,18 +410,16 @@ ArmSetMemoryRegionReadOnly (
   UINT32      MemoryAttributes;
   UINT32      PermissionRequest;
   BOOLEAN     UseFfaAbis;
-  UINT16      MajorVersion;
-  UINT16      MinorVersion;
+  UINT32      Version;
   UINTN       Size;
   UINT32      PageCount;
 
-  UseFfaAbis = IsFfaMemoryAbiSupported (&MajorVersion, &MinorVersion);
+  UseFfaAbis = IsFfaMemoryAbiSupported (&Version);
 
   while (Length > 0) {
     Status = GetMemoryPermissions (
                UseFfaAbis,
-               MajorVersion,
-               MinorVersion,
+               Version,
                BaseAddress,
                Length,
                &MemoryAttributes,
@@ -487,18 +474,16 @@ ArmClearMemoryRegionReadOnly (
   UINT32      MemoryAttributes;
   UINT32      PermissionRequest;
   BOOLEAN     UseFfaAbis;
-  UINT16      MajorVersion;
-  UINT16      MinorVersion;
+  UINT32      Version;
   UINTN       Size;
   UINT32      PageCount;
 
-  UseFfaAbis = IsFfaMemoryAbiSupported (&MajorVersion, &MinorVersion);
+  UseFfaAbis = IsFfaMemoryAbiSupported (&Version);
 
   while (Length > 0) {
     Status = GetMemoryPermissions (
                UseFfaAbis,
-               MajorVersion,
-               MinorVersion,
+               Version,
                BaseAddress,
                Length,
                &MemoryAttributes,

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaCommon.c
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaCommon.c
@@ -176,19 +176,15 @@ ArmCallFfa (
 /**
   Get FF-A version.
 
-  @param [in]    RequestMajorVersion          Minimal request major version
-  @param [in]    RequestMinorVersion          Minimal request minor version
-  @param [out]   CurrentMajorVersion          Current major version
-  @param [out]   CurrentMinorVersion          Current minor version
+  @param [in]    RequestVersion          Minimal request version
+  @param [out]   CurrentVersion          Current major version
 
 **/
 EFI_STATUS
 EFIAPI
 ArmFfaLibGetVersion (
-  IN  UINT16  RequestMajorVersion,
-  IN  UINT16  RequestMinorVersion,
-  OUT UINT16  *CurrentMajorVersion,
-  OUT UINT16  *CurrentMinorVersion
+  IN  UINT32  RequestVersion,
+  OUT UINT32  *CurrentVersion
   )
 {
   EFI_STATUS    Status;
@@ -197,10 +193,7 @@ ArmFfaLibGetVersion (
   ZeroMem (&FfaArgs, sizeof (ARM_FFA_ARGS));
 
   FfaArgs.Arg0 = ARM_FID_FFA_VERSION;
-  FfaArgs.Arg1 = ARM_FFA_CREATE_VERSION (
-                   RequestMajorVersion,
-                   RequestMinorVersion
-                   );
+  FfaArgs.Arg1 = RequestVersion;
 
   ArmCallFfa (&FfaArgs);
 
@@ -209,12 +202,8 @@ ArmFfaLibGetVersion (
     return Status;
   }
 
-  if (CurrentMajorVersion != NULL) {
-    *CurrentMajorVersion = ARM_FFA_MAJOR_VERSION_GET (FfaArgs.Arg0);
-  }
-
-  if (CurrentMinorVersion != NULL) {
-    *CurrentMinorVersion = ARM_FFA_MINOR_VERSION_GET (FfaArgs.Arg0);
+  if (CurrentVersion != NULL) {
+    *CurrentVersion = FfaArgs.Arg0;
   }
 
   return EFI_SUCCESS;
@@ -1208,31 +1197,26 @@ ArmFfaLibIsFfaSupported (
   )
 {
   EFI_STATUS  Status;
-  UINT16      CurrentMajorVersion;
-  UINT16      CurrentMinorVersion;
+  UINT32      CurrentVersion;
 
   Status = ArmFfaLibGetVersion (
-             ARM_FFA_MAJOR_VERSION,
-             ARM_FFA_MINOR_VERSION,
-             &CurrentMajorVersion,
-             &CurrentMinorVersion
+             ARM_FFA_CREATE_VERSION (ARM_FFA_MAJOR_VERSION, ARM_FFA_MINOR_VERSION),
+             &CurrentVersion
              );
   if (EFI_ERROR (Status)) {
     return FALSE;
   }
 
-  if ((ARM_FFA_MAJOR_VERSION != CurrentMajorVersion) ||
-      (ARM_FFA_MINOR_VERSION > CurrentMinorVersion))
-  {
+  if (!ARM_FFA_ABI_COMPATIBLE (CurrentVersion, ARM_FFA_MAJOR_VERSION, ARM_FFA_MINOR_VERSION)) {
     DEBUG ((
       DEBUG_INFO,
       "Incompatible FF-A Versions.\n" \
       "Request Version: Major=0x%x, Minor=0x%x.\n" \
-      "Current Version: Major=0x%x, Minor>=0x%x.\n",
+      "Current Version: Major=0x%x, Minor=0x%x.\n",
       ARM_FFA_MAJOR_VERSION,
       ARM_FFA_MINOR_VERSION,
-      CurrentMajorVersion,
-      CurrentMinorVersion
+      ARM_FFA_MAJOR_VERSION_GET (CurrentVersion),
+      ARM_FFA_MINOR_VERSION_GET (CurrentVersion)
       ));
     return FALSE;
   }

--- a/MdePkg/Include/IndustryStandard/ArmFfaSvc.h
+++ b/MdePkg/Include/IndustryStandard/ArmFfaSvc.h
@@ -113,6 +113,15 @@
   (((major) << ARM_FFA_MAJOR_VERSION_SHIFT) | \
    ((minor) << ARM_FFA_MINOR_VERSION_SHIFT))
 
+#define ARM_FFA_ABI_COMPATIBLE(version, major, minor) \
+  ((BOOLEAN)(((ARM_FFA_MAJOR_VERSION_GET(version)) == major) && \
+             ((ARM_FFA_MINOR_VERSION_GET(version)) >= minor)))
+
+#define ARM_FFA_ABI_MINIMUM(version, major, minor) \
+  ((BOOLEAN)(((ARM_FFA_MAJOR_VERSION_GET(version)) < major) ? FALSE :  \
+              (((ARM_FFA_MAJOR_VERSION_GET(version)) > major) ? TRUE : \
+                ((ARM_FFA_MINOR_VERSION_GET(version)) >= minor))))
+
 #define ARM_FFA_FEATURES_ID_TYPE_SHIFT     31
 #define ARM_FFA_FEATURES_ID_TYPE_MASK      1
 #define ARM_FFA_FEATURES_ID_TYPE_FEATURE   0

--- a/MdePkg/Include/Library/ArmFfaLib.h
+++ b/MdePkg/Include/Library/ArmFfaLib.h
@@ -172,19 +172,15 @@ ArmFfaLibGetRxTxBuffers (
 /**
   Get FF-A version
 
-  @param [in]    RequestMajorVersion          Minimal request major version
-  @param [in]    RequestMinorVersion          Minimal request minor version
-  @param [out]   CurrentMajorVersion          Current major version
-  @param [out]   CurrentMinorVersion          Current minor version
+  @param [in]    RequestVersion          Minimal request version
+  @param [out]   CurrentVersion          Current major version
 
 **/
 EFI_STATUS
 EFIAPI
 ArmFfaLibGetVersion (
-  IN  UINT16  RequestMajorVersion,
-  IN  UINT16  RequestMinorVersion,
-  OUT UINT16  *CurrentMajorVersion,
-  OUT UINT16  *CurrentMinorVersion
+  IN  UINT32  RequestVersion,
+  OUT UINT32  *CurrentVersion
   );
 
 /**


### PR DESCRIPTION
# Description

commit 4ca452c ("ArmPkg/Library: Update StandaloneMmuLib with FF-A v1.2 with page granularity") introduced page-granular memory permission updates to fix the StandaloneMm load failure.

However, this approach results in issuing an SMC call per page when updating permissions over a region.

Since FF-A Memory Management Protocol v1.3 [0],
FFA_MEM_PERM_GET has been updated to return the number of contiguous pages that share the same memory permission starting from a base address.

With this change, update memory permissions in bulk (per contiguous page range) to reduce the number of SMC calls, leveraging FF-A Memory Management Protocol v1.3 [0].

Also, This patch includes to change ArmFfaGetVersion()'s argumtents type to remove
some impression treating major and minor version of the ABI as two unrelated 16-bit variables
as opposed to the upper and lower 16-bits of a 32-bit version variable.

Link: https://developer.arm.com/documentation/den0140/latest [0]

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Boot testing StandaloneMm in FVP revC

## Integration Instructions

N/A