### PR TITLE
4594_arm_cca_secure_boot_v1_s1: Add AArch64 host-unit-test support.

### DIFF
--- a/CryptoPkg/Library/BaseCryptLib/UnitTestHostBaseCryptLib.inf
+++ b/CryptoPkg/Library/BaseCryptLib/UnitTestHostBaseCryptLib.inf
@@ -61,6 +61,9 @@
 [Sources.X64]
   Rand/CryptRandTsc.c
 
+[Sources.AARCH64]
+  Rand/CryptRand.c
+
 [Packages]
   MdePkg/MdePkg.dec
   CryptoPkg/CryptoPkg.dec

--- a/CryptoPkg/Test/CryptoPkgHostUnitTest.dsc
+++ b/CryptoPkg/Test/CryptoPkgHostUnitTest.dsc
@@ -13,7 +13,7 @@
   PLATFORM_VERSION        = 0.1
   DSC_SPECIFICATION       = 0x00010005
   OUTPUT_DIRECTORY        = Build/CryptoPkg/HostTest
-  SUPPORTED_ARCHITECTURES = IA32|X64
+  SUPPORTED_ARCHITECTURES = IA32|X64|AARCH64
   BUILD_TARGETS           = NOOPT
   SKUID_IDENTIFIER        = DEFAULT
 
@@ -39,6 +39,9 @@
 [LibraryClasses.X64, LibraryClasses.IA32]
   RngLib|MdePkg/Library/BaseRngLib/BaseRngLib.inf
 
+[LibraryClasses.AARCH64]
+  RngLib|UnitTestFrameworkPkg/Library/UnitTestHostRngLib/UnitTestHostRngLib.inf
+
 [Components]
   #
   # Build HOST_APPLICATION that tests the SampleUnitTest
@@ -48,12 +51,6 @@
     <LibraryClasses>
       OpensslLib|CryptoPkg/Library/OpensslLib/OpensslLibFull.inf
   }
-  CryptoPkg/Test/UnitTest/Library/BaseCryptLib/TestBaseCryptLibHost.inf {
-    <Defines>
-      FILE_GUID = 3604CCB8-138C-488F-8045-18704F73E734
-    <LibraryClasses>
-      OpensslLib|CryptoPkg/Library/OpensslLib/OpensslLibFullAccel.inf
-  }
 !endif
 
 !if $(CRYPTO_TEST_TYPE) IN "MBEDTLS"
@@ -62,6 +59,16 @@
       BaseCryptLib|CryptoPkg/Library/BaseCryptLibMbedTls/UnitTestHostBaseCryptLib.inf
       OpensslLib|CryptoPkg/Library/OpensslLib/OpensslLibSm3.inf
       MbedTlsLib|CryptoPkg/Library/MbedTlsLib/MbedTlsLib.inf
+  }
+!endif
+
+[Components.X64, Components.IA32]
+!if $(CRYPTO_TEST_TYPE) IN "OPENSSL"
+  CryptoPkg/Test/UnitTest/Library/BaseCryptLib/TestBaseCryptLibHost.inf {
+    <Defines>
+      FILE_GUID = 3604CCB8-138C-488F-8045-18704F73E734
+    <LibraryClasses>
+      OpensslLib|CryptoPkg/Library/OpensslLib/OpensslLibFullAccel.inf
   }
 !endif
 

