### PR TITLE
Smbios memory generators

### DIFF
--- a/DynamicTablesPkg/DynamicTables.dsc.inc
+++ b/DynamicTablesPkg/DynamicTables.dsc.inc
@@ -114,6 +114,7 @@
   DynamicTablesPkg/Library/Smbios/SmbiosType7Lib/SmbiosType7Lib.inf
   DynamicTablesPkg/Library/Smbios/SmbiosType16Lib/SmbiosType16Lib.inf
   DynamicTablesPkg/Library/Smbios/SmbiosType17Lib/SmbiosType17Lib.inf
+  DynamicTablesPkg/Library/Smbios/SmbiosType19Lib/SmbiosType19Lib.inf
 
   # AML Fixup (Arm specific)
   DynamicTablesPkg/Library/Acpi/Arm/AcpiSsdtCmn600LibArm/SsdtCmn600LibArm.inf
@@ -163,6 +164,7 @@
       NULL|DynamicTablesPkg/Library/Smbios/SmbiosType7Lib/SmbiosType7Lib.inf
       NULL|DynamicTablesPkg/Library/Smbios/SmbiosType16Lib/SmbiosType16Lib.inf
       NULL|DynamicTablesPkg/Library/Smbios/SmbiosType17Lib/SmbiosType17Lib.inf
+      NULL|DynamicTablesPkg/Library/Smbios/SmbiosType19Lib/SmbiosType19Lib.inf
   }
 
 [Components.RISCV64]

--- a/DynamicTablesPkg/DynamicTables.dsc.inc
+++ b/DynamicTablesPkg/DynamicTables.dsc.inc
@@ -111,6 +111,7 @@
   DynamicTablesPkg/Library/Smbios/SmbiosType0Lib/SmbiosType0Lib.inf
   DynamicTablesPkg/Library/Smbios/SmbiosType4Lib/SmbiosType4Lib.inf
   DynamicTablesPkg/Library/Smbios/SmbiosType7Lib/SmbiosType7Lib.inf
+  DynamicTablesPkg/Library/Smbios/SmbiosType16Lib/SmbiosType16Lib.inf
 
   # AML Fixup (Arm specific)
   DynamicTablesPkg/Library/Acpi/Arm/AcpiSsdtCmn600LibArm/SsdtCmn600LibArm.inf
@@ -158,6 +159,7 @@
       NULL|DynamicTablesPkg/Library/Smbios/SmbiosType0Lib/SmbiosType0Lib.inf
       NULL|DynamicTablesPkg/Library/Smbios/SmbiosType4Lib/SmbiosType4Lib.inf
       NULL|DynamicTablesPkg/Library/Smbios/SmbiosType7Lib/SmbiosType7Lib.inf
+      NULL|DynamicTablesPkg/Library/Smbios/SmbiosType16Lib/SmbiosType16Lib.inf
   }
 
 [Components.RISCV64]

--- a/DynamicTablesPkg/DynamicTables.dsc.inc
+++ b/DynamicTablesPkg/DynamicTables.dsc.inc
@@ -23,6 +23,7 @@
   SsdtSerialPortFixupLib|DynamicTablesPkg/Library/Common/SsdtSerialPortFixupLib/SsdtSerialPortFixupLib.inf
   TableHelperLib|DynamicTablesPkg/Library/Common/TableHelperLib/TableHelperLib.inf
   SmbiosStringTableLib|DynamicTablesPkg/Library/Common/SmbiosStringTableLib/SmbiosStringTableLib.inf
+  JedecJep106Lib|MdePkg/Library/JedecJep106Lib/JedecJep106Lib.inf
   MetadataObjLib|DynamicTablesPkg/Library/Common/MetadataObjLib/MetadataObjLib.inf
   MetadataHandlerLib|DynamicTablesPkg/Library/Common/MetadataHandlerLib/MetadataHandlerLib.inf
   Tpm2DeviceTableLib|DynamicTablesPkg/Library/Common/Tpm2DeviceTableLib/Tpm2DeviceTableLib.inf
@@ -112,6 +113,7 @@
   DynamicTablesPkg/Library/Smbios/SmbiosType4Lib/SmbiosType4Lib.inf
   DynamicTablesPkg/Library/Smbios/SmbiosType7Lib/SmbiosType7Lib.inf
   DynamicTablesPkg/Library/Smbios/SmbiosType16Lib/SmbiosType16Lib.inf
+  DynamicTablesPkg/Library/Smbios/SmbiosType17Lib/SmbiosType17Lib.inf
 
   # AML Fixup (Arm specific)
   DynamicTablesPkg/Library/Acpi/Arm/AcpiSsdtCmn600LibArm/SsdtCmn600LibArm.inf
@@ -160,6 +162,7 @@
       NULL|DynamicTablesPkg/Library/Smbios/SmbiosType4Lib/SmbiosType4Lib.inf
       NULL|DynamicTablesPkg/Library/Smbios/SmbiosType7Lib/SmbiosType7Lib.inf
       NULL|DynamicTablesPkg/Library/Smbios/SmbiosType16Lib/SmbiosType16Lib.inf
+      NULL|DynamicTablesPkg/Library/Smbios/SmbiosType17Lib/SmbiosType17Lib.inf
   }
 
 [Components.RISCV64]

--- a/DynamicTablesPkg/DynamicTablesPkg.ci.yaml
+++ b/DynamicTablesPkg/DynamicTablesPkg.ci.yaml
@@ -152,7 +152,9 @@
            "imsics",
            "plics",
            "rintc",
-           "smcbios"
+           "smcbios",
+           "jedec",
+           "jep"
            ],           # words to extend to the dictionary for this package
         "IgnoreStandardPaths": [],   # Standard Plugin defined paths that
                                      # should be ignore

--- a/DynamicTablesPkg/Include/ArchCommonNameSpaceObjects.h
+++ b/DynamicTablesPkg/Include/ArchCommonNameSpaceObjects.h
@@ -82,6 +82,7 @@ typedef enum ArchCommonObjectID {
   EArchCommonObjPlatformFwInfo,                 ///< 54 - Platform Firmware Info
   EArchCommonObjPhysicalMemoryArray,            ///< 55 - Physical Memory Array Info
   EArchCommonObjMemoryDeviceInfo,               ///< 56 - Memory Device Info
+  EArchCommonObjMemoryArrayMappedAddress,       ///< 57 - Memory Array Mapped Address Info
   EArchCommonObjMax
 } EARCH_COMMON_OBJECT_ID;
 
@@ -1443,5 +1444,24 @@ typedef struct CmArchCommonMemoryDeviceInfo {
   /// RCD revision number.
   UINT16                                     RcdRevisionNumber;
 } CM_ARCH_COMMON_MEMORY_DEVICE_INFO;
+
+/** A structure that describes a Memory Array Mapped Address.
+
+  SMBIOS Specification v3.9.0 Type 19
+
+  ID: EArchCommonObjMemoryArrayMappedAddress
+**/
+typedef struct CmArchCommonMemoryArrayMappedAddress {
+  /// CM Object Token uniquely identifying this mapped address entry.
+  CM_OBJECT_TOKEN         MemoryArrayMappedAddressToken;
+  /// Starting physical address of the mapped memory range.
+  EFI_PHYSICAL_ADDRESS    StartingAddress;
+  /// Ending physical address of the mapped memory range.
+  EFI_PHYSICAL_ADDRESS    EndingAddress;
+  /// CM Object Token of the associated Physical Memory Array.
+  CM_OBJECT_TOKEN         PhysMemArrayToken;
+  /// Number of memory devices that form a row in the address partition.
+  UINT8                   NumMemDevices;
+} CM_ARCH_COMMON_MEMORY_ARRAY_MAPPED_ADDRESS;
 
 #pragma pack()

--- a/DynamicTablesPkg/Include/ArchCommonNameSpaceObjects.h
+++ b/DynamicTablesPkg/Include/ArchCommonNameSpaceObjects.h
@@ -80,6 +80,7 @@ typedef enum ArchCommonObjectID {
   EArchCommonObjErrSourceGenericHwVer2Info,     ///< 53 - Generic Hardware Error Source Info version 2
   EArchCommonObjEinjInstructionsInfo,           ///< 54 - Einj Instruction Info
   EArchCommonObjPlatformFwInfo,                 ///< 54 - Platform Firmware Info
+  EArchCommonObjPhysicalMemoryArray,            ///< 55 - Physical Memory Array Info
   EArchCommonObjMax
 } EARCH_COMMON_OBJECT_ID;
 
@@ -1332,5 +1333,30 @@ typedef struct CmArchCommonPlatformFwInfo {
   /// Embedded Controller firmware minor release.
   UINT8                        ECFirmwareMinorRelease;
 } CM_ARCH_COMMON_PLATFORM_FW_INFO;
+
+/** A structure that describes the Physical Memory Array.
+
+  SMBIOS Specification v3.9.0 Type 16
+
+  ID: EArchCommonObjPhysicalMemoryArray
+**/
+typedef struct CmArchCommonPhysicalMemoryArray {
+  /// CM Object Token uniquely identifying this Physical Memory Array.
+  CM_OBJECT_TOKEN    PhysMemArrayToken;
+  /// Physical location of the memory array.
+  UINT8              Location;
+  /// Use of the memory array (e.g. system, video).
+  UINT8              Use;
+  /// Error correction type enumeration value.
+  UINT8              MemoryErrorCorrectionType;
+  /// Maximum capacity of the array in bytes.
+  UINT64             Size;
+  /// Unsupported until SMBIOS Type 18/Type 33 generators are available.
+  /// Kept here to reserve the Type 17 memory error information handle source
+  /// field in the CM object.
+  CM_OBJECT_TOKEN    MemoryErrorInfoToken;
+  /// Number of memory devices (slots or sockets) in the array.
+  UINT16             NumberOfMemoryDevices;
+} CM_ARCH_COMMON_PHYSICAL_MEMORY_ARRAY;
 
 #pragma pack()

--- a/DynamicTablesPkg/Include/ArchCommonNameSpaceObjects.h
+++ b/DynamicTablesPkg/Include/ArchCommonNameSpaceObjects.h
@@ -81,6 +81,7 @@ typedef enum ArchCommonObjectID {
   EArchCommonObjEinjInstructionsInfo,           ///< 54 - Einj Instruction Info
   EArchCommonObjPlatformFwInfo,                 ///< 54 - Platform Firmware Info
   EArchCommonObjPhysicalMemoryArray,            ///< 55 - Physical Memory Array Info
+  EArchCommonObjMemoryDeviceInfo,               ///< 56 - Memory Device Info
   EArchCommonObjMax
 } EARCH_COMMON_OBJECT_ID;
 
@@ -1358,5 +1359,89 @@ typedef struct CmArchCommonPhysicalMemoryArray {
   /// Number of memory devices (slots or sockets) in the array.
   UINT16             NumberOfMemoryDevices;
 } CM_ARCH_COMMON_PHYSICAL_MEMORY_ARRAY;
