### PR TITLE
Global: Fix some incorrect MODULE_TYPEs in INF files

### DIFF
--- a/ArmPkg/Filesystem/SemihostFs/SemihostFs.inf
+++ b/ArmPkg/Filesystem/SemihostFs/SemihostFs.inf
@@ -12,7 +12,7 @@
   INF_VERSION                    = 0x00010005
   BASE_NAME                      = SemihostFs
   FILE_GUID                      = C5B9C74A-6D72-4719-99AB-C59F199091EB
-  MODULE_TYPE                    = UEFI_DRIVER
+  MODULE_TYPE                    = DXE_DRIVER
   VERSION_STRING                 = 1.0
 
   ENTRY_POINT                    = SemihostFsEntryPoint
@@ -40,3 +40,5 @@
   gEfiSimpleFileSystemProtocolGuid
   gEfiDevicePathProtocolGuid
 
+[Depex]
+  TRUE

--- a/EmbeddedPkg/Drivers/AndroidFastbootTransportTcpDxe/FastbootTransportTcpDxe.inf
+++ b/EmbeddedPkg/Drivers/AndroidFastbootTransportTcpDxe/FastbootTransportTcpDxe.inf
@@ -11,7 +11,7 @@
   INF_VERSION                    = 0x00010005
   BASE_NAME                      = TcpFastbootTransportDxe
   FILE_GUID                      = 86787704-8fed-11e3-b3ff-f33b73acfec2
-  MODULE_TYPE                    = UEFI_DRIVER
+  MODULE_TYPE                    = DXE_DRIVER
   VERSION_STRING                 = 1.0
   ENTRY_POINT                    = TcpFastbootTransportEntryPoint
 
@@ -44,3 +44,6 @@
 
 [FixedPcd]
   gEmbeddedTokenSpaceGuid.PcdAndroidFastbootTcpPort
+
+[Depex]
+  gEfiSimpleTextOutProtocolGuid

--- a/EmbeddedPkg/Drivers/AndroidFastbootTransportUsbDxe/FastbootTransportUsbDxe.inf
+++ b/EmbeddedPkg/Drivers/AndroidFastbootTransportUsbDxe/FastbootTransportUsbDxe.inf
@@ -11,7 +11,7 @@
   INF_VERSION                    = 0x00010005
   BASE_NAME                      = FastbootTransportUsbDxe
   FILE_GUID                      = f6bec3fe-88fb-11e3-ae84-e73b77561c35
-  MODULE_TYPE                    = UEFI_DRIVER
+  MODULE_TYPE                    = DXE_DRIVER
   VERSION_STRING                 = 1.0
   ENTRY_POINT                    = FastbootTransportUsbEntryPoint
 
@@ -39,3 +39,6 @@
 [FixedPcd]
   gEmbeddedTokenSpaceGuid.PcdAndroidFastbootUsbVendorId
   gEmbeddedTokenSpaceGuid.PcdAndroidFastbootUsbProductId
+
+[Depex]
+  gUsbDeviceProtocolGuid

--- a/EmbeddedPkg/GdbStub/GdbStub.inf
+++ b/EmbeddedPkg/GdbStub/GdbStub.inf
@@ -18,7 +18,7 @@
   INF_VERSION                    = 0x00010005
   BASE_NAME                      = GdbStub
   FILE_GUID                      = 1F2CCB4F-D817-404E-98E7-80E4851FB33E
-  MODULE_TYPE                    = UEFI_DRIVER
+  MODULE_TYPE                    = DXE_DRIVER
   VERSION_STRING                 = 1.0
 
   ENTRY_POINT                    = GdbStubEntry
@@ -67,3 +67,6 @@
 
 [FixedPcd.common]
   gEmbeddedTokenSpaceGuid.PcdGdbMaxPacketRetryCount
+
+[Depex]
+  gEfiDebugSupportProtocolGuid

--- a/MdeModulePkg/Universal/Acpi/BootGraphicsResourceTableDxe/BootGraphicsResourceTableDxe.inf
+++ b/MdeModulePkg/Universal/Acpi/BootGraphicsResourceTableDxe/BootGraphicsResourceTableDxe.inf
@@ -12,7 +12,7 @@
   BASE_NAME                      = BootGraphicsResourceTableDxe
   MODULE_UNI_FILE                = BootGraphicsResourceTableDxe.uni
   FILE_GUID                      = B8E62775-BB0A-43f0-A843-5BE8B14F8CCD
