### PR TITLE
MdeModulePkg: Display VID and DID using 4-digit hexadecimal number

### DIFF
--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciEnumeratorSupport.c
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciEnumeratorSupport.c
@@ -373,7 +373,7 @@ PciSearchDevice (
 
   DEBUG ((
     DEBUG_INFO,
-    "PciBus: Discovered %s @ [%02x|%02x|%02x]  [VID = 0x%x, DID = 0x%0x]\n",
+    "PciBus: Discovered %s @ [%02x|%02x|%02x]  [VID = 0x%04x, DID = 0x%04x]\n",
     IS_PCI_BRIDGE (Pci) ?     L"PPB" :
     IS_CARDBUS_BRIDGE (Pci) ? L"P2C" :
     L"PCI",


### PR DESCRIPTION
# Description

Usually，device id and vendor id are shown as 4-digit hexadecimal number. So this patch changes the format to make them more readable.

No functional change.

## How This Was Tested

Check the firmware running log, the VID and DID in PciBus are all 4-digit hexadecimal numbers.

## Integration Instructions

N/A
