### PR TITLE
NvmExpressDxe: Add PcdNvmeGenericTimeout to configure timeout per platform

### DIFF
--- a/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpress.h
+++ b/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpress.h
@@ -106,9 +106,9 @@ extern EFI_DRIVER_SUPPORTED_EFI_VERSION_PROTOCOL  gNvmExpressDriverSupportedEfiV
 #define NVME_CONTROLLER_ID  0
 
 //
-// Time out value for Nvme transaction execution
+// Time out value for Nvme transaction execution (in seconds, from PcdNvmeGenericTimeout).
 //
-#define NVME_GENERIC_TIMEOUT  EFI_TIMER_PERIOD_SECONDS (5)
+#define NVME_GENERIC_TIMEOUT  EFI_TIMER_PERIOD_SECONDS (FixedPcdGet32 (PcdNvmeGenericTimeout))
 
 //
 // Nvme async transfer timer interval, set by experience.

--- a/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressDxe.inf
+++ b/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressDxe.inf
@@ -77,6 +77,9 @@
   gMediaSanitizeProtocolGuid                  ## PRODUCES
   gEfiResetNotificationProtocolGuid           ## CONSUMES
 
+[FixedPcd]
+  gEfiMdeModulePkgTokenSpaceGuid.PcdNvmeGenericTimeout            ## CONSUMES
+
 # [Event]
 # EVENT_TYPE_RELATIVE_TIMER ## SOMETIMES_CONSUMES
 #

--- a/MdeModulePkg/Bus/Pci/NvmExpressDxe/UnitTest/MediaSanitizeUnitTestHost.inf
+++ b/MdeModulePkg/Bus/Pci/NvmExpressDxe/UnitTest/MediaSanitizeUnitTestHost.inf
@@ -35,3 +35,7 @@
   UnitTestLib
   PrintLib
   MemoryAllocationLib
+  PcdLib
+
+[FixedPcd]
+  gEfiMdeModulePkgTokenSpaceGuid.PcdNvmeGenericTimeout            ## CONSUMES

--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -1230,6 +1230,10 @@
   # @ValidRange 0x80000001 | 1 - 255
   gEfiMdeModulePkgTokenSpaceGuid.PcdUsbNetworkPeriodicTimerInterval|16|UINT8|0x30001063
 
+  ## Timeout, in seconds, used for generic NVMe transactions issued by NvmExpressDxe.
+  # @Prompt NVMe generic command timeout (seconds).
+  gEfiMdeModulePkgTokenSpaceGuid.PcdNvmeGenericTimeout|5|UINT32|0x40000154
+
 [PcdsFixedAtBuild, PcdsPatchableInModule]
   ## Dynamic type PCD can be registered callback function for Pcd setting action.
   #  PcdMaxPeiPcdCallBackNumberPerPcdEntry indicates the maximum number of callback function


### PR DESCRIPTION
# Description

Changes the NvmExpressDxe driver to reference `PcdNvmeGenericTimeout` for generic timeouts, allowing platforms to define their own timeout value.

Virtual machine firmware like [mu_msvm ](https://github.com/microsoft/mu_msvm) is dependent on this change. In Azure, some virtual machines' backing storage resolve to remote storage backends. Traditionally, we have seen that SCSI devices waiting on remote storage can take far longer than 5 seconds. Others have previously agreed that NVMe devices using the same backing remote storage can also suffer from this. 

mu_msvm previously had a fork of NvmExpressDxe that overrode this value to 120 seconds. Now, mu_msvm has agreed to use the upstream NvmExpressDxe driver, but this change is lacking, and thus we lack full parity with our old fork currently.

Using a PCD prevents other consumers of this driver from having to make their own override.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Tested with CI validation

## Integration Instructions

N/A