### PR TITLE
5259_arm_cca_measured_boot_v1_s3: Enable CCEL ACPI table parsing in Acpiview

### DIFF
--- a/ShellPkg/Library/UefiShellAcpiViewCommandLib/AcpiParser.c
+++ b/ShellPkg/Library/UefiShellAcpiViewCommandLib/AcpiParser.c
@@ -625,6 +625,53 @@ DumpReservedBits (
 }
 
 /**
+  This function validates reserved fields to check if they are 0.
+
+  @param [in] Ptr       Pointer to the start of the field data.
+  @param [in] Length    Length of the field.
+  @param [in] Context   Pointer to context specific information.
+**/
+VOID
+EFIAPI
+ValidateReserved (
+  IN UINT8   *Ptr,
+  IN UINT32  Length,
+  IN VOID    *Context
+  )
+{
+  while (Length > 0) {
+    if (Ptr[Length - 1] != 0) {
+      IncrementErrorCount ();
+      Print (L"\nERROR : Reserved field must be 0\n");
+      break;
+    }
+
+    Length--;
+  }
+}
+
+/**
+  This function validates bit-length reserved fields to check if they are 0.
+
+  @param [in] Ptr       Pointer to the start of the field data.
+  @param [in] Length    Length of the field.
+  @param [in] Context   Pointer to context specific information.
+**/
+VOID
+EFIAPI
+ValidateReservedBits (
+  IN UINT8   *Ptr,
+  IN UINT32  Length,
+  IN VOID    *Context
+  )
+{
+  UINT32  ByteLength;
+
+  ByteLength = (Length + 7) >> 3;
+  ValidateReserved (Ptr, ByteLength, Context);
+}
+
+/**
   This function indents and prints the ACPI table Field Name.
 
   @param [in] Indent      Number of spaces to add to the global table indent.

--- a/ShellPkg/Library/UefiShellAcpiViewCommandLib/AcpiParser.h
+++ b/ShellPkg/Library/UefiShellAcpiViewCommandLib/AcpiParser.h
@@ -699,6 +699,25 @@ ParseAcpiBgrt (
   );
 
 /**
+  This function parses the ACPI CCEL table.
+  When trace is enabled this function parses the CCEL table and
+  traces the ACPI table fields.
+
+  @param [in] Trace              If TRUE, trace the ACPI fields.
+  @param [in] Ptr                Pointer to the start of the buffer.
+  @param [in] AcpiTableLength    Length of the ACPI table.
+  @param [in] AcpiTableRevision  Revision of the ACPI table.
+**/
+VOID
+EFIAPI
+ParseAcpiCcel (
+  IN BOOLEAN  Trace,
+  IN UINT8    *Ptr,
+  IN UINT32   AcpiTableLength,
+  IN UINT8    AcpiTableRevision
+  );
+
+/**
   This function parses the ACPI DBG2 table.
   When trace is enabled this function parses the DBG2 table and
   traces the ACPI table fields.

--- a/ShellPkg/Library/UefiShellAcpiViewCommandLib/AcpiParser.h
+++ b/ShellPkg/Library/UefiShellAcpiViewCommandLib/AcpiParser.h
@@ -268,6 +268,36 @@ DumpReservedBits (
   );
 
 /**
+  This function validates reserved fields to check if they are 0.
+
+  @param [in] Ptr       Pointer to the start of the field data.
+  @param [in] Length    Length of the field.
+  @param [in] Context   Pointer to context specific information.
+**/
+VOID
+EFIAPI
+ValidateReserved (
+  IN UINT8   *Ptr,
+  IN UINT32  Length,
+  IN VOID    *Context
+  );
+
+/**
+  This function validates bit-length reserved fields to check if they are 0.
+
+  @param [in] Ptr       Pointer to the start of the field data.
+  @param [in] Length    Length of the field.
+  @param [in] Context   Pointer to context specific information.
+**/
+VOID
+EFIAPI
+ValidateReservedBits (
+  IN UINT8   *Ptr,
+  IN UINT32  Length,
+  IN VOID    *Context
+  );
+
+/**
   This function indents and prints the ACPI table Field Name.
 
   @param [in] Indent      Number of spaces to add to the global table

--- a/ShellPkg/Library/UefiShellAcpiViewCommandLib/AcpiTableParser.h
+++ b/ShellPkg/Library/UefiShellAcpiViewCommandLib/AcpiTableParser.h
@@ -10,7 +10,7 @@
 /**
   The maximum number of ACPI table parsers.
 */
-#define MAX_ACPI_TABLE_PARSERS  32
+#define MAX_ACPI_TABLE_PARSERS  128
 
 /** An invalid/NULL signature value.
 */

