### PR TITLE
Global: Remove duplicate items  in INF files

### DIFF
--- a/ArmPkg/Drivers/ArmGicDxe/ArmGicDxe.inf
+++ b/ArmPkg/Drivers/ArmGicDxe/ArmGicDxe.inf
@@ -46,7 +46,6 @@
   IoLib
   PcdLib
   TimerLib
-  UefiLib
 
 [Protocols]
   gHardwareInterruptProtocolGuid  ## PRODUCES

--- a/EmbeddedPkg/Drivers/AndroidFastbootTransportTcpDxe/FastbootTransportTcpDxe.inf
+++ b/EmbeddedPkg/Drivers/AndroidFastbootTransportTcpDxe/FastbootTransportTcpDxe.inf
@@ -35,7 +35,6 @@
   gEfiTcp4ServiceBindingProtocolGuid
   gEfiSimpleTextOutProtocolGuid
   gEfiTcp4ProtocolGuid
-  gEfiSimpleTextOutProtocolGuid
 
 [Packages]
   MdePkg/MdePkg.dec

--- a/EmulatorPkg/Unix/Host/Host.inf
+++ b/EmulatorPkg/Unix/Host/Host.inf
@@ -69,7 +69,6 @@
 
 [Protocols]
   gEmuIoThunkProtocolGuid
-  gEmuIoThunkProtocolGuid
   gEmuGraphicsWindowProtocolGuid
   gEmuThreadThunkProtocolGuid
   gEmuBlockIoProtocolGuid

--- a/IntelFsp2WrapperPkg/Library/FspWrapperMultiPhaseProcessLib/FspWrapperMultiPhaseProcessLib.inf
+++ b/IntelFsp2WrapperPkg/Library/FspWrapperMultiPhaseProcessLib/FspWrapperMultiPhaseProcessLib.inf
@@ -38,7 +38,6 @@
   FspWrapperPlatformLib
   PeiServicesLib
   FspWrapperPlatformMultiPhaseLib
-  BaseMemoryLib
   HobLib
 
 [Ppis]

--- a/MdeModulePkg/Bus/Pci/PciSioSerialDxe/PciSioSerialDxe.inf
+++ b/MdeModulePkg/Bus/Pci/PciSioSerialDxe/PciSioSerialDxe.inf
@@ -55,10 +55,9 @@
 
 [Protocols]
   gEfiSioProtocolGuid                           ## TO_START
-  gEfiDevicePathProtocolGuid                    ## TO_START
+  gEfiDevicePathProtocolGuid                    ## TO_START ## BY_START
   gEfiPciIoProtocolGuid                         ## TO_START
   gEfiSerialIoProtocolGuid                      ## BY_START
