### PR TITLE
.pytool/EccCheck: Skip ignored and missing scan paths

### DIFF
--- a/.pytool/Plugin/EccCheck/EccCheck.py
+++ b/.pytool/Plugin/EccCheck/EccCheck.py
@@ -97,7 +97,7 @@ class EccCheck(ICiBuildPlugin):
             temp_diff_output = os.path.join (temp_path, 'diff.txt')
 
             self.ApplyConfig(pkgconfig, temp_path, packagename)
-            modify_dir_list = self.GetModifyDir(packagename, temp_diff_output)
+            modify_dir_list = self.GetModifyDir(packagename, temp_diff_output, temp_path)
             patch = self.GetDiff(packagename, temp_diff_output)
             ecc_diff_range = self.GetDiffRange(patch, packagename, temp_path)
             #
@@ -148,7 +148,7 @@ class EccCheck(ICiBuildPlugin):
             patch = file.read().strip().split('\n')
         return patch
 
-    def GetModifyDir(self, pkg: str, temp_diff_output: str) -> List[str]:
+    def GetModifyDir(self, pkg: str, temp_diff_output: str, temp_path: str) -> List[str]:
         #
         # Generate diff between origin/master and HEAD using --diff-filter to
         # exclude deleted and renamed files that do not need to be scanned by
@@ -198,6 +198,13 @@ class EccCheck(ICiBuildPlugin):
             # EDK II meta data files (DEC, DSC, FDF).
             #
             if file_dir == pkg:
+                continue
+            #
+            # Skip directory names that no longer exist in the temporary package
+            # copy after applying IgnoreFiles configuration.
+            #
+            target_dir = os.path.normpath(os.path.join(temp_path, file_dir))
+            if not os.path.exists(target_dir):
                 continue
             #
             # Skip directory names that are already in the modified dir list
@@ -297,6 +304,9 @@ class EccCheck(ICiBuildPlugin):
         report    = os.path.normpath(os.path.join(temp_path, "Ecc.csv"))
         for modify_dir in modify_dir_list:
             target = os.path.normpath(os.path.join(temp_path, modify_dir))
+            if not os.path.exists(target):
+                logging.warning("Skip ECC on missing path %s", target)
+                continue
             logging.info('Run ECC tool for the commit in %s' % modify_dir)
             ecc_need = True
             ecc_params = "-c {0} -e {1} -t {2} -r {3}".format(config, exception, target, report)


### PR DESCRIPTION
# Description

EccCheck applies IgnoreFiles by removing matching paths from the temporary package copybefore collectingmodified directories from git diff output.

When a modified directory is covered by IgnoreFiles, it can still be selected for ECC scanning because GetModifyDir() does not verify that the candidate path still exists in the temporary tree. This leads to an invalid Ecc target path and causes the plugin to fail.

For example, an ignored path A can still be selected for ECC scanning and fail with:

    "IgnoreFiles": [
        "A",
        ...
    ]

    EccMain.py...
     : error 1003: Invalid value of option
     Target [.../A]
     does NOT exist

Skip modified directories that no longer exist after applying the package configuration, and keep a final existence check before invoking Ecc.

This keeps IgnoreFiles consistent with the generated ECC scan list and prevents ignored paths from failing the plugin with an invalid target error.


## How This Was Tested

stuart_ci_build -c edk2/.pytool/CISettings.py -p [XxxPkg]   --disable-all EccCheck=run

## Integration Instructions

CI
