### PR TITLE
MdeModulePkg: Remove duplicate library class in dsc file

### DIFF
--- a/MdeModulePkg/MdeModulePkg.dsc
+++ b/MdeModulePkg/MdeModulePkg.dsc
@@ -100,7 +100,6 @@
   ImagePropertiesRecordLib|MdeModulePkg/Library/ImagePropertiesRecordLib/ImagePropertiesRecordLib.inf
 
   FmpAuthenticationLib|MdeModulePkg/Library/FmpAuthenticationLibNull/FmpAuthenticationLibNull.inf
-  CapsuleLib|MdeModulePkg/Library/DxeCapsuleLibNull/DxeCapsuleLibNull.inf
   BmpSupportLib|MdeModulePkg/Library/BaseBmpSupportLib/BaseBmpSupportLib.inf
   SafeIntLib|MdePkg/Library/BaseSafeIntLib/BaseSafeIntLib.inf
   DisplayUpdateProgressLib|MdeModulePkg/Library/DisplayUpdateProgressLibGraphics/DisplayUpdateProgressLibGraphics.inf


### PR DESCRIPTION
# Description

In MdeModulePkg.dsc, CapsuleLib appears twice in [LibraryClasses] section, so remove the duplicate one.
https://github.com/tianocore/edk2/blob/03a07cb0f5e9b8148dfeba2f509a3092aff419af/MdeModulePkg/MdeModulePkg.dsc#L74
https://github.com/tianocore/edk2/blob/03a07cb0f5e9b8148dfeba2f509a3092aff419af/MdeModulePkg/MdeModulePkg.dsc#L103


## How This Was Tested

Pass CI check.

## Integration Instructions

N/A