+
+/** A structure that describes a Memory Device.
+
+  SMBIOS Specification v3.9.0 Type 17
+
+  ID: EArchCommonObjMemoryDeviceInfo
+**/
+typedef struct CmArchCommonMemoryDeviceInfo {
+  /// CM Object Token uniquely identifying this Memory Device.
+  CM_OBJECT_TOKEN                            MemoryDeviceInfoToken;
+  /// CM Object Token of the Physical Memory Array containing this device.
+  CM_OBJECT_TOKEN                            PhysicalArrayToken;
+  /// CM Object Token of the associated memory error information structure.
+  /// Set to CM_NULL_TOKEN if not present; the generator will use 0xFFFE (Not Provided).
+  CM_OBJECT_TOKEN                            MemoryErrorInfoToken;
+  /// Total width of the device in bits (including ECC bits).
+  UINT16                                     TotalWidth;
+  /// Data width of the device in bits.
+  UINT16                                     DataWidth;
+  /// Size of memory in bytes.
+  UINT64                                     Size;
+  /// Form factor enumeration value.
+  MEMORY_FORM_FACTOR                         FormFactor;
+  /// Device Set number (0 = not part of a set).
+  UINT8                                      DeviceSet;
+  /// Device Locator string (slot/position on board).
+  CHAR8                                      DeviceLocator[SMBIOS_MAX_STRING_SIZE];
+  /// Bank Locator string.
+  CHAR8                                      BankLocator[SMBIOS_MAX_STRING_SIZE];
+  /// Memory device type enumeration value.
+  MEMORY_DEVICE_TYPE                         MemoryType;
+  /// Type detail flags.
+  MEMORY_DEVICE_TYPE_DETAIL                  TypeDetail;
+  /// Speed of the device in MegaTransfers/second.
+  UINT32                                     Speed;
+  /// Serial Number string.
+  CHAR8                                      SerialNum[SMBIOS_MAX_STRING_SIZE];
+  /// Asset Tag string.
+  CHAR8                                      AssetTag[SMBIOS_MAX_STRING_SIZE];
+  /// Part Number string.
+  CHAR8                                      PartNum[SMBIOS_MAX_STRING_SIZE];
+  /// Rank of the device.
+  UINT8                                      Rank;
+  /// Configured speed of the device in MegaTransfers/second.
+  UINT32                                     ConfiguredMemorySpeed;
+  /// Minimum operating voltage in millivolts.
+  UINT16                                     MinVolt;
+  /// Maximum operating voltage in millivolts.
+  UINT16                                     MaxVolt;
+  /// Configured voltage in millivolts.
+  UINT16                                     ConfVolt;
+  /// Memory technology enumeration value.
+  MEMORY_DEVICE_TECHNOLOGY                   MemoryTechnology;
+  /// Operating mode capability flags.
+  MEMORY_DEVICE_OPERATING_MODE_CAPABILITY    MemoryOperatingModeCapability;
+  /// Firmware version string of the memory device.
+  CHAR8                                      FirmwareVersion[SMBIOS_MAX_STRING_SIZE];
+  /// 2-byte Manufacturer Id per JEDEC JEP106AV.
+  UINT16                                     ModuleManufacturerId;
+  /// 2-byte Manufacturer Product Id.
+  UINT16                                     ModuleProductId;
+  /// 2-byte Memory Subsystem Controller Manufacturer Id per JEDEC JEP106AV.
+  UINT16                                     MemorySubsystemControllerManufacturerId;
+  /// 2-byte Memory Subsystem Controller Product Id.
+  UINT16                                     MemorySubsystemControllerProductId;
+  /// Size of non-volatile memory in bytes.
+  /// If the Non-Volatile Size is unknown, the field is set to FFFFFFFFFFFFFFFFh
+  UINT64                                     NonVolatileSize;
+  /// Size of volatile memory in bytes.
+  /// If the Volatile Size is unknown, the field is set to FFFFFFFFFFFFFFFFh
+  UINT64                                     VolatileSize;
+  /// Size of cache memory in bytes.
+  UINT64                                     CacheSize;
+  /// Logical size of the memory device in bytes.
+  UINT64                                     LogicalSize;
+  /// 2-byte PMIC0 Manufacturer Id per JEDEC JEP106AV.
+  UINT16                                     Pmic0ManufacturerId;
+  /// PMIC0 revision number.
+  UINT16                                     Pmic0RevisionNumber;
+  /// 2-byte RCD Manufacturer Id per JEDEC JEP106AV.
+  UINT16                                     RcdManufacturerId;
+  /// RCD revision number.
+  UINT16                                     RcdRevisionNumber;
+} CM_ARCH_COMMON_MEMORY_DEVICE_INFO;
 
 #pragma pack()

--- a/DynamicTablesPkg/Include/Library/SmbiosStringTableLib.h
+++ b/DynamicTablesPkg/Include/Library/SmbiosStringTableLib.h
@@ -114,3 +114,27 @@ EFIAPI
 StringTableFree (
   IN STRING_TABLE *CONST  StrTable
   );
+
+/** Allocate a zeroed buffer for a SMBIOS record, including the string area.
+
+  Per SMBIOS Specification Section 6.1.3, if the structure has no strings the
+  formatted section is followed by two null (00h) bytes.  If strings are
+  present each string is null-terminated and the set is terminated by an
+  additional null byte.  This function encapsulates that rule so callers do
+  not need to account for the terminator explicitly.
+
+  @param[in]  StructSize  Size of the fixed-size part of the SMBIOS structure.
+  @param[in]  StrTable    Optional pointer to a populated string table.
+                          If NULL, the allocation includes only the two-byte
+                          double-NULL terminator.
+                          If non-NULL, the allocation includes the full string
+                          area as returned by StringTableGetStringSetSize().
+
+  @return  Pointer to the allocated SMBIOS record buffer, or NULL on failure.
+**/
+VOID *
+EFIAPI
+AllocateSmbiosRecord (
+  IN        UINTN   StructSize,
+  IN  STRING_TABLE  *StrTable    OPTIONAL
+  );

--- a/DynamicTablesPkg/Library/Common/SmbiosStringTableLib/SmbiosStringTableLib.c
+++ b/DynamicTablesPkg/Library/Common/SmbiosStringTableLib/SmbiosStringTableLib.c
@@ -225,3 +225,35 @@ StringTableFree (
   ZeroMem (StrTable, sizeof (STRING_TABLE));
   return EFI_SUCCESS;
 }
+
+/** Allocate a zeroed buffer for a SMBIOS record, including the string area.
+
+  Per SMBIOS Specification Section 6.1.3, if the structure has no strings the
+  formatted section is followed by two null (00h) bytes.  If strings are
+  present each string is null-terminated and the set is terminated by an
+  additional null byte.  This function encapsulates that rule so callers do
+  not need to account for the terminator explicitly.
+
+  @param[in]  StructSize  Size of the fixed-size part of the SMBIOS structure.
+  @param[in]  StrTable    Optional pointer to a populated string table.
+                          If NULL, the allocation includes only the two-byte
+                          double-NULL terminator.
+                          If non-NULL, the allocation includes the full string
+                          area as returned by StringTableGetStringSetSize().
+
+  @return  Pointer to the allocated SMBIOS record buffer, or NULL on failure.
+**/
+VOID *
+EFIAPI
+AllocateSmbiosRecord (
+  IN        UINTN   StructSize,
+  IN  STRING_TABLE  *StrTable    OPTIONAL
+  )
+{
+  UINTN  StringAreaSize;
+
+  // Per SMBIOS spec Section 6.1.3: two null bytes when no strings are present;
+  // StringTableGetStringSetSize() already encodes this rule for non-empty tables.
+  StringAreaSize = (StrTable == NULL) ? 2 : StringTableGetStringSetSize (StrTable);
+  return AllocateZeroPool (StructSize + StringAreaSize);
+}

--- a/DynamicTablesPkg/Library/Common/TableHelperLib/ConfigurationManagerObjectParser.c
+++ b/DynamicTablesPkg/Library/Common/TableHelperLib/ConfigurationManagerObjectParser.c
@@ -1197,6 +1197,16 @@ STATIC CONST CM_OBJ_PARSER  CmArchCommonMemoryDeviceInfoParser[] = {
   { "RcdRevisionNumber",                       sizeof (UINT16),                                  "0x%x",  NULL        },
 };
 
+/** A parser for EArchCommonObjMemoryArrayMappedAddress.
+*/
+STATIC CONST CM_OBJ_PARSER  CmArchCommonMemoryArrayMappedAddressParser[] = {
+  { "MemoryArrayMappedAddressToken", sizeof (CM_OBJECT_TOKEN),      "0x%p",  NULL },
+  { "StartingAddress",               sizeof (EFI_PHYSICAL_ADDRESS), "0x%lx", NULL },
+  { "EndingAddress",                 sizeof (EFI_PHYSICAL_ADDRESS), "0x%lx", NULL },
+  { "PhysMemArrayToken",             sizeof (CM_OBJECT_TOKEN),      "0x%p",  NULL },
+  { "NumMemDevices",                 sizeof (UINT8),                "0x%u",  NULL },
+};
+
 /** A parser for Arch Common namespace objects.
 */
 STATIC CONST CM_OBJ_PARSER_ARRAY  ArchCommonNamespaceObjectParser[] = {
@@ -1258,6 +1268,7 @@ STATIC CONST CM_OBJ_PARSER_ARRAY  ArchCommonNamespaceObjectParser[] = {
   CM_PARSER_ADD_OBJECT (EArchCommonObjPlatformFwInfo,               CmArchCommonPlatformFwInfoParser),
   CM_PARSER_ADD_OBJECT (EArchCommonObjPhysicalMemoryArray,          CmArchCommonPhysicalMemoryArrayParser),
   CM_PARSER_ADD_OBJECT (EArchCommonObjMemoryDeviceInfo,             CmArchCommonMemoryDeviceInfoParser),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjMemoryArrayMappedAddress,     CmArchCommonMemoryArrayMappedAddressParser),
   CM_PARSER_ADD_OBJECT_RESERVED (EArchCommonObjMax)
 };
 

--- a/DynamicTablesPkg/Library/Common/TableHelperLib/ConfigurationManagerObjectParser.c
+++ b/DynamicTablesPkg/Library/Common/TableHelperLib/ConfigurationManagerObjectParser.c
@@ -1156,6 +1156,47 @@ STATIC CONST CM_OBJ_PARSER  CmArchCommonPhysicalMemoryArrayParser[] = {
   { "NumberOfMemoryDevices",     sizeof (UINT16),          "0x%u",  NULL },
 };
 
