### PR TITLE
BaseTools/GenFw: Fix LoongArch ELF-to-PE RVA conversion

### DIFF
--- a/BaseTools/Source/C/GenFw/Elf64Convert.c
+++ b/BaseTools/Source/C/GenFw/Elf64Convert.c
@@ -1739,16 +1739,24 @@ WriteSections64 (
             INT32     LoImm, HiImm;
             UINT8     *PreTarg;
             Elf_Rela  *PreRel;
+            INT64     SymCoffRva;
+            INT64     InsnCoffRva;
+            INT64     PairHiCoffRva;
 
           case R_LARCH_SOP_PUSH_ABSOLUTE:
+          case R_LARCH_64:
             //
-            // Absolute relocation.
+            // R_LARCH_SOP_PUSH_ABSOLUTE is an absolute relocation, and
+            // R_LARCH_64 stores an absolute runtime address in section
+            // contents.  Translate such values from the linked ELF section
+            // address space to the generated PE/COFF RVA space.
+            // WriteRelocations64() still emits the PE/COFF base relocation
+            // for load-time image rebasing.
             //
             *(UINT64 *)Targ = *(UINT64 *)Targ - SymShdr->sh_addr + mCoffSectionsOffset[Sym->st_shndx];
             break;
 
           case R_LARCH_MARK_LA:
-          case R_LARCH_64:
           case R_LARCH_NONE:
           case R_LARCH_32:
           case R_LARCH_RELATIVE:
@@ -1851,29 +1859,32 @@ WriteSections64 (
           case R_LARCH_PCALA_HI20:
           case R_LARCH_GOT_PC_HI20:
             Offset = 0;
+            SymCoffRva = (INT64)Sym->st_value - (INT64)SymShdr->sh_addr + (INT64)mCoffSectionsOffset[Sym->st_shndx];
+            InsnCoffRva = (INT64)(UINTN)(Targ - mCoffFile);
             if (ELF_R_TYPE(Rel->r_info) == R_LARCH_PCALA_HI20) {
               //
-              // Recover the offset of the ELF PCALAU12I symbol relative to PC.
+              // Calculate the PE PC-relative offset.  SymCoffRva is the
+              // referenced symbol in the generated PE/COFF RVA space, and
+              // InsnCoffRva is the PE/COFF RVA of this instruction.
               //
-              Offset = (INT32)((Sym->st_value + Rel->r_addend) - (Rel->r_offset & ~0xFFF));
-              //
-              // Calculate the offset of PE PCADDU12I relative to PC.
-              //
-              Offset -= (UINTN)(Targ - mCoffFile) & 0xFFF;
+              Offset = (INT32)((SymCoffRva + Rel->r_addend) - InsnCoffRva);
             } else if (ELF_R_TYPE(Rel->r_info) == R_LARCH_GOT_PC_HI20) {
               //
-              // Calculate the offset of PE PCADDU12I relative to PC using the ELF symbol value.
+              // Convert the referenced symbol from the linked ELF section
+              // address space to the generated PE/COFF RVA space before
+              // calculating the PE PC-relative offset.  Targ already points
+              // into the generated PE/COFF image buffer.
               //
-              Offset = Sym->st_value - (UINTN)(Targ - mCoffFile);
+              Offset = SymCoffRva - InsnCoffRva;
             } else {
               Error (NULL, 0, 3000, "Invalid", "LoongArch PC related: wrong relocation type.");
               break;
             }
 
             //
-            // PCALA or GOT offset is relative to the previous page boundary, whereas PCADD
-            // offset is relative to the instruction itself.
-            // So fix up the offset so it points to the page containing the symbol.
+            // The original PCALA/GOT_PC relocations are page based, but this
+            // path rewrites the HI/LO pair to PCADDU12I plus ADDI.D.  Split
+            // the generated PE/COFF instruction-relative offset for that pair.
             //
             HiImm = (UINT32)((Offset + 0x800) >> 12) & 0xFFFFF;
 
@@ -1912,11 +1923,12 @@ WriteSections64 (
             }
 
             //
-            // Calculate the corresponding HI relative to PC using the ELF symbol value and fix the LO offset.
+            // Calculate the corresponding HI relative to PC using the PE symbol RVA and fix the LO offset.
             //
             if (ELF_R_TYPE(Rel->r_info) == R_LARCH_PCALA_LO12 && ELF_R_TYPE(PreRel->r_info) == R_LARCH_PCALA_HI20) {
-              Offset = (INT32)((Sym->st_value + PreRel->r_addend) - (PreRel->r_offset & ~0xFFF));
-              Offset -= (UINTN)(PreTarg - mCoffFile) & 0xFFF;
+              SymCoffRva = (INT64)Sym->st_value - (INT64)SymShdr->sh_addr + (INT64)mCoffSectionsOffset[Sym->st_shndx];
+              PairHiCoffRva = (INT64)(UINTN)(PreTarg - mCoffFile);
+              Offset = (INT32)((SymCoffRva + PreRel->r_addend) - PairHiCoffRva);
               LoImm = (UINT32)(Offset & 0xFFF);
               //
               // Only fill the LO offset in corresponding instructions.
@@ -1924,7 +1936,9 @@ WriteSections64 (
               *(UINT32 *)Targ &= 0xFFC003FF;
               *(UINT32 *)Targ |= LoImm << 10;
             } else if (ELF_R_TYPE(Rel->r_info) == R_LARCH_GOT_PC_LO12 && ELF_R_TYPE(PreRel->r_info) == R_LARCH_GOT_PC_HI20) {
-              Offset = Sym->st_value - (UINTN)(PreTarg - mCoffFile);
+              SymCoffRva = (INT64)Sym->st_value - (INT64)SymShdr->sh_addr + (INT64)mCoffSectionsOffset[Sym->st_shndx];
+              PairHiCoffRva = (INT64)(UINTN)(PreTarg - mCoffFile);
+              Offset = SymCoffRva - PairHiCoffRva;
               LoImm = (UINT32)(Offset & 0xFFF);
               //
               // Convert this instruction as ADDI.D and fill the LO offset into it.


### PR DESCRIPTION
# Description

Fix LoongArch64 GenFw relocation handling when the linked ELF section addresses differ from the generated PE/COFF section RVAs.

GenFw converts linked ELF images to PE/COFF images using a new section layout. The generated PE/COFF section RVAs are not required to match the linked ELF section addresses, so relocation fixups that rewrite section contents must use the generated PE/COFF RVA space.

A linker script layout change can expose this on LoongArch64 when `.text` and `.data` are linked with `0x1000` alignment while `.hii` still keeps a `0x4000` alignment. GenFw then keeps a `0x4000` PE/COFF section alignment because of `.hii`, producing different ELF and PE/COFF layouts, for example:

```text
ELF:     .text 0x1000, .data 0x6000, .hii  0x8000
PE/COFF: .text 0x4000, .data 0xc000, .rsrc 0x10000
```

This fixes two LoongArch relocation paths exposed by that layout mismatch:

- `R_LARCH_64` entries stored in section contents, such as switch jump tables, are translated from the linked ELF section address space to the generated PE/COFF RVA space.
- `R_LARCH_PCALA_*` and `R_LARCH_GOT_PC_*` convert the referenced symbol to its generated PE/COFF RVA before calculating the PC-relative offset.

The LoongArch ELF ABI defines PCALA/GOT_PC relocations as page-based, but this GenFw path rewrites the HI/LO pair to `PCADDU12I` plus `ADDI.D`. After that rewrite, the offset split must be based on the generated PE/COFF instruction-relative offset.

For example, in the failing LogoDxe image, `_gUefiDriverRevision` is at ELF address `0x5400` in `.text`, and the relocation referencing it is at ELF address `0x104c`. With ELF `.text` at `0x1000` and PE/COFF `.text` at `0x4000`, the generated PE/COFF RVAs are `0x8400` for the symbol and `0x404c` for the relocation site. Mixing the ELF symbol address with the PE/COFF relocation-site RVA makes the entry wrapper read PE/COFF RVA `0x5400` instead of `0x8400`, causing `EFI_INCOMPATIBLE_VERSION`.

`WriteRelocations64()` base relocation emission is kept unchanged for load-time image rebasing.

# How This Was Tested

Test setup included a linker script layout change similar to:
https://git.codelinaro.org/linaro/dcap/edk2/-/commit/3533d17062f6dfbeea4f15a50d686be8199ef450

Additional reference checked:
https://github.com/loongson/la-abi-specs/blob/master/laelf.adoc

Validation performed:

1. Rebuilt GenFw:

```bash
make -C BaseTools/Source/C/GenFw -j$(nproc)
```

2. Confirmed the changed file keeps CRLF line endings and passes whitespace check.

3. Rebuilt BaseTools and performed a clean LoongArchVirtQemu DEBUG build after applying the alignment-triggering linker script change:

```bash
make -C BaseTools/Source/C -j$(nproc)
source edksetup.sh BaseTools
build -p OvmfPkg/LoongArchVirt/LoongArchVirtQemu.dsc -a LOONGARCH64 -t GCC -b DEBUG clean
build -p OvmfPkg/LoongArchVirt/LoongArchVirtQemu.dsc -a LOONGARCH64 -t GCC -b DEBUG
```

4. Ran QEMU with ramfb:

```bash
qemu-system-loongarch64 -m 2G -M virt -smp 2 -cpu la464 \
  -bios Build/LoongArchVirtQemu/DEBUG_GCC/FV/QEMU_EFI.fd \
  -serial file:qemu.log -display vnc=127.0.0.1:66 -device ramfb
```

Observed result:

- `LogoDxe.efi` starts successfully.
- `dpDynamicCommand.efi` no longer returns `EFI_INCOMPATIBLE_VERSION` after a clean rebuild.
- `GraphicsConsole` starts at `800 x 600`.
- The TianoCore logo is visible on the framebuffer.

5. Checked GCC-generated LoongArch relocations with small `-fPIC` and `-fno-pic -fno-PIE` objects:

- `-fPIC` emits `R_LARCH_GOT_PC_HI20` / `R_LARCH_GOT_PC_LO12` for global/local data references.
- `-fno-pic -fno-PIE` emits `R_LARCH_PCALA_HI20` / `R_LARCH_PCALA_LO12` for local data references and still uses `GOT_PC` for external data references.

# Integration Instructions

N/A