### PR TITLE
SecurityPkg: Add support for LOONGARCH64 and RISCV when parsing PE image

### DIFF
--- a/SecurityPkg/VariableAuthenticated/SecureBootConfigDxe/SecureBootConfigImpl.c
+++ b/SecurityPkg/VariableAuthenticated/SecureBootConfigDxe/SecureBootConfigImpl.c
@@ -1805,6 +1805,8 @@ LoadPeImage (
     mSecDataDir = (EFI_IMAGE_SECURITY_DATA_DIRECTORY *)&(NtHeader32->OptionalHeader.DataDirectory[EFI_IMAGE_DIRECTORY_ENTRY_SECURITY]);
   } else if (  (NtHeader32->FileHeader.Machine == EFI_IMAGE_MACHINE_IA64)
             || (NtHeader32->FileHeader.Machine == EFI_IMAGE_MACHINE_X64)
+            || (NtHeader32->FileHeader.Machine == EFI_IMAGE_MACHINE_LOONGARCH64)
+            || (NtHeader32->FileHeader.Machine == EFI_IMAGE_MACHINE_RISCV64)
             || (NtHeader32->FileHeader.Machine == EFI_IMAGE_MACHINE_AARCH64))
   {
     //

--- a/SecurityPkg/VariableAuthenticated/SecureBootConfigDxe/SecureBootConfigImpl.c
+++ b/SecurityPkg/VariableAuthenticated/SecureBootConfigDxe/SecureBootConfigImpl.c
@@ -83,9 +83,8 @@ HASH_TABLE  mHash[] = {
 //
 UINT32                               mPeCoffHeaderOffset = 0;
 WIN_CERTIFICATE                      *mCertificate       = NULL;
-IMAGE_TYPE                           mImageType;
-UINT8                                *mImageBase = NULL;
-UINTN                                mImageSize  = 0;
+UINT8                                *mImageBase         = NULL;
+UINTN                                mImageSize          = 0;
 UINT8                                mImageDigest[MAX_DIGEST_SIZE];
 UINTN                                mImageDigestSize;
 EFI_GUID                             mCertType;
@@ -1803,7 +1802,6 @@ LoadPeImage (
     //
     // 32-bits Architecture
     //
-    mImageType  = ImageType_IA32;
     mSecDataDir = (EFI_IMAGE_SECURITY_DATA_DIRECTORY *)&(NtHeader32->OptionalHeader.DataDirectory[EFI_IMAGE_DIRECTORY_ENTRY_SECURITY]);
   } else if (  (NtHeader32->FileHeader.Machine == EFI_IMAGE_MACHINE_IA64)
             || (NtHeader32->FileHeader.Machine == EFI_IMAGE_MACHINE_X64)
@@ -1812,7 +1810,6 @@ LoadPeImage (
     //
     // 64-bits Architecture
     //
-    mImageType  = ImageType_X64;
     NtHeader64  = (EFI_IMAGE_NT_HEADERS64 *)(mImageBase + mPeCoffHeaderOffset);
     mSecDataDir = (EFI_IMAGE_SECURITY_DATA_DIRECTORY *)&(NtHeader64->OptionalHeader.DataDirectory[EFI_IMAGE_DIRECTORY_ENTRY_SECURITY]);
   } else {

--- a/SecurityPkg/VariableAuthenticated/SecureBootConfigDxe/SecureBootConfigImpl.h
+++ b/SecurityPkg/VariableAuthenticated/SecureBootConfigDxe/SecureBootConfigImpl.h
@@ -159,11 +159,6 @@ typedef struct {
   UINT32    SizeOfCert;             // size of certificate appended
 } EFI_IMAGE_SECURITY_DATA_DIRECTORY;
 
-typedef enum {
-  ImageType_IA32,
-  ImageType_X64
-} IMAGE_TYPE;
-
 ///
 /// HII specific Vendor Device Path definition.
 ///


### PR DESCRIPTION
# Description

- SecurityPkg/SecureBootConfigDxe: Remove unused variable mImageType

Remove mImageType as it is assigned but never used. The definition of struct IMAGE_TYPE is also removed.

- SecurityPkg: Add support for LOONGARCH64 and RISCV64 when parsing PE image

If the machine type of PE/COFF image is LOONGARCH64 or RISCV64, the LoadPeImage() should return EFI_SUCCESS. This patch is intended as a preparation for future use of LOONGARCH64 or RISCV64 PE image file.


## How This Was Tested

Pass CI check.

## Integration Instructions

N/A
