### PR TITLE
CryptoPkg: Log TLS handshake certificate verification error reason

### DIFF
--- a/CryptoPkg/Library/TlsLib/TlsProcess.c
+++ b/CryptoPkg/Library/TlsLib/TlsProcess.c
@@ -151,6 +151,22 @@ TlsDoHandshake (
           Func,
           Data
           ));
+
+        if ((ERR_GET_LIB (ErrorCode) == ERR_LIB_SSL) && \
+            (ERR_GET_REASON (ErrorCode) == SSL_R_CERTIFICATE_VERIFY_FAILED))
+        {
+          INT32  X509Err;
+
+          X509Err = SSL_get_verify_result (TlsConn->Ssl);
+
+          DEBUG ((
+            DEBUG_ERROR,
+            "%a X509_verify_result: %d (%a)\n",
+            __func__,
+            X509Err,
+            X509_verify_cert_error_string (X509Err)
+            ));
+        }
       }
 
       DEBUG_CODE_END ();


### PR DESCRIPTION
# Description

When the TLS error is `SSL_R_CERTIFICATE_VERIFY_FAILED`, the verification failure reason is reported by `SSL_get_verify_result`.

Adding this reason to the debug logs is valuable to pin-point certificate rejection that are specific to EDK II.

- [ ] Breaking change? - No, only a log in DEBUG mode
- [ ] Impacts security? - No, only a log in DEBUG mode
- [ ] Includes tests? - N/A

## How This Was Tested

This was tested with Qemu on Ubuntu 26.04 by HTTPS-booting https://boot.netboot.xyz/ipxe/netboot.xyz-snponly.efi. This specific URL fails because it is signed by an RSA 2048 private key which is rejected by the security level 3 required by `CryptoPkg`. With this patch, the following additional log line was produced:

```
TlsDoHandshake X509_verify_result: 66 (EE certificate key too weak)
```

## Integration Instructions

N/A
