### PR TITLE
RedfishPkg/RedfishDiscoverDxe: Do not require TCP6 if IPv6 HTTP off

### DIFF
--- a/RedfishPkg/RedfishDiscoverDxe/RedfishDiscoverDxe.c
+++ b/RedfishPkg/RedfishDiscoverDxe/RedfishDiscoverDxe.c
@@ -69,6 +69,30 @@ static REDFISH_DISCOVER_REQUIRED_PROTOCOL  mRequiredProtocol[] = {
 };
 
 /**
+  Reports whether a required-protocol table entry is used on this platform.
+
+  TCP6 is required only when PcdIPv6HttpSupport is TRUE so Redfish discovery
+  can run on IPv4-only network stacks (PcdIPv6HttpSupport FALSE).
+
+  @param[in]  Index  Index in mRequiredProtocol.
+
+  @retval TRUE   The entry is required and must be present.
+  @retval FALSE  The entry is skipped (TCP6 when IPv6 HTTP is disabled).
+**/
+STATIC
+BOOLEAN
+IsRedfishRequiredProtocolIndexActive (
+  IN UINTN  Index
+  )
+{
+  if (mRequiredProtocol[Index].ProtocolType == ProtocolTypeTcp6) {
+    return PcdGetBool (PcdIPv6HttpSupport);
+  }
+
+  return TRUE;
+}
+
+/**
   This function creates REST EX instance for the found Resfish service.
   by known owner handle.
 
@@ -1788,6 +1812,10 @@ TestForRequiredProtocols (
 
   ListCount = (sizeof (mRequiredProtocol) / sizeof (REDFISH_DISCOVER_REQUIRED_PROTOCOL));
   for (Index = 0; Index < ListCount; Index++) {
+    if (!IsRedfishRequiredProtocolIndexActive (Index)) {
+      continue;
+    }
+
     Status = gBS->OpenProtocol (
                     ControllerHandle,
                     mRequiredProtocol[Index].RequiredServiceBindingProtocolGuid,
@@ -1858,6 +1886,10 @@ BuildupNetworkInterface (
   RestExInstance               = NULL;
 
   for (Index = 0; Index < ListCount; Index++) {
+    if (!IsRedfishRequiredProtocolIndexActive (Index)) {
+      continue;
+    }
+
     Status = gBS->OpenProtocol (
                     // Already in list?
                     ControllerHandle,
@@ -2076,6 +2108,10 @@ StopServiceOnNetworkInterface (
   EFI_REDFISH_DISCOVER_PROTOCOL                    *RedfishDiscoverProtocol;
 
   for (Index = 0; Index < (sizeof (mRequiredProtocol) / sizeof (REDFISH_DISCOVER_REQUIRED_PROTOCOL)); Index++) {
+    if (!IsRedfishRequiredProtocolIndexActive (Index)) {
+      continue;
+    }
+
     Status = gBS->HandleProtocol (
                     ControllerHandle,
                     mRequiredProtocol[Index].RequiredProtocolGuid,

--- a/RedfishPkg/RedfishDiscoverDxe/RedfishDiscoverDxe.inf
+++ b/RedfishPkg/RedfishDiscoverDxe/RedfishDiscoverDxe.inf
@@ -54,4 +54,5 @@
 
 [Pcd]
   gEfiRedfishPkgTokenSpaceGuid.PcdRedfishDiscoverAccessModeInBand ## CONSUMES
-  gEfiRedfishPkgTokenSpaceGuid.PcdRedfishSendReceiveTimeout       ## CONSUEMS
+  gEfiRedfishPkgTokenSpaceGuid.PcdRedfishSendReceiveTimeout       ## CONSUMES
+  gEfiNetworkPkgTokenSpaceGuid.PcdIPv6HttpSupport                 ## CONSUMES

--- a/RedfishPkg/RedfishDiscoverDxe/RedfishDiscoverInternal.h
+++ b/RedfishPkg/RedfishDiscoverDxe/RedfishDiscoverInternal.h
@@ -26,6 +26,7 @@
 #include <Library/DebugLib.h>
 #include <Library/MemoryAllocationLib.h>
 #include <Library/NetLib.h>
+#include <Library/PcdLib.h>
 #include <Library/PrintLib.h>
 #include <Library/RedfishDebugLib.h>
 #include <Library/RestExLib.h>


### PR DESCRIPTION
Redfish discover required TCP4, TCP6, and REST EX on every controller. Platforms that disable IPv6 HTTP
(PcdIPv6HttpSupport FALSE) do not install TCP6, so driver Supported/Start/Stop failed and discovery did not run over IPv4. Skip the TCP6 row in the required-protocol walk when gEfiNetworkPkgTokenSpaceGuid.PcdIPv6HttpSupport is FALSE, consistent with NetworkPkg's IPv6 HTTP gating.

Cc: Abner Chang <abner.chang@amd.com>
Cc: Nickle Wang <nicklew@nvidia.com>
Cc: Igor Kulchytskyy <igork@ami.com>

# Description

Redfish discover required TCP4, TCP6, and REST EX on every controller. Platforms that disable IPv6 HTTP
(PcdIPv6HttpSupport FALSE) do not install TCP6, so driver Supported/Start/Stop failed and discovery did not run over IPv4. Skip the TCP6 row in the required-protocol walk when gEfiNetworkPkgTokenSpaceGuid.PcdIPv6HttpSupport is FALSE, consistent with NetworkPkg's IPv6 HTTP gating.

## How This Was Tested

Built using AMD internal repository and boot test for functionality.

## Integration Instructions

N/A