### PR TITLE
Close the Redfish interface when the connection is no longer needed

### DIFF
--- a/RedfishPkg/RedfishConfigHandler/RedfishConfigHandlerDriver.c
+++ b/RedfishPkg/RedfishConfigHandler/RedfishConfigHandlerDriver.c
@@ -41,6 +41,43 @@ EFI_DRIVER_BINDING_PROTOCOL  gRedfishConfigDriverBinding = {
 };
 
 /**
+  Disconnect the interface communication with REST EX protocol.
+
+  @param[in]   Event    Event whose notification function is being invoked.
+  @param[out]  Context  Pointer to the Context buffer
+
+**/
+VOID
+EFIAPI
+RedfishConfigDisconnection (
+  IN  EFI_EVENT  Event,
+  OUT VOID       *Context
+  )
+{
+  EFI_STATUS                   Status;
+  EFI_REDFISH_DISCOVERED_LIST  *DiscoveredList;
+
+  if (gRedfishServiceDiscovered) {
+    DiscoveredList = (EFI_REDFISH_DISCOVERED_LIST *)Context;
+    if (DiscoveredList == NULL) {
+      DEBUG ((DEBUG_ERROR, "%a: DiscoveredList == NULL, failed to release Redfish service.\n", __func__));
+      return;
+    } else {
+      Status = gEfiRedfishDiscoverProtocol->ReleaseRedfishService (gEfiRedfishDiscoverProtocol, DiscoveredList);
+      FreePool (DiscoveredList);
+      if (!EFI_ERROR (Status)) {
+        gBS->CloseEvent (Event);
+        gRedfishServiceDiscovered = FALSE;
+        DEBUG ((DEBUG_MANAGEABILITY, "%a: Redfish service is released.\n", __func__));
+        return;
+      }
+
+      DEBUG ((DEBUG_ERROR, "%a: Failed to release Redfish service.: %r\n", __func__, Status));
+    }
+  }
+}
+
+/**
   Stop acquiring Redfish service.
 
 **/
