### PR TITLE
OvmfPkg: Seperate OvmfPkg reset vectors from UefiCpuPkg

### DIFF
--- a/OvmfPkg/Bhyve/ResetVector/ResetVector.inf
+++ b/OvmfPkg/Bhyve/ResetVector/ResetVector.inf
@@ -29,10 +29,6 @@
   MdePkg/MdePkg.dec
   UefiCpuPkg/UefiCpuPkg.dec
 
-[BuildOptions]
-   *_*_IA32_NASMB_FLAGS = -I$(WORKSPACE)/UefiCpuPkg/ResetVector/Vtf0/
-   *_*_X64_NASMB_FLAGS = -I$(WORKSPACE)/UefiCpuPkg/ResetVector/Vtf0/
-
 [Pcd]
   gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSecPageTablesBase
   gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSecPageTablesSize

--- a/OvmfPkg/Bhyve/ResetVector/ResetVector.nasmb
+++ b/OvmfPkg/Bhyve/ResetVector/ResetVector.nasmb
@@ -32,16 +32,16 @@
   %error "Either ARCH_IA32 or ARCH_X64 must be defined."
 %endif
 
-%include "CommonMacros.inc"
+%include "Ia32/CommonMacros.inc"
 
-%include "PostCodes.inc"
+%include "Ia32/PostCodes.inc"
 
 %ifdef DEBUG_PORT80
-  %include "Port80Debug.nasm.inc"
+  %include "Ia32/Port80Debug.nasm.inc"
 %elifdef DEBUG_SERIAL
-  %include "SerialDebug.nasm.inc"
+  %include "Ia32/SerialDebug.nasm.inc"
 %else
-  %include "DebugDisabled.nasm.inc"
+  %include "Ia32/DebugDisabled.nasm.inc"
 %endif
 
 %include "Ia32/SearchForBfvBase.nasm.inc"
@@ -62,7 +62,7 @@
 %include "Ia16/Real16ToFlat32.nasm.inc"
 %include "Ia16/Init16.nasm.inc"
 
-%include "Main.nasm.inc"
+%include "Ia32/Main.nasm.inc"
 
 %include "Ia16/ResetVectorVtf0.nasm.inc"
 

--- a/OvmfPkg/Include/Ia16/Init16.nasm.inc
+++ b/OvmfPkg/Include/Ia16/Init16.nasm.inc
@@ -1,0 +1,35 @@
+;------------------------------------------------------------------------------
+; @file
+; 16-bit initialization code
+;
+; Copyright (c) 2008 - 2009, Intel Corporation. All rights reserved.<BR>
+; SPDX-License-Identifier: BSD-2-Clause-Patent
+;
+;------------------------------------------------------------------------------
+
+
+BITS    16
+
+;
+; @param[out] DI    'BP' to indicate boot-strap processor
+;
+EarlyBspInitReal16:
+    mov     di, 'BP'
+    jmp     short Main16
+
+;
+; Modified:  EAX
+;
+; @param[in]  EAX   Initial value of the EAX register (BIST: Built-in Self Test)
+; @param[out] ESP   Initial value of the EAX register (BIST: Built-in Self Test)
+;
+EarlyInit16:
+    ;
+    ; ESP -  Initial value of the EAX register (BIST: Built-in Self Test)
+    ;
+    mov     esp, eax
+
+    debugInitialize
+
+    OneTimeCallRet EarlyInit16
+

