### PR TITLE
DynamicTablesPkg: Adds ACPI EINJ Table generation support

### DIFF
--- a/DynamicTablesPkg/DynamicTables.dsc.inc
+++ b/DynamicTablesPkg/DynamicTables.dsc.inc
@@ -47,6 +47,7 @@
   DynamicTablesPkg/Library/Acpi/Common/AcpiSlitLib/AcpiSlitLib.inf
   DynamicTablesPkg/Library/Acpi/Common/AcpiSpmiLib/AcpiSpmiLib.inf
   DynamicTablesPkg/Library/Acpi/Common/AcpiHestLib/AcpiHestLib.inf
+  DynamicTablesPkg/Library/Acpi/Common/AcpiEinjLib/AcpiEinjLib.inf
 
   # AML Fixup (Common)
   DynamicTablesPkg/Library/Acpi/Common/AcpiSsdtSerialPortLib/SsdtSerialPortLib.inf
@@ -135,6 +136,7 @@
       NULL|DynamicTablesPkg/Library/Acpi/Common/AcpiSratLib/AcpiSratLib.inf
       NULL|DynamicTablesPkg/Library/Acpi/Common/AcpiTpm2Lib/AcpiTpm2Lib.inf
       NULL|DynamicTablesPkg/Library/Acpi/Common/AcpiHestLib/AcpiHestLib.inf
+      NULL|DynamicTablesPkg/Library/Acpi/Common/AcpiEinjLib/AcpiEinjLib.inf
       #   Arm specific
       NULL|DynamicTablesPkg/Library/Acpi/Arm/AcpiGtdtLibArm/AcpiGtdtLibArm.inf
       NULL|DynamicTablesPkg/Library/Acpi/Arm/AcpiIortLibArm/AcpiIortLibArm.inf

--- a/DynamicTablesPkg/Include/AcpiTableGenerator.h
+++ b/DynamicTablesPkg/Include/AcpiTableGenerator.h
@@ -89,6 +89,8 @@ The Dynamic Tables Framework implements the following ACPI table generators:
             Configuration Manager and builds the SLIT table.
   - HEST  : The HEST generator collates the HEST information from the
             Configuration Manager and builds the HEST table.
+  - EINJ  : The EINJ generator collates the required platform information from
+            the Configuration Manager and builds the EINJ table.
 */
 
 /** The ACPI_TABLE_GENERATOR_ID type describes ACPI table generator ID.
@@ -129,6 +131,7 @@ typedef enum StdAcpiTableId {
   EStdAcpiTableIdRhct,                          ///< RHCT Generator
   EStdAcpiTableIdSsdtDmc620Pmu,                 ///< SSDT DMC620 PMU Generator
   EStdAcpiTableIdHest,                          ///< Hest Generator
+  EStdAcpiTableIdEinj,                          ///< EINJ Generator
   EStdAcpiTableIdMax
 } ESTD_ACPI_TABLE_ID;
 

--- a/DynamicTablesPkg/Include/ArchCommonNameSpaceObjects.h
+++ b/DynamicTablesPkg/Include/ArchCommonNameSpaceObjects.h
@@ -78,6 +78,7 @@ typedef enum ArchCommonObjectID {
   EArchCommonObjErrSourcePciBridgeInfo,         ///< 51 - PCI Express AER Info for Bridge
   EArchCommonObjErrSourceGenericHwInfo,         ///< 52 - Generic Hardware Error Source Info
   EArchCommonObjErrSourceGenericHwVer2Info,     ///< 53 - Generic Hardware Error Source Info version 2
+  EArchCommonObjEinjInstructionsInfo,           ///< 54 - Einj Instruction Info
   EArchCommonObjMax
 } EARCH_COMMON_OBJECT_ID;
 
@@ -1285,5 +1286,19 @@ typedef struct CmArchCommonObjErrSourceGenericHwVer2Info {
   /// (v2) Contains a mask of bits to set when writing the Read Ack register.
   UINT64                                    ReadAckWrite;
 } CM_ARCH_COMMON_ERROR_SOURCE_GENERIC_HW_VERSION_2_INFO;
+
+/** A structure that describes a
+    Einj Instruction Entry.
+
+    ID: EArchCommonObjEinjInstructionsInfo
+*/
+typedef struct {
+  UINT8                                     InjectionAction;
+  UINT8                                     Instruction;
+  UINT8                                     Flags;
+  EFI_ACPI_6_5_GENERIC_ADDRESS_STRUCTURE    RegisterRegion;
+  UINT64                                    Value;
+  UINT64                                    Mask;
+} CM_ARCH_COMMON_EINJ_INSTRUCTIONS_INFO;
 
 #pragma pack()

