### PR TITLE
DynamicTablesPkg: Sync documented ACPI table generator lists

### DIFF
--- a/DynamicTablesPkg/Include/TableGenerator.h
+++ b/DynamicTablesPkg/Include/TableGenerator.h
@@ -45,16 +45,32 @@ _______________________________________________________________________________
 
     Standard ACPI Table IDs:
        0 - Reserved
-       1 - RAW
+       1 - RAW, DSDT, SSDT
        2 - FADT
-       3 - DSDT
-       4 - SSDT
-       5 - MADT
-       6 - GTDT
-       7 - DBG2
-       8 - SPCR
-       9 - MCFG
-      10 - PPTT
+       3 - MADT
+       4 - GTDT
+       5 - DBG2
+       6 - SPCR
+       7 - MCFG
+       8 - IORT
+       9 - PPTT
+      10 - SRAT
+      11 - SSDT Serial Port
+      12 - SSDT CMN
+      13 - SSDT Cpu
+      14 - SSDT Pcie
+      15 - SSDT Plic/Aplic
+      16 - PCCT
+      17 - TPM2
+      18 - WSMT
+      19 - HPET
+      20 - SSDT HPET
+      21 - SPMI
+      22 - FACS
+      23 - CEDT
+      24 - SLIT
+      25 - RHCT
+      26 - SSDT DMC
       27 - HEST
 
     Standard SMBIOS Table IDs:

--- a/DynamicTablesPkg/Readme.md
+++ b/DynamicTablesPkg/Readme.md
@@ -43,22 +43,38 @@ generators implement the functionality required for ARM architecture;
 the framework is extensible, and support for other architectures can
 be added easily.
 
-The framework currently supports the following table generators for ARM:
-* DBG2 - Debug Port Table 2
+The framework currently supports the following table generators:
+
 * DSDT - Differentiated system description table. This is essentially
          a RAW table generator.
-* FADT - Fixed ACPI Description Table
-* GTDT - Generic Timer Description Table
-* IORT - IO Remapping Table
-* MADT - Multiple APIC Description Table
-* MCFG - PCI Express memory mapped configuration space base address
-         Description Table
-* PCCT - Platform Communications Channel Table
-* PPTT - Processor Properties Topology Table
-* SPCR - Serial Port Console Redirection Table
-* SRAT - System Resource Affinity Table
 * SSDT - Secondary System Description Table. This is essentially
          a RAW table generator.
+* MADT - Multiple APIC Description Table
+* GTDT - Generic Timer Description Table
+* DBG2 - Debug Port Table 2
+* SPCR - Serial Port Console Redirection Table
+* MCFG - PCI Express memory mapped configuration space base address
+         Description Table
+* IORT - IO Remapping Table
+* PPTT - Processor Properties Topology Table
+* SRAT - System Resource Affinity Table
+* SSDT Serial Port
+* SSDT CMN
+* SSDT Cpu
+* SSDT Pcie
+* SSDT Plic/Aplic
+* PCCT - Platform Communications Channel Table
+* FADT - Fixed ACPI Description Table
+* TPM2 - Trusted Platform Module 2 Table
+* WSMT - Windows Security Mitigation Table
+* HPET - IA-PC High Precision Event Timer Table
+* SSDT HPET
+* SPMI - Server Platform Management Interface Table
+* FACS - Firmware ACPI Control Structure
+* CEDT - CXL Early Discovery Table
+* SLIT - System Locality Information Table
+* RHCT - RISC-V Hart Capabilities Table
+* SSDT DMC
 * HEST - Hardware Error Source Table
 
 ## Dynamic AML


### PR DESCRIPTION
DynamicTablesPkg: Sync documented ACPI table generator lists

Update the DynamicTablesPkg documentation for standard ACPI table
generators so it matches the current generator IDs and supported table
set.

Sync the Standard ACPI Table IDs listed in TableGenerator.h with the
ESTD_ACPI_TABLE_ID enum in AcpiTableGenerator.h. This fixes the
RAW/DSDT/SSDT aliasing at ID 1, corrects the numbering of the remaining
standard ACPI table generators, and adds the missing IDs.

Update the DynamicTablesPkg README to reflect the current set of
supported ACPI table generators. Add missing entries for SSDT variants
and newer table generators, and include the expanded names for the
non-SSDT tables.