### PR TITLE
Fix stringtableinitialize smbios type 4 7

### DIFF
--- a/DynamicTablesPkg/Library/Smbios/SmbiosType4Lib/SmbiosType4Generator.c
+++ b/DynamicTablesPkg/Library/Smbios/SmbiosType4Lib/SmbiosType4Generator.c
@@ -2,7 +2,7 @@
   SMBIOS Type4 Table Generator.
 
   Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-  Copyright (c) 2020 - 2025, Arm Limited. All rights reserved.<BR>
+  Copyright (c) 2020 - 2026, Arm Limited. All rights reserved.<BR>
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
@@ -284,7 +284,17 @@ BuildSmbiosType4TableEx (
       continue;
     }
 
-    StringTableInitialize (&StrTable, SMBIOS_TYPE4_MAX_STRINGS);
+    Status = StringTableInitialize (&StrTable, SMBIOS_TYPE4_MAX_STRINGS);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((
+        DEBUG_ERROR,
+        "%a: Failed to initialize string table for ProcHierarchyNodeList[%u]. Status = %r\n",
+        __func__,
+        Index,
+        Status
+        ));
+      goto exitErrorBuildSmbiosType4Table;
+    }
 
     SocketDesignationRef     = 0;
     ProcessorManufacturerRef = 0;
@@ -299,6 +309,7 @@ BuildSmbiosType4TableEx (
       if (EFI_ERROR (Status)) {
         DEBUG ((DEBUG_ERROR, "Failed to add Socket Designation String %r\n", Status));
         ASSERT (!EFI_ERROR (Status));
+        StringTableFree (&StrTable);
         goto exitErrorBuildSmbiosType4Table;
       }
     }
@@ -308,6 +319,7 @@ BuildSmbiosType4TableEx (
       if (EFI_ERROR (Status)) {
         DEBUG ((DEBUG_ERROR, "Failed to add Processor Manufacturer String %r\n", Status));
         ASSERT (!EFI_ERROR (Status));
+        StringTableFree (&StrTable);
         goto exitErrorBuildSmbiosType4Table;
       }
     }
@@ -317,6 +329,7 @@ BuildSmbiosType4TableEx (
       if (EFI_ERROR (Status)) {
         DEBUG ((DEBUG_ERROR, "Failed to add Processor Version String %r\n", Status));
         ASSERT (!EFI_ERROR (Status));
+        StringTableFree (&StrTable);
         goto exitErrorBuildSmbiosType4Table;
       }
     }
@@ -326,6 +339,7 @@ BuildSmbiosType4TableEx (
       if (EFI_ERROR (Status)) {
         DEBUG ((DEBUG_ERROR, "Failed to add Serial Number String %r\n", Status));
         ASSERT (!EFI_ERROR (Status));
+        StringTableFree (&StrTable);
         goto exitErrorBuildSmbiosType4Table;
       }
     }
@@ -335,6 +349,7 @@ BuildSmbiosType4TableEx (
       if (EFI_ERROR (Status)) {
         DEBUG ((DEBUG_ERROR, "Failed to add Asset Tag String %r\n", Status));
         ASSERT (!EFI_ERROR (Status));
+        StringTableFree (&StrTable);
         goto exitErrorBuildSmbiosType4Table;
       }
     }
@@ -344,6 +359,7 @@ BuildSmbiosType4TableEx (
       if (EFI_ERROR (Status)) {
         DEBUG ((DEBUG_ERROR, "Failed to add Part Number String %r\n", Status));
         ASSERT (!EFI_ERROR (Status));
+        StringTableFree (&StrTable);
         goto exitErrorBuildSmbiosType4Table;
       }
     }
@@ -353,6 +369,7 @@ BuildSmbiosType4TableEx (
       if (EFI_ERROR (Status)) {
         DEBUG ((DEBUG_ERROR, "Failed to add Socket Type String %r\n", Status));
         ASSERT (!EFI_ERROR (Status));
+        StringTableFree (&StrTable);
         goto exitErrorBuildSmbiosType4Table;
       }
     }
