### PR TITLE
NetworkPkg: Fix Coverity static analysis issues

### DIFF
--- a/NetworkPkg/Dhcp6Dxe/Dhcp6Io.c
+++ b/NetworkPkg/Dhcp6Dxe/Dhcp6Io.c
@@ -538,7 +538,9 @@ Dhcp6UpdateIaInfo (
   T1 = 0;
   T2 = 0;
 
-  ASSERT (Instance->Config != NULL);
+  if (Instance->Config == NULL) {
+    return EFI_DEVICE_ERROR;
+  }
 
   // OptionLen is the length of the Options excluding the DHCP header.
   // Length of the EFI_DHCP6_PACKET from the first byte of the Header field to the last

--- a/NetworkPkg/Dhcp6Dxe/Dhcp6Utility.c
+++ b/NetworkPkg/Dhcp6Dxe/Dhcp6Utility.c
@@ -1335,7 +1335,7 @@ Dhcp6GenerateIaCb (
   UINT32        IaSize;
   EFI_DHCP6_IA  *Ia;
 
-  if (Instance->IaCb.Ia == NULL) {
+  if ((Instance->IaCb.Ia == NULL) || (Instance->Config == NULL)) {
     return EFI_DEVICE_ERROR;
   }
 

--- a/NetworkPkg/Ip6Dxe/Ip6Driver.c
+++ b/NetworkPkg/Ip6Dxe/Ip6Driver.c
@@ -190,6 +190,14 @@ Ip6CleanService (
   Ip6CleanPrefixListTable (IpSb, &IpSb->OnlinkPrefix);
   Ip6CleanPrefixListTable (IpSb, &IpSb->AutonomousPrefix);
 
+  //
+  // Free the Neighbor Discovery resources before MNP teardown.
+  //
+  while (!IsListEmpty (&IpSb->NeighborTable)) {
+    NeighborCache = NET_LIST_HEAD (&IpSb->NeighborTable, IP6_NEIGHBOR_ENTRY, Link);
+    Ip6FreeNeighborEntry (IpSb, NeighborCache, FALSE, TRUE, EFI_SUCCESS, NULL, NULL);
+  }
+
   if (IpSb->RouteTable != NULL) {
     Ip6CleanRouteTable (IpSb->RouteTable);
     IpSb->RouteTable = NULL;
@@ -229,14 +237,6 @@ Ip6CleanService (
 
   if (IpSb->RecvRequest.MnpToken.Event != NULL) {
     gBS->CloseEvent (IpSb->RecvRequest.MnpToken.Event);
-  }
-
-  //
-  // Free the Neighbor Discovery resources
-  //
-  while (!IsListEmpty (&IpSb->NeighborTable)) {
-    NeighborCache = NET_LIST_HEAD (&IpSb->NeighborTable, IP6_NEIGHBOR_ENTRY, Link);
-    Ip6FreeNeighborEntry (IpSb, NeighborCache, FALSE, TRUE, EFI_SUCCESS, NULL, NULL);
   }
 
   return EFI_SUCCESS;

--- a/NetworkPkg/Ip6Dxe/Ip6Nd.c
+++ b/NetworkPkg/Ip6Dxe/Ip6Nd.c
@@ -2277,6 +2277,7 @@ Ip6ProcessRouterAdvertise (
           //
           if ((PrefixList == NULL) &&
               (PrefixOption.ValidLifetime != 0) &&
+              (IpSb->InterfaceId != NULL) &&
               (PrefixOption.PrefixLength + IpSb->InterfaceIdLen * 8 == 128)
               )
           {

--- a/NetworkPkg/UefiPxeBcDxe/PxeBcDhcp6.c
+++ b/NetworkPkg/UefiPxeBcDxe/PxeBcDhcp6.c
@@ -2053,7 +2053,7 @@ PxeBcDhcp6CallBack (
       //
       // Cache the dhcp discover packet to mode data directly.
       //
-      CopyMem (&Mode->DhcpDiscover.Dhcpv4, &Packet->Dhcp6, Packet->Length);
+      CopyMem (&Mode->DhcpDiscover.Dhcpv6, &Packet->Dhcp6, Packet->Length);
       break;
 
     case Dhcp6RcvdAdvertise:


### PR DESCRIPTION
This PR fixes Coverity static analysis findings in NetworkPkg modules.

**NetworkPkg/Dhcp6Dxe/Dhcp6Utility.c**
Replace the ASSERT (Instance->Config != NULL) in Dhcp6UpdateIaInfo with
an explicit NULL check that returns EFI_DEVICE_ERROR. Also add a
complementary guard in Dhcp6GenerateIaCb alongside the existing check for
Instance->IaCb.Ia. These are defensive changes to prevent potential NULL
pointer dereferences.

**NetworkPkg/Ip6Dxe/Ip6Driver.c**
In Ip6CleanService, Ip6FreeNeighborEntry may attempt to send packets via
MNP. Defensively move the neighbor table cleanup to occur before MNP teardown
so that the MNP child handle and its resources remain valid during neighbor
entry cleanup.

**NetworkPkg/Ip6Dxe/Ip6Nd.c**
In `Ip6ProcessRouterAdvertise`, `IpSb->InterfaceId` is dereferenced in
`CopyMem` to form a stateless address. Add a guard to ensure
`IpSb->InterfaceId` is not NULL before entering the block.

**NetworkPkg/UefiPxeBcDxe/PxeBcDhcp6.c**
When caching the DHCPv6 discover packet to `Mode->DhcpDiscover` in
`PxeBcDhcp6CallBack`, the destination was incorrectly specified as
`Mode->DhcpDiscover.Dhcpv4` (the DHCPv4 union member). Change it to
`Mode->DhcpDiscover` to correctly reference the union.

Cc: Saloni Kasbekar <saloni.kasbekar@intel.com>
Cc: Zachary Clark-williams <zachary.clark-williams@intel.com>
Cc: Mike Beaton <mjsbeaton@gmail.com>

Signed-off-by: Abuthahir M <abuthahirm@ami.com>