### PR TITLE
MdeModulePkg/UefiBootManagerLib: round HTTP ramdisk size

### DIFF
--- a/MdeModulePkg/Library/UefiBootManagerLib/BmBoot.c
+++ b/MdeModulePkg/Library/UefiBootManagerLib/BmBoot.c
@@ -1426,6 +1426,7 @@ BmExpandLoadFile (
   VOID                      *FileBuffer;
   EFI_HANDLE                RamDiskHandle;
   UINTN                     BufferSize;
+  UINTN                     AllocatedPages;
   EFI_DEVICE_PATH_PROTOCOL  *FullPath;
 
   Status = gBS->OpenProtocol (
@@ -1459,7 +1460,8 @@ BmExpandLoadFile (
   // wish to map this with huge page support.
   //
 
-  FileBuffer = AllocateAlignedReservedPages (EFI_SIZE_TO_PAGES (BufferSize), SIZE_2MB);
+  AllocatedPages = EFI_SIZE_TO_PAGES (ALIGN_VALUE (BufferSize, RUNTIME_PAGE_ALLOCATION_GRANULARITY));
+  FileBuffer     = AllocateAlignedReservedPages (AllocatedPages, SIZE_2MB);
   if (FileBuffer == NULL) {
     DEBUG_CODE_BEGIN ();
     EFI_DEVICE_PATH  *LoadFilePath;
@@ -1500,7 +1502,7 @@ BmExpandLoadFile (
 
   Status = LoadFile->LoadFile (LoadFile, FilePath, TRUE, &BufferSize, FileBuffer);
   if (EFI_ERROR (Status)) {
-    FreeAlignedPages (FileBuffer, EFI_SIZE_TO_PAGES (BufferSize));
+    FreeAlignedPages (FileBuffer, AllocatedPages);
     return NULL;
   }
 


### PR DESCRIPTION
HTTP ramdisk boot allocates the downloaded image with AllocateAlignedReservedPages() so the NVDIMM-backed ramdisk starts on a 2 MB boundary. The allocation path uses the image page count while the aligned allocation helper frees unused pages around the aligned buffer.

For reserved-memory allocations, those helper frees must satisfy the runtime page allocation granularity. If the downloaded image size is not rounded to that granularity, the tail free can use an invalid boundary and trip ASSERT_EFI_ERROR().

Round BufferSize to RUNTIME_PAGE_ALLOCATION_GRANULARITY before calculating the page count, and reuse that count when freeing the buffer after a load failure.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

HTTP boot Linux as well as Windows iso

## Integration Instructions

N/A
