### PR TITLE
Return EFI_NOT_FOUND for NULL SourceBuffer and DevicePath in LoadImage

### DIFF
--- a/MdeModulePkg/Core/Dxe/Image/Image.c
+++ b/MdeModulePkg/Core/Dxe/Image/Image.c
@@ -1210,7 +1210,7 @@ CoreLoadImageCommon (
     }
   } else {
     if (FilePath == NULL) {
-      return EFI_INVALID_PARAMETER;
+      return EFI_NOT_FOUND;
     }
 
     //


### PR DESCRIPTION
# Description

Update CoreLoadImageCommon to return EFI_NOT_FOUND instead of EFI_INVALID_PARAMETER when both SourceBuffer and DevicePath are NULL. UEFI 2.11 specification requires this change for LoadImage().

+ References:
[UEFI Spec](https://uefi.org/specs/UEFI/2.11/07_Services_Boot_Services.html#efi-boot-services-loadimage)
[SCT update patch](https://github.com/tianocore/edk2-test/issues/312)

## How This Was Tested
Successfully passed the Arm SystemReady SCT (Self-Certification Test) suite.
BS.LoadImage - ConsistencyTestCheckpoint2.
