### PR TITLE
Add AARCH64 definitions for VS2026 toolchain.

### DIFF
--- a/BaseTools/Conf/tools_def.template
+++ b/BaseTools/Conf/tools_def.template
@@ -907,6 +907,36 @@ NOOPT_VS2026_X64_DLINK_FLAGS    = /NOLOGO /NODEFAULTLIB /IGNORE:4001 /IGNORE:428
 # BaseTools cannot handle XIP modules with different section and file alignment
 *_VS2026_X64_DLINK_XIPFLAGS     = /ALIGN:32
 
+#####################
+# AARCH64 definitions
+#####################
+*_VS2026_AARCH64_CC_PATH           = DEF(VS2026_BIN_AARCH64)\cl.exe
+*_VS2026_AARCH64_VFRPP_PATH        = DEF(VS2026_BIN_AARCH64)\cl.exe
+*_VS2026_AARCH64_SLINK_PATH        = DEF(VS2026_BIN_AARCH64)\lib.exe
+*_VS2026_AARCH64_DLINK_PATH        = DEF(VS2026_BIN_AARCH64)\link.exe
+*_VS2026_AARCH64_APP_PATH          = DEF(VS2026_BIN_AARCH64)\cl.exe
+*_VS2026_AARCH64_PP_PATH           = DEF(VS2026_BIN_AARCH64)\cl.exe
+*_VS2026_AARCH64_ASM_PATH          = DEF(VS2026_BIN_AARCH64)\armasm64.exe
+*_VS2026_AARCH64_ASLCC_PATH        = DEF(VS2026_BIN_AARCH64)\cl.exe
+*_VS2026_AARCH64_ASLPP_PATH        = DEF(VS2026_BIN_AARCH64)\cl.exe
+*_VS2026_AARCH64_ASLDLINK_PATH     = DEF(VS2026_BIN_AARCH64)\link.exe
+
+      *_VS2026_AARCH64_MAKE_FLAGS  = /nologo
+  DEBUG_VS2026_AARCH64_CC_FLAGS    = /nologo /c /WX /GS- /W4 /Gs32768 /D UNICODE /O1b2 /GL /FIAutoGen.h /EHs-c- /GR- /GF /Gy /Zi /Gw /Oi-
+RELEASE_VS2026_AARCH64_CC_FLAGS    = /nologo /c /WX /GS- /W4 /Gs32768 /D UNICODE /O1b2 /GL /FIAutoGen.h /EHs-c- /GR- /GF /Gw /Oi-
+NOOPT_VS2026_AARCH64_CC_FLAGS      = /nologo /c /WX /GS- /W4 /Gs32768 /D UNICODE /FIAutoGen.h /EHs-c- /GR- /GF /Gy /Zi /Od /Oi-
+
+  DEBUG_VS2026_AARCH64_ASM_FLAGS   = /nologo /g
+RELEASE_VS2026_AARCH64_ASM_FLAGS   = /nologo
+NOOPT_VS2026_AARCH64_ASM_FLAGS     = /nologo
+
+# Linker warning 4210 is disabled globally, because it checks if static initializers are present and the VCRuntime is
+# linked. We do not link the VCRuntime (except for HOST_APPLICATIONs) so this warning can be generated erroneously
+# whenever there are static initializers, because we will always fail the VCRuntime linking check
+  DEBUG_VS2026_AARCH64_DLINK_FLAGS = /NOLOGO /NODEFAULTLIB /IGNORE:4001 /IGNORE:4226 /OPT:REF /OPT:ICF=10 /MAP /SECTION:.xdata,D /SECTION:.pdata,D /MACHINE:ARM64 /LTCG /DLL /ENTRY:$(IMAGE_ENTRY_POINT) /SUBSYSTEM:EFI_BOOT_SERVICE_DRIVER /SAFESEH:NO /DRIVER /DEBUG /WX /IGNORE:4210
+RELEASE_VS2026_AARCH64_DLINK_FLAGS = /NOLOGO /NODEFAULTLIB /IGNORE:4001 /IGNORE:4226 /IGNORE:4254 /OPT:REF /OPT:ICF=10 /MAP /SECTION:.xdata,D /SECTION:.pdata,D /MACHINE:ARM64 /LTCG /DLL /ENTRY:$(IMAGE_ENTRY_POINT) /SUBSYSTEM:EFI_BOOT_SERVICE_DRIVER /SAFESEH:NO /DRIVER /MERGE:.rdata=.data /WX /IGNORE:4210
+NOOPT_VS2026_AARCH64_DLINK_FLAGS   = /NOLOGO /NODEFAULTLIB /IGNORE:4001 /IGNORE:4226 /OPT:REF /OPT:ICF=10 /MAP /SECTION:.xdata,D /SECTION:.pdata,D /MACHINE:ARM64 /LTCG /DLL /ENTRY:$(IMAGE_ENTRY_POINT) /SUBSYSTEM:EFI_BOOT_SERVICE_DRIVER /SAFESEH:NO /DRIVER /DEBUG /WX /IGNORE:4210
+
 ####################################################################################
 # GCC Common
 ####################################################################################


### PR DESCRIPTION
# Description

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

`edksetup.bat Reconfig VS2026`
`build`

## Integration Instructions
