### PR TITLE
Add the stack protector for LoongArch64

### DIFF
--- a/BaseTools/Conf/tools_def.template
+++ b/BaseTools/Conf/tools_def.template
@@ -586,10 +586,10 @@ NOOPT_*_*_OBJCOPY_ADDDEBUGFLAG     = --add-gnu-debuglink="$(DEBUG_DIR)/$(MODULE_
 *_*_*_DTCPP_PATH                   = DEF(DTCPP_BIN)
 *_*_*_DTC_PATH                     = DEF(DTC_BIN)
 
-# All supported GCC archs except LOONGARCH64 support -mstack-protector-guard=global, so set that on everything except LOONGARCH64
+# Because LOONGARCH64 supports global stack protector guard by default, it does not support the parameter -mstack-protector-guard=global, and this parameter will be supported in GCC17. So set that on every thing except LOONGARCH64.
 DEFINE GCC_ALL_CC_COMMON               = -g -Os -fshort-wchar -fno-builtin -fno-strict-aliasing -Wall -Werror -Wno-array-bounds -include AutoGen.h -fno-common -fstack-protector
 DEFINE GCC_IA32_X64_CC_FLAGS           = -mstack-protector-guard=global
-DEFINE GCC_LOONGARCH64_CC_FLAGS        = DEF(GCC_ALL_CC_COMMON) -mabi=lp64d -fno-asynchronous-unwind-tables -Wno-address -fno-short-enums -fsigned-char -ffunction-sections -fdata-sections -march=loongarch64 -mno-memcpy -Werror -Wno-maybe-uninitialized -Wno-stringop-overflow -Wno-pointer-to-int-cast -no-pie -fno-stack-protector -mno-explicit-relocs -mno-relax
+DEFINE GCC_LOONGARCH64_CC_FLAGS        = DEF(GCC_ALL_CC_COMMON) -mabi=lp64d -fno-asynchronous-unwind-tables -Wno-address -fno-short-enums -fsigned-char -ffunction-sections -fdata-sections -march=loongarch64 -mno-memcpy -Werror -Wno-maybe-uninitialized -Wno-stringop-overflow -Wno-pointer-to-int-cast -no-pie -mno-explicit-relocs -mno-relax
 DEFINE GCC_AARCH64_CC_COMMON           = DEF(GCC_ALL_CC_COMMON) -mlittle-endian -fno-short-enums -fverbose-asm -funsigned-char  -ffunction-sections -fdata-sections -Wno-address -fno-asynchronous-unwind-tables -fno-unwind-tables -fno-pic -fno-pie -ffixed-x18 -mstack-protector-guard=global
 DEFINE GCC_AARCH64_CC_XIPCOMMON        = -mstrict-align -mgeneral-regs-only
 DEFINE GCC_RISCV64_CC_XIPFLAGS         = -mstrict-align -mgeneral-regs-only

--- a/MdePkg/Library/DynamicStackCookieEntryPointLib/DxeCoreEntryPoint.inf
+++ b/MdePkg/Library/DynamicStackCookieEntryPointLib/DxeCoreEntryPoint.inf
@@ -19,7 +19,7 @@
 
 
 #
-#  VALID_ARCHITECTURES           = IA32 X64 AARCH64
+#  VALID_ARCHITECTURES           = IA32 X64 AARCH64 LOONGARCH64
 #
 
 [Sources]
@@ -36,6 +36,9 @@
 [Sources.AARCH64]
   AArch64/DynamicCookieGcc.S | GCC
 
+[Sources.LOONGARCH64]
+  LoongArch64/DynamicCookieGcc.S | GCC
+
 [Packages]
   MdePkg/MdePkg.dec
 
@@ -43,3 +46,6 @@
   BaseLib
   DebugLib
   StackCheckLib
+
+[LibraryClasses.LOONGARCH64]
+  RngLib

