### PR TITLE
MdeModulePkg/UefiBootManagerLib: Report boot option variable failures

### DIFF
--- a/MdeModulePkg/Library/UefiBootManagerLib/BmBoot.c
+++ b/MdeModulePkg/Library/UefiBootManagerLib/BmBoot.c
@@ -2523,7 +2523,16 @@ EfiBootManagerRefreshAllBootOption (
   //
   for (Index = 0; Index < BootOptionCount; Index++) {
     if (EfiBootManagerFindLoadOption (&BootOptions[Index], NvBootOptions, NvBootOptionCount) == -1) {
-      EfiBootManagerAddLoadOptionVariable (&BootOptions[Index], (UINTN)-1);
+      Status = EfiBootManagerAddLoadOptionVariable (&BootOptions[Index], (UINTN)-1);
+      if (EFI_ERROR (Status)) {
+        DEBUG ((
+          DEBUG_ERROR,
+          "[Bds] Failed to add boot option for '%s': %r\n",
+          BootOptions[Index].Description,
+          Status
+          ));
+      }
+
       //
       // Try best to add the boot options so continue upon failure.
       //

--- a/MdeModulePkg/Library/UefiBootManagerLib/BmLoadOption.c
+++ b/MdeModulePkg/Library/UefiBootManagerLib/BmLoadOption.c
@@ -260,13 +260,13 @@ structure.
     VariableAttributes = EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_RUNTIME_ACCESS;
   }
 
-  Status = gRT->SetVariable (
-                  OptionName,
-                  &gEfiGlobalVariableGuid,
-                  VariableAttributes,
-                  VariableSize,
-                  Variable
-                  );
+  Status = BmSetVariableAndReportStatusCodeOnError (
+             OptionName,
+             &gEfiGlobalVariableGuid,
+             VariableAttributes,
+             VariableSize,
+             Variable
+             );
   FreePool (Variable);
 
   return Status;
@@ -323,13 +323,13 @@ BmAddOptionNumberToOrderVariable (
 
     NewOptionOrder[Position] = OptionNumber;
 
-    Status = gRT->SetVariable (
-                    OptionOrderName,
-                    &gEfiGlobalVariableGuid,
-                    EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_RUNTIME_ACCESS | EFI_VARIABLE_NON_VOLATILE,
-                    OptionOrderSize + sizeof (UINT16),
-                    NewOptionOrder
-                    );
+    Status = BmSetVariableAndReportStatusCodeOnError (
+               OptionOrderName,
+               &gEfiGlobalVariableGuid,
+               EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_RUNTIME_ACCESS | EFI_VARIABLE_NON_VOLATILE,
+               OptionOrderSize + sizeof (UINT16),
+               NewOptionOrder
+               );
     FreePool (NewOptionOrder);
   }
 


### PR DESCRIPTION
# Description

When `EfiBootManagerRefreshAllBootOption()` discovers a bootable device
that is not present in `BootOrder`, it attempts to persist the device as
a `Boot####` option. This operation is best-effort and the refresh
continues on failure.

If the UEFI variable store is full, the device can still be connected
and visible from the UEFI Shell through `SimpleFileSystem`, but setup or
boot manager pages that rely on `BootOrder`/`Boot####` do not show the
device. Without a boot manager level message, this condition is difficult
to distinguish from a device enumeration issue.

Report `SetVariable()` failures through the existing status-code helper
when updating `Boot####` and `*Order` variables. Also log failures when
auto-created boot options cannot be added during boot option refresh.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Tested with the following commands:

```bash
python3 BaseTools/Scripts/PatchCheck.py HEAD
make -C BaseTools -j$(nproc)
. edksetup.sh
build -a X64 -t GCC -b DEBUG -p OvmfPkg/OvmfPkgX64.dsc
```

Built a helper UEFI application from `UefiToolsPkg` to fill the OVMF
non-volatile variable store:

```bash
build -p UefiToolsPkg/UefiToolsPkg.dsc \
  -m UefiToolsPkg/Applications/FillNvVars/FillNvVars.inf \
  -a X64 -t GCC -b DEBUG
```

The helper application is available here:

https://github.com/MarsDoge/UefiToolsPkg/tree/main/Applications/FillNvVars

Manual QEMU reproduction:

1. Booted OVMF with a SATA disk containing `FillNvVars.efi` as
   `EFI/BOOT/BOOTX64.EFI`.
2. `FillNvVars.efi` wrote dummy non-volatile variables until
   `SetVariable()` returned `EFI_OUT_OF_RESOURCES`, then reset the
   system.
3. Reused the same `OVMF_VARS.fd`, kept the existing SATA boot device,
   and attached additional bootable USB storage devices.
4. Confirmed BDS failed to persist a newly discovered boot option when
   the variable store was full.

The debug log showed the existing variable error reporting path for the
failed `Boot####` write:

```text
RecordVarErrorFlag (0xEF) Boot0005:8BE4DF61-93CA-11D2-AA0D-00E098032B8C - 0x00000007 - 0xDC
```

The debug log also showed the new boot manager diagnostic message added
by this change:

```text
[Bds] Failed to add boot option for 'UEFI QEMU QEMU USB HARDDRIVE 1-0000:00:02.0-2': Out of Resources
```

## Integration Instructions

N/A
