### PR TITLE
RedfishPkg/RedfishHttpDxe: Improve RedfishHttpOperation error handling

### DIFF
--- a/RedfishPkg/RedfishHttpDxe/RedfishHttpOperation.c
+++ b/RedfishPkg/RedfishHttpDxe/RedfishHttpOperation.c
@@ -587,6 +587,9 @@ ParseResponseMessage (
       RedfishResponse->Payload = CreateRedfishPayload (ServicePrivate, JsonData);
       if (RedfishResponse->Payload == NULL) {
         DEBUG ((DEBUG_ERROR, "%a: Failed to create payload\n.", __func__));
+        JsonValueFree (JsonData);
+        Status = EFI_DEVICE_ERROR;
+        goto ON_ERROR;
       }
 
       JsonValueFree (JsonData);


### PR DESCRIPTION
Improve RedfishHttpOperation error handling by
returning EFI_DEVICE_ERROR if CreateRedfishPayload is NULL

Cc: Abner Chang <abner.chang@amd.com>
Cc: Nickle Wang <nicklew@nvidia.com>
Cc: Igor Kulchytskyy <igork@ami.com>

# Description

Improve RedfishHttpOperation error handling by
returning EFI_DEVICE_ERROR if CreateRedfishPayload is NULL

## How This Was Tested

AMD Internal CI

## Integration Instructions

N/A
