### PR TITLE
NetworkPkg/IScsiDxe: bound value length in IScsiBuildKeyValueList

### DIFF
--- a/NetworkPkg/IScsiDxe/IScsiProto.c
+++ b/NetworkPkg/IScsiDxe/IScsiProto.c
@@ -1922,7 +1922,7 @@ IScsiBuildKeyValueList (
 
     KeyValuePair->Value = Data;
 
-    Status = SafeUint32Add ((UINT32)AsciiStrLen (KeyValuePair->Value), 1, &Result);
+    Status = SafeUint32Add ((UINT32)AsciiStrnLenS (KeyValuePair->Value, Len), 1, &Result);
     if (EFI_ERROR (Status)) {
       DEBUG ((DEBUG_ERROR, "%a Memory Overflow is Detected.\n", __func__));
       FreePool (KeyValuePair);


### PR DESCRIPTION
Noticed IScsiBuildKeyValueList runs AsciiStrLen on the value pointer before checking it against the remaining data-segment bytes. A login or CHAP response whose last key=value isn't NUL-terminated makes the scan read past the received PDU buffer, since the segment copied off the wire (AllocatePool(Len) + NetbufQueCopy) carries no terminator. Bound it with AsciiStrnLenS(Value, Len) so the scan stays inside the segment and the existing SafeUint32Sub rejects an unterminated value.