### PR TITLE
ManageabilityPkg: Declare variadic function with EFIAPI

### DIFF
--- a/ManageabilityPkg/Include/Library/ManageabilityTransportHelperLib.h
+++ b/ManageabilityPkg/Include/Library/ManageabilityTransportHelperLib.h
@@ -180,6 +180,7 @@ HelperManageabilityPayLoadDebugPrint (
 
 **/
 VOID
+EFIAPI
 HelperManageabilityDebugPrint (
   IN  VOID         *Payload,
   IN  UINT32       PayloadSize,

--- a/ManageabilityPkg/Library/BaseManageabilityTransportHelperLib/BaseManageabilityTransportHelper.c
+++ b/ManageabilityPkg/Library/BaseManageabilityTransportHelperLib/BaseManageabilityTransportHelper.c
@@ -450,6 +450,7 @@ HelperManageabilityPayLoadDebugPrint (
 
 **/
 VOID
+EFIAPI
 HelperManageabilityDebugPrint (
   IN  VOID         *Payload,
   IN  UINT32       PayloadSize,


### PR DESCRIPTION
# Description

Resolves #12693 

`HelperManageabilityDebugPrint()` is a variadic function that is not declared with EFIAPI, leading to a compiler failure when building with CLANGDWARF:

```
  BaseManageabilityTransportHelper.c:462:3: error:
    '__builtin_ms_va_start' used in System V ABI function
```

While other functions in the header should also use `EFIAPI`, this commit is making a minimal change to fix CI from failing for every commit to master.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

- ManageabilityPkg CLANGDWARF build
- Tested in CLANGDWARF pipeline:
  [Ubuntu - CLANGDWARF - 20260618.2 • ManageabilityPkg: Declare variadic function with EFIAPI](https://dev.azure.com/tianocore/edk2-ci/_build/results?buildId=259203&view=results)

## Integration Instructions

- N/A