### PR TITLE
MdeModulePkg: CxlDxe: Fix IA32 Build Break

### DIFF
--- a/MdeModulePkg/Bus/Pci/CxlDxe/CxlDxe.c
+++ b/MdeModulePkg/Bus/Pci/CxlDxe/CxlDxe.c
@@ -60,7 +60,7 @@ PciUefiMemReadUInt32Array (
   )
 {
   EFI_STATUS  Status;
-  UINT64      BufferIndex;
+  UINTN       BufferIndex;
   UINT64      Offset;
 
   ASSERT ((SizeInBytes % 4) == 0);
@@ -81,7 +81,7 @@ PciUefiMemReadUInt32Array (
                                    );
 
     if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_ERROR, "%a: PciIo read error at 0x%lx: %r \n", __func__, BufferIndex, Status));
+      DEBUG ((DEBUG_ERROR, "%a: PciIo read error at 0x%lx: %r \n", __func__, (UINT64)BufferIndex, Status));
       return Status;
     }
 
@@ -115,7 +115,7 @@ PciUefiMemWriteUInt32Array (
   )
 {
   EFI_STATUS  Status;
-  UINT64      BufferIndex;
+  UINTN       BufferIndex;
   UINT64      Offset;
 
   ASSERT ((SizeInBytes % 4) == 0);
@@ -136,7 +136,7 @@ PciUefiMemWriteUInt32Array (
                                    );
 
     if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_ERROR, "%a: PciIo write error at 0x%lx: %r \n", __func__, BufferIndex, Status));
+      DEBUG ((DEBUG_ERROR, "%a: PciIo write error at 0x%lx: %r \n", __func__, (UINT64)BufferIndex, Status));
       return Status;
     }
 
@@ -303,7 +303,7 @@ CxlDecodeRegblock (
   Bar = (UINT8)(Block->OffsetLow.Bits.RegisterBir / 2);
 
   Offset =
-    ((UINT64)Block->OffsetHigh.Bits.RegisterBlockOffsetHigh << 32) |
+    LShiftU64 ((UINT64)Block->OffsetHigh.Bits.RegisterBlockOffsetHigh, 32) |
     (Block->OffsetLow.Bits.RegisterBlockOffsetLow << 16);
 
   RegisterMap->RegisterType        = Block->OffsetLow.Bits.RegisterBlockIdentifier;


### PR DESCRIPTION
# Description

CxlDxe is currently compiled as part of the MdeModulePkg IA32 CI. When running CI with VS2022 version 14.44.35228.0, the CI build fails with:

CxlDxe.lib(CxlDxe.obj) : unresolved external symbol __allmul
CxlDxe(CxlDxe.obj) : unresolved external symbol __allshl

CxlDxe is not intended to run on IA32 DXE systems, as such systems are legacy, but until edk2 drops build support for IA32 DXE (or at least CI for it), the build needs to work.

This fixes the 64 bit multiplication/shifting that occurs in CxlDxe to use the BaseLib functions that avoid the compiler intrinsics.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

```bash
stuart_ci_build -c .pytool\CISettings.py TOOL_CHAIN_TAG=VS2022 -a IA32 -p MdeModulePkg -t NOOPT BUILDMODULE=MdeModulePkg\Bus\Pci\CxlDxe\CxlDxe.inf
```

Failed before this change, succeeds with it.

## Integration Instructions

N/A.