### PR TITLE
OvmfPkg/VirtioBlkDxe: protect SynchronousRequest against interrupts

### DIFF
--- a/OvmfPkg/VirtioBlkDxe/VirtioBlk.c
+++ b/OvmfPkg/VirtioBlkDxe/VirtioBlk.c
@@ -253,6 +253,7 @@ SynchronousRequest (
   EFI_PHYSICAL_ADDRESS     RequestDeviceAddress;
   EFI_STATUS               Status;
   EFI_STATUS               UnmapStatus;
+  EFI_TPL                  CurrentTpl;
 
   BlockSize = Dev->BlockIoMedia.BlockSize;
 
@@ -365,6 +366,8 @@ SynchronousRequest (
     goto UnmapDataBuffer;
   }
 
+  CurrentTpl = gBS->RaiseTPL (TPL_NOTIFY);
+
   VirtioPrepare (&Dev->Ring, &Indices);
 
   //
@@ -438,6 +441,7 @@ SynchronousRequest (
     Status = EFI_DEVICE_ERROR;
   }
 
+  gBS->RestoreTPL (CurrentTpl);
   Dev->VirtIo->UnmapSharedBuffer (Dev->VirtIo, StatusMapping);
 
 UnmapDataBuffer:


### PR DESCRIPTION
# Description

I think the VirtioBlk driver in OVMF is affected by the same bug as #11987. Please see my example code below that could trigger the race condition. I'm not 100% sure but it seems very plausible to me. I'm seeking maintainer feedback.

- [ ] Breaking change? NO
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security? NO
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests? NO
   - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

I didn't yet hit that race condition (I didn't put too much effort into it yet) but it looks **plausible** that it is the same bug as we've seen in #11987.

Let's look at the following UEFI application. Please specifically look for the `
    // Now imagine this uses the virtio-blk driver in background: race condition!` **lines**

```rust
// SPDX-License-Identifier: MIT OR Apache-2.0

#![no_std]
#![no_main]

use core::ffi::c_void;
use core::ptr::NonNull;
use uefi::boot::{
    self, EventType, OpenProtocolAttributes, OpenProtocolParams, SearchType, TimerTrigger, Tpl,
};
use uefi::entry;
use uefi::proto::media::block::BlockIO;
use uefi::proto::media::disk::DiskIo;
use uefi::{Event, Handle, Status};

#[macro_use]
extern crate log;
extern "efiapi" fn timer_callback(_event: Event, _context: Option<NonNull<c_void>>) {
    log::info!("timer called!");
    // Now imagine this uses the virtio-blk driver in background: race condition!
    probe_block_device("timer");
}

fn first_disk_handle() -> Option<Handle> {
    let handles = boot::locate_handle_buffer(SearchType::from_proto::<DiskIo>()).ok()?;
    handles.first().copied()
}

fn read_lba0_via_disk_io(handle: Handle) -> Result<(), Status> {
    let media_id = unsafe {
        boot::open_protocol::<BlockIO>(
            OpenProtocolParams {
                handle,
                agent: boot::image_handle(),
                controller: None,
            },
            OpenProtocolAttributes::GetProtocol,
        )
        .map_err(|err| err.status())?
        .media()
        .media_id()
    };

    let disk_io = boot::open_protocol_exclusive::<DiskIo>(handle).map_err(|err| err.status())?;
    let mut sector0 = [0u8; 512];
    disk_io
        .read_disk(media_id, 0, &mut sector0)
        .map_err(|err| err.status())?;

    info!(
        "sector0 signature = {:02x}{:02x}",
        sector0[510],
        sector0[511]
    );

    Ok(())
}

fn probe_block_device(origin: &str) {
    let Some(handle) = first_disk_handle() else {
        info!("{origin}: no DiskIo handle found");
        return;
    };

    match read_lba0_via_disk_io(handle) {
        Ok(()) => info!("{origin}: DiskIo read succeeded"),
        Err(status) => info!("{origin}: DiskIo read failed: {status:?}"),
    }
}

#[entry]
fn efi_main() -> Status {
    // Initialize utilities (logging, memory allocation...)
    uefi::helpers::init().expect("Failed to initialize utilities");

    let event = unsafe { uefi::boot::create_event(
        EventType::TIMER | EventType::NOTIFY_SIGNAL,
        Tpl::NOTIFY,
        Some(timer_callback),
        None,
    ).unwrap() };

    info!("Timer configured");
    boot::set_timer(&event, TimerTrigger::Relative(50_000 /* 5 ms */)).unwrap();

    info!("Entering loop");
    // Now imagine this uses the virtio-blk driver in background: race condition!
    probe_block_device("main");
    loop {
        core::hint::spin_loop();
    }
}
```

## Integration Instructions


