### PR TITLE
ManageabilityPkg: add configurable KCS status-check timeout PCD

### DIFF
--- a/ManageabilityPkg/Library/ManageabilityTransportKcsLib/BaseManageabilityTransportKcs.inf
+++ b/ManageabilityPkg/Library/ManageabilityTransportKcsLib/BaseManageabilityTransportKcs.inf
@@ -40,5 +40,6 @@
   gManageabilityProtocolIpmiGuid
 
 [FixedPcd]
-  gEfiMdePkgTokenSpaceGuid.PcdIpmiKcsIoBaseAddress   # Used as default KCS I/O base adddress
+  gEfiMdePkgTokenSpaceGuid.PcdIpmiKcsIoBaseAddress                        # Used as default KCS I/O base adddress
+  gManageabilityPkgTokenSpaceGuid.PcdKcsStatusCheckTimeout                 # Use the predefined timeout value in micro seconds
 

--- a/ManageabilityPkg/Library/ManageabilityTransportKcsLib/Dxe/DxeManageabilityTransportKcs.inf
+++ b/ManageabilityPkg/Library/ManageabilityTransportKcsLib/Dxe/DxeManageabilityTransportKcs.inf
@@ -40,5 +40,6 @@
   gManageabilityProtocolIpmiGuid
 
 [FixedPcd]
-  gEfiMdePkgTokenSpaceGuid.PcdIpmiKcsIoBaseAddress   # Used as default KCS I/O base adddress
+  gEfiMdePkgTokenSpaceGuid.PcdIpmiKcsIoBaseAddress                        # Used as default KCS I/O base adddress
+  gManageabilityPkgTokenSpaceGuid.PcdKcsStatusCheckTimeout                 # Use the predefined timeout value in micro seconds
 

--- a/ManageabilityPkg/Library/ManageabilityTransportKcsLib/KcsCommon.c
+++ b/ManageabilityPkg/Library/ManageabilityTransportKcsLib/KcsCommon.c
@@ -15,6 +15,7 @@
 #include <Library/ManageabilityTransportHelperLib.h>
 #include <Library/ManageabilityTransportMctpLib.h>
 #include <Library/MemoryAllocationLib.h>
+#include <Library/PcdLib.h>
 #include <Library/TimerLib.h>
 
 #include "ManageabilityTransportKcs.h"
@@ -41,7 +42,8 @@ WaitStatusSet (
   while ((KcsRegisterRead8 (KCS_REG_STATUS) & Flag) != TRUE) {
     MicroSecondDelay (IPMI_KCS_TIMEOUT_1MS);
     Timeout = Timeout + IPMI_KCS_TIMEOUT_1MS;
-    if (Timeout >= IPMI_KCS_TIMEOUT_5_SEC) {
+    if (Timeout >= PcdGet64 (PcdKcsStatusCheckTimeout)) {
+      DEBUG ((DEBUG_MANAGEABILITY, "%a: %d microseconds timeout expired in OBF check.\n", __func__, PcdGet64 (PcdKcsStatusCheckTimeout)));
       return EFI_TIMEOUT;
     }
   }
@@ -69,7 +71,8 @@ WaitStatusClear (
   while (KcsRegisterRead8 (KCS_REG_STATUS) & Flag) {
     MicroSecondDelay (IPMI_KCS_TIMEOUT_1MS);
     Timeout = Timeout + IPMI_KCS_TIMEOUT_1MS;
-    if (Timeout >= IPMI_KCS_TIMEOUT_5_SEC) {
+    if (Timeout >= PcdGet64 (PcdKcsStatusCheckTimeout)) {
+      DEBUG ((DEBUG_MANAGEABILITY, "%a: %d microseconds timeout expired in IBF check.\n", __func__, PcdGet64 (PcdKcsStatusCheckTimeout)));
       return EFI_TIMEOUT;
     }
   }

--- a/ManageabilityPkg/Library/ManageabilityTransportKcsLib/ManageabilityTransportKcs.h
+++ b/ManageabilityPkg/Library/ManageabilityTransportKcsLib/ManageabilityTransportKcs.h
@@ -34,9 +34,7 @@ typedef struct {
 
 #define MCTP_KCS_MTU_IN_POWER_OF_2  8
 
-/// 5 sec, according to IPMI spec
-#define IPMI_KCS_TIMEOUT_5_SEC  5000*1000
-#define IPMI_KCS_TIMEOUT_1MS    1000
+#define IPMI_KCS_TIMEOUT_1MS  1000
 
 /**
   This service communicates with BMC using KCS protocol.

--- a/ManageabilityPkg/ManageabilityPkg.dec
+++ b/ManageabilityPkg/ManageabilityPkg.dec
@@ -91,6 +91,9 @@
   ## This is the value of MCTP KCS I/O base address
   # @Prompt MCTP KCS (Memory mapped) I/O base address
   gManageabilityPkgTokenSpaceGuid.PcdMctpKcsBaseAddress|0xca2|UINT32|0x00000004
+  ## This is the timeout value for the KCS status check.
+  # @Prompt KCS interface status check timeout in microseconds.
+  gManageabilityPkgTokenSpaceGuid.PcdKcsStatusCheckTimeout|5000000|UINT64|0x00000005
 
   ## This value is the PLDM source and destination terminus ID for transmiting PLDM message.
   # @Prompt PLDM source terminus ID


### PR DESCRIPTION
Replace the hardcoded IPMI_KCS_TIMEOUT_5_SEC macro in WaitStatusSet() and WaitStatusClear() with PcdKcsStatusCheckTimeout so platform firmware can tune the KCS timeout without recompiling the library.

- ManageabilityPkg.dec: declare PcdKcsStatusCheckTimeout (UINT64, 5000000 us)
- KcsCommon.c: use PcdGet64(PcdKcsStatusCheckTimeout); add DEBUG on timeout
- ManageabilityTransportKcs.h: remove now-unused IPMI_KCS_TIMEOUT_5_SEC macro
- BaseManageabilityTransportKcs.inf, Dxe/DxeManageabilityTransportKcs.inf: add PcdKcsStatusCheckTimeout to [FixedPcd]

# Description
- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested
Tested with AMD platform.

## Integration Instructions
N/A

