### PR TITLE
UefiPayloadEntry: Fix use of uninitialized memory

### DIFF
--- a/UefiPayloadPkg/Include/Library/BlParseLib.h
+++ b/UefiPayloadPkg/Include/Library/BlParseLib.h
@@ -68,7 +68,7 @@ ParseMemoryInfo (
 /**
   Acquire SMBIOS table from bootloader.
 
-  @param  SmbiosTable           Pointer to the system table info
+  @param  SmBiosEntryPoint          Pointer to the SMBIOS structure.
 
   @retval RETURN_SUCCESS            Successfully find out the tables.
   @retval RETURN_NOT_FOUND          Failed to find the tables.
@@ -77,7 +77,7 @@ ParseMemoryInfo (
 RETURN_STATUS
 EFIAPI
 ParseSmbiosTable (
-  OUT UNIVERSAL_PAYLOAD_SMBIOS_TABLE  *SmbiosTable
+  OUT UINT64  *SmBiosEntryPoint
   );
 
 /**

--- a/UefiPayloadPkg/Library/CbParseLib/CbParseLib.c
+++ b/UefiPayloadPkg/Library/CbParseLib/CbParseLib.c
@@ -411,7 +411,7 @@ ParseMemoryInfo (
 /**
   Acquire SMBIOS table from coreboot.
 
-  @param  SmbiosTable               Pointer to the SMBIOS table info.
+  @param  SmBiosEntryPoint          Pointer to the SMBIOS structure.
 
   @retval RETURN_SUCCESS            Successfully find out the tables.
   @retval RETURN_NOT_FOUND          Failed to find the tables.
@@ -420,19 +420,23 @@ ParseMemoryInfo (
 RETURN_STATUS
 EFIAPI
 ParseSmbiosTable (
-  OUT UNIVERSAL_PAYLOAD_SMBIOS_TABLE  *SmbiosTable
+  OUT UINT64  *SmBiosEntryPoint
   )
 {
   EFI_STATUS  Status;
   VOID        *MemTable;
   UINT32      MemTableSize;
 
+  if (SmBiosEntryPoint == NULL) {
+    return RETURN_INVALID_PARAMETER;
+  }
+
   Status = ParseCbMemTable (SIGNATURE_32 ('T', 'B', 'M', 'S'), &MemTable, &MemTableSize);
   if (EFI_ERROR (Status)) {
     return EFI_NOT_FOUND;
   }
 
-  SmbiosTable->SmBiosEntryPoint = (UINT64)(UINTN)MemTable;
+  *SmBiosEntryPoint = (UINT64)(UINTN)MemTable;
 
   return RETURN_SUCCESS;
 }

--- a/UefiPayloadPkg/Library/SblParseLib/SblParseLib.c
+++ b/UefiPayloadPkg/Library/SblParseLib/SblParseLib.c
@@ -113,7 +113,7 @@ ParseMemoryInfo (
 /**
   Acquire SMBIOS table from slim bootloader.
 
-  @param  SmbiosTable           Pointer to the SMBIOS table info.
+  @param  SmBiosEntryPoint          Pointer to the SMBIOS structure.
 
   @retval RETURN_SUCCESS            Successfully find out the tables.
   @retval RETURN_NOT_FOUND          Failed to find the tables.
@@ -122,10 +122,14 @@ ParseMemoryInfo (
 RETURN_STATUS
 EFIAPI
 ParseSmbiosTable (
-  OUT UNIVERSAL_PAYLOAD_SMBIOS_TABLE  *SmbiosTable
+  OUT UINT64  *SmBiosEntryPoint
   )
 {
   UNIVERSAL_PAYLOAD_SMBIOS_TABLE  *TableInfo;
+
+  if (SmBiosEntryPoint == NULL) {
+    return RETURN_INVALID_PARAMETER;
+  }
 
   TableInfo = (UNIVERSAL_PAYLOAD_SMBIOS_TABLE *)GetGuidHobDataFromSbl (&gUniversalPayloadSmbiosTableGuid);
   if (TableInfo == NULL) {
@@ -133,7 +137,7 @@ ParseSmbiosTable (
     return RETURN_NOT_FOUND;
   }
 
-  SmbiosTable->SmBiosEntryPoint = TableInfo->SmBiosEntryPoint;
+  *SmBiosEntryPoint = TableInfo->SmBiosEntryPoint;
 
   return RETURN_SUCCESS;
 }

--- a/UefiPayloadPkg/UefiPayloadEntry/UefiPayloadEntry.c
+++ b/UefiPayloadPkg/UefiPayloadEntry/UefiPayloadEntry.c
@@ -350,6 +350,7 @@ BuildHobFromBl (
   EFI_PEI_GRAPHICS_DEVICE_INFO_HOB  *NewGfxDeviceInfo;
   UNIVERSAL_PAYLOAD_SMBIOS_TABLE    *SmBiosTableHob;
   UNIVERSAL_PAYLOAD_ACPI_TABLE      *AcpiTableHob;
+  UINT64                            SmBiosEntryPoint;
 
   //
   // First find TOLUD
@@ -415,14 +416,15 @@ BuildHobFromBl (
   //
   // Create SmBios table Hob
   //
-  SmBiosTableHob = BuildGuidHob (&gUniversalPayloadSmbiosTableGuid, sizeof (UNIVERSAL_PAYLOAD_SMBIOS_TABLE));
-  ASSERT (SmBiosTableHob != NULL);
-  SmBiosTableHob->Header.Revision = UNIVERSAL_PAYLOAD_SMBIOS_TABLE_REVISION;
-  SmBiosTableHob->Header.Length   = sizeof (UNIVERSAL_PAYLOAD_SMBIOS_TABLE);
-  DEBUG ((DEBUG_INFO, "Create smbios table gUniversalPayloadSmbiosTableGuid guid hob\n"));
-  Status = ParseSmbiosTable (SmBiosTableHob);
+  Status = ParseSmbiosTable (&SmBiosEntryPoint);
   if (!EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_INFO, "Detected Smbios Table at 0x%lx\n", SmBiosTableHob->SmBiosEntryPoint));
+    DEBUG ((DEBUG_INFO, "Detected Smbios Table at 0x%lx\n", SmBiosEntryPoint));
+    SmBiosTableHob = BuildGuidHob (&gUniversalPayloadSmbiosTableGuid, sizeof (UNIVERSAL_PAYLOAD_SMBIOS_TABLE));
+    ASSERT (SmBiosTableHob != NULL);
+    SmBiosTableHob->Header.Revision  = UNIVERSAL_PAYLOAD_SMBIOS_TABLE_REVISION;
+    SmBiosTableHob->Header.Length    = sizeof (UNIVERSAL_PAYLOAD_SMBIOS_TABLE);
+    SmBiosTableHob->SmBiosEntryPoint = SmBiosEntryPoint;
+    DEBUG ((DEBUG_INFO, "Create smbios table gUniversalPayloadSmbiosTableGuid guid hob\n"));
   }
 
   //


### PR DESCRIPTION
In coreboot the SMBIOS table generation is optional.

When no SMBIOS tables where found UefiPayloadEntry creates the gUniversalPayloadSmbiosTableGuid HOB, but never initializeses the contents, resulting in uninitialized memory, causing SmbiosDxe to crash when it doesn't point to mapped DRAM.

Fix that by only creating gUniversalPayloadSmbiosTableGuid HOB when SMBIOS tables where found.

# Description

- [ ] Breaking change?
  - No
- [x] Impacts security?
  - Fixes use of uninitialized memory
- [ ] Includes tests?
  - No

## How This Was Tested

* Build UEFIPayload for coreboot as bootloader.
* Disabled SMBIOS table generation in coreboot.
* Found UEFIPayload booting into Linux without crash seen in SmbiosDxe.

## Integration Instructions

N/A
