### PR TITLE
3945_arm_cca_v5_s6: Introduce Arm CCA PEI initialisation library (ArmCcaInitPeiLib)

### DIFF
--- a/ArmVirtPkg/ArmVirt.dsc.inc
+++ b/ArmVirtPkg/ArmVirt.dsc.inc
@@ -194,6 +194,8 @@ DEFINE FD_SIZE_IN_MB    = 3
   DebugLib|ArmVirtPkg/Library/DebugLibFdtPL011Uart/DebugLibFdtPL011UartFlash.inf
 !endif
 
+  ArmCcaInitPeiLib|ArmVirtPkg/Library/ArmCcaInitPeiLibNull/ArmCcaInitPeiLibNull.inf
+
 [LibraryClasses.common.PEI_CORE]
   PcdLib|MdePkg/Library/PeiPcdLib/PeiPcdLib.inf
   BaseMemoryLib|MdePkg/Library/BaseMemoryLib/BaseMemoryLib.inf

--- a/ArmVirtPkg/ArmVirtPkg.dec
+++ b/ArmVirtPkg/ArmVirtPkg.dec
@@ -26,6 +26,7 @@
   Include                        # Root include for the package
 
 [LibraryClasses]
+  ArmCcaInitPeiLib|Include/Library/ArmCcaInitPeiLib.h
   ArmCcaLib|Include/Library/ArmCcaLib.h
   ArmCcaRsiLib|Include/Library/ArmCcaRsiLib.h
   ArmVirtMemInfoLib|Include/Library/ArmVirtMemInfoLib.h

--- a/ArmVirtPkg/Include/Library/ArmCcaInitPeiLib.h
+++ b/ArmVirtPkg/Include/Library/ArmCcaInitPeiLib.h
@@ -1,0 +1,30 @@
+/** @file
+  Library that implements the Arm CCA helper functions.
+
+  Copyright (c) 2022 2026, Arm Ltd. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+    - Rsi or RSI   - Realm Service Interface
+    - IPA          - Intermediate Physical Address
+    - RIPAS        - Realm IPA state
+**/
+
+#pragma once
+
+#include <Base.h>
+
+/**
+  Configure the System Memory region as Protected RAM.
+
+  When a VMM creates a Realm, a small amount of DRAM (which contains the
+  firmware image) and the initial content is configured as Protected RAM.
+  The remaining System Memory is in the Protected Empty state. The firmware
+  must then initialise the remaining System Memory as Protected RAM before
+  it can be accessed.
+
+**/
+VOID
+EFIAPI
+ArmCcaConfigureSystemMemory (
+  VOID
+  );

--- a/ArmVirtPkg/Include/Library/ArmCcaInitPeiLib.h
+++ b/ArmVirtPkg/Include/Library/ArmCcaInitPeiLib.h
@@ -28,3 +28,15 @@ EFIAPI
 ArmCcaConfigureSystemMemory (
   VOID
   );
+
+/** Initialise Arm CCA HOBs
+
+  @retval RETURN_SUCCESS             Success.
+  @retval RETURN_INVALID_PARAMETER   A parameter is invalid.
+  @retval RETURN_OUT_OF_RESOURCES    Out of resources.
+**/
+RETURN_STATUS
+EFIAPI
+ArmCcaInitialiseHobs (
+  VOID
+  );

