### PR TITLE
ArmPkg: MmCommunicationDxe: Fix Comm Buffer Init

### DIFF
--- a/ArmPkg/Drivers/MmCommunicationDxe/MmCommunication.c
+++ b/ArmPkg/Drivers/MmCommunicationDxe/MmCommunication.c
@@ -5,6 +5,9 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
+
+#include <PiDxe.h>
+
 #include <Library/ArmLib.h>
 #include <Library/ArmFfaLib.h>
 #include <Library/ArmSmcLib.h>
@@ -23,6 +26,8 @@
 #include <IndustryStandard/ArmStdSmc.h>
 #include <IndustryStandard/ArmFfaSvc.h>
 #include <IndustryStandard/MmCommunicate.h>
+
+#define COMM_BUFFER_ATTRS  (EFI_MEMORY_WB | EFI_MEMORY_XP | EFI_MEMORY_RUNTIME)
 
 //
 // Partition ID if FF-A support is enabled
@@ -690,8 +695,9 @@ MmCommunication2Initialize (
   IN EFI_SYSTEM_TABLE  *SystemTable
   )
 {
-  EFI_STATUS  Status;
-  UINTN       Index;
+  EFI_STATUS                       Status;
+  UINTN                            Index;
+  EFI_GCD_MEMORY_SPACE_DESCRIPTOR  GcdDescriptor;
 
   // Initialize to make mm communication
   Status = InitializeCommunication ();
@@ -708,67 +714,68 @@ MmCommunication2Initialize (
 
   ASSERT (mNsCommBuffMemRegion.Length != 0);
 
-  Status = gDS->AddMemorySpace (
-                  EfiGcdMemoryTypeReserved,
+  Status = gDS->GetMemorySpaceDescriptor (
                   mNsCommBuffMemRegion.PhysicalBase,
-                  mNsCommBuffMemRegion.Length,
-                  EFI_MEMORY_WB |
-                  EFI_MEMORY_XP |
-                  EFI_MEMORY_RUNTIME
+                  &GcdDescriptor
                   );
-  if (EFI_ERROR (Status) && (Status != EFI_ACCESS_DENIED)) {
-    DEBUG ((
-      DEBUG_ERROR,
-      "MmCommunicateInitialize: "
-      "Failed to add MM-NS Buffer Memory Space - %r\n",
-      Status
-      ));
-    goto ReturnErrorStatus;
-  } else if (Status == EFI_ACCESS_DENIED) {
-    Status = gDS->FreeMemorySpace (
-                    mNsCommBuffMemRegion.PhysicalBase,
-                    mNsCommBuffMemRegion.Length
-                    );
-    if (EFI_ERROR (Status)) {
-      DEBUG ((
-        DEBUG_ERROR,
-        "MmCommunicateInitialize: "
-        "Failed to free existing MM-NS Buffer Memory Space - %r\n",
-        Status
-        ));
-      goto ReturnErrorStatus;
-    }
 
-    Status = gDS->RemoveMemorySpace (
-                    mNsCommBuffMemRegion.PhysicalBase,
-                    mNsCommBuffMemRegion.Length
-                    );
-    if (EFI_ERROR (Status)) {
-      DEBUG ((
-        DEBUG_ERROR,
-        "MmCommunicateInitialize: "
-        "Failed to remove existing MM-NS Buffer Memory Space - %r\n",
-        Status
-        ));
-      goto ReturnErrorStatus;
-    }
-
-    // Try to add the memory space again
+  if (EFI_ERROR (Status) || (GcdDescriptor.GcdMemoryType == EfiGcdMemoryTypeNonExistent)) {
+    // if this doesn't exist, add it ourselves
     Status = gDS->AddMemorySpace (
                     EfiGcdMemoryTypeReserved,
                     mNsCommBuffMemRegion.PhysicalBase,
                     mNsCommBuffMemRegion.Length,
-                    EFI_MEMORY_WB |
-                    EFI_MEMORY_XP |
-                    EFI_MEMORY_RUNTIME
+                    COMM_BUFFER_ATTRS
                     );
     if (EFI_ERROR (Status)) {
       DEBUG ((
         DEBUG_ERROR,
-        "MmCommunicateInitialize: "
-        "Failed to add MM-NS Buffer Memory Space (second attempt) - %r\n",
+        "%a: "
+        "Failed to add MM-NS Buffer Memory Space - %r\n",
+        __func__,
         Status
         ));
+      goto ReturnErrorStatus;
+    }
+  } else if (!((GcdDescriptor.BaseAddress <= mNsCommBuffMemRegion.PhysicalBase) &&
+               ((GcdDescriptor.BaseAddress + GcdDescriptor.Length) >=
+                (mNsCommBuffMemRegion.PhysicalBase + mNsCommBuffMemRegion.Length))))
+  {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: Existing GCD memory space does not completely cover MM-NS Buffer Memory Space\n",
+      __func__
+      ));
+    ASSERT (FALSE);
+    Status = EFI_ABORTED;
+    goto ReturnErrorStatus;
+  } else if (GcdDescriptor.GcdMemoryType != EfiGcdMemoryTypeReserved) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: Existing GCD memory space is not EfiGcdMemoryTypeReserved for the MM-NS Buffer Memory Space\n",
+      __func__
+      ));
+    ASSERT (FALSE);
+    Status = EFI_ABORTED;
+    goto ReturnErrorStatus;
+  } else if ((GcdDescriptor.Capabilities & (COMM_BUFFER_ATTRS)) !=
+             (COMM_BUFFER_ATTRS))
+  {
+    Status = gDS->SetMemorySpaceCapabilities (
+                    mNsCommBuffMemRegion.PhysicalBase,
+                    mNsCommBuffMemRegion.Length,
+                    COMM_BUFFER_ATTRS
+                    );
+
+    if (EFI_ERROR (Status)) {
+      DEBUG ((
+        DEBUG_ERROR,
+        "%a: "
+        "Failed to set MM-NS Buffer Memory capabilities with Status %r\n",
+        __func__,
+        Status
+        ));
+      ASSERT_EFI_ERROR (Status);
       goto ReturnErrorStatus;
     }
   }
