### PR TITLE
ShellPkg/AcpiView: Update MPAM table "MMIO size" field check

### DIFF
--- a/ShellPkg/Library/UefiShellAcpiViewCommandLib/Parsers/Mpam/MpamParser.c
+++ b/ShellPkg/Library/UefiShellAcpiViewCommandLib/Parsers/Mpam/MpamParser.c
@@ -154,10 +154,10 @@ ValidateMmioSize (
   if (InterfaceType == EFI_ACPI_MPAM_INTERFACE_PCC) {
     MmioSize = *((UINT32 *)Ptr);
 
-    if (MmioSize != 0) {
+    if (MmioSize > 1) {
       IncrementErrorCount ();
       Print (
-        L"\nERROR: MMIO size must be 0 for PCC interface type. Size - %u\n",
+        L"\nERROR: MMIO size must be 0 or 1 for PCC interface type. Size - %u\n",
         MmioSize
         );
     }


### PR DESCRIPTION
The "ACPI for Memory System Resource Partitioning and Monitoring" spec (Arm DEN0065, [1]) in version 2.0 described the "MMIO size" field in the "MPAM MSC node" subtable as being always 0 if the the "PCC" interface type is used for that MSC. Version 3.0 of the spec changes that field to convey the enablement status of that MSC: "If set to 1, this MSC is accessible ... If set to 0, this MSC is non-functional...."
Relax the strict check for this value being 0 in the acpiview validation checks, to also allow the new value of "1".

[1] https://developer.arm.com/documentation/den0065/3-0/

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

Adding an MPAM ACPI table describing one MSC as using the MPAM-Fb interface type. Then running "acpiview" to validate the table. Tested on the kvmtool port.

## Integration Instructions
N/A