--- a/ArmVirtPkg/Library/ArmCcaInitPeiLib/ArmCcaInitPeiLib.c
+++ b/ArmVirtPkg/Library/ArmCcaInitPeiLib/ArmCcaInitPeiLib.c
@@ -1,0 +1,50 @@
+/** @file
+  Library that implements the Arm CCA initialisation in PEI phase.
+
+  Copyright (c) 2022 2026, Arm Limited. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+  @par Glossary:
+    - Rsi or RSI   - Realm Service Interface
+    - IPA          - Intermediate Physical Address
+    - RIPAS        - Realm IPA state
+**/
+#include <PiPei.h>
+
+#include <Library/ArmCcaLib.h>
+#include <Library/ArmCcaRsiLib.h>
+#include <Library/BaseLib.h>
+
+/**
+  Configure the System Memory region as Protected RAM.
+
+  When a VMM creates a Realm, a small amount of DRAM (which contains the
+  firmware image) and the initial content is configured as Protected RAM.
+  The remaining System Memory is in the Protected Empty state. The firmware
+  must then initialise the remaining System Memory as Protected RAM before
+  it can be accessed.
+
+**/
+VOID
+EFIAPI
+ArmCcaConfigureSystemMemory (
+  VOID
+  )
+{
+  RETURN_STATUS  Status;
+
+  if (!ArmCcaIsRealm ()) {
+    return;
+  }
+
+  Status =  ArmCcaRsiSetIpaState (
+              (UINT64 *)PcdGet64 (PcdSystemMemoryBase),
+              PcdGet64 (PcdSystemMemorySize),
+              RipasRam,
+              ARM_CCA_RIPAS_CHANGE_FLAGS_RSI_NO_CHANGE_DESTROYED
+              );
+  if (RETURN_ERROR (Status)) {
+    // Panic
+    CpuDeadLoop ();
+  }
+}

--- a/ArmVirtPkg/Library/ArmCcaInitPeiLib/ArmCcaInitPeiLib.c
+++ b/ArmVirtPkg/Library/ArmCcaInitPeiLib/ArmCcaInitPeiLib.c
@@ -14,6 +14,8 @@
 #include <Library/ArmCcaLib.h>
 #include <Library/ArmCcaRsiLib.h>
 #include <Library/BaseLib.h>
+#include <Library/DebugLib.h>
+#include <Library/HobLib.h>
 
 /**
   Configure the System Memory region as Protected RAM.
@@ -47,4 +49,61 @@ ArmCcaConfigureSystemMemory (
     // Panic
     CpuDeadLoop ();
   }
+}
+
+/** Initialise Arm CCA HOBs
+
+  @retval RETURN_SUCCESS             Success.
+  @retval RETURN_INVALID_PARAMETER   A parameter is invalid.
+  @retval RETURN_OUT_OF_RESOURCES    Out of resources.
+**/
+RETURN_STATUS
+EFIAPI
+ArmCcaInitialiseHobs (
+  VOID
+  )
+{
+  RETURN_STATUS  Status;
+  UINT64         *IsRealmHobData;
+  BOOLEAN        RealmWorld;
+  UINT64         IpaWidth;
+  UINT64         *IpaWidthHobData;
+
+  RealmWorld = ArmCcaIsRealm ();
+  if (!RealmWorld) {
+    // nothing to do.
+    return RETURN_SUCCESS;
+  }
+
+  // Create a Guid HOB to cache the IsRealm value.
+  IsRealmHobData = BuildGuidHob (
+                     &gArmCcaIsRealmGuid,
+                     sizeof (*IsRealmHobData)
+                     );
+  if (IsRealmHobData == NULL) {
+    ASSERT (IsRealmHobData != NULL);
+    return RETURN_OUT_OF_RESOURCES;
+  }
+
+  *IsRealmHobData = RealmWorld;
+
+  // Read the IPA width and Create the Guid HOB, to cache the value in the HOB.
+  Status = ArmCcaGetIpaWidth (&IpaWidth);
+  if (RETURN_ERROR (Status)) {
+    ASSERT (0);
+    return Status;
+  }
+
+  IpaWidthHobData = BuildGuidHob (
+                      &gArmCcaIpaWidthGuid,
+                      sizeof (*IpaWidthHobData)
+                      );
+  if (IpaWidthHobData == NULL) {
+    ASSERT (IpaWidthHobData != NULL);
+    return RETURN_OUT_OF_RESOURCES;
+  }
+
+  *IpaWidthHobData = IpaWidth;
+
+  return RETURN_SUCCESS;
 }

--- a/ArmVirtPkg/Library/ArmCcaInitPeiLib/ArmCcaInitPeiLib.inf
+++ b/ArmVirtPkg/Library/ArmCcaInitPeiLib/ArmCcaInitPeiLib.inf
@@ -1,7 +1,7 @@
 ## @file
 #  Library that implements the Arm CCA initialisation in PEI phase.
 #
-#  Copyright (c) 2022 - 2023, Arm Limited. All rights reserved.<BR>
+#  Copyright (c) 2022 - 2026, Arm Limited. All rights reserved.<BR>
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -27,8 +27,13 @@
   ArmCcaLib
   ArmCcaRsiLib
   BaseLib
