### PR TITLE
UefiCpuPkg/BaseRiscVMmuLib: fix bitwise-vs-logical typo in SetPpnToPte ASSERT

### DIFF
--- a/UefiCpuPkg/Library/BaseRiscVMmuLib/BaseRiscVMmuLib.c
+++ b/UefiCpuPkg/Library/BaseRiscVMmuLib/BaseRiscVMmuLib.c
@@ -240,7 +240,7 @@ SetPpnToPte (
   UINT64  Ppn;
 
   Ppn = ((Address >> RISCV_MMU_PAGE_SHIFT) << PTE_PPN_SHIFT);
-  ASSERT (~(Ppn & ~PTE_PPN_MASK));
+  ASSERT (!(Ppn & ~PTE_PPN_MASK));
   Entry &= ~PTE_PPN_MASK;
   return Entry | Ppn;
 }


### PR DESCRIPTION
## Description

`SetPpnToPte()` in `UefiCpuPkg/Library/BaseRiscVMmuLib/BaseRiscVMmuLib.c`
asserts that no bits of the encoded physical page number fall outside
`PTE_PPN_MASK`, but uses bitwise NOT (`~`) where logical NOT (`!`) was
intended:

```c
ASSERT (~(Ppn & ~PTE_PPN_MASK));
```

`~(Ppn & ~PTE_PPN_MASK)` is zero only when `(Ppn & ~PTE_PPN_MASK)` equals
`~(UINT64)0`, which is impossible here — `Ppn` is built by shifting
`Address` right by `RISCV_MMU_PAGE_SHIFT` then left by `PTE_PPN_SHIFT`,
so its low bits are always clear. The assertion therefore always passes
regardless of whether the PPN actually fits.

The sibling routine `RiscVMmuSetSatpMode()` a few lines below uses the
correct idiom:

```c
ASSERT (!(Ppn & ~(SATP64_PPN)));
```

This change makes `SetPpnToPte()` match it.

- This change is **not** a functional change in RELEASE builds (the
  `ASSERT` is compiled out).
- In DEBUG builds the assert now correctly fires if a caller passes an
  address whose PPN field does not fit in `PTE_PPN_MASK`.

Found while auditing the RISC-V page-table mutation path for an
unrelated image-protection investigation; submitting independently as
it stands on its own.

## How this was tested

Build-only: the affected line is identical on `master` and
`edk2-stable202408`. The change is a single operator (`~` → `!`) inside
an `ASSERT` macro; no behavioural change in RELEASE, and the DEBUG
assertion now evaluates the intended condition.

Signed-off-by: David Delavennat <tannevaled@users.noreply.github.com>