### PR TITLE
.mergify/config.yml: Set update_method to merge

### DIFF
--- a/.mergify/config.yml
+++ b/.mergify/config.yml
@@ -34,7 +34,7 @@ queue_rules:
       - label=push
     merge_method: rebase
     update_bot_account: tianocore-issues
-    update_method: rebase
+    update_method: merge
 
 pull_request_rules:
   - name: Automatically merge a PR when all required checks pass and 'push' label is present


### PR DESCRIPTION
# Description

Originally, edk2 sought to have mergify use rebases to update PR branches. However, mergify is deprecating pull requests from forks with update_method=rebase and update_bot_account impersonation:

>  Deprecation notice: This pull request comes from a fork and was
>  queued with update_method=rebase and update_bot_account
>  impersonation. This capability will be removed on July 1, 2026.
>  After this date, the merge queue will no longer be able to rebase
>  fork pull requests with this configuration. To avoid disruption,
>  switch to update_method=merge in configuration. To avoid disruption,
>  switch to update_method=merge in your queue rule.

This change explicitly sets the update_method to merge per the deprecation guidance.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

- The config does not apply until the change in the master branch.

## Integration Instructions

- N/A - Only impacts repo config