### PR TITLE
MdeModulePkg: Dxe Core: Allocate Memory Bins Contiguously

### DIFF
--- a/MdeModulePkg/Core/Dxe/Mem/Page.c
+++ b/MdeModulePkg/Core/Dxe/Mem/Page.c
@@ -650,6 +650,13 @@ CoreSetMemoryTypeInformationRange (
     }
   }
 
+  DEBUG ((
+    DEBUG_INFO,
+    "%a: Inherited range 0x%llx - 0x%llx for memory bins\n",
+    __func__,
+    Start,
+    Start + Length -1
+    ));
   mMemoryTypeInformationInitialized = TRUE;
 }
 
@@ -677,11 +684,10 @@ CoreAddMemoryDescriptor (
   )
 {
   EFI_PHYSICAL_ADDRESS  End;
-  EFI_STATUS            Status;
   UINTN                 Index;
-  UINTN                 FreeIndex;
-  UINT64                Alignment;
-  UINT64                BinSize;
+  EFI_PHYSICAL_ADDRESS  BaseAddress;
+  EFI_PHYSICAL_ADDRESS  LastBinAddress;
+  UINT64                RequiredSize;
 
   if ((Start & EFI_PAGE_MASK) != 0) {
     return;
@@ -718,6 +724,42 @@ CoreAddMemoryDescriptor (
     return;
   }
 
+  BaseAddress  = 0;
+  RequiredSize = CalculateTotalMemoryBinSizeNeeded (NULL);
+  if (RequiredSize == 0) {
+    mMemoryTypeInformationInitialized = TRUE;
+    return;
+  }
+
+  // To ensure we get a contiguous range of memory for our bins, we will attempt to allocate
+  // all of the memory needed in one go. If that works, we can then carve it up into the individual bins.
+  // Our size is already aligned to the correct granularity, allocate aligned pages to ensure the base address is
+  // aligned.
+  BaseAddress = (EFI_PHYSICAL_ADDRESS)(UINTN)AllocateAlignedPages (
+                                               EFI_SIZE_TO_PAGES ((UINTN)RequiredSize),
+                                               RUNTIME_PAGE_ALLOCATION_GRANULARITY
+                                               );
+
+  if (BaseAddress == 0) {
+    DEBUG ((
+      DEBUG_INFO,
+      "%a: Could not allocate contiguous pages for all memory bins. It will be attempted again when more memory is added.\n",
+      __func__
+      ));
+    return;
+  }
+
+  DEBUG ((
+    DEBUG_INFO,
+    "%a: Allocated 0x%llx - 0x%llx for memory bins\n",
+    __func__,
+    BaseAddress,
+    BaseAddress + RequiredSize - 1
+    ));
+
+  LastBinAddress         = BaseAddress + RequiredSize;
+  mDefaultMaximumAddress = BaseAddress - 1;
+
   //
   // Loop through each memory type in the order specified by the gMemoryTypeInformation[] array
   //
@@ -731,71 +773,9 @@ CoreAddMemoryDescriptor (
     }
 
     if (gMemoryTypeInformation[Index].NumberOfPages != 0) {
-      Alignment = DEFAULT_PAGE_ALLOCATION_GRANULARITY;
-      if ((gMemoryTypeInformation[Index].Type == EfiReservedMemoryType) ||
-          (gMemoryTypeInformation[Index].Type == EfiACPIMemoryNVS) ||
-          (gMemoryTypeInformation[Index].Type == EfiRuntimeServicesCode) ||
-          (gMemoryTypeInformation[Index].Type == EfiRuntimeServicesData))
-      {
-        Alignment = RUNTIME_PAGE_ALLOCATION_GRANULARITY;
-      }
-
-      BinSize = EFI_PAGES_TO_SIZE ((UINTN)gMemoryTypeInformation[Index].NumberOfPages);
-      BinSize = ALIGN_VALUE (BinSize, Alignment);
-
-      gMemoryTypeInformation[Index].NumberOfPages = (UINT32)EFI_SIZE_TO_PAGES ((UINTN)BinSize);
-
-      //
-      // Allocate pages for the current memory type from the top of available memory
-      //
-      Status = CoreAllocatePages (
-                 AllocateAnyPages,
-                 Type,
-                 gMemoryTypeInformation[Index].NumberOfPages,
-                 &mMemoryTypeStatistics[Type].BaseAddress
-                 );
-      if (EFI_ERROR (Status)) {
-        //
-        // If an error occurs allocating the pages for the current memory type, then
-        // free all the pages allocates for the previous memory types and return.  This
-        // operation with be retied when/if more memory is added to the system
-        //
-        for (FreeIndex = 0; FreeIndex < Index; FreeIndex++) {
-          //
-          // Make sure the memory type in the gMemoryTypeInformation[] array is valid
-          //
-          Type = (EFI_MEMORY_TYPE)(gMemoryTypeInformation[FreeIndex].Type);
-          if ((UINT32)Type > EfiMaxMemoryType) {
-            continue;
-          }
-
-          if (gMemoryTypeInformation[FreeIndex].NumberOfPages != 0) {
-            CoreFreePages (
-              mMemoryTypeStatistics[Type].BaseAddress,
-              gMemoryTypeInformation[FreeIndex].NumberOfPages
-              );
-            mMemoryTypeStatistics[Type].BaseAddress    = 0;
-            mMemoryTypeStatistics[Type].MaximumAddress = MAX_ALLOC_ADDRESS;
-          }
-        }
-
-        return;
-      }
-
-      //
-      // Compute the address at the top of the current statistics
-      //
-      mMemoryTypeStatistics[Type].MaximumAddress =
-        mMemoryTypeStatistics[Type].BaseAddress +
-        LShiftU64 (gMemoryTypeInformation[Index].NumberOfPages, EFI_PAGE_SHIFT) - 1;
-
-      //
-      // If the current base address is the lowest address so far, then update the default
-      // maximum address
-      //
-      if (mMemoryTypeStatistics[Type].BaseAddress < mDefaultMaximumAddress) {
-        mDefaultMaximumAddress = mMemoryTypeStatistics[Type].BaseAddress - 1;
-      }
+      mMemoryTypeStatistics[Type].BaseAddress    = LastBinAddress - EFI_PAGES_TO_SIZE (gMemoryTypeInformation[Index].NumberOfPages);
+      mMemoryTypeStatistics[Type].MaximumAddress = LastBinAddress - 1;
+      LastBinAddress                             = mMemoryTypeStatistics[Type].BaseAddress;
     }
   }
 
@@ -804,6 +784,10 @@ CoreAddMemoryDescriptor (
   // those memory areas can be freed for future allocations, and all future memory
   // allocations can occur within their respective bins
   //
+  FreeAlignedPages (
+    (VOID *)(UINTN)BaseAddress,
+    EFI_SIZE_TO_PAGES ((UINTN)RequiredSize)
+    );
   for (Index = 0; gMemoryTypeInformation[Index].Type != EfiMaxMemoryType; Index++) {
     //
     // Make sure the memory type in the gMemoryTypeInformation[] array is valid
@@ -814,10 +798,6 @@ CoreAddMemoryDescriptor (
     }
 
     if (gMemoryTypeInformation[Index].NumberOfPages != 0) {
-      CoreFreePages (
-        mMemoryTypeStatistics[Type].BaseAddress,
-        gMemoryTypeInformation[Index].NumberOfPages
-        );
       mMemoryTypeStatistics[Type].NumberOfPages   = gMemoryTypeInformation[Index].NumberOfPages;
       gMemoryTypeInformation[Index].NumberOfPages = 0;
     }


### PR DESCRIPTION
# Description

Currently, there is no guarantee that the memory bins will be allocated contiguously. However, there are assumptions in the code that bins are allocated contiguously, such as the GCD init code requiring a free memory region be large enough for a contiguous bin range on DXE Core init.

Ensuring contiguous bins also makes a cleaner model for the bins and keeps the memory map in a more standard configuration between different configurations, as platforms today can pass a resource descriptor HOB to DXE core to describe the bin range and this only supports a contiguous range.

This also sets up reusing the memory bin logic for PEI memory bin support which will use the aforementioned resource descriptor HOB to pass the bin range to DXE.

This commit updates CoreAddMemoryDescriptor() to allocate a contiguous range.

Note: This was split off from #12086 and is required to go in before that PR does.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Tested with the PEI memory bin changes.

## Integration Instructions

N/A.
