### PR TITLE
ShellPkg: Fix the issue that the UEFI Shell layout is messed up

### DIFF
--- a/ShellPkg/Library/UefiShellLevel2CommandsLib/Map.c
+++ b/ShellPkg/Library/UefiShellLevel2CommandsLib/Map.c
@@ -698,9 +698,9 @@ PerformMappingDisplay (
 
   if (!Found) {
     if (Specific != NULL) {
-      ShellPrintHiiEx (gST->ConOut->Mode->CursorColumn, gST->ConOut->Mode->CursorRow-1, NULL, STRING_TOKEN (STR_MAP_NF), gShellLevel2HiiHandle, L"map", Specific);
+      ShellPrintHiiDefaultEx (STRING_TOKEN (STR_MAP_NF), gShellLevel2HiiHandle, L"map", Specific);
     } else {
-      ShellPrintHiiEx (gST->ConOut->Mode->CursorColumn, gST->ConOut->Mode->CursorRow-1, NULL, STRING_TOKEN (STR_CD_NF), gShellLevel2HiiHandle, L"map");
+      ShellPrintHiiDefaultEx (STRING_TOKEN (STR_CD_NF), gShellLevel2HiiHandle, L"map");
     }
   }
 


### PR DESCRIPTION
# Description

Fixes https://github.com/tianocore/edk2/issues/12689

When the UEFI Shell mapping table is empty (NULL), the console layout becomes corrupted in DEBUG builds. This occurs because the cursor position for the message `map: No mapping found.` is computed incorrectly under DEBUG mode. The presence of DEBUG output from the Shell driver causes gST->ConOut->Mode->CursorRow to no longer reflect the actual cursor position on the serial port, leading to misplacement of subsequent output.

This patch replaces the existing print routine with ShellPrintHiiDefaultEx(). The new function automatically calculates the correct cursor position for the `map: No mapping found.` line, eliminating the dependency on the stale CursorRow value. As a result, the layout remains consistent regardless of DEBUG message activity.


## How This Was Tested

See the description in https://github.com/tianocore/edk2/issues/12689.

## Integration Instructions

N/A