### PR TITLE
BaseTools/Ecc: Avoid traceback on missing DSC PCD values

### DIFF
--- a/BaseTools/Source/Python/Ecc/MetaFileWorkspace/MetaFileParser.py
+++ b/BaseTools/Source/Python/Ecc/MetaFileWorkspace/MetaFileParser.py
@@ -1042,6 +1042,7 @@ class DscParser(MetaFileParser):
             EdkLogger.error('Parser', FORMAT_INVALID, "No PCD value given",
                             ExtraData=self._CurrentLine + " (<TokenSpaceGuidCName>.<TokenCName>|<PcdValue>)",
                             File=self.MetaFile, Line=self._LineIndex+1)
+            return
         # if value are 'True', 'true', 'TRUE' or 'False', 'false', 'FALSE', replace with integer 1 or 0.
         DscPcdValueList = GetSplitValueList(TokenList[1], TAB_VALUE_SPLIT, 1)
         if DscPcdValueList[0] in ['True', 'true', 'TRUE']:


### PR DESCRIPTION


# Description

The DSC PCD parser reports "No PCD value given" when a PCD entry does not provide a value, but it still continues into the boolean value normalization logic and unconditionally accesses TokenList[1].

This can turn an expected parser error into a Python traceback. For example, ECC may report:

    error 3000: No PCD value given
    gEfixxxPkgTokenSpaceGuid.Pcdxxx
    (<TokenSpaceGuidCName>.<TokenCName>|<PcdValue>)
    INFO - Traceback (most recent call last):
    ...

and then continue into a traceback from _PcdParser().

Return after reporting the missing PCD value so ECC reports the input error without crashing the parser.


## How This Was Tested

stuart_ci_build -c edk2/.pytool/CISettings.py -p [XxxPkg] --disable-all EccCheck=run


## Integration Instructions

CI
