### PR TITLE
Fix/qemukernelloader fwcfg size overflow

### DIFF
--- a/OvmfPkg/OvmfPkg.ci.yaml
+++ b/OvmfPkg/OvmfPkg.ci.yaml
@@ -33,7 +33,7 @@
 
     ## options defined .pytool/Plugin/HostUnitTestCompilerPlugin
     "HostUnitTestCompilerPlugin": {
-        "DscPath": "" # Don't support this test
+        "DscPath": "Test/OvmfPkgHostTest.dsc"
     },
 
     ## options defined .pytool/Plugin/CharEncodingCheck
@@ -75,7 +75,7 @@
     ## options defined .pytool/Plugin/HostUnitTestDscCompleteCheck
     "HostUnitTestDscCompleteCheck": {
         "IgnoreInf": [""],
-        "DscPath": "" # Don't support this test
+        "DscPath": "Test/OvmfPkgHostTest.dsc"
     },
 
     ## options defined .pytool/Plugin/GuidCheck

--- a/OvmfPkg/QemuKernelLoaderFsDxe/QemuKernelLoaderFsDxe.c
+++ b/OvmfPkg/QemuKernelLoaderFsDxe/QemuKernelLoaderFsDxe.c
@@ -990,6 +990,7 @@ QemuKernelFetchBlob (
   )
 {
   UINT32       Size;
+  UINT64       TotalSize;
   UINTN        Idx;
   UINT8        *ChunkData;
   KERNEL_BLOB  *Blob;
@@ -1001,7 +1002,13 @@ QemuKernelFetchBlob (
   //   SizeKey != 0   ->  read size from fw_cfg
   //   both are 0     ->  unused entry
   //
-  for (Size = 0, Idx = 0; Idx < ARRAY_SIZE (BlobItems->FwCfgItem); Idx++) {
+  // Accumulate in 64-bit to detect a total that does not fit in UINT32. The
+  // per-item sizes are host-controlled (fw_cfg), and the blob is served from a
+  // single UINT32-sized allocation that is later filled by copying each item's
+  // UINT32 size. Summing into a UINT32 here could wrap and undersize the
+  // allocation, after which the copy loop below would overflow it.
+  //
+  for (TotalSize = 0, Idx = 0; Idx < ARRAY_SIZE (BlobItems->FwCfgItem); Idx++) {
     if ((BlobItems->FwCfgItem[Idx].SizeKey == 0) &&
         (BlobItems->FwCfgItem[Idx].Size == 0))
     {
@@ -1013,8 +1020,21 @@ QemuKernelFetchBlob (
       BlobItems->FwCfgItem[Idx].Size = QemuFwCfgRead32 ();
     }
 
-    Size += BlobItems->FwCfgItem[Idx].Size;
+    TotalSize += BlobItems->FwCfgItem[Idx].Size;
   }
+
+  if (TotalSize > MAX_UINT32) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: total fw_cfg blob size 0x%Lx too large for \"%s\"\n",
+      __func__,
+      TotalSize,
+      BlobItems->Name
+      ));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Size = (UINT32)TotalSize;
 
   if (Size == 0) {
     return EFI_SUCCESS;

--- a/OvmfPkg/QemuKernelLoaderFsDxe/UnitTest/QemuKernelLoaderFsDxeUnitTest.c
+++ b/OvmfPkg/QemuKernelLoaderFsDxe/UnitTest/QemuKernelLoaderFsDxeUnitTest.c
@@ -1,0 +1,294 @@
+/** @file
+  Host-based unit test for QemuKernelLoaderFsDxe blob fetching.
+
+  Exercises QemuKernelFetchBlob() against a programmable fw_cfg stub to
+  reproduce the integer-overflow heap buffer overflow tracked as
+  review-notes D1 (CWE-190 -> CWE-787): the per-blob sizes returned by the
+  (host-controlled) fw_cfg interface are summed into a UINT32 with no overflow
+  check, so a wrapping sum makes the allocation far smaller than the number of
+  bytes the copy loop subsequently writes.
+
+  The test #includes the module under test as a single translation unit so the
+  STATIC QemuKernelFetchBlob() and its STATIC fw_cfg item table are reachable.
+  The fw_cfg, HOB, device-path and blob-verifier dependencies have no
+  host-library instance, so minimal stubs are provided locally; everything else
+  links against the standard host libraries.
+
+  Copyright (c) 2026, Canonical Ltd. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <stdio.h>
+#include <string.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+
+#include <PiDxe.h>
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/QemuFwCfgLib.h>
+#include <Library/HobLib.h>
+#include <Library/DevicePathLib.h>
+#include <Library/BlobVerifierLib.h>
+#include <Library/UnitTestLib.h>
+
+#define UNIT_TEST_APP_NAME     "QemuKernelLoaderFsDxe Unit Tests"
+#define UNIT_TEST_APP_VERSION  "1.0"
+
+//
+// ---------------------------------------------------------------------------
+// Programmable fw_cfg stub.
+//
+// The module reads each blob's size with QemuFwCfgRead32() after selecting the
+// matching size item, then streams the blob bytes with QemuFwCfgReadBytes()
+// after selecting the matching data item. The stub returns a caller-chosen
+// size per item and, on a data read, actually writes that many bytes into the
+// destination buffer so an over-large request overflows the (short) allocation.
+// ---------------------------------------------------------------------------
+//
+STATIC FIRMWARE_CONFIG_ITEM  mSelectedItem;
+STATIC UINT32                mKernelSetupSize;
+STATIC UINT32                mKernelImageSize;
+STATIC UINT64                mTotalBytesRead;
+
+BOOLEAN
+EFIAPI
+QemuFwCfgIsAvailable (
+  VOID
+  )
+{
+  return TRUE;
+}
+
+VOID
+EFIAPI
+QemuFwCfgSelectItem (
+  IN FIRMWARE_CONFIG_ITEM  QemuFwCfgItem
+  )
+{
+  mSelectedItem = QemuFwCfgItem;
+}
+
+UINT32
+EFIAPI
+QemuFwCfgRead32 (
+  VOID
+  )
+{
+  switch (mSelectedItem) {
+    case QemuFwCfgItemKernelSetupSize:
+      return mKernelSetupSize;
+    case QemuFwCfgItemKernelSize:
+      return mKernelImageSize;
+    default:
+      return 0;
+  }
+}
+
+VOID
+EFIAPI
+QemuFwCfgReadBytes (
+  IN UINTN  Size,
+  IN VOID   *Buffer  OPTIONAL
+  )
+{
+  mTotalBytesRead += Size;
+  if (Buffer != NULL) {
+    //
+    // Faithfully transfer the requested number of host bytes. If the module
+    // sized the allocation from a wrapped sum, this write runs past the end of
+    // Buffer and AddressSanitizer reports the heap-buffer-overflow.
+    //
+    SetMem (Buffer, Size, 0xAB);
+  }
+}
+
+//
+// ---------------------------------------------------------------------------
+// Minimal stubs for the remaining dependencies that have no host instance.
+// None are exercised by QemuKernelFetchBlob(); they only need to link because
+// the whole module is compiled as one translation unit.
+// ---------------------------------------------------------------------------
+//
+VOID *
+EFIAPI
+GetFirstGuidHob (
+  IN CONST EFI_GUID  *Guid
+  )
+{
+  return NULL;
+}
+
+VOID *
+EFIAPI
+GetNextGuidHob (
+  IN CONST EFI_GUID  *Guid,
+  IN CONST VOID      *HobStart
+  )
+{
+  return NULL;
+}
+
+BOOLEAN
+EFIAPI
+IsDevicePathValid (
+  IN CONST EFI_DEVICE_PATH_PROTOCOL  *DevicePath,
+  IN       UINTN                     MaxSize
+  )
+{
+  return TRUE;
+}
+
+EFI_STATUS
+EFIAPI
+VerifyBlob (
+  IN  CONST CHAR16  *BlobName,
+  IN  CONST VOID    *Buf,
+  IN  UINT32        BufSize,
+  IN  EFI_STATUS    FetchStatus
+  )
+{
+  return EFI_SUCCESS;
+}
+
+//
+// Pull in the module under test (STATIC QemuKernelFetchBlob + mKernelBlobItems).
+//
+#include "../QemuKernelLoaderFsDxe.c"
+
+/**
+  A host-controlled fw_cfg reports a kernel setup size near UINT32_MAX and a
+  small image size whose sum wraps to a tiny value. Pre-fix, the allocation is
+  sized from the wrapped sum while the copy loop writes the full (un-wrapped)
+  per-item sizes -> heap buffer overflow (caught by ASan). Post-fix,
+  QemuKernelFetchBlob() must reject the input and append no blob.
+**/
+STATIC
+UNIT_TEST_STATUS
+EFIAPI
+KernelSizeSumOverflowIsRejected (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  EFI_STATUS  Status;
+
+  // Reset module state touched by the function under test.
+  mKernelBlobs    = NULL;
+  mKernelBlobCount = 0;
+  mTotalBlobBytes = 0;
+  mTotalBytesRead = 0;
+
+  // 0xFFFFFF00 + 0x200 wraps (UINT32) to 0x100.
+  mKernelSetupSize = 0xFFFFFF00;
+  mKernelImageSize = 0x00000200;
+
+  Status = QemuKernelFetchBlob (&mKernelBlobItems[0]);
+
+  //
+  // Reaching this point means no overflow occurred (post-fix). The contract is:
+  // the malformed sizes are rejected and no blob is recorded.
+  //
+  UT_ASSERT_TRUE (EFI_ERROR (Status));
+  UT_ASSERT_EQUAL (mKernelBlobCount, 0);
+  UT_ASSERT_TRUE (mKernelBlobs == NULL);
+
+  return UNIT_TEST_PASSED;
+}
+
+/**
+  Sanity case: a well-formed kernel blob (setup + image) must be fetched
+  successfully and recorded with the summed size.
+**/
+STATIC
+UNIT_TEST_STATUS
+EFIAPI
+WellFormedKernelBlobIsFetched (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  EFI_STATUS  Status;
+
+  mKernelBlobs    = NULL;
+  mKernelBlobCount = 0;
+  mTotalBlobBytes = 0;
+  mTotalBytesRead = 0;
+
+  mKernelSetupSize = 0x1000;
+  mKernelImageSize = 0x4000;
+
+  Status = QemuKernelFetchBlob (&mKernelBlobItems[0]);
+
+  UT_ASSERT_NOT_EFI_ERROR (Status);
+  UT_ASSERT_EQUAL (mKernelBlobCount, 1);
+  UT_ASSERT_TRUE (mKernelBlobs != NULL);
+  UT_ASSERT_EQUAL (mKernelBlobs->Size, 0x5000);
+  UT_ASSERT_EQUAL (mTotalBytesRead, 0x5000);
+
+  // The fetched blob was prepended to the module's global list; free it so the
+  // test run is leak-clean (the module itself never frees fetched blobs).
+  FreePool (mKernelBlobs->Data);
+  FreePool (mKernelBlobs);
+  mKernelBlobs = NULL;
+
+  return UNIT_TEST_PASSED;
+}
+
+/**
+  Build and run the test suite.
+**/
+STATIC
+EFI_STATUS
+EFIAPI
+UnitTestingEntry (
+  VOID
+  )
+{
+  EFI_STATUS                  Status;
+  UNIT_TEST_FRAMEWORK_HANDLE  Framework;
+  UNIT_TEST_SUITE_HANDLE      FetchTests;
+
+  Framework = NULL;
+
+  DEBUG ((DEBUG_INFO, "%a v%a\n", UNIT_TEST_APP_NAME, UNIT_TEST_APP_VERSION));
+
+  Status = InitUnitTestFramework (&Framework, UNIT_TEST_APP_NAME, gEfiCallerBaseName, UNIT_TEST_APP_VERSION);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "Failed in InitUnitTestFramework. Status = %r\n", Status));
+    goto EXIT;
+  }
+
+  Status = CreateUnitTestSuite (&FetchTests, Framework, "QemuKernelFetchBlob Tests", "QemuKernelLoaderFsDxe.Fetch", NULL, NULL);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "Failed in CreateUnitTestSuite for FetchTests\n"));
+    Status = EFI_OUT_OF_RESOURCES;
+    goto EXIT;
+  }
+
+  AddTestCase (FetchTests, "Well-formed kernel blob is fetched", "WellFormed", WellFormedKernelBlobIsFetched, NULL, NULL, NULL);
+  AddTestCase (FetchTests, "Overflowing size sum is rejected", "SizeOverflow", KernelSizeSumOverflowIsRejected, NULL, NULL, NULL);
+
+  Status = RunAllTestSuites (Framework);
+
+EXIT:
+  if (Framework) {
+    FreeUnitTestFramework (Framework);
+  }
+
+  return Status;
+}
+
+/**
+  Standard POSIX C entry point for host based unit test execution.
+**/
+int
+main (
+  int   argc,
+  char  *argv[]
+  )
+{
+  return UnitTestingEntry ();
+}

