### PR TITLE
Tpl fix v3

### DIFF
--- a/ArmPkg/Drivers/TimerDxe/TimerDxe.c
+++ b/ArmPkg/Drivers/TimerDxe/TimerDxe.c
@@ -289,16 +289,8 @@ TimerInterruptHandler (
   IN  EFI_SYSTEM_CONTEXT         SystemContext
   )
 {
-  EFI_TPL  OriginalTPL;
-  UINT64   CurrentValue;
-  UINT64   CompareValue;
-
-  //
-  // DXE core uses this callback for the EFI timer tick. The DXE core uses locks
-  // that raise to TPL_HIGH and then restore back to current level. Thus we need
-  // to make sure TPL level is set to TPL_HIGH while we are handling the timer tick.
-  //
-  OriginalTPL = gBS->RaiseTPL (TPL_HIGH_LEVEL);
+  UINT64  CurrentValue;
+  UINT64  CompareValue;
 
   // Signal end of interrupt early to help avoid losing subsequent ticks
   // from long duration handlers
@@ -333,8 +325,6 @@ TimerInterruptHandler (
     ArmGenericTimerReenableTimer ();
     ArmInstructionSynchronizationBarrier ();
   }
-
-  gBS->RestoreTPL (OriginalTPL);
 }
 
 /**

--- a/EmulatorPkg/CpuRuntimeDxe/Cpu.c
+++ b/EmulatorPkg/CpuRuntimeDxe/Cpu.c
@@ -36,7 +36,6 @@ CPU_ARCH_PROTOCOL_PRIVATE  mCpuTemplate = {
       CpuIoServiceWrite
     }
   },
-  TRUE
 };
 
 #define EFI_CPU_DATA_MAXIMUM_LENGTH  0x100
@@ -277,10 +276,6 @@ EmuEnableInterrupt (
   IN EFI_CPU_ARCH_PROTOCOL  *This
   )
 {
-  CPU_ARCH_PROTOCOL_PRIVATE  *Private;
-
-  Private                 = CPU_ARCH_PROTOCOL_PRIVATE_DATA_FROM_THIS (This);
-  Private->InterruptState = TRUE;
   gEmuThunk->EnableInterrupt ();
   return EFI_SUCCESS;
 }
@@ -291,10 +286,6 @@ EmuDisableInterrupt (
   IN EFI_CPU_ARCH_PROTOCOL  *This
   )
 {
-  CPU_ARCH_PROTOCOL_PRIVATE  *Private;
-
-  Private                 = CPU_ARCH_PROTOCOL_PRIVATE_DATA_FROM_THIS (This);
-  Private->InterruptState = FALSE;
   gEmuThunk->DisableInterrupt ();
   return EFI_SUCCESS;
 }
@@ -306,14 +297,11 @@ EmuGetInterruptState (
   OUT BOOLEAN               *State
   )
 {
-  CPU_ARCH_PROTOCOL_PRIVATE  *Private;
-
   if (State == NULL) {
     return EFI_INVALID_PARAMETER;
   }
 
-  Private = CPU_ARCH_PROTOCOL_PRIVATE_DATA_FROM_THIS (This);
-  *State  = Private->InterruptState;
+  *State = gEmuThunk->GetInterruptState ();
   return EFI_SUCCESS;
 }
 

--- a/EmulatorPkg/CpuRuntimeDxe/CpuDriver.h
+++ b/EmulatorPkg/CpuRuntimeDxe/CpuDriver.h
@@ -45,7 +45,6 @@ typedef struct {
   //
   // Local Data for CPU interface goes here
   //
-  BOOLEAN                  InterruptState;
 } CPU_ARCH_PROTOCOL_PRIVATE;
 
 #define CPU_ARCH_PROTOCOL_PRIVATE_DATA_FROM_THIS(a) \

--- a/EmulatorPkg/Include/Protocol/EmuThunk.h
+++ b/EmulatorPkg/Include/Protocol/EmuThunk.h
@@ -116,6 +116,12 @@ VOID
   );
 
 typedef
+BOOLEAN
+(EFIAPI *EMU_GET_INTERRUPT_STATE)(
+  VOID
+  );
+
+typedef
 UINT64
 (EFIAPI *EMU_QUERY_PERFORMANCE_FREQENCY)(
   VOID
@@ -225,6 +231,7 @@ struct _EMU_THUNK_PROTOCOL {
   ///
   EMU_ENABLE_INERRUPTS                 EnableInterrupt;
   EMU_DISABLE_INERRUPTS                DisableInterrupt;
+  EMU_GET_INTERRUPT_STATE              GetInterruptState;
   EMU_QUERY_PERFORMANCE_FREQENCY       QueryPerformanceFrequency;
   EMU_QUERY_PERFORMANCE_COUNTER        QueryPerformanceCounter;
 

--- a/EmulatorPkg/TimerDxe/Timer.c
+++ b/EmulatorPkg/TimerDxe/Timer.c
@@ -55,24 +55,15 @@ TimerCallback (
   UINT64  DeltaMs
   )
 {
-  EFI_TPL           OriginalTPL;
-  EFI_TIMER_NOTIFY  CallbackFunction;
-
-  OriginalTPL = gBS->RaiseTPL (TPL_HIGH_LEVEL);
-
-  if (OriginalTPL < TPL_HIGH_LEVEL) {
-    CallbackFunction = mTimerNotifyFunction;
-
-    //
-    // Only invoke the callback function if a Non-NULL handler has been
-    // registered. Assume all other handlers are legal.
-    //
-    if (CallbackFunction != NULL) {
-      CallbackFunction (MultU64x32 (DeltaMs, 10000));
-    }
+  //
+  // Only invoke the callback function if a Non-NULL handler has been
+  // registered. Assume all other handlers are legal.
+  //
+  if (mTimerNotifyFunction != NULL) {
+    gEmuThunk->DisableInterrupt ();
+    mTimerNotifyFunction (MultU64x32 (DeltaMs, 10000));
+    gEmuThunk->EnableInterrupt ();
   }
-
-  gBS->RestoreTPL (OriginalTPL);
 }
 
 EFI_STATUS

--- a/EmulatorPkg/Unix/Host/EmuThunk.c
+++ b/EmulatorPkg/Unix/Host/EmuThunk.c
@@ -32,7 +32,7 @@ int             settimer_initialized;
 struct timeval  settimer_timeval;
 UINTN           settimer_callback = 0;
 
-BOOLEAN  gEmulatorInterruptEnabled = FALSE;
+BOOLEAN  gEmulatorInterruptEnabled = TRUE;
 
 STATIC BOOLEAN         mEmulatorStdInConfigured = FALSE;
 STATIC struct termios  mOldTty;
@@ -186,7 +186,6 @@ SecSetTimer (
     act.sa_handler       = settimer_handler;
     act.sa_flags         = 0;
     sigemptyset (&act.sa_mask);
-    gEmulatorInterruptEnabled = TRUE;
     if (sigaction (SIGALRM, &act, NULL) != 0) {
       printf ("SetTimer: sigaction error %s\n", strerror (errno));
     }
@@ -420,6 +419,7 @@ EMU_THUNK_PROTOCOL  gEmuThunkProtocol = {
   GasketSecPeCoffUnloadImageExtraAction,
   GasketSecEnableInterrupt,
   GasketSecDisableInterrupt,
+  GasketSecGetInterruptState,
   GasketQueryPerformanceFrequency,
   GasketQueryPerformanceCounter,
   GasketSecSleep,

--- a/EmulatorPkg/Unix/Host/Gasket.h
+++ b/EmulatorPkg/Unix/Host/Gasket.h
@@ -102,6 +102,12 @@ GasketSecDisableInterrupt (
   VOID
   );
 
+BOOLEAN
+EFIAPI
+GasketSecGetInterruptState (
+  VOID
+  );
+
 UINT64
 EFIAPI
 GasketQueryPerformanceFrequency (

--- a/EmulatorPkg/Unix/Host/Ia32/Gasket.S
+++ b/EmulatorPkg/Unix/Host/Ia32/Gasket.S
@@ -188,6 +188,18 @@ ASM_PFX(GasketSecDisableInterrupt):
   leave
   ret
 
+ASM_GLOBAL ASM_PFX(GasketSecGetInterruptState)
+ASM_PFX(GasketSecGetInterruptState):
+  pushl %ebp
+  movl  %esp, %ebp
+  subl  $24, %esp      // sub extra 16 from the stack for alignment
+  and   $-16, %esp    // stack needs to end in 0xFFFFFFF0 before call
+
+  call    ASM_PFX(SecInterruptEanbled)
+
+  leave
+  ret
+
 ASM_GLOBAL ASM_PFX(GasketQueryPerformanceFrequency)
 ASM_PFX(GasketQueryPerformanceFrequency):
   pushl %ebp

--- a/EmulatorPkg/Unix/Host/X64/Gasket.S
+++ b/EmulatorPkg/Unix/Host/X64/Gasket.S
@@ -222,6 +222,21 @@ ASM_PFX(GasketSecDisableInterrupt):
   popq    %rbp
   ret
 
+ASM_GLOBAL ASM_PFX(GasketSecGetInterruptState)
+ASM_PFX(GasketSecGetInterruptState):
+  pushq   %rbp            // stack frame is for the debugger
+  movq    %rsp, %rbp
+
+  pushq   %rsi          // %rsi & %rdi are volatile in Unix and callee-save in EFI ABI
+  pushq   %rdi
+
+  call    ASM_PFX(SecInterruptEanbled)
+
+  popq    %rdi          // restore state
+  popq    %rsi
+  popq    %rbp
+  ret
+
 ASM_GLOBAL ASM_PFX(GasketQueryPerformanceFrequency)
 ASM_PFX(GasketQueryPerformanceFrequency):
   pushq   %rbp            // stack frame is for the debugger

--- a/EmulatorPkg/Win/Host/WinThunk.c
+++ b/EmulatorPkg/Win/Host/WinThunk.c
@@ -261,7 +261,7 @@ CRITICAL_SECTION  mNtCriticalSection;
 //
 UINT  mMMTimerThreadID = 0;
 
-volatile BOOLEAN  mInterruptEnabled = FALSE;
+volatile BOOLEAN  mInterruptEnabled = TRUE;
 
 VOID
 CALLBACK
@@ -448,6 +448,14 @@ SecDisableInterrupt (
   mInterruptEnabled = FALSE;
 }
 
+BOOLEAN
+SecGetInterruptState (
+  VOID
+  )
+{
+  return mInterruptEnabled;
+}
+
 UINT64
 SecQueryPerformanceFrequency (
   VOID
@@ -597,6 +605,7 @@ EMU_THUNK_PROTOCOL  gEmuThunkProtocol = {
   PeCoffLoaderUnloadImageExtraAction,
   SecEnableInterrupt,
   SecDisableInterrupt,
+  SecGetInterruptState,
   SecQueryPerformanceFrequency,
   SecQueryPerformanceCounter,
   SecSleep,

--- a/MdeModulePkg/Core/Dxe/DxeMain.h
+++ b/MdeModulePkg/Core/Dxe/DxeMain.h
@@ -428,16 +428,18 @@ CalculateEfiHdrCrc (
   );
 
 /**
-  Called by the platform code to process a tick.
+  Register the DXE core timer tick handler with the timer driver.
 
-  @param  Duration               The number of 100ns elapsed since the last call
-                                 to TimerTick
+  @retval EFI_SUCCESS           The timer handler was registered.
+  @retval EFI_UNSUPPORTED       The platform does not support timer interrupts.
+  @retval EFI_ALREADY_STARTED   A handler is already registered.
+  @retval EFI_DEVICE_ERROR      The timer handler could not be registered.
 
 **/
