### PR TITLE
OvmfPkg/LoongArchVirt: Cache early serial base in KS1

### DIFF
--- a/OvmfPkg/LoongArchVirt/Library/EarlyFdtSerialPortLib16550/EarlyFdtSerialPortLib16550.c
+++ b/OvmfPkg/LoongArchVirt/Library/EarlyFdtSerialPortLib16550/EarlyFdtSerialPortLib16550.c
@@ -13,6 +13,7 @@
 #include <Library/IoLib.h>
 #include <Library/PcdLib.h>
 #include <Library/SerialPortLib.h>
+#include <Register/LoongArch64/Csr.h>
 
 //
 // PCI Defintions.
@@ -124,6 +125,16 @@ GetSerialRegisterBase (
   VOID           *Base;
   RETURN_STATUS  Status;
   UINT64         SerialConsoleAddress;
+  UINTN          SerialRegisterBase;
+
+  //
+  // The LoongArchVirt serial hook path uses KS1 to hand off the UART base.
+  // Reuse it here to avoid repeated FDT lookups during early debug output.
+  //
+  SerialRegisterBase = CsrRead (LOONGARCH_CSR_KS1);
+  if (SerialRegisterBase != 0) {
+    return SerialRegisterBase;
+  }
 
   Base   = (VOID *)(UINTN)PcdGet64 (PcdDeviceTreeInitialBaseAddress);
   Status = FdtSerialGetConsolePort (Base, &SerialConsoleAddress);
@@ -131,7 +142,10 @@ GetSerialRegisterBase (
     return (UINTN)0;
   }
 
-  return SerialConsoleAddress;
+  SerialRegisterBase = (UINTN)SerialConsoleAddress;
+  CsrWrite (LOONGARCH_CSR_KS1, SerialRegisterBase);
+
+  return SerialRegisterBase;
 }
 
 /**


### PR DESCRIPTION
# Description

EarlyFdtSerialPortLib16550 currently resolves the UART base from the
device tree every time GetSerialRegisterBase() is called. This path is
used by early debug output, so repeated FDT lookups add noticeable boot
time overhead in DEBUG builds.

This change reuses LOONGARCH_CSR_KS1 as the cache location for the UART
base, matching the existing LoongArchVirt serial hook handoff path. A
non-zero KS1 value is used directly; otherwise the UART base is resolved
from FDT and saved back to KS1 for later calls.

KS1 is used instead of a writable global variable because this library can
run very early from flash/XIP code paths. Avoiding writable global state
keeps the cache usable before normal writable data storage is available.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

- Ran CRLF-aware whitespace check:
  `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check`
- Ran PatchCheck:
  `python3 BaseTools/Scripts/PatchCheck.py --oneline HEAD`
- Built LoongArchVirtQemu DEBUG firmware:
  `build -a LOONGARCH64 -t GCC -p OvmfPkg/LoongArchVirt/LoongArchVirtQemu.dsc -b DEBUG -n 6`
- Ran local QEMU LoongArch virt DEBUG A/B testing with normal serial
  output enabled. The measurement was from QEMU launch to the
  `[Bds] Entry...` serial marker.

  Results from 10 runs per firmware:
  - Baseline mean: 2.163s
  - KS1-cache mean: 1.271s
  - Average saving: about 0.89s

  Using the more conservative median values, the measured saving was
  about 0.84s, so the observed boot-to-BDS improvement is about 0.85s.

## Integration Instructions

N/A