--- a/ShellPkg/Library/UefiShellAcpiViewCommandLib/Parsers/Agdi/AgdiParser.c
+++ b/ShellPkg/Library/UefiShellAcpiViewCommandLib/Parsers/Agdi/AgdiParser.c
@@ -43,34 +43,11 @@ ValidateSignalingFlags (
 }
 
 /**
-  Validate that the Reserved field has expected value.
-
-  @param [in] Ptr       Pointer to the start of the field data.
-  @param [in] Length    Length of the field.
-  @param [in] Context   Pointer to context specific information e.g. this
-                        could be a pointer to the ACPI table header.
-**/
-STATIC
-VOID
-EFIAPI
-ValidateResField (
-  IN UINT8   *Ptr,
-  IN UINT32  Length,
-  IN VOID    *Context
-  )
-{
-  if (*Ptr != 0) {
-    IncrementErrorCount ();
-    Print (L"\nERROR: Reserved bits in Flags must be 0");
-  }
-}
-
-/**
   An ACPI_PARSER array describing the AGDI Signaling Mode Flags field.
 **/
 STATIC CONST ACPI_PARSER  AgdiSignalingModeFlags[] = {
-  { L"Signaling Mode", 2, 0, L"%u", NULL, NULL, ValidateSignalingFlags, NULL },
-  { L"Reserved",       6, 2, L"%u", NULL, NULL, ValidateResField,       NULL },
+  { L"Signaling Mode", 2, 0, L"%u", NULL,             NULL, ValidateSignalingFlags, NULL },
+  { L"Reserved",       6, 2, NULL,  DumpReservedBits, NULL, ValidateReservedBits,   NULL },
 };
 
 /**

--- a/ShellPkg/Library/UefiShellAcpiViewCommandLib/Parsers/Ccel/CcelParser.c
+++ b/ShellPkg/Library/UefiShellAcpiViewCommandLib/Parsers/Ccel/CcelParser.c
@@ -1,0 +1,127 @@
+/** @file
+  CCEL table parser
+
+  Copyright (c) 2025, Arm Limited. All rights reserved.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+  @par Reference(s):
+    - ACPI 6.5 Specification - 29 Aug 2022
+**/
+
+#include <IndustryStandard/Acpi.h>
+#include <Library/UefiLib.h>
+#include "AcpiParser.h"
+#include "AcpiTableParser.h"
+#include "AcpiViewConfig.h"
+
+// Local variables.
+STATIC ACPI_DESCRIPTION_HEADER_INFO  AcpiHdrInfo;
+
+/**
+  Print the CC Type.
+
+  @param [in] Format  Optional format string for tracing the data.
+  @param [in] Ptr     Pointer to the start of the buffer.
+  @param [in] Length  Length of the field.
+**/
+VOID
+EFIAPI
+PrintCcType (
+  IN CONST CHAR16  *Format OPTIONAL,
+  IN UINT8         *Ptr,
+  IN UINT32        Length
+  )
+{
+  UINT8  CcType;
+
+  CcType = *Ptr;
+  switch (CcType) {
+    case EFI_ACPI_6_5_CC_TYPE_NONE:
+      Print (L"CC Type '%u' - None", CcType);
+      break;
+    case EFI_ACPI_6_5_CC_TYPE_SEV:
+      Print (L"CC Type '%u' - SEV", CcType);
+      break;
+    case EFI_ACPI_6_5_CC_TYPE_TDX:
+      Print (L"CC Type '%u' - TDX", CcType);
+      break;
+    case EFI_ACPI_6_5_CC_TYPE_APTEE:
+      Print (L"CC Type '%u' - APTEE", CcType);
+      break;
+    case EFI_ACPI_6_5_CC_TYPE_ARMCCA:
+      Print (L"CC Type '%u' - Arm CCA", CcType);
+      break;
+    default:
+      Print (L"CC Type '%u' - Unknown", CcType);
+  } // switch
+}
+
+/**
+  This function validates CC Type field.
+
+  @param [in] Ptr       Pointer to the start of the field data.
+  @param [in] Length    Length of the field.
+  @param [in] Context   Pointer to context specific information.
+**/
+VOID
+EFIAPI
+ValidateCcType (
+  IN UINT8   *Ptr,
+  IN UINT32  Length,
+  IN VOID    *Context
+  )
+{
+  UINT8  CcType;
+
+  CcType = *Ptr;
+
+  if (CcType > EFI_ACPI_6_5_CC_TYPE_ARMCCA) {
+    IncrementErrorCount ();
+    Print (L"\nERROR : Invalid/Unknown CC Type - %u.\n", CcType);
+  }
+}
+
+/**
+  An ACPI_PARSER array describing the ACPI CCEL Table.
+**/
+STATIC CONST ACPI_PARSER  CcelParser[] = {
+  PARSE_ACPI_HEADER (&AcpiHdrInfo),
+  { L"CC Type",                    1,  36, L"%d",    NULL,         NULL, NULL,             NULL },
+  { L"CC Subtype",                 1,  37, L"%d",    PrintCcType,  NULL, ValidateCcType,   NULL },
+  { L"Reserved",                   2,  38, NULL,     DumpReserved, NULL, ValidateReserved, NULL },
+  { L"Log Area Minimum Length (LAML)",8,  40, L"0x%lx", NULL,         NULL, NULL,             NULL },
+  { L"Log Area Start Address (LASA)",8,  48, L"0x%lx", NULL,         NULL, NULL,             NULL }
+};
+
+/**
+  This function parses the ACPI CCEL table.
+  When trace is enabled this function parses the CCEL table and
+  traces the ACPI table fields.
+
+  @param [in] Trace              If TRUE, trace the ACPI fields.
+  @param [in] Ptr                Pointer to the start of the buffer.
+  @param [in] AcpiTableLength    Length of the ACPI table.
+  @param [in] AcpiTableRevision  Revision of the ACPI table.
+**/
+VOID
+EFIAPI
+ParseAcpiCcel (
+  IN BOOLEAN  Trace,
+  IN UINT8    *Ptr,
+  IN UINT32   AcpiTableLength,
+  IN UINT8    AcpiTableRevision
+  )
+{
+  if (!Trace) {
+    return;
+  }
+
+  ParseAcpi (
+    TRUE,
+    0,
+    "CCEL",
+    Ptr,
+    AcpiTableLength,
+    PARSER_PARAMS (CcelParser)
+    );
+}

