### PR TITLE
MdeModulePkg/PciBusDxe: Scan funcs when func 0 is absent

### DIFF
--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciBusDxe.inf
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciBusDxe.inf
@@ -90,6 +90,7 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdPciBridgeIoAlignmentProbe       ## CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdUnalignedPciIoEnable            ## CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdPciDegradeResourceForOptionRom  ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdPciScanFuncIfFunc0Absent       ## CONSUMES
 
 [Pcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdSrIovSystemPageSize         ## SOMETIMES_CONSUMES

--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciEnumeratorSupport.c
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciEnumeratorSupport.c
@@ -266,10 +266,21 @@ PciPciDeviceInfoCollector (
                  );
 
       if (EFI_ERROR (Status) && (Func == 0)) {
+        if (!FeaturePcdGet (PcdPciScanFuncIfFunc0Absent)) {
+          //
+          // Preserve default behavior for physical platforms: go to next
+          // device if there is no Function 0.
+          //
+          break;
+        }
+
         //
-        // go to next device if there is no Function 0
+        // Some virtualized PCI topologies may let a hypervisor expose
+        // selected non-zero functions to a guest while Function 0 is absent.
+        // Some platforms may require probing such functions.
+        // Keep scanning only when enabled by platform policy.
         //
-        break;
+        continue;
       }
 
       if (!EFI_ERROR (Status)) {

--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -882,6 +882,12 @@
   # @Prompt Enable PCI bridge IO alignment probe.
   gEfiMdeModulePkgTokenSpaceGuid.PcdPciBridgeIoAlignmentProbe|FALSE|BOOLEAN|0x0001004e
 
+  ## Indicates if the PciBus driver scans functions 1..7 when function 0 is absent.<BR>
+  #   TRUE  - PciBus driver scans non-zero functions when Function 0 is absent.<BR>
+  #   FALSE - PciBus driver skips the device when Function 0 is absent.<BR>
+  # @Prompt Enable scanning PCI functions 1..7 without Function 0.
+  gEfiMdeModulePkgTokenSpaceGuid.PcdPciScanFuncIfFunc0Absent|FALSE|BOOLEAN|0x0001007a
+
   ## Indicates if PEI phase StatusCode will be replayed in DXE phase.<BR><BR>
   #   TRUE  - Replays PEI phase StatusCode in DXE phased.<BR>
   #   FALSE - Does not replay PEI phase StatusCode in DXE phase.<BR>


### PR DESCRIPTION
# Description        
## Summary                                                                                                                                          
- Add `PcdPciScanFuncIfFunc0Absent`, default `FALSE`.
- Let PciBusDxe continue collecting device information for functions 1..7 when function 0 is absent and the PCD is enabled.
- Preserve existing platform behavior by default.

## Background
Some virtualized PCI topologies may expose selected non-zero functions to a guest while function 0 is hidden. Platforms that require this behavior can opt in through the new Feature PCD.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested
Tested on a physical platform that exposes a multi-function PCI device
where function 0 is intentionally unavailable after its clock is disabled,
while function 1 is still required by the platform.
    
With the new PCD enabled, PciBusDxe continued scanning functions 1..7
after function 0 was not detected, and the required function 1 device was
discovered during PCI enumeration.

    Built OVMF with the new PCD disabled and enabled:
    
    bash
    build -p OvmfPkg/OvmfPkgX64.dsc -a X64 -b DEBUG -t GCC \
      --pcd PcdPciScanFuncIfFunc0Absent=FALSE
    
    build -p OvmfPkg/OvmfPkgX64.dsc -a X64 -b DEBUG -t GCC \
      --pcd PcdPciScanFuncIfFunc0Absent=TRUE
    
    
    Booted OVMF with QEMU using an e1000e device placed at function 1 while
    function 0 was absent:
    
    bash
    qemu-system-x86_64 \
      -machine q35,accel=tcg \
      -m 512M \
      -nodefaults \
      -display none \
      -monitor none \
      -no-reboot \
      -bios Build/OvmfX64/DEBUG_GCC/FV/OVMF.fd \
      -debugcon file:/tmp/qemu-pci-func-test/ovmf-debug.log \
      -global isa-debugcon.iobase=0x402 \
      -device e1000e,bus=pcie.0,addr=0x5.1,multifunction=on
    
    
    QEMU reported:
    
    text
    Bus  0, device   5, function 1:
      Ethernet controller: PCI device 8086:10d3
    
    
    With the PCD set to FALSE, OVMF did not discover [00|05|01].
    With the PCD set to TRUE, OVMF discovered it:
    
    text
    PciBus: Discovered PCI @ [00|05|01]  [VID = 0x8086, DID = 0x10D3]

## Integration Instructions
Platforms that need to discover valid non-zero PCI functions when function 0 is absent can enable the new Feature PCD in their DSC.





