### PR TITLE
MdeModulePkg/Universal/ExStatusCodeHandler: Add ExStatusCodeHandlerPei

### DIFF
--- a/MdeModulePkg/Include/Guid/SerialPortConfig.h
+++ b/MdeModulePkg/Include/Guid/SerialPortConfig.h
@@ -1,0 +1,125 @@
+/** @file
+  Provides serial port configuration.
+
+  Copyright (c) 2025, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef _SERIAL_PORT_CONFIG_H
+#define _SERIAL_PORT_CONFIG_H
+
+#include <Uefi/UefiBaseType.h>
+
+#define SERIAL_PORT_CONFIG_MAX       3
+#define SERIAL_PORT_CONFIG_SIZE_MAX  100
+
+typedef union {
+  struct {
+    /**
+      Enables the eSPI interface for serial logging.
+    **/
+    UINT8    EspiUartEnable  : 1;
+
+    /**
+      Enables the local UART controller for serial logging.
+    **/
+    UINT8    LocalUartEnable : 1;
+
+    /**
+      Following values are supported for COM selection:
+      000 3F8h - 3FFh (COM 1)
+      001 2F8h - 2FFh (COM 2)
+      010 3E8h - 3EFh (COM 3)
+      011 2E8h - 2EFh (COM 4)
+    **/
+    UINT8    EspiComSelect  : 3;
+    UINT8    LocalComSelect : 3;
+  } Fields;
+
+  UINT8    Raw;
+} PLATFORM_SERIAL_PORT_CONFIG;
+
+typedef UINT8 SERIAL_PORT_DEVICE_CONFIG[SERIAL_PORT_CONFIG_SIZE_MAX];
+
+typedef
+RETURN_STATUS
+(*SERIAL_PORT_INITIALIZE) (
+  IN SERIAL_PORT_DEVICE_CONFIG  SerialPortDeviceConfig
+  );
+
+typedef
+UINTN
+(*SERIAL_PORT_WRITE) (
+  IN SERIAL_PORT_DEVICE_CONFIG  SerialPortDeviceConfig,
+  IN UINT8                      *Buffer,
+  IN UINTN                      NumberOfBytes
+  );
+
+typedef
+UINTN
+(*SERIAL_PORT_READ) (
+  IN SERIAL_PORT_DEVICE_CONFIG  SerialPortDeviceConfig,
+  IN UINT8                      *Buffer,
+  IN UINTN                      NumberOfBytes
+  );
+
+typedef
+BOOLEAN
+(*SERIAL_PORT_POLL) (
+  IN SERIAL_PORT_DEVICE_CONFIG  SerialPortDeviceConfig
+  );
+
+typedef struct {
+  /*
+    UART device enabled by the platform.
+  */
+  BOOLEAN                      EnabledByPlatform;
+
+  /*
+    UART device enabled by the platform and available on the current platform.
+  */
+  BOOLEAN                      Enabled;
+
+  /*
+    UART device initialization hook.
+  */
+  SERIAL_PORT_INITIALIZE       Initialize;
+
+  /*
+    UART device write hook.
+  */
+  SERIAL_PORT_WRITE            WriteBytes;
+
+  /*
+    UART device read hook.
+  */
+  SERIAL_PORT_READ             ReadBytes;
+
+  /*
+    UART device poll hook.
+  */
+  SERIAL_PORT_POLL             Poll;
+
+  /*
+    UART device configuration data. Convert to a device-specific type before
+    use.
+  */
+  SERIAL_PORT_DEVICE_CONFIG    DeviceConfig;
+} SERIAL_PORT_CONFIG_SINGLE;
+
+typedef struct {
+  /*
+    Array of all UART device configurations.
+  */
+  SERIAL_PORT_CONFIG_SINGLE    Configurations[SERIAL_PORT_CONFIG_MAX];
+
+  /*
+    Number of UART devices present.
+  */
+  UINT8                        Count;
+
+  BOOLEAN                      InitializeDevices;
+} SERIAL_PORT_CONFIG;
+
+#endif // _SERIAL_PORT_CONFIG_H

--- a/MdeModulePkg/Include/Guid/StatusCodeDataTypeExDebug.h
+++ b/MdeModulePkg/Include/Guid/StatusCodeDataTypeExDebug.h
@@ -1,0 +1,46 @@
+/** @file
+  GUID and structure used for debug status code policy.
+
+  Copyright (c) 2025, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Library/SemaphoreLib.h>
+
+#define STATUS_CODE_DATA_TYPE_EX_DEBUG_GUID \
+  { 0x7859daa2, 0x926e, 0x4b01,{0x85, 0x86, 0xc6, 0x2d, 0x45, 0x64, 0x21, 0xd2} }
+
+#define MAX_EX_DEBUG_SIZE     0x200 // Inherited from PEI status code max
+#define MAX_EX_DEBUG_STR_LEN  (MAX_EX_DEBUG_SIZE - sizeof(EX_DEBUG_INFO))
+
+typedef
+CHAR8 *
+(EFIAPI *PROCESS_BUFFER)(
+  IN     VOID   *ProcessDataPtr,
+  IN     CHAR8  *Buffer,
+  IN OUT UINTN  *BufferSize
+  );
+
+typedef
+EFI_STATUS
+(EFIAPI *PRINT_SYNC_ACQUIRE)(
+  VOID
+  );
+
+typedef
+EFI_STATUS
+(EFIAPI *PRINT_SYNC_RELEASE)(
+  VOID
+  );
+
+typedef struct {
+  PROCESS_BUFFER        ProcessBuffer;    // Buffer processing function
+  VOID                  *ProcessDataPtr;  // Data needed for processing
+  PRINT_SYNC_ACQUIRE    PrintSyncAcquire; // Acquire sync function
+  PRINT_SYNC_RELEASE    PrintSyncRelease; // Release sync function
+  UINT32                DebugStringLen;
+  CHAR8                 *DebugString;      // Provided debug string
+} EX_DEBUG_INFO;
+
+extern EFI_GUID  gStatusCodeDataTypeExDebugGuid;

--- a/MdeModulePkg/Include/Library/ModuleAddrCalcLib.h
+++ b/MdeModulePkg/Include/Library/ModuleAddrCalcLib.h
@@ -1,0 +1,36 @@
+/** @file
+  Calculate Module Offset
+
+  Copyright (c) 2025, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+/**
+  Calculate the module entry point offset after PEIM shadowing.
+
+  @param[in, out] ModuleOffset    Absolute offset between the original PEIM
+                                  entry point and the shadowed entry point.
+  @param[in, out] ModulePositive  TRUE if the PEIM moved to a higher address.
+                                  FALSE if it moved to a lower address.
+
+  This helper supports PEIMs that may run twice: once from temporary storage and
+  once after shadowing into permanent memory.
+
+  This helper supports both 32-bit and 64-bit PEIMs.
+
+  @retval EFI_SUCCESS          The PEIM is running before shadowing. Ignore the
+                               returned offset and direction values.
+  @retval EFI_ALREADY_STARTED  The PEIM is running after shadowing. ModuleOffset
+                               and ModulePositive contain valid results.
+
+  @return Status  The return value is expected to be either EFI_SUCCESS or
+                  EFI_ALREADY_STARTED because a PEIM is shadowed at most once.
+**/
+EFI_STATUS
+ModuleOffsetCalculator (
+  IN     EFI_PEI_FILE_HANDLE  FileHandle,
+  IN     EFI_GUID             *CallerGuid,
+  IN OUT UINTN                *ModuleOffset,
+  IN OUT BOOLEAN              *ModulePositive
+  );