--- a/OvmfPkg/Include/Ia16/Real16ToFlat32.nasm.inc
+++ b/OvmfPkg/Include/Ia16/Real16ToFlat32.nasm.inc
@@ -1,0 +1,167 @@
+;------------------------------------------------------------------------------
+; @file
+; Transition from 16 bit real mode into 32 bit flat protected mode
+;
+; Copyright (c) 2008 - 2022, Intel Corporation. All rights reserved.<BR>
+; SPDX-License-Identifier: BSD-2-Clause-Patent
+;
+;------------------------------------------------------------------------------
+
+%define SEC_DEFAULT_CR0  0x00000023
+%define SEC_DEFAULT_CR4  0x640
+
+BITS    16
+
+;
+; Modified:  EAX, EBX
+;
+; @param[out]     DS       Selector allowing flat access to all addresses
+; @param[out]     ES       Selector allowing flat access to all addresses
+; @param[out]     FS       Selector allowing flat access to all addresses
+; @param[out]     GS       Selector allowing flat access to all addresses
+; @param[out]     SS       Selector allowing flat access to all addresses
+;
+TransitionFromReal16To32BitFlat:
+
+    debugShowPostCode POSTCODE_16BIT_MODE
+
+    cli
+
+    mov     bx, 0xf000
+    mov     ds, bx
+
+    mov     bx, ADDR16_OF(gdtr)
+
+o32 lgdt    [cs:bx]
+
+    mov     eax, SEC_DEFAULT_CR0
+    mov     cr0, eax
+
+    jmp     LINEAR_CODE_SEL:dword ADDR_OF(jumpTo32BitAndLandHere)
+BITS    32
+jumpTo32BitAndLandHere:
+
+    mov     eax, SEC_DEFAULT_CR4
+    mov     cr4, eax
+
+    debugShowPostCode POSTCODE_32BIT_MODE
+
+    mov     ax, LINEAR_SEL
+    mov     ds, ax
+    mov     es, ax
+    mov     fs, ax
+    mov     gs, ax
+    mov     ss, ax
+
+    OneTimeCallRet TransitionFromReal16To32BitFlat
+
+ALIGN   2
+
+gdtr:
+    dw      GDT_END - GDT_BASE - 1   ; GDT limit
+    dd      ADDR_OF(GDT_BASE)
+
+ALIGN   16
+
+;
+; Macros for GDT entries
+;
+
+%define  PRESENT_FLAG(p) (p << 7)
+%define  DPL(dpl) (dpl << 5)
+%define  SYSTEM_FLAG(s) (s << 4)
+%define  DESC_TYPE(t) (t)
+
+; Type: data, expand-up, writable, accessed
+%define  DATA32_TYPE 3
+
+; Type: execute, readable, expand-up, accessed
+%define  CODE32_TYPE 0xb
+
+; Type: execute, readable, expand-up, accessed
+%define  CODE64_TYPE 0xb
+
+%define  GRANULARITY_FLAG(g) (g << 7)
+%define  DEFAULT_SIZE32(d) (d << 6)
+%define  CODE64_FLAG(l) (l << 5)
+%define  UPPER_LIMIT(l) (l)
+
+;
+; The Global Descriptor Table (GDT)
+;
+
+GDT_BASE:
+; null descriptor
+NULL_SEL            equ $-GDT_BASE    ; Selector [0x0]
+    DW      0            ; limit 15:0
+    DW      0            ; base 15:0
+    DB      0            ; base 23:16
+    DB      0            ; sys flag, dpl, type
+    DB      0            ; limit 19:16, flags
+    DB      0            ; base 31:24
+
+; Spare segment descriptor
+SPARE1_SEL          equ $-GDT_BASE    ; Selector [0x8]
+    DW      0            ; limit 15:0
+    DW      0            ; base 15:0
+    DB      0            ; base 23:16
+    DB      0            ; sys flag, dpl, type
+    DB      0            ; limit 19:16, flags
+    DB      0            ; base 31:24
+
+; linear code segment descriptor
+LINEAR_CODE_SEL     equ $-GDT_BASE    ; Selector [0x10]
+    DW      0xffff       ; limit 15:0
+    DW      0            ; base 15:0
+    DB      0            ; base 23:16
+    DB      PRESENT_FLAG(1)|DPL(0)|SYSTEM_FLAG(1)|DESC_TYPE(CODE32_TYPE)           ; 09Bh
+    DB      GRANULARITY_FLAG(1)|DEFAULT_SIZE32(1)|CODE64_FLAG(0)|UPPER_LIMIT(0xf)  ; 0CFh
+    DB      0            ; base 31:24
+
+; linear data segment descriptor
+LINEAR_SEL          equ $-GDT_BASE    ; Selector [0x18]
+    DW      0xffff       ; limit 15:0
+    DW      0            ; base 15:0
+    DB      0            ; base 23:16
+    DB      PRESENT_FLAG(1)|DPL(0)|SYSTEM_FLAG(1)|DESC_TYPE(DATA32_TYPE)           ; 093h
+    DB      GRANULARITY_FLAG(1)|DEFAULT_SIZE32(1)|CODE64_FLAG(0)|UPPER_LIMIT(0xf)  ; 0CFh
+    DB      0            ; base 31:24
+
+; Spare segment descriptor
+SPARE2_SEL          equ $-GDT_BASE    ; Selector [0x20]
+    DW      0            ; limit 15:0
+    DW      0            ; base 15:0
+    DB      0            ; base 23:16
+    DB      0            ; sys flag, dpl, type
+    DB      0            ; limit 19:16, flags
+    DB      0            ; base 31:24
+
+; linear code (16-bit) segment descriptor
+LINEAR_CODE16_SEL   equ $-GDT_BASE    ; Selector [0x28]
+    DW      0xffff       ; limit 15:0
+    DW      0            ; base 15:0
+    DB      0            ; base 23:16
+    DB      PRESENT_FLAG(1)|DPL(0)|SYSTEM_FLAG(1)|DESC_TYPE(CODE32_TYPE)           ; 09Bh
+    DB      GRANULARITY_FLAG(1)|DEFAULT_SIZE32(0)|CODE64_FLAG(0)|UPPER_LIMIT(0xf)  ; 08Fh
+    DB      0            ; base 31:24
+
+; linear data (16-bit) segment descriptor
+LINEAR_DATA16_SEL   equ $-GDT_BASE    ; Selector [0x30]
+    DW      0xffff       ; limit 15:0
+    DW      0            ; base 15:0
+    DB      0            ; base 23:16
+    DB      PRESENT_FLAG(1)|DPL(0)|SYSTEM_FLAG(1)|DESC_TYPE(DATA32_TYPE)           ; 093h
+    DB      0
+    DB      0            ; base 31:24
+
+; linear code (64-bit) segment descriptor
+LINEAR_CODE64_SEL   equ $-GDT_BASE    ; Selector [0x38]
+    DW      0xffff       ; limit 15:0
+    DW      0            ; base 15:0
+    DB      0            ; base 23:16
+    DB      PRESENT_FLAG(1)|DPL(0)|SYSTEM_FLAG(1)|DESC_TYPE(CODE64_TYPE)           ; 09Bh
+    DB      GRANULARITY_FLAG(1)|DEFAULT_SIZE32(0)|CODE64_FLAG(1)|UPPER_LIMIT(0xf)  ; 0AFh
+    DB      0            ; base 31:24
+
+GDT_END:
+