--- a/OvmfPkg/QemuKernelLoaderFsDxe/UnitTest/QemuKernelLoaderFsDxeUnitTest.inf
+++ b/OvmfPkg/QemuKernelLoaderFsDxe/UnitTest/QemuKernelLoaderFsDxeUnitTest.inf
@@ -1,0 +1,48 @@
+## @file
+# Host-based unit test for QemuKernelLoaderFsDxe blob fetching.
+#
+# Copyright (c) 2026, Canonical Ltd. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010006
+  BASE_NAME                      = QemuKernelLoaderFsDxeUnitTest
+  FILE_GUID                      = 6E2D9C7A-1F0B-4B3E-9C2A-7C5E1A4D8B30
+  MODULE_TYPE                    = HOST_APPLICATION
+  VERSION_STRING                 = 1.0
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  QemuKernelLoaderFsDxeUnitTest.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  OvmfPkg/OvmfPkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  BaseMemoryLib
+  DebugLib
+  MemoryAllocationLib
+  PrintLib
+  UnitTestLib
+  UefiBootServicesTableLib
+  UefiRuntimeServicesTableLib
+
+[Guids]
+  gEfiIgvmDataHobGuid
+  gEfiFileInfoGuid
+  gEfiFileSystemInfoGuid
+  gEfiFileSystemVolumeLabelInfoIdGuid
+
+[Protocols]
+  gEfiDevicePathProtocolGuid
+  gEfiLoadFile2ProtocolGuid
+  gEfiSimpleFileSystemProtocolGuid