--- a/MdePkg/Library/DynamicStackCookieEntryPointLib/LoongArch64/DynamicCookieGcc.S
+++ b/MdePkg/Library/DynamicStackCookieEntryPointLib/LoongArch64/DynamicCookieGcc.S
@@ -1,0 +1,71 @@
+#------------------------------------------------------------------------------
+#
+# Copyright (c) Microsoft Corporation.
+# Copyright (c) 2026, Loongson Technology Corporation Limited. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+# Module Name:
+#
+#   DynamicCookieGcc.S
+#
+# Abstract:
+#
+#   Generates random number through the RdTime instruction on a 64-bit LOONGARCH64 platform
+#   to store a random value in the GCC __stack_check_guard stack cookie.
+#   The first byte is 0'd to prevent string copy functions from clobbering
+#   the stack cookie.
+#
+# Notes:
+#
+# Use the RngLib library to get random numbers. LoongArch64 currently does not support like
+# `RdRand` or `RNDR` instructions, it can use the `RdTime` and a xorshift64 algorithms to
+# generate pseudo-random numbers.
+#
+#------------------------------------------------------------------------------
+
+#include <Library/RngLib.h>
+
+ASM_GLOBAL ASM_PFX (_ModuleEntryPoint)
+
+#------------------------------------------------------------------------------
+# VOID
+# EFIAPI
+# _ModuleEntryPoint (
+#   The parameters are saved to the stack when it calls other functions.
+# )
+#------------------------------------------------------------------------------
+ASM_PFX(_ModuleEntryPoint):
+  addi.d    $sp, $sp, -0x20
+  st.d      $a0, $sp, 0x0
+  st.d      $a1, $sp, 0x8
+  st.d      $ra, $sp, 0x10
+
+  //
+  // Use the stack to pass parameters.
+  //
+  addi.d    $a0, $sp, 0x18
+  bl        GetRandomNumber64
+
+  //
+  // Load the random number from the stack.
+  //
+  ld.d      $t0, $sp, 0x18
+
+  //
+  // Zero the first byte of the random value
+  //
+  bstrins.d $t0, $zero, 7, 0
+
+  la.local  $t1, __stack_chk_guard
+  st.d      $t0, $t1, 0
+  dbar      0
+
+  ld.d      $a0, $sp, 0x0
+  ld.d      $a1, $sp, 0x8
+  ld.d      $ra, $sp, 0x10
+  addi.d    $sp, $sp, 0x20
+
+c_entry:
+  b         _CModuleEntryPoint     // Jump to the C module entry point
+
+.end

--- a/MdePkg/Library/DynamicStackCookieEntryPointLib/StandaloneMmDriverEntryPoint.inf
+++ b/MdePkg/Library/DynamicStackCookieEntryPointLib/StandaloneMmDriverEntryPoint.inf
@@ -23,7 +23,7 @@
 #
 # The following information is for reference only and not required by the build tools.
 #
-#  VALID_ARCHITECTURES           = X64 AARCH64
+#  VALID_ARCHITECTURES           = X64 AARCH64 LOONGARCH64
 #
 
 [Sources]
@@ -40,6 +40,9 @@
 [Sources.AARCH64]
   AArch64/DynamicCookieGcc.S | GCC
 
+[Sources.LOONGARCH64]
+  LoongArch64/DynamicCookieGcc.S | GCC
+
 [Packages]
   MdePkg/MdePkg.dec
 
@@ -48,6 +51,9 @@
   DebugLib
   MmServicesTableLib
   StackCheckLib
+
+[LibraryClasses.LOONGARCH64]
+  RngLib
 
 [Protocols]
   gEfiLoadedImageProtocolGuid      ## SOMETIMES_CONSUMES

--- a/MdePkg/Library/DynamicStackCookieEntryPointLib/UefiApplicationEntryPoint.inf
+++ b/MdePkg/Library/DynamicStackCookieEntryPointLib/UefiApplicationEntryPoint.inf
@@ -18,7 +18,7 @@
   LIBRARY_CLASS                  = UefiApplicationEntryPoint|UEFI_APPLICATION
 
 #
