### PR TITLE
MdePkg: Coerce MSVC/CLANGPDB AARCH64 to Use AAPCS64 ABI for VA_LIST

### DIFF
--- a/.pytool/Plugin/SpellCheck/cspell.base.yaml
+++ b/.pytool/Plugin/SpellCheck/cspell.base.yaml
@@ -27,6 +27,7 @@
     "ignoreWords": [],
     "words": [
         "AABBCCDD",
+        "AAPCS",
         "ABPID",
         "ACPIBAR",
         "ACPICA",

--- a/MdePkg/Include/Base.h
+++ b/MdePkg/Include/Base.h
@@ -579,14 +579,27 @@ struct _LIST_ENTRY {
 
 #if defined (_M_ARM64)
 //
-// MSFT ARM variable argument list support.
+// MSVC AARCH64 and CLANGPDB AARCH64 hit this path. By default, they use the MS ABI for VA_LIST and
+// friends. However, this is against the AAPCS64 ABI and cause interop issues with GCC and CLANGDWARF.
+// These definitions coerce MSVC/CLANGPDB to use the AAPCS64 ABI.
 //
 
-typedef char *VA_LIST;
+typedef struct {
+  char    *Stack; // next stack param
+  char    *GrTop; // end of GP arg reg save area
+  char    *VrTop; // end of FP/SIMD arg reg save area
+  int     GrOffs; // offset from  GrTop to next GP register arg
+  int     VrOffs; // offset from  VrTop to next FP/SIMD register arg
+} VA_LIST;
 
-#define VA_START(Marker, Parameter)  __va_start (&Marker, &Parameter, _INT_SIZE_OF (Parameter), __alignof(Parameter), &Parameter)
-#define VA_ARG(Marker, TYPE)         (*(TYPE *) ((Marker += _INT_SIZE_OF (TYPE) + ((-(INTN)Marker) & (sizeof(TYPE) - 1))) - _INT_SIZE_OF (TYPE)))
-#define VA_END(Marker)               (Marker = (VA_LIST) 0)
+#define VA_START(Marker, Parameter)  (Marker).GrTop = (Marker).VrTop = NULL, \
+                                     (Marker).GrOffs = (Marker).VrOffs = 0,  \
+                                     __va_start (&(Marker).Stack, &Parameter, _INT_SIZE_OF (Parameter), __alignof (Parameter), &Parameter)
+#define VA_STACK_ARG(Marker, TYPE)   (((Marker).Stack += _INT_SIZE_OF (TYPE) + ((-(INTN)(Marker).Stack) & (sizeof(TYPE) - 1))) - _INT_SIZE_OF (TYPE))
+#define VA_ARG(Marker, TYPE)         (*(TYPE *) (((Marker).GrOffs += _INT_SIZE_OF (TYPE)) <= 0 \
+                                     ? &(Marker).GrTop[(Marker).GrOffs - _INT_SIZE_OF (TYPE)] \
+                                     : VA_STACK_ARG(Marker, TYPE)))
+#define VA_END(Marker)               ((Marker).Stack = NULL)
 #define VA_COPY(Dest, Start)         ((void)((Dest) = (Start)))
 
 #elif defined (__GNUC__) || defined (__clang__)


### PR DESCRIPTION
# Description

MSVC AARCH64 and CLANGPDB AARCH64 currently use the MS ABI for variadics in edk2. However, this breaks the AAPCS64 ABI and interopability with GCC/CLANGDWARF built binaries.

Because the architecture defines the single ABI, MSVC AARCH64 has little usage, and CLANGPDB AARCH64 is new to edk2, coerce these toolchains to use the AAPCS64 ABI instead of the MS ABI. This allows interopability between all supported AARCH64 toolchains in edk2 for variadics.

Note that variadic functions themselves are unaffected by this change, e.g. functions that take ... as the last parameter. This affects the VA_LIST structure and the associated helpers to parse it.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Tested in two ways:
- With the original failing case in CryptoPkg that passes a VA_LIST across a protocol. When one side is built with GCC and one with CLANGPDB, this was broken. After this fix it works.
- With two test drivers that communicate via protocol, calling variadic functions, calling functions that take VA_LIST as a parameter, and functions that take VA_LIST* as a parameter. Inputs/outputs were validated they were correct. All four cases of producer/consumer built with GCC/CLANGPDB were tested and all passed. Prior to the change all had failed.

## Integration Instructions

N/A.