--- a/OvmfPkg/Test/OvmfPkgHostTest.dsc
+++ b/OvmfPkg/Test/OvmfPkgHostTest.dsc
@@ -1,0 +1,29 @@
+## @file
+# OvmfPkg DSC file used to build host-based unit tests.
+#
+# Copyright (c) 2026, Canonical Ltd. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  PLATFORM_NAME           = OvmfPkgHostTest
+  PLATFORM_GUID           = 7C2A5F3D-6B41-4E8A-9F0C-2D1B8E4A6C57
+  PLATFORM_VERSION        = 0.1
+  DSC_SPECIFICATION       = 0x00010005
+  OUTPUT_DIRECTORY        = Build/OvmfPkg/HostTest
+  SUPPORTED_ARCHITECTURES = IA32|X64
+  BUILD_TARGETS           = NOOPT
+  SKUID_IDENTIFIER        = DEFAULT
+
+!include UnitTestFrameworkPkg/UnitTestFrameworkPkgHost.dsc.inc
+
+[LibraryClasses]
+  BaseMemoryLib|MdePkg/Library/BaseMemoryLib/BaseMemoryLib.inf
+  PrintLib|MdePkg/Library/BasePrintLib/BasePrintLib.inf
+  UefiRuntimeServicesTableLib|MdePkg/Library/UefiRuntimeServicesTableLib/UefiRuntimeServicesTableLib.inf
+
+[Components]
+  #
+  # Build OvmfPkg HOST_APPLICATION Tests
+  #
+  OvmfPkg/QemuKernelLoaderFsDxe/UnitTest/QemuKernelLoaderFsDxeUnitTest.inf


