### PR TITLE
Global: Remove redundant section name in inf files

### DIFF
--- a/ArmPkg/Library/ArmStandaloneMmCoreEntryPoint/ArmStandaloneMmCoreEntryPoint.inf
+++ b/ArmPkg/Library/ArmStandaloneMmCoreEntryPoint/ArmStandaloneMmCoreEntryPoint.inf
@@ -35,9 +35,6 @@
   StandaloneMmPkg/StandaloneMmPkg.dec
   UefiCpuPkg/UefiCpuPkg.dec
 
-[Packages]
-  ArmPkg/ArmPkg.dec
-
 [LibraryClasses]
   BaseLib
   DebugLib

--- a/ArmPlatformPkg/Library/PL011SerialPortLib/PL011SerialPortLib.inf
+++ b/ArmPlatformPkg/Library/PL011SerialPortLib/PL011SerialPortLib.inf
@@ -33,8 +33,6 @@
 [Pcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdSerialRegisterBase
   gEfiMdeModulePkgTokenSpaceGuid.PcdSerialUseHardwareFlowControl
-
-[Pcd]
   gEfiMdePkgTokenSpaceGuid.PcdUartDefaultBaudRate
   gEfiMdePkgTokenSpaceGuid.PcdUartDefaultDataBits
   gEfiMdePkgTokenSpaceGuid.PcdUartDefaultParity

--- a/MdePkg/Library/BaseMemoryLibOptDxe/BaseMemoryLibOptDxe.inf
+++ b/MdePkg/Library/BaseMemoryLibOptDxe/BaseMemoryLibOptDxe.inf
@@ -25,9 +25,6 @@
 #  VALID_ARCHITECTURES           = IA32 X64 AARCH64
 #
 
-[Sources]
-  MemLibInternals.h
-
 [Sources.Ia32]
   Ia32/ScanMem64.nasm
   Ia32/ScanMem32.nasm
@@ -77,6 +74,7 @@
   AArch64/MemLibGuid.c
 
 [Sources]
+  MemLibInternals.h
   ScanMem64Wrapper.c
   ScanMem32Wrapper.c
   ScanMem16Wrapper.c

--- a/MdePkg/Library/DynamicStackCookieEntryPointLib/StandaloneMmCoreEntryPoint.inf
+++ b/MdePkg/Library/DynamicStackCookieEntryPointLib/StandaloneMmCoreEntryPoint.inf
@@ -24,8 +24,6 @@
 
 [Sources.X64]
   StandaloneMmCore/X64/StandaloneMmCoreEntryPoint.c
-
-[Sources.X64]
   X64/DynamicCookieGcc.nasm   | GCC
   X64/DynamicCookieMsvc.nasm  | MSFT
 

--- a/OvmfPkg/Library/XenHypercallLib/XenHypercallLib.inf
+++ b/OvmfPkg/Library/XenHypercallLib/XenHypercallLib.inf
@@ -23,14 +23,10 @@
 
 [Sources.X64]
   X86XenHypercall.c
-
-[Sources.X64]
   X64/hypercall.nasm
 
 [Sources.AARCH64]
   ArmXenHypercall.c
-
-[Sources.AARCH64]
   AArch64/Hypercall.S
 
 [Sources]

--- a/SecurityPkg/RandomNumberGenerator/RngDxe/RngDxe.inf
+++ b/SecurityPkg/RandomNumberGenerator/RngDxe/RngDxe.inf
@@ -44,8 +44,6 @@
 [Sources.AARCH64]
   ArmRngDxe.c
   ArmTrng.c
-
-[Sources.AARCH64]
   AArch64/AArch64Algo.c
 
 [Packages]

--- a/UefiCpuPkg/Library/SecPeiDxeTimerLibUefiCpu/SecPeiDxeTimerLibUefiCpu.inf
+++ b/UefiCpuPkg/Library/SecPeiDxeTimerLibUefiCpu/SecPeiDxeTimerLibUefiCpu.inf
@@ -43,8 +43,6 @@
 
 [LibraryClasses]
   BaseLib
-
-[LibraryClasses]
   PcdLib
   DebugLib
   LocalApicLib


### PR DESCRIPTION
# Description

Some section names such as [Sources], [Packages], and [Pcd] may appear twice in INF files. Although the INF specification does not require section names to be unique, removing the redundant ones makes the file more concise.

No functional changes.

## How This Was Tested

Pass CI check.

## Integration Instructions

N/A
