### PR TITLE
StandaloneMmPkg/Core: Return when processing malformed DEPEX

### DIFF
--- a/StandaloneMmPkg/Core/Dependency.c
+++ b/StandaloneMmPkg/Core/Dependency.c
@@ -220,6 +220,7 @@ MmIsSchedulable (
         //
         DEBUG ((DEBUG_DISPATCH, "  RESULT = FALSE (Unexpected BEFORE or AFTER opcode)\n"));
         ASSERT (FALSE);
+        return FALSE;
 
       case EFI_DEP_PUSH:
         //


### PR DESCRIPTION
# Description

This PR addresses contains,

fix: StandaloneMmPkg/Core: Return when processing malformed DEPEX

For a well-formed Dependency Expression, the code should never get here. Switch case EFI_DEP_BEFORE and case EFI_DEP_AFTER are processed prior to this routine's invocation. If the code flow arrives at this point, present code only called ASSERT(FALSE), causing release builds to fall through to the EFI_DEP_SOR case.

Adding an explicit return FALSE after the assertion ensures correct error handling in release and debug build modes.

This commit also addresses the fix for Coverity issue "MISSING BREAK"

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested


## Integration Instructions

N/A