### PR TITLE
.pytool/EccCheck: Report package-relative paths in ECC findings

### DIFF
--- a/.pytool/Plugin/EccCheck/EccCheck.py
+++ b/.pytool/Plugin/EccCheck/EccCheck.py
@@ -34,6 +34,10 @@ class EccCheck(ICiBuildPlugin):
     LineScopePattern = (r'@@ -\d*\,*\d* \+\d*\,*\d* @@.*')
     LineNumRange = re.compile(r'@@ -\d*\,*\d* \+(\d*)\,*(\d*) @@.*')
 
+    # Sub-directory of the workspace where the package under review is copied
+    # and scanned by ECC.
+    BuildTempSubDir = os.path.join('Build', '.pytool', 'Plugin', 'EccCheck')
+
     def GetTestName(self, packagename: str, environment: VarDict) -> tuple:
         """ Provide the testcase name and classname for use in reporting
             testclassname: a descriptive string for the testcase can include whitespace
@@ -77,7 +81,7 @@ class EccCheck(ICiBuildPlugin):
             return 0
 
         # Create temp directory
-        temp_path = os.path.join(workspace_path, 'Build', '.pytool', 'Plugin', 'EccCheck')
+        temp_path = os.path.join(workspace_path, self.BuildTempSubDir)
         try:
             # Delete temp directory
             if os.path.exists(temp_path):
@@ -327,6 +331,8 @@ class EccCheck(ICiBuildPlugin):
                             for i in ecc_diff_range[modify_file]:
                                 line_no = int(row[4])
                                 if i[0] <= line_no <= i[1] and row[1] not in ignore_error_code:
+                                    row[3] = modify_file
+                                    row[5] = row[5].replace(self.BuildTempSubDir + os.sep, '')
                                     row[0] = '\nEFI coding style error'
                                     row[1] = 'Error code: ' + row[1]
                                     row[3] = 'file: ' + row[3]


### PR DESCRIPTION
# Description

The EccCheck plugin currently reports incorrect paths that are confusing to a user, such as:

```
*file: C:\src\edk2\Build\.pytool\Plugin\EccCheck\MdePkg\Include\
       Protocol\AuthenticationInfo.h
```

This is because the EccCheck plugin does not scan the package in place. Before running ECC, it copies the package into `Build/.pytool/Plugin/EccCheck/` and points the ECC tool at that temporary location. As a result, the paths ECC records in its report refer to the temporary copy rather than the file in the actual source tree.

This affected two fields that are printed:

  - The "file:" line is taken from ECC's File column (`row[3]`), which holds the absolute path of the scanned file. It always pointed into the temporary scan directory.

  - The descriptive message (`row[5]`) paths were prefixed with `Build/.pytool/Plugin/EccCheck/`.

The temporary path is an internal build detail and doesn't need to be printed. The temporary path prevents resolution against the actual source file.

This change translates the reported paths back to the package-relative path before printing.

---

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

- Run EccCheck plugin against MdePkg and MdeModulePkg
  - Example command to just run EccCheck: `stuart_ci_build -c .\.pytool\CISettings.py -p MdePkg -t NO-TARGET --disable-all EccCheck=run`

Introduce several intentional ECC violations to verify paths for different rules.

**Before**

```
PROGRESS - --Running MdePkg: EccCheck Test NO-TARGET --
ERROR - 
ERROR - EFI coding style error
ERROR - *Error code: 6004
ERROR - *Include files should contain only public or only private data and cannot contain code or define data variables
ERROR - *file: C:\src\edk2\Build\.pytool\Plugin\EccCheck\MdePkg\Include\Protocol\AuthenticationInfo.h
ERROR - *Line number: 30
ERROR - *Variable definition appears in header file
ERROR - 
ERROR - EFI coding style error
ERROR - *Error code: 6006
ERROR - *Include files should use '#pragma once' instead of a traditional #ifndef/#define include guard
ERROR - *file: C:\src\edk2\Build\.pytool\Plugin\EccCheck\MdePkg\Include\Protocol\Variable.h
ERROR - *Line number: 28
ERROR - *Include file [Build\.pytool\Plugin\EccCheck\MdePkg\Include\Protocol\Variable.h] uses a traditional #ifndef/#define include guard, please use '#pragma once' instead
ERROR - 
ERROR - EFI coding style error
ERROR - *Error code: 8001
ERROR - *Only capital letters are allowed to be used for #define declarations
ERROR - *file: C:\src\edk2\Build\.pytool\Plugin\EccCheck\MdePkg\Include\Protocol\UserCredential.h
ERROR - *Line number: 16
ERROR - *The #define name [efi_user_credential_protocol_guid] does not follow the rules
ERROR - --->Test Failed: EccCheck Test NO-TARGET returned "1"
```

**After**

```
PROGRESS - --Running MdePkg: EccCheck Test NO-TARGET --
ERROR - 
ERROR - EFI coding style error
ERROR - *Error code: 6004
ERROR - *Include files should contain only public or only private data and cannot contain code or define data variables
ERROR - *file: MdePkg\Include\Protocol\AuthenticationInfo.h
ERROR - *Line number: 30
ERROR - *Variable definition appears in header file
ERROR - 
ERROR - EFI coding style error
ERROR - *Error code: 6006
ERROR - *Include files should use '#pragma once' instead of a traditional #ifndef/#define include guard
ERROR - *file: MdePkg\Include\Protocol\Variable.h
ERROR - *Line number: 28
ERROR - *Include file [MdePkg\Include\Protocol\Variable.h] uses a traditional #ifndef/#define include guard, please use '#pragma once' instead
ERROR - 
ERROR - EFI coding style error
ERROR - *Error code: 8001
ERROR - *Only capital letters are allowed to be used for #define declarations
ERROR - *file: MdePkg\Include\Protocol\UserCredential.h
ERROR - *Line number: 16
ERROR - *The #define name [efi_user_credential_protocol_guid] does not follow the rules
ERROR - --->Test Failed: EccCheck Test NO-TARGET returned "1"
```

## Integration Instructions

- N/A - Plugin usability fix