### PR TITLE
DynamicTablesPkg/AmlLib: Add AmlMethodParamTypeBuffer support

### DIFF
--- a/DynamicTablesPkg/Include/Library/AmlLib/AmlLib.h
+++ b/DynamicTablesPkg/Include/Library/AmlLib/AmlLib.h
@@ -107,6 +107,7 @@ typedef enum {
     1 - AmlMethodParamTypeString
     2 - AmlMethodParamTypeArg
     3 - AmlMethodParamTypeLocal
+    4 - AmlMethodParamTypeBuffer
 
   @par Reference(s)
   - ACPI 6.5, s20.2.5 "Term Objects Encoding"
@@ -116,7 +117,8 @@ typedef enum {
   AmlMethodParamTypeInteger = 0,
   AmlMethodParamTypeString  = 1,
   AmlMethodParamTypeArg     = 2,
-  AmlMethodParamTypeLocal   = 3
+  AmlMethodParamTypeLocal   = 3,
+  AmlMethodParamTypeBuffer  = 4
 } AML_METHOD_PARAM_TYPE;
 
 /** AML Method parameter data
@@ -142,7 +144,10 @@ typedef union {
             If Type is AmlMethodParamTypeLocal
               then Data contains the Local variable number,
               0 to 7 are supported value.
-  DataSize - for future use
+            If Type is AmlMethodParamTypeBuffer
+              then Data.Buffer points to a UINT8 byte array and
+              DataSize holds the byte count of that array.
+  DataSize - byte count when Type is AmlMethodParamTypeBuffer; unused otherwise.
 **/
 typedef struct {
   AML_METHOD_PARAM_TYPE    Type;

--- a/DynamicTablesPkg/Library/Common/AmlLib/CodeGen/AmlCodeGen.c
+++ b/DynamicTablesPkg/Library/Common/AmlLib/CodeGen/AmlCodeGen.c
@@ -4138,6 +4138,26 @@ AmlCodeGenInvokeMethod (
           }
 
           break;
+        case AmlMethodParamTypeBuffer:
+          if ((Parameters[Index].Data.Buffer == NULL) !=
+              (Parameters[Index].DataSize == 0))
+          {
+            ASSERT_EFI_ERROR (EFI_INVALID_PARAMETER);
+            Status = EFI_INVALID_PARAMETER;
+            goto exit_handler;
+          }
+
+          Status = AmlCodeGenBuffer (
+                     Parameters[Index].Data.Buffer,
+                     (UINT32)Parameters[Index].DataSize,
+                     &ObjectNode
+                     );
+          if (EFI_ERROR (Status)) {
+            ASSERT_EFI_ERROR (Status);
+            goto exit_handler;
+          }
+
+          break;
         default:
           ASSERT_EFI_ERROR (EFI_INVALID_PARAMETER);
           Status = EFI_INVALID_PARAMETER;


### PR DESCRIPTION
Extend AML_METHOD_PARAM_TYPE enum with AmlMethodParamTypeBuffer (= 4) to allow callers to pass a raw byte Buffer as an AML method argument.

Add a Buffer case to the switch in AmlCodeGenInvokeMethod() that delegates to the existing AmlCodeGenBuffer() helper, with NULL-pointer and zero-length guards matching the pattern of the other cases. AmlCodeGenReturnInvokeMethod() already delegates to AmlCodeGenInvokeMethod() so it picks up the new case automatically.

Update AML_METHOD_PARAM documentation: clarify that DataSize carries the byte count when Type is AmlMethodParamTypeBuffer, and update the union/struct field comments accordingly.

Cc: Pierre Gondois <pierre.gondois@arm.com>
Cc: Sami Mujawar <sami.mujawar@arm.com>

# Description

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested
Tested on AMD platform

## Integration Instructions
N/A