### PR TITLE
CryptoPkg/OpensslLib: Avoid __int128 helpers on LoongArch64

### DIFF
--- a/CryptoPkg/Library/OpensslLib/OpensslLibFull.inf
+++ b/CryptoPkg/Library/OpensslLib/OpensslLibFull.inf
@@ -846,7 +846,7 @@
   GCC:*_*_X64_CC_FLAGS     = -U_WIN32 -UWIN32 -U_WIN64 -U_MSC_VER $(OPENSSL_FLAGS) $(OPENSSL_FLAGS_NOASM) -Wno-error=maybe-uninitialized -Wno-error=format -Wno-format -Wno-error=unused-but-set-variable -DNO_MSABI_VA_FUNCS
   GCC:*_*_AARCH64_CC_FLAGS = $(OPENSSL_FLAGS) -Wno-error=maybe-uninitialized -Wno-format -Wno-error=unused-but-set-variable -Wno-error=format
   GCC:*_*_RISCV64_CC_FLAGS = $(OPENSSL_FLAGS) -Wno-error=maybe-uninitialized -Wno-format -Wno-error=unused-but-set-variable
-  GCC:*_*_LOONGARCH64_CC_FLAGS = $(OPENSSL_FLAGS) -Wno-error=maybe-uninitialized -Wno-format -Wno-error=unused-but-set-variable
+  GCC:*_*_LOONGARCH64_CC_FLAGS = $(OPENSSL_FLAGS) -U__SIZEOF_INT128__ -Wno-error=maybe-uninitialized -Wno-format -Wno-error=unused-but-set-variable
   GCC:*_CLANGDWARF_*_CC_FLAGS = -std=c99 -Wno-error=uninitialized -Wno-error=incompatible-pointer-types -Wno-error=pointer-sign -Wno-error=implicit-function-declaration -Wno-error=ignored-pragma-optimize
   GCC:*_CLANGPDB_*_CC_FLAGS = -U_WIN32 -UWIN32 -U_WIN64 -U_MSC_VER -std=c99 -Wno-error=uninitialized -Wno-error=incompatible-pointer-types -Wno-error=pointer-sign -Wno-error=implicit-function-declaration -Wno-error=ignored-pragma-optimize -Wno-error=unused-function
 


### PR DESCRIPTION
OpenSSL selects its 64-bit Curve448 implementation when the compiler defines __SIZEOF_INT128__. With the LoongArch64 GCC toolchain this path can emit libgcc helper references, such as __ashlti3, for 128-bit shifts.

EDK II modules are linked with -nostdlib and do not pull in libgcc. Consequently TlsDxe fails to link when it consumes OpensslLibFull.

Undefine __SIZEOF_INT128__ for LoongArch64 OpenSSL builds so Curve448 uses the portable 32-bit implementation and does not require compiler runtime helpers.

Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Yi Li <yi1.li@intel.com>
Cc: Chao Li <lichao@loongson.cn>

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

1. Modify the DSC file to compile OpensslLibFull.inf.
diff --git a/OvmfPkg/LoongArchVirt/LoongArchVirtQemu.dsc b/OvmfPkg/LoongArchVirt/LoongArchVirtQemu.dsc
index 60907d7939..142168d461 100644
--- a/OvmfPkg/LoongArchVirt/LoongArchVirtQemu.dsc
+++ b/OvmfPkg/LoongArchVirt/LoongArchVirtQemu.dsc
@@ -47,7 +47,7 @@
   DEFINE NETWORK_IP6_ENABLE              = FALSE
   DEFINE NETWORK_HTTP_BOOT_ENABLE        = FALSE
   DEFINE NETWORK_SNP_ENABLE              = FALSE
-  DEFINE NETWORK_TLS_ENABLE              = FALSE
+  DEFINE NETWORK_TLS_ENABLE              = TRUE^M
   DEFINE NETWORK_ALLOW_HTTP_CONNECTIONS  = TRUE
   DEFINE NETWORK_ISCSI_ENABLE            = FALSE
   DEFINE NETWORK_PXE_BOOT_ENABLE         = TRUE
@@ -177,7 +177,7 @@
   #
   IntrinsicLib                     | CryptoPkg/Library/IntrinsicLib/IntrinsicLib.inf
 !if $(NETWORK_TLS_ENABLE) == TRUE
-  OpensslLib                       | CryptoPkg/Library/OpensslLib/OpensslLib.inf
+  OpensslLib                       | CryptoPkg/Library/OpensslLib/OpensslLibFull.inf^M
 !else
   OpensslLib                       | CryptoPkg/Library/OpensslLib/OpensslLibCrypto.inf
 !endif

2. Building LoongArch QEMU virt FW with GCC
The build completed successfully and generated `QEMU_EFI.fd` and `QEMU_VARS.fd`.

## Integration Instructions
N/A
