### PR TITLE
NetworkPkg/TcpDxe: Skip RST when no IpIo sender exists for Dst

### DIFF
--- a/NetworkPkg/TcpDxe/TcpInput.c
+++ b/NetworkPkg/TcpDxe/TcpInput.c
@@ -725,6 +725,7 @@ TcpInput (
   UINT16      Checksum;
   INT32       Usable;
   EFI_STATUS  Status;
+  IP_IO       *IpIoProbe;
 
   ASSERT ((Version == IP_VERSION_4) || (Version == IP_VERSION_6));
 
@@ -780,9 +781,15 @@ TcpInput (
           );
 
   if ((Tcb == NULL) || (Tcb->State == TCP_CLOSED)) {
-    DEBUG ((DEBUG_NET, "TcpInput: send reset because no TCB found\n"));
+    //
+    // No IpIo sender for Dst: cannot emit RST; discard to avoid failed sends.
+    //
+    IpIoProbe = NULL;
+    Tcb       = NULL;
+    if (IpIoFindSender (&IpIoProbe, Version, Dst) == NULL) {
+      goto DISCARD;
+    }
 
-    Tcb = NULL;
     goto SEND_RESET;
   }
 


### PR DESCRIPTION
Unknown or closed segments still go down the RST path into TcpSendIpPacket. When no IpIo sender exists for the destination, each packet logs “No appropriate IpSender.” next to the usual discard traces and floods the console. The change calls IpIoFindSender before SEND_RESET and discards when it fails, which stops that storm and leaves normal RST behavior unchanged when a sender is present.

Cc: Saloni Kasbekar <saloni.kasbekar@intel.com>
Cc: Zachary Clark-williams <zachary.clark-williams@intel.com>
Cc: Mike Beaton <mjsbeaton@gmail.com>

# Description

Unknown or closed segments still go down the RST path into TcpSendIpPacket. When no IpIo sender exists for the destination, each packet logs “No appropriate IpSender.” next to the usual discard traces and floods the console. The change calls IpIoFindSender before SEND_RESET and discards when it fails, which stops that storm and leaves normal RST behavior unchanged when a sender is present.

## How This Was Tested

AMD Internal CI

## Integration Instructions

N/A — drop-in NetworkPkg change; no platform or build integration steps beyond merging and rebuilding firmware that includes TcpDxe.
