### PR TITLE
MdeModulePkg: GCD: Use Alignment Requirement In Bin Size Calc

### DIFF
--- a/MdeModulePkg/Core/Dxe/DxeMain.h
+++ b/MdeModulePkg/Core/Dxe/DxeMain.h
@@ -2802,3 +2802,22 @@ EFI_STATUS
 CoreInitializeHandleServices (
   VOID
   );
+
+/**
+  Calculate total memory bin size needed.
+
+  @param BinTop                The top address of the memory bins. This is an optional parameter.
+                               When NULL, the returned size meets the alignment requirements as long as
+                               the base address selected also meets the alignment requirements. When
+                               non-NULL, then the returned BinTop value and the returned size both meet
+                               the alignment requirements. When non-NULL, this will be updated on
+                               output to the new top address of the memory bins that must be used to
+                               satisfy alignment requirements.
+
+  @return The total memory bin size needed.
+
+**/
+UINT64
+CalculateTotalMemoryBinSizeNeeded (
+  IN OUT OPTIONAL EFI_PHYSICAL_ADDRESS  *BinTop
+  );

--- a/MdeModulePkg/Core/Dxe/Gcd/Gcd.c
+++ b/MdeModulePkg/Core/Dxe/Gcd/Gcd.c
@@ -135,25 +135,6 @@ GLOBAL_REMOVE_IF_UNREFERENCED CONST CHAR8  *mGcdAllocationTypeNames[] = {
 };
 
 /**
-  Calculate total memory bin size needed.
-
-  @param BinTop                The top address of the memory bins. This is an optional parameter.
-                               When NULL, the returned size meets the alignment requirements as long as
-                               the base address selected also meets the alignment requirements. When
-                               non-NULL, then the returned BinTop value and the returned size both meet
-                               the alignment requirements. When non-NULL, this will be updated on
-                               output to the new top address of the memory bins that must be used to
-                               satisfy alignment requirements.
-
-  @return The total memory bin size needed.
-
-**/
-UINT64
-CalculateTotalMemoryBinSizeNeeded (
-  IN OUT OPTIONAL EFI_PHYSICAL_ADDRESS  *BinTop
-  );
-
-/**
   Dump the entire contents if the GCD Memory Space Map using DEBUG() macros when
   PcdDebugPrintErrorLevel has the DEBUG_GCD bit set.
 

--- a/MdeModulePkg/Core/Dxe/Gcd/Gcd.c
+++ b/MdeModulePkg/Core/Dxe/Gcd/Gcd.c
@@ -135,6 +135,25 @@ GLOBAL_REMOVE_IF_UNREFERENCED CONST CHAR8  *mGcdAllocationTypeNames[] = {
 };
 
 /**
+  Calculate total memory bin size needed.
+
+  @param BinTop                The top address of the memory bins. This is an optional parameter.
+                               When NULL, the returned size meets the alignment requirements as long as
+                               the base address selected also meets the alignment requirements. When
+                               non-NULL, then the returned BinTop value and the returned size both meet
+                               the alignment requirements. When non-NULL, this will be updated on
+                               output to the new top address of the memory bins that must be used to
+                               satisfy alignment requirements.
+
+  @return The total memory bin size needed.
+
+**/
+UINT64
+CalculateTotalMemoryBinSizeNeeded (
+  IN OUT OPTIONAL EFI_PHYSICAL_ADDRESS  *BinTop
+  );
+
+/**
   Dump the entire contents if the GCD Memory Space Map using DEBUG() macros when
   PcdDebugPrintErrorLevel has the DEBUG_GCD bit set.
 
@@ -2165,25 +2184,60 @@ CoreConvertResourceDescriptorHobAttributesToCapabilities (
 }
 
 /**
-  Calculate total memory bin size neeeded.
+  Calculate total memory bin size needed.
 
-  @return The total memory bin size neeeded.
+  @param BinTop                The top address of the memory bins. This is an optional parameter.
+                               When NULL, the returned size meets the alignment requirements as long as
+                               the base address selected also meets the alignment requirements. When
+                               non-NULL, then the returned BinTop value and the returned size both meet
+                               the alignment requirements. When non-NULL, this will be updated on
+                               output to the new top address of the memory bins that must be used to
+                               satisfy alignment requirements.
+
+  @return The total memory bin size needed.
 
 **/
 UINT64
 CalculateTotalMemoryBinSizeNeeded (
-  VOID
+  IN OUT OPTIONAL EFI_PHYSICAL_ADDRESS  *BinTop
   )
 {
   UINTN   Index;
   UINT64  TotalSize;
+  UINT64  Granularity;
 
   //
   // Loop through each memory type in the order specified by the gMemoryTypeInformation[] array
   //
   TotalSize = 0;
   for (Index = 0; gMemoryTypeInformation[Index].Type != EfiMaxMemoryType; Index++) {
+    Granularity = DEFAULT_PAGE_ALLOCATION_GRANULARITY;
+    if ((gMemoryTypeInformation[Index].Type == EfiReservedMemoryType) ||
+        (gMemoryTypeInformation[Index].Type == EfiACPIMemoryNVS) ||
+        (gMemoryTypeInformation[Index].Type == EfiRuntimeServicesCode) ||
+        (gMemoryTypeInformation[Index].Type == EfiRuntimeServicesData))
+    {
+      Granularity = RUNTIME_PAGE_ALLOCATION_GRANULARITY;
+    }
+
+    // gMemoryTypeInformation[Index].NumberOfPages is already aligned to the allocation granularity
     TotalSize += LShiftU64 (gMemoryTypeInformation[Index].NumberOfPages, EFI_PAGE_SHIFT);
+
+    // BinTop is optional
+    if (BinTop == NULL) {
+      continue;
+    }
+
+    // Lower the bin top to the next aligned address, taking any padding into account in the size
+    *BinTop   -= (UINTN)LShiftU64 (gMemoryTypeInformation[Index].NumberOfPages, EFI_PAGE_SHIFT);
+    TotalSize += (*BinTop & (Granularity - 1));
+    *BinTop   &= ~(Granularity - 1);
+  }
+
+  if (BinTop != NULL) {
+    // Set *BinTop to the new top of the memory bins. It currently points to the base address of
+    // the memory bins
+    *BinTop += TotalSize;
   }
 
   return TotalSize;
@@ -2289,6 +2343,7 @@ CoreInitializeMemoryServices (
   UINT32                       ReservedCodePageNumber;
   UINT64                       MinimalMemorySizeNeeded;
   EFI_PHYSICAL_ADDRESS         ResourceHobMemoryTop;
+  EFI_PHYSICAL_ADDRESS         BinTop;
 
   //
   // Point at the first HOB.  This must be the PHIT HOB.
@@ -2363,7 +2418,8 @@ CoreInitializeMemoryServices (
           continue;
         }
 
-        if (ResourceHob->ResourceLength >= CalculateTotalMemoryBinSizeNeeded ()) {
+        BinTop = ResourceHob->PhysicalStart + ResourceHob->ResourceLength;
+        if (ResourceHob->ResourceLength >= CalculateTotalMemoryBinSizeNeeded (&BinTop)) {
           MemoryTypeInformationResourceHob = ResourceHob;
         }
       }
@@ -2377,7 +2433,7 @@ CoreInitializeMemoryServices (
   //
   // Include the total memory bin size needed to make sure memory bin could be allocated successfully.
   //
-  MinimalMemorySizeNeeded = MINIMUM_INITIAL_MEMORY_SIZE + CalculateTotalMemoryBinSizeNeeded ();
+  MinimalMemorySizeNeeded = MINIMUM_INITIAL_MEMORY_SIZE + CalculateTotalMemoryBinSizeNeeded (NULL);
 
   //
   // Find the Resource Descriptor HOB that contains PHIT range EfiFreeMemoryBottom..EfiFreeMemoryTop

--- a/MdeModulePkg/Core/Dxe/Mem/Page.c
+++ b/MdeModulePkg/Core/Dxe/Mem/Page.c
@@ -583,8 +583,6 @@ CoreSetMemoryTypeInformationRange (
   EFI_MEMORY_TYPE       Type;
   UINTN                 Index;
   UINT64                Size;
-  UINT64                Alignment;
-  UINT64                BinSize;
 
   //
   // Return if Memory Type Information bin locations have already been set
@@ -598,44 +596,7 @@ CoreSetMemoryTypeInformationRange (
   // Return if size of the Memory Type Information bins is greater than Length
   //
   Top  = Start + Length;
-  Size = 0;
-  for (Index = 0; gMemoryTypeInformation[Index].Type != EfiMaxMemoryType; Index++) {
-    //
-    // Make sure the memory type in the gMemoryTypeInformation[] array is valid
-    //
-    Type = (EFI_MEMORY_TYPE)(gMemoryTypeInformation[Index].Type);
-    if ((UINT32)Type > EfiMaxMemoryType) {
-      continue;
-    }
-
-    if (gMemoryTypeInformation[Index].NumberOfPages != 0) {
-      Alignment = DEFAULT_PAGE_ALLOCATION_GRANULARITY;
-      if ((gMemoryTypeInformation[Index].Type == EfiReservedMemoryType) ||
-          (gMemoryTypeInformation[Index].Type == EfiACPIMemoryNVS) ||
-          (gMemoryTypeInformation[Index].Type == EfiRuntimeServicesCode) ||
-          (gMemoryTypeInformation[Index].Type == EfiRuntimeServicesData))
-      {
-        Alignment = RUNTIME_PAGE_ALLOCATION_GRANULARITY;
-      }
-
-      BinSize = EFI_PAGES_TO_SIZE ((UINTN)gMemoryTypeInformation[Index].NumberOfPages);
-      BinSize = ALIGN_VALUE (BinSize, Alignment);
-
-      Size += BinSize;
-      if (Size > Length) {
-        return;
-      }
-
-      Top -= BinSize;
-
-      Size += (Top & (Alignment - 1));
-      if (Size > Length) {
-        return;
-      }
-
-      Top &= ~(Alignment - 1);
-    }
-  }
+  Size = CalculateTotalMemoryBinSizeNeeded (&Top);
 
   if (Size > Length) {
     return;
@@ -645,7 +606,6 @@ CoreSetMemoryTypeInformationRange (
   // Loop through each memory type in the order specified by the
   // gMemoryTypeInformation[] array
   //
-  Top = Start + Length;
   for (Index = 0; gMemoryTypeInformation[Index].Type != EfiMaxMemoryType; Index++) {
     //
     // Make sure the memory type in the gMemoryTypeInformation[] array is valid
@@ -656,22 +616,9 @@ CoreSetMemoryTypeInformationRange (
     }
 
     if (gMemoryTypeInformation[Index].NumberOfPages != 0) {
-      Alignment = DEFAULT_PAGE_ALLOCATION_GRANULARITY;
-      if ((gMemoryTypeInformation[Index].Type == EfiReservedMemoryType) ||
-          (gMemoryTypeInformation[Index].Type == EfiACPIMemoryNVS) ||
-          (gMemoryTypeInformation[Index].Type == EfiRuntimeServicesCode) ||
-          (gMemoryTypeInformation[Index].Type == EfiRuntimeServicesData))
-      {
-        Alignment = RUNTIME_PAGE_ALLOCATION_GRANULARITY;
-      }
-
-      BinSize = EFI_PAGES_TO_SIZE ((UINTN)gMemoryTypeInformation[Index].NumberOfPages);
-      BinSize = ALIGN_VALUE (BinSize, Alignment);
-
-      Top = (Top - BinSize) & ~(Alignment - 1);
-
+      mMemoryTypeStatistics[Type].MaximumAddress = Top - 1;
+      Top                                       -= LShiftU64 (gMemoryTypeInformation[Index].NumberOfPages, EFI_PAGE_SHIFT);
       mMemoryTypeStatistics[Type].BaseAddress    = Top;
-      mMemoryTypeStatistics[Type].MaximumAddress = Top + BinSize - 1;
 
       //
       // If the current base address is the lowest address so far, then update
@@ -681,7 +628,7 @@ CoreSetMemoryTypeInformationRange (
         mDefaultMaximumAddress = mMemoryTypeStatistics[Type].BaseAddress - 1;
       }
 
-      mMemoryTypeStatistics[Type].NumberOfPages   = EFI_SIZE_TO_PAGES ((UINTN)BinSize);
+      mMemoryTypeStatistics[Type].NumberOfPages   = gMemoryTypeInformation[Index].NumberOfPages;
       gMemoryTypeInformation[Index].NumberOfPages = 0;
     }
   }


### PR DESCRIPTION
# Description

This PR consists of two commits:

MdeModulePkg: GCD: Use Alignment Requirement in Bin Size Calc
--
Currently CalculateTotalMemoryBinSizeNeeded() does not take runtime alignment granularity considerations into account. This
means that the GCD initialization code can choose resource desc HOBs to use for the bin region that are actually too small and
fail to initialize the bins.

This fixes CalculateTotalMemoryBinSizeNeeded() to take the alignment requirements into consideration, both for size and for alignment of the bin address range.

MdeModulePkg: Dxe Core: Use CalculateTotalMemoryBinSizeNeeded()
--
CoreSetMemoryTypeInformationRange() currently calculates the bin size needed independently from the CalculateTotalMemoryBinSizeNeeded() function. This commit updates to use that function and remove the duplication.

Note: This PR was split off from #12086 and is required to merge before it and the second PR #12591 split off from it.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Tested with the memory bins PR #12086 and ensured bins were calculated correctly and passed from PEI to DXE.

## Integration Instructions

N/A.
