### PR TITLE
CryptoPkg: Match OpenSSL's default security level

### DIFF
--- a/CryptoPkg/Library/TlsLib/TlsInit.c
+++ b/CryptoPkg/Library/TlsLib/TlsInit.c
@@ -186,11 +186,6 @@ TlsNew (
   }
 
   //
-  // This retains compatibility with previous version of OpenSSL.
-  //
-  SSL_set_security_level (TlsConn->Ssl, 3);
-
-  //
   // Initialize the created SSL Object
   //
   SSL_set_info_callback (TlsConn->Ssl, NULL);


### PR DESCRIPTION
# Description

`TlsNew()` explicitly sets the default security level to 3. The current default in OpenSSL is security level 2 which is inherited by Linux distributions like Ubuntu 26.04. This is also the security level that was announced in https://edk2.groups.io/g/devel/topic/115039926.

- [ ] Breaking change?
- [x] Impacts security? - Lower the default SSL security level to match OpenSSL's / Ubuntu 26.04
- [ ] Includes tests?

## How This Was Tested

This was tested with Qemu on Ubuntu 26.04 by HTTPS-booting https://boot.netboot.xyz/ipxe/netboot.xyz-snponly.efi. This specific URL works with Curl and Firefox Nightly but fails in EDK II without this patch with:

```
TlsDoHandshake X509_verify_result: 66 (EE certificate key too weak)
```

With this patch, the boot succeeds.

## Integration Instructions

N/A