--- a/ShellPkg/Library/UefiShellAcpiViewCommandLib/Parsers/Mpam/MpamParser.c
+++ b/ShellPkg/Library/UefiShellAcpiViewCommandLib/Parsers/Mpam/MpamParser.c
@@ -71,61 +71,6 @@ MpamLengthError (
 }
 
 /**
-  This function validates reserved fields. Any reserved field within the MPAM
-  specification must be 0.
-
-  @param [in] Ptr       Pointer to the start of the field data.
-  @param [in] Length    Length of the field.
-  @param [in] Context   Pointer to context specific information. For this
-                        particular function, context holds the size of the
-                        reserved field that needs to be validated.
-**/
-STATIC
-VOID
-EFIAPI
-ValidateReserved (
-  IN UINT8   *Ptr,
-  IN UINT32  Length,
-  IN VOID    *Context
-  )
-{
-  while (Length > 0) {
-    if (Ptr[Length-1] != 0) {
-      IncrementErrorCount ();
-      Print (L"\nERROR : Reserved field must be 0\n");
-      break;
-    }
-
-    Length--;
-  }
-}
-
-/**
-  This function validates bit-length reserved fields. Any reserved field within
-  the MPAM specification must be 0.
-
-  @param [in] Ptr       Pointer to the start of the field data.
-  @param [in] Length    Length of the field.
-  @param [in] Context   Pointer to context specific information. For this
-                        particular function, context holds the size of the
-                        reserved field that needs to be validated.
-**/
-STATIC
-VOID
-EFIAPI
-ValidateReservedBits (
-  IN UINT8   *Ptr,
-  IN UINT32  Length,
-  IN VOID    *Context
-  )
-{
-  UINT32  ByteLength;
-
-  ByteLength = (Length + 7) >> 3;
-  ValidateReserved (Ptr, ByteLength, Context);
-}
-
-/**
   This function validates the MMIO size within the MSC node body for MPAM ACPI
   table. MPAM ACPI specification states that the MMIO size for an MSC having PCC
   type interface should be zero.

--- a/ShellPkg/Library/UefiShellAcpiViewCommandLib/Parsers/Wsmt/WsmtParser.c
+++ b/ShellPkg/Library/UefiShellAcpiViewCommandLib/Parsers/Wsmt/WsmtParser.c
@@ -50,40 +50,13 @@ ValidateWsmtProtectionFlag (
 }
 
 /**
-  This function validates the reserved bits in the WSMT Protection flag.
-
-  @param [in] Ptr     Pointer to the start of the buffer.
-  @param [in] Length  Length of the field.
-  @param [in] Context Pointer to context specific information e.g. this
-                      could be a pointer to the ACPI table header.
-**/
-STATIC
-VOID
-EFIAPI
-ValidateReserved (
-  IN UINT8   *Ptr,
-  IN UINT32  Length,
-  IN VOID    *Context
-  )
-{
-  UINT32  ProtectionFlag;
-
-  ProtectionFlag = *(UINT32 *)Ptr;
-
-  if ((ProtectionFlag & 0xFFFFFFF8) != 0) {
-    IncrementErrorCount ();
-    Print (L"ERROR: Reserved bits are not zero.\n");
-  }
-}
-
-/**
   An ACPI_PARSER array describing the WSMT Protection flag .
 **/
 STATIC CONST ACPI_PARSER  WsmtProtectionFlagParser[] = {
-  { L"FIXED_COMM_BUFFERS ",                1,  0, L"0x%x", NULL, NULL, NULL,             NULL },
-  { L"COMM_BUFFER_NESTED_PTR_PROTECTION ", 1,  1, L"0x%x", NULL, NULL, NULL,             NULL },
-  { L"SYSTEM_RESOURCE_PROTECTION ",        1,  2, L"0x%x", NULL, NULL, NULL,             NULL },
-  { L"Reserved ",                          29, 3, L"0x%x", NULL, NULL, ValidateReserved, NULL },
+  { L"FIXED_COMM_BUFFERS ",                1,  0, L"0x%x", NULL,             NULL, NULL,                 NULL },
+  { L"COMM_BUFFER_NESTED_PTR_PROTECTION ", 1,  1, L"0x%x", NULL,             NULL, NULL,                 NULL },
+  { L"SYSTEM_RESOURCE_PROTECTION ",        1,  2, L"0x%x", NULL,             NULL, NULL,                 NULL },
+  { L"Reserved ",                          29, 3, NULL,    DumpReservedBits, NULL, ValidateReservedBits, NULL },
 };
 
 /**

--- a/ShellPkg/Library/UefiShellAcpiViewCommandLib/UefiShellAcpiViewCommandLib.c
+++ b/ShellPkg/Library/UefiShellAcpiViewCommandLib/UefiShellAcpiViewCommandLib.c
@@ -55,6 +55,7 @@ ACPI_TABLE_PARSER  ParserList[] = {
   { EFI_ACPI_ARM_AGDI_TABLE_SIGNATURE,                                                                   ParseAcpiAgdi },
   { EFI_ACPI_6_4_ARM_PERFORMANCE_MONITORING_UNIT_TABLE_SIGNATURE,                                        ParseAcpiApmt },
   { EFI_ACPI_6_2_BOOT_GRAPHICS_RESOURCE_TABLE_SIGNATURE,                                                 ParseAcpiBgrt },
+  { EFI_ACPI_6_5_CONFIDENTIAL_COMPUTING_EVENT_LOG_TABLE_SIGNATURE,                                       ParseAcpiCcel },
   { EFI_ACPI_6_2_DEBUG_PORT_2_TABLE_SIGNATURE,                                                           ParseAcpiDbg2 },
   { EFI_ACPI_6_2_DIFFERENTIATED_SYSTEM_DESCRIPTION_TABLE_SIGNATURE,
     ParseAcpiDsdt },

--- a/ShellPkg/Library/UefiShellAcpiViewCommandLib/UefiShellAcpiViewCommandLib.inf
+++ b/ShellPkg/Library/UefiShellAcpiViewCommandLib/UefiShellAcpiViewCommandLib.inf
@@ -33,6 +33,7 @@
   Parsers/Agdi/AgdiParser.c
   Parsers/Apmt/ApmtParser.c
   Parsers/Bgrt/BgrtParser.c
+  Parsers/Ccel/CcelParser.c
   Parsers/Dbg2/Dbg2Parser.c
   Parsers/Dsdt/DsdtParser.c
   Parsers/Einj/EinjParser.c


### PR DESCRIPTION
# Enable CCEL ACPI table parsing in Acpiview

This PR enhances the AcpiView command in ShellPkg by addressing parser scalability limitations and adding support for a new ACPI table.

Firstly, it increases the maximum number of supported ACPI table parsers from 32 to 128. This change resolves EFI_OUT_OF_RESOURCES failures encountered in RegisterParser() due to exhaustion of the parser list.

Secondly, it adds support for parsing the CCEL (Confidential Compute Event Log) ACPI table introduced in the ACPI 6.5 specification. A new parser is implemented and registered, enabling users to decode and inspect CCEL table contents from the UEFI Shell.

Note: 
- This PR is a subset of the PR that tracks the enablement of measured boot support for Arm CCA https://github.com/tianocore/edk2/pull/12531
- This PR is dependent on https://github.com/tianocore/edk2/pull/12533 which must be merged before this PR can be merged. The CI builds will also not succeed until then.

- [ ] Breaking change?
  - No
- [ ] Impacts security?
  - No
- [ ] Includes tests?
  - No
  
## How This Was Tested

Only build tested. Actual functionality can only be tested when the remaining patches from PR https://github.com/tianocore/edk2/pull/12224 are integrated in the future.

## Integration Instructions

N/A