+  DebugLib
+  HobLib
 
 [Pcd]
   gArmTokenSpaceGuid.PcdSystemMemoryBase
   gArmTokenSpaceGuid.PcdSystemMemorySize
 
+[Guids]
+  gArmCcaIpaWidthGuid
+  gArmCcaIsRealmGuid

--- a/ArmVirtPkg/Library/ArmCcaInitPeiLib/ArmCcaInitPeiLib.inf
+++ b/ArmVirtPkg/Library/ArmCcaInitPeiLib/ArmCcaInitPeiLib.inf
@@ -1,0 +1,34 @@
+## @file
+#  Library that implements the Arm CCA initialisation in PEI phase.
+#
+#  Copyright (c) 2022 - 2023, Arm Limited. All rights reserved.<BR>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x0001001B
+  BASE_NAME                      = ArmCcaInitPeiLib
+  FILE_GUID                      = 9A8C3768-79ED-487E-8155-BBF4DD638296
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = ArmCcaInitPeiLib
+
+[Sources]
+  ArmCcaInitPeiLib.c
+
+[Packages]
+  ArmPkg/ArmPkg.dec
+  ArmVirtPkg/ArmVirtPkg.dec
+  MdePkg/MdePkg.dec
+
+[LibraryClasses]
+  ArmCcaLib
+  ArmCcaRsiLib
+  BaseLib
+
+[Pcd]
+  gArmTokenSpaceGuid.PcdSystemMemoryBase
+  gArmTokenSpaceGuid.PcdSystemMemorySize
+

--- a/ArmVirtPkg/Library/ArmCcaInitPeiLibNull/ArmCcaInitPeiLibNull.c
+++ b/ArmVirtPkg/Library/ArmCcaInitPeiLibNull/ArmCcaInitPeiLibNull.c
@@ -29,3 +29,18 @@ ArmCcaConfigureSystemMemory (
   )
 {
 }
+
+/** Initialise Arm CCA HOBs
+
+  @retval RETURN_SUCCESS             Success.
+  @retval RETURN_INVALID_PARAMETER   A parameter is invalid.
+  @retval RETURN_OUT_OF_RESOURCES    Out of resources.
+**/
+RETURN_STATUS
+EFIAPI
+ArmCcaInitialiseHobs (
+  VOID
+  )
+{
+  return RETURN_SUCCESS;
+}

--- a/ArmVirtPkg/Library/ArmCcaInitPeiLibNull/ArmCcaInitPeiLibNull.c
+++ b/ArmVirtPkg/Library/ArmCcaInitPeiLibNull/ArmCcaInitPeiLibNull.c
@@ -1,0 +1,31 @@
+/** @file
+  Library that implements a NULL implementation of the ArmCcaInitPeiLib.
+
+  Copyright (c) 2022 - 2026, Arm Limited. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+  @par Glossary:
+    - Rsi or RSI   - Realm Service Interface
+    - IPA          - Intermediate Physical Address
+    - RIPAS        - Realm IPA state
+**/
+
+#include <Base.h>
+
+/**
+  Configure the System Memory region as Protected RAM.
+
+  When a VMM creates a Realm, a small amount of DRAM (which contains the
+  firmware image) and the initial content is configured as Protected RAM.
+  The remaining System Memory is in the Protected Empty state. The firmware
+  must then initialise the remaining System Memory as Protected RAM before
+  it can be accessed.
+
+**/
+VOID
+EFIAPI
+ArmCcaConfigureSystemMemory (
+  VOID
+  )
+{
+}

--- a/ArmVirtPkg/Library/ArmCcaInitPeiLibNull/ArmCcaInitPeiLibNull.inf
+++ b/ArmVirtPkg/Library/ArmCcaInitPeiLibNull/ArmCcaInitPeiLibNull.inf
@@ -1,0 +1,26 @@
+## @file
+#  Library that implements a NULL implementation of the ArmCcaInitPeiLib.
+#
+#  Copyright (c) 2022 - 2023, Arm Limited. All rights reserved.<BR>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x0001001B
+  BASE_NAME                      = ArmCcaInitPeiLib
+  FILE_GUID                      = 60686C60-8433-49EE-9F2C-DDC424A95652
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = ArmCcaInitPeiLib
+
+[Sources]
+  ArmCcaInitPeiLibNull.c
+
+[Packages]
+  ArmVirtPkg/ArmVirtPkg.dec
+  MdePkg/MdePkg.dec
+
+[LibraryClasses]
+  BaseLib