--- a/MdeModulePkg/Include/Library/SemaphoreLib.h
+++ b/MdeModulePkg/Include/Library/SemaphoreLib.h
@@ -1,0 +1,373 @@
+/** @file
+  The Semaphore Library API provides the necessary functions to acquire/release
+  the global or a socket's semaphore.
+  This API is designed to allow a calling agent to acquire a global (the SBSP)
+  semaphore or a socket's semaphore.  It also provides functionality to release
+  the semaphore and check if ownership has been obtained.  If a semaphore is
+  desired, an agent should first attempt to acquire it, then check if it has
+  ownership.  If ownership has not been obtained, the agent must wait until
+  ownership has been obtained before proceeding.  Once the desired task is complete
+  the semaphore must be released.  Semaphores should be used when ensuring
+  exclusive access to resources among CPU sockets is necessary.
+
+  Copyright (c) 2025, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef _SEMAPHORE_LIB_H_
+#define _SEMAPHORE_LIB_H_
+
+#include <Uefi.h>
+
+///
+/// Used to identify which system semaphore is being accessed. There are
+/// currently two System Semaphores available for use (0 and 1).
+///
+typedef enum {
+  SystemSemaphore0,     ///< Semaphore 0 - Used for SPD/SMBus access
+  SystemSemaphore1,     ///< Semaphore 1 - Used for Debug print
+  SystemSemaphore2,
+  SystemSemaphore3,
+  SystemSemaphoreMax
+} SYSTEM_SEMAPHORE_NUMBER;
+
+///
+/// Used to identify which local semaphore is being accessed. There are
+/// currently two Local Semaphores available for use (0 and 1).
+///
+typedef enum {
+  LocalSemaphore0,
+  LocalSemaphore1,
+  LocalSemaphore2,
+  LocalSemaphore3,
+  LocalSemaphoreMax
+} LOCAL_SEMAPHORE_NUMBER;
+
+#define DO_NOT_ADD_TO_QUEUE  FALSE
+#define ADD_TO_QUEUE         TRUE
+
+/**
+  Acquire a global (BSP) semaphore for the calling socket.
+
+  Used for ensuring exclusive access to resources among CPU sockets.
+
+  IMPORTANT:
+    The functions must be called in the sequence below:
+      ......
+      Owned = AcquireGlobalSemaphore (SystemSemaphore0, ADD_TO_QUEUE, &QNum);
+      while (!Owned) {
+        Owned = IsGlobalSemaphoreOwned (SystemSemaphore0, QNum));
+      }
+      DoSomething ();
+      ReleaseGlobalSemaphore (SystemSemaphore0);
+      ......
+
+  @param[in]  SemaphoreNumber   - SYSTEMSEMAPHORE register number (0 or 1)
+  @param[in]  AddToQueue        - specifies whether to add the requesting
+                                  socket to the queue (TRUE or FALSE)
+  @param[out] QueueNumber       - assigned place in line of semaphore request,
+                                  if adding to queue
+
+  @retval TRUE                  - successfully acquired semaphore
+  @retval FALSE                 - semaphore not acquired
+**/
+BOOLEAN
+EFIAPI
+AcquireGlobalSemaphore (
+  IN  SYSTEM_SEMAPHORE_NUMBER  SemaphoreNumber,
+  IN  BOOLEAN                  AddToQueue,
+  OUT UINT32                   *QueueNumber      OPTIONAL
+  );
+
+/**
+  Checks if a global (BSP) semaphore is owned by the calling socket.
+
+  Used for ensuring exclusive access to resources among CPU sockets.
+
+  IMPORTANT:
+    The functions must be called in the sequence below:
+      ......
+      Owned = AcquireGlobalSemaphore (SystemSemaphore0, ADD_TO_QUEUE, &QNum);
+      while (!Owned) {
+        Owned = IsGlobalSemaphoreOwned (SystemSemaphore0, QNum));
+      }
+      DoSomething ();
+      ReleaseGlobalSemaphore (SystemSemaphore0);
+      ......
+
+  @param[in]  SemaphoreNumber   - SYSTEMSEMAPHORE register number (0 or 1)
+  @param[in]  QueueNumber       - assigned place in line of semaphore request
+                                  that was returned by AcquireGlobalSemaphore
+
+  @retval TRUE                  - successfully acquired semaphore
+  @retval FALSE                 - semaphore not acquired
+**/
+BOOLEAN
+EFIAPI
+IsGlobalSemaphoreOwned (
+  IN  SYSTEM_SEMAPHORE_NUMBER  SemaphoreNumber,
+  IN  UINT32                   QueueNumber
+  );
+
+/**
+  Release a global (BSP) semaphore owned by the calling socket.
+
+  Used for ensuring exclusive access to resources among CPU sockets.
+
+  IMPORTANT:
+    The functions must be called in the sequence below:
+      ......
+      Owned = AcquireGlobalSemaphore (SystemSemaphore0, ADD_TO_QUEUE, &QNum);
+      while (!Owned) {
+        Owned = IsGlobalSemaphoreOwned (SystemSemaphore0, QNum));
+      }
+      DoSomething ();
+      ReleaseGlobalSemaphore (SystemSemaphore0);
+      ......
+
+  @param[in]  SemaphoreNumber   - SYSTEMSEMAPHORE register number (0 or 1)
+
+  @retval EFI_SUCCESS           - successfully released semaphore
+  @retval EFI_DEVICE_ERROR      - error releasing semaphore
+**/
+EFI_STATUS
+EFIAPI
+ReleaseGlobalSemaphore (
+  IN  SYSTEM_SEMAPHORE_NUMBER  SemaphoreNumber
+  );
+
+/**
+  Acquire a socket semaphore for the calling socket.
+
+  Used for ensuring exclusive access to resources among CPU sockets.
+
+  IMPORTANT:
+    The functions must be called in the sequence below:
+      ......
+      Owned = AcquireSocketSemaphore (Socket, SystemSemaphore0, ADD_TO_QUEUE, &QNum);
+      while (!Owned) {
+        Owned = IsSocketSemaphoreOwned (Socket, SystemSemaphore0, QNum));
+      }
+      DoSomething ();
+      ReleaseSocketSemaphore (Socket, SystemSemaphore0);
+      ......
+
+  @param[in]  Socket            - Socket where the semaphore is located
+  @param[in]  SemaphoreNumber   - SYSTEMSEMAPHORE register number (0 or 1)
+  @param[in]  AddToQueue        - specifies whether to add the requesting
+                                  socket to the queue (TRUE or FALSE)
+  @param[out] QueueNumber       - assigned place in line of semaphore request,
+                                  if adding to queue
+
+  @retval TRUE                  - successfully acquired semaphore
+  @retval FALSE                 - semaphore not acquired
+**/
+BOOLEAN
+EFIAPI
+AcquireSocketSemaphore (
+  IN  UINT8                    Socket,
+  IN  SYSTEM_SEMAPHORE_NUMBER  SemaphoreNumber,
+  IN  BOOLEAN                  AddToQueue,
+  OUT UINT32                   *QueueNumber      OPTIONAL
+  );
+
+/**
+  Checks if a socket semaphore is owned by the calling socket.
+
+  Used for ensuring exclusive access to resources among CPU sockets.
+
+  IMPORTANT:
+    The functions must be called in the sequence below:
+      ......
+      Owned = AcquireSocketSemaphore (Socket, SystemSemaphore0, ADD_TO_QUEUE, &QNum);
+      while (!Owned) {
+        Owned = IsSocketSemaphoreOwned (Socket, SystemSemaphore0, QNum));
+      }
+      DoSomething ();
+      ReleaseSocketSemaphore (Socket, SystemSemaphore0);
+      ......
+
+  @param[in]  Socket            - Socket where the semaphore is located
+  @param[in]  SemaphoreNumber   - SYSTEMSEMAPHORE register number (0 or 1)
+  @param[in]  QueueNumber       - assigned place in line of semaphore request
+                                  that was returned by AcquireSocketSemaphore
+
+  @retval TRUE                  - successfully acquired semaphore
+  @retval FALSE                 - semaphore not acquired
+**/
+BOOLEAN
+EFIAPI
+IsSocketSemaphoreOwned (
+  IN  UINT8                    Socket,
+  IN  SYSTEM_SEMAPHORE_NUMBER  SemaphoreNumber,
+  IN  UINT32                   QueueNumber
+  );
+
+/**
+  Release a socket semaphore owned by the calling socket.
+
+  Used for ensuring exclusive access to resources among CPU sockets.
+
+  IMPORTANT:
+    The functions must be called in the sequence below:
+      ......
+      Owned = AcquireSocketSemaphore (Socket, SystemSemaphore0, ADD_TO_QUEUE, &QNum);
+      while (!Owned) {
+        Owned = IsSocketSemaphoreOwned (Socket, SystemSemaphore0, QNum));
+      }
+      DoSomething ();
+      ReleaseSocketSemaphore (Socket, SystemSemaphore0);
+      ......
+
+  @param[in]  Socket            - Socket to release semaphore
+  @param[in]  SemaphoreNumber   - SYSTEMSEMAPHORE register number (0 or 1)
+
+  @retval EFI_SUCCESS           - successfully released semaphore
+  @retval EFI_DEVICE_ERROR      - error releasing semaphore
+**/
+EFI_STATUS
+EFIAPI
+ReleaseSocketSemaphore (
+  IN  UINT8                    Socket,
+  IN  SYSTEM_SEMAPHORE_NUMBER  SemaphoreNumber
+  );
+
+/**
+  Acquire a local semaphore for the calling thread.
+
+  Used for ensuring exclusive access to resources among CPU threads.
+
+  IMPORTANT:
+    The functions must be called in the sequence below:
+      ......
+      Owned = AcquireLocalSemaphore (LocalSemaphore0, ADD_TO_QUEUE, &QNum);
+      while (!Owned) {
+        Owned = IsLocalSemaphoreOwned (LocalSemaphore0, QNum));
+      }
+      DoSomething ();
+      ReleaseLocalSemaphore (LocalSemaphore0);
+      ......
+
+  @param[in]  SemaphoreNumber   - LOCALSEMAPHORE register number (0 or 1)
+  @param[in]  AddToQueue        - specifies whether to add the requesting
+                                  thread to the queue (TRUE or FALSE)
+  @param[out] QueueNumber       - assigned place in line of semaphore request,
+                                  if adding to queue
+
+  @retval TRUE                  - successfully acquired semaphore
+  @retval FALSE                 - semaphore not acquired
+**/
+BOOLEAN
+EFIAPI
+AcquireLocalSemaphore (
+  IN  LOCAL_SEMAPHORE_NUMBER  SemaphoreNumber,
+  IN  BOOLEAN                 AddToQueue,
+  OUT UINT32                  *QueueNumber      OPTIONAL
+  );
+
+/**
+  Checks if a local semaphore is owned by the calling thread.
+
+  Used for ensuring exclusive access to resources among CPU threads.
+
+  IMPORTANT:
+    The functions must be called in the sequence below:
+      ......
+      Owned = AcquireLocalSemaphore (LocalSemaphore0, ADD_TO_QUEUE, &QNum);
+      while (!Owned) {
+        Owned = IsLocalSemaphoreOwned (LocalSemaphore0, QNum));
+      }
+      DoSomething ();
+      ReleaseLocalSemaphore (LocalSemaphore0);
+      ......
+
+  @param[in]  SemaphoreNumber   - LOCALSEMAPHORE register number (0 or 1)
+  @param[in]  QueueNumber       - assigned place in line of semaphore request
+                                  that was returned by AcquireLocalSemaphore
+
+  @retval TRUE                  - successfully acquired semaphore
+  @retval FALSE                 - semaphore not acquired
+**/
+BOOLEAN
+EFIAPI
+IsLocalSemaphoreOwned (
+  IN  LOCAL_SEMAPHORE_NUMBER  SemaphoreNumber,
+  IN  UINT32                  QueueNumber
+  );
+
+/**
+  Release a local semaphore owned by the calling thread.
+
+  Used for ensuring exclusive access to resources among CPU threads.
+
+  IMPORTANT:
+    The functions must be called in the sequence below:
+      ......
+      Owned = AcquireLocalSemaphore (LocalSemaphore0, ADD_TO_QUEUE, &QNum);
+      while (!Owned) {
+        Owned = IsLocalSemaphoreOwned (LocalSemaphore0, QNum));
+      }
+      DoSomething ();
+      ReleaseLocalSemaphore (LocalSemaphore0);
+      ......
+
+  @param[in]  SemaphoreNumber   - LOCALSEMAPHORE register number (0 or 1)
+
+  @retval EFI_SUCCESS           - successfully released semaphore
+  @retval EFI_INVALID_PARAMETER - semaphore number is out of range
+  @retval EFI_DEVICE_ERROR      - error releasing semaphore
+**/
+EFI_STATUS
+EFIAPI
+ReleaseLocalSemaphore (
+  IN  LOCAL_SEMAPHORE_NUMBER  SemaphoreNumber
+  );
+
+/**
+  Check if any semaphore is owned.
+
+  This function should only be called at a time when no semaphores are expected
+  to be owned. If any are owned, it prints a warning message.
+**/
+VOID
+EFIAPI
+CheckAnySemaphoreOwned (
+  VOID
+  );
+
+/**
+  Checks if a GlobalSemaphore is owned by some socket.
+
+  @param[in]  SocketOwned       - socket number
+                                  if semaphore is owned by the socket
+
+  @retval TRUE                  - semaphore is owned by the socket
+  @retval FALSE                 - semaphore is not owned by the socket
+**/
+BOOLEAN
+EFIAPI
+CheckGlobalSemaphoreOwned (
+  IN      UINT8  Socket
+  );
+
+/**
+  Get Bios semaphore registers' flat address
+
+  @param SocId            - CPU Socket Node number (Socket ID)
+  @param RegIndex         - Release semaphore register index
+  @param RegAddress       - Register address
+
+  @retval                 - EFI_INVALID_PARAMETER: input Pad index doesn't exist for this SOC
+                            EFI_SUCCESS:     the function is excuted successfully
+
+**/
+EFI_STATUS
+EFIAPI
+GetReleaseSemaphoreAddr (
+  IN  UINT8  Socket,
+  IN  UINT8  RegIndex,
+  OUT UINTN  *RegAddress
+  );
+
+#endif // _SEMAPHORE_LIB_H_

