### PR TITLE
Smbios type0 generator

### DIFF
--- a/DynamicTablesPkg/DynamicTables.dsc.inc
+++ b/DynamicTablesPkg/DynamicTables.dsc.inc
@@ -108,6 +108,7 @@
   DynamicTablesPkg/Library/Acpi/Arm/AcpiIortLibArm/AcpiIortLibArm.inf
   DynamicTablesPkg/Library/Acpi/Arm/AcpiMadtLibArm/AcpiMadtLibArm.inf
 
+  DynamicTablesPkg/Library/Smbios/SmbiosType0Lib/SmbiosType0Lib.inf
   DynamicTablesPkg/Library/Smbios/SmbiosType4Lib/SmbiosType4Lib.inf
   DynamicTablesPkg/Library/Smbios/SmbiosType7Lib/SmbiosType7Lib.inf
 
@@ -154,6 +155,7 @@
       NULL|DynamicTablesPkg/Library/Acpi/Common/AcpiSsdtCpuTopologyLib/SsdtCpuTopologyLib.inf
       NULL|DynamicTablesPkg/Library/Acpi/Common/AcpiSsdtPcieLib/SsdtPcieLib.inf
 
+      NULL|DynamicTablesPkg/Library/Smbios/SmbiosType0Lib/SmbiosType0Lib.inf
       NULL|DynamicTablesPkg/Library/Smbios/SmbiosType4Lib/SmbiosType4Lib.inf
       NULL|DynamicTablesPkg/Library/Smbios/SmbiosType7Lib/SmbiosType7Lib.inf
   }

--- a/DynamicTablesPkg/Include/ArchCommonNameSpaceObjects.h
+++ b/DynamicTablesPkg/Include/ArchCommonNameSpaceObjects.h
@@ -79,6 +79,7 @@ typedef enum ArchCommonObjectID {
   EArchCommonObjErrSourceGenericHwInfo,         ///< 52 - Generic Hardware Error Source Info
   EArchCommonObjErrSourceGenericHwVer2Info,     ///< 53 - Generic Hardware Error Source Info version 2
   EArchCommonObjEinjInstructionsInfo,           ///< 54 - Einj Instruction Info
+  EArchCommonObjPlatformFwInfo,                 ///< 54 - Platform Firmware Info
   EArchCommonObjMax
 } EARCH_COMMON_OBJECT_ID;
 
@@ -1300,5 +1301,36 @@ typedef struct {
   UINT64                                    Value;
   UINT64                                    Mask;
 } CM_ARCH_COMMON_EINJ_INSTRUCTIONS_INFO;
+
+/** A structure that describes BIOS Information.
+
+  SMBIOS Specification v3.9.0 Type 0
+
+  ID: EArchCommonObjPlatformFwInfo
+**/
+typedef struct CmArchCommonPlatformFwInfo {
+  /// CM Object Token uniquely identifying this Platform Firmware info entry.
+  CM_OBJECT_TOKEN              BiosInfoToken;
+  /// BIOS vendor name string.
+  CHAR8                        BiosVendor[SMBIOS_MAX_STRING_SIZE];
+  /// BIOS version string.
+  CHAR8                        BiosVersion[SMBIOS_MAX_STRING_SIZE];
+  /// BIOS release date string.
+  CHAR8                        BiosReleaseDate[SMBIOS_MAX_STRING_SIZE];
+  /// BIOS ROM size in bytes.
+  UINT64                       BiosSize;
+  /// Bit field of supported BIOS functions.
+  MISC_BIOS_CHARACTERISTICS    BiosCharacteristics;
+  /// Optional set of functions that BIOS supports (bytes 0 and 1).
+  UINT8                        BIOSCharacteristicsExtensionBytes[2];
+  /// System BIOS firmware major version.
+  UINT8                        SystemBiosMajorRelease;
+  /// System BIOS firmware minor version.
+  UINT8                        SystemBiosMinorRelease;
+  /// Embedded Controller firmware major release.
+  UINT8                        ECFirmwareMajorRelease;
+  /// Embedded Controller firmware minor release.
+  UINT8                        ECFirmwareMinorRelease;
+} CM_ARCH_COMMON_PLATFORM_FW_INFO;
 
 #pragma pack()

