### PR TITLE
NetworkPkg/Dhcp6Dxe: bound IA inner option length to buffer

### DIFF
--- a/NetworkPkg/Dhcp6Dxe/Dhcp6Impl.h
+++ b/NetworkPkg/Dhcp6Dxe/Dhcp6Impl.h
@@ -148,8 +148,8 @@ STATIC_ASSERT (
   );
 
 // This is the size of IA_NA without options (16)
-#define DHCP6_MIN_SIZE_OF_IA_NA  DHCP6_SIZE_OF_COMBINED_CODE_AND_LEN + \
-                                 DHCP6_SIZE_OF_COMBINED_IAID_T1_T2
+#define DHCP6_MIN_SIZE_OF_IA_NA  (DHCP6_SIZE_OF_COMBINED_CODE_AND_LEN + \
+                                  DHCP6_SIZE_OF_COMBINED_IAID_T1_T2)
 STATIC_ASSERT (
   DHCP6_MIN_SIZE_OF_IA_NA == 16,
   "Minimum combined size of IA_TA per RFC 8415"

--- a/NetworkPkg/Dhcp6Dxe/Dhcp6Io.c
+++ b/NetworkPkg/Dhcp6Dxe/Dhcp6Io.c
@@ -750,6 +750,13 @@ Dhcp6SeekInnerOptionSafe (
     }
 
     IaInnerLenTmp -= DHCP6_SIZE_OF_COMBINED_IAID_T1_T2;
+
+    //
+    // Verify the declared inner length does not run past the option buffer.
+    //
+    if (IaInnerLenTmp > OptionLen - DHCP6_MIN_SIZE_OF_IA_NA) {
+      return EFI_DEVICE_ERROR;
+    }
   } else if (IaType == Dhcp6OptIata) {
     //
     // Verify the OptionLen is valid.
@@ -769,6 +776,13 @@ Dhcp6SeekInnerOptionSafe (
     }
 
     IaInnerLenTmp -= DHCP6_SIZE_OF_IAID;
+
+    //
+    // Verify the declared inner length does not run past the option buffer.
+    //
+    if (IaInnerLenTmp > OptionLen - DHCP6_MIN_SIZE_OF_IA_TA) {
+      return EFI_DEVICE_ERROR;
+    }
   } else {
     return EFI_DEVICE_ERROR;
   }

--- a/NetworkPkg/Dhcp6Dxe/GoogleTest/Dhcp6IoGoogleTest.cpp
+++ b/NetworkPkg/Dhcp6Dxe/GoogleTest/Dhcp6IoGoogleTest.cpp
@@ -699,6 +699,182 @@ TEST_F (Dhcp6SeekInnerOptionSafeTest, InvalidOption) {
   ASSERT_EQ (Result, EFI_DEVICE_ERROR);
 }
 