--- a/OvmfPkg/Include/Ia16/ResetVectorVtf0.nasm.inc
+++ b/OvmfPkg/Include/Ia16/ResetVectorVtf0.nasm.inc
@@ -1,0 +1,64 @@
+;------------------------------------------------------------------------------
+; @file
+; First code executed by processor after resetting.
+;
+; Copyright (c) 2008 - 2014, Intel Corporation. All rights reserved.<BR>
+; SPDX-License-Identifier: BSD-2-Clause-Patent
+;
+;------------------------------------------------------------------------------
+
+BITS    16
+
+ALIGN   16
+
+;
+; Pad the image size to 4k when page tables are in VTF0
+;
+; If the VTF0 image has page tables built in, then we need to make
+; sure the end of VTF0 is 4k above where the page tables end.
+;
+; This is required so the page tables will be 4k aligned when VTF0 is
+; located just below 0x100000000 (4GB) in the firmware device.
+;
+%ifdef ALIGN_TOP_TO_4K_FOR_PAGING
+    TIMES (0x1000 - ($ - EndOfPageTables)) DB 0
+;
+; Pad the VTF0 Reset code for Bsp & Ap to 4k aligned block.
+; Some implementations may need to keep the initial Reset code
+; to be separated out from rest of the code.
+; This padding will make sure lower 4K region below 4 GB may
+; only contains few jmp instructions and data.
+;
+    TIMES (0x1000 - 0x20) DB 0
+%endif
+
+;
+; 0xffffffe0
+;
+    DD      0, 0, 0
+
+;
+; The VTF signature (0xffffffec)
+;
+; VTF-0 means that the VTF (Volume Top File) code does not require
+; any fixups.
+;
+vtfSignature:
+    DB      'V', 'T', 'F', 0
+
+ALIGN   16
+
+resetVector:
+;
+; Reset Vector
+;
+; This is where the processor will begin execution
+;
+    nop
+    nop
+    jmp     EarlyBspInitReal16
+
+ALIGN   16
+
+fourGigabytes:
+

--- a/OvmfPkg/Include/Ia32/CommonMacros.inc
+++ b/OvmfPkg/Include/Ia32/CommonMacros.inc
@@ -1,0 +1,25 @@
+;------------------------------------------------------------------------------
+; @file
+; Common macros used in the ResetVector VTF module.
+;
+; Copyright (c) 2008, Intel Corporation. All rights reserved.<BR>
+; SPDX-License-Identifier: BSD-2-Clause-Patent
+;
+;------------------------------------------------------------------------------
+
+%define ADDR16_OF(x) (0x10000 - fourGigabytes + x)
+%define ADDR_OF(x) (0x100000000 - fourGigabytes + x)
+
+%macro  OneTimeCall 1
+    jmp     %1
+%1 %+ OneTimerCallReturn:
+%endmacro
+
+%macro  OneTimeCallRet 1
+    jmp     %1 %+ OneTimerCallReturn
+%endmacro
+
+StartOfResetVectorCode:
+
+%define ADDR_OF_START_OF_RESET_CODE ADDR_OF(StartOfResetVectorCode)
+

--- a/OvmfPkg/Include/Ia32/DebugDisabled.nasm.inc
+++ b/OvmfPkg/Include/Ia32/DebugDisabled.nasm.inc
@@ -1,0 +1,20 @@
+;------------------------------------------------------------------------------
+; @file
+; Debug disabled
+;
+; Copyright (c) 2009, Intel Corporation. All rights reserved.<BR>
+; SPDX-License-Identifier: BSD-2-Clause-Patent
+;
+;------------------------------------------------------------------------------
+
+BITS    16
+
+%macro  debugInitialize 0
+    ;
+    ; No initialization is required
+    ;
+%endmacro
+
+%macro  debugShowPostCode 1
+%endmacro
+

--- a/OvmfPkg/Include/Ia32/Flat32ToFlat64.nasm.inc
+++ b/OvmfPkg/Include/Ia32/Flat32ToFlat64.nasm.inc
@@ -1,0 +1,39 @@
+;------------------------------------------------------------------------------
+; @file
+; Transition from 32 bit flat protected mode into 64 bit flat protected mode
+;
+; Copyright (c) 2008 - 2018, Intel Corporation. All rights reserved.<BR>
+; SPDX-License-Identifier: BSD-2-Clause-Patent
+;
+;------------------------------------------------------------------------------
+
+BITS    32
+
+;
+; Modified:  EAX
+;
+Transition32FlatTo64Flat:
+
+    OneTimeCall SetCr3ForPageTables64
+
+    mov     eax, cr4
+    bts     eax, 5                      ; enable PAE
+    mov     cr4, eax
+
+    mov     ecx, 0xc0000080
+    rdmsr
+    bts     eax, 8                      ; set LME
+    wrmsr
+
+    mov     eax, cr0
+    bts     eax, 31                     ; set PG
+    mov     cr0, eax                    ; enable paging
+
+    jmp     LINEAR_CODE64_SEL:ADDR_OF(jumpTo64BitAndLandHere)
+BITS    64
+jumpTo64BitAndLandHere:
+
+    debugShowPostCode POSTCODE_64BIT_MODE
+
+    OneTimeCallRet Transition32FlatTo64Flat
+

