### PR TITLE
OvmfPkg: Add WSMT ACPI table

### DIFF
--- a/MdePkg/Include/IndustryStandard/WindowsSmmSecurityMitigationTable.h
+++ b/MdePkg/Include/IndustryStandard/WindowsSmmSecurityMitigationTable.h
@@ -1,10 +1,22 @@
 /** @file
   Defines Windows SMM Security Mitigation Table
-  @ https://msdn.microsoft.com/windows/hardware/drivers/bringup/acpi-system-description-tables#wsmt
+  @ https://learn.microsoft.com/en-us/windows-hardware/drivers/bringup/acpi-system-description-tables#windows-smm-security-mitigations-table-wsmt
 
   Copyright (c) 2016 - 2018, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
+  Supported versions of Windows operating systems read the WSMT early
+  during initialization, prior to start of the ACPI interpreter and
+  subsequent evaluation of the _OSI method. The Protection Flags field
+  indicates the presence of specific BIOS security mitigations in system
+  firmware.  Firmware setting any of the Protections Flags represents an
+  attestation by the platform to OSPM that the corresponding firmware
+  feature or coding practice has been implemented.  OSPM may not be able
+  to functionally validate that this is indeed the case, and must rely
+  on system firmware to accurately represent its capabilities.
+  Windows operating systems may elect to enable, disable, or de-feature
+  certain security features based on the presence of these SMM
+  Protections Flags.
 **/
 
 #pragma once
@@ -22,8 +34,40 @@ typedef struct {
   UINT32                         ProtectionFlags;
 } EFI_ACPI_WSMT_TABLE;
 
-#define EFI_WSMT_PROTECTION_FLAGS_FIXED_COMM_BUFFERS                 0x1
+// FIXED_COMM_BUFFERS
+// If set, expresses that for all synchronous SMM entries, SMM will
+// validate that input and output buffers lie entirely within the
+// expected fixed memory regions.
+// Firmware setting this bit should refer to the SMM Communication
+// ACPI Table defined in the UEFI 2.6 specification.  Firmware should
+// also consider all other possible data exchanges between SMM and
+// non-SMM, including but not limited to EFI_SMM_COMMUNICATION_PROTOCOL,
+// ACPINVS in ASL code, general purpose registers as buffer pointers,
+// etc.
+#define EFI_WSMT_PROTECTION_FLAGS_FIXED_COMM_BUFFERS  0x1
+
+// COMM_BUFFER_NESTED_PTR_PROTECTION
+// If set, expresses that for all synchronous SMM entries, SMM will
+// validate that input and output pointers embedded within the fixed
+// communication buffer only refer to address ranges that lie entirely
+// within the expected fixed memory regions.
+// Firmware setting this bit must also set the FIXED_COMM_BUFFERS bit.
 #define EFI_WSMT_PROTECTION_FLAGS_COMM_BUFFER_NESTED_PTR_PROTECTION  0x2
-#define EFI_WSMT_PROTECTION_FLAGS_SYSTEM_RESOURCE_PROTECTION         0x4
+
+// SYSTEM_RESOURCE_PROTECTION
+// Firmware setting this bit is an indication that it will not allow
+// reconfiguration of system resources via non-architectural mechanisms.
+// After ExitBootServices(), firmware setting this bit shall not allow
+// any software to make changes to the locations of: IOMMU’s, interrupt
+// controllers, PCI Configuration Space, the Firmware ACPI Control
+// Structure (FACS), or any registers reported through ACPI fixed
+// tables (e.g. PMx Control registers, reset register, etc.).
+// This also includes disallowing changes to RAM layout and ensuring
+// that decodes to RAM and any system resources as described above take
+// priority over software configurable registers.  For example, if
+// software configures a PCI Express BAR to overlay RAM, accesses by
+// the CPU to the affected system physical addresses must decode to
+// RAM.
+#define EFI_WSMT_PROTECTION_FLAGS_SYSTEM_RESOURCE_PROTECTION  0x4
 
 #pragma pack()