@@ -361,6 +378,7 @@ BuildSmbiosType4TableEx (
     SmbiosRecord     = (SMBIOS_TABLE_TYPE4 *)AllocateZeroPool (SmbiosRecordSize);
     if (SmbiosRecord == NULL) {
       Status = EFI_OUT_OF_RESOURCES;
+      StringTableFree (&StrTable);
       goto exitErrorBuildSmbiosType4Table;
     }
 
@@ -400,6 +418,8 @@ BuildSmbiosType4TableEx (
         if (Node == NULL) {
           ASSERT (Node != NULL);
           Status = EFI_INVALID_PARAMETER;
+          FreePool (SmbiosRecord);
+          StringTableFree (&StrTable);
           goto exitErrorBuildSmbiosType4Table;
         }
 
@@ -472,6 +492,8 @@ BuildSmbiosType4TableEx (
 
     StringTablePublishStringSet (&StrTable, (CHAR8 *)(SmbiosRecord + 1), SmbiosRecordSize - sizeof (SMBIOS_TABLE_TYPE4));
 
+    StringTableFree (&StrTable);
+
     TableList[ObjIndex] = (SMBIOS_STRUCTURE *)SmbiosRecord;
     ObjIndex++;
     ASSERT (ObjIndex <= SocketCount);
@@ -486,7 +508,13 @@ BuildSmbiosType4TableEx (
   return EFI_SUCCESS;
 
 exitErrorBuildSmbiosType4Table:
-  if (TableList) {
+  if (TableList != NULL) {
+    for (Index = 0; Index < ObjIndex; Index++) {
+      if (TableList[Index] != NULL) {
+        FreePool (TableList[Index]);
+      }
+    }
+
     FreePool (TableList);
   }
 

--- a/DynamicTablesPkg/Library/Smbios/SmbiosType7Lib/SmbiosType7Generator.c
+++ b/DynamicTablesPkg/Library/Smbios/SmbiosType7Lib/SmbiosType7Generator.c
@@ -2,7 +2,7 @@
   SMBIOS Type7 Table Generator.
 
   Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-  Copyright (c) 2020 - 2025, Arm Limited. All rights reserved.<BR>
+  Copyright (c) 2020 - 2026, Arm Limited. All rights reserved.<BR>
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
@@ -630,19 +630,36 @@ BuildSmbiosType7TableEx (
         SmbiosRecord->Associativity = CacheAssociativityOther;
       } else {
         // No previously seen cache at this level, create new table entry
-        StringTableInitialize (&StrTable, SMBIOS_TYPE7_MAX_STRINGS);
+        Status = StringTableInitialize (&StrTable, SMBIOS_TYPE7_MAX_STRINGS);
+        if (EFI_ERROR (Status)) {
+          DEBUG ((
+            DEBUG_ERROR,
+            "%a: Failed to initialize string table. Status = %r\n",
+            __func__,
+            Status
+            ));
+          goto exitErrorBuildSmbiosType7Table;
+        }
+
         SocketDesignationRef = 0;
 
         if (CacheNode->SocketDesignation[0]) {
           Status = StringTableAddString (&StrTable, CacheNode->SocketDesignation, &SocketDesignationRef);
           if (EFI_ERROR (Status)) {
             DEBUG ((DEBUG_ERROR, "Failed to add Socket Designation String %r\n", Status));
+            StringTableFree (&StrTable);
             goto exitErrorBuildSmbiosType7Table;
           }
         }
 
         SmbiosRecordSize = sizeof (SMBIOS_TABLE_TYPE7) + StringTableGetStringSetSize (&StrTable);
         SmbiosRecord     = (SMBIOS_TABLE_TYPE7 *)AllocateZeroPool (SmbiosRecordSize);
+        if (SmbiosRecord == NULL) {
+          Status = EFI_OUT_OF_RESOURCES;
+          DEBUG ((DEBUG_ERROR, "Failed to allocate memory\n"));
+          StringTableFree (&StrTable);
+          goto exitErrorBuildSmbiosType7Table;
+        }
 
         // Set up the header
         SmbiosRecord->Hdr.Type   = EFI_SMBIOS_TYPE_CACHE_INFORMATION;
@@ -665,6 +682,8 @@ BuildSmbiosType7TableEx (
         if (CacheUsers < 0) {
           ASSERT (CacheUsers >= 0);
           Status = EFI_INVALID_PARAMETER;
+          StringTableFree (&StrTable);
+          FreePool (SmbiosRecord);
           goto exitErrorBuildSmbiosType7Table;
         }
 
@@ -682,6 +701,8 @@ BuildSmbiosType7TableEx (
         SmbiosRecord->Associativity   = GetCacheAssociativity (CacheNode->Associativity);
 
         StringTablePublishStringSet (&StrTable, (CHAR8 *)(SmbiosRecord + 1), SmbiosRecordSize - sizeof (SMBIOS_TABLE_TYPE7));
+
+        StringTableFree (&StrTable);
 
         TableList[ObjIndex]          = (SMBIOS_STRUCTURE *)SmbiosRecord;
         CmObjectList[ObjIndex]       = CM_ABSTRACT_TOKEN_MAKE (ETokenNameSpaceSmbios, EStdSmbiosTableIdType07, CacheNode->Level | (SocketIndex << 2));
@@ -737,6 +758,12 @@ exitErrorBuildSmbiosType7Table:
   }
 
   if (TableList) {
+    for (Index = 0; Index < ObjIndex; Index++) {
+      if (TableList[Index] != NULL) {
+        FreePool (TableList[Index]);
+      }
+    }
+
     FreePool (TableList);
   }
 


### PR DESCRIPTION
Fix SMBIOS Type 4 and Type 7 generator cleanup paths.

Both generators now check StringTableInitialize() before using the string
table and free the string table on failure paths after initialization.
The Type 4 path also frees a partially allocated SMBIOS record if PPTT
hierarchy traversal fails. Both generators now free already-created table
records when a later error causes generation to fail.

This avoids memory leaks during partial table generation failures.

These are the patches based on a [comment](https://github.com/tianocore/edk2/pull/12474#discussion_r3274017219) from @pierregondois 