--- a/OvmfPkg/Include/Ia32/Main.nasm.inc
+++ b/OvmfPkg/Include/Ia32/Main.nasm.inc
@@ -1,0 +1,105 @@
+;------------------------------------------------------------------------------
+; @file
+; Main routine of the pre-SEC code up through the jump into SEC
+;
+; Copyright (c) 2008 - 2009, Intel Corporation. All rights reserved.<BR>
+; SPDX-License-Identifier: BSD-2-Clause-Patent
+;
+;------------------------------------------------------------------------------
+
+
+BITS    16
+
+;
+; Modified:  EBX, ECX, EDX, EBP
+;
+; @param[in,out]  RAX/EAX  Initial value of the EAX register
+;                          (BIST: Built-in Self Test)
+; @param[in,out]  DI       'BP': boot-strap processor, or
+;                          'AP': application processor
+; @param[out]     RBP/EBP  Address of Boot Firmware Volume (BFV)
+; @param[out]     DS       Selector allowing flat access to all addresses
+; @param[out]     ES       Selector allowing flat access to all addresses
+; @param[out]     FS       Selector allowing flat access to all addresses
+; @param[out]     GS       Selector allowing flat access to all addresses
+; @param[out]     SS       Selector allowing flat access to all addresses
+;
+; @return         None  This routine jumps to SEC and does not return
+;
+Main16:
+    OneTimeCall EarlyInit16
+
+    ;
+    ; Transition the processor from 16-bit real mode to 32-bit flat mode
+    ;
+    OneTimeCall TransitionFromReal16To32BitFlat
+
+BITS    32
+
+    ;
+    ; Search for the Boot Firmware Volume (BFV)
+    ;
+    OneTimeCall Flat32SearchForBfvBase
+
+    ;
+    ; EBP - Start of BFV
+    ;
+
+    ;
+    ; Search for the SEC entry point
+    ;
+    OneTimeCall Flat32SearchForSecEntryPoint
+
+    ;
+    ; ESI - SEC Core entry point
+    ; EBP - Start of BFV
+    ;
+
+%ifdef ARCH_IA32
+
+    ;
+    ; Restore initial EAX value into the EAX register
+    ;
+    mov     eax, esp
+
+    ;
+    ; Jump to the 32-bit SEC entry point
+    ;
+    jmp     esi
+
+%else
+
+    ;
+    ; Transition the processor from 32-bit flat mode to 64-bit flat mode
+    ;
+    OneTimeCall Transition32FlatTo64Flat
+
+BITS    64
+
+    ;
+    ; Some values were calculated in 32-bit mode.  Make sure the upper
+    ; 32-bits of 64-bit registers are zero for these values.
+    ;
+    mov     rax, 0x00000000ffffffff
+    and     rsi, rax
+    and     rbp, rax
+    and     rsp, rax
+
+    ;
+    ; RSI - SEC Core entry point
+    ; RBP - Start of BFV
+    ;
+
+    ;
+    ; Restore initial EAX value into the RAX register
+    ;
+    mov     rax, rsp
+
+    ;
+    ; Jump to the 64-bit SEC entry point
+    ;
+    jmp     rsi
+
+%endif
+
+

--- a/OvmfPkg/Include/Ia32/Port80Debug.nasm.inc
+++ b/OvmfPkg/Include/Ia32/Port80Debug.nasm.inc
@@ -1,0 +1,22 @@
+;------------------------------------------------------------------------------
+; @file
+; Port 0x80 debug support macros
+;
+; Copyright (c) 2009, Intel Corporation. All rights reserved.<BR>
+; SPDX-License-Identifier: BSD-2-Clause-Patent
+;
+;------------------------------------------------------------------------------
+
+BITS    16
+
+%macro  debugInitialize 0
+    ;
+    ; No initialization is required
+    ;
+%endmacro
+
+%macro  debugShowPostCode 1
+    mov     al, %1
+    out     0x80, al
+%endmacro
+

--- a/OvmfPkg/Include/Ia32/PostCodes.inc
+++ b/OvmfPkg/Include/Ia32/PostCodes.inc
@@ -1,0 +1,19 @@
+;------------------------------------------------------------------------------
+; @file
+; Definitions of POST CODES for the reset vector module
+;
+; Copyright (c) 2009, Intel Corporation. All rights reserved.<BR>
+; SPDX-License-Identifier: BSD-2-Clause-Patent
+;
+;------------------------------------------------------------------------------
+
+%define POSTCODE_16BIT_MODE     0x16
+%define POSTCODE_32BIT_MODE     0x32
+%define POSTCODE_64BIT_MODE     0x64
+
+%define POSTCODE_BFV_NOT_FOUND  0xb0
+%define POSTCODE_BFV_FOUND      0xb1
+
+%define POSTCODE_SEC_NOT_FOUND  0xf0
+%define POSTCODE_SEC_FOUND      0xf1
+

