### PR TITLE
5259_arm_cca_measured_boot_v1_s2: Add CCEL and Arm CCA related definitions to MdePkg headers.

### DIFF
--- a/MdePkg/Include/IndustryStandard/Acpi65.h
+++ b/MdePkg/Include/IndustryStandard/Acpi65.h
@@ -3072,10 +3072,11 @@ typedef struct {
 ///
 /// Confidential Computing Type definitions.
 ///
-#define EFI_ACPI_6_5_CC_TYPE_NONE   0
-#define EFI_ACPI_6_5_CC_TYPE_SEV    1
-#define EFI_ACPI_6_5_CC_TYPE_TDX    2
-#define EFI_ACPI_6_5_CC_TYPE_APTEE  3
+#define EFI_ACPI_6_5_CC_TYPE_NONE    0
+#define EFI_ACPI_6_5_CC_TYPE_SEV     1
+#define EFI_ACPI_6_5_CC_TYPE_TDX     2
+#define EFI_ACPI_6_5_CC_TYPE_APTEE   3
+#define EFI_ACPI_6_5_CC_TYPE_ARMCCA  4
 
 ///
 /// Confidential Computing Event Log ACPI Table (CCEL).

--- a/MdePkg/Include/IndustryStandard/Acpi65.h
+++ b/MdePkg/Include/IndustryStandard/Acpi65.h
@@ -3069,6 +3069,36 @@ typedef struct {
 #define EFI_ACPI_6_5_PHAT_RESET_REASON_REASON_POWER_LOSS        0x24
 #define EFI_ACPI_6_5_PHAT_RESET_REASON_REASON_POWER_BUTTON      0x25
 
+///
+/// Confidential Computing Type definitions.
+///
+#define EFI_ACPI_6_5_CC_TYPE_NONE   0
+#define EFI_ACPI_6_5_CC_TYPE_SEV    1
+#define EFI_ACPI_6_5_CC_TYPE_TDX    2
+#define EFI_ACPI_6_5_CC_TYPE_APTEE  3
+
+///
+/// Confidential Computing Event Log ACPI Table (CCEL).
+///
+typedef struct {
+  EFI_ACPI_DESCRIPTION_HEADER    Header;
+  /// Confidential Computing (CC) type.
+  UINT8                          Type;
+  /// Confidential Computing (CC) sub type.
+  UINT8                          SubType;
+  /// Reserved.
+  UINT16                         Reserved;
+  /// Log Area Minimum Length.
+  UINT64                         Laml;
+  /// Log Area Start Address.
+  UINT64                         Lasa;
+} EFI_ACPI_6_5_CONFIDENTIAL_COMPUTING_EVENT_LOG_TABLE;
+
+///
+/// CCEL Revision (as defined in ACPI 6.5 spec.)
+///
+#define EFI_ACPI_6_5_CONFIDENTIAL_COMPUTING_EVENT_LOG_TABLE_REVISION  0x01
+
 //
 // Known table signatures
 //
@@ -3097,6 +3127,11 @@ typedef struct {
 /// "BGRT" Boot Graphics Resource Table
 ///
 #define EFI_ACPI_6_5_BOOT_GRAPHICS_RESOURCE_TABLE_SIGNATURE  SIGNATURE_32('B', 'G', 'R', 'T')
+
+///
+/// "CCEL" Confidential Compute Event Log Table
+///
+#define EFI_ACPI_6_5_CONFIDENTIAL_COMPUTING_EVENT_LOG_TABLE_SIGNATURE  SIGNATURE_32('C', 'C', 'E', 'L')
 
 ///
 /// "CDIT" Component Distance Information Table

--- a/MdePkg/Include/IndustryStandard/Acpi66.h
+++ b/MdePkg/Include/IndustryStandard/Acpi66.h
@@ -3232,6 +3232,36 @@ typedef struct {
 
 #define EFI_ACPI_6_6_RHCT_HART_INFO_NODE_STRUCTURE_VERSION  1
 
+///
+/// Confidential Computing Type definitions.
+///
+#define EFI_ACPI_6_6_CC_TYPE_NONE   0
+#define EFI_ACPI_6_6_CC_TYPE_SEV    1
+#define EFI_ACPI_6_6_CC_TYPE_TDX    2
+#define EFI_ACPI_6_6_CC_TYPE_APTEE  3
+
+///
+/// Confidential Computing Event Log ACPI Table (CCEL).
+///
+typedef struct {
+  EFI_ACPI_DESCRIPTION_HEADER    Header;
+  /// Confidential Computing (CC) type.
+  UINT8                          Type;
+  /// Confidential Computing (CC) sub type.
+  UINT8                          SubType;
+  /// Reserved.
+  UINT16                         Reserved;
+  /// Log Area Minimum Length.
+  UINT64                         Laml;
+  /// Log Area Start Address.
+  UINT64                         Lasa;
+} EFI_ACPI_6_6_CONFIDENTIAL_COMPUTING_EVENT_LOG_TABLE;
+
+///
+/// CCEL Revision (as defined in ACPI 6.6 spec.)
+///
+#define EFI_ACPI_6_6_CONFIDENTIAL_COMPUTING_EVENT_LOG_TABLE_REVISION  0x01
+
 //
 // Known table signatures
 //
@@ -3260,6 +3290,11 @@ typedef struct {
 /// "BGRT" Boot Graphics Resource Table
 ///
 #define EFI_ACPI_6_6_BOOT_GRAPHICS_RESOURCE_TABLE_SIGNATURE  SIGNATURE_32('B', 'G', 'R', 'T')
+
+///
+/// "CCEL" Confidential Compute Event Log Table
+///
+#define EFI_ACPI_6_6_CONFIDENTIAL_COMPUTING_EVENT_LOG_TABLE_SIGNATURE  SIGNATURE_32('C', 'C', 'E', 'L')
 
 ///
 /// "CDIT" Component Distance Information Table

--- a/MdePkg/Include/IndustryStandard/Acpi66.h
+++ b/MdePkg/Include/IndustryStandard/Acpi66.h
@@ -3235,10 +3235,11 @@ typedef struct {
 ///
 /// Confidential Computing Type definitions.
 ///
-#define EFI_ACPI_6_6_CC_TYPE_NONE   0
-#define EFI_ACPI_6_6_CC_TYPE_SEV    1
-#define EFI_ACPI_6_6_CC_TYPE_TDX    2
-#define EFI_ACPI_6_6_CC_TYPE_APTEE  3
+#define EFI_ACPI_6_6_CC_TYPE_NONE    0
+#define EFI_ACPI_6_6_CC_TYPE_SEV     1
+#define EFI_ACPI_6_6_CC_TYPE_TDX     2
+#define EFI_ACPI_6_6_CC_TYPE_APTEE   3
+#define EFI_ACPI_6_6_CC_TYPE_ARMCCA  4
 
 ///
 /// Confidential Computing Event Log ACPI Table (CCEL).

--- a/MdePkg/Include/Protocol/CcMeasurement.h
+++ b/MdePkg/Include/Protocol/CcMeasurement.h
@@ -88,7 +88,9 @@ typedef UINT32 EFI_CC_MR_INDEX;
 #define   ARMCCA_MR_INDEX_INVALID  4
 
 #define EFI_CC_EVENT_LOG_FORMAT_TCG_2  0x00000002
+#define EFI_CC_BOOT_HASH_ALG_SHA256    0x00000002
 #define EFI_CC_BOOT_HASH_ALG_SHA384    0x00000004
+#define EFI_CC_BOOT_HASH_ALG_SHA512    0x00000008
 
 //
 // This bit is shall be set when an event shall be extended but not logged.

--- a/MdePkg/Include/Protocol/CcMeasurement.h
+++ b/MdePkg/Include/Protocol/CcMeasurement.h
@@ -16,6 +16,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #pragma once
 
+#include <IndustryStandard/Acpi.h>
 #include <IndustryStandard/UefiTcgPlatform.h>
 
 #define EFI_CC_MEASUREMENT_PROTOCOL_GUID  \
@@ -29,16 +30,18 @@ typedef struct {
   UINT8    Minor;
 } EFI_CC_VERSION;
 
-//
-// EFI_CC Type/SubType definition
-//
-#define EFI_CC_TYPE_NONE   0
-#define EFI_CC_TYPE_SEV    1
-#define EFI_CC_TYPE_TDX    2
-#define EFI_CC_TYPE_APTEE  3
+/**
+  A structure defining the Confidential Computing (CC) type and subtype.
 
+  The Type and Subtype field values must match the definitions in the ACPI
+  specification version 6.5 or later,
+  e.g. the macros EFI_ACPI_6_5_CC_TYPE_* must be used to populate the
+  Type field.
+*/
 typedef struct {
+  /// Confidential Computing (CC) type.
   UINT8    Type;
+  /// Confidential Computing (CC) sub type.
   UINT8    SubType;
 } EFI_CC_TYPE;
 
@@ -298,24 +301,3 @@ typedef struct {
   {0xdd4a4648, 0x2de7, 0x4665, {0x96, 0x4d, 0x21, 0xd9, 0xef, 0x5f, 0xb4, 0x46}}
 
 extern EFI_GUID  gEfiCcFinalEventsTableGuid;
-
-//
-// Define the CC Measure EventLog ACPI Table
-//
-#pragma pack(1)
-
-typedef struct {
-  EFI_ACPI_DESCRIPTION_HEADER    Header;
-  EFI_CC_TYPE                    CcType;
-  UINT16                         Rsvd;
-  UINT64                         Laml;
-  UINT64                         Lasa;
-} EFI_CC_EVENTLOG_ACPI_TABLE;
-
-#pragma pack()
-
-//
-// Define the signature and revision of CC Measurement EventLog ACPI Table
-//
-#define EFI_CC_EVENTLOG_ACPI_TABLE_SIGNATURE  SIGNATURE_32('C', 'C', 'E', 'L')
-#define EFI_CC_EVENTLOG_ACPI_TABLE_REVISION   1

--- a/MdePkg/Include/Protocol/CcMeasurement.h
+++ b/MdePkg/Include/Protocol/CcMeasurement.h
@@ -10,6 +10,7 @@
   capability.
 
 Copyright (c) 2020 - 2021, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2025, Arm Limited. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -58,6 +59,33 @@ typedef UINT32 EFI_CC_MR_INDEX;
 #define TDX_MR_INDEX_RTMR1  2
 #define TDX_MR_INDEX_RTMR2  3
 #define TDX_MR_INDEX_RTMR3  4
+
+/**
+  Macro definitions for mapping CC Measurement indices to Arm CCA
+  Realm measurement registers.
+
+  The mapping between the TPM PCR index and the Arm CCA Realm
+  Extensible measurement as defined by the UEFI specification
+  in section 38.4.3 Arm Confidential Compute Architecture Extension.
+
+  The following table shows the TPM PCR index mapping and CC event log
+  measurement register index interpretation for Arm CCA where:
+    - RIM means Realm Initial Measurement Register and
+    - REM means Realm Extensible Measurement Register
+
+  TPM PCR Index | CC Measurement  | Arm CCA-measurement |
+                | Register Index  |  register           |
+  -------------------------------------------------------
+  0             |   0             |   RIM               |
+  1, 7          |   1             |   REM[0]            |
+  2~6           |   2             |   REM[1]            |
+  8~15          |   3             |   REM[2]            |
+*/
+#define   ARMCCA_MR_INDEX_0_RIM    0
+#define   ARMCCA_MR_INDEX_1_REM0   1
+#define   ARMCCA_MR_INDEX_2_REM1   2
+#define   ARMCCA_MR_INDEX_3_REM2   3
+#define   ARMCCA_MR_INDEX_INVALID  4
 
 #define EFI_CC_EVENT_LOG_FORMAT_TCG_2  0x00000002
 #define EFI_CC_BOOT_HASH_ALG_SHA384    0x00000004

--- a/OvmfPkg/Tcg/TdTcg2Dxe/TdTcg2Dxe.c
+++ b/OvmfPkg/Tcg/TdTcg2Dxe/TdTcg2Dxe.c
@@ -108,20 +108,21 @@ VARIABLE_TYPE  mVariableType[] = {
   { EFI_IMAGE_SECURITY_DATABASE1, &gEfiImageSecurityDatabaseGuid },
 };
 
-EFI_CC_EVENTLOG_ACPI_TABLE  mTdxEventlogAcpiTemplate = {
+EFI_ACPI_6_5_CONFIDENTIAL_COMPUTING_EVENT_LOG_TABLE  mTdxEventlogAcpiTemplate = {
   {
-    EFI_CC_EVENTLOG_ACPI_TABLE_SIGNATURE,
+    EFI_ACPI_6_5_CONFIDENTIAL_COMPUTING_EVENT_LOG_TABLE_SIGNATURE,
     sizeof (mTdxEventlogAcpiTemplate),
-    EFI_CC_EVENTLOG_ACPI_TABLE_REVISION,
+    EFI_ACPI_6_5_CONFIDENTIAL_COMPUTING_EVENT_LOG_TABLE_REVISION,
     //
     // Compiler initializes the remaining bytes to 0
     // These fields should be filled in production
     //
   },
-  { EFI_CC_TYPE_TDX, 0 }, // CcType
-  0,                      // rsvd
-  0,                      // laml
-  0,                      // lasa
+  EFI_ACPI_6_5_CC_TYPE_TDX,        // CcType
+  0,                               // CC Sub Type
+  0,                               // Reserved
+  0,                               // laml
+  0,                               // lasa
 };
 
 EFI_HANDLE  mImageHandle;

--- a/SecurityPkg/Library/DxeTpm2MeasureBootLib/DxeTpm2MeasureBootLib.c
+++ b/SecurityPkg/Library/DxeTpm2MeasureBootLib/DxeTpm2MeasureBootLib.c
@@ -548,7 +548,7 @@ GetMeasureBootProtocols (
     ZeroMem (&CcProtocolCapability, sizeof (CcProtocolCapability));
     CcProtocolCapability.Size = sizeof (CcProtocolCapability);
     Status                    = CcProtocol->GetCapability (CcProtocol, &CcProtocolCapability);
-    if (EFI_ERROR (Status) || (CcProtocolCapability.CcType.Type == EFI_CC_TYPE_NONE)) {
+    if (EFI_ERROR (Status) || (CcProtocolCapability.CcType.Type == EFI_ACPI_6_5_CC_TYPE_NONE)) {
       DEBUG ((DEBUG_ERROR, " CcProtocol->GetCapability returns : %x, %r\n", CcProtocolCapability.CcType.Type, Status));
       CcProtocol = NULL;
     }


### PR DESCRIPTION
# Add CCEL and Arm CCA related definitions to MdePkg headers.

This series:
- Adds the ACPI 6.5 CCEL table signature definition.
- Aligns EFI_CC_EVENTLOG_ACPI_TABLE_SIGNATURE with the ACPI 6.5 CCEL signature.
- Adds EFI_CC_TYPE_ARMCCA.
- Defines Arm CCA measurement register index mappings for RIM/REM.
- Adds SHA-256 and SHA-512 CC measurement hash algorithm IDs.

These changes align EDK II industry-standard and CC measurement protocol headers with the ACPI 6.5 CCEL table and Arm CCA Code First specification proposals.

Note: This PR is a subset of the PR that tracks the enablement of measured boot support for Arm CCA https://github.com/tianocore/edk2/pull/12531

- [ ] Breaking change?
  - No
- [ ] Impacts security?
  - No
- [ ] Includes tests?
  - No

## How This Was Tested

Only build tested. Actual functionality can only be tested when the remaining patches from PR https://github.com/tianocore/edk2/pull/12224 are integrated in the future.

## Integration Instructions

N/A
