### PR TITLE
BaseTools/Source/Python: Add -noattr to capsule signing openssl commands

### DIFF
--- a/BaseTools/Source/Python/Capsule/GenerateCapsule.py
+++ b/BaseTools/Source/Python/Capsule/GenerateCapsule.py
@@ -192,7 +192,7 @@ def SignPayloadOpenSsl (Payload, ToolPath, SignerPrivateCertFile, OtherPublicCer
         ToolPath = ''
     Command = ''
     Command = Command + '"{Path}" '.format (Path = os.path.join (ToolPath, 'openssl'))
-    Command = Command + 'smime -sign -binary -outform DER -md {HashAlgorithm} '.format (HashAlgorithm = HashAlgorithm)
+    Command = Command + 'smime -sign -binary -noattr -outform DER -md {HashAlgorithm} '.format (HashAlgorithm = HashAlgorithm)
     Command = Command + '-signer "{Private}" -certfile "{Public}" '.format (Private = SignerPrivateCertFile, Public = OtherPublicCertFile)
     Command = Command + '-out "{Output}"'.format (Output = TempSignatureFilePath)
     if Verbose:

--- a/BaseTools/Source/Python/Pkcs7Sign/Pkcs7Sign.py
+++ b/BaseTools/Source/Python/Pkcs7Sign/Pkcs7Sign.py
@@ -201,7 +201,7 @@ if __name__ == '__main__':
     #
     # Sign the input file using the specified private key and capture signature from STDOUT
     #
-    Process = subprocess.Popen('%s smime -sign -binary -signer "%s" -outform DER -md sha256 -certfile "%s"' % (OpenSslCommand, args.SignerPrivateCertFileName, args.OtherPublicCertFileName), stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+    Process = subprocess.Popen('%s smime -sign -binary -noattr -signer "%s" -outform DER -md sha256 -certfile "%s"' % (OpenSslCommand, args.SignerPrivateCertFileName, args.OtherPublicCertFileName), stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
     Signature = Process.communicate(input=FullInputFileBuffer)[0]
     if Process.returncode != 0:
       sys.exit(Process.returncode)

--- a/BaseTools/Source/Python/Pkcs7Sign/Readme.md
+++ b/BaseTools/Source/Python/Pkcs7Sign/Readme.md
@@ -144,7 +144,7 @@ NOTE: User MUST set a UNIQUE "Common Name" on the different certificate
 1) Sign a Binary File to generate a detached PKCS7 signature:
 
     ```cmd
-    openssl smime -sign -binary -signer TestCert.pem -outform DER -md sha256 -certfile TestSub.pub.pem -out test.bin.p7 -in test.bin
+    openssl smime -sign -binary -noattr -signer TestCert.pem -outform DER -md sha256 -certfile TestSub.pub.pem -out test.bin.p7 -in test.bin
     ```
 
 2) Verify PKCS7 Signature of a Binary File:


### PR DESCRIPTION
# Description

This makes capsule PKCS#7 signatures reproducible.

openssl smime -sign embeds a signingTime signed attribute (current UTCTime) by default. Because the attribute is inside the signed digest, the resulting RSA signature differs on every invocation even when the key and payload are identical, breaking reproducible builds of signed FMP capsules.

Pass -noattr to drop all signed attributes from the SignerInfo. The signature is then computed directly over the content, producing byte-identical output across runs.

The FMP update path is unaffected: FmpAuthenticationLibPkcs7 calls Pkcs7Verify() without extracting signed attributes, and rollback protection uses FwVersion / LowestSupportedVersion in FMP_PAYLOAD_HEADER plus the auth header MonotonicCount, not signingTime. signingTime is only consumed by DxeImageVerificationLib for Secure Boot dbt checks on PE/COFF images, which is a separate code path.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

A coreboot image with edk2 as payload was built, and then a capsule was generated multiple times with multiple-second pauses between tool calls. SHA256 sums of the generated capsules were compared to confirm all capsules were identical.

## Integration Instructions

N/A