### PR TITLE
NetworkPkg/Ip6Dxe: Enforce RFC 4861 8-octet minimum in ND redirect parse

### DIFF
--- a/NetworkPkg/Ip6Dxe/Ip6Nd.c
+++ b/NetworkPkg/Ip6Dxe/Ip6Nd.c
@@ -2511,10 +2511,15 @@ Ip6ProcessRedirect (
   // Check the options. The only interested option here is the target-link layer
   // address option.
   //
+  // Per RFC 4861 Section 4.6, every ND option length is in units of 8 octets,
+  // so the smallest valid option is 8 bytes (Length field = 1). Guard with
+  // ">= 8" instead of "> 0" to avoid parsing malformed trailing fragments
+  // that cannot form a complete option.
+  //
   Length          = Packet->TotalSize - 40;
   Option          = (UINT8 *)(IcmpDest + 1);
   LinkLayerOption = NULL;
-  while (Length > 0) {
+  while (Length >= 8) {
     switch (*Option) {
       case Ip6OptionEtherTarget:
 

--- a/NetworkPkg/Ip6Dxe/Ip6Option.c
+++ b/NetworkPkg/Ip6Dxe/Ip6Option.c
@@ -173,10 +173,12 @@ Ip6IsNDOptionValid (
 
   //
   // RFC 4861 states that Neighbor Discovery packet can contain zero or more
-  // options. Start processing the options if at least Type + Length fields
-  // fit within the input buffer.
+  // options. RFC 4861 Section 4.6 states that every ND option length is in
+  // units of 8 octets, so the smallest valid option is 8 bytes (Length
+  // field = 1). Only enter the loop when at least one complete minimum-size
+  // option can exist in the remaining buffer.
   //
-  while (Offset + sizeof (IP6_OPTION_HEADER) - 1 < OptionLen) {
+  while (Offset + 8 <= (UINT32)OptionLen) {
     OptionHeader = (IP6_OPTION_HEADER *)(Option + Offset);
     Length       = (UINT16)OptionHeader->Length * 8;
 
@@ -234,7 +236,12 @@ Ip6IsNDOptionValid (
     Offset += Length;
   }
 
-  return TRUE;
+  //
+  // Per RFC 4861 Section 4.6, a well-formed option region is an exact
+  // integer multiple of 8 octets. If any bytes remain after the loop,
+  // the option region contains a malformed trailing fragment.
+  //
+  return (Offset == (UINT32)OptionLen);
 }
 
 /**


### PR DESCRIPTION
NetworkPkg/Ip6Dxe: Enforce RFC 4861 8-octet minimum in ND redirect parse

RFC 4861 Section 4.6 defines every Neighbor Discovery option
length in units of 8 octets. Therefore, valid ND option
regions must be consumed as an exact multiple of 8 bytes, and
trailing 1-7 byte fragments are malformed.

This change hardens ND option parsing in two place:
01. Ip6ProcessRedirect() in Ip6Nd.c
- Change loop guard from:
   while (Length > 0)
  to
   while (Length >= 8)
02. Ip6IsNDOptionValid() in Ip6Option.c
- Change loop guard from:
   while (Offset + sizeof (IP6_OPTION_HEADER) -1 < OptionLen)
  to
   while (Offset + 8 <= (UINT32)OptionLen)
- Change final return from:
   return TRUE;
  to
   return (Offset == (UINT32)OptionLen);

Together these updates reject malformed trailing fragments
and preserve behavior for well-formed ND option regions.

Signed-off-by: Mark Wu <mark.wu1@dell.com>

