### PR TITLE
OvmfPkg: Add SVSM support to VirtMmCommunicationDxe

### DIFF
--- a/MdePkg/Include/Register/Amd/Svsm.h
+++ b/MdePkg/Include/Register/Amd/Svsm.h
@@ -102,6 +102,7 @@ typedef union {
 #define SVSM_PROTOCOL_CORE         0
 #define SVSM_PROTOCOL_ATTESTATION  1
 #define SVSM_PROTOCOL_VTPM         2
+#define SVSM_UEFI_MM_PROTOCOL      4
 /// @}
 
 /// SVSM Core Protocol calls
@@ -120,4 +121,9 @@ typedef union {
 /// @{
 #define SVSM_VTPM_QUERY  0
 #define SVSM_VTPM_CMD    1
+/// @}
+
+/// SVSM UEFI MM Protocol calls
+/// @{
+#define SVSM_UEFI_MM_REQUEST  1
 /// @}

--- a/OvmfPkg/Library/AmdSvsmLib/AmdSvsmLib.c
+++ b/OvmfPkg/Library/AmdSvsmLib/AmdSvsmLib.c
@@ -12,6 +12,7 @@
 #include <Library/AmdSvsmLib.h>
 #include <Register/Amd/Msr.h>
 #include <Register/Amd/Svsm.h>
+#include <Register/Amd/SvsmMsr.h>
 
 #define PAGES_PER_2MB_ENTRY  512
 
@@ -639,4 +640,34 @@ AmdSvsmQueryProtocol (
   }
 
   return TRUE;
+}
+
+BOOLEAN
+EFIAPI
+AmdSvsmUefiMmRequest (
+  IN  UINT64  BufferAddr,
+  IN  UINT64  BufferSize
+  )
+{
+  SVSM_CALL_DATA  SvsmCallData;
+  SVSM_FUNCTION   Function;
+  UINT64          Caa;
+  UINTN           Ret;
+
+  Function.Id.Protocol = SVSM_UEFI_MM_PROTOCOL;
+  Function.Id.CallId   = SVSM_UEFI_MM_REQUEST;
+
+  // This is (also) called from rumtime services.  We can not use
+  // AmdSvsmSnpGetCaa() here because (a) this function works for BootServices
+  // only, and (b) the OS might have moved the CAA page to a different place.
+  // So read the CCA MSR instead to get the address.
+  Caa = AsmReadMsr64 (MSR_SVSM_CAA);
+
+  SvsmCallData.Caa   = (SVSM_CAA *)Caa;
+  SvsmCallData.RaxIn = Function.Uint64;
+  SvsmCallData.RcxIn = BufferAddr;
+  SvsmCallData.RdxIn = BufferSize;
+
+  Ret = SvsmMsrProtocol (&SvsmCallData);
+  return (Ret == 0) ? TRUE : FALSE;
 }

--- a/OvmfPkg/VirtMmCommunicationDxe/Svsm.c
+++ b/OvmfPkg/VirtMmCommunicationDxe/Svsm.c
@@ -1,0 +1,61 @@
+/** @file
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Library/BaseLib.h>
+
+#include <Library/AmdSvsmLib.h>
+#include <Register/Amd/Msr.h>
+#include <Register/Amd/Svsm.h>
+
+#include "VirtMmCommunication.h"
+
+BOOLEAN
+EFIAPI
+VirtMmSvsmProbe (
+  VOID
+  )
+{
+  UINT32  Min, Max;
+
+  if (!AmdSvsmIsSvsmPresent ()) {
+    DEBUG ((DEBUG_VERBOSE, "%a: no SVSM present\n", __func__));
+    return FALSE;
+  }
+
+  if (!AmdSvsmQueryProtocol (SVSM_UEFI_MM_PROTOCOL, 1, &Min, &Max)) {
+    DEBUG ((DEBUG_VERBOSE, "%a: SVSM UEFI MM protocol not supported\n", __func__));
+    return FALSE;
+  }
+
+  DEBUG ((
+    DEBUG_INFO,
+    "%a: SVSM UEFI MM protocol available (min %d, max %d)\n",
+    __func__,
+    Min,
+    Max
+    ));
+  return TRUE;
+}
+
+EFI_STATUS
+EFIAPI
+VirtMmSvsmComm (
+  VOID
+  )
+{
+  UINT64  Addr, Size;
+
+  Addr = (UINT64)(UINTN)mCommunicateBufferPhys;
+  Size = MAX_BUFFER_SIZE;
+
+  DEBUG ((DEBUG_VERBOSE, "%a: request\n", __func__));
+  if (!AmdSvsmUefiMmRequest (Addr, Size)) {
+    DEBUG ((DEBUG_ERROR, "%a: SVSM_UEFI_MM_REQUEST failed\n", __func__));
+    return EFI_DEVICE_ERROR;
+  }
+
+  return EFI_SUCCESS;
+}

--- a/OvmfPkg/VirtMmCommunicationDxe/SvsmNull.c
+++ b/OvmfPkg/VirtMmCommunicationDxe/SvsmNull.c
@@ -1,0 +1,25 @@
+/** @file
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Library/BaseLib.h>
+
+BOOLEAN
+EFIAPI
+VirtMmSvsmProbe (
+  VOID
+  )
+{
+  return FALSE;
+}
+
+EFI_STATUS
+EFIAPI
+VirtMmSvsmComm (
+  VOID
+  )
+{
+  return EFI_UNSUPPORTED;
+}

--- a/OvmfPkg/VirtMmCommunicationDxe/VirtMmCommunication.c
+++ b/OvmfPkg/VirtMmCommunicationDxe/VirtMmCommunication.c
@@ -20,7 +20,8 @@
 
 VOID                  *mCommunicateBuffer;
 EFI_PHYSICAL_ADDRESS  mCommunicateBufferPhys;
-BOOLEAN               mUsePioTransfer = FALSE;
+BOOLEAN               mUseSvsmProtocol = FALSE;
+BOOLEAN               mUsePioTransfer  = FALSE;
 
 // Notification event when virtual address map is set.
 STATIC EFI_EVENT  mSetVirtualAddressMapEvent;
@@ -142,7 +143,17 @@ VirtMmCommunication2Communicate (
     return Status;
   }
 
-  if (mUsePioTransfer) {
+  if (mUseSvsmProtocol) {
+    CopyMem (mCommunicateBuffer, CommBufferVirtual, BufferSize);
+
+    Status = VirtMmSvsmComm ();
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_WARN, "%a: svsm comm error: %r\n", __func__, Status));
+      return Status;
+    }
+
+    CopyMem (CommBufferVirtual, mCommunicateBuffer, BufferSize);
+  } else if (mUsePioTransfer) {
     Status = VirtMmHwPioTransfer (CommBufferVirtual, BufferSize, TRUE);
     if (EFI_ERROR (Status)) {
       DEBUG ((DEBUG_WARN, "%a: pio write error: %r\n", __func__, Status));
@@ -220,12 +231,16 @@ VirtMmNotifySetVirtualAddressMap (
       ));
   }
 
-  Status = VirtMmHwVirtMap ();
+  if (!mUseSvsmProtocol) {
+    Status = VirtMmHwVirtMap ();
+  }
+
   if (EFI_ERROR (Status)) {
     DEBUG ((
       DEBUG_ERROR,
-      "%a: VirtMmHwVirtMap failed. Status: %r\n",
+      "%a: VirtMm%aVirtMap failed. Status: %r\n",
       __func__,
+      mUseSvsmProtocol ? "Svsm" : "Hw",
       Status
       ));
   }
@@ -309,12 +324,20 @@ VirtMmCommunication2Initialize (
   }
 
   mCommunicateBufferPhys = (EFI_PHYSICAL_ADDRESS)(UINTN)(mCommunicateBuffer);
-  Status                 = VirtMmHwInit ();
+
+  if (VirtMmSvsmProbe ()) {
+    mUseSvsmProtocol = TRUE;
+    Status           = EFI_SUCCESS;
+  } else {
+    Status = VirtMmHwInit ();
+  }
+
   if (EFI_ERROR (Status)) {
     DEBUG ((
       DEBUG_ERROR,
-      "%a: Failed to init HW: %r\n",
+      "%a: Failed to init %a: %r\n",
       __func__,
+      mUseSvsmProtocol ? "SVSM" : "HW",
       Status
       ));
     goto FreeBufferPages;

--- a/OvmfPkg/VirtMmCommunicationDxe/VirtMmCommunication.h
+++ b/OvmfPkg/VirtMmCommunicationDxe/VirtMmCommunication.h
@@ -48,3 +48,17 @@ VirtMmHwPioTransfer (
   UINT32   BufferSize,
   BOOLEAN  ToDevice
   );
+
+/* svsm hooks */
+
+BOOLEAN
+EFIAPI
+VirtMmSvsmProbe (
+  VOID
+  );
+
+EFI_STATUS
+EFIAPI
+VirtMmSvsmComm (
+  VOID
+  );

--- a/OvmfPkg/VirtMmCommunicationDxe/VirtMmCommunication.inf
+++ b/OvmfPkg/VirtMmCommunicationDxe/VirtMmCommunication.inf
@@ -22,10 +22,12 @@
 #  QemuX64.c
   QemuHwInfo.c
   QemuMmio.c
+  Svsm.c
 
 [Sources.AARCH64, Sources.RISCV64, Sources.LOONGARCH64]
   QemuFdt.c
   QemuMmio.c
+  SvsmNull.c
 
 [Packages]
   MdePkg/MdePkg.dec
@@ -34,6 +36,9 @@
 
 [Packages.AARCH64, Packages.RISCV64, Packages.LOONGARCH64]
   EmbeddedPkg/EmbeddedPkg.dec
+
+[Packages.X64]
+  UefiCpuPkg/UefiCpuPkg.dec
 
 [LibraryClasses]
   BaseMemoryLib
@@ -47,6 +52,7 @@
 [LibraryClasses.X64]
   DxeHardwareInfoLib
   QemuFwCfgLib
+  AmdSvsmLib
 
 [LibraryClasses.AARCH64, LibraryClasses.RISCV64, LibraryClasses.LOONGARCH64]
   FdtLib

--- a/UefiCpuPkg/Include/Library/AmdSvsmLib.h
+++ b/UefiCpuPkg/Include/Library/AmdSvsmLib.h
@@ -146,3 +146,10 @@ AmdSvsmQueryProtocol (
   OUT UINT32  *ProtocolMin,
   OUT UINT32  *ProtocolMax
   );
+
+BOOLEAN
+EFIAPI
+AmdSvsmUefiMmRequest (
+  IN  UINT64  BufferAddr,
+  IN  UINT64  BufferSize
+  );

--- a/UefiCpuPkg/Library/AmdSvsmLibNull/AmdSvsmLibNull.c
+++ b/UefiCpuPkg/Library/AmdSvsmLibNull/AmdSvsmLibNull.c
@@ -165,3 +165,25 @@ AmdSvsmQueryProtocol (
 {
   return FALSE;
 }
+
+/**
+  Perform a SVSM_UEFI_MM_REQUEST operation
+
+  Send the specified MM communication buffer to the SVSM.
+
+  @param[in] BufferAddr  Physical address of the buffer.
+  @param[in] BufferSize  Size of the buffer.
+
+  @retval TRUE           The command was processed.
+  @retval FALSE          The command was not processed.
+
+**/
+BOOLEAN
+EFIAPI
+AmdSvsmUefiMmRequest (
+  IN  UINT64  BufferAddr,
+  IN  UINT64  BufferSize
+  )
+{
+  return FALSE;
+}


### PR DESCRIPTION
- **MdePkg/Svsm: add SVSM_UEFI_MM_PROTOCOL**
- **UefiCpuPkg/AmdSvsmLib: add AmdSvsmUefiMmRequest**
- **OvmfPkg/AmdSvsmLib: add AmdSvsmUefiMmRequest**
- **OvmfPkg/VirtMmCommunicationDxe: add SVSM support**

# Description

The SVSM_UEFI_MM_PROTOCOL protocol allows to send MM communication buffers to
the SVSM (instead of edk2 MM code) and let SVSM manage EFI variables that way.

This PR adds support for this to VirtMmCommunicationDxe and also adds a helper
to AmdSvsmLib.

