### PR TITLE
NetworkPkg/DnsDxe: Bound query name length in ParseDnsResponse

### DIFF
--- a/NetworkPkg/DnsDxe/DnsImpl.c
+++ b/NetworkPkg/DnsDxe/DnsImpl.c
@@ -1218,7 +1218,7 @@ ParseDnsResponse (
   //
   QueryName = (CHAR8 *)(RxString + sizeof (*DnsHeader));
 
-  QueryNameLen = (UINT32)AsciiStrLen (QueryName) + 1;
+  QueryNameLen = (UINT32)AsciiStrnLenS (QueryName, RemainingLength) + 1;
 
   //
   // Check whether the remaining packet length is available or not.


### PR DESCRIPTION
ParseDnsResponse() runs AsciiStrLen over the query name taken straight from the received packet, before any length check. A response whose name field carries no terminating zero makes the scan walk past the packet buffer returned by NetbufGetByte. Bounding the scan to the remaining packet length keeps it inside the datagram, and the existing check then rejects a name that never terminates.