--- a/OvmfPkg/Include/Ia32/SearchForBfvBase.nasm.inc
+++ b/OvmfPkg/Include/Ia32/SearchForBfvBase.nasm.inc
@@ -1,0 +1,102 @@
+;------------------------------------------------------------------------------
+; @file
+; Search for the Boot Firmware Volume (BFV) base address
+;
+; Copyright (c) 2008 - 2022, Intel Corporation. All rights reserved.<BR>
+; SPDX-License-Identifier: BSD-2-Clause-Patent
+;
+;------------------------------------------------------------------------------
+
+;#define EFI_FIRMWARE_FILE_SYSTEM2_GUID \
+;  { 0x8c8ce578, 0x8a3d, 0x4f1c, { 0x99, 0x35, 0x89, 0x61, 0x85, 0xc3, 0x2d, 0xd3 } }
+%define FFS2_GUID_DWORD0 0x8c8ce578
+%define FFS2_GUID_DWORD1 0x4f1c8a3d
+%define FFS2_GUID_DWORD2 0x61893599
+%define FFS2_GUID_DWORD3 0xd32dc385
+
+;#define EFI_FIRMWARE_FILE_SYSTEM3_GUID \
+;  { 0x8c8ce578, 0x3dcb, 0x4dca, { 0xbd, 0x6f, 0x1e, 0x96, 0x89, 0xe7, 0x34, 0x9a } }
+%define FFS3_GUID_DWORD0 0x5473c07a
+%define FFS3_GUID_DWORD1 0x4dca3dcb
+%define FFS3_GUID_DWORD2 0x961e6fbd
+%define FFS3_GUID_DWORD3 0x9a34e789
+
+BITS    32
+
+;
+; Modified:  EAX, EBX
+; Preserved: EDI, ESP
+;
+; @param[out]  EBP  Address of Boot Firmware Volume (BFV)
+;
+Flat32SearchForBfvBase:
+
+    xor     eax, eax
+searchingForBfvHeaderLoop:
+    ;
+    ; We check for a firmware volume at every 4KB address in the top 16MB
+    ; just below 4GB.  (Addresses at 0xffHHH000 where H is any hex digit.)
+    ;
+    sub     eax, 0x1000
+    cmp     eax, 0xff000000
+    jb      searchedForBfvHeaderButNotFound
+
+    ;
+    ; Check FFS3 GUID
+    ;
+    cmp     dword [eax + 0x10], FFS3_GUID_DWORD0
+    jne     searchingForFfs2Guid
+    cmp     dword [eax + 0x14], FFS3_GUID_DWORD1
+    jne     searchingForFfs2Guid
+    cmp     dword [eax + 0x18], FFS3_GUID_DWORD2
+    jne     searchingForFfs2Guid
+    cmp     dword [eax + 0x1c], FFS3_GUID_DWORD3
+    jne     searchingForFfs2Guid
+    jmp     checkingFvLength
+
+searchingForFfs2Guid:
+    ;
+    ; Check FFS2 GUID
+    ;
+    cmp     dword [eax + 0x10], FFS2_GUID_DWORD0
+    jne     searchingForBfvHeaderLoop
+    cmp     dword [eax + 0x14], FFS2_GUID_DWORD1
+    jne     searchingForBfvHeaderLoop
+    cmp     dword [eax + 0x18], FFS2_GUID_DWORD2
+    jne     searchingForBfvHeaderLoop
+    cmp     dword [eax + 0x1c], FFS2_GUID_DWORD3
+    jne     searchingForBfvHeaderLoop
+
+checkingFvLength:
+    ;
+    ; Check FV Length
+    ;
+    cmp     dword [eax + 0x24], 0
+    jne     searchingForBfvHeaderLoop
+    mov     ebx, eax
+    add     ebx, dword [eax + 0x20]
+    jnz     searchingForBfvHeaderLoop
+
+    jmp     searchedForBfvHeaderAndItWasFound
+
+searchedForBfvHeaderButNotFound:
+    ;
+    ; Hang if the SEC entry point was not found
+    ;
+    debugShowPostCode POSTCODE_BFV_NOT_FOUND
+
+    ;
+    ; 0xbfbfbfbf in the EAX & EBP registers helps signal what failed
+    ; for debugging purposes.
+    ;
+    mov     eax, 0xBFBFBFBF
+    mov     ebp, eax
+    jmp     $
+
+searchedForBfvHeaderAndItWasFound:
+    mov     ebp, eax
+
+    debugShowPostCode POSTCODE_BFV_FOUND
+
+    OneTimeCallRet Flat32SearchForBfvBase
+