--- a/MdeModulePkg/Include/Ppi/ExReportStatusCodeHandler.h
+++ b/MdeModulePkg/Include/Ppi/ExReportStatusCodeHandler.h
@@ -1,0 +1,39 @@
+/** @file
+  Define the EFI_PEI_EX_RSC_HANDLER_PPI used to register
+  ExSerialStatusCodeReportWorker for ReportStatusCode() notifications.
+
+  Copyright (c) 2025, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef __EX_REPORT_STATUS_CODE_HANDLER_PPI_H__
+#define __EX_REPORT_STATUS_CODE_HANDLER_PPI_H__
+
+/**
+  Register ExSerialStatusCodeReportWorker for ReportStatusCode()
+  notifications.
+
+
+  @param[in] PeiServices        Pointer to PEI Services Table.
+
+  @retval EFI_SUCCESS           Function was successfully registered.
+  @retval EFI_INVALID_PARAMETER The callback function was NULL.
+  @retval EFI_OUT_OF_RESOURCES  The internal buffer ran out of space. No more functions can be
+                                registered.
+  @retval EFI_ALREADY_STARTED   The function was already registered. It can't be registered again.
+
+**/
+typedef
+EFI_STATUS
+(EFIAPI *EFI_PEI_EX_RSC_HANDLER_REGISTER)(
+  IN CONST  EFI_PEI_SERVICES        **PeiServices
+  );
+
+typedef struct _EFI_EX_PEI_RSC_HANDLER_PPI {
+  EFI_PEI_EX_RSC_HANDLER_REGISTER    RegisterExStatusCodeHandler;
+} EFI_PEI_EX_RSC_HANDLER_PPI;
+
+extern EFI_GUID  gEfiPeiExStatusCodeHandlerPpiGuid;
+
+#endif // __EX_REPORT_STATUS_CODE_HANDLER_PPI_H__

--- a/MdeModulePkg/Library/ModuleAddrCalcLib/ModuleAddrCalcLib.c
+++ b/MdeModulePkg/Library/ModuleAddrCalcLib/ModuleAddrCalcLib.c
@@ -1,0 +1,98 @@
+/** @file
+  Calculate Module Offset
+
+  Copyright (c) 2025, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Library/PeiServicesLib.h>
+#include <Library/DebugLib.h>
+#include <Library/HobLib.h>
+#include <Library/PeimEntryPoint.h>
+
+/**
+  Only record the EntryPoint now
+  Consumed by ModuleOffsetCalculator only
+**/
+typedef struct _MODULE_OFFSET_HOB {
+  UINTN    EntryPoint;
+} MODULE_OFFSET_HOB;
+
+/**
+  Calculate Module Offset when Module Migration.
+
+  Security haven't be considered yet.
+
+  It support 32 and 64. So it can support 64BIT PEIM.
+
+  @param[in]      FileHandle      Handle of the file being invoked.
+  @param[in]      CallerGuid      GUID of the caller module.
+  @param[in,out]  ModuleOffset    Offset before and after PeiCore migrate PEIM.
+  @param[in,out]  ModulePositive  Migrate to high address will be TRUE. Otherwise will be FALSE.
+
+  @retval EFI_SUCCESS         Indicate that first run. There are no valid ModuleOffset and ModulePositive.
+                              Should ignore these.
+  @retval EFI_ALREADY_STARTED Indicate the logical have done and have valid ModuleOffset and ModulePositive.
+**/
+EFI_STATUS
+ModuleOffsetCalculator (
+  IN     EFI_PEI_FILE_HANDLE  FileHandle,
+  IN     EFI_GUID             *CallerGuid,
+  IN OUT UINTN                *ModuleOffset,
+  IN OUT BOOLEAN              *ModulePositive
+  )
+{
+  EFI_STATUS         Status;
+  MODULE_OFFSET_HOB  *ModuleOffsetHob;
+
+  Status = PeiServicesRegisterForShadow (FileHandle);
+
+  if (Status == EFI_SUCCESS) {
+    ModuleOffsetHob = BuildGuidHob (CallerGuid, sizeof (MODULE_OFFSET_HOB));
+
+    if (ModuleOffsetHob != NULL) {
+      ModuleOffsetHob->EntryPoint = (UINTN)_ModuleEntryPoint;
+    } else {
+      // This branch mean that fail to create HOB previously. HOB must be created successfully to calculate offset.
+      ASSERT (ModuleOffsetHob != NULL);
+
+      // Should never arrive here and unpredictable behavior may happened.
+      return Status;
+    }
+  } else if (Status == EFI_ALREADY_STARTED) {
+    ModuleOffsetHob = GetFirstGuidHob (CallerGuid);
+
+    if (ModuleOffsetHob != NULL) {
+      ModuleOffsetHob = GET_GUID_HOB_DATA (ModuleOffsetHob);
+    } else {
+      // This branch mean that fail to create HOB previously. HOB must be created successfully to calculate offset.
+      ASSERT (ModuleOffsetHob != NULL);
+
+      // Use 0 as return for safe.
+      *ModulePositive = TRUE;
+      *ModuleOffset   = 0;
+
+      // Should never arrive here and unpredictable behavior may happened.
+      return Status;
+    }
+
+    DEBUG ((DEBUG_INFO, "Address before and after Migration: 0x%X -> 0x%X\n", ModuleOffsetHob->EntryPoint, _ModuleEntryPoint));
+  } else {
+    // Status can only be Success or AlreadyStarted
+    ASSERT (FALSE);
+
+    // Should never arrive here and unpredictable behavior may happened.
+    return Status;
+  }
+
+  if ((UINTN)_ModuleEntryPoint >= ModuleOffsetHob->EntryPoint) {
+    *ModulePositive = TRUE;
+    *ModuleOffset   = (UINTN)_ModuleEntryPoint - ModuleOffsetHob->EntryPoint;
+  } else {
+    *ModulePositive = FALSE;
+    *ModuleOffset   = ModuleOffsetHob->EntryPoint - (UINTN)_ModuleEntryPoint;
+  }
+
+  return Status;
+}

--- a/MdeModulePkg/Library/ModuleAddrCalcLib/ModuleAddrCalcLib.inf
+++ b/MdeModulePkg/Library/ModuleAddrCalcLib/ModuleAddrCalcLib.inf
@@ -1,0 +1,32 @@
+## @file
+# Calculate the offset of Module in which case Module is migrated.
+#
+#  Copyright (c) 2025, Intel Corporation. All rights reserved.<BR>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION     = 0x00010017
+  BASE_NAME       = ModuleAddrCalcLib
+  FILE_GUID       = EE230143-54A2-41FA-8A4A-EE8BA0C9EC12
+  VERSION_STRING  = 1.0
+  MODULE_TYPE     = PEIM
+  LIBRARY_CLASS   = ModuleAddrCalcLib
+#
+# The following information is for reference only and not required by the build tools.
+#
+# VALID_ARCHITECTURES = IA32 X64 IPF
+#
+
+[LibraryClasses]
+  PeiServicesLib
+  DebugLib
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+
+[Sources]
+  ModuleAddrCalcLib.c