--- a/DynamicTablesPkg/Library/Common/TableHelperLib/ConfigurationManagerObjectParser.c
+++ b/DynamicTablesPkg/Library/Common/TableHelperLib/ConfigurationManagerObjectParser.c
@@ -1128,6 +1128,22 @@ STATIC CONST CM_OBJ_PARSER  CmArchCommonObjEinjInstructionsInfoParser[] = {
   { "Mask",            8,                                               "0x%llx", NULL },
 };
 
+/** A parser for EArchCommonObjPlatformFwInfo.
+*/
+STATIC CONST CM_OBJ_PARSER  CmArchCommonPlatformFwInfoParser[] = {
+  { "BiosInfoToken",                     sizeof (CM_OBJECT_TOKEN),           "0x%p",   NULL        },
+  { "BiosVendor",                        SMBIOS_MAX_STRING_SIZE,             NULL,     PrintString },
+  { "BiosVersion",                       SMBIOS_MAX_STRING_SIZE,             NULL,     PrintString },
+  { "BiosReleaseDate",                   SMBIOS_MAX_STRING_SIZE,             NULL,     PrintString },
+  { "BiosSize",                          sizeof (UINT64),                    "0x%llx", NULL        },
+  { "BiosCharacteristics",               sizeof (MISC_BIOS_CHARACTERISTICS), "0x%lx",  NULL        },
+  { "BIOSCharacteristicsExtensionBytes", 2,                                  "0x%x",   NULL        },
+  { "SystemBiosMajorRelease",            sizeof (UINT8),                     "0x%u",   NULL        },
+  { "SystemBiosMinorRelease",            sizeof (UINT8),                     "0x%u",   NULL        },
+  { "ECFirmwareMajorRelease",            sizeof (UINT8),                     "0x%u",   NULL        },
+  { "ECFirmwareMinorRelease",            sizeof (UINT8),                     "0x%u",   NULL        },
+};
+
 /** A parser for Arch Common namespace objects.
 */
 STATIC CONST CM_OBJ_PARSER_ARRAY  ArchCommonNamespaceObjectParser[] = {
@@ -1186,6 +1202,7 @@ STATIC CONST CM_OBJ_PARSER_ARRAY  ArchCommonNamespaceObjectParser[] = {
   CM_PARSER_ADD_OBJECT (EArchCommonObjErrSourceGenericHwInfo,       CmArchCommonObjErrSourceGenericHwInfoParser),
   CM_PARSER_ADD_OBJECT (EArchCommonObjErrSourceGenericHwVer2Info,   CmArchCommonObjErrSourceGenericHwVer2InfoParser),
   CM_PARSER_ADD_OBJECT (EArchCommonObjEinjInstructionsInfo,         CmArchCommonObjEinjInstructionsInfoParser),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjPlatformFwInfo,               CmArchCommonPlatformFwInfoParser),
   CM_PARSER_ADD_OBJECT_RESERVED (EArchCommonObjMax)
 };
 

