### PR TITLE
NetworkPkg/UefiPxeBcDxe: Exit gracefully when PXE is disconnected

### DIFF
--- a/NetworkPkg/Mtftp4Dxe/Mtftp4Impl.c
+++ b/NetworkPkg/Mtftp4Dxe/Mtftp4Impl.c
@@ -1086,7 +1086,10 @@ EfiMtftp4Poll (
 
   Udp    = Instance->UnicastPort->Protocol.Udp4;
   Status = Udp->Poll (Udp);
-  Mtftp4OnTimerTick (NULL, Instance->Service);
+  if ((Instance->Token != NULL)) {
+    Mtftp4OnTimerTick (NULL, Instance->Service);
+  }
+
   return Status;
 }
 

--- a/NetworkPkg/UefiPxeBcDxe/PxeBcBoot.c
+++ b/NetworkPkg/UefiPxeBcDxe/PxeBcBoot.c
@@ -1060,6 +1060,12 @@ PxeBcUninstallCallback (
 {
   EFI_PXE_BASE_CODE_PROTOCOL  *PxeBc;
 
+  if ((Private == NULL) ||
+      (Private->Signature != PXEBC_PRIVATE_DATA_SIGNATURE))
+  {
+    return;
+  }
+
   PxeBc = &Private->PxeBc;
 
   if (NewMakeCallback) {

--- a/NetworkPkg/UefiPxeBcDxe/PxeBcDhcp4.c
+++ b/NetworkPkg/UefiPxeBcDxe/PxeBcDhcp4.c
@@ -1717,6 +1717,12 @@ PxeBcDhcp4Dora (
     goto ON_EXIT;
   }
 
+  if ((Private == NULL) ||
+      (Private->Signature != PXEBC_PRIVATE_DATA_SIGNATURE))
+  {
+    return Status;
+  }
+
   //
   // Get the acquired IPv4 address and store them.
   //
@@ -1749,6 +1755,13 @@ PxeBcDhcp4Dora (
   AsciiPrint ("\n");
 
 ON_EXIT:
+
+  if ((Private == NULL) ||
+      (Private->Signature != PXEBC_PRIVATE_DATA_SIGNATURE))
+  {
+    return Status;
+  }
+
   if (EFI_ERROR (Status)) {
     Dhcp4->Stop (Dhcp4);
     Dhcp4->Configure (Dhcp4, NULL);

--- a/NetworkPkg/UefiPxeBcDxe/PxeBcImpl.c
+++ b/NetworkPkg/UefiPxeBcDxe/PxeBcImpl.c
@@ -470,6 +470,10 @@ EfiPxeBcDhcp (
     Status = PxeBcDhcp4Dora (Private, Private->Dhcp4);
   }
 
+  if (Private->Signature != PXEBC_PRIVATE_DATA_SIGNATURE) {
+    return Status;
+  }
+
   //
   // Reconfigure the UDP instance with the default configuration.
   //
@@ -1005,6 +1009,10 @@ EfiPxeBcMtftp (
       Status = EFI_INVALID_PARAMETER;
 
       break;
+  }
+
+  if (Status == EFI_DEVICE_ERROR) {
+    return Status;
   }
 
   if (Status == EFI_ICMP_ERROR) {
@@ -2427,6 +2435,10 @@ EfiPxeLoadFile (
     //   2. success to get file size.
     //   3. unsupported.
     //
+    if (PxeBc->Revision != EFI_PXE_BASE_CODE_PROTOCOL_REVISION) {
+      return Status;
+    }
+
     PxeBc->Stop (PxeBc);
   } else {
     //

--- a/NetworkPkg/UefiPxeBcDxe/PxeBcMtftp.c
+++ b/NetworkPkg/UefiPxeBcDxe/PxeBcMtftp.c
@@ -753,7 +753,14 @@ PxeBcMtftp4ReadFile (
   UINT8                WindowsizeBuf[10];
   EFI_STATUS           Status;
 
-  Status                    = EFI_DEVICE_ERROR;
+  Status = EFI_DEVICE_ERROR;
+
+  if ((Private == NULL) ||
+      (Private->Signature != PXEBC_PRIVATE_DATA_SIGNATURE))
+  {
+    return Status;
+  }
+
   Mtftp4                    = Private->Mtftp4;
   OptCnt                    = 0;
   Config->InitialServerPort = PXEBC_BS_DOWNLOAD_PORT;
@@ -798,6 +805,11 @@ PxeBcMtftp4ReadFile (
   Token.PacketNeeded    = NULL;
 
   Status = Mtftp4->ReadFile (Mtftp4, &Token);
+
+  if (Private->Signature != PXEBC_PRIVATE_DATA_SIGNATURE) {
+    return EFI_DEVICE_ERROR;
+  }
+
   //
   // Get the real size of received buffer.
   //


### PR DESCRIPTION
This PR resolves [[Issue #12390](https://github.com/tianocore/edk2/issues/12390)], where PXE boot crashes occur in NetworkPkg when the network link disconnects during NBP (Network Boot Program) download. The root cause is invalid or NULL private data access triggered by unexpected PXE disconnection.

Description
- Added validation checks to ensure private data structures are valid before use.
- Improved error handling in DHCP and MTFTP flows to return meaningful status codes instead of crashing.
- Updated driver logic to exit gracefully when PXE is disconnected, preventing hangs and resource leaks.
- These changes strengthen PXE boot reliability by ensuring the system handles disconnect scenarios cleanly.

- [ ] Breaking change?
No. This update does not introduce new library classes or move modules; it only enhances existing driver behavior.
- [ ] Impacts security?
No. This change does not affect cryptographic algorithms or security-sensitive code paths.
- [ ] Includes tests?
No explicit tests included. Validation was performed through functional boot testing.
## How This Was Tested

Functional boot testing was performed by reproducing the issue as below
- Start a PXE boot installation.
- Disconnect the PXE cable mid‑installation.
- Verified that Mtftp4Dxe and UefiPxeBcDxe exit gracefully without hangs or resource leaks.
- Confirmed normal PXE boot continues to work when PXE remains connected.

## Integration Instructions
- Consumers of NetworkPkg can integrate these changes directly.
- No build or configuration changes are needed.