-  gEfiDevicePathProtocolGuid                    ## BY_START
 
 [FeaturePcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdSerialUseHalfHandshake|FALSE   ## CONSUMES

--- a/MdeModulePkg/Core/PiSmmCore/PiSmmCore.inf
+++ b/MdeModulePkg/Core/PiSmmCore/PiSmmCore.inf
@@ -86,7 +86,6 @@
   gEfiSmmIoTrapDispatch2ProtocolGuid            ## SOMETIMES_CONSUMES
   gEfiSmmUsbDispatch2ProtocolGuid               ## SOMETIMES_CONSUMES
   gEdkiiSmmMemoryAttributeProtocolGuid          ## CONSUMES
-  gEfiSmmSxDispatch2ProtocolGuid                ## SOMETIMES_CONSUMES
 
 [Pcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdLoadFixAddressSmmCodePageNumber     ## SOMETIMES_CONSUMES

--- a/MdeModulePkg/Core/PiSmmCore/PiSmmIpl.inf
+++ b/MdeModulePkg/Core/PiSmmCore/PiSmmIpl.inf
@@ -75,9 +75,6 @@
   ## SOMETIMES_CONSUMES ## Event
   ## SOMETIMES_PRODUCES ## UNDEFINED # Used to do smm communication
   gEfiEventExitBootServicesGuid
-  ## SOMETIMES_CONSUMES ## Event
-  ## SOMETIMES_PRODUCES ## UNDEFINED # Used to do smm communication
-  gEfiEventReadyToBootGuid
   gEfiEventVirtualAddressChangeGuid             ## CONSUMES             ## Event
   gEfiEndOfDxeEventGroupGuid                    ## CONSUMES             ## Event
   gLoadFixedAddressConfigurationTableGuid       ## SOMETIMES_CONSUMES   ## SystemTable

--- a/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleLib.inf
+++ b/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleLib.inf
@@ -89,10 +89,9 @@
   ## SOMETIMES_CONSUMES ## Variable:L"CapsuleMax"
   ## SOMETIMES_PRODUCES ## Variable:L"CapsuleMax"
   gEfiCapsuleReportGuid
-  gEfiCapsuleVendorGuid                   ## SOMETIMES_CONSUMES ## Variable:L"CapsuleUpdateData"
+  gEfiCapsuleVendorGuid                   ## SOMETIMES_CONSUMES ## Variable:L"CapsuleUpdateData", L"CodRelocationInfo"
   gEfiEndOfDxeEventGroupGuid              ## CONSUMES ## Event
   gEfiPartTypeSystemPartGuid              ## SOMETIMES_CONSUMES
-  gEfiCapsuleVendorGuid                   ## SOMETIMES_CONSUMES ## Variable:L"CodRelocationInfo"
   ## SOMETIMES_CONSUMES ## Variable:L"OsIndications"
   ## SOMETIMES_PRODUCES ## Variable:L"OsIndications"
   ## SOMETIMES_CONSUMES ## Variable:L"BootNext"

--- a/NetworkPkg/Ip6Dxe/GoogleTest/Ip6DxeGoogleTest.inf
+++ b/NetworkPkg/Ip6Dxe/GoogleTest/Ip6DxeGoogleTest.inf
@@ -20,7 +20,6 @@
   Ip6OptionGoogleTest.h
   Ip6DxeGoogleTest.cpp
   Ip6OptionGoogleTest.cpp
-  Ip6OptionGoogleTest.h
 
 [Packages]
   MdePkg/MdePkg.dec

--- a/OvmfPkg/Sec/SecMain.inf
+++ b/OvmfPkg/Sec/SecMain.inf
@@ -84,7 +84,6 @@
   gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSecValidatedEnd
   gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSecGhcbBackupBase
   gUefiOvmfPkgTokenSpaceGuid.PcdTdxAcceptPageSize
-  gUefiOvmfPkgTokenSpaceGuid.PcdOvmfWorkAreaBase
   gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSecApicPageTableBase
   gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSecApicPageTableSize
 

--- a/SecurityPkg/DeviceSecurity/SpdmLib/SpdmSecuredMessageLib.inf
+++ b/SecurityPkg/DeviceSecurity/SpdmLib/SpdmSecuredMessageLib.inf
@@ -24,7 +24,6 @@
 [Sources]
   libspdm/library/spdm_secured_message_lib/libspdm_secmes_context_data.c
   libspdm/library/spdm_secured_message_lib/libspdm_secmes_encode_decode.c
-  libspdm/library/spdm_secured_message_lib/libspdm_secmes_encode_decode.c
   libspdm/library/spdm_secured_message_lib/libspdm_secmes_key_exchange.c
   libspdm/library/spdm_secured_message_lib/libspdm_secmes_session.c
 

--- a/ShellPkg/Application/Shell/Shell.inf
+++ b/ShellPkg/Application/Shell/Shell.inf
@@ -70,7 +70,6 @@
 [Guids]
   gShellVariableGuid                                      ## SOMETIMES_CONSUMES ## GUID
   gShellAliasGuid                                         ## SOMETIMES_CONSUMES ## GUID
-  gShellAliasGuid                                         ## SOMETIMES_PRODUCES ## GUID
 
 [Protocols]
   gEfiShellProtocolGuid                                   ## PRODUCES

--- a/SourceLevelDebugPkg/Library/DebugAgent/DxeDebugAgentLib.inf
+++ b/SourceLevelDebugPkg/Library/DebugAgent/DxeDebugAgentLib.inf
@@ -71,7 +71,6 @@
   PrintLib
   PeCoffGetEntryPointLib
   PeCoffExtraActionLib
-  MemoryAllocationLib
 
 [Guids]
   ## PRODUCES ## SystemTable

--- a/UefiCpuPkg/CpuDxeRiscV64/CpuDxeRiscV64.inf
+++ b/UefiCpuPkg/CpuDxeRiscV64/CpuDxeRiscV64.inf
@@ -39,7 +39,6 @@
   RiscVSbiLib
   RiscVMmuLib
   CacheMaintenanceLib
-  TimerLib
 
 [Sources]
   CpuDxe.c

--- a/UefiCpuPkg/Library/RegisterCpuFeaturesLib/DxeRegisterCpuFeaturesLib.inf
+++ b/UefiCpuPkg/Library/RegisterCpuFeaturesLib/DxeRegisterCpuFeaturesLib.inf
@@ -41,7 +41,6 @@
   SynchronizationLib
   UefiBootServicesTableLib
   IoLib
-  UefiBootServicesTableLib
   UefiLib
 
 [Protocols]

--- a/UefiPayloadPkg/Library/SpiFlashLib/SpiFlashLib.inf
+++ b/UefiPayloadPkg/Library/SpiFlashLib/SpiFlashLib.inf
@@ -39,7 +39,6 @@
   PciLib
   HobLib
   TimerLib
-  BaseLib
 
 [Guids]
   gSpiFlashInfoGuid

--- a/UefiPayloadPkg/PayloadLoaderPeim/PayloadLoaderPeim.inf
+++ b/UefiPayloadPkg/PayloadLoaderPeim/PayloadLoaderPeim.inf
@@ -29,7 +29,6 @@
   ElfLib/ElfCommon.h
   ElfLib/Elf32.h
   ElfLib/Elf64.h
-  ElfLib/ElfLibInternal.h
   ElfLib/ElfLib.c
   ElfLib/Elf32Lib.c
   ElfLib/Elf64Lib.c


### PR DESCRIPTION
# Description

The INF specification said, each source file/protocol/guid/libraryclass/PCD must be listed only once per section. But many drivers don't follow this rule. This PR removed the duplicate items in INF files.

No functional changes.

## How This Was Tested

Pass CI check.

## Integration Instructions

N/A
