### PR TITLE
NetworkPkg/SnpDxe: Fix UEFI SCT regression in SnpUndi32Reset

### DIFF
--- a/NetworkPkg/SnpDxe/Reset.c
+++ b/NetworkPkg/SnpDxe/Reset.c
@@ -103,7 +103,6 @@ SnpUndi32Reset (
   //
   if (!ExtendedVerification) {
     DEBUG ((DEBUG_WARN, "ExtendedVerification = %d is not implemented!\n", ExtendedVerification));
-    return EFI_INVALID_PARAMETER;
   }
 
   if (This == NULL) {


### PR DESCRIPTION
# Description

Fix UEFI SCT regression in SnpUndi32Reset caused by upstream EDK2 spec alignment

Upstream EDK2 changed SnpUndi32Reset to return EFI_INVALID_PARAMETER when ExtendedVerification is FALSE per spec alignment (edk2 #10495, PR #5901).
This caused UEFI SCT failures in test cases 5.11.1.4.1 and 5.11.1.4.2 which expected EFI_SUCCESS.

Remove early EFI_INVALID_PARAMETER return and retain only warning message to allow normal SNP reset flow via PxeReset(), returning EFI_SUCCESS on successful reset operation.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

  1. Running UEFI SCT (System Configuration Test) - Specifically the Network Protocols SNP/PXE/BIS  test suite
  2. Targeted test cases - Test cases 5.11.1.4.1 and 5.11.1.4.2 in14_Network_Protocols_SNP_PXE_BIS_Test.md
  3. Verification - Confirming that after removing the early EFI_INVALID_PARAMETER return, the SnpUndi32Reset() function now returns EFI_SUCCESS when ExtendedVerification is FALSE, allowing the SCT tests to pass

## Integration Instructions

N/A
