### PR TITLE
MdePkg/CompilerIntrinsicsLib: Add LoongArch64 __ashlti3

### DIFF
--- a/MdePkg/Library/CompilerIntrinsicsLib/CompilerIntrinsicsLib.inf
+++ b/MdePkg/Library/CompilerIntrinsicsLib/CompilerIntrinsicsLib.inf
@@ -30,6 +30,9 @@
   AArch64/Atomics.S    | GCC
   AArch64/ashlti3.S    | GCC
 
+[Sources.LOONGARCH64]
+  LoongArch64/Ashlti3.S | GCC
+
 [Packages]
   MdePkg/MdePkg.dec
 

--- a/MdePkg/Library/CompilerIntrinsicsLib/LoongArch64/Ashlti3.S
+++ b/MdePkg/Library/CompilerIntrinsicsLib/LoongArch64/Ashlti3.S
@@ -1,0 +1,52 @@
+#------------------------------------------------------------------------------
+#
+# Copyright (c) 2026, Loongson Technology Corporation Limited. All rights reserved.<BR>
+#
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+#------------------------------------------------------------------------------
+
+ASM_GLOBAL ASM_PFX(__ashlti3)
+
+#/**
+#  Left shift a 128-bit integer.
+#
+#  @param[in]  $a0  Low 64 bits of the value.
+#  @param[in]  $a1  High 64 bits of the value.
+#  @param[in]  $a2  Shift count.
+#
+#  @return     $a0  Low 64 bits of the shifted value.
+#  @return     $a1  High 64 bits of the shifted value.
+#**/
+ASM_PFX(__ashlti3):
+  beqz    $a2, Ret
+
+  li.d    $t0, 64
+  bge     $a2, $t0, ShiftGreaterOrEqual64
+
+  sub.d   $t1, $t0, $a2
+  srl.d   $t1, $a0, $t1
+  sll.d   $a1, $a1, $a2
+  or      $a1, $a1, $t1
+  sll.d   $a0, $a0, $a2
+  b       Ret
+
+ShiftGreaterOrEqual64:
+  li.d    $t1, 128
+  bge     $a2, $t1, ShiftGreaterOrEqual128
+
+  sub.d   $t1, $a2, $t0
+  sll.d   $a1, $a0, $t1
+  move    $a0, $zero
+  b       Ret
+
+ShiftGreaterOrEqual128:
+  move    $a0, $zero
+  move    $a1, $zero
+
+Ret:
+  jirl    $zero, $ra, 0
+
+  .size   ASM_PFX(__ashlti3), . - ASM_PFX(__ashlti3)
+
+  .end


### PR DESCRIPTION
GCC may emit a call to __ashlti3 for 128-bit left shifts when compiling code that uses unsigned __int128, such as OpenSSL Curve448 code in CryptoPkg. The LoongArch64 firmware build does not link against libgcc, so provide the helper from CompilerIntrinsicsLib.

Implement __ashlti3 using the LoongArch64 ABI: the low and high 64-bit halves are passed in $a0 and $a1, the shift count is passed in $a2, and the result is returned in $a0 and $a1.

Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Chao Li <lichao@loongson.cn>

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested
1. Modify the DSC file to compile OpensslLibFull.inf.

NETWORK_TLS_ENABLE to TRUE and compile OpensslLibFull.inf.

```
diff --git a/OvmfPkg/LoongArchVirt/LoongArchVirtQemu.dsc b/OvmfPkg/LoongArchVirt/LoongArchVirtQemu.dsc
index 60907d7939..142168d461 100644
--- a/OvmfPkg/LoongArchVirt/LoongArchVirtQemu.dsc
+++ b/OvmfPkg/LoongArchVirt/LoongArchVirtQemu.dsc
@@ -47,7 +47,7 @@
   DEFINE NETWORK_IP6_ENABLE              = FALSE
   DEFINE NETWORK_HTTP_BOOT_ENABLE        = FALSE
   DEFINE NETWORK_SNP_ENABLE              = FALSE
-  DEFINE NETWORK_TLS_ENABLE              = FALSE
+  DEFINE NETWORK_TLS_ENABLE              = TRUE^M
   DEFINE NETWORK_ALLOW_HTTP_CONNECTIONS  = TRUE
   DEFINE NETWORK_ISCSI_ENABLE            = FALSE
   DEFINE NETWORK_PXE_BOOT_ENABLE         = TRUE
@@ -177,7 +177,7 @@
   #
   IntrinsicLib                     | CryptoPkg/Library/IntrinsicLib/IntrinsicLib.inf
 !if $(NETWORK_TLS_ENABLE) == TRUE
-  OpensslLib                       | CryptoPkg/Library/OpensslLib/OpensslLib.inf
+  OpensslLib                       | CryptoPkg/Library/OpensslLib/OpensslLibFull.inf
 !else
   OpensslLib                       | CryptoPkg/Library/OpensslLib/OpensslLibCrypto.inf
 !endif
```
2. Building LoongArch QEMU virt FW with GCC
The build completed successfully and generated QEMU_EFI.fd and QEMU_VARS.fd.
## Integration Instructions

N/A