### PR TITLE
ShellPkg/Acpiview: Refactor EINJ table parser for improved validation

### DIFF
--- a/ShellPkg/Library/UefiShellAcpiViewCommandLib/Parsers/Einj/EinjParser.c
+++ b/ShellPkg/Library/UefiShellAcpiViewCommandLib/Parsers/Einj/EinjParser.c
@@ -327,7 +327,9 @@ ParseAcpiEinj (
              );
 
   // Validate Error Source Descriptors Count.
-  if ((mEinjInjectionHdrSize == NULL) || (*mEinjInjectionHdrSize != Offset)) {
+  if ((mEinjInjectionHdrSize == NULL) ||
+      (*mEinjInjectionHdrSize != (Offset - sizeof (EFI_ACPI_DESCRIPTION_HEADER))))
+  {
     IncrementErrorCount ();
     Print (L"ERROR: Invalid Injection Header...\n");
     return;


### PR DESCRIPTION
# Description

ACPI defines the EINJ Injection Header Size field as the length of the EINJ injection header, not the absolute offset of the injection instruction entries. The parser previously compared this field directly against the parsed table offset, which incorrectly rejected valid EINJ tables that report the spec-defined header size.

Update the EINJ parser validation to compute the instruction entry offset from the ACPI table header size plus the Injection Header Size field. This aligns the validation with the ACPI specification and with the layout accepted by Linux APEI EINJ handling.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

Verified with AcpiView against an EINJ table that reports `Injection Header Size` as `12` and has instruction entries beginning at offset `48`. The table now parses without the previous `ERROR: Invalid Injection Header...` validation failure.

## Integration Instructions

N/A