### PR TITLE
MdeModulePkg/PciBusDxe: Fix Mem64 BAR handling in IsPciDeviceRejected()

### DIFF
--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciEnumeratorSupport.c
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciEnumeratorSupport.c
@@ -2921,13 +2921,12 @@ IsPciDeviceRejected (
       //
       // Mem Bar
       //
-      Mask      = 0xFFFFFFF0;
-      TestValue = TestValue & Mask;
-
+      Mask = 0xFFFFFFF0;
       if ((TestValue & 0x07) == 0x04) {
         //
         // Mem64 or PMem64
         //
+        TestValue  = TestValue & Mask;
         BarOffset += sizeof (UINT32);
         if ((TestValue != 0) && (TestValue == (OldValue & Mask))) {
           //
@@ -2942,6 +2941,7 @@ IsPciDeviceRejected (
         //
         // Mem32 or PMem32
         //
+        TestValue = TestValue & Mask;
         if ((TestValue != 0) && (TestValue == (OldValue & Mask))) {
           return TRUE;
         }


### PR DESCRIPTION
# Description

IsPciDeviceRejected() masks BAR value with 0xFFFFFFF0 before testing the type bits (2:1) that mark a 64-bit memory BAR, essentially clears them, making the 64-bit BAR code path unreachable and treated as if it were 32-bit.

The function rejects a device when BAR looks unprogrammed by comparing if its size mask equals its value. When a 64-bit BAR is mistaken for a 32-bit one, only its lower part is compared, possibly leading a valid BAR being falsely rejected. For example, a 2G BAR with size mask 0x80000000 at 0x180000000 matches and the device is dropped.

This code runs during light enumeration (PciEnumeratorLight), used when PCI resources are already assigned by the platform (e.g. Xen HVM, where hvmloader programs the BARs). The rejected device never receives a PciIo handle, so no driver can bind to it. For example, a virtio-vga with a 64-bit BAR vanishes under OVMF on Xen, leaving the guest with no graphics output.

Fix by testing the type bits on the raw BAR value before masking.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Tested by launching Xen HVM guest with a custom virtio-vga device that has a 2G BAR at above 4G address. Confirmed GOP output works.

## Integration Instructions

N/A