+/** A parser for EArchCommonObjMemoryDeviceInfo.
+*/
+STATIC CONST CM_OBJ_PARSER  CmArchCommonMemoryDeviceInfoParser[] = {
+  { "MemoryDeviceInfoToken",                   sizeof (CM_OBJECT_TOKEN),                         "0x%p",  NULL        },
+  { "PhysicalArrayToken",                      sizeof (CM_OBJECT_TOKEN),                         "0x%p",  NULL        },
+  { "MemoryErrorInfoToken",                    sizeof (CM_OBJECT_TOKEN),                         "0x%p",  NULL        },
+  { "TotalWidth",                              sizeof (UINT16),                                  "0x%u",  NULL        },
+  { "DataWidth",                               sizeof (UINT16),                                  "0x%u",  NULL        },
+  { "Size",                                    sizeof (UINT64),                                  "0x%lx", NULL        },
+  { "FormFactor",                              sizeof (MEMORY_FORM_FACTOR),                      "0x%x",  NULL        },
+  { "DeviceSet",                               sizeof (UINT8),                                   "0x%u",  NULL        },
+  { "DeviceLocator",                           SMBIOS_MAX_STRING_SIZE,                           NULL,    PrintString },
+  { "BankLocator",                             SMBIOS_MAX_STRING_SIZE,                           NULL,    PrintString },
+  { "MemoryType",                              sizeof (MEMORY_DEVICE_TYPE),                      "0x%x",  NULL        },
+  { "TypeDetail",                              sizeof (MEMORY_DEVICE_TYPE_DETAIL),               "0x%x",  NULL        },
+  { "Speed",                                   sizeof (UINT32),                                  "0x%u",  NULL        },
+  { "SerialNum",                               SMBIOS_MAX_STRING_SIZE,                           NULL,    PrintString },
+  { "AssetTag",                                SMBIOS_MAX_STRING_SIZE,                           NULL,    PrintString },
+  { "PartNum",                                 SMBIOS_MAX_STRING_SIZE,                           NULL,    PrintString },
+  { "Rank",                                    sizeof (UINT8),                                   "0x%u",  NULL        },
+  { "ConfiguredMemorySpeed",                   sizeof (UINT32),                                  "0x%u",  NULL        },
+  { "MinVolt",                                 sizeof (UINT16),                                  "0x%u",  NULL        },
+  { "MaxVolt",                                 sizeof (UINT16),                                  "0x%u",  NULL        },
+  { "ConfVolt",                                sizeof (UINT16),                                  "0x%u",  NULL        },
+  { "MemoryTechnology",                        sizeof (MEMORY_DEVICE_TECHNOLOGY),                "0x%x",  NULL        },
+  { "MemoryOperatingModeCapability",           sizeof (MEMORY_DEVICE_OPERATING_MODE_CAPABILITY), "0x%x",  NULL        },
+  { "FirmwareVersion",                         SMBIOS_MAX_STRING_SIZE,                           NULL,    PrintString },
+  { "ModuleManufacturerId",                    sizeof (UINT16),                                  "0x%x",  NULL        },
+  { "ModuleProductId",                         sizeof (UINT16),                                  "0x%x",  NULL        },
+  { "MemorySubsystemControllerManufacturerId", sizeof (UINT16),                                  "0x%x",  NULL        },
+  { "MemorySubsystemControllerProductId",      sizeof (UINT16),                                  "0x%x",  NULL        },
+  { "NonVolatileSize",                         sizeof (UINT64),                                  "0x%lx", NULL        },
+  { "VolatileSize",                            sizeof (UINT64),                                  "0x%lx", NULL        },
+  { "CacheSize",                               sizeof (UINT64),                                  "0x%lx", NULL        },
+  { "LogicalSize",                             sizeof (UINT64),                                  "0x%lx", NULL        },
+  { "Pmic0ManufacturerId",                     sizeof (UINT16),                                  "0x%x",  NULL        },
+  { "Pmic0RevisionNumber",                     sizeof (UINT16),                                  "0x%x",  NULL        },
+  { "RcdManufacturerId",                       sizeof (UINT16),                                  "0x%x",  NULL        },
+  { "RcdRevisionNumber",                       sizeof (UINT16),                                  "0x%x",  NULL        },
+};
+
 /** A parser for Arch Common namespace objects.
 */
 STATIC CONST CM_OBJ_PARSER_ARRAY  ArchCommonNamespaceObjectParser[] = {
@@ -1216,6 +1257,7 @@ STATIC CONST CM_OBJ_PARSER_ARRAY  ArchCommonNamespaceObjectParser[] = {
   CM_PARSER_ADD_OBJECT (EArchCommonObjEinjInstructionsInfo,         CmArchCommonObjEinjInstructionsInfoParser),
   CM_PARSER_ADD_OBJECT (EArchCommonObjPlatformFwInfo,               CmArchCommonPlatformFwInfoParser),
   CM_PARSER_ADD_OBJECT (EArchCommonObjPhysicalMemoryArray,          CmArchCommonPhysicalMemoryArrayParser),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjMemoryDeviceInfo,             CmArchCommonMemoryDeviceInfoParser),
   CM_PARSER_ADD_OBJECT_RESERVED (EArchCommonObjMax)
 };
 

--- a/DynamicTablesPkg/Library/Common/TableHelperLib/ConfigurationManagerObjectParser.c
+++ b/DynamicTablesPkg/Library/Common/TableHelperLib/ConfigurationManagerObjectParser.c
@@ -1144,6 +1144,18 @@ STATIC CONST CM_OBJ_PARSER  CmArchCommonPlatformFwInfoParser[] = {
   { "ECFirmwareMinorRelease",            sizeof (UINT8),                     "0x%u",   NULL        },
 };
 
+/** A parser for EArchCommonObjPhysicalMemoryArray.
+*/
+STATIC CONST CM_OBJ_PARSER  CmArchCommonPhysicalMemoryArrayParser[] = {
+  { "PhysMemArrayToken",         sizeof (CM_OBJECT_TOKEN), "0x%p",  NULL },
+  { "Location",                  sizeof (UINT8),           "0x%x",  NULL },
+  { "Use",                       sizeof (UINT8),           "0x%x",  NULL },
+  { "MemoryErrorCorrectionType", sizeof (UINT8),           "0x%x",  NULL },
+  { "Size",                      sizeof (UINT64),          "0x%lx", NULL },
+  { "MemoryErrorInfoToken",      sizeof (CM_OBJECT_TOKEN), "0x%p",  NULL },
+  { "NumberOfMemoryDevices",     sizeof (UINT16),          "0x%u",  NULL },
+};
+
 /** A parser for Arch Common namespace objects.
 */
 STATIC CONST CM_OBJ_PARSER_ARRAY  ArchCommonNamespaceObjectParser[] = {
@@ -1203,6 +1215,7 @@ STATIC CONST CM_OBJ_PARSER_ARRAY  ArchCommonNamespaceObjectParser[] = {
   CM_PARSER_ADD_OBJECT (EArchCommonObjErrSourceGenericHwVer2Info,   CmArchCommonObjErrSourceGenericHwVer2InfoParser),
   CM_PARSER_ADD_OBJECT (EArchCommonObjEinjInstructionsInfo,         CmArchCommonObjEinjInstructionsInfoParser),
   CM_PARSER_ADD_OBJECT (EArchCommonObjPlatformFwInfo,               CmArchCommonPlatformFwInfoParser),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjPhysicalMemoryArray,          CmArchCommonPhysicalMemoryArrayParser),
   CM_PARSER_ADD_OBJECT_RESERVED (EArchCommonObjMax)
 };
 

