### PR TITLE
 OvmfPkg,SecurityPkg: Document explicitly the referenced TCG Spec. revisions

### DIFF
--- a/OvmfPkg/Tcg/TdTcg2Dxe/TdTcg2Dxe.c
+++ b/OvmfPkg/Tcg/TdTcg2Dxe/TdTcg2Dxe.c
@@ -316,7 +316,7 @@ InternalDumpHex (
 
   This function initialize TD_EVENT_HDR for EV_NO_ACTION
   Event Type other than EFI Specification ID event. The behavior is defined
-  by TCG PC Client PFP Spec. Section 9.3.4 EV_NO_ACTION Event Types
+  by TCG PC Client PFP Spec. 00.21 (2016) Section 9.3.4 EV_NO_ACTION Event Types
 
   @param[in, out]   NoActionEvent  Event Header of EV_NO_ACTION Event
   @param[in]        EventSize      Event Size of the EV_NO_ACTION Event
@@ -1480,8 +1480,8 @@ SetupCcEventLog (
   //
   // TD Event log re-use the spec of TCG2 Event log.
   // Log TcgEfiSpecIdEventStruct as the first Event. Event format is TCG_PCR_EVENT.
-  //   TCG EFI Protocol Spec. Section 5.3 Event Log Header
-  //   TCG PC Client PFP spec. Section 9.2 Measurement Event Entries and Log
+  //   TCG EFI Protocol Spec. 00.13 (2016) Section 5.3 Event Log Header
+  //   TCG PC Client PFP Spec. 00.21 (2016) Section 9.2 Measurement Event Entries and Log
   //
   Status = TdxDxeLogEvent (
              LogFormat,
@@ -1817,7 +1817,7 @@ ReadAndMeasureVariable (
 
 /**
   Read then Measure and log an EFI boot variable, and extend the measurement result into PCR[1].
-according to TCG PC Client PFP spec 0021 Section 2.4.4.2
+according to TCG PC Client PFP Spec. 00.21 (2016) Section 2.4.4.2
 
   @param[in]   VarName          A Null-terminated string that is the name of the vendor's variable.
   @param[in]   VendorGuid       A unique identifier for the vendor.
@@ -2158,7 +2158,7 @@ OnReadyToBoot (
 
     //
     // 7. Next boot attempt, measure "Calling EFI Application from Boot Option" again
-    // TCG PC Client PFP spec Section 2.4.4.5 Step 4
+    // TCG PC Client PFP Spec. 00.21 (2016) Section 2.4.4.5 Step 4
     //
     Status = TdMeasureAction (
                TdxMeasurementMapPcrToMrIndex (4),

--- a/SecurityPkg/Tcg/Tcg2Dxe/Tcg2Dxe.c
+++ b/SecurityPkg/Tcg/Tcg2Dxe/Tcg2Dxe.c
@@ -175,7 +175,7 @@ InternalDumpData (
 /**
 
   This function initialize TCG_PCR_EVENT2_HDR for EV_NO_ACTION Event Type other than EFI Specification ID event
-  The behavior is defined by TCG PC Client PFP Spec. Section 9.3.4 EV_NO_ACTION Event Types
+  The behavior is defined by TCG PC Client PFP Spec. 00.21 (2016) Section 9.3.4 EV_NO_ACTION Event Types
 
   @param[in, out]   NoActionEvent  Event Header of EV_NO_ACTION Event
   @param[in]        EventSize      Event Size of the EV_NO_ACTION Event
@@ -1735,8 +1735,8 @@ SetupEventLog (
 
         //
         // Log TcgEfiSpecIdEventStruct as the first Event. Event format is TCG_PCR_EVENT.
-        //   TCG EFI Protocol Spec. Section 5.3 Event Log Header
-        //   TCG PC Client PFP spec. Section 9.2 Measurement Event Entries and Log
+        //   TCG EFI Protocol Spec. 00.13 (2016) Section 5.3 Event Log Header
+        //   TCG PC Client PFP Spec. 00.21 (2016) Section 9.2 Measurement Event Entries and Log
         //
         Status = TcgDxeLogEvent (
                    mTcg2EventInfo[Index].LogFormat,
@@ -1790,7 +1790,7 @@ SetupEventLog (
 
           //
           // Log EfiStartupLocalityEvent as the second Event
-          //   TCG PC Client PFP spec. Section 9.3.4.3 Startup Locality Event
+          //   TCG PC Client PFP Spec. 00.21 (2016) Section 9.3.4.3 Startup Locality Event
           //
           Status = TcgDxeLogEvent (
                      mTcg2EventInfo[Index].LogFormat,
@@ -2196,7 +2196,7 @@ ReadAndMeasureVariable (
 
 /**
   Read then Measure and log an EFI boot variable, and extend the measurement result into PCR[1].
-according to TCG PC Client PFP spec 0021 Section 2.4.4.2
+according to TCG PC Client PFP Spec. 00.21 (2016) Section 2.4.4.2
 
   @param[in]   VarName          A Null-terminated string that is the name of the vendor's variable.
   @param[in]   VendorGuid       A unique identifier for the vendor.
@@ -2565,7 +2565,7 @@ OnReadyToBoot (
 
     //
     // 7. Next boot attempt, measure "Calling EFI Application from Boot Option" again
-    // TCG PC Client PFP spec Section 2.4.4.5 Step 4
+    // TCG PC Client PFP Spec. 00.21 (2016) Section 2.4.4.5 Step 4
     //
     Status = TcgMeasureAction (
                4,


### PR DESCRIPTION
# Description

Where sections in TCG Specification documents are referenced, be explicit about which revision of the document that is referenced.

This is a pure change to documentation, to the comments in the C code.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

## Integration Instructions
