### PR TITLE
Fix invalid UTF-8

### DIFF
--- a/BaseTools/Source/C/VfrCompile/Pccts/CHANGES_FROM_133.txt
+++ b/BaseTools/Source/C/VfrCompile/Pccts/CHANGES_FROM_133.txt
@@ -40,7 +40,7 @@ List of Implemented Fixes and Changes for Maintenance Releases of PCCTS
 #309. (Changed in MR32) Renamed baseName because of VMS name conflict
 
     Renamed baseName to pcctsBaseName to avoid library name conflict with
-    VMS library routine.  Reported by Jean-François PIÉRONNE.
+    VMS library routine.  Reported by Jean-FranÃ§ois PIÃ‰RONNE.
     
 #308. (Changed in MR32) Used "template" as name of formal in C routine
 
@@ -975,7 +975,7 @@ List of Implemented Fixes and Changes for Maintenance Releases of PCCTS
     
 #249. (MR21) Changes for DEC/VMS systems
 
-    Jean-François Piéronne (jfp altavista.net) has updated some
+    Jean-FranÃ§ois PiÃ©ronne (jfp altavista.net) has updated some
     VMS related command files and fixed some minor problems related
     to building pccts under the DEC/VMS operating system.  For DEC/VMS
     users the most important differences are:
@@ -1750,7 +1750,7 @@ List of Implemented Fixes and Changes for Maintenance Releases of PCCTS
       Under certain circumstances a predicate test could generate
       a #line directive which was not at column 1.
 