--- a/DynamicTablesPkg/Library/Smbios/SmbiosType16Lib/SmbiosType16Generator.c
+++ b/DynamicTablesPkg/Library/Smbios/SmbiosType16Lib/SmbiosType16Generator.c
@@ -1,0 +1,418 @@
+/** @file
+  SMBIOS Type16 Table Generator.
+
+  Copyright (c) 2024 - 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  Copyright (c) 2020 - 2021, Arm Limited. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
+#include <Library/PrintLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/UefiBootServicesTableLib.h>
+#include <Library/SmbiosStringTableLib.h>
+
+// Module specific include files.
+#include <ConfigurationManagerObject.h>
+#include <ConfigurationManagerHelper.h>
+#include <Protocol/ConfigurationManagerProtocol.h>
+#include <Protocol/DynamicTableFactoryProtocol.h>
+#include <Protocol/Smbios.h>
+#include <IndustryStandard/SmBios.h>
+
+/** This macro expands to a function that retrieves the Memory Device
+    information from the Configuration Manager.
+*/
+GET_OBJECT_LIST (
+  EObjNameSpaceArchCommon,
+  EArchCommonObjPhysicalMemoryArray,
+  CM_ARCH_COMMON_PHYSICAL_MEMORY_ARRAY
+  )
+
+#define EXTENDED_SIZE_THRESHOLD  (SIZE_2TB)
+
+/**
+  Free any resources allocated when installing SMBIOS Type16 table.
+
+  @param [in]  This                 Pointer to the SMBIOS table generator.
+  @param [in]  TableFactoryProtocol Pointer to the SMBIOS Table Factory
+                                    Protocol interface.
+  @param [in]  SmbiosTableInfo      Pointer to the SMBIOS table information.
+  @param [in]  CfgMgrProtocol       Pointer to the Configuration Manager
+                                    Protocol interface.
+  @param [in]  Table                Pointer to the SMBIOS table.
+  @param [in]  CmObjectToken        Pointer to the CM ObjectToken Array.
+  @param [in]  TableCount           Number of SMBIOS tables.
+
+  @retval EFI_SUCCESS            Table generated successfully.
+  @retval EFI_BAD_BUFFER_SIZE    The size returned by the Configuration
+                                 Manager is less than the Object size for
+                                 the requested object.
+  @retval EFI_INVALID_PARAMETER  A parameter is invalid.
+  @retval EFI_NOT_FOUND          Could not find information.
+  @retval EFI_OUT_OF_RESOURCES   Could not allocate memory.
+  @retval EFI_UNSUPPORTED        Unsupported configuration.
+**/
+STATIC
+EFI_STATUS
+FreeSmbiosType16TableEx (
+  IN      CONST SMBIOS_TABLE_GENERATOR                    *CONST   This,
+  IN      CONST EDKII_DYNAMIC_TABLE_FACTORY_PROTOCOL      *CONST   TableFactoryProtocol,
+  IN      CONST CM_STD_OBJ_SMBIOS_TABLE_INFO              *CONST   SmbiosTableInfo,
+  IN      CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL      *CONST   CfgMgrProtocol,
+  IN      SMBIOS_STRUCTURE                               ***CONST  Table,
+  IN      CM_OBJECT_TOKEN                                          **CmObjectToken,
+  IN      CONST UINTN                                              TableCount
+  )
+{
+  UINTN             Index;
+  SMBIOS_STRUCTURE  **TableList;
+
+  TableList = *Table;
+  for (Index = 0; Index < TableCount; Index++) {
+    if (TableList[Index] != NULL) {
+      FreePool (TableList[Index]);
+    }
+  }
+
+  if (*CmObjectToken != NULL) {
+    FreePool (*CmObjectToken);
+  }
+
+  if (TableList != NULL) {
+    FreePool (TableList);
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Update the Size encoding for Type 16.
+
+  @param [in]      SizeBytes    Size of the Memory device.
+  @param [in,out]  SmbiosRecord SMBIOS record to update.
+**/
+STATIC
+VOID
+UpdateSmbiosType16Size (
+  IN     UINT64               SizeBytes,
+  IN OUT SMBIOS_TABLE_TYPE16  *SmbiosRecord
+  )
+{
+  UINT64  SizeKb;
+
+  SizeKb = SizeBytes / SIZE_1KB;
+
+  if (SizeBytes < EXTENDED_SIZE_THRESHOLD) {
+    SmbiosRecord->MaximumCapacity = SizeKb;
+  } else {
+    SmbiosRecord->MaximumCapacity         = 0x80000000;
+    SmbiosRecord->ExtendedMaximumCapacity = SizeBytes;
+  }
+}
+
+/**
+  Add the SMBIOS table handle reference to the Error Tables.
+
+  @param [out]  SmbiosRecord          SMBIOS record to update.
+**/
+STATIC
+VOID
+AddMemErrDeviceHandle (
+  OUT SMBIOS_TABLE_TYPE16  *SmbiosRecord
+  )
+{
+  // TODO: Query for Type 18/33 CM objects via CfgMgrProtocol to determine
+  // whether the platform supports memory error information structures.
+  // Set 0xFFFF if supported but no error detected on this array, or 0xFFFE
+  // if error information structures are not supported at all.
+  // When implementing, add MemoryErrInfoToken to CM_ARCH_COMMON_PHYSICAL_MEMORY_ARRAY
+  // and pass CfgMgrProtocol and TableFactoryProtocol as parameters to resolve
+  // the token to an actual SMBIOS handle.
+  SmbiosRecord->MemoryErrorInformationHandle = 0xFFFE;
+}
+
+/** Construct SMBIOS Type16 Table describing memory devices.
+
+  If this function allocates any resources then they must be freed
+  in the FreeXXXXTableResources function.
+
+  @param [in]  This                 Pointer to the SMBIOS table generator.
+  @param [in]  TableFactoryProtocol Pointer to the SMBIOS Table Factory
+                                    Protocol interface.
+  @param [in]  SmbiosTableInfo      Pointer to the SMBIOS table information.
+  @param [in]  CfgMgrProtocol       Pointer to the Configuration Manager
+                                    Protocol interface.
+  @param [out] Table                Pointer to the SMBIOS table.
+  @param [out] CmObjectToken        Pointer to the CM Object Token Array.
+  @param [out] TableCount           Number of tables installed.
+
+  @retval EFI_SUCCESS            Table generated successfully.
+  @retval EFI_BAD_BUFFER_SIZE    The size returned by the Configuration
+                                 Manager is less than the Object size for
+                                 the requested object.
+  @retval EFI_INVALID_PARAMETER  A parameter is invalid.
+  @retval EFI_NOT_FOUND          Could not find information.
+  @retval EFI_OUT_OF_RESOURCES   Could not allocate memory.
+  @retval EFI_UNSUPPORTED        Unsupported configuration.
+**/
+STATIC
+EFI_STATUS
+BuildSmbiosType16TableEx (
+  IN  CONST SMBIOS_TABLE_GENERATOR                         *This,
+  IN  CONST EDKII_DYNAMIC_TABLE_FACTORY_PROTOCOL   *CONST  TableFactoryProtocol,
+  IN        CM_STD_OBJ_SMBIOS_TABLE_INFO           *CONST  SmbiosTableInfo,
+  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL   *CONST  CfgMgrProtocol,
+  OUT       SMBIOS_STRUCTURE                               ***Table,
+  OUT       CM_OBJECT_TOKEN                                **CmObjectToken,
+  OUT       UINTN                                  *CONST  TableCount
+  )
+{
+  EFI_STATUS                            Status;
+  SMBIOS_STRUCTURE                      **TableList;
+  SMBIOS_TABLE_TYPE16                   *SmbiosRecord;
+  CM_OBJECT_TOKEN                       *CmObjectList;
+  CM_ARCH_COMMON_PHYSICAL_MEMORY_ARRAY  *PhysMemoryArray;
+  UINT32                                NumObj;
+  UINTN                                 Index;
+
+  SmbiosRecord = NULL;
+
+  ASSERT (This != NULL);
+  ASSERT (SmbiosTableInfo != NULL);
+  ASSERT (CfgMgrProtocol != NULL);
+  ASSERT (Table != NULL);
+  ASSERT (TableCount != NULL);
+  ASSERT (SmbiosTableInfo->TableGeneratorId == This->GeneratorID);
+
+  if ((This == NULL) || (SmbiosTableInfo == NULL) || (CfgMgrProtocol == NULL) ||
+      (Table == NULL) || (TableCount == NULL) ||
+      (SmbiosTableInfo->TableGeneratorId != This->GeneratorID))
+  {
+    DEBUG ((DEBUG_ERROR, "%a:Invalid Parameter\n ", __func__));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  *Table       = NULL;
+  TableList    = NULL;
+  CmObjectList = NULL;
+  Status       = GetEArchCommonObjPhysicalMemoryArray (
+                   CfgMgrProtocol,
+                   CM_NULL_TOKEN,
+                   &PhysMemoryArray,
+                   &NumObj
+                   );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: Failed to get Memory Devices CM Object %r\n",
+      __func__,
+      Status
+      ));
+    return Status;
+  }
+
+  if (NumObj == 0) {
+    DEBUG ((DEBUG_ERROR, "%a: No Physical Memory Array CM Objects found\n", __func__));
+    return EFI_NOT_FOUND;
+  }
+
+  TableList = (SMBIOS_STRUCTURE **)AllocateZeroPool (sizeof (SMBIOS_STRUCTURE *) * NumObj);
+  if (TableList == NULL) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: Failed to alloc memory for %u devices table\n",
+      __func__,
+      NumObj
+      ));
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  CmObjectList = (CM_OBJECT_TOKEN *)AllocateZeroPool (sizeof (CM_OBJECT_TOKEN *) * NumObj);
+  if (CmObjectList == NULL) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: Failed to alloc memory for %u CM Objects.\n",
+      __func__,
+      NumObj
+      ));
+    Status = EFI_OUT_OF_RESOURCES;
+    goto exitBuildSmbiosType16Table;
+  }
+
+  for (Index = 0; Index < NumObj; Index++) {
+    SmbiosRecord = (SMBIOS_TABLE_TYPE16 *)AllocateSmbiosRecord (sizeof (SMBIOS_TABLE_TYPE16), NULL);
+    if (SmbiosRecord == NULL) {
+      Status = EFI_OUT_OF_RESOURCES;
+      goto exitBuildSmbiosType16Table;
+    }
+
+    if (PhysMemoryArray[Index].Location > MemoryArrayLocationCXLAddonCard) {
+      DEBUG ((
+        DEBUG_ERROR,
+        "%a: Invalid Location 0x%x for PhysMemoryArray[%u]\n",
+        __func__,
+        PhysMemoryArray[Index].Location,
+        Index
+        ));
+      Status = EFI_INVALID_PARAMETER;
+      goto exitBuildSmbiosType16Table;
+    }
+
+    if (PhysMemoryArray[Index].Use > MemoryArrayUseCacheMemory) {
+      DEBUG ((
+        DEBUG_ERROR,
+        "%a: Invalid Use 0x%x for PhysMemoryArray[%u]\n",
+        __func__,
+        PhysMemoryArray[Index].Use,
+        Index
+        ));
+      Status = EFI_INVALID_PARAMETER;
+      goto exitBuildSmbiosType16Table;
+    }
+
+    if (PhysMemoryArray[Index].MemoryErrorCorrectionType > MemoryErrorCorrectionCrc) {
+      DEBUG ((
+        DEBUG_ERROR,
+        "%a: Invalid MemoryErrorCorrectionType 0x%x for PhysMemoryArray[%u]\n",
+        __func__,
+        PhysMemoryArray[Index].MemoryErrorCorrectionType,
+        Index
+        ));
+      Status = EFI_INVALID_PARAMETER;
+      goto exitBuildSmbiosType16Table;
+    }
+
+    UpdateSmbiosType16Size (PhysMemoryArray[Index].Size, SmbiosRecord);
+    SmbiosRecord->Location              = PhysMemoryArray[Index].Location;
+    SmbiosRecord->Use                   = PhysMemoryArray[Index].Use;
+    SmbiosRecord->MemoryErrorCorrection = PhysMemoryArray[Index].MemoryErrorCorrectionType;
+    if (PhysMemoryArray[Index].NumberOfMemoryDevices == 0) {
+      DEBUG ((
+        DEBUG_ERROR,
+        "%a: NumberOfMemoryDevices is 0 for PhysMemoryArray[%u]\n",
+        __func__,
+        Index
+        ));
+      Status = EFI_INVALID_PARAMETER;
+      goto exitBuildSmbiosType16Table;
+    }
+
+    SmbiosRecord->NumberOfMemoryDevices = PhysMemoryArray[Index].NumberOfMemoryDevices;
+    AddMemErrDeviceHandle (SmbiosRecord);
+
+    // Setup the header
+    SmbiosRecord->Hdr.Type   = EFI_SMBIOS_TYPE_PHYSICAL_MEMORY_ARRAY;
+    SmbiosRecord->Hdr.Length = sizeof (SMBIOS_TABLE_TYPE16);
+
+    TableList[Index]    = (SMBIOS_STRUCTURE *)SmbiosRecord;
+    CmObjectList[Index] = PhysMemoryArray[Index].PhysMemArrayToken;
+  }
+
+  SmbiosRecord   = NULL;
+  *Table         = TableList;
+  *CmObjectToken = CmObjectList;
+  *TableCount    = NumObj;
+exitBuildSmbiosType16Table:
+  if (EFI_ERROR (Status)) {
+    if (TableList != NULL) {
+      for (Index = 0; Index < NumObj; Index++) {
+        if (TableList[Index] != NULL) {
+          FreePool (TableList[Index]);
+        }
+      }
+
+      FreePool (TableList);
+    }
+
+    if (CmObjectList != NULL) {
+      FreePool (CmObjectList);
+    }
+  }
+
+  if (SmbiosRecord != NULL) {
+    FreePool (SmbiosRecord);
+  }
+
+  return Status;
+}
+
+/** The interface for the SMBIOS Type16 Table Generator.
+*/
+STATIC
+CONST
+SMBIOS_TABLE_GENERATOR  SmbiosType16Generator = {
+  // Generator ID
+  CREATE_STD_SMBIOS_TABLE_GEN_ID (EStdSmbiosTableIdType16),
+  // Generator Description
+  L"SMBIOS.TYPE16.GENERATOR",
+  // SMBIOS Table Type
+  EFI_SMBIOS_TYPE_PHYSICAL_MEMORY_ARRAY,
+  NULL,
+  NULL,
+  // Build table function.
+  BuildSmbiosType16TableEx,
+  // Free function.
+  FreeSmbiosType16TableEx,
+};
+
+/** Register the Generator with the SMBIOS Table Factory.
+
+  @param [in]  ImageHandle  The handle to the image.
+  @param [in]  SystemTable  Pointer to the System Table.
+
+  @retval EFI_SUCCESS           The Generator is registered.
+  @retval EFI_INVALID_PARAMETER A parameter is invalid.
+  @retval EFI_ALREADY_STARTED   The Generator for the Table ID
+                                is already registered.
+**/
+EFI_STATUS
+EFIAPI
+SmbiosType16LibConstructor (
+  IN  EFI_HANDLE        ImageHandle,
+  IN  EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  EFI_STATUS  Status;
+
+  Status = RegisterSmbiosTableGenerator (&SmbiosType16Generator);
+  DEBUG ((
+    DEBUG_INFO,
+    "SMBIOS Type 16: Register Generator. Status = %r\n",
+    Status
+    ));
+  ASSERT_EFI_ERROR (Status);
+
+  return Status;
+}
+
+/** Deregister the Generator from the SMBIOS Table Factory.
+
+  @param [in]  ImageHandle  The handle to the image.
+  @param [in]  SystemTable  Pointer to the System Table.
+
+  @retval EFI_SUCCESS           The Generator is deregistered.
+  @retval EFI_INVALID_PARAMETER A parameter is invalid.
+  @retval EFI_NOT_FOUND         The Generator is not registered.
+**/
+EFI_STATUS
+EFIAPI
+SmbiosType16LibDestructor (
+  IN  EFI_HANDLE        ImageHandle,
+  IN  EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  EFI_STATUS  Status;
+
+  Status = DeregisterSmbiosTableGenerator (&SmbiosType16Generator);
+  DEBUG ((
+    DEBUG_INFO,
+    "SMBIOS Type16: Deregister Generator. Status = %r\n",
+    Status
+    ));
+  ASSERT_EFI_ERROR (Status);
+  return Status;
+}

