### PR TITLE
.pytool,.azurepipelines: Add Cspell Ignore Regex List

### DIFF
--- a/.azurepipelines/templates/spell-check-prereq-steps.yml
+++ b/.azurepipelines/templates/spell-check-prereq-steps.yml
@@ -17,6 +17,6 @@ steps:
     #checkLatest: false # Optional
   condition: and(gt(variables.pkg_count, 0), succeeded())
 
-- script: npm install -g cspell@5.20.0
+- script: npm install -g cspell@10.0.0
   displayName: 'Install cspell npm'
   condition: and(gt(variables.pkg_count, 0), succeeded())

--- a/.pytool/Plugin/SpellCheck/cspell.base.yaml
+++ b/.pytool/Plugin/SpellCheck/cspell.base.yaml
@@ -24,6 +24,12 @@
     "allowCompoundWords": true,
     "maxNumberOfProblems": 200,
     "maxDuplicateProblems": 200,
+    "ignoreRegExpList": [
+        # Ignore copyrights
+        "/Copyright\\s*\\([cC]\\).*$/gm",
+        # Ignore hex values
+        "/0x[0-9a-fA-F]+/"
+    ],
     "ignoreWords": [],
     "words": [
         "AABBCCDD",
@@ -367,6 +373,7 @@
         "frcerr",
         "freqcsr",
         "fsgsbase",
+        "fstack",
         "fvmain",
         "fword",
         "fwvol",


### PR DESCRIPTION
# Description

This adds two regexes to ignore in cspell: copyright notices (which may have companies not in the companies dictionary or individuals listed) and hex values (which may have things like 0xABEABCAB...).

While we are here, edk2 is using an old version of cspell that doesn't do as good of a job of ignoring some things it should. Update to the latest. This only brought one additional failure, which is added to the global ignore list as it comes from the gcc/clang -fstack-protector flag.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Ran the spell check plugin against the failing copyright notice from https://github.com/tianocore/edk2/pull/12622 and it now passes. Ran the spell check plugin against the whole repo with the new version.

## Integration Instructions

N/A.