### PR TITLE
MdeModulePkg/UsbBusPei: Use dynamic buffer for USB configuration data

### DIFF
--- a/MdeModulePkg/Bus/Usb/UsbBusPei/UsbPeim.c
+++ b/MdeModulePkg/Bus/Usb/UsbBusPei/UsbPeim.c
@@ -3,6 +3,7 @@ The module to produce Usb Bus PPI.
 
 Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.<BR>
 Copyright (c) 2006 - 2018, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2026 Dell Inc. All rights reserved.<BR>
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -722,7 +723,7 @@ PeiUsbGetAllConfiguration (
   )
 {
   EFI_STATUS                 Status;
-  EFI_USB_CONFIG_DESCRIPTOR  *ConfigDesc;
+  EFI_USB_CONFIG_DESCRIPTOR  ConfigDescHeader;
   PEI_USB_IO_PPI             *UsbIoPpi;
   UINT16                     ConfigDescLength;
   UINT8                      *Ptr;
@@ -735,7 +736,7 @@ PeiUsbGetAllConfiguration (
   UsbIoPpi = &PeiUsbDevice->UsbIoPpi;
 
   //
-  // First get its 4-byte configuration descriptor
+  // First get its 4-byte configuration descriptor to learn TotalLength.
   //
   Status = PeiUsbGetDescriptor (
              PeiServices,
@@ -743,7 +744,7 @@ PeiUsbGetAllConfiguration (
              (USB_DT_CONFIG << 8), // Value
              0,                    // Index
              4,                    // Length
-             PeiUsbDevice->ConfigurationData
+             (UINT8 *)&ConfigDescHeader
              );
 
   if (EFI_ERROR (Status)) {
@@ -753,21 +754,18 @@ PeiUsbGetAllConfiguration (
 
   MicroSecondDelay (USB_GET_CONFIG_DESCRIPTOR_STALL);
 
-  ConfigDesc       = (EFI_USB_CONFIG_DESCRIPTOR *)PeiUsbDevice->ConfigurationData;
-  ConfigDescLength = ConfigDesc->TotalLength;
+  ConfigDescLength = ConfigDescHeader.TotalLength;
 
   //
   // Reject if TotalLength even cannot cover itself.
   //
-  if (ConfigDescLength < OFFSET_OF (EFI_USB_CONFIG_DESCRIPTOR, TotalLength) + sizeof (ConfigDesc->TotalLength)) {
+  if (ConfigDescLength < OFFSET_OF (EFI_USB_CONFIG_DESCRIPTOR, TotalLength) + sizeof (ConfigDescHeader.TotalLength)) {
     return EFI_DEVICE_ERROR;
   }
 
-  //
-  // Reject if TotalLength exceeds the PeiUsbDevice->ConfigurationData.
-  //
-  if (ConfigDescLength > sizeof (PeiUsbDevice->ConfigurationData)) {
-    return EFI_DEVICE_ERROR;
+  Status = PeiServicesAllocatePool (ConfigDescLength, (VOID **)&PeiUsbDevice->ConfigurationData);
+  if (EFI_ERROR (Status)) {
+    return Status;
   }
 
   //

--- a/MdeModulePkg/Bus/Usb/UsbBusPei/UsbPeim.h
+++ b/MdeModulePkg/Bus/Usb/UsbBusPei/UsbPeim.h
@@ -2,6 +2,7 @@
 Usb Peim definition.
 
 Copyright (c) 2006 - 2018, Intel Corporation. All rights reserved. <BR>
+Copyright (c) 2026 Dell Inc. All rights reserved.<BR>
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -50,7 +51,6 @@ typedef struct {
   UINT8                                 DownStreamPortNo;
   UINTN                                 AllocateAddress;
   PEI_USB2_HOST_CONTROLLER_PPI          *Usb2HcPpi;
-  UINT8                                 ConfigurationData[1024];
   EFI_USB_CONFIG_DESCRIPTOR             *ConfigDesc;
   EFI_USB_INTERFACE_DESCRIPTOR          *InterfaceDesc;
   EFI_USB_INTERFACE_DESCRIPTOR          *InterfaceDescList[MAX_INTERFACE];
@@ -58,6 +58,7 @@ typedef struct {
   EFI_USB_ENDPOINT_DESCRIPTOR           *EndpointDescList[MAX_INTERFACE][MAX_ENDPOINT];
   EFI_USB2_HC_TRANSACTION_TRANSLATOR    Translator;
   UINT8                                 Tier;
+  UINT8                                 *ConfigurationData;
 } PEI_USB_DEVICE;
 
 #define PEI_USB_DEVICE_FROM_THIS(a)  CR (a, PEI_USB_DEVICE, UsbIoPpi, PEI_USB_DEVICE_SIGNATURE)


### PR DESCRIPTION
USB devices whose configuration descriptor TotalLength exceeds 1024 bytes (e.g. IR cameras with large descriptor tables) previously hit an EFI_DEVICE_ERROR hard-limit and failed to enumerate in PEI.

Replace the fixed array with a UINT8 * pointer and dynamically allocate the exact amount of memory required via
PeiServicesAllocatePool() after the TotalLength is learned from the initial 4-byte descriptor probe. The minimum-size sanity check (TotalLength must cover its own header) is preserved; the 1024-byte upper-bound check is removed.

# Description

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Test in real hardware.

## Integration Instructions

N/A.