--- a/MdeModulePkg/Library/SemaphoreLibNull/SemaphoreLibNull.c
+++ b/MdeModulePkg/Library/SemaphoreLibNull/SemaphoreLibNull.c
@@ -1,0 +1,376 @@
+/** @file
+  Null implementation of SemaphoreLib functions
+
+  This library provides a Null implementation of acquire/release functions for
+  global/socket semaphores. It should only be used with code that is guaranteed
+  to only be executed on the BSP.
+
+  Copyright (c) 2025, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Uefi/UefiBaseType.h>
+#include <Library/SemaphoreLib.h>
+
+/**
+  Acquire a global (BSP) semaphore for the calling socket.
+
+  Used for ensuring exclusive access to resources among CPU sockets.
+
+  IMPORTANT:
+    The functions must be called in the sequence below:
+      ......
+      Owned = AcquireGlobalSemaphore (SystemSemaphore0, ADD_TO_QUEUE, &QNum);
+      while (!Owned) {
+        Owned = IsGlobalSemaphoreOwned (SystemSemaphore0, QNum));
+      }
+      DoSomething ();
+      ReleaseGlobalSemaphore (SystemSemaphore0);
+      ......
+
+  @param[in]  SemaphoreNumber   - SYSTEMSEMAPHORE register number (0 or 1)
+  @param[in]  AddToQueue        - specifies whether to add the requesting
+                                  socket to the queue (TRUE or FALSE)
+  @param[out] QueueNumber       - assigned place in line of semaphore request,
+                                  if adding to queue
+
+  @retval TRUE                  - successfully acquired semaphore
+  @retval FALSE                 - semaphore not acquired
+**/
+BOOLEAN
+EFIAPI
+AcquireGlobalSemaphore (
+  IN  SYSTEM_SEMAPHORE_NUMBER  SemaphoreNumber,
+  IN  BOOLEAN                  AddToQueue,
+  OUT UINT32                   *QueueNumber      OPTIONAL
+  )
+{
+  return TRUE;
+}
+
+/**
+  Checks if a global (BSP) semaphore is owned by the calling socket.
+
+  Used for ensuring exclusive access to resources among CPU sockets.
+
+  IMPORTANT:
+    The functions must be called in the sequence below:
+      ......
+      Owned = AcquireGlobalSemaphore (SystemSemaphore0, ADD_TO_QUEUE, &QNum);
+      while (!Owned) {
+        Owned = IsGlobalSemaphoreOwned (SystemSemaphore0, QNum));
+      }
+      DoSomething ();
+      ReleaseGlobalSemaphore (SystemSemaphore0);
+      ......
+
+  @param[in]  SemaphoreNumber   - SYSTEMSEMAPHORE register number (0 or 1)
+  @param[in]  QueueNumber       - assigned place in line of semaphore request
+                                  that was returned by AcquireGlobalSemaphore
+
+  @retval TRUE                  - successfully acquired semaphore
+  @retval FALSE                 - semaphore not acquired
+**/
+BOOLEAN
+EFIAPI
+IsGlobalSemaphoreOwned (
+  IN  SYSTEM_SEMAPHORE_NUMBER  SemaphoreNumber,
+  IN  UINT32                   QueueNumber
+  )
+{
+  return TRUE;
+}
+
+/**
+  Release a global (BSP) semaphore owned by the calling socket.
+
+  Used for ensuring exclusive access to resources among CPU sockets.
+
+  IMPORTANT:
+    The functions must be called in the sequence below:
+      ......
+      Owned = AcquireGlobalSemaphore (SystemSemaphore0, ADD_TO_QUEUE, &QNum);
+      while (!Owned) {
+        Owned = IsGlobalSemaphoreOwned (SystemSemaphore0, QNum));
+      }
+      DoSomething ();
+      ReleaseGlobalSemaphore (SystemSemaphore0);
+      ......
+
+  @param[in]  SemaphoreNumber   - SYSTEMSEMAPHORE register number (0 or 1)
+
+  @retval EFI_SUCCESS           - successfully released semaphore
+  @retval EFI_DEVICE_ERROR      - error releasing semaphore
+**/
+EFI_STATUS
+EFIAPI
+ReleaseGlobalSemaphore (
+  IN  SYSTEM_SEMAPHORE_NUMBER  SemaphoreNumber
+  )
+{
+  return EFI_SUCCESS;
+}
+
+/**
+  Acquire a socket semaphore for the calling socket.
+
+  Used for ensuring exclusive access to resources among CPU sockets.
+
+  IMPORTANT:
+    The functions must be called in the sequence below:
+      ......
+      Owned = AcquireSocketSemaphore (Socket, SystemSemaphore0, ADD_TO_QUEUE, &QNum);
+      while (!Owned) {
+        Owned = IsSocketSemaphoreOwned (Socket, SystemSemaphore0, QNum));
+      }
+      DoSomething ();
+      ReleaseSocketSemaphore (Socket, SystemSemaphore0);
+      ......
+
+  @param[in]  Socket            - Socket where the semaphore is located
+  @param[in]  SemaphoreNumber   - SYSTEMSEMAPHORE register number (0 or 1)
+  @param[in]  AddToQueue        - specifies whether to add the requesting
+                                  socket to the queue (TRUE or FALSE)
+  @param[out] QueueNumber       - assigned place in line of semaphore request,
+                                  if adding to queue
+
+  @retval TRUE                  - successfully acquired semaphore
+  @retval FALSE                 - semaphore not acquired
+**/
+BOOLEAN
+EFIAPI
+AcquireSocketSemaphore (
+  IN  UINT8                    Socket,
+  IN  SYSTEM_SEMAPHORE_NUMBER  SemaphoreNumber,
+  IN  BOOLEAN                  AddToQueue,
+  OUT UINT32                   *QueueNumber      OPTIONAL
+  )
+{
+  return TRUE;
+}
+
+/**
+  Checks if a socket semaphore is owned by the calling socket.
+
+  Used for ensuring exclusive access to resources among CPU sockets.
+
+  IMPORTANT:
+    The functions must be called in the sequence below:
+      ......
+      Owned = AcquireSocketSemaphore (Socket, SystemSemaphore0, ADD_TO_QUEUE, &QNum);
+      while (!Owned) {
+        Owned = IsSocketSemaphoreOwned (Socket, SystemSemaphore0, QNum));
+      }
+      DoSomething ();
+      ReleaseSocketSemaphore (Socket, SystemSemaphore0);
+      ......
+
+  @param[in]  Socket            - Socket where the semaphore is located
+  @param[in]  SemaphoreNumber   - SYSTEMSEMAPHORE register number (0 or 1)
+  @param[in]  QueueNumber       - assigned place in line of semaphore request
+                                  that was returned by AcquireSocketSemaphore
+
+  @retval TRUE                  - successfully acquired semaphore
+  @retval FALSE                 - semaphore not acquired
+**/
+BOOLEAN
+EFIAPI
+IsSocketSemaphoreOwned (
+  IN  UINT8                    Socket,
+  IN  SYSTEM_SEMAPHORE_NUMBER  SemaphoreNumber,
+  IN  UINT32                   QueueNumber
+  )
+{
+  return TRUE;
+}
+
+/**
+  Release a socket semaphore owned by the calling socket.
+
+  Used for ensuring exclusive access to resources among CPU sockets.
+
+  IMPORTANT:
+    The functions must be called in the sequence below:
+      ......
+      Owned = AcquireSocketSemaphore (Socket, SystemSemaphore0, ADD_TO_QUEUE, &QNum);
+      while (!Owned) {
+        Owned = IsSocketSemaphoreOwned (Socket, SystemSemaphore0, QNum));
+      }
+      DoSomething ();
+      ReleaseSocketSemaphore (Socket, SystemSemaphore0);
+      ......
+
+  @param[in]  Socket            - Socket to release semaphore
+  @param[in]  SemaphoreNumber   - SYSTEMSEMAPHORE register number (0 or 1)
+
+  @retval EFI_SUCCESS           - successfully released semaphore
+  @retval EFI_DEVICE_ERROR      - error releasing semaphore
+**/
+EFI_STATUS
+EFIAPI
+ReleaseSocketSemaphore (
+  IN  UINT8                    Socket,
+  IN  SYSTEM_SEMAPHORE_NUMBER  SemaphoreNumber
+  )
+{
+  return EFI_SUCCESS;
+}
+
+/**
+  Acquire a local semaphore for the calling thread.
+
+  Used for ensuring exclusive access to resources among CPU threads.
+
+  IMPORTANT:
+    The functions must be called in the sequence below:
+      ......
+      Owned = AcquireLocalSemaphore (LocalSemaphore0, ADD_TO_QUEUE, &QNum);
+      while (!Owned) {
+        Owned = IsLocalSemaphoreOwned (LocalSemaphore0, QNum));
+      }
+      DoSomething ();
+      ReleaseLocalSemaphore (LocalSemaphore0);
+      ......
+
+  @param[in]  SemaphoreNumber   - LOCALSEMAPHORE register number (0 or 1)
+  @param[in]  AddToQueue        - specifies whether to add the requesting
+                                  thread to the queue (TRUE or FALSE)
+  @param[out] QueueNumber       - assigned place in line of semaphore request,
+                                  if adding to queue
+
+  @retval TRUE                  - successfully acquired semaphore
+  @retval FALSE                 - semaphore not acquired
+**/
+BOOLEAN
+EFIAPI
+AcquireLocalSemaphore (
+  IN  LOCAL_SEMAPHORE_NUMBER  SemaphoreNumber,
+  IN  BOOLEAN                 AddToQueue,
+  OUT UINT32                  *QueueNumber      OPTIONAL
+  )
+{
+  return TRUE;
+}
+
+/**
+  Checks if a local semaphore is owned by the calling thread.
+
+  Used for ensuring exclusive access to resources among CPU threads.
+
+  IMPORTANT:
+    The functions must be called in the sequence below:
+      ......
+      Owned = AcquireLocalSemaphore (LocalSemaphore0, ADD_TO_QUEUE, &QNum);
+      while (!Owned) {
+        Owned = IsLocalSemaphoreOwned (LocalSemaphore0, QNum));
+      }
+      DoSomething ();
+      ReleaseLocalSemaphore (LocalSemaphore0);
+      ......
+
+  @param[in]  SemaphoreNumber   - LOCALSEMAPHORE register number (0 or 1)
+  @param[in]  QueueNumber       - assigned place in line of semaphore request
+                                  that was returned by AcquireLocalSemaphore
+
+  @retval TRUE                  - successfully acquired semaphore
+  @retval FALSE                 - semaphore not acquired
+**/
+BOOLEAN
+EFIAPI
+IsLocalSemaphoreOwned (
+  IN  LOCAL_SEMAPHORE_NUMBER  SemaphoreNumber,
+  IN  UINT32                  QueueNumber
+  )
+{
+  return TRUE;
+}
+
+/**
+  Release a local semaphore owned by the calling thread.
+
+  Used for ensuring exclusive access to resources among CPU threads.
+
+  IMPORTANT:
+    The functions must be called in the sequence below:
+      ......
+      Owned = AcquireLocalSemaphore (LocalSemaphore0, ADD_TO_QUEUE, &QNum);
+      while (!Owned) {
+        Owned = IsLocalSemaphoreOwned (LocalSemaphore0, QNum));
+      }
+      DoSomething ();
+      ReleaseLocalSemaphore (LocalSemaphore0);
+      ......
+
+  @param[in]  SemaphoreNumber   - LOCALSEMAPHORE register number (0 or 1)
+
+  @retval EFI_SUCCESS           - successfully released semaphore
+  @retval EFI_INVALID_PARAMETER - semaphore number is out of range
+  @retval EFI_DEVICE_ERROR      - error releasing semaphore
+**/
+EFI_STATUS
+EFIAPI
+ReleaseLocalSemaphore (
+  IN  LOCAL_SEMAPHORE_NUMBER  SemaphoreNumber
+  )
+{
+  return EFI_SUCCESS;
+}
+
+/**
+  Check if any semaphore is owned.
+
+  This function should only be called at a time when no semaphores are expected
+  to be owned. If any are owned, it prints a warning message.
+**/
+VOID
+EFIAPI
+CheckAnySemaphoreOwned (
+  VOID
+  )
+{
+}
+
+/**
+  Checks if a GlobalSemaphore is owned by some socket.
+
+  @param[in]  SocketOwned       - socket number
+                                  if semaphore is owned by the socket
+
+  @retval TRUE                  - semaphore is owned by the socket
+  @retval FALSE                 - semaphore is not owned by the socket
+**/
+BOOLEAN
+EFIAPI
+CheckGlobalSemaphoreOwned (
+  IN      UINT8  Socket
+  )
+{
+  return TRUE;
+}
+
+/**
+  Get Bios semaphore Registers' flat address.
+
+  @param SocId            - CPU Socket Node number (Socket ID)
+  @param RegIndex         - Release semaphore register index
+  @param RegAddress       - Register address
+
+  @retval                 - EFI_INVALID_PARAMETER: input Pad index doesn't exist for this SOC
+                            EFI_SUCCESS:     the function is executed successfully
+
+**/
+EFI_STATUS
+EFIAPI
+GetReleaseSemaphoreAddr (
+  IN  UINT8  Socket,
+  IN  UINT8  RegIndex,
+  OUT UINTN  *RegAddress
+  )
+{
+  //
+  // Set RegAddress to an invalid data.
+  //
+  *RegAddress = 0x0;
+  return EFI_SUCCESS;
+}

