### PR TITLE
SecurityPkg: Correct sanity check for File and FileBuffer inputs

### DIFF
--- a/SecurityPkg/Library/DxeImageVerificationLib/DxeImageVerificationLib.c
+++ b/SecurityPkg/Library/DxeImageVerificationLib/DxeImageVerificationLib.c
@@ -1705,9 +1705,13 @@ DxeImageVerificationHandler (
   IsFoundInDatabase = FALSE;
 
   //
-  // Sanity check
+  // Sanity check:
+  // Ensure that either File or FileBuffer is provided.
+  // Return EFI_INVALID_PARAMETER if both are NULL.
+  // This prevents security verification from proceeding
+  // when no valid input buffer is available.
   //
-  if (File == NULL) {
+  if ((File == NULL) && (FileBuffer == NULL)) {
     return EFI_INVALID_PARAMETER;
   }
 


### PR DESCRIPTION
# Description

Add a sanity check to ensure that either File or FileBuffer is provided before proceeding with security verification.
If both are NULL, return EFI_INVALID_PARAMETER. This change prevents verification from running without a valid input buffer and improves robustness of the check.

- [ ] Breaking change?
  - No – This does not alter build or boot behavior.
- [ ] Impacts security?
  - Yes – Prevents potential misuse of verification routines with invalid inputs.
- [ ] Includes tests?
  - No – No explicit test code included, but verified through functional build and runtime checks.

## How This Was Tested

Built the affected module successfully in the EDK2 environment.

Verified runtime behavior by passing valid and invalid File/FileBuffer combinations.

Confirmed that invalid inputs correctly return EFI_INVALID_PARAMETER without proceeding to verification.

## Integration Instructions

No special integration steps required.
This patch can be merged directly into master.

Fixes #12678

Signed-off-by: Vignesh G <vigneshg@ami.com>