--- a/OvmfPkg/OvmfPkgIa32X64.dsc
+++ b/OvmfPkg/OvmfPkgIa32X64.dsc
@@ -883,6 +883,7 @@
   MdeModulePkg/Universal/Acpi/S3SaveStateDxe/S3SaveStateDxe.inf
   MdeModulePkg/Universal/Acpi/BootScriptExecutorDxe/BootScriptExecutorDxe.inf
   MdeModulePkg/Universal/Acpi/BootGraphicsResourceTableDxe/BootGraphicsResourceTableDxe.inf
+  OvmfPkg/WsmtDxe/WsmtDxe.inf
 
   #
   # Hash2 Protocol producer

--- a/OvmfPkg/OvmfPkgIa32X64.fdf
+++ b/OvmfPkg/OvmfPkgIa32X64.fdf
@@ -324,6 +324,8 @@ INF  MdeModulePkg/Universal/FaultTolerantWriteDxe/FaultTolerantWriteDxe.inf
 INF  MdeModulePkg/Universal/Variable/RuntimeDxe/VariableRuntimeDxe.inf
 !endif
 
+INF  OvmfPkg/WsmtDxe/WsmtDxe.inf
+
 #
 # TPM support
 #

--- a/OvmfPkg/OvmfPkgX64.dsc
+++ b/OvmfPkg/OvmfPkgX64.dsc
@@ -1019,6 +1019,7 @@
   MdeModulePkg/Universal/Acpi/BootScriptExecutorDxe/BootScriptExecutorDxe.inf
 !endif
   MdeModulePkg/Universal/Acpi/BootGraphicsResourceTableDxe/BootGraphicsResourceTableDxe.inf
+  OvmfPkg/WsmtDxe/WsmtDxe.inf
 
   #
   # Hash2 Protocol producer

--- a/OvmfPkg/OvmfPkgX64.fdf
+++ b/OvmfPkg/OvmfPkgX64.fdf
@@ -368,6 +368,8 @@ INF  MdeModulePkg/Universal/Variable/RuntimeDxe/VariableRuntimeDxe.inf
 !endif
 !endif
 
+INF  OvmfPkg/WsmtDxe/WsmtDxe.inf
+
 #
 # EFI_CC_MEASUREMENT_PROTOCOL
 #