--- a/DynamicTablesPkg/Include/TableGenerator.h
+++ b/DynamicTablesPkg/Include/TableGenerator.h
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2017 - 2019, ARM Limited. All rights reserved.
+  Copyright (c) 2017 - 2026, ARM Limited. All rights reserved.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -72,6 +72,7 @@ _______________________________________________________________________________
       25 - RHCT
       26 - SSDT DMC
       27 - HEST
+      28 - EINJ
 
     Standard SMBIOS Table IDs:
        0 - Reserved

--- a/DynamicTablesPkg/Library/Acpi/Common/AcpiEinjLib/AcpiEinjLib.inf
+++ b/DynamicTablesPkg/Library/Acpi/Common/AcpiEinjLib/AcpiEinjLib.inf
@@ -1,0 +1,29 @@
+## @file
+#  Einj Table Generator
+#
+#  Copyright (c) 2026, Arm Limited. All rights reserved.<BR>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION    = 0x0001001B
+  BASE_NAME      = AcpiEinjLib
+  FILE_GUID      = 5F2C3A9E-8C7B-4F0E-9A53-0B7C2D1F6E84
+  VERSION_STRING = 1.0
+  MODULE_TYPE    = DXE_DRIVER
+  LIBRARY_CLASS  = NULL|DXE_DRIVER
+  CONSTRUCTOR    = AcpiEinjLibConstructor
+  DESTRUCTOR     = AcpiEinjLibDestructor
+
+[Sources]
+  EinjGenerator.c
+
+[Packages]
+  DynamicTablesPkg/DynamicTablesPkg.dec
+  EmbeddedPkg/EmbeddedPkg.dec
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+
+[LibraryClasses]
+  BaseLib

