### PR TITLE
MdeModulePkg/ReportStatusCodeRouter: Prevent recursive entry in PEI phase

### DIFF
--- a/MdeModulePkg/Universal/ReportStatusCodeRouter/Pei/ReportStatusCodeRouterPei.c
+++ b/MdeModulePkg/Universal/ReportStatusCodeRouter/Pei/ReportStatusCodeRouterPei.c
@@ -33,6 +33,38 @@ EFI_PEI_PPI_DESCRIPTOR  mStatusCodePpiList[] = {
   }
 };
 
+//
+// GUID for the Report Status Code Router nest status HOB.
+// This HOB stores the reentrant lock to prevent recursive calls in PEI phase.
+//
+EFI_GUID  mRscRouterNestStatusHobGuid = RSC_ROUTER_NEST_STATUS_HOB_GUID;
+
+typedef struct {
+  UINT32    NestStatus;
+} RSC_ROUTER_NEST_STATUS_HOB;
+
+/**
+  Check the RSC Router nest status HOB.
+
+  @return  Pointer to the RSC_ROUTER_NEST_STATUS_HOB data, or NULL on failure.
+
+**/
+STATIC
+RSC_ROUTER_NEST_STATUS_HOB *
+CheckNestStatusHob (
+  VOID
+  )
+{
+  EFI_HOB_GUID_TYPE  *GuidHob;
+
+  GuidHob = GetFirstGuidHob (&mRscRouterNestStatusHobGuid);
+  if (GuidHob != NULL) {
+    return GET_GUID_HOB_DATA (GuidHob);
+  }
+
+  return NULL;
+}
+
 /**
   Worker function to create one memory status code GUID'ed HOB,
   using PacketIndex to identify the packet.
@@ -241,6 +273,17 @@ ReportDispatcher (
   EFI_PEI_RSC_HANDLER_CALLBACK  *CallbackEntry;
   UINTN                         *NumberOfEntries;
   UINTN                         Index;
+  RSC_ROUTER_NEST_STATUS_HOB    *NestStatusHob;
+
+  //
+  // Use atom operation to avoid the reentant of report.
+  // If current status is not zero, then the function is reentrancy.
+  //
+  NestStatusHob = CheckNestStatusHob ();
+
+  if ((NestStatusHob != NULL) && ((InterlockedCompareExchange32 (&NestStatusHob->NestStatus, 0, 1) == 1))) {
+    return EFI_DEVICE_ERROR;
+  }
 
   Hob.Raw = GetFirstGuidHob (&gStatusCodeCallbackGuid);
   while (Hob.Raw != NULL) {
@@ -261,6 +304,13 @@ ReportDispatcher (
 
     Hob.Raw = GET_NEXT_HOB (Hob);
     Hob.Raw = GetNextGuidHob (&gStatusCodeCallbackGuid, Hob.Raw);
+  }
+
+  //
+  // Restore the nest status of report
+  //
+  if (NestStatusHob != NULL) {
+    InterlockedCompareExchange32 (&NestStatusHob->NestStatus, 1, 0);
   }
 
   return EFI_SUCCESS;
@@ -285,11 +335,22 @@ GenericStatusCodePeiEntry (
   IN CONST EFI_PEI_SERVICES     **PeiServices
   )
 {
-  EFI_STATUS                 Status;
-  EFI_PEI_PPI_DESCRIPTOR     *OldDescriptor;
-  EFI_PEI_PROGRESS_CODE_PPI  *OldStatusCodePpi;
+  EFI_STATUS                  Status;
+  EFI_PEI_PPI_DESCRIPTOR      *OldDescriptor;
+  EFI_PEI_PROGRESS_CODE_PPI   *OldStatusCodePpi;
+  RSC_ROUTER_NEST_STATUS_HOB  *NestStatusHob;
 
   CreateRscHandlerCallbackPacket ();
+
+  //
+  // Build NestStatus HOB for installing PPIs to avoid recursive calls.
+  //
+  if (GetFirstGuidHob (&mRscRouterNestStatusHobGuid) == NULL) {
+    NestStatusHob = BuildGuidHob (&mRscRouterNestStatusHobGuid, sizeof (RSC_ROUTER_NEST_STATUS_HOB));
+    if (NestStatusHob != NULL) {
+      NestStatusHob->NestStatus = 0;
+    }
+  }
 
   //
   // Install Report Status Code Handler PPI

--- a/MdeModulePkg/Universal/ReportStatusCodeRouter/Pei/ReportStatusCodeRouterPei.h
+++ b/MdeModulePkg/Universal/ReportStatusCodeRouter/Pei/ReportStatusCodeRouterPei.h
@@ -17,6 +17,11 @@
 #include <Library/HobLib.h>
 #include <Library/PeiServicesLib.h>
 #include <Library/PeimEntryPoint.h>
+#include <Library/SynchronizationLib.h>
+
+#define RSC_ROUTER_NEST_STATUS_HOB_GUID  { \
+    0x7a1a8e9e, 0x2c3f, 0x4a5b, { 0x8d, 0x1c, 0x3e, 0x72, 0xa9, 0x1f, 0x6b, 0x04 } \
+  }
 
 /**
   Register the callback function for ReportStatusCode() notification.

--- a/MdeModulePkg/Universal/ReportStatusCodeRouter/Pei/ReportStatusCodeRouterPei.inf
+++ b/MdeModulePkg/Universal/ReportStatusCodeRouter/Pei/ReportStatusCodeRouterPei.inf
@@ -37,6 +37,7 @@
   PeiServicesLib
   DebugLib
   HobLib
+  SynchronizationLib
 
 [Guids]
   ## PRODUCES ## HOB


### PR DESCRIPTION
MdeModulePkg/ReportStatusCodeRouter: Prevent recursive entry in PEI phase

Prevent recursive invocation of the PEI Report Status Code (RSC) Router that can lead
to system hang or unexpected re-entrancy behavior during early boot. The defect
was observed when PEI modules reported status codes while the router was already
processing a previous request.

This patch aligns PEI behavior with the robust RSC routing mechanisms already used
in DXE and Runtime phases by adding a lightweight recursion guard to the PEI router.
This ensures consistent behavior across boot stages and improves early-boot
stability.

Signed-off-by: Jared Pan <jared.pan@dell.com>

# Description

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

- Added debug messages in the PEI RSC router to trace entry and exit paths, as well as to detect re-entrant invocation.
- Created test scenarios where PEI modules intentionally report status codes while the router is already processing a previous request.
- Verified through debug logs that recursive entry into the router is prevented by the newly added guard.
- Confirmed that no duplicate or nested router invocation occurs during stress testing.
- Observed stable system boot behavior with no hangs or unexpected re-entrancy issues in early boot.
- Ensured that normal status code reporting flow remains unaffected when no recursion occurs.

## Integration Instructions

N/A