--- a/MdePkg/Library/BaseLib/AArch64UnitTestHost.c
+++ b/MdePkg/Library/BaseLib/AArch64UnitTestHost.c
@@ -1,0 +1,30 @@
+/** @file
+  AArch64 specific Unit Test Host functions.
+
+  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2025, Arm Limited. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "UnitTestHost.h"
+
+///
+/// Common services
+///
+STATIC UNIT_TEST_HOST_BASE_LIB_COMMON  mUnitTestHostBaseLibCommon = {
+  UnitTestHostBaseLibEnableInterrupts,
+  UnitTestHostBaseLibDisableInterrupts,
+  UnitTestHostBaseLibEnableDisableInterrupts,
+  UnitTestHostBaseLibGetInterruptState,
+};
+
+///
+/// Structure of hook functions for BaseLib functions that can not be used from
+/// a host application.  A simple emulation of these function is provided by
+/// default.  A specific unit test can provide its own implementation for any
+/// of these functions.
+///
+UNIT_TEST_HOST_BASE_LIB  gUnitTestHostBaseLib = {
+  &mUnitTestHostBaseLibCommon,
+};

--- a/MdePkg/Library/BaseLib/UnitTestHostBaseLib.inf
+++ b/MdePkg/Library/BaseLib/UnitTestHostBaseLib.inf
@@ -23,7 +23,7 @@
   LIBRARY_CLASS                  = UnitTestHostBaseLib|HOST_APPLICATION
 
 #
-#  VALID_ARCHITECTURES           = IA32 X64
+#  VALID_ARCHITECTURES           = IA32 X64 AARCH64
 #
 
 [Sources]
@@ -182,9 +182,10 @@
   Math64.c
 
 [Sources.AARCH64]
+  AArch64UnitTestHost.c
   AArch64/InternalSwitchStack.c
-  AArch64/Unaligned.c
   Math64.c
+  Unaligned.c
 
   AArch64/MemoryFence.S             | GCC
   AArch64/SwitchStack.S             | GCC

--- a/MdePkg/MdePkg.ci.yaml
+++ b/MdePkg/MdePkg.ci.yaml
@@ -63,7 +63,8 @@
             "8002", "aligned (",
             "4002", "_ReturnAddress",
             "8005", "__security_cookie",
-            "8006", "__stack_chk_fail"
+            "8006", "__stack_chk_fail",
+            "8005", "UNIT_TEST_HOST_BASE_LIB.X86"
         ],
         ## Both file path and directory path are accepted.
         "IgnoreFiles": [

--- a/MdePkg/Test/MdePkgHostTest.dsc
+++ b/MdePkg/Test/MdePkgHostTest.dsc
@@ -13,7 +13,7 @@
   PLATFORM_VERSION        = 0.1
   DSC_SPECIFICATION       = 0x00010005
   OUTPUT_DIRECTORY        = Build/MdePkg/HostTest
-  SUPPORTED_ARCHITECTURES = IA32|X64
+  SUPPORTED_ARCHITECTURES = IA32|X64|AARCH64
   BUILD_TARGETS           = NOOPT
   SKUID_IDENTIFIER        = DEFAULT
 
@@ -30,8 +30,19 @@
   #
   MdePkg/Test/UnitTest/Library/BaseSafeIntLib/TestBaseSafeIntLibHost.inf
   MdePkg/Test/UnitTest/Library/BaseLib/BaseLibUnitTestsHost.inf
-  MdePkg/Test/GoogleTest/Library/BaseSafeIntLib/GoogleTestBaseSafeIntLib.inf
   MdePkg/Test/UnitTest/Library/DevicePathLib/TestDevicePathLibHost.inf
+
+  #
+  # Build HOST_APPLICATION Libraries
+  #
+  MdePkg/Library/BaseLib/UnitTestHostBaseLib.inf
+
+[Components.Ia32, Components.X64]
+  #
+  # Build HOST_APPLICATION that tests the SafeIntLib
+  #
+  MdePkg/Test/GoogleTest/Library/BaseSafeIntLib/GoogleTestBaseSafeIntLib.inf
+
   #
   # BaseLib tests
   #
@@ -40,7 +51,6 @@
   #
   # Build HOST_APPLICATION Libraries
   #
-  MdePkg/Library/BaseLib/UnitTestHostBaseLib.inf
   MdePkg/Test/Mock/Library/GoogleTest/MockUefiLib/MockUefiLib.inf
   MdePkg/Test/Mock/Library/GoogleTest/MockUefiRuntimeServicesTableLib/MockUefiRuntimeServicesTableLib.inf
   MdePkg/Test/Mock/Library/GoogleTest/MockUefiBootServicesTableLib/MockUefiBootServicesTableLib.inf

--- a/MdePkg/Test/UnitTest/Include/Library/UnitTestHostBaseLib.h
+++ b/MdePkg/Test/UnitTest/Include/Library/UnitTestHostBaseLib.h
@@ -8,6 +8,10 @@
 
 #pragma once
 
+#include <ProcessorBind.h>
+
+#if defined (MDE_CPU_X64) || defined (MDE_CPU_IA32)
+
 /**
   Prototype of service with no parameters and no return value.
 **/
