### PR TITLE
EmbeddedPkg: Add Goldfish Rtc Driver

### DIFF
--- a/EmbeddedPkg/EmbeddedPkg.dsc
+++ b/EmbeddedPkg/EmbeddedPkg.dsc
@@ -211,6 +211,7 @@
   EmbeddedPkg/Library/NonCoherentDmaLib/NonCoherentDmaLib.inf
   EmbeddedPkg/Library/DxeDtPlatformDtbLoaderLibDefault/DxeDtPlatformDtbLoaderLibDefault.inf
   EmbeddedPkg/Library/VirtualRealTimeClockLib/VirtualRealTimeClockLib.inf
+  EmbeddedPkg/Library/GoldfishRealTimeClockLib/GoldfishRealTimeClockLib.inf
 
   EmbeddedPkg/EmbeddedMonotonicCounter/EmbeddedMonotonicCounter.inf
   EmbeddedPkg/RealTimeClockRuntimeDxe/RealTimeClockRuntimeDxe.inf

--- a/EmbeddedPkg/Library/GoldfishRealTimeClockLib/GoldfishRealTimeClock.h
+++ b/EmbeddedPkg/Library/GoldfishRealTimeClockLib/GoldfishRealTimeClock.h
@@ -1,0 +1,13 @@
+#pragma once
+
+// Goldfish Registers
+#define GOLDFISH_RTC_TIME_LOW         0x00
+#define GOLDFISH_RTC_TIME_HIGH        0x04
+#define GOLDFISH_RTC_ALARM_LOW        0x08
+#define GOLDFISH_RTC_ALARM_HIGH       0x0c
+#define GOLDFISH_RTC_IRQ_ENABLED      0x10
+#define GOLDFISH_RTC_CLEAR_ALARM      0x14
+#define GOLDFISH_RTC_ALARM_STATUS     0x18
+#define GOLDFISH_RTC_CLEAR_INTERRUPT  0x1c
+
+#define NANO_SEC  1000000000L