--- a/MdeModulePkg/Library/SemaphoreLibNull/SemaphoreLibNull.inf
+++ b/MdeModulePkg/Library/SemaphoreLibNull/SemaphoreLibNull.inf
@@ -1,0 +1,25 @@
+## @file
+# Null instance of the SemaphoreLib.
+#
+# This library provides a Null implementation of acquire/release functions for
+# global/socket semaphores. It should only be used with code that is guaranteed
+# to only be executed on the BSP.
+#
+#  Copyright (c) 2025, Intel Corporation. All rights reserved.<BR>
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = SemaphoreLibNull
+  FILE_GUID                      = 7A1833AC-A75D-44C3-A601-2D501D37B188
+  MODULE_TYPE                    = BASE
+  LIBRARY_CLASS                  = SemaphoreLib
+
+[Sources]
+  SemaphoreLibNull.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec

--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -186,6 +186,14 @@
   #
   RealTimeClockLib|Include/Library/RealTimeClockLib.h
 
+  ##  @libraryclass  provide semaphore services
+  #
+  SemaphoreLib|Include/Library/SemaphoreLib.h
+
+  ##  @libraryclass  provide services to calculate module offset when module migration
+  #
+  ModuleAddrCalcLib|Include/Library/ModuleAddrCalcLib.h
+
 [Guids]
   ## MdeModule package token space guid
   # Include/Guid/MdeModulePkgTokenSpace.h
@@ -286,6 +294,13 @@
   ## GUID used to pass DEBUG() macro information through the Status Code Protocol and Status Code PPI
   #  Include/Guid/StatusCodeDataTypeDebug.h
   gEfiStatusCodeDataTypeDebugGuid  = { 0x9A4E9246, 0xD553, 0x11D5, { 0x87, 0xE2, 0x00, 0x06, 0x29, 0x45, 0xC3, 0xB9 }}
+
+  #  Include/Guid/StatusCodeDataTypeExDebug.h
+  gStatusCodeDataTypeExDebugGuid  = { 0x7859daa2, 0x926e, 0x4b01, { 0x85, 0x86, 0xc6, 0x2d, 0x45, 0x64, 0x21, 0xd2 }}
+
+  ## HOB GUID used to publish serial port configuration.
+  #  Include/Guid/SerialPortConfig.h
+  gSerialPortConfigGuid  = { 0x2bd22eb0, 0x0018, 0x3c45, { 0x45, 0x7a, 0xbe, 0x83, 0x58, 0x0c, 0x43, 0x5b }}
 
   ##  A configuration Table Guid for Load module at fixed address
   #  Include/Guid/LoadModuleAtFixedAddress.h
@@ -590,6 +605,9 @@
 
   ## Include/Ppi/MigrateTempRam.h
   gEdkiiPeiMigrateTempRamPpiGuid            = { 0xc79dc53b, 0xafcd, 0x4a6a, { 0xad, 0x94, 0xa7, 0x6a, 0x3f, 0xa9, 0xe9, 0xc2 } }
+
+  ## Include/Ppi/ExReportStatusCodeHandler.h
+  gEfiPeiExStatusCodeHandlerPpiGuid = { 0x4e942617, 0xbbca, 0x4726, { 0x77, 0xb9, 0x49, 0x68, 0x85, 0xf9, 0xc4, 0xf4 } }
 
 [Protocols]
   ## Load File protocol provides capability to load and unload EFI image into memory and execute it.

--- a/MdeModulePkg/MdeModulePkg.dsc
+++ b/MdeModulePkg/MdeModulePkg.dsc
@@ -109,6 +109,7 @@
   VariableFlashInfoLib|MdeModulePkg/Library/BaseVariableFlashInfoLib/BaseVariableFlashInfoLib.inf
   IpmiCommandLib|MdeModulePkg/Library/BaseIpmiCommandLibNull/BaseIpmiCommandLibNull.inf
   SpiHcPlatformLib|MdeModulePkg/Library/BaseSpiHcPlatformLibNull/BaseSpiHcPlatformLibNull.inf
+  SemaphoreLib|MdeModulePkg/Library/SemaphoreLibNull/SemaphoreLibNull.inf
 
 [LibraryClasses.EBC.PEIM]
   IoLib|MdePkg/Library/PeiIoLibCpuIo/PeiIoLibCpuIo.inf
@@ -123,6 +124,7 @@
   ExtractGuidedSectionLib|MdePkg/Library/PeiExtractGuidedSectionLib/PeiExtractGuidedSectionLib.inf
   LockBoxLib|MdeModulePkg/Library/SmmLockBoxLib/SmmLockBoxPeiLib.inf
   DevicePathLib|MdePkg/Library/UefiDevicePathLib/UefiDevicePathLibBase.inf
+  ModuleAddrCalcLib|MdeModulePkg/Library/ModuleAddrCalcLib/ModuleAddrCalcLib.inf
 
 [LibraryClasses.common.DXE_CORE]
   HobLib|MdePkg/Library/DxeCoreHobLib/DxeCoreHobLib.inf
@@ -206,6 +208,7 @@
 
 [PcdsDynamicExDefault]
   gEfiMdeModulePkgTokenSpaceGuid.PcdRecoveryFileName|L"FVMAIN.FV"
+  gEfiMdeModulePkgTokenSpaceGuid.PcdStatusCodeUseSerial|FALSE
 
 [Components]
   MdeModulePkg/Application/HelloWorld/HelloWorld.inf
@@ -348,6 +351,8 @@
   MdeModulePkg/Library/DisplayUpdateProgressLibText/DisplayUpdateProgressLibText.inf
   MdeModulePkg/Library/BaseRngLibTimerLib/BaseRngLibTimerLib.inf
   MdeModulePkg/Library/HobPrintLib/HobPrintLib.inf
+  MdeModulePkg/Library/SemaphoreLibNull/SemaphoreLibNull.inf
+  MdeModulePkg/Library/ModuleAddrCalcLib/ModuleAddrCalcLib.inf
 
   MdeModulePkg/Universal/BdsDxe/BdsDxe.inf
   MdeModulePkg/Application/BootManagerMenuApp/BootManagerMenuApp.inf
@@ -418,6 +423,7 @@
   MdeModulePkg/Universal/LegacyRegion2Dxe/LegacyRegion2Dxe.inf
 
   MdeModulePkg/Universal/StatusCodeHandler/Pei/StatusCodeHandlerPei.inf