### PR DESCRIPTION
# Description

 QemuKernelFetchBlob() in OvmfPkg/QemuKernelLoaderFsDxe reads the kernel blob's component sizes (kernel setup size + kernel image size) from QEMU fw_cfg, which is host-controlled, and sums them into a UINT32 with no overflow check. The blob is then served from a single UINT32-sized AllocatePool(), while the copy loop streams each component's full UINT32 size into that buffer. A host that reports, e.g., setup size 0xFFFFFF00 and image size 0x200 makes the UINT32 sum wrap to 0x100, so a 256-byte allocation is subsequently written with ~4 GiB of attacker-controlled bytes: a controllable heap buffer overflow. The fetch runs before VerifyBlob(), so the SEV/TDX measured-boot hash gate does not cover it; on confidential-compute platforms (host outside the guest TCB) this is a guest integrity break.

  This PR fixes the overflow by accumulating the component sizes in a UINT64 and rejecting any total that does not fit in UINT32 (EFI_INVALID_PARAMETER) before allocating, so the allocation can no longer be undersized by a wrapping sum.

  It also adds a host-based unit test that drives QemuKernelFetchBlob() through a programmable fw_cfg stub. OvmfPkg had no host-based unit test platform, so the PR introduces OvmfPkg/Test/OvmfPkgHostTest.dsc and wires it into CI via the HostUnitTestCompilerPlugin and HostUnitTestDscCompleteCheck plugins.


- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [x] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [x] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Built and ran the new host-based unit test on Linux/GCC X64 with the UnitTestFrameworkPkg host DSC (AddressSanitizer enabled by default):

     build -p OvmfPkg/Test/OvmfPkgHostTest.dsc -a X64 -t GCC -b NOOPT
     Build/OvmfPkg/HostTest/NOOPT_GCC/X64/QemuKernelLoaderFsDxeUnitTest

Two cases run: a well-formed kernel blob is fetched correctly, and a size sum that overflows UINT32 is rejected. With the fix applied both cases pass. To confirm the test is meaningful, the fix was reverted while keeping the test: the overflow case then reproduces the heap buffer overflow under AddressSanitizer (heap-buffer-overflow WRITE in InternalMemSetMem, allocation undersized to 256 bytes), while the well-formed case still passes.
## Integration Instructions

N/A
