### PR TITLE
UefiCpuPkg/SmmCpuFeaturesLib: Add Standalone MM file for AMD family

### DIFF
--- a/UefiCpuPkg/Library/SmmCpuFeaturesLib/AmdStandaloneMmCpuFeaturesLib.c
+++ b/UefiCpuPkg/Library/SmmCpuFeaturesLib/AmdStandaloneMmCpuFeaturesLib.c
@@ -1,0 +1,33 @@
+/** @file
+Standalone MM CPU specific programming for AMD based platforms.
+
+Copyright (c) 2010 - 2019, Intel Corporation. All rights reserved.<BR>
+Copyright (c) Microsoft Corporation.<BR>
+Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <PiMm.h>
+#include "CpuFeaturesLib.h"
+
+/**
+  The Standalone MM library constructor.
+
+  @param[in] ImageHandle  Image handle of this driver.
+  @param[in] SystemTable  A Pointer to the EFI System Table.
+
+  @retval EFI_SUCCESS     This constructor always returns success.
+
+**/
+EFI_STATUS
+EFIAPI
+StandaloneMmCpuFeaturesLibConstructor (
+  IN EFI_HANDLE           ImageHandle,
+  IN EFI_MM_SYSTEM_TABLE  *SystemTable
+  )
+{
+  CpuFeaturesLibInitialization ();
+
+  return EFI_SUCCESS;
+}

--- a/UefiCpuPkg/Library/SmmCpuFeaturesLib/AmdStandaloneMmCpuFeaturesLib.inf
+++ b/UefiCpuPkg/Library/SmmCpuFeaturesLib/AmdStandaloneMmCpuFeaturesLib.inf
@@ -3,7 +3,7 @@
 #
 #  Copyright (c) 2009 - 2023, Intel Corporation. All rights reserved.<BR>
 #  Copyright (c) Microsoft Corporation.<BR>
-#  Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.<BR>
+#  Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -21,7 +21,7 @@
 
 [Sources]
   SmmCpuFeaturesLibCommon.c
-  StandaloneMmCpuFeaturesLib.c
+  AmdStandaloneMmCpuFeaturesLib.c
   AmdSmmCpuFeaturesLib.c
   CpuFeaturesLib.h
 
@@ -39,9 +39,6 @@
 
 [Guids]
   gSmmBaseHobGuid                ## CONSUMES
-
-[FixedPcd]
-  gUefiCpuPkgTokenSpaceGuid.PcdCpuMaxLogicalProcessorNumber   ## SOMETIMES_CONSUMES
 
 [FeaturePcd]
   gUefiCpuPkgTokenSpaceGuid.PcdSmrrEnable                     ## CONSUMES


### PR DESCRIPTION
Add AmdStandaloneMmCpuFeaturesLib.c for AMD family, which is built for the AMD Standalone MM library (AmdStandaloneMmCpuFeaturesLib). It is based on the existing file, StandaloneMmCpuFeaturesLib.c. It focuses on the AMD library, as aligning with the AMD Traditional MM library.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

It has been verified on AMD platform that enables Standalone MM support.

## Integration Instructions

N/A