-      Reported with fix by David Kågedal  (davidk lysator.liu.se)
+      Reported with fix by David KÃ¥gedal  (davidk lysator.liu.se)
       (http://www.lysator.liu.se/~davidk/).
 
 #194. (Changed in MR14) (C Mode only) Demand lookahead with #tokclass

--- a/BaseTools/Source/C/VfrCompile/Pccts/README
+++ b/BaseTools/Source/C/VfrCompile/Pccts/README
@@ -136,7 +136,7 @@ The kit is now distributed with both MSVC 5 and MSVC6 style projects.
                       INSTALLATION (DEC/VMS)
 -------------------------------------------------------------------------
 
-DEC/VMS support added by Piéronne Jean-François (jfp@altavista.net)
+DEC/VMS support added by Jean-FranÃ§ois PiÃ©ronne (jfp@altavista.net)
 
 0. Download http://www.polhode.com/pccts133mr.zip
 

--- a/BaseTools/Source/C/VfrCompile/Pccts/antlr/AntlrPPC.mak
+++ b/BaseTools/Source/C/VfrCompile/Pccts/antlr/AntlrPPC.mak
@@ -20,82 +20,83 @@
 #   Created:    Sunday, May 17, 1998 10:24:53 PM
 #	Author:		Kenji Tanaka
 MAKEFILE     = antlrPPC.make
-¥MondoBuild¥ = {MAKEFILE}  # Make blank to avoid rebuilds when makefile is modified
-Includes     = ¶
-		-i "::h:" ¶
+MondoBuild = ${MAKEFILE}  # Make blank to avoid rebuilds when makefile is modified
+Includes     =\
+		-i "::h:"\
 		-i "::support:set:"
-Sym¥PPC      = 
-ObjDir¥PPC   = :Obj:
-PPCCOptions  = {Includes} {Sym¥PPC} -w off -d MPW -d __STDC__=1 -d USER_ZZSYN
-Objects¥PPC  = ¶
-		"{ObjDir¥PPC}set.c.x" ¶
-		"{ObjDir¥PPC}antlr.c.x" ¶
-		"{ObjDir¥PPC}bits.c.x" ¶
-		"{ObjDir¥PPC}build.c.x" ¶
-		"{ObjDir¥PPC}egman.c.x" ¶
-		"{ObjDir¥PPC}err.c.x" ¶
-		"{ObjDir¥PPC}fcache.c.x" ¶
-		"{ObjDir¥PPC}fset2.c.x" ¶
-		"{ObjDir¥PPC}fset.c.x" ¶
-		"{ObjDir¥PPC}gen.c.x" ¶
-		"{ObjDir¥PPC}globals.c.x" ¶
-		"{ObjDir¥PPC}hash.c.x" ¶
-		"{ObjDir¥PPC}lex.c.x" ¶
-		"{ObjDir¥PPC}main.c.x" ¶
-		"{ObjDir¥PPC}misc.c.x" ¶
-		"{ObjDir¥PPC}mrhoist.c.x" ¶
-		"{ObjDir¥PPC}pred.c.x" ¶
-		"{ObjDir¥PPC}scan.c.x"
-antlrPPC ÄÄ {¥MondoBuild¥} {Objects¥PPC}
-	PPCLink ¶
-		-o {Targ} {Sym¥PPC} ¶
-		{Objects¥PPC} ¶
-		-t 'MPST' ¶
-		-c 'MPS ' ¶
-		"{SharedLibraries}InterfaceLib" ¶
-		"{SharedLibraries}StdCLib" ¶
-		#"{SharedLibraries}MathLib" ¶
-		"{PPCLibraries}StdCRuntime.o" ¶
-		"{PPCLibraries}PPCCRuntime.o" ¶
-		"{PPCLibraries}PPCToolLibs.o"
-"{ObjDir¥PPC}set.c.x" Ä {¥MondoBuild¥} "::support:set:set.c"
-	{PPCC} "::support:set:set.c" -o {Targ} {PPCCOptions}
-"{ObjDir¥PPC}antlr.c.x" Ä {¥MondoBuild¥} antlr.c
-	{PPCC} antlr.c -o {Targ} {PPCCOptions}
-"{ObjDir¥PPC}bits.c.x" Ä {¥MondoBuild¥} bits.c
-	{PPCC} bits.c -o {Targ} {PPCCOptions}
-"{ObjDir¥PPC}build.c.x" Ä {¥MondoBuild¥} build.c
-	{PPCC} build.c -o {Targ} {PPCCOptions}
-"{ObjDir¥PPC}egman.c.x" Ä {¥MondoBuild¥} egman.c
-	{PPCC} egman.c -o {Targ} {PPCCOptions}
-"{ObjDir¥PPC}err.c.x" Ä {¥MondoBuild¥} err.c
-	{PPCC} err.c -o {Targ} {PPCCOptions}
-"{ObjDir¥PPC}fcache.c.x" Ä {¥MondoBuild¥} fcache.c
-	{PPCC} fcache.c -o {Targ} {PPCCOptions}
-"{ObjDir¥PPC}fset2.c.x" Ä {¥MondoBuild¥} fset2.c
-	{PPCC} fset2.c -o {Targ} {PPCCOptions}
-"{ObjDir¥PPC}fset.c.x" Ä {¥MondoBuild¥} fset.c
-	{PPCC} fset.c -o {Targ} {PPCCOptions}
-"{ObjDir¥PPC}gen.c.x" Ä {¥MondoBuild¥} gen.c
-	{PPCC} gen.c -o {Targ} {PPCCOptions}
-"{ObjDir¥PPC}globals.c.x" Ä {¥MondoBuild¥} globals.c
-	{PPCC} globals.c -o {Targ} {PPCCOptions}
-"{ObjDir¥PPC}hash.c.x" Ä {¥MondoBuild¥} hash.c
-	{PPCC} hash.c -o {Targ} {PPCCOptions}
-"{ObjDir¥PPC}lex.c.x" Ä {¥MondoBuild¥} lex.c
-	{PPCC} lex.c -o {Targ} {PPCCOptions}
-"{ObjDir¥PPC}main.c.x" Ä {¥MondoBuild¥} main.c
-	{PPCC} main.c -o {Targ} {PPCCOptions}
-"{ObjDir¥PPC}misc.c.x" Ä {¥MondoBuild¥} misc.c
-	{PPCC} misc.c -o {Targ} {PPCCOptions}
-"{ObjDir¥PPC}mrhoist.c.x" Ä {¥MondoBuild¥} mrhoist.c
-	{PPCC} mrhoist.c -o {Targ} {PPCCOptions}
-"{ObjDir¥PPC}pred.c.x" Ä {¥MondoBuild¥} pred.c
-	{PPCC} pred.c -o {Targ} {PPCCOptions}
-"{ObjDir¥PPC}scan.c.x" Ä {¥MondoBuild¥} scan.c
-	{PPCC} scan.c -o {Targ} {PPCCOptions}
+SymPPC      = 
+ObjDirPPC   = :Obj:
+PPCCOptions  = ${Includes} ${SymPPC} -w off -d MPW -d __STDC__=1 -d USER_ZZSYN
+ObjectsPPC  =\
+		"${ObjDirPPC}set.c.x"\
+		"${ObjDirPPC}antlr.c.x"\
+		"${ObjDirPPC}bits.c.x"\
+		"${ObjDirPPC}build.c.x"\
+		"${ObjDirPPC}egman.c.x"\
+		"${ObjDirPPC}err.c.x"\
+		"${ObjDirPPC}fcache.c.x"\
+		"${ObjDirPPC}fset2.c.x"\
+		"${ObjDirPPC}fset.c.x"\
+		"${ObjDirPPC}gen.c.x"\
+		"${ObjDirPPC}globals.c.x"\
+		"${ObjDirPPC}hash.c.x"\
+		"${ObjDirPPC}lex.c.x"\
+		"${ObjDirPPC}main.c.x"\
+		"${ObjDirPPC}misc.c.x"\
+		"${ObjDirPPC}mrhoist.c.x"\
+		"${ObjDirPPC}pred.c.x"\
+		"${ObjDirPPC}scan.c.x"
 
-antlrPPC ÄÄ antlr.r
+antlrPPC: ${MondoBuild} ${ObjectsPPC}
+	PPCLink\
+		-o ${Targ} ${SymPPC}\
+		${ObjectsPPC}\
+		-t 'MPST'\
+		-c 'MPS '\
+		"${SharedLibraries}InterfaceLib"\
+		"${SharedLibraries}StdCLib"\
+		#"${SharedLibraries}MathLib"\
+		"${PPCLibraries}StdCRuntime.o"\
+		"${PPCLibraries}PPCCRuntime.o"\
+		"${PPCLibraries}PPCToolLibs.o"\
+"${ObjDirPPC}set.c.x": ${MondoBuild} "::support:set:set.c"
+	${PPCC} "::support:set:set.c" -o ${Targ} ${PPCCOptions}
+"${ObjDirPPC}antlr.c.x": ${MondoBuild} antlr.c
+	${PPCC} antlr.c -o ${Targ} ${PPCCOptions}
+"${ObjDirPPC}bits.c.x": ${MondoBuild} bits.c
+	${PPCC} bits.c -o ${Targ} ${PPCCOptions}
+"${ObjDirPPC}build.c.x": ${MondoBuild} build.c
+	${PPCC} build.c -o ${Targ} ${PPCCOptions}
+"${ObjDirPPC}egman.c.x": ${MondoBuild} egman.c
+	${PPCC} egman.c -o ${Targ} ${PPCCOptions}
+"${ObjDirPPC}err.c.x": ${MondoBuild} err.c
+	${PPCC} err.c -o ${Targ} ${PPCCOptions}
+"${ObjDirPPC}fcache.c.x": ${MondoBuild} fcache.c
+	${PPCC} fcache.c -o ${Targ} ${PPCCOptions}
+"${ObjDirPPC}fset2.c.x": ${MondoBuild} fset2.c
+	${PPCC} fset2.c -o ${Targ} ${PPCCOptions}
+"${ObjDirPPC}fset.c.x": ${MondoBuild} fset.c
+	${PPCC} fset.c -o ${Targ} ${PPCCOptions}
+"${ObjDirPPC}gen.c.x": ${MondoBuild} gen.c
+	${PPCC} gen.c -o ${Targ} ${PPCCOptions}
+"${ObjDirPPC}globals.c.x": ${MondoBuild} globals.c
+	${PPCC} globals.c -o ${Targ} ${PPCCOptions}
+"${ObjDirPPC}hash.c.x": ${MondoBuild} hash.c
+	${PPCC} hash.c -o ${Targ} ${PPCCOptions}
+"${ObjDirPPC}lex.c.x": ${MondoBuild} lex.c
+	${PPCC} lex.c -o ${Targ} ${PPCCOptions}
+"${ObjDirPPC}main.c.x": ${MondoBuild} main.c
+	${PPCC} main.c -o ${Targ} ${PPCCOptions}
+"${ObjDirPPC}misc.c.x": ${MondoBuild} misc.c
+	${PPCC} misc.c -o ${Targ} ${PPCCOptions}
+"${ObjDirPPC}mrhoist.c.x": ${MondoBuild} mrhoist.c
+	${PPCC} mrhoist.c -o ${Targ} ${PPCCOptions}
+"${ObjDirPPC}pred.c.x": ${MondoBuild} pred.c
+	${PPCC} pred.c -o ${Targ} ${PPCCOptions}
+"${ObjDirPPC}scan.c.x": ${MondoBuild} scan.c
+	${PPCC} scan.c -o ${Targ} ${PPCCOptions}
+
+antlrPPC: antlr.r
 	Rez antlr.r -o antlrPPC -a
-Install  Ä antlrPPC
+Install: antlrPPC
 	Duplicate -y antlrPPC "{MPW}"Tools:antlr

--- a/BaseTools/Source/C/VfrCompile/Pccts/antlr/antlr.r
+++ b/BaseTools/Source/C/VfrCompile/Pccts/antlr/antlr.r
@@ -41,7 +41,7 @@ resource 'cmdo' (128, "Antlr") {
 
 			},
 			MultiFiles {
-				"Grammar File(s)…",
+				"Grammar File(s)",
 				"Choose the grammar specification files y"
 				"ou wish to have ANTLR process.",
 				{79, 22, 98, 152},
@@ -73,7 +73,7 @@ resource 'cmdo' (128, "Antlr") {
 					"Choose the directory where ANTLR will pu"
 					"t its output.",
 					dim,
-					"Output Directory…",
+					"Output Directory",
 					"",
 					""
 				},
@@ -113,7 +113,7 @@ resource 'cmdo' (128, "Antlr") {
 			NestedDialog {
 				5,
 				{20, 324, 40, 460},
-				"Parse Options…",
+				"Parse Options",
 				"Parse control options may be set with th"
 				"is button."
 			},
@@ -124,7 +124,7 @@ resource 'cmdo' (128, "Antlr") {
 			NestedDialog {
 				2,
 				{50, 324, 70, 460},
-				"Generate Options…",
+				"Generate Options",
 				"Various command line options may be set "
 				"with this button."
 			},
@@ -135,7 +135,7 @@ resource 'cmdo' (128, "Antlr") {
 			NestedDialog {
 				3,
 				{78, 324, 98, 460},
-				"More Options…",
+				"More Options",
 				"Antlr has ALOT of options. There are eve"
 				"n more to be found with this button."
 			},
@@ -146,7 +146,7 @@ resource 'cmdo' (128, "Antlr") {
 			NestedDialog {
 				4,
 				{106, 324, 126, 460},
-				"Rename Options…",
+				"Rename Options",
 				"Options for renaming output files may be"
 				" set with this button."
 			},
@@ -453,7 +453,7 @@ resource 'cmdo' (128, "Antlr") {
 				"More warnings",
 				"-w2",
 				"If this option is checked, ANTLR will wa"
-				"rn if semantic predicates and/or (…)? bl"
+				"rn if semantic predicates and/or ()? bl"
 				"ocks are assumed to cover ambiguous alte"
 				"rnatives."
 			},

--- a/BaseTools/Source/C/VfrCompile/Pccts/dlg/DlgPPC.mak
+++ b/BaseTools/Source/C/VfrCompile/Pccts/dlg/DlgPPC.mak
@@ -14,71 +14,71 @@
 
 
 MAKEFILE     = dlgPPC.make
-¥MondoBuild¥ = {MAKEFILE}  # Make blank to avoid rebuilds when makefile is modified
-Includes     = ¶
-		-i "::h:" ¶
-		-i "::support:set:"
-Sym¥PPC      = 
-ObjDir¥PPC   = ":Obj:"
+MondoBuild = ${MAKEFILE}  # Make blank to avoid rebuilds when makefile is modified
+Includes     =\
+		-i "::h:"\
+		-i "::support:set:"\
+SymPPC      = 
+ObjDirPPC   = ":Obj:"
 
-PPCCOptions  = {Includes} {Sym¥PPC}  -w off -d MPW -d __STDC__=1 -d USER_ZZSYN
+PPCCOptions  = ${Includes} ${SymPPC}  -w off -d MPW -d __STDC__=1 -d USER_ZZSYN
 
-Objects¥PPC  = ¶
-		"{ObjDir¥PPC}automata.c.x" ¶
-		"{ObjDir¥PPC}dlg_a.c.x" ¶
-		"{ObjDir¥PPC}dlg_p.c.x" ¶
-		"{ObjDir¥PPC}err.c.x" ¶
-		"{ObjDir¥PPC}main.c.x" ¶
-		"{ObjDir¥PPC}output.c.x" ¶
-		"{ObjDir¥PPC}relabel.c.x" ¶
-		"{ObjDir¥PPC}support.c.x" ¶
-		"{ObjDir¥PPC}set.c.x"
-
-
-dlgPPC ÄÄ {¥MondoBuild¥} {Objects¥PPC}
-	PPCLink ¶
-		-o {Targ} {Sym¥PPC} ¶
-		{Objects¥PPC} ¶
-		-t 'MPST' ¶
-		-c 'MPS ' ¶
-		"{SharedLibraries}InterfaceLib" ¶
-		"{SharedLibraries}StdCLib" ¶
-		"{SharedLibraries}MathLib" ¶
-		"{PPCLibraries}StdCRuntime.o" ¶
-		"{PPCLibraries}PPCCRuntime.o" ¶
-		"{PPCLibraries}PPCToolLibs.o"
+ObjectsPPC  =\
+		"${ObjDirPPC}automata.c.x"\
+		"${ObjDirPPC}dlg_a.c.x"\
+		"${ObjDirPPC}dlg_p.c.x"\
+		"${ObjDirPPC}err.c.x"\
+		"${ObjDirPPC}main.c.x"\
+		"${ObjDirPPC}output.c.x"\
+		"${ObjDirPPC}relabel.c.x"\
+		"${ObjDirPPC}support.c.x"\
+		"${ObjDirPPC}set.c.x"\
 
 
-"{ObjDir¥PPC}automata.c.x" Ä {¥MondoBuild¥} automata.c
-	{PPCC} automata.c -o {Targ} {PPCCOptions}
-
-"{ObjDir¥PPC}dlg_a.c.x" Ä {¥MondoBuild¥} dlg_a.c
-	{PPCC} dlg_a.c -o {Targ} {PPCCOptions}
-
-"{ObjDir¥PPC}dlg_p.c.x" Ä {¥MondoBuild¥} dlg_p.c
-	{PPCC} dlg_p.c -o {Targ} {PPCCOptions}
-
-"{ObjDir¥PPC}err.c.x" Ä {¥MondoBuild¥} err.c
-	{PPCC} err.c -o {Targ} {PPCCOptions}
-
-"{ObjDir¥PPC}main.c.x" Ä {¥MondoBuild¥} main.c
-	{PPCC} main.c -o {Targ} {PPCCOptions}
-
-"{ObjDir¥PPC}output.c.x" Ä {¥MondoBuild¥} output.c
-	{PPCC} output.c -o {Targ} {PPCCOptions}
-
-"{ObjDir¥PPC}relabel.c.x" Ä {¥MondoBuild¥} relabel.c
-	{PPCC} relabel.c -o {Targ} {PPCCOptions}
-
-"{ObjDir¥PPC}support.c.x" Ä {¥MondoBuild¥} support.c
-	{PPCC} support.c -o {Targ} {PPCCOptions}
-
-"{ObjDir¥PPC}set.c.x" Ä {¥MondoBuild¥} "::support:set:set.c"
-	{PPCC} "::support:set:set.c" -o {Targ} {PPCCOptions}
+dlgPPC: ${MondoBuild} ${ObjectsPPC}
+	PPCLink\
+		-o ${Targ} ${SymPPC}\
+		${ObjectsPPC}\
+		-t 'MPST'\
+		-c 'MPS '\
+		"${SharedLibraries}InterfaceLib"\
+		"${SharedLibraries}StdCLib"\
+		"${SharedLibraries}MathLib"\
+		"${PPCLibraries}StdCRuntime.o"\
+		"${PPCLibraries}PPCCRuntime.o"\
+		"${PPCLibraries}PPCToolLibs.o"\
 
 
-dlgPPC ÄÄ dlg.r
+"${ObjDirPPC}automata.c.x":  ${MondoBuild} automata.c
+	${PPCC} automata.c -o ${Targ} ${PPCCOptions}
+
+"${ObjDirPPC}dlg_a.c.x":  ${MondoBuild} dlg_a.c
+	${PPCC} dlg_a.c -o ${Targ} ${PPCCOptions}
+
+"${ObjDirPPC}dlg_p.c.x":  ${MondoBuild} dlg_p.c
+	${PPCC} dlg_p.c -o ${Targ} ${PPCCOptions}
+
+"${ObjDirPPC}err.c.x":  ${MondoBuild} err.c
+	${PPCC} err.c -o ${Targ} ${PPCCOptions}
+
+"${ObjDirPPC}main.c.x":  ${MondoBuild} main.c
+	${PPCC} main.c -o ${Targ} ${PPCCOptions}
+
+"${ObjDirPPC}output.c.x":  ${MondoBuild} output.c
+	${PPCC} output.c -o ${Targ} ${PPCCOptions}
+
+"${ObjDirPPC}relabel.c.x":  ${MondoBuild} relabel.c
+	${PPCC} relabel.c -o ${Targ} ${PPCCOptions}
+
+"${ObjDirPPC}support.c.x":  ${MondoBuild} support.c
+	${PPCC} support.c -o ${Targ} ${PPCCOptions}
+
+"${ObjDirPPC}set.c.x":  ${MondoBuild} "::support:set:set.c"
+	${PPCC} "::support:set:set.c" -o ${Targ} ${PPCCOptions}
+
+
+dlgPPC: dlg.r
 	Rez dlg.r -o dlgPPC -a
 
-Install  Ä dlgPPC
-	Duplicate -y dlgPPC "{MPW}"Tools:dlg
+Install:  dlgPPC
+	Duplicate -y dlgPPC "${MPW}"Tools:dlg


### PR DESCRIPTION
# Description

This patch fixes the invalid UTF-8 sequences which caused me some problems with CI(in the attempt to remove the carriage returns).

Some of the CI scripts(like the following) read the diff as UTF-8:
- `.pytool\Plugin\EccCheck\EccCheck.py`
- `.pytool\Plugin\LicenseCheck\LicenseCheck.py`

This means that if invalid UTF-8 was removed in a patch, it will raise an exception.

I do not anticipate this passing CI, however, if merged, it should prevent future CI problems.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

Tested with OVMF in QEMU. I ran the affected make files to assert that there were no new parsing errors. I built `antlr` & `dlg` with no issues.

## Integration Instructions

N/A