### PR TITLE
.github: Use windows-2022 for UPL build

### DIFF
--- a/.github/workflows/upl-build.yml
+++ b/.github/workflows/upl-build.yml
@@ -17,7 +17,7 @@ jobs:
   build_vs2022:
     strategy:
       matrix:
-        os: [windows-latest]
+        os: [windows-2022]
         python-version: ['3.12']
         tool-chain: ['VS2022']
         target: ['DEBUG']


### PR DESCRIPTION
# Description

Currently, the UPL fails on Windows hosts because it specifies `windows-latest` which has moved on to Visual Studio 2026 while the build uses VS2022.

The decision to move the actual build to a later Visual Studio version can be made independently, but for now, this change allows the UPL build to succeed on GitHub hosted runner Windows hosts.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

- Tested UPL build (using the `workflow_dispatch` trigger) with the change on my edk2 fork
  - https://github.com/makubacki/edk2/actions/runs/27572035675/job/81510765604

## Integration Instructions

- N/A