### PR TITLE
ArmPkg/CpuDxe: Drop GCD check, enforce XN on device mappings

### DIFF
--- a/ArmPkg/Drivers/CpuDxe/MemoryAttribute.c
+++ b/ArmPkg/Drivers/CpuDxe/MemoryAttribute.c
@@ -9,42 +9,6 @@
 #include "CpuDxe.h"
 
 /**
-  Check whether the provided memory range is covered by a single entry of type
-  EfiGcdSystemMemory in the GCD memory map.
-
-  @param  BaseAddress       The physical address that is the start address of
-                            a memory region.
-  @param  Length            The size in bytes of the memory region.
-
-  @return Whether the region is system memory or not.
-**/
-STATIC
-BOOLEAN
-RegionIsSystemMemory (
-  IN  EFI_PHYSICAL_ADDRESS  BaseAddress,
-  IN  UINT64                Length
-  )
-{
-  EFI_GCD_MEMORY_SPACE_DESCRIPTOR  GcdDescriptor;
-  EFI_PHYSICAL_ADDRESS             GcdEndAddress;
-  EFI_STATUS                       Status;
-
-  Status = gDS->GetMemorySpaceDescriptor (BaseAddress, &GcdDescriptor);
-  if (EFI_ERROR (Status) ||
-      (GcdDescriptor.GcdMemoryType != EfiGcdMemoryTypeSystemMemory))
-  {
-    return FALSE;
-  }
-
-  GcdEndAddress = GcdDescriptor.BaseAddress + GcdDescriptor.Length;
-
-  //
-  // Return TRUE if the GCD descriptor covers the range entirely
-  //
-  return GcdEndAddress >= (BaseAddress + Length);
-}
-
-/**
   This function retrieves the attributes of the memory region specified by
   BaseAddress and Length. If different attributes are obtained from different
   parts of the memory region, EFI_NO_MAPPING will be returned.
@@ -90,10 +54,6 @@ GetMemoryAttributes (
       Length
       ));
     return EFI_INVALID_PARAMETER;
-  }
-
-  if (!RegionIsSystemMemory (BaseAddress, Length)) {
-    return EFI_UNSUPPORTED;
   }
 
   DEBUG ((
@@ -212,10 +172,6 @@ SetMemoryAttributes (
     return EFI_INVALID_PARAMETER;
   }
 
-  if (!RegionIsSystemMemory (BaseAddress, Length)) {
-    return EFI_UNSUPPORTED;
-  }
-
   return ArmSetMemoryAttributes (BaseAddress, Length, Attributes, Attributes);
 }
 
@@ -278,10 +234,6 @@ ClearMemoryAttributes (
       Attributes
       ));
     return EFI_INVALID_PARAMETER;
-  }
-
-  if (!RegionIsSystemMemory (BaseAddress, Length)) {
-    return EFI_UNSUPPORTED;
   }
 
   return ArmSetMemoryAttributes (BaseAddress, Length, 0, Attributes);

--- a/ArmPkg/Drivers/CpuDxe/MemoryAttribute.c
+++ b/ArmPkg/Drivers/CpuDxe/MemoryAttribute.c
@@ -9,6 +9,51 @@
 #include "CpuDxe.h"
 
 /**
+  Check whether any part of the provided memory range is mapped as device
+  memory in the translation table.
+
+  @param  BaseAddress       The physical address that is the start address of
+                            a memory region.
+  @param  Length            The size in bytes of the memory region.
+
+  @retval TRUE   At least one page in the range is mapped as device memory.
+  @retval FALSE  No page in the range is mapped as device memory, or the
+                 range contains no valid mapping.
+**/
+STATIC
+BOOLEAN
+RegionContainsDeviceMemory (
+  IN  EFI_PHYSICAL_ADDRESS  BaseAddress,
+  IN  UINT64                Length
+  )
+{
+  UINTN       RegionAddress;
+  UINTN       RegionLength;
+  UINTN       RegionAttributes;
+  EFI_STATUS  Status;
+
+  for (RegionAddress = (UINTN)BaseAddress;
+       RegionAddress < (UINTN)(BaseAddress + Length);
+       RegionAddress += RegionLength)
+  {
+    Status = GetMemoryRegion (
+               &RegionAddress,
+               &RegionLength,
+               &RegionAttributes
+               );
+    if (EFI_ERROR (Status)) {
+      return FALSE;
+    }
+
+    if ((RegionAttributes & TT_ATTR_INDX_MASK) == TT_ATTR_INDX_DEVICE_MEMORY) {
+      return TRUE;
+    }
+  }
+
+  return FALSE;
+}
+
+/**
   This function retrieves the attributes of the memory region specified by
   BaseAddress and Length. If different attributes are obtained from different
   parts of the memory region, EFI_NO_MAPPING will be returned.

--- a/ArmPkg/Drivers/CpuDxe/MemoryAttribute.c
+++ b/ArmPkg/Drivers/CpuDxe/MemoryAttribute.c
@@ -214,6 +214,11 @@ ClearMemoryAttributes (
   IN  UINT64                         Attributes
   )
 {
+  UINTN       RegionAddress;
+  UINTN       RegionLength;
+  UINTN       RegionAttributes;
+  EFI_STATUS  Status;
+
   DEBUG ((
     DEBUG_INFO,
     "%a: BaseAddress == 0x%lx, Length == 0x%lx, Attributes == 0x%lx\n",
@@ -234,6 +239,27 @@ ClearMemoryAttributes (
       Attributes
       ));
     return EFI_INVALID_PARAMETER;
+  }
+
+  // ARM requires XN on device memory to prevent speculative instruction fetches
+  if ((Attributes & EFI_MEMORY_XP) != 0) {
+    for (RegionAddress = (UINTN)BaseAddress;
+         RegionAddress < (UINTN)(BaseAddress + Length);
+         RegionAddress += RegionLength)
+    {
+      Status = GetMemoryRegion (
+                 &RegionAddress,
+                 &RegionLength,
+                 &RegionAttributes
+                 );
+      if (EFI_ERROR (Status)) {
+        return EFI_UNSUPPORTED;
+      }
+
+      if ((RegionAttributes & TT_ATTR_INDX_MASK) == TT_ATTR_INDX_DEVICE_MEMORY) {
+        return EFI_UNSUPPORTED;
+      }
+    }
   }
 
   return ArmSetMemoryAttributes (BaseAddress, Length, 0, Attributes);

--- a/ArmPkg/Drivers/CpuDxe/MemoryAttribute.c
+++ b/ArmPkg/Drivers/CpuDxe/MemoryAttribute.c
@@ -281,6 +281,12 @@ ClearMemoryAttributes (
     return EFI_INVALID_PARAMETER;
   }
 
+  if (((Attributes & EFI_MEMORY_XP) != 0) &&
+      RegionContainsDeviceMemory (BaseAddress, Length))
+  {
+    return EFI_UNSUPPORTED;
+  }
+
   return ArmSetMemoryAttributes (BaseAddress, Length, 0, Attributes);
 }
 


### PR DESCRIPTION
# Description
The UEFI specification does not restrict the MemoryAttribute Protocol
to system memory only. The protocol should permit manipulating
permission attributes on any existing, valid mapping, consistent with
other architectures.
    
Remove RegionIsSystemMemory() and its use as a precondition in
GetMemoryAttributes(), SetMemoryAttributes() and
ClearMemoryAttributes().

The ARM architecture requires the XN attribute on device memory
mappings. Failure to preserve XN permits speculative instruction
fetches to MMIO regions, leading to unpredictable behavior such as
stuck transactions in the memory controller or the I-cache prefetcher
inadvertently acknowledging device interrupts.
    
Add a check in ClearMemoryAttributes() that returns EFI_UNSUPPORTED
when the caller requests clearing EFI_MEMORY_XP on a region that
contains device memory. The check traverses the translation table
to determine whether any portion of the given address range is
mapped with the device memory attribute.                                                                                                                                                                                        
   
Based on the review feedback at  https://github.com/tianocore/edk2/pull/12361

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Use the GetMemoryAttributes, SetMemoryAttributes and ClearMemoryAttributes function for testing.

## Integration Instructions

N/A