@@ -776,15 +783,18 @@ MmCommunication2Initialize (
   Status = gDS->SetMemorySpaceAttributes (
                   mNsCommBuffMemRegion.PhysicalBase,
                   mNsCommBuffMemRegion.Length,
-                  EFI_MEMORY_WB | EFI_MEMORY_XP | EFI_MEMORY_RUNTIME
+                  COMM_BUFFER_ATTRS
                   );
   if (EFI_ERROR (Status)) {
     DEBUG ((
       DEBUG_ERROR,
-      "MmCommunicateInitialize: "
-      "Failed to set MM-NS Buffer Memory attributes\n"
+      "%a: "
+      "Failed to set MM-NS Buffer Memory attributes with Status %r\n",
+      __func__,
+      Status
       ));
-    goto CleanAddedMemorySpace;
+    ASSERT_EFI_ERROR (Status);
+    goto ReturnErrorStatus;
   }
 
   // Install the communication protocol
@@ -799,10 +809,11 @@ MmCommunication2Initialize (
   if (EFI_ERROR (Status)) {
     DEBUG ((
       DEBUG_ERROR,
-      "MmCommunicationInitialize: "
-      "Failed to install MM communication protocol\n"
+      "%a: "
+      "Failed to install MM communication protocol\n",
+      __func__
       ));
-    goto CleanAddedMemorySpace;
+    goto ReturnErrorStatus;
   }
 
   // Register notification callback when virtual address is associated
@@ -852,12 +863,6 @@ UninstallProtocol:
          mMmCommunicateHandle,
          &gEfiMmCommunication2ProtocolGuid,
          &mMmCommunication2
-         );
-
-CleanAddedMemorySpace:
-  gDS->RemoveMemorySpace (
-         mNsCommBuffMemRegion.PhysicalBase,
-         mNsCommBuffMemRegion.Length
          );
 
 ReturnErrorStatus:


### PR DESCRIPTION
# Description

Currently, MmCommunicationDxe expects the MM comm buffer to either be not added by the platform or added and allocated by the platform. However, not all platforms follow this pattern.

This commit makes the handling more generic by checking to see if a GCD descriptor exists that covers this range. If it does, the capabilities are updated as needed. If only a partial desc exists for this range, the driver will fail as that is a platform misconfiguration.

If the descriptor does not exist, the driver will add the buffer.

Then, for all successful cases, the attributes are updated on the buffer to what the driver expects them to be.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Tested on a physical ARM64 platform that was failing to boot due to the MM comm buffer being described in a resource descriptor HOB but not allocated. After this change, it successfully booted. Also did a regression test on another ARM64 physical platform that was succeeding with the existing logic and saw it boot.

## Integration Instructions

Platforms should either not produce a resource descriptor HOB for the MM comm buffer region or should produce a reserved resource descriptor HOB that covers the entire MM comm buffer region.
