### PR TITLE
ManageabilityPkg: Fix build failure issue on CLANGDWARF X64

### DIFF
--- a/ManageabilityPkg/Include/Library/ManageabilityTransportHelperLib.h
+++ b/ManageabilityPkg/Include/Library/ManageabilityTransportHelperLib.h
@@ -180,6 +180,7 @@ HelperManageabilityPayLoadDebugPrint (
 
 **/
 VOID
+EFIAPI
 HelperManageabilityDebugPrint (
   IN  VOID         *Payload,
   IN  UINT32       PayloadSize,

--- a/ManageabilityPkg/Library/BaseManageabilityTransportHelperLib/BaseManageabilityTransportHelper.c
+++ b/ManageabilityPkg/Library/BaseManageabilityTransportHelperLib/BaseManageabilityTransportHelper.c
@@ -450,6 +450,7 @@ HelperManageabilityPayLoadDebugPrint (
 
 **/
 VOID
+EFIAPI
 HelperManageabilityDebugPrint (
   IN  VOID         *Payload,
   IN  UINT32       PayloadSize,


### PR DESCRIPTION
# Description

When building ManageabilityPkg with `-a X64 -t CLANGDWARF`, error message is throwed:
BaseManageabilityTransportHelper.c:462:3: error:
'__builtin_ms_va_start' used in System V ABI function
  462 |   VA_START (Marker, Format);
      |   ^

Functions that call VA_START()/VA_END() must be declared with EFIAPI. The function HelperManageabilityDebugPrint() should also be declared with EFIAPI to ensure compliance with Microsoft X64 calling convention for CLANG.


## How This Was Tested

Run command `build -b DEBUG -t CLANGDWARF -a X64 -p ManageabilityPkg/ManageabilityPkg.dsc`, no error occured.

## Integration Instructions

N/A