--- a/OvmfPkg/Include/Ia32/SearchForSecEntry.nasm.inc
+++ b/OvmfPkg/Include/Ia32/SearchForSecEntry.nasm.inc
@@ -1,0 +1,194 @@
+;------------------------------------------------------------------------------
+; @file
+; Search for the SEC Core entry point
+;
+; Copyright (c) 2008 - 2011, Intel Corporation. All rights reserved.<BR>
+; SPDX-License-Identifier: BSD-2-Clause-Patent
+;
+;------------------------------------------------------------------------------
+
+BITS    32
+
+%define EFI_FV_FILETYPE_SECURITY_CORE         0x03
+
+;
+; Modified:  EAX, EBX, ECX, EDX
+; Preserved: EDI, EBP, ESP
+;
+; @param[in]   EBP  Address of Boot Firmware Volume (BFV)
+; @param[out]  ESI  SEC Core Entry Point Address
+;
+Flat32SearchForSecEntryPoint:
+
+    ;
+    ; Initialize EBX and ESI to 0
+    ;
+    xor     ebx, ebx
+    mov     esi, ebx
+
+    ;
+    ; Pass over the BFV header
+    ;
+    mov     eax, ebp
+    mov     bx, [ebp + 0x30]
+    add     eax, ebx
+    jc      secEntryPointWasNotFound
+
+    jmp     searchingForFfsFileHeaderLoop
+
+moveForwardWhileSearchingForFfsFileHeaderLoop:
+    ;
+    ; Make forward progress in the search
+    ;
+    inc     eax
+    jc      secEntryPointWasNotFound
+
+searchingForFfsFileHeaderLoop:
+    test    eax, eax
+    jz      secEntryPointWasNotFound
+
+    ;
+    ; Ensure 8 byte alignment
+    ;
+    add     eax, 7
+    jc      secEntryPointWasNotFound
+    and     al, 0xf8
+
+    ;
+    ; Look to see if there is an FFS file at eax
+    ;
+    mov     bl, [eax + 0x17]
+    test    bl, 0x20
+    jz      moveForwardWhileSearchingForFfsFileHeaderLoop
+    mov     ecx, [eax + 0x14]
+    and     ecx, 0x00ffffff
+    or      ecx, ecx
+    jz      moveForwardWhileSearchingForFfsFileHeaderLoop
+    add     ecx, eax
+    jz      jumpSinceWeFoundTheLastFfsFile
+    jc      moveForwardWhileSearchingForFfsFileHeaderLoop
+jumpSinceWeFoundTheLastFfsFile:
+
+    ;
+    ; There seems to be a valid file at eax
+    ;
+    cmp     byte [eax + 0x12], EFI_FV_FILETYPE_SECURITY_CORE ; Check File Type
+    jne     readyToTryFfsFileAtEcx
+
+fileTypeIsSecCore:
+    OneTimeCall GetEntryPointOfFfsFile
+    test    eax, eax
+    jnz     doneSeachingForSecEntryPoint
+
+readyToTryFfsFileAtEcx:
+    ;
+    ; Try the next FFS file at ECX
+    ;
+    mov     eax, ecx
+    jmp     searchingForFfsFileHeaderLoop
+
+secEntryPointWasNotFound:
+    xor     eax, eax
+
+doneSeachingForSecEntryPoint:
+    mov     esi, eax
+
+    test    esi, esi
+    jnz     secCoreEntryPointWasFound
+
+secCoreEntryPointWasNotFound:
+    ;
+    ; Hang if the SEC entry point was not found
+    ;
+    debugShowPostCode POSTCODE_SEC_NOT_FOUND
+    jz      $
+
+secCoreEntryPointWasFound:
+    debugShowPostCode POSTCODE_SEC_FOUND
+
+    OneTimeCallRet Flat32SearchForSecEntryPoint
+
+%define EFI_SECTION_PE32                  0x10
+%define EFI_SECTION_TE                    0x12
+
+;
+; Input:
+;   EAX - Start of FFS file
+;   ECX - End of FFS file
+;
+; Output:
+;   EAX - Entry point of PE32 (or 0 if not found)
+;
+; Modified:
+;   EBX
+;
+GetEntryPointOfFfsFile:
+    test    eax, eax
+    jz      getEntryPointOfFfsFileErrorReturn
+    add     eax, 0x18       ; EAX = Start of section
+
+getEntryPointOfFfsFileLoopForSections:
+    cmp     eax, ecx
+    jae     getEntryPointOfFfsFileErrorReturn
+
+    cmp     byte [eax + 3], EFI_SECTION_PE32
+    je      getEntryPointOfFfsFileFoundPe32Section
+
+    cmp     byte [eax + 3], EFI_SECTION_TE
+    je      getEntryPointOfFfsFileFoundTeSection
+
+    ;
+    ; The section type was not PE32 or TE, so move to next section
+    ;
+    mov     ebx, dword [eax]
+    and     ebx, 0x00ffffff
+    add     eax, ebx
+    jc      getEntryPointOfFfsFileErrorReturn
+
+    ;
+    ; Ensure that FFS section is 32-bit aligned
+    ;
+    add     eax, 3
+    jc      getEntryPointOfFfsFileErrorReturn
+    and     al, 0xfc
+    jmp     getEntryPointOfFfsFileLoopForSections
+
+getEntryPointOfFfsFileFoundPe32Section:
+    add     eax, 4       ; EAX = Start of PE32 image
+
+    cmp     word [eax], 'MZ'
+    jne     getEntryPointOfFfsFileErrorReturn
+    movzx   ebx, word [eax + 0x3c]
+    add     ebx, eax
+
+    ; if (Hdr.Pe32->Signature == EFI_IMAGE_NT_SIGNATURE)
+    cmp     dword [ebx], `PE\x00\x00`
+    jne     getEntryPointOfFfsFileErrorReturn
+
+    ; *EntryPoint = (VOID *)((UINTN)Pe32Data +
+    ;   (UINTN)(Hdr.Pe32->OptionalHeader.AddressOfEntryPoint & 0x0ffffffff));
+    add     eax, [ebx + 0x4 + 0x14 + 0x10]
+    jmp     getEntryPointOfFfsFileReturn
+
+getEntryPointOfFfsFileFoundTeSection:
+    add     eax, 4       ; EAX = Start of TE image
+    mov     ebx, eax
+
+    ; if (Hdr.Te->Signature == EFI_TE_IMAGE_HEADER_SIGNATURE)
+    cmp     word [ebx], 'VZ'
+    jne     getEntryPointOfFfsFileErrorReturn
+    ; *EntryPoint = (VOID *)((UINTN)Pe32Data +
+    ;   (UINTN)(Hdr.Te->AddressOfEntryPoint & 0x0ffffffff) +
+    ;   sizeof(EFI_TE_IMAGE_HEADER) - Hdr.Te->StrippedSize);
+    add     eax, [ebx + 0x8]
+    add     eax, 0x28
+    movzx   ebx, word [ebx + 0x6]
+    sub     eax, ebx
+    jmp     getEntryPointOfFfsFileReturn
+
+getEntryPointOfFfsFileErrorReturn:
+    mov     eax, 0
+
+getEntryPointOfFfsFileReturn:
+    OneTimeCallRet GetEntryPointOfFfsFile
+

