### PR TITLE
MdeModulePkg/CapsuleOnDisk: Skip network boot options when searching for ESP

### DIFF
--- a/MdeModulePkg/Application/CapsuleApp/CapsuleOnDisk.c
+++ b/MdeModulePkg/Application/CapsuleApp/CapsuleOnDisk.c
@@ -13,6 +13,57 @@ EFI_GUID  mCapsuleOnDiskBootOptionGuid = {
 };
 
 /**
+  Check if a device path is a network boot option that cannot host an EFI
+  System Partition.  Returns TRUE if the device path contains a network node
+  (MAC, IPv4, IPv6, or URI) and does NOT contain an iSCSI node.  iSCSI boot
+  options travel over the network but can present an EFI System Partition and
+  must not be skipped.
+
+  @param[in] DevicePath  The device path to check.
+
+  @retval TRUE   The device path is a non-iSCSI network boot option.
+  @retval FALSE  The device path is not a network boot option, or it is iSCSI.
+**/
+STATIC
+BOOLEAN
+IsPxeBootDevicePath (
+  IN EFI_DEVICE_PATH_PROTOCOL  *DevicePath
+  )
+{
+  EFI_DEVICE_PATH_PROTOCOL  *Node;
+  BOOLEAN                   HasNetworkNode;
+
+  if (DevicePath == NULL) {
+    return FALSE;
+  }
+
+  HasNetworkNode = FALSE;
+
+  for (Node = DevicePath; !IsDevicePathEnd (Node); Node = NextDevicePathNode (Node)) {
+    if (DevicePathType (Node) == MESSAGING_DEVICE_PATH) {
+      switch (DevicePathSubType (Node)) {
+        case MSG_MAC_ADDR_DP:
+        case MSG_IPv4_DP:
+        case MSG_IPv6_DP:
+        case MSG_URI_DP:
+          HasNetworkNode = TRUE;
+          break;
+        case MSG_ISCSI_DP:
+          //
+          // iSCSI is network-based but can host an EFI System Partition.
+          // Do not skip iSCSI boot options.
+          //
+          return FALSE;
+        default:
+          break;
+      }
+    }
+  }
+
+  return HasNetworkNode;
+}
+
+/**
   Get file name from file path.
 
   @param  FilePath    File path.
@@ -475,6 +526,15 @@ GetUpdateFileSystem (
     if (((BootOptionBuffer[Index].Attributes & LOAD_OPTION_ACTIVE) == 0) ||
         (DevicePathType (DevicePath) == BBS_DEVICE_PATH))
     {
+      continue;
+    }
+
+    //
+    // Skip PXE and HTTP boot options - they do not provide an EFI System
+    // Partition. iSCSI boot options are not skipped as they can host an ESP.
+    //
+    if (IsPxeBootDevicePath (DevicePath)) {
+      DEBUG ((DEBUG_INFO, "CapsuleOnDisk: Skip network boot option\n"));
       continue;
     }
 

--- a/MdeModulePkg/Application/CapsuleApp/CapsuleOnDisk.c
+++ b/MdeModulePkg/Application/CapsuleApp/CapsuleOnDisk.c
@@ -13,6 +13,57 @@ EFI_GUID  mCapsuleOnDiskBootOptionGuid = {
 };
 
 /**
+  Check if a device path is a network boot option that cannot host an EFI
+  System Partition.  Returns TRUE if the device path contains a network node
+  (MAC, IPv4, IPv6, or URI) and does NOT contain an iSCSI node.  iSCSI boot
+  options travel over the network but can present an EFI System Partition and
+  must not be skipped.
+
+  @param[in] DevicePath  The device path to check.
+
+  @retval TRUE   The device path is a non-iSCSI network boot option.
+  @retval FALSE  The device path is not a network boot option, or it is iSCSI.
+**/
+STATIC
+BOOLEAN
+IsNetworkDevicePath (
+  IN EFI_DEVICE_PATH_PROTOCOL  *DevicePath
+  )
+{
+  EFI_DEVICE_PATH_PROTOCOL  *Node;
+  BOOLEAN                   HasNetworkNode;
+
+  if (DevicePath == NULL) {
+    return FALSE;
+  }
+
+  HasNetworkNode = FALSE;
+
+  for (Node = DevicePath; !IsDevicePathEnd (Node); Node = NextDevicePathNode (Node)) {
+    if (DevicePathType (Node) == MESSAGING_DEVICE_PATH) {
+      switch (DevicePathSubType (Node)) {
+        case MSG_MAC_ADDR_DP:
+        case MSG_IPv4_DP:
+        case MSG_IPv6_DP:
+        case MSG_URI_DP:
+          HasNetworkNode = TRUE;
+          break;
+        case MSG_ISCSI_DP:
+          //
+          // iSCSI is network-based but can host an EFI System Partition.
+          // Do not skip iSCSI boot options.
+          //
+          return FALSE;
+        default:
+          break;
+      }
+    }
+  }
+
+  return HasNetworkNode;
+}
+
+/**
   Get file name from file path.
 
   @param  FilePath    File path.
@@ -475,6 +526,15 @@ GetUpdateFileSystem (
     if (((BootOptionBuffer[Index].Attributes & LOAD_OPTION_ACTIVE) == 0) ||
         (DevicePathType (DevicePath) == BBS_DEVICE_PATH))
     {
+      continue;
+    }
+
+    //
+    // Skip PXE and HTTP boot options - they do not provide an EFI System
+    // Partition. iSCSI boot options are not skipped as they can host an ESP.
+    //
+    if (IsNetworkDevicePath (DevicePath)) {
+      DEBUG ((DEBUG_INFO, "CapsuleOnDisk: Skip network boot option\n"));
       continue;
     }
 


### PR DESCRIPTION



# Description

When CapsuleApp searches for an EFI System Partition (ESP) to write capsule-on-disk data, it iterates through all active boot options in BootOrder. If network boot options (HTTP Boot, PXE) appear before disk-based options, EfiBootManagerConnectDevicePath() is called on each network device path, triggering actual HTTP/PXE boot attempts that are slow and always fail since network devices cannot contain an ESP.

Add IsPxeBootDevicePath() to detect device paths containing MSG_MAC_ADDR_DP, MSG_IPv4_DP, MSG_IPv6_DP, or MSG_URI_DP nodes and skip them during the boot option iteration in GetUpdateFileSystem(), however iSCSI boot options (MSG_ISCSI_DP) can have an EFI System Partition, so excluding them would prevent capsule delivery to iSCSI-hosted ESPs.

This avoids unnecessary network connection attempts and significantly reduces capsule-on-disk provisioning time on systems with network boot options enabled.

- [ ] Breaking change? No
- [ ] Impacts security? No
- [ ] Includes tests? No (validated manually on target hardware)

## How This Was Tested

Tested with HTTP and PXE boot options enabled.
Verified CapsuleApp no longer triggers network boot attempts during
capsule-on-disk provisioning.

## Integration Instructions

N/A
