### PR TITLE
NetworkPkg/WifiConnectionManagerDxe: Add more check for WPA3 192 bit mode

### DIFF
--- a/NetworkPkg/WifiConnectionManagerDxe/WifiConnectionMgrImpl.c
+++ b/NetworkPkg/WifiConnectionManagerDxe/WifiConnectionMgrImpl.c
@@ -836,6 +836,49 @@ WifiMgrGetLinkState (
 }
 
 /**
+  Check an AKM suite list and a Cipher suite list to see if 192 bit mode is supported.
+  In WiFi 6 standard, 192 bit mode is defined in Suite B, which requires AKM suite
+  to be 802.1X Suite B 192 and Cipher suite to be GCMP-256.
+
+  @param[in]  AKMSuiteSelector                     The target AKM suite list to be checked.
+  @param[in]  CipherSuiteSelector                  The target Cipher suite list to be checked
+
+  @retval TRUE   192 bit mode is supported.
+  @retval FALSE  One or more parameters are invalid or the suite is not supported.
+
+**/
+STATIC
+BOOLEAN
+IsSuiteB192Mode (
+  IN    EFI_80211_AKM_SUITE_SELECTOR     *AKMSuiteSelector,
+  IN    EFI_80211_CIPHER_SUITE_SELECTOR  *CipherSuiteSelector
+  )
+{
+  UINT16  IndexOfAKMSuiteList;
+  UINT16  IndexOfCipherSuiteList;
+  UINT32  *AKMSuiteType;
+  UINT32  *CipherSuiteType;
+
+  if ((AKMSuiteSelector == NULL) || (CipherSuiteSelector == NULL)) {
+    return FALSE;
+  }
+
+  for (IndexOfAKMSuiteList = 0; IndexOfAKMSuiteList < AKMSuiteSelector->AKMSuiteCount; IndexOfAKMSuiteList++) {
+    AKMSuiteType = (UINT32 *)((AKMSuiteSelector->AKMSuiteList) + IndexOfAKMSuiteList);
+    for (IndexOfCipherSuiteList = 0; IndexOfCipherSuiteList < CipherSuiteSelector->CipherSuiteCount; IndexOfCipherSuiteList++) {
+      CipherSuiteType = (UINT32 *)((CipherSuiteSelector->CipherSuiteList) + IndexOfCipherSuiteList);
+      if ((*AKMSuiteType == IEEE_80211_AKM_SUITE_8021X_SUITE_B192) &&
+          (*CipherSuiteType == IEEE_80211_PAIRWISE_CIPHER_SUITE_GCMP256))
+      {
+        return TRUE;
+      }
+    }
+  }
+
+  return FALSE;
+}
+
+/**
   Prepare configuration work before connecting to the target network.
   For WPA2 Personal networks, password should be checked; and for EAP networks, parameters
   are different for different networks.
@@ -894,9 +937,30 @@ WifiMgrPrepareConnection (
         break;
 
       case SECURITY_TYPE_WPA2_ENTERPRISE:
-      case SECURITY_TYPE_WPA3_ENTERPRISE:
 
         Status = WifiMgrConfigEap (Nic, Profile);
+        if (EFI_ERROR (Status)) {
+          if (Status == EFI_INVALID_PARAMETER) {
+            if (Nic->OneTimeConnectRequest) {
+              WifiMgrUpdateConnectMessage (Nic, FALSE, L"Connect Failed: Invalid Configuration!");
+            }
+          }
+
+          return Status;
+        }
+
+        break;
+
+      case SECURITY_TYPE_WPA3_ENTERPRISE:
+
+        if (IsSuiteB192Mode (Profile->Network.AKMSuite, Profile->Network.CipherSuite) &&
+            ((Profile->EapAuthMethod == EAP_AUTH_METHOD_TTLS) || (Profile->EapAuthMethod == EAP_AUTH_METHOD_PEAP)))
+        {
+          Status = EFI_INVALID_PARAMETER;
+        } else {
+          Status = WifiMgrConfigEap (Nic, Profile);
+        }
+
         if (EFI_ERROR (Status)) {
           if (Status == EFI_INVALID_PARAMETER) {
             if (Nic->OneTimeConnectRequest) {


### PR DESCRIPTION
The patch consists of adding a check for WPA3 Enterprise 192 bit mode to allow security type of EAP-TLS connect to AP only.
From WPA3 Specification, we should only allow certificate validation by using EAP-TLS method when connecting to the WPA3 Enterprise 192 bit mode.
The main change is to only allow the AKM Suite/Cipher Suite operated in 192 bit mode to continue the EAP configuration when using EAP-TLS method.

Try to launch Option ROM in pre-boot environment, and try to connect the Wi-Fi AP(WPA3 Enterprise 192 bit Support) by using these three different methods (EAP-TLS/PEAP/TTLS). Check if only EAP-TLS can connect to the AP successfully.

Signed-off-by: Feng, Vincent [vfeng@hp.com](mailto:vfeng@hp.com)

Reviewed-by: Anbazhagan, Baraneedharan [anbazhagan@hp.com](mailto:anbazhagan@hp.com)
Reviewed-by: Chang, Harry [harry.chang@hp.com](mailto:harry.chang@hp.com)