--- a/OvmfPkg/Include/Ia32/SerialDebug.nasm.inc
+++ b/OvmfPkg/Include/Ia32/SerialDebug.nasm.inc
@@ -1,0 +1,126 @@
+;------------------------------------------------------------------------------
+; @file
+; Serial port debug support macros
+;
+; Copyright (c) 2008 - 2018, Intel Corporation. All rights reserved.<BR>
+; SPDX-License-Identifier: BSD-2-Clause-Patent
+;
+;------------------------------------------------------------------------------
+
+;//---------------------------------------------
+;// UART Register Offsets
+;//---------------------------------------------
+%define BAUD_LOW_OFFSET         0x00
+%define BAUD_HIGH_OFFSET        0x01
+%define IER_OFFSET              0x01
+%define LCR_SHADOW_OFFSET       0x01
+%define FCR_SHADOW_OFFSET       0x02
+%define IR_CONTROL_OFFSET       0x02
+%define FCR_OFFSET              0x02
+%define EIR_OFFSET              0x02
+%define BSR_OFFSET              0x03
+%define LCR_OFFSET              0x03
+%define MCR_OFFSET              0x04
+%define LSR_OFFSET              0x05
+%define MSR_OFFSET              0x06
+
+;//---------------------------------------------
+;// UART Register Bit Defines
+;//---------------------------------------------
+%define LSR_TXRDY               0x20
+%define LSR_RXDA                0x01
+%define DLAB                    0x01
+
+; UINT16  gComBase = 0x3f8;
+; UINTN   gBps = 115200;
+; UINT8   gData = 8;
+; UINT8   gStop = 1;
+; UINT8   gParity = 0;
+; UINT8   gBreakSet = 0;
+
+%define DEFAULT_COM_BASE 0x3f8
+%define DEFAULT_BPS 115200
+%define DEFAULT_DATA 8
+%define DEFAULT_STOP 1
+%define DEFAULT_PARITY 0
+%define DEFAULT_BREAK_SET 0
+
+%define SERIAL_DEFAULT_LCR ( \
+     (DEFAULT_BREAK_SET << 6) | \
+     (DEFAULT_PARITY << 3) | \
+     (DEFAULT_STOP << 2) | \
+     (DEFAULT_DATA - 5) \
+    )
+
+%define SERIAL_PORT_IO_BASE_ADDRESS DEFAULT_COM_BASE
+
+%macro  inFromSerialPort 1
+    mov     dx, (SERIAL_PORT_IO_BASE_ADDRESS + %1)
+    in      al, dx
+%endmacro
+
+%macro  waitForSerialTxReady 0
+
+%%waitingForTx:
+    inFromSerialPort LSR_OFFSET
+    test    al, LSR_TXRDY
+    jz      %%waitingForTx
+
+%endmacro
+
+%macro  outToSerialPort 2
+    mov     dx, (SERIAL_PORT_IO_BASE_ADDRESS + %1)
+    mov     al, %2
+    out     dx, al
+%endmacro
+
+%macro  debugShowCharacter 1
+    waitForSerialTxReady
+    outToSerialPort 0, %1
+%endmacro
+
+%macro  debugShowHexDigit 1
+  %if (%1 < 0xa)
+    debugShowCharacter BYTE ('0' + (%1))
+  %else
+    debugShowCharacter BYTE ('a' + ((%1) - 0xa))
+  %endif
+%endmacro
+
+%macro  debugNewline 0
+    debugShowCharacter `\r`
+    debugShowCharacter `\n`
+%endmacro
+
+%macro  debugShowPostCode 1
+    debugShowHexDigit (((%1) >> 4) & 0xf)
+    debugShowHexDigit ((%1) & 0xf)
+    debugNewline
+%endmacro
+
+BITS    16
+
+%macro  debugInitialize 0
+  jmp  real16InitDebug
+real16InitDebugReturn:
+%endmacro
+
+real16InitDebug:
+    ;
+    ; Set communications format
+    ;
+    outToSerialPort LCR_OFFSET, ((DLAB << 7) | SERIAL_DEFAULT_LCR)
+
+    ;
+    ; Configure baud rate
+    ;
+    outToSerialPort BAUD_HIGH_OFFSET, ((115200 / DEFAULT_BPS) >> 8)
+    outToSerialPort BAUD_LOW_OFFSET, ((115200 / DEFAULT_BPS) & 0xff)
+
+    ;
+    ; Switch back to bank 0
+    ;
+    outToSerialPort LCR_OFFSET, SERIAL_DEFAULT_LCR
+
+    jmp     real16InitDebugReturn
+