--- a/EmbeddedPkg/Library/GoldfishRealTimeClockLib/GoldfishRealTimeClockLib.c
+++ b/EmbeddedPkg/Library/GoldfishRealTimeClockLib/GoldfishRealTimeClockLib.c
@@ -1,0 +1,296 @@
+#include <PiDxe.h>
+#include <Library/BaseLib.h>
+#include <Library/DebugLib.h>
+#include <Library/IoLib.h>
+#include <Library/RealTimeClockLib.h>
+#include <Library/DxeServicesTableLib.h>
+#include <Library/UefiBootServicesTableLib.h>
+#include <Library/TimeBaseLib.h>
+#include <Library/FdtLib.h>
+#include <Library/HobLib.h>
+#include <Library/UefiRuntimeLib.h>
+
+#include <Guid/EventGroup.h>
+#include <Guid/FdtHob.h>
+
+#include "GoldfishRealTimeClock.h"
+
+STATIC EFI_EVENT  mRtcVirtualAddrChangeEvent;
+STATIC UINTN      mRtcRegisterBase;
+
+/**
+  Returns the current time and date information, and the time-keeping capabilities
+  of the hardware platform.
+
+  @param  Time                  A pointer to storage to receive a snapshot of the current time.
+  @param  Capabilities          An optional pointer to a buffer to receive the real time clock
+                                device's capabilities.
+
+  @retval EFI_SUCCESS           The operation completed successfully.
+  @retval EFI_INVALID_PARAMETER Time is NULL.
+  @retval EFI_DEVICE_ERROR      The time could not be retrieved due to hardware error.
+
+**/
+EFI_STATUS
+EFIAPI
+LibGetTime (
+  OUT EFI_TIME                *Time,
+  OUT  EFI_TIME_CAPABILITIES  *Capabilities
+  )
+{
+  UINTN   Base;
+  UINT32  Low;
+  UINT32  High;
+  UINT64  EpochSeconds;
+
+  if (Time == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Base = mRtcRegisterBase;
+
+  Low  = MmioRead32 (Base + GOLDFISH_RTC_TIME_LOW);
+  High = MmioRead32 (Base + GOLDFISH_RTC_TIME_HIGH);
+
+  EpochSeconds = ((UINT64)High << 32) | Low;
+  EpochSeconds = EpochSeconds / NANO_SEC;
+
+  // Adjust for the correct time zone
+  // The timezone setting also reflects the DST setting of the clock
+  if (Time->TimeZone != EFI_UNSPECIFIED_TIMEZONE) {
+    EpochSeconds += Time->TimeZone * SEC_PER_MIN;
+  } else if ((Time->Daylight & EFI_TIME_IN_DAYLIGHT) == EFI_TIME_IN_DAYLIGHT) {
+    // Convert to adjusted time, i.e. spring forwards one hour
+    EpochSeconds += SEC_PER_HOUR;
+  }
+
+  // Convert from internal time to UEFI time
+  EpochToEfiTime (EpochSeconds, Time);
+
+  // Upadte the Capability info
+  if (Capabilities != NULL) {
+    // runs at frequency 1Hz
+    Capabilities->Resolution = 1;
+    // Accuracy in ppm multiplied by 1,000,000,
+    Capabilities->Accuracy = 50000000;
+    // FALSE: Setting the time does not clear the vlaues below the resolution level
+    Capabilities->SetsToZero = FALSE;
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Sets the current local time and date information.
+
+  @param  Time                  A pointer to the current time.
+
+  @retval EFI_SUCCESS           The operation completed successfully.
+  @retval EFI_INVALID_PARAMETER A time field is out of range.
+  @retval EFI_DEVICE_ERROR      The time could not be set due to hardware error.
+
+**/
+EFI_STATUS
+EFIAPI
+LibSetTime (
+  IN EFI_TIME  *Time
+  )
+{
+  UINTN   Base;
+  UINT64  EpochSeconds;
+
+  Base = mRtcRegisterBase;
+
+  //
+  // Use Time, to set the time in your RTC hardware
+  //
+  if (Time == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  EpochSeconds = (UINT64)EfiTimeToEpoch (Time);
+  EpochSeconds = EpochSeconds * NANO_SEC;
+
+  // Adjust for the correct time zone, i.e. convert to UTC time zone
+  // The timezone setting also reflects the DST setting of the clock
+  if (Time->TimeZone != EFI_UNSPECIFIED_TIMEZONE) {
+    EpochSeconds -= Time->TimeZone * SEC_PER_MIN;
+  } else if ((Time->Daylight & EFI_TIME_IN_DAYLIGHT) == EFI_TIME_IN_DAYLIGHT) {
+    // Convert to un-adjusted time, i.e. fall back one hour
+    EpochSeconds -= SEC_PER_HOUR;
+  }
+
+  MmioWrite32 (Base + GOLDFISH_RTC_TIME_HIGH, (EpochSeconds >> 32));
+  MmioWrite32 (Base + GOLDFISH_RTC_TIME_LOW, EpochSeconds);
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Returns the current wakeup alarm clock setting.
+
+  @param  Enabled               Indicates if the alarm is currently enabled or disabled.
+  @param  Pending               Indicates if the alarm signal is pending and requires acknowledgement.
+  @param  Time                  The current alarm setting.
+
+  @retval EFI_SUCCESS           The alarm settings were returned.
+  @retval EFI_INVALID_PARAMETER Any parameter is NULL.
+  @retval EFI_DEVICE_ERROR      The wakeup time could not be retrieved due to a hardware error.
+
+**/
+EFI_STATUS
+EFIAPI
+LibGetWakeupTime (
+  OUT BOOLEAN   *Enabled,
+  OUT BOOLEAN   *Pending,
+  OUT EFI_TIME  *Time
+  )
+{
+  // Not a required feature
+  return EFI_UNSUPPORTED;
+}
+
+/**
+  Sets the system wakeup alarm clock time.
+
+  @param  Enabled               Enable or disable the wakeup alarm.
+  @param  Time                  If Enable is TRUE, the time to set the wakeup alarm for.
+
+  @retval EFI_SUCCESS           If Enable is TRUE, then the wakeup alarm was enabled. If
+                                Enable is FALSE, then the wakeup alarm was disabled.
+  @retval EFI_INVALID_PARAMETER A time field is out of range.
+  @retval EFI_DEVICE_ERROR      The wakeup time could not be set due to a hardware error.
+  @retval EFI_UNSUPPORTED       A wakeup timer is not supported on this platform.
+
+**/
+EFI_STATUS
+EFIAPI
+LibSetWakeupTime (
+  IN BOOLEAN    Enabled,
+  OUT EFI_TIME  *Time
+  )
+{
+  // Not a required feature
+  return EFI_UNSUPPORTED;
+}
+
+/**
+  Fixup internal data so that EFI can be call in virtual mode.
+  Converts the base address of the RTC registers for runtime calls.
+
+  @param[in]    Event   The Event that is being processed
+  @param[in]    Context Event Context
+**/
+STATIC
+VOID
+EFIAPI
+VirtualNotifyEvent (
+  IN EFI_EVENT  Event,
+  IN VOID       *Context
+  )
+{
+  // This call will convert the physical address (maintained in the library)
+  // to a virtual address that can be used during runtime.
+  EfiConvertPointer (0x0, (VOID **)&mRtcRegisterBase);
+  return;
+}
+
+EFI_STATUS
+GetGoldfishRtcBase (
+  OUT  UINTN  *BaseAddress
+  )
+{
+  VOID        *Hob;
+  VOID        *Base;
+  INT32       Node;
+  INT32       SubNode;
+  INT32       Len;
+  CONST VOID  *Data;
+
+  Hob = GetFirstGuidHob (&gFdtHobGuid);
+  if ((Hob == NULL) || (GET_GUID_HOB_DATA_SIZE (Hob) != sizeof (UINT64))) {
+    return EFI_NOT_FOUND;
+  }
+
+  Base = (VOID *)(UINTN)*(UINT64 *)GET_GUID_HOB_DATA (Hob);
+  if (FdtCheckHeader (Base) != 0) {
+    return EFI_NOT_FOUND;
+  }
+
+  Node = FdtPathOffset (Base, "/soc");
+  if (Node < 0 ) {
+    return EFI_NOT_FOUND;
+  }
+
+  SubNode = FdtNodeOffsetByCompatible (Base, Node, "google,goldfish-rtc");
+  if (SubNode < 0 ) {
+    return EFI_NOT_FOUND;
+  }
+
+  Data = FdtGetProp (Base, SubNode, "reg", &Len);
+  if (Data == NULL) {
+    return EFI_LOAD_ERROR;
+  }
+
+  *BaseAddress = (UINTN)Fdt64ToCpu (*(UINT64 *)Data);
+  return EFI_SUCCESS;
+}
+
+/**
+  This is the declaration of an EFI image entry point. This can be the entry point to an application
+  written to this specification, an EFI boot service driver, or an EFI runtime driver.
+
+  @param  ImageHandle           Handle that identifies the loaded image.
+  @param  SystemTable           System Table for this image.
+
+  @retval EFI_SUCCESS           The operation completed successfully.
+
+**/
+EFI_STATUS
+EFIAPI
+LibRtcInitialize (
+  IN EFI_HANDLE        ImageHandle,
+  IN EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  EFI_STATUS  Status;
+
+  // initial RTC Base Address
+  Status = GetGoldfishRtcBase (&mRtcRegisterBase);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  // Declare the controller as EFI_MEMORY_RUNTIME
+  Status = gDS->AddMemorySpace (
+                                EfiGcdMemoryTypeMemoryMappedIo,
+                                mRtcRegisterBase,
+                                SIZE_4KB,
+                                EFI_MEMORY_UC | EFI_MEMORY_RUNTIME | EFI_MEMORY_XP
+                                );
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Status = gDS->SetMemorySpaceAttributes (
+                                          mRtcRegisterBase,
+                                          SIZE_4KB,
+                                          EFI_MEMORY_UC | EFI_MEMORY_RUNTIME | EFI_MEMORY_XP
+                                          );
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  // register for the virtual address change event
+  Status = gBS->CreateEventEx (
+                               EVT_NOTIFY_SIGNAL,
+                               TPL_NOTIFY,
+                               VirtualNotifyEvent,
+                               NULL,
+                               &gEfiEventVirtualAddressChangeGuid,
+                               &mRtcVirtualAddrChangeEvent
+                               );
+  ASSERT_EFI_ERROR (Status);
+
+  return Status;
+}

--- a/EmbeddedPkg/Library/GoldfishRealTimeClockLib/GoldfishRealTimeClockLib.inf
+++ b/EmbeddedPkg/Library/GoldfishRealTimeClockLib/GoldfishRealTimeClockLib.inf
@@ -1,0 +1,31 @@
+[Defines]
+  INF_VERSION                    = 0x0001001A
+  BASE_NAME                      = GoldfishRealTimeClockLib
+  FILE_GUID                      = D065956E-D64E-46AB-A70F-C4E7015B77A9
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = RealTimeClockLib
+
+[Sources.common]
+  GoldfishRealTimeClockLib.c
+  GoldfishRealTimeClock.h
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  EmbeddedPkg/EmbeddedPkg.dec
+
+[LibraryClasses]
+  IoLib
+  DebugLib
+  TimerLib
+  TimeBaseLib
+  UefiRuntimeLib
+  PcdLib
+  DxeServicesTableLib
+  BaseMemoryLib
+  HobLib
+
+[Guids]
+  gEfiEventVirtualAddressChangeGuid
+  gFdtHobGuid


### PR DESCRIPTION
# Description

Add Goldfish RTC (Real Time Clock) Driver Library to EmbeddedPkg. This driver is used for the Goldfish virtual RTC device in emulators (e.g., QEMU), providing time read/write functionality. The change encapsulates RTC operations into a standalone library for other modules to consume.


- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - This change only adds a new library. It does not modify any existing interfaces or modules, so no build or boot behavior is broken.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - This change adds a virtual RTC driver only. It does not involve cryptographic algorithms or security-sensitive fixes such as buffer overflow patches.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - No unit tests or integration tests are included in this commit.

## How This Was Tested

Basic verification was performed on the QEMU Virt RISC-V platform:
- The GoldfishRtcLib was built into the firmware. The time read interface was called and successfully returned expected time data from the emulated RTC device.
- No system boot or runtime errors were observed.

## Integration Instructions

1. Reference this library in the platform DSC file:
2. 2. The platform must provide support for the following Guids:
- `gEfiEventVirtualAddressChangeGuid`
- `gFdtHobGuid`
3. The Goldfish RTC device MMIO base address is obtained from the FDT via `gFdtHobGuid`. The library parses the device node to get the address. No extra PCD configuration is required.
4. This library does not replace or affect other existing RTC implementations in EmbeddedPkg.
5. Verified on QEMU Virt RISC-V platform (no specific DSC/FDF example is provided).