--- a/DynamicTablesPkg/Library/Acpi/Common/AcpiEinjLib/EinjGenerator.c
+++ b/DynamicTablesPkg/Library/Acpi/Common/AcpiEinjLib/EinjGenerator.c
@@ -1,0 +1,392 @@
+/** @file
+  EINJ Table Generator
+
+  Copyright (c) 2026, ARM Limited. All rights reserved.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+  @par Reference(s):
+  - ACPI 6.5 Specification, August 2022
+
+  @par Glossary:
+  - Cm or CM   - Configuration Manager
+  - Obj or OBJ - Object
+**/
+#include <Library/AcpiLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
+#include <Library/MemoryAllocationLib.h>
+
+// Module specific include files.
+#include <AcpiTableGenerator.h>
+#include <ConfigurationManagerObject.h>
+#include <ConfigurationManagerHelper.h>
+#include <Protocol/ConfigurationManagerProtocol.h>
+#include <Library/TableHelperLib.h>
+
+/** ARM standard EINJ Generator
+
+Requirements:
+  The following Configuration Manager Object(s) are required by
+  this Generator:
+  - EArchCommonObjEinjInstructionsInfo
+*/
+
+/** This macro expands to a function that retrieves the EINJ
+    Instruction Entry Information from the Configuration Manager.
+**/
+GET_OBJECT_LIST (
+  EObjNameSpaceArchCommon,
+  EArchCommonObjEinjInstructionsInfo,
+  CM_ARCH_COMMON_EINJ_INSTRUCTIONS_INFO
+  );
+
+/** Populate the EINJ injection instruction entry list.
+
+  @param [in] Einj              Pointer to the first injection instruction
+                                entry (i.e. immediately after the EINJ header).
+  @param [in] Instructions      Pointer to the CM instruction entry array.
+  @param [in] InstructionsCount Number of entries in Instructions.
+
+  @retval EFI_SUCCESS           Entries populated successfully.
+  @retval EFI_INVALID_PARAMETER A parameter is invalid.
+**/
+STATIC
+EFI_STATUS
+EFIAPI
+PopulateEinjTable (
+  IN  VOID                                   *Einj,
+  IN  CM_ARCH_COMMON_EINJ_INSTRUCTIONS_INFO  *Instructions,
+  IN  UINT32                                 InstructionsCount
+  )
+{
+  UINT32                                         Index;
+  EFI_ACPI_6_5_EINJ_INJECTION_INSTRUCTION_ENTRY  *EinjAcpi;
+
+  ASSERT (Einj != NULL);
+  ASSERT (Instructions != NULL);
+
+  EinjAcpi = (EFI_ACPI_6_5_EINJ_INJECTION_INSTRUCTION_ENTRY *)Einj;
+
+  for (Index = 0; Index < InstructionsCount; Index++) {
+    if (Instructions->InjectionAction > EFI_ACPI_6_5_EINJ_EINJV2_GET_ERROR_TYPE) {
+      DEBUG ((
+        DEBUG_ERROR,
+        "ERROR: EINJ: Instructions->InjectionAction value = %d, is not supported.\n",
+        Instructions->InjectionAction
+        ));
+      return EFI_INVALID_PARAMETER;
+    }
+
+    if (Instructions->Instruction > EFI_ACPI_6_5_EINJ_NOOP) {
+      DEBUG ((
+        DEBUG_ERROR,
+        "ERROR: EINJ: Instructions->Instruction value = %d, is not supported.\n",
+        Instructions->Instruction
+        ));
+      return EFI_INVALID_PARAMETER;
+    }
+
+    if ((Instructions->Flags & ~EFI_ACPI_6_5_EINJ_PRESERVE_REGISTER) != 0) {
+      return EFI_INVALID_PARAMETER;
+    }
+
+    if ((Instructions->RegisterRegion.AddressSpaceId != EFI_ACPI_6_5_SYSTEM_MEMORY) &&
+        (Instructions->RegisterRegion.AddressSpaceId != EFI_ACPI_6_5_SYSTEM_IO))
+    {
+      DEBUG ((
+        DEBUG_ERROR,
+        "ERROR: EINJ: Instructions->RegisterRegion.AddressSpaceId value = %d, is not supported.\n",
+        Instructions->RegisterRegion.AddressSpaceId
+        ));
+      return EFI_INVALID_PARAMETER;
+    }
+
+    if ((Instructions->Mask >> Instructions->RegisterRegion.RegisterBitWidth) != 0) {
+      return EFI_INVALID_PARAMETER;
+    }
+
+    EinjAcpi->InjectionAction = Instructions->InjectionAction;
+    EinjAcpi->Instruction     = Instructions->Instruction;
+    EinjAcpi->Flags           = Instructions->Flags;
+    EinjAcpi->Value           = Instructions->Value;
+    EinjAcpi->Mask            = Instructions->Mask;
+
+    CopyMem (
+      &EinjAcpi->RegisterRegion,
+      &Instructions->RegisterRegion,
+      sizeof (EFI_ACPI_6_5_GENERIC_ADDRESS_STRUCTURE)
+      );
+
+    Instructions++;
+    EinjAcpi++;
+  }
+
+  return EFI_SUCCESS;
+}
+
+/** Construct the EINJ ACPI table.
+
+  Called by the Dynamic Table Manager, this function invokes the
+  Configuration Manager protocol interface to get the required hardware
+  information for generating the ACPI table.
+
+  If this function allocates any resources then they must be freed
+  in the FreeXXXXTableResources function.
+
+  @param [in]  This           Pointer to the table generator.
+  @param [in]  AcpiTableInfo  Pointer to the ACPI Table Info.
+  @param [in]  CfgMgrProtocol Pointer to the Configuration Manager
+                              Protocol Interface.
+  @param [out] Table          Pointer to the constructed ACPI Table.
+
+  @retval EFI_SUCCESS           Table generated successfully.
+  @retval EFI_INVALID_PARAMETER A parameter is invalid.
+  @retval EFI_NOT_FOUND         The required object was not found.
+  @retval EFI_BAD_BUFFER_SIZE   The size returned by the Configuration
+                                Manager is less than the Object size for the
+                                requested object.
+  @retval EFI_BUFFER_TOO_SMALL   Buffer too small.
+  @retval EFI_OUT_OF_RESOURCES  Memory allocation failed.
+**/
+STATIC
+EFI_STATUS
+EFIAPI
+BuildEinjTable (
+  IN  CONST ACPI_TABLE_GENERATOR                  *CONST  This,
+  IN  CONST CM_STD_OBJ_ACPI_TABLE_INFO            *CONST  AcpiTableInfo,
+  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST  CfgMgrProtocol,
+  OUT       EFI_ACPI_DESCRIPTION_HEADER          **CONST  Table
+  )
+{
+  EFI_STATUS                                 Status;
+  CM_ARCH_COMMON_EINJ_INSTRUCTIONS_INFO      *EinjInstructions;
+  UINT32                                     EinjInstructionsCount;
+  UINT32                                     TableSize;
+  UINT8                                      *Buffer;
+  EFI_ACPI_6_5_ERROR_INJECTION_TABLE_HEADER  *Einj;
+
+  ASSERT (This != NULL);
+  ASSERT (AcpiTableInfo != NULL);
+  ASSERT (CfgMgrProtocol != NULL);
+  ASSERT (Table != NULL);
+  ASSERT (AcpiTableInfo->TableGeneratorId == This->GeneratorID);
+  ASSERT (AcpiTableInfo->AcpiTableSignature == This->AcpiTableSignature);
+
+  if ((AcpiTableInfo->AcpiTableRevision < This->MinAcpiTableRevision) ||
+      (AcpiTableInfo->AcpiTableRevision > This->AcpiTableRevision))
+  {
+    DEBUG ((
+      DEBUG_ERROR,
+      "ERROR: EINJ: Requested table revision = %d, is not supported."
+      "Supported table revisions: Min = %d, Max = %d\n",
+      AcpiTableInfo->AcpiTableRevision,
+      This->MinAcpiTableRevision,
+      This->AcpiTableRevision
+      ));
+    ASSERT_EFI_ERROR (EFI_INVALID_PARAMETER);
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Status = GetEArchCommonObjEinjInstructionsInfo (
+             CfgMgrProtocol,
+             CM_NULL_TOKEN,
+             &EinjInstructions,
+             &EinjInstructionsCount
+             );
+  if ((Status == EFI_NOT_FOUND) ||
+      (EinjInstructionsCount == 0))
+  {
+    DEBUG ((DEBUG_INFO, "EINJ: No instruction entries found; skipping table.\n"));
+    return EFI_NOT_FOUND;
+  }
+
+  if (EFI_ERROR (Status)) {
+    ASSERT_EFI_ERROR (Status);
+    return Status;
+  }
+
+  TableSize  = sizeof (EFI_ACPI_6_5_ERROR_INJECTION_TABLE_HEADER);
+  TableSize += EinjInstructionsCount * sizeof (EFI_ACPI_6_5_EINJ_INJECTION_INSTRUCTION_ENTRY);
+
+  // Allocate a Buffer for the EINJ table.
+  *Table = (EFI_ACPI_DESCRIPTION_HEADER *)AllocateZeroPool (TableSize);
+  if (*Table == NULL) {
+    Status = EFI_OUT_OF_RESOURCES;
+    ASSERT_EFI_ERROR (Status);
+    goto error_handler;
+  }
+
+  Einj = (EFI_ACPI_6_5_ERROR_INJECTION_TABLE_HEADER *)*Table;
+
+  Status = AddAcpiHeader (
+             CfgMgrProtocol,
+             This,
+             &Einj->Header,
+             AcpiTableInfo,
+             TableSize
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "ERROR: EINJ: Failed to add ACPI header. Status = %r\n",
+      Status
+      ));
+    ASSERT_EFI_ERROR (Status);
+    goto error_handler;
+  }
+
+  Buffer  = (UINT8 *)Einj;
+  Buffer += sizeof (EFI_ACPI_6_5_ERROR_INJECTION_TABLE_HEADER);
+
+  Status = PopulateEinjTable (
+             Buffer,
+             EinjInstructions,
+             EinjInstructionsCount
+             );
+  if (EFI_ERROR (Status)) {
+    ASSERT_EFI_ERROR (Status);
+    goto error_handler;
+  }
+
+  Einj->InjectionEntryCount = EinjInstructionsCount;
+  Einj->InjectionHeaderSize =
+    sizeof (EFI_ACPI_6_5_ERROR_INJECTION_TABLE_HEADER) -
+    sizeof (EFI_ACPI_DESCRIPTION_HEADER);
+
+  return EFI_SUCCESS;
+
+error_handler:
+  DEBUG ((
+    DEBUG_ERROR,
+    "ERROR: EINJ: Failed to build table. Status = %r\n",
+    Status
+    ));
+
+  if (*Table != NULL) {
+    FreePool (*Table);
+    *Table = NULL;
+  }
+
+  return Status;
+}
+
+/** Free any resources allocated for constructing the EINJ.
+
+  @param [in]      This           Pointer to the table generator.
+  @param [in]      AcpiTableInfo  Pointer to the ACPI Table Info.
+  @param [in]      CfgMgrProtocol Pointer to the Configuration Manager
+                                  Protocol Interface.
+  @param [in, out] Table          Pointer to the ACPI Table.
+
+  @retval EFI_SUCCESS           The resources were freed successfully.
+  @retval EFI_INVALID_PARAMETER The table pointer is NULL or invalid.
+**/
+STATIC
+EFI_STATUS
+EFIAPI
+FreeEinjTableResources (
+  IN      CONST ACPI_TABLE_GENERATOR                  *CONST  This,
+  IN      CONST CM_STD_OBJ_ACPI_TABLE_INFO            *CONST  AcpiTableInfo,
+  IN      CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST  CfgMgrProtocol,
+  IN OUT        EFI_ACPI_DESCRIPTION_HEADER          **CONST  Table
+  )
+{
+  ASSERT (This != NULL);
+  ASSERT (AcpiTableInfo != NULL);
+  ASSERT (CfgMgrProtocol != NULL);
+  ASSERT (AcpiTableInfo->TableGeneratorId == This->GeneratorID);
+  ASSERT (AcpiTableInfo->AcpiTableSignature == This->AcpiTableSignature);
+
+  if ((Table == NULL) || (*Table == NULL)) {
+    DEBUG ((DEBUG_ERROR, "ERROR: EINJ: Invalid Table Pointer\n"));
+    ASSERT ((Table != NULL) && (*Table != NULL));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  FreePool (*Table);
+  *Table = NULL;
+  return EFI_SUCCESS;
+}
+
+/** This macro defines the EINJ Table Generator revision.
+*/
+#define EINJ_GENERATOR_REVISION  CREATE_REVISION (1, 0)
+
+/** The interface for the EINJ Table Generator.
+*/
+STATIC
+CONST
+ACPI_TABLE_GENERATOR  EinjGenerator = {
+  // Generator ID
+  CREATE_STD_ACPI_TABLE_GEN_ID (EStdAcpiTableIdEinj),
+  // Generator Description
+  L"ACPI.STD.EINJ.GENERATOR",
+  // ACPI Table Signature
+  EFI_ACPI_6_5_ERROR_INJECTION_TABLE_SIGNATURE,
+  // ACPI Table Revision supported by this Generator
+  EFI_ACPI_6_5_ERROR_INJECTION_TABLE_REVISION,
+  // Minimum ACPI Table Revision supported by this Generator
+  EFI_ACPI_6_5_ERROR_INJECTION_TABLE_REVISION,
+  // Creator ID
+  TABLE_GENERATOR_CREATOR_ID,
+  // Creator Revision
+  EINJ_GENERATOR_REVISION,
+  // Build Table function
+  BuildEinjTable,
+  // Free Resource function
+  FreeEinjTableResources,
+  // Extended build function not needed
+  NULL,
+  // Extended build function not implemented by the generator.
+  // Hence extended free resource function is not required.
+  NULL
+};
+
+/** Register the Generator with the ACPI Table Factory.
+
+  @param [in]  ImageHandle  The handle to the image.
+  @param [in]  SystemTable  Pointer to the System Table.
+
+  @retval EFI_SUCCESS           The Generator is registered.
+  @retval EFI_INVALID_PARAMETER A parameter is invalid.
+  @retval EFI_ALREADY_STARTED   The Generator for the Table ID
+                                is already registered.
+**/
+EFI_STATUS
+EFIAPI
+AcpiEinjLibConstructor (
+  IN  EFI_HANDLE        ImageHandle,
+  IN  EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  EFI_STATUS  Status;
+
+  Status = RegisterAcpiTableGenerator (&EinjGenerator);
+  DEBUG ((DEBUG_INFO, "EINJ: Register Generator. Status = %r\n", Status));
+  ASSERT_EFI_ERROR (Status);
+  return Status;
+}
+
+/** Deregister the Generator from the ACPI Table Factory.
+
+  @param [in]  ImageHandle  The handle to the image.
+  @param [in]  SystemTable  Pointer to the System Table.
+
+  @retval EFI_SUCCESS           The Generator is deregistered.
+  @retval EFI_INVALID_PARAMETER A parameter is invalid.
+  @retval EFI_NOT_FOUND         The Generator is not registered.
+**/
+EFI_STATUS
+EFIAPI
+AcpiEinjLibDestructor (
+  IN  EFI_HANDLE        ImageHandle,
+  IN  EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  EFI_STATUS  Status;
+
+  Status = DeregisterAcpiTableGenerator (&EinjGenerator);
+  DEBUG ((DEBUG_INFO, "EINJ: Deregister Generator. Status = %r\n", Status));
+  ASSERT_EFI_ERROR (Status);
+  return Status;
+}

--- a/DynamicTablesPkg/Library/Common/TableHelperLib/ConfigurationManagerObjectParser.c
+++ b/DynamicTablesPkg/Library/Common/TableHelperLib/ConfigurationManagerObjectParser.c
@@ -1115,6 +1115,19 @@ STATIC CONST CM_OBJ_PARSER  CmArchCommonObjErrSourceGenericHwVer2InfoParser[] = 
   { "ReadAckWrite",    8,                                              "0x%llx",  NULL },
 };
 
