### PR TITLE
ShellPkg, MdeModulePkg: Remove Depex sections in UEFI_DRIVER or UEFI_APPLICATION INF files

### DIFF
--- a/MdeModulePkg/Bus/Usb/UsbNetwork/NetworkCommon/NetworkCommon.inf
+++ b/MdeModulePkg/Bus/Usb/UsbNetwork/NetworkCommon/NetworkCommon.inf
@@ -45,6 +45,3 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdUsbNetworkRateLimitingCredit
   gEfiMdeModulePkgTokenSpaceGuid.PcdUsbNetworkRateLimitingFactor
   gEfiMdeModulePkgTokenSpaceGuid.PcdUsbNetworkPeriodicTimerInterval
-
-[Depex]
-  TRUE

--- a/MdeModulePkg/Bus/Usb/UsbNetwork/UsbCdcEcm/UsbCdcEcm.inf
+++ b/MdeModulePkg/Bus/Usb/UsbNetwork/UsbCdcEcm/UsbCdcEcm.inf
@@ -37,6 +37,3 @@
   gEfiDevicePathProtocolGuid
   gEfiDriverBindingProtocolGuid
   gEdkIIUsbEthProtocolGuid
-
-[Depex]
-  TRUE

--- a/MdeModulePkg/Bus/Usb/UsbNetwork/UsbCdcNcm/UsbCdcNcm.inf
+++ b/MdeModulePkg/Bus/Usb/UsbNetwork/UsbCdcNcm/UsbCdcNcm.inf
@@ -37,6 +37,3 @@
   gEfiDevicePathProtocolGuid
   gEfiDriverBindingProtocolGuid
   gEdkIIUsbEthProtocolGuid
-
-[Depex]
-  TRUE

--- a/MdeModulePkg/Bus/Usb/UsbNetwork/UsbRndis/UsbRndis.inf
+++ b/MdeModulePkg/Bus/Usb/UsbNetwork/UsbRndis/UsbRndis.inf
@@ -37,6 +37,3 @@
   gEfiDevicePathProtocolGuid
   gEfiDriverBindingProtocolGuid
   gEdkIIUsbEthProtocolGuid
-
-[Depex]
-  TRUE

--- a/MdeModulePkg/Universal/EbcDxe/EbcDebuggerConfig.inf
+++ b/MdeModulePkg/Universal/EbcDxe/EbcDebuggerConfig.inf
@@ -50,8 +50,5 @@
   gEfiDebuggerConfigurationProtocolGuid     ## CONSUMES
   gEfiShellParametersProtocolGuid           ## CONSUMES
 
-[Depex]
-  TRUE
-
 [UserExtensions.TianoCore."ExtraFiles"]
   EbcDebuggerConfigExtra.uni

--- a/ShellPkg/DynamicCommand/VariablePolicyDynamicCommand/VariablePolicyApp.inf
+++ b/ShellPkg/DynamicCommand/VariablePolicyDynamicCommand/VariablePolicyApp.inf
@@ -57,6 +57,3 @@
   gMtcVendorGuid
   gShellAliasGuid
   gShellVariableGuid
-
-[DEPEX]
-  TRUE


### PR DESCRIPTION
# Description

According to INF specification:
> If the module is not a library (no LIBRARY_CLASS in the [Defines] section) and the MODULE_TYPE is SEC, SMM_CORE, DXE_CORE, PEI_CORE, UEFI_DRIVER, UEFI_APPLICATION or HOST_APPLICATION a Depex section is not permitted. 
So remove Depex sections in UEFI_DRIVER or UEFI_APPLICATION INF files from ShellPkg and MdeModulePkg.

The two commits are inherited from https://github.com/tianocore/edk2/pull/12343. Since https://github.com/tianocore/edk2/pull/12343 is not merged due to unreviewed controversial code, the uncontroversial commits are resubmitted in this PR.

## How This Was Tested

Pass CI check.

## Integration Instructions

N/A
