### PR TITLE
MdeModulePkg/TerminalDxe: Change print level to eliminate interference

### DIFF
--- a/MdeModulePkg/Universal/Console/TerminalDxe/TerminalConIn.c
+++ b/MdeModulePkg/Universal/Console/TerminalDxe/TerminalConIn.c
@@ -390,7 +390,7 @@ TerminalConInRegisterKeyNotify (
     // protocol.
     //
     DEBUG ((
-      DEBUG_INFO,
+      DEBUG_VERBOSE,
       "%a: Attempt to register notifier for the key 0x%04x (scan code 0x%04x) with shift state 0x%08x and toggle state 0x%02x.\n",
       __func__,
       KeyData->Key.UnicodeChar,


### PR DESCRIPTION
# Description

The debug message introduced by [PR#12282](https://github.com/tianocore/edk2/pull/12282) was printed at DEBUG_INFO level, which caused screen corruption in the UEFI Shell when running in DEBUG mode. Change the print level to DEBUG_VERBOSE to keep the Shell output clean during normal DEBUG builds while still retaining the message for verbose debugging scenarios.

<img width="1367" height="373" alt="image" src="https://github.com/user-attachments/assets/79a4241b-649a-422d-a798-8559ab2d43e0" />

## How This Was Tested

Build AArch64 virtual firmware, and run the firmware with QEMU, entering UEFI Shell, the screen interference disappears.

## Integration Instructions

N/A