+// Test Description:
+// This test verifies that Dhcp6SeekInnerOptionSafe rejects an IANA option whose
+// declared length runs past the end of the option buffer.
+TEST_F (Dhcp6SeekInnerOptionSafeTest, IANAInnerLenExceedsBufferExpectFail) {
+  EFI_STATUS           Status;
+  UINT8                Option[sizeof (DHCPv6_OPTION_IA_NA) + SEARCH_PATTERN_LEN] = { 0 };
+  UINT32               OptionLength                                              = sizeof (Option);
+  DHCPv6_OPTION_IA_NA  *OptionPtr                                                = (DHCPv6_OPTION_IA_NA *)Option;
+
+  UINT8   *InnerOptionPtr   = NULL;
+  UINT16  InnerOptionLength = 0;
+
+  OptionPtr->Header.Code = Dhcp6OptIana;
+  OptionPtr->Header.Len  = HTONS (0xFFFF); // Declare far more inner data than the buffer holds
+  OptionPtr->Header.IAID = 0x12345678;
+  OptionPtr->T1          = 0x11111111;
+  OptionPtr->T2          = 0x22222222;
+
+  Status = Dhcp6SeekInnerOptionSafe (
+             Dhcp6OptIana,
+             Option,
+             OptionLength,
+             &InnerOptionPtr,
+             &InnerOptionLength
+             );
+  ASSERT_EQ (Status, EFI_DEVICE_ERROR);
+}
+
+// Test Description:
+// This test verifies that Dhcp6SeekInnerOptionSafe rejects an IATA option whose
+// declared length runs past the end of the option buffer.
+TEST_F (Dhcp6SeekInnerOptionSafeTest, IATAInnerLenExceedsBufferExpectFail) {
+  EFI_STATUS           Status;
+  UINT8                Option[sizeof (DHCPv6_OPTION_IA_TA) + SEARCH_PATTERN_LEN] = { 0 };
+  UINT32               OptionLength                                              = sizeof (Option);
+  DHCPv6_OPTION_IA_TA  *OptionPtr                                                = (DHCPv6_OPTION_IA_TA *)Option;
+
+  UINT8   *InnerOptionPtr   = NULL;
+  UINT16  InnerOptionLength = 0;
+
+  OptionPtr->Header.Code = Dhcp6OptIata;
+  OptionPtr->Header.Len  = HTONS (0xFFFF); // Declare far more inner data than the buffer holds
+  OptionPtr->Header.IAID = 0x12345678;
+
+  Status = Dhcp6SeekInnerOptionSafe (
+             Dhcp6OptIata,
+             Option,
+             OptionLength,
+             &InnerOptionPtr,
+             &InnerOptionLength
+             );
+  ASSERT_EQ (Status, EFI_DEVICE_ERROR);
+}
+
+// Test Description:
+// This test verifies that Dhcp6SeekInnerOptionSafe rejects an IANA option whose
+// declared inner length is one byte past the end of the option buffer.
+TEST_F (Dhcp6SeekInnerOptionSafeTest, IANAInnerLenOffByOneExpectFail) {
+  EFI_STATUS           Status;
+  UINT8                Option[sizeof (DHCPv6_OPTION_IA_NA) + SEARCH_PATTERN_LEN] = { 0 };
+  UINT32               OptionLength                                              = sizeof (Option);
+  DHCPv6_OPTION_IA_NA  *OptionPtr                                                = (DHCPv6_OPTION_IA_NA *)Option;
+
+  UINT8   *InnerOptionPtr   = NULL;
+  UINT16  InnerOptionLength = 0;
+
+  OptionPtr->Header.Code = Dhcp6OptIana;
+  // One byte more inner data than OptionLen - DHCP6_MIN_SIZE_OF_IA_NA allows
+  OptionPtr->Header.Len  = HTONS (DHCP6_SIZE_OF_COMBINED_IAID_T1_T2 + (OptionLength - DHCP6_MIN_SIZE_OF_IA_NA) + 1);
+  OptionPtr->Header.IAID = 0x12345678;
+  OptionPtr->T1          = 0x11111111;
+  OptionPtr->T2          = 0x22222222;
+
+  Status = Dhcp6SeekInnerOptionSafe (
+             Dhcp6OptIana,
+             Option,
+             OptionLength,
+             &InnerOptionPtr,
+             &InnerOptionLength
+             );
+  ASSERT_EQ (Status, EFI_DEVICE_ERROR);
+}
+
+// Test Description:
+// This test verifies that Dhcp6SeekInnerOptionSafe rejects an IATA option whose
+// declared inner length is one byte past the end of the option buffer.
+TEST_F (Dhcp6SeekInnerOptionSafeTest, IATAInnerLenOffByOneExpectFail) {
+  EFI_STATUS           Status;
+  UINT8                Option[sizeof (DHCPv6_OPTION_IA_TA) + SEARCH_PATTERN_LEN] = { 0 };
+  UINT32               OptionLength                                              = sizeof (Option);
+  DHCPv6_OPTION_IA_TA  *OptionPtr                                                = (DHCPv6_OPTION_IA_TA *)Option;
+
+  UINT8   *InnerOptionPtr   = NULL;
+  UINT16  InnerOptionLength = 0;
+
+  OptionPtr->Header.Code = Dhcp6OptIata;
+  // One byte more inner data than OptionLen - DHCP6_MIN_SIZE_OF_IA_TA allows
+  OptionPtr->Header.Len  = HTONS ((UINT16)(DHCP6_SIZE_OF_IAID + (OptionLength - DHCP6_MIN_SIZE_OF_IA_TA) + 1));
+  OptionPtr->Header.IAID = 0x12345678;
+
+  Status = Dhcp6SeekInnerOptionSafe (
+             Dhcp6OptIata,
+             Option,
+             OptionLength,
+             &InnerOptionPtr,
+             &InnerOptionLength
+             );
+  ASSERT_EQ (Status, EFI_DEVICE_ERROR);
+}
+
+// Test Description:
+// This test verifies that Dhcp6SeekInnerOptionSafe accepts an IANA option whose
+// declared inner length exactly matches OptionLen - DHCP6_MIN_SIZE_OF_IA_NA.
+TEST_F (Dhcp6SeekInnerOptionSafeTest, IANAInnerLenExactMatchExpectSuccess) {
+  EFI_STATUS           Status;
+  UINT8                Option[sizeof (DHCPv6_OPTION_IA_NA) + SEARCH_PATTERN_LEN] = { 0 };
+  UINT32               OptionLength                                              = sizeof (Option);
+  DHCPv6_OPTION_IA_NA  *OptionPtr                                                = (DHCPv6_OPTION_IA_NA *)Option;
+  UINT32               SearchPattern                                             = SEARCH_PATTERN;
+
+  UINTN   SearchPatternLength = SEARCH_PATTERN_LEN;
+  UINT8   *InnerOptionPtr     = NULL;
+  UINT16  InnerOptionLength   = 0;
+
+  OptionPtr->Header.Code = Dhcp6OptIana;
+  // Inner length exactly equal to OptionLen - DHCP6_MIN_SIZE_OF_IA_NA
+  OptionPtr->Header.Len  = HTONS (DHCP6_SIZE_OF_COMBINED_IAID_T1_T2 + (OptionLength - DHCP6_MIN_SIZE_OF_IA_NA));
+  OptionPtr->Header.IAID = 0x12345678;
+  OptionPtr->T1          = 0x11111111;
+  OptionPtr->T2          = 0x22222222;
+  CopyMem (OptionPtr->InnerOptions, &SearchPattern, SearchPatternLength);
+
+  Status = Dhcp6SeekInnerOptionSafe (
+             Dhcp6OptIana,
+             Option,
+             OptionLength,
+             &InnerOptionPtr,
+             &InnerOptionLength
+             );
+  ASSERT_EQ (Status, EFI_SUCCESS);
+  ASSERT_EQ (InnerOptionLength, (UINT16)(OptionLength - DHCP6_MIN_SIZE_OF_IA_NA));
+  ASSERT_EQ (CompareMem (InnerOptionPtr, &SearchPattern, SearchPatternLength), 0);
+}
+
+// Test Description:
+// This test verifies that Dhcp6SeekInnerOptionSafe accepts an IATA option whose
+// declared inner length exactly matches OptionLen - DHCP6_MIN_SIZE_OF_IA_TA.
+TEST_F (Dhcp6SeekInnerOptionSafeTest, IATAInnerLenExactMatchExpectSuccess) {
+  EFI_STATUS           Status;
+  UINT8                Option[sizeof (DHCPv6_OPTION_IA_TA) + SEARCH_PATTERN_LEN] = { 0 };
+  UINT32               OptionLength                                              = sizeof (Option);
+  DHCPv6_OPTION_IA_TA  *OptionPtr                                                = (DHCPv6_OPTION_IA_TA *)Option;
+  UINT32               SearchPattern                                             = SEARCH_PATTERN;
+
+  UINTN   SearchPatternLength = SEARCH_PATTERN_LEN;
+  UINT8   *InnerOptionPtr     = NULL;
+  UINT16  InnerOptionLength   = 0;
+
+  OptionPtr->Header.Code = Dhcp6OptIata;
+  // Inner length exactly equal to OptionLen - DHCP6_MIN_SIZE_OF_IA_TA
+  OptionPtr->Header.Len  = HTONS ((UINT16)(DHCP6_SIZE_OF_IAID + (OptionLength - DHCP6_MIN_SIZE_OF_IA_TA)));
+  OptionPtr->Header.IAID = 0x12345678;
+  CopyMem (OptionPtr->InnerOptions, &SearchPattern, SearchPatternLength);
+
+  Status = Dhcp6SeekInnerOptionSafe (
+             Dhcp6OptIata,
+             Option,
+             OptionLength,
+             &InnerOptionPtr,
+             &InnerOptionLength
+             );
+  ASSERT_EQ (Status, EFI_SUCCESS);
+  ASSERT_EQ (InnerOptionLength, (UINT16)(OptionLength - DHCP6_MIN_SIZE_OF_IA_TA));
+  ASSERT_EQ (CompareMem (InnerOptionPtr, &SearchPattern, SearchPatternLength), 0);
+}
+
 ////////////////////////////////////////////////////////////////////////
 // Dhcp6SeekStsOption Tests
 ////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Dhcp6SeekInnerOptionSafe trusts the IA option's declared length field but never checks it against OptionLen, so a reply claiming more inner data than the datagram holds makes Dhcp6SeekOption walk past the packet buffer. Bound the declared inner length against the remaining buffer for both IA_NA and IA_TA. Adds host tests for the over-declared case.