@@ -575,5 +579,50 @@ typedef struct {
   UNIT_TEST_HOST_BASE_LIB_COMMON    *Common;
   UNIT_TEST_HOST_BASE_LIB_X86       *X86;
 } UNIT_TEST_HOST_BASE_LIB;
+
+#elif defined (MDE_CPU_AARCH64)
+
+/**
+  Prototype of service with no parameters and no return value.
+**/
+typedef
+VOID
+(EFIAPI *UNIT_TEST_HOST_BASE_LIB_VOID)(
+  VOID
+  );
+
+/**
+  Prototype of service that reads and returns a BOOLEAN value.
+
+  @return The value read.
+**/
+typedef
+BOOLEAN
+(EFIAPI *UNIT_TEST_HOST_BASE_LIB_READ_BOOLEAN)(
+  VOID
+  );
+
+///
+/// Common services
+///
+typedef struct {
+  UNIT_TEST_HOST_BASE_LIB_VOID            EnableInterrupts;
+  UNIT_TEST_HOST_BASE_LIB_VOID            DisableInterrupts;
+  UNIT_TEST_HOST_BASE_LIB_VOID            EnableDisableInterrupts;
+  UNIT_TEST_HOST_BASE_LIB_READ_BOOLEAN    GetInterruptState;
+} UNIT_TEST_HOST_BASE_LIB_COMMON;
+
+///
+/// Data structure that contains pointers structures of common services and CPU
+/// architecture specific services.  Support for additional CPU architectures
+/// can be added to the end of this structure.
+///
+typedef struct {
+  UNIT_TEST_HOST_BASE_LIB_COMMON    *Common;
+} UNIT_TEST_HOST_BASE_LIB;
+
+#else
+  #error "Unsupported architecture for HostUnitTest."
+#endif
 
 extern UNIT_TEST_HOST_BASE_LIB  gUnitTestHostBaseLib;

--- a/UnitTestFrameworkPkg/Library/CmockaLib/CmockaLib.inf
+++ b/UnitTestFrameworkPkg/Library/CmockaLib/CmockaLib.inf
@@ -34,3 +34,4 @@
   GCC:*_*_IA32_CC_FLAGS  =  -m32
   GCC:*_*_X64_CC_FLAGS   =  -m64
   GCC:*_CLANGPDB_*_CC_FLAGS = -DHAVE_VSNPRINTF -DHAVE_SNPRINTF -Wno-deprecated-declarations
+  GCC:*_*_AARCH64_CC_XIPFLAGS == -mstrict-align

--- a/UnitTestFrameworkPkg/Library/UnitTestDebugAssertLib/UnitTestDebugAssertLibHost.cpp
+++ b/UnitTestFrameworkPkg/Library/UnitTestDebugAssertLib/UnitTestDebugAssertLibHost.cpp
@@ -8,8 +8,10 @@
 
 #include <stdexcept>
 
