### PR TITLE
MdeModulePkg: Don't Allow Guard Pages to Cross Bin Boundaries

### DIFF
--- a/MdeModulePkg/Core/Dxe/Mem/HeapGuard.c
+++ b/MdeModulePkg/Core/Dxe/Mem/HeapGuard.c
@@ -814,21 +814,37 @@ UnsetGuardForMemory (
   memory blocks, and try to use it as the Guard page of the memory to be
   allocated.
 
-  @param[in]  Start           Start address of free memory block.
-  @param[in]  Size            Size of free memory block.
-  @param[in]  SizeRequested   Size of memory to allocate.
+  A guard page is not allowed to be placed at page 0 because it may be used for
+  NULL pointer detection or have special meaning if it is left mapped. This API
+  will reject the memory block if the only available place for the head guard is
+  page 0.
+
+  @param[in,out]  Start           Start address of the free memory block. On successful return, this will contain the
+                                  adjusted start address of the proposed allocation.
+  @param[in]      Size            Size of free memory block.
+  @param[in,out]  SizeRequested   Size of memory to allocate. On successful return, this will contain the adjusted size
+                                  of memory to allocate.
 
   @return The end address of memory block found.
   @return 0 if no enough space for the required size of memory and its Guard.
 **/
 UINT64
 AdjustMemoryS (
-  IN UINT64  Start,
-  IN UINT64  Size,
-  IN UINT64  SizeRequested
+  IN OUT UINT64  *Start,
+  IN UINT64      Size,
+  IN OUT UINT64  *SizeRequested
   )
 {
-  UINT64  Target;
+  UINT64   Target;
+  BOOLEAN  HasHeadGuard;
+  UINT64   OriginalSizeRequested;
+  UINT64   OriginalStart;
+
+  HasHeadGuard = TRUE;
+
+  if ((Start == NULL) || (SizeRequested == NULL) || (*SizeRequested == 0) || (Size < *SizeRequested)) {
+    return 0;
+  }
 
   //
   // UEFI spec requires that allocated pool must be 8-byte aligned. If it's
@@ -836,36 +852,53 @@ AdjustMemoryS (
   // make sure alignment of the returned pool address.
   //
   if ((PcdGet8 (PcdHeapGuardPropertyMask) & BIT7) == 0) {
-    SizeRequested = ALIGN_VALUE (SizeRequested, 8);
+    *SizeRequested = ALIGN_VALUE (*SizeRequested, 8);
   }
 
-  Target = Start + Size - SizeRequested;
-  ASSERT (Target >= Start);
-  if (Target == 0) {
+  // Take into account the alignment requirement
+  OriginalSizeRequested = *SizeRequested;
+  OriginalStart         = *Start;
+
+  Target = OriginalStart + Size - OriginalSizeRequested;
+  if ((Target <= EFI_PAGE_SIZE) || (Target < OriginalStart)) {
+    // If Target is at page 1 or below, we don't have a shared guard page and can't add a new one,
+    // so reject this memory block. Page 0 is reserved for NULL pointer detection.
+    // Our alignment requirement may have caused Target to be outside of the free memory block,
+    // so reject the block in that case as well.
     return 0;
   }
 
-  if (!IsGuardPage (Start + Size)) {
+  if (!IsGuardPage (OriginalStart + Size)) {
     // No Guard at tail to share. One more page is needed.
-    Target -= EFI_PAGES_TO_SIZE (1);
+    Target         -= EFI_PAGES_TO_SIZE (1);
+    *SizeRequested += EFI_PAGES_TO_SIZE (1);
   }
 
   // Out of range?
-  if (Target < Start) {
+  if ((Target < OriginalStart) || (Target <= EFI_PAGE_SIZE)) {
     return 0;
   }
 
+  // We are done adjusting Target at this point, so set the start of the proposed allocation
+  // to Target
+  *Start = Target;
+
+  // Check if we have a head guard to share. If not, we need one more page for the head Guard.
+  if (!IsGuardPage (Target - EFI_PAGES_TO_SIZE (1))) {
+    HasHeadGuard    = FALSE;
+    *Start         -= EFI_PAGES_TO_SIZE (1);
+    *SizeRequested += EFI_PAGES_TO_SIZE (1);
+  }
+
   // At the edge?
-  if (Target == Start) {
-    if (!IsGuardPage (Target - EFI_PAGES_TO_SIZE (1))) {
-      // No enough space for a new head Guard if no Guard at head to share.
-      return 0;
-    }
+  if ((Target == OriginalStart) && !HasHeadGuard) {
+    // Not enough space for a new head guard page and there isn't one to share
+    return 0;
   }
 
   // OK, we have enough pages for memory and its Guards. Return the End of the
   // free space.
-  return Target + SizeRequested - 1;
+  return Target + OriginalSizeRequested - 1;
 }
 
 /**

--- a/MdeModulePkg/Core/Dxe/Mem/HeapGuard.h
+++ b/MdeModulePkg/Core/Dxe/Mem/HeapGuard.h
@@ -275,18 +275,25 @@ AdjustMemoryF (
   memory blocks, and try to use it as the Guard page of the memory to be
   allocated.
 
-  @param[in]  Start           Start address of free memory block.
-  @param[in]  Size            Size of free memory block.
-  @param[in]  SizeRequested   Size of memory to allocate.
+  A guard page is not allowed to be placed at page 0 because it may be used for
+  NULL pointer detection or have special meaning if it is left mapped. This API
+  will reject the memory block if the only available place for the head guard is
+  page 0.
+
+  @param[in,out]  Start           Start address of the free memory block. On successful return, this will contain the
+                                  adjusted start address of the proposed allocation.
+  @param[in]      Size            Size of free memory block.
+  @param[in,out]  SizeRequested   Size of memory to allocate. On successful return, this will contain the adjusted size
+                                  of memory to allocate.
 
   @return The end address of memory block found.
   @return 0 if no enough space for the required size of memory and its Guard.
 **/
 UINT64
 AdjustMemoryS (
-  IN UINT64  Start,
-  IN UINT64  Size,
-  IN UINT64  SizeRequested
+  IN OUT UINT64  *Start,
+  IN UINT64      Size,
+  IN OUT UINT64  *SizeRequested
   );
 
 /**

--- a/MdeModulePkg/Core/Dxe/Mem/Page.c
+++ b/MdeModulePkg/Core/Dxe/Mem/Page.c
@@ -1235,6 +1235,8 @@ CoreFindFreePagesI (
   UINT64      DescNumberOfBytes;
   LIST_ENTRY  *Link;
   MEMORY_MAP  *Entry;
+  UINT64      ProposedStart;
+  UINT64      ProposedSize;
 
   if ((MaxAddress < EFI_PAGE_MASK) || (NumberOfPages == 0)) {
     return 0;
@@ -1324,12 +1326,17 @@ CoreFindFreePagesI (
       //
       if (DescEnd > Target) {
         if (NeedGuard) {
-          DescEnd = AdjustMemoryS (
-                      DescEnd + 1 - DescNumberOfBytes,
-                      DescNumberOfBytes,
-                      NumberOfBytes
-                      );
-          if (DescEnd == 0) {
+          ProposedStart = DescEnd + 1 - DescNumberOfBytes;
+          ProposedSize  = NumberOfBytes;
+          DescEnd       = AdjustMemoryS (
+                            &ProposedStart,
+                            DescNumberOfBytes,
+                            &ProposedSize
+                            );
+
+          // Check if there was not enough space in the descriptor for the allocation after adjusting for the guard
+          // or if the adjusted range is outside of the bin we are searching within
+          if ((DescEnd == 0) || (ProposedStart < MinAddress) || (ProposedStart + ProposedSize - 1 > MaxAddress)) {
             continue;
           }
         }

--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -1153,6 +1153,10 @@
   #      page or tail guard page.
   #   c) UEFI freed-memory guard and UEFI pool/page guard cannot be enabled
   #      at the same time.
+  #   d) It is not supported to have a guard page at page 0 because this page
+  #      may be used for NULL pointer detection or have special meaning if left
+  #      mapped. Heap Guard will reject a memory allocation if the head guard
+  #      would land on page 0.
   #
   #   BIT0 - Enable UEFI page guard.<BR>
   #   BIT1 - Enable UEFI pool guard.<BR>


### PR DESCRIPTION
# Description

Currently, the DXE page allocator does not ensure that guard page allocations stay within the bin that it is attempting to allocate within. As a result, S4 resume is jeopardized by bins expanding due to guard pages, either into other bins or out of bins. This is caught by a new assert in CoreGetMemoryMap() to ensure the bins are correct.

This fixes this by changing the internal heap guard API to return the adjusted size and start address of a proposed allocation. The page allocator then can ensure that the adjusted allocation still fits within the bin it is attempting to allocate within; if not, it will search for another descriptor.

This is attempting to fix the same issue as https://github.com/tianocore/edk2/pull/12384. After offline discussion, it was determined that a different approach than that PR was desired to create a smaller change.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Repro'd a similar issue on OVMF as described here: https://github.com/tianocore/edk2/pull/12384. After this change, OVMF with heap guard enabled boots to shell instead of hitting the assert.

## Integration Instructions

N/A.
