### PR TITLE
OvmfPkg,UefiCpuPkg: Enable LoongArch NULL pointer detection

### DIFF
--- a/OvmfPkg/LoongArchVirt/Library/ResetSystemAcpiLib/DxeResetSystemAcpiGed.c
+++ b/OvmfPkg/LoongArchVirt/Library/ResetSystemAcpiLib/DxeResetSystemAcpiGed.c
@@ -8,6 +8,7 @@
 **/
 
 #include <Base.h>
+#include <Library/BaseLib.h>
 #include <Library/DebugLib.h>
 #include <Library/DxeServicesTableLib.h>
 #include <Library/UefiBootServicesTableLib.h>
@@ -104,7 +105,9 @@ GetPowerManagerByParseAcpiInfo (
   EFI_ACPI_DESCRIPTION_HEADER                   *Xsdt    = NULL;
   EFI_ACPI_DESCRIPTION_HEADER                   *Rsdt    = NULL;
   UINT32                                        *Entry32 = NULL;
-  UINTN                                         Entry32Num;
+  UINT8                                         *Entry64 = NULL;
+  UINT64                                        EntryAddress;
+  UINTN                                         EntryNum;
   UINT32                                        *Signature = NULL;
   UINTN                                         Idx;
   EFI_STATUS                                    Status;
@@ -119,27 +122,40 @@ GetPowerManagerByParseAcpiInfo (
     return RETURN_NOT_FOUND;
   }
 
-  Rsdt       = (EFI_ACPI_DESCRIPTION_HEADER *)(UINTN)Rsdp->RsdtAddress;
-  Entry32    = (UINT32 *)(UINTN)(Rsdt + 1);
-  Entry32Num = (Rsdt->Length - sizeof (EFI_ACPI_DESCRIPTION_HEADER)) >> 2;
-  for (Idx = 0; Idx < Entry32Num; Idx++) {
-    Signature = (UINT32 *)(UINTN)Entry32[Idx];
-    if (*Signature == EFI_ACPI_5_0_FIXED_ACPI_DESCRIPTION_TABLE_SIGNATURE) {
-      Fadt = (EFI_ACPI_5_0_FIXED_ACPI_DESCRIPTION_TABLE *)Signature;
-      DEBUG ((DEBUG_INFO, "Found Fadt in Rsdt\n"));
-      goto Done;
+  if (Rsdp->RsdtAddress != 0) {
+    Rsdt     = (EFI_ACPI_DESCRIPTION_HEADER *)(UINTN)Rsdp->RsdtAddress;
+    Entry32  = (UINT32 *)(UINTN)(Rsdt + 1);
+    EntryNum = (Rsdt->Length - sizeof (EFI_ACPI_DESCRIPTION_HEADER)) >> 2;
+    for (Idx = 0; Idx < EntryNum; Idx++) {
+      if (Entry32[Idx] == 0) {
+        continue;
+      }
+
+      Signature = (UINT32 *)(UINTN)Entry32[Idx];
+      if (*Signature == EFI_ACPI_5_0_FIXED_ACPI_DESCRIPTION_TABLE_SIGNATURE) {
+        Fadt = (EFI_ACPI_5_0_FIXED_ACPI_DESCRIPTION_TABLE *)Signature;
+        DEBUG ((DEBUG_INFO, "Found Fadt in Rsdt\n"));
+        goto Done;
+      }
     }
   }
 
-  Xsdt       = (EFI_ACPI_DESCRIPTION_HEADER *)Rsdp->XsdtAddress;
-  Entry32    = (UINT32 *)(Xsdt + 1);
-  Entry32Num = (Xsdt->Length - sizeof (EFI_ACPI_DESCRIPTION_HEADER)) >> 2;
-  for (Idx = 0; Idx < Entry32Num; Idx++) {
-    Signature = (UINT32 *)(UINTN)Entry32[Idx];
-    if (*Signature == EFI_ACPI_5_0_FIXED_ACPI_DESCRIPTION_TABLE_SIGNATURE) {
-      Fadt = (EFI_ACPI_5_0_FIXED_ACPI_DESCRIPTION_TABLE *)Signature;
-      DEBUG ((DEBUG_INFO, "Found Fadt in Xsdt\n"));
-      goto Done;
+  if (Rsdp->XsdtAddress != 0) {
+    Xsdt     = (EFI_ACPI_DESCRIPTION_HEADER *)(UINTN)Rsdp->XsdtAddress;
+    Entry64  = (UINT8 *)(UINTN)(Xsdt + 1);
+    EntryNum = (Xsdt->Length - sizeof (EFI_ACPI_DESCRIPTION_HEADER)) >> 3;
+    for (Idx = 0; Idx < EntryNum; Idx++) {
+      EntryAddress = ReadUnaligned64 ((UINT64 *)(UINTN)(Entry64 + (Idx * sizeof (UINT64))));
+      if (EntryAddress == 0) {
+        continue;
+      }
+
+      Signature = (UINT32 *)(UINTN)EntryAddress;
+      if (*Signature == EFI_ACPI_5_0_FIXED_ACPI_DESCRIPTION_TABLE_SIGNATURE) {
+        Fadt = (EFI_ACPI_5_0_FIXED_ACPI_DESCRIPTION_TABLE *)Signature;
+        DEBUG ((DEBUG_INFO, "Found Fadt in Xsdt\n"));
+        goto Done;
+      }
     }
   }
 

--- a/OvmfPkg/LoongArchVirt/Library/ResetSystemAcpiLib/DxeResetSystemAcpiGedLib.inf
+++ b/OvmfPkg/LoongArchVirt/Library/ResetSystemAcpiLib/DxeResetSystemAcpiGedLib.inf
@@ -30,6 +30,7 @@
   OvmfPkg/OvmfPkg.dec
 
 [LibraryClasses]
+  BaseLib
   DebugLib
   DxeServicesTableLib
   UefiBootServicesTableLib

--- a/UefiCpuPkg/CpuDxe/LoongArch64/CpuDxe.c
+++ b/UefiCpuPkg/CpuDxe/LoongArch64/CpuDxe.c
@@ -489,6 +489,17 @@ InitializeCpu (
   //
   RefreshGcdMemoryAttributes ();
 
+  //
+  // LoongArch page tables identity-map RAM from physical address 0 during
+  // early boot.  When DXE NULL pointer detection is enabled, explicitly make
+  // the first page read-protected after the CPU architectural protocol is
+  // installed, matching the generic DXE NULL pointer protection semantics.
+  //
+  if ((PcdGet8 (PcdNullPointerDetectionPropertyMask) & BIT0) != 0) {
+    Status = CpuSetMemoryAttributes (&gCpu, 0, EFI_PAGE_SIZE, EFI_MEMORY_RP);
+    ASSERT_EFI_ERROR (Status);
+  }
+
   Status = gCpu.RegisterInterruptHandler (
                   &gCpu,
                   EXCEPT_LOONGARCH_INT_IPI,

--- a/UefiCpuPkg/Library/CpuMmuLib/LoongArch64/CpuMmu.c
+++ b/UefiCpuPkg/Library/CpuMmuLib/LoongArch64/CpuMmu.c
@@ -513,6 +513,10 @@ UpdateRegionMappingRecursive (
         EntryValue |= PAGE_GLOBAL | PAGE_VALID;
       }
 
+      if ((AttributeSetMask & PAGE_NO_READ) != 0) {
+        EntryValue &= ~PAGE_VALID;
+      }
+
       ReplaceTableEntry (Entry, EntryValue, RegionStart, TableIsLive);
     }
   }


### PR DESCRIPTION
# Description

This series enables NULL pointer detection for LoongArchVirt when
`PcdNullPointerDetectionPropertyMask` BIT0 is set.

LoongArchVirt already sets `PcdNullPointerDetectionPropertyMask` to `1`, but
virtual address `0x0` remained readable in DXE because the LoongArch64 CPU/MMU
path did not apply a read-protected/invalid mapping for page 0. As a result,
NULL pointer detection only prevented allocation of page 0, but did not make a
runtime load from address 0 fault.

The change updates the LoongArch64 CPU DXE path to apply `EFI_MEMORY_RP` to
page 0 when BIT0 is enabled, and updates the LoongArch64 MMU attribute handling
so a no-read page is made invalid in the page table. This makes a real load from
virtual address `0x0` raise a LoongArch64 page-invalid-load exception.

While enabling this, a latent LoongArchVirt reset-library ACPI table-walk issue
was exposed. `ResetSystemAcpiLib` could dereference address 0 while walking
RSDT/XSDT entries. The library now skips zero RSDT/XSDT addresses and zero table
entries, and parses XSDT entries as 64-bit addresses using an unaligned-safe
read.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Built LoongArchVirt:

```bash
export GCC_LOONGARCH64_PREFIX=loongarch64-linux-gnu-
. edksetup.sh
build -a LOONGARCH64 -t GCC \
  -p OvmfPkg/LoongArchVirt/LoongArchVirtQemu.dsc \
  -b DEBUG
```

Validated with an external UEFI Shell diagnostic application that performs a
real LoongArch64 load from virtual address `0x0` using inline assembly. The
reference probe source is available at:

```text
https://github.com/MarsDoge/UefiToolsPkg/blob/feat/null-address-probe/Applications/NullAddressProbe/NullAddressProbe.c
```

The application was placed at `\EFI\BOOT\BOOTLOONGARCH64.EFI` on a FAT ESP and
booted by QEMU LoongArchVirt.

With `PcdNullPointerDetectionPropertyMask | 1` in
`OvmfPkg/LoongArchVirt/LoongArchVirtQemu.dsc`, the probe raised the expected
LoongArch64 page-invalid-load exception and did not print the success line:

```text
NullAddressProbe: about to load from virtual address 0x0.
NullAddressProbe: if NULL protection works, a CPU exception should occur now.

!!!! LoongArch64 Exception Type - 01(#PIL - Page invalid exception for Load option) !!!!
ECFG  - 0x0000000000000800, ESTAT - 0x0000000000010000,
ERA   - 0x000000000E072454, BADV - 0x0000000000000000
```

As a control test, with `PcdNullPointerDetectionPropertyMask | 0`, the same
probe completed successfully, confirming that the fault is controlled by the
PCD:

```text
NullAddressProbe: about to load from virtual address 0x0.
NullAddressProbe: if NULL protection works, a CPU exception should occur now.
NullAddressProbe: load from 0x0 succeeded: 0x0
NullAddressProbe: DONE; address 0x0 is readable in this firmware mapping.
```

Also ran:

```bash
git diff --check origin/master...HEAD
python3 BaseTools/Scripts/PatchCheck.py -2
```

Both passed.

## Integration Instructions

N/A