--- a/DynamicTablesPkg/Library/Smbios/SmbiosType16Lib/SmbiosType16Lib.inf
+++ b/DynamicTablesPkg/Library/Smbios/SmbiosType16Lib/SmbiosType16Lib.inf
@@ -1,0 +1,35 @@
+## @file
+#  SMBIOS Type16 Table Generator
+#
+#  Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#  Copyright (c) 2019 - 2021, Arm Limited. All rights reserved.<BR>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION    = 0x0001001B
+  BASE_NAME      = SmbiosType16LibArm
+  FILE_GUID      = d7a9fe93-2825-4b3b-912e-11d94430f01a
+  VERSION_STRING = 1.0
+  MODULE_TYPE    = DXE_DRIVER
+  LIBRARY_CLASS  = NULL|DXE_DRIVER
+  CONSTRUCTOR    = SmbiosType16LibConstructor
+  DESTRUCTOR     = SmbiosType16LibDestructor
+
+[Sources]
+  SmbiosType16Generator.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  EmbeddedPkg/EmbeddedPkg.dec
+  ArmPlatformPkg/ArmPlatformPkg.dec
+  DynamicTablesPkg/DynamicTablesPkg.dec
+
+[Protocols]
+  gEfiSmbiosProtocolGuid                        # PROTOCOL ALWAYS_CONSUMED
+
+[LibraryClasses]
+  BaseLib
+  DebugLib

