### PR TITLE
UefiCpuPkg/CpuDxe: Always refresh MTRR and page tables

### DIFF
--- a/UefiCpuPkg/CpuDxe/CpuDxe.c
+++ b/UefiCpuPkg/CpuDxe/CpuDxe.c
@@ -13,9 +13,8 @@
 //
 // Global Variables
 //
-BOOLEAN     InterruptState = FALSE;
-EFI_HANDLE  mCpuHandle     = NULL;
-BOOLEAN     mIsFlushingGCD;
+BOOLEAN     InterruptState         = FALSE;
+EFI_HANDLE  mCpuHandle             = NULL;
 BOOLEAN     mIsAllocatingPageTable = FALSE;
 UINT64      mTimerPeriod           = 0;
 
@@ -321,17 +320,6 @@ CpuSetMemoryAttributes (
   UINT64                    CacheAttributes;
   UINT64                    MemoryAttributes;
   MTRR_MEMORY_CACHE_TYPE    CurrentCacheType;
-
-  //
-  // If this function is called because GCD SetMemorySpaceAttributes () is called
-  // by RefreshGcdMemoryAttributes (), then we are just synchronizing GCD memory
-  // map with MTRR values. So there is no need to modify MTRRs, just return immediately
-  // to avoid unnecessary computing.
-  //
-  if (mIsFlushingGCD) {
-    DEBUG ((DEBUG_VERBOSE, "  Flushing GCD\n"));
-    return EFI_SUCCESS;
-  }
 
   //
   // During memory attributes updating, new pages may be allocated to setup
@@ -681,8 +669,6 @@ RefreshGcdMemoryAttributes (
   VOID
   )
 {
-  mIsFlushingGCD = TRUE;
-
   if (IsMtrrSupported ()) {
     RefreshMemoryAttributesFromMtrr ();
   }
@@ -690,8 +676,6 @@ RefreshGcdMemoryAttributes (
   if (IsPagingAndPageAddressExtensionsEnabled ()) {
     RefreshGcdMemoryAttributesFromPaging ();
   }
-
-  mIsFlushingGCD = FALSE;
 }
 
 /**


### PR DESCRIPTION
# Description

The current implementation of CpuSetMemoryAttributes() checks if the function is called by GCD refresh to do nothing and return. However when DxeCore runs out of memory and freed memory guard enabled, DxeCore will reclaim free guarded pages into free pool while those pages are being set to non present by freed guard before. PromoteGuardedFreePages() will call CpuSetMemoryAttributes() to mark those pages as present but since it is called by RefreshGcdMemoryAttributes() it will do nothing leaving pages as non present which causes #PF later on usage.

This condition happens when RefreshGcdMemoryAttributes() calls functions that may call AllocatePool() or AllocatePage() and if memory is run out then DxeCore will reclaim free guarded pages which are non-present resulting allocation functions to return inaccessible memory.

These changes force CpuSetMemoryAttributes() to always update MTRRs and page tables according to parameters.

```

!!!! X64 Exception Type - 0E(#PF - Page-Fault)  CPU Apic ID - 00000000 !!!!
ExceptionData - 0000000000000002  I:0 R:0 U:0 W:1 P:0 PK:0 SS:0 SGX:0
RIP  - 0000000003F061F1, CS  - 0000000000000038, RFLAGS - 0000000000010246
RAX  - 0000000000000000, RCX - 0000000000000007, RDX - 0000000000000004
RBX  - 0000000000002D38, RSP - 0000000003EF5810, RBP - 0000000003EF5870
RSI  - 0000000003F1DD00, RDI - 0000000003F1C880
R8   - 00000000037FC000, R9  - 0000000000003000, R10 - 0000000000000001
R11  - 00000000000000FF, R12 - 0000000003F1E240, R13 - 00000000037FC018
R14  - 0000000000002D10, R15 - 00000000037FC000
DS   - 0000000000000030, ES  - 0000000000000030, FS  - 0000000000000030
GS   - 0000000000000030, SS  - 0000000000000030
CR0  - 0000000080010033, CR2 - 00000000037FC010, CR3 - 0000000003801000
CR4  - 0000000000000668, CR8 - 0000000000000000
DR0  - 0000000000000000, DR1 - 0000000000000000, DR2 - 0000000000000000
DR3  - 0000000000000000, DR6 - 00000000FFFF0FF0, DR7 - 0000000000000400
GDTR - 0000000001E9B000 0000000000000047, LDTR - 0000000000000000
IDTR - 0000000001A2EF58 0000000000000FFF,   TR - 0000000000000050
FXSAVE_STATE - 0000000003F259A0
!!!! Find image based on IP(0x3F061F1) /home/khaalid/Documents/edk2/Build/OvmfX64/DEBUG_GCC5/X64/MdeModulePkg/Core/Dxe/DxeMain/DEBUG/DxeCore.dll (ImageBase=0000000003EF6000, EntryPoint=0000000003F0EF76) !!!!
```
- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

OVMF X64 enabling UEFI freed-memory guard and Qemu x86_64

## Integration Instructions

N/A
