### PR TITLE
ArmPlatformPkg, EmbededPkg: Add EFIAPI for UEFI event handlers and protocol member functions

### DIFF
--- a/ArmPlatformPkg/Drivers/LcdGraphicsOutputDxe/LcdGraphicsOutputDxe.c
+++ b/ArmPlatformPkg/Drivers/LcdGraphicsOutputDxe/LcdGraphicsOutputDxe.c
@@ -220,6 +220,7 @@ EXIT:
   and uninstall the protocols
 **/
 VOID
+EFIAPI
 LcdGraphicsExitBootServicesEvent (
   IN EFI_EVENT  Event,
   IN VOID       *Context

--- a/ArmPlatformPkg/Drivers/LcdGraphicsOutputDxe/LcdGraphicsOutputDxe.h
+++ b/ArmPlatformPkg/Drivers/LcdGraphicsOutputDxe/LcdGraphicsOutputDxe.h
@@ -44,6 +44,7 @@ typedef struct {
 //
 
 VOID
+EFIAPI
 LcdGraphicsExitBootServicesEvent (
   IN EFI_EVENT  Event,
   IN VOID       *Context

--- a/EmbeddedPkg/Application/AndroidFastboot/AndroidFastbootApp.c
+++ b/EmbeddedPkg/Application/AndroidFastboot/AndroidFastbootApp.c
@@ -367,6 +367,7 @@ AcceptData (
 */
 STATIC
 VOID
+EFIAPI
 DataReady (
   IN EFI_EVENT  Event,
   IN VOID       *Context
@@ -406,6 +407,7 @@ DataReady (
 */
 STATIC
 VOID
+EFIAPI
 FatalErrorNotify (
   IN EFI_EVENT  Event,
   IN VOID       *Context

--- a/EmbeddedPkg/Drivers/AndroidFastbootTransportTcpDxe/FastbootTransportTcp.c
+++ b/EmbeddedPkg/Drivers/AndroidFastbootTransportTcpDxe/FastbootTransportTcp.c
@@ -292,6 +292,7 @@ ConnectionAccepted (
   start waiting for a TCP connection on the Fastboot port.
 */
 EFI_STATUS
+EFIAPI
 TcpFastbootTransportStart (
   EFI_EVENT  ReceiveEvent
   )
@@ -466,6 +467,7 @@ TcpFastbootTransportStart (
 }
 
 EFI_STATUS
+EFIAPI
 TcpFastbootTransportStop (
   VOID
   )
@@ -558,6 +560,7 @@ DataSent (
 }
 
 EFI_STATUS
+EFIAPI
 TcpFastbootTransportSend (
   IN        UINTN      BufferSize,
   IN  CONST VOID       *Buffer,
@@ -603,6 +606,7 @@ TcpFastbootTransportSend (
 }
 
 EFI_STATUS
+EFIAPI
 TcpFastbootTransportReceive (
   OUT UINTN  *BufferSize,
   OUT VOID   **Buffer

--- a/EmbeddedPkg/Drivers/AndroidFastbootTransportTcpDxe/FastbootTransportTcp.c
+++ b/EmbeddedPkg/Drivers/AndroidFastbootTransportTcpDxe/FastbootTransportTcp.c
@@ -123,6 +123,7 @@ SubmitRecieveToken (
 */
 STATIC
 VOID
+EFIAPI
 ConnectionClosed (
   IN EFI_EVENT  Event,
   IN VOID       *Context

--- a/EmbeddedPkg/Include/Protocol/AndroidFastbootTransport.h
+++ b/EmbeddedPkg/Include/Protocol/AndroidFastbootTransport.h
@@ -42,7 +42,7 @@ extern EFI_GUID  gAndroidFastbootTransportProtocolGuid;
 */
 typedef
 EFI_STATUS
-(*FASTBOOT_TRANSPORT_START) (
+(EFIAPI *FASTBOOT_TRANSPORT_START)(
   IN EFI_EVENT  ReceiveEvent
   );
 
@@ -60,7 +60,7 @@ EFI_STATUS
 */
 typedef
 EFI_STATUS
-(*FASTBOOT_TRANSPORT_STOP) (
+(EFIAPI *FASTBOOT_TRANSPORT_STOP)(
   VOID
   );
 
@@ -85,7 +85,7 @@ EFI_STATUS
  */
 typedef
 EFI_STATUS
-(*FASTBOOT_TRANSPORT_SEND) (
+(EFIAPI *FASTBOOT_TRANSPORT_SEND)(
   IN        UINTN      BufferSize,
   IN  CONST VOID       *Buffer,
   IN        EFI_EVENT  *FatalErrorEvent
@@ -110,7 +110,7 @@ EFI_STATUS
 */
 typedef
 EFI_STATUS
-(*FASTBOOT_TRANSPORT_RECEIVE) (
+(EFIAPI *FASTBOOT_TRANSPORT_RECEIVE)(
   OUT UINTN  *BufferSize,
   OUT VOID   **Buffer
   );


### PR DESCRIPTION
# Description

According to [UEFI specification Calling Convention:](https://uefi.org/specs/UEFI/2.10/02_Overview.html#calling-conventions)

> All public interfaces of a UEFI module must follow the UEFI calling convention. Public interfaces include the image entry point, UEFI event handlers, and protocol member functions. The type EFIAPI is used to indicate conformance to the calling conventions defined in this section. 

This patch set adds EFIAPI for UEFI event handlers and protocol member functions in ArmPlatformPkg and EmbededPkg.

## How This Was Tested

Pass CI check.

## Integration Instructions

N/A
