### PR TITLE
Create IoMmuLib and new IoMmu protocol function

### DIFF
--- a/ArmVirtPkg/ArmVirt.dsc.inc
+++ b/ArmVirtPkg/ArmVirt.dsc.inc
@@ -130,6 +130,7 @@ DEFINE FD_SIZE_IN_MB    = 3
   BootLogoLib|MdeModulePkg/Library/BootLogoLib/BootLogoLib.inf
   CapsuleLib|MdeModulePkg/Library/DxeCapsuleLibNull/DxeCapsuleLibNull.inf
   CustomizedDisplayLib|MdeModulePkg/Library/CustomizedDisplayLib/CustomizedDisplayLib.inf
+  IoMmuLib|MdeModulePkg/Library/IoMmuLibNull/IoMmuLibNull.inf
   TpmMeasurementLib|MdeModulePkg/Library/TpmMeasurementLibNull/TpmMeasurementLibNull.inf
 
   PlatformPeiLib|ArmVirtPkg/Library/PlatformPeiLib/PlatformPeiLib.inf

--- a/ArmVirtPkg/ArmVirt.dsc.inc
+++ b/ArmVirtPkg/ArmVirt.dsc.inc
@@ -152,6 +152,7 @@ DEFINE FD_SIZE_IN_MB    = 3
   BootLogoLib|MdeModulePkg/Library/BootLogoLib/BootLogoLib.inf
   CapsuleLib|MdeModulePkg/Library/DxeCapsuleLibNull/DxeCapsuleLibNull.inf
   CustomizedDisplayLib|MdeModulePkg/Library/CustomizedDisplayLib/CustomizedDisplayLib.inf
+  IoMmuLib|MdeModulePkg/Library/IoMmuLibNull/IoMmuLibNull.inf
   TpmMeasurementLib|MdeModulePkg/Library/TpmMeasurementLibNull/TpmMeasurementLibNull.inf
 
   PlatformPeiLib|ArmVirtPkg/Library/PlatformPeiLib/PlatformPeiLib.inf

--- a/EmbeddedPkg/Drivers/NonCoherentIoMmuDxe/NonCoherentIoMmuDxe.c
+++ b/EmbeddedPkg/Drivers/NonCoherentIoMmuDxe/NonCoherentIoMmuDxe.c
@@ -142,6 +142,8 @@ NonCoherentIoMmuMap (
            DmaOperation,
            HostAddress,
            NumberOfBytes,
+           0, // IommuBase=0 opts out of IoMmu programming
+           0, // DmaId unused
            DeviceAddress,
            Mapping
            );

--- a/EmbeddedPkg/EmbeddedPkg.dsc
+++ b/EmbeddedPkg/EmbeddedPkg.dsc
@@ -73,6 +73,7 @@
  # Need to change this for IPF
  #
   IoLib|MdePkg/Library/BaseIoLibIntrinsic/BaseIoLibIntrinsic.inf
+  IoMmuLib|MdeModulePkg/Library/IoMmuLibNull/IoMmuLibNull.inf
 
   MemoryAllocationLib|MdePkg/Library/UefiMemoryAllocationLib/UefiMemoryAllocationLib.inf
   UefiLib|MdePkg/Library/UefiLib/UefiLib.inf

