### PR TITLE
ArmPkg: Flush data cache when mapping region as WC

### DIFF
--- a/ArmPkg/Drivers/CpuDxe/CpuMmuCommon.c
+++ b/ArmPkg/Drivers/CpuDxe/CpuMmuCommon.c
@@ -204,6 +204,23 @@ SetGcdMemorySpaceAttributes (
 }
 
 /**
+  Checks if the specified ARM translation table attributes are cacheable memory.
+
+  @param[in]  Attributes  ARM memory attributes.
+
+  @retval TRUE if the attributes are cacheable, FALSE otherwise.
+**/
+STATIC
+BOOLEAN
+IsArmAttributeCacheable (
+  IN UINT64  Attributes
+  )
+{
+  return ((Attributes & TT_ATTR_INDX_MASK) == TT_ATTR_INDX_MEMORY_WRITE_THROUGH) ||
+         ((Attributes & TT_ATTR_INDX_MASK) == TT_ATTR_INDX_MEMORY_WRITE_BACK);
+}
+
+/**
   This function modifies the attributes for the memory region specified by BaseAddress and
   Length from their current attributes to the attributes specified by Attributes.
 
@@ -238,6 +255,7 @@ CpuSetMemoryAttributes (
   UINTN       RegionBaseAddress;
   UINTN       RegionLength;
   UINTN       RegionArmAttributes;
+  BOOLEAN     FlushCache;
 
   if (mIsFlushingGCD) {
     return EFI_SUCCESS;
@@ -261,8 +279,34 @@ CpuSetMemoryAttributes (
   if (EFI_ERROR (Status) || (RegionArmAttributes != ArmAttributes) ||
       ((BaseAddress + Length) > (RegionBaseAddress + RegionLength)))
   {
-    return ArmSetMemoryAttributes (BaseAddress, Length, EfiAttributes, 0);
-  } else {
-    return EFI_SUCCESS;
+    //
+    // If the region was previously mapped as a cacheable normal memory,
+    // and is changed to device or non-cacheable memory, ensure any
+    // stale cache lines are written back and invalidated. If this is not done,
+    // depending on the caching behavior of the platform, dirty cache lines may
+    // be written back corrupting data in the future, or stale cache lines may
+    // persist if caching is enabled later.
+    //
+    FlushCache = FALSE;
+    if (!EFI_ERROR (Status) && IsArmAttributeCacheable (RegionArmAttributes) && !IsArmAttributeCacheable (ArmAttributes)) {
+      FlushCache = TRUE;
+    }
+
+    Status = ArmSetMemoryAttributes (BaseAddress, Length, EfiAttributes, 0);
+    if (EFI_ERROR (Status)) {
+      return Status;
+    }
+
+    if (FlushCache) {
+      //
+      // A data barrier is required to ensure that all page updates are complete and the TLB is flushed prior to the
+      // cache invalidation to avoid any unexpected cache lines being created.
+      //
+
+      ArmDataSynchronizationBarrier ();
+      WriteBackInvalidateDataCacheRange ((VOID *)(UINTN)BaseAddress, (UINTN)Length);
+    }
   }
+
+  return EFI_SUCCESS;
 }


### PR DESCRIPTION
# Description

When mapping a region as WC (Normal Memory Non-Cacheable), dirty cache lines may persistent, and depending on the caching behavior of the platform, may be written back corrupting data in the future. To prevent this, the data cache should be flushed and invalidated for the range after the mapping has been changed, but before accessing the memory. Currently, the EFI_CPU_ARCH_PROTOCOL implementation makes the caller responsible for this, but this is prone to obscure and difficult to diagnose memory issues if this is missed. It is safer to always perform the flush when mapping as WC, even if this may be redundant in some cases.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

Tested booting to operating system and with one-off shell test application.

## Integration Instructions

N/A