--- a/DynamicTablesPkg/Library/Smbios/SmbiosType17Lib/SmbiosType17Generator.c
+++ b/DynamicTablesPkg/Library/Smbios/SmbiosType17Lib/SmbiosType17Generator.c
@@ -1,0 +1,620 @@
+/** @file
+  SMBIOS Type17 Table Generator.
+
+  Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  Copyright (c) 2020 - 2021, Arm Limited. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
+#include <Library/PrintLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/UefiBootServicesTableLib.h>
+#include <Library/SmbiosStringTableLib.h>
+#include <Library/JedecJep106Lib.h>
+
+// Module specific include files.
+#include <ConfigurationManagerObject.h>
+#include <ConfigurationManagerHelper.h>
+#include <Protocol/ConfigurationManagerProtocol.h>
+#include <Protocol/DynamicTableFactoryProtocol.h>
+#include <Protocol/Smbios.h>
+#include <IndustryStandard/SmBios.h>
+
+/** This macro expands to a function that retrieves the Memory Device
+    information from the Configuration Manager.
+*/
+GET_OBJECT_LIST (
+  EObjNameSpaceArchCommon,
+  EArchCommonObjMemoryDeviceInfo,
+  CM_ARCH_COMMON_MEMORY_DEVICE_INFO
+  )
+
+#define EXTENDED_SIZE_THRESHOLD     (0x7FFF00000LL)
+#define SIZE_GRANULARITY_THRESHOLD  (0x100000L)
+#define SIZE_GRANULARITY_BITMASK    (0x8000)
+#define EXTENDED_SPEED_THRESHOLD    (0xFFFF)
+#define SMBIOS_TYPE17_MAX_STRINGS   (7)
+#define RANK_MASK                   (0xF)
+
+/**
+  Free any resources allocated when installing SMBIOS Type17 table.
+
+  @param [in]  This                 Pointer to the SMBIOS table generator.
+  @param [in]  TableFactoryProtocol Pointer to the SMBIOS Table Factory
+                                    Protocol interface.
+  @param [in]  SmbiosTableInfo      Pointer to the SMBIOS table information.
+  @param [in]  CfgMgrProtocol       Pointer to the Configuration Manager
+                                    Protocol interface.
+  @param [in]  Table                Pointer to the SMBIOS table.
+  @param [in]  CmObjectToken        Pointer to the CM ObjectToken Array.
+  @param [in]  TableCount           Number of SMBIOS tables.
+
+  @retval EFI_SUCCESS  Resources freed successfully.
+**/
+STATIC
+EFI_STATUS
+FreeSmbiosType17TableEx (
+  IN      CONST SMBIOS_TABLE_GENERATOR                   *CONST  This,
+  IN      CONST EDKII_DYNAMIC_TABLE_FACTORY_PROTOCOL     *CONST  TableFactoryProtocol,
+  IN      CONST CM_STD_OBJ_SMBIOS_TABLE_INFO             *CONST  SmbiosTableInfo,
+  IN      CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL     *CONST  CfgMgrProtocol,
+  IN      SMBIOS_STRUCTURE                             ***CONST  Table,
+  IN      CM_OBJECT_TOKEN                                        **CmObjectToken,
+  IN      CONST UINTN                                            TableCount
+  )
+{
+  UINTN             Index;
+  SMBIOS_STRUCTURE  **TableList;
+
+  TableList = *Table;
+  for (Index = 0; Index < TableCount; Index++) {
+    if (TableList[Index] != NULL) {
+      FreePool (TableList[Index]);
+    }
+  }
+
+  if (*CmObjectToken != NULL) {
+    FreePool (*CmObjectToken);
+  }
+
+  if (TableList != NULL) {
+    FreePool (TableList);
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Set the Memory Error Information handle in the Type17 record.
+
+  If CmObjToken is CM_NULL_TOKEN the handle is set to 0xFFFE (Not Provided).
+
+  @param [in]   TableFactoryProtocol  Pointer to the SMBIOS Table Factory.
+  @param [in]   CmObjToken            CM token of the Memory Error Info structure,
+                                      or CM_NULL_TOKEN if not present.
+  @param [out]  SmbiosRecord          SMBIOS record to update.
+**/
+STATIC
+VOID
+AddMemErrHandle (
+  IN  CONST EDKII_DYNAMIC_TABLE_FACTORY_PROTOCOL   *CONST  TableFactoryProtocol,
+  IN  CM_OBJECT_TOKEN                                      CmObjToken,
+  OUT SMBIOS_TABLE_TYPE17                                  *SmbiosRecord
+  )
+{
+  SMBIOS_HANDLE_MAP  *HandleMap;
+
+  if (CmObjToken == CM_NULL_TOKEN) {
+    SmbiosRecord->MemoryErrorInformationHandle = 0xFFFE;
+    return;
+  }
+
+  HandleMap = TableFactoryProtocol->GetSmbiosHandle (CmObjToken);
+  if (HandleMap == NULL) {
+    DEBUG ((DEBUG_ERROR, "%a: Failed to get SMBIOS Handle for MemoryErrorInfo\n", __func__));
+    SmbiosRecord->MemoryErrorInformationHandle = 0xFFFE;
+  } else {
+    SmbiosRecord->MemoryErrorInformationHandle = HandleMap->SmbiosTblHandle;
+  }
+}
+
+/**
+  Set the Physical Memory Array handle in the Type17 record.
+
+  @param [in]   TableFactoryProtocol  Pointer to the SMBIOS Table Factory.
+  @param [in]   CmObjToken            CM token of the Physical Memory Array.
+  @param [out]  SmbiosRecord          SMBIOS record to update.
+**/
+STATIC
+EFI_STATUS
+AddPhysArrHandle (
+  IN  CONST EDKII_DYNAMIC_TABLE_FACTORY_PROTOCOL   *CONST  TableFactoryProtocol,
+  IN  CM_OBJECT_TOKEN                                      CmObjToken,
+  OUT SMBIOS_TABLE_TYPE17                                  *SmbiosRecord
+  )
+{
+  SMBIOS_HANDLE_MAP  *HandleMap;
+
+  HandleMap = TableFactoryProtocol->GetSmbiosHandle (CmObjToken);
+  if (HandleMap == NULL) {
+    DEBUG ((DEBUG_ERROR, "%a:Failed to get Type 16 SMBIOS Handle\n", __func__));
+    ASSERT (HandleMap != NULL);
+    return EFI_NOT_FOUND;
+  }
+
+  SmbiosRecord->MemoryArrayHandle = HandleMap->SmbiosTblHandle;
+  return EFI_SUCCESS;
+}
+
+/**
+  Update the Size encoding for Type 17.
+
+  @param [in]   Size          Size of the memory device in bytes.
+  @param [out]  SmbiosRecord  SMBIOS record to update.
+**/
+STATIC
+VOID
+UpdateSmbiosType17Size (
+  IN  UINT64               Size,
+  OUT SMBIOS_TABLE_TYPE17  *SmbiosRecord
+  )
+{
+  if (Size < SIZE_GRANULARITY_THRESHOLD) {
+    SmbiosRecord->Size  = Size / SIZE_1KB;
+    SmbiosRecord->Size |= SIZE_GRANULARITY_BITMASK;
+  } else if (Size >= EXTENDED_SIZE_THRESHOLD) {
+    SmbiosRecord->Size         = 0x7FFF;
+    SmbiosRecord->ExtendedSize = (Size / SIZE_1MB);
+  } else {
+    SmbiosRecord->Size = (Size / SIZE_1MB);
+  }
+}
+
+/**
+  Update the Speed encoding for Type 17.
+
+  @param [in]   Speed                      Memory device speed in MHz.
+  @param [in]   ConfiguredMemoryClockSpeed Configured memory clock speed in MHz.
+  @param [out]  SmbiosRecord               SMBIOS record to update.
+**/
+STATIC
+VOID
+UpdateSmbiosType17Speed (
+  IN  UINT32               Speed,
+  IN  UINT32               ConfiguredMemoryClockSpeed,
+  OUT SMBIOS_TABLE_TYPE17  *SmbiosRecord
+  )
+{
+  if (Speed > EXTENDED_SPEED_THRESHOLD) {
+    SmbiosRecord->Speed         = EXTENDED_SPEED_THRESHOLD;
+    SmbiosRecord->ExtendedSpeed = Speed;
+  } else {
+    SmbiosRecord->Speed = Speed;
+  }
+
+  if (ConfiguredMemoryClockSpeed > EXTENDED_SPEED_THRESHOLD) {
+    SmbiosRecord->ConfiguredMemoryClockSpeed    = EXTENDED_SPEED_THRESHOLD;
+    SmbiosRecord->ExtendedConfiguredMemorySpeed = ConfiguredMemoryClockSpeed;
+  } else {
+    SmbiosRecord->ConfiguredMemoryClockSpeed = ConfiguredMemoryClockSpeed;
+  }
+}
+
+/**
+  Update the Rank encoding for Type 17.
+
+  @param [in]   Rank          Memory device rank.
+  @param [out]  SmbiosRecord  SMBIOS record to update.
+**/
+STATIC
+VOID
+UpdateSmbiosType17Rank (
+  IN  UINT8                Rank,
+  OUT SMBIOS_TABLE_TYPE17  *SmbiosRecord
+  )
+{
+  if (Rank > RANK_MASK) {
+    SmbiosRecord->Attributes = 0;
+  } else {
+    SmbiosRecord->Attributes |= (Rank & RANK_MASK);
+  }
+}
+
+/** Construct SMBIOS Type17 Table describing memory devices.
+
+  If this function allocates any resources then they must be freed
+  in the FreeXXXXTableResources function.
+
+  @param [in]  This                 Pointer to the SMBIOS table generator.
+  @param [in]  TableFactoryProtocol Pointer to the SMBIOS Table Factory
+                                    Protocol interface.
+  @param [in]  SmbiosTableInfo      Pointer to the SMBIOS table information.
+  @param [in]  CfgMgrProtocol       Pointer to the Configuration Manager
+                                    Protocol interface.
+  @param [out] Table                Pointer to the SMBIOS table.
+  @param [out] CmObjectToken        Pointer to the CM Object Token Array.
+  @param [out] TableCount           Number of tables installed.
+
+  @retval EFI_SUCCESS            Table generated successfully.
+  @retval EFI_BAD_BUFFER_SIZE    The size returned by the Configuration
+                                 Manager is less than the Object size for
+                                 the requested object.
+  @retval EFI_INVALID_PARAMETER  A parameter is invalid.
+  @retval EFI_NOT_FOUND          Could not find information.
+  @retval EFI_OUT_OF_RESOURCES   Could not allocate memory.
+  @retval EFI_UNSUPPORTED        Unsupported configuration.
+**/
+STATIC
+EFI_STATUS
+BuildSmbiosType17TableEx (
+  IN  CONST SMBIOS_TABLE_GENERATOR                         *This,
+  IN  CONST EDKII_DYNAMIC_TABLE_FACTORY_PROTOCOL   *CONST  TableFactoryProtocol,
+  IN        CM_STD_OBJ_SMBIOS_TABLE_INFO           *CONST  SmbiosTableInfo,
+  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL   *CONST  CfgMgrProtocol,
+  OUT       SMBIOS_STRUCTURE                               ***Table,
+  OUT       CM_OBJECT_TOKEN                                **CmObjectToken,
+  OUT       UINTN                                  *CONST  TableCount
+  )
+{
+  EFI_STATUS                         Status;
+  UINT32                             NumMemDevices;
+  SMBIOS_STRUCTURE                   **TableList;
+  CM_OBJECT_TOKEN                    *CmObjectList;
+  CM_ARCH_COMMON_MEMORY_DEVICE_INFO  *MemoryDevicesInfo;
+  UINTN                              Index;
+  UINT8                              SerialNumRef;
+  UINT8                              AssetTagRef;
+  UINT8                              DeviceLocatorRef;
+  UINT8                              BankLocatorRef;
+  UINT8                              FirmwareVersionRef;
+  UINT8                              ManufacturerNameRef;
+  CHAR8                              *ManufacturerName;
+  UINT8                              PartNumRef;
+  CHAR8                              *OptionalStrings;
+  SMBIOS_TABLE_TYPE17                *SmbiosRecord;
+  STRING_TABLE                       StrTable;
+
+  ASSERT (This != NULL);
+  ASSERT (SmbiosTableInfo != NULL);
+  ASSERT (CfgMgrProtocol != NULL);
+  ASSERT (Table != NULL);
+  ASSERT (TableCount != NULL);
+  ASSERT (SmbiosTableInfo->TableGeneratorId == This->GeneratorID);
+
+  if ((This == NULL) || (SmbiosTableInfo == NULL) || (CfgMgrProtocol == NULL) ||
+      (Table == NULL) || (TableCount == NULL) ||
+      (SmbiosTableInfo->TableGeneratorId != This->GeneratorID))
+  {
+    DEBUG ((DEBUG_ERROR, "%a:Invalid Parameter\n ", __func__));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  *Table = NULL;
+  Status = GetEArchCommonObjMemoryDeviceInfo (
+             CfgMgrProtocol,
+             CM_NULL_TOKEN,
+             &MemoryDevicesInfo,
+             &NumMemDevices
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "Failed to get Memory Devices CM Object %r\n",
+      Status
+      ));
+    return Status;
+  }
+
+  TableList = (SMBIOS_STRUCTURE **)AllocateZeroPool (sizeof (SMBIOS_STRUCTURE *) * NumMemDevices);
+  if (TableList == NULL) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a:Failed to alloc memory for %u devices table\n",
+      __func__,
+      NumMemDevices
+      ));
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  CmObjectList = (CM_OBJECT_TOKEN *)AllocateZeroPool (sizeof (CM_OBJECT_TOKEN *) * NumMemDevices);
+  if (CmObjectList == NULL) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: Failed to alloc memory for %u CM Objects\n",
+      __func__,
+      NumMemDevices
+      ));
+    Status = EFI_OUT_OF_RESOURCES;
+    goto exit;
+  }
+
+  for (Index = 0; Index < NumMemDevices; Index++) {
+    Status = StringTableInitialize (&StrTable, SMBIOS_TYPE17_MAX_STRINGS);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((
+        DEBUG_ERROR,
+        "%a: Failed to initialize string table for MemoryDevicesInfo[%u]. Status = %r\n",
+        __func__,
+        Index,
+        Status
+        ));
+      goto exit;
+    }
+
+    SerialNumRef        = 0;
+    AssetTagRef         = 0;
+    DeviceLocatorRef    = 0;
+    BankLocatorRef      = 0;
+    FirmwareVersionRef  = 0;
+    ManufacturerNameRef = 0;
+    PartNumRef          = 0;
+    ManufacturerName    = NULL;
+
+    if (MemoryDevicesInfo[Index].DeviceLocator[0] != '\0') {
+      Status = StringTableAddString (
+                 &StrTable,
+                 MemoryDevicesInfo[Index].DeviceLocator,
+                 &DeviceLocatorRef
+                 );
+      if (EFI_ERROR (Status)) {
+        DEBUG ((DEBUG_ERROR, "Failed to add DeviceLocator String %r \n", Status));
+      }
+    }
+
+    if (MemoryDevicesInfo[Index].BankLocator[0] != '\0') {
+      Status = StringTableAddString (
+                 &StrTable,
+                 MemoryDevicesInfo[Index].BankLocator,
+                 &BankLocatorRef
+                 );
+      if (EFI_ERROR (Status)) {
+        DEBUG ((DEBUG_ERROR, "Failed to BankLocator String %r \n", Status));
+      }
+    }
+
+    if (MemoryDevicesInfo[Index].SerialNum[0] != '\0') {
+      Status = StringTableAddString (
+                 &StrTable,
+                 MemoryDevicesInfo[Index].SerialNum,
+                 &SerialNumRef
+                 );
+      if (EFI_ERROR (Status)) {
+        DEBUG ((DEBUG_ERROR, "Failed to add SerialNum String %r \n", Status));
+      }
+    }
+
+    if (MemoryDevicesInfo[Index].AssetTag[0] != '\0') {
+      Status = StringTableAddString (
+                 &StrTable,
+                 MemoryDevicesInfo[Index].AssetTag,
+                 &AssetTagRef
+                 );
+      if (EFI_ERROR (Status)) {
+        DEBUG ((DEBUG_ERROR, "Failed to add Asset Tag String %r \n", Status));
+      }
+    }
+
+    if (MemoryDevicesInfo[Index].FirmwareVersion[0] != '\0') {
+      Status = StringTableAddString (
+                 &StrTable,
+                 MemoryDevicesInfo[Index].FirmwareVersion,
+                 &FirmwareVersionRef
+                 );
+      if (EFI_ERROR (Status)) {
+        DEBUG ((DEBUG_ERROR, "Failed to add Firmware Version String %r \n", Status));
+      }
+    }
+
+    if (MemoryDevicesInfo[Index].PartNum[0] != '\0') {
+      Status = StringTableAddString (
+                 &StrTable,
+                 MemoryDevicesInfo[Index].PartNum,
+                 &PartNumRef
+                 );
+      if (EFI_ERROR (Status)) {
+        DEBUG ((DEBUG_ERROR, "Failed to PartNum String %r \n", Status));
+      }
+    }
+
+    ManufacturerName = (CHAR8 *)Jep106GetManufacturerName (
+                                  (MemoryDevicesInfo[Index].ModuleManufacturerId >> 8) & 0xFF,
+                                  MemoryDevicesInfo[Index].ModuleManufacturerId & 0x7F
+                                  );
+    if (ManufacturerName != NULL) {
+      Status = StringTableAddString (
+                 &StrTable,
+                 ManufacturerName,
+                 &ManufacturerNameRef
+                 );
+      if (EFI_ERROR (Status)) {
+        DEBUG ((DEBUG_ERROR, "Failed to add Manufacturer String %r \n", Status));
+      }
+    }
+
+    SmbiosRecord = (SMBIOS_TABLE_TYPE17 *)AllocateSmbiosRecord (sizeof (SMBIOS_TABLE_TYPE17), &StrTable);
+    if (SmbiosRecord == NULL) {
+      StringTableFree (&StrTable);
+      Status = EFI_OUT_OF_RESOURCES;
+      goto exit;
+    }
+
+    UpdateSmbiosType17Size (MemoryDevicesInfo[Index].Size, SmbiosRecord);
+    UpdateSmbiosType17Speed (MemoryDevicesInfo[Index].Speed, MemoryDevicesInfo[Index].ConfiguredMemorySpeed, SmbiosRecord);
+    UpdateSmbiosType17Rank (MemoryDevicesInfo[Index].Rank, SmbiosRecord);
+
+    SmbiosRecord->VolatileSize         = MemoryDevicesInfo[Index].VolatileSize;
+    SmbiosRecord->DeviceSet            = MemoryDevicesInfo[Index].DeviceSet;
+    SmbiosRecord->ModuleManufacturerID =
+      MemoryDevicesInfo[Index].ModuleManufacturerId;
+    SmbiosRecord->ModuleProductID =
+      MemoryDevicesInfo[Index].ModuleProductId;
+    SmbiosRecord->DataWidth                     = MemoryDevicesInfo[Index].DataWidth;
+    SmbiosRecord->TotalWidth                    = MemoryDevicesInfo[Index].TotalWidth;
+    SmbiosRecord->MemoryType                    = MemoryDevicesInfo[Index].MemoryType;
+    SmbiosRecord->FormFactor                    = MemoryDevicesInfo[Index].FormFactor;
+    SmbiosRecord->MinimumVoltage                = MemoryDevicesInfo[Index].MinVolt;
+    SmbiosRecord->MaximumVoltage                = MemoryDevicesInfo[Index].MaxVolt;
+    SmbiosRecord->ConfiguredVoltage             = MemoryDevicesInfo[Index].ConfVolt;
+    SmbiosRecord->MemoryTechnology              = MemoryDevicesInfo[Index].MemoryTechnology;
+    SmbiosRecord->TypeDetail                    = MemoryDevicesInfo[Index].TypeDetail;
+    SmbiosRecord->MemoryOperatingModeCapability = MemoryDevicesInfo[Index].MemoryOperatingModeCapability;
+    AddMemErrHandle (
+      TableFactoryProtocol,
+      MemoryDevicesInfo[Index].MemoryErrorInfoToken,
+      SmbiosRecord
+      );
+    Status = AddPhysArrHandle (
+               TableFactoryProtocol,
+               MemoryDevicesInfo[Index].PhysicalArrayToken,
+               SmbiosRecord
+               );
+    if (EFI_ERROR (Status)) {
+      StringTableFree (&StrTable);
+      FreePool (SmbiosRecord);
+      goto exit;
+    }
+
+    SmbiosRecord->DeviceLocator                           = DeviceLocatorRef;
+    SmbiosRecord->BankLocator                             = BankLocatorRef;
+    SmbiosRecord->AssetTag                                = AssetTagRef;
+    SmbiosRecord->SerialNumber                            = SerialNumRef;
+    SmbiosRecord->FirmwareVersion                         = FirmwareVersionRef;
+    SmbiosRecord->Manufacturer                            = ManufacturerNameRef;
+    SmbiosRecord->PartNumber                              = PartNumRef;
+    SmbiosRecord->MemorySubsystemControllerManufacturerID =
+      MemoryDevicesInfo[Index].MemorySubsystemControllerManufacturerId;
+    SmbiosRecord->MemorySubsystemControllerProductID =
+      MemoryDevicesInfo[Index].MemorySubsystemControllerProductId;
+    SmbiosRecord->NonVolatileSize =
+      MemoryDevicesInfo[Index].NonVolatileSize;
+    SmbiosRecord->CacheSize =
+      MemoryDevicesInfo[Index].CacheSize;
+    SmbiosRecord->LogicalSize =
+      MemoryDevicesInfo[Index].LogicalSize;
+    SmbiosRecord->Pmic0ManufacturerID =
+      MemoryDevicesInfo[Index].Pmic0ManufacturerId;
+    SmbiosRecord->Pmic0RevisionNumber =
+      MemoryDevicesInfo[Index].Pmic0RevisionNumber;
+    SmbiosRecord->RcdManufacturerID =
+      MemoryDevicesInfo[Index].RcdManufacturerId;
+    SmbiosRecord->RcdRevisionNumber =
+      MemoryDevicesInfo[Index].RcdRevisionNumber;
+
+    OptionalStrings = (CHAR8 *)(SmbiosRecord + 1);
+    // publish the string set
+    StringTablePublishStringSet (
+      &StrTable,
+      OptionalStrings,
+      StringTableGetStringSetSize (&StrTable)
+      );
+    // setup the header
+    SmbiosRecord->Hdr.Type   = EFI_SMBIOS_TYPE_MEMORY_DEVICE;
+    SmbiosRecord->Hdr.Length = sizeof (SMBIOS_TABLE_TYPE17);
+    TableList[Index]         = (SMBIOS_STRUCTURE *)SmbiosRecord;
+    CmObjectList[Index]      = MemoryDevicesInfo[Index].MemoryDeviceInfoToken;
+    StringTableFree (&StrTable);
+  }
+
+  *Table         = TableList;
+  *CmObjectToken = CmObjectList;
+  *TableCount    = NumMemDevices;
+exit:
+  if (EFI_ERROR (Status)) {
+    if (TableList != NULL) {
+      for (Index = 0; Index < NumMemDevices; Index++) {
+        if (TableList[Index] != NULL) {
+          FreePool (TableList[Index]);
+        }
+      }
+
+      FreePool (TableList);
+    }
+
+    if (CmObjectList != NULL) {
+      FreePool (CmObjectList);
+    }
+  }
+
+  return Status;
+}
+
+/** The interface for the SMBIOS Type17 Table Generator.
+*/
+STATIC
+CONST
+SMBIOS_TABLE_GENERATOR  SmbiosType17Generator = {
+  // Generator ID
+  CREATE_STD_SMBIOS_TABLE_GEN_ID (EStdSmbiosTableIdType17),
+  // Generator Description
+  L"SMBIOS.TYPE17.GENERATOR",
+  // SMBIOS Table Type
+  EFI_SMBIOS_TYPE_MEMORY_DEVICE,
+  NULL,
+  NULL,
+  // Build table function Extended.
+  BuildSmbiosType17TableEx,
+  // Free function Extended.
+  FreeSmbiosType17TableEx
+};
+
+/** Register the Generator with the SMBIOS Table Factory.
+
+  @param [in]  ImageHandle  The handle to the image.
+  @param [in]  SystemTable  Pointer to the System Table.
+
+  @retval EFI_SUCCESS           The Generator is registered.
+  @retval EFI_INVALID_PARAMETER A parameter is invalid.
+  @retval EFI_ALREADY_STARTED   The Generator for the Table ID
+                                is already registered.
+**/
+EFI_STATUS
+EFIAPI
+SmbiosType17LibConstructor (
+  IN  EFI_HANDLE        ImageHandle,
+  IN  EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  EFI_STATUS  Status;
+
+  Status = RegisterSmbiosTableGenerator (&SmbiosType17Generator);
+  DEBUG ((
+    DEBUG_INFO,
+    "SMBIOS Type 17: Register Generator. Status = %r\n",
+    Status
+    ));
+  ASSERT_EFI_ERROR (Status);
+
+  return Status;
+}
+
+/** Deregister the Generator from the SMBIOS Table Factory.
+
+  @param [in]  ImageHandle  The handle to the image.
+  @param [in]  SystemTable  Pointer to the System Table.
+
+  @retval EFI_SUCCESS           The Generator is deregistered.
+  @retval EFI_INVALID_PARAMETER A parameter is invalid.
+  @retval EFI_NOT_FOUND         The Generator is not registered.
+**/
+EFI_STATUS
+EFIAPI
+SmbiosType17LibDestructor (
+  IN  EFI_HANDLE        ImageHandle,
+  IN  EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  EFI_STATUS  Status;
+
+  Status = DeregisterSmbiosTableGenerator (&SmbiosType17Generator);
+  DEBUG ((
+    DEBUG_INFO,
+    "SMBIOS Type17: Deregister Generator. Status = %r\n",
+    Status
+    ));
+  ASSERT_EFI_ERROR (Status);
+  return Status;
+}