--- a/EmbeddedPkg/Include/Library/DmaLib.h
+++ b/EmbeddedPkg/Include/Library/DmaLib.h
@@ -59,6 +59,10 @@ typedef enum {
   @param  HostAddress           The system memory address to map to the DMA controller.
   @param  NumberOfBytes         On input the number of bytes to map. On output the number of bytes
                                 that were mapped.
+  @param  IommuBase             Base MMIO address of the IOMMU that owns the DMA agent's DmaId.
+                                Pass 0 if the caller does not require IOMMU programming.
+  @param  DmaId                 DMA identifier emitted by the DMA agent on the IOMMU identified
+                                by IommuBase (e.g. StreamID on Arm SMMU, RequesterID on VT-d).
   @param  DeviceAddress         The resulting map address for the bus master controller to use to
                                 access the hosts HostAddress.
   @param  Mapping               A resulting value to pass to DmaUnmap().
@@ -76,6 +80,8 @@ DmaMap (
   IN     DMA_MAP_OPERATION  Operation,
   IN     VOID               *HostAddress,
   IN OUT UINTN              *NumberOfBytes,
+  IN     UINT64             IommuBase,
+  IN     UINT32             DmaId,
   OUT    PHYSICAL_ADDRESS   *DeviceAddress,
   OUT    VOID               **Mapping
   );

--- a/EmbeddedPkg/Library/CoherentDmaLib/CoherentDmaLib.c
+++ b/EmbeddedPkg/Library/CoherentDmaLib/CoherentDmaLib.c
@@ -10,7 +10,15 @@
 #include <Uefi.h>
 #include <Library/DebugLib.h>
 #include <Library/DmaLib.h>
+#include <Library/IoMmuLib.h>
 #include <Library/MemoryAllocationLib.h>
+#include <Protocol/IoMmu.h>
+
+typedef struct {
+  VOID      *IoMmuContext;
+  UINT64    IommuBase;
+  UINT32    DmaId;
+} COHERENT_MAP_INFO;
 
 STATIC
 PHYSICAL_ADDRESS
@@ -19,6 +27,138 @@ HostToDeviceAddress (
   )
 {
   return (PHYSICAL_ADDRESS)(UINTN)Address + PcdGet64 (PcdDmaDeviceOffset);
+}
+
+/**
+  Translate a DMA bus master operation into the corresponding IOMMU operation
+  and access attributes, install an IOMMU mapping for IoMmuHostAddress and set
+  the access attributes on the resulting mapping via (Map->IommuBase, Map->DmaId).
+
+  On success, Map->IoMmuContext holds the mapping handle that DmaUnmapIoMmu()
+  can later release. On failure, no IOMMU mapping is leaked.
+
+  @param[in]      Operation         The DMA bus master operation.
+  @param[in]      IoMmuHostAddress  Host address to be mapped through the IOMMU.
+  @param[in,out]  NumberOfBytes     Length of the mapping.
+  @param[in,out]  DeviceAddress     Resulting device address.
+  @param[in,out]  Map               Map info; Map->IoMmuContext is populated on
+                                    success.
+
+  @retval EFI_SUCCESS            Mapping established and attributes set.
+  @retval EFI_INVALID_PARAMETER  Operation is not a valid bus master operation.
+  @retval Other                  Error returned by the IOMMU library.
+**/
+STATIC
+EFI_STATUS
+DmaMapIoMmu (
+  IN     DMA_MAP_OPERATION  Operation,
+  IN     VOID               *IoMmuHostAddress,
+  IN OUT UINTN              *NumberOfBytes,
+  IN OUT PHYSICAL_ADDRESS   *DeviceAddress,
+  IN OUT COHERENT_MAP_INFO  *Map
+  )
+{
+  EFI_STATUS             Status;
+  EDKII_IOMMU_OPERATION  IoMmuOperation;
+  UINT64                 IoMmuAttribute;
+
+  if ((Operation >= MapOperationMaximum) || (IoMmuHostAddress == NULL) ||
+      (NumberOfBytes == NULL) || (DeviceAddress == NULL) || (Map == NULL))
+  {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  switch (Operation) {
+    case MapOperationBusMasterRead:
+      IoMmuOperation = EdkiiIoMmuOperationBusMasterRead;
+      IoMmuAttribute = EDKII_IOMMU_ACCESS_READ;
+      break;
+
+    case MapOperationBusMasterWrite:
+      IoMmuOperation = EdkiiIoMmuOperationBusMasterWrite;
+      IoMmuAttribute = EDKII_IOMMU_ACCESS_WRITE;
+      break;
+
+    case MapOperationBusMasterCommonBuffer:
+      IoMmuOperation = EdkiiIoMmuOperationBusMasterCommonBuffer;
+      IoMmuAttribute = (EDKII_IOMMU_ACCESS_READ | EDKII_IOMMU_ACCESS_WRITE);
+      break;
+
+    default:
+      DEBUG ((DEBUG_ERROR, "%a - Invalid operation %d\n", __func__, Operation));
+      ASSERT (FALSE);
+      return EFI_INVALID_PARAMETER;
+  }
+
+  Status = IoMmuMap (
+             IoMmuOperation,
+             IoMmuHostAddress,
+             NumberOfBytes,
+             DeviceAddress,
+             &Map->IoMmuContext
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a - IoMmuMap failed.\n", __func__));
+    ASSERT (FALSE);
+    return Status;
+  }
+
+  Status = IoMmuSetAttributeById (
+             Map->IommuBase,
+             Map->DmaId,
+             Map->IoMmuContext,
+             IoMmuAttribute
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a - IoMmuSetAttributeById failed.\n", __func__));
+    ASSERT (FALSE);
+    if (EFI_ERROR (IoMmuUnmap (Map->IoMmuContext))) {
+      DEBUG ((DEBUG_ERROR, "%a - IoMmuUnmap failed.\n", __func__));
+      ASSERT (FALSE);
+    }
+
+    Map->IoMmuContext = NULL;
+  }
+
+  return Status;
+}
+
+/**
+  Reverse a previous DmaMapIoMmu() call by clearing the IOMMU access attributes
+  and tearing down the mapping.
+
+  @param[in] Map  Map info populated by DmaMapIoMmu().
+
+  @retval EFI_SUCCESS  The mapping has been released.
+  @retval Other        Error returned by the IOMMU library.
+**/
+STATIC
+EFI_STATUS
+DmaUnmapIoMmu (
+  IN COHERENT_MAP_INFO  *Map
+  )
+{
+  EFI_STATUS  Status;
+
+  if ((Map == NULL)) {
+    return EFI_SUCCESS;
+  }
+
+  Status = IoMmuSetAttributeById (Map->IommuBase, Map->DmaId, Map->IoMmuContext, 0);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a - IoMmuSetAttributeById failed.\n", __func__));
+    ASSERT (FALSE);
+    return Status;
+  }
+
+  Status = IoMmuUnmap (Map->IoMmuContext);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a - IoMmuUnmap failed.\n", __func__));
+    ASSERT (FALSE);
+    return Status;
+  }
+
+  return EFI_SUCCESS;
 }
 
 /**
@@ -47,10 +187,16 @@ DmaMap (
   IN     DMA_MAP_OPERATION  Operation,
   IN     VOID               *HostAddress,
   IN OUT UINTN              *NumberOfBytes,
+  IN     UINT64             IommuBase,
+  IN     UINT32             DmaId,
   OUT    PHYSICAL_ADDRESS   *DeviceAddress,
   OUT    VOID               **Mapping
   )
 {
+  EFI_STATUS         Status;
+  VOID               *IoMmuHostAddress;
+  COHERENT_MAP_INFO  *Map;
+
   if ((HostAddress == NULL) ||
       (NumberOfBytes == NULL) ||
       (DeviceAddress == NULL) ||
@@ -59,8 +205,36 @@ DmaMap (
     return EFI_INVALID_PARAMETER;
   }
 
-  *DeviceAddress = HostToDeviceAddress (HostAddress);
-  *Mapping       = NULL;
+  *DeviceAddress   = HostToDeviceAddress (HostAddress);
+  IoMmuHostAddress = HostAddress;
+  *Mapping         = NULL;
+
+  if (IommuBase == 0) {
+    // No IoMmu
+    return EFI_SUCCESS;
+  }
+
+  Map = AllocateZeroPool (sizeof (COHERENT_MAP_INFO));
+  if (Map == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  Map->IommuBase = IommuBase;
+  Map->DmaId     = DmaId;
+
+  Status = DmaMapIoMmu (
+             Operation,
+             IoMmuHostAddress,
+             NumberOfBytes,
+             DeviceAddress,
+             Map
+             );
+  if (EFI_ERROR (Status)) {
+    FreePool (Map);
+    return Status;
+  }
+
+  *Mapping = Map;
   return EFI_SUCCESS;
 }
 
@@ -80,6 +254,21 @@ DmaUnmap (
   IN  VOID  *Mapping
   )
 {
+  EFI_STATUS         Status;
+  COHERENT_MAP_INFO  *Map;
+
+  if (Mapping == NULL) {
+    return EFI_SUCCESS;
+  }
+
+  Map = (COHERENT_MAP_INFO *)Mapping;
+
+  Status = DmaUnmapIoMmu (Map);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  FreePool (Map);
   return EFI_SUCCESS;
 }
 

--- a/EmbeddedPkg/Library/CoherentDmaLib/CoherentDmaLib.c
+++ b/EmbeddedPkg/Library/CoherentDmaLib/CoherentDmaLib.c
@@ -10,7 +10,15 @@
 #include <Uefi.h>
 #include <Library/DebugLib.h>
 #include <Library/DmaLib.h>
+#include <Library/IoMmuLib.h>
 #include <Library/MemoryAllocationLib.h>
+#include <Protocol/IoMmu.h>
+
+typedef struct {
+  VOID      *IoMmuContext;
+  UINT64    IommuBase;
+  UINT32    DmaId;
+} COHERENT_MAP_INFO;
 
 STATIC
 PHYSICAL_ADDRESS
@@ -19,6 +27,138 @@ HostToDeviceAddress (
   )
 {
   return (PHYSICAL_ADDRESS)(UINTN)Address + PcdGet64 (PcdDmaDeviceOffset);
+}
+
+/**
+  Translate a DMA bus master operation into the corresponding IOMMU operation
+  and access attributes, install an IOMMU mapping for IoMmuHostAddress and set
+  the access attributes on the resulting mapping via (Map->IommuBase, Map->DmaId).
+
+  On success, Map->IoMmuContext holds the mapping handle that DmaUnmapIoMmu()
+  can later release. On failure, no IOMMU mapping is leaked.
+
+  @param[in]      Operation         The DMA bus master operation.
+  @param[in]      IoMmuHostAddress  Host address to be mapped through the IOMMU.
+  @param[in,out]  NumberOfBytes     Length of the mapping.
+  @param[in,out]  DeviceAddress     Resulting device address.
+  @param[in,out]  Map               Map info; Map->IoMmuContext is populated on
+                                    success.
+
+  @retval EFI_SUCCESS            Mapping established and attributes set.
+  @retval EFI_INVALID_PARAMETER  Operation is not a valid bus master operation.
+  @retval Other                  Error returned by the IOMMU library.
+**/
+STATIC
+EFI_STATUS
+DmaMapIoMmu (
+  IN     DMA_MAP_OPERATION  Operation,
+  IN     VOID               *IoMmuHostAddress,
+  IN OUT UINTN              *NumberOfBytes,
+  IN OUT PHYSICAL_ADDRESS   *DeviceAddress,
+  IN OUT COHERENT_MAP_INFO  *Map
+  )
+{
+  EFI_STATUS             Status;
+  EDKII_IOMMU_OPERATION  IoMmuOperation;
+  UINT64                 IoMmuAttribute;
+
+  if ((Operation >= MapOperationMaximum) || (IoMmuHostAddress == NULL) ||
+      (NumberOfBytes == NULL) || (DeviceAddress == NULL) || (Map == NULL))
+  {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  switch (Operation) {
+    case MapOperationBusMasterRead:
+      IoMmuOperation = EdkiiIoMmuOperationBusMasterRead;
+      IoMmuAttribute = EDKII_IOMMU_ACCESS_READ;
+      break;
+
+    case MapOperationBusMasterWrite:
+      IoMmuOperation = EdkiiIoMmuOperationBusMasterWrite;
+      IoMmuAttribute = EDKII_IOMMU_ACCESS_WRITE;
+      break;
+
+    case MapOperationBusMasterCommonBuffer:
+      IoMmuOperation = EdkiiIoMmuOperationBusMasterCommonBuffer;
+      IoMmuAttribute = (EDKII_IOMMU_ACCESS_READ | EDKII_IOMMU_ACCESS_WRITE);
+      break;
+
+    default:
+      DEBUG ((DEBUG_ERROR, "%a - Invalid operation %d\n", __func__, Operation));
+      ASSERT (FALSE);
+      return EFI_INVALID_PARAMETER;
+  }
+
+  Status = IoMmuMap (
+             IoMmuOperation,
+             IoMmuHostAddress,
+             NumberOfBytes,
+             DeviceAddress,
+             &Map->IoMmuContext
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a - IoMmuMap failed.\n", __func__));
+    ASSERT (FALSE);
+    return Status;
+  }
+
+  Status = IoMmuSetAttributeById (
+             Map->IommuBase,
+             Map->DmaId,
+             Map->IoMmuContext,
+             IoMmuAttribute
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a - IoMmuSetAttributeById failed.\n", __func__));
+    ASSERT (FALSE);
+    if (EFI_ERROR (IoMmuUnmap (Map->IoMmuContext))) {
+      DEBUG ((DEBUG_ERROR, "%a - IoMmuUnmap failed.\n", __func__));
+      ASSERT (FALSE);
+    }
+
+    Map->IoMmuContext = NULL;
+  }
+
+  return Status;
+}
+
+/**
+  Reverse a previous DmaMapIoMmu() call by clearing the IOMMU access attributes
+  and tearing down the mapping.
+
+  @param[in] Map  Map info populated by DmaMapIoMmu().
+
+  @retval EFI_SUCCESS  The mapping has been released.
+  @retval Other        Error returned by the IOMMU library.
+**/
+STATIC
+EFI_STATUS
+DmaUnmapIoMmu (
+  IN COHERENT_MAP_INFO  *Map
+  )
+{
+  EFI_STATUS  Status;
+
+  if ((Map == NULL)) {
+    return EFI_SUCCESS;
+  }
+
+  Status = IoMmuSetAttributeById (Map->IommuBase, Map->DmaId, Map->IoMmuContext, 0);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a - IoMmuSetAttributeById failed.\n", __func__));
+    ASSERT (FALSE);
+    return Status;
+  }
+
+  Status = IoMmuUnmap (Map->IoMmuContext);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a - IoMmuUnmap failed.\n", __func__));
+    ASSERT (FALSE);
+    return Status;
+  }
+
+  return EFI_SUCCESS;
 }
 
 /**
@@ -47,10 +187,16 @@ DmaMap (
   IN     DMA_MAP_OPERATION  Operation,
   IN     VOID               *HostAddress,
   IN OUT UINTN              *NumberOfBytes,
+  IN     UINT64             IommuBase,
+  IN     UINT32             DmaId,
   OUT    PHYSICAL_ADDRESS   *DeviceAddress,
   OUT    VOID               **Mapping
   )
 {
+  EFI_STATUS         Status;
+  VOID               *IoMmuHostAddress;
+  COHERENT_MAP_INFO  *Map;
+
   if ((HostAddress == NULL) ||
       (NumberOfBytes == NULL) ||
       (DeviceAddress == NULL) ||
@@ -59,8 +205,36 @@ DmaMap (
     return EFI_INVALID_PARAMETER;
   }
 
-  *DeviceAddress = HostToDeviceAddress (HostAddress);
-  *Mapping       = NULL;
+  *DeviceAddress   = HostToDeviceAddress (HostAddress);
+  IoMmuHostAddress = HostAddress;
+  *Mapping         = NULL;
+
+  if (IommuBase == 0) {
+    // No IoMmu
+    return EFI_SUCCESS;
+  }
+
+  Map = AllocateZeroPool (sizeof (COHERENT_MAP_INFO));
+  if (Map == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  Map->IommuBase = IommuBase;
+  Map->DmaId     = DmaId;
+
+  Status = DmaMapIoMmu (
+             Operation,
+             IoMmuHostAddress,
+             NumberOfBytes,
+             DeviceAddress,
+             Map
+             );
+  if (EFI_ERROR (Status)) {
+    FreePool (Map);
+    return Status;
+  }
+
+  *Mapping = Map;
   return EFI_SUCCESS;
 }
 
@@ -80,7 +254,22 @@ DmaUnmap (
   IN  VOID  *Mapping
   )
 {
-  return EFI_SUCCESS;
+  EFI_STATUS         Status;
+  COHERENT_MAP_INFO  *Map;
+
+  if (Mapping == NULL) {
+    return EFI_SUCCESS;
+  }
+
+  Map = (COHERENT_MAP_INFO *)Mapping;
+
+  Status = DmaUnmapIoMmu (Map);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a - DmaUnmapIoMmu failed: %r\n", __func__, Status));
+  }
+
+  FreePool (Map);
+  return Status;
 }
 
 /**

--- a/EmbeddedPkg/Library/CoherentDmaLib/CoherentDmaLib.inf
+++ b/EmbeddedPkg/Library/CoherentDmaLib/CoherentDmaLib.inf
@@ -20,10 +20,12 @@
 
 [Packages]
   MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
   EmbeddedPkg/EmbeddedPkg.dec
 
 [LibraryClasses]
   DebugLib
+  IoMmuLib
   MemoryAllocationLib
 
 [Pcd]

--- a/EmbeddedPkg/Library/NonCoherentDmaLib/NonCoherentDmaLib.c
+++ b/EmbeddedPkg/Library/NonCoherentDmaLib/NonCoherentDmaLib.c
@@ -18,7 +18,8 @@
 #include <Library/UefiBootServicesTableLib.h>
 #include <Library/IoLib.h>
 #include <Library/BaseMemoryLib.h>
-
+#include <Library/IoMmuLib.h>
+#include <Protocol/IoMmu.h>
 #include <Protocol/Cpu.h>
 
 typedef struct {
@@ -27,6 +28,9 @@ typedef struct {
   UINTN                   NumberOfBytes;
   DMA_MAP_OPERATION       Operation;
   BOOLEAN                 DoubleBuffer;
+  VOID                    *IoMmuContext;
+  UINT64                  IommuBase;
+  UINT32                  DmaId;
 } MAP_INFO_INSTANCE;
 
 typedef struct {
@@ -48,6 +52,138 @@ HostToDeviceAddress (
   )
 {
   return (PHYSICAL_ADDRESS)(UINTN)Address + PcdGet64 (PcdDmaDeviceOffset);
+}
+
+/**
+  Translate a DMA bus master operation into the corresponding IOMMU operation
+  and access attributes, install an IOMMU mapping for IoMmuHostAddress and set
+  the access attributes on the resulting mapping via (Map->IommuBase, Map->DmaId).
+
+  On success, Map->IoMmuContext holds the mapping handle that DmaUnmapIoMmu()
+  can later release. On failure, no IOMMU mapping is leaked.
+
+  @param[in]      Operation         The DMA bus master operation.
+  @param[in]      IoMmuHostAddress  Host address to be mapped through the IOMMU.
+  @param[in,out]  NumberOfBytes     Length of the mapping.
+  @param[in,out]  DeviceAddress     Resulting device address.
+  @param[in,out]  Map               Map info; Map->IoMmuContext is populated on
+                                    success.
+
+  @retval EFI_SUCCESS            Mapping established and attributes set.
+  @retval EFI_INVALID_PARAMETER  Operation is not a valid bus master operation.
+  @retval Other                  Error returned by the IOMMU library.
+**/
+STATIC
+EFI_STATUS
+DmaMapIoMmu (
+  IN     DMA_MAP_OPERATION  Operation,
+  IN     VOID               *IoMmuHostAddress,
+  IN OUT UINTN              *NumberOfBytes,
+  IN OUT PHYSICAL_ADDRESS   *DeviceAddress,
+  IN OUT MAP_INFO_INSTANCE  *Map
+  )
+{
+  EFI_STATUS             Status;
+  EDKII_IOMMU_OPERATION  IoMmuOperation;
+  UINT64                 IoMmuAttribute;
+
+  if ((Operation >= MapOperationMaximum) || (IoMmuHostAddress == NULL) ||
+      (NumberOfBytes == NULL) || (DeviceAddress == NULL) || (Map == NULL))
+  {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  switch (Operation) {
+    case MapOperationBusMasterRead:
+      IoMmuOperation = EdkiiIoMmuOperationBusMasterRead;
+      IoMmuAttribute = EDKII_IOMMU_ACCESS_READ;
+      break;
+
+    case MapOperationBusMasterWrite:
+      IoMmuOperation = EdkiiIoMmuOperationBusMasterWrite;
+      IoMmuAttribute = EDKII_IOMMU_ACCESS_WRITE;
+      break;
+
+    case MapOperationBusMasterCommonBuffer:
+      IoMmuOperation = EdkiiIoMmuOperationBusMasterCommonBuffer;
+      IoMmuAttribute = (EDKII_IOMMU_ACCESS_READ | EDKII_IOMMU_ACCESS_WRITE);
+      break;
+
+    default:
+      DEBUG ((DEBUG_ERROR, "%a - Invalid operation %d\n", __func__, Operation));
+      ASSERT (FALSE);
+      return EFI_INVALID_PARAMETER;
+  }
+
+  Status = IoMmuMap (
+             IoMmuOperation,
+             IoMmuHostAddress,
+             NumberOfBytes,
+             DeviceAddress,
+             &Map->IoMmuContext
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a - IoMmuMap failed.\n", __func__));
+    ASSERT (FALSE);
+    return Status;
+  }
+
+  Status = IoMmuSetAttributeById (
+             Map->IommuBase,
+             Map->DmaId,
+             Map->IoMmuContext,
+             IoMmuAttribute
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a - IoMmuSetAttributeById failed.\n", __func__));
+    ASSERT (FALSE);
+    if (EFI_ERROR (IoMmuUnmap (Map->IoMmuContext))) {
+      DEBUG ((DEBUG_ERROR, "%a - IoMmuUnmap failed.\n", __func__));
+      ASSERT (FALSE);
+    }
+
+    Map->IoMmuContext = NULL;
+  }
+
+  return Status;
+}
+
+/**
+  Reverse a previous DmaMapIoMmu() call by clearing the IOMMU access attributes
+  and tearing down the mapping.
+
+  @param[in] Map  Map info populated by DmaMapIoMmu().
+
+  @retval EFI_SUCCESS  The mapping has been released.
+  @retval Other        Error returned by the IOMMU library.
+**/
+STATIC
+EFI_STATUS
+DmaUnmapIoMmu (
+  IN MAP_INFO_INSTANCE  *Map
+  )
+{
+  EFI_STATUS  Status;
+
+  if ((Map == NULL)) {
+    return EFI_SUCCESS;
+  }
+
+  Status = IoMmuSetAttributeById (Map->IommuBase, Map->DmaId, Map->IoMmuContext, 0);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a - IoMmuSetAttributeById failed.\n", __func__));
+    ASSERT (FALSE);
+    return Status;
+  }
+
+  Status = IoMmuUnmap (Map->IoMmuContext);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a - IoMmuUnmap failed.\n", __func__));
+    ASSERT (FALSE);
+    return Status;
+  }
+
+  return EFI_SUCCESS;
 }
 
 /**
@@ -192,6 +328,8 @@ DmaMap (
   IN     DMA_MAP_OPERATION  Operation,
   IN     VOID               *HostAddress,
   IN OUT UINTN              *NumberOfBytes,
+  IN     UINT64             IommuBase,
+  IN     UINT32             DmaId,
   OUT    PHYSICAL_ADDRESS   *DeviceAddress,
   OUT    VOID               **Mapping
   )
@@ -201,6 +339,7 @@ DmaMap (
   VOID                             *Buffer;
   EFI_GCD_MEMORY_SPACE_DESCRIPTOR  GcdDescriptor;
   UINTN                            AllocSize;
+  VOID                             *IoMmuHostAddress;
 
   if ((HostAddress == NULL) ||
       (NumberOfBytes == NULL) ||
@@ -214,7 +353,8 @@ DmaMap (
     return EFI_INVALID_PARAMETER;
   }
 
-  *DeviceAddress = HostToDeviceAddress (HostAddress);
+  *DeviceAddress   = HostToDeviceAddress (HostAddress);
+  IoMmuHostAddress = HostAddress;
 
   // Remember range so we can flush on the other side
   Map = AllocatePool (sizeof (MAP_INFO_INSTANCE));
@@ -249,7 +389,8 @@ DmaMap (
             EfiCpuFlushTypeWriteBack
             );
 
-    *DeviceAddress = HostToDeviceAddress (Map->BufferAddress);
+    *DeviceAddress   = HostToDeviceAddress (Map->BufferAddress);
+    IoMmuHostAddress = Map->BufferAddress;
   } else if ((Operation != MapOperationBusMasterRead) &&
              ((((UINTN)HostAddress & (mCpu->DmaBufferAlignment - 1)) != 0) ||
               ((*NumberOfBytes & (mCpu->DmaBufferAlignment - 1)) != 0)))
@@ -286,8 +427,9 @@ DmaMap (
         goto FreeMapInfo;
       }
 
-      Buffer         = ALIGN_POINTER (Map->BufferAddress, mCpu->DmaBufferAlignment);
-      *DeviceAddress = HostToDeviceAddress (Buffer);
+      Buffer           = ALIGN_POINTER (Map->BufferAddress, mCpu->DmaBufferAlignment);
+      *DeviceAddress   = HostToDeviceAddress (Buffer);
+      IoMmuHostAddress = Buffer;
 
       //
       // Get rid of any dirty cachelines covering the double buffer. This
@@ -338,8 +480,27 @@ DmaMap (
   Map->HostAddress   = (UINTN)HostAddress;
   Map->NumberOfBytes = *NumberOfBytes;
   Map->Operation     = Operation;
+  Map->IoMmuContext  = NULL;
+  Map->IommuBase     = IommuBase;
+  Map->DmaId         = DmaId;
 
   *Mapping = Map;
+
+  if (IommuBase == 0) {
+    // No IoMmu
+    return EFI_SUCCESS;
+  }
+
+  Status = DmaMapIoMmu (
+             Operation,
+             IoMmuHostAddress,
+             NumberOfBytes,
+             DeviceAddress,
+             Map
+             );
+  if (EFI_ERROR (Status)) {
+    goto FreeMapInfo;
+  }
 
   return EFI_SUCCESS;
 
@@ -389,6 +550,13 @@ DmaUnmap (
   }
 
   Map = (MAP_INFO_INSTANCE *)Mapping;
+
+  if (Map->IommuBase != 0) {
+    Status = DmaUnmapIoMmu (Map);
+    if (EFI_ERROR (Status)) {
+      return Status;
+    }
+  }
 
   Status = EFI_SUCCESS;
   if (((UINTN)Map->HostAddress + Map->NumberOfBytes) > mDmaHostAddressLimit) {

--- a/EmbeddedPkg/Library/NonCoherentDmaLib/NonCoherentDmaLib.c
+++ b/EmbeddedPkg/Library/NonCoherentDmaLib/NonCoherentDmaLib.c
@@ -18,7 +18,8 @@
 #include <Library/UefiBootServicesTableLib.h>
 #include <Library/IoLib.h>
 #include <Library/BaseMemoryLib.h>
-
+#include <Library/IoMmuLib.h>
+#include <Protocol/IoMmu.h>
 #include <Protocol/Cpu.h>
 
 typedef struct {
@@ -27,6 +28,9 @@ typedef struct {
   UINTN                   NumberOfBytes;
   DMA_MAP_OPERATION       Operation;
   BOOLEAN                 DoubleBuffer;
+  VOID                    *IoMmuContext;
+  UINT64                  IommuBase;
+  UINT32                  DmaId;
 } MAP_INFO_INSTANCE;
 
 typedef struct {
@@ -48,6 +52,138 @@ HostToDeviceAddress (
   )
 {
   return (PHYSICAL_ADDRESS)(UINTN)Address + PcdGet64 (PcdDmaDeviceOffset);
+}
+
+/**
+  Translate a DMA bus master operation into the corresponding IOMMU operation
+  and access attributes, install an IOMMU mapping for IoMmuHostAddress and set
+  the access attributes on the resulting mapping via (Map->IommuBase, Map->DmaId).
+
+  On success, Map->IoMmuContext holds the mapping handle that DmaUnmapIoMmu()
+  can later release. On failure, no IOMMU mapping is leaked.
+
+  @param[in]      Operation         The DMA bus master operation.
+  @param[in]      IoMmuHostAddress  Host address to be mapped through the IOMMU.
+  @param[in,out]  NumberOfBytes     Length of the mapping.
+  @param[in,out]  DeviceAddress     Resulting device address.
+  @param[in,out]  Map               Map info; Map->IoMmuContext is populated on
+                                    success.
+
+  @retval EFI_SUCCESS            Mapping established and attributes set.
+  @retval EFI_INVALID_PARAMETER  Operation is not a valid bus master operation.
+  @retval Other                  Error returned by the IOMMU library.
+**/
+STATIC
+EFI_STATUS
+DmaMapIoMmu (
+  IN     DMA_MAP_OPERATION  Operation,
+  IN     VOID               *IoMmuHostAddress,
+  IN OUT UINTN              *NumberOfBytes,
+  IN OUT PHYSICAL_ADDRESS   *DeviceAddress,
+  IN OUT MAP_INFO_INSTANCE  *Map
+  )
+{
+  EFI_STATUS             Status;
+  EDKII_IOMMU_OPERATION  IoMmuOperation;
+  UINT64                 IoMmuAttribute;
+
+  if ((Operation >= MapOperationMaximum) || (IoMmuHostAddress == NULL) ||
+      (NumberOfBytes == NULL) || (DeviceAddress == NULL) || (Map == NULL))
+  {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  switch (Operation) {
+    case MapOperationBusMasterRead:
+      IoMmuOperation = EdkiiIoMmuOperationBusMasterRead;
+      IoMmuAttribute = EDKII_IOMMU_ACCESS_READ;
+      break;
+
+    case MapOperationBusMasterWrite:
+      IoMmuOperation = EdkiiIoMmuOperationBusMasterWrite;
+      IoMmuAttribute = EDKII_IOMMU_ACCESS_WRITE;
+      break;
+
+    case MapOperationBusMasterCommonBuffer:
+      IoMmuOperation = EdkiiIoMmuOperationBusMasterCommonBuffer;
+      IoMmuAttribute = (EDKII_IOMMU_ACCESS_READ | EDKII_IOMMU_ACCESS_WRITE);
+      break;
+
+    default:
+      DEBUG ((DEBUG_ERROR, "%a - Invalid operation %d\n", __func__, Operation));
+      ASSERT (FALSE);
+      return EFI_INVALID_PARAMETER;
+  }
+
+  Status = IoMmuMap (
+             IoMmuOperation,
+             IoMmuHostAddress,
+             NumberOfBytes,
+             DeviceAddress,
+             &Map->IoMmuContext
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a - IoMmuMap failed.\n", __func__));
+    ASSERT (FALSE);
+    return Status;
+  }
+
+  Status = IoMmuSetAttributeById (
+             Map->IommuBase,
+             Map->DmaId,
+             Map->IoMmuContext,
+             IoMmuAttribute
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a - IoMmuSetAttributeById failed.\n", __func__));
+    ASSERT (FALSE);
+    if (EFI_ERROR (IoMmuUnmap (Map->IoMmuContext))) {
+      DEBUG ((DEBUG_ERROR, "%a - IoMmuUnmap failed.\n", __func__));
+      ASSERT (FALSE);
+    }
+
+    Map->IoMmuContext = NULL;
+  }
+
+  return Status;
+}
+
+/**
+  Reverse a previous DmaMapIoMmu() call by clearing the IOMMU access attributes
+  and tearing down the mapping.
+
+  @param[in] Map  Map info populated by DmaMapIoMmu().
+
+  @retval EFI_SUCCESS  The mapping has been released.
+  @retval Other        Error returned by the IOMMU library.
+**/
+STATIC
+EFI_STATUS
+DmaUnmapIoMmu (
+  IN MAP_INFO_INSTANCE  *Map
+  )
+{
+  EFI_STATUS  Status;
+
+  if ((Map == NULL)) {
+    return EFI_SUCCESS;
+  }
+
+  Status = IoMmuSetAttributeById (Map->IommuBase, Map->DmaId, Map->IoMmuContext, 0);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a - IoMmuSetAttributeById failed.\n", __func__));
+    ASSERT (FALSE);
+    return Status;
+  }
+
+  Status = IoMmuUnmap (Map->IoMmuContext);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a - IoMmuUnmap failed.\n", __func__));
+    ASSERT (FALSE);
+    return Status;
+  }
+
+  return EFI_SUCCESS;
 }
 
 /**
@@ -192,6 +328,8 @@ DmaMap (
   IN     DMA_MAP_OPERATION  Operation,
   IN     VOID               *HostAddress,
   IN OUT UINTN              *NumberOfBytes,
+  IN     UINT64             IommuBase,
+  IN     UINT32             DmaId,
   OUT    PHYSICAL_ADDRESS   *DeviceAddress,
   OUT    VOID               **Mapping
   )
@@ -201,6 +339,7 @@ DmaMap (
   VOID                             *Buffer;
   EFI_GCD_MEMORY_SPACE_DESCRIPTOR  GcdDescriptor;
   UINTN                            AllocSize;
+  VOID                             *IoMmuHostAddress;
 
   if ((HostAddress == NULL) ||
       (NumberOfBytes == NULL) ||
@@ -214,7 +353,8 @@ DmaMap (
     return EFI_INVALID_PARAMETER;
   }
 
-  *DeviceAddress = HostToDeviceAddress (HostAddress);
+  *DeviceAddress   = HostToDeviceAddress (HostAddress);
+  IoMmuHostAddress = HostAddress;
 
   // Remember range so we can flush on the other side
   Map = AllocatePool (sizeof (MAP_INFO_INSTANCE));
@@ -249,7 +389,8 @@ DmaMap (
             EfiCpuFlushTypeWriteBack
             );
 
-    *DeviceAddress = HostToDeviceAddress (Map->BufferAddress);
+    *DeviceAddress   = HostToDeviceAddress (Map->BufferAddress);
+    IoMmuHostAddress = Map->BufferAddress;
   } else if ((Operation != MapOperationBusMasterRead) &&
              ((((UINTN)HostAddress & (mCpu->DmaBufferAlignment - 1)) != 0) ||
               ((*NumberOfBytes & (mCpu->DmaBufferAlignment - 1)) != 0)))
@@ -286,8 +427,9 @@ DmaMap (
         goto FreeMapInfo;
       }
 
-      Buffer         = ALIGN_POINTER (Map->BufferAddress, mCpu->DmaBufferAlignment);
-      *DeviceAddress = HostToDeviceAddress (Buffer);
+      Buffer           = ALIGN_POINTER (Map->BufferAddress, mCpu->DmaBufferAlignment);
+      *DeviceAddress   = HostToDeviceAddress (Buffer);
+      IoMmuHostAddress = Buffer;
 
       //
       // Get rid of any dirty cachelines covering the double buffer. This
@@ -338,6 +480,22 @@ DmaMap (
   Map->HostAddress   = (UINTN)HostAddress;
   Map->NumberOfBytes = *NumberOfBytes;
   Map->Operation     = Operation;
+  Map->IoMmuContext  = NULL;
+  Map->IommuBase     = IommuBase;
+  Map->DmaId         = DmaId;
+
+  if (IommuBase != 0) {
+    Status = DmaMapIoMmu (
+               Operation,
+               IoMmuHostAddress,
+               NumberOfBytes,
+               DeviceAddress,
+               Map
+               );
+    if (EFI_ERROR (Status)) {
+      goto FreeMapInfo;
+    }
+  }
 
   *Mapping = Map;
 
@@ -391,6 +549,14 @@ DmaUnmap (
   Map = (MAP_INFO_INSTANCE *)Mapping;
 
   Status = EFI_SUCCESS;
+
+  if (Map->IommuBase != 0) {
+    Status = DmaUnmapIoMmu (Map);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a - DmaUnmapIoMmu failed: %r\n", __func__, Status));
+    }
+  }
+
   if (((UINTN)Map->HostAddress + Map->NumberOfBytes) > mDmaHostAddressLimit) {
     AllocSize = ALIGN_VALUE (Map->NumberOfBytes, mCpu->DmaBufferAlignment);
     if (Map->Operation == MapOperationBusMasterWrite) {

--- a/EmbeddedPkg/Library/NonCoherentDmaLib/NonCoherentDmaLib.inf
+++ b/EmbeddedPkg/Library/NonCoherentDmaLib/NonCoherentDmaLib.inf
@@ -24,12 +24,14 @@
 [Packages]
   EmbeddedPkg/EmbeddedPkg.dec
   MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
 
 [LibraryClasses]
   BaseMemoryLib
   DebugLib
   DxeServicesTableLib
   IoLib
+  IoMmuLib
   MemoryAllocationLib
   UefiBootServicesTableLib
 

--- a/EmulatorPkg/EmulatorPkg.dsc
+++ b/EmulatorPkg/EmulatorPkg.dsc
@@ -115,6 +115,7 @@
   #
   UefiScsiLib|MdePkg/Library/UefiScsiLib/UefiScsiLib.inf
   OemHookStatusCodeLib|MdeModulePkg/Library/OemHookStatusCodeLibNull/OemHookStatusCodeLibNull.inf
+  IoMmuLib|MdeModulePkg/Library/IoMmuLibNull/IoMmuLibNull.inf
   BootLogoLib|MdeModulePkg/Library/BootLogoLib/BootLogoLib.inf
   FileExplorerLib|MdeModulePkg/Library/FileExplorerLib/FileExplorerLib.inf
   UefiBootManagerLib|MdeModulePkg/Library/UefiBootManagerLib/UefiBootManagerLib.inf

--- a/MdeModulePkg/Bus/Pci/NonDiscoverablePciDeviceDxe/NonDiscoverablePciDeviceDxe.c
+++ b/MdeModulePkg/Bus/Pci/NonDiscoverablePciDeviceDxe/NonDiscoverablePciDeviceDxe.c
@@ -260,6 +260,12 @@ NonDiscoverablePciDeviceStart (
   //
   Dev->UniqueId = Dev->Device->UniqueId;
 
+  //
+  // Remember the controller handle so PciIoMap/SetAttribute
+  // can pass it to IoMmuSetAttribute for DMA identifier resolution.
+  //
+  Dev->Handle = DeviceHandle;
+
   return EFI_SUCCESS;
 
 CloseProtocol:

--- a/MdeModulePkg/Bus/Pci/NonDiscoverablePciDeviceDxe/NonDiscoverablePciDeviceDxe.c
+++ b/MdeModulePkg/Bus/Pci/NonDiscoverablePciDeviceDxe/NonDiscoverablePciDeviceDxe.c
@@ -10,9 +10,6 @@
 
 #include <Protocol/DriverBinding.h>
 
-#define MAX_NON_DISCOVERABLE_PCI_DEVICE_ID  (32 * 256)
-
-STATIC UINTN           mUniqueIdCounter = 0;
 EFI_CPU_ARCH_PROTOCOL  *mCpu;
 
 //
@@ -124,6 +121,75 @@ CloseProtocol:
 }
 
 /**
+  Check whether any other handle bound to gEdkiiNonDiscoverableDeviceProtocolGuid
+  already advertises the given UniqueId. Used to enforce that the
+  platform-assigned UniqueId is distinct across NonDiscoverableDevice instances.
+
+  @param[in]  DeviceHandle  The controller handle being bound; excluded from the
+                            duplicate check.
+  @param[in]  UniqueId      The UniqueId to look for on other handles.
+
+  @retval EFI_SUCCESS       No other handle advertises UniqueId.
+  @retval EFI_DEVICE_ERROR  Another handle already uses UniqueId.
+  @retval Other             Error returned by LocateHandleBuffer().
+**/
+STATIC
+EFI_STATUS
+CheckUniqueIdNotInUse (
+  IN EFI_HANDLE  DeviceHandle,
+  IN UINTN       UniqueId
+  )
+{
+  EFI_STATUS               Status;
+  UINTN                    HandleCount;
+  EFI_HANDLE               *HandleBuffer;
+  UINTN                    Index;
+  NON_DISCOVERABLE_DEVICE  *OtherDevice;
+
+  HandleCount  = 0;
+  HandleBuffer = NULL;
+  Status       = gBS->LocateHandleBuffer (
+                        ByProtocol,
+                        &gEdkiiNonDiscoverableDeviceProtocolGuid,
+                        NULL,
+                        &HandleCount,
+                        &HandleBuffer
+                        );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: LocateHandleBuffer failed: %r\n", __func__, Status));
+    return Status;
+  }
+
+  Status = EFI_SUCCESS;
+  for (Index = 0; Index < HandleCount; Index++) {
+    // Skip our own handle
+    if (HandleBuffer[Index] == DeviceHandle) {
+      continue;
+    }
+
+    if (EFI_ERROR (
+          gBS->HandleProtocol (
+                 HandleBuffer[Index],
+                 &gEdkiiNonDiscoverableDeviceProtocolGuid,
+                 (VOID **)&OtherDevice
+                 )
+          ))
+    {
+      continue;
+    }
+
+    if (OtherDevice->UniqueId == UniqueId) {
+      DEBUG ((DEBUG_ERROR, "%a: duplicate NonDiscoverableDevice UniqueId 0x%llx\n", __func__, UniqueId));
+      Status = EFI_DEVICE_ERROR;
+      break;
+    }
+  }
+
+  FreePool (HandleBuffer);
+  return Status;
+}
+
+/**
   This routine is called right after the .Supported() called and
   Start this driver on ControllerHandle.
 
@@ -148,11 +214,6 @@ NonDiscoverablePciDeviceStart (
   NON_DISCOVERABLE_PCI_DEVICE  *Dev;
   EFI_STATUS                   Status;
 
-  ASSERT (mUniqueIdCounter < MAX_NON_DISCOVERABLE_PCI_DEVICE_ID);
-  if (mUniqueIdCounter >= MAX_NON_DISCOVERABLE_PCI_DEVICE_ID) {
-    return EFI_OUT_OF_RESOURCES;
-  }
-
   Dev = AllocateZeroPool (sizeof *Dev);
   if (Dev == NULL) {
     return EFI_OUT_OF_RESOURCES;
@@ -168,6 +229,13 @@ NonDiscoverablePciDeviceStart (
                   );
   if (EFI_ERROR (Status)) {
     goto FreeDev;
+  }
+
+  // Reject duplicate UniqueId across NonDiscoverableDevice handles, so the
+  // platform is forced to assign a distinct ID per registration.
+  Status = CheckUniqueIdNotInUse (DeviceHandle, Dev->Device->UniqueId);
+  if (EFI_ERROR (Status)) {
+    goto CloseProtocol;
   }
 
   InitializePciIoProtocol (Dev);
@@ -187,7 +255,10 @@ NonDiscoverablePciDeviceStart (
     goto CloseProtocol;
   }
 
-  Dev->UniqueId = mUniqueIdCounter++;
+  //
+  // Use platform-supplied UniqueId from NON_DISCOVERABLE_DEVICE.
+  //
+  Dev->UniqueId = Dev->Device->UniqueId;
 
   return EFI_SUCCESS;
 

--- a/MdeModulePkg/Bus/Pci/NonDiscoverablePciDeviceDxe/NonDiscoverablePciDeviceDxe.c
+++ b/MdeModulePkg/Bus/Pci/NonDiscoverablePciDeviceDxe/NonDiscoverablePciDeviceDxe.c
@@ -276,6 +276,12 @@ NonDiscoverablePciDeviceStart (
   //
   Dev->UniqueId = Dev->Device->UniqueId;
 
+  //
+  // Remember the controller handle so PciIoMap/SetAttribute
+  // can pass it to IoMmuSetAttribute for DMA identifier resolution.
+  //
+  Dev->Handle = DeviceHandle;
+
   return EFI_SUCCESS;
 
 CloseProtocol:

--- a/MdeModulePkg/Bus/Pci/NonDiscoverablePciDeviceDxe/NonDiscoverablePciDeviceDxe.c
+++ b/MdeModulePkg/Bus/Pci/NonDiscoverablePciDeviceDxe/NonDiscoverablePciDeviceDxe.c
@@ -12,7 +12,6 @@
 
 #define MAX_NON_DISCOVERABLE_PCI_DEVICE_ID  (32 * 256)
 
-STATIC UINTN           mUniqueIdCounter = 0;
 EFI_CPU_ARCH_PROTOCOL  *mCpu;
 
 //
@@ -124,6 +123,89 @@ CloseProtocol:
 }
 
 /**
+  Check whether any other handle bound to gEdkiiNonDiscoverableDeviceProtocolGuid
+  already advertises the given UniqueId. Used to enforce that the
+  platform-assigned UniqueId is distinct across NonDiscoverableDevice instances,
+  and that it fits in the BDF range this driver synthesizes for GetLocation().
+
+  @param[in]  DeviceHandle  The controller handle being bound; excluded from the
+                            duplicate check.
+  @param[in]  UniqueId      The UniqueId to look for on other handles.
+
+  @retval EFI_SUCCESS           No other handle advertises UniqueId.
+  @retval EFI_DEVICE_ERROR      Another handle already uses UniqueId.
+  @retval EFI_OUT_OF_RESOURCES  UniqueId exceeds MAX_NON_DISCOVERABLE_PCI_DEVICE_ID.
+  @retval Other                 Error returned by LocateHandleBuffer().
+**/
+STATIC
+EFI_STATUS
+CheckUniqueIdNotInUse (
+  IN EFI_HANDLE  DeviceHandle,
+  IN UINTN       UniqueId
+  )
+{
+  EFI_STATUS               Status;
+  UINTN                    HandleCount;
+  EFI_HANDLE               *HandleBuffer;
+  UINTN                    Index;
+  NON_DISCOVERABLE_DEVICE  *OtherDevice;
+
+  ASSERT (UniqueId < MAX_NON_DISCOVERABLE_PCI_DEVICE_ID);
+  if (UniqueId >= MAX_NON_DISCOVERABLE_PCI_DEVICE_ID) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: NonDiscoverableDevice UniqueId 0x%llx exceeds max 0x%x\n",
+      __func__,
+      (UINT64)UniqueId,
+      MAX_NON_DISCOVERABLE_PCI_DEVICE_ID
+      ));
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  HandleCount  = 0;
+  HandleBuffer = NULL;
+  Status       = gBS->LocateHandleBuffer (
+                        ByProtocol,
+                        &gEdkiiNonDiscoverableDeviceProtocolGuid,
+                        NULL,
+                        &HandleCount,
+                        &HandleBuffer
+                        );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: LocateHandleBuffer failed: %r\n", __func__, Status));
+    return Status;
+  }
+
+  Status = EFI_SUCCESS;
+  for (Index = 0; Index < HandleCount; Index++) {
+    // Skip our own handle
+    if (HandleBuffer[Index] == DeviceHandle) {
+      continue;
+    }
+
+    if (EFI_ERROR (
+          gBS->HandleProtocol (
+                 HandleBuffer[Index],
+                 &gEdkiiNonDiscoverableDeviceProtocolGuid,
+                 (VOID **)&OtherDevice
+                 )
+          ))
+    {
+      continue;
+    }
+
+    if (OtherDevice->UniqueId == UniqueId) {
+      DEBUG ((DEBUG_ERROR, "%a: duplicate NonDiscoverableDevice UniqueId 0x%llx\n", __func__, UniqueId));
+      Status = EFI_DEVICE_ERROR;
+      break;
+    }
+  }
+
+  FreePool (HandleBuffer);
+  return Status;
+}
+
+/**
   This routine is called right after the .Supported() called and
   Start this driver on ControllerHandle.
 
@@ -148,11 +230,6 @@ NonDiscoverablePciDeviceStart (
   NON_DISCOVERABLE_PCI_DEVICE  *Dev;
   EFI_STATUS                   Status;
 
-  ASSERT (mUniqueIdCounter < MAX_NON_DISCOVERABLE_PCI_DEVICE_ID);
-  if (mUniqueIdCounter >= MAX_NON_DISCOVERABLE_PCI_DEVICE_ID) {
-    return EFI_OUT_OF_RESOURCES;
-  }
-
   Dev = AllocateZeroPool (sizeof *Dev);
   if (Dev == NULL) {
     return EFI_OUT_OF_RESOURCES;
@@ -168,6 +245,13 @@ NonDiscoverablePciDeviceStart (
                   );
   if (EFI_ERROR (Status)) {
     goto FreeDev;
+  }
+
+  // Reject duplicate UniqueId across NonDiscoverableDevice handles, so the
+  // platform is forced to assign a distinct ID per registration.
+  Status = CheckUniqueIdNotInUse (DeviceHandle, Dev->Device->UniqueId);
+  if (EFI_ERROR (Status)) {
+    goto CloseProtocol;
   }
 
   InitializePciIoProtocol (Dev);
@@ -187,7 +271,10 @@ NonDiscoverablePciDeviceStart (
     goto CloseProtocol;
   }
 
-  Dev->UniqueId = mUniqueIdCounter++;
+  //
+  // Use platform-supplied UniqueId from NON_DISCOVERABLE_DEVICE.
+  //
+  Dev->UniqueId = Dev->Device->UniqueId;
 
   return EFI_SUCCESS;
 

--- a/MdeModulePkg/Bus/Pci/NonDiscoverablePciDeviceDxe/NonDiscoverablePciDeviceDxe.inf
+++ b/MdeModulePkg/Bus/Pci/NonDiscoverablePciDeviceDxe/NonDiscoverablePciDeviceDxe.inf
@@ -29,6 +29,7 @@
   BaseMemoryLib
   DebugLib
   DxeServicesTableLib
+  IoMmuLib
   MemoryAllocationLib
   UefiBootServicesTableLib
   UefiDriverEntryPoint

--- a/MdeModulePkg/Bus/Pci/NonDiscoverablePciDeviceDxe/NonDiscoverablePciDeviceIo.c
+++ b/MdeModulePkg/Bus/Pci/NonDiscoverablePciDeviceDxe/NonDiscoverablePciDeviceIo.c
@@ -778,7 +778,7 @@ PciIoMapIoMmu (
   }
 
   Status = IoMmuSetAttribute (
-             NULL,
+             Dev->Handle,
              MapInfo->IoMmuContext,
              IoMmuAttribute
              );
@@ -815,7 +815,7 @@ PciIoUnmapIoMmu (
     return EFI_INVALID_PARAMETER;
   }
 
-  Status = IoMmuSetAttribute (NULL, MapInfo->IoMmuContext, 0);
+  Status = IoMmuSetAttribute (Dev->Handle, MapInfo->IoMmuContext, 0);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a - IoMmuSetAttribute failed.\n", __func__));
     ASSERT (FALSE);

--- a/MdeModulePkg/Bus/Pci/NonDiscoverablePciDeviceDxe/NonDiscoverablePciDeviceIo.c
+++ b/MdeModulePkg/Bus/Pci/NonDiscoverablePciDeviceDxe/NonDiscoverablePciDeviceIo.c
@@ -15,11 +15,14 @@
 
 #include <Protocol/PciRootBridgeIo.h>
 
+#include <Library/IoMmuLib.h>
+
 typedef struct {
   EFI_PHYSICAL_ADDRESS             AllocAddress;
   VOID                             *HostAddress;
   EFI_PCI_IO_PROTOCOL_OPERATION    Operation;
   UINTN                            NumberOfBytes;
+  VOID                             *IoMmuContext;
 } NON_DISCOVERABLE_PCI_DEVICE_MAP_INFO;
 
 /**
@@ -693,6 +696,143 @@ PciIoCopyMem (
 }
 
 /**
+  Translate a PCI IO bus master operation into the equivalent IOMMU operation
+  and access attributes, install an IOMMU mapping for HostAddress and set the
+  access attributes on the resulting mapping.
+
+  On success, MapInfo->IoMmuContext holds the mapping handle that
+  PciIoUnmapIoMmu() can later release. On failure, no IOMMU mapping is leaked.
+
+  @param[in]      Dev               The non-discoverable PCI device.
+  @param[in]      Operation         The PCI IO bus master operation.
+  @param[in]      IoMmuHostAddress  Host address to be mapped through the IOMMU.
+  @param[in,out]  NumberOfBytes     Length of the mapping.
+  @param[in,out]  DeviceAddress     Resulting device address.
+  @param[in,out]  MapInfo           Map info structure; MapInfo->IoMmuContext is
+                                    populated on success.
+
+  @retval EFI_SUCCESS            Mapping established and attributes set.
+  @retval EFI_INVALID_PARAMETER  Operation is not a valid bus master operation.
+  @retval Other                  Error returned by the IOMMU library.
+**/
+STATIC
+EFI_STATUS
+PciIoMapIoMmu (
+  IN     NON_DISCOVERABLE_PCI_DEVICE           *Dev,
+  IN     EFI_PCI_IO_PROTOCOL_OPERATION         Operation,
+  IN     VOID                                  *IoMmuHostAddress,
+  IN OUT UINTN                                 *NumberOfBytes,
+  IN OUT EFI_PHYSICAL_ADDRESS                  *DeviceAddress,
+  IN OUT NON_DISCOVERABLE_PCI_DEVICE_MAP_INFO  *MapInfo
+  )
+{
+  EFI_STATUS             Status;
+  EDKII_IOMMU_OPERATION  IoMmuOperation;
+  UINT64                 IoMmuAttribute;
+  BOOLEAN                DualAddressCycle;
+
+  if ((Operation >= EfiPciIoOperationMaximum) || (Dev == NULL) || (IoMmuHostAddress == NULL) ||
+      (NumberOfBytes == NULL) || (DeviceAddress == NULL) || (MapInfo == NULL))
+  {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  DualAddressCycle = (Dev->Attributes & EFI_PCI_IO_ATTRIBUTE_DUAL_ADDRESS_CYCLE) != 0;
+
+  switch (Operation) {
+    case EfiPciIoOperationBusMasterRead:
+      IoMmuOperation = DualAddressCycle ? EdkiiIoMmuOperationBusMasterRead64
+                                         : EdkiiIoMmuOperationBusMasterRead;
+      IoMmuAttribute = EDKII_IOMMU_ACCESS_READ;
+      break;
+
+    case EfiPciIoOperationBusMasterWrite:
+      IoMmuOperation = DualAddressCycle ? EdkiiIoMmuOperationBusMasterWrite64
+                                         : EdkiiIoMmuOperationBusMasterWrite;
+      IoMmuAttribute = EDKII_IOMMU_ACCESS_WRITE;
+      break;
+
+    case EfiPciIoOperationBusMasterCommonBuffer:
+      IoMmuOperation = DualAddressCycle ? EdkiiIoMmuOperationBusMasterCommonBuffer64
+                                         : EdkiiIoMmuOperationBusMasterCommonBuffer;
+      IoMmuAttribute = EDKII_IOMMU_ACCESS_READ | EDKII_IOMMU_ACCESS_WRITE;
+      break;
+
+    default:
+      DEBUG ((DEBUG_ERROR, "%a - Invalid operation %d\n", __func__, Operation));
+      ASSERT (FALSE);
+      return EFI_INVALID_PARAMETER;
+  }
+
+  Status = IoMmuMap (
+             IoMmuOperation,
+             IoMmuHostAddress,
+             NumberOfBytes,
+             DeviceAddress,
+             &MapInfo->IoMmuContext
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a - IoMmuMap failed.\n", __func__));
+    ASSERT (FALSE);
+    return Status;
+  }
+
+  Status = IoMmuSetAttribute (
+             NULL,
+             MapInfo->IoMmuContext,
+             IoMmuAttribute
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a - IoMmuSetAttribute failed.\n", __func__));
+    ASSERT (FALSE);
+    IoMmuUnmap (MapInfo->IoMmuContext);
+    MapInfo->IoMmuContext = NULL;
+  }
+
+  return Status;
+}
+
+/**
+  Reverse a previous PciIoMapIoMmu() call by clearing the IOMMU access
+  attributes and tearing down the mapping.
+
+  @param[in] Dev      The non-discoverable PCI device.
+  @param[in] MapInfo  Map info structure populated by PciIoMapIoMmu().
+
+  @retval EFI_SUCCESS  The mapping has been released.
+  @retval Other        Error returned by the IOMMU library.
+**/
+STATIC
+EFI_STATUS
+PciIoUnmapIoMmu (
+  IN NON_DISCOVERABLE_PCI_DEVICE           *Dev,
+  IN NON_DISCOVERABLE_PCI_DEVICE_MAP_INFO  *MapInfo
+  )
+{
+  EFI_STATUS  Status;
+
+  if ((Dev == NULL) || (MapInfo == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Status = IoMmuSetAttribute (NULL, MapInfo->IoMmuContext, 0);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a - IoMmuSetAttribute failed.\n", __func__));
+    ASSERT (FALSE);
+    return Status;
+  }
+
+  Status = IoMmuUnmap (MapInfo->IoMmuContext);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a - IoMmuUnmap failed.\n", __func__));
+    ASSERT (FALSE);
+    return Status;
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
   Provides the PCI controller-specific addresses needed to access system memory.
 
   @param  This                  A pointer to the EFI_PCI_IO_PROTOCOL instance.
@@ -726,6 +866,7 @@ CoherentPciIoMap (
   NON_DISCOVERABLE_PCI_DEVICE           *Dev;
   EFI_STATUS                            Status;
   NON_DISCOVERABLE_PCI_DEVICE_MAP_INFO  *MapInfo;
+  VOID                                  *IoMmuHostAddress;
 
   if ((Operation != EfiPciIoOperationBusMasterRead) &&
       (Operation != EfiPciIoOperationBusMasterWrite) &&
@@ -742,6 +883,16 @@ CoherentPciIoMap (
     return EFI_INVALID_PARAMETER;
   }
 
+  MapInfo = AllocatePool (sizeof *MapInfo);
+  if (MapInfo == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  MapInfo->AllocAddress  = MAX_UINT32;
+  MapInfo->HostAddress   = HostAddress;
+  MapInfo->Operation     = Operation;
+  MapInfo->NumberOfBytes = *NumberOfBytes;
+  MapInfo->IoMmuContext  = NULL;
   //
   // If HostAddress exceeds 4 GB, and this device does not support 64-bit DMA
   // addressing, we need to allocate a bounce buffer and copy over the data.
@@ -754,18 +905,9 @@ CoherentPciIoMap (
     // Bounce buffering is not possible for consistent mappings
     //
     if (Operation == EfiPciIoOperationBusMasterCommonBuffer) {
-      return EFI_UNSUPPORTED;
+      Status = EFI_UNSUPPORTED;
+      goto ErrorExit;
     }
-
-    MapInfo = AllocatePool (sizeof *MapInfo);
-    if (MapInfo == NULL) {
-      return EFI_OUT_OF_RESOURCES;
-    }
-
-    MapInfo->AllocAddress  = MAX_UINT32;
-    MapInfo->HostAddress   = HostAddress;
-    MapInfo->Operation     = Operation;
-    MapInfo->NumberOfBytes = *NumberOfBytes;
 
     Status = gBS->AllocatePages (
                     AllocateMaxAddress,
@@ -779,8 +921,8 @@ CoherentPciIoMap (
       // 4 GB to begin with. There is not much we can do about that other than
       // fail the map request.
       //
-      FreePool (MapInfo);
-      return EFI_DEVICE_ERROR;
+      Status = EFI_DEVICE_ERROR;
+      goto ErrorExit;
     }
 
     if (Operation == EfiPciIoOperationBusMasterRead) {
@@ -791,14 +933,32 @@ CoherentPciIoMap (
              );
     }
 
-    *DeviceAddress = MapInfo->AllocAddress;
-    *Mapping       = MapInfo;
+    *DeviceAddress   = MapInfo->AllocAddress;
+    IoMmuHostAddress = (VOID *)(UINTN)MapInfo->AllocAddress;
   } else {
-    *DeviceAddress = (EFI_PHYSICAL_ADDRESS)(UINTN)HostAddress;
-    *Mapping       = NULL;
+    *DeviceAddress   = (EFI_PHYSICAL_ADDRESS)(UINTN)HostAddress;
+    IoMmuHostAddress = HostAddress;
+  }
+
+  *Mapping = MapInfo;
+
+  Status = PciIoMapIoMmu (
+             Dev,
+             Operation,
+             IoMmuHostAddress,
+             NumberOfBytes,
+             DeviceAddress,
+             MapInfo
+             );
+  if (EFI_ERROR (Status)) {
+    goto ErrorExit;
   }
 
   return EFI_SUCCESS;
+
+ErrorExit:
+  FreePool (MapInfo);
+  return Status;
 }
 
 /**
@@ -819,9 +979,25 @@ CoherentPciIoUnmap (
   )
 {
   NON_DISCOVERABLE_PCI_DEVICE_MAP_INFO  *MapInfo;
+  NON_DISCOVERABLE_PCI_DEVICE           *Dev;
+  EFI_STATUS                            Status;
+
+  if (Mapping == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
 
   MapInfo = Mapping;
-  if (MapInfo != NULL) {
+  Dev     = NON_DISCOVERABLE_PCI_DEVICE_FROM_PCI_IO (This);
+
+  Status = PciIoUnmapIoMmu (Dev, MapInfo);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  // Only copy the data back and free for the bounce buffer case.
+  if (((Dev->Attributes & EFI_PCI_IO_ATTRIBUTE_DUAL_ADDRESS_CYCLE) == 0) &&
+      ((EFI_PHYSICAL_ADDRESS)(UINTN)MapInfo->HostAddress + MapInfo->NumberOfBytes > SIZE_4GB))
+  {
     if (MapInfo->Operation == EfiPciIoOperationBusMasterWrite) {
       gBS->CopyMem (
              MapInfo->HostAddress,
@@ -834,8 +1010,9 @@ CoherentPciIoUnmap (
            MapInfo->AllocAddress,
            EFI_SIZE_TO_PAGES (MapInfo->NumberOfBytes)
            );
-    FreePool (MapInfo);
   }
+
+  FreePool (MapInfo);
 
   return EFI_SUCCESS;
 }
@@ -1272,6 +1449,7 @@ NonCoherentPciIoMap (
   VOID                                  *AllocAddress;
   EFI_GCD_MEMORY_SPACE_DESCRIPTOR       GcdDescriptor;
   BOOLEAN                               Bounce;
+  VOID                                  *IoMmuHostAddress;
 
   if ((HostAddress   == NULL) ||
       (NumberOfBytes == NULL) ||
@@ -1296,6 +1474,7 @@ NonCoherentPciIoMap (
   MapInfo->HostAddress   = HostAddress;
   MapInfo->Operation     = Operation;
   MapInfo->NumberOfBytes = *NumberOfBytes;
+  MapInfo->IoMmuContext  = NULL;
 
   Dev = NON_DISCOVERABLE_PCI_DEVICE_FROM_PCI_IO (This);
 
@@ -1345,7 +1524,7 @@ NonCoherentPciIoMap (
   if (Bounce) {
     if (Operation == EfiPciIoOperationBusMasterCommonBuffer) {
       Status = EFI_DEVICE_ERROR;
-      goto FreeMapInfo;
+      goto ErrorExit;
     }
 
     Status = NonCoherentPciIoAllocateBuffer (
@@ -1357,7 +1536,7 @@ NonCoherentPciIoMap (
                EFI_PCI_ATTRIBUTE_MEMORY_WRITE_COMBINE
                );
     if (EFI_ERROR (Status)) {
-      goto FreeMapInfo;
+      goto ErrorExit;
     }
 
     MapInfo->AllocAddress = (EFI_PHYSICAL_ADDRESS)(UINTN)AllocAddress;
@@ -1365,10 +1544,12 @@ NonCoherentPciIoMap (
       gBS->CopyMem (AllocAddress, HostAddress, *NumberOfBytes);
     }
 
-    *DeviceAddress = MapInfo->AllocAddress;
+    *DeviceAddress   = MapInfo->AllocAddress;
+    IoMmuHostAddress = (VOID *)(UINTN)MapInfo->AllocAddress;
   } else {
     MapInfo->AllocAddress = 0;
     *DeviceAddress        = (EFI_PHYSICAL_ADDRESS)(UINTN)HostAddress;
+    IoMmuHostAddress      = HostAddress;
 
     //
     // We are not using a bounce buffer: the mapping is sufficiently
@@ -1389,9 +1570,22 @@ NonCoherentPciIoMap (
   }
 
   *Mapping = MapInfo;
+
+  Status = PciIoMapIoMmu (
+             Dev,
+             Operation,
+             IoMmuHostAddress,
+             NumberOfBytes,
+             DeviceAddress,
+             MapInfo
+             );
+  if (EFI_ERROR (Status)) {
+    goto ErrorExit;
+  }
+
   return EFI_SUCCESS;
 
-FreeMapInfo:
+ErrorExit:
   FreePool (MapInfo);
 
   return Status;
@@ -1415,12 +1609,21 @@ NonCoherentPciIoUnmap (
   )
 {
   NON_DISCOVERABLE_PCI_DEVICE_MAP_INFO  *MapInfo;
+  NON_DISCOVERABLE_PCI_DEVICE           *Dev;
+  EFI_STATUS                            Status;
 
   if (Mapping == NULL) {
     return EFI_DEVICE_ERROR;
   }
 
   MapInfo = Mapping;
+  Dev     = NON_DISCOVERABLE_PCI_DEVICE_FROM_PCI_IO (This);
+
+  Status = PciIoUnmapIoMmu (Dev, MapInfo);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
   if (MapInfo->AllocAddress != 0) {
     //
     // We are using a bounce buffer: copy back the data if necessary,

--- a/MdeModulePkg/Bus/Pci/NonDiscoverablePciDeviceDxe/NonDiscoverablePciDeviceIo.c
+++ b/MdeModulePkg/Bus/Pci/NonDiscoverablePciDeviceDxe/NonDiscoverablePciDeviceIo.c
@@ -15,11 +15,14 @@
 
 #include <Protocol/PciRootBridgeIo.h>
 
+#include <Library/IoMmuLib.h>
+
 typedef struct {
   EFI_PHYSICAL_ADDRESS             AllocAddress;
   VOID                             *HostAddress;
   EFI_PCI_IO_PROTOCOL_OPERATION    Operation;
   UINTN                            NumberOfBytes;
+  VOID                             *IoMmuContext;
 } NON_DISCOVERABLE_PCI_DEVICE_MAP_INFO;
 
 /**
@@ -693,6 +696,143 @@ PciIoCopyMem (
 }
 
 /**
+  Translate a PCI IO bus master operation into the equivalent IOMMU operation
+  and access attributes, install an IOMMU mapping for HostAddress and set the
+  access attributes on the resulting mapping.
+
+  On success, MapInfo->IoMmuContext holds the mapping handle that
+  PciIoUnmapIoMmu() can later release. On failure, no IOMMU mapping is leaked.
+
+  @param[in]      Dev               The non-discoverable PCI device.
+  @param[in]      Operation         The PCI IO bus master operation.
+  @param[in]      IoMmuHostAddress  Host address to be mapped through the IOMMU.
+  @param[in,out]  NumberOfBytes     Length of the mapping.
+  @param[in,out]  DeviceAddress     Resulting device address.
+  @param[in,out]  MapInfo           Map info structure; MapInfo->IoMmuContext is
+                                    populated on success.
+
+  @retval EFI_SUCCESS            Mapping established and attributes set.
+  @retval EFI_INVALID_PARAMETER  Operation is not a valid bus master operation.
+  @retval Other                  Error returned by the IOMMU library.
+**/
+STATIC
+EFI_STATUS
+PciIoMapIoMmu (
+  IN     NON_DISCOVERABLE_PCI_DEVICE           *Dev,
+  IN     EFI_PCI_IO_PROTOCOL_OPERATION         Operation,
+  IN     VOID                                  *IoMmuHostAddress,
+  IN OUT UINTN                                 *NumberOfBytes,
+  IN OUT EFI_PHYSICAL_ADDRESS                  *DeviceAddress,
+  IN OUT NON_DISCOVERABLE_PCI_DEVICE_MAP_INFO  *MapInfo
+  )
+{
+  EFI_STATUS             Status;
+  EDKII_IOMMU_OPERATION  IoMmuOperation;
+  UINT64                 IoMmuAttribute;
+  BOOLEAN                DualAddressCycle;
+
+  if ((Operation >= EfiPciIoOperationMaximum) || (Dev == NULL) || (IoMmuHostAddress == NULL) ||
+      (NumberOfBytes == NULL) || (DeviceAddress == NULL) || (MapInfo == NULL))
+  {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  DualAddressCycle = (Dev->Attributes & EFI_PCI_IO_ATTRIBUTE_DUAL_ADDRESS_CYCLE) != 0;
+
+  switch (Operation) {
+    case EfiPciIoOperationBusMasterRead:
+      IoMmuOperation = DualAddressCycle ? EdkiiIoMmuOperationBusMasterRead64
+                                         : EdkiiIoMmuOperationBusMasterRead;
+      IoMmuAttribute = EDKII_IOMMU_ACCESS_READ;
+      break;
+
+    case EfiPciIoOperationBusMasterWrite:
+      IoMmuOperation = DualAddressCycle ? EdkiiIoMmuOperationBusMasterWrite64
+                                         : EdkiiIoMmuOperationBusMasterWrite;
+      IoMmuAttribute = EDKII_IOMMU_ACCESS_WRITE;
+      break;
+
+    case EfiPciIoOperationBusMasterCommonBuffer:
+      IoMmuOperation = DualAddressCycle ? EdkiiIoMmuOperationBusMasterCommonBuffer64
+                                         : EdkiiIoMmuOperationBusMasterCommonBuffer;
+      IoMmuAttribute = EDKII_IOMMU_ACCESS_READ | EDKII_IOMMU_ACCESS_WRITE;
+      break;
+
+    default:
+      DEBUG ((DEBUG_ERROR, "%a - Invalid operation %d\n", __func__, Operation));
+      ASSERT (FALSE);
+      return EFI_INVALID_PARAMETER;
+  }
+
+  Status = IoMmuMap (
+             IoMmuOperation,
+             IoMmuHostAddress,
+             NumberOfBytes,
+             DeviceAddress,
+             &MapInfo->IoMmuContext
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a - IoMmuMap failed.\n", __func__));
+    ASSERT (FALSE);
+    return Status;
+  }
+
+  Status = IoMmuSetAttribute (
+             NULL,
+             MapInfo->IoMmuContext,
+             IoMmuAttribute
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a - IoMmuSetAttribute failed.\n", __func__));
+    ASSERT (FALSE);
+    IoMmuUnmap (MapInfo->IoMmuContext);
+    MapInfo->IoMmuContext = NULL;
+  }
+
+  return Status;
+}
+
+/**
+  Reverse a previous PciIoMapIoMmu() call by clearing the IOMMU access
+  attributes and tearing down the mapping.
+
+  @param[in] Dev      The non-discoverable PCI device.
+  @param[in] MapInfo  Map info structure populated by PciIoMapIoMmu().
+
+  @retval EFI_SUCCESS  The mapping has been released.
+  @retval Other        Error returned by the IOMMU library.
+**/
+STATIC
+EFI_STATUS
+PciIoUnmapIoMmu (
+  IN NON_DISCOVERABLE_PCI_DEVICE           *Dev,
+  IN NON_DISCOVERABLE_PCI_DEVICE_MAP_INFO  *MapInfo
+  )
+{
+  EFI_STATUS  Status;
+
+  if ((Dev == NULL) || (MapInfo == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Status = IoMmuSetAttribute (NULL, MapInfo->IoMmuContext, 0);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a - IoMmuSetAttribute failed.\n", __func__));
+    ASSERT (FALSE);
+    return Status;
+  }
+
+  Status = IoMmuUnmap (MapInfo->IoMmuContext);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a - IoMmuUnmap failed.\n", __func__));
+    ASSERT (FALSE);
+    return Status;
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
   Provides the PCI controller-specific addresses needed to access system memory.
 
   @param  This                  A pointer to the EFI_PCI_IO_PROTOCOL instance.
@@ -726,6 +866,7 @@ CoherentPciIoMap (
   NON_DISCOVERABLE_PCI_DEVICE           *Dev;
   EFI_STATUS                            Status;
   NON_DISCOVERABLE_PCI_DEVICE_MAP_INFO  *MapInfo;
+  VOID                                  *IoMmuHostAddress;
 
   if ((Operation != EfiPciIoOperationBusMasterRead) &&
       (Operation != EfiPciIoOperationBusMasterWrite) &&
@@ -742,6 +883,16 @@ CoherentPciIoMap (
     return EFI_INVALID_PARAMETER;
   }
 
+  MapInfo = AllocatePool (sizeof *MapInfo);
+  if (MapInfo == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  MapInfo->AllocAddress  = MAX_UINT32;
+  MapInfo->HostAddress   = HostAddress;
+  MapInfo->Operation     = Operation;
+  MapInfo->NumberOfBytes = *NumberOfBytes;
+  MapInfo->IoMmuContext  = NULL;
   //
   // If HostAddress exceeds 4 GB, and this device does not support 64-bit DMA
   // addressing, we need to allocate a bounce buffer and copy over the data.
@@ -754,18 +905,9 @@ CoherentPciIoMap (
     // Bounce buffering is not possible for consistent mappings
     //
     if (Operation == EfiPciIoOperationBusMasterCommonBuffer) {
-      return EFI_UNSUPPORTED;
+      Status = EFI_UNSUPPORTED;
+      goto ErrorExit;
     }
-
-    MapInfo = AllocatePool (sizeof *MapInfo);
-    if (MapInfo == NULL) {
-      return EFI_OUT_OF_RESOURCES;
-    }
-
-    MapInfo->AllocAddress  = MAX_UINT32;
-    MapInfo->HostAddress   = HostAddress;
-    MapInfo->Operation     = Operation;
-    MapInfo->NumberOfBytes = *NumberOfBytes;
 
     Status = gBS->AllocatePages (
                     AllocateMaxAddress,
@@ -779,8 +921,8 @@ CoherentPciIoMap (
       // 4 GB to begin with. There is not much we can do about that other than
       // fail the map request.
       //
-      FreePool (MapInfo);
-      return EFI_DEVICE_ERROR;
+      Status = EFI_DEVICE_ERROR;
+      goto ErrorExit;
     }
 
     if (Operation == EfiPciIoOperationBusMasterRead) {
@@ -791,14 +933,32 @@ CoherentPciIoMap (
              );
     }
 
-    *DeviceAddress = MapInfo->AllocAddress;
-    *Mapping       = MapInfo;
+    *DeviceAddress   = MapInfo->AllocAddress;
+    IoMmuHostAddress = (VOID *)(UINTN)MapInfo->AllocAddress;
   } else {
-    *DeviceAddress = (EFI_PHYSICAL_ADDRESS)(UINTN)HostAddress;
-    *Mapping       = NULL;
+    *DeviceAddress   = (EFI_PHYSICAL_ADDRESS)(UINTN)HostAddress;
+    IoMmuHostAddress = HostAddress;
   }
 
+  Status = PciIoMapIoMmu (
+             Dev,
+             Operation,
+             IoMmuHostAddress,
+             NumberOfBytes,
+             DeviceAddress,
+             MapInfo
+             );
+  if (EFI_ERROR (Status)) {
+    goto ErrorExit;
+  }
+
+  *Mapping = MapInfo;
+
   return EFI_SUCCESS;
+
+ErrorExit:
+  FreePool (MapInfo);
+  return Status;
 }
 
 /**
@@ -819,9 +979,25 @@ CoherentPciIoUnmap (
   )
 {
   NON_DISCOVERABLE_PCI_DEVICE_MAP_INFO  *MapInfo;
+  NON_DISCOVERABLE_PCI_DEVICE           *Dev;
+  EFI_STATUS                            Status;
+
+  if (Mapping == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
 
   MapInfo = Mapping;
-  if (MapInfo != NULL) {
+  Dev     = NON_DISCOVERABLE_PCI_DEVICE_FROM_PCI_IO (This);
+
+  Status = PciIoUnmapIoMmu (Dev, MapInfo);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a - PciIoUnmapIoMmu failed: %r\n", __func__, Status));
+  }
+
+  // Only copy the data back and free for the bounce buffer case.
+  if (((Dev->Attributes & EFI_PCI_IO_ATTRIBUTE_DUAL_ADDRESS_CYCLE) == 0) &&
+      ((EFI_PHYSICAL_ADDRESS)(UINTN)MapInfo->HostAddress + MapInfo->NumberOfBytes > SIZE_4GB))
+  {
     if (MapInfo->Operation == EfiPciIoOperationBusMasterWrite) {
       gBS->CopyMem (
              MapInfo->HostAddress,
@@ -834,10 +1010,11 @@ CoherentPciIoUnmap (
            MapInfo->AllocAddress,
            EFI_SIZE_TO_PAGES (MapInfo->NumberOfBytes)
            );
-    FreePool (MapInfo);
   }
 
-  return EFI_SUCCESS;
+  FreePool (MapInfo);
+
+  return Status;
 }
 
 /**
@@ -1272,6 +1449,7 @@ NonCoherentPciIoMap (
   VOID                                  *AllocAddress;
   EFI_GCD_MEMORY_SPACE_DESCRIPTOR       GcdDescriptor;
   BOOLEAN                               Bounce;
+  VOID                                  *IoMmuHostAddress;
 
   if ((HostAddress   == NULL) ||
       (NumberOfBytes == NULL) ||
@@ -1296,6 +1474,7 @@ NonCoherentPciIoMap (
   MapInfo->HostAddress   = HostAddress;
   MapInfo->Operation     = Operation;
   MapInfo->NumberOfBytes = *NumberOfBytes;
+  MapInfo->IoMmuContext  = NULL;
 
   Dev = NON_DISCOVERABLE_PCI_DEVICE_FROM_PCI_IO (This);
 
@@ -1345,7 +1524,7 @@ NonCoherentPciIoMap (
   if (Bounce) {
     if (Operation == EfiPciIoOperationBusMasterCommonBuffer) {
       Status = EFI_DEVICE_ERROR;
-      goto FreeMapInfo;
+      goto ErrorExit;
     }
 
     Status = NonCoherentPciIoAllocateBuffer (
@@ -1357,7 +1536,7 @@ NonCoherentPciIoMap (
                EFI_PCI_ATTRIBUTE_MEMORY_WRITE_COMBINE
                );
     if (EFI_ERROR (Status)) {
-      goto FreeMapInfo;
+      goto ErrorExit;
     }
 
     MapInfo->AllocAddress = (EFI_PHYSICAL_ADDRESS)(UINTN)AllocAddress;
@@ -1365,10 +1544,12 @@ NonCoherentPciIoMap (
       gBS->CopyMem (AllocAddress, HostAddress, *NumberOfBytes);
     }
 
-    *DeviceAddress = MapInfo->AllocAddress;
+    *DeviceAddress   = MapInfo->AllocAddress;
+    IoMmuHostAddress = (VOID *)(UINTN)MapInfo->AllocAddress;
   } else {
     MapInfo->AllocAddress = 0;
     *DeviceAddress        = (EFI_PHYSICAL_ADDRESS)(UINTN)HostAddress;
+    IoMmuHostAddress      = HostAddress;
 
     //
     // We are not using a bounce buffer: the mapping is sufficiently
@@ -1388,10 +1569,23 @@ NonCoherentPciIoMap (
             );
   }
 
+  Status = PciIoMapIoMmu (
+             Dev,
+             Operation,
+             IoMmuHostAddress,
+             NumberOfBytes,
+             DeviceAddress,
+             MapInfo
+             );
+  if (EFI_ERROR (Status)) {
+    goto ErrorExit;
+  }
+
   *Mapping = MapInfo;
+
   return EFI_SUCCESS;
 
-FreeMapInfo:
+ErrorExit:
   FreePool (MapInfo);
 
   return Status;
@@ -1415,12 +1609,21 @@ NonCoherentPciIoUnmap (
   )
 {
   NON_DISCOVERABLE_PCI_DEVICE_MAP_INFO  *MapInfo;
+  NON_DISCOVERABLE_PCI_DEVICE           *Dev;
+  EFI_STATUS                            Status;
 
   if (Mapping == NULL) {
     return EFI_DEVICE_ERROR;
   }
 
   MapInfo = Mapping;
+  Dev     = NON_DISCOVERABLE_PCI_DEVICE_FROM_PCI_IO (This);
+
+  Status = PciIoUnmapIoMmu (Dev, MapInfo);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a - PciIoUnmapIoMmu failed: %r\n", __func__, Status));
+  }
+
   if (MapInfo->AllocAddress != 0) {
     //
     // We are using a bounce buffer: copy back the data if necessary,
@@ -1456,7 +1659,7 @@ NonCoherentPciIoUnmap (
   }
 
   FreePool (MapInfo);
-  return EFI_SUCCESS;
+  return Status;
 }
 
 /**

--- a/MdeModulePkg/Bus/Pci/NonDiscoverablePciDeviceDxe/NonDiscoverablePciDeviceIo.h
+++ b/MdeModulePkg/Bus/Pci/NonDiscoverablePciDeviceDxe/NonDiscoverablePciDeviceIo.h
@@ -100,6 +100,12 @@ typedef struct {
   // may change when disconnecting/reconnecting the driver.
   //
   UINTN                      UniqueId;
+  //
+  // The controller handle this driver is bound to. Same handle the
+  // EFI_PCI_IO_PROTOCOL is installed on; passed to IoMmuSetAttribute so
+  // an IOMMU producer can resolve the DMA identifier from the handle.
+  //
+  EFI_HANDLE                 Handle;
 } NON_DISCOVERABLE_PCI_DEVICE;
 
 /**

--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciBus.c
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciBus.c
@@ -36,7 +36,6 @@ UINT64                                        gAllZero                       = 0
 
 EFI_PCI_PLATFORM_PROTOCOL       *gPciPlatformProtocol;
 EFI_PCI_OVERRIDE_PROTOCOL       *gPciOverrideProtocol;
-EDKII_IOMMU_PROTOCOL            *mIoMmuProtocol;
 EDKII_DEVICE_SECURITY_PROTOCOL  *mDeviceSecurityProtocol;
 
 GLOBAL_REMOVE_IF_UNREFERENCED EFI_PCI_HOTPLUG_REQUEST_PROTOCOL  mPciHotPlugRequest = {
@@ -283,14 +282,6 @@ PciBusDriverBindingStart (
            &gEfiPciOverrideProtocolGuid,
            NULL,
            (VOID **)&gPciOverrideProtocol
-           );
-  }
-
-  if (mIoMmuProtocol == NULL) {
-    gBS->LocateProtocol (
-           &gEdkiiIoMmuProtocolGuid,
-           NULL,
-           (VOID **)&mIoMmuProtocol
            );
   }
 

--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciBus.h
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciBus.h
@@ -36,6 +36,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/MemoryAllocationLib.h>
 #include <Library/UefiBootServicesTableLib.h>
 #include <Library/DevicePathLib.h>
+#include <Library/IoMmuLib.h>
 #include <Library/PcdLib.h>
 
 #include <IndustryStandard/Pci.h>

--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciBusDxe.inf
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciBusDxe.inf
@@ -64,6 +64,7 @@
   BaseLib
   UefiDriverEntryPoint
   DebugLib
+  IoMmuLib
 
 [Protocols]
   gEfiPciHotPlugRequestProtocolGuid               ## SOMETIMES_PRODUCES
@@ -80,7 +81,6 @@
   gEfiPciRootBridgeIoProtocolGuid                 ## TO_START
   gEfiIncompatiblePciDeviceSupportProtocolGuid    ## SOMETIMES_CONSUMES
   gEfiLoadFile2ProtocolGuid                       ## SOMETIMES_PRODUCES
-  gEdkiiIoMmuProtocolGuid                         ## SOMETIMES_CONSUMES
   gEdkiiDeviceSecurityProtocolGuid                ## SOMETIMES_CONSUMES
   gEdkiiDeviceIdentifierTypePciGuid               ## SOMETIMES_CONSUMES
   gEfiLoadedImageDevicePathProtocolGuid           ## CONSUMES

--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciIo.c
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciIo.c
@@ -8,8 +8,6 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #include "PciBus.h"
 
-extern EDKII_IOMMU_PROTOCOL  *mIoMmuProtocol;
-
 //
 // Pci Io Protocol Interface
 //
@@ -974,6 +972,7 @@ PciIoMap (
   PCI_IO_DEVICE                              *PciIoDevice;
   UINT64                                     IoMmuAttribute;
   EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL_OPERATION  RootBridgeIoOperation;
+  BOOLEAN                                    DualAddressCycle;
 
   PciIoDevice = PCI_IO_DEVICE_FROM_PCI_IO_THIS (This);
 
@@ -985,9 +984,27 @@ PciIoMap (
     return EFI_INVALID_PARAMETER;
   }
 
-  RootBridgeIoOperation = (EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL_OPERATION)Operation;
-  if ((PciIoDevice->Attributes & EFI_PCI_IO_ATTRIBUTE_DUAL_ADDRESS_CYCLE) != 0) {
-    RootBridgeIoOperation = (EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL_OPERATION)(Operation + EfiPciOperationBusMasterRead64);
+  DualAddressCycle = (PciIoDevice->Attributes & EFI_PCI_IO_ATTRIBUTE_DUAL_ADDRESS_CYCLE) != 0;
+
+  switch (Operation) {
+    case EfiPciIoOperationBusMasterRead:
+      RootBridgeIoOperation = DualAddressCycle ? EfiPciOperationBusMasterRead64
+                                               : EfiPciOperationBusMasterRead;
+      IoMmuAttribute = EDKII_IOMMU_ACCESS_READ;
+      break;
+    case EfiPciIoOperationBusMasterWrite:
+      RootBridgeIoOperation = DualAddressCycle ? EfiPciOperationBusMasterWrite64
+                                               : EfiPciOperationBusMasterWrite;
+      IoMmuAttribute = EDKII_IOMMU_ACCESS_WRITE;
+      break;
+    case EfiPciIoOperationBusMasterCommonBuffer:
+      RootBridgeIoOperation = DualAddressCycle ? EfiPciOperationBusMasterCommonBuffer64
+                                               : EfiPciOperationBusMasterCommonBuffer;
+      IoMmuAttribute = EDKII_IOMMU_ACCESS_READ | EDKII_IOMMU_ACCESS_WRITE;
+      break;
+    default:
+      ASSERT (FALSE);
+      return EFI_INVALID_PARAMETER;
   }
 
   Status = PciIoDevice->PciRootBridgeIo->Map (
@@ -1005,32 +1022,17 @@ PciIoMap (
       EFI_IO_BUS_PCI | EFI_IOB_EC_CONTROLLER_ERROR,
       PciIoDevice->DevicePath
       );
+    return Status;
   }
 
-  if (mIoMmuProtocol != NULL) {
-    if (!EFI_ERROR (Status)) {
-      switch (Operation) {
-        case EfiPciIoOperationBusMasterRead:
-          IoMmuAttribute = EDKII_IOMMU_ACCESS_READ;
-          break;
-        case EfiPciIoOperationBusMasterWrite:
-          IoMmuAttribute = EDKII_IOMMU_ACCESS_WRITE;
-          break;
-        case EfiPciIoOperationBusMasterCommonBuffer:
-          IoMmuAttribute = EDKII_IOMMU_ACCESS_READ | EDKII_IOMMU_ACCESS_WRITE;
-          break;
-        default:
-          ASSERT (FALSE);
-          return EFI_INVALID_PARAMETER;
-      }
-
-      Status = mIoMmuProtocol->SetAttribute (
-                                 mIoMmuProtocol,
-                                 PciIoDevice->Handle,
-                                 *Mapping,
-                                 IoMmuAttribute
-                                 );
-    }
+  Status = IoMmuSetAttribute (
+             PciIoDevice->Handle,
+             *Mapping,
+             IoMmuAttribute
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a - IoMmuSetAttribute failed.\n", __func__));
+    ASSERT (FALSE);
   }
 
   return Status;
@@ -1057,14 +1059,16 @@ PciIoUnmap (
   PCI_IO_DEVICE  *PciIoDevice;
 
   PciIoDevice = PCI_IO_DEVICE_FROM_PCI_IO_THIS (This);
+  Status      = IoMmuSetAttribute (
+                  PciIoDevice->Handle,
+                  Mapping,
+                  0
+                  );
 
-  if (mIoMmuProtocol != NULL) {
-    mIoMmuProtocol->SetAttribute (
-                      mIoMmuProtocol,
-                      PciIoDevice->Handle,
-                      Mapping,
-                      0
-                      );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a - IoMmuSetAttribute failed.\n", __func__));
+    ASSERT (FALSE);
+    return Status;
   }
 
   Status = PciIoDevice->PciRootBridgeIo->Unmap (

--- a/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostBridge.c
+++ b/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostBridge.c
@@ -20,10 +20,6 @@ GLOBAL_REMOVE_IF_UNREFERENCED CHAR16  *mPciResourceTypeStr[] = {
   L"I/O", L"Mem", L"PMem", L"Mem64", L"PMem64", L"Bus"
 };
 
-EDKII_IOMMU_PROTOCOL  *mIoMmu;
-EFI_EVENT             mIoMmuEvent;
-VOID                  *mIoMmuRegistration;
-
 /**
   This routine gets translation offset from a root bridge instance by resource type.
 
@@ -400,28 +396,6 @@ FreeMemorySpaceMap:
 }
 
 /**
-  Event notification that is fired when IOMMU protocol is installed.
-
-  @param  Event                 The Event that is being processed.
-  @param  Context               Event Context.
-
-**/
-VOID
-EFIAPI
-IoMmuProtocolCallback (
-  IN  EFI_EVENT  Event,
-  IN  VOID       *Context
-  )
-{
-  EFI_STATUS  Status;
-
-  Status = gBS->LocateProtocol (&gEdkiiIoMmuProtocolGuid, NULL, (VOID **)&mIoMmu);
-  if (!EFI_ERROR (Status)) {
-    gBS->CloseEvent (mIoMmuEvent);
-  }
-}
-
-/**
 
   Entry point of this driver.
 
@@ -621,16 +595,6 @@ InitializePciHostBridge (
   }
 
   PciHostBridgeFreeRootBridges (RootBridges, RootBridgeCount);
-
-  if (!EFI_ERROR (Status)) {
-    mIoMmuEvent = EfiCreateProtocolNotifyEvent (
-                    &gEdkiiIoMmuProtocolGuid,
-                    TPL_CALLBACK,
-                    IoMmuProtocolCallback,
-                    NULL,
-                    &mIoMmuRegistration
-                    );
-  }
 
   return Status;
 }

--- a/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostBridge.h
+++ b/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostBridge.h
@@ -264,4 +264,3 @@ GetTranslationByResourceType (
   );
 
 extern EFI_CPU_IO2_PROTOCOL  *mCpuIo;
-extern EDKII_IOMMU_PROTOCOL  *mIoMmu;

--- a/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostBridgeDxe.inf
+++ b/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostBridgeDxe.inf
@@ -39,13 +39,13 @@
   UefiLib
   PciHostBridgeLib
   TimerLib
+  IoMmuLib
 
 [Protocols]
   gEfiCpuIo2ProtocolGuid                          ## CONSUMES
   gEfiDevicePathProtocolGuid                      ## BY_START
   gEfiPciRootBridgeIoProtocolGuid                 ## BY_START
   gEfiPciHostBridgeResourceAllocationProtocolGuid ## BY_START
-  gEdkiiIoMmuProtocolGuid                         ## SOMETIMES_CONSUMES
 
 [Depex]
   gEfiCpuIo2ProtocolGuid AND

--- a/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciRootBridgeIo.c
+++ b/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciRootBridgeIo.c
@@ -10,6 +10,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include "PciHostBridge.h"
 #include "PciRootBridge.h"
 #include "PciHostResource.h"
+#include <Library/IoMmuLib.h>
 
 #define NO_MAPPING  (VOID *) (UINTN) -1
 
@@ -1341,6 +1342,7 @@ RootBridgeIoMap (
   PCI_ROOT_BRIDGE_INSTANCE  *RootBridge;
   EFI_PHYSICAL_ADDRESS      PhysicalAddress;
   MAP_INFO                  *MapInfo;
+  EDKII_IOMMU_OPERATION     IoMmuOperation;
 
   if ((HostAddress == NULL) || (NumberOfBytes == NULL) || (DeviceAddress == NULL) ||
       (Mapping == NULL))
@@ -1357,24 +1359,44 @@ RootBridgeIoMap (
 
   RootBridge = ROOT_BRIDGE_FROM_THIS (This);
 
-  if (mIoMmu != NULL) {
-    if (!RootBridge->DmaAbove4G) {
-      //
-      // Clear 64bit support
-      //
-      if (Operation > EfiPciOperationBusMasterCommonBuffer) {
-        Operation = (EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL_OPERATION)(Operation - EfiPciOperationBusMasterRead64);
-      }
+  IoMmuOperation = (EDKII_IOMMU_OPERATION)Operation;
+
+  if (!RootBridge->DmaAbove4G) {
+    //
+    // Clear 64bit support: downgrade 64-bit variants to their 32-bit
+    // equivalents.
+    //
+    switch (Operation) {
+      case EfiPciOperationBusMasterRead64:
+        IoMmuOperation = EdkiiIoMmuOperationBusMasterRead;
+        break;
+      case EfiPciOperationBusMasterWrite64:
+        IoMmuOperation = EdkiiIoMmuOperationBusMasterWrite;
+        break;
+      case EfiPciOperationBusMasterCommonBuffer64:
+        IoMmuOperation = EdkiiIoMmuOperationBusMasterCommonBuffer;
+        break;
+      default:
+        //
+        // 32-bit variants pass through unchanged (already set above).
+        //
+        break;
+    }
+  }
+
+  if (IoMmuIsPresent ()) {
+    Status = IoMmuMap (
+               (EDKII_IOMMU_OPERATION)IoMmuOperation,
+               HostAddress,
+               NumberOfBytes,
+               DeviceAddress,
+               Mapping
+               );
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a - IoMmuMap failed.\n", __func__));
+      ASSERT (FALSE);
     }
 
-    Status = mIoMmu->Map (
-                       mIoMmu,
-                       (EDKII_IOMMU_OPERATION)Operation,
-                       HostAddress,
-                       NumberOfBytes,
-                       DeviceAddress,
-                       Mapping
-                       );
     return Status;
   }
 
@@ -1504,11 +1526,13 @@ RootBridgeIoUnmap (
   PCI_ROOT_BRIDGE_INSTANCE  *RootBridge;
   EFI_STATUS                Status;
 
-  if (mIoMmu != NULL) {
-    Status = mIoMmu->Unmap (
-                       mIoMmu,
-                       Mapping
-                       );
+  if (IoMmuIsPresent ()) {
+    Status = IoMmuUnmap (Mapping);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a - IoMmuUnmap failed.\n", __func__));
+      ASSERT (FALSE);
+    }
+
     return Status;
   }
 
@@ -1608,6 +1632,7 @@ RootBridgeIoAllocateBuffer (
   EFI_PHYSICAL_ADDRESS      PhysicalAddress;
   PCI_ROOT_BRIDGE_INSTANCE  *RootBridge;
   EFI_ALLOCATE_TYPE         AllocateType;
+  UINT64                    IoMmuAttributes;
 
   //
   // Validate Attributes
@@ -1635,22 +1660,28 @@ RootBridgeIoAllocateBuffer (
 
   RootBridge = ROOT_BRIDGE_FROM_THIS (This);
 
-  if (mIoMmu != NULL) {
-    if (!RootBridge->DmaAbove4G) {
-      //
-      // Clear DUAL_ADDRESS_CYCLE
-      //
-      Attributes &= ~((UINT64)EFI_PCI_ATTRIBUTE_DUAL_ADDRESS_CYCLE);
+  IoMmuAttributes = Attributes;
+
+  if (!RootBridge->DmaAbove4G) {
+    //
+    // Clear DUAL_ADDRESS_CYCLE
+    //
+    IoMmuAttributes &= ~((UINT64)EFI_PCI_ATTRIBUTE_DUAL_ADDRESS_CYCLE);
+  }
+
+  if (IoMmuIsPresent ()) {
+    Status = IoMmuAllocateBuffer (
+               Type,
+               MemoryType,
+               Pages,
+               HostAddress,
+               IoMmuAttributes
+               );
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a - IoMmuAllocateBuffer failed.\n", __func__));
+      ASSERT (FALSE);
     }
 
-    Status = mIoMmu->AllocateBuffer (
-                       mIoMmu,
-                       Type,
-                       MemoryType,
-                       Pages,
-                       HostAddress,
-                       Attributes
-                       );
     return Status;
   }
 
@@ -1702,12 +1733,13 @@ RootBridgeIoFreeBuffer (
 {
   EFI_STATUS  Status;
 
-  if (mIoMmu != NULL) {
-    Status = mIoMmu->FreeBuffer (
-                       mIoMmu,
-                       Pages,
-                       HostAddress
-                       );
+  if (IoMmuIsPresent ()) {
+    Status = IoMmuFreeBuffer (Pages, HostAddress);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a - IoMmuFreeBuffer failed.\n", __func__));
+      ASSERT (FALSE);
+    }
+
     return Status;
   }
 

--- a/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciRootBridgeIo.c
+++ b/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciRootBridgeIo.c
@@ -10,6 +10,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include "PciHostBridge.h"
 #include "PciRootBridge.h"
 #include "PciHostResource.h"
+#include <Library/IoMmuLib.h>
 
 #define NO_MAPPING  (VOID *) (UINTN) -1
 
@@ -1358,6 +1359,7 @@ RootBridgeIoMap (
   PCI_ROOT_BRIDGE_INSTANCE  *RootBridge;
   EFI_PHYSICAL_ADDRESS      PhysicalAddress;
   MAP_INFO                  *MapInfo;
+  EDKII_IOMMU_OPERATION     IoMmuOperation;
 
   if ((HostAddress == NULL) || (NumberOfBytes == NULL) || (DeviceAddress == NULL) ||
       (Mapping == NULL))
@@ -1374,24 +1376,44 @@ RootBridgeIoMap (
 
   RootBridge = ROOT_BRIDGE_FROM_THIS (This);
 
-  if (mIoMmu != NULL) {
-    if (!RootBridge->DmaAbove4G) {
-      //
-      // Clear 64bit support
-      //
-      if (Operation > EfiPciOperationBusMasterCommonBuffer) {
-        Operation = (EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL_OPERATION)(Operation - EfiPciOperationBusMasterRead64);
-      }
+  IoMmuOperation = (EDKII_IOMMU_OPERATION)Operation;
+
+  if (!RootBridge->DmaAbove4G) {
+    //
+    // Clear 64bit support: downgrade 64-bit variants to their 32-bit
+    // equivalents.
+    //
+    switch (Operation) {
+      case EfiPciOperationBusMasterRead64:
+        IoMmuOperation = EdkiiIoMmuOperationBusMasterRead;
+        break;
+      case EfiPciOperationBusMasterWrite64:
+        IoMmuOperation = EdkiiIoMmuOperationBusMasterWrite;
+        break;
+      case EfiPciOperationBusMasterCommonBuffer64:
+        IoMmuOperation = EdkiiIoMmuOperationBusMasterCommonBuffer;
+        break;
+      default:
+        //
+        // 32-bit variants pass through unchanged (already set above).
+        //
+        break;
+    }
+  }
+
+  if (IoMmuIsPresent ()) {
+    Status = IoMmuMap (
+               (EDKII_IOMMU_OPERATION)IoMmuOperation,
+               HostAddress,
+               NumberOfBytes,
+               DeviceAddress,
+               Mapping
+               );
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a - IoMmuMap failed.\n", __func__));
+      ASSERT (FALSE);
     }
 
-    Status = mIoMmu->Map (
-                       mIoMmu,
-                       (EDKII_IOMMU_OPERATION)Operation,
-                       HostAddress,
-                       NumberOfBytes,
-                       DeviceAddress,
-                       Mapping
-                       );
     return Status;
   }
 
@@ -1521,11 +1543,13 @@ RootBridgeIoUnmap (
   PCI_ROOT_BRIDGE_INSTANCE  *RootBridge;
   EFI_STATUS                Status;
 
-  if (mIoMmu != NULL) {
-    Status = mIoMmu->Unmap (
-                       mIoMmu,
-                       Mapping
-                       );
+  if (IoMmuIsPresent ()) {
+    Status = IoMmuUnmap (Mapping);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a - IoMmuUnmap failed.\n", __func__));
+      ASSERT (FALSE);
+    }
+
     return Status;
   }
 
@@ -1625,6 +1649,7 @@ RootBridgeIoAllocateBuffer (
   EFI_PHYSICAL_ADDRESS      PhysicalAddress;
   PCI_ROOT_BRIDGE_INSTANCE  *RootBridge;
   EFI_ALLOCATE_TYPE         AllocateType;
+  UINT64                    IoMmuAttributes;
 
   //
   // Validate Attributes
@@ -1652,22 +1677,28 @@ RootBridgeIoAllocateBuffer (
 
   RootBridge = ROOT_BRIDGE_FROM_THIS (This);
 
-  if (mIoMmu != NULL) {
-    if (!RootBridge->DmaAbove4G) {
-      //
-      // Clear DUAL_ADDRESS_CYCLE
-      //
-      Attributes &= ~((UINT64)EFI_PCI_ATTRIBUTE_DUAL_ADDRESS_CYCLE);
+  IoMmuAttributes = Attributes;
+
+  if (!RootBridge->DmaAbove4G) {
+    //
+    // Clear DUAL_ADDRESS_CYCLE
+    //
+    IoMmuAttributes &= ~((UINT64)EFI_PCI_ATTRIBUTE_DUAL_ADDRESS_CYCLE);
+  }
+
+  if (IoMmuIsPresent ()) {
+    Status = IoMmuAllocateBuffer (
+               Type,
+               MemoryType,
+               Pages,
+               HostAddress,
+               IoMmuAttributes
+               );
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a - IoMmuAllocateBuffer failed.\n", __func__));
+      ASSERT (FALSE);
     }
 
-    Status = mIoMmu->AllocateBuffer (
-                       mIoMmu,
-                       Type,
-                       MemoryType,
-                       Pages,
-                       HostAddress,
-                       Attributes
-                       );
     return Status;
   }
 
@@ -1719,12 +1750,13 @@ RootBridgeIoFreeBuffer (
 {
   EFI_STATUS  Status;
 
-  if (mIoMmu != NULL) {
-    Status = mIoMmu->FreeBuffer (
-                       mIoMmu,
-                       Pages,
-                       HostAddress
-                       );
+  if (IoMmuIsPresent ()) {
+    Status = IoMmuFreeBuffer (Pages, HostAddress);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a - IoMmuFreeBuffer failed.\n", __func__));
+      ASSERT (FALSE);
+    }
+
     return Status;
   }
 

--- a/MdeModulePkg/Include/Library/IoMmuLib.h
+++ b/MdeModulePkg/Include/Library/IoMmuLib.h
@@ -125,3 +125,31 @@ IoMmuSetAttribute (
   IN VOID        *MappingInfo,
   IN UINT64      IoMmuAccess
   );
+
+/**
+  Set the R/W access attributes for MappingInfo in the Page Table for a caller
+  that explicitly specifies (IommuBase, DmaId) instead of an EFI_HANDLE.
+
+  Intended for firmware-internal DMA agents that have no UEFI device
+  handle (and therefore cannot be resolved via the IORT). The caller is
+  responsible for providing the correct IommuBase and DmaId.
+
+  @param [in]  IommuBase     Base MMIO address of the IOMMU that owns DmaId.
+  @param [in]  DmaId         DMA identifier emitted by the calling DMA agent (e.g. StreamID on Arm SMMU, RequesterID on VT-d).
+  @param [in]  MappingInfo   The mapping returned from IoMmuMap.
+  @param [in]  IoMmuAccess   The IOMMU access attributes.
+
+  @retval EFI_SUCCESS            Success.
+  @retval EFI_NOT_READY          The IoMmu protocol is not ready.
+  @retval EFI_UNSUPPORTED        The IoMmu protocol does not implement
+                                 SetAttributeById.
+  @retval Other                  Other errors as defined by the IoMmu protocol.
+**/
+EFI_STATUS
+EFIAPI
+IoMmuSetAttributeById (
+  IN UINT64  IommuBase,
+  IN UINT32  DmaId,
+  IN VOID    *MappingInfo,
+  IN UINT64  IoMmuAccess
+  );

--- a/MdeModulePkg/Include/Library/IoMmuLib.h
+++ b/MdeModulePkg/Include/Library/IoMmuLib.h
@@ -1,0 +1,127 @@
+/** @file IoMmuLib.h
+
+    This file is the IoMmuLib header file for the IoMmu lib:
+
+    Copyright (c) Microsoft Corporation.<BR>
+    SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#pragma once
+
+#include <Uefi.h>
+#include <Protocol/IoMmu.h>
+
+/**
+  Returns True if the IoMmu protocol is available, otherwise returns False.
+
+  @retval BOOLEAN    TRUE if the IoMmu protocol is available, FALSE otherwise.
+**/
+BOOLEAN
+EFIAPI
+IoMmuIsPresent (
+  VOID
+  );
+
+/**
+  Map a host address to a device address using the Page Table.
+  Currently, this function only supports identity mapping.
+
+  @param [in]      Operation       The type of IOMMU operation.
+  @param [in]      HostAddress     The host address to map.
+  @param [in, out] NumberOfBytes   On input, the number of bytes to map. On output, the number of bytes mapped.
+  @param [out]     DeviceAddress   The resulting device address.
+  @param [out]     MappingInfo     A double pointer to the mapping. Used by IoMmuUnmap to unmap the address and IoMmuSetAttribute to set attributes.
+                                   IoMmuMap allocates this memory, and it is be freed by IoMmuUnmap.
+
+  @retval EFI_SUCCESS              Success.
+  @retval EFI_NOT_READY            The IoMmu protocol is not ready.
+  @retval Other                    Other errors as defined by the IoMmu protocol.
+
+**/
+EFI_STATUS
+EFIAPI
+IoMmuMap (
+  IN     EDKII_IOMMU_OPERATION  Operation,
+  IN     VOID                   *HostAddress,
+  IN OUT UINTN                  *NumberOfBytes,
+  OUT    EFI_PHYSICAL_ADDRESS   *DeviceAddress,
+  OUT    VOID                   **MappingInfo
+  );
+
+/**
+  Unmap a device address in the Page Table, also invaldidates the TLB by VA.
+
+  @param [in]  MappingInfo   The mapping to unmap. This is the mapping that is returned from IoMmuMap.
+
+  @retval EFI_SUCCESS            Success.
+  @retval EFI_NOT_READY          The IoMmu protocol is not ready.
+  @retval Other                  Other errors as defined by the IoMmu protocol.
+
+**/
+EFI_STATUS
+EFIAPI
+IoMmuUnmap (
+  IN  VOID  *MappingInfo
+  );
+
+/**
+  Free a buffer allocated by IoMmuAllocateBuffer.
+
+  @param [in]  Pages         The number of pages to free.
+  @param [in]  HostAddress   The host address to free.
+
+  @retval EFI_SUCCESS            Success.
+  @retval EFI_NOT_READY          The IoMmu protocol is not ready.
+  @retval Other                  Other errors as defined by the IoMmu protocol.
+**/
+EFI_STATUS
+EFIAPI
+IoMmuFreeBuffer (
+  IN  UINTN  Pages,
+  IN  VOID   *HostAddress
+  );
+
+/**
+  Allocate a buffer for DMA use with the IoMmu.
+
+  @param [in]      Type          The type of allocation to perform.
+  @param [in]      MemoryType    The type of memory to allocate.
+  @param [in]      Pages         The number of pages to allocate.
+  @param [in, out] HostAddress   On input, the desired host address. On output, the allocated host address.
+  @param [in]      Attributes    The memory attributes to use for the allocation.
+
+  @retval EFI_SUCCESS           The requested pages were allocated.
+  @retval EFI_NOT_READY         The IoMmu protocol is not ready.
+  @retval Other                 Other errors as defined by the IoMmu protocol.
+
+**/
+EFI_STATUS
+EFIAPI
+IoMmuAllocateBuffer (
+  IN     EFI_ALLOCATE_TYPE  Type,
+  IN     EFI_MEMORY_TYPE    MemoryType,
+  IN     UINTN              Pages,
+  IN OUT VOID               **HostAddress,
+  IN     UINT64             Attributes
+  );
+
+/**
+  Set the R/W access attributes for MappingInfo in the Page Table.
+
+  @param [in]  DeviceHandle  The device handle to set attributes for.
+  @param [in]  MappingInfo   The mapping to set attributes for. This is the mapping that is returned from IoMmuMap.
+  @param [in]  IoMmuAccess   The IOMMU access attributes.
+
+  @retval EFI_SUCCESS            Success.
+  @retval EFI_NOT_READY          The IoMmu protocol is not ready.
+  @retval Other                  Other errors as defined by the IoMmu protocol.
+
+**/
+EFI_STATUS
+EFIAPI
+IoMmuSetAttribute (
+  IN EFI_HANDLE  DeviceHandle,
+  IN VOID        *MappingInfo,
+  IN UINT64      IoMmuAccess
+  );

--- a/MdeModulePkg/Include/Library/NonDiscoverableDeviceRegistrationLib.h
+++ b/MdeModulePkg/Include/Library/NonDiscoverableDeviceRegistrationLib.h
@@ -23,29 +23,35 @@ typedef enum {
 } NON_DISCOVERABLE_DEVICE_TYPE;
 
 /**
-  Register a non-discoverable MMIO device
+  Register a non-discoverable MMIO device with a caller-supplied UniqueId.
 
-  @param[in]      Type                The type of non-discoverable device
-  @param[in]      DmaType             Whether the device is DMA coherent
+  The platform must provide a UniqueId that NonDiscoverablePciDeviceDxe will
+  use via EFI_PCI_IO_PROTOCOL.GetLocation(). Any value is accepted; the
+  platform is responsible for keeping IDs unique across registrations.
+
+  @param[in]      UniqueId            Platform-assigned UniqueId.
+  @param[in]      Type                The type of non-discoverable device.
+  @param[in]      DmaType             Whether the device is DMA coherent.
   @param[in]      InitFunc            Initialization routine to be invoked when
-                                      the device is enabled
+                                      the device is enabled.
   @param[in,out]  Handle              The handle onto which to install the
                                       non-discoverable device protocol.
                                       If Handle is NULL or *Handle is NULL, a
                                       new handle will be allocated.
   @param[in]      NumMmioResources    The number of UINTN base/size pairs that
                                       follow, each describing an MMIO region
-                                      owned by the device
-  @param[in]  ...                     The variable argument list which contains the
-                                      info about MmioResources.
+                                      owned by the device.
+  @param[in]  ...                     MmioResource base/size pairs.
 
   @retval EFI_SUCCESS                 The registration succeeded.
+  @retval EFI_INVALID_PARAMETER       An invalid argument was given.
   @retval Other                       The registration failed.
 
 **/
 EFI_STATUS
 EFIAPI
 RegisterNonDiscoverableMmioDevice (
+  IN      UINTN                             UniqueId,
   IN      NON_DISCOVERABLE_DEVICE_TYPE      Type,
   IN      NON_DISCOVERABLE_DEVICE_DMA_TYPE  DmaType,
   IN      NON_DISCOVERABLE_DEVICE_INIT      InitFunc,

--- a/MdeModulePkg/Include/Protocol/IoMmu.h
+++ b/MdeModulePkg/Include/Protocol/IoMmu.h
@@ -26,7 +26,7 @@ typedef struct _EDKII_IOMMU_PROTOCOL EDKII_IOMMU_PROTOCOL;
 //          All future revisions must be backwards compatible.
 //          If a future version is not back wards compatible it is not the same GUID.
 //
-#define EDKII_IOMMU_PROTOCOL_REVISION  0x00010000
+#define EDKII_IOMMU_PROTOCOL_REVISION  0x00010001
 
 //
 // IOMMU Access for SetAttribute
@@ -128,6 +128,39 @@ EFI_STATUS
 (EFIAPI *EDKII_IOMMU_SET_ATTRIBUTE)(
   IN EDKII_IOMMU_PROTOCOL  *This,
   IN EFI_HANDLE            DeviceHandle,
+  IN VOID                  *Mapping,
+  IN UINT64                IoMmuAccess
+  );
+
+/**
+  Set IOMMU attributes for a DMA mapping when the caller cannot supply an
+  EFI_HANDLE for the device (for example, a firmware-internal MMIO/DMA
+  agent that has no UEFI device handle and is not described in the IORT).
+
+  The caller is responsible for providing the IOMMU base address that owns
+  the device and the DMA identifier the device emits, which would normally
+  be resolved by the IOMMU implementation via the IORT from a DeviceHandle.
+
+  @param [in]  This          Pointer to the IOMMU protocol instance.
+  @param [in]  IommuBase     Base MMIO address of the IOMMU that owns DmaId.
+  @param [in]  DmaId         DMA identifier emitted by the calling DMA agent
+                             (e.g. StreamID on Arm SMMU, RequesterID on VT-d).
+  @param [in]  Mapping       The mapping returned from Map().
+  @param [in]  IoMmuAccess   The IOMMU access attributes (R/W bits).
+
+  @retval EFI_SUCCESS            Success.
+  @retval EFI_INVALID_PARAMETER  Invalid parameter.
+  @retval EFI_NOT_FOUND          No IOMMU is configured at IommuBase.
+  @retval EFI_UNSUPPORTED        The IOMMU does not support this entry point.
+  @retval EFI_OUT_OF_RESOURCES   Out of resources.
+  @retval EFI_DEVICE_ERROR       The IOMMU device reported an error.
+**/
+typedef
+EFI_STATUS
+(EFIAPI *EDKII_IOMMU_SET_ATTRIBUTE_BY_ID)(
+  IN EDKII_IOMMU_PROTOCOL  *This,
+  IN UINT64                IommuBase,
+  IN UINT32                DmaId,
   IN VOID                  *Mapping,
   IN UINT64                IoMmuAccess
   );
@@ -235,12 +268,17 @@ EFI_STATUS
 /// IOMMU Protocol structure.
 ///
 struct _EDKII_IOMMU_PROTOCOL {
-  UINT64                         Revision;
-  EDKII_IOMMU_SET_ATTRIBUTE      SetAttribute;
-  EDKII_IOMMU_MAP                Map;
-  EDKII_IOMMU_UNMAP              Unmap;
-  EDKII_IOMMU_ALLOCATE_BUFFER    AllocateBuffer;
-  EDKII_IOMMU_FREE_BUFFER        FreeBuffer;
+  UINT64                             Revision;
+  EDKII_IOMMU_SET_ATTRIBUTE          SetAttribute;
+  EDKII_IOMMU_MAP                    Map;
+  EDKII_IOMMU_UNMAP                  Unmap;
+  EDKII_IOMMU_ALLOCATE_BUFFER        AllocateBuffer;
+  EDKII_IOMMU_FREE_BUFFER            FreeBuffer;
+  ///
+  /// Optional. Set IOMMU attributes for callers that do not have an
+  /// EFI_HANDLE for the DMA agent.
+  ///
+  EDKII_IOMMU_SET_ATTRIBUTE_BY_ID    SetAttributeById;
 };
 
 ///

--- a/MdeModulePkg/Include/Protocol/NonDiscoverableDevice.h
+++ b/MdeModulePkg/Include/Protocol/NonDiscoverableDevice.h
@@ -63,6 +63,12 @@ struct _NON_DISCOVERABLE_DEVICE {
   // The MMIO and I/O regions owned by the device
   //
   EFI_ACPI_ADDRESS_SPACE_DESCRIPTOR    *Resources;
+  //
+  // Platform-assigned UniqueId used by NonDiscoverablePciDeviceDxe
+  // to derive a deterministic SBDF in EFI_PCI_IO_PROTOCOL.GetLocation().
+  // The platform must ensure values are unique across all registrations.
+  //
+  UINTN                                UniqueId;
 };
 
 extern EFI_GUID  gEdkiiNonDiscoverableDeviceProtocolGuid;

--- a/MdeModulePkg/Library/IoMmuLib/IoMmuLib.c
+++ b/MdeModulePkg/Library/IoMmuLib/IoMmuLib.c
@@ -179,7 +179,40 @@ IoMmuSetAttribute (
 }
 
 /**
-  The constructor function for IoMmuLib.
+  Set the R/W access attributes for MappingInfo in the Page Table for a caller
+  that explicitly specifies (IommuBase, DmaId) instead of an EFI_HANDLE.
+
+  @param [in]  IommuBase     Base MMIO address of the IOMMU that owns DmaId.
+  @param [in]  DmaId         DMA identifier emitted by the calling DMA agent (e.g. StreamID on Arm SMMU, RequesterID on VT-d).
+  @param [in]  MappingInfo   The mapping to set attributes for. Returned from IoMmuMap.
+  @param [in]  IoMmuAccess   The IOMMU access attributes.
+
+  @retval EFI_SUCCESS        Success
+  @retval EFI_NOT_READY      The IoMmu protocol is not ready.
+  @retval Other              Other errors as defined by the IoMmu protocol.
+**/
+EFI_STATUS
+EFIAPI
+IoMmuSetAttributeById (
+  IN UINT64  IommuBase,
+  IN UINT32  DmaId,
+  IN VOID    *MappingInfo,
+  IN UINT64  IoMmuAccess
+  )
+{
+  if (mIoMmuProtocol == NULL) {
+    DEBUG ((DEBUG_ERROR, "%a: IoMmuProtocol is NULL\n", __func__));
+    ASSERT (mIoMmuProtocol != NULL);
+    return EFI_NOT_READY;
+  }
+
+  if ((mIoMmuProtocol->Revision < EDKII_IOMMU_PROTOCOL_REVISION) || (mIoMmuProtocol->SetAttributeById == NULL)) {
+    DEBUG ((DEBUG_WARN, "%a: SetAttributeById not implemented by IoMmu producer.\n", __func__));
+    return EFI_UNSUPPORTED;
+  }
+
+  return mIoMmuProtocol->SetAttributeById (mIoMmuProtocol, IommuBase, DmaId, MappingInfo, IoMmuAccess);
+}
 
 /**
   The constructor function for IoMmuLib.

--- a/MdeModulePkg/Library/IoMmuLib/IoMmuLib.c
+++ b/MdeModulePkg/Library/IoMmuLib/IoMmuLib.c
@@ -1,0 +1,215 @@
+/** @file IoMmuLib.c
+
+    This file contains all the IoMmu library functions.
+    Wraps the IoMmu protocol functions to provide a generic interface for mapping host memory to device memory.
+
+    Copyright (c) Microsoft Corporation.<BR>
+    SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+#include <Library/BaseLib.h>
+#include <Library/DebugLib.h>
+#include <Library/IoMmuLib.h>
+#include <Library/UefiBootServicesTableLib.h>
+#include <Library/UefiLib.h>
+#include <Protocol/IoMmu.h>
+
+EDKII_IOMMU_PROTOCOL  *mIoMmuProtocol = NULL;
+
+/**
+  Returns True if the IoMmu protocol is available, otherwise returns False.
+
+  @retval BOOLEAN    TRUE if the IoMmu protocol is available, FALSE otherwise.
+**/
+BOOLEAN
+EFIAPI
+IoMmuIsPresent (
+  VOID
+  )
+{
+  return TRUE;
+}
+
+/**
+  Map a host address to a device address using the Page Table.
+  Currently, this function only supports identity mapping.
+
+  @param [in]      Operation       The type of IOMMU operation.
+  @param [in]      HostAddress     The host address to map.
+  @param [in, out] NumberOfBytes   On input, the number of bytes to map. On output, the number of bytes mapped.
+  @param [out]     DeviceAddress   The resulting device address.
+  @param [out]     MappingInfo     A double pointer to the mapping. Used by IoMmuUnmap to unmap the address and IoMmuSetAttribute to set attributes.
+                                   IoMmuMap allocates this memory, and it is be freed by IoMmuUnmap.
+
+  @retval EFI_SUCCESS              Success.
+  @retval EFI_NOT_READY            The IoMmu protocol is not ready.
+  @retval Other                    Other errors as defined by the IoMmu protocol.
+
+**/
+EFI_STATUS
+EFIAPI
+IoMmuMap (
+  IN     EDKII_IOMMU_OPERATION  Operation,
+  IN     VOID                   *HostAddress,
+  IN OUT UINTN                  *NumberOfBytes,
+  OUT    EFI_PHYSICAL_ADDRESS   *DeviceAddress,
+  OUT    VOID                   **MappingInfo
+  )
+{
+  if (mIoMmuProtocol == NULL) {
+    DEBUG ((DEBUG_ERROR, "%a: IoMmuProtocol is NULL\n", __func__));
+    ASSERT (mIoMmuProtocol != NULL);
+    return EFI_NOT_READY;
+  }
+
+  return mIoMmuProtocol->Map (mIoMmuProtocol, Operation, HostAddress, NumberOfBytes, DeviceAddress, MappingInfo);
+}
+
+/**
+  Unmap a device address in the Page Table, also invaldidates the TLB by VA.
+
+  @param [in]  MappingInfo   The mapping to unmap. This is the mapping that is returned from IoMmuMap.
+
+  @retval EFI_SUCCESS            Success.
+  @retval EFI_NOT_READY          The IoMmu protocol is not ready.
+  @retval Other                  Other errors as defined by the IoMmu protocol.
+
+**/
+EFI_STATUS
+EFIAPI
+IoMmuUnmap (
+  IN  VOID  *MappingInfo
+  )
+{
+  if (mIoMmuProtocol == NULL) {
+    DEBUG ((DEBUG_ERROR, "%a: IoMmuProtocol is NULL\n", __func__));
+    ASSERT (mIoMmuProtocol != NULL);
+    return EFI_NOT_READY;
+  }
+
+  return mIoMmuProtocol->Unmap (mIoMmuProtocol, MappingInfo);
+}
+
+/**
+  Free a buffer allocated by IoMmuAllocateBuffer.
+
+  @param [in]  Pages         The number of pages to free.
+  @param [in]  HostAddress   The host address to free.
+
+  @retval EFI_SUCCESS            Success.
+  @retval EFI_NOT_READY          The IoMmu protocol is not ready.
+  @retval Other                  Other errors as defined by the IoMmu protocol.
+**/
+EFI_STATUS
+EFIAPI
+IoMmuFreeBuffer (
+  IN  UINTN  Pages,
+  IN  VOID   *HostAddress
+  )
+{
+  if (mIoMmuProtocol == NULL) {
+    DEBUG ((DEBUG_ERROR, "%a: IoMmuProtocol is NULL\n", __func__));
+    ASSERT (mIoMmuProtocol != NULL);
+    return EFI_NOT_READY;
+  }
+
+  return mIoMmuProtocol->FreeBuffer (mIoMmuProtocol, Pages, HostAddress);
+}
+
+/**
+  Allocate a buffer for DMA use with the IoMmu.
+
+  @param [in]      Type          The type of allocation to perform.
+  @param [in]      MemoryType    The type of memory to allocate.
+  @param [in]      Pages         The number of pages to allocate.
+  @param [in, out] HostAddress   On input, the desired host address. On output, the allocated host address.
+  @param [in]      Attributes    The memory attributes to use for the allocation.
+
+  @retval EFI_SUCCESS           The requested pages were allocated.
+  @retval EFI_NOT_READY         The IoMmu protocol is not ready.
+  @retval Other                 Other errors as defined by the IoMmu protocol.
+
+**/
+EFI_STATUS
+EFIAPI
+IoMmuAllocateBuffer (
+  IN     EFI_ALLOCATE_TYPE  Type,
+  IN     EFI_MEMORY_TYPE    MemoryType,
+  IN     UINTN              Pages,
+  IN OUT VOID               **HostAddress,
+  IN     UINT64             Attributes
+  )
+{
+  if (mIoMmuProtocol == NULL) {
+    DEBUG ((DEBUG_ERROR, "%a: IoMmuProtocol is NULL\n", __func__));
+    ASSERT (mIoMmuProtocol != NULL);
+    return EFI_NOT_READY;
+  }
+
+  return mIoMmuProtocol->AllocateBuffer (mIoMmuProtocol, Type, MemoryType, Pages, HostAddress, Attributes);
+}
+
+/**
+  Set the R/W access attributes for MappingInfo in the Page Table.
+
+  @param [in]  DeviceHandle  The device handle to set attributes for.
+  @param [in]  MappingInfo   The mapping to set attributes for. This is the mapping that is returned from IoMmuMap.
+  @param [in]  IoMmuAccess   The IOMMU access attributes.
+
+  @retval EFI_SUCCESS            Success.
+  @retval EFI_NOT_READY          The IoMmu protocol is not ready.
+  @retval Other                  Other errors as defined by the IoMmu protocol.
+
+**/
+EFI_STATUS
+EFIAPI
+IoMmuSetAttribute (
+  IN EFI_HANDLE  DeviceHandle,
+  IN VOID        *MappingInfo,
+  IN UINT64      IoMmuAccess
+  )
+{
+  if (mIoMmuProtocol == NULL) {
+    DEBUG ((DEBUG_ERROR, "%a: IoMmuProtocol is NULL\n", __func__));
+    ASSERT (mIoMmuProtocol != NULL);
+    return EFI_NOT_READY;
+  }
+
+  return mIoMmuProtocol->SetAttribute (mIoMmuProtocol, DeviceHandle, MappingInfo, IoMmuAccess);
+}
+
+/**
+  The constructor function for IoMmuLib.
+
+/**
+  The constructor function for IoMmuLib.
+
+  Locates the EDKII IOMMU protocol. The library's INF declares a DEPEX on
+  gEdkiiIoMmuProtocolGuid, so the protocol is guaranteed to be available by
+  the time this constructor runs.
+
+  @param[in]  ImageHandle  The firmware allocated handle for the EFI image.
+  @param[in]  SystemTable  A pointer to the EFI System Table.
+
+  @retval EFI_SUCCESS  The constructor completed successfully.
+  @retval Other        The IoMmu protocol was not located despite the DEPEX.
+
+**/
+EFI_STATUS
+EFIAPI
+IoMmuLibInit (
+  IN EFI_HANDLE        ImageHandle,
+  IN EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  EFI_STATUS  Status;
+
+  Status = gBS->LocateProtocol (&gEdkiiIoMmuProtocolGuid, NULL, (VOID **)&mIoMmuProtocol);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: IoMmuProtocol not found despite DEPEX. Status = %r\n", __func__, Status));
+    ASSERT_EFI_ERROR (Status);
+    return Status;
+  }
+
+  return Status;
+}

--- a/MdeModulePkg/Library/IoMmuLib/IoMmuLib.inf
+++ b/MdeModulePkg/Library/IoMmuLib/IoMmuLib.inf
@@ -1,0 +1,35 @@
+## @file
+#  IoMmuLib - Wrapper library for the EDKII IOMMU protocol functions.
+#
+#  Copyright (c) Microsoft Corporation.<BR>
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x0001001E
+  BASE_NAME                      = IoMmuLib
+  FILE_GUID                      = 55af180d-a4ee-47fa-84d5-01071643ad35
+  MODULE_TYPE                    = DXE_DRIVER
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = IoMmuLib
+  CONSTRUCTOR                    = IoMmuLibInit
+
+[Sources]
+  IoMmuLib.c
+
+[LibraryClasses]
+  BaseLib
+  DebugLib
+  UefiBootServicesTableLib
+  UefiLib
+
+[Packages]
+  MdeModulePkg/MdeModulePkg.dec
+  MdePkg/MdePkg.dec
+
+[Protocols]
+  gEdkiiIoMmuProtocolGuid             ## CONSUMES
+
+[Depex]
+  gEdkiiIoMmuProtocolGuid             ## CONSUMES

--- a/MdeModulePkg/Library/IoMmuLib/README.md
+++ b/MdeModulePkg/Library/IoMmuLib/README.md
@@ -171,6 +171,57 @@ Sets read/write access attributes for a mapped region in the IOMMU page table.
 - `EFI_NOT_READY`: The IoMmu protocol is not ready.
 - Other status codes as defined by the underlying IOMMU protocol
 
+### IoMmuSetAttributeById
+
+```c
+EFI_STATUS
+EFIAPI
+IoMmuSetAttributeById (
+  IN UINT64  IommuBase,
+  IN UINT32  DmaId,
+  IN VOID    *MappingInfo,
+  IN UINT64  IoMmuAccess
+  );
+```
+
+Sets read/write access attributes for a mapped region in the IOMMU page table by explicitly
+specifying the `(IommuBase, DmaId)` pair instead of an `EFI_HANDLE`.
+
+This function is intended for firmware-internal DMA agents that have no UEFI device handle and
+therefore cannot be resolved through the IORT (I/O Remapping Table). In such cases the caller is
+responsible for providing the correct `IommuBase` and `DmaId`.
+
+**Parameters:**
+
+- `IommuBase`: Base MMIO address of the IOMMU that owns `DmaId`
+- `DmaId`: The DMA identifier emitted by the calling DMA agent (e.g. StreamID on Arm SMMU, RequesterID on VT-d)
+- `MappingInfo`: The mapping handle returned by `IoMmuMap()`
+- `IoMmuAccess`: The desired IOMMU access attributes
+
+**Returns:**
+
+- `EFI_SUCCESS`: Attributes set successfully
+- `EFI_NOT_READY`: The IoMmu protocol is not ready.
+- `EFI_UNSUPPORTED`: The underlying IOMMU protocol does not implement `SetAttributeById`. This occurs when
+  the producer's `EDKII_IOMMU_PROTOCOL` revision is older than `EDKII_IOMMU_PROTOCOL_REVISION` or does not
+  provide a `SetAttributeById` function. The rest of the library remains fully functional.
+- Other status codes as defined by the underlying IOMMU protocol
+
+#### IoMmuSetAttribute vs IoMmuSetAttributeById
+
+Use `IoMmuSetAttribute` when the DMA agent has a UEFI device handle (`EFI_HANDLE`) that the IOMMU
+producer can resolve through the IORT to determine the owning IOMMU and DMA identifier. This is the
+common case for PCIe devices and other handle-backed devices.
+
+Use `IoMmuSetAttributeById` instead of `IoMmuSetAttribute` when the calling DMA agent has **no** UEFI
+device handle and therefore cannot be resolved via the IORT. Because the caller supplies the
+`IommuBase` and `DmaId` directly, the IOMMU producer does not need to look up the device handle. The
+caller is responsible for providing the correct values.
+
+> Note: `IoMmuSetAttributeById` requires an IOMMU producer whose protocol revision is at least
+> `EDKII_IOMMU_PROTOCOL_REVISION` and implements `SetAttributeById`. If this is not the case, the
+> function returns `EFI_UNSUPPORTED`; callers should fall back to `IoMmuSetAttribute` where possible.
+
 ## Usage Guidelines
 
 ### Example Usage Pattern

--- a/MdeModulePkg/Library/IoMmuLib/README.md
+++ b/MdeModulePkg/Library/IoMmuLib/README.md
@@ -1,0 +1,239 @@
+# IoMmuLib
+
+IoMmuLib is a library that provides a simplified interface for IOMMU (Input/Output Memory Management Unit) operations.
+This library abstracts the complexity of directly interfacing with the IOMMU protocol.
+It eliminates the need for PCD (Platform Configuration Database) dependencies and removes the requirement for manual
+protocol location within driver code.
+
+## Overview
+
+The library wraps the EDK II IOMMU protocol dependency (depex) and provides a clean,
+consistent API for IOMMU operations across different platforms. By using IoMmuLib,
+drivers no longer need to:
+
+- Manually locate the gEdkiiIoMmuProtocolGuid IOMMU protocol using `gBS->LocateProtocol()`
+- Handle PCD configurations for IOMMU settings
+- Manage protocol availability checks
+
+## Architecture
+
+IoMmuLib consists of two implementation files:
+
+- **IoMmuLib.c**: The functional implementation that interfaces with the actual IOMMU protocol. IoMmuIsPresent == TRUE.
+- **IoMmuLibNull.c**: A null implementation that returns `EFI_SUCCESS` for all operations. IoMmuIsPresent == FALSE.
+
+The appropriate implementation is selected during the build process based on platform requirements.
+Callers of the IoMmuLib library functions can handle for if the IoMmu is present with the IoMmuisPresent() function.
+
+## Functions
+
+### IoMmuIsPresent
+
+```c
+BOOLEAN
+EFIAPI
+IoMmuIsPresent (
+  VOID
+  );
+```
+
+Returns True if IoMmu is found, False otherwise.
+
+### IoMmuMap
+
+```c
+EFI_STATUS
+EFIAPI
+IoMmuMap (
+  IN     EDKII_IOMMU_OPERATION  Operation,
+  IN     VOID                   *HostAddress,
+  IN OUT UINTN                  *NumberOfBytes,
+  OUT    EFI_PHYSICAL_ADDRESS   *DeviceAddress,
+  OUT    VOID                   **MappingInfo
+  );
+```
+
+Maps a host address to a device address using the IOMMU page table. Currently supports identity mapping operations.
+
+**Parameters:**
+
+- `Operation`: The type of IOMMU operation to perform
+- `HostAddress`: The host memory address to map
+- `NumberOfBytes`: Input - bytes to map; Output - bytes actually mapped
+- `DeviceAddress`: Returns the resulting device-accessible address
+- `MappingInfo`: Returns a pointer for the mapping (used by unmap and set attribute operations)
+
+**Returns:**
+
+- `EFI_SUCCESS`: Mapping completed successfully
+- `EFI_NOT_READY`: The IoMmu protocol is not ready.
+- Other status codes as defined by the underlying IOMMU protocol
+
+### IoMmuUnmap
+
+```c
+EFI_STATUS
+EFIAPI
+IoMmuUnmap (
+  IN  VOID  *MappingInfo
+  );
+```
+
+Unmaps a previously mapped device address and invalidates the corresponding TLB entries.
+
+**Parameters:**
+
+- `MappingInfo`: The mapping info returned by `IoMmuMap()`
+
+**Returns:**
+
+- `EFI_SUCCESS`: Unmapping completed successfully
+- `EFI_NOT_READY`: The IoMmu protocol is not ready.
+- Other status codes as defined by the underlying IOMMU protocol
+
+### IoMmuAllocateBuffer
+
+```c
+EFI_STATUS
+EFIAPI
+IoMmuAllocateBuffer (
+  IN     EFI_ALLOCATE_TYPE  Type,
+  IN     EFI_MEMORY_TYPE    MemoryType,
+  IN     UINTN              Pages,
+  IN OUT VOID               **HostAddress,
+  IN     UINT64             Attributes
+  );
+```
+
+Allocates a buffer suitable for IOMMU operations with specified memory attributes.
+
+**Parameters:**
+
+- `Type`: The allocation type (AllocateAnyPages, AllocateMaxAddress, AllocateAddress)
+- `MemoryType`: The type of memory to allocate
+- `Pages`: Number of 4KB pages to allocate
+- `HostAddress`: Input - desired address (if Type is AllocateAddress); Output - allocated address
+- `Attributes`: Memory attributes for the allocation
+
+**Returns:**
+
+- `EFI_SUCCESS`: Buffer allocated successfully
+- `EFI_NOT_READY`: The IoMmu protocol is not ready.
+- Other status codes as defined by the underlying IOMMU protocol
+
+### IoMmuFreeBuffer
+
+```c
+EFI_STATUS
+EFIAPI
+IoMmuFreeBuffer (
+  IN  UINTN  Pages,
+  IN  VOID   *HostAddress
+  );
+```
+
+Frees a buffer that was previously allocated by `IoMmuAllocateBuffer()`.
+
+**Parameters:**
+
+- `Pages`: Number of pages to free (must match the original allocation)
+- `HostAddress`: The host address to free
+
+**Returns:**
+
+- `EFI_SUCCESS`: Buffer freed successfully
+- `EFI_NOT_READY`: The IoMmu protocol is not ready.
+- Other status codes as defined by the underlying IOMMU protocol
+
+### IoMmuSetAttribute
+
+```c
+EFI_STATUS
+EFIAPI
+IoMmuSetAttribute (
+  IN EFI_HANDLE  DeviceHandle,
+  IN VOID        *MappingInfo,
+  IN UINT64      IoMmuAccess
+  );
+```
+
+Sets read/write access attributes for a mapped region in the IOMMU page table.
+
+**Parameters:**
+
+- `DeviceHandle`: The device handle associated with the mapping
+- `MappingInfo`: The mapping handle returned by `IoMmuMap()`
+- `IoMmuAccess`: The desired IOMMU access attributes
+
+**Returns:**
+
+- `EFI_SUCCESS`: Attributes set successfully
+- `EFI_NOT_READY`: The IoMmu protocol is not ready.
+- Other status codes as defined by the underlying IOMMU protocol
+
+## Usage Guidelines
+
+### Example Usage Pattern
+
+Many other usage cases could occur and the caller must handle the return status appropriatley.
+Caller must handle for cases where IOMMU is available/not available with proper error handling.
+
+```c
+// Initialize all inputs to the IoMmuLib functions appropriatley. The below is just an example.
+EFI_STATUS Status;
+VOID *Mapping;
+EFI_PHYSICAL_ADDRESS DeviceAddress;
+UINTN NumberOfBytes;
+UINT64 IoMmuAccess;
+
+// Map host buffer for device access
+Status = IoMmuMap (
+           EdkiiIoMmuOperationBusMasterRead,
+           HostBuffer,
+           &NumberOfBytes,
+           &DeviceAddress,
+           &Mapping
+           );
+
+if (EFI_ERROR (Status)) {
+  DEBUG ((DEBUG_ERROR, "%a - IoMmuMap failed.\n", __func__));
+  ASSERT (FALSE);
+}
+
+Status = IoMmuSetAttribute (
+            NULL,
+            Mapping,
+            IoMmuAccess
+            );
+
+// Perform device operation using DeviceAddress
+
+// Unmap when done
+Status = IoMmuUnmap (Mapping);
+
+```
+
+## Platform Integration
+
+The library automatically adapts to platform capabilities. On platforms without IOMMU support, use IoMmuLibNull.
+On platforms with IOMMU support, use IoMmuLib.
+
+For integrating with a platform, in the top level DSC, you can do the following for example:
+
+```text
+  # Enable IoMmu/Smmu support
+  DEFINE REQUIRE_IOMMU             = TRUE
+
+!if $(REQUIRE_IOMMU) == TRUE
+  IoMmuLib|MdeModulePkg/Library/IoMmuLib/IoMmuLib.inf
+!else
+  IoMmuLib|MdeModulePkg/Library/IoMmuLibNull/IoMmuLibNull.inf
+!endif
+```
+
+### Dispatch ordering (Depex)
+
+`IoMmuLib.inf` declares an unconditional depex on `gEdkiiIoMmuProtocolGuid` so
+that any consumer of `IoMmuLib` is guaranteed the IOMMU protocol has been
+published before the consuming driver dispatches. Platforms that do not have an
+IOMMU producer must link against `IoMmuLibNull` instead.

--- a/MdeModulePkg/Library/IoMmuLibNull/IoMmuLibNull.c
+++ b/MdeModulePkg/Library/IoMmuLibNull/IoMmuLibNull.c
@@ -1,0 +1,133 @@
+/** @file IoMmuLib.c
+
+    This file contains all the NULL implementation of the IoMmu protocol library functions.
+
+    Copyright (c) Microsoft Corporation.<BR>
+    SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+#include <Library/BaseLib.h>
+#include <Library/IoMmuLib.h>
+
+/**
+  Returns True if the IoMmu protocol is available, otherwise returns False.
+  This is a NULL implementation, so it always returns FALSE.
+
+  @retval BOOLEAN    False, as this is a NULL implementation.
+**/
+BOOLEAN
+EFIAPI
+IoMmuIsPresent (
+  VOID
+  )
+{
+  return FALSE;
+}
+
+/**
+  NULL implementation of IoMmuMap.
+
+  @param [in]      Operation       The type of IOMMU operation.
+  @param [in]      HostAddress     The host address to map.
+  @param [in, out] NumberOfBytes   On input, the number of bytes to map. On output, the number of bytes mapped.
+  @param [out]     DeviceAddress   The resulting device address.
+  @param [out]     MappingInfo     A handle to the mapping. Used by IoMmuUnmap to unmap the address and IoMmuSetAttribute to set attributes.
+                                   IoMmuMap allocates this memory, and it is be freed by IoMmuUnmap.
+
+  @retval EFI_SUCCESS          NULL implementation, this function always succeeds.
+
+**/
+EFI_STATUS
+EFIAPI
+IoMmuMap (
+  IN     EDKII_IOMMU_OPERATION  Operation,
+  IN     VOID                   *HostAddress,
+  IN OUT UINTN                  *NumberOfBytes,
+  OUT    EFI_PHYSICAL_ADDRESS   *DeviceAddress,
+  OUT    VOID                   **MappingInfo
+  )
+{
+  return EFI_SUCCESS;
+}
+
+/**
+  NULL implementation of IoMmuUnmap.
+
+  @param [in]  MappingInfo   The mapping to unmap. This is the mapping that is returned from IoMmuMap.
+
+  @retval EFI_SUCCESS          NULL implementation, this function always succeeds.
+
+**/
+EFI_STATUS
+EFIAPI
+IoMmuUnmap (
+  IN  VOID  *MappingInfo
+  )
+{
+  return EFI_SUCCESS;
+}
+
+/**
+  NULL implementation of IoMmuFreeBuffer.
+
+  @param [in]  Pages         The number of pages to free.
+  @param [in]  HostAddress   The host address to free.
+
+  @retval EFI_SUCCESS          NULL implementation, this function always succeeds.
+
+**/
+EFI_STATUS
+EFIAPI
+IoMmuFreeBuffer (
+  IN  UINTN  Pages,
+  IN  VOID   *HostAddress
+  )
+{
+  return EFI_SUCCESS;
+}
+
+/**
+  NULL implementation of IoMmuAllocateBuffer.
+
+  @param [in]      Type          The type of allocation to perform.
+  @param [in]      MemoryType    The type of memory to allocate.
+  @param [in]      Pages         The number of pages to allocate.
+  @param [in, out] HostAddress   On input, the desired host address. On output, the allocated host address.
+  @param [in]      Attributes    The memory attributes to use for the allocation.
+
+  @retval EFI_SUCCESS          NULL implementation, this function always succeeds.
+
+**/
+EFI_STATUS
+EFIAPI
+IoMmuAllocateBuffer (
+  IN     EFI_ALLOCATE_TYPE  Type,
+  IN     EFI_MEMORY_TYPE    MemoryType,
+  IN     UINTN              Pages,
+  IN OUT VOID               **HostAddress,
+  IN     UINT64             Attributes
+  )
+{
+  return EFI_SUCCESS;
+}
+
+/**
+  NULL implementation of IoMmuSetAttribute.
+
+  @param [in]  DeviceHandle  The device handle to set attributes for.
+  @param [in]  MappingInfo   The mapping to set attributes for. This is the mapping that is returned from IoMmuMap.
+  @param [in]  IoMmuAccess   The IOMMU access attributes.
+
+  @retval EFI_SUCCESS          NULL implementation, this function always succeeds.
+
+**/
+EFI_STATUS
+EFIAPI
+IoMmuSetAttribute (
+  IN EFI_HANDLE  DeviceHandle,
+  IN VOID        *MappingInfo,
+  IN UINT64      IoMmuAccess
+  )
+{
+  return EFI_SUCCESS;
+}

--- a/MdeModulePkg/Library/IoMmuLibNull/IoMmuLibNull.c
+++ b/MdeModulePkg/Library/IoMmuLibNull/IoMmuLibNull.c
@@ -131,3 +131,25 @@ IoMmuSetAttribute (
 {
   return EFI_SUCCESS;
 }
+
+/**
+  NULL implementation of IoMmuSetAttributeById.
+
+  @param [in]  IommuBase     Base MMIO address of the IOMMU that owns DmaId.
+  @param [in]  DmaId     DMA identifier emitted by the calling DMA agent (e.g. StreamID on Arm SMMU, RequesterID on VT-d).
+  @param [in]  MappingInfo  The mapping to set attributes for.
+  @param [in]  IoMmuAccess  The IOMMU access attributes.
+
+  @retval EFI_SUCCESS       NULL implementation, this function always succeeds.
+**/
+EFI_STATUS
+EFIAPI
+IoMmuSetAttributeById (
+  IN UINT64  IommuBase,
+  IN UINT32  DmaId,
+  IN VOID    *MappingInfo,
+  IN UINT64  IoMmuAccess
+  )
+{
+  return EFI_SUCCESS;
+}

--- a/MdeModulePkg/Library/IoMmuLibNull/IoMmuLibNull.inf
+++ b/MdeModulePkg/Library/IoMmuLibNull/IoMmuLibNull.inf
@@ -1,0 +1,25 @@
+## @file
+#  IoMmuLibNull - NULL instance of IoMmuLib for platforms without an IOMMU.
+#
+#  Copyright (c) Microsoft Corporation.<BR>
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x0001001E
+  BASE_NAME                      = IoMmuLibNull
+  FILE_GUID                      = 743616a1-4fe5-41c2-9534-e222f6f61081
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = IoMmuLib
+
+[Sources]
+  IoMmuLibNull.c
+
+[LibraryClasses]
+  BaseLib
+
+[Packages]
+  MdeModulePkg/MdeModulePkg.dec
+  MdePkg/MdePkg.dec

--- a/MdeModulePkg/Library/NonDiscoverableDeviceRegistrationLib/NonDiscoverableDeviceRegistrationLib.c
+++ b/MdeModulePkg/Library/NonDiscoverableDeviceRegistrationLib/NonDiscoverableDeviceRegistrationLib.c
@@ -76,30 +76,35 @@ typedef struct {
 #pragma pack ()
 
 /**
-  Register a non-discoverable MMIO device.
+  Register a non-discoverable MMIO device with a caller-supplied UniqueId.
 
-  @param[in]      Type                The type of non-discoverable device
-  @param[in]      DmaType             Whether the device is DMA coherent
+  The platform must provide a UniqueId that NonDiscoverablePciDeviceDxe will
+  use via EFI_PCI_IO_PROTOCOL.GetLocation(). Any value is accepted; the
+  platform is responsible for keeping IDs unique across registrations.
+
+  @param[in]      UniqueId            Platform-assigned UniqueId.
+  @param[in]      Type                The type of non-discoverable device.
+  @param[in]      DmaType             Whether the device is DMA coherent.
   @param[in]      InitFunc            Initialization routine to be invoked when
-                                      the device is enabled
+                                      the device is enabled.
   @param[in,out]  Handle              The handle onto which to install the
                                       non-discoverable device protocol.
                                       If Handle is NULL or *Handle is NULL, a
                                       new handle will be allocated.
   @param[in]      NumMmioResources    The number of UINTN base/size pairs that
                                       follow, each describing an MMIO region
-                                      owned by the device
-  @param[in]  ...                     The variable argument list which contains the
-                                      info about MmioResources.
+                                      owned by the device.
+  @param[in]  ...                     MmioResource base/size pairs.
 
   @retval EFI_SUCCESS                 The registration succeeded.
-  @retval EFI_INVALID_PARAMETER       An invalid argument was given
+  @retval EFI_INVALID_PARAMETER       An invalid argument was given.
   @retval Other                       The registration failed.
 
 **/
 EFI_STATUS
 EFIAPI
 RegisterNonDiscoverableMmioDevice (
+  IN      UINTN                             UniqueId,
   IN      NON_DISCOVERABLE_DEVICE_TYPE      Type,
   IN      NON_DISCOVERABLE_DEVICE_DMA_TYPE  DmaType,
   IN      NON_DISCOVERABLE_DEVICE_INIT      InitFunc,
@@ -145,6 +150,7 @@ RegisterNonDiscoverableMmioDevice (
   Device->DmaType    = DmaType;
   Device->Initialize = InitFunc;
   Device->Resources  = (EFI_ACPI_ADDRESS_SPACE_DESCRIPTOR *)(Device + 1);
+  Device->UniqueId   = UniqueId;
 
   VA_START (Args, NumMmioResources);
   for (Index = 0; Index < NumMmioResources; Index++) {

--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -186,6 +186,10 @@
   #
   HobPrintLib|Include/Library/HobPrintLib.h
 
+  ## @libraryclass IoMmu library that can be used for IoMmu Protocol functions.
+  #
+  IoMmuLib|Include/Library/IoMmuLib.h
+
 [Guids]
   ## MdeModule package token space guid
   # Include/Guid/MdeModulePkgTokenSpace.h

--- a/MdeModulePkg/MdeModulePkg.dsc
+++ b/MdeModulePkg/MdeModulePkg.dsc
@@ -76,6 +76,7 @@
   PcdLib|MdePkg/Library/BasePcdLibNull/BasePcdLibNull.inf
   CustomizedDisplayLib|MdeModulePkg/Library/CustomizedDisplayLib/CustomizedDisplayLib.inf
   FrameBufferBltLib|MdeModulePkg/Library/FrameBufferBltLib/FrameBufferBltLib.inf
+  IoMmuLib|MdeModulePkg/Library/IoMmuLibNull/IoMmuLibNull.inf
   #
   # Misc
   #
@@ -350,6 +351,8 @@
   MdeModulePkg/Library/DisplayUpdateProgressLibText/DisplayUpdateProgressLibText.inf
   MdeModulePkg/Library/BaseRngLibTimerLib/BaseRngLibTimerLib.inf
   MdeModulePkg/Library/HobPrintLib/HobPrintLib.inf
+  MdeModulePkg/Library/IoMmuLib/IoMmuLib.inf
+  MdeModulePkg/Library/IoMmuLibNull/IoMmuLibNull.inf
 
   MdeModulePkg/Universal/BdsDxe/BdsDxe.inf
   MdeModulePkg/Application/BootManagerMenuApp/BootManagerMenuApp.inf

--- a/OvmfPkg/AmdSev/AmdSevX64.dsc
+++ b/OvmfPkg/AmdSev/AmdSevX64.dsc
@@ -143,6 +143,7 @@
   PciCapPciSegmentLib|OvmfPkg/Library/BasePciCapPciSegmentLib/BasePciCapPciSegmentLib.inf
   PciCapPciIoLib|OvmfPkg/Library/UefiPciCapPciIoLib/UefiPciCapPciIoLib.inf
   IoLib|MdePkg/Library/BaseIoLibIntrinsic/BaseIoLibIntrinsicSev.inf
+  IoMmuLib|OvmfPkg/Library/IoMmuLib/IoMmuLib.inf
   OemHookStatusCodeLib|MdeModulePkg/Library/OemHookStatusCodeLibNull/OemHookStatusCodeLibNull.inf
   SerialPortLib|PcAtChipsetPkg/Library/SerialIoLib/SerialIoLib.inf
   MtrrLib|UefiCpuPkg/Library/MtrrLib/MtrrLib.inf

--- a/OvmfPkg/Bhyve/BhyveX64.dsc
+++ b/OvmfPkg/Bhyve/BhyveX64.dsc
@@ -159,6 +159,7 @@
   PciCapPciSegmentLib|OvmfPkg/Library/BasePciCapPciSegmentLib/BasePciCapPciSegmentLib.inf
   PciCapPciIoLib|OvmfPkg/Library/UefiPciCapPciIoLib/UefiPciCapPciIoLib.inf
   IoLib|MdePkg/Library/BaseIoLibIntrinsic/BaseIoLibIntrinsicSev.inf
+  IoMmuLib|OvmfPkg/Library/IoMmuLib/IoMmuLib.inf
   OemHookStatusCodeLib|MdeModulePkg/Library/OemHookStatusCodeLibNull/OemHookStatusCodeLibNull.inf
   SerialPortLib|PcAtChipsetPkg/Library/SerialIoLib/SerialIoLib.inf
   MtrrLib|UefiCpuPkg/Library/MtrrLib/MtrrLib.inf

--- a/OvmfPkg/CloudHv/CloudHvX64.dsc
+++ b/OvmfPkg/CloudHv/CloudHvX64.dsc
@@ -165,6 +165,7 @@
   PciCapPciSegmentLib|OvmfPkg/Library/BasePciCapPciSegmentLib/BasePciCapPciSegmentLib.inf
   PciCapPciIoLib|OvmfPkg/Library/UefiPciCapPciIoLib/UefiPciCapPciIoLib.inf
   IoLib|MdePkg/Library/BaseIoLibIntrinsic/BaseIoLibIntrinsicSev.inf
+  IoMmuLib|OvmfPkg/Library/IoMmuLib/IoMmuLib.inf
   OemHookStatusCodeLib|MdeModulePkg/Library/OemHookStatusCodeLibNull/OemHookStatusCodeLibNull.inf
   SerialPortLib|PcAtChipsetPkg/Library/SerialIoLib/SerialIoLib.inf
   MtrrLib|UefiCpuPkg/Library/MtrrLib/MtrrLib.inf

--- a/OvmfPkg/IntelTdx/IntelTdxX64.dsc
+++ b/OvmfPkg/IntelTdx/IntelTdxX64.dsc
@@ -147,6 +147,7 @@
   PciCapPciIoLib|OvmfPkg/Library/UefiPciCapPciIoLib/UefiPciCapPciIoLib.inf
   CcProbeLib|OvmfPkg/Library/CcProbeLib/DxeCcProbeLib.inf
   IoLib|MdePkg/Library/BaseIoLibIntrinsic/BaseIoLibIntrinsicSev.inf
+  IoMmuLib|OvmfPkg/Library/IoMmuLib/IoMmuLib.inf
   OemHookStatusCodeLib|MdeModulePkg/Library/OemHookStatusCodeLibNull/OemHookStatusCodeLibNull.inf
   SerialPortLib|PcAtChipsetPkg/Library/SerialIoLib/SerialIoLib.inf
   MtrrLib|UefiCpuPkg/Library/MtrrLib/MtrrLib.inf

--- a/OvmfPkg/Library/IoMmuLib/IoMmuLib.c
+++ b/OvmfPkg/Library/IoMmuLib/IoMmuLib.c
@@ -1,0 +1,245 @@
+/** @file
+  OVMF-specific IoMmuLib instance.
+
+  This library switches behavior at runtime based on platform policy signaled
+  by either gEdkiiIoMmuProtocolGuid (IOMMU present) or
+  gIoMmuAbsentProtocolGuid (IOMMU intentionally absent). The library's INF
+  declares a DEPEX on
+  (gEdkiiIoMmuProtocolGuid OR gIoMmuAbsentProtocolGuid), so exactly one of
+  those protocols is guaranteed to be published before this library's
+  consumer dispatches.
+
+  Copyright (c) Microsoft Corporation.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <Library/BaseLib.h>
+#include <Library/DebugLib.h>
+#include <Library/IoMmuLib.h>
+#include <Library/UefiBootServicesTableLib.h>
+#include <Protocol/IoMmu.h>
+
+//
+// Cached IoMmu protocol pointer set by IoMmuLibInit.
+//   Non-NULL -> IOMMU present  (gEdkiiIoMmuProtocolGuid was located).
+//   NULL     -> IOMMU absent   (gIoMmuAbsentProtocolGuid was located).
+//
+EDKII_IOMMU_PROTOCOL  *mIoMmuProtocol = NULL;
+
+/**
+  Returns True if the IoMmu protocol is available, otherwise returns False.
+
+  @retval BOOLEAN    TRUE if the IoMmu protocol is available, FALSE otherwise.
+**/
+BOOLEAN
+EFIAPI
+IoMmuIsPresent (
+  VOID
+  )
+{
+  return (mIoMmuProtocol != NULL);
+}
+
+/**
+  Map a host address to a device address using the Page Table.
+
+  @param [in]      Operation       The type of IOMMU operation.
+  @param [in]      HostAddress     The host address to map.
+  @param [in, out] NumberOfBytes   On input, the number of bytes to map. On output, the number of bytes mapped.
+  @param [out]     DeviceAddress   The resulting device address.
+  @param [out]     MappingInfo     A double pointer to the mapping.
+
+  @retval EFI_SUCCESS              Success (also returned when IOMMU is absent).
+  @retval Other                    Errors as defined by the IoMmu protocol.
+**/
+EFI_STATUS
+EFIAPI
+IoMmuMap (
+  IN     EDKII_IOMMU_OPERATION  Operation,
+  IN     VOID                   *HostAddress,
+  IN OUT UINTN                  *NumberOfBytes,
+  OUT    EFI_PHYSICAL_ADDRESS   *DeviceAddress,
+  OUT    VOID                   **MappingInfo
+  )
+{
+  if (mIoMmuProtocol == NULL) {
+    return EFI_SUCCESS;
+  }
+
+  return mIoMmuProtocol->Map (mIoMmuProtocol, Operation, HostAddress, NumberOfBytes, DeviceAddress, MappingInfo);
+}
+
+/**
+  Unmap a device address in the Page Table.
+
+  @param [in]  MappingInfo   The mapping to unmap.
+
+  @retval EFI_SUCCESS            Success (also returned when IOMMU is absent).
+  @retval Other                  Errors as defined by the IoMmu protocol.
+**/
+EFI_STATUS
+EFIAPI
+IoMmuUnmap (
+  IN  VOID  *MappingInfo
+  )
+{
+  if (mIoMmuProtocol == NULL) {
+    return EFI_SUCCESS;
+  }
+
+  return mIoMmuProtocol->Unmap (mIoMmuProtocol, MappingInfo);
+}
+
+/**
+  Free a buffer allocated by IoMmuAllocateBuffer.
+
+  @param [in]  Pages         The number of pages to free.
+  @param [in]  HostAddress   The host address to free.
+
+  @retval EFI_SUCCESS            Success (also returned when IOMMU is absent).
+  @retval Other                  Errors as defined by the IoMmu protocol.
+**/
+EFI_STATUS
+EFIAPI
+IoMmuFreeBuffer (
+  IN  UINTN  Pages,
+  IN  VOID   *HostAddress
+  )
+{
+  if (mIoMmuProtocol == NULL) {
+    return EFI_SUCCESS;
+  }
+
+  return mIoMmuProtocol->FreeBuffer (mIoMmuProtocol, Pages, HostAddress);
+}
+
+/**
+  Allocate a buffer for DMA use with the IoMmu.
+
+  @param [in]      Type          The type of allocation to perform.
+  @param [in]      MemoryType    The type of memory to allocate.
+  @param [in]      Pages         The number of pages to allocate.
+  @param [in, out] HostAddress   On input, the desired host address. On output, the allocated host address.
+  @param [in]      Attributes    The memory attributes to use for the allocation.
+
+  @retval EFI_SUCCESS           Success (also returned when IOMMU is absent).
+  @retval Other                 Errors as defined by the IoMmu protocol.
+**/
+EFI_STATUS
+EFIAPI
+IoMmuAllocateBuffer (
+  IN     EFI_ALLOCATE_TYPE  Type,
+  IN     EFI_MEMORY_TYPE    MemoryType,
+  IN     UINTN              Pages,
+  IN OUT VOID               **HostAddress,
+  IN     UINT64             Attributes
+  )
+{
+  if (mIoMmuProtocol == NULL) {
+    return EFI_SUCCESS;
+  }
+
+  return mIoMmuProtocol->AllocateBuffer (mIoMmuProtocol, Type, MemoryType, Pages, HostAddress, Attributes);
+}
+
+/**
+  Set the R/W access attributes for MappingInfo in the Page Table.
+
+  @param [in]  DeviceHandle  The device handle to set attributes for.
+  @param [in]  MappingInfo   The mapping to set attributes for.
+  @param [in]  IoMmuAccess   The IOMMU access attributes.
+
+  @retval EFI_SUCCESS            Success (also returned when IOMMU is absent).
+  @retval Other                  Errors as defined by the IoMmu protocol.
+**/
+EFI_STATUS
+EFIAPI
+IoMmuSetAttribute (
+  IN EFI_HANDLE  DeviceHandle,
+  IN VOID        *MappingInfo,
+  IN UINT64      IoMmuAccess
+  )
+{
+  if (mIoMmuProtocol == NULL) {
+    return EFI_SUCCESS;
+  }
+
+  return mIoMmuProtocol->SetAttribute (mIoMmuProtocol, DeviceHandle, MappingInfo, IoMmuAccess);
+}
+
+/**
+  Set the R/W access attributes for MappingInfo in the Page Table for a caller
+  that explicitly specifies (IommuBase, DmaId) instead of an EFI_HANDLE.
+
+  @param [in]  IommuBase     Base MMIO address of the IOMMU that owns DmaId.
+  @param [in]  DmaId         DMA identifier emitted by the calling DMA agent.
+  @param [in]  MappingInfo   The mapping to set attributes for.
+  @param [in]  IoMmuAccess   The IOMMU access attributes.
+
+  @retval EFI_SUCCESS        Success (also returned when IOMMU is absent).
+  @retval EFI_UNSUPPORTED    The IoMmu protocol does not implement SetAttributeById.
+  @retval Other              Errors as defined by the IoMmu protocol.
+**/
+EFI_STATUS
+EFIAPI
+IoMmuSetAttributeById (
+  IN UINT64  IommuBase,
+  IN UINT32  DmaId,
+  IN VOID    *MappingInfo,
+  IN UINT64  IoMmuAccess
+  )
+{
+  if (mIoMmuProtocol == NULL) {
+    return EFI_SUCCESS;
+  }
+
+  if ((mIoMmuProtocol->Revision < EDKII_IOMMU_PROTOCOL_REVISION) || (mIoMmuProtocol->SetAttributeById == NULL)) {
+    DEBUG ((DEBUG_WARN, "%a: SetAttributeById not implemented by IoMmu producer.\n", __func__));
+    return EFI_UNSUPPORTED;
+  }
+
+  return mIoMmuProtocol->SetAttributeById (mIoMmuProtocol, IommuBase, DmaId, MappingInfo, IoMmuAccess);
+}
+
+/**
+  Constructor for OVMF IoMmuLib.
+
+  Locates whichever of gEdkiiIoMmuProtocolGuid or gIoMmuAbsentProtocolGuid was
+  published by IoMmuDxe and caches the runtime mode. The library's INF declares
+  a DEPEX on either GUID, so at least one of them is guaranteed to be present
+  by the time this constructor runs.
+
+  @param[in]  ImageHandle  The firmware allocated handle for the EFI image.
+  @param[in]  SystemTable  A pointer to the EFI System Table.
+
+  @retval EFI_SUCCESS  The constructor completed successfully.
+  @retval Other        Neither protocol was located despite the DEPEX.
+**/
+EFI_STATUS
+EFIAPI
+IoMmuLibInit (
+  IN EFI_HANDLE        ImageHandle,
+  IN EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  EFI_STATUS  Status;
+  VOID        *AbsentInterface;
+
+  Status = gBS->LocateProtocol (&gEdkiiIoMmuProtocolGuid, NULL, (VOID **)&mIoMmuProtocol);
+  if (!EFI_ERROR (Status) && (mIoMmuProtocol != NULL)) {
+    DEBUG ((DEBUG_VERBOSE, "%a: gEdkiiIoMmuProtocolGuid located; IOMMU present.\n", __func__));
+    return EFI_SUCCESS;
+  }
+
+  mIoMmuProtocol = NULL;
+
+  Status = gBS->LocateProtocol (&gIoMmuAbsentProtocolGuid, NULL, &AbsentInterface);
+  if (!EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_VERBOSE, "%a: gIoMmuAbsentProtocolGuid located; IOMMU absent.\n", __func__));
+    return EFI_SUCCESS;
+  }
+
+  DEBUG ((DEBUG_ERROR, "%a: Neither IoMmu nor IoMmuAbsent protocol found despite DEPEX. Status = %r\n", __func__, Status));
+  ASSERT_EFI_ERROR (Status);
+  return Status;
+}

--- a/OvmfPkg/Library/IoMmuLib/IoMmuLib.inf
+++ b/OvmfPkg/Library/IoMmuLib/IoMmuLib.inf
@@ -1,0 +1,38 @@
+## @file
+#  OVMF-specific IoMmuLib instance that switches behavior based on protocol policy.
+#
+#  Copyright (c) Microsoft Corporation.<BR>
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x0001001E
+  BASE_NAME                      = OvmfIoMmuLib
+  FILE_GUID                      = 822fcb30-ebeb-4b30-8b91-663447304e80
+  MODULE_TYPE                    = DXE_DRIVER
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = IoMmuLib
+  CONSTRUCTOR                    = IoMmuLibInit
+
+[Sources]
+  IoMmuLib.c
+
+[LibraryClasses]
+  BaseLib
+  DebugLib
+  MemoryAllocationLib
+  UefiBootServicesTableLib
+
+[Packages]
+  MdeModulePkg/MdeModulePkg.dec
+  MdePkg/MdePkg.dec
+  OvmfPkg/OvmfPkg.dec
+
+[Protocols]
+  gEdkiiIoMmuProtocolGuid             ## SOMETIMES_CONSUMES
+  gIoMmuAbsentProtocolGuid            ## SOMETIMES_CONSUMES
+
+[Depex]
+  gEdkiiIoMmuProtocolGuid OR
+  gIoMmuAbsentProtocolGuid

--- a/OvmfPkg/LoongArchVirt/LoongArchVirtQemu.dsc
+++ b/OvmfPkg/LoongArchVirt/LoongArchVirtQemu.dsc
@@ -133,6 +133,7 @@
   PciCapPciIoLib                   | OvmfPkg/Library/UefiPciCapPciIoLib/UefiPciCapPciIoLib.inf
   DxeHardwareInfoLib               | OvmfPkg/Library/HardwareInfoLib/DxeHardwareInfoLib.inf
   IoLib                            | MdePkg/Library/BaseIoLibIntrinsic/BaseIoLibIntrinsic.inf
+  IoMmuLib                         | MdeModulePkg/Library/IoMmuLibNull/IoMmuLibNull.inf
   FdtSerialPortAddressLib          | OvmfPkg/Library/FdtSerialPortAddressLib/FdtSerialPortAddressLib.inf
   PlatformHookLib                  | OvmfPkg/LoongArchVirt/Library/Fdt16550SerialPortHookLib/Fdt16550SerialPortHookLib.inf
   SerialPortLib                    | OvmfPkg/LoongArchVirt/Library/EarlyFdtSerialPortLib16550/EarlyFdtSerialPortLib16550.inf

--- a/OvmfPkg/Microvm/MicrovmX64.dsc
+++ b/OvmfPkg/Microvm/MicrovmX64.dsc
@@ -166,6 +166,7 @@
   PciCapPciSegmentLib|OvmfPkg/Library/BasePciCapPciSegmentLib/BasePciCapPciSegmentLib.inf
   PciCapPciIoLib|OvmfPkg/Library/UefiPciCapPciIoLib/UefiPciCapPciIoLib.inf
   IoLib|MdePkg/Library/BaseIoLibIntrinsic/BaseIoLibIntrinsicSev.inf
+  IoMmuLib|OvmfPkg/Library/IoMmuLib/IoMmuLib.inf
   OemHookStatusCodeLib|MdeModulePkg/Library/OemHookStatusCodeLibNull/OemHookStatusCodeLibNull.inf
   SerialPortLib|PcAtChipsetPkg/Library/SerialIoLib/SerialIoLib.inf
   MtrrLib|UefiCpuPkg/Library/MtrrLib/MtrrLib.inf

--- a/OvmfPkg/OvmfPkgIa32X64.dsc
+++ b/OvmfPkg/OvmfPkgIa32X64.dsc
@@ -172,6 +172,7 @@
   PciCapPciIoLib|OvmfPkg/Library/UefiPciCapPciIoLib/UefiPciCapPciIoLib.inf
   CcProbeLib|MdePkg/Library/CcProbeLibNull/CcProbeLibNull.inf
   IoLib|MdePkg/Library/BaseIoLibIntrinsic/BaseIoLibIntrinsicSev.inf
+  IoMmuLib|OvmfPkg/Library/IoMmuLib/IoMmuLib.inf
   OemHookStatusCodeLib|MdeModulePkg/Library/OemHookStatusCodeLibNull/OemHookStatusCodeLibNull.inf
   SerialPortLib|PcAtChipsetPkg/Library/SerialIoLib/SerialIoLib.inf
   MtrrLib|UefiCpuPkg/Library/MtrrLib/MtrrLib.inf

--- a/OvmfPkg/OvmfPkgX64.dsc
+++ b/OvmfPkg/OvmfPkgX64.dsc
@@ -185,6 +185,7 @@
   PciCapPciSegmentLib|OvmfPkg/Library/BasePciCapPciSegmentLib/BasePciCapPciSegmentLib.inf
   PciCapPciIoLib|OvmfPkg/Library/UefiPciCapPciIoLib/UefiPciCapPciIoLib.inf
   IoLib|MdePkg/Library/BaseIoLibIntrinsic/BaseIoLibIntrinsicSev.inf
+  IoMmuLib|OvmfPkg/Library/IoMmuLib/IoMmuLib.inf
   OemHookStatusCodeLib|MdeModulePkg/Library/OemHookStatusCodeLibNull/OemHookStatusCodeLibNull.inf
   SerialPortLib|PcAtChipsetPkg/Library/SerialIoLib/SerialIoLib.inf
   MtrrLib|UefiCpuPkg/Library/MtrrLib/MtrrLib.inf

--- a/OvmfPkg/OvmfXen.dsc
+++ b/OvmfPkg/OvmfXen.dsc
@@ -157,6 +157,7 @@
   PciCapPciIoLib|OvmfPkg/Library/UefiPciCapPciIoLib/UefiPciCapPciIoLib.inf
   CcProbeLib|MdePkg/Library/CcProbeLibNull/CcProbeLibNull.inf
   IoLib|MdePkg/Library/BaseIoLibIntrinsic/BaseIoLibIntrinsicSev.inf
+  IoMmuLib|OvmfPkg/Library/IoMmuLib/IoMmuLib.inf
   OemHookStatusCodeLib|MdeModulePkg/Library/OemHookStatusCodeLibNull/OemHookStatusCodeLibNull.inf
   SerialPortLib|PcAtChipsetPkg/Library/SerialIoLib/SerialIoLib.inf
   MtrrLib|UefiCpuPkg/Library/MtrrLib/MtrrLib.inf

--- a/OvmfPkg/RiscVVirt/RiscVVirtQemu.dsc
+++ b/OvmfPkg/RiscVVirt/RiscVVirtQemu.dsc
@@ -129,6 +129,7 @@
   PciPcdProducerLib|OvmfPkg/Fdt/FdtPciPcdProducerLib/FdtPciPcdProducerLib.inf
   PciSegmentLib|MdePkg/Library/BasePciSegmentLibPci/BasePciSegmentLibPci.inf
   PciHostBridgeLib|OvmfPkg/Fdt/FdtPciHostBridgeLib/FdtPciHostBridgeLib.inf
+  IoMmuLib|MdeModulePkg/Library/IoMmuLibNull/IoMmuLibNull.inf
   PciHostBridgeUtilityLib|OvmfPkg/Library/PciHostBridgeUtilityLib/PciHostBridgeUtilityLib.inf
   PeiHardwareInfoLib|OvmfPkg/Library/HardwareInfoLib/PeiHardwareInfoLib.inf
   PlatformHookLib|MdeModulePkg/Library/BasePlatformHookLibNull/BasePlatformHookLibNull.inf

--- a/UefiPayloadPkg/UefiPayloadPkg.dsc
+++ b/UefiPayloadPkg/UefiPayloadPkg.dsc
@@ -293,6 +293,7 @@
   UefiUsbLib|MdePkg/Library/UefiUsbLib/UefiUsbLib.inf
   UefiScsiLib|MdePkg/Library/UefiScsiLib/UefiScsiLib.inf
   OemHookStatusCodeLib|MdeModulePkg/Library/OemHookStatusCodeLibNull/OemHookStatusCodeLibNull.inf
+  IoMmuLib|MdeModulePkg/Library/IoMmuLibNull/IoMmuLibNull.inf
   !if $(CAPSULE_SUPPORT) == TRUE
   CapsuleLib|MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleLib.inf
   BmpSupportLib|MdeModulePkg/Library/BaseBmpSupportLib/BaseBmpSupportLib.inf


### PR DESCRIPTION
# Description

Adds `IoMmuLib`, a wrapper library for the EDKII IOMMU protocol, extends the
IOMMU protocol and DMA paths to support handle-less DMA agents.

Summary of the changes (6 commits):

**MdeModulePkg**
- **Create IoMmuLib** – new wrapper library around the EDKII IOMMU protocol that
  centralizes locating and invoking the protocol, removing per-driver PCD usage
  and protocol-notify callbacks.
- **Add SetAttributeById to IoMmu Protocol** – new
  `EDKII_IOMMU_PROTOCOL.SetAttributeById` for DMA agents that have no `EFI_HANDLE`.
  The caller supplies the owning IOMMU base address and the DMA identifier
   (StreamID on Arm SMMU, RequesterID on VT-d). Protocol revision bumped to `0x00010001`;
  `IoMmuLibNull` returns `EFI_SUCCESS`, and producers that don't implement it
  leave the pointer NULL (`IoMmuSetAttributeById` returns `EFI_UNSUPPORTED`).
- **Add IoMmuLib support to PCI drivers** – `NonDiscoverablePciDeviceDxe`,
  `PciBusDxe`, and `PciHostBridgeDxe` now perform IOMMU mappings through
  `IoMmuLib`.
- **Add UniqueId to NonDiscoverableDeviceRegistrationLib** –
  `RegisterNonDiscoverableMmioDevice()` takes a platform-assigned `UniqueId`
  used to synthesize a deterministic BDF (`Segment=0xFF`, `Bus=UniqueId>>5`,
  `Device=UniqueId&0x1F`, `Function=0`) in `PciIo->GetLocation()`.
- **Add Handle to NON_DISCOVERABLE_PCI_DEVICE** – the bound controller
  `EFI_HANDLE` is remembered and passed to `IoMmuSetAttribute`, letting an IOMMU
  producer resolve a non-discoverable device's StreamID via the IORT instead of
  falling back to bypass.

**EmbeddedPkg**
- **Add IoMmu support to CoherentDmaLib & NonCoherentDmaLib** – `DmaMap()` gains
  two parameters, `IommuBase` and `DmaId`, forwarded to `IoMmuSetAttributeById`
  so handle-less DMA agents can program the IOMMU.

- [x] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - `DmaMap()` and `RegisterNonDiscoverableMmioDevice()` signatures change, the
    IOMMU protocol gains a member, and a new `IoMmuLib` library class is
    introduced; all consumers must be updated.
- [x] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Adds per-StreamID DMA isolation (Stage 2 translation) via the new SMMUv3
    driver and the handle-less IOMMU programming path.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - No explicit test code.

## How This Was Tested

Tested physical x64 and ARM64 platforms. Also tested on ArmVirtPkg in mu_tiano_platforms.

## Integration Instructions

**IoMmuLib (`IoMmuLib`/`IoMmuLibNull`)** - use `IoMmuLib` in the platform DSC for cases where the platform installs the IoMmu protocol. Use `IoMmuLibNull` in the platform DSC when there is no IoMmu protocol producer on the platform.
For OvmfPkg, there is a OvmfPkg version of the IoMmuLib that must be used.

**DmaLib (`DmaMap`/`DmaUnmap`)** – `DmaMap()` now takes two additional parameters, `IommuBase` and `DmaId`:

```c
EFI_STATUS
DmaMap (
  IN     DMA_MAP_OPERATION  Operation,
  IN     VOID               *HostAddress,
  IN OUT UINTN              *NumberOfBytes,
  IN     UINT64             IommuBase,   // IOMMU base owning DmaId; 0 = no IOMMU programming
  IN     UINT32             DmaId,       // StreamID (Arm SMMU) / RequesterID (VT-d)
  OUT    PHYSICAL_ADDRESS   *DeviceAddress,
  OUT    VOID               **Mapping
  );
```