### PR TITLE
Maintainers.txt: Add Chris Fernald as maintainer to SecurityPkg

### DIFF
--- a/Maintainers.txt
+++ b/Maintainers.txt
@@ -629,6 +629,7 @@ SecurityPkg
 F: SecurityPkg/
 W: https://www.tianocore.org/tianocore-wiki.github.io/platforms-packages/core-packages/security_pkg.html
 M: Jiewen Yao <jiewen.yao@intel.com> [jyao1]
+M: Chris Fernald <chfernal@microsoft.com> [cfernald]
 
 SecurityPkg: Secure boot related modules
 F: SecurityPkg/Library/DxeImageVerificationLib/


### PR DESCRIPTION
# Description

Adds me as a maintainer for security package.

I work in security and related technologies both in UEFI and in the OS and can help to maintain security package, which we expect will see increased activity as new requirements and features land in the coming years.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?
