### PR TITLE
StandaloneMmPkg: Fix possible infinite loop due invalid Hob

### DIFF
--- a/StandaloneMmPkg/Drivers/StandaloneMmIplPei/StandaloneMmIplPei.c
+++ b/StandaloneMmPkg/Drivers/StandaloneMmIplPei/StandaloneMmIplPei.c
@@ -504,7 +504,7 @@ CreateMmHobList (
   Status = CreateMmFoundationHobList (
              (UINT8 *)HobList + PhitHobSize + PlatformHobSize,
              &FoundationHobSize,
-             HobList,
+             (UINT8 *)HobList + PhitHobSize,
              PlatformHobSize,
              MmFvBase,
              MmFvSize,


### PR DESCRIPTION
# Description

The second call to CreateMmFoundationHobList () expects the address of the beginning of the platform hob list in the third parameter. However it has being given the beginning of the HobList which is PHIT. This causes later wrong address calculations which in turns puts MM core in infinite loop, because the IPL passed hob without EFI_HOB_TYPE_END_OF_HOB_LIST.


- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

OVMF X64 with standaloneMm and SMM profiling enabled.

## Integration Instructions
N//A