--- a/DynamicTablesPkg/Library/Smbios/SmbiosType0Lib/SmbiosType0Generator.c
+++ b/DynamicTablesPkg/Library/Smbios/SmbiosType0Lib/SmbiosType0Generator.c
@@ -1,0 +1,362 @@
+/** @file
+  SMBIOS Type0 Table Generator.
+
+  Copyright (c) 2024 - 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  Copyright (c) 2020 - 2021, Arm Limited. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+  @par Reference(s):
+  - SMBIOS Specification 3.9.0
+
+**/
+
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/SmbiosStringTableLib.h>
+
+// Module specific include files.
+#include <ConfigurationManagerObject.h>
+#include <ConfigurationManagerHelper.h>
+#include <Protocol/ConfigurationManagerProtocol.h>
+#include <Protocol/DynamicTableFactoryProtocol.h>
+#include <Protocol/Smbios.h>
+#include <IndustryStandard/SmBios.h>
+
+#define SMBIOS_TYPE0_MAX_LEGACY_ROM_SIZE  (255 * SIZE_64KB)
+#define SMBIOS_TYPE0_MAX_EXT_SIZE         0x3FFF
+
+/** This macro expands to a function that retrieves the BIOS Information
+    from the Configuration Manager.
+*/
+GET_OBJECT_LIST (
+  EObjNameSpaceArchCommon,
+  EArchCommonObjPlatformFwInfo,
+  CM_ARCH_COMMON_PLATFORM_FW_INFO
+  )
+
+/**
+  Free any resources allocated when installing SMBIOS Type0 table.
+
+  @param [in]  This                 Pointer to the SMBIOS table generator.
+  @param [in]  TableFactoryProtocol Pointer to the SMBIOS Table Factory
+                                    Protocol interface.
+  @param [in]  SmbiosTableInfo      Pointer to the SMBIOS table information.
+  @param [in]  CfgMgrProtocol       Pointer to the Configuration Manager
+                                    Protocol interface.
+  @param [in]  Table                Pointer to the SMBIOS table.
+
+  @retval EFI_SUCCESS  Table freed successfully.
+**/
+STATIC
+EFI_STATUS
+FreeSmbiosType0Table (
+  IN      CONST SMBIOS_TABLE_GENERATOR                   *CONST   This,
+  IN      CONST EDKII_DYNAMIC_TABLE_FACTORY_PROTOCOL     *CONST   TableFactoryProtocol,
+  IN      CONST CM_STD_OBJ_SMBIOS_TABLE_INFO             *CONST   SmbiosTableInfo,
+  IN      CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL     *CONST   CfgMgrProtocol,
+  IN      SMBIOS_STRUCTURE                               **CONST  Table
+  )
+{
+  if (*Table != NULL) {
+    FreePool (*Table);
+  }
+
+  return EFI_SUCCESS;
+}
+
+/** Construct SMBIOS Type0 Table describing BIOS information.
+
+  If this function allocates any resources then they must be freed
+  in the FreeSmbiosType0Table function.
+
+  @param [in]  This                 Pointer to the SMBIOS table generator.
+  @param [in]  TableFactoryProtocol Pointer to the SMBIOS Table Factory
+                                    Protocol interface.
+  @param [in]  SmbiosTableInfo      Pointer to the SMBIOS table information.
+  @param [in]  CfgMgrProtocol       Pointer to the Configuration Manager
+                                    Protocol interface.
+  @param [out] Table                Pointer to the SMBIOS table.
+  @param [out] CmObjectToken        Pointer to the CM Object Token.
+
+  @retval EFI_SUCCESS            Table generated successfully.
+  @retval EFI_INVALID_PARAMETER  A parameter is invalid.
+  @retval EFI_NOT_FOUND          Could not find information.
+  @retval EFI_OUT_OF_RESOURCES   Could not allocate memory.
+**/
+STATIC
+EFI_STATUS
+BuildSmbiosType0Table (
+  IN  CONST SMBIOS_TABLE_GENERATOR                         *This,
+  IN  CONST EDKII_DYNAMIC_TABLE_FACTORY_PROTOCOL   *CONST  TableFactoryProtocol,
+  IN        CM_STD_OBJ_SMBIOS_TABLE_INFO           *CONST  SmbiosTableInfo,
+  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL   *CONST  CfgMgrProtocol,
+  OUT       SMBIOS_STRUCTURE                               **Table,
+  OUT       CM_OBJECT_TOKEN                                *CmObjectToken
+  )
+{
+  EFI_STATUS                       Status;
+  CM_OBJECT_TOKEN                  CmObject;
+  UINT8                            VendorRef;
+  UINT8                            VersionRef;
+  UINT8                            ReleaseDateRef;
+  SMBIOS_TABLE_TYPE0               *SmbiosRecord;
+  UINTN                            SmbiosRecordSize;
+  STRING_TABLE                     StrTable;
+  CHAR8                            *OptionalStrings;
+  CM_ARCH_COMMON_PLATFORM_FW_INFO  *BiosInfo;
+
+  SmbiosRecord = NULL;
+
+  ASSERT (This != NULL);
+  ASSERT (SmbiosTableInfo != NULL);
+  ASSERT (CfgMgrProtocol != NULL);
+  ASSERT (Table != NULL);
+  ASSERT (SmbiosTableInfo->TableGeneratorId == This->GeneratorID);
+
+  if ((This == NULL) ||
+      (SmbiosTableInfo == NULL) ||
+      (CfgMgrProtocol == NULL) ||
+      (Table == NULL) ||
+      (SmbiosTableInfo->TableGeneratorId != This->GeneratorID))
+  {
+    DEBUG ((DEBUG_ERROR, "%a: Invalid Parameter\n", __func__));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  //
+  // Retrieve BIOS info from CM object
+  //
+  *Table = NULL;
+  Status = GetEArchCommonObjPlatformFwInfo (
+             CfgMgrProtocol,
+             CM_NULL_TOKEN,
+             &BiosInfo,
+             NULL
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: Failed to get Bios Info CM Object %r\n",
+      __func__,
+      Status
+      ));
+    return Status;
+  }
+
+  //
+  // Copy strings to SMBIOS table
+  //
+  Status = StringTableInitialize (&StrTable, 3);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: Failed to allocate string table for CM Object, %r\n",
+      __func__,
+      Status
+      ));
+    return Status;
+  }
+
+  VendorRef      = 0;
+  VersionRef     = 0;
+  ReleaseDateRef = 0;
+
+  if (BiosInfo->BiosVendor[0] != '\0') {
+    Status = StringTableAddString (&StrTable, BiosInfo->BiosVendor, &VendorRef);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a: Failed to add BiosVendor string %r\n", __func__, Status));
+      goto exit;
+    }
+  }
+
+  if (BiosInfo->BiosVersion[0] != '\0') {
+    Status = StringTableAddString (&StrTable, BiosInfo->BiosVersion, &VersionRef);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a: Failed to add BiosVersion string %r\n", __func__, Status));
+      goto exit;
+    }
+  }
+
+  if (BiosInfo->BiosReleaseDate[0] != '\0') {
+    Status = StringTableAddString (&StrTable, BiosInfo->BiosReleaseDate, &ReleaseDateRef);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a: Failed to add BiosReleaseDate string %r\n", __func__, Status));
+      goto exit;
+    }
+  }
+
+  SmbiosRecordSize = sizeof (SMBIOS_TABLE_TYPE0) +
+                     StringTableGetStringSetSize (&StrTable);
+  SmbiosRecord = (SMBIOS_TABLE_TYPE0 *)AllocateZeroPool (SmbiosRecordSize);
+  if (SmbiosRecord == NULL) {
+    DEBUG ((DEBUG_ERROR, "%a: memory allocation failed for smbios type0 record\n", __func__));
+    Status = EFI_OUT_OF_RESOURCES;
+    goto exit;
+  }
+
+  SmbiosRecord->BiosSegment = 0;
+
+  if (BiosInfo->BiosSize != 0) {
+    // check if the size is <= 255*64KiB and is multiple of 64 KiB
+    if ((BiosInfo->BiosSize <= SMBIOS_TYPE0_MAX_LEGACY_ROM_SIZE) &&
+        ((BiosInfo->BiosSize % SIZE_64KB) == 0))
+    {
+      SmbiosRecord->BiosSize              = (UINT8)((BiosInfo->BiosSize / SIZE_64KB) - 1);
+      SmbiosRecord->ExtendedBiosSize.Size = 0;
+      SmbiosRecord->ExtendedBiosSize.Unit = 0;
+    } else {
+      SmbiosRecord->BiosSize = 0xFF;
+      // check if size is multiple of 1MB and can be fit in max size
+      if (((BiosInfo->BiosSize % SIZE_1MB) == 0) &&
+          ((BiosInfo->BiosSize / SIZE_1MB) <= SMBIOS_TYPE0_MAX_EXT_SIZE))
+      {
+        SmbiosRecord->ExtendedBiosSize.Size = (UINT16)(BiosInfo->BiosSize / SIZE_1MB);
+        SmbiosRecord->ExtendedBiosSize.Unit = 0; // MiB/MB unit per spec
+      }
+      // check if size is multiple of 1GB and can be fit in max size
+      else if (((BiosInfo->BiosSize % SIZE_1GB) == 0) &&
+               ((BiosInfo->BiosSize / SIZE_1GB) <= SMBIOS_TYPE0_MAX_EXT_SIZE))
+      {
+        SmbiosRecord->ExtendedBiosSize.Size = (UINT16)(BiosInfo->BiosSize / SIZE_1GB);
+        SmbiosRecord->ExtendedBiosSize.Unit = 1; // GiB/GB unit per spec
+      } else {
+        DEBUG ((DEBUG_ERROR, "%a: BiosSize is invalid\n", __func__));
+        Status = EFI_INVALID_PARAMETER;
+        goto exit;
+      }
+    }
+  } else {
+    DEBUG ((DEBUG_ERROR, "%a: BiosSize is invalid\n", __func__));
+    Status = EFI_INVALID_PARAMETER;
+    goto exit;
+  }
+
+  SmbiosRecord->BiosCharacteristics = BiosInfo->BiosCharacteristics;
+
+  SmbiosRecord->BIOSCharacteristicsExtensionBytes[0] = BiosInfo->BIOSCharacteristicsExtensionBytes[0];
+  SmbiosRecord->BIOSCharacteristicsExtensionBytes[1] = BiosInfo->BIOSCharacteristicsExtensionBytes[1];
+
+  SmbiosRecord->SystemBiosMajorRelease = BiosInfo->SystemBiosMajorRelease;
+  SmbiosRecord->SystemBiosMinorRelease = BiosInfo->SystemBiosMinorRelease;
+
+  SmbiosRecord->EmbeddedControllerFirmwareMajorRelease = BiosInfo->ECFirmwareMajorRelease;
+  SmbiosRecord->EmbeddedControllerFirmwareMinorRelease = BiosInfo->ECFirmwareMinorRelease;
+
+  SmbiosRecord->Vendor          = VendorRef;
+  SmbiosRecord->BiosVersion     = VersionRef;
+  SmbiosRecord->BiosReleaseDate = ReleaseDateRef;
+
+  OptionalStrings = (CHAR8 *)(SmbiosRecord + 1);
+  // publish the string set
+  Status = StringTablePublishStringSet (
+             &StrTable,
+             OptionalStrings,
+             (SmbiosRecordSize - sizeof (SMBIOS_TABLE_TYPE0))
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: Failed to publish string set %r\n", __func__, Status));
+    goto exit;
+  }
+
+  // setup the header
+  SmbiosRecord->Hdr.Type   = EFI_SMBIOS_TYPE_BIOS_INFORMATION;
+  SmbiosRecord->Hdr.Length = sizeof (SMBIOS_TABLE_TYPE0);
+  CmObject                 = BiosInfo->BiosInfoToken;
+
+  *Table         = (SMBIOS_STRUCTURE *)SmbiosRecord;
+  *CmObjectToken = CmObject;
+
+  // free string table
+  StringTableFree (&StrTable);
+  return Status;
+
+exit:
+  // free string table
+  StringTableFree (&StrTable);
+
+  if (SmbiosRecord != NULL) {
+    FreePool (SmbiosRecord);
+  }
+
+  return Status;
+}
+
+/** The interface for the SMBIOS Type0 Table Generator.
+*/
+STATIC
+CONST
+SMBIOS_TABLE_GENERATOR  SmbiosType0Generator = {
+  // Generator ID
+  CREATE_STD_SMBIOS_TABLE_GEN_ID (EStdSmbiosTableIdType00),
+  // Generator Description
+  L"SMBIOS.TYPE0.GENERATOR",
+  // SMBIOS Table Type
+  EFI_SMBIOS_TYPE_BIOS_INFORMATION,
+  // Build table function
+  BuildSmbiosType0Table,
+  // Free function
+  FreeSmbiosType0Table,
+  NULL,
+  NULL
+};
+
+/** Register the Generator with the SMBIOS Table Factory.
+
+  @param [in]  ImageHandle  The handle to the image.
+  @param [in]  SystemTable  Pointer to the System Table.
+
+  @retval EFI_SUCCESS           The Generator is registered.
+  @retval EFI_INVALID_PARAMETER A parameter is invalid.
+  @retval EFI_ALREADY_STARTED   The Generator for the Table ID
+                                is already registered.
+**/
+EFI_STATUS
+EFIAPI
+SmbiosType0LibConstructor (
+  IN  EFI_HANDLE        ImageHandle,
+  IN  EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  EFI_STATUS  Status;
+
+  Status = RegisterSmbiosTableGenerator (&SmbiosType0Generator);
+  DEBUG ((
+    DEBUG_INFO,
+    "SMBIOS Type 0: Register Generator. Status = %r\n",
+    Status
+    ));
+  ASSERT_EFI_ERROR (Status);
+
+  return Status;
+}
+
+/** Deregister the Generator from the SMBIOS Table Factory.
+
+  @param [in]  ImageHandle  The handle to the image.
+  @param [in]  SystemTable  Pointer to the System Table.
+
+  @retval EFI_SUCCESS           The Generator is deregistered.
+  @retval EFI_INVALID_PARAMETER A parameter is invalid.
+  @retval EFI_NOT_FOUND         The Generator is not registered.
+**/
+EFI_STATUS
+EFIAPI
+SmbiosType0LibDestructor (
+  IN  EFI_HANDLE        ImageHandle,
+  IN  EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  EFI_STATUS  Status;
+
+  Status = DeregisterSmbiosTableGenerator (&SmbiosType0Generator);
+  DEBUG ((
+    DEBUG_INFO,
+    "SMBIOS Type0: Deregister Generator. Status = %r\n",
+    Status
+    ));
+  ASSERT_EFI_ERROR (Status);
+  return Status;
+}

