### PR TITLE
RedfishPkg: fix memory leaks

### DIFF
--- a/RedfishPkg/Library/HiiUtilityLib/HiiUtilityInternal.c
+++ b/RedfishPkg/Library/HiiUtilityLib/HiiUtilityInternal.c
@@ -621,6 +621,7 @@ StorageToConfigResp (
                       (VOID **)&HiiConfigRouting
                       );
       if (EFI_ERROR (Status)) {
+        FreePool (TempConfigRequest);
         return Status;
       }
 
@@ -662,6 +663,7 @@ StorageToConfigResp (
       break;
   }
 
+  FreePool (TempConfigRequest);
   return Status;
 }
 
@@ -1246,6 +1248,10 @@ LoadFormSetStorage (
                   (VOID **)&HiiConfigRouting
                   );
   if (EFI_ERROR (Status)) {
+    if (ConfigRequest != NULL) {
+      FreePool (ConfigRequest);
+    }
+
     return;
   }
 
@@ -1269,18 +1275,9 @@ LoadFormSetStorage (
   }
 
   Storage->ConfigRequest = AllocateCopyPool (StrSize (ConfigRequest), ConfigRequest);
-  if (Storage->ConfigRequest == NULL) {
-    if (ConfigRequest != NULL) {
-      FreePool (ConfigRequest);
-    }
-
-    return;
-  }
-
-  if (Storage->Type != EFI_HII_VARSTORE_NAME_VALUE) {
-    if (ConfigRequest != NULL) {
-      FreePool (ConfigRequest);
-    }
+  ASSERT (Storage->ConfigRequest != NULL);
+  if (ConfigRequest != NULL) {
+    FreePool (ConfigRequest);
   }
 }
 
@@ -1696,6 +1693,9 @@ GetQuestionValue (
     MaxLen        = Length + 1;
     ConfigRequest = AllocatePool (MaxLen * sizeof (CHAR16));
     ASSERT (ConfigRequest != NULL);
+    if (ConfigRequest == NULL) {
+      return EFI_OUT_OF_RESOURCES;
+    }
 
     StrCpyS (ConfigRequest, MaxLen, FormsetStorage->ConfigHdr);
     if (IsBufferStorage) {
@@ -1711,6 +1711,7 @@ GetQuestionValue (
                     (VOID **)&HiiConfigRouting
                     );
     if (EFI_ERROR (Status)) {
+      FreePool (ConfigRequest);
       return Status;
     }
 

--- a/RedfishPkg/RedfishHttpDxe/RedfishHttpDxe.c
+++ b/RedfishPkg/RedfishHttpDxe/RedfishHttpDxe.c
@@ -449,7 +449,7 @@ ON_RELEASE:
   }
 
   if (EncodedAuthString != NULL) {
-    ZeroMem (BasicAuthString, EncodedAuthStrSize);
+    ZeroMem (EncodedAuthString, EncodedAuthStrSize);
     FreePool (EncodedAuthString);
   }
 

--- a/RedfishPkg/RedfishHttpDxe/RedfishHttpOperation.c
+++ b/RedfishPkg/RedfishHttpDxe/RedfishHttpOperation.c
@@ -664,7 +664,7 @@ HttpSendReceive (
     return EFI_INVALID_PARAMETER;
   }
 
-  DEBUG ((REDFISH_HTTP_CACHE_DEBUG_REQUEST, "%a: Method: 0x%x %s\n", __func__, Method, Uri));
+  DEBUG ((REDFISH_HTTP_CACHE_DEBUG_REQUEST, "%a: Method: %a %s\n", __func__, HttpMethodToString (Method), Uri));
 
   ServicePrivate = (REDFISH_SERVICE_PRIVATE *)Service;
   if (ServicePrivate->Signature != REDFISH_HTTP_SERVICE_SIGNATURE) {

--- a/RedfishPkg/RedfishRestExDxe/RedfishRestExProtocol.c
+++ b/RedfishPkg/RedfishRestExDxe/RedfishRestExProtocol.c
@@ -533,20 +533,18 @@ RedfishRestExGetService (
   RESTEX_INSTANCE           *Instance;
   EFI_REST_EX_SERVICE_INFO  *ServiceInfo;
 
-  ServiceInfo = NULL;
-
   if ((This == NULL) || (RestExServiceInfo == NULL)) {
     return EFI_INVALID_PARAMETER;
   }
-
-  OldTpl = gBS->RaiseTPL (TPL_CALLBACK);
-
-  Instance = RESTEX_INSTANCE_FROM_THIS (This);
 
   ServiceInfo = AllocateZeroPool (sizeof (EFI_REST_EX_SERVICE_INFO));
   if (ServiceInfo == NULL) {
     return EFI_OUT_OF_RESOURCES;
   }
+
+  OldTpl = gBS->RaiseTPL (TPL_CALLBACK);
+
+  Instance = RESTEX_INSTANCE_FROM_THIS (This);
 
   CopyMem (ServiceInfo, &(Instance->Service->RestExServiceInfo), sizeof (EFI_REST_EX_SERVICE_INFO));
 


### PR DESCRIPTION
# Description

This PR provides fixes for some findings in RedfishPkg.
In general it refines and fixes trivial memory leaks on an error path.

## How This Was Tested

Smoke test.

## Integration Instructions

N/A
