### PR TITLE
MdePkg: StackCheckLib: Update __stack_chk_guard for GCC 17

### DIFF
--- a/MdePkg/Include/Library/StackCheckLib.h
+++ b/MdePkg/Include/Library/StackCheckLib.h
@@ -17,7 +17,10 @@
 // and the return address so that continuously writing past the stack variables will cause
 // the stack cookie to be overwritten. Before the function returns, the stack cookie value
 // will be checked and if there is a mismatch then StackCheckLib handles the failure.
-extern VOID  *__stack_chk_guard;
+// __UINTPTR_TYPE__ will be the same bitwidth as UINTN, but is a different type that edk2 does
+// not define (e.g. on X64 this is unsigned long) and so we cannot use UINTN here. Newer versions
+// of GCC define this as uintptr_t, which is unsigned long on X64.
+extern __UINTPTR_TYPE__  __stack_chk_guard;
 
 /**
   Called when a stack cookie check fails. The return address is the failing address.

--- a/MdePkg/Library/StackCheckLib/StackCheckLibCommonGcc.c
+++ b/MdePkg/Library/StackCheckLib/StackCheckLibCommonGcc.c
@@ -21,7 +21,7 @@ TriggerStackCookieInterrupt (
   VOID
   );
 
-VOID  *__stack_chk_guard = (VOID *)(UINTN)STACK_COOKIE_VALUE;
+__UINTPTR_TYPE__  __stack_chk_guard = (__UINTPTR_TYPE__)STACK_COOKIE_VALUE;
 
 /**
   This function gets called when a gcc/clang generated stack cookie fails. This implementation calls into a platform

--- a/MdePkg/Library/StackCheckLibNull/StackCheckLibNullGcc.c
+++ b/MdePkg/Library/StackCheckLibNull/StackCheckLibNullGcc.c
@@ -8,7 +8,7 @@
 #include <Uefi.h>
 #include <Library/StackCheckLib.h>
 
-VOID  *__stack_chk_guard = (VOID *)(UINTN)0x0;
+__UINTPTR_TYPE__  __stack_chk_guard = 0;
 
 /**
   This function gets called when a gcc/clang generated stack cookie fails. This implementation does nothing when


### PR DESCRIPTION
# Description

GCC 17 (upcoming release) is updating the type of
__stack_chk_guard from a void * to a uintptr_t.

This is only a type change, not a size change. However, it does cause the GCC 17 build to fail because of the type mismatch.

uintptr_t is defined as unsigned long, which is not a type edk2 defines. It has the same size as UINTN on a given system, but on 64 bit systems we have the same type issue because UINTN is defined as unsigned long long, not unsigned long.

To work around this and avoid defining a new type in edk2, use the compiler built in __UINTPTR_TYPE__ which is the underlying definition in GCC.

This is a backwards compatible change with previous versions of GCC and CLANGDWARF but also fixes the upcoming definition change for GCC 17.

Closes #12547 .

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Built GCC 17 at the commit referenced in the GCC bugzilla for this: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=121911.
Built OvmfPkgIa32X64 and ArmVirtQemu with this GCC and confirmed I saw the build failure and the new definition works and boots.

Then used my system GCC (GCC 15) and confirmed the same scenarios worked.

Then enabled stack cookies on CLANGDWARF as an extra test and confirmed the same scenarios work.

## Integration Instructions

N/A.
