### PR TITLE
OvmfPkg/IntelTdx: Move BootManagerMenuApp from NCCFV to DXEFV

### DIFF
--- a/OvmfPkg/IntelTdx/IntelTdxX64.fdf
+++ b/OvmfPkg/IntelTdx/IntelTdxX64.fdf
@@ -261,6 +261,8 @@ INF OvmfPkg/Tcg/TdTcg2Dxe/TdTcg2Dxe.inf
   #
 INF MdeModulePkg/Universal/SmbiosMeasurementDxe/SmbiosMeasurementDxe.inf
 
+INF  MdeModulePkg/Application/BootManagerMenuApp/BootManagerMenuApp.inf
+
 ################################################################################
 
 [FV.NCCFV]
@@ -304,7 +306,6 @@ INF  OvmfPkg/VirtioFsDxe/VirtioFsDxe.inf
 INF  MdeModulePkg/Logo/LogoDxe.inf
 
 INF  MdeModulePkg/Application/UiApp/UiApp.inf
-INF  MdeModulePkg/Application/BootManagerMenuApp/BootManagerMenuApp.inf
 
 #
 # Usb Support


### PR DESCRIPTION
# Description

Commit 03a07cb0f5 moved both UiApp and BootManagerMenuApp to NCCFV to reduce the attack surface for TD guests. However, NCCFV is not discovered when TDX is enabled, which means that EfiBootManagerGetBootManagerMenu() fails to find the BootManagerMenuApp, triggering the assert:

[Bds]BootManagerMenu FFS section can not be found, skip its boot option registration

ASSERT_EFI_ERROR (Status = Not Found)
ASSERT BdsPlatform.c(155): !(((RETURN_STATUS)(Status)) >= 0x8000000000000000ULL)

that prevents any any boot option to work.

Move BootManagerMenuApp back to DXEFV so the ASSERT is satisfied.

Fixes: 03a07cb0f5 ("OvmfPkg/IntelTdx: only add UI to NCCFV")

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Boot a tdx machine with a virtio-blk disk attached.

## Integration Instructions
N/A
