### PR TITLE
DynamicTablesPkg: Fix dependency issues with consumed protocols

### DIFF
--- a/DynamicTablesPkg/Drivers/DynamicTableManagerDxe/AcpiTableBuilder.c
+++ b/DynamicTablesPkg/Drivers/DynamicTableManagerDxe/AcpiTableBuilder.c
@@ -684,6 +684,21 @@ AcpiTableProtocolReady (
   CM_STD_OBJ_CONFIGURATION_MANAGER_INFO  *CfgMfrInfo;
   EDKII_DYNAMIC_TABLE_FACTORY_PROTOCOL   *TableFactoryProtocol;
   METADATA_ROOT_HANDLE                   Root;
+  EFI_ACPI_TABLE_PROTOCOL                *AcpiTableProtocol;
+
+  // Find the AcpiTable protocol
+  Status = gBS->LocateProtocol (
+                  &gEfiAcpiTableProtocolGuid,
+                  NULL,
+                  (VOID **)&AcpiTableProtocol
+                  );
+
+  // The event handler function is called at least once
+  // during installation even if the protocol is not available
+  // at that point.
+  if (EFI_ERROR (Status)) {
+    return;
+  }
 
   // Locate the Dynamic Table Factory
   Status = gBS->LocateProtocol (

--- a/DynamicTablesPkg/Drivers/DynamicTableManagerDxe/SmbiosTableBuilder.c
+++ b/DynamicTablesPkg/Drivers/DynamicTableManagerDxe/SmbiosTableBuilder.c
@@ -555,6 +555,20 @@ SmbiosProtocolReady (
   EDKII_CONFIGURATION_MANAGER_PROTOCOL   *CfgMgrProtocol;
   CM_STD_OBJ_CONFIGURATION_MANAGER_INFO  *CfgMfrInfo;
   EDKII_DYNAMIC_TABLE_FACTORY_PROTOCOL   *TableFactoryProtocol;
+  EFI_SMBIOS_PROTOCOL                    *SmbiosProtocol;
+
+  Status = gBS->LocateProtocol (
+                  &gEfiSmbiosProtocolGuid,
+                  NULL,
+                  (VOID **)&SmbiosProtocol
+                  );
+
+  // The event handler function is called at least once
+  // during installation even if the protocol is not available
+  // at that point.
+  if (EFI_ERROR (Status)) {
+    return;
+  }
 
   // Locate the Dynamic Table Factory
   Status = gBS->LocateProtocol (


### PR DESCRIPTION
# Description

Fix the DynamicTablesPkg dependency resolution logic on AcpiTablesProtocol for some cases. It may work if the AcpiTableDxe is happenned to be loaded before DynamicTableManagerDxe but not in general case. 

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

### Build

```
host$ docker run --rm -ti -v "${HOME}":"${HOME}" \
    -e EDK2_DOCKER_USER_HOME="${HOME}" \
    -v $(pwd):/host -w /host \
    --name edk2-ubuntu-dev \
    ghcr.io/tianocore/containers/ubuntu-22-dev:latest /bin/bash
docker$ export WORKSPACE=$(pwd)
docker$ export EDK_TOOLS_PATH=/host/edk2/BaseTools
docker$ source edk2/edksetup.sh
docker$ make -j$(nproc) -C edk2/BaseTools
docker$ git clone -b fix-dynamic-tables-dep https://github.com/gonzoua/edk2-dut.git /tmp/edk2-dut
docker$ export PACKAGES_PATH=$(pwd):/tmp/edk2-dut
docker$ build -t GCC -a AARCH64 -p /tmp/edk2-dut/Arm64Dut.dsc
```

### Test

```
export CODE=Build/Arm64Dut/$B/FV/QEMU_EFI.fd
export VARS=Build/Arm64Dut/$B/FV/QEMU_VARS.fd

dd of="QEMU_EFI-pflash.raw" if="/dev/zero" bs=1M count=64
dd of="QEMU_EFI-pflash.raw" if="${CODE}" conv=notrunc
dd of="QEMU_VARS-pflash.raw" if="/dev/zero" bs=1M count=64
dd of="QEMU_VARS-pflash.raw" if="${VARS}" conv=notrunc

qemu-system-aarch64 -m 4G -cpu cortex-a57 -M virt -nographic \
       -drive file=QEMU_EFI-pflash.raw,format=raw,if=pflash \
       -drive file=QEMU_VARS-pflash.raw,format=raw,if=pflash 
```

Without the fix boot fails with assertion:
```
add-symbol-file /host/Build/Arm64Dut/DEBUG_GCC/AARCH64/DynamicTablesPkg/Drivers/DynamicTableManagerDxe/DynamicTableManagerDxe/DEBUG/DynamicTableManagerDxe.dll 0x13F4FC000
Loading driver at 0x0013F4FB000 EntryPoint=0x0013F500CB0 DynamicTableManagerDxe.efi
InstallProtocolInterface: BC62157E-3E33-4FEC-9920-2D3B36D750DF 13F5A2018
ProtectUefiImageCommon - 0x3F5AF540
  - 0x000000013F4FB000 - 0x000000000000B000
INFO: CmObjectId = 0, Ptr = 0x13F5FA0F2, Size = 10, Count = 1
INFO: Configuration Manager Version = 0x0, OemID = TESTCM
ERROR: Failed to find AcpiTable protocol. Status = Not Found
ERROR: ACPI Table processing failure. Status = Not Found

ASSERT_EFI_ERROR (Status = Not Found)
ASSERT [DynamicTableManagerDxe] AcpiTableBuilder.c(758): !(((RETURN_STATUS)(Status)) >= 0x8000000000000000ULL)
```


## Integration Instructions