--- a/ArmVirtPkg/Library/KvmtoolPlatformPeiLib/KvmtoolPlatformPeiLib.c
+++ b/ArmVirtPkg/Library/KvmtoolPlatformPeiLib/KvmtoolPlatformPeiLib.c
@@ -1,7 +1,7 @@
 /** @file
   Kvmtool platform PEI library.
 
-  Copyright (c) 2020, ARM Limited. All rights reserved.
+  Copyright (c) 2020 - 2026, ARM Limited. All rights reserved.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -12,6 +12,7 @@
 #include <Guid/Early16550UartBaseAddress.h>
 #include <Guid/FdtHob.h>
 
+#include <Library/ArmCcaInitPeiLib.h>
 #include <Library/MemoryAllocationLib.h>
 #include <Library/DebugLib.h>
 #include <Library/FdtLib.h>
@@ -31,12 +32,13 @@ PlatformPeim (
   VOID
   )
 {
-  VOID    *Base;
-  VOID    *NewBase;
-  UINTN   FdtSize;
-  UINTN   FdtPages;
-  UINT64  *FdtHobData;
-  UINT64  *UartHobData;
+  RETURN_STATUS  RetStatus;
+  VOID           *Base;
+  VOID           *NewBase;
+  UINTN          FdtSize;
+  UINTN          FdtPages;
+  UINT64         *FdtHobData;
+  UINT64         *UartHobData;
 
   Base = (VOID *)(UINTN)PcdGet64 (PcdDeviceTreeInitialBaseAddress);
   if ((Base == NULL) || (FdtCheckHeader (Base) != 0)) {
@@ -74,6 +76,12 @@ PlatformPeim (
   *UartHobData = PcdGet64 (PcdSerialRegisterBase);
 
   BuildFvHob (PcdGet64 (PcdFvBaseAddress), PcdGet32 (PcdFvSize));
+
+  RetStatus = ArmCcaInitialiseHobs ();
+  if (RETURN_ERROR (RetStatus)) {
+    ASSERT (0);
+    return (EFI_STATUS)RetStatus;
+  }
 
   return EFI_SUCCESS;
 }

--- a/ArmVirtPkg/Library/KvmtoolPlatformPeiLib/KvmtoolPlatformPeiLib.inf
+++ b/ArmVirtPkg/Library/KvmtoolPlatformPeiLib/KvmtoolPlatformPeiLib.inf
@@ -26,6 +26,7 @@
   OvmfPkg/OvmfPkg.dec
 
 [LibraryClasses]
+  ArmCcaInitPeiLib
   DebugLib
   HobLib
   FdtLib


### PR DESCRIPTION
# Introduce Arm CCA PEI initialisation library (ArmCcaInitPeiLib)

This series introduces an ArmCcaInitPeiLib library that performs CCA-specific initialisation, including configuring system memory as Protected RAM. The series further extends the library with helper functionality to initialise and publish Arm CCA-related HOBs, caching key parameters such as Realm state and IPA width during PEI.

To support platforms that do not implement CCA (e.g. non-Realm VMMs), a NULL instance of the library is also provided.
Finally, the Kvmtool platform PEI library is updated to invoke this helper so that the relevant HOBs are created during early platform initialisation.

**Note:** 
1. This is a PR series that includes patches from PR https://github.com/tianocore/edk2/pull/12224
2. This PR  is dependent on the PR https://github.com/tianocore/edk2/pull/12505 which must be merged before this series.

- [ ] Breaking change?
  - No
- [ ] Impacts security?
  - No
- [ ] Includes tests?
  - No explicit test, run Kvmtool guest firmware.

## How This Was Tested

Only build tested. Actual functionality can only be tested when the remaining patches from PR https://github.com/tianocore/edk2/pull/12224 are integrated in the future.

## Integration Instructions

N/A