--- a/OvmfPkg/WsmtDxe/WsmtDxe.c
+++ b/OvmfPkg/WsmtDxe/WsmtDxe.c
@@ -1,0 +1,119 @@
+/** @file
+  Install the WSMT (Windows SMM Security Mitigation Table) ACPI table.
+
+  The WSMT table informs the OS that the firmware's SMM implementation
+  satisfies specific security properties.
+
+  Copyright (c) 2026, Nutanix, Inc. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <IndustryStandard/WindowsSmmSecurityMitigationTable.h>
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
+#include <Library/PcdLib.h>
+#include <Library/UefiBootServicesTableLib.h>
+#include <Protocol/AcpiTable.h>
+
+STATIC EFI_ACPI_WSMT_TABLE  mWsmtTable = {
+  {
+    EFI_ACPI_WINDOWS_SMM_SECURITY_MITIGATION_TABLE_SIGNATURE,
+    sizeof (EFI_ACPI_WSMT_TABLE),        // Length of the WSMT table, must be 40 for Revision 1
+    EFI_WSMT_TABLE_REVISION,             // Revision 1 of the WSMT table
+    0,                                   // Checksum - filled by InstallAcpiTable
+    //
+    // It is expected that these values will be updated at EntryPoint.
+    //
+    { 0x00 },   // OEM ID is a 6 bytes long field
+    0x00,       // OEM Table ID (8 bytes long)
+    0x00,       // OEM Revision
+    0x00,       // Creator ID
+    0x00,       // Creator Revision
+  },
+  // Protection Flags - updated at EntryPoint.
+  0
+};
+
+STATIC_ASSERT (
+  sizeof (EFI_ACPI_WSMT_TABLE) == 40,
+  "EFI_ACPI_WSMT_TABLE must be 40 for Revision 1"
+  );
+
+/**
+  Entry point for the WSMT DXE driver.
+
+  Installs the WSMT ACPI table when firmware can attest to supported
+  MM communication buffer protections.
+
+  @param[in] ImageHandle  The firmware allocated handle for the EFI image.
+  @param[in] SystemTable  A pointer to the EFI System Table.
+
+  @retval EFI_SUCCESS      The WSMT table was installed successfully.
+  @retval EFI_UNSUPPORTED  No supported WSMT protection is enabled.
+  @retval Others           Error from protocol location or table installation.
+**/
+EFI_STATUS
+EFIAPI
+WsmtDxeEntryPoint (
+  IN EFI_HANDLE        ImageHandle,
+  IN EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  EFI_ACPI_TABLE_PROTOCOL  *AcpiTable;
+  EFI_STATUS               Status;
+  UINTN                    TableKey;
+
+  if (!FeaturePcdGet (PcdSmmSmramRequire) &&
+      !FeaturePcdGet (PcdQemuVarsRequire))
+  {
+    return EFI_UNSUPPORTED;
+  }
+
+  mWsmtTable.ProtectionFlags =
+    EFI_WSMT_PROTECTION_FLAGS_FIXED_COMM_BUFFERS |
+    EFI_WSMT_PROTECTION_FLAGS_COMM_BUFFER_NESTED_PTR_PROTECTION;
+
+  // Update the WSMT table header with the PCDs.
+  CopyMem (
+    mWsmtTable.Header.OemId,
+    PcdGetPtr (PcdAcpiDefaultOemId),
+    sizeof (mWsmtTable.Header.OemId)
+    );
+  mWsmtTable.Header.OemTableId      = PcdGet64 (PcdAcpiDefaultOemTableId);
+  mWsmtTable.Header.OemRevision     = PcdGet32 (PcdAcpiDefaultOemRevision);
+  mWsmtTable.Header.CreatorId       = PcdGet32 (PcdAcpiDefaultCreatorId);
+  mWsmtTable.Header.CreatorRevision = PcdGet32 (PcdAcpiDefaultCreatorRevision);
+
+  Status = gBS->LocateProtocol (
+                  &gEfiAcpiTableProtocolGuid,
+                  NULL,
+                  (VOID **)&AcpiTable
+                  );
+  ASSERT_EFI_ERROR (Status);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  TableKey = 0;
+  Status   = AcpiTable->InstallAcpiTable (
+                          AcpiTable,
+                          &mWsmtTable,
+                          sizeof (mWsmtTable),
+                          &TableKey
+                          );
+  ASSERT_EFI_ERROR (Status);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  DEBUG ((
+    DEBUG_INFO,
+    "%a: Installed WSMT table (ProtectionFlags=0x%x)\n",
+    __func__,
+    mWsmtTable.ProtectionFlags
+    ));
+
+  return EFI_REQUEST_UNLOAD_IMAGE;
+}