@@ -320,8 +357,11 @@ RedfishServiceDiscoveredCallback (
   OUT VOID       *Context
   )
 {
+  EFI_STATUS                       Status;
+  EFI_EVENT                        ThisEvent;
   EFI_REDFISH_DISCOVERED_TOKEN     *RedfishDiscoveredToken;
   EFI_REDFISH_DISCOVERED_INSTANCE  *RedfishInstance;
+  EFI_REDFISH_DISCOVERED_LIST      *ThisDiscoveredList;
 
   RedfishDiscoveredToken = (EFI_REDFISH_DISCOVERED_TOKEN *)Context;
   gBS->CloseEvent (RedfishDiscoveredToken->Event);
@@ -331,6 +371,33 @@ RedfishServiceDiscoveredCallback (
   //
   if (!gRedfishServiceDiscovered) {
     RedfishInstance = RedfishDiscoveredToken->DiscoverList.RedfishInstances;
+
+    // Save EFI_REDFISH_DISCOVERED_LIST for the later release.
+    ThisDiscoveredList = (EFI_REDFISH_DISCOVERED_LIST *)AllocatePool (sizeof (EFI_REDFISH_DISCOVERED_LIST));
+    if (ThisDiscoveredList == NULL) {
+      DEBUG ((DEBUG_ERROR, "%a: Memory allocation of EFI_REDFISH_DISCOVERED_LIST is failed.\n", __func__));
+      goto ErrorExit;
+    }
+
+    CopyMem ((VOID *)ThisDiscoveredList, (VOID *)&RedfishDiscoveredToken->DiscoverList, sizeof (EFI_REDFISH_DISCOVERED_LIST));
+
+    //
+    // Create gEdkIIRedfisEventRedfishInterfaceDisconnectionGuid event to stop Redfish service.
+    //
+    Status = gBS->CreateEventEx (
+                    EVT_NOTIFY_SIGNAL,
+                    TPL_CALLBACK,
+                    RedfishConfigDisconnection,
+                    (VOID *)ThisDiscoveredList,
+                    &gEdkIIRedfisEventRedfishInterfaceDisconnectionGuid,
+                    &ThisEvent
+                    );
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a: Fail to register Redfish transport interface disconnection event.\n", __func__));
+      FreePool (ThisDiscoveredList);
+      goto ErrorExit;
+    }
+
     //
     // Only pick up the first found Redfish service.
     //
@@ -355,6 +422,7 @@ RedfishServiceDiscoveredCallback (
     RedfishConfigHandlerInstalledCallback (gRedfishConfigData.Event, &gRedfishConfigData);
   }
 
+ErrorExit:
   FreePool (RedfishDiscoveredToken);
 }
 

--- a/RedfishPkg/RedfishConfigHandler/RedfishConfigHandlerDriver.inf
+++ b/RedfishPkg/RedfishConfigHandler/RedfishConfigHandlerDriver.inf
@@ -53,6 +53,7 @@
   gEdkIIRedfishCredentialProtocolGuid          ## CONSUMES
 
 [Guids]
-  gEfiEventExitBootServicesGuid                ## CONSUMES ## Event
-  gEfiEndOfDxeEventGroupGuid                   ## CONSUMES ## Event
+  gEfiEventExitBootServicesGuid                       ## CONSUMES ## Event
+  gEfiEndOfDxeEventGroupGuid                          ## CONSUMES ## Event
+  gEdkIIRedfisEventRedfishInterfaceDisconnectionGuid  ## CONSUMES ## Event
 

--- a/RedfishPkg/RedfishDiscoverDxe/RedfishDiscoverDxe.c
+++ b/RedfishPkg/RedfishDiscoverDxe/RedfishDiscoverDxe.c
@@ -3,7 +3,7 @@
   The implementation of EFI Redfish Discover Protocol.
 
   (C) Copyright 2021 Hewlett Packard Enterprise Development LP<BR>
-  Copyright (c) 2022, AMD Incorporated. All rights reserved.
+  Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
   Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
   Copyright (c) 2023, Ampere Computing LLC. All rights reserved.<BR>
   Copyright (c) 2023, Mike Maslenkin <mike.maslenkin@gmail.com> <BR>
@@ -1644,12 +1644,18 @@ RedfishServiceReleaseService (
   IN EFI_REDFISH_DISCOVERED_LIST    *InstanceList
   )
 {
+  EFI_STATUS                            Status;
   UINTN                                 NumService;
   BOOLEAN                               AnyFailRelease;
   EFI_REDFISH_DISCOVERED_INSTANCE       *ThisRedfishInstance;
   EFI_REDFISH_DISCOVERED_INTERNAL_LIST  *DiscoveredRedfishInstance;
+  EFI_REST_EX_PROTOCOL                  *RestExProtocol;
 
-  DEBUG ((DEBUG_MANAGEABILITY, "%a: Entry.\n", __func__));
+  if (InstanceList == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  DEBUG ((DEBUG_MANAGEABILITY, "%a: Entry, to release %d Redfish instance(s).\n", __func__, InstanceList->NumberOfServiceFound));
 
   if (IsListEmpty (&mRedfishInstanceList)) {
     DEBUG ((DEBUG_ERROR, "%a:No any discovered Redfish service.\n", __func__));
@@ -1662,6 +1668,24 @@ RedfishServiceReleaseService (
     DiscoveredRedfishInstance = (EFI_REDFISH_DISCOVERED_INTERNAL_LIST *)GetFirstNode (&mRedfishInstanceList);
     do {
       if (DiscoveredRedfishInstance->Instance == ThisRedfishInstance) {
+        //
+        // Disable REST EX instance by setting configuration to NULL.
+        // This also closes the underlying protocols, such HTTP.
+        //
+        Status = gBS->LocateProtocol (&gEfiRestExProtocolGuid, NULL, (VOID **)&RestExProtocol);
+        if (!EFI_ERROR (Status)) {
+          Status = RestExProtocol->Configure (
+                                     RestExProtocol,
+                                     NULL
+                                     );
+        }
+
+        if (!EFI_ERROR (Status)) {
+          DEBUG ((DEBUG_MANAGEABILITY, "%a: REST EX connection is closed.\n", __func__));
+        } else {
+          DEBUG ((DEBUG_MANAGEABILITY, "%a: REST EX connection is not propery closed.\n", __func__));
+        }
+
         RemoveEntryList (&DiscoveredRedfishInstance->NextInstance);
         FreeInformationData (&ThisRedfishInstance->Information);
         FreePool ((VOID *)ThisRedfishInstance);

--- a/RedfishPkg/RedfishPkg.dec
+++ b/RedfishPkg/RedfishPkg.dec
@@ -5,7 +5,7 @@
 # (C) Copyright 2021 Hewlett Packard Enterprise Development LP<BR>
 # Copyright (c) 2023, American Megatrends International LLC.
 # Copyright (c) 2023-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.<BR>
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.<BR>
 #
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 ##
@@ -115,6 +115,9 @@
 
   # Redfish variable guid
   gEfiRedfishVariableGuid           = { 0x85ef8dd3, 0xe606, 0x4b89, { 0x8b, 0xbd, 0x93, 0xbf, 0x5c, 0xbe, 0x1c, 0x18 } }
+
+  # Redfish Configuration Handler Disconnection
+  gEdkIIRedfisEventRedfishInterfaceDisconnectionGuid = { 0x11B81837, 0x249B, 0x4843, { 0xA5, 0x2C, 0xC8, 0x23, 0x7B, 0x35, 0xBF, 0xC2 } }
 
 [PcdsFixedAtBuild, PcdsPatchableInModule]
   #


### PR DESCRIPTION
# Description
Close the Redfish interface when the connection is no longer needed. This is the follow-up PR of https://github.com/tianocore/edk2/pull/11437.

The use case is on edk2-redfish-clinet, https://github.com/tianocore/edk2-redfish-client/pull/129.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested
Tested on AMD platform.

## Integration Instructions

N/A