-#  VALID_ARCHITECTURES           = IA32 X64 AARCH64
+#  VALID_ARCHITECTURES           = IA32 X64 AARCH64 LOONGARCH64
 #
 
 [Sources]
@@ -35,6 +35,9 @@
 [Sources.AARCH64]
   AArch64/DynamicCookieGcc.S | GCC
 
+[Sources.LOONGARCH64]
+  LoongArch64/DynamicCookieGcc.S | GCC
+
 [Packages]
   MdePkg/MdePkg.dec
 
@@ -43,3 +46,6 @@
   DebugLib
   BaseLib
   StackCheckLib
+
+[LibraryClasses.LOONGARCH64]
+  RngLib

--- a/MdePkg/Library/DynamicStackCookieEntryPointLib/UefiDriverEntryPoint.inf
+++ b/MdePkg/Library/DynamicStackCookieEntryPointLib/UefiDriverEntryPoint.inf
@@ -20,7 +20,7 @@
 #
 # The following information is for reference only and not required by the build tools.
 #
-#  VALID_ARCHITECTURES           = IA32 X64 AARCH64
+#  VALID_ARCHITECTURES           = IA32 X64 AARCH64 LOONGARCH64
 #
 
 [Sources]
@@ -40,11 +40,17 @@
 [Sources.AARCH64]
   AArch64/DynamicCookieGcc.S | GCC
 
+[Sources.LOONGARCH64]
+  LoongArch64/DynamicCookieGcc.S | GCC
+
 [LibraryClasses]
   UefiBootServicesTableLib
   DebugLib
   BaseLib
   StackCheckLib
+
+[LibraryClasses.LOONGARCH64]
+  RngLib
 
 [Protocols]
   gEfiLoadedImageProtocolGuid                   ## SOMETIMES_CONSUMES

--- a/MdePkg/Library/StackCheckLib/LoongArch64/StackCookieInterrupt.S
+++ b/MdePkg/Library/StackCheckLib/LoongArch64/StackCookieInterrupt.S
@@ -1,0 +1,21 @@
+#------------------------------------------------------------------------------
+#
+# LoongArch64/StackCookieInterrupt.S
+#
+# Copyright (c) 2026, Loongson Technology Corporation Limited. All rights reserved.<BR>
+#
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+#------------------------------------------------------------------------------
+
+#include <Library/BaseLib.h>
+ASM_GLOBAL ASM_PFX(TriggerStackCookieInterrupt)
+
+#/**
+#  Calling `CpuBreakpoint` to create a breakpoint to the LoongArch64 exception handle and stop.
+#**/
+
+ASM_PFX(TriggerStackCookieInterrupt):
+  bl    CpuBreakpoint
+  jirl  $zero, $ra, 0
+.end

--- a/MdePkg/Library/StackCheckLib/StackCheckLib.inf
+++ b/MdePkg/Library/StackCheckLib/StackCheckLib.inf
@@ -30,6 +30,9 @@
   AArch64/StackCookieInterrupt.S   |GCC
   AArch64/StackCookieInterrupt.asm |MSFT
 
+[Sources.LOONGARCH64]
+  LoongArch64/StackCookieInterrupt.S | GCC
+
 [Packages]
   MdePkg/MdePkg.dec
 


### PR DESCRIPTION
# Description

Patch1: Added LoongArch64 stack cookie interrupt instance, calling `CpuBreakpoint` to stop the CPU.
Patch2: Add LoongArch64 support for dynamic stack cookie entry point library
Patch3: Enable stack protector for LoongArch64

## How This Was Tested

Build a  module using the `-stack-protector-all`, and try to tamper with the "guard value" after it has been loaded the `guard` but before it is compared, it should `break` the CPU and tell us the stack has been changed.

## Integration Instructions

N/A
