### PR TITLE
RedfishPkg: Remove unnecessary Depex section in library modules

### DIFF
--- a/RedfishPkg/Library/HiiUtilityLib/HiiUtilityLib.inf
+++ b/RedfishPkg/Library/HiiUtilityLib/HiiUtilityLib.inf
@@ -57,6 +57,3 @@
   gEfiUnicodeCollation2ProtocolGuid
   gEfiRegularExpressionProtocolGuid
   gEfiUserManagerProtocolGuid
-
-[Depex]
-  TRUE

--- a/RedfishPkg/Library/RedfishDebugLib/RedfishDebugLib.inf
+++ b/RedfishPkg/Library/RedfishDebugLib/RedfishDebugLib.inf
@@ -38,6 +38,3 @@
 
 [FixedPcd]
   gEfiRedfishPkgTokenSpaceGuid.PcdRedfishDebugCategory
-
-[Depex]
-  TRUE

--- a/RedfishPkg/Library/RedfishHttpLib/RedfishHttpLib.inf
+++ b/RedfishPkg/Library/RedfishHttpLib/RedfishHttpLib.inf
@@ -37,7 +37,3 @@
 
 [Protocols]
   gEdkIIRedfishHttpProtocolGuid   ## CONSUMES ##
-
-[depex]
-  TRUE
-


### PR DESCRIPTION


# Description

Libraries that may be consumed by UEFI_DRIVER should not have depex section for UEFI_DRIVER. The INF specification said: If the Module is a Library, then a [Depex] section is optional. Regarding HiiUtilityLib, RedfishDebugLib and RedfishHttpLib, they don't have additional dependence, so the Depex sections should be removed to ensure no adverse impact on the UEFI_DRIVER.

## How This Was Tested

Pass CI check.

## Integration Instructions

N/A