--- a/DynamicTablesPkg/Library/Smbios/SmbiosType17Lib/SmbiosType17Lib.inf
+++ b/DynamicTablesPkg/Library/Smbios/SmbiosType17Lib/SmbiosType17Lib.inf
@@ -1,0 +1,37 @@
+## @file
+#  SMBIOS Type17 Table Generator
+#
+#  Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#  Copyright (c) 2019 - 2021, Arm Limited. All rights reserved.<BR>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION    = 0x0001001B
+  BASE_NAME      = SmbiosType17LibArm
+  FILE_GUID      = 1f063bac-f8f1-4e08-8ffd-9aae52c75497
+  VERSION_STRING = 1.0
+  MODULE_TYPE    = DXE_DRIVER
+  LIBRARY_CLASS  = NULL|DXE_DRIVER
+  CONSTRUCTOR    = SmbiosType17LibConstructor
+  DESTRUCTOR     = SmbiosType17LibDestructor
+
+[Sources]
+  SmbiosType17Generator.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  EmbeddedPkg/EmbeddedPkg.dec
+  ArmPlatformPkg/ArmPlatformPkg.dec
+  DynamicTablesPkg/DynamicTablesPkg.dec
+
+[Protocols]
+  gEfiSmbiosProtocolGuid                        # PROTOCOL ALWAYS_CONSUMED
+
+[LibraryClasses]
+  BaseLib
+  DebugLib
+  SmbiosStringTableLib
+  JedecJep106Lib

