### PR TITLE
EmbeddedPkg, OvmfPkg: Improve FV2/3 HOB Handling

### DIFF
--- a/EmbeddedPkg/Include/Library/PrePiLib.h
+++ b/EmbeddedPkg/Include/Library/PrePiLib.h
@@ -180,7 +180,8 @@ FfsGetVolumeInfo (
 /**
   Get Fv image from the FV type file, then add FV & FV2 Hob.
 
-  @param FileHandle      File handle of a Fv type file.
+  @param FvFileHandle        File handle of a Fv type file.
+  @param ParentVolumeHandle  Parent volume handle, for filling out FvName field in FV2 Hob
 
   @retval EFI_NOT_FOUND  FV image can't be found.
   @retval EFI_SUCCESS    Successfully to process it.
@@ -189,7 +190,8 @@ FfsGetVolumeInfo (
 EFI_STATUS
 EFIAPI
 FfsProcessFvFile (
-  IN  EFI_PEI_FILE_HANDLE  FvFileHandle
+  IN  EFI_PEI_FILE_HANDLE  FvFileHandle,
+  IN EFI_PEI_FV_HANDLE     ParentVolumeHandle
   );
 
 /**
@@ -209,22 +211,6 @@ FfsAnyFvFindFirstFile (
   IN  EFI_FV_FILETYPE      FileType,
   OUT EFI_PEI_FV_HANDLE    *VolumeHandle,
   OUT EFI_PEI_FILE_HANDLE  *FileHandle
-  );
-
-/**
-  Get Fv image from the FV type file, then add FV & FV2 Hob.
-
-  @param FileHandle  File handle of a Fv type file.
-
-
-  @retval EFI_NOT_FOUND  FV image can't be found.
-  @retval EFI_SUCCESS    Successfully to process it.
-
-**/
-EFI_STATUS
-EFIAPI
-FfsProcessFvFile (
-  IN  EFI_PEI_FILE_HANDLE  FvFileHandle
   );
 
 /**

--- a/EmbeddedPkg/Include/Library/PrePiLib.h
+++ b/EmbeddedPkg/Include/Library/PrePiLib.h
@@ -68,9 +68,11 @@ EFI_STATUS
 
   @param  SectionType           The value of the section type to find.
   @param  SectionCheckHook      A hook which can check if the section is the target one.
-  @param  FileHeader            A pointer to the file header that contains the set of sections to
+  @param  FileHandle            A pointer to the file header that contains the set of sections to
                                 be searched.
   @param  SectionData           A pointer to the discovered section, if successful.
+  @param  AuthenticationStatus  Pointer to the authentication status. This parameter is optional. If non-NULL and
+                                GUIDed extraction occurs, the authentication status will be updated.
 
   @retval EFI_SUCCESS           The section was found.
   @retval EFI_NOT_FOUND         The section was not found.
@@ -82,7 +84,8 @@ FfsFindSectionDataWithHook (
   IN EFI_SECTION_TYPE        SectionType,
   IN FFS_CHECK_SECTION_HOOK  SectionCheckHook,
   IN EFI_PEI_FILE_HANDLE     FileHandle,
-  OUT VOID                   **SectionData
+  OUT VOID                   **SectionData,
+  OUT UINT32                 *AuthenticationStatus OPTIONAL
   );
 
 /**

--- a/EmbeddedPkg/Library/PrePiLib/FwVol.c
+++ b/EmbeddedPkg/Library/PrePiLib/FwVol.c
@@ -858,8 +858,8 @@ FfsAnyFvFindFirstFile (
 /**
   Get Fv image from the FV type file, then add FV & FV2 Hob.
 
-  @param FileHandle  File handle of a Fv type file.
-
+  @param FvFileHandle        File handle of a Fv type file.
+  @param ParentVolumeHandle  Parent volume handle, for filling out FvName field in FV2 Hob
 
   @retval EFI_NOT_FOUND  FV image can't be found.
   @retval EFI_SUCCESS    Successfully to process it.
@@ -868,12 +868,14 @@ FfsAnyFvFindFirstFile (
 EFI_STATUS
 EFIAPI
 FfsProcessFvFile (
-  IN  EFI_PEI_FILE_HANDLE  FvFileHandle
+  IN  EFI_PEI_FILE_HANDLE  FvFileHandle,
+  IN EFI_PEI_FV_HANDLE     ParentVolumeHandle
   )
 {
   EFI_STATUS            Status;
   EFI_PEI_FV_HANDLE     FvImageHandle;
   EFI_FV_INFO           FvImageInfo;
+  EFI_FV_INFO           ParentVolumeInfo;
   UINT32                FvAlignment;
   VOID                  *FvBuffer;
   EFI_PEI_HOB_POINTERS  Hob;
@@ -945,6 +947,9 @@ FfsProcessFvFile (
   //
   BuildFvHob ((EFI_PHYSICAL_ADDRESS)(UINTN)FvImageInfo.FvStart, FvImageInfo.FvSize);
 
+  Status = FfsGetVolumeInfo (ParentVolumeHandle, &ParentVolumeInfo);
+  ASSERT_EFI_ERROR (Status);
+
   //
   // Makes the encapsulated volume show up in DXE phase to skip processing of
   // encapsulated file again.
@@ -952,7 +957,7 @@ FfsProcessFvFile (
   BuildFv2Hob (
     (EFI_PHYSICAL_ADDRESS)(UINTN)FvImageInfo.FvStart,
     FvImageInfo.FvSize,
-    &FvImageInfo.FvName,
+    &ParentVolumeInfo.FvName,
     &(((EFI_FFS_FILE_HEADER *)FvFileHandle)->Name)
     );
 

--- a/EmbeddedPkg/Library/PrePiLib/FwVol.c
+++ b/EmbeddedPkg/Library/PrePiLib/FwVol.c
@@ -798,6 +798,7 @@ FfsGetVolumeInfo (
     return EFI_INVALID_PARAMETER;
   }
 
+  ZeroMem (VolumeInfo, sizeof (*VolumeInfo));
   VolumeInfo->FvAttributes = FwVolHeader.Attributes;
   VolumeInfo->FvStart      = (VOID *)VolumeHandle;
   VolumeInfo->FvSize       = FwVolHeader.FvLength;
@@ -912,7 +913,6 @@ FfsProcessFvFile (
   //
   // Collect FvImage Info.
   //
-  ZeroMem (&FvImageInfo, sizeof (FvImageInfo));
   Status = FfsGetVolumeInfo (FvImageHandle, &FvImageInfo);
   ASSERT_EFI_ERROR (Status);
 

--- a/EmbeddedPkg/Library/PrePiLib/FwVol.c
+++ b/EmbeddedPkg/Library/PrePiLib/FwVol.c
@@ -353,11 +353,13 @@ GetSectionNCompressionType (
   Go through the file to search SectionType section,
   when meeting an encapsuled section.
 
-  @param  SectionType       - Filter to find only section of this type.
-  @param  SectionCheckHook  - A hook which can check if the section is the target one.
-  @param  Section           - From where to search.
-  @param  SectionSize       - The file size to search.
-  @param  OutputBuffer      - Pointer to the section to search.
+  @param  SectionType           - Filter to find only section of this type.
+  @param  SectionCheckHook      - A hook which can check if the section is the target one.
+  @param  Section               - From where to search.
+  @param  SectionSize           - The file size to search.
+  @param  OutputBuffer          - Pointer to the section to search.
+  @param  AuthenticationStatus  - Pointer to the authentication status. This parameter is optional. If non-NULL and
+                                  GUIDed extraction occurs, the authentication status will be updated.
 
   @retval EFI_SUCCESS
 **/
@@ -367,7 +369,8 @@ FfsProcessSection (
   IN FFS_CHECK_SECTION_HOOK     SectionCheckHook,
   IN EFI_COMMON_SECTION_HEADER  *Section,
   IN UINTN                      SectionSize,
-  OUT VOID                      **OutputBuffer
+  OUT VOID                      **OutputBuffer,
+  OUT UINT32                    *AuthenticationStatus OPTIONAL
   )
 {
   EFI_STATUS  Status;
@@ -375,6 +378,7 @@ FfsProcessSection (
   UINTN       ParsedLength;
   UINT32      DstBufferSize;
   VOID        *DstBuffer;
+  UINT32      TempAuthStatus;
 
   ParsedLength = 0;
 
@@ -472,14 +476,16 @@ FfsProcessSection (
                    ScratchBuffer
                    );
       } else if (Section->Type == EFI_SECTION_GUID_DEFINED) {
-        UINT32  AuthenticationStatus;
-
         Status = ExtractGuidedSectionDecode (
                    Section,
                    &DstBuffer,
                    ScratchBuffer,
-                   &AuthenticationStatus
+                   &TempAuthStatus
                    );
+
+        if ((Status == EFI_SUCCESS) && (AuthenticationStatus != NULL)) {
+          *AuthenticationStatus = TempAuthStatus;
+        }
       }
 
       if (EFI_ERROR (Status)) {
@@ -495,7 +501,8 @@ FfsProcessSection (
                SectionCheckHook,
                DstBuffer,
                DstBufferSize,
-               OutputBuffer
+               OutputBuffer,
+               AuthenticationStatus
                );
     }
 
@@ -524,6 +531,8 @@ CheckNextSection:
   @param  FileHandle            A pointer to the file header that contains the set of sections to
                                 be searched.
   @param  SectionData           A pointer to the discovered section, if successful.
+  @param  AuthenticationStatus  Pointer to the authentication status. This parameter is optional. If non-NULL and
+                                GUIDed extraction occurs, the authentication status will be updated.
 
   @retval EFI_SUCCESS           The section was found.
   @retval EFI_NOT_FOUND         The section was not found.
@@ -535,7 +544,8 @@ FfsFindSectionDataWithHook (
   IN EFI_SECTION_TYPE        SectionType,
   IN FFS_CHECK_SECTION_HOOK  SectionCheckHook,
   IN EFI_PEI_FILE_HANDLE     FileHandle,
-  OUT VOID                   **SectionData
+  OUT VOID                   **SectionData,
+  OUT UINT32                 *AuthenticationStatus OPTIONAL
   )
 {
   EFI_FFS_FILE_HEADER        *FfsFileHeader;
@@ -556,7 +566,8 @@ FfsFindSectionDataWithHook (
            SectionCheckHook,
            Section,
            FileSize,
-           SectionData
+           SectionData,
+           AuthenticationStatus
            );
 }
 
@@ -580,7 +591,7 @@ FfsFindSectionData (
   OUT VOID                **SectionData
   )
 {
-  return FfsFindSectionDataWithHook (SectionType, NULL, FileHandle, SectionData);
+  return FfsFindSectionDataWithHook (SectionType, NULL, FileHandle, SectionData, NULL);
 }
 
 /**
@@ -879,8 +890,10 @@ FfsProcessFvFile (
   UINT32                FvAlignment;
   VOID                  *FvBuffer;
   EFI_PEI_HOB_POINTERS  Hob;
+  UINT32                AuthenticationStatus;
 
-  FvBuffer = NULL;
+  FvBuffer             = NULL;
+  AuthenticationStatus = 0;
 
   //
   // Check if this EFI_FV_FILETYPE_FIRMWARE_VOLUME_IMAGE file has already
@@ -907,7 +920,7 @@ FfsProcessFvFile (
   //
   // Find FvImage in FvFile
   //
-  Status = FfsFindSectionDataWithHook (EFI_SECTION_FIRMWARE_VOLUME_IMAGE, NULL, FvFileHandle, (VOID **)&FvImageHandle);
+  Status = FfsFindSectionDataWithHook (EFI_SECTION_FIRMWARE_VOLUME_IMAGE, NULL, FvFileHandle, (VOID **)&FvImageHandle, &AuthenticationStatus);
   if (EFI_ERROR (Status)) {
     return Status;
   }
@@ -957,6 +970,15 @@ FfsProcessFvFile (
   BuildFv2Hob (
     (EFI_PHYSICAL_ADDRESS)(UINTN)FvImageInfo.FvStart,
     FvImageInfo.FvSize,
+    &ParentVolumeInfo.FvName,
+    &(((EFI_FFS_FILE_HEADER *)FvFileHandle)->Name)
+    );
+
+  BuildFv3Hob (
+    (EFI_PHYSICAL_ADDRESS)(UINTN)FvImageInfo.FvStart,
+    FvImageInfo.FvSize,
+    AuthenticationStatus,
+    TRUE,
     &ParentVolumeInfo.FvName,
     &(((EFI_FFS_FILE_HEADER *)FvFileHandle)->Name)
     );

--- a/EmbeddedPkg/Library/PrePiLib/FwVol.c
+++ b/EmbeddedPkg/Library/PrePiLib/FwVol.c
@@ -875,7 +875,7 @@ FfsProcessFvFile (
   EFI_FV_INFO           FvImageInfo;
   UINT32                FvAlignment;
   VOID                  *FvBuffer;
-  EFI_PEI_HOB_POINTERS  HobFv2;
+  EFI_PEI_HOB_POINTERS  Hob;
 
   FvBuffer = NULL;
 
@@ -883,16 +883,22 @@ FfsProcessFvFile (
   // Check if this EFI_FV_FILETYPE_FIRMWARE_VOLUME_IMAGE file has already
   // been extracted.
   //
-  HobFv2.Raw = GetHobList ();
-  while ((HobFv2.Raw = GetNextHob (EFI_HOB_TYPE_FV2, HobFv2.Raw)) != NULL) {
-    if (CompareGuid (&(((EFI_FFS_FILE_HEADER *)FvFileHandle)->Name), &HobFv2.FirmwareVolume2->FileName)) {
-      //
-      // this FILE has been dispatched, it will not be dispatched again.
-      //
-      return EFI_SUCCESS;
+  for (Hob.Raw = GetHobList (); !END_OF_HOB_LIST (Hob); Hob.Raw = GET_NEXT_HOB (Hob)) {
+    if (GET_HOB_TYPE (Hob) == EFI_HOB_TYPE_FV2) {
+      if (CompareGuid (&(((EFI_FFS_FILE_HEADER *)FvFileHandle)->Name), &Hob.FirmwareVolume2->FileName)) {
+        //
+        // this FILE has been dispatched, it will not be dispatched again.
+        //
+        return EFI_SUCCESS;
+      }
+    } else if ((GET_HOB_TYPE (Hob) == EFI_HOB_TYPE_FV3) && Hob.FirmwareVolume3->ExtractedFv) {
+      if (CompareGuid (&(((EFI_FFS_FILE_HEADER *)FvFileHandle)->Name), &Hob.FirmwareVolume3->FileName)) {
+        //
+        // this FILE has been dispatched, it will not be dispatched again.
+        //
+        return EFI_SUCCESS;
+      }
     }
-
-    HobFv2.Raw = GET_NEXT_HOB (HobFv2);
   }
 
   //

--- a/EmbeddedPkg/Library/PrePiLib/PrePi.h
+++ b/EmbeddedPkg/Library/PrePiLib/PrePi.h
@@ -22,16 +22,6 @@
 #include <Library/MemoryAllocationLib.h>
 #include <Library/TimerLib.h>
 #include <Library/PerformanceLib.h>
+#include <Library/HobLib.h>
 
 #include <Guid/MemoryAllocationHob.h>
-
-#define GET_HOB_TYPE(Hob)     ((Hob).Header->HobType)
-#define GET_HOB_LENGTH(Hob)   ((Hob).Header->HobLength)
-#define GET_NEXT_HOB(Hob)     ((Hob).Raw + GET_HOB_LENGTH (Hob))
-#define END_OF_HOB_LIST(Hob)  (GET_HOB_TYPE (Hob) == EFI_HOB_TYPE_END_OF_HOB_LIST)
-
-//
-// Get the data and data size field of GUID
-//
-#define GET_GUID_HOB_DATA(GuidHob)       ((VOID *) (((UINT8 *) &((GuidHob)->Name)) + sizeof (EFI_GUID)))
-#define GET_GUID_HOB_DATA_SIZE(GuidHob)  (((GuidHob)->Header).HobLength - sizeof (EFI_HOB_GUID_TYPE))

--- a/EmbeddedPkg/Library/PrePiLib/PrePiLib.c
+++ b/EmbeddedPkg/Library/PrePiLib/PrePiLib.c
@@ -231,7 +231,7 @@ DecompressFirstFv (
 
   Status = FfsAnyFvFindFirstFile (EFI_FV_FILETYPE_FIRMWARE_VOLUME_IMAGE, &VolumeHandle, &FileHandle);
   if (!EFI_ERROR (Status)) {
-    Status = FfsProcessFvFile (FileHandle);
+    Status = FfsProcessFvFile (FileHandle, VolumeHandle);
   }
 
   return Status;

--- a/EmbeddedPkg/Library/PrePiLib/PrePiLib.c
+++ b/EmbeddedPkg/Library/PrePiLib/PrePiLib.c
@@ -131,7 +131,7 @@ LoadDxeCoreFromFfsFile (
   VOID                  *Hob;
   EFI_FV_FILE_INFO      FvFileInfo;
 
-  Status = FfsFindSectionDataWithHook (EFI_SECTION_PE32, NULL, FileHandle, &PeCoffImage);
+  Status = FfsFindSectionDataWithHook (EFI_SECTION_PE32, NULL, FileHandle, &PeCoffImage, NULL);
   if (EFI_ERROR (Status)) {
     return Status;
   }

--- a/OvmfPkg/Library/PeilessStartupLib/DxeLoad.c
+++ b/OvmfPkg/Library/PeilessStartupLib/DxeLoad.c
@@ -120,7 +120,7 @@ FindDxeCore (
     if (*FileHandle) {
       // Assume the FV that contains multiple compressed FVs.
       // So decompress the compressed FVs
-      Status = FfsProcessFvFile (*FileHandle);
+      Status = FfsProcessFvFile (*FileHandle, VolumeHandle);
       ASSERT_EFI_ERROR (Status);
       Status = FfsAnyFvFindFirstFile (EFI_FV_FILETYPE_DXE_CORE, &VolumeHandle, FileHandle);
     }

--- a/OvmfPkg/Library/PeilessStartupLib/DxeLoad.c
+++ b/OvmfPkg/Library/PeilessStartupLib/DxeLoad.c
@@ -171,7 +171,7 @@ CheckSectionHookForDxeNonCc (
  * Find the NonCc FV.
  *
  * @param FvInstance    The FvInstance number.
- * @return EFI_STATUS   Successfuly find the NonCc FV.
+ * @return EFI_STATUS   Successfully find the NonCc FV.
  */
 EFI_STATUS
 EFIAPI
@@ -186,6 +186,7 @@ FindDxeNonCc (
   EFI_FV_INFO          FvImageInfo;
   UINT32               FvAlignment;
   VOID                 *FvBuffer;
+  EFI_FV_INFO          ParentVolumeInfo;
 
   FileHandle = NULL;
 
@@ -237,6 +238,9 @@ FindDxeNonCc (
     FfsGetVolumeInfo ((EFI_PEI_FV_HANDLE)FvBuffer, &FvImageInfo);
   }
 
+  Status = FfsGetVolumeInfo (VolumeHandle, &ParentVolumeInfo);
+  ASSERT_EFI_ERROR (Status);
+
   //
   // Inform HOB consumer phase, i.e. DXE core, the existence of this FV
   //
@@ -249,7 +253,7 @@ FindDxeNonCc (
   BuildFv2Hob (
     (EFI_PHYSICAL_ADDRESS)(UINTN)FvImageInfo.FvStart,
     FvImageInfo.FvSize,
-    &FvImageInfo.FvName,
+    &ParentVolumeInfo.FvName,
     &(((EFI_FFS_FILE_HEADER *)FileHandle)->Name)
     );
 

--- a/OvmfPkg/Library/PeilessStartupLib/DxeLoad.c
+++ b/OvmfPkg/Library/PeilessStartupLib/DxeLoad.c
@@ -20,6 +20,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/PrePiLib.h>
 #include "X64/PageTables.h"
 #include <Library/ReportStatusCodeLib.h>
+#include <Library/HobLib.h>
 
 #define STACK_SIZE  0x20000
 extern EFI_GUID  gEfiNonCcFvGuid;
@@ -187,6 +188,7 @@ FindDxeNonCc (
   UINT32               FvAlignment;
   VOID                 *FvBuffer;
   EFI_FV_INFO          ParentVolumeInfo;
+  UINT32               AuthenticationStatus;
 
   FileHandle = NULL;
 
@@ -202,7 +204,7 @@ FindDxeNonCc (
   //
   // Find FvImage in FvFile
   //
-  Status = FfsFindSectionDataWithHook (EFI_SECTION_FIRMWARE_VOLUME_IMAGE, CheckSectionHookForDxeNonCc, FileHandle, (VOID **)&FvImageHandle);
+  Status = FfsFindSectionDataWithHook (EFI_SECTION_FIRMWARE_VOLUME_IMAGE, CheckSectionHookForDxeNonCc, FileHandle, (VOID **)&FvImageHandle, &AuthenticationStatus);
   if (EFI_ERROR (Status)) {
     return Status;
   }
@@ -257,6 +259,15 @@ FindDxeNonCc (
     &(((EFI_FFS_FILE_HEADER *)FileHandle)->Name)
     );
 
+  BuildFv3Hob (
+    (EFI_PHYSICAL_ADDRESS)(UINTN)FvImageInfo.FvStart,
+    FvImageInfo.FvSize,
+    AuthenticationStatus,
+    TRUE,
+    &ParentVolumeInfo.FvName,
+    &(((EFI_FFS_FILE_HEADER *)FileHandle)->Name)
+    );
+
   return Status;
 }
 
@@ -299,7 +310,7 @@ DxeLoadCore (
   //
   // Load the DXE Core from a Firmware Volume.
   //
-  Status = FfsFindSectionDataWithHook (EFI_SECTION_PE32, NULL, FileHandle, &PeCoffImage);
+  Status = FfsFindSectionDataWithHook (EFI_SECTION_PE32, NULL, FileHandle, &PeCoffImage, NULL);
   if (EFI_ERROR (Status)) {
     return Status;
   }

--- a/OvmfPkg/RiscVVirt/Library/PlatformSecLib/PlatformSecLib.c
+++ b/OvmfPkg/RiscVVirt/Library/PlatformSecLib/PlatformSecLib.c
@@ -155,7 +155,7 @@ SecPEIlessStartup (
              );
   ASSERT_EFI_ERROR (Status);
 
-  Status = FfsProcessFvFile (FileHandle);
+  Status = FfsProcessFvFile (FileHandle, BootFirmwareVolume);
   ASSERT_EFI_ERROR (Status);
 
   //


### PR DESCRIPTION
# Description

This PR improves handling of FV3 HOBs in EmbeddedPkg and OvmfPkg, which have not been updated to follow what PEI Core does.

There are three commits in this PR:

EmbeddedPkg: PrePi.h: Drop Duplicate HOB Defintions
--
PrePi.h has some duplicate HOB definitions from HobLib.h. Instead of redefining them, use HobLib.h as this already defined for the PrePi environment.

EmbeddedPkg: PrePiLib: Skip Extracting if FV3 HOB Found
--
PrePiLib only searches for the existence of an FV2 HOB to determine if an FV has already been extracted. However, FV2 HOBs have been superceded by FV3 HOBs for describing extracted FVs.

This commit updates PrePiLib to check for the existence of either an FV2 or FV3 HOB for this FV and skips extracting if either is found.

This follows the same proposed behavior in https://github.com/tianocore/edk2/pull/12671.

EmbeddedPkg: PrePiLib: Zero Volume Info Buffer Before Writing
--
FfsGetVolumeInfo() in PrePiLib does not zero the VolumeInfo buffer before writing to it. However, it has some fields that are expected to be zero if certain conditions are not met.

For example, the FvName is expected to be all 0's if the extended header is not present in the FV. Currently, the FvName field will point to garbage if the caller does not zero the buffer first.

Flip the expectation and have FfsGetVolumeInfo() zero the buffer before it writes to it.

EmbeddedPkg, OvmfPkg: PrePiLib: Use Correct FvName in FV2 HOB Production
--
PrePiLib is incorrectly producing FV2 HOBs. The FvName field of the FV2 HOB is intended to be the parent FV's name. This way the HOB consumer phase can identify when an FV has already been extracted: if the file name of the extracted FV and the parent FV name match in the FV2 HOB.

With the incorrect FvName, DXE will re-extract the already extracted FV, which can be a large performance hit (some platforms we have seen ~1 second).

This requires an update to FfsProcessFvFile to pass the parent FV handle through so the FV2 HOB can be correctly produced. OvmfPkg consumers are also updated.

Closes #9780 .

OvmfPkg: PeilessStartupLib: Fix FV2 HOB Production
--
PeilessStartupLib is incorrectly producing FV2 HOBs. The FvName field of the FV2 HOB is intended to be the parent FV's name. This way the HOB consumer phase can identify when an FV has already been extracted: if the file name of the extracted FV and the parent FV name match in the FV2 HOB.

With the incorrect FvName, DXE will re-extract the already extracted FV, which can be a large performance hit (some platforms we have seen ~1 second).

EmbeddedPkg, OvmfPkg: Produce FV3 HOBs for Extracted FVs
--
EmbeddedPkg's PrePiLib and OvmfPkg's PeilessStartupLib (which uses PrePiLib) only produce FV2 HOBs for extracted FVs. However, FV3 HOBs have superceded FV2 HOBs for describing extracted FVs.

This commit updates both of these libs to also produce FV3 HOBs, following PEI's pattern of producing an FV, FV2, and FV3 HOB for each extracted FV.

Eventually, only FV3 HOBs will be produced, so this paves the way for that.

In order to produce the FV3 HOB, the authentication status is required to be piped out from PrePiLib when the GUIDed extraction occurs. As such, a breaking change is introduced to add an optional parameter to `FfsFindSectionDataWithHook()` that allows the authentication status to be retrieved.

- [x] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Tested booting OvmfPkg/IntelTdx to shell with this change and with only producing FV3 HOBs. Confirmed that extracted FVs were being re-extracted with current code, after the changes, not being re-extracted.

## Integration Instructions

Callers of `FfsFindSectionDataWithHook()` must update the call to add the `AuthenticationStatus` parameter. For existing use cases, this can always be `NULL`. If the authentication status is desired to be returned, then a UINT32 pointer may be passed here.

Callers of `FfsProcessFvFile()` must update the call to add the `ParentVolumeHandle`.
