### PR TITLE
NetworkPkg/DnsDxe: Parse answers with uncompressed domain name

### DIFF
--- a/NetworkPkg/DnsDxe/DnsImpl.c
+++ b/NetworkPkg/DnsDxe/DnsImpl.c
@@ -1146,6 +1146,7 @@ ParseDnsResponse (
   UINT32  RRCount;
   UINT32  AnswerSectionNum;
   UINT32  CNameTtl;
+  UINT32  LabelSize;
 
   EFI_IPv4_ADDRESS  *HostAddr4;
   EFI_IPv6_ADDRESS  *HostAddr6;
@@ -1397,22 +1398,64 @@ ParseDnsResponse (
       *Completed = FALSE;
       Status     = EFI_ABORTED;
       goto ON_EXIT;
-    } else {
-      RemainingLength -= (sizeof (UINT16) + sizeof (DNS_ANSWER_SECTION));
     }
 
     //
-    // Answer name should be PTR, else EFI_UNSUPPORTED returned.
+    // Answer name should be PTR.
     //
     if ((*(UINT8 *)AnswerName & 0xC0) != 0xC0) {
-      Status = EFI_UNSUPPORTED;
-      goto ON_EXIT;
+      //
+      // Some DNS servers may respond with uncompressed domain name.
+      // Skip the domain labels, the last label is a zero length label.
+      // (RFC1035 - 4.1.4. Message compression)
+      //
+      while (TRUE) {
+        if (RemainingLength < sizeof (UINT8)) {
+          *Completed = FALSE;
+          Status     = EFI_ABORTED;
+          goto ON_EXIT;
+        }
+
+        LabelSize        = *(UINT8 *)AnswerName;
+        AnswerName      += sizeof (UINT8);
+        RemainingLength -= sizeof (UINT8);
+        if (LabelSize == 0) {
+          break;
+        }
+
+        // Label size cannot be greater than DNS_MAXIMUM_LABEL_LEN (63),
+        // because the last two bits (7 and 6) of label size must be zero.
+        if ((LabelSize > DNS_MAXIMUM_LABEL_LEN) || (RemainingLength < LabelSize)) {
+          *Completed = FALSE;
+          Status     = EFI_ABORTED;
+          goto ON_EXIT;
+        }
+
+        // Skip this domain label.
+        AnswerName      += LabelSize;
+        RemainingLength -= LabelSize;
+      }
+
+      if (RemainingLength < sizeof (DNS_ANSWER_SECTION)) {
+        *Completed = FALSE;
+        Status     = EFI_ABORTED;
+        goto ON_EXIT;
+      }
+
+      RemainingLength -= sizeof (DNS_ANSWER_SECTION);
+
+      // Get Answer section.
+      AnswerSection = (DNS_ANSWER_SECTION *)AnswerName;
+    } else {
+      RemainingLength -= (sizeof (UINT16) + sizeof (DNS_ANSWER_SECTION));
+
+      // Get Answer section.
+      AnswerSection = (DNS_ANSWER_SECTION *)(AnswerName + sizeof (UINT16));
     }
 
     //
-    // Get Answer section.
+    // Convert Answer section endianess.
     //
-    AnswerSection             = (DNS_ANSWER_SECTION *)(AnswerName + sizeof (UINT16));
     AnswerSection->Type       = NTOHS (AnswerSection->Type);
     AnswerSection->Class      = NTOHS (AnswerSection->Class);
     AnswerSection->Ttl        = NTOHL (AnswerSection->Ttl);

--- a/NetworkPkg/DnsDxe/DnsImpl.h
+++ b/NetworkPkg/DnsDxe/DnsImpl.h
@@ -82,6 +82,8 @@ extern EFI_DNS6_PROTOCOL             mDns6Protocol;
 
 #define DNS_TIME_TO_GETMAP  5
 
+#define DNS_MAXIMUM_LABEL_LEN  63
+
 #pragma pack(1)
 
 typedef union _DNS_FLAGS DNS_FLAGS;


### PR DESCRIPTION
# Description

Some DNS servers may respond with answers that does not use domain name compression, resulting in DNS query failures.
Now these types of answers will be correctly parsed and name resolution will work for such DNS servers.

Below is a DNS packet dump returned by a DNS server that responds with uncompressed domain.
Uncompressed domain answer (microsoft.com). The original EDK code fails to handle such packet.
```
[DnsDxe]:     00000000: 42 C4 81 00 00 01 00 02-00 00 00 00 09 6D 69 63  *B............mic*
[DnsDxe]:     00000010: 72 6F 73 6F 66 74 03 63-6F 6D 00 00 01 00 01 09  *rosoft.com......*
[DnsDxe]:     00000020: 6D 69 63 72 6F 73 6F 66-74 03 63 6F 6D 00 00 01  *microsoft.com...*
[DnsDxe]:     00000030: 00 01 00 00 02 4D 00 04-0D 6B E2 22 09 6D 69 63  *.....M...k.".mic*
[DnsDxe]:     00000040: 72 6F 73 6F 66 74 03 63-6F 6D 00 00 01 00 01 00  *rosoft.com......*
[DnsDxe]:     00000050: 00 02 4D 00 04 0D 6B FD-22                       *..M...k."*
```

Below is a DNS packet dump with compressed domain answer (the usual) - Returned by 8.8.8.8
The original EDK code succeeds.
```
[DnsDxe]:     00000000: 80 06 81 80 00 01 00 01-00 00 00 00 09 6D 69 63  *.............mic*
[DnsDxe]:     00000010: 72 6F 73 6F 66 74 03 63-6F 6D 00 00 01 00 01 C0  *rosoft.com......*
[DnsDxe]:     00000020: 0C 00 01 00 01 00 00 05-C1 00 04 96 AB 6E 25     *.............n%*
```

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

To test the fix, a DNS that responds with uncompressed domain names is required.
I set up local one using https://github.com/jc21/dnsrouter

To execute the test, I used the UEFI Shell with http.efi application (part of ShellPkg) 
and configured the network using ifconfig, example below:

== Test uncompressed domain names ==
192.168.3.121 is the local DNS server running "dnsrouter"
```
fs0:
ifconfig -s eth0 static 192.168.3.254 255.255.255.0 192.168.3.1
ifconfig -s eth0 dns 192.168.3.121
http.efi google.com index.html
```
http.efi must not fail with DNS error, but will fail if TLS CAs are not available.

== Test compressed domain names - Reboot first to avoid DNS cache ==
8.8.8.8 is the Google public DNS server
```
fs0:
ifconfig -s eth0 static 192.168.3.254 255.255.255.0 192.168.3.1
ifconfig -s eth0 dns 8.8.8.8
http.efi google.com index.html
```
http.efi must not fail with DNS error, but will fail if TLS CAs are not available.

## Integration Instructions

N/A
