### PR TITLE
BaseTools/Build: Fix arch macro expansion scope in DSC parser

### DIFF
--- a/BaseTools/Source/Python/Workspace/MetaFileParser.py
+++ b/BaseTools/Source/Python/Workspace/MetaFileParser.py
@@ -1400,6 +1400,17 @@ class DscParser(MetaFileParser):
 
             self._Scope = [[S1, S2, S3]]
             #
+            # Expand macros in arch field for all records so that per-module
+            # sub-items (e.g. <LibraryClasses> under [Components.$(PEI_ARCH)])
+            # resolve correctly, not just the Component record itself.
+            #
+            self._Scope[0][0] = ReplaceMacro(self._Scope[0][0], self._Macros)
+            if '$(' in self._Scope[0][0] and S1 != TAB_ARCH_COMMON:
+                EdkLogger.warn("Parser",
+                               "Macro in arch field was not resolved. "
+                               "'%s' used in section header is not defined." % S1,
+                               File=self._FileWithError, Line=LineStart)
+            #
             # For !include directive, handle it specially,
             # merge arch and module type in case of duplicate items
             #
@@ -1712,7 +1723,6 @@ class DscParser(MetaFileParser):
 
     def __ProcessComponent(self):
         self._ValueList[0] = ReplaceMacro(self._ValueList[0], self._Macros)
-        self._Scope[0][0] = ReplaceMacro(self._Scope[0][0], self._Macros)
 
     def __ProcessBuildOption(self):
         self._ValueList = [ReplaceMacro(Value, self._Macros, RaiseError=False)


### PR DESCRIPTION
In the EDK2 DSC parser, macro expansion for the arch field in `[Components.$(MACRO)]` sections was only performed on the Component record itself inside `__ProcessComponent()`. Sub-items under that component (e.g. `<LibraryClasses>`, `<BuildOptions>`) retained the unexpanded `$(MACRO)` string in their scope, causing arch matching to fail. As a result, per-module library class overrides and build options under macro-based arch sections were silently ignored during the build.

**Changes:**
- Moved the `ReplaceMacro()` call for `self._Scope[0][0]` from `__ProcessComponent()` to the main processing loop in `__ProcessAll()`, immediately after `self._Scope` is assigned. This ensures macro expansion of the arch field applies to all record types (Component entries, LibraryClasses sub-items, BuildOptions sub-items, etc.), not just Component records.
- Removed the now-redundant `ReplaceMacro()` call from `__ProcessComponent()`.
- Added a warning when a macro in the arch field cannot be resolved, since the EDK2 DSC spec does not allow unresolved macros in final section headers (e.g. `[Components.]` or `[Components.$(UndefString)]`).

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Verified with a DSC file using `[Components.$(PEI_ARCH)]` sections containing per-module `<LibraryClasses>` and `<BuildOptions>` sub-items. Before the fix, the sub-items were silently ignored (arch field remained as the unexpanded macro string). After the fix, all sub-items correctly resolve and apply to the expected architecture target.

## Integration Instructions

N/A