### PR TITLE
NetworkPkg/IScsiDxe: Fix AttemptName cleared on loading defaults

### DIFF
--- a/NetworkPkg/IScsiDxe/IScsiConfig.c
+++ b/NetworkPkg/IScsiDxe/IScsiConfig.c
@@ -3416,6 +3416,22 @@ IScsiFormCallback (
     return EFI_SUCCESS;
   }
 
+  if (Action == EFI_BROWSER_ACTION_DEFAULT_STANDARD) {
+    if ((QuestionId == KEY_ATTEMPT_NAME) && (Value != NULL) && (mCallbackInfo->Current != NULL)) {
+      CHAR16         TmpName[ATTEMPT_NAME_SIZE];
+      EFI_STRING_ID  StringId;
+
+      AsciiStrToUnicodeStrS (mCallbackInfo->Current->AttemptName, TmpName, ATTEMPT_NAME_SIZE);
+      StringId = HiiSetString (mCallbackInfo->RegisteredHandle, 0, TmpName, NULL);
+      if (StringId == 0) {
+        return EFI_OUT_OF_RESOURCES;
+      }
+
+      Value->string = StringId;
+      return EFI_SUCCESS;
+    }
+  }
+
   if ((Action != EFI_BROWSER_ACTION_CHANGING) && (Action != EFI_BROWSER_ACTION_CHANGED)) {
     //
     // All other type return unsupported.

--- a/NetworkPkg/IScsiDxe/IScsiConfig.c
+++ b/NetworkPkg/IScsiDxe/IScsiConfig.c
@@ -3357,6 +3357,44 @@ Exit:
 }
 
 /**
+  Restore the current attempt name when the form browser loads defaults.
+  The AttemptName is driver-assigned and should not be reset to empty
+  when defaults are loaded.
+
+  @param[in]      Type    The type of the question value.
+  @param[in, out] Value   On return, contains the HII string ID of the
+                          current attempt name.
+
+  @retval EFI_SUCCESS           AttemptName was restored successfully.
+  @retval EFI_UNSUPPORTED       Type is not EFI_IFR_TYPE_STRING, or no
+                                current attempt is selected.
+  @retval EFI_OUT_OF_RESOURCES  Failed to register the HII string.
+**/
+EFI_STATUS
+IScsiGetAttemptNameDefault (
+  IN      UINT8               Type,
+  IN OUT  EFI_IFR_TYPE_VALUE  *Value
+  )
+{
+  CHAR16         TmpName[ATTEMPT_NAME_SIZE];
+  EFI_STRING_ID  StringId;
+
+  if (Type != EFI_IFR_TYPE_STRING) {
+    return EFI_UNSUPPORTED;
+  }
+
+  AsciiStrToUnicodeStrS (mCallbackInfo->Current->AttemptName, TmpName, ATTEMPT_NAME_SIZE);
+
+  StringId = HiiSetString (mCallbackInfo->RegisteredHandle, 0, TmpName, NULL);
+  if (StringId == 0) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  Value->string = StringId;
+  return EFI_SUCCESS;
+}
+
+/**
 
   This function is called to provide results data to the driver.
   This data consists of a unique key that is used to identify
@@ -3414,6 +3452,17 @@ IScsiFormCallback (
     // Do nothing for UEFI OPEN/CLOSE Action
     //
     return EFI_SUCCESS;
+  }
+
+  if ((Action == EFI_BROWSER_ACTION_DEFAULT_STANDARD)      ||
+      (Action == EFI_BROWSER_ACTION_DEFAULT_MANUFACTURING) ||
+      (Action == EFI_BROWSER_ACTION_DEFAULT_SAFE))
+  {
+    if ((QuestionId == KEY_ATTEMPT_NAME) && (Value != NULL) && (mCallbackInfo->Current != NULL)) {
+      return IScsiGetAttemptNameDefault (Type, Value);
+    }
+
+    return EFI_UNSUPPORTED;
   }
 
   if ((Action != EFI_BROWSER_ACTION_CHANGING) && (Action != EFI_BROWSER_ACTION_CHANGED)) {

--- a/NetworkPkg/IScsiDxe/IScsiConfigVfr.vfr
+++ b/NetworkPkg/IScsiDxe/IScsiConfigVfr.vfr
@@ -115,7 +115,7 @@ formset
     string  varid   = ISCSI_CONFIG_IFR_NVDATA.AttemptName,
             prompt  = STRING_TOKEN(STR_ISCSI_ATTEMPT_NAME),
             help    = STRING_TOKEN(STR_ISCSI_ATTEMPT_NAME_HELP),
-            flags   = READ_ONLY,
+            flags   = READ_ONLY | INTERACTIVE,
             key     = KEY_ATTEMPT_NAME,
             minsize = 0,
             maxsize = ATTEMPT_NAME_SIZE,


### PR DESCRIPTION

The AttemptName field in the iSCSI configuration form gets wiped out
when optimized defaults are loaded (F3), replacing names like
"Attempt 1", "Attempt 2" with blank strings.

**Root Cause:**
The AttemptName string field in IScsiConfigVfr.vfr had default = STRING_TOKEN(STR_NULL), which resolves to an empty string. When defaults are loaded, the form browser resets every field to its defined default, clearing all attempt names.

The AttemptName is driver-assigned as the identifier for the attempt — it is not a user-configurable setting like target IP or port. The STR_NULL default was a VFR formality (string fields require a default token in VFR syntax), not the intended behaviour. An empty AttemptName leaves the form with a blank title, making it impossible to distinguish between attempts in the UI.

**Fix:**

Add the INTERACTIVE flag to the AttemptName string field in VFR so the form browser invokes the driver callback when loading defaults instead of applying the hardcoded empty string.
Introduce a helper function IScsiGetAttemptNameDefault() that validates Type == EFI_IFR_TYPE_STRING, converts the stored attempt name to a HII string, and sets Value->string.
In IScsiFormCallback, handle EFI_BROWSER_ACTION_DEFAULT_STANDARD, EFI_BROWSER_ACTION_DEFAULT_MANUFACTURING, and EFI_BROWSER_ACTION_DEFAULT_SAFE for KEY_ATTEMPT_NAME by delegating to the helper. This ensures loading any class of defaults always restores the correct attempt name.

Cc: Saloni Kasbekar saloni.kasbekar@intel.com
Cc: Zachary Clark-williams zachary.clark-williams@intel.com

Signed-off-by: Abuthahir M abuthahirm@ami.com