### PR TITLE
UefiCpuPkg/LoongArch64: Keep no-read mappings valid

### DIFF
--- a/UefiCpuPkg/Library/CpuMmuLib/LoongArch64/CpuMmu.c
+++ b/UefiCpuPkg/Library/CpuMmuLib/LoongArch64/CpuMmu.c
@@ -513,9 +513,6 @@ UpdateRegionMappingRecursive (
         EntryValue |= PAGE_GLOBAL | PAGE_VALID;
       }
 
-      if ((AttributeSetMask & PAGE_NO_READ) != 0) {
-        EntryValue &= ~PAGE_VALID;
-      }
 
       ReplaceTableEntry (Entry, EntryValue, RegionStart, TableIsLive);
     }


### PR DESCRIPTION
# Description

Keep LoongArch64 `EFI_MEMORY_RP` mappings valid and rely on the architectural
`PAGE_NO_READ` permission bit.

The current LoongArch64 MMU code makes `EFI_MEMORY_RP` effective by setting
`PAGE_NO_READ` and then clearing `PAGE_VALID`. That makes the NULL-page guard
fault reliably, but it is stronger than the requested read-protect semantics:
the mapping becomes fully invalid instead of valid-but-not-readable.

LoongArch software TLB refill does not require hardware page table walk support
to preserve the no-read permission bit. A TLB entry with `V=1` and `NR=1`
should fault a data load with a page non-readable exception.

This change keeps `PAGE_VALID` set for `EFI_MEMORY_RP` mappings and avoids
turning every read-protected mapping into a fully invalid mapping. With this
change, a protected load faults with `#PNR` instead of `#PIL`.

During bring-up, a local older QEMU binary appeared to require the stronger
invalid-PTE fallback. Further debugging showed that edk2 had written `NR=1` into
the page-table PTE, but the QEMU `LDPTE`/`TLBFILL` path dropped the `NR` bit
before installing the guest TLB entry. QEMU then installed the mapping as
readable.

That QEMU issue has been fixed by:

```text
2d877bc02a3b (target/loongarch: Preserve PTE permission bits in LDPTE)
```

Link:

```text
https://github.com/qemu/qemu/commit/2d877bc02a3b94998cbdd784d194c173d308a98a
```

With that QEMU fix, and on hardware that preserves the architectural
LoongArch64 TLB permission bits, `PAGE_NO_READ` is honored without requiring
firmware to invalidate the PTE.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Built LoongArchVirt:

```bash
export GCC_LOONGARCH64_PREFIX=loongarch64-linux-gnu-
. edksetup.sh
build -a LOONGARCH64 -t GCC \
  -p OvmfPkg/LoongArchVirt/LoongArchVirtQemu.dsc \
  -b DEBUG
```

Also ran:

```bash
git diff --check origin/master...HEAD
python3 BaseTools/Scripts/PatchCheck.py -1
```

Both passed.

Runtime validation was performed with an external UEFI diagnostic application
that executes a real LoongArch64 load from a protected address using inline
assembly. The reference source is available at:

```text
https://github.com/MarsDoge/UefiToolsPkg/blob/main/Applications/NullAddressProbe/NullAddressProbe.c
```

Before this change, the protected page was made invalid by clearing
`PAGE_VALID`. The diagnostic load faulted with a page-invalid-load exception:

```text
!!!! LoongArch64 Exception Type - 01(#PIL - Page invalid exception for Load option) !!!!
BADV - 0x0000000000000000
```

After this change, the mapping remains valid but has `PAGE_NO_READ` set. A load
from the protected NULL page faults with a page non-readable exception instead:

```text
!!!! LoongArch64 Exception Type - 05(#PNR - Page non-readable exception) !!!!
BADV - 0x0000000000000000
```

This confirms that the protected mapping is still enforced through the
architectural no-read permission rather than by invalidating the PTE.

During bring-up on an older local QEMU binary, additional debug output confirmed
that edk2 wrote `NR=1` into the page-table PTE:

```text
PTE0[VA0]=2000000000000053 V=1 D=1 G=1 NR=1 NX=0
```

The same older QEMU binary dropped `NR` while loading the PTE into the guest TLB
through `LDPTE`/`TLBFILL`:

```text
TLBELO0=0000000000000053 V=1 D=1 G=1 NR=0 NX=0
```

QEMU then installed the mapping as readable:

```text
loongarch_cpu_tlb_fill address=0 physical 0000000000000000 prot 7
```

This matches the emulator issue fixed by QEMU commit:

```text
2d877bc02a3b (target/loongarch: Preserve PTE permission bits in LDPTE)
```

## Integration Instructions

N/A
