### PR TITLE
MdeModulePkg/ArmFfaLib: Fix VM ID handling for RX release and RXTX unmap

### DIFF
--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaCommon.c
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaCommon.c
@@ -2,6 +2,8 @@
   Arm Ffa library common code.
 
   Copyright (c) 2024, Arm Limited. All rights reserved.<BR>
+  Copyright (c) Qualcomm Technologies, Inc. All rights reserved.<BR>
+
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
    @par Glossary:
@@ -323,6 +325,13 @@ ArmFfaLibRxRelease (
   ZeroMem (&FfaArgs, sizeof (ARM_FFA_ARGS));
 
   FfaArgs.Arg0 = ARM_FID_FFA_RX_RELEASE;
+
+  /*
+   * Per Table 13.21: FFA_RX_RELEASE function syntax in
+   * DEN0077A_Firmware_Framework_Arm_A-profile_1.3_ALP1.pdf
+   * PartId should be set to 0 in ARM_FID_FFA_RX_RELEASE.
+   */
+  PartId       = 0;
   FfaArgs.Arg1 = PartId;
 
   ArmCallFfa (&FfaArgs);

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaRxTxMap.c
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaRxTxMap.c
@@ -2,6 +2,8 @@
   Arm Ffa library common code.
 
   Copyright (c) 2024, Arm Limited. All rights reserved.<BR>
+  Copyright (c) Qualcomm Technologies, Inc. All rights reserved.<BR>
+
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
    @par Glossary:
@@ -191,11 +193,16 @@ ArmFfaLibRxTxUnmap (
   VOID          *Buffers;
   UINT16        PartId;
 
-  ArmFfaLibGetPartId (&PartId);
-
   ZeroMem (&FfaArgs, sizeof (ARM_FFA_ARGS));
 
   FfaArgs.Arg0 = ARM_FID_FFA_RXTX_UNMAP;
+
+  /*
+   * Per Table 13.30: FFA_RXTX_UNMAP function syntax in
+   * DEN0077A_Firmware_Framework_Arm_A-profile_1.3_ALP1.pdf
+   * PartId should be set to 0 in ARM_FID_FFA_RXTX_UNMAP.
+   */
+  PartId       = 0;
   FfaArgs.Arg1 = (PartId << ARM_FFA_SOURCE_EP_SHIFT);
 
   ArmCallFfa (&FfaArgs);
@@ -290,8 +297,6 @@ RemapFfaRxTxBuffer (
   EFI_HOB_MEMORY_ALLOCATION  *RxTxBufferAllocationHob;
   UINT16                     PartId;
 
-  ArmFfaLibGetPartId (&PartId);
-
   RxTxBufferAllocationHob = FindRxTxBufferAllocationHob (TRUE);
   if (RxTxBufferAllocationHob == NULL) {
     return EFI_NOT_FOUND;
@@ -301,6 +306,13 @@ RemapFfaRxTxBuffer (
 
   ZeroMem (&FfaArgs, sizeof (ARM_FFA_ARGS));
   FfaArgs.Arg0 = ARM_FID_FFA_RXTX_UNMAP;
+
+  /*
+   * Per Table 13.30: FFA_RXTX_UNMAP function syntax in
+   * DEN0077A_Firmware_Framework_Arm_A-profile_1.3_ALP1.pdf
+   * PartId should be set to 0 in ARM_FID_FFA_RXTX_UNMAP.
+   */
+  PartId       = 0;
   FfaArgs.Arg1 = (PartId << ARM_FFA_SOURCE_EP_SHIFT);
 
   ArmCallFfa (&FfaArgs);

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaSecRxTxMap.c
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaSecRxTxMap.c
@@ -2,6 +2,8 @@
   Arm Ffa library common code.
 
   Copyright (c) 2025, Arm Limited. All rights reserved.<BR>
+  Copyright (c) Qualcomm Technologies, Inc. All rights reserved.<BR>
+
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
    @par Glossary:
@@ -309,15 +311,16 @@ ArmFfaLibRxTxUnmap (
     return EFI_INVALID_PARAMETER;
   }
 
-  Status = ArmFfaLibPartitionIdGet (&PartId);
-  if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a, Failed to acquire partition ID. Status: %r\n", __func__, Status));
-    return EFI_INVALID_PARAMETER;
-  }
-
   ZeroMem (&FfaArgs, sizeof (ARM_FFA_ARGS));
 
   FfaArgs.Arg0 = ARM_FID_FFA_RXTX_UNMAP;
+
+  /*
+   * Per Table 13.30: FFA_RXTX_UNMAP function syntax in
+   * DEN0077A_Firmware_Framework_Arm_A-profile_1.3_ALP1.pdf
+   * PartId should be set to 0 in ARM_FID_FFA_RXTX_UNMAP.
+   */
+  PartId       = 0;
   FfaArgs.Arg1 = (PartId << ARM_FFA_SOURCE_EP_SHIFT);
 
   ArmCallFfa (&FfaArgs);

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaStandaloneMmRxTxMap.c
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaStandaloneMmRxTxMap.c
@@ -2,6 +2,8 @@
   Arm Ffa library common code.
 
   Copyright (c) 2024-2025, Arm Limited. All rights reserved.<BR>
+  Copyright (c) Qualcomm Technologies, Inc. All rights reserved.<BR>
+
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
    @par Glossary:
@@ -216,8 +218,6 @@ ArmFfaLibRxTxUnmap (
   VOID          *Buffers;
   UINT16        SourceId;
 
-  ArmFfaLibGetPartId (&SourceId);
-
   if (mArmFfaRxTxBufferStmmInfoHandle == NULL) {
     // This means that the agent tried to unmap the buffers before even know them.
     // Let's be a nice player...
@@ -227,6 +227,13 @@ ArmFfaLibRxTxUnmap (
   ZeroMem (&FfaArgs, sizeof (ARM_FFA_ARGS));
 
   FfaArgs.Arg0 = ARM_FID_FFA_RXTX_UNMAP;
+
+  /*
+   * Per Table 13.30: FFA_RXTX_UNMAP function syntax in
+   * DEN0077A_Firmware_Framework_Arm_A-profile_1.3_ALP1.pdf
+   * SourceId should be set to 0 in ARM_FID_FFA_RXTX_UNMAP.
+   */
+  SourceId     = 0;
   FfaArgs.Arg1 = (SourceId << ARM_FFA_SOURCE_EP_SHIFT);
 
   ArmCallFfa (&FfaArgs);


### PR DESCRIPTION
### **Description**

This is follow-up of https://github.com/tianocore/edk2/pull/12235

According to the FF‑A specification, when FFA_RX_RELEASE or FFA_RXTX_UNMAP is invoked from UEFI as a non-secure virtual instance, the w1 register must be zero (MBZ). Supplying a non‑zero value in this context results in the SPMC returning FFA_INVALID_PARAMETER.

When these functions are invoked from UEFI as a non-secure physical instance, FFA_ID_GET always returns a VM ID of zero. As a result, passing a non‑zero VM ID is unnecessary and may be invalid.

Therefore, in edk2, w1 (VM ID or partition ID) should always be set to zero when invoking FFA_RX_RELEASE and FFA_RXTX_UNMAP.

 [ ] Breaking change?

 [ ] Impacts security?

 [ ] Includes tests?

### **How This Was Tested**
This change was tested on an internal device that complies with the Hafnium implementation.

### **Integration Instructions**
There is no special requirements.