--- a/OvmfPkg/ResetVector/ResetVector.inf
+++ b/OvmfPkg/ResetVector/ResetVector.inf
@@ -29,10 +29,6 @@
   MdeModulePkg/MdeModulePkg.dec
   UefiCpuPkg/UefiCpuPkg.dec
 
-[BuildOptions]
-   *_*_IA32_NASMB_FLAGS = -I$(WORKSPACE)/UefiCpuPkg/ResetVector/Vtf0/
-   *_*_X64_NASMB_FLAGS = -I$(WORKSPACE)/UefiCpuPkg/ResetVector/Vtf0/
-
 [Pcd]
   gUefiCpuPkgTokenSpaceGuid.PcdSevEsWorkAreaBase
   gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSecGhcbBase

--- a/OvmfPkg/ResetVector/ResetVector.nasmb
+++ b/OvmfPkg/ResetVector/ResetVector.nasmb
@@ -32,20 +32,20 @@
   %error "Either ARCH_IA32 or ARCH_X64 must be defined."
 %endif
 
-%include "CommonMacros.inc"
+%include "Ia32/CommonMacros.inc"
 
-%include "PostCodes.inc"
+%include "Ia32/PostCodes.inc"
 
 %ifdef DEBUG_PORT80
-  %include "Port80Debug.nasm.inc"
+  %include "Ia32/Port80Debug.nasm.inc"
 %elifdef DEBUG_SERIAL
-  %include "SerialDebug.nasm.inc"
+  %include "Ia32/SerialDebug.nasm.inc"
 %elif 0
 ; Set ^ this to 1 to enable postcodes on the qemu debug console.
 ; Disabled by default because it is incompatible with SEV-ES/SEV-SNP and TDX.
   %include "QemuDebugCon.nasm.inc"
 %else
-  %include "DebugDisabled.nasm.inc"
+  %include "Ia32/DebugDisabled.nasm.inc"
 %endif
 
 %include "Ia32/SearchForBfvBase.nasm.inc"

--- a/OvmfPkg/XenResetVector/XenResetVector.inf
+++ b/OvmfPkg/XenResetVector/XenResetVector.inf
@@ -29,10 +29,6 @@
   MdePkg/MdePkg.dec
   UefiCpuPkg/UefiCpuPkg.dec
 
-[BuildOptions]
-   *_*_IA32_NASMB_FLAGS = -I$(WORKSPACE)/UefiCpuPkg/ResetVector/Vtf0/
-   *_*_X64_NASMB_FLAGS = -I$(WORKSPACE)/UefiCpuPkg/ResetVector/Vtf0/
-
 [Pcd]
   gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSecPageTablesBase
   gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSecPageTablesSize

--- a/OvmfPkg/XenResetVector/XenResetVector.nasmb
+++ b/OvmfPkg/XenResetVector/XenResetVector.nasmb
@@ -32,18 +32,18 @@
   %error "Either ARCH_IA32 or ARCH_X64 must be defined."
 %endif
 
-%include "CommonMacros.inc"
+%include "Ia32/CommonMacros.inc"
 
 %define PVH_SPACE(Offset) (FixedPcdGet32 (PcdXenPvhStartOfDayStructPtr) + (Offset))
 
-%include "PostCodes.inc"
+%include "Ia32/PostCodes.inc"
 
 %ifdef DEBUG_PORT80
-  %include "Port80Debug.nasm.inc"
+  %include "Ia32/Port80Debug.nasm.inc"
 %elifdef DEBUG_SERIAL
-  %include "SerialDebug.nasm.inc"
+  %include "Ia32/SerialDebug.nasm.inc"
 %else
-  %include "DebugDisabled.nasm.inc"
+  %include "Ia32/DebugDisabled.nasm.inc"
 %endif
 
 %include "Ia32/SearchForBfvBase.nasm.inc"
@@ -64,7 +64,7 @@
 %include "Ia16/Real16ToFlat32.nasm.inc"
 %include "Ia16/Init16.nasm.inc"
 
-%include "Main.nasm.inc"
+%include "Ia32/Main.nasm.inc"
 %include "Ia32/XenPVHMain.nasm.inc"
 
 %include "Ia16/ResetVectorVtf0.nasm.inc"


### PR DESCRIPTION
# Description

The current OvmfPkg reset vectors  directly include and reference UefiCpuPkg reset vector. This has been brought up on #12312 as violation to edk2 packaging standards. A package shouldn't reference the private code of another package because it is a layering violation. So, this PR resolves that violation and makes all OvmfPkg reset vectors to be independent of UefiCpuPkg.

Also, according to DEC specification 1.27:

>All paths must be relative to the directory that contains the DEC file. Use of absolute paths, or WORKSPACE relative paths is prohibited.

### Details of the PR

This PR achieves the seperation by first copying referenced files from UefiCpuPkg (which are about 12 files). In order to minimize the duplication all OvmfPkg reset vectors will share those files internally independent of UefiCpuPkg. To miantain the organization of the include directory two directories have been introduced Ia16 which houses common 16-bit code that all reset vectors may reference and and Ia32 which houses 32-bit and common code.

Thus, all OvmfPkg reset vectors have been forwarded to reference that local include directory relative to package directory instead using `WORKSPACE` or absolute paths. No runtime changes have been introduced.

All of these has been done as per discussions in the linked issue.

Resolves: #12333 
- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Built locally and project CI.

## Integration Instructions

N/A
