### PR TITLE
NetworkPkg/DpcDxe: Stop adding entries on allocation failure

### DIFF
--- a/NetworkPkg/DpcDxe/Dpc.c
+++ b/NetworkPkg/DpcDxe/Dpc.c
@@ -145,6 +145,8 @@ DpcQueueDpc (
           ReturnStatus = EFI_OUT_OF_RESOURCES;
           goto Done;
         }
+
+        break;
       }
 
       //


### PR DESCRIPTION

# Description

DpcQueueDpc() expands the DPC entry free list when it is empty. If an allocation fails after at least one entry has already been added to the free list, the current code continues and inserts the failed allocation result into the list.

Stop expanding the free list when an allocation fails and the free list already contains entries. The caller can then continue with one of the entries that was successfully allocated.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested
PXE/HTTP/iSCSI


## Integration Instructions

N/A