--- a/DynamicTablesPkg/Library/Smbios/SmbiosType0Lib/SmbiosType0Lib.inf
+++ b/DynamicTablesPkg/Library/Smbios/SmbiosType0Lib/SmbiosType0Lib.inf
@@ -1,0 +1,37 @@
+## @file
+#  SMBIOS Type0 Table Generator
+#
+#  Copyright (c) 2024 - 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#  Copyright (c) 2019 - 2021, Arm Limited. All rights reserved.<BR>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION    = 0x0001001B
+  BASE_NAME      = SmbiosType0LibArm
+  FILE_GUID      = 8f95040b-4846-4c7e-b5c1-e4565bfcfa4b
+  VERSION_STRING = 1.0
+  MODULE_TYPE    = DXE_DRIVER
+  LIBRARY_CLASS  = NULL|DXE_DRIVER
+  CONSTRUCTOR    = SmbiosType0LibConstructor
+  DESTRUCTOR     = SmbiosType0LibDestructor
+
+[Sources]
+  SmbiosType0Generator.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  EmbeddedPkg/EmbeddedPkg.dec
+  ArmPlatformPkg/ArmPlatformPkg.dec
+  DynamicTablesPkg/DynamicTablesPkg.dec
+
+[Protocols]
+  gEfiSmbiosProtocolGuid                        # PROTOCOL ALWAYS_CONSUMED
+
+[LibraryClasses]
+  BaseLib
+  DebugLib
+  SmbiosStringTableLib
+  MemoryAllocationLib


### PR DESCRIPTION
DynamicTablesPkg: Add SMBIOS Type 0 generation support

Add a Platform Firmware Information CM object and parser for SMBIOS BIOS
Information data.

Add an SMBIOS Type 0 generator that consumes this CM object to build the BIOS
Information record, including vendor, version, release date, BIOS size,
characteristics, release fields, EC firmware release fields, and extended
BIOS size.

Register the new generator and wire it into the DynamicTablesPkg AArch64 DSC.

This PR originated from the work by @gmahadevan in https://github.com/tianocore/edk2/pull/12481
For reference: https://github.com/tianocore/edk2/pull/12481#issuecomment-4384671328