+  MdeModulePkg/Universal/ExStatusCodeHandler/Pei/ExStatusCodeHandlerPei.inf
   MdeModulePkg/Universal/StatusCodeHandler/RuntimeDxe/StatusCodeHandlerRuntimeDxe.inf
 
   MdeModulePkg/Universal/Acpi/FirmwarePerformanceDataTablePei/FirmwarePerformancePei.inf {

--- a/MdeModulePkg/Universal/ExStatusCodeHandler/Pei/ExMemoryStatusCodeWorker.c
+++ b/MdeModulePkg/Universal/ExStatusCodeHandler/Pei/ExMemoryStatusCodeWorker.c
@@ -1,0 +1,117 @@
+/** @file
+  PEI memory status code worker.
+
+  Copyright (c) 2006 - 2018, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "ExStatusCodeHandlerPei.h"
+
+/**
+  Create the first memory status code GUID'ed HOB as initialization for the
+  memory status code worker.
+
+  @retval EFI_SUCCESS  The GUID'ed HOB was created successfully.
+
+**/
+EFI_STATUS
+MemoryStatusCodeInitializeWorker (
+  VOID
+  )
+{
+  MEMORY_STATUSCODE_PACKET_HEADER  *PacketHeader;
+
+  //
+  // Create a GUID'ed HOB using the PCD-defined size.
+  //
+  PacketHeader = BuildGuidHob (
+                   &gMemoryStatusCodeRecordGuid,
+                   PcdGet16 (PcdStatusCodeMemorySize) * 1024 + sizeof (MEMORY_STATUSCODE_PACKET_HEADER)
+                   );
+  ASSERT (PacketHeader != NULL);
+
+  PacketHeader->MaxRecordsNumber = (PcdGet16 (PcdStatusCodeMemorySize) * 1024) / sizeof (MEMORY_STATUSCODE_RECORD);
+  PacketHeader->PacketIndex      = 0;
+  PacketHeader->RecordIndex      = 0;
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Report a status code into the GUID'ed HOB.
+
+  This function reports a status code into the GUID'ed HOB. If the current
+  packet still has room, the status code is written into the next available
+  entry. Otherwise, recording wraps to the beginning of the packet.
+
+  @param  PeiServices      An indirect pointer to the EFI_PEI_SERVICES table
+                           published by the PEI Foundation.
+  @param  CodeType         Indicates the type of status code being reported.
+  @param  Value            Describes the current status of a hardware or
+                           software entity. This includes information about the
+                           class and subclass that are used to classify the
+                           entity as well as an operation. For progress codes,
+                           the operation is the current activity. For error
+                           codes, it is the exception. For debug codes, it is
+                           not defined at this time.
+  @param  Instance         The enumeration of a hardware or software entity
+                           within the system. A system may contain multiple
+                           entities that match a class/subclass pairing. The
+                           instance differentiates between them. An instance of
+                           0 indicates that instance information is unavailable,
+                           not meaningful, or not relevant. Valid instance
+                           numbers start with 1.
+  @param  CallerId         This optional parameter may be used to identify the
+                           caller. This parameter allows the status code driver
+                           to apply different rules to different callers.
+  @param  Data             This optional parameter may be used to pass
+                           additional data.
+
+  @retval EFI_SUCCESS      The function always returns EFI_SUCCESS.
+
+**/
+EFI_STATUS
+EFIAPI
+MemoryStatusCodeReportWorker (
+  IN CONST  EFI_PEI_SERVICES     **PeiServices,
+  IN EFI_STATUS_CODE_TYPE        CodeType,
+  IN EFI_STATUS_CODE_VALUE       Value,
+  IN UINT32                      Instance,
+  IN CONST EFI_GUID              *CallerId,
+  IN CONST EFI_STATUS_CODE_DATA  *Data OPTIONAL
+  )
+{
+  EFI_PEI_HOB_POINTERS             Hob;
+  MEMORY_STATUSCODE_PACKET_HEADER  *PacketHeader;
+  MEMORY_STATUSCODE_RECORD         *Record;
+
+  //
+  // Find the GUID'ed HOB that contains the current record buffer.
+  //
+  Hob.Raw = GetFirstGuidHob (&gMemoryStatusCodeRecordGuid);
+  ASSERT (Hob.Raw != NULL);
+
+  PacketHeader = (MEMORY_STATUSCODE_PACKET_HEADER *)GET_GUID_HOB_DATA (Hob.Guid);
+  Record       = (MEMORY_STATUSCODE_RECORD *)(PacketHeader + 1);
+  Record       = &Record[PacketHeader->RecordIndex++];
+
+  //
+  // Save the status code.
+  //
+  Record->CodeType = CodeType;
+  Record->Instance = Instance;
+  Record->Value    = Value;
+
+  //
+  // If the record index reaches the maximum record count, wrap it back to the
+  // beginning. Consumers can detect wrap-around by comparing the total number
+  // of recorded entries with MaxRecordsNumber.
+  //
+  if (PacketHeader->RecordIndex == PacketHeader->MaxRecordsNumber) {
+    PacketHeader->RecordIndex = 0;
+    PacketHeader->PacketIndex++;
+  }
+
+  return EFI_SUCCESS;
+}

--- a/MdeModulePkg/Universal/ExStatusCodeHandler/Pei/ExSerialStatusCodeWorker.c
+++ b/MdeModulePkg/Universal/ExStatusCodeHandler/Pei/ExSerialStatusCodeWorker.c
@@ -1,0 +1,204 @@
+/** @file
+  Serial I/O status code reporting worker for the Extended Status Code Handler
+  PEIM. Supports the EX_DEBUG_INFO payload to serialize concurrent serial
+  output across threads/sockets.
+
+  Copyright (c) 2006 - 2018, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include "ExStatusCodeHandlerPei.h"
+
+/**
+  Convert status code value and extended data to readable ASCII string, send string to serial I/O device.
+
+  @param  PeiServices      An indirect pointer to the EFI_PEI_SERVICES table published by the PEI Foundation.
+  @param  CodeType         Indicates the type of status code being reported.
+  @param  Value            Describes the current status of a hardware or
+                           software entity. This includes information about the class and
+                           subclass that is used to classify the entity as well as an operation.
+                           For progress codes, the operation is the current activity.
+                           For error codes, it is the exception. For debug
+                           codes, it is not defined at this time.
+  @param  Instance         The enumeration of a hardware or software entity within
+                           the system. A system may contain multiple entities that match a class/subclass
+                           pairing. The instance differentiates between them. An instance of 0 indicates
+                           that instance information is unavailable, not meaningful, or not relevant.
+                           Valid instance numbers start with 1.
+  @param  CallerId         This optional parameter may be used to identify the caller.
+                           This parameter allows the status code driver to apply different rules to
+                           different callers.
+  @param  Data             This optional parameter may be used to pass additional data.
+
+  @retval EFI_SUCCESS      Status code reported to serial I/O successfully.
+
+**/
+EFI_STATUS
+EFIAPI
+ExSerialStatusCodeReportWorker (
+  IN CONST  EFI_PEI_SERVICES     **PeiServices,
+  IN EFI_STATUS_CODE_TYPE        CodeType,
+  IN EFI_STATUS_CODE_VALUE       Value,
+  IN UINT32                      Instance,
+  IN CONST EFI_GUID              *CallerId,
+  IN CONST EFI_STATUS_CODE_DATA  *Data OPTIONAL
+  )
+{
+  CHAR8          *Filename;
+  CHAR8          *Description;
+  CHAR8          *Format;
+  CHAR8          Buffer[MAX_EX_DEBUG_STR_LEN];
+  CHAR8          *BufferPtr;
+  UINT32         ErrorLevel;
+  UINT32         LineNumber;
+  UINTN          CharCount;
+  BASE_LIST      Marker;
+  EX_DEBUG_INFO  *ExDebugInfo;
+
+  ExDebugInfo = NULL;
+  Buffer[0]   = '\0';
+  CharCount   = 0;
+
+  if ((Data != NULL) &&
+      CompareGuid (&Data->Type, &gStatusCodeDataTypeExDebugGuid))
+  {
+    ExDebugInfo = (EX_DEBUG_INFO *)(Data + 1);
+  } else if ((Data != NULL) &&
+             ReportStatusCodeExtractAssertInfo (CodeType, Value, Data, &Filename, &Description, &LineNumber))
+  {
+    //
+    // Print ASSERT() information into output buffer.
+    //
+    CharCount = AsciiSPrint (
+                  Buffer,
+                  sizeof (Buffer),
+                  "\n\rPEI_ASSERT!: %a (%d): %a\n\r",
+                  Filename,
+                  LineNumber,
+                  Description
+                  );
+  } else if ((Data != NULL) &&
+             ReportStatusCodeExtractDebugInfo (Data, &ErrorLevel, &Marker, &Format))
+  {
+    //
+    // Print DEBUG() information into output buffer.
+    //
+    CharCount = AsciiBSPrint (
+                  Buffer,
+                  sizeof (Buffer),
+                  Format,
+                  Marker
+                  );
+  } else if ((CodeType & EFI_STATUS_CODE_TYPE_MASK) == EFI_ERROR_CODE) {
+    //
+    // Print ERROR information into output buffer.
+    //
+    CharCount = AsciiSPrint (
+                  Buffer,
+                  sizeof (Buffer),
+                  "ERROR: C%08x:V%08x I%x",
+                  CodeType,
+                  Value,
+                  Instance
+                  );
+
+    ASSERT (CharCount > 0);
+
+    if (CallerId != NULL) {
+      CharCount += AsciiSPrint (
+                     &Buffer[CharCount],
+                     (sizeof (Buffer) - (sizeof (Buffer[0]) * CharCount)),
+                     " %g",
+                     CallerId
+                     );
+    }
+
+    if (Data != NULL) {
+      CharCount += AsciiSPrint (
+                     &Buffer[CharCount],
+                     (sizeof (Buffer) - (sizeof (Buffer[0]) * CharCount)),
+                     " %x",
+                     Data
+                     );
+    }
+
+    CharCount += AsciiSPrint (
+                   &Buffer[CharCount],
+                   (sizeof (Buffer) - (sizeof (Buffer[0]) * CharCount)),
+                   "\n\r"
+                   );
+  } else if ((CodeType & EFI_STATUS_CODE_TYPE_MASK) == EFI_PROGRESS_CODE) {
+    //
+    // Print PROGRESS information into output buffer.
+    //
+    CharCount = AsciiSPrint (
+                  Buffer,
+                  sizeof (Buffer),
+                  "PROGRESS CODE: V%08x I%x\n\r",
+                  Value,
+                  Instance
+                  );
+  } else if ((Data != NULL) &&
+             CompareGuid (&Data->Type, &gEfiStatusCodeDataTypeStringGuid) &&
+             (((EFI_STATUS_CODE_STRING_DATA *)Data)->StringType == EfiStringAscii))
+  {
+    //
+    // EFI_STATUS_CODE_STRING_DATA
+    //
+    CharCount = AsciiSPrint (
+                  Buffer,
+                  sizeof (Buffer),
+                  "%a",
+                  ((EFI_STATUS_CODE_STRING_DATA *)Data)->String.Ascii
+                  );
+  } else {
+    //
+    // Code type is not defined.
+    //
+    CharCount = AsciiSPrint (
+                  Buffer,
+                  sizeof (Buffer),
+                  "Undefined: C%08x:V%08x I%x\n\r",
+                  CodeType,
+                  Value,
+                  Instance
+                  );
+  }
+
+  //
+  // No EX info, just call SerialPort Lib function to do print and exit.
+  //
+  if (ExDebugInfo == NULL) {
+    SerialPortWrite ((UINT8 *)Buffer, CharCount);
+    return EFI_SUCCESS;
+  }
+
+  //
+  // EX handling here - point at correct string and then take action.
+  // Acquire print, process buffer, write to serial, release print.
+  // Skip any if not requested.
+  //
+  CharCount = ExDebugInfo->DebugStringLen;
+  BufferPtr = ExDebugInfo->DebugString;
+  if (ExDebugInfo->PrintSyncAcquire != NULL) {
+    ExDebugInfo->PrintSyncAcquire ();
+  }
+
+  if (ExDebugInfo->ProcessBuffer != NULL) {
+    BufferPtr = ExDebugInfo->ProcessBuffer (
+                               ExDebugInfo->ProcessDataPtr,
+                               Buffer,
+                               &CharCount
+                               );
+  }
+
+  if (BufferPtr != NULL) {
+    SerialPortWrite ((UINT8 *)BufferPtr, CharCount);
+  }
+
+  if (ExDebugInfo->PrintSyncRelease != NULL) {
+    ExDebugInfo->PrintSyncRelease ();
+  }
+
+  return EFI_SUCCESS;
+}

--- a/MdeModulePkg/Universal/ExStatusCodeHandler/Pei/ExStatusCodeHandlerPei.c
+++ b/MdeModulePkg/Universal/ExStatusCodeHandler/Pei/ExStatusCodeHandlerPei.c
@@ -1,0 +1,166 @@
+/** @file
+  Extended Report Status Code Handler PEIM which produces general handlers
+  and hooks them onto the PEI status code router. It extends the standard
+  StatusCodeHandlerPei with cross-thread/cross-socket serialized serial output
+  and PEIM-shadow callback fixup support.
+
+  Copyright (c) 2009 - 2020, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "ExStatusCodeHandlerPei.h"
+
+EFI_PEI_EX_RSC_HANDLER_PPI  mExStatusCodeHandlerPpi = {
+  RegisterExStatusCodeHandler
+};
+
+EFI_PEI_PPI_DESCRIPTOR  mExStatusCodeHandlerPpiList[] = {
+  {
+    EFI_PEI_PPI_DESCRIPTOR_PPI | EFI_PEI_PPI_DESCRIPTOR_TERMINATE_LIST,
+    &gEfiPeiExStatusCodeHandlerPpiGuid,
+    &mExStatusCodeHandlerPpi
+  }
+};
+
+/**
+  Register ExSerialStatusCodeReportWorker for ReportStatusCode()
+  notifications.
+
+
+  @param[in] PeiServices        Pointer to PEI Services Table.
+
+  @retval EFI_SUCCESS           Function was successfully registered.
+  @retval EFI_INVALID_PARAMETER The callback function was NULL.
+  @retval EFI_OUT_OF_RESOURCES  The internal buffer ran out of space. No more functions can be
+                                registered.
+  @retval EFI_ALREADY_STARTED   The function was already registered. It can't be registered again.
+
+**/
+EFI_STATUS
+EFIAPI
+RegisterExStatusCodeHandler (
+  IN CONST  EFI_PEI_SERVICES  **PeiServices
+  )
+{
+  EFI_STATUS               Status;
+  EFI_PEI_RSC_HANDLER_PPI  *RscHandlerPpi;
+
+  Status = PeiServicesLocatePpi (
+             &gEfiPeiRscHandlerPpiGuid,
+             0,
+             NULL,
+             (VOID **)&RscHandlerPpi
+             );
+  ASSERT_EFI_ERROR (Status);
+
+  if (PcdGetBool (PcdStatusCodeUseSerial)) {
+    Status = RscHandlerPpi->Register (ExSerialStatusCodeReportWorker);
+    if (Status != EFI_ALREADY_STARTED) {
+      ASSERT_EFI_ERROR (Status);
+    }
+  }
+
+  return Status;
+}
+
+/**
+  Entry point of the Extended Status Code Handler PEIM.
+
+  This function initializes the serial and memory status code handlers and
+  registers them with the PEI status code router. When the PEIM is invoked
+  again after shadowing (PcdMigrateTemporaryRamFirmwareVolumes), it fixes up
+  the serial-port callback pointers stored in the SERIAL_PORT_CONFIG HOB.
+
+  @param  FileHandle  Handle of the file being invoked.
+  @param  PeiServices Describes the list of possible PEI Services.
+
+  @retval EFI_SUCCESS The PEIM executed successfully.
+
+**/
+EFI_STATUS
+EFIAPI
+ExStatusCodeHandlerPeiEntry (
+  IN       EFI_PEI_FILE_HANDLE  FileHandle,
+  IN CONST EFI_PEI_SERVICES     **PeiServices
+  )
+{
+  EFI_STATUS               Status;
+  EFI_PEI_RSC_HANDLER_PPI  *RscHandlerPpi;
+  UINT32                   DebugPrintErrorLevel;
+  UINTN                    ModuleOffset;
+  UINTN                    Index;
+  BOOLEAN                  ModulePositive;
+  SERIAL_PORT_CONFIG       *SerialPortConfig;
+
+  if (PcdGetBool (PcdMigrateTemporaryRamFirmwareVolumes)) {
+    Status = ModuleOffsetCalculator (FileHandle, &gEfiCallerIdGuid, &ModuleOffset, &ModulePositive);
+    if (Status == EFI_ALREADY_STARTED) {
+      SerialPortConfig = GetFirstGuidHob (&gSerialPortConfigGuid);
+      if (SerialPortConfig != NULL) {
+        SerialPortConfig = GET_GUID_HOB_DATA (SerialPortConfig);
+        if (ModulePositive) {
+          for (Index = 0; Index < SERIAL_PORT_CONFIG_MAX; Index++) {
+            *(UINTN *)(UINTN)(&SerialPortConfig->Configurations[Index].Initialize) += ModuleOffset;
+            *(UINTN *)(UINTN)(&SerialPortConfig->Configurations[Index].WriteBytes) += ModuleOffset;
+          }
+        } else {
+          for (Index = 0; Index < SERIAL_PORT_CONFIG_MAX; Index++) {
+            *(UINTN *)(UINTN)(&SerialPortConfig->Configurations[Index].Initialize) -= ModuleOffset;
+            *(UINTN *)(UINTN)(&SerialPortConfig->Configurations[Index].WriteBytes) -= ModuleOffset;
+          }
+        }
+      }
+
+      return EFI_SUCCESS;
+    }
+  }
+
+  Status = PeiServicesLocatePpi (
+             &gEfiPeiRscHandlerPpiGuid,
+             0,
+             NULL,
+             (VOID **)&RscHandlerPpi
+             );
+  ASSERT_EFI_ERROR (Status);
+
+  //
+  // Dispatch initialization request to sub-statuscode-devices.
+  // If enable UseSerial, then initialize serial port.
+  // if enable UseMemory, then initialize memory status code worker.
+  //
+
+  //
+  // If serial logging is disabled. set PcdStatusCodeUseSerial to FALSE.
+  //
+  DebugPrintErrorLevel = GetDebugPrintErrorLevel ();
+  if (DebugPrintErrorLevel == 0) {
+    Status = PcdSetBoolS (PcdStatusCodeUseSerial, FALSE);
+    ASSERT_EFI_ERROR (Status);
+  }
+
+  if (PcdGetBool (PcdStatusCodeUseSerial)) {
+    //
+    // Dispatch initialization request to sub-statuscode-devices.
+    //
+    Status = SerialPortInitialize ();
+    ASSERT_EFI_ERROR (Status);
+    Status = RscHandlerPpi->Register (ExSerialStatusCodeReportWorker);
+    ASSERT_EFI_ERROR (Status);
+  }
+
+  //
+  // Install Report Status Code Handler PPI
+  //
+  Status = PeiServicesInstallPpi (mExStatusCodeHandlerPpiList);
+  ASSERT_EFI_ERROR (Status);
+
+  if (PcdGetBool (PcdStatusCodeUseMemory)) {
+    Status = MemoryStatusCodeInitializeWorker ();
+    ASSERT_EFI_ERROR (Status);
+    Status = RscHandlerPpi->Register (MemoryStatusCodeReportWorker);
+    ASSERT_EFI_ERROR (Status);
+  }
+
+  return EFI_SUCCESS;
+}

--- a/MdeModulePkg/Universal/ExStatusCodeHandler/Pei/ExStatusCodeHandlerPei.h
+++ b/MdeModulePkg/Universal/ExStatusCodeHandler/Pei/ExStatusCodeHandlerPei.h
@@ -1,0 +1,136 @@
+/** @file
+  Internal include file for the Extended Status Code Handler PEIM.
+
+  Copyright (c) 2006 - 2012, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Ppi/ReportStatusCodeHandler.h>
+#include <Ppi/ExReportStatusCodeHandler.h>
+#include <Guid/MemoryStatusCodeRecord.h>
+#include <Guid/StatusCodeDataTypeId.h>
+#include <Guid/StatusCodeDataTypeDebug.h>
+#include <Guid/StatusCodeDataTypeExDebug.h>
+#include <Guid/SerialPortConfig.h>
+
+#include <Library/DebugLib.h>
+#include <Library/DebugPrintErrorLevelLib.h>
+#include <Library/PrintLib.h>
+#include <Library/ReportStatusCodeLib.h>
+#include <Library/SerialPortLib.h>
+#include <Library/HobLib.h>
+#include <Library/PcdLib.h>
+#include <Library/ModuleAddrCalcLib.h>
+#include <Library/PeiServicesLib.h>
+#include <Library/PeimEntryPoint.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/SemaphoreLib.h>
+
+//
+// Define the maximum message length
+//
+#define MAX_DEBUG_MESSAGE_LENGTH  0x100
+
+/**
+  Register ExSerialStatusCodeReportWorker for ReportStatusCode()
+  notifications.
+
+
+  @param[in] PeiServices        Pointer to PEI Services Table.
+
+  @retval EFI_SUCCESS           Function was successfully registered.
+  @retval EFI_INVALID_PARAMETER The callback function was NULL.
+  @retval EFI_OUT_OF_RESOURCES  The internal buffer ran out of space. No more functions can be
+                                registered.
+  @retval EFI_ALREADY_STARTED   The function was already registered. It can't be registered again.
+
+**/
+EFI_STATUS
+EFIAPI
+RegisterExStatusCodeHandler (
+  IN CONST  EFI_PEI_SERVICES  **PeiServices
+  );
+
+/**
+  Convert status code value and extended data to readable ASCII string, send string to serial I/O device.
+
+  @param  PeiServices      An indirect pointer to the EFI_PEI_SERVICES table published by the PEI Foundation.
+  @param  CodeType         Indicates the type of status code being reported.
+  @param  Value            Describes the current status of a hardware or
+                           software entity. This includes information about the class and
+                           subclass that is used to classify the entity as well as an operation.
+                           For progress codes, the operation is the current activity.
+                           For error codes, it is the exception. For debug
+                           codes, it is not defined at this time.
+  @param  Instance         The enumeration of a hardware or software entity within
+                           the system. A system may contain multiple entities that match a class/subclass
+                           pairing. The instance differentiates between them. An instance of 0 indicates
+                           that instance information is unavailable, not meaningful, or not relevant.
+                           Valid instance numbers start with 1.
+  @param  CallerId         This optional parameter may be used to identify the caller.
+                           This parameter allows the status code driver to apply different rules to
+                           different callers.
+  @param  Data             This optional parameter may be used to pass additional data.
+
+  @retval EFI_SUCCESS      Status code reported to serial I/O successfully.
+
+**/
+EFI_STATUS
+EFIAPI
+ExSerialStatusCodeReportWorker (
+  IN CONST  EFI_PEI_SERVICES     **PeiServices,
+  IN EFI_STATUS_CODE_TYPE        CodeType,
+  IN EFI_STATUS_CODE_VALUE       Value,
+  IN UINT32                      Instance,
+  IN CONST EFI_GUID              *CallerId,
+  IN CONST EFI_STATUS_CODE_DATA  *Data OPTIONAL
+  );
+
+/**
+  Create the first memory status code GUID'ed HOB as initialization for memory status code worker.
+
+  @retval EFI_SUCCESS  The GUID'ed HOB is created successfully.
+
+**/
+EFI_STATUS
+MemoryStatusCodeInitializeWorker (
+  VOID
+  );
+
+/**
+  Report status code into GUID'ed HOB.
+
+  This function reports status code into GUID'ed HOB. If not all packets are full, then
+  write status code into available entry. Otherwise, create a new packet for it.
+
+  @param  PeiServices      An indirect pointer to the EFI_PEI_SERVICES table published by the PEI Foundation.
+  @param  CodeType         Indicates the type of status code being reported.
+  @param  Value            Describes the current status of a hardware or
+                           software entity. This includes information about the class and
+                           subclass that is used to classify the entity as well as an operation.
+                           For progress codes, the operation is the current activity.
+                           For error codes, it is the exception.For debug codes,it is not defined at this time.
+  @param  Instance         The enumeration of a hardware or software entity within
+                           the system. A system may contain multiple entities that match a class/subclass
+                           pairing. The instance differentiates between them. An instance of 0 indicates
+                           that instance information is unavailable, not meaningful, or not relevant.
+                           Valid instance numbers start with 1.
+  @param  CallerId         This optional parameter may be used to identify the caller.
+                           This parameter allows the status code driver to apply different rules to
+                           different callers.
+  @param  Data             This optional parameter may be used to pass additional data.
+
+  @retval EFI_SUCCESS      The function always returns EFI_SUCCESS.
+
+**/
+EFI_STATUS
+EFIAPI
+MemoryStatusCodeReportWorker (
+  IN CONST  EFI_PEI_SERVICES     **PeiServices,
+  IN EFI_STATUS_CODE_TYPE        CodeType,
+  IN EFI_STATUS_CODE_VALUE       Value,
+  IN UINT32                      Instance,
+  IN CONST EFI_GUID              *CallerId,
+  IN CONST EFI_STATUS_CODE_DATA  *Data OPTIONAL
+  );

--- a/MdeModulePkg/Universal/ExStatusCodeHandler/Pei/ExStatusCodeHandlerPei.inf
+++ b/MdeModulePkg/Universal/ExStatusCodeHandler/Pei/ExStatusCodeHandlerPei.inf
@@ -1,0 +1,71 @@
+## @file
+#  Extended Report Status Code Handler PEIM which produces general handlers and
+#  hooks them onto the PEI status code router. Adds serialized serial output and
+#  PEIM-shadow callback fixup support over the standard StatusCodeHandlerPei.
+#
+#  Copyright (c) 2009 - 2018, Intel Corporation. All rights reserved.<BR>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = ExStatusCodeHandlerPei
+  MODULE_UNI_FILE                = ExStatusCodeHandlerPei.uni
+  FILE_GUID                      = 6E1339A4-B3A3-55C5-8E4E-CF783DBDA452
+  MODULE_TYPE                    = PEIM
+  VERSION_STRING                 = 1.0
+  ENTRY_POINT                    = ExStatusCodeHandlerPeiEntry
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64 EBC (EBC is only for build)
+#
+
+[Sources]
+  ExStatusCodeHandlerPei.c
+  ExStatusCodeHandlerPei.h
+  ExSerialStatusCodeWorker.c
+  ExMemoryStatusCodeWorker.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+
+[LibraryClasses]
+  PeimEntryPoint
+  PeiServicesLib
+  PcdLib
+  HobLib
+  SerialPortLib
+  ReportStatusCodeLib
+  PrintLib
+  DebugLib
+  DebugPrintErrorLevelLib
+  BaseMemoryLib
+  ModuleAddrCalcLib
+
+[Guids]
+  gMemoryStatusCodeRecordGuid
+  gEfiStatusCodeDataTypeStringGuid              ## SOMETIMES_CONSUMES   ## UNDEFINED
+  gStatusCodeDataTypeExDebugGuid                ## SOMETIMES_CONSUMES
+  gSerialPortConfigGuid                         ## SOMETIMES_CONSUMES
+
+[Ppis]
+  gEfiPeiRscHandlerPpiGuid                      ## CONSUMES
+  gEfiPeiExStatusCodeHandlerPpiGuid             ## PRODUCES
+
+[Pcd]
+  gEfiMdeModulePkgTokenSpaceGuid.PcdStatusCodeUseSerial ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdMigrateTemporaryRamFirmwareVolumes  ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdStatusCodeUseMemory ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdStatusCodeMemorySize|1|gEfiMdeModulePkgTokenSpaceGuid.PcdStatusCodeUseMemory    ## SOMETIMES_CONSUMES
+
+[Depex]
+  gEfiPeiRscHandlerPpiGuid
+
+[UserExtensions.TianoCore."ExtraFiles"]
+  ExStatusCodeHandlerPeiExtra.uni

--- a/MdeModulePkg/Universal/ExStatusCodeHandler/Pei/ExStatusCodeHandlerPei.uni
+++ b/MdeModulePkg/Universal/ExStatusCodeHandler/Pei/ExStatusCodeHandlerPei.uni
@@ -1,0 +1,16 @@
+// /** @file
+// Extended Report Status Code Handler PEIM which produces general handlers and hooks them onto the PEI status code router.
+//
+// This is the Extended Report Status Code Handler PEIM that produces general handlers and hooks them onto the PEI status code router.
+//
+// Copyright (c) 2009 - 2014, Intel Corporation. All rights reserved.<BR>
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+// **/
+
+
+#string STR_MODULE_ABSTRACT             #language en-US "Extended PEIM that produces general handlers and hooks them onto the PEI status code router"
+
+#string STR_MODULE_DESCRIPTION          #language en-US "This is the Extended Report Status Code Handler PEIM that produces general handlers and hooks them onto the PEI status code router."
+

--- a/MdeModulePkg/Universal/ExStatusCodeHandler/Pei/ExStatusCodeHandlerPeiExtra.uni
+++ b/MdeModulePkg/Universal/ExStatusCodeHandler/Pei/ExStatusCodeHandlerPeiExtra.uni
@@ -1,0 +1,14 @@
+// /** @file
+// ExStatusCodeHandlerPei Localized Strings and Content
+//
+// Copyright (c) 2013 - 2018, Intel Corporation. All rights reserved.<BR>
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+// **/
+
+#string STR_PROPERTIES_MODULE_NAME
+#language en-US
+"Extended Status Code Handler PEI Module"
+
+


### PR DESCRIPTION
# Description

Add `ExStatusCodeHandlerPei` as an extension of the existing `StatusCodeHandlerPei`. The new handler keeps full compatibility with the legacy PEIM but adds three capabilities that the current PEI status code handler cannot provide:

- Thread-safe serial output. Serialize status-code prints across multiple threads/CPUs so messages from concurrent producers no longer interleave on the UART.
- Shadow-safe serial callbacks. Work correctly with `PcdMigrateTemporaryRamFirmwareVolumes` by fixing up serial-port callback pointers after PEIM shadowing, so the handler keeps reporting once PEI is migrated to permanent memory.
- Runtime gating of serial output. Drive registration of the serial worker from `PcdStatusCodeUseSerial`, which itself is derived from `GetDebugPrintErrorLevel ()`, so platforms can disable serial status code output without rebuilding.

No existing module is modified. `StatusCodeHandlerPei` continues to work as-is; platforms opt in to the new PEIM in their DSC/FDF.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Built `MdeModulePkg` with the new PEIM and its supporting libraries/PPIs/GUIDs using the standard edk2 CI build matrix. Ran the edk2 CI package-level checks (build, EccCheck, package tests) on `MdeModulePkg` to confirm no regressions. Boot-tested the new `ExStatusCodeHandlerPei` on an internal platform DSC that opts in to the PEIM, and verified:
- Serial status code output still appears during PEI.
- Output remains correct after PEIM shadowing with `PcdMigrateTemporaryRamFirmwareVolumes` enabled.
- Concurrent prints from multiple CPUs are serialized and do not interleave on the UART.
- Setting debug print error level to 0 disables serial status code output at runtime without rebuilding.

## Integration Instructions

Platforms that want the new capabilities should add `MdeModulePkg/Universal/ExStatusCodeHandler/Pei/ExStatusCodeHandlerPei.inf` (and its required library instances for `SemaphoreLib` and `ModuleAddrCalcLib`) to their DSC/FDF in place of, or in addition to, `StatusCodeHandlerPei`. Existing platforms that do not consume the new PEIM require no changes.
