### PR TITLE
MdeModulePkg/DxeCapsuleLibFmp: Tolerate EFI_ALREADY_STARTED in LockVariable

### DIFF
--- a/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleReportLib.c
+++ b/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleReportLib.c
@@ -122,7 +122,7 @@ LockVariable (
              VARIABLE_POLICY_NO_CANT_ATTR,
              VARIABLE_POLICY_TYPE_LOCK_NOW
              );
-  if (EFI_ERROR (Status)) {
+  if (EFI_ERROR (Status) && (Status != EFI_ALREADY_STARTED)) {
     DEBUG ((
       DEBUG_ERROR,
       "DxeCapsuleLibFmp: Failed to lock variable %g %s.  Status = %r\n",


### PR DESCRIPTION
When multiple DXE drivers link DxeCapsuleLib, each driver's constructor calls InitCapsuleVariable() which attempts to lock capsule-related variables. The second instance fails with EFI_ALREADY_STARTED because the policy is already registered, triggering a false ASSERT.

EFI_ALREADY_STARTED from RegisterBasicVariablePolicy means the variable is already locked, which is the desired state. Treat it as success.

- [ ] Breaking change? No
- [ ] Impacts security? No
- [ ] Includes tests? No (validated manually on target hardware)

## How This Was Tested
Tested with including the DxeCapsuleLib with multiple DXE drivers

## Integration Instructions

N/A