--- a/DynamicTablesPkg/Library/Smbios/SmbiosType19Lib/SmbiosType19Generator.c
+++ b/DynamicTablesPkg/Library/Smbios/SmbiosType19Lib/SmbiosType19Generator.c
@@ -1,0 +1,388 @@
+/** @file
+  SMBIOS Type19 Table Generator.
+
+  Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  Copyright (c) 2020 - 2021, Arm Limited. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
+#include <Library/PrintLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/UefiBootServicesTableLib.h>
+#include <Library/SmbiosStringTableLib.h>
+
+// Module specific include files.
+#include <ConfigurationManagerObject.h>
+#include <ConfigurationManagerHelper.h>
+#include <Protocol/ConfigurationManagerProtocol.h>
+#include <Protocol/DynamicTableFactoryProtocol.h>
+#include <Protocol/Smbios.h>
+#include <IndustryStandard/SmBios.h>
+
+/** This macro expands to a function that retrieves the Memory Device
+    information from the Configuration Manager.
+*/
+GET_OBJECT_LIST (
+  EObjNameSpaceArchCommon,
+  EArchCommonObjMemoryArrayMappedAddress,
+  CM_ARCH_COMMON_MEMORY_ARRAY_MAPPED_ADDRESS
+  )
+
+#define EXTENDED_ADDRESS_THRESHOLD  (0xFFFFFFFFL)
+
+/**
+  Free any resources allocated when installing SMBIOS Type19 table.
+
+  @param [in]  This                 Pointer to the SMBIOS table generator.
+  @param [in]  TableFactoryProtocol Pointer to the SMBIOS Table Factory
+                                    Protocol interface.
+  @param [in]  SmbiosTableInfo      Pointer to the SMBIOS table information.
+  @param [in]  CfgMgrProtocol       Pointer to the Configuration Manager
+                                    Protocol interface.
+  @param [in]  Table                Pointer to the SMBIOS table.
+  @param [in]  CmObjectToken        Pointer to the CM ObjectToken Array.
+  @param [in]  TableCount           Number of SMBIOS tables.
+
+  @retval EFI_SUCCESS            Table generated successfully.
+  @retval EFI_BAD_BUFFER_SIZE    The size returned by the Configuration
+                                 Manager is less than the Object size for
+                                 the requested object.
+  @retval EFI_INVALID_PARAMETER  A parameter is invalid.
+  @retval EFI_NOT_FOUND          Could not find information.
+  @retval EFI_OUT_OF_RESOURCES   Could not allocate memory.
+  @retval EFI_UNSUPPORTED        Unsupported configuration.
+**/
+STATIC
+EFI_STATUS
+FreeSmbiosType19TableEx (
+  IN      CONST SMBIOS_TABLE_GENERATOR                   *CONST  This,
+  IN      CONST EDKII_DYNAMIC_TABLE_FACTORY_PROTOCOL     *CONST  TableFactoryProtocol,
+  IN      CONST CM_STD_OBJ_SMBIOS_TABLE_INFO             *CONST  SmbiosTableInfo,
+  IN      CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL     *CONST  CfgMgrProtocol,
+  IN      SMBIOS_STRUCTURE                             ***CONST  Table,
+  IN      CM_OBJECT_TOKEN                                        **CmObjectToken,
+  IN      CONST UINTN                                            TableCount
+  )
+{
+  UINTN             Index;
+  SMBIOS_STRUCTURE  **TableList;
+
+  TableList = *Table;
+  for (Index = 0; Index < TableCount; Index++) {
+    if (TableList[Index] != NULL) {
+      FreePool (TableList[Index]);
+    }
+  }
+
+  if (*CmObjectToken != NULL) {
+    FreePool (*CmObjectToken);
+  }
+
+  if (TableList != NULL) {
+    FreePool (TableList);
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Add the SMBIOS table handle reference to the Physical Array Table.
+
+  @param [in]   TableFactoryProtocol  Pointer to the SMBIOS Table Factory.
+  @param [in]   CmObjToken            CM Token to lookup.
+  @param [out]  SmbiosRecord          SMBIOS record to update.
+**/
+STATIC
+EFI_STATUS
+AddPhysArrHandle (
+  IN  CONST EDKII_DYNAMIC_TABLE_FACTORY_PROTOCOL   *CONST  TableFactoryProtocol,
+  IN  CM_OBJECT_TOKEN                                      CmObjToken,
+  OUT SMBIOS_TABLE_TYPE19                                  *SmbiosRecord
+  )
+{
+  SMBIOS_HANDLE_MAP  *HandleMap;
+
+  HandleMap = TableFactoryProtocol->GetSmbiosHandle (CmObjToken);
+  if (HandleMap == NULL) {
+    DEBUG ((DEBUG_ERROR, "%a:Failed to get Type 16 SMBIOS Handle\n", __func__));
+    ASSERT (HandleMap != NULL);
+    return EFI_NOT_FOUND;
+  }
+
+  SmbiosRecord->MemoryArrayHandle = HandleMap->SmbiosTblHandle;
+  return EFI_SUCCESS;
+}
+
+/**
+  Update the Address encoding for Type 19.
+
+  @param [in]   StartAddress  Starting memory address covered by the device.
+  @param [in]   EndAddress    Ending memory address covered by the device.
+  @param [out]  SmbiosRecord  SMBIOS record to update.
+**/
+STATIC
+VOID
+UpdateSmbiosType19Address (
+  IN  UINT64               StartAddress,
+  IN  UINT64               EndAddress,
+  OUT SMBIOS_TABLE_TYPE19  *SmbiosRecord
+  )
+{
+  UINT64  StartingAddressKb;
+  UINT64  EndingAddressKb;
+
+  StartingAddressKb = StartAddress / SIZE_1KB;
+  EndingAddressKb   = EndAddress / SIZE_1KB;
+
+  if ((StartingAddressKb >= EXTENDED_ADDRESS_THRESHOLD) ||
+      (EndingAddressKb >= EXTENDED_ADDRESS_THRESHOLD))
+  {
+    SmbiosRecord->StartingAddress         = EXTENDED_ADDRESS_THRESHOLD;
+    SmbiosRecord->EndingAddress           = EXTENDED_ADDRESS_THRESHOLD;
+    SmbiosRecord->ExtendedStartingAddress = StartAddress;
+    SmbiosRecord->ExtendedEndingAddress   = EndAddress;
+  } else {
+    SmbiosRecord->StartingAddress = StartingAddressKb;
+    SmbiosRecord->EndingAddress   = EndingAddressKb;
+  }
+}
+
+/** Construct SMBIOS Type19 Table describing memory devices.
+
+  If this function allocates any resources then they must be freed
+  in the FreeXXXXTableResources function.
+
+  @param [in]  This                 Pointer to the SMBIOS table generator.
+  @param [in]  TableFactoryProtocol Pointer to the SMBIOS Table Factory
+                                    Protocol interface.
+  @param [in]  SmbiosTableInfo      Pointer to the SMBIOS table information.
+  @param [in]  CfgMgrProtocol       Pointer to the Configuration Manager
+                                    Protocol interface.
+  @param [out] Table                Pointer to the SMBIOS table.
+  @param [out] CmObjectToken        Pointer to the CM Object Token Array.
+  @param [out] TableCount           Number of tables installed.
+
+  @retval EFI_SUCCESS            Table generated successfully.
+  @retval EFI_BAD_BUFFER_SIZE    The size returned by the Configuration
+                                 Manager is less than the Object size for
+                                 the requested object.
+  @retval EFI_INVALID_PARAMETER  A parameter is invalid.
+  @retval EFI_NOT_FOUND          Could not find information.
+  @retval EFI_OUT_OF_RESOURCES   Could not allocate memory.
+  @retval EFI_UNSUPPORTED        Unsupported configuration.
+**/
+STATIC
+EFI_STATUS
+BuildSmbiosType19TableEx (
+  IN  CONST SMBIOS_TABLE_GENERATOR                         *This,
+  IN  CONST EDKII_DYNAMIC_TABLE_FACTORY_PROTOCOL   *CONST  TableFactoryProtocol,
+  IN        CM_STD_OBJ_SMBIOS_TABLE_INFO           *CONST  SmbiosTableInfo,
+  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL   *CONST  CfgMgrProtocol,
+  OUT       SMBIOS_STRUCTURE                               ***Table,
+  OUT       CM_OBJECT_TOKEN                                **CmObjectToken,
+  OUT       UINTN                                  *CONST  TableCount
+  )
+{
+  EFI_STATUS                                  Status;
+  UINT32                                      NumMemMap;
+  SMBIOS_STRUCTURE                            **TableList;
+  CM_OBJECT_TOKEN                             *CmObjectList;
+  CM_ARCH_COMMON_MEMORY_ARRAY_MAPPED_ADDRESS  *MemoryMapInfo;
+  SMBIOS_TABLE_TYPE19                         *SmbiosRecord;
+  UINTN                                       Index;
+
+  SmbiosRecord = NULL;
+
+  ASSERT (This != NULL);
+  ASSERT (SmbiosTableInfo != NULL);
+  ASSERT (CfgMgrProtocol != NULL);
+  ASSERT (Table != NULL);
+  ASSERT (TableCount != NULL);
+  ASSERT (SmbiosTableInfo->TableGeneratorId == This->GeneratorID);
+
+  if ((This == NULL) || (SmbiosTableInfo == NULL) || (CfgMgrProtocol == NULL) ||
+      (Table == NULL) || (TableCount == NULL) ||
+      (SmbiosTableInfo->TableGeneratorId != This->GeneratorID))
+  {
+    DEBUG ((DEBUG_ERROR, "%a:Invalid Parameter\n ", __func__));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  *Table = NULL;
+  Status = GetEArchCommonObjMemoryArrayMappedAddress (
+             CfgMgrProtocol,
+             CM_NULL_TOKEN,
+             &MemoryMapInfo,
+             &NumMemMap
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "Failed to get Memory Devices CM Object %r\n",
+      Status
+      ));
+    return Status;
+  }
+
+  TableList = (SMBIOS_STRUCTURE **)AllocateZeroPool (sizeof (SMBIOS_STRUCTURE *) * NumMemMap);
+  if (TableList == NULL) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: Failed to alloc memory for %u devices table\n",
+      __func__,
+      NumMemMap
+      ));
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  CmObjectList = (CM_OBJECT_TOKEN *)AllocateZeroPool (sizeof (CM_OBJECT_TOKEN *) * NumMemMap);
+  if (CmObjectList == NULL) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: Failed to alloc memory for %u CMObjects\n",
+      __func__,
+      NumMemMap
+      ));
+    Status = EFI_OUT_OF_RESOURCES;
+    goto exitBuildSmbiosType19TableEx;
+  }
+
+  for (Index = 0; Index < NumMemMap; Index++) {
+    SmbiosRecord = (SMBIOS_TABLE_TYPE19 *)AllocateSmbiosRecord (sizeof (SMBIOS_TABLE_TYPE19), NULL);
+    if (SmbiosRecord == NULL) {
+      Status = EFI_OUT_OF_RESOURCES;
+      goto exitBuildSmbiosType19TableEx;
+    }
+
+    UpdateSmbiosType19Address (
+      MemoryMapInfo[Index].StartingAddress,
+      MemoryMapInfo[Index].EndingAddress,
+      SmbiosRecord
+      );
+    SmbiosRecord->PartitionWidth = MemoryMapInfo[Index].NumMemDevices;
+    Status                       = AddPhysArrHandle (
+                                     TableFactoryProtocol,
+                                     MemoryMapInfo[Index].PhysMemArrayToken,
+                                     SmbiosRecord
+                                     );
+    if (EFI_ERROR (Status)) {
+      goto exitBuildSmbiosType19TableEx;
+    }
+
+    // setup the header
+    SmbiosRecord->Hdr.Type   = EFI_SMBIOS_TYPE_MEMORY_ARRAY_MAPPED_ADDRESS;
+    SmbiosRecord->Hdr.Length = sizeof (SMBIOS_TABLE_TYPE19);
+    TableList[Index]         = (SMBIOS_STRUCTURE *)SmbiosRecord;
+    CmObjectList[Index]      = MemoryMapInfo[Index].MemoryArrayMappedAddressToken;
+  }
+
+  SmbiosRecord = NULL;
+
+  *Table         = TableList;
+  *CmObjectToken = CmObjectList;
+  *TableCount    = NumMemMap;
+
+exitBuildSmbiosType19TableEx:
+  if (EFI_ERROR (Status)) {
+    if (TableList != NULL) {
+      for (Index = 0; Index < NumMemMap; Index++) {
+        if (TableList[Index] != NULL) {
+          FreePool (TableList[Index]);
+        }
+      }
+
+      FreePool (TableList);
+    }
+
+    if (CmObjectList != NULL) {
+      FreePool (CmObjectList);
+    }
+  }
+
+  if (SmbiosRecord != NULL) {
+    FreePool (SmbiosRecord);
+  }
+
+  return Status;
+}
+
+/** The interface for the SMBIOS Type19 Table Generator.
+*/
+STATIC
+CONST
+SMBIOS_TABLE_GENERATOR  SmbiosType19Generator = {
+  // Generator ID
+  CREATE_STD_SMBIOS_TABLE_GEN_ID (EStdSmbiosTableIdType19),
+  // Generator Description
+  L"SMBIOS.TYPE19.GENERATOR",
+  // SMBIOS Table Type
+  EFI_SMBIOS_TYPE_MEMORY_ARRAY_MAPPED_ADDRESS,
+  NULL,
+  NULL,
+  // Build table function Extended.
+  BuildSmbiosType19TableEx,
+  // Free function Extended.
+  FreeSmbiosType19TableEx
+};
+
+/** Register the Generator with the SMBIOS Table Factory.
+
+  @param [in]  ImageHandle  The handle to the image.
+  @param [in]  SystemTable  Pointer to the System Table.
+
+  @retval EFI_SUCCESS           The Generator is registered.
+  @retval EFI_INVALID_PARAMETER A parameter is invalid.
+  @retval EFI_ALREADY_STARTED   The Generator for the Table ID
+                                is already registered.
+**/
+EFI_STATUS
+EFIAPI
+SmbiosType19LibConstructor (
+  IN  EFI_HANDLE        ImageHandle,
+  IN  EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  EFI_STATUS  Status;
+
+  Status = RegisterSmbiosTableGenerator (&SmbiosType19Generator);
+  DEBUG ((
+    DEBUG_INFO,
+    "SMBIOS Type 19: Register Generator. Status = %r\n",
+    Status
+    ));
+  ASSERT_EFI_ERROR (Status);
+
+  return Status;
+}
+
+/** Deregister the Generator from the SMBIOS Table Factory.
+
+  @param [in]  ImageHandle  The handle to the image.
+  @param [in]  SystemTable  Pointer to the System Table.
+
+  @retval EFI_SUCCESS           The Generator is deregistered.
+  @retval EFI_INVALID_PARAMETER A parameter is invalid.
+  @retval EFI_NOT_FOUND         The Generator is not registered.
+**/
+EFI_STATUS
+EFIAPI
+SmbiosType19LibDestructor (
+  IN  EFI_HANDLE        ImageHandle,
+  IN  EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  EFI_STATUS  Status;
+
+  Status = DeregisterSmbiosTableGenerator (&SmbiosType19Generator);
+  DEBUG ((
+    DEBUG_INFO,
+    "SMBIOS Type19: Deregister Generator. Status = %r\n",
+    Status
+    ));
+  ASSERT_EFI_ERROR (Status);
+  return Status;
+}

--- a/DynamicTablesPkg/Library/Smbios/SmbiosType19Lib/SmbiosType19Lib.inf
+++ b/DynamicTablesPkg/Library/Smbios/SmbiosType19Lib/SmbiosType19Lib.inf
@@ -1,0 +1,36 @@
+## @file
+#  SMBIOS Type19 Table Generator
+#
+#  Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#  Copyright (c) 2019 - 2021, Arm Limited. All rights reserved.<BR>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION    = 0x0001001B
+  BASE_NAME      = SmbiosType19LibArm
+  FILE_GUID      = 36da84ff-2c7d-4983-99a0-c9e1a8675fb4
+  VERSION_STRING = 1.0
+  MODULE_TYPE    = DXE_DRIVER
+  LIBRARY_CLASS  = NULL|DXE_DRIVER
+  CONSTRUCTOR    = SmbiosType19LibConstructor
+  DESTRUCTOR     = SmbiosType19LibDestructor
+
+[Sources]
+  SmbiosType19Generator.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  EmbeddedPkg/EmbeddedPkg.dec
+  ArmPlatformPkg/ArmPlatformPkg.dec
+  DynamicTablesPkg/DynamicTablesPkg.dec
+
+[Protocols]
+  gEfiSmbiosProtocolGuid                        # PROTOCOL ALWAYS_CONSUMED
+
+[LibraryClasses]
+  BaseLib
+  DebugLib
+  SmbiosStringTableLib


### PR DESCRIPTION
Add SMBIOS Dynamic Table generators for memory-related structures:

    Type 16 (Physical Memory Array): Generator for the Physical Memory Array table describing the collection of memory
    devices that make up the system's physical memory.
    Type 17 (Memory Device): Generator for the Memory Device table describing each memory device (e.g. DIMM) installed in the system.
    Type 19 (Memory Array Mapped Address): Generator for the Memory Array Mapped Address table describing the address range mapped to a Physical Memory Array.

Each generator uses the Configuration Manager protocol to obtain platform-specific memory topology information and
produces the corresponding SMBIOS structures.

This PR originated from the work by @gmahadevan  in https://github.com/tianocore/edk2/pull/12474
For reference: https://github.com/tianocore/edk2/pull/12474#issuecomment-4384666881