### PR TITLE
MdeModulePkg: Dxe: Skip FV Extraction When FV3 HOB Found

### DIFF
--- a/MdeModulePkg/Core/Dxe/Dispatcher/Dispatcher.c
+++ b/MdeModulePkg/Core/Dxe/Dispatcher/Dispatcher.c
@@ -901,37 +901,39 @@ CoreAddToDriverList (
 
 /**
   Check if a FV Image type file (EFI_FV_FILETYPE_FIRMWARE_VOLUME_IMAGE) is
-  described by a EFI_HOB_FIRMWARE_VOLUME2 Hob.
+  described by a EFI_HOB_FIRMWARE_VOLUME2 or an extracted EFI_HOB_FIRMWARE_VOLUME3 Hob.
 
   @param  FvNameGuid            The FV image guid specified.
   @param  DriverName            The driver guid specified.
 
-  @retval TRUE                  This file is found in a EFI_HOB_FIRMWARE_VOLUME2
-                                Hob.
+  @retval TRUE                  This file is found in a EFI_HOB_FIRMWARE_VOLUME2 or
+                                an extracted EFI_HOB_FIRMWARE_VOLUME3 Hob.
   @retval FALSE                 Not found.
 
 **/
+static
 BOOLEAN
-FvFoundInHobFv2 (
+FvFoundInExtractedFvHob (
   IN  CONST EFI_GUID  *FvNameGuid,
   IN  CONST EFI_GUID  *DriverName
   )
 {
-  EFI_PEI_HOB_POINTERS  HobFv2;
+  EFI_PEI_HOB_POINTERS  Hob;
 
-  HobFv2.Raw = GetHobList ();
-
-  while ((HobFv2.Raw = GetNextHob (EFI_HOB_TYPE_FV2, HobFv2.Raw)) != NULL) {
-    //
-    // Compare parent FvNameGuid and FileGuid both.
-    //
-    if (CompareGuid (DriverName, &HobFv2.FirmwareVolume2->FileName) &&
-        CompareGuid (FvNameGuid, &HobFv2.FirmwareVolume2->FvName))
-    {
-      return TRUE;
+  for (Hob.Raw = GetHobList (); !END_OF_HOB_LIST (Hob); Hob.Raw = GET_NEXT_HOB (Hob)) {
+    if (GET_HOB_TYPE (Hob) == EFI_HOB_TYPE_FV2) {
+      if (CompareGuid (DriverName, &Hob.FirmwareVolume2->FileName) &&
+          CompareGuid (FvNameGuid, &Hob.FirmwareVolume2->FvName))
+      {
+        return TRUE;
+      }
+    } else if ((GET_HOB_TYPE (Hob) == EFI_HOB_TYPE_FV3) && Hob.FirmwareVolume3->ExtractedFv) {
+      if (CompareGuid (DriverName, &Hob.FirmwareVolume3->FileName) &&
+          CompareGuid (FvNameGuid, &Hob.FirmwareVolume3->FvName))
+      {
+        return TRUE;
+      }
     }
-
-    HobFv2.Raw = GET_NEXT_HOB (HobFv2);
   }
 
   return FALSE;
@@ -1334,7 +1336,7 @@ CoreFwVolEventProtocolNotify (
             // Check if this EFI_FV_FILETYPE_FIRMWARE_VOLUME_IMAGE file has already
             // been extracted.
             //
-            if (FvFoundInHobFv2 (&KnownHandle->FvNameGuid, &NameGuid)) {
+            if (FvFoundInExtractedFvHob (&KnownHandle->FvNameGuid, &NameGuid)) {
               continue;
             }
 


### PR DESCRIPTION
# Description

Currently, the DXE dispatcher will skip extracting an FV file when an FV2 HOB is found for it, as that indicates pre-DXE extracted it.

However, the dispatcher does not check for FV3 HOBs, which also can describe extracted FVs. That can result in extracting the same FV in DXE that is already extracted, which can be a large performance hit.

This updates the DXE dispatcher to check for the existence of either an FV2 or FV3 HOB for this FV and skip extracting if either is found.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Tested on ArmVirtPkg/OvmfPkg by not producing FV2 HOBs for extracted regions, only FV3, and seeing DXE correctly skip re-extracting them.

## Integration Instructions

N/A.
