### PR TITLE
MdeModulePkg/GptLib: Bound GPT entry array size to MAX_UINT32

### DIFF
--- a/MdeModulePkg/Library/GptLib/Gpt.c
+++ b/MdeModulePkg/Library/GptLib/Gpt.c
@@ -198,10 +198,13 @@ PartitionValidGptTable (
   //
   // Ensure PartitionEntryLBA * BlockSize and
   // NumberOfPartitionEntries * SizeOfPartitionEntry don't overflow when they
-  // are later used to read and size the partition entry array.
+  // are later used to read and size the partition entry array. Both entry
+  // fields are UINT32, so the product is evaluated in 32-bit arithmetic and
+  // must be bounded by MAX_UINT32 to avoid truncation before it is widened
+  // to UINTN.
   //
   if ((PartHdr->PartitionEntryLBA > DivU64x32 (MAX_UINT64, BlockSize)) ||
-      (PartHdr->NumberOfPartitionEntries > DivU64x32 (MAX_UINTN, PartHdr->SizeOfPartitionEntry)))
+      (PartHdr->NumberOfPartitionEntries > DivU64x32 (MAX_UINT32, PartHdr->SizeOfPartitionEntry)))
   {
     FreePool (PartHdr);
     return FALSE;


### PR DESCRIPTION
Noticed the overflow guard in PartitionValidGptTable caps NumberOfPartitionEntries against MAX_UINTN, but the value it guards, NumberOfPartitionEntries * SizeOfPartitionEntry, is a UINT32 product that truncates. On a 64-bit build a header declaring 16 entries of 0x10000000 bytes clears the check while the product wraps to 0, so the entry array is allocated empty and the per-entry loop reads far past it. Bound against MAX_UINT32 to match the width of the multiplication.