### PR TITLE
MdeModulePkg/UefiBootManagerLib: add PCD to ignore boot option desc

### DIFF
--- a/MdeModulePkg/Include/Library/UefiBootManagerLib.h
+++ b/MdeModulePkg/Include/Library/UefiBootManagerLib.h
@@ -232,6 +232,8 @@ EfiBootManagerSortLoadOptionVariable (
   The function consider two load options are equal when the
   OptionType, Attributes, Description, FilePath and OptionalData are equal.
 
+  If PcdFindLoadOptionIgnoreDescription is TRUE, then Description is not compared.
+
   @param Key    Pointer to the load option to be found.
   @param Array  Pointer to the array of load options to be found.
   @param Count  Number of entries in the Array.

--- a/MdeModulePkg/Library/UefiBootManagerLib/BmLoadOption.c
+++ b/MdeModulePkg/Library/UefiBootManagerLib/BmLoadOption.c
@@ -538,6 +538,8 @@ EfiBootManagerInitializeLoadOption (
   The function consider two load options are equal when the
   OptionType, Attributes, Description, FilePath and OptionalData are equal.
 
+  If PcdFindLoadOptionIgnoreDescription is TRUE, then Description is not compared.
+
   @param Key    Pointer to the load option to be found.
   @param Array  Pointer to the array of load options to be found.
   @param Count  Number of entries in the Array.
@@ -558,7 +560,8 @@ EfiBootManagerFindLoadOption (
   for (Index = 0; Index < Count; Index++) {
     if ((Key->OptionType == Array[Index].OptionType) &&
         (Key->Attributes == Array[Index].Attributes) &&
-        (StrCmp (Key->Description, Array[Index].Description) == 0) &&
+        (PcdGetBool (PcdFindLoadOptionIgnoreDescription) ||
+         (StrCmp (Key->Description, Array[Index].Description) == 0)) &&
         (CompareMem (Key->FilePath, Array[Index].FilePath, GetDevicePathSize (Key->FilePath)) == 0) &&
         (Key->OptionalDataSize == Array[Index].OptionalDataSize) &&
         (CompareMem (Key->OptionalData, Array[Index].OptionalData, Key->OptionalDataSize) == 0))

--- a/MdeModulePkg/Library/UefiBootManagerLib/UefiBootManagerLib.inf
+++ b/MdeModulePkg/Library/UefiBootManagerLib/UefiBootManagerLib.inf
@@ -119,3 +119,4 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdBootManagerMenuFile                     ## CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdDriverHealthConfigureForm               ## SOMETIMES_CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdMaxRepairCount                          ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFindLoadOptionIgnoreDescription         ## CONSUMES

--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -1584,6 +1584,11 @@
   # @Prompt Boot Manager Menu File
   gEfiMdeModulePkgTokenSpaceGuid.PcdBootManagerMenuFile|{ 0xdc, 0x5b, 0xc2, 0xee, 0xf2, 0x67, 0x95, 0x4d, 0xb1, 0xd5, 0xf8, 0x1b, 0x20, 0x39, 0xd1, 0x1d }|VOID*|0x0001006b
 
+  ## When TRUE, EfiBootManagerFindLoadOption() matches load options without comparing
+  #  the Description field (OptionType, Attributes, FilePath, and OptionalData must still match).
+  # @Prompt Ignore load option description when finding a matching load option
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFindLoadOptionIgnoreDescription|FALSE|BOOLEAN|0x0001007B
+
   ## This PCD points to the formset GUID of the driver health management form
   #  The form will be popped up by BDS core when there are Configuration Required driver health instances.
   #  Platform can customize the PCD to point to different formset.

--- a/MdeModulePkg/MdeModulePkg.uni
+++ b/MdeModulePkg/MdeModulePkg.uni
@@ -865,6 +865,11 @@
 #string STR_gEfiMdeModulePkgTokenSpaceGuid_PcdBootManagerMenuFile_HELP  #language en-US "This PCD points to the file name GUID of the BootManagerMenuApp\n"
                                                                                         "Platform can customize the PCD to point to different application for Boot Manager Menu"
 
+#string STR_gEfiMdeModulePkgTokenSpaceGuid_PcdFindLoadOptionIgnoreDescription_PROMPT  #language en-US "Ignore load option description when finding a matching load option"
+
+#string STR_gEfiMdeModulePkgTokenSpaceGuid_PcdFindLoadOptionIgnoreDescription_HELP  #language en-US "When TRUE, EfiBootManagerFindLoadOption() treats two load options as equal without comparing the Description string.\n"
+                                                                                              "OptionType, Attributes, FilePath, and OptionalData must still match."
+
 #string STR_gEfiMdeModulePkgTokenSpaceGuid_PcdDriverHealthConfigureForm_PROMPT  #language en-US "Driver Health Management Form"
 
 #string STR_gEfiMdeModulePkgTokenSpaceGuid_PcdDriverHealthConfigureForm_HELP  #language en-US "This PCD points to the formset GUID of the driver health management form\n"


### PR DESCRIPTION
# Description
Add PcdFindLoadOptionIgnoreDescription to allow EfiBootManagerFindLoadOption() to ignore the Description field when comparing load options.

Can be used to avoid treating an existing boot option as a new option if the default description has changed.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Set the PcdFindLoadOptionIgnoreDescription TRUE and verified that existing boot options were processed correctly despite description field mismatch.

## Integration Instructions

N/A