-#ifdef NULL
-  #undef NULL
+#ifndef MDE_CPU_AARCH64
+  #ifdef NULL
+    #undef NULL
+  #endif
 #endif
 
 extern "C" {

--- a/UnitTestFrameworkPkg/Library/UnitTestHostRngLib/UnitTestHostRngLib.c
+++ b/UnitTestFrameworkPkg/Library/UnitTestHostRngLib/UnitTestHostRngLib.c
@@ -1,0 +1,151 @@
+/** @file
+  Random number generator services that uses the stdlib
+  function rand() to provide random numbers.
+
+  Copyright (c) 2025, Arm Limited. All rights reserved.<BR>
+  Copyright (c) 2021, NUVIA Inc. All rights reserved.<BR>
+  Copyright (c) 2015, Intel Corporation. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Uefi.h>
+#include <Library/BaseLib.h>
+#include <Library/DebugLib.h>
+#include <Library/RngLib.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+
+STATIC BOOLEAN  mRandSeeded = FALSE;
+
+/**
+ * Constructor for UnitTestHostRngLib.
+
+  @retval TRUE         Support.
+**/
+EFI_STATUS
+EFIAPI
+BaseRngLibConstructor (
+  VOID
+  )
+{
+  if (!mRandSeeded) {
+    srand ((unsigned)time (NULL));
+    mRandSeeded = TRUE;
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Generates a 16-bit random number.
+
+  if Rand is NULL, then ASSERT().
+
+  @param[out] Rand     Buffer pointer to store the 16-bit random value.
+
+  @retval TRUE         Random number generated successfully.
+  @retval FALSE        Failed to generate the random number.
+
+**/
+BOOLEAN
+EFIAPI
+GetRandomNumber16 (
+  OUT     UINT16  *Rand
+  )
+{
+  int  RandLo;
+
+  RandLo = rand ();
+
+  *Rand = (UINT16)RandLo;
+
+  return TRUE;
+}
+
+/**
+  Generates a 32-bit random number.
+
+  if Rand is NULL, then ASSERT().
+
+  @param[out] Rand     Buffer pointer to store the 32-bit random value.
+
+  @retval TRUE         Random number generated successfully.
+  @retval FALSE        Failed to generate the random number.
+
+**/
+BOOLEAN
+EFIAPI
+GetRandomNumber32 (
+  OUT     UINT32  *Rand
+  )
+{
+  int  RandLo;
+
+  RandLo = rand ();
+
+  *Rand = (UINT32)RandLo;
+
+  return TRUE;
+}
+
+/**
+  Generates a 64-bit random number.
+
+  if Rand is NULL, then ASSERT().
+
+  @param[out] Rand     Buffer pointer to store the 64-bit random value.
+
+  @retval TRUE         Random number generated successfully.
+  @retval FALSE        Failed to generate the random number.
+
+**/
+BOOLEAN
+EFIAPI
+GetRandomNumber64 (
+  OUT     UINT64  *Rand
+  )
+{
+  int  RandHi;
+  int  RandLo;
+
+  RandLo = rand ();
+  RandHi = rand ();
+
+  *Rand = (UINT64)(((UINT64)RandHi << 32) | (UINT32)RandLo);
+
+  return TRUE;
+}
+
+/**
+  Generates a 128-bit random number.
+
+  if Rand is NULL, then ASSERT().
+
+  @param[out] Rand     Buffer pointer to store the 128-bit random value.
+
+  @retval TRUE         Random number generated successfully.
+  @retval FALSE        Failed to generate the random number.
+
+**/
+BOOLEAN
+EFIAPI
+GetRandomNumber128 (
+  OUT     UINT64  *Rand
+  )
+{
+  //
+  // Read first 64 bits
+  //
+  if (!GetRandomNumber64 (Rand)) {
+    return FALSE;
+  }
+
+  //
+  // Read second 64 bits
+  //
+  return GetRandomNumber64 (++Rand);
+}

--- a/UnitTestFrameworkPkg/Library/UnitTestHostRngLib/UnitTestHostRngLib.inf
+++ b/UnitTestFrameworkPkg/Library/UnitTestHostRngLib/UnitTestHostRngLib.inf
@@ -1,0 +1,33 @@
+## @file
+#  Instance of RNG (Random Number Generator) Library.
+#
+#  BaseRng Library that uses the stdlib function
+#  rand() to provide random numbers.
+#
+#  Copyright (c) 2025, Arm Limited. All rights reserved.<BR>
+#  Copyright (c) 2021, NUVIA Inc. All rights reserved.<BR>
+#  Copyright (c) 2015, Intel Corporation. All rights reserved.<BR>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x0001001B
+  BASE_NAME                      = UnitTestHostRngLib
+  MODULE_UNI_FILE                = UnitTestHostRngLib.uni
+  FILE_GUID                      = 6c099959-267f-4a5b-9fa8-b5845e78c796
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = RngLib|HOST_APPLICATION
+
+[Sources]
+  UnitTestHostRngLib.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+
+[LibraryClasses]
+  BaseLib
+  DebugLib

--- a/UnitTestFrameworkPkg/Library/UnitTestHostRngLib/UnitTestHostRngLib.uni
+++ b/UnitTestFrameworkPkg/Library/UnitTestHostRngLib/UnitTestHostRngLib.uni
@@ -1,0 +1,17 @@
+// /** @file
+//  Instance of RNG (Random Number Generator) Library.
+//
+//  BaseRng Library that the stdlib function rand()
+//  to provide random numbers.
+//
+//  Copyright (c) 2025, Arm Limited. All rights reserved.<BR>
+//  Copyright (c) 2015, Intel Corporation. All rights reserved.<BR>
+//
+//  SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+// **/
+
+
+#string STR_MODULE_ABSTRACT             #language en-US "Instance of Pesudo RNG Library in Unix"
+
+#string STR_MODULE_DESCRIPTION          #language en-US "BaseRng Library that uses the stdlib function rand() to provide random numbers"

--- a/UnitTestFrameworkPkg/Test/UnitTestFrameworkPkgHostTest.dsc
+++ b/UnitTestFrameworkPkg/Test/UnitTestFrameworkPkgHostTest.dsc
@@ -39,3 +39,4 @@
   UnitTestFrameworkPkg/Library/SubhookLib/SubhookLib.inf
   UnitTestFrameworkPkg/Library/UnitTestLib/UnitTestLibCmocka.inf
   UnitTestFrameworkPkg/Library/UnitTestDebugAssertLib/UnitTestDebugAssertLibHost.inf
+  UnitTestFrameworkPkg/Library/UnitTestHostRngLib/UnitTestHostRngLib.inf

--- a/UnitTestFrameworkPkg/UnitTestFrameworkPkg.ci.yaml
+++ b/UnitTestFrameworkPkg/UnitTestFrameworkPkg.ci.yaml
@@ -118,7 +118,8 @@
             "corthon",      # Contact GitHub account in Readme
             "mdkinney",     # Contact GitHub account in Readme
             "spbrogan",     # Contact GitHub account in Readme
-            "uintn"
+            "uintn",
+            "mstrict"
         ],
         "IgnoreStandardPaths": [],   # Standard Plugin defined paths that should be ignore
         "AdditionalIncludePaths": [] # Additional paths to spell check (wildcards supported)

--- a/UnitTestFrameworkPkg/UnitTestFrameworkPkgHost.dsc.inc
+++ b/UnitTestFrameworkPkg/UnitTestFrameworkPkgHost.dsc.inc
@@ -36,9 +36,6 @@
   CpuLib|MdePkg/Library/BaseCpuLibNull/BaseCpuLibNull.inf
   CacheMaintenanceLib|MdePkg/Library/BaseCacheMaintenanceLibNull/BaseCacheMaintenanceLibNull.inf
   CmockaLib|UnitTestFrameworkPkg/Library/CmockaLib/CmockaLib.inf
-  GoogleTestLib|UnitTestFrameworkPkg/Library/GoogleTestLib/GoogleTestLib.inf
-  SubhookLib|UnitTestFrameworkPkg/Library/SubhookLib/SubhookLib.inf
-  FunctionMockLib|UnitTestFrameworkPkg/Library/FunctionMockLib/FunctionMockLib.inf
   UnitTestLib|UnitTestFrameworkPkg/Library/UnitTestLib/UnitTestLibCmocka.inf
   DebugLib|UnitTestFrameworkPkg/Library/Posix/DebugLibPosix/DebugLibPosix.inf
   MemoryAllocationLib|UnitTestFrameworkPkg/Library/Posix/MemoryAllocationLibPosix/MemoryAllocationLibPosix.inf
@@ -124,6 +121,15 @@
     !endif
   !endif
 !endif
+
+[LibraryClasses.Ia32, LibraryClasses.X64]
+  GoogleTestLib|UnitTestFrameworkPkg/Library/GoogleTestLib/GoogleTestLib.inf
+  SubhookLib|UnitTestFrameworkPkg/Library/SubhookLib/SubhookLib.inf
+  FunctionMockLib|UnitTestFrameworkPkg/Library/FunctionMockLib/FunctionMockLib.inf
+  NULL|UnitTestFrameworkPkg/Library/UnitTestDebugAssertLib/UnitTestDebugAssertLibHost.inf
+
+[LibraryClasses.AARCH64]
+  NULL|UnitTestFrameworkPkg/Library/UnitTestDebugAssertLib/UnitTestDebugAssertLib.inf
 
 [BuildOptions]
 !if $(WIN_MINGW32_BUILD)
@@ -264,6 +270,7 @@
 !endif
   GCC:*_*_IA32_DLINK_FLAGS = -m32
   GCC:*_*_X64_DLINK_FLAGS  = -m64
+  GCC:*_*_AARCH64_DLINK_FLAGS  == -o $(BIN_DIR)/$(MODULE_NAME_GUID)
 
 !if $(UNIT_TESTING_ADDRESS_SANITIZER_ENABLE)
   #

--- a/UnitTestFrameworkPkg/UnitTestFrameworkPkgHost.dsc.inc
+++ b/UnitTestFrameworkPkg/UnitTestFrameworkPkgHost.dsc.inc
@@ -130,6 +130,7 @@
 
 [LibraryClasses.AARCH64]
   NULL|UnitTestFrameworkPkg/Library/UnitTestDebugAssertLib/UnitTestDebugAssertLib.inf
+  RngLib|UnitTestFrameworkPkg/Library/UnitTestHostRngLib/UnitTestHostRngLib.inf
 
 [BuildOptions]
 !if $(WIN_MINGW32_BUILD)


### PR DESCRIPTION
# Add AArch64 host-unit-test support.

This change enables AArch64 host builds by adding an AArch64 UnitTestHostBaseLib instance, wiring the UnitTestFrameworkPkg host DSC for AArch64, fixing an AArch64 build issue in UnitTestDebugAssertLib, and moving GoogleTest-only libraries/components into IA32/X64 sections where they are not available for AArch64.

It also adds a host-based RngLib implementation for unit tests and uses it to enable CryptoPkg AArch64 host unit-test builds that require random number generation.

Note: This PR is a subset of the PR that tracks the enablement of secure boot support for Arm CCA https://github.com/tianocore/edk2/pull/12625

- [ ] Breaking change?
  - No
- [ ] Impacts security?
  - No
- [ ] Includes tests?
  - No

## How This Was Tested
Tested using Arm CCA Test User Context service which is a Host Based Unit Test application in a local environment that incorporates the PR https://github.com/tianocore/edk2/pull/12224.

## Integration Instructions
- This PR depends on the Arm CCA guest firmware enablement PR https://github.com/tianocore/edk2/pull/12224