### PR TITLE
ManageabilityPkg/KcsLib: Fix KCS Read Phase missing dummy byte and incorrect size check

### DIFF
--- a/ManageabilityPkg/Library/ManageabilityTransportKcsLib/KcsCommon.c
+++ b/ManageabilityPkg/Library/ManageabilityTransportKcsLib/KcsCommon.c
@@ -685,7 +685,6 @@ KcsTransportSendCommand (
 {
   EFI_STATUS  Status;
   UINT8       *RspHeader;
-  UINT32      ExpectedResponseDataSize;
 
   if ((RequestData != NULL) && (RequestDataSize == 0)) {
     DEBUG ((DEBUG_ERROR, "%a: Mismatched values of RequestData and RequestDataSize\n", __func__));
@@ -759,24 +758,13 @@ KcsTransportSendCommand (
 
     FreePool (RspHeader);
 
-    ExpectedResponseDataSize = *ResponseDataSize;
-    Status                   = KcsTransportRead (ResponseData, ResponseDataSize);
+    Status = KcsTransportRead (ResponseData, ResponseDataSize);
     if (EFI_ERROR (Status)) {
       DEBUG ((DEBUG_ERROR, "KCS response read Failed with Status(%r)\n", Status));
     }
 
     // Print out the response payloads.
     if (*ResponseDataSize != 0) {
-      if (ExpectedResponseDataSize != *ResponseDataSize) {
-        DEBUG ((
-          DEBUG_ERROR,
-          "Expected KCS response size : %d is not matched to returned size : %d.\n",
-          ExpectedResponseDataSize,
-          *ResponseDataSize
-          ));
-        return EFI_DEVICE_ERROR;
-      }
-
       HelperManageabilityDebugPrint ((VOID *)ResponseData, (UINT32)*ResponseDataSize, "KCS Response Data:\n");
       Status = KcsCheckResponseData (ResponseData, *ResponseDataSize, AdditionalStatus);
     } else {

--- a/ManageabilityPkg/Library/ManageabilityTransportKcsLib/KcsCommon.c
+++ b/ManageabilityPkg/Library/ManageabilityTransportKcsLib/KcsCommon.c
@@ -383,6 +383,47 @@ KcsTransportRead (
     }
   }
 
+  //
+  // Per IPMI 2.0 Spec Figure 9-7, drain remaining bytes until
+  // BMC transitions to IDLE_STATE.
+  //
+  while (TRUE) {
+    Status = WaitStatusClear (IPMI_KCS_IBF);
+    if (EFI_ERROR (Status)) {
+      *Length = ReadLength;
+      return Status;
+    }
+
+    if (IPMI_KCS_GET_STATE (KcsRegisterRead8 (KCS_REG_STATUS)) == IpmiKcsIdleState) {
+      Status = WaitStatusSet (IPMI_KCS_OBF);
+      if (EFI_ERROR (Status)) {
+        *Length = ReadLength;
+        return Status;
+      }
+
+      KcsRegisterRead8 (KCS_REG_DATA_IN);
+      break;
+    } else if (IPMI_KCS_GET_STATE (KcsRegisterRead8 (KCS_REG_STATUS)) == IpmiKcsReadState) {
+      Status = WaitStatusSet (IPMI_KCS_OBF);
+      if (EFI_ERROR (Status)) {
+        *Length = ReadLength;
+        return Status;
+      }
+
+      KcsRegisterRead8 (KCS_REG_DATA_IN);
+      Status = WaitStatusClear (IPMI_KCS_IBF);
+      if (EFI_ERROR (Status)) {
+        *Length = ReadLength;
+        return Status;
+      }
+
+      KcsRegisterWrite8 (KCS_REG_DATA_OUT, IPMI_KCS_CONTROL_CODE_READ);
+    } else {
+      *Length = ReadLength;
+      return EFI_DEVICE_ERROR;
+    }
+  }
+
   *Length = ReadLength;
   return EFI_SUCCESS;
 }


### PR DESCRIPTION
## Summary

Two bug fixes in ManageabilityTransportKcsLib that cause KCS interface to get stuck in READ_STATE, resulting in BMC NOT_READY failures during continuous IPMI command sequences.

### Bug 1: Missing dummy byte read leaves KCS in READ_STATE

When `ResponseBufferSize == actual BMC response size`, the read loop exits via `ReadLength >= *Length` without completing the IPMI Spec Figure 9-7 handshake. The host never reads the final dummy byte at IDLE_STATE, so the KCS interface stays stuck in READ_STATE. The next IPMI command then sees a non-idle interface and fails with `EFI_NOT_READY`.

This is extremely obvious when sending multiple IPMI commands back to back.

### Bug 2: Incorrect response size equality check

`KcsTransportSendCommand()` saves `*ResponseDataSize` (buffer capacity) before calling `KcsTransportRead()`, then returns `EFI_DEVICE_ERROR` if actual bytes read != buffer capacity. Since IPMI responses are variable-length, most commands return fewer bytes than the buffer can hold — this check incorrectly rejects valid responses.

When this check triggers, it also causes the host to skip the read-phase drain (Bug 1), compounding the NOT_READY failure.

## Test Plan

- Tested on SpaceMit V100 EVB platform with BMC over KCS
- Verified IPMI commands succeed when response is shorter than buffer
- Verified KCS interface returns to IDLE_STATE after buffer-full reads
- Confirmed no regression in normal IPMI command flow (Get Device ID, Get SEL Info, etc.)
- Continuous IPMI command sequences no longer trigger NOT_READY

Signed-off-by: Pan Jinbao <jinbao.pan@spacemit.com>