### PR TITLE
ArmPkg: Only flush cache for memory that is mapped

### DIFF
--- a/ArmPkg/Drivers/CpuDxe/CpuMmuCommon.c
+++ b/ArmPkg/Drivers/CpuDxe/CpuMmuCommon.c
@@ -285,10 +285,18 @@ CpuSetMemoryAttributes (
     // stale cache lines are written back and invalidated. If this is not done,
     // depending on the caching behavior of the platform, dirty cache lines may
     // be written back corrupting data in the future, or stale cache lines may
-    // persist if caching is enabled later.
+    // persist if caching is enabled later. In scenarios where the caller didn't
+    // explicitly change the cacheability, ignore this. This could still lead to
+    // unexpected caches, but this is a necessary concession to incorrect behavior
+    // in higher-level components.
     //
     FlushCache = FALSE;
-    if (!EFI_ERROR (Status) && IsArmAttributeCacheable (RegionArmAttributes) && !IsArmAttributeCacheable (ArmAttributes)) {
+    if (!EFI_ERROR (Status) &&
+        ((EfiAttributes & EFI_MEMORY_RP) == 0) &&
+        ((EfiAttributes & EFI_MEMORY_CACHETYPE_MASK) != 0) &&
+        IsArmAttributeCacheable (RegionArmAttributes) &&
+        !IsArmAttributeCacheable (ArmAttributes))
+    {
       FlushCache = TRUE;
     }
 


### PR DESCRIPTION
# Description

The previous commit to add cache flushing for memory being changed from
a cacheable memory to non-cacheable memory did not check if the new memory
type would be marked as a valid mapping. Because of this, if the cacheability
is changed on memory that has `EFI_MEMORY_RP` set, the flush be VA would still
be invoked which would cause a synchronous data abort.

Additionally, this commit removes flushing the cache if no attribute was
provided by the caller. It have been observed that in some cases, including
the core itself, the caller does not provide a cacheability attribute and
this code will default to a unused (so device) index. To avoid unexpected
behavior, we must ignore this scenario since it is already in err and
this shouldn't be made worse.

Fixes regression introduced in this PR: https://github.com/tianocore/edk2/pull/12509

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

Test on physical & virtual platform using custom test. Testing switching catches and now testing with read-protect set.

## Integration Instructions

N/A