--- a/OvmfPkg/WsmtDxe/WsmtDxe.inf
+++ b/OvmfPkg/WsmtDxe/WsmtDxe.inf
@@ -1,0 +1,52 @@
+## @file
+#  WSMT (Windows SMM Security Mitigation Table) ACPI table driver.
+#
+#  Publishes the WSMT ACPI table when OVMF can attest to supported
+#  MM communication buffer protections.
+#
+#  Copyright (c) 2026, Nutanix, Inc. All rights reserved.<BR>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION    = 1.30
+  BASE_NAME      = WsmtDxe
+  FILE_GUID      = f6394dd2-bafd-4d8e-999e-7590df8fc546
+  MODULE_TYPE    = DXE_DRIVER
+  VERSION_STRING = 1.0
+  ENTRY_POINT    = WsmtDxeEntryPoint
+
+[Sources]
+  WsmtDxe.c
+
+[Packages]
+  MdeModulePkg/MdeModulePkg.dec
+  MdePkg/MdePkg.dec
+  OvmfPkg/OvmfPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  BaseMemoryLib
+  DebugLib
+  PcdLib
+  UefiBootServicesTableLib
+  UefiDriverEntryPoint
+
+[Protocols]
+  gEfiAcpiTableProtocolGuid    ## CONSUMES
+
+[Pcd]
+  gEfiMdeModulePkgTokenSpaceGuid.PcdAcpiDefaultOemId            ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdAcpiDefaultOemTableId       ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdAcpiDefaultOemRevision      ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdAcpiDefaultCreatorId        ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdAcpiDefaultCreatorRevision  ## CONSUMES
+
+[FeaturePcd]
+  gUefiOvmfPkgTokenSpaceGuid.PcdSmmSmramRequire
+  gUefiOvmfPkgTokenSpaceGuid.PcdQemuVarsRequire
+
+[Depex]
+  gEfiAcpiTableProtocolGuid


### PR DESCRIPTION
# Description

This change adds the Windows SMM Security Mitigation Table (WSMT) as a new table to OVMF secure boot virtual machines.

WSMT is an ACPI table defined by Microsoft that allows system firmware to confirm to the operating system that certain security best practices have been implemented in System Management Mode (SMM) software. The WSMT table definition is described in the [Windows SMM Security Mitigations Table (WMST) specification](https://learn.microsoft.com/en-us/windows-hardware/drivers/bringup/acpi-system-description-tables) and is already defined in MdePkg/Include/IndustryStandard/WindowsSmmSecurityMitigationTable.h.

In addition to creating a small DXE driver that creates and attaches the table to secure boot enabled VMs, this change extends the documentation within EDK2's IndustryStandard header, to make sure that we're properly reflecting the upstream standards within the EDK2 code base.

From the commit:
```
Windows uses the Windows SMM Security Mitigation Table to decide
whether SMM firmware advertises the communication-buffer protections
needed by VBS [1].

WSMT ProtectionFlags represent a pinky promise that the underlying
firmware will implement various security practices [2].

Add a small DXE driver that installs a revision 1 WSMT table for the
OvmfPkgIa32X64 and OvmfPkgX64 builds.

WSMT ProtectionFlags are set to 0x3, asserting:
  EFI_WSMT_PROTECTION_FLAGS_FIXED_COMM_BUFFERS
  EFI_WSMT_PROTECTION_FLAGS_COMM_BUFFER_NESTED_PTR_PROTECTION

Note, we are intentionally not asserting
EFI_WSMT_PROTECTION_FLAGS_SYSTEM_RESOURCE_PROTECTION, as the QEMU side
is not yet tuned up to enforce this protection.

Note: when Windows Hypervisor Enforced Code Integrity is enabled,
Windows msinfo -> Virtualization-based security Available Security
Properties will NOT include "SMM Security Mitigations 1.0", due to
the missing SYSTEM_RESOURCE_PROTECTION flag. Note, WSMT is required
for default enablement of HVCI [3], so we're taking a step in the right
direction here, but not yet 100% complete as of this patch.
```

References:
[1] https://learn.microsoft.com/en-us/windows-hardware/design/device-experiences/oem-vbs
[2] https://learn.microsoft.com/en-us/windows-hardware/design/device-experiences/oem-uefi-wsmt
[3] https://learn.microsoft.com/en-us/windows-hardware/design/device-experiences/oem-hvci-enablement#check-results-of-memory-integrity-default-enablement

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

- Tested with local EDK2 + QEMU Q35 VM, with Windows 11 25H2 guest and Ubuntu guest
- Inspected debug logs to make sure that the debug statement does print/format correctly

## Integration Instructions

N/A