### PR TITLE
BaseTools: Update tools_def.template version to 3.07

### DIFF
--- a/BaseTools/Conf/tools_def.template
+++ b/BaseTools/Conf/tools_def.template
@@ -27,8 +27,15 @@
 # 3.05 - Add CLANGPDB AARCH64 Support
 # 3.06 - Remove GCC48, GCC49 and GCC5
 # 3.07 - Switch alignemnt to 4k for X64 builds add XIP_FLAGS.
+#      - Add --apply-dynamic-relocs option for AARCH64 CLANGDWARF builds
+#      - Add missing CLANGDWARF OBJCOPY_FLAGS
+#      - Canonicalize CLANGDWARF definitions
+#      - Align X64 CLANGDWARF and CLANGPDB definitions
+#      - Add GENFWHII_FLAGS to fix VS2026 GenFw build issue
+#      - Add -malign-double to IA32 ASLCC_FLAGS
+#      - Add CLANGDWARF support for LoongArch64
 #
-#!VERSION=3.06
+#!VERSION=3.07
 
 IDENTIFIER = Default TOOL_CHAIN_CONF
 


### PR DESCRIPTION
# Description

Commit 87e486f defined a 3.07 version for tools_def.template, but the version in the file was not updated. This commit updates the version to 3.07 and includes changes made since 3.06. Updating the version informs users that they should update their conf files during the build process.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

Build with the change to verify the update message appears:

<img width="948" height="130" alt="image" src="https://github.com/user-attachments/assets/871ea5c5-c67d-4581-a26f-9fb9f95460a0" />

## Integration Instructions

Remove your local `Conf/tools_def.txt` file so the build process can copy the new file over, so the latest build settings are active in your local workspace.