### PR TITLE
ArmPkg/Driver: Remove the stale mPartId and duplicate ArmFfaLibRxRelease

### DIFF
--- a/ArmPkg/Drivers/MmCommunicationDxe/MmCommunication.c
+++ b/ArmPkg/Drivers/MmCommunicationDxe/MmCommunication.c
@@ -32,7 +32,6 @@
 //
 // Partition ID if FF-A support is enabled
 //
-STATIC UINT16  mPartId;
 STATIC UINT16  mStMmPartId;
 
 //
@@ -548,16 +547,6 @@ InitializeFfaCommunication (
 {
   EFI_STATUS              Status;
   EFI_FFA_PART_INFO_DESC  StmmPartInfo;
-
-  Status = ArmFfaLibPartitionIdGet (&mPartId);
-  if (EFI_ERROR (Status)) {
-    DEBUG ((
-      DEBUG_ERROR,
-      "Failed to get partition id. Status: %r\n",
-      Status
-      ));
-    return Status;
-  }
 
   Status = ArmFfaLibGetPartitionInfo (&gEfiMmCommunication2ProtocolGuid, &StmmPartInfo);
   if (EFI_ERROR (Status)) {

--- a/ArmPkg/Drivers/MmCommunicationPei/MmCommunicationPei.c
+++ b/ArmPkg/Drivers/MmCommunicationPei/MmCommunicationPei.c
@@ -26,7 +26,6 @@
 //
 // Partition ID if FF-A support is enabled
 //
-STATIC UINT16  mPartId;
 STATIC UINT16  mStMmPartId;
 
 /**
@@ -139,16 +138,6 @@ InitializeFfaCommunication (
   EFI_STATUS              Status;
   EFI_FFA_PART_INFO_DESC  StmmPartInfo;
 
-  Status = ArmFfaLibPartitionIdGet (&mPartId);
-  if (EFI_ERROR (Status)) {
-    DEBUG ((
-      DEBUG_ERROR,
-      "Failed to get partition id. Status: %r\n",
-      Status
-      ));
-    return Status;
-  }
-
   Status = ArmFfaLibGetPartitionInfo (&gEfiMmCommunication2ProtocolGuid, &StmmPartInfo);
   if (EFI_ERROR (Status)) {
     DEBUG ((
@@ -163,14 +152,12 @@ InitializeFfaCommunication (
   if ((StmmPartInfo.PartitionProps & FFA_PART_PROP_RECV_DIRECT_REQ) == 0x00) {
     Status = EFI_UNSUPPORTED;
     DEBUG ((DEBUG_ERROR, "StandaloneMm doesn't receive DIRECT_MSG_REQ...\n"));
-    goto ErrorHandler;
+    return Status;
   }
 
   mStMmPartId = StmmPartInfo.PartitionId;
 
-ErrorHandler:
-  ArmFfaLibRxRelease (mPartId);
-  return Status;
+  return EFI_SUCCESS;
 }
 
 /**


### PR DESCRIPTION
# Description

ArmFfaLibGetPartitionInfo() helper replaces the manual partition info lookup sequence used by FF-A clients:

* ArmFfaLibPartitionIdGet()
* ArmFfaLibGetRxTxBuffers()
* ArmFfaLibPartitionInfoGet(..., FFA_PART_INFO_FLAG_TYPE_DESC, ...)
* copy EFI_FFA_PART_INFO_DESC from the RX buffer
* ArmFfaLibRxRelease()

The collateral evolutions in b80000847a and 96ad9bd397 use the helper as the owner of that sequence. Their callers only consume the copied partition descriptor and do not keep a local partition ID solely for RX buffer release.

Commit 8955d8db32 converted MmCommunication to call ArmFfaLibGetPartitionInfo(), but kept caller-side partition ID state and, in PEI, still released the RX buffer after the helper returned. That made the ArmPkg conversion inconsistent with b80000847a and 96ad9bd397, and inconsistent with the helper ownership model. In the ArmFfaLibPartitionInfoGetRegs path, there is no RX buffer to release, while in the RX/TX buffer path, the buffer is already released inside ArmFfaLibGetPartitionInfo().

This patch removes the stale local mPartId state and the remaining caller-side ArmFfaLibRxRelease() from the DXE and PEI MM communication drivers. The callers now match the helper contract: get the descriptor, validate DIRECT_MSG_REQ support, and store the StandaloneMM partition ID.

The current version was generated by running the following Coccinelle script on 8955d8db32^, then rebasing the resulting fixup to master.

``` smpl
@replace_old_sequence@
typedef EFI_STATUS;
identifier Fn;
identifier Info, Count, TxBuffer, TxBufferSize, RxBuffer, RxBufferSize; identifier PartId, Status, Size;
expression Guid;
position p;
statement S1, S2;
type SizeArgT;
@@
EFI_STATUS Fn@p (...) {
...
- EFI_FFA_PART_INFO_DESC *Info;
+ EFI_FFA_PART_INFO_DESC Info; ...
- Status = ArmFfaLibPartitionIdGet (&PartId);
- if (EFI_ERROR (Status)) S1 ...
- Status = ArmFfaLibGetRxTxBuffers (
-            &TxBuffer,
-            &TxBufferSize,
-            &RxBuffer,
-            &RxBufferSize
-            );
- if (EFI_ERROR (Status)) S2
...
- Status = ArmFfaLibPartitionInfoGet (
-            Guid,
-            FFA_PART_INFO_FLAG_TYPE_DESC,
-            &Count,
-            (SizeArgT)&Size
-            );
+ Status = ArmFfaLibGetPartitionInfo (Guid, &Info);
...
(
- if ((Count != 1) || (Size < sizeof (EFI_FFA_PART_INFO_DESC))) {
-   ...
- } else {
-   Info = (EFI_FFA_PART_INFO_DESC *)RxBuffer;
    ...
- }
|
- if ((Count != 1) || (Size < sizeof (EFI_FFA_PART_INFO_DESC))) {
-   ...
- }
  ...
- Info = (EFI_FFA_PART_INFO_DESC *)RxBuffer;
)
  ...
- ArmFfaLibRxRelease (PartId);
  ...
}

@part_info_members depends on replace_old_sequence@ identifier replace_old_sequence.Info;
identifier Field =~ "^(PartitionId|PartitionProps)$"; @@
- Info->Field
+ Info.Field

@remove_old_variables depends on replace_old_sequence@ identifier replace_old_sequence.Count, replace_old_sequence.TxBuffer; identifier replace_old_sequence.TxBufferSize, replace_old_sequence.RxBuffer, replace_old_sequence.RxBufferSize; identifier replace_old_sequence.PartId;
identifier replace_old_sequence.Size;
type T;
@@
(
- T *TxBuffer;
|
- UINT64 TxBufferSize; 
|
- T *RxBuffer; 
|
- UINT64 RxBufferSize;
|
- UINT32 Count; 
|
- UINT32 Size; 
|
- UINT16 PartId;
|
- static UINT16 PartId;
)
```

- [ ] Breaking change
- [ ] Impacts security
- [ ] Includes tests

## How This Was Tested

CI

## Integration Instructions

N/A