### PR TITLE
RedfishPkg/BmcUsbNicLib: Fix MAC address underflow check

### DIFF
--- a/RedfishPkg/Library/PlatformHostInterfaceBmcUsbNicLib/PlatformHostInterfaceBmcUsbNicLib.c
+++ b/RedfishPkg/Library/PlatformHostInterfaceBmcUsbNicLib/PlatformHostInterfaceBmcUsbNicLib.c
@@ -751,7 +751,7 @@ HostInterfaceIpmiCheckMacAddress (
              (VOID *)&IpmiLanChannelMacAddress.Addr,
              IpmiLanMacAddressSize - 1
              ) != 0) ||
-          ((IpmiLanChannelMacAddress.Addr[IpmiLanMacAddressSize - 1] - 1) !=
+          (((UINT8)(IpmiLanChannelMacAddress.Addr[IpmiLanMacAddressSize - 1] - 1)) !=
            *(UsbNicInfo->MacAddress + IpmiLanMacAddressSize - 1))
           )
       {


### PR DESCRIPTION
## Description

HostInterfaceIpmiCheckMacAddress compares the host-end USB NIC MAC
address against the BMC-end MAC address minus one in the last octet.

When the BMC-end last octet is 0x00, C integer promotion evaluates the
subtraction as -1 instead of the expected UINT8 wraparound value 0xff.
This prevents the documented BMC ...:00 to host ...:ff case from
matching correctly.

Cast the subtraction result back to UINT8 before comparing it with the
host-end MAC address octet.

## Verification

- `python3 BaseTools/Scripts/PatchCheck.py -1`
