### PR TITLE
MdeModulePkg: Fix LoadImage when NULL SourceBuffer and FilePath

### DIFF
--- a/MdeModulePkg/Core/Dxe/Image/Image.c
+++ b/MdeModulePkg/Core/Dxe/Image/Image.c
@@ -1210,7 +1210,7 @@ CoreLoadImageCommon (
     }
   } else {
     if (FilePath == NULL) {
-      return EFI_INVALID_PARAMETER;
+      return EFI_NOT_FOUND;
     }
 
     //


### PR DESCRIPTION
# Description

Section 7.4.1 of the UEFI Specification 2.11 says
EFI_BOOT_SERVICES.LoadImage() should return EFI_NOT_FOUND if both SourceBuffer and DevicePath are NULL.

This is checked with the UEFI SCT test
'BS.LoadImage - ConsistencyTestCheckpoint2'.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - The UEFI SCT verifies this.

## How This Was Tested

I ran the SCT and verified that the test now passes.

## Integration Instructions

N/A