-VOID
+EFI_STATUS
 EFIAPI
-CoreTimerTick (
-  IN UINT64  Duration
+CoreRegisterTimerHandler (
+  VOID
   );
 
 /**

--- a/MdeModulePkg/Core/Dxe/DxeMain.h
+++ b/MdeModulePkg/Core/Dxe/DxeMain.h
@@ -582,6 +582,21 @@ CoreRestoreTpl (
   );
 
 /**
+  Lowers the task priority from TPL_HIGH_LEVEL to the previous value.
+  If the new priority unmasks events at a higher priority, they are
+  dispatched with interrupts enabled. Upon return, interrupts will be
+  disabled.
+
+  @param  NewTpl  New, lower, task priority
+
+**/
+VOID
+EFIAPI
+CoreRestoreTplWithInterruptsMasked (
+  IN EFI_TPL  NewTpl
+  );
+
+/**
   Introduces a fine-grained stall.
 
   @param  Microseconds           The number of microseconds to stall execution.

--- a/MdeModulePkg/Core/Dxe/DxeMain/DxeProtocolNotify.c
+++ b/MdeModulePkg/Core/Dxe/DxeMain/DxeProtocolNotify.c
@@ -152,7 +152,7 @@ GenericProtocolNotify (
     //
     // Register the Core timer tick handler with the Timer AP
     //
-    gTimer->RegisterHandler (gTimer, CoreTimerTick);
+    CoreRegisterTimerHandler ();
   }
 
   if (CompareGuid (Entry->ProtocolGuid, &gEfiRuntimeArchProtocolGuid)) {

--- a/MdeModulePkg/Core/Dxe/Event/Timer.c
+++ b/MdeModulePkg/Core/Dxe/Event/Timer.c
@@ -190,7 +190,10 @@ CoreTimerTick (
   IN UINT64  Duration
   )
 {
-  IEVENT  *Event;
+  EFI_TPL  OriginalTPL;
+  IEVENT   *Event;
+
+  OriginalTPL = CoreRaiseTpl (TPL_HIGH_LEVEL);
 
   //
   // Check runtiem flag in case there are ticks while exiting boot services
@@ -215,6 +218,18 @@ CoreTimerTick (
   }
 
   CoreReleaseLock (&mEfiSystemTimeLock);
+
+  //
+  // Restore the original TPL but without re-enabling interrupts. This is the
+  // responsibility of the caller, which will do so implicitly by returning
+  // from the timer ISR in an architecture-specific manner (IRET, ERET, etc).
+  //
+  // Re-enabling interrupts before that leaves a window where the timer
+  // interrupt, which has been re-armed at this point, may fire again
+  // immediately, resulting in unbounded recursion if the interrupts are
+  // arriving at a higher rate than they can be serviced.
+  //
+  CoreRestoreTplWithInterruptsMasked (OriginalTPL);
 }
 
 /**

--- a/MdeModulePkg/Core/Dxe/Event/Timer.c
+++ b/MdeModulePkg/Core/Dxe/Event/Timer.c
@@ -183,6 +183,7 @@ CoreInitializeTimer (
                                  to TimerTick
 
 **/
+STATIC
 VOID
 EFIAPI
 CoreTimerTick (
@@ -288,4 +289,22 @@ CoreSetTimer (
   CoreReleaseLock (&mEfiTimerLock);
 
   return EFI_SUCCESS;
+}
+
+/**
+  Register the DXE core timer tick handler with the timer driver.
+
+  @retval EFI_SUCCESS           The timer handler was registered.
+  @retval EFI_UNSUPPORTED       The platform does not support timer interrupts.
+  @retval EFI_ALREADY_STARTED   A handler is already registered.
+  @retval EFI_DEVICE_ERROR      The timer handler could not be registered.
+
+**/
+EFI_STATUS
+EFIAPI
+CoreRegisterTimerHandler (
+  VOID
+  )
+{
+  return gTimer->RegisterHandler (gTimer, CoreTimerTick);
 }

--- a/MdeModulePkg/Core/Dxe/Event/Timer.c
+++ b/MdeModulePkg/Core/Dxe/Event/Timer.c
@@ -193,6 +193,16 @@ CoreTimerTick (
   EFI_TPL  OriginalTPL;
   IEVENT   *Event;
 
+  DEBUG_CODE_BEGIN ();
+  if (gCpu != NULL) {
+    BOOLEAN  State;
+
+    ASSERT_EFI_ERROR (gCpu->GetInterruptState (gCpu, &State));
+    ASSERT (!State);
+  }
+
+  DEBUG_CODE_END ();
+
   OriginalTPL = CoreRaiseTpl (TPL_HIGH_LEVEL);
 
   //

--- a/MdeModulePkg/Core/Dxe/Event/Tpl.c
+++ b/MdeModulePkg/Core/Dxe/Event/Tpl.c
@@ -90,9 +90,10 @@ CoreRaiseTpl (
   @param  NewTpl  New, lower, task priority
 
 **/
+STATIC
 VOID
 EFIAPI
-CoreRestoreTpl (
+InternalCoreRestoreTpl (
   IN EFI_TPL  NewTpl
   )
 {
@@ -132,6 +133,22 @@ CoreRestoreTpl (
 
     CoreDispatchEventNotifies (gEfiCurrentTpl);
   }
+}
+
+/**
+  Lowers the task priority to the previous value.   If the new
+  priority unmasks events at a higher priority, they are dispatched.
+
+  @param  NewTpl  New, lower, task priority
+
+**/
+VOID
+EFIAPI
+CoreRestoreTpl (
+  IN EFI_TPL  NewTpl
+  )
+{
+  InternalCoreRestoreTpl (NewTpl);
 
   //
   // Set the new value

--- a/MdeModulePkg/Core/Dxe/Event/Tpl.c
+++ b/MdeModulePkg/Core/Dxe/Event/Tpl.c
@@ -164,3 +164,35 @@ CoreRestoreTpl (
     CoreSetInterruptState (TRUE);
   }
 }
+
+/**
+  Lowers the task priority from TPL_HIGH_LEVEL to the previous value.
+  If the new priority unmasks events at a higher priority, they are
+  dispatched with interrupts enabled. Upon return, interrupts will be
+  disabled.
+
+  @param  NewTpl  New, lower, task priority
+
+**/
+VOID
+EFIAPI
+CoreRestoreTplWithInterruptsMasked (
+  IN EFI_TPL  NewTpl
+  )
+{
+  ASSERT (gEfiCurrentTpl == TPL_HIGH_LEVEL);
+
+  InternalCoreRestoreTpl (NewTpl);
+
+  //
+  // Disable interrupts before setting the TPL to its final value. This is
+  // crucial to ensure that reentrant calls into this function (due to nested
+  // timer interrupts) are bounded by the number of distinct TPL levels.
+  //
+  CoreSetInterruptState (FALSE);
+
+  //
+  // Set the new value
+  //
+  gEfiCurrentTpl = NewTpl;
+}

--- a/OvmfPkg/AmdSev/AmdSevX64.dsc
+++ b/OvmfPkg/AmdSev/AmdSevX64.dsc
@@ -375,7 +375,6 @@
 !endif
   PciLib|OvmfPkg/Library/DxePciLibI440FxQ35/DxePciLibI440FxQ35.inf
   MpInitLib|UefiCpuPkg/Library/MpInitLib/DxeMpInitLib.inf
-  NestedInterruptTplLib|OvmfPkg/Library/NestedInterruptTplLib/NestedInterruptTplLib.inf
   QemuFwCfgS3Lib|OvmfPkg/Library/QemuFwCfgS3Lib/DxeQemuFwCfgS3LibFwCfg.inf
   QemuLoadImageLib|OvmfPkg/Library/GenericQemuLoadImageLib/GenericQemuLoadImageLib.inf
 

--- a/OvmfPkg/CloudHv/CloudHvX64.dsc
+++ b/OvmfPkg/CloudHv/CloudHvX64.dsc
@@ -409,7 +409,6 @@
 !endif
   PciLib|OvmfPkg/Library/DxePciLibI440FxQ35/DxePciLibI440FxQ35.inf
   MpInitLib|UefiCpuPkg/Library/MpInitLib/DxeMpInitLib.inf
-  NestedInterruptTplLib|OvmfPkg/Library/NestedInterruptTplLib/NestedInterruptTplLib.inf
   QemuFwCfgS3Lib|OvmfPkg/Library/QemuFwCfgS3Lib/DxeQemuFwCfgS3LibFwCfg.inf
   QemuLoadImageLib|OvmfPkg/Library/X86QemuLoadImageLib/X86QemuLoadImageLib.inf
 

--- a/OvmfPkg/IntelTdx/IntelTdxX64.dsc
+++ b/OvmfPkg/IntelTdx/IntelTdxX64.dsc
@@ -312,7 +312,6 @@
   LockBoxLib|OvmfPkg/Library/LockBoxLib/LockBoxDxeLib.inf
   PciLib|OvmfPkg/Library/DxePciLibI440FxQ35/DxePciLibI440FxQ35.inf
   MpInitLib|UefiCpuPkg/Library/MpInitLib/DxeMpInitLib.inf
-  NestedInterruptTplLib|OvmfPkg/Library/NestedInterruptTplLib/NestedInterruptTplLib.inf
   QemuFwCfgS3Lib|OvmfPkg/Library/QemuFwCfgS3Lib/DxeQemuFwCfgS3LibFwCfg.inf
   QemuLoadImageLib|OvmfPkg/Library/X86QemuLoadImageLib/X86QemuLoadImageLib.inf
   TdxMeasurementLib|OvmfPkg/IntelTdx/TdxMeasurementLib/DxeTdxMeasurementLib.inf

--- a/OvmfPkg/LocalApicTimerDxe/LocalApicTimerDxe.c
+++ b/OvmfPkg/LocalApicTimerDxe/LocalApicTimerDxe.c
@@ -8,8 +8,6 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
 
-#include <Library/NestedInterruptTplLib.h>
-
 #include "LocalApicTimerDxe.h"
 
 //
@@ -60,11 +58,6 @@ TimerInterruptHandler (
   IN EFI_SYSTEM_CONTEXT  SystemContext
   )
 {
-  STATIC NESTED_INTERRUPT_STATE  NestedInterruptState;
-  EFI_TPL                        OriginalTPL;
-
-  OriginalTPL = NestedInterruptRaiseTPL ();
-
   SendApicEoi ();
 
   if (mTimerNotifyFunction != NULL) {
@@ -73,8 +66,6 @@ TimerInterruptHandler (
     //
     mTimerNotifyFunction (mTimerPeriod);
   }
-
-  NestedInterruptRestoreTPL (OriginalTPL, SystemContext, &NestedInterruptState);
 }
 
 /**

--- a/OvmfPkg/LocalApicTimerDxe/LocalApicTimerDxe.inf
+++ b/OvmfPkg/LocalApicTimerDxe/LocalApicTimerDxe.inf
@@ -21,13 +21,11 @@
 [Packages]
   MdePkg/MdePkg.dec
   UefiCpuPkg/UefiCpuPkg.dec
-  OvmfPkg/OvmfPkg.dec
 
 [LibraryClasses]
   UefiBootServicesTableLib
   BaseLib
   DebugLib
-  NestedInterruptTplLib
   UefiDriverEntryPoint
   LocalApicLib
 

--- a/OvmfPkg/Microvm/MicrovmX64.dsc
+++ b/OvmfPkg/Microvm/MicrovmX64.dsc
@@ -417,7 +417,6 @@
   PciPcdProducerLib|OvmfPkg/Fdt/FdtPciPcdProducerLib/FdtPciPcdProducerLib.inf
   PciExpressLib|OvmfPkg/Library/BaseCachingPciExpressLib/BaseCachingPciExpressLib.inf
   MpInitLib|UefiCpuPkg/Library/MpInitLib/DxeMpInitLib.inf
-  NestedInterruptTplLib|OvmfPkg/Library/NestedInterruptTplLib/NestedInterruptTplLib.inf
   QemuFwCfgS3Lib|OvmfPkg/Library/QemuFwCfgS3Lib/DxeQemuFwCfgS3LibFwCfg.inf
   QemuLoadImageLib|OvmfPkg/Library/X86QemuLoadImageLib/X86QemuLoadImageLib.inf
 

--- a/OvmfPkg/OvmfPkgIa32X64.dsc
+++ b/OvmfPkg/OvmfPkgIa32X64.dsc
@@ -417,7 +417,6 @@
 !endif
   PciLib|OvmfPkg/Library/DxePciLibI440FxQ35/DxePciLibI440FxQ35.inf
   MpInitLib|UefiCpuPkg/Library/MpInitLib/DxeMpInitLib.inf
-  NestedInterruptTplLib|OvmfPkg/Library/NestedInterruptTplLib/NestedInterruptTplLib.inf
   QemuFwCfgS3Lib|OvmfPkg/Library/QemuFwCfgS3Lib/DxeQemuFwCfgS3LibFwCfg.inf
   QemuLoadImageLib|OvmfPkg/Library/X86QemuLoadImageLib/X86QemuLoadImageLib.inf
 

--- a/OvmfPkg/OvmfPkgX64.dsc
+++ b/OvmfPkg/OvmfPkgX64.dsc
@@ -460,7 +460,6 @@
 !endif
   PciLib|OvmfPkg/Library/DxePciLibI440FxQ35/DxePciLibI440FxQ35.inf
   MpInitLib|UefiCpuPkg/Library/MpInitLib/DxeMpInitLib.inf
-  NestedInterruptTplLib|OvmfPkg/Library/NestedInterruptTplLib/NestedInterruptTplLib.inf
   QemuFwCfgS3Lib|OvmfPkg/Library/QemuFwCfgS3Lib/DxeQemuFwCfgS3LibFwCfg.inf
   QemuLoadImageLib|OvmfPkg/Library/X86QemuLoadImageLib/X86QemuLoadImageLib.inf
   TdxMeasurementLib|OvmfPkg/IntelTdx/TdxMeasurementLib/DxeTdxMeasurementLib.inf

--- a/OvmfPkg/OvmfXen.dsc
+++ b/OvmfPkg/OvmfXen.dsc
@@ -342,7 +342,6 @@
 !endif
   PciLib|OvmfPkg/Library/DxePciLibI440FxQ35/DxePciLibI440FxQ35.inf
   MpInitLib|UefiCpuPkg/Library/MpInitLib/DxeMpInitLib.inf
-  NestedInterruptTplLib|OvmfPkg/Library/NestedInterruptTplLib/NestedInterruptTplLib.inf
   QemuFwCfgS3Lib|OvmfPkg/Library/QemuFwCfgS3Lib/DxeQemuFwCfgS3LibFwCfg.inf
 
 [LibraryClasses.common.UEFI_APPLICATION]

--- a/UefiCpuPkg/CpuDxe/CpuDxe.c
+++ b/UefiCpuPkg/CpuDxe/CpuDxe.c
@@ -13,8 +13,7 @@
 //
 // Global Variables
 //
-BOOLEAN     InterruptState = FALSE;
-EFI_HANDLE  mCpuHandle     = NULL;
+EFI_HANDLE  mCpuHandle = NULL;
 BOOLEAN     mIsFlushingGCD;
 BOOLEAN     mIsAllocatingPageTable = FALSE;
 UINT64      mTimerPeriod           = 0;
@@ -87,8 +86,6 @@ CpuEnableInterrupt (
   )
 {
   EnableInterrupts ();
-
-  InterruptState = TRUE;
   return EFI_SUCCESS;
 }
 
@@ -108,8 +105,6 @@ CpuDisableInterrupt (
   )
 {
   DisableInterrupts ();
-
-  InterruptState = FALSE;
   return EFI_SUCCESS;
 }
 
@@ -134,7 +129,8 @@ CpuGetInterruptState (
     return EFI_INVALID_PARAMETER;
   }
 
-  *State = InterruptState;
+  *State = GetInterruptState ();
+
   return EFI_SUCCESS;
 }
 


### PR DESCRIPTION
# Description

Alternative proposal for preventing unbounded recursion in the timer interrupt handler.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

OVMF boot on KVM

## Integration Instructions

Downstream implementations of timer interrupt handlers should be updated to avoid manipulating the TPL before invoking the callback provided by the DXE core, if the unbounded recursion guarantee is needed.

Without such changes, everything will work exactly as before, given that `CoreTimerTick()` will perform a no-op TPL raise/restore of TPL_HIGH_LEVEL to TPL_HIGH_LEVEL and vice versa when called with the TPL already at TPL_HIGH_LEVEL.