### PR TITLE
5259_arm_cca_measured_boot_v1_s1: Enable Hash algorithm support required for Arm CCA measured boot

### DIFF
--- a/CryptoPkg/Library/BaseCryptLib/SecCryptLib.inf
+++ b/CryptoPkg/Library/BaseCryptLib/SecCryptLib.inf
@@ -23,7 +23,7 @@
 #
 # The following information is for reference only and not required by the build tools.
 #
-#  VALID_ARCHITECTURES           = IA32 X64
+#  VALID_ARCHITECTURES           = IA32 X64 AARCH64
 #
 
 [Sources]
@@ -32,7 +32,7 @@
 
   Hash/CryptMd5Null.c
   Hash/CryptSha1Null.c
-  Hash/CryptSha256Null.c
+  Hash/CryptSha256.c
   Hash/CryptSm3Null.c
   Hash/CryptParallelHashNull.c
   Hmac/CryptHmacNull.c

--- a/SecurityPkg/Library/HashInstanceLibSha256/HashInstanceLibSha256.c
+++ b/SecurityPkg/Library/HashInstanceLibSha256/HashInstanceLibSha256.c
@@ -10,7 +10,6 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <PiPei.h>
 #include <Library/BaseLib.h>
 #include <Library/BaseMemoryLib.h>
-#include <Library/Tpm2CommandLib.h>
 #include <Library/DebugLib.h>
 #include <Library/BaseCryptLib.h>
 #include <Library/MemoryAllocationLib.h>

--- a/SecurityPkg/Library/HashInstanceLibSha256/HashInstanceLibSha256.inf
+++ b/SecurityPkg/Library/HashInstanceLibSha256/HashInstanceLibSha256.inf
@@ -36,6 +36,5 @@
   BaseLib
   BaseMemoryLib
   DebugLib
-  Tpm2CommandLib
   MemoryAllocationLib
   BaseCryptLib


### PR DESCRIPTION
# Enable Hash algorithm support required for Arm CCA measured boot

Enable SHA256 support in SecCryptLib for AARCH64 so Arm CCA early boot measurements can use SHA256 for Realm Extensible Measurement registers.
Also remove the unused Tpm2CommandLib dependency from HashInstanceLibSha256 to avoid unnecessary TPM library dependencies in non-TPM builds.

Note: This PR is a subset of the PR that tracks the enablement of measured boot support for Arm CCA https://github.com/tianocore/edk2/pull/12531

- [ ] Breaking change?
  - No
- [ ] Impacts security?
  - No
- [ ] Includes tests?
  - No
  
## How This Was Tested

Only build tested. Actual functionality can only be tested when the remaining patches from PR https://github.com/tianocore/edk2/pull/12224 are integrated in the future.

## Integration Instructions

N/A