+/** A parser for CmArchCommonObjEinjInstructionsInfo
+*/
+STATIC CONST CM_OBJ_PARSER  CmArchCommonObjEinjInstructionsInfoParser[] = {
+  { "InjectionAction", 1,                                               "0x%x",   NULL },
+  { "Instruction",     1,                                               "0x%x",   NULL },
+  { "Flags",           1,                                               "0x%x",   NULL },
+  { "RegisterRegion",  sizeof (EFI_ACPI_6_5_GENERIC_ADDRESS_STRUCTURE),
+    NULL, NULL, AcpiGenericAddressParser,
+    ARRAY_SIZE (AcpiGenericAddressParser) },
+  { "Value",           8,                                               "0x%llx", NULL },
+  { "Mask",            8,                                               "0x%llx", NULL },
+};
+
 /** A parser for Arch Common namespace objects.
 */
 STATIC CONST CM_OBJ_PARSER_ARRAY  ArchCommonNamespaceObjectParser[] = {
@@ -1172,6 +1185,7 @@ STATIC CONST CM_OBJ_PARSER_ARRAY  ArchCommonNamespaceObjectParser[] = {
   CM_PARSER_ADD_OBJECT (EArchCommonObjErrSourcePciBridgeInfo,       CmArchCommonObjErrSourcePciBridgeInfoParser),
   CM_PARSER_ADD_OBJECT (EArchCommonObjErrSourceGenericHwInfo,       CmArchCommonObjErrSourceGenericHwInfoParser),
   CM_PARSER_ADD_OBJECT (EArchCommonObjErrSourceGenericHwVer2Info,   CmArchCommonObjErrSourceGenericHwVer2InfoParser),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjEinjInstructionsInfo,         CmArchCommonObjEinjInstructionsInfoParser),
   CM_PARSER_ADD_OBJECT_RESERVED (EArchCommonObjMax)
 };
 

--- a/DynamicTablesPkg/Readme.md
+++ b/DynamicTablesPkg/Readme.md
@@ -76,6 +76,7 @@ The framework currently supports the following table generators:
 * RHCT - RISC-V Hart Capabilities Table
 * SSDT DMC
 * HEST - Hardware Error Source Table
+* EINJ - APEI Error Injection Table
 
 ## Dynamic AML
 


### PR DESCRIPTION
Add an ACPI Error Injection (EINJ) table generator that uses the Configuration Manager to obtain the platform error-injection instruction entries.

Ref: ACPI Specification, Section 18.6 (Error Injection—EINJ table).