### PR TITLE
MdeModulePkg/NvmExpressDxe: Mark CDW10/CDW11 valid for Format and San…

### DIFF
--- a/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressMediaSanitize.c
+++ b/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressMediaSanitize.c
@@ -109,6 +109,7 @@ NvmExpressFormatNvm (
   LbaFormat           = (Flbas == 0 ? Device->NamespaceData.Flbas : Flbas);
   FormatNvmCdw10.Lbaf = LbaFormat & NVME_LBA_FORMATNVM_LBAF_MASK;
   CopyMem (&CommandPacket.NvmeCmd->Cdw10, &FormatNvmCdw10, sizeof (NVME_ADMIN_FORMAT_NVM));
+  CommandPacket.NvmeCmd->Flags = CDW10_VALID;
 
   //
   // Send Format NVM command via passthru and wait for completion
@@ -236,6 +237,7 @@ NvmExpressSanitize (
   SanitizeCdw10Cdw11.Sanact = SanitizeAction;
   SanitizeCdw10Cdw11.Ovrpat = OverwritePattern;
   CopyMem (&CommandPacket.NvmeCmd->Cdw10, &SanitizeCdw10Cdw11, sizeof (NVME_ADMIN_SANITIZE));
+  CommandPacket.NvmeCmd->Flags = CDW10_VALID | CDW11_VALID;
 
   //
   // Send Format NVM command via passthru and wait for completion


### PR DESCRIPTION
NVMe Format and Sanitize operations are not marking valid codewords
in passthru command packet.

# Description

Sanitize command fails with the below log

> NvmExpressSanitize: NVMe Sanitize admin command failed SCT = 0x0, SC = 0x2

Per NVMe Spec 1.4c, Figure 128, SC = 0x2 translates to
"Invalid field in command"

NVMe Format and Sanitize admin commands correctly populate CDW10
(and CDW11 for Sanitize), but these codewords are not marked as valid
in the passthru command packet. As a result, the passthru layer does
not include the populated codewords in the command payload, causing
the commands to fail.

Set the appropriate CDW validity flags in the passthru command packet:
- Format NVM: CDW10_VALID
- Sanitize: CDW10_VALID | CDW11_VALID

This ensures the populated codewords are included in the passthru
command payload and the commands are issued correctly.


- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

MEDIA_SANITIZE_PROTOCOL is used to sanitize/ format NVMe
Readback from deterministic locations to verify data erase

## Integration Instructions

N/A