### PR TITLE
Fix for Out of Bound Memory access

### DIFF
--- a/EmbeddedPkg/Library/PrePiLib/FwVol.c
+++ b/EmbeddedPkg/Library/PrePiLib/FwVol.c
@@ -10,6 +10,7 @@
 **/
 
 #include <PrePi.h>
+#include <Pi/PiFirmwareFile.h>
 #include <Library/ExtractGuidedSectionLib.h>
 
 #define GET_OCCUPIED_SIZE(ActualSize, Alignment) \
@@ -190,10 +191,9 @@ FindFileEx (
     }
   } else {
     //
-    // Length is 24 bits wide so mask upper 8 bits
     // FileLength is adjusted to FileOccupiedSize as it is 8 byte aligned.
     //
-    FileLength       = *(UINT32 *)(*FileHeader)->Size & 0x00FFFFFF;
+    FileLength       = FFS_FILE_SIZE (*FileHeader);
     FileOccupiedSize = GET_OCCUPIED_SIZE (FileLength, 8);
     FfsFileHeader    = (EFI_FFS_FILE_HEADER *)((UINT8 *)*FileHeader + FileOccupiedSize);
   }
@@ -224,7 +224,7 @@ FindFileEx (
           return EFI_NOT_FOUND;
         }
 
-        FileLength       = *(UINT32 *)(FfsFileHeader->Size) & 0x00FFFFFF;
+        FileLength       = FFS_FILE_SIZE (FfsFileHeader);
         FileOccupiedSize = GET_OCCUPIED_SIZE (FileLength, 8);
 
         if (FileName != NULL) {
@@ -244,7 +244,7 @@ FindFileEx (
         break;
 
       case EFI_FILE_DELETED:
-        FileLength       = *(UINT32 *)(FfsFileHeader->Size) & 0x00FFFFFF;
+        FileLength       = FFS_FILE_SIZE (FfsFileHeader);
         FileOccupiedSize = GET_OCCUPIED_SIZE (FileLength, 8);
         FileOffset      += FileOccupiedSize;
         FfsFileHeader    = (EFI_FFS_FILE_HEADER *)((UINT8 *)FfsFileHeader + FileOccupiedSize);
@@ -545,12 +545,10 @@ FfsFindSectionDataWithHook (
   FfsFileHeader = (EFI_FFS_FILE_HEADER *)(FileHandle);
 
   //
-  // Size is 24 bits wide so mask upper 8 bits.
-  // Does not include FfsFileHeader header size
   // FileSize is adjusted to FileOccupiedSize as it is 8 byte aligned.
   //
   Section   = (EFI_COMMON_SECTION_HEADER *)(FfsFileHeader + 1);
-  FileSize  = *(UINT32 *)(FfsFileHeader->Size) & 0x00FFFFFF;
+  FileSize  = FFS_FILE_SIZE (FfsFileHeader);
   FileSize -= sizeof (EFI_FFS_FILE_HEADER);
 
   return FfsProcessSection (
@@ -752,7 +750,7 @@ FfsGetFileInfo (
   CopyMem (&FileInfo->FileName, &FileHeader->Name, sizeof (EFI_GUID));
   FileInfo->FileType       = FileHeader->Type;
   FileInfo->FileAttributes = FileHeader->Attributes;
-  FileInfo->BufferSize     = ((*(UINT32 *)FileHeader->Size) & 0x00FFFFFF) -  sizeof (EFI_FFS_FILE_HEADER);
+  FileInfo->BufferSize     = (FFS_FILE_SIZE (FileHeader) -  sizeof (EFI_FFS_FILE_HEADER));
   FileInfo->Buffer         = (FileHeader + 1);
   return EFI_SUCCESS;
 }


### PR DESCRIPTION
# Description

This PR addresses the fix for out of bounds memory access

Symptom:Unsafe typecasting may lead to out‑of‑bound memory access

RootCause: FileSize, FileLength and SectionLength are declared as
UINT32 and masked with 0x00FFFFFF to store only the lower 24 bits.
Although this approach yields the correct result,
it introduces a potential risk due to unsafe typecasting and
dereferencing.

Solution: Using the predefined macro FFS_FILE_SIZE()
and SECTION_SIZE from MdePkg\Include\Pi\PiFirmwareFile.h,
which safely performs the same operation by reconstructing
the size using individual byte access.

This PR also addresses the fix for coverity issue "OVERRUN"

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested


## Integration Instructions

N/A 
