### PR TITLE
MdePkg/ArmFfaMemMgmtLib: Set NS bit support in FFA_FEATURES query

### DIFF
--- a/MdePkg/Include/IndustryStandard/ArmFfaMemMgmt.h
+++ b/MdePkg/Include/IndustryStandard/ArmFfaMemMgmt.h
@@ -270,6 +270,17 @@ typedef struct {
 #define FFA_MEMORY_REGION_FLAG_BYPASS_BORROWERS_CHECK  (0x1U << 10)
 
 /**
+  FFA_FEATURES input properties for FFA_MEM_RETRIEVE_REQ.
+
+  This corresponds to section 1.10.4.1.1 of the FF-A Memory Management v1.3 APL1,
+  "Discovery of NS bit usage". Bit[1] in the Input properties parameter indicates
+  NS bit usage support. FF-A v1.1+ Secure Partitions must set this bit when
+  querying FFA_MEM_RETRIEVE_REQ features to indicate support for interpreting
+  the NS bit in FFA_MEM_RETRIEVE_RESP invocations.
+**/
+#define FFA_FEATURES_MEM_RETRIEVE_REQ_NS_SUPPORT  (0x1U << 1)
+
+/**
   Information about a set of pages which are being shared.
 
   This corresponds to table 1.20 of the FF-A Memory Management v1.3 APL1, "Memory

--- a/MdePkg/Library/ArmFfaMemMgmtLib/ArmFfaMemMgmtLib.c
+++ b/MdePkg/Library/ArmFfaMemMgmtLib/ArmFfaMemMgmtLib.c
@@ -3,7 +3,7 @@
 /** @file
   This library implements the FF-A memory manage protocol.
 
-  Copyright (c) 2020-2022, Arm Limited and Contributors. All rights reserved.
+  Copyright (c) 2020-2026, Arm Limited and Contributors. All rights reserved.
   Copyright (c), Microsoft Corporation.
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -351,7 +351,7 @@ ArmFfaMemLibRetrieveReq (
 
   Status = ArmFfaLibGetFeatures (
              FfaArgs.Arg0,
-             0,
+             FFA_FEATURES_MEM_RETRIEVE_REQ_NS_SUPPORT,
              &FfaArgs.Arg1,
              &FfaArgs.Arg2
              );


### PR DESCRIPTION
# Description

Add FFA_FEATURES_MEM_RETRIEVE_REQ_NS_SUPPORT macro and use it in FFA_FEATURES call for FFA_MEM_RETRIEVE_REQ to indicate NS bit usage support.

According to DEN0140 FF-A Memory Management Protocol v1.3 ALP1 specification section 1.10.4.1.1 "Discovery of NS bit usage":

"A v1.1 SP must set Bit[1] in the Input properties parameter."

This bit indicates that the Secure Partition supports interpreting the NS (Non-Secure) bit in FFA_MEM_RETRIEVE_RESP invocations from the SPMC (Secure Partition Manager Core). The NS bit is used to specify the security state of a memory region being retrieved.

The Hafnium SPMC implementation enforces this requirement for FF-A v1.1+ endpoints. Without this bit set, Hafnium returns FFA_NOT_SUPPORTED:

This change is required for proper operation with Hafnium and other v1.1+ compliant SPMCs that enforce NS bit negotiation.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested
Tested on FVP

## Integration Instructions
N/A