-  MODULE_TYPE                    = UEFI_DRIVER
+  MODULE_TYPE                    = DXE_DRIVER
   VERSION_STRING                 = 1.0
   ENTRY_POINT                    = BootGraphicsDxeEntryPoint
 
@@ -58,3 +58,6 @@
 
 [UserExtensions.TianoCore."ExtraFiles"]
   BootGraphicsResourceTableDxeExtra.uni
+
+[Depex]
+  TRUE

--- a/MdeModulePkg/Universal/HiiResourcesSampleDxe/HiiResourcesSampleDxe.inf
+++ b/MdeModulePkg/Universal/HiiResourcesSampleDxe/HiiResourcesSampleDxe.inf
@@ -16,7 +16,7 @@
   BASE_NAME                      = HiiResourcesSample
   MODULE_UNI_FILE                = HiiResourcesSample.uni
   FILE_GUID                      = D49D2EB0-44D5-4621-9FD6-1A92C9109B99
-  MODULE_TYPE                    = UEFI_DRIVER
+  MODULE_TYPE                    = DXE_DRIVER
   VERSION_STRING                 = 1.0
   ENTRY_POINT                    = HiiResourcesSampleInit
   UNLOAD_IMAGE                   = HiiResourcesSampleUnload
@@ -52,3 +52,6 @@
 
 [UserExtensions.TianoCore."ExtraFiles"]
   HiiResourcesSampleExtra.uni
+
+[Depex]
+  TRUE

--- a/MdeModulePkg/Universal/RegularExpressionDxe/RegularExpressionDxe.inf
+++ b/MdeModulePkg/Universal/RegularExpressionDxe/RegularExpressionDxe.inf
@@ -11,7 +11,7 @@
   INF_VERSION     = 0x00010018
   BASE_NAME       = RegularExpressionDxe
   FILE_GUID       = 3E197E9C-D8DC-42D3-89CE-B04FA9833756
-  MODULE_TYPE     = UEFI_DRIVER
+  MODULE_TYPE     = DXE_DRIVER
   VERSION_STRING  = 1.0
   ENTRY_POINT     = RegularExpressionDxeEntry
 
@@ -131,3 +131,6 @@
   # Not add -Wno-error=maybe-uninitialized option for XCODE
   # XCODE doesn't know this option
   XCODE:*_*_*_CC_FLAGS =
+
+[Depex]
+  TRUE

--- a/UefiPayloadPkg/PciPlatformDxe/PciPlatformDxe.inf
+++ b/UefiPayloadPkg/PciPlatformDxe/PciPlatformDxe.inf
@@ -12,7 +12,7 @@
   INF_VERSION                    = 0x00010005
   BASE_NAME                      = PciPlatformDxe
   FILE_GUID                      = 86D58F7B-6E7C-401F-BDD4-E32E6D582AAD
-  MODULE_TYPE                    = UEFI_DRIVER
+  MODULE_TYPE                    = DXE_DRIVER
   VERSION_STRING                 = 1.0
   ENTRY_POINT                    = InstallPciPlatformProtocol
 
@@ -35,3 +35,6 @@
 [Protocols]
   gEfiPciPlatformProtocolGuid                   ## PRODUCES
   gEfiPciIoProtocolGuid                         ## COMSUMES
+
+[Depex]
+  TRUE


### PR DESCRIPTION
# Description

The following drivers-PciPlatformDxe in UefiPayloadPkg, SemihostFs in ArmPkg, BootGraphicsResourceTableDxe, HiiResourcesSampleDxe, RegularExpressionDxe in MdeModulePkg, and AndroidFastbootTransportTcpDxe, AndroidFastbootTransportUsbDxe, GdbStub in EmbeddedPkg-do not follow UEFI driver model, so the MODULE_TYPE should be DXE_DRIVER instead of UEFI_DRIVER.

In EmbeddedPkg, FastbootTransportTcpDxe Driver is dependent on gEfiSimpleTextOutProtocolGuid, FastbootTransportUsbDxe Driver is dependent on gUsbDeviceProtocolGuid, GdbStub Driver is dependent on gEfiDebugSupportProtocolGuid. So the [Depex] should be updated too.

No functional changes.

## How This Was Tested

Pass CI check.